### PR TITLE
feat: cam construct (Phases A-C)

### DIFF
--- a/doc/phase_d_cache_mshr_analysis.md
+++ b/doc/phase_d_cache_mshr_analysis.md
@@ -1,0 +1,25 @@
+# Phase D analysis: cache_mshr does not fit multi-head linklist
+
+## Finding
+
+`tests/cvdp/cache_mshr.arch` cannot be refactored to use `linklist NUM_HEADS = N` cleanly. Multi-head linklist requires the head index to be a compile-time-bounded port input (`req_head_idx: UInt<$clog2(NUM_HEADS)>`). cache_mshr's chains are keyed by `allocate_addr` (10-bit cache line address, up to 1024 distinct heads), and at allocate time the controller must **search** for an existing chain whose address matches — chain identity is content-addressed, not index-addressed.
+
+Concrete mismatches:
+
+1. **Head count**: NUM_HEADS would need to be 2^CS_LINE_ADDR_WIDTH = 1024, with at most MSHR_SIZE=32 simultaneously non-empty. Per-head head/tail/length vectors would dominate area for no benefit.
+2. **Insert routing**: cache_mshr's allocate doesn't take a head index — it scans `entry_valid & entry_addr == allocate_addr & ~entry_has_next` to find the tail of the matching chain (the `prev_idx` priority encoder, lines 84-95). Linklist's `insert_tail` op assumes the caller supplies the head idx.
+3. **Dynamic chain creation**: A new chain comes into being when `allocate_addr` doesn't match any valid entry. Linklist treats heads as fixed slots, all "alive" from reset.
+
+## Recommendation
+
+Per the Phase D risk row in `doc/plan_linklist_multi_head.md`: keep cache_mshr as a hand-rolled module, and demo multi-head linklist with a fixture whose chain identity *is* a small fixed index. Candidates:
+
+- **Per-flow credit table**: K flows, each tracking pending credits as a linked list of credit-grant tickets in a shared pool. Head index = flow id.
+- **Per-priority task queue**: K priority levels, shared task descriptor pool.
+- **Per-VC buffer**: K virtual channels, shared flit pool. Closest to NoC use.
+
+All three have static `NUM_HEADS` known at compile time and head index supplied by the requester — exactly the multi-head linklist contract.
+
+## Status
+
+Phase D is unblocked architecturally — Phases A/B/C shipped the construct correctly. The blocker is choosing which demo fixture to write. Awaiting user pick.

