### PR TITLE
typecheck: reject bare-ident <= inside 'for' loop in seq

### DIFF
--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -393,6 +393,14 @@ impl<'a> TypeChecker<'a> {
                     }
                     // Reject wait until / do..until in module seq blocks (only valid in pipeline stages)
                     Self::reject_wait_in_stmts(&rb.stmts, &mut self.errors);
+                    // Reject `target <= expr;` (bare-ident target) inside a
+                    // `for` loop in seq — last-iteration's NBA write wins,
+                    // so the loop never has the cumulative effect users
+                    // expect. Indexed targets (`vec[i] <= ...`) write a
+                    // distinct element each iteration and stay allowed.
+                    for stmt in &rb.stmts {
+                        Self::reject_bare_assign_in_for(stmt, false, &mut self.errors);
+                    }
                     // Validate reset consistency: all registers with reset in the
                     // same seq block must agree on signal name, sync/async, and polarity.
                     self.check_always_block_reset_consistency(rb, m);
@@ -1952,6 +1960,53 @@ impl<'a> TypeChecker<'a> {
     }
 
     /// Reject `wait until` / `do..until` in non-pipeline seq blocks.
+    /// Reject `target <= expr;` (bare-ident LHS) inside a `for` loop in
+    /// a seq block. Each iteration evaluates the RHS using the same
+    /// pre-block value of every signal, then the last iteration's
+    /// non-blocking schedule wins — so the loop never has the
+    /// cumulative effect users expect (see also the SV antipattern
+    /// `sum <= sum + data[i];` inside `for`).
+    ///
+    /// Indexed targets (`vec[i] <= ...`) write a different element
+    /// each iteration and stay allowed — that's the canonical shift
+    /// register pattern. Same for field-access targets like
+    /// `bus.data <= ...` where the LHS varies per iteration.
+    ///
+    /// Recurses into nested `if/elsif/else`, `match`, and nested `for`
+    /// (where the rule still applies). The `in_for` flag activates the
+    /// rejection only when we're inside at least one for-loop.
+    fn reject_bare_assign_in_for(stmt: &Stmt, in_for: bool, errors: &mut Vec<CompileError>) {
+        match stmt {
+            Stmt::Assign(a) => {
+                if in_for && matches!(&a.target.kind, ExprKind::Ident(_)) {
+                    errors.push(CompileError::general(
+                        "non-blocking assignment `<=` to a bare identifier inside a `for` loop in seq has no cumulative effect — every iteration reads the same pre-block value of the target and only the last iteration's update commits. Compute the value combinationally in a `comb` block (which uses blocking `=` and accumulates correctly), then register it once with `<=` in seq. Indexed targets like `vec[i] <= ...` are fine because each iteration writes a different element.",
+                        a.span,
+                    ));
+                }
+            }
+            Stmt::IfElse(ie) => {
+                for s in &ie.then_stmts { Self::reject_bare_assign_in_for(s, in_for, errors); }
+                for s in &ie.else_stmts { Self::reject_bare_assign_in_for(s, in_for, errors); }
+            }
+            Stmt::For(f) => {
+                for s in &f.body { Self::reject_bare_assign_in_for(s, true, errors); }
+            }
+            Stmt::Match(m) => {
+                for arm in &m.arms {
+                    for s in &arm.body { Self::reject_bare_assign_in_for(s, in_for, errors); }
+                }
+            }
+            Stmt::Init(ib) => {
+                for s in &ib.body { Self::reject_bare_assign_in_for(s, in_for, errors); }
+            }
+            Stmt::DoUntil { body, .. } => {
+                for s in body { Self::reject_bare_assign_in_for(s, in_for, errors); }
+            }
+            _ => {}
+        }
+    }
+
     fn reject_wait_in_stmts(stmts: &[Stmt], errors: &mut Vec<CompileError>) {
         for stmt in stmts {
             match stmt {
@@ -4020,6 +4075,12 @@ impl<'a> TypeChecker<'a> {
                     ModuleBodyItem::PipeRegDecl(p) => self.check_snake_case(&p.name),
                     ModuleBodyItem::Inst(inst) => self.check_snake_case(&inst.name),
                     _ => {}
+                }
+                // Reject bare-ident `<=` inside `for` loops in stage seq blocks.
+                if let ModuleBodyItem::RegBlock(rb) = item {
+                    for s in &rb.stmts {
+                        Self::reject_bare_assign_in_for(s, false, &mut self.errors);
+                    }
                 }
             }
         }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1223,6 +1223,74 @@ end module BitExtract
 }
 
 #[test]
