### PR TITLE
feat: TLM initiator call-site lowering (partial, AST-level)

### DIFF
--- a/doc/ARCH_HDL_Specification.md
+++ b/doc/ARCH_HDL_Specification.md
@@ -4764,8 +4764,15 @@ Full design history and the broader roadmap are in `doc/plan_credit_channel.md` 
 
 **18d. First-Class Sub-Construct: tlm_method (inside bus)** — *parser scaffolding, v1 blocking only*
 
-> **Status (v0.44.12):** grammar, wire flattening, and target-side
-> thread body lowering are all live. `lower_tlm_target_threads`
+> **Status (v0.44.13):** grammar, wire flattening, target-side thread
+> body lowering, and **initiator call-site expansion**
+> (`d <= m.method(args);` inside a thread body) are all live at the AST
+> level. Known limitation for v1: the thread-state drives of flattened
+> bus-port members (`m.method_req_valid`, etc.) trip the comb-block
+> no-latch check at typecheck — works around by refactoring through a
+> local reg. Tracked in `doc/plan_tlm_method.md`; proper fix extends
+> `lower_threads` to treat FieldAccess-on-bus-port targets as flat
+> signals for default emission. `lower_tlm_target_threads`
 > (runs before the generic thread lowering) rewrites
 > `thread port.method(args) ... return expr; end` into a regular
 > thread that drives `<port>_<method>_req_ready`, latches args into

--- a/src/elaborate.rs
+++ b/src/elaborate.rs
@@ -4012,3 +4012,221 @@ fn rewrite_tlm_body_stmt(
         other => vec![other], // IfElse / ForkJoin / For / Lock / DoUntil / Log / WaitCycles — arg-rename deferred
     }
 }
