### PR TITLE
chore: migrate test corpus from port reg to pipe_reg<T, 1>

### DIFF
--- a/tests/assert_cover/light.arch
+++ b/tests/assert_cover/light.arch
@@ -2,7 +2,7 @@ fsm TrafficLight
   port clk: in Clock<SysDomain>;
   port rst: in Reset<Async, High>;
   port tick: in Bool;
-  port reg light: out UInt<2> reset rst=>0;
+  port light: out pipe_reg<UInt<2>, 1> reset rst=>0;
 
   state [Red, Green, Yellow]
   default state Red;

--- a/tests/axi_dma/AxiLiteRegs.arch
+++ b/tests/axi_dma/AxiLiteRegs.arch
@@ -8,9 +8,9 @@ module AxiLiteRegs
   port axil: target BusAxiLite;
 
   // MM2S direct control outputs (simple DMA mode)
-  port reg mm2s_start:     out Bool reset rst=>false;
-  port reg mm2s_src_addr:  out UInt<32> reset rst=>0;
-  port reg mm2s_num_beats: out UInt<8> reset rst=>0;
+  port mm2s_start: out pipe_reg<Bool, 1> reset rst=>false;
+  port mm2s_src_addr: out pipe_reg<UInt<32>, 1> reset rst=>0;
+  port mm2s_num_beats: out pipe_reg<UInt<8>, 1> reset rst=>0;
 
   // MM2S status inputs
   port mm2s_done:   in Bool;
@@ -18,9 +18,9 @@ module AxiLiteRegs
   port mm2s_idle:   in Bool;
 
   // S2MM direct control outputs (simple DMA mode)
-  port reg s2mm_start:     out Bool reset rst=>false;
-  port reg s2mm_dst_addr:  out UInt<32> reset rst=>0;
-  port reg s2mm_num_beats: out UInt<8> reset rst=>0;
+  port s2mm_start: out pipe_reg<Bool, 1> reset rst=>false;
+  port s2mm_dst_addr: out pipe_reg<UInt<32>, 1> reset rst=>0;
+  port s2mm_num_beats: out pipe_reg<UInt<8>, 1> reset rst=>0;
 
   // S2MM status inputs
   port s2mm_done:   in Bool;
@@ -28,14 +28,14 @@ module AxiLiteRegs
   port s2mm_idle:   in Bool;
 
   // Scatter-Gather control outputs
-  port reg mm2s_sg_start:   out Bool reset rst=>false;
-  port reg mm2s_curdesc_o:  out UInt<32> reset rst=>0;
-  port reg mm2s_taildesc_o: out UInt<32> reset rst=>0;
+  port mm2s_sg_start: out pipe_reg<Bool, 1> reset rst=>false;
+  port mm2s_curdesc_o: out pipe_reg<UInt<32>, 1> reset rst=>0;
+  port mm2s_taildesc_o: out pipe_reg<UInt<32>, 1> reset rst=>0;
   port mm2s_sg_done: in Bool;
 
-  port reg s2mm_sg_start:   out Bool reset rst=>false;
-  port reg s2mm_curdesc_o:  out UInt<32> reset rst=>0;
-  port reg s2mm_taildesc_o: out UInt<32> reset rst=>0;
+  port s2mm_sg_start: out pipe_reg<Bool, 1> reset rst=>false;
+  port s2mm_curdesc_o: out pipe_reg<UInt<32>, 1> reset rst=>0;
+  port s2mm_taildesc_o: out pipe_reg<UInt<32>, 1> reset rst=>0;
   port s2mm_sg_done: in Bool;
 
   // SG active flags
@@ -43,8 +43,8 @@ module AxiLiteRegs
   port s2mm_sg_active: in Bool;
 
   // Interrupt outputs
-  port reg mm2s_introut: out Bool reset rst=>false;
-  port reg s2mm_introut: out Bool reset rst=>false;
+  port mm2s_introut: out pipe_reg<Bool, 1> reset rst=>false;
+  port s2mm_introut: out pipe_reg<Bool, 1> reset rst=>false;
 
   // Internal registers for AXI-Lite outputs (bus port can't be port reg)
   reg awready_r: Bool reset rst=>false;

--- a/tests/axi_dma_multi/AxiLiteRegs.arch
+++ b/tests/axi_dma_multi/AxiLiteRegs.arch
@@ -8,9 +8,9 @@ module AxiLiteRegs
   port axil: target BusAxiLite;
 
   // MM2S direct control outputs (simple DMA mode)
-  port reg mm2s_start:     out Bool reset rst=>false;
-  port reg mm2s_src_addr:  out UInt<32> reset rst=>0;
-  port reg mm2s_num_beats: out UInt<8> reset rst=>0;
+  port mm2s_start: out pipe_reg<Bool, 1> reset rst=>false;
+  port mm2s_src_addr: out pipe_reg<UInt<32>, 1> reset rst=>0;
+  port mm2s_num_beats: out pipe_reg<UInt<8>, 1> reset rst=>0;
 
   // MM2S status inputs
   port mm2s_done:   in Bool;
@@ -18,9 +18,9 @@ module AxiLiteRegs
   port mm2s_idle:   in Bool;
 
   // S2MM direct control outputs (simple DMA mode)
-  port reg s2mm_start:     out Bool reset rst=>false;
-  port reg s2mm_dst_addr:  out UInt<32> reset rst=>0;
-  port reg s2mm_num_beats: out UInt<8> reset rst=>0;
+  port s2mm_start: out pipe_reg<Bool, 1> reset rst=>false;
+  port s2mm_dst_addr: out pipe_reg<UInt<32>, 1> reset rst=>0;
+  port s2mm_num_beats: out pipe_reg<UInt<8>, 1> reset rst=>0;
 
   // S2MM status inputs
   port s2mm_done:   in Bool;
@@ -28,14 +28,14 @@ module AxiLiteRegs
   port s2mm_idle:   in Bool;
 
   // Scatter-Gather control outputs
-  port reg mm2s_sg_start:   out Bool reset rst=>false;
-  port reg mm2s_curdesc_o:  out UInt<32> reset rst=>0;
-  port reg mm2s_taildesc_o: out UInt<32> reset rst=>0;
+  port mm2s_sg_start: out pipe_reg<Bool, 1> reset rst=>false;
+  port mm2s_curdesc_o: out pipe_reg<UInt<32>, 1> reset rst=>0;
+  port mm2s_taildesc_o: out pipe_reg<UInt<32>, 1> reset rst=>0;
   port mm2s_sg_done: in Bool;
 
-  port reg s2mm_sg_start:   out Bool reset rst=>false;
-  port reg s2mm_curdesc_o:  out UInt<32> reset rst=>0;
-  port reg s2mm_taildesc_o: out UInt<32> reset rst=>0;
+  port s2mm_sg_start: out pipe_reg<Bool, 1> reset rst=>false;
+  port s2mm_curdesc_o: out pipe_reg<UInt<32>, 1> reset rst=>0;
+  port s2mm_taildesc_o: out pipe_reg<UInt<32>, 1> reset rst=>0;
   port s2mm_sg_done: in Bool;
 
   // SG active flags
@@ -43,8 +43,8 @@ module AxiLiteRegs
   port s2mm_sg_active: in Bool;
 
   // Interrupt outputs
-  port reg mm2s_introut: out Bool reset rst=>false;
-  port reg s2mm_introut: out Bool reset rst=>false;
+  port mm2s_introut: out pipe_reg<Bool, 1> reset rst=>false;
+  port s2mm_introut: out pipe_reg<Bool, 1> reset rst=>false;
 
   // Internal registers for AXI-Lite outputs (bus port can't be port reg)
   reg awready_r: Bool reset rst=>false;

--- a/tests/axi_dma_thread/AxiLiteRegs.arch
+++ b/tests/axi_dma_thread/AxiLiteRegs.arch
@@ -8,9 +8,9 @@ module AxiLiteRegs
   port axil: target BusAxiLite;
 
   // MM2S direct control outputs (simple DMA mode)
-  port reg mm2s_start:     out Bool reset rst=>false;
-  port reg mm2s_src_addr:  out UInt<32> reset rst=>0;
-  port reg mm2s_num_beats: out UInt<8> reset rst=>0;
+  port mm2s_start: out pipe_reg<Bool, 1> reset rst=>false;
+  port mm2s_src_addr: out pipe_reg<UInt<32>, 1> reset rst=>0;
+  port mm2s_num_beats: out pipe_reg<UInt<8>, 1> reset rst=>0;
 
   // MM2S status inputs
   port mm2s_done:   in Bool;
@@ -18,9 +18,9 @@ module AxiLiteRegs
   port mm2s_idle:   in Bool;
 
   // S2MM direct control outputs (simple DMA mode)
-  port reg s2mm_start:     out Bool reset rst=>false;
-  port reg s2mm_dst_addr:  out UInt<32> reset rst=>0;
-  port reg s2mm_num_beats: out UInt<8> reset rst=>0;
+  port s2mm_start: out pipe_reg<Bool, 1> reset rst=>false;
+  port s2mm_dst_addr: out pipe_reg<UInt<32>, 1> reset rst=>0;
+  port s2mm_num_beats: out pipe_reg<UInt<8>, 1> reset rst=>0;
 
   // S2MM status inputs
   port s2mm_done:   in Bool;
@@ -28,14 +28,14 @@ module AxiLiteRegs
   port s2mm_idle:   in Bool;
 
   // Scatter-Gather control outputs
-  port reg mm2s_sg_start:   out Bool reset rst=>false;
-  port reg mm2s_curdesc_o:  out UInt<32> reset rst=>0;
-  port reg mm2s_taildesc_o: out UInt<32> reset rst=>0;
+  port mm2s_sg_start: out pipe_reg<Bool, 1> reset rst=>false;
+  port mm2s_curdesc_o: out pipe_reg<UInt<32>, 1> reset rst=>0;
+  port mm2s_taildesc_o: out pipe_reg<UInt<32>, 1> reset rst=>0;
   port mm2s_sg_done: in Bool;
 
-  port reg s2mm_sg_start:   out Bool reset rst=>false;
-  port reg s2mm_curdesc_o:  out UInt<32> reset rst=>0;
-  port reg s2mm_taildesc_o: out UInt<32> reset rst=>0;
+  port s2mm_sg_start: out pipe_reg<Bool, 1> reset rst=>false;
+  port s2mm_curdesc_o: out pipe_reg<UInt<32>, 1> reset rst=>0;
+  port s2mm_taildesc_o: out pipe_reg<UInt<32>, 1> reset rst=>0;
   port s2mm_sg_done: in Bool;
 
   // SG active flags
@@ -43,8 +43,8 @@ module AxiLiteRegs
   port s2mm_sg_active: in Bool;
 
   // Interrupt outputs
-  port reg mm2s_introut: out Bool reset rst=>false;
-  port reg s2mm_introut: out Bool reset rst=>false;
+  port mm2s_introut: out pipe_reg<Bool, 1> reset rst=>false;
+  port s2mm_introut: out pipe_reg<Bool, 1> reset rst=>false;
 
   // Internal registers for AXI-Lite outputs (bus port can't be port reg)
   reg awready_r: Bool reset rst=>false;

--- a/tests/cvdp/APBGlobalHistoryRegister.arch
+++ b/tests/cvdp/APBGlobalHistoryRegister.arch
@@ -14,9 +14,9 @@ module APBGlobalHistoryRegister
   port penable: in Bool;
   port pwrite:  in Bool;
   port pwdata:  in UInt<8>;
