### PR TITLE
feat: allow bus types as wire/reg types (direction-agnostic)

### DIFF
--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -43,6 +43,12 @@ pub struct Codegen<'a> {
     overload_map: std::collections::HashMap<usize, usize>,
     /// Bus port names in the current module → bus name (for FieldAccess rewriting).
     bus_ports: std::collections::HashMap<String, String>,
+    /// Bus-typed wire names in the current module → bus name. Bus wires are
+    /// flattened into individual SV signals `<wire>_<field>` at emission
+    /// time (no SV interfaces or structs are generated for buses), so
+    /// FieldAccess on a bus wire rewrites to the flat name just like a bus
+    /// port does.
+    bus_wires: std::collections::HashMap<String, String>,
     /// Reset port names in the current module → (kind, level), for `.asserted` emission.
     reset_ports: std::collections::HashMap<String, (ResetKind, ResetLevel)>,
     /// Name of the construct currently being emitted (for symbol lookups).
@@ -80,6 +86,7 @@ impl<'a> Codegen<'a> {
             pending_functions: Vec::new(),
             overload_map,
             bus_ports: std::collections::HashMap::new(),
+            bus_wires: std::collections::HashMap::new(),
             reset_ports: std::collections::HashMap::new(),
             current_construct: String::new(),
             ident_subst: std::collections::HashMap::new(),
@@ -495,6 +502,7 @@ impl<'a> Codegen<'a> {
 
         // Ports — bus ports are flattened to individual signals
         self.bus_ports.clear();
+        self.bus_wires.clear();
         self.reset_ports.clear();
         self.vec_sizes.clear();
         for p in m.ports.iter() {
@@ -784,6 +792,35 @@ impl<'a> Codegen<'a> {
                     self.emit_pipe_reg(p, &m_clone);
                 }
                 ModuleBodyItem::WireDecl(w) => {
+                    // Bus-typed wires: flatten into individual SV signals
+                    // `<wire>_<field>`. No SV interface/struct is generated
+                    // for the bus; the bus exists purely as a compile-time
+                    // abstraction. Record the wire in `bus_wires` so field
+                    // access rewrites (see emit_expr_str) produce the flat
+                    // name.
+                    if let TypeExpr::Named(id) = &w.ty {
+                        if let Some((crate::resolve::Symbol::Bus(info), _)) =
+                            self.symbols.globals.get(&id.name)
+                        {
+                            self.bus_wires.insert(w.name.name.clone(), id.name.clone());
+                            let param_map: std::collections::HashMap<String, &Expr> =
+                                info.params.iter()
+                                    .filter_map(|pd| pd.default.as_ref()
+                                        .map(|d| (pd.name.name.clone(), d)))
+                                    .collect();
+                            for (sname, _sdir, sty) in info.effective_signals(&param_map) {
+                                let (ty_str, arr_suffix) =
+                                    self.emit_type_and_array_suffix(&sty);
+                                self.line(&format!(
+                                    "{} {}_{}{};",
+                                    ty_str, w.name.name, sname, arr_suffix
+                                ));
+                                declared_names.insert(format!("{}_{}", w.name.name, sname));
+                            }
+                            declared_names.insert(w.name.name.clone());
+                            continue;
+                        }
+                    }
                     let (ty_str, arr_suffix) = self.emit_type_and_array_suffix(&w.ty);
                     self.line(&format!("{} {}{};", ty_str, w.name.name, arr_suffix));
                     declared_names.insert(w.name.name.clone());
@@ -5438,9 +5475,12 @@ impl<'a> Codegen<'a> {
                         }
                     }
                 }
-                // Bus port: axi.aw_valid → axi_aw_valid (underscore, not dot)
+                // Bus port / bus wire: axi.aw_valid → axi_aw_valid (flat).
+                // Bus wires flatten to individual SV signals, same naming.
                 if let ExprKind::Ident(base_name) = &base.kind {
-                    if self.bus_ports.contains_key(base_name) {
+                    if self.bus_ports.contains_key(base_name)
+                        || self.bus_wires.contains_key(base_name)
+                    {
                         return format!("{}_{}", base_name, field.name);
                     }
                 }

--- a/src/sim_codegen.rs
+++ b/src/sim_codegen.rs
@@ -1078,6 +1078,7 @@ fn expand_bus_connections(
     inst: &InstDecl,
     source: &SourceFile,
     symbols: &crate::resolve::SymbolTable,
+    bus_wire_names: &HashSet<String>,
 ) -> Vec<Connection> {
     // Find the target construct's bus ports (with perspective info)
     let target_ports: Option<&[PortDecl]> = source.items.iter()
@@ -1097,12 +1098,21 @@ fn expand_bus_connections(
         if let Some((_, bus_name, perspective, bus_params)) = target_bus_ports.iter().find(|(pn, _, _, _)| *pn == c.port_name.name) {
             // Bus connection — expand to individual signal connections
             if let Some((crate::resolve::Symbol::Bus(info), _)) = symbols.globals.get(*bus_name) {
-                let sig_name = match &c.signal.kind {
-                    ExprKind::Ident(name) => name.clone(),
+                // Two shapes for the parent-side signal on a whole-bus binding:
+                //   * `p -> ident` where `ident` is a bus port or a bus wire
+                //   * `p -> base.field` where `base.field` is a bus port on the parent
+                // For bus WIRES we keep the bus-wire name as the struct base and
+                // emit FieldAccess exprs per signal so cpp_expr resolves them
+                // to `_let_<wire>.<field>`. For bus PORTS we emit flat idents
+                // (the port has been flattened elsewhere into `<port>_<field>`).
+                let (sig_base, wire_bound) = match &c.signal.kind {
+                    ExprKind::Ident(name) => {
+                        let is_wire = bus_wire_names.contains(name.as_str());
+                        (name.clone(), is_wire)
+                    }
                     ExprKind::FieldAccess(base, field) => {
-                        // axi_rd -> parent.bus_port — just use the field access text
                         if let ExprKind::Ident(base_name) = &base.kind {
-                            format!("{}_{}", base_name, field.name)
+                            (format!("{}_{}", base_name, field.name), false)
                         } else {
                             continue;
                         }
@@ -1113,7 +1123,6 @@ fn expand_bus_connections(
                 for pa in *bus_params { _pm.insert(pa.name.name.clone(), &pa.value); }
                 let _eff = info.effective_signals(&_pm); for (sname, sdir, _) in &_eff {
                     let inst_flat = format!("{}_{}", c.port_name.name, sname);
-                    let parent_flat = format!("{}_{}", sig_name, sname);
                     // Determine actual direction from the inst's bus perspective.
                     // For initiator: bus out → inst Output, bus in → inst Input.
                     // For target: bus out → inst Input (flipped), bus in → inst Output (flipped).
@@ -1125,18 +1134,26 @@ fn expand_bus_connections(
                         Direction::Out => ConnectDir::Output,
                         Direction::In => ConnectDir::Input,
                     };
-                    // If the ORIGINAL connection direction is Input (parent → inst),
-                    // we need to flip: the user wrote `axi_rd <- parent_bus` meaning
-                    // all signals flow from parent to inst. But for a bus, the actual
-                    // direction per signal comes from the bus definition.
-                    // Actually, for bus connections we should use the bus signal direction
-                    // (from initiator perspective) regardless of the `<-` or `->` in the
-                    // connection. The user writes `axi_rd -> parent_bus` to mean "connect
-                    // the whole bus", and each signal's direction comes from the bus def.
+                    // Bus WIRE target → struct-field access on the wire.
+                    // Bus PORT target → flat `<port>_<field>` ident.
+                    let parent_signal = if wire_bound {
+                        Expr::new(
+                            ExprKind::FieldAccess(
+                                Box::new(Expr::new(ExprKind::Ident(sig_base.clone()), c.signal.span)),
+                                Ident::new(sname.clone(), c.signal.span),
+                            ),
+                            c.signal.span,
+                        )
+                    } else {
+                        Expr::new(
+                            ExprKind::Ident(format!("{}_{}", sig_base, sname)),
+                            c.signal.span,
+                        )
+                    };
                     expanded.push(Connection {
                         port_name: Ident::new(inst_flat, c.port_name.span),
                         direction: dir,
-                        signal: Expr::new(ExprKind::Ident(parent_flat), c.signal.span),
+                        signal: parent_signal,
                         reset_override: None,
                         span: c.span,
                     });
@@ -3356,10 +3373,26 @@ impl<'a> SimCodegen<'a> {
             .filter_map(|i| if let ModuleBodyItem::Inst(inst) = i { Some(inst) } else { None })
             .collect();
 
+        // Bus-typed wires in this module — needed by expand_bus_connections so
+        // that `child_port -> bus_wire` emits struct-field-access exprs instead
+        // of flat `<wire>_<field>` idents (which would dangle; bus wires are
+        // declared as a C++ struct field, not as N flat fields).
+        let bus_wire_names: HashSet<String> = m.body.iter()
+            .filter_map(|i| if let ModuleBodyItem::WireDecl(w) = i {
+                if let TypeExpr::Named(id) = &w.ty {
+                    if matches!(self.symbols.globals.get(&id.name),
+                                Some((crate::resolve::Symbol::Bus(_), _))) {
+                        return Some(w.name.name.clone());
+                    }
+                }
+                None
+            } else { None })
+            .collect();
+
         // Pre-expand bus connections: whole-bus connections like `axi_rd -> m_axi_mm2s`
         // are expanded to per-signal connections using the bus definition.
         let expanded_conns: Vec<Vec<Connection>> = insts.iter()
-            .map(|inst| expand_bus_connections(inst, self.source, self.symbols))
+            .map(|inst| expand_bus_connections(inst, self.source, self.symbols, &bus_wire_names))
             .collect();
 
         // Build map: parent_signal_name → Vec element count for inst-output Vec ports.
@@ -3823,7 +3856,12 @@ impl<'a> SimCodegen<'a> {
 
         // Private fields for sub-instance output wires
         for sig_name in &inst_out {
-            if !port_names.contains(sig_name) && !reg_names.contains(sig_name) {
+            if !port_names.contains(sig_name) && !reg_names.contains(sig_name)
+                // Bus wires are handled via the struct-typed `_let_<name>`
+                // field emitted above; a fallback `uint32_t <name>;` here
+                // would shadow the bus wire with a scalar.
+                && !bus_wire_names.contains(sig_name)
+            {
                 // Vec output ports need a C array, not a scalar
                 if let Some((elem_ty, count)) = inst_vec_out.get(sig_name) {
                     h.push_str(&format!("  {elem_ty} {sig_name}[{count}];\n"));
@@ -6590,6 +6628,45 @@ impl<'a> SimCodegen<'a> {
             }
             h.push_str(&format!("  {}() : {} {{}}\n", s.name.name, field_inits.join(", ")));
             h.push_str("};\n\n");
+        }
+
+        // Bus-as-wire support: emit a plain C++ struct for every `bus`, with
+        // one field per effective (flattened) signal. Direction information is
+        // intentionally dropped — when a bus appears as a `wire` (not a port),
+        // each signal is just a named piece of data driven by whichever
+        // module's assignment reaches it. Field directions only matter at
+        // port boundaries, where the perspective (initiator/target) chooses
+        // which side drives which field.
+        for item in &self.source.items {
+            if let Item::Bus(b) = item {
+                let param_map: HashMap<String, &Expr> = HashMap::new();
+                let effective = crate::resolve::BusInfo {
+                    name: b.name.name.clone(),
+                    params: b.params.clone(),
+                    signals: b.signals.iter()
+                        .map(|p| (p.name.name.clone(), p.direction, p.ty.clone()))
+                        .collect(),
+                    generates: b.generates.clone(),
+                    handshakes: b.handshakes.clone(),
+                }.effective_signals(&param_map);
+                h.push_str(&format!("struct {} {{\n", b.name.name));
+                let mut field_inits = Vec::new();
+                for (sname, _dir, sty) in &effective {
+                    let ty = cpp_internal_type(sty);
+                    h.push_str(&format!("  {} {};\n", ty, sname));
+                    if matches!(sty, TypeExpr::Named(_)) {
+                        field_inits.push(format!("{}()", sname));
+                    } else {
+                        field_inits.push(format!("{}(0)", sname));
+                    }
+                }
+                if field_inits.is_empty() {
+                    h.push_str(&format!("  {}() {{}}\n", b.name.name));
+                } else {
+                    h.push_str(&format!("  {}() : {} {{}}\n", b.name.name, field_inits.join(", ")));
+                }
+                h.push_str("};\n\n");
+            }
         }
 
         SimModel {

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -2126,6 +2126,11 @@ impl<'a> TypeChecker<'a> {
                             let bits = enum_width(info.variants.len());
                             Ty::Enum(ident.name.clone(), bits)
                         }
+                        // Bus types are permitted as wire/reg types — direction
+                        // metadata is only meaningful on ports; in a wire
+                        // context the bus is just a named bundle of fields.
+                        // Each field becomes a flat signal at codegen.
+                        crate::resolve::Symbol::Bus(_) => Ty::Bus(ident.name.clone()),
                         _ => {
                             self.errors.push(CompileError::type_mismatch(
                                 "type",

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -2381,6 +2381,114 @@ fn test_let_destructure_unknown_field_errors() {
             "expected unknown-field message, got: {msg}");
 }
 
+#[test]
+fn test_bus_wire_typechecks_and_codegens() {
+    // Buses as wire types: direction info on each field is ignored in wire
+    // context (each signal has one driver, determined by the assignment
+    // reaching it). The C++ struct is emitted at file scope so the
+    // generated `FooBus _let_w;` field is a valid type, and bus-port →
+    // bus-wire connections flow through struct field access.
+    let source = "
+        bus FooBus
+          cmd:  out UInt<8>;
+          resp: in  UInt<8>;
+        end bus FooBus
+
+        module Child
+          port p: target FooBus;
+          comb
+            p.resp = (p.cmd + 8'h1).trunc<8>();
+          end comb
+        end module Child
+
+        module Parent
+          port x_in:  in  UInt<8>;
+          port x_out: out UInt<8>;
+          wire w: FooBus;
+          comb
+            w.cmd = x_in;
+            x_out = w.resp;
+          end comb
+          inst c: Child
+            p -> w;
+          end inst c
+        end module Parent
+    ";
+    let h = compile_to_sim_h(source, false);
+    // VStructs.h should emit a plain C++ struct for the bus.
+    assert!(h.contains("struct FooBus {"),
+            "expected `struct FooBus {{` in generated structs header:\n{h}");
+    assert!(h.contains("uint8_t cmd;") && h.contains("uint8_t resp;"),
+            "expected bus fields as struct members:\n{h}");
+
+    // VParent.h should declare the wire as a struct-typed member and must
+    // NOT emit a shadow `uint32_t w;` scalar.
+    let parent = h.split("// ---\n").find(|p| p.contains("class VParent"))
+        .expect("no VParent header section");
+    assert!(parent.contains("FooBus _let_w;"),
+            "expected `FooBus _let_w;` in VParent header:\n{parent}");
+    assert!(!parent.contains("uint32_t w;"),
+            "unexpected shadow `uint32_t w;` in VParent header:\n{parent}");
+}
+
+#[test]
+fn test_bus_wire_sv_flattens_to_individual_signals() {
+    // SV codegen has no bus interface/struct: a bus-typed wire becomes N
+    // individual SV wires named `<wire>_<field>`. Field access on the
+    // wire rewrites to the flat name, same as for bus ports.
+    use arch::codegen::Codegen;
+    let source = "
+        bus FooBus
+          cmd:  out UInt<8>;
+          resp: in  UInt<8>;
+        end bus FooBus
+
+        module Child
+          port p: target FooBus;
+          comb
+            p.resp = (p.cmd + 8'h1).trunc<8>();
+          end comb
+        end module Child
+
+        module Parent
+          port x_in:  in  UInt<8>;
+          port x_out: out UInt<8>;
+          wire w: FooBus;
+          comb
+            w.cmd = x_in;
+            x_out = w.resp;
+          end comb
+          inst c: Child
+            p -> w;
+          end inst c
+        end module Parent
+    ";
+    let tokens = arch::lexer::tokenize(source).expect("lexer");
+    let mut parser = arch::parser::Parser::new(tokens, source);
+    let parsed_ast = parser.parse_source_file().expect("parse");
+    let ast = arch::elaborate::elaborate(parsed_ast).expect("elaborate");
+    let symbols = arch::resolve::resolve(&ast).expect("resolve");
+    let checker = arch::typecheck::TypeChecker::new(&symbols, &ast);
+    let (_w, overload_map) = checker.check().expect("type check");
+    let cg = Codegen::new(&symbols, &ast, overload_map);
+    let sv = cg.generate();
+
+    // Bus wire must decompose into flat signals.
+    assert!(sv.contains("logic [7:0] w_cmd;") && sv.contains("logic [7:0] w_resp;"),
+            "expected flat `w_cmd` / `w_resp` wires:\n{sv}");
+    // No `FooBus w;` placeholder left behind.
+    assert!(!sv.contains("FooBus w"),
+            "unexpected `FooBus w` decl (should be flattened):\n{sv}");
+    // Field access on bus wire rewrites to flat name.
+    assert!(sv.contains("assign w_cmd = x_in") || sv.contains("w_cmd = x_in"),
+            "expected `w_cmd = x_in` assignment:\n{sv}");
+    assert!(sv.contains("x_out = w_resp"),
+            "expected `x_out = w_resp` assignment:\n{sv}");
+    // Inst binding connects to the flat wires.
+    assert!(sv.contains(".p_cmd(w_cmd)") && sv.contains(".p_resp(w_resp)"),
+            "expected inst binding to flat wires:\n{sv}");
+}
+
 fn compile_to_pybind_cpps(source: &str) -> Vec<(String, String)> {
     use arch::sim_codegen::SimCodegen;
     let tokens = arch::lexer::tokenize(source).expect("lexer");


### PR DESCRIPTION
## Summary

\`wire w: FooBus;\` was previously rejected with \`type mismatch: expected type, found FooBus\`. Buses could only appear as ports with an \`initiator\`/\`target\` perspective. This blocked the natural pattern of connecting two sub-instances' bus ports via a common glue signal inside a parent module — forcing users to hand-split buses back into flat signals.

With this change, bus types are first-class in wire/reg positions. Direction info on each field is only semantically meaningful at port boundaries (initiator drives \`out\`, target drives \`in\`); in a wire/reg context each field has a single driver determined by whichever assignment reaches it.

## Why this matters

Surfaced in [rdl2arch-riscv](https://github.com/arch-hdl-lang/rdl2arch-riscv), which wanted to wire an access-controller's output bus directly into a CSR-file's input bus inside a test-only integrated top. Without bus wires, the only way to compose those two bus ports was to keep them flat at the submodule level — which forced [PR #9](https://github.com/arch-hdl-lang/rdl2arch-riscv/pull/9) to leave the access controller flat even though the CSR file moved to a handshake bus.

## Implementation

### Typecheck
\`resolve_type_expr\` accepts \`Symbol::Bus(_)\` and returns \`Ty::Bus(name)\`. \`Ty::Bus\` was already a first-class type for port annotations — it just wasn't reachable from the \`Named\` type resolution path used by wire/reg.

### Sim codegen (C++)
1. Emit a plain C++ \`struct FooBus { uint8_t cmd; uint8_t resp; }\` for every bus in the compilation unit, alongside user struct decls in \`VStructs.h\`. Uses \`effective_signals\` (flattened handshake channels + payloads) so handshake-bearing buses work too.
2. Bus-typed wires emit as \`FooBus _let_w;\` (now a valid C++ type).
3. \`expand_bus_connections\` gets a \`bus_wire_names\` set from the parent module. When the target of a whole-bus binding like \`child_port -> w\` is a bus wire, the synthesized per-signal connection uses \`FieldAccess(Ident(\"w\"), Ident(\"cmd\"))\` so \`cpp_expr\` lowers it to \`_let_w.cmd\`. Bus *ports* continue to use the flat \`<port>_<sig>\` naming since ports are always flattened in the C++ class.
4. Suppress the vestigial \`uint32_t <name>;\` shadow that was emitted for inst-output signal names when the name happens to be a bus wire.

### SV codegen
Bus wires decompose into individual SV signals \`<wire>_<field>\` at emission time (no SV interface/struct is generated for buses). A new \`bus_wires\` map mirrors the existing \`bus_ports\` map so FieldAccess on bus wires rewrites to the flat name, same as bus ports. Inst binding already used the flat \`<sig>_<field>\` pattern, so no change needed there.

## Test plan

- [x] **Unit**: \`test_bus_wire_typechecks_and_codegens\` — VStructs.h emits the bus struct; VParent.h has \`FooBus _let_w;\` and no shadow scalar.
- [x] **Unit**: \`test_bus_wire_sv_flattens_to_individual_signals\` — SV emits flat \`w_cmd\` / \`w_resp\`, field access rewrites, inst binding uses flat names.
- [x] **\`cargo test\`**: 88/88 passing (2 new + 86 existing).
- [x] **End-to-end functional**: pybind sim of \`Top → w: FooBus → inst Echo(+1)\` returns \`x_out = x_in + 1\` correctly.
- [x] **SV lint**: Verilator \`--lint-only\` clean on the emitted SV.
- [x] **Downstream**: \`rdl2arch-riscv\`'s 45-test suite still green against the new arch binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)