### PR TITLE
feat(elaborate): credit_channel read-side method dispatch

### DIFF
--- a/doc/ARCH_HDL_Specification.md
+++ b/doc/ARCH_HDL_Specification.md
@@ -4632,8 +4632,12 @@ v1 scope: nested `generate_if` inside a payload branch is a compile error. A han
 
 **18c. First-Class Sub-Construct: credit_channel (inside bus)** — *wire layer live, elaboration pending*
 
-> **Status (v0.44.4):** grammar, wire flattening, sender-side credit counter,
-> and **target-side FIFO** are all in place. On the receiver module
+> **Status (v0.44.5):** grammar, wire flattening, sender-side credit counter,
+> target-side FIFO, and **read-side method dispatch** (`port.ch.can_send` on
+> the sender, `port.ch.valid` / `port.ch.data` on the receiver) are all in
+> place. Method dispatch is implemented as an elaborate pass that rewrites
+> the dotted access into `ExprKind::SynthIdent` pointing at the
+> codegen-emitted SV wires. On the receiver module
 > (`target` perspective on a `send`-role channel) the codegen synthesizes a
 > depth-DEPTH packet buffer (`__<port>_<ch>_buf`) with head/tail/occupancy
 > pointers, pushed on `<port>_<ch>_send_valid` and popped when the user

--- a/src/elaborate.rs
+++ b/src/elaborate.rs
@@ -3543,3 +3543,177 @@ fn rewrite_seq_stmts_pp(stmts: Vec<Stmt>, pipes: &[PipePortInfoLocal]) -> Vec<St
     out
 }
 