-  port reg pready:  out Bool reset presetn => false;
-  port reg prdata:  out UInt<8> reset presetn => 0;
-  port reg pslverr: out Bool reset presetn => false;
+  port pready: out pipe_reg<Bool, 1> reset presetn => false;
+  port prdata: out pipe_reg<UInt<8>, 1> reset presetn => 0;
+  port pslverr: out pipe_reg<Bool, 1> reset presetn => false;
   port history_shift_valid: in Bool;
   port clk_gate_en: in Bool;
   port history_full:    out Bool;

--- a/tests/cvdp/FILO_RTL.arch
+++ b/tests/cvdp/FILO_RTL.arch
@@ -7,9 +7,9 @@ module FILO_RTL
   port push:  in Bool;
   port pop:   in Bool;
   port data_in: in UInt<DATA_WIDTH>;
-  port reg data_out: out UInt<DATA_WIDTH> reset reset=>0;
-  port reg full:     out Bool reset reset=>0;
-  port reg empty:    out Bool reset reset=>1;
+  port data_out: out pipe_reg<UInt<DATA_WIDTH>, 1> reset reset=>0;
+  port full: out pipe_reg<Bool, 1> reset reset=>0;
+  port empty: out pipe_reg<Bool, 1> reset reset=>1;
 
   default seq on clk rising;
 

--- a/tests/cvdp/JK_flipflop.arch
+++ b/tests/cvdp/JK_flipflop.arch
@@ -3,8 +3,8 @@ module JK_flipflop
   port i_rst_b: in Reset<Async, Low>;
   port i_J: in Bool;
   port i_K: in Bool;
-  port reg o_Q: out Bool reset i_rst_b=>false;
-  port reg o_Q_b: out Bool reset i_rst_b=>true;
+  port o_Q: out pipe_reg<Bool, 1> reset i_rst_b=>false;
+  port o_Q_b: out pipe_reg<Bool, 1> reset i_rst_b=>true;
 
   default seq on i_clk rising;
 

--- a/tests/cvdp/Word_Change_Pulse.arch
+++ b/tests/cvdp/Word_Change_Pulse.arch
@@ -7,9 +7,9 @@ module Word_Change_Pulse
   port match_pattern:       in UInt<DATA_WIDTH>;
   port enable:              in Bool;
   port latch_pattern:       in Bool;
-  port reg word_change_pulse:   out Bool reset reset=>false;
-  port reg pattern_match_pulse: out Bool reset reset=>false;
-  port reg latched_pattern:     out UInt<DATA_WIDTH> reset reset=>0;
+  port word_change_pulse: out pipe_reg<Bool, 1> reset reset=>false;
+  port pattern_match_pulse: out pipe_reg<Bool, 1> reset reset=>false;
+  port latched_pattern: out pipe_reg<UInt<DATA_WIDTH>, 1> reset reset=>0;
 
   wire change_pulses: UInt<DATA_WIDTH>;
 

--- a/tests/cvdp/adc_data_rotate.arch
+++ b/tests/cvdp/adc_data_rotate.arch
@@ -5,8 +5,8 @@ module adc_data_rotate
   port i_adc_data_in: in UInt<DATA_WIDTH>;
   port i_shift_count: in UInt<4>;
   port i_shift_direction: in Bool;
-  port reg o_processed_data: out UInt<DATA_WIDTH> reset i_rst_n=>0;
-  port reg o_operation_status: out Bool reset i_rst_n=>false;
+  port o_processed_data: out pipe_reg<UInt<DATA_WIDTH>, 1> reset i_rst_n=>0;
+  port o_operation_status: out pipe_reg<Bool, 1> reset i_rst_n=>false;
 
   default seq on i_clk rising;
 

--- a/tests/cvdp/apb_dsp_unit.arch
+++ b/tests/cvdp/apb_dsp_unit.arch
@@ -7,9 +7,9 @@ fsm apb_dsp_unit
   port pwrite:  in Bool;
   port pwdata:  in UInt<8>;
   port sram_valid: in Clock<SysDomain>;
-  port reg pready:  out Bool reset presetn => false;
-  port reg prdata:  out UInt<8> reset presetn => 0;
-  port reg pslverr: out Bool reset presetn => false;
+  port pready: out pipe_reg<Bool, 1> reset presetn => false;
+  port prdata: out pipe_reg<UInt<8>, 1> reset presetn => 0;
+  port pslverr: out pipe_reg<Bool, 1> reset presetn => false;
 
   state [Idle, WriteAccess, ReadAccess]
   default state Idle;

--- a/tests/cvdp/axi_register.arch
+++ b/tests/cvdp/axi_register.arch
@@ -7,34 +7,34 @@ module axi_register
   // Write address channel
   port awaddr_i:   in UInt<ADDR_WIDTH>;
   port awvalid_i:  in Bool;
-  port reg awready_o: out Bool reset rst_n_i=>false;
+  port awready_o: out pipe_reg<Bool, 1> reset rst_n_i=>false;
 
   // Write data channel
   port wdata_i:    in UInt<DATA_WIDTH>;
   port wstrb_i:    in UInt<DATA_WIDTH/8>;
   port wvalid_i:   in Bool;
-  port reg wready_o: out Bool reset rst_n_i=>false;
+  port wready_o: out pipe_reg<Bool, 1> reset rst_n_i=>false;
 
   // Write response channel
-  port reg bresp_o:  out UInt<2> reset rst_n_i=>0;
-  port reg bvalid_o: out Bool reset rst_n_i=>false;
+  port bresp_o: out pipe_reg<UInt<2>, 1> reset rst_n_i=>0;
+  port bvalid_o: out pipe_reg<Bool, 1> reset rst_n_i=>false;
   port bready_i:     in Bool;
 
   // Read address channel
   port araddr_i:   in UInt<ADDR_WIDTH>;
   port arvalid_i:  in Bool;
-  port reg arready_o: out Bool reset rst_n_i=>false;
+  port arready_o: out pipe_reg<Bool, 1> reset rst_n_i=>false;
 
   // Read data channel
-  port reg rdata_o:  out UInt<DATA_WIDTH> reset rst_n_i=>0;
-  port reg rvalid_o: out Bool reset rst_n_i=>false;
-  port reg rresp_o:  out UInt<2> reset rst_n_i=>0;
+  port rdata_o: out pipe_reg<UInt<DATA_WIDTH>, 1> reset rst_n_i=>0;
+  port rvalid_o: out pipe_reg<Bool, 1> reset rst_n_i=>false;
+  port rresp_o: out pipe_reg<UInt<2>, 1> reset rst_n_i=>0;
   port rready_i:     in Bool;
 
   // Control outputs
-  port reg beat_o:      out UInt<20> reset rst_n_i=>0;
-  port reg start_o:     out Bool reset rst_n_i=>false;
-  port reg writeback_o: out Bool reset rst_n_i=>false;
+  port beat_o: out pipe_reg<UInt<20>, 1> reset rst_n_i=>0;
+  port start_o: out pipe_reg<Bool, 1> reset rst_n_i=>false;
+  port writeback_o: out pipe_reg<Bool, 1> reset rst_n_i=>false;
   port done_i:          in Bool;
 
   // Internal registers

--- a/tests/cvdp/bcd_counter.arch
+++ b/tests/cvdp/bcd_counter.arch
@@ -1,12 +1,12 @@
 module bcd_counter
   port clk:    in Clock<SysDomain>;
   port rst:    in Reset<Sync>;
-  port reg ms_hr:  out UInt<4> reset rst=>0;
-  port reg ls_hr:  out UInt<4> reset rst=>0;
-  port reg ms_min: out UInt<4> reset rst=>0;
-  port reg ls_min: out UInt<4> reset rst=>0;
-  port reg ms_sec: out UInt<4> reset rst=>0;
-  port reg ls_sec: out UInt<4> reset rst=>0;
+  port ms_hr: out pipe_reg<UInt<4>, 1> reset rst=>0;
+  port ls_hr: out pipe_reg<UInt<4>, 1> reset rst=>0;
+  port ms_min: out pipe_reg<UInt<4>, 1> reset rst=>0;
+  port ls_min: out pipe_reg<UInt<4>, 1> reset rst=>0;
+  port ms_sec: out pipe_reg<UInt<4>, 1> reset rst=>0;
+  port ls_sec: out pipe_reg<UInt<4>, 1> reset rst=>0;
 
   seq on clk rising
     if ls_sec < 4'd9

--- a/tests/cvdp/car_parking_system.arch
+++ b/tests/cvdp/car_parking_system.arch
@@ -7,16 +7,16 @@ module car_parking_system
   port current_slot: in UInt<4>;
   port current_time: in UInt<32>;
   port hour_of_day: in UInt<5>;
-  port reg available_spaces: out UInt<4> reset reset=>TOTAL_SPACES;
-  port reg count_car: out UInt<4> reset reset=>0;
-  port reg led_status: out Bool reset reset=>true;
-  port reg parking_fee: out UInt<16> reset reset=>0;
-  port reg fee_ready: out Bool reset reset=>false;
-  port reg qr_code: out UInt<128> reset reset=>0;
-  port reg seven_seg_display_available_tens: out UInt<7> reset reset=>0;
-  port reg seven_seg_display_available_units: out UInt<7> reset reset=>0;
-  port reg seven_seg_display_count_tens: out UInt<7> reset reset=>0;
-  port reg seven_seg_display_count_units: out UInt<7> reset reset=>0;
+  port available_spaces: out pipe_reg<UInt<4>, 1> reset reset=>TOTAL_SPACES;
+  port count_car: out pipe_reg<UInt<4>, 1> reset reset=>0;
+  port led_status: out pipe_reg<Bool, 1> reset reset=>true;
+  port parking_fee: out pipe_reg<UInt<16>, 1> reset reset=>0;
+  port fee_ready: out pipe_reg<Bool, 1> reset reset=>false;
+  port qr_code: out pipe_reg<UInt<128>, 1> reset reset=>0;
+  port seven_seg_display_available_tens: out pipe_reg<UInt<7>, 1> reset reset=>0;
+  port seven_seg_display_available_units: out pipe_reg<UInt<7>, 1> reset reset=>0;
+  port seven_seg_display_count_tens: out pipe_reg<UInt<7>, 1> reset reset=>0;
+  port seven_seg_display_count_units: out pipe_reg<UInt<7>, 1> reset reset=>0;
 
   default seq on clk rising;
 

--- a/tests/cvdp/cascaded_adder.arch
+++ b/tests/cvdp/cascaded_adder.arch
@@ -7,8 +7,8 @@ module cascaded_adder
   port rst_n: in Reset<Async, Low>;
   port i_valid: in Bool;
   port i_data: in UInt<IN_DATA_WIDTH * IN_DATA_NS>;
-  port reg o_valid: out Bool reset rst_n=>0;
-  port reg o_data: out UInt<OUT_WIDTH> reset rst_n=>0;
+  port o_valid: out pipe_reg<Bool, 1> reset rst_n=>0;
+  port o_data: out pipe_reg<UInt<OUT_WIDTH>, 1> reset rst_n=>0;
 
   reg valid_d1: Bool reset rst_n=>0;
   reg sum_reg: UInt<OUT_WIDTH> reset rst_n=>0;

--- a/tests/cvdp/clock_divider.arch
+++ b/tests/cvdp/clock_divider.arch
@@ -2,7 +2,7 @@ module clock_divider
   port clk: in Clock<SysDomain>;
   port rst_n: in Reset<Async, Low>;
   port sel: in UInt<2>;
-  port reg clk_out: out Bool reset rst_n=>0;
+  port clk_out: out pipe_reg<Bool, 1> reset rst_n=>0;
 
   reg cnt: UInt<3> reset rst_n=>0;
 

--- a/tests/cvdp/clock_jitter_detection_module.arch
+++ b/tests/cvdp/clock_jitter_detection_module.arch
@@ -3,7 +3,7 @@ module clock_jitter_detection_module
   port clk: in Clock<SysDomain>;
   port system_clk: in Bool;
   port rst: in Reset<Sync>;
