### PR TITLE
fix: tighten generate_for LHS check — accept only loop-var-indexed writes

### DIFF
--- a/src/elaborate.rs
+++ b/src/elaborate.rs
@@ -539,38 +539,38 @@ fn expr_mentions_ident(expr: &Expr, name: &str) -> bool {
 }
 
 /// Every unrolled iteration of a generate_for must write a *distinct* target,
-/// otherwise N copies of the loop body all drive the same signal. There are
-/// two legitimate ways an LHS can be distinct per iteration:
+/// otherwise N copies of the loop body all drive the same signal. The only
+/// accepted LHS shape is an index by the loop variable:
 ///
-///   1. Indexed by the loop var: `vec_reg[i]` (or nested through a field /
-///      bit-slice, e.g. `vec_reg[i].field`, `vec_reg[i][7:0]`).
-///   2. The base identifier contains the loop var as a suffix (or IS the loop
-///      var), which gets suffix-substituted during port / inst expansion.
-///      E.g. writing to `rdata_i` inside `generate_for i in 0..3` yields
-///      three distinct scalars `rdata_0 / rdata_1 / rdata_2`.
-fn lhs_is_distinct_per_iteration(lhs: &Expr, var: &str) -> bool {
+///   `vec_reg[i] <= ...`, or nested through a field / bit-slice, e.g.
+///   `vec_reg[i].field <= ...`, `vec_reg[i][7:0] = ...`.
+///
+/// A bare-identifier LHS — even one with an `_i` suffix — is rejected. The
+/// earlier revision accepted suffix names on the reasoning that ports / insts
+/// declared inside generate_for get substituted into distinct `_0 / _1 / ...`
+/// names. But that only holds when the target IS a generate_for-substituted
+/// declaration; a scalar reg at module scope happening to end with `_i` was
+/// silently accepted, then substituted to non-existent names like `cnt_0`,
+/// leaving `arch check` / `arch build` happy while emitting SV that Verilator
+/// rejects. The Vec-at-module-scope pattern (`reg store: Vec<T, N>` + `store[i]
+/// <= ...`) supersedes the suffix shape cleanly.
+fn lhs_is_loop_indexed(lhs: &Expr, var: &str) -> bool {
     match &lhs.kind {
         ExprKind::Index(_, idx) => expr_mentions_ident(idx, var),
-        ExprKind::FieldAccess(base, _) => lhs_is_distinct_per_iteration(base, var),
-        ExprKind::BitSlice(base, _, _) => lhs_is_distinct_per_iteration(base, var),
-        ExprKind::Ident(name) => {
-            // name ends with `_<var>` or is exactly `<var>` — suffix-substituted
-            // into a unique identifier per iteration.
-            name == var || name.ends_with(&format!("_{}", var))
-        }
+        ExprKind::FieldAccess(base, _) => lhs_is_loop_indexed(base, var),
+        ExprKind::BitSlice(base, _, _) => lhs_is_loop_indexed(base, var),
         _ => false,
     }
 }
 
 fn reject_bad_lhs(lhs: &Expr, var: &str, errors: &mut Vec<CompileError>) {
-    if !lhs_is_distinct_per_iteration(lhs, var) {
+    if !lhs_is_loop_indexed(lhs, var) {
         errors.push(CompileError::general(
             &format!(
-                "write target inside generate_for must be distinct per iteration \
-                 — either `vec_name[{var}]` (indexed by the loop var) or a name \
-                 with an `_{var}` suffix (suffix-substituted per iteration). \
-                 Writing to anything else would produce multiple drivers after \
-                 the loop unrolls."
+                "write target inside generate_for must be indexed by the loop \
+                 variable `{var}`, e.g. `vec_reg[{var}] <= ...`. Declare the \
+                 Vec-typed reg or port at module scope and index it here — \
+                 scalar writes would produce multiple drivers after unrolling."
             ),
             lhs.span,
         ));


### PR DESCRIPTION
## Summary

Tightens the write-target check introduced in #11 so that the only accepted LHS shape inside `generate_for` seq/comb is `<ident>[<expr-using-loop-var>]` (possibly nested through field access or bit-slice). Drops the `_<loop_var>`-suffixed bare-ident escape hatch, which was unsound.

## The bug

The original rule accepted two LHS shapes:
1. `vec[i]` / `vec[i].field` / `vec[i][hi:lo]` (indexed form) — **sound**.
2. `<ident>` where name ended with `_<loop_var>` (suffix form) — **unsound**.

(2) only works when the target was itself declared as a suffix-substituted item inside the same `generate_for` (e.g. `port rdata_i:` → expands to `rdata_0..rdata_N-1`). A scalar reg at module scope that happened to end with `_i` was silently accepted, then substituted to *nowhere-declared* names.

### Before

```arch
module M
  port clk: in Clock<SysDomain>;
  port rst: in Reset<Sync>;

  default seq on clk rising;
  reg cnt_i: UInt<8> reset rst => 0;    // scalar reg, odd name but legal

  generate_for i in 0..3
    seq
      cnt_i <= cnt_i + 1;               // check silently permits
    end seq
  end generate_for
end module M
```

`arch check` → OK. `arch build` → wrote `M.sv`. But:

```sv
logic [7:0] cnt_i;
always_ff @(posedge clk) begin
  cnt_0 <= cnt_0 + 1;                    // cnt_0 never declared
end
always_ff @(posedge clk) begin
  cnt_1 <= cnt_1 + 1;
end
...
```

Broken SV that only surfaces at downstream Verilator lint.

### After

```
error: write target inside generate_for must be indexed by the loop
       variable `i`, e.g. `vec_reg[i] <= ...`. Declare the Vec-typed
       reg or port at module scope and index it here — scalar writes
       would produce multiple drivers after unrolling.
```

## Rationale

The suffix-LHS form was also aesthetically worse: it pushed users toward `rdata_0 / rdata_1 / rdata_2 / rdata_3` separately-named SV ports instead of a single `logic [3:0][7:0] rdata` via Vec-typed ports. Vec ports already work out of the box — no compiler change needed there — and they produce cleaner SV, cleaner arch sources, and no name-mangling.

Canonical pattern is now:

```arch
port rdata: out Vec<UInt<8>, 4>;        // module-scope Vec port
reg  store: Vec<UInt<8>, 4> reset rst => 0;

generate_for i in 0..3
  seq
    if we[i]
      store[i] <= wdata[i];
    end if
  end seq
  comb
    rdata[i] = store[i];
  end comb
end generate_for
```

## Test plan

- [ ] `vec[i] <= ...`, `vec[i].field <= ...`, `vec[i][hi:lo] = ...` — accepted, unchanged.
- [ ] Scalar reg write from inside generate_for — rejected (unchanged behavior for this case).
- [ ] `cnt_i <= ...` where `cnt_i` is a scalar reg at module scope — **now rejected** (was silently miscompiled before).
- [ ] `rdata_i = ...` where `rdata_i` was declared as a `port rdata_i: out ...` inside the same generate_for — **now rejected** (users should use Vec ports). Documented as the recommended migration in the error message.

## Reviewer notes

Tightening of a check that merged yesterday (#11). Any code written against the suffix-LHS form gets a clear error pointing at the replacement.