### PR TITLE
feat: CAN_SEND_REGISTERED next-state flop for credit_channel

### DIFF
--- a/doc/ARCH_HDL_Specification.md
+++ b/doc/ARCH_HDL_Specification.md
@@ -4632,12 +4632,16 @@ v1 scope: nested `generate_if` inside a payload branch is a compile error. A han
 
 **18c. First-Class Sub-Construct: credit_channel (inside bus)** — *wire layer live, elaboration pending*
 
-> **Status (v0.44.5):** grammar, wire flattening, sender-side credit counter,
-> target-side FIFO, and **read-side method dispatch** (`port.ch.can_send` on
-> the sender, `port.ch.valid` / `port.ch.data` on the receiver) are all in
-> place. Method dispatch is implemented as an elaborate pass that rewrites
-> the dotted access into `ExprKind::SynthIdent` pointing at the
-> codegen-emitted SV wires. On the receiver module
+> **Status (v0.44.6):** grammar, wire flattening, sender-side credit counter,
+> target-side FIFO, **read-side method dispatch** (`port.ch.can_send` on the
+> sender, `port.ch.valid` / `port.ch.data` on the receiver), and the
+> **`CAN_SEND_REGISTERED` timing-relief knob** are all in place. The knob is
+> a channel-level param — `param CAN_SEND_REGISTERED: const = 1;` inside the
+> `credit_channel` block flops `can_send` off the next-state counter
+> (option b: full throughput preserved, fan-out comes from a register so the
+> combinational critical path ends at the flop input). Default is 0
+> (combinational). Method dispatch rewrites `port.ch.can_send` to the
+> synthesized wire/reg regardless of the choice. On the receiver module
 > (`target` perspective on a `send`-role channel) the codegen synthesizes a
 > depth-DEPTH packet buffer (`__<port>_<ch>_buf`) with head/tail/occupancy
 > pointers, pushed on `<port>_<ch>_send_valid` and popped when the user

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -2843,41 +2843,73 @@ impl<'a> Codegen<'a> {
             let Some(depth_expr) = depth_expr else { continue; };
             let depth_str = self.emit_expr_str(depth_expr);
             let credit_reg = format!("__{port_name}_{ch}_credit");
-            let cs_wire    = format!("__{port_name}_{ch}_can_send");
+            let cs_name    = format!("__{port_name}_{ch}_can_send");
             let send_valid = format!("{port_name}_{ch}_send_valid");
             let credit_ret = format!("{port_name}_{ch}_credit_return");
+            // Look up CAN_SEND_REGISTERED (option b — next-state flop, agreed
+            // semantics). Non-zero = register the can_send signal so its
+            // fan-out comes off a flop; the combinational critical path then
+            // ends at the flop input. Full throughput is preserved because the
+            // flopped signal reflects counter_next (current counter ± same-
+            // cycle send/return), so send_valid |-> counter > 0 still holds.
+            let registered = cc.params.iter()
+                .find(|p| p.name.name == "CAN_SEND_REGISTERED")
+                .and_then(|p| p.default.as_ref())
+                .map(|e| self.emit_expr_str(e))
+                .map(|s| s.trim() != "0")
+                .unwrap_or(false);
             // Width = $clog2(DEPTH + 1). Emit as-is; SV reduces at elab.
             self.line(&format!(
                 "logic [$clog2(({depth_str}) + 1) - 1:0] {credit_reg};"
             ));
-            self.line(&format!(
-                "wire  {cs_wire} = {credit_reg} != 0;"
-            ));
+            if registered {
+                self.line(&format!("logic {cs_name};"));
+            } else {
+                self.line(&format!("wire  {cs_name} = {credit_reg} != 0;"));
+            }
+            // Emit the counter update (always_ff). If registered, also flop
+            // can_send: `__..._can_send <= counter_next > 0`. The counter_next
+            // is not an SV-visible signal; we inline the next-state expression
+            // to preserve semantics without introducing an extra wire.
+            //
+            // counter_next =  credit + 1   when (credit_return && !send_valid)
+            //               | credit - 1   when (send_valid && !credit_return)
+            //               | credit       otherwise
+            //
+            // So counter_next > 0 reduces to:
+            //   (credit_return && !send_valid) ? 1
+            //   : (send_valid && !credit_return) ? (credit > 1)
+            //   : (credit > 0)
+            let cs_next = format!(
+                "({credit_ret} && !{send_valid}) ? 1'b1 : \
+                 ({send_valid} && !{credit_ret}) ? ({credit_reg} > 1) : \
+                 ({credit_reg} != 0)"
+            );
             match &rst_active {
                 Some(r) => {
-                    self.line(&format!(
-                        "always_ff @(posedge {clk}{rst_edge}) begin"
-                    ));
+                    self.line(&format!("always_ff @(posedge {clk}{rst_edge}) begin"));
                     self.indent += 1;
-                    self.line(&format!("if ({r}) {credit_reg} <= {depth_str};"));
-                    self.line(&format!(
-                        "else if ({send_valid} && !{credit_ret}) {credit_reg} <= {credit_reg} - 1;"
-                    ));
-                    self.line(&format!(
-                        "else if ({credit_ret} && !{send_valid}) {credit_reg} <= {credit_reg} + 1;"
-                    ));
+                    self.line(&format!("if ({r}) begin"));
+                    self.indent += 1;
+                    self.line(&format!("{credit_reg} <= {depth_str};"));
+                    if registered { self.line(&format!("{cs_name} <= ({depth_str}) != 0;")); }
+                    self.indent -= 1;
+                    self.line("end else begin");
+                    self.indent += 1;
+                    self.line(&format!("if ({send_valid} && !{credit_ret}) {credit_reg} <= {credit_reg} - 1;"));
+                    self.line(&format!("else if ({credit_ret} && !{send_valid}) {credit_reg} <= {credit_reg} + 1;"));
+                    if registered { self.line(&format!("{cs_name} <= {cs_next};")); }
+                    self.indent -= 1;
+                    self.line("end");
                     self.indent -= 1;
                     self.line("end");
                 }
                 None => {
                     self.line(&format!("always_ff @(posedge {clk}) begin"));
                     self.indent += 1;
-                    self.line(&format!(
-                        "if ({send_valid} && !{credit_ret}) {credit_reg} <= {credit_reg} - 1;"
-                    ));
-                    self.line(&format!(
-                        "else if ({credit_ret} && !{send_valid}) {credit_reg} <= {credit_reg} + 1;"
-                    ));
+                    self.line(&format!("if ({send_valid} && !{credit_ret}) {credit_reg} <= {credit_reg} - 1;"));
+                    self.line(&format!("else if ({credit_ret} && !{send_valid}) {credit_reg} <= {credit_reg} + 1;"));
+                    if registered { self.line(&format!("{cs_name} <= {cs_next};")); }
                     self.indent -= 1;
                     self.line("end");
                 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -3791,6 +3791,73 @@ fn test_credit_channel_valid_and_data_method_dispatch_on_receiver() {
 }
 
 #[test]
+fn test_credit_channel_can_send_registered_emits_flop() {
+    // PR #3b-iv: CAN_SEND_REGISTERED=1 flops can_send off the next-state
+    // counter (option b — full throughput preserved; fan-out comes off a
+    // register).
+    let source = "
+        bus DmaCh
+          credit_channel data: send
+            param T:                   type  = UInt<8>;
+            param DEPTH:               const = 4;
+            param CAN_SEND_REGISTERED: const = 1;
+          end credit_channel data
+        end bus DmaCh
+
+        use DmaCh;
+
+        module Prod
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync>;
+          port p:   initiator DmaCh;
+          comb
+            p.data_send_valid = 1'b0;
+            p.data_send_data  = 8'h0;
+          end comb
+        end module Prod
+    ";
+    let sv = compile_to_sv(source);
+    // Registered form declares can_send as `logic` (register), not `wire`.
+    assert!(sv.contains("logic __p_data_can_send;"),
+        "CAN_SEND_REGISTERED=1 should declare can_send as a register:\n{sv}");
+    // And assigns it inside the always_ff block.
+    assert!(sv.contains("__p_data_can_send <="),
+        "registered can_send should be updated via non-blocking assign:\n{sv}");
+    // No `wire` form for can_send.
+    assert!(!sv.contains("wire  __p_data_can_send"),
+        "CAN_SEND_REGISTERED=1 must not emit the combinational wire form:\n{sv}");
+}
+
+#[test]
+fn test_credit_channel_can_send_default_is_combinational() {
+    // Default (CAN_SEND_REGISTERED omitted / 0) keeps the existing
+    // combinational wire — unchanged from PR #3b-ii.
+    let source = "
+        bus DmaCh
+          credit_channel data: send
+            param T:     type  = UInt<8>;
+            param DEPTH: const = 4;
+          end credit_channel data
+        end bus DmaCh
+
+        use DmaCh;
+
+        module Prod
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync>;
+          port p:   initiator DmaCh;
+          comb
+            p.data_send_valid = 1'b0;
+            p.data_send_data  = 8'h0;
+          end comb
+        end module Prod
+    ";
+    let sv = compile_to_sv(source);
+    assert!(sv.contains("wire  __p_data_can_send = __p_data_credit != 0"),
+        "default (unregistered) can_send should stay combinational:\n{sv}");
+}
+
+#[test]
 fn test_credit_channel_mismatched_closing_keyword_errors() {
     let source = "
         bus B


### PR DESCRIPTION
## Summary
- PR #3b-iv. Adds the approved option-(b) timing-relief knob.
- \`param CAN_SEND_REGISTERED: const = 1;\` inside a credit_channel block flops can_send off the next-state counter — full throughput preserved; critical path of downstream logic starts at a flop.
- Default is 0 (combinational), zero behavior change for existing users.

## Test plan
- [x] \`cargo test\` — 125/125 pass (123 existing + 2 new regressions).
- [x] Registered variant declares can_send as \`logic\` and updates in always_ff.
- [x] Default variant keeps the existing \`wire\` form.