### PR TITLE
feat: synthesize sender-side credit counter for credit_channel

### DIFF
--- a/doc/ARCH_HDL_Specification.md
+++ b/doc/ARCH_HDL_Specification.md
@@ -4632,18 +4632,19 @@ v1 scope: nested `generate_if` inside a payload branch is a compile error. A han
 
 **18c. First-Class Sub-Construct: credit_channel (inside bus)** — *wire layer live, elaboration pending*
 
-> **Status (v0.44.2):** the grammar is parsed, and the wire protocol
-> flattens at the bus port: a `credit_channel <ch>: send` declaration
-> materializes three signals — `<ch>_send_valid`, `<ch>_send_data`, and
-> `<ch>_credit_return` — with directions derived from the role and flipped
-> on the `target` perspective (same mechanism as `handshake_channel`). Not
-> yet implemented: per-port-site **counter register** on the initiator,
-> **FIFO** on the target, the **`CAN_SEND_REGISTERED` timing-relief knob**
-> (next-state flop), and **method dispatch** for `ch.send()` / `ch.pop()` /
-> `ch.can_send` / `ch.valid` / `ch.data`. Users can drive the flattened
-> wires directly today; attempts to invoke the method abstraction fail at
-> member resolution. Tier-2 SVA invariants land with the elaboration PR.
-> Full design in `doc/plan_credit_channel.md`.
+> **Status (v0.44.3):** the grammar is parsed, the wire protocol flattens at
+> the bus port (`<ch>_send_valid`, `<ch>_send_data`, `<ch>_credit_return`),
+> and the **sender-side credit counter** is now auto-synthesized on any
+> module with a `send`-role credit_channel bus port: `__<port>_<ch>_credit`
+> tracks available credit (reset to `DEPTH`, decrements on `send_valid &&
+> !credit_return`, increments on `credit_return && !send_valid`), and
+> `__<port>_<ch>_can_send` exposes current-cycle availability. Users can
+> read `__<port>_<ch>_can_send` and drive `<port>_<ch>_send_valid` from comb
+> to build a compliant sender today. Not yet implemented: **target-side
+> FIFO** + credit-return pulse wiring, the **`CAN_SEND_REGISTERED`
+> timing-relief knob** (next-state flop, option (b)), **method dispatch**
+> for `ch.send()` / `ch.pop()` / `ch.can_send` / `ch.valid` / `ch.data`,
+> and **Tier-2 SVA invariants**. Full design in `doc/plan_credit_channel.md`.
 
 `credit_channel` carries stateful credit-based flow control as a bus sub-construct, sibling to `handshake_channel`. Syntax nests inside a bus body:
 

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -879,6 +879,10 @@ impl<'a> Codegen<'a> {
         // bus definition contains one or more `handshake` channels.
         self.emit_handshake_asserts(&m_clone);
 
+        // Emit the synthesized credit counter + can_send wire for each
+        // `send`-role credit_channel bus port on the module (PR #3b-ii).
+        self.emit_credit_channel_state(&m_clone);
+
         // Emit log file descriptors: initial $fopen / final $fclose
         let log_files = Self::collect_log_files(&m_clone.body);
         if !log_files.is_empty() {
@@ -2755,6 +2759,126 @@ impl<'a> Codegen<'a> {
             }
         }
         self.line("// synopsys translate_on");
+    }
+
+    /// Emit the synthesized credit-counter state for each `send`-role
+    /// `credit_channel` sub-construct on a bus port of this module.
+    ///
+    /// Per port+channel pair, emits three things:
+    ///
+    /// 1. `logic [W-1:0] __<port>_<ch>_credit;` — the credit register,
+    ///    width = clog2(DEPTH+1).
+    /// 2. An `always_ff` block that resets the counter to DEPTH on reset
+    ///    and updates it each cycle:
+    ///       -1 when send_valid && !credit_return
+    ///       +1 when credit_return && !send_valid
+    ///       no change when both fire in the same cycle (plan §Lowering).
+    /// 3. `wire __<port>_<ch>_can_send = __<port>_<ch>_credit != 0;` —
+    ///    combinational current-cycle availability. Users whose design
+    ///    needs a timing-relief flop will opt in via the upcoming
+    ///    `CAN_SEND_REGISTERED` channel param (next-state flop semantics,
+    ///    option (b) — see doc/plan_credit_channel.md).
+    ///
+    /// PR #3b-ii emits only the sender-side state — target-side FIFO +
+    /// credit_return-pulse wiring lands in PR #3b-iii; `ch.send()` /
+    /// `ch.can_send` method dispatch desugars to `__<port>_<ch>_*` in a
+    /// follow-up. Users today can read `__<port>_<ch>_can_send` directly
+    /// and drive `<port>_<ch>_send_valid` from their own comb to build
+    /// a compliant sender without the sugar.
+    fn emit_credit_channel_state(&mut self, m: &ModuleDecl) {
+        let mut emissions: Vec<(String, crate::ast::CreditChannelMeta)> = Vec::new();
+        for p in &m.ports {
+            let Some(ref bi) = p.bus_info else { continue; };
+            let Some((crate::resolve::Symbol::Bus(info), _)) =
+                self.symbols.globals.get(&bi.bus_name.name) else { continue; };
+            for cc in &info.credit_channels {
+                // Initiator perspective drives send; on the target perspective
+                // the same bus flip inverts the data direction, but the sender
+                // state belongs on whichever side actually issues sends.
+                let is_sender = match (cc.role_dir, bi.perspective) {
+                    (Direction::Out, crate::ast::BusPerspective::Initiator) => true,
+                    (Direction::In,  crate::ast::BusPerspective::Target)    => true,
+                    _ => false,
+                };
+                if is_sender {
+                    emissions.push((p.name.name.clone(), cc.clone()));
+                }
+            }
+        }
+        if emissions.is_empty() { return; }
+
+        let clk = m.ports.iter()
+            .find(|p| matches!(&p.ty, TypeExpr::Clock(_)))
+            .map(|p| p.name.name.clone());
+        let Some(clk) = clk else { return; };
+        let rst_port = m.ports.iter()
+            .find(|p| matches!(&p.ty, TypeExpr::Reset(_, _)));
+        let (rst_edge, rst_active) = match rst_port {
+            Some(p) => {
+                let active = match &p.ty {
+                    TypeExpr::Reset(_, ResetLevel::Low) => format!("!{}", p.name.name),
+                    _ => p.name.name.clone(),
+                };
+                let edge = match &p.ty {
+                    TypeExpr::Reset(ResetKind::Async, ResetLevel::Low) => format!(" or negedge {}", p.name.name),
+                    TypeExpr::Reset(ResetKind::Async, ResetLevel::High) => format!(" or posedge {}", p.name.name),
+                    _ => String::new(),
+                };
+                (edge, Some(active))
+            }
+            None => (String::new(), None),
+        };
+
+        self.line("");
+        self.line("// Auto-generated credit_channel state (PR #3b-ii, sender side)");
+        for (port_name, cc) in &emissions {
+            let ch = &cc.name.name;
+            let depth_expr = cc.params.iter()
+                .find(|p| p.name.name == "DEPTH")
+                .and_then(|p| p.default.as_ref());
+            let Some(depth_expr) = depth_expr else { continue; };
+            let depth_str = self.emit_expr_str(depth_expr);
+            let credit_reg = format!("__{port_name}_{ch}_credit");
+            let cs_wire    = format!("__{port_name}_{ch}_can_send");
+            let send_valid = format!("{port_name}_{ch}_send_valid");
+            let credit_ret = format!("{port_name}_{ch}_credit_return");
+            // Width = $clog2(DEPTH + 1). Emit as-is; SV reduces at elab.
+            self.line(&format!(
+                "logic [$clog2(({depth_str}) + 1) - 1:0] {credit_reg};"
+            ));
+            self.line(&format!(
+                "wire  {cs_wire} = {credit_reg} != 0;"
+            ));
+            match &rst_active {
+                Some(r) => {
+                    self.line(&format!(
+                        "always_ff @(posedge {clk}{rst_edge}) begin"
+                    ));
+                    self.indent += 1;
+                    self.line(&format!("if ({r}) {credit_reg} <= {depth_str};"));
+                    self.line(&format!(
+                        "else if ({send_valid} && !{credit_ret}) {credit_reg} <= {credit_reg} - 1;"
+                    ));
+                    self.line(&format!(
+                        "else if ({credit_ret} && !{send_valid}) {credit_reg} <= {credit_reg} + 1;"
+                    ));
+                    self.indent -= 1;
+                    self.line("end");
+                }
+                None => {
+                    self.line(&format!("always_ff @(posedge {clk}) begin"));
+                    self.indent += 1;
+                    self.line(&format!(
+                        "if ({send_valid} && !{credit_ret}) {credit_reg} <= {credit_reg} - 1;"
+                    ));
+                    self.line(&format!(
+                        "else if ({credit_ret} && !{send_valid}) {credit_reg} <= {credit_reg} + 1;"
+                    ));
+                    self.indent -= 1;
+                    self.line("end");
+                }
+            }
+        }
     }
 
     /// "Is this a compile-time reducible constant?" test. Matches the sim-

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -3583,6 +3583,77 @@ fn test_credit_channel_wires_flip_on_target_perspective() {
 }
 
 #[test]
