### PR TITLE
noc_credit: Layer-1 validation + sim_codegen implicit-bus-wire fix

### DIFF
--- a/src/sim_codegen/mod.rs
+++ b/src/sim_codegen/mod.rs
@@ -3415,6 +3415,49 @@ impl<'a> SimCodegen<'a> {
             .map(|inst| expand_bus_connections(inst, self.source, self.symbols, &bus_wire_names))
             .collect();
 
+        // Augment `inst_out` with output signals discovered through bus
+        // expansion. The raw `collect_inst_output_signals(&m.body)` only
+        // sees `out <- noc_link` (whole-bus) and records nothing useful;
+        // the per-signal expansion produces directional connections like
+        // `noc_link_flits_send_valid` (from prod) that must be declared
+        // as private members on the parent. Without this, two insts
+        // sharing an undeclared bus name (the implicit-bus-wire case)
+        // generate code that references undeclared identifiers.
+        let mut inst_out = inst_out;
+        for conns in &expanded_conns {
+            for conn in conns {
+                if conn.direction == ConnectDir::Output {
+                    if let ExprKind::Ident(name) = &conn.signal.kind {
+                        inst_out.insert(name.clone());
+                    }
+                }
+            }
+        }
+        // Also populate `widths` for implicit-bus-wire signals so the
+        // private member emission picks the right C++ type (e.g. uint64_t
+        // for a 64-bit `send_data` instead of the uint32_t fallback).
+        for inst in insts.iter() {
+            for p in &m.ports { let _ = p; }  // placate borrow-check noise
+            for sub_port in self.lookup_inst_ports(&inst.module_name.name) {
+                let Some(bi) = &sub_port.bus_info else { continue; };
+                let Some((crate::resolve::Symbol::Bus(info), _)) =
+                    self.symbols.globals.get(&bi.bus_name.name) else { continue; };
+                // Find the parent-side connection name for this bus port.
+                let parent_name = inst.connections.iter()
+                    .find(|c| c.port_name.name == sub_port.name.name)
+                    .and_then(|c| if let ExprKind::Ident(n) = &c.signal.kind {
+                        Some(n.clone())
+                    } else { None });
+                let Some(parent_name) = parent_name else { continue; };
+                let mut pm = info.default_param_map();
+                for pa in &bi.params { pm.insert(pa.name.name.clone(), &pa.value); }
+                for (sname, _sdir, ty) in info.effective_signals(&pm) {
+                    let bits = type_bits_te(&ty);
+                    widths.entry(format!("{parent_name}_{sname}")).or_insert(bits);
+                }
+            }
+        }
+
         // Build map: parent_signal_name → Vec element count for inst-output Vec ports.
         // When a sub-instance has a Vec output port and the parent connects it to a scalar
         // wire (e.g. thread lowering creates `thread_complete -> thread_complete`), we need
@@ -3892,7 +3935,14 @@ impl<'a> SimCodegen<'a> {
                 if let Some((elem_ty, count)) = inst_vec_out.get(sig_name) {
                     h.push_str(&format!("  {elem_ty} {sig_name}[{count}];\n"));
                 } else {
-                    h.push_str(&format!("  uint32_t {sig_name};\n"));
+                    // Pick the C++ type from the resolved width when known
+                    // (implicit bus wires + flat bus signals propagate through
+                    // `widths`). Default to uint32_t when the width isn't
+                    // tracked — preserves prior behaviour for plain scalars.
+                    let ty = widths.get(sig_name).copied()
+                        .map(cpp_uint)
+                        .unwrap_or("uint32_t");
+                    h.push_str(&format!("  {ty} {sig_name};\n"));
                 }
             }
         }