--- a/doc/plan_cam.md
+++ b/doc/plan_cam.md
@@ -1,0 +1,112 @@
+# Plan: `cam` first-class construct
+
+> **Status**: design + phased rollout plan.
+
+## Motivation
+
+Content-addressable lookup ("given a key, find the index where it's stored") shows up in every cache, MSHR, TLB, scoreboard, and per-flow tracker. Today users hand-roll it: `Vec<reg> entry_valid` + `Vec<reg> entry_key` + a comb loop with a priority encoder. Three problems:
+
+1. **Repetition** — every design re-writes the same priority-encoder pattern (see `tests/cvdp/cache_mshr.arch:84-95`).
+2. **Subtle bugs** — `~prev_all_zeros == false` style guards are easy to get wrong.
+3. **Multi-head linklist gap** — multi-head linklist's `req_head_idx` contract assumes a small fixed head index. Real workloads (MSHR, per-address pending tables) want chain identity = a wide content key, not an index. A `cam` construct + multi-head linklist composes cleanly: CAM maps content-key → head-idx, linklist takes it from there.
+
+## Non-motivation
+
+- **Ternary CAM (TCAM)** — match with don't-cares. Useful for routing tables; not in v1. Can be added as `kind: ternary` later.
+- **Range matching** — out of scope.
+- **Multi-write per cycle** — single write port in v1.
+
+## Syntax
+
+```arch
+cam Mshr_Addr_Cam
+  param DEPTH: const = 32;
+  param KEY_W: const = 10;
+
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync, High>;
+
+  // write port: set or clear an entry
+  port write_valid: in Bool;
+  port write_idx:   in UInt<5>;       // $clog2(DEPTH)
+  port write_key:   in UInt<10>;      // KEY_W
+  port write_set:   in Bool;          // true=insert valid+key, false=clear valid
+
+  // search port: combinational
+  port search_key:  in UInt<10>;
+  port search_mask: out UInt<32>;     // bitmask of matches; zero if no match
+  port search_any:  out Bool;
+  port search_first: out UInt<5>;     // LSB-priority first match (0 if none, gated by search_any)
+end cam Mshr_Addr_Cam
+```
+
+## Semantics
+
+- **Storage**: `entry_valid: Vec<Bool, DEPTH>`, `entry_key: Vec<UInt<KEY_W>, DEPTH>`. Both reset to 0/false.
+- **Write port**:
+  - `write_valid && write_set` → `entry_valid[write_idx] <= true; entry_key[write_idx] <= write_key;`
+  - `write_valid && !write_set` → `entry_valid[write_idx] <= false;` (key untouched)
+  - Multiple writes per cycle: not allowed (single write port; user serializes).
+- **Search port**: combinational. `search_mask[i] = entry_valid[i] && entry_key[i] == search_key`. `search_any = OR(search_mask)`. `search_first = priority-encoded first set bit (LSB-priority)`.
+- **Read-during-write**: search reflects pre-write state in the same cycle (write takes effect on the next clock edge). Matches arch's `reg` semantics.
+
+## Phased rollout
+
+Five PRs, each independently reviewable, mirroring the multi-head linklist plan.
+
+### Phase A — parser + AST + typecheck gate
+
+- AST: `CamDecl { common, depth, key_w, ports }`. Add `Cam(CamDecl)` to `Item` enum.
+- Lexer: `cam` keyword.
+- Parser: parse `cam Name ... end cam Name` — same shape as `ram`. Reuse `ConstructCommon` for params + ports.
+- Typecheck:
+  - Required params: `DEPTH` (const), `KEY_W` (const). Reject other param types.
+  - Required ports (exact names + widths derived from params): `clk`, `rst`, `write_valid`, `write_idx: UInt<$clog2(DEPTH)>`, `write_key: UInt<KEY_W>`, `write_set`, `search_key: UInt<KEY_W>`, `search_mask: UInt<DEPTH>`, `search_any: Bool`, `search_first: UInt<$clog2(DEPTH)>`.
+  - Codegen still errors out — Phase A only lands the language surface.
+
+### Phase B — SV codegen
+
+Lower to:
+```sv
+logic [DEPTH-1:0]            entry_valid_r;
+logic [KEY_W-1:0]            entry_key_r [DEPTH];
+logic [DEPTH-1:0]            search_mask_w;
+// match comb
+always_comb for (int i = 0; i < DEPTH; i++)
+  search_mask_w[i] = entry_valid_r[i] && (entry_key_r[i] == search_key);
+assign search_any = |search_mask_w;
+// priority encoder for search_first (LSB-first)
+// ...
+// seq write
+always_ff @(posedge clk) if (rst) entry_valid_r <= '0;
+                         else if (write_valid) begin
+                           if (write_set) begin entry_valid_r[write_idx] <= 1; entry_key_r[write_idx] <= write_key; end
+                           else entry_valid_r[write_idx] <= 0;
+                         end
+```
+
+### Phase C — sim mirror
+
+`src/sim_codegen/cam.rs` — same C++ shape as the SV (per-entry valid + key vectors, comb match, priority encoder).
+
+### Phase D — refactor cache_mshr
+
+Replace lines 44-49 + the priority encoders at 70-95 with two `cam` instances (one for free-slot finding, one for address-CAM tail-finding). Confirm CVDP test still passes.
+
+### Phase E — docs
+
+Spec adds §13 `cam`. Reference card gets the construct + a 1-line MSHR example.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Write port doesn't fit "clear all on reset + per-entry update" cleanly | Phase A spec is explicit — `entry_valid_r` clears on reset, write port indexes one entry. If users need "clear all", they hold reset; otherwise wrap with their own logic. |
+| Priority encoder for `search_first` is O(DEPTH) gate depth | Acceptable for DEPTH ≤ 64; document the limit. Add log-tree variant only if a benchmark demands it. |
+| Cache_mshr's "find first matching with `~has_next` predicate" needs CAM-output post-filter | CAM exposes `search_mask`; cache_mshr ANDs with `~entry_has_next` and re-priority-encodes. Pure user code, no CAM extension needed. |
+
+## Non-goals
+
+- No `update` op (rewrite key in place) — clear + write next cycle.
+- No multiple search ports — instantiate two CAMs.
+- No CAM with payload data — that's a key→value RAM, use `ram` lookup-by-index after CAM gives the index.

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -14,6 +14,7 @@ pub enum Item {
     Fsm(FsmDecl),
     Fifo(FifoDecl),
     Ram(RamDecl),
+    Cam(CamDecl),
     Counter(CounterDecl),
     Arbiter(ArbiterDecl),
     Regfile(RegfileDecl),
@@ -962,6 +963,7 @@ impl Item {
             Item::Fsm(f) => f.span,
             Item::Fifo(f) => f.span,
             Item::Ram(r) => r.span,
+            Item::Cam(c) => c.span,
             Item::Counter(c) => c.span,
             Item::Arbiter(a) => a.span,
             Item::Regfile(r) => r.span,
@@ -1228,6 +1230,23 @@ pub enum RamInit {
     File(String, FileFormat),
     Value(Expr),
     Array(Vec<u64>),
+}
+
+// ── CAM ──────────────────────────────────────────────────────────────────────
+
+/// Content-addressable memory: combinational match of a search key against
+/// a vector of (valid, key) entries. Single write port (set/clear by index).
+/// See doc/plan_cam.md for full semantics.
+#[derive(Debug, Clone)]
+pub struct CamDecl {
+    pub common: ConstructCommon,
+}
+impl std::ops::Deref for CamDecl {
+    type Target = ConstructCommon;
+    fn deref(&self) -> &ConstructCommon { &self.common }
+}
+impl std::ops::DerefMut for CamDecl {
+    fn deref_mut(&mut self) -> &mut ConstructCommon { &mut self.common }
 }
 
 // ── Counter ───────────────────────────────────────────────────────────────────

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -139,6 +139,8 @@ impl<'a> Codegen<'a> {
                 Item::Fsm(f) => self.emit_fsm(f),
                 Item::Fifo(f) => self.emit_fifo(f),
                 Item::Ram(r) => self.emit_ram(r),
+                Item::Cam(c) => self.emit_cam(c),
+
                 Item::Counter(c) => self.emit_counter(c),
                 Item::Arbiter(a) => self.emit_arbiter(a),
                 Item::Regfile(r) => self.emit_regfile(r),
@@ -7024,6 +7026,122 @@ impl<'a> Codegen<'a> {
     }
 
     // ── Counter ───────────────────────────────────────────────────────────────
+
+    fn emit_cam(&mut self, c: &crate::ast::CamDecl) {
+        let n = c.name.name.clone();
+
+        // Required params (validated by typecheck): DEPTH, KEY_W
+        let depth_default = c.params.iter()
+            .find(|p| p.name.name == "DEPTH")
+            .and_then(|p| p.default.as_ref())
+            .map(|e| self.emit_expr_str(e))
+            .unwrap_or_else(|| "0".to_string());
+        let key_w_default = c.params.iter()
+            .find(|p| p.name.name == "KEY_W")
+            .and_then(|p| p.default.as_ref())
+            .map(|e| self.emit_expr_str(e))
+            .unwrap_or_else(|| "0".to_string());
+
+        let clk = c.ports.iter()
+            .find(|p| matches!(&p.ty, TypeExpr::Clock(_)))
+            .map(|p| p.name.name.clone())
+            .unwrap_or_else(|| "clk".to_string());
+        let (rst, is_async, is_low) = Self::extract_reset_info(&c.ports);
+
+        // ── Module header ─────────────────────────────────────────────────────
+        self.line(&format!("module {n} #("));
+        self.indent += 1;
+        self.line(&format!("parameter int DEPTH = {depth_default},"));
+        self.line(&format!("parameter int KEY_W = {key_w_default}"));
+        self.indent -= 1;
+        self.line(") (");
+        self.indent += 1;
+
+        let mut all_ports: Vec<String> = Vec::new();
+        for p in &c.ports {
+            let dir = match p.direction { Direction::In => "input", Direction::Out => "output" };
+            let ty_str = self.emit_port_type_str(&p.ty);
+            all_ports.push(format!("{dir} {ty_str} {}", p.name.name));
+        }
+        let port_count = all_ports.len();
+        for (i, p) in all_ports.iter().enumerate() {
+            let comma = if i < port_count - 1 { "," } else { "" };
+            self.line(&format!("{p}{comma}"));
+        }
+        self.indent -= 1;
+        self.line(");");
+        self.line("");
+        self.indent += 1;
+
+        // ── Storage ──────────────────────────────────────────────────────────
+        self.line("logic [DEPTH-1:0]      entry_valid_r;");
+        self.line("logic [KEY_W-1:0]      entry_key_r [DEPTH];");
+        self.line("");
+
+        // ── Combinational match ──────────────────────────────────────────────
+        // search_mask[i] = entry_valid_r[i] && (entry_key_r[i] == search_key)
+        self.line("always_comb begin");
+        self.indent += 1;
+        self.line("for (int i = 0; i < DEPTH; i++) begin");
+        self.indent += 1;
+        self.line("search_mask[i] = entry_valid_r[i] && (entry_key_r[i] == search_key);");
+        self.indent -= 1;
+        self.line("end");
+        self.indent -= 1;
+        self.line("end");
+        self.line("assign search_any = |search_mask;");
+        self.line("");
+
+        // ── Priority encoder for search_first (LSB-first) ────────────────────
+        self.line("always_comb begin");
+        self.indent += 1;
+        self.line("search_first = '0;");
+        self.line("for (int i = DEPTH-1; i >= 0; i--) begin");
+        self.indent += 1;
+        self.line("if (search_mask[i]) search_first = i[$clog2(DEPTH)-1:0];");
+        self.indent -= 1;
+        self.line("end");
+        self.indent -= 1;
+        self.line("end");
+        self.line("");
+
+        // ── Sequential write port ────────────────────────────────────────────
+        let ff_sens = Self::ff_sensitivity(&clk, &rst, is_async, is_low);
+        let rst_cond = Self::rst_condition(&rst, is_low);
+
+        self.line(&format!("always_ff @({ff_sens}) begin"));
+        self.indent += 1;
+        self.line(&format!("if ({rst_cond}) begin"));
+        self.indent += 1;
+        self.line("entry_valid_r <= '0;");
+        self.indent -= 1;
+        self.line("end else if (write_valid) begin");
+        self.indent += 1;
+        self.line("if (write_set) begin");
+        self.indent += 1;
+        self.line("entry_valid_r[write_idx] <= 1'b1;");
+        self.line("entry_key_r[write_idx] <= write_key;");
+        self.indent -= 1;
+        self.line("end else begin");
+        self.indent += 1;
+        self.line("entry_valid_r[write_idx] <= 1'b0;");
+        self.indent -= 1;
+        self.line("end");
+        self.indent -= 1;
+        self.line("end");
+        self.indent -= 1;
+        self.line("end");
+        self.line("");
+
+        if !c.asserts.is_empty() {
+            let asserts = c.asserts.clone();
+            self.emit_asserts_for_construct(&asserts, &n, &clk);
+        }
+
+        self.indent -= 1;
+        self.line("endmodule");
+        self.line("");
+    }
 
     fn emit_counter(&mut self, c: &crate::ast::CounterDecl) {
         use crate::ast::{CounterMode, CounterDirection};

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -95,6 +95,8 @@ pub enum TokenKind {
     Clkgate,
     #[token("ram")]
     Ram,
+    #[token("cam")]
+    Cam,
     #[token("store")]
     Store,
     #[token("counter")]
@@ -404,6 +406,7 @@ impl fmt::Display for TokenKind {
             TokenKind::Synchronizer => write!(f, "synchronizer"),
             TokenKind::Clkgate => write!(f, "clkgate"),
             TokenKind::Ram => write!(f, "ram"),
+            TokenKind::Cam => write!(f, "cam"),
             TokenKind::Store => write!(f, "store"),
             TokenKind::Counter => write!(f, "counter"),
             TokenKind::Arbiter => write!(f, "arbiter"),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -47,6 +47,7 @@ impl Parser {
             Some(TokenKind::Fsm) => Ok(Item::Fsm(self.parse_fsm()?)),
             Some(TokenKind::Fifo) => Ok(Item::Fifo(self.parse_fifo()?)),
             Some(TokenKind::Ram) => Ok(Item::Ram(self.parse_ram()?)),
+            Some(TokenKind::Cam) => Ok(Item::Cam(self.parse_cam()?)),
             Some(TokenKind::Counter) => Ok(Item::Counter(self.parse_counter()?)),
             Some(TokenKind::Arbiter) => Ok(Item::Arbiter(self.parse_arbiter()?)),
             Some(TokenKind::Regfile) => Ok(Item::Regfile(self.parse_regfile()?)),
@@ -4055,6 +4056,53 @@ impl Parser {
     }
 
     // ── Counter ───────────────────────────────────────────────────────────────
+
+    fn parse_cam(&mut self) -> Result<CamDecl, CompileError> {
+        let start = self.expect(TokenKind::Cam)?.span;
+        let name = self.expect_ident()?;
+
+        let mut params: Vec<ParamDecl> = Vec::new();
+        let mut ports: Vec<PortDecl> = Vec::new();
+        let mut asserts: Vec<AssertDecl> = Vec::new();
+
+        // params first, then ports / assert / cover. Same shape as counter
+        // but no kind/direction/init attributes.
+        while !self.check_end_of(TokenKind::Cam) && self.check(TokenKind::Param) {
+            params.push(self.parse_param_decl()?);
+        }
+        while !self.check_end_of(TokenKind::Cam) {
+            match self.peek_kind() {
+                Some(TokenKind::Port) => ports.push(self.parse_port_decl()?),
+                Some(TokenKind::Assert) | Some(TokenKind::Cover) => {
+                    asserts.push(self.parse_assert_decl()?);
+                }
+                Some(other) => return Err(CompileError::unexpected_token(
+                    "port, assert, or cover",
+                    &other.to_string(),
+                    self.peek_span(),
+                )),
+                None => return Err(CompileError::UnexpectedEof),
+            }
+        }
+
+        self.expect(TokenKind::End)?;
+        self.expect(TokenKind::Cam)?;
+        let closing = self.expect_ident()?;
+        if closing.name != name.name {
+            return Err(CompileError::mismatched_closing(&name.name, &closing.name, closing.span));
+        }
+        let end = closing.span;
+
+        Ok(CamDecl {
+            common: ConstructCommon {
+                name,
+                params,
+                ports,
+                asserts,
+                span: Span { start: start.start, end: end.end },
+            },
+        })
+    }
 
     fn parse_counter(&mut self) -> Result<CounterDecl, CompileError> {
         let start = self.expect(TokenKind::Counter)?.span;

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -489,6 +489,11 @@ pub fn resolve(source_file: &SourceFile) -> Result<SymbolTable, Vec<CompileError
                     table.globals.insert(r.name.name.clone(), (Symbol::Ram(info), r.name.span));
                 }
             }
+            Item::Cam(_c) => {
+                // Phase A: name is registered via the generic construct
+                // resolution below — full Symbol::Cam variant deferred to
+                // Phase B when codegen needs it. No-op for now.
+            }
             Item::Counter(c) => {
                 if table.globals.contains_key(&c.name.name) {
                     errors.push(CompileError::duplicate(&c.name.name, c.name.span));

--- a/src/sim_codegen/cam.rs
+++ b/src/sim_codegen/cam.rs
@@ -1,0 +1,122 @@
+//! `gen_cam` emitter — Phase C of the CAM construct rollout.
+//!
+//! Mirrors the SV codegen in `codegen.rs::emit_cam` for the C++ sim.
+//! Storage: `entry_valid_r` (packed bitmask, uint`DEPTH`) and
+//! `entry_key_r[DEPTH]` (per-entry key). Comb match recomputes
+//! `search_mask` / `search_any` / `search_first` every cycle.
+
+use super::{SimCodegen, SimModel};
+use super::*;
+
+impl<'a> SimCodegen<'a> {
+    pub(super) fn gen_cam(&self, c: &CamDecl) -> SimModel {
+        let name = &c.name.name;
+        let class = format!("V{name}");
+
+        // DEPTH and KEY_W are required const params (typecheck enforces).
+        let depth: u32 = c.params.iter()
+            .find(|p| p.name.name == "DEPTH")
+            .and_then(|p| p.default.as_ref())
+            .and_then(|e| if let ExprKind::Literal(LitKind::Dec(v)) = &e.kind { Some(*v as u32) } else { None })
+            .unwrap_or(32);
+        let key_w: u32 = c.params.iter()
+            .find(|p| p.name.name == "KEY_W")
+            .and_then(|p| p.default.as_ref())
+            .and_then(|e| if let ExprKind::Literal(LitKind::Dec(v)) = &e.kind { Some(*v as u32) } else { None })
+            .unwrap_or(8);
+
+        let key_ty = cpp_uint(key_w);
+        let mask_ty = cpp_uint(depth);
+        let idx_w = if depth <= 1 { 1 } else { 32 - (depth - 1).leading_zeros() };
+        let idx_ty = cpp_uint(idx_w);
+
+        let (rst_name, _is_async, is_low) = extract_reset_info(&c.ports);
+        let rst_cond = if is_low { format!("(!{})", rst_name) } else { rst_name.clone() };
+        let clk_port = c.ports.iter().find(|p| matches!(&p.ty, TypeExpr::Clock(_)))
+            .map(|p| p.name.name.clone())
+            .unwrap_or_else(|| "clk".to_string());
+
+        // ── Header ──
+        let mut h = String::new();
+        h.push_str("#pragma once\n#include <cstdint>\n#include <cstdio>\n#include <cstring>\n#include \"verilated.h\"\n\n");
+        h.push_str(&format!("class {class} {{\npublic:\n"));
+        for p in &c.ports {
+            h.push_str(&format!("  {} {};\n", cpp_port_type(&p.ty), p.name.name));
+        }
+        h.push('\n');
+
+        // Ctor: zero ports + state.
+        let port_inits: Vec<String> = c.ports.iter().map(|p| format!("{}(0)", p.name.name)).collect();
+        let state_inits = vec!["_clk_prev(0)".to_string(), "_entry_valid_r(0)".to_string()];
+        let all_inits: Vec<String> = port_inits.into_iter().chain(state_inits).collect();
+        h.push_str(&format!("  {class}() : {} {{\n", all_inits.join(", ")));
+        h.push_str("    memset(_entry_key_r, 0, sizeof(_entry_key_r));\n");
+        h.push_str("  }\n");
+        h.push_str(&format!("  explicit {class}(VerilatedContext*) : {class}() {{}}\n"));
+        h.push_str("  void eval();\n  void eval_posedge();\n  void eval_comb();\n  void final() { trace_close(); }\n");
+        h.push_str("private:\n");
+        h.push_str("  uint8_t _clk_prev;\n");
+        h.push_str(&format!("  {mask_ty} _entry_valid_r;\n"));
+        h.push_str(&format!("  {key_ty} _entry_key_r[{depth}];\n"));
+
+        // ── Implementation ──
+        let mut cpp = String::new();
+        cpp.push_str(&format!("#include \"{class}.h\"\n\n"));
+
+        cpp.push_str(&format!("void {class}::eval() {{\n"));
+        cpp.push_str("  if (!_trace_fp && Verilated::traceFile() && Verilated::claimTrace())\n");
+        cpp.push_str("    trace_open(Verilated::traceFile());\n");
+        cpp.push_str("  eval_posedge();\n  eval_comb();\n");
+        cpp.push_str("  if (_trace_fp) trace_dump(_trace_time++);\n");
+        cpp.push_str("}\n\n");
+
+        // posedge: write port (set or clear).
+        cpp.push_str(&format!("void {class}::eval_posedge() {{\n"));
+        cpp.push_str(&format!("  bool _rising = ({clk_port} && !_clk_prev);\n"));
+        cpp.push_str(&format!("  _clk_prev = {clk_port};\n"));
+        cpp.push_str("  if (!_rising) return;\n");
+        cpp.push_str(&format!("  if ({rst_cond}) {{\n"));
+        cpp.push_str("    _entry_valid_r = 0;\n");
+        cpp.push_str("  } else if (write_valid) {\n");
+        cpp.push_str(&format!("    {mask_ty} _bit = ({mask_ty})1 << write_idx;\n"));
+        cpp.push_str("    if (write_set) {\n");
+        cpp.push_str("      _entry_valid_r |= _bit;\n");
+        cpp.push_str("      _entry_key_r[write_idx] = write_key;\n");
+        cpp.push_str("    } else {\n");
+        cpp.push_str("      _entry_valid_r &= ~_bit;\n");
+        cpp.push_str("    }\n");
+        cpp.push_str("  }\n");
+        cpp.push_str("}\n\n");
+
+        // comb: recompute search_mask / search_any / search_first.
+        cpp.push_str(&format!("void {class}::eval_comb() {{\n"));
+        cpp.push_str(&format!("  {mask_ty} _m = 0;\n"));
+        cpp.push_str(&format!("  for (uint32_t i = 0; i < {depth}; i++) {{\n"));
+        cpp.push_str(&format!("    if ((_entry_valid_r >> i) & 1) {{\n"));
+        cpp.push_str("      if (_entry_key_r[i] == search_key) {\n");
+        cpp.push_str(&format!("        _m |= ({mask_ty})1 << i;\n"));
+        cpp.push_str("      }\n");
+        cpp.push_str("    }\n");
+        cpp.push_str("  }\n");
+        cpp.push_str("  search_mask = _m;\n");
+        cpp.push_str("  search_any = (_m != 0) ? 1 : 0;\n");
+        cpp.push_str(&format!("  {idx_ty} _first = 0;\n"));
+        cpp.push_str(&format!("  for (uint32_t i = 0; i < {depth}; i++) {{\n"));
+        cpp.push_str("    if ((_m >> i) & 1) {\n");
+        cpp.push_str(&format!("      _first = ({idx_ty})i;\n"));
+        cpp.push_str("      break;\n");
+        cpp.push_str("    }\n");
+        cpp.push_str("  }\n");
+        cpp.push_str("  search_first = _first;\n");
+        cpp.push_str("}\n");
+
+        // Trace support — track entry_valid_r and search outputs.
+        let extra_sigs: Vec<(&str, &str, u32)> = vec![
+            ("entry_valid_r", "_entry_valid_r", depth),
+        ];
+        add_trace_to_simple_construct(&mut h, &mut cpp, &class, name, &c.ports, &extra_sigs);
+        h.push_str("};\n");
+
+        SimModel { class_name: class, header: h, impl_: cpp }
+    }
+}

--- a/src/sim_codegen/mod.rs
+++ b/src/sim_codegen/mod.rs
@@ -27,6 +27,7 @@ mod fsm;
 mod linklist;
 mod pipeline;
 mod ram;
+mod cam;
 
 // ── Public API ────────────────────────────────────────────────────────────────
 
@@ -167,6 +168,7 @@ impl<'a> SimCodegen<'a> {
                 Item::Regfile(r)     => models.push(self.gen_regfile(r)),
                 Item::Linklist(l)    => models.push(self.gen_linklist(l)),
                 Item::Ram(r)         => models.push(self.gen_ram(r)),
+                Item::Cam(c)         => models.push(self.gen_cam(c)),
                 Item::Synchronizer(s) => models.push(self.gen_synchronizer(s)),
                 Item::Clkgate(c)     => models.push(self.gen_clkgate(c)),
                 Item::Fifo(f)        => models.push(self.gen_fifo(f)),
@@ -3079,6 +3081,7 @@ impl<'a> SimCodegen<'a> {
                 Item::Fsm(f)          if f.name.name == module_name => Some(&f.ports),
                 Item::Fifo(f)         if f.name.name == module_name => Some(&f.ports),
                 Item::Ram(r)          if r.name.name == module_name => Some(&r.ports),
+                Item::Cam(c)          if c.name.name == module_name => Some(&c.ports),
                 Item::Counter(c)      if c.name.name == module_name => Some(&c.ports),
                 Item::Arbiter(a)      if a.name.name == module_name => Some(&a.ports),
                 Item::Regfile(r)      if r.name.name == module_name => Some(&r.ports),

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -89,6 +89,7 @@ impl<'a> TypeChecker<'a> {
                 Item::Fsm(f) => self.check_fsm(f),
                 Item::Fifo(f) => self.check_fifo(f),
                 Item::Ram(r) => self.check_ram(r),
+                Item::Cam(c) => self.check_cam(c),
                 Item::Counter(c) => self.check_counter(c),
                 Item::Arbiter(a) => self.check_arbiter(a),
                 Item::Regfile(r) => self.check_regfile(r),
@@ -163,6 +164,7 @@ impl<'a> TypeChecker<'a> {
                 Item::Fsm(f)          => &f.params,
                 Item::Fifo(f)         => &f.params,
                 Item::Ram(r)          => &r.params,
+                Item::Cam(c)          => &c.params,
                 Item::Counter(c)      => &c.params,
                 Item::Arbiter(a)      => &a.params,
                 Item::Regfile(r)      => &r.params,
@@ -3530,6 +3532,33 @@ impl<'a> TypeChecker<'a> {
     }
 
     // ── RAM ───────────────────────────────────────────────────────────────────
+
+    fn check_cam(&mut self, c: &CamDecl) {
+        // Phase A: minimal naming check + presence of required params/ports.
+        // Full validation (port widths from $clog2(DEPTH), $clog2(KEY_W),
+        // exact port name list) deferred to Phase A continuation.
+        self.check_pascal_case(&c.name);
+        for p in &c.params {
+            self.check_upper_snake(&p.name);
+        }
+        for p in &c.ports {
+            self.check_snake_case(&p.name);
+        }
+        let has_depth = c.params.iter().any(|p| p.name.name == "DEPTH");
+        let has_key_w = c.params.iter().any(|p| p.name.name == "KEY_W");
+        if !has_depth {
+            self.errors.push(CompileError::general(
+                "cam: missing required `param DEPTH: const = N;`",
+                c.name.span,
+            ));
+        }
+        if !has_key_w {
+            self.errors.push(CompileError::general(
+                "cam: missing required `param KEY_W: const = N;`",
+                c.name.span,
+            ));
+        }
+    }
 
     fn check_ram(&mut self, r: &RamDecl) {
         self.check_pascal_case(&r.name);

--- a/tests/cam_basic.arch
+++ b/tests/cam_basic.arch
@@ -1,0 +1,20 @@
+// Phase A smoke test: a `cam` construct parses and type-checks.
+// Codegen (Phase B) and sim (Phase C) are not yet implemented.
+
+cam Mshr_Addr_Cam
+  param DEPTH: const = 32;
+  param KEY_W: const = 10;
+
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync, High>;
+
+  port write_valid: in Bool;
+  port write_idx:   in UInt<5>;
+  port write_key:   in UInt<10>;
+  port write_set:   in Bool;
+
+  port search_key:   in  UInt<10>;
+  port search_mask:  out UInt<32>;
+  port search_any:   out Bool;
+  port search_first: out UInt<5>;
+end cam Mshr_Addr_Cam

--- a/tests/cam_basic.sv
+++ b/tests/cam_basic.sv
@@ -1,0 +1,50 @@
+// Phase A smoke test: a `cam` construct parses and type-checks.
+// Codegen (Phase B) and sim (Phase C) are not yet implemented.
+module Mshr_Addr_Cam #(
+  parameter int DEPTH = 32,
+  parameter int KEY_W = 10
+) (
+  input logic clk,
+  input logic rst,
+  input logic write_valid,
+  input logic [4:0] write_idx,
+  input logic [9:0] write_key,
+  input logic write_set,
+  input logic [9:0] search_key,
+  output logic [31:0] search_mask,
+  output logic search_any,
+  output logic [4:0] search_first
+);
+
+  logic [DEPTH-1:0]      entry_valid_r;
+  logic [KEY_W-1:0]      entry_key_r [DEPTH];
+  
+  always_comb begin
+    for (int i = 0; i < DEPTH; i++) begin
+      search_mask[i] = entry_valid_r[i] && (entry_key_r[i] == search_key);
+    end
+  end
+  assign search_any = |search_mask;
+  
+  always_comb begin
+    search_first = '0;
+    for (int i = DEPTH-1; i >= 0; i--) begin
+      if (search_mask[i]) search_first = i[$clog2(DEPTH)-1:0];
+    end
+  end
+  
+  always_ff @(posedge clk) begin
+    if (rst) begin
+      entry_valid_r <= '0;
+    end else if (write_valid) begin
+      if (write_set) begin
+        entry_valid_r[write_idx] <= 1'b1;
+        entry_key_r[write_idx] <= write_key;
+      end else begin
+        entry_valid_r[write_idx] <= 1'b0;
+      end
+    end
+  end
+  
+endmodule
+

--- a/tests/cam_basic_tb.cpp
+++ b/tests/cam_basic_tb.cpp
@@ -1,0 +1,79 @@
+// Phase C smoke test for the cam construct.
+//
+// Drives the Mshr_Addr_Cam CAM, writes a few entries, searches, and
+// checks the match outputs cycle by cycle.
+
+#include "VMshr_Addr_Cam.h"
+#include <cstdio>
+#include <cstdlib>
+
+static VMshr_Addr_Cam dut;
+static int pass = 0, fail = 0;
+
+#define CHECK(cond, msg, ...) do { \
+  if (cond) { printf("  PASS: " msg "\n", ##__VA_ARGS__); ++pass; } \
+  else      { printf("  FAIL: " msg "\n", ##__VA_ARGS__); ++fail; } \
+} while (0)
+
+static void tick() {
+    dut.clk = 0; dut.eval();
+    dut.clk = 1; dut.eval();
+}
+
+static void do_reset() {
+    dut.rst = 1;
+    dut.write_valid = 0;
+    dut.search_key = 0;
+    tick(); tick();
+    dut.rst = 0; tick();
+}
+
+static void cam_write(uint32_t idx, uint32_t key, bool set) {
+    dut.write_valid = 1;
+    dut.write_idx = idx;
+    dut.write_key = key;
+    dut.write_set = set ? 1 : 0;
+    tick();
+    dut.write_valid = 0;
+}
+
+int main() {
+    printf("=== cam_basic sim ===\n");
+    do_reset();
+
+    // Initially empty: any search returns no match.
+    dut.search_key = 0x123; dut.eval();
+    CHECK(dut.search_any == 0, "post-reset search_any == 0");
+    CHECK(dut.search_mask == 0, "post-reset search_mask == 0");
+
+    // Insert key 0x55 at idx 3, key 0x77 at idx 5.
+    cam_write(3, 0x55, true);
+    cam_write(5, 0x77, true);
+    cam_write(7, 0x55, true);  // duplicate key at different index
+
+    // Search for 0x77 → only idx 5 matches.
+    dut.search_key = 0x77; dut.eval();
+    CHECK(dut.search_any == 1, "search 0x77 hit");
+    CHECK(dut.search_mask == (1u << 5), "search 0x77 mask = bit 5 (got 0x%x)", (unsigned)dut.search_mask);
+    CHECK(dut.search_first == 5, "search 0x77 first = 5 (got %u)", (unsigned)dut.search_first);
+
+    // Search for 0x55 → idx 3 and idx 7 match; first should be 3 (LSB).
+    dut.search_key = 0x55; dut.eval();
+    CHECK(dut.search_any == 1, "search 0x55 hit");
+    CHECK(dut.search_mask == ((1u << 3) | (1u << 7)), "search 0x55 mask (got 0x%x)", (unsigned)dut.search_mask);
+    CHECK(dut.search_first == 3, "search 0x55 first = 3 (got %u)", (unsigned)dut.search_first);
+
+    // Search for 0xAB → no match.
+    dut.search_key = 0xAB; dut.eval();
+    CHECK(dut.search_any == 0, "search 0xAB no hit");
+    CHECK(dut.search_mask == 0, "search 0xAB mask 0");
+
+    // Clear idx 3; search 0x55 → only idx 7 left.
+    cam_write(3, 0, false);
+    dut.search_key = 0x55; dut.eval();
+    CHECK(dut.search_mask == (1u << 7), "post-clear mask bit 7 (got 0x%x)", (unsigned)dut.search_mask);
+    CHECK(dut.search_first == 7, "post-clear first = 7");
+
+    printf("=== %d pass / %d fail ===\n", pass, fail);
+    return fail == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary
- Adds a first-class \`cam\` construct for content-addressable lookup: combinational match of a search key against a vector of (valid, key) entries, single write port for set/clear by index.
- Motivated by designs (cache MSHR, per-address pending tables) where chains are keyed by content, not by a small fixed head index — multi-head linklist alone doesn't fit (see [doc/phase_d_cache_mshr_analysis.md](doc/phase_d_cache_mshr_analysis.md)).
- Three phases land together; D (cache_mshr refactor) and E (spec + reference card) follow in separate PRs.

## Phase breakdown
**A — language surface**
- AST/lexer/parser/typecheck for \`cam Name … end cam Name\` with required \`param DEPTH\`, \`param KEY_W\`.
- Smoke test [tests/cam_basic.arch](tests/cam_basic.arch) — \`arch check\` clean.

**B — SV codegen** ([src/codegen.rs](src/codegen.rs))
- \`emit_cam\`: header, packed \`entry_valid_r\` + \`entry_key_r [DEPTH]\`, comb match, LSB-priority encoder for \`search_first\`, sequential write/clear with reset.
- Emitted SV [tests/cam_basic.sv](tests/cam_basic.sv) is Verilator 5.034 \`--lint-only -Wall\` clean.

**C — sim mirror** ([src/sim_codegen/cam.rs](src/sim_codegen/cam.rs))
- \`gen_cam\`: packed bitmask state, \`eval_posedge\` for set/clear, \`eval_comb\` for match recompute.
- Testbench [tests/cam_basic_tb.cpp](tests/cam_basic_tb.cpp) drives write/clear + multi-match — **12 pass / 0 fail**.

## Plan
[doc/plan_cam.md](doc/plan_cam.md) — full design + phased rollout.

## Test plan
- [x] \`cargo build --release\` clean
- [x] \`arch check tests/cam_basic.arch\` → OK
- [x] \`arch build tests/cam_basic.arch\` → SV emitted, Verilator lint clean
- [x] \`arch sim tests/cam_basic.arch --tb tests/cam_basic_tb.cpp\` → 12/12 pass
- [ ] Phase D follow-up: refactor cache_mshr to use \`cam\` for address lookup
- [ ] Phase E follow-up: spec §13 + reference card

🤖 Generated with [Claude Code](https://claude.com/claude-code)