### PR TITLE
feat: Vec methods v1a — any/all/count/contains/reduce_* with item/index binders

### DIFF
--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -47,6 +47,15 @@ pub struct Codegen<'a> {
     reset_ports: std::collections::HashMap<String, (ResetKind, ResetLevel)>,
     /// Name of the construct currently being emitted (for symbol lookups).
     current_construct: String,
+    /// Context-sensitive identifier substitutions.
+    /// Used during Vec method predicate emission to rebind `item` and
+    /// `index` to per-iteration expressions (e.g. `vec[3]`, `2'd3`).
+    /// Checked first in `emit_expr_str`'s Ident branch; empty otherwise.
+    ident_subst: std::collections::HashMap<String, String>,
+    /// Map of Vec-typed signal name → element count N.
+    /// Populated per-module at emit time so Vec method lowerings
+    /// (`any`/`all`/`count`/etc.) can unroll over N iterations.
+    vec_sizes: std::collections::HashMap<String, u32>,
 }
 
 impl<'a> Codegen<'a> {
@@ -68,6 +77,8 @@ impl<'a> Codegen<'a> {
             bus_ports: std::collections::HashMap::new(),
             reset_ports: std::collections::HashMap::new(),
             current_construct: String::new(),
+            ident_subst: std::collections::HashMap::new(),
+            vec_sizes: std::collections::HashMap::new(),
         }
     }
 
@@ -461,9 +472,42 @@ impl<'a> Codegen<'a> {
         // Ports — bus ports are flattened to individual signals
         self.bus_ports.clear();
         self.reset_ports.clear();
+        self.vec_sizes.clear();
         for p in m.ports.iter() {
             if let TypeExpr::Reset(kind, level) = &p.ty {
                 self.reset_ports.insert(p.name.name.clone(), (*kind, *level));
+            }
+            if let TypeExpr::Vec(_, size_expr) = &p.ty {
+                if let Some(n) = self.eval_const_u32(size_expr, &m.params) {
+                    self.vec_sizes.insert(p.name.name.clone(), n);
+                }
+            }
+        }
+        // Vec-typed regs, wires, and let bindings are also eligible receivers.
+        for item in &m.body {
+            match item {
+                ModuleBodyItem::RegDecl(r) => {
+                    if let TypeExpr::Vec(_, size_expr) = &r.ty {
+                        if let Some(n) = self.eval_const_u32(size_expr, &m.params) {
+                            self.vec_sizes.insert(r.name.name.clone(), n);
+                        }
+                    }
+                }
+                ModuleBodyItem::WireDecl(w) => {
+                    if let TypeExpr::Vec(_, size_expr) = &w.ty {
+                        if let Some(n) = self.eval_const_u32(size_expr, &m.params) {
+                            self.vec_sizes.insert(w.name.name.clone(), n);
+                        }
+                    }
+                }
+                ModuleBodyItem::LetBinding(lb) => {
+                    if let Some(TypeExpr::Vec(_, size_expr)) = &lb.ty {
+                        if let Some(n) = self.eval_const_u32(size_expr, &m.params) {
+                            self.vec_sizes.insert(lb.name.name.clone(), n);
+                        }
+                    }
+                }
+                _ => {}
             }
         }
         // Collect all flattened port lines first so we can add commas correctly
@@ -4123,6 +4167,10 @@ impl<'a> Codegen<'a> {
                             b
                         }
                     }
+                    "any" | "all" | "count" | "contains"
+                    | "reduce_or" | "reduce_and" | "reduce_xor" => {
+                        self.emit_vec_method(&b, base, method, args)
+                    }
                     _ => format!("{b}.{}()", method.name),
                 }
             }
@@ -4302,6 +4350,10 @@ impl<'a> Codegen<'a> {
                         } else {
                             b
                         }
+                    }
+                    "any" | "all" | "count" | "contains"
+                    | "reduce_or" | "reduce_and" | "reduce_xor" => {
+                        self.emit_vec_method(&b, base, method, args)
                     }
                     _ => format!("{b}.{}()", method.name),
                 }
