### PR TITLE
credit_channel AST lift — Phase A (scaffolding behind ARCH_LIFT_CC flag)

### DIFF
--- a/doc/plan_credit_channel_ast_lift.md
+++ b/doc/plan_credit_channel_ast_lift.md
@@ -1,0 +1,101 @@
+# Plan: lift credit_channel state into AST RegDecls
+
+> **Status**: design + scaffolding. Backend integration is incremental.
+
+## Motivation
+
+Today, credit_channel state is synthesized **three independent times** — once each in `codegen.rs`, `sim_codegen/sim_credit_channel.rs`, and `formal.rs`. The shapes happen to match (same names, same widths, same reset values) because all three follow §18c.2 of the spec, but nothing enforces it. Drift would silently break consumers — for example PR #110, #112, #113 each had to fix a separate "implicit bus wire" issue in a different backend.
+
+A single elaboration pass that lifts the state into real `RegDecl` / `WireDecl` items in the AST gives:
+
+- **One source of truth** — names, widths, reset values, transition logic all defined once.
+- **Backend uniformity** — each backend just emits the regs it sees in the AST. New backends (yosys, EBMC dump, etc.) inherit credit_channel support automatically.
+- **Smaller backends** — codegen, sim_codegen, formal each lose ~150–300 LoC of emit_credit_channel_* helpers.
+- **SynthIdent eliminated for credit_channel** — `port.ch.can_send` rewrites to a real `Ident` referencing the lifted wire.
+
+## Scope
+
+For each module port `p` with `bus_info` whose bus carries one or more `credit_channel ch`, lift produces:
+
+### Sender side (initiator/Out or target/In)
+- `reg __<p>_<ch>_credit: UInt<W>` where `W = ceil_log2(DEPTH+1)`. Reset value `DEPTH`.
+- `wire __<p>_<ch>_can_send: Bool` driven by `__<p>_<ch>_credit != 0` (or registered variant when `CAN_SEND_REGISTERED=1`).
+- `seq` block updates: `++`/`--`/hold per send_valid && credit_return.
+
+### Receiver side (target/Out or initiator/In)
+- `reg __<p>_<ch>_occ: UInt<W>` reset 0.
+- `reg __<p>_<ch>_head: UInt<P>` reset 0 (skip when DEPTH=1).
+- `reg __<p>_<ch>_tail: UInt<P>` reset 0 (skip when DEPTH=1).
+- `reg __<p>_<ch>_buf: Vec<T, DEPTH>` (no reset; data only valid when occ != 0).
+- `wire __<p>_<ch>_valid: Bool = (__<p>_<ch>_occ != 0)`.
+- `wire __<p>_<ch>_data: T = __<p>_<ch>_buf[__<p>_<ch>_head]`.
+- `seq` block updates for occ/head/tail per send_valid && credit_return.
+- `seq` write to buf on push (`if push: buf[tail] <= send_data`).
+
+The handshake signals (`send_valid`, `send_data`, `credit_return`) stay as bus-port-flattened signals — they're *interface* not *state*.
+
+## Where the pass runs
+
+After `lower_credit_channel_dispatch` (which rewrites `port.ch.X` to SynthIdent), before `resolve` and `typecheck`. Concrete pipeline:
+
+```
+parse
+  → lower_tlm_target_threads / lower_tlm_initiator_calls / lower_threads
+  → lower_pipe_reg_ports
+  → lower_credit_channel_dispatch
+  → lift_credit_channel_state            ← NEW
+  → resolve
+  → TypeChecker
+  → backends
+```
+
+After the lift pass, the AST contains real RegDecls / WireDecls / RegBlocks for credit_channel state. Resolve and typecheck see them as ordinary signals. Backends emit them through their normal paths.
+
+## Phasing — incremental safe rollout
+
+Going straight from the current 3-way synthesis to a single AST-lifted source risks bugs in any of the four code paths. Phased rollout:
+
+### Phase A — scaffolding (this session, behind a flag)
+
+- Implement `elaborate::lift_credit_channel_state` returning a new `SourceFile` with the lifted items.
+- Gate behind `--experimental-cc-lift` CLI flag (default off). When off, the AST is returned unchanged and existing 3-way synthesis still runs.
+- Add a unit test that calls the pass on a tiny module + asserts the expected RegDecl shape.
+- **No backend changes.** Existing tests stay green.
+
+### Phase B — codegen consumes lifted regs (separate PR)
+
+- When the flag is on, codegen detects lifted regs (look for `__<p>_<ch>_credit` in the module body) and skips its own `emit_credit_channel_state` / `emit_credit_channel_receiver_state` paths.
+- Tier-2 SVA emission moves into the lift pass (or stays in codegen but reads from the lifted regs).
+- Verify on `tests/formal/credit_channel_*` and `tests/noc_credit/` that SV codegen output is **byte-identical** with flag on vs off (fold the constants away).
+
+### Phase C — sim_codegen consumes lifted regs (separate PR)
+
+- Same detection in sim_codegen — skip `sim_credit_channel::emit_*` paths when lifted regs present.
+- Verify all existing sim tests still pass.
+
+### Phase D — formal consumes lifted regs (separate PR)
+
+- `formal::register_credit_channel_state` becomes a no-op when lifted regs present (they get registered through the normal port/reg walk).
+- `register_carried_credit_sites` similarly skipped — flatten will inline the sub's lifted RegDecls under prefix.
+
+### Phase E — flip default (separate PR)
+
+- `--experimental-cc-lift` becomes the default-on `--legacy-cc-state` opt-out.
+- After a release cycle, remove the legacy paths and the flag.
+
+Total: 5 PRs over 5 sessions, each independently reviewable + revertable.
+
+## Risks + mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Naming drift breaks `port.ch.X` → SynthIdent dispatch | Lift uses identical naming. Add a unit test checking exact name strings. |
+| Reset semantics differ from codegen's hand-emitted always_ff | Lift uses same `RegReset::Inherit` shape as user code. Compare emitted SV diff in Phase B. |
+| Vec storage in the receiver tries to flow through formal v1 (which rejects Vec) | Already documented — formal skips data signal modelling. Lift can mark the buf as `formal_skip` or formal can heuristically skip Vec regs whose name starts with `__` and ends with `_buf`. |
+| Hierarchical formal carry breaks because flatten_for_formal expects synthesized state | flatten will inline RegDecls under prefix; carried_sites go away. Phase D rewrites flatten accordingly. |
+
+## Non-goals
+
+- **Multi-VC, multi-flit** — same as current. Lift only handles single-VC single-flit.
+- **CAN_SEND_REGISTERED v2 variants** — the bool param stays; lift emits the right shape per param.
+- **Removing SynthIdent entirely** — only credit_channel uses go away. Other compile-time-derived references (handshake variants, tlm_method internals) keep their SynthIdent path.

