### PR TITLE
feat: parse 'implement' clause on thread header (TLM glue scaffolding)

### DIFF
--- a/doc/ARCH_HDL_Specification.md
+++ b/doc/ARCH_HDL_Specification.md
@@ -1552,6 +1552,8 @@ end thread Name
 
 **Repeating vs once**: by default a thread loops — after the last body statement it returns to state 0. Write `thread once Name on …` to stop in the terminal state instead.
 
+**`implement` clause (parser-accepted in v0.44.18+, lowering pending)**: a thread may be declared `implement <port>.<method>()` (initiator side) or `implement target <port>.<method>(args)` (target side) between the thread name and the `on` clock clause. This glues the thread to a TLM method, opting into compiler-managed id allocation + arbitration across multiple co-implementers. Initiator form requires empty parens (method calls in the body supply args per-site); target form binds the declared args as thread-local names (generalizes the v1 dotted-name target syntax). Multi-thread lowering with id routing lands in follow-up PRs — see `doc/plan_tlm_implement_thread.md`.
+
 **Reentrant (parser-accepted in v0.44.17+, lowering pending)**: a thread may be declared `reentrant [max N]` after the reset clause. A reentrant thread allows a fresh invocation to start as soon as the previous one hits a `wait` or blocking call, up to `max N` concurrent instances. Use case: pipelining TLM method calls inside a single thread body without inventing new `Future<T>`/`await` syntax. Grammar is parsed today; FSM-cloning lowering ships in a follow-up PR (tracked in `doc/plan_tlm_pipelined.md`). Until then, a reentrant thread is a compile error with a targeted scaffolding-only message.
 
 **Multiple threads** in one module are declared independently; they all compile into the same `_ModuleName_threads` submodule and share one `always_ff` block to avoid multi-driver conflicts.

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -449,6 +449,14 @@ pub struct ThreadBlock {
     /// Captured at parse time (PR-tlm-3); lowering to an FSM (entry gate
     /// on req_valid, arg bindings, `return` → rsp drive) ships next.
     pub tlm_target: Option<TlmTargetBinding>,
+    /// `implement <port>.<method>()` (initiator) or `implement target
+    /// <port>.<method>(args)` (target) clause on the thread header.
+    /// Opts the thread into the compiler's id allocation + arbitration
+    /// machinery across N co-implementers (see doc/plan_tlm_implement_thread.md).
+    /// Initiator form is NEW in v2; target form is a generalization of
+    /// the v1 dotted-name binding (both populate `tlm_target` for
+    /// downstream lowering compat).
+    pub implement: Option<TlmImplementBinding>,
     /// Reentrant threads allow a fresh invocation to start before the
     /// previous one completes. Captured at parse time by the optional
     /// `reentrant [max N]` clause on the thread header (see
@@ -473,6 +481,27 @@ pub struct TlmTargetBinding {
     /// Argument names bound as thread-local values for the body.
     /// Types come from the bus's `TlmMethodMeta.args` at lowering time.
     pub args: Vec<Ident>,
+}
+
+/// `implement` clause on a thread header — glues the thread to a TLM
+/// method declaration. Initiator form binds the thread as one of
+/// potentially N id-tagged issue agents; target form generalizes the
+/// v1 dotted-name target syntax. See `doc/plan_tlm_implement_thread.md`.
+#[derive(Debug, Clone)]
+pub struct TlmImplementBinding {
+    pub kind: TlmImplementKind,
+    pub port: Ident,
+    pub method: Ident,
+    /// Target form binds the declared method args as thread-local names
+    /// (same semantics as v1 `thread s.read(addr) ...`). Initiator form
+    /// has empty args — the thread body supplies args at each call site.
+    pub args: Vec<Ident>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TlmImplementKind {
+    Initiator,
+    Target,
 }
 
 /// A statement inside a thread block.

--- a/src/elaborate.rs
+++ b/src/elaborate.rs
@@ -776,6 +776,7 @@ fn subst_thread(t: &ThreadBlock, var: &str, val: i64) -> ThreadBlock {
         )),
         tlm_target: t.tlm_target.clone(),
         reentrant: t.reentrant.clone(),
+        implement: t.implement.clone(),
         body: t.body.iter().map(|s| subst_thread_stmt(s, var, val)).collect(),
         span: t.span,
     }
