### PR TITLE
fix(sim_codegen): skip struct-typed let/wire in VCD trace emission

### DIFF
--- a/src/sim_codegen.rs
+++ b/src/sim_codegen.rs
@@ -827,14 +827,17 @@ fn collect_trace_signals(
         }
     }
 
-    // Let bindings and wire decls (skip Vec types — they're C arrays, not scalar)
+    // Let bindings and wire decls — skip Vec (C arrays) and struct/enum-typed
+    // (Named), which can't be bit-shifted scalar-style. Matches the filter
+    // already applied to ports and regs above.
     for item in body {
         match item {
             ModuleBodyItem::LetBinding(l) => {
                 // ty=None means assignment to existing port/wire — already traced, skip
                 if l.ty.is_none() { continue; }
                 let name = &l.name.name;
-                if l.ty.as_ref().map_or(false, |t| matches!(t, TypeExpr::Vec(..))) { continue; }
+                if l.ty.as_ref().map_or(false,
+                    |t| matches!(t, TypeExpr::Vec(..) | TypeExpr::Named(_))) { continue; }
                 let width = l.ty.as_ref().map(|t| type_width(t)).unwrap_or(
                     widths.get(name.as_str()).copied().unwrap_or(32)
                 );
@@ -846,7 +849,7 @@ fn collect_trace_signals(
                 });
             }
             ModuleBodyItem::WireDecl(w) => {
-                if matches!(w.ty, TypeExpr::Vec(..)) { continue; }
+                if matches!(w.ty, TypeExpr::Vec(..) | TypeExpr::Named(_)) { continue; }
                 let name = &w.name.name;
                 let width = type_width(&w.ty);
                 sigs.push(TraceSignal {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -2515,6 +2515,40 @@ fn test_pybind_struct_bindings_transitive_closure() {
 }
 
 #[test]
+fn test_trace_skips_struct_typed_let_and_wire() {
+    // Struct-typed `let` and `wire` decls must NOT appear in the VCD trace
+    // emission — they can't be bit-shifted scalar-style, and previously
+    // produced invalid C++ (`(hwif_w >> i) & 1` against a struct type) that
+    // failed to compile. Ports and regs with struct types were already
+    // filtered; this extends the same filter to let/wire.
+    let source = "
+        struct Payload
+          a: UInt<8>;
+          b: UInt<8>;
+        end struct Payload
+
+        module M
+          port clk:   in Clock<SysDomain>;
+          port rst:   in Reset<Sync>;
+          port p_in:  in  Payload;
+          port out_a: out UInt<8>;
+          wire scratch: Payload;
+          let  view:    Payload = p_in;
+          comb
+            scratch.a = p_in.a;
+            scratch.b = p_in.b;
+            out_a = view.a | scratch.b;
+          end comb
+        end module M
+    ";
+    let h = compile_to_sim_h(source, false);
+    assert!(!h.contains("(_let_scratch >> _i)"),
+            "scratch (struct wire) leaked into trace:\n{h}");
+    assert!(!h.contains("(_let_view >> _i)"),
+            "view (struct let) leaked into trace:\n{h}");
+}
+
+#[test]
 fn test_find_first_destructure_basic() {
     let source = "
         module M


### PR DESCRIPTION
## Summary

\`emit_trace_methods\` already filters \`TypeExpr::Named(_)\` (struct/enum) out of the port and reg trace loops — bit-shifting a struct scalar-style produces invalid C++. The let and wire loops had only the \`Vec\` filter, not the \`Named\` filter, so a struct-typed \`let x: Foo = ...;\` or \`wire x: Foo;\` flowed into the trace emitter and generated:

\`\`\`cpp
fprintf(_trace_fp, \"%c\", ((_let_x >> _i) & 1) ? '1' : '0');
// error: invalid operands to binary expression ('Foo' and 'int')
\`\`\`

This blocks any multi-module integration that wires struct-typed signals (e.g. a HwifIn bus) through intermediate signals at the parent-module scope — which is exactly what [rdl2arch-riscv](https://github.com/arch-hdl-lang/rdl2arch-riscv)'s upcoming Phase 4b (integrated CSR top) needs.

## Fix

Extend the existing filter pattern. One-line change to each of the two matchers so let/wire behave consistently with port/reg. Struct-typed signals are simply omitted from the VCD — their individual fields can still be traced via the submodule ports that consume them.

## Test plan

- [x] New: \`test_trace_skips_struct_typed_let_and_wire\` — compiles a module with a struct-typed wire and a struct-typed let, asserts neither appears as a bit-shifted trace expression
- [x] \`cargo test\` — 86/86 tests pass
- [x] End-to-end: the rdl2arch-riscv integrated top (which declares \`wire hwif_live_w: HwifIn;\` and \`wire hwif_drive_w: HwifIn;\`) now builds cleanly through \`arch sim --pybind\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)