### PR TITLE
linklist: Phase B — multi-head SV codegen (NUM_HEADS > 1, shared pool)

### DIFF
--- a/doc/ARCH_HDL_Specification.md
+++ b/doc/ARCH_HDL_Specification.md
@@ -2549,6 +2549,48 @@ Every linklist declaration compiles to the following hardware components, genera
   **circular_doubly**   next + prev (circular)   O(1)                                         High-performance scheduling, deques
   -------------------------------------------------------------------------------------------------------------------------------------------
 
+**12.2a Multi-Head (homogeneous chains, shared pool)**
+
+`linklist` accepts an optional `param NUM_HEADS: const = N;` that turns a single list into *K* homogeneous linked chains sharing one node pool and one free list. Every chain has the same DATA type and the same topology kind; they differ only in which entries belong to which chain. The canonical use case is a **miss status holding register (MSHR)**, **per-flow queue array**, or any "one logical list per index, total capacity N across all indices" pattern.
+
+- Default is `NUM_HEADS = 1` → single-head behaviour, byte-identical SV emission.
+- `NUM_HEADS > 1` → every head-addressed op (`insert_head`, `insert_tail`, `insert_after`, `delete_head`, `delete`) **must** declare an input port `req_head_idx: in UInt<$clog2(NUM_HEADS)>`. The compiler latches the index at the accept cycle and indexes the per-head head / tail / length registers on subsequent busy cycles. Head-independent ops (`alloc`, `free`, `read_data`, `write_data`, `next`, `prev`) take no `req_head_idx`.
+
+```
+linklist MshrChains
+  param DEPTH: const = 32;           // total slots in the shared pool
+  param NUM_HEADS: const = 16;       // 16 chains share those 32 slots
+  param DATA: type = UInt<64>;
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  kind singly;
+  track tail: true;
+
+  op insert_tail
+    latency: 2;
+    port req_valid:    in Bool;
+    port req_ready:    out Bool;
+    port req_head_idx: in UInt<4>;   // 0..NUM_HEADS-1
+    port req_data:     in UInt<64>;
+    port resp_valid:   out Bool;
+    port resp_handle:  out UInt<5>;
+  end op insert_tail
+
+  op delete_head
+    latency: 2;
+    port req_valid:    in Bool;
+    port req_ready:    out Bool;
+    port req_head_idx: in UInt<4>;
+    port resp_valid:   out Bool;
+    port resp_data:    out UInt<64>;
+  end op delete_head
+end linklist MshrChains
+```
+
+Distinction from §12.6 `linklist_pool`: `linklist_pool` declares *heterogeneous* named lists (different depths / types) sharing a pool; `NUM_HEADS` declares an *array of identical chains* inside a single `linklist`. Use `linklist_pool` when lists differ; use `NUM_HEADS` when they're uniform and indexed.
+
+Current implementation supports `insert_tail` and `delete_head` with `NUM_HEADS > 1`; the other head-addressed ops are staged in a follow-up.
+
 **12.3 Operation Latency**
 
 Every operation on a linklist has a latency declaration --- the number of clock cycles from request assertion to result valid. The compiler uses this budget to choose an implementation: lower latency requires simpler (potentially slower-clocking) logic; higher latency allows pipelining for higher Fmax.

--- a/doc/Arch_AI_Reference_Card.md
+++ b/doc/Arch_AI_Reference_Card.md
@@ -809,6 +809,8 @@ end linklist Name
 
 Operations (via `op` port): `insert_head`, `insert_tail`, `insert_after`, `delete_head`, `delete`, `next`, `prev` (doubly), `alloc`, `free`, `read_data`, `write_data`. 2-cycle latency per operation.
 
