### PR TITLE
feat(sim): pre-lowering thread sim Phase 1 + fsm `state` builtin

### DIFF
--- a/doc/plan_arch_coverage.md
+++ b/doc/plan_arch_coverage.md
@@ -54,6 +54,16 @@ For each scalar wire/reg, count 0→1 and 1→0 transitions. Useful for catching
 
 Emit Verilator's \`# SystemC: …\`-prefixed format alongside the text report so users can run \`verilator_coverage --annotate-min 1 --annotate annot/ coverage.dat\` and get HTML annotation against the *.sv files. (The arch source lines won't match SV lines exactly, but the text report from phases 1-4 gives the arch-source view; the .dat gives the SV view.)
 
+### Phase 6 — construct port toggle coverage (TODO)
+
+Today toggle coverage (Phase 4/4b) instruments scalar/Vec \`reg\` declarations inside \`gen_module\` only. The non-module construct emitters (\`fifo\`, \`arbiter\`, \`ram\`, \`cam\`, \`linklist\`, \`pipeline\`, plus \`fsm\` datapath regs) install no \`CoverageRegistry\`, so their internals contribute zero coverage. For most designs this is fine — the producing reg in the wrapping module is already toggled — but at black-box construct boundaries (e.g. an \`inst sub: SomeFifo\`) there is no signal we can attribute toggles to.
+
+Phase 6 fills that gap by toggling the **interface ports** of every construct from the *consumer* side: in \`gen_module\`, when emitting an instance, declare a \`_prev_<inst>_<port>\` shadow per output port and bump a popcount counter at the end of each \`eval()\`. Counter category \`v_toggle\`, comment \`toggle <inst>.<port>\`. This treats the construct as opaque (correct, since we don't own its internals) while still surfacing dead lanes / tied-off interfaces.
+
+Skip in v1: bus ports (already flatten to multiple scalars — nice-to-have but the per-leaf shadow set gets verbose); wide ports >64b (split popcount).
+
+Promote when a real consumer asks (most likely: arbiter grant-fairness audits, or fifo data-bus dead-bit hunting).
+
 ## Non-goals (v1)
 
 - **Cross-test merging**: each \`arch sim\` run overwrites \`coverage.txt\`. \`verilator_coverage --merge\` semantics deferred until users ask.

--- a/doc/plan_thread_parallel_sim.md
+++ b/doc/plan_thread_parallel_sim.md
@@ -1,0 +1,230 @@
+# Plan: pre-lowering parallel thread simulation
+
+> **Status**: design draft. Not started. Bumped from "queued" by the
+> observation that source-level thread sim unlocks true multi-core
+> parallel execution — a perf win the post-lowering FSM-crank path can
+> never reach.
+
+## Motivation
+
+Today every `thread` block is rewritten by `lower_threads`
+([src/elaborate.rs:1156](../src/elaborate.rs#L1156)) into an `fsm` AST
+node before sim_codegen runs. The post-lowering AST is the single source
+of truth for both `arch sim` and `arch build`, which gives strong
+sim/synth equivalence — but it costs us three things:
+
+1. **Coverage legibility.** Synthesized state names (`_thr_0`, `_thr_1`,
+   …) replace user landmarks (`wait until ready`, `fork`/`join`). The
+   `coverage.dat` is correct but unreadable without the lowering map.
+2. **Wait-cycle simulation cost.** `wait N cycle` cranks N posedges in
+   the fsm sim; pre-lowering sim could skip directly to the wake event.
+3. **Single-threaded execution.** Many-thread designs (SoCs with N DMA
+   engines, NoC mesh nodes, per-channel sequencers) serialize through
+   one `eval()` loop on one core. No matter how optimized the inner
+   loop, ceiling = 1× core throughput.
+
+(3) is the load-bearing motivation. (1) and (2) are real but the
+annotation fix in [doc/plan_arch_coverage.md](plan_arch_coverage.md)
+covers (1), and (2) is local to designs that wait a lot. (3) is a
+structural ceiling we cannot raise from the post-lowering side.
+
+## Design
+
+### Thread runtime model
+
+Three options; recommend **(c) hybrid**:
+
+| Option | Per-thread cost | Parallelism | Determinism | Complexity |
+|---|---|---|---|---|
+| (a) Coroutines (`<coroutine>` / Boost.Context) | ~KB stack | Single-core | Trivial | Low — same as today, just cooperative |
+| (b) OS threads (`std::thread`) | ~MB stack, syscall context-switch | True multi-core | Hard — needs barriers + ordered reads | High |
+| (c) Hybrid: thread groups | KB stack inside group, MB across groups | True multi-core across groups | Medium — barriers between groups only | Medium |
+
+**(c) Hybrid:** the user (or a heuristic on thread count) partitions
+threads into N groups where N = available cores. Each group runs in one
+OS thread; threads inside a group run as cooperatively-scheduled
+coroutines. Barriers run at clock edges across groups; intra-group
+threads share state lock-free because they never run concurrently.
+
+This matches the SystemC SC_THREAD model and the Verilator
+`--threads N` partitioning, both proven workable.
+
+### Clock-edge barrier scheduler
+
+Single-clock-domain version (extend later for multi-domain):
+
+```
+loop:
+  // Phase A — combinational settle (parallel across groups)
+  for each group in parallel:
+    run all threads until each blocks on (wait edge | wait until cond | yield)
+    settle comb signals owned by this group
+  barrier()
+
+  // Phase B — read combinational from other groups, settle again if needed
+  // (fixed-point iteration — bounded by combinational path depth)
+  for each group in parallel:
+    re-evaluate threads whose `wait until` predicates depend on cross-group
+    signals
+    if any signal changed: mark dirty
+  barrier()
+  if any dirty: goto Phase B  (in practice converges in 1-3 iters)
+
+  // Phase C — clock posedge: wake threads waiting on `wait edge` /
+  // `wait N cycle` whose deadline matches; commit reg writes
+  for each group in parallel:
+    advance time, wake matching threads, commit nonblocking writes
+  barrier()
+```
+
+Determinism: at each barrier, a fixed iteration order over groups (and
+over threads within a group) makes inter-group signal propagation
+order reproducible regardless of OS thread scheduling.
+
+### Shared-signal access protocol
+
+Two categories:
+
+- **Owned signals** (declared inside a thread or written by exactly one
+  thread): no synchronization. Owner writes during its phase, others
+  read snapshot at the next barrier.
+- **Cross-thread signals** (read by ≥1 threads other than owner): each
+  group keeps a local-write buffer during Phase A; barrier publishes
+  buffers; Phase B reads the published values. Same shape as
+  Verilator's NBA region or VCS's PLI sample-and-update.
+
+Compile-time analysis (already partially done by `comb_graph` and
+`collect_thread_signals` in [src/elaborate.rs](../src/elaborate.rs))
+identifies which signals fall in which category. Cross-group signals
+get the buffer treatment; everything else is direct-access. Most signals
+are owned — buffer overhead is minimal.
+
+### Dual-pass cross-check harness
+
+CLI: `arch sim --thread-sim=parallel`, `--thread-sim=fsm` (default),
+`--thread-sim=both`.
+
+- **`fsm`** (default): existing path, post-lowering, fully validated
+  against `arch build` SV.
+- **`parallel`**: new path, pre-lowering, multi-core. Used after
+  cross-check confidence builds.
+- **`both`**: run parallel and fsm in the same process, share the
+  testbench, compare a chosen observable each cycle. Mismatch ⇒
+  `ARCH-ERROR: thread sim divergence at cycle N: <signal> parallel=X
+  fsm=Y` + abort.
+
+Comparison observable: the **set of all output port values at each
+positive clock edge of the top clock**. Rationale: this is the
+synthesizable contract — internal sequencer states can differ
+(different schedulers, possible) as long as the design's externally
+observable behavior matches.
+
+Cross-check coverage targets: every thread-using `.arch` test in
+`tests/` runs `--thread-sim=both` in CI on small testbench
+inputs. Large benchmarks (axi_dma multi-channel, NoC mesh) opt
+into `parallel` directly once a baseline cross-check signs off.
+
+## Phased rollout
+
+| Phase | Scope | Gate |
+|---|---|---|
+| 0 — design lock | This doc, refined after one round of review | Reviewer sign-off |
+| 1 — coroutine single-core | Pre-lowering thread sim using `<coroutine>`, single OS thread, wait-skip optimization. Validates the runtime model on an existing thread test (e.g. `tests/axi_dma_thread/`). Not yet faster — proves correctness. | Cross-check passes on all `tests/axi_dma_thread/*` |
+| 2 — dual-pass `--thread-sim=both` | Comparison harness, divergence abort, CI integration | Green CI |
+| 3 — group partitioning + OS threads | Hybrid scheduler, configurable group count, barriers | Single-clock-domain perf win measured on axi_dma 4-channel |
+| 4 — multi-clock domain barriers | Per-domain scheduler, CDC-aware sync | Multi-clock thread test passes cross-check |
+| 5 — wait-skip + speculative comb | Pre-lowering perf optimizations that the FSM path cannot match (skip `wait N cycle`, batch comb-only updates) | Measurable speedup on `wait`-heavy benchmark |
+
+## Non-goals (v1)
+
+- **Thread-level parallelism in `gen_module`** (parallelizing comb
+  blocks). Out of scope — only thread blocks are user-marked as
+  concurrent. Module comb blocks have implicit ordering.
+- **Replacing the FSM path.** The post-lowering FSM sim stays the
+  default and the synth-equivalence ground truth. The parallel path is
+  an opt-in performance lane.
+- **GPU / SIMD execution.** Coarse-grained thread parallelism only;
+  bit-level vectorization is a separate workstream.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Sim/synth divergence in parallel path missed by cross-check | Cross-check observable is exhaustive (all output ports per cycle). Any divergence aborts. CI gate prevents regression. |
+| Thread-runtime maintenance burden doubles sim_codegen | Coroutine path is ~500 LOC; hybrid scheduler ~300 LOC on top. Cap accepted in exchange for the perf lane. Reviewable per-phase. |
+| Determinism breaks when porting C++ across compilers / OSes | Fixed barrier order + fixed group→thread mapping makes scheduling reproducible. Test in CI on macOS + Linux. |
+| Parallel speedup eaten by barrier overhead on small designs | Heuristic: fall back to single-OS-thread (coroutine-only) when thread count < 2× core count. User can override. |
+| `wait until cross-group-signal` introduces inter-group dependency cycles | Phase B fixed-point iteration converges in bounded steps; if not, error out with a "combinational cycle across thread boundary" diagnostic at compile time (extend `comb_graph` to thread-cross edges). |
+
+## Prior art: what to borrow from Verilator
+
+Verilator's `--threads N` mode (production since ~2019) solves a harder
+version of the same problem (parallelism discovered from a flattened
+RTL netlist rather than user-marked at the source). Several specific
+techniques transfer directly:
+
+1. **Static MTask partitioning.** The dependency graph between parallel
+   work units is computed at C++ generation time and baked into the
+   emitted scheduler. No runtime work-stealing, no per-cycle thread-pool
+   decisions. For us: each `thread` block (and possibly each independent
+   module instance) is one MTask analog. We get the partitioning for
+   free — the user already drew the boundaries.
+   *Source:* `V3Partition.cpp` in Verilator.
+2. **Lock-free per-edge sync words.** Inter-MTask synchronization is one
+   `std::atomic<uint64_t>` per dependency edge: producer increments at
+   completion, consumer spins until ≥ expected. ~10 ns per barrier vs
+   ~µs for OS mutex/condvar. Load-bearing perf trick.
+   *Source:* `verilated_threads.h` (`VlMTaskVertex`,
+   `VlAssignableWaitable`).
+3. **Two-region evaluation with one barrier per cycle.** Settle
+   combinational across all threads → barrier → commit NBA writes →
+   barrier → advance time. Maps to our Phase A/B/C scheduler; we may be
+   able to collapse to one barrier per posedge if the comb fixed-point
+   stays intra-thread.
+4. **Hash-stable MTask ordering.** Topological-sort tiebreak on a hash
+   of the MTask's source position guarantees same input + same
+   `--threads N` = same execution order = bit-identical traces. **We
+   need exactly this for `--thread-sim=both` cross-check to be
+   meaningful** — without reproducibility the divergence detector fires
+   on legitimate scheduling jitter.
+5. **Per-thread bump-arena allocators.** Worker threads never call
+   `malloc` on the hot path; signal buffers come from per-thread arenas
+   reset at the cycle boundary.
+
+What **doesn't** transfer or isn't needed:
+
+- Verilator's dynamic re-partitioning + cost model (added in 5.x). At
+  `thread`-granularity (tens to low hundreds of parallel units, not
+  thousands of fine-grained MTasks), static one-thread-per-MTask is
+  enough. Revisit only if a real consumer hits a load-balance ceiling.
+- Sub-module / sub-`always_comb` MTask splitting. Verilator needs this
+  because it has no source-level concurrency hint; we do.
+- `force`/`release`/hierarchical-reference handling. ARCH has no
+  equivalent SV testbench constructs, so the cross-thread access
+  protocol stays simpler than Verilator's.
+
+Both Verilator and ARCH are **2-state by default** — same integer-typed
+signal storage, same lack of X/Z propagation cost. So the parallel-sim
+techniques above port over without semantic adjustment.
+
+References:
+- Snyder, *Verilator and SystemPerl: Open Source SystemVerilog
+  Simulation* — original SystemPerl/Verilator paper.
+- Lane, et al., *Verilator V4.0 multithreaded simulation* — DVCon
+  presentation describing the MTask scheduler and sync-word design.
+- Verilator source: `src/V3Partition.cpp` (graph partitioning),
+  `include/verilated_threads.h` (runtime).
+
+## Open questions
+
+- Coroutine library: C++20 `<coroutine>` (clean but heap-allocates frames
+  by default), Boost.Context (stackful, fast switch), or roll-our-own
+  ucontext. Defer to Phase 1 prototype.
+- Should `--thread-sim=both` run in a single process (shared TB,
+  in-memory comparison) or two processes (subprocess + diff trace)?
+  Single-process is faster but couples the two sim binaries; two-process
+  cleaner but slower. Lean single-process.
+- Does the cross-check observable need to include reg-state at clock
+  edges, or only ports? Reg-state catches more bugs but is brittle
+  across legitimate schedule differences. Lean ports-only with reg-state
+  as an opt-in `--thread-sim=both --strict` mode.

--- a/runtime/arch_thread_rt.h
+++ b/runtime/arch_thread_rt.h
@@ -1,0 +1,143 @@
+// arch_thread_rt.h — Minimal coroutine runtime for pre-lowering thread sim.
+//
+// Design (Phase 1 spike, single-thread, single-clock-domain):
+//   - Each `thread` block compiles to a C++ coroutine returning `ArchThread`.
+//   - The scheduler exposes one method per clock edge: `tick()`. It resumes
+//     every coroutine that is ready (predicate satisfied or cycle deadline
+//     reached); coroutines run statements until they hit `co_await wait_*`.
+//   - Statements between `wait`s execute atomically at one posedge —
+//     matching the lowered-fsm semantics where one state's seq block runs
+//     in one always_ff iteration.
+//   - Awaiters:
+//       * `wait_until(pred)`  — suspend; resume on next posedge where
+//                                pred() returns true.
+//       * `wait_cycles(N)`    — suspend; resume after N posedges (N>=1).
+//
+// Not yet handled in this spike: fork/join, multiple threads,
+// resource locks, cross-thread signal access, parallel execution.
+// Those land in later phases.
+
+#pragma once
+
+#include <coroutine>
+#include <functional>
+#include <cstdint>
+#include <vector>
+
+namespace arch_rt {
+
+// Forward decls
+struct ThreadScheduler;
+
+// Promise type — minimal. The coroutine returns void; the handle is
+// owned by the scheduler.
+struct ArchThread {
+    struct promise_type {
+        ArchThread get_return_object() {
+            return ArchThread{ std::coroutine_handle<promise_type>::from_promise(*this) };
+        }
+        std::suspend_always initial_suspend() noexcept { return {}; }
+        std::suspend_always final_suspend()   noexcept { return {}; }
+        void return_void() noexcept {}
+        void unhandled_exception() { std::terminate(); }
+    };
+    std::coroutine_handle<promise_type> h;
+    bool done() const { return !h || h.done(); }
+    void resume() { if (h && !h.done()) h.resume(); }
+    void destroy() { if (h) { h.destroy(); h = nullptr; } }
+};
+
+// State a suspended thread is parked on.
+//   Ready       — not currently suspended; will run on next tick().
+//   WaitUntil   — resume when pred() returns true at a posedge.
+//   WaitCycles  — resume after `cycles_remaining` posedges.
+//   Done        — coroutine finished.
+enum class WaitKind : uint8_t { Ready, WaitUntil, WaitCycles, Done };
+
+// One scheduled thread. The scheduler owns these; awaiters mutate the
+// fields when a coroutine suspends.
+struct ThreadSlot {
+    ArchThread thread;
+    WaitKind   kind = WaitKind::Ready;
+    uint32_t   cycles_remaining = 0;
+    std::function<bool()> pred;  // for WaitUntil
+};
+
+// Awaiter: `co_await wait_until(pred)`. Captures the predicate by value;
+// the awaiter object lives in the coroutine frame for the duration of
+// the suspend, so the lambda's captures must outlive that — which is
+// trivially true since the caller is the same coroutine.
+struct WaitUntilAwaiter {
+    std::function<bool()> pred;
+    ThreadSlot* slot;
+    bool await_ready() noexcept {
+        // Don't short-circuit: even if pred is true now, we want the
+        // semantics of "resumes at the *next* posedge where pred is true",
+        // matching the lowered-fsm behavior.
+        return false;
+    }
+    void await_suspend(std::coroutine_handle<>) noexcept {
+        slot->kind = WaitKind::WaitUntil;
+        slot->pred = std::move(pred);
+    }
+    void await_resume() noexcept {}
+};
+
+// Awaiter: `co_await wait_cycles(N)`. N must be >= 1.
+struct WaitCyclesAwaiter {
+    uint32_t n;
+    ThreadSlot* slot;
+    bool await_ready() noexcept { return n == 0; }
+    void await_suspend(std::coroutine_handle<>) noexcept {
+        slot->kind = WaitKind::WaitCycles;
+        slot->cycles_remaining = n;
+    }
+    void await_resume() noexcept {}
+};
+
+// Scheduler: one per module instance. Owns all threads in that module.
+struct ThreadScheduler {
+    std::vector<ThreadSlot*> slots;
+
+    // Called by the module's posedge handler after combinational settle.
+    // For each slot:
+    //   - Done:        skip.
+    //   - WaitCycles:  decrement; if hits 0, mark Ready.
+    //   - WaitUntil:   evaluate pred; if true, mark Ready.
+    //   - Ready:       (only first tick, or just-marked-ready) resume the
+    //                  coroutine until it suspends or finishes.
+    void tick() {
+        // First pass: advance wait conditions.
+        for (auto* s : slots) {
+            if (s->kind == WaitKind::Done) continue;
+            if (s->kind == WaitKind::WaitCycles) {
+                if (s->cycles_remaining > 0) --s->cycles_remaining;
+                if (s->cycles_remaining == 0) s->kind = WaitKind::Ready;
+            } else if (s->kind == WaitKind::WaitUntil) {
+                if (s->pred && s->pred()) s->kind = WaitKind::Ready;
+            }
+        }
+        // Second pass: resume ready coroutines. They run until they hit
+        // another co_await (which sets kind to WaitUntil/WaitCycles) or
+        // return (done() == true ⇒ mark Done).
+        for (auto* s : slots) {
+            if (s->kind == WaitKind::Ready) {
+                s->thread.resume();
+                if (s->thread.done()) s->kind = WaitKind::Done;
+                // Otherwise the awaiter set kind to WaitUntil / WaitCycles.
+            }
+        }
+    }
+
+    bool all_done() const {
+        for (auto* s : slots) if (s->kind != WaitKind::Done) return false;
+        return true;
+    }
+};
+
+// Convenience constructors. Pass the slot the coroutine is parked in so
+// the awaiter knows where to write its suspend state.
+inline WaitUntilAwaiter  wait_until (ThreadSlot* s, std::function<bool()> p) { return {std::move(p), s}; }
+inline WaitCyclesAwaiter wait_cycles(ThreadSlot* s, uint32_t n)              { return {n, s}; }
+
+} // namespace arch_rt

--- a/runtime/spike/.gitignore
+++ b/runtime/spike/.gitignore
@@ -1,0 +1,2 @@
+DelayPulse_tb
+*.dSYM/

--- a/runtime/spike/DelayPulse_tb.cpp
+++ b/runtime/spike/DelayPulse_tb.cpp
@@ -1,0 +1,59 @@
+#include "DelayPulse_thread.h"
+#include <cstdio>
+
+static int pass = 0, fail = 0;
+#define CHECK(c, m, ...) do { \
+    if (c) { ++pass; printf("PASS: " m "\n", ##__VA_ARGS__); } \
+    else   { ++fail; printf("FAIL: " m "\n", ##__VA_ARGS__); } \
+} while (0)
+
+static DelayPulse dut;
+
+// One full clock cycle: low → high (posedge fires the thread).
+static void cycle() {
+    dut.clk = 0; dut.eval();
+    dut.clk = 1; dut.eval(); dut.posedge_clk();
+}
+
+int main() {
+    // Reset sequence.
+    dut.rst_n = 0; dut.start = 0; dut.eval();
+    dut.posedge_clk();   // reset: thread (re)constructed.
+    dut.rst_n = 1;
+
+    // Cycle 0: thread runs first time, hits `wait until start`. Suspended.
+    cycle();
+    CHECK(dut.pulse == 0, "C0: pulse=0 before start");
+
+    // Cycle 1: still no start.
+    cycle();
+    CHECK(dut.pulse == 0, "C1: still pulse=0");
+
+    // Assert start.
+    dut.start = 1;
+
+    // Cycle 2: pred satisfied → resume → hits `wait 5 cycle`. Suspended.
+    // Sets cycles_remaining = 5.
+    cycle();
+    CHECK(dut.pulse == 0, "C2: just hit wait-5-cycle, pulse still 0");
+
+    // Cycles 3,4,5,6: cycles_remaining decrements 5→4→3→2→1.
+    cycle(); CHECK(dut.pulse == 0, "C3: pulse=0 (cycles_remaining=4)");
+    cycle(); CHECK(dut.pulse == 0, "C4: pulse=0 (cycles_remaining=3)");
+    cycle(); CHECK(dut.pulse == 0, "C5: pulse=0 (cycles_remaining=2)");
+    cycle(); CHECK(dut.pulse == 0, "C6: pulse=0 (cycles_remaining=1)");
+
+    // Cycle 7: cycles_remaining hits 0 → resume → `pulse = 1` → hits
+    // `wait 1 cycle`. Suspended.
+    cycle();
+    CHECK(dut.pulse == 1, "C7: pulse asserted after 5-cycle wait");
+
+    // Cycle 8: 1-cycle wait elapses → resume → co_return → Done.
+    // pulse falls back to 0 because the per-tick default zeroes it and
+    // the coroutine no longer re-asserts (it's done).
+    cycle();
+    CHECK(dut.pulse == 0, "C8: pulse=0 after thread completes");
+
+    printf("=== %d pass / %d fail ===\n", pass, fail);
+    return fail == 0 ? 0 : 1;
+}

--- a/runtime/spike/DelayPulse_thread.h
+++ b/runtime/spike/DelayPulse_thread.h
@@ -1,0 +1,80 @@
+// Hand-written spike: what the pre-lowering thread sim emitter should
+// produce for tests/thread/wait_cycles.arch (module DelayPulse).
+//
+// Compare to the lowered-fsm sim output to validate runtime semantics
+// before automating the codegen.
+
+#pragma once
+
+#include "../arch_thread_rt.h"
+#include <cstdint>
+
+class DelayPulse {
+public:
+    // Ports (mirror the .arch port list)
+    uint8_t clk   = 0;
+    uint8_t rst_n = 0;
+    uint8_t start = 0;
+    uint8_t pulse = 0;
+
+    DelayPulse() {
+        // Construct the thread coroutine and register it in the scheduler.
+        _slot.thread = make_thread();
+        _sched.slots.push_back(&_slot);
+    }
+
+    ~DelayPulse() { _slot.thread.destroy(); }
+
+    // Combinational settle. For DelayPulse there's no combinational
+    // logic in the module — only the thread drives `pulse` — so this
+    // is a no-op. (The emitter will populate this for non-thread
+    // comb blocks in other modules.)
+    void eval() {}
+
+    // Driven by the testbench whenever `clk` transitions. The thread
+    // runs at posedge.
+    void posedge_clk() {
+        // Per-cycle default: zero all non-reg outputs the thread drives.
+        // Matches the lowered-fsm semantic where state-local comb assigns
+        // don't persist past the state. The coroutine re-asserts during
+        // its span if it should still hold.
+        // Emitter will derive this set from thread-body assignment
+        // analysis (analogous to fsm `default` block).
+        pulse = 0;
+        // Async-active-low reset: re-create the thread.
+        if (!rst_n) {
+            // Reset side effects on outputs that the thread drives.
+            // (In the lowered-fsm path this happens in the always_ff
+            // reset arm. Here we mirror it explicitly.)
+            pulse = 0;
+            // Destroy + recreate the coroutine so it restarts from
+            // the top. Cheap: the frame is one heap alloc per reset.
+            _slot.thread.destroy();
+            _slot.thread = make_thread();
+            _slot.kind = arch_rt::WaitKind::Ready;
+            _slot.cycles_remaining = 0;
+            _slot.pred = nullptr;
+            return;
+        }
+        _sched.tick();
+    }
+
+private:
+    arch_rt::ThreadScheduler _sched;
+    arch_rt::ThreadSlot      _slot;
+
+    // The thread body — direct mechanical translation of:
+    //   thread on clk rising, rst_n low
+    //     wait until start;
+    //     wait 5 cycle;
+    //     pulse = 1;
+    //     wait 1 cycle;
+    //   end thread
+    arch_rt::ArchThread make_thread() {
+        co_await arch_rt::wait_until(&_slot, [this]{ return start != 0; });
+        co_await arch_rt::wait_cycles(&_slot, 5);
+        pulse = 1;
+        co_await arch_rt::wait_cycles(&_slot, 1);
+        co_return;
+    }
+};

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -3536,6 +3536,11 @@ impl<'a> Codegen<'a> {
 
     fn emit_fsm(&mut self, f: &FsmDecl) {
         self.current_construct = f.name.name.clone();
+        // Built-in `state` identifier inside fsm scope: read of the current
+        // encoded state register. SV emission lowers to `state_r` (the enum
+        // register), which implicitly casts to the user-declared output port
+        // width. Cleared at the end of emit_fsm.
+        self.ident_subst.insert("state".to_string(), "state_r".to_string());
         let n = f.name.name.clone();
         let n_states = f.state_names.len();
         let state_bits = enum_width(n_states);
@@ -3628,14 +3633,19 @@ impl<'a> Codegen<'a> {
         }
 
         // ── Let wire declarations ────────────────────────────────────────────
+        let port_names_in_fsm: std::collections::HashSet<&str> =
+            f.ports.iter().map(|p| p.name.name.as_str()).collect();
         for lb in &f.lets {
-            let ty = if let Some(t) = &lb.ty {
-                self.emit_type_str(t)
-            } else {
-                "logic".to_string()
-            };
             let val = self.emit_expr_str(&lb.value);
-            self.line(&format!("{ty} {};", lb.name.name));
+            let aliases_port = lb.ty.is_none() && port_names_in_fsm.contains(lb.name.name.as_str());
+            if !aliases_port {
+                let ty = if let Some(t) = &lb.ty {
+                    self.emit_type_str(t)
+                } else {
+                    "logic".to_string()
+                };
+                self.line(&format!("{ty} {};", lb.name.name));
+            }
             self.line(&format!("assign {} = {};", lb.name.name, val));
         }
         if !f.lets.is_empty() {
@@ -3869,6 +3879,7 @@ impl<'a> Codegen<'a> {
         self.line("");
         self.line("endmodule");
         self.line("");
+        self.ident_subst.remove("state");
     }
 
     // ── Pipeline ──────────────────────────────────────────────────────────────

--- a/src/main.rs
+++ b/src/main.rs
@@ -129,6 +129,11 @@ enum Command {
         /// --annotate annot/ <file>`.
         #[arg(long)]
         coverage_dat: Option<Option<String>>,
+        /// Thread-sim mode: `fsm` (default; threads lowered to FSM, single-core)
+        /// or `parallel` (Phase 1 spike: pre-lowering coroutine sim). See
+        /// doc/plan_thread_parallel_sim.md.
+        #[arg(long = "thread-sim", default_value = "fsm")]
+        thread_sim: String,
         /// Generate pybind11 Python module for cocotb-compatible testing
         #[arg(long)]
         pybind: bool,
@@ -347,7 +352,7 @@ fn main() -> miette::Result<()> {
             }
             Ok(())
         }
-        Command::Sim { arch_files, tb_files, outdir, check_uninit, inputs_start_uninit, check_uninit_ram, cdc_random, wave, debug, debug_depth, debug_fsm, coverage, coverage_dat, pybind, test, pybind_module_name } => {
+        Command::Sim { arch_files, tb_files, outdir, check_uninit, inputs_start_uninit, check_uninit_ram, cdc_random, wave, debug, debug_depth, debug_fsm, coverage, coverage_dat, thread_sim, pybind, test, pybind_module_name } => {
             let dbg_ports = debug || debug_fsm;  // any debug option implies port logging
             // --inputs-start-uninit and --check-uninit-ram both imply --check-uninit
             let check_uninit = check_uninit || inputs_start_uninit || check_uninit_ram;
@@ -356,8 +361,13 @@ fn main() -> miette::Result<()> {
             // → Some(None) → default "coverage.dat"; absent → None.
             let cov_dat_path: Option<String> = coverage_dat.map(|opt| opt.unwrap_or_else(|| "coverage.dat".to_string()));
             let coverage = coverage || cov_dat_path.is_some();
+            let thread_sim_parallel = match thread_sim.as_str() {
+                "fsm" => false,
+                "parallel" => true,
+                other => return Err(miette::miette!("--thread-sim: expected `fsm` or `parallel`, got `{}`", other)),
+            };
             learn_wrap(&arch_files, || {
-                run_sim(&arch_files, &tb_files, outdir.as_deref(), check_uninit, inputs_start_uninit, check_uninit_ram, cdc_random, wave.as_deref(), dbg_ports, debug_depth, debug_fsm, coverage, cov_dat_path.clone(), pybind, test.as_deref(), pybind_module_name.as_deref())
+                run_sim(&arch_files, &tb_files, outdir.as_deref(), check_uninit, inputs_start_uninit, check_uninit_ram, cdc_random, wave.as_deref(), dbg_ports, debug_depth, debug_fsm, coverage, cov_dat_path.clone(), thread_sim_parallel, pybind, test.as_deref(), pybind_module_name.as_deref())
             })
         }
         Command::Build { files, o } => {
@@ -478,6 +488,7 @@ fn run_sim(
     debug_fsm: bool,
     coverage: bool,
     coverage_dat: Option<String>,
+    thread_sim_parallel: bool,
     pybind: bool,
     test_file: Option<&std::path::Path>,
     pybind_module_name_override: Option<&str>,
@@ -485,7 +496,7 @@ fn run_sim(
     // 1. Parse + type-check
     let all_files = resolve_use_imports(arch_files)?;
     let ms = MultiSource::from_files(&all_files)?;
-    let (ast, symbols, overload_map) = run_check_multi(&ms)?;
+    let (ast, symbols, overload_map) = run_check_multi_opts(&ms, thread_sim_parallel)?;
 
     // 2. Set up output directory
     let build_dir = outdir
@@ -494,16 +505,34 @@ fn run_sim(
     fs::create_dir_all(&build_dir).into_diagnostic()?;
 
     // 3. Generate C++ models
-    let mut sim = SimCodegen::new(&symbols, &ast, overload_map).check_uninit(check_uninit).inputs_start_uninit(inputs_start_uninit).check_uninit_ram(check_uninit_ram).cdc_random(cdc_random).debug(debug, debug_depth).with_debug_fsm(debug_fsm).coverage(coverage).coverage_dat(coverage_dat);
-    if coverage {
-        // Build a SourceMap so the coverage dumper can render
-        // file:line instead of opaque branch[N] ordinals.
-        let segs: Vec<(usize, String, String)> = ms.segments.iter()
-            .map(|(start, _end, name, src)| (*start, name.clone(), src.clone()))
-            .collect();
-        sim = sim.with_source_map(arch::sim_codegen::SourceMap::new(segs));
-    }
-    let models = sim.generate();
+    let models: Vec<arch::sim_codegen::SimModel> = if thread_sim_parallel {
+        // Pre-lowering thread sim path: route every module containing
+        // a `thread` block through the new emitter; reject mixed
+        // modules (Phase 1 limitation).
+        let mut out = Vec::new();
+        for item in &ast.items {
+            if let arch::ast::Item::Module(m) = item {
+                let has_thread = m.body.iter().any(|i| matches!(i, arch::ast::ModuleBodyItem::Thread(_)));
+                if has_thread {
+                    let model = arch::sim_codegen::thread_sim::gen_module_thread(m)
+                        .map_err(|e| miette::miette!("thread sim: {}", e))?;
+                    out.push(model);
+                }
+            }
+        }
+        out
+    } else {
+        let mut sim = SimCodegen::new(&symbols, &ast, overload_map.clone()).check_uninit(check_uninit).inputs_start_uninit(inputs_start_uninit).check_uninit_ram(check_uninit_ram).cdc_random(cdc_random).debug(debug, debug_depth).with_debug_fsm(debug_fsm).coverage(coverage).coverage_dat(coverage_dat.clone());
+        if coverage {
+            // Build a SourceMap so the coverage dumper can render
+            // file:line instead of opaque branch[N] ordinals.
+            let segs: Vec<(usize, String, String)> = ms.segments.iter()
+                .map(|(start, _end, name, src)| (*start, name.clone(), src.clone()))
+                .collect();
+            sim = sim.with_source_map(arch::sim_codegen::SourceMap::new(segs));
+        }
+        sim.generate()
+    };
 
     if models.is_empty() {
         eprintln!("warning: no synthesizable constructs found (module/counter/fsm)");
@@ -527,8 +556,23 @@ fn run_sim(
     fs::write(&verilated_cpp, SimCodegen::verilated_cpp()).into_diagnostic()?;
     generated_cpps.push(verilated_cpp);
 
+    // 4b. Thread sim runtime header (only used under --thread-sim parallel,
+    // but emit unconditionally — cheap and keeps the build dir self-contained).
+    let arch_thread_rt_h = build_dir.join("arch_thread_rt.h");
+    fs::write(&arch_thread_rt_h, arch::sim_codegen::thread_sim::arch_thread_rt_h()).into_diagnostic()?;
+
     // ── Pybind11 mode ────────────────────────────────────────────────────
     if pybind {
+        if thread_sim_parallel {
+            return Err(miette::miette!("--pybind not yet supported with --thread-sim parallel"));
+        }
+        let mut sim = SimCodegen::new(&symbols, &ast, overload_map.clone()).check_uninit(check_uninit).inputs_start_uninit(inputs_start_uninit).check_uninit_ram(check_uninit_ram).cdc_random(cdc_random).debug(debug, debug_depth).with_debug_fsm(debug_fsm).coverage(coverage).coverage_dat(coverage_dat.clone());
+        if coverage {
+            let segs: Vec<(usize, String, String)> = ms.segments.iter()
+                .map(|(start, _end, name, src)| (*start, name.clone(), src.clone()))
+                .collect();
+            sim = sim.with_source_map(arch::sim_codegen::SourceMap::new(segs));
+        }
         let pybind_wrappers = sim.generate_pybind();
         if pybind_wrappers.is_empty() {
             eprintln!("warning: no pybind11 wrappers generated");
@@ -773,7 +817,8 @@ sys.exit(0 if ok else 1)
     // 5. Compile with g++
     let sim_bin = build_dir.join("sim_out");
     let mut cmd = std::process::Command::new("g++");
-    cmd.arg("-std=c++17")
+    let cpp_std = if thread_sim_parallel { "-std=c++20" } else { "-std=c++17" };
+    cmd.arg(cpp_std)
        .arg("-O1")
        .arg("-I").arg(&build_dir);
 
@@ -991,6 +1036,13 @@ fn resolve_use_imports(files: &[PathBuf]) -> miette::Result<Vec<PathBuf>> {
 fn run_check_multi(
     ms: &MultiSource,
 ) -> miette::Result<(arch::ast::SourceFile, resolve::SymbolTable, std::collections::HashMap<usize, usize>)> {
+    run_check_multi_opts(ms, /*skip_lower_threads=*/ false)
+}
+
+fn run_check_multi_opts(
+    ms: &MultiSource,
+    skip_lower_threads: bool,
+) -> miette::Result<(arch::ast::SourceFile, resolve::SymbolTable, std::collections::HashMap<usize, usize>)> {
     let source = &ms.combined;
 
     // Lex
@@ -1038,11 +1090,17 @@ fn run_check_multi(
         ms.report_error(err)
     })?;
 
