### PR TITLE
feat(sim): mirror credit_channel sender-side state in C++

### DIFF
--- a/src/sim_codegen.rs
+++ b/src/sim_codegen.rs
@@ -3675,9 +3675,15 @@ impl<'a> SimCodegen<'a> {
 
         // Collect log file paths early so constructor can open them
         let log_files_for_ctor = collect_log_files(&m.body);
+        // Credit-channel sites are used by the constructor (zero-init), the
+        // field-decl section, the eval_posedge update, and eval_comb — so
+        // collect once up front.
+        let cc_sites = crate::sim_credit_channel::collect_credit_channels(m, self.symbols);
         // Constructor always has a body (for auto-trace open)
         h.push_str(&format!("  {class}() : {} {{\n", all_inits.join(", ")));
         for line in &vec_reg_inits { h.push_str(&format!("{line}\n")); }
+        // Zero-init credit_channel synthesized fields (DEPTH for the counter).
+        crate::sim_credit_channel::emit_constructor_inits(&cc_sites, &mut h);
         for path in &log_files_for_ctor {
             h.push_str(&format!("    {} = fopen(\"{}\", \"w\");\n", log_fd_name(path), path));
         }
@@ -3881,6 +3887,10 @@ impl<'a> SimCodegen<'a> {
                 }
             }
         }
+
+        // Credit-channel synthesized fields (sim mirror of SV codegen's
+        // emit_credit_channel_state / _receiver_state).
+        crate::sim_credit_channel::emit_header_fields(&cc_sites, &mut h);
 
         // Private fields for comb-block intermediate signals (not ports/regs/inst_out)
         let comb_targets = collect_comb_targets(&m.body);
@@ -4481,6 +4491,28 @@ impl<'a> SimCodegen<'a> {
             }
         }
 
+        // Credit-channel counter update (sender side). Gated on the
+        // primary clock's rising edge and the module's first reset port
+        // (active-high / active-low derived from the port's polarity).
+        if !cc_sites.is_empty() {
+            let primary_clk = all_clks.first().cloned();
+            let rst_expr = m.ports.iter()
+                .find(|p| matches!(&p.ty, TypeExpr::Reset(_, _)))
+                .map(|p| match &p.ty {
+                    TypeExpr::Reset(_, ResetLevel::Low) => format!("!{}", p.name.name),
+                    _ => p.name.name.clone(),
+                });
+            if let Some(clk) = primary_clk {
+                cpp.push_str(&format!("  if (_rising_{clk}) {{\n"));
+                crate::sim_credit_channel::emit_posedge_updates(
+                    &cc_sites,
+                    rst_expr.as_deref(),
+                    &mut cpp,
+                );
+                cpp.push_str("  }\n");
+            }
+        }
+
         cpp.push_str("}\n\n");
 
         // eval_comb()
