### PR TITLE
feat: parse credit_channel as a bus sub-construct (scaffolding)

### DIFF
--- a/doc/ARCH_HDL_Specification.md
+++ b/doc/ARCH_HDL_Specification.md
@@ -4626,11 +4626,44 @@ v1 scope: nested `generate_if` inside a payload branch is a compile error. A han
 
 **18a.7 Not Covered**
 
-- **Stateful protocols** (credit-based flow control, PCIe credit accounting). These are not variants of `handshake`; they belong in a future `credit_channel` construct (not yet designed) because they imply the compiler owns counter + credit-return logic, not just port shape.
+- **Stateful protocols** (credit-based flow control, PCIe credit accounting). These are not variants of `handshake_channel`; they belong in the sibling `credit_channel` sub-construct (see §18c) because they imply the compiler owns counter + credit-return logic, not just port shape.
 - **Handshake at the module port level directly.** Valid only inside a `bus` body. A single-channel interface is expressed by a one-handshake bus declaration plus an ordinary bus port.
 - **`req_ack_2phase` Tier-2 assertions** — requires `$past` tracking; deferred.
 
-**18b. Standard Bus Library**
+**18c. First-Class Sub-Construct: credit_channel (inside bus)** — *parser scaffolding, v0.44.1*
+
+> **Status (v0.44.1):** the grammar is recognized and parsed into
+> `BusDecl::credit_channels`, but elaboration — per-port-site counter
+> register + FIFO instantiation, `ch.send()` / `ch.pop()` / `ch.can_send`
+> method dispatch, and Tier-2 SVA invariants — is **not yet implemented**.
+> Declaring a `credit_channel` in a bus today produces a compile error:
+> *"credit_channel is parser scaffolding only"*. The follow-up PRs in
+> `doc/plan_credit_channel.md` land the elaboration, codegen, SVA, and
+> the NoC flit validation test.
+
+`credit_channel` carries stateful credit-based flow control as a bus sub-construct, sibling to `handshake_channel`. Syntax nests inside a bus body:
+
+```
+bus DmaCh
+  credit_channel data: send
+    param T:     type  = UInt<64>;
+    param DEPTH: const = 8;
+  end credit_channel data
+end bus DmaCh
+```
+
+Grammar (parser-accepted in v0.44.1; not yet usable):
+
+```
+CreditChannelBlock := 'credit_channel' Ident ':' Role NEWLINE
+                        ParamDecl*
+                      'end' 'credit_channel' Ident
+Role               := 'send' | 'receive'
+```
+
+Knobs: payload type `T` (use a struct for multi-field payloads) and credit depth `DEPTH`. No protocol variants — credit is one protocol. Full semantics, lowering, auto-SVA, and the NoC-flit validation test are specified in `doc/plan_credit_channel.md`.
+
+**18d. Standard Bus Library**
 
 The ARCH compiler ships with a standard library of curated `bus` definitions under `<install>/stdlib/`. These are ordinary `.arch` files built on `bus` + `handshake` + `generate_if` — no new compiler machinery — that users import with zero setup:
 

--- a/doc/Arch_AI_Reference_Card.md
+++ b/doc/Arch_AI_Reference_Card.md
@@ -890,6 +890,21 @@ end bus BusAxiLite
 
 Full spec: `doc/ARCH_HDL_Specification.md` §18a.
 
+### credit_channel (inside bus) — scaffolding only in v0.44.1
+
+Stateful credit-based flow control as a bus sub-construct. Grammar is accepted; **elaboration is not yet implemented** — any bus declaring a `credit_channel` currently fails typecheck with *"parser scaffolding only"*.
+
+```
+bus DmaCh
+  credit_channel data: send
+    param T:     type  = UInt<64>;
+    param DEPTH: const = 8;
+  end credit_channel data
+end bus DmaCh
+```
+
+When elaboration lands: `ch.can_send` / `ch.send(x)` on the initiator; `ch.valid` / `ch.data` / `ch.pop()` on the target. Compiler owns counter + FIFO. See `doc/plan_credit_channel.md` for the full design and `doc/plan_bus_unification.md` for the sibling-channel framing.
+
 ### Standard bus library (zero-setup `use`)
 
 The ARCH compiler ships curated bus definitions under `<install>/stdlib/`. Use any of them from any file with no path setup:

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -67,6 +67,12 @@ pub struct BusDecl {
     /// list preserves the grouping so codegen can emit per-variant SVA
     /// protocol assertions.
     pub handshakes: Vec<HandshakeMeta>,
+    /// Credit channel sub-constructs declared in this bus. PR #3 scaffolding:
+    /// parser populates this, but elaboration (counter reg + fifo synthesis,
+    /// method dispatch for `ch.send()`/`ch.pop()`/`ch.can_send`) is not yet
+    /// implemented. Typecheck rejects any bus port whose bus carries a
+    /// credit_channel until the elaboration PR lands.
+    pub credit_channels: Vec<CreditChannelMeta>,
     pub span: Span,
 }
 
