### PR TITLE
feat: stdlib BusApb + spec/reference-card coverage for stdlib

### DIFF
--- a/doc/ARCH_HDL_Specification.md
+++ b/doc/ARCH_HDL_Specification.md
@@ -4592,7 +4592,76 @@ Two stages catch the two bug classes adjacent to protocol timing:
 
 - **Consumer bug — payload read without checking valid.** At `arch check`, a compile-time lint warns when any read of `<port>.<payload_field>` is not inside an `if <port>.<valid_field>` scope. The guard is recognized as a direct field access or as an AND-conjunct of the if-condition; let-binding indirection is not yet traced (known false-positive source). `ready_only` is exempt from the lint (no valid signal exists).
 
-**18a.6 Not Covered**
+**18a.6 Conditional Payload Fields**
+
+Inside a `handshake` payload block, `generate_if COND ... end generate_if` branches conditionally include payload fields based on the port-site param map. Same evaluator as bus-level `generate_if` (truthy-if-nonzero for bare idents / literals; comparison and `and`/`or` supported). This lets one bus definition parameterize optional signals:
+
+```
+bus BusAxiStream
+  param DATA_W:   const = 32;
+  param USE_LAST: const = 1;
+  param ID_W:     const = 0;
+
+  handshake t: send kind: valid_ready
+    data: UInt<DATA_W>;
+    generate_if USE_LAST
+      last: Bool;
+    end generate_if
+    generate_if ID_W > 0
+      id: UInt<ID_W>;
+    end generate_if
+  end handshake t
+end bus BusAxiStream
+```
+
+Users pick toggles at the port site:
+```
+port m_axis: initiator BusAxiStream<DATA_W=32, USE_LAST=1, ID_W=4>;   // t_last + t_id present
+port slim:   initiator BusAxiStream<DATA_W=8, USE_LAST=0>;            // t_last absent
+```
+
+v1 scope: nested `generate_if` inside a payload branch is a compile error. A handshake with payload `generate_if` also cannot itself live inside a bus-level `generate_if` (same error class).
+
+**18a.7 Not Covered**
+
+- **Stateful protocols** (credit-based flow control, PCIe credit accounting). These are not variants of `handshake`; they belong in a future `credit_channel` construct (not yet designed) because they imply the compiler owns counter + credit-return logic, not just port shape.
+- **Handshake at the module port level directly.** Valid only inside a `bus` body. A single-channel interface is expressed by a one-handshake bus declaration plus an ordinary bus port.
+- **`req_ack_2phase` Tier-2 assertions** — requires `$past` tracking; deferred.
+
+**18b. Standard Bus Library**
+
+The ARCH compiler ships with a standard library of curated `bus` definitions under `<install>/stdlib/`. These are ordinary `.arch` files built on `bus` + `handshake` + `generate_if` — no new compiler machinery — that users import with zero setup:
+
+```
+use BusAxiStream;
+module Producer
+  port m_axis: initiator BusAxiStream<DATA_W=32, USE_LAST=1, USE_KEEP=1>;
+  ...
+end module Producer
+```
+
+**v1 contents:**
+
+  -------------------------------------------------------------------------------------------------------------------------
+  **Bus**          **Protocol**                              **Key parameters**
+  ---------------- ----------------------------------------- --------------------------------------------------------------
+  `BusAxiStream`   AXI4-Stream (ARM IHI 0051)                `DATA_W`, `USE_LAST`, `USE_KEEP`, `USE_STRB`, `ID_W`, `DEST_W`, `USER_W`
+
+  `BusAxiLite`     AXI4-Lite memory-mapped                   `ADDR_W`, `DATA_W`
+
+  `BusApb`         APB3 / APB4 peripheral bus (ARM IHI 0024) `ADDR_W`, `DATA_W`, `USE_PPROT`, `USE_PSTRB`
+  -------------------------------------------------------------------------------------------------------------------------
+
+**Discovery**: `use BusX;` resolves in this order:
+1. Same-directory relative path (`./BusX.arch`)
+2. Colon-separated paths in `$ARCH_LIB_PATH` (if set)
+3. `<install>/stdlib/` (unless `ARCH_NO_STDLIB=1` is set)
+
+The `$ARCH_STDLIB_PATH` env var overrides the compiler's install-relative search, useful for point-testing modified stdlib files.
+
+**Third-party packages**: any user or team can ship their own `BusMyCompanyProto.arch` package the same way, either bundled with their ARCH project or shipped via a separate repo on `$ARCH_LIB_PATH`. The compiler treats stdlib and user buses identically — no privileged path, no special syntax.
+
+**Not covered in v1**: `BusAxi4` full memory-mapped (ID/burst/cache/prot/qos/region/lock/resp), `BusAvalonSt`, `BusAvalonMM`, `BusWishbone`. Each is one additional `.arch` file in `stdlib/` when demand materializes.
 
 - **Stateful protocols** (credit-based flow control, PCIe credit accounting). These are not variants of `handshake`; they belong in a future `credit_channel` construct (not yet designed) because they imply the compiler owns counter + credit-return logic, not just port shape.
 - **Handshake at the module port level directly.** Valid only inside a `bus` body. A single-channel interface is expressed by a one-handshake bus declaration plus an ordinary bus port.

