### PR TITLE
feat(coverage): Phase 6 — construct port toggle coverage

### DIFF
--- a/doc/plan_arch_coverage.md
+++ b/doc/plan_arch_coverage.md
@@ -54,7 +54,7 @@ For each scalar wire/reg, count 0→1 and 1→0 transitions. Useful for catching
 
 Emit Verilator's \`# SystemC: …\`-prefixed format alongside the text report so users can run \`verilator_coverage --annotate-min 1 --annotate annot/ coverage.dat\` and get HTML annotation against the *.sv files. (The arch source lines won't match SV lines exactly, but the text report from phases 1-4 gives the arch-source view; the .dat gives the SV view.)
 
-### Phase 6 — construct port toggle coverage (TODO)
+### Phase 6 — construct port toggle coverage (SHIPPED)
 
 Today toggle coverage (Phase 4/4b) instruments scalar/Vec \`reg\` declarations inside \`gen_module\` only. The non-module construct emitters (\`fifo\`, \`arbiter\`, \`ram\`, \`cam\`, \`linklist\`, \`pipeline\`, plus \`fsm\` datapath regs) install no \`CoverageRegistry\`, so their internals contribute zero coverage. For most designs this is fine — the producing reg in the wrapping module is already toggled — but at black-box construct boundaries (e.g. an \`inst sub: SomeFifo\`) there is no signal we can attribute toggles to.
 

--- a/src/sim_codegen/mod.rs
+++ b/src/sim_codegen/mod.rs
@@ -4105,6 +4105,31 @@ impl<'a> SimCodegen<'a> {
         for c in &all_clks {
             h.push_str(&format!("  bool _rising_{c};\n"));
         }
+        // --coverage Phase 6: per-(inst, output-port) prev-value
+        // shadow for construct port toggle counters. Allocated only
+        // when coverage is on AND port is scalar (≤64 bits). Skips
+        // bus / Vec / wide ports (v1).
+        if self.coverage {
+            for (inst_idx, inst) in insts.iter().enumerate() {
+                let conns = &expanded_conns[inst_idx];
+                for conn in conns {
+                    if conn.direction != ConnectDir::Output { continue; }
+                    let sig_name = if let crate::ast::ExprKind::Ident(n) = &conn.signal.kind { n.as_str() } else { continue; };
+                    let w = widths.get(sig_name).copied().unwrap_or(0);
+                    if w == 0 || w > 64 { continue; }
+                    if wide_names.contains(sig_name) { continue; }
+                    if vec_port_names.contains(sig_name) { continue; }
+                    // Skip Vec regs/wires (they connect to flattened
+                    // sub-instance port names like `name_0..name_{n-1}`,
+                    // not the bare `name`). Phase 6 v1 = scalars only.
+                    if vec_wire_counts.contains_key(sig_name) { continue; }
+                    h.push_str(&format!(
+                        "  uint64_t _prev_{}_{} = 0;\n",
+                        inst.name.name, conn.port_name.name
+                    ));
+                }
+            }
+        }
 
         // Private reg fields. Use params-aware Vec sizing — bare
         // `vec_array_info` returns 0 for params-as-length, which would
@@ -4719,6 +4744,45 @@ impl<'a> SimCodegen<'a> {
             for inst in &insts {
                 if debug_module_set.contains(&inst.module_name.name) {
                     cpp.push_str(&format!("  _inst_{}._debug_log_ports();\n", inst.name.name));
+                }
+            }
+        }
+
+        // --coverage Phase 6: construct port toggle. For each scalar
+        // OUTPUT port of each instantiated sub-construct, popcount-XOR
+        // the current value against a per-port _prev shadow and
+        // accumulate into a coverage counter. Surfaces dead lanes /
+        // tied-off interfaces at black-box construct boundaries
+        // (fifo, arbiter, ram, cam — anywhere the sub's internals
+        // contribute zero coverage from the consumer's viewpoint).
+        // Skip in v1: bus ports, wide (>64b) ports.
+        if let Some(reg) = cov_handle {
+            for (inst_idx, inst) in insts.iter().enumerate() {
+                let conns = &expanded_conns[inst_idx];
+                for conn in conns {
+                    if conn.direction != ConnectDir::Output { continue; }
+                    // Resolve parent-side storage name + width.
+                    let sig_name = if let crate::ast::ExprKind::Ident(n) = &conn.signal.kind { n.as_str() } else { continue; };
+                    let w = widths.get(sig_name).copied().unwrap_or(0);
+                    if w == 0 || w > 64 { continue; }
+                    if wide_names.contains(sig_name) { continue; }
+                    if vec_port_names.contains(sig_name) { continue; }
+                    // Skip Vec regs/wires (they connect to flattened
+                    // sub-instance port names like `name_0..name_{n-1}`,
+                    // not the bare `name`). Phase 6 v1 = scalars only.
+                    if vec_wire_counts.contains_key(sig_name) { continue; }
+                    let cidx = reg.borrow_mut().alloc(
+                        "toggle",
+                        inst.span.start,
+                        format!("toggle {}.{}", inst.name.name, conn.port_name.name),
+                    );
+                    let inst_n = &inst.name.name;
+                    let port_n = &conn.port_name.name;
+                    cpp.push_str(&format!(
+                        "  {{ uint64_t _cur = (uint64_t)_inst_{inst_n}.{port_n}; \
+                         _arch_cov[{cidx}] += __builtin_popcountll(_cur ^ _prev_{inst_n}_{port_n}); \
+                         _prev_{inst_n}_{port_n} = _cur; }}\n"
+                    ));
                 }
             }
         }


### PR DESCRIPTION
## Summary

For each scalar OUTPUT port of each instantiated sub-construct in a \`gen_module\`, popcount-XOR the current value against a per-port \`_prev\` shadow and accumulate into a coverage counter. Surfaces dead lanes / tied-off interfaces at black-box construct boundaries (fifo, arbiter, ram, cam, lowered fsm sub-modules — anywhere the sub's internals contribute zero coverage from the consumer's viewpoint).

Closes the gap from \`doc/plan_arch_coverage.md\` Phase 6.

## Implementation

- One \`uint64_t _prev_<inst>_<port>\` field per scalar inst output (allocated only when \`--coverage\` / \`--coverage-dat\` is on).
- At end of \`eval()\` (after settle, before VCD dump): \`_arch_cov[N] += __builtin_popcountll(_cur ^ _prev); _prev = _cur;\`
- Counter category \`v_toggle\`, comment \`toggle <inst>.<port>\`.

## v1 limits

- Scalar Bool/UInt<≤64> output ports only.
- Vec port outputs skipped (they connect to flattened sub-port names like \`name_0..name_{n-1}\` — v1 handles bare scalars only).
- Wide >64b skipped.

## Verified

\`arch sim --coverage-dat=cov.dat ThreadMm2s.arch ...\` now emits per-sub-port toggle entries alongside the existing scalar-reg ones:

\`\`\`
toggle _threads.ar_addr  96 hits
toggle _threads.ar_burst 32
toggle _threads.ar_id    32
toggle _threads.ar_len   64
toggle _threads.ar_size  32
toggle _threads.ar_valid 32
toggle _threads.push_valid 128
toggle _threads.r_ready  2
\`\`\`

## Test plan

- [x] \`cargo test --lib\` — 15/15
- [x] \`cargo test --test integration_test\` — 167/167
- [x] All 5 thread cross-checks PASS
- [x] ThreadMm2s coverage output includes per-sub-port toggle entries
- [x] No behavior change when \`--coverage\` not set