-  port reg jitter_detected: out Bool reset rst=>false;
+  port jitter_detected: out pipe_reg<Bool, 1> reset rst=>false;
 
   default seq on clk rising;
 

--- a/tests/cvdp/complex_multiplier.arch
+++ b/tests/cvdp/complex_multiplier.arch
@@ -5,8 +5,8 @@ module complex_multiplier
   port a_imag: in SInt<16>;
   port b_real: in SInt<16>;
   port b_imag: in SInt<16>;
-  port reg result_real: out SInt<32> reset arst_n=>0;
-  port reg result_imag: out SInt<32> reset arst_n=>0;
+  port result_real: out pipe_reg<SInt<32>, 1> reset arst_n=>0;
+  port result_imag: out pipe_reg<SInt<32>, 1> reset arst_n=>0;
 
   // (a+bj)*(c+dj) = (ac-bd) + (ad+bc)j
   wire ac: SInt<32>;

--- a/tests/cvdp/cont_adder.arch
+++ b/tests/cvdp/cont_adder.arch
@@ -13,11 +13,11 @@ module cont_adder
   port data_valid: in Bool;
   port window_size: in UInt<8>;
 
-  port reg sum_out:      out SInt<ACCUM_WIDTH> reset rst_n=>0;
-  port reg avg_out:      out SInt<DATA_WIDTH> reset rst_n=>0;
-  port reg threshold_1:  out Bool reset rst_n=>false;
-  port reg threshold_2:  out Bool reset rst_n=>false;
-  port reg sum_ready:    out Bool reset rst_n=>false;
+  port sum_out: out pipe_reg<SInt<ACCUM_WIDTH>, 1> reset rst_n=>0;
+  port avg_out: out pipe_reg<SInt<DATA_WIDTH>, 1> reset rst_n=>0;
+  port threshold_1: out pipe_reg<Bool, 1> reset rst_n=>false;
+  port threshold_2: out pipe_reg<Bool, 1> reset rst_n=>false;
+  port sum_ready: out pipe_reg<Bool, 1> reset rst_n=>false;
 
   // Backward-compatible aliases used by some older harnesses.
   port accum_out:      out UInt<ACCUM_WIDTH>;

--- a/tests/cvdp/convolutional_encoder.arch
+++ b/tests/cvdp/convolutional_encoder.arch
@@ -2,8 +2,8 @@ module convolutional_encoder
   port clk:              in Clock<SysDomain>;
   port rst:              in Reset<Async, High>;
   port data_in:          in Bool;
-  port reg encoded_bit1: out Bool reset rst=>0;
-  port reg encoded_bit2: out Bool reset rst=>0;
+  port encoded_bit1: out pipe_reg<Bool, 1> reset rst=>0;
+  port encoded_bit2: out pipe_reg<Bool, 1> reset rst=>0;
 
   // shift_reg[0] = most recent, shift_reg[1] = oldest
   reg shift_reg: UInt<2> reset rst=>0;

--- a/tests/cvdp/crossbar_switch.arch
+++ b/tests/cvdp/crossbar_switch.arch
@@ -16,15 +16,15 @@ module crossbar_switch
   port valid_in2: in Bit;
   port valid_in3: in Bit;
 
-  port reg out0: out UInt<DATA_WIDTH> reset reset=>0;
-  port reg out1: out UInt<DATA_WIDTH> reset reset=>0;
-  port reg out2: out UInt<DATA_WIDTH> reset reset=>0;
-  port reg out3: out UInt<DATA_WIDTH> reset reset=>0;
+  port out0: out pipe_reg<UInt<DATA_WIDTH>, 1> reset reset=>0;
+  port out1: out pipe_reg<UInt<DATA_WIDTH>, 1> reset reset=>0;
+  port out2: out pipe_reg<UInt<DATA_WIDTH>, 1> reset reset=>0;
+  port out3: out pipe_reg<UInt<DATA_WIDTH>, 1> reset reset=>0;
 
-  port reg valid_out0: out Bit reset reset=>0;
-  port reg valid_out1: out Bit reset reset=>0;
-  port reg valid_out2: out Bit reset reset=>0;
-  port reg valid_out3: out Bit reset reset=>0;
+  port valid_out0: out pipe_reg<Bit, 1> reset reset=>0;
+  port valid_out1: out pipe_reg<Bit, 1> reset reset=>0;
+  port valid_out2: out pipe_reg<Bit, 1> reset reset=>0;
+  port valid_out3: out pipe_reg<Bit, 1> reset reset=>0;
 
   default seq on clk rising;
 

--- a/tests/cvdp/cvdp_convolutional_encoder_RTL_comp.arch
+++ b/tests/cvdp/cvdp_convolutional_encoder_RTL_comp.arch
@@ -2,8 +2,8 @@ module convolutional_encoder
   port clk: in Clock<SysDomain>;
   port rst: in Reset<Sync>;
   port data_in: in Bit;
-  port reg encoded_bit1: out Bit reset rst =>0;
-  port reg encoded_bit2: out Bit reset rst =>0;
+  port encoded_bit1: out pipe_reg<Bit, 1> reset rst =>0;
+  port encoded_bit2: out pipe_reg<Bit, 1> reset rst =>0;
 
   default seq on clk rising;
 

--- a/tests/cvdp/cvdp_copilot_bus_arbiter.arch
+++ b/tests/cvdp/cvdp_copilot_bus_arbiter.arch
@@ -3,8 +3,8 @@ module cvdp_copilot_bus_arbiter
   port reset: in Reset<Async, High>;
   port req1: in Bool;
   port req2: in Bool;
-  port reg grant1: out Bool init false reset reset=>false;
-  port reg grant2: out Bool init false reset reset=>false;
+  port grant1: out pipe_reg<Bool, 1> init false reset reset=>false;
+  port grant2: out pipe_reg<Bool, 1> init false reset reset=>false;
 
   default seq on clk rising;
 

--- a/tests/cvdp/cvdp_copilot_register_file_2R1W.arch
+++ b/tests/cvdp/cvdp_copilot_register_file_2R1W.arch
@@ -11,9 +11,9 @@ module cvdp_copilot_register_file_2R1W
   port clk:    in Clock<SysDomain>;
   port resetn: in Reset<Async, Low>;
 
-  port reg dout1:     out UInt<DATA_WIDTH> reset resetn=>0;
-  port reg dout2:     out UInt<DATA_WIDTH> reset resetn=>0;
-  port reg collision: out Bool reset resetn=>false;
+  port dout1: out pipe_reg<UInt<DATA_WIDTH>, 1> reset resetn=>0;
+  port dout2: out pipe_reg<UInt<DATA_WIDTH>, 1> reset resetn=>0;
+  port collision: out pipe_reg<Bool, 1> reset resetn=>false;
 
   // Clock gating: enable latch captured on falling edge
   reg en_latch_r: Bool init false;

--- a/tests/cvdp/data_bus_controller.arch
+++ b/tests/cvdp/data_bus_controller.arch
@@ -13,8 +13,8 @@ module data_bus_controller
   port m1_data:  in UInt<32>;
 
   port s_ready:  in Bool;
-  port reg s_valid: out Bool reset rst_n=>false;
-  port reg s_data:  out UInt<32> reset rst_n=>0;
+  port s_valid: out pipe_reg<Bool, 1> reset rst_n=>false;
+  port s_data: out pipe_reg<UInt<32>, 1> reset rst_n=>0;
 
   default seq on clk rising;
 

--- a/tests/cvdp/data_width_converter.arch
+++ b/tests/cvdp/data_width_converter.arch
@@ -3,8 +3,8 @@ module data_width_converter
   port reset:            in Reset<Async, High>;
   port data_in:          in UInt<32>;
   port data_valid:       in Bool;
-  port reg o_data_out:       out UInt<128> init 0 reset reset=>0;
-  port reg o_data_out_valid: out Bool init 0 reset reset=>0;
+  port o_data_out: out pipe_reg<UInt<128>, 1> init 0 reset reset=>0;
+  port o_data_out_valid: out pipe_reg<Bool, 1> init 0 reset reset=>0;
 
   reg cnt: UInt<2> init 0 reset reset=>0;
   reg buf0: UInt<32> init 0 reset reset=>0;

--- a/tests/cvdp/dbi_dec.arch
+++ b/tests/cvdp/dbi_dec.arch
@@ -3,7 +3,7 @@ module dbi_dec
   port rst_n: in Reset<Async, Low>;
   port data_in: in UInt<40>;
   port dbi_cntrl: in UInt<2>;
-  port reg data_out: out UInt<40> reset rst_n=>0;
+  port data_out: out pipe_reg<UInt<40>, 1> reset rst_n=>0;
 
   default seq on clk rising;
 

--- a/tests/cvdp/dbi_enc.arch
+++ b/tests/cvdp/dbi_enc.arch
@@ -2,8 +2,8 @@ module dbi_enc
   port clk:      in Clock<SysDomain>;
   port rst_n:    in Reset<Async, Low>;
   port data_in:  in UInt<40>;
-  port reg data_out:  out UInt<40> reset rst_n=>0;
-  port reg dbi_cntrl: out UInt<2> reset rst_n=>0;
+  port data_out: out pipe_reg<UInt<40>, 1> reset rst_n=>0;
+  port dbi_cntrl: out pipe_reg<UInt<2>, 1> reset rst_n=>0;
 
   default seq on clk rising;
 

--- a/tests/cvdp/decimator_and_peak_detector.arch
+++ b/tests/cvdp/decimator_and_peak_detector.arch
@@ -8,9 +8,9 @@ module advanced_decimator_with_adaptive_peak_detection
   port reset: in Reset<Async>;
   port valid_in: in Bool;
   port data_in: in UInt<DATA_WIDTH * N>;
-  port reg valid_out: out Bool reset reset=>false;
-  port reg data_out: out UInt<DATA_WIDTH * NUM_DEC> reset reset=>0;
-  port reg peak_value: out SInt<DATA_WIDTH> reset reset=>0;
+  port valid_out: out pipe_reg<Bool, 1> reset reset=>false;
+  port data_out: out pipe_reg<UInt<DATA_WIDTH * NUM_DEC>, 1> reset reset=>0;
+  port peak_value: out pipe_reg<SInt<DATA_WIDTH>, 1> reset reset=>0;
 
   default seq on clk rising;
 

--- a/tests/cvdp/decoder_64b66b.arch
+++ b/tests/cvdp/decoder_64b66b.arch
@@ -3,10 +3,10 @@ module decoder_64b66b
   port rst_in: in Reset<Async, High>;
   port decoder_data_valid_in: in Bool;
   port decoder_data_in: in UInt<66>;
-  port reg decoder_data_out: out UInt<64> reset rst_in=>0;
-  port reg decoder_control_out: out UInt<8> reset rst_in=>0;
-  port reg sync_error: out Bool reset rst_in=>false;
-  port reg decoder_error_out: out Bool reset rst_in=>false;
+  port decoder_data_out: out pipe_reg<UInt<64>, 1> reset rst_in=>0;
+  port decoder_control_out: out pipe_reg<UInt<8>, 1> reset rst_in=>0;
+  port sync_error: out pipe_reg<Bool, 1> reset rst_in=>false;
+  port decoder_error_out: out pipe_reg<Bool, 1> reset rst_in=>false;
 
   default seq on clk_in rising;
 

--- a/tests/cvdp/decoder_8b10b.arch
+++ b/tests/cvdp/decoder_8b10b.arch
@@ -2,8 +2,8 @@ module decoder_8b10b
   port clk_in:      in Clock<SysDomain>;
   port reset_in:    in Reset<Async>;
   port decoder_in:  in UInt<10>;
