### PR TITLE
feat: TLM target thread FSM lowering

### DIFF
--- a/doc/ARCH_HDL_Specification.md
+++ b/doc/ARCH_HDL_Specification.md
@@ -4764,13 +4764,17 @@ Full design history and the broader roadmap are in `doc/plan_credit_channel.md` 
 
 **18d. First-Class Sub-Construct: tlm_method (inside bus)** — *parser scaffolding, v1 blocking only*
 
-> **Status (v0.44.11):** grammar is parsed, the two-channel wire
-> protocol flattens at the bus port, and the **target-side** `thread
-> port.method(args) on clk ..., rst ... ... end thread port.method`
-> shape is recognized by the parser. FSM lowering for the target body
-> (entry gate on req_valid, arg bindings, `return` → rsp drive) is
-> rejected by `lower_threads` with a targeted message and ships in the
-> next PR. Each `tlm_method name(args) ->
+> **Status (v0.44.12):** grammar, wire flattening, and target-side
+> thread body lowering are all live. `lower_tlm_target_threads`
+> (runs before the generic thread lowering) rewrites
+> `thread port.method(args) ... return expr; end` into a regular
+> thread that drives `<port>_<method>_req_ready`, latches args into
+> synthesized `__tlm_<port>_<method>_<arg>_latched` regs, and turns
+> each `return expr;` into the
+> `rsp_valid=1; rsp_data=expr; wait until rsp_ready;` sequence. The
+> thread's natural loop-back (non-`once`) carries control back to the
+> entry state to accept the next request. Initiator call-site
+> lowering, Tier-2 SVA, and sim mirror ship in the remaining PRs. Each `tlm_method name(args) ->
 > Ret: blocking;` produces `<name>_req_valid`, `<name>_<arg>` per arg,
 > `<name>_req_ready`, `<name>_rsp_valid`, `<name>_rsp_data` (omitted
 > for void methods), `<name>_rsp_ready` — directions from the

--- a/src/elaborate.rs
+++ b/src/elaborate.rs
@@ -1205,16 +1205,15 @@ fn lower_module_threads(m: ModuleDecl) -> Result<(ModuleDecl, Vec<Item>), Vec<Co
     for item in m.body {
         match item {
             ModuleBodyItem::Thread(t) => {
-                // PR-tlm-3 scaffolding: TLM target-side thread bodies
-                // (`thread port.method(args) ...`) are recognized by the
-                // parser but FSM lowering (entry gate on req_valid, arg
-                // bindings, `return` → rsp drive) ships in a follow-up PR.
-                // Reject cleanly so users get a targeted message rather
-                // than a surprise from the generic thread lowering.
+                // TLM target threads are rewritten into regular threads
+                // by lower_tlm_target_threads (runs before lower_threads).
+                // Any surviving tlm_target here means the pass wasn't
+                // invoked — defensive error to catch a caller that
+                // skipped the transform.
                 if let Some(ref t_binding) = t.tlm_target {
                     return Err(vec![CompileError::general(
                         &format!(
-                            "TLM target thread body `thread {}.{}(...)` lowering is not yet implemented — tracked in doc/plan_tlm_method.md PR-tlm-3b/4.",
+                            "internal error: TLM target thread `{}.{}(...)` reached lower_threads without being rewritten. Call `lower_tlm_target_threads` first.",
                             t_binding.port.name, t_binding.method.name
                         ),
                         t.span,
@@ -3748,5 +3747,268 @@ fn rewrite_expr_cc(e: &mut Expr, ctx: &CcDispatchCtx) {
                 }
             }
         }
+    }
+}
+
+// ── TLM target thread lowering (PR-tlm-3c) ──────────────────────────────────
+//
+// Transforms each `thread port.method(args) ... end` body into a regular
+// thread that:
+//  1. Waits for `<port>_<method>_req_valid`, driving
+//     `<port>_<method>_req_ready = 1` while waiting (accept-on-transition).
+//  2. Latches each declared arg from the request bus into a synthesized
+//     reg `__tlm_<port>_<method>_<arg>_latched` (SeqAssign fires on
+//     transition, i.e. the cycle the request is accepted).
+//  3. Executes the user body with arg ident references rewritten to the
+//     latched reg names.
+//  4. Rewrites each `return expr;` into the response drive sequence:
+//     `rsp_valid = 1; rsp_data = expr; wait until rsp_ready;`.
+//  5. Loops back to state 0 via the normal non-`once` thread semantics.
+//
+// Runs before lower_threads. Synthesized latch regs are injected as
+// RegDecls at the start of the module body.
+
+pub fn lower_tlm_target_threads(ast: SourceFile) -> Result<SourceFile, Vec<CompileError>> {
+    use std::collections::HashMap;
+    // Build {bus_name -> Vec<TlmMethodMeta>}.
+    let mut bus_methods: HashMap<String, Vec<TlmMethodMeta>> = HashMap::new();
+    for it in &ast.items {
+        match it {
+            Item::Bus(b) => {
+                if !b.tlm_methods.is_empty() {
+                    bus_methods.insert(b.name.name.clone(), b.tlm_methods.clone());
+                }
+            }
+            Item::Package(pkg) => {
+                for b in &pkg.buses {
+                    if !b.tlm_methods.is_empty() {
+                        bus_methods.insert(b.name.name.clone(), b.tlm_methods.clone());
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    if bus_methods.is_empty() { return Ok(ast); }
+
+    let mut out_items: Vec<Item> = Vec::with_capacity(ast.items.len());
+    let mut errors: Vec<CompileError> = Vec::new();
+    for it in ast.items {
+        match it {
+            Item::Module(mut m) => {
+                // Build port → bus_name map for this module.
+                let port_buses: HashMap<String, String> = m.ports.iter()
+                    .filter_map(|p| p.bus_info.as_ref().map(|bi|
+                        (p.name.name.clone(), bi.bus_name.name.clone())))
+                    .collect();
+
+                // Collect TLM target threads + their method metadata.
+                let mut latch_regs: Vec<RegDecl> = Vec::new();
+                let mut new_body: Vec<ModuleBodyItem> = Vec::new();
+                for item in std::mem::take(&mut m.body) {
+                    if let ModuleBodyItem::Thread(t) = &item {
+                        if let Some(binding) = t.tlm_target.clone() {
+                            let bus_name = match port_buses.get(&binding.port.name) {
+                                Some(b) => b.clone(),
+                                None => {
+                                    errors.push(CompileError::general(
+                                        &format!(
+                                            "thread `{}.{}(...)` references port `{}` which is not a bus port on module `{}`",
+                                            binding.port.name, binding.method.name, binding.port.name, m.name.name,
+                                        ),
+                                        binding.port.span,
+                                    ));
+                                    new_body.push(item);
+                                    continue;
+                                }
+                            };
+                            let method = match bus_methods.get(&bus_name)
+                                .and_then(|v| v.iter().find(|mm| mm.name.name == binding.method.name))
+                            {
+                                Some(m) => m.clone(),
+                                None => {
+                                    errors.push(CompileError::general(
+                                        &format!(
+                                            "bus `{}` has no `tlm_method {}` matching `thread {}.{}(...)`",
+                                            bus_name, binding.method.name, binding.port.name, binding.method.name,
+                                        ),
+                                        binding.method.span,
+                                    ));
+                                    new_body.push(item);
+                                    continue;
+                                }
+                            };
+                            // Arg count / name check.
+                            if binding.args.len() != method.args.len() {
+                                errors.push(CompileError::general(
+                                    &format!(
+                                        "`thread {}.{}(...)` takes {} args but `tlm_method {}` declares {}",
+                                        binding.port.name, binding.method.name, binding.args.len(),
+                                        method.name.name, method.args.len(),
+                                    ),
+                                    binding.method.span,
+                                ));
+                                new_body.push(item);
+                                continue;
+                            }
+                            let t_moved = if let ModuleBodyItem::Thread(t) = item { t } else { unreachable!() };
+                            let (new_thread, mut regs) = lower_one_tlm_target(t_moved, &binding, &method);
+                            latch_regs.append(&mut regs);
+                            new_body.push(ModuleBodyItem::Thread(new_thread));
+                        } else {
+                            new_body.push(item);
+                        }
+                    } else {
+                        new_body.push(item);
+                    }
+                }
+                // Prepend latch regs so they're declared before any seq block
+                // that might reference them.
+                let mut combined: Vec<ModuleBodyItem> =
+                    latch_regs.into_iter().map(ModuleBodyItem::RegDecl).collect();
+                combined.extend(new_body);
+                m.body = combined;
+                out_items.push(Item::Module(m));
+            }
+            other => out_items.push(other),
+        }
+    }
+    if !errors.is_empty() { return Err(errors); }
+    Ok(SourceFile { items: out_items })
+}
+
+fn lower_one_tlm_target(
+    t: ThreadBlock,
+    binding: &TlmTargetBinding,
+    method: &TlmMethodMeta,
+) -> (ThreadBlock, Vec<RegDecl>) {
+    let port = &binding.port.name;
+    let method_name = &binding.method.name;
+    let span = t.span;
+    let mk_ident = |name: String| Ident { name, span };
+    let mk_port_member = |member: String| Expr::new(
+        ExprKind::FieldAccess(
+            Box::new(Expr::new(ExprKind::Ident(port.clone()), span)),
+            mk_ident(member),
+        ),
+        span,
+    );
+    let lit_true = Expr::new(ExprKind::Literal(LitKind::Sized(1, 1)), span);
+
+    // Latch regs + arg rename map.
+    let mut latch_regs: Vec<RegDecl> = Vec::new();
+    let mut arg_renames: Vec<(String, String)> = Vec::new();
+    let mut preamble: Vec<ThreadStmt> = Vec::new();
+    preamble.push(ThreadStmt::CombAssign(CombAssign {
+        target: mk_port_member(format!("{method_name}_req_ready")),
+        value: lit_true.clone(),
+        span,
+    }));
+    for (i, (user_arg, method_arg)) in binding.args.iter()
+        .zip(method.args.iter())
+        .enumerate()
+    {
+        let latch_name = format!("__tlm_{port}_{method_name}_{}_latched", method_arg.0.name);
+        latch_regs.push(RegDecl {
+            name: mk_ident(latch_name.clone()),
+            ty: method_arg.1.clone(),
+            init: None,
+            reset: RegReset::None,
+            guard: None,
+            span,
+        });
+        // SeqAssign: <latch> <= <port>.<method>_<arg>
+        preamble.push(ThreadStmt::SeqAssign(RegAssign {
+            target: Expr::new(ExprKind::Ident(latch_name.clone()), span),
+            value: mk_port_member(format!("{method_name}_{}", method_arg.0.name)),
+            span,
+        }));
+        arg_renames.push((user_arg.name.clone(), latch_name));
+        let _ = i;
+    }
+    preamble.push(ThreadStmt::WaitUntil(
+        mk_port_member(format!("{method_name}_req_valid")),
+        span,
+    ));
+
+    // Rewrite user body: rename args to latched names, replace Return.
+    let rewritten_body: Vec<ThreadStmt> = t.body.into_iter()
+        .map(|s| rewrite_tlm_body_stmt(s, port, method_name, &arg_renames, method.ret.is_some()))
+        .flatten()
+        .collect();
+
+    let mut final_body = preamble;
+    final_body.extend(rewritten_body);
+
+    let new_thread = ThreadBlock {
+        name: Some(mk_ident(format!("__tlm_{port}_{method_name}"))),
+        clock: t.clock,
+        clock_edge: t.clock_edge,
+        reset: t.reset,
+        reset_level: t.reset_level,
+        once: false,
+        default_when: t.default_when,
+        tlm_target: None,
+        body: final_body,
+        span: t.span,
+    };
+    (new_thread, latch_regs)
+}
+
+fn rewrite_tlm_body_stmt(
+    s: ThreadStmt,
+    port: &str,
+    method: &str,
+    arg_renames: &[(String, String)],
+    has_ret: bool,
+) -> Vec<ThreadStmt> {
+    // Helper: rename arg idents in an expression.
+    let rename_args = |e: Expr| -> Expr {
+        let mut cur = e;
+        for (from, to) in arg_renames {
+            cur = rewrite_var_expr(cur, from, to);
+        }
+        cur
+    };
+    match s {
+        ThreadStmt::Return(e, span) => {
+            let expr = rename_args(e);
+            let mk_field = |member: String| Expr::new(
+                ExprKind::FieldAccess(
+                    Box::new(Expr::new(ExprKind::Ident(port.to_string()), span)),
+                    Ident { name: member, span },
+                ),
+                span,
+            );
+            let one = Expr::new(ExprKind::Literal(LitKind::Sized(1, 1)), span);
+            let mut out = vec![
+                ThreadStmt::CombAssign(CombAssign {
+                    target: mk_field(format!("{method}_rsp_valid")),
+                    value: one,
+                    span,
+                }),
+            ];
+            if has_ret {
+                out.push(ThreadStmt::CombAssign(CombAssign {
+                    target: mk_field(format!("{method}_rsp_data")),
+                    value: expr,
+                    span,
+                }));
+            }
+            out.push(ThreadStmt::WaitUntil(mk_field(format!("{method}_rsp_ready")), span));
+            out
+        }
+        ThreadStmt::CombAssign(ca) => vec![ThreadStmt::CombAssign(CombAssign {
+            target: rename_args(ca.target),
+            value: rename_args(ca.value),
+            span: ca.span,
+        })],
+        ThreadStmt::SeqAssign(ra) => vec![ThreadStmt::SeqAssign(RegAssign {
+            target: rename_args(ra.target),
+            value: rename_args(ra.value),
+            span: ra.span,
+        })],
+        ThreadStmt::WaitUntil(cond, span) => vec![ThreadStmt::WaitUntil(rename_args(cond), span)],
+        other => vec![other], // IfElse / ForkJoin / For / Lock / DoUntil / Log / WaitCycles — arg-rename deferred
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -995,6 +995,14 @@ fn run_check_multi(
         ms.report_error(err)
     })?;
 
+    // Rewrite TLM target threads (`thread port.method(args) ...`) into
+    // regular threads that drive the req/rsp handshake. Must run before
+    // the generic lower_threads, which rejects TLM-bound threads.
+    let ast = elaborate::lower_tlm_target_threads(ast).map_err(|errs| {
+        let err = errs.into_iter().next().unwrap();
+        ms.report_error(err)
+    })?;
+
     // Lower thread blocks to FSM + inst
     let ast = elaborate::lower_threads(ast).map_err(|errs| {
         let err = errs.into_iter().next().unwrap();

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -10,6 +10,7 @@ fn compile_to_sv(source: &str) -> String {
     let mut parser = Parser::new(tokens, source);
     let parsed_ast = parser.parse_source_file().expect("parse error");
     let ast = elaborate::elaborate(parsed_ast).expect("elaborate error");
+    let ast = elaborate::lower_tlm_target_threads(ast).expect("tlm_target lowering error");
     let ast = elaborate::lower_threads(ast).expect("lower_threads error");
     let ast = elaborate::lower_pipe_reg_ports(ast).expect("lower_pipe_reg_ports error");
     let ast = elaborate::lower_credit_channel_dispatch(ast).expect("credit_channel dispatch error");
@@ -4309,7 +4310,10 @@ fn test_tlm_target_thread_parses_with_dotted_name() {
 }
 
 #[test]
-fn test_tlm_target_thread_rejected_in_lower_threads() {
+fn test_tlm_target_thread_lowers_to_regular_thread() {
+    // PR-tlm-3c: lower_tlm_target_threads rewrites a TLM target thread
+    // into a regular thread + synthesized latch regs. The tlm_target
+    // field is cleared after the pass.
     let source = "
         bus Mem
           tlm_method read(addr: UInt<32>) -> UInt<64>: blocking;
@@ -4324,6 +4328,7 @@ fn test_tlm_target_thread_rejected_in_lower_threads() {
           port ready: in Bool;
           thread s.read(addr) on clk rising, rst high
             wait until ready;
+            return 64'h42;
           end thread s.read
         end module MemTarget
     ";
@@ -4331,12 +4336,22 @@ fn test_tlm_target_thread_rejected_in_lower_threads() {
     let mut parser = arch::parser::Parser::new(tokens, source);
     let ast = parser.parse_source_file().expect("parse");
     let ast = arch::elaborate::elaborate(ast).expect("elaborate");
-    let result = arch::elaborate::lower_threads(ast);
-    assert!(result.is_err(), "lower_threads should reject TLM target threads until PR-tlm-3b lands");
-    let errs = result.unwrap_err();
-    let msg = format!("{:?}", errs);
-    assert!(msg.contains("TLM target") && msg.contains("not yet implemented"),
-        "expected scaffolding error, got: {msg}");
+    let ast = arch::elaborate::lower_tlm_target_threads(ast).expect("tlm lowering");
+    let m = ast.items.iter().find_map(|it| match it {
+        arch::ast::Item::Module(m) if m.name.name == "MemTarget" => Some(m),
+        _ => None,
+    }).expect("MemTarget");
+    // After lowering, thread.tlm_target is cleared.
+    let t = m.body.iter().find_map(|i| match i {
+        arch::ast::ModuleBodyItem::Thread(t) => Some(t),
+        _ => None,
+    }).expect("thread");
+    assert!(t.tlm_target.is_none(), "tlm_target should be cleared after lowering");
+    // Synthesized latch reg injected.
+    let has_latch = m.body.iter().any(|i| matches!(
+        i, arch::ast::ModuleBodyItem::RegDecl(r) if r.name.name == "__tlm_s_read_addr_latched"
+    ));
+    assert!(has_latch, "latch reg should be injected");
 }
 
 #[test]


### PR DESCRIPTION
PR-tlm-3c. Rewrites 'thread port.method(args) ... return expr; end' into a regular thread that drives the req/rsp handshake.

- New pass lower_tlm_target_threads runs before lower_threads.
- Injects per-arg latch regs, entry gate on req_valid, return→rsp drive sequence.
- lower_threads now only errors defensively if tlm_target survives.

cargo test: 142/142 pass.

Follow-ups: PR-tlm-4 (initiator call site), PR-tlm-5 (SVA), PR-tlm-6 (sim_codegen), PR-tlm-7 (docs + canonical test).