### PR TITLE
chore: rename handshake → handshake_channel in stdlib

### DIFF
--- a/stdlib/BusAxiLite.arch
+++ b/stdlib/BusAxiLite.arch
@@ -23,31 +23,31 @@ bus BusAxiLite
   param DATA_W: const = 32;
 
   // Write address channel.
-  handshake aw: send kind: valid_ready
+  handshake_channel aw: send kind: valid_ready
     addr: UInt<ADDR_W>;
     prot: UInt<3>;
-  end handshake aw
+  end handshake_channel aw
 
   // Write data channel.
-  handshake w: send kind: valid_ready
+  handshake_channel w: send kind: valid_ready
     data: UInt<DATA_W>;
     strb: UInt<DATA_W / 8>;
-  end handshake w
+  end handshake_channel w
 
   // Write response channel (target → initiator).
-  handshake b: receive kind: valid_ready
+  handshake_channel b: receive kind: valid_ready
     resp: UInt<2>;
-  end handshake b
+  end handshake_channel b
 
   // Read address channel.
-  handshake ar: send kind: valid_ready
+  handshake_channel ar: send kind: valid_ready
     addr: UInt<ADDR_W>;
     prot: UInt<3>;
-  end handshake ar
+  end handshake_channel ar
 
   // Read data channel (target → initiator).
-  handshake r: receive kind: valid_ready
+  handshake_channel r: receive kind: valid_ready
     data: UInt<DATA_W>;
     resp: UInt<2>;
-  end handshake r
+  end handshake_channel r
 end bus BusAxiLite

--- a/stdlib/BusAxiStream.arch
+++ b/stdlib/BusAxiStream.arch
@@ -32,7 +32,7 @@ bus BusAxiStream
   param DEST_W:   const = 0;
   param USER_W:   const = 0;
 
-  handshake t: send kind: valid_ready
+  handshake_channel t: send kind: valid_ready
     data: UInt<DATA_W>;
     generate_if USE_LAST
       last: Bool;
@@ -52,5 +52,5 @@ bus BusAxiStream
     generate_if USER_W > 0
       user: UInt<USER_W>;
     end generate_if
-  end handshake t
+  end handshake_channel t
 end bus BusAxiStream


### PR DESCRIPTION
## Summary
- Follow-up to #57 (PR #2B of the bus unification roadmap).
- Renames the sub-construct keyword in the two stdlib bundles that use it: `BusAxiLite` and `BusAxiStream`.
- No test-corpus changes needed — a sweep found `handshake` in tests/ only in prose comments or as the synchronizer `kind handshake` (a different construct).
- `BusApb` doesn't use the sub-construct.

## Test plan
- [x] `cargo test` — 113/113 pass
- [x] Stdlib files still parse + emit SV with the new keyword