### PR TITLE
fix(sim --pybind): expose every module as its own importable .so

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -559,7 +559,14 @@ fn run_sim(
             _ => ".so".to_string(),
         };
 
-        // Compile shared library
+        // Compile shared library. All wrappers' .cpp files are linked into
+        // ONE shared object — each wrapper has its own `PYBIND11_MODULE` and
+        // therefore its own `PyInit_V<name>_pybind` symbol. Python's import
+        // system looks up `PyInit_<modname>` by the filename you load, so to
+        // expose each wrapper as its own importable module we name the .so
+        // after the first wrapper and then symlink every other wrapper's
+        // name to the same file. All symlinks share one physical .so but
+        // resolve distinct PyInit entry points.
         let so_path = build_dir.join(format!("{pybind_module_name}{ext_suffix}"));
         let mut cmd = std::process::Command::new("g++");
         cmd.arg("-std=c++17")
@@ -590,6 +597,42 @@ fn run_sim(
             std::process::exit(1);
         }
         eprintln!("Built: {}", so_path.display());
+
+        // Expose every remaining pybind wrapper by symlinking `<name>.so`
+        // onto the combined shared object. Python import resolves each
+        // symlink independently and finds the matching `PyInit_<name>`
+        // inside the shared library. Skip the first wrapper (already
+        // named correctly) and skip anything whose symlink would collide
+        // with the primary path.
+        let primary = so_path.file_name().and_then(|n| n.to_str()).map(|s| s.to_string());
+        for wrapper in pybind_wrappers.iter().skip(1) {
+            let alias = format!("{}{ext_suffix}", wrapper.class_name);
+            if primary.as_deref() == Some(alias.as_str()) { continue; }
+            let alias_path = build_dir.join(&alias);
+            // Remove any stale symlink / file so repeated builds don't fail
+            // on `already exists`.
+            if alias_path.exists() || fs::symlink_metadata(&alias_path).is_ok() {
+                let _ = fs::remove_file(&alias_path);
+            }
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::symlink;
+                if let Err(e) = symlink(&so_path.file_name().unwrap(), &alias_path) {
+                    eprintln!("warning: failed to symlink {alias}: {e}");
+                    continue;
+                }
+            }
+            #[cfg(not(unix))]
+            {
+                // Non-Unix: fall back to copying the shared object. Each
+                // module then occupies full disk space but stays importable.
+                if let Err(e) = fs::copy(&so_path, &alias_path) {
+                    eprintln!("warning: failed to copy {alias}: {e}");
+                    continue;
+                }
+            }
+            eprintln!("Built: {}", alias_path.display());
+        }
 
         // If --test is given, run the test file. The launcher:
         //   1. Executes the test file as `__main__` via `runpy.run_path` so


### PR DESCRIPTION
## Summary

\`arch sim --pybind\` on a multi-module design generated a pybind wrapper \`.cpp\` per module but only emitted ONE \`.so\`, named after the first wrapper. The .so's linker command included every wrapper's .cpp (so all \`PyInit_V<X>_pybind\` symbols were present inside), but Python's import system looks up the \`PyInit_<modname>\` matching the filename it loaded — siblings whose names didn't match the .so filename were silently dead code.

## Repro

\`\`\`
$ arch sim --pybind Adder.arch Subber.arch -o build
Generated pybind11 wrapper: build/VAdder_pybind.cpp
Generated pybind11 wrapper: build/VSubber_pybind.cpp
Compiling pybind11 module...
Built: build/VAdder_pybind.cpython-313-darwin.so
# (no VSubber_pybind.so — Python can't load VSubber)
\`\`\`

Downstream effect: users with multi-module designs had to invoke \`arch sim --pybind\` separately per module (re-emitting the same shared verilated .cpp files each time), or rely on undocumented source-order tricks to pick which module's wrapper got the single .so. Phase 4a of [rdl2arch-riscv](https://github.com/arch-hdl-lang/rdl2arch-riscv) did three separate invocations to work around this.

## Fix

Keep the single-link-step model (one physical .so with all wrappers' \`PYBIND11_MODULE\` symbols) and add a symlink per additional wrapper so each module name resolves through the filesystem to the same .so. Python load of \`V<X>_pybind\` follows the symlink and initializes the matching \`PyInit_V<X>_pybind\`.

- **Unix**: \`std::os::unix::fs::symlink\` creates a relative symlink to the primary filename.
- **Non-Unix**: falls back to \`fs::copy\` (disk-cheap for small files, keeps each module self-contained).

Stale symlinks from prior builds are removed before rewriting so repeated \`arch sim --pybind\` invocations don't fail.

## Verification

- **Multi-module toy** (\`Adder\` + \`Subber\` with \`+%\` / \`-%\` wrap ops): both .so files built, both independently loadable, each returns correct arithmetic results (10+3=13, 10-3=7).
- **rdl2arch-riscv**: the 4-file emission (pkg + CsrFile + CsrAccess + CsrTrapCoord) now produces 3 loadable .so files (one physical, two symlinks). All 45 rdl2arch-riscv tests still pass — the harness there currently uses one-invocation-per-module and continues to work, but can now be simplified to a single invocation in a follow-up.
- **\`cargo test\`**: 95/95 arch-com tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)