### PR TITLE
feat: diagnose unlocked multi-thread TLM sharing; shelve pipelined mode

### DIFF
--- a/doc/plan_tlm_pipelined.md
+++ b/doc/plan_tlm_pipelined.md
@@ -1,4 +1,28 @@
-# Plan: `tlm_method` pipelined via multi-thread arbitration (v2a)
+# Plan: `tlm_method` pipelined — **SHELVED** (2026-04-23)
+
+> **Shelved per design review (2026-04-23).** The concurrency-mode
+> label `pipelined` doesn't buy capability beyond what users already
+> express with `generate for threads` + `lock RESOURCE` (for request
+> serialization) + ID-tagged responses (for routing). See
+> `tests/axi_dma_thread/ThreadMm2s.arch` for the canonical
+> multi-outstanding AXI pattern — it uses these building blocks
+> without any dedicated TLM "pipelined" support.
+>
+> The genuinely new capability is **`out_of_order`** mode (auto-route
+> responses by ID tag); that's the next real v2 target. Tracking in
+> a future `plan_tlm_out_of_order.md`.
+>
+> `reentrant` grammar on ThreadBlock (merged in PR #86) stays as
+> dead-but-parsed code; removal or repurposing is a future cleanup.
+> A targeted diagnostic (PR-tlm-p3) points users at the
+> `lock RESOURCE` idiom for multi-thread TLM sharing today.
+>
+> Historical design below kept for context — the reentrant thread
+> and Future<T>/await sketches led to the current framing.
+
+---
+
+# (Historical) Plan: `tlm_method` pipelined via multi-thread arbitration (v2a)
 
 *Author: session of 2026-04-22. Supersedes the earlier `Future<T>`/
 `await` sketch and the `reentrant thread` sketch. Builds on

--- a/src/elaborate.rs
+++ b/src/elaborate.rs
@@ -4062,6 +4062,46 @@ pub fn lower_tlm_initiator_calls(ast: SourceFile) -> Result<SourceFile, Vec<Comp
                     .filter_map(|p| p.bus_info.as_ref().map(|bi|
                         (p.name.name.clone(), bi.bus_name.name.clone())))
                     .collect();
+
+                // Detect unlocked multi-thread sharing of a (port, method)
+                // pair. ARCH's existing `lock RESOURCE` construct serializes
+                // bus-channel drives across threads; wrapping each TLM call
+                // in a lock makes the resource mutex handle request-side
+                // arbitration uniformly with other shared-channel idioms
+                // (AXI AR/AW in ThreadMm2s, etc.). Without lock, multiple
+                // threads drive `<port>_<method>_req_valid` simultaneously
+                // and the later single-driver check fires a confusing
+                // multi-driver error. Emit a targeted diagnostic here
+                // pointing at the lock/resource idiom.
+                {
+                    let mut bare_uses: HashMap<(String, String), Vec<Span>> = HashMap::new();
+                    for item in &m.body {
+                        if let ModuleBodyItem::Thread(t) = item {
+                            if t.tlm_target.is_some() { continue; }
+                            collect_bare_tlm_calls(&t.body, t.span, &port_buses, &bus_methods, &mut bare_uses);
+                        }
+                    }
+                    for ((port, method), spans) in &bare_uses {
+                        let mut sorted_offsets: Vec<(usize, usize)> = spans.iter()
+                            .map(|s| (s.start, s.end)).collect();
+                        sorted_offsets.sort();
+                        sorted_offsets.dedup();
+                        if sorted_offsets.len() > 1 {
+                            errors.push(CompileError::general(
+                                &format!(
+                                    "multi-thread sharing of `{port}.{method}` without a `lock` — {n} threads issue calls on this method outside any lock block. Wrap each call in `lock <res> ... end lock <res>` and declare `resource <res>: mutex<round_robin>;` at module scope. Lock serializes request-side drive across threads (same idiom as AXI AR/AW sharing). Concurrent-in-flight pipelining ships with `out_of_order` mode (v2b).",
+                                    n = sorted_offsets.len(),
+                                ),
+                                *spans.first().unwrap(),
+                            ));
+                        }
+                    }
+                }
+                if !errors.is_empty() {
+                    out_items.push(Item::Module(m));
+                    continue;
+                }
+
                 // Identify threads that contain TLM calls and inline them.
                 let mut new_body: Vec<ModuleBodyItem> = Vec::new();
                 for item in std::mem::take(&mut m.body) {
@@ -4089,6 +4129,46 @@ pub fn lower_tlm_initiator_calls(ast: SourceFile) -> Result<SourceFile, Vec<Comp
     }
     if !errors.is_empty() { return Err(errors); }
     Ok(SourceFile { items: out_items })
+}
+
+/// Walk a thread body and record spans of any TLM call that is NOT
+/// inside a `lock RESOURCE ... end lock` block. Used by the multi-
+/// thread sharing diagnostic in `lower_tlm_initiator_calls` — calls
+/// wrapped in a lock are considered safely serialized by the existing
+/// resource-mutex machinery, so we skip them.
+fn collect_bare_tlm_calls(
+    stmts: &[ThreadStmt],
+    thread_span: Span,
+    port_buses: &std::collections::HashMap<String, String>,
+    bus_methods: &std::collections::HashMap<String, Vec<TlmMethodMeta>>,
+    out: &mut std::collections::HashMap<(String, String), Vec<Span>>,
+) {
+    for s in stmts {
+        match s {
+            ThreadStmt::SeqAssign(ra) => {
+                if let Some(call) = match_tlm_call(&ra.value, port_buses, bus_methods) {
+                    out.entry((call.port.clone(), call.method.clone()))
+                        .or_default()
+                        .push(thread_span);
+                }
+            }
+            ThreadStmt::Lock { .. } => {
+                // TLM calls inside a lock are serialized by the resource
+                // mutex — not a multi-driver hazard. Skip.
+            }
+            ThreadStmt::IfElse(ie) => {
+                collect_bare_tlm_calls(&ie.then_stmts, thread_span, port_buses, bus_methods, out);
+                collect_bare_tlm_calls(&ie.else_stmts, thread_span, port_buses, bus_methods, out);
+            }
+            ThreadStmt::For { body, .. } => {
+                collect_bare_tlm_calls(body, thread_span, port_buses, bus_methods, out);
+            }
+            ThreadStmt::DoUntil { body, .. } => {
+                collect_bare_tlm_calls(body, thread_span, port_buses, bus_methods, out);
+            }
+            _ => {}
+        }
+    }
 }
 
 fn thread_body_has_tlm_call(

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -4557,6 +4557,43 @@ fn test_reentrant_thread_rejected_in_lower_threads() {
 }
 
 #[test]
+fn test_tlm_multi_thread_sharing_without_lock_errors() {
+    // Multi-thread sharing of a TLM method outside any lock block →
+    // targeted diagnostic pointing at the lock/resource idiom.
+    let source = "
+        bus Mem
+          tlm_method read(addr: UInt<32>) -> UInt<64>: blocking;
+        end bus Mem
+
+        use Mem;
+
+        module Shared
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync>;
+          port m:   initiator Mem;
+          reg   d0: UInt<64> reset rst => 0;
+          reg   d1: UInt<64> reset rst => 0;
+          thread w0 on clk rising, rst high
+            d0 <= m.read(32'h1000);
+          end thread w0
+          thread w1 on clk rising, rst high
+            d1 <= m.read(32'h1004);
+          end thread w1
+        end module Shared
+    ";
+    let tokens = arch::lexer::tokenize(source).expect("lexer");
+    let mut parser = arch::parser::Parser::new(tokens, source);
+    let ast = parser.parse_source_file().expect("parse");
+    let ast = arch::elaborate::elaborate(ast).expect("elaborate");
+    let ast = arch::elaborate::lower_tlm_target_threads(ast).expect("tlm target");
+    let r = arch::elaborate::lower_tlm_initiator_calls(ast);
+    assert!(r.is_err(), "bare multi-thread TLM should error");
+    let msg = format!("{:?}", r.unwrap_err());
+    assert!(msg.contains("multi-thread sharing") && msg.contains("lock"),
+        "expected lock/resource diagnostic, got: {msg}");
+}
+
+#[test]
 fn test_tlm_call_rejected_outside_seq_assign_rhs() {
     // Arithmetic on a TLM call RHS is not supported in v1 — must be
     // direct.


### PR DESCRIPTION
Shelves the tlm_method pipelined work. Design review concluded users already express multi-outstanding via generate_for + lock + ID-tagged responses (ThreadMm2s pattern). pipelined mode as a separate label adds no capability. Next v2 target: out_of_order.

Includes a targeted diagnostic for bare (unlocked) multi-thread TLM sharing, pointing at the lock/resource idiom.

cargo test: 151/151 pass.