### PR TITLE
feat(sim_codegen): --coverage phase 2 — block-execution coverage

### DIFF
--- a/src/sim_codegen/mod.rs
+++ b/src/sim_codegen/mod.rs
@@ -4665,6 +4665,14 @@ impl<'a> SimCodegen<'a> {
                 // Guard each seq block on its specific clock's rising edge
                 cpp.push_str(&format!("  if (_rising_{}) {{\n", rb.clock.name));
                 let base_indent: usize = 2;
+                // --coverage phase 2: count seq-block entries (rising
+                // edges seen). One counter per top-level seq block;
+                // catches dead clock domains where branch coverage
+                // shows 0/0 trivially.
+                if let Some(reg) = cov_handle {
+                    let idx = reg.borrow_mut().alloc("seq", rb.span.start, format!("seq @{}", rb.clock.name));
+                    cpp.push_str(&format!("{}_arch_cov[{idx}]++;\n", "  ".repeat(base_indent)));
+                }
 
                 if let Some((rst_name, _is_async, is_low)) = &reset_sig {
                     let cond = if *is_low { format!("(!{})", rst_name) } else { rst_name.clone() };
@@ -5167,6 +5175,15 @@ impl<'a> SimCodegen<'a> {
         for item in &m.body {
             if let ModuleBodyItem::CombBlock(cb) = item {
                 let mut body = String::new();
+                // --coverage phase 2: count comb-block entries (eval_comb
+                // calls per block). Caveat: comb blocks may evaluate
+                // multiple times per cycle during the settle loop, so
+                // counters reflect "block evaluations" rather than
+                // "cycles where block was active".
+                if let Some(reg) = cov_handle {
+                    let idx = reg.borrow_mut().alloc("comb", cb.span.start, "comb".to_string());
+                    body.push_str(&format!("  _arch_cov[{idx}]++;\n"));
+                }
                 emit_comb_stmts(&cb.stmts, &ctx_comb, &mut body, 1);
                 cpp.push_str(&body);
             }


### PR DESCRIPTION
## Summary
Phase 2 of the rollout (#131; revised in #133): one counter per top-level seq/comb block, incremented on every entry. Catches the gap branch coverage misses — a seq or comb block with no branches where you'd want to know "did this block ever run?".

## Example
\`\`\`
[Vcache_mshr] branch coverage: 8/16 hit (50.0%)
  tests/cvdp/cache_mshr.arch:179 (seq):  13 hits
  tests/cvdp/cache_mshr.arch:130 (comb): 104 hits
  tests/cvdp/cache_mshr.arch:146 (comb): 104 hits
  tests/cvdp/cache_mshr.arch:159 (comb): 104 hits
  ...
\`\`\`

If any of those block counters were 0, you'd know:
- the seq's clock domain never toggled, OR
- the module was never instantiated, OR
- the parent's \`eval_comb()\` never reached this comb (rare; means the comb DAG analysis bypassed it).

Comb counts reflect block *evaluations* per the parent's eval_comb settle loop (cache_mshr: ~13 ticks × ~8 settle iterations).

## Implementation
- **seq site**: when coverage handle is Some, alloc a \`seq\` CovPoint at the block's \`span.start\` and emit \`_arch_cov[N]++;\` right after the rising-edge guard.
- **comb site**: per \`CombBlock\`, alloc a \`comb\` CovPoint and emit \`_arch_cov[N]++;\` at the start of the per-block body.

Off-by-default — no \`--coverage\` means no instrumentation.

## Regressions clean
cam_basic 12/12, cam_value_basic 8/8, mac_table 9/9, inst_vec_port_regression 8/8.

## Stack
Builds on #135 → #134 → #132. Merge order: #132 → #133 (plan revision) → #134 → #135 → this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)