### PR TITLE
feat(sim): `--thread-sim both` cross-check harness via two-process diff

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -361,14 +361,21 @@ fn main() -> miette::Result<()> {
             // → Some(None) → default "coverage.dat"; absent → None.
             let cov_dat_path: Option<String> = coverage_dat.map(|opt| opt.unwrap_or_else(|| "coverage.dat".to_string()));
             let coverage = coverage || cov_dat_path.is_some();
-            let thread_sim_parallel = match thread_sim.as_str() {
-                "fsm" => false,
-                "parallel" => true,
-                other => return Err(miette::miette!("--thread-sim: expected `fsm` or `parallel`, got `{}`", other)),
-            };
-            learn_wrap(&arch_files, || {
-                run_sim(&arch_files, &tb_files, outdir.as_deref(), check_uninit, inputs_start_uninit, check_uninit_ram, cdc_random, wave.as_deref(), dbg_ports, debug_depth, debug_fsm, coverage, cov_dat_path.clone(), thread_sim_parallel, pybind, test.as_deref(), pybind_module_name.as_deref())
-            })
+            match thread_sim.as_str() {
+                "fsm" => learn_wrap(&arch_files, || {
+                    run_sim(&arch_files, &tb_files, outdir.as_deref(), check_uninit, inputs_start_uninit, check_uninit_ram, cdc_random, wave.as_deref(), dbg_ports, debug_depth, debug_fsm, coverage, cov_dat_path.clone(), false, pybind, test.as_deref(), pybind_module_name.as_deref())
+                }),
+                "parallel" => learn_wrap(&arch_files, || {
+                    run_sim(&arch_files, &tb_files, outdir.as_deref(), check_uninit, inputs_start_uninit, check_uninit_ram, cdc_random, wave.as_deref(), dbg_ports, debug_depth, debug_fsm, coverage, cov_dat_path.clone(), true, pybind, test.as_deref(), pybind_module_name.as_deref())
+                }),
+                "both" => {
+                    // Cross-check: build + run both fsm and parallel sims
+                    // independently with --debug, then diff the port-change
+                    // traces. Mismatch ⇒ abort with first divergence.
+                    run_thread_sim_cross_check(&arch_files, &tb_files, outdir.as_deref())
+                }
+                other => return Err(miette::miette!("--thread-sim: expected `fsm`, `parallel`, or `both`, got `{}`", other)),
+            }
         }
         Command::Build { files, o } => {
             let files_for_learn = files.clone();
@@ -473,6 +480,93 @@ fn main() -> miette::Result<()> {
     }
 }
 
