### PR TITLE
cleanup(hmac_reg_interface): rewrite as fsm

### DIFF
--- a/tests/cvdp/hmac_reg_interface.arch
+++ b/tests/cvdp/hmac_reg_interface.arch
@@ -1,4 +1,4 @@
-module hmac_reg_interface
+fsm hmac_reg_interface
   param DATA_WIDTH: const = 8;
   param ADDR_WIDTH: const = 8;
 
@@ -9,152 +9,107 @@ module hmac_reg_interface
   port addr:      in UInt<ADDR_WIDTH>;
   port wdata:     in UInt<DATA_WIDTH>;
   port i_wait_en: in Bool;
-  port rdata: out pipe_reg<UInt<DATA_WIDTH>, 1> reset rst_n=>0;
-  port hmac_valid: out pipe_reg<Bool, 1> reset rst_n=>false;
+  port rdata:          out pipe_reg<UInt<DATA_WIDTH>, 1> reset rst_n=>0;
+  port hmac_valid:     out pipe_reg<Bool, 1> reset rst_n=>false;
   port hmac_key_error: out pipe_reg<Bool, 1> reset rst_n=>false;
 
-  default seq on clk rising;
-
-  // FSM state encoding
-  let ST_IDLE:      UInt<3> = 0;
-  let ST_ANALYZE:   UInt<3> = 1;
-  let ST_XOR_DATA:  UInt<3> = 2;
-  let ST_WRITE:     UInt<3> = 3;
-  let ST_LOST:      UInt<3> = 4;
-  let ST_CHECK_KEY: UInt<3> = 5;
-  let ST_TRIG_WAIT: UInt<3> = 6;
-
-  reg current_state: UInt<3> reset rst_n=>0;
+  // Datapath regs (alongside FSM state)
   reg hmac_key:  UInt<DATA_WIDTH> reset rst_n=>0;
   reg hmac_data: UInt<DATA_WIDTH> reset rst_n=>0;
   reg registers: Vec<UInt<DATA_WIDTH>, 256> reset rst_n=>0;
 
-  // xor_data: current wdata XOR'd with '01010101...' mask — exposed for testbench visibility.
-  // The Python model sets processed_data = wdata (plain) for all states except PROCESS/XOR_DATA,
-  // and in WRITE state it immediately uses that overwritten value. This means the WRITE state
-  // always writes the current wdata directly, not a previously XOR'd value.
-  wire xor_data: UInt<DATA_WIDTH>;
-  wire xor_mask: UInt<DATA_WIDTH>;
-
-  comb
-    xor_mask = 0.zext<DATA_WIDTH>();
-    for i in 0..DATA_WIDTH/2-1
-      xor_mask[i*2+1:i*2] = 2'd1;
-    end for
-  end comb
-
-  comb
-    xor_data = wdata ^ xor_mask;
-  end comb
-
-  // Key validation: 2 MSB and 2 LSB of hmac_key must be zero for key to be valid
-  wire key_valid: Bool;
-  comb
-    key_valid = (hmac_key[DATA_WIDTH-1:DATA_WIDTH-2] == 0) & (hmac_key[1:0] == 0);
-  end comb
-
-  // Next-cycle hmac_key (what hmac_key will be after the next clock edge)
-  // Used so hmac_key_error is updated in same cycle as hmac_key write
-  wire next_hmac_key: UInt<DATA_WIDTH>;
-  comb
-    if (current_state == ST_WRITE) & (addr == 0)
-      next_hmac_key = wdata;
-    else
-      next_hmac_key = hmac_key;
-    end if
-  end comb
-
+  // Internal wires for the look-ahead key-error path.
+  wire xor_data:       UInt<DATA_WIDTH>;
+  wire xor_mask:       UInt<DATA_WIDTH>;
+  wire key_valid:      Bool;
+  wire next_hmac_key:  UInt<DATA_WIDTH>;
   wire next_key_valid: Bool;
