### PR TITLE
feat: Vec.find_first with struct return + destructure lowering

### DIFF
--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -56,6 +56,11 @@ pub struct Codegen<'a> {
     /// Populated per-module at emit time so Vec method lowerings
     /// (`any`/`all`/`count`/etc.) can unroll over N iterations.
     vec_sizes: std::collections::HashMap<String, u32>,
+    /// Set of index widths used by `.find_first(...)` calls in this file.
+    /// Drives emission of one `typedef struct packed ... __ArchFindResult_<W>;`
+    /// per unique W at the top of the generated SV. Interior-mutability
+    /// so the `&self` emission path can record widths as it goes.
+    find_first_widths: std::cell::RefCell<std::collections::BTreeSet<u32>>,
 }
 
 impl<'a> Codegen<'a> {
@@ -79,6 +84,7 @@ impl<'a> Codegen<'a> {
             current_construct: String::new(),
             ident_subst: std::collections::HashMap::new(),
             vec_sizes: std::collections::HashMap::new(),
+            find_first_widths: std::cell::RefCell::new(std::collections::BTreeSet::new()),
         }
     }
 
@@ -143,6 +149,24 @@ impl<'a> Codegen<'a> {
         // Flush any trailing comments after the last item.
         let end = usize::MAX;
         self.emit_comments_before(end);
+
+        // Prepend typedefs for any synthesized find_first result structs.
+        // One packed struct per unique index width used in the source.
+        let widths = self.find_first_widths.borrow();
+        if !widths.is_empty() {
+            let mut prefix = String::new();
+            prefix.push_str("// Auto-generated result struct(s) for Vec.find_first\n");
+            for w in widths.iter() {
+                prefix.push_str(&format!(
+                    "typedef struct packed {{ logic found; logic [{}:0] index; }} __ArchFindResult_{};\n",
+                    w.saturating_sub(1),
+                    w
+                ));
+            }
+            prefix.push('\n');
+            prefix.push_str(&self.out);
+            self.out = prefix;
+        }
         std::mem::take(&mut self.out)
     }
 