+
+// ── credit_channel method-dispatch (PR #3b-v-β) ─────────────────────────────
+//
+// Rewrites `port.ch.valid` / `port.ch.data` / `port.ch.can_send` expressions,
+// where `port` is a bus port declaring `credit_channel ch`, into
+// `ExprKind::SynthIdent(__<port>_<ch>_<member>, ty)` pointing at the SV wires
+// emitted by codegen boilerplate in PR #3b-ii / #3b-iii.
+//
+// Role-gated: `can_send` is valid only on the sender side (initiator of a
+// `send` channel, target of a `receive` channel); `valid` and `data` are
+// valid only on the receiver side. Mismatches are left as untransformed
+// nested FieldAccess and fall through to normal bus-member resolution.
+
+pub fn lower_credit_channel_dispatch(ast: SourceFile) -> Result<SourceFile, Vec<CompileError>> {
+    use std::collections::HashMap;
+    let mut bus_ccs: HashMap<String, Vec<CreditChannelMeta>> = HashMap::new();
+    for item in &ast.items {
+        match item {
+            Item::Bus(b) => {
+                if !b.credit_channels.is_empty() {
+                    bus_ccs.insert(b.name.name.clone(), b.credit_channels.clone());
+                }
+            }
+            Item::Package(pkg) => {
+                for b in &pkg.buses {
+                    if !b.credit_channels.is_empty() {
+                        bus_ccs.insert(b.name.name.clone(), b.credit_channels.clone());
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    if bus_ccs.is_empty() { return Ok(ast); }
+    let mut items: Vec<Item> = Vec::with_capacity(ast.items.len());
+    for item in ast.items {
+        match item {
+            Item::Module(mut m) => {
+                let port_buses: HashMap<String, (String, BusPerspective)> = m.ports.iter()
+                    .filter_map(|p| p.bus_info.as_ref().map(|bi|
+                        (p.name.name.clone(), (bi.bus_name.name.clone(), bi.perspective))
+                    ))
+                    .collect();
+                if port_buses.values().any(|(b, _)| bus_ccs.contains_key(b)) {
+                    let ctx = CcDispatchCtx { bus_ccs: &bus_ccs, port_buses: &port_buses };
+                    for bi in &mut m.body {
+                        rewrite_body_item_cc(bi, &ctx);
+                    }
+                }
+                items.push(Item::Module(m));
+            }
+            other => items.push(other),
+        }
+    }
+    Ok(SourceFile { items })
+}
+
+struct CcDispatchCtx<'a> {
+    bus_ccs: &'a std::collections::HashMap<String, Vec<CreditChannelMeta>>,
+    port_buses: &'a std::collections::HashMap<String, (String, BusPerspective)>,
+}
+
+fn rewrite_body_item_cc(bi: &mut ModuleBodyItem, ctx: &CcDispatchCtx) {
+    match bi {
+        ModuleBodyItem::CombBlock(cb) => {
+            for s in &mut cb.stmts { rewrite_comb_stmt_cc(s, ctx); }
+        }
+        ModuleBodyItem::RegBlock(rb) => {
+            for s in &mut rb.stmts { rewrite_reg_stmt_cc(s, ctx); }
+        }
+        ModuleBodyItem::LetBinding(l) => { rewrite_expr_cc(&mut l.value, ctx); }
+        _ => {}
+    }
+}
+
+fn rewrite_comb_stmt_cc(s: &mut CombStmt, ctx: &CcDispatchCtx) {
+    match s {
+        CombStmt::Assign(a) => { rewrite_expr_cc(&mut a.value, ctx); }
+        CombStmt::IfElse(ie) => {
+            rewrite_expr_cc(&mut ie.cond, ctx);
+            for s in &mut ie.then_stmts { rewrite_comb_stmt_cc(s, ctx); }
+            for s in &mut ie.else_stmts { rewrite_comb_stmt_cc(s, ctx); }
+        }
+        CombStmt::For(fl) => {
+            for s in &mut fl.body { rewrite_reg_stmt_cc(s, ctx); }
+        }
+        _ => {}
+    }
+}
+
+fn rewrite_reg_stmt_cc(s: &mut Stmt, ctx: &CcDispatchCtx) {
+    match s {
+        Stmt::Assign(a) => { rewrite_expr_cc(&mut a.value, ctx); }
+        Stmt::IfElse(ie) => {
+            rewrite_expr_cc(&mut ie.cond, ctx);
+            for s in &mut ie.then_stmts { rewrite_reg_stmt_cc(s, ctx); }
+            for s in &mut ie.else_stmts { rewrite_reg_stmt_cc(s, ctx); }
+        }
+        Stmt::For(fl) => { for s in &mut fl.body { rewrite_reg_stmt_cc(s, ctx); } }
+        Stmt::Match(m) => {
+            for arm in &mut m.arms {
+                for s in &mut arm.body { rewrite_reg_stmt_cc(s, ctx); }
+            }
+        }
+        _ => {}
+    }
+}
+
+fn rewrite_expr_cc(e: &mut Expr, ctx: &CcDispatchCtx) {
+    match &mut e.kind {
+        ExprKind::Binary(_, l, r) => { rewrite_expr_cc(l, ctx); rewrite_expr_cc(r, ctx); }
+        ExprKind::Unary(_, x) | ExprKind::Cast(x, _) | ExprKind::Clog2(x)
+        | ExprKind::Onehot(x) | ExprKind::Signed(x) | ExprKind::Unsigned(x)
+        | ExprKind::LatencyAt(x, _) => { rewrite_expr_cc(x, ctx); }
+        ExprKind::Index(b, i) => { rewrite_expr_cc(b, ctx); rewrite_expr_cc(i, ctx); }
+        ExprKind::BitSlice(b, hi, lo) => {
+            rewrite_expr_cc(b, ctx); rewrite_expr_cc(hi, ctx); rewrite_expr_cc(lo, ctx);
+        }
+        ExprKind::PartSelect(b, s, w, _) => {
+            rewrite_expr_cc(b, ctx); rewrite_expr_cc(s, ctx); rewrite_expr_cc(w, ctx);
+        }
+        ExprKind::Ternary(c, t, el) => {
+            rewrite_expr_cc(c, ctx); rewrite_expr_cc(t, ctx); rewrite_expr_cc(el, ctx);
+        }
+        ExprKind::Concat(xs) | ExprKind::FunctionCall(_, xs) => {
+            for x in xs { rewrite_expr_cc(x, ctx); }
+        }
+        ExprKind::Repeat(n, x) => { rewrite_expr_cc(n, ctx); rewrite_expr_cc(x, ctx); }
+        ExprKind::MethodCall(recv, _, args) => {
+            rewrite_expr_cc(recv, ctx);
+            for a in args { rewrite_expr_cc(a, ctx); }
+        }
+        ExprKind::FieldAccess(base, _) => { rewrite_expr_cc(base, ctx); }
+        ExprKind::StructLiteral(_, fields) => {
+            for fi in fields { rewrite_expr_cc(&mut fi.value, ctx); }
+        }
+        _ => {}
+    }
+    if let ExprKind::FieldAccess(base, member) = &e.kind {
+        if let ExprKind::FieldAccess(inner, ch) = &base.kind {
+            if let ExprKind::Ident(port) = &inner.kind {
+                if let Some((bus_name, perspective)) = ctx.port_buses.get(port) {
+                    if let Some(ccs) = ctx.bus_ccs.get(bus_name) {
+                        if let Some(cc) = ccs.iter().find(|c| c.name.name == ch.name) {
+                            let is_sender = matches!(
+                                (cc.role_dir, perspective),
+                                (Direction::Out, BusPerspective::Initiator)
+                              | (Direction::In,  BusPerspective::Target)
+                            );
+                            let synth = match member.name.as_str() {
+                                "can_send" if is_sender => Some((TypeExpr::Bool, "can_send")),
+                                "valid"    if !is_sender => Some((TypeExpr::Bool, "valid")),
+                                "data"     if !is_sender => {
+                                    cc.params.iter()
+                                        .find(|p| p.name.name == "T")
+                                        .and_then(|p| match &p.kind {
+                                            ParamKind::Type(te) => Some(te.clone()),
+                                            _ => None,
+                                        })
+                                        .map(|ty| (ty, "data"))
+                                }
+                                _ => None,
+                            };
+                            if let Some((ty, suffix)) = synth {
+                                let name = format!("__{port}_{}_{suffix}", ch.name);
+                                e.kind = ExprKind::SynthIdent(name, ty);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1007,6 +1007,13 @@ fn run_check_multi(
         ms.report_error(err)
     })?;
 
+    // Rewrite `port.ch.valid` / `.data` / `.can_send` to SynthIdent so they
+    // reference the codegen-emitted SV wires (credit_channel method dispatch).
+    let ast = elaborate::lower_credit_channel_dispatch(ast).map_err(|errs| {
+        let err = errs.into_iter().next().unwrap();
+        ms.report_error(err)
+    })?;
+
     // Resolve
     let symbols = resolve::resolve(&ast).map_err(|errs| {
         let err = errs.into_iter().next().unwrap();

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -12,6 +12,7 @@ fn compile_to_sv(source: &str) -> String {
     let ast = elaborate::elaborate(parsed_ast).expect("elaborate error");
     let ast = elaborate::lower_threads(ast).expect("lower_threads error");
     let ast = elaborate::lower_pipe_reg_ports(ast).expect("lower_pipe_reg_ports error");
+    let ast = elaborate::lower_credit_channel_dispatch(ast).expect("credit_channel dispatch error");
     let symbols = resolve::resolve(&ast).expect("resolve error");
     let checker = TypeChecker::new(&symbols, &ast);
     let (_warnings, overload_map) = checker.check().expect("type check error");
@@ -3723,6 +3724,70 @@ fn test_credit_channel_no_counter_on_receive_role() {
     let sv = compile_to_sv(source);
     assert!(!sv.contains("__p_data_credit"),
         "target-role module should not emit sender counter:\n{sv}");
+}
+
+#[test]
+fn test_credit_channel_can_send_method_dispatch() {
+    // PR #3b-v-β: sender reads port.ch.can_send; dispatch rewrites it to
+    // the synthesized SV wire __<port>_<ch>_can_send.
+    let source = "
+        bus DmaCh
+          credit_channel data: send
+            param T:     type  = UInt<8>;
+            param DEPTH: const = 4;
+          end credit_channel data
+        end bus DmaCh
+
+        use DmaCh;
+
+        module Prod
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync>;
+          port p:   initiator DmaCh;
+          port have_data: in Bool;
+          port payload:   in UInt<8>;
+          comb
+            p.data_send_valid = p.data.can_send and have_data;
+            p.data_send_data  = payload;
+          end comb
+        end module Prod
+    ";
+    let sv = compile_to_sv(source);
+    assert!(sv.contains("__p_data_can_send"),
+        "dispatch should rewrite p.data.can_send → __p_data_can_send:\n{sv}");
+    assert!(sv.contains("p_data_send_valid = __p_data_can_send"),
+        "valid assignment should reference the rewritten name:\n{sv}");
+}
+
+#[test]
+fn test_credit_channel_valid_and_data_method_dispatch_on_receiver() {
+    let source = "
+        bus DmaCh
+          credit_channel data: send
+            param T:     type  = UInt<8>;
+            param DEPTH: const = 4;
+          end credit_channel data
+        end bus DmaCh
+
+        use DmaCh;
+
+        module Cons
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync>;
+          port p:   target DmaCh;
+          port want_pop: in Bool;
+          port latest:   out UInt<8>;
+          comb
+            latest = p.data.data;
+            p.data_credit_return = p.data.valid and want_pop;
+          end comb
+        end module Cons
+    ";
+    let sv = compile_to_sv(source);
+    assert!(sv.contains("latest = __p_data_data"),
+        "receiver read of p.data.data should rewrite to __p_data_data:\n{sv}");
+    assert!(sv.contains("__p_data_valid"),
+        "p.data.valid should rewrite to __p_data_valid:\n{sv}");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- PR #3b-v-β. Builds on #63 (SynthIdent scaffolding).
- Adds \`lower_credit_channel_dispatch\` elaborate pass that rewrites \`port.ch.{can_send,valid,data}\` into \`ExprKind::SynthIdent\` pointing at the codegen-emitted SV wires.
- Role-gated: can_send only on sender; valid/data only on receiver.

## End-to-end pattern
Sender:
\`\`\`
comb
  p.data_send_valid = p.data.can_send and have_data;
  p.data_send_data  = payload;
end comb
\`\`\`

Receiver:
\`\`\`
comb
  latest = p.data.data;
  p.data_credit_return = p.data.valid and want_pop;
end comb
\`\`\`

## What's still unimplemented
- Write-side methods \`ch.send(x)\` / \`ch.pop()\` as statement-level sugar (requires grammar extension).
- \`CAN_SEND_REGISTERED\` next-state flop (option b, already approved).
- Tier-2 SVA invariants.
- sim_codegen mirror for credit_channel state (arch sim currently won't resolve the C++ names — arch build works).

## Test plan
- [x] \`cargo test\` — 123/123 pass (121 existing + 2 new).
- [x] Sender reads \`p.data.can_send\` → emitted SV references \`__p_data_can_send\`.
- [x] Receiver reads \`p.data.valid\` / \`.data\` → emitted SV references \`__p_data_valid\` / \`__p_data_data\`.