### PR TITLE
fix(elaborate): collapse redundant wait state in thread lowering

### DIFF
--- a/src/elaborate.rs
+++ b/src/elaborate.rs
@@ -2283,13 +2283,13 @@ fn partition_thread_body(
                 cur_seq.push(Stmt::Log(l.clone()));
             }
             ThreadStmt::WaitUntil(cond, _) => {
-                // `wait until` is a pure state boundary.
-                // ALL pending assigns (comb + seq) go into a prior state
-                // that fires once and advances unconditionally.
-                // Use `do..until` instead when comb outputs must be held while waiting.
-                if !cur_comb.is_empty() || !cur_seq.is_empty() {
+                // Comb assigns flow INTO the wait state so they hold while
+                // waiting (matches `valid=1; wait until ready;` AXI intent).
+                // Seq assigns (`<=`) still need a fire-once predecessor state
+                // — putting them in the wait state would re-fire each cycle.
+                if !cur_seq.is_empty() {
                     states.push(ThreadFsmState {
-                        comb_stmts: std::mem::take(&mut cur_comb),
+                        comb_stmts: Vec::new(),
                         seq_stmts: std::mem::take(&mut cur_seq),
                         transition_cond: None,
                         wait_cycles: None,
@@ -2297,7 +2297,7 @@ fn partition_thread_body(
                     });
                 }
                 states.push(ThreadFsmState {
-                    comb_stmts: Vec::new(),
+                    comb_stmts: std::mem::take(&mut cur_comb),
                     seq_stmts: Vec::new(),
                     transition_cond: Some(cond.clone()),
                     wait_cycles: None,


### PR DESCRIPTION
## Summary

\`valid = 1; wait until ready;\` was lowering to **two** states — a fire-once predecessor that asserts \`valid=1\`, then an empty wait state where \`valid\` falls back to its default 0. The comment in \`partition_thread_body\` explicitly acknowledged this and told users to use \`do..until\` to hold outputs across the wait.

This is wrong for the standard AXI valid/ready intuition. For:
\`\`\`
thread on clk rising, rst_n low
  valid = 1
  wait until ready
end thread
\`\`\`

the user expects \`valid\` to hold for the entire wait. With the buggy lowering, if the receiver isn't already asserting \`ready\` when \`valid\` pulses for one cycle, the handshake **misses**.

## Fix

Split pending statements before a \`wait until\` by kind:
- **SeqAssign (\`<=\`)**: keeps the fire-once predecessor state. Registered writes need to fire exactly once, not re-fire each cycle the wait persists.
- **CombAssign (\`=\`)**: flows **into** the wait state's \`comb_stmts\` so it holds while the wait predicate is being evaluated each cycle.

## Effects on lowered SV

A single-segment thread like \`ThreadIfElse\` goes from 2 states (assert + wait) to 1 state (assert + wait fused). End-to-end latency per iteration drops by 1 cycle. The wait state's \`comb\` block now contains the held assertions instead of defaulting to 0.

## Cross-check

Verified against \`arch sim --thread-sim parallel\` (PR #143):
- \`BasicThread\` now produces bit-identical output on both paths (C0..C3 same).

## Test plan

- [x] \`cargo test --lib\` — 15/15
- [x] \`cargo test --test integration_test\` — 167/167
- [x] All 11 \`tests/thread/*.arch\` build cleanly (the 2 that don't are pre-existing parser issues unrelated to this change)
- [x] \`tests/axi_dma_thread/Thread{Mm2s,S2mm}.arch\` build cleanly