+**Multi-head (NUM_HEADS > 1)**: add `param NUM_HEADS: const = N;` to turn the linklist into K homogeneous chains sharing one node pool + free list. Each head-addressed op (`insert_*`, `delete_*`) must then declare `port req_head_idx: in UInt<$clog2(NUM_HEADS)>`. Typical use: MSHR, per-flow queues, per-address pending tables. `NUM_HEADS == 1` (default) emits byte-identical SV to before. Today `insert_tail` + `delete_head` are fully supported in multi-head; other head-addressed ops stage in a follow-up. For *heterogeneous* named lists with different depths/types sharing a pool, use `linklist_pool` (spec §12.6).
+
 ---
 
 ### generate

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -8184,6 +8184,18 @@ impl<'a> Codegen<'a> {
         let is_doubly = matches!(l.kind, LinklistKind::Doubly | LinklistKind::CircularDoubly);
         let is_circular = matches!(l.kind, LinklistKind::CircularSingly | LinklistKind::CircularDoubly);
 
+        // Multi-head linklist support. NUM_HEADS defaults to 1; when set
+        // to N > 1, the head / tail / length registers become arrays
+        // indexed by a per-op `req_head_idx` port (validated at typecheck).
+        // The node pool and free list stay shared across all heads.
+        let num_heads = crate::typecheck::linklist_num_heads(l);
+        let multi_head = num_heads > 1;
+        let num_heads_expr = l.params.iter()
+            .find(|p| p.name.name == "NUM_HEADS")
+            .and_then(|p| p.default.as_ref())
+            .map(|e| self.emit_expr_str(e))
+            .unwrap_or_else(|| "1".to_string());
+
         // Resolve DEPTH default expression and DATA SV type
         let depth_expr = l.params.iter()
             .find(|p| p.name.name == "DEPTH")
@@ -8199,6 +8211,14 @@ impl<'a> Codegen<'a> {
             })
             .unwrap_or_else(|| "logic [7:0]".to_string());
 
+        // Operations that touch a specific head (need `req_head_idx` when
+        // multi-head). Shared-pool ops (alloc, free) and slot-addressed
+        // ops (read_data, write_data, next, prev) don't.
+        let head_addressed_op = |name: &str| matches!(
+            name,
+            "insert_head" | "insert_tail" | "insert_after" | "delete_head" | "delete"
+        );
+
         // Find clk/rst port names
         let clk_name = l.ports.iter()
             .find(|p| matches!(&p.ty, crate::ast::TypeExpr::Clock(_)))