@@ -89,6 +95,23 @@ pub struct HandshakeMeta {
     /// for documentation in generated SV comments — directions/types are
     /// already materialized as PortDecls in BusDecl::signals.
     pub payload_names: Vec<Ident>,
+    pub span: Span,
+}
+
+/// Metadata for one `credit_channel` sub-construct inside a bus. PR #3
+/// scaffolding: parser stores shape + params, but no PortDecls are
+/// materialized yet — the wire protocol (send_valid / send_data /
+/// credit_return) and the per-port-site counter + fifo synthesis land in a
+/// follow-up PR. See doc/plan_credit_channel.md.
+#[derive(Debug, Clone)]
+pub struct CreditChannelMeta {
+    /// Channel name (e.g. `data`).
+    pub name: Ident,
+    /// Role on the initiator side: `Out` = send, `In` = receive.
+    pub role_dir: Direction,
+    /// Params local to this credit_channel (`T`, `DEPTH`). Same ParamDecl
+    /// shape as bus-level params; scope is limited to this channel.
+    pub params: Vec<ParamDecl>,
     pub span: Span,
 }
 

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -119,6 +119,8 @@ pub enum TokenKind {
     Handshake,
     #[token("handshake_channel")]
     HandshakeChannel,
+    #[token("credit_channel")]
+    CreditChannel,
     #[token("implements")]
     Implements,
     #[token("return")]
@@ -412,6 +414,7 @@ impl fmt::Display for TokenKind {
             TokenKind::Bus => write!(f, "bus"),
             TokenKind::Handshake => write!(f, "handshake"),
             TokenKind::HandshakeChannel => write!(f, "handshake_channel"),
+            TokenKind::CreditChannel => write!(f, "credit_channel"),
             TokenKind::Implements => write!(f, "implements"),
             TokenKind::Return => write!(f, "return"),
             TokenKind::Stage => write!(f, "stage"),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -139,6 +139,7 @@ impl Parser {
         let mut signals = Vec::new();
         let mut generates = Vec::new();
         let mut handshakes = Vec::new();
+        let mut credit_channels = Vec::new();
         while !self.check_end_keyword() {
             if self.check_param() {
                 params.push(self.parse_param_decl()?);
@@ -149,6 +150,8 @@ impl Parser {
                 signals.extend(ports);
                 generates.extend(gen_ifs);
                 handshakes.push(meta);
+            } else if self.check(TokenKind::CreditChannel) {
+                credit_channels.push(self.parse_credit_channel_block(start)?);
             } else {
                 signals.push(self.parse_bus_signal(start)?);
             }
@@ -170,6 +173,53 @@ impl Parser {
             signals,
             generates,
             handshakes,
+            credit_channels,
+        })
+    }
+
+    /// Parse a `credit_channel` block inside a bus body. PR #3 scaffolding:
+    /// captures the channel name, role, and params (`T`, `DEPTH`). No
+    /// PortDecls are materialized — the wire protocol + per-port-site counter
+    /// + fifo synthesis land in a follow-up PR. See doc/plan_credit_channel.md.
+    ///
+    /// Grammar:
+    ///   'credit_channel' Ident ':' ('send'|'receive') NEWLINE
+    ///     ParamDecl*
+    ///   'end' 'credit_channel' Ident
+    fn parse_credit_channel_block(&mut self, _parent_span: Span) -> Result<CreditChannelMeta, CompileError> {
+        let start = self.expect(TokenKind::CreditChannel)?.span;
+        let ch_name = self.expect_ident()?;
+        self.expect(TokenKind::Colon)?;
+        let role_dir = if self.eat_contextual("send") {
+            Direction::Out
+        } else if self.eat_contextual("receive") {
+            Direction::In
+        } else {
+            return Err(CompileError::unexpected_token(
+                "send or receive",
+                &self.peek_kind().map(|k| k.to_string()).unwrap_or("EOF".into()),
+                self.peek_span(),
+            ));
+        };
+        let mut params = Vec::new();
+        while self.check_param() {
+            params.push(self.parse_param_decl()?);
+        }
+        self.expect(TokenKind::End)?;
+        self.expect(TokenKind::CreditChannel)?;
+        let closing_name = self.expect_ident()?;
+        if closing_name.name != ch_name.name {
+            return Err(CompileError::mismatched_closing(
+                &ch_name.name,
+                &closing_name.name,
+                closing_name.span,
+            ));
+        }
+        Ok(CreditChannelMeta {
+            name: ch_name,
+            role_dir,
+            params,
+            span: start.merge(closing_name.span),
         })
     }
 

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -124,6 +124,11 @@ pub struct BusInfo {
     pub generates: Vec<BusGenerateIf>,
     /// Handshake channels declared in this bus (Tier 2 SVA emission).
     pub handshakes: Vec<crate::ast::HandshakeMeta>,
+    /// Credit channels declared in this bus. PR #3 scaffolding: elaboration
+    /// rejects modules that instantiate a bus with non-empty credit_channels
+    /// because counter + fifo synthesis is not wired up yet. See
+    /// doc/plan_credit_channel.md.
+    pub credit_channels: Vec<crate::ast::CreditChannelMeta>,
 }
 
 impl BusInfo {
@@ -511,6 +516,7 @@ pub fn resolve(source_file: &SourceFile) -> Result<SymbolTable, Vec<CompileError
                             .collect(),
                         generates: b.generates.clone(),
                         handshakes: b.handshakes.clone(),
+                        credit_channels: b.credit_channels.clone(),
                     };
                     table.globals.insert(b.name.name.clone(), (Symbol::Bus(info), b.name.span));
                 }
@@ -584,6 +590,7 @@ pub fn resolve(source_file: &SourceFile) -> Result<SymbolTable, Vec<CompileError
                                     .collect(),
                                 generates: b.generates.clone(),
                                 handshakes: b.handshakes.clone(),
+                                credit_channels: b.credit_channels.clone(),
                             };
                             table.globals.insert(b.name.name.clone(), (Symbol::Bus(info), b.name.span));
                         }