@@ -637,6 +661,62 @@ impl<'a> Codegen<'a> {
                     // per binding; structurally-identical expressions are
                     // fine at this stage (synth CSE handles it).
                     if !l.destructure_fields.is_empty() {
+                        // Special case: RHS is `vec.find_first(pred)`.
+                        // Emit the raw OR + priority encoder directly so we
+                        // don't pay for the bulky struct-literal-then-field
+                        // access shape. Widths come from the synthesized
+                        // __ArchFindResult_<W> name.
+                        if let ExprKind::MethodCall(recv, mname, margs) = &l.value.kind {
+                            if mname.name == "find_first" {
+                                let recv_str = self.emit_expr_str(recv);
+                                let n = match &recv.kind {
+                                    ExprKind::Ident(nm) => self.vec_sizes.get(nm).copied(),
+                                    _ => None,
+                                };
+                                if let Some(n) = n {
+                                    let idx_w = std::cmp::max(1, (n as f64).log2().ceil() as u32);
+                                    // Record width so the typedef still emits
+                                    // (field access paths may still reference
+                                    // the struct type).
+                                    self.find_first_widths.borrow_mut().insert(idx_w);
+                                    // Emit per-iteration predicate strings.
+                                    let emit_at_i = |cg: &Codegen, i: u32| -> String {
+                                        let this = cg as *const Codegen as *mut Codegen;
+                                        unsafe {
+                                            (*this).ident_subst.insert("item".to_string(), format!("{recv_str}[{i}]"));
+                                            (*this).ident_subst.insert("index".to_string(), format!("{idx_w}'d{i}"));
+                                        }
+                                        let s = cg.emit_expr_str(&margs[0]);
+                                        unsafe {
+                                            (*this).ident_subst.remove("item");
+                                            (*this).ident_subst.remove("index");
+                                        }
+                                        s
+                                    };
+                                    let hits: Vec<String> = (0..n).map(|i| emit_at_i(self, i)).collect();
+                                    let found_expr = hits.join(" || ");
+                                    let mut idx_expr = format!("{idx_w}'d0");
+                                    for i in (0..n).rev() {
+                                        let hit = &hits[i as usize];
+                                        idx_expr = format!("({hit}) ? {idx_w}'d{i} : {idx_expr}");
+                                    }
+                                    for bind in &l.destructure_fields {
+                                        match bind.name.as_str() {
+                                            "found" => {
+                                                self.line("logic found;");
+                                                self.line(&format!("assign found = {found_expr};"));
+                                            }
+                                            "index" => {
+                                                self.line(&format!("logic [{}:0] index;", idx_w.saturating_sub(1)));
+                                                self.line(&format!("assign index = {idx_expr};"));
+                                            }
+                                            _ => {}
+                                        }
+                                    }
+                                    continue;
+                                }
+                            }
+                        }
                         let rhs_ty = self.infer_expr_struct_name(&l.value);
                         let val_str = self.emit_expr_str(&l.value);
                         for bind in &l.destructure_fields {
@@ -4191,7 +4271,8 @@ impl<'a> Codegen<'a> {
                         }
                     }
                     "any" | "all" | "count" | "contains"
-                    | "reduce_or" | "reduce_and" | "reduce_xor" => {
+                    | "reduce_or" | "reduce_and" | "reduce_xor"
+                    | "find_first" => {
                         self.emit_vec_method(&b, base, method, args)
                     }
                     _ => format!("{b}.{}()", method.name),
@@ -4375,7 +4456,8 @@ impl<'a> Codegen<'a> {
                         }
                     }
                     "any" | "all" | "count" | "contains"
-                    | "reduce_or" | "reduce_and" | "reduce_xor" => {
+                    | "reduce_or" | "reduce_and" | "reduce_xor"
+                    | "find_first" => {
                         self.emit_vec_method(&b, base, method, args)
                     }
                     _ => format!("{b}.{}()", method.name),
@@ -5067,6 +5149,26 @@ impl<'a> Codegen<'a> {
                       .collect::<Vec<_>>()
                       .join(" ^ ")
             }
+            "find_first" => {
+                // Record the index width so a matching typedef is emitted
+                // at the top of the generated SV file.
+                self.find_first_widths.borrow_mut().insert(idx_w);
+                if n_usize == 0 {
+                    return format!("'{{found: 1'b0, index: {idx_w}'d0}}");
+                }
+                // Per-iteration hit expression: <pred with item=recv[i], index=i'd>.
+                let hits: Vec<String> = (0..n).map(emit_at).collect();
+                // found: OR of all hits.
+                let found = hits.join(" || ");
+                // index: priority-encoded first hit via nested ternary,
+                // lowest-index-wins. Falls through to 0 when no hit.
+                let mut index = format!("{idx_w}'d0");
+                for i in (0..n).rev() {
+                    let hit = &hits[i as usize];
+                    index = format!("({hit}) ? {idx_w}'d{i} : {index}");
+                }
+                format!("'{{found: ({found}), index: ({index})}}")
+            }
             _ => format!("{recv_b}.{}()", method.name),
         }
     }
@@ -5413,7 +5515,8 @@ impl<'a> Codegen<'a> {
                         }
                     }
                     "any" | "all" | "count" | "contains"
