### PR TITLE
feat: ThreadStmt::Return variant + parser for TLM target thread bodies

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -489,6 +489,11 @@ pub enum ThreadStmt {
     DoUntil { body: Vec<ThreadStmt>, cond: Expr, span: Span },
     /// `log(Level, "TAG", "fmt", args...);` — debug output
     Log(LogStmt),
+    /// `return expr;` — valid only inside a TLM target thread body
+    /// (`thread port.method(args) ...`). The `lower_tlm_target_threads`
+    /// pass rewrites this into the rsp_valid / rsp_data / wait_for_ready
+    /// sequence before regular thread lowering runs.
+    Return(Expr, Span),
 }
 
 /// Generic if/else statement, parameterized by statement body type `S`.

--- a/src/elaborate.rs
+++ b/src/elaborate.rs
@@ -827,6 +827,7 @@ fn subst_thread_stmt(stmt: &ThreadStmt, var: &str, val: i64) -> ThreadStmt {
             span: *span,
         },
         ThreadStmt::Log(l) => ThreadStmt::Log(l.clone()),
+        ThreadStmt::Return(e, span) => ThreadStmt::Return(subst_expr_names(e.clone(), var, val), *span),
     }
 }
 
@@ -1979,6 +1980,9 @@ fn collect_thread_signals(body: &[ThreadStmt]) -> (HashSet<String>, HashSet<Stri
                     collect_expr_reads(cond, all_read);
                 }
                 ThreadStmt::Log(_) => {}
+                ThreadStmt::Return(e, _) => {
+                    collect_expr_reads(e, all_read);
+                }
             }
         }
     }
@@ -2448,6 +2452,18 @@ fn partition_thread_body(
                     wait_cycles: None,
                     multi_transitions: Vec::new(),
                 });
+            }
+            ThreadStmt::Return(_, span) => {
+                // `return expr;` is only valid inside a TLM method target
+                // thread body, which has its own dedicated lowering pass
+                // that rewrites Return into the rsp_valid/rsp_data drive
+                // sequence before this pass runs. Reaching this arm means
+                // a regular thread contained `return`, which is a user
+                // error.
+                return Err(CompileError::general(
+                    "`return` is only valid inside a TLM method target thread (`thread port.method(args) ...`). Remove the return or wrap the body in a TLM target binding.",
+                    *span,
+                ));
             }
         }
     }
@@ -2962,6 +2978,7 @@ fn rewrite_loop_var(stmt: &ThreadStmt, var: &str, replacement: &str) -> ThreadSt
             span: *span,
         },
         ThreadStmt::Log(l) => ThreadStmt::Log(l.clone()),
+        ThreadStmt::Return(e, span) => ThreadStmt::Return(rewrite_var_expr(e.clone(), var, replacement), *span),
     }
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1357,6 +1357,16 @@ impl Parser {
             return Ok(ThreadStmt::Log(self.parse_log_stmt()?));
         }
 
+        // `return expr;` — valid only inside TLM method target threads.
+        // Parser is scope-blind so we accept it here; lower_threads
+        // produces a targeted error if used in a non-TLM-target thread.
+        if self.check(TokenKind::Return) {
+            let start = self.advance().span;
+            let value = self.parse_expr()?;
+            let semi_span = self.expect(TokenKind::Semi)?.span;
+            return Ok(ThreadStmt::Return(value, start.merge(semi_span)));
+        }
+
         // `wait` (contextual keyword)
         if self.check_ident("wait") {
             let wait_start = self.advance().span;

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -4340,6 +4340,70 @@ fn test_tlm_target_thread_rejected_in_lower_threads() {
 }
 
 #[test]
+fn test_tlm_target_thread_parses_return_stmt() {
+    // PR-tlm-3b: `return expr;` inside a thread body is now a valid
+    // ThreadStmt::Return variant. (lower_threads still rejects TLM
+    // target threads; FSM rewrite lands in PR-tlm-3c.)
+    let source = "
+        bus Mem
+          tlm_method read(addr: UInt<32>) -> UInt<64>: blocking;
+        end bus Mem
+
+        use Mem;
+
+        module MemTarget
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync>;
+          port s:   target Mem;
+          port ready: in Bool;
+          thread s.read(addr) on clk rising, rst high
+            wait until ready;
+            return 64'h42;
+          end thread s.read
+        end module MemTarget
+    ";
+    let tokens = arch::lexer::tokenize(source).expect("lexer");
+    let mut parser = arch::parser::Parser::new(tokens, source);
+    let ast = parser.parse_source_file().expect("parse");
+    let m = ast.items.iter().find_map(|it| match it {
+        arch::ast::Item::Module(m) if m.name.name == "MemTarget" => Some(m),
+        _ => None,
+    }).expect("MemTarget in AST");
+    let t = m.body.iter().find_map(|i| match i {
+        arch::ast::ModuleBodyItem::Thread(t) => Some(t),
+        _ => None,
+    }).expect("thread in body");
+    let has_return = t.body.iter().any(|s| matches!(s, arch::ast::ThreadStmt::Return(_, _)));
+    assert!(has_return, "body should contain a Return stmt");
+}
+
+#[test]
+fn test_return_in_regular_thread_errors_in_lower_threads() {
+    // `return` outside a TLM target thread is a user error — hit by
+    // lower_threads with a targeted message.
+    let source = "
+        module M
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync>;
+          port reg out_r: out UInt<8> reset rst => 0;
+          thread stray on clk rising, rst high
+            out_r <= 8'h1;
+            return 8'h2;
+          end thread stray
+        end module M
+    ";
+    let tokens = arch::lexer::tokenize(source).expect("lexer");
+    let mut parser = arch::parser::Parser::new(tokens, source);
+    let ast = parser.parse_source_file().expect("parse");
+    let ast = arch::elaborate::elaborate(ast).expect("elaborate");
+    let result = arch::elaborate::lower_threads(ast);
+    assert!(result.is_err(), "regular thread with return should error");
+    let msg = format!("{:?}", result.unwrap_err());
+    assert!(msg.contains("return") && msg.contains("TLM method target thread"),
+        "expected targeted error, got: {msg}");
+}
+
+#[test]
 fn test_tlm_target_thread_accepts_matched_closing_method_name() {
     // Closing `end thread port.method` should match the opening.
     let source = "


### PR DESCRIPTION
PR-tlm-3b. AST + parser groundwork for 'return expr;' inside TLM target thread bodies.

- New ThreadStmt::Return(Expr, Span) variant.
- Parser accepts 'return expr;' inside any thread body.
- elaborate match sites get passthrough arms; main thread-to-FSM converter rejects Return in non-TLM threads with a targeted error.

Actual FSM rewrite for TLM target threads ships in PR-tlm-3c (entry gate on req_valid, arg latching, return → rsp drive sequence).

cargo test: 142/142 pass (140 + 2 new).