-  comb
-    next_key_valid = (next_hmac_key[DATA_WIDTH-1:DATA_WIDTH-2] == 0) & (next_hmac_key[1:0] == 0);
-  end comb
+  // The CVDP TB probes `dut.current_state.value`; alias state_r so the
+  // test can read it without renaming inside the auto-generated FSM.
+  let current_state: UInt<3> = state_r;
 
-  // Next state combinational logic
-  wire next_state: UInt<3>;
-  comb
-    if current_state == ST_IDLE
-      if write_en
-        next_state = ST_ANALYZE;
-      else
-        next_state = ST_IDLE;
-      end if
-    elsif current_state == ST_ANALYZE
-      if wdata[DATA_WIDTH-1:DATA_WIDTH-1] == 1
-        next_state = ST_XOR_DATA;
-      else
-        next_state = ST_WRITE;
-      end if
-    elsif current_state == ST_XOR_DATA
-      next_state = ST_WRITE;
-    elsif current_state == ST_WRITE
-      if write_en
-        next_state = ST_IDLE;
-      else
-        next_state = ST_LOST;
-      end if
-    elsif current_state == ST_LOST
-      if read_en
-        next_state = ST_CHECK_KEY;
-      else
-        next_state = ST_LOST;
-      end if
-    elsif current_state == ST_CHECK_KEY
-      if key_valid
-        next_state = ST_TRIG_WAIT;
-      else
-        next_state = ST_WRITE;
-      end if
-    elsif current_state == ST_TRIG_WAIT
-      if i_wait_en
-        next_state = ST_TRIG_WAIT;
-      elsif (hmac_data != 0) & (hmac_key != 0)
-        next_state = ST_IDLE;
-      else
-        next_state = ST_WRITE;
-      end if
-    else
-      next_state = ST_IDLE;
-    end if
-  end comb
+  state [IDLE, ANALYZE, XOR_DATA, WRITE, LOST, CHECK_KEY, TRIG_WAIT]
+  default state IDLE;
+  default seq on clk rising;
 
-  // Sequential: state register
-  seq
-    current_state <= next_state;
-  end seq
+  default
+    comb
+      // xor_mask: alternating-1s pattern (01010101...) — TB-visible.
+      xor_mask = 0.zext<DATA_WIDTH>();
+      for i in 0..DATA_WIDTH/2-1
+        xor_mask[i*2+1:i*2] = 2'd1;
+      end for
+      xor_data = wdata ^ xor_mask;
 
-  // Sequential: key error flag — updated with look-ahead so it reflects
-  // the key value being written in WRITE state in the same cycle
-  seq
-    hmac_key_error <= ~next_key_valid;
-  end seq
+      // Key validation: 2 MSB and 2 LSB of hmac_key must be zero.
+      key_valid = (hmac_key[DATA_WIDTH-1:DATA_WIDTH-2] == 0) & (hmac_key[1:0] == 0);
 
-  // Sequential: Write and valid logic
-  // The model writes wdata (current cycle's value) directly in WRITE state.
-  seq
-    hmac_valid <= false;
-    if current_state == ST_WRITE
+      // Look-ahead so hmac_key_error tracks the key being written *this* cycle.
+      if (state_r == WRITE) & (addr == 0)
+        next_hmac_key = wdata;
+      else
+        next_hmac_key = hmac_key;
+      end if
+      next_key_valid = (next_hmac_key[DATA_WIDTH-1:DATA_WIDTH-2] == 0)
+                     & (next_hmac_key[1:0] == 0);
+    end comb
+    seq
+      hmac_key_error <= ~next_key_valid;
+      hmac_valid     <= false;
+      // Reads: serve from non-WRITE states.
+      if read_en & (state_r != WRITE)
+        if addr == 0
+          rdata <= hmac_key;
+        elsif addr == 1
+          rdata <= hmac_data;
+        else
+          rdata <= registers[addr];
+        end if
+      end if
+    end seq
+  end default
+
+  state IDLE
+    -> ANALYZE when write_en;
+  end state IDLE
+
+  state ANALYZE
+    -> XOR_DATA when wdata[DATA_WIDTH-1:DATA_WIDTH-1] == 1;
+    -> WRITE    when wdata[DATA_WIDTH-1:DATA_WIDTH-1] == 0;
+  end state ANALYZE
+
+  state XOR_DATA
+    -> WRITE;
+  end state XOR_DATA
+
+  state WRITE
+    seq
       if addr == 0
         hmac_key <= wdata;
       elsif addr == 1
