### PR TITLE
docs: credit_channel canonical spec section + NoC validation test

### DIFF
--- a/doc/ARCH_HDL_Specification.md
+++ b/doc/ARCH_HDL_Specification.md
@@ -4630,59 +4630,23 @@ v1 scope: nested `generate_if` inside a payload branch is a compile error. A han
 - **Handshake at the module port level directly.** Valid only inside a `bus` body. A single-channel interface is expressed by a one-handshake bus declaration plus an ordinary bus port.
 - **`req_ack_2phase` Tier-2 assertions** — requires `$past` tracking; deferred.
 
-**18c. First-Class Sub-Construct: credit_channel (inside bus)** — *wire layer live, elaboration pending*
+**18c. First-Class Sub-Construct: credit_channel (inside bus)**
 
-> **Status (v0.44.8):** grammar, wire flattening, sender-side credit counter,
-> target-side FIFO, **read-side method dispatch** (`port.ch.can_send` on the
-> sender, `port.ch.valid` / `port.ch.data` on the receiver), the
-> **`CAN_SEND_REGISTERED` timing-relief knob**, **Tier-2 protocol SVA**, and
-> **write-side statement sugar** (`port.ch.send(x);` / `port.ch.pop();` as
-> bare statements) are all in place. Sugar desugars in the parser: `.send(x)`
-> becomes two assigns (`send_valid=1; send_data=x;`) wrapped in a
-> compile-time-true `if` block (SV flattens it away); `.pop()` becomes a
-> single `credit_return=1` assign. Method names `send` / `pop` are narrowly
-> gated in the parser — any other port shape falls through to a normal
-> unknown-field error. Auto-emitted assertions (labels follow
-> `_auto_cc_<port>_<ch>_<rule>`, wrapped in `translate_off/on`):
-> (1) `credit <= DEPTH` on the sender; (2) `send_valid |-> credit > 0`
-> on the sender; (3) `credit_return |-> buffer_valid` on the receiver.
-> Consumed by Verilator `--assert`, EBMC, and SymbiYosys like the existing
-> handshake / bounds / divide-by-zero labels. The cross-module occupancy
-> invariant (`occupancy == DEPTH - credit`) is deferred to the hierarchical
-> formal story. The knob is
-> a channel-level param — `param CAN_SEND_REGISTERED: const = 1;` inside the
-> `credit_channel` block flops `can_send` off the next-state counter
-> (option b: full throughput preserved, fan-out comes from a register so the
-> combinational critical path ends at the flop input). Default is 0
-> (combinational). Method dispatch rewrites `port.ch.can_send` to the
-> synthesized wire/reg regardless of the choice. On the receiver module
-> (`target` perspective on a `send`-role channel) the codegen synthesizes a
-> depth-DEPTH packet buffer (`__<port>_<ch>_buf`) with head/tail/occupancy
-> pointers, pushed on `<port>_<ch>_send_valid` and popped when the user
-> drives `<port>_<ch>_credit_return` high while the FIFO is non-empty. The
-> user-driven `credit_return` is therefore both the pop trigger and the
-> credit-return pulse to the sender — a clean single-signal contract. Still
-> not implemented (in order): **ARCH-level method dispatch** for
-> `port.ch.valid` / `port.ch.data` / `port.ch.can_send` / `ch.send()` /
-> `ch.pop()`, the **`CAN_SEND_REGISTERED` timing-relief knob** (next-state
-> flop, option (b)), and **Tier-2 SVA invariants**. The FIFO internals are
-> visible in SV only for now — cocotb TBs and raw SV drivers can use them
-> today; method dispatch is blocked on an AST design decision for
-> typecheck-visible synthesized wires.
+`credit_channel` carries stateful credit-based flow control as a bus sub-construct, sibling to `handshake_channel`. The compiler owns three pieces of hardware per channel: the sender-side credit counter, the receiver-side FIFO, and the protocol wires between them — so users get a one-line declaration for what is otherwise 150+ lines of hand-rolled valid/data/credit plumbing and the attendant off-by-one bugs. Arch build emits the counter, the FIFO, and the Tier-2 protocol SVA automatically; there is no standalone form, credit channels always nest inside a `bus`.
 
-`credit_channel` carries stateful credit-based flow control as a bus sub-construct, sibling to `handshake_channel`. Syntax nests inside a bus body:
+**18c.1 Declaration**
 
 ```
 bus DmaCh
   credit_channel data: send
-    param T:     type  = UInt<64>;
-    param DEPTH: const = 8;
+    param T:                   type  = UInt<64>;
+    param DEPTH:               const = 8;
+    param CAN_SEND_REGISTERED: const = 0;   // optional timing-relief flop
   end credit_channel data
 end bus DmaCh
 ```
 