@@ -4813,6 +4865,154 @@ impl<'a> Codegen<'a> {
         self.emit_expr_prec(expr, 0)
     }
 
+    /// Lower a Vec method call (any/all/count/contains/reduce_*) to a
+    /// parallel-compare + reduction expression. Fully unrolled at codegen
+    /// time because N is known.
+    ///
+    /// Predicate identifier substitution for `item` / `index` is applied
+    /// via `self.ident_subst`, which is a reentrant context we push before
+    /// emitting each iteration's expression and pop after.
+    ///
+    /// Safety: this is `&self`, but we need to temporarily mutate
+    /// `ident_subst`. We cast away immutability in a narrowly-scoped
+    /// block that restores the previous state before returning. The
+    /// alternative (threading a mutable binding map through every
+    /// `emit_expr_str` caller) would touch ~30 sites; this is localized.
+    #[allow(clippy::ptr_arg)]
+    fn emit_vec_method(
+        &self,
+        recv_b: &str,
+        recv: &Expr,
+        method: &Ident,
+        args: &[Expr],
+    ) -> String {
+        // Resolve N. The receiver is an Ident in v1; more complex
+        // expressions are not lowered (falls through to placeholder).
+        let n = match &recv.kind {
+            ExprKind::Ident(n) => self.vec_sizes.get(n).copied(),
+            _ => None,
+        };
+        let Some(n) = n else {
+            // Size unknown → bail to the fallback shape; SV tools will
+            // reject it, telling the user we couldn't unroll.
+            return format!("{recv_b}.{}()", method.name);
+        };
+        let n_usize = n as usize;
+        let idx_w = std::cmp::max(1, (n as f64).log2().ceil() as u32);
+
+        // Helper: emit an expression with `item` bound to recv[i] and
+        // `index` bound to a sized literal. `ident_subst` is a field of
+        // Codegen; we use interior-mutability-via-unsafe here because
+        // emit_expr_str is `&self`. The Codegen type is `!Sync` and
+        // emission is single-threaded, so this is safe.
+        let emit_at = |i: u32| -> String {
+            let this = self as *const Codegen as *mut Codegen;
+            // SAFETY: single-threaded emission; no aliasing.
+            unsafe {
+                (*this).ident_subst.insert("item".to_string(), format!("{recv_b}[{i}]"));
+                (*this).ident_subst.insert("index".to_string(), format!("{idx_w}'d{i}"));
+            }
+            let result = if let Some(pred) = args.first() {
+                self.emit_expr_str(pred)
+            } else {
+                // contains / reduce_*: see caller below; we won't be called
+                // without args from those paths.
+                String::new()
+            };
+            unsafe {
+                (*this).ident_subst.remove("item");
+                (*this).ident_subst.remove("index");
+            }
+            result
+        };
+
+        match method.name.as_str() {
+            "any" => {
+                if n_usize == 0 { return "1'b0".to_string(); }
+                (0..n).map(emit_at).collect::<Vec<_>>().join(" || ")
+            }
+            "all" => {
+                if n_usize == 0 { return "1'b1".to_string(); }
+                (0..n).map(emit_at).collect::<Vec<_>>().join(" && ")
+            }
+            "count" => {
+                if n_usize == 0 { return "0".to_string(); }
+                let w = std::cmp::max(1, ((n + 1) as f64).log2().ceil() as u32);
+                // Sum of bool conversions. SV auto-widens `+` per 1800-2012 §11.6.
+                let terms: Vec<String> = (0..n)
+                    .map(|i| format!("{w}'({} ? 1 : 0)", emit_at(i)))
+                    .collect();
+                format!("({})", terms.join(" + "))
+            }
+            "contains" => {
+                // `contains(x)` is `any(item == x)` — but the user supplies x,
+                // not a predicate. Emit n equality comparisons against the
+                // argument, OR'd.
+                let Some(x_expr) = args.first() else {
+                    return "1'b0".to_string();
+                };
+                let x = self.emit_expr_str(x_expr);
+                if n_usize == 0 { return "1'b0".to_string(); }
+                (0..n).map(|i| format!("({recv_b}[{i}] == {x})"))
+                      .collect::<Vec<_>>()
+                      .join(" || ")
+            }
+            "reduce_or" => {
+                if n_usize == 0 { return "0".to_string(); }
+                (0..n).map(|i| format!("{recv_b}[{i}]"))
+                      .collect::<Vec<_>>()
+                      .join(" | ")
+            }
+            "reduce_and" => {
+                if n_usize == 0 { return "0".to_string(); }
+                (0..n).map(|i| format!("{recv_b}[{i}]"))
+                      .collect::<Vec<_>>()
+                      .join(" & ")
+            }
+            "reduce_xor" => {
+                if n_usize == 0 { return "0".to_string(); }
+                (0..n).map(|i| format!("{recv_b}[{i}]"))
+                      .collect::<Vec<_>>()
+                      .join(" ^ ")
+            }
+            _ => format!("{recv_b}.{}()", method.name),
+        }
+    }
+
+    /// Evaluate a compile-time constant expression (Vec size, etc.) to a u32.
+    /// Handles literals, const-param references, and simple binary ops.
+    /// Returns None if the expression can't be reduced — caller then treats
+    /// the receiver as size-unknown and skips Vec method lowering.
+    fn eval_const_u32(&self, e: &Expr, params: &[ParamDecl]) -> Option<u32> {
+        match &e.kind {
+            ExprKind::Literal(LitKind::Dec(v)) => Some(*v as u32),
+            ExprKind::Literal(LitKind::Hex(v))
+            | ExprKind::Literal(LitKind::Bin(v))
+            | ExprKind::Literal(LitKind::Sized(_, v)) => Some(*v as u32),
+            ExprKind::Ident(n) => {
+                let p = params.iter().find(|p| p.name.name == *n)?;
+                match &p.kind {
+                    ParamKind::Const | ParamKind::WidthConst(..) => {}
+                    _ => return None,
+                }
+                let d = p.default.as_ref()?;
+                self.eval_const_u32(d, params)
+            }
+            ExprKind::Binary(op, l, r) => {
+                let lv = self.eval_const_u32(l, params)?;
+                let rv = self.eval_const_u32(r, params)?;
+                Some(match op {
+                    BinOp::Add => lv + rv,
+                    BinOp::Sub => lv.saturating_sub(rv),
+                    BinOp::Mul => lv * rv,
+                    BinOp::Div if rv != 0 => lv / rv,
+                    _ => return None,
+                })
+            }
+            _ => None,
+        }
+    }
+
     /// Infer the SV bit-width of an expression as a string constant expression.
     /// Used to emit the width cast for wrapping arithmetic operators (+%, -%, *%).
     fn infer_sv_width_str(&self, expr: &Expr) -> String {
@@ -4947,6 +5147,11 @@ impl<'a> Codegen<'a> {
             ExprKind::Bool(true) => "1'b1".to_string(),
             ExprKind::Bool(false) => "1'b0".to_string(),
             ExprKind::Ident(name) => {
+                // Context-sensitive substitution: used by Vec method predicate
+                // lowering to rebind `item` → `recv[i]`, `index` → `W'd<i>`.
+                if let Some(sub) = self.ident_subst.get(name) {
+                    return sub.clone();
+                }
                 name.clone()
             }
             ExprKind::Binary(op, lhs, rhs) => {
@@ -5114,6 +5319,10 @@ impl<'a> Codegen<'a> {
                         } else {
                             b
                         }
+                    }
+                    "any" | "all" | "count" | "contains"
+                    | "reduce_or" | "reduce_and" | "reduce_xor" => {
+                        self.emit_vec_method(&b, base, method, args)
                     }
                     _ => format!("{b}.{}()", method.name),
                 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2277,13 +2277,22 @@ impl Parser {
             if self.check(TokenKind::Dot) {
                 self.advance();
                 let field = self.expect_ident()?;
-                // Check for method call: .trunc<N>(), .zext<N>(), .sext<N>(), .reverse(N)
-                if self.check(TokenKind::LParen) && field.name == "reverse" {
+                // Method call with paren args: .reverse(N), plus the
+                // Vec reduction/predicate family (any/all/count/contains/
+                // reduce_or/reduce_and/reduce_xor).
+                let paren_method = self.check(TokenKind::LParen)
+                    && matches!(field.name.as_str(),
+                        "reverse" | "any" | "all" | "count" | "contains"
+                        | "reduce_or" | "reduce_and" | "reduce_xor");
+                if paren_method {
                     self.advance(); // (
-                    let mut args = vec![self.parse_expr()?];
-                    while self.check(TokenKind::Comma) {
-                        self.advance();
+                    let mut args = Vec::new();
+                    if !self.check(TokenKind::RParen) {
                         args.push(self.parse_expr()?);
+                        while self.check(TokenKind::Comma) {
+                            self.advance();
+                            args.push(self.parse_expr()?);
+                        }
                     }
                     self.expect(TokenKind::RParen)?;
                     let span = lhs.span.merge(self.tokens[self.pos.saturating_sub(1)].span);

--- a/src/sim_codegen.rs
+++ b/src/sim_codegen.rs
@@ -1280,6 +1280,10 @@ struct Ctx<'a> {
     /// FSM Vec port-regs: always resolve to `_name` (internal C array), regardless of fsm_mode.
     /// These ports have flat public fields (name_0..name_N-1) but internal storage `_name[N]`.
     fsm_vec_port_regs: Option<&'a HashSet<String>>,
+    /// Identifier substitutions active while emitting a Vec method predicate
+    /// (e.g. "item" → "vec[3]", "index" → "3"). Checked first in the Ident
+    /// branch of `cpp_expr`; None or missing key means normal resolution.
+    ident_subst: Option<&'a HashMap<String, String>>,
 }
 
 impl<'a> Ctx<'a> {
@@ -1298,7 +1302,8 @@ impl<'a> Ctx<'a> {
         let reset_levels = EMPTY_RESET_LEVELS.get_or_init(HashMap::new);
         Ctx { reg_names, port_names, let_names, inst_names, wide_names,
               widths, posedge_lhs: false, fsm_mode: false, enum_map, bus_ports,
-              reset_levels, vec_names: None, vec_sizes: None, fsm_vec_port_regs: None }
+              reset_levels, vec_names: None, vec_sizes: None, fsm_vec_port_regs: None,
+              ident_subst: None }
     }
 
     fn with_vec_sizes(mut self, vec_sizes: &'a HashMap<String, u64>) -> Self {
@@ -1499,6 +1504,95 @@ fn infer_expr_width(expr: &Expr, ctx: &Ctx) -> u32 {
 
 // ── Expression emitter ────────────────────────────────────────────────────────
 
+/// Lower a Vec method call (any/all/count/contains/reduce_*) to an
+/// unrolled C++ expression. Predicate identifier substitution for
+/// `item`/`index` is done by building a fresh `Ctx` with `ident_subst`
+/// pointing at the per-iteration map.
+fn lower_vec_method_cpp(
+    recv_b: &str,
+    recv: &Expr,
+    method: &Ident,
+    args: &[Expr],
+    ctx: &Ctx,
+) -> String {
+    let n = match &recv.kind {
+        ExprKind::Ident(n) => ctx.vec_sizes.and_then(|m| m.get(n)).copied(),
+        _ => None,
+    };
+    let Some(n) = n else {
+        return format!("{recv_b}.{}()", method.name);
+    };
+    let n_usize = n as usize;
+
+    let emit_at = |i: u64| -> String {
+        let mut sub: HashMap<String, String> = HashMap::new();
+        sub.insert("item".to_string(), format!("{recv_b}[{i}]"));
+        sub.insert("index".to_string(), format!("{i}"));
+        let sub_ctx = Ctx {
+            reg_names: ctx.reg_names, port_names: ctx.port_names,
+            let_names: ctx.let_names, inst_names: ctx.inst_names,
+            wide_names: ctx.wide_names, widths: ctx.widths,
+            posedge_lhs: ctx.posedge_lhs, fsm_mode: ctx.fsm_mode,
+            enum_map: ctx.enum_map, bus_ports: ctx.bus_ports,
+            reset_levels: ctx.reset_levels, vec_names: ctx.vec_names,
+            vec_sizes: ctx.vec_sizes, fsm_vec_port_regs: ctx.fsm_vec_port_regs,
+            ident_subst: None, // replaced below via a temporary binding
+        };
+        // The sub map must outlive the cpp_expr call. We keep `sub` as a
+        // stack-local binding whose lifetime covers the call.
+        let ctx_with_sub = Ctx { ident_subst: Some(&sub), ..sub_ctx };
+        if let Some(pred) = args.first() {
+            cpp_expr(pred, &ctx_with_sub)
+        } else {
+            String::new()
+        }
+    };
+
+    match method.name.as_str() {
+        "any" => {
+            if n_usize == 0 { return "false".to_string(); }
+            let terms: Vec<String> = (0..n as u64).map(emit_at).collect();
+            format!("({})", terms.join(" || "))
+        }
+        "all" => {
+            if n_usize == 0 { return "true".to_string(); }
+            let terms: Vec<String> = (0..n as u64).map(emit_at).collect();
+            format!("({})", terms.join(" && "))
+        }
+        "count" => {
+            if n_usize == 0 { return "0".to_string(); }
+            let terms: Vec<String> = (0..n as u64)
+                .map(|i| format!("({} ? 1u : 0u)", emit_at(i)))
+                .collect();
+            format!("({})", terms.join(" + "))
+        }
+        "contains" => {
+            let Some(x_expr) = args.first() else { return "false".to_string(); };
+            let x = cpp_expr(x_expr, ctx);
+            if n_usize == 0 { return "false".to_string(); }
+            let terms: Vec<String> = (0..n as u64)
+                .map(|i| format!("({recv_b}[{i}] == {x})")).collect();
+            format!("({})", terms.join(" || "))
+        }
+        "reduce_or" => {
+            if n_usize == 0 { return "0".to_string(); }
+            let terms: Vec<String> = (0..n as u64).map(|i| format!("{recv_b}[{i}]")).collect();
+            format!("({})", terms.join(" | "))
+        }
+        "reduce_and" => {
+            if n_usize == 0 { return "0".to_string(); }
+            let terms: Vec<String> = (0..n as u64).map(|i| format!("{recv_b}[{i}]")).collect();
+            format!("({})", terms.join(" & "))
+        }
+        "reduce_xor" => {
+            if n_usize == 0 { return "0".to_string(); }
+            let terms: Vec<String> = (0..n as u64).map(|i| format!("{recv_b}[{i}]")).collect();
+            format!("({})", terms.join(" ^ "))
+        }
+        _ => format!("{recv_b}.{}()", method.name),
+    }
+}
+
 fn cpp_expr(expr: &Expr, ctx: &Ctx) -> String {
     cpp_expr_inner(expr, ctx, false)
 }
@@ -1519,6 +1613,11 @@ fn cpp_expr_inner(expr: &Expr, ctx: &Ctx, is_lhs: bool) -> String {
         ExprKind::Bool(false) => "0".to_string(),
 
         ExprKind::Ident(name) => {
+            // Vec method predicate binder: `item` / `index` are rebound per
+            // iteration by the enclosing `cpp_expr` Vec-method handler.
+            if let Some(sub) = ctx.ident_subst.and_then(|m| m.get(name)) {
+                return sub.clone();
+            }
             if is_lhs {
                 ctx.resolve_name(name, true)
             } else {
@@ -1743,6 +1842,10 @@ fn cpp_expr_inner(expr: &Expr, ctx: &Ctx, is_lhs: bool) -> String {
                                 ty = cpp_uint(base_w), nc = n_chunks, c = chunk)
                         }
                     }
+                }
+                "any" | "all" | "count" | "contains"
+                | "reduce_or" | "reduce_and" | "reduce_xor" => {
+                    lower_vec_method_cpp(&b, base, method, args, ctx)
                 }
                 _ => format!("{b}.{}()", method.name),
             }
@@ -6870,7 +6973,7 @@ impl<'a> SimCodegen<'a> {
     ) -> String {
         let empty = HashSet::new();
         let empty_rl: HashMap<String, ResetLevel> = HashMap::new();
-        let ctx = Ctx { reg_names: rn, port_names: pn, let_names: ln, inst_names: &empty, wide_names: &empty, widths: w, posedge_lhs: false, fsm_mode: false, enum_map: em, bus_ports: &empty, reset_levels: &empty_rl, vec_names: None, vec_sizes: None, fsm_vec_port_regs: None };
+        let ctx = Ctx { reg_names: rn, port_names: pn, let_names: ln, inst_names: &empty, wide_names: &empty, widths: w, posedge_lhs: false, fsm_mode: false, enum_map: em, bus_ports: &empty, reset_levels: &empty_rl, vec_names: None, vec_sizes: None, fsm_vec_port_regs: None, ident_subst: None };
         match &expr.kind {
             ExprKind::FieldAccess(base, field) => {
                 if let ExprKind::Ident(bn) = &base.kind {

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -2265,6 +2265,127 @@ impl<'a> TypeChecker<'a> {
                             Ty::Error
                         }
                     }
+                    // Vec reduction + predicate methods (plan_vec_methods.md v1, PR #1 subset).
+                    // `item` is the per-iteration element, `index` is the position (UInt<clog2(N)>).
+                    // Both are injected into the predicate's local scope during checking.
+                    "any" | "all" | "count" | "contains"
+                    | "reduce_or" | "reduce_and" | "reduce_xor" => {
+                        let (elem_ty, n) = match &base_ty {
+                            Ty::Vec(inner, count) => ((**inner).clone(), *count),
+                            _ => {
+                                self.errors.push(CompileError::general(
+                                    &format!("`.{}(...)` requires a Vec<T,N> receiver, got {}",
+                                        method.name, base_ty.display()),
+                                    method.span,
+                                ));
+                                return Ty::Error;
+                            }
+                        };
+                        if n == 0 {
+                            self.errors.push(CompileError::general(
+                                &format!("`.{}(...)` on a zero-length Vec has no meaningful result", method.name),
+                                method.span,
+                            ));
+                            return Ty::Error;
+                        }
+                        let idx_w = std::cmp::max(1, (n as f64).log2().ceil() as u32);
+                        let pred_needed = !matches!(method.name.as_str(),
+                            "reduce_or" | "reduce_and" | "reduce_xor" | "contains");
+
+                        if pred_needed {
+                            if args.len() != 1 {
+                                self.errors.push(CompileError::general(
+                                    &format!("`.{}(pred)` takes exactly 1 argument (the predicate)", method.name),
+                                    method.span,
+                                ));
+                                return Ty::Error;
+                            }
+                            // Inject item/index into the predicate's scope.
+                            let mut pred_scope = local_types.clone();
+                            // Shadow warnings: user-declared signals with these names.
+                            for n in ["item", "index"] {
+                                if local_types.contains_key(n) {
+                                    self.warnings.push(CompileWarning {
+                                        message: format!(
+                                            "Vec method predicate binder `{}` shadows an enclosing signal with the same name — rename the outer signal to avoid confusion",
+                                            n),
+                                        span: method.span,
+                                    });
+                                }
+                            }
+                            pred_scope.insert("item".to_string(), elem_ty.clone());
+                            pred_scope.insert("index".to_string(), Ty::UInt(idx_w));
+                            let pred_ty = self.resolve_expr_type(&args[0], module_name, &pred_scope);
+                            if !matches!(pred_ty, Ty::Bool | Ty::UInt(1)) && pred_ty != Ty::Error {
+                                self.errors.push(CompileError::general(
+                                    &format!(
+                                        "`.{}` predicate must be Bool, got {}",
+                                        method.name, pred_ty.display()),
+                                    args[0].span,
+                                ));
+                                return Ty::Error;
+                            }
+                        } else if matches!(method.name.as_str(), "contains") {
+                            if args.len() != 1 {
+                                self.errors.push(CompileError::general(
+                                    "`.contains(x)` takes exactly 1 argument",
+                                    method.span,
+                                ));
+                                return Ty::Error;
+                            }
+                            let arg_ty = self.resolve_expr_type(&args[0], module_name, local_types);
+                            // Basic element-type compatibility (same kind + width).
+                            let compatible = match (&elem_ty, &arg_ty) {
+                                (Ty::UInt(a), Ty::UInt(b))
+                                | (Ty::SInt(a), Ty::SInt(b)) => a == b,
+                                (Ty::Bool, Ty::Bool) => true,
+                                _ => elem_ty == arg_ty,
+                            };
+                            if !compatible && arg_ty != Ty::Error && elem_ty != Ty::Error {
+                                self.errors.push(CompileError::general(
+                                    &format!("`.contains(x)` argument type `{}` doesn't match Vec element type `{}`",
+                                        arg_ty.display(), elem_ty.display()),
+                                    args[0].span,
+                                ));
+                                return Ty::Error;
+                            }
+                        } else {
+                            // reduce_or/and/xor: no argument
+                            if !args.is_empty() {
+                                self.errors.push(CompileError::general(
+                                    &format!("`.{}()` takes no arguments", method.name),
+                                    method.span,
+                                ));
+                                return Ty::Error;
+                            }
+                        }
+
+                        match method.name.as_str() {
+                            "any" | "all" | "contains" => Ty::Bool,
+                            "count" => {
+                                // clog2(N+1) for popcount result width.
+                                let w = std::cmp::max(1, ((n + 1) as f64).log2().ceil() as u32);
+                                Ty::UInt(w)
+                            }
+                            "reduce_or" | "reduce_and" | "reduce_xor" => {
+                                // Returns a value of the element's width (or Bool if element is Bool).
+                                match &elem_ty {
+                                    Ty::Bool => Ty::Bool,
+                                    Ty::UInt(w) => Ty::UInt(*w),
+                                    Ty::SInt(w) => Ty::SInt(*w),
+                                    _ => {
+                                        self.errors.push(CompileError::general(
+                                            &format!("`.{}()` requires UInt/SInt/Bool element type, got `{}`",
+                                                method.name, elem_ty.display()),
+                                            method.span,
+                                        ));
+                                        return Ty::Error;
+                                    }
+                                }
+                            }
+                            _ => unreachable!(),
+                        }
+                    }
                     _ => Ty::Error,
                 }
             }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -2177,3 +2177,94 @@ fn test_handshake_tier15_req_ack_uses_req_as_guard() {
     assert!(!ws.iter().any(|m| m.contains("handshake payload")),
             "if b.ch_req should guard req_ack payload; got: {:?}", ws);
 }
+
+#[test]
+fn test_vec_methods_any_all_expand_to_reduction() {
+    // vec.any(pred) → OR of per-element substitutions
+    // vec.all(pred) → AND of per-element substitutions
+    let source = "
+        module M
+          port vec: in Vec<UInt<8>, 4>;
+          port needle: in UInt<8>;
+          port any_eq: out Bool;
+          port all_nz:  out Bool;
+          comb
+            any_eq = vec.any(item == needle);
+            all_nz = vec.all(item != 0);
+          end comb
+        end module M
+    ";
+    let sv = compile_to_sv(source);
+    // Fully unrolled, item → vec[i]:
+    assert!(sv.contains("vec[0] == needle || vec[1] == needle"),
+            "expected any to expand to OR of 4 compares: {sv}");
+    assert!(sv.contains("vec[0] != 0 && vec[1] != 0"),
+            "expected all to expand to AND of 4 compares: {sv}");
+}
+
+#[test]
+fn test_vec_methods_index_binder() {
+    // `index` is bound to the iteration position (sized literal).
+    let source = "
+        module M
+          port vec: in Vec<UInt<8>, 4>;
+          port needle: in UInt<8>;
+          port start: in UInt<2>;
+          port found: out Bool;
+          comb
+            found = vec.any(item == needle and index >= start);
+          end comb
+        end module M
+    ";
+    let sv = compile_to_sv(source);
+    // index should expand to 2-bit literals 2'd0..2'd3 (clog2(4)=2).
+    assert!(sv.contains("2'd0") && sv.contains("2'd3"),
+            "expected index binder to emit sized literals: {sv}");
+}
+
+#[test]
+fn test_vec_methods_count_and_contains() {
+    let source = "
+        module M
+          port vec: in Vec<UInt<8>, 4>;
+          port x: in UInt<8>;
+          port n: out UInt<3>;
+          port has: out Bool;
+          comb
+            n   = vec.count(item == x);
+            has = vec.contains(x);
+          end comb
+        end module M
+    ";
+    let sv = compile_to_sv(source);
+    // count emits 3-bit population-count expression (clog2(N+1)=3 for N=4).
+    assert!(sv.contains("3'(vec[0] == x ? 1 : 0)"),
+            "expected count to emit width-3 bool-to-bit casts: {sv}");
+    // contains lowers identically to any(item == x).
+    assert!(sv.contains("(vec[0] == x) || (vec[1] == x)"),
+            "expected contains to OR per-element equality: {sv}");
+}
+
+#[test]
+fn test_vec_methods_reduce_or_and_xor() {
+    let source = "
+        module M
+          port flags: in Vec<Bool, 4>;
+          port any_flag: out Bool;
+          port all_flag: out Bool;
+          port parity:   out Bool;
+          comb
+            any_flag = flags.reduce_or();
+            all_flag = flags.reduce_and();
+            parity   = flags.reduce_xor();
+          end comb
+        end module M
+    ";
+    let sv = compile_to_sv(source);
+    assert!(sv.contains("flags[0] | flags[1] | flags[2] | flags[3]"),
+            "reduce_or expected: {sv}");
+    assert!(sv.contains("flags[0] & flags[1] & flags[2] & flags[3]"),
+            "reduce_and expected: {sv}");
+    assert!(sv.contains("flags[0] ^ flags[1] ^ flags[2] ^ flags[3]"),
+            "reduce_xor expected: {sv}");
+}


### PR DESCRIPTION
## Summary

First PR from [doc/plan_vec_methods.md](doc/plan_vec_methods.md). Adds seven parallel-reduction methods on \`Vec<T,N>\` receivers with implicit \`item\` / \`index\` binders inside predicate expressions.

| Method | Returns | Shape |
|---|---|---|
| \`vec.any(pred)\` | \`Bool\` | N compares, OR-reduce |
| \`vec.all(pred)\` | \`Bool\` | N compares, AND-reduce |
| \`vec.count(pred)\` | \`UInt<clog2(N+1)>\` | Popcount tree |
| \`vec.contains(x)\` | \`Bool\` | N equality compares, OR-reduce |
| \`vec.reduce_or()\` / \`.reduce_and()\` / \`.reduce_xor()\` | \`T\` | Per-element reduce |

Predicate binders (only in scope inside the argument expression):
- \`item\` — per-iteration element (type \`T\`)
- \`index\` — position (\`UInt<clog2(N)>\`)
- Shadowing an enclosing signal of the same name emits a warning

## End-to-end verification

- \`arch check\` accepts predicates with \`item\`/\`index\`; rejects non-Bool predicate
- \`arch build\` emits fully-unrolled SV; Verilator 5.034 lint-clean
- \`arch sim\` compiles + runs a small test case (needle match / miss) with correct results

Four new integration tests cover the emission shape of each method family.

## Deferred to follow-up PRs (per plan)

- **PR #2**: struct destructuring in \`let\` (general language feature). Unlocks the \`find_first\` UX.
- **PR #3**: \`find_first\` with synthesized \`FindResult { found, index }\` struct return.
- **v2**: \`map\`, \`fold\`, \`zip\`, \`find_last\`, \`take_while\` (need tuple types + multi-binder predicates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)