### PR TITLE
feat: flatten credit_channel wires at bus port use site

### DIFF
--- a/doc/ARCH_HDL_Specification.md
+++ b/doc/ARCH_HDL_Specification.md
@@ -4630,16 +4630,20 @@ v1 scope: nested `generate_if` inside a payload branch is a compile error. A han
 - **Handshake at the module port level directly.** Valid only inside a `bus` body. A single-channel interface is expressed by a one-handshake bus declaration plus an ordinary bus port.
 - **`req_ack_2phase` Tier-2 assertions** — requires `$past` tracking; deferred.
 
-**18c. First-Class Sub-Construct: credit_channel (inside bus)** — *parser scaffolding, v0.44.1*
+**18c. First-Class Sub-Construct: credit_channel (inside bus)** — *wire layer live, elaboration pending*
 
-> **Status (v0.44.1):** the grammar is recognized and parsed into
-> `BusDecl::credit_channels`, but elaboration — per-port-site counter
-> register + FIFO instantiation, `ch.send()` / `ch.pop()` / `ch.can_send`
-> method dispatch, and Tier-2 SVA invariants — is **not yet implemented**.
-> Declaring a `credit_channel` in a bus today produces a compile error:
-> *"credit_channel is parser scaffolding only"*. The follow-up PRs in
-> `doc/plan_credit_channel.md` land the elaboration, codegen, SVA, and
-> the NoC flit validation test.
+> **Status (v0.44.2):** the grammar is parsed, and the wire protocol
+> flattens at the bus port: a `credit_channel <ch>: send` declaration
+> materializes three signals — `<ch>_send_valid`, `<ch>_send_data`, and
+> `<ch>_credit_return` — with directions derived from the role and flipped
+> on the `target` perspective (same mechanism as `handshake_channel`). Not
+> yet implemented: per-port-site **counter register** on the initiator,
+> **FIFO** on the target, the **`CAN_SEND_REGISTERED` timing-relief knob**
+> (next-state flop), and **method dispatch** for `ch.send()` / `ch.pop()` /
+> `ch.can_send` / `ch.valid` / `ch.data`. Users can drive the flattened
+> wires directly today; attempts to invoke the method abstraction fail at
+> member resolution. Tier-2 SVA invariants land with the elaboration PR.
+> Full design in `doc/plan_credit_channel.md`.
 
 `credit_channel` carries stateful credit-based flow control as a bus sub-construct, sibling to `handshake_channel`. Syntax nests inside a bus body:
 

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -150,6 +150,41 @@ impl BusInfo {
                 result.push((s.name.name.clone(), s.direction, s.ty.clone()));
             }
         }
+        // Expand credit_channel sub-constructs into their wire protocol:
+        //   <ch>_send_valid     : Bool (initiator→target)
+        //   <ch>_send_data      : T    (initiator→target)
+        //   <ch>_credit_return  : Bool (target→initiator)
+        // Directions below are from the INITIATOR perspective; the existing
+        // `target` bus-port perspective flip inverts them uniformly.
+        // Per PR #3b-i scope: method dispatch (`ch.send`/`ch.pop`/...), the
+        // counter reg on the initiator side, and the fifo on the target side
+        // are NOT yet synthesized — that lands in the elaboration PR. Users
+        // who touch these wires directly today (e.g. to drive send_valid from
+        // a comb block) compile cleanly; users who invoke the method
+        // abstraction get a typecheck error pointing at the scaffolding gap.
+        for cc in &self.credit_channels {
+            let (vd_dir, ret_dir) = match cc.role_dir {
+                Direction::Out => (Direction::Out, Direction::In),   // send role
+                Direction::In  => (Direction::In,  Direction::Out),  // receive role
+            };
+            // Payload type: take the default of the channel's `T` param.
+            // Channel-level param overrides at the bus-port-instance site
+            // are a future extension.
+            let payload_ty = cc.params.iter()
+                .find(|p| p.name.name == "T")
+                .and_then(|p| match &p.kind {
+                    crate::ast::ParamKind::Type(te) => Some(te.clone()),
+                    _ => None,
+                })
+                .unwrap_or_else(|| TypeExpr::UInt(Box::new(Expr::new(
+                    ExprKind::Literal(LitKind::Dec(64)),
+                    cc.span,
+                ))));
+            let bool_ty = TypeExpr::Bool;
+            result.push((format!("{}_send_valid", cc.name.name), vd_dir, bool_ty.clone()));
+            result.push((format!("{}_send_data",  cc.name.name), vd_dir, payload_ty));
+            result.push((format!("{}_credit_return", cc.name.name), ret_dir, bool_ty));
+        }
         result
     }
 }

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -118,21 +118,15 @@ impl<'a> TypeChecker<'a> {
                             }
                         }
                     }