--- a/doc/Arch_AI_Reference_Card.md
+++ b/doc/Arch_AI_Reference_Card.md
@@ -885,6 +885,32 @@ end bus BusAxiLite
 
 Full spec: `doc/ARCH_HDL_Specification.md` §18a.
 
+### Standard bus library (zero-setup `use`)
+
+The ARCH compiler ships curated bus definitions under `<install>/stdlib/`. Use any of them from any file with no path setup:
+
+```
+use BusAxiStream;
+port m_axis: initiator BusAxiStream<DATA_W=32, USE_LAST=1, USE_KEEP=1>;
+
+use BusAxiLite;
+port s_axi:  target BusAxiLite<ADDR_W=12, DATA_W=32>;
+
+use BusApb;
+port s_apb:  target BusApb<ADDR_W=16, DATA_W=32, USE_PPROT=1, USE_PSTRB=1>;
+```
+
+**v1 stdlib buses**:
+- `BusAxiStream` — AXI4-Stream. Params: `DATA_W`, `USE_LAST`, `USE_KEEP`, `USE_STRB`, `ID_W`, `DEST_W`, `USER_W`.
+- `BusAxiLite` — AXI4-Lite memory-mapped. Params: `ADDR_W`, `DATA_W`. Full 5-channel aw/w/b/ar/r bundle.
+- `BusApb` — APB3 / APB4. Params: `ADDR_W`, `DATA_W`, `USE_PPROT`, `USE_PSTRB`.
+
+**Discovery order**: same-dir → `$ARCH_LIB_PATH` → `<install>/stdlib/` (disable with `ARCH_NO_STDLIB=1`; override the install path with `$ARCH_STDLIB_PATH`).
+
+Third-party packages ship the same way — drop `BusMyProto.arch` into `$ARCH_LIB_PATH` and `use BusMyProto;` works identically to the stdlib.
+
+Full spec: `doc/ARCH_HDL_Specification.md` §18b.
+
 ---
 
 ### template