-        hmac_data <= wdata;
+        hmac_data  <= wdata;
         hmac_valid <= true;
       else
         registers[addr] <= wdata;
       end if
-    end if
-  end seq
+    end seq
+    -> IDLE when write_en;
+    -> LOST when not write_en;
+  end state WRITE
 
-  // Sequential: Read logic
-  seq
-    if read_en & (current_state != ST_WRITE)
-      if addr == 0
-        rdata <= hmac_key;
-      elsif addr == 1
-        rdata <= hmac_data;
-      else
-        rdata <= registers[addr];
-      end if
-    end if
-  end seq
+  state LOST
+    -> CHECK_KEY when read_en;
+  end state LOST
 
-end module hmac_reg_interface
+  state CHECK_KEY
+    -> TRIG_WAIT when key_valid;
+    -> WRITE     when not key_valid;
+  end state CHECK_KEY
+
+  state TRIG_WAIT
+    -> TRIG_WAIT when i_wait_en;
+    -> IDLE      when (not i_wait_en) & (hmac_data != 0) & (hmac_key != 0);
+    -> WRITE     when (not i_wait_en) & ((hmac_data == 0) | (hmac_key == 0));
+  end state TRIG_WAIT
+
+end fsm hmac_reg_interface

--- a/tests/cvdp/hmac_reg_interface.arch
+++ b/tests/cvdp/hmac_reg_interface.arch
@@ -24,9 +24,9 @@ fsm hmac_reg_interface
   wire key_valid:      Bool;
   wire next_hmac_key:  UInt<DATA_WIDTH>;
   wire next_key_valid: Bool;
-  // The CVDP TB probes `dut.current_state.value`; alias state_r so the
+  // The CVDP TB probes `dut.current_state.value`; alias `state` so the
   // test can read it without renaming inside the auto-generated FSM.
-  let current_state: UInt<3> = state_r;
+  let current_state: UInt<3> = state;
 
   state [IDLE, ANALYZE, XOR_DATA, WRITE, LOST, CHECK_KEY, TRIG_WAIT]
   default state IDLE;
@@ -45,7 +45,7 @@ fsm hmac_reg_interface
       key_valid = (hmac_key[DATA_WIDTH-1:DATA_WIDTH-2] == 0) & (hmac_key[1:0] == 0);
 
       // Look-ahead so hmac_key_error tracks the key being written *this* cycle.
-      if (state_r == WRITE) & (addr == 0)
+      if (state == WRITE) & (addr == 0)
         next_hmac_key = wdata;
       else
         next_hmac_key = hmac_key;
@@ -57,7 +57,7 @@ fsm hmac_reg_interface
       hmac_key_error <= ~next_key_valid;
       hmac_valid     <= false;
       // Reads: serve from non-WRITE states.
-      if read_en & (state_r != WRITE)
+      if read_en & (state != WRITE)
         if addr == 0
           rdata <= hmac_key;
         elsif addr == 1

--- a/tests/cvdp/hmac_reg_interface.arch
+++ b/tests/cvdp/hmac_reg_interface.arch
@@ -18,12 +18,14 @@ fsm hmac_reg_interface
   reg hmac_data: UInt<DATA_WIDTH> reset rst_n=>0;
   reg registers: Vec<UInt<DATA_WIDTH>, 256> reset rst_n=>0;
 
-  // Internal wires for the look-ahead key-error path.
+  // Internal wires.
   wire xor_data:       UInt<DATA_WIDTH>;
   wire xor_mask:       UInt<DATA_WIDTH>;
   wire key_valid:      Bool;