@@ -1226,6 +1227,18 @@ fn lower_module_threads(m: ModuleDecl) -> Result<(ModuleDecl, Vec<Item>), Vec<Co
                 if t.reentrant.is_some() {
                     return Err(vec![CompileError::general(
                         "`reentrant` thread lowering is not yet implemented — tracked in doc/plan_tlm_pipelined.md PR-tlm-p2/p3.",
+                        t.span,
+                    )]);
+                }
+                // PR-tlm-i1 scaffolding: `implement` clause parses but
+                // lowering ships in PR-tlm-i2 (target sugar), PR-tlm-i3
+                // (initiator single), PR-tlm-i4 (multi-thread id routing).
+                if let Some(ref b) = t.implement {
+                    return Err(vec![CompileError::general(
+                        &format!(
+                            "`implement {}.{}(...)` thread lowering is not yet implemented — tracked in doc/plan_tlm_implement_thread.md PR-tlm-i2/i3/i4.",
+                            b.port.name, b.method.name
+                        ),
                         t.span,
                     )]);
                 }
@@ -3960,6 +3973,7 @@ fn lower_one_tlm_target(
         default_when: t.default_when,
         tlm_target: None,
         reentrant: None,
+        implement: None,
         body: final_body,
         span: t.span,
     };
@@ -4107,6 +4121,13 @@ pub fn lower_tlm_initiator_calls(ast: SourceFile) -> Result<SourceFile, Vec<Comp
                 for item in std::mem::take(&mut m.body) {
                     if let ModuleBodyItem::Thread(t) = &item {
                         if t.tlm_target.is_some() {
+                            new_body.push(item);
+                            continue;
+                        }
+                        // `implement`-bound threads skip this pass — lower_threads
+                        // will hit the PR-tlm-i1 scaffolding reject. (Future i3/i4
+                        // lowering replaces this pass-through with proper handling.)
+                        if t.implement.is_some() {
                             new_body.push(item);
                             continue;
                         }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1215,6 +1215,43 @@ impl Parser {
             }
         };
 
+        // Optional `implement [target] <port>.<method>(args...)` clause —
+        // glues the thread to a TLM method (see
+        // doc/plan_tlm_implement_thread.md). Must come BEFORE the `on`
+        // clock clause. Initiator form has empty parens (method calls
+        // inside the body supply args at each site); target form binds
+        // the declared args as thread-local names.
+        let implement = if self.check_ident("implement") {
+            self.advance();
+            let kind = if self.check_ident("target") {
+                self.advance();
+                TlmImplementKind::Target
+            } else {
+                TlmImplementKind::Initiator
+            };
+            let port_i = self.expect_ident()?;
+            self.expect(TokenKind::Dot)?;
+            let method_i = self.expect_ident()?;
+            self.expect(TokenKind::LParen)?;
+            let mut args = Vec::new();
+            if !self.check(TokenKind::RParen) {
+                loop {
+                    args.push(self.expect_ident()?);
+                    if self.check(TokenKind::Comma) { self.advance(); } else { break; }
+                }
+            }
+            self.expect(TokenKind::RParen)?;
+            if kind == TlmImplementKind::Initiator && !args.is_empty() {
+                return Err(CompileError::general(
+                    "initiator-side `implement <port>.<method>()` must have empty parens — method args are supplied at each call site inside the thread body",
+                    port_i.span,
+                ));
+            }
+            Some(TlmImplementBinding { kind, port: port_i, method: method_i, args })
+        } else {
+            None
+        };
+
         // Clock clause: `on CLK rising|falling`
         self.expect(TokenKind::On)?;
         let clock = self.expect_ident()?;
@@ -1329,6 +1366,7 @@ impl Parser {
             default_when,
             tlm_target,
             reentrant,
+            implement,
             body,
             span: start.merge(end_span),
         })

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -4557,6 +4557,139 @@ fn test_reentrant_thread_rejected_in_lower_threads() {
 }
 
 #[test]
