### PR TITLE
fix(typecheck): two bus/handshake lint false positives

### DIFF
--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -602,7 +602,15 @@ impl<'a> TypeChecker<'a> {
                             .collect())
                         .unwrap_or_default();
 
-                    // Check for unconnected ports on the instantiated construct
+                    // Check for unconnected ports on the instantiated construct.
+                    //
+                    // Bus ports can be connected in one of two shapes:
+                    //   (a) whole-bus: `p -> tb;` — connection.port_name == "p"
+                    //   (b) per-field: `p.cmd_valid <- x; p.cmd_addr <- y;` —
+                    //       the parser concatenates base.field, producing
+                    //       port_name == "p_cmd_valid", "p_cmd_addr", ...
+                    // For the per-field shape we consider the bus port connected
+                    // if any connection's port_name starts with `<bus_port>_`.
                     {
                         let child_ports: Option<&[PortDecl]> = self.source.items.iter()
                             .find_map(|item| match item {
@@ -619,12 +627,21 @@ impl<'a> TypeChecker<'a> {
                                 // Skip Clock and Reset ports — they may be handled via domain defaults
                                 let is_infra = matches!(&port.ty, TypeExpr::Clock(_) | TypeExpr::Reset(_, _));
                                 if is_infra { continue; }
-                                if !connected.contains(port.name.name.as_str()) {
+                                let name = port.name.name.as_str();
+                                let is_connected = if port.bus_info.is_some() {
+                                    // Accept whole-bus OR per-field bindings.
+                                    let prefix = format!("{}_", name);
+                                    connected.contains(name)
+                                        || connected.iter().any(|c| c.starts_with(&prefix))
+                                } else {
+                                    connected.contains(name)
+                                };
+                                if !is_connected {
                                     if port.direction == Direction::In {
                                         self.errors.push(CompileError::general(
                                             &format!(
                                                 "input port `{}` of `{}` is not connected in inst `{}`",
-                                                port.name.name, inst.module_name.name, inst.name.name
+                                                name, inst.module_name.name, inst.name.name
                                             ),
                                             inst.span,
                                         ));
@@ -632,7 +649,7 @@ impl<'a> TypeChecker<'a> {
                                         self.warnings.push(CompileWarning {
                                             message: format!(
                                                 "output port `{}` of `{}` is not connected in inst `{}`",
-                                                port.name.name, inst.module_name.name, inst.name.name
+                                                name, inst.module_name.name, inst.name.name
                                             ),
                                             span: inst.span,
                                         });
@@ -1100,9 +1117,21 @@ impl<'a> TypeChecker<'a> {
                 }
                 self.check_expr_for_unguarded_payload(base, enclosing, info, default_span);
             }
-            ExprKind::Binary(_, l, r) => {
+            ExprKind::Binary(op, l, r) => {
                 self.check_expr_for_unguarded_payload(l, enclosing, info, default_span);
-                self.check_expr_for_unguarded_payload(r, enclosing, info, default_span);
+                // Short-circuit `and` / `&`: the right-hand side only evaluates
+                // when the left-hand side is true, so `l` acts as an enclosing
+                // guard while we check `r`. Matches the recursive walk in
+                // `cond_contains_access` which also treats And/BitAnd as
+                // conjunction. `Or` does not short-circuit this way (either
+                // side can be the deciding operand), so leave it alone.
+                if matches!(op, BinOp::And | BinOp::BitAnd) {
+                    let mut extended: Vec<&Expr> = enclosing.to_vec();
+                    extended.push(l);
+                    self.check_expr_for_unguarded_payload(r, &extended, info, default_span);
+                } else {
+                    self.check_expr_for_unguarded_payload(r, enclosing, info, default_span);
+                }
             }
             ExprKind::Unary(_, e) => {
                 self.check_expr_for_unguarded_payload(e, enclosing, info, default_span);
@@ -1130,10 +1159,14 @@ impl<'a> TypeChecker<'a> {
             }
             ExprKind::Ternary(c, t, e) => {
                 self.check_expr_for_unguarded_payload(c, enclosing, info, default_span);
-                // Then/else branches of a ternary could also be tracked with
-                // `c`/`!c` as guards; v1 keeps this simple and only accepts
-                // if-statement guards. Extend later if a real case arises.
-                self.check_expr_for_unguarded_payload(t, enclosing, info, default_span);
+                // Then-branch only evaluates when `c` is true → treat `c` as
+                // an enclosing guard. Else-branch stays un-augmented because
+                // we can't easily synthesize `!c` as a condition the existing
+                // `cond_contains_access` walker understands (it only accepts
+                // positive AND-conjunctions of guard fields).
+                let mut then_encl: Vec<&Expr> = enclosing.to_vec();
+                then_encl.push(c);
+                self.check_expr_for_unguarded_payload(t, &then_encl, info, default_span);
                 self.check_expr_for_unguarded_payload(e, enclosing, info, default_span);
             }
             ExprKind::ExprMatch(s, arms) => {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -2582,6 +2582,150 @@ fn test_package_nested_bus_used_as_wire_and_port() {
             "inst binding should use flat wire names:\n{sv}");
 }
 
+#[test]
+fn test_bus_port_connected_via_per_field_bindings_no_warning() {
+    // Per-field bus port bindings at inst time — `p.cmd_valid <- ...;
+    // p.cmd_addr <- ...` — should count as the bus port being connected.
+    // Prior to this fix, the connectivity check only recognized whole-bus
+    // bindings and emitted a false-positive "output port `p` not connected"
+    // warning even when every field was wired explicitly.
+    let source = "
+        bus TestBus
+          cmd:  out UInt<8>;
+          resp: in  UInt<8>;
+        end bus TestBus
+
+        module Child
+          port p: target TestBus;
+          comb
+            p.resp = (p.cmd + 8'h1).trunc<8>();
+          end comb
+        end module Child
+
+        module Parent
+          port x_in:  in  UInt<8>;
+          port x_out: out UInt<8>;
+          inst c: Child
+            p.cmd  <- x_in;
+            p.resp -> x_out;
+          end inst c
+        end module Parent
+    ";
+    let ws = warnings_from(source);
+    assert!(!ws.iter().any(|m| m.contains("output port `p`")
+                               && m.contains("not connected")),
+            "per-field bus binding should not trigger 'not connected': {:?}", ws);
+}
+
+#[test]
+fn test_bus_port_unconnected_still_warns() {
+    // Confirm the gap-6 fix doesn't regress the real case: an inst that
+    // never mentions its bus port at all should still warn.
+    let source = "
+        bus TestBus
+          cmd:  out UInt<8>;
+          resp: in  UInt<8>;
+        end bus TestBus
+
+        module Child
+          port p: target TestBus;
+          comb
+            p.resp = p.cmd;
+          end comb
+        end module Child
+
+        module Parent
+          port x: in UInt<8>;
+          inst c: Child
+          end inst c
+        end module Parent
+    ";
+    let ws = warnings_from(source);
+    assert!(ws.iter().any(|m| m.contains("output port `p`")
+                              && m.contains("not connected")),
+            "completely-unbound bus port should still warn: {:?}", ws);
+}
+
+#[test]
+fn test_handshake_payload_guard_via_short_circuit_and() {
+    // `p.cmd_valid and (p.cmd_op != 0)` — the right-hand side of a
+    // short-circuit `and` is only evaluated when the left-hand side is
+    // true, so the checker must treat `p.cmd_valid` as an enclosing
+    // guard when descending into the right side.
+    let source = "
+        bus BusHS
+          handshake cmd: send kind: valid_ready
+            op: UInt<2>;
+          end handshake cmd
+        end bus BusHS
+
+        module Consumer
+          port b: target BusHS;
+          port o: out Bool;
+          comb
+            o = b.cmd_valid and (b.cmd_op != 2'b00);
+            b.cmd_ready = 1'b1;
+          end comb
+        end module Consumer
+    ";
+    let ws = warnings_from(source);
+    assert!(!ws.iter().any(|m| m.contains("cmd_op") && m.contains("unguarded")
+                               || (m.contains("cmd_op") && m.contains("outside"))),
+            "short-circuit `and` should guard cmd_op read; got: {:?}", ws);
+}
+
+#[test]
+fn test_handshake_payload_guard_via_ternary_condition() {
+    // Ternary: `cond ? then : else` — the then-branch only evaluates
+    // when cond is true, so the checker must treat cond as an enclosing
+    // guard when descending into the then-branch. Here the payload read
+    // `b.cmd_op` sits inside the then-branch with a cmd_valid guard.
+    let source = "
+        bus BusHS
+          handshake cmd: send kind: valid_ready
+            op: UInt<2>;
+          end handshake cmd
+        end bus BusHS
+
+        module Consumer
+          port b: target BusHS;
+          port o: out UInt<2>;
+          comb
+            o = b.cmd_valid ? b.cmd_op : 2'b00;
+            b.cmd_ready = 1'b1;
+          end comb
+        end module Consumer
+    ";
+    let ws = warnings_from(source);
+    assert!(!ws.iter().any(|m| m.contains("cmd_op") && m.contains("outside")),
+            "ternary condition should guard cmd_op read; got: {:?}", ws);
+}
+
+#[test]
+fn test_handshake_payload_truly_unguarded_still_warns() {
+    // Confirm the gap-7 fix doesn't weaken the real case: reading a
+    // payload with no valid guard anywhere must still warn.
+    let source = "
+        bus BusHS
+          handshake cmd: send kind: valid_ready
+            op: UInt<2>;
+          end handshake cmd
+        end bus BusHS
+
+        module Consumer
+          port b: target BusHS;
+          port o: out UInt<2>;
+          comb
+            o = b.cmd_op;
+            b.cmd_ready = 1'b1;
+          end comb
+        end module Consumer
+    ";
+    let ws = warnings_from(source);
+    assert!(ws.iter().any(|m| m.contains("cmd_op") && m.contains("outside")),
+            "genuinely unguarded cmd_op read should still warn: {:?}", ws);
+}
+
 fn compile_to_pybind_cpps(source: &str) -> Vec<(String, String)> {
     use arch::sim_codegen::SimCodegen;
     let tokens = arch::lexer::tokenize(source).expect("lexer");


### PR DESCRIPTION
## Summary

Two narrow false positives in the type checker's lint passes around bus ports and handshake payload staleness. Both fire on semantically correct code, forcing users to add noise or restructure around the checker. Surfaced during [rdl2arch-riscv](https://github.com/arch-hdl-lang/rdl2arch-riscv) development.

## Gap 6: bus-port connectivity recognizes per-field inst bindings

The connectivity check only recognized whole-bus bindings (\`p -> tb;\`) and warned \`output port 'p' not connected\` even when every field was explicitly wired:

\`\`\`arch
inst c: Child
  p.cmd_valid <- x;   // parser names this connection \"p_cmd_valid\"
  p.cmd_addr  <- y;   // etc.
  ...
end inst c
// → warning: output port \`p\` of \`Child\` is not connected in inst \`c\`
\`\`\`

**Fix**: when the child port has \`bus_info\`, consider it connected if any connection's port_name starts with \`<port>_\`. Preserves the warning for truly unbound buses.

## Gap 7: handshake payload staleness honors short-circuit guards

\`check_expr_for_unguarded_payload\` descends into \`Binary\` and \`Ternary\` subexpressions without propagating the short-circuit predicate as an enclosing guard. So this warned:

\`\`\`arch
o = b.cmd_valid and (b.cmd_op != 2'b00);
// → warning: handshake payload \`b.cmd_op\` is read outside an \`if b.cmd_valid\` guard
\`\`\`

…even though \`and\` short-circuits and \`b.cmd_op\` only evaluates when \`b.cmd_valid\` is true.

**Fix**: in \`Binary(And|BitAnd, l, r)\`, push \`l\` into enclosing when descending into \`r\`. In \`Ternary(c, t, _)\`, push \`c\` into enclosing when descending into the then-branch (else-branch stays unaugmented — no positive predicate derivable from \`!c\`). Preserves the warning for truly unguarded reads.

## Test plan

5 new regression tests:
- **Gap 6 positive**: per-field binding → no warning
- **Gap 6 negative**: completely unbound bus port → still warns
- **Gap 7 short-circuit AND**: \`valid and (op != 0)\` → no warning
- **Gap 7 ternary condition**: \`valid ? op : 0\` → no warning
- **Gap 7 negative**: plain \`o = op\` with no guard → still warns

- [x] \`cargo test\` — 95/95 passing (5 new + 90 existing)
- [x] Downstream \`rdl2arch-riscv\` 45/45 still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)