### PR TITLE
feat: pipe_reg<T,N> port type + @N latency operator (PR #1)

### DIFF
--- a/doc/ARCH_HDL_Specification.md
+++ b/doc/ARCH_HDL_Specification.md
@@ -932,6 +932,35 @@ Arch has three kinds of module-scope signal declarations. Each has a distinct sy
 
 **`port reg`** declares an output port that is also a register, eliminating the common `reg r` + `comb out = r; end comb` boilerplate. The syntax is `port reg name: out T [init V] [reset R=>V];`. It can only be used on output ports (`in` direction is a compile error). The port is assigned with `<=` inside a `seq` block, just like a regular `reg`. If `reg default:` is in scope, it inherits the default init and reset. In generated SV, the port is declared as `output logic [W-1:0] name` and driven directly in the `always_ff` block.
 
+**`pipe_reg<T, N>` port type** — the preferred spelling for a registered output port, with latency `N` visible in the port signature. This is the recommended replacement for `port reg`; `port reg` remains accepted and is exactly equivalent to `port q: out pipe_reg<T, 1>`.
+
+```
+port q: out pipe_reg<UInt<8>, 1> reset rst => 0;    // 1-cycle registered output (same as `port reg q: out UInt<8>`)
+port q: out pipe_reg<UInt<8>, 3> reset rst => 0;    // 3-cycle output pipe (cascade of 3 flops)
+port q: out pipe_reg<UInt<8>, 2> init 0;            // 2-cycle pipe with init (no reset)
+```
+
+The `N` parameter is a compile-time integer literal (≥ 1). `pipe_reg<T, 0>` is a compile error — use the plain `port q: out T;` form for a combinational output.
+
+**Assignment uses the `@N` operator** to make latency visible at every write site. The assignment `q@N <= Y` reads as "Y will appear at q's output N cycles from now," and `N` must equal the port's declared depth:
+
+```
+port q: out pipe_reg<UInt<8>, 3> reset rst => 0;
+seq on clk rising
+  q@3 <= next_q;      // next_q reaches q in 3 cycles
+end seq
+```
+
+For N = 1, the bare assignment form `q <= Y` is also accepted (same flop count as `port reg`). For N > 1, only `q@N <= Y` is valid — bare `q <= Y` is a compile error (*"assignment to pipe_reg port `q` is ambiguous — write `q@N <= ...` to state the latency"*).
+
+**Reading** a `pipe_reg` port on the RHS returns the final-output stage. The explicit form `q@0` reads as "current value" and is equivalent to bare `q`. Reading intermediate stages (`q@K` for K > 0 on the RHS) is a compile error in v1 — *"reading intermediate stage `@K` is not yet supported"*.
+
+**Uniform reset / init across stages.** A single `reset R => V` or `init V` clause applies to every flop in the chain. When `rst` asserts, all N stages simultaneously drop to the reset value; one cycle after deassert, a new write to `q@N` begins propagating. This matches today's module-scope `pipe_reg` semantics.
+
+**Lowering**. For N = 1, the SV output is byte-identical to `port reg`: a single `always_ff` with one assignment. For N > 1, the compiler synthesizes `N - 1` intermediate registers named `q_stg1` ... `q_stg{N-1}` and emits a cascade inside one `always_ff` block, with the reset branch covering every stage.
+
+*Why `pipe_reg<T, N>`* — registered outputs have tripped LLM agents because the keyword `port reg` places the latency information *outside* the signature. With `pipe_reg<T, N>`, every reader of the port list sees the depth in the type; every writer sees it in the `@N` at the assignment. This eliminates a common off-by-one class of testbench bugs.
+
 **`guard` clause** — `reg NAME: T guard VALID_SIG [init V] [reset R=>V];` declares that the register is intentionally uninitialized as long as `VALID_SIG` is low. This is the canonical valid-data pattern: a wide data register stays reset-free (saving area and power) while a companion valid flag gates consumers. The `guard` clause goes right after the type, before any `init` or `reset` clause. `VALID_SIG` must be a single identifier — for multi-signal predicates, combine them via a `let` binding first. `port reg` supports the same clause.
 
 ```

--- a/doc/Arch_AI_Reference_Card.md
+++ b/doc/Arch_AI_Reference_Card.md
@@ -58,16 +58,23 @@ reg r: UInt<8>;                      // inherits reset from reg default
 reg data: UInt<32> guard valid_r;    // guarded (no reset) — valid_r tells consumers when data is live;
                                      //   --check-uninit silences spurious read warnings AND catches the
                                      //   producer bug (valid_r=true but data never written)
-port reg q: out UInt<8> reset rst => 0;  // output port + register combined (1-cycle output latency)
-port reg q: out UInt<8>;             // inherits reset from reg default
-port reg dout: out UInt<32> guard dout_valid;  // port form of guarded reg
-pipe_reg delayed: source stages 3;  // N-stage delay chain, type inferred
+// Registered output port — latency is visible in the port signature.
+// Assign with `@N <= Y` in seq; reads as "Y will be in q N cycles from now".
+port q: out pipe_reg<UInt<8>, 1> reset rst => 0;    // 1-cycle registered output
+port q: out pipe_reg<UInt<8>, 3> reset rst => 0;    // 3-cycle output pipe
+                                                     // q@N <= Y in seq; bare q <= Y is an error for N>1
 
-// OUTPUT TIMING: port reg vs port (critical for FSM outputs)
-//   port reg o: out T  → driven in seq (<=), output lags state by 1 cycle
-//   port     o: out T  → driven in comb (=) or let, output reflects state same cycle
-// Use plain port + comb for zero-latency FSM outputs (e.g. cocotb expects same-cycle response)
-// Use port reg for glitch-free registered outputs (adds 1-cycle pipeline delay)
+// Legacy `port reg` still accepted (equivalent to pipe_reg<T, 1>).
+port reg q: out UInt<8> reset rst => 0;              // 1-cycle registered output
+port reg dout: out UInt<32> guard dout_valid;        // port form of guarded reg
+pipe_reg delayed: source stages 3;                   // N-stage internal delay chain
+
+// OUTPUT TIMING (critical for FSM outputs):
+//   port q: out T                   → comb (=), output reflects state same cycle
+//   port q: out pipe_reg<T, 1> ...  → seq q@1 <= ...; 1-cycle latency
+//   port q: out pipe_reg<T, N> ...  → seq q@N <= ...; N-cycle latency (cascade)
+// Use plain port + comb for zero-latency FSM outputs (e.g. cocotb expects same-cycle response).
+// Use pipe_reg<T, N> for glitch-free registered outputs; N visible to LLMs in the signature.
 
 default seq on clk rising;           // set default clock for all seq blocks
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -182,7 +182,9 @@ pub enum SharedReduction {
     And,
 }
 
-/// Register metadata for a `port reg` declaration.
+/// Register metadata for a `port reg` declaration OR a
+/// `port X: out pipe_reg<T, N>` declaration (the latter carries
+/// `latency = N`; legacy `port reg` implies `latency = 1`).
 #[derive(Debug, Clone)]
 pub struct PortRegInfo {
     pub init: Option<Expr>,
@@ -191,6 +193,10 @@ pub struct PortRegInfo {
     /// uninitialized as long as the guard signal is low. See
     /// `doc/plan_reg_guard_syntax.md` for semantics.
     pub guard: Option<Ident>,
+    /// Pipeline depth (number of clock edges between internal write and
+    /// external observation). Legacy `port reg` syntax: 1.
+    /// New `port X: out pipe_reg<T, N>` syntax: N (≥ 1).
+    pub latency: u32,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -701,6 +707,12 @@ pub enum ExprKind {
     Clog2(Box<Expr>),
     /// onehot(index) — one-hot decode: 1 << index. Width inferred from context.
     Onehot(Box<Expr>),
+    /// `expr @ N` — latency annotation. On LHS of a seq assignment, marks
+    /// the cycle offset at which the write materializes (e.g. `q@3 <= Y`
+    /// reads as "Y arrives at q's output in 3 cycles"). On RHS, names the
+    /// stage (v1: only `@0` as explicit "current value"). Typecheck enforces
+    /// placement and N validity based on the signal's declared pipe depth.
+    LatencyAt(Box<Expr>, u32),
     /// signed(expr) — same-width reinterpret cast to SInt.
     Signed(Box<Expr>),
     /// unsigned(expr) — same-width reinterpret cast to UInt.

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -2050,6 +2050,7 @@ impl<'a> Codegen<'a> {
             ExprKind::Ident(n) => n.clone(),
             ExprKind::FieldAccess(base, _) => Self::expr_root_name(base),
             ExprKind::Index(base, _) | ExprKind::BitSlice(base, _, _) | ExprKind::PartSelect(base, _, _, _) => Self::expr_root_name(base),
+            ExprKind::LatencyAt(inner, _) => Self::expr_root_name(inner),
             _ => String::new(),
         }
     }
@@ -5530,6 +5531,12 @@ impl<'a> Codegen<'a> {
     /// Core expression emitter — never adds outer parens itself.
     fn emit_expr_inner(&self, expr: &Expr) -> String {
         match &expr.kind {
+            // Latency annotation is purely documentary on emission.
+            // On RHS, `q@0` reads as the current value of `q` (the pipe's
+            // final output). On LHS inside an assignment, the enclosing
+            // assignment emitter strips the annotation before routing the
+            // value to the appropriate stage 0 of the pipe chain.
+            ExprKind::LatencyAt(inner, _) => self.emit_expr_inner(inner),
             ExprKind::Literal(lit) => match lit {
                 LitKind::Dec(v) => format!("{v}"),
                 LitKind::Hex(v) => format!("'h{v:X}"),

--- a/src/elaborate.rs
+++ b/src/elaborate.rs
@@ -1323,6 +1323,7 @@ fn lower_module_threads(m: ModuleDecl) -> Result<(ModuleDecl, Vec<Item>), Vec<Co
                 ty: info.ty.clone(), default: None,
                 reg_info: Some(PortRegInfo {
                     init: info.reg_init.clone(), reset: info.reg_reset.clone(), guard: None,
+                    latency: 1,
                 }),
                 bus_info: None, shared: None, span: sp,
             });
@@ -3173,3 +3174,369 @@ fn rename_ident_in_comb_stmts(stmts: &mut [CombStmt], old: &str, new: &str) {
 fn make_zero_expr(sp: Span) -> Expr {
     Expr::new(ExprKind::Literal(LitKind::Dec(0)), sp)
 }
+
+// ── pipe_reg<T, N> port lowering ─────────────────────────────────────────
+//
+// Expand every `port q: out pipe_reg<T, N>` with N > 1 into:
+//   - The original port keeps `latency = 1` (emits as today's `port reg`)
+//   - N-1 synthesized regs `q_stg1` .. `q_stg{N-1}` of type T
+//   - Every `q@N <= expr` is rewritten to the cascade:
+//         q_stg1 <= expr;
+//         q_stg2 <= q_stg1;
+//         ...
+//         q      <= q_stg{N-1};
+//
+// Reset/init propagate from the original port's reg_info to every
+// intermediate reg (uniform behavior — all stages reset to the same value,
+// matching today's pipe_reg semantics).
+//
+// Called from main.rs after `lower_threads` so every other elaboration
+// pass sees the original unexpanded form.
+
+pub fn lower_pipe_reg_ports(ast: SourceFile) -> Result<SourceFile, Vec<CompileError>> {
+    let mut new_items: Vec<Item> = Vec::with_capacity(ast.items.len());
+    let mut errors: Vec<CompileError> = Vec::new();
+    for item in ast.items {
+        match item {
+            Item::Module(m) => match lower_pipe_reg_module(m) {
+                Ok(new_m) => new_items.push(Item::Module(new_m)),
+                Err(mut errs) => errors.append(&mut errs),
+            },
+            other => new_items.push(other),
+        }
+    }
+    if !errors.is_empty() { return Err(errors); }
+    Ok(SourceFile { items: new_items })
+}
+
+struct PipePortInfoLocal {
+    name: String,
+    latency: u32,
+    ty: TypeExpr,
+    reset: RegReset,
+    init: Option<Expr>,
+    span: Span,
+}
+
+fn lower_pipe_reg_module(mut m: ModuleDecl) -> Result<ModuleDecl, Vec<CompileError>> {
+    // Collect metadata for every pipe_reg port (latency >= 1).
+    // Ports with latency == 1 still participate in the @N validation —
+    // legacy `port reg` is equivalent to `pipe_reg<T, 1>`.
+    let mut all_pipe_ports: Vec<PipePortInfoLocal> = Vec::new();
+    for p in &m.ports {
+        if let Some(ri) = &p.reg_info {
+            all_pipe_ports.push(PipePortInfoLocal {
+                name: p.name.name.clone(),
+                latency: ri.latency,
+                ty: p.ty.clone(),
+                reset: ri.reset.clone(),
+                init: ri.init.clone(),
+                span: p.span,
+            });
+        }
+    }
+    // Validation: walk every seq assignment. Errors for
+    //   - q@N <= Y when N != declared depth
+    //   - bare q <= Y on pipe_reg with depth > 1 (ambiguous)
+    //   - q@K on RHS for K > 0 (intermediate stage reads not supported v1)
+    //   - q@0 = Y on combinational port (not a pipe_reg)
+    let mut errors: Vec<CompileError> = Vec::new();
+    for bi in &m.body {
+        if let ModuleBodyItem::RegBlock(rb) = bi {
+            validate_pipe_assignments(&rb.stmts, &all_pipe_ports, &mut errors);
+        }
+        if let ModuleBodyItem::CombBlock(cb) = bi {
+            validate_comb_pipe_refs(&cb.stmts, &all_pipe_ports, &m.ports, &mut errors);
+        }
+    }
+    if !errors.is_empty() { return Err(errors); }
+
+    // Filter to ports that actually need the cascade expansion (latency > 1).
+    let pipes: Vec<PipePortInfoLocal> = all_pipe_ports.into_iter()
+        .filter(|pp| pp.latency > 1)
+        .collect();
+    if pipes.is_empty() {
+        return Ok(m);
+    }
+    // Collapse each pipe port to latency=1 (so it emits as a regular port-reg).
+    for p in &mut m.ports {
+        if let Some(ri) = &mut p.reg_info {
+            if ri.latency > 1 {
+                ri.latency = 1;
+            }
+        }
+    }
+
+    // For each pipe port, insert N-1 RegDecls for the intermediate stages.
+    let mut extra_body: Vec<ModuleBodyItem> = Vec::new();
+    for pp in &pipes {
+        for stage in 1..pp.latency {
+            let stg_name = format!("{}_stg{}", pp.name, stage);
+            extra_body.push(ModuleBodyItem::RegDecl(RegDecl {
+                name: Ident::new(stg_name, pp.span),
+                ty: pp.ty.clone(),
+                init: pp.init.clone(),
+                reset: pp.reset.clone(),
+                guard: None,
+                span: pp.span,
+            }));
+        }
+    }
+
+    // Rewrite every `q@N <= expr` assignment inside seq/reg blocks into the
+    // cascade. The rewrite happens recursively through if/match/for bodies.
+    for bi in &mut m.body {
+        if let ModuleBodyItem::RegBlock(rb) = bi {
+            rb.stmts = rewrite_seq_stmts(std::mem::take(&mut rb.stmts), &pipes);
+        }
+    }
+
+    // Prepend the synthesized regs just before the first RegBlock, so
+    // module-body ordering stays sane (regs before seq blocks by
+    // convention).
+    let mut new_body: Vec<ModuleBodyItem> = Vec::with_capacity(m.body.len() + extra_body.len());
+    let mut inserted = false;
+    for bi in m.body {
+        if !inserted && matches!(bi, ModuleBodyItem::RegBlock(_)) {
+            new_body.extend(extra_body.drain(..));
+            inserted = true;
+        }
+        new_body.push(bi);
+    }
+    if !inserted {
+        new_body.extend(extra_body.drain(..));
+    }
+    m.body = new_body;
+    Ok(m)
+}
+
+// Validation helpers for @N placement / depth consistency.
+
+fn validate_pipe_assignments(
+    stmts: &[Stmt],
+    ports: &[PipePortInfoLocal],
+    errors: &mut Vec<CompileError>,
+) {
+    for s in stmts {
+        validate_pipe_assign_stmt(s, ports, errors);
+    }
+}
+
+fn validate_pipe_assign_stmt(
+    stmt: &Stmt,
+    ports: &[PipePortInfoLocal],
+    errors: &mut Vec<CompileError>,
+) {
+    match stmt {
+        Stmt::Assign(a) => {
+            // Inspect the target: LatencyAt(Ident, N) or bare Ident into a
+            // pipe_reg port. Validate per the error matrix.
+            let (target_name, latency_opt) = match &a.target.kind {
+                ExprKind::LatencyAt(inner, n) => match &inner.kind {
+                    ExprKind::Ident(name) => (name.clone(), Some(*n)),
+                    _ => return,
+                },
+                ExprKind::Ident(name) => (name.clone(), None),
+                _ => return,
+            };
+            let Some(pp) = ports.iter().find(|p| p.name == target_name) else { return; };
+            match latency_opt {
+                Some(n) if n != pp.latency => {
+                    errors.push(CompileError::general(
+                        &format!(
+                            "`{name}@{n}` exceeds declared latency {depth} — write `{name}@{depth} <= ...` for this port",
+                            name = pp.name, n = n, depth = pp.latency
+                        ),
+                        a.span,
+                    ));
+                }
+                None if pp.latency > 1 => {
+                    errors.push(CompileError::general(
+                        &format!(
+                            "assignment to pipe_reg port `{name}` is ambiguous — write `{name}@{depth} <= ...` to state the latency",
+                            name = pp.name, depth = pp.latency
+                        ),
+                        a.span,
+                    ));
+                }
+                _ => {}
+            }
+            // Validate RHS too — no @K for K > 0 in v1.
+            validate_rhs_latency(&a.value, errors);
+        }
+        Stmt::IfElse(ie) => {
+            validate_pipe_assignments(&ie.then_stmts, ports, errors);
+            validate_pipe_assignments(&ie.else_stmts, ports, errors);
+        }
+        Stmt::Match(m) => {
+            for arm in &m.arms {
+                validate_pipe_assignments(&arm.body, ports, errors);
+            }
+        }
+        Stmt::For(f) => validate_pipe_assignments(&f.body, ports, errors),
+        Stmt::Init(ib) => validate_pipe_assignments(&ib.body, ports, errors),
+        _ => {}
+    }
+}
+
+fn validate_rhs_latency(e: &Expr, errors: &mut Vec<CompileError>) {
+    match &e.kind {
+        ExprKind::LatencyAt(inner, n) => {
+            if *n != 0 {
+                let root = pipe_reg_expr_root_name(inner);
+                errors.push(CompileError::general(
+                    &format!("reading intermediate stage `@{n}` is not yet supported — read `{root}` or `{root}@0` for the current value"),
+                    e.span,
+                ));
+            }
+            validate_rhs_latency(inner, errors);
+        }
+        ExprKind::Binary(_, l, r) => { validate_rhs_latency(l, errors); validate_rhs_latency(r, errors); }
+        ExprKind::Unary(_, x) => validate_rhs_latency(x, errors),
+        ExprKind::Ternary(c, t, e2) => {
+            validate_rhs_latency(c, errors);
+            validate_rhs_latency(t, errors);
+            validate_rhs_latency(e2, errors);
+        }
+        ExprKind::FieldAccess(b, _) => validate_rhs_latency(b, errors),
+        ExprKind::Index(b, i) => { validate_rhs_latency(b, errors); validate_rhs_latency(i, errors); }
+        ExprKind::BitSlice(b, h, l) => {
+            validate_rhs_latency(b, errors);
+            validate_rhs_latency(h, errors);
+            validate_rhs_latency(l, errors);
+        }
+        ExprKind::MethodCall(b, _, args) => {
+            validate_rhs_latency(b, errors);
+            for a in args { validate_rhs_latency(a, errors); }
+        }
+        ExprKind::FunctionCall(_, args) => {
+            for a in args { validate_rhs_latency(a, errors); }
+        }
+        _ => {}
+    }
+}
+
+fn pipe_reg_expr_root_name(e: &Expr) -> String {
+    match &e.kind {
+        ExprKind::Ident(n) => n.clone(),
+        ExprKind::LatencyAt(inner, _) => pipe_reg_expr_root_name(inner),
+        ExprKind::FieldAccess(b, _) => pipe_reg_expr_root_name(b),
+        _ => "<expr>".to_string(),
+    }
+}
+
+fn validate_comb_pipe_refs(
+    stmts: &[CombStmt],
+    pipe_ports: &[PipePortInfoLocal],
+    all_ports: &[PortDecl],
+    errors: &mut Vec<CompileError>,
+) {
+    for s in stmts {
+        match s {
+            CombStmt::Assign(a) => {
+                // LHS @0 on a plain (non-pipe_reg) port is an error.
+                if let ExprKind::LatencyAt(inner, n) = &a.target.kind {
+                    if let ExprKind::Ident(name) = &inner.kind {
+                        let is_pipe = pipe_ports.iter().any(|p| &p.name == name);
+                        if !is_pipe && all_ports.iter().any(|p| p.name.name == *name) {
+                            errors.push(CompileError::general(
+                                &format!("`{name}@{n}` is only valid on pipe_reg<T, N> ports; drop the `@{n}` or change the port type"),
+                                a.target.span,
+                            ));
+                        }
+                    }
+                }
+                validate_rhs_latency(&a.value, errors);
+            }
+            CombStmt::IfElse(ie) => {
+                validate_comb_pipe_refs(&ie.then_stmts, pipe_ports, all_ports, errors);
+                validate_comb_pipe_refs(&ie.else_stmts, pipe_ports, all_ports, errors);
+            }
+            CombStmt::MatchExpr(_) | CombStmt::For(_) | CombStmt::Log(_) => {}
+        }
+    }
+}
+
+fn rewrite_seq_stmts(stmts: Vec<Stmt>, pipes: &[PipePortInfoLocal]) -> Vec<Stmt> {
+    let mut out: Vec<Stmt> = Vec::with_capacity(stmts.len());
+    for s in stmts {
+        out.extend(rewrite_seq_stmt(s, pipes));
+    }
+    out
+}
+
+fn rewrite_seq_stmt(stmt: Stmt, pipes: &[PipePortInfoLocal]) -> Vec<Stmt> {
+    match stmt {
+        Stmt::Assign(a) => {
+            let (root, latency, span) = match &a.target.kind {
+                ExprKind::LatencyAt(inner, n) => match &inner.kind {
+                    ExprKind::Ident(name) => (name.clone(), *n, a.span),
+                    _ => return vec![Stmt::Assign(a)],
+                },
+                _ => return vec![Stmt::Assign(a)],
+            };
+            let Some(pp) = pipes.iter().find(|p| p.name == root) else {
+                return vec![Stmt::Assign(a)];
+            };
+            if latency != pp.latency {
+                // Typecheck should have rejected this; leave it and let
+                // downstream errors surface.
+                return vec![Stmt::Assign(a)];
+            }
+            // Build the cascade: stg1 <= expr; stg2 <= stg1; ...; q <= stg{N-1};
+            let value = a.value;
+            let n = pp.latency;
+            let mut out: Vec<Stmt> = Vec::with_capacity(n as usize);
+            // stg1 <= value
+            out.push(Stmt::Assign(Assign {
+                target: Expr::new(ExprKind::Ident(format!("{}_stg1", pp.name)), span),
+                value,
+                span,
+            }));
+            // stg{k} <= stg{k-1} for k = 2..N-1
+            for k in 2..n {
+                out.push(Stmt::Assign(Assign {
+                    target: Expr::new(ExprKind::Ident(format!("{}_stg{}", pp.name, k)), span),
+                    value: Expr::new(ExprKind::Ident(format!("{}_stg{}", pp.name, k - 1)), span),
+                    span,
+                }));
+            }
+            // q <= stg{N-1}
+            out.push(Stmt::Assign(Assign {
+                target: Expr::new(ExprKind::Ident(pp.name.clone()), span),
+                value: Expr::new(ExprKind::Ident(format!("{}_stg{}", pp.name, n - 1)), span),
+                span,
+            }));
+            out
+        }
+        Stmt::IfElse(mut ie) => {
+            ie.then_stmts = rewrite_seq_stmts_pp(std::mem::take(&mut ie.then_stmts), pipes);
+            ie.else_stmts = rewrite_seq_stmts_pp(std::mem::take(&mut ie.else_stmts), pipes);
+            vec![Stmt::IfElse(ie)]
+        }
+        Stmt::Match(mut m) => {
+            for arm in &mut m.arms {
+                arm.body = rewrite_seq_stmts_pp(std::mem::take(&mut arm.body), pipes);
+            }
+            vec![Stmt::Match(m)]
+        }
+        Stmt::For(mut f) => {
+            f.body = rewrite_seq_stmts_pp(std::mem::take(&mut f.body), pipes);
+            vec![Stmt::For(f)]
+        }
+        Stmt::Init(mut ib) => {
+            ib.body = rewrite_seq_stmts_pp(std::mem::take(&mut ib.body), pipes);
+            vec![Stmt::Init(ib)]
+        }
+        other => vec![other],
+    }
+}
+
+fn rewrite_seq_stmts_pp(stmts: Vec<Stmt>, pipes: &[PipePortInfoLocal]) -> Vec<Stmt> {
+    let mut out: Vec<Stmt> = Vec::with_capacity(stmts.len());
+    for s in stmts {
+        out.extend(rewrite_seq_stmt(s, pipes));
+    }
+    out
+}
+

--- a/src/formal.rs
+++ b/src/formal.rs
@@ -818,6 +818,10 @@ impl<'a> FormalCtx<'a> {
     fn encode_raw(&self, expr: &Expr, t: u32) -> Result<SmtTerm, CompileError> {
         use ExprKind::*;
         match &expr.kind {
+            // Latency annotation is transparent to SMT: at timepoint t,
+            // `q@0` is the same as `q` at t. Non-@0 reads are rejected by
+            // typecheck before reaching formal emission.
+            LatencyAt(inner, _) => self.encode_raw(inner, t),
             Literal(l) => Ok(lit_to_term(l)),
             Bool(b) => Ok(SmtTerm {
                 s: if *b { "#b1".to_string() } else { "#b0".to_string() },

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -135,6 +135,8 @@ pub enum TokenKind {
     Linklist,
     #[token("pipe_reg")]
     PipeReg,
+    #[token("@")]
+    At,
     #[token("op")]
     Op,
     #[token("track")]
@@ -416,6 +418,7 @@ impl fmt::Display for TokenKind {
             TokenKind::Forward => write!(f, "forward"),
             TokenKind::Linklist => write!(f, "linklist"),
             TokenKind::PipeReg => write!(f, "pipe_reg"),
+            TokenKind::At => write!(f, "@"),
             TokenKind::Op => write!(f, "op"),
             TokenKind::Track => write!(f, "track"),
             TokenKind::Latency => write!(f, "latency"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -943,6 +943,12 @@ fn run_check_multi(
         ms.report_error(err)
     })?;
 
+    // Lower `pipe_reg<T, N>` ports with N > 1 into an N-stage cascade.
+    let ast = elaborate::lower_pipe_reg_ports(ast).map_err(|errs| {
+        let err = errs.into_iter().next().unwrap();
+        ms.report_error(err)
+    })?;
+
     // Resolve
     let symbols = resolve::resolve(&ast).map_err(|errs| {
         let err = errs.into_iter().next().unwrap();

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -659,7 +659,52 @@ impl Parser {
                 start.merge(self.peek_span()),
             ));
         }
-        let ty = self.parse_type_expr()?;
+
+        // `port X: out pipe_reg<T, N> [modifiers];` — same semantics as
+        // `port reg X: out T ...` for N=1, N-stage output pipe for N>=2.
+        // The pipe_reg type is detected *before* normal type parsing.
+        let (ty, pipe_reg_latency) = if self.check(TokenKind::PipeReg) {
+            if direction == Direction::In {
+                return Err(CompileError::general(
+                    "pipe_reg<T, N> port must be an output",
+                    self.peek_span(),
+                ));
+            }
+            self.advance();
+            self.expect(TokenKind::Lt)?;
+            let old_no_angle = self.no_angle;
+            self.no_angle = true;
+            let inner_ty = self.parse_type_expr()?;
+            self.expect(TokenKind::Comma)?;
+            let depth_expr = self.parse_expr()?;
+            self.no_angle = old_no_angle;
+            self.expect(TokenKind::Gt)?;
+            // Evaluate depth. Only constant literal is supported in v1.
+            let depth = match &depth_expr.kind {
+                ExprKind::Literal(LitKind::Dec(n))
+                | ExprKind::Literal(LitKind::Hex(n))
+                | ExprKind::Literal(LitKind::Bin(n))
+                | ExprKind::Literal(LitKind::Sized(_, n)) => *n as u32,
+                _ => {
+                    return Err(CompileError::general(
+                        "pipe_reg<T, N> depth must be a compile-time integer literal",
+                        depth_expr.span,
+                    ));
+                }
+            };
+            if depth == 0 {
+                return Err(CompileError::general(
+                    "pipe_reg depth must be >= 1; use plain `out T` for a combinational port",
+                    depth_expr.span,
+                ));
+            }
+            (inner_ty, Some(depth))
+        } else {
+            (self.parse_type_expr()?, None)
+        };
+        // A pipe_reg port is semantically identical to a legacy `port reg`
+        // with the given latency, so drive the existing reg_info parsing path.
+        let is_reg = is_reg || pipe_reg_latency.is_some();
 
         // For `port reg`, parse optional guard/init/reset (same syntax as `reg` decl).
         let reg_info = if is_reg {
@@ -686,7 +731,7 @@ impl Parser {
             } else {
                 RegReset::None
             };
-            Some(PortRegInfo { init, reset, guard })
+            Some(PortRegInfo { init, reset, guard, latency: pipe_reg_latency.unwrap_or(1) })
         } else {
             None
         };
@@ -2304,6 +2349,32 @@ impl Parser {
         let mut lhs = self.parse_prefix()?;
 
         loop {
+            // Postfix `@N` — latency annotation on pipe_reg references.
+            // Valid on LHS (sink side, N = declared depth) and on RHS (source
+            // side, only N = 0 in v1 per doc/plan_pipe_reg_at_syntax.md).
+            // Parser is permissive here; typecheck enforces the placement
+            // and value constraints.
+            if self.check(TokenKind::At) {
+                self.advance(); // @
+                let n_expr = self.parse_prefix()?;
+                let n = match &n_expr.kind {
+                    ExprKind::Literal(LitKind::Dec(v))
+                    | ExprKind::Literal(LitKind::Hex(v))
+                    | ExprKind::Literal(LitKind::Bin(v))
+                    | ExprKind::Literal(LitKind::Sized(_, v)) => *v as u32,
+                    _ => return Err(CompileError::general(
+                        "`@N` latency must be an integer literal",
+                        n_expr.span,
+                    )),
+                };
+                let span = lhs.span.merge(n_expr.span);
+                lhs = Expr {
+                    kind: ExprKind::LatencyAt(Box::new(lhs), n),
+                    span,
+                    parenthesized: false,
+                };
+                continue;
+            }
             // Postfix: `.field`, `.method<N>()`, `[i]`, `as T`
             if self.check(TokenKind::Dot) {
                 self.advance();

--- a/src/sim_codegen.rs
+++ b/src/sim_codegen.rs
@@ -1671,6 +1671,10 @@ fn cpp_expr_lhs(expr: &Expr, ctx: &Ctx) -> String {
 
 fn cpp_expr_inner(expr: &Expr, ctx: &Ctx, is_lhs: bool) -> String {
     match &expr.kind {
+        // Latency annotation: transparent to sim emission. The assignment
+        // site handles directing the write to stage 0 of the pipe chain;
+        // reads of `q@0` collapse to the final-output field of the pipe.
+        ExprKind::LatencyAt(inner, _) => cpp_expr_inner(inner, ctx, is_lhs),
         ExprKind::Literal(lit) => match lit {
             LitKind::Dec(v) => format!("{v}"),
             LitKind::Hex(v) => format!("0x{v:X}"),

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -1579,6 +1579,7 @@ impl<'a> TypeChecker<'a> {
             ExprKind::Ident(n) => n.clone(),
             ExprKind::FieldAccess(base, _) => Self::expr_root_name_tc(base),
             ExprKind::Index(base, _) | ExprKind::BitSlice(base, _, _) | ExprKind::PartSelect(base, _, _, _) => Self::expr_root_name_tc(base),
+            ExprKind::LatencyAt(inner, _) => Self::expr_root_name_tc(inner),
             _ => String::new(),
         }
     }
@@ -1587,6 +1588,7 @@ impl<'a> TypeChecker<'a> {
     /// (e.g. `itcm.cmd_valid` → `"itcm_cmd_valid"`). Used for bus port driven tracking.
     fn expr_flat_name_tc(expr: &Expr) -> String {
         match &expr.kind {
+            ExprKind::LatencyAt(inner, _) => Self::expr_flat_name_tc(inner),
             ExprKind::Ident(n) => n.clone(),
             ExprKind::FieldAccess(base, field) => {
                 if let ExprKind::Ident(base_name) = &base.kind {
@@ -2188,6 +2190,13 @@ impl<'a> TypeChecker<'a> {
         local_types: &HashMap<String, Ty>,
     ) -> Ty {
         match &expr.kind {
+            ExprKind::LatencyAt(inner, _) => {
+                // Latency annotation is a typing no-op — the value's type
+                // matches the underlying signal. Placement/value validation
+                // happens in check_reg_stmt / check_comb_stmt where the
+                // target context is known.
+                self.resolve_expr_type(inner, module_name, local_types)
+            }
             ExprKind::Todo => {
                 self.warnings.push(CompileWarning {
                     message: "todo! placeholder will abort at runtime".to_string(),

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -10,6 +10,8 @@ fn compile_to_sv(source: &str) -> String {
     let mut parser = Parser::new(tokens, source);
     let parsed_ast = parser.parse_source_file().expect("parse error");
     let ast = elaborate::elaborate(parsed_ast).expect("elaborate error");
+    let ast = elaborate::lower_threads(ast).expect("lower_threads error");
+    let ast = elaborate::lower_pipe_reg_ports(ast).expect("lower_pipe_reg_ports error");
     let symbols = resolve::resolve(&ast).expect("resolve error");
     let checker = TypeChecker::new(&symbols, &ast);
     let (_warnings, overload_map) = checker.check().expect("type check error");
@@ -3056,4 +3058,126 @@ fn test_find_first_unknown_binding_errors() {
     let msg = format!("{:?}", result.unwrap_err());
     assert!(msg.contains("find_first result has no field named `wrong_name`"),
             "expected specific error message, got: {msg}");
+}
+
+#[test]
+fn test_pipe_reg_port_n1_equivalent_to_port_reg() {
+    // port q: out pipe_reg<T, 1> ... emits the same SV as port reg q: out T
+    let src_new = "
+        module M
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync>;
+          port a: in UInt<8>;
+          port q: out pipe_reg<UInt<8>, 1> reset rst => 0;
+          default seq on clk rising;
+          seq
+            q@1 <= a;
+          end seq
+        end module M
+    ";
+    let src_old = "
+        module M
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync>;
+          port a: in UInt<8>;
+          port reg q: out UInt<8> reset rst => 0;
+          default seq on clk rising;
+          seq
+            q <= a;
+          end seq
+        end module M
+    ";
+    assert_eq!(compile_to_sv(src_new), compile_to_sv(src_old),
+        "pipe_reg<T, 1> + @1 should be byte-identical to port reg");
+}
+
+#[test]
+fn test_pipe_reg_port_n3_emits_cascade() {
+    let source = "
+        module M
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync>;
+          port a: in UInt<8>;
+          port q: out pipe_reg<UInt<8>, 3> reset rst => 0;
+          default seq on clk rising;
+          seq
+            q@3 <= a;
+          end seq
+        end module M
+    ";
+    let sv = compile_to_sv(source);
+    // Two intermediate stage regs should be declared + cascade assigns.
+    assert!(sv.contains("q_stg1") && sv.contains("q_stg2"),
+        "expected 2 intermediate stages for depth=3:\n{sv}");
+    assert!(sv.contains("q_stg1 <= a;"), "stage 0 write missing:\n{sv}");
+    assert!(sv.contains("q_stg2 <= q_stg1;"), "stage 1 shift missing:\n{sv}");
+    assert!(sv.contains("q <= q_stg2;"), "final output write missing:\n{sv}");
+    // Uniform reset across all stages:
+    assert!(sv.contains("q_stg1 <= 0") && sv.contains("q_stg2 <= 0") && sv.contains("q <= 0"),
+        "expected uniform reset across all stages:\n{sv}");
+}
+
+#[test]
+fn test_pipe_reg_port_depth_mismatch_errors() {
+    let source = "
+        module M
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync>;
+          port a: in UInt<8>;
+          port q: out pipe_reg<UInt<8>, 3> reset rst => 0;
+          default seq on clk rising;
+          seq
+            q@5 <= a;
+          end seq
+        end module M
+    ";
+    let tokens = arch::lexer::tokenize(source).expect("lexer");
+    let mut parser = arch::parser::Parser::new(tokens, source);
+    let ast = parser.parse_source_file().expect("parse");
+    let ast = arch::elaborate::elaborate(ast).expect("elaborate base");
+    let ast = arch::elaborate::lower_threads(ast).expect("lower threads");
+    let result = arch::elaborate::lower_pipe_reg_ports(ast);
+    assert!(result.is_err(), "expected depth-mismatch error");
+    let msg = format!("{:?}", result.unwrap_err());
+    assert!(msg.contains("exceeds declared latency 3"),
+        "expected specific error message, got: {msg}");
+}
+
+#[test]
+fn test_pipe_reg_port_bare_assign_ambiguous_errors() {
+    let source = "
+        module M
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync>;
+          port a: in UInt<8>;
+          port q: out pipe_reg<UInt<8>, 3> reset rst => 0;
+          default seq on clk rising;
+          seq
+            q <= a;
+          end seq
+        end module M
+    ";
+    let tokens = arch::lexer::tokenize(source).expect("lexer");
+    let mut parser = arch::parser::Parser::new(tokens, source);
+    let ast = parser.parse_source_file().expect("parse");
+    let ast = arch::elaborate::elaborate(ast).expect("elaborate base");
+    let ast = arch::elaborate::lower_threads(ast).expect("lower threads");
+    let result = arch::elaborate::lower_pipe_reg_ports(ast);
+    assert!(result.is_err(), "expected ambiguous-assignment error");
+    let msg = format!("{:?}", result.unwrap_err());
+    assert!(msg.contains("is ambiguous"),
+        "expected specific error message, got: {msg}");
+}
+
+#[test]
+fn test_pipe_reg_depth_zero_errors() {
+    let source = "
+        module M
+          port q: out pipe_reg<UInt<8>, 0>;
+        end module M
+    ";
+    let tokens = arch::lexer::tokenize(source).expect("lexer");
+    let mut parser = arch::parser::Parser::new(tokens, source);
+    let result = parser.parse_source_file();
+    assert!(result.is_err(), "expected depth=0 error");
 }


### PR DESCRIPTION
## Summary

First PR of [\`doc/plan_pipe_reg_at_syntax.md\`](doc/plan_pipe_reg_at_syntax.md). Makes output latency visible in the port signature and at every assignment site.

```arch
port q: out UInt<8>;                       // comb (unchanged)
port q: out pipe_reg<UInt<8>, 1> reset rst => 0;   // today's port reg — byte-identical SV
port q: out pipe_reg<UInt<8>, 3> reset rst => 0;   // 3-cycle output pipe

seq
  q@3 <= next_q;   // reads as "next_q will be in q 3 cycles from now"
end seq
```

## What's in this PR

1. **New port type**: \`pipe_reg<T, N>\` (N ≥ 1). N=1 is a drop-in for \`port reg\`; N>1 synthesizes an N-stage output cascade with uniform reset across every stage.
2. **New \`@N\` operator** on LHS (required on \`pipe_reg<T,N>\` with N>1; grammar-permissive, typecheck enforces) and RHS (v1: only \`@0\` accepted).
3. **Validation errors** covering the doc's error matrix:
   - \`q@5 <= Y\` on \`pipe_reg<T,3>\` → "exceeds declared latency 3"
   - bare \`q <= Y\` on \`pipe_reg<T,3>\` → "ambiguous — write \`q@3 <= …\`"
   - \`q@2\` on RHS → "reading intermediate stage not yet supported"
   - \`pipe_reg<T, 0>\` → "depth must be ≥ 1"

## End-to-end verification

- **N=1 parity**: \`compile_to_sv\` for \`port q: out pipe_reg<T,1>\` is byte-identical to the existing \`port reg q: out T\` output (regression test \`test_pipe_reg_port_n1_equivalent_to_port_reg\`).
- **N=3 cascade**: Verilator sim with a cycle-accurate TB confirms \`in_data=42\` at cycle 0 emerges at \`q\` on cycle 3; \`arch sim\` (native C++) agrees.

## Test plan
- [x] \`cargo build\` clean
- [x] \`cargo test\` — 102 passing, including 5 new regressions
- [x] Verilator 5.034 full sim on a 3-stage pipe

## What's next

- **PR #2**: module-scope \`pipe_reg\` sourceless form + one-shot auto-rewrite of legacy \`port reg\` and \`pipe_reg name: src stages N\` into the new spellings.
- **PR #3**: spec §4.x and reference card updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)