-                    // Parser-scaffolding guard: the grammar accepts
-                    // `credit_channel` as a bus sub-construct, but elaboration
-                    // (counter reg + fifo synthesis, ch.send/ch.pop/ch.can_send
-                    // method dispatch) is not yet wired up. Reject here so no
-                    // one starts depending on an unimplemented feature. See
-                    // doc/plan_credit_channel.md §Implementation roadmap.
-                    for cc in &b.credit_channels {
-                        self.errors.push(CompileError::general(
-                            &format!(
-                                "`credit_channel {name}` is parser scaffolding only — elaboration (counter + fifo synthesis, method dispatch) is not yet implemented. Tracked in doc/plan_credit_channel.md.",
-                                name = cc.name.name
-                            ),
-                            cc.span,
-                        ));
-                    }
+                    // Wire flattening (send_valid, send_data, credit_return)
+                    // is live as of PR #3b-i. The remaining
+                    // not-yet-implemented layers — counter reg on the
+                    // initiator, fifo + credit-return pulse on the target,
+                    // and method dispatch for `ch.send` / `ch.pop` /
+                    // `ch.can_send` / `ch.valid` / `ch.data` — land in a
+                    // follow-up PR. Users who drive the flattened wires
+                    // directly today compile cleanly; method-dispatch use
+                    // sites are rejected at the access resolution site.
                 }
                 Item::Package(pkg) => {
                     for e in &pkg.enums { self.check_enum(e); }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -3522,27 +3522,64 @@ fn test_credit_channel_parses_as_bus_sub_construct() {
 }
 
 #[test]
-fn test_credit_channel_rejected_in_typecheck_as_unimplemented() {
+fn test_credit_channel_wires_flatten_at_bus_port() {
+    // PR #3b-i: a bus with a credit_channel sub-construct flattens to three
+    // wires (send_valid, send_data, credit_return) at the port use site.
+    // Method dispatch (ch.send/ch.pop/ch.can_send) is still unimplemented;
+    // users who drive the flattened wires directly compile cleanly.
     let source = "
         bus DmaCh
           credit_channel data: send
-            param T:     type  = UInt<64>;
-            param DEPTH: const = 8;
+            param T:     type  = UInt<16>;
+            param DEPTH: const = 4;
           end credit_channel data
         end bus DmaCh
+
+        use DmaCh;
+
+        module Prod
+          port p: initiator DmaCh;
+          comb
+            p.data_send_valid = 1'b0;
+            p.data_send_data  = 16'h0;
+          end comb
+        end module Prod
     ";
-    let tokens = arch::lexer::tokenize(source).expect("lexer");
-    let mut parser = arch::parser::Parser::new(tokens, source);
-    let ast = parser.parse_source_file().expect("parse");
-    let ast = arch::elaborate::elaborate(ast).expect("elaborate");
-    let ast = arch::elaborate::lower_threads(ast).expect("lower threads");
-    let ast = arch::elaborate::lower_pipe_reg_ports(ast).expect("lower pipe_reg");
-    let symbols = arch::resolve::resolve(&ast).expect("resolve");
-    let result = arch::typecheck::TypeChecker::new(&symbols, &ast).check();
-    assert!(result.is_err(), "typecheck should reject credit_channel until elaboration ships");
-    let err_str = format!("{:?}", result.unwrap_err());
-    assert!(err_str.contains("credit_channel") && err_str.contains("scaffolding"),
-        "expected scaffolding error, got: {err_str}");
+    let sv = compile_to_sv(source);
+    assert!(sv.contains("output logic p_data_send_valid"),
+        "credit_channel should emit send_valid as an initiator output:\n{sv}");
+    assert!(sv.contains("output logic [15:0] p_data_send_data"),
+        "credit_channel should emit send_data with the payload type:\n{sv}");
+    assert!(sv.contains("input logic p_data_credit_return"),
+        "credit_channel should emit credit_return as an initiator input:\n{sv}");
+}
+
+#[test]
+fn test_credit_channel_wires_flip_on_target_perspective() {
+    let source = "
+        bus DmaCh
+          credit_channel data: send
+            param T:     type  = UInt<16>;
+            param DEPTH: const = 4;
+          end credit_channel data
+        end bus DmaCh
+
+        use DmaCh;
+
+        module Cons
+          port p: target DmaCh;
+          comb
+            p.data_credit_return = 1'b0;
+          end comb
+        end module Cons
+    ";
+    let sv = compile_to_sv(source);
+    assert!(sv.contains("input logic p_data_send_valid"),
+        "on target perspective, send_valid should be an input:\n{sv}");
+    assert!(sv.contains("input logic [15:0] p_data_send_data"),
+        "on target perspective, send_data should be an input:\n{sv}");
+    assert!(sv.contains("output logic p_data_credit_return"),
+        "on target perspective, credit_return should be an output:\n{sv}");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- PR #3b-i of the credit_channel rollout. Builds on #59 (parser scaffolding).
- \`BusInfo::effective_signals\` now emits three wires per \`credit_channel\` sub-construct: \`<ch>_send_valid\`, \`<ch>_send_data\` (type = channel's \`T\` default), \`<ch>_credit_return\`.
- Directions flip on \`target\` ports via the existing bus-perspective machinery.
- The PR #3a scaffolding-reject at bus declaration is lifted — modules that drive the flattened wires directly now compile to SV cleanly.

## What's still unimplemented (blocking follow-ups)
- Counter register on the initiator side.
- FIFO on the target side (credit-return pulse wiring).
- \`CAN_SEND_REGISTERED\` next-state-flop timing-relief knob (agreed: option (b) from the design discussion).
- Method dispatch: \`ch.send()\` / \`ch.pop()\` / \`ch.can_send\` / \`ch.valid\` / \`ch.data\`.
- The four Tier-2 SVA invariants from \`plan_credit_channel.md\` §Lowering.

These all land in PR #3b-ii. Users attempting method dispatch today fail at the regular member-resolution site (since \`.send\` isn't a flattened wire name).

## Test plan
- [x] \`cargo test\` — 117/117 pass (115 existing + 2 new wire-flattening regressions).
- [x] \`test_credit_channel_wires_flatten_at_bus_port\` — initiator perspective emits out/out/in.
- [x] \`test_credit_channel_wires_flip_on_target_perspective\` — target perspective emits in/in/out.

## Docs
- Spec §18c status block rewritten to call out what's live vs pending.