### PR TITLE
feat(sim_codegen): --coverage phases 1b-5 (rebased onto main)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -481,7 +481,15 @@ fn run_sim(
     fs::create_dir_all(&build_dir).into_diagnostic()?;
 
     // 3. Generate C++ models
-    let sim = SimCodegen::new(&symbols, &ast, overload_map).check_uninit(check_uninit).inputs_start_uninit(inputs_start_uninit).check_uninit_ram(check_uninit_ram).cdc_random(cdc_random).debug(debug, debug_depth).with_debug_fsm(debug_fsm).coverage(coverage);
+    let mut sim = SimCodegen::new(&symbols, &ast, overload_map).check_uninit(check_uninit).inputs_start_uninit(inputs_start_uninit).check_uninit_ram(check_uninit_ram).cdc_random(cdc_random).debug(debug, debug_depth).with_debug_fsm(debug_fsm).coverage(coverage);
+    if coverage {
+        // Build a SourceMap so the coverage dumper can render
+        // file:line instead of opaque branch[N] ordinals.
+        let segs: Vec<(usize, String, String)> = ms.segments.iter()
+            .map(|(start, _end, name, src)| (*start, name.clone(), src.clone()))
+            .collect();
+        sim = sim.with_source_map(arch::sim_codegen::SourceMap::new(segs));
+    }
     let models = sim.generate();
 
     if models.is_empty() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -122,6 +122,13 @@ enum Command {
         /// (branch → line → FSM → toggle → Verilator-compatible coverage.dat).
         #[arg(long)]
         coverage: bool,
+        /// Also emit a Verilator-compatible coverage.dat alongside the stderr
+        /// report. Path defaults to `coverage.dat` in the cwd; pass a value to
+        /// override (e.g. --coverage-dat=build/cov.dat). Implies --coverage.
+        /// Output is consumed by `verilator_coverage --annotate-min 1
+        /// --annotate annot/ <file>`.
+        #[arg(long)]
+        coverage_dat: Option<Option<String>>,
         /// Generate pybind11 Python module for cocotb-compatible testing
         #[arg(long)]
         pybind: bool,
@@ -340,12 +347,17 @@ fn main() -> miette::Result<()> {
             }
             Ok(())
         }
-        Command::Sim { arch_files, tb_files, outdir, check_uninit, inputs_start_uninit, check_uninit_ram, cdc_random, wave, debug, debug_depth, debug_fsm, coverage, pybind, test, pybind_module_name } => {
+        Command::Sim { arch_files, tb_files, outdir, check_uninit, inputs_start_uninit, check_uninit_ram, cdc_random, wave, debug, debug_depth, debug_fsm, coverage, coverage_dat, pybind, test, pybind_module_name } => {
             let dbg_ports = debug || debug_fsm;  // any debug option implies port logging
             // --inputs-start-uninit and --check-uninit-ram both imply --check-uninit
             let check_uninit = check_uninit || inputs_start_uninit || check_uninit_ram;
+            // --coverage-dat resolves to a path: explicit --coverage-dat=foo
+            // → Some(Some("foo")) → "foo"; bare --coverage-dat
+            // → Some(None) → default "coverage.dat"; absent → None.
+            let cov_dat_path: Option<String> = coverage_dat.map(|opt| opt.unwrap_or_else(|| "coverage.dat".to_string()));
+            let coverage = coverage || cov_dat_path.is_some();
             learn_wrap(&arch_files, || {
-                run_sim(&arch_files, &tb_files, outdir.as_deref(), check_uninit, inputs_start_uninit, check_uninit_ram, cdc_random, wave.as_deref(), dbg_ports, debug_depth, debug_fsm, coverage, pybind, test.as_deref(), pybind_module_name.as_deref())
+                run_sim(&arch_files, &tb_files, outdir.as_deref(), check_uninit, inputs_start_uninit, check_uninit_ram, cdc_random, wave.as_deref(), dbg_ports, debug_depth, debug_fsm, coverage, cov_dat_path.clone(), pybind, test.as_deref(), pybind_module_name.as_deref())
             })
         }
         Command::Build { files, o } => {
@@ -465,6 +477,7 @@ fn run_sim(
     debug_depth: u32,
     debug_fsm: bool,
     coverage: bool,
+    coverage_dat: Option<String>,
     pybind: bool,
     test_file: Option<&std::path::Path>,
     pybind_module_name_override: Option<&str>,
@@ -481,7 +494,7 @@ fn run_sim(
     fs::create_dir_all(&build_dir).into_diagnostic()?;
 
     // 3. Generate C++ models
-    let mut sim = SimCodegen::new(&symbols, &ast, overload_map).check_uninit(check_uninit).inputs_start_uninit(inputs_start_uninit).check_uninit_ram(check_uninit_ram).cdc_random(cdc_random).debug(debug, debug_depth).with_debug_fsm(debug_fsm).coverage(coverage);
+    let mut sim = SimCodegen::new(&symbols, &ast, overload_map).check_uninit(check_uninit).inputs_start_uninit(inputs_start_uninit).check_uninit_ram(check_uninit_ram).cdc_random(cdc_random).debug(debug, debug_depth).with_debug_fsm(debug_fsm).coverage(coverage).coverage_dat(coverage_dat);
     if coverage {
         // Build a SourceMap so the coverage dumper can render
         // file:line instead of opaque branch[N] ordinals.

--- a/src/sim_codegen/fsm.rs
+++ b/src/sim_codegen/fsm.rs
@@ -452,11 +452,22 @@ impl<'a> SimCodegen<'a> {
             cpp.push_str(&format!("  uint64_t total = 0; uint64_t hit = 0;\n"));
             cpp.push_str(&format!("  for (uint32_t i = 0; i < {n_cov}; i++) {{ total++; if ({class}::_arch_cov[i]) hit++; }}\n"));
             cpp.push_str(&format!("  fprintf(stderr, \"[{class}] FSM coverage: %llu/%llu hit (%.1f%%)\\n\", (unsigned long long)hit, (unsigned long long)total, total ? (100.0 * hit / total) : 0.0);\n"));
+            // --coverage-dat: also append per-point Verilator-compatible
+            // lines for the FSM coverage points.
+            if let Some(path) = &self.coverage_dat {
+                let path_lit = path.replace('\\', "\\\\").replace('"', "\\\"");
+                cpp.push_str(&format!("  FILE* _dat = _arch_cov_dat_open(\"{path_lit}\");\n"));
+            }
             for (i, p) in cov_reg.borrow().points.iter().enumerate() {
-                let location = if let Some(sm) = &self.source_map {
+                let (file_disp, line_no) = if let Some(sm) = &self.source_map {
                     sm.locate(p.span_start)
-                        .map(|(file, line)| format!("{}:{}", file, line))
-                        .unwrap_or_else(|| format!("point[{i}]"))
+                        .map(|(f, l)| (f.to_string(), l))
+                        .unwrap_or_else(|| (String::new(), 0))
+                } else {
+                    (String::new(), 0)
+                };
+                let location = if !file_disp.is_empty() {
+                    format!("{file_disp}:{line_no}")
                 } else {
                     format!("point[{i}]")
                 };
@@ -465,6 +476,20 @@ impl<'a> SimCodegen<'a> {
                     "  fprintf(stderr, \"  {location} ({}) [{label_escaped}]: %llu hits%s\\n\", (unsigned long long){class}::_arch_cov[{i}], {class}::_arch_cov[{i}] ? \"\" : \" *NOT HIT*\");\n",
                     p.kind
                 ));
+                if self.coverage_dat.is_some() && !file_disp.is_empty() {
+                    let file_esc = file_disp.replace('\\', "\\\\").replace('"', "\\\"");
+                    let page = match p.kind {
+                        "state" | "trans" => "v_user/fsm",
+                        _                 => "v_user",
+                    };
+                    cpp.push_str(&format!(
+                        "  if (_dat) fprintf(_dat, \"C '\" \"\\x01\" \"file\" \"\\x02\" \"{file_esc}\" \"\\x01\" \"line\" \"\\x02\" \"{line_no}\" \"\\x01\" \"page\" \"\\x02\" \"{page}\" \"\\x01\" \"comment\" \"\\x02\" \"{kind} {comment}\" \"' %llu\\n\", (unsigned long long){class}::_arch_cov[{i}]);\n",
+                        kind = p.kind, comment = label_escaped
+                    ));
+                }
+            }
+            if self.coverage_dat.is_some() {
+                cpp.push_str("  if (_dat) fclose(_dat);\n");
             }
             cpp.push_str("}\n");
             cpp.push_str("struct _ArchCovInit { _ArchCovInit() { atexit(_arch_cov_dump); } };\n");

--- a/src/sim_codegen/fsm.rs
+++ b/src/sim_codegen/fsm.rs
@@ -16,6 +16,14 @@ impl<'a> SimCodegen<'a> {
         let class = format!("V{name}");
         let enum_map = build_enum_map(self.symbols);
 
+        // --coverage phase 3: per-state and per-transition counter
+        // registry. Same pattern as gen_module: emit `_arch_cov[N]++;`
+        // at each state's case body (state-entry coverage) and at each
+        // transition's `if (cond) ...` (transition-arc coverage).
+        let cov_reg: std::cell::RefCell<CoverageRegistry> = std::cell::RefCell::new(CoverageRegistry::default());
+        let cov_handle: Option<&std::cell::RefCell<CoverageRegistry>> =
+            if self.coverage { Some(&cov_reg) } else { None };
+
         // Collect bus port names and flattened signals (same pattern as gen_module)
         let mut bus_port_names: HashSet<String> = HashSet::new();
         let mut bus_flat: Vec<(String, TypeExpr)> = Vec::new();
@@ -299,6 +307,14 @@ impl<'a> SimCodegen<'a> {
         for sb in &f.states {
             let idx = state_idx.get(&sb.name.name).copied().unwrap_or(0);
             cpp.push_str(&format!("      case {idx}: // {}\n", sb.name.name));
+            // --coverage: state-entry counter (per posedge that
+            // dispatched into this state's case). 0 hits means the
+            // state was never entered — useful for unreachable-state
+            // diagnostics.
+            if let Some(reg) = cov_handle {
+                let cidx = reg.borrow_mut().alloc("state", sb.name.span.start, format!("state {}", sb.name.name));
+                cpp.push_str(&format!("        _arch_cov[{cidx}]++;\n"));
+            }
             // Emit seq_stmts for this state
             for stmt in &sb.seq_stmts {
                 let mut body = String::new();
@@ -308,18 +324,30 @@ impl<'a> SimCodegen<'a> {
             for tr in &sb.transitions {
                 let cond = cpp_expr(&tr.condition, &ctx_fsm);
                 let target_idx = state_idx.get(&tr.target.name).copied().unwrap_or(0);
+                // --coverage: per-transition counter. The bump is
+                // inside the `if (cond) { ... }` so it only increments
+                // when the arc is actually taken (not on every
+                // condition evaluation).
+                let cov_bump = if let Some(reg) = cov_handle {
+                    let cidx = reg.borrow_mut().alloc(
+                        "trans",
+                        tr.condition.span.start,
+                        format!("trans {} -> {}", sb.name.name, tr.target.name),
+                    );
+                    format!("_arch_cov[{cidx}]++; ")
+                } else { String::new() };
                 if self.debug_fsm {
                     // Escape the condition for printf literal
                     let cond_escaped = cond.replace('\\', "\\\\").replace('"', "\\\"").replace('%', "%%");
                     cpp.push_str(&format!(
-                        "        if ({cond}) {{ _n_state = {target_idx}; \
+                        "        if ({cond}) {{ {cov_bump}_n_state = {target_idx}; \
                          printf(\"[FSM][{name}] {src} -> {tgt} ({cond_lit})\\n\"); break; }}\n",
                         src = sb.name.name,
                         tgt = tr.target.name,
                         cond_lit = cond_escaped,
                     ));
                 } else {
-                    cpp.push_str(&format!("        if ({cond}) {{ _n_state = {target_idx}; break; }}\n"));
+                    cpp.push_str(&format!("        if ({cond}) {{ {cov_bump}_n_state = {target_idx}; break; }}\n"));
                 }
             }
             cpp.push_str("        break;\n");
@@ -410,6 +438,40 @@ impl<'a> SimCodegen<'a> {
             .map(|(n, e, w)| (n.as_str(), e.as_str(), *w))
             .collect();
         add_trace_to_simple_construct(&mut h, &mut cpp, &class, name, &f.ports, &extra_sigs_ref);
+
+        // --coverage: per-FSM counter storage + atexit dumper. Same
+        // shape as gen_module's coverage emission (#132/#134).
+        let n_cov = cov_reg.borrow().points.len();
+        if self.coverage && n_cov > 0 {
+            h.push_str(&format!("public:\n  static uint64_t _arch_cov[{n_cov}];\n  static bool _arch_cov_dumped;\n"));
+            cpp.push_str(&format!("uint64_t {class}::_arch_cov[{n_cov}] = {{}};\nbool {class}::_arch_cov_dumped = false;\n\n"));
+            cpp.push_str("namespace {\n");
+            cpp.push_str("static void _arch_cov_dump() {\n");
+            cpp.push_str(&format!("  if ({class}::_arch_cov_dumped) return;\n"));
+            cpp.push_str(&format!("  {class}::_arch_cov_dumped = true;\n"));
+            cpp.push_str(&format!("  uint64_t total = 0; uint64_t hit = 0;\n"));
+            cpp.push_str(&format!("  for (uint32_t i = 0; i < {n_cov}; i++) {{ total++; if ({class}::_arch_cov[i]) hit++; }}\n"));
+            cpp.push_str(&format!("  fprintf(stderr, \"[{class}] FSM coverage: %llu/%llu hit (%.1f%%)\\n\", (unsigned long long)hit, (unsigned long long)total, total ? (100.0 * hit / total) : 0.0);\n"));
+            for (i, p) in cov_reg.borrow().points.iter().enumerate() {
+                let location = if let Some(sm) = &self.source_map {
+                    sm.locate(p.span_start)
+                        .map(|(file, line)| format!("{}:{}", file, line))
+                        .unwrap_or_else(|| format!("point[{i}]"))
+                } else {
+                    format!("point[{i}]")
+                };
+                let label_escaped = p.label.replace('"', "\\\"");
+                cpp.push_str(&format!(
+                    "  fprintf(stderr, \"  {location} ({}) [{label_escaped}]: %llu hits%s\\n\", (unsigned long long){class}::_arch_cov[{i}], {class}::_arch_cov[{i}] ? \"\" : \" *NOT HIT*\");\n",
+                    p.kind
+                ));
+            }
+            cpp.push_str("}\n");
+            cpp.push_str("struct _ArchCovInit { _ArchCovInit() { atexit(_arch_cov_dump); } };\n");
+            cpp.push_str("static _ArchCovInit _arch_cov_init;\n");
+            cpp.push_str("} // namespace\n\n");
+        }
+
         h.push_str("};\n");
 
         SimModel { class_name: class, header: h, impl_: cpp }

--- a/src/sim_codegen/mod.rs
+++ b/src/sim_codegen/mod.rs
@@ -50,6 +50,46 @@ pub struct SimCodegen<'a> {
     debug_depth: u32,
     debug_fsm: bool,
     coverage: bool,
+    /// Optional source map for resolving span byte offsets to
+    /// (file:line). Populated by main.rs from MultiSource when
+    /// --coverage is enabled.
+    source_map: Option<SourceMap>,
+}
+
+/// Maps byte offsets in the concatenated source (as produced by
+/// `MultiSource::from_files` in `main.rs`) back to (file_path,
+/// 1-based line number). Used by --coverage to render
+/// `cache_mshr.arch:111` instead of opaque `branch[3]` ordinals.
+#[derive(Debug, Default, Clone)]
+pub struct SourceMap {
+    /// (start_offset_in_combined, file_path, source_text). Sorted by
+    /// start_offset; segments may have padding bytes between them.
+    segments: Vec<(usize, String, String)>,
+}
+
+impl SourceMap {
+    pub fn new(segments: Vec<(usize, String, String)>) -> Self {
+        let mut s = segments;
+        s.sort_by_key(|(start, _, _)| *start);
+        Self { segments: s }
+    }
+
+    /// Resolve a byte offset → (file_path, 1-based line). Returns None
+    /// when the offset doesn't fall inside any registered segment
+    /// (defensive — well-formed AST spans should always resolve).
+    pub fn locate(&self, offset: usize) -> Option<(&str, u32)> {
+        for i in 0..self.segments.len() {
+            let (start, file, src) = &self.segments[i];
+            let next_start = self.segments.get(i + 1).map(|s| s.0).unwrap_or(usize::MAX);
+            if offset >= *start && offset < next_start {
+                let local = offset.saturating_sub(*start);
+                if local > src.len() { return None; }
+                let line = 1 + src[..local].matches('\n').count() as u32;
+                return Some((file.as_str(), line));
+            }
+        }
+        None
+    }
 }
 
 /// One coverage point recorded during gen_module. Currently only branch
@@ -88,11 +128,16 @@ impl<'a> SimCodegen<'a> {
         source: &'a SourceFile,
         overload_map: HashMap<usize, usize>,
     ) -> Self {
-        Self { symbols, source, overload_map, check_uninit: false, inputs_start_uninit: false, check_uninit_ram: false, cdc_random: false, debug: false, debug_depth: 1, debug_fsm: false, coverage: false }
+        Self { symbols, source, overload_map, check_uninit: false, inputs_start_uninit: false, check_uninit_ram: false, cdc_random: false, debug: false, debug_depth: 1, debug_fsm: false, coverage: false, source_map: None }
     }
 
     pub fn coverage(mut self, enabled: bool) -> Self {
         self.coverage = enabled;
+        self
+    }
+
+    pub fn with_source_map(mut self, sm: SourceMap) -> Self {
+        self.source_map = Some(sm);
         self
     }
 
@@ -5358,13 +5403,20 @@ impl<'a> SimCodegen<'a> {
             cpp.push_str(&format!("  uint64_t total = 0; uint64_t hit = 0;\n"));
             cpp.push_str(&format!("  for (uint32_t i = 0; i < {n_cov}; i++) {{ total++; if ({class}::_arch_cov[i]) hit++; }}\n"));
             cpp.push_str(&format!("  fprintf(stderr, \"[{class}] branch coverage: %llu/%llu hit (%.1f%%)\\n\", (unsigned long long)hit, (unsigned long long)total, total ? (100.0 * hit / total) : 0.0);\n"));
-            // Per-arm breakdown — one line per counter, kind ordinal only
-            // (file:line resolution is phase 1b once the source-text plumbing
-            // is in place; for now the user maps ordinal → branch by the
-            // alloc-order, which is left-to-right top-to-bottom).
+            // Per-arm breakdown — file:line if a SourceMap is available,
+            // ordinal-only fallback otherwise. (Phase 1b lands the
+            // source-text plumbing so the dump shows
+            // `tests/cvdp/cache_mshr.arch:111` instead of `branch[0]`.)
             for (i, p) in cov_reg.borrow().points.iter().enumerate() {
+                let location = if let Some(sm) = &self.source_map {
+                    sm.locate(p.span_start)
+                        .map(|(f, l)| format!("{}:{}", f, l))
+                        .unwrap_or_else(|| format!("branch[{i}]"))
+                } else {
+                    format!("branch[{i}]")
+                };
                 cpp.push_str(&format!(
-                    "  fprintf(stderr, \"  branch[{i}] ({}): %llu hits%s\\n\", (unsigned long long){class}::_arch_cov[{i}], {class}::_arch_cov[{i}] ? \"\" : \" *NOT HIT*\");\n",
+                    "  fprintf(stderr, \"  {location} ({}): %llu hits%s\\n\", (unsigned long long){class}::_arch_cov[{i}], {class}::_arch_cov[{i}] ? \"\" : \" *NOT HIT*\");\n",
                     p.kind
                 ));
             }

--- a/src/sim_codegen/mod.rs
+++ b/src/sim_codegen/mod.rs
@@ -4674,6 +4674,14 @@ impl<'a> SimCodegen<'a> {
                 // Guard each seq block on its specific clock's rising edge
                 cpp.push_str(&format!("  if (_rising_{}) {{\n", rb.clock.name));
                 let base_indent: usize = 2;
+                // --coverage phase 2: count seq-block entries (rising
+                // edges seen). One counter per top-level seq block;
+                // catches dead clock domains where branch coverage
+                // shows 0/0 trivially.
+                if let Some(reg) = cov_handle {
+                    let idx = reg.borrow_mut().alloc("seq", rb.span.start, format!("seq @{}", rb.clock.name));
+                    cpp.push_str(&format!("{}_arch_cov[{idx}]++;\n", "  ".repeat(base_indent)));
+                }
 
                 if let Some((rst_name, _is_async, is_low)) = &reset_sig {
                     let cond = if *is_low { format!("(!{})", rst_name) } else { rst_name.clone() };
@@ -5176,6 +5184,15 @@ impl<'a> SimCodegen<'a> {
         for item in &m.body {
             if let ModuleBodyItem::CombBlock(cb) = item {
                 let mut body = String::new();
+                // --coverage phase 2: count comb-block entries (eval_comb
+                // calls per block). Caveat: comb blocks may evaluate
+                // multiple times per cycle during the settle loop, so
+                // counters reflect "block evaluations" rather than
+                // "cycles where block was active".
+                if let Some(reg) = cov_handle {
+                    let idx = reg.borrow_mut().alloc("comb", cb.span.start, "comb".to_string());
+                    body.push_str(&format!("  _arch_cov[{idx}]++;\n"));
+                }
                 emit_comb_stmts(&cb.stmts, &ctx_comb, &mut body, 1);
                 cpp.push_str(&body);
             }

--- a/src/sim_codegen/mod.rs
+++ b/src/sim_codegen/mod.rs
@@ -50,6 +50,10 @@ pub struct SimCodegen<'a> {
     debug_depth: u32,
     debug_fsm: bool,
     coverage: bool,
+    /// Phase 5: also write a Verilator-compatible coverage.dat.
+    /// Implies --coverage. Filename comes via main.rs (defaults to
+    /// `coverage.dat` in cwd).
+    coverage_dat: Option<String>,
     /// Optional source map for resolving span byte offsets to
     /// (file:line). Populated by main.rs from MultiSource when
     /// --coverage is enabled.
@@ -128,11 +132,17 @@ impl<'a> SimCodegen<'a> {
         source: &'a SourceFile,
         overload_map: HashMap<usize, usize>,
     ) -> Self {
-        Self { symbols, source, overload_map, check_uninit: false, inputs_start_uninit: false, check_uninit_ram: false, cdc_random: false, debug: false, debug_depth: 1, debug_fsm: false, coverage: false, source_map: None }
+        Self { symbols, source, overload_map, check_uninit: false, inputs_start_uninit: false, check_uninit_ram: false, cdc_random: false, debug: false, debug_depth: 1, debug_fsm: false, coverage: false, coverage_dat: None, source_map: None }
     }
 
     pub fn coverage(mut self, enabled: bool) -> Self {
         self.coverage = enabled;
+        self
+    }
+
+    pub fn coverage_dat(mut self, path: Option<String>) -> Self {
+        self.coverage_dat = path;
+        if self.coverage_dat.is_some() { self.coverage = true; }
         self
     }
 
@@ -593,6 +603,12 @@ r#"        .def_property("{field}",
 #include <cstdlib>
 #include <cstring>
 
+// --coverage-dat: forward declaration for the helper defined in
+// verilated.cpp. Each class's atexit dumper calls this to get a
+// FILE* opened for append (with the header line written once on
+// first call).
+extern "C" FILE* _arch_cov_dat_open(const char* path);
+
 /// Minimal Verilated compatibility shim for arch-generated C++ simulation models.
 class Verilated {
 public:
@@ -766,11 +782,29 @@ static inline uint64_t _arch_repeat(uint64_t val, uint32_t n, uint32_t val_width
     }
 
     pub fn verilated_cpp() -> String {
-        r#"#include "verilated.h"
+        r##"#include "verilated.h"
+#include <cstdio>
+#include <cstdlib>
 int Verilated::_s_verbosity = 1;
 const char* Verilated::_s_trace_file = nullptr;
 bool Verilated::_s_trace_claimed = false;
-"#.to_string()
+
+// --coverage-dat: Verilator-compatible coverage.dat writer. Each
+// class's atexit dumper calls _arch_cov_dat_open() to get a FILE*
+// opened for append; the first call writes the header line so
+// verilator_coverage --annotate parses cleanly. Subsequent calls
+// just append their point lines.
+extern "C" FILE* _arch_cov_dat_open(const char* path) {
+    static bool _header_written = false;
+    FILE* f = fopen(path, _header_written ? "a" : "w");
+    if (!f) return nullptr;
+    if (!_header_written) {
+        fprintf(f, "# SystemC::Coverage-3\n");
+        _header_written = true;
+    }
+    return f;
+}
+"##.to_string()
     }
 }
 
@@ -5459,11 +5493,22 @@ impl<'a> SimCodegen<'a> {
             // ordinal-only fallback otherwise. (Phase 1b lands the
             // source-text plumbing so the dump shows
             // `tests/cvdp/cache_mshr.arch:111` instead of `branch[0]`.)
+            // --coverage-dat: also append per-point Verilator-compatible
+            // lines to the coverage.dat file.
+            if let Some(path) = &self.coverage_dat {
+                let path_lit = path.replace('\\', "\\\\").replace('"', "\\\"");
+                cpp.push_str(&format!("  FILE* _dat = _arch_cov_dat_open(\"{path_lit}\");\n"));
+            }
             for (i, p) in cov_reg.borrow().points.iter().enumerate() {
-                let location = if let Some(sm) = &self.source_map {
+                let (file_disp, line_no) = if let Some(sm) = &self.source_map {
                     sm.locate(p.span_start)
-                        .map(|(f, l)| format!("{}:{}", f, l))
-                        .unwrap_or_else(|| format!("branch[{i}]"))
+                        .map(|(f, l)| (f.to_string(), l))
+                        .unwrap_or_else(|| (String::new(), 0))
+                } else {
+                    (String::new(), 0)
+                };
+                let location = if !file_disp.is_empty() {
+                    format!("{file_disp}:{line_no}")
                 } else {
                     format!("branch[{i}]")
                 };
@@ -5471,6 +5516,28 @@ impl<'a> SimCodegen<'a> {
                     "  fprintf(stderr, \"  {location} ({}): %llu hits%s\\n\", (unsigned long long){class}::_arch_cov[{i}], {class}::_arch_cov[{i}] ? \"\" : \" *NOT HIT*\");\n",
                     p.kind
                 ));
+                if self.coverage_dat.is_some() && !file_disp.is_empty() {
+                    let file_esc = file_disp.replace('\\', "\\\\").replace('"', "\\\"");
+                    let page = match p.kind {
+                        "if" | "elsif" | "else" => "v_branch",
+                        "seq" | "comb"          => "v_line",
+                        "state" | "trans"       => "v_user/fsm",
+                        "toggle"                => "v_toggle",
+                        _                       => "v_user",
+                    };
+                    let comment = p.label.replace('\\', "\\\\").replace('"', "\\\"");
+                    // Verilator coverage.dat field separators are \x01 (key)
+                    // and \x02 (value). C++ greedy-matches hex escapes, so
+                    // each escape is its own string literal — adjacent
+                    // string concatenation joins them safely.
+                    cpp.push_str(&format!(
+                        "  if (_dat) fprintf(_dat, \"C '\" \"\\x01\" \"file\" \"\\x02\" \"{file_esc}\" \"\\x01\" \"line\" \"\\x02\" \"{line_no}\" \"\\x01\" \"page\" \"\\x02\" \"{page}\" \"\\x01\" \"comment\" \"\\x02\" \"{kind} {comment}\" \"' %llu\\n\", (unsigned long long){class}::_arch_cov[{i}]);\n",
+                        kind = p.kind
+                    ));
+                }
+            }
+            if self.coverage_dat.is_some() {
+                cpp.push_str("  if (_dat) fclose(_dat);\n");
             }
             cpp.push_str("}\n");
             cpp.push_str("struct _ArchCovInit { _ArchCovInit() { atexit(_arch_cov_dump); } };\n");

--- a/src/sim_codegen/mod.rs
+++ b/src/sim_codegen/mod.rs
@@ -4779,6 +4779,25 @@ impl<'a> SimCodegen<'a> {
                 if vec_array_info(&rd.ty).is_some() {
                     cpp.push_str(&format!("  memcpy(_{n}, _n_{n}, sizeof(_{n}));\n"));
                 } else {
+                    // --coverage phase 4: toggle counter — popcount of
+                    // (prev XOR new) sums all bits that flipped this
+                    // posedge. Skip Vec / wide regs in v1 (Vec needs
+                    // per-element handling; wide needs split popcount).
+                    // Skip enums — toggle on a state reg is mostly
+                    // noise, FSM coverage is more useful there.
+                    if let Some(reg) = cov_handle {
+                        let bits = type_bits_te(&rd.ty);
+                        if bits > 0 && bits <= 64 && !matches!(rd.ty, TypeExpr::Named(_)) {
+                            let cidx = reg.borrow_mut().alloc(
+                                "toggle",
+                                rd.name.span.start,
+                                format!("toggle {n}"),
+                            );
+                            cpp.push_str(&format!(
+                                "  _arch_cov[{cidx}] += __builtin_popcountll((uint64_t)_{n} ^ (uint64_t)_n_{n});\n"
+                            ));
+                        }
+                    }
                     cpp.push_str(&format!("  _{n} = _n_{n};\n"));
                 }
             }

--- a/src/sim_codegen/mod.rs
+++ b/src/sim_codegen/mod.rs
@@ -2612,6 +2612,17 @@ fn emit_comb_if_else(ie: &CombIfElse, ctx: &Ctx, out: &mut String, indent: usize
     } else {
         out.push_str(&format!("{}if ({}) {{\n", ind(indent), cond));
     }
+    // --coverage phase 1c: same instrumentation as emit_reg_if_else for
+    // comb if/elsif/else arms. Note that comb blocks may evaluate
+    // multiple times per cycle during the settle loop — counters
+    // therefore reflect "branch entries", not "cycles where branch was
+    // active". For most arch designs the settle loop converges in 1-2
+    // iterations so this is close to the cycle count.
+    if let Some(reg) = ctx.coverage {
+        let kind = if is_chain { "elsif" } else { "if" };
+        let idx = reg.borrow_mut().alloc(kind, ie.cond.span.start, String::new());
+        out.push_str(&format!("{}  _arch_cov[{idx}]++;\n", ind(indent)));
+    }
     emit_comb_stmts(&ie.then_stmts, ctx, out, indent + 1);
     if ie.else_stmts.len() == 1 {
         if let CombStmt::IfElse(nested) = &ie.else_stmts[0] {
@@ -2621,6 +2632,10 @@ fn emit_comb_if_else(ie: &CombIfElse, ctx: &Ctx, out: &mut String, indent: usize
     }
     if !ie.else_stmts.is_empty() {
         out.push_str(&format!("{}}} else {{\n", ind(indent)));
+        if let Some(reg) = ctx.coverage {
+            let idx = reg.borrow_mut().alloc("else", ie.span.end, String::new());
+            out.push_str(&format!("{}  _arch_cov[{idx}]++;\n", ind(indent)));
+        }
         emit_comb_stmts(&ie.else_stmts, ctx, out, indent + 1);
     }
     out.push_str(&format!("{}}}\n", ind(indent)));
@@ -4889,7 +4904,8 @@ impl<'a> SimCodegen<'a> {
         cpp.push_str(&format!("void {class}::eval_comb() {{\n"));
         let ctx_comb = Ctx::new(&reg_names, &port_names, &let_names, &inst_names,
                                 &wide_names, &widths, &enum_map, &bus_port_names)
-                           .with_vec_names(&vec_reg_names).with_vec_sizes(&vec_sizes);
+                           .with_vec_names(&vec_reg_names).with_vec_sizes(&vec_sizes)
+                           .with_coverage(cov_handle);
 
         // Credit-channel combinational wires (sender can_send; receiver
         // valid/data once PR-sim-2 lands). Emit early so user comb code


### PR DESCRIPTION
## Summary
Re-stacks the closed coverage PRs (#134, #136, #138 + their dependents #135, #137, #139) onto current main as a **single linear branch** with the 6 phase commits preserved in history. The original stack failed because each PR's base was the prior PR's branch — when one was closed, the rest had no path to main.

## Phases included (one commit each, in order)

| Phase | What |
|---|---|
| 1b  | file:line resolution via SourceMap; dump shows `cache_mshr.arch:111` instead of `branch[0]` |
| 1c  | comb if/elsif/else branch coverage |
| 2   | block-execution coverage (per-seq + per-comb counters; catches dead clock domains) |
| 3   | FSM state + transition coverage; per-arc and per-state counters |
| 4   | toggle coverage for scalar regs; popcount(prev XOR new) |
| 5   | Verilator-compatible `coverage.dat` via `--coverage-dat[=PATH]` |

Phase 1 (seq if/elsif/else) is already on main from #132.

## End-to-end smoke (cache_mshr with all phases active)
\`\`\`
$ arch sim --coverage-dat=coverage.dat tests/cvdp/cache_mshr.arch --tb mini.cpp
[Vcache_mshr] branch coverage: 17/21 hit (81.0%)
  tests/cvdp/cache_mshr.arch:179 (seq):  13 hits
  tests/cvdp/cache_mshr.arch:130 (comb): 104 hits
  tests/cvdp/cache_mshr.arch:134 (if):   104 hits  ← was 0 pre-#140
  tests/cvdp/cache_mshr.arch:135 (if):   104 hits  ← was 0 pre-#140
  tests/cvdp/cache_mshr.arch:163 (if):  1344 hits  ← was 0 pre-#140
  tests/cvdp/cache_mshr.arch:164 (if):    64 hits  ← was 0 pre-#140
  ...
$ head -2 coverage.dat | cat -v
# SystemC::Coverage-3
C '^Afile^Btests/cvdp/cache_mshr.arch^Aline^B179^Apage^Bv_line^Acomment^Bseq seq @clk' 13
\`\`\`

The lines that previously showed \`*NOT HIT*\` are now exercised — coverage was correctly identifying a real bug, and #140's Bool \`~\` masking fix made them visible.

## Off-by-default
No \`--coverage\` flag means no instrumentation, byte-identical SimModel output.

## Regressions clean
- arch sim: cam_basic 12/12, cam_dual_basic 10/10, cam_value_basic 8/8, mac_table 9/9, inst_vec_port_regression 8/8, sim_bool_not_regression 4/4
- iverilog: test_mshr_sim 8/8 MSHR sizes
- \`cargo build --release\` clean

## Merge strategy
Squash or rebase-merge — the 6 commits are individually reviewable and represent the original phased rollout. Merge commit / squash also fine; the diff size is moderate (~300 lines total) and most logic is in \`src/sim_codegen/mod.rs\` + \`src/sim_codegen/fsm.rs\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)