### PR TITLE
feat(thread-sim): Phase 3.2 — multi-OS-thread parallel sim (`--threads N`)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -372,18 +372,12 @@ fn main() -> miette::Result<()> {
             if threads > 1 && thread_sim != "parallel" {
                 return Err(miette::miette!("--threads N (N>1) requires --thread-sim parallel"));
             }
-            if threads > 1 {
-                return Err(miette::miette!(
-                    "--threads {} not yet implemented (Phase 3.2 work). Currently --threads 1 only.",
-                    threads
-                ));
-            }
             match thread_sim.as_str() {
                 "fsm" => learn_wrap(&arch_files, || {
-                    run_sim(&arch_files, &tb_files, outdir.as_deref(), check_uninit, inputs_start_uninit, check_uninit_ram, cdc_random, wave.as_deref(), dbg_ports, debug_depth, debug_fsm, coverage, cov_dat_path.clone(), false, pybind, test.as_deref(), pybind_module_name.as_deref())
+                    run_sim(&arch_files, &tb_files, outdir.as_deref(), check_uninit, inputs_start_uninit, check_uninit_ram, cdc_random, wave.as_deref(), dbg_ports, debug_depth, debug_fsm, coverage, cov_dat_path.clone(), false, threads, pybind, test.as_deref(), pybind_module_name.as_deref())
                 }),
                 "parallel" => learn_wrap(&arch_files, || {
-                    run_sim(&arch_files, &tb_files, outdir.as_deref(), check_uninit, inputs_start_uninit, check_uninit_ram, cdc_random, wave.as_deref(), dbg_ports, debug_depth, debug_fsm, coverage, cov_dat_path.clone(), true, pybind, test.as_deref(), pybind_module_name.as_deref())
+                    run_sim(&arch_files, &tb_files, outdir.as_deref(), check_uninit, inputs_start_uninit, check_uninit_ram, cdc_random, wave.as_deref(), dbg_ports, debug_depth, debug_fsm, coverage, cov_dat_path.clone(), true, threads, pybind, test.as_deref(), pybind_module_name.as_deref())
                 }),
                 "both" => {
                     // Cross-check: build + run both fsm and parallel sims
@@ -575,6 +569,7 @@ fn build_and_capture(
         /*debug*/ true, /*debug_depth*/ 1, /*debug_fsm*/ false,
         /*coverage*/ false, /*coverage_dat*/ None,
         parallel,
+        /*threads*/ 1,
         /*pybind*/ false, /*test_file*/ None, /*pybind_module_name_override*/ None,
         /*no_exit*/ true,
     )?;
@@ -605,13 +600,14 @@ fn run_sim(
     coverage: bool,
     coverage_dat: Option<String>,
     thread_sim_parallel: bool,
+    threads: u32,
     pybind: bool,
     test_file: Option<&std::path::Path>,
     pybind_module_name_override: Option<&str>,
 ) -> miette::Result<()> {
     run_sim_opts(arch_files, tb_files, outdir, check_uninit, inputs_start_uninit, check_uninit_ram,
         cdc_random, wave, debug, debug_depth, debug_fsm, coverage, coverage_dat, thread_sim_parallel,
-        pybind, test_file, pybind_module_name_override, /*no_exit=*/false)
+        threads, pybind, test_file, pybind_module_name_override, /*no_exit=*/false)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -630,6 +626,7 @@ fn run_sim_opts(
     coverage: bool,
     coverage_dat: Option<String>,
     thread_sim_parallel: bool,
+    threads: u32,
     pybind: bool,
     test_file: Option<&std::path::Path>,
     pybind_module_name_override: Option<&str>,
@@ -656,7 +653,7 @@ fn run_sim_opts(
             if let arch::ast::Item::Module(m) = item {
                 let has_thread = m.body.iter().any(|i| matches!(i, arch::ast::ModuleBodyItem::Thread(_)));
                 if has_thread {
-                    let model = arch::sim_codegen::thread_sim::gen_module_thread(m, debug, wave.is_some())
+                    let model = arch::sim_codegen::thread_sim::gen_module_thread(m, debug, wave.is_some(), threads)
                         .map_err(|e| miette::miette!("thread sim: {}", e))?;
                     out.push(model);
                 }

--- a/src/sim_codegen/thread_sim.rs
+++ b/src/sim_codegen/thread_sim.rs
@@ -103,7 +103,7 @@ struct ThreadInfo {
     branches: Vec<Branch>,
 }
 
-pub fn gen_module_thread(m: &ModuleDecl, debug: bool, wave: bool) -> Result<SimModel, String> {
+pub fn gen_module_thread(m: &ModuleDecl, debug: bool, wave: bool, num_os_threads: u32) -> Result<SimModel, String> {
     // Match the Verilator/fsm convention: V<ModuleName>. Lets the same
     // TB drive either --thread-sim path without changing #includes,
     // which is what makes --thread-sim=both cross-check practical.
@@ -236,6 +236,7 @@ pub fn gen_module_thread(m: &ModuleDecl, debug: bool, wave: bool) -> Result<SimM
     // until the cycle after that). The initial tick doesn't increment
     // _dbg_cycle (cycle counter lives in eval()) so cycle alignment
     // matches fsm's "state register starts at entry state" semantic.
+    let mt = num_os_threads > 1;
     header.push_str(&format!("  {}() {{\n", class));
     for (i, info) in thread_infos.iter().enumerate() {
         header.push_str(&format!("    _slot_{i}.thread = _make_thread_{i}();\n"));
@@ -249,14 +250,31 @@ pub fn gen_module_thread(m: &ModuleDecl, debug: bool, wave: bool) -> Result<SimM
     }
     // Initial settle — run each per-thread scheduler in declaration
     // order so thread N can read signals set by threads 0..N-1 during
-    // their entry segments. At N=1 OS thread (current) this is a
-    // sequential loop; sub-phase 3.2 will dispatch each call into a
-    // dedicated worker OS thread synchronized via Barrier.
+    // their entry segments. ALWAYS sequential in the constructor (workers
+    // not yet spawned).
     for (i, _) in thread_infos.iter().enumerate() {
         header.push_str(&format!("    _sched_{i}.tick();\n"));
     }
+    if mt {
+        // Spawn one worker OS thread per user thread. Each worker waits
+        // at _start_barrier, ticks its scheduler when signaled, then
+        // signals _end_barrier. The main TB-driving thread (caller of
+        // eval()) coordinates by hitting both barriers per posedge.
+        for (i, _) in thread_infos.iter().enumerate() {
+            header.push_str(&format!("    _worker_{i} = std::thread([this]{{ _worker_loop_{i}(); }});\n"));
+        }
+    }
     header.push_str("  }\n");
     header.push_str(&format!("  ~{}() {{\n", class));
+    if mt {
+        // Wake workers via _start_barrier so they observe _shutdown=true
+        // and break out of their loops, then join them.
+        header.push_str("    _shutdown.store(true, std::memory_order_release);\n");
+        header.push_str("    _start_barrier.wait();\n");
+        for (i, _) in thread_infos.iter().enumerate() {
+            header.push_str(&format!("    if (_worker_{i}.joinable()) _worker_{i}.join();\n"));
+        }
+    }
     for (i, info) in thread_infos.iter().enumerate() {
         header.push_str(&format!("    _slot_{i}.thread.destroy();\n"));
         for br in &info.branches {
@@ -466,11 +484,17 @@ pub fn gen_module_thread(m: &ModuleDecl, debug: bool, wave: bool) -> Result<SimM
             }
         }
     }
-    // Per-user-thread tick (Phase 3 architecture). At N=1 OS thread
-    // these run sequentially in declaration order; sub-phase 3.2 will
-    // dispatch each into a worker OS thread synchronized via Barrier.
-    for (i, _) in thread_infos.iter().enumerate() {
-        header.push_str(&format!("    _sched_{i}.tick();\n"));
+    if mt {
+        // Multi-OS-thread tick: workers wait at _start_barrier; signal
+        // them to begin their per-thread tick, then wait at _end_barrier
+        // for them to complete.
+        header.push_str("    _start_barrier.wait();\n");
+        header.push_str("    _end_barrier.wait();\n");
+    } else {
+        // Sequential tick (single OS thread, current default).
+        for (i, _) in thread_infos.iter().enumerate() {
+            header.push_str(&format!("    _sched_{i}.tick();\n"));
+        }
     }
     header.push_str("    eval();\n");
     // Note: --debug logging fires from eval() at end (matches fsm
@@ -629,11 +653,23 @@ pub fn gen_module_thread(m: &ModuleDecl, debug: bool, wave: bool) -> Result<SimM
         }
     }
     // Per-user-thread scheduler. Each owns its main slot + its fork
-    // branches. At N=1 OS thread (current), all schedulers tick
-    // sequentially in the calling OS thread; sub-phase 3.2 wraps
-    // each tick in a worker OS thread synchronized via Barrier.
+    // branches. At N=1 OS thread, all schedulers tick sequentially in
+    // the calling OS thread; at N>1 each tick runs in a dedicated
+    // worker OS thread synchronized via Barrier.
     for (i, _) in thread_infos.iter().enumerate() {
         header.push_str(&format!("  arch_rt::ThreadScheduler _sched_{i};\n"));
+    }
+    if mt {
+        // Multi-OS-thread coordination state. The +1 in barrier targets
+        // is the calling thread (TB driver) which hits both barriers
+        // each posedge.
+        let total = thread_infos.len() + 1;
+        header.push_str("  std::atomic<bool> _shutdown{false};\n");
+        header.push_str(&format!("  arch_rt::Barrier _start_barrier{{{total}}};\n"));
+        header.push_str(&format!("  arch_rt::Barrier _end_barrier{{{total}}};\n"));
+        for (i, _) in thread_infos.iter().enumerate() {
+            header.push_str(&format!("  std::thread _worker_{i};\n"));
+        }
     }
     // One holder field per resource: int32_t = current owning thread
     // index, or -1 when free. Reset to -1 in posedge_clk's reset arm.
@@ -842,6 +878,22 @@ pub fn gen_module_thread(m: &ModuleDecl, debug: bool, wave: bool) -> Result<SimM
                 }
             }
             header.push_str("    co_return;\n");
+            header.push_str("  }\n\n");
+        }
+    }
+
+    if mt {
+        // Per-worker loop method. Each worker waits at _start_barrier,
+        // checks _shutdown, ticks its scheduler, then waits at
+        // _end_barrier. Loops until shutdown.
+        for (i, _) in thread_infos.iter().enumerate() {
+            header.push_str(&format!("  void _worker_loop_{i}() {{\n"));
+            header.push_str("    while (true) {\n");
+            header.push_str("      _start_barrier.wait();\n");
+            header.push_str("      if (_shutdown.load(std::memory_order_acquire)) break;\n");
+            header.push_str(&format!("      _sched_{i}.tick();\n"));
+            header.push_str("      _end_barrier.wait();\n");
+            header.push_str("    }\n");
             header.push_str("  }\n\n");
         }
     }


### PR DESCRIPTION
## Summary

Wires up actual N>1 OS-thread parallelism. Each user \`thread\` block runs in its own \`std::thread\`, synchronized via the atomic spin-wait \`Barrier\` from #154, on top of the per-user-thread scheduler architecture from #155.

\`arch sim --thread-sim parallel --threads N\` is now functional for N>1.

## Generated emit at N>1

- **Constructor**: spawns one \`std::thread\` per user thread AFTER initial settle. Each worker runs \`_worker_loop_<i>\` which loops on \`(start_barrier → tick own scheduler → end_barrier)\`.
- **\`_do_posedge\` non-reset path**: caller hits \`start_barrier\` (workers begin tick), \`end_barrier\` (workers done), then settles comb via \`eval()\`. Replaces the sequential per-thread tick loop.
- **Reset path**: stays sequential — workers are blocked at \`start_barrier\`; caller mutates state safely without signaling them.
- **Destructor**: sets atomic \`_shutdown\`, signals \`start_barrier\` so workers observe it and break, joins them.

## Verified

| Test | Result |
|---|---|
| named_thread (2 user threads) at \`--threads 2\` | Output **bit-identical** to \`--threads 1\` |
| ThreadMm2s (5 user threads) at \`--threads 5\` | Compiles cleanly |
| All 5 thread-test cross-checks at default \`--threads 1\` | PASS (no behavior change) |
| \`cargo test --lib\` | 15/15 |
| \`cargo test --test integration_test\` | 167/167 |

## Phase 3.2 limits (deferred to later sub-phases)

- **No deterministic ordering across runs** (Phase 3.3 work — affinity + ordered publish at barriers). For **owned-output ports** (each port has exactly one writer thread) this doesn't matter. For \`shared(or)\` ports or cross-thread writes via published values, ordering CAN matter — none of the existing tests exercise these under MT.
- **No perf benchmarking yet** (Phase 3.4 — measure speedup on axi_dma_thread).
- **Reset path serializes** through the caller. For low-frequency resets this is fine.

## What's next

- Phase 3.3: determinism (affinity + ordered publish)
- Phase 3.4: perf benchmark + tuning
- Phase 3.5: optional thread groups for oversubscription (host_cores < num_user_threads)