### PR TITLE
feat: synthesize target-side FIFO for credit_channel

### DIFF
--- a/doc/ARCH_HDL_Specification.md
+++ b/doc/ARCH_HDL_Specification.md
@@ -4632,19 +4632,21 @@ v1 scope: nested `generate_if` inside a payload branch is a compile error. A han
 
 **18c. First-Class Sub-Construct: credit_channel (inside bus)** — *wire layer live, elaboration pending*
 
-> **Status (v0.44.3):** the grammar is parsed, the wire protocol flattens at
-> the bus port (`<ch>_send_valid`, `<ch>_send_data`, `<ch>_credit_return`),
-> and the **sender-side credit counter** is now auto-synthesized on any
-> module with a `send`-role credit_channel bus port: `__<port>_<ch>_credit`
-> tracks available credit (reset to `DEPTH`, decrements on `send_valid &&
-> !credit_return`, increments on `credit_return && !send_valid`), and
-> `__<port>_<ch>_can_send` exposes current-cycle availability. Users can
-> read `__<port>_<ch>_can_send` and drive `<port>_<ch>_send_valid` from comb
-> to build a compliant sender today. Not yet implemented: **target-side
-> FIFO** + credit-return pulse wiring, the **`CAN_SEND_REGISTERED`
-> timing-relief knob** (next-state flop, option (b)), **method dispatch**
-> for `ch.send()` / `ch.pop()` / `ch.can_send` / `ch.valid` / `ch.data`,
-> and **Tier-2 SVA invariants**. Full design in `doc/plan_credit_channel.md`.
+> **Status (v0.44.4):** grammar, wire flattening, sender-side credit counter,
+> and **target-side FIFO** are all in place. On the receiver module
+> (`target` perspective on a `send`-role channel) the codegen synthesizes a
+> depth-DEPTH packet buffer (`__<port>_<ch>_buf`) with head/tail/occupancy
+> pointers, pushed on `<port>_<ch>_send_valid` and popped when the user
+> drives `<port>_<ch>_credit_return` high while the FIFO is non-empty. The
+> user-driven `credit_return` is therefore both the pop trigger and the
+> credit-return pulse to the sender — a clean single-signal contract. Still
+> not implemented (in order): **ARCH-level method dispatch** for
+> `port.ch.valid` / `port.ch.data` / `port.ch.can_send` / `ch.send()` /
+> `ch.pop()`, the **`CAN_SEND_REGISTERED` timing-relief knob** (next-state
+> flop, option (b)), and **Tier-2 SVA invariants**. The FIFO internals are
+> visible in SV only for now — cocotb TBs and raw SV drivers can use them
+> today; method dispatch is blocked on an AST design decision for
+> typecheck-visible synthesized wires.
 
 `credit_channel` carries stateful credit-based flow control as a bus sub-construct, sibling to `handshake_channel`. Syntax nests inside a bus body:
 

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -883,6 +883,10 @@ impl<'a> Codegen<'a> {
         // `send`-role credit_channel bus port on the module (PR #3b-ii).
         self.emit_credit_channel_state(&m_clone);
 
+        // Emit the target-side FIFO for each credit_channel bus port on
+        // the module where this side is the receiver (PR #3b-iii).
+        self.emit_credit_channel_receiver_state(&m_clone);
+
         // Emit log file descriptors: initial $fopen / final $fclose
         let log_files = Self::collect_log_files(&m_clone.body);
         if !log_files.is_empty() {
@@ -2874,6 +2878,155 @@ impl<'a> Codegen<'a> {
                     self.line(&format!(
                         "else if ({credit_ret} && !{send_valid}) {credit_reg} <= {credit_reg} + 1;"
                     ));
+                    self.indent -= 1;
+                    self.line("end");
+                }
+            }
+        }
+    }
+
+    /// Emit the receiver-side FIFO + pop wiring for each credit_channel
+    /// where this module is the consumer (target on a `send`-role channel,
+    /// or initiator on a `receive`-role channel). Pops when the user-driven
+    /// `<port>_<ch>_credit_return` is asserted and the FIFO is non-empty.
+    ///
+    /// Emits the following per (port, credit_channel):
+    ///   logic [W-1:0]      __<port>_<ch>_buf [DEPTH];
+    ///   logic [AW-1:0]     __<port>_<ch>_head;
+    ///   logic [AW-1:0]     __<port>_<ch>_tail;
+    ///   logic [OW-1:0]     __<port>_<ch>_occ;     // 0..DEPTH
+    ///   wire              __<port>_<ch>_valid = __<port>_<ch>_occ != 0;
+    ///   wire [W-1:0]      __<port>_<ch>_data  = __<port>_<ch>_buf[head];
+    ///   always_ff          // push on send_valid, pop on credit_return && valid
+    ///
+    /// Where W = type width of the payload T, AW = $clog2(DEPTH),
+    /// OW = $clog2(DEPTH+1).
+    ///
+    /// Scope note (PR #3b-iii): these wires are SV-level only. ARCH-level
+    /// method dispatch (`port.ch.valid`, `port.ch.data`) is not yet wired
+    /// up — that lands once the AST-level synthesized-wire story is
+    /// locked down. In the interim, the FIFO is observable by reading
+    /// the SV names directly (e.g. from a cocotb TB) or by writing raw
+    /// send/credit_return drives and trusting the invariants hold.
+    fn emit_credit_channel_receiver_state(&mut self, m: &ModuleDecl) {
+        let mut emissions: Vec<(String, crate::ast::CreditChannelMeta)> = Vec::new();
+        for p in &m.ports {
+            let Some(ref bi) = p.bus_info else { continue; };
+            let Some((crate::resolve::Symbol::Bus(info), _)) =
+                self.symbols.globals.get(&bi.bus_name.name) else { continue; };
+            for cc in &info.credit_channels {
+                // Receiver side mirrors the sender-state selector:
+                //   send role + target perspective → this module is the receiver
+                //   receive role + initiator perspective → this module is the receiver
+                let is_receiver = match (cc.role_dir, bi.perspective) {
+                    (Direction::Out, crate::ast::BusPerspective::Target)    => true,
+                    (Direction::In,  crate::ast::BusPerspective::Initiator) => true,
+                    _ => false,
+                };
+                if is_receiver {
+                    emissions.push((p.name.name.clone(), cc.clone()));
+                }
+            }
+        }
+        if emissions.is_empty() { return; }
+
+        let clk = m.ports.iter()
+            .find(|p| matches!(&p.ty, TypeExpr::Clock(_)))
+            .map(|p| p.name.name.clone());
+        let Some(clk) = clk else { return; };
+        let rst_port = m.ports.iter()
+            .find(|p| matches!(&p.ty, TypeExpr::Reset(_, _)));
+        let (rst_edge, rst_active) = match rst_port {
+            Some(p) => {
+                let active = match &p.ty {
+                    TypeExpr::Reset(_, ResetLevel::Low) => format!("!{}", p.name.name),
+                    _ => p.name.name.clone(),
+                };
+                let edge = match &p.ty {
+                    TypeExpr::Reset(ResetKind::Async, ResetLevel::Low) => format!(" or negedge {}", p.name.name),
+                    TypeExpr::Reset(ResetKind::Async, ResetLevel::High) => format!(" or posedge {}", p.name.name),
+                    _ => String::new(),
+                };
+                (edge, Some(active))
+            }
+            None => (String::new(), None),
+        };
+
+        self.line("");
+        self.line("// Auto-generated credit_channel target-side FIFO (PR #3b-iii)");
+        for (port_name, cc) in &emissions {
+            let ch = &cc.name.name;
+            let depth_expr = cc.params.iter()
+                .find(|p| p.name.name == "DEPTH")
+                .and_then(|p| p.default.as_ref());
+            let Some(depth_expr) = depth_expr else { continue; };
+            let depth_str = self.emit_expr_str(depth_expr);
+            // Payload type width — resolve via the ParamKind::Type default.
+            let payload_ty_opt = cc.params.iter()
+                .find(|p| p.name.name == "T")
+                .and_then(|p| match &p.kind {
+                    crate::ast::ParamKind::Type(te) => Some(te.clone()),
+                    _ => None,
+                });
+            let Some(payload_ty) = payload_ty_opt else { continue; };
+            let Some(width_str) = self.type_expr_data_width(&payload_ty) else { continue; };
+            let buf = format!("__{port_name}_{ch}_buf");
+            let head = format!("__{port_name}_{ch}_head");
+            let tail = format!("__{port_name}_{ch}_tail");
+            let occ  = format!("__{port_name}_{ch}_occ");
+            let valid_w = format!("__{port_name}_{ch}_valid");
+            let data_w  = format!("__{port_name}_{ch}_data");
+            let push = format!("{port_name}_{ch}_send_valid");
+            let pushd= format!("{port_name}_{ch}_send_data");
+            let pop_drv = format!("{port_name}_{ch}_credit_return");
+
+            self.line(&format!("logic [({width_str}) - 1:0] {buf} [({depth_str})];"));
+            self.line(&format!("logic [$clog2({depth_str}) == 0 ? 0 : $clog2({depth_str}) - 1:0] {head};"));
+            self.line(&format!("logic [$clog2({depth_str}) == 0 ? 0 : $clog2({depth_str}) - 1:0] {tail};"));
+            self.line(&format!("logic [$clog2(({depth_str}) + 1) - 1:0] {occ};"));
+            self.line(&format!("wire  {valid_w} = {occ} != 0;"));
+            self.line(&format!("wire [({width_str}) - 1:0] {data_w} = {buf}[{head}];"));
+
+            // Update block: push on send_valid, pop on user-driven credit_return.
+            let pop_fire = format!("({pop_drv} && {valid_w})");
+            match &rst_active {
+                Some(r) => {
+                    self.line(&format!("always_ff @(posedge {clk}{rst_edge}) begin"));
+                    self.indent += 1;
+                    self.line(&format!("if ({r}) begin"));
+                    self.indent += 1;
+                    self.line(&format!("{head} <= 0;"));
+                    self.line(&format!("{tail} <= 0;"));
+                    self.line(&format!("{occ}  <= 0;"));
+                    self.indent -= 1;
+                    self.line("end else begin");
+                    self.indent += 1;
+                    self.line(&format!("if ({push}) begin"));
+                    self.indent += 1;
+                    self.line(&format!("{buf}[{tail}] <= {pushd};"));
+                    self.line(&format!("{tail} <= ({tail} + 1) % ({depth_str});"));
+                    self.indent -= 1;
+                    self.line("end");
+                    self.line(&format!("if ({pop_fire}) {head} <= ({head} + 1) % ({depth_str});"));
+                    self.line(&format!("if ({push} && !{pop_fire}) {occ} <= {occ} + 1;"));
+                    self.line(&format!("else if (!{push} &&  {pop_fire}) {occ} <= {occ} - 1;"));
+                    self.indent -= 1;
+                    self.line("end");
+                    self.indent -= 1;
+                    self.line("end");
+                }
+                None => {
+                    self.line(&format!("always_ff @(posedge {clk}) begin"));
+                    self.indent += 1;
+                    self.line(&format!("if ({push}) begin"));
+                    self.indent += 1;
+                    self.line(&format!("{buf}[{tail}] <= {pushd};"));
+                    self.line(&format!("{tail} <= ({tail} + 1) % ({depth_str});"));
+                    self.indent -= 1;
+                    self.line("end");
+                    self.line(&format!("if ({pop_fire}) {head} <= ({head} + 1) % ({depth_str});"));
+                    self.line(&format!("if ({push} && !{pop_fire}) {occ} <= {occ} + 1;"));
+                    self.line(&format!("else if (!{push} &&  {pop_fire}) {occ} <= {occ} - 1;"));
                     self.indent -= 1;
                     self.line("end");
                 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -3624,6 +3624,78 @@ fn test_credit_channel_emits_sender_counter_state() {
 }
 
 #[test]
+fn test_credit_channel_emits_target_fifo() {
+    // PR #3b-iii: target-side module gets a synthesized FIFO with push on
+    // send_valid and pop on user-driven credit_return.
+    let source = "
+        bus DmaCh
+          credit_channel data: send
+            param T:     type  = UInt<8>;
+            param DEPTH: const = 4;
+          end credit_channel data
+        end bus DmaCh
+
+        use DmaCh;
+
+        module Cons
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync>;
+          port p:   target DmaCh;
+          comb
+            p.data_credit_return = 1'b0;
+          end comb
+        end module Cons
+    ";
+    let sv = compile_to_sv(source);
+    assert!(sv.contains("__p_data_buf"),
+        "target FIFO buffer array should be declared:\n{sv}");
+    assert!(sv.contains("__p_data_head"),
+        "FIFO head pointer should be declared:\n{sv}");
+    assert!(sv.contains("__p_data_tail"),
+        "FIFO tail pointer should be declared:\n{sv}");
+    assert!(sv.contains("__p_data_occ"),
+        "FIFO occupancy should be declared:\n{sv}");
+    assert!(sv.contains("__p_data_valid = __p_data_occ != 0"),
+        "valid wire should report non-empty:\n{sv}");
+    assert!(sv.contains("__p_data_data = __p_data_buf[__p_data_head]"),
+        "data wire should read the head slot:\n{sv}");
+    assert!(sv.contains("if (p_data_send_valid)"),
+        "push path should be gated on send_valid:\n{sv}");
+    assert!(sv.contains("p_data_credit_return && __p_data_valid"),
+        "pop should fire on user-driven credit_return when FIFO non-empty:\n{sv}");
+}
+
+#[test]
+fn test_credit_channel_no_target_fifo_on_send_role() {
+    // Sender-side module on a `send` channel is the producer — it gets the
+    // credit counter (PR #3b-ii), NOT the target FIFO. Guard against cross-
+    // contamination.
+    let source = "
+        bus DmaCh
+          credit_channel data: send
+            param T:     type  = UInt<8>;
+            param DEPTH: const = 4;
+          end credit_channel data
+        end bus DmaCh
+
+        use DmaCh;
+
+        module Prod
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync>;
+          port p:   initiator DmaCh;
+          comb
+            p.data_send_valid = 1'b0;
+            p.data_send_data  = 8'h0;
+          end comb
+        end module Prod
+    ";
+    let sv = compile_to_sv(source);
+    assert!(!sv.contains("__p_data_buf"),
+        "sender-role module must not emit target FIFO buffer:\n{sv}");
+}
+
+#[test]
 fn test_credit_channel_no_counter_on_receive_role() {
     // A `send`-role channel where this module is the target should NOT
     // emit a sender counter — this module is the receiver. (The target


### PR DESCRIPTION
## Summary
- PR #3b-iii. Builds on #61 (sender-side counter).
- Emits the target-side FIFO in SV for every module that is the credit_channel receiver: head/tail/occupancy pointers, depth-DEPTH buffer, push on \`send_valid\`, pop on user-driven \`credit_return\`.
- Pop and credit-return are unified onto a single user-driven signal — when the user asserts \`p.data_credit_return\` and the FIFO is non-empty, the FIFO pops and the sender's counter increments from the same pulse. No separate pop wire.

## Deferred: method dispatch
\`port.ch.valid\` / \`port.ch.data\` / \`port.ch.can_send\` as ARCH expressions need an AST decision (how to inject typecheck-visible synthesized wires that are driven by codegen boilerplate). Surfacing as a separate design discussion rather than one-shotting a dubious approach.

## Test plan
- [x] \`cargo test\` — 121/121 pass (119 existing + 2 new regressions).