### PR TITLE
feat: allow seq and comb blocks inside generate_for, with a write-target rule

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -248,13 +248,23 @@ pub struct AssertDecl {
 
 // ── Generate ──────────────────────────────────────────────────────────────────
 
-/// An item inside a generate block: port, instance, or thread.
+/// An item inside a generate block: port, instance, thread, or a
+/// restricted-form seq / comb block.
+///
+/// Inside `generate_for`, `seq` / `comb` blocks may only drive targets of the
+/// form `<ident>[<expr-referencing-loop-var>]` — writing to a scalar reg from
+/// the loop body would produce N conflicting drivers after unrolling. This
+/// constraint is enforced in `elaborate::expand_generate_for` before the
+/// block is substituted and emitted. Module-scope Vec regs are the intended
+/// write target; scalar-reg reads in RHS expressions remain unrestricted.
 #[derive(Debug, Clone)]
 pub enum GenItem {
     Port(PortDecl),
     Inst(InstDecl),
     Thread(ThreadBlock),
     Assert(AssertDecl),
+    Seq(RegBlock),
+    Comb(CombBlock),
 }
 
 /// `generate for VAR in START..END ... end generate for VAR`

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -2040,6 +2040,8 @@ impl<'a> Codegen<'a> {
                         GenItem::Inst(inst) => self.emit_inst(inst),
                         GenItem::Port(_) => unreachable!("port GenItems should have been lifted by elaboration"),
                         GenItem::Thread(_) => unreachable!("thread GenItems should have been lowered by elaboration"),
+                        GenItem::Seq(_) | GenItem::Comb(_) => unreachable!(
+                            "seq/comb GenItems should have been unrolled by elaboration"),
                         GenItem::Assert(_) => {
                             // SVA inside generate for: not yet supported in SV codegen (SVA needs static clock ref)
                         }
@@ -2057,6 +2059,8 @@ impl<'a> Codegen<'a> {
                         GenItem::Inst(inst) => self.emit_inst(inst),
                         GenItem::Port(_) => unreachable!("port GenItems should have been lifted by elaboration"),
                         GenItem::Thread(_) => unreachable!("thread GenItems should have been lowered by elaboration"),
+                        GenItem::Seq(_) | GenItem::Comb(_) => unreachable!(
+                            "seq/comb GenItems should have been lifted by elaboration"),
                         GenItem::Assert(_) => {}
                     }
                 }
@@ -2069,6 +2073,8 @@ impl<'a> Codegen<'a> {
                             GenItem::Inst(inst) => self.emit_inst(inst),
                             GenItem::Port(_) => unreachable!("port GenItems should have been lifted by elaboration"),
                             GenItem::Thread(_) => unreachable!("thread GenItems should have been lowered by elaboration"),
+                            GenItem::Seq(_) | GenItem::Comb(_) => unreachable!(
+                                "seq/comb GenItems should have been lifted by elaboration"),
                             GenItem::Assert(_) => {}
                         }
                     }