-Grammar (parser-accepted in v0.44.1; not yet usable):
-
+Grammar:
 ```
 CreditChannelBlock := 'credit_channel' Ident ':' Role NEWLINE
                         ParamDecl*
@@ -4690,7 +4654,113 @@ CreditChannelBlock := 'credit_channel' Ident ':' Role NEWLINE
 Role               := 'send' | 'receive'
 ```
 
-Knobs: payload type `T` (use a struct for multi-field payloads) and credit depth `DEPTH`. No protocol variants — credit is one protocol. Full semantics, lowering, auto-SVA, and the NoC-flit validation test are specified in `doc/plan_credit_channel.md`.
+Knobs:
+- `T` — payload type. Use a struct for multi-field payloads (same pattern as `fifo`).
+- `DEPTH` — buffer depth and initial credit pool. Must be ≥ 1.
+- `CAN_SEND_REGISTERED` — `0` (default) makes `can_send` combinational off the counter. `1` flops it off the *next-state* counter (option b — full throughput preserved; fan-out comes off a register so the combinational critical path of downstream logic ends at the flop input). Use when the can_send fan-out is timing-critical.
+
+**18c.2 Wire protocol**
+
+Each credit_channel flattens at the bus port into three signals. Directions below are from the initiator perspective; the `target` bus-port flip inverts them.
+
+| Signal | Direction | Driver |
+|---|---|---|
+| `<ch>_send_valid` | initiator → target | user's comb (sender) |
+| `<ch>_send_data` | initiator → target | user's comb (sender) |
+| `<ch>_credit_return` | target → initiator | user's comb (receiver) |
+
+The user-driven `credit_return` signal has a dual role: it tells the sender to increment its counter *and* tells the receiver's FIFO to dequeue. One signal, one decision point, no double-bookkeeping.
+
+**18c.3 Method dispatch (read side)**
+
+Inside a module that owns a credit_channel port, these expressions resolve to the compiler-synthesized state:
+
+| Expression | Available on | Resolves to |
+|---|---|---|
+| `port.ch.can_send` | sender | `__<port>_<ch>_can_send` (combinational or flopped per `CAN_SEND_REGISTERED`) |
+| `port.ch.valid` | receiver | FIFO occupancy ≠ 0 |
+| `port.ch.data` | receiver | FIFO front |
+
+Attempts to access the wrong side produce a normal unknown-field error at typecheck.
+
+**18c.4 Statement sugar (write side)**
+
+Inside a comb or seq block, two method-call statements desugar to wire drives:
+
+| Sugar | Desugars to |
+|---|---|
+| `port.ch.send(x);` | `port.<ch>_send_valid = 1; port.<ch>_send_data = x;` |
+| `port.ch.pop();` | `port.<ch>_credit_return = 1;` |
+
+`.pop()` and manually writing `credit_return = 1` are exactly equivalent — `.pop()` just names the receiver-side verb.
+
+**18c.5 Canonical pattern**
+
+```
+bus NocChannel
+  credit_channel flits: send
+    param T:     type  = UInt<64>;
+    param DEPTH: const = 8;
+  end credit_channel flits
+end bus NocChannel
+
+module NocProducer
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port out: initiator NocChannel;
+  reg seq_no: UInt<64> reset rst => 0;
+  comb
+    out.flits_send_valid = 1'b0;
+    out.flits_send_data  = 64'h0;
+    if out.flits.can_send
+      out.flits.send(seq_no);
+    end if
+  end comb
+  seq on clk rising
+    if out.flits.can_send
+      seq_no <= (seq_no + 1).trunc<64>();
+    end if
+  end seq
+end module NocProducer
+
+module NocConsumer
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port incoming: target NocChannel;
+  port reg last_seq: out UInt<64> reset rst => 0;
+  comb
+    incoming.flits_credit_return = 1'b0;
+    if incoming.flits.valid
+      incoming.flits.pop();
+    end if
+  end comb
+  seq on clk rising
+    if incoming.flits.valid
+      last_seq <= incoming.flits.data;
+    end if
+  end seq
+end module NocConsumer
+```
+
+**18c.6 Auto-emitted SVA (Tier 2)**
+
+Labels follow `_auto_cc_<port>_<ch>_<rule>`, wrapped in `synopsys translate_off/on`. Consumed by Verilator `--assert`, EBMC, and SymbiYosys just like the existing handshake and bounds labels.
+
+- Sender: `credit_bounds` — `__<port>_<ch>_credit <= DEPTH`.
+- Sender: `send_requires_credit` — `send_valid |-> credit > 0`.
+- Receiver: `credit_return_requires_buffered` — `credit_return |-> __<port>_<ch>_valid`.
+
+The cross-module occupancy invariant (`occupancy == DEPTH - credit`) is deferred — it needs a hierarchical-formal harness. Available in the same validation path once that lands.
+
+**18c.7 Not covered in v1**
+
+- Cross-clock-domain credit channels (v2 — needs gray-coded counters).
+- Credit-return batching (v1 is 1-pop = 1-return).
+- Multi-initiator (point-to-point only; many-to-one composes via `arbiter`).
+- Runtime-parameterizable depth (DEPTH is compile-time const).
+- `arch sim --pybind --test` simulation (C++ counter + FIFO mirror not yet emitted by `sim_codegen` — use `arch build` + Verilator / iverilog for now).
+
+Full design history and the broader roadmap are in `doc/plan_credit_channel.md` and `doc/plan_bus_unification.md`.
 
 **18d. Standard Bus Library**
 