-  wire next_hmac_key:  UInt<DATA_WIDTH>;
+  // Look-ahead key-error: default = check current hmac_key, WRITE
+  // state overrides to check wdata when writing the key (addr == 0).
   wire next_key_valid: Bool;
+
   // The CVDP TB probes `dut.current_state.value`; alias `state` so the
   // test can read it without renaming inside the auto-generated FSM.
   let current_state: UInt<3> = state;
@@ -41,17 +43,10 @@ fsm hmac_reg_interface
       end for
       xor_data = wdata ^ xor_mask;
 
-      // Key validation: 2 MSB and 2 LSB of hmac_key must be zero.
-      key_valid = (hmac_key[DATA_WIDTH-1:DATA_WIDTH-2] == 0) & (hmac_key[1:0] == 0);
-
-      // Look-ahead so hmac_key_error tracks the key being written *this* cycle.
-      if (state == WRITE) & (addr == 0)
-        next_hmac_key = wdata;
-      else
-        next_hmac_key = hmac_key;
-      end if
-      next_key_valid = (next_hmac_key[DATA_WIDTH-1:DATA_WIDTH-2] == 0)
-                     & (next_hmac_key[1:0] == 0);
+      // Key validation: 2 MSB and 2 LSB must be zero.
+      key_valid      = (hmac_key[DATA_WIDTH-1:DATA_WIDTH-2] == 0) & (hmac_key[1:0] == 0);
+      // Default look-ahead: not writing the key this cycle.
+      next_key_valid = key_valid;
     end comb
     seq
       hmac_key_error <= ~next_key_valid;
@@ -83,6 +78,13 @@ fsm hmac_reg_interface
   end state XOR_DATA
 
   state WRITE
+    comb
+      // Look-ahead override: when writing the key this cycle, validate
+      // against wdata so hmac_key_error tracks it without a 1-cycle lag.
+      if addr == 0
+        next_key_valid = (wdata[DATA_WIDTH-1:DATA_WIDTH-2] == 0) & (wdata[1:0] == 0);
+      end if
+    end comb
     seq
       if addr == 0
         hmac_key <= wdata;

--- a/tests/cvdp/hmac_reg_interface.sv
+++ b/tests/cvdp/hmac_reg_interface.sv
@@ -14,147 +14,55 @@ module hmac_reg_interface #(
   output logic hmac_key_error
 );
 
-  // FSM state encoding
-  logic [2:0] ST_IDLE;
-  assign ST_IDLE = 0;
-  logic [2:0] ST_ANALYZE;
-  assign ST_ANALYZE = 1;
-  logic [2:0] ST_XOR_DATA;
-  assign ST_XOR_DATA = 2;
-  logic [2:0] ST_WRITE;
-  assign ST_WRITE = 3;
-  logic [2:0] ST_LOST;
-  assign ST_LOST = 4;
-  logic [2:0] ST_CHECK_KEY;
-  assign ST_CHECK_KEY = 5;
-  logic [2:0] ST_TRIG_WAIT;
-  assign ST_TRIG_WAIT = 6;
-  logic [2:0] current_state;
+  typedef enum logic [2:0] {
+    IDLE = 3'd0,
+    ANALYZE = 3'd1,
+    XOR_DATA = 3'd2,
+    WRITE = 3'd3,
+    LOST = 3'd4,
+    CHECK_KEY = 3'd5,
+    TRIG_WAIT = 3'd6
+  } hmac_reg_interface_state_t;
+  
+  hmac_reg_interface_state_t state_r, state_next;
+  
   logic [DATA_WIDTH-1:0] hmac_key;
   logic [DATA_WIDTH-1:0] hmac_data;
   logic [255:0] [DATA_WIDTH-1:0] registers;
-  // xor_data: current wdata XOR'd with '01010101...' mask — exposed for testbench visibility.
-  // The Python model sets processed_data = wdata (plain) for all states except PROCESS/XOR_DATA,
-  // and in WRITE state it immediately uses that overwritten value. This means the WRITE state
-  // always writes the current wdata directly, not a previously XOR'd value.
+  
+  logic [2:0] current_state;
+  assign current_state = state_r;
+  
   logic [DATA_WIDTH-1:0] xor_data;
   logic [DATA_WIDTH-1:0] xor_mask;
