### PR TITLE
fix: sim codegen — include VStructs.h when a Vec element type is a named struct

### DIFF
--- a/src/sim_codegen.rs
+++ b/src/sim_codegen.rs
@@ -3073,8 +3073,21 @@ impl<'a> SimCodegen<'a> {
         let has_functions = self.source.items.iter().any(|i| matches!(i, Item::Function(_)));
 
         // ── Header ───────────────────────────────────────────────────────────
-        let has_structs = m.body.iter().any(|i| matches!(i, ModuleBodyItem::RegDecl(r) if matches!(r.ty, TypeExpr::Named(_))))
-            || m.ports.iter().any(|p| matches!(p.ty, TypeExpr::Named(_)));
+        // Recurse into Vec<> so `reg foo: Vec<Entry, N>` and port types like
+        // `Vec<SomeStruct, N>` trigger the VStructs.h include. Previously
+        // `has_structs` only matched bare `TypeExpr::Named(_)`, so a design
+        // whose only struct use was inside a Vec produced headers that
+        // referenced the struct without declaring it — both the reg storage
+        // line (`Entry _ent[N];`) and the pybind wrapper failed to compile.
+        fn ty_references_named(ty: &TypeExpr) -> bool {
+            match ty {
+                TypeExpr::Named(_) => true,
+                TypeExpr::Vec(inner, _) => ty_references_named(inner),
+                _ => false,
+            }
+        }
+        let has_structs = m.body.iter().any(|i| matches!(i, ModuleBodyItem::RegDecl(r) if ty_references_named(&r.ty)))
+            || m.ports.iter().any(|p| ty_references_named(&p.ty));
         let mut h = String::new();
         h.push_str(&format!("#pragma once\n#include <cstdint>\n#include <cstdio>\n#include \"verilated.h\"\n"));
         if has_structs {


### PR DESCRIPTION
## Summary

`has_structs` at the top of `gen_module` only matched bare `TypeExpr::Named(_)`, so a module whose only struct use was inside a `Vec<Struct, N>` produced sim headers that referenced the struct without declaring it. `arch build` (SV path) was unaffected; only `arch sim --pybind` broke.

## Repro

```arch
use VecStructPkg;

module VecStruct
  port clk: in Clock<SysDomain>;
  port rst: in Reset<Sync>;

  generate_for i in 0..3
    port we_i:    in Bool;
    port wdata_i: in UInt<8>;
    port rv_i:    out Bool;
    port rd_i:    out UInt<8>;
  end generate_for

  default seq on clk rising;
  reg ent: Vec<Entry, 4> reset rst => Entry { valid: false, data: 0 };

  generate_for i in 0..3
    seq
      if we_i
        ent[i].valid <= true;
        ent[i].data  <= wdata_i;
      end if
    end seq
    comb
      rv_i = ent[i].valid;
      rd_i = ent[i].data;
    end comb
  end generate_for
end module VecStruct
```

Before this fix:
```
arch_sim_build/VVecStruct.h:45:3: error: unknown type name 'Entry'
   45 |   Entry _ent[4];                  // reg storage
arch_sim_build/VVecStruct_pybind.cpp:8:16: error: use of undeclared identifier 'Entry'
    8 |     py::class_<Entry>(m, "Entry", py::module_local())
```

After:
```
Compiling pybind11 module...
Built: arch_sim_build/VVecStruct_pybind.cpython-313-darwin.so
Running test: test_vec.py
[1/1] Running drive_each_bank...
VECSTRUCT_TEST_OK
  PASS: drive_each_bank
```

## The fix

Recurse into `TypeExpr::Vec` when computing `has_structs`, and apply the same check to port types. One local helper + two call sites:

```rust
fn ty_references_named(ty: &TypeExpr) -> bool {
    match ty {
        TypeExpr::Named(_) => true,
        TypeExpr::Vec(inner, _) => ty_references_named(inner),
        _ => false,
    }
}
```

## Test plan

- [ ] Existing designs with bare `TypeExpr::Named` regs/ports still trigger the include (unchanged behavior for the `hwif_in: MyIpHwifIn` case etc.).
- [ ] Designs with *only* `Vec<NamedStruct, N>` now correctly include VStructs.h and compile through `arch sim --pybind`.
- [ ] Designs with no struct types at all still skip the include (no spurious dependency).

## Reviewer notes

Unblocks end-to-end sim verification for the generate_for + `Vec<Struct, N>` pattern introduced in #11. Without this, the SV compiles and runs correctly but the sim-side path was broken for any design using that shape.

Motivated by spot-checking rdl2arch's future "one Vec reg per register array" refactor — the compiler piece is now ready; generator refactor still deferred per the rdl2arch design note.