### PR TITLE
feat: bus `embed` composition + fix generate_if in module typecheck

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -62,6 +62,18 @@ pub struct BusDecl {
     pub params: Vec<ParamDecl>,
     pub signals: Vec<PortDecl>,  // direction = from initiator's perspective
     pub generates: Vec<BusGenerateIf>,  // conditional signal groups
+    pub embeds: Vec<BusEmbed>,  // embedded sub-buses
+    pub span: Span,
+}
+
+/// Embedded sub-bus inside a bus definition.
+/// `embed prefix: BusName<PARAM=val, ...>;`
+/// Flattens to `prefix_signal` for each signal in the referenced bus.
+#[derive(Debug, Clone)]
+pub struct BusEmbed {
+    pub prefix: Ident,
+    pub bus_name: Ident,
+    pub params: Vec<ParamAssign>,
     pub span: Span,
 }
 
@@ -71,7 +83,9 @@ pub struct BusDecl {
 pub struct BusGenerateIf {
     pub cond: Expr,
     pub then_signals: Vec<PortDecl>,
+    pub then_embeds: Vec<BusEmbed>,
     pub else_signals: Vec<PortDecl>,
+    pub else_embeds: Vec<BusEmbed>,
     pub span: Span,
 }
 

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -69,7 +69,18 @@ fn emit_bus_interface(b: &BusDecl) -> String {
     let name = &b.name.name;
     let mut s = format!("bus {name}\n");
     emit_params(&mut s, &b.params);
-    emit_ports(&mut s, &b.signals);
+    emit_bus_signals(&mut s, &b.signals);
+    for emb in &b.embeds {
+        let pa_str = if emb.params.is_empty() {
+            String::new()
+        } else {
+            let parts: Vec<String> = emb.params.iter()
+                .map(|p| format!("{}={}", p.name.name, expr_str(&p.value)))
+                .collect();
+            format!("<{}>", parts.join(", "))
+        };
+        s.push_str(&format!("  embed {}: {}{pa_str};\n", emb.prefix.name, emb.bus_name.name));
+    }
     s.push_str(&format!("end bus {name}\n"));
     s
 }
@@ -279,6 +290,20 @@ fn emit_params(s: &mut String, params: &[ParamDecl]) {
                 ));
             }
         }