-  port reg decoder_out: out UInt<8> reset reset_in=>0;
-  port reg control_out: out Bool reset reset_in=>0;
+  port decoder_out: out pipe_reg<UInt<8>, 1> reset reset_in=>0;
+  port control_out: out pipe_reg<Bool, 1> reset reset_in=>0;
 
   default seq on clk_in rising;
 

--- a/tests/cvdp/deinter_block.arch
+++ b/tests/cvdp/deinter_block.arch
@@ -16,7 +16,7 @@ module deinter_block
   port rst_n:    in  Reset<Async, Low>;
   port i_valid:  in  Bool;
   port in_data:  in  UInt<DATA_WIDTH>;
-  port reg out_data: out UInt<OUT_DATA_WIDTH> reset rst_n => 0;
+  port out_data: out pipe_reg<UInt<OUT_DATA_WIDTH>, 1> reset rst_n => 0;
 
   default seq on clk rising;
 

--- a/tests/cvdp/digital_dice_roller.arch
+++ b/tests/cvdp/digital_dice_roller.arch
@@ -4,7 +4,7 @@ module digital_dice_roller
   port clk: in Clock<SysDomain>;
   port reset: in Reset<Async, Low>;
   port button: in Bool;
-  port reg dice_value: out UInt<3> reset reset=>1;
+  port dice_value: out pipe_reg<UInt<3>, 1> reset reset=>1;
 
   seq on clk rising
     if button

--- a/tests/cvdp/encoder_64b66b.arch
+++ b/tests/cvdp/encoder_64b66b.arch
@@ -3,7 +3,7 @@ module encoder_64b66b
   port rst_in:  in Reset<Async, High>;
   port encoder_data_in:    in UInt<64>;
   port encoder_control_in: in UInt<8>;
-  port reg encoder_data_out: out UInt<66> reset rst_in=>0;
+  port encoder_data_out: out pipe_reg<UInt<66>, 1> reset rst_in=>0;
 
   seq on clk_in rising
     if encoder_control_in == 8'd0

--- a/tests/cvdp/enhanced_fsm_signal_processor.arch
+++ b/tests/cvdp/enhanced_fsm_signal_processor.arch
@@ -11,13 +11,13 @@ module enhanced_fsm_signal_processor
   port i_vector_4: in UInt<5>;
   port i_vector_5: in UInt<5>;
   port i_vector_6: in UInt<5>;
-  port reg o_ready:      out Bit       reset i_rst_n=>0;
-  port reg o_error:      out Bit       reset i_rst_n=>0;
-  port reg o_fsm_status: out UInt<2>   reset i_rst_n=>0;
-  port reg o_vector_1:   out UInt<8>   reset i_rst_n=>0;
-  port reg o_vector_2:   out UInt<8>   reset i_rst_n=>0;
-  port reg o_vector_3:   out UInt<8>   reset i_rst_n=>0;
-  port reg o_vector_4:   out UInt<8>   reset i_rst_n=>0;
+  port o_ready: out pipe_reg<Bit, 1>       reset i_rst_n=>0;
+  port o_error: out pipe_reg<Bit, 1>       reset i_rst_n=>0;
+  port o_fsm_status: out pipe_reg<UInt<2>, 1>   reset i_rst_n=>0;
+  port o_vector_1: out pipe_reg<UInt<8>, 1>   reset i_rst_n=>0;
+  port o_vector_2: out pipe_reg<UInt<8>, 1>   reset i_rst_n=>0;
+  port o_vector_3: out pipe_reg<UInt<8>, 1>   reset i_rst_n=>0;
+  port o_vector_4: out pipe_reg<UInt<8>, 1>   reset i_rst_n=>0;
 
   default seq on i_clk rising;
 

--- a/tests/cvdp/factorial.arch
+++ b/tests/cvdp/factorial.arch
@@ -3,9 +3,9 @@ fsm factorial
   port arst_n: in Reset<Async, Low>;
   port num_in: in UInt<5>;
   port start: in Bool;
-  port reg busy: out Bool reset arst_n=>false;
-  port reg done: out Bool reset arst_n=>false;
-  port reg fact: out UInt<64> reset arst_n=>0;
+  port busy: out pipe_reg<Bool, 1> reset arst_n=>false;
+  port done: out pipe_reg<Bool, 1> reset arst_n=>false;
+  port fact: out pipe_reg<UInt<64>, 1> reset arst_n=>0;
 
   reg cnt: UInt<5> reset arst_n=>0;
   reg acc: UInt<64> reset arst_n=>1;

--- a/tests/cvdp/fibonacci_series.arch
+++ b/tests/cvdp/fibonacci_series.arch
@@ -1,8 +1,8 @@
 module fibonacci_series
   port clk:           in Clock<SysDomain>;
   port rst:           in Reset<Async, High>;
-  port reg fib_out:       out UInt<32> reset rst=>0;
-  port reg overflow_flag: out Bool reset rst=>0;
+  port fib_out: out pipe_reg<UInt<32>, 1> reset rst=>0;
+  port overflow_flag: out pipe_reg<Bool, 1> reset rst=>0;
 
   reg RegA: UInt<32> reset rst=>0;
   reg RegB: UInt<32> reset rst=>1;

--- a/tests/cvdp/fifo_async.arch
+++ b/tests/cvdp/fifo_async.arch
@@ -12,8 +12,8 @@ module fifo_async
   port r_rst:  in Reset<Sync>;
   port r_inc:  in Bool;
 
-  port reg w_full:  out Bool reset w_rst =>false;
-  port reg r_empty: out Bool reset r_rst =>true;
+  port w_full: out pipe_reg<Bool, 1> reset w_rst =>false;
+  port r_empty: out pipe_reg<Bool, 1> reset r_rst =>true;
   port r_data: out UInt<DATA_WIDTH>;
 
   // Memory array

--- a/tests/cvdp/galois_encryption.arch
+++ b/tests/cvdp/galois_encryption.arch
@@ -66,8 +66,8 @@ module galois_encryption
   port i_valid: in Bool;
   port i_data: in UInt<NBW_DATA>;
   port i_encrypt: in Bool;
-  port reg o_data: out UInt<NBW_DATA> reset rst_async_n => 0;
-  port reg o_valid: out Bool reset rst_async_n => 0;
+  port o_data: out pipe_reg<UInt<NBW_DATA>, 1> reset rst_async_n => 0;
+  port o_valid: out pipe_reg<Bool, 1> reset rst_async_n => 0;
 
   reg default: reset rst_async_n => 0;
 

--- a/tests/cvdp/hebb_gates.arch
+++ b/tests/cvdp/hebb_gates.arch
@@ -5,19 +5,19 @@ module hebb_gates
   port a: in SInt<4>;
   port b: in SInt<4>;
   port gate_select: in UInt<2>;
-  port reg w1: out SInt<4> reset rst=>0;
-  port reg w2: out SInt<4> reset rst=>0;
-  port reg bias: out SInt<4> reset rst=>0;
-  port reg present_state: out UInt<4> reset rst=>0;
-  port reg next_state: out UInt<4> reset rst=>0;
-  port reg test_x1: out SInt<4> reset rst=>0;
-  port reg test_x2: out SInt<4> reset rst=>0;
-  port reg expected_output: out SInt<4> reset rst=>0;
-  port reg test_output: out SInt<4> reset rst=>0;
-  port reg test_result: out SInt<4> reset rst=>0;
-  port reg test_done: out UInt<1> reset rst=>0;
-  port reg test_present_state: out UInt<4> reset rst=>0;
-  port reg test_index: out UInt<4> reset rst=>0;
+  port w1: out pipe_reg<SInt<4>, 1> reset rst=>0;
+  port w2: out pipe_reg<SInt<4>, 1> reset rst=>0;
+  port bias: out pipe_reg<SInt<4>, 1> reset rst=>0;
+  port present_state: out pipe_reg<UInt<4>, 1> reset rst=>0;
+  port next_state: out pipe_reg<UInt<4>, 1> reset rst=>0;
+  port test_x1: out pipe_reg<SInt<4>, 1> reset rst=>0;
+  port test_x2: out pipe_reg<SInt<4>, 1> reset rst=>0;
+  port expected_output: out pipe_reg<SInt<4>, 1> reset rst=>0;
+  port test_output: out pipe_reg<SInt<4>, 1> reset rst=>0;
+  port test_result: out pipe_reg<SInt<4>, 1> reset rst=>0;
+  port test_done: out pipe_reg<UInt<1>, 1> reset rst=>0;
+  port test_present_state: out pipe_reg<UInt<4>, 1> reset rst=>0;
+  port test_index: out pipe_reg<UInt<4>, 1> reset rst=>0;
 
   default seq on clk rising;
 

--- a/tests/cvdp/hill_cipher.arch
+++ b/tests/cvdp/hill_cipher.arch
@@ -4,8 +4,8 @@ module hill_cipher
   port start: in Bool;
   port plaintext: in UInt<15>;
   port key: in UInt<45>;
-  port reg ciphertext: out UInt<15> reset reset=>0;
-  port reg done: out Bool reset reset=>0;
+  port ciphertext: out pipe_reg<UInt<15>, 1> reset reset=>0;
+  port done: out pipe_reg<Bool, 1> reset reset=>0;
 
   default seq on clk rising;
 

--- a/tests/cvdp/hmac_reg_interface.arch
+++ b/tests/cvdp/hmac_reg_interface.arch
@@ -9,9 +9,9 @@ module hmac_reg_interface
   port addr:      in UInt<ADDR_WIDTH>;
   port wdata:     in UInt<DATA_WIDTH>;
   port i_wait_en: in Bool;
-  port reg rdata:          out UInt<DATA_WIDTH> reset rst_n=>0;
-  port reg hmac_valid:     out Bool reset rst_n=>false;
-  port reg hmac_key_error: out Bool reset rst_n=>false;
+  port rdata: out pipe_reg<UInt<DATA_WIDTH>, 1> reset rst_n=>0;
+  port hmac_valid: out pipe_reg<Bool, 1> reset rst_n=>false;
+  port hmac_key_error: out pipe_reg<Bool, 1> reset rst_n=>false;
 
   default seq on clk rising;
 

--- a/tests/cvdp/huffman_encoder.arch
+++ b/tests/cvdp/huffman_encoder.arch
@@ -10,9 +10,9 @@ module huffman_encoder
   port config_code:    in UInt<7>;
   port config_length:  in UInt<3>;
 
-  port reg huffman_code_out: out UInt<7> reset reset=>0;
-  port reg code_valid:       out Bool reset reset=>false;
-  port reg error_flag:       out Bool reset reset=>false;
+  port huffman_code_out: out pipe_reg<UInt<7>, 1> reset reset=>0;
+  port code_valid: out pipe_reg<Bool, 1> reset reset=>false;
+  port error_flag: out pipe_reg<Bool, 1> reset reset=>false;
 
   default seq on clk rising;
 

--- a/tests/cvdp/ir_receiver.arch
+++ b/tests/cvdp/ir_receiver.arch
@@ -2,8 +2,8 @@ module ir_receiver
   port clk_in: in Clock<SysDomain>;
   port reset_in: in Reset<Async, High>;
   port ir_signal_in: in Bool;
-  port reg ir_frame_out: out UInt<12> reset reset_in=>0;
-  port reg ir_frame_valid: out Bool reset reset_in=>false;
+  port ir_frame_out: out pipe_reg<UInt<12>, 1> reset reset_in=>0;
+  port ir_frame_valid: out pipe_reg<Bool, 1> reset reset_in=>false;
   port ir_device_address_out: out UInt<5>;
   port ir_function_code_out: out UInt<7>;
   port ir_output_valid: out Bool;

--- a/tests/cvdp/load_store_unit.arch
+++ b/tests/cvdp/load_store_unit.arch
@@ -3,11 +3,11 @@ module load_store_unit
   port rst_n:  in Reset<Async, Low>;
 
   // Data-cache interface
