### PR TITLE
feat: accept bus declarations inside package blocks

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1316,6 +1316,7 @@ pub struct PackageDecl {
     pub domains: Vec<DomainDecl>,
     pub enums: Vec<EnumDecl>,
     pub structs: Vec<StructDecl>,
+    pub buses: Vec<BusDecl>,
     pub functions: Vec<FunctionDecl>,
     pub span: Span,
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -4669,6 +4669,7 @@ impl Parser {
         let mut domains = Vec::new();
         let mut enums = Vec::new();
         let mut structs = Vec::new();
+        let mut buses = Vec::new();
         let mut functions = Vec::new();
 
         while !self.check_end_keyword() {
@@ -4677,10 +4678,11 @@ impl Parser {
                 Some(TokenKind::Domain) => domains.push(self.parse_domain()?),
                 Some(TokenKind::Enum) => enums.push(self.parse_enum()?),
                 Some(TokenKind::Struct) => structs.push(self.parse_struct()?),
+                Some(TokenKind::Bus) => buses.push(self.parse_bus()?),
                 Some(TokenKind::Function) => functions.push(self.parse_function()?),
                 Some(other) => {
                     return Err(CompileError::unexpected_token(
-                        "param, domain, enum, struct, or function",
+                        "param, domain, enum, struct, bus, or function",
                         &other.to_string(),
                         self.peek_span(),
                     ));
@@ -4707,6 +4709,7 @@ impl Parser {
             domains,
             enums,
             structs,
+            buses,
             functions,
         })
     }

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -513,6 +513,22 @@ pub fn resolve(source_file: &SourceFile) -> Result<SymbolTable, Vec<CompileError
                             table.globals.insert(s.name.name.clone(), (Symbol::Struct(info), s.name.span));
                         }
                     }
+                    for b in &pkg.buses {
+                        if table.globals.contains_key(&b.name.name) {
+                            errors.push(CompileError::duplicate(&b.name.name, b.name.span));
+                        } else {
+                            let info = BusInfo {
+                                name: b.name.name.clone(),
+                                params: b.params.clone(),
+                                signals: b.signals.iter()
+                                    .map(|s| (s.name.name.clone(), s.direction, s.ty.clone()))
+                                    .collect(),
+                                generates: b.generates.clone(),
+                                handshakes: b.handshakes.clone(),
+                            };
+                            table.globals.insert(b.name.name.clone(), (Symbol::Bus(info), b.name.span));
+                        }
+                    }
                     for f in &pkg.functions {
                         let info = FunctionInfo {
                             name: f.name.name.clone(),

--- a/src/sim_codegen.rs
+++ b/src/sim_codegen.rs
@@ -6637,36 +6637,45 @@ impl<'a> SimCodegen<'a> {
         // module's assignment reaches it. Field directions only matter at
         // port boundaries, where the perspective (initiator/target) chooses
         // which side drives which field.
+        // Collect buses from both file scope AND packages. `bus` in a package
+        // is equivalent to file-scope `bus` — just grouped with the types
+        // that define the same package's interface.
+        let mut buses: Vec<&BusDecl> = Vec::new();
         for item in &self.source.items {
-            if let Item::Bus(b) = item {
-                let param_map: HashMap<String, &Expr> = HashMap::new();
-                let effective = crate::resolve::BusInfo {
-                    name: b.name.name.clone(),
-                    params: b.params.clone(),
-                    signals: b.signals.iter()
-                        .map(|p| (p.name.name.clone(), p.direction, p.ty.clone()))
-                        .collect(),
-                    generates: b.generates.clone(),
-                    handshakes: b.handshakes.clone(),
-                }.effective_signals(&param_map);
-                h.push_str(&format!("struct {} {{\n", b.name.name));
-                let mut field_inits = Vec::new();
-                for (sname, _dir, sty) in &effective {
-                    let ty = cpp_internal_type(sty);
-                    h.push_str(&format!("  {} {};\n", ty, sname));
-                    if matches!(sty, TypeExpr::Named(_)) {
-                        field_inits.push(format!("{}()", sname));
-                    } else {
-                        field_inits.push(format!("{}(0)", sname));
-                    }
-                }
-                if field_inits.is_empty() {
-                    h.push_str(&format!("  {}() {{}}\n", b.name.name));
-                } else {
-                    h.push_str(&format!("  {}() : {} {{}}\n", b.name.name, field_inits.join(", ")));
-                }
-                h.push_str("};\n\n");
+            match item {
+                Item::Bus(b) => buses.push(b),
+                Item::Package(p) => { for b in &p.buses { buses.push(b); } }
+                _ => {}
             }
+        }
+        for b in &buses {
+            let param_map: HashMap<String, &Expr> = HashMap::new();
+            let effective = crate::resolve::BusInfo {
+                name: b.name.name.clone(),
+                params: b.params.clone(),
+                signals: b.signals.iter()
+                    .map(|p| (p.name.name.clone(), p.direction, p.ty.clone()))
+                    .collect(),
+                generates: b.generates.clone(),
+                handshakes: b.handshakes.clone(),
+            }.effective_signals(&param_map);
+            h.push_str(&format!("struct {} {{\n", b.name.name));
+            let mut field_inits = Vec::new();
+            for (sname, _dir, sty) in &effective {
+                let ty = cpp_internal_type(sty);
+                h.push_str(&format!("  {} {};\n", ty, sname));
+                if matches!(sty, TypeExpr::Named(_)) {
+                    field_inits.push(format!("{}()", sname));
+                } else {
+                    field_inits.push(format!("{}(0)", sname));
+                }
+            }
+            if field_inits.is_empty() {
+                h.push_str(&format!("  {}() {{}}\n", b.name.name));
+            } else {
+                h.push_str(&format!("  {}() : {} {{}}\n", b.name.name, field_inits.join(", ")));
+            }
+            h.push_str("};\n\n");
         }
 
         SimModel {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -2489,6 +2489,99 @@ fn test_bus_wire_sv_flattens_to_individual_signals() {
             "expected inst binding to flat wires:\n{sv}");
 }
 
+#[test]
+fn test_bus_declaration_inside_package_parses() {
+    // `bus` is now accepted alongside `struct`, `enum`, etc. inside a
+    // `package` block. Previously the parser rejected this with
+    // "unexpected token: expected param, domain, enum, struct, or function".
+    let source = "
+        package MyPkg
+          struct Header
+            tag: UInt<4>;
+          end struct Header
+
+          bus MyBus
+            cmd_valid: out Bool;
+            cmd_data:  out UInt<8>;
+            rsp_data:  in  UInt<8>;
+          end bus MyBus
+        end package MyPkg
+    ";
+    let tokens = arch::lexer::tokenize(source).expect("lexer");
+    let mut parser = arch::parser::Parser::new(tokens, source);
+    let sf = parser.parse_source_file().expect("parse");
+    let pkg = sf.items.iter().find_map(|i|
+        if let arch::ast::Item::Package(p) = i { Some(p) } else { None }
+    ).expect("parsed package");
+    assert_eq!(pkg.structs.len(), 1, "struct should still parse alongside bus");
+    assert_eq!(pkg.buses.len(), 1, "bus should be collected into package.buses");
+    assert_eq!(pkg.buses[0].name.name, "MyBus");
+}
+
+#[test]
+fn test_package_nested_bus_used_as_wire_and_port() {
+    // End-to-end: a bus declared inside a package is (a) registered in the
+    // global symbol table, (b) usable as a wire type in a consumer module,
+    // (c) flattened at port sites on a target submodule, and (d) emitted as
+    // a C++ struct by sim codegen + flat SV wires by SV codegen.
+    let source = "
+        package MyPkg
+          bus MyBus
+            cmd_valid: out Bool;
+            cmd_data:  out UInt<8>;
+            rsp_data:  in  UInt<8>;
+          end bus MyBus
+        end package MyPkg
+
+        use MyPkg;
+
+        module Top
+          port x_in:  in  UInt<8>;
+          port x_out: out UInt<8>;
+          wire b: MyBus;
+          comb
+            b.cmd_valid = true;
+            b.cmd_data = x_in;
+            x_out = b.rsp_data;
+          end comb
+          inst e: Echo
+            p -> b;
+          end inst e
+        end module Top
+
+        module Echo
+          port p: target MyBus;
+          comb
+            p.rsp_data = p.cmd_valid ? (p.cmd_data + 8'h1).trunc<8>() : 8'h0;
+          end comb
+        end module Echo
+    ";
+    // Sim codegen: struct MyBus lands in VStructs header.
+    let sim_h = compile_to_sim_h(source, false);
+    assert!(sim_h.contains("struct MyBus {"),
+            "expected `struct MyBus` in sim structs header:\n{sim_h}");
+    assert!(sim_h.contains("uint8_t cmd_valid;") && sim_h.contains("uint8_t cmd_data;"),
+            "expected bus fields as struct members:\n{sim_h}");
+
+    // SV codegen: package emits no bus type; wires flatten to per-signal.
+    use arch::codegen::Codegen;
+    let tokens = arch::lexer::tokenize(source).expect("lexer");
+    let mut parser = arch::parser::Parser::new(tokens, source);
+    let ast = parser.parse_source_file().expect("parse");
+    let ast = arch::elaborate::elaborate(ast).expect("elaborate");
+    let symbols = arch::resolve::resolve(&ast).expect("resolve");
+    let checker = arch::typecheck::TypeChecker::new(&symbols, &ast);
+    let (_w, overload_map) = checker.check().expect("type check");
+    let cg = Codegen::new(&symbols, &ast, overload_map);
+    let sv = cg.generate();
+    assert!(sv.contains("logic b_cmd_valid;"),
+            "bus wire should flatten to b_cmd_valid:\n{sv}");
+    assert!(sv.contains("logic [7:0] b_cmd_data;"),
+            "bus wire should flatten to b_cmd_data:\n{sv}");
+    assert!(sv.contains(".p_cmd_data(b_cmd_data)"),
+            "inst binding should use flat wire names:\n{sv}");
+}
+
 fn compile_to_pybind_cpps(source: &str) -> Vec<(String, String)> {
     use arch::sim_codegen::SimCodegen;
     let tokens = arch::lexer::tokenize(source).expect("lexer");


### PR DESCRIPTION
## Summary

\`bus\` declarations were only allowed at file scope. Nesting one inside \`package My ... end package\` was rejected with \`unexpected token: expected param, domain, enum, struct, or function\`. This forced emitters wanting to group a bus with the types of the same package interface to split them across two grammar scopes — file-scope bus alongside a separate \`package ... end package\` block.

This PR lifts the restriction. A \`bus\` inside a \`package\` is equivalent in every way to a file-scope bus: same symbol-table registration, same codegen, same port-flattening behavior. At the SV output level nothing changes — buses remain compile-time abstractions (flattened at port sites) and the SV \`package\` block still only emits param / enum / struct / function.

## Motivation

Surfaced while working on [rdl2arch-riscv](https://github.com/arch-hdl-lang/rdl2arch-riscv): its package emits all the types defining the CSR interface (address enum + per-reg structs + hwif structs + CSR bus), but the bus had to live at file scope since the parser rejected it inside the package. Grouping it inside the package makes the emitted file reflect the logical boundary of "this is the pipeline interface this design exposes."

## Implementation

- **AST**: \`PackageDecl\` grows \`buses: Vec<BusDecl>\`.
- **Parser**: \`parse_package\` accepts \`TokenKind::Bus → parse_bus()\` alongside the existing kinds; error message updated.
- **Resolve**: package-item registration adds a \`for b in &pkg.buses\` arm that constructs the same \`Symbol::Bus(BusInfo { ... })\` entry as the file-scope path.
- **Sim codegen** (C++ bus struct emission — added in the earlier bus-as-wire PR): now iterates both file-scope \`Item::Bus\` AND \`Package { buses }\`.
- **SV codegen**: no change — emit_package still only emits param/enum/struct/function. Port flattening already queries the global symbol table, so it finds package-nested buses automatically.

## Test plan

- [x] **Unit**: \`test_bus_declaration_inside_package_parses\` — parser accepts the shape and collects buses into \`PackageDecl.buses\`.
- [x] **Unit**: \`test_package_nested_bus_used_as_wire_and_port\` — end-to-end: the bus is usable as a wire type in one module and a target port on another, emits a C++ struct in sim codegen, flattens to SV wires at each inst site.
- [x] **\`cargo test\`**: 90/90 passing (2 new + 88 existing).
- [x] **End-to-end functional**: Verilator sim and pybind sim both drive a Top with a package-nested-bus wire through a sub-instance echo module; all vectors match (\`x_in+1 mod 256\` = \`x_out\`).
- [x] **Downstream**: \`rdl2arch-riscv\`'s 45-test suite green against the new arch binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)