+
+// ── TLM initiator call-site lowering (PR-tlm-4) ─────────────────────────────
+//
+// Recognizes `target_reg <= port.method(args);` as a TLM call site inside a
+// thread body and expands it into the two-state issue + wait-response
+// sequence described in doc/plan_tlm_method.md §Lowering. Call sites
+// outside this shape are rejected with a targeted message.
+
+pub fn lower_tlm_initiator_calls(ast: SourceFile) -> Result<SourceFile, Vec<CompileError>> {
+    use std::collections::HashMap;
+    let mut bus_methods: HashMap<String, Vec<TlmMethodMeta>> = HashMap::new();
+    for it in &ast.items {
+        match it {
+            Item::Bus(b) => {
+                if !b.tlm_methods.is_empty() {
+                    bus_methods.insert(b.name.name.clone(), b.tlm_methods.clone());
+                }
+            }
+            Item::Package(pkg) => {
+                for b in &pkg.buses {
+                    if !b.tlm_methods.is_empty() {
+                        bus_methods.insert(b.name.name.clone(), b.tlm_methods.clone());
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    if bus_methods.is_empty() { return Ok(ast); }
+
+    let mut errors: Vec<CompileError> = Vec::new();
+    let mut out_items: Vec<Item> = Vec::with_capacity(ast.items.len());
+    for it in ast.items {
+        match it {
+            Item::Module(mut m) => {
+                let port_buses: HashMap<String, String> = m.ports.iter()
+                    .filter_map(|p| p.bus_info.as_ref().map(|bi|
+                        (p.name.name.clone(), bi.bus_name.name.clone())))
+                    .collect();
+                for bi in &mut m.body {
+                    if let ModuleBodyItem::Thread(t) = bi {
+                        if t.tlm_target.is_some() { continue; } // target-side, already handled
+                        let body = std::mem::take(&mut t.body);
+                        t.body = body.into_iter()
+                            .flat_map(|s| rewrite_thread_stmt_for_init_calls(s, &port_buses, &bus_methods, &mut errors))
+                            .collect();
+                    }
+                }
+                out_items.push(Item::Module(m));
+            }
+            other => out_items.push(other),
+        }
+    }
+    if !errors.is_empty() { return Err(errors); }
+    Ok(SourceFile { items: out_items })
+}
+
+fn rewrite_thread_stmt_for_init_calls(
+    s: ThreadStmt,
+    port_buses: &std::collections::HashMap<String, String>,
+    bus_methods: &std::collections::HashMap<String, Vec<TlmMethodMeta>>,
+    errors: &mut Vec<CompileError>,
+) -> Vec<ThreadStmt> {
+    match s {
+        ThreadStmt::SeqAssign(ra) => {
+            if let Some(call) = match_tlm_call(&ra.value, port_buses, bus_methods) {
+                // Check no TLM calls nested in the LHS (shouldn't be any).
+                if contains_tlm_call(&ra.target, port_buses, bus_methods) {
+                    errors.push(CompileError::general(
+                        "TLM method calls cannot appear on the LHS of an assignment",
+                        ra.span,
+                    ));
+                    return vec![ThreadStmt::SeqAssign(ra)];
+                }
+                return expand_tlm_call_site(ra.target, call, ra.span);
+            }
+            // Defensive: reject nested TLM calls in a non-TLM-RHS expression.
+            if contains_tlm_call(&ra.value, port_buses, bus_methods) {
+                errors.push(CompileError::general(
+                    "TLM method call must be the direct right-hand side of `<=` in a thread body — nested or composed uses are not supported in v1",
+                    ra.span,
+                ));
+            }
+            vec![ThreadStmt::SeqAssign(ra)]
+        }
+        ThreadStmt::CombAssign(ca) => {
+            if contains_tlm_call(&ca.value, port_buses, bus_methods)
+                || contains_tlm_call(&ca.target, port_buses, bus_methods)
+            {
+                errors.push(CompileError::general(
+                    "TLM method calls must live on the right-hand side of a non-blocking assign (`<=`) in a thread body; combinational assignment rejected",
+                    ca.span,
+                ));
+            }
+            vec![ThreadStmt::CombAssign(ca)]
+        }
+        ThreadStmt::IfElse(ie) => {
+            let mut new_then = Vec::new();
+            for s in ie.then_stmts {
+                new_then.extend(rewrite_thread_stmt_for_init_calls(s, port_buses, bus_methods, errors));
+            }
+            let mut new_else = Vec::new();
+            for s in ie.else_stmts {
+                new_else.extend(rewrite_thread_stmt_for_init_calls(s, port_buses, bus_methods, errors));
+            }
+            vec![ThreadStmt::IfElse(IfElseOf {
+                cond: ie.cond,
+                then_stmts: new_then,
+                else_stmts: new_else,
+                unique: ie.unique,
+                span: ie.span,
+            })]
+        }
+        other => vec![other],
+    }
+}
+
+struct TlmCall {
+    port: String,
+    method: String,
+    args: Vec<Expr>,
+    method_meta: TlmMethodMeta,
+}
+
+fn match_tlm_call(
+    e: &Expr,
+    port_buses: &std::collections::HashMap<String, String>,
+    bus_methods: &std::collections::HashMap<String, Vec<TlmMethodMeta>>,
+) -> Option<TlmCall> {
+    if let ExprKind::MethodCall(recv, method, args) = &e.kind {
+        if let ExprKind::Ident(port_name) = &recv.kind {
+            let bus = port_buses.get(port_name)?;
+            let methods = bus_methods.get(bus)?;
+            let meta = methods.iter().find(|m| m.name.name == method.name)?;
+            return Some(TlmCall {
+                port: port_name.clone(),
+                method: method.name.clone(),
+                args: args.clone(),
+                method_meta: meta.clone(),
+            });
+        }
+    }
+    None
+}
+
+fn contains_tlm_call(
+    e: &Expr,
+    port_buses: &std::collections::HashMap<String, String>,
+    bus_methods: &std::collections::HashMap<String, Vec<TlmMethodMeta>>,
+) -> bool {
+    if match_tlm_call(e, port_buses, bus_methods).is_some() { return true; }
+    match &e.kind {
+        ExprKind::Binary(_, l, r) => contains_tlm_call(l, port_buses, bus_methods) || contains_tlm_call(r, port_buses, bus_methods),
+        ExprKind::Unary(_, x) | ExprKind::Cast(x, _) | ExprKind::Clog2(x)
+        | ExprKind::Onehot(x) | ExprKind::Signed(x) | ExprKind::Unsigned(x)
+        | ExprKind::LatencyAt(x, _) => contains_tlm_call(x, port_buses, bus_methods),
+        ExprKind::Index(b, i) => contains_tlm_call(b, port_buses, bus_methods) || contains_tlm_call(i, port_buses, bus_methods),
+        ExprKind::FieldAccess(b, _) => contains_tlm_call(b, port_buses, bus_methods),
+        ExprKind::MethodCall(recv, _, args) => {
+            contains_tlm_call(recv, port_buses, bus_methods)
+                || args.iter().any(|a| contains_tlm_call(a, port_buses, bus_methods))
+        }
+        ExprKind::Ternary(c, t, el) => contains_tlm_call(c, port_buses, bus_methods) || contains_tlm_call(t, port_buses, bus_methods) || contains_tlm_call(el, port_buses, bus_methods),
+        ExprKind::Concat(xs) | ExprKind::FunctionCall(_, xs) => xs.iter().any(|x| contains_tlm_call(x, port_buses, bus_methods)),
+        ExprKind::Repeat(n, x) => contains_tlm_call(n, port_buses, bus_methods) || contains_tlm_call(x, port_buses, bus_methods),
+        _ => false,
+    }
+}
+
+fn expand_tlm_call_site(dest: Expr, call: TlmCall, span: Span) -> Vec<ThreadStmt> {
+    let port = &call.port;
+    let method = &call.method;
+    let mk_ident = |name: String| Ident { name, span };
+    let mk_field = |member: String| Expr::new(
+        ExprKind::FieldAccess(
+            Box::new(Expr::new(ExprKind::Ident(port.clone()), span)),
+            mk_ident(member),
+        ),
+        span,
+    );
+    let one = Expr::new(ExprKind::Literal(LitKind::Sized(1, 1)), span);
+
+    let mut out: Vec<ThreadStmt> = Vec::new();
+    // Issue state comb drives
+    out.push(ThreadStmt::CombAssign(CombAssign {
+        target: mk_field(format!("{method}_req_valid")),
+        value: one.clone(),
+        span,
+    }));
+    for (i, (arg_name, _arg_ty)) in call.method_meta.args.iter().enumerate() {
+        if let Some(arg_expr) = call.args.get(i) {
+            out.push(ThreadStmt::CombAssign(CombAssign {
+                target: mk_field(format!("{method}_{}", arg_name.name)),
+                value: arg_expr.clone(),
+                span,
+            }));
+        }
+    }
+    // Transition: wait for req_ready. This closes the issue state.
+    out.push(ThreadStmt::WaitUntil(mk_field(format!("{method}_req_ready")), span));
+
+    // Wait-response state: drive rsp_ready; capture rsp_data on transition;
+    // transition on rsp_valid.
+    out.push(ThreadStmt::CombAssign(CombAssign {
+        target: mk_field(format!("{method}_rsp_ready")),
+        value: one,
+        span,
+    }));
+    if call.method_meta.ret.is_some() {
+        out.push(ThreadStmt::SeqAssign(RegAssign {
+            target: dest,
+            value: mk_field(format!("{method}_rsp_data")),
+            span,
+        }));
+    }
+    out.push(ThreadStmt::WaitUntil(mk_field(format!("{method}_rsp_valid")), span));
+    out
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1003,6 +1003,13 @@ fn run_check_multi(
         ms.report_error(err)
     })?;
 
+    // Expand initiator-side TLM call sites (`x <= m.method(args);`) in
+    // thread bodies into the issue + wait-response state pair.
+    let ast = elaborate::lower_tlm_initiator_calls(ast).map_err(|errs| {
+        let err = errs.into_iter().next().unwrap();
+        ms.report_error(err)
+    })?;
+
     // Lower thread blocks to FSM + inst
     let ast = elaborate::lower_threads(ast).map_err(|errs| {
         let err = errs.into_iter().next().unwrap();

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2636,13 +2636,13 @@ impl Parser {
                 // Method call with paren args: .reverse(N), plus the
                 // Vec reduction/predicate family (any/all/count/contains/
                 // reduce_or/reduce_and/reduce_xor).
-                let paren_method = self.check(TokenKind::LParen)
-                    && matches!(field.name.as_str(),
-                        "reverse" | "any" | "all" | "count" | "contains"
-                        | "reduce_or" | "reduce_and" | "reduce_xor"
-                        | "find_first"
-                        // credit_channel write-side sugar (PR #3b-vi).
-                        | "send" | "pop");
+                // Any `ident . ident (` shape parses as a method call —
+                // there is no syntactic ambiguity at this point (function
+                // calls in ARCH are `Name(args)`, never `recv.name(args)`).
+                // Historically this was an allowlist (`reverse`, `any`,
+                // `send`, `pop`, etc.) but that prevented user-defined
+                // TLM method names from parsing cleanly.
+                let paren_method = self.check(TokenKind::LParen);
                 if paren_method {
                     self.advance(); // (
                     let mut args = Vec::new();

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -11,6 +11,7 @@ fn compile_to_sv(source: &str) -> String {
     let parsed_ast = parser.parse_source_file().expect("parse error");
     let ast = elaborate::elaborate(parsed_ast).expect("elaborate error");
     let ast = elaborate::lower_tlm_target_threads(ast).expect("tlm_target lowering error");
+    let ast = elaborate::lower_tlm_initiator_calls(ast).expect("tlm_initiator lowering error");
     let ast = elaborate::lower_threads(ast).expect("lower_threads error");
     let ast = elaborate::lower_pipe_reg_ports(ast).expect("lower_pipe_reg_ports error");
     let ast = elaborate::lower_credit_channel_dispatch(ast).expect("credit_channel dispatch error");
@@ -4307,6 +4308,92 @@ fn test_tlm_target_thread_parses_with_dotted_name() {
     assert_eq!(binding.method.name, "read");
     assert_eq!(binding.args.len(), 1);
     assert_eq!(binding.args[0].name, "addr");
+}
+
+#[test]
+fn test_tlm_initiator_call_site_expands_in_ast() {
+    // PR-tlm-4: `d <= m.read(arg);` expands to the two-state issue +
+    // wait-response sequence. Verified at the AST level (post-pass)
+    // because the end-to-end SV pipeline trips the no-latch check on
+    // bus-port-member drives from thread states — a known limitation
+    // documented in doc/plan_tlm_method.md §Open questions. Users
+    // should refactor through a local handshake in the meantime.
+    let source = "
+        bus Mem
+          tlm_method read(addr: UInt<32>) -> UInt<64>: blocking;
+        end bus Mem
+
+        use Mem;
+
+        module Initiator
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync>;
+          port m:   initiator Mem;
+          reg   d:  UInt<64> reset rst => 0;
+          thread driver on clk rising, rst high
+            d <= m.read(32'h1000);
+          end thread driver
+        end module Initiator
+    ";
+    let tokens = arch::lexer::tokenize(source).expect("lexer");
+    let mut parser = arch::parser::Parser::new(tokens, source);
+    let ast = parser.parse_source_file().expect("parse");
+    let ast = arch::elaborate::elaborate(ast).expect("elaborate");
+    let ast = arch::elaborate::lower_tlm_target_threads(ast).expect("tlm target");
+    let ast = arch::elaborate::lower_tlm_initiator_calls(ast).expect("tlm init");
+    let m = ast.items.iter().find_map(|it| match it {
+        arch::ast::Item::Module(m) if m.name.name == "Initiator" => Some(m),
+        _ => None,
+    }).expect("Initiator module");
+    let t = m.body.iter().find_map(|i| match i {
+        arch::ast::ModuleBodyItem::Thread(t) => Some(t),
+        _ => None,
+    }).expect("thread");
+    // Single `d <= m.read(...)` should have become multiple stmts
+    // (CombAssigns for req_valid/arg/rsp_ready + SeqAssign for rsp_data
+    // + two WaitUntils). Expect at least 5 statements.
+    assert!(t.body.len() >= 5,
+        "initiator call site should expand to multiple stmts, got {}: {:?}",
+        t.body.len(), t.body);
+    // At least one WaitUntil (req_ready), and a second (rsp_valid).
+    let wait_count = t.body.iter()
+        .filter(|s| matches!(s, arch::ast::ThreadStmt::WaitUntil(_, _)))
+        .count();
+    assert!(wait_count >= 2,
+        "expected >=2 WaitUntils (req_ready + rsp_valid), got {wait_count}");
+}
+
+#[test]
+fn test_tlm_call_rejected_outside_seq_assign_rhs() {
+    // Arithmetic on a TLM call RHS is not supported in v1 — must be
+    // direct.
+    let source = "
+        bus Mem
+          tlm_method read(addr: UInt<32>) -> UInt<64>: blocking;
+        end bus Mem
+
+        use Mem;
+
+        module Bad
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync>;
+          port m:   initiator Mem;
+          reg   d:  UInt<64> reset rst => 0;
+          thread driver on clk rising, rst high
+            d <= m.read(32'h1000) + 64'h1;
+          end thread driver
+        end module Bad
+    ";
+    let tokens = arch::lexer::tokenize(source).expect("lexer");
+    let mut parser = arch::parser::Parser::new(tokens, source);
+    let ast = parser.parse_source_file().expect("parse");
+    let ast = arch::elaborate::elaborate(ast).expect("elaborate");
+    let ast = arch::elaborate::lower_tlm_target_threads(ast).expect("tlm target");
+    let r = arch::elaborate::lower_tlm_initiator_calls(ast);
+    assert!(r.is_err(), "nested TLM call in RHS should be rejected");
+    let msg = format!("{:?}", r.unwrap_err());
+    assert!(msg.contains("direct right-hand side") || msg.contains("direct"),
+        "expected direct-RHS error, got: {msg}");
 }
 
 #[test]


### PR DESCRIPTION
PR-tlm-4. Expands 'd <= m.method(args);' inside a thread body into the issue + wait-response FSM sequence at the AST level.

New pass lower_tlm_initiator_calls runs before lower_threads. Non-direct TLM calls in RHS (or on LHS, or in comb assigns) are rejected with targeted errors.

Parser change: removed the paren_method allowlist so user-defined TLM method names parse cleanly.

Known v1 limitation: end-to-end SV compilation still trips the no-latch check on bus-port-member drives from thread states. Requires a separate lower_threads fix — tracked in plan_tlm_method.md. AST-level test verifies the pass emits the expected stmt sequence.

cargo test: 144/144 pass (142 + 2 new).