### PR TITLE
credit_channel formal: derived signals + Verilator SVA cross-check on mesh

### DIFF
--- a/examples/mesh_noc_4x4/mesh4x4_sva_tb.sv
+++ b/examples/mesh_noc_4x4/mesh4x4_sva_tb.sv
@@ -1,0 +1,55 @@
+// SystemVerilog testbench using built-in concurrent assertions. Drives Mesh4x4 through
+// stress traffic pattern (balanced + backpressure + recovery) so the
+// auto-emitted credit_channel SVA gets exercised across all 80 channels
+// in the design. A passing run = no `_auto_cc_*_credit_bounds`,
+// `_auto_cc_*_send_requires_credit`, or
+// `_auto_cc_*_credit_return_requires_buffered` assertion fired.
+
+`timescale 1ns/1ps
+
+module sva_tb;
+  logic clk = 0;
+  logic rst = 1;
+  logic [7:0] gen_pressure = 0;
+  logic [7:0] pop_pressure = 0;
+  logic [1:0] dst_x = 2'd3;
+  logic [1:0] dst_y = 2'd3;
+
+  logic [31:0] popped_count;
+  logic [27:0] last_payload;
+
+  Mesh4x4 dut (
+    .clk(clk), .rst(rst),
+    .gen_pressure(gen_pressure), .pop_pressure(pop_pressure),
+    .dst_x(dst_x), .dst_y(dst_y),
+    .popped_count(popped_count),
+    .last_payload(last_payload)
+  );
+
+  always #5 clk = ~clk;
+
+  initial begin
+    // Reset
+    rst = 1; gen_pressure = 0; pop_pressure = 0;
+    repeat (5) @(posedge clk);
+    rst = 0;
+
+    // Balanced — both pressures at 128, 4000 cycles.
+    gen_pressure = 8'd128; pop_pressure = 8'd128;
+    repeat (4000) @(posedge clk);
+    $display("balanced: popped=%0d", popped_count);
+
+    // Backpressure — producer fast, consumer slow.
+    gen_pressure = 8'd255; pop_pressure = 8'd32;
+    repeat (4000) @(posedge clk);
+    $display("backpressure: popped=%0d", popped_count);
+
+    // Recovery — full speed both sides.
+    gen_pressure = 8'd255; pop_pressure = 8'd255;
+    repeat (2000) @(posedge clk);
+    $display("recovery: popped=%0d", popped_count);
+
+    $display("=== SVA TB completed without violations ===");
+    $finish;
+  end
+endmodule

--- a/examples/mesh_noc_4x4/run_sva.sh
+++ b/examples/mesh_noc_4x4/run_sva.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Tier-2 SVA cross-check on the 4×4 mesh. Builds the design via
+# `arch build`, runs Verilator with --assert across the full SV (80
+# credit_channel SVA properties total), and runs a stress traffic
+# pattern. A passing run = no _auto_cc_*_credit_bounds,
+# _send_requires_credit, or _credit_return_requires_buffered fired.
+
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/../.." && pwd)"
+BUILD="${TMPDIR:-/tmp}/mesh_sva_build"
+
+ARCH="${ARCH_BIN:-$REPO/target/debug/arch}"
+[ -x "$ARCH" ] || ARCH="$REPO/target/release/arch"
+[ -x "$ARCH" ] || { echo "no arch binary built — run 'cargo build' first" >&2; exit 1; }
+
+SV="$BUILD/mesh4x4.sv"
+mkdir -p "$BUILD"
+"$ARCH" build "$HERE/mesh4x4.arch" -o "$SV"
+
+cd "$BUILD"
+verilator --binary --assert --top sva_tb -Wno-fatal \
+    "$SV" "$HERE/mesh4x4_sva_tb.sv"
+"$BUILD/obj_dir/Vsva_tb"

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -784,8 +784,33 @@ impl<'a> Codegen<'a> {
                 ModuleBodyItem::RegBlock(rb) => self.emit_reg_block(rb, &m_clone),
                 ModuleBodyItem::LatchBlock(lb) => self.emit_latch_block(lb),
                 ModuleBodyItem::Inst(inst) => {
-                    // Auto-declare output wires that aren't already declared
+                    // Auto-declare output wires that aren't already declared.
+                    // Track newly-emitted names so a later inst that connects
+                    // to the same parent-side bus wire skips re-declaration.
+                    let mut just_added: Vec<String> = Vec::new();
                     self.emit_inst_output_wire_decls(inst, &declared_names);
+                    // Collect names we added so subsequent insts know.
+                    if let Some((Symbol::Module(info), _)) =
+                        self.symbols.globals.get(&inst.module_name.name)
+                    {
+                        let module_ports = info.ports.clone();
+                        for conn in &inst.connections {
+                            let Some(port) = module_ports.iter().find(|p| p.name.name == conn.port_name.name) else { continue; };
+                            let Some(bi) = &port.bus_info else { continue; };
+                            let ExprKind::Ident(parent_name) = &conn.signal.kind else { continue; };
+                            let Some((Symbol::Bus(bus_info), _)) =
+                                self.symbols.globals.get(&bi.bus_name.name) else { continue; };
+                            let mut pm = bus_info.default_param_map();
+                            for pa in &bi.params { pm.insert(pa.name.name.clone(), &pa.value); }
+                            for (sname, _sdir, _ty) in bus_info.effective_signals(&pm) {
+                                just_added.push(format!("{parent_name}_{sname}"));
+                            }
+                            // Also mark the whole-bus parent name as "claimed"
+                            // so later code doesn't re-emit a scalar for it.
+                            just_added.push(parent_name.clone());
+                        }
+                    }
+                    for n in just_added { declared_names.insert(n); }
                     self.emit_inst(inst);
                 }
                 ModuleBodyItem::PipeRegDecl(p) => {
@@ -2282,6 +2307,29 @@ impl<'a> Codegen<'a> {
             Vec::new()
         };
 
+        // Implicit bus wires: for any inst connection on a bus port
+        // whose parent-side signal is an undeclared Ident, declare each
+        // flattened bus signal as a wire on the parent. Mirrors the
+        // sim_codegen fix from PRs #110+#112. Without this, Verilator
+        // creates 1-bit IMPLICIT wires that silently truncate wider
+        // signals like `_flits_send_data` and the design appears dead.
+        let mut bus_emitted: std::collections::HashSet<String> = std::collections::HashSet::new();
+        for conn in &inst.connections {
+            let Some(port) = module_ports.iter().find(|p| p.name.name == conn.port_name.name) else { continue; };
+            let Some(bi) = &port.bus_info else { continue; };
+            let ExprKind::Ident(parent_name) = &conn.signal.kind else { continue; };
+            let Some((Symbol::Bus(bus_info), _)) =
+                self.symbols.globals.get(&bi.bus_name.name) else { continue; };
+            let mut pm = bus_info.default_param_map();
+            for pa in &bi.params { pm.insert(pa.name.name.clone(), &pa.value); }
+            for (sname, _sdir, ty) in bus_info.effective_signals(&pm) {
+                let flat = format!("{parent_name}_{sname}");
+                if declared.contains(&flat) || !bus_emitted.insert(flat.clone()) { continue; }
+                let (ty_str, arr_suffix) = self.emit_type_and_array_suffix(&ty);
+                self.line(&format!("{} {}{};", ty_str, flat, arr_suffix));
+            }
+        }
+
         for conn in &inst.connections {
             if conn.direction != ConnectDir::Output {
                 continue;
@@ -2290,8 +2338,9 @@ impl<'a> Codegen<'a> {
                 if declared.contains(target) {
                     continue;
                 }
-                // Find the port type from the module definition
+                // Bus ports are handled above as a separate pass; skip.
                 if let Some(port) = module_ports.iter().find(|p| p.name.name == conn.port_name.name) {
+                    if port.bus_info.is_some() { continue; }
                     let (ty_str, arr_suffix) = self.emit_type_and_array_suffix(&port.ty);
                     self.line(&format!("{} {}{};", ty_str, target, arr_suffix));
                 } else if let Some((_, ty)) = ram_flat_ports.iter().find(|(n, _)| *n == conn.port_name.name) {
@@ -6170,8 +6219,12 @@ impl<'a> Codegen<'a> {
             }
             ExprKind::BitSlice(base, hi, lo) => {
                 let b = self.emit_expr_str(base);
-                // Parenthesize complex base expressions to avoid precedence issues
-                let b = if matches!(base.kind, ExprKind::Ident(_) | ExprKind::Literal(_)
+                // Parenthesize complex base expressions to avoid precedence issues.
+                // SynthIdent is a compiler-renamed bare identifier with the same
+                // semantics as Ident — no parens needed (Verilator rejects
+                // `(__name)[hi:lo]` as a syntax error).
+                let b = if matches!(base.kind, ExprKind::Ident(_) | ExprKind::SynthIdent(_, _)
+                    | ExprKind::Literal(_)
                     | ExprKind::Index(_, _) | ExprKind::FieldAccess(_, _)) { b }
                     else { format!("({})", b) };
                 // Try to emit indexed part-select: base[lo +: width]

--- a/src/formal.rs
+++ b/src/formal.rs
@@ -1931,15 +1931,37 @@ impl<'a> FormalCtx<'a> {
             // variant) is still unsupported.
             SynthIdent(name, _) => {
                 if self.sigs.contains_key(name) {
-                    self.encode_ident(name, t, expr.span)
-                } else {
-                    Err(CompileError::general(
-                        &format!(
-                            "formal encoding of synthesized identifier `{name}` is not yet supported — only credit_channel scalar state is modelled today (see doc/plan_hierarchical_formal.md PR-hf4)",
-                        ),
-                        expr.span,
-                    ))
+                    return self.encode_ident(name, t, expr.span);
                 }
+                // Derived comb signals: codegen exposes `can_send` and
+                // `valid` as combinational outputs of the credit_channel
+                // state. Encode them as comparisons against the lifted
+                // regs so user code that gates traffic on these (the
+                // canonical pattern) flows through correctly.
+                //
+                //   __<port>_<ch>_can_send  ≡  __<port>_<ch>_credit != 0
+                //   __<port>_<ch>_valid     ≡  __<port>_<ch>_occ    != 0
+                if let Some(stem) = name.strip_suffix("_can_send")
+                    .or_else(|| name.strip_suffix("_valid"))
+                {
+                    let suffix = if name.ends_with("_can_send") { "_credit" } else { "_occ" };
+                    let reg = format!("{stem}{suffix}");
+                    if self.sigs.contains_key(&reg) {
+                        let r = self.encode_ident(&reg, t, expr.span)?;
+                        let zero = bv_zero(r.width);
+                        return Ok(SmtTerm {
+                            s: format!("(ite (= {} {zero}) #b0 #b1)", r.s),
+                            width: 1,
+                            signed: false,
+                        });
+                    }
+                }
+                Err(CompileError::general(
+                    &format!(
+                        "formal encoding of synthesized identifier `{name}` is not yet supported — only credit_channel scalar state and derived can_send/valid are modelled today (see doc/plan_hierarchical_formal.md PR-hf4)",
+                    ),
+                    expr.span,
+                ))
             }
             Literal(l) => Ok(lit_to_term(l)),
             Bool(b) => Ok(SmtTerm {
@@ -2123,6 +2145,24 @@ impl<'a> FormalCtx<'a> {
                 width: info.width,
                 signed: info.signed,
             });
+        }
+        // 4. Derived credit_channel signal: `__<port>_<ch>_can_send`
+        // resolves to `credit != 0`, `_valid` resolves to `occ != 0`.
+        // Mirrors the SynthIdent path so user-written asserts that
+        // reference the lifted state work too.
+        if let Some(stem) = name.strip_suffix("_can_send")
+            .or_else(|| name.strip_suffix("_valid"))
+        {
+            let suffix = if name.ends_with("_can_send") { "_credit" } else { "_occ" };
+            let reg = format!("{stem}{suffix}");
+            if let Some(info) = self.sigs.get(&reg) {
+                let zero = bv_zero(info.width);
+                return Ok(SmtTerm {
+                    s: format!("(ite (= {reg}_{t} {zero}) #b0 #b1)"),
+                    width: 1,
+                    signed: false,
+                });
+            }
         }
         Err(CompileError::general(
             &format!("unknown identifier `{name}` in arch formal encoding"),

--- a/tests/formal/credit_channel_active.arch
+++ b/tests/formal/credit_channel_active.arch
@@ -1,0 +1,78 @@
+// Active-traffic credit_channel occupancy invariant. Builds on
+// tests/formal/credit_channel_invariant.arch (vacuous proof — both
+// sides idle) by adding the codegen-canonical can_send / valid gating:
+//
+//   sender:   send_valid = can_send AND go      (go is a free input)
+//   receiver: credit_return = valid AND pop     (pop is a free input)
+//
+// `go` and `pop` are free environment inputs, so the solver explores
+// every send/pop pattern. The invariant `credit + occ == DEPTH` should
+// PROVE — the codegen-style gating prevents underflow on either side.
+
+bus CreditBus
+  credit_channel data: send
+    param T:     type  = UInt<8>;
+    param DEPTH: const = 4;
+  end credit_channel data
+end bus CreditBus
+
+module ActiveSender
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port s:   initiator CreditBus;
+  port go:  in Bool;
+
+  comb
+    s.data_send_valid = 1'b0;
+    s.data_send_data  = 8'h0;
+    if go and s.data.can_send
+      s.data.send(8'h42);
+    end if
+  end comb
+end module ActiveSender
+
+module ActiveReceiver
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port r:   target CreditBus;
+  port pop: in Bool;
+
+  comb
+    r.data_credit_return = 1'b0;
+    if pop and r.data.valid
+      r.data.pop();
+    end if
+  end comb
+end module ActiveReceiver
+
+module CreditPairActive
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port go:  in Bool;
+  port pop: in Bool;
+
+  inst snd: ActiveSender
+    clk <- clk;
+    rst <- rst;
+    s   <- chwire;
+    go  <- go;
+  end inst snd
+
+  inst rcv: ActiveReceiver
+    clk <- clk;
+    rst <- rst;
+    r   <- chwire;
+    pop <- pop;
+  end inst rcv
+
+  // The conservation invariant. With can_send / valid gating, this
+  // should PROVE for any input sequence.
+  assert credit_balance: __chwire_data_credit + __chwire_data_occ == 3'd4;
+  // Derived-signal sanity: can_send should be the disjunction of
+  // "credit is non-zero". The active-traffic encoding makes the SynthIdent
+  // resolvable, so we can phrase this directly.
+  assert can_send_iff_credit:
+    __chwire_data_can_send == (__chwire_data_credit != 3'd0);
+  assert valid_iff_occ:
+    __chwire_data_valid == (__chwire_data_occ != 3'd0);
+end module CreditPairActive

--- a/tests/formal_test.rs
+++ b/tests/formal_test.rs
@@ -171,6 +171,23 @@ fn formal_hier_multi_inst_proves() {
 }
 
 #[test]
+fn formal_credit_channel_active_proves() {
+    if !z3_available() { eprintln!("skipping: z3 not in PATH"); return; }
+    // Active-traffic version of the occupancy invariant: sender drives
+    // send_valid via can_send gating, receiver drives credit_return via
+    // valid gating. Also asserts the derived-signal equivalences
+    // (`can_send ⇔ credit != 0`, `valid ⇔ occ != 0`) which use the
+    // newly-resolvable SynthIdents added on top of PR-hf4 Phase 1.
+    let (code, out) = run_formal(
+        "tests/formal/credit_channel_active.arch",
+        &["--top", "CreditPairActive", "--bound", "8"],
+    );
+    assert_eq!(code, 0, "expected exit 0 (PROVED); got {code}\n{out}");
+    assert_eq!(out.matches("PROVED").count(), 3,
+               "expected 3 PROVEDs (credit_balance, can_send_iff_credit, valid_iff_occ):\n{out}");
+}
+
+#[test]
 fn formal_credit_channel_invariant_proves() {
     if !z3_available() { eprintln!("skipping: z3 not in PATH"); return; }
     // PR-hf4 Phase 1 end-to-end: the credit_channel occupancy invariant


### PR DESCRIPTION
## Summary

Two follow-ups to the recent credit_channel + NoC arc:

### Item 1 — Active-traffic formal (commit `e16d685`)

Resolves the PR-hf4 Phase 1 future-work item: register the codegen-derived
combinational signals `__<port>_<ch>_can_send` (= credit != 0) and
`__<port>_<ch>_valid` (= occ != 0) so user code that gates traffic on
them — the canonical credit_channel pattern — flows through formal cleanly.

- `SynthIdent` path in `encode_raw` matches `_can_send` / `_valid`
  suffixes and synthesizes the comparison against the lifted reg.
- `encode_ident` applies the same matching for user-written identifiers
  in asserts.
- New test `tests/formal/credit_channel_active.arch` proves three
  properties at bound 8: occupancy invariant + the two derived-signal
  equivalences, with active sender/receiver traffic gated on can_send/valid.

### Item 2 — Tier-2 SVA cross-check on the mesh (commit `798363d`)

Two SV codegen fixes uncovered by running Verilator `--assert` against
the 4×4 mesh:

1. **Bit-slice over-parenthesized**: `incoming.flits.data[31:4]`
   emitted `(__incoming_flits_data)[31:4]`, syntax error in Verilator.
   Add `SynthIdent` to the no-parens whitelist in BitSlice emission.

2. **Implicit bus wires undeclared in SV**: same bug class as
   PRs #110+#112 fixed in sim_codegen, but for SV codegen. Without
   per-flat-signal wire declarations on the parent, Verilator inferred
   1-bit IMPLICIT wires and silently truncated 32-bit `flits_send_data`.
   Design appeared dead. Now declared properly via the bus's effective
   signal table; dedup across insts AND within an inst.

`examples/mesh_noc_4x4/run_sva.sh` reproduces the cross-check end-to-end:

```
$ examples/mesh_noc_4x4/run_sva.sh
balanced: popped=1984
backpressure: popped=2473
recovery: popped=4465
=== SVA TB completed without violations ===
```

80 credit_channel SVA properties active across all routers — none fire.

## Test plan

- [x] `cargo build` clean
- [x] `cargo test` — 189 passing (+1 from active-formal test)
- [x] `examples/mesh_noc_4x4/run_sva.sh` — Verilator SVA passes

## Out of scope

- Track (a) AST-lift consolidation (multi-day cleanup, separate session)
- Active-traffic formal proof on the *full mesh* — current proof is on
  the 2-module scaffold. Formal scaling to 80 credit_channels is a
  separate exercise.