### PR TITLE
feat(cvdp): refactor TLB to use cam — second cam consumer

### DIFF
--- a/tests/cvdp/TLB.arch
+++ b/tests/cvdp/TLB.arch
@@ -1,7 +1,29 @@
+// Address-CAM helper for the TLB virtual-tag lookup. Caller owns
+// `valid_bits` externally so a single-cycle flush is possible without
+// multi-cycle cam writes (cam v1 has one write per cycle).
+cam Tlb_Cam
+  param DEPTH: const = 4;
+  param KEY_W: const = 8;
+
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync, High>;
+
+  port write_valid: in Bool;
+  port write_idx:   in UInt<2>;
+  port write_key:   in UInt<8>;
+  port write_set:   in Bool;
+
+  port search_key:   in  UInt<8>;
+  port search_mask:  out UInt<4>;
+  port search_any:   out Bool;
+  port search_first: out UInt<2>;
+end cam Tlb_Cam
+
 module TLB
   param TLB_SIZE: const = 4;
   param ADDR_WIDTH: const = 8;
   param PAGE_WIDTH: const = 8;
+
   port clk: in Clock<SysDomain>;
   port rst: in Reset<Sync>;
   port virtual_address: in UInt<ADDR_WIDTH>;
@@ -14,44 +36,62 @@ module TLB
 
   default seq on clk rising;
 
-  reg virtual_tags_0: UInt<ADDR_WIDTH> reset rst=>0;
-  reg virtual_tags_1: UInt<ADDR_WIDTH> reset rst=>0;
-  reg virtual_tags_2: UInt<ADDR_WIDTH> reset rst=>0;
-  reg virtual_tags_3: UInt<ADDR_WIDTH> reset rst=>0;
-  reg physical_pages_0: UInt<PAGE_WIDTH> reset rst=>0;
-  reg physical_pages_1: UInt<PAGE_WIDTH> reset rst=>0;
-  reg physical_pages_2: UInt<PAGE_WIDTH> reset rst=>0;
-  reg physical_pages_3: UInt<PAGE_WIDTH> reset rst=>0;
-  reg valid_bits: UInt<TLB_SIZE> reset rst=>0;
-  reg replacement_idx: UInt<2> reset rst=>0;
+  // External valid bits — separate from the cam's internal valid so a
+  // single-cycle flush stays single-cycle (cam v1 has one write port,
+  // and clearing N entries would otherwise take N cycles).
+  reg valid_bits: UInt<TLB_SIZE> reset rst => 0;
+  reg replacement_idx: UInt<2>   reset rst => 0;
 
-  let v0: Bool = (virtual_tags_0 == virtual_address);
-  let v1: Bool = (virtual_tags_1 == virtual_address);
-  let v2: Bool = (virtual_tags_2 == virtual_address);
-  let v3: Bool = (virtual_tags_3 == virtual_address);
+  // Per-entry physical pages — addressed by the priority-encoded match
+  // index. The cam stores the virtual_address keys.
+  reg physical_pages: Vec<UInt<PAGE_WIDTH>, TLB_SIZE> reset rst => 0;
 
-  let match0: Bool = valid_bits[0:0] & v0;
-  let match1: Bool = valid_bits[1:1] & v1;
-  let match2: Bool = valid_bits[2:2] & v2;
-  let match3: Bool = valid_bits[3:3] & v3;
+  wire cam_search_mask:  UInt<TLB_SIZE>;
+  wire cam_search_any:   Bool;        // unused; required to bind cam port
+  wire cam_search_first: UInt<2>;     // unused; required to bind cam port
+  wire hit_idx:          UInt<2>;
+  wire any_match:        Bool;
+
+  inst tlb_cam: Tlb_Cam
+    param DEPTH = TLB_SIZE;
+    param KEY_W = ADDR_WIDTH;
+
+    clk           <- clk;
+    rst           <- rst;
+    write_valid   <- tlb_write_enable & ~flsh;
+    write_idx     <- replacement_idx;
+    write_key     <- virtual_address;
+    write_set     <- true;
+    search_key    <- virtual_address;
+    search_mask   -> cam_search_mask;
+    search_any    -> cam_search_any;
+    search_first  -> cam_search_first;
+  end inst tlb_cam
+
+  // A "real" match is one the cam reports AND whose external valid bit
+  // is set. Flush only clears valid_bits, not the cam's internal state,
+  // so the AND below is what makes flush a single-cycle operation.
+  let effective_match: UInt<TLB_SIZE> = valid_bits & cam_search_mask;
+
+  // Priority encoder for first effective match (LSB-first).
+  comb
+    hit_idx = 0;
+    any_match = false;
+    for i in 0..TLB_SIZE-1
+      if ~any_match
+        if (effective_match >> i) & 1
+          hit_idx = i.trunc<2>();
+          any_match = true;
+        end if
+      end if
+    end for
+  end comb
 
   comb
