### PR TITLE
feat(thread-sim): Phase 3.0 — `--threads N` CLI + Barrier infrastructure

### DIFF
--- a/runtime/arch_thread_rt.h
+++ b/runtime/arch_thread_rt.h
@@ -23,6 +23,8 @@
 #include <functional>
 #include <cstdint>
 #include <vector>
+#include <atomic>
+#include <thread>
 
 namespace arch_rt {
 
@@ -161,6 +163,39 @@ struct ThreadScheduler {
     bool all_done() const {
         for (auto* s : slots) if (s->kind != WaitKind::Done) return false;
         return true;
+    }
+};
+
+// ─── Multi-OS-thread support (Phase 3) ────────────────────────────────
+//
+// Atomic spin-wait barrier. ~10-30 ns per round-trip vs ~µs for
+// std::condition_variable. Used by MtScheduler to synchronize one
+// "tick" across N OS threads.
+//
+// Usage: construct with `target` = number of participating threads.
+// Each thread calls wait() at the synchronization point; all
+// participants advance together.
+struct Barrier {
+    std::atomic<uint32_t> count{0};
+    std::atomic<uint32_t> generation{0};
+    uint32_t target;
+    explicit Barrier(uint32_t target) : target(target) {}
+    void wait() {
+        uint32_t gen = generation.load(std::memory_order_acquire);
+        if (count.fetch_add(1, std::memory_order_acq_rel) + 1 == target) {
+            count.store(0, std::memory_order_release);
+            generation.fetch_add(1, std::memory_order_release);
+        } else {
+            // Spin briefly, then yield to avoid pegging a core when
+            // other participants are slow (or oversubscribed).
+            uint32_t spins = 0;
+            while (generation.load(std::memory_order_acquire) == gen) {
+                if (++spins > 1000) {
+                    std::this_thread::yield();
+                    spins = 0;
+                }
+            }
+        }
     }
 };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -129,11 +129,19 @@ enum Command {
         /// --annotate annot/ <file>`.
         #[arg(long)]
         coverage_dat: Option<Option<String>>,
-        /// Thread-sim mode: `fsm` (default; threads lowered to FSM, single-core)
-        /// or `parallel` (Phase 1 spike: pre-lowering coroutine sim). See
-        /// doc/plan_thread_parallel_sim.md.
+        /// Thread-sim mode: `fsm` (default; threads lowered to FSM, single-core),
+        /// `parallel` (pre-lowering coroutine sim — Verilator-style use
+        /// `--threads N` to spread N OS threads), or `both` (cross-check
+        /// fsm vs parallel). See doc/plan_thread_parallel_sim.md and
+        /// doc/plan_thread_parallel_sim_phase3.md.
         #[arg(long = "thread-sim", default_value = "fsm")]
         thread_sim: String,
+        /// Number of OS threads to use under `--thread-sim parallel`.
+        /// Default 1 = cooperative single-OS-thread coroutine scheduler
+        /// (current behavior). N>1 spawns one OS thread per user
+        /// `thread` block (Verilator-style). See Phase 3 plan.
+        #[arg(long = "threads", default_value_t = 1)]
+        threads: u32,
         /// Generate pybind11 Python module for cocotb-compatible testing
         #[arg(long)]
         pybind: bool,
@@ -352,7 +360,7 @@ fn main() -> miette::Result<()> {
             }
             Ok(())
         }
-        Command::Sim { arch_files, tb_files, outdir, check_uninit, inputs_start_uninit, check_uninit_ram, cdc_random, wave, debug, debug_depth, debug_fsm, coverage, coverage_dat, thread_sim, pybind, test, pybind_module_name } => {
+        Command::Sim { arch_files, tb_files, outdir, check_uninit, inputs_start_uninit, check_uninit_ram, cdc_random, wave, debug, debug_depth, debug_fsm, coverage, coverage_dat, thread_sim, threads, pybind, test, pybind_module_name } => {
             let dbg_ports = debug || debug_fsm;  // any debug option implies port logging
             // --inputs-start-uninit and --check-uninit-ram both imply --check-uninit
             let check_uninit = check_uninit || inputs_start_uninit || check_uninit_ram;
@@ -361,6 +369,15 @@ fn main() -> miette::Result<()> {
             // → Some(None) → default "coverage.dat"; absent → None.
             let cov_dat_path: Option<String> = coverage_dat.map(|opt| opt.unwrap_or_else(|| "coverage.dat".to_string()));
             let coverage = coverage || cov_dat_path.is_some();
+            if threads > 1 && thread_sim != "parallel" {
+                return Err(miette::miette!("--threads N (N>1) requires --thread-sim parallel"));
+            }
+            if threads > 1 {
+                return Err(miette::miette!(
+                    "--threads {} not yet implemented (Phase 3.2 work). Currently --threads 1 only.",
+                    threads
+                ));
+            }
             match thread_sim.as_str() {
                 "fsm" => learn_wrap(&arch_files, || {
                     run_sim(&arch_files, &tb_files, outdir.as_deref(), check_uninit, inputs_start_uninit, check_uninit_ram, cdc_random, wave.as_deref(), dbg_ports, debug_depth, debug_fsm, coverage, cov_dat_path.clone(), false, pybind, test.as_deref(), pybind_module_name.as_deref())


### PR DESCRIPTION
## Summary

Foundation for Phase 3 multi-OS-thread parallel sim per [doc/plan_thread_parallel_sim_phase3.md](doc/plan_thread_parallel_sim_phase3.md). Lands the CLI flag and the runtime Barrier class so the actual implementation in sub-phases 3.1-3.2 can drop in without touching the CLI.

## Changes

1. **\`--threads N\` flag** (default 1) — Verilator-style. Combines with \`--thread-sim parallel\` to control OS thread count. N=1 preserves current cooperative single-OS-thread behavior (no change to existing TBs or CI).

2. **\`arch_rt::Barrier\` class** in runtime — atomic spin-wait barrier with generation counting. ~10-30 ns per round-trip. After 1000 spins, falls back to \`std::this_thread::yield()\` to avoid pegging a core under oversubscription.

3. **Validation**: \`--threads N\` outside \`--thread-sim parallel\` errors clearly; N>1 currently returns a clear "not yet implemented (sub-phase 3.2)" message rather than silently misbehaving.

## Behavior

| Invocation | Behavior |
|---|---|
| \`--thread-sim fsm\` (default) | Unchanged |
| \`--thread-sim parallel\` (default \`--threads 1\`) | Unchanged — current cooperative coroutine sim |
| \`--thread-sim parallel --threads 2\` | Errors: "not yet implemented (Phase 3.2 work)" |
| \`--threads 4\` (without parallel mode) | Errors: "requires --thread-sim parallel" |

## Test plan

- [x] \`cargo test --lib\` — 15/15
- [x] \`cargo test --test integration_test\` — 167/167
- [x] All 5 thread cross-checks PASS (unaffected — all run at default --threads 1)
- [x] \`--threads 2\` errors with clear message
- [x] No code changes to existing \`--thread-sim {fsm,parallel,both}\` paths

## What's next

Per the phased rollout in [plan_thread_parallel_sim_phase3.md](doc/plan_thread_parallel_sim_phase3.md):

- **Sub-phase 3.1**: refactor emitter to emit per-OS-thread scheduler + barrier-coordinated cycle, working at N=1 through the new structure (proves correctness)
- **Sub-phase 3.2**: wire up actual N>1 OS threads (the perf payload)
- **Sub-phase 3.3**: determinism layer (affinity + ordered publish)
- **Sub-phase 3.4**: perf benchmark on axi_dma_thread

Each independently shippable.