### PR TITLE
feat: learning system v1.1 — prune, MCP tools, --from-stderr, auto-hint, retrieved_count

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ tests/realbench/debug/
 # Claude session data
 .claude/
 critique2.txt
+
+# Private draft — crowd-sourced data co-op proposal (not for publication)
+doc/plan_arch_data_coop.md

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ arch check MyModule.arch            # succeeds → prints: 📚 Learned: [width_
 arch learn-index                    # rebuild BM25 retrieval index
 arch advise "width mismatch"        # top-K past fixes matching the query
 arch learn-stats                    # counts by error_code
+arch learn-prune --code other --dry-run    # preview removal by error code, substring, or age
 arch learn-clear                    # wipe the store
 ```
 

--- a/doc/plan_arch_learning_system.md
+++ b/doc/plan_arch_learning_system.md
@@ -96,45 +96,65 @@ Rule of thumb: start with RAG (low commitment, high value), and **promote stable
 
 ## Roadmap
 
-### v1 (this commit scope) — the minimum useful local loop
+### v1 — minimum useful local loop (SHIPPED in v0.42.0)
 
-New subcommands and flags:
+Delivered in commits on branch `learn` (PR #17).
 
-- **`arch check --learn <file.arch>`** — run check as normal. Additionally:
-  - If check *fails*: record pending state `(file_path, src_hash, error_code, error_span, error_message, timestamp)` in `~/.arch/learn/pending/<file_hash>.json`.
-  - If check *succeeds* and there's a pending entry for this file: compute the diff between pending `src_before` and current `src_after`, append an event to `~/.arch/learn/events.jsonl`:
+- **Always-on capture.** Every `arch check`/`build`/`sim`/`formal` invocation records error→fix pairs into `~/.arch/learn/events.jsonl`. No flag required; `ARCH_NO_LEARN=1` opts out.
+  - On failure: stash `(file_path, src, error_code, error_message, timestamp)` into `~/.arch/learn/pending/<file_hash>.json`.
+  - On success with a pending entry: pair into an `error_fix` event, append to `events.jsonl`, print `📚 Learned: [<code>] <diff>`.
+  - Event schema:
     ```json
     {
       "ts": "2026-04-18T20:00:00Z",
       "kind": "error_fix",
       "error_code": "width_mismatch",
       "error_message": "RHS is UInt<9> but LHS is UInt<8>",
+      "file_path": "MyMod.arch",
       "src_before": "<full file text before fix>",
       "src_after": "<full file text after fix>",
       "diff_summary": "cnt <= cnt + 1;  →  cnt <= (cnt + 1).trunc<8>();"
     }
     ```
-  - Delete the pending entry.
+- **Size cap.** 100 MB default (override `ARCH_LEARN_MAX_MB`). Warns once at ≥90% full; hard-skips writes at 100%.
+- **`arch learn-index`** — BM25 lexical index over error_code + error_message + diff_summary. Pure Rust; no new deps.
+- **`arch advise <query> [-k N]`** — top-K retrieval with score, code, message, file, diff.
+- **`arch learn-stats`** — event count + breakdown by error_code.
+- **`arch learn-clear`** — wipe the whole store.
+- **`arch learn-prune --code|--contains|--older-than-days [--dry-run]`** — remove events by filter; auto-invalidates the index.
+- **MCP tools**: `arch_advise`, `arch_learn_index`, `arch_learn_stats`, `arch_learn_prune` exposed to agents. Server instructions tell agents to call `arch_advise` on every compile error before attempting a fix.
+- **Retroactive backfill**: a one-off Python miner (`/tmp/mine_learn.py`, not in repo) parses Claude Code session logs and extracts fail→edit→success triples into the store. Used to seed ~44 events across 9 historical sessions.
 
-- **`arch learn-index`** — read `events.jsonl`, compute a simple BM25/TF-IDF inverted index over error messages and diff content, write to `~/.arch/learn/index.json`. No external embedding model in v1; pure lexical retrieval is adequate for the volume (<1000 events/user typically).
+JSONL is the source of truth; BM25 `index.json` is disposable and rebuilt on demand. No external embedding model, no network, no telemetry, single static compiler binary.
 
-- **`arch advise <query>`** — load `events.jsonl` + `index.json`, score entries against the query string (combine error_message, error_code, diff_summary fields), print top-K (default K=3) with full before/after diff.
+### v1.1 — quality-of-life (partial)
 
-Data formats are plain JSONL — easy to inspect, diff, and script against. No new dependencies beyond what's in the tree today.
+- [SHIPPED] `arch learn-stats`, `arch learn-clear`, `arch learn-prune`
+- [TODO] `arch advise --from-stderr` — pipe the latest compiler error into advise without copying.
+- [TODO] Auto-suggestion hook: `arch check` prints "💡 `arch advise` found 2 similar past errors" when the store has relevant entries for the current failure.
+- [TODO] **Usage counters.** Add `retrieved_count` (bumped on every `advise` top-K hit) and `helped_count` (bumped when a compile-clean follows an advise within the same session). These become the downstream-utility signal for the data-coop ranker (see `plan_arch_data_coop.md`, §3.2). Step 1 (retrieved_count) is cheap; step 2 needs a per-session nonce written to pending state.
 
-### v1.1 — quality-of-life
+### v2 — richer capture + semantic retrieval
 
-- `arch advise --from-stderr` — pipe the latest compiler error directly into advise without copying.
-- `arch learn stats` — show counts by error_code, most-frequent fixes.
-- `arch learn clear` — reset local store.
-- Auto-suggestion hook: `arch check` prints "💡 `arch advise` found 2 similar past errors; run `arch advise` to see" when the store has relevant entries.
-
-### v2 — richer capture
-
+**Capture expansions** (orthogonal to retrieval backend):
 - Record **successful compiles** of multi-construct designs → idiom corpus.
 - Record **verification failures** (EBMC, SVA) → root-cause corpus.
 - Record **prompt → code** pairs (requires editor/agent integration; new `arch learn-prompt` API).
-- Swap BM25 index for local embeddings (sentence-transformers via Python subprocess, or a Rust ONNX runtime with a small code-aware model).
+
+**Retrieval upgrade: SQLite + sqlite-vec + local ONNX embeddings.** Deferred until the lexical BM25 v1 shows concrete limits — volume or semantic-miss symptoms. Design when we pick it up:
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Vector DB | `sqlite-vec` via `rusqlite` | One file under `~/.arch/learn/store.db`; preserves "nothing leaves the machine" story |
+| Embedding backend | Pure-Rust ONNX (`ort` + `tokenizers`) | No Python dep; no bundled 1 GB venv; runs offline after first-use download |
+| Model | `all-MiniLM-L6-v2` (384-dim, ~90 MB) as default; offer `bge-code-v1.5` (1024-dim, code-specialized, ~340 MB) as opt-in | MiniLM is fast enough for real-time `advise`; code-specialized is a later tuning knob |
+| Model storage | `~/.arch/learn/model/` — auto-download on first `arch learn-index` | Compiler binary stays small; one-time cost |
+| API-based embeddings | **Rejected** | Would send source off-device; violates always-local privacy rule |
+| Migration | Rebuild `store.db` from `events.jsonl`; keep JSONL as source of truth | `events.jsonl` stays human-inspectable; prune/clear stay trivial |
+| Reranking | Embed query → top-50 cosine candidates → BM25 rerank | Fuses semantic recall with exact-term precision |
+| Scale test | New `arch learn-bench` synthesizes N events and reports query latency at N = 100/1K/10K/100K | Concrete evidence for when the v2 investment pays off |
+
+**Exit criteria for triggering v2 work**: either (a) single-user store passes ~1,000 events and `advise` top-3 starts feeling stale, or (b) queries with no lexical overlap (e.g. "too-wide assignment" vs. a stored "width mismatch") consistently miss good matches. Until then, BM25 is adequate and cheaper on every axis.
 
 ### v3 — contributor sharing
 

--- a/doc/plan_arch_learning_system.md
+++ b/doc/plan_arch_learning_system.md
@@ -127,12 +127,13 @@ Delivered in commits on branch `learn` (PR #17).
 
 JSONL is the source of truth; BM25 `index.json` is disposable and rebuilt on demand. No external embedding model, no network, no telemetry, single static compiler binary.
 
-### v1.1 — quality-of-life (partial)
+### v1.1 — quality-of-life (SHIPPED)
 
 - [SHIPPED] `arch learn-stats`, `arch learn-clear`, `arch learn-prune`
-- [TODO] `arch advise --from-stderr` — pipe the latest compiler error into advise without copying.
-- [TODO] Auto-suggestion hook: `arch check` prints "💡 `arch advise` found 2 similar past errors" when the store has relevant entries for the current failure.
-- [TODO] **Usage counters.** Add `retrieved_count` (bumped on every `advise` top-K hit) and `helped_count` (bumped when a compile-clean follows an advise within the same session). These become the downstream-utility signal for the data-coop ranker (see `plan_arch_data_coop.md`, §3.2). Step 1 (retrieved_count) is cheap; step 2 needs a per-session nonce written to pending state.
+- [SHIPPED] `arch advise --from-stderr` — reads the query from stdin, so `arch check ... 2>&1 | arch advise --from-stderr` works without copying.
+- [SHIPPED] Compile-failure hint: on every failed `arch check/build/sim/formal`, if the local store has similar past fixes, print `💡 arch advise found N similar past fixes — run 'arch advise "<code>"' to see them.` Uses a zero-side-effect `peek` that does not bump retrieval counts.
+- [SHIPPED] **`retrieved_count`** — each time `arch advise` returns an event in its top-K, that event's counter is incremented. Stored in `~/.arch/learn/retrieval_counts.json` keyed by a stable event id (fnv hash of `ts + error_code + diff_summary`), so `events.jsonl` stays append-only. Exposed in `advise` output as `retrieved N×`.
+- [TODO — deferred to v2 alongside richer capture] **`helped_count`** — bump when a compile-clean follows an advise within the same session. Needs per-session correlation (nonce written into pending state, cleared on successful pair). Harder because attribution is fuzzy; deferring until we have a story for v2 capture (idioms, prompts) so the tracking hooks land once.
 
 ### v2 — richer capture + semantic retrieval
 

--- a/mcp/arch_mcp_server.py
+++ b/mcp/arch_mcp_server.py
@@ -181,9 +181,49 @@ def get_construct_syntax(construct: str) -> str:
 
 @mcp.tool()
 def arch_check(files: list[str]) -> str:
-    """Type-check one or more .arch files. Returns diagnostics."""
+    """Type-check one or more .arch files. Returns diagnostics.
+
+    Note: every invocation records error→fix pairs into ~/.arch/learn/ for
+    retrieval via `arch_advise`. Disable with env ARCH_NO_LEARN=1.
+    """
     paths = [str(_resolve_safe(f)) for f in files]
     return _run([ARCH_BIN, "check"] + paths)
+
+
+@mcp.tool()
+def arch_advise(query: str, top: int = 3) -> str:
+    """Retrieve past error→fix pairs from the local learning store that
+    match `query`. Useful when an agent hits a compiler error and wants to
+    see how the same user fixed a similar error before. Returns the top-K
+    matches (default 3) with error code, error message, file, and diff.
+
+    The store is built passively by every `arch check/build/sim/formal`
+    invocation and lives at ~/.arch/learn/. Run `arch_learn_index` once
+    after new events accumulate to refresh the BM25 retrieval index.
+
+    Example queries:
+      - "width mismatch trunc"
+      - "duplicate definition"
+      - "undeclared identifier"
+    """
+    return _run([ARCH_BIN, "advise", "-k", str(top), query])
+
+
+@mcp.tool()
+def arch_learn_index() -> str:
+    """Rebuild the BM25 retrieval index over the local learning store.
+    Call after many new events have been recorded; `arch_advise` works
+    without this but may miss recent entries until the index is refreshed.
+    """
+    return _run([ARCH_BIN, "learn-index"])
+
+
+@mcp.tool()
+def arch_learn_stats() -> str:
+    """Summarize the local learning store: total events and counts by
+    error_code. Useful to see what kinds of mistakes the user has been
+    making, or to decide whether the store is worth querying."""
+    return _run([ARCH_BIN, "learn-stats"])
 
 
 @mcp.tool()

--- a/mcp/arch_mcp_server.py
+++ b/mcp/arch_mcp_server.py
@@ -219,6 +219,31 @@ def arch_learn_index() -> str:
 
 
 @mcp.tool()
+def arch_learn_prune(
+    code: str | None = None,
+    contains: str | None = None,
+    older_than_days: int | None = None,
+    dry_run: bool = True,
+) -> str:
+    """Remove events from the local learning store. At least one filter is
+    required. An event is removed if ANY filter matches.
+
+    - code: exact error_code (e.g. "parse_error", "other", "width_mismatch")
+    - contains: substring match against diff, message, or file path
+    - older_than_days: remove entries older than N days
+
+    Defaults to dry_run=True — always preview before deleting. Pass
+    dry_run=False to actually prune.
+    """
+    cmd = [ARCH_BIN, "learn-prune"]
+    if code: cmd += ["--code", code]
+    if contains: cmd += ["--contains", contains]
+    if older_than_days is not None: cmd += ["--older-than-days", str(older_than_days)]
+    if dry_run: cmd += ["--dry-run"]
+    return _run(cmd)
+
+
+@mcp.tool()
 def arch_learn_stats() -> str:
     """Summarize the local learning store: total events and counts by
     error_code. Useful to see what kinds of mistakes the user has been

--- a/mcp/instructions.md
+++ b/mcp/instructions.md
@@ -5,6 +5,8 @@ IMPORTANT WORKFLOW — follow this order when writing .arch code:
 2. THEN write the .arch code using write_and_check() (writes + type-checks in one call)
 3. THEN call arch_build_and_lint() to generate SV and verify with Verilator
 
+WHEN A COMPILE ERROR APPEARS: call arch_advise(query="<error message keywords>") before attempting a fix. It retrieves past error→fix pairs from the user's local learning store (~/.arch/learn/). If a match exists, prefer its approach — the user has hit this before. Every check/build/sim/formal invocation silently records new error→fix pairs, so the store grows over time. Use arch_learn_stats() to see what's accumulated.
+
 CONSTRUCT SELECTION — use first-class constructs when possible:
 - FSM behavior → use 'fsm' (NOT a module with manual state register)
 - FIFO → use 'fifo' (NOT a module with manual pointers); MUST declare a type parameter (e.g. 'param WIDTH: type = UInt<32>;') and use it on push_data/pop_data ports ('in WIDTH', NOT 'in UInt<32>')

--- a/src/learn.rs
+++ b/src/learn.rs
@@ -303,10 +303,86 @@ pub fn build_index() -> std::io::Result<usize> {
 pub struct Match {
     pub score: f64,
     pub event: Event,
+    pub retrieved_count: u32,
+}
+
+/// Stable, order-independent fingerprint for an event — used as the key in
+/// `retrieval_counts.json`. Hash ts + error_code + diff_summary so the id
+/// survives any future field additions without breaking existing counts.
+pub fn event_id(e: &Event) -> String {
+    let mut h: u64 = 0xcbf29ce484222325;
+    for chunk in [e.ts.as_bytes(), e.error_code.as_bytes(), e.diff_summary.as_bytes()] {
+        for b in chunk {
+            h ^= *b as u64;
+            h = h.wrapping_mul(0x100000001b3);
+        }
+        h ^= b'|' as u64;
+        h = h.wrapping_mul(0x100000001b3);
+    }
+    format!("{h:016x}")
+}
+
+fn counts_path() -> std::io::Result<PathBuf> {
+    Ok(learn_dir()?.join("retrieval_counts.json"))
+}
+
+fn load_counts() -> std::io::Result<std::collections::HashMap<String, u32>> {
+    let path = counts_path()?;
+    if !path.exists() {
+        return Ok(std::collections::HashMap::new());
+    }
+    let raw = fs::read_to_string(&path)?;
+    let mut out = std::collections::HashMap::new();
+    // Tiny parser: `{"id":N,"id":N,...}`
+    let trimmed = raw.trim().trim_start_matches('{').trim_end_matches('}');
+    for entry in trimmed.split(',') {
+        let entry = entry.trim();
+        if entry.is_empty() { continue; }
+        if let Some((k, v)) = entry.split_once(':') {
+            let k = k.trim().trim_matches('"').to_string();
+            if let Ok(n) = v.trim().parse::<u32>() {
+                out.insert(k, n);
+            }
+        }
+    }
+    Ok(out)
+}
+
+fn save_counts(counts: &std::collections::HashMap<String, u32>) -> std::io::Result<()> {
+    let path = counts_path()?;
+    let mut s = String::from("{");
+    let mut first = true;
+    for (k, v) in counts {
+        if !first { s.push(','); }
+        first = false;
+        s.push_str(&format!("\"{}\":{}", k, v));
+    }
+    s.push('}');
+    fs::write(&path, s)
+}
+
+fn bump_counts(ids: &[String]) -> std::io::Result<()> {
+    if ids.is_empty() { return Ok(()); }
+    let mut counts = load_counts()?;
+    for id in ids {
+        *counts.entry(id.clone()).or_insert(0) += 1;
+    }
+    save_counts(&counts)
+}
+
+/// Quick advise that does not bump retrieval counts — used by the inline
+/// compile-failure hint in `arch check` to avoid inflating counts on
+/// suggestions the user never actually looked at.
+pub fn peek(query: &str, k: usize) -> std::io::Result<Vec<Match>> {
+    advise_impl(query, k, false)
 }
 
 /// Load events, tokenize the query, score each event via BM25, return top-K.
 pub fn advise(query: &str, k: usize) -> std::io::Result<Vec<Match>> {
+    advise_impl(query, k, true)
+}
+
+fn advise_impl(query: &str, k: usize, bump: bool) -> std::io::Result<Vec<Match>> {
     let dir = learn_dir()?;
     let events_path = dir.join("events.jsonl");
     if !events_path.exists() {
@@ -356,7 +432,20 @@ pub fn advise(query: &str, k: usize) -> std::io::Result<Vec<Match>> {
     }
     scored.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
     scored.truncate(k);
-    Ok(scored.into_iter().map(|(s, e)| Match { score: s, event: e }).collect())
+
+    let counts = load_counts().unwrap_or_default();
+    let top: Vec<Match> = scored.into_iter().map(|(s, e)| {
+        let id = event_id(&e);
+        let c = *counts.get(&id).unwrap_or(&0);
+        Match { score: s, event: e, retrieved_count: c }
+    }).collect();
+
+    if bump {
+        let ids: Vec<String> = top.iter().map(|m| event_id(&m.event)).collect();
+        let _ = bump_counts(&ids);
+    }
+
+    Ok(top)
 }
 
 /// Print stored stats.

--- a/src/learn.rs
+++ b/src/learn.rs
@@ -391,6 +391,89 @@ pub fn print_stats() -> std::io::Result<()> {
     Ok(())
 }
 
+/// Prune events from the store. Returns (kept, removed).
+/// An event is removed if it matches *any* of the filters:
+/// - `code == Some(c)`: event's error_code equals `c`
+/// - `substr == Some(s)`: `s` appears in diff_summary, error_message, or file_path
+/// - `older_than_days == Some(d)`: event timestamp is older than `d` days ago
+/// If `dry_run` is true, nothing is written; just counts.
+pub fn prune(
+    code: Option<&str>,
+    substr: Option<&str>,
+    older_than_days: Option<u64>,
+    dry_run: bool,
+) -> std::io::Result<(usize, usize)> {
+    let dir = learn_dir()?;
+    let events_path = dir.join("events.jsonl");
+    if !events_path.exists() {
+        return Ok((0, 0));
+    }
+    let raw = fs::read_to_string(&events_path)?;
+    let cutoff_ts: Option<String> = older_than_days.map(|d| {
+        let now_secs = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|x| x.as_secs())
+            .unwrap_or(0);
+        let cutoff = now_secs.saturating_sub(d * 86400);
+        let (y, mo, da, hh, mm, ss) = epoch_to_utc(cutoff);
+        format!("{y:04}-{mo:02}-{da:02}T{hh:02}:{mm:02}:{ss:02}Z")
+    });
+
+    let mut kept_lines: Vec<String> = Vec::new();
+    let mut removed = 0usize;
+    for line in raw.lines() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let ev = match json_to_event(line) {
+            Some(e) => e,
+            None => {
+                kept_lines.push(line.to_string());
+                continue;
+            }
+        };
+        let mut drop = false;
+        if let Some(c) = code {
+            if ev.error_code == c {
+                drop = true;
+            }
+        }
+        if !drop {
+            if let Some(s) = substr {
+                if ev.diff_summary.contains(s)
+                    || ev.error_message.contains(s)
+                    || ev.file_path.contains(s)
+                {
+                    drop = true;
+                }
+            }
+        }
+        if !drop {
+            if let Some(cutoff) = &cutoff_ts {
+                if ev.ts.as_str() < cutoff.as_str() {
+                    drop = true;
+                }
+            }
+        }
+        if drop {
+            removed += 1;
+        } else {
+            kept_lines.push(line.to_string());
+        }
+    }
+    let kept = kept_lines.len();
+    if !dry_run && removed > 0 {
+        let mut out = kept_lines.join("\n");
+        if !out.is_empty() {
+            out.push('\n');
+        }
+        fs::write(&events_path, out)?;
+        // Index is now stale; remove so `advise` rebuilds / warns.
+        let _ = fs::remove_file(dir.join("index.json"));
+    }
+    Ok((kept, removed))
+}
+
 // ── helpers ──────────────────────────────────────────────────────────────
 
 fn iso8601_now() -> String {

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,6 +33,22 @@ enum Command {
     LearnIndex,
     /// Delete the entire local learning store at ~/.arch/learn/
     LearnClear,
+    /// Remove individual events from the learning store by filter.
+    /// Combine filters freely; an event is removed if ANY filter matches.
+    LearnPrune {
+        /// Remove events with this error_code (e.g. "parse_error", "other")
+        #[arg(long)]
+        code: Option<String>,
+        /// Remove events whose diff/message/file_path contains this substring
+        #[arg(long)]
+        contains: Option<String>,
+        /// Remove events older than this many days
+        #[arg(long)]
+        older_than_days: Option<u64>,
+        /// Report what would be removed without modifying the store
+        #[arg(long)]
+        dry_run: bool,
+    },
     /// Retrieve past error→fix pairs matching the query
     Advise {
         /// Query string (free text; matched against error codes, messages, diffs)
@@ -267,6 +283,24 @@ fn main() -> miette::Result<()> {
         Command::LearnClear => {
             arch::learn::clear_store().into_diagnostic()?;
             eprintln!("Cleared ~/.arch/learn/");
+            Ok(())
+        }
+        Command::LearnPrune { code, contains, older_than_days, dry_run } => {
+            if code.is_none() && contains.is_none() && older_than_days.is_none() {
+                eprintln!("error: specify at least one of --code / --contains / --older-than-days");
+                std::process::exit(2);
+            }
+            let (kept, removed) = arch::learn::prune(
+                code.as_deref(),
+                contains.as_deref(),
+                older_than_days,
+                dry_run,
+            ).into_diagnostic()?;
+            if dry_run {
+                eprintln!("Would remove {} events; {} would remain.", removed, kept);
+            } else {
+                eprintln!("Removed {} events; {} remain. Run `arch learn-index` to refresh the index.", removed, kept);
+            }
             Ok(())
         }
         Command::Sim { arch_files, tb_files, outdir, check_uninit, inputs_start_uninit, check_uninit_ram, cdc_random, wave, debug, debug_depth, debug_fsm, pybind, test, pybind_module_name } => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,12 +51,15 @@ enum Command {
     },
     /// Retrieve past error→fix pairs matching the query
     Advise {
-        /// Query string (free text; matched against error codes, messages, diffs)
-        #[arg(required = true)]
+        /// Query string (free text; matched against error codes, messages, diffs).
+        /// May be omitted when --from-stderr is set.
         query: Vec<String>,
         /// Number of top results to print
         #[arg(short = 'k', long, default_value_t = 3)]
         top: usize,
+        /// Read the query from stdin (e.g. `arch check foo.arch 2>&1 | arch advise --from-stderr`)
+        #[arg(long)]
+        from_stderr: bool,
     },
     /// Show stats about the local learning store
     LearnStats,
@@ -236,6 +239,20 @@ where
                     let _ = arch::learn::record_failure(&path_str, &code, &msg, &src);
                 }
             }
+            // Inline suggestion: if the local store has similar past fixes,
+            // tell the user. `peek` does not bump retrieval counters.
+            let query = format!("{} {}", code, msg);
+            if let Ok(hits) = arch::learn::peek(&query, 3) {
+                if !hits.is_empty() {
+                    let suggest = hits[0].event.error_code.clone();
+                    eprintln!(
+                        "💡 arch advise found {} similar past fix{} — run `arch advise \"{}\"` to see them.",
+                        hits.len(),
+                        if hits.len() == 1 { "" } else { "es" },
+                        suggest,
+                    );
+                }
+            }
         }
     }
     result
