### PR TITLE
feat: cam v3 — optional value payload (VAL_W + write_value/read_value)

### DIFF
--- a/doc/ARCH_HDL_Specification.md
+++ b/doc/ARCH_HDL_Specification.md
@@ -3143,6 +3143,44 @@ end cam Mshr_Addr_Cam_Dual
 - **Different indices:** both writes commit independently.
 - **Same index:** port 2 wins (last-write semantics --- the SV codegen processes port 1 then port 2 in the same \`always_ff\` block, so the port-2 assignment overwrites). Use this to encode "allocate beats finalize" or "set beats clear" --- pick which side maps to port 2 based on which should win the race in your design.
 
+**13.0b Value Payload (v3)**
+
+By default a cam stores only \`(valid, key)\` per slot --- callers that want an associated value typically pair the cam with a \`Vec\` indexed by \`search_first\`. v3 absorbs that pattern into the construct itself: an optional \`VAL_W\` param + \`write_value\` / \`read_value\` ports adds a parallel value array.
+
+```
+cam Tag_Value_Cam
+  param DEPTH: const = 8;
+  param KEY_W: const = 16;
+  param VAL_W: const = 32;       // ← activates the value bundle
+
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync, High>;
+
+  port write_valid: in Bool;
+  port write_idx:   in UInt<3>;
+  port write_key:   in UInt<16>;
+  port write_value: in UInt<32>;  // ← required when VAL_W is present
+  port write_set:   in Bool;
+
+  port search_key:   in  UInt<16>;
+  port search_mask:  out UInt<8>;
+  port search_any:   out Bool;
+  port search_first: out UInt<3>;
+  port read_value:   out UInt<32>; // ← required when VAL_W is present
+end cam Tag_Value_Cam
+```
+
+**Activation:** \`VAL_W\`, \`write_value\`, and \`read_value\` are **all-or-nothing** --- declaring any one of them requires all three. With v2 dual-write, \`write2_value\` is also required. A cam without \`VAL_W\` keeps v1/v2 semantics (key-only); existing CAMs are byte-identical.
+
+**Semantics:**
+- **Storage:** internal \`entry_value_r [DEPTH]\` parallel to \`entry_key_r\`. Both reset to zero.
+- **Write:** \`write_valid && write_set\` updates \`entry_key_r[write_idx]\` AND \`entry_value_r[write_idx]\` together. Clear (\`write_set=false\`) only invalidates --- the value is left as-is, but unreachable until the slot is re-set.
+- **Read:** \`read_value = entry_value_r[search_first]\` --- combinational mux into the same priority-encoded slot the rest of the search-port outputs reference. **Caller must qualify with \`search_any\`**: when no entry matches, \`search_first\` reads as 0 and \`read_value\` reflects whatever's at slot 0 (typically stale or zero), so consumers should gate with \`if search_any\`.
+
+**When to use:** any design that previously paired a cam with \`Vec<UInt<W>, DEPTH>\` indexed by \`cam.search_first\` --- TLBs (key=virtual page → value=physical page), MAC learning tables (key=MAC → value=port), scoreboards (key=tag → value=in-flight state), reservation stations.
+
+**When not to use:** designs that need to read the value at an index *other* than \`search_first\` (e.g. designs that apply an external valid mask and re-priority-encode the result --- see [tests/cvdp/TLB.arch](tests/cvdp/TLB.arch) for an example where a flush-gated valid_bits AND'd with \`search_mask\` selects a different index than the cam's own \`search_first\`). Those designs should keep using a separate \`Vec\` indexed by their own hit_idx.
+
 **13.1 CAM Kinds** *(aspirational --- not yet implemented)*
 
   ----------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/doc/Arch_AI_Reference_Card.md
+++ b/doc/Arch_AI_Reference_Card.md
@@ -712,6 +712,17 @@ end cam Mshr_Addr_Cam
 
 All four are required together (all-or-nothing). On the same edge: different indices both commit; same index → port 2 wins (last-write). Map your "winner" stream to port 2.
 
+**Value payload (v3):** absorb the per-entry value (otherwise kept in a parallel `Vec<UInt<W>, DEPTH>`) into the cam itself by adding `param VAL_W` + the matching write/read ports:
+
+```
+  param VAL_W: const = 32;
+  port write_value: in UInt<32>;
+  port read_value:  out UInt<32>;
+  // and write2_value if dual-write is enabled
+```
+
+All-or-nothing within the value bundle. `read_value = entry_value_r[search_first]`; gate with `search_any` (reads as 0 when no entry matches). Use this for TLB virtual→physical, MAC table MAC→port, scoreboard tag→state. Don't use it when the design re-priority-encodes against an external mask (different index than `search_first`) — keep a separate `Vec` for that case.
+
 ---
 
 ### counter

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -7041,6 +7041,13 @@ impl<'a> Codegen<'a> {
             .and_then(|p| p.default.as_ref())
             .map(|e| self.emit_expr_str(e))
             .unwrap_or_else(|| "0".to_string());
+        // v3: optional VAL_W param activates the value-payload bundle.
+        let has_value = c.params.iter().any(|p| p.name.name == "VAL_W");
+        let val_w_default = c.params.iter()
+            .find(|p| p.name.name == "VAL_W")
+            .and_then(|p| p.default.as_ref())
+            .map(|e| self.emit_expr_str(e))
+            .unwrap_or_else(|| "0".to_string());
 
         let clk = c.ports.iter()
             .find(|p| matches!(&p.ty, TypeExpr::Clock(_)))
@@ -7051,8 +7058,14 @@ impl<'a> Codegen<'a> {
         // ── Module header ─────────────────────────────────────────────────────
         self.line(&format!("module {n} #("));
         self.indent += 1;
-        self.line(&format!("parameter int DEPTH = {depth_default},"));
-        self.line(&format!("parameter int KEY_W = {key_w_default}"));
+        if has_value {
+            self.line(&format!("parameter int DEPTH = {depth_default},"));
+            self.line(&format!("parameter int KEY_W = {key_w_default},"));
+            self.line(&format!("parameter int VAL_W = {val_w_default}"));
+        } else {
+            self.line(&format!("parameter int DEPTH = {depth_default},"));
+            self.line(&format!("parameter int KEY_W = {key_w_default}"));
+        }
         self.indent -= 1;
         self.line(") (");
         self.indent += 1;
@@ -7076,6 +7089,9 @@ impl<'a> Codegen<'a> {
         // ── Storage ──────────────────────────────────────────────────────────
         self.line("logic [DEPTH-1:0]      entry_valid_r;");
         self.line("logic [KEY_W-1:0]      entry_key_r [DEPTH];");
+        if has_value {
+            self.line("logic [VAL_W-1:0]      entry_value_r [DEPTH];");
+        }
         self.line("");
 
         // ── Combinational match ──────────────────────────────────────────────
@@ -7105,6 +7121,14 @@ impl<'a> Codegen<'a> {
         self.line("end");
         self.line("");
 
+        // ── Value-payload read (v3) ──────────────────────────────────────────
+        // read_value reflects the entry at search_first; the caller should
+        // qualify with search_any (it reads as 0 when there is no match).
+        if has_value {
+            self.line("assign read_value = entry_value_r[search_first];");
+            self.line("");
+        }
+
         // ── Sequential write port(s) ─────────────────────────────────────────
         // v2: if write2_* ports exist, emit two sequential write blocks back-
         // to-back (write1 first, then write2) so write2 wins on same-index
@@ -7129,6 +7153,9 @@ impl<'a> Codegen<'a> {
         self.indent += 1;
         self.line("entry_valid_r[write_idx] <= 1'b1;");
         self.line("entry_key_r[write_idx] <= write_key;");
+        if has_value {
+            self.line("entry_value_r[write_idx] <= write_value;");
+        }
         self.indent -= 1;
         self.line("end else begin");
         self.indent += 1;
@@ -7145,6 +7172,9 @@ impl<'a> Codegen<'a> {
             self.indent += 1;
             self.line("entry_valid_r[write2_idx] <= 1'b1;");
             self.line("entry_key_r[write2_idx] <= write2_key;");
+            if has_value {
+                self.line("entry_value_r[write2_idx] <= write2_value;");
+            }
             self.indent -= 1;
             self.line("end else begin");
             self.indent += 1;

--- a/src/sim_codegen/cam.rs
+++ b/src/sim_codegen/cam.rs
@@ -24,8 +24,16 @@ impl<'a> SimCodegen<'a> {
             .and_then(|p| p.default.as_ref())
             .and_then(|e| if let ExprKind::Literal(LitKind::Dec(v)) = &e.kind { Some(*v as u32) } else { None })
             .unwrap_or(8);
+        // v3: optional value payload.
+        let has_value = c.params.iter().any(|p| p.name.name == "VAL_W");
+        let val_w: u32 = c.params.iter()
+            .find(|p| p.name.name == "VAL_W")
+            .and_then(|p| p.default.as_ref())
+            .and_then(|e| if let ExprKind::Literal(LitKind::Dec(v)) = &e.kind { Some(*v as u32) } else { None })
+            .unwrap_or(8);
 
         let key_ty = cpp_uint(key_w);
+        let val_ty = cpp_uint(val_w);
         let mask_ty = cpp_uint(depth);
         let idx_w = if depth <= 1 { 1 } else { 32 - (depth - 1).leading_zeros() };
         let idx_ty = cpp_uint(idx_w);
@@ -51,6 +59,9 @@ impl<'a> SimCodegen<'a> {
         let all_inits: Vec<String> = port_inits.into_iter().chain(state_inits).collect();
         h.push_str(&format!("  {class}() : {} {{\n", all_inits.join(", ")));
         h.push_str("    memset(_entry_key_r, 0, sizeof(_entry_key_r));\n");
+        if has_value {
+            h.push_str("    memset(_entry_value_r, 0, sizeof(_entry_value_r));\n");
+        }
         h.push_str("  }\n");
         h.push_str(&format!("  explicit {class}(VerilatedContext*) : {class}() {{}}\n"));
         h.push_str("  void eval();\n  void eval_posedge();\n  void eval_comb();\n  void final() { trace_close(); }\n");
@@ -58,6 +69,9 @@ impl<'a> SimCodegen<'a> {
         h.push_str("  uint8_t _clk_prev;\n");
         h.push_str(&format!("  {mask_ty} _entry_valid_r;\n"));
         h.push_str(&format!("  {key_ty} _entry_key_r[{depth}];\n"));
+        if has_value {
+            h.push_str(&format!("  {val_ty} _entry_value_r[{depth}];\n"));
+        }
 
         // ── Implementation ──
         let mut cpp = String::new();
@@ -88,6 +102,9 @@ impl<'a> SimCodegen<'a> {
         cpp.push_str("    if (write_set) {\n");
         cpp.push_str("      _entry_valid_r |= _bit;\n");
         cpp.push_str("      _entry_key_r[write_idx] = write_key;\n");
+        if has_value {
+            cpp.push_str("      _entry_value_r[write_idx] = write_value;\n");
+        }
         cpp.push_str("    } else {\n");
         cpp.push_str("      _entry_valid_r &= ~_bit;\n");
         cpp.push_str("    }\n");
@@ -99,6 +116,9 @@ impl<'a> SimCodegen<'a> {
             cpp.push_str("    if (write2_set) {\n");
             cpp.push_str("      _entry_valid_r |= _bit2;\n");
             cpp.push_str("      _entry_key_r[write2_idx] = write2_key;\n");
+            if has_value {
+                cpp.push_str("      _entry_value_r[write2_idx] = write2_value;\n");
+            }
             cpp.push_str("    } else {\n");
             cpp.push_str("      _entry_valid_r &= ~_bit2;\n");
             cpp.push_str("    }\n");
@@ -126,7 +146,14 @@ impl<'a> SimCodegen<'a> {
         cpp.push_str("    }\n");
         cpp.push_str("  }\n");
         cpp.push_str("  search_first = _first;\n");
+        if has_value {
+            // Mux into entry_value_r at search_first; caller qualifies with search_any.
+            cpp.push_str("  read_value = _entry_value_r[_first];\n");
+        }
         cpp.push_str("}\n");
+
+        // Suppress unused-variable warning when val_ty isn't referenced.
+        let _ = val_ty;
 
         // Trace support — track entry_valid_r and search outputs.
         let extra_sigs: Vec<(&str, &str, u32)> = vec![

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -3566,7 +3566,8 @@ impl<'a> TypeChecker<'a> {
         let w2_present: Vec<bool> = w2_names.iter()
             .map(|n| c.ports.iter().any(|p| p.name.name == *n))
             .collect();
-        if w2_present.iter().any(|b| *b) && !w2_present.iter().all(|b| *b) {
+        let has_w2 = w2_present.iter().any(|b| *b);
+        if has_w2 && !w2_present.iter().all(|b| *b) {
             let missing: Vec<&str> = w2_names.iter().zip(&w2_present)
                 .filter(|(_, present)| !**present)
                 .map(|(name, _)| *name)
@@ -3576,6 +3577,37 @@ impl<'a> TypeChecker<'a> {
                     "cam: dual-write port is all-or-nothing — missing port(s): {}",
                     missing.join(", ")
                 ),
+                c.name.span,
+            ));
+        }
+        // v3: optional value payload. Activation = VAL_W param + write_value
+        // + read_value (and write2_value if dual-write is enabled).
+        let has_val_w     = c.params.iter().any(|p| p.name.name == "VAL_W");
+        let has_write_val = c.ports.iter().any(|p| p.name.name == "write_value");
+        let has_read_val  = c.ports.iter().any(|p| p.name.name == "read_value");
+        let has_w2_val    = c.ports.iter().any(|p| p.name.name == "write2_value");
+        if has_val_w || has_write_val || has_read_val || has_w2_val {
+            // Any one present → all required (matched to the active write port set).
+            let mut missing: Vec<&str> = Vec::new();
+            if !has_val_w     { missing.push("param VAL_W");      }
+            if !has_write_val { missing.push("port write_value"); }
+            if !has_read_val  { missing.push("port read_value");  }
+            if has_w2 && !has_w2_val { missing.push("port write2_value"); }
+            if !missing.is_empty() {
+                self.errors.push(CompileError::general(
+                    &format!(
+                        "cam: value-type bundle is all-or-nothing — missing: {}",
+                        missing.join(", ")
+                    ),
+                    c.name.span,
+                ));
+            }
+        }
+        // Reject value-side ports declared without VAL_W (caught above when
+        // VAL_W is missing) or write2_value without dual-write.
+        if has_w2_val && !has_w2 {
+            self.errors.push(CompileError::general(
+                "cam: `write2_value` requires the full dual-write port set (write2_{valid,idx,key,set})",
                 c.name.span,
             ));
         }

--- a/tests/cam_value_basic.arch
+++ b/tests/cam_value_basic.arch
@@ -1,0 +1,26 @@
+// Cam v3 smoke test: optional value-payload bundle.
+//
+// Adds VAL_W param + write_value + read_value ports. Each entry now
+// stores (valid, key, value) instead of just (valid, key); the read
+// side returns the value at search_first directly.
+
+cam Tag_Value_Cam
+  param DEPTH: const = 8;
+  param KEY_W: const = 16;
+  param VAL_W: const = 32;
+
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync, High>;
+
+  port write_valid: in Bool;
+  port write_idx:   in UInt<3>;
+  port write_key:   in UInt<16>;
+  port write_value: in UInt<32>;
+  port write_set:   in Bool;
+
+  port search_key:   in  UInt<16>;
+  port search_mask:  out UInt<8>;
+  port search_any:   out Bool;
+  port search_first: out UInt<3>;
+  port read_value:   out UInt<32>;
+end cam Tag_Value_Cam

--- a/tests/cam_value_basic.sv
+++ b/tests/cam_value_basic.sv
@@ -1,0 +1,62 @@
+// Cam v3 smoke test: optional value-payload bundle.
+//
+// Adds VAL_W param + write_value + read_value ports. Each entry now
+// stores (valid, key, value) instead of just (valid, key); the read
+// side returns the value at search_first directly.
+module Tag_Value_Cam #(
+  parameter int DEPTH = 8,
+  parameter int KEY_W = 16,
+  parameter int VAL_W = 32
+) (
+  input logic clk,
+  input logic rst,
+  input logic write_valid,
+  input logic [2:0] write_idx,
+  input logic [15:0] write_key,
+  input logic [31:0] write_value,
+  input logic write_set,
+  input logic [15:0] search_key,
+  output logic [7:0] search_mask,
+  output logic search_any,
+  output logic [2:0] search_first,
+  output logic [31:0] read_value
+);
+
+  logic [DEPTH-1:0]      entry_valid_r;
+  logic [KEY_W-1:0]      entry_key_r [DEPTH];
+  logic [VAL_W-1:0]      entry_value_r [DEPTH];
+  
+  always_comb begin
+    for (int i = 0; i < DEPTH; i++) begin
+      search_mask[i] = entry_valid_r[i] && (entry_key_r[i] == search_key);
+    end
+  end
+  assign search_any = |search_mask;
+  
+  always_comb begin
+    search_first = '0;
+    for (int i = DEPTH-1; i >= 0; i--) begin
+      if (search_mask[i]) search_first = i[$clog2(DEPTH)-1:0];
+    end
+  end
+  
+  assign read_value = entry_value_r[search_first];
+  
+  always_ff @(posedge clk) begin
+    if (rst) begin
+      entry_valid_r <= '0;
+    end else begin
+      if (write_valid) begin
+        if (write_set) begin
+          entry_valid_r[write_idx] <= 1'b1;
+          entry_key_r[write_idx] <= write_key;
+          entry_value_r[write_idx] <= write_value;
+        end else begin
+          entry_valid_r[write_idx] <= 1'b0;
+        end
+      end
+    end
+  end
+  
+endmodule
+

--- a/tests/cam_value_basic_tb.cpp
+++ b/tests/cam_value_basic_tb.cpp
@@ -1,0 +1,87 @@
+// Cam v3 value_type smoke test.
+// Insert (key, value) tuples, search by key, read back the value.
+
+#include "VTag_Value_Cam.h"
+#include <cstdio>
+#include <cstdint>
+
+static VTag_Value_Cam dut;
+static int pass = 0, fail = 0;
+
+#define CHECK(cond, msg, ...) do { \
+  if (cond) { printf("  PASS: " msg "\n", ##__VA_ARGS__); ++pass; } \
+  else      { printf("  FAIL: " msg "\n", ##__VA_ARGS__); ++fail; } \
+} while (0)
+
+static void tick() {
+    dut.clk = 0; dut.eval();
+    dut.clk = 1; dut.eval();
+}
+
+static void do_reset() {
+    dut.rst = 1;
+    dut.write_valid = 0;
+    tick(); tick();
+    dut.rst = 0; tick();
+}
+
+static void write(uint32_t idx, uint32_t key, uint32_t value, bool set) {
+    dut.write_valid = 1;
+    dut.write_idx = idx;
+    dut.write_key = key;
+    dut.write_value = value;
+    dut.write_set = set ? 1 : 0;
+    tick();
+    dut.write_valid = 0;
+}
+
+int main() {
+    printf("=== cam_value_basic sim ===\n");
+    do_reset();
+
+    // Empty CAM: no match.
+    dut.search_key = 0x100; dut.eval();
+    CHECK(dut.search_any == 0, "empty: no match");
+
+    // Insert 3 entries with distinct (key, value).
+    write(0, 0x100, 0xDEAD0000, true);
+    write(1, 0x200, 0xDEAD0001, true);
+    write(2, 0x300, 0xDEAD0002, true);
+
+    // Lookup each: hit + correct value.
+    dut.search_key = 0x100; dut.eval();
+    CHECK(dut.search_any == 1 && dut.search_first == 0 && dut.read_value == 0xDEAD0000,
+          "key=0x100 → idx 0, value DEAD0000 (got first=%u value=0x%08x)",
+          (unsigned)dut.search_first, (unsigned)dut.read_value);
+
+    dut.search_key = 0x200; dut.eval();
+    CHECK(dut.search_any == 1 && dut.search_first == 1 && dut.read_value == 0xDEAD0001,
+          "key=0x200 → idx 1, value DEAD0001");
+
+    dut.search_key = 0x300; dut.eval();
+    CHECK(dut.search_any == 1 && dut.search_first == 2 && dut.read_value == 0xDEAD0002,
+          "key=0x300 → idx 2, value DEAD0002");
+
+    // Unknown key: search_any=0; read_value is whatever happens to be at idx 0
+    // (caller must qualify with search_any).
+    dut.search_key = 0x999; dut.eval();
+    CHECK(dut.search_any == 0, "unknown key: search_any == 0 (read_value undefined)");
+
+    // Update value at existing slot — overwrite with set=true.
+    write(1, 0x200, 0xCAFE2222, true);
+    dut.search_key = 0x200; dut.eval();
+    CHECK(dut.read_value == 0xCAFE2222, "update slot 1 value (got 0x%08x)", (unsigned)dut.read_value);
+
+    // Clear slot 0 — same key now misses.
+    write(0, 0, 0, false);
+    dut.search_key = 0x100; dut.eval();
+    CHECK(dut.search_any == 0, "post-clear: key 0x100 misses");
+
+    // Reset wipes everything.
+    do_reset();
+    dut.search_key = 0x200; dut.eval();
+    CHECK(dut.search_any == 0, "post-reset: empty");
+
+    printf("=== %d pass / %d fail ===\n", pass, fail);
+    return fail == 0 ? 0 : 1;
+}

--- a/tests/mac_table.arch
+++ b/tests/mac_table.arch
@@ -1,31 +1,30 @@
-// Ethernet MAC address learning table — textbook CAM use case.
+// Ethernet MAC address learning table — refactored on cam v3 (value_type).
 //
-// On the lookup side: given a destination MAC, return the egress port
-// (or signal "miss" so the caller can broadcast). On the learn side:
-// when a frame arrives, the caller picks a slot and writes
-// (src_mac, ingress_port). v1 single-write port suffices because lookup
-// and learn never write the CAM in the same cycle (lookup is purely
-// combinational; only learn drives writes).
-//
-// Slot selection is the caller's job (round-robin in this demo). Real
-// switches add aging / LRU on top.
+// The cam now stores (mac_addr, port) pairs directly via the value-payload
+// bundle (VAL_W param + write_value/read_value ports). The previous version
+// kept a parallel `port_table: Vec<UInt<PORT_W>, NUM_ENTRIES>` and indexed
+// it by `cam.search_first` — pure boilerplate that v3 absorbs into the
+// CAM itself.
 
 cam Mac_Cam
   param DEPTH: const = 8;
   param KEY_W: const = 48;     // Ethernet MAC width
+  param VAL_W: const = 2;      // PORT_W
 
   port clk: in Clock<SysDomain>;
   port rst: in Reset<Sync, High>;
 
   port write_valid: in Bool;
-  port write_idx:   in UInt<3>;     // $clog2(DEPTH)
+  port write_idx:   in UInt<3>;
   port write_key:   in UInt<48>;
-  port write_set:   in Bool;        // true=insert, false=clear (unused in demo)
+  port write_value: in UInt<2>;
+  port write_set:   in Bool;
 
   port search_key:   in  UInt<48>;
   port search_mask:  out UInt<8>;
   port search_any:   out Bool;
   port search_first: out UInt<3>;
+  port read_value:   out UInt<2>;
 end cam Mac_Cam
 
 module mac_table
@@ -42,7 +41,7 @@ module mac_table
   port lookup_hit:  out Bool;       // miss → caller floods/broadcasts
   port lookup_port: out UInt<PORT_W>;
 
-  // Learn interface — writes a MAC→port binding into the slot
+  // Learn interface — writes a (MAC → port) binding into the slot
   // chosen by the caller (round-robin, LRU, etc.; out of scope here).
   port learn_valid: in Bool;
   port learn_mac:   in UInt<48>;
@@ -51,36 +50,30 @@ module mac_table
 
   default seq on clk rising;
 
-  // Per-entry port number — addressed by the cam's first-match index.
-  // The CAM itself stores the MAC keys; this Vec stores the values.
-  reg port_table: Vec<UInt<PORT_W>, NUM_ENTRIES> reset rst => 0;
-
   wire cam_search_mask:  UInt<NUM_ENTRIES>;     // unused; required to bind cam port
   wire cam_search_any:   Bool;
-  wire cam_search_first: UInt<IDX_W>;
+  wire cam_search_first: UInt<IDX_W>;            // unused; required to bind cam port
+  wire cam_read_value:   UInt<PORT_W>;
 
   inst mac_cam: Mac_Cam
     param DEPTH = NUM_ENTRIES;
     param KEY_W = 48;
+    param VAL_W = PORT_W;
 
     clk           <- clk;
     rst           <- rst;
     write_valid   <- learn_valid;
     write_idx     <- learn_idx;
     write_key     <- learn_mac;
+    write_value   <- learn_port;
     write_set     <- true;
     search_key    <- lookup_mac;
     search_mask   -> cam_search_mask;
     search_any    -> cam_search_any;
     search_first  -> cam_search_first;
+    read_value    -> cam_read_value;
   end inst mac_cam
 
   let lookup_hit  = cam_search_any;
-  let lookup_port = port_table[cam_search_first];
-
-  seq
-    if learn_valid
-      port_table[learn_idx] <= learn_port;
-    end if
-  end seq
+  let lookup_port = cam_read_value;
 end module mac_table

--- a/tests/mac_table.sv
+++ b/tests/mac_table.sv
@@ -1,32 +1,32 @@
-// Ethernet MAC address learning table — textbook CAM use case.
+// Ethernet MAC address learning table — refactored on cam v3 (value_type).
 //
-// On the lookup side: given a destination MAC, return the egress port
-// (or signal "miss" so the caller can broadcast). On the learn side:
-// when a frame arrives, the caller picks a slot and writes
-// (src_mac, ingress_port). v1 single-write port suffices because lookup
-// and learn never write the CAM in the same cycle (lookup is purely
-// combinational; only learn drives writes).
-//
-// Slot selection is the caller's job (round-robin in this demo). Real
-// switches add aging / LRU on top.
+// The cam now stores (mac_addr, port) pairs directly via the value-payload
+// bundle (VAL_W param + write_value/read_value ports). The previous version
+// kept a parallel `port_table: Vec<UInt<PORT_W>, NUM_ENTRIES>` and indexed
+// it by `cam.search_first` — pure boilerplate that v3 absorbs into the
+// CAM itself.
 module Mac_Cam #(
   parameter int DEPTH = 8,
-  parameter int KEY_W = 48
+  parameter int KEY_W = 48,
+  parameter int VAL_W = 2
 ) (
   input logic clk,
   input logic rst,
   input logic write_valid,
   input logic [2:0] write_idx,
   input logic [47:0] write_key,
+  input logic [1:0] write_value,
   input logic write_set,
   input logic [47:0] search_key,
   output logic [7:0] search_mask,
   output logic search_any,
-  output logic [2:0] search_first
+  output logic [2:0] search_first,
+  output logic [1:0] read_value
 );
 
   logic [DEPTH-1:0]      entry_valid_r;
   logic [KEY_W-1:0]      entry_key_r [DEPTH];
+  logic [VAL_W-1:0]      entry_value_r [DEPTH];
   
   always_comb begin
     for (int i = 0; i < DEPTH; i++) begin
@@ -42,6 +42,8 @@ module Mac_Cam #(
     end
   end
   
+  assign read_value = entry_value_r[search_first];
+  
   always_ff @(posedge clk) begin
     if (rst) begin
       entry_valid_r <= '0;
@@ -50,6 +52,7 @@ module Mac_Cam #(
         if (write_set) begin
           entry_valid_r[write_idx] <= 1'b1;
           entry_key_r[write_idx] <= write_key;
+          entry_value_r[write_idx] <= write_value;
         end else begin
           entry_valid_r[write_idx] <= 1'b0;
         end
@@ -60,8 +63,7 @@ module Mac_Cam #(
 endmodule
 
 // Ethernet MAC width
-// $clog2(DEPTH)
-// true=insert, false=clear (unused in demo)
+// PORT_W
 module mac_table #(
   parameter int NUM_ENTRIES = 8,
   parameter int NUM_PORTS = 4,
@@ -81,45 +83,30 @@ module mac_table #(
 
   // Lookup interface (combinational)
   // miss → caller floods/broadcasts
-  // Learn interface — writes a MAC→port binding into the slot
+  // Learn interface — writes a (MAC → port) binding into the slot
   // chosen by the caller (round-robin, LRU, etc.; out of scope here).
-  // Per-entry port number — addressed by the cam's first-match index.
-  // The CAM itself stores the MAC keys; this Vec stores the values.
-  logic [NUM_ENTRIES-1:0] [PORT_W-1:0] port_table;
   logic [NUM_ENTRIES-1:0] cam_search_mask;
   // unused; required to bind cam port
   logic cam_search_any;
   logic [IDX_W-1:0] cam_search_first;
-  Mac_Cam #(.DEPTH(NUM_ENTRIES), .KEY_W(48)) mac_cam (
+  // unused; required to bind cam port
+  logic [PORT_W-1:0] cam_read_value;
+  Mac_Cam #(.DEPTH(NUM_ENTRIES), .KEY_W(48), .VAL_W(PORT_W)) mac_cam (
     .clk(clk),
     .rst(rst),
     .write_valid(learn_valid),
     .write_idx(learn_idx),
     .write_key(learn_mac),
+    .write_value(learn_port),
     .write_set(1'b1),
     .search_key(lookup_mac),
     .search_mask(cam_search_mask),
     .search_any(cam_search_any),
-    .search_first(cam_search_first)
+    .search_first(cam_search_first),
+    .read_value(cam_read_value)
   );
   assign lookup_hit = cam_search_any;
-  assign lookup_port = port_table[cam_search_first];
-  always_ff @(posedge clk) begin
-    if (rst) begin
-      for (int __ri0 = 0; __ri0 < NUM_ENTRIES; __ri0++) begin
-        port_table[__ri0] <= 0;
-      end
-    end else begin
-      if (learn_valid) begin
-        port_table[learn_idx] <= learn_port;
-      end
-    end
-  end
-  // synopsys translate_off
-  // Auto-generated safety assertions (bounds / divide-by-zero)
-  _auto_bound_vec_0: assert property (@(posedge clk) disable iff (rst) (learn_idx) < (NUM_ENTRIES))
-    else $fatal(1, "BOUNDS VIOLATION: mac_table._auto_bound_vec_0");
-  // synopsys translate_on
+  assign lookup_port = cam_read_value;
 
 endmodule
 


### PR DESCRIPTION
## Summary
Absorbs the per-entry value (previously kept by callers in a parallel \`Vec<UInt<W>, DEPTH>\` indexed by \`cam.search_first\`) into the cam itself. Targets the TLB / MAC-table / scoreboard pattern where every entry has a key + an associated value.

## Activation
All-or-nothing within the value bundle: declaring any of
\`\`\`
param VAL_W:    const = N;
port write_value: in UInt<VAL_W>;
port read_value:  out UInt<VAL_W>;
\`\`\`
requires all three. With v2 dual-write enabled, \`write2_value\` is also required. CAMs without \`VAL_W\` keep v1/v2 semantics — byte-identical SV (regression-checked: cam_basic/cam_dual_basic still pass 12/12 and 10/10).

## Semantics
- Storage: internal \`entry_value_r [DEPTH]\` parallel to \`entry_key_r\`; both reset to zero.
- Write: \`write_set=true\` commits key + value together. Clear (\`write_set=false\`) only invalidates — the value is left as-is.
- Read: \`read_value = entry_value_r[search_first]\` — combinational mux into the same priority-encoded slot the rest of the search outputs reference. **Caller MUST gate with \`search_any\`** (read_value reflects whatever's at slot 0 when no entry matches).

## Demo simplification
[tests/mac_table.arch](tests/mac_table.arch) drops its parallel \`port_table: Vec<UInt<PORT_W>, NUM_ENTRIES>\` and the \`lookup_port = port_table[search_first]\` wiring — the cam now holds (mac, port) directly. Same testbench (tests/mac_table_tb.cpp) still passes **9/9** → semantic equivalence with simpler arch source.

## Why TLB stays unchanged
[tests/cvdp/TLB.arch](tests/cvdp/TLB.arch) AND-s an external \`valid_bits\` with \`cam.search_mask\` and re-priority-encodes, picking a different index than the cam's own \`search_first\`. \`value_type\`'s \`read_value\` is pinned to \`search_first\`, so it would read the wrong slot post-flush. The spec documents this as the case where value_type doesn't fit and a separate Vec is the right call.

## Files
- [src/typecheck.rs](src/typecheck.rs) — all-or-nothing + write2_value dual-write linkage
- [src/codegen.rs](src/codegen.rs) — \`emit_cam\`: VAL_W parameter, \`entry_value_r[DEPTH]\` storage, value-aware writes, \`assign read_value = entry_value_r[search_first]\`
- [src/sim_codegen/cam.rs](src/sim_codegen/cam.rs) — same shape in C++
- [tests/cam_value_basic.arch](tests/cam_value_basic.arch) + [_tb.cpp](tests/cam_value_basic_tb.cpp) — 8 scenarios, **8/8 pass**
- [doc/ARCH_HDL_Specification.md](doc/ARCH_HDL_Specification.md) — new **§13.0b "Value Payload (v3)"**
- [doc/Arch_AI_Reference_Card.md](doc/Arch_AI_Reference_Card.md) — cam card extended

## Test plan (all green)
- \`cargo build --release\`
- \`arch check tests/cam_value_basic.arch\` → OK
- Negative test: cam with VAL_W but missing write_value → "value-type bundle is all-or-nothing" error
- \`arch sim cam_value_basic.arch\` → 8/8
- \`arch sim cam_basic.arch\` → 12/12 (regression)
- \`arch sim cam_dual_basic.arch\` → 10/10 (regression)
- \`arch sim mac_table.arch\` → 9/9 (now using value_type)
- \`arch sim inst_vec_port_regression.arch\` → 8/8 (regression)
- \`iverilog test_mshr_sim.py\` → ALL PASS (regression)
- \`iverilog test_tlb_sim.py\` → 14/14 (regression)
- Verilator \`--lint-only -Wall\` clean on emitted SV

🤖 Generated with [Claude Code](https://claude.com/claude-code)