### PR TITLE
feat: parse target-side 'thread port.method(args) ... end' syntax

### DIFF
--- a/doc/ARCH_HDL_Specification.md
+++ b/doc/ARCH_HDL_Specification.md
@@ -4764,8 +4764,13 @@ Full design history and the broader roadmap are in `doc/plan_credit_channel.md` 
 
 **18d. First-Class Sub-Construct: tlm_method (inside bus)** — *parser scaffolding, v1 blocking only*
 
-> **Status (v0.44.10):** grammar is parsed, and the two-channel wire
-> protocol flattens at the bus port. Each `tlm_method name(args) ->
+> **Status (v0.44.11):** grammar is parsed, the two-channel wire
+> protocol flattens at the bus port, and the **target-side** `thread
+> port.method(args) on clk ..., rst ... ... end thread port.method`
+> shape is recognized by the parser. FSM lowering for the target body
+> (entry gate on req_valid, arg bindings, `return` → rsp drive) is
+> rejected by `lower_threads` with a targeted message and ships in the
+> next PR. Each `tlm_method name(args) ->
 > Ret: blocking;` produces `<name>_req_valid`, `<name>_<arg>` per arg,
 > `<name>_req_ready`, `<name>_rsp_valid`, `<name>_rsp_data` (omitted
 > for void methods), `<name>_rsp_ready` — directions from the

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -444,8 +444,26 @@ pub struct ThreadBlock {
     /// When `cond` is true in any state, the listed seq assigns fire and the
     /// thread returns to state 0, taking priority over normal transitions.
     pub default_when: Option<(Expr, Vec<ThreadStmt>)>,
+    /// Set when the thread is a TLM method target body:
+    ///   `thread PORT.METHOD(ARG1, ARG2, ...) on clk rising, rst high`.
+    /// Captured at parse time (PR-tlm-3); lowering to an FSM (entry gate
+    /// on req_valid, arg bindings, `return` → rsp drive) ships next.
+    pub tlm_target: Option<TlmTargetBinding>,
     pub body: Vec<ThreadStmt>,
     pub span: Span,
+}
+
+/// Binding of a `thread` body to a TLM method declaration on a bus port.
+/// See `doc/plan_tlm_method.md` for the lowering semantics.
+#[derive(Debug, Clone)]
+pub struct TlmTargetBinding {
+    /// Bus port name that carries the method (e.g. `s`).
+    pub port: Ident,
+    /// Method name (e.g. `read`).
+    pub method: Ident,
+    /// Argument names bound as thread-local values for the body.
+    /// Types come from the bus's `TlmMethodMeta.args` at lowering time.
+    pub args: Vec<Ident>,
 }
 
 /// A statement inside a thread block.

--- a/src/elaborate.rs
+++ b/src/elaborate.rs
@@ -774,6 +774,7 @@ fn subst_thread(t: &ThreadBlock, var: &str, val: i64) -> ThreadBlock {
             subst_expr_names(cond.clone(), var, val),
             stmts.iter().map(|s| subst_thread_stmt(s, var, val)).collect(),
         )),
+        tlm_target: t.tlm_target.clone(),
         body: t.body.iter().map(|s| subst_thread_stmt(s, var, val)).collect(),
         span: t.span,
     }
@@ -1203,6 +1204,21 @@ fn lower_module_threads(m: ModuleDecl) -> Result<(ModuleDecl, Vec<Item>), Vec<Co
     for item in m.body {
         match item {
             ModuleBodyItem::Thread(t) => {
+                // PR-tlm-3 scaffolding: TLM target-side thread bodies
+                // (`thread port.method(args) ...`) are recognized by the
+                // parser but FSM lowering (entry gate on req_valid, arg
+                // bindings, `return` → rsp drive) ships in a follow-up PR.
+                // Reject cleanly so users get a targeted message rather
+                // than a surprise from the generic thread lowering.
+                if let Some(ref t_binding) = t.tlm_target {
+                    return Err(vec![CompileError::general(
+                        &format!(
+                            "TLM target thread body `thread {}.{}(...)` lowering is not yet implemented — tracked in doc/plan_tlm_method.md PR-tlm-3b/4.",
+                            t_binding.port.name, t_binding.method.name
+                        ),
+                        t.span,
+                    )]);
+                }
                 let name = t.name.as_ref()
                     .map(|n| n.name.clone())
                     .unwrap_or_else(|| {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1186,11 +1186,33 @@ impl Parser {
         if once { self.advance(); }
 
         // Optional name — peek: if we see Ident followed by `on`, it's a name.
-        // If we see `on` directly, no name.
-        let name = if self.check(TokenKind::On) {
-            None
+        // If we see `on` directly, no name. If we see `Ident . Ident (`, this
+        // is a TLM target binding: `thread port.method(args) on clk ...`.
+        let (name, tlm_target) = if self.check(TokenKind::On) {
+            (None, None)
         } else {
-            Some(self.expect_ident()?)
+            let first = self.expect_ident()?;
+            if self.check(TokenKind::Dot) {
+                self.advance(); // consume `.`
+                let method = self.expect_ident()?;
+                self.expect(TokenKind::LParen)?;
+                let mut args = Vec::new();
+                if !self.check(TokenKind::RParen) {
+                    loop {
+                        args.push(self.expect_ident()?);
+                        if self.check(TokenKind::Comma) { self.advance(); } else { break; }
+                    }
+                }
+                self.expect(TokenKind::RParen)?;
+                // The thread's display name for `end thread X.Y` matching
+                // stays as the `port` ident; closing match accepts either
+                // form (`end thread port` or `end thread port.method`).
+                (Some(first.clone()), Some(TlmTargetBinding {
+                    port: first, method, args,
+                }))
+            } else {
+                (Some(first), None)
+            }
         };
 
         // Clock clause: `on CLK rising|falling`
@@ -1261,6 +1283,19 @@ impl Parser {
                     &n.name, &closing_name.name, closing_name.span,
                 ));
             }
+            // TLM target: `end thread port.method` is allowed (and
+            // recommended for readability) but `end thread port` is
+            // also accepted.
+            if tlm_target.is_some() && self.check(TokenKind::Dot) {
+                self.advance();
+                let method_close = self.expect_ident()?;
+                let declared = tlm_target.as_ref().unwrap().method.name.clone();
+                if method_close.name != declared {
+                    return Err(CompileError::mismatched_closing(
+                        &declared, &method_close.name, method_close.span,
+                    ));
+                }
+            }
             end_span = closing_name.span;
         } else if once {
             // `end thread once`
@@ -1278,6 +1313,7 @@ impl Parser {
             reset_level,
             once,
             default_when,
+            tlm_target,
             body,
             span: start.merge(end_span),
         })

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -4269,6 +4269,103 @@ fn test_tlm_method_void_omits_rsp_data() {
 }
 
 #[test]
+fn test_tlm_target_thread_parses_with_dotted_name() {
+    // PR-tlm-3 scaffolding: parser recognizes
+    //   `thread port.method(arg1, arg2, ...) on clk rising, rst high`
+    // and stores the TLM target binding on the ThreadBlock.
+    let source = "
+        bus Mem
+          tlm_method read(addr: UInt<32>) -> UInt<64>: blocking;
+        end bus Mem
+
+        use Mem;
+
+        module MemTarget
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync>;
+          port s:   target Mem;
+          port ready: in Bool;
+          thread s.read(addr) on clk rising, rst high
+            wait until ready;
+          end thread s.read
+        end module MemTarget
+    ";
+    let tokens = arch::lexer::tokenize(source).expect("lexer");
+    let mut parser = arch::parser::Parser::new(tokens, source);
+    let ast = parser.parse_source_file().expect("parse");
+    let m = ast.items.iter().find_map(|it| match it {
+        arch::ast::Item::Module(m) if m.name.name == "MemTarget" => Some(m),
+        _ => None,
+    }).expect("MemTarget in AST");
+    let t = m.body.iter().find_map(|i| match i {
+        arch::ast::ModuleBodyItem::Thread(t) => Some(t),
+        _ => None,
+    }).expect("thread in MemTarget body");
+    let binding = t.tlm_target.as_ref().expect("tlm_target should be populated");
+    assert_eq!(binding.port.name, "s");
+    assert_eq!(binding.method.name, "read");
+    assert_eq!(binding.args.len(), 1);
+    assert_eq!(binding.args[0].name, "addr");
+}
+
+#[test]
+fn test_tlm_target_thread_rejected_in_lower_threads() {
+    let source = "
+        bus Mem
+          tlm_method read(addr: UInt<32>) -> UInt<64>: blocking;
+        end bus Mem
+
+        use Mem;
+
+        module MemTarget
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync>;
+          port s:   target Mem;
+          port ready: in Bool;
+          thread s.read(addr) on clk rising, rst high
+            wait until ready;
+          end thread s.read
+        end module MemTarget
+    ";
+    let tokens = arch::lexer::tokenize(source).expect("lexer");
+    let mut parser = arch::parser::Parser::new(tokens, source);
+    let ast = parser.parse_source_file().expect("parse");
+    let ast = arch::elaborate::elaborate(ast).expect("elaborate");
+    let result = arch::elaborate::lower_threads(ast);
+    assert!(result.is_err(), "lower_threads should reject TLM target threads until PR-tlm-3b lands");
+    let errs = result.unwrap_err();
+    let msg = format!("{:?}", errs);
+    assert!(msg.contains("TLM target") && msg.contains("not yet implemented"),
+        "expected scaffolding error, got: {msg}");
+}
+
+#[test]
+fn test_tlm_target_thread_accepts_matched_closing_method_name() {
+    // Closing `end thread port.method` should match the opening.
+    let source = "
+        bus Mem
+          tlm_method read(addr: UInt<32>) -> UInt<64>: blocking;
+        end bus Mem
+
+        use Mem;
+
+        module MemTarget
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync>;
+          port s:   target Mem;
+          port ready: in Bool;
+          thread s.read(addr) on clk rising, rst high
+            wait until ready;
+          end thread s.wrong_method
+        end module MemTarget
+    ";
+    let tokens = arch::lexer::tokenize(source).expect("lexer");
+    let mut parser = arch::parser::Parser::new(tokens, source);
+    assert!(parser.parse_source_file().is_err(),
+        "mismatched closing method name should be a parse error");
+}
+
+#[test]
 fn test_tlm_method_target_perspective_flips() {
     let source = "
         bus Mem


### PR DESCRIPTION
PR-tlm-3 (parser half). Extends thread grammar to accept a TLM target-binding form.

- AST: new TlmTargetBinding { port, method, args } on ThreadBlock.
- Parser: dotted name with arg list maps to this binding.
- Closing tag matches either 'end thread port' or 'end thread port.method'.
- lower_threads rejects TLM target threads with a targeted scaffolding message — FSM lowering ships in a follow-up PR.

cargo test: 140/140 pass (137 + 3 new regressions).

Follow-ups: PR-tlm-3b (target FSM lowering), PR-tlm-4 (initiator call site), PR-tlm-5 (SVA), PR-tlm-6 (sim_codegen).