--- a/stdlib/BusApb.arch
+++ b/stdlib/BusApb.arch
@@ -1,0 +1,54 @@
+// APB3 / APB4 peripheral bus — ARM AMBA Advanced Peripheral Bus.
+//
+// Classic low-bandwidth control/status bus used to access peripheral
+// registers. A transfer takes 2–3 cycles:
+//   - SETUP (psel high, penable low)
+//   - ACCESS (psel high, penable high) — completer asserts pready when done
+//
+// This bus is modeled as a single bidirectional transaction channel plus
+// the APB4 sideband signals (pprot, pstrb, pslverr) gated by toggle
+// parameters. APB3 users leave USE_PPROT / USE_PSTRB at 0.
+//
+// Toggles (nonzero = include, zero = omit):
+//   USE_PPROT — 3-bit protection attribute (APB4)
+//   USE_PSTRB — DATA_W/8-bit byte enables on writes (APB4)
+//
+// Non-conditional signals follow the direction convention: everything
+// from initiator → completer except prdata + pready + pslverr.
+//
+// Reference: ARM IHI 0024 "AMBA APB Protocol Specification".
+//
+// Example:
+//   use BusApb;
+//   module CsrBank
+//     port s_apb: target BusApb<ADDR_W=12, DATA_W=32>;
+//     ...
+//   end module CsrBank
+
+bus BusApb
+  param ADDR_W:    const = 32;
+  param DATA_W:    const = 32;
+  param USE_PPROT: const = 0;
+  param USE_PSTRB: const = 0;
+
+  // Initiator → completer
+  psel:    out Bool;
+  penable: out Bool;
+  pwrite:  out Bool;
+  paddr:   out UInt<ADDR_W>;
+  pwdata:  out UInt<DATA_W>;
+
+  // Completer → initiator
+  pready:  in  Bool;
+  prdata:  in  UInt<DATA_W>;
+
+  generate_if USE_PPROT
+    pprot:   out UInt<3>;
+  end generate_if
+  generate_if USE_PSTRB
+    pstrb:   out UInt<DATA_W / 8>;
+  end generate_if
+  generate_if USE_PPROT
+    pslverr: in Bool;
+  end generate_if
+end bus BusApb

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -3318,3 +3318,24 @@ fn test_handshake_generate_if_nested_in_bus_genif_errors() {
     assert!(msg.contains("not supported when the handshake itself is nested"),
         "expected specific nesting-error message, got: {msg}");
 }
+
+#[test]
+fn test_stdlib_bus_apb_discovery_apb3_minimal() {
+    let td = tempfile::tempdir().expect("tempdir");
+    let src = td.path().join("Csr.arch");
+    std::fs::write(&src, "\
+        use BusApb;\n\
+        module Csr\n\
+          port clk: in Clock<SysDomain>;\n\
+          port rst: in Reset<Sync>;\n\
+          port s_apb: target BusApb<ADDR_W=12, DATA_W=32>;\n\
+          comb s_apb.pready = 1'b1; s_apb.prdata = 32'h0; end comb\n\
+        end module Csr\n\
+    ").unwrap();
+    let arch_bin = env!("CARGO_BIN_EXE_arch");
+    let out = std::process::Command::new(arch_bin)
+        .arg("check").arg(&src).output().expect("run arch check");
+    assert!(out.status.success(),
+        "APB3 minimal should compile; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr));
+}


### PR DESCRIPTION
## Summary

Closes the v1 stdlib target from [\`doc/plan_stdlib_buses.md\`](doc/plan_stdlib_buses.md): three curated bus files (\`BusAxiStream\` + \`BusAxiLite\` + \`BusApb\`), and both the spec and AI reference card now document the stdlib.

### New bus

\`stdlib/BusApb.arch\` — APB3 / APB4 per ARM IHI 0024.

| Signals | Direction | Gated? |
|---|---|---|
| \`psel\`, \`penable\`, \`pwrite\`, \`paddr\`, \`pwdata\` | initiator → completer | unconditional |
| \`pready\`, \`prdata\` | completer → initiator | unconditional |
| \`pprot\` (3-bit protection attr) | initiator → completer | \`USE_PPROT=1\` |
| \`pstrb\` (\`DATA_W/8\` byte enables) | initiator → completer | \`USE_PSTRB=1\` |
| \`pslverr\` | completer → initiator | \`USE_PPROT=1\` |

APB3 (defaults): 7 ports. APB4 full: 10 ports. Unlike AXI buses, APB does not fit the valid/ready handshake mold (2–3 phase protocol with its own pready semantics), so this bus uses plain port declarations instead of the handshake sub-construct.

### Docs

- **Spec §18a.6** — new subsection covering \`generate_if\` inside handshake payload (PR #49 feature was missing from the spec).
- **Spec §18b Standard Bus Library** — table of the three v1 buses, discovery order, env-var overrides, third-party package story.
- **Reference card** — compact "Standard bus library" section with the three import examples.

## Test plan
- [x] \`cargo test\` — 107 passing (+1 new: BusApb APB3 minimal E2E via real arch binary)
- [x] BusApb APB3 and APB4 configs both Verilator lint-clean (manual E2E)

🤖 Generated with [Claude Code](https://claude.com/claude-code)