--- a/doc/Arch_AI_Reference_Card.md
+++ b/doc/Arch_AI_Reference_Card.md
@@ -890,20 +890,50 @@ end bus BusAxiLite
 
 Full spec: `doc/ARCH_HDL_Specification.md` §18a.
 
-### credit_channel (inside bus) — scaffolding only in v0.44.1
+### credit_channel (inside bus)
 
-Stateful credit-based flow control as a bus sub-construct. Grammar is accepted; **elaboration is not yet implemented** — any bus declaring a `credit_channel` currently fails typecheck with *"parser scaffolding only"*.
+Stateful credit-based flow control. The compiler owns the sender counter, the receiver FIFO, and the Tier-2 protocol SVA. Nests inside a `bus`; no standalone form.
 
 ```
 bus DmaCh
   credit_channel data: send
-    param T:     type  = UInt<64>;
-    param DEPTH: const = 8;
+    param T:                   type  = UInt<64>;
+    param DEPTH:               const = 8;
+    param CAN_SEND_REGISTERED: const = 0;   // 1 = flop can_send off counter_next
   end credit_channel data
 end bus DmaCh
 ```
 
-When elaboration lands: `ch.can_send` / `ch.send(x)` on the initiator; `ch.valid` / `ch.data` / `ch.pop()` on the target. Compiler owns counter + FIFO. See `doc/plan_credit_channel.md` for the full design and `doc/plan_bus_unification.md` for the sibling-channel framing.
+**API** (read-side methods + write-side sugar):
+- Sender: `port.ch.can_send` (read); `port.ch.send(x);` (statement — desugars to `send_valid=1; send_data=x;`).
+- Receiver: `port.ch.valid`, `port.ch.data` (read); `port.ch.pop();` (statement — drives `credit_return=1`).
+- Credit return and pop are the same signal (`<port>_<ch>_credit_return`), by design.
+
+**Canonical pattern**:
+```
+// Sender
+comb
+  out.flits_send_valid = 1'b0;
+  out.flits_send_data  = 64'h0;
+  if out.flits.can_send
+    out.flits.send(seq_no);
+  end if
+end comb
+
+// Receiver
+comb
+  incoming.flits_credit_return = 1'b0;
+  if incoming.flits.valid
+    incoming.flits.pop();
+  end if
+end comb
+```
+
+**Auto-emitted SVA (Tier 2)**: `_auto_cc_<port>_<ch>_{credit_bounds,send_requires_credit,credit_return_requires_buffered}` under `translate_off/on`.
+
+Simulation caveat: `arch sim --pybind --test` does not yet mirror the counter/FIFO in C++ — use `arch build` + Verilator for now.
+
+Full spec: `doc/ARCH_HDL_Specification.md` §18c.
 
 ### Standard bus library (zero-setup `use`)
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -3986,6 +3986,107 @@ fn test_credit_channel_pop_sugar() {
 }
 
 #[test]