-  always_comb begin
-    xor_mask = DATA_WIDTH'($unsigned(0));
-    for (int i = 0; i <= DATA_WIDTH / 2 - 1; i++) begin
-      xor_mask[i * 2 +: 2] = 2'd1;
-    end
-  end
-  assign xor_data = wdata ^ xor_mask;
-  // Key validation: 2 MSB and 2 LSB of hmac_key must be zero for key to be valid
   logic key_valid;
-  assign key_valid = (hmac_key[DATA_WIDTH - 2 +: 2] == 0) & (hmac_key[1:0] == 0);
-  // Next-cycle hmac_key (what hmac_key will be after the next clock edge)
-  // Used so hmac_key_error is updated in same cycle as hmac_key write
   logic [DATA_WIDTH-1:0] next_hmac_key;
-  always_comb begin
-    if ((current_state == ST_WRITE) & (addr == 0)) begin
-      next_hmac_key = wdata;
-    end else begin
-      next_hmac_key = hmac_key;
-    end
-  end
   logic next_key_valid;
-  assign next_key_valid = (next_hmac_key[DATA_WIDTH - 2 +: 2] == 0) & (next_hmac_key[1:0] == 0);
-  // Next state combinational logic
-  logic [2:0] next_state;
-  always_comb begin
-    if (current_state == ST_IDLE) begin
-      if (write_en) begin
-        next_state = ST_ANALYZE;
-      end else begin
-        next_state = ST_IDLE;
-      end
-    end else if (current_state == ST_ANALYZE) begin
-      if (wdata[DATA_WIDTH - 1 +: 1] == 1) begin
-        next_state = ST_XOR_DATA;
-      end else begin
-        next_state = ST_WRITE;
-      end
-    end else if (current_state == ST_XOR_DATA) begin
-      next_state = ST_WRITE;
-    end else if (current_state == ST_WRITE) begin
-      if (write_en) begin
-        next_state = ST_IDLE;
-      end else begin
-        next_state = ST_LOST;
-      end
-    end else if (current_state == ST_LOST) begin
-      if (read_en) begin
-        next_state = ST_CHECK_KEY;
-      end else begin
-        next_state = ST_LOST;
-      end
-    end else if (current_state == ST_CHECK_KEY) begin
-      if (key_valid) begin
-        next_state = ST_TRIG_WAIT;
-      end else begin
-        next_state = ST_WRITE;
-      end
-    end else if (current_state == ST_TRIG_WAIT) begin
-      if (i_wait_en) begin
-        next_state = ST_TRIG_WAIT;
-      end else if ((hmac_data != 0) & (hmac_key != 0)) begin
-        next_state = ST_IDLE;
-      end else begin
-        next_state = ST_WRITE;
-      end
-    end else begin
-      next_state = ST_IDLE;
-    end
-  end
-  // Sequential: state register
+  
   always_ff @(posedge clk or negedge rst_n) begin
     if ((!rst_n)) begin
-      current_state <= 0;
-    end else begin
-      current_state <= next_state;
-    end
-  end
-  // Sequential: key error flag — updated with look-ahead so it reflects
-  // the key value being written in WRITE state in the same cycle
-  always_ff @(posedge clk or negedge rst_n) begin
-    if ((!rst_n)) begin
+      state_r <= IDLE;
+      hmac_key <= 0;
+      hmac_data <= 0;
+      for (int __ri_registers = 0; __ri_registers < 256; __ri_registers++) begin
+        registers[__ri_registers] <= 0;
+      end
+      rdata <= 0;
+      hmac_valid <= 1'b0;
       hmac_key_error <= 1'b0;
     end else begin
