### PR TITLE
fix(sim_codegen): scope pybind struct bindings to module-used structs

### DIFF
--- a/src/sim_codegen.rs
+++ b/src/sim_codegen.rs
@@ -197,6 +197,39 @@ impl<'a> SimCodegen<'a> {
         wrappers
     }
 
+    /// Structs the module actually depends on (port types, internal reg
+    /// types, plus the transitive closure of their field types). Only these
+    /// get `py::class_<...>` bindings — the module's own `V{Name}.h` won't
+    /// declare unrelated package structs.
+    fn collect_used_structs(
+        m: &ModuleDecl,
+        all_structs: &HashMap<String, &StructDecl>,
+    ) -> HashSet<String> {
+        fn push_named(ty: &TypeExpr, stack: &mut Vec<String>) {
+            match ty {
+                TypeExpr::Named(id) => stack.push(id.name.clone()),
+                TypeExpr::Vec(inner, _) => push_named(inner, stack),
+                _ => {}
+            }
+        }
+        let mut stack: Vec<String> = Vec::new();
+        for p in &m.ports { push_named(&p.ty, &mut stack); }
+        for item in &m.body {
+            if let ModuleBodyItem::RegDecl(r) = item {
+                push_named(&r.ty, &mut stack);
+            }
+        }
+        let mut used: HashSet<String> = HashSet::new();
+        while let Some(name) = stack.pop() {
+            if used.insert(name.clone()) {
+                if let Some(sd) = all_structs.get(&name) {
+                    for f in &sd.fields { push_named(&f.ty, &mut stack); }
+                }
+            }
+        }
+        used
+    }
+
     /// Emit pybind11 wrapper for a module.
     fn emit_pybind_module(&self, m: &ModuleDecl) -> Option<SimModel> {
         let name = &m.name.name;
@@ -332,20 +365,35 @@ impl<'a> SimCodegen<'a> {
         let port_info_str = port_info_entries.join(",\n");
 
         // Collect all struct types declared in the compilation unit (file-scope
-        // and inside packages). Register each with pybind so that struct-typed
-        // ports like `hwif_in: MyIpHwifIn` are reachable from Python as
-        // `dut.hwif_in.field`.
-        let mut all_structs: Vec<&StructDecl> = Vec::new();
+        // and inside packages), then bind ONLY the ones this module actually
+        // references through its ports or internal regs (plus any nested
+        // structs they transitively contain). Binding every unit-level struct
+        // regardless of use produced `undeclared identifier` errors when a
+        // shared package was built with a module whose own `V{Name}.h` didn't
+        // include those structs — a sibling module's header did instead.
+        let mut all_structs: HashMap<String, &StructDecl> = HashMap::new();
         for item in &self.source.items {
             match item {
-                Item::Struct(s) => all_structs.push(s),
-                Item::Package(p) => { for s in &p.structs { all_structs.push(s); } }
+                Item::Struct(s) => { all_structs.insert(s.name.name.clone(), s); }
+                Item::Package(p) => {
+                    for s in &p.structs { all_structs.insert(s.name.name.clone(), s); }
+                }
                 _ => {}
             }
         }
+        let used_structs = Self::collect_used_structs(m, &all_structs);
         let mut struct_bindings = String::new();
-        for s in &all_structs {
+        // Iterate in source order (not HashMap order) for stable output.
+        let ordered: Vec<&StructDecl> = self.source.items.iter().flat_map(|item| -> Vec<&StructDecl> {
+            match item {
+                Item::Struct(s) => vec![s],
+                Item::Package(p) => p.structs.iter().collect(),
+                _ => vec![],
+            }
+        }).collect();
+        for s in ordered {
             let sname = &s.name.name;
+            if !used_structs.contains(sname) { continue; }
             // `py::module_local()` scopes the struct type to this extension
             // module so multiple pybind builds sharing struct names (e.g. two
             // cpuif variants of the same design) can coexist in one process.

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -2380,3 +2380,136 @@ fn test_let_destructure_unknown_field_errors() {
     assert!(msg.contains("has no field named `z`"),
             "expected unknown-field message, got: {msg}");
 }
+
+fn compile_to_pybind_cpps(source: &str) -> Vec<(String, String)> {
+    use arch::sim_codegen::SimCodegen;
+    let tokens = arch::lexer::tokenize(source).expect("lexer");
+    let mut parser = arch::parser::Parser::new(tokens, source);
+    let parsed_ast = parser.parse_source_file().expect("parse");
+    let ast = arch::elaborate::elaborate(parsed_ast).expect("elaborate");
+    let symbols = arch::resolve::resolve(&ast).expect("resolve");
+    let checker = arch::typecheck::TypeChecker::new(&symbols, &ast);
+    let (_warnings, overload_map) = checker.check().expect("type check");
+    let sim = SimCodegen::new(&symbols, &ast, overload_map);
+    sim.generate_pybind().into_iter().map(|m| (m.class_name, m.impl_)).collect()
+}
+
+#[test]
+fn test_pybind_struct_bindings_are_scoped_to_module() {
+    // When a shared package declares structs used by only one of several
+    // sibling modules, each module's pybind wrapper must bind ONLY the
+    // structs that module actually references. Binding unused structs
+    // fails to compile because the module's own `V{Name}.h` doesn't
+    // declare them.
+    let source = "
+        package SharedPkg
+          struct Reg1
+            a: UInt<4>;
+            b: UInt<4>;
+          end struct Reg1
+          struct Reg2
+            x: UInt<8>;
+          end struct Reg2
+          struct PipeBus
+            data: UInt<8>;
+          end struct PipeBus
+        end package SharedPkg
+
+        use SharedPkg;
+
+        // Consumes Reg1 + Reg2 as internal regs.
+        module UsesStructs
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync>;
+          port out: out UInt<12>;
+          reg r1: Reg1 reset rst => Reg1 { a: 4'h0, b: 4'h0 };
+          reg r2: Reg2 reset rst => Reg2 { x: 8'h0 };
+          default seq on clk rising;
+          seq
+            r1.a <= 4'h1;
+            r2.x <= 8'h2;
+          end seq
+          comb
+            out = {r1.a, r1.b, r2.x[3:0]};
+          end comb
+        end module UsesStructs
+
+        // No struct-typed ports, no struct-typed regs — must NOT bind Reg1/Reg2.
+        module PrimitivesOnly
+          port a: in UInt<8>;
+          port b: out UInt<8>;
+          comb
+            b = a;
+          end comb
+        end module PrimitivesOnly
+
+        // Uses only PipeBus. Must bind PipeBus, but not Reg1/Reg2.
+        module UsesOneStruct
+          port bus_in:  in  PipeBus;
+          port bus_out: out PipeBus;
+          comb
+            bus_out = bus_in;
+          end comb
+        end module UsesOneStruct
+    ";
+
+    let pybinds = compile_to_pybind_cpps(source);
+    let prim = pybinds.iter().find(|(n, _)| n.contains("PrimitivesOnly"))
+        .expect("PrimitivesOnly pybind wrapper").1.clone();
+    let one = pybinds.iter().find(|(n, _)| n.contains("UsesOneStruct"))
+        .expect("UsesOneStruct pybind wrapper").1.clone();
+    let uses = pybinds.iter().find(|(n, _)| n.contains("UsesStructs"))
+        .expect("UsesStructs pybind wrapper").1.clone();
+
+    // PrimitivesOnly: no struct bindings at all.
+    assert!(!prim.contains("py::class_<Reg1>"),
+            "PrimitivesOnly must not bind Reg1:\n{prim}");
+    assert!(!prim.contains("py::class_<Reg2>"),
+            "PrimitivesOnly must not bind Reg2:\n{prim}");
+    assert!(!prim.contains("py::class_<PipeBus>"),
+            "PrimitivesOnly must not bind PipeBus:\n{prim}");
+
+    // UsesOneStruct: binds PipeBus, nothing else.
+    assert!(one.contains("py::class_<PipeBus>"),
+            "UsesOneStruct must bind PipeBus:\n{one}");
+    assert!(!one.contains("py::class_<Reg1>"),
+            "UsesOneStruct must not bind Reg1:\n{one}");
+    assert!(!one.contains("py::class_<Reg2>"),
+            "UsesOneStruct must not bind Reg2:\n{one}");
+
+    // UsesStructs: binds Reg1 and Reg2 (internal reg types).
+    assert!(uses.contains("py::class_<Reg1>"),
+            "UsesStructs must bind Reg1:\n{uses}");
+    assert!(uses.contains("py::class_<Reg2>"),
+            "UsesStructs must bind Reg2:\n{uses}");
+}
+
+#[test]
+fn test_pybind_struct_bindings_transitive_closure() {
+    // If a port-level struct has a field whose type is another struct,
+    // the nested struct must also be bound.
+    let source = "
+        struct Inner
+          v: UInt<8>;
+        end struct Inner
+
+        struct Outer
+          a: UInt<4>;
+          inner: Inner;
+        end struct Outer
+
+        module M
+          port o: in Outer;
+          port x: out UInt<8>;
+          comb
+            x = o.inner.v;
+          end comb
+        end module M
+    ";
+    let pybinds = compile_to_pybind_cpps(source);
+    let m = pybinds.iter().find(|(n, _)| n.contains("VM_pybind"))
+        .expect("M pybind wrapper").1.clone();
+    assert!(m.contains("py::class_<Outer>"), "must bind Outer:\n{m}");
+    assert!(m.contains("py::class_<Inner>"),
+            "must bind Inner (transitive via Outer.inner):\n{m}");
+}


### PR DESCRIPTION
## Summary

`arch sim --pybind Pkg.arch ModA.arch ModB.arch` currently binds every struct declared in the compilation unit into every module's pybind extension. When one module's own header doesn't reference a package struct — because a sibling module uses it instead — the wrapper compile fails with \`undeclared identifier 'FooStruct'\`.

This blocks multi-module layouts that share a package, like the CSR file + access controller + trap coordinator emitted by [rdl2arch-riscv](https://github.com/arch-hdl-lang/rdl2arch-riscv): the access controller has only primitive-typed ports, so its \`V{Name}.h\` never pulls in the per-register struct types, yet the old wrapper still tried to bind them.

## Fix

Compute the transitive closure of struct names each module actually references — via its port types, internal \`reg\` decl types, and their nested struct fields. Only emit \`py::class_<...>\` bindings for that set. Source-order iteration keeps codegen deterministic.

## Test plan

- [x] New: \`test_pybind_struct_bindings_are_scoped_to_module\` — three sibling modules on one package verify:
  - Primitive-only module: no struct bindings at all
  - Module using only one package struct: binds only that struct
  - Module using multiple structs as internal regs: binds those and only those
- [x] New: \`test_pybind_struct_bindings_transitive_closure\` — nested struct in a field type still gets bound
- [x] \`cargo test\` — all 82 tests pass
- [x] End-to-end: \`arch sim --pybind\` on the rdl2arch-riscv 4-file output (previously failing on the access controller + trap coordinator) now builds and loads cleanly in Python

🤖 Generated with [Claude Code](https://claude.com/claude-code)