+fn test_implement_initiator_parses() {
+    // PR-tlm-i1: `implement m.read()` clause populates
+    // ThreadBlock.implement with kind = Initiator and empty args.
+    let source = "
+        bus Mem
+          tlm_method read(addr: UInt<32>) -> UInt<64>: blocking;
+        end bus Mem
+
+        use Mem;
+
+        module M
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync>;
+          port m:   initiator Mem;
+          reg   d:  UInt<64> reset rst => 0;
+          thread driver implement m.read() on clk rising, rst high
+            d <= m.read(32'h1000);
+          end thread driver
+        end module M
+    ";
+    let tokens = arch::lexer::tokenize(source).expect("lexer");
+    let mut parser = arch::parser::Parser::new(tokens, source);
+    let ast = parser.parse_source_file().expect("parse");
+    let m = ast.items.iter().find_map(|it| match it {
+        arch::ast::Item::Module(m) if m.name.name == "M" => Some(m),
+        _ => None,
+    }).expect("module M");
+    let t = m.body.iter().find_map(|i| match i {
+        arch::ast::ModuleBodyItem::Thread(t) => Some(t),
+        _ => None,
+    }).expect("thread");
+    let b = t.implement.as_ref().expect("implement should be populated");
+    assert_eq!(b.kind, arch::ast::TlmImplementKind::Initiator);
+    assert_eq!(b.port.name, "m");
+    assert_eq!(b.method.name, "read");
+    assert!(b.args.is_empty(), "initiator form requires empty args");
+}
+
+#[test]
+fn test_implement_target_parses() {
+    let source = "
+        bus Mem
+          tlm_method read(addr: UInt<32>) -> UInt<64>: blocking;
+        end bus Mem
+
+        use Mem;
+
+        module T
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync>;
+          port s:   target Mem;
+          port ready: in Bool;
+          thread server implement target s.read(addr) on clk rising, rst high
+            wait until ready;
+            return 64'h42;
+          end thread server
+        end module T
+    ";
+    let tokens = arch::lexer::tokenize(source).expect("lexer");
+    let mut parser = arch::parser::Parser::new(tokens, source);
+    let ast = parser.parse_source_file().expect("parse");
+    let m = ast.items.iter().find_map(|it| match it {
+        arch::ast::Item::Module(m) if m.name.name == "T" => Some(m),
+        _ => None,
+    }).expect("module T");
+    let t = m.body.iter().find_map(|i| match i {
+        arch::ast::ModuleBodyItem::Thread(t) => Some(t),
+        _ => None,
+    }).expect("thread");
+    let b = t.implement.as_ref().expect("implement should be populated");
+    assert_eq!(b.kind, arch::ast::TlmImplementKind::Target);
+    assert_eq!(b.args.len(), 1);
+    assert_eq!(b.args[0].name, "addr");
+}
+
+#[test]
+fn test_implement_rejected_at_lower_threads() {
+    let source = "
+        bus Mem
+          tlm_method read(addr: UInt<32>) -> UInt<64>: blocking;
+        end bus Mem
+
+        use Mem;
+
+        module M
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync>;
+          port m:   initiator Mem;
+          reg   d:  UInt<64> reset rst => 0;
+          thread driver implement m.read() on clk rising, rst high
+            d <= m.read(32'h1000);
+          end thread driver
+        end module M
+    ";
+    let tokens = arch::lexer::tokenize(source).expect("lexer");
+    let mut parser = arch::parser::Parser::new(tokens, source);
+    let ast = parser.parse_source_file().expect("parse");
+    let ast = arch::elaborate::elaborate(ast).expect("elaborate");
+    let ast = arch::elaborate::lower_tlm_target_threads(ast).expect("tlm target");
+    let ast = arch::elaborate::lower_tlm_initiator_calls(ast).expect("tlm init");
+    let r = arch::elaborate::lower_threads(ast);
+    assert!(r.is_err(), "implement thread should be rejected until i2/i3/i4 ship");
+    let msg = format!("{:?}", r.unwrap_err());
+    assert!(msg.contains("implement") && msg.contains("not yet implemented"),
+        "expected scaffolding error, got: {msg}");
+}
+
+#[test]
+fn test_implement_initiator_with_args_in_parens_errors() {
+    let source = "
+        bus Mem
+          tlm_method read(addr: UInt<32>) -> UInt<64>: blocking;
+        end bus Mem
+
+        use Mem;
+
+        module M
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync>;
+          port m:   initiator Mem;
+          reg   d:  UInt<64> reset rst => 0;
+          thread driver implement m.read(addr) on clk rising, rst high
+            d <= m.read(32'h1000);
+          end thread driver
+        end module M
+    ";
+    let tokens = arch::lexer::tokenize(source).expect("lexer");
+    let mut parser = arch::parser::Parser::new(tokens, source);
+    let r = parser.parse_source_file();
+    assert!(r.is_err(), "initiator implement with args should be a parse error");
+}
+
+#[test]
 fn test_tlm_multi_thread_sharing_without_lock_errors() {
     // Multi-thread sharing of a TLM method outside any lock block →
     // targeted diagnostic pointing at the lock/resource idiom.


### PR DESCRIPTION
PR-tlm-i1. Grammar + AST + scaffolding reject for the 'implement' clause that glues threads to TLM methods.

Initiator form: thread NAME implement PORT.METHOD() on clk ...
Target form:    thread NAME implement target PORT.METHOD(args) on clk ...

Lowering ships in PR-tlm-i2/i3/i4. Spec note added.

cargo test: 155/155 pass.