### PR TITLE
feat(cvdp): refactor cache_mshr to use cam (Phase D)

### DIFF
--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -13,6 +13,7 @@ pub enum Symbol {
     Fsm(FsmInfo),
     Fifo(FifoInfo),
     Ram(RamInfo),
+    Cam(CamInfo),
     Counter(CounterInfo),
     Arbiter(ArbiterInfo),
     Regfile(RegfileInfo),
@@ -92,6 +93,11 @@ pub struct RamInfo {
     pub name: String,
     pub kind: crate::ast::RamKind,
     pub latency: u32,
+}
+
+#[derive(Debug, Clone)]
+pub struct CamInfo {
+    pub name: String,
 }
 
 #[derive(Debug, Clone)]
@@ -489,10 +495,13 @@ pub fn resolve(source_file: &SourceFile) -> Result<SymbolTable, Vec<CompileError
                     table.globals.insert(r.name.name.clone(), (Symbol::Ram(info), r.name.span));
                 }
             }
-            Item::Cam(_c) => {
-                // Phase A: name is registered via the generic construct
-                // resolution below — full Symbol::Cam variant deferred to
-                // Phase B when codegen needs it. No-op for now.
+            Item::Cam(c) => {
+                if table.globals.contains_key(&c.name.name) {
+                    errors.push(CompileError::duplicate(&c.name.name, c.name.span));
+                } else {
+                    let info = CamInfo { name: c.name.name.clone() };
+                    table.globals.insert(c.name.name.clone(), (Symbol::Cam(info), c.name.span));
+                }
             }
             Item::Counter(c) => {
                 if table.globals.contains_key(&c.name.name) {

--- a/tests/cvdp/cache_mshr.arch
+++ b/tests/cvdp/cache_mshr.arch
@@ -1,3 +1,32 @@
+// Address-CAM helper used by cache_mshr to find the tail of the chain
+// for a given line address. Maintains (valid, addr) per slot; the cam's
+// dual-write port commits allocate (port 2, wins on conflict) and
+// finalize (port 1) on the same edge.
+cam Mshr_Addr_Cam
+  param DEPTH: const = 32;
+  param KEY_W: const = 10;
+
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync, High>;
+
+  // Port 1: finalize (clear by id)
+  port write_valid: in Bool;
+  port write_idx:   in UInt<5>;
+  port write_key:   in UInt<10>;
+  port write_set:   in Bool;
+
+  // Port 2: allocate (insert at alloc_idx with allocate_addr) — wins on same-idx conflict
+  port write2_valid: in Bool;
+  port write2_idx:   in UInt<5>;
+  port write2_key:   in UInt<10>;
+  port write2_set:   in Bool;
+
+  port search_key:   in  UInt<10>;
+  port search_mask:  out UInt<32>;
+  port search_any:   out Bool;
+  port search_first: out UInt<5>;
+end cam Mshr_Addr_Cam
+
 module cache_mshr
   param MSHR_SIZE: const = 32;
   param CS_LINE_ADDR_WIDTH: const = 10;
@@ -60,13 +89,44 @@ module cache_mshr
   reg dq_valid_r:   Bool;
   reg dq_idx_r:     UInt<MSHR_ADDR_WIDTH>;
 
-  // Wires for priority encoder
+  // Wires for the free-slot priority encoder
   wire alloc_idx:      UInt<MSHR_ADDR_WIDTH>;
   wire full_flag:      Bool;
-  wire prev_idx:       UInt<MSHR_ADDR_WIDTH>;
-  wire prev_all_zeros: Bool;
 
-  // Priority encoder: find first free slot (LSB-first)
+  // Wires for the address-CAM lookup chain
+  wire addr_search_mask:  UInt<MSHR_SIZE>;
+  wire addr_search_any:   Bool;                       // unused; required to bind cam port
+  wire addr_search_first: UInt<MSHR_ADDR_WIDTH>;      // unused; required to bind cam port
+  wire has_next_mask:     UInt<MSHR_SIZE>;
+  wire tail_mask:         UInt<MSHR_SIZE>;
+  wire prev_idx:          UInt<MSHR_ADDR_WIDTH>;
+  wire prev_all_zeros:    Bool;
+
+  // Address CAM: maintains (valid, addr) per slot. Port 1 = finalize,
+  // port 2 = allocate (wins on same-idx conflict, matching the original
+  // last-assignment-wins seq semantics).
+  inst addr_cam: Mshr_Addr_Cam
+    param DEPTH = MSHR_SIZE;
+    param KEY_W = CS_LINE_ADDR_WIDTH;
+
+    clk           <- clk;
+    rst           <- reset;
+    write_valid   <- finalize_valid;
+    write_idx     <- finalize_id;
+    write_key     <- 0.zext<CS_LINE_ADDR_WIDTH>();  // ignored on clear; explicit width to silence iverilog literal-prune warning
+    write_set     <- false;
+    write2_valid  <- allocate_valid & ~full_flag;
+    write2_idx    <- alloc_idx;
+    write2_key    <- allocate_addr;
+    write2_set    <- true;
+    search_key    <- allocate_addr;
+    search_mask   -> addr_search_mask;
+    search_any    -> addr_search_any;
+    search_first  -> addr_search_first;
+  end inst addr_cam
+
+  // Free-slot priority encoder: find first ~entry_valid (LSB-first).
+  // Not a CAM lookup (no key matching), so still hand-rolled.
   comb
     alloc_idx = 0;
     full_flag = true;
@@ -80,13 +140,28 @@ module cache_mshr
     end for
   end comb
 
-  // Priority encoder: find first matching entry with no next (LSB-first)
+  // Pack entry_has_next into a UInt mask so we can AND it with the
+  // CAM's search_mask. The tail of a chain is an entry that matches
+  // the address AND has no next pointer.
+  comb
+    has_next_mask = 0;
+    for i in 0..MSHR_SIZE-1
+      if entry_has_next[i]
+        has_next_mask = has_next_mask | ((1.zext<MSHR_SIZE>()) << i);
+      end if
+    end for
+  end comb
+
+  let tail_mask_w: UInt<MSHR_SIZE> = addr_search_mask & ~has_next_mask;
+  let tail_mask = tail_mask_w;
+
+  // Priority-encode tail_mask to get prev_idx (LSB-first).
   comb
     prev_idx = 0;
     prev_all_zeros = true;
     for i in 0..MSHR_SIZE-1
       if ~prev_all_zeros == false
-        if entry_valid[i] & (entry_addr[i] == allocate_addr) & ~entry_has_next[i]
+        if (tail_mask >> i) & 1
           prev_idx = i.trunc<MSHR_ADDR_WIDTH>();
           prev_all_zeros = false;
         end if

--- a/tests/cvdp/cache_mshr.sv
+++ b/tests/cvdp/cache_mshr.sv
@@ -1,10 +1,78 @@
+// Address-CAM helper used by cache_mshr to find the tail of the chain
+// for a given line address. Maintains (valid, addr) per slot; the cam's
+// dual-write port commits allocate (port 2, wins on conflict) and
+// finalize (port 1) on the same edge.
+module Mshr_Addr_Cam #(
+  parameter int DEPTH = 32,
+  parameter int KEY_W = 10
+) (
+  input logic clk,
+  input logic rst,
+  input logic write_valid,
+  input logic [4:0] write_idx,
+  input logic [9:0] write_key,
+  input logic write_set,
+  input logic write2_valid,
+  input logic [4:0] write2_idx,
+  input logic [9:0] write2_key,
+  input logic write2_set,
+  input logic [9:0] search_key,
+  output logic [31:0] search_mask,
+  output logic search_any,
+  output logic [4:0] search_first
+);
+
+  logic [DEPTH-1:0]      entry_valid_r;
+  logic [KEY_W-1:0]      entry_key_r [DEPTH];
+  
+  always_comb begin
+    for (int i = 0; i < DEPTH; i++) begin
+      search_mask[i] = entry_valid_r[i] && (entry_key_r[i] == search_key);
+    end
+  end
+  assign search_any = |search_mask;
+  
+  always_comb begin
+    search_first = '0;
+    for (int i = DEPTH-1; i >= 0; i--) begin
+      if (search_mask[i]) search_first = i[$clog2(DEPTH)-1:0];
+    end
+  end
+  
+  always_ff @(posedge clk) begin
+    if (rst) begin
+      entry_valid_r <= '0;
+    end else begin
+      if (write_valid) begin
+        if (write_set) begin
+          entry_valid_r[write_idx] <= 1'b1;
+          entry_key_r[write_idx] <= write_key;
+        end else begin
+          entry_valid_r[write_idx] <= 1'b0;
+        end
+      end
+      if (write2_valid) begin
+        if (write2_set) begin
+          entry_valid_r[write2_idx] <= 1'b1;
+          entry_key_r[write2_idx] <= write2_key;
+        end else begin
+          entry_valid_r[write2_idx] <= 1'b0;
+        end
+      end
+    end
+  end
+  
+endmodule
+
+// Port 1: finalize (clear by id)
+// Port 2: allocate (insert at alloc_idx with allocate_addr) — wins on same-idx conflict
 module cache_mshr #(
   parameter int MSHR_SIZE = 32,
   parameter int CS_LINE_ADDR_WIDTH = 10,
   parameter int WORD_SEL_WIDTH = 4,
   parameter int WORD_SIZE = 4,
   localparam int MSHR_ADDR_WIDTH = $clog2(MSHR_SIZE),
-  localparam int TAG_WIDTH = 32 - CS_LINE_ADDR_WIDTH - $clog2(WORD_SIZE) - WORD_SEL_WIDTH,
+  localparam int TAG_WIDTH = ((32 - CS_LINE_ADDR_WIDTH) - $clog2(WORD_SIZE)) - WORD_SEL_WIDTH,
   localparam int CS_WORD_WIDTH = WORD_SIZE * 8,
   localparam int DATA_WIDTH = WORD_SEL_WIDTH + WORD_SIZE + CS_WORD_WIDTH + TAG_WIDTH
 ) (
@@ -36,13 +104,13 @@ module cache_mshr #(
   // Allocate interface
   // Finalize interface
   // Entry metadata registers
-  logic entry_valid [MSHR_SIZE-1:0];
-  logic [CS_LINE_ADDR_WIDTH-1:0] entry_addr [MSHR_SIZE-1:0];
-  logic entry_write [MSHR_SIZE-1:0];
-  logic entry_has_next [MSHR_SIZE-1:0];
-  logic [MSHR_ADDR_WIDTH-1:0] entry_next_idx [MSHR_SIZE-1:0];
+  logic [MSHR_SIZE-1:0] entry_valid;
+  logic [MSHR_SIZE-1:0] [CS_LINE_ADDR_WIDTH-1:0] entry_addr;
+  logic [MSHR_SIZE-1:0] entry_write;
+  logic [MSHR_SIZE-1:0] entry_has_next;
+  logic [MSHR_SIZE-1:0] [MSHR_ADDR_WIDTH-1:0] entry_next_idx;
   // Data RAM
-  logic [DATA_WIDTH-1:0] data_mem [MSHR_SIZE-1:0];
+  logic [MSHR_SIZE-1:0] [DATA_WIDTH-1:0] data_mem;
   // Registered outputs for allocate
   logic [MSHR_ADDR_WIDTH-1:0] allocate_id_r;
   logic allocate_pending_r;
@@ -50,12 +118,41 @@ module cache_mshr #(
   // Dequeue state registers
   logic dq_valid_r;
   logic [MSHR_ADDR_WIDTH-1:0] dq_idx_r;
-  // Wires for priority encoder
+  // Wires for the free-slot priority encoder
   logic [MSHR_ADDR_WIDTH-1:0] alloc_idx;
   logic full_flag;
+  // Wires for the address-CAM lookup chain
+  logic [MSHR_SIZE-1:0] addr_search_mask;
+  logic addr_search_any;
+  // unused; required to bind cam port
+  logic [MSHR_ADDR_WIDTH-1:0] addr_search_first;
+  // unused; required to bind cam port
+  logic [MSHR_SIZE-1:0] has_next_mask;
+  logic [MSHR_SIZE-1:0] tail_mask;
   logic [MSHR_ADDR_WIDTH-1:0] prev_idx;
   logic prev_all_zeros;
-  // Priority encoder: find first free slot (LSB-first)
+  // Address CAM: maintains (valid, addr) per slot. Port 1 = finalize,
+  // port 2 = allocate (wins on same-idx conflict, matching the original
+  // last-assignment-wins seq semantics).
+  Mshr_Addr_Cam #(.DEPTH(MSHR_SIZE), .KEY_W(CS_LINE_ADDR_WIDTH)) addr_cam (
+    .clk(clk),
+    .rst(reset),
+    .write_valid(finalize_valid),
+    .write_idx(finalize_id),
+    .write_key(CS_LINE_ADDR_WIDTH'($unsigned(0))),
+    .write_set(1'b0),
+    .write2_valid(allocate_valid & ~full_flag),
+    .write2_idx(alloc_idx),
+    .write2_key(allocate_addr),
+    .write2_set(1'b1),
+    .search_key(allocate_addr),
+    .search_mask(addr_search_mask),
+    .search_any(addr_search_any),
+    .search_first(addr_search_first)
+  );
+  // ignored on clear; explicit width to silence iverilog literal-prune warning
+  // Free-slot priority encoder: find first ~entry_valid (LSB-first).
+  // Not a CAM lookup (no key matching), so still hand-rolled.
   always_comb begin
     alloc_idx = 0;
     full_flag = 1'b1;
@@ -68,13 +165,27 @@ module cache_mshr #(
       end
     end
   end
-  // Priority encoder: find first matching entry with no next (LSB-first)
+  // Pack entry_has_next into a UInt mask so we can AND it with the
+  // CAM's search_mask. The tail of a chain is an entry that matches
+  // the address AND has no next pointer.
+  always_comb begin
+    has_next_mask = 0;
+    for (int i = 0; i <= MSHR_SIZE - 1; i++) begin
+      if (entry_has_next[i]) begin
+        has_next_mask = has_next_mask | MSHR_SIZE'($unsigned(1)) << i;
+      end
+    end
+  end
+  logic [MSHR_SIZE-1:0] tail_mask_w;
+  assign tail_mask_w = addr_search_mask & ~has_next_mask;
+  assign tail_mask = tail_mask_w;
+  // Priority-encode tail_mask to get prev_idx (LSB-first).
   always_comb begin
     prev_idx = 0;
     prev_all_zeros = 1'b1;
     for (int i = 0; i <= MSHR_SIZE - 1; i++) begin
       if (~prev_all_zeros == 1'b0) begin
-        if (entry_valid[i] & entry_addr[i] == allocate_addr & ~entry_has_next[i]) begin
+        if (tail_mask >> i & 1) begin
           prev_idx = MSHR_ADDR_WIDTH'(i);
           prev_all_zeros = 1'b0;
         end
@@ -161,6 +272,17 @@ module cache_mshr #(
   assign dequeue_rw = entry_write[dq_idx_r];
   assign dequeue_data = data_mem[dq_idx_r];
   assign dequeue_id = dq_idx_r;
+  // synopsys translate_off
+  // Auto-generated safety assertions (bounds / divide-by-zero)
+  _auto_bound_vec_0: assert property (@(posedge clk) disable iff (reset) (dq_idx_r) < (MSHR_SIZE))
+    else $fatal(1, "BOUNDS VIOLATION: cache_mshr._auto_bound_vec_0");
+  _auto_bound_vec_1: assert property (@(posedge clk) disable iff (reset) (finalize_id) < (MSHR_SIZE))
+    else $fatal(1, "BOUNDS VIOLATION: cache_mshr._auto_bound_vec_1");
+  _auto_bound_vec_2: assert property (@(posedge clk) disable iff (reset) (alloc_idx) < (MSHR_SIZE))
+    else $fatal(1, "BOUNDS VIOLATION: cache_mshr._auto_bound_vec_2");
+  _auto_bound_vec_3: assert property (@(posedge clk) disable iff (reset) (prev_idx) < (MSHR_SIZE))
+    else $fatal(1, "BOUNDS VIOLATION: cache_mshr._auto_bound_vec_3");
+  // synopsys translate_on
 
 endmodule
 

--- a/tests/cvdp/test_mshr_compile.py
+++ b/tests/cvdp/test_mshr_compile.py
@@ -6,7 +6,7 @@ sv_file = os.path.join(os.path.dirname(__file__), 'cache_mshr.sv')
 
 # Test 1: compile with default params
 r = subprocess.run(
-    ['iverilog', '-o', '/tmp/mshr_test.vvp', '-s', 'cache_mshr', '-g2012', sv_file],
+    ['iverilog', '-o', '/tmp/mshr_test.vvp', '-s', 'cache_mshr', '-g2012', '-gsupported-assertions', sv_file],
     capture_output=True, text=True, timeout=30
 )
 print(f"Compile (default params): rc={r.returncode}")
@@ -15,7 +15,7 @@ if r.stderr: print("STDERR:", r.stderr[:1000])
 
 # Test 2: compile with MSHR_SIZE=4
 r2 = subprocess.run(
-    ['iverilog', '-o', '/tmp/mshr_test2.vvp', '-s', 'cache_mshr', '-g2012',
+    ['iverilog', '-o', '/tmp/mshr_test2.vvp', '-s', 'cache_mshr', '-g2012', '-gsupported-assertions',
      '-Pcache_mshr.MSHR_SIZE=4', sv_file],
     capture_output=True, text=True, timeout=30
 )
@@ -25,7 +25,7 @@ if r2.stderr: print("STDERR:", r2.stderr[:1000])
 
 # Test 3: compile with MSHR_SIZE=28
 r3 = subprocess.run(
-    ['iverilog', '-o', '/tmp/mshr_test3.vvp', '-s', 'cache_mshr', '-g2012',
+    ['iverilog', '-o', '/tmp/mshr_test3.vvp', '-s', 'cache_mshr', '-g2012', '-gsupported-assertions',
      '-Pcache_mshr.MSHR_SIZE=28', sv_file],
     capture_output=True, text=True, timeout=30
 )

--- a/tests/cvdp/test_mshr_sim.py
+++ b/tests/cvdp/test_mshr_sim.py
@@ -167,6 +167,7 @@ all_pass = True
 for mshr_size in [4, 8, 12, 16, 20, 24, 28, 32]:
     r = subprocess.run(
         ['iverilog', '-o', os.path.join(workdir, 'sim.vvp'), '-s', 'tb', '-g2012',
+         '-gsupported-assertions',
          f'-Ptb.MSHR_SIZE={mshr_size}', sv_file, tb_file],
         capture_output=True, text=True, timeout=30
     )


### PR DESCRIPTION
## Summary
Replaces the hand-rolled \`prev_idx\` priority-encoder loop in [tests/cvdp/cache_mshr.arch](tests/cvdp/cache_mshr.arch) with a \`Mshr_Addr_Cam\` instance using the dual-write port from cam v2 (#124). Closes the cam rollout.

## Why this needed cam v2
The address-CAM lookup ("find the tail of the chain matching \`allocate_addr\`") was the canonical motivating example for the cam construct. v1 single-write couldn't fit because cache_mshr drives both finalize (clear) and allocate (insert) on the same edge in [test_mshr_sim.py Test 4](tests/cvdp/test_mshr_sim.py) (simultaneous allocate + finalize). v2's optional second write port closes the gap.

## Wiring
- Port 1 = finalize, Port 2 = allocate → port 2 wins on same-index conflict, exactly matching the original "allocate wins on conflict" \`seq\` semantics (last-assignment-wins).
- The post-filter (\`~entry_has_next\`) is applied externally: \`tail_mask = addr_search_mask & ~has_next_mask\`, then priority-encoded → \`prev_idx\`.
- cache_mshr keeps its own \`entry_valid\` / \`entry_addr\` (still used by the alloc_idx free-slot encoder and the dequeue_addr lookup); the cam mirrors them via the same write_valid signals, staying in sync each cycle.
- The free-slot priority encoder for \`alloc_idx\` is unchanged (it's a "find first ~entry_valid", not a content match — out of scope for cam v1).

## Resolve fix (small)
[src/resolve.rs](src/resolve.rs): cam declarations are now registered in \`table.globals\` as \`Symbol::Cam(CamInfo { name })\` so that \`inst addr_cam: Mshr_Addr_Cam\` resolves. Phase A had left this as a no-op stub; not exercised until now.

## Test gates (all pass)
- \`tests/cvdp/test_mshr_compile.py\` → rc=0 for default + \`MSHR_SIZE\` in {4, 28}
- \`tests/cvdp/test_mshr_sim.py\` → **ALL PASS** for \`MSHR_SIZE\` in {4, 8, 12, 16, 20, 24, 28, 32}, including Test 4 simultaneous allocate+finalize
- \`verilator --lint-only -Wall\` on the regenerated [tests/cvdp/cache_mshr.sv](tests/cvdp/cache_mshr.sv): clean modulo cosmetic width/unused-signal warnings

The test scripts now pass \`-gsupported-assertions\` to iverilog so the auto-emitted SVA bounds checks (introduced after the previous \`cache_mshr.sv\` was committed) parse cleanly. \`test_mshr_*.py\` are ours (per memory \`feedback_run_cvdp_ours.md\`), so this is a normal update.

## Closes the cam rollout
- Phases A-C: #122 (merged)
- Phase E: #123 (merged)
- Cam v2 dual-write: #124 (merged)
- **Phase D: this PR**

🤖 Generated with [Claude Code](https://claude.com/claude-code)