+      state_r <= state_next;
+      // Datapath regs (alongside FSM state)
+      // Internal wires for the look-ahead key-error path.
+      // The CVDP TB probes `dut.current_state.value`; alias state_r so the
+      // test can read it without renaming inside the auto-generated FSM.
+      // xor_mask: alternating-1s pattern (01010101...) — TB-visible.
+      // Key validation: 2 MSB and 2 LSB of hmac_key must be zero.
+      // Look-ahead so hmac_key_error tracks the key being written *this* cycle.
       hmac_key_error <= ~next_key_valid;
-    end
-  end
-  // Sequential: Write and valid logic
-  // The model writes wdata (current cycle's value) directly in WRITE state.
-  always_ff @(posedge clk or negedge rst_n) begin
-    if ((!rst_n)) begin
-      hmac_data <= 0;
-      hmac_key <= 0;
       hmac_valid <= 1'b0;
-      for (int __ri0 = 0; __ri0 < 256; __ri0++) begin
-        registers[__ri0] <= 0;
-      end
-    end else begin
-      hmac_valid <= 1'b0;
-      if (current_state == ST_WRITE) begin
-        if (addr == 0) begin
-          hmac_key <= wdata;
-        end else if (addr == 1) begin
-          hmac_data <= wdata;
-          hmac_valid <= 1'b1;
-        end else begin
-          registers[addr] <= wdata;
-        end
-      end
-    end
-  end
-  // Sequential: Read logic
-  always_ff @(posedge clk or negedge rst_n) begin
-    if ((!rst_n)) begin
-      rdata <= 0;
-    end else begin
-      if (read_en & (current_state != ST_WRITE)) begin
+      // Reads: serve from non-WRITE states.
+      if (read_en & (state_r != WRITE)) begin
         if (addr == 0) begin
           rdata <= hmac_key;
         end else if (addr == 1) begin
@@ -163,8 +71,110 @@ module hmac_reg_interface #(
           rdata <= registers[addr];
         end
       end
+      case (state_r)
+        WRITE: begin
+          if (addr == 0) begin
+            hmac_key <= wdata;
+          end else if (addr == 1) begin
+            hmac_data <= wdata;
+            hmac_valid <= 1'b1;
+          end else begin
+            registers[addr] <= wdata;
+          end
+        end
+        default: ;
+      endcase
     end
   end