--- a/tests/noc_credit/noc_credit.arch
+++ b/tests/noc_credit/noc_credit.arch
@@ -1,0 +1,109 @@
+// Layer 1 NoC validation for credit_channel — see doc/plan_credit_channel.md
+// §"Validation plan — NoC flit credit". A producer + consumer connected
+// through a single credit_channel(DEPTH=8) carrying UInt<64> flits, with
+// LFSR-throttled rates so the C++ TB can stress balanced / asymmetric
+// scenarios and verify backpressure correctness end-to-end.
+
+bus NocBus
+  credit_channel flits: send
+    param T:     type  = UInt<64>;
+    param DEPTH: const = 8;
+  end credit_channel flits
+end bus NocBus
+
+module NocProducer
+  port clk:          in Clock<SysDomain>;
+  port rst:          in Reset<Sync>;
+  port gen_pressure: in UInt<8>;     // TB-controlled send rate (0 = idle, 255 = max)
+  port out:          initiator NocBus;
+
+  reg seq_no: UInt<64> reset rst => 64'h0;
+  reg lfsr:   UInt<8>  reset rst => 8'h5A;
+
+  comb
+    out.flits_send_valid = 1'b0;
+    out.flits_send_data  = 64'h0;
+    if out.flits.can_send and (lfsr < gen_pressure)
+      out.flits.send(seq_no);
+    end if
+  end comb
+
+  seq on clk rising
+    // Galois LFSR: shift right; XOR taps when LSB pops out.
+    if lfsr[0]
+      lfsr <= (lfsr >> 1) ^ 8'hB8;
+    else
+      lfsr <= (lfsr >> 1);
+    end if
+    if out.flits.can_send and (lfsr < gen_pressure)
+      seq_no <= (seq_no + 64'h1).trunc<64>();
+    end if
+  end seq
+end module NocProducer
+
+module NocConsumer
+  port clk:          in Clock<SysDomain>;
+  port rst:          in Reset<Sync>;
+  port pop_pressure: in UInt<8>;     // TB-controlled pop rate
+  port incoming:     target NocBus;
+
+  port reg popped_count: out UInt<64> reset rst => 64'h0;
+  port reg last_seq:     out UInt<64> reset rst => 64'h0;
+  port reg in_order:     out Bool     reset rst => 1'b1;
+  port reg saw_any:      out Bool     reset rst => 1'b0;
+
+  reg lfsr: UInt<8> reset rst => 8'hC3;
+
+  comb
+    incoming.flits_credit_return = 1'b0;
+    if incoming.flits.valid and (lfsr < pop_pressure)
+      incoming.flits.pop();
+    end if
+  end comb
+
+  seq on clk rising
+    if lfsr[0]
+      lfsr <= (lfsr >> 1) ^ 8'hB8;
+    else
+      lfsr <= (lfsr >> 1);
+    end if
+    if incoming.flits.valid and (lfsr < pop_pressure)
+      popped_count <= (popped_count + 64'h1).trunc<64>();
+      last_seq     <= incoming.flits.data;
+      // Each popped seq_no should be exactly previous + 1 (or 0 on first).
+      if saw_any and incoming.flits.data != (last_seq + 64'h1).trunc<64>()
+        in_order <= 1'b0;
+      end if
+      saw_any <= 1'b1;
+    end if
+  end seq
+end module NocConsumer
+
+module NocCreditTop
+  port clk:          in Clock<SysDomain>;
+  port rst:          in Reset<Sync>;
+  port gen_pressure: in UInt<8>;
+  port pop_pressure: in UInt<8>;
+  port popped_count: out UInt<64>;
+  port last_seq:     out UInt<64>;
+  port in_order:     out Bool;
+  port saw_any:      out Bool;
+
+  inst prod: NocProducer
+    clk          <- clk;
+    rst          <- rst;
+    gen_pressure <- gen_pressure;
+    out          <- noc_link;
+  end inst prod
+
+  inst cons: NocConsumer
+    clk           <- clk;
+    rst           <- rst;
+    pop_pressure  <- pop_pressure;
+    incoming      <- noc_link;
+    popped_count  -> popped_count;
+    last_seq      -> last_seq;
+    in_order      -> in_order;
+    saw_any       -> saw_any;
+  end inst cons
+end module NocCreditTop

--- a/tests/noc_credit/noc_credit_tb.cpp
+++ b/tests/noc_credit/noc_credit_tb.cpp
@@ -1,0 +1,118 @@
+// NoC credit_channel testbench — see doc/plan_credit_channel.md §"Validation
+// plan — NoC flit credit". Exercises the producer/consumer pair under
+// balanced, producer-fast, and recovery scenarios. Self-checks for
+// in-order delivery + monotonic seq_no progress.
+
+#define private public
+#include "VNocCreditTop.h"
+#undef private
+#include <cstdio>
+#include <cstdint>
+#include <cassert>
+
+static int pass_count = 0;
+static int fail_count = 0;
+
+#define CHECK(cond, msg, ...) \
+  do { \
+    if (cond) { printf("  PASS: " msg "\n", ##__VA_ARGS__); ++pass_count; } \
+    else { printf("  FAIL: " msg "\n", ##__VA_ARGS__); ++fail_count; } \
+  } while (0)
+
+static VNocCreditTop dut;
+
+static void tick() {
+    dut.clk = 0; dut.eval();
+    dut.clk = 1; dut.eval();
+}
+
+static void reset_and_idle() {
+    dut.rst = 1;
+    dut.gen_pressure = 0;
+    dut.pop_pressure = 0;
+    tick(); tick(); tick();
+    dut.rst = 0;
+    tick();
+}
+
+static uint64_t run_window(uint8_t gen, uint8_t pop, int cycles) {
+    dut.gen_pressure = gen;
+    dut.pop_pressure = pop;
+    uint64_t before = dut.popped_count;
+    for (int i = 0; i < cycles; ++i) tick();
+    return dut.popped_count - before;
+}
+
+int main() {
+    printf("=== NoC credit_channel TB ===\n");
+
+    reset_and_idle();
+
+    // Sanity 1: idle (gen=0, pop=0) → no progress over 200 cycles.
+    {
+        uint64_t popped = run_window(0, 0, 200);
+        CHECK(popped == 0, "idle: 200 cycles produce 0 pops (got %llu)",
+              (unsigned long long)popped);
+        CHECK(dut.in_order, "in_order still true after idle");
+    }
+
+    // Scenario 1: balanced 50/50 — both pressures at 128, 1000 cycles.
+    // LFSR < 128 ≈ half the time; producer + consumer both fire ~half-cycles.
+    // Expected throughput is bounded by the slower side; with both at 128
+    // we should see a few hundred flits.
+    {
+        uint64_t popped = run_window(128, 128, 1000);
+        CHECK(popped >= 200,
+              "balanced (gen=128, pop=128, 1000 cyc): popped %llu >= 200",
+              (unsigned long long)popped);
+        CHECK(dut.in_order, "in_order still true after balanced run");
+        printf("  info: balanced popped=%llu, last_seq=%llu\n",
+               (unsigned long long)popped,
+               (unsigned long long)dut.last_seq);
+    }
+
+    // Scenario 2: producer fast / consumer slow — credit drains, sender
+    // backpressures naturally via can_send. Throughput is bounded by the
+    // consumer's pop rate.
+    {
+        uint64_t popped = run_window(255, 32, 2000);
+        CHECK(popped > 100,
+              "backpressure (gen=255, pop=32, 2000 cyc): popped %llu > 100",
+              (unsigned long long)popped);
+        // Consumer-bounded: ~32/255 of 2000 ≈ 250 pops max. Real number is
+        // smaller because LFSR<32 ≈ 12.5% of the time. Loose upper bound:
+        CHECK(popped < 600,
+              "backpressure: popped %llu < 600 (consumer-bounded)",
+              (unsigned long long)popped);
+        CHECK(dut.in_order, "in_order still true after backpressure run");
+        printf("  info: backpressure popped=%llu\n",
+               (unsigned long long)popped);
+    }
+
+    // Scenario 3: recovery — speed consumer back up to 255, producer
+    // already at 255. Drained credits should refill and throughput rises.
+    uint64_t recovery_baseline = dut.popped_count;
+    {
+        uint64_t popped = run_window(255, 255, 1000);
+        CHECK(popped >= 300,
+              "recovery (gen=255, pop=255, 1000 cyc): popped %llu >= 300",
+              (unsigned long long)popped);
+        CHECK(dut.in_order, "in_order still true after recovery run");
+        printf("  info: recovery popped=%llu (cumulative %llu)\n",
+               (unsigned long long)popped,
+               (unsigned long long)(dut.popped_count - 0));
+    }
+    (void)recovery_baseline;
+
+    // Final invariant: every popped flit's seq_no incremented by 1, so
+    // last_seq == popped_count - 1 (when saw_any is set).
+    if (dut.saw_any) {
+        CHECK(dut.last_seq == dut.popped_count - 1,
+              "monotonic: last_seq=%llu == popped_count-1=%llu",
+              (unsigned long long)dut.last_seq,
+              (unsigned long long)(dut.popped_count - 1));
+    }
+
+    printf("\n=== Summary: %d pass, %d fail ===\n", pass_count, fail_count);
+    return fail_count == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

Layer-1 of the NoC validation plan from
[doc/plan_credit_channel.md §"Validation plan — NoC flit credit"](doc/plan_credit_channel.md):
a NocProducer + NocConsumer pair connected through one
`credit_channel(UInt<64>, DEPTH=8)`, plus a C++ TB that hammers the
pair under balanced / producer-fast / recovery scenarios and
self-checks in-order delivery + monotonic seq_no progress.

Required one sim_codegen fix to land the test:

**`sim_codegen` bug**: when two insts share a parent-side bus
connection name that isn't declared as a wire, the generated C++
referenced `<connection_name>_<field>` identifiers without declaring
them as members. Compilation failed with `use of undeclared identifier`.

Fix:
- After bus-connection expansion, augment `inst_out` with the
  per-signal output names produced by expansion (the raw connection
  walk only sees the whole-bus binding).
- Populate `widths` for those names from the bus's effective signal
  table so member types match (uint64_t for a 64-bit `send_data` etc.)
  instead of the uint32_t fallback.

## Test results

- TB: **10 / 10 PASS** across idle, balanced (gen=128 / pop=128, 466
  flits in 1000 cyc), backpressure (gen=255 / pop=32, consumer-bounded
  243 flits in 2000 cyc), recovery (996 flits in 1000 cyc), and final
  monotonic invariant.
- `cargo test` — 188 passing, no regressions.

## Run locally

```
arch sim tests/noc_credit/noc_credit.arch \
    --tb tests/noc_credit/noc_credit_tb.cpp
```

## Out of scope

- Cocotb / pybind testbench (the spec mentions both; this PR ships C++).
- 4×4 mesh stretch demo (Layer 2; planned as `examples/mesh_noc_4x4/`
  in the future).
- Tier-2 SVA cross-check via Verilator `--assert` and EBMC formal —
  the formal occupancy invariant just landed in PR #109; integrating
  it into this test harness is follow-up work.