### PR TITLE
cleanup(gmii_rx): rewrite as a thread

### DIFF
--- a/tests/cvdp/gmii_rx_to_axi_stream.arch
+++ b/tests/cvdp/gmii_rx_to_axi_stream.arch
@@ -1,63 +1,42 @@
 module gmii_rx_to_axi_stream
-  port gmii_rx_clk: in Clock<SysDomain>;
-  port gmii_rxd: in UInt<8>;
-  port gmii_rx_dv: in Bool;
-  port m_axis_tdata: out UInt<8>;
-  port m_axis_tvalid: out Bool;
-  port m_axis_tready: in Bool;
-  port m_axis_tlast: out Bool;
+  port gmii_rx_clk:   in  Clock<SysDomain>;
+  // `thread` requires a reset clause. The CVDP TB doesn't drive a
+  // reset signal, but `dut_init` zeroes every input — so a sync-high
+  // reset port stays deasserted throughout the test.
+  port reset:         in  Reset<Sync, High>;
+  port gmii_rxd:      in  UInt<8>;
+  port gmii_rx_dv:    in  Bool;
+  // `port reg` so the thread can drive these directly via `<=`.
+  port reg m_axis_tdata:  out UInt<8>  reset reset => 0;
+  port reg m_axis_tvalid: out Bool     reset reset => false;
+  port reg m_axis_tlast:  out Bool     reset reset => false;
+  port m_axis_tready: in  Bool;
 
-  default seq on gmii_rx_clk rising;
+  // 1. Idle until rx_dv asserts.
+  // 2. Forward each byte while rx_dv stays high (de-asserting valid on
+  //    backpressured cycles, matching the original FSM's behavior).
+  // 3. When rx_dv drops, present the last marker until tready accepts.
+  thread on gmii_rx_clk rising, reset high
+    m_axis_tvalid <= false;
+    m_axis_tlast  <= false;
+    wait until gmii_rx_dv;
 
-  reg state_r: UInt<2> init 0;
-  reg data_r: UInt<8> init 0;
-  reg valid_r: Bool init false;
-  reg last_r: Bool init false;
-  reg dv_prev: Bool init false;
+    m_axis_tdata  <= gmii_rxd;
+    m_axis_tvalid <= true;
+    m_axis_tlast  <= false;
 
-  seq
-    dv_prev <= gmii_rx_dv;
-  end seq
-
-  seq
-    if state_r == 0
-      // IDLE
-      if gmii_rx_dv
-        state_r <= 1;
-        data_r <= gmii_rxd;
-        valid_r <= true;
-        last_r <= false;
-      else
-        valid_r <= false;
-        last_r <= false;
-      end if
-    elsif state_r == 1
-      // RECEIVING
-      if gmii_rx_dv
-        if m_axis_tready
-          data_r <= gmii_rxd;
-          valid_r <= true;
-        else
-          valid_r <= false;
-        end if
-        last_r <= false;
-      else
-        // dv dropped, end of frame
-        state_r <= 2;
-        valid_r <= true;
-        last_r <= true;
-      end if
-    else
-      // FINISHED
+    do
       if m_axis_tready
-        state_r <= 0;
-        valid_r <= false;
-        last_r <= false;
+        m_axis_tdata  <= gmii_rxd;
+        m_axis_tvalid <= true;
+      else
+        m_axis_tvalid <= false;
       end if
-    end if
-  end seq
+      m_axis_tlast <= false;
+    until not gmii_rx_dv;
 
-  let m_axis_tdata = data_r;
-  let m_axis_tvalid = valid_r;
-  let m_axis_tlast = last_r;
+    m_axis_tvalid <= true;
+    m_axis_tlast  <= true;
+    wait until m_axis_tready;
+  end thread
 end module gmii_rx_to_axi_stream

