### PR TITLE
docs: cam construct (Phase E) — spec §13.0 + reference card

### DIFF
--- a/doc/ARCH_HDL_Specification.md
+++ b/doc/ARCH_HDL_Specification.md
@@ -3061,7 +3061,52 @@ For a linklist of kind doubly, depth D, and payload type T, the compiler generat
 
 A cam (Content-Addressable Memory) is a first-class construct that searches by content rather than by address. Instead of \'return the value at address X,\' a CAM answers \'is key X present, and if so at which index?\' The designer declares the CAM kind, depth, key and value types, match policy, and a lookup latency budget. The compiler generates the comparator array, priority encoder, replacement logic, and pipeline registers to meet the declared constraints.
 
-**13.1 CAM Kinds**
+> *⚑ Implementation status (v1): the surface in **§13.0** is implemented end-to-end — parser, type-check, SV codegen (Verilator-clean), and arch-sim. The richer surface in §13.1 onward (kind: ternary/associative, replace: lru/fifo/random, value_type, op-style lookup/insert with latency budgets) is aspirational design and not yet accepted by the compiler.*
+
+**13.0 v1 Surface --- Combinational Binary Match**
+
+The v1 \`cam\` is a stateless-controller helper: a vector of (valid, key) entries with a single write port (set or clear by index) and a combinational search port returning a one-hot match mask, an any-match flag, and the LSB-priority first-match index.
+
+```
+cam Mshr_Addr_Cam
+  param DEPTH: const = 32;
+  param KEY_W: const = 10;
+
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync, High>;
+
+  // Write port: set or clear an entry
+  port write_valid: in Bool;
+  port write_idx:   in UInt<5>;       // $clog2(DEPTH)
+  port write_key:   in UInt<10>;      // KEY_W
+  port write_set:   in Bool;          // true = insert valid+key, false = clear valid
+
+  // Search port: combinational
+  port search_key:   in  UInt<10>;
+  port search_mask:  out UInt<32>;    // bitmask of matches; zero if no match
+  port search_any:   out Bool;
+  port search_first: out UInt<5>;     // LSB-priority first match (0 when search_any == 0)
+end cam Mshr_Addr_Cam
+```
+
+**Required params:** \`DEPTH\` and \`KEY_W\` (both \`const\`). The compiler rejects a \`cam\` declaration that omits either.
+
+**Semantics:**
+- **Storage:** internal \`entry_valid_r [DEPTH]\` (1 bit per entry) and \`entry_key_r [DEPTH]\` (KEY_W bits per entry). Both reset to zero.
+- **Write:** when \`write_valid\` is high on a clock edge, \`entry_valid_r[write_idx]\` is set to \`write_set\`; if \`write_set\` is true the corresponding \`entry_key_r[write_idx]\` is updated to \`write_key\`. Multiple writes per cycle are not supported (single write port; the user serializes).
+- **Search:** combinational. \`search_mask[i] = entry_valid_r[i] && (entry_key_r[i] == search_key)\`. \`search_any = OR(search_mask)\`. \`search_first\` is the LSB-priority first set bit of \`search_mask\` (0 when there is no match; gate consumers with \`search_any\`).
+- **Read-during-write:** the search port reflects the *pre-write* state on the same cycle as a write; the write commits on the next clock edge. Same convention as ARCH \`reg\`.
+
+**Typical use:** content-keyed lookup in cache MSHR, per-flow tables, scoreboard tag CAM, or any design that today hand-rolls \`Vec<reg>\` + a comb match loop. Compose with \`linklist\` (CAM finds head index → linklist owns the chain) for content-keyed multi-list designs.
+
+**Limitations of v1 (deferred to follow-ups):**
+- No ternary (TCAM) kind --- exact match only.
+- No \`value_type\` --- key only; pair with a \`ram\` indexed by \`search_first\` to recover an associated value.
+- No replacement policy --- the user picks the index to write (typically a free-slot priority encoder driven by \`~entry_valid_r\`).
+- No multi-cycle pipelined comparator --- a single combinational compare. Adequate for DEPTH ≤ 64; larger CAMs should pipeline manually for now.
+- No multiple search ports --- instantiate two CAMs.
+
+**13.1 CAM Kinds** *(aspirational --- not yet implemented)*
 
   ----------------------------------------------------------------------------------------------------------------------------------------------------------
   **kind**          **Match Semantics**                             **Don\'t-Care Bits**   **Typical Applications**

--- a/doc/Arch_AI_Reference_Card.md
+++ b/doc/Arch_AI_Reference_Card.md
@@ -670,6 +670,39 @@ end ram Name
 
 ---
 
+### cam
+
+Content-addressable lookup. Combinational match of a search key against a vector of (valid, key) entries; single write port for set/clear by index. Use for cache MSHR address lookup, per-flow tables, scoreboard tag CAM, or any design that today hand-rolls `Vec<reg>` + a comb match loop. Compose with `linklist` (CAM finds head index → linklist owns the chain) for content-keyed multi-list designs.
+
+```
+cam Mshr_Addr_Cam
+  param DEPTH: const = 32;            // required
+  param KEY_W: const = 10;            // required
+
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync, High>;
+
+  // Write port: set (write_set=true → insert valid+key) or clear (false → invalidate)
+  port write_valid: in Bool;
+  port write_idx:   in UInt<5>;       // $clog2(DEPTH)
+  port write_key:   in UInt<10>;      // KEY_W
+  port write_set:   in Bool;
+
+  // Search port: combinational
+  port search_key:   in  UInt<10>;
+  port search_mask:  out UInt<32>;    // bitmask of matches; zero if no match
+  port search_any:   out Bool;
+  port search_first: out UInt<5>;     // LSB-priority first match (gate with search_any)
+end cam Mshr_Addr_Cam
+```
+
+**Semantics:**
+- One write per cycle. Search reads pre-write state on the same cycle as a write; the write commits on the next clock edge.
+- `search_first` is the LSB-priority first set bit of `search_mask`; consumers should qualify with `search_any` (it reads as 0 when there is no match).
+- v1 is exact-match only (no TCAM/wildcards), no value payload (pair with a `ram` indexed by `search_first` to recover an associated value), no built-in replacement policy (the user picks the index to write — typically a free-slot priority encoder over `~entry_valid_r`).
+
+---
+
 ### counter
 
 Configurable counter. `kind: wrap | saturate | gray | one_hot | johnson`.


### PR DESCRIPTION
## Summary
- Documents the v1 \`cam\` surface that landed in #122 (Phases A-C).
- Spec gets a new **§13.0 "v1 Surface --- Combinational Binary Match"** describing the implemented surface (required \`DEPTH\`/\`KEY_W\`, write/search ports, semantics, limitations) plus a status callout at the top of §13 distinguishing v1 from the aspirational design that was already in §13.1+ (ternary/associative kinds, replace policies, op-style lookup --- not yet implemented).
- Reference card gets a new \`### cam\` card between \`ram\` and \`counter\` with the same syntax + 1-paragraph semantics summary.

## Files
- [doc/ARCH_HDL_Specification.md](doc/ARCH_HDL_Specification.md) — +1 status callout, +new §13.0
- [doc/Arch_AI_Reference_Card.md](doc/Arch_AI_Reference_Card.md) — +new \`### cam\` card

## Closes the cam rollout
Phase A-C: #122 (merged). Phase D (cache_mshr refactor using \`cam\`) remains open as a follow-up but is not blocking the language surface from being documented.

## Test plan
- [x] Manual review --- syntax in spec/card matches \`tests/cam_basic.arch\` byte-for-byte
- [x] Status callout makes the v1-vs-aspirational split explicit
- [x] No code changes; no compiler tests required

🤖 Generated with [Claude Code](https://claude.com/claude-code)