### PR TITLE
feat: --inputs-start-uninit tracks bus-flattened input signals

### DIFF
--- a/src/sim_codegen.rs
+++ b/src/sim_codegen.rs
@@ -2447,7 +2447,19 @@ fn collect_expr_idents(expr: &Expr, out: &mut std::collections::BTreeSet<String>
             collect_expr_idents(start, out);
             collect_expr_idents(width, out);
         }
-        ExprKind::FieldAccess(base, _) => collect_expr_idents(base, out),
+        ExprKind::FieldAccess(base, field) => {
+            collect_expr_idents(base, out);
+            // For bus-style access `port.signal`, the emitted C++ reads
+            // the flat name `port_signal` (matching SV bus flattening).
+            // Emit that flat name as a candidate so --check-uninit and any
+            // other name-indexed downstream analysis catches bus-port reads.
+            // Non-bus field access (e.g. struct.field) is also a valid
+            // candidate here; the downstream filter (e.g. uninit_inputs
+            // membership) decides whether the name warrants action.
+            if let ExprKind::Ident(b) = &base.kind {
+                out.insert(format!("{}_{}", b, field.name));
+            }
+        }
         ExprKind::MethodCall(base, _, args) => {
             collect_expr_idents(base, out);
             for a in args { collect_expr_idents(a, out); }
@@ -3001,17 +3013,50 @@ impl<'a> SimCodegen<'a> {
         // --inputs-start-uninit: treat every primary input port as uninitialized.
         // TB must call the generated `set_<port>()` setter to mark an input initialized.
         // Reads of uninit inputs anywhere in the design emit a warning.
-        // v1 scope: scalar non-clock/reset/bus inputs only.
-        let uninit_inputs: HashSet<String> = if self.inputs_start_uninit {
-            m.ports.iter()
-                .filter(|p| matches!(p.direction, Direction::In))
-                .filter(|p| p.bus_info.is_none())
-                .filter(|p| !matches!(&p.ty, TypeExpr::Clock(_) | TypeExpr::Reset(_, _)))
-                .map(|p| p.name.name.clone())
-                .collect()
-        } else {
-            HashSet::new()
-        };
+        // v2 scope: scalar non-clock/reset inputs PLUS bus-flattened In signals
+        // (per-signal perspective flip respected; Clock/Reset sub-signals skipped).
+        let mut uninit_inputs: HashSet<String> = HashSet::new();
+        if self.inputs_start_uninit {
+            for p in m.ports.iter() {
+                // Scalar non-bus input ports.
+                if p.bus_info.is_none() {
+                    if matches!(p.direction, Direction::In)
+                        && !matches!(&p.ty, TypeExpr::Clock(_) | TypeExpr::Reset(_, _))
+                    {
+                        uninit_inputs.insert(p.name.name.clone());
+                    }
+                    continue;
+                }
+                // Bus-typed port: expand flattened signals via the symbol table,
+                // apply per-signal perspective flip, track the ones that are
+                // inputs from THIS module's side.
+                let Some(ref bi) = p.bus_info else { continue; };
+                let Some(crate::resolve::Symbol::Bus(info)) =
+                    self.symbols.globals.get(&bi.bus_name.name).map(|(s, _)| s)
+                    else { continue; };
+                // Build param map: bus defaults, overridden by port-site params.
+                let mut param_map: std::collections::HashMap<String, &Expr> =
+                    info.params.iter()
+                        .filter_map(|pd| pd.default.as_ref().map(|d| (pd.name.name.clone(), d)))
+                        .collect();
+                for pa in &bi.params {
+                    param_map.insert(pa.name.name.clone(), &pa.value);
+                }
+                for (sname, sdir, sty) in info.effective_signals(&param_map) {
+                    // Apply perspective flip (target flips every signal).
+                    let actual_dir = match bi.perspective {
+                        crate::ast::BusPerspective::Initiator => sdir,
+                        crate::ast::BusPerspective::Target => sdir.flip(),
+                    };
+                    if !matches!(actual_dir, Direction::In) { continue; }
+                    // Clock/Reset sub-signals follow the scalar-path exclusion.
+                    if matches!(&sty, TypeExpr::Clock(_) | TypeExpr::Reset(_, _)) {
+                        continue;
+                    }
+                    uninit_inputs.insert(format!("{}_{}", p.name.name, sname));
+                }
+            }
+        }
         // Fold inputs into the shared uninit_regs set so existing warning plumbing
         // (shadow-bit decl + read-site warning) picks them up uniformly.
         uninit_regs.extend(uninit_inputs.iter().cloned());
@@ -3409,12 +3454,44 @@ impl<'a> SimCodegen<'a> {
         if !uninit_inputs.is_empty() {
             h.push_str("  // --inputs-start-uninit setters (mark TB-driven inputs as initialized)\n");
             for p in &m.ports {
-                if !uninit_inputs.contains(&p.name.name) { continue; }
-                let pname = &p.name.name;
-                let ty = cpp_port_type(&p.ty);
-                h.push_str(&format!(
-                    "  void set_{pname}({ty} v) {{ {pname} = v; _{pname}_vinit = true; }}\n"
-                ));
+                // Scalar non-bus input.
+                if p.bus_info.is_none() {
+                    if !uninit_inputs.contains(&p.name.name) { continue; }
+                    let pname = &p.name.name;
+                    let ty = cpp_port_type(&p.ty);
+                    h.push_str(&format!(
+                        "  void set_{pname}({ty} v) {{ {pname} = v; _{pname}_vinit = true; }}\n"
+                    ));
+                    continue;
+                }
+                // Bus port: emit one setter per flattened In signal.
+                let Some(ref bi) = p.bus_info else { continue; };
+                let Some(crate::resolve::Symbol::Bus(info)) =
+                    self.symbols.globals.get(&bi.bus_name.name).map(|(s, _)| s)
+                    else { continue; };
+                let mut param_map: std::collections::HashMap<String, &Expr> =
+                    info.params.iter()
+                        .filter_map(|pd| pd.default.as_ref().map(|d| (pd.name.name.clone(), d)))
+                        .collect();
+                for pa in &bi.params {
+                    param_map.insert(pa.name.name.clone(), &pa.value);
+                }
+                for (sname, sdir, sty) in info.effective_signals(&param_map) {
+                    let actual_dir = match bi.perspective {
+                        crate::ast::BusPerspective::Initiator => sdir,
+                        crate::ast::BusPerspective::Target => sdir.flip(),
+                    };
+                    if !matches!(actual_dir, Direction::In) { continue; }
+                    if matches!(&sty, TypeExpr::Clock(_) | TypeExpr::Reset(_, _)) {
+                        continue;
+                    }
+                    let flat = format!("{}_{}", p.name.name, sname);
+                    if !uninit_inputs.contains(&flat) { continue; }
+                    let ty = cpp_port_type(&sty);
+                    h.push_str(&format!(
+                        "  void set_{flat}({ty} v) {{ {flat} = v; _{flat}_vinit = true; }}\n"
+                    ));
+                }
             }
         }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1825,3 +1825,105 @@ fn test_use_package_still_emits_sv_import() {
     assert!(sv.contains("import PkgA::*;"),
             "expected SV import for a package-typed use:\n{sv}");
 }
+
+fn compile_to_sim_h(source: &str, inputs_start_uninit: bool) -> String {
+    use arch::sim_codegen::SimCodegen;
+    let tokens = arch::lexer::tokenize(source).expect("lexer error");
+    let mut parser = arch::parser::Parser::new(tokens, source);
+    let parsed_ast = parser.parse_source_file().expect("parse error");
+    let ast = arch::elaborate::elaborate(parsed_ast).expect("elaborate error");
+    let symbols = arch::resolve::resolve(&ast).expect("resolve error");
+    let checker = arch::typecheck::TypeChecker::new(&symbols, &ast);
+    let (_warnings, overload_map) = checker.check().expect("type check error");
+    let sim = SimCodegen::new(&symbols, &ast, overload_map)
+        .check_uninit(inputs_start_uninit)
+        .inputs_start_uninit(inputs_start_uninit);
+    let models = sim.generate();
+    // Concatenate all model headers — tests can grep across them.
+    models.iter().map(|m| m.header.clone()).collect::<Vec<_>>().join("\n// ---\n")
+}
+
+#[test]
+fn test_inputs_start_uninit_bus_flattened() {
+    // --inputs-start-uninit should now emit shadow vinit bits and setters
+    // for each flattened INPUT signal of a bus-typed port.
+    let source = "
+        bus BusSimple
+          data:  in UInt<8>;
+          valid: in Bool;
+        end bus BusSimple
+
+        use BusSimple;
+
+        module Reader
+          port b:     initiator BusSimple;
+          port out_r: out UInt<8>;
+          comb
+            if b.valid
+              out_r = b.data;
+            else
+              out_r = 8'h0;
+            end if
+          end comb
+        end module Reader
+    ";
+    let h = compile_to_sim_h(source, true);
+    assert!(h.contains("bool _b_data_vinit = false;"),
+            "expected shadow bit for flattened bus input 'b_data':\n{h}");
+    assert!(h.contains("bool _b_valid_vinit = false;"),
+            "expected shadow bit for flattened bus input 'b_valid':\n{h}");
+    assert!(h.contains("void set_b_data("),
+            "expected setter for flattened bus input 'b_data':\n{h}");
+    assert!(h.contains("void set_b_valid("),
+            "expected setter for flattened bus input 'b_valid':\n{h}");
+}
+
+#[test]
+fn test_inputs_start_uninit_bus_skips_output_direction() {
+    // Target perspective flips direction: 'in' signals on the bus
+    // become 'out' from the module's side — those MUST NOT get
+    // uninit tracking (they're driven by this module).
+    let source = "
+        bus BusSimple
+          data:  in UInt<8>;
+          valid: in Bool;
+        end bus BusSimple
+
+        use BusSimple;
+
+        module Driver
+          port b: target BusSimple;
+          comb
+            b.data  = 8'hAA;
+            b.valid = 1'b1;
+          end comb
+        end module Driver
+    ";
+    let h = compile_to_sim_h(source, true);
+    assert!(!h.contains("_b_data_vinit"),
+            "did not expect vinit for output-side bus signal 'b_data':\n{h}");
+    assert!(!h.contains("set_b_data("),
+            "did not expect setter for output-side bus signal 'b_data':\n{h}");
+}
+
+#[test]
+fn test_inputs_start_uninit_without_flag_emits_nothing() {
+    let source = "
+        bus BusSimple
+          data: in UInt<8>;
+        end bus BusSimple
+
+        use BusSimple;
+
+        module Reader
+          port b:     initiator BusSimple;
+          port out_r: out UInt<8>;
+          comb
+            out_r = b.data;
+          end comb
+        end module Reader
+    ";
+    let h = compile_to_sim_h(source, false);
+    assert!(!h.contains("_b_data_vinit"),
+            "no --inputs-start-uninit → no bus vinit tracking:\n{h}");
+}


### PR DESCRIPTION
## Summary

\`--inputs-start-uninit\` previously skipped bus ports entirely. A TB that read \`axi.aw_addr\` without calling any setter got no warning, defeating the flag for any design with bus ports. Scalar input tracking was already in place; the bus-port skip was a historical oversight — no semantic reason for it.

This PR extends the existing machinery to cover bus-flattened input signals 1:1 with the scalar path. Also unblocks Tier 1.5 of the handshake primitive (auto-guard on payload).

## Three coordinated changes (sim_codegen.rs)

1. **Identifier collector**: \`FieldAccess(Ident(b), field)\` now also emits the flat name \`b_field\` as a read candidate. The generated C++ already reads the flat form (matching SV bus flattening), so the existing name-indexed warning filter just works for bus reads.
2. **\`uninit_inputs\` collection**: walks each bus-typed port, expands via \`BusInfo.effective_signals()\`, applies per-signal perspective flip (target flips every signal), skips Clock/Reset sub-signals, adds the remaining In signals as flat names.
3. **Setter emission**: mirrors (2), emitting \`set_<port>_<sig>(T v)\` per flattened In bus signal with the correct C++ type. UX is identical to the scalar path.

## End-to-end verification

Small test case with a bus and two TB variants:

```
// TB that only does plain assignment (bad pattern):
dut.b_valid = 1; dut.b_data = 0x42; dut.eval();
// → WARNING: read of uninitialized input 'b_data' — TB never called set_b_data()
// → WARNING: read of uninitialized input 'b_valid' — TB never called set_b_valid()

// TB using generated setters (correct pattern):
dut.set_b_valid(1); dut.set_b_data(0x42); dut.eval();
// → silent (no warning)
```

## Test plan
- [x] \`cargo build\` clean
- [x] \`cargo test\` — 90 passing, including 3 new regression tests:
  - \`test_inputs_start_uninit_bus_flattened\` — shadow bit + setter emission
  - \`test_inputs_start_uninit_bus_skips_output_direction\` — target perspective correctly excludes output-side signals
  - \`test_inputs_start_uninit_without_flag_emits_nothing\` — feature off produces no instrumentation
- [x] End-to-end sim with bad + good TBs

## Follow-up

Tier 1.5 of the handshake primitive (auto-guard on payload) is now unblocked — next step is synthesizing a \`guard X_valid\` annotation on payload regs at the producer side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)