### PR TITLE
feat: allow reg and let declarations inside generate_for / generate_if

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -248,13 +248,17 @@ pub struct AssertDecl {
 
 // ── Generate ──────────────────────────────────────────────────────────────────
 
-/// An item inside a generate block: port, instance, or thread.
+/// An item inside a generate block: port, instance, thread, reg, or let.
+/// Reg and let are always expanded at elaboration time (there's no SV `generate
+/// for reg r: ...`), so using them forces the range to be compile-time known.
 #[derive(Debug, Clone)]
 pub enum GenItem {
     Port(PortDecl),
     Inst(InstDecl),
     Thread(ThreadBlock),
     Assert(AssertDecl),
+    Reg(RegDecl),
+    Let(LetBinding),
 }
 
 /// `generate for VAR in START..END ... end generate for VAR`

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -2040,6 +2040,8 @@ impl<'a> Codegen<'a> {
                         GenItem::Inst(inst) => self.emit_inst(inst),
                         GenItem::Port(_) => unreachable!("port GenItems should have been lifted by elaboration"),
                         GenItem::Thread(_) => unreachable!("thread GenItems should have been lowered by elaboration"),
+                        GenItem::Reg(_) | GenItem::Let(_) => unreachable!(
+                            "reg/let GenItems should have been unrolled by elaboration"),
                         GenItem::Assert(_) => {
                             // SVA inside generate for: not yet supported in SV codegen (SVA needs static clock ref)
                         }
@@ -2057,6 +2059,8 @@ impl<'a> Codegen<'a> {
                         GenItem::Inst(inst) => self.emit_inst(inst),
                         GenItem::Port(_) => unreachable!("port GenItems should have been lifted by elaboration"),
                         GenItem::Thread(_) => unreachable!("thread GenItems should have been lowered by elaboration"),
+                        GenItem::Reg(_) | GenItem::Let(_) => unreachable!(
+                            "reg/let GenItems should have been unrolled by elaboration"),
                         GenItem::Assert(_) => {}
                     }
                 }
@@ -2069,6 +2073,8 @@ impl<'a> Codegen<'a> {
                             GenItem::Inst(inst) => self.emit_inst(inst),
                             GenItem::Port(_) => unreachable!("port GenItems should have been lifted by elaboration"),
                             GenItem::Thread(_) => unreachable!("thread GenItems should have been lowered by elaboration"),
+                            GenItem::Reg(_) | GenItem::Let(_) => unreachable!(
+                                "reg/let GenItems should have been unrolled by elaboration"),
                             GenItem::Assert(_) => {}
                         }
                     }