@@ -8212,6 +8232,9 @@ impl<'a> Codegen<'a> {
         // ── Module header ─────────────────────────────────────────────────────
         self.line(&format!("module {n} #("));
         self.indent += 1;
+        if multi_head {
+            self.line(&format!("parameter int  NUM_HEADS = {num_heads_expr},"));
+        }
         self.line(&format!("parameter int  DEPTH = {depth_expr},"));
         self.line(&format!("parameter type DATA  = {data_default_sv}"));
         self.indent -= 1;
@@ -8254,6 +8277,9 @@ impl<'a> Codegen<'a> {
         // ── Internal constants ────────────────────────────────────────────────
         self.line("localparam int HANDLE_W = $clog2(DEPTH);");
         self.line("localparam int CNT_W    = $clog2(DEPTH + 1);");
+        if multi_head {
+            self.line("localparam int HEAD_IDX_W = $clog2(NUM_HEADS);");
+        }
         self.line("");
 
         // ── Free list: circular FIFO of slot indices ──────────────────────────
@@ -8275,9 +8301,21 @@ impl<'a> Codegen<'a> {
 
         // ── Head / tail / length registers ───────────────────────────────────
         self.line("// Head / tail registers");
-        self.line("logic [HANDLE_W-1:0] _head_r;");
-        if l.track_tail {
-            self.line("logic [HANDLE_W-1:0] _tail_r;");
+        if multi_head {
+            self.line("logic [HANDLE_W-1:0] _head_r [NUM_HEADS];");
+            if l.track_tail {
+                self.line("logic [HANDLE_W-1:0] _tail_r [NUM_HEADS];");
+            }
+            // Internal per-head occupancy counter — used for "this head
+            // is empty" detection (insert vs. append branch, delete
+            // req_ready gating). Always emitted in multi-head mode;
+            // not user-visible.
+            self.line("logic [CNT_W-1:0]    _length_r [NUM_HEADS];");
+        } else {
+            self.line("logic [HANDLE_W-1:0] _head_r;");
+            if l.track_tail {
+                self.line("logic [HANDLE_W-1:0] _tail_r;");
+            }
         }
         self.line("");
 
@@ -8312,6 +8350,11 @@ impl<'a> Codegen<'a> {
                 }
                 _ => {}
             }
+            // Multi-head: latch the requested head idx at accept cycle so
+            // the busy cycle can reuse it without re-reading the live port.
+            if multi_head && head_addressed_op(on) && op.latency > 1 {
+                self.line(&format!("logic [HEAD_IDX_W-1:0] _ctrl_{on}_head_idx;"));
+            }
             self.line("");
         }
 
@@ -8335,17 +8378,27 @@ impl<'a> Codegen<'a> {
         self.line("// req_ready: combinational");
         for op in all_ops {
             let on = &op.name.name;
+            let is_head_addr = head_addressed_op(on);
             if op.ports.iter().any(|p| p.name.name == "req_ready") {
                 let guard = if op.latency > 1 {
                     format!("!_ctrl_{on}_busy && ")
                 } else {
                     String::new()
                 };
+                // Multi-head delete: gate on "this head has entries"
+                // rather than "pool has any entries". Insert ops still
+                // gate on the shared free list (full pool = stall).
                 let cond = match on.as_str() {
                     "alloc" | "insert_head" | "insert_tail" | "insert_after" => {
                         format!("{guard}!(_fl_cnt == '0)")
                     }
-                    "free" | "delete_head" | "delete" => {
+                    "free" => {
+                        format!("{guard}!(_fl_cnt == CNT_W'(DEPTH))")
+                    }
+                    "delete_head" | "delete" if multi_head && is_head_addr => {
+                        format!("{guard}(_length_r[{on}_req_head_idx] != '0)")
+                    }
+                    "delete_head" | "delete" => {
                         format!("{guard}!(_fl_cnt == CNT_W'(DEPTH))")
                     }
                     _ => format!("{guard}1'b1"),
@@ -8376,8 +8429,18 @@ impl<'a> Codegen<'a> {
         self.line("_fl_rdp <= '0;");
         self.line("_fl_wrp <= '0;");
         self.line("_fl_cnt <= CNT_W'(DEPTH);");
-        self.line("_head_r <= '0;");
-        if l.track_tail { self.line("_tail_r <= '0;"); }
+        if multi_head {
+            self.line("for (_ll_i = 0; _ll_i < NUM_HEADS; _ll_i++) begin");
+            self.indent += 1;
+            self.line("_head_r[_ll_i] <= '0;");
+            if l.track_tail { self.line("_tail_r[_ll_i] <= '0;"); }
+            self.line("_length_r[_ll_i] <= '0;");
+            self.indent -= 1;
+            self.line("end");
+        } else {
+            self.line("_head_r <= '0;");
+            if l.track_tail { self.line("_tail_r <= '0;"); }
+        }
         for op in all_ops {
             let on = &op.name.name;
             if op.latency > 1 { self.line(&format!("_ctrl_{on}_busy <= 1'b0;")); }
@@ -8399,7 +8462,7 @@ impl<'a> Codegen<'a> {
 
         // Per-op logic
         for op in all_ops {
-            self.emit_ll_op_controller(op, l.track_tail, is_doubly, is_circular);
+            self.emit_ll_op_controller(op, l.track_tail, is_doubly, is_circular, num_heads);
         }
 
         self.indent -= 1;
@@ -8438,14 +8501,55 @@ impl<'a> Codegen<'a> {
         track_tail: bool,
         is_doubly: bool,
         _is_circular: bool,
+        num_heads: u32,
     ) {
         let on = &op.name.name;
         let has_req_valid   = op.ports.iter().any(|p| p.name.name == "req_valid");
         let has_resp_valid  = op.ports.iter().any(|p| p.name.name == "resp_valid");
         let has_req_handle  = op.ports.iter().any(|p| p.name.name == "req_handle");
         let has_req_data    = op.ports.iter().any(|p| p.name.name == "req_data");
+        let multi_head = num_heads > 1;
+        let is_head_addr = matches!(
+            on.as_str(),
+            "insert_head" | "insert_tail" | "insert_after" | "delete_head" | "delete"
+        );
+        // Head-register access expressions.
+        // - `_accept` variant is used in the accept cycle (latency==1 or
+        //   the first branch of a latency>1 op). Reads the live
+        //   `req_head_idx` port directly.
+        // - `_busy` variant is used in subsequent busy cycles. Reads the
+        //   latched `_ctrl_<op>_head_idx`.
+        // For single-head lists both resolve to bare `_head_r` / `_tail_r`
+        // so the emitted SV stays byte-identical with the pre-multi-head
+        // compiler.
+        let head_r_accept = if multi_head && is_head_addr {
+            format!("_head_r[{on}_req_head_idx]")
+        } else { "_head_r".to_string() };
+        let head_r_busy = if multi_head && is_head_addr {
+            format!("_head_r[_ctrl_{on}_head_idx]")
+        } else { "_head_r".to_string() };
+        // _tail_r is only read at the busy cycle (post-accept). The
+        // accept-cycle variant would be `_tail_r[<op>_req_head_idx]`
+        // if an op ever needed it.
+        let tail_r_busy = if multi_head && is_head_addr {
+            format!("_tail_r[_ctrl_{on}_head_idx]")
+        } else { "_tail_r".to_string() };
 
         self.line(&format!("// ── {on} ─────────────────────────────────────────"));
+
+        // Phase-B scope: multi-head supports insert_tail + delete_head
+        // only. Other head-addressed ops need wiring the latched head_idx
+        // into their branching / pointer-patch paths; deferred to a
+        // follow-up phase.
+        if multi_head && matches!(on.as_str(), "insert_head" | "insert_after" | "delete") {
+            self.line(&format!(
+                "// NOTE: op `{on}` is not yet supported for multi-head linklist (Phase B)."
+            ));
+            self.line(&format!(
+                "initial $fatal(1, \"linklist: op `{on}` not yet implemented for multi-head (NUM_HEADS > 1)\");"
+            ));
+            return;
+        }
 
         match on.as_str() {
             "alloc" => {
@@ -8531,22 +8635,33 @@ impl<'a> Codegen<'a> {
                 if has_req_data { self.line(&format!("_data_mem[{slot}] <= {on}_req_data;")); }
                 self.line("_fl_rdp <= _fl_rdp + 1'b1;");
                 self.line("_fl_cnt <= _fl_cnt - 1'b1;");
-                self.line(&format!("_ctrl_{on}_was_empty <= (_fl_cnt == CNT_W'(DEPTH));"));
+                // Empty check: single-head uses pool occupancy; multi-head
+                // uses the per-head length counter so chains from other
+                // heads don't mask this head's emptiness.
+                if multi_head {
+                    self.line(&format!("_ctrl_{on}_was_empty <= (_length_r[{on}_req_head_idx] == '0);"));
+                    self.line(&format!("_ctrl_{on}_head_idx  <= {on}_req_head_idx;"));
+                } else {
+                    self.line(&format!("_ctrl_{on}_was_empty <= (_fl_cnt == CNT_W'(DEPTH));"));
+                }
                 self.line(&format!("_ctrl_{on}_busy <= 1'b1;"));
                 self.indent -= 1;
                 self.line(&format!("end else if (_ctrl_{on}_busy) begin"));
                 self.indent += 1;
                 if track_tail {
-                    self.line(&format!("if (!_ctrl_{on}_was_empty) _next_mem[_tail_r] <= _ctrl_{on}_resp_handle;"));
+                    self.line(&format!("if (!_ctrl_{on}_was_empty) _next_mem[{tail_r_busy}] <= _ctrl_{on}_resp_handle;"));
                     if is_doubly {
                         // new node.prev = old tail
-                        self.line(&format!("_prev_mem[_ctrl_{on}_resp_handle] <= _tail_r;"));
+                        self.line(&format!("_prev_mem[_ctrl_{on}_resp_handle] <= {tail_r_busy};"));
                     }
-                    self.line(&format!("_tail_r <= _ctrl_{on}_resp_handle;"));
-                    self.line(&format!("if (_ctrl_{on}_was_empty) _head_r <= _ctrl_{on}_resp_handle;"));
+                    self.line(&format!("{tail_r_busy} <= _ctrl_{on}_resp_handle;"));
+                    self.line(&format!("if (_ctrl_{on}_was_empty) {head_r_busy} <= _ctrl_{on}_resp_handle;"));
                 } else {
-                    self.line(&format!("if (!_ctrl_{on}_was_empty) _next_mem[_head_r] <= _ctrl_{on}_resp_handle;"));
-                    self.line(&format!("if (_ctrl_{on}_was_empty) _head_r <= _ctrl_{on}_resp_handle;"));
+                    self.line(&format!("if (!_ctrl_{on}_was_empty) _next_mem[{head_r_busy}] <= _ctrl_{on}_resp_handle;"));
+                    self.line(&format!("if (_ctrl_{on}_was_empty) {head_r_busy} <= _ctrl_{on}_resp_handle;"));
+                }
+                if multi_head {
+                    self.line(&format!("_length_r[_ctrl_{on}_head_idx] <= _length_r[_ctrl_{on}_head_idx] + 1'b1;"));
                 }
                 if has_resp_valid { self.line(&format!("_ctrl_{on}_resp_v <= 1'b1;")); }
                 self.line(&format!("_ctrl_{on}_busy <= 1'b0;"));
@@ -8555,11 +8670,19 @@ impl<'a> Codegen<'a> {
             }
             "delete_head" => {
                 // Latency-2: read head data, advance head, free old head slot
-                let guard = format!("!_ctrl_{on}_busy && {on}_req_valid && !(_fl_cnt == CNT_W'(DEPTH))");
+                let pool_gate = if multi_head {
+                    format!("(_length_r[{on}_req_head_idx] != '0)")
+                } else {
+                    "!(_fl_cnt == CNT_W'(DEPTH))".to_string()
+                };
+                let guard = format!("!_ctrl_{on}_busy && {on}_req_valid && {pool_gate}");
                 self.line(&format!("if ({guard}) begin"));
                 self.indent += 1;
-                self.line("_ctrl_delete_head_resp_data <= _data_mem[_head_r];");
-                self.line("_ctrl_delete_head_slot      <= _head_r;");
+                self.line(&format!("_ctrl_delete_head_resp_data <= _data_mem[{head_r_accept}];"));
+                self.line(&format!("_ctrl_delete_head_slot      <= {head_r_accept};"));
+                if multi_head {
+                    self.line(&format!("_ctrl_{on}_head_idx          <= {on}_req_head_idx;"));
+                }
                 self.line(&format!("_ctrl_{on}_busy <= 1'b1;"));
                 self.indent -= 1;
                 self.line(&format!("end else if (_ctrl_{on}_busy) begin"));
@@ -8569,7 +8692,10 @@ impl<'a> Codegen<'a> {
                 self.line("_fl_wrp <= _fl_wrp + 1'b1;");
                 self.line("_fl_cnt <= _fl_cnt + 1'b1;");
                 // Advance head
-                self.line("_head_r <= _next_mem[_ctrl_delete_head_slot];");
+                self.line(&format!("{head_r_busy} <= _next_mem[_ctrl_delete_head_slot];"));
+                if multi_head {
+                    self.line(&format!("_length_r[_ctrl_{on}_head_idx] <= _length_r[_ctrl_{on}_head_idx] - 1'b1;"));
+                }
                 if has_resp_valid { self.line(&format!("_ctrl_{on}_resp_v <= 1'b1;")); }
                 self.line(&format!("_ctrl_{on}_busy <= 1'b0;"));
                 self.indent -= 1;

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -4263,6 +4263,70 @@ impl<'a> TypeChecker<'a> {
                 span: l.name.span,
             });
         }
+
+        // ── Multi-head linklist (NUM_HEADS param) ──────────────────────────
+        //
+        // When NUM_HEADS > 1, ops that touch a specific chain (insert_*,
+        // delete_*) must take a `req_head_idx` port of the right width so
+        // the controller knows which head to index. When NUM_HEADS == 1,
+        // the port must NOT appear (back-compat + avoids confusion).
+        let num_heads = linklist_num_heads(l);
+        let head_idx_w = if num_heads <= 1 { 0 } else { clog2_u32(num_heads) };
+        let head_addressed = [
+            "insert_head", "insert_tail", "insert_after", "delete_head", "delete",
+        ];
+        for op in &l.ops {
+            let has_head_idx = op.ports.iter().any(|p| p.name.name == "req_head_idx");
+            let is_head_addressed = head_addressed.contains(&op.name.name.as_str());
+            if num_heads <= 1 && has_head_idx {
+                self.errors.push(CompileError::general(
+                    &format!(
+                        "linklist `{}`: op `{}` declares `req_head_idx` but the linklist is single-head (no `param NUM_HEADS: const = N;` with N > 1). Remove the port, or set NUM_HEADS > 1 to opt into multi-head mode.",
+                        l.name.name, op.name.name,
+                    ),
+                    op.name.span,
+                ));
+            }
+            if num_heads > 1 && is_head_addressed && !has_head_idx {
+                self.errors.push(CompileError::general(
+                    &format!(
+                        "linklist `{}`: op `{}` is a per-head op but the linklist has NUM_HEADS = {num_heads} and the op does not declare `req_head_idx: in UInt<{head_idx_w}>`. Add the port so the controller can route the op to the requested chain.",
+                        l.name.name, op.name.name,
+                    ),
+                    op.name.span,
+                ));
+            }
+            // Check req_head_idx width when it exists and the linklist is
+            // multi-head. Expected width is ceil_log2(NUM_HEADS).
+            if num_heads > 1 && has_head_idx {
+                if let Some(p) = op.ports.iter().find(|p| p.name.name == "req_head_idx") {
+                    if p.direction != crate::ast::Direction::In {
+                        self.errors.push(CompileError::general(
+                            &format!(
+                                "linklist `{}`: `req_head_idx` must be an input port (`in UInt<{head_idx_w}>`)",
+                                l.name.name,
+                            ),
+                            p.span,
+                        ));
+                    }
+                    let width_ok = match &p.ty {
+                        crate::ast::TypeExpr::UInt(w) => {
+                            matches!(self.eval_const_expr(w, &HashMap::new()), Some(v) if v as u32 == head_idx_w)
+                        }
+                        _ => false,
+                    };
+                    if !width_ok {
+                        self.errors.push(CompileError::general(
+                            &format!(
+                                "linklist `{}`: op `{}` declares `req_head_idx` with the wrong type. Expected `in UInt<{head_idx_w}>` for NUM_HEADS = {num_heads}.",
+                                l.name.name, op.name.name,
+                            ),
+                            p.span,
+                        ));
+                    }
+                }
+            }
+        }
     }
 
     fn check_function(&mut self, f: &FunctionDecl) {
@@ -4751,4 +4815,26 @@ pub fn enum_width(num_variants: usize) -> u32 {
     } else {
         (num_variants as f64).log2().ceil() as u32
     }
+}
+
+/// Fold a linklist's `NUM_HEADS` param to a u32. Returns 1 when the param
+/// is absent (back-compat default) or the default doesn't reduce to a
+/// plain integer literal — typecheck only allows literal defaults for
+/// this param (matches DEPTH).
+pub fn linklist_num_heads(l: &crate::ast::LinklistDecl) -> u32 {
+    use crate::ast::{ExprKind, LitKind};
+    let Some(p) = l.params.iter().find(|p| p.name.name == "NUM_HEADS") else { return 1; };
+    let Some(def) = &p.default else { return 1; };
+    match &def.kind {
+        ExprKind::Literal(LitKind::Dec(v))
+        | ExprKind::Literal(LitKind::Hex(v))
+        | ExprKind::Literal(LitKind::Bin(v)) => *v as u32,
+        ExprKind::Literal(LitKind::Sized(_, v)) => *v as u32,
+        _ => 1,
+    }
+}
+
+/// ceil_log2 for u32. `clog2_u32(1) = 0`, `clog2_u32(2) = 1`, `clog2_u32(16) = 4`.
+pub fn clog2_u32(n: u32) -> u32 {
+    if n <= 1 { 0 } else { (n - 1).ilog2() + 1 }
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1731,6 +1731,128 @@ end linklist SchedList
 }
 
 #[test]
+fn test_linklist_multi_head_compiles() {
+    // Phase B: multi-head linklist with NUM_HEADS > 1 emits per-head
+    // head/tail/length arrays and latches req_head_idx per op.
+    let source = r#"
+linklist MhQ
+  param DEPTH: const = 16;
+  param NUM_HEADS: const = 4;
+  param DATA: type = UInt<8>;
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  kind singly;
+  track tail: true;
+  op insert_tail
+    latency: 2;
+    port req_valid:    in Bool;
+    port req_ready:    out Bool;
+    port req_head_idx: in UInt<2>;
+    port req_data:     in UInt<8>;
+    port resp_valid:   out Bool;
+    port resp_handle:  out UInt<4>;
+  end op insert_tail
+  op delete_head
+    latency: 2;
+    port req_valid:    in Bool;
+    port req_ready:    out Bool;
+    port req_head_idx: in UInt<2>;
+    port resp_valid:   out Bool;
+    port resp_data:    out UInt<8>;
+  end op delete_head
+end linklist MhQ
+"#;
+    let sv = compile_to_sv(source);
+    // Module header carries NUM_HEADS param
+    assert!(sv.contains("parameter int  NUM_HEADS = 4"), "missing NUM_HEADS param:\n{sv}");
+    // Head/tail/length become arrays indexed by NUM_HEADS
+    assert!(sv.contains("_head_r [NUM_HEADS]"), "missing head array");
+    assert!(sv.contains("_tail_r [NUM_HEADS]"), "missing tail array");
+    assert!(sv.contains("_length_r [NUM_HEADS]"), "missing internal length array");
+    // Per-op latched head_idx register
+    assert!(sv.contains("_ctrl_insert_tail_head_idx"), "missing insert_tail head_idx latch");
+    assert!(sv.contains("_ctrl_delete_head_head_idx"), "missing delete_head head_idx latch");
+    // Accept cycle reads head/tail by request idx directly; busy cycle
+    // by the latched idx.
+    assert!(sv.contains("_head_r[delete_head_req_head_idx]"), "missing accept-cycle head ref");
+    assert!(sv.contains("_tail_r[_ctrl_insert_tail_head_idx]"), "missing busy-cycle tail ref");
+    // req_ready for delete gated by per-head length
+    assert!(sv.contains("_length_r[delete_head_req_head_idx] != '0"),
+            "missing per-head delete ready gate");
+    // Reset loops through NUM_HEADS
+    assert!(sv.contains("for (_ll_i = 0; _ll_i < NUM_HEADS; _ll_i++)"),
+            "missing NUM_HEADS reset loop");
+}
+
+#[test]
+fn test_linklist_multi_head_rejects_missing_head_idx() {
+    // NUM_HEADS > 1 but per-head op omits req_head_idx → typecheck error
+    let source = r#"
+linklist BadMh
+  param DEPTH: const = 8;
+  param NUM_HEADS: const = 2;
+  param DATA: type = UInt<8>;
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  kind singly;
+  track tail: true;
+  op insert_tail
+    latency: 2;
+    port req_valid:    in Bool;
+    port req_ready:    out Bool;
+    port req_data:     in UInt<8>;
+    port resp_valid:   out Bool;
+    port resp_handle:  out UInt<3>;
+  end op insert_tail
+end linklist BadMh
+"#;
+    let tokens = lexer::tokenize(source).expect("lexer");
+    let mut parser = Parser::new(tokens, source);
+    let parsed = parser.parse_source_file().expect("parse");
+    let ast = elaborate::elaborate(parsed).expect("elaborate");
+    let symbols = resolve::resolve(&ast).expect("resolve");
+    let result = TypeChecker::new(&symbols, &ast).check();
+    assert!(result.is_err(), "expected typecheck to reject per-head op without req_head_idx");
+    let msg = result.unwrap_err().iter().map(|e| format!("{e:?}")).collect::<String>();
+    assert!(msg.contains("req_head_idx") && msg.contains("multi-head") == false && msg.contains("NUM_HEADS"),
+            "expected NUM_HEADS-specific error, got: {msg}");
+}
+
+#[test]
+fn test_linklist_single_head_rejects_stray_head_idx() {
+    // NUM_HEADS default=1 but op declares req_head_idx → reject
+    let source = r#"
+linklist BadSh
+  param DEPTH: const = 4;
+  param DATA: type = UInt<8>;
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  kind singly;
+  track tail: true;
+  op insert_tail
+    latency: 2;
+    port req_valid:    in Bool;
+    port req_ready:    out Bool;
+    port req_head_idx: in UInt<0>;
+    port req_data:     in UInt<8>;
+    port resp_valid:   out Bool;
+    port resp_handle:  out UInt<2>;
+  end op insert_tail
+end linklist BadSh
+"#;
+    let tokens = lexer::tokenize(source).expect("lexer");
+    let mut parser = Parser::new(tokens, source);
+    let parsed = parser.parse_source_file().expect("parse");
+    let ast = elaborate::elaborate(parsed).expect("elaborate");
+    let symbols = resolve::resolve(&ast).expect("resolve");
+    let result = TypeChecker::new(&symbols, &ast).check();
+    assert!(result.is_err(), "expected typecheck to reject req_head_idx on single-head list");
+    let msg = result.unwrap_err().iter().map(|e| format!("{e:?}")).collect::<String>();
+    assert!(msg.contains("req_head_idx") && msg.contains("single-head"),
+            "expected single-head-specific error, got: {msg}");
+}
+
+#[test]
 fn test_linklist_prev_on_singly_is_error() {
     let source = r#"
 linklist BadList


### PR DESCRIPTION
## Summary

Phase B of the multi-head linklist feature — SV codegen for
`NUM_HEADS > 1`. See
[doc/plan_linklist_multi_head.md](doc/plan_linklist_multi_head.md)
for the design and phased rollout.

## What's in this PR

When a linklist declares `param NUM_HEADS: const = N;` with N > 1,
the generated SV now:

- Takes `NUM_HEADS` as a module parameter.
- Emits `_head_r [NUM_HEADS]` / `_tail_r [NUM_HEADS]` arrays.
- Emits an internal `_length_r [NUM_HEADS]` counter used for per-head
  emptiness detection (req_ready gating + insert's was_empty check).
- Latches `<op>_req_head_idx` into `_ctrl_<op>_head_idx` at the accept
  cycle and uses it to index head/tail on the busy cycle.
- Gates `delete_head` `req_ready` on **per-head** length, not pool
  occupancy — chains from other heads can't mask the emptiness of
  the addressed chain.
- Leaves the shared node pool + free list exactly as today.

Typecheck preconditions:
- NUM_HEADS == 1 (default): reject any op declaring `req_head_idx`.
- NUM_HEADS > 1: every per-head op must declare
  `req_head_idx: in UInt<clog2(NUM_HEADS)>`.

## Scope

- `insert_tail`, `delete_head` — fully supported in multi-head (the
  canonical MSHR / task-queue pattern).
- `insert_head`, `insert_after`, `delete` — emit a `$fatal` stub;
  pointer-patch plumbing still needs multi-head wiring. Deferred.

## Regression anchors

**Byte-identical** SV for every existing single-head linklist:
- `tests/cvdp/hw_task_queue.arch`
- `examples/linklist_basic.arch`
- `examples/linklist_doubly.arch`
- `examples/pkt_queue.arch`

## Test plan

- [x] `cargo build` clean
- [x] `cargo test` 197 passing (+3 new: multi-head emission shape,
      missing req_head_idx rejected, stray req_head_idx rejected)
- [x] Verilator 5.034 lint/build clean on a 4-head × 16-slot test design

## Next

- Phase C — sim mirror in `sim_codegen/linklist.rs`
- Phase D — refactor `cache_mshr.arch` as multi-head linklist demo
- Phase E — spec + reference card