+/// `--thread-sim both` driver: build + run fsm and parallel sims
+/// independently with --debug, then diff their port-change traces.
+/// Mismatch ⇒ abort with the first divergence highlighted.
+fn run_thread_sim_cross_check(
+    arch_files: &[PathBuf],
+    tb_files: &[PathBuf],
+    outdir: Option<&std::path::Path>,
+) -> miette::Result<()> {
+    let base = outdir.map(|p| p.to_path_buf()).unwrap_or_else(|| PathBuf::from("arch_sim_build"));
+    let fsm_dir = base.with_file_name(format!("{}_fsm", base.file_name().and_then(|s| s.to_str()).unwrap_or("arch_sim_build")));
+    let par_dir = base.with_file_name(format!("{}_par", base.file_name().and_then(|s| s.to_str()).unwrap_or("arch_sim_build")));
+
+    eprintln!("=== arch sim --thread-sim both: building fsm path ===");
+    let fsm_trace = build_and_capture(arch_files, tb_files, &fsm_dir, /*parallel=*/false)?;
+    eprintln!("=== arch sim --thread-sim both: building parallel path ===");
+    let par_trace = build_and_capture(arch_files, tb_files, &par_dir, /*parallel=*/true)?;
+
+    // Filter to just the [cycle][...] debug lines, ignore TB output.
+    let extract_trace = |s: &str| -> Vec<String> {
+        s.lines()
+            .filter(|l| l.starts_with('[') && l.contains("](in)") || l.contains("](out)"))
+            .map(|l| l.to_string())
+            .collect()
+    };
+    let fsm_lines = extract_trace(&fsm_trace);
+    let par_lines = extract_trace(&par_trace);
+
+    if fsm_lines == par_lines {
+        eprintln!("=== Cross-check PASS: {} port-change events match ===", fsm_lines.len());
+        return Ok(());
+    }
+
+    eprintln!("=== Cross-check FAIL: traces diverge ===");
+    let n = fsm_lines.len().max(par_lines.len());
+    let empty = String::new();
+    for i in 0..n {
+        let f = fsm_lines.get(i).unwrap_or(&empty);
+        let p = par_lines.get(i).unwrap_or(&empty);
+        if f != p {
+            eprintln!("  first divergence at event #{}:", i);
+            eprintln!("    fsm:      {}", f);
+            eprintln!("    parallel: {}", p);
+            return Err(miette::miette!("--thread-sim both: cross-check failed"));
+        }
+    }
+    Err(miette::miette!("--thread-sim both: trace lengths differ ({} fsm vs {} parallel)",
+        fsm_lines.len(), par_lines.len()))
+}
+
+/// Helper for run_thread_sim_cross_check: build a sim binary in `dir`
+/// (fsm or parallel mode), run it, capture its stdout.
+fn build_and_capture(
+    arch_files: &[PathBuf],
+    tb_files: &[PathBuf],
+    dir: &std::path::Path,
+    parallel: bool,
+) -> miette::Result<String> {
+    // Capture stdout via a temp file: redirect the child's stdout to it,
+    // then read it back. Easier than threading capture through run_sim.
+    let stdout_path = dir.with_extension("trace.txt");
+    // Ensure clean dir + previous trace.
+    let _ = std::fs::remove_dir_all(dir);
+    let _ = std::fs::remove_file(&stdout_path);
+    fs::create_dir_all(dir).into_diagnostic()?;
+
+    // Generate models + verilated stubs into dir.
+    run_sim_opts(
+        arch_files, tb_files, Some(dir),
+        /*check_uninit*/ false, /*inputs_start_uninit*/ false, /*check_uninit_ram*/ false,
+        /*cdc_random*/ false, /*wave*/ None,
+        /*debug*/ true, /*debug_depth*/ 1, /*debug_fsm*/ false,
+        /*coverage*/ false, /*coverage_dat*/ None,
+        parallel,
+        /*pybind*/ false, /*test_file*/ None, /*pybind_module_name_override*/ None,
+        /*no_exit*/ true,
+    )?;
+
+    // The sim_out binary was already executed by run_sim; capture its
+    // stdout would require modifying run_sim. For now, run the binary
+    // a second time and capture this run.
+    let sim_bin = dir.join("sim_out");
+    let output = std::process::Command::new(&sim_bin)
+        .output()
+        .into_diagnostic()?;
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
 #[allow(clippy::too_many_arguments)]
 fn run_sim(
     arch_files: &[PathBuf],
@@ -492,6 +586,32 @@ fn run_sim(
     pybind: bool,
     test_file: Option<&std::path::Path>,
     pybind_module_name_override: Option<&str>,
+) -> miette::Result<()> {
+    run_sim_opts(arch_files, tb_files, outdir, check_uninit, inputs_start_uninit, check_uninit_ram,
+        cdc_random, wave, debug, debug_depth, debug_fsm, coverage, coverage_dat, thread_sim_parallel,
+        pybind, test_file, pybind_module_name_override, /*no_exit=*/false)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn run_sim_opts(
+    arch_files: &[PathBuf],
+    tb_files: &[PathBuf],
+    outdir: Option<&std::path::Path>,
+    check_uninit: bool,
+    inputs_start_uninit: bool,
+    check_uninit_ram: bool,
+    cdc_random: bool,
+    wave: Option<&std::path::Path>,
+    debug: bool,
+    debug_depth: u32,
+    debug_fsm: bool,
+    coverage: bool,
+    coverage_dat: Option<String>,
+    thread_sim_parallel: bool,
+    pybind: bool,
+    test_file: Option<&std::path::Path>,
+    pybind_module_name_override: Option<&str>,
+    no_exit: bool,
 ) -> miette::Result<()> {
     // 1. Parse + type-check
     let all_files = resolve_use_imports(arch_files)?;
@@ -514,7 +634,7 @@ fn run_sim(
             if let arch::ast::Item::Module(m) = item {
                 let has_thread = m.body.iter().any(|i| matches!(i, arch::ast::ModuleBodyItem::Thread(_)));
                 if has_thread {
-                    let model = arch::sim_codegen::thread_sim::gen_module_thread(m)
+                    let model = arch::sim_codegen::thread_sim::gen_module_thread(m, debug)
                         .map_err(|e| miette::miette!("thread sim: {}", e))?;
                     out.push(model);
                 }
@@ -846,6 +966,14 @@ sys.exit(0 if ok else 1)
     if let Some(wave_path) = wave {
         run_cmd.arg(format!("+trace+{}", wave_path.display()));
         eprintln!("VCD waveform will be written to {}", wave_path.display());
+    }
+    if no_exit {
+        // Cross-check mode: don't take over stdout/exit. Inherit stdio
+        // so the binary's output appears interleaved with the parent's
+        // logs as usual; the cross-check driver re-runs the binary
+        // itself to capture stdout.
+        let _ = run_cmd.status();
+        return Ok(());
     }
     let run_status = run_cmd
         .status()

--- a/src/main.rs
+++ b/src/main.rs
@@ -497,10 +497,15 @@ fn run_thread_sim_cross_check(
     eprintln!("=== arch sim --thread-sim both: building parallel path ===");
     let par_trace = build_and_capture(arch_files, tb_files, &par_dir, /*parallel=*/true)?;
 
-    // Filter to just the [cycle][...] debug lines, ignore TB output.
+    // Filter to just the [cycle][Mod.port](in/out) debug lines, ignore
+    // TB stdout. The fsm path uses --debug --depth N to optionally
+    // include sub-instance traces; we only invoke with depth=1 above,
+    // so only top-module ports appear in either trace. (For cross-check
+    // we want top-module observable behavior — sub-module internals
+    // are implementation detail and may legitimately differ.)
     let extract_trace = |s: &str| -> Vec<String> {
         s.lines()
-            .filter(|l| l.starts_with('[') && l.contains("](in)") || l.contains("](out)"))
+            .filter(|l| l.starts_with('[') && (l.contains("](in)") || l.contains("](out)")))
             .map(|l| l.to_string())
             .collect()
     };

--- a/src/sim_codegen/thread_sim.rs
+++ b/src/sim_codegen/thread_sim.rs
@@ -103,8 +103,11 @@ struct ThreadInfo {
     branches: Vec<Branch>,
 }
 
-pub fn gen_module_thread(m: &ModuleDecl) -> Result<SimModel, String> {
-    let class = m.name.name.clone();
+pub fn gen_module_thread(m: &ModuleDecl, debug: bool) -> Result<SimModel, String> {
+    // Match the Verilator/fsm convention: V<ModuleName>. Lets the same
+    // TB drive either --thread-sim path without changing #includes,
+    // which is what makes --thread-sim=both cross-check practical.
+    let class = format!("V{}", m.name.name);
 
     let threads: Vec<&ThreadBlock> = m.body.iter().filter_map(|i| match i {
         ModuleBodyItem::Thread(t) => Some(t),
@@ -230,6 +233,25 @@ pub fn gen_module_thread(m: &ModuleDecl) -> Result<SimModel, String> {
     // eval(): zero thread-driven outputs, run each thread's segment
     // hold-comb, then evaluate combinational lets.
     header.push_str("  void eval() {\n");
+    // Detect rising edge of clk (Verilator convention) and run the
+    // posedge logic. Update _clk_prev BEFORE the dispatch so the
+    // recursive eval() call inside _do_posedge doesn't re-trigger.
+    header.push_str(&format!("    bool _rising = ({clk_name} && !_clk_prev);\n"));
+    header.push_str(&format!("    _clk_prev = {clk_name};\n"));
+    header.push_str("    if (_rising) {\n");
+    header.push_str("      _do_posedge();\n");
+    if debug {
+        // Match fsm sim's --debug pattern: log FIRST with current
+        // cycle counter, THEN increment. So a port change logged on
+        // the Nth rising edge reports cycle N (counting from 0 at
+        // the initial pre-clock eval).
+        header.push_str("      _dbg_log_ports();\n");
+        header.push_str("      _dbg_cycle++;\n");
+    }
+    header.push_str("      return;\n");  // _do_posedge settled comb via its own eval() at the end
+    header.push_str("    }\n");
+    // Comb-only eval (clk falling or steady) — falls through to the
+    // segment switches and module-level comb below, then logs at end.
     for n in &driven_outputs {
         header.push_str(&format!("    {} = 0;\n", n));
     }
@@ -285,10 +307,16 @@ pub fn gen_module_thread(m: &ModuleDecl) -> Result<SimModel, String> {
             }
         }
     }
+    if debug {
+        header.push_str("    _dbg_log_ports();\n");
+    }
     header.push_str("  }\n\n");
 
     // posedge handler: reset → recreate; else → tick + eval.
-    header.push_str(&format!("  void posedge_{}() {{\n", clk_name));
+    // Posedge handler — called from eval() on rising edge of clk.
+    // Kept as a private method for internal call; previously was
+    // public posedge_<clk>() and called explicitly by TB.
+    header.push_str("  void _do_posedge() {\n");
     let rst_check = if rst_active_low {
         format!("if (!{}) {{", rst_name)
     } else {
@@ -385,11 +413,53 @@ pub fn gen_module_thread(m: &ModuleDecl) -> Result<SimModel, String> {
     }
     header.push_str("    _sched.tick();\n");
     header.push_str("    eval();\n");
+    // Note: --debug logging fires from eval() at end (matches fsm
+    // pattern). _dbg_cycle increments on rising edge in eval() too.
     header.push_str("  }\n\n");
+
+    if debug {
+        // Initial log: capture port-state at construction (cycle 0
+        // before any posedge). Called once from constructor or first
+        // eval — for parity with fsm, we emit it as a public method
+        // the TB can call after reset.
+        header.push_str(&format!("  void _dbg_log_ports() {{\n"));
+        for p in &m.ports {
+            if matches!(&p.ty, TypeExpr::Clock(_)) { continue; }
+            let pname = &p.name.name;
+            let dir = match p.direction { Direction::In => "in", Direction::Out => "out" };
+            let bits = match &p.ty {
+                TypeExpr::Bool | TypeExpr::Bit | TypeExpr::Reset(..) => 1,
+                TypeExpr::UInt(w) => eval_const(w),
+                _ => continue,  // Vec / wide / bus skipped in Phase 5 spike
+            };
+            if bits == 0 || bits > 64 { continue; }
+            header.push_str(&format!("    if ({pname} != _dbg_prev_{pname}) {{\n"));
+            header.push_str(&format!(
+                "      printf(\"[%llu][{mod}.{pname}]({dir}) 0x%llx -> 0x%llx\\n\", \
+                 (unsigned long long)_dbg_cycle, \
+                 (unsigned long long)_dbg_prev_{pname}, \
+                 (unsigned long long){pname});\n",
+                mod = m.name.name
+            ));
+            header.push_str(&format!("      _dbg_prev_{pname} = {pname};\n"));
+            header.push_str("    }\n");
+        }
+        header.push_str("  }\n\n");
+    }
 
     let _ = (&clk_name, &rst_name);
 
     header.push_str("private:\n");
+    header.push_str("  uint8_t _clk_prev = 0;\n");
+    if debug {
+        header.push_str("  uint64_t _dbg_cycle = 0;\n");
+        for p in &m.ports {
+            if matches!(&p.ty, TypeExpr::Clock(_)) { continue; }
+            let cpp_ty = port_or_reg_cpp_ty(&p.ty)
+                .map_err(|e| format!("module `{}` port `{}`: {}", class, p.name.name, e))?;
+            header.push_str(&format!("  {cpp_ty} _dbg_prev_{} = 0;\n", p.name.name));
+        }
+    }
     header.push_str("  arch_rt::ThreadScheduler _sched;\n");
     // One holder field per resource: int32_t = current owning thread
     // index, or -1 when free. Reset to -1 in posedge_clk's reset arm.
@@ -771,10 +841,30 @@ fn partition(body: &[ThreadStmt], branches: &mut Vec<Branch>, thread_id: usize) 
             other => return Err(format!("thread stmt not yet supported: {:?}", std::mem::discriminant(other))),
         }
     }
-    // Trailing segment: terminal yield (if non-empty).
-    if !cur.hold_comb.is_empty() || !cur.entry_seq.is_empty() || !cur.entry_seq_if.is_empty() {
+    // Trailing segment: if it's pure-seq (no held comb), fold its
+    // assigns into the previous wait segment's post_wait_seq — they
+    // fire on the cycle the previous wait completes, no extra cycle
+    // of latency. This matches the lowered-fsm trailing-statement
+    // optimization (elaborate.rs §4 "Trailing statements"). For
+    // trailing segments with held comb, we still need a Terminal
+    // segment with a 1-cycle yield so the comb is visible.
+    if !cur.hold_comb.is_empty() {
         cur.wait_kind = WaitKind::Terminal;
         segs.push(cur);
+    } else if !cur.entry_seq.is_empty() || !cur.entry_seq_if.is_empty() {
+        if let Some(prev) = segs.last_mut() {
+            // Only fold into a wait segment (not Terminal/ForkJoin etc.).
+            if matches!(prev.wait_kind, WaitKind::Until(_) | WaitKind::Cycles(_)) {
+                prev.post_wait_seq.extend(std::mem::take(&mut cur.entry_seq));
+                prev.post_wait_seq_if.extend(std::mem::take(&mut cur.entry_seq_if));
+            } else {
+                cur.wait_kind = WaitKind::Terminal;
+                segs.push(cur);
+            }
+        } else {
+            cur.wait_kind = WaitKind::Terminal;
+            segs.push(cur);
+        }
     }
     if segs.is_empty() {
         return Err("thread body has no statements".into());


### PR DESCRIPTION
## Summary

Per-suggestion: implement the cross-check from doc/plan_thread_parallel_sim.md as a **two-process trace diff** instead of an in-process wrapper. Reuses the existing \`--debug\` infrastructure — each path prints port-change traces; driver diffs them post-sim.

Far simpler than the wrapper (no class-name disambiguation, no API reconciliation, no inline diff code) and more user-friendly: one CLI invocation does the whole thing.

## CLI

\`arch sim --thread-sim both M.arch --tb tb.cpp\`
1. Build fsm path into \`arch_sim_build_fsm/\`, run with \`--debug\`, capture stdout
2. Build parallel path into \`arch_sim_build_par/\`, same
3. Extract \`[cycle][Mod.port](in/out) old -> new\` lines
4. Diff: PASS if identical, FAIL with first divergence highlighted

## Cross-check results

| Test | Result |
|---|---|
| DelayPulse (wait_cycles) | **PASS** — 4 port-change events |
| named_thread (2 threads) | **PASS** — 5 events |
| basic_thread (reg + let) | **PASS** — 16 events |
| thread_if_else (cond branches) | **PASS** — 6 events |
| fork_join (AxiWrite) | FAIL — known 1-cycle alignment in branch trailing-yield |

4/5 thread tests bit-identical between fsm and parallel paths.

## Implementation changes

### \`thread_sim.rs\`

- **Class name**: now \`V<M>\` (matches fsm/Verilator), so a single TB with \`#include \"V<M>.h\"\` drives either path. Existing parallel-only TBs need a one-line update (\`<M>\` → \`V<M>\`).
- **\`eval()\` detects clk rising edge internally** (Verilator convention); \`posedge_<clk>()\` is now a private \`_do_posedge()\` called from eval(). TB no longer needs to call posedge explicitly — same API as fsm.
- **\`--debug\` support**: \`_dbg_prev_<port>\` shadows + \`_dbg_log_ports()\` method called at end of every eval(), with \`_dbg_cycle\` increment on rising edge AFTER logging (matches fsm cycle-N reporting).
- **Trailing-seq optimization**: trailing segments with only seq assigns (no held comb) fold into the previous wait segment's \`post_wait_seq\`. Removes a 1-cycle latency at the end of every thread iteration. Matches the lowered-fsm trailing-statement optimization in elaborate.rs §4.

### \`main.rs\`

- \`--thread-sim {fsm,parallel,both}\` flag (was \`fsm\`/\`parallel\`).
- \`run_thread_sim_cross_check\` driver: builds + runs both paths, diffs trace lines, reports PASS/FAIL with first divergence.
- \`run_sim\` factored into \`run_sim_opts\` with a \`no_exit\` parameter so the cross-check driver can call it without the process-exit at the end.

## Known limitations

- Fork/join cross-check diverges by 1 cycle at branch trailing comb (\`wait_cycles(1)\` yield differs from FSM's "trailing comb visible 1 cycle then advance"). To align, fold trailing comb into post-fork segment — separate optimization.
- Vec/wide port debug-logging not yet emitted in parallel sim (Phase 5 spike: scalars only).
- Two-process model is slower than in-process. Fine for dev; if scaled to large benchmarks, in-process wrapper becomes worth it.

## Test plan

- [x] \`cargo test --lib\` — 15/15
- [x] \`cargo test --test integration_test\` — 167/167
- [x] 4/5 \`tests/thread/\` cross-checks PASS (fork_join known)
- [x] \`tests/axi_dma_thread/ThreadMm2s.arch\` still compiles under \`--thread-sim parallel\`
- [x] Default \`--thread-sim fsm\` path unchanged