### PR TITLE
fix: forbid port declarations inside generate_for (consistency tightening)

### DIFF
--- a/examples/generate_for.arch
+++ b/examples/generate_for.arch
@@ -1,22 +1,36 @@
-// Test: generate_for loop expanding ports
-// `generate_for i in 0..1` creates two copies of req_i and gnt_i.
+// Test: generate_for + Vec-typed ports + inst.
+//
+// A Vec-typed port declared at module scope is indexed by the loop variable
+// on inst connections inside the generate_for body. This replaces the older
+// `port req_i:` form whose expansion produced ugly `_0 / _1 / ...` scalar
+// port names at the SV boundary. The Vec form scales cleanly to large N
+// and keeps the module's external interface a single indexed signal.
 
 domain SysDomain
   freq_mhz: 100
 end domain SysDomain
 
-module GenDemo
-  port clk: in Clock<SysDomain>;
-  port rst: in Reset<Sync>;
-
-  generate_for i in 0..1
-    port req_i: in Bool;
-    port gnt_i: out Bool;
-  end generate_for
+module PassThrough
+  port a: in  Bool;
+  port b: out Bool;
 
   comb
-    gnt_0 = req_0;
-    gnt_1 = req_1;
+    b = a;
   end comb
+end module PassThrough
+
+module GenDemo
+  param N: const = 2;
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port req: in  Vec<Bool, N>;
+  port gnt: out Vec<Bool, N>;
+
+  generate_for i in 0..N-1
+    inst pt_i: PassThrough
+      a <- req[i];
+      b -> gnt[i];
+    end inst pt_i
+  end generate_for
 
 end module GenDemo

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1883,7 +1883,6 @@ impl Parser {
         let mut items = Vec::new();
         while !self.check_end_generate_for() {
             match self.peek_kind() {
-                Some(TokenKind::Port) => items.push(GenItem::Port(self.parse_port_decl()?)),
                 Some(TokenKind::Inst) => items.push(GenItem::Inst(self.parse_inst()?)),
                 Some(TokenKind::Thread) => items.push(GenItem::Thread(self.parse_thread_block()?)),
                 Some(TokenKind::Assert) | Some(TokenKind::Cover) => {
@@ -1895,30 +1894,37 @@ impl Parser {
                 Some(TokenKind::Comb) => {
                     items.push(GenItem::Comb(self.parse_comb_block()?));
                 }
-                Some(TokenKind::Reg) | Some(TokenKind::Let) => {
-                    // Reject with a targeted hint — reg/let decls inside
-                    // generate_for would force per-iteration unrolling that
-                    // produces ugly suffix-mangled SV names, or (for reg)
-                    // implies multi-driver conflicts. The approved shape is
-                    // "declare Vec regs at module scope; index them by the
-                    // loop var in a seq/comb inside generate_for".
-                    let kw = match self.peek_kind() {
-                        Some(TokenKind::Reg) => "reg",
-                        _ => "let",
+                // Module-scope declarations (port / reg / let) are not allowed
+                // inside generate_for — the body is for per-iteration members
+                // (insts, seq / comb, threads, asserts). Declarations go at
+                // module scope; use Vec types for per-element access. This
+                // keeps the SV boundary from sprouting `_0 / _1 / ... / _N-1`
+                // scalar port names for what is naturally a single indexed
+                // signal.
+                Some(tok @ (TokenKind::Port | TokenKind::Reg | TokenKind::Let)) => {
+                    let (kw, hint) = match tok {
+                        TokenKind::Port => ("port",
+                            "Declare ports at module scope using Vec types for \
+                             per-iteration elements, e.g. `port done: out Vec<Bool, N>;` \
+                             outside, then `done -> done[i];` inside an inst here."),
+                        TokenKind::Reg => ("reg",
+                            "Declare Vec-typed regs at module scope and index them in a \
+                             seq / comb block here, e.g. `reg store: Vec<UInt<8>, N> ...;` \
+                             outside, then `store[i] <= ...;` inside generate_for."),
+                        _ => ("let",
+                            "Move the let binding to module scope; reference it freely \
+                             from seq / comb inside generate_for."),
                     };
                     return Err(CompileError::general(
                         &format!(
-                            "'{kw}' declarations are not allowed inside generate_for. \
-                             Declare Vec-typed regs at module scope and index them in a \
-                             seq/comb block here: e.g. `reg store: Vec<UInt<8>, {{N}}> ...;` \
-                             outside, then `store[i] <= ...;` inside generate_for."
+                            "'{kw}' declarations are not allowed inside generate_for. {hint}"
                         ),
                         self.peek_span(),
                     ));
                 }
                 Some(other) => {
                     return Err(CompileError::unexpected_token(
-                        "port, inst, thread, seq, comb, assert, or cover",
+                        "inst, thread, seq, comb, assert, or cover",
                         &other.to_string(),
                         self.peek_span(),
                     ));

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -545,11 +545,12 @@ end module BadCounter
 fn test_generate_for() {
     let source = include_str!("../examples/generate_for.arch");
     let sv = compile_to_sv(source);
-    // After elaboration, generate_for 0..1 should expand to 2 ports each
-    assert!(sv.contains("req_0"), "expected req_0 port, got:\n{sv}");
-    assert!(sv.contains("req_1"), "expected req_1 port, got:\n{sv}");
-    assert!(sv.contains("gnt_0"), "expected gnt_0 port, got:\n{sv}");
-    assert!(sv.contains("gnt_1"), "expected gnt_1 port, got:\n{sv}");
+    // Ports are declared as Vec<Bool, N> at module scope — the SV boundary is
+    // a single packed vector per direction, not N separately-named scalars.
+    assert!(sv.contains("input logic [N-1:0] req"), "expected Vec req port, got:\n{sv}");
+    assert!(sv.contains("output logic [N-1:0] gnt"), "expected Vec gnt port, got:\n{sv}");
+    // generate_for unrolls the insts into gen_i blocks.
+    assert!(sv.contains("gen_i"), "expected gen_i block, got:\n{sv}");
     insta::assert_snapshot!(sv);
 }
 

--- a/tests/snapshots/integration_test__generate_for.snap
+++ b/tests/snapshots/integration_test__generate_for.snap
@@ -5,16 +5,30 @@ expression: sv
 // domain SysDomain
 //   freq_mhz: 100
 
-module GenDemo (
-  input logic clk,
-  input logic rst,
-  input logic req_0,
-  output logic gnt_0,
-  input logic req_1,
-  output logic gnt_1
+module PassThrough (
+  input logic a,
+  output logic b
 );
 
-  assign gnt_0 = req_0;
-  assign gnt_1 = req_1;
+  assign b = a;
+
+endmodule
+
+module GenDemo #(
+  parameter int N = 2
+) (
+  input logic clk,
+  input logic rst,
+  input logic [N-1:0] req,
+  output logic [N-1:0] gnt
+);
+
+  genvar i;
+  for (i = 0; i <= N - 1; i = i + 1) begin : gen_i
+    PassThrough pt_i (
+      .a(req[i]),
+      .b(gnt[i])
+    );
+  end
 
 endmodule


### PR DESCRIPTION
## Summary

Completes the "no module-scope declarations inside generate_for" consistency story. `reg` / `let` decls were already rejected (#11). Scalar LHS writes in seq / comb were rejected (#14). `port` was the remaining hole — `port foo_i:` unrolled to `foo_0`, `foo_1`, ... scalar boundary ports, producing the ugly `_0 / _1 / ... / _N-1` naming that users end up wiring externally.

Reject `port` declarations inside `generate_for` body. Declare ports at module scope and use Vec types for per-iteration elements.

## Before / after

Before:
```arch
module GenDemo
  generate_for i in 0..1
    port req_i: in  Bool;
    port gnt_i: out Bool;
  end generate_for
  comb
    gnt_0 = req_0;
    gnt_1 = req_1;
  end comb
end module GenDemo
```

SV:
```sv
module GenDemo (
  input  logic req_0,
  input  logic req_1,
  output logic gnt_0,
  output logic gnt_1
);
```

After — recommended Vec-port form, scales to any N:
```arch
module GenDemo
  param N: const = 2;
  port req: in  Vec<Bool, N>;
  port gnt: out Vec<Bool, N>;

  generate_for i in 0..N-1
    inst pt_i: PassThrough
      a <- req[i];
      b -> gnt[i];
    end inst pt_i
  end generate_for
end module GenDemo
```

SV:
```sv
module GenDemo #(parameter int N = 2) (
  input  logic [N-1:0] req,
  output logic [N-1:0] gnt
);
  genvar i;
  for (i = 0; i <= N - 1; i = i + 1) begin : gen_i
    PassThrough pt (
      .a(req[i]),
      .b(gnt[i])
    );
  end
endmodule
```

## Consistency map

generate_for body is for per-iteration *repeatable* members. Declarations belong at module scope:

| What | Where it's rejected | PR |
|---|---|---|
| `reg` / `let` decls | `parse_gen_items_for` | #11 |
| Scalar LHS writes in seq / comb | elaborator `check_gen_for_*_stmts` | #14 |
| **`port` decls** | `parse_gen_items_for` | **this PR** |

## Scope

Applies only to `generate_for`. `generate_if` continues to allow conditional port decls — that's a different pattern ("this port or not" driven by a param, not "N copies"), and both the RDL reference card and existing examples rely on it:

```arch
generate if DEBUG_EN
  port dbg: out UInt<32>;
end generate if
```

## Migration

- `examples/generate_for.arch` updated to the Vec-port form.
- Integration test `test_generate_for` updated + snapshot refreshed.
- No other in-tree examples use the old pattern — `examples/connect_index_test.arch` was already using Vec wires + inst inside generate_for.

## Test plan

- [ ] Existing valid generate_for designs (inst, seq, comb, thread, assert inside) unchanged.
- [ ] `port` inside generate_for emits the new directed error.
- [ ] `generate if { port ... }` still works (conditional port decls are legitimate).
- [ ] rdl2arch 43-test suite passes.

## Reviewer notes

This is a breaking change at the language level — any user that wrote `port foo_i:` inside generate_for gets a clear error + migration hint. No in-tree code triggers it after the example migration. If there's downstream code relying on the suffix-port form, the error message walks them to the Vec replacement.