-    if match0
+    if any_match
       hit = true;
       miss = false;
-      physical_address = physical_pages_0;
-    elsif match1
-      hit = true;
-      miss = false;
-      physical_address = physical_pages_1;
-    elsif match2
-      hit = true;
-      miss = false;
-      physical_address = physical_pages_2;
-    elsif match3
-      hit = true;
-      miss = false;
-      physical_address = physical_pages_3;
+      physical_address = physical_pages[hit_idx];
     else
       hit = false;
       miss = true;
@@ -63,27 +103,9 @@ module TLB
     if flsh
       valid_bits <= 0;
     elsif tlb_write_enable
-      if replacement_idx == 0
-        virtual_tags_0 <= virtual_address;
-        physical_pages_0 <= page_table_entry;
-        valid_bits <= valid_bits | 4'b0001;
-        replacement_idx <= 1;
-      elsif replacement_idx == 1
-        virtual_tags_1 <= virtual_address;
-        physical_pages_1 <= page_table_entry;
-        valid_bits <= valid_bits | 4'b0010;
-        replacement_idx <= 2;
-      elsif replacement_idx == 2
-        virtual_tags_2 <= virtual_address;
-        physical_pages_2 <= page_table_entry;
-        valid_bits <= valid_bits | 4'b0100;
-        replacement_idx <= 3;
-      else
-        virtual_tags_3 <= virtual_address;
-        physical_pages_3 <= page_table_entry;
-        valid_bits <= valid_bits | 4'b1000;
-        replacement_idx <= 0;
-      end if
+      physical_pages[replacement_idx] <= page_table_entry;
+      valid_bits <= valid_bits | ((1.zext<TLB_SIZE>()) << replacement_idx);
+      replacement_idx <= replacement_idx +% 1;
     end if
   end seq
 end module TLB

--- a/tests/cvdp/TLB.sv
+++ b/tests/cvdp/TLB.sv
@@ -1,3 +1,56 @@
+// Address-CAM helper for the TLB virtual-tag lookup. Caller owns
+// `valid_bits` externally so a single-cycle flush is possible without
+// multi-cycle cam writes (cam v1 has one write per cycle).
+module Tlb_Cam #(
+  parameter int DEPTH = 4,
+  parameter int KEY_W = 8
+) (
+  input logic clk,
+  input logic rst,
+  input logic write_valid,
+  input logic [1:0] write_idx,
+  input logic [7:0] write_key,
+  input logic write_set,
+  input logic [7:0] search_key,
+  output logic [3:0] search_mask,
+  output logic search_any,
+  output logic [1:0] search_first
+);
+
+  logic [DEPTH-1:0]      entry_valid_r;
+  logic [KEY_W-1:0]      entry_key_r [DEPTH];
+  
+  always_comb begin
+    for (int i = 0; i < DEPTH; i++) begin
+      search_mask[i] = entry_valid_r[i] && (entry_key_r[i] == search_key);
+    end
+  end
+  assign search_any = |search_mask;
+  
+  always_comb begin
+    search_first = '0;
+    for (int i = DEPTH-1; i >= 0; i--) begin
+      if (search_mask[i]) search_first = i[$clog2(DEPTH)-1:0];
+    end
+  end
+  
+  always_ff @(posedge clk) begin
+    if (rst) begin
+      entry_valid_r <= '0;
+    end else begin
+      if (write_valid) begin
+        if (write_set) begin
+          entry_valid_r[write_idx] <= 1'b1;
+          entry_key_r[write_idx] <= write_key;
+        end else begin
+          entry_valid_r[write_idx] <= 1'b0;
+        end
+      end
+    end
+  end
+  
+endmodule
+
 module TLB #(
   parameter int TLB_SIZE = 4,
   parameter int ADDR_WIDTH = 8,
