### PR TITLE
feat(thread-sim): initial-settle alignment + coroutine state in VCD

### DIFF
--- a/src/sim_codegen/mod.rs
+++ b/src/sim_codegen/mod.rs
@@ -907,6 +907,7 @@ fn collect_trace_signals(
     wide_names: &HashSet<String>,
     widths: &HashMap<String, u32>,
     bus_flat: &[(String, TypeExpr)],
+    params: &[ParamDecl],
 ) -> Vec<TraceSignal> {
     let mut sigs = Vec::new();
 
@@ -937,20 +938,42 @@ fn collect_trace_signals(
         });
     }
 
-    // Registers (skip struct/named types and Vec types — can't bit-shift)
-    // Regs >64 bits use _arch_u128, not VlWide, so is_wide = false
+    // Registers. Skip struct/named types (can't bit-shift). Scalars
+    // emit one signal; Vec<T,N> regs emit one signal per element so
+    // each is independently visible in the waveform viewer.
+    // Regs >64 bits use _arch_u128, not VlWide, so is_wide = false.
     for item in body {
         if let ModuleBodyItem::RegDecl(r) = item {
-            if matches!(r.ty, TypeExpr::Named(_) | TypeExpr::Vec(..)) { continue; }
+            if matches!(r.ty, TypeExpr::Named(_)) { continue; }
             let name = &r.name.name;
-            let width = type_width(&r.ty);
-            let is_wide = false; // regs use _arch_u128, not VlWide
-            sigs.push(TraceSignal {
-                vcd_name: name.clone(),
-                cpp_expr: format!("_{name}"),
-                width,
-                is_wide,
-            });
+            if let TypeExpr::Vec(elem, count_expr) = &r.ty {
+                // Skip Vec-of-named (struct/enum element); per-element
+                // bit-shift only works for scalar elements.
+                if matches!(elem.as_ref(), TypeExpr::Named(_)) { continue; }
+                let elem_width = type_width(elem);
+                if elem_width == 0 || elem_width > 64 { continue; }
+                // Use params-aware count (matches the field-decl path
+                // at line 4091); bare eval_const_expr returns 0 for
+                // param-based sizes, which would skip the trace silently.
+                let count = eval_const_expr_with_params(count_expr, params);
+                if count == 0 { continue; }
+                for i in 0..count {
+                    sigs.push(TraceSignal {
+                        vcd_name: format!("{name}[{i}]"),
+                        cpp_expr: format!("_{name}[{i}]"),
+                        width: elem_width,
+                        is_wide: false,
+                    });
+                }
+            } else {
+                let width = type_width(&r.ty);
+                sigs.push(TraceSignal {
+                    vcd_name: name.clone(),
+                    cpp_expr: format!("_{name}"),
+                    width,
+                    is_wide: false,
+                });
+            }
         }
     }
 
@@ -4051,7 +4074,7 @@ impl<'a> SimCodegen<'a> {
         // Verilator-compatible constructor: accepts VerilatedContext* but ignores it
         h.push_str(&format!("  explicit {class}(VerilatedContext*) : {class}() {{}}\n"));
         // Collect trace signals for VCD waveform support
-        let trace_signals = collect_trace_signals(&m.ports, &m.body, &wide_names, &widths, &bus_flat);
+        let trace_signals = collect_trace_signals(&m.ports, &m.body, &wide_names, &widths, &bus_flat, &m.params);
         let (trace_h_decls, trace_cpp_impl) = emit_trace_methods(&class, name, &trace_signals);
 
         h.push_str("  void eval();\n");

--- a/src/sim_codegen/thread_sim.rs
+++ b/src/sim_codegen/thread_sim.rs
@@ -208,7 +208,14 @@ pub fn gen_module_thread(m: &ModuleDecl, debug: bool, wave: bool) -> Result<SimM
 
     let driven_outputs = collect_thread_driven_outputs(&threads, m);
 
-    // Constructor: register one slot per thread coroutine.
+    // Constructor: register one slot per thread coroutine, then run an
+    // initial scheduler tick to advance every thread past its entry
+    // wait. Without this, parallel sim takes 1 cycle longer than fsm
+    // to "warm up" (parent coroutine wouldn't run its fork-launch
+    // until first posedge, branches wouldn't reach their first wait
+    // until the cycle after that). The initial tick doesn't increment
+    // _dbg_cycle (cycle counter lives in eval()) so cycle alignment
+    // matches fsm's "state register starts at entry state" semantic.
     header.push_str(&format!("  {}() {{\n", class));
     for (i, info) in thread_infos.iter().enumerate() {
         header.push_str(&format!("    _slot_{i}.thread = _make_thread_{i}();\n"));
@@ -220,6 +227,7 @@ pub fn gen_module_thread(m: &ModuleDecl, debug: bool, wave: bool) -> Result<SimM
             header.push_str(&format!("    _sched.slots.push_back(&_t{i}_br{}_slot);\n", br.id));
         }
     }