+fn test_credit_channel_end_to_end_noc_producer_consumer() {
+    // PR #5: canonical credit_channel validation — one producer, one
+    // consumer, one shared credit_channel. Exercises the full stack:
+    //  * Wire flattening at both port perspectives.
+    //  * Sender-side credit counter + can_send dispatch.
+    //  * Target-side FIFO + pop/credit_return wiring.
+    //  * Read-side dispatch (can_send / valid / data).
+    //  * Write-side sugar (.send(x) / .pop()).
+    //  * Tier-2 SVA on both sides.
+    let source = "
+        bus NocChannel
+          credit_channel flits: send
+            param T:     type  = UInt<64>;
+            param DEPTH: const = 8;
+          end credit_channel flits
+        end bus NocChannel
+
+        use NocChannel;
+
+        module NocProducer
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync>;
+          port out: initiator NocChannel;
+          port gen_pressure: in UInt<8>;
+          reg seq_no: UInt<64> init 0 reset rst => 0;
+          reg lfsr:   UInt<8>  init 8'h5A reset rst => 8'h5A;
+          comb
+            out.flits_send_valid = 1'b0;
+            out.flits_send_data  = 64'h0;
+            if out.flits.can_send
+              out.flits.send(seq_no);
+            end if
+          end comb
+          seq on clk rising
+            if (lfsr[0] == 1'b1)
+              lfsr <= (lfsr >> 1) ^ 8'hB8;
+            else
+              lfsr <= lfsr >> 1;
+            end if
+            if out.flits.can_send and (lfsr < gen_pressure)
+              seq_no <= (seq_no + 1).trunc<64>();
+            end if
+          end seq
+        end module NocProducer
+
+        module NocConsumer
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync>;
+          port incoming: target NocChannel;
+          port pop_pressure:      in  UInt<8>;
+          port reg popped_count:  out UInt<64> reset rst => 0;
+          port reg last_seq:      out UInt<64> reset rst => 0;
+          reg lfsr: UInt<8> init 8'hC3 reset rst => 8'hC3;
+          comb
+            incoming.flits_credit_return = 1'b0;
+            if incoming.flits.valid and (lfsr < pop_pressure)
+              incoming.flits.pop();
+            end if
+          end comb
+          seq on clk rising
+            if (lfsr[0] == 1'b1)
+              lfsr <= (lfsr >> 1) ^ 8'hB8;
+            else
+              lfsr <= lfsr >> 1;
+            end if
+            if incoming.flits.valid and (lfsr < pop_pressure)
+              popped_count <= (popped_count + 1).trunc<64>();
+              last_seq     <= incoming.flits.data;
+            end if
+          end seq
+        end module NocConsumer
+    ";
+    let sv = compile_to_sv(source);
+
+    // Sender-side checks
+    assert!(sv.contains("__out_flits_credit"), "sender credit reg:\n{sv}");
+    assert!(sv.contains("__out_flits_can_send"), "sender can_send:\n{sv}");
+    assert!(sv.contains("_auto_cc_out_flits_credit_bounds"), "sender SVA:\n{sv}");
+    assert!(sv.contains("_auto_cc_out_flits_send_requires_credit"), "sender SVA:\n{sv}");
+
+    // .send(x) sugar must materialize both signals
+    assert!(sv.contains("out_flits_send_valid = 1'd1"), "send sugar valid:\n{sv}");
+    assert!(sv.contains("out_flits_send_data = seq_no"), "send sugar data:\n{sv}");
+
+    // Receiver-side checks
+    assert!(sv.contains("__incoming_flits_buf"), "receiver buffer:\n{sv}");
+    assert!(sv.contains("__incoming_flits_valid"), "receiver valid wire:\n{sv}");
+    assert!(sv.contains("__incoming_flits_data"), "receiver data wire:\n{sv}");
+    assert!(sv.contains("_auto_cc_incoming_flits_credit_return_requires_buffered"),
+        "receiver SVA:\n{sv}");
+
+    // .pop() sugar
+    assert!(sv.contains("incoming_flits_credit_return = 1'd1"),
+        "pop sugar credit_return:\n{sv}");
+
+    // Read-side dispatch in seq and comb contexts
+    assert!(sv.contains("last_seq <= __incoming_flits_data"),
+        "read-side dispatch in seq:\n{sv}");
+}
+
+#[test]
 fn test_credit_channel_mismatched_closing_keyword_errors() {
     let source = "
         bus B


### PR DESCRIPTION
PR 5. Closes out the credit_channel rollout.

- Spec 18c rewritten as a coherent canonical section (declaration, wire protocol, method dispatch, sugar, canonical pattern, SVA, not-covered).
- Reference card matches.
- Adds an end-to-end integration test covering a minimal NocProducer / NocConsumer pair and verifying all synthesized pieces appear in the generated SV.

Simulation via arch sim --pybind --test remains blocked on sim_codegen mirroring the counter + FIFO in C++ — called out explicitly in the spec.

cargo test: 130/130 pass (129 + 1 new).