--- a/tests/cvdp/gmii_rx_to_axi_stream.sv
+++ b/tests/cvdp/gmii_rx_to_axi_stream.sv
@@ -1,59 +1,94 @@
+module _gmii_rx_to_axi_stream_threads (
+  input logic gmii_rx_clk,
+  input logic reset,
+  input logic gmii_rx_dv,
+  input logic [7:0] gmii_rxd,
+  input logic m_axis_tready,
+  output logic [7:0] m_axis_tdata,
+  output logic m_axis_tlast,
+  output logic m_axis_tvalid
+);
+
+  logic [2:0] _t0_state = 0;
+  always_ff @(posedge gmii_rx_clk) begin
+    if (reset) begin
+      _t0_state <= 0;
+      m_axis_tdata <= 0;
+      m_axis_tlast <= 1'b0;
+      m_axis_tvalid <= 1'b0;
+    end else begin
+      if (_t0_state == 0) begin
+        // `thread` requires a reset clause. The CVDP TB doesn't drive a
+        // reset signal, but `dut_init` zeroes every input — so a sync-high
+        // reset port stays deasserted throughout the test.
+        // `port reg` so the thread can drive these directly via `<=`.
+        // 1. Idle until rx_dv asserts.
+        // 2. Forward each byte while rx_dv stays high (de-asserting valid on
+        //    backpressured cycles, matching the original FSM's behavior).
+        // 3. When rx_dv drops, present the last marker until tready accepts.
+        m_axis_tvalid <= 1'b0;
+        m_axis_tlast <= 1'b0;
+        _t0_state <= 1;
+      end
+      if (_t0_state == 1) begin
+        if (gmii_rx_dv) begin
+          _t0_state <= 2;
+        end
+      end
+      if (_t0_state == 2) begin
+        m_axis_tdata <= gmii_rxd;
+        m_axis_tvalid <= 1'b1;
+        m_axis_tlast <= 1'b0;
+        _t0_state <= 3;
+      end
+      if (_t0_state == 3) begin
+        if (m_axis_tready) begin
+          m_axis_tdata <= gmii_rxd;
+          m_axis_tvalid <= 1'b1;
+        end else begin
+          m_axis_tvalid <= 1'b0;
+        end
+        m_axis_tlast <= 1'b0;
+        if (!gmii_rx_dv) begin
+          _t0_state <= 4;
+        end
+      end
+      if (_t0_state == 4) begin
+        m_axis_tvalid <= 1'b1;
+        m_axis_tlast <= 1'b1;
+        _t0_state <= 5;
+      end
+      if (_t0_state == 5) begin
+        if (m_axis_tready) begin
+          _t0_state <= 0;
+        end
+      end
+    end
+  end
+
+endmodule
+
 module gmii_rx_to_axi_stream (
   input logic gmii_rx_clk,
+  input logic reset,
   input logic [7:0] gmii_rxd,
   input logic gmii_rx_dv,
   output logic [7:0] m_axis_tdata,
   output logic m_axis_tvalid,
-  input logic m_axis_tready,
-  output logic m_axis_tlast
+  output logic m_axis_tlast,
+  input logic m_axis_tready
 );
 
-  logic [1:0] state_r = 0;
-  logic [7:0] data_r = 0;
-  logic valid_r = 1'b0;
-  logic last_r = 1'b0;
-  logic dv_prev = 1'b0;
-  always_ff @(posedge gmii_rx_clk) begin
-    dv_prev <= gmii_rx_dv;
-  end
-  always_ff @(posedge gmii_rx_clk) begin
-    if (state_r == 0) begin
-      // IDLE
-      if (gmii_rx_dv) begin
-        state_r <= 1;
-        data_r <= gmii_rxd;
-        valid_r <= 1'b1;
-        last_r <= 1'b0;
-      end else begin
-        valid_r <= 1'b0;
-        last_r <= 1'b0;
-      end
-    end else if (state_r == 1) begin
-      // RECEIVING
-      if (gmii_rx_dv) begin
-        if (m_axis_tready) begin
-          data_r <= gmii_rxd;
-          valid_r <= 1'b1;
-        end else begin
-          valid_r <= 1'b0;
-        end
-        last_r <= 1'b0;
-      end else begin
-        // dv dropped, end of frame
-        state_r <= 2;
-        valid_r <= 1'b1;
-        last_r <= 1'b1;
-      end
-    end else if (m_axis_tready) begin
-      // FINISHED
-      state_r <= 0;
-      valid_r <= 1'b0;
-      last_r <= 1'b0;
-    end
-  end
-  assign m_axis_tdata = data_r;
-  assign m_axis_tvalid = valid_r;
-  assign m_axis_tlast = last_r;
+  _gmii_rx_to_axi_stream_threads _threads (
+    .gmii_rx_clk(gmii_rx_clk),
+    .reset(reset),
+    .gmii_rx_dv(gmii_rx_dv),
+    .gmii_rxd(gmii_rxd),
+    .m_axis_tready(m_axis_tready),
+    .m_axis_tdata(m_axis_tdata),
+    .m_axis_tlast(m_axis_tlast),
+    .m_axis_tvalid(m_axis_tvalid)
+  );
 
 endmodule
 


### PR DESCRIPTION
Replace a hand-rolled 3-state FSM (`if state_r == 0 / elsif == 1 / else`) and a dead `dv_prev` reg with a `thread` block driving `port reg` outputs.

The thread reads top-to-bottom as the protocol: idle → wait for `rx_dv` → forward bytes (with backpressure-aware valid de-assert, matching the original FSM) → on `rx_dv` drop, present the last marker → wait for `tready`.

A sync-high reset port is added (threads require a reset clause); the CVDP TB's `hrs_lb.dut_init` zeros every input so it stays deasserted.

**63 → 42 lines.** CVDP test still PASS.