### PR TITLE
fix(parser): friendly error when a reserved keyword is used as an identifier

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -4044,9 +4044,35 @@ impl Parser {
                 let tok = self.advance();
                 Ok(Ident::new(name, tok.span))
             }
-            other => Err(CompileError::unexpected_token(
+            Some(other) => {
+                let found = other.to_string();
+                // If `found` looks like a keyword (starts with a lowercase
+                // letter and is all alphanumeric/underscore), upgrade the
+                // error message to name the reserved word and suggest a
+                // quick workaround. Otherwise fall back to the generic
+                // "expected identifier" form.
+                let is_reserved_keyword = found.starts_with(|c: char| c.is_ascii_lowercase())
+                    && found.chars().all(|c| c.is_ascii_alphanumeric() || c == '_');
+                if is_reserved_keyword {
+                    Err(CompileError::general(
+                        &format!(
+                            "'{found}' is a reserved ARCH keyword and cannot be used as an \
+                             identifier here. Rename it (e.g. '{found}_', 's_{found}', or \
+                             'my_{found}')."
+                        ),
+                        self.peek_span(),
+                    ))
+                } else {
+                    Err(CompileError::unexpected_token(
+                        "identifier",
+                        &found,
+                        self.peek_span(),
+                    ))
+                }
+            }
+            None => Err(CompileError::unexpected_token(
                 "identifier",
-                &other.map(|k| k.to_string()).unwrap_or("EOF".into()),
+                "EOF",
                 self.peek_span(),
             )),
         }


### PR DESCRIPTION
## Summary

The parser's \"identifier expected\" error didn't distinguish between \"you typed garbage\" and \"you used a reserved keyword as a name.\" The second case is common for generator authors — `bus`, `match`, `state`, `module` are natural names for signals/ports but all happen to be keywords — and the existing message names the symptom without suggesting a fix.

## Before / after

Before:
```
port bus: in UInt<8>;
     ^^^
error: unexpected token: expected identifier, found bus
```

After:
```
port bus: in UInt<8>;
     ^^^
error: 'bus' is a reserved ARCH keyword and cannot be used as an
       identifier here. Rename it (e.g. 'bus_', 's_bus', or 'my_bus').
```

## How it works

In `expect_ident`, when the fallback path sees a non-identifier token whose Display string is all lowercase ASCII alphanumeric + underscore (matches every current keyword and any plausible future one), it routes through `CompileError::general` with a hinting message. Non-keyword failures (`port 42:`, `port +foo:`) keep the existing generic `unexpected_token` form.

## Test plan

- [ ] `port bus: ...`, `port match: ...`, `port state: ...`, etc. → friendly keyword error.
- [ ] `port 42: ...`, `port :foo:` → generic `unexpected_token` error (unchanged).
- [ ] Existing contextual-keyword-as-identifier cases (`op`, `track`, `kind`, etc.) still accepted — the early-exit path is unchanged.

## Reviewer notes

No grammar change. Only the error message in the non-identifier fallback of `expect_ident` was touched. Motivated by rdl2arch falling back to `s_axi` / `s_apb` because `bus` is reserved — the generic error pointed at the symptom but not the fix.