-    // Lower thread blocks to FSM + inst
-    let ast = elaborate::lower_threads(ast).map_err(|errs| {
-        let err = errs.into_iter().next().unwrap();
-        ms.report_error(err)
-    })?;
+    // Lower thread blocks to FSM + inst (skipped under --thread-sim parallel,
+    // where the new pre-lowering thread sim emitter consumes thread blocks
+    // directly via coroutines).
+    let ast = if skip_lower_threads {
+        ast
+    } else {
+        elaborate::lower_threads(ast).map_err(|errs| {
+            let err = errs.into_iter().next().unwrap();
+            ms.report_error(err)
+        })?
+    };
 
     // Lower `pipe_reg<T, N>` ports with N > 1 into an N-stage cascade.
     let ast = elaborate::lower_pipe_reg_ports(ast).map_err(|errs| {

--- a/src/sim_codegen/fsm.rs
+++ b/src/sim_codegen/fsm.rs
@@ -139,8 +139,11 @@ impl<'a> SimCodegen<'a> {
                 h.push_str(&format!("  {} {};\n", ty, reg.name.name));
             }
         }
-        // Let bindings as public members
+        // Let bindings as public members. Skip lets that alias an existing
+        // output port (no separate storage — `eval_comb` writes the port
+        // directly via the let's RHS).
         for lb in &f.lets {
+            if port_names.contains(&lb.name.name) { continue; }
             let ty = lb.ty.as_ref().map(|t| cpp_internal_type(t)).unwrap_or_else(|| "uint32_t".to_string());
             h.push_str(&format!("  {} {};\n", ty, lb.name.name));
         }
@@ -232,11 +235,18 @@ impl<'a> SimCodegen<'a> {
             if let Some(ty) = &l.ty { fsm_widths.insert(l.name.name.clone(), type_bits_te(ty)); }
         }
         for w in &f.wires { fsm_widths.insert(w.name.name.clone(), type_bits_te(&w.ty)); }
+        // Built-in `state` identifier inside fsm scope: read of the current
+        // encoded state. Lowers to `_state_r` in sim, with width = clog2(N).
+        fsm_widths.insert("state".to_string(), state_bits as u32);
+        let fsm_ident_subst: HashMap<String, String> = std::iter::once(
+            ("state".to_string(), "_state_r".to_string())
+        ).collect();
         let ctx_fsm = {
             let mut c = Ctx::new(&fsm_reg_names, &port_names, &fsm_let_names, &empty_insts,
                                  &empty_wide, &fsm_widths, &enum_map, &bus_port_names)
                 .with_vec_names(&fsm_vec_names)
-                .with_fsm_vec_port_regs(&fsm_vec_port_reg_names);
+                .with_fsm_vec_port_regs(&fsm_vec_port_reg_names)
+                .with_ident_subst(&fsm_ident_subst);
             c.fsm_mode = true;
             c
         };
@@ -292,7 +302,8 @@ impl<'a> SimCodegen<'a> {
             let mut c = Ctx::new(&fsm_reg_names, &port_names, &fsm_let_names, &empty_insts,
                                  &empty_wide, &fsm_widths, &enum_map, &bus_port_names)
                 .with_vec_names(&fsm_vec_names)
-                .with_fsm_vec_port_regs(&fsm_vec_port_reg_names);
+                .with_fsm_vec_port_regs(&fsm_vec_port_reg_names)
+                .with_ident_subst(&fsm_ident_subst);
             c.posedge_lhs = true;
             c.fsm_mode = true;
             c

--- a/src/sim_codegen/mod.rs
+++ b/src/sim_codegen/mod.rs
@@ -28,6 +28,7 @@ mod linklist;
 mod pipeline;
 mod ram;
 mod cam;
+pub mod thread_sim;
 
 // ── Public API ────────────────────────────────────────────────────────────────
 
@@ -1590,6 +1591,11 @@ impl<'a> Ctx<'a> {
 
     fn with_fsm_vec_port_regs(mut self, fsm_vec_port_regs: &'a HashSet<String>) -> Self {
         self.fsm_vec_port_regs = Some(fsm_vec_port_regs);
+        self
+    }
+
+    fn with_ident_subst(mut self, ident_subst: &'a HashMap<String, String>) -> Self {
+        self.ident_subst = Some(ident_subst);
         self
     }
 

--- a/src/sim_codegen/thread_sim.rs
+++ b/src/sim_codegen/thread_sim.rs
@@ -1,0 +1,297 @@
+// thread_sim.rs — Pre-lowering thread sim emitter (Phase 1 spike).
+//
+// Emits C++20 coroutine-based per-module classes that simulate `thread`
+// blocks directly, without lowering them to FSMs. See
+// doc/plan_thread_parallel_sim.md and runtime/arch_thread_rt.h for
+// design + runtime API.
+//
+// Scope (Phase 1): handles the spike target — single thread per module,
+// scalar Bool/UInt ports, `wait until <ident>` predicates, `wait <const>
+// cycle`, plain port assignments. Anything else returns an error so the
+// caller can fall back to the lowered-fsm path or report unsupported.
+
+use crate::ast::{
+    Direction, Expr, ExprKind, LitKind, ModuleBodyItem, ModuleDecl,
+    ResetLevel, ThreadBlock, ThreadStmt, TypeExpr, UnaryOp,
+};
+use crate::sim_codegen::SimModel;
+
+pub fn gen_module_thread(m: &ModuleDecl) -> Result<SimModel, String> {
+    let class = m.name.name.clone();
+
+    // Collect threads and reject unsupported features for Phase 1.
+    let threads: Vec<&ThreadBlock> = m.body.iter().filter_map(|i| match i {
+        ModuleBodyItem::Thread(t) => Some(t),
+        _ => None,
+    }).collect();
+    if threads.is_empty() {
+        return Err(format!("module `{}` has no thread blocks", class));
+    }
+    if threads.len() > 1 {
+        return Err(format!(
+            "module `{}` has {} thread blocks; Phase 1 spike supports 1 thread/module",
+            class, threads.len()
+        ));
+    }
+    let t = threads[0];
+    if t.tlm_target.is_some() || t.implement.is_some() || t.reentrant.is_some() {
+        return Err(format!("module `{}`: TLM/implement/reentrant threads not yet supported", class));
+    }
+    if t.default_when.is_some() {
+        return Err(format!("module `{}`: thread `default when` not yet supported", class));
+    }
+
+    // Reject non-thread top-level items the spike doesn't handle yet.
+    for item in &m.body {
+        match item {
+            ModuleBodyItem::Thread(_) => {}
+            ModuleBodyItem::RegDecl(_) => {} // accepted
+            ModuleBodyItem::LetBinding(_) => {} // accepted (assigned in eval)
+            _ => return Err(format!(
+                "module `{}`: thread sim Phase 1 only supports `thread` + `reg` + `let` items",
+                class
+            )),
+        }
+    }
+
+    let mut header = String::new();
+    header.push_str("#pragma once\n");
+    header.push_str("#include \"arch_thread_rt.h\"\n");
+    header.push_str("#include <cstdint>\n");
+    header.push_str("#include \"verilated.h\"\n\n");
+    header.push_str(&format!("class {} {{\npublic:\n", class));
+
+    // Identify clock and reset ports.
+    let clk_name = m.ports.iter()
+        .find(|p| matches!(&p.ty, TypeExpr::Clock(_)))
+        .map(|p| p.name.name.clone())
+        .ok_or_else(|| format!("module `{}` has no clock port", class))?;
+    let (rst_name, rst_active_low) = m.ports.iter()
+        .find_map(|p| match &p.ty {
+            TypeExpr::Reset(_, lvl) => Some((p.name.name.clone(), matches!(lvl, ResetLevel::Low))),
+            _ => None,
+        })
+        .ok_or_else(|| format!("module `{}` has no reset port", class))?;
+
+    // Emit port fields (scalar Bool/UInt only).
+    for p in &m.ports {
+        let cpp_ty = match &p.ty {
+            TypeExpr::Clock(_) | TypeExpr::Reset(..) | TypeExpr::Bool | TypeExpr::Bit => "uint8_t".to_string(),
+            TypeExpr::UInt(w) => uint_cpp_ty(eval_const(w))?,
+            other => return Err(format!(
+                "module `{}` port `{}`: type {:?} not supported by thread sim Phase 1",
+                class, p.name.name, other
+            )),
+        };
+        header.push_str(&format!("  {} {} = 0;\n", cpp_ty, p.name.name));
+    }
+    header.push('\n');
+
+    // Emit reg fields (scalar UInt/Bool).
+    for item in &m.body {
+        if let ModuleBodyItem::RegDecl(r) = item {
+            let cpp_ty = match &r.ty {
+                TypeExpr::Bool | TypeExpr::Bit => "uint8_t".to_string(),
+                TypeExpr::UInt(w) => uint_cpp_ty(eval_const(w))?,
+                other => return Err(format!(
+                    "module `{}` reg `{}`: type {:?} not supported",
+                    class, r.name.name, other
+                )),
+            };
+            header.push_str(&format!("  {} {} = 0;\n", cpp_ty, r.name.name));
+        }
+    }
+    header.push('\n');
+
+    // Identify which non-reg ports the thread writes — those get
+    // zeroed at the start of each tick (state-local comb semantic).
+    let driven_outputs = collect_thread_driven_outputs(t, m);
+
+    // Constructor + lifecycle.
+    header.push_str(&format!("  {}() {{\n", class));
+    header.push_str("    _slot.thread = make_thread();\n");
+    header.push_str("    _sched.slots.push_back(&_slot);\n");
+    header.push_str("  }\n");
+    header.push_str(&format!("  ~{}() {{ _slot.thread.destroy(); }}\n\n", class));
+
+    // eval(): combinational settle. For modules with `let` bindings we
+    // evaluate them here. Phase 1 supports trivial lets only.
+    header.push_str("  void eval() {\n");
+    for item in &m.body {
+        if let ModuleBodyItem::LetBinding(lb) = item {
+            let rhs = expr_to_cpp(&lb.value)?;
+            header.push_str(&format!("    {} = {};\n", lb.name.name, rhs));
+        }
+    }
+    header.push_str("  }\n\n");
+
+    // posedge handler: reset → recreate coroutine; else → default-zero
+    // outputs + tick scheduler.
+    header.push_str(&format!("  void posedge_{}() {{\n", clk_name));
+    let rst_check = if rst_active_low {
+        format!("if (!{}) {{", rst_name)
+    } else {
+        format!("if ({}) {{", rst_name)
+    };
+    header.push_str(&format!("    {}\n", rst_check));
+    for n in &driven_outputs {
+        header.push_str(&format!("      {} = 0;\n", n));
+    }
+    header.push_str("      _slot.thread.destroy();\n");
+    header.push_str("      _slot.thread = make_thread();\n");
+    header.push_str("      _slot.kind = arch_rt::WaitKind::Ready;\n");
+    header.push_str("      _slot.cycles_remaining = 0;\n");
+    header.push_str("      _slot.pred = nullptr;\n");
+    header.push_str("      return;\n");
+    header.push_str("    }\n");
+    // State-local comb default for thread-driven non-reg outputs.
+    for n in &driven_outputs {
+        header.push_str(&format!("    {} = 0;\n", n));
+    }
+    header.push_str("    _sched.tick();\n");
+    header.push_str("  }\n\n");
+
+    // Suppress unused-port warnings (clk/rst/inputs not read by host).
+    let _ = (&clk_name, &rst_name);
+
+    header.push_str("private:\n");
+    header.push_str("  arch_rt::ThreadScheduler _sched;\n");
+    header.push_str("  arch_rt::ThreadSlot      _slot;\n\n");
+
+    // Coroutine body.
+    header.push_str("  arch_rt::ArchThread make_thread() {\n");
+    let mut body_cpp = String::new();
+    emit_thread_body(&t.body, &mut body_cpp, 4)?;
+    header.push_str(&body_cpp);
+    header.push_str("    co_return;\n");
+    header.push_str("  }\n");
+
+    header.push_str("};\n");
+
+    // No separate .cpp; everything is inline header for the spike.
+    Ok(SimModel {
+        class_name: class.clone(),
+        header,
+        impl_: format!("// {} thread-sim: header-only (Phase 1 spike)\n", class),
+    })
+}
+
+fn emit_thread_body(stmts: &[ThreadStmt], out: &mut String, indent: usize) -> Result<(), String> {
+    let pad = " ".repeat(indent);
+    for s in stmts {
+        match s {
+            ThreadStmt::CombAssign(a) => {
+                let lhs = expr_to_cpp(&a.target)?;
+                let rhs = expr_to_cpp(&a.value)?;
+                out.push_str(&format!("{}{} = {};\n", pad, lhs, rhs));
+            }
+            ThreadStmt::SeqAssign(a) => {
+                let lhs = expr_to_cpp(&a.target)?;
+                let rhs = expr_to_cpp(&a.value)?;
+                out.push_str(&format!("{}{} = {};\n", pad, lhs, rhs));
+            }
+            ThreadStmt::WaitUntil(cond, _) => {
+                let pred = expr_to_cpp_bool(cond)?;
+                out.push_str(&format!(
+                    "{}co_await arch_rt::wait_until(&_slot, [this]{{ return {}; }});\n",
+                    pad, pred
+                ));
+            }
+            ThreadStmt::WaitCycles(n, _) => {
+                let n_str = match &n.kind {
+                    ExprKind::Literal(LitKind::Dec(v)) => format!("{}", v),
+                    ExprKind::Literal(LitKind::Sized(_, v)) => format!("{}", v),
+                    _ => return Err("wait <N> cycle: Phase 1 supports only literal N".into()),
+                };
+                out.push_str(&format!("{}co_await arch_rt::wait_cycles(&_slot, {});\n", pad, n_str));
+            }
+            other => return Err(format!("thread stmt not yet supported: {:?}", std::mem::discriminant(other))),
+        }
+    }
+    Ok(())
+}
+
+fn expr_to_cpp(e: &Expr) -> Result<String, String> {
+    match &e.kind {
+        ExprKind::Ident(n) => Ok(n.clone()),
+        ExprKind::Literal(LitKind::Dec(v)) => Ok(format!("{}", v)),
+        ExprKind::Literal(LitKind::Hex(v)) => Ok(format!("0x{:X}", v)),
+        ExprKind::Literal(LitKind::Bin(v)) => Ok(format!("{}", v)),
+        ExprKind::Literal(LitKind::Sized(_, v)) => Ok(format!("{}", v)),
+        ExprKind::Bool(true) => Ok("1".into()),
+        ExprKind::Bool(false) => Ok("0".into()),
+        ExprKind::Unary(UnaryOp::Not, inner) => Ok(format!("!({})", expr_to_cpp(inner)?)),
+        _ => Err(format!("expr shape not supported by thread sim Phase 1: {:?}", std::mem::discriminant(&e.kind))),
+    }
+}
+
+// Predicate context: coerce ident/expr to a C++ bool comparison.
+fn expr_to_cpp_bool(e: &Expr) -> Result<String, String> {
+    match &e.kind {
+        ExprKind::Ident(n) => Ok(format!("{} != 0", n)),
+        ExprKind::Bool(true) => Ok("true".into()),
+        ExprKind::Bool(false) => Ok("false".into()),
+        ExprKind::Unary(UnaryOp::Not, inner) => Ok(format!("!({})", expr_to_cpp_bool(inner)?)),
+        _ => expr_to_cpp(e),
+    }
+}
+
+fn eval_const(e: &Expr) -> u64 {
+    match &e.kind {
+        ExprKind::Literal(LitKind::Dec(v)) => *v,
+        ExprKind::Literal(LitKind::Hex(v)) => *v,
+        ExprKind::Literal(LitKind::Bin(v)) => *v,
+        ExprKind::Literal(LitKind::Sized(_, v)) => *v,
+        _ => 0,
+    }
+}
+
+fn uint_cpp_ty(bits: u64) -> Result<String, String> {
+    Ok(match bits {
+        0 => return Err("UInt<0> not supported".into()),
+        1..=8 => "uint8_t".to_string(),
+        9..=16 => "uint16_t".to_string(),
+        17..=32 => "uint32_t".to_string(),
+        33..=64 => "uint64_t".to_string(),
+        _ => return Err(format!("UInt<{}> > 64 bits not supported by thread sim Phase 1", bits)),
+    })
+}
+
+fn collect_thread_driven_outputs(t: &ThreadBlock, m: &ModuleDecl) -> Vec<String> {
+    use std::collections::HashSet;
+    let mut out: HashSet<String> = HashSet::new();
+    let port_outs: HashSet<&str> = m.ports.iter()
+        .filter(|p| p.direction == Direction::Out && p.reg_info.is_none())
+        .map(|p| p.name.name.as_str())
+        .collect();
+    fn walk(stmts: &[ThreadStmt], port_outs: &HashSet<&str>, out: &mut HashSet<String>) {
+        for s in stmts {
+            match s {
+                ThreadStmt::CombAssign(a) => {
+                    if let ExprKind::Ident(n) = &a.target.kind {
+                        if port_outs.contains(n.as_str()) { out.insert(n.clone()); }
+                    }
+                }
+                ThreadStmt::IfElse(ie) => {
+                    walk(&ie.then_stmts, port_outs, out);
+                    walk(&ie.else_stmts, port_outs, out);
+                }
+                ThreadStmt::For { body, .. } => walk(body, port_outs, out),
+                ThreadStmt::Lock { body, .. } => walk(body, port_outs, out),
+                ThreadStmt::DoUntil { body, .. } => walk(body, port_outs, out),
+                ThreadStmt::ForkJoin(branches, _) => {
+                    for b in branches { walk(b, port_outs, out); }
+                }
+                _ => {}
+            }
+        }
+    }
+    walk(&t.body, &port_outs, &mut out);
+    let mut v: Vec<String> = out.into_iter().collect();
+    v.sort();
+    v
+}
+
+pub fn arch_thread_rt_h() -> &'static str {
+    include_str!("../../runtime/arch_thread_rt.h")
+}

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -793,8 +793,45 @@ impl<'a> TypeChecker<'a> {
                         }
                     }
                 }
