### PR TITLE
typecheck: reject pipeline stage refs that skip stages (critique #4)

### DIFF
--- a/doc/plan_credit_channel_ast_lift.md
+++ b/doc/plan_credit_channel_ast_lift.md
@@ -1,0 +1,125 @@
+# Plan: lift credit_channel state into AST RegDecls
+
+> **Status (2026-04-23): DEFERRED — premature consolidation.**
+>
+> Phase A scaffolding was implemented in PR #114 (closed) and the
+> rationale was reviewed. The "drift risk" motivation is theoretical:
+> the three synthesis paths (codegen / sim_codegen / formal) have
+> stayed in sync since credit_channel shipped, and the recent compiler
+> bugs in this area (PRs #110 / #112 / #113) were about implicit bus
+> wires — not credit_channel state drift. AST-lift wouldn't have
+> prevented them.
+>
+> Revisit this plan if/when one of the following triggers fires:
+> - A real drift bug appears (a credit_channel feature that works in
+>   one backend but not another because the synthesis paths diverged).
+> - A new backend (yosys, custom RTL emitter, third-party formal tool)
+>   needs credit_channel support and the duplication becomes painful.
+> - An incremental feature (multi-VC, batched credit return, CDC
+>   credit channels) requires changing the state shape in all three
+>   places at once and the consolidation pays for itself.
+>
+> Until then, the 3-way synthesis is fine. This doc stays as a
+> "we already thought about this" reference.
+
+---
+
+## Original design + scaffolding
+
+## Motivation
+
+Today, credit_channel state is synthesized **three independent times** — once each in `codegen.rs`, `sim_codegen/sim_credit_channel.rs`, and `formal.rs`. The shapes happen to match (same names, same widths, same reset values) because all three follow §18c.2 of the spec, but nothing enforces it. Drift would silently break consumers — for example PR #110, #112, #113 each had to fix a separate "implicit bus wire" issue in a different backend.
+
+A single elaboration pass that lifts the state into real `RegDecl` / `WireDecl` items in the AST gives:
+
+- **One source of truth** — names, widths, reset values, transition logic all defined once.
+- **Backend uniformity** — each backend just emits the regs it sees in the AST. New backends (yosys, EBMC dump, etc.) inherit credit_channel support automatically.
+- **Smaller backends** — codegen, sim_codegen, formal each lose ~150–300 LoC of emit_credit_channel_* helpers.
+- **SynthIdent eliminated for credit_channel** — `port.ch.can_send` rewrites to a real `Ident` referencing the lifted wire.
+
+## Scope
+
+For each module port `p` with `bus_info` whose bus carries one or more `credit_channel ch`, lift produces:
+
+### Sender side (initiator/Out or target/In)
+- `reg __<p>_<ch>_credit: UInt<W>` where `W = ceil_log2(DEPTH+1)`. Reset value `DEPTH`.
+- `wire __<p>_<ch>_can_send: Bool` driven by `__<p>_<ch>_credit != 0` (or registered variant when `CAN_SEND_REGISTERED=1`).
+- `seq` block updates: `++`/`--`/hold per send_valid && credit_return.
+
+### Receiver side (target/Out or initiator/In)
+- `reg __<p>_<ch>_occ: UInt<W>` reset 0.
+- `reg __<p>_<ch>_head: UInt<P>` reset 0 (skip when DEPTH=1).
+- `reg __<p>_<ch>_tail: UInt<P>` reset 0 (skip when DEPTH=1).
+- `reg __<p>_<ch>_buf: Vec<T, DEPTH>` (no reset; data only valid when occ != 0).
+- `wire __<p>_<ch>_valid: Bool = (__<p>_<ch>_occ != 0)`.
+- `wire __<p>_<ch>_data: T = __<p>_<ch>_buf[__<p>_<ch>_head]`.
+- `seq` block updates for occ/head/tail per send_valid && credit_return.
+- `seq` write to buf on push (`if push: buf[tail] <= send_data`).
+
+The handshake signals (`send_valid`, `send_data`, `credit_return`) stay as bus-port-flattened signals — they're *interface* not *state*.
+
+## Where the pass runs
+
+After `lower_credit_channel_dispatch` (which rewrites `port.ch.X` to SynthIdent), before `resolve` and `typecheck`. Concrete pipeline:
+
+```
+parse
+  → lower_tlm_target_threads / lower_tlm_initiator_calls / lower_threads
+  → lower_pipe_reg_ports
+  → lower_credit_channel_dispatch
+  → lift_credit_channel_state            ← NEW
+  → resolve
+  → TypeChecker
+  → backends
+```
+
+After the lift pass, the AST contains real RegDecls / WireDecls / RegBlocks for credit_channel state. Resolve and typecheck see them as ordinary signals. Backends emit them through their normal paths.
+
+## Phasing — incremental safe rollout
+
+Going straight from the current 3-way synthesis to a single AST-lifted source risks bugs in any of the four code paths. Phased rollout:
+
+### Phase A — scaffolding (this session, behind a flag)
+
+- Implement `elaborate::lift_credit_channel_state` returning a new `SourceFile` with the lifted items.
+- Gate behind `--experimental-cc-lift` CLI flag (default off). When off, the AST is returned unchanged and existing 3-way synthesis still runs.
+- Add a unit test that calls the pass on a tiny module + asserts the expected RegDecl shape.
+- **No backend changes.** Existing tests stay green.
+
+### Phase B — codegen consumes lifted regs (separate PR)
+
+- When the flag is on, codegen detects lifted regs (look for `__<p>_<ch>_credit` in the module body) and skips its own `emit_credit_channel_state` / `emit_credit_channel_receiver_state` paths.
+- Tier-2 SVA emission moves into the lift pass (or stays in codegen but reads from the lifted regs).
+- Verify on `tests/formal/credit_channel_*` and `tests/noc_credit/` that SV codegen output is **byte-identical** with flag on vs off (fold the constants away).
+
+### Phase C — sim_codegen consumes lifted regs (separate PR)
+
+- Same detection in sim_codegen — skip `sim_credit_channel::emit_*` paths when lifted regs present.
+- Verify all existing sim tests still pass.
+
+### Phase D — formal consumes lifted regs (separate PR)
+
+- `formal::register_credit_channel_state` becomes a no-op when lifted regs present (they get registered through the normal port/reg walk).
+- `register_carried_credit_sites` similarly skipped — flatten will inline the sub's lifted RegDecls under prefix.
+
+### Phase E — flip default (separate PR)
+
+- `--experimental-cc-lift` becomes the default-on `--legacy-cc-state` opt-out.
+- After a release cycle, remove the legacy paths and the flag.
+
+Total: 5 PRs over 5 sessions, each independently reviewable + revertable.
+
+## Risks + mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Naming drift breaks `port.ch.X` → SynthIdent dispatch | Lift uses identical naming. Add a unit test checking exact name strings. |
+| Reset semantics differ from codegen's hand-emitted always_ff | Lift uses same `RegReset::Inherit` shape as user code. Compare emitted SV diff in Phase B. |
+| Vec storage in the receiver tries to flow through formal v1 (which rejects Vec) | Already documented — formal skips data signal modelling. Lift can mark the buf as `formal_skip` or formal can heuristically skip Vec regs whose name starts with `__` and ends with `_buf`. |
+| Hierarchical formal carry breaks because flatten_for_formal expects synthesized state | flatten will inline RegDecls under prefix; carried_sites go away. Phase D rewrites flatten accordingly. |
+
+## Non-goals
+
+- **Multi-VC, multi-flit** — same as current. Lift only handles single-VC single-flit.
+- **CAN_SEND_REGISTERED v2 variants** — the bool param stays; lift emits the right shape per param.
+- **Removing SynthIdent entirely** — only credit_channel uses go away. Other compile-time-derived references (handshake variants, tlm_method internals) keep their SynthIdent path.

--- a/examples/cpu_pipeline.arch
+++ b/examples/cpu_pipeline.arch
@@ -64,11 +64,16 @@ pipeline CpuPipe
     reg rd: UInt<REG_ADDR_W> reset rst => 0;
     reg rs1_val: UInt<XLEN> reset rst => 0;
     reg rs2_val: UInt<XLEN> reset rst => 0;
+    // Pass PC forward stage-by-stage (registered) instead of doing
+    // `pc_out = Fetch.pc` in Writeback, which would emit a 3-hop
+    // combinational path through the pipeline.
+    reg pc: UInt<XLEN> reset rst => 0;
     seq on clk rising
       opcode  <= Fetch.instr[6:0];
       rd      <= Fetch.instr[11:7];
       rs1_val <= rs1_data;
       rs2_val <= rs2_data;
+      pc      <= Fetch.pc;
     end seq
     // Explicit forwarding mux: bypass ALU result on RAW hazard
     comb
@@ -85,10 +90,12 @@ pipeline CpuPipe
     reg alu_result: UInt<XLEN> reset rst => 0;
     reg rd: UInt<REG_ADDR_W> reset rst => 0;
     reg we: Bool reset rst => false;
+    reg pc: UInt<XLEN> reset rst => 0;
     seq on clk rising
       alu_result <= alu_out;
       rd <= Decode.rd;
       we <= Decode.opcode != 0;
+      pc <= Decode.pc;
     end seq
     // Combinational ALU instance
     inst alu0: Alu
@@ -104,16 +111,18 @@ pipeline CpuPipe
     reg result: UInt<XLEN> reset rst => 0;
     reg rd: UInt<REG_ADDR_W> reset rst => 0;
     reg valid: Bool reset rst => false;
+    reg pc: UInt<XLEN> reset rst => 0;
     seq on clk rising
       result <= Execute.alu_result;
       rd <= Execute.rd;
       valid <= Execute.we;
+      pc <= Execute.pc;
     end seq
     comb
       wb_data = result;
       wb_rd = rd;
       wb_we = valid and valid_r;
-      pc_out = Fetch.pc;
+      pc_out = pc;
     end comb
   end stage Writeback
 

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -3842,6 +3842,147 @@ impl<'a> TypeChecker<'a> {
     }
     // ── Pipeline ──────────────────────────────────────────────────────────────
 
+    /// Walk a body item and report any `<Stage>.<field>` reference
+    /// whose target stage is more than one hop from the owning stage.
+    /// Stall conditions, flush directives, and forward directives are
+    /// hazard signals and live outside the body — they're intentionally
+    /// exempt from this check.
+    fn collect_pipeline_cross_stage_refs(
+        &mut self,
+        item: &ModuleBodyItem,
+        cur_idx: usize,
+        stage_idx: &HashMap<&str, usize>,
+        cur_name: &str,
+    ) {
+        match item {
+            ModuleBodyItem::CombBlock(cb) => {
+                for s in &cb.stmts { self.walk_pipeline_comb_stmt(s, cur_idx, stage_idx, cur_name); }
+            }
+            ModuleBodyItem::RegBlock(rb) => {
+                for s in &rb.stmts { self.walk_pipeline_stmt(s, cur_idx, stage_idx, cur_name); }
+            }
+            ModuleBodyItem::LetBinding(lb) => {
+                self.check_pipeline_cross_stage_expr(&lb.value, cur_idx, stage_idx, cur_name);
+            }
+            ModuleBodyItem::RegDecl(rd) => {
+                if let Some(init) = &rd.init {
+                    self.check_pipeline_cross_stage_expr(init, cur_idx, stage_idx, cur_name);
+                }
+                if let RegReset::Inherit(_, val) | RegReset::Explicit(_, _, _, val) = &rd.reset {
+                    self.check_pipeline_cross_stage_expr(val, cur_idx, stage_idx, cur_name);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn walk_pipeline_comb_stmt(
+        &mut self, s: &CombStmt, cur_idx: usize,
+        stage_idx: &HashMap<&str, usize>, cur_name: &str,
+    ) {
+        match s {
+            CombStmt::Assign(a) => {
+                self.check_pipeline_cross_stage_expr(&a.value, cur_idx, stage_idx, cur_name);
+            }
+            CombStmt::IfElse(ie) => {
+                self.check_pipeline_cross_stage_expr(&ie.cond, cur_idx, stage_idx, cur_name);
+                for s in &ie.then_stmts { self.walk_pipeline_comb_stmt(s, cur_idx, stage_idx, cur_name); }
+                for s in &ie.else_stmts { self.walk_pipeline_comb_stmt(s, cur_idx, stage_idx, cur_name); }
+            }
+            _ => {}
+        }
+    }
+
+    fn walk_pipeline_stmt(
+        &mut self, s: &Stmt, cur_idx: usize,
+        stage_idx: &HashMap<&str, usize>, cur_name: &str,
+    ) {
+        match s {
+            Stmt::Assign(a) => {
+                self.check_pipeline_cross_stage_expr(&a.value, cur_idx, stage_idx, cur_name);
+            }
+            Stmt::IfElse(ie) => {
+                self.check_pipeline_cross_stage_expr(&ie.cond, cur_idx, stage_idx, cur_name);
+                for s in &ie.then_stmts { self.walk_pipeline_stmt(s, cur_idx, stage_idx, cur_name); }
+                for s in &ie.else_stmts { self.walk_pipeline_stmt(s, cur_idx, stage_idx, cur_name); }
+            }
+            _ => {}
+        }
+    }
+
+    fn check_pipeline_cross_stage_expr(
+        &mut self, expr: &Expr, cur_idx: usize,
+        stage_idx: &HashMap<&str, usize>, cur_name: &str,
+    ) {
+        match &expr.kind {
+            ExprKind::FieldAccess(base, _field) => {
+                if let ExprKind::Ident(name) = &base.kind {
+                    if let Some(&j) = stage_idx.get(name.as_str()) {
+                        // Only flag backward references that *skip* a stage,
+                        // i.e. j < cur_idx - 1. These bypass the intermediate
+                        // stages' registers and emit a direct combinational
+                        // path. Self (j == cur_idx) and previous-stage
+                        // (j + 1 == cur_idx) reads are the canonical data-flow
+                        // patterns. Forward references (j > cur_idx) are
+                        // hazard reads — Decode reading Execute for forwarding
+                        // / load-use stall — and are intentional.
+                        if j + 1 < cur_idx {
+                            let hops = cur_idx - j;
+                            self.errors.push(CompileError::general(
+                                &format!(
+                                    "pipeline stage `{cur_name}` references stage `{name}` ({hops} stages back), bypassing the intermediate stages' registers. This emits a direct combinational path that silently breaks timing. Pass the value forward through stage registers (one register per intermediate stage). Forward references (Decode reading Execute, etc.) are allowed because they're hazard reads, but backward references must go through registered pipeline state.",
+                                ),
+                                expr.span,
+                            ));
+                        }
+                    }
+                }
+                // Recurse to catch nested cases like `Stage.field.bit`.
+                self.check_pipeline_cross_stage_expr(base, cur_idx, stage_idx, cur_name);
+            }
+            ExprKind::Binary(_, l, r) => {
+                self.check_pipeline_cross_stage_expr(l, cur_idx, stage_idx, cur_name);
+                self.check_pipeline_cross_stage_expr(r, cur_idx, stage_idx, cur_name);
+            }
+            ExprKind::Unary(_, e) | ExprKind::Cast(e, _) | ExprKind::Clog2(e)
+            | ExprKind::Onehot(e) | ExprKind::Signed(e) | ExprKind::Unsigned(e)
+            | ExprKind::LatencyAt(e, _) => {
+                self.check_pipeline_cross_stage_expr(e, cur_idx, stage_idx, cur_name);
+            }
+            ExprKind::Index(b, i) => {
+                self.check_pipeline_cross_stage_expr(b, cur_idx, stage_idx, cur_name);
+                self.check_pipeline_cross_stage_expr(i, cur_idx, stage_idx, cur_name);
+            }
+            ExprKind::BitSlice(b, hi, lo) => {
+                self.check_pipeline_cross_stage_expr(b, cur_idx, stage_idx, cur_name);
+                self.check_pipeline_cross_stage_expr(hi, cur_idx, stage_idx, cur_name);
+                self.check_pipeline_cross_stage_expr(lo, cur_idx, stage_idx, cur_name);
+            }
+            ExprKind::PartSelect(b, s, w, _) => {
+                self.check_pipeline_cross_stage_expr(b, cur_idx, stage_idx, cur_name);
+                self.check_pipeline_cross_stage_expr(s, cur_idx, stage_idx, cur_name);
+                self.check_pipeline_cross_stage_expr(w, cur_idx, stage_idx, cur_name);
+            }
+            ExprKind::Ternary(c, t, e) => {
+                self.check_pipeline_cross_stage_expr(c, cur_idx, stage_idx, cur_name);
+                self.check_pipeline_cross_stage_expr(t, cur_idx, stage_idx, cur_name);
+                self.check_pipeline_cross_stage_expr(e, cur_idx, stage_idx, cur_name);
+            }
+            ExprKind::Concat(xs) | ExprKind::FunctionCall(_, xs) => {
+                for x in xs { self.check_pipeline_cross_stage_expr(x, cur_idx, stage_idx, cur_name); }
+            }
+            ExprKind::Repeat(n, x) => {
+                self.check_pipeline_cross_stage_expr(n, cur_idx, stage_idx, cur_name);
+                self.check_pipeline_cross_stage_expr(x, cur_idx, stage_idx, cur_name);
+            }
+            ExprKind::MethodCall(recv, _, args) => {
+                self.check_pipeline_cross_stage_expr(recv, cur_idx, stage_idx, cur_name);
+                for a in args { self.check_pipeline_cross_stage_expr(a, cur_idx, stage_idx, cur_name); }
+            }
+            _ => {}
+        }
+    }
+
     fn check_pipeline(&mut self, p: &PipelineDecl) {
         self.check_pascal_case(&p.name);
 
@@ -3880,6 +4021,25 @@ impl<'a> TypeChecker<'a> {
                     ModuleBodyItem::Inst(inst) => self.check_snake_case(&inst.name),
                     _ => {}
                 }
+            }
+        }
+
+        // Cross-stage span check: in a stage's body (data path),
+        // `<Stage>.<field>` references are allowed only for self
+        // (`<Stage_i>.<field>`) and the immediately preceding stage
+        // (`<Stage_{i-1}>.<field>`). References that span more than one
+        // hop emit a direct combinational path through the pipeline,
+        // bypassing the intermediate stages' registers — silently
+        // breaks timing. Hazard expressions (stall_cond / flush /
+        // forward) live outside `stage.body` and are intentionally
+        // exempt.
+        let stage_idx: HashMap<&str, usize> = stage_names.iter()
+            .enumerate()
+            .map(|(i, n)| (*n, i))
+            .collect();
+        for (i, stage) in p.stages.iter().enumerate() {
+            for item in &stage.body {
+                self.collect_pipeline_cross_stage_refs(item, i, &stage_idx, &stage.name.name);
             }
         }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1169,7 +1169,9 @@ fn test_cpu_pipeline() {
     assert!(sv.contains("execute_alu_result"), "missing rewritten execute ref");
     // Outputs
     assert!(sv.contains("assign wb_data = writeback_result"), "missing wb output");
-    assert!(sv.contains("assign pc_out = fetch_pc"), "missing pc output");
+    // pc is now passed forward through registered stages instead of
+    // being read directly from Fetch (which would be a 3-hop bypass).
+    assert!(sv.contains("assign pc_out = writeback_pc"), "missing pc output");
     // Explicit forwarding mux
     assert!(sv.contains("decode_rs1_fwd"), "missing forwarding mux wire");
     assert!(sv.contains("always_comb"), "missing always_comb for forwarding mux");
@@ -1218,6 +1220,109 @@ end module BitExtract
     // trunc<14,12>() → instr[14:12]
     assert!(sv.contains("instr[14:12]"), "expected trunc<14,12> → instr[14:12], got:\n{sv}");
     insta::assert_snapshot!(sv);
+}
+
+#[test]
+fn test_pipeline_cross_stage_skip_rejected() {
+    // Regression for #4 (pipeline_critique): a stage that reads from
+    // a stage more than one hop back must error at typecheck. The
+    // reference would emit a direct combinational path bypassing the
+    // intermediate stages' registers.
+    let source = r#"
+domain SysDomain
+  freq_mhz: 100
+end domain SysDomain
+
+pipeline SkipBypass
+  param XLEN: const = 32;
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port data_in: in UInt<XLEN>;
+  port out: out UInt<XLEN>;
+
+  stage Fetch
+    reg captured: UInt<XLEN> reset rst => 0;
+    seq on clk rising
+      captured <= data_in;
+    end seq
+  end stage Fetch
+
+  stage Decode
+    reg copy: UInt<XLEN> reset rst => 0;
+    seq on clk rising
+      copy <= Fetch.captured;
+    end seq
+  end stage Decode
+
+  stage Writeback
+    reg result: UInt<XLEN> reset rst => 0;
+    seq on clk rising
+      result <= Decode.copy;
+    end seq
+    comb
+      // BAD: reaches back two stages — bypasses Decode's register.
+      out = Fetch.captured;
+    end comb
+  end stage Writeback
+end pipeline SkipBypass
+"#;
+    let tokens = arch::lexer::tokenize(source).expect("lexer");
+    let mut parser = arch::parser::Parser::new(tokens, source);
+    let ast = parser.parse_source_file().expect("parse");
+    let symbols = arch::resolve::resolve(&ast).expect("resolve");
+    let checker = arch::typecheck::TypeChecker::new(&symbols, &ast);
+    let result = checker.check();
+    let errs = result.expect_err("expected typecheck to flag the 2-hop bypass");
+    let msg = errs.iter().map(|e| format!("{e:?}")).collect::<String>();
+    assert!(msg.contains("bypassing the intermediate"),
+            "expected bypass message, got: {msg}");
+}
+
+#[test]
+fn test_pipeline_forward_reference_allowed() {
+    // Forward references (Decode reading Execute) are hazard reads and
+    // must NOT be flagged by the cross-stage span check — they're the
+    // canonical pattern for forwarding muxes and load-use stall checks.
+    let source = r#"
+domain SysDomain
+  freq_mhz: 100
+end domain SysDomain
+
+pipeline ForwardRead
+  param XLEN: const = 32;
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port data_in: in UInt<XLEN>;
+  port out: out UInt<XLEN>;
+
+  stage Decode
+    reg val: UInt<XLEN> reset rst => 0;
+    seq on clk rising
+      val <= data_in;
+    end seq
+    comb
+      // Forward read into Execute is allowed (hazard).
+      forwarded = Execute.result;
+    end comb
+  end stage Decode
+
+  stage Execute
+    reg result: UInt<XLEN> reset rst => 0;
+    seq on clk rising
+      result <= Decode.val;
+    end seq
+    comb
+      out = result;
+    end comb
+  end stage Execute
+end pipeline ForwardRead
+"#;
+    let tokens = arch::lexer::tokenize(source).expect("lexer");
+    let mut parser = arch::parser::Parser::new(tokens, source);
+    let ast = parser.parse_source_file().expect("parse");
+    let symbols = arch::resolve::resolve(&ast).expect("resolve");
+    let checker = arch::typecheck::TypeChecker::new(&symbols, &ast);
+    checker.check().expect("forward-reference pattern should typecheck");
 }
 
 #[test]

--- a/tests/snapshots/integration_test__cpu_pipeline.snap
+++ b/tests/snapshots/integration_test__cpu_pipeline.snap
@@ -48,14 +48,17 @@ module CpuPipe #(
   logic [REG_ADDR_W-1:0] decode_rd = 0;
   logic [XLEN-1:0] decode_rs1_val = 0;
   logic [XLEN-1:0] decode_rs2_val = 0;
+  logic [XLEN-1:0] decode_pc = 0;
   logic [XLEN-1:0] decode_rs1_fwd;
   logic [XLEN-1:0] execute_alu_result = 0;
   logic [REG_ADDR_W-1:0] execute_rd = 0;
   logic execute_we = 1'b0;
+  logic [XLEN-1:0] execute_pc = 0;
   logic [XLEN-1:0] execute_alu_out;
   logic [XLEN-1:0] writeback_result = 0;
   logic [REG_ADDR_W-1:0] writeback_rd = 0;
   logic writeback_valid = 1'b0;
+  logic [XLEN-1:0] writeback_pc = 0;
   
   // ── Stall signals ──
   logic fetch_stall;
@@ -78,14 +81,17 @@ module CpuPipe #(
       decode_rd <= 0;
       decode_rs1_val <= 0;
       decode_rs2_val <= 0;
+      decode_pc <= 0;
       execute_valid_r <= 1'b0;
       execute_alu_result <= 0;
       execute_rd <= 0;
       execute_we <= 1'b0;
+      execute_pc <= 0;
       writeback_valid_r <= 1'b0;
       writeback_result <= 0;
       writeback_rd <= 0;
       writeback_valid <= 1'b0;
+      writeback_pc <= 0;
     end else begin
       if (!fetch_stall) begin
         fetch_valid_r <= 1'b1;
@@ -98,18 +104,21 @@ module CpuPipe #(
         decode_rd <= fetch_instr[11:7];
         decode_rs1_val <= rs1_data;
         decode_rs2_val <= rs2_data;
+        decode_pc <= fetch_pc;
       end
       if (!execute_stall) begin
         execute_valid_r <= decode_stall ? 1'b0 : decode_valid_r;
         execute_alu_result <= execute_alu_out;
         execute_rd <= decode_rd;
         execute_we <= (decode_opcode != 0);
+        execute_pc <= decode_pc;
       end
       if (!writeback_stall) begin
         writeback_valid_r <= execute_stall ? 1'b0 : execute_valid_r;
         writeback_result <= execute_alu_result;
         writeback_rd <= execute_rd;
         writeback_valid <= execute_we;
+        writeback_pc <= execute_pc;
       end
       if (branch_taken) begin
         fetch_valid_r <= 1'b0;
@@ -136,6 +145,6 @@ module CpuPipe #(
   assign wb_data = writeback_result;
   assign wb_rd = writeback_rd;
   assign wb_we = (writeback_valid && writeback_valid_r);
-  assign pc_out = fetch_pc;
+  assign pc_out = writeback_pc;
 
 endmodule


### PR DESCRIPTION
## Summary

Pipeline critique #4 ([memory: project_pipeline_critique](../../.claude/projects/-Users-shuqingzhao-github-arch-com/memory/project_pipeline_critique.md)):
A stage that reads from a stage more than one hop back emits a direct
combinational path that bypasses the intermediate stages' registers
and silently breaks timing. Canonical example: `pc_out = Fetch.pc` in
`Writeback` — looks innocuous, generates a 3-hop comb fan-back through
the entire pipeline.

This is option **(b)** from the triage — reject at typecheck with a
clear fix suggestion. Option **(a)** (auto-shadow registers through
intermediate stages) is bigger work and stays deferred.

## Rule

| Pattern | Allowed | Rationale |
|---|---|---|
| `<self>.<field>` | yes | self-reference, redundant |
| `<prev>.<field>` (1 hop back) | yes | canonical pipeline data flow |
| `<future>.<field>` (forward read) | yes | hazard read — forwarding mux, load-use stall |
| `<j>.<field>` where j+1 < cur | **no** | bypass, silent timing bug |

Stall conditions, flush directives, and forward directives live
outside `stage.body` and are exempt.

## Changes

- `src/typecheck.rs`: new `check_pipeline_cross_stage_expr` walks
  comb / seq / let / reg-init expressions and reports any backward
  reference that skips a stage.
- `examples/cpu_pipeline.arch`: was triggering the new rule with the
  exact `pc_out = Fetch.pc` pattern. Now passes `pc` forward through
  registered Decode → Execute → Writeback regs.
- 2 new integration tests covering rejection + forward-reference allowance.

## Test plan

- [x] `cargo build` clean
- [x] `cargo test` 191 passing (+2 new)
- [x] `examples/cpu_pipeline.arch` still type-checks and matches snapshot