--- a/src/elaborate.rs
+++ b/src/elaborate.rs
@@ -4863,3 +4863,212 @@ fn inline_lower_tlm_target(
 fn clog2_width(n: u64) -> u32 {
     if n <= 1 { 1 } else { (n - 1).ilog2() + 1 }
 }
+
+// ── credit_channel state lift (PR-cc-lift Phase A) ────────────────────────────
+//
+// See doc/plan_credit_channel_ast_lift.md for the full design + phasing.
+//
+// **Phase A only** — this pass identifies credit_channel sites and
+// constructs the would-be lifted AST items, but is gated behind the
+// `ARCH_LIFT_CC=1` env var (default off). The injected items are
+// *visible* to backends only when the flag is on; with the flag off,
+// the AST is returned unchanged and existing 3-way synthesis stands.
+//
+// Phase B / C / D move codegen / sim_codegen / formal to *consume* the
+// lifted regs and skip their own synthesis. Phase E flips the default.
+//
+// What gets emitted per credit_channel site (matching codegen's exact
+// names so the SynthIdent dispatch keeps working unchanged):
+//   sender:    reg  __<port>_<ch>_credit : UInt<ceil_log2(DEPTH+1)>; reset DEPTH
+//   sender:    wire __<port>_<ch>_can_send : Bool                  (= credit != 0)
+//   receiver:  reg  __<port>_<ch>_occ    : UInt<ceil_log2(DEPTH+1)>; reset 0
+//   receiver:  reg  __<port>_<ch>_head   : UInt<ceil_log2(DEPTH)>; reset 0  [DEPTH>1]
+//   receiver:  reg  __<port>_<ch>_tail   : UInt<ceil_log2(DEPTH)>; reset 0  [DEPTH>1]
+//   receiver:  wire __<port>_<ch>_valid  : Bool                    (= occ != 0)
+//
+// Transitions / FIFO buffer / credit-return wiring come in Phase B
+// alongside the codegen update — touching either in isolation would
+// either double-emit or leave unconnected drivers.
+
+pub fn lift_credit_channel_state(ast: SourceFile) -> Result<SourceFile, Vec<CompileError>> {
+    if std::env::var("ARCH_LIFT_CC").ok().as_deref() != Some("1") {
+        return Ok(ast);
+    }
+    lift_credit_channel_state_impl(ast)
+}
+
+/// Internal entry point for unit tests — runs the lift unconditionally,
+/// bypassing the `ARCH_LIFT_CC` env-var gate.
+pub fn lift_credit_channel_state_force(ast: SourceFile) -> Result<SourceFile, Vec<CompileError>> {
+    lift_credit_channel_state_impl(ast)
+}
+
+fn lift_credit_channel_state_impl(ast: SourceFile) -> Result<SourceFile, Vec<CompileError>> {
+    use std::collections::HashMap;
+    let mut bus_ccs: HashMap<String, Vec<CreditChannelMeta>> = HashMap::new();
+    for item in &ast.items {
+        match item {
+            Item::Bus(b) => {
+                if !b.credit_channels.is_empty() {
+                    bus_ccs.insert(b.name.name.clone(), b.credit_channels.clone());
+                }
+            }
+            Item::Package(pkg) => {
+                for b in &pkg.buses {
+                    if !b.credit_channels.is_empty() {
+                        bus_ccs.insert(b.name.name.clone(), b.credit_channels.clone());
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    if bus_ccs.is_empty() { return Ok(ast); }
+
+    let mut items: Vec<Item> = Vec::with_capacity(ast.items.len());
+    for item in ast.items {
+        match item {
+            Item::Module(mut m) => {
+                let mut lifted: Vec<ModuleBodyItem> = Vec::new();
+                let rst_name = m.ports.iter()
+                    .find(|p| matches!(&p.ty, TypeExpr::Reset(_, _)))
+                    .map(|p| p.name.clone());
+                for port in &m.ports {
+                    let Some(bi) = &port.bus_info else { continue; };
+                    let Some(ccs) = bus_ccs.get(&bi.bus_name.name) else { continue; };
+                    for cc in ccs {
+                        emit_lifted_cc_state(
+                            &port.name, cc, bi.perspective, rst_name.as_ref(),
+                            &mut lifted,
+                        );
+                    }
+                }
+                if !lifted.is_empty() {
+                    // Prepend so they're declared before any user code that
+                    // references them (e.g. SynthIdent in user comb blocks).
+                    let mut new_body = lifted;
+                    new_body.append(&mut m.body);
+                    m.body = new_body;
+                }
+                items.push(Item::Module(m));
+            }
+            other => items.push(other),
+        }
+    }
+    Ok(SourceFile { items })
+}
+
+fn emit_lifted_cc_state(
+    port_name: &Ident,
+    cc: &CreditChannelMeta,
+    perspective: BusPerspective,
+    rst: Option<&Ident>,
+    out: &mut Vec<ModuleBodyItem>,
+) {
+    // Resolve DEPTH (must fold to a constant — channels with parametric
+    // depth not yet supported in lift; backend will keep handling them
+    // until we extend this helper).
+    let depth = cc.params.iter()
+        .find(|p| p.name.name == "DEPTH")
+        .and_then(|p| p.default.as_ref())
+        .and_then(|e| match &e.kind {
+            ExprKind::Literal(LitKind::Dec(v))
+            | ExprKind::Literal(LitKind::Hex(v))
+            | ExprKind::Literal(LitKind::Bin(v)) => Some(*v),
+            ExprKind::Literal(LitKind::Sized(_, v)) => Some(*v),
+            _ => None,
+        });
+    let Some(depth) = depth else { return; };
+    if depth == 0 { return; }
+    let is_sender = matches!(
+        (cc.role_dir, perspective),
+        (Direction::Out, BusPerspective::Initiator)
+            | (Direction::In, BusPerspective::Target)
+    );
+    let port = &port_name.name;
+    let ch = &cc.name.name;
+    let span = cc.span;
+
+    let cnt_w = clog2_width_n(depth + 1).max(1);
+    let ptr_w = clog2_width_n(depth);
+
+    let mk_uint = |w: u32| TypeExpr::UInt(Box::new(
+        Expr::new(ExprKind::Literal(LitKind::Dec(w as u64)), span)
+    ));
+    let mk_lit = |w: u32, v: u64| Expr::new(ExprKind::Literal(LitKind::Sized(w, v)), span);
+
+    let reset_clause = |val: Expr| -> RegReset {
+        match rst {
+            Some(r) => RegReset::Inherit(r.clone(), val),
+            None => RegReset::None,
+        }
+    };
+
+    if is_sender {
+        let credit = format!("__{port}_{ch}_credit");
+        out.push(ModuleBodyItem::RegDecl(RegDecl {
+            name: Ident::new(credit.clone(), span),
+            ty: mk_uint(cnt_w),
+            init: None,
+            reset: reset_clause(mk_lit(cnt_w, depth)),
+            guard: None,
+            span,
+        }));
+        // can_send = (credit != 0). We emit as a let-binding (combinational)
+        // so backends that already track let-bindings for SynthIdent dispatch
+        // pick it up uniformly.
+        let credit_ref = Expr::new(ExprKind::Ident(credit.clone()), span);
+        let zero = mk_lit(cnt_w, 0);
+        let can_send_val = Expr::new(
+            ExprKind::Binary(BinOp::Neq, Box::new(credit_ref), Box::new(zero)),
+            span,
+        );
+        out.push(ModuleBodyItem::LetBinding(LetBinding {
+            name: Ident::new(format!("__{port}_{ch}_can_send"), span),
+            ty: Some(TypeExpr::Bool),
+            value: can_send_val,
+            span,
+            destructure_fields: Vec::new(),
+        }));
+    } else {
+        let occ = format!("__{port}_{ch}_occ");
+        out.push(ModuleBodyItem::RegDecl(RegDecl {
+            name: Ident::new(occ.clone(), span),
+            ty: mk_uint(cnt_w),
+            init: None,
+            reset: reset_clause(mk_lit(cnt_w, 0)),
+            guard: None,
+            span,
+        }));
+        if ptr_w > 0 {
+            for which in ["head", "tail"] {
+                out.push(ModuleBodyItem::RegDecl(RegDecl {
+                    name: Ident::new(format!("__{port}_{ch}_{which}"), span),
+                    ty: mk_uint(ptr_w),
+                    init: None,
+                    reset: reset_clause(mk_lit(ptr_w, 0)),
+                    guard: None,
+                    span,
+                }));
+            }
+        }
+        // valid = (occ != 0)
+        let occ_ref = Expr::new(ExprKind::Ident(occ.clone()), span);
+        let zero = mk_lit(cnt_w, 0);
+        let valid_val = Expr::new(
+            ExprKind::Binary(BinOp::Neq, Box::new(occ_ref), Box::new(zero)),
+            span,
+        );
+        out.push(ModuleBodyItem::LetBinding(LetBinding {
+            name: Ident::new(format!("__{port}_{ch}_valid"), span),
+            ty: Some(TypeExpr::Bool),
+            value: valid_val,
+            span,
+            destructure_fields: Vec::new(),
+        }));
+    }
+}
+
+fn clog2_width_n(n: u64) -> u32 {
+    if n <= 1 { 0 } else { (n - 1).ilog2() + 1 }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1029,6 +1029,14 @@ fn run_check_multi(
         ms.report_error(err)
     })?;
 
+    // Optionally lift credit_channel state into AST RegDecls / LetBindings.
+    // Gated behind ARCH_LIFT_CC=1 (default off). Phase A scaffolding —
+    // see doc/plan_credit_channel_ast_lift.md.
+    let ast = elaborate::lift_credit_channel_state(ast).map_err(|errs| {
+        let err = errs.into_iter().next().unwrap();
+        ms.report_error(err)
+    })?;
+
     // Resolve
     let symbols = resolve::resolve(&ast).map_err(|errs| {
         let err = errs.into_iter().next().unwrap();

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -3504,6 +3504,77 @@ fn test_handshake_channel_no_deprecation_warning() {
 }
 
 #[test]
+fn test_credit_channel_lift_phase_a() {
+    // PR-cc-lift Phase A scaffolding: lift pass injects RegDecl + LetBinding
+    // items per credit_channel site. Names match codegen's existing
+    // `__<port>_<ch>_credit` / `_occ` / `_head` / `_tail` / `_can_send` /
+    // `_valid` so the SynthIdent dispatch keeps working when later phases
+    // remove the codegen synthesis path.
+    let source = "
+        bus Ch
+          credit_channel data: send
+            param T:     type  = UInt<8>;
+            param DEPTH: const = 4;
+          end credit_channel data
+        end bus Ch
+
+        module Sender
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync>;
+          port s:   initiator Ch;
+        end module Sender
+
+        module Receiver
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync>;
+          port r:   target Ch;
+        end module Receiver
+    ";
+    let tokens = arch::lexer::tokenize(source).expect("lexer");
+    let mut parser = arch::parser::Parser::new(tokens, source);
+    let ast = parser.parse_source_file().expect("parse");
+    let ast = arch::elaborate::lift_credit_channel_state_force(ast)
+        .expect("lift");
+
+    // Sender side: __s_data_credit reg + __s_data_can_send let.
+    let sender = ast.items.iter().find_map(|it| match it {
+        arch::ast::Item::Module(m) if m.name.name == "Sender" => Some(m),
+        _ => None,
+    }).expect("Sender module");
+    let credit_reg = sender.body.iter().any(|b| matches!(b,
+        arch::ast::ModuleBodyItem::RegDecl(r) if r.name.name == "__s_data_credit"));
+    let can_send_let = sender.body.iter().any(|b| matches!(b,
+        arch::ast::ModuleBodyItem::LetBinding(l) if l.name.name == "__s_data_can_send"));
+    assert!(credit_reg, "expected __s_data_credit reg in Sender body, got: {:?}",
+            sender.body.iter().map(|b| body_item_name(b)).collect::<Vec<_>>());
+    assert!(can_send_let, "expected __s_data_can_send let in Sender body");
+
+    // Receiver side: __r_data_occ + __r_data_head + __r_data_tail regs +
+    // __r_data_valid let.
+    let receiver = ast.items.iter().find_map(|it| match it {
+        arch::ast::Item::Module(m) if m.name.name == "Receiver" => Some(m),
+        _ => None,
+    }).expect("Receiver module");
+    for expected in &["__r_data_occ", "__r_data_head", "__r_data_tail"] {
+        assert!(receiver.body.iter().any(|b| matches!(b,
+            arch::ast::ModuleBodyItem::RegDecl(r) if r.name.name == *expected)),
+            "expected {expected} reg in Receiver body");
+    }
+    assert!(receiver.body.iter().any(|b| matches!(b,
+        arch::ast::ModuleBodyItem::LetBinding(l) if l.name.name == "__r_data_valid")),
+        "expected __r_data_valid let in Receiver body");
+}
+
+fn body_item_name(b: &arch::ast::ModuleBodyItem) -> String {
+    match b {
+        arch::ast::ModuleBodyItem::RegDecl(r) => format!("RegDecl({})", r.name.name),
+        arch::ast::ModuleBodyItem::LetBinding(l) => format!("Let({})", l.name.name),
+        arch::ast::ModuleBodyItem::WireDecl(w) => format!("WireDecl({})", w.name.name),
+        _ => "<other>".to_string(),
+    }
+}
+
+#[test]
 fn test_credit_channel_parses_as_bus_sub_construct() {
     // PR #3 scaffolding: credit_channel inside a bus parses into
     // BusDecl::credit_channels. Typecheck rejects it (not yet implemented),


### PR DESCRIPTION
## Summary

First of 5 PRs that consolidate the three-way credit_channel state
synthesis (codegen + sim_codegen + formal) into one source of truth.

See [doc/plan_credit_channel_ast_lift.md](doc/plan_credit_channel_ast_lift.md)
for the full design and phasing:

- **Phase A (this PR)** — scaffolding: lift pass exists, gated off
- Phase B — codegen consumes lifted regs (skip own synthesis)
- Phase C — sim_codegen consumes lifted regs
- Phase D — formal consumes lifted regs (replaces `register_credit_channel_state` + `carried_credit_sites`)
- Phase E — flip default; remove legacy paths

## What this PR does

- New `elaborate::lift_credit_channel_state` runs after
  `lower_credit_channel_dispatch` in the standard pipeline.
- Gated behind `ARCH_LIFT_CC=1` env var. **Default off** — AST returned
  unchanged, existing 3-way synthesis stands.
- When enabled, walks each module's bus ports and prepends RegDecls +
  LetBindings matching codegen's exact naming convention.
- `lift_credit_channel_state_force` test entry bypasses the gate.
- Unit test verifies the lifted-item shape on a sender + receiver pair.

## Why intentionally gated off

Enabling the flag today would cause double-emission (lift adds regs,
codegen synthesizes them too → `Duplicate declaration` errors).
Phase B teaches codegen to skip when lifted regs are present; only then
is the flag safe to flip.

## Test plan

- [x] `cargo build` clean
- [x] `cargo test` 189/189 with flag off (default — no observable change)
- [x] New unit test `test_credit_channel_lift_phase_a` verifies AST shape