### PR TITLE
feat: handshake primitive inside bus — Tier 1 + Tier 2 (SVA verified)

### DIFF
--- a/doc/plan_handshake_construct.md
+++ b/doc/plan_handshake_construct.md
@@ -273,7 +273,19 @@ interpreted as "producer drives continuously, consumer decides when to
 consume." No auto-guard applies; `--check-uninit` behaves as if the user
 wrote no guard at all.
 
-## Tier 2 — auto-emitted protocol assertions
+## Tier 2 — auto-emitted protocol assertions (SHIPPED — initial set)
+
+**v1 coverage**:
+- `valid_ready`: `_auto_hs_<port>_<ch>_valid_stable` — once valid is asserted it stays asserted until ready is observed.
+- `valid_stall`: `_auto_hs_<port>_<ch>_valid_stable_while_stall` — valid must not change while stall is asserted.
+- `req_ack_4phase`: `_auto_hs_<port>_<ch>_req_holds_until_ack` — req stays asserted until ack is observed.
+- `valid_only`, `ready_only`, `req_ack_2phase`: parsed + ports expand correctly, but no Tier-2 assertion emitted yet (valid_only has no back-signal; ready_only has no valid; 2-phase req-toggle needs `$past` tracking — deferred).
+
+All properties are concurrent SVA wrapped in `synopsys translate_off/on`, using the module's first Clock port and `disable iff (<reset>)` on the first Reset port — same convention as `_auto_bound_*` / `_auto_div0_*`. Modules with no clock skip assertion emission (the ports still expand).
+
+Remaining work documented below for future extensions:
+
+
 
 When `arch build` emits SV, each handshake additionally emits a small
 block of concurrent SVA (inside `synopsys translate_off/on`, same

--- a/doc/plan_handshake_construct.md
+++ b/doc/plan_handshake_construct.md
@@ -37,7 +37,7 @@ bus BusAxi4
   param DATA_W: const = 32;
   param ID_W:   const = 1;
 
-  handshake aw: out kind: valid_ready
+  handshake aw: send kind: valid_ready
     addr: UInt<ADDR_W>;
     id:   UInt<ID_W>;
     len:  UInt<8>;
@@ -45,13 +45,13 @@ bus BusAxi4
     burst: UInt<2>;
   end handshake aw
 
-  handshake w: out kind: valid_ready
+  handshake w: send kind: valid_ready
     data: UInt<DATA_W>;
     strb: UInt<DATA_W/8>;
     last: Bool;
   end handshake w
 
-  handshake b: in kind: valid_ready
+  handshake b: receive kind: valid_ready
     id:   UInt<ID_W>;
     resp: UInt<2>;
   end handshake b
@@ -65,19 +65,21 @@ HandshakePort := 'handshake' Ident ':' Direction 'kind' ':' Variant NEWLINE
                   PayloadField* 
                 'end' 'handshake' Ident
 PayloadField  := Ident ':' TypeExpr ';'
-Direction     := 'in' | 'out'
+Direction     := 'send' | 'receive'
 Variant       := 'valid_ready' | 'valid_only' | 'ready_only'
                | 'valid_stall' | 'req_ack_4phase' | 'req_ack_2phase'
 ```
 
-`Direction` names the direction of the **payload flow**, not the individual
-control signals:
-- `out`: this side is the *producer* (drives valid / req, receives ready / ack)
-- `in`:  this side is the *consumer* (receives valid / req, drives ready / ack)
+`Direction` names the channel's **payload role**, NOT any individual
+wire's direction. Using role keywords (not `in`/`out`) avoids the
+ambiguity of naming a single wire direction in a construct that
+produces signals in both directions:
+- `send`:    this side is the *producer* (drives valid/req and payload, receives ready/ack)
+- `receive`: this side is the *consumer* (receives valid/req and payload, drives ready/ack)
 
-This is the one rule the user has to remember; all sub-port directions are
-derived by the compiler, eliminating the "I flipped valid and ready" bug
-class.
+This is the one rule the user has to remember; all individual wire
+directions are derived by the compiler, eliminating the "I flipped valid
+and ready" bug class.
 
 ## Variant catalog (Tier 1 — port expansion)
 
@@ -85,7 +87,7 @@ Given `handshake X: <dir> kind: <V>` with payload fields `f1, f2, …`, the
 following flat ports are synthesized. All appear with `X_` prefix at the
 SV level, matching today's `bus` flattening convention.
 
-| Variant | Producer side (`out`) | Consumer side (`in`) | Payload direction |
+| Variant | Producer side (`send`) | Consumer side (`receive`) | Payload direction |
 |---|---|---|---|
 | `valid_ready`   | `X_valid: out Bool; X_ready: in Bool;`  | `X_valid: in Bool; X_ready: out Bool;`  | same as channel dir |
 | `valid_only`    | `X_valid: out Bool;`                    | `X_valid: in Bool;`                      | same |
@@ -98,7 +100,7 @@ Payload fields emit as individual flat ports with the same direction as the
 handshake (`<X>_<field>: <dir> <type>;`). The `target` keyword on the bus
 port still flips everything — including valid/ready — as today.
 
-Example expansion of `handshake aw: out kind: valid_ready { addr: UInt<32>; id: UInt<1>; }`:
+Example expansion of `handshake aw: send kind: valid_ready { addr: UInt<32>; id: UInt<1>; }`:
 
 ```
 aw_valid: out Bool;
@@ -252,10 +254,10 @@ reg/port X_field: T guard X_valid;
 ```
 
 Effects:
-- **Consumer side** (`handshake X: in`): `--check-uninit` stays silent at the
+- **Consumer side** (`handshake X: receive`): `--check-uninit` stays silent at the
   use site when the consumer qualifies its reads with `if X_valid` (or
   conditions derived from it) — no manual `guard` annotation needed.
-- **Producer side** (`handshake X: out`): the compiler requires that every
+- **Producer side** (`handshake X: send`): the compiler requires that every
   payload field reg has *some* driver whose activity window covers the
   cycles where `X_valid` is asserted. If a producer asserts `X_valid` while
   a payload reg was never written in a path that reaches `X_valid=1`,
@@ -335,8 +337,8 @@ Each assertion inherits the module's reset polarity and clock, same as
 ## Open questions
 
 1. **Single-line shorthand?** Channels with zero payload (e.g. a pure
-   interrupt wire `handshake irq: out kind: valid_ready end`) look noisy.
-   Could allow `handshake irq: out kind: valid_ready;` (no body) as a
+   interrupt wire `handshake irq: send kind: valid_ready end`) look noisy.
+   Could allow `handshake irq: send kind: valid_ready;` (no body) as a
    one-liner when the payload is empty.
 2. **Payload sub-ports in SV output**: keep flattened (`aw_addr`, `aw_id`)
    to match the existing convention, or introduce optional `struct packed`
@@ -421,6 +423,6 @@ variant provides — e.g. a protocol that's like `valid_ready` but allows
 `valid` to deassert mid-transaction. The mitigation: all six variants
 are port-shape-only at Tier 1, so a user whose protocol doesn't fit can
 fall back to hand-rolled `bus` declarations with zero loss. Tier 2
-assertions are opt-out via a `no_assert` modifier (`handshake X: out
+assertions are opt-out via a `no_assert` modifier (`handshake X: send
 kind: valid_ready no_assert`) for when the user knows the protocol
 diverges from the canonical rules.

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -62,6 +62,29 @@ pub struct BusDecl {
     pub params: Vec<ParamDecl>,
     pub signals: Vec<PortDecl>,  // direction = from initiator's perspective
     pub generates: Vec<BusGenerateIf>,  // conditional signal groups
+    /// Handshake sub-constructs declared in this bus. The synthesized
+    /// PortDecls already live in `signals` (or inside `generates`); this
+    /// list preserves the grouping so codegen can emit per-variant SVA
+    /// protocol assertions.
+    pub handshakes: Vec<HandshakeMeta>,
+    pub span: Span,
+}
+
+/// Metadata for one `handshake` channel inside a bus. Flattened PortDecls
+/// for the control and payload signals already live in BusDecl::signals
+/// (or inside a BusGenerateIf branch); this carries the grouping.
+#[derive(Debug, Clone)]
+pub struct HandshakeMeta {
+    /// Channel name (e.g. `aw`).
+    pub name: Ident,
+    /// Variant keyword (e.g. `valid_ready`, `req_ack_4phase`).
+    pub variant: Ident,
+    /// Role on the initiator side: `Out` = send, `In` = receive.
+    pub role_dir: Direction,
+    /// Field names of the payload (without the channel prefix). Used only
+    /// for documentation in generated SV comments — directions/types are
+    /// already materialized as PortDecls in BusDecl::signals.
+    pub payload_names: Vec<Ident>,
     pub span: Span,
 }
 

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -672,6 +672,10 @@ impl<'a> Codegen<'a> {
         // _ARCH_BCHK so iverilog/Verilator/formal tools see the invariant.
         self.emit_bound_asserts(&m_clone);
 
+        // Emit per-variant handshake protocol SVA for each bus port whose
+        // bus definition contains one or more `handshake` channels.
+        self.emit_handshake_asserts(&m_clone);
+
         // Emit log file descriptors: initial $fopen / final $fclose
         let log_files = Self::collect_log_files(&m_clone.body);
         if !log_files.is_empty() {
@@ -2303,6 +2307,96 @@ impl<'a> Codegen<'a> {
                 "  else $fatal(1, \"{violation_kind} VIOLATION: {mod}.{label}\");",
                 mod = m.name.name
             ));
+        }
+        self.line("// synopsys translate_on");
+    }
+
+    /// Tier 2 of the handshake primitive: for every bus port on this module
+    /// whose bus definition declares `handshake` channels, emit per-variant
+    /// concurrent SVA protocol assertions, wrapped in `translate_off/on`.
+    ///
+    /// Labels follow `_auto_hs_<port>_<channel>_<rule>`, mirroring
+    /// `_auto_bound_*` / `_auto_div0_*` for consistency with formal tools
+    /// (EBMC, SymbiYosys) and simulator lint (`--assert`).
+    ///
+    /// The protocol rules are symmetric — they bind regardless of whether
+    /// this module is the sender (initiator) or receiver (target), so
+    /// perspective-flip on the bus port doesn't change which signals
+    /// participate in the property.
+    ///
+    /// Current coverage (v1): valid_ready → valid-stable-until-ready,
+    /// valid_stall → valid-stable-while-stalled, req_ack_4phase →
+    /// req-holds-until-ack. Other variants are parsed and their ports
+    /// expand correctly, but no auto-SVA is emitted for them yet
+    /// (valid_only has no back-signal; ready_only has no valid;
+    /// req_ack_2phase requires $past tracking that's deferred).
+    fn emit_handshake_asserts(&mut self, m: &ModuleDecl) {
+        // Gather (port_name, HandshakeMeta) for each bus-typed port whose
+        // bus declares one or more handshake channels.
+        let mut emissions: Vec<(String, crate::ast::HandshakeMeta)> = Vec::new();
+        for p in &m.ports {
+            let Some(ref bi) = p.bus_info else { continue; };
+            let Some((crate::resolve::Symbol::Bus(info), _)) =
+                self.symbols.globals.get(&bi.bus_name.name) else { continue; };
+            for hs in &info.handshakes {
+                emissions.push((p.name.name.clone(), hs.clone()));
+            }
+        }
+        if emissions.is_empty() { return; }
+
+        // Reuse the same clock/reset picking convention as emit_bound_asserts.
+        let clk = m.ports.iter()
+            .find(|p| matches!(&p.ty, TypeExpr::Clock(_)))
+            .map(|p| p.name.name.clone());
+        let Some(clk) = clk else { return; };
+        let rst_active = m.ports.iter()
+            .find(|p| matches!(&p.ty, TypeExpr::Reset(_, _)))
+            .map(|p| match &p.ty {
+                TypeExpr::Reset(_, ResetLevel::Low) => format!("!{}", p.name.name),
+                _ => p.name.name.clone(),
+            });
+        let disable = rst_active.as_ref()
+            .map(|r| format!(" disable iff ({r})"))
+            .unwrap_or_default();
+
+        self.line("// synopsys translate_off");
+        self.line("// Auto-generated handshake protocol assertions (Tier 2)");
+        for (port_name, hs) in &emissions {
+            let ch = &hs.name.name;
+            let variant = hs.variant.name.as_str();
+            let sig = |s: &str| format!("{}_{}_{}", port_name, ch, s);
+            let mod_name = &m.name.name;
+            let emit_property = |cg: &mut Codegen, rule: &str, predicate: String, message: &str| {
+                let label = format!("_auto_hs_{}_{}_{}", port_name, ch, rule);
+                cg.line(&format!(
+                    "{label}: assert property (@(posedge {clk}){disable} {predicate})"
+                ));
+                cg.line(&format!(
+                    "  else $fatal(1, \"HANDSHAKE VIOLATION ({message}): {mod_name}.{label}\");"
+                ));
+            };
+            match variant {
+                "valid_ready" => {
+                    let v = sig("valid"); let r = sig("ready");
+                    emit_property(self, "valid_stable",
+                        format!("({v} && !{r}) |=> {v}"),
+                        "valid must stay asserted until ready");
+                }
+                "valid_stall" => {
+                    let v = sig("valid"); let s = sig("stall");
+                    emit_property(self, "valid_stable_while_stall",
+                        format!("({v} && {s}) |=> {v}"),
+                        "valid must not change while stalled");
+                }
+                "req_ack_4phase" => {
+                    let rq = sig("req"); let ak = sig("ack");
+                    emit_property(self, "req_holds_until_ack",
+                        format!("({rq} && !{ak}) |=> {rq}"),
+                        "req must stay asserted until ack");
+                }
+                // Variants with no Tier-2 v1 property are silently skipped.
+                _ => {}
+            }
         }
         self.line("// synopsys translate_on");
     }

