### PR TITLE
feat: detect multi-thread TLM method sharing + targeted diagnostic

### DIFF
--- a/src/elaborate.rs
+++ b/src/elaborate.rs
@@ -4062,6 +4062,52 @@ pub fn lower_tlm_initiator_calls(ast: SourceFile) -> Result<SourceFile, Vec<Comp
                     .filter_map(|p| p.bus_info.as_ref().map(|bi|
                         (p.name.name.clone(), bi.bus_name.name.clone())))
                     .collect();
+
+                // Detect multi-thread sharing of a (port, method) pair. v2a
+                // plan (doc/plan_tlm_pipelined.md) routes these through an
+                // arbiter + response-routing FIFO synthesized at module
+                // scope. The actual arbiter machinery is tracked as
+                // PR-tlm-p3b; for now emit a targeted diagnostic so users
+                // don't hit the confusing 'multi-driver on req_valid' that
+                // the naive existing inline lowering produces.
+                let mut method_uses: HashMap<(String, String), Vec<Span>> = HashMap::new();
+                for item in &m.body {
+                    if let ModuleBodyItem::Thread(t) = item {
+                        if t.tlm_target.is_some() { continue; }
+                        if !thread_body_has_tlm_call(&t.body, &port_buses, &bus_methods) { continue; }
+                        for stmt in &t.body {
+                            if let ThreadStmt::SeqAssign(ra) = stmt {
+                                if let Some(call) = match_tlm_call(&ra.value, &port_buses, &bus_methods) {
+                                    method_uses.entry((call.port.clone(), call.method.clone()))
+                                        .or_default()
+                                        .push(t.span);
+                                }
+                            }
+                        }
+                    }
+                }
+                for ((port, method), spans) in &method_uses {
+                    // Count distinct threads — spans may repeat if one
+                    // thread calls the same method multiple times.
+                    let mut sorted_offsets: Vec<(usize, usize)> = spans.iter()
+                        .map(|s| (s.start, s.end)).collect();
+                    sorted_offsets.sort();
+                    sorted_offsets.dedup();
+                    if sorted_offsets.len() > 1 {
+                        errors.push(CompileError::general(
+                            &format!(
+                                "multi-thread sharing of `{port}.{method}` is not yet implemented — {n} threads in the current module issue calls on this method. The compiler arbiter + response-routing that enables this (the `generate for` pipelining pattern) is tracked as PR-tlm-p3b in doc/plan_tlm_pipelined.md. Single-thread access works today.",
+                                n = sorted_offsets.len(),
+                            ),
+                            *spans.first().unwrap(),
+                        ));
+                    }
+                }
+                if !errors.is_empty() {
+                    out_items.push(Item::Module(m));
+                    continue;
+                }
+
                 // Identify threads that contain TLM calls and inline them.
                 let mut new_body: Vec<ModuleBodyItem> = Vec::new();
                 for item in std::mem::take(&mut m.body) {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -4557,6 +4557,67 @@ fn test_reentrant_thread_rejected_in_lower_threads() {
 }
 
 #[test]
+fn test_tlm_multi_thread_sharing_gets_targeted_error() {
+    // PR-tlm-p3a: multi-thread sharing of a TLM method produces a
+    // targeted error (not a cryptic multi-driver diagnostic) until
+    // the arbiter + routing machinery lands in PR-tlm-p3b.
+    let source = "
+        bus Mem
+          tlm_method read(addr: UInt<32>) -> UInt<64>: blocking;
+        end bus Mem
+
+        use Mem;
+
+        module Shared
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync>;
+          port m:   initiator Mem;
+          reg   d0: UInt<64> reset rst => 0;
+          reg   d1: UInt<64> reset rst => 0;
+          thread w0 on clk rising, rst high
+            d0 <= m.read(32'h1000);
+          end thread w0
+          thread w1 on clk rising, rst high
+            d1 <= m.read(32'h1004);
+          end thread w1
+        end module Shared
+    ";
+    let tokens = arch::lexer::tokenize(source).expect("lexer");
+    let mut parser = arch::parser::Parser::new(tokens, source);
+    let ast = parser.parse_source_file().expect("parse");
+    let ast = arch::elaborate::elaborate(ast).expect("elaborate");
+    let ast = arch::elaborate::lower_tlm_target_threads(ast).expect("tlm target");
+    let r = arch::elaborate::lower_tlm_initiator_calls(ast);
+    assert!(r.is_err(), "2-thread sharing of a TLM method should error until PR-tlm-p3b");
+    let msg = format!("{:?}", r.unwrap_err());
+    assert!(msg.contains("multi-thread sharing") && msg.contains("m.read"),
+        "expected targeted diagnostic, got: {msg}");
+}
+
+#[test]
+fn test_tlm_single_thread_unchanged() {
+    // Single-thread case must still compile end-to-end.
+    let source = "
+        bus Mem
+          tlm_method read(addr: UInt<32>) -> UInt<64>: blocking;
+        end bus Mem
+
+        use Mem;
+
+        module Single
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync>;
+          port m:   initiator Mem;
+          reg   d:  UInt<64> reset rst => 0;
+          thread driver on clk rising, rst high
+            d <= m.read(32'h1000);
+          end thread driver
+        end module Single
+    ";
+    let _sv = compile_to_sv(source);
+}
+
+#[test]
 fn test_tlm_call_rejected_outside_seq_assign_rhs() {
     // Arithmetic on a TLM call RHS is not supported in v1 — must be
     // direct.


### PR DESCRIPTION
PR-tlm-p3a. Pre-flight groundwork for auto-arbitration.

Detects multi-thread sharing of a TLM method and produces a targeted error pointing at PR-tlm-p3b (the actual arbiter work). Single-thread case unchanged.

cargo test: 152/152 pass.

Follow-up: PR-tlm-p3b builds the round-robin arbiter + issue FIFO + response routing when N>1 threads share a (port, method) pair.