+    }
+}
+
+/// Emit bus signals without the `port` keyword.
+/// Bus bodies use `name: dir Type;` syntax, not `port name: ...`.
+fn emit_bus_signals(s: &mut String, signals: &[PortDecl]) {
+    for sig in signals {
+        let dir = match sig.direction {
+            Direction::In => "in",
+            Direction::Out => "out",
+        };
+        let name = &sig.name.name;
+        let ty = type_str(&sig.ty);
+        s.push_str(&format!("  {name}: {dir} {ty};\n"));
     }
 }
 

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -115,6 +115,8 @@ pub enum TokenKind {
     Template,
     #[token("bus")]
     Bus,
+    #[token("embed")]
+    Embed,
     #[token("implements")]
     Implements,
     #[token("return")]
@@ -404,6 +406,7 @@ impl fmt::Display for TokenKind {
             TokenKind::Hook => write!(f, "hook"),
             TokenKind::Template => write!(f, "template"),
             TokenKind::Bus => write!(f, "bus"),
+            TokenKind::Embed => write!(f, "embed"),
             TokenKind::Implements => write!(f, "implements"),
             TokenKind::Return => write!(f, "return"),
             TokenKind::Stage => write!(f, "stage"),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -134,11 +134,14 @@ impl Parser {
         let mut params = Vec::new();
         let mut signals = Vec::new();
         let mut generates = Vec::new();
+        let mut embeds = Vec::new();
         while !self.check_end_keyword() {
             if self.check_param() {
                 params.push(self.parse_param_decl()?);
             } else if self.check(TokenKind::GenerateIf) {
                 generates.push(self.parse_bus_generate_if(start)?);
+            } else if self.check(TokenKind::Embed) {
+                embeds.push(self.parse_bus_embed()?);
             } else {
                 signals.push(self.parse_bus_signal(start)?);
             }
@@ -159,6 +162,40 @@ impl Parser {
             params,
             signals,
             generates,
+            embeds,
+        })
+    }
+
+    /// Parse `embed prefix: BusName<PARAM=val, ...>;`
+    fn parse_bus_embed(&mut self) -> Result<BusEmbed, CompileError> {
+        let start = self.expect(TokenKind::Embed)?.span;
+        let prefix = self.expect_ident()?;
+        self.expect(TokenKind::Colon)?;
+        let bus_name = self.expect_ident()?;
+        let params = if self.check(TokenKind::Lt) {
+            self.advance();
+            let old_no_angle = self.no_angle;
+            self.no_angle = true;
+            let mut pa = Vec::new();
+            loop {
+                let pname = self.expect_ident()?;
+                self.expect(TokenKind::Eq)?;
+                let pvalue = self.parse_expr()?;
+                pa.push(ParamAssign { name: pname, value: pvalue });
+                if !self.eat(TokenKind::Comma) { break; }
+            }
+            self.no_angle = old_no_angle;
+            self.expect(TokenKind::Gt)?;
+            pa
+        } else {
+            Vec::new()
+        };
+        let end_span = self.expect(TokenKind::Semi)?.span;
+        Ok(BusEmbed {
+            prefix,
+            bus_name,
+            params,
+            span: start.merge(end_span),
         })
     }
 
@@ -195,30 +232,40 @@ impl Parser {
         let start = self.expect(TokenKind::GenerateIf)?.span;
         let cond = self.parse_expr()?;
         let mut then_signals = Vec::new();
-        // Parse then-branch signals until end generate_if or generate_else
+        let mut then_embeds = Vec::new();
         while !self.check_bus_gen_end() {
-            then_signals.push(self.parse_bus_signal(parent_span)?);
+            if self.check(TokenKind::Embed) {
+                then_embeds.push(self.parse_bus_embed()?);
+            } else {
+                then_signals.push(self.parse_bus_signal(parent_span)?);
+            }
         }
-        // Optional generate_else
-        let else_signals = if self.check(TokenKind::GenerateElse) {
+        let (else_signals, else_embeds) = if self.check(TokenKind::GenerateElse) {
             self.advance();
             let mut sigs = Vec::new();
+            let mut embs = Vec::new();
             while !(self.pos + 1 < self.tokens.len()
                 && self.tokens[self.pos].kind == TokenKind::End
                 && self.tokens[self.pos + 1].kind == TokenKind::GenerateIf)
             {
-                sigs.push(self.parse_bus_signal(parent_span)?);
+                if self.check(TokenKind::Embed) {
+                    embs.push(self.parse_bus_embed()?);
+                } else {
+                    sigs.push(self.parse_bus_signal(parent_span)?);
+                }
             }
-            sigs
+            (sigs, embs)
         } else {
-            Vec::new()
+            (Vec::new(), Vec::new())
         };
         self.expect(TokenKind::End)?;
         let end_span = self.expect(TokenKind::GenerateIf)?.span;
         Ok(BusGenerateIf {
             cond,
             then_signals,
+            then_embeds,
             else_signals,
+            else_embeds,
             span: start.merge(end_span),
         })
     }

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -147,6 +147,82 @@ impl BusInfo {
     }
 }
 
+/// Substitute param references in a type expression with their mapped values.
+/// Used during embed expansion to translate the embedded bus's param names
+/// into the parent bus's param namespace.
+fn subst_type_expr(ty: &TypeExpr, params: &HashMap<String, &Expr>) -> TypeExpr {
+    match ty {
+        TypeExpr::UInt(w) => TypeExpr::UInt(Box::new(subst_expr(w, params))),
+        TypeExpr::SInt(w) => TypeExpr::SInt(Box::new(subst_expr(w, params))),
+        TypeExpr::Vec(inner, len) => TypeExpr::Vec(
+            Box::new(subst_type_expr(inner, params)),
+            Box::new(subst_expr(len, params)),
+        ),
+        other => other.clone(),
+    }
+}
+
+fn subst_expr(expr: &Expr, params: &HashMap<String, &Expr>) -> Expr {
+    match &expr.kind {
+        ExprKind::Ident(name) => {
+            if let Some(replacement) = params.get(name.as_str()) {
+                (*replacement).clone()
+            } else {
+                expr.clone()
+            }
+        }
+        ExprKind::Binary(op, l, r) => Expr::new(
+            ExprKind::Binary(*op, Box::new(subst_expr(l, params)), Box::new(subst_expr(r, params))),
+            expr.span,
+        ),
+        ExprKind::Unary(op, e) => Expr::new(
+            ExprKind::Unary(*op, Box::new(subst_expr(e, params))),
+            expr.span,
+        ),
+        ExprKind::Clog2(e) => Expr::new(
+            ExprKind::Clog2(Box::new(subst_expr(e, params))),
+            expr.span,
+        ),
+        _ => expr.clone(),
+    }
+}
+
+/// Expand a single embed directive into a list of prefixed PortDecls.
+/// Returns None if the referenced bus is unknown (error is pushed).
+fn expand_embed(
+    emb: &BusEmbed,
+    table: &SymbolTable,
+    errors: &mut Vec<CompileError>,
+) -> Option<Vec<PortDecl>> {
+    if let Some((Symbol::Bus(ref_info), _)) = table.globals.get(&emb.bus_name.name) {
+        let mut param_map = ref_info.default_param_map();
+        for pa in &emb.params {
+            param_map.insert(pa.name.name.clone(), &pa.value);
+        }
+        let ref_signals = ref_info.effective_signals(&param_map);
+        let ports = ref_signals.into_iter().map(|(sname, sdir, sty)| {
+            let subst_ty = subst_type_expr(&sty, &param_map);
+            PortDecl {
+                name: Ident { name: format!("{}_{}", emb.prefix.name, sname), span: emb.span },
+                direction: sdir,
+                ty: subst_ty,
+                default: None,
+                reg_info: None,
+                bus_info: None,
+                shared: None,
+                span: emb.span,
+            }
+        }).collect();
+        Some(ports)
+    } else {
+        errors.push(CompileError::general(
+            &format!("embed: unknown bus `{}`", emb.bus_name.name),
+            emb.bus_name.span,
+        ));
+        None
+    }
+}
+
 /// Evaluate a generate_if condition in a bus context.
 /// Supports simple param references (truthy if nonzero) and literal integers.
 fn eval_bus_cond(expr: &Expr, param_map: &HashMap<String, &Expr>) -> bool {
@@ -442,6 +518,8 @@ pub fn resolve(source_file: &SourceFile) -> Result<SymbolTable, Vec<CompileError
                 if table.globals.contains_key(&b.name.name) {
                     errors.push(CompileError::duplicate(&b.name.name, b.name.span));
                 } else {
+                    // Phase 1: register with direct signals only (no embed expansion yet).
+                    // Embeds are expanded in a second pass after all buses are registered.
                     let info = BusInfo {
                         name: b.name.name.clone(),
                         params: b.params.clone(),
@@ -561,7 +639,56 @@ pub fn resolve(source_file: &SourceFile) -> Result<SymbolTable, Vec<CompileError
         }
     }
 
-    // Second pass: resolve module-level symbols
+    // Phase 2: expand bus embeds now that all buses are registered.
+    // Handles both top-level embeds and embeds inside generate_if branches.
+    // Processes buses in source order for correct transitive expansion.
+    for item in &source_file.items {
+        if let Item::Bus(b) = item {
+            let has_embeds = !b.embeds.is_empty()
+                || b.generates.iter().any(|g| !g.then_embeds.is_empty() || !g.else_embeds.is_empty());
+            if !has_embeds { continue; }
+
+            let mut extra_signals: Vec<PortDecl> = Vec::new();
+            let mut gen_extra: Vec<(usize, Vec<PortDecl>, Vec<PortDecl>)> = Vec::new();
+
+            // Expand top-level embeds → append to signals
+            for emb in &b.embeds {
+                match expand_embed(emb, &table, &mut errors) {
+                    Some(ports) => extra_signals.extend(ports),
+                    None => {}
+                }
+            }
+
+            // Expand embeds inside generate_if branches
+            for (gi, gen) in b.generates.iter().enumerate() {
+                let then_ports: Vec<PortDecl> = gen.then_embeds.iter()
+                    .filter_map(|emb| expand_embed(emb, &table, &mut errors))
+                    .flatten()
+                    .collect();
+                let else_ports: Vec<PortDecl> = gen.else_embeds.iter()
+                    .filter_map(|emb| expand_embed(emb, &table, &mut errors))
+                    .flatten()
+                    .collect();
+                if !then_ports.is_empty() || !else_ports.is_empty() {
+                    gen_extra.push((gi, then_ports, else_ports));
+                }
+            }
+
+            if let Some((Symbol::Bus(ref mut info), _)) = table.globals.get_mut(&b.name.name) {
+                // Append top-level embed expansions as (name, dir, ty) tuples
+                for port in extra_signals {
+                    info.signals.push((port.name.name, port.direction, port.ty));
+                }
+                // Append generate_if branch embed expansions to the branch signal lists
+                for (gi, then_ports, else_ports) in gen_extra {
+                    info.generates[gi].then_signals.extend(then_ports);
+                    info.generates[gi].else_signals.extend(else_ports);
+                }
+            }
+        }
+    }
+
+    // Third pass: resolve module-level symbols
     for item in &source_file.items {
         if let Item::Module(m) = item {
             let mut scope = HashMap::new();

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -455,8 +455,8 @@ impl<'a> TypeChecker<'a> {
                         if let Some((_, bus_name)) = target_bus_ports.iter().find(|(pn, _)| *pn == conn.port_name.name) {
                             if let Some((crate::resolve::Symbol::Bus(info), _)) = self.symbols.globals.get(bus_name) {
                                 if let ExprKind::Ident(sig_base) = &conn.signal.kind {
-                                    // Find the inst's bus port perspective
-                                    let inst_perspective = self.source.items.iter()
+                                    // Find the inst's bus port perspective and params
+                                    let inst_bus_info = self.source.items.iter()
                                         .find_map(|item| match item {
                                             Item::Module(m2) if m2.name.name == inst.module_name.name => Some(m2.ports.as_slice()),
                                             Item::Fsm(f2) if f2.name.name == inst.module_name.name => Some(f2.ports.as_slice()),
@@ -464,10 +464,15 @@ impl<'a> TypeChecker<'a> {
                                         })
                                         .and_then(|ports| ports.iter()
                                             .find(|p| p.name.name == conn.port_name.name)
-                                            .and_then(|p| p.bus_info.as_ref())
-                                            .map(|bi| bi.perspective));
+                                            .and_then(|p| p.bus_info.as_ref()));
+                                    let inst_perspective = inst_bus_info.map(|bi| bi.perspective);
 
-                                    let _eff = info.effective_signals(&info.default_param_map()); for (sname, sdir, _) in &_eff {
+                                    let mut pm = info.default_param_map();
+                                    if let Some(bi) = inst_bus_info {
+                                        for pa in &bi.params { pm.insert(pa.name.name.clone(), &pa.value); }
+                                    }
+                                    let eff = info.effective_signals(&pm);
+                                    for (sname, sdir, _) in &eff {
                                         // Determine actual direction from inst's perspective
                                         let inst_dir = match inst_perspective {
                                             Some(BusPerspective::Initiator) => *sdir,
@@ -554,7 +559,10 @@ impl<'a> TypeChecker<'a> {
                 // Bus port: check each output signal is driven (flattened name: port_signal)
                 let bus_name = &bi.bus_name.name;
                 if let Some((crate::resolve::Symbol::Bus(info), _)) = self.symbols.globals.get(bus_name) {
-                    let _eff = info.effective_signals(&info.default_param_map()); for (sname, sdir, _) in &_eff {
+                    let mut pm = info.default_param_map();
+                    for pa in &bi.params { pm.insert(pa.name.name.clone(), &pa.value); }
+                    let eff = info.effective_signals(&pm);
+                    for (sname, sdir, _) in &eff {
                         let actual_dir = match bi.perspective {
                             BusPerspective::Initiator => *sdir,
                             BusPerspective::Target => (*sdir).flip(),

--- a/tests/bus_embed/BusAxiAddr.arch
+++ b/tests/bus_embed/BusAxiAddr.arch
@@ -1,0 +1,63 @@
+// Minimal AXI address channel bus
+bus BusAxiAddr
+  param ADDR_W: const = 32;
+  param ID_W:   const = 4;
+  valid: out Bool;
+  ready: in  Bool;
+  addr:  out UInt<ADDR_W>;
+  id:    out UInt<ID_W>;
+  len:   out UInt<8>;
+end bus BusAxiAddr
+
+// AXI R data channel bus
+bus BusAxiRData
+  param DATA_W: const = 32;
+  param ID_W:   const = 4;
+  valid: in  Bool;
+  ready: out Bool;
+  data:  in  UInt<DATA_W>;
+  id:    in  UInt<ID_W>;
+  last:  in  Bool;
+end bus BusAxiRData
+
+// AXI W data channel bus
+bus BusAxiWData
+  param DATA_W: const = 32;
+  param STRB_W: const = 4;
+  valid: out Bool;
+  ready: in  Bool;
+  data:  out UInt<DATA_W>;
+  strb:  out UInt<STRB_W>;
+  last:  out Bool;
+end bus BusAxiWData
+
+// Composed read-only AXI bus using embed
+bus BusAxi4Read
+  param ADDR_W: const = 32;
+  param DATA_W: const = 32;
+  param ID_W:   const = 4;
+  embed ar: BusAxiAddr<ADDR_W=ADDR_W, ID_W=ID_W>;
+  embed r:  BusAxiRData<DATA_W=DATA_W, ID_W=ID_W>;
+end bus BusAxi4Read
+
+// Composed write-only AXI bus using embed
+bus BusAxi4Write
+  param ADDR_W: const = 32;
+  param DATA_W: const = 32;
+  param STRB_W: const = 4;
+  param ID_W:   const = 4;
+  embed aw: BusAxiAddr<ADDR_W=ADDR_W, ID_W=ID_W>;
+  embed w:  BusAxiWData<DATA_W=DATA_W, STRB_W=STRB_W>;
+end bus BusAxi4Write
+
+// Composed full AXI bus: re-embeds the same primitives
+bus BusAxi4Full
+  param ADDR_W: const = 32;
+  param DATA_W: const = 32;
+  param STRB_W: const = 4;
+  param ID_W:   const = 4;
+  embed ar: BusAxiAddr<ADDR_W=ADDR_W, ID_W=ID_W>;
+  embed r:  BusAxiRData<DATA_W=DATA_W, ID_W=ID_W>;
+  embed aw: BusAxiAddr<ADDR_W=ADDR_W, ID_W=ID_W>;
+  embed w:  BusAxiWData<DATA_W=DATA_W, STRB_W=STRB_W>;
+end bus BusAxi4Full

--- a/tests/bus_embed/ParamRemap.arch
+++ b/tests/bus_embed/ParamRemap.arch
@@ -1,0 +1,32 @@
+package PkgRemap
+  domain SysDomain
+    freq_mhz: 100
+  end domain SysDomain
+end package PkgRemap
+
+// Parent bus uses DIFFERENT param names than the embedded bus.
+// This tests that param substitution maps correctly.
+bus BusWide
+  param MY_WIDTH: const = 16;
+  param MY_ID_W: const = 2;
+  embed ch: BusAxiAddr<ADDR_W=MY_WIDTH, ID_W=MY_ID_W>;
+end bus BusWide
+
+// Module that uses BusWide with non-default params.
+// This verifies the full chain: parent param override → embed param subst → SV type.
+module ParamRemapTest
+  param W: const = 64;
+
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+
+  port bus_port: initiator BusWide<MY_WIDTH=W, MY_ID_W=8>;
+
+  comb
+    bus_port.ch_valid = true;
+    bus_port.ch_addr  = 0;
+    bus_port.ch_id    = 0;
+    bus_port.ch_len   = 0;
+  end comb
+
+end module ParamRemapTest

--- a/tests/bus_embed/ParamRemap.sv
+++ b/tests/bus_embed/ParamRemap.sv
@@ -1,0 +1,32 @@
+package PkgRemap;
+endpackage
+
+// Parent bus uses DIFFERENT param names than the embedded bus.
+// This tests that param substitution maps correctly.
+// Module that uses BusWide with non-default params.
+// This verifies the full chain: parent param override → embed param subst → SV type.
+module ParamRemapTest #(
+  parameter int W = 64
+) (
+  input logic clk,
+  input logic rst,
+  output logic bus_port_ch_valid,
+  input logic bus_port_ch_ready,
+  output logic [W-1:0] bus_port_ch_addr,
+  output logic [7:0] bus_port_ch_id,
+  output logic [7:0] bus_port_ch_len
+);
+
+  assign bus_port_ch_valid = 1'b1;
+  assign bus_port_ch_addr = 0;
+  assign bus_port_ch_id = 0;
+  assign bus_port_ch_len = 0;
+
+endmodule
+
+// Minimal AXI address channel bus
+// AXI R data channel bus
+// AXI W data channel bus
+// Composed read-only AXI bus using embed
+// Composed write-only AXI bus using embed
+// Composed full AXI bus: re-embeds the same primitives

--- a/tests/bus_embed/ReadMaster.arch
+++ b/tests/bus_embed/ReadMaster.arch
@@ -1,0 +1,52 @@
+package PkgTest
+  domain SysDomain
+    freq_mhz: 100
+  end domain SysDomain
+end package PkgTest
+
+// A simple read master using the composed BusAxi4Read
+module ReadMaster
+  param ADDR_W: const = 32;
+  param DATA_W: const = 32;
+  param ID_W:   const = 4;
+
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+
+  // Read-only AXI master — uses the embed-composed bus
+  port axi_rd: initiator BusAxi4Read<ADDR_W=ADDR_W, DATA_W=DATA_W, ID_W=ID_W>;
+
+  // Control
+  port start_i:    in Bool;
+  port addr_i:     in UInt<ADDR_W>;
+  port data_o:     out UInt<DATA_W>;
+  port data_vld_o: out Bool;
+
+  reg active_q: Bool reset rst => false;
+
+  default seq on clk rising;
+
+  // Drive AR channel using the prefixed signal names (ar_valid, ar_addr, etc.)
+  comb
+    axi_rd.ar_valid = start_i and not active_q;
+    axi_rd.ar_addr  = addr_i;
+    axi_rd.ar_id    = 0;
+    axi_rd.ar_len   = 0;
+  end comb
+
+  // Accept R channel
+  comb
+    axi_rd.r_ready = true;
+    data_o     = axi_rd.r_data;
+    data_vld_o = axi_rd.r_valid;
+  end comb
+
+  seq
+    if start_i and not active_q
+      active_q <= true;
+    elsif axi_rd.r_valid and axi_rd.r_last
+      active_q <= false;
+    end if
+  end seq
+
+end module ReadMaster

--- a/tests/bus_embed/ReadMaster.sv
+++ b/tests/bus_embed/ReadMaster.sv
@@ -1,0 +1,59 @@
+package PkgTest;
+endpackage
+
+// A simple read master using the composed BusAxi4Read
+module ReadMaster #(
+  parameter int ADDR_W = 32,
+  parameter int DATA_W = 32,
+  parameter int ID_W = 4
+) (
+  input logic clk,
+  input logic rst,
+  output logic axi_rd_ar_valid,
+  input logic axi_rd_ar_ready,
+  output logic [ADDR_W-1:0] axi_rd_ar_addr,
+  output logic [ID_W-1:0] axi_rd_ar_id,
+  output logic [7:0] axi_rd_ar_len,
+  input logic axi_rd_r_valid,
+  output logic axi_rd_r_ready,
+  input logic [DATA_W-1:0] axi_rd_r_data,
+  input logic [ID_W-1:0] axi_rd_r_id,
+  input logic axi_rd_r_last,
+  input logic start_i,
+  input logic [ADDR_W-1:0] addr_i,
+  output logic [DATA_W-1:0] data_o,
+  output logic data_vld_o
+);
+
+  // Read-only AXI master — uses the embed-composed bus
+  // Control
+  logic active_q;
+  // Drive AR channel using the prefixed signal names (ar_valid, ar_addr, etc.)
+  assign axi_rd_ar_valid = start_i && !active_q;
+  assign axi_rd_ar_addr = addr_i;
+  assign axi_rd_ar_id = 0;
+  assign axi_rd_ar_len = 0;
+  // Accept R channel
+  assign axi_rd_r_ready = 1'b1;
+  assign data_o = axi_rd_r_data;
+  assign data_vld_o = axi_rd_r_valid;
+  always_ff @(posedge clk) begin
+    if (rst) begin
+      active_q <= 1'b0;
+    end else begin
+      if (start_i && !active_q) begin
+        active_q <= 1'b1;
+      end else if (axi_rd_r_valid && axi_rd_r_last) begin
+        active_q <= 1'b0;
+      end
+    end
+  end
+
+endmodule
+
+// Minimal AXI address channel bus
+// AXI R data channel bus
+// AXI W data channel bus
+// Composed read-only AXI bus using embed
+// Composed write-only AXI bus using embed
+// Composed full AXI bus: re-embeds the same primitives

--- a/tests/bus_embed/TransitiveEmbed.arch
+++ b/tests/bus_embed/TransitiveEmbed.arch
@@ -1,0 +1,35 @@
+package PkgTrans
+  domain SysDomain
+    freq_mhz: 100
+  end domain SysDomain
+end package PkgTrans
+
+// Level 0: leaf bus
+bus BusLeaf
+  data: out UInt<8>;
+end bus BusLeaf
+
+// Level 1: embeds leaf
+bus BusMid
+  embed leaf: BusLeaf;
+  ctrl: out Bool;
+end bus BusMid
+
+// Level 2: embeds mid (transitive — should include leaf_data)
+bus BusTop
+  embed mid: BusMid;
+  top_flag: out Bool;
+end bus BusTop
+
+// Module using the transitively-composed bus
+module TransTest
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port top_port: initiator BusTop;
+
+  comb
+    top_port.top_flag      = true;
+    top_port.mid_ctrl      = true;
+    top_port.mid_leaf_data = 42;
+  end comb
+end module TransTest

--- a/tests/bus_embed/TransitiveEmbed.sv
+++ b/tests/bus_embed/TransitiveEmbed.sv
@@ -1,0 +1,21 @@
+package PkgTrans;
+endpackage
+
+// Level 0: leaf bus
+// Level 1: embeds leaf
+// Level 2: embeds mid (transitive — should include leaf_data)
+// Module using the transitively-composed bus
+module TransTest (
+  input logic clk,
+  input logic rst,
+  output logic top_port_top_flag,
+  output logic top_port_mid_ctrl,
+  output logic [7:0] top_port_mid_leaf_data
+);
+
+  assign top_port_top_flag = 1'b1;
+  assign top_port_mid_ctrl = 1'b1;
+  assign top_port_mid_leaf_data = 42;
+
+endmodule
+

--- a/tests/bus_genif_bug/BusGenIf.arch
+++ b/tests/bus_genif_bug/BusGenIf.arch
@@ -1,0 +1,80 @@
+package PkgTest
+  domain SysDomain
+    freq_mhz: 100
+  end domain SysDomain
+end package PkgTest
+
+bus BusAxi4
+  param ADDR_W: const = 64;
+  param DATA_W: const = 64;
+  param ID_W:   const = 4;
+  param USER_W: const = 1;
+  param READ:   const = 1;
+  param WRITE:  const = 1;
+
+  generate_if READ
+    ar_valid:  out Bool;
+    ar_ready:  in  Bool;
+    ar_addr:   out UInt<ADDR_W>;
+    r_valid:   in  Bool;
+    r_ready:   out Bool;
+    r_data:    in  UInt<DATA_W>;
+  end generate_if
+
+  generate_if WRITE
+    aw_valid:  out Bool;
+    aw_ready:  in  Bool;
+    aw_addr:   out UInt<ADDR_W>;
+    w_valid:   out Bool;
+    w_ready:   in  Bool;
+    w_data:    out UInt<DATA_W>;
+    b_valid:   in  Bool;
+    b_ready:   out Bool;
+  end generate_if
+end bus BusAxi4
+
+// Read-only transport: should only have AR+R ports, no AW/W/B
+module ReadTransport
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port axi: initiator BusAxi4<READ=1, WRITE=0>;
+
+  comb
+    axi.ar_valid = true;
+    axi.ar_addr  = 0;
+    axi.r_ready  = true;
+  end comb
+end module ReadTransport
+
+// Write-only transport: should only have AW/W/B ports, no AR/R
+module WriteTransport
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port axi: initiator BusAxi4<READ=0, WRITE=1>;
+
+  comb
+    axi.aw_valid = true;
+    axi.aw_addr  = 0;
+    axi.w_valid  = true;
+    axi.w_data   = 0;
+    axi.b_ready  = true;
+  end comb
+end module WriteTransport
+
+// Full transport: all channels
+module FullTransport
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port axi: initiator BusAxi4<READ=1, WRITE=1>;
+
+  comb
+    axi.ar_valid = true;
+    axi.ar_addr  = 0;
+    axi.r_ready  = true;
+    axi.aw_valid = true;
+    axi.aw_addr  = 0;
+    axi.w_valid  = true;
+    axi.w_data   = 0;
+    axi.b_ready  = true;
+  end comb
+end module FullTransport


### PR DESCRIPTION
## Summary

- **Fix `generate_if` bus typecheck bug**: The driven-output check for bus ports used `default_param_map()` instead of port-site parameter overrides, causing false "output port is not driven" errors when using `BusAxi4<WRITE=0>` in `module` contexts. FSMs were unaffected because they use a different code path. Fix: build the param map from defaults + port overrides, matching the pattern already used in codegen.

- **Add `embed` bus composition**: New `embed prefix: BusName<PARAM=val>;` syntax inside bus bodies to compose buses from reusable sub-bus building blocks. Each embed flattens the referenced bus's signals with a name prefix. Supports param substitution, transitive embedding, two-pass resolve (file-order independent), and `.archi` round-trip.

- **Allow `embed` inside `generate_if` branches**: Enables conditional channel composition, e.g. a single `BusAxi4` with `generate_if READ` / `generate_if WRITE` branches that embed channel-level buses.

## Motivation

Defining AXI4 bus variants (read-only, write-only, full) required either:
1. One bus with `generate_if` — but this was broken for `module` contexts (only worked in `fsm`)
2. Three separate bus types — duplicating ~40 signal definitions 3x

With these changes, a single parameterized bus works correctly everywhere:

```
bus BusAxi4
  param READ:  const = 1;
  param WRITE: const = 1;

  generate_if READ
    embed ar: BusAxiAddr;
    embed r:  BusAxiRData;
  end generate_if

  generate_if WRITE
    embed aw: BusAxiAddr;
    embed w:  BusAxiWData;
    embed b:  BusAxiBresp;
  end generate_if
end bus BusAxi4
```

Used as `BusAxi4<WRITE=0>` for read-only, `BusAxi4<READ=0>` for write-only, or `BusAxi4` for full.

## Test plan

- [x] All 64 existing tests pass (12 unit + 52 integration)
- [x] New test: `bus_genif_bug/BusGenIf.arch` — `generate_if` with READ/WRITE in module ports
- [x] New test: `bus_embed/ReadMaster.arch` — basic embed composition + SV build + Verilator lint
- [x] New test: `bus_embed/ParamRemap.arch` — param name remapping through embed chain
- [x] New test: `bus_embed/TransitiveEmbed.arch` — three-level transitive embed
- [x] Verilator lint clean on all generated SV (zero warnings)
- [x] Separate compilation via `.archi` files round-trips correctly