### PR TITLE
feat: Tier-2 SVA for credit_channel

### DIFF
--- a/doc/ARCH_HDL_Specification.md
+++ b/doc/ARCH_HDL_Specification.md
@@ -4632,10 +4632,18 @@ v1 scope: nested `generate_if` inside a payload branch is a compile error. A han
 
 **18c. First-Class Sub-Construct: credit_channel (inside bus)** — *wire layer live, elaboration pending*
 
-> **Status (v0.44.6):** grammar, wire flattening, sender-side credit counter,
+> **Status (v0.44.7):** grammar, wire flattening, sender-side credit counter,
 > target-side FIFO, **read-side method dispatch** (`port.ch.can_send` on the
-> sender, `port.ch.valid` / `port.ch.data` on the receiver), and the
-> **`CAN_SEND_REGISTERED` timing-relief knob** are all in place. The knob is
+> sender, `port.ch.valid` / `port.ch.data` on the receiver), the
+> **`CAN_SEND_REGISTERED` timing-relief knob**, and the **Tier-2 protocol
+> SVA** are all in place. Auto-emitted assertions (labels follow
+> `_auto_cc_<port>_<ch>_<rule>`, wrapped in `translate_off/on`):
+> (1) `credit <= DEPTH` on the sender; (2) `send_valid |-> credit > 0`
+> on the sender; (3) `credit_return |-> buffer_valid` on the receiver.
+> Consumed by Verilator `--assert`, EBMC, and SymbiYosys like the existing
+> handshake / bounds / divide-by-zero labels. The cross-module occupancy
+> invariant (`occupancy == DEPTH - credit`) is deferred to the hierarchical
+> formal story. The knob is
 > a channel-level param — `param CAN_SEND_REGISTERED: const = 1;` inside the
 > `credit_channel` block flops `can_send` off the next-state counter
 > (option b: full throughput preserved, fan-out comes from a register so the

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -887,6 +887,9 @@ impl<'a> Codegen<'a> {
         // the module where this side is the receiver (PR #3b-iii).
         self.emit_credit_channel_receiver_state(&m_clone);
 
+        // Emit the Tier-2 credit_channel protocol assertions (PR #4).
+        self.emit_credit_channel_asserts(&m_clone);
+
         // Emit log file descriptors: initial $fopen / final $fclose
         let log_files = Self::collect_log_files(&m_clone.body);
         if !log_files.is_empty() {
@@ -3087,6 +3090,106 @@ impl<'a> Codegen<'a> {
             ExprKind::Unary(_, a) => Self::is_const_reducible_with(a, const_params),
             _ => false,
         }
+    }
+
+    /// Emit Tier-2 SVA protocol assertions for each credit_channel on this
+    /// module. Labels follow `_auto_cc_<port>_<ch>_<rule>`, mirroring the
+    /// handshake / bounds / divide-by-zero naming so EBMC and Verilator
+    /// `--assert` consumers can target them uniformly.
+    ///
+    /// Invariants emitted:
+    /// - **credit_bounds** (sender): `__<port>_<ch>_credit <= DEPTH`. Holds
+    ///   because the counter update is strictly ±1 and the reset value is
+    ///   DEPTH — but provable properties catch any future regression that
+    ///   double-decrements or misses reset.
+    /// - **send_requires_credit** (sender): `send_valid |-> credit > 0`.
+    ///   The user is responsible for gating send_valid on can_send; if they
+    ///   fail to, this trips.
+    /// - **credit_return_requires_buffered** (receiver): `credit_return |->
+    ///   __<port>_<ch>_valid`. The receiver must only pulse credit_return
+    ///   when the FIFO actually has something to pop; otherwise the sender
+    ///   sees a spurious credit and can overflow the buffer.
+    ///
+    /// Deferred: occupancy = DEPTH - credit (cross-module property; lands
+    /// with a hierarchical-formal story).
+    fn emit_credit_channel_asserts(&mut self, m: &ModuleDecl) {
+        let mut sender_emissions:   Vec<(String, crate::ast::CreditChannelMeta)> = Vec::new();
+        let mut receiver_emissions: Vec<(String, crate::ast::CreditChannelMeta)> = Vec::new();
+        for p in &m.ports {
+            let Some(ref bi) = p.bus_info else { continue; };
+            let Some((crate::resolve::Symbol::Bus(info), _)) =
+                self.symbols.globals.get(&bi.bus_name.name) else { continue; };
+            for cc in &info.credit_channels {
+                let is_sender = matches!(
+                    (cc.role_dir, bi.perspective),
+                    (Direction::Out, crate::ast::BusPerspective::Initiator)
+                  | (Direction::In,  crate::ast::BusPerspective::Target)
+                );
+                if is_sender { sender_emissions.push((p.name.name.clone(), cc.clone())); }
+                else         { receiver_emissions.push((p.name.name.clone(), cc.clone())); }
+            }
+        }
+        if sender_emissions.is_empty() && receiver_emissions.is_empty() { return; }
+
+        let clk = m.ports.iter()
+            .find(|p| matches!(&p.ty, TypeExpr::Clock(_)))
+            .map(|p| p.name.name.clone());
+        let Some(clk) = clk else { return; };
+        let rst_active = m.ports.iter()
+            .find(|p| matches!(&p.ty, TypeExpr::Reset(_, _)))
+            .map(|p| match &p.ty {
+                TypeExpr::Reset(_, ResetLevel::Low) => format!("!{}", p.name.name),
+                _ => p.name.name.clone(),
+            });
+        let disable = rst_active.as_ref()
+            .map(|r| format!(" disable iff ({r})"))
+            .unwrap_or_default();
+        let mod_name = m.name.name.clone();
+
+        self.line("");
+        self.line("// synopsys translate_off");
+        self.line("// Auto-generated credit_channel protocol assertions (Tier 2)");
+
+        for (port_name, cc) in &sender_emissions {
+            let ch = &cc.name.name;
+            let Some(depth_expr) = cc.params.iter()
+                .find(|p| p.name.name == "DEPTH")
+                .and_then(|p| p.default.as_ref()) else { continue; };
+            let depth_str  = self.emit_expr_str(depth_expr);
+            let credit_reg = format!("__{port_name}_{ch}_credit");
+            let send_valid = format!("{port_name}_{ch}_send_valid");
+
+            let label = format!("_auto_cc_{port_name}_{ch}_credit_bounds");
+            self.line(&format!(
+                "{label}: assert property (@(posedge {clk}){disable} {credit_reg} <= ({depth_str}))"
+            ));
+            self.line(&format!(
+                "  else $fatal(1, \"CREDIT-CHANNEL VIOLATION (credit exceeds DEPTH): {mod_name}.{label}\");"
+            ));
+
+            let label = format!("_auto_cc_{port_name}_{ch}_send_requires_credit");
+            self.line(&format!(
+                "{label}: assert property (@(posedge {clk}){disable} {send_valid} |-> {credit_reg} > 0)"
+            ));
+            self.line(&format!(
+                "  else $fatal(1, \"CREDIT-CHANNEL VIOLATION (send without credit): {mod_name}.{label}\");"
+            ));
+        }
+
+        for (port_name, cc) in &receiver_emissions {
+            let ch = &cc.name.name;
+            let credit_ret = format!("{port_name}_{ch}_credit_return");
+            let buf_valid  = format!("__{port_name}_{ch}_valid");
+            let label = format!("_auto_cc_{port_name}_{ch}_credit_return_requires_buffered");
+            self.line(&format!(
+                "{label}: assert property (@(posedge {clk}){disable} {credit_ret} |-> {buf_valid})"
+            ));
+            self.line(&format!(
+                "  else $fatal(1, \"CREDIT-CHANNEL VIOLATION (credit_return without buffered data): {mod_name}.{label}\");"
+            ));
+        }
+
+        self.line("// synopsys translate_on");
     }
 
     /// Stringify a compile-time constant expression to an SV literal/expression.

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -3858,6 +3858,67 @@ fn test_credit_channel_can_send_default_is_combinational() {
 }
 
 #[test]
+fn test_credit_channel_tier2_sender_assertions() {
+    let source = "
+        bus DmaCh
+          credit_channel data: send
+            param T:     type  = UInt<8>;
+            param DEPTH: const = 4;
+          end credit_channel data
+        end bus DmaCh
+
+        use DmaCh;
+
+        module Prod
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync>;
+          port p:   initiator DmaCh;
+          comb
+            p.data_send_valid = 1'b0;
+            p.data_send_data  = 8'h0;
+          end comb
+        end module Prod
+    ";
+    let sv = compile_to_sv(source);
+    assert!(sv.contains("_auto_cc_p_data_credit_bounds"),
+        "credit_bounds assertion label should be present on sender:\n{sv}");
+    assert!(sv.contains("__p_data_credit <= (4)"),
+        "credit_bounds property should compare credit reg to DEPTH:\n{sv}");
+    assert!(sv.contains("_auto_cc_p_data_send_requires_credit"),
+        "send_requires_credit assertion should be present:\n{sv}");
+    assert!(sv.contains("p_data_send_valid |-> __p_data_credit > 0"),
+        "send_requires_credit property should encode valid-implies-credit:\n{sv}");
+}
+
+#[test]
+fn test_credit_channel_tier2_receiver_assertion() {
+    let source = "
+        bus DmaCh
+          credit_channel data: send
+            param T:     type  = UInt<8>;
+            param DEPTH: const = 4;
+          end credit_channel data
+        end bus DmaCh
+
+        use DmaCh;
+
+        module Cons
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync>;
+          port p:   target DmaCh;
+          comb
+            p.data_credit_return = 1'b0;
+          end comb
+        end module Cons
+    ";
+    let sv = compile_to_sv(source);
+    assert!(sv.contains("_auto_cc_p_data_credit_return_requires_buffered"),
+        "receiver-side assertion should be present:\n{sv}");
+    assert!(sv.contains("p_data_credit_return |-> __p_data_valid"),
+        "credit_return should imply buffer-non-empty:\n{sv}");
+}
+
+#[test]
 fn test_credit_channel_mismatched_closing_keyword_errors() {
     let source = "
         bus B


### PR DESCRIPTION
## Summary
- PR #4. Auto-emits three Tier-2 protocol assertions per credit_channel.
- Labels: \`_auto_cc_<port>_<ch>_{credit_bounds,send_requires_credit,credit_return_requires_buffered}\`.
- Sender gets the first two; receiver gets the third. Cross-module occupancy invariant deferred (needs hierarchical formal).

## Test plan
- [x] \`cargo test\` — 127/127 pass (125 existing + 2 new regressions).
- [x] Sender SV contains credit_bounds + send_requires_credit labels.
- [x] Receiver SV contains credit_return_requires_buffered label.