-  port reg dmem_req_o:       out Bool reset rst_n=>false;
-  port reg dmem_req_addr_o:  out UInt<32> reset rst_n=>0;
-  port reg dmem_req_we_o:    out Bool reset rst_n=>false;
-  port reg dmem_req_be_o:    out UInt<4> reset rst_n=>0;
-  port reg dmem_req_wdata_o: out UInt<32> reset rst_n=>0;
+  port dmem_req_o: out pipe_reg<Bool, 1> reset rst_n=>false;
+  port dmem_req_addr_o: out pipe_reg<UInt<32>, 1> reset rst_n=>0;
+  port dmem_req_we_o: out pipe_reg<Bool, 1> reset rst_n=>false;
+  port dmem_req_be_o: out pipe_reg<UInt<4>, 1> reset rst_n=>0;
+  port dmem_req_wdata_o: out pipe_reg<UInt<32>, 1> reset rst_n=>0;
   port dmem_gnt_i:           in Bool;
   port dmem_rvalid_i:        in Bool;
   port dmem_rsp_rdata_i:     in UInt<32>;
@@ -19,11 +19,11 @@ module load_store_unit
   port ex_if_wdata_i:        in UInt<32>;
   port ex_if_addr_base_i:    in UInt<32>;
   port ex_if_addr_offset_i:  in UInt<32>;
-  port reg ex_if_ready_o:    out Bool reset rst_n=>true;
+  port ex_if_ready_o: out pipe_reg<Bool, 1> reset rst_n=>true;
 
   // Writeback interface
-  port reg wb_if_rdata_o:    out UInt<32> reset rst_n=>0;
-  port reg wb_if_rvalid_o:   out Bool reset rst_n=>false;
+  port wb_if_rdata_o: out pipe_reg<UInt<32>, 1> reset rst_n=>0;
+  port wb_if_rvalid_o: out pipe_reg<Bool, 1> reset rst_n=>false;
 
   default seq on clk rising;
 

--- a/tests/cvdp/low_pass_filter.arch
+++ b/tests/cvdp/low_pass_filter.arch
@@ -11,7 +11,7 @@ module low_pass_filter
   port valid_in: in Bool;
   port coeffs: in UInt<COEFF_WIDTH * NUM_TAPS>;
   port data_out: out SInt<OUT_WIDTH>;
-  port reg valid_out: out Bool reset reset=>false;
+  port valid_out: out pipe_reg<Bool, 1> reset reset=>false;
 
   default seq on clk rising;
 

--- a/tests/cvdp/mux_synch.arch
+++ b/tests/cvdp/mux_synch.arch
@@ -4,7 +4,7 @@ module mux_synch
   port dst_clk:  in Clock<SysDomain>;
   port src_clk:  in Clock<SrcDomain>;
   port nrst:     in Reset<Async, Low>;
-  port reg data_out: out UInt<8> reset nrst=>0;
+  port data_out: out pipe_reg<UInt<8>, 1> reset nrst=>0;
 
   // Synchronize req to dst_clk domain using 2-flop synchronizer
   wire req_syncd: Bit;

--- a/tests/cvdp/nff.arch
+++ b/tests/cvdp/nff.arch
@@ -2,7 +2,7 @@ module nff
   port d_in:    in Bit;
   port dst_clk: in Clock<SysDomain>;
   port rst:     in Reset<Async, Low>;
-  port reg syncd: out Bit reset rst=>0;
+  port syncd: out pipe_reg<Bit, 1> reset rst=>0;
 
   reg ff1: Bit reset rst=>0;
 

--- a/tests/cvdp/one_hot_gen.arch
+++ b/tests/cvdp/one_hot_gen.arch
@@ -6,8 +6,8 @@ module one_hot_gen
   port rst_async_n:       in  Reset<Async, Low>;
   port i_config:          in  UInt<2>;
   port i_start:           in  Bool;
-  port reg o_ready:       out Bool reset rst_async_n=>true;
-  port reg o_address_one_hot: out UInt<NS_A+NS_B> reset rst_async_n=>0;
+  port o_ready: out pipe_reg<Bool, 1> reset rst_async_n=>true;
+  port o_address_one_hot: out pipe_reg<UInt<NS_A+NS_B>, 1> reset rst_async_n=>0;
 
   default seq on clk rising;
 

--- a/tests/cvdp/packet_controller.arch
+++ b/tests/cvdp/packet_controller.arch
@@ -4,8 +4,8 @@ module packet_controller
   port rx_valid_i: in Bool;
   port rx_data_8_i: in UInt<8>;
   port tx_done_tick_i: in Bool;
-  port reg tx_start_o: out Bool reset rst=>false;
-  port reg tx_data_8_o: out UInt<8> reset rst=>0;
+  port tx_start_o: out pipe_reg<Bool, 1> reset rst=>false;
+  port tx_data_8_o: out pipe_reg<UInt<8>, 1> reset rst=>0;
 
   default seq on clk rising;
 

--- a/tests/cvdp/password_generator.arch
+++ b/tests/cvdp/password_generator.arch
@@ -2,7 +2,7 @@ module password_generator
   param WIDTH: const = 4;
   port clk: in Clock<SysDomain>;
   port reset: in Reset<Async>;
-  port reg password: out UInt<WIDTH * 8> reset reset=>0;
+  port password: out pipe_reg<UInt<WIDTH * 8>, 1> reset reset=>0;
 
   default seq on clk rising;
 

--- a/tests/cvdp/perceptron_gates.arch
+++ b/tests/cvdp/perceptron_gates.arch
@@ -7,17 +7,17 @@ module perceptron_gates
   port threshold: in SInt<4>;
   port gate_select: in UInt<2>;
 
-  port reg percep_w1: out SInt<4> reset rst_n=>0;
-  port reg percep_w2: out SInt<4> reset rst_n=>0;
-  port reg percep_bias: out SInt<4> reset rst_n=>0;
-  port reg present_addr: out UInt<4> reset rst_n=>0;
-  port reg stop: out Bool reset rst_n=>false;
-  port reg input_index: out UInt<3> reset rst_n=>0;
-  port reg y_in: out SInt<4> reset rst_n=>0;
-  port reg y: out SInt<4> reset rst_n=>0;
-  port reg prev_percep_wt_1: out SInt<4> reset rst_n=>0;
-  port reg prev_percep_wt_2: out SInt<4> reset rst_n=>0;
-  port reg prev_percep_bias: out SInt<4> reset rst_n=>0;
+  port percep_w1: out pipe_reg<SInt<4>, 1> reset rst_n=>0;
+  port percep_w2: out pipe_reg<SInt<4>, 1> reset rst_n=>0;
+  port percep_bias: out pipe_reg<SInt<4>, 1> reset rst_n=>0;
+  port present_addr: out pipe_reg<UInt<4>, 1> reset rst_n=>0;
+  port stop: out pipe_reg<Bool, 1> reset rst_n=>false;
+  port input_index: out pipe_reg<UInt<3>, 1> reset rst_n=>0;
+  port y_in: out pipe_reg<SInt<4>, 1> reset rst_n=>0;
+  port y: out pipe_reg<SInt<4>, 1> reset rst_n=>0;
+  port prev_percep_wt_1: out pipe_reg<SInt<4>, 1> reset rst_n=>0;
+  port prev_percep_wt_2: out pipe_reg<SInt<4>, 1> reset rst_n=>0;
+  port prev_percep_bias: out pipe_reg<SInt<4>, 1> reset rst_n=>0;
 
   default seq on clk rising;
 

--- a/tests/cvdp/perfect_squares_generator.arch
+++ b/tests/cvdp/perfect_squares_generator.arch
@@ -1,7 +1,7 @@
 module perfect_squares_generator
   port clk: in Clock<SysDomain>;
   port reset: in Reset<Async, High>;
-  port reg sqr_o: out UInt<32> reset reset=>1;
+  port sqr_o: out pipe_reg<UInt<32>, 1> reset reset=>1;
 
   // Incremental: (n+1)^2 = n^2 + 2n + 1 = sqr + odd, odd += 2
   // Start: sqr=1, odd=3 → 4, 9, 16, ...

--- a/tests/cvdp/ping_pong_buffer.arch
+++ b/tests/cvdp/ping_pong_buffer.arch
@@ -5,9 +5,9 @@ module ping_pong_buffer
   port read_enable: in Bool;
   port data_in: in UInt<8>;
   port data_out: out UInt<8>;
-  port reg buffer_full: out Bool reset rst_n =>false;
-  port reg buffer_empty: out Bool reset rst_n =>true;
-  port reg buffer_select: out Bool reset rst_n =>false;
+  port buffer_full: out pipe_reg<Bool, 1> reset rst_n =>false;
+  port buffer_empty: out pipe_reg<Bool, 1> reset rst_n =>true;
+  port buffer_select: out pipe_reg<Bool, 1> reset rst_n =>false;
 
   default seq on clk rising;
 

--- a/tests/cvdp/ping_pong_fifo_2_axi_stream.arch
+++ b/tests/cvdp/ping_pong_fifo_2_axi_stream.arch
@@ -6,17 +6,17 @@ module ping_pong_fifo_2_axi_stream
 
   port rst:                in Reset<Async, High>;
   port i_block_fifo_rdy:   in Bool;
-  port reg o_block_fifo_act: out Bool init 0 reset rst=>0;
+  port o_block_fifo_act: out pipe_reg<Bool, 1> init 0 reset rst=>0;
   port i_block_fifo_size:  in UInt<24>;
   port i_block_fifo_data:  in UInt<DATA_WIDTH + 1>;
-  port reg o_block_fifo_stb: out Bool init 0 reset rst=>0;
+  port o_block_fifo_stb: out pipe_reg<Bool, 1> init 0 reset rst=>0;
   port i_axi_user:         in UInt<4>;
   port i_axi_clk:          in Clock<SysDomain>;
-  port reg o_axi_user:     out UInt<4> init 0 reset rst=>0;
+  port o_axi_user: out pipe_reg<UInt<4>, 1> init 0 reset rst=>0;
   port i_axi_ready:        in Bool;
-  port reg o_axi_data:     out UInt<DATA_WIDTH> init 0 reset rst=>0;
-  port reg o_axi_last:     out Bool init 0 reset rst=>0;
-  port reg o_axi_valid:    out Bool init 0 reset rst=>0;
+  port o_axi_data: out pipe_reg<UInt<DATA_WIDTH>, 1> init 0 reset rst=>0;
+  port o_axi_last: out pipe_reg<Bool, 1> init 0 reset rst=>0;
+  port o_axi_valid: out pipe_reg<Bool, 1> init 0 reset rst=>0;
 
   reg fifo_data_buffer: UInt<DATA_WIDTH> init 0 reset rst=>0;
   reg fifo_valid_buffer: Bool init 0 reset rst=>0;

--- a/tests/cvdp/precision_counter_axi.arch
+++ b/tests/cvdp/precision_counter_axi.arch
@@ -7,28 +7,28 @@ module precision_counter_axi
 
   port axi_awaddr:  in UInt<C_S_AXI_ADDR_WIDTH>;
   port axi_awvalid: in Bool;
-  port reg axi_awready: out Bool reset axi_aresetn=>false;
+  port axi_awready: out pipe_reg<Bool, 1> reset axi_aresetn=>false;
 
   port axi_wdata:   in UInt<C_S_AXI_DATA_WIDTH>;
   port axi_wstrb:   in UInt<C_S_AXI_DATA_WIDTH/8>;
   port axi_wvalid:  in Bool;
-  port reg axi_wready: out Bool reset axi_aresetn=>false;
+  port axi_wready: out pipe_reg<Bool, 1> reset axi_aresetn=>false;
 
