### PR TITLE
fix: sim codegen — Vec port body indexing references the internal _name array

### DIFF
--- a/src/sim_codegen.rs
+++ b/src/sim_codegen.rs
@@ -1345,6 +1345,14 @@ impl<'a> Ctx<'a> {
             }
         } else if self.inst_names.contains(name) {
             format!("_inst_{name}")
+        } else if self.port_names.contains(name)
+                  && self.vec_names.map_or(false, |s| s.contains(name)) {
+            // Vec-typed port: header exposes flattened `name_0..name_N-1`
+            // scalars for external access, but the body indexes into the
+            // internal `_name[N]` array. Without this branch, a body that
+            // reads / writes `port_name[i]` lowered to `port_name[0]` —
+            // referencing a name that doesn't exist in the C++ class.
+            format!("_{name}")
         } else {
             name.to_string()
         }


### PR DESCRIPTION
## Summary

`port foo: in Vec<T, N>` flattens in the C++ class to per-element scalars `foo_0..foo_N-1` (for external pybind / TB access) and is backed by an internal array `T _foo[N]` used by the sim body. When source code referenced `foo[i]`, sim codegen lowered the base via `Ctx::resolve_name`, which had no Vec-port branch and returned the bare `"foo"` — yielding `foo[0]` in the cpp body, where `foo` doesn't exist as either a scalar or an array.

The SV path was unaffected (`input logic [N-1:0] foo` is a real packed port; `foo[0]` works directly).

## Repro

Surfaced by the canonical generate_for + Vec-port pattern that #11 / #14 settled on:

```arch
module Bank
  port clk: in Clock<SysDomain>;
  port rst: in Reset<Sync>;
  port we:    in  Vec<Bool,    4>;
  port wdata: in  Vec<UInt<8>, 4>;
  port rv:    out Vec<Bool,    4>;
  port rd:    out Vec<UInt<8>, 4>;

  default seq on clk rising;
  reg sto: Vec<UInt<8>, 4> reset rst => 0;

  generate_for i in 0..3
    seq
      if we[i]
        sto[i] <= wdata[i];
      end if
    end seq
    comb
      rv[i] = (sto[i] != 0);
      rd[i] = sto[i];
    end comb
  end generate_for
end module Bank
```

Before:
```
$ arch sim --pybind Bank.arch
arch_sim_build/VBank.cpp:18:9: error: use of undeclared identifier 'we'
arch_sim_build/VBank.cpp:20:25: error: use of undeclared identifier 'wdata'
... (16 errors)
Pybind11 compilation failed
```

After:
```
$ arch sim --pybind --test test_vec.py Bank.arch
Compiling pybind11 module...
Built: arch_sim_build/VBank_pybind.cpython-313-darwin.so
Running test: test_vec.py
[1/1] Running drive_each_bank...
VECSTRUCT_TEST_OK
  PASS: drive_each_bank
```

## The fix

In `Ctx::resolve_name`, recognize when a name is *both* a port (`port_names`) and a Vec (`vec_names`, which already collects vec ports alongside vec regs at the gen_module callsite). For that case, return the internal `_<name>` form, matching how Vec-typed regs are already resolved. The bounds-check + Index handler then composes `_foo[i]` correctly.

```rust
} else if self.port_names.contains(name)
          && self.vec_names.map_or(false, |s| s.contains(name)) {
    format!("_{name}")
}
```

## Test plan

- [ ] Vec input port read via `port[i]` lowers to `_port[i]` and compiles.
- [ ] Vec output port write via `port[i] = ...` lowers to `_port[i] = ...` (LHS path uses the same resolve_name).
- [ ] Vec ports still expose `port_0..port_N-1` scalars to pybind / external code (only the body's subscript form changes).
- [ ] Scalar (non-Vec) ports unchanged — no `port_names && vec_names` overlap means no `_` prefix.
- [ ] Vec regs unchanged — they go through the existing `reg_names` branch.

## Reviewer notes

Closes the last gap in the generate_for + Vec-at-module-scope flow that #11 and #14 enabled. With this in, the canonical pattern works end-to-end: `arch check`, `arch build`, and `arch sim --pybind --test` all pass on a 4-bank Vec-of-struct fixture with cocotb-style assertions on per-bank state.

8-line code change. Ctx already has both `port_names` and `vec_names` plumbed; this just adds the cross-check.