### PR TITLE
fix(sim_codegen): resolve param idents in Vec sizes; add mac_table cam demo

### DIFF
--- a/src/sim_codegen/mod.rs
+++ b/src/sim_codegen/mod.rs
@@ -265,7 +265,7 @@ impl<'a> SimCodegen<'a> {
         let vec_port_infos: Vec<(String, String, u64, bool)> = m.ports.iter()
             .filter(|p| p.bus_info.is_none())
             .filter_map(|p| {
-                if let Some((elem_ty, count_str)) = vec_array_info(&p.ty) {
+                if let Some((elem_ty, count_str)) = vec_array_info_with_params(&p.ty, &m.params) {
                     let count: u64 = count_str.parse().unwrap_or(0);
                     Some((p.name.name.clone(), elem_ty, count, p.direction == Direction::In))
                 } else {
@@ -1213,13 +1213,82 @@ fn vec_array_info(ty: &TypeExpr) -> Option<(String, String)> {
 }
 
 /// Evaluate a constant expression to a u64, resolving basic arithmetic.
+/// Backward-compatible wrapper that doesn't resolve param identifiers —
+/// see [`eval_const_expr_with_params`] for the version that does. Use
+/// the param-aware version anywhere a Vec / array length needs to fold
+/// across `param N: const = …;` references (otherwise the result is 0
+/// and downstream code emits zero-sized C++ arrays — see the regression
+/// fixed in PR #cam-zero-array).
 fn eval_const_expr(expr: &Expr) -> u64 {
+    eval_const_expr_with_params(expr, &[])
+}
+
+/// Param-aware constant evaluator. Resolves bare identifiers against
+/// `params` (regular + local) by recursing on each param's `default`
+/// expression. Handles literals, `$clog2(x)`, unary `-`/`~`, and
+/// binary `+`, `-`, `*`, `/`, `%`, `<<`, `>>`, `&`, `|`, `^`. Returns 0
+/// for anything it can't fold (e.g. non-literal port reads), matching
+/// the conservative behavior of the legacy single-arg version.
+fn eval_const_expr_with_params(expr: &Expr, params: &[ParamDecl]) -> u64 {
     match &expr.kind {
         ExprKind::Literal(LitKind::Dec(v)) => *v,
         ExprKind::Literal(LitKind::Hex(v)) => *v,
         ExprKind::Literal(LitKind::Bin(v)) => *v,
         ExprKind::Literal(LitKind::Sized(_, v)) => *v,
+        ExprKind::Ident(name) => {
+            if let Some(p) = params.iter().find(|p| p.name.name == *name) {
+                if let Some(d) = &p.default {
+                    return eval_const_expr_with_params(d, params);
+                }
+            }
+            0
+        }
+        ExprKind::Clog2(a) => {
+            let v = eval_const_expr_with_params(a, params);
+            if v <= 1 { 0 } else { 64 - (v - 1).leading_zeros() as u64 }
+        }
+        ExprKind::Unary(op, a) => {
+            let v = eval_const_expr_with_params(a, params);
+            match op {
+                UnaryOp::Not => !v,
+                UnaryOp::Neg => v.wrapping_neg(),
+                _ => 0,
+            }
+        }
+        ExprKind::Binary(op, l, r) => {
+            let lv = eval_const_expr_with_params(l, params);
+            let rv = eval_const_expr_with_params(r, params);
+            match op {
+                BinOp::Add => lv.wrapping_add(rv),
+                BinOp::Sub => lv.wrapping_sub(rv),
+                BinOp::Mul => lv.wrapping_mul(rv),
+                BinOp::Div => if rv == 0 { 0 } else { lv / rv },
+                BinOp::Mod => if rv == 0 { 0 } else { lv % rv },
+                BinOp::Shl => lv.wrapping_shl(rv as u32),
+                BinOp::Shr => lv.wrapping_shr(rv as u32),
+                BinOp::BitAnd => lv & rv,
+                BinOp::BitOr => lv | rv,
+                BinOp::BitXor => lv ^ rv,
+                _ => 0,
+            }
+        }
         _ => 0,
+    }
+}
+
+/// Param-aware variant of [`vec_array_info`]. Uses
+/// [`eval_const_expr_with_params`] so that `Vec<_, NUM_ENTRIES>` style
+/// declarations whose count is a param identifier resolve to the
+/// param's literal default (rather than silently degrading to 0 and
+/// emitting a zero-sized C++ scratch array, which corrupts the
+/// surrounding stack on memcpy/index).
+fn vec_array_info_with_params(ty: &TypeExpr, params: &[ParamDecl]) -> Option<(String, String)> {
+    if let TypeExpr::Vec(elem, count_expr) = ty {
+        let elem_type = cpp_internal_type(elem);
+        let count_str = eval_const_expr_with_params(count_expr, params).to_string();
+        Some((elem_type, count_str))
+    } else {
+        None
     }
 }
 
@@ -3247,7 +3316,7 @@ impl<'a> SimCodegen<'a> {
         let vec_port_infos: Vec<VecPortInfo> = m.ports.iter()
             .filter(|p| p.bus_info.is_none())
             .filter_map(|p| {
-                if let Some((elem_ty, count_str)) = vec_array_info(&p.ty) {
+                if let Some((elem_ty, count_str)) = vec_array_info_with_params(&p.ty, &m.params) {
                     let count: u64 = count_str.parse().unwrap_or(0);
                     Some(VecPortInfo {
                         name: p.name.name.clone(),
@@ -3785,10 +3854,12 @@ impl<'a> SimCodegen<'a> {
             h.push_str(&format!("  bool _rising_{c};\n"));
         }
 
-        // Private reg fields
+        // Private reg fields. Use params-aware Vec sizing — bare
+        // `vec_array_info` returns 0 for params-as-length, which would
+        // emit `_arr[0]` and corrupt stack on memcpy / index.
         for item in &m.body {
             if let ModuleBodyItem::RegDecl(r) = item {
-                if let Some((elem_ty, count)) = vec_array_info(&r.ty) {
+                if let Some((elem_ty, count)) = vec_array_info_with_params(&r.ty, &m.params) {
                     h.push_str(&format!("  {elem_ty} _{}[{count}];\n", r.name.name));
                 } else {
                     let ty = cpp_internal_type(&r.ty);
@@ -3905,7 +3976,7 @@ impl<'a> SimCodegen<'a> {
                     h.push_str(&format!("  {ty} _let_{};\n", l.name.name));
                 }
                 ModuleBodyItem::WireDecl(w) => {
-                    if let Some((elem_ty, count)) = vec_array_info(&w.ty) {
+                    if let Some((elem_ty, count)) = vec_array_info_with_params(&w.ty, &m.params) {
                         h.push_str(&format!("  {elem_ty} _let_{}[{count}];\n", w.name.name));
                     } else {
                         let ty = cpp_internal_type(&w.ty);
@@ -4264,10 +4335,12 @@ impl<'a> SimCodegen<'a> {
             .collect();
 
         if !reg_blocks.is_empty() || !pipe_regs.is_empty() {
-            // Declare _n_ temporaries for all regs
+            // Declare _n_ temporaries for all regs. Use the param-aware
+            // helper so Vec<_, PARAM_NAME> resolves to the literal default
+            // (otherwise we emit `_n_arr[0]` and corrupt stack on memcpy).
             for rd in &reg_decls {
                 let n = &rd.name.name;
-                if let Some((elem_ty, count)) = vec_array_info(&rd.ty) {
+                if let Some((elem_ty, count)) = vec_array_info_with_params(&rd.ty, &m.params) {
                     cpp.push_str(&format!("  {elem_ty} _n_{n}[{count}]; memcpy(_n_{n}, _{n}, sizeof(_{n}));\n"));
                 } else {
                     let ty = cpp_internal_type(&rd.ty);

--- a/tests/mac_table.arch
+++ b/tests/mac_table.arch
@@ -1,0 +1,86 @@
+// Ethernet MAC address learning table — textbook CAM use case.
+//
+// On the lookup side: given a destination MAC, return the egress port
+// (or signal "miss" so the caller can broadcast). On the learn side:
+// when a frame arrives, the caller picks a slot and writes
+// (src_mac, ingress_port). v1 single-write port suffices because lookup
+// and learn never write the CAM in the same cycle (lookup is purely
+// combinational; only learn drives writes).
+//
+// Slot selection is the caller's job (round-robin in this demo). Real
+// switches add aging / LRU on top.
+
+cam Mac_Cam
+  param DEPTH: const = 8;
+  param KEY_W: const = 48;     // Ethernet MAC width
+
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync, High>;
+
+  port write_valid: in Bool;
+  port write_idx:   in UInt<3>;     // $clog2(DEPTH)
+  port write_key:   in UInt<48>;
+  port write_set:   in Bool;        // true=insert, false=clear (unused in demo)
+
+  port search_key:   in  UInt<48>;
+  port search_mask:  out UInt<8>;
+  port search_any:   out Bool;
+  port search_first: out UInt<3>;
+end cam Mac_Cam
+
+module mac_table
+  param NUM_ENTRIES: const = 8;
+  param NUM_PORTS:   const = 4;
+  local param IDX_W: const = 3;
+  local param PORT_W: const = 2;
+
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync, High>;
+
+  // Lookup interface (combinational)
+  port lookup_mac:  in  UInt<48>;
+  port lookup_hit:  out Bool;       // miss → caller floods/broadcasts
+  port lookup_port: out UInt<PORT_W>;
+
+  // Learn interface — writes a MAC→port binding into the slot
+  // chosen by the caller (round-robin, LRU, etc.; out of scope here).
+  port learn_valid: in Bool;
+  port learn_mac:   in UInt<48>;
+  port learn_port:  in UInt<PORT_W>;
+  port learn_idx:   in UInt<IDX_W>;
+
+  default seq on clk rising;
+
+  // Per-entry port number — addressed by the cam's first-match index.
+  // The CAM itself stores the MAC keys; this Vec stores the values.
+  reg port_table: Vec<UInt<PORT_W>, NUM_ENTRIES> reset rst => 0;
+
+  wire cam_search_mask:  UInt<NUM_ENTRIES>;     // unused; required to bind cam port
+  wire cam_search_any:   Bool;
+  wire cam_search_first: UInt<IDX_W>;
+
+  inst mac_cam: Mac_Cam
+    param DEPTH = NUM_ENTRIES;
+    param KEY_W = 48;
+
+    clk           <- clk;
+    rst           <- rst;
+    write_valid   <- learn_valid;
+    write_idx     <- learn_idx;
+    write_key     <- learn_mac;
+    write_set     <- true;
+    search_key    <- lookup_mac;
+    search_mask   -> cam_search_mask;
+    search_any    -> cam_search_any;
+    search_first  -> cam_search_first;
+  end inst mac_cam
+
+  let lookup_hit  = cam_search_any;
+  let lookup_port = port_table[cam_search_first];
+
+  seq
+    if learn_valid
+      port_table[learn_idx] <= learn_port;
+    end if
+  end seq
+end module mac_table

--- a/tests/mac_table.sv
+++ b/tests/mac_table.sv
@@ -1,0 +1,125 @@
+// Ethernet MAC address learning table — textbook CAM use case.
+//
+// On the lookup side: given a destination MAC, return the egress port
+// (or signal "miss" so the caller can broadcast). On the learn side:
+// when a frame arrives, the caller picks a slot and writes
+// (src_mac, ingress_port). v1 single-write port suffices because lookup
+// and learn never write the CAM in the same cycle (lookup is purely
+// combinational; only learn drives writes).
+//
+// Slot selection is the caller's job (round-robin in this demo). Real
+// switches add aging / LRU on top.
+module Mac_Cam #(
+  parameter int DEPTH = 8,
+  parameter int KEY_W = 48
+) (
+  input logic clk,
+  input logic rst,
+  input logic write_valid,
+  input logic [2:0] write_idx,
+  input logic [47:0] write_key,
+  input logic write_set,
+  input logic [47:0] search_key,
+  output logic [7:0] search_mask,
+  output logic search_any,
+  output logic [2:0] search_first
+);
+
+  logic [DEPTH-1:0]      entry_valid_r;
+  logic [KEY_W-1:0]      entry_key_r [DEPTH];
+  
+  always_comb begin
+    for (int i = 0; i < DEPTH; i++) begin
+      search_mask[i] = entry_valid_r[i] && (entry_key_r[i] == search_key);
+    end
+  end
+  assign search_any = |search_mask;
+  
+  always_comb begin
+    search_first = '0;
+    for (int i = DEPTH-1; i >= 0; i--) begin
+      if (search_mask[i]) search_first = i[$clog2(DEPTH)-1:0];
+    end
+  end
+  
+  always_ff @(posedge clk) begin
+    if (rst) begin
+      entry_valid_r <= '0;
+    end else begin
+      if (write_valid) begin
+        if (write_set) begin
+          entry_valid_r[write_idx] <= 1'b1;
+          entry_key_r[write_idx] <= write_key;
+        end else begin
+          entry_valid_r[write_idx] <= 1'b0;
+        end
+      end
+    end
+  end
+  
+endmodule
+
+// Ethernet MAC width
+// $clog2(DEPTH)
+// true=insert, false=clear (unused in demo)
+module mac_table #(
+  parameter int NUM_ENTRIES = 8,
+  parameter int NUM_PORTS = 4,
+  localparam int IDX_W = 3,
+  localparam int PORT_W = 2
+) (
+  input logic clk,
+  input logic rst,
+  input logic [47:0] lookup_mac,
+  output logic lookup_hit,
+  output logic [PORT_W-1:0] lookup_port,
+  input logic learn_valid,
+  input logic [47:0] learn_mac,
+  input logic [PORT_W-1:0] learn_port,
+  input logic [IDX_W-1:0] learn_idx
+);
+
+  // Lookup interface (combinational)
+  // miss → caller floods/broadcasts
+  // Learn interface — writes a MAC→port binding into the slot
+  // chosen by the caller (round-robin, LRU, etc.; out of scope here).
+  // Per-entry port number — addressed by the cam's first-match index.
+  // The CAM itself stores the MAC keys; this Vec stores the values.
+  logic [NUM_ENTRIES-1:0] [PORT_W-1:0] port_table;
+  logic [NUM_ENTRIES-1:0] cam_search_mask;
+  // unused; required to bind cam port
+  logic cam_search_any;
+  logic [IDX_W-1:0] cam_search_first;
+  Mac_Cam #(.DEPTH(NUM_ENTRIES), .KEY_W(48)) mac_cam (
+    .clk(clk),
+    .rst(rst),
+    .write_valid(learn_valid),
+    .write_idx(learn_idx),
+    .write_key(learn_mac),
+    .write_set(1'b1),
+    .search_key(lookup_mac),
+    .search_mask(cam_search_mask),
+    .search_any(cam_search_any),
+    .search_first(cam_search_first)
+  );
+  assign lookup_hit = cam_search_any;
+  assign lookup_port = port_table[cam_search_first];
+  always_ff @(posedge clk) begin
+    if (rst) begin
+      for (int __ri0 = 0; __ri0 < NUM_ENTRIES; __ri0++) begin
+        port_table[__ri0] <= 0;
+      end
+    end else begin
+      if (learn_valid) begin
+        port_table[learn_idx] <= learn_port;
+      end
+    end
+  end
+  // synopsys translate_off
+  // Auto-generated safety assertions (bounds / divide-by-zero)
+  _auto_bound_vec_0: assert property (@(posedge clk) disable iff (rst) (learn_idx) < (NUM_ENTRIES))
+    else $fatal(1, "BOUNDS VIOLATION: mac_table._auto_bound_vec_0");
+  // synopsys translate_on
+
+endmodule
+

--- a/tests/mac_table_tb.cpp
+++ b/tests/mac_table_tb.cpp
@@ -1,0 +1,87 @@
+// MAC learning table testbench. Exercises:
+//   1. Cold lookup → miss
+//   2. Learn (mac_a, port_2); lookup mac_a → hit on port 2
+//   3. Multiple learns; each MAC routes to its own port
+//   4. Lookup of an unknown MAC → miss (broadcast path)
+//   5. Re-learn the same MAC at a new slot+port → routing updates
+//      (oldest entry still hits per LSB-priority of cam.search_first)
+
+#include "Vmac_table.h"
+#include <cstdio>
+#include <cstdint>
+
+static Vmac_table dut;
+static int pass = 0, fail = 0;
+
+#define CHECK(cond, msg, ...) do { \
+  if (cond) { printf("  PASS: " msg "\n", ##__VA_ARGS__); ++pass; } \
+  else      { printf("  FAIL: " msg "\n", ##__VA_ARGS__); ++fail; } \
+} while (0)
+
+static void tick() {
+    dut.clk = 0; dut.eval();
+    dut.clk = 1; dut.eval();
+}
+
+static void do_reset() {
+    dut.rst = 1;
+    dut.learn_valid = 0;
+    dut.lookup_mac = 0;
+    tick(); tick();
+    dut.rst = 0; tick();
+}
+
+static void learn(uint64_t mac, uint32_t port, uint32_t idx) {
+    dut.learn_valid = 1;
+    dut.learn_mac = mac;
+    dut.learn_port = port;
+    dut.learn_idx = idx;
+    tick();
+    dut.learn_valid = 0;
+}
+
+int main() {
+    printf("=== mac_table sim ===\n");
+    do_reset();
+
+    // ── 1. Cold lookup: any MAC misses ──
+    dut.lookup_mac = 0xDEADBEEFCAFEULL; dut.eval();
+    CHECK(dut.lookup_hit == 0, "cold lookup misses");
+
+    // ── 2. Learn one entry, look it up ──
+    learn(0xAABBCCDDEEFFULL, 2, 0);
+    dut.lookup_mac = 0xAABBCCDDEEFFULL; dut.eval();
+    CHECK(dut.lookup_hit == 1, "post-learn lookup hits");
+    CHECK(dut.lookup_port == 2, "  routed to port 2 (got %u)", (unsigned)dut.lookup_port);
+
+    // ── 3. Multiple distinct entries route to distinct ports ──
+    learn(0x111111111111ULL, 1, 1);
+    learn(0x222222222222ULL, 3, 2);
+    learn(0x333333333333ULL, 0, 3);
+
+    dut.lookup_mac = 0x111111111111ULL; dut.eval();
+    CHECK(dut.lookup_hit == 1 && dut.lookup_port == 1, "mac1 → port 1");
+    dut.lookup_mac = 0x222222222222ULL; dut.eval();
+    CHECK(dut.lookup_hit == 1 && dut.lookup_port == 3, "mac2 → port 3");
+    dut.lookup_mac = 0x333333333333ULL; dut.eval();
+    CHECK(dut.lookup_hit == 1 && dut.lookup_port == 0, "mac3 → port 0");
+
+    // ── 4. Unknown MAC misses ──
+    dut.lookup_mac = 0x999999999999ULL; dut.eval();
+    CHECK(dut.lookup_hit == 0, "unknown MAC misses (broadcast path)");
+
+    // ── 5. Re-learn the same MAC at a new slot — both entries match,
+    //      cam.search_first returns the LSB-priority slot, so the
+    //      OLDER entry still wins. Caller's port_table for that slot
+    //      hasn't changed → port stays the same. (To migrate, the
+    //      caller would clear the old slot first; out of scope here.)
+    learn(0xAABBCCDDEEFFULL, 3, 5);
+    dut.lookup_mac = 0xAABBCCDDEEFFULL; dut.eval();
+    CHECK(dut.lookup_hit == 1, "re-learn lookup still hits");
+    CHECK(dut.lookup_port == 2,
+          "LSB-priority of search_first → original slot 0 wins (port 2; got %u)",
+          (unsigned)dut.lookup_port);
+
+    printf("=== %d pass / %d fail ===\n", pass, fail);
+    return fail == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary
While building a third cam demo (textbook MAC address learning table), uncovered a long-standing latent bug in [src/sim_codegen/mod.rs](src/sim_codegen/mod.rs): \`eval_const_expr\` only handled \`LitKind::*\` literals — \`ExprKind::Ident\` fell through to \`_ => 0\`. So **any** \`reg name: Vec<_, PARAM_NAME>\` (or wire / Vec port) with a param identifier as the count emitted \`name[0]\` in the C++ sim.

Two corruption paths in the generated sim:
1. **Storage decl** in the header: \`uint8_t _name[0];\`
2. **Next-state scratch** in eval_posedge: \`uint8_t _n_name[0]; memcpy(_n_name, _name, sizeof(_name));\` — the memcpy's \`sizeof\` reads N bytes but writes into a 0-sized array.

## Why the regression suite missed it
\`cache_mshr\` emitted both \`_entry_valid[0]\` and \`_n_entry_valid[0]\` — matching zero sizes meant the memcpy ping-pong cancelled out and \`_entry_valid[idx]=v\` happened to land on adjacent stack memory at the same logical location each cycle. \`test_mshr_sim.py\` passed by accident. The new \`mac_table\` demo (different stack frame layout where \`_n_port_table\` preceded other live locals) corrupted those locals on write — \`lookup_port\` (a \`UInt<2>\` field) read back \`33\` instead of \`2\`. That's what surfaced the bug.

## Fix
- New \`eval_const_expr_with_params(expr, params)\` that recursively resolves Idents against the module's params (regular + local), and folds \`Clog2\` / unary \`{!, -}\` / binary \`{+, -, *, /, %, <<, >>, &, |, ^}\` over reducible subtrees.
- \`eval_const_expr\` is now a thin wrapper that calls the above with empty params (back-compat).
- \`vec_array_info_with_params(ty, params)\` wrapper threads the param map through.
- 5 call sites in \`gen_module\` switched to the params-aware helper (private reg storage, private wire-let storage, Vec port info x2, next-state scratch). Five remaining \`vec_array_info(&...).is_some()\` callers are Some/None checks so param resolution doesn't change their answer; left unchanged.

## Demo
- [tests/mac_table.arch](tests/mac_table.arch) — Ethernet MAC learning table; cam consumer using \`search_any\` + \`search_first\` → \`port_table[idx]\` for the value lookup. Third use shape after cache_mshr (dual-write) and TLB (external-valid+flush).
- [tests/mac_table_tb.cpp](tests/mac_table_tb.cpp) — 9 scenarios: cold miss, learn + hit, multiple distinct MACs, unknown miss, re-learn LSB-priority semantics.

## Test gates (all pass)
- \`arch sim tests/mac_table.arch --tb tests/mac_table_tb.cpp\` → **9/9** (pre-fix: **6/9** with garbage reads)
- \`arch sim tests/cam_basic.arch ...\` → **12/12** (regression)
- \`arch sim tests/cam_dual_basic.arch ...\` → **10/10** (regression)
- \`python3 tests/cvdp/test_mshr_sim.py\` → **ALL PASS** for MSHR_SIZE in {4..32} (regression — these were passing by accident before, but storage now correctly sized)
- \`cargo build --release\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)