### PR TITLE
cleanup(gf_mul8): use Vec wires + for loop instead of unrolled iterations

### DIFF
--- a/tests/cvdp/gf_mul8.arch
+++ b/tests/cvdp/gf_mul8.arch
@@ -3,64 +3,23 @@ module gf_mul8
   port b_in:  in UInt<8>;
   port p_out: out UInt<8>;
 
-  // Russian peasant GF(2^8) multiply, irreducible poly 0x11B
-  // Unrolled 8 iterations. Shift left: extend to 9 bits, shift, XOR upper bit check.
-
-  wire sh0: UInt<9>;
-  wire sh1: UInt<9>;
-  wire sh2: UInt<9>;
-  wire sh3: UInt<9>;
-  wire sh4: UInt<9>;
-  wire sh5: UInt<9>;
-  wire sh6: UInt<9>;
-
-  wire p0: UInt<8>;
-  wire a0: UInt<8>;
-  wire p1: UInt<8>;
-  wire a1: UInt<8>;
-  wire p2: UInt<8>;
-  wire a2: UInt<8>;
-  wire p3: UInt<8>;
-  wire a3: UInt<8>;
-  wire p4: UInt<8>;
-  wire a4: UInt<8>;
-  wire p5: UInt<8>;
-  wire a5: UInt<8>;
-  wire p6: UInt<8>;
-  wire a6: UInt<8>;
-  wire p7: UInt<8>;
+  // Russian peasant GF(2^8) multiply, irreducible poly 0x11B.
+  // Loop unrolls to 8 combinational "iterations" indexed 0..7.
+  //   p[i+1] = b_in[i] ? p[i] ^ a[i] : p[i]
+  //   a[i+1] = (a[i] << 1) reduced mod 0x11B
+  // Final result = p[8].
+  wire p:  Vec<UInt<8>, 9>;
+  wire a:  Vec<UInt<8>, 9>;
+  wire sh: Vec<UInt<9>, 8>;
 
   comb
-    // iteration 0
-    p0  = (b_in[0:0] == 1) ? a_in : 0.zext<8>();
-    sh0 = a_in.zext<9>() << 1;
-    a0  = (sh0[8:8] == 1) ? (sh0[7:0] ^ 0x1B.zext<8>()) : sh0[7:0];
-    // iteration 1
-    p1  = (b_in[1:1] == 1) ? ((p0 ^ a0)) : p0;
-    sh1 = a0.zext<9>() << 1;
-    a1  = (sh1[8:8] == 1) ? (sh1[7:0] ^ 0x1B.zext<8>()) : sh1[7:0];
-    // iteration 2
-    p2  = (b_in[2:2] == 1) ? ((p1 ^ a1)) : p1;
-    sh2 = a1.zext<9>() << 1;
-    a2  = (sh2[8:8] == 1) ? (sh2[7:0] ^ 0x1B.zext<8>()) : sh2[7:0];
-    // iteration 3
-    p3  = (b_in[3:3] == 1) ? ((p2 ^ a2)) : p2;
-    sh3 = a2.zext<9>() << 1;
-    a3  = (sh3[8:8] == 1) ? (sh3[7:0] ^ 0x1B.zext<8>()) : sh3[7:0];
-    // iteration 4
-    p4  = (b_in[4:4] == 1) ? ((p3 ^ a3)) : p3;
-    sh4 = a3.zext<9>() << 1;
-    a4  = (sh4[8:8] == 1) ? (sh4[7:0] ^ 0x1B.zext<8>()) : sh4[7:0];
-    // iteration 5
-    p5  = (b_in[5:5] == 1) ? ((p4 ^ a4)) : p4;
-    sh5 = a4.zext<9>() << 1;
-    a5  = (sh5[8:8] == 1) ? (sh5[7:0] ^ 0x1B.zext<8>()) : sh5[7:0];
-    // iteration 6
-    p6  = (b_in[6:6] == 1) ? ((p5 ^ a5)) : p5;
-    sh6 = a5.zext<9>() << 1;
-    a6  = (sh6[8:8] == 1) ? (sh6[7:0] ^ 0x1B.zext<8>()) : sh6[7:0];
-    // iteration 7
-    p7  = (b_in[7:7] == 1) ? ((p6 ^ a6)) : p6;
-    p_out = p7;
+    p[0] = 0;
+    a[0] = a_in;
+    for i in 0..7
+      p[i + 1] = (b_in[i:i] == 1) ? (p[i] ^ a[i]) : p[i];
+      sh[i]    = a[i].zext<9>() << 1;
+      a[i + 1] = (sh[i][8:8] == 1) ? (sh[i][7:0] ^ 0x1B.zext<8>()) : sh[i][7:0];
+    end for
+    p_out = p[8];
   end comb
 end module gf_mul8

