### PR TITLE
feat(sim_codegen): --coverage phase 4 — toggle coverage for scalar regs

### DIFF
--- a/src/sim_codegen/mod.rs
+++ b/src/sim_codegen/mod.rs
@@ -4770,6 +4770,25 @@ impl<'a> SimCodegen<'a> {
                 if vec_array_info(&rd.ty).is_some() {
                     cpp.push_str(&format!("  memcpy(_{n}, _n_{n}, sizeof(_{n}));\n"));
                 } else {
+                    // --coverage phase 4: toggle counter — popcount of
+                    // (prev XOR new) sums all bits that flipped this
+                    // posedge. Skip Vec / wide regs in v1 (Vec needs
+                    // per-element handling; wide needs split popcount).
+                    // Skip enums — toggle on a state reg is mostly
+                    // noise, FSM coverage is more useful there.
+                    if let Some(reg) = cov_handle {
+                        let bits = type_bits_te(&rd.ty);
+                        if bits > 0 && bits <= 64 && !matches!(rd.ty, TypeExpr::Named(_)) {
+                            let cidx = reg.borrow_mut().alloc(
+                                "toggle",
+                                rd.name.span.start,
+                                format!("toggle {n}"),
+                            );
+                            cpp.push_str(&format!(
+                                "  _arch_cov[{cidx}] += __builtin_popcountll((uint64_t)_{n} ^ (uint64_t)_n_{n});\n"
+                            ));
+                        }
+                    }
                     cpp.push_str(&format!("  _{n} = _n_{n};\n"));
                 }
             }


### PR DESCRIPTION
## Summary
Per-signal bit-toggle counter, summed across all bits per posedge. Catches "this register is reset and never updated" patterns that branch / block / FSM coverage all miss because the dead-write site might still be syntactically reachable in a never-executed path.

## Implementation
At the commit step in eval_posedge (\`_<n> = _n_<n>;\`), for each scalar reg the codegen now also emits:
\`\`\`c++
_arch_cov[N] += __builtin_popcountll((uint64_t)_<n> ^ (uint64_t)_n_<n>);
\`\`\`
before the assignment. Same per-class \`_arch_cov\` array as the other coverage kinds; same atexit dumper.

## Scope (v1)
- Scalar UInt/SInt/Bool regs only.
- Skip Vec regs (each element would need its own counter; future phase 4b if needed).
- Skip wide regs (>64 bits — popcount needs split across words).
- Skip enum-typed regs — toggle on a state reg is mostly noise; FSM coverage already gives state/transition signal.
- Skip ports (externally driven; toggle there reflects testbench activity, not design coverage).

## Smoke (cache_mshr with mini TB)
Toggle counters for the 5 scalar regs:
\`\`\`
  allocate_id_r:      0 hits  ← never updated (latent sim bug from #135)
  allocate_pending_r: 7 hits
  allocate_previd_r:  0 hits  ← real diagnostic signal
  dq_valid_r:         2 hits
  dq_idx_r:           0 hits  ← TB only exercised one fill cycle
\`\`\`

## Off-by-default
The popcount runs only when \`--coverage\` is on; the bare register commit is byte-identical to before.

## Regressions clean
cam_basic 12/12, cam_value_basic 8/8, mac_table 9/9, inst_vec_port_regression 8/8.

## Stack
#137 → #136 → #135 → #134 → #132. Merge order: #132 → #133 → #134 → #135 → #136 → #137 → this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)