-  port reg axi_bresp:  out UInt<2> reset axi_aresetn=>0;
-  port reg axi_bvalid: out Bool reset axi_aresetn=>false;
+  port axi_bresp: out pipe_reg<UInt<2>, 1> reset axi_aresetn=>0;
+  port axi_bvalid: out pipe_reg<Bool, 1> reset axi_aresetn=>false;
   port axi_bready: in Bool;
 
   port axi_araddr:  in UInt<C_S_AXI_ADDR_WIDTH>;
   port axi_arvalid: in Bool;
-  port reg axi_arready: out Bool reset axi_aresetn=>false;
+  port axi_arready: out pipe_reg<Bool, 1> reset axi_aresetn=>false;
 
-  port reg axi_rdata:  out UInt<C_S_AXI_DATA_WIDTH> reset axi_aresetn=>0;
-  port reg axi_rresp:  out UInt<2> reset axi_aresetn=>0;
-  port reg axi_rvalid: out Bool reset axi_aresetn=>false;
+  port axi_rdata: out pipe_reg<UInt<C_S_AXI_DATA_WIDTH>, 1> reset axi_aresetn=>0;
+  port axi_rresp: out pipe_reg<UInt<2>, 1> reset axi_aresetn=>0;
+  port axi_rvalid: out pipe_reg<Bool, 1> reset axi_aresetn=>false;
   port axi_rready: in Bool;
 
-  port reg axi_ap_done: out Bool reset axi_aresetn=>false;
-  port reg irq: out Bool reset axi_aresetn=>false;
+  port axi_ap_done: out pipe_reg<Bool, 1> reset axi_aresetn=>false;
+  port irq: out pipe_reg<Bool, 1> reset axi_aresetn=>false;
 
   default seq on axi_aclk rising;
 

--- a/tests/cvdp/reed_solomon_encoder.arch
+++ b/tests/cvdp/reed_solomon_encoder.arch
@@ -8,10 +8,10 @@ module reed_solomon_encoder
   port enable:        in Bool;
   port data_in:       in UInt<DATA_WIDTH>;
   port valid_in:      in Bool;
-  port reg codeword_out:  out UInt<DATA_WIDTH> reset reset=>0;
-  port reg valid_out:     out Bool reset reset=>false;
-  port reg parity_0:      out UInt<DATA_WIDTH> reset reset=>0;
-  port reg parity_1:      out UInt<DATA_WIDTH> reset reset=>0;
+  port codeword_out: out pipe_reg<UInt<DATA_WIDTH>, 1> reset reset=>0;
+  port valid_out: out pipe_reg<Bool, 1> reset reset=>false;
+  port parity_0: out pipe_reg<UInt<DATA_WIDTH>, 1> reset reset=>0;
+  port parity_1: out pipe_reg<UInt<DATA_WIDTH>, 1> reset reset=>0;
 
   // Generator polynomial coefficient
   let gp: UInt<DATA_WIDTH> = 8'h33;

--- a/tests/cvdp/restore_division.arch
+++ b/tests/cvdp/restore_division.arch
@@ -5,9 +5,9 @@ module restoring_division
   port start: in Bool;
   port dividend: in UInt<WIDTH>;
   port divisor: in UInt<WIDTH>;
-  port reg quotient: out UInt<WIDTH> reset rst=>0;
-  port reg remainder: out UInt<WIDTH> reset rst=>0;
-  port reg valid: out Bool reset rst=>false;
+  port quotient: out pipe_reg<UInt<WIDTH>, 1> reset rst=>0;
+  port remainder: out pipe_reg<UInt<WIDTH>, 1> reset rst=>0;
+  port valid: out pipe_reg<Bool, 1> reset rst=>false;
 
   default seq on clk rising;
 

--- a/tests/cvdp/restoring_division.arch
+++ b/tests/cvdp/restoring_division.arch
@@ -6,9 +6,9 @@ module restoring_division
   port start:     in Bool;
   port dividend:  in UInt<WIDTH>;
   port divisor:   in UInt<WIDTH>;
-  port reg quotient:  out UInt<WIDTH> reset rst => 0;
-  port reg remainder: out UInt<WIDTH> reset rst => 0;
-  port reg valid:     out Bool reset rst => false;
+  port quotient: out pipe_reg<UInt<WIDTH>, 1> reset rst => 0;
+  port remainder: out pipe_reg<UInt<WIDTH>, 1> reset rst => 0;
+  port valid: out pipe_reg<Bool, 1> reset rst => false;
 
   default seq on clk rising;
 

--- a/tests/cvdp/run_length.arch
+++ b/tests/cvdp/run_length.arch
@@ -4,9 +4,9 @@ module run_length
   port clk:      in Clock<SysDomain>;
   port reset_n:  in Reset<Async, Low>;
   port data_in:  in Bit;
-  port reg data_out:  out Bit reset reset_n=>0;
-  port reg run_value: out UInt<$clog2(DATA_WIDTH) + 1> reset reset_n=>0;
-  port reg valid:     out Bit reset reset_n=>0;
+  port data_out: out pipe_reg<Bit, 1> reset reset_n=>0;
+  port run_value: out pipe_reg<UInt<$clog2(DATA_WIDTH) + 1>, 1> reset reset_n=>0;
+  port valid: out pipe_reg<Bit, 1> reset reset_n=>0;
 
   default seq on clk rising;
 

--- a/tests/cvdp/secure_read_write_bus_interface.arch
+++ b/tests/cvdp/secure_read_write_bus_interface.arch
@@ -9,8 +9,8 @@ module secure_read_write_bus_interface
   port i_data_in: in UInt<P_DATA_WIDTH>;
   port i_key_in: in UInt<8>;
   port i_read_write_enable: in Bit;
-  port reg o_data_out: out UInt<P_DATA_WIDTH> reset i_reset_bar=>0;
-  port reg o_error: out Bit reset i_reset_bar=>0;
+  port o_data_out: out pipe_reg<UInt<P_DATA_WIDTH>, 1> reset i_reset_bar=>0;
+  port o_error: out pipe_reg<Bit, 1> reset i_reset_bar=>0;
 
   default seq on i_capture_pulse rising;
 

--- a/tests/cvdp/secure_variable_timer.arch
+++ b/tests/cvdp/secure_variable_timer.arch
@@ -2,9 +2,9 @@ module secure_variable_timer
   port i_clk: in Clock<SysDomain>;
   port i_rst_n: in Reset<Sync, Low>;
   port i_data_in: in Bool;
-  port reg o_time_left: out UInt<4> reset i_rst_n=>0;
-  port reg o_processing: out Bool reset i_rst_n=>false;
-  port reg o_completed: out Bool reset i_rst_n=>false;
+  port o_time_left: out pipe_reg<UInt<4>, 1> reset i_rst_n=>0;
+  port o_processing: out pipe_reg<Bool, 1> reset i_rst_n=>false;
+  port o_completed: out pipe_reg<Bool, 1> reset i_rst_n=>false;
   port i_ack: in Bool;
 
   default seq on i_clk rising;

--- a/tests/cvdp/sgd_linear_regression.arch
+++ b/tests/cvdp/sgd_linear_regression.arch
@@ -9,8 +9,8 @@ module sgd_linear_regression
   port reset: in Reset<Async, High>;
   port x_in: in SInt<DATA_WIDTH>;
   port y_true: in SInt<DATA_WIDTH>;
-  port reg w_out: out SInt<DATA_WIDTH> reset reset=>0;
-  port reg b_out: out SInt<DATA_WIDTH> reset reset=>0;
+  port w_out: out pipe_reg<SInt<DATA_WIDTH>, 1> reset reset=>0;
+  port b_out: out pipe_reg<SInt<DATA_WIDTH>, 1> reset reset=>0;
 
   default seq on clk rising;
 

--- a/tests/cvdp/single_port_ram.arch
+++ b/tests/cvdp/single_port_ram.arch
@@ -6,7 +6,7 @@ module single_port_ram
   port we:   in Bool;
   port addr: in UInt<ADDR_WIDTH>;
   port din:  in UInt<DATA_WIDTH>;
-  port reg dout: out UInt<DATA_WIDTH>;
+  port dout: out pipe_reg<UInt<DATA_WIDTH>, 1>;
 
   default seq on clk rising;
 

--- a/tests/cvdp/spi_fsm.arch
+++ b/tests/cvdp/spi_fsm.arch
@@ -8,12 +8,12 @@ module spi_fsm
   port i_fault:    in Bool;
   port i_clear:    in Bool;
 
-  port reg o_spi_cs_b:  out Bool      reset i_rst_b => true;
-  port reg o_spi_clk:   out Bool      reset i_rst_b => false;
-  port reg o_spi_data:  out Bool      reset i_rst_b => false;
-  port reg o_bits_left: out UInt<5>   reset i_rst_b => 5'h10;
-  port reg o_done:      out Bool      reset i_rst_b => false;
-  port reg o_fsm_state: out UInt<2>   reset i_rst_b => 0;
+  port o_spi_cs_b: out pipe_reg<Bool, 1>      reset i_rst_b => true;
+  port o_spi_clk: out pipe_reg<Bool, 1>      reset i_rst_b => false;
+  port o_spi_data: out pipe_reg<Bool, 1>      reset i_rst_b => false;
+  port o_bits_left: out pipe_reg<UInt<5>, 1>   reset i_rst_b => 5'h10;
+  port o_done: out pipe_reg<Bool, 1>      reset i_rst_b => false;
+  port o_fsm_state: out pipe_reg<UInt<2>, 1>   reset i_rst_b => 0;
 
   reg shift_r: UInt<16> reset i_rst_b => 0;
   reg state_r: UInt<2>  reset i_rst_b => 0;

--- a/tests/cvdp/sprite_fsm.arch
+++ b/tests/cvdp/sprite_fsm.arch
@@ -9,13 +9,13 @@ fsm sprite_controller_fsm
   port clk: in Clock<SysDomain>;
   port rst_n: in Reset<Sync, Low>;
   port i_wait: in UInt<WAIT_WIDTH>;
-  port reg rw: out Bool reset rst_n=>false;
-  port reg write_addr: out UInt<MEM_ADDR_WIDTH> reset rst_n=>0;
-  port reg write_data: out UInt<PIXEL_WIDTH> reset rst_n=>0;
-  port reg x_pos: out UInt<SPRITE_WIDTH> reset rst_n=>0;
-  port reg y_pos: out UInt<SPRITE_HEIGHT> reset rst_n=>0;
+  port rw: out pipe_reg<Bool, 1> reset rst_n=>false;
+  port write_addr: out pipe_reg<UInt<MEM_ADDR_WIDTH>, 1> reset rst_n=>0;
+  port write_data: out pipe_reg<UInt<PIXEL_WIDTH>, 1> reset rst_n=>0;
+  port x_pos: out pipe_reg<UInt<SPRITE_WIDTH>, 1> reset rst_n=>0;
+  port y_pos: out pipe_reg<UInt<SPRITE_HEIGHT>, 1> reset rst_n=>0;
   port pixel_out: in UInt<PIXEL_WIDTH>;
-  port reg done: out Bool reset rst_n=>false;
+  port done: out pipe_reg<Bool, 1> reset rst_n=>false;
 
   reg addr_cnt: UInt<MEM_ADDR_WIDTH> reset rst_n=>0;
   reg data_cnt: UInt<PIXEL_WIDTH> reset rst_n=>0;

--- a/tests/cvdp/strob_gen.arch
+++ b/tests/cvdp/strob_gen.arch
@@ -4,7 +4,7 @@ module strob_gen
   port clk:      in Clock<SysDomain>;
   port nrst:     in Reset<Async, Low>;
   port enable:   in Bool;
