### PR TITLE
feat: handshake Tier 1.5 PR #1 — gate payload uninit warnings on valid

### DIFF
--- a/src/sim_codegen.rs
+++ b/src/sim_codegen.rs
@@ -3061,6 +3061,40 @@ impl<'a> SimCodegen<'a> {
         // (shadow-bit decl + read-site warning) picks them up uniformly.
         uninit_regs.extend(uninit_inputs.iter().cloned());
 
+        // Tier 1.5 (Option D): for every bus input that is a handshake payload,
+        // compute the channel's valid/req guard signal name. The --inputs-
+        // start-uninit read-site warning will gate on this guard so it only
+        // fires when the channel is actively asserting data — silencing the
+        // legitimate "TB hasn't driven valid yet" case without weakening
+        // detection of the producer bug "valid asserted, payload never set."
+        //
+        // Variant guard map:
+        //   valid_ready | valid_only | valid_stall  -> "valid"
+        //   req_ack_4phase                          -> "req"
+        //   ready_only                              -> no guard (silent on all reads)
+        //   req_ack_2phase                          -> deferred (stateful toggle)
+        let mut payload_guards: HashMap<String, String> = HashMap::new();
+        if self.inputs_start_uninit {
+            for p in m.ports.iter() {
+                let Some(ref bi) = p.bus_info else { continue; };
+                let Some(crate::resolve::Symbol::Bus(info)) =
+                    self.symbols.globals.get(&bi.bus_name.name).map(|(s, _)| s)
+                    else { continue; };
+                for hs in &info.handshakes {
+                    let guard_sig = match hs.variant.name.as_str() {
+                        "valid_ready" | "valid_only" | "valid_stall" => "valid",
+                        "req_ack_4phase" => "req",
+                        _ => continue, // ready_only / req_ack_2phase: no guard
+                    };
+                    let guard_flat = format!("{}_{}_{}", p.name.name, hs.name.name, guard_sig);
+                    for payload in &hs.payload_names {
+                        let payload_flat = format!("{}_{}_{}", p.name.name, hs.name.name, payload.name);
+                        payload_guards.insert(payload_flat, guard_flat.clone());
+                    }
+                }
+            }
+        }
+
         // Collect guard-annotated regs: reg_name → guard_signal_name.
         // Used for Check A (producer bug: "guard asserts but reg never written").
         let guarded_regs: HashMap<String, String> = m.body.iter()
@@ -4299,9 +4333,17 @@ impl<'a> SimCodegen<'a> {
                 }
                 for name in &all_reads {
                     if uninit_inputs.contains(name) {
+                        // Tier 1.5 (Option D): if this input is a handshake
+                        // payload, gate the warning on the channel's valid/req
+                        // signal — only the producer bug (valid asserted but
+                        // payload never set) should fire. Non-payload inputs
+                        // fall through to the unconditional check.
+                        let gate = payload_guards.get(name)
+                            .map(|g| format!(" && {g}"))
+                            .unwrap_or_default();
                         cpp.push_str(&format!(
-                            "  {{ static bool _w_{name} = false; if (!_{name}_vinit && !_w_{name}) {{ fprintf(stderr, \"WARNING: read of uninitialized input '{name}' — TB never called set_{name}()\\n\"); _w_{name} = true; }} }}\n",
-                            name = name
+                            "  {{ static bool _w_{name} = false; if (!_{name}_vinit{gate} && !_w_{name}) {{ fprintf(stderr, \"WARNING: read of uninitialized input '{name}' — TB never called set_{name}()\\n\"); _w_{name} = true; }} }}\n",
+                            name = name, gate = gate
                         ));
                     }
                 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1927,3 +1927,100 @@ fn test_inputs_start_uninit_without_flag_emits_nothing() {
     assert!(!h.contains("_b_data_vinit"),
             "no --inputs-start-uninit → no bus vinit tracking:\n{h}");
 }
+
+#[test]
+fn test_handshake_tier15_payload_warning_gated_on_valid() {
+    // Tier 1.5 (Option D): when a handshake payload is also a --check-uninit-
+    // tracked input, its read-site warning should be gated on the channel's
+    // valid signal so legitimate "valid low so payload doesn't matter" usage
+    // is silent — but producer bug "valid asserted, payload never set" still
+    // warns.
+    use arch::sim_codegen::SimCodegen;
+    let source = "
+        bus BusHS
+          handshake ch: send kind: valid_ready
+            data: UInt<8>;
+          end handshake ch
+        end bus BusHS
+
+        use BusHS;
+
+        module Consumer
+          port b: target BusHS;
+          port o: out UInt<8>;
+          comb
+            if b.ch_valid
+              o = b.ch_data;
+            else
+              o = 8'h0;
+            end if
+            b.ch_ready = 1'b1;
+          end comb
+        end module Consumer
+    ";
+    let tokens = arch::lexer::tokenize(source).expect("lexer error");
+    let mut parser = arch::parser::Parser::new(tokens, source);
+    let parsed_ast = parser.parse_source_file().expect("parse error");
+    let ast = arch::elaborate::elaborate(parsed_ast).expect("elaborate error");
+    let symbols = arch::resolve::resolve(&ast).expect("resolve error");
+    let checker = arch::typecheck::TypeChecker::new(&symbols, &ast);
+    let (_warnings, overload_map) = checker.check().expect("type check error");
+    let sim = SimCodegen::new(&symbols, &ast, overload_map)
+        .check_uninit(true)
+        .inputs_start_uninit(true);
+    let models = sim.generate();
+    let cpp = models.iter().find(|m| m.class_name == "VConsumer").unwrap().impl_.clone();
+
+    // Payload-signal read warning must be AND'd with the handshake's valid.
+    assert!(cpp.contains("!_b_ch_data_vinit && b_ch_valid"),
+            "expected payload warning gated on valid signal:\n{cpp}");
+
+    // Valid-signal itself is tracked but NOT a payload, so its warning is
+    // unconditional (no extra gate).
+    let valid_check_line = cpp.lines()
+        .find(|l| l.contains("!_b_ch_valid_vinit"))
+        .expect("expected warning for b_ch_valid signal");
+    assert!(!valid_check_line.contains("&& b_ch_valid"),
+            "valid signal's own warning should not self-gate:\n{valid_check_line}");
+}
+
+#[test]
+fn test_handshake_tier15_req_ack_4phase_uses_req_as_guard() {
+    use arch::sim_codegen::SimCodegen;
+    let source = "
+        bus BusRA
+          handshake ch: send kind: req_ack_4phase
+            payload: UInt<16>;
+          end handshake ch
+        end bus BusRA
+
+        use BusRA;
+
+        module C
+          port b: target BusRA;
+          port o: out UInt<16>;
+          comb
+            if b.ch_req
+              o = b.ch_payload;
+            else
+              o = 16'h0;
+            end if
+            b.ch_ack = 1'b1;
+          end comb
+        end module C
+    ";
+    let tokens = arch::lexer::tokenize(source).expect("lexer error");
+    let mut parser = arch::parser::Parser::new(tokens, source);
+    let parsed_ast = parser.parse_source_file().expect("parse error");
+    let ast = arch::elaborate::elaborate(parsed_ast).expect("elaborate error");
+    let symbols = arch::resolve::resolve(&ast).expect("resolve error");
+    let checker = arch::typecheck::TypeChecker::new(&symbols, &ast);
+    let (_warnings, overload_map) = checker.check().expect("type check error");
+    let sim = SimCodegen::new(&symbols, &ast, overload_map)
+        .check_uninit(true)
+        .inputs_start_uninit(true);
+    let models = sim.generate();
+    let cpp = models.iter().find(|m| m.class_name == "VC").unwrap().impl_.clone();
+    assert!(cpp.contains("!_b_ch_payload_vinit && b_ch_req"),
+            "req_ack_4phase payload should gate on b_ch_req:\n{cpp}");
+}


### PR DESCRIPTION
## Summary

Implements **Option D** from the Tier 1.5 design in [plan_handshake_construct.md](doc/plan_handshake_construct.md) (merged in #24): when a bus input signal is a handshake payload, gate the existing \`--inputs-start-uninit\` warning on the channel's \`valid\`/\`req\` signal.

Catches the **producer bug** class — "valid asserted, payload never driven" — without false-positiving the legitimate case where the TB simply hasn't driven valid yet and the payload content doesn't matter. Reuses the bus-input uninit machinery from #23; no new infrastructure.

## Variant → guard signal

| Variant | Guard signal |
|---|---|
| \`valid_ready\`, \`valid_only\`, \`valid_stall\` | \`<port>_<ch>_valid\` |
| \`req_ack_4phase\` | \`<port>_<ch>_req\` |
| \`ready_only\` | no guard — no valid signal exists |
| \`req_ack_2phase\` | deferred — stateful toggle guard |

## End-to-end verification (small valid_ready handshake)

| TB scenario | Expected | Observed |
|---|---|---|
| \`set_b_ch_valid(0)\`, payload never set | silent | silent |
| \`set_b_ch_valid(1)\`, payload never set | **WARN** (producer bug) | WARN on \`b_ch_data\` |
| \`set_b_ch_valid(1)\` + \`set_b_ch_data(0xAB)\` | silent | silent |

## Test plan
- [x] \`cargo build\` clean
- [x] \`cargo test\` — 92 passing, including 2 new Tier 1.5 regressions:
  - \`test_handshake_tier15_payload_warning_gated_on_valid\` (valid_ready)
  - \`test_handshake_tier15_req_ack_4phase_uses_req_as_guard\`
- [x] End-to-end sim against three TB variants above

## Follow-up

PR #2 will add the consumer-side compile-time lint (Option A): warn at \`arch check\` time when a handshake payload is read outside an \`if <port>.<valid>\` scope. Catches the consumer-bug class (stale payload read without guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)