### PR TITLE
feat: credit_channel send/pop statement sugar

### DIFF
--- a/doc/ARCH_HDL_Specification.md
+++ b/doc/ARCH_HDL_Specification.md
@@ -4632,11 +4632,17 @@ v1 scope: nested `generate_if` inside a payload branch is a compile error. A han
 
 **18c. First-Class Sub-Construct: credit_channel (inside bus)** — *wire layer live, elaboration pending*
 
-> **Status (v0.44.7):** grammar, wire flattening, sender-side credit counter,
+> **Status (v0.44.8):** grammar, wire flattening, sender-side credit counter,
 > target-side FIFO, **read-side method dispatch** (`port.ch.can_send` on the
 > sender, `port.ch.valid` / `port.ch.data` on the receiver), the
-> **`CAN_SEND_REGISTERED` timing-relief knob**, and the **Tier-2 protocol
-> SVA** are all in place. Auto-emitted assertions (labels follow
+> **`CAN_SEND_REGISTERED` timing-relief knob**, **Tier-2 protocol SVA**, and
+> **write-side statement sugar** (`port.ch.send(x);` / `port.ch.pop();` as
+> bare statements) are all in place. Sugar desugars in the parser: `.send(x)`
+> becomes two assigns (`send_valid=1; send_data=x;`) wrapped in a
+> compile-time-true `if` block (SV flattens it away); `.pop()` becomes a
+> single `credit_return=1` assign. Method names `send` / `pop` are narrowly
+> gated in the parser — any other port shape falls through to a normal
+> unknown-field error. Auto-emitted assertions (labels follow
 > `_auto_cc_<port>_<ch>_<rule>`, wrapped in `translate_off/on`):
 > (1) `credit <= DEPTH` on the sender; (2) `send_valid |-> credit > 0`
 > on the sender; (3) `credit_return |-> buffer_valid` on the receiver.

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1642,6 +1642,12 @@ impl Parser {
         self.no_lteq = true;
         let target = self.parse_expr()?;
         self.no_lteq = old_no_lteq;
+        if self.check(TokenKind::Semi) {
+            if let Some(stmt) = desugar_cc_method_call_reg_stmt(&target) {
+                self.expect(TokenKind::Semi)?;
+                return Ok(stmt);
+            }
+        }
         self.expect(TokenKind::LtEq)?;
         let value = self.parse_expr()?;
         self.expect(TokenKind::Semi)?;
@@ -1897,8 +1903,15 @@ impl Parser {
             }
             unreachable!();
         }
-        // target = expr;
+        // target = expr;   OR   bare method-call statement (credit_channel sugar).
         let target = self.parse_expr()?;
+        if self.check(TokenKind::Semi) {
+            // Candidate for `port.ch.send(x);` or `port.ch.pop();` sugar.
+            if let Some(stmt) = desugar_cc_method_call_comb_stmt(&target) {
+                self.expect(TokenKind::Semi)?;
+                return Ok(stmt);
+            }
+        }
         self.expect(TokenKind::Eq)?;
         let value = self.parse_expr()?;
         self.expect(TokenKind::Semi)?;
@@ -2523,7 +2536,9 @@ impl Parser {
                     && matches!(field.name.as_str(),
                         "reverse" | "any" | "all" | "count" | "contains"
                         | "reduce_or" | "reduce_and" | "reduce_xor"
-                        | "find_first");
+                        | "find_first"
+                        // credit_channel write-side sugar (PR #3b-vi).
+                        | "send" | "pop");
                 if paren_method {
                     self.advance(); // (
                     let mut args = Vec::new();
@@ -4667,7 +4682,89 @@ impl Parser {
 }
 
 fn is_method_name(name: &str) -> bool {
-    matches!(name, "trunc" | "zext" | "sext" | "resize" | "reverse")
+    matches!(
+        name,
+        "trunc" | "zext" | "sext" | "resize" | "reverse"
+        // credit_channel write-side sugar (PR #3b-vi). These are only
+        // meaningful as bare statements; the parser's `parse_comb_stmt`
+        // and `parse_reg_stmt` desugar `port.ch.send(x);` / `.pop();` to
+        // the underlying wire assignments. Accepting them here as method
+        // names makes parse_expr succeed; in any other context the type
+        // checker flags them as unsupported.
+        | "send" | "pop"
+    )
+}
+
+/// Recognize a bare `port.ch.send(x);` / `port.ch.pop();` method-call
+/// statement and return the underlying wire assignments.
+///
+/// `.send(x)` produces two assigns (valid + data); `.pop()` produces one
+/// (credit_return). Runs at parse time without access to the symbol
+/// table, so the rewrite is narrowly gated on the exact method names
+/// `send` and `pop`. Any mismatch (unknown channel, wrong port, etc.) is
+/// caught later at typecheck as a normal unknown-field error.
+fn desugar_cc_method_call_assigns(expr: &Expr) -> Option<Vec<CombAssign>> {
+    let ExprKind::MethodCall(recv, method, args) = &expr.kind else { return None; };
+    let ExprKind::FieldAccess(port_expr, ch_ident) = &recv.kind else { return None; };
+    if !matches!(&port_expr.kind, ExprKind::Ident(_)) { return None; }
+    let ch = &ch_ident.name;
+    let span = expr.span;
+    let mk_field = |name: String| -> Expr {
+        Expr::new(
+            ExprKind::FieldAccess((*port_expr).clone(), Ident::new(name, span)),
+            span,
+        )
+    };
+    let one = Expr::new(ExprKind::Literal(LitKind::Sized(1, 1)), span);
+    match method.name.as_str() {
+        "send" if args.len() == 1 => Some(vec![
+            CombAssign { target: mk_field(format!("{ch}_send_valid")), value: one.clone(), span },
+            CombAssign { target: mk_field(format!("{ch}_send_data")),  value: args[0].clone(), span },
+        ]),
+        "pop" if args.is_empty() => Some(vec![
+            CombAssign { target: mk_field(format!("{ch}_credit_return")), value: one, span },
+        ]),
+        _ => None,
+    }
+}
+
+/// Desugar a credit_channel method-call statement into a single CombStmt.
+/// Multi-assign cases (`.send(x)`) wrap the two assigns in an `if (1'b1)`
+/// block so the caller always gets exactly one statement — avoids
+/// threading a mutation-buffer through every stmt-list-collection loop.
+/// SV synthesis trivially flattens the always-true guard.
+fn desugar_cc_method_call_comb_stmt(expr: &Expr) -> Option<CombStmt> {
+    let assigns = desugar_cc_method_call_assigns(expr)?;
+    if assigns.len() == 1 {
+        return Some(CombStmt::Assign(assigns.into_iter().next().unwrap()));
+    }
+    let span = expr.span;
+    Some(CombStmt::IfElse(CombIfElse {
+        cond: Expr::new(ExprKind::Literal(LitKind::Sized(1, 1)), span),
+        then_stmts: assigns.into_iter().map(CombStmt::Assign).collect(),
+        else_stmts: Vec::new(),
+        unique: false,
+        span,
+    }))
+}
+
+/// Same idea, seq-block (non-blocking) variant.
+fn desugar_cc_method_call_reg_stmt(expr: &Expr) -> Option<Stmt> {
+    let assigns = desugar_cc_method_call_assigns(expr)?;
+    let reg_assigns: Vec<Stmt> = assigns.into_iter()
+        .map(|a| Stmt::Assign(RegAssign { target: a.target, value: a.value, span: a.span }))
+        .collect();
+    if reg_assigns.len() == 1 {
+        return Some(reg_assigns.into_iter().next().unwrap());
+    }
+    let span = expr.span;
+    Some(Stmt::IfElse(IfElseOf {
+        cond: Expr::new(ExprKind::Literal(LitKind::Sized(1, 1)), span),
+        then_stmts: reg_assigns,
+        else_stmts: Vec::new(),
+        unique: false,
+        span,
+    }))
 }
 
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -3919,6 +3919,73 @@ fn test_credit_channel_tier2_receiver_assertion() {
 }
 
 #[test]
+fn test_credit_channel_send_sugar() {
+    // PR #3b-vi: `p.data.send(x);` desugars to two assignments that set
+    // send_valid and send_data.
+    let source = "
+        bus DmaCh
+          credit_channel data: send
+            param T:     type  = UInt<8>;
+            param DEPTH: const = 4;
+          end credit_channel data
+        end bus DmaCh
+
+        use DmaCh;
+
+        module Prod
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync>;
+          port p:   initiator DmaCh;
+          port payload: in UInt<8>;
+          comb
+            p.data_send_valid = 1'b0;       // default — overridden below
+            p.data_send_data  = 8'h0;
+            if p.data.can_send
+              p.data.send(payload);
+            end if
+          end comb
+        end module Prod
+    ";
+    let sv = compile_to_sv(source);
+    assert!(sv.contains("p_data_send_valid = 1'd1")
+          || sv.contains("p_data_send_valid = 1'b1"),
+        ".send() should set send_valid to 1:\n{sv}");
+    assert!(sv.contains("p_data_send_data = payload"),
+        ".send(payload) should set send_data to payload:\n{sv}");
+}
+
+#[test]
+fn test_credit_channel_pop_sugar() {
+    let source = "
+        bus DmaCh
+          credit_channel data: send
+            param T:     type  = UInt<8>;
+            param DEPTH: const = 4;
+          end credit_channel data
+        end bus DmaCh
+
+        use DmaCh;
+
+        module Cons
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync>;
+          port p:   target DmaCh;
+          port want_pop: in Bool;
+          comb
+            p.data_credit_return = 1'b0;
+            if p.data.valid and want_pop
+              p.data.pop();
+            end if
+          end comb
+        end module Cons
+    ";
+    let sv = compile_to_sv(source);
+    assert!(sv.contains("p_data_credit_return = 1'd1")
+          || sv.contains("p_data_credit_return = 1'b1"),
+        ".pop() should assert credit_return:\n{sv}");
+}
+
+#[test]
 fn test_credit_channel_mismatched_closing_keyword_errors() {
     let source = "
         bus B


### PR DESCRIPTION
PR 3b-vi. Completes the write-side ergonomics for credit_channel.

- p.data.send(payload); desugars to two assigns (valid + data), wrapped in if(1'b1) so the parser returns a single CombStmt.
- p.data.pop(); desugars to a single credit_return assign.
- Narrowly gated on method names send and pop only.

cargo test: 129/129 pass (127 existing + 2 new).

Follow-up: PR 5 for docs + NoC flit validation test.