+  
+  always_comb begin
+    state_next = state_r; // hold by default
+    case (state_r)
+      IDLE: begin
+        if (write_en) state_next = ANALYZE;
+      end
+      ANALYZE: begin
+        if (wdata[DATA_WIDTH - 1 +: 1] == 1) state_next = XOR_DATA;
+        else if (wdata[DATA_WIDTH - 1 +: 1] == 0) state_next = WRITE;
+      end
+      XOR_DATA: begin
+        state_next = WRITE;
+      end
+      WRITE: begin
+        if (write_en) state_next = IDLE;
+        else if (!write_en) state_next = LOST;
+      end
+      LOST: begin
+        if (read_en) state_next = CHECK_KEY;
+      end
+      CHECK_KEY: begin
+        if (key_valid) state_next = TRIG_WAIT;
+        else if (!key_valid) state_next = WRITE;
+      end
+      TRIG_WAIT: begin
+        if (i_wait_en) state_next = TRIG_WAIT;
+        else if (!i_wait_en & (hmac_data != 0) & (hmac_key != 0)) state_next = IDLE;
+        else if (!i_wait_en & ((hmac_data == 0) | (hmac_key == 0))) state_next = WRITE;
+      end
+      default: state_next = state_r;
+    endcase
+  end
+  
+  always_comb begin
+    xor_mask = DATA_WIDTH'($unsigned(0));
+    for (int i = 0; i <= DATA_WIDTH / 2 - 1; i++) begin
+      xor_mask[i * 2 +: 2] = 2'd1;
+    end
+    xor_data = wdata ^ xor_mask;
+    key_valid = (hmac_key[DATA_WIDTH - 2 +: 2] == 0) & (hmac_key[1:0] == 0);
+    if ((state_r == WRITE) & (addr == 0)) begin
+      next_hmac_key = wdata;
+    end else begin
+      next_hmac_key = hmac_key;
+    end
+    next_key_valid = (next_hmac_key[DATA_WIDTH - 2 +: 2] == 0) & (next_hmac_key[1:0] == 0);
+    case (state_r)
+      IDLE: begin
+      end
+      ANALYZE: begin
+      end
+      XOR_DATA: begin
+      end
+      WRITE: begin
+      end
+      LOST: begin
+      end
+      CHECK_KEY: begin
+      end
+      TRIG_WAIT: begin
+      end
+      default: ;
+    endcase
+  end
+  
+  // synopsys translate_off
+  _auto_legal_state: assert property (@(posedge clk) rst_n |-> state_r < 7)
+    else $fatal(1, "FSM ILLEGAL STATE: hmac_reg_interface.state_r = %0d", state_r);
+  _auto_reach_IDLE: cover property (@(posedge clk) state_r == IDLE);
+  _auto_reach_ANALYZE: cover property (@(posedge clk) state_r == ANALYZE);
+  _auto_reach_XOR_DATA: cover property (@(posedge clk) state_r == XOR_DATA);
+  _auto_reach_WRITE: cover property (@(posedge clk) state_r == WRITE);
+  _auto_reach_LOST: cover property (@(posedge clk) state_r == LOST);
+  _auto_reach_CHECK_KEY: cover property (@(posedge clk) state_r == CHECK_KEY);
+  _auto_reach_TRIG_WAIT: cover property (@(posedge clk) state_r == TRIG_WAIT);
+  _auto_tr_IDLE_to_ANALYZE: cover property (@(posedge clk) state_r == IDLE && state_next == ANALYZE);
+  _auto_tr_ANALYZE_to_XOR_DATA: cover property (@(posedge clk) state_r == ANALYZE && state_next == XOR_DATA);
+  _auto_tr_ANALYZE_to_WRITE: cover property (@(posedge clk) state_r == ANALYZE && state_next == WRITE);
+  _auto_tr_XOR_DATA_to_WRITE: cover property (@(posedge clk) state_r == XOR_DATA && state_next == WRITE);
+  _auto_tr_WRITE_to_IDLE: cover property (@(posedge clk) state_r == WRITE && state_next == IDLE);
+  _auto_tr_WRITE_to_LOST: cover property (@(posedge clk) state_r == WRITE && state_next == LOST);
+  _auto_tr_LOST_to_CHECK_KEY: cover property (@(posedge clk) state_r == LOST && state_next == CHECK_KEY);
+  _auto_tr_CHECK_KEY_to_TRIG_WAIT: cover property (@(posedge clk) state_r == CHECK_KEY && state_next == TRIG_WAIT);
+  _auto_tr_CHECK_KEY_to_WRITE: cover property (@(posedge clk) state_r == CHECK_KEY && state_next == WRITE);
+  _auto_tr_TRIG_WAIT_to_TRIG_WAIT: cover property (@(posedge clk) state_r == TRIG_WAIT && state_next == TRIG_WAIT);
+  _auto_tr_TRIG_WAIT_to_IDLE: cover property (@(posedge clk) state_r == TRIG_WAIT && state_next == IDLE);
+  _auto_tr_TRIG_WAIT_to_WRITE: cover property (@(posedge clk) state_r == TRIG_WAIT && state_next == WRITE);
+  // synopsys translate_on
 
 endmodule
 

--- a/tests/cvdp/hmac_reg_interface.sv
+++ b/tests/cvdp/hmac_reg_interface.sv
@@ -36,7 +36,6 @@ module hmac_reg_interface #(
   logic [DATA_WIDTH-1:0] xor_data;
   logic [DATA_WIDTH-1:0] xor_mask;
   logic key_valid;
-  logic [DATA_WIDTH-1:0] next_hmac_key;
   logic next_key_valid;
   
   always_ff @(posedge clk or negedge rst_n) begin
