### PR TITLE
fix: use port-site params in typecheck bus signal driven check

### DIFF
--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -455,8 +455,8 @@ impl<'a> TypeChecker<'a> {
                         if let Some((_, bus_name)) = target_bus_ports.iter().find(|(pn, _)| *pn == conn.port_name.name) {
                             if let Some((crate::resolve::Symbol::Bus(info), _)) = self.symbols.globals.get(bus_name) {
                                 if let ExprKind::Ident(sig_base) = &conn.signal.kind {
-                                    // Find the inst's bus port perspective
-                                    let inst_perspective = self.source.items.iter()
+                                    // Find the inst's bus port perspective and params
+                                    let inst_bus_info = self.source.items.iter()
                                         .find_map(|item| match item {
                                             Item::Module(m2) if m2.name.name == inst.module_name.name => Some(m2.ports.as_slice()),
                                             Item::Fsm(f2) if f2.name.name == inst.module_name.name => Some(f2.ports.as_slice()),
@@ -464,10 +464,15 @@ impl<'a> TypeChecker<'a> {
                                         })
                                         .and_then(|ports| ports.iter()
                                             .find(|p| p.name.name == conn.port_name.name)
-                                            .and_then(|p| p.bus_info.as_ref())
-                                            .map(|bi| bi.perspective));
+                                            .and_then(|p| p.bus_info.as_ref()));
+                                    let inst_perspective = inst_bus_info.map(|bi| bi.perspective);
 
-                                    let _eff = info.effective_signals(&info.default_param_map()); for (sname, sdir, _) in &_eff {
+                                    let mut pm = info.default_param_map();
+                                    if let Some(bi) = inst_bus_info {
+                                        for pa in &bi.params { pm.insert(pa.name.name.clone(), &pa.value); }
+                                    }
+                                    let eff = info.effective_signals(&pm);
+                                    for (sname, sdir, _) in &eff {
                                         // Determine actual direction from inst's perspective
                                         let inst_dir = match inst_perspective {
                                             Some(BusPerspective::Initiator) => *sdir,
@@ -554,7 +559,10 @@ impl<'a> TypeChecker<'a> {
                 // Bus port: check each output signal is driven (flattened name: port_signal)
                 let bus_name = &bi.bus_name.name;
                 if let Some((crate::resolve::Symbol::Bus(info), _)) = self.symbols.globals.get(bus_name) {
-                    let _eff = info.effective_signals(&info.default_param_map()); for (sname, sdir, _) in &_eff {
+                    let mut pm = info.default_param_map();
+                    for pa in &bi.params { pm.insert(pa.name.name.clone(), &pa.value); }
+                    let eff = info.effective_signals(&pm);
+                    for (sname, sdir, _) in &eff {
                         let actual_dir = match bi.perspective {
                             BusPerspective::Initiator => *sdir,
                             BusPerspective::Target => (*sdir).flip(),

--- a/tests/bus_genif_bug/BusGenIf.arch
+++ b/tests/bus_genif_bug/BusGenIf.arch
@@ -1,0 +1,80 @@
+package PkgTest
+  domain SysDomain
+    freq_mhz: 100
+  end domain SysDomain
+end package PkgTest
+
+bus BusAxi4
+  param ADDR_W: const = 64;
+  param DATA_W: const = 64;
+  param ID_W:   const = 4;
+  param USER_W: const = 1;
+  param READ:   const = 1;
+  param WRITE:  const = 1;
+
+  generate_if READ
+    ar_valid:  out Bool;
+    ar_ready:  in  Bool;
+    ar_addr:   out UInt<ADDR_W>;
+    r_valid:   in  Bool;
+    r_ready:   out Bool;
+    r_data:    in  UInt<DATA_W>;
+  end generate_if
+
+  generate_if WRITE
+    aw_valid:  out Bool;
+    aw_ready:  in  Bool;
+    aw_addr:   out UInt<ADDR_W>;
+    w_valid:   out Bool;
+    w_ready:   in  Bool;
+    w_data:    out UInt<DATA_W>;
+    b_valid:   in  Bool;
+    b_ready:   out Bool;
+  end generate_if
+end bus BusAxi4
+
+// Read-only transport: should only have AR+R ports, no AW/W/B
+module ReadTransport
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port axi: initiator BusAxi4<READ=1, WRITE=0>;
+
+  comb
+    axi.ar_valid = true;
+    axi.ar_addr  = 0;
+    axi.r_ready  = true;
+  end comb
+end module ReadTransport
+
+// Write-only transport: should only have AW/W/B ports, no AR/R
+module WriteTransport
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port axi: initiator BusAxi4<READ=0, WRITE=1>;
+
+  comb
+    axi.aw_valid = true;
+    axi.aw_addr  = 0;
+    axi.w_valid  = true;
+    axi.w_data   = 0;
+    axi.b_ready  = true;
+  end comb
+end module WriteTransport
+
+// Full transport: all channels
+module FullTransport
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port axi: initiator BusAxi4<READ=1, WRITE=1>;
+
+  comb
+    axi.ar_valid = true;
+    axi.ar_addr  = 0;
+    axi.r_ready  = true;
+    axi.aw_valid = true;
+    axi.aw_addr  = 0;
+    axi.w_valid  = true;
+    axi.w_data   = 0;
+    axi.b_ready  = true;
+  end comb
+end module FullTransport


### PR DESCRIPTION
## Summary

The driven-output check for bus ports called `effective_signals()` with `default_param_map()`, ignoring port-site parameter overrides. This caused `module` contexts using parameterized buses like `BusAxi4<WRITE=0>` to report false "output port is not driven" errors for signals excluded by `generate_if` conditions.

The codegen path already builds the param map correctly (defaults + port overrides). The typecheck just needed the same pattern.

**Affected call sites** (both fixed):
- Module output driven check — `BusAxi4<WRITE=0>` falsely required `aw_valid` etc.
- Instance bus connection tracking — whole-bus connections didn't filter by port-site params

**Not affected**: FSM contexts use a different code path that was already correct.

## Test plan

- [x] All 64 existing tests pass
- [x] New regression test: `tests/bus_genif_bug/BusGenIf.arch` — three modules using `BusAxi4<WRITE=0>`, `BusAxi4<READ=0>`, and `BusAxi4` verify correct port subsets
- [x] Generated SV verified with Verilator lint (zero warnings)