+fn test_credit_channel_emits_sender_counter_state() {
+    // PR #3b-ii: on the initiator side of a `send`-role credit_channel,
+    // the SV output includes the credit register, can_send wire, and
+    // counter-update always_ff block. Target-side fifo + method dispatch
+    // are still TBD (PR #3b-iii / #3b-iv).
+    let source = "
+        bus DmaCh
+          credit_channel data: send
+            param T:     type  = UInt<8>;
+            param DEPTH: const = 4;
+          end credit_channel data
+        end bus DmaCh
+
+        use DmaCh;
+
+        module Prod
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync>;
+          port p:   initiator DmaCh;
+          comb
+            p.data_send_valid = 1'b0;
+            p.data_send_data  = 8'h0;
+          end comb
+        end module Prod
+    ";
+    let sv = compile_to_sv(source);
+    assert!(sv.contains("__p_data_credit"),
+        "credit register should be declared:\n{sv}");
+    assert!(sv.contains("__p_data_can_send"),
+        "can_send wire should be declared:\n{sv}");
+    assert!(sv.contains("__p_data_can_send = __p_data_credit != 0"),
+        "can_send wire should read the credit reg:\n{sv}");
+    assert!(sv.contains("p_data_send_valid && !p_data_credit_return"),
+        "counter-update should decrement on pure send:\n{sv}");
+    assert!(sv.contains("p_data_credit_return && !p_data_send_valid"),
+        "counter-update should increment on pure credit_return:\n{sv}");
+    assert!(sv.contains("always_ff"),
+        "counter should update in an always_ff block:\n{sv}");
+}
+
+#[test]
+fn test_credit_channel_no_counter_on_receive_role() {
+    // A `send`-role channel where this module is the target should NOT
+    // emit a sender counter — this module is the receiver. (The target
+    // fifo lands in PR #3b-iii; for now no helper state at all on the
+    // target side.)
+    let source = "
+        bus DmaCh
+          credit_channel data: send
+            param T:     type  = UInt<8>;
+            param DEPTH: const = 4;
+          end credit_channel data
+        end bus DmaCh
+
+        use DmaCh;
+
+        module Cons
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync>;
+          port p:   target DmaCh;
+          comb
+            p.data_credit_return = 1'b0;
+          end comb
+        end module Cons
+    ";
+    let sv = compile_to_sv(source);
+    assert!(!sv.contains("__p_data_credit"),
+        "target-role module should not emit sender counter:\n{sv}");
+}
+
+#[test]
 fn test_credit_channel_mismatched_closing_keyword_errors() {
     let source = "
         bus B


### PR DESCRIPTION
## Summary
- PR #3b-ii. Builds on #60 (wire flattening).
- Emits the sender-side credit counter + can_send wire per \`send\`-role credit_channel bus port. Reset = DEPTH; decrement on pure send; increment on pure credit_return; no-op on simultaneous.
- Reset polarity/kind inferred from the module's \`Reset<...>\` port, matching the handshake-SVA / bounds-assert pattern.
- Target-side fifo, \`CAN_SEND_REGISTERED\` flop, method dispatch, and Tier-2 SVA are still unimplemented; see follow-ups.

## What works now
A sender can be written today without method sugar:
\`\`\`
comb
  p.data_send_valid = __p_data_can_send && have_data;
  p.data_send_data  = next_payload;
end comb
\`\`\`

## Test plan
- [x] \`cargo test\` — 119/119 pass (117 existing + 2 new regressions).
- [x] \`test_credit_channel_emits_sender_counter_state\` — SV contains the reg, the can_send wire, and the signed update expressions.
- [x] \`test_credit_channel_no_counter_on_receive_role\` — target-role module on a \`send\` channel does not emit the sender counter.