### PR TITLE
feat: parse 'reentrant [max N]' clause on thread declarations

### DIFF
--- a/doc/ARCH_HDL_Specification.md
+++ b/doc/ARCH_HDL_Specification.md
@@ -1552,6 +1552,8 @@ end thread Name
 
 **Repeating vs once**: by default a thread loops — after the last body statement it returns to state 0. Write `thread once Name on …` to stop in the terminal state instead.
 
+**Reentrant (parser-accepted in v0.44.17+, lowering pending)**: a thread may be declared `reentrant [max N]` after the reset clause. A reentrant thread allows a fresh invocation to start as soon as the previous one hits a `wait` or blocking call, up to `max N` concurrent instances. Use case: pipelining TLM method calls inside a single thread body without inventing new `Future<T>`/`await` syntax. Grammar is parsed today; FSM-cloning lowering ships in a follow-up PR (tracked in `doc/plan_tlm_pipelined.md`). Until then, a reentrant thread is a compile error with a targeted scaffolding-only message.
+
 **Multiple threads** in one module are declared independently; they all compile into the same `_ModuleName_threads` submodule and share one `always_ff` block to avoid multi-driver conflicts.
 
 **`generate_for` over threads:**

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -449,6 +449,15 @@ pub struct ThreadBlock {
     /// Captured at parse time (PR-tlm-3); lowering to an FSM (entry gate
     /// on req_valid, arg bindings, `return` → rsp drive) ships next.
     pub tlm_target: Option<TlmTargetBinding>,
+    /// Reentrant threads allow a fresh invocation to start before the
+    /// previous one completes. Captured at parse time by the optional
+    /// `reentrant [max N]` clause on the thread header (see
+    /// `doc/plan_tlm_pipelined.md`). Encoding:
+    ///   - `None`                  — v1 semantics; exactly one instance.
+    ///   - `Some(None)`            — `reentrant` alone (unbounded — v1
+    ///     lowering rejects; reserved for future use).
+    ///   - `Some(Some(Expr))`      — `reentrant max <expr>` (const-reducible).
+    pub reentrant: Option<Option<Expr>>,
     pub body: Vec<ThreadStmt>,
     pub span: Span,
 }

--- a/src/elaborate.rs
+++ b/src/elaborate.rs
@@ -775,6 +775,7 @@ fn subst_thread(t: &ThreadBlock, var: &str, val: i64) -> ThreadBlock {
             stmts.iter().map(|s| subst_thread_stmt(s, var, val)).collect(),
         )),
         tlm_target: t.tlm_target.clone(),
+        reentrant: t.reentrant.clone(),
         body: t.body.iter().map(|s| subst_thread_stmt(s, var, val)).collect(),
         span: t.span,
     }
@@ -1216,6 +1217,15 @@ fn lower_module_threads(m: ModuleDecl) -> Result<(ModuleDecl, Vec<Item>), Vec<Co
                             "internal error: TLM target thread `{}.{}(...)` reached lower_threads without being rewritten. Call `lower_tlm_target_threads` first.",
                             t_binding.port.name, t_binding.method.name
                         ),
+                        t.span,
+                    )]);
+                }
+                // PR-tlm-p1 scaffolding: reentrant threads parse but the
+                // N-instance FSM lowering ships in PR-tlm-p2 (non-TLM)
+                // and PR-tlm-p3 (with issue arbiter for TLM calls).
+                if t.reentrant.is_some() {
+                    return Err(vec![CompileError::general(
+                        "`reentrant` thread lowering is not yet implemented — tracked in doc/plan_tlm_pipelined.md PR-tlm-p2/p3.",
                         t.span,
                     )]);
                 }
@@ -3949,6 +3959,7 @@ fn lower_one_tlm_target(
         once: false,
         default_when: t.default_when,
         tlm_target: None,
+        reentrant: None,
         body: final_body,
         span: t.span,
     };

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1245,6 +1245,20 @@ impl Parser {
             ));
         };
 
+        // Optional `reentrant [max <expr>]` clause — PR-tlm-p1 scaffolding.
+        // Stored on ThreadBlock.reentrant; lowering ships in PR-tlm-p2/p3.
+        let reentrant = if self.check_ident("reentrant") {
+            self.advance();
+            if self.check_ident("max") {
+                self.advance();
+                Some(Some(self.parse_expr()?))
+            } else {
+                Some(None)
+            }
+        } else {
+            None
+        };
+
         // Optional `default when <cond> ... end default` — must come first in the body.
         let default_when = if self.check(TokenKind::Default) {
             let _kw = self.advance(); // consume `default`
@@ -1314,6 +1328,7 @@ impl Parser {
             once,
             default_when,
             tlm_target,
+            reentrant,
             body,
             span: start.merge(end_span),
         })

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -4473,6 +4473,90 @@ fn test_tlm_canonical_end_to_end_initiator_plus_target() {
 }
 
 #[test]