-  port reg strobe_o: out Bool reset nrst=>false;
+  port strobe_o: out pipe_reg<Bool, 1> reset nrst=>false;
 
   default seq on clk rising;
 

--- a/tests/cvdp/swizzler.arch
+++ b/tests/cvdp/swizzler.arch
@@ -14,8 +14,8 @@ module swizzler
   reg swizzle_reg: UInt<N>;
   reg error_reg: Bit;
   reg operation_reg: UInt<N>;
-  port reg data_out: out UInt<N>;
-  port reg error_flag: out Bit;
+  port data_out: out pipe_reg<UInt<N>, 1>;
+  port error_flag: out pipe_reg<Bit, 1>;
 
   // Combinational wires
   wire temp_error_flag: Bit;

--- a/tests/cvdp/sync_lifo.arch
+++ b/tests/cvdp/sync_lifo.arch
@@ -8,9 +8,9 @@ module sync_lifo
   port write_en: in Bool;
   port read_en: in Bool;
   port data_in: in UInt<DATA_WIDTH>;
-  port reg empty: out Bool reset reset=>true;
-  port reg full: out Bool reset reset=>false;
-  port reg data_out: out UInt<DATA_WIDTH> reset reset=>0;
+  port empty: out pipe_reg<Bool, 1> reset reset=>true;
+  port full: out pipe_reg<Bool, 1> reset reset=>false;
+  port data_out: out pipe_reg<UInt<DATA_WIDTH>, 1> reset reset=>0;
 
   default seq on clock rising;
 

--- a/tests/cvdp/sync_pos_neg_edge_detector.arch
+++ b/tests/cvdp/sync_pos_neg_edge_detector.arch
@@ -2,8 +2,8 @@ module sync_pos_neg_edge_detector
   port i_clk: in Clock<SysDomain>;
   port i_rstb: in Reset<Async, Low>;
   port i_detection_signal: in Bool;
-  port reg o_positive_edge_detected: out Bool reset i_rstb => 0;
-  port reg o_negative_edge_detected: out Bool reset i_rstb => 0;
+  port o_positive_edge_detected: out pipe_reg<Bool, 1> reset i_rstb => 0;
+  port o_negative_edge_detected: out pipe_reg<Bool, 1> reset i_rstb => 0;
 
   reg prev: Bool reset i_rstb => 0;
 

--- a/tests/cvdp/thermostat.arch
+++ b/tests/cvdp/thermostat.arch
@@ -6,14 +6,14 @@ module thermostat
   port i_enable:        in Bool;
   port i_fault:         in Bool;
   port i_clr:           in Bool;
-  port reg o_heater_full:   out Bool reset i_rst=>false;
-  port reg o_heater_medium: out Bool reset i_rst=>false;
-  port reg o_heater_low:    out Bool reset i_rst=>false;
-  port reg o_aircon_full:   out Bool reset i_rst=>false;
-  port reg o_aircon_medium: out Bool reset i_rst=>false;
-  port reg o_aircon_low:    out Bool reset i_rst=>false;
-  port reg o_fan:           out Bool reset i_rst=>false;
-  port reg o_state:         out UInt<3> reset i_rst=>3;
+  port o_heater_full: out pipe_reg<Bool, 1> reset i_rst=>false;
+  port o_heater_medium: out pipe_reg<Bool, 1> reset i_rst=>false;
+  port o_heater_low: out pipe_reg<Bool, 1> reset i_rst=>false;
+  port o_aircon_full: out pipe_reg<Bool, 1> reset i_rst=>false;
+  port o_aircon_medium: out pipe_reg<Bool, 1> reset i_rst=>false;
+  port o_aircon_low: out pipe_reg<Bool, 1> reset i_rst=>false;
+  port o_fan: out pipe_reg<Bool, 1> reset i_rst=>false;
+  port o_state: out pipe_reg<UInt<3>, 1> reset i_rst=>3;
 
   reg fault_latch: Bool reset i_rst=>false;
 

--- a/tests/cvdp/ttc_counter_lite.arch
+++ b/tests/cvdp/ttc_counter_lite.arch
@@ -6,7 +6,7 @@ module ttc_counter_lite
   port axi_write_en: in Bool;
   port axi_read_en:  in Bool;
   port axi_rdata:    out UInt<32>;
-  port reg interrupt:     out Bool reset reset=>0;
+  port interrupt: out pipe_reg<Bool, 1> reset reset=>0;
 
   default seq on clk rising;
 

--- a/tests/cvdp/vending_machine.arch
+++ b/tests/cvdp/vending_machine.arch
@@ -5,13 +5,13 @@ fsm vending_machine
   port item_selected: in UInt<3>;
   port coin_input: in UInt<4>;
   port cancel: in Bool;
-  port reg dispense_item: out Bool reset rst=>false;
-  port reg return_change: out Bool reset rst=>false;
-  port reg item_price: out UInt<5> reset rst=>0;
-  port reg change_amount: out UInt<5> reset rst=>0;
-  port reg dispense_item_id: out UInt<3> reset rst=>0;
-  port reg error: out Bool reset rst=>false;
-  port reg return_money: out Bool reset rst=>false;
+  port dispense_item: out pipe_reg<Bool, 1> reset rst=>false;
+  port return_change: out pipe_reg<Bool, 1> reset rst=>false;
+  port item_price: out pipe_reg<UInt<5>, 1> reset rst=>0;
+  port change_amount: out pipe_reg<UInt<5>, 1> reset rst=>0;
+  port dispense_item_id: out pipe_reg<UInt<3>, 1> reset rst=>0;
+  port error: out pipe_reg<Bool, 1> reset rst=>false;
+  port return_money: out pipe_reg<Bool, 1> reset rst=>false;
 
   reg coins_accumulated: UInt<5> reset rst=>0;
   reg selected_item: UInt<3> reset rst=>0;

--- a/tests/cvdp/vga_controller.arch
+++ b/tests/cvdp/vga_controller.arch
@@ -14,16 +14,16 @@ module vga_controller
   port reset: in Reset<Async, High>;
   port color_in: in UInt<8>;
 
-  port reg hsync: out Bool reset reset=>true;
-  port reg vsync: out Bool reset reset=>true;
-  port reg red: out UInt<8> reset reset=>0;
-  port reg green: out UInt<8> reset reset=>0;
-  port reg blue: out UInt<8> reset reset=>0;
-  port reg next_x: out UInt<10> reset reset=>0;
-  port reg next_y: out UInt<10> reset reset=>0;
+  port hsync: out pipe_reg<Bool, 1> reset reset=>true;
+  port vsync: out pipe_reg<Bool, 1> reset reset=>true;
+  port red: out pipe_reg<UInt<8>, 1> reset reset=>0;
+  port green: out pipe_reg<UInt<8>, 1> reset reset=>0;
+  port blue: out pipe_reg<UInt<8>, 1> reset reset=>0;
+  port next_x: out pipe_reg<UInt<10>, 1> reset reset=>0;
+  port next_y: out pipe_reg<UInt<10>, 1> reset reset=>0;
   port sync: out Bool;
   port clk_out: out Clock<SysDomain>;
-  port reg blank: out Bool reset reset=>0;
+  port blank: out pipe_reg<Bool, 1> reset reset=>0;
 
   reg h_counter: UInt<10> reset reset=>0;
   reg v_counter: UInt<10> reset reset=>0;

--- a/tests/cvdp/write_buffer_merge.arch
+++ b/tests/cvdp/write_buffer_merge.arch
@@ -14,9 +14,9 @@ module write_buffer_merge
   port wr_en_in: in Bool;
   port wr_addr_in: in UInt<INPUT_ADDR_WIDTH>;
   port wr_data_in: in UInt<INPUT_DATA_WIDTH>;
-  port reg wr_en_out: out Bool reset srst=>false;
-  port reg wr_addr_out: out UInt<OUTPUT_ADDR_WIDTH> reset srst=>0;
-  port reg wr_data_out: out UInt<OUTPUT_DATA_WIDTH> reset srst=>0;
+  port wr_en_out: out pipe_reg<Bool, 1> reset srst=>false;
+  port wr_addr_out: out pipe_reg<UInt<OUTPUT_ADDR_WIDTH>, 1> reset srst=>0;
+  port wr_data_out: out pipe_reg<UInt<OUTPUT_DATA_WIDTH>, 1> reset srst=>0;
 
   default seq on clk rising;
 

--- a/tests/l1d/FsmAxi4Fill.arch
+++ b/tests/l1d/FsmAxi4Fill.arch
@@ -11,7 +11,7 @@ fsm FsmAxi4Fill
   port fill_done:  out Bool;
 
   // Filled line words — registered Vec, retain value after Done
-  port reg fill_word: out Vec<UInt<64>, 8> reset rst=>0;
+  port fill_word: out pipe_reg<Vec<UInt<64>, 8>, 1> reset rst=>0;
 
   // AXI4 read address channel
   port ar_valid: out Bool;

--- a/tests/verilog_eval/Prob031_dff.arch
+++ b/tests/verilog_eval/Prob031_dff.arch
@@ -1,7 +1,7 @@
 module TopModule
   port clk: in Clock<SysDomain>;
   port d: in Bool;
-  port reg q: out Bool;
+  port q: out pipe_reg<Bool, 1>;
 
   default seq on clk rising;
 

--- a/tests/verilog_eval/Prob034_dff8.arch
+++ b/tests/verilog_eval/Prob034_dff8.arch
@@ -1,7 +1,7 @@
 module TopModule
   port clk: in Clock<SysDomain>;
   port d: in UInt<8>;
-  port reg q: out UInt<8>;
+  port q: out pipe_reg<UInt<8>, 1>;
 
   default seq on clk rising;
 

--- a/tests/verilog_eval/Prob035_count1to10.arch
+++ b/tests/verilog_eval/Prob035_count1to10.arch
@@ -1,7 +1,7 @@
 module TopModule
   port clk: in Clock<SysDomain>;
   port reset: in Reset<Sync>;
-  port reg q: out UInt<4> reset reset=>1;
+  port q: out pipe_reg<UInt<4>, 1> reset reset=>1;
 
   default seq on clk rising;
 

--- a/tests/verilog_eval/Prob037_review2015_count1k.arch
+++ b/tests/verilog_eval/Prob037_review2015_count1k.arch
@@ -1,7 +1,7 @@
 module TopModule
   port clk: in Clock<SysDomain>;
   port reset: in Reset<Sync>;
-  port reg q: out UInt<10> reset reset=>0;
+  port q: out pipe_reg<UInt<10>, 1> reset reset=>0;
 
   default seq on clk rising;
 

--- a/tests/verilog_eval/Prob041_dff8r.arch
+++ b/tests/verilog_eval/Prob041_dff8r.arch
@@ -2,7 +2,7 @@ module TopModule
   port clk: in Clock<SysDomain>;
   port reset: in Reset<Sync>;
   port d: in UInt<8>;
-  port reg q: out UInt<8> reset reset=>0;
+  port q: out pipe_reg<UInt<8>, 1> reset reset=>0;
 
   default seq on clk rising;
 

--- a/tests/verilog_eval/Prob045_edgedetect2.arch
+++ b/tests/verilog_eval/Prob045_edgedetect2.arch
@@ -2,7 +2,7 @@
 module TopModule
   port clk: in Clock<SysDomain>;
   port in: in UInt<8>;
-  port reg anyedge: out UInt<8> init 0 reset none;
+  port anyedge: out pipe_reg<UInt<8>, 1> init 0 reset none;
 
   default seq on clk rising;
 

--- a/tests/verilog_eval/Prob046_dff8p.arch
+++ b/tests/verilog_eval/Prob046_dff8p.arch
@@ -3,7 +3,7 @@ module TopModule
   port clk: in Clock<SysDomain>;
   port reset: in Reset<Sync>;
   port d: in UInt<8>;