--- a/tests/cvdp/gf_mul8.sv
+++ b/tests/cvdp/gf_mul8.sv
@@ -4,61 +4,24 @@ module gf_mul8 (
   output logic [7:0] p_out
 );
 
-  // Russian peasant GF(2^8) multiply, irreducible poly 0x11B
-  // Unrolled 8 iterations. Shift left: extend to 9 bits, shift, XOR upper bit check.
-  logic [8:0] sh0;
-  logic [8:0] sh1;
-  logic [8:0] sh2;
-  logic [8:0] sh3;
-  logic [8:0] sh4;
-  logic [8:0] sh5;
-  logic [8:0] sh6;
-  logic [7:0] p0;
-  logic [7:0] a0;
-  logic [7:0] p1;
-  logic [7:0] a1;
-  logic [7:0] p2;
-  logic [7:0] a2;
-  logic [7:0] p3;
-  logic [7:0] a3;
-  logic [7:0] p4;
-  logic [7:0] a4;
-  logic [7:0] p5;
-  logic [7:0] a5;
-  logic [7:0] p6;
-  logic [7:0] a6;
-  logic [7:0] p7;
-  assign p0 = b_in[0:0] == 1 ? a_in : 8'($unsigned(0));
-  assign sh0 = 9'($unsigned(a_in)) << 1;
-  assign a0 = sh0[8:8] == 1 ? sh0[7:0] ^ 8'($unsigned('h1B)) : sh0[7:0];
-  assign p1 = b_in[1:1] == 1 ? p0 ^ a0 : p0;
-  assign sh1 = 9'($unsigned(a0)) << 1;
-  assign a1 = sh1[8:8] == 1 ? sh1[7:0] ^ 8'($unsigned('h1B)) : sh1[7:0];
-  assign p2 = b_in[2:2] == 1 ? p1 ^ a1 : p1;
-  assign sh2 = 9'($unsigned(a1)) << 1;
-  assign a2 = sh2[8:8] == 1 ? sh2[7:0] ^ 8'($unsigned('h1B)) : sh2[7:0];
-  assign p3 = b_in[3:3] == 1 ? p2 ^ a2 : p2;
-  assign sh3 = 9'($unsigned(a2)) << 1;
-  assign a3 = sh3[8:8] == 1 ? sh3[7:0] ^ 8'($unsigned('h1B)) : sh3[7:0];
-  assign p4 = b_in[4:4] == 1 ? p3 ^ a3 : p3;
-  assign sh4 = 9'($unsigned(a3)) << 1;
-  assign a4 = sh4[8:8] == 1 ? sh4[7:0] ^ 8'($unsigned('h1B)) : sh4[7:0];
-  assign p5 = b_in[5:5] == 1 ? p4 ^ a4 : p4;
-  assign sh5 = 9'($unsigned(a4)) << 1;
-  assign a5 = sh5[8:8] == 1 ? sh5[7:0] ^ 8'($unsigned('h1B)) : sh5[7:0];
-  assign p6 = b_in[6:6] == 1 ? p5 ^ a5 : p5;
-  assign sh6 = 9'($unsigned(a5)) << 1;
-  assign a6 = sh6[8:8] == 1 ? sh6[7:0] ^ 8'($unsigned('h1B)) : sh6[7:0];
-  assign p7 = b_in[7:7] == 1 ? p6 ^ a6 : p6;
-  assign p_out = p7;
+  // Russian peasant GF(2^8) multiply, irreducible poly 0x11B.
+  // Loop unrolls to 8 combinational "iterations" indexed 0..7.
+  //   p[i+1] = b_in[i] ? p[i] ^ a[i] : p[i]
+  //   a[i+1] = (a[i] << 1) reduced mod 0x11B
+  // Final result = p[8].
+  logic [8:0] [7:0] p;
+  logic [8:0] [7:0] a;
+  logic [7:0] [8:0] sh;
+  always_comb begin
+    p[0] = 0;
+    a[0] = a_in;
+    for (int i = 0; i <= 7; i++) begin
+      p[i + 1] = b_in[i +: 1] == 1 ? p[i] ^ a[i] : p[i];
+      sh[i] = 9'($unsigned(a[i])) << 1;
+      a[i + 1] = sh[i][8:8] == 1 ? sh[i][7:0] ^ 8'($unsigned('h1B)) : sh[i][7:0];
+    end
+    p_out = p[8];
+  end
 
 endmodule
 
-// iteration 0
-// iteration 1
-// iteration 2
-// iteration 3
-// iteration 4
-// iteration 5
-// iteration 6
-// iteration 7


### PR DESCRIPTION
Replace 22 hand-unrolled wire decls (`sh0..sh6`, `p0..p7`, `a0..a6`) and 8 explicit comb iterations with three `Vec` wires and one `for` loop. **66 → 25 lines.**

Both CVDP tests that consume `gf_mul8` (`gf_mac`, `gf_multiplier`) still PASS.