+fn test_seq_for_loop_bare_assign_rejected() {
+    // SV antipattern: `target <= expr;` inside a `for` loop in seq has
+    // no cumulative effect — every iteration reads the same pre-block
+    // value of the target and only the last write commits. Reject at
+    // typecheck.
+    let bad = r#"
+domain SysDomain
+  freq_mhz: 100
+end domain SysDomain
+
+module BadAccum
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port d: in UInt<8>;
+  port o: out UInt<10>;
+  reg sum: UInt<10> reset rst => 10'h0;
+  comb o = sum; end comb
+  seq on clk rising
+    for i in 0..3
+      sum <= sum + d.zext<10>();   // bug: never accumulates
+    end for
+  end seq
+end module BadAccum
+"#;
+    let tokens = arch::lexer::tokenize(bad).expect("lexer");
+    let mut parser = arch::parser::Parser::new(tokens, bad);
+    let ast = parser.parse_source_file().expect("parse");
+    let symbols = arch::resolve::resolve(&ast).expect("resolve");
+    let result = arch::typecheck::TypeChecker::new(&symbols, &ast).check();
+    let errs = result.expect_err("expected typecheck to reject bare-ident <= in seq for-loop");
+    let msg = errs.iter().map(|e| format!("{e:?}")).collect::<String>();
+    assert!(msg.contains("non-blocking assignment") && msg.contains("for"),
+            "expected for-loop NBA error, got: {msg}");
+}
+
+#[test]
+fn test_seq_for_loop_indexed_assign_allowed() {
+    // Indexed targets (`vec[i] <= ...`) write a different element per
+    // iteration and stay allowed — canonical shift-register / fill-Vec
+    // patterns. Verify the rule doesn't false-positive on these.
+    let ok = r#"
+domain SysDomain
+  freq_mhz: 100
+end domain SysDomain
+
+module ShiftFill
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port d: in UInt<8>;
+  port o: out Vec<UInt<8>, 4>;
+  reg shifty: Vec<UInt<8>, 4> reset rst => 0;
+  comb o = shifty; end comb
+  seq on clk rising
+    for i in 0..3
+      shifty[i] <= d;     // indexed: each iter writes a different slot — OK
+    end for
+  end seq
+end module ShiftFill
+"#;
+    let tokens = arch::lexer::tokenize(ok).expect("lexer");
+    let mut parser = arch::parser::Parser::new(tokens, ok);
+    let ast = parser.parse_source_file().expect("parse");
+    let symbols = arch::resolve::resolve(&ast).expect("resolve");
+    arch::typecheck::TypeChecker::new(&symbols, &ast).check()
+        .expect("indexed-target NBA in for-loop should typecheck");
+}
+
+#[test]
 fn test_pipeline_flush_clear_emits_data_reset() {
     // Pipeline critique #6: `flush <Stage> when <cond> clear;` resets
     // every data register in the target stage, not just `valid_r`.


### PR DESCRIPTION
## Summary

Reject the SV non-blocking accumulator antipattern at typecheck:

```arch
seq on clk rising
  for i in 0..3
    sum <= sum + d.zext<10>();   // bug: never accumulates
  end for
end seq
```

In SV semantics, every loop iteration evaluates the RHS using the
same pre-block value of `sum`, then "last NBA write wins" picks the
i=N-1 update. Verified empirically with Verilator on a minimal SV
testbench — the result is `sum + d[N-1]` per cycle, never the
cumulative sum.

This pattern is a frequent footgun when porting an `always_comb`
accumulator into an `always_ff` (or moving from a `comb` block into
a `seq` block in ARCH).

## Rule

| Pattern | Allowed | Notes |
|---|---|---|
| `target <= ...;` (no for-loop) | yes | Canonical counter / register update |
| `target <= ...;` inside `for` (bare ident) | **no** | Antipattern — last iteration wins |
| `vec[i] <= ...;` inside `for` (indexed) | yes | Each iter writes a different element — shift register / fill-Vec |
| `bus.field <= ...;` inside `for` | yes | Field access varies per iter |

Recurses through nested `if/elsif/else`, `match`, `do..until`, `init`,
and nested for-loops. Applies to both module seq blocks and pipeline
stage seq blocks.

## Error message

Points at the working alternative — compute combinationally with `=`
in a `comb` block (which accumulates correctly), then register the
result once with `<=` in seq. Example: `cascaded_adder.arch` uses
exactly this pattern.

## Test plan

- [x] `cargo build` clean
- [x] `cargo test` 194 passing (+2 new)
- [x] No CVDP design (267) triggers the new rule

## Out of scope

- Adding `=` (blocking) inside seq for-loops as a more local fix —
  separate language design discussion. The comb-then-register pattern
  is sufficient today.