### PR TITLE
plan: arch sim coverage (Verilator-style); reserve --coverage CLI flag

### DIFF
--- a/doc/plan_arch_coverage.md
+++ b/doc/plan_arch_coverage.md
@@ -1,0 +1,57 @@
+# Plan: arch sim coverage
+
+> **Status**: design + phased rollout. MVP (Phase 1) ships branch coverage with text report.
+
+## Motivation
+
+Verilator's `--coverage` instrument-then-replay model is the gold standard for HDL sim coverage: enables it at compile, runs unchanged, dumps `coverage.dat` at exit, post-processes with `verilator_coverage --annotate`. Arch sim should match that ergonomics: `arch sim --coverage Tb.arch --tb tb.cpp` and at exit you get a coverage report keyed to *.arch source lines (not the generated SV/C++).
+
+## Phased rollout
+
+### Phase 1 (MVP) — branch coverage
+
+Each \`if\` / \`elsif\` / \`else\` arm in seq and comb blocks gets a counter. At sim exit, dump a per-arm hit count keyed to the source line. Smallest useful slice: tells you whether every branch in the design was exercised by your testbench.
+
+- CLI: \`arch sim --coverage Tb.arch ...\`
+- Instrument: in [src/sim_codegen/mod.rs], when emitting \`if (cond) { … } else if … else …\`, prefix each arm with \`_arch_cov[N]++;\` where N is a globally unique counter index. Maintain a sidecar map from N → (file, line, arm_kind).
+- Emit a per-class \`_arch_cov\` array of \`uint64_t\` and a static initialization-time registration so \`final()\` (or atexit) can dump.
+- Output: \`coverage.txt\` in the working directory:
+  ```
+  cache_mshr.arch:111 if fill_valid              : hit 14
+  cache_mshr.arch:114 elsif dq_valid_r & ready   : hit 6
+  cache_mshr.arch:116 if entry_has_next[dq_idx]  : hit 2
+  cache_mshr.arch:118 else                       : hit 4
+  ...
+  Summary: 12/14 branches hit (85.7%)
+  ```
+
+### Phase 2 — line coverage
+
+Counter per \`<=\` and \`=\` statement in seq/comb. Often subsumes branch coverage but distinct: a branch may be entered without all its statements firing (early-return-style patterns).
+
+### Phase 3 — FSM state + transition coverage
+
+For each \`fsm\`: a counter per state (entries) and per transition arc. Output: which states never entered, which transitions never taken.
+
+### Phase 4 — toggle coverage
+
+For each scalar wire/reg, count 0→1 and 1→0 transitions. Useful for catching tied-off signals. Costly (per-bit per-cycle), so opt-in via \`--coverage=toggle\` separate from default \`--coverage\`.
+
+### Phase 5 — Verilator-compatible \`coverage.dat\`
+
+Emit Verilator's \`# SystemC: …\`-prefixed format alongside the text report so users can run \`verilator_coverage --annotate-min 1 --annotate annot/ coverage.dat\` and get HTML annotation against the *.sv files. (The arch source lines won't match SV lines exactly, but the text report from phases 1-4 gives the arch-source view; the .dat gives the SV view.)
+
+## Non-goals (v1)
+
+- **Cross-test merging**: each \`arch sim\` run overwrites \`coverage.txt\`. \`verilator_coverage --merge\` semantics deferred until users ask.
+- **Functional coverage** (\`covergroup\` / \`coverpoint\`): out of scope. Arch's \`cover\` blocks already lower to SVA \`cover property\`; hooking those into a runtime hit-counter is a separate feature.
+- **Source-position-perfect spans**: phase 1 records line numbers. Column-accurate spans + multi-line if conditions deferred.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Counter increments slow down sim by 10×+ for hot loops | Counters are `uint64_t` increments — single instruction. Measure on cache_mshr; if regression > 5%, gate behind `--coverage` (which we already do — it's opt-in). |
+| Sidecar map breaks when source files change | Embed (file, line, span) directly in the dump-time text-format emit. No sidecar lookup at sim time. |
+| Atexit dump gets lost on crash / abort() | `final()` already exists for trace close; reuse it. For abort paths (bounds check fail), call dump from the abort handler too. |
+| Per-class storage doesn't compose across multiple instances | Counters are per-class (static), so 100 instances of cache_mshr share one counter set. Matches Verilator. Per-instance is a future opt-in. |

--- a/src/main.rs
+++ b/src/main.rs
@@ -116,6 +116,12 @@ enum Command {
         /// How many module levels to instrument with --debug (default 1 = top module only)
         #[arg(long = "depth", default_value_t = 1)]
         debug_depth: u32,
+        /// Enable code coverage instrumentation. Counts each if/elsif/else arm
+        /// in seq and comb blocks and dumps `coverage.txt` keyed to .arch source
+        /// lines at sim exit. See doc/plan_arch_coverage.md for the phased rollout
+        /// (branch → line → FSM → toggle → Verilator-compatible coverage.dat).
+        #[arg(long)]
+        coverage: bool,
         /// Generate pybind11 Python module for cocotb-compatible testing
         #[arg(long)]
         pybind: bool,
@@ -334,7 +340,10 @@ fn main() -> miette::Result<()> {
             }
             Ok(())
         }
-        Command::Sim { arch_files, tb_files, outdir, check_uninit, inputs_start_uninit, check_uninit_ram, cdc_random, wave, debug, debug_depth, debug_fsm, pybind, test, pybind_module_name } => {
+        Command::Sim { arch_files, tb_files, outdir, check_uninit, inputs_start_uninit, check_uninit_ram, cdc_random, wave, debug, debug_depth, debug_fsm, coverage, pybind, test, pybind_module_name } => {
+            if coverage {
+                eprintln!("warning: --coverage is reserved but not yet implemented (see doc/plan_arch_coverage.md). Continuing without instrumentation.");
+            }
             let dbg_ports = debug || debug_fsm;  // any debug option implies port logging
             // --inputs-start-uninit and --check-uninit-ram both imply --check-uninit
             let check_uninit = check_uninit || inputs_start_uninit || check_uninit_ram;


### PR DESCRIPTION
## Summary
Documents the phased rollout for arch-source-keyed code coverage in \`arch sim\` and reserves the \`--coverage\` CLI flag (with a deferral warning) so the follow-up phase 1 PR is purely an instrumentation diff with no CLI churn.

## Phased rollout (in [doc/plan_arch_coverage.md](doc/plan_arch_coverage.md))
- **Phase 1 (MVP)**: branch coverage — counter per if/elsif/else arm in seq+comb, dump \`coverage.txt\` at sim exit, keyed to .arch source lines
- **Phase 2**: line coverage — counter per \`<=\` / \`=\` statement
- **Phase 3**: FSM state + transition coverage
- **Phase 4**: toggle coverage (opt-in via \`--coverage=toggle\`)
- **Phase 5**: Verilator-compatible \`coverage.dat\` (so \`verilator_coverage --annotate\` tooling works against the emitted .sv view)

## Surface
\`\`\`
arch sim --coverage Tb.arch --tb tb.cpp
\`\`\`
Currently emits:
\`\`\`
warning: --coverage is reserved but not yet implemented (see doc/plan_arch_coverage.md). Continuing without instrumentation.
\`\`\`

## Non-goals (v1, in plan)
- Cross-test \`coverage.txt\` merging — defer to user demand
- Functional coverage (covergroup / coverpoint) — separate feature; arch's \`cover\` blocks already lower to SVA

## Test plan
- [x] \`cargo build --release\` clean
- [x] \`arch sim --coverage tests/cam_value_basic.arch ...\` prints the deferral warning then runs unchanged
- [ ] Phase 1 follow-up PR: branch counters + text report

🤖 Generated with [Claude Code](https://claude.com/claude-code)