### PR TITLE
feat: single-implementer initiator 'implement m.method()' end-to-end

### DIFF
--- a/src/elaborate.rs
+++ b/src/elaborate.rs
@@ -4148,6 +4148,13 @@ pub fn lower_tlm_initiator_calls(ast: SourceFile) -> Result<SourceFile, Vec<Comp
                     for item in &m.body {
                         if let ModuleBodyItem::Thread(t) = item {
                             if t.tlm_target.is_some() { continue; }
+                            // Threads carrying `implement` are the opt-in
+                            // mechanism for multi-thread TLM — skip the
+                            // lock-idiom diagnostic on them. Multi-
+                            // implementer rejection is handled below by
+                            // PR-tlm-i3 (initiator) with its own targeted
+                            // message.
+                            if t.implement.is_some() { continue; }
                             collect_bare_tlm_calls(&t.body, t.span, &port_buses, &bus_methods, &mut bare_uses);
                         }
                     }
@@ -4173,6 +4180,22 @@ pub fn lower_tlm_initiator_calls(ast: SourceFile) -> Result<SourceFile, Vec<Comp
                 }
 
                 // Identify threads that contain TLM calls and inline them.
+                // PR-tlm-i3: count initiator-side `implement m.method()`
+                // threads per (port, method). Single-implementer routes
+                // through existing inline lowering (equivalent to v1
+                // single-thread); multi-implementer is PR-tlm-i4.
+                let mut init_impl_counts: HashMap<(String, String), usize> = HashMap::new();
+                for item in &m.body {
+                    if let ModuleBodyItem::Thread(t) = item {
+                        if let Some(ib) = &t.implement {
+                            if ib.kind == TlmImplementKind::Initiator {
+                                *init_impl_counts.entry((ib.port.name.clone(), ib.method.name.clone()))
+                                    .or_insert(0) += 1;
+                            }
+                        }
+                    }
+                }
+
                 let mut new_body: Vec<ModuleBodyItem> = Vec::new();
                 for item in std::mem::take(&mut m.body) {
                     if let ModuleBodyItem::Thread(t) = &item {
@@ -4180,12 +4203,35 @@ pub fn lower_tlm_initiator_calls(ast: SourceFile) -> Result<SourceFile, Vec<Comp
                             new_body.push(item);
                             continue;
                         }
-                        // `implement`-bound threads skip this pass — lower_threads
-                        // will hit the PR-tlm-i1 scaffolding reject. (Future i3/i4
-                        // lowering replaces this pass-through with proper handling.)
-                        if t.implement.is_some() {
-                            new_body.push(item);
-                            continue;
+                        // Target-side `implement` is handled by
+                        // lower_tlm_target_threads before this pass runs,
+                        // so anything reaching here is initiator (if set).
+                        if let Some(ib) = &t.implement {
+                            if ib.kind == TlmImplementKind::Initiator {
+                                let count = init_impl_counts
+                                    .get(&(ib.port.name.clone(), ib.method.name.clone()))
+                                    .copied().unwrap_or(0);
+                                if count > 1 {
+                                    // Multi-implementer — PR-tlm-i4.
+                                    errors.push(CompileError::general(
+                                        &format!(
+                                            "multi-implementer initiator for `{}.{}()` is not yet implemented — {count} threads carry `implement` on this method. id-tagged request arbitration ships in PR-tlm-i4 (see doc/plan_tlm_implement_thread.md).",
+                                            ib.port.name, ib.method.name,
+                                        ),
+                                        t.span,
+                                    ));
+                                    new_body.push(item);
+                                    continue;
+                                }
+                                // Single-implementer initiator — fall through
+                                // to the inline lowering (v1 equivalent).
+                            } else {
+                                // Target kind here is unexpected (should've
+                                // been consumed earlier). Leave for the
+                                // lower_threads defensive error.
+                                new_body.push(item);
+                                continue;
+                            }
                         }
                         if thread_body_has_tlm_call(&t.body, &port_buses, &bus_methods) {
                             let t_moved = if let ModuleBodyItem::Thread(t) = item { t } else { unreachable!() };

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -4702,7 +4702,9 @@ fn test_implement_target_multi_implementer_rejected() {
 }
 
 #[test]
-fn test_implement_rejected_at_lower_threads() {
+fn test_implement_initiator_single_compiles_end_to_end() {
+    // PR-tlm-i3: single-implementer initiator routes through the
+    // existing v1 inline lowering. End-to-end SV compiles.
     let source = "
         bus Mem
           tlm_method read(addr: UInt<32>) -> UInt<64>: blocking;
@@ -4720,17 +4722,48 @@ fn test_implement_rejected_at_lower_threads() {
           end thread driver
         end module M
     ";
+    let sv = compile_to_sv(source);
+    assert!(sv.contains("_tlm_init_driver_state"),
+        "single-implementer initiator should use v1 inline lowering:\n{sv}");
+    assert!(sv.contains("m_read_req_valid") && sv.contains("m_read_rsp_ready"),
+        "bus signals should be driven:\n{sv}");
+}
+
+#[test]
+fn test_implement_initiator_multi_implementer_rejected() {
+    // PR-tlm-i3: multi-implementer initiator → targeted error pointing
+    // at PR-tlm-i4.
+    let source = "
+        bus Mem
+          tlm_method read(addr: UInt<32>) -> UInt<64>: blocking;
+        end bus Mem
+
+        use Mem;
+
+        module M
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync>;
+          port m:   initiator Mem;
+          reg   d0: UInt<64> reset rst => 0;
+          reg   d1: UInt<64> reset rst => 0;
+          thread w0 implement m.read() on clk rising, rst high
+            d0 <= m.read(32'h1000);
+          end thread w0
+          thread w1 implement m.read() on clk rising, rst high
+            d1 <= m.read(32'h1004);
+          end thread w1
+        end module M
+    ";
     let tokens = arch::lexer::tokenize(source).expect("lexer");
     let mut parser = arch::parser::Parser::new(tokens, source);
     let ast = parser.parse_source_file().expect("parse");
     let ast = arch::elaborate::elaborate(ast).expect("elaborate");
     let ast = arch::elaborate::lower_tlm_target_threads(ast).expect("tlm target");
-    let ast = arch::elaborate::lower_tlm_initiator_calls(ast).expect("tlm init");
-    let r = arch::elaborate::lower_threads(ast);
-    assert!(r.is_err(), "implement thread should be rejected until i2/i3/i4 ship");
+    let r = arch::elaborate::lower_tlm_initiator_calls(ast);
+    assert!(r.is_err(), "multi-implementer initiator should error until PR-tlm-i4");
     let msg = format!("{:?}", r.unwrap_err());
-    assert!(msg.contains("implement") && msg.contains("not yet implemented"),
-        "expected scaffolding error, got: {msg}");
+    assert!(msg.contains("multi-implementer initiator") && msg.contains("m.read"),
+        "expected targeted error, got: {msg}");
 }
 
 #[test]


### PR DESCRIPTION
PR-tlm-i3. Single-implementer initiator routes through the v1 inline lowering — end-to-end SV compiles.

Multi-implementer case rejected with a targeted error pointing at PR-tlm-i4 (the actual id-tagged request arbitration work).

cargo test: 158/158 pass.