### PR TITLE
examples/noc_chain: 3-stage credit_channel forwarding demo

### DIFF
--- a/examples/noc_chain/noc_chain.arch
+++ b/examples/noc_chain/noc_chain.arch
@@ -1,0 +1,151 @@
+// 3-stage credit_channel forwarding chain — see doc/plan_credit_channel.md
+// §"Stretch: 4×4 mesh" for the broader vision. This is the minimal multi-
+// hop demo: a Producer feeds Router0 → Router1 → Router2 → Consumer,
+// each link a separate credit_channel. Validates that credit-based
+// backpressure composes correctly through multiple stages — when the
+// consumer slows, each router's buffer fills and the producer
+// back-pressures naturally. A mesh is just this pattern in 2D plus
+// XY routing.
+
+bus FlitBus
+  credit_channel flits: send
+    param T:     type  = UInt<32>;
+    param DEPTH: const = 4;
+  end credit_channel flits
+end bus FlitBus
+
+module FlitProducer
+  port clk:          in Clock<SysDomain>;
+  port rst:          in Reset<Sync>;
+  port gen_pressure: in UInt<8>;
+  port out:          initiator FlitBus;
+
+  reg seq_no: UInt<32> reset rst => 32'h0;
+  reg lfsr:   UInt<8>  reset rst => 8'h5A;
+
+  comb
+    out.flits_send_valid = 1'b0;
+    out.flits_send_data  = 32'h0;
+    if out.flits.can_send and (lfsr < gen_pressure)
+      out.flits.send(seq_no);
+    end if
+  end comb
+
+  seq on clk rising
+    if lfsr[0]
+      lfsr <= (lfsr >> 1) ^ 8'hB8;
+    else
+      lfsr <= lfsr >> 1;
+    end if
+    if out.flits.can_send and (lfsr < gen_pressure)
+      seq_no <= seq_no +% 32'h1;
+    end if
+  end seq
+end module FlitProducer
+
+// Forwarding router: pop a flit from the input as soon as it's
+// valid AND the output has credit. Single-cycle forwarding — no
+// internal buffering beyond what the credit_channel already provides.
+module FlitRouter
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port up:   target    FlitBus;     // upstream  (incoming)
+  port down: initiator FlitBus;     // downstream (outgoing)
+
+  comb
+    down.flits_send_valid = 1'b0;
+    down.flits_send_data  = 32'h0;
+    up.flits_credit_return = 1'b0;
+    if up.flits.valid and down.flits.can_send
+      down.flits.send(up.flits.data);
+      up.flits.pop();
+    end if
+  end comb
+end module FlitRouter
+
+module FlitConsumer
+  port clk:          in Clock<SysDomain>;
+  port rst:          in Reset<Sync>;
+  port pop_pressure: in UInt<8>;
+  port incoming:     target FlitBus;
+
+  port reg popped_count: out UInt<32> reset rst => 32'h0;
+  port reg last_seq:     out UInt<32> reset rst => 32'h0;
+  port reg in_order:     out Bool     reset rst => 1'b1;
+  port reg saw_any:      out Bool     reset rst => 1'b0;
+
+  reg lfsr: UInt<8> reset rst => 8'hC3;
+
+  comb
+    incoming.flits_credit_return = 1'b0;
+    if incoming.flits.valid and (lfsr < pop_pressure)
+      incoming.flits.pop();
+    end if
+  end comb
+
+  seq on clk rising
+    if lfsr[0]
+      lfsr <= (lfsr >> 1) ^ 8'hB8;
+    else
+      lfsr <= lfsr >> 1;
+    end if
+    if incoming.flits.valid and (lfsr < pop_pressure)
+      popped_count <= popped_count +% 32'h1;
+      last_seq     <= incoming.flits.data;
+      if saw_any and incoming.flits.data != (last_seq +% 32'h1)
+        in_order <= 1'b0;
+      end if
+      saw_any <= 1'b1;
+    end if
+  end seq
+end module FlitConsumer
+
+module NocChainTop
+  port clk:          in Clock<SysDomain>;
+  port rst:          in Reset<Sync>;
+  port gen_pressure: in UInt<8>;
+  port pop_pressure: in UInt<8>;
+  port popped_count: out UInt<32>;
+  port last_seq:     out UInt<32>;
+  port in_order:     out Bool;
+  port saw_any:      out Bool;
+
+  inst prod: FlitProducer
+    clk          <- clk;
+    rst          <- rst;
+    gen_pressure <- gen_pressure;
+    out          <- link_p_r0;
+  end inst prod
+
+  inst r0: FlitRouter
+    clk  <- clk;
+    rst  <- rst;
+    up   <- link_p_r0;
+    down <- link_r0_r1;
+  end inst r0
+
+  inst r1: FlitRouter
+    clk  <- clk;
+    rst  <- rst;
+    up   <- link_r0_r1;
+    down <- link_r1_r2;
+  end inst r1
+
+  inst r2: FlitRouter
+    clk  <- clk;
+    rst  <- rst;
+    up   <- link_r1_r2;
+    down <- link_r2_c;
+  end inst r2
+
+  inst cons: FlitConsumer
+    clk           <- clk;
+    rst           <- rst;
+    pop_pressure  <- pop_pressure;
+    incoming      <- link_r2_c;
+    popped_count  -> popped_count;
+    last_seq      -> last_seq;
+    in_order      -> in_order;
+    saw_any       -> saw_any;
+  end inst cons
+end module NocChainTop

--- a/examples/noc_chain/noc_chain_tb.cpp
+++ b/examples/noc_chain/noc_chain_tb.cpp
@@ -1,0 +1,98 @@
+// 3-stage credit_channel chain TB. Demonstrates that backpressure
+// composes through multiple credit_channel hops: when the consumer
+// slows, all 3 router buffers fill and producer-side can_send falls.
+
+#define private public
+#include "VNocChainTop.h"
+#undef private
+#include <cstdio>
+#include <cstdint>
+
+static int pass_count = 0;
+static int fail_count = 0;
+
+#define CHECK(cond, msg, ...) \
+  do { \
+    if (cond) { printf("  PASS: " msg "\n", ##__VA_ARGS__); ++pass_count; } \
+    else { printf("  FAIL: " msg "\n", ##__VA_ARGS__); ++fail_count; } \
+  } while (0)
+
+static VNocChainTop dut;
+
+static void tick() {
+    dut.clk = 0; dut.eval();
+    dut.clk = 1; dut.eval();
+}
+
+static void reset_and_idle() {
+    dut.rst = 1;
+    dut.gen_pressure = 0;
+    dut.pop_pressure = 0;
+    tick(); tick(); tick();
+    dut.rst = 0;
+    tick();
+}
+
+static uint32_t run_window(uint8_t gen, uint8_t pop, int cycles) {
+    dut.gen_pressure = gen;
+    dut.pop_pressure = pop;
+    uint32_t before = dut.popped_count;
+    for (int i = 0; i < cycles; ++i) tick();
+    return dut.popped_count - before;
+}
+
+int main() {
+    printf("=== NoC chain credit_channel TB (3-router pipeline) ===\n");
+
+    reset_and_idle();
+
+    {
+        uint32_t popped = run_window(0, 0, 200);
+        CHECK(popped == 0, "idle: 200 cycles produce 0 pops (got %u)", popped);
+    }
+
+    // Balanced flow: both at 128 → ~half the cycles produce/consume.
+    // With 3-deep pipeline, expect O(few hundred) flits in 1000 cycles
+    // minus a few cycles of fill latency.
+    {
+        uint32_t popped = run_window(128, 128, 1000);
+        CHECK(popped >= 200,
+              "balanced (gen=128, pop=128, 1000 cyc): popped %u >= 200", popped);
+        CHECK(dut.in_order, "in_order true after balanced");
+        printf("  info: balanced popped=%u, last_seq=%u\n", popped, dut.last_seq);
+    }
+
+    // Backpressure through 3 routers: producer fast, consumer slow.
+    // All 3 router buffers + producer's credit (DEPTH=4 each = 16 total
+    // in-flight slots) must drain through the consumer's slow rate.
+    {
+        uint32_t popped = run_window(255, 16, 4000);
+        CHECK(popped > 100,
+              "backpressure (gen=255, pop=16, 4000 cyc): popped %u > 100", popped);
+        CHECK(popped < 800,
+              "backpressure: popped %u < 800 (consumer-bounded)", popped);
+        CHECK(dut.in_order, "in_order true after backpressure");
+        printf("  info: backpressure popped=%u\n", popped);
+    }
+
+    // Recovery: consumer speeds back up. The pipeline should drain
+    // and resume full-throughput steady state.
+    {
+        uint32_t popped = run_window(255, 255, 1000);
+        CHECK(popped >= 300,
+              "recovery (gen=255, pop=255, 1000 cyc): popped %u >= 300", popped);
+        CHECK(dut.in_order, "in_order true after recovery");
+        printf("  info: recovery popped=%u (cumulative %u)\n",
+               popped, dut.popped_count);
+    }
+
+    // Final invariant: every flit popped exactly once, in order.
+    if (dut.saw_any) {
+        CHECK(dut.last_seq == dut.popped_count - 1,
+              "monotonic: last_seq=%u == popped_count-1=%u",
+              dut.last_seq, dut.popped_count - 1);
+    }
+
+    printf("\n=== Summary: %d pass, %d fail ===\n", pass_count, fail_count);
+    return fail_count == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

Multi-hop credit_channel demo — Producer → Router → Router → Router → Consumer.
Each link is a separate `credit_channel(UInt<32>, DEPTH=4)`, proving that
credit-based backpressure composes correctly through multiple stages.

This is a stepping stone toward the full 4×4 mesh demo flagged as
\"Stretch\" in [doc/plan_credit_channel.md](doc/plan_credit_channel.md).
A 2D mesh extends this pattern with XY routing + per-output arbitration;
the multi-stage credit handshake is the same.

## Test results

```
arch sim examples/noc_chain/noc_chain.arch \
    --tb examples/noc_chain/noc_chain_tb.cpp
```

- **9 / 9 PASS** across idle, balanced (gen=128 / pop=128, 489 flits/1000 cyc),
  backpressure (gen=255 / pop=16, consumer-bounded 238 flits/4000 cyc),
  recovery (996 flits/1000 cyc), monotonic delivery.
- `cargo test` — still 188 passing.

## Out of scope

- Full 4×4 mesh with XY routing + 5×5 router ports + arbitration
  (Layer 2 stretch goal — substantial design work, ~next session).
- Tier-2 SVA cross-check via Verilator `--assert` and EBMC formal.