-                    | "reduce_or" | "reduce_and" | "reduce_xor" => {
+                    | "reduce_or" | "reduce_and" | "reduce_xor"
+                    | "find_first" => {
                         self.emit_vec_method(&b, base, method, args)
                     }
                     _ => format!("{b}.{}()", method.name),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2314,7 +2314,8 @@ impl Parser {
                 let paren_method = self.check(TokenKind::LParen)
                     && matches!(field.name.as_str(),
                         "reverse" | "any" | "all" | "count" | "contains"
-                        | "reduce_or" | "reduce_and" | "reduce_xor");
+                        | "reduce_or" | "reduce_and" | "reduce_xor"
+                        | "find_first");
                 if paren_method {
                     self.advance(); // (
                     let mut args = Vec::new();

--- a/src/sim_codegen.rs
+++ b/src/sim_codegen.rs
@@ -4454,6 +4454,59 @@ impl<'a> SimCodegen<'a> {
             if let ModuleBodyItem::LetBinding(l) = item {
                 // Destructuring: emit one assignment per bound field.
                 if !l.destructure_fields.is_empty() {
+                    // Special case: RHS is `vec.find_first(pred)`. Emit the
+                    // raw OR + priority encoder directly; avoids the
+                    // non-existent `.find_first()` member access on C++
+                    // vector fields.
+                    if let ExprKind::MethodCall(recv, mname, margs) = &l.value.kind {
+                        if mname.name == "find_first" {
+                            let recv_cpp = cpp_expr(recv, &ctx_comb);
+                            let n = match &recv.kind {
+                                ExprKind::Ident(nm) => ctx_comb.vec_sizes
+                                    .and_then(|s| s.get(nm)).copied(),
+                                _ => None,
+                            };
+                            if let Some(n) = n {
+                                // Build per-iteration predicate strings.
+                                let mut hits: Vec<String> = Vec::with_capacity(n as usize);
+                                for i in 0..n {
+                                    let mut sub: HashMap<String, String> = HashMap::new();
+                                    sub.insert("item".to_string(), format!("{recv_cpp}[{i}]"));
+                                    sub.insert("index".to_string(), format!("{i}"));
+                                    let sub_ctx = Ctx {
+                                        reg_names: ctx_comb.reg_names, port_names: ctx_comb.port_names,
+                                        let_names: ctx_comb.let_names, inst_names: ctx_comb.inst_names,
+                                        wide_names: ctx_comb.wide_names, widths: ctx_comb.widths,
+                                        posedge_lhs: ctx_comb.posedge_lhs, fsm_mode: ctx_comb.fsm_mode,
+                                        enum_map: ctx_comb.enum_map, bus_ports: ctx_comb.bus_ports,
+                                        reset_levels: ctx_comb.reset_levels, vec_names: ctx_comb.vec_names,
+                                        vec_sizes: ctx_comb.vec_sizes, fsm_vec_port_regs: ctx_comb.fsm_vec_port_regs,
+                                        ident_subst: Some(&sub),
+                                    };
+                                    hits.push(cpp_expr(&margs[0], &sub_ctx));
+                                }
+                                let found_expr: String = hits.iter()
+                                    .map(|h| format!("({h})"))
+                                    .collect::<Vec<_>>().join(" || ");
+                                let mut idx_expr = "0u".to_string();
+                                for i in (0..n as u64).rev() {
+                                    let hit = &hits[i as usize];
+                                    idx_expr = format!("(({hit}) ? (uint32_t){i} : {idx_expr})");
+                                }
+                                for bind in &l.destructure_fields {
+                                    let rhs = match bind.name.as_str() {
+                                        "found" => format!("({found_expr})"),
+                                        "index" => idx_expr.clone(),
+                                        _ => continue,
+                                    };
+                                    cpp.push_str(&format!(
+                                        "  _let_{fn} = {rhs};\n", fn = bind.name
+                                    ));
+                                }
+                                continue;
+                            }
+                        }
+                    }
                     let val = cpp_expr(&l.value, &ctx_comb);
                     for bind in &l.destructure_fields {
                         cpp.push_str(&format!(

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -295,6 +295,21 @@ impl<'a> TypeChecker<'a> {
                         // main pass re-checks.
                         let rhs_ty = self.resolve_expr_type(&l.value, &m.name.name, &local_types);
                         if let Ty::Struct(sname) = &rhs_ty {
+                            // Synthesized find_first result: derive fields
+                            // directly from the width-suffixed name.
+                            if let Some(w_str) = sname.strip_prefix("__ArchFindResult_") {
+                                if let Ok(w) = w_str.parse::<u32>() {
+                                    for bind in &l.destructure_fields {
+                                        let bty = match bind.name.as_str() {
+                                            "found" => Ty::Bool,
+                                            "index" => Ty::UInt(w),
+                                            _ => Ty::Error,
+                                        };
+                                        local_types.insert(bind.name.clone(), bty);
+                                    }
+                                    continue;
+                                }
+                            }
                             if let Some((crate::resolve::Symbol::Struct(info), _)) =
                                 self.symbols.globals.get(sname)
                             {
@@ -391,6 +406,30 @@ impl<'a> TypeChecker<'a> {
                             }
                             continue;
                         };
+                        // Synthesized find_first result: fields are derived
+                        // from the struct name's width suffix, no StructInfo
+                        // is registered in globals.
+                        if sname.starts_with("__ArchFindResult_") {
+                            for bind in &l.destructure_fields {
+                                self.check_snake_case(bind);
+                                if !matches!(bind.name.as_str(), "found" | "index") {
+                                    self.errors.push(CompileError::general(
+                                        &format!(
+                                            "find_first result has no field named `{}`; valid fields are `found` and `index`",
+                                            bind.name),
+                                        bind.span,
+                                    ));
+                                }
+                                let is_port = m.ports.iter().any(|p| p.name.name == bind.name);
+                                if is_port {
+                                    self.errors.push(CompileError::general(
+                                        &format!("`{}` is already declared as a port", bind.name),
+                                        bind.span,
+                                    ));
+                                }
+                            }
+                            continue;
+                        }
                         let Some((crate::resolve::Symbol::Struct(info), _)) =
                             self.symbols.globals.get(sname).cloned()
                         else {
@@ -2179,6 +2218,18 @@ impl<'a> TypeChecker<'a> {
                     return Ty::Error;
                 }
                 if let Ty::Struct(name) = &base_ty {
+                    // Synthesized find_first result struct: no entry lives in
+                    // symbols.globals; fields are computed from the name's
+                    // width suffix.
+                    if let Some(w_str) = name.strip_prefix("__ArchFindResult_") {
+                        if let Ok(w) = w_str.parse::<u32>() {
+                            return match field.name.as_str() {
+                                "found" => Ty::Bool,
+                                "index" => Ty::UInt(w),
+                                _ => Ty::Error,
+                            };
+                        }
+                    }
                     if let Some((sym, _)) = self.symbols.globals.get(name) {
                         if let crate::resolve::Symbol::Struct(info) = sym {
                             for (fname, fty) in &info.fields {
@@ -2336,7 +2387,7 @@ impl<'a> TypeChecker<'a> {
                     // `item` is the per-iteration element, `index` is the position (UInt<clog2(N)>).
                     // Both are injected into the predicate's local scope during checking.
                     "any" | "all" | "count" | "contains"
-                    | "reduce_or" | "reduce_and" | "reduce_xor" => {
+                    | "reduce_or" | "reduce_and" | "reduce_xor" | "find_first" => {
                         let (elem_ty, n) = match &base_ty {
                             Ty::Vec(inner, count) => ((**inner).clone(), *count),
                             _ => {
@@ -2429,6 +2480,13 @@ impl<'a> TypeChecker<'a> {
 
                         match method.name.as_str() {
                             "any" | "all" | "contains" => Ty::Bool,
+                            "find_first" => {
+                                // Synthesized struct { found: Bool; index: UInt<idx_w> }.
+                                // Name is unique per idx_w; the typechecker's struct-field
+                                // lookup has a targeted fallback for this prefix, so no
+                                // entry needs to live in symbols.globals.
+                                Ty::Struct(format!("__ArchFindResult_{}", idx_w))
+                            }
                             "count" => {
                                 // clog2(N+1) for popcount result width.
                                 let w = std::cmp::max(1, ((n + 1) as f64).log2().ceil() as u32);

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -2513,3 +2513,85 @@ fn test_pybind_struct_bindings_transitive_closure() {
     assert!(m.contains("py::class_<Inner>"),
             "must bind Inner (transitive via Outer.inner):\n{m}");
 }
+
+#[test]
+fn test_find_first_destructure_basic() {
+    let source = "
+        module M
+          port vec: in Vec<UInt<8>, 4>;
+          port needle: in UInt<8>;
+          port ok:  out Bool;
+          port pos: out UInt<2>;
+          let {found, index} = vec.find_first(item == needle);
+          comb
+            ok  = found;
+            pos = index;
+          end comb
+        end module M
+    ";
+    let sv = compile_to_sv(source);
+    // Typedef emitted for the synthesized result struct.
+    assert!(sv.contains("typedef struct packed { logic found; logic [1:0] index; } __ArchFindResult_2;"),
+            "expected ArchFindResult typedef: {sv}");
+    // Raw OR reduction for `found`, no spurious struct literal:
+    assert!(sv.contains("assign found = vec[0] == needle || vec[1] == needle"),
+            "expected OR reduction: {sv}");
+    // Priority encoder for `index`, nested ternary:
+    assert!(sv.contains("assign index = (vec[0] == needle) ? 2'd0 : (vec[1] == needle) ? 2'd1"),
+            "expected priority encoder: {sv}");
+    // Correct width on `index`:
+    assert!(sv.contains("logic [1:0] index;"),
+            "expected 2-bit index wire: {sv}");
+}
+
+#[test]
+fn test_find_first_partial_destructure() {
+    // Bind only `found` (don't care about where).
+    let source = "
+        module M
+          port vec: in Vec<UInt<8>, 4>;
+          port needle: in UInt<8>;
+          port ok:  out Bool;
+          let {found} = vec.find_first(item == needle);
+          comb
+            ok = found;
+          end comb
+        end module M
+    ";
+    let sv = compile_to_sv(source);
+    assert!(sv.contains("logic found;") && sv.contains("assign found ="),
+            "expected `found` wire + assign: {sv}");
+    // No `index` wire should be emitted since the user didn't bind it.
+    // (It can still appear as a module port in the future; for now, assert
+    // no `logic index` declaration at module scope.)
+    assert!(!sv.lines().any(|l| l.trim_start().starts_with("logic ") && l.contains(" index;")),
+            "did not expect unbound `index`: {sv}");
+}
+
+#[test]
+fn test_find_first_unknown_binding_errors() {
+    // Binding a name that isn't `found` or `index` must error.
+    let source = "
+        module M
+          port vec: in Vec<UInt<8>, 4>;
+          port needle: in UInt<8>;
+          port ok: out Bool;
+          let {found, wrong_name} = vec.find_first(item == needle);
+          comb
+            ok = found;
+          end comb
+        end module M
+    ";
+    let tokens = arch::lexer::tokenize(source).expect("lexer");
+    let mut parser = arch::parser::Parser::new(tokens, source);
+    let ast = parser.parse_source_file().expect("parse");
+    let ast = arch::elaborate::elaborate(ast).expect("elaborate");
+    let symbols = arch::resolve::resolve(&ast).expect("resolve");
+    let checker = arch::typecheck::TypeChecker::new(&symbols, &ast);
+    let result = checker.check();
+    assert!(result.is_err(),
+            "expected type-check error for bad destructure binding");
+    let msg = format!("{:?}", result.unwrap_err());
+    assert!(msg.contains("find_first result has no field named `wrong_name`"),
+            "expected specific error message, got: {msg}");
+}


### PR DESCRIPTION
## Summary

PR #3 of the Vec-methods roadmap ([plan_vec_methods.md](doc/plan_vec_methods.md)). Completes the initial Vec method surface:

```
let {found, index} = vec.find_first(item == needle);
if found
  out = vec[index];
end if
```

\`find_first\` returns a synthesized struct \`__ArchFindResult_<W>\` with fields \`{found: Bool, index: UInt<W>}\` where W = clog2(N). Composes directly with the destructure-let feature from PR #2.

## Hardware

Destructure-let with a find_first RHS lowers to the minimum hardware:
- **\`found\`**: N-way OR reduction of the per-element predicate
- **\`index\`**: nested ternary priority encoder, lowest-matching-index wins, defaults to 0 when no match

Example 4-element emission:
```systemverilog
typedef struct packed { logic found; logic [1:0] index; } __ArchFindResult_2;

logic found;
assign found = vec[0] == needle || vec[1] == needle || vec[2] == needle || vec[3] == needle;
logic [1:0] index;
assign index = (vec[0] == needle) ? 2'd0 : (vec[1] == needle) ? 2'd1 : (vec[2] == needle) ? 2'd2 : (vec[3] == needle) ? 2'd3 : 2'd0;
```

## End-to-end verification

- \`arch check + build\`: Verilator 5.034 lint-clean
- \`arch sim\`: needle=30 in [10,20,30,40] → ok=1 pos=2; needle=99 → ok=0 pos=0

## Test plan
- [x] \`cargo build\` clean
- [x] \`cargo test\` — 113 passing, including 3 new find_first regressions

## v1 constraint

Non-destructure use (\`let r = vec.find_first(pred); r.found\`) typechecks but emits a structural struct-literal-then-field-access (uglier SV; same hardware after synth CSE). The destructure form is the documented v1 spelling.

## What this closes

Original Vec-methods plan now fully shipped for v1:
- #30 → any / all / count / contains / reduce_or/and/xor + item/index binders
- #31 → struct destructuring in let bindings
- #32 (this) → find_first with synthesized struct + destructure lowering

v2 items (map, fold, zip, find_last, take_while) remain deferred per the plan — they need tuple types and multi-binder predicates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)