### PR TITLE
feat(sim_codegen): --coverage phase 1c — branch coverage for comb if/elsif/else

### DIFF
--- a/src/sim_codegen/mod.rs
+++ b/src/sim_codegen/mod.rs
@@ -2612,6 +2612,17 @@ fn emit_comb_if_else(ie: &CombIfElse, ctx: &Ctx, out: &mut String, indent: usize
     } else {
         out.push_str(&format!("{}if ({}) {{\n", ind(indent), cond));
     }
+    // --coverage phase 1c: same instrumentation as emit_reg_if_else for
+    // comb if/elsif/else arms. Note that comb blocks may evaluate
+    // multiple times per cycle during the settle loop — counters
+    // therefore reflect "branch entries", not "cycles where branch was
+    // active". For most arch designs the settle loop converges in 1-2
+    // iterations so this is close to the cycle count.
+    if let Some(reg) = ctx.coverage {
+        let kind = if is_chain { "elsif" } else { "if" };
+        let idx = reg.borrow_mut().alloc(kind, ie.cond.span.start, String::new());
+        out.push_str(&format!("{}  _arch_cov[{idx}]++;\n", ind(indent)));
+    }
     emit_comb_stmts(&ie.then_stmts, ctx, out, indent + 1);
     if ie.else_stmts.len() == 1 {
         if let CombStmt::IfElse(nested) = &ie.else_stmts[0] {
@@ -2621,6 +2632,10 @@ fn emit_comb_if_else(ie: &CombIfElse, ctx: &Ctx, out: &mut String, indent: usize
     }
     if !ie.else_stmts.is_empty() {
         out.push_str(&format!("{}}} else {{\n", ind(indent)));
+        if let Some(reg) = ctx.coverage {
+            let idx = reg.borrow_mut().alloc("else", ie.span.end, String::new());
+            out.push_str(&format!("{}  _arch_cov[{idx}]++;\n", ind(indent)));
+        }
         emit_comb_stmts(&ie.else_stmts, ctx, out, indent + 1);
     }
     out.push_str(&format!("{}}}\n", ind(indent)));
@@ -4880,7 +4895,8 @@ impl<'a> SimCodegen<'a> {
         cpp.push_str(&format!("void {class}::eval_comb() {{\n"));
         let ctx_comb = Ctx::new(&reg_names, &port_names, &let_names, &inst_names,
                                 &wide_names, &widths, &enum_map, &bus_port_names)
-                           .with_vec_names(&vec_reg_names).with_vec_sizes(&vec_sizes);
+                           .with_vec_names(&vec_reg_names).with_vec_sizes(&vec_sizes)
+                           .with_coverage(cov_handle);
 
         // Credit-channel combinational wires (sender can_send; receiver
         // valid/data once PR-sim-2 lands). Emit early so user comb code


### PR DESCRIPTION
## Summary
Extends the phase 1 instrumentation to comb blocks. Same mechanism as \`emit_reg_if_else\`: at each arm of an if/elsif/else chain in a comb block, allocate a counter id and emit \`_arch_cov[N]++;\`.

## Settle-loop note
Comb blocks may evaluate multiple times per cycle when a parent's \`eval_comb\` settle loop runs more than one iteration to converge combinational feedback. Counters therefore reflect "branch entries" rather than "cycles where branch was active". For most arch designs the settle loop converges in 1-2 iterations so this is close to the cycle count.

## Bonus finding (separate from this PR)
Smoke on cache_mshr surfaced a **pre-existing C++ sim bug**: the comb branches at lines 134 / 163 of cache_mshr.arch all show 0 hits, but the design source is \`if ~full_flag == false\`. Investigation showed sim_codegen emits \`((~(_let_full_flag)) == 0)\` without masking the unary \`~\` to 1 bit. So \`~uint8_t(1) == 0xFE\`, never \`== 0\`, and the branch never enters in the C++ sim. iverilog masks correctly so \`test_mshr_sim.py\` still passes, which is why this hasn't shown up before. **Coverage instrumentation is doing its job naming the gap** — the underlying sim bug is tracked separately.

## Smoke
A tiny \`cov_smoke.arch\` with one comb if/elsif/else, TB hits only the \`if\` arm twice:
\`\`\`
[Vcov_smoke] branch coverage: 1/3 hit (33.3%)
  /tmp/cov_smoke.arch:10 (if): 4 hits
  /tmp/cov_smoke.arch:13 (elsif): 0 hits *NOT HIT*
  /tmp/cov_smoke.arch:19 (else): 0 hits *NOT HIT*
\`\`\`

cache_mshr smoke now reports **4/12 hit** (vs 4/7 with seq-only).

## Regressions clean
- cam_basic 12/12
- cam_value_basic 8/8
- mac_table 9/9
- inst_vec_port_regression 8/8

## Stack
Builds on #134 (file:line) which builds on #132 (phase 1 seq-only). Merge order: #132 → #134 → this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)