-  port reg q: out UInt<8> reset reset=>0x34;
+  port q: out pipe_reg<UInt<8>, 1> reset reset=>0x34;
 
   default seq on clk falling;
 

--- a/tests/verilog_eval/Prob047_dff8ar.arch
+++ b/tests/verilog_eval/Prob047_dff8ar.arch
@@ -2,7 +2,7 @@ module TopModule
   port clk: in Clock<SysDomain>;
   port areset: in Reset<Async>;
   port d: in UInt<8>;
-  port reg q: out UInt<8> reset areset=>0;
+  port q: out pipe_reg<UInt<8>, 1> reset areset=>0;
 
   default seq on clk rising;
 

--- a/tests/verilog_eval/Prob048_m2014_q4c.arch
+++ b/tests/verilog_eval/Prob048_m2014_q4c.arch
@@ -2,7 +2,7 @@ module TopModule
   port clk: in Clock<SysDomain>;
   port r: in Reset<Sync>;
   port d: in Bool;
-  port reg q: out Bool reset r=>0;
+  port q: out pipe_reg<Bool, 1> reset r=>0;
 
   default seq on clk rising;
 

--- a/tests/verilog_eval/Prob049_m2014_q4b.arch
+++ b/tests/verilog_eval/Prob049_m2014_q4b.arch
@@ -2,7 +2,7 @@ module TopModule
   port clk: in Clock<SysDomain>;
   port ar: in Reset<Async>;
   port d: in Bool;
-  port reg q: out Bool reset ar=>0;
+  port q: out pipe_reg<Bool, 1> reset ar=>0;
 
   default seq on clk rising;
 

--- a/tests/verilog_eval/Prob053_m2014_q4d.arch
+++ b/tests/verilog_eval/Prob053_m2014_q4d.arch
@@ -1,7 +1,7 @@
 module TopModule
   port clk: in Clock<SysDomain>;
   port in: in Bool;
-  port reg out: out Bool;
+  port out: out pipe_reg<Bool, 1>;
 
   default seq on clk rising;
 

--- a/tests/verilog_eval/Prob054_edgedetect.arch
+++ b/tests/verilog_eval/Prob054_edgedetect.arch
@@ -2,7 +2,7 @@
 module TopModule
   port clk: in Clock<SysDomain>;
   port in: in UInt<8>;
-  port reg pedge: out UInt<8>;
+  port pedge: out pipe_reg<UInt<8>, 1>;
 
   default seq on clk rising;
 

--- a/tests/verilog_eval/Prob056_ece241_2013_q7.arch
+++ b/tests/verilog_eval/Prob056_ece241_2013_q7.arch
@@ -2,7 +2,7 @@ module TopModule
   port clk: in Clock<SysDomain>;
   port j: in Bool;
   port k: in Bool;
-  port reg Q: out Bool;
+  port Q: out pipe_reg<Bool, 1>;
 
   default seq on clk rising;
 

--- a/tests/verilog_eval/Prob058_alwaysblock2.arch
+++ b/tests/verilog_eval/Prob058_alwaysblock2.arch
@@ -4,7 +4,7 @@ module TopModule
   port b: in Bool;
   port out_assign: out Bool;
   port out_always_comb: out Bool;
-  port reg out_always_ff: out Bool;
+  port out_always_ff: out pipe_reg<Bool, 1>;
 
   default seq on clk rising;
 

--- a/tests/verilog_eval/Prob061_2014_q4a.arch
+++ b/tests/verilog_eval/Prob061_2014_q4a.arch
@@ -5,7 +5,7 @@ module TopModule
   port R: in Bool;
   port E: in Bool;
   port L: in Bool;
-  port reg Q: out Bool;
+  port Q: out pipe_reg<Bool, 1>;
 
   default seq on clk rising;
 

--- a/tests/verilog_eval/Prob063_review2015_shiftcount.arch
+++ b/tests/verilog_eval/Prob063_review2015_shiftcount.arch
@@ -5,7 +5,7 @@ module TopModule
   port shift_ena: in Bool;
   port count_ena: in Bool;
   port data: in Bool;
-  port reg q: out UInt<4>;
+  port q: out pipe_reg<UInt<4>, 1>;
 
   default seq on clk rising;
 

--- a/tests/verilog_eval/Prob067_countslow.arch
+++ b/tests/verilog_eval/Prob067_countslow.arch
@@ -2,7 +2,7 @@ module TopModule
   port clk: in Clock<SysDomain>;
   port reset: in Reset<Sync>;
   port slowena: in Bool;
-  port reg q: out UInt<4> reset reset=>0;
+  port q: out pipe_reg<UInt<4>, 1> reset reset=>0;
 
   default seq on clk rising;
 

--- a/tests/verilog_eval/Prob073_dff16e.arch
+++ b/tests/verilog_eval/Prob073_dff16e.arch
@@ -4,7 +4,7 @@ module TopModule
   port resetn: in Reset<Sync, Low>;
   port byteena: in UInt<2>;
   port d: in UInt<16>;
-  port reg q: out UInt<16> reset resetn=>0;
+  port q: out pipe_reg<UInt<16>, 1> reset resetn=>0;
 
   default seq on clk rising;
 

--- a/tests/verilog_eval/Prob075_counter_2bc.arch
+++ b/tests/verilog_eval/Prob075_counter_2bc.arch
@@ -4,7 +4,7 @@ module TopModule
   port areset: in Reset<Async>;
   port train_valid: in Bool;
   port train_taken: in Bool;
-  port reg state: out UInt<2> reset areset=>1;
+  port state: out pipe_reg<UInt<2>, 1> reset areset=>1;
 
   default seq on clk rising;
 

--- a/tests/verilog_eval/Prob082_lfsr32.arch
+++ b/tests/verilog_eval/Prob082_lfsr32.arch
@@ -1,7 +1,7 @@
 module TopModule
   port clk: in Clock<SysDomain>;
   port reset: in Reset<Sync>;
-  port reg q: out UInt<32> reset reset=>1;
+  port q: out pipe_reg<UInt<32>, 1> reset reset=>1;
 
   default seq on clk rising;
 

--- a/tests/verilog_eval/Prob085_shift4.arch
+++ b/tests/verilog_eval/Prob085_shift4.arch
@@ -4,7 +4,7 @@ module TopModule
   port load: in Bool;
   port ena: in Bool;
   port data: in UInt<4>;
-  port reg q: out UInt<4> reset areset=>0;
+  port q: out pipe_reg<UInt<4>, 1> reset areset=>0;
 
   default seq on clk rising;
 

--- a/tests/verilog_eval/Prob098_circuit7.arch
+++ b/tests/verilog_eval/Prob098_circuit7.arch
@@ -1,7 +1,7 @@
 module TopModule
   port clk: in Clock<SysDomain>;
   port a: in Bool;
-  port reg q: out Bool;
+  port q: out pipe_reg<Bool, 1>;
 
   default seq on clk rising;
 

--- a/tests/verilog_eval/Prob104_mt2015_muxdff.arch
+++ b/tests/verilog_eval/Prob104_mt2015_muxdff.arch
@@ -3,7 +3,7 @@ module TopModule
   port L: in Bool;
   port q_in: in Bool;
   port r_in: in Bool;
-  port reg Q: out Bool;
+  port Q: out pipe_reg<Bool, 1>;
 
   default seq on clk rising;
 

--- a/tests/verilog_eval/Prob105_rotate100.arch
+++ b/tests/verilog_eval/Prob105_rotate100.arch
@@ -3,7 +3,7 @@ module TopModule
   port load: in Bool;
   port ena: in UInt<2>;
   port data: in UInt<100>;
-  port reg q: out UInt<100>;
+  port q: out pipe_reg<UInt<100>, 1>;
 
   default seq on clk rising;
 

--- a/tests/verilog_eval/Prob108_rule90.arch
+++ b/tests/verilog_eval/Prob108_rule90.arch
@@ -2,7 +2,7 @@ module TopModule
   port clk: in Clock<SysDomain>;
   port load: in Bool;
   port data: in UInt<512>;
-  port reg q: out UInt<512>;
+  port q: out pipe_reg<UInt<512>, 1>;
 
   default seq on clk rising;
 

--- a/tests/verilog_eval/Prob117_circuit9.arch
+++ b/tests/verilog_eval/Prob117_circuit9.arch
@@ -1,7 +1,7 @@
 module TopModule
   port clk: in Clock<SysDomain>;
   port a: in Bool;
-  port reg q: out UInt<3>;
+  port q: out pipe_reg<UInt<3>, 1>;
 
   default seq on clk rising;
 

--- a/tests/verilog_eval/Prob118_history_shift.arch
+++ b/tests/verilog_eval/Prob118_history_shift.arch
@@ -6,7 +6,7 @@ module TopModule
   port train_mispredicted: in Bool;
   port train_taken: in Bool;
   port train_history: in UInt<32>;
-  port reg predict_history: out UInt<32> reset areset=>0;
+  port predict_history: out pipe_reg<UInt<32>, 1> reset areset=>0;
 
   default seq on clk rising;
 

--- a/tests/verilog_eval/Prob124_rule110.arch
+++ b/tests/verilog_eval/Prob124_rule110.arch
@@ -2,7 +2,7 @@ module TopModule
   port clk: in Clock<SysDomain>;
   port load: in Bool;
   port data: in UInt<512>;
-  port reg q: out UInt<512>;
+  port q: out pipe_reg<UInt<512>, 1>;
 
   default seq on clk rising;
 

--- a/tests/verilog_eval/Prob144_conwaylife.arch
+++ b/tests/verilog_eval/Prob144_conwaylife.arch
@@ -3,7 +3,7 @@ module TopModule
   port clk: in Clock<SysDomain>;
   port load: in Bool;
   port data: in UInt<256>;
-  port reg q: out UInt<256> init 0 reset none;
+  port q: out pipe_reg<UInt<256>, 1> init 0 reset none;
 
   default seq on clk rising;
 

--- a/tests/verilog_eval/Prob147_circuit10.arch
+++ b/tests/verilog_eval/Prob147_circuit10.arch
@@ -5,7 +5,7 @@ module TopModule
   port clk: in Clock<SysDomain>;
   port a: in Bool;
   port b: in Bool;
-  port reg state: out Bool;
+  port state: out pipe_reg<Bool, 1>;
   port q: out Bool;
 
   default seq on clk rising;


### PR DESCRIPTION
## Summary

Pure-source-level rename across \`tests/\`: \`port reg NAME: out T [modifiers];\` → \`port NAME: out pipe_reg<T, 1> [modifiers];\`. Zero SV output changes (byte-identical lowering, guaranteed by \`test_pipe_reg_port_n1_equivalent_to_port_reg\` from #45).

### Surface

| | before | after |
|---|---|---|
| \`.arch\` port decls | 318 | 318 migrated |
| \`.archi\` interface file decls | 196 | 196 migrated |
| Total files touched | — | 163 |
| Snapshot diffs | — | 0 |

### What didn't change

- **Assignments** (\`name <= expr\`) are unchanged because the compiler accepts bare \`<=\` for N=1; only N>1 forces \`@N\`.
- **Legacy \`port reg\` syntax** still compiles; this just moves the canonical teaching form in the test corpus.
- **Two comments** that describe runtime timing behavior (not syntax) are left as-is.

### Why

PR #45 landed \`pipe_reg<T, N>\` + \`@N\` but deferred corpus migration. LLMs and humans reading tests see the dominant spelling first — moving the corpus to the new form makes the latency-in-signature win visible everywhere.

## Test plan
- [x] \`cargo test\` — 102 tests pass after the rewrite
- [x] \`git diff tests/snapshots/\` — zero diff (byte-identical SV output)

🤖 Generated with [Claude Code](https://claude.com/claude-code)