+fn test_reentrant_thread_parses_with_max() {
+    // PR-tlm-p1: `reentrant max N` clause parses into
+    // ThreadBlock.reentrant = Some(Some(Expr::Literal(N))).
+    let source = "
+        module M
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync>;
+          port reg out_r: out UInt<8> reset rst => 0;
+          thread driver on clk rising, rst high reentrant max 8
+            out_r <= 8'h1;
+          end thread driver
+        end module M
+    ";
+    let tokens = arch::lexer::tokenize(source).expect("lexer");
+    let mut parser = arch::parser::Parser::new(tokens, source);
+    let ast = parser.parse_source_file().expect("parse");
+    let m = ast.items.iter().find_map(|it| match it {
+        arch::ast::Item::Module(m) if m.name.name == "M" => Some(m),
+        _ => None,
+    }).expect("module M");
+    let t = m.body.iter().find_map(|i| match i {
+        arch::ast::ModuleBodyItem::Thread(t) => Some(t),
+        _ => None,
+    }).expect("thread");
+    match &t.reentrant {
+        Some(Some(_)) => {} // OK — bounded
+        other => panic!("expected Some(Some(Expr)) for `reentrant max 8`, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_reentrant_thread_parses_without_max() {
+    let source = "
+        module M
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync>;
+          port reg out_r: out UInt<8> reset rst => 0;
+          thread driver on clk rising, rst high reentrant
+            out_r <= 8'h1;
+          end thread driver
+        end module M
+    ";
+    let tokens = arch::lexer::tokenize(source).expect("lexer");
+    let mut parser = arch::parser::Parser::new(tokens, source);
+    let ast = parser.parse_source_file().expect("parse");
+    let m = ast.items.iter().find_map(|it| match it {
+        arch::ast::Item::Module(m) if m.name.name == "M" => Some(m),
+        _ => None,
+    }).expect("module M");
+    let t = m.body.iter().find_map(|i| match i {
+        arch::ast::ModuleBodyItem::Thread(t) => Some(t),
+        _ => None,
+    }).expect("thread");
+    assert!(matches!(t.reentrant, Some(None)),
+        "expected Some(None) for unbounded reentrant, got {:?}", t.reentrant);
+}
+
+#[test]
+fn test_reentrant_thread_rejected_in_lower_threads() {
+    // PR-tlm-p1 scaffolding: lowering ships in PR-tlm-p2/p3.
+    let source = "
+        module M
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync>;
+          port reg out_r: out UInt<8> reset rst => 0;
+          thread driver on clk rising, rst high reentrant max 4
+            out_r <= 8'h1;
+          end thread driver
+        end module M
+    ";
+    let tokens = arch::lexer::tokenize(source).expect("lexer");
+    let mut parser = arch::parser::Parser::new(tokens, source);
+    let ast = parser.parse_source_file().expect("parse");
+    let ast = arch::elaborate::elaborate(ast).expect("elaborate");
+    let ast = arch::elaborate::lower_tlm_target_threads(ast).expect("tlm target");
+    let ast = arch::elaborate::lower_tlm_initiator_calls(ast).expect("tlm init");
+    let result = arch::elaborate::lower_threads(ast);
+    assert!(result.is_err(), "reentrant thread should be rejected until PR-tlm-p2/p3 land");
+    let msg = format!("{:?}", result.unwrap_err());
+    assert!(msg.contains("reentrant") && msg.contains("not yet implemented"),
+        "expected scaffolding error, got: {msg}");
+}
+
+#[test]
 fn test_tlm_call_rejected_outside_seq_assign_rhs() {
     // Arithmetic on a TLM call RHS is not supported in v1 — must be
     // direct.


### PR DESCRIPTION
PR-tlm-p1. Grammar + AST + scaffolding reject for the reentrant-thread pipelining model.

- Parser accepts 'reentrant' and 'reentrant max <expr>' after the reset clause.
- AST: ThreadBlock.reentrant: Option<Option<Expr>>.
- lower_threads rejects reentrant threads with a targeted scaffolding error until PR-tlm-p2/p3 land.

cargo test: 150/150 pass.

Follow-ups: PR-tlm-p2 (non-TLM reentrant lowering), PR-tlm-p3 (TLM issue arbiter + response routing), PR-tlm-p4 (docs + canonical pipelined test).