### PR TITLE
feat: standard bus library — BusAxiStream + BusAxiLite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,6 +81,7 @@ dependencies = [
  "insta",
  "logos",
  "miette",
+ "tempfile",
  "thiserror",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,4 @@ clap = { version = "4", features = ["derive"] }
 
 [dev-dependencies]
 insta = "1"
+tempfile = "3"

--- a/doc/plan_stdlib_buses.md
+++ b/doc/plan_stdlib_buses.md
@@ -1,0 +1,226 @@
+# Plan: Standard bus package
+
+*Author: session of 2026-04-22. Status: design draft; v1 scope is small.*
+
+## Motivation
+
+AXI4-Stream, AXI4-Lite, AXI4-Full, APB, and Avalon-ST are the bus
+shapes that dominate SoC glue code. Every user who tries to write them
+by hand runs into the same problems: direction-flip mistakes, forgotten
+sideband signals, and LLMs fabricating made-up field names. The
+existing `bus` + `handshake` + `generate_if` vocabulary can express
+every one of these cleanly — but users shouldn't have to rewrite them
+from scratch in every project.
+
+The natural answer is a **standard library**: a set of curated `.arch`
+files shipped with the compiler, each defining one canonical bus, that
+users import with `use BusX;`. This keeps the language surface unchanged
+and pushes the domain knowledge into a library that evolves
+independently of the compiler.
+
+This is the "library not language" instinct — the same choice Chisel,
+SpinalHDL, and FIRRTL communities eventually landed on for bundled
+protocols.
+
+## Principles
+
+1. **No new compiler construct.** Standard buses are `.arch` files that
+   use `bus`, `handshake`, and `generate_if` exactly the way user code
+   would. If a user reads a stdlib bus file, they learn the canonical
+   pattern and can compose their own.
+2. **Parameterized, not hardcoded.** Each bus carries the knobs that
+   every real design configures: data width, address width, ID width,
+   user-signal width, optional feature toggles (e.g., "does this
+   AXI-Stream carry `last` + `keep`?"). Users set params at the port
+   site, compiler generates the right port set.
+3. **Versioned by file, not by release.** Fixing an AXI-Stream bug or
+   adding a missing signal is a single PR against one file. No
+   compiler work required.
+4. **Extensible.** A third party can ship `BusMyCompanyProto.arch`
+   the same way; the ARCH compiler treats stdlib and user buses
+   identically.
+
+## Package discovery
+
+Today `use X;` resolves `X.arch` by searching:
+1. The directory of the current source file
+2. `ARCH_LIB_PATH` environment variable (colon-separated paths)
+
+**Extension for stdlib**: the compiler binary itself knows its install
+location and adds `<install>/stdlib/` to the search path as a lowest-
+priority entry (user code + `ARCH_LIB_PATH` shadow it). A built-in bus
+like `BusAxiStream` is then `use BusAxiStream;` with zero setup.
+
+Install-location resolution:
+- **Release install**: `<exe>/../stdlib/` where `<exe>` is the directory
+  of the `arch` binary — matches Unix convention where `<prefix>/bin/arch`
+  and `<prefix>/stdlib/` are siblings. Falls back to `<prefix>/share/arch/stdlib/`
+  if the binary is installed to `/usr/local/bin/`.
+- **Dev build (`cargo run`)**: walk up from `<exe>` to find a `Cargo.toml`
+  and use its `../stdlib/`. Lets `cargo run -- build foo.arch` find the
+  stdlib without any env var setup.
+- **Override**: `ARCH_STDLIB_PATH` (if set) wins outright.
+- **Disable**: `ARCH_NO_STDLIB=1` skips the stdlib search entirely
+  (for tests and debugging shadowing).
+
+The resolution order becomes:
+1. Same-directory relative path
+2. `ARCH_LIB_PATH` entries (user)
+3. `<install>/stdlib/` (unless `ARCH_NO_STDLIB=1`)
+
+## Naming convention
+
+Flat names with a `Bus` prefix, e.g., `BusAxiStream`, `BusAxiLite`,
+`BusApb`. Matches the existing working convention in the test corpus
+(`BusAxiLite` already exists in `tests/axi_dma/`). When/if ARCH gets
+module-path namespacing, these can migrate to `Std.AxiStream` etc.
+without source churn — just renaming the files.
+
+## v1 contents — ship only these three
+
+Starting narrow on purpose. Adding more is one file each; easy to do
+after the first three shake out the structure.
+
+| Bus | Coverage | Key params |
+|---|---|---|
+| `BusAxiStream`  | AXI4-Stream simple + full | `DATA_W`, `USE_LAST`, `USE_KEEP`, `USE_STRB`, `ID_W`, `DEST_W`, `USER_W` |
+| `BusAxiLite`    | AXI4-Lite memory-mapped   | `ADDR_W`, `DATA_W` |
+| `BusApb`        | APB3 / APB4               | `ADDR_W`, `DATA_W`, `USE_PPROT`, `USE_PSTRB` |
+
+Explicitly **not** in v1:
+- AXI4-Full (ID width, burst, lock, cache, prot, qos, region, response
+  channels) — large surface, defer to v2 after the first three prove
+  the pattern.
+- Avalon-ST, Avalon-MM, Wishbone — demand-driven additions.
+- Stateful protocols (credit-based flow control) — belongs in a future
+  `credit_channel` construct, not in this package.
+
+## Example: `BusAxiStream` (expected shape)
+
+```
+// stdlib/BusAxiStream.arch
+bus BusAxiStream
+  param DATA_W:  const = 32;
+  param ID_W:    const = 0;     // 0 → omit tid
+  param DEST_W:  const = 0;     // 0 → omit tdest
+  param USER_W:  const = 0;     // 0 → omit tuser
+  param USE_LAST: const = 1;    // 0 → omit tlast
+  param USE_KEEP: const = 1;    // 0 → omit tkeep
+  param USE_STRB: const = 0;    // 0 → omit tstrb
+
+  handshake t: send kind: valid_ready
+    data: UInt<DATA_W>;
+    generate_if USE_LAST
+      last: Bool;
+    end generate_if
+    generate_if USE_KEEP
+      keep: UInt<DATA_W/8>;
+    end generate_if
+    generate_if USE_STRB
+      strb: UInt<DATA_W/8>;
+    end generate_if
+    generate_if ID_W > 0
+      id: UInt<ID_W>;
+    end generate_if
+    generate_if DEST_W > 0
+      dest: UInt<DEST_W>;
+    end generate_if
+    generate_if USER_W > 0
+      user: UInt<USER_W>;
+    end generate_if
+  end handshake t
+end bus BusAxiStream
+```
+
+Usage:
+
+```
+use BusAxiStream;
+
+module Producer
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port axi: initiator BusAxiStream<DATA_W=32, USE_LAST=1, USE_KEEP=0>;
+  ...
+end module Producer
+```
+
+The port expands to:
+
+```systemverilog
+output logic       axi_t_valid,
+input  logic       axi_t_ready,
+output logic [31:0] axi_t_data,
+output logic        axi_t_last
+```
+
+Clean, matches industry naming, zero boilerplate at the use site.
+
+## Constraints that surface v2 work
+
+Writing `BusAxiStream` against the current grammar surfaces one real
+issue: **`handshake` payload field declarations inside `generate_if`
+aren't yet supported**. Today the handshake parser expects a flat list
+of `name: type;` fields with no conditional branches. Before v1 ships,
+we need to extend the handshake parser to accept `generate_if` inside
+a payload list (reusing the existing generate_if machinery).
+
+That's the only compiler-side work required for v1 stdlib. Everything
+else is pure data.
+
+## Testing
+
+Each stdlib bus ships with a matching test:
+
+- `tests/stdlib/bus_axi_stream_test.arch` — a Producer + Consumer pair
+  using `BusAxiStream`, connected via inst. `arch build` should produce
+  Verilator-lint-clean SV; a small TB drives a handful of beats and
+  asserts protocol correctness.
+- Same pattern for `BusAxiLite` and `BusApb`.
+
+This gives us regression coverage without forcing every test in the
+repo to migrate to stdlib names.
+
+## Implementation roadmap
+
+### PR #1 — compiler: stdlib path discovery + handshake-in-generate_if
+
+1. `main.rs resolve_use_imports`: after same-dir + `ARCH_LIB_PATH` lookup,
+   consult `<install>/stdlib/`. Respect `ARCH_STDLIB_PATH` override and
+   `ARCH_NO_STDLIB=1`.
+2. Parser: allow `generate_if COND ... end generate_if` inside
+   `handshake` payload blocks, mirroring the existing bus-level
+   generate_if. Elaboration already handles the condition evaluation.
+3. One integration test confirming stdlib discovery works (a stub
+   `.arch` file in `stdlib/` that a module can `use`).
+
+### PR #2 — write the three bus files + tests
+
+1. `stdlib/BusAxiStream.arch`
+2. `stdlib/BusAxiLite.arch`
+3. `stdlib/BusApb.arch`
+4. `tests/stdlib/` Producer/Consumer tests for each.
+
+### PR #3 — docs
+
+Spec mention of stdlib with the contents table and one example;
+reference card entry showing `use BusAxiStream;` as the canonical way
+to introduce an AXI-Stream port.
+
+## Non-goals
+
+- Not a full AXI4-Full implementation in v1. Defer until the basic
+  three shake out the structure.
+- Not introducing a namespace / module-path system. Flat `BusX` names
+  for now; namespace refactor is a separate language change.
+- Not building a formal verification library alongside. Each stdlib
+  bus should work with `arch formal` via the normal path (including
+  the Tier 2 auto-emitted handshake assertions), but no dedicated
+  formal harness ships with the stdlib in v1.
+
+## Open question
+
+Do we want a **versioned** stdlib (`use BusAxiStream@v2;` pinning) or
+always-latest? v1 answer: always-latest. If a breaking change to a
+stdlib bus ever becomes necessary, we introduce a new name (e.g.,
+`BusAxiStreamV2`) rather than invent a versioning syntax.

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -5952,15 +5952,42 @@ impl<'a> Codegen<'a> {
     }
 
     fn subst_expr(expr: &Expr, params: &std::collections::HashMap<String, &Expr>) -> Expr {
-        match &expr.kind {
+        let kind = match &expr.kind {
             ExprKind::Ident(name) => {
                 if let Some(replacement) = params.get(name) {
-                    (*replacement).clone()
-                } else {
-                    expr.clone()
+                    return (*replacement).clone();
                 }
+                ExprKind::Ident(name.clone())
             }
-            _ => expr.clone(),
+            // Recurse into expression trees so arithmetic width expressions
+            // (e.g. `UInt<DATA_W / 8>`, `UInt<DATA_W * 2>`) get the param
+            // substituted in every operand. Without this, the ident shows
+            // up verbatim in the emitted SV and downstream tools fail.
+            ExprKind::Binary(op, l, r) => ExprKind::Binary(
+                *op,
+                Box::new(Self::subst_expr(l, params)),
+                Box::new(Self::subst_expr(r, params)),
+            ),
+            ExprKind::Unary(op, e) => ExprKind::Unary(
+                *op,
+                Box::new(Self::subst_expr(e, params)),
+            ),
+            ExprKind::Ternary(c, t, e) => ExprKind::Ternary(
+                Box::new(Self::subst_expr(c, params)),
+                Box::new(Self::subst_expr(t, params)),
+                Box::new(Self::subst_expr(e, params)),
+            ),
+            ExprKind::Clog2(e) => ExprKind::Clog2(Box::new(Self::subst_expr(e, params))),
+            ExprKind::Index(b, i) => ExprKind::Index(
+                Box::new(Self::subst_expr(b, params)),
+                Box::new(Self::subst_expr(i, params)),
+            ),
+            _ => return expr.clone(),
+        };
+        Expr {
+            kind,
+            span: expr.span,
+            parenthesized: expr.parenthesized,
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -784,6 +784,37 @@ sys.exit(0 if ok else 1)
 /// Resolve `use PkgName;` imports: find PkgName.arch files relative to the
 /// first input file's directory. Returns an extended MultiSource with
 /// dependency files prepended.
+/// Locate the shipped standard library directory containing curated bus
+/// definitions (BusAxiStream, BusAxiLite, BusApb, etc.). Resolution:
+///   1. `ARCH_STDLIB_PATH` env override (absolute path to stdlib/)
+///   2. Disabled entirely if `ARCH_NO_STDLIB=1`
+///   3. `<exe>/../stdlib/` — matches `cargo run` layout (target/debug/arch → ../../stdlib)
+///   4. `<exe>/../../stdlib/` — matches cargo workspace runs
+///   5. `<exe>/../share/arch/stdlib/` — matches Unix `<prefix>/bin/arch` installs
+/// Returns None if none of these resolve to an existing directory.
+fn resolve_stdlib_dir() -> Option<PathBuf> {
+    if std::env::var("ARCH_NO_STDLIB").is_ok() { return None; }
+    if let Ok(p) = std::env::var("ARCH_STDLIB_PATH") {
+        let p = PathBuf::from(p);
+        if p.is_dir() { return Some(p); }
+    }
+    let exe = std::env::current_exe().ok()?;
+    for up in 1..=4 {
+        let mut candidate = exe.clone();
+        for _ in 0..up {
+            candidate = candidate.parent()?.to_path_buf();
+        }
+        let stdlib = candidate.join("stdlib");
+        if stdlib.is_dir() { return Some(stdlib); }
+    }
+    // Unix prefix install: /usr/local/bin/arch → /usr/local/share/arch/stdlib
+    let exe_parent = exe.parent()?;
+    let prefix = exe_parent.parent()?;
+    let share = prefix.join("share").join("arch").join("stdlib");
+    if share.is_dir() { return Some(share); }
+    None
+}
+
 fn resolve_use_imports(files: &[PathBuf]) -> miette::Result<Vec<PathBuf>> {
     use std::collections::HashSet;
 
@@ -817,9 +848,29 @@ fn resolve_use_imports(files: &[PathBuf]) -> miette::Result<Vec<PathBuf>> {
         let mut deps = Vec::new();
         for item in &parsed.items {
             if let arch::ast::Item::Use(u) = item {
-                let dep_path = base_dir.join(format!("{}.arch", u.name.name));
-                if dep_path.exists() {
-                    deps.push(dep_path);
+                // Resolution order:
+                //   1. Same-directory relative path
+                //   2. ARCH_LIB_PATH entries (colon-separated)
+                //   3. <install>/stdlib/ (unless ARCH_NO_STDLIB=1)
+                let file_name = format!("{}.arch", u.name.name);
+                let same_dir = base_dir.join(&file_name);
+                if same_dir.exists() {
+                    deps.push(same_dir);
+                    continue;
+                }
+                let mut found = false;
+                if let Ok(lib_path) = std::env::var("ARCH_LIB_PATH") {
+                    for dir in lib_path.split(':') {
+                        let p = std::path::Path::new(dir).join(&file_name);
+                        if p.exists() { deps.push(p); found = true; break; }
+                    }
+                }
+                if found { continue; }
+                if let Some(stdlib) = resolve_stdlib_dir() {
+                    let p = stdlib.join(&file_name);
+                    if p.exists() {
+                        deps.push(p);
+                    }
                 }
             }
         }
@@ -865,6 +916,13 @@ fn resolve_use_imports(files: &[PathBuf]) -> miette::Result<Vec<PathBuf>> {
                         let p = std::path::Path::new(dir).join(format!("{inst_name}.arch"));
                         if p.exists() { deps.push(p); break; }
                     }
+                }
+                // Fall back to the shipped standard library.
+                if let Some(stdlib) = resolve_stdlib_dir() {
+                    let p = stdlib.join(format!("{inst_name}.arch"));
+                    if p.exists() { deps.push(p); continue; }
+                    let p = stdlib.join(format!("{inst_name}.archi"));
+                    if p.exists() { deps.push(p); }
                 }
             }
         }

--- a/stdlib/BusAxiLite.arch
+++ b/stdlib/BusAxiLite.arch
@@ -1,0 +1,53 @@
+// AXI4-Lite memory-mapped bus — simplified AXI4 for control/status registers.
+//
+// Five channels, each an independent valid/ready handshake:
+//   aw — write address
+//   w  — write data
+//   b  — write response
+//   ar — read address
+//   r  — read data
+//
+// Matches the ARM AMBA AXI4-Lite spec: no burst, no ID, fixed data widths of
+// 32 or 64 bits (DATA_W defaults to 32, but the bus is structurally
+// parameterizable).
+//
+// Example:
+//   use BusAxiLite;
+//   module CsrBank
+//     port s_axi: target BusAxiLite<ADDR_W=12, DATA_W=32>;
+//     ...
+//   end module CsrBank
+
+bus BusAxiLite
+  param ADDR_W: const = 32;
+  param DATA_W: const = 32;
+
+  // Write address channel.
+  handshake aw: send kind: valid_ready
+    addr: UInt<ADDR_W>;
+    prot: UInt<3>;
+  end handshake aw
+
+  // Write data channel.
+  handshake w: send kind: valid_ready
+    data: UInt<DATA_W>;
+    strb: UInt<DATA_W / 8>;
+  end handshake w
+
+  // Write response channel (target → initiator).
+  handshake b: receive kind: valid_ready
+    resp: UInt<2>;
+  end handshake b
+
+  // Read address channel.
+  handshake ar: send kind: valid_ready
+    addr: UInt<ADDR_W>;
+    prot: UInt<3>;
+  end handshake ar
+
+  // Read data channel (target → initiator).
+  handshake r: receive kind: valid_ready
+    data: UInt<DATA_W>;
+    resp: UInt<2>;
+  end handshake r
+end bus BusAxiLite

--- a/stdlib/BusAxiStream.arch
+++ b/stdlib/BusAxiStream.arch
@@ -1,0 +1,25 @@
+// AXI4-Stream simple flow-control bundle.
+//
+// Canonical streaming bus with valid/ready handshake + data + tlast + tkeep.
+// Matches the ARM AMBA AXI4-Stream spec for the simple variant.
+//
+// v1 ships with a fixed payload (data + last + keep). If you need id/dest/user
+// or a leaner variant without last/keep, either compose a custom bus or wait
+// for BusAxiStreamLite / BusAxiStreamFull.
+//
+// Example:
+//   use BusAxiStream;
+//   module Producer
+//     port m_axis: initiator BusAxiStream<DATA_W=32>;
+//     ...
+//   end module Producer
+
+bus BusAxiStream
+  param DATA_W: const = 32;
+
+  handshake t: send kind: valid_ready
+    data: UInt<DATA_W>;
+    last: Bool;
+    keep: UInt<DATA_W / 8>;
+  end handshake t
+end bus BusAxiStream

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -3181,3 +3181,59 @@ fn test_pipe_reg_depth_zero_errors() {
     let result = parser.parse_source_file();
     assert!(result.is_err(), "expected depth=0 error");
 }
+
+#[test]
+fn test_stdlib_bus_axi_stream_discovery() {
+    // A module that `use BusAxiStream;` should pick the stdlib definition
+    // up automatically — no ARCH_LIB_PATH setup required. Verified here
+    // by running the real compiler binary against a stub test case.
+    let td = tempfile::tempdir().expect("tempdir");
+    let src = td.path().join("Prod.arch");
+    std::fs::write(&src, "\
+        use BusAxiStream;\n\
+        module Prod\n\
+          port clk: in Clock<SysDomain>;\n\
+          port rst: in Reset<Sync>;\n\
+          port m_axis: initiator BusAxiStream<DATA_W=32>;\n\
+          comb\n\
+            m_axis.t_valid = 1'b0;\n\
+            m_axis.t_data  = 32'h0;\n\
+            m_axis.t_last  = 1'b0;\n\
+            m_axis.t_keep  = 4'h0;\n\
+          end comb\n\
+        end module Prod\n\
+    ").unwrap();
+    let arch_bin = env!("CARGO_BIN_EXE_arch");
+    let out = std::process::Command::new(arch_bin)
+        .arg("check")
+        .arg(&src)
+        .output()
+        .expect("run arch check");
+    assert!(out.status.success(),
+        "arch check should succeed with stdlib discovery; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr));
+}
+
+#[test]
+fn test_stdlib_disabled_via_env() {
+    // ARCH_NO_STDLIB=1 should skip the stdlib search entirely — a module
+    // that depends on stdlib should then fail to resolve.
+    let td = tempfile::tempdir().expect("tempdir");
+    let src = td.path().join("Prod.arch");
+    std::fs::write(&src, "\
+        use BusAxiStream;\n\
+        module Prod\n\
+          port m_axis: initiator BusAxiStream<DATA_W=32>;\n\
+          comb m_axis.t_valid = 1'b0; m_axis.t_data = 32'h0; m_axis.t_last = 1'b0; m_axis.t_keep = 4'h0; end comb\n\
+        end module Prod\n\
+    ").unwrap();
+    let arch_bin = env!("CARGO_BIN_EXE_arch");
+    let out = std::process::Command::new(arch_bin)
+        .arg("check")
+        .arg(&src)
+        .env("ARCH_NO_STDLIB", "1")
+        .output()
+        .expect("run arch check");
+    assert!(!out.status.success(),
+        "expected failure when ARCH_NO_STDLIB=1 disables stdlib resolution");
+}


### PR DESCRIPTION
## Summary

First slice of [doc/plan_stdlib_buses.md](doc/plan_stdlib_buses.md). Ships two curated bus files under \`stdlib/\` that users import with zero setup:

```arch
use BusAxiStream;
module Producer
  port m_axis: initiator BusAxiStream<DATA_W=32>;
  ...
end module Producer
```

### Contents

| File | Coverage | Params |
|---|---|---|
| \`stdlib/BusAxiStream.arch\` | AXI4-Stream simple (valid/ready + data + last + keep) | \`DATA_W\` |
| \`stdlib/BusAxiLite.arch\` | AXI4-Lite memory-mapped (aw/w/b + ar/r channels) | \`ADDR_W\`, \`DATA_W\` |

Both compile to Verilator-lint-clean SV end-to-end, verified with real Producer/Csr modules using the new \`use\` path.

### Compiler changes (minimal)

1. **stdlib discovery in \`main.rs\`**: \`resolve_use_imports\` falls back to \`<install>/stdlib/\` after same-dir + \`ARCH_LIB_PATH\`. Handles \`cargo run\` dev layouts and Unix-prefix installs (\`<prefix>/share/arch/stdlib/\`). \`ARCH_STDLIB_PATH\` overrides; \`ARCH_NO_STDLIB=1\` disables.

2. **Bug fix in \`codegen.rs subst_expr\`**: the function was only substituting bare \`Ident\` — expressions like \`UInt<DATA_W / 8>\` left the ident verbatim in emitted SV, breaking Verilator. Now recurses into Binary/Unary/Ternary/Clog2/Index. Found while writing \`BusAxiLite.w_strb\`.

## Test plan

- [x] \`cargo build\` clean
- [x] \`cargo test\` — 104 passing (102 + 2 new stdlib regressions)
  - \`test_stdlib_bus_axi_stream_discovery\` — verifies zero-setup \`use BusAxiStream;\`
  - \`test_stdlib_disabled_via_env\` — verifies \`ARCH_NO_STDLIB=1\` escape hatch
- [x] End-to-end: \`arch build Producer.arch\` → Verilator lint-clean on the emitted SV
- [x] \`BusAxiLite\` end-to-end with \`w_strb: UInt<DATA_W/8>\` arithmetic param

## Deferred to follow-ups

- \`BusApb\` (APB3/APB4 bundle) — same shape, one more file
- \`BusAxi4\` full memory-mapped (ID width, burst, cache, prot, qos, region, response)
- \`generate_if\` inside handshake payload (lets us parameterize optional fields like \`USE_LAST\` / \`USE_KEEP\` in one bus file instead of variant files)
- Doc updates (spec + reference card) showing the stdlib as the canonical way to introduce AXI/APB ports

🤖 Generated with [Claude Code](https://claude.com/claude-code)