### PR TITLE
fix(elaborate): elide redundant join state in fork/join lowering

### DIFF
--- a/src/elaborate.rs
+++ b/src/elaborate.rs
@@ -2644,10 +2644,21 @@ fn lower_fork_join(
         }
 
         if all_done {
-            result.push(ThreadFsmState {
-                comb_stmts: comb, seq_stmts: seq,
-                transition_cond: None, wait_cycles: None, multi_transitions: Vec::new(),
-            });
+            // Skip the all-done product state. The done-marker per-branch
+            // states are already empty (lines 2597-2600 push them with
+            // empty comb/seq), so the merged comb/seq here are also
+            // empty — this state is purely a 1-cycle pass-through.
+            // Multi-transitions in non-all_done states encode their
+            // destination as `total - 1` (= the would-be all_done
+            // index) which, after `fork_base` adjustment in
+            // `partition_thread_body`, points at the first post-fork
+            // state. Eliding the all_done state removes one cycle of
+            // FSM-state-cranking latency at every join.
+            //
+            // Sanity assert: comb + seq merged here must be empty
+            // (otherwise we'd be losing user-driven assignments).
+            debug_assert!(comb.is_empty() && seq.is_empty(),
+                "fork all_done state non-empty — branch done-hold states have unexpected content");
             continue;
         }
 


### PR DESCRIPTION
## Summary

Same shape of bug as PR #145's wait-state fix, applied to fork/join.

\`lower_fork_join\` was pushing an empty \"all-done\" product state — a 1-cycle pass-through with empty comb, empty seq, no transitions. The FSM-state emission then adds an unconditional advance to that empty state, costing **one wasted cycle at every join**.

## Fix

Skip pushing the all-done product state in \`lower_fork_join\`. The multi-transitions in non-all-done states already encode the all-done destination as \`total - 1\` (the would-be all-done index). After the caller's \`fork_base\` adjustment in \`partition_thread_body\`, that index points exactly at the first post-fork state. So eliding the empty state collapses one cycle of FSM-state-cranking latency.

Sanity: \`debug_assert!\` that the merged comb+seq for the all-done state is empty before eliding (the per-branch done-marker states are pushed empty at lines 2597-2600, so this should always hold).

## Verification

Tested on \`tests/thread/fork_join.arch\` (AxiWrite — fork+join with AW/W parallel + b_ready after join):
- **Before**: lowered FSM took one full extra cycle for the all-done pass-through state before reaching b_ready.
- **After**: b_ready asserts the cycle immediately following both branches' completion.
- **Cross-check**: against \`arch sim --thread-sim parallel\` (PR #144, pending) — now **bit-identical** on C0..C3.

## Test plan

- [x] \`cargo test --lib\` — 15/15
- [x] \`cargo test --test integration_test\` — 167/167
- [x] \`tests/thread/fork_join.arch\` builds + simulates correctly
- [x] All other thread tests still build cleanly