### PR TITLE
feat: accept 'handshake_channel' keyword; deprecate 'handshake'

### DIFF
--- a/doc/ARCH_HDL_Specification.md
+++ b/doc/ARCH_HDL_Specification.md
@@ -4465,9 +4465,11 @@ Real schedulers rarely use a single integer key. Arch allows struct types as pri
   **Occupancy counter**      counter\<wrap\>                            Tracks current size; drives full/empty
   ----------------------------------------------------------------------------------------------------------------------------------------
 
-**18a. First-Class Sub-Construct: handshake (inside bus)**
+**18a. First-Class Sub-Construct: handshake_channel (inside bus)**
 
-`handshake` collapses the valid/ready/payload vocabulary that dominates every on-chip interface — AXI/APB/AHB/Avalon, streaming pipelines, async GALS bridges — into one declaration per channel. It is a **compile-time sum type**: a single keyword names the *payload role*, a variant name selects the flow-control shape, and the compiler synthesizes the flat individual-wire port declarations with their directions derived mechanically. The user never flips individual wires by hand, so the dominant "I flipped valid and ready" bug class is eliminated by construction.
+> **Keyword rename (v0.44.0):** the opening/closing keyword is `handshake_channel`. The legacy `handshake` keyword still parses and emits a deprecation warning (silence with `ARCH_NO_DEPRECATIONS=1`); it will be removed in v0.45.0. The rename aligns this sub-construct with its siblings `credit_channel` and `tlm_method` under the unified `bus` umbrella (see `doc/plan_bus_unification.md`). Semantics are unchanged.
+
+`handshake_channel` collapses the valid/ready/payload vocabulary that dominates every on-chip interface — AXI/APB/AHB/Avalon, streaming pipelines, async GALS bridges — into one declaration per channel. It is a **compile-time sum type**: a single keyword names the *payload role*, a variant name selects the flow-control shape, and the compiler synthesizes the flat individual-wire port declarations with their directions derived mechanically. The user never flips individual wires by hand, so the dominant "I flipped valid and ready" bug class is eliminated by construction.
 
 `handshake` is only valid inside a `bus` body. To expose a single-channel handshake-shaped interface from a module, define a one-handshake bus and attach it as an ordinary bus port.
 
@@ -4478,27 +4480,27 @@ bus BusAxiLite
   param ADDR_W: const = 32;
   param DATA_W: const = 32;
 
-  handshake aw: send kind: valid_ready
+  handshake_channel aw: send kind: valid_ready
     addr: UInt<ADDR_W>;
     prot: UInt<3>;
-  end handshake aw
+  end handshake_channel aw
 
-  handshake w: send kind: valid_ready
+  handshake_channel w: send kind: valid_ready
     data: UInt<DATA_W>;
     strb: UInt<DATA_W/8>;
-  end handshake w
+  end handshake_channel w
 
-  handshake b: receive kind: valid_ready
+  handshake_channel b: receive kind: valid_ready
     resp: UInt<2>;
-  end handshake b
+  end handshake_channel b
 end bus BusAxiLite
 ```
 
 Grammar:
 ```
-HandshakeBlock := 'handshake' Ident ':' Role 'kind' ':' Variant NEWLINE
+HandshakeBlock := 'handshake_channel' Ident ':' Role 'kind' ':' Variant NEWLINE
                     (Ident ':' TypeExpr ';')*
-                  'end' 'handshake' Ident
+                  'end' 'handshake_channel' Ident
 Role           := 'send' | 'receive'
 Variant        := 'valid_ready' | 'valid_only' | 'ready_only'
                 | 'valid_stall' | 'req_ack_4phase' | 'req_ack_2phase'

--- a/doc/Arch_AI_Reference_Card.md
+++ b/doc/Arch_AI_Reference_Card.md
@@ -854,20 +854,22 @@ end module Slave
 
 SV output: flattened to individual ports (`axi_aw_valid`, `axi_aw_addr`, etc.).
 
-### handshake (inside bus)
+### handshake_channel (inside bus)
 
 Valid/ready/payload channels as a compile-time sum type. Six variants; compiler derives every individual wire direction from the role keyword.
 
