### PR TITLE
fix: elaborate — inst connection signals use suffix-aware substitution

### DIFF
--- a/src/elaborate.rs
+++ b/src/elaborate.rs
@@ -740,13 +740,20 @@ fn subst_inst(inst: &InstDecl, var: &str, val: i64) -> InstDecl {
                 value: subst_expr(pa.value.clone(), var, val),
             })
             .collect(),
+        // Connection signals may reference suffix-substituted names from the
+        // enclosing generate_for (e.g. `done -> done_i` becomes `done -> done_0`
+        // for i=0). `subst_expr` only rewrites bare loop-var idents; using the
+        // suffix-aware `subst_expr_names` matches how thread-stmt / seq-stmt
+        // substitution already handles this, and fixes a bug where inst
+        // outputs connecting to per-iteration output ports didn't propagate
+        // the drive through unroll.
         connections: inst
             .connections
             .iter()
             .map(|c| Connection {
                 port_name: subst_ident(&c.port_name, var, val),
                 direction: c.direction,
-                signal: subst_expr(c.signal.clone(), var, val),
+                signal: subst_expr_names(c.signal.clone(), var, val),
                 reset_override: c.reset_override,
                 span: c.span,
             })


### PR DESCRIPTION
## Summary

`inst` inside `generate_for` driving a per-iteration output port failed downstream typecheck with `output port X_0 is not driven`, even though the same connection shape outside generate_for works fine. Root cause: `subst_inst` used the bare-ident-only `subst_expr` for connection signals, so `done -> done_i` stayed `done -> done_i` after unroll instead of becoming `done -> done_0`, `done -> done_1`, ...

## Repro

```arch
generate_for i in 0..1
  port done_i: out Bool;
  inst c_i: Counter
    clk   <- clk;
    rst   <- rst;
    start <- start_i;
    done  -> done_i;         // before: stays `done -> done_i` post-unroll
  end inst c_i
end generate_for
```

Before:
```
error: output port `done_0` is not driven
```

After:
```
$ arch build genfor_fsm.arch
Wrote genfor_fsm.sv

  output logic done_0, output logic done_1
  Counter c_0 ( ... .done(done_0) );
  Counter c_1 ( ... .done(done_1) );
```

## The fix

One-character change: `subst_expr` → `subst_expr_names` (the suffix-aware variant) in `subst_inst::connections`. Same pattern as the sibling substitution functions that already handle suffix rewriting correctly:

- `subst_thread_stmt` — uses `subst_expr_names`.
- `subst_reg_block` / `subst_comb_block` (added in #11) — use `subst_expr_names`.
- `subst_inst::connections` — was using `subst_expr`. **This PR.**

## Verified with

- `fsm` instantiation inside generate_for driving per-iteration output ports.
- `counter` ditto.
- `fifo` ditto.
- rdl2arch 43-test suite still green.

## Test plan

- [ ] FSM / counter / ram / fifo `inst` inside generate_for with outputs going to per-iteration output ports builds cleanly.
- [ ] FSM / counter / ram / fifo `inst` outside generate_for still works (unchanged).
- [ ] `param_assigns` values inside generate_for left on `subst_expr` — they only reference the bare loop var in practice, not suffix-named params. Could consider changing for consistency if any user hits it.

## Reviewer notes

Completes the sweep started by #11/#14/#15: everything that `generate_for` declaratively supports (ports, insts of first-class constructs, threads, seq, comb) now correctly substitutes suffix-named references through the unroll. No architectural change — a pure bug fix in the substitution helper.