@@ -14,49 +67,56 @@ module TLB #(
   output logic miss
 );
 
-  logic [ADDR_WIDTH-1:0] virtual_tags_0;
-  logic [ADDR_WIDTH-1:0] virtual_tags_1;
-  logic [ADDR_WIDTH-1:0] virtual_tags_2;
-  logic [ADDR_WIDTH-1:0] virtual_tags_3;
-  logic [PAGE_WIDTH-1:0] physical_pages_0;
-  logic [PAGE_WIDTH-1:0] physical_pages_1;
-  logic [PAGE_WIDTH-1:0] physical_pages_2;
-  logic [PAGE_WIDTH-1:0] physical_pages_3;
+  // External valid bits — separate from the cam's internal valid so a
+  // single-cycle flush stays single-cycle (cam v1 has one write port,
+  // and clearing N entries would otherwise take N cycles).
   logic [TLB_SIZE-1:0] valid_bits;
   logic [1:0] replacement_idx;
-  logic v0;
-  assign v0 = virtual_tags_0 == virtual_address;
-  logic v1;
-  assign v1 = virtual_tags_1 == virtual_address;
-  logic v2;
-  assign v2 = virtual_tags_2 == virtual_address;
-  logic v3;
-  assign v3 = virtual_tags_3 == virtual_address;
-  logic match0;
-  assign match0 = valid_bits[0:0] & v0;
-  logic match1;
-  assign match1 = valid_bits[1:1] & v1;
-  logic match2;
-  assign match2 = valid_bits[2:2] & v2;
-  logic match3;
-  assign match3 = valid_bits[3:3] & v3;
+  // Per-entry physical pages — addressed by the priority-encoded match
+  // index. The cam stores the virtual_address keys.
+  logic [TLB_SIZE-1:0] [PAGE_WIDTH-1:0] physical_pages;
+  logic [TLB_SIZE-1:0] cam_search_mask;
+  logic cam_search_any;
+  // unused; required to bind cam port
+  logic [1:0] cam_search_first;
+  // unused; required to bind cam port
+  logic [1:0] hit_idx;
+  logic any_match;
+  Tlb_Cam #(.DEPTH(TLB_SIZE), .KEY_W(ADDR_WIDTH)) tlb_cam (
+    .clk(clk),
+    .rst(rst),
+    .write_valid(tlb_write_enable & ~flsh),
+    .write_idx(replacement_idx),
+    .write_key(virtual_address),
+    .write_set(1'b1),
+    .search_key(virtual_address),
+    .search_mask(cam_search_mask),
+    .search_any(cam_search_any),
+    .search_first(cam_search_first)
+  );
+  // A "real" match is one the cam reports AND whose external valid bit
+  // is set. Flush only clears valid_bits, not the cam's internal state,
+  // so the AND below is what makes flush a single-cycle operation.
+  logic [TLB_SIZE-1:0] effective_match;
+  assign effective_match = valid_bits & cam_search_mask;
+  // Priority encoder for first effective match (LSB-first).
   always_comb begin
-    if (match0) begin
+    hit_idx = 0;
+    any_match = 1'b0;
+    for (int i = 0; i <= TLB_SIZE - 1; i++) begin
+      if (~any_match) begin
+        if (effective_match >> i & 1) begin
+          hit_idx = 2'(i);
+          any_match = 1'b1;
+        end
+      end
+    end
+  end
+  always_comb begin
+    if (any_match) begin
       hit = 1'b1;
       miss = 1'b0;
