### PR TITLE
codegen: emit reset always_ff for orphan reset-only regs

### DIFF
--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -856,6 +856,15 @@ impl<'a> Codegen<'a> {
             }
         }
 
+        // Emit reset-only always_ff for any reg whose decl has a
+        // `reset` clause but which is never assigned in any seq block.
+        // Without this, a `reg X: T reset rst => V;` paired with no
+        // seq-block update vanishes from the emitted SV — the decl is
+        // kept but the reset never drives the flop, leaving it at X.
+        // That shape is common for spec-constant CSR fields
+        // (xdebugver, mhpmevent*, vendor/arch/impl IDs, etc.).
+        self.emit_orphan_reset_regs(&m_clone);
+
         // Emit guard-contract SVA: for each `reg ... guard <sig>`, prove that
         // whenever `<sig>` is high, the reg has been written at least once.
         // Uses a shadow `_<reg>_written` set on any seq-block commit (over-approx).
@@ -1620,6 +1629,158 @@ impl<'a> Codegen<'a> {
     /// Resolve a register's reset info: returns Some((signal_name, is_async, is_low))
     /// or None if the register has no reset.
     /// Extract the reset value expression from a RegReset variant.
+    /// Emit `always_ff` reset assignments for registers that have a
+    /// `reset` clause on their decl but are never assigned in any seq
+    /// block. Without this, the reset clause is silently dropped and
+    /// the flop sits at X after reset (Verilator lints as UNDRIVEN).
+    ///
+    /// Clock source: we prefer a clock that's already the `seq on
+    /// <clk>` for some RegBlock in this module (preserves clock-domain
+    /// grouping with the rest of the flops). If the module has no
+    /// RegBlocks at all, fall back to the first `Clock`-typed input
+    /// port — by construction that's the only clock the orphan reg can
+    /// belong to in a well-formed module.
+    ///
+    /// Orphans are grouped by (clock, reset_signal, is_async, is_low)
+    /// so each group becomes exactly one `always_ff`.
+    fn emit_orphan_reset_regs(&mut self, m: &ModuleDecl) {
+        // 1. Collect names assigned in any RegBlock.
+        let mut assigned_in_any_block = std::collections::BTreeSet::new();
+        for item in &m.body {
+            if let ModuleBodyItem::RegBlock(rb) = item {
+                Self::collect_assigned_roots(&rb.stmts, &mut assigned_in_any_block);
+            }
+        }
+
+        // 2. Find orphans: RegDecls with reset != None and not assigned.
+        #[derive(Debug)]
+        struct Orphan<'a> {
+            name: String,
+            init: String,
+            reset_signal: String,
+            is_async: bool,
+            is_low: bool,
+            ty: &'a TypeExpr,
+        }
+
+        let mut orphans: Vec<Orphan> = Vec::new();
+        for item in &m.body {
+            let ModuleBodyItem::RegDecl(r) = item else { continue };
+            if matches!(r.reset, RegReset::None) {
+                continue;
+            }
+            if assigned_in_any_block.contains(&r.name.name) {
+                continue;
+            }
+            let Some((signal, is_async, is_low)) = self.resolve_reg_reset(&r.reset, m) else {
+                // Reset resolution failed (malformed decl after typecheck —
+                // shouldn't happen, but guard anyway).
+                continue;
+            };
+            let val_expr = Self::reset_value_expr(&r.reset).expect("non-None reset has value");
+            let init = self.emit_expr_str(val_expr);
+            orphans.push(Orphan {
+                name: r.name.name.clone(),
+                init,
+                reset_signal: signal,
+                is_async,
+                is_low,
+                ty: &r.ty,
+            });
+        }
+
+        if orphans.is_empty() {
+            return;
+        }
+
+        // 3. Pick a clock. Prefer one used by an existing RegBlock so
+        // the orphans land in the same clock domain as the other
+        // flops. Fall back to the first Clock-typed input port.
+        let rb_clock: Option<&Ident> = m.body.iter().find_map(|i| {
+            if let ModuleBodyItem::RegBlock(rb) = i { Some(&rb.clock) } else { None }
+        });
+        let port_clock = m.ports.iter()
+            .find(|p| matches!(&p.ty, TypeExpr::Clock(_)))
+            .map(|p| &p.name);
+        let Some(clock_ident) = rb_clock.or(port_clock) else {
+            // No clock available — can't emit a clocked reset. Leave
+            // the reg as-is; Verilator will still warn, but that's
+            // a more fundamental design issue the user needs to fix.
+            return;
+        };
+        let clk_name = &clock_ident.name;
+
+        // 4. Group by (reset_signal, is_async, is_low). We collapse
+        // orphans into one always_ff per group.
+        let mut groups: std::collections::BTreeMap<(String, bool, bool), Vec<&Orphan>> =
+            std::collections::BTreeMap::new();
+        for o in &orphans {
+            groups.entry((o.reset_signal.clone(), o.is_async, o.is_low))
+                .or_default()
+                .push(o);
+        }
+
+        // 5. Emit one always_ff per group.
+        for ((reset_signal, is_async, is_low), group) in &groups {
+            let rst_cond = if *is_low {
+                format!("(!{})", reset_signal)
+            } else {
+                reset_signal.clone()
+            };
+            if *is_async {
+                let rst_edge = if *is_low { "negedge" } else { "posedge" };
+                self.line(&format!(
+                    "always_ff @(posedge {} or {} {}) begin",
+                    clk_name, rst_edge, reset_signal
+                ));
+            } else {
+                self.line(&format!("always_ff @(posedge {}) begin", clk_name));
+            }
+            self.indent += 1;
+            self.line(&format!("if ({}) begin", rst_cond));
+            self.indent += 1;
+            for o in group {
+                self.emit_reset_only_assignment(o.name.as_str(), o.ty, o.init.as_str());
+            }
+            self.indent -= 1;
+            self.line("end");
+            self.indent -= 1;
+            self.line("end");
+        }
+    }
+
+    /// Emit a single `<name> <= <init>;` with for-loop unpacking if the
+    /// reg is a Vec (unpacked array). Mirrors the per-name emission in
+    /// `emit_reg_block`'s reset branch, just factored out for reuse.
+    fn emit_reset_only_assignment(&mut self, name: &str, ty: &TypeExpr, init: &str) {
+        // Collect Vec dimensions (outermost first — same order as the
+        // SV unpacked-array suffix).
+        let mut dims: Vec<String> = Vec::new();
+        let mut t = ty;
+        while let TypeExpr::Vec(inner, size) = t {
+            dims.push(self.emit_expr_str(size));
+            t = inner;
+        }
+        if dims.is_empty() {
+            self.line(&format!("{name} <= {init};"));
+            return;
+        }
+        let idx_vars: Vec<String> = (0..dims.len()).map(|d| format!("__ri{d}")).collect();
+        for (d, dim_size) in dims.iter().enumerate() {
+            self.line(&format!(
+                "for (int {} = 0; {} < {}; {}++) begin",
+                idx_vars[d], idx_vars[d], dim_size, idx_vars[d]
+            ));
+            self.indent += 1;
+        }
+        let idx_str: String = idx_vars.iter().map(|v| format!("[{v}]")).collect();
+        self.line(&format!("{name}{idx_str} <= {init};"));
+        for _ in 0..dims.len() {
+            self.indent -= 1;
+            self.line("end");
+        }
+    }
+
     fn reset_value_expr(reset: &RegReset) -> Option<&Expr> {
         match reset {
             RegReset::None => None,

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -891,6 +891,89 @@ end module MixedReset
 }
 
 #[test]
+fn test_reset_only_reg_is_driven() {
+    // A `reg` declared with a reset clause but never assigned in any seq
+    // block should still get its reset value emitted into an always_ff.
+    // Without this, Verilator lints the reg as undriven and the flop sits
+    // at X after reset — which silently breaks spec-common RO-constant
+    // CSRs (xdebugver, mvendorid, mhpmevent*, etc. — the pattern
+    // `field { sw = r; hw = r; reset = <const>; }` compiles to a reg
+    // whose reset value is the only thing that ever writes it).
+    let source = r#"
+domain SysDomain
+  freq_mhz: 100
+end domain SysDomain
+
+module RoConst
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port out_val: out UInt<32>;
+
+  reg roconst_r: UInt<32> reset rst=>32'h4;
+
+  comb
+    out_val = roconst_r;
+  end comb
+end module RoConst
+"#;
+    let sv = compile_to_sv(source);
+    // The reset value must be driven somewhere in an always_ff.
+    assert!(sv.contains("always_ff @(posedge clk)"),
+        "expected an always_ff for the reset-only reg, got:\n{sv}");
+    assert!(sv.contains("if (rst)"),
+        "expected reset guard, got:\n{sv}");
+    // arch-com emits the literal as decimal; accept either form since
+    // what matters is that the RHS is the reset value (4).
+    assert!(sv.contains("roconst_r <= 32'd4;") || sv.contains("roconst_r <= 32'h4;"),
+        "expected roconst_r reset-init assignment, got:\n{sv}");
+    insta::assert_snapshot!(sv);
+}
+
+#[test]
+fn test_reset_only_reg_alongside_seq_block() {
+    // Module has an active seq block driving one reg AND an orphan
+    // reset-only reg. The orphan needs its own always_ff without
+    // disturbing the existing seq-block-generated one.
+    let source = r#"
+domain SysDomain
+  freq_mhz: 100
+end domain SysDomain
+
+module MixedOrphan
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port data_in: in UInt<8>;
+  port ticker_out: out UInt<8>;
+  port const_out: out UInt<32>;
+
+  reg ticker_r: UInt<8> init 0 reset rst=>0;
+  reg constant_r: UInt<32> reset rst=>32'd42;
+
+  seq on clk rising
+    ticker_r <= data_in;
+  end seq
+
+  comb
+    ticker_out = ticker_r;
+    const_out  = constant_r;
+  end comb
+end module MixedOrphan
+"#;
+    let sv = compile_to_sv(source);
+    // Original seq-block always_ff resets ticker_r.
+    assert!(sv.contains("ticker_r <= 0;"),
+        "expected ticker_r reset in seq-block always_ff, got:\n{sv}");
+    // Orphan reset always_ff fires for constant_r.
+    assert!(sv.contains("constant_r <= 32'd42;"),
+        "expected constant_r orphan reset assignment, got:\n{sv}");
+    // Two distinct always_ff blocks — one for each.
+    let always_count = sv.matches("always_ff @").count();
+    assert!(always_count >= 2,
+        "expected >=2 always_ff blocks (seq + orphan), got {always_count}:\n{sv}");
+    insta::assert_snapshot!(sv);
+}
+
+#[test]
 fn test_reset_consistency_error_mixed_signals() {
     let source = r#"
 domain SysDomain

--- a/tests/snapshots/integration_test__reset_only_reg_alongside_seq_block.snap
+++ b/tests/snapshots/integration_test__reset_only_reg_alongside_seq_block.snap
@@ -1,0 +1,33 @@
+---
+source: tests/integration_test.rs
+expression: sv
+---
+// domain SysDomain
+//   freq_mhz: 100
+
+module MixedOrphan (
+  input logic clk,
+  input logic rst,
+  input logic [7:0] data_in,
+  output logic [7:0] ticker_out,
+  output logic [31:0] const_out
+);
+
+  logic [7:0] ticker_r = 0;
+  logic [31:0] constant_r;
+  always_ff @(posedge clk) begin
+    if (rst) begin
+      ticker_r <= 0;
+    end else begin
+      ticker_r <= data_in;
+    end
+  end
+  assign ticker_out = ticker_r;
+  assign const_out = constant_r;
+  always_ff @(posedge clk) begin
+    if (rst) begin
+      constant_r <= 32'd42;
+    end
+  end
+
+endmodule

--- a/tests/snapshots/integration_test__reset_only_reg_is_driven.snap
+++ b/tests/snapshots/integration_test__reset_only_reg_is_driven.snap
@@ -1,0 +1,22 @@
+---
+source: tests/integration_test.rs
+expression: sv
+---
+// domain SysDomain
+//   freq_mhz: 100
+
+module RoConst (
+  input logic clk,
+  input logic rst,
+  output logic [31:0] out_val
+);
+
+  logic [31:0] roconst_r;
+  assign out_val = roconst_r;
+  always_ff @(posedge clk) begin
+    if (rst) begin
+      roconst_r <= 32'd4;
+    end
+  end
+
+endmodule


### PR DESCRIPTION
## Summary

A register declared as `reg X: T reset rst => V;` with no corresponding seq-block update was silently dropped from the emitted SystemVerilog — the decl survived, but the reset never drove the flop, leaving it at X under Verilator (UNDRIVEN lint) and at whatever init value the tool defaults to.

This shows up in any spec-constant HDL register:
- Debug spec 0.13.2 mandates `dcsr.xdebugver = 0x4`.
- RISC-V HPM event selectors hardwire `mhpmeventN = 1 << (N - 3)`.
- `mvendorid`, `marchid`, `mimpid`, `mconfigptr` are all reset-value-only.
- Any `field { sw = r; hw = r; reset = <const>; }` in a RISC-V RDL maps to exactly this shape.

## Root cause

`emit_reg_block` in `src/codegen.rs` only emits an `always_ff` reset branch for registers that are assigned somewhere in that block's seq statements. Registers with reset clauses but no seq-block assignments were invisible to the reset pass.

## Fix

Added `emit_orphan_reset_regs` — runs after the main body-items loop. Collects every RegDecl with a reset clause whose name wasn't assigned in any RegBlock, groups the orphans by (clock, reset signal, async/sync, polarity), and emits one residual `always_ff` per group with just the reset-time assignments.

Clock source selection, in order:
1. Re-use a clock from an existing RegBlock in this module (keeps orphans in the same clock domain as other flops).
2. Fall back to the module's first `Clock`-typed input port (when there are no seq blocks at all).

Vec (unpacked-array) regs get the same nested for-loop reset as `emit_reg_block` produces.

## Test coverage

Two new `integration_test.rs` cases:

- `test_reset_only_reg_is_driven`: module whose only reg is reset-only. Confirms the residual `always_ff` appears and drives the reset value instead of leaving the flop undriven.
- `test_reset_only_reg_alongside_seq_block`: module with both a seq-driven reg and a reset-only reg. Confirms two distinct `always_ff` blocks exist and neither disturbs the other.

## Test plan

- [x] `cargo test` — **121/121 pass** (+2 new)
- [x] `cargo test test_reset_only_reg_is_driven` — passes with the fix, fails without it (I wrote the failing test first)
- [x] Existing `test_mixed_reset_and_no_reset` and `test_active_low_reset` still pass

## Downstream

Surfaced while working on `rdl2arch-riscv`'s Ibex integration. RISC-V RDL fixtures like `mhpmevent3..12` (reads `1 << (N - 3)` hardwired) and `dcsr.xdebugver` (reads `0x4`) compile to exactly this orphan-reset shape. With the fix, those generate clean SV that Verilator doesn't lint as undriven.

One note for clock-gated designs: Ibex gates its internal `u_ibex_top.clk` based on `core_busy | debug_req | irq_pending | irq_nm`, which is off during reset. A reset-only flop on that gated clock never sees a posedge to latch its value. That's an integration-level concern (caller should use an ungated clock or an always-on hwif_in drive), not a codegen concern — the fix here is still correct for non-clock-gated designs and is the right default behaviour.