@@ -259,15 +276,29 @@ fn main() -> miette::Result<()> {
             eprintln!("Indexed {} events.", n);
             Ok(())
         }
-        Command::Advise { query, top } => {
-            let q = query.join(" ");
+        Command::Advise { query, top, from_stderr } => {
+            let mut q = query.join(" ");
+            if from_stderr {
+                use std::io::Read;
+                let mut buf = String::new();
+                std::io::stdin().read_to_string(&mut buf).into_diagnostic()?;
+                if !buf.trim().is_empty() {
+                    if !q.is_empty() { q.push(' '); }
+                    q.push_str(buf.trim());
+                }
+            }
+            if q.trim().is_empty() {
+                eprintln!("error: empty query (pass a query string or pipe via --from-stderr)");
+                std::process::exit(2);
+            }
             let matches = arch::learn::advise(&q, top).into_diagnostic()?;
             if matches.is_empty() {
                 eprintln!("No matches.");
                 return Ok(());
             }
             for (i, m) in matches.iter().enumerate() {
-                println!("── match #{} (score {:.3}) ──────────────────────", i + 1, m.score);
+                println!("── match #{} (score {:.3}, retrieved {}×) ──────────────────────",
+                         i + 1, m.score, m.retrieved_count);
                 println!("  code:    {}", m.event.error_code);
                 println!("  message: {}", m.event.error_message);
                 println!("  file:    {}", m.event.file_path);


### PR DESCRIPTION
## Summary

Follow-on to merged #17 (v0.42.0 always-on local learning). Adds the v1.1 quality-of-life layer plus MCP integration so agents can query the store directly.

### New user-facing features

- **\`arch learn-prune\`** — remove events from the store by \`--code\`, \`--contains\`, or \`--older-than-days\`; combinable, OR semantics, \`--dry-run\` previews. Auto-invalidates the BM25 index on real prune.
- **\`arch advise --from-stderr\`** — reads the query from stdin so the compile output can pipe directly: \`arch check foo.arch 2>&1 | arch advise --from-stderr\`.
- **Inline compile-failure hint** — on any failed \`arch check/build/sim/formal\`, if the local store has similar past fixes, the compiler prints one line: \`💡 arch advise found N similar past fixes — run 'arch advise "<code>"' to see them.\` Uses a zero-side-effect \`peek\` that does NOT bump retrieval counts.
- **Per-event \`retrieved_count\`** — incremented whenever an event appears in \`arch advise\` top-K; surfaced as \`retrieved N×\` in the advise header. Stored separately in \`~/.arch/learn/retrieval_counts.json\` keyed by a stable event id (fnv hash of \`ts + error_code + diff_summary\`) so \`events.jsonl\` stays append-only.

### MCP integration

- New tools exposed to agents: \`arch_advise\`, \`arch_learn_index\`, \`arch_learn_stats\`, \`arch_learn_prune\` (\`dry_run=True\` default for agent safety).
- \`mcp/instructions.md\` now directs agents: on every compile error, call \`arch_advise\` before attempting a fix.

### Docs

- \`doc/plan_arch_learning_system.md\` — v1/v1.1 sections rewritten to reflect shipped state; v2 section now specifies the deferred retrieval upgrade concretely (rusqlite + sqlite-vec + pure-Rust ONNX, MiniLM default, bge-code opt-in), and names explicit exit criteria (~1K events or consistent lexical-miss queries) before v2 work begins.
- \`README.md\` — \`learn-prune\` line added.
- \`.gitignore\` — shields a private co-op data draft from publication.

\`helped_count\` (the second half of v1.1 usage counters) is deferred to v2 because session-correlation is cleanest to build alongside the v2 capture expansions (idioms, prompt→code pairs).

## Test plan
- [x] \`cargo build\` clean
- [x] \`cargo test --lib\` — 15 passing
- [x] End-to-end: auto-hint fires on failure once store is populated
- [x] \`--from-stderr\` returns correct top-K from piped compile output
- [x] \`retrieved_count\` increments on advise, unchanged by \`peek\`/auto-hint
- [x] \`learn-prune\` by each filter class (code / contains / older-than-days) + \`--dry-run\`
- [x] Backfilled local store with 44 historical events from 9 Claude Code sessions via an out-of-tree miner script

🤖 Generated with [Claude Code](https://claude.com/claude-code)