### PR TITLE
feat(sim_codegen): --coverage phases 4b + 1d (Vec toggle + match arms)

### DIFF
--- a/src/sim_codegen/mod.rs
+++ b/src/sim_codegen/mod.rs
@@ -2452,17 +2452,27 @@ fn emit_reg_stmt(stmt: &Stmt, ctx: &Ctx, out: &mut String, indent: usize) {
             let scrut = cpp_expr(&m.scrutinee, ctx);
             out.push_str(&format!("{}switch ({}) {{\n", ind(indent), scrut));
             for arm in &m.arms {
-                let case_str = match &arm.pattern {
-                    Pattern::Wildcard | Pattern::Ident(_) => "default".to_string(),
-                    Pattern::Literal(e) => format!("case {}", cpp_expr(e, ctx)),
+                let (case_str, label) = match &arm.pattern {
+                    Pattern::Wildcard => ("default".to_string(), "match _".to_string()),
+                    Pattern::Ident(id) => ("default".to_string(), format!("match {}", id.name)),
+                    Pattern::Literal(e) => (format!("case {}", cpp_expr(e, ctx)), "match lit".to_string()),
                     Pattern::EnumVariant(en, vr) => {
                         if let Some(variants) = ctx.enum_map.get(&en.name) {
                             let idx = variants.iter().find(|(n, _)| *n == vr.name).map(|(_, v)| *v).unwrap_or(0);
-                            format!("case {idx}")
-                        } else { "default".to_string() }
+                            (format!("case {idx}"), format!("match {}::{}", en.name, vr.name))
+                        } else { ("default".to_string(), format!("match {}::{}", en.name, vr.name)) }
                     }
                 };
                 out.push_str(&format!("{}{}: {{\n", ind(indent + 1), case_str));
+                // --coverage phase 1d: per match-arm counter. Use the
+                // match's span.start so the report points to the match
+                // statement (per-arm spans aren't tracked on MatchArm);
+                // the label disambiguates which arm.
+                if let Some(reg) = ctx.coverage {
+                    let kind = if matches!(arm.pattern, Pattern::Wildcard | Pattern::Ident(_)) { "match-default" } else { "match-arm" };
+                    let cidx = reg.borrow_mut().alloc(kind, m.span.start, label);
+                    out.push_str(&format!("{}  _arch_cov[{cidx}]++;\n", ind(indent + 1)));
+                }
                 emit_reg_stmts(&arm.body, ctx, out, indent + 2);
                 out.push_str(&format!("{}  break;\n", ind(indent + 1)));
                 out.push_str(&format!("{}}}\n", ind(indent + 1)));
@@ -2591,17 +2601,23 @@ fn emit_comb_stmt(stmt: &CombStmt, ctx: &Ctx, out: &mut String, indent: usize) {
             let scrut = cpp_expr(&m.scrutinee, ctx);
             out.push_str(&format!("{}switch ({}) {{\n", ind(indent), scrut));
             for arm in &m.arms {
-                let case_str = match &arm.pattern {
-                    Pattern::Wildcard | Pattern::Ident(_) => "default".to_string(),
-                    Pattern::Literal(e) => format!("case {}", cpp_expr(e, ctx)),
+                let (case_str, label) = match &arm.pattern {
+                    Pattern::Wildcard => ("default".to_string(), "match _".to_string()),
+                    Pattern::Ident(id) => ("default".to_string(), format!("match {}", id.name)),
+                    Pattern::Literal(e) => (format!("case {}", cpp_expr(e, ctx)), "match lit".to_string()),
                     Pattern::EnumVariant(en, vr) => {
                         if let Some(variants) = ctx.enum_map.get(&en.name) {
                             let idx = variants.iter().find(|(n, _)| *n == vr.name).map(|(_, v)| *v).unwrap_or(0);
-                            format!("case {idx}")
-                        } else { "default".to_string() }
+                            (format!("case {idx}"), format!("match {}::{}", en.name, vr.name))
+                        } else { ("default".to_string(), format!("match {}::{}", en.name, vr.name)) }
                     }
                 };
                 out.push_str(&format!("{}{}: {{\n", ind(indent + 1), case_str));
+                if let Some(reg) = ctx.coverage {
+                    let kind = if matches!(arm.pattern, Pattern::Wildcard | Pattern::Ident(_)) { "match-default" } else { "match-arm" };
+                    let cidx = reg.borrow_mut().alloc(kind, m.span.start, label);
+                    out.push_str(&format!("{}  _arch_cov[{cidx}]++;\n", ind(indent + 1)));
+                }
                 for s in &arm.body {
                     if let Stmt::Assign(a) = s {
                         let rhs = cpp_expr(&a.value, ctx);
@@ -4810,7 +4826,27 @@ impl<'a> SimCodegen<'a> {
             cpp.push('\n');
             for rd in &reg_decls {
                 let n = &rd.name.name;
-                if vec_array_info(&rd.ty).is_some() {
+                if let Some((_, count_str)) = vec_array_info_with_params(&rd.ty, &m.params) {
+                    // --coverage phase 4b: per-Vec-reg aggregate toggle
+                    // counter — sum of popcount(prev XOR new) across all
+                    // elements. One counter per Vec reg (not per element)
+                    // to keep the dump size manageable; the per-element
+                    // breakdown stays a future opt-in.
+                    if let Some(reg) = cov_handle {
+                        if let TypeExpr::Vec(elem_ty, _) = &rd.ty {
+                            let elem_bits = type_bits_te(elem_ty);
+                            if elem_bits > 0 && elem_bits <= 64 {
+                                let cidx = reg.borrow_mut().alloc(
+                                    "toggle",
+                                    rd.name.span.start,
+                                    format!("toggle {n}[]"),
+                                );
+                                cpp.push_str(&format!(
+                                    "  for (uint32_t _ti = 0; _ti < {count_str}; _ti++) {{ _arch_cov[{cidx}] += __builtin_popcountll((uint64_t)_{n}[_ti] ^ (uint64_t)_n_{n}[_ti]); }}\n"
+                                ));
+                            }
+                        }
+                    }
                     cpp.push_str(&format!("  memcpy(_{n}, _n_{n}, sizeof(_{n}));\n"));
                 } else {
                     // --coverage phase 4: toggle counter — popcount of


### PR DESCRIPTION
## Summary
Closes the two coverage gaps left after the main #141 stack:

### Phase 4b — Vec-element toggle coverage
Phase 4 (#141) skipped Vec regs to keep the diff small. v1 worked for cache_mshr's 5 scalar regs (\`allocate_id_r\` etc.) but left the Vec regs (\`entry_valid\`, \`entry_addr\`, \`entry_write\`, \`entry_has_next\`, \`entry_next_idx\`, \`data_mem\`) invisible to toggle coverage.

Fix: at the Vec-reg memcpy commit site, emit:
\`\`\`c++
for (uint32_t _ti = 0; _ti < N; _ti++) {
    _arch_cov[N] += __builtin_popcountll((uint64_t)_v[_ti] ^ (uint64_t)_n_v[_ti]);
}
\`\`\`
One **aggregate** counter per Vec reg (sum across all elements). Per-element breakdown stays a future opt-in — the dump would otherwise blow up for designs with deep Vec regs.

### Phase 1d — match arm coverage
\`match\` / \`case\` statements in seq + comb were missing from phases 1/1c. Each arm now gets its own counter (\`match-arm\` for explicit patterns, \`match-default\` for \`_\` / Ident catch-all). Label carries the pattern info: \`match Foo::Bar\` / \`match lit\` / \`match _\`.

Per-arm spans aren't tracked on \`MatchArm\` in the AST, so all arms share the match statement's \`span.start\` (line points to the match keyword). The label disambiguates which arm hit.

## Smoke
**cache_mshr (Vec toggle)** — 5 new toggle counters surface:
\`\`\`
  cache_mshr.arch:74 (toggle): 2 hits   ← entry_valid
  cache_mshr.arch:75 (toggle): 2 hits   ← entry_addr
  cache_mshr.arch:76 (toggle): 0 hits *NOT HIT*  ← entry_write (rw=0 in TB)
  cache_mshr.arch:77 (toggle): 2 hits   ← entry_has_next
  cache_mshr.arch:78 (toggle): 0 hits *NOT HIT*  ← entry_next_idx (no chain)
  cache_mshr.arch:81 (toggle): 11 hits  ← data_mem
\`\`\`

**Tiny match fixture** — 3 cases + default, TB hits cases 0/1/2:
\`\`\`
  /tmp/match_cov.arch:8 (match-arm): 2 hits      ← case 0
  /tmp/match_cov.arch:8 (match-arm): 2 hits      ← case 1
  /tmp/match_cov.arch:8 (match-arm): 2 hits      ← case 2
  /tmp/match_cov.arch:8 (match-default): 0 hits *NOT HIT*
\`\`\`

## Off-by-default
No \`--coverage\` runs are byte-identical to before this PR.

## Regressions clean
- arch sim: cam_basic 12/12, cam_value_basic 8/8, mac_table 9/9, inst_vec_port_regression 8/8, sim_bool_not_regression 4/4
- iverilog: test_mshr_sim 8/8 MSHR sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)