### PR TITLE
fix(codegen): fsm-scope SInt regs/lets get arithmetic >>> shift

### DIFF
--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -1984,10 +1984,11 @@ impl<'a> Codegen<'a> {
     }
 
     /// Check if a let binding is typed as SInt by looking up the AST.
+    /// Searches modules and fsms (which carry their own `lets` field).
     fn let_binding_is_sint(&self, name: &str) -> bool {
         for item in &self.source.items {
-            if let Item::Module(m) = item {
-                if m.name.name == self.current_construct {
+            match item {
+                Item::Module(m) if m.name.name == self.current_construct => {
                     for bi in &m.body {
                         if let ModuleBodyItem::LetBinding(l) = bi {
                             if l.name.name == name {
@@ -1996,6 +1997,14 @@ impl<'a> Codegen<'a> {
                         }
                     }
                 }
+                Item::Fsm(f) if f.name.name == self.current_construct => {
+                    for l in &f.lets {
+                        if l.name.name == name {
+                            return l.ty.as_ref().map_or(false, |t| matches!(t, TypeExpr::SInt(_)));
+                        }
+                    }
+                }
+                _ => {}
             }
         }
         false

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -833,6 +833,44 @@ pub fn resolve(source_file: &SourceFile) -> Result<SymbolTable, Vec<CompileError
             table.module_scopes.insert(m.name.name.clone(), scope);
         }
 
+        // Per-fsm scope: params + ports + datapath regs + lets + wires.
+        // Lets codegen lookups (`ident_is_sint`, etc.) find SInt regs
+        // declared inside an fsm — same as it does for modules.
+        if let Item::Fsm(f) = item {
+            let mut scope = HashMap::new();
+            for p in &f.params {
+                scope.insert(p.name.name.clone(),
+                    (Symbol::Param(p.name.name.clone()), p.name.span));
+            }
+            for p in &f.ports {
+                scope.insert(p.name.name.clone(),
+                    (Symbol::Port(PortInfo {
+                        name: p.name.name.clone(),
+                        direction: p.direction,
+                        ty: p.ty.clone(),
+                    }), p.name.span));
+            }
+            for r in &f.regs {
+                scope.entry(r.name.name.clone()).or_insert_with(||
+                    (Symbol::Reg(RegInfo {
+                        name: r.name.name.clone(),
+                        ty: r.ty.clone(),
+                        reset: r.reset.clone(),
+                    }), r.name.span));
+            }
+            for l in &f.lets {
+                if l.ty.is_some() {
+                    scope.entry(l.name.name.clone()).or_insert_with(||
+                        (Symbol::Let(l.name.name.clone()), l.name.span));
+                }
+            }
+            for w in &f.wires {
+                scope.entry(w.name.name.clone()).or_insert_with(||
+                    (Symbol::Let(w.name.name.clone()), w.name.span));
+            }
+            table.module_scopes.insert(f.name.name.clone(), scope);
+        }
+
         // Validate inst references inside pipeline stages
         if let Item::Pipeline(p) = item {
             for stage in &p.stages {

--- a/tests/cvdp/fsm_linear_reg.arch
+++ b/tests/cvdp/fsm_linear_reg.arch
@@ -1,4 +1,6 @@
-module fsm_linear_reg
+// 3-state linear-regression accumulator: idle until `start`, compute for
+// one cycle, then assert `done`.
+fsm fsm_linear_reg
   param DATA_WIDTH: const = 16;
   port clk:     in Clock<SysDomain>;
   port reset:   in Reset<Async, High>;
@@ -10,45 +12,54 @@ module fsm_linear_reg
   port result2: out SInt<DATA_WIDTH + 1>;
   port done:    out Bool;
 
-  reg state: UInt<2> reset reset=>0;
+  // Datapath registers — drive the output ports directly via `comb`.
   reg buf_result1: SInt<DATA_WIDTH * 2> reset reset=>0;
   reg buf_result2: SInt<DATA_WIDTH + 1> reset reset=>0;
-  reg buf_done: Bool reset reset=>0;
+  reg buf_done:    Bool                  reset reset=>false;
 
-  let x_shifted: SInt<DATA_WIDTH> = x_in >> 2;
-  let w_ext: SInt<DATA_WIDTH * 2> = w_in.sext<DATA_WIDTH * 2>();
-  let x_ext: SInt<DATA_WIDTH * 2> = x_in.sext<DATA_WIDTH * 2>();
-  let product: SInt<DATA_WIDTH * 2> = (w_ext * x_ext).trunc<DATA_WIDTH * 2>();
-  let b_ext: SInt<DATA_WIDTH + 1> = b_in.sext<DATA_WIDTH + 1>();
-  let xs_ext: SInt<DATA_WIDTH + 1> = x_shifted.sext<DATA_WIDTH + 1>();
+  // Combinational MAC — only the seq capture is gated by state.
+  let x_shifted: SInt<DATA_WIDTH>     = x_in >> 2;
+  let w_ext:     SInt<DATA_WIDTH * 2> = w_in.sext<DATA_WIDTH * 2>();
+  let x_ext:     SInt<DATA_WIDTH * 2> = x_in.sext<DATA_WIDTH * 2>();
+  let product:   SInt<DATA_WIDTH * 2> = (w_ext * x_ext).trunc<DATA_WIDTH * 2>();
+  let b_ext:     SInt<DATA_WIDTH + 1> = b_in.sext<DATA_WIDTH + 1>();
+  let xs_ext:    SInt<DATA_WIDTH + 1> = x_shifted.sext<DATA_WIDTH + 1>();
 
-  comb
-    result1 = buf_result1;
-    result2 = buf_result2;
-    done    = buf_done;
-  end comb
+  state [Idle, Compute, Done]
+  default state Idle;
+  default seq on clk rising;
 
-  seq on clk rising
-    if state == 0
-      if start
-        state <= 1;
-      end if
+  default
+    comb
+      result1 = buf_result1;
+      result2 = buf_result2;
+      done    = buf_done;
+    end comb
+  end default
+
+  state Idle
+    seq
       buf_result1 <= 0;
       buf_result2 <= 0;
       buf_done    <= false;
-    elsif state == 1
+    end seq
+    -> Compute when start;
+  end state Idle
+
+  state Compute
+    seq
       buf_result1 <= product >> 1;
       buf_result2 <= (b_ext + xs_ext).trunc<DATA_WIDTH + 1>();
       buf_done    <= false;
-      state       <= 2;
-    elsif state == 2
+    end seq
+    -> Done;
+  end state Compute
+
+  state Done
+    seq
       buf_done <= true;
-      state    <= 0;
-    else
-      state       <= 0;
-      buf_result1 <= 0;
-      buf_result2 <= 0;
-      buf_done    <= false;
-    end if
-  end seq
-end module fsm_linear_reg
+    end seq
+    -> Idle;
+  end state Done
+
+end fsm fsm_linear_reg

--- a/tests/cvdp/fsm_linear_reg.sv
+++ b/tests/cvdp/fsm_linear_reg.sv
@@ -1,3 +1,5 @@
+// 3-state linear-regression accumulator: idle until `start`, compute for
+// one cycle, then assert `done`.
 module fsm_linear_reg #(
   parameter int DATA_WIDTH = 16
 ) (
@@ -12,10 +14,18 @@ module fsm_linear_reg #(
   output logic done
 );
 
-  logic [1:0] state;
+  typedef enum logic [1:0] {
+    IDLE = 2'd0,
+    COMPUTE = 2'd1,
+    DONE = 2'd2
+  } fsm_linear_reg_state_t;
+  
+  fsm_linear_reg_state_t state_r, state_next;
+  
   logic signed [DATA_WIDTH * 2-1:0] buf_result1;
   logic signed [DATA_WIDTH + 1-1:0] buf_result2;
   logic buf_done;
+  
   logic signed [DATA_WIDTH-1:0] x_shifted;
   assign x_shifted = x_in >>> 2;
   logic signed [DATA_WIDTH * 2-1:0] w_ext;
@@ -28,39 +38,77 @@ module fsm_linear_reg #(
   assign b_ext = {{(DATA_WIDTH + 1-$bits(b_in)){b_in[$bits(b_in)-1]}}, b_in};
   logic signed [DATA_WIDTH + 1-1:0] xs_ext;
   assign xs_ext = {{(DATA_WIDTH + 1-$bits(x_shifted)){x_shifted[$bits(x_shifted)-1]}}, x_shifted};
-  assign result1 = buf_result1;
-  assign result2 = buf_result2;
-  assign done = buf_done;
+  
   always_ff @(posedge clk or posedge reset) begin
     if (reset) begin
-      buf_done <= 0;
+      state_r <= IDLE;
       buf_result1 <= 0;
       buf_result2 <= 0;
-      state <= 0;
+      buf_done <= 1'b0;
     end else begin
-      if (state == 0) begin
-        if (start) begin
-          state <= 1;
+      state_r <= state_next;
+      case (state_r)
+        IDLE: begin
+          // Datapath registers — drive the output ports directly via `comb`.
+          // Combinational MAC — only the seq capture is gated by state.
+          buf_result1 <= 0;
+          buf_result2 <= 0;
+          buf_done <= 1'b0;
         end
-        buf_result1 <= 0;
-        buf_result2 <= 0;
-        buf_done <= 1'b0;
-      end else if (state == 1) begin
-        buf_result1 <= product >>> 1;
-        buf_result2 <= (DATA_WIDTH + 1)'(b_ext + xs_ext);
-        buf_done <= 1'b0;
-        state <= 2;
-      end else if (state == 2) begin
-        buf_done <= 1'b1;
-        state <= 0;
-      end else begin
-        state <= 0;
-        buf_result1 <= 0;
-        buf_result2 <= 0;
-        buf_done <= 1'b0;
-      end
+        COMPUTE: begin
+          buf_result1 <= product >>> 1;
+          buf_result2 <= (DATA_WIDTH + 1)'(b_ext + xs_ext);
+          buf_done <= 1'b0;
+        end
+        DONE: begin
+          buf_done <= 1'b1;
+        end
+        default: ;
+      endcase
     end
   end
+  
+  always_comb begin
+    state_next = state_r; // hold by default
+    case (state_r)
+      IDLE: begin
+        if (start) state_next = COMPUTE;
+      end
+      COMPUTE: begin
+        state_next = DONE;
+      end
+      DONE: begin
+        state_next = IDLE;
+      end
+      default: state_next = state_r;
+    endcase
+  end
+  
+  always_comb begin
+    result1 = buf_result1;
+    result2 = buf_result2;
+    done = buf_done;
+    case (state_r)
+      IDLE: begin
+      end
+      COMPUTE: begin
+      end
+      DONE: begin
+      end
+      default: ;
+    endcase
+  end
+  
+  // synopsys translate_off
+  _auto_legal_state: assert property (@(posedge clk) !reset |-> state_r < 3)
+    else $fatal(1, "FSM ILLEGAL STATE: fsm_linear_reg.state_r = %0d", state_r);
+  _auto_reach_Idle: cover property (@(posedge clk) state_r == IDLE);
+  _auto_reach_Compute: cover property (@(posedge clk) state_r == COMPUTE);
+  _auto_reach_Done: cover property (@(posedge clk) state_r == DONE);
+  _auto_tr_IDLE_to_COMPUTE: cover property (@(posedge clk) state_r == IDLE && state_next == COMPUTE);
+  _auto_tr_COMPUTE_to_DONE: cover property (@(posedge clk) state_r == COMPUTE && state_next == DONE);
+  _auto_tr_DONE_to_IDLE: cover property (@(posedge clk) state_r == DONE && state_next == IDLE);
+  // synopsys translate_on
 
 endmodule
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -5795,3 +5795,36 @@ fn test_pipe_reg_tap_out_of_range_errors() {
     assert!(errs.iter().any(|e| format!("{e:?}").contains("exceeds pipe_reg depth")),
         "error should mention depth: {errs:?}");
 }
+
+#[test]
+fn test_fsm_sint_uses_arithmetic_shift() {
+    // SInt regs/lets declared inside an `fsm` should have `>>` emit `>>>`
+    // (arithmetic shift right) — same as inside a `module`. Regression
+    // test for the missing fsm scope in module_scopes.
+    let source = r#"
+        fsm F
+          port clk: in Clock<SysDomain>;
+          port reset: in Reset<Async, High>;
+          port a: in SInt<8>;
+          port y: out SInt<8>;
+
+          reg buf_y: SInt<8> reset reset=>0;
+
+          state [Idle]
+          default state Idle;
+          default seq on clk rising;
+          default
+            comb y = buf_y; end comb
+          end default
+          state Idle
+            seq buf_y <= a >> 1; end seq
+            -> Idle;
+          end state Idle
+        end fsm F
+    "#;
+    let sv = compile_to_sv(source);
+    assert!(sv.contains("a >>> 1"),
+        "fsm-scope SInt port `a` shifted right should emit `>>>` (arithmetic):\n{sv}");
+    assert!(!sv.contains("a >> 1"),
+        "should not emit `>>` (logical) for SInt:\n{sv}");
+}


### PR DESCRIPTION
## Summary

When refactoring \`tests/cvdp/fsm_linear_reg.arch\` from a hand-rolled module-with-state-encoding into the proper \`fsm\` construct, the cocotb test failed with \`assert 7 == -1\`. Root cause: \`>>\` on an \`SInt\` reg inside an fsm emitted \`>>\` (logical) instead of \`>>>\` (arithmetic).

## Why

The codegen's \`ident_is_sint\` looks up signals in \`SymbolTable.module_scopes\`, but \`resolve()\` only registered per-construct scopes for \`Item::Module\` — not for \`Item::Fsm\`. So an fsm's regs/lets/ports were invisible to the SInt check, and the codegen defaulted to \`>>\` (the logical-right path).

Other \`ident_is_sint\` consumers (sext on indexed reads, signed comparisons, etc.) were silently broken in the same way for fsm-scope SInt signals.

## Fix

- \`resolve.rs\`: add a parallel scope-build for \`Item::Fsm\` that registers the fsm's \`params\` / \`ports\` / \`regs\` / \`lets\` / \`wires\` into \`module_scopes\` the same way the module loop does.
- \`codegen.rs\`: extend \`let_binding_is_sint\` to also walk \`Item::Fsm\` (which carries lets in its own \`lets\` field, separate from module body items).

## Demo

\`tests/cvdp/fsm_linear_reg.arch\` rewritten from:

\`\`\`
reg state: UInt<2> reset reset=>0;
seq on clk rising
  if state == 0
    if start state <= 1; end if
    buf_result1 <= 0; ...
  elsif state == 1
    buf_result1 <= product >> 1; ...
    state <= 2;
  ...
\`\`\`

to:

\`\`\`
state [Idle, Compute, Done]
default state Idle;
default seq on clk rising;
state Idle
  seq buf_result1 <= 0; ... end seq
  -> Compute when start;
end state Idle
state Compute
  seq buf_result1 <= product >> 1; ... end seq
  -> Done;
end state Compute
...
\`\`\`

Cocotb test: 35/35 PASS (was passing as the module form; now also passing as the fsm form with arithmetic shift).

## Test plan

- [x] CVDP \`fsm_linear_reg\` cocotb 35/35 PASS
- [x] New integration test \`fsm_sint_uses_arithmetic_shift\` (regression)
- [x] All 181 integration + 20 formal tests pass