### PR TITLE
fix(sim_codegen): inst sub-module Vec port wiring (in + out, param-aware)

### DIFF
--- a/src/sim_codegen/mod.rs
+++ b/src/sim_codegen/mod.rs
@@ -3167,6 +3167,34 @@ impl<'a> SimCodegen<'a> {
         Vec::new()
     }
 
+    /// Sibling of [`lookup_inst_ports`] for the sub-module's params. Used
+    /// when resolving Vec<_, PARAM> port widths at an inst site so the
+    /// generated sim doesn't silently drop the wiring with a 0-count
+    /// degenerate match. Same construct coverage as the ports lookup.
+    fn lookup_inst_params(&self, module_name: &str) -> Vec<ParamDecl> {
+        for item in &self.source.items {
+            let params = match item {
+                Item::Module(m)       if m.name.name == module_name => Some(&m.params),
+                Item::Fsm(f)          if f.name.name == module_name => Some(&f.params),
+                Item::Fifo(f)         if f.name.name == module_name => Some(&f.params),
+                Item::Ram(r)          if r.name.name == module_name => Some(&r.params),
+                Item::Cam(c)          if c.name.name == module_name => Some(&c.params),
+                Item::Counter(c)      if c.name.name == module_name => Some(&c.params),
+                Item::Arbiter(a)      if a.name.name == module_name => Some(&a.params),
+                Item::Regfile(r)      if r.name.name == module_name => Some(&r.params),
+                Item::Pipeline(p)     if p.name.name == module_name => Some(&p.params),
+                Item::Linklist(l)     if l.name.name == module_name => Some(&l.params),
+                Item::Synchronizer(s) if s.name.name == module_name => Some(&s.params),
+                Item::Clkgate(c)      if c.name.name == module_name => Some(&c.params),
+                _ => None,
+            };
+            if let Some(p) = params {
+                return p.clone();
+            }
+        }
+        Vec::new()
+    }
+
     fn gen_module(&self, m: &ModuleDecl, emit_debug: bool, debug_module_set: &std::collections::HashSet<String>) -> SimModel {
         let name = &m.name.name;
         let class = format!("V{name}");
@@ -3543,13 +3571,24 @@ impl<'a> SimCodegen<'a> {
         let mut inst_vec_out: HashMap<String, (String, u64)> = HashMap::new();  // sig → (elem_ty, count)
         for (inst_idx, inst) in insts.iter().enumerate() {
             let sub_ports = self.lookup_inst_ports(&inst.module_name.name);
+            // Build the effective param map for this instance: start with
+            // the sub-module's defaults, then apply the inst's `param NAME = …;`
+            // overrides. Without this, a Vec<_, PARAM> port on the sub-module
+            // resolves only against the sub-module's default (which may be a
+            // small placeholder) instead of the actual instantiated width.
+            let mut sub_params = self.lookup_inst_params(&inst.module_name.name);
+            for pa in &inst.param_assigns {
+                if let Some(p) = sub_params.iter_mut().find(|p| p.name.name == pa.name.name) {
+                    p.default = Some(pa.value.clone());
+                }
+            }
             let conns = &expanded_conns[inst_idx];
             for conn in conns {
                 if conn.direction == ConnectDir::Output {
                     if let ExprKind::Ident(sig_name) = &conn.signal.kind {
                         // Check if the port on the sub-instance is a Vec type
                         if let Some(port) = sub_ports.iter().find(|p| p.name.name == conn.port_name.name) {
-                            if let Some((elem_ty, count_str)) = vec_array_info(&port.ty) {
+                            if let Some((elem_ty, count_str)) = vec_array_info_with_params(&port.ty, &sub_params) {
                                 let count: u64 = count_str.parse().unwrap_or(0);
                                 if count > 0 {
                                     inst_vec_out.insert(sig_name.clone(), (elem_ty, count));
@@ -4157,10 +4196,23 @@ impl<'a> SimCodegen<'a> {
                 for conn in conns {
                     if conn.direction == ConnectDir::Input {
                         if let crate::ast::ExprKind::Ident(src_name) = &conn.signal.kind {
-                            // Vec wire → inst Vec port: expand element-by-element
+                            // Vec wire/reg → inst Vec port: expand element-by-element
                             if let Some(&n) = vec_wire_counts.get(src_name.as_str()) {
                                 for i in 0..n {
                                     cpp.push_str(&format!("    _inst_{}.{}_{i} = _let_{src_name}[{i}];\n",
+                                        inst.name.name, conn.port_name.name));
+                                }
+                                continue;
+                            }
+                            // Parent Vec PORT (input) → inst Vec port:
+                            // parent's src is stored as flat fields
+                            // `src_0..src_{n-1}`.
+                            if vec_port_names.contains(src_name.as_str()) {
+                                let n = vec_port_infos.iter()
+                                    .find(|v| v.name == *src_name)
+                                    .map(|v| v.count).unwrap_or(0);
+                                for i in 0..n {
+                                    cpp.push_str(&format!("    _inst_{}.{}_{i} = {src_name}_{i};\n",
                                         inst.name.name, conn.port_name.name));
                                 }
                                 continue;
@@ -4183,13 +4235,30 @@ impl<'a> SimCodegen<'a> {
                         // inst Vec port → Vec wire/reg: expand element-by-element
                         if let ExprKind::Ident(sig_name) = &conn.signal.kind {
                             if let Some(&n) = vec_wire_counts.get(sig_name.as_str()) {
-                                // Determine prefix: regs use `_`, wires use `_let_`, inst-outputs use bare name
-                                let prefix = if reg_names.contains(sig_name.as_str()) { "_" }
-                                    else if inst_out.contains(sig_name.as_str()) { "" }
-                                    else { "_let_" };
-                                for i in 0..n {
-                                    cpp.push_str(&format!("    {prefix}{sig_name}[{i}] = _inst_{}.{}_{i};\n",
-                                        inst.name.name, conn.port_name.name));
+                                // Parent Vec PORT (output) is stored as flat
+                                // fields `name_0..name_{n-1}`, not as a C array.
+                                // For all other targets (reg, wire, inst-output
+                                // wire), the storage IS an array, so we emit
+                                // `prefix name[i]` syntax.
+                                if vec_port_names.contains(sig_name.as_str()) {
+                                    // Vec OUTPUT port: write to the internal
+                                    // _{name}[i] storage; the flat-field sync
+                                    // emitted at the end of eval_comb copies
+                                    // _{name}[i] → {name}_i. Writing the flat
+                                    // field directly here would be clobbered
+                                    // by that sync.
+                                    for i in 0..n {
+                                        cpp.push_str(&format!("    _{sig_name}[{i}] = _inst_{}.{}_{i};\n",
+                                            inst.name.name, conn.port_name.name));
+                                    }
+                                } else {
+                                    let prefix = if reg_names.contains(sig_name.as_str()) { "_" }
+                                        else if inst_out.contains(sig_name.as_str()) { "" }
+                                        else { "_let_" };
+                                    for i in 0..n {
+                                        cpp.push_str(&format!("    {prefix}{sig_name}[{i}] = _inst_{}.{}_{i};\n",
+                                            inst.name.name, conn.port_name.name));
+                                    }
                                 }
                                 continue;
                             }
@@ -4233,10 +4302,23 @@ impl<'a> SimCodegen<'a> {
                 for conn in conns {
                     if conn.direction == ConnectDir::Input {
                         if let crate::ast::ExprKind::Ident(src_name) = &conn.signal.kind {
-                            // Vec wire → inst Vec port: expand element-by-element
+                            // Vec wire/reg → inst Vec port: expand element-by-element
                             if let Some(&n) = vec_wire_counts.get(src_name.as_str()) {
                                 for i in 0..n {
                                     cpp.push_str(&format!("    _inst_{}.{}_{i} = _let_{src_name}[{i}];\n",
+                                        inst.name.name, conn.port_name.name));
+                                }
+                                continue;
+                            }
+                            // Parent Vec PORT (input) → inst Vec port:
+                            // parent's src is stored as flat fields
+                            // `src_0..src_{n-1}`.
+                            if vec_port_names.contains(src_name.as_str()) {
+                                let n = vec_port_infos.iter()
+                                    .find(|v| v.name == *src_name)
+                                    .map(|v| v.count).unwrap_or(0);
+                                for i in 0..n {
+                                    cpp.push_str(&format!("    _inst_{}.{}_{i} = {src_name}_{i};\n",
                                         inst.name.name, conn.port_name.name));
                                 }
                                 continue;
@@ -4259,12 +4341,25 @@ impl<'a> SimCodegen<'a> {
                         // inst Vec port → Vec wire/reg: expand element-by-element
                         if let ExprKind::Ident(sig_name) = &conn.signal.kind {
                             if let Some(&n) = vec_wire_counts.get(sig_name.as_str()) {
-                                let prefix = if reg_names.contains(sig_name.as_str()) { "_" }
-                                    else if inst_out.contains(sig_name.as_str()) { "" }
-                                    else { "_let_" };
-                                for i in 0..n {
-                                    cpp.push_str(&format!("    {prefix}{sig_name}[{i}] = _inst_{}.{}_{i};\n",
-                                        inst.name.name, conn.port_name.name));
+                                if vec_port_names.contains(sig_name.as_str()) {
+                                    // Vec OUTPUT port: write to the internal
+                                    // _{name}[i] storage; the flat-field sync
+                                    // emitted at the end of eval_comb copies
+                                    // _{name}[i] → {name}_i. Writing the flat
+                                    // field directly here would be clobbered
+                                    // by that sync.
+                                    for i in 0..n {
+                                        cpp.push_str(&format!("    _{sig_name}[{i}] = _inst_{}.{}_{i};\n",
+                                            inst.name.name, conn.port_name.name));
+                                    }
+                                } else {
+                                    let prefix = if reg_names.contains(sig_name.as_str()) { "_" }
+                                        else if inst_out.contains(sig_name.as_str()) { "" }
+                                        else { "_let_" };
+                                    for i in 0..n {
+                                        cpp.push_str(&format!("    {prefix}{sig_name}[{i}] = _inst_{}.{}_{i};\n",
+                                            inst.name.name, conn.port_name.name));
+                                    }
                                 }
                                 continue;
                             }
@@ -4770,10 +4865,21 @@ impl<'a> SimCodegen<'a> {
                 for conn in conns {
                     if conn.direction == ConnectDir::Input {
                         if let crate::ast::ExprKind::Ident(src_name) = &conn.signal.kind {
-                            // Vec wire → inst Vec port: expand element-by-element
+                            // Vec wire/reg → inst Vec port: expand element-by-element
                             if let Some(&n) = vec_wire_counts.get(src_name.as_str()) {
                                 for i in 0..n {
                                     cpp.push_str(&format!("  _inst_{}.{}_{i} = _let_{src_name}[{i}];\n",
+                                        inst.name.name, conn.port_name.name));
+                                }
+                                continue;
+                            }
+                            // Parent Vec PORT (input) → inst Vec port: flat field syntax
+                            if vec_port_names.contains(src_name.as_str()) {
+                                let n = vec_port_infos.iter()
+                                    .find(|v| v.name == *src_name)
+                                    .map(|v| v.count).unwrap_or(0);
+                                for i in 0..n {
+                                    cpp.push_str(&format!("  _inst_{}.{}_{i} = {src_name}_{i};\n",
                                         inst.name.name, conn.port_name.name));
                                 }
                                 continue;
@@ -4805,12 +4911,23 @@ impl<'a> SimCodegen<'a> {
                         // inst Vec port → Vec wire/reg: expand element-by-element
                         if let ExprKind::Ident(sig_name) = &conn.signal.kind {
                             if let Some(&n) = vec_wire_counts.get(sig_name.as_str()) {
-                                let prefix = if reg_names.contains(sig_name.as_str()) { "_" }
-                                    else if inst_out.contains(sig_name.as_str()) { "" }
-                                    else { "_let_" };
-                                for i in 0..n {
-                                    cpp.push_str(&format!("  {prefix}{sig_name}[{i}] = _inst_{}.{}_{i};\n",
-                                        inst.name.name, conn.port_name.name));
+                                if vec_port_names.contains(sig_name.as_str()) {
+                                    // See note in the input-wiring case: write
+                                    // to internal _{name}[i] storage, not flat
+                                    // field, so the eval_comb-tail sync isn't
+                                    // overwritten.
+                                    for i in 0..n {
+                                        cpp.push_str(&format!("  _{sig_name}[{i}] = _inst_{}.{}_{i};\n",
+                                            inst.name.name, conn.port_name.name));
+                                    }
+                                } else {
+                                    let prefix = if reg_names.contains(sig_name.as_str()) { "_" }
+                                        else if inst_out.contains(sig_name.as_str()) { "" }
+                                        else { "_let_" };
+                                    for i in 0..n {
+                                        cpp.push_str(&format!("  {prefix}{sig_name}[{i}] = _inst_{}.{}_{i};\n",
+                                            inst.name.name, conn.port_name.name));
+                                    }
                                 }
                                 continue;
                             }

--- a/tests/inst_vec_port_regression.arch
+++ b/tests/inst_vec_port_regression.arch
@@ -1,0 +1,46 @@
+// Regression test for the sub-instance Vec port wiring fix.
+//
+// The sub-module declares an output port whose Vec count is a param.
+// The parent instantiates it with `param N = 8;`. Pre-fix, the
+// parent's sim_codegen looked up the sub-module's port type and
+// asked vec_array_info for the count, which fell through to 0
+// because N is an Ident. The Vec wiring was then silently dropped
+// (count==0 filter), and the parent read garbage from the sub's
+// outputs.
+//
+// Post-fix: lookup_inst_params + inst-time param overrides feed
+// vec_array_info_with_params, so the count resolves correctly and
+// the per-element wiring is emitted.
+
+module Mirror
+  param N: const = 4;
+
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync, High>;
+
+  port in_vec:  in  Vec<UInt<8>, N>;
+  port out_vec: out Vec<UInt<8>, N>;
+
+  comb
+    for i in 0..N-1
+      out_vec[i] = in_vec[i];
+    end for
+  end comb
+end module Mirror
+
+module Top
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync, High>;
+
+  port src: in  Vec<UInt<8>, 8>;
+  port dst: out Vec<UInt<8>, 8>;
+
+  inst mirror: Mirror
+    param N = 8;
+
+    clk     <- clk;
+    rst     <- rst;
+    in_vec  <- src;
+    out_vec -> dst;
+  end inst mirror
+end module Top

--- a/tests/inst_vec_port_regression.sv
+++ b/tests/inst_vec_port_regression.sv
@@ -1,0 +1,46 @@
+// Regression test for the sub-instance Vec port wiring fix.
+//
+// The sub-module declares an output port whose Vec count is a param.
+// The parent instantiates it with `param N = 8;`. Pre-fix, the
+// parent's sim_codegen looked up the sub-module's port type and
+// asked vec_array_info for the count, which fell through to 0
+// because N is an Ident. The Vec wiring was then silently dropped
+// (count==0 filter), and the parent read garbage from the sub's
+// outputs.
+//
+// Post-fix: lookup_inst_params + inst-time param overrides feed
+// vec_array_info_with_params, so the count resolves correctly and
+// the per-element wiring is emitted.
+module Mirror #(
+  parameter int N = 8
+) (
+  input logic clk,
+  input logic rst,
+  input logic [N-1:0] [7:0] in_vec,
+  output logic [N-1:0] [7:0] out_vec
+);
+
+  always_comb begin
+    for (int i = 0; i <= N - 1; i++) begin
+      out_vec[i] = in_vec[i];
+    end
+  end
+
+endmodule
+
+module Top (
+  input logic clk,
+  input logic rst,
+  input logic [7:0] [7:0] src,
+  output logic [7:0] [7:0] dst
+);
+
+  Mirror #(.N(8)) mirror (
+    .clk(clk),
+    .rst(rst),
+    .in_vec(src),
+    .out_vec(dst)
+  );
+
+endmodule
+

--- a/tests/inst_vec_port_regression_tb.cpp
+++ b/tests/inst_vec_port_regression_tb.cpp
@@ -1,0 +1,48 @@
+// Drive Top's `src` Vec, expect `dst` to mirror element-by-element.
+// If the sub-instance Vec port wiring is broken, dst stays at zero.
+
+#include "VTop.h"
+#include <cstdio>
+#include <cstdint>
+
+static VTop dut;
+static int pass = 0, fail = 0;
+
+#define CHECK(cond, msg, ...) do { \
+  if (cond) { printf("  PASS: " msg "\n", ##__VA_ARGS__); ++pass; } \
+  else      { printf("  FAIL: " msg "\n", ##__VA_ARGS__); ++fail; } \
+} while (0)
+
+static void tick() {
+    dut.clk = 0; dut.eval();
+    dut.clk = 1; dut.eval();
+}
+
+int main() {
+    printf("=== inst_vec_port_regression sim ===\n");
+    dut.rst = 1; tick(); tick();
+    dut.rst = 0; tick();
+
+    // Drive each element of `src` to a distinct value; expect `dst` to mirror.
+    dut.src_0 = 0x11;
+    dut.src_1 = 0x22;
+    dut.src_2 = 0x33;
+    dut.src_3 = 0x44;
+    dut.src_4 = 0x55;
+    dut.src_5 = 0x66;
+    dut.src_6 = 0x77;
+    dut.src_7 = 0x88;
+    dut.eval();
+
+    CHECK(dut.dst_0 == 0x11, "dst[0] = 0x11 (got 0x%02x)", (unsigned)dut.dst_0);
+    CHECK(dut.dst_1 == 0x22, "dst[1] = 0x22 (got 0x%02x)", (unsigned)dut.dst_1);
+    CHECK(dut.dst_2 == 0x33, "dst[2] = 0x33 (got 0x%02x)", (unsigned)dut.dst_2);
+    CHECK(dut.dst_3 == 0x44, "dst[3] = 0x44 (got 0x%02x)", (unsigned)dut.dst_3);
+    CHECK(dut.dst_4 == 0x55, "dst[4] = 0x55 (got 0x%02x)", (unsigned)dut.dst_4);
+    CHECK(dut.dst_5 == 0x66, "dst[5] = 0x66 (got 0x%02x)", (unsigned)dut.dst_5);
+    CHECK(dut.dst_6 == 0x77, "dst[6] = 0x77 (got 0x%02x)", (unsigned)dut.dst_6);
+    CHECK(dut.dst_7 == 0x88, "dst[7] = 0x88 (got 0x%02x)", (unsigned)dut.dst_7);
+
+    printf("=== %d pass / %d fail ===\n", pass, fail);
+    return fail == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary
Three composing bugs in the parent-instantiates-sub-module path when the sub-module exposes Vec-typed input or output ports. Surfaced while auditing the remaining \`vec_array_info(&...)\` callers from #127.

### Bugs fixed

**1. Sub-module port count not resolved against inst-time params** ([src/sim_codegen/mod.rs:3580](src/sim_codegen/mod.rs#L3580))
The \`inst_vec_out\` collection used the non-params-aware \`vec_array_info\`, so \`Vec<_, PARAM_NAME>\` ports on the sub-module folded to count=0 and the wiring was silently dropped (\`count > 0\` filter). Now uses \`vec_array_info_with_params\` with an effective param map = sub-module defaults overlaid with the inst's \`param NAME = …;\` overrides. Adds \`lookup_inst_params\` sibling of \`lookup_inst_ports\` to fetch the sub-module's param list.

**2. Output wiring wrote flat fields instead of internal Vec storage**
Parent Vec OUTPUT ports are emitted as both flat fields (\`name_0..name_{n-1}\`) and an internal storage array (\`_name[i]\`), with an end-of-eval_comb sync that copies \`_name[i]\` → \`name_i\`. The previous wiring path emitted \`name[i] = _inst_x.port_i\` which (a) doesn't compile (parent's Vec port is flat fields, not array) and (b) would be clobbered by the sync anyway. Fix: write to \`_name[i]\` so the existing flat-sync correctly propagates.

**3. Input wiring of parent Vec PORT → inst Vec port**
The vec-expansion path only matched when the source name was in \`vec_wire_counts\` (which tracks Vec wires + regs, not Vec ports). When the parent connects one of its OWN Vec input ports to a sub-inst Vec input port, the expansion was skipped and a scalar \`_inst_x.in_vec = src\` was emitted — broken because both are flat-field stored. Fix: parallel branch that detects parent-Vec-port sources via \`vec_port_names\` and emits per-element \`_inst_x.in_vec_i = src_i\`.

## Regression test
- [tests/inst_vec_port_regression.arch](tests/inst_vec_port_regression.arch) — minimal \`Mirror\` sub-module (\`Vec in_vec → Vec out_vec\`, count is a param) instantiated by \`Top\` with \`param N = 8;\`. Covers all three bug paths in one fixture.
- [tests/inst_vec_port_regression_tb.cpp](tests/inst_vec_port_regression_tb.cpp) — drives \`src_0..7\` distinct values, expects \`dst_0..7\` to mirror them. **8/8 PASS post-fix; 0/8 pre-fix** (compile error or all-zero reads).

## Other regressions confirmed clean
| Test | Result |
|---|---|
| \`arch sim cam_basic.arch\` | 12/12 |
| \`arch sim cam_dual_basic.arch\` | 10/10 |
| \`arch sim mac_table.arch\` | 9/9 |
| \`iverilog test_mshr_sim.py\` | 8/8 MSHR sizes |
| \`iverilog test_tlb_sim.py\` | 14/14 scenarios |

🤖 Generated with [Claude Code](https://claude.com/claude-code)