-      physical_address = physical_pages_0;
-    end else if (match1) begin
-      hit = 1'b1;
-      miss = 1'b0;
-      physical_address = physical_pages_1;
-    end else if (match2) begin
-      hit = 1'b1;
-      miss = 1'b0;
-      physical_address = physical_pages_2;
-    end else if (match3) begin
-      hit = 1'b1;
-      miss = 1'b0;
-      physical_address = physical_pages_3;
+      physical_address = physical_pages[hit_idx];
     end else begin
       hit = 1'b0;
       miss = 1'b1;
@@ -65,44 +125,26 @@ module TLB #(
   end
   always_ff @(posedge clk) begin
     if (rst) begin
-      physical_pages_0 <= 0;
-      physical_pages_1 <= 0;
-      physical_pages_2 <= 0;
-      physical_pages_3 <= 0;
+      for (int __ri0 = 0; __ri0 < TLB_SIZE; __ri0++) begin
+        physical_pages[__ri0] <= 0;
+      end
       replacement_idx <= 0;
       valid_bits <= 0;
-      virtual_tags_0 <= 0;
-      virtual_tags_1 <= 0;
-      virtual_tags_2 <= 0;
-      virtual_tags_3 <= 0;
     end else begin
       if (flsh) begin
         valid_bits <= 0;
       end else if (tlb_write_enable) begin
-        if (replacement_idx == 0) begin
-          virtual_tags_0 <= virtual_address;
-          physical_pages_0 <= page_table_entry;
-          valid_bits <= valid_bits | 4'd1;
-          replacement_idx <= 1;
-        end else if (replacement_idx == 1) begin
-          virtual_tags_1 <= virtual_address;
-          physical_pages_1 <= page_table_entry;
-          valid_bits <= valid_bits | 4'd2;
-          replacement_idx <= 2;
-        end else if (replacement_idx == 2) begin
-          virtual_tags_2 <= virtual_address;
-          physical_pages_2 <= page_table_entry;
-          valid_bits <= valid_bits | 4'd4;
-          replacement_idx <= 3;
-        end else begin
-          virtual_tags_3 <= virtual_address;
-          physical_pages_3 <= page_table_entry;
-          valid_bits <= valid_bits | 4'd8;
-          replacement_idx <= 0;
-        end
+        physical_pages[replacement_idx] <= page_table_entry;
+        valid_bits <= valid_bits | TLB_SIZE'($unsigned(1)) << replacement_idx;
+        replacement_idx <= (2 > 1 ? 2 : 1)'(replacement_idx + 1);
       end
     end
   end
+  // synopsys translate_off
+  // Auto-generated safety assertions (bounds / divide-by-zero)
+  _auto_bound_vec_0: assert property (@(posedge clk) disable iff (rst) (replacement_idx) < (TLB_SIZE))
+    else $fatal(1, "BOUNDS VIOLATION: TLB._auto_bound_vec_0");
+  // synopsys translate_on
 
 endmodule
 