@@ -53,12 +52,14 @@ module hmac_reg_interface #(
     end else begin
       state_r <= state_next;
       // Datapath regs (alongside FSM state)
-      // Internal wires for the look-ahead key-error path.
+      // Internal wires.
+      // Look-ahead key-error: default = check current hmac_key, WRITE
+      // state overrides to check wdata when writing the key (addr == 0).
       // The CVDP TB probes `dut.current_state.value`; alias `state` so the
       // test can read it without renaming inside the auto-generated FSM.
       // xor_mask: alternating-1s pattern (01010101...) — TB-visible.
-      // Key validation: 2 MSB and 2 LSB of hmac_key must be zero.
-      // Look-ahead so hmac_key_error tracks the key being written *this* cycle.
+      // Key validation: 2 MSB and 2 LSB must be zero.
+      // Default look-ahead: not writing the key this cycle.
       hmac_key_error <= ~next_key_valid;
       hmac_valid <= 1'b0;
       // Reads: serve from non-WRITE states.
@@ -73,6 +74,8 @@ module hmac_reg_interface #(
       end
       case (state_r)
         WRITE: begin
+          // Look-ahead override: when writing the key this cycle, validate
+          // against wdata so hmac_key_error tracks it without a 1-cycle lag.
           if (addr == 0) begin
             hmac_key <= wdata;
           end else if (addr == 1) begin
@@ -127,12 +130,7 @@ module hmac_reg_interface #(
     end
     xor_data = wdata ^ xor_mask;
     key_valid = (hmac_key[DATA_WIDTH - 2 +: 2] == 0) & (hmac_key[1:0] == 0);
-    if ((state_r == WRITE) & (addr == 0)) begin
-      next_hmac_key = wdata;
-    end else begin
-      next_hmac_key = hmac_key;
-    end
-    next_key_valid = (next_hmac_key[DATA_WIDTH - 2 +: 2] == 0) & (next_hmac_key[1:0] == 0);
+    next_key_valid = key_valid;
     case (state_r)
       IDLE: begin
       end
@@ -141,6 +139,9 @@ module hmac_reg_interface #(
       XOR_DATA: begin
       end
       WRITE: begin
+        if (addr == 0) begin
+          next_key_valid = (wdata[DATA_WIDTH - 2 +: 2] == 0) & (wdata[1:0] == 0);
+        end
       end
       LOST: begin
       end

--- a/tests/cvdp/hmac_reg_interface.sv
+++ b/tests/cvdp/hmac_reg_interface.sv
@@ -54,7 +54,7 @@ module hmac_reg_interface #(
       state_r <= state_next;
       // Datapath regs (alongside FSM state)
       // Internal wires for the look-ahead key-error path.
-      // The CVDP TB probes `dut.current_state.value`; alias state_r so the
+      // The CVDP TB probes `dut.current_state.value`; alias `state` so the
       // test can read it without renaming inside the auto-generated FSM.
       // xor_mask: alternating-1s pattern (01010101...) — TB-visible.
       // Key validation: 2 MSB and 2 LSB of hmac_key must be zero.


### PR DESCRIPTION
Replace the hand-rolled state machine (`let ST_IDLE = 0; ...` + 7-arm if/elsif next-state mux + three separate `seq` blocks) with the `fsm` construct.

Transitions become explicit `-> Target when cond;` arrows instead of a hand-built next-state expression. Three `seq` blocks collapse into one `default seq` (refresh key_error / hmac_valid every cycle, serve reads from non-WRITE states) plus a per-state `seq` inside `state WRITE` for the actual write logic.

The CVDP TB probes `dut.current_state`. The fsm construct emits its state reg as `state_r`, so a one-line alias (`let current_state: UInt<3> = state_r;`) inside the fsm scope exposes the expected name to the test.

**Tests: 12/12 PASS** (`cvdp_copilot_hmac_register_0001`, parametric over DATA_WIDTH ∈ {8, 32, 64, ...} × ADDR_WIDTH ∈ {4, 8, ...}).

160 → 115 lines.