+> **Rename note (v0.44.0):** `handshake_channel` is the current keyword. Legacy `handshake` still parses and emits a deprecation warning; removal scheduled for v0.45.0. Silence with `ARCH_NO_DEPRECATIONS=1`.
+
 ```
 bus BusAxiLite
-  handshake aw: send kind: valid_ready     // this side drives valid + payload, reads ready
+  handshake_channel aw: send kind: valid_ready     // this side drives valid + payload, reads ready
     addr: UInt<32>;
     prot: UInt<3>;
-  end handshake aw
+  end handshake_channel aw
 
-  handshake b: receive kind: valid_ready   // flipped: reads valid + payload, drives ready
+  handshake_channel b: receive kind: valid_ready   // flipped: reads valid + payload, drives ready
     resp: UInt<2>;
-  end handshake b
+  end handshake_channel b
 end bus BusAxiLite
 ```
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -79,6 +79,10 @@ pub struct HandshakeMeta {
     pub name: Ident,
     /// Variant keyword (e.g. `valid_ready`, `req_ack_4phase`).
     pub variant: Ident,
+    /// True if the declaration used the legacy `handshake` keyword rather
+    /// than `handshake_channel`. Typecheck emits a deprecation warning for
+    /// the legacy form — semantics are identical. See plan_bus_unification.md.
+    pub legacy_handshake_kw: bool,
     /// Role on the initiator side: `Out` = send, `In` = receive.
     pub role_dir: Direction,
     /// Field names of the payload (without the channel prefix). Used only

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -117,6 +117,8 @@ pub enum TokenKind {
     Bus,
     #[token("handshake")]
     Handshake,
+    #[token("handshake_channel")]
+    HandshakeChannel,
     #[token("implements")]
     Implements,
     #[token("return")]
@@ -409,6 +411,7 @@ impl fmt::Display for TokenKind {
             TokenKind::Template => write!(f, "template"),
             TokenKind::Bus => write!(f, "bus"),
             TokenKind::Handshake => write!(f, "handshake"),
+            TokenKind::HandshakeChannel => write!(f, "handshake_channel"),
             TokenKind::Implements => write!(f, "implements"),
             TokenKind::Return => write!(f, "return"),
             TokenKind::Stage => write!(f, "stage"),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -144,7 +144,7 @@ impl Parser {
                 params.push(self.parse_param_decl()?);
             } else if self.check(TokenKind::GenerateIf) {
                 generates.push(self.parse_bus_generate_if(start)?);
-            } else if self.check(TokenKind::Handshake) {
+            } else if self.check(TokenKind::Handshake) || self.check(TokenKind::HandshakeChannel) {
                 let (ports, gen_ifs, meta) = self.parse_handshake_block(start)?;
                 signals.extend(ports);
                 generates.extend(gen_ifs);
@@ -208,7 +208,7 @@ impl Parser {
         let mut then_signals = Vec::new();
         // Parse then-branch signals until end generate_if or generate_else
         while !self.check_bus_gen_end() {
-            if self.check(TokenKind::Handshake) {
+            if self.check(TokenKind::Handshake) || self.check(TokenKind::HandshakeChannel) {
                 let (ports, gen_ifs, _meta) = self.parse_handshake_block(parent_span)?;
                 if !gen_ifs.is_empty() {
                     return Err(CompileError::general(
@@ -229,7 +229,7 @@ impl Parser {
                 && self.tokens[self.pos].kind == TokenKind::End
                 && self.tokens[self.pos + 1].kind == TokenKind::GenerateIf)
             {
-                if self.check(TokenKind::Handshake) {
+                if self.check(TokenKind::Handshake) || self.check(TokenKind::HandshakeChannel) {
                     let (ports, gen_ifs, _meta) = self.parse_handshake_block(parent_span)?;
                     if !gen_ifs.is_empty() {
                         return Err(CompileError::general(
@@ -279,7 +279,11 @@ impl Parser {
     /// `send` = this side produces the payload (drives valid/req/payload,
     /// receives ready/ack); `receive` = consumer side.
     fn parse_handshake_block(&mut self, parent_span: Span) -> Result<(Vec<PortDecl>, Vec<BusGenerateIf>, HandshakeMeta), CompileError> {
-        let start = self.expect(TokenKind::Handshake)?.span;
+        // Accept both `handshake` (legacy) and `handshake_channel` (new).
+        // See plan_bus_unification.md for the rename rationale.
+        let is_legacy = self.check(TokenKind::Handshake);
+        let opening_tok = if is_legacy { TokenKind::Handshake } else { TokenKind::HandshakeChannel };
+        let start = self.expect(opening_tok)?.span;
         let ch_name = self.expect_ident()?;
         self.expect(TokenKind::Colon)?;
         let dir = if self.eat_contextual("send") {
@@ -364,7 +368,14 @@ impl Parser {
             payload.push((f_name, ty, f_span));
         }
         self.expect(TokenKind::End)?;
-        self.expect(TokenKind::Handshake)?;
+        // Closing keyword must match the opening one (`handshake` or
+        // `handshake_channel`). Mismatch is a parse error with a clear
+        // message pointing the user at the fix.
+        if is_legacy {
+            self.expect(TokenKind::Handshake)?;
+        } else {
+            self.expect(TokenKind::HandshakeChannel)?;
+        }
         let closing = self.expect_ident()?;
         if closing.name != ch_name.name {
             return Err(CompileError::mismatched_closing(
@@ -442,6 +453,7 @@ impl Parser {
             role_dir: dir,
             payload_names,
             span: block_span,
+            legacy_handshake_kw: is_legacy,
         };
         Ok((out, generates, meta))
     }

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -98,7 +98,27 @@ impl<'a> TypeChecker<'a> {
                 Item::Template(t) => self.check_template(t),
                 Item::Synchronizer(s) => self.check_synchronizer(s),
                 Item::Clkgate(c) => self.check_clkgate(c),
-                Item::Bus(_) => {} // validated at port usage sites
+                Item::Bus(b) => {
+                    // Deprecation: legacy `handshake` keyword inside a bus
+                    // is being renamed to `handshake_channel` for
+                    // consistency with its sibling sub-constructs
+                    // (`credit_channel`, future `tlm_method`). Same soft
+                    // nudge pattern as `port reg`; silenceable via
+                    // ARCH_NO_DEPRECATIONS=1.
+                    if std::env::var("ARCH_NO_DEPRECATIONS").is_err() {
+                        for hs in &b.handshakes {
+                            if hs.legacy_handshake_kw {
+                                self.warnings.push(CompileWarning {
+                                    message: format!(
+                                        "`handshake {name}: ...` is deprecated — use `handshake_channel {name}: ...` instead (identical semantics; matches the new `credit_channel` / `tlm_method` sibling sub-construct naming).",
+                                        name = hs.name.name
+                                    ),
+                                    span: hs.span,
+                                });
+                            }
+                        }
+                    }
+                }
                 Item::Package(pkg) => {
                     for e in &pkg.enums { self.check_enum(e); }
                     for s in &pkg.structs { self.check_struct(s); }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -3395,3 +3395,116 @@ fn test_pipe_reg_port_no_deprecation_warning() {
         "did not expect deprecation warning for pipe_reg<T,1>, got: {:?}",
         warnings.iter().map(|w| &w.message).collect::<Vec<_>>());
 }
+
+#[test]
+fn test_handshake_channel_parses_new_keyword() {
+    let source = "
+        bus BusNew
+          handshake_channel cmd: send kind: valid_ready
+            addr: UInt<32>;
+          end handshake_channel cmd
+        end bus BusNew
+
+        use BusNew;
+
+        module M
+          port p: initiator BusNew;
+          comb
+            p.cmd_valid = 1'b0;
+            p.cmd_addr  = 32'h0;
+          end comb
+        end module M
+    ";
+    let sv = compile_to_sv(source);
+    assert!(sv.contains("output logic p_cmd_valid"),
+        "handshake_channel should expand to the same ports as legacy `handshake`:\n{sv}");
+    assert!(sv.contains("input logic p_cmd_ready"),
+        "handshake_channel should emit the ready signal:\n{sv}");
+    assert!(sv.contains("output logic [31:0] p_cmd_addr"),
+        "handshake_channel should emit the payload:\n{sv}");
+}
+
+#[test]
+fn test_handshake_legacy_keyword_emits_deprecation_warning() {
+    let source = "
+        bus BusLegacy
+          handshake cmd: send kind: valid_ready
+            addr: UInt<32>;
+          end handshake cmd
+        end bus BusLegacy
+
+        use BusLegacy;
+
+        module M
+          port p: initiator BusLegacy;
+          comb
+            p.cmd_valid = 1'b0;
+            p.cmd_addr  = 32'h0;
+          end comb
+        end module M
+    ";
+    let tokens = arch::lexer::tokenize(source).expect("lexer");
+    let mut parser = arch::parser::Parser::new(tokens, source);
+    let ast = parser.parse_source_file().expect("parse");
+    let ast = arch::elaborate::elaborate(ast).expect("elaborate");
+    let ast = arch::elaborate::lower_threads(ast).expect("lower threads");
+    let ast = arch::elaborate::lower_pipe_reg_ports(ast).expect("lower pipe_reg");
+    let symbols = arch::resolve::resolve(&ast).expect("resolve");
+    let (warnings, _) = arch::typecheck::TypeChecker::new(&symbols, &ast).check().expect("typecheck");
+    assert!(warnings.iter().any(|w|
+        w.message.contains("`handshake cmd")
+        && w.message.contains("deprecated")
+        && w.message.contains("handshake_channel")),
+        "expected deprecation warning, got: {:?}",
+        warnings.iter().map(|w| &w.message).collect::<Vec<_>>());
+}
+
+#[test]
+fn test_handshake_channel_no_deprecation_warning() {
+    let source = "
+        bus BusNew
+          handshake_channel cmd: send kind: valid_ready
+            addr: UInt<32>;
+          end handshake_channel cmd
+        end bus BusNew
+
+        use BusNew;
+
+        module M
+          port p: initiator BusNew;
+          comb
+            p.cmd_valid = 1'b0;
+            p.cmd_addr  = 32'h0;
+          end comb
+        end module M
+    ";
+    let tokens = arch::lexer::tokenize(source).expect("lexer");
+    let mut parser = arch::parser::Parser::new(tokens, source);
+    let ast = parser.parse_source_file().expect("parse");
+    let ast = arch::elaborate::elaborate(ast).expect("elaborate");
+    let ast = arch::elaborate::lower_threads(ast).expect("lower threads");
+    let ast = arch::elaborate::lower_pipe_reg_ports(ast).expect("lower pipe_reg");
+    let symbols = arch::resolve::resolve(&ast).expect("resolve");
+    let (warnings, _) = arch::typecheck::TypeChecker::new(&symbols, &ast).check().expect("typecheck");
+    assert!(!warnings.iter().any(|w| w.message.contains("handshake_channel")
+                                    && w.message.contains("deprecated")),
+        "did not expect deprecation warning for handshake_channel form, got: {:?}",
+        warnings.iter().map(|w| &w.message).collect::<Vec<_>>());
+}
+
+#[test]
+fn test_handshake_mismatched_closing_keyword_errors() {
+    // Opening with `handshake_channel` but closing with `end handshake`
+    // (or vice versa) should be a parse error.
+    let source = "
+        bus B
+          handshake_channel cmd: send kind: valid_ready
+            addr: UInt<32>;
+          end handshake cmd
+        end bus B
+    ";
+    let tokens = arch::lexer::tokenize(source).expect("lexer");
+    let mut parser = arch::parser::Parser::new(tokens, source);
+    let result = parser.parse_source_file();
+    assert!(result.is_err(), "expected parse error for mismatched opening/closing keyword");
+}


### PR DESCRIPTION
## Summary

First code PR of the bus unification roadmap ([plan_bus_unification.md](doc/plan_bus_unification.md), merged as #55). Adds \`handshake_channel\` as the preferred spelling; legacy \`handshake\` still compiles but emits a soft deprecation warning.

Identical SV output from both forms — pure rename, same playbook as \`port reg\` → \`pipe_reg\` (#51) and \`WIDTH\` → \`T\` (#53).

### Why

Consistency with the sibling sub-constructs that nest inside \`bus\`:
- \`handshake_channel\` (this PR)
- \`credit_channel\` (planned, PR #3 in the unification roadmap)
- \`tlm_method\` (planned, PR #6)

All three share the \`_channel\` / \`_method\` suffix naming.

### Implementation

| File | Change |
|---|---|
| \`lexer.rs\` | new \`HandshakeChannel\` token alongside \`Handshake\` |
| \`parser.rs\` | \`parse_handshake_block\` accepts either opening keyword; closing keyword must match; three call sites updated |
| \`ast.rs\` | \`HandshakeMeta.legacy_handshake_kw: bool\` |
| \`typecheck.rs\` | emit \`CompileWarning\` for legacy-flagged handshakes; silenceable via \`ARCH_NO_DEPRECATIONS=1\` |

## Test plan
- [x] \`cargo test\` — 113 passing (was 109 + 4 new regressions):
  - \`test_handshake_channel_parses_new_keyword\`
  - \`test_handshake_legacy_keyword_emits_deprecation_warning\`
  - \`test_handshake_channel_no_deprecation_warning\`
  - \`test_handshake_mismatched_closing_keyword_errors\`
- [x] End-to-end: both forms produce identical SV; deprecation warning fires on legacy, silent on new, silenceable via env var

## Follow-ups
- **PR #2B**: mechanical corpus rename (tests/ + stdlib/ + docs)
- **Release gate**: legacy \`handshake\` keyword removal scheduled for v0.45.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)