### PR TITLE
fix: sim codegen — struct field width inside a Vec subscript

### DIFF
--- a/src/sim_codegen.rs
+++ b/src/sim_codegen.rs
@@ -1460,9 +1460,20 @@ fn infer_expr_width(expr: &Expr, ctx: &Ctx) -> u32 {
         }
         ExprKind::FieldAccess(base, field) => {
             // Struct field access: look up by "<base>.<field>" key the caller
-            // populated from the struct decl (so e.g. ctrl_r.mode resolves to
-            // the declared bit width, not the C++ storage width).
-            if let ExprKind::Ident(name) = &base.kind {
+            // populated from the struct decl. Covers two shapes:
+            //   - `ctrl_r.mode`             — base is Ident
+            //   - `ch_r[0].threshold`       — base is Index of Ident (Vec elem)
+            // Both resolve to the same struct-field width regardless of which
+            // element index is being accessed.
+            let base_name = match &base.kind {
+                ExprKind::Ident(name) => Some(name.as_str()),
+                ExprKind::Index(b, _) => match &b.kind {
+                    ExprKind::Ident(name) => Some(name.as_str()),
+                    _ => None,
+                },
+                _ => None,
+            };
+            if let Some(name) = base_name {
                 let key = format!("{}.{}", name, field.name);
                 if let Some(&w) = ctx.widths.get(key.as_str()) {
                     return w;
@@ -2863,14 +2874,28 @@ impl<'a> SimCodegen<'a> {
             map
         };
         let mut struct_typed_names: Vec<(String, &str)> = Vec::new();
+        // Helper: peel `Vec<T, N>` once so a Vec-of-named-struct reg/port
+        // also contributes per-field widths (the body indexes into it as
+        // `<reg>[i].<field>`, and infer_expr_width's FieldAccess handler
+        // looks up `<reg>.<field>` for that case).
+        fn named_or_vec_named(ty: &TypeExpr) -> Option<&Ident> {
+            match ty {
+                TypeExpr::Named(n) => Some(n),
+                TypeExpr::Vec(inner, _) => match inner.as_ref() {
+                    TypeExpr::Named(n) => Some(n),
+                    _ => None,
+                },
+                _ => None,
+            }
+        }
         for p in &m.ports {
-            if let TypeExpr::Named(n) = &p.ty {
+            if let Some(n) = named_or_vec_named(&p.ty) {
                 struct_typed_names.push((p.name.name.clone(), n.name.as_str()));
             }
         }
         for item in &m.body {
             if let ModuleBodyItem::RegDecl(r) = item {
-                if let TypeExpr::Named(n) = &r.ty {
+                if let Some(n) = named_or_vec_named(&r.ty) {
                     struct_typed_names.push((r.name.name.clone(), n.name.as_str()));
                 }
             }


### PR DESCRIPTION
## Summary

Final width-inference hole in the Vec-of-struct family of bugs. `infer_expr_width` for `FieldAccess` only matched when the base was an `Ident` (e.g. `ctrl_r.mode`). The Vec-element shape `ch_r[0].threshold` fell through to the flat-name fallback, never hit the widths map, and silently defaulted to 8. That put `threshold << 8` into the C++ readback mux instead of the field's declared lsb shift, wedging readback for any design using `Vec<Struct, N>` regs.

## Repro

A 4-bank register file emitted by rdl2arch:

```arch
reg ch_r: Vec<ChReg, 4> reset rst => ChReg { enable: 0, threshold: 0 };

let rdata_mux: UInt<32> = match s_axi.ar_addr
  6'h0 => {16'h0, ch_r[0].threshold, ch_r[0].enable},
  ...
end match;
```

Where `ChReg` has `enable: UInt<1>` (lsb 0) and `threshold: UInt<15>` (lsb 1).

After writing 0x11 to address 0 and reading back:
- Expected: `(8 << 1) | 1` = 0x11.
- Got: `(8 << 8) | 1` = 0x801 — threshold scattered into the upper half of the word.

## The fix

Two small edits in `sim_codegen.rs`:

1. Extend the `widths` population to also cover `Vec<Named, N>` reg / port types. Peel one level of `Vec<>` so a Vec-of-named-struct contributes per-field widths under the usual `<reg>.<field>` key. No per-index entries needed — every `ch_r[i].threshold` lookup resolves to the same field width.

2. Extend `infer_expr_width`'s `FieldAccess` arm to also try the shortcut lookup when the base is `Index(Ident, _)` (the Vec-elem shape), not just bare `Ident`.

## Test plan

- [ ] `Vec<Struct, N>` reg + concat readback `{..., reg[i].field, ...}` produces correct shifts (verified with rdl2arch's channelized fixture: `ch_r[i].threshold << 1`, not `<< 8`).
- [ ] Bare `Ident.field` lookup still works (unchanged path).
- [ ] Designs with no struct types still skip the lookup (no spurious matches).

## Closes the family

Together with #6/#12 (bare Named regs/ports), #13 (VStructs.h include for Vec<Named>), #15 (Vec port body indexing), this closes the last width-inference / sim-codegen hole for Vec-of-struct designs. The canonical generate_for + Vec-at-module-scope pattern from #11/#14 now works end-to-end through `arch sim --pybind`.

Discovered via rdl2arch's generator-side refactor to use the new pattern (Python-time unroll → one Vec-typed reg). All 43 downstream rdl2arch tests pass with this fix in place.