### PR TITLE
fix: don't emit spurious SV import for non-package 'use' targets

### DIFF
--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -427,10 +427,20 @@ impl<'a> Codegen<'a> {
 
     fn emit_module(&mut self, m: &ModuleDecl) {
         self.current_construct = m.name.name.clone();
-        // Emit import statements for any packages referenced via `use` before the module
+        // Emit SV `import NAME::*;` only for `use NAME;` whose target is an
+        // actual `package` — package contents become an SV package and need
+        // the import for typedef/enum/struct visibility. Other `use` targets
+        // (bus, module, fsm, ...) are pure compile-time references that the
+        // ARCH compiler resolves before codegen; emitting `import` for them
+        // breaks Verilator/iverilog since no corresponding SV package exists.
         for item in &self.source.items {
             if let Item::Use(u) = item {
-                self.out.push_str(&format!("import {}::*;\n", u.name.name));
+                let is_package = self.source.items.iter().any(|i| {
+                    matches!(i, Item::Package(p) if p.name.name == u.name.name)
+                });
+                if is_package {
+                    self.out.push_str(&format!("import {}::*;\n", u.name.name));
+                }
             }
         }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1768,3 +1768,60 @@ fn test_handshake_tier2_no_clock_no_assertions() {
     assert!(sv.contains("output logic bus_p_aw_valid"));
     assert!(!sv.contains("_auto_hs_"));
 }
+
+#[test]
+fn test_use_bus_does_not_emit_sv_import() {
+    // Regression: `use BusName;` referencing a bus (not a package) must
+    // NOT emit `import BusName::*;` in the generated SV. Bus ports are
+    // fully flattened at the port boundary, and no SV package is
+    // synthesized — emitting the import breaks Verilator/iverilog.
+    let source = "
+        bus BusS
+          handshake ch: send kind: valid_ready
+            data: UInt<8>;
+          end handshake ch
+        end bus BusS
+
+        use BusS;
+
+        module M
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync>;
+          port p: initiator BusS;
+          comb
+            p.ch_valid = 1'b0;
+            p.ch_data  = 8'h0;
+          end comb
+        end module M
+    ";
+    let sv = compile_to_sv(source);
+    assert!(!sv.contains("import BusS"),
+            "spurious SV import emitted for a bus-typed use:\n{sv}");
+}
+
+#[test]
+fn test_use_package_still_emits_sv_import() {
+    // The positive case: `use Foo;` of an actual `package Foo ... end`
+    // still emits `import Foo::*;` because package contents become an
+    // SV package whose typedefs need importing.
+    let source = "
+        package PkgA
+          enum Op
+            ADD,
+            SUB,
+          end enum Op
+        end package PkgA
+
+        use PkgA;
+
+        module M
+          port o: out Op;
+          comb
+            o = Op::ADD;
+          end comb
+        end module M
+    ";
+    let sv = compile_to_sv(source);
+    assert!(sv.contains("import PkgA::*;"),
+            "expected SV import for a package-typed use:\n{sv}");
+}


### PR DESCRIPTION
## Summary

Fixes a longstanding bug where \`arch build\` emitted \`import NAME::*;\` at the top of every SV file for any \`use NAME;\` in the source, regardless of whether \`NAME\` was an actual package.

For bus/module/fsm/etc., that import is always wrong — ARCH resolves those at compile time and flattens bus ports into ordinary SV ports, so no corresponding SV package exists. Verilator and iverilog both reject the generated SV. This was flagged during Tier 2 handshake SVA verification (#21): every \`use BusX;\` produced uncompilable output and I had to \`sed\` the bad line away before Verilator would accept it.

## Fix

Emit \`import NAME::*;\` only when \`NAME\` matches an \`Item::Package\` in the source file. Package use still works (SV \`package\` is still generated and its contents still need import visibility in consuming modules).

## Test plan
- [x] \`cargo test\` — 87 passing, including two new regression tests:
  - \`test_use_bus_does_not_emit_sv_import\` — negative case
  - \`test_use_package_still_emits_sv_import\` — positive case (package import still emitted)
- [x] End-to-end: \`arch build Producer.arch\` (handshake-using) → Verilator --binary --assert → violating TB trips \`_auto_hs_p_ch_valid_stable\` assertion. Previously needed \`sed\`; now works direct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)