### PR TITLE
feat: generate_if inside handshake payload + parameterized BusAxiStream

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -145,8 +145,9 @@ impl Parser {
             } else if self.check(TokenKind::GenerateIf) {
                 generates.push(self.parse_bus_generate_if(start)?);
             } else if self.check(TokenKind::Handshake) {
-                let (ports, meta) = self.parse_handshake_block(start)?;
+                let (ports, gen_ifs, meta) = self.parse_handshake_block(start)?;
                 signals.extend(ports);
+                generates.extend(gen_ifs);
                 handshakes.push(meta);
             } else {
                 signals.push(self.parse_bus_signal(start)?);
@@ -208,7 +209,13 @@ impl Parser {
         // Parse then-branch signals until end generate_if or generate_else
         while !self.check_bus_gen_end() {
             if self.check(TokenKind::Handshake) {
-                let (ports, _meta) = self.parse_handshake_block(parent_span)?;
+                let (ports, gen_ifs, _meta) = self.parse_handshake_block(parent_span)?;
+                if !gen_ifs.is_empty() {
+                    return Err(CompileError::general(
+                        "`generate_if` inside a handshake payload is not supported when the handshake itself is nested inside a bus-level `generate_if`",
+                        parent_span,
+                    ));
+                }
                 then_signals.extend(ports);
             } else {
                 then_signals.push(self.parse_bus_signal(parent_span)?);
@@ -223,7 +230,13 @@ impl Parser {
                 && self.tokens[self.pos + 1].kind == TokenKind::GenerateIf)
             {
                 if self.check(TokenKind::Handshake) {
-                    let (ports, _meta) = self.parse_handshake_block(parent_span)?;
+                    let (ports, gen_ifs, _meta) = self.parse_handshake_block(parent_span)?;
+                    if !gen_ifs.is_empty() {
+                        return Err(CompileError::general(
+                            "`generate_if` inside a handshake payload is not supported when the handshake itself is nested inside a bus-level `generate_if`",
+                            parent_span,
+                        ));
+                    }
                     sigs.extend(ports);
                 } else {
                     sigs.push(self.parse_bus_signal(parent_span)?);
@@ -265,7 +278,7 @@ impl Parser {
     /// `send`/`receive` name the payload-flow role (NOT wire direction):
     /// `send` = this side produces the payload (drives valid/req/payload,
     /// receives ready/ack); `receive` = consumer side.
-    fn parse_handshake_block(&mut self, parent_span: Span) -> Result<(Vec<PortDecl>, HandshakeMeta), CompileError> {
+    fn parse_handshake_block(&mut self, parent_span: Span) -> Result<(Vec<PortDecl>, Vec<BusGenerateIf>, HandshakeMeta), CompileError> {
         let start = self.expect(TokenKind::Handshake)?.span;
         let ch_name = self.expect_ident()?;
         self.expect(TokenKind::Colon)?;
@@ -297,12 +310,49 @@ impl Parser {
             ));
         }
 
-        // Parse payload fields until `end handshake`.
+        // Parse payload fields until `end handshake`. Each field is either
+        // an unconditional `name: type;` line or a `generate_if COND ...
+        // end generate_if` block whose body is a list of unconditional
+        // fields (nested generate_if inside a handshake payload is not
+        // supported in v1).
         let mut payload: Vec<(Ident, TypeExpr, Span)> = Vec::new();
         let mut payload_names: Vec<Ident> = Vec::new();
+        let mut conditional_branches: Vec<(Expr, Vec<(Ident, TypeExpr, Span)>, Span)> = Vec::new();
         loop {
             if self.check(TokenKind::End) {
                 break;
+            }
+            if self.check(TokenKind::GenerateIf) {
+                let gi_start = self.expect(TokenKind::GenerateIf)?.span;
+                let cond = self.parse_expr()?;
+                let mut branch_fields: Vec<(Ident, TypeExpr, Span)> = Vec::new();
+                loop {
+                    // End-of-branch: `end generate_if`
+                    if self.pos + 1 < self.tokens.len()
+                        && self.tokens[self.pos].kind == TokenKind::End
+                        && self.tokens[self.pos + 1].kind == TokenKind::GenerateIf
+                    {
+                        break;
+                    }
+                    if self.check(TokenKind::GenerateIf) {
+                        return Err(CompileError::general(
+                            "nested `generate_if` inside a handshake payload is not supported in v1",
+                            self.peek_span(),
+                        ));
+                    }
+                    let f_name = self.expect_ident()?;
+                    self.expect(TokenKind::Colon)?;
+                    let ty = self.parse_type_expr()?;
+                    self.expect(TokenKind::Semi)?;
+                    let f_span_end = self.tokens.get(self.pos.saturating_sub(1)).map(|t| t.span).unwrap_or(parent_span);
+                    let f_span = f_name.span.merge(f_span_end);
+                    payload_names.push(f_name.clone());
+                    branch_fields.push((f_name, ty, f_span));
+                }
+                self.expect(TokenKind::End)?;
+                let gi_end = self.expect(TokenKind::GenerateIf)?.span;
+                conditional_branches.push((cond, branch_fields, gi_start.merge(gi_end)));
+                continue;
             }
             let f_name = self.expect_ident()?;
             self.expect(TokenKind::Colon)?;
@@ -362,10 +412,29 @@ impl Parser {
             }
             _ => unreachable!(),
         }
-        // Payload signals flow in the channel's declared direction.
+        // Unconditional payload signals flow in the channel's declared
+        // direction.
         for (f_name, ty, f_span) in payload {
             let port_name = format!("{}_{}", ch_name.name, f_name.name);
             out.push(mk_port(port_name, dir, ty, f_span));
+        }
+        // Conditional payload branches: each becomes a BusGenerateIf at the
+        // bus level. The existing codegen + elaboration machinery for
+        // bus-level generate_if (eval_bus_cond + effective_signals) handles
+        // the per-port-site param substitution uniformly.
+        let mut generates: Vec<BusGenerateIf> = Vec::new();
+        for (cond, branch_fields, gi_span) in conditional_branches {
+            let mut branch_signals: Vec<PortDecl> = Vec::new();
+            for (f_name, ty, f_span) in branch_fields {
+                let port_name = format!("{}_{}", ch_name.name, f_name.name);
+                branch_signals.push(mk_port(port_name, dir, ty, f_span));
+            }
+            generates.push(BusGenerateIf {
+                cond,
+                then_signals: branch_signals,
+                else_signals: Vec::new(),
+                span: gi_span,
+            });
         }
         let meta = HandshakeMeta {
             name: ch_name,
@@ -374,7 +443,7 @@ impl Parser {
             payload_names,
             span: block_span,
         };
-        Ok((out, meta))
+        Ok((out, generates, meta))
     }
 
     // --- Enum ---

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -152,6 +152,7 @@ impl BusInfo {
 /// Evaluate a generate_if condition in a bus context.
 /// Supports simple param references (truthy if nonzero) and literal integers.
 fn eval_bus_cond(expr: &Expr, param_map: &HashMap<String, &Expr>) -> bool {
+    // Truthy-if-nonzero rule for Ident / Literal expressions.
     match &expr.kind {
         ExprKind::Ident(name) => {
             if let Some(val_expr) = param_map.get(name.as_str()) {
@@ -167,7 +168,65 @@ fn eval_bus_cond(expr: &Expr, param_map: &HashMap<String, &Expr>) -> bool {
             }
         }
         ExprKind::Bool(b) => *b,
+        // Binary comparison / logical ops — evaluate both operands as
+        // integers (when possible) and apply the op. Supports the common
+        // stdlib-bus patterns `ID_W > 0`, `MODE == 2`, `A && B`.
+        ExprKind::Binary(op, l, r) => {
+            use crate::ast::BinOp;
+            match op {
+                BinOp::And => eval_bus_cond(l, param_map) && eval_bus_cond(r, param_map),
+                BinOp::Or  => eval_bus_cond(l, param_map) || eval_bus_cond(r, param_map),
+                _ => match (eval_bus_int(l, param_map), eval_bus_int(r, param_map)) {
+                    (Some(lv), Some(rv)) => match op {
+                        BinOp::Eq  => lv == rv,
+                        BinOp::Neq => lv != rv,
+                        BinOp::Lt  => lv < rv,
+                        BinOp::Gt  => lv > rv,
+                        BinOp::Lte => lv <= rv,
+                        BinOp::Gte => lv >= rv,
+                        _ => true, // conservative
+                    },
+                    _ => true, // conservative
+                }
+            }
+        }
+        ExprKind::Unary(op, e) => {
+            use crate::ast::UnaryOp;
+            match op {
+                UnaryOp::Not => !eval_bus_cond(e, param_map),
+                _ => true,
+            }
+        }
         _ => true, // conservative: include signals if condition can't be evaluated
+    }
+}
+
+/// Evaluate a bus-condition expression as an integer when possible.
+/// Returns None if the expression can't be reduced (e.g. runtime signals).
+fn eval_bus_int(expr: &Expr, param_map: &HashMap<String, &Expr>) -> Option<i64> {
+    match &expr.kind {
+        ExprKind::Literal(lit) => match lit {
+            LitKind::Dec(n) | LitKind::Hex(n) | LitKind::Bin(n) | LitKind::Sized(_, n) => Some(*n as i64),
+        },
+        ExprKind::Ident(name) => {
+            let val_expr = param_map.get(name.as_str())?;
+            eval_bus_int(val_expr, param_map)
+        }
+        ExprKind::Bool(b) => Some(if *b { 1 } else { 0 }),
+        ExprKind::Binary(op, l, r) => {
+            use crate::ast::BinOp;
+            let lv = eval_bus_int(l, param_map)?;
+            let rv = eval_bus_int(r, param_map)?;
+            Some(match op {
+                BinOp::Add => lv + rv,
+                BinOp::Sub => lv - rv,
+                BinOp::Mul => lv * rv,
+                BinOp::Div if rv != 0 => lv / rv,
+                BinOp::Mod if rv != 0 => lv % rv,
+                _ => return None,
+            })
+        }
+        _ => None,
     }
 }
 

--- a/stdlib/BusAxiStream.arch
+++ b/stdlib/BusAxiStream.arch
@@ -1,25 +1,56 @@
 // AXI4-Stream simple flow-control bundle.
 //
-// Canonical streaming bus with valid/ready handshake + data + tlast + tkeep.
-// Matches the ARM AMBA AXI4-Stream spec for the simple variant.
+// Canonical streaming bus with valid/ready handshake. Optional payload
+// signals are guarded by toggle params; set them at the port site to
+// include or omit the signal for that instance.
 //
-// v1 ships with a fixed payload (data + last + keep). If you need id/dest/user
-// or a leaner variant without last/keep, either compose a custom bus or wait
-// for BusAxiStreamLite / BusAxiStreamFull.
+// Toggles (nonzero = include, zero = omit):
+//   USE_LAST — tlast (frame boundary marker)
+//   USE_KEEP — tkeep (byte enables on the beat)
+//   USE_STRB — tstrb (per-byte position/data distinction, rarely used)
+//
+// Width params (> 0 = include, 0 = omit):
+//   ID_W    — tid
+//   DEST_W  — tdest
+//   USER_W  — tuser
+//
+// Matches the ARM AMBA AXI4-Stream spec (IHI 0051).
 //
 // Example:
 //   use BusAxiStream;
 //   module Producer
-//     port m_axis: initiator BusAxiStream<DATA_W=32>;
+//     port m_axis: initiator BusAxiStream<DATA_W=32, USE_LAST=1, USE_KEEP=1>;
 //     ...
 //   end module Producer
 
 bus BusAxiStream
-  param DATA_W: const = 32;
+  param DATA_W:   const = 32;
+  param USE_LAST: const = 1;
+  param USE_KEEP: const = 1;
+  param USE_STRB: const = 0;
+  param ID_W:     const = 0;
+  param DEST_W:   const = 0;
+  param USER_W:   const = 0;
 
   handshake t: send kind: valid_ready
     data: UInt<DATA_W>;
-    last: Bool;
-    keep: UInt<DATA_W / 8>;
+    generate_if USE_LAST
+      last: Bool;
+    end generate_if
+    generate_if USE_KEEP
+      keep: UInt<DATA_W / 8>;
+    end generate_if
+    generate_if USE_STRB
+      strb: UInt<DATA_W / 8>;
+    end generate_if
+    generate_if ID_W > 0
+      id: UInt<ID_W>;
+    end generate_if
+    generate_if DEST_W > 0
+      dest: UInt<DEST_W>;
+    end generate_if
+    generate_if USER_W > 0
+      user: UInt<USER_W>;
+    end generate_if
   end handshake t
 end bus BusAxiStream

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -3237,3 +3237,84 @@ fn test_stdlib_disabled_via_env() {
     assert!(!out.status.success(),
         "expected failure when ARCH_NO_STDLIB=1 disables stdlib resolution");
 }
+
+#[test]
+fn test_handshake_generate_if_payload_toggle() {
+    // `generate_if` inside a handshake payload should conditionally
+    // include fields based on port-site param overrides.
+    let source = "
+        bus BusFlex
+          param DATA_W: const = 8;
+          param USE_LAST: const = 1;
+          param ID_W: const = 0;
+
+          handshake t: send kind: valid_ready
+            data: UInt<DATA_W>;
+            generate_if USE_LAST
+              last: Bool;
+            end generate_if
+            generate_if ID_W > 0
+              id: UInt<ID_W>;
+            end generate_if
+          end handshake t
+        end bus BusFlex
+
+        module Full
+          port p: initiator BusFlex<DATA_W=16, USE_LAST=1, ID_W=4>;
+          comb
+            p.t_valid = 1'b0;
+            p.t_data  = 16'h0;
+            p.t_last  = 1'b0;
+            p.t_id    = 4'h0;
+          end comb
+        end module Full
+
+        module Bare
+          port p: initiator BusFlex<DATA_W=8, USE_LAST=0>;
+          comb
+            p.t_valid = 1'b0;
+            p.t_data  = 8'h0;
+          end comb
+        end module Bare
+    ";
+    let sv = compile_to_sv(source);
+    // Full config emits all four optional ports.
+    assert!(sv.contains("output logic [15:0] p_t_data"), "Full: data 16-bit expected:\n{sv}");
+    assert!(sv.contains("output logic p_t_last"), "Full: t_last present:\n{sv}");
+    assert!(sv.contains("output logic [3:0] p_t_id"), "Full: t_id [3:0]:\n{sv}");
+    // Bare config omits t_last (USE_LAST=0) AND t_id (ID_W=0).
+    // Both Full and Bare emit into the same SV string; check Bare's
+    // module block specifically for the absence of those fields.
+    let bare = sv.split("module Bare").nth(1).expect("Bare module present");
+    let bare_until_end = bare.split("endmodule").next().unwrap_or("");
+    assert!(!bare_until_end.contains("t_last"),
+        "Bare config should omit t_last: {bare_until_end}");
+    assert!(!bare_until_end.contains("t_id"),
+        "Bare config should omit t_id: {bare_until_end}");
+}
+
+#[test]
+fn test_handshake_generate_if_nested_in_bus_genif_errors() {
+    // A handshake with payload generate_if placed INSIDE a bus-level
+    // generate_if is not supported in v1 — must error with a clear message.
+    let source = "
+        bus BusBad
+          param ENABLE: const = 1;
+          generate_if ENABLE
+            handshake t: send kind: valid_ready
+              data: UInt<8>;
+              generate_if ENABLE
+                extra: Bool;
+              end generate_if
+            end handshake t
+          end generate_if
+        end bus BusBad
+    ";
+    let tokens = arch::lexer::tokenize(source).expect("lexer");
+    let mut parser = arch::parser::Parser::new(tokens, source);
+    let result = parser.parse_source_file();
+    assert!(result.is_err(), "expected parser error");
+    let msg = format!("{:?}", result.unwrap_err());
+    assert!(msg.contains("not supported when the handshake itself is nested"),
+        "expected specific nesting-error message, got: {msg}");
+}


### PR DESCRIPTION
## Summary

Closes the "one bus file per variant" gap left by #48. The handshake sub-construct now accepts \`generate_if\` branches in its payload, so a single \`BusAxiStream.arch\` can parameterize \`USE_LAST\` / \`USE_KEEP\` / \`ID_W\` / \`DEST_W\` / \`USER_W\` instead of shipping BusAxiStreamLite / BusAxiStream / BusAxiStreamFull variants.

```arch
// stdlib/BusAxiStream.arch
bus BusAxiStream
  param DATA_W:   const = 32;
  param USE_LAST: const = 1;
  param ID_W:     const = 0;
  ...
  handshake t: send kind: valid_ready
    data: UInt<DATA_W>;
    generate_if USE_LAST
      last: Bool;
    end generate_if
    generate_if ID_W > 0
      id: UInt<ID_W>;
    end generate_if
    ...
  end handshake t
end bus BusAxiStream
```

```arch
// User picks what they want at the port site:
port m_axis: initiator BusAxiStream<DATA_W=32, USE_LAST=1, ID_W=4>;
// Emits: t_valid / t_ready / t_data[31:0] / t_last / t_id[3:0]
//   (no t_keep/strb/dest/user because defaults are 0)
```

### Implementation

- **Parser** (`parse_handshake_block`): recognize `generate_if COND ... end generate_if` in the payload loop. Each branch is lowered to a synthesized `BusGenerateIf` appended to the parent bus's `generates`. Return signature widened from `(ports, meta)` → `(ports, gen_ifs, meta)`.
- **Nesting error**: a handshake whose payload contains `generate_if` cannot itself live inside a bus-level `generate_if` (v1 scope; clear error message). Plain handshakes still nest fine.
- **`resolve::eval_bus_cond`**: extended to handle `Binary` comparison (`==`, `!=`, `<`, `<=`, `>`, `>=`) + logical `and`/`or` + `Unary::Not`. New helper `eval_bus_int` reduces arithmetic constant expressions so `ID_W > 0`, `MODE == 2`, etc. work.
- **`stdlib/BusAxiStream.arch`**: rewritten to use the new form with 3 toggle params + 3 width params.

### Test plan
- [x] `cargo test` — 106 passing (+2 new regressions)
- [x] End-to-end Verilator lint-clean on both full and minimal configurations
- [x] Nested-use error test

🤖 Generated with [Claude Code](https://claude.com/claude-code)