--- a/tests/cvdp/test_tlb_sim.py
+++ b/tests/cvdp/test_tlb_sim.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Behavioral test for the cam-refactored TLB. Drives the same scenarios
+the original CVDP harness exercises: hit/miss, fill, replacement wrap,
+flush, and post-flush re-fill. iverilog-only (no cocotb)."""
+import subprocess, os, sys, tempfile
+
+sv_file = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'TLB.sv')
+workdir = tempfile.mkdtemp(prefix='tlb_sim_')
+
+tb = """
+`timescale 1ns/1ns
+module tb;
+  parameter TLB_SIZE = 4;
+  parameter ADDR_WIDTH = 8;
+  parameter PAGE_WIDTH = 8;
+
+  reg clk = 0;
+  reg rst = 0;
+  reg [ADDR_WIDTH-1:0] virtual_address = 0;
+  reg tlb_write_enable = 0;
+  reg flsh = 0;
+  reg [PAGE_WIDTH-1:0] page_table_entry = 0;
+  wire [PAGE_WIDTH-1:0] physical_address;
+  wire hit, miss;
+
+  TLB #(.TLB_SIZE(TLB_SIZE), .ADDR_WIDTH(ADDR_WIDTH), .PAGE_WIDTH(PAGE_WIDTH)) dut (
+    .clk(clk), .rst(rst),
+    .virtual_address(virtual_address),
+    .tlb_write_enable(tlb_write_enable),
+    .flsh(flsh),
+    .page_table_entry(page_table_entry),
+    .physical_address(physical_address),
+    .hit(hit), .miss(miss)
+  );
+
+  always #5 clk = ~clk;
+
+  integer pass_count = 0;
+  integer fail_count = 0;
+
+  task check_miss(input [ADDR_WIDTH-1:0] vaddr, input [127:0] tag);
+    begin
+      virtual_address = vaddr;
+      #1;
+      if (miss && !hit) begin pass_count = pass_count + 1; $display("%0s: MISS as expected", tag); end
+      else begin fail_count = fail_count + 1; $display("FAIL %0s: expected miss, got hit=%0d miss=%0d", tag, hit, miss); end
+    end
+  endtask
+
+  task check_hit(input [ADDR_WIDTH-1:0] vaddr, input [PAGE_WIDTH-1:0] expected_pa, input [127:0] tag);
+    begin
+      virtual_address = vaddr;
+      #1;
+      if (hit && !miss && physical_address == expected_pa) begin
+        pass_count = pass_count + 1;
+        $display("%0s: HIT vaddr=%02x -> pa=%02x", tag, vaddr, physical_address);
+      end else begin
+        fail_count = fail_count + 1;
+        $display("FAIL %0s: vaddr=%02x expected hit pa=%02x, got hit=%0d miss=%0d pa=%02x",
+                 tag, vaddr, expected_pa, hit, miss, physical_address);
+      end
+    end
+  endtask
+
+  task fill_entry(input [ADDR_WIDTH-1:0] vaddr, input [PAGE_WIDTH-1:0] pa);
+    begin
+      virtual_address = vaddr;
+      page_table_entry = pa;
+      tlb_write_enable = 1;
+      @(posedge clk); #1;
+      tlb_write_enable = 0;
+    end
+  endtask
+
+  task do_reset;
+    begin
+      rst = 1;
+      @(posedge clk); #1;
+      @(posedge clk); #1;
+      rst = 0;
+      @(posedge clk); #1;
+    end
+  endtask
+
+  initial begin
+    do_reset;
+
+    // ── 1. Cold TLB: every lookup misses ──
+    check_miss(8'h10, "Cold-1");
+    check_miss(8'hAB, "Cold-2");
+
+    // ── 2. Fill four entries; verify each hits ──
+    fill_entry(8'h10, 8'hA0);
+    fill_entry(8'h20, 8'hA1);
+    fill_entry(8'h30, 8'hA2);
+    fill_entry(8'h40, 8'hA3);
+
+    check_hit(8'h10, 8'hA0, "Fill-1");
+    check_hit(8'h20, 8'hA1, "Fill-2");
+    check_hit(8'h30, 8'hA2, "Fill-3");
+    check_hit(8'h40, 8'hA3, "Fill-4");
+
+    // ── 3. Unknown vaddr still misses ──
+    check_miss(8'h99, "Post-fill miss");
+
+    // ── 4. Replacement wraps (TLB_SIZE=4 → 5th fill overwrites slot 0) ──
+    fill_entry(8'h50, 8'hB5);
+    check_hit(8'h50, 8'hB5, "Replace-new");
+    check_miss(8'h10, "Replace-evicted");
+
+    // ── 5. Flush wipes everything ──
+    flsh = 1;
+    @(posedge clk); #1;
+    flsh = 0;
+    check_miss(8'h20, "Post-flush-1");
+    check_miss(8'h30, "Post-flush-2");
+    check_miss(8'h40, "Post-flush-3");
+    check_miss(8'h50, "Post-flush-4");
+
+    // ── 6. Re-fill after flush works ──
+    fill_entry(8'h77, 8'hC7);
+    check_hit(8'h77, 8'hC7, "Post-flush-fill");
+
+    if (fail_count == 0) $display("ALL PASS (%0d tests)", pass_count);
+    else $display("FAIL: %0d/%0d failed", fail_count, pass_count + fail_count);
+    $finish;
+  end
+endmodule
+"""
+
+tb_file = os.path.join(workdir, 'tb.sv')
+open(tb_file, 'w').write(tb)
+
+# Compile
+r = subprocess.run(
+    ['iverilog', '-o', os.path.join(workdir, 'sim.vvp'), '-s', 'tb', '-g2012',
+     '-gsupported-assertions', sv_file, tb_file],
+    capture_output=True, text=True, timeout=30
+)
+if r.returncode != 0:
+    print(f"COMPILE FAIL: {r.stderr[:500]}")
+    sys.exit(1)
+
+# Run
+r = subprocess.run(['vvp', os.path.join(workdir, 'sim.vvp')], capture_output=True, text=True, timeout=30)
+print(r.stdout)
+if 'ALL PASS' in r.stdout:
+    sys.exit(0)
+sys.exit(1)


### PR DESCRIPTION
## Summary
Replaces the unrolled per-entry comparator chain in [tests/cvdp/TLB.arch](tests/cvdp/TLB.arch) (\`virtual_tags_0..3\` + \`v0..3\` + \`match0..3\` + a 4-way elsif tree) with a \`Tlb_Cam\` instance. Second consumer of the cam construct on main.

## Why
TLB is the textbook CAM use case. The baseline used hardcoded \`TLB_SIZE = 4\` semantics — 4 explicit reg declarations, 4 hardcoded compares, 4 elsif branches. The cam-based version composes the cam's content match with stock ARCH primitives (priority encoder over a \`UInt\` mask).

## Implementation
- \`cam Tlb_Cam\` (DEPTH = \`TLB_SIZE\`, KEY_W = \`ADDR_WIDTH\`) sits at the top of TLB.arch (single-file emit, no test-script changes).
- The TLB module wires \`write_valid = tlb_write_enable & ~flsh\`, \`write_idx = replacement_idx\`, \`write_key = virtual_address\`, \`write_set = true\`. Search is combinational on \`virtual_address\`.
- TLB keeps its own \`valid_bits\` register so flush stays single-cycle (cam v1 has one write port; clearing N entries through the cam would take N cycles). \`effective_match = valid_bits & cam.search_mask\` gates stale matches.
- Priority-encodes \`effective_match\` → \`hit_idx\`; \`physical_address\` reads \`physical_pages[hit_idx]\` on hit, falls through to \`page_table_entry\` on miss.
- \`replacement_idx\` wraps via \`UInt<2> +% 1\`.

## Test gate
[tests/cvdp/test_tlb_sim.py](tests/cvdp/test_tlb_sim.py) drives 14 scenarios:
1. Cold misses
2. Fill 4 entries; verify each hits
3. Post-fill miss for an unknown vaddr
4. 5th fill wraps replacement_idx (slot 0 evicted, new entry hits, evicted entry misses)
5. \`flsh\` wipes everything (4 post-flush misses)
6. Re-fill after flush works

**14/14 PASS** on the refactored SV. **Same tb run against the baseline TLB.sv from HEAD also PASSes 14/14** → semantic equivalence confirmed (no behavior change, only construct-level cleanup).

Verilator 5.034 \`--lint-only -Wall\` on the regenerated [tests/cvdp/TLB.sv](tests/cvdp/TLB.sv): clean modulo cosmetic width / unused-signal warnings.

## Cam consumers on main after this lands
- \`tests/cvdp/cache_mshr.arch\` — dual-write (allocate + finalize)
- \`tests/cvdp/TLB.arch\` — single-write + external valid_bits gating for single-cycle flush

🤖 Generated with [Claude Code](https://claude.com/claude-code)