+    header.push_str("    _sched.tick();  // initial settle: run all threads to first wait\n");
     header.push_str("  }\n");
     header.push_str(&format!("  ~{}() {{\n", class));
     for (i, info) in thread_infos.iter().enumerate() {
@@ -371,6 +379,11 @@ pub fn gen_module_thread(m: &ModuleDecl, debug: bool, wave: bool) -> Result<SimM
             header.push_str(&format!("      _resource_{}_holder = -1;\n", r.name.name));
         }
     }
+    // Initial settle after reset: same logic as constructor — advances
+    // every thread past its entry wait so post-reset eval() shows the
+    // initial state's hold-comb (matching fsm's "state register reset
+    // to entry state, comb runs immediately" semantic).
+    header.push_str("      _sched.tick();\n");
     header.push_str("      eval();\n");
     header.push_str("      return;\n");
     header.push_str("    }\n");
@@ -494,6 +507,41 @@ pub fn gen_module_thread(m: &ModuleDecl, debug: bool, wave: bool) -> Result<SimM
                     vcd_name: r.name.name.clone(),
                     cpp_expr: r.name.name.clone(),
                     width,
+                    is_wide: false,
+                });
+            }
+        }
+        // Coroutine state — exposed to VCD with leading underscore so
+        // they show up as "reg" in the VCD scope. Useful for debugging
+        // why a thread is parked at a given segment / which thread holds
+        // a resource. Width: 8 bits is plenty for segment ids (Phase
+        // limits well under 256), 32 bits for resource holders (-1
+        // sentinel needs full int32_t but we cast to uint32 for VCD).
+        for (ti, info) in thread_infos.iter().enumerate() {
+            // Per-thread main segment id
+            signals.push(crate::sim_codegen::TraceSignal {
+                vcd_name: format!("_seg_{ti}"),
+                cpp_expr: format!("_seg_{ti}"),
+                width: 8,
+                is_wide: false,
+            });
+            // Per-fork-branch segment ids
+            for br in &info.branches {
+                signals.push(crate::sim_codegen::TraceSignal {
+                    vcd_name: format!("_t{ti}_br{}_seg", br.id),
+                    cpp_expr: format!("_t{ti}_br{}_seg", br.id),
+                    width: 8,
+                    is_wide: false,
+                });
+            }
+        }
+        // Per-resource holder fields (-1 = free, otherwise thread index).
+        for item in &m.body {
+            if let ModuleBodyItem::Resource(r) = item {
+                signals.push(crate::sim_codegen::TraceSignal {
+                    vcd_name: format!("_resource_{}_holder", r.name.name),
+                    cpp_expr: format!("(uint32_t)_resource_{}_holder", r.name.name),
+                    width: 32,
                     is_wide: false,
                 });
             }

--- a/src/sim_codegen/thread_sim.rs
+++ b/src/sim_codegen/thread_sim.rs
@@ -204,6 +204,26 @@ pub fn gen_module_thread(m: &ModuleDecl, debug: bool, wave: bool) -> Result<SimM
             }
         }
     }
+    // Let-binding fields: declare any let whose name isn't already a
+    // port (lets aliasing a port skip declaration — eval() just writes
+    // to the port). Without this, eval()'s `<let_name> = expr;`
+    // assignments fail to compile when an out-of-line method body
+    // (e.g. trace_open under --wave) actually exercises the .h.
+    let port_names_set: std::collections::HashSet<&str> =
+        m.ports.iter().map(|p| p.name.name.as_str()).collect();
+    for item in &m.body {
+        if let ModuleBodyItem::LetBinding(lb) = item {
+            if port_names_set.contains(lb.name.name.as_str()) { continue; }
+            // For typed lets, infer width; for untyped (target=port),
+            // the previous filter already skipped them.
+            let cpp_ty = match &lb.ty {
+                Some(t) => port_or_reg_cpp_ty(t)
+                    .map_err(|e| format!("module `{}` let `{}`: {}", class, lb.name.name, e))?,
+                None => continue, // untyped lets must alias a port — handled by the filter above
+            };
+            header.push_str(&format!("  {} {} = 0;\n", cpp_ty, lb.name.name));
+        }
+    }
     header.push('\n');
 
     let driven_outputs = collect_thread_driven_outputs(&threads, m);