-                ModuleBodyItem::Thread(_) | ModuleBodyItem::Resource(_) => {
-                    // Threads and resources are lowered before typecheck.
+                ModuleBodyItem::Thread(t) => {
+                    // Under --thread-sim parallel, lower_threads is skipped,
+                    // so threads survive to typecheck. Mark thread-driven
+                    // signals (CombAssign + SeqAssign LHS) as driven so the
+                    // single-driver check sees them. Full typecheck of thread
+                    // bodies is light in Phase 1 (the spike emitter rejects
+                    // unsupported shapes itself).
+                    fn walk_thread(stmts: &[crate::ast::ThreadStmt], driven: &mut HashSet<String>) {
+                        use crate::ast::ThreadStmt;
+                        for s in stmts {
+                            match s {
+                                ThreadStmt::CombAssign(a) => {
+                                    if let crate::ast::ExprKind::Ident(n) = &a.target.kind {
+                                        driven.insert(n.clone());
+                                    }
+                                }
+                                ThreadStmt::SeqAssign(a) => {
+                                    if let crate::ast::ExprKind::Ident(n) = &a.target.kind {
+                                        driven.insert(n.clone());
+                                    }
+                                }
+                                ThreadStmt::IfElse(ie) => {
+                                    walk_thread(&ie.then_stmts, driven);
+                                    walk_thread(&ie.else_stmts, driven);
+                                }
+                                ThreadStmt::For { body, .. }
+                                | ThreadStmt::Lock { body, .. }
+                                | ThreadStmt::DoUntil { body, .. } => walk_thread(body, driven),
+                                ThreadStmt::ForkJoin(branches, _) => {
+                                    for b in branches { walk_thread(b, driven); }
+                                }
+                                _ => {}
+                            }
+                        }
+                    }
+                    walk_thread(&t.body, &mut driven);
+                }
+                ModuleBodyItem::Resource(_) => {
+                    // Resources are lowered before typecheck.
                 }
                 ModuleBodyItem::Assert(a) => {
                     // Verify expr is Bool; require a Clock port

--- a/tests/cvdp/Bitstream.arch
+++ b/tests/cvdp/Bitstream.arch
@@ -1,4 +1,4 @@
-module Bitstream
+fsm Bitstream
   port clk: in Clock<SysDomain>;
   port rst_n: in Reset<Async, Low>;
   port enb: in Bool;
@@ -10,89 +10,60 @@ module Bitstream
   port rinc_out: out Bool;
   port curr_state: out UInt<2>;
 
-  reg default: reset rst_n => 0;
+  reg bp:       UInt<4> reset rst_n => 0;
+  reg byte_buf: UInt<8> reset rst_n => 0;
 
-  // State register: 0=IDLE, 1=WaitR, 2=Ready
-  reg state_r: UInt<2>;
-  // Data registers
-  reg bp: UInt<4>;
-  reg byte_buf: UInt<8>;
-
-  let curr_state = state_r;
+  // Mirror the encoded fsm state onto the user-declared output port.
+  // Encoding follows declaration order (Idle=0, WaitR=1, Ready=2),
+  // matching the original UInt<2> encoding.
+  let curr_state = state;
 
   // rde: read-done flag (bp[3]=1 means all 8 bits consumed)
   let rde: Bool = bp[3];
 
-  // Combinatorial outputs based on CURRENT state and inputs
-  wire rinc_out_c: Bool;
-  wire rempty_out_c: Bool;
-
-  comb
-    if state_r == 0
-      // IDLE
-      rinc_out_c = false;
-      rempty_out_c = true;
-    elsif state_r == 1
-      // WaitR
-      rempty_out_c = true;
-      if rempty_in
-        rinc_out_c = false;
-      else
-        rinc_out_c = true;
-      end if
-    elsif state_r == 2
-      // Ready
-      if rde
-        if rempty_in
-          rinc_out_c = false;
-          rempty_out_c = true;
-        else
-          rinc_out_c = true;
-          rempty_out_c = true;
-        end if
-      else
-        rinc_out_c = false;
-        rempty_out_c = false;
-      end if
-    else
-      rinc_out_c = false;
-      rempty_out_c = true;
-    end if
-
-    rinc_out = rinc_out_c;
-    rempty_out = rempty_out_c;
-    // o_bit: combinatorial from current byte_buf and bp
-    o_bit = byte_buf[bp[2:0]];
-  end comb
-
+  state [Idle, WaitR, Ready]
+  default state Idle;
   default seq on clk rising;
 
-  seq
-    // State machine transitions
-    if state_r == 0
-      // IDLE
-      if enb
-        state_r <= 1;
+  default
+    comb
+      rinc_out   = false;
+      rempty_out = true;
+      o_bit      = byte_buf[bp[2:0]];
+    end comb
+    seq
+      // Datapath updates gated on the state's effective rinc_out value.
+      if rinc_out
+        byte_buf <= i_byte;
+        bp       <= 0;
+      elsif rinc_in & ~rempty_out
+        bp <= (bp + 4'b0001).trunc<4>();
       end if
-    elsif state_r == 1
-      // WaitR
-      if ~rempty_in
-        state_r <= 2;
-      end if
-    elsif state_r == 2
-      // Ready
-      if rde & rempty_in
-        state_r <= 1;
-      end if
-    end if
+    end seq
+  end default
 
-    // Update data registers based on combinatorial rinc_out
-    if rinc_out_c
-      byte_buf <= i_byte;
-      bp <= 0;
-    elsif rinc_in & ~rempty_out_c
-      bp <= (bp + 4'b0001).trunc<4>();
-    end if
-  end seq
+  state Idle
+    -> WaitR when enb;
+  end state Idle
 
-end module Bitstream
+  state WaitR
+    comb
+      rinc_out = ~rempty_in;
+    end comb
+    -> Ready when ~rempty_in;
+  end state WaitR
+
+  state Ready
+    comb
+      if rde
+        rinc_out   = ~rempty_in;
+        rempty_out = true;
+      else
+        rinc_out   = false;
+        rempty_out = false;
+      end if
+    end comb
+    -> WaitR when rde & rempty_in;
+  end state Ready
+
+end fsm Bitstream

--- a/tests/cvdp/Bitstream.sv
+++ b/tests/cvdp/Bitstream.sv
@@ -11,86 +11,94 @@ module Bitstream (
   output logic [1:0] curr_state
 );
 
-  // State register: 0=IDLE, 1=WaitR, 2=Ready
-  logic [1:0] state_r;
-  // Data registers
+  typedef enum logic [1:0] {
+    IDLE = 2'd0,
+    WAITR = 2'd1,
+    READY = 2'd2
+  } Bitstream_state_t;
+  
+  Bitstream_state_t state_r, state_next;
+  
   logic [3:0] bp;
   logic [7:0] byte_buf;
+  
   assign curr_state = state_r;
-  // rde: read-done flag (bp[3]=1 means all 8 bits consumed)
   logic rde;
   assign rde = bp[3];
-  // Combinatorial outputs based on CURRENT state and inputs
-  logic rinc_out_c;
-  logic rempty_out_c;
-  always_comb begin
-    if (state_r == 0) begin
-      // IDLE
-      rinc_out_c = 1'b0;
-      rempty_out_c = 1'b1;
-    end else if (state_r == 1) begin
-      // WaitR
-      rempty_out_c = 1'b1;
-      if (rempty_in) begin
-        rinc_out_c = 1'b0;
-      end else begin
-        rinc_out_c = 1'b1;
-      end
-    end else if (state_r == 2) begin
-      // Ready
-      if (rde) begin
-        if (rempty_in) begin
-          rinc_out_c = 1'b0;
-          rempty_out_c = 1'b1;
-        end else begin
-          rinc_out_c = 1'b1;
-          rempty_out_c = 1'b1;
-        end
-      end else begin
-        rinc_out_c = 1'b0;
-        rempty_out_c = 1'b0;
-      end
-    end else begin
-      rinc_out_c = 1'b0;
-      rempty_out_c = 1'b1;
-    end
-    rinc_out = rinc_out_c;
-    rempty_out = rempty_out_c;
-    // o_bit: combinatorial from current byte_buf and bp
-    o_bit = byte_buf[bp[2:0]];
-  end
+  
   always_ff @(posedge clk or negedge rst_n) begin
     if ((!rst_n)) begin
+      state_r <= IDLE;
       bp <= 0;
       byte_buf <= 0;
-      state_r <= 0;
     end else begin
-      // State machine transitions
-      if (state_r == 0) begin
-        // IDLE
-        if (enb) begin
-          state_r <= 1;
-        end
-      end else if (state_r == 1) begin
-        // WaitR
-        if (~rempty_in) begin
-          state_r <= 2;
-        end
-      end else if (state_r == 2) begin
-        // Ready
-        if (rde & rempty_in) begin
-          state_r <= 1;
-        end
-      end
-      // Update data registers based on combinatorial rinc_out
-      if (rinc_out_c) begin
+      state_r <= state_next;
+      // Mirror the encoded fsm state onto the user-declared output port.
+      // Encoding follows declaration order (Idle=0, WaitR=1, Ready=2),
+      // matching the original UInt<2> encoding.
+      // rde: read-done flag (bp[3]=1 means all 8 bits consumed)
+      // Datapath updates gated on the state's effective rinc_out value.
+      if (rinc_out) begin
         byte_buf <= i_byte;
         bp <= 0;
-      end else if (rinc_in & ~rempty_out_c) begin
+      end else if (rinc_in & ~rempty_out) begin
         bp <= 4'(bp + 4'd1);
       end
+      case (state_r)
+        default: ;
+      endcase
     end
   end
+  
+  always_comb begin
+    state_next = state_r; // hold by default
+    case (state_r)
+      IDLE: begin
+        if (enb) state_next = WAITR;
+      end
+      WAITR: begin
+        if (~rempty_in) state_next = READY;
+      end
+      READY: begin
+        if (rde & rempty_in) state_next = WAITR;
+      end
+      default: state_next = state_r;
+    endcase
+  end
+  
+  always_comb begin
+    rinc_out = 1'b0;
+    rempty_out = 1'b1;
+    o_bit = byte_buf[bp[2:0]];
+    case (state_r)
+      IDLE: begin
+      end
+      WAITR: begin
+        rinc_out = ~rempty_in;
+      end
+      READY: begin
+        if (rde) begin
+          rinc_out = ~rempty_in;
+          rempty_out = 1'b1;
+        end else begin
+          rinc_out = 1'b0;
+          rempty_out = 1'b0;
+        end
+      end
+      default: ;
+    endcase
+  end
+  
+  // synopsys translate_off
+  _auto_legal_state: assert property (@(posedge clk) rst_n |-> state_r < 3)
+    else $fatal(1, "FSM ILLEGAL STATE: Bitstream.state_r = %0d", state_r);
+  _auto_reach_Idle: cover property (@(posedge clk) state_r == IDLE);
+  _auto_reach_WaitR: cover property (@(posedge clk) state_r == WAITR);
+  _auto_reach_Ready: cover property (@(posedge clk) state_r == READY);
+  _auto_tr_IDLE_to_WAITR: cover property (@(posedge clk) state_r == IDLE && state_next == WAITR);
+  _auto_tr_WAITR_to_READY: cover property (@(posedge clk) state_r == WAITR && state_next == READY);
+  _auto_tr_READY_to_WAITR: cover property (@(posedge clk) state_r == READY && state_next == WAITR);
+  // synopsys translate_on
 
 endmodule
 


### PR DESCRIPTION
## Summary

Three threaded changes from one session, bundled because they share `src/sim_codegen/mod.rs` touches:

### 1. `--thread-sim parallel` (main work)

Phase 1 spike of the pre-lowering thread sim path described in [doc/plan_thread_parallel_sim.md](doc/plan_thread_parallel_sim.md).

- New CLI flag `--thread-sim {fsm,parallel}` (default `fsm`, unchanged behavior).
- When `parallel`: `lower_threads` is skipped; modules with `thread` blocks route to a new emitter ([src/sim_codegen/thread_sim.rs](src/sim_codegen/thread_sim.rs)) that emits a header-only C++20 coroutine class per module.
- New runtime header [runtime/arch_thread_rt.h](runtime/arch_thread_rt.h): `wait_until` / `wait_cycles` awaiters, single-thread scheduler with per-tick advance + resume.
- C++ build switches to `-std=c++20` under `--thread-sim parallel`.
- `tests/thread/wait_cycles.arch` (DelayPulse) passes 9/9 cycles via the new path, bit-identical to the lowered-fsm sim output.

**Phase 1 limits** (anything else returns a clean error so Phase 1.5 can incrementally widen):
- One thread per module
- Scalar `Bool` / `UInt<N>` (N ≤ 64) ports + regs
- `wait until <ident>`, `wait <literal> cycle`
- Plain port assigns

The hand-written spike that validated the runtime design lives at [runtime/spike/](runtime/spike/) for reference.

### 2. fsm `state` builtin (related, demo'd on Bitstream)

`let curr_state = state;` inside an fsm now resolves to the encoded current-state register — `state_r` in SV (with implicit enum→logic cast) and `_state_r` in sim. Encoding follows declaration order (`Idle=0, WaitR=1, …`), matching the implicit convention. No new grammar — purely an ident substitution in fsm scope.

[tests/cvdp/Bitstream.arch](tests/cvdp/Bitstream.arch) refactored as the demo consumer: now an `fsm` with three named states + `let curr_state = state;` instead of a hand-rolled `module` with `reg state_r: UInt<2>` + elsif chains. All 5 CVDP tests still PASS.

### 3. Coverage Phase 6 todo (doc only)

[doc/plan_arch_coverage.md](doc/plan_arch_coverage.md) gains a Phase 6 section describing construct-port toggle coverage instrumented from the consumer side (per-port `_prev_<inst>_<port>` shadows + popcount in `gen_module`'s eval). Not implemented; design sketch only, awaiting a real consumer ask to promote.

## Test plan

- [x] `cargo build` — clean
- [x] `cargo test --lib` — 15/15 PASS
- [x] `cargo test --test integration_test` — 167/167 PASS
- [x] `arch sim --thread-sim parallel tests/thread/wait_cycles.arch --tb tb.cpp` — 9/9 PASS, cycle-accurate match to default fsm path
- [x] `arch sim tests/thread/wait_cycles.arch --tb tb.cpp` (default `--thread-sim fsm`) — unchanged
- [x] CVDP `Bitstream` — 5/5 PASS via `python3 run_cvdp.py Bitstream`
- [x] CVDP `Attenuator`, `fsm_seq_detector` — spot-checked PASS
- [x] `arch build tests/axi_dma/Fsm{Mm2s,S2mm,SgEngine}.arch` — clean (no SV regressions)