### PR TITLE
fix(sim+codegen): struct-typed ports/regs and packed-struct bit layout (v0.41.1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,14 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Commit conventions
+
+**Do not add `Co-Authored-By:` trailers for AI agents** (Claude, Copilot, etc.)
+when creating commits. The human author of record takes full ownership of the
+change, and AI co-author trailers break the CLA Assistant (which requires every
+listed author to individually sign the CLA — `noreply@anthropic.com` can't).
+Just write a normal commit message with no AI attribution trailer.
+
 ## Project Overview
 
 `arch-com` is a compiler for **ARCH**, a purpose-built hardware description language (HDL) for micro-architecture work. The compiler ingests `.arch` source files and emits deterministic, readable SystemVerilog. The language is explicitly designed to be generated correctly by LLMs from natural-language hardware descriptions.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,7 +75,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arch"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "clap",
  "insta",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arch"
-version = "0.41.0"
+version = "0.41.1"
 edition = "2021"
 description = "Compiler for the ARCH hardware description language"
 license = "LGPL-3.0-or-later"

--- a/doc/ARCH_HDL_Specification.md
+++ b/doc/ARCH_HDL_Specification.md
@@ -311,7 +311,7 @@ The Arch type system enforces four independent safety dimensions simultaneously.
 
   **Vec\<T,N\>**       N × \|T\|            Fixed-size array of any hardware type T.
 
-  **struct S**         Σ fields             Named aggregate. Width = sum of field widths (packed).
+  **struct S**         Σ fields             Named aggregate. Width = sum of field widths (packed). **Bit layout: declaration-first = MSB, last-declared = LSB — matching SV `struct packed` convention.** A testbench that reads a struct-typed signal as an integer finds the first-declared field in the top bits. The C++ simulation model lays out fields in declaration order in memory (natural C++); per-field access through pybind is by name, so the memory layout is not observable to testbenches.
 
   **enum E**           ⌈log₂n⌉ bits         Discriminated union. Compiler picks minimum encoding width.
 

--- a/doc/Arch_AI_Reference_Card.md
+++ b/doc/Arch_AI_Reference_Card.md
@@ -150,6 +150,7 @@ enum E   { A, B, }
 - `Bit` is an alias for `UInt<1>`
 - `Token`, `Future<T>`, `Token<T, id_width: N>` (planned — TLM only)
 - `Clock<Domain>` may be `out` — use for passthrough (`comb clk_out = clk_in;`), gating (`comb clk_out = clk_in & en;`), or division. For integrated latch-based gating use the `clkgate` construct.
+- **`struct` packed bit layout: declaration-first = MSB** (SV convention). A TB reading a struct-typed signal as an integer finds the first-declared field in the top bits, last-declared at the LSBs.
 
 **Width conversions** (always explicit):
 

--- a/doc/COMPILER_STATUS.md
+++ b/doc/COMPILER_STATUS.md
@@ -1,7 +1,7 @@
 # ARCH Compiler — Status & Roadmap
 
 > Last updated: 2026-04-17
-> Compiler version: 0.41.0 (`arch formal` direct SMT-LIB2 bounded model checking; `<=` now parses as less-than-or-equal in expression contexts)
+> Compiler version: 0.41.1 (`arch formal` direct SMT-LIB2 bounded model checking; `<=` parses as less-than-or-equal in expression contexts; packed-struct bit layout flipped to SV convention — declaration-first = MSB)
 
 ---
 
@@ -35,7 +35,7 @@
 | Construct | Status | Notes |
 |-----------|--------|-------|
 | `domain` | ✅ | Emitted as SV comments; **`SysDomain` is built-in** — no explicit `domain SysDomain end domain SysDomain` declaration needed; can be overridden by user |
-| `struct` | ✅ | `typedef struct packed` |
+| `struct` | ✅ | `typedef struct packed`; **packed bit layout: declaration-first = MSB** (SV convention, v0.41.1+). Earlier versions packed declaration-first = LSB — regenerate any pre-v0.41.1 `.sv` before mixing with new output |
 | `enum` | ✅ | `typedef enum logic`; auto width ⌈log₂(N)⌉ |
 | `module` | ✅ | Params, ports, reg/comb/let/wire/inst body; `seq on` clocked blocks with per-reg reset; **`default seq on clk rising\|falling;`** sets module-level default clock — enables multi-line `seq ... end seq` without explicit clock; **register syntax**: `reg x: UInt<8> [init VALUE] [reset SIGNAL=VALUE [sync\|async high\|low]];` — `init` (optional) sets SV declaration initializer, `reset SIGNAL=VALUE` (optional) sets async/sync reset with explicit reset value (value is **required** after `=`); `reset none` for no reset; `reg default:` applies defaults; compiler auto-generates reset guards; mixed reset/no-reset partitioning; **`let` two forms**: `let x: T = expr;` declares a new combinational wire (type required); `let x = expr;` (no type) assigns to an already-declared output port or wire — replaces the former `comb x = expr;` one-liner; `wire name: T;` declares a combinational net driven by `let x = expr;` or inside a `comb ... end comb` block (type checker enforces: only `wire` and output ports are valid comb targets; assigning a `reg` in `comb` is a compile error); **`comb` one-liner removed**: `comb x = expr;` is no longer valid — use `let x = expr;` instead; `comb ... end comb` block form still required for conditional assignments; **for loops**: `for VAR in START..END ... end for` in both `comb` and `seq` blocks — emits SV `for (int VAR = START; VAR <= END; VAR++)`; **indexed comb targets**: `port[i] = expr` in `comb` blocks is correctly detected as driving the port for driven-port and multiple-driver checks; **comb same-block reassignment**: multiple assignments to the same signal within a single `comb` block are allowed (default + override in if/elsif/else branches — standard latch-free combinational pattern) |
 | `latch` block | ✅ | `latch on ENABLE ... end latch` — level-sensitive storage; enable signal must be `Bool` or `Clock`; body uses `<=` assignments to `reg` targets; emits SV `always_latch begin if (enable) ... end` |

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -375,11 +375,13 @@ impl<'a> Codegen<'a> {
     }
 
     fn emit_struct(&mut self, s: &StructDecl) {
-        // SV packed structs are MSB-first: first field listed = most significant bits.
-        // Fields are reversed so the first ARCH field occupies the LSBs (C-style layout).
-        self.line(&format!("typedef struct packed {{ // fields: LSB→MSB (reverse of declaration order)"));
+        // Canonical ARCH packed-struct bit layout: first-declared field = MSB,
+        // last-declared field = LSB — matching SV's `struct packed` convention
+        // (fields listed top-to-bottom inside `struct packed { ... }` are emitted
+        // MSB-first by the SV standard). Emit fields in declaration order.
+        self.line("typedef struct packed {");
         self.indent += 1;
-        for field in s.fields.iter().rev() {
+        for field in s.fields.iter() {
             let ty_str = self.emit_type_str(&field.ty);
             self.line(&format!("{} {};", ty_str, field.name.name));
         }

--- a/src/sim_codegen.rs
+++ b/src/sim_codegen.rs
@@ -6027,6 +6027,24 @@ impl<'a> SimCodegen<'a> {
             h.push('\n');
         }
 
+        // C++ struct emission for ARCH packed structs.
+        //
+        // Canonical ARCH bit layout is first-declared-field = MSB, last-declared = LSB
+        // (SV convention, see codegen.rs::emit_struct and the Language Specification
+        // §"Packed bit layout"). The C++ struct below lays fields out in declaration
+        // order in memory — this is the natural C++ idiom and what pybind11 expects
+        // when we expose per-field handles via `.def_readwrite`. Per-field access is
+        // bit-order-agnostic, so the C++ memory layout and the SV bit layout don't
+        // need to agree structurally.
+        //
+        // ⚠ Future maintainers: on a little-endian host (x86_64, ARM64 in default
+        // mode) a `memcpy`/`reinterpret_cast` of this C++ struct into a wide integer
+        // puts the FIRST field at the LSBs — the OPPOSITE of ARCH's canonical bit
+        // layout. If you add a code path that serializes a whole struct to a single
+        // integer (a `struct as UInt<N>` codegen, a pybind11 `__int__` / `.value`
+        // shim, a VCD compound-signal trace, etc.), you MUST explicitly concatenate
+        // `first_field → MSB, last_field → LSB` — do NOT rely on `memcpy` or
+        // `reinterpret_cast`.
         for s in &structs {
             h.push_str(&format!("struct {} {{\n", s.name.name));
             let mut field_inits = Vec::new();

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1524,6 +1524,33 @@ end module RfUser
     insta::assert_snapshot!(sv);
 }
 
+/// Regression: ARCH packed-struct bit layout is *declaration-first = MSB*,
+/// matching SV's `struct packed` convention. The first-declared ARCH field
+/// must appear *first* inside the emitted `typedef struct packed { ... }`,
+/// so it lands in the MSBs of the packed bit vector.
+/// Pre-v0.41.1 the compiler reversed field order (first = LSB); this test
+/// prevents that from silently returning.
+#[test]
+fn test_struct_packed_declaration_first_is_msb() {
+    let source = r#"
+struct Foo
+  a: UInt<8>;
+  b: UInt<4>;
+end struct Foo
+"#;
+    let sv = compile_to_sv(source);
+    let td = sv.find("typedef struct packed").expect("expected typedef struct packed in SV");
+    let end = sv[td..].find("} Foo;").expect("expected `} Foo;` closing") + td;
+    let body = &sv[td..end];
+    let pos_a = body.find("a;").expect("expected field `a`");
+    let pos_b = body.find("b;").expect("expected field `b`");
+    assert!(
+        pos_a < pos_b,
+        "field `a` (declared first) must appear before `b` in the packed typedef \
+         (SV convention: first listed = MSB). Got:\n{body}"
+    );
+}
+
 /// Regression: `<=` must be accepted as less-than-or-equal in expression context
 /// (assert/cover RHS, comb RHS, let RHS, if conditions, ternary branches), while
 /// still working as the non-blocking-assignment token at the statement level.

--- a/tests/snapshots/integration_test__struct_and_enum.snap
+++ b/tests/snapshots/integration_test__struct_and_enum.snap
@@ -2,9 +2,9 @@
 source: tests/integration_test.rs
 expression: sv
 ---
-typedef struct packed { // fields: LSB→MSB (reverse of declaration order)
-  logic valid;
+typedef struct packed {
   logic [31:0] data;
+  logic valid;
 } Packet;
 
 typedef enum logic [1:0] {


### PR DESCRIPTION
## Summary

Three struct-related fixes discovered while writing cocotb tests for a SystemRDL-generated register block (`dut.hwif_in.value`):

1. **sim codegen — struct support** (8a300d8): three related bugs in the sim/pybind path that only triggered on modules with struct-typed ports or regs (SV path was fine):
   - `VStructs.h` was empty when structs/enums lived inside a `package` — descent into `Item::Package.{structs,enums}` was missing.
   - Struct-typed port initializer emitted invalid C++ (`hwif_in(0)` on a struct field) — now emits `name()` for `TypeExpr::Named` and `name(0)` for scalars.
   - VCD trace codegen bit-shifted struct ports — `collect_trace_signals` now skips `TypeExpr::Named`.

2. **packed-struct bit layout flipped to SV convention** (d00f60e): ARCH previously packed "declaration-first = LSB" (codegen reversed field order when emitting `typedef struct packed`). That's opposite of SV and confuses any TB decoding a struct-typed signal's value. Now emits declaration order → first field = MSB, matching SV. A defensive comment in `sim_codegen.rs` flags the LE-bitcast trap for future maintainers (any code path that serializes a C++ struct to a wide int must concat first→MSB explicitly, not rely on `memcpy`). Spec §3, AI Reference Card, and COMPILER_STATUS updated. New regression test pins the order.

3. **CLAUDE.md — drop AI Co-Authored-By trailers** (6de36b4): they break CLA gating (each listed author must individually sign), so future AI-assisted commits won't add them.

Version: 0.41.0 → 0.41.1.

Impact is measured, not guessed: 0 struct declarations in `tests/**/*.arch` (599 files), only `examples/dma_engine.arch` uses one, no TB decodes its bits. Snapshot regen: one file (`test_struct_and_enum`).

## Test plan

- [x] `cargo build` clean (no new errors/warnings in affected files)
- [x] `cargo test --quiet` — all 76 tests pass (12 + 10 + 54 + new `test_struct_packed_declaration_first_is_msb`)
- [x] Snapshot `integration_test__struct_and_enum.snap` regenerated and inspected — fields now appear in declaration order in the packed typedef
- [x] Manual: `arch formal` integration tests (10) still pass, incl. solver parity (z3 / boolector / bitwuzla)
- [ ] Downstream sanity check: a cocotb test that decodes `dut.hwif_in.value` now sees fields in SV-canonical order (motivating scenario for this PR)