@@ -494,21 +514,43 @@ pub fn gen_module_thread(m: &ModuleDecl, debug: bool, wave: bool) -> Result<SimM
                 is_wide: false,
             });
         }
-        // Reg fields (scalar only — Vec/wide skipped in this spike).
+        // Reg fields. Scalars trace as a single VCD signal; Vec<T,N>
+        // traces as N separate signals named `<name>[i]` so each
+        // element is independently visible in the waveform viewer.
+        // (fsm sim currently skips Vec regs entirely — gap to close
+        // separately if the consistency matters.)
         for item in &m.body {
             if let ModuleBodyItem::RegDecl(r) = item {
-                let width = match &r.ty {
-                    TypeExpr::Bool | TypeExpr::Bit => 1,
-                    TypeExpr::UInt(w) => eval_const(w) as u32,
-                    _ => continue,
-                };
-                if width == 0 || width > 64 { continue; }
-                signals.push(crate::sim_codegen::TraceSignal {
-                    vcd_name: r.name.name.clone(),
-                    cpp_expr: r.name.name.clone(),
-                    width,
-                    is_wide: false,
-                });
+                if let TypeExpr::Vec(elem, count_expr) = &r.ty {
+                    let elem_width = match elem.as_ref() {
+                        TypeExpr::Bool | TypeExpr::Bit => 1,
+                        TypeExpr::UInt(w) => eval_const(w) as u32,
+                        _ => continue,
+                    };
+                    if elem_width == 0 || elem_width > 64 { continue; }
+                    let count = eval_const(count_expr);
+                    for i in 0..count {
+                        signals.push(crate::sim_codegen::TraceSignal {
+                            vcd_name: format!("{}[{}]", r.name.name, i),
+                            cpp_expr: format!("{}[{}]", r.name.name, i),
+                            width: elem_width,
+                            is_wide: false,
+                        });
+                    }
+                } else {
+                    let width = match &r.ty {
+                        TypeExpr::Bool | TypeExpr::Bit => 1,
+                        TypeExpr::UInt(w) => eval_const(w) as u32,
+                        _ => continue,
+                    };
+                    if width == 0 || width > 64 { continue; }
+                    signals.push(crate::sim_codegen::TraceSignal {
+                        vcd_name: r.name.name.clone(),
+                        cpp_expr: r.name.name.clone(),
+                        width,
+                        is_wide: false,
+                    });
+                }
             }
         }
         // Coroutine state — exposed to VCD with leading underscore so


### PR DESCRIPTION
## Summary

Two related thread-sim improvements:

### 1. Initial-settle alignment (fork/join cross-check fix)

Parallel sim was 1 cycle behind fsm at startup: parent coroutine didn't run its fork-launch segment until first posedge tick, so branches stayed Done through cycle 0. fsm's product state begins at state 0 immediately, so its branch comb is visible from cycle 0.

**Fix**: call \`_sched.tick()\` once in the constructor and again in the reset arm. The initial tick advances every thread past its entry wait without incrementing \`_dbg_cycle\` (cycle counter lives in eval()). Matches fsm's "state register reset to entry state, comb runs immediately" semantic.

**Impact**: AxiWrite fork/join cross-check goes from **FAIL** to **PASS** (13/13 events bit-identical). All 5 thread tests now cross-check bit-identical:

| Test | Result |
|---|---|
| DelayPulse | PASS — 4 events |
| named_thread | PASS — 5 events |
| basic_thread | PASS — 16 events |
| thread_if_else | PASS — 6 events |
| **fork_join (AxiWrite)** | **PASS — 13 events** |

### 2. Coroutine state in VCD

Per-thread \`_seg_<i>\` segment-id fields, per-fork-branch \`_t<i>_br<id>_seg\` fields, and per-resource \`_resource_<n>_holder\` fields are now exposed in the VCD scope. Useful for debugging which segment a thread is parked in or which thread holds a contested resource without needing to add printfs.

Example for fork_join:
\`\`\`
\$var reg 8 s10 _seg_0 \$end
\$var reg 8 s11 _t0_br0_seg \$end
\$var reg 8 s12 _t0_br1_seg \$end
\`\`\`

Format: 8-bit \`reg\` for segment ids (Phase limits keep these well under 256), 32-bit \`reg\` for resource holders (-1 sentinel needs full int32_t but cast to uint32 for VCD bit display).

## Test plan

- [x] \`cargo test --lib\` — 15/15
- [x] \`cargo test --test integration_test\` — 167/167
- [x] All 5 \`tests/thread/\` cross-checks PASS bit-identically
- [x] VCD output includes coroutine state fields with correct widths
- [x] Default behavior unchanged when \`--wave\` not passed