--- a/src/learn.rs
+++ b/src/learn.rs
@@ -11,7 +11,7 @@
 //! - No embeddings, no network, no sharing mechanism
 //!
 //! Data layout:
-//! ```
+//! ```text
 //! ~/.arch/learn/
 //!   ├── events.jsonl            append-only capture stream
 //!   ├── index.json              BM25 index built by `arch learn-index`

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -115,6 +115,8 @@ pub enum TokenKind {
     Template,
     #[token("bus")]
     Bus,
+    #[token("handshake")]
+    Handshake,
     #[token("implements")]
     Implements,
     #[token("return")]
@@ -404,6 +406,7 @@ impl fmt::Display for TokenKind {
             TokenKind::Hook => write!(f, "hook"),
             TokenKind::Template => write!(f, "template"),
             TokenKind::Bus => write!(f, "bus"),
+            TokenKind::Handshake => write!(f, "handshake"),
             TokenKind::Implements => write!(f, "implements"),
             TokenKind::Return => write!(f, "return"),
             TokenKind::Stage => write!(f, "stage"),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -138,13 +138,16 @@ impl Parser {
         let mut params = Vec::new();
         let mut signals = Vec::new();
         let mut generates = Vec::new();
+        let mut handshakes = Vec::new();
         while !self.check_end_keyword() {
             if self.check_param() {
                 params.push(self.parse_param_decl()?);
             } else if self.check(TokenKind::GenerateIf) {
                 generates.push(self.parse_bus_generate_if(start)?);
             } else if self.check(TokenKind::Handshake) {
-                signals.extend(self.parse_handshake_block(start)?);
+                let (ports, meta) = self.parse_handshake_block(start)?;
+                signals.extend(ports);
+                handshakes.push(meta);
             } else {
                 signals.push(self.parse_bus_signal(start)?);
             }
@@ -165,6 +168,7 @@ impl Parser {
             params,
             signals,
             generates,
+            handshakes,
         })
     }
 
@@ -204,7 +208,8 @@ impl Parser {
         // Parse then-branch signals until end generate_if or generate_else
         while !self.check_bus_gen_end() {
             if self.check(TokenKind::Handshake) {
-                then_signals.extend(self.parse_handshake_block(parent_span)?);
+                let (ports, _meta) = self.parse_handshake_block(parent_span)?;
+                then_signals.extend(ports);
             } else {
                 then_signals.push(self.parse_bus_signal(parent_span)?);
             }
@@ -218,7 +223,8 @@ impl Parser {
                 && self.tokens[self.pos + 1].kind == TokenKind::GenerateIf)
             {
                 if self.check(TokenKind::Handshake) {
-                    sigs.extend(self.parse_handshake_block(parent_span)?);
+                    let (ports, _meta) = self.parse_handshake_block(parent_span)?;
+                    sigs.extend(ports);
                 } else {
                     sigs.push(self.parse_bus_signal(parent_span)?);
                 }
@@ -259,7 +265,7 @@ impl Parser {
     /// `send`/`receive` name the payload-flow role (NOT wire direction):
     /// `send` = this side produces the payload (drives valid/req/payload,
     /// receives ready/ack); `receive` = consumer side.
-    fn parse_handshake_block(&mut self, parent_span: Span) -> Result<Vec<PortDecl>, CompileError> {
+    fn parse_handshake_block(&mut self, parent_span: Span) -> Result<(Vec<PortDecl>, HandshakeMeta), CompileError> {
         let start = self.expect(TokenKind::Handshake)?.span;
         let ch_name = self.expect_ident()?;
         self.expect(TokenKind::Colon)?;
@@ -293,6 +299,7 @@ impl Parser {
 
         // Parse payload fields until `end handshake`.
         let mut payload: Vec<(Ident, TypeExpr, Span)> = Vec::new();
+        let mut payload_names: Vec<Ident> = Vec::new();
         loop {
             if self.check(TokenKind::End) {
                 break;
@@ -303,6 +310,7 @@ impl Parser {
             self.expect(TokenKind::Semi)?;
             let f_span_end = self.tokens.get(self.pos.saturating_sub(1)).map(|t| t.span).unwrap_or(parent_span);
             let f_span = f_name.span.merge(f_span_end);
+            payload_names.push(f_name.clone());
             payload.push((f_name, ty, f_span));
         }
         self.expect(TokenKind::End)?;
@@ -359,7 +367,14 @@ impl Parser {
             let port_name = format!("{}_{}", ch_name.name, f_name.name);
             out.push(mk_port(port_name, dir, ty, f_span));
         }
-        Ok(out)
+        let meta = HandshakeMeta {
+            name: ch_name,
+            variant: variant_ident,
+            role_dir: dir,
+            payload_names,
+            span: block_span,
+        };
+        Ok((out, meta))
     }
 
     // --- Enum ---

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -143,6 +143,8 @@ impl Parser {
                 params.push(self.parse_param_decl()?);
             } else if self.check(TokenKind::GenerateIf) {
                 generates.push(self.parse_bus_generate_if(start)?);
+            } else if self.check(TokenKind::Handshake) {
+                signals.extend(self.parse_handshake_block(start)?);
             } else {
                 signals.push(self.parse_bus_signal(start)?);
             }
@@ -201,7 +203,11 @@ impl Parser {
         let mut then_signals = Vec::new();
         // Parse then-branch signals until end generate_if or generate_else
         while !self.check_bus_gen_end() {
-            then_signals.push(self.parse_bus_signal(parent_span)?);
+            if self.check(TokenKind::Handshake) {
+                then_signals.extend(self.parse_handshake_block(parent_span)?);
+            } else {
+                then_signals.push(self.parse_bus_signal(parent_span)?);
+            }
         }
         // Optional generate_else
         let else_signals = if self.check(TokenKind::GenerateElse) {
@@ -211,7 +217,11 @@ impl Parser {
                 && self.tokens[self.pos].kind == TokenKind::End
                 && self.tokens[self.pos + 1].kind == TokenKind::GenerateIf)
             {
-                sigs.push(self.parse_bus_signal(parent_span)?);
+                if self.check(TokenKind::Handshake) {
+                    sigs.extend(self.parse_handshake_block(parent_span)?);
+                } else {
+                    sigs.push(self.parse_bus_signal(parent_span)?);
+                }
             }
             sigs
         } else {
@@ -233,6 +243,123 @@ impl Parser {
         self.pos + 1 < self.tokens.len()
             && self.tokens[self.pos].kind == TokenKind::End
             && self.tokens[self.pos + 1].kind == TokenKind::GenerateIf
+    }
+
+    /// Parse a `handshake` block inside a bus body and return the fully
+    /// expanded list of `PortDecl`s (control signals + payload signals).
+    ///
+    /// Grammar:
+    ///   'handshake' Ident ':' ('send'|'receive') 'kind' ':' VariantName
+    ///     (Ident ':' TypeExpr ';')*
+    ///   'end' 'handshake' Ident
+    ///
+    /// Variants: valid_ready, valid_only, ready_only, valid_stall,
+    /// req_ack_4phase, req_ack_2phase. See doc/plan_handshake_construct.md.
+    ///
+    /// `send`/`receive` name the payload-flow role (NOT wire direction):
+    /// `send` = this side produces the payload (drives valid/req/payload,
+    /// receives ready/ack); `receive` = consumer side.
+    fn parse_handshake_block(&mut self, parent_span: Span) -> Result<Vec<PortDecl>, CompileError> {
+        let start = self.expect(TokenKind::Handshake)?.span;
+        let ch_name = self.expect_ident()?;
+        self.expect(TokenKind::Colon)?;
+        let dir = if self.eat_contextual("send") {
+            Direction::Out
+        } else if self.eat_contextual("receive") {
+            Direction::In
+        } else {
+            return Err(CompileError::unexpected_token(
+                "send or receive",
+                &self.peek_kind().map(|k| k.to_string()).unwrap_or("EOF".into()),
+                self.peek_span(),
+            ));
+        };
+        self.expect(TokenKind::Kind)?;
+        self.expect(TokenKind::Colon)?;
+        let variant_ident = self.expect_ident()?;
+        let variant = variant_ident.name.as_str();
+        let known = matches!(
+            variant,
+            "valid_ready" | "valid_only" | "ready_only" | "valid_stall"
+              | "req_ack_4phase" | "req_ack_2phase"
+        );
+        if !known {
+            return Err(CompileError::unexpected_token(
+                "one of valid_ready, valid_only, ready_only, valid_stall, req_ack_4phase, req_ack_2phase",
+                &variant_ident.name,
+                variant_ident.span,
+            ));
+        }
+
+        // Parse payload fields until `end handshake`.
+        let mut payload: Vec<(Ident, TypeExpr, Span)> = Vec::new();
+        loop {
+            if self.check(TokenKind::End) {
+                break;
+            }
+            let f_name = self.expect_ident()?;
+            self.expect(TokenKind::Colon)?;
+            let ty = self.parse_type_expr()?;
+            self.expect(TokenKind::Semi)?;
+            let f_span_end = self.tokens.get(self.pos.saturating_sub(1)).map(|t| t.span).unwrap_or(parent_span);
+            let f_span = f_name.span.merge(f_span_end);
+            payload.push((f_name, ty, f_span));
+        }
+        self.expect(TokenKind::End)?;
+        self.expect(TokenKind::Handshake)?;
+        let closing = self.expect_ident()?;
+        if closing.name != ch_name.name {
+            return Err(CompileError::mismatched_closing(
+                &ch_name.name,
+                &closing.name,
+                closing.span,
+            ));
+        }
+        let block_span = start.merge(closing.span);
+
+        // Synthesize flat PortDecls based on the variant. Directions are
+        // relative to the channel's declared direction: `out` = producer
+        // (this side drives valid/req and payload, receives ready/ack).
+        let opposite = match dir { Direction::In => Direction::Out, Direction::Out => Direction::In };
+        let mut out: Vec<PortDecl> = Vec::new();
+        let mk_port = |n: String, d: Direction, ty: TypeExpr, sp: Span| PortDecl {
+            name: Ident { name: n, span: sp },
+            direction: d,
+            ty,
+            default: None,
+            reg_info: None,
+            bus_info: None,
+            shared: None,
+            span: sp,
+        };
+        // Control signals (payload-direction = `dir`, back-signal = `opposite`).
+        match variant {
+            "valid_ready" => {
+                out.push(mk_port(format!("{}_valid", ch_name.name), dir, TypeExpr::Bool, block_span));
+                out.push(mk_port(format!("{}_ready", ch_name.name), opposite, TypeExpr::Bool, block_span));
+            }
+            "valid_only" => {
+                out.push(mk_port(format!("{}_valid", ch_name.name), dir, TypeExpr::Bool, block_span));
+            }
+            "ready_only" => {
+                out.push(mk_port(format!("{}_ready", ch_name.name), opposite, TypeExpr::Bool, block_span));
+            }
+            "valid_stall" => {
+                out.push(mk_port(format!("{}_valid", ch_name.name), dir, TypeExpr::Bool, block_span));
+                out.push(mk_port(format!("{}_stall", ch_name.name), opposite, TypeExpr::Bool, block_span));
+            }
+            "req_ack_4phase" | "req_ack_2phase" => {
+                out.push(mk_port(format!("{}_req", ch_name.name), dir, TypeExpr::Bool, block_span));
+                out.push(mk_port(format!("{}_ack", ch_name.name), opposite, TypeExpr::Bool, block_span));
+            }
+            _ => unreachable!(),
+        }
+        // Payload signals flow in the channel's declared direction.
+        for (f_name, ty, f_span) in payload {
+            let port_name = format!("{}_{}", ch_name.name, f_name.name);
+            out.push(mk_port(port_name, dir, ty, f_span));
+        }
+        Ok(out)
     }
 
     // --- Enum ---

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -122,6 +122,8 @@ pub struct BusInfo {
     pub params: Vec<ParamDecl>,
     pub signals: Vec<(String, Direction, TypeExpr)>,
     pub generates: Vec<BusGenerateIf>,
+    /// Handshake channels declared in this bus (Tier 2 SVA emission).
+    pub handshakes: Vec<crate::ast::HandshakeMeta>,
 }
 
 impl BusInfo {
@@ -449,6 +451,7 @@ pub fn resolve(source_file: &SourceFile) -> Result<SymbolTable, Vec<CompileError
                             .map(|s| (s.name.name.clone(), s.direction, s.ty.clone()))
                             .collect(),
                         generates: b.generates.clone(),
+                        handshakes: b.handshakes.clone(),
                     };
                     table.globals.insert(b.name.name.clone(), (Symbol::Bus(info), b.name.span));
                 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1682,3 +1682,89 @@ fn test_handshake_all_variants_parse() {
     assert!(sv.contains("output logic p_e_req") && sv.contains("input logic p_e_ack"));
     assert!(sv.contains("output logic p_f_req") && sv.contains("input logic p_f_ack"));
 }
+
+#[test]
+fn test_handshake_tier2_valid_ready_assertion() {
+    // Tier 2: a valid_ready handshake should emit a `valid_stable` SVA
+    // property referencing the flattened valid/ready signals, wrapped in
+    // synopsys translate_off/on, with disable iff (rst).
+    let source = "
+        bus BusLite
+          handshake aw: send kind: valid_ready
+            addr: UInt<32>;
+          end handshake aw
+        end bus BusLite
+
+        module Producer
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync>;
+          port bus_p: initiator BusLite;
+          comb
+            bus_p.aw_valid = 1'b0;
+            bus_p.aw_addr  = 32'h0;
+          end comb
+        end module Producer
+    ";
+    let sv = compile_to_sv(source);
+    assert!(sv.contains("// Auto-generated handshake protocol assertions"));
+    assert!(sv.contains("_auto_hs_bus_p_aw_valid_stable"));
+    assert!(sv.contains("(bus_p_aw_valid && !bus_p_aw_ready) |=> bus_p_aw_valid"));
+    assert!(sv.contains("disable iff (rst)"));
+    assert!(sv.contains("synopsys translate_off"));
+    assert!(sv.contains("synopsys translate_on"));
+}
+
+#[test]
+fn test_handshake_tier2_multiple_variants() {
+    // Tier 2: a bus with mixed variants should emit exactly the
+    // properties covered by v1 — valid_stable, valid_stable_while_stall,
+    // and req_holds_until_ack. Other variants are silently skipped.
+    let source = "
+        bus BusMix
+          handshake a: send kind: valid_ready  end handshake a
+          handshake b: send kind: valid_only   end handshake b
+          handshake c: send kind: valid_stall  end handshake c
+          handshake d: send kind: req_ack_4phase end handshake d
+        end bus BusMix
+
+        module Top
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync>;
+          port p: initiator BusMix;
+          comb
+            p.a_valid = 1'b0;
+            p.b_valid = 1'b0;
+            p.c_valid = 1'b0;
+            p.d_req   = 1'b0;
+          end comb
+        end module Top
+    ";
+    let sv = compile_to_sv(source);
+    // Covered variants:
+    assert!(sv.contains("_auto_hs_p_a_valid_stable"));
+    assert!(sv.contains("_auto_hs_p_c_valid_stable_while_stall"));
+    assert!(sv.contains("_auto_hs_p_d_req_holds_until_ack"));
+    // valid_only has no back-signal, so no property is emitted for `b`:
+    assert!(!sv.contains("_auto_hs_p_b_"));
+}
+
+#[test]
+fn test_handshake_tier2_no_clock_no_assertions() {
+    // A module without a Clock port can't host concurrent assertions.
+    // Bus ports are still emitted; the assertion block is simply skipped.
+    let source = "
+        bus BusLite
+          handshake aw: send kind: valid_ready end handshake aw
+        end bus BusLite
+
+        module Combo
+          port bus_p: initiator BusLite;
+          comb
+            bus_p.aw_valid = 1'b0;
+          end comb
+        end module Combo
+    ";
+    let sv = compile_to_sv(source);
+    assert!(sv.contains("output logic bus_p_aw_valid"));
+    assert!(!sv.contains("_auto_hs_"));
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1585,3 +1585,100 @@ end module LteExpr
         "expected assert `cnt <= 200` in SV, got:\n{sv}"
     );
 }
+
+#[test]
+fn test_handshake_valid_ready_expansion() {
+    // Tier 1: a bus with three valid_ready handshake channels should
+    // expand into flat valid/ready/payload ports with correct directions.
+    let source = "
+        bus BusLite
+          handshake aw: send kind: valid_ready
+            addr: UInt<32>;
+            prot: UInt<3>;
+          end handshake aw
+
+          handshake b: receive kind: valid_ready
+            resp: UInt<2>;
+          end handshake b
+        end bus BusLite
+
+        module Producer
+          port bus_p: initiator BusLite;
+          comb
+            bus_p.aw_valid = 1'b0;
+            bus_p.aw_addr  = 32'h0;
+            bus_p.aw_prot  = 3'h0;
+            bus_p.b_ready  = 1'b1;
+          end comb
+        end module Producer
+    ";
+    let sv = compile_to_sv(source);
+    // Send-side valid is OUTPUT, ready is INPUT.
+    assert!(sv.contains("output logic bus_p_aw_valid"), "aw_valid should be output on initiator");
+    assert!(sv.contains("input logic bus_p_aw_ready"), "aw_ready should be input on initiator");
+    assert!(sv.contains("output logic [31:0] bus_p_aw_addr"), "aw payload out");
+    // Receive-side b: valid becomes INPUT for the initiator.
+    assert!(sv.contains("input logic bus_p_b_valid"), "b_valid should be input on initiator");
+    assert!(sv.contains("output logic bus_p_b_ready"), "b_ready should be output on initiator");
+    assert!(sv.contains("input logic [1:0] bus_p_b_resp"), "b payload in");
+}
+
+#[test]
+fn test_handshake_target_flip() {
+    // When a handshake-using bus is attached at a `target` port, every
+    // signal (valid, ready, payload) must flip — same mechanism the bus
+    // perspective flip uses today.
+    let source = "
+        bus BusLite
+          handshake aw: send kind: valid_ready
+            addr: UInt<32>;
+          end handshake aw
+        end bus BusLite
+
+        module Consumer
+          port bus_c: target BusLite;
+          comb
+            bus_c.aw_ready = 1'b1;
+          end comb
+        end module Consumer
+    ";
+    let sv = compile_to_sv(source);
+    // Target flips: producer-side 'out' becomes 'in' at the consumer.
+    assert!(sv.contains("input logic bus_c_aw_valid"), "target flip: aw_valid becomes input");
+    assert!(sv.contains("output logic bus_c_aw_ready"), "target flip: aw_ready becomes output");
+    assert!(sv.contains("input logic [31:0] bus_c_aw_addr"), "target flip: payload becomes input");
+}
+
+#[test]
+fn test_handshake_all_variants_parse() {
+    // All six variants must parse + type-check and produce the expected
+    // control signals with correct directions.
+    let source = "
+        bus BusAll
+          handshake a: send kind: valid_ready  end handshake a
+          handshake b: send kind: valid_only   end handshake b
+          handshake c: send kind: ready_only   end handshake c
+          handshake d: send kind: valid_stall  end handshake d
+          handshake e: send kind: req_ack_4phase end handshake e
+          handshake f: send kind: req_ack_2phase end handshake f
+        end bus BusAll
+
+        module Top
+          port p: initiator BusAll;
+          comb
+            p.a_valid = 1'b0;
+            p.b_valid = 1'b0;
+            p.d_valid = 1'b0;
+            p.e_req   = 1'b0;
+            p.f_req   = 1'b0;
+          end comb
+        end module Top
+    ";
+    let sv = compile_to_sv(source);
+    assert!(sv.contains("output logic p_a_valid") && sv.contains("input logic p_a_ready"));
+    assert!(sv.contains("output logic p_b_valid") && !sv.contains("p_b_ready"));
+    assert!(sv.contains("input logic p_c_ready") && !sv.contains("p_c_valid"));
+    assert!(sv.contains("output logic p_d_valid") && sv.contains("input logic p_d_stall"));
+    assert!(sv.contains("output logic p_e_req") && sv.contains("input logic p_e_ack"));
+    assert!(sv.contains("output logic p_f_req") && sv.contains("input logic p_f_ack"));
+}


### PR DESCRIPTION
## Summary

Adds a new `handshake` sub-construct inside `bus`, implementing Tier 1 (port shape) and Tier 2 (protocol SVA) from [`doc/plan_handshake_construct.md`](doc/plan_handshake_construct.md). Addresses the "AXI has 5 repetitive valid/ready/payload channels" pain point with a compile-time sum-type abstraction covering 6 standard flow-control variants. See also the text-waveform reference in the plan for each variant.

## Syntax

```arch
bus BusAxiLite
  param ADDR_W: const = 32;
  param DATA_W: const = 32;

  handshake aw: send kind: valid_ready
    addr: UInt<ADDR_W>;
    prot: UInt<3>;
  end handshake aw

  handshake b: receive kind: valid_ready
    resp: UInt<2>;
  end handshake b
end bus BusAxiLite
```

Role keywords are **`send` / `receive`** (not `in` / `out`) to avoid ambiguity in a construct that produces signals in both directions — the keyword names the payload role; the compiler derives every individual wire direction. Eliminates the "I flipped valid and ready" bug class by construction.

## Variants

| Variant | Control signals (send side) |
|---|---|
| `valid_ready`    | `_valid: out`, `_ready: in`  |
| `valid_only`     | `_valid: out`                |
| `ready_only`     | `_ready: in`                 |
| `valid_stall`    | `_valid: out`, `_stall: in`  |
| `req_ack_4phase` | `_req: out`, `_ack: in`      |
| `req_ack_2phase` | `_req: out`, `_ack: in`      |

Payload fields flow in the channel direction. `target` perspective at the bus use-site flips every signal as usual.

## Tier 2 — auto-emitted SVA

Each module with a handshake-using bus port gets per-variant concurrent assertions wrapped in `synopsys translate_off/on`, labeled `_auto_hs_<port>_<channel>_<rule>`:

| Variant | v1 property |
|---|---|
| `valid_ready`    | `valid_stable`: valid must stay asserted until ready |
| `valid_stall`    | `valid_stable_while_stall`: valid must not change while stall |
| `req_ack_4phase` | `req_holds_until_ack`: req must stay asserted until ack |

`valid_only` / `ready_only` / `req_ack_2phase` parse + expand ports correctly but emit no Tier-2 assertion (documented rationale in the plan; 2-phase needs `$past` tracking deferred). Modules without a Clock port skip assertion emission.

## Verification

| Tool | Result |
|---|---|
| **Verilator 5.034 `--assert`** | Violating TB trips: `%Fatal: HANDSHAKE VIOLATION (valid must stay asserted until ready): Producer._auto_hs_p_ch_valid_stable`. Clean TB is silent — no false positive. |
| **EBMC 5.11** | SVA accepted; `REFUTED` with unconstrained bug input, `PROVED up to bound 10` with bug tied off. Property is genuinely solvable, not just syntactically acceptable. |
| **`arch formal`** | Pre-existing v1 limitation — "named type is not supported" for bus ports. Unrelated to this change; EBMC on the SV output covers the formal use case. |

## Test plan
- [x] `cargo build` clean
- [x] `cargo test` — 66 passing, including 6 new handshake integration tests
- [x] End-to-end Verilator sim with violating TB
- [x] EBMC bounded model check (REFUTED + PROVED)
- [x] All 6 variants expand ports with correct directions
- [x] `target` perspective flip verified

## Follow-up (after merge)

Verilator/iverilog both reject the spurious `import BusS::*;` that ARCH emits at the top of SV for any module with a bus port, because no corresponding SV package is generated. **Pre-existing bug, unrelated to this feature**, but it's a real wart I had to `sed` past during verification. Will fix on a separate branch after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)