### PR TITLE
plan: tlm_implement scope refine — multi-thread target-side only

### DIFF
--- a/doc/plan_tlm_implement_thread.md
+++ b/doc/plan_tlm_implement_thread.md
@@ -9,6 +9,16 @@
 > remains a permanent error until that mode ships. The AXI multi-
 > outstanding idiom (one issuer + N RCollect threads filtering by
 > ID, per ThreadMm2s) stays as the hand-rolled pattern for now.
+>
+> **Target-side model**: N `implement target` threads form a
+> **server pool**. Dispatch is internal — a module-level round-robin
+> dispatcher picks an idle thread per incoming request and grants it
+> the work. The bus wire protocol stays as v1 single-implementer (no
+> ID tags on the wire); concurrency is entirely inside the target
+> module. Up to N concurrent in-flight requests are served (one per
+> thread instance). `req_ready = any-thread-idle`; `rsp_valid = OR
+> of per-thread respond states`; `rsp_data = mux over which thread
+> is responding`.
 
 
 *Author: session of 2026-04-23. Supersedes the shelved pipelined plan

--- a/doc/plan_tlm_implement_thread.md
+++ b/doc/plan_tlm_implement_thread.md
@@ -19,6 +19,32 @@
 > thread instance). `req_ready = any-thread-idle`; `rsp_valid = OR
 > of per-thread respond states`; `rsp_data = mux over which thread
 > is responding`.
+>
+> **Initiator-side model** (Model B, per 2026-04-23 design review):
+> N `implement m.method()` threads form a **worker pool**, decoupled
+> from the call site. Call sites (in another thread body or a seq
+> block) issue `d <= m.read(addr);`; the compiler dispatches to an
+> idle worker which drives the bus transaction and routes the
+> response back to the caller's destination reg.
+>
+> v2a (PR-tlm-i4) initiator scope:
+>   - Caller must be in a thread body (seq-block async semantics TBD;
+>     initial impl rejects seq callers).
+>   - Worker threads with EMPTY user bodies: compiler synthesizes the
+>     full issue → wait-response FSM and populates the dispatch
+>     interface. User-body workers are a v2b extension (user runs
+>     custom logic before driving the bus, e.g. address translation).
+>   - Dispatcher: round-robin across idle workers, stalls the caller
+>     when none available.
+>   - Per-worker capture reg for rsp_data; router copies to caller's
+>     destination on completion + marks worker idle.
+>   - Per-call FIFO entry (caller_site_id, worker_id) so the router
+>     knows where to send the response. Depth = N (one per worker).
+>
+> Multi-thread initiator WITHOUT `implement` pool stays an error —
+> plain threads calling `m.read()` serialize via the lock-wrap
+> diagnostic (PR #89). `implement m.method()` is the explicit opt-in
+> for compiler-managed dispatch.
 
 
 *Author: session of 2026-04-23. Supersedes the shelved pipelined plan

--- a/doc/plan_tlm_implement_thread.md
+++ b/doc/plan_tlm_implement_thread.md
@@ -1,5 +1,16 @@
 # Plan: `implement` — glue TLM methods to threads (v2)
 
+> **Scope refinement (2026-04-23)**: with `blocking` mode only,
+> initiator-side multi-thread is not meaningful — each call is an
+> atomic issue+wait so N threads can't split the work. Multi-thread
+> is a **target-side-only** feature in v2. `implement` on the
+> initiator side is accepted for forward-compat with future
+> out_of_order mode, but N>1 implementers on the initiator side
+> remains a permanent error until that mode ships. The AXI multi-
+> outstanding idiom (one issuer + N RCollect threads filtering by
+> ID, per ThreadMm2s) stays as the hand-rolled pattern for now.
+
+
 *Author: session of 2026-04-23. Supersedes the shelved pipelined plan
 (`plan_tlm_pipelined.md`) and the prior Future<T>/reentrant sketches.*
 


### PR DESCRIPTION
Per design review: with blocking mode, initiator multi-thread can't split atomic issue+wait calls meaningfully. Target side is where N>1 makes sense (N threads handling N IDs, like RCollect in ThreadMm2s).

Narrows PR-tlm-i4 to target-side arbitration only.