### PR TITLE
feat: implement target <port>.<method>(args) lowers via existing v1 target path

### DIFF
--- a/src/elaborate.rs
+++ b/src/elaborate.rs
@@ -1230,13 +1230,24 @@ fn lower_module_threads(m: ModuleDecl) -> Result<(ModuleDecl, Vec<Item>), Vec<Co
                         t.span,
                     )]);
                 }
-                // PR-tlm-i1 scaffolding: `implement` clause parses but
-                // lowering ships in PR-tlm-i2 (target sugar), PR-tlm-i3
-                // (initiator single), PR-tlm-i4 (multi-thread id routing).
+                // `implement target` threads should have been consumed by
+                // lower_tlm_target_threads (which now treats them like
+                // v1 tlm_target). If one reaches here, it's an internal
+                // error. `implement` (initiator) threads still need
+                // lowering (PR-tlm-i3/i4).
                 if let Some(ref b) = t.implement {
+                    if b.kind == TlmImplementKind::Target {
+                        return Err(vec![CompileError::general(
+                            &format!(
+                                "internal error: `implement target {}.{}(...)` reached lower_threads without being consumed by lower_tlm_target_threads.",
+                                b.port.name, b.method.name
+                            ),
+                            t.span,
+                        )]);
+                    }
                     return Err(vec![CompileError::general(
                         &format!(
-                            "`implement {}.{}(...)` thread lowering is not yet implemented — tracked in doc/plan_tlm_implement_thread.md PR-tlm-i2/i3/i4.",
+                            "initiator-side `implement {}.{}()` thread lowering is not yet implemented — tracked in doc/plan_tlm_implement_thread.md PR-tlm-i3/i4.",
                             b.port.name, b.method.name
                         ),
                         t.span,
@@ -3825,12 +3836,57 @@ pub fn lower_tlm_target_threads(ast: SourceFile) -> Result<SourceFile, Vec<Compi
                         (p.name.name.clone(), bi.bus_name.name.clone())))
                     .collect();
 
+                // Detect multi-implementer target case (2+ threads
+                // implementing the same (port, method)). PR-tlm-i4
+                // will add id-routing; for now reject with a targeted
+                // message so users don't hit the confusing multi-driver
+                // error on rsp_valid / rsp_data / req_ready.
+                {
+                    let mut counts: HashMap<(String, String), (usize, Span)> = HashMap::new();
+                    for item in &m.body {
+                        if let ModuleBodyItem::Thread(t) = item {
+                            let key = if let Some(tb) = &t.tlm_target {
+                                Some((tb.port.name.clone(), tb.method.name.clone()))
+                            } else if let Some(ib) = &t.implement {
+                                if ib.kind == TlmImplementKind::Target {
+                                    Some((ib.port.name.clone(), ib.method.name.clone()))
+                                } else { None }
+                            } else { None };
+                            if let Some(k) = key {
+                                let e = counts.entry(k).or_insert((0, t.span));
+                                e.0 += 1;
+                            }
+                        }
+                    }
+                    for ((port, method), (n, span)) in &counts {
+                        if *n > 1 {
+                            errors.push(CompileError::general(
+                                &format!(
+                                    "multi-implementer target for `{port}.{method}` is not yet implemented — {n} threads in this module bind to this method as target. id-tagged routing ships in PR-tlm-i4 (see doc/plan_tlm_implement_thread.md).",
+                                ),
+                                *span,
+                            ));
+                        }
+                    }
+                }
+
                 // Collect TLM target threads + their method metadata.
                 let mut latch_regs: Vec<RegDecl> = Vec::new();
                 let mut new_body: Vec<ModuleBodyItem> = Vec::new();
                 for item in std::mem::take(&mut m.body) {
                     if let ModuleBodyItem::Thread(t) = &item {
-                        if let Some(binding) = t.tlm_target.clone() {
+                        // v1 dotted-name form populates `tlm_target`; v2
+                        // `implement target port.method(args)` populates
+                        // `implement`. Normalize to a single TlmTargetBinding.
+                        let effective_target: Option<TlmTargetBinding> = t.tlm_target.clone()
+                            .or_else(|| t.implement.as_ref()
+                                .filter(|b| b.kind == TlmImplementKind::Target)
+                                .map(|b| TlmTargetBinding {
+                                    port: b.port.clone(),
+                                    method: b.method.clone(),
+                                    args: b.args.clone(),
+                                }));
+                        if let Some(binding) = effective_target {
                             let bus_name = match port_buses.get(&binding.port.name) {
                                 Some(b) => b.clone(),
                                 None => {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -4633,6 +4633,75 @@ fn test_implement_target_parses() {
 }
 
 #[test]
+fn test_implement_target_single_compiles_end_to_end() {
+    // PR-tlm-i2: `thread NAME implement target s.read(addr) ... return;`
+    // is sugar for the v1 dotted-name target form. Single-implementer
+    // case compiles through to SV via existing target lowering.
+    let source = "
+        bus Mem
+          tlm_method read(addr: UInt<32>) -> UInt<64>: blocking;
+        end bus Mem
+
+        use Mem;
+
+        module MemTarget
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync>;
+          port s:   target Mem;
+          port ready: in Bool;
+          thread server implement target s.read(addr) on clk rising, rst high
+            wait until ready;
+            return 64'h42;
+          end thread server
+        end module MemTarget
+    ";
+    let sv = compile_to_sv(source);
+    assert!(sv.contains("_tlm_s_read_state"),
+        "state reg should appear in SV:\n{sv}");
+    assert!(sv.contains("_tlm_s_read_addr_latched"),
+        "arg latch reg should appear in SV:\n{sv}");
+    assert!(sv.contains("s_read_req_ready"),
+        "req_ready driver should appear:\n{sv}");
+}
+
+#[test]
+fn test_implement_target_multi_implementer_rejected() {
+    // PR-tlm-i2: multi-implementer target case produces a targeted
+    // error pointing at PR-tlm-i4.
+    let source = "
+        bus Mem
+          tlm_method read(addr: UInt<32>) -> UInt<64>: blocking;
+        end bus Mem
+
+        use Mem;
+
+        module MemTarget
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync>;
+          port s:   target Mem;
+          port ready: in Bool;
+          thread server0 implement target s.read(addr) on clk rising, rst high
+            wait until ready;
+            return 64'h42;
+          end thread server0
+          thread server1 implement target s.read(addr) on clk rising, rst high
+            wait until ready;
+            return 64'h43;
+          end thread server1
+        end module MemTarget
+    ";
+    let tokens = arch::lexer::tokenize(source).expect("lexer");
+    let mut parser = arch::parser::Parser::new(tokens, source);
+    let ast = parser.parse_source_file().expect("parse");
+    let ast = arch::elaborate::elaborate(ast).expect("elaborate");
+    let r = arch::elaborate::lower_tlm_target_threads(ast);
+    assert!(r.is_err(), "multi-implementer target should error until PR-tlm-i4");
+    let msg = format!("{:?}", r.unwrap_err());
+    assert!(msg.contains("multi-implementer target") && msg.contains("s.read"),
+        "expected targeted error, got: {msg}");
+}
+
+#[test]
 fn test_implement_rejected_at_lower_threads() {
     let source = "
         bus Mem


### PR DESCRIPTION
PR-tlm-i2. Sugar for the v1 dotted-name target syntax.

Single-implementer target case compiles end-to-end — lower_tlm_target_threads derives a TlmTargetBinding from the implement clause and flows through the existing inline lowering unchanged.

Multi-implementer target is detected and rejected with a targeted error pointing at PR-tlm-i4.

cargo test: 157/157 pass.