--- a/src/sim_codegen.rs
+++ b/src/sim_codegen.rs
@@ -6662,6 +6662,7 @@ impl<'a> SimCodegen<'a> {
                     .collect(),
                 generates: b.generates.clone(),
                 handshakes: b.handshakes.clone(),
+                credit_channels: b.credit_channels.clone(),
             }.effective_signals(&param_map);
             h.push_str(&format!("struct {} {{\n", b.name.name));
             let mut field_inits = Vec::new();

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -118,6 +118,21 @@ impl<'a> TypeChecker<'a> {
                             }
                         }
                     }
+                    // Parser-scaffolding guard: the grammar accepts
+                    // `credit_channel` as a bus sub-construct, but elaboration
+                    // (counter reg + fifo synthesis, ch.send/ch.pop/ch.can_send
+                    // method dispatch) is not yet wired up. Reject here so no
+                    // one starts depending on an unimplemented feature. See
+                    // doc/plan_credit_channel.md §Implementation roadmap.
+                    for cc in &b.credit_channels {
+                        self.errors.push(CompileError::general(
+                            &format!(
+                                "`credit_channel {name}` is parser scaffolding only — elaboration (counter + fifo synthesis, method dispatch) is not yet implemented. Tracked in doc/plan_credit_channel.md.",
+                                name = cc.name.name
+                            ),
+                            cc.span,
+                        ));
+                    }
                 }
                 Item::Package(pkg) => {
                     for e in &pkg.enums { self.check_enum(e); }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -3493,6 +3493,75 @@ fn test_handshake_channel_no_deprecation_warning() {
 }
 
 #[test]
+fn test_credit_channel_parses_as_bus_sub_construct() {
+    // PR #3 scaffolding: credit_channel inside a bus parses into
+    // BusDecl::credit_channels. Typecheck rejects it (not yet implemented),
+    // but parser + resolve should succeed.
+    let source = "
+        bus DmaCh
+          credit_channel data: send
+            param T:     type  = UInt<64>;
+            param DEPTH: const = 8;
+          end credit_channel data
+        end bus DmaCh
+    ";
+    let tokens = arch::lexer::tokenize(source).expect("lexer");
+    let mut parser = arch::parser::Parser::new(tokens, source);
+    let ast = parser.parse_source_file().expect("parse");
+    let bus = ast.items.iter().find_map(|it| match it {
+        arch::ast::Item::Bus(b) if b.name.name == "DmaCh" => Some(b),
+        _ => None,
+    }).expect("DmaCh bus should be in AST");
+    assert_eq!(bus.credit_channels.len(), 1);
+    let cc = &bus.credit_channels[0];
+    assert_eq!(cc.name.name, "data");
+    assert_eq!(cc.role_dir, arch::ast::Direction::Out);
+    assert_eq!(cc.params.len(), 2);
+    assert_eq!(cc.params[0].name.name, "T");
+    assert_eq!(cc.params[1].name.name, "DEPTH");
+}
+
+#[test]
+fn test_credit_channel_rejected_in_typecheck_as_unimplemented() {
+    let source = "
+        bus DmaCh
+          credit_channel data: send
+            param T:     type  = UInt<64>;
+            param DEPTH: const = 8;
+          end credit_channel data
+        end bus DmaCh
+    ";
+    let tokens = arch::lexer::tokenize(source).expect("lexer");
+    let mut parser = arch::parser::Parser::new(tokens, source);
+    let ast = parser.parse_source_file().expect("parse");
+    let ast = arch::elaborate::elaborate(ast).expect("elaborate");
+    let ast = arch::elaborate::lower_threads(ast).expect("lower threads");
+    let ast = arch::elaborate::lower_pipe_reg_ports(ast).expect("lower pipe_reg");
+    let symbols = arch::resolve::resolve(&ast).expect("resolve");
+    let result = arch::typecheck::TypeChecker::new(&symbols, &ast).check();
+    assert!(result.is_err(), "typecheck should reject credit_channel until elaboration ships");
+    let err_str = format!("{:?}", result.unwrap_err());
+    assert!(err_str.contains("credit_channel") && err_str.contains("scaffolding"),
+        "expected scaffolding error, got: {err_str}");
+}
+
+#[test]
+fn test_credit_channel_mismatched_closing_keyword_errors() {
+    let source = "
+        bus B
+          credit_channel data: send
+            param T:     type  = UInt<64>;
+            param DEPTH: const = 8;
+          end credit_channel wrong_name
+        end bus B
+    ";
+    let tokens = arch::lexer::tokenize(source).expect("lexer");
+    let mut parser = arch::parser::Parser::new(tokens, source);
+    assert!(parser.parse_source_file().is_err(),
+        "mismatched credit_channel close should be a parse error");
+}
+
+#[test]
 fn test_handshake_mismatched_closing_keyword_errors() {
     // Opening with `handshake_channel` but closing with `end handshake`
     // (or vice versa) should be a parse error.


### PR DESCRIPTION
## Summary
- First slice of PR #3 from the bus-unification roadmap (see `doc/plan_bus_unification.md` §Implementation roadmap).
- Adds grammar + AST + resolve support for the `credit_channel` sub-construct nested inside `bus`. Parser stores channel name, role, and params (`T`, `DEPTH`) in `BusDecl.credit_channels`.
- **Elaboration is intentionally not included**: typecheck rejects any bus declaring a `credit_channel` with a targeted "parser scaffolding only" error. This keeps the grammar under version control while making it impossible for anyone to depend on the half-built feature.

## Why split
Full credit_channel is a large feature — counter reg + fifo synthesis per port site, method dispatch (`ch.send()`, `ch.pop()`, `ch.can_send`, `ch.valid`, `ch.data`), Tier-2 SVA invariants, and the NoC-flit validation test. Landing the grammar first lets follow-up PRs focus on semantics without re-litigating syntax.

## Roadmap
- **PR #3b**: per-port-site elaboration — inject counter reg + fifo inst + method dispatch.
- **PR #4**: codegen + the four Tier-2 SVA invariants from `plan_credit_channel.md` §Lowering.
- **PR #5**: docs pass + NoC flit validation test from `plan_credit_channel.md` §Validation plan.

## Test plan
- [x] `cargo test` — 116/116 pass (113 existing + 3 new regressions).
- [x] `test_credit_channel_parses_as_bus_sub_construct` — grammar accepted; AST populated.
- [x] `test_credit_channel_rejected_in_typecheck_as_unimplemented` — typecheck surfaces the scaffolding-only error.
- [x] `test_credit_channel_mismatched_closing_keyword_errors` — mismatched closer is a parse error.