### PR TITLE
feat(ast): add ExprKind::SynthIdent variant for synthesized signal refs

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -716,6 +716,14 @@ impl Expr {
 pub enum ExprKind {
     Literal(LitKind),
     Ident(String),
+    /// Compiler-synthesized identifier — behaves exactly like `Ident(name)`
+    /// for codegen / sim / formal purposes, but carries its own known type
+    /// so typecheck doesn't need to resolve it via the symbol table. Used
+    /// by the credit_channel method-dispatch elaborate pass (PR #3b-v) to
+    /// point expressions at codegen-emitted SV wires (`__<port>_<ch>_valid`,
+    /// `_data`, `_can_send`) whose declaration lives in the emitted SV
+    /// boilerplate rather than in the ARCH module body.
+    SynthIdent(String, TypeExpr),
     Binary(BinOp, Box<Expr>, Box<Expr>),
     Unary(UnaryOp, Box<Expr>),
     FieldAccess(Box<Expr>, Ident),

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -5814,6 +5814,11 @@ impl<'a> Codegen<'a> {
             // assignment emitter strips the annotation before routing the
             // value to the appropriate stage 0 of the pipe chain.
             ExprKind::LatencyAt(inner, _) => self.emit_expr_inner(inner),
+            // SynthIdent: compiler-synthesized name pointing at codegen-
+            // emitted SV wires (credit_channel dispatch targets). Emits as
+            // a plain identifier — the declaration + driver live elsewhere
+            // in the emitted SV.
+            ExprKind::SynthIdent(name, _) => name.clone(),
             ExprKind::Literal(lit) => match lit {
                 LitKind::Dec(v) => format!("{v}"),
                 LitKind::Hex(v) => format!("'h{v:X}"),

--- a/src/formal.rs
+++ b/src/formal.rs
@@ -822,6 +822,19 @@ impl<'a> FormalCtx<'a> {
             // `q@0` is the same as `q` at t. Non-@0 reads are rejected by
             // typecheck before reaching formal emission.
             LatencyAt(inner, _) => self.encode_raw(inner, t),
+            // SynthIdent is not yet handled by formal encoding — it points
+            // at codegen-emitted SV state (credit_channel synthesized
+            // wires) that `arch formal` has no SMT mirror for. Reject
+            // clearly; the credit_channel formal story lands with the
+            // Tier-2 SVA PR.
+            SynthIdent(name, _) => {
+                return Err(CompileError::general(
+                    &format!(
+                        "formal encoding of synthesized identifier `{name}` is not yet supported — credit_channel formal invariants land in a follow-up PR",
+                    ),
+                    expr.span,
+                ));
+            }
             Literal(l) => Ok(lit_to_term(l)),
             Bool(b) => Ok(SmtTerm {
                 s: if *b { "#b1".to_string() } else { "#b0".to_string() },

--- a/src/sim_codegen.rs
+++ b/src/sim_codegen.rs
@@ -1675,6 +1675,13 @@ fn cpp_expr_inner(expr: &Expr, ctx: &Ctx, is_lhs: bool) -> String {
         // site handles directing the write to stage 0 of the pipe chain;
         // reads of `q@0` collapse to the final-output field of the pipe.
         ExprKind::LatencyAt(inner, _) => cpp_expr_inner(inner, ctx, is_lhs),
+        // SynthIdent: emit as a plain identifier. Simulation support for
+        // credit_channel (counter + FIFO mirror in C++) is separate work;
+        // designs that use method dispatch today work under `arch build`
+        // but not under `arch sim` — the name will reference an undefined
+        // C++ symbol at sim-compile time. Intentional: we surface the gap
+        // loudly rather than silently succeed.
+        ExprKind::SynthIdent(name, _) => name.clone(),
         ExprKind::Literal(lit) => match lit {
             LitKind::Dec(v) => format!("{v}"),
             LitKind::Hex(v) => format!("0x{v:X}"),

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -2246,6 +2246,26 @@ impl<'a> TypeChecker<'a> {
                 // target context is known.
                 self.resolve_expr_type(inner, module_name, local_types)
             }
+            ExprKind::SynthIdent(_, ty) => {
+                // SynthIdent carries its own type — used by the
+                // credit_channel dispatch pass (PR #3b-v). No symbol-table
+                // lookup needed; the declaration lives in codegen.
+                match ty {
+                    TypeExpr::UInt(w) => eval_type_width_expr(w).map(Ty::UInt).unwrap_or(Ty::Error),
+                    TypeExpr::SInt(w) => eval_type_width_expr(w).map(Ty::SInt).unwrap_or(Ty::Error),
+                    TypeExpr::Bool | TypeExpr::Bit => Ty::Bool,
+                    TypeExpr::Named(ident) => {
+                        if let Some((crate::resolve::Symbol::Struct(_), _)) = self.symbols.globals.get(&ident.name) {
+                            Ty::Struct(ident.name.clone())
+                        } else if let Some((crate::resolve::Symbol::Enum(info), _)) = self.symbols.globals.get(&ident.name) {
+                            Ty::Enum(ident.name.clone(), enum_width(info.variants.len()))
+                        } else {
+                            Ty::Error
+                        }
+                    }
+                    _ => Ty::Error,
+                }
+            }
             ExprKind::Todo => {
                 self.warnings.push(CompileWarning {
                     message: "todo! placeholder will abort at runtime".to_string(),


### PR DESCRIPTION
## Summary
- PR #3b-v-α. Pure AST scaffolding for the credit_channel method-dispatch PR that follows.
- Adds \`ExprKind::SynthIdent(String, TypeExpr)\` — an identifier expression that carries its own type, pointing at SV wires declared in codegen boilerplate.
- Four match arms added (the only sites the Rust compiler flagged as non-exhaustive — most expression walkers use wildcards). No elaborate pass produces the variant yet, so behavior is unchanged.

## Why now
The credit_channel dispatch pass (#3b-v-β) will rewrite \`port.ch.valid\` → \`SynthIdent("__port_ch_valid", Bool)\`. Landing the variant in a separate PR keeps the behavior PR smaller and easier to review.

## Test plan
- [x] \`cargo test\` — 121/121 pass, unchanged from main.