### PR TITLE
cleanup(hamming_code_receiver): match + algebraic flip-bit

### DIFF
--- a/tests/cvdp/hamming_code_receiver.arch
+++ b/tests/cvdp/hamming_code_receiver.arch
@@ -14,23 +14,11 @@ module hamming_code_receiver
     c3 = data_in[4] ^ data_in[5] ^ data_in[6] ^ data_in[7];
     syndrome = {c3, c2, c1};
 
-    if syndrome == 3'd0
-      corrected = data_in;
-    elsif syndrome == 3'd1
-      corrected = data_in ^ 8'd2;
-    elsif syndrome == 3'd2
-      corrected = data_in ^ 8'd4;
-    elsif syndrome == 3'd3
-      corrected = data_in ^ 8'd8;
-    elsif syndrome == 3'd4
-      corrected = data_in ^ 8'd16;
-    elsif syndrome == 3'd5
-      corrected = data_in ^ 8'd32;
-    elsif syndrome == 3'd6
-      corrected = data_in ^ 8'd64;
-    else
-      corrected = data_in ^ 8'd128;
-    end if
+    // Syndrome k (1..7) flips bit k of data_in; syndrome 0 = no error.
+    corrected = match syndrome
+      3'd0 => data_in,
+      _    => (data_in ^ (8'd1 << syndrome)).trunc<8>(),
+    end match;
 
     // d3=corrected[7], d2=corrected[6], d1=corrected[5], d0=corrected[3]
     data_out = {corrected[7], corrected[6], corrected[5], corrected[3]};

--- a/tests/cvdp/hamming_code_receiver.sv
+++ b/tests/cvdp/hamming_code_receiver.sv
@@ -13,23 +13,11 @@ module hamming_code_receiver (
     c2 = data_in[2] ^ data_in[3] ^ data_in[6] ^ data_in[7];
     c3 = data_in[4] ^ data_in[5] ^ data_in[6] ^ data_in[7];
     syndrome = {c3, c2, c1};
-    if (syndrome == 3'd0) begin
-      corrected = data_in;
-    end else if (syndrome == 3'd1) begin
-      corrected = data_in ^ 8'd2;
-    end else if (syndrome == 3'd2) begin
-      corrected = data_in ^ 8'd4;
-    end else if (syndrome == 3'd3) begin
-      corrected = data_in ^ 8'd8;
-    end else if (syndrome == 3'd4) begin
-      corrected = data_in ^ 8'd16;
-    end else if (syndrome == 3'd5) begin
-      corrected = data_in ^ 8'd32;
-    end else if (syndrome == 3'd6) begin
-      corrected = data_in ^ 8'd64;
-    end else begin
-      corrected = data_in ^ 8'd128;
-    end
+    // Syndrome k (1..7) flips bit k of data_in; syndrome 0 = no error.
+    case (syndrome)
+      3'd0: corrected = data_in;
+      default: corrected = 8'(data_in ^ 8'd1 << syndrome);
+    endcase
     // d3=corrected[7], d2=corrected[6], d1=corrected[5], d0=corrected[3]
     data_out = {corrected[7], corrected[6], corrected[5], corrected[3]};
   end


### PR DESCRIPTION
Replace the 8-arm `if/elsif` chain (each XORing a hand-coded bitmask) with a 2-arm `match` + algebraic `(8'd1 << syndrome)` — syndrome k flips bit k, so the only special case is k=0 (no error).

**38 → 26 lines.** CVDP test still PASS.