@@ -4490,6 +4522,11 @@ impl<'a> SimCodegen<'a> {
         let ctx_comb = Ctx::new(&reg_names, &port_names, &let_names, &inst_names,
                                 &wide_names, &widths, &enum_map, &bus_port_names)
                            .with_vec_names(&vec_reg_names).with_vec_sizes(&vec_sizes);
+
+        // Credit-channel combinational wires (sender can_send; receiver
+        // valid/data once PR-sim-2 lands). Emit early so user comb code
+        // can read them.
+        crate::sim_credit_channel::emit_comb_updates(&cc_sites, &mut cpp);
 
         // Flat → internal bridge for input Vec ports (non-reg)
         for vi in &vec_port_infos {

--- a/src/sim_credit_channel.rs
+++ b/src/sim_credit_channel.rs
@@ -69,27 +69,132 @@ pub fn collect_credit_channels(m: &ModuleDecl, symbols: &SymbolTable) -> Vec<Cre
 // `todo!`-style no-ops would silently drop behavior; instead the callers
 // simply won't invoke them until we wire each up.
 
-/// Append C++ private field declarations for each site to the header
-/// buffer. Matches the SV names emitted by codegen so `SynthIdent`
-/// references resolve to real symbols.
-pub fn emit_header_fields(_sites: &[CreditChannelSite], _h: &mut String) {
-    // PR-sim-1 (sender) / PR-sim-2 (receiver) land here.
+/// Append C++ private field declarations for each site.
+///
+/// Sender emits:
+///   uint32_t __<port>_<ch>_credit;
+///   uint8_t  __<port>_<ch>_can_send;
+///
+/// Receiver FIFO fields land in the receiver-side slice (PR-sim-2).
+pub fn emit_header_fields(sites: &[CreditChannelSite], h: &mut String) {
+    for s in sites {
+        match s.role {
+            CreditChannelRole::Sender => {
+                let port = &s.port_name;
+                let ch = &s.channel.name.name;
+                h.push_str(&format!("  uint32_t __{port}_{ch}_credit;\n"));
+                h.push_str(&format!("  uint8_t  __{port}_{ch}_can_send;\n"));
+            }
+            CreditChannelRole::Receiver => {
+                // PR-sim-2 — FIFO buffer, head/tail/occupancy, valid/data.
+            }
+        }
+    }
 }
 
-/// Append C++ constructor zero-initializers for each site to the buffer.
-pub fn emit_constructor_inits(_sites: &[CreditChannelSite], _cpp: &mut String) {
-    // PR-sim-1 / PR-sim-2 land here.
+/// Append C++ constructor zero-initializers for each site. Runs as a
+/// constructor-body fragment (not an init list) — each line is a plain
+/// `field = 0;` statement.
+pub fn emit_constructor_inits(sites: &[CreditChannelSite], cpp: &mut String) {
+    for s in sites {
+        match s.role {
+            CreditChannelRole::Sender => {
+                let port = &s.port_name;
+                let ch = &s.channel.name.name;
+                // Initial values match the SV reset semantics:
+                //   credit = DEPTH, can_send = (DEPTH != 0).
+                // DEPTH is a const param; we resolve its literal value
+                // below when we have one, else fall through to 0.
+                let depth = depth_literal(&s.channel).unwrap_or(0);
+                cpp.push_str(&format!("  __{port}_{ch}_credit = {depth};\n"));
+                cpp.push_str(&format!("  __{port}_{ch}_can_send = {};\n",
+                    if depth != 0 { 1 } else { 0 }));
+            }
+            CreditChannelRole::Receiver => {}
+        }
+    }
 }
 
-/// Append C++ `eval_posedge` update logic for each site to the buffer.
-/// `rst_active` is the C++ expression that evaluates to 1 when the
-/// module's reset is active (or `None` if the module has no reset port).
+/// Append C++ `eval_posedge` update logic for each site. Mirrors the SV
+/// `always_ff` emitted by codegen:
+///
+///   if (rst_active) { credit = DEPTH; can_send = (DEPTH != 0); }
+///   else if ( send_valid && !credit_return) credit--;
+///   else if (!send_valid &&  credit_return) credit++;
+///   (and can_send is re-derived in eval_comb — see emit_comb_updates)
+///
+/// `rst_active` is a C++ boolean expression that is true while reset is
+/// asserted. `None` means the module has no reset port; the reset branch
+/// is suppressed.
 pub fn emit_posedge_updates(
-    _sites: &[CreditChannelSite],
-    _rst_active: Option<&str>,
-    _cpp: &mut String,
+    sites: &[CreditChannelSite],
+    rst_active: Option<&str>,
+    cpp: &mut String,
 ) {
-    // PR-sim-1 / PR-sim-2 land here.
+    for s in sites {
+        match s.role {
+            CreditChannelRole::Sender => {
+                let port = &s.port_name;
+                let ch = &s.channel.name.name;
+                let credit = format!("__{port}_{ch}_credit");
+                let send_valid = format!("{port}_{ch}_send_valid");
+                let credit_ret = format!("{port}_{ch}_credit_return");
+                let depth = depth_literal(&s.channel).unwrap_or(0);
+                cpp.push_str("  {\n");
+                if let Some(r) = rst_active {
+                    cpp.push_str(&format!("    if ({r}) {{ {credit} = {depth}; }}\n"));
+                    cpp.push_str(&format!("    else if ({send_valid} && !{credit_ret}) {credit}--;\n"));
+                    cpp.push_str(&format!("    else if (!{send_valid} &&  {credit_ret}) {credit}++;\n"));
+                } else {
+                    cpp.push_str(&format!("    if ({send_valid} && !{credit_ret}) {credit}--;\n"));
+                    cpp.push_str(&format!("    else if (!{send_valid} &&  {credit_ret}) {credit}++;\n"));
+                }
+                cpp.push_str("  }\n");
+            }
+            CreditChannelRole::Receiver => {}
+        }
+    }
+}
+
+/// Append C++ `eval_comb` updates for each site. Handles the
+/// combinational `can_send` wire (and, for receivers, the `valid` /
+/// `data` wires — PR-sim-2).
+pub fn emit_comb_updates(sites: &[CreditChannelSite], cpp: &mut String) {
+    for s in sites {
+        match s.role {
+            CreditChannelRole::Sender => {
+                let port = &s.port_name;
+                let ch = &s.channel.name.name;
+                // Combinational can_send. If CAN_SEND_REGISTERED=1, this
+                // assignment is overridden at eval_posedge time (register
+                // holds its value between edges); keeping the comb
+                // assignment is still safe — it just recomputes what the
+                // flop already holds.
+                cpp.push_str(&format!(
+                    "  __{port}_{ch}_can_send = (__{port}_{ch}_credit != 0) ? 1 : 0;\n"
+                ));
+            }
+            CreditChannelRole::Receiver => {}
+        }
+    }
+}
+
+/// Resolve the channel's DEPTH param to an integer literal if possible.
+/// Returns None for non-literal expressions (param references etc.); the
+/// caller falls back to 0 (zero-init), matching the SV behavior of
+/// leaving the counter at DEPTH evaluated from the port-site param map.
+fn depth_literal(cc: &CreditChannelMeta) -> Option<u64> {
+    use crate::ast::{ExprKind, LitKind};
+    cc.params.iter()
+        .find(|p| p.name.name == "DEPTH")
+        .and_then(|p| p.default.as_ref())
+        .and_then(|e| match &e.kind {
+            ExprKind::Literal(LitKind::Dec(v))
+            | ExprKind::Literal(LitKind::Hex(v))
+            | ExprKind::Literal(LitKind::Bin(v))
+            | ExprKind::Literal(LitKind::Sized(_, v)) => Some(*v),
+            _ => None,
+        })
 }
 
 /// Convenience: C++ type for the payload type of a credit_channel.

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1918,6 +1918,9 @@ fn compile_to_sim_h(source: &str, inputs_start_uninit: bool) -> String {
     let mut parser = arch::parser::Parser::new(tokens, source);
     let parsed_ast = parser.parse_source_file().expect("parse error");
     let ast = arch::elaborate::elaborate(parsed_ast).expect("elaborate error");
+    let ast = arch::elaborate::lower_threads(ast).expect("lower threads error");
+    let ast = arch::elaborate::lower_pipe_reg_ports(ast).expect("lower pipe_reg error");
+    let ast = arch::elaborate::lower_credit_channel_dispatch(ast).expect("cc dispatch error");
     let symbols = arch::resolve::resolve(&ast).expect("resolve error");
     let checker = arch::typecheck::TypeChecker::new(&symbols, &ast);
     let (_warnings, overload_map) = checker.check().expect("type check error");
@@ -1925,8 +1928,11 @@ fn compile_to_sim_h(source: &str, inputs_start_uninit: bool) -> String {
         .check_uninit(inputs_start_uninit)
         .inputs_start_uninit(inputs_start_uninit);
     let models = sim.generate();
-    // Concatenate all model headers — tests can grep across them.
-    models.iter().map(|m| m.header.clone()).collect::<Vec<_>>().join("\n// ---\n")
+    // Concatenate all model headers + impl files — tests can grep across them.
+    models.iter()
+        .map(|m| format!("{}\n// ---\n{}", m.header, m.impl_))
+        .collect::<Vec<_>>()
+        .join("\n// ---\n")
 }
 
 #[test]
@@ -4084,6 +4090,47 @@ fn test_credit_channel_end_to_end_noc_producer_consumer() {
     // Read-side dispatch in seq and comb contexts
     assert!(sv.contains("last_seq <= __incoming_flits_data"),
         "read-side dispatch in seq:\n{sv}");
+}
+
+#[test]
+fn test_credit_channel_sim_emits_sender_state() {
+    // PR-sim-1: arch sim --pybind --test path now mirrors the sender-side
+    // credit counter. Verifies the C++ model contains the field, the
+    // constructor init, eval_comb's can_send assignment, and the
+    // eval_posedge counter update.
+    let source = "
+        bus DmaCh
+          credit_channel data: send
+            param T:     type  = UInt<8>;
+            param DEPTH: const = 4;
+          end credit_channel data
+        end bus DmaCh
+
+        use DmaCh;
+
+        module Prod
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync>;
+          port p:   initiator DmaCh;
+          comb
+            p.data_send_valid = 1'b0;
+            p.data_send_data  = 8'h0;
+          end comb
+        end module Prod
+    ";
+    let out = compile_to_sim_h(source, false);
+    assert!(out.contains("uint32_t __p_data_credit;"),
+        "sender credit field should be declared:\n{out}");
+    assert!(out.contains("uint8_t  __p_data_can_send;"),
+        "sender can_send field should be declared:\n{out}");
+    assert!(out.contains("__p_data_credit = 4;"),
+        "constructor should initialize credit to DEPTH:\n{out}");
+    assert!(out.contains("__p_data_can_send = (__p_data_credit != 0)"),
+        "eval_comb should assign can_send combinationally:\n{out}");
+    assert!(out.contains("__p_data_credit--"),
+        "eval_posedge should decrement on pure send:\n{out}");
+    assert!(out.contains("__p_data_credit++"),
+        "eval_posedge should increment on pure credit_return:\n{out}");
 }
 
 #[test]


### PR DESCRIPTION
PR-sim-1. Sender half of the arch sim credit_channel support.

- sim_credit_channel::emit_header_fields emits the credit + can_send fields on the module class.
- emit_constructor_inits zero/DEPTH-initialize them.
- emit_comb_updates computes can_send combinationally.
- emit_posedge_updates applies the counter update gated on the primary clock rising edge and the module's Reset<Kind,Polarity>.

compile_to_sim_h now runs the full pipeline (lower_threads, lower_pipe_reg_ports, lower_credit_channel_dispatch) so tests exercise the same AST flow as arch build.

cargo test: 131/131 pass (130 + 1 new sim regression).

Follow-ups: PR-sim-2 (receiver FIFO), PR-sim-3 (other construct types), PR-sim-4 (end-to-end pybind TB).