--- a/src/elaborate.rs
+++ b/src/elaborate.rs
@@ -438,6 +438,14 @@ fn expand_generate_for(
 
     let has_port_items = gf.items.iter().any(|item| matches!(item, GenItem::Port(_)));
     let has_thread_items = gf.items.iter().any(|item| matches!(item, GenItem::Thread(_)));
+    // Reg / let items also force elaboration-time expansion: SV's native
+    // `generate for` can host reg/wire, but ARCH's reg-reset and let-with-
+    // optional-type-annotation forms don't round-trip cleanly through the
+    // preserve-as-SV path without additional codegen work. Always unrolling
+    // covers the common "N identical registers" pattern and keeps the range
+    // constraint simple (must be compile-time known).
+    let has_reg_or_let = gf.items.iter().any(|item|
+        matches!(item, GenItem::Reg(_) | GenItem::Let(_)));
     let range_depends_on_param = expr_references_param(&gf.start, &param_names)
         || expr_references_param(&gf.end, &param_names);
 
@@ -449,7 +457,7 @@ fn expand_generate_for(
     // preserve the generate block as-is so codegen emits SV generate for.
     // This allows the SV to be parameterized (e.g. NUM_MODULES can be overridden).
     // Threads must always be expanded (they need concrete lowering to FSMs).
-    if range_depends_on_param && !has_port_items && !has_thread_items {
+    if range_depends_on_param && !has_port_items && !has_thread_items && !has_reg_or_let {
         return Ok((
             Vec::new(),
             vec![ModuleBodyItem::Generate(GenerateDecl::For(gf))],
@@ -484,6 +492,8 @@ fn expand_generate_for(
                 GenItem::Inst(inst) => body.push(ModuleBodyItem::Inst(subst_inst(inst, var, i))),
                 GenItem::Thread(t) => body.push(ModuleBodyItem::Thread(subst_thread(t, var, i))),
                 GenItem::Assert(a) => body.push(ModuleBodyItem::Assert(subst_assert(a, var, i))),
+                GenItem::Reg(r) => body.push(ModuleBodyItem::RegDecl(subst_reg_decl(r, var, i))),
+                GenItem::Let(l) => body.push(ModuleBodyItem::LetBinding(subst_let_binding(l, var, i))),
             }
         }
     }
@@ -513,6 +523,10 @@ fn expand_generate_if(
             GenItem::Inst(inst) => body.push(ModuleBodyItem::Inst(inst)),
             GenItem::Thread(t) => body.push(ModuleBodyItem::Thread(t)),
             GenItem::Assert(a) => body.push(ModuleBodyItem::Assert(a)),
+            // No substitution needed in generate_if — the loop var doesn't
+            // exist here, so regs/lets pass through verbatim.
+            GenItem::Reg(r) => body.push(ModuleBodyItem::RegDecl(r)),
+            GenItem::Let(l) => body.push(ModuleBodyItem::LetBinding(l)),
         }
     }
     Ok((ports, body))
@@ -699,6 +713,42 @@ fn subst_assert(a: &AssertDecl, var: &str, val: i64) -> AssertDecl {
     }
 }
 
+fn subst_reg_reset(reset: &RegReset, var: &str, val: i64) -> RegReset {
+    match reset {
+        RegReset::None => RegReset::None,
+        RegReset::Inherit(sig, v) => RegReset::Inherit(
+            subst_ident(sig, var, val),
+            subst_expr(v.clone(), var, val),
+        ),
+        RegReset::Explicit(sig, kind, level, v) => RegReset::Explicit(
+            subst_ident(sig, var, val),
+            *kind,
+            *level,
+            subst_expr(v.clone(), var, val),
+        ),
+    }
+}
+
+fn subst_reg_decl(r: &RegDecl, var: &str, val: i64) -> RegDecl {
+    RegDecl {
+        name: subst_ident(&r.name, var, val),
+        ty: subst_type_expr(&r.ty, var, val),
+        init: r.init.as_ref().map(|e| subst_expr(e.clone(), var, val)),
+        reset: subst_reg_reset(&r.reset, var, val),
+        guard: r.guard.as_ref().map(|n| subst_ident(n, var, val)),
+        span: r.span,
+    }
+}
+
+fn subst_let_binding(l: &LetBinding, var: &str, val: i64) -> LetBinding {
+    LetBinding {
+        name: subst_ident(&l.name, var, val),
+        ty: l.ty.as_ref().map(|t| subst_type_expr(t, var, val)),
+        value: subst_expr(l.value.clone(), var, val),
+        span: l.span,
+    }
+}
+
 fn subst_name(name: &str, var: &str, val: i64) -> String {
     let suffix = format!("_{}", var);
     if name.ends_with(&suffix) {
@@ -726,6 +776,13 @@ fn subst_type_expr(ty: &TypeExpr, var: &str, val: i64) -> TypeExpr {
 fn subst_expr(expr: Expr, var: &str, val: i64) -> Expr {
     let new_kind = match expr.kind {
         ExprKind::Ident(ref name) if name == var => ExprKind::Literal(LitKind::Dec(val as u64)),
+        // Rewrite identifier suffixes the same way declared names get renamed
+        // (e.g. `r_i` → `r_0`), so an expression inside a generate_for body
+        // that references a peer unrolled declaration by its loop-var-suffixed
+        // name resolves to the right unrolled instance.
+        ExprKind::Ident(ref name) if name.ends_with(&format!("_{}", var)) => {
+            ExprKind::Ident(subst_name(name, var, val))
+        }
         ExprKind::Binary(op, l, r) => ExprKind::Binary(
             op,
             Box::new(subst_expr(*l, var, val)),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1889,9 +1889,11 @@ impl Parser {
                 Some(TokenKind::Assert) | Some(TokenKind::Cover) => {
                     items.push(GenItem::Assert(self.parse_assert_decl()?));
                 }
+                Some(TokenKind::Reg) => items.push(GenItem::Reg(self.parse_reg_decl()?)),
+                Some(TokenKind::Let) => items.push(GenItem::Let(self.parse_let_binding()?)),
                 Some(other) => {
                     return Err(CompileError::unexpected_token(
-                        "port, inst, thread, assert, or cover",
+                        "port, inst, thread, assert, cover, reg, or let",
                         &other.to_string(),
                         self.peek_span(),
                     ));
@@ -1912,9 +1914,11 @@ impl Parser {
                 Some(TokenKind::Assert) | Some(TokenKind::Cover) => {
                     items.push(GenItem::Assert(self.parse_assert_decl()?));
                 }
+                Some(TokenKind::Reg) => items.push(GenItem::Reg(self.parse_reg_decl()?)),
+                Some(TokenKind::Let) => items.push(GenItem::Let(self.parse_let_binding()?)),
                 Some(other) => {
                     return Err(CompileError::unexpected_token(
-                        "port, inst, thread, assert, or cover",
+                        "port, inst, thread, assert, cover, reg, or let",
                         &other.to_string(),
                         self.peek_span(),
                     ));


### PR DESCRIPTION
## Summary

Extends `GenItem` with `Reg(RegDecl)` and `Let(LetBinding)` variants. `generate_for` / `generate_if` bodies now accept the same `reg` and `let` forms as plain module bodies, so register-array-style patterns can be expressed idiomatically instead of requiring hand-unrolling.

## Before / after

Before:
```
generate_for i in 0..3
  port inp_i: in UInt<8>;
  port out_i: out UInt<8>;
end generate_for
reg r_0: UInt<8> reset rst => 0;
reg r_1: UInt<8> reset rst => 0;
reg r_2: UInt<8> reset rst => 0;   // hand-unrolled
reg r_3: UInt<8> reset rst => 0;
```

After:
```
generate_for i in 0..3
  port inp_i: in UInt<8>;
  port out_i: out UInt<8>;
  reg   r_i:   UInt<8> reset rst => 0;
  let   lout_i: UInt<8> = r_i;
end generate_for
```

## What changed

- `ast::GenItem` gains `Reg(RegDecl)` and `Let(LetBinding)` variants.
- Parser's `parse_gen_items_for` / `parse_gen_items_if` accept the `reg` and `let` tokens (delegating to the existing `parse_reg_decl` / `parse_let_binding`).
- Elaborator's `expand_generate_for` substitutes the loop variable into each item's name (via the existing `subst_name` suffix rewrite) and emits `ModuleBodyItem::RegDecl` / `LetBinding` per iteration. New helpers `subst_reg_decl`, `subst_let_binding`, `subst_reg_reset`.
- `subst_expr` now also rewrites identifier suffixes (`r_i` → `r_0`), so in-body expressions referencing peer unrolled names resolve correctly. Previously only declared names were renamed, not their uses.
- Reg / let items force elaboration-time expansion (same constraint as ports and threads); the loop range must be compile-time known.
- SV codegen added `unreachable!` arms for `Reg` / `Let` since they never survive elaboration.

## Test plan

- [ ] Existing `generate_for` / `generate_if` designs (ports, insts, threads, asserts only) behave unchanged — no new elaboration path unless `reg` or `let` is present.
- [ ] `reg r_i` inside `generate_for i in 0..N-1` produces N distinct registers with suffix-substituted names, resets, and init values.
- [ ] `let lout_i: T = r_i;` substitutes both declared name and `r_i` reference.
- [ ] Using `reg`/`let` with a non-const range yields a "must be compile-time constant" error (same as ports do today).

## Reviewer notes

Motivated by register-file-style generators (rdl2arch) that want to emit N identical registers without the caller hand-unrolling. Exercise code:

```arch
module GenRegLet
  port clk: in Clock<SysDomain>;
  port rst: in Reset<Sync>;
  port out_0: out UInt<8>;
  port out_1: out UInt<8>;
  port out_2: out UInt<8>;

  default seq on clk rising;

  generate_for i in 0..2
    reg r_i: UInt<8> reset rst => 0;
    let lout_i: UInt<8> = r_i;
  end generate_for

  seq
    r_0 <= 8'h11;
    r_1 <= 8'h22;
    r_2 <= 8'h33;
  end seq

  comb
    out_0 = lout_0; out_1 = lout_1; out_2 = lout_2;
  end comb
end module GenRegLet
```

`arch build` round-trips this to clean SV (`r_0..r_2`, `lout_0..lout_2`).