### PR TITLE
feat(sim_codegen): --coverage phase 5 — Verilator-compatible coverage.dat

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -122,6 +122,13 @@ enum Command {
         /// (branch → line → FSM → toggle → Verilator-compatible coverage.dat).
         #[arg(long)]
         coverage: bool,
+        /// Also emit a Verilator-compatible coverage.dat alongside the stderr
+        /// report. Path defaults to `coverage.dat` in the cwd; pass a value to
+        /// override (e.g. --coverage-dat=build/cov.dat). Implies --coverage.
+        /// Output is consumed by `verilator_coverage --annotate-min 1
+        /// --annotate annot/ <file>`.
+        #[arg(long)]
+        coverage_dat: Option<Option<String>>,
         /// Generate pybind11 Python module for cocotb-compatible testing
         #[arg(long)]
         pybind: bool,
@@ -340,12 +347,17 @@ fn main() -> miette::Result<()> {
             }
             Ok(())
         }
-        Command::Sim { arch_files, tb_files, outdir, check_uninit, inputs_start_uninit, check_uninit_ram, cdc_random, wave, debug, debug_depth, debug_fsm, coverage, pybind, test, pybind_module_name } => {
+        Command::Sim { arch_files, tb_files, outdir, check_uninit, inputs_start_uninit, check_uninit_ram, cdc_random, wave, debug, debug_depth, debug_fsm, coverage, coverage_dat, pybind, test, pybind_module_name } => {
             let dbg_ports = debug || debug_fsm;  // any debug option implies port logging
             // --inputs-start-uninit and --check-uninit-ram both imply --check-uninit
             let check_uninit = check_uninit || inputs_start_uninit || check_uninit_ram;
+            // --coverage-dat resolves to a path: explicit --coverage-dat=foo
+            // → Some(Some("foo")) → "foo"; bare --coverage-dat
+            // → Some(None) → default "coverage.dat"; absent → None.
+            let cov_dat_path: Option<String> = coverage_dat.map(|opt| opt.unwrap_or_else(|| "coverage.dat".to_string()));
+            let coverage = coverage || cov_dat_path.is_some();
             learn_wrap(&arch_files, || {
-                run_sim(&arch_files, &tb_files, outdir.as_deref(), check_uninit, inputs_start_uninit, check_uninit_ram, cdc_random, wave.as_deref(), dbg_ports, debug_depth, debug_fsm, coverage, pybind, test.as_deref(), pybind_module_name.as_deref())
+                run_sim(&arch_files, &tb_files, outdir.as_deref(), check_uninit, inputs_start_uninit, check_uninit_ram, cdc_random, wave.as_deref(), dbg_ports, debug_depth, debug_fsm, coverage, cov_dat_path.clone(), pybind, test.as_deref(), pybind_module_name.as_deref())
             })
         }
         Command::Build { files, o } => {
@@ -465,6 +477,7 @@ fn run_sim(
     debug_depth: u32,
     debug_fsm: bool,
     coverage: bool,
+    coverage_dat: Option<String>,
     pybind: bool,
     test_file: Option<&std::path::Path>,
     pybind_module_name_override: Option<&str>,
@@ -481,7 +494,7 @@ fn run_sim(
     fs::create_dir_all(&build_dir).into_diagnostic()?;
 
     // 3. Generate C++ models
-    let mut sim = SimCodegen::new(&symbols, &ast, overload_map).check_uninit(check_uninit).inputs_start_uninit(inputs_start_uninit).check_uninit_ram(check_uninit_ram).cdc_random(cdc_random).debug(debug, debug_depth).with_debug_fsm(debug_fsm).coverage(coverage);
+    let mut sim = SimCodegen::new(&symbols, &ast, overload_map).check_uninit(check_uninit).inputs_start_uninit(inputs_start_uninit).check_uninit_ram(check_uninit_ram).cdc_random(cdc_random).debug(debug, debug_depth).with_debug_fsm(debug_fsm).coverage(coverage).coverage_dat(coverage_dat);
     if coverage {
         // Build a SourceMap so the coverage dumper can render
         // file:line instead of opaque branch[N] ordinals.

--- a/src/sim_codegen/fsm.rs
+++ b/src/sim_codegen/fsm.rs
@@ -452,11 +452,22 @@ impl<'a> SimCodegen<'a> {
             cpp.push_str(&format!("  uint64_t total = 0; uint64_t hit = 0;\n"));
             cpp.push_str(&format!("  for (uint32_t i = 0; i < {n_cov}; i++) {{ total++; if ({class}::_arch_cov[i]) hit++; }}\n"));
             cpp.push_str(&format!("  fprintf(stderr, \"[{class}] FSM coverage: %llu/%llu hit (%.1f%%)\\n\", (unsigned long long)hit, (unsigned long long)total, total ? (100.0 * hit / total) : 0.0);\n"));
+            // --coverage-dat: also append per-point Verilator-compatible
+            // lines for the FSM coverage points.
+            if let Some(path) = &self.coverage_dat {
+                let path_lit = path.replace('\\', "\\\\").replace('"', "\\\"");
+                cpp.push_str(&format!("  FILE* _dat = _arch_cov_dat_open(\"{path_lit}\");\n"));
+            }
             for (i, p) in cov_reg.borrow().points.iter().enumerate() {
-                let location = if let Some(sm) = &self.source_map {
+                let (file_disp, line_no) = if let Some(sm) = &self.source_map {
                     sm.locate(p.span_start)
-                        .map(|(file, line)| format!("{}:{}", file, line))
-                        .unwrap_or_else(|| format!("point[{i}]"))
+                        .map(|(f, l)| (f.to_string(), l))
+                        .unwrap_or_else(|| (String::new(), 0))
+                } else {
+                    (String::new(), 0)
+                };
+                let location = if !file_disp.is_empty() {
+                    format!("{file_disp}:{line_no}")
                 } else {
                     format!("point[{i}]")
                 };
@@ -465,6 +476,20 @@ impl<'a> SimCodegen<'a> {
                     "  fprintf(stderr, \"  {location} ({}) [{label_escaped}]: %llu hits%s\\n\", (unsigned long long){class}::_arch_cov[{i}], {class}::_arch_cov[{i}] ? \"\" : \" *NOT HIT*\");\n",
                     p.kind
                 ));
+                if self.coverage_dat.is_some() && !file_disp.is_empty() {
+                    let file_esc = file_disp.replace('\\', "\\\\").replace('"', "\\\"");
+                    let page = match p.kind {
+                        "state" | "trans" => "v_user/fsm",
+                        _                 => "v_user",
+                    };
+                    cpp.push_str(&format!(
+                        "  if (_dat) fprintf(_dat, \"C '\" \"\\x01\" \"file\" \"\\x02\" \"{file_esc}\" \"\\x01\" \"line\" \"\\x02\" \"{line_no}\" \"\\x01\" \"page\" \"\\x02\" \"{page}\" \"\\x01\" \"comment\" \"\\x02\" \"{kind} {comment}\" \"' %llu\\n\", (unsigned long long){class}::_arch_cov[{i}]);\n",
+                        kind = p.kind, comment = label_escaped
+                    ));
+                }
+            }
+            if self.coverage_dat.is_some() {
+                cpp.push_str("  if (_dat) fclose(_dat);\n");
             }
             cpp.push_str("}\n");
             cpp.push_str("struct _ArchCovInit { _ArchCovInit() { atexit(_arch_cov_dump); } };\n");

--- a/src/sim_codegen/mod.rs
+++ b/src/sim_codegen/mod.rs
@@ -50,6 +50,10 @@ pub struct SimCodegen<'a> {
     debug_depth: u32,
     debug_fsm: bool,
     coverage: bool,
+    /// Phase 5: also write a Verilator-compatible coverage.dat.
+    /// Implies --coverage. Filename comes via main.rs (defaults to
+    /// `coverage.dat` in cwd).
+    coverage_dat: Option<String>,
     /// Optional source map for resolving span byte offsets to
     /// (file:line). Populated by main.rs from MultiSource when
     /// --coverage is enabled.
@@ -128,11 +132,17 @@ impl<'a> SimCodegen<'a> {
         source: &'a SourceFile,
         overload_map: HashMap<usize, usize>,
     ) -> Self {
-        Self { symbols, source, overload_map, check_uninit: false, inputs_start_uninit: false, check_uninit_ram: false, cdc_random: false, debug: false, debug_depth: 1, debug_fsm: false, coverage: false, source_map: None }
+        Self { symbols, source, overload_map, check_uninit: false, inputs_start_uninit: false, check_uninit_ram: false, cdc_random: false, debug: false, debug_depth: 1, debug_fsm: false, coverage: false, coverage_dat: None, source_map: None }
     }
 
     pub fn coverage(mut self, enabled: bool) -> Self {
         self.coverage = enabled;
+        self
+    }
+
+    pub fn coverage_dat(mut self, path: Option<String>) -> Self {
+        self.coverage_dat = path;
+        if self.coverage_dat.is_some() { self.coverage = true; }
         self
     }
 
@@ -593,6 +603,12 @@ r#"        .def_property("{field}",
 #include <cstdlib>
 #include <cstring>
 
+// --coverage-dat: forward declaration for the helper defined in
+// verilated.cpp. Each class's atexit dumper calls this to get a
+// FILE* opened for append (with the header line written once on
+// first call).
+extern "C" FILE* _arch_cov_dat_open(const char* path);
+
 /// Minimal Verilated compatibility shim for arch-generated C++ simulation models.
 class Verilated {
 public:
@@ -766,11 +782,29 @@ static inline uint64_t _arch_repeat(uint64_t val, uint32_t n, uint32_t val_width
     }
 
     pub fn verilated_cpp() -> String {
-        r#"#include "verilated.h"
+        r##"#include "verilated.h"
+#include <cstdio>
+#include <cstdlib>
 int Verilated::_s_verbosity = 1;
 const char* Verilated::_s_trace_file = nullptr;
 bool Verilated::_s_trace_claimed = false;
-"#.to_string()
+
+// --coverage-dat: Verilator-compatible coverage.dat writer. Each
+// class's atexit dumper calls _arch_cov_dat_open() to get a FILE*
+// opened for append; the first call writes the header line so
+// verilator_coverage --annotate parses cleanly. Subsequent calls
+// just append their point lines.
+extern "C" FILE* _arch_cov_dat_open(const char* path) {
+    static bool _header_written = false;
+    FILE* f = fopen(path, _header_written ? "a" : "w");
+    if (!f) return nullptr;
+    if (!_header_written) {
+        fprintf(f, "# SystemC::Coverage-3\n");
+        _header_written = true;
+    }
+    return f;
+}
+"##.to_string()
     }
 }
 
@@ -5450,11 +5484,22 @@ impl<'a> SimCodegen<'a> {
             // ordinal-only fallback otherwise. (Phase 1b lands the
             // source-text plumbing so the dump shows
             // `tests/cvdp/cache_mshr.arch:111` instead of `branch[0]`.)
+            // --coverage-dat: also append per-point Verilator-compatible
+            // lines to the coverage.dat file.
+            if let Some(path) = &self.coverage_dat {
+                let path_lit = path.replace('\\', "\\\\").replace('"', "\\\"");
+                cpp.push_str(&format!("  FILE* _dat = _arch_cov_dat_open(\"{path_lit}\");\n"));
+            }
             for (i, p) in cov_reg.borrow().points.iter().enumerate() {
-                let location = if let Some(sm) = &self.source_map {
+                let (file_disp, line_no) = if let Some(sm) = &self.source_map {
                     sm.locate(p.span_start)
-                        .map(|(f, l)| format!("{}:{}", f, l))
-                        .unwrap_or_else(|| format!("branch[{i}]"))
+                        .map(|(f, l)| (f.to_string(), l))
+                        .unwrap_or_else(|| (String::new(), 0))
+                } else {
+                    (String::new(), 0)
+                };
+                let location = if !file_disp.is_empty() {
+                    format!("{file_disp}:{line_no}")
                 } else {
                     format!("branch[{i}]")
                 };
@@ -5462,6 +5507,28 @@ impl<'a> SimCodegen<'a> {
                     "  fprintf(stderr, \"  {location} ({}): %llu hits%s\\n\", (unsigned long long){class}::_arch_cov[{i}], {class}::_arch_cov[{i}] ? \"\" : \" *NOT HIT*\");\n",
                     p.kind
                 ));
+                if self.coverage_dat.is_some() && !file_disp.is_empty() {
+                    let file_esc = file_disp.replace('\\', "\\\\").replace('"', "\\\"");
+                    let page = match p.kind {
+                        "if" | "elsif" | "else" => "v_branch",
+                        "seq" | "comb"          => "v_line",
+                        "state" | "trans"       => "v_user/fsm",
+                        "toggle"                => "v_toggle",
+                        _                       => "v_user",
+                    };
+                    let comment = p.label.replace('\\', "\\\\").replace('"', "\\\"");
+                    // Verilator coverage.dat field separators are \x01 (key)
+                    // and \x02 (value). C++ greedy-matches hex escapes, so
+                    // each escape is its own string literal — adjacent
+                    // string concatenation joins them safely.
+                    cpp.push_str(&format!(
+                        "  if (_dat) fprintf(_dat, \"C '\" \"\\x01\" \"file\" \"\\x02\" \"{file_esc}\" \"\\x01\" \"line\" \"\\x02\" \"{line_no}\" \"\\x01\" \"page\" \"\\x02\" \"{page}\" \"\\x01\" \"comment\" \"\\x02\" \"{kind} {comment}\" \"' %llu\\n\", (unsigned long long){class}::_arch_cov[{i}]);\n",
+                        kind = p.kind
+                    ));
+                }
+            }
+            if self.coverage_dat.is_some() {
+                cpp.push_str("  if (_dat) fclose(_dat);\n");
             }
             cpp.push_str("}\n");
             cpp.push_str("struct _ArchCovInit { _ArchCovInit() { atexit(_arch_cov_dump); } };\n");


### PR DESCRIPTION
## Summary
Opt-in \`--coverage-dat[=PATH]\` flag that, in addition to the stderr text dump from phases 1-4, appends a Verilator-compatible \`coverage.dat\`. Output is consumed by \`verilator_coverage --annotate-min 1 --annotate annot/ <file>\` so users with an existing tooling chain get HTML-annotated source for free.

## Format
Header emitted once per process by a shared helper in \`verilated.cpp\` (\`_arch_cov_dat_open\`) — first writer truncates and prints \`# SystemC::Coverage-3\`, subsequent writers open for append.

Per coverage point: \`C '\x01file\x02<path>\x01line\x02<n>\x01page\x02<page>\x01comment\x02<kind> <label>' <count>\`.

Pages map to Verilator categories:
| arch coverage kind | Verilator page |
|---|---|
| if / elsif / else | \`v_branch\` |
| seq / comb | \`v_line\` |
| state / trans | \`v_user/fsm\` |
| toggle | \`v_toggle\` |

## C++ hex escape gotcha
C++ greedy-matches hex escapes (\`\x01file\` reads as one escape consuming 'file'). Worked around by emitting each escape as its own string literal: \`"\x01" "file" "\x02" "..."\` — adjacent string concatenation joins them safely.

## CLI shape
\`\`\`
--coverage              stderr text dump only (phases 1-4)
--coverage-dat=path     text dump + write coverage.dat to <path>
                        (implies --coverage)
--coverage-dat          same with default path "coverage.dat"
\`\`\`

## Smoke (cache_mshr)
\`\`\`
$ arch sim --coverage-dat=coverage.dat tests/cvdp/cache_mshr.arch --tb mini.cpp
$ head -5 coverage.dat | cat -v
# SystemC::Coverage-3
C '^Afile^Btests/cvdp/cache_mshr.arch^Aline^B179^Apage^Bv_line^Acomment^Bseq seq @clk' 13
C '^Afile^Btests/cvdp/cache_mshr.arch^Aline^B186^Apage^Bv_branch^Acomment^Bif ' 1
C '^Afile^Btests/cvdp/cache_mshr.arch^Aline^B189^Apage^Bv_branch^Acomment^Belsif ' 1
C '^Afile^Btests/cvdp/cache_mshr.arch^Aline^B190^Apage^Bv_branch^Acomment^Bif ' 0
\`\`\`

\`\x01\` (^A) and \`\x02\` (^B) separators present; format parses cleanly.

## Off-by-default
\`.dat\` write happens only when \`--coverage-dat\` is set. Existing tests without the flag: byte-identical SimModel output.

## Stack
#138 → #137 → #136 → #135 → #134 → #132. Final coverage rollout PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)