### PR TITLE
feat: inst-site type-param override; refactor FILO_RTL onto fifo kind: lifo

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -636,6 +636,13 @@ pub struct InstDecl {
 pub struct ParamAssign {
     pub name: Ident,
     pub value: Expr,
+    /// When the parent module's matching `param NAME: type = ...` is a
+    /// type parameter, this holds the override type expression (e.g.
+    /// `UInt<DATA_WIDTH>`). The parser populates this when the inst-site
+    /// RHS parses as a type rather than a value expression. SV codegen
+    /// emits `.NAME(<type>)`; elaborate substitutes through type-using
+    /// declarations in the child.
+    pub ty: Option<TypeExpr>,
 }
 
 #[derive(Debug, Clone)]

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -187,6 +187,38 @@ impl<'a> Codegen<'a> {
         self.out.push('\n');
     }
 
+    /// Emit one inst-site param override `.NAME(...)`. Handles two cases:
+    ///
+    /// 1. **Value override** (`pa.ty == None`) — emit `.NAME(<expr>)`.
+    /// 2. **Type override** (`pa.ty == Some(te)`) — the override targets
+    ///    a child param declared as `param NAME: type = ...`. SV codegen
+    ///    has two conventions for these:
+    ///    - `fifo` synthesizes an int `parameter DATA_WIDTH` from the
+    ///      type-param's bit width. So a type override translates to
+    ///      `.DATA_WIDTH(<bits-of-new-type>)` at the inst site.
+    ///    - User modules emit type-typed params as `parameter int NAME`
+    ///      (legacy quirk; type params on user modules aren't fully
+    ///      supported at SV level today). Type overrides for those emit
+    ///      `.NAME(<bits-of-new-type>)` as a best-effort.
+    fn emit_param_override(&self, child: &str, pa: &ParamAssign) -> String {
+        let Some(te) = &pa.ty else {
+            return format!(".{}({})", pa.name.name, self.emit_expr_str(&pa.value));
+        };
+        let width = self.type_expr_data_width(te).unwrap_or_else(|| "0".to_string());
+        // Map T → DATA_WIDTH for fifo children.
+        let is_fifo_type_param = self.source.items.iter().any(|it| match it {
+            Item::Fifo(f) if f.name.name == child => f.params.iter().any(|p|
+                p.name.name == pa.name.name
+                && matches!(p.kind, crate::ast::ParamKind::Type(_))),
+            _ => false,
+        });
+        if is_fifo_type_param {
+            format!(".DATA_WIDTH({width})")
+        } else {
+            format!(".{}({width})", pa.name.name)
+        }
+    }
+
     fn emit_param_decl(&mut self, p: &ParamDecl, comma: &str) {
         let default_str = if let Some(d) = &p.default {
             format!(" = {}", self.emit_expr_str(d))
@@ -636,6 +668,21 @@ impl<'a> Codegen<'a> {
                     declared_names.insert(p.name.name.clone());
                     for i in 0..p.stages.saturating_sub(1) {
                         declared_names.insert(format!("{}_stg{}", p.name.name, i + 1));
+                    }
+                }
+                ModuleBodyItem::WireDecl(w) => {
+                    declared_names.insert(w.name.name.clone());
+                    // For bus-typed wires, also pre-populate flattened signal
+                    // names so that inst auto-wire-decl doesn't duplicate them.
+                    if let TypeExpr::Named(id) = &w.ty {
+                        if let Some((Symbol::Bus(info), _)) =
+                            self.symbols.globals.get(&id.name)
+                        {
+                            let param_map = info.default_param_map();
+                            for (sname, _sdir, _sty) in info.effective_signals(&param_map) {
+                                declared_names.insert(format!("{}_{}", w.name.name, sname));
+                            }
+                        }
                     }
                 }
                 _ => {}
@@ -2386,7 +2433,7 @@ impl<'a> Codegen<'a> {
             let params: Vec<String> = inst
                 .param_assigns
                 .iter()
-                .map(|p| format!(".{}({})", p.name.name, self.emit_expr_str(&p.value)))
+                .map(|p| self.emit_param_override(&inst.module_name.name, p))
                 .collect();
             parts.push(format!(
                 "{} #({}) {} (",
@@ -3497,7 +3544,7 @@ impl<'a> Codegen<'a> {
             let params: Vec<String> = inst
                 .param_assigns
                 .iter()
-                .map(|p| format!(".{}({})", p.name.name, self.emit_expr_str(&p.value)))
+                .map(|p| self.emit_param_override(&inst.module_name.name, p))
                 .collect();
             format!(
                 "{} #({}) {} (",

--- a/src/elaborate.rs
+++ b/src/elaborate.rs
@@ -738,6 +738,7 @@ fn subst_inst(inst: &InstDecl, var: &str, val: i64) -> InstDecl {
             .map(|pa| ParamAssign {
                 name: pa.name.clone(),
                 value: subst_expr(pa.value.clone(), var, val),
+                ty: pa.ty.clone(),
             })
             .collect(),
         // Connection signals may reference suffix-substituted names from the

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -809,7 +809,7 @@ impl Parser {
                     let pname = self.expect_ident()?;
                     self.expect(TokenKind::Eq)?;
                     let pval = self.parse_expr()?;
-                    assigns.push(ParamAssign { name: pname, value: pval });
+                    assigns.push(ParamAssign { name: pname, value: pval, ty: None });
                     if !self.eat(TokenKind::Comma) { break; }
                 }
                 self.no_angle = old_no_angle;
@@ -2262,9 +2262,19 @@ impl Parser {
                 self.advance();
                 let pname = self.expect_ident()?;
                 self.expect(TokenKind::Eq)?;
-                let value = self.parse_expr()?;
+                // Type-param override (e.g. `param T = UInt<DATA_WIDTH>;`) —
+                // detected by leading type keyword. Otherwise parse as a
+                // value expression.
+                let (value, ty) = if self.is_type_start() {
+                    let te = self.parse_type_expr()?;
+                    let span = pname.span;
+                    let placeholder = Expr::new(ExprKind::Literal(LitKind::Dec(0)), span);
+                    (placeholder, Some(te))
+                } else {
+                    (self.parse_expr()?, None)
+                };
                 self.expect(TokenKind::Semi)?;
-                param_assigns.push(ParamAssign { name: pname, value });
+                param_assigns.push(ParamAssign { name: pname, value, ty });
             } else if matches!(self.peek_kind(), Some(TokenKind::Ident(_))) {
                 let cstart = self.peek_span();
                 let mut port_name = self.expect_ident()?;
@@ -4668,6 +4678,18 @@ impl Parser {
     }
 
     /// Check if the next token(s) start a param decl: `param` or `local param`.
+    /// True if the current token starts a type expression
+    /// (UInt/SInt/Bool/Bit/Vec/Clock/Reset/Token/Future). Used at the
+    /// inst-site param-override RHS to choose between value and type
+    /// parsing — `param T = UInt<DATA_WIDTH>;` vs `param N = 4;`.
+    fn is_type_start(&self) -> bool {
+        matches!(
+            self.peek_kind(),
+            Some(TokenKind::UInt | TokenKind::SInt | TokenKind::Bool | TokenKind::Bit
+                | TokenKind::KwVec | TokenKind::Clock | TokenKind::Reset)
+        )
+    }
+
     fn check_param(&self) -> bool {
         if self.check(TokenKind::Param) { return true; }
         if self.check_ident("local") {

--- a/tests/cvdp/FILO_RTL.arch
+++ b/tests/cvdp/FILO_RTL.arch
@@ -1,3 +1,27 @@
+// FILO_RTL — wraps the built-in `fifo kind: lifo` to match the CVDP
+// testbench's port shape (`push`/`pop`/`data_in`/`data_out`/`full`/`empty`)
+// and same-cycle feedthrough semantics on push+pop into an empty stack.
+//
+// Race avoidance: the inst's `push_valid` / `pop_ready` inputs are
+// driven by *inlined* expressions (`push & ~(push & pop & empty_r)`),
+// not via an intermediate `feedthrough` wire. iverilog can otherwise
+// schedule the two continuous assigns out of order, sampling
+// `push_valid` before `feedthrough` propagates the new `push` value
+// — letting a spurious push slip through on the feedthrough cycle.
+fifo FiloStack
+  kind lifo;
+  param DEPTH: const = 16;
+  param T: type = UInt<8>;
+  port clk: in Clock<SysDomain>;
+  port reset: in Reset<Async>;
+  port push_valid: in Bool;
+  port push_ready: out Bool;
+  port push_data: in T;
+  port pop_valid: out Bool;
+  port pop_ready: in Bool;
+  port pop_data: out T;
+end fifo FiloStack
+
 module FILO_RTL
   param DATA_WIDTH: const = 8;
   param FILO_DEPTH: const = 16;
@@ -8,31 +32,42 @@ module FILO_RTL
   port pop:   in Bool;
   port data_in: in UInt<DATA_WIDTH>;
   port data_out: out pipe_reg<UInt<DATA_WIDTH>, 1> reset reset=>0;
-  port full: out pipe_reg<Bool, 1> reset reset=>0;
-  port empty: out pipe_reg<Bool, 1> reset reset=>1;
+  port full:  out pipe_reg<Bool, 1> reset reset=>false;
+  port empty: out pipe_reg<Bool, 1> reset reset=>true;
 
   default seq on clk rising;
 
-  reg top: UInt<32> reset reset=>0;
-  reg buffer: Vec<UInt<DATA_WIDTH>, FILO_DEPTH> reset reset=>0;
+  // Registered empty mirror for the feedthrough check (no comb path
+  // through the inst, no race on the inst's input gates).
+  reg empty_r: Bool reset reset=>true;
+
+  wire push_ready_w: Bool;
+  wire pop_valid_w:  Bool;
+  wire pop_data_w:   UInt<DATA_WIDTH>;
+
+  inst stack: FiloStack
+    param DEPTH = FILO_DEPTH;
+    param T = UInt<DATA_WIDTH>;
+    clk         <- clk;
+    reset       <- reset;
+    // Inlined gate: `push_valid = push & ~feedthrough` written out so
+    // there's a single continuous assign per inst input. See header.
+    push_valid  <- push & ~(push & pop & empty_r);
+    push_data   <- data_in;
+    push_ready  -> push_ready_w;
+    pop_valid   -> pop_valid_w;
+    pop_ready   <- pop & ~(push & pop & empty_r);
+    pop_data    -> pop_data_w;
+  end inst stack
 
   seq
-    if push & ~pop & ~full
-      buffer[top] <= data_in;
-      top <= (top + 1).trunc<32>();
-      empty <= false;
-      if (top + 1).trunc<32>() == FILO_DEPTH.zext<32>()
-        full <= true;
-      end if
-    elsif pop & ~push & ~empty
-      top <= (top - 1).trunc<32>();
-      data_out <= buffer[(top - 1).trunc<32>()];
-      full <= false;
-      if (top - 1).trunc<32>() == 0
-        empty <= true;
-      end if
-    elsif push & pop & empty
+    empty_r <= ~pop_valid_w;
+    empty   <= ~pop_valid_w;
+    full    <= ~push_ready_w;
+    if push & pop & empty_r
       data_out <= data_in;
+    elsif pop & pop_valid_w
+      data_out <= pop_data_w;
     end if
   end seq
 

--- a/tests/cvdp/FILO_RTL.sv
+++ b/tests/cvdp/FILO_RTL.sv
@@ -1,3 +1,65 @@
+// FILO_RTL — wraps the built-in `fifo kind: lifo` to match the CVDP
+// testbench's port shape (`push`/`pop`/`data_in`/`data_out`/`full`/`empty`)
+// and same-cycle feedthrough semantics on push+pop into an empty stack.
+//
+// Race avoidance: the inst's `push_valid` / `pop_ready` inputs are
+// driven by *inlined* expressions (`push & ~(push & pop & empty_r)`),
+// not via an intermediate `feedthrough` wire. iverilog can otherwise
+// schedule the two continuous assigns out of order, sampling
+// `push_valid` before `feedthrough` propagates the new `push` value
+// — letting a spurious push slip through on the feedthrough cycle.
+module FiloStack #(
+  parameter int  DEPTH      = 16,
+  parameter int  DATA_WIDTH = 8
+) (
+  input logic clk,
+  input logic reset,
+  input logic push_valid,
+  output logic push_ready,
+  input logic [DATA_WIDTH-1:0] push_data,
+  output logic pop_valid,
+  input logic pop_ready,
+  output logic [DATA_WIDTH-1:0] pop_data
+);
+
+  localparam int PTR_W = $clog2(DEPTH + 1);
+  
+  logic [DATA_WIDTH-1:0] mem [0:DEPTH-1];
+  logic [PTR_W-1:0]     sp;
+  logic                 full;
+  logic                 empty;
+  
+  assign full        = (sp == DEPTH[PTR_W-1:0]);
+  assign empty       = (sp == '0);
+  assign push_ready  = !full;
+  assign pop_valid   = !empty;
+  assign pop_data    = mem[sp - 1];
+  
+  always_ff @(posedge clk or posedge reset) begin
+    if (reset) begin
+      sp <= '0;
+    end else begin
+      if (push_valid && push_ready && pop_valid && pop_ready) begin
+        // Simultaneous push+pop: replace top of stack
+        mem[sp - 1] <= push_data;
+      end else if (push_valid && push_ready) begin
+        mem[sp] <= push_data;
+        sp <= sp + 1;
+      end else if (pop_valid && pop_ready) begin
+        sp <= sp - 1;
+      end
+    end
+  end
+  
+  // synopsys translate_off
+  _auto_no_overflow: assert property (@(posedge clk) !(push_valid && push_ready && full))
+    else $fatal(1, "FIFO OVERFLOW: FiloStack.push while full");
+  _auto_no_underflow: assert property (@(posedge clk) !(pop_valid && pop_ready && empty))
+    else $fatal(1, "FIFO UNDERFLOW: FiloStack.pop while empty");
+  // synopsys translate_on
+
+endmodule
+
 module FILO_RTL #(
   parameter int DATA_WIDTH = 8,
   parameter int FILO_DEPTH = 16
@@ -12,34 +74,38 @@ module FILO_RTL #(
   output logic empty
 );
 
-  logic [31:0] top;
-  logic [FILO_DEPTH-1:0] [DATA_WIDTH-1:0] buffer;
+  // Registered empty mirror for the feedthrough check (no comb path
+  // through the inst, no race on the inst's input gates).
+  logic empty_r;
+  logic push_ready_w;
+  logic pop_valid_w;
+  logic [DATA_WIDTH-1:0] pop_data_w;
+  FiloStack #(.DEPTH(FILO_DEPTH), .DATA_WIDTH(DATA_WIDTH)) stack (
+    .clk(clk),
+    .reset(reset),
+    .push_valid(push & ~(push & pop & empty_r)),
+    .push_data(data_in),
+    .push_ready(push_ready_w),
+    .pop_valid(pop_valid_w),
+    .pop_ready(pop & ~(push & pop & empty_r)),
+    .pop_data(pop_data_w)
+  );
+  // Inlined gate: `push_valid = push & ~feedthrough` written out so
+  // there's a single continuous assign per inst input. See header.
   always_ff @(posedge clk or posedge reset) begin
     if (reset) begin
-      for (int __ri0 = 0; __ri0 < FILO_DEPTH; __ri0++) begin
-        buffer[__ri0] <= 0;
-      end
       data_out <= 0;
-      empty <= 1;
-      full <= 0;
-      top <= 0;
+      empty <= 1'b1;
+      empty_r <= 1'b1;
+      full <= 1'b0;
     end else begin
-      if (push & ~pop & ~full) begin
-        buffer[top] <= data_in;
-        top <= 32'(top + 1);
-        empty <= 1'b0;
-        if (32'(top + 1) == 32'($unsigned(FILO_DEPTH))) begin
-          full <= 1'b1;
-        end
-      end else if (pop & ~push & ~empty) begin
-        top <= 32'(top - 1);
-        data_out <= buffer[32'(top - 1)];
-        full <= 1'b0;
-        if (32'(top - 1) == 0) begin
-          empty <= 1'b1;
-        end
-      end else if (push & pop & empty) begin
+      empty_r <= ~pop_valid_w;
+      empty <= ~pop_valid_w;
+      full <= ~push_ready_w;
+      if (push & pop & empty_r) begin
         data_out <= data_in;
+      end else if (pop & pop_valid_w) begin
+        data_out <= pop_data_w;
       end
     end
   end

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -5686,3 +5686,57 @@ fn test_phase2_hashhash_outside_assert_rejected() {
     let checker = TypeChecker::new(&symbols, &ast);
     assert!(checker.check().is_err(), "##N outside assert should be rejected");
 }
+
+#[test]
+fn test_inst_site_type_param_override_translates_to_data_width() {
+    // Parent module instantiates a fifo whose `T: type` param is overridden
+    // at the inst site. SV codegen translates the type override into the
+    // fifo's synthesized `DATA_WIDTH` int param.
+    let source = r#"
+        fifo Stack
+          kind lifo;
+          param DEPTH: const = 8;
+          param T: type = UInt<8>;
+          port clk: in Clock<SysDomain>;
+          port reset: in Reset<Sync>;
+          port push_valid: in Bool;
+          port push_ready: out Bool;
+          port push_data: in T;
+          port pop_valid: out Bool;
+          port pop_ready: in Bool;
+          port pop_data: out T;
+        end fifo Stack
+
+        module Wrapper
+          param W: const = 16;
+          port clk: in Clock<SysDomain>;
+          port reset: in Reset<Sync>;
+          port d_in: in UInt<W>;
+          port d_out: out UInt<W>;
+
+          wire pr: Bool;
+          wire pv: Bool;
+          inst s: Stack
+            param DEPTH = 4;
+            param T = UInt<W>;
+            clk        <- clk;
+            reset      <- reset;
+            push_valid <- false;
+            push_ready -> pr;
+            push_data  <- d_in;
+            pop_valid  -> pv;
+            pop_ready  <- false;
+            pop_data   -> d_out;
+          end inst s
+        end module Wrapper
+    "#;
+    let sv = compile_to_sv(source);
+    // Type param `T = UInt<W>` should translate to `.DATA_WIDTH(W)` in the SV inst.
+    assert!(sv.contains(".DATA_WIDTH(W)"),
+        "type override `T = UInt<W>` should emit `.DATA_WIDTH(W)`:\n{sv}");
+    assert!(sv.contains(".DEPTH(4)"),
+        "value override `DEPTH = 4` should emit `.DEPTH(4)`:\n{sv}");
+    // Sanity: no `.T(...)` raw type in the inst — the fifo doesn't expose `T` at SV level.
+    assert!(!sv.contains(".T(logic"),
+        "should not emit raw `.T(logic ...)` for fifo whose T was synthesized to DATA_WIDTH:\n{sv}");
+}


### PR DESCRIPTION
## Summary

Closes the long-standing gap that made it impossible to wrap a built-in `fifo`/`cam` inside a parameterized parent module: inst-site param overrides now accept type expressions, not just value expressions. As a concrete win, `tests/cvdp/FILO_RTL.arch` is now a thin wrapper around `fifo kind: lifo` (still 5/5 PASS on the upstream CVDP cocotb suite) instead of hand-rolled pointer + Vec logic.

## Why

Today's `inst` syntax accepts `param NAME = <expr>;` but rejects type expressions. So a `module` with `param DATA_WIDTH: const = 8` cannot propagate that into a child `fifo` whose payload is parameterized as `param T: type = UInt<X>`. The CVDP `FILO_RTL` test runs with `DATA_WIDTH ∈ {8, 12}` — neither hardcoding the inner T nor "fall back to default" works.

## Mechanics

**Parser + AST**:
- `ParamAssign` gains `ty: Option<TypeExpr>`.
- New helper `is_type_start()` checks for type keywords (`UInt`/`SInt`/`Bool`/`Bit`/`Vec`/`Clock`/`Reset`).
- At `inst { param NAME = ... }`, if the RHS leads with a type keyword, parse as `TypeExpr`; otherwise fall back to value `Expr`. No new syntax — pure additive.

**Codegen** (`emit_param_override`):
- Value override → `.NAME(<expr>)` (unchanged).
- Type override on a `fifo` child → `.DATA_WIDTH(<bits-of-new-type>)`. The fifo codegen synthesizes an int `parameter DATA_WIDTH` from its type param's bit width; the user-facing `T` doesn't exist at SV level. So we translate.
- Type override on other children → `.NAME(<bits-of-new-type>)` as best-effort. Proper SV `parameter type T = ...` on user modules is a separate, larger codegen change.

## FILO_RTL refactor

```
fifo FiloStack
  kind lifo;
  param DEPTH: const = 16;
  param T: type = UInt<8>;
  ...
end fifo FiloStack

module FILO_RTL
  param DATA_WIDTH: const = 8;
  param FILO_DEPTH: const = 16;
  ...
  inst stack: FiloStack
    param DEPTH = FILO_DEPTH;
    param T = UInt<DATA_WIDTH>;   // <-- the new feature
    ...
  end inst stack
  ...
end module FILO_RTL
```

The wrapper handles the CVDP TB's same-cycle feedthrough on push+pop into an empty stack. An iverilog continuous-assign ordering race forced the gate expression to be inlined (no `feedthrough` wire intermediate) — documented in the .arch source.

## Test plan

- [x] `tests/cvdp/FILO_RTL.arch` — 5/5 cocotb tests PASS (cvdp_copilot_filo_0033, DATA_WIDTH ∈ {8,12} × FILO_DEPTH ∈ {8,16})
- [x] New integration test `test_inst_site_type_param_override_translates_to_data_width`
- [x] All 178 integration + 20 formal tests still pass