--- a/src/elaborate.rs
+++ b/src/elaborate.rs
@@ -477,6 +477,21 @@ fn expand_generate_for(
     let mut ports = Vec::new();
     let mut body = Vec::new();
 
+    // Before unrolling, enforce Reading B on seq / comb bodies: every LHS
+    // must be indexed by the loop variable. Writing to a scalar from inside
+    // generate_for would produce N conflicting drivers after unrolling.
+    let mut errors: Vec<CompileError> = Vec::new();
+    for item in &gf.items {
+        match item {
+            GenItem::Seq(rb)  => check_gen_for_reg_stmts(&rb.stmts, var, &mut errors),
+            GenItem::Comb(cb) => check_gen_for_comb_stmts(&cb.stmts, var, &mut errors),
+            _ => {}
+        }
+    }
+    if !errors.is_empty() {
+        return Err(errors);
+    }
+
     for i in start..=end {
         for item in &gf.items {
             match item {
@@ -484,11 +499,187 @@ fn expand_generate_for(
                 GenItem::Inst(inst) => body.push(ModuleBodyItem::Inst(subst_inst(inst, var, i))),
                 GenItem::Thread(t) => body.push(ModuleBodyItem::Thread(subst_thread(t, var, i))),
                 GenItem::Assert(a) => body.push(ModuleBodyItem::Assert(subst_assert(a, var, i))),
+                GenItem::Seq(rb)  => body.push(ModuleBodyItem::RegBlock(subst_reg_block(rb, var, i))),
+                GenItem::Comb(cb) => body.push(ModuleBodyItem::CombBlock(subst_comb_block(cb, var, i))),
             }
         }
     }
 
     Ok((ports, body))
+}
+
+// ── generate_for seq/comb write-target check (Reading B) ──────────────────────
+//
+// Inside a generate_for's seq/comb body, every assignment LHS must be of the
+// form `<ident>[<expr-using-loop-var>]` (with optional nested struct-field or
+// bit-slice access). Reads on RHS are unrestricted.
+
+fn expr_mentions_ident(expr: &Expr, name: &str) -> bool {
+    match &expr.kind {
+        ExprKind::Ident(n) => n == name,
+        ExprKind::Binary(_, l, r) =>
+            expr_mentions_ident(l, name) || expr_mentions_ident(r, name),
+        ExprKind::Unary(_, x) => expr_mentions_ident(x, name),
+        ExprKind::FieldAccess(b, _) => expr_mentions_ident(b, name),
+        ExprKind::Index(b, i) =>
+            expr_mentions_ident(b, name) || expr_mentions_ident(i, name),
+        ExprKind::BitSlice(b, h, l) =>
+            expr_mentions_ident(b, name) || expr_mentions_ident(h, name)
+            || expr_mentions_ident(l, name),
+        ExprKind::Cast(e, _) => expr_mentions_ident(e, name),
+        ExprKind::Ternary(c, t, f) =>
+            expr_mentions_ident(c, name) || expr_mentions_ident(t, name)
+            || expr_mentions_ident(f, name),
+        ExprKind::Concat(xs) => xs.iter().any(|x| expr_mentions_ident(x, name)),
+        ExprKind::MethodCall(r, _, args) =>
+            expr_mentions_ident(r, name)
+            || args.iter().any(|a| expr_mentions_ident(a, name)),
+        _ => false,
+    }
+}
+
+/// Every unrolled iteration of a generate_for must write a *distinct* target,
+/// otherwise N copies of the loop body all drive the same signal. There are
+/// two legitimate ways an LHS can be distinct per iteration:
+///
+///   1. Indexed by the loop var: `vec_reg[i]` (or nested through a field /
+///      bit-slice, e.g. `vec_reg[i].field`, `vec_reg[i][7:0]`).
+///   2. The base identifier contains the loop var as a suffix (or IS the loop
+///      var), which gets suffix-substituted during port / inst expansion.
+///      E.g. writing to `rdata_i` inside `generate_for i in 0..3` yields
+///      three distinct scalars `rdata_0 / rdata_1 / rdata_2`.
+fn lhs_is_distinct_per_iteration(lhs: &Expr, var: &str) -> bool {
+    match &lhs.kind {
+        ExprKind::Index(_, idx) => expr_mentions_ident(idx, var),
+        ExprKind::FieldAccess(base, _) => lhs_is_distinct_per_iteration(base, var),
+        ExprKind::BitSlice(base, _, _) => lhs_is_distinct_per_iteration(base, var),
+        ExprKind::Ident(name) => {
+            // name ends with `_<var>` or is exactly `<var>` — suffix-substituted
+            // into a unique identifier per iteration.
+            name == var || name.ends_with(&format!("_{}", var))
+        }
+        _ => false,
+    }
+}
+
+fn reject_bad_lhs(lhs: &Expr, var: &str, errors: &mut Vec<CompileError>) {
+    if !lhs_is_distinct_per_iteration(lhs, var) {
+        errors.push(CompileError::general(
+            &format!(
+                "write target inside generate_for must be distinct per iteration \
+                 — either `vec_name[{var}]` (indexed by the loop var) or a name \
+                 with an `_{var}` suffix (suffix-substituted per iteration). \
+                 Writing to anything else would produce multiple drivers after \
+                 the loop unrolls."
+            ),
+            lhs.span,
+        ));
+    }
+}
+
+fn check_gen_for_reg_stmts(stmts: &[Stmt], var: &str, errors: &mut Vec<CompileError>) {
+    for s in stmts {
+        match s {
+            Stmt::Assign(a) => reject_bad_lhs(&a.target, var, errors),
+            Stmt::IfElse(ie) => {
+                check_gen_for_reg_stmts(&ie.then_stmts, var, errors);
+                check_gen_for_reg_stmts(&ie.else_stmts, var, errors);
+            }
+            Stmt::Match(m) => for arm in &m.arms {
+                check_gen_for_reg_stmts(&arm.body, var, errors);
+            },
+            Stmt::For(f)  => check_gen_for_reg_stmts(&f.body, var, errors),
+            Stmt::Init(ib) => check_gen_for_reg_stmts(&ib.body, var, errors),
+            Stmt::Log(_) | Stmt::WaitUntil(..) | Stmt::DoUntil { .. } => {}
+        }
+    }
+}
+
+fn check_gen_for_comb_stmts(stmts: &[CombStmt], var: &str, errors: &mut Vec<CompileError>) {
+    for s in stmts {
+        match s {
+            CombStmt::Assign(a) => reject_bad_lhs(&a.target, var, errors),
+            CombStmt::IfElse(ie) => {
+                check_gen_for_comb_stmts(&ie.then_stmts, var, errors);
+                check_gen_for_comb_stmts(&ie.else_stmts, var, errors);
+            }
+            // MatchExpr arms are value-producing (no further LHS to check).
+            CombStmt::MatchExpr(_) => {}
+            CombStmt::For(f) => check_gen_for_reg_stmts(&f.body, var, errors),
+            CombStmt::Log(_) => {}
+        }
+    }
+}
+
+// ── Substitution helpers for generate_for's seq / comb bodies ─────────────────
+
+fn subst_reg_block(rb: &RegBlock, var: &str, val: i64) -> RegBlock {
+    RegBlock {
+        clock: rb.clock.clone(),
+        clock_edge: rb.clock_edge,
+        stmts: rb.stmts.iter().map(|s| subst_reg_stmt(s, var, val)).collect(),
+        span: rb.span,
+    }
+}
+
+fn subst_reg_stmt(s: &Stmt, var: &str, val: i64) -> Stmt {
+    // Use subst_expr_names (suffix-rewriting variant) consistent with how
+    // thread bodies and generate_for ports/insts are substituted. That
+    // correctly rewrites `rdata_i` → `rdata_0` and also substitutes bare `i`
+    // uses in indices like `store[i]` → `store[0]`.
+    match s {
+        Stmt::Assign(a) => Stmt::Assign(Assign {
+            target: subst_expr_names(a.target.clone(), var, val),
+            value:  subst_expr_names(a.value.clone(),  var, val),
+            span:   a.span,
+        }),
+        Stmt::IfElse(ie) => Stmt::IfElse(IfElseOf {
+            cond:       subst_expr_names(ie.cond.clone(), var, val),
+            then_stmts: ie.then_stmts.iter().map(|x| subst_reg_stmt(x, var, val)).collect(),
+            else_stmts: ie.else_stmts.iter().map(|x| subst_reg_stmt(x, var, val)).collect(),
+            unique:     ie.unique,
+            span:       ie.span,
+        }),
+        Stmt::Match(m) => Stmt::Match(MatchStmt {
+            scrutinee: subst_expr_names(m.scrutinee.clone(), var, val),
+            arms: m.arms.iter().map(|arm| MatchArm {
+                pattern: arm.pattern.clone(),
+                body: arm.body.iter().map(|s| subst_reg_stmt(s, var, val)).collect(),
+            }).collect(),
+            unique: m.unique,
+            span: m.span,
+        }),
+        // Log/For/Init/WaitUntil/DoUntil: pass through. If we ever want to
+        // support loop-var substitution in these nested contexts we can
+        // extend this match — for now they're unusual inside generate_for
+        // and the LHS check above already guards correctness.
+        other => other.clone(),
+    }
+}
+
+fn subst_comb_block(cb: &CombBlock, var: &str, val: i64) -> CombBlock {
+    CombBlock {
+        stmts: cb.stmts.iter().map(|s| subst_comb_stmt(s, var, val)).collect(),
+        span: cb.span,
+    }
+}
+
+fn subst_comb_stmt(s: &CombStmt, var: &str, val: i64) -> CombStmt {
+    match s {
+        CombStmt::Assign(a) => CombStmt::Assign(Assign {
+            target: subst_expr_names(a.target.clone(), var, val),
+            value:  subst_expr_names(a.value.clone(),  var, val),
+            span:   a.span,
+        }),
+        CombStmt::IfElse(ie) => CombStmt::IfElse(IfElseOf {
+            cond:       subst_expr_names(ie.cond.clone(), var, val),
+            then_stmts: ie.then_stmts.iter().map(|x| subst_comb_stmt(x, var, val)).collect(),
+            else_stmts: ie.else_stmts.iter().map(|x| subst_comb_stmt(x, var, val)).collect(),
+            unique:     ie.unique,
+            span:       ie.span,
+        }),
+        other => other.clone(),
+    }
 }
 
 fn expand_generate_if(
@@ -513,6 +704,10 @@ fn expand_generate_if(
             GenItem::Inst(inst) => body.push(ModuleBodyItem::Inst(inst)),
             GenItem::Thread(t) => body.push(ModuleBodyItem::Thread(t)),
             GenItem::Assert(a) => body.push(ModuleBodyItem::Assert(a)),
+            // No loop var in generate_if, so seq/comb pass through verbatim.
+            // Reading B's write-target rule only applies to generate_for.
+            GenItem::Seq(rb)  => body.push(ModuleBodyItem::RegBlock(rb)),
+            GenItem::Comb(cb) => body.push(ModuleBodyItem::CombBlock(cb)),
         }
     }
     Ok((ports, body))

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1889,9 +1889,36 @@ impl Parser {
                 Some(TokenKind::Assert) | Some(TokenKind::Cover) => {
                     items.push(GenItem::Assert(self.parse_assert_decl()?));
                 }
+                Some(TokenKind::Seq) => {
+                    items.push(GenItem::Seq(self.parse_always_block()?));
+                }
+                Some(TokenKind::Comb) => {
+                    items.push(GenItem::Comb(self.parse_comb_block()?));
+                }
+                Some(TokenKind::Reg) | Some(TokenKind::Let) => {
+                    // Reject with a targeted hint — reg/let decls inside
+                    // generate_for would force per-iteration unrolling that
+                    // produces ugly suffix-mangled SV names, or (for reg)
+                    // implies multi-driver conflicts. The approved shape is
+                    // "declare Vec regs at module scope; index them by the
+                    // loop var in a seq/comb inside generate_for".
+                    let kw = match self.peek_kind() {
+                        Some(TokenKind::Reg) => "reg",
+                        _ => "let",
+                    };
+                    return Err(CompileError::general(
+                        &format!(
+                            "'{kw}' declarations are not allowed inside generate_for. \
+                             Declare Vec-typed regs at module scope and index them in a \
+                             seq/comb block here: e.g. `reg store: Vec<UInt<8>, {{N}}> ...;` \
+                             outside, then `store[i] <= ...;` inside generate_for."
+                        ),
+                        self.peek_span(),
+                    ));
+                }
                 Some(other) => {
                     return Err(CompileError::unexpected_token(
-                        "port, inst, thread, assert, or cover",
+                        "port, inst, thread, seq, comb, assert, or cover",
                         &other.to_string(),
                         self.peek_span(),
                     ));


### PR DESCRIPTION
## Summary

Replaces the withdrawn [#9](https://github.com/arch-hdl-lang/arch-com/pull/9) (scalar reg unrolling) with a cleaner shape for expressing N-bank designs:

`generate_for` body now accepts `seq` and `comb` blocks, and every LHS inside them must be **distinct per iteration** so unrolling never produces multiple drivers for the same signal. Reads on RHS are unrestricted.

Accepted LHS forms:
- **Indexed by the loop variable:** `vec_reg[i]` (optionally nested through field access or bit-slice — `vec[i].field`, `vec[i][7:0]`).
- **Suffix-substituted identifier:** base identifier ends with `_<loop_var>` or IS the loop var — gets rewritten into a unique name per iteration (matches how ports and insts inside generate_for already behave, e.g. `rdata_i` → `rdata_0`, `rdata_1`, ...).

Anything else — scalar LHS from outside, vec indexed by a runtime signal, etc. — is rejected with a targeted error.

`reg` and `let` declarations inside `generate_for` are also explicitly rejected (the unroll shape is ugly and the right pattern is "Vec at module scope, index here").

## Example

N-bank register file, no hand-unrolling:

```arch
module Bank
  port clk: in Clock<SysDomain>;
  port rst: in Reset<Sync>;

  generate_for i in 0..3
    port we_i:    in Bool;
    port wdata_i: in UInt<8>;
    port rdata_i: out UInt<8>;
  end generate_for

  default seq on clk rising;
  reg sto: Vec<UInt<8>, 4> reset rst => 0;

  generate_for i in 0..3
    seq
      if we_i
        sto[i] <= wdata_i;
      end if
    end seq
    comb
      rdata_i = sto[i];
    end comb
  end generate_for
end module Bank
```

`arch build` round-trips this to 4 `always_ff` blocks (one per bank), 4 `assign rdata_N = sto[N];` lines, and distinct per-bank input ports.

## Errors surfaced

```
reg foo: ... reset ... => ...;   inside generate_for
→ 'reg' declarations are not allowed inside generate_for. Declare Vec-typed
  regs at module scope and index them in a seq/comb block here: e.g. `reg
  store: Vec<UInt<8>, {N}> ...;` outside, then `store[i] <= ...;` inside
  generate_for.

scalar_r <= wdata;    inside generate_for
→ write target inside generate_for must be distinct per iteration — either
  `vec_name[i]` (indexed by the loop var) or a name with an `_i` suffix
  (suffix-substituted per iteration). Writing to anything else would produce
  multiple drivers after the loop unrolls.
```

## Changes

- **ast**: `GenItem` gains `Seq(RegBlock)` and `Comb(CombBlock)` variants.
- **parser**: `parse_gen_items_for` / `parse_gen_items_if` accept seq/comb; reject reg/let with a directed error message.
- **elaborate**:
  - `expand_generate_for` runs a write-target check (`check_gen_for_{reg,comb}_stmts` → `reject_bad_lhs`) before substitution.
  - New `subst_reg_block` / `subst_comb_block` walk stmt trees and call `subst_expr_names` (the suffix-rewriting variant, matching how thread-stmt substitution already handles this).
  - `expand_generate_if` passes seq/comb through verbatim (no loop var).
- **codegen**: `unreachable!` arms for Seq/Comb in the preserve-as-SV paths (they always expand at elaboration time).

## Test plan

- [ ] Existing `generate_for` / `generate_if` designs (ports, insts, threads, asserts only) behave unchanged — the check only runs when `seq` or `comb` is present.
- [ ] Vec-indexed writes `vec[i] <= ...` round-trip correctly through `arch build`.
- [ ] Scalar-LHS writes inside generate_for rejected with the hinting error.
- [ ] `reg` / `let` inside generate_for rejected with the hinting error.
- [ ] Reading scalar regs defined outside in RHS expressions: allowed.

## Reviewer notes

No behavior change for existing designs. The write-target rule fires only when a seq or comb block exists inside `generate_for` — new syntactic territory. Motivated by generator authors (rdl2arch) wanting to express N-bank patterns idiomatically; previously they hand-unrolled to N scalar names at generation time.

Obsoletes [docs/hwif-port-shape.md](https://github.com/arch-hdl-lang/rdl2arch/blob/claude/hardcore-mcclintock-09e55e/docs/register-array-shape.md)'s "reg inside generate_for doesn't work" lament — the Vec-at-module-scope pattern it proposed as the future direction is exactly what this enables.