### PR TITLE
feat(pipe_reg): RHS tap-line reads q@K for K in [0..N]

### DIFF
--- a/doc/ARCH_HDL_Specification.md
+++ b/doc/ARCH_HDL_Specification.md
@@ -953,7 +953,28 @@ end seq
 
 For N = 1, the bare assignment form `q <= Y` is also accepted (same flop count as `port reg`). For N > 1, only `q@N <= Y` is valid — bare `q <= Y` is a compile error (*"assignment to pipe_reg port `q` is ambiguous — write `q@N <= ...` to state the latency"*).
 
-**Reading** a `pipe_reg` port on the RHS returns the final-output stage. The explicit form `q@0` reads as "current value" and is equivalent to bare `q`. Reading intermediate stages (`q@K` for K > 0 on the RHS) is a compile error in v1 — *"reading intermediate stage `@K` is not yet supported"*.
+**Reading** a `pipe_reg` port or module-scope `pipe_reg` decl on the RHS supports tap-line indexing: `q@K` reads the value at K cycles of delay from the input. For `pipe_reg q: src stages N`:
+
+| Read | Value |
+|---|---|
+| `q@0` | `src` (raw input, no flop) |
+| `q@1` | after 1 flop |
+| `q@K` (1 ≤ K < N) | after K flops |
+| `q@N` | after N flops = same as bare `q` (final output) |
+| bare `q` | final output (= `q@N`) |
+
+`q@K` for K > N is a compile error (`q@N+1 exceeds pipe_reg depth N`). `name@K` on a non-pipe_reg signal is rejected with the legacy "only `@0` is allowed" message. The classic 4-tap FIR pattern collapses from three separate delay regs to one declaration:
+
+```
+pipe_reg sample_pipe: input_sample stages 3;
+
+comb
+  prod0 = sample_pipe@0 * coeff0;   // input_sample
+  prod1 = sample_pipe@1 * coeff1;   // 1-cycle-delayed
+  prod2 = sample_pipe@2 * coeff2;   // 2-cycle-delayed
+  prod3 = sample_pipe@3 * coeff3;   // 3-cycle-delayed = bare sample_pipe
+end comb
+```
 
 **Uniform reset / init across stages.** A single `reset R => V` or `init V` clause applies to every flop in the chain. When `rst` asserts, all N stages simultaneously drop to the reset value; one cycle after deassert, a new write to `q@N` begins propagating. This matches today's module-scope `pipe_reg` semantics.
 

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -62,6 +62,11 @@ pub struct Codegen<'a> {
     /// Populated per-module at emit time so Vec method lowerings
     /// (`any`/`all`/`count`/etc.) can unroll over N iterations.
     vec_sizes: std::collections::HashMap<String, u32>,
+    /// Map of pipe_reg name → (source name, total stages N) for the
+    /// current module being emitted. Used to lower `q@K` reads on RHS
+    /// to the right SV intermediate signal: `q@0` → source, `q@K` for
+    /// 1≤K<N → `q_stg{K}`, `q@N` → `q` (= bare q).
+    pipe_regs: std::collections::HashMap<String, (String, u32)>,
     /// Set of index widths used by `.find_first(...)` calls in this file.
     /// Drives emission of one `typedef struct packed ... __ArchFindResult_<W>;`
     /// per unique W at the top of the generated SV. Interior-mutability
@@ -91,6 +96,7 @@ impl<'a> Codegen<'a> {
             current_construct: String::new(),
             ident_subst: std::collections::HashMap::new(),
             vec_sizes: std::collections::HashMap::new(),
+            pipe_regs: std::collections::HashMap::new(),
             find_first_widths: std::cell::RefCell::new(std::collections::BTreeSet::new()),
         }
     }
@@ -539,6 +545,12 @@ impl<'a> Codegen<'a> {
         self.bus_wires.clear();
         self.reset_ports.clear();
         self.vec_sizes.clear();
+        self.pipe_regs.clear();
+        for bi in &m.body {
+            if let ModuleBodyItem::PipeRegDecl(p) = bi {
+                self.pipe_regs.insert(p.name.name.clone(), (p.source.name.clone(), p.stages));
+            }
+        }
         for p in m.ports.iter() {
             if let TypeExpr::Reset(kind, level) = &p.ty {
                 self.reset_ports.insert(p.name.name.clone(), (*kind, *level));
@@ -6067,12 +6079,30 @@ impl<'a> Codegen<'a> {
     /// Core expression emitter — never adds outer parens itself.
     fn emit_expr_inner(&self, expr: &Expr) -> String {
         match &expr.kind {
-            // Latency annotation is purely documentary on emission.
-            // On RHS, `q@0` reads as the current value of `q` (the pipe's
-            // final output). On LHS inside an assignment, the enclosing
-            // assignment emitter strips the annotation before routing the
-            // value to the appropriate stage 0 of the pipe chain.
-            ExprKind::LatencyAt(inner, _) => self.emit_expr_inner(inner),
+            // `q@K` on RHS lowers to the K-th tap of the pipe_reg
+            // chain (`q` being the final flop, source being the input
+            // before any flop). Numbering counts cycles of delay from
+            // the input: `@0` = source comb, `@K` = after K flops,
+            // `@N` = bare `q`. Falls through transparently when the
+            // base isn't a known pipe_reg name (typecheck rejects
+            // out-of-range / non-pipe-reg uses earlier).
+            ExprKind::LatencyAt(inner, n) => {
+                if let ExprKind::Ident(name) = &inner.kind {
+                    if let Some((source, stages)) = self.pipe_regs.get(name) {
+                        let stages = *stages;
+                        if *n == 0 {
+                            return source.clone();
+                        }
+                        if *n == stages {
+                            return name.clone();
+                        }
+                        if *n < stages {
+                            return format!("{name}_stg{n}");
+                        }
+                    }
+                }
+                self.emit_expr_inner(inner)
+            }
             // SVA forward-shift: `##N expr` only legal inside an assert
             // /cover property (typecheck enforces). Emit verbatim — SV
             // accepts it natively in property context.

--- a/src/elaborate.rs
+++ b/src/elaborate.rs
@@ -3321,13 +3321,25 @@ fn lower_pipe_reg_module(mut m: ModuleDecl) -> Result<ModuleDecl, Vec<CompileErr
     //   - bare q <= Y on pipe_reg with depth > 1 (ambiguous)
     //   - q@K on RHS for K > 0 (intermediate stage reads not supported v1)
     //   - q@0 = Y on combinational port (not a pipe_reg)
+    // Build name → total-stages for tap-bound checks of `q@K` reads.
+    // Includes module-scope `pipe_reg` decls (depth = `stages`) and
+    // pipe_reg ports (depth = port latency).
+    let mut pipe_depths: std::collections::HashMap<String, u32> = std::collections::HashMap::new();
+    for pp in &all_pipe_ports {
+        pipe_depths.insert(pp.name.clone(), pp.latency);
+    }
+    for bi in &m.body {
+        if let ModuleBodyItem::PipeRegDecl(p) = bi {
+            pipe_depths.insert(p.name.name.clone(), p.stages);
+        }
+    }
     let mut errors: Vec<CompileError> = Vec::new();
     for bi in &m.body {
         if let ModuleBodyItem::RegBlock(rb) = bi {
-            validate_pipe_assignments(&rb.stmts, &all_pipe_ports, &mut errors);
+            validate_pipe_assignments(&rb.stmts, &all_pipe_ports, &pipe_depths, &mut errors);
         }
         if let ModuleBodyItem::CombBlock(cb) = bi {
-            validate_comb_pipe_refs(&cb.stmts, &all_pipe_ports, &m.ports, &mut errors);
+            validate_comb_pipe_refs(&cb.stmts, &all_pipe_ports, &m.ports, &pipe_depths, &mut errors);
         }
     }
     if !errors.is_empty() { return Err(errors); }
@@ -3396,16 +3408,18 @@ fn lower_pipe_reg_module(mut m: ModuleDecl) -> Result<ModuleDecl, Vec<CompileErr
 fn validate_pipe_assignments(
     stmts: &[Stmt],
     ports: &[PipePortInfoLocal],
+    pipe_depths: &std::collections::HashMap<String, u32>,
     errors: &mut Vec<CompileError>,
 ) {
     for s in stmts {
-        validate_pipe_assign_stmt(s, ports, errors);
+        validate_pipe_assign_stmt(s, ports, pipe_depths, errors);
     }
 }
 
 fn validate_pipe_assign_stmt(
     stmt: &Stmt,
     ports: &[PipePortInfoLocal],
+    pipe_depths: &std::collections::HashMap<String, u32>,
     errors: &mut Vec<CompileError>,
 ) {
     match stmt {
@@ -3442,67 +3456,76 @@ fn validate_pipe_assign_stmt(
                 }
                 _ => {}
             }
-            // Validate RHS too — no @K for K > 0 in v1.
-            validate_rhs_latency(&a.value, errors);
+            // RHS `q@K` for pipe_reg `q`: K must be 0..=N.
+            validate_rhs_latency_with_depths(&a.value, pipe_depths, errors);
         }
         Stmt::IfElse(ie) => {
-            validate_pipe_assignments(&ie.then_stmts, ports, errors);
-            validate_pipe_assignments(&ie.else_stmts, ports, errors);
+            validate_pipe_assignments(&ie.then_stmts, ports, pipe_depths, errors);
+            validate_pipe_assignments(&ie.else_stmts, ports, pipe_depths, errors);
         }
         Stmt::Match(m) => {
             for arm in &m.arms {
-                validate_pipe_assignments(&arm.body, ports, errors);
+                validate_pipe_assignments(&arm.body, ports, pipe_depths, errors);
             }
         }
-        Stmt::For(f) => validate_pipe_assignments(&f.body, ports, errors),
-        Stmt::Init(ib) => validate_pipe_assignments(&ib.body, ports, errors),
+        Stmt::For(f) => validate_pipe_assignments(&f.body, ports, pipe_depths, errors),
+        Stmt::Init(ib) => validate_pipe_assignments(&ib.body, ports, pipe_depths, errors),
         _ => {}
     }
 }
 
-fn validate_rhs_latency(e: &Expr, errors: &mut Vec<CompileError>) {
+fn validate_rhs_latency_with_depths(
+    e: &Expr,
+    pipe_depths: &std::collections::HashMap<String, u32>,
+    errors: &mut Vec<CompileError>,
+) {
+    // RHS `q@K` reads the K-th tap of pipe_reg `q` (K=0 = source comb,
+    // K=N = final output = bare `q`). Validate K ≤ N when the base is
+    // a known pipe_reg name; if the base isn't a pipe_reg, reject @K
+    // for K > 0 (legacy "no @ on plain regs" rule).
     match &e.kind {
         ExprKind::LatencyAt(inner, n) => {
-            if *n != 0 {
-                let root = pipe_reg_expr_root_name(inner);
-                errors.push(CompileError::general(
-                    &format!("reading intermediate stage `@{n}` is not yet supported — read `{root}` or `{root}@0` for the current value"),
-                    e.span,
-                ));
+            if let ExprKind::Ident(name) = &inner.kind {
+                match pipe_depths.get(name) {
+                    Some(depth) if *n > *depth => {
+                        errors.push(CompileError::general(
+                            &format!("`{name}@{n}` exceeds pipe_reg depth {depth} (valid taps: 0..={depth})"),
+                            e.span,
+                        ));
+                    }
+                    None if *n != 0 => {
+                        errors.push(CompileError::general(
+                            &format!("`{name}@{n}` — `{name}` is not a pipe_reg, only `@0` is allowed on plain signals"),
+                            e.span,
+                        ));
+                    }
+                    _ => {}
+                }
             }
-            validate_rhs_latency(inner, errors);
+            validate_rhs_latency_with_depths(inner, pipe_depths, errors);
         }
-        ExprKind::Binary(_, l, r) => { validate_rhs_latency(l, errors); validate_rhs_latency(r, errors); }
-        ExprKind::Unary(_, x) => validate_rhs_latency(x, errors),
+        ExprKind::Binary(_, l, r) => { validate_rhs_latency_with_depths(l, pipe_depths, errors); validate_rhs_latency_with_depths(r, pipe_depths, errors); }
+        ExprKind::Unary(_, x) => validate_rhs_latency_with_depths(x, pipe_depths, errors),
         ExprKind::Ternary(c, t, e2) => {
-            validate_rhs_latency(c, errors);
-            validate_rhs_latency(t, errors);
-            validate_rhs_latency(e2, errors);
+            validate_rhs_latency_with_depths(c, pipe_depths, errors);
+            validate_rhs_latency_with_depths(t, pipe_depths, errors);
+            validate_rhs_latency_with_depths(e2, pipe_depths, errors);
         }
-        ExprKind::FieldAccess(b, _) => validate_rhs_latency(b, errors),
-        ExprKind::Index(b, i) => { validate_rhs_latency(b, errors); validate_rhs_latency(i, errors); }
+        ExprKind::FieldAccess(b, _) => validate_rhs_latency_with_depths(b, pipe_depths, errors),
+        ExprKind::Index(b, i) => { validate_rhs_latency_with_depths(b, pipe_depths, errors); validate_rhs_latency_with_depths(i, pipe_depths, errors); }
         ExprKind::BitSlice(b, h, l) => {
-            validate_rhs_latency(b, errors);
-            validate_rhs_latency(h, errors);
-            validate_rhs_latency(l, errors);
+            validate_rhs_latency_with_depths(b, pipe_depths, errors);
+            validate_rhs_latency_with_depths(h, pipe_depths, errors);
+            validate_rhs_latency_with_depths(l, pipe_depths, errors);
         }
         ExprKind::MethodCall(b, _, args) => {
-            validate_rhs_latency(b, errors);
-            for a in args { validate_rhs_latency(a, errors); }
+            validate_rhs_latency_with_depths(b, pipe_depths, errors);
+            for a in args { validate_rhs_latency_with_depths(a, pipe_depths, errors); }
         }
         ExprKind::FunctionCall(_, args) => {
-            for a in args { validate_rhs_latency(a, errors); }
+            for a in args { validate_rhs_latency_with_depths(a, pipe_depths, errors); }
         }
         _ => {}
-    }
-}
-
-fn pipe_reg_expr_root_name(e: &Expr) -> String {
-    match &e.kind {
-        ExprKind::Ident(n) => n.clone(),
-        ExprKind::LatencyAt(inner, _) => pipe_reg_expr_root_name(inner),
-        ExprKind::FieldAccess(b, _) => pipe_reg_expr_root_name(b),
-        _ => "<expr>".to_string(),
     }
 }
 
@@ -3510,6 +3533,7 @@ fn validate_comb_pipe_refs(
     stmts: &[CombStmt],
     pipe_ports: &[PipePortInfoLocal],
     all_ports: &[PortDecl],
+    pipe_depths: &std::collections::HashMap<String, u32>,
     errors: &mut Vec<CompileError>,
 ) {
     for s in stmts {
@@ -3527,11 +3551,11 @@ fn validate_comb_pipe_refs(
                         }
                     }
                 }
-                validate_rhs_latency(&a.value, errors);
+                validate_rhs_latency_with_depths(&a.value, pipe_depths, errors);
             }
             CombStmt::IfElse(ie) => {
-                validate_comb_pipe_refs(&ie.then_stmts, pipe_ports, all_ports, errors);
-                validate_comb_pipe_refs(&ie.else_stmts, pipe_ports, all_ports, errors);
+                validate_comb_pipe_refs(&ie.then_stmts, pipe_ports, all_ports, pipe_depths, errors);
+                validate_comb_pipe_refs(&ie.else_stmts, pipe_ports, all_ports, pipe_depths, errors);
             }
             CombStmt::MatchExpr(_) | CombStmt::For(_) | CombStmt::Log(_) => {}
         }

--- a/tests/cvdp/fir_filter.arch
+++ b/tests/cvdp/fir_filter.arch
@@ -9,9 +9,11 @@ module fir_filter
   port coeff2: in SInt<16>;
   port coeff3: in SInt<16>;
 
-  reg sample_delay1: SInt<16> reset reset=>0;
-  reg sample_delay2: SInt<16> reset reset=>0;
-  reg sample_delay3: SInt<16> reset reset=>0;
+  // 3-stage delay line over input_sample. Tap K = K cycles of delay
+  // from the input: @0 = input_sample, @1..@2 = intermediate stages,
+  // @3 = bare `sample_pipe` (final output).
+  pipe_reg sample_pipe: input_sample stages 3;
+
   reg accumulator: SInt<32> reset reset=>0;
   reg out_reg: SInt<16> reset reset=>0;
 
@@ -22,17 +24,14 @@ module fir_filter
   wire acc_sum: SInt<32>;
 
   comb
-    prod0 = input_sample * coeff0;
-    prod1 = sample_delay1 * coeff1;
-    prod2 = sample_delay2 * coeff2;
-    prod3 = sample_delay3 * coeff3;
+    prod0 = sample_pipe@0 * coeff0;
+    prod1 = sample_pipe@1 * coeff1;
+    prod2 = sample_pipe@2 * coeff2;
+    prod3 = sample_pipe@3 * coeff3;
     acc_sum = (prod0.sext<34>() + prod1.sext<34>() + prod2.sext<34>() + prod3.sext<34>()).trunc<32>();
   end comb
 
   seq on clk rising
-    sample_delay1 <= input_sample;
-    sample_delay2 <= sample_delay1;
-    sample_delay3 <= sample_delay2;
     accumulator <= acc_sum;
     out_reg <= accumulator.trunc<16>();
   end seq

--- a/tests/cvdp/fir_filter.sv
+++ b/tests/cvdp/fir_filter.sv
@@ -10,9 +10,23 @@ module fir_filter (
   input logic signed [15:0] coeff3
 );
 
-  logic signed [15:0] sample_delay1;
-  logic signed [15:0] sample_delay2;
-  logic signed [15:0] sample_delay3;
+  // 3-stage delay line over input_sample. Tap K = K cycles of delay
+  // from the input: @0 = input_sample, @1..@2 = intermediate stages,
+  // @3 = bare `sample_pipe` (final output).
+  logic signed [15:0] sample_pipe_stg1;
+  logic signed [15:0] sample_pipe_stg2;
+  logic signed [15:0] sample_pipe;
+  always_ff @(posedge clk) begin
+    if (reset) begin
+      sample_pipe_stg1 <= '0;
+      sample_pipe_stg2 <= '0;
+      sample_pipe <= '0;
+    end else begin
+      sample_pipe_stg1 <= input_sample;
+      sample_pipe_stg2 <= sample_pipe_stg1;
+      sample_pipe <= sample_pipe_stg2;
+    end
+  end
   logic signed [31:0] accumulator;
   logic signed [15:0] out_reg;
   logic signed [31:0] prod0;
@@ -21,21 +35,15 @@ module fir_filter (
   logic signed [31:0] prod3;
   logic signed [31:0] acc_sum;
   assign prod0 = input_sample * coeff0;
-  assign prod1 = sample_delay1 * coeff1;
-  assign prod2 = sample_delay2 * coeff2;
-  assign prod3 = sample_delay3 * coeff3;
+  assign prod1 = sample_pipe_stg1 * coeff1;
+  assign prod2 = sample_pipe_stg2 * coeff2;
+  assign prod3 = sample_pipe * coeff3;
   assign acc_sum = 32'({{(34-$bits(prod0)){prod0[$bits(prod0)-1]}}, prod0} + {{(34-$bits(prod1)){prod1[$bits(prod1)-1]}}, prod1} + {{(34-$bits(prod2)){prod2[$bits(prod2)-1]}}, prod2} + {{(34-$bits(prod3)){prod3[$bits(prod3)-1]}}, prod3});
   always_ff @(posedge clk or posedge reset) begin
     if (reset) begin
       accumulator <= 0;
       out_reg <= 0;
-      sample_delay1 <= 0;
-      sample_delay2 <= 0;
-      sample_delay3 <= 0;
     end else begin
-      sample_delay1 <= input_sample;
-      sample_delay2 <= sample_delay1;
-      sample_delay3 <= sample_delay2;
       accumulator <= acc_sum;
       out_reg <= 16'(accumulator);
     end

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -5740,3 +5740,58 @@ fn test_inst_site_type_param_override_translates_to_data_width() {
     assert!(!sv.contains(".T(logic"),
         "should not emit raw `.T(logic ...)` for fifo whose T was synthesized to DATA_WIDTH:\n{sv}");
 }
+
+#[test]
+fn test_pipe_reg_tap_reads_q_at_k() {
+    // `q@K` on RHS reads the K-th tap of a pipe_reg chain.
+    // K=0 is the source comb; K=N is the bare q (final output).
+    let source = r#"
+        module M
+          port clk: in Clock<SysDomain>;
+          port reset: in Reset<Async, High>;
+          port a: in UInt<8>;
+          port o0: out UInt<8>;
+          port o1: out UInt<8>;
+          port o2: out UInt<8>;
+          port o3: out UInt<8>;
+
+          pipe_reg q: a stages 3;
+
+          comb
+            o0 = q@0;   // source = a
+            o1 = q@1;   // q_stg1
+            o2 = q@2;   // q_stg2
+            o3 = q@3;   // bare q (final flop)
+          end comb
+        end module M
+    "#;
+    let sv = compile_to_sv(source);
+    assert!(sv.contains("assign o0 = a;"), "q@0 should be source `a`:\n{sv}");
+    assert!(sv.contains("assign o1 = q_stg1;"), "q@1 should be q_stg1:\n{sv}");
+    assert!(sv.contains("assign o2 = q_stg2;"), "q@2 should be q_stg2:\n{sv}");
+    assert!(sv.contains("assign o3 = q;"), "q@3 should be bare q:\n{sv}");
+}
+
+#[test]
+fn test_pipe_reg_tap_out_of_range_errors() {
+    let source = r#"
+        module M
+          port clk: in Clock<SysDomain>;
+          port reset: in Reset<Async, High>;
+          port a: in UInt<8>;
+          port o: out UInt<8>;
+          pipe_reg q: a stages 3;
+          comb
+            o = q@4;   // out of range (max is 3)
+          end comb
+        end module M
+    "#;
+    let tokens = lexer::tokenize(source).expect("lex");
+    let mut parser = Parser::new(tokens, source);
+    let parsed_ast = parser.parse_source_file().expect("parse");
+    let result = elaborate::lower_pipe_reg_ports(parsed_ast);
+    assert!(result.is_err(), "q@4 should be rejected for stages=3");
+    let errs = result.err().unwrap();
+    assert!(errs.iter().any(|e| format!("{e:?}").contains("exceeds pipe_reg depth")),
+        "error should mention depth: {errs:?}");
+}


### PR DESCRIPTION
## Summary

Adds tap-line indexing for \`pipe_reg\` reads — \`q@K\` returns the value at K cycles of delay from the chain's input. Closes the v1 limitation that only allowed bare \`q\` / \`q@0\`.

For \`pipe_reg q: src stages N\`:

| Read | Value |
|---|---|
| \`q@0\` | \`src\` (raw input, no flop) |
| \`q@1\` | after 1 flop |
| \`q@K\` (1 ≤ K < N) | after K flops |
| \`q@N\` | after N flops = bare \`q\` (final output) |
| bare \`q\` | final output (= \`q@N\`) |

## Why

Classic FIR / delay-line patterns currently require N separate \`reg\` decls + N seq update lines. With tap reads, one \`pipe_reg\` declaration replaces all of them. Demo: \`tests/cvdp/fir_filter.arch\` collapses 3 delay regs + 3 seq assignments into a single \`pipe_reg sample_pipe: input_sample stages 3;\`. Cocotb test still 3/3 PASS.

## Mechanics

- **Codegen**: new \`pipe_regs\` map per module (built in \`emit_module\`) maps \`name → (source, stages)\`. The \`LatencyAt\` arm in \`emit_expr_inner\` looks up the base and rewrites \`q@0\` → source name, \`q@K\` (1 ≤ K < N) → \`q_stg{K}\`, \`q@N\` → bare \`q\`. Falls through transparently when the base isn't a known pipe_reg.
- **Validation**: \`validate_rhs_latency_with_depths\` accepts K ∈ [0, N] and emits a clear out-of-range error. Threaded through \`validate_pipe_assignments\` / \`validate_comb_pipe_refs\` with a \`pipe_depths\` map collected from both pipe_reg ports and module-scope pipe_reg decls.
- **LHS unchanged**: \`q@K <= y\` still means "y arrives at q's output in K cycles" (latency annotation, writes to source). Zero LHS @K usage in tests today; semantics preserved.

## Test plan

- [x] 2 new integration tests covering tap reads + out-of-range error
- [x] CVDP \`fir_filter\` cocotb test 3/3 PASS with the refactored .arch
- [x] All 181 integration + 20 formal tests pass

## Spec

§pipe_reg updated with the tap table and the FIR canonical example.