### PR TITLE
cleanup(huffman_encoder): split into fsm core + ram wrapper module

### DIFF
--- a/tests/cvdp/huffman_encoder.arch
+++ b/tests/cvdp/huffman_encoder.arch
@@ -1,194 +1,81 @@
-module huffman_encoder
+// 7-state Huffman encoder.
+// State machine lives in `fsm huffman_encoder_core`; the wrapper
+// `module huffman_encoder` owns the 5 RAM instances and connects
+// them to the fsm. (`fsm` bodies don't host `inst` declarations.)
+
+fsm huffman_encoder_core
   port clk:     in Clock<SysDomain>;
   port reset:   in Reset<Async>;
 
-  port data_valid:     in Bool;
-  port data_in:        in UInt<4>;
-  port data_priority:  in UInt<2>;
-  port update_enable:  in Bool;
-  port config_symbol:  in UInt<4>;
-  port config_code:    in UInt<7>;
-  port config_length:  in UInt<3>;
+  // External I/O (mirrors top-level)
+  port data_valid:    in Bool;
+  port data_in:       in UInt<4>;
+  port data_priority: in UInt<2>;
+  port update_enable: in Bool;
+  port config_symbol: in UInt<4>;
+  port config_code:   in UInt<7>;
+  port config_length: in UInt<3>;
 
   port huffman_code_out: out pipe_reg<UInt<7>, 1> reset reset=>0;
-  port code_valid: out pipe_reg<Bool, 1> reset reset=>false;
-  port error_flag: out pipe_reg<Bool, 1> reset reset=>false;
+  port code_valid:       out pipe_reg<Bool, 1>     reset reset=>false;
+  port error_flag:       out pipe_reg<Bool, 1>     reset reset=>false;
 
-  default seq on clk rising;
+  // RAM driver ports (combinational outputs to the wrapper).
+  port ht_we: out Bool; port ht_addr: out UInt<4>; port ht_din: out UInt<7>; port ht_dout: in UInt<7>;
+  port cl_we: out Bool; port cl_addr: out UInt<4>; port cl_din: out UInt<3>; port cl_dout: in UInt<3>;
+  port qh_we: out Bool; port qh_addr: out UInt<4>; port qh_din: out UInt<4>; port qh_dout: in UInt<4>;
+  port qm_we: out Bool; port qm_addr: out UInt<4>; port qm_din: out UInt<4>; port qm_dout: in UInt<4>;
+  port ql_we: out Bool; port ql_addr: out UInt<4>; port ql_din: out UInt<4>; port ql_dout: in UInt<4>;
 
-  // FSM states: 0=IDLE,1=PREPARE,2=CHECK_UPDATE,3=ENCODE,4=OUTPUT,5=HANDLE_ERROR,6=UPDATE_TABLE
-  reg state: UInt<3> reset reset=>0;
-
-  // RAM interface wires
-  wire ht_we: Bool;
-  wire ht_addr: UInt<4>;
-  wire ht_din: UInt<7>;
-  wire ht_dout: UInt<7>;
-
-  wire cl_we: Bool;
-  wire cl_addr: UInt<4>;
-  wire cl_din: UInt<3>;
-  wire cl_dout: UInt<3>;
-
-  wire qh_we: Bool;
-  wire qh_addr: UInt<4>;
-  wire qh_din: UInt<4>;
-  wire qh_dout: UInt<4>;
-
-  wire qm_we: Bool;
-  wire qm_addr: UInt<4>;
-  wire qm_din: UInt<4>;
-  wire qm_dout: UInt<4>;
-
-  wire ql_we: Bool;
-  wire ql_addr: UInt<4>;
-  wire ql_din: UInt<4>;
-  wire ql_dout: UInt<4>;
-
-  // Queue write pointers
+  // Datapath regs alongside the FSM state.
   reg qh_wptr: UInt<4> reset reset=>0;
   reg qm_wptr: UInt<4> reset reset=>0;
   reg ql_wptr: UInt<4> reset reset=>0;
-
-  // Queue read pointers
   reg qh_rptr: UInt<4> reset reset=>0;
   reg qm_rptr: UInt<4> reset reset=>0;
   reg ql_rptr: UInt<4> reset reset=>0;
+  reg cur_symbol:  UInt<4> reset reset=>0;
+  reg upd_symbol:  UInt<4> reset reset=>0;
+  reg upd_code:    UInt<7> reset reset=>0;
+  reg upd_length:  UInt<3> reset reset=>0;
+  reg upd_pending: Bool    reset reset=>false;
 
-  // Saved symbol for encoding
-  reg cur_symbol: UInt<4> reset reset=>0;
-  // Saved update params
-  reg upd_symbol: UInt<4> reset reset=>0;
-  reg upd_code: UInt<7> reset reset=>0;
-  reg upd_length: UInt<3> reset reset=>0;
-  reg upd_pending: Bool reset reset=>false;
+  state [IDLE, PREPARE, CHECK_UPDATE, ENCODE, OUTPUT, HANDLE_ERROR, UPDATE_TABLE]
+  default state IDLE;
+  default seq on clk rising;
 
-  // RAM instances
-  inst ht_ram: single_port_ram
-    param DATA_WIDTH = 7;
-    param ADDR_WIDTH = 4;
-    clk  <- clk;
-    we   <- ht_we;
-    addr <- ht_addr;
-    din  <- ht_din;
-    dout -> ht_dout;
-  end inst ht_ram
+  // RAM idle defaults — every state overrides what it needs.
+  default
+    comb
+      ht_we = false; ht_addr = 0; ht_din = 0;
+      cl_we = false; cl_addr = 0; cl_din = 0;
+      qh_we = false; qh_addr = 0; qh_din = 0;
+      qm_we = false; qm_addr = 0; qm_din = 0;
+      ql_we = false; ql_addr = 0; ql_din = 0;
+    end comb
+  end default
 
-  inst cl_ram: single_port_ram
-    param DATA_WIDTH = 3;
-    param ADDR_WIDTH = 4;
-    clk  <- clk;
-    we   <- cl_we;
-    addr <- cl_addr;
-    din  <- cl_din;
-    dout -> cl_dout;
-  end inst cl_ram
-
-  inst qh_ram: single_port_ram
-    param DATA_WIDTH = 4;
-    param ADDR_WIDTH = 4;
-    clk  <- clk;
-    we   <- qh_we;
-    addr <- qh_addr;
-    din  <- qh_din;
-    dout -> qh_dout;
-  end inst qh_ram
-
-  inst qm_ram: single_port_ram
-    param DATA_WIDTH = 4;
-    param ADDR_WIDTH = 4;
-    clk  <- clk;
-    we   <- qm_we;
-    addr <- qm_addr;
-    din  <- qm_din;
-    dout -> qm_dout;
-  end inst qm_ram
-
-  inst ql_ram: single_port_ram
-    param DATA_WIDTH = 4;
-    param ADDR_WIDTH = 4;
-    clk  <- clk;
-    we   <- ql_we;
-    addr <- ql_addr;
-    din  <- ql_din;
-    dout -> ql_dout;
-  end inst ql_ram
-
-  // Default RAM drive signals (combinational)
-  comb
-    ht_we = false;
-    ht_addr = 0;
-    ht_din = 0;
-    cl_we = false;
-    cl_addr = 0;
-    cl_din = 0;
-    qh_we = false;
-    qh_addr = 0;
-    qh_din = 0;
-    qm_we = false;
-    qm_addr = 0;
-    qm_din = 0;
-    ql_we = false;
-    ql_addr = 0;
-    ql_din = 0;
-
-    if state == 0
-      // IDLE: enqueue data if valid
+  state IDLE
+    comb
+      // Enqueue incoming data into its priority queue.
       if data_valid
         if data_priority == 3
-          qh_we = true;
-          qh_addr = qh_wptr;
-          qh_din = data_in;
+          qh_we = true; qh_addr = qh_wptr; qh_din = data_in;
         elsif data_priority == 2
-          qm_we = true;
-          qm_addr = qm_wptr;
-          qm_din = data_in;
+          qm_we = true; qm_addr = qm_wptr; qm_din = data_in;
         else
-          ql_we = true;
-          ql_addr = ql_wptr;
-          ql_din = data_in;
+          ql_we = true; ql_addr = ql_wptr; ql_din = data_in;
         end if
       end if
-    elsif state == 1
-      // PREPARE: read from highest priority queue
-      if qh_rptr != qh_wptr
-        qh_addr = qh_rptr;
-      elsif qm_rptr != qm_wptr
-        qm_addr = qm_rptr;
-      elsif ql_rptr != ql_wptr
-        ql_addr = ql_rptr;
-      end if
-    elsif state == 2
-      // CHECK_UPDATE
-      ht_addr = upd_symbol;
-      cl_addr = upd_symbol;
-    elsif state == 3
-      // ENCODE: read huffman table for current symbol
-      ht_addr = cur_symbol;
-      cl_addr = cur_symbol;
-    elsif state == 6
-      // UPDATE_TABLE: write new code and length
-      ht_we = true;
-      ht_addr = upd_symbol;
-      ht_din = upd_code;
-      cl_we = true;
-      cl_addr = upd_symbol;
-      cl_din = upd_length;
-    end if
-  end comb
-
-  // FSM sequential logic
-  seq
-    if state == 0
-      // IDLE
+    end comb
+    seq
       code_valid <= false;
       error_flag <= false;
       if update_enable
-        upd_symbol <= config_symbol;
-        upd_code <= config_code;
-        upd_length <= config_length;
+        upd_symbol  <= config_symbol;
+        upd_code    <= config_code;
+        upd_length  <= config_length;
         upd_pending <= true;
-        state <= 2;
       elsif data_valid
         if data_priority == 3
           qh_wptr <= (qh_wptr + 1).trunc<4>();
@@ -197,48 +84,147 @@ module huffman_encoder
         else
           ql_wptr <= (ql_wptr + 1).trunc<4>();
         end if
-        state <= 1;
       end if
-    elsif state == 1
-      // PREPARE
+    end seq
+    -> CHECK_UPDATE when update_enable;
+    -> PREPARE      when (not update_enable) & data_valid;
+  end state IDLE
+
+  state PREPARE
+    comb
+      // Address the highest-priority non-empty queue.
+      if qh_rptr != qh_wptr
+        qh_addr = qh_rptr;
+      elsif qm_rptr != qm_wptr
+        qm_addr = qm_rptr;
+      elsif ql_rptr != ql_wptr
+        ql_addr = ql_rptr;
+      end if
+    end comb
+    seq
       if qh_rptr != qh_wptr
         cur_symbol <= qh_dout;
-        qh_rptr <= (qh_rptr + 1).trunc<4>();
-        state <= 3;
+        qh_rptr    <= (qh_rptr + 1).trunc<4>();
       elsif qm_rptr != qm_wptr
         cur_symbol <= qm_dout;
-        qm_rptr <= (qm_rptr + 1).trunc<4>();
-        state <= 3;
+        qm_rptr    <= (qm_rptr + 1).trunc<4>();
       elsif ql_rptr != ql_wptr
         cur_symbol <= ql_dout;
-        ql_rptr <= (ql_rptr + 1).trunc<4>();
-        state <= 3;
-      else
-        state <= 0;
+        ql_rptr    <= (ql_rptr + 1).trunc<4>();
       end if
-    elsif state == 2
-      // CHECK_UPDATE
+    end seq
+    -> ENCODE when (qh_rptr != qh_wptr) | (qm_rptr != qm_wptr) | (ql_rptr != ql_wptr);
+    -> IDLE   when (qh_rptr == qh_wptr) & (qm_rptr == qm_wptr) & (ql_rptr == ql_wptr);
+  end state PREPARE
+
+  state CHECK_UPDATE
+    comb
+      ht_addr = upd_symbol;
+      cl_addr = upd_symbol;
+    end comb
+    seq
       if upd_length == 0
         error_flag <= true;
-        state <= 5;
-      else
-        state <= 6;
       end if
-    elsif state == 3
-      // ENCODE
-      state <= 4;
-    elsif state == 4
-      // OUTPUT
+    end seq
+    -> HANDLE_ERROR when upd_length == 0;
+    -> UPDATE_TABLE when upd_length != 0;
+  end state CHECK_UPDATE
+
+  state ENCODE
+    comb
+      ht_addr = cur_symbol;
+      cl_addr = cur_symbol;
+    end comb
+    -> OUTPUT;
+  end state ENCODE
+
+  state OUTPUT
+    seq
       huffman_code_out <= ht_dout;
-      code_valid <= true;
-      state <= 0;
-    elsif state == 5
-      // HANDLE_ERROR
-      state <= 0;
-    elsif state == 6
-      // UPDATE_TABLE
+      code_valid       <= true;
+    end seq
+    -> IDLE;
+  end state OUTPUT
+
+  state HANDLE_ERROR
+    -> IDLE;
+  end state HANDLE_ERROR
+
+  state UPDATE_TABLE
+    comb
+      ht_we = true; ht_addr = upd_symbol; ht_din = upd_code;
+      cl_we = true; cl_addr = upd_symbol; cl_din = upd_length;
+    end comb
+    seq
       upd_pending <= false;
-      state <= 0;
-    end if
-  end seq
+    end seq
+    -> IDLE;
+  end state UPDATE_TABLE
+end fsm huffman_encoder_core
+
+
+// Top-level wrapper: 5 single-port RAMs + 1 fsm core.
+module huffman_encoder
+  port clk:     in Clock<SysDomain>;
+  port reset:   in Reset<Async>;
+
+  port data_valid:    in Bool;
+  port data_in:       in UInt<4>;
+  port data_priority: in UInt<2>;
+  port update_enable: in Bool;
+  port config_symbol: in UInt<4>;
+  port config_code:   in UInt<7>;
+  port config_length: in UInt<3>;
+
+  port huffman_code_out: out UInt<7>;
+  port code_valid:       out Bool;
+  port error_flag:       out Bool;
+
+  // FSM ↔ RAM interconnect wires.
+  wire ht_we: Bool; wire ht_addr: UInt<4>; wire ht_din: UInt<7>; wire ht_dout: UInt<7>;
+  wire cl_we: Bool; wire cl_addr: UInt<4>; wire cl_din: UInt<3>; wire cl_dout: UInt<3>;
+  wire qh_we: Bool; wire qh_addr: UInt<4>; wire qh_din: UInt<4>; wire qh_dout: UInt<4>;
+  wire qm_we: Bool; wire qm_addr: UInt<4>; wire qm_din: UInt<4>; wire qm_dout: UInt<4>;
+  wire ql_we: Bool; wire ql_addr: UInt<4>; wire ql_din: UInt<4>; wire ql_dout: UInt<4>;
+
+  inst ht_ram: single_port_ram
+    param DATA_WIDTH = 7; param ADDR_WIDTH = 4;
+    clk <- clk; we <- ht_we; addr <- ht_addr; din <- ht_din; dout -> ht_dout;
+  end inst ht_ram
+
+  inst cl_ram: single_port_ram
+    param DATA_WIDTH = 3; param ADDR_WIDTH = 4;
+    clk <- clk; we <- cl_we; addr <- cl_addr; din <- cl_din; dout -> cl_dout;
+  end inst cl_ram
+
+  inst qh_ram: single_port_ram
+    param DATA_WIDTH = 4; param ADDR_WIDTH = 4;
+    clk <- clk; we <- qh_we; addr <- qh_addr; din <- qh_din; dout -> qh_dout;
+  end inst qh_ram
+
+  inst qm_ram: single_port_ram
+    param DATA_WIDTH = 4; param ADDR_WIDTH = 4;
+    clk <- clk; we <- qm_we; addr <- qm_addr; din <- qm_din; dout -> qm_dout;
+  end inst qm_ram
+
+  inst ql_ram: single_port_ram
+    param DATA_WIDTH = 4; param ADDR_WIDTH = 4;
+    clk <- clk; we <- ql_we; addr <- ql_addr; din <- ql_din; dout -> ql_dout;
+  end inst ql_ram
+
+  inst core: huffman_encoder_core
+    clk <- clk; reset <- reset;
+    data_valid <- data_valid; data_in <- data_in; data_priority <- data_priority;
+    update_enable <- update_enable; config_symbol <- config_symbol;
+    config_code <- config_code; config_length <- config_length;
+    huffman_code_out -> huffman_code_out;
+    code_valid       -> code_valid;
+    error_flag       -> error_flag;
+    ht_we -> ht_we; ht_addr -> ht_addr; ht_din -> ht_din; ht_dout <- ht_dout;
+    cl_we -> cl_we; cl_addr -> cl_addr; cl_din -> cl_din; cl_dout <- cl_dout;
+    qh_we -> qh_we; qh_addr -> qh_addr; qh_din -> qh_din; qh_dout <- qh_dout;
+    qm_we -> qm_we; qm_addr -> qm_addr; qm_din -> qm_din; qm_dout <- qm_dout;
+    ql_we -> ql_we; ql_addr -> ql_addr; ql_din -> ql_din; ql_dout <- ql_dout;
+  end inst core
 end module huffman_encoder

--- a/tests/cvdp/huffman_encoder.sv
+++ b/tests/cvdp/huffman_encoder.sv
@@ -16,6 +16,11 @@ module single_port_ram__DATA_WIDTH_7 #(
     end
     dout <= mem[4'(addr)];
   end
+  // synopsys translate_off
+  // Auto-generated safety assertions (bounds / divide-by-zero)
+  _auto_bound_vec_0: assert property (@(posedge clk) (4'(addr)) < (16))
+    else $fatal(1, "BOUNDS VIOLATION: single_port_ram__DATA_WIDTH_7._auto_bound_vec_0");
+  // synopsys translate_on
 
 endmodule
 
@@ -37,6 +42,11 @@ module single_port_ram__DATA_WIDTH_3 #(
     end
     dout <= mem[4'(addr)];
   end
+  // synopsys translate_off
+  // Auto-generated safety assertions (bounds / divide-by-zero)
+  _auto_bound_vec_0: assert property (@(posedge clk) (4'(addr)) < (16))
+    else $fatal(1, "BOUNDS VIOLATION: single_port_ram__DATA_WIDTH_3._auto_bound_vec_0");
+  // synopsys translate_on
 
 endmodule
 
@@ -58,9 +68,273 @@ module single_port_ram__DATA_WIDTH_4 #(
     end
     dout <= mem[4'(addr)];
   end
+  // synopsys translate_off
+  // Auto-generated safety assertions (bounds / divide-by-zero)
+  _auto_bound_vec_0: assert property (@(posedge clk) (4'(addr)) < (16))
+    else $fatal(1, "BOUNDS VIOLATION: single_port_ram__DATA_WIDTH_4._auto_bound_vec_0");
+  // synopsys translate_on
 
 endmodule
 
+// 7-state Huffman encoder.
+// State machine lives in `fsm huffman_encoder_core`; the wrapper
+// `module huffman_encoder` owns the 5 RAM instances and connects
+// them to the fsm. (`fsm` bodies don't host `inst` declarations.)
+module huffman_encoder_core (
+  input logic clk,
+  input logic reset,
+  input logic data_valid,
+  input logic [3:0] data_in,
+  input logic [1:0] data_priority,
+  input logic update_enable,
+  input logic [3:0] config_symbol,
+  input logic [6:0] config_code,
+  input logic [2:0] config_length,
+  output logic [6:0] huffman_code_out,
+  output logic code_valid,
+  output logic error_flag,
+  output logic ht_we,
+  output logic [3:0] ht_addr,
+  output logic [6:0] ht_din,
+  input logic [6:0] ht_dout,
+  output logic cl_we,
+  output logic [3:0] cl_addr,
+  output logic [2:0] cl_din,
+  input logic [2:0] cl_dout,
+  output logic qh_we,
+  output logic [3:0] qh_addr,
+  output logic [3:0] qh_din,
+  input logic [3:0] qh_dout,
+  output logic qm_we,
+  output logic [3:0] qm_addr,
+  output logic [3:0] qm_din,
+  input logic [3:0] qm_dout,
+  output logic ql_we,
+  output logic [3:0] ql_addr,
+  output logic [3:0] ql_din,
+  input logic [3:0] ql_dout
+);
+
+  typedef enum logic [2:0] {
+    IDLE = 3'd0,
+    PREPARE = 3'd1,
+    CHECK_UPDATE = 3'd2,
+    ENCODE = 3'd3,
+    OUTPUT = 3'd4,
+    HANDLE_ERROR = 3'd5,
+    UPDATE_TABLE = 3'd6
+  } huffman_encoder_core_state_t;
+  
+  huffman_encoder_core_state_t state_r, state_next;
+  
+  logic [3:0] qh_wptr;
+  logic [3:0] qm_wptr;
+  logic [3:0] ql_wptr;
+  logic [3:0] qh_rptr;
+  logic [3:0] qm_rptr;
+  logic [3:0] ql_rptr;
+  logic [3:0] cur_symbol;
+  logic [3:0] upd_symbol;
+  logic [6:0] upd_code;
+  logic [2:0] upd_length;
+  logic upd_pending;
+  
+  always_ff @(posedge clk or posedge reset) begin
+    if (reset) begin
+      state_r <= IDLE;
+      qh_wptr <= 0;
+      qm_wptr <= 0;
+      ql_wptr <= 0;
+      qh_rptr <= 0;
+      qm_rptr <= 0;
+      ql_rptr <= 0;
+      cur_symbol <= 0;
+      upd_symbol <= 0;
+      upd_code <= 0;
+      upd_length <= 0;
+      upd_pending <= 1'b0;
+      huffman_code_out <= 0;
+      code_valid <= 1'b0;
+      error_flag <= 1'b0;
+    end else begin
+      state_r <= state_next;
+      case (state_r)
+        IDLE: begin
+          // External I/O (mirrors top-level)
+          // RAM driver ports (combinational outputs to the wrapper).
+          // Datapath regs alongside the FSM state.
+          // RAM idle defaults — every state overrides what it needs.
+          // Enqueue incoming data into its priority queue.
+          code_valid <= 1'b0;
+          error_flag <= 1'b0;
+          if (update_enable) begin
+            upd_symbol <= config_symbol;
+            upd_code <= config_code;
+            upd_length <= config_length;
+            upd_pending <= 1'b1;
+          end else if (data_valid) begin
+            if (data_priority == 3) begin
+              qh_wptr <= 4'(qh_wptr + 1);
+            end else if (data_priority == 2) begin
+              qm_wptr <= 4'(qm_wptr + 1);
+            end else begin
+              ql_wptr <= 4'(ql_wptr + 1);
+            end
+          end
+        end
+        PREPARE: begin
+          // Address the highest-priority non-empty queue.
+          if (qh_rptr != qh_wptr) begin
+            cur_symbol <= qh_dout;
+            qh_rptr <= 4'(qh_rptr + 1);
+          end else if (qm_rptr != qm_wptr) begin
+            cur_symbol <= qm_dout;
+            qm_rptr <= 4'(qm_rptr + 1);
+          end else if (ql_rptr != ql_wptr) begin
+            cur_symbol <= ql_dout;
+            ql_rptr <= 4'(ql_rptr + 1);
+          end
+        end
+        CHECK_UPDATE: begin
+          if (upd_length == 0) begin
+            error_flag <= 1'b1;
+          end
+        end
+        OUTPUT: begin
+          huffman_code_out <= ht_dout;
+          code_valid <= 1'b1;
+        end
+        UPDATE_TABLE: begin
+          upd_pending <= 1'b0;
+        end
+        default: ;
+      endcase
+    end
+  end
+  
+  always_comb begin
+    state_next = state_r; // hold by default
+    case (state_r)
+      IDLE: begin
+        if (update_enable) state_next = CHECK_UPDATE;
+        else if (!update_enable & data_valid) state_next = PREPARE;
+      end
+      PREPARE: begin
+        if ((qh_rptr != qh_wptr) | (qm_rptr != qm_wptr) | (ql_rptr != ql_wptr)) state_next = ENCODE;
+        else if ((qh_rptr == qh_wptr) & (qm_rptr == qm_wptr) & (ql_rptr == ql_wptr)) state_next = IDLE;
+      end
+      CHECK_UPDATE: begin
+        if (upd_length == 0) state_next = HANDLE_ERROR;
+        else if (upd_length != 0) state_next = UPDATE_TABLE;
+      end
+      ENCODE: begin
+        state_next = OUTPUT;
+      end
+      OUTPUT: begin
+        state_next = IDLE;
+      end
+      HANDLE_ERROR: begin
+        state_next = IDLE;
+      end
+      UPDATE_TABLE: begin
+        state_next = IDLE;
+      end
+      default: state_next = state_r;
+    endcase
+  end
+  
+  always_comb begin
+    ht_we = 1'b0;
+    ht_addr = 0;
+    ht_din = 0;
+    cl_we = 1'b0;
+    cl_addr = 0;
+    cl_din = 0;
+    qh_we = 1'b0;
+    qh_addr = 0;
+    qh_din = 0;
+    qm_we = 1'b0;
+    qm_addr = 0;
+    qm_din = 0;
+    ql_we = 1'b0;
+    ql_addr = 0;
+    ql_din = 0;
+    case (state_r)
+      IDLE: begin
+        if (data_valid) begin
+          if (data_priority == 3) begin
+            qh_we = 1'b1;
+            qh_addr = qh_wptr;
+            qh_din = data_in;
+          end else if (data_priority == 2) begin
+            qm_we = 1'b1;
+            qm_addr = qm_wptr;
+            qm_din = data_in;
+          end else begin
+            ql_we = 1'b1;
+            ql_addr = ql_wptr;
+            ql_din = data_in;
+          end
+        end
+      end
+      PREPARE: begin
+        if (qh_rptr != qh_wptr) begin
+          qh_addr = qh_rptr;
+        end else if (qm_rptr != qm_wptr) begin
+          qm_addr = qm_rptr;
+        end else if (ql_rptr != ql_wptr) begin
+          ql_addr = ql_rptr;
+        end
+      end
+      CHECK_UPDATE: begin
+        ht_addr = upd_symbol;
+        cl_addr = upd_symbol;
+      end
+      ENCODE: begin
+        ht_addr = cur_symbol;
+        cl_addr = cur_symbol;
+      end
+      OUTPUT: begin
+      end
+      HANDLE_ERROR: begin
+      end
+      UPDATE_TABLE: begin
+        ht_we = 1'b1;
+        ht_addr = upd_symbol;
+        ht_din = upd_code;
+        cl_we = 1'b1;
+        cl_addr = upd_symbol;
+        cl_din = upd_length;
+      end
+      default: ;
+    endcase
+  end
+  
+  // synopsys translate_off
+  _auto_legal_state: assert property (@(posedge clk) !reset |-> state_r < 7)
+    else $fatal(1, "FSM ILLEGAL STATE: huffman_encoder_core.state_r = %0d", state_r);
+  _auto_reach_IDLE: cover property (@(posedge clk) state_r == IDLE);
+  _auto_reach_PREPARE: cover property (@(posedge clk) state_r == PREPARE);
+  _auto_reach_CHECK_UPDATE: cover property (@(posedge clk) state_r == CHECK_UPDATE);
+  _auto_reach_ENCODE: cover property (@(posedge clk) state_r == ENCODE);
+  _auto_reach_OUTPUT: cover property (@(posedge clk) state_r == OUTPUT);
+  _auto_reach_HANDLE_ERROR: cover property (@(posedge clk) state_r == HANDLE_ERROR);
+  _auto_reach_UPDATE_TABLE: cover property (@(posedge clk) state_r == UPDATE_TABLE);
+  _auto_tr_IDLE_to_CHECK_UPDATE: cover property (@(posedge clk) state_r == IDLE && state_next == CHECK_UPDATE);
+  _auto_tr_IDLE_to_PREPARE: cover property (@(posedge clk) state_r == IDLE && state_next == PREPARE);
+  _auto_tr_PREPARE_to_ENCODE: cover property (@(posedge clk) state_r == PREPARE && state_next == ENCODE);
+  _auto_tr_PREPARE_to_IDLE: cover property (@(posedge clk) state_r == PREPARE && state_next == IDLE);
+  _auto_tr_CHECK_UPDATE_to_HANDLE_ERROR: cover property (@(posedge clk) state_r == CHECK_UPDATE && state_next == HANDLE_ERROR);
+  _auto_tr_CHECK_UPDATE_to_UPDATE_TABLE: cover property (@(posedge clk) state_r == CHECK_UPDATE && state_next == UPDATE_TABLE);
+  _auto_tr_ENCODE_to_OUTPUT: cover property (@(posedge clk) state_r == ENCODE && state_next == OUTPUT);
+  _auto_tr_OUTPUT_to_IDLE: cover property (@(posedge clk) state_r == OUTPUT && state_next == IDLE);
+  _auto_tr_HANDLE_ERROR_to_IDLE: cover property (@(posedge clk) state_r == HANDLE_ERROR && state_next == IDLE);
+  _auto_tr_UPDATE_TABLE_to_IDLE: cover property (@(posedge clk) state_r == UPDATE_TABLE && state_next == IDLE);
+  // synopsys translate_on
+
+endmodule
+
+// Top-level wrapper: 5 single-port RAMs + 1 fsm core.
 module huffman_encoder (
   input logic clk,
   input logic reset,
@@ -76,9 +350,7 @@ module huffman_encoder (
   output logic error_flag
 );
 
-  // FSM states: 0=IDLE,1=PREPARE,2=CHECK_UPDATE,3=ENCODE,4=OUTPUT,5=HANDLE_ERROR,6=UPDATE_TABLE
-  logic [2:0] state;
-  // RAM interface wires
+  // FSM ↔ RAM interconnect wires.
   logic ht_we;
   logic [3:0] ht_addr;
   logic [6:0] ht_din;
@@ -99,22 +371,6 @@ module huffman_encoder (
   logic [3:0] ql_addr;
   logic [3:0] ql_din;
   logic [3:0] ql_dout;
-  // Queue write pointers
-  logic [3:0] qh_wptr;
-  logic [3:0] qm_wptr;
-  logic [3:0] ql_wptr;
-  // Queue read pointers
-  logic [3:0] qh_rptr;
-  logic [3:0] qm_rptr;
-  logic [3:0] ql_rptr;
-  // Saved symbol for encoding
-  logic [3:0] cur_symbol;
-  // Saved update params
-  logic [3:0] upd_symbol;
-  logic [6:0] upd_code;
-  logic [2:0] upd_length;
-  logic upd_pending;
-  // RAM instances
   single_port_ram__DATA_WIDTH_7 #(.DATA_WIDTH(7), .ADDR_WIDTH(4)) ht_ram (
     .clk(clk),
     .we(ht_we),
@@ -150,149 +406,40 @@ module huffman_encoder (
     .din(ql_din),
     .dout(ql_dout)
   );
-  // Default RAM drive signals (combinational)
-  always_comb begin
-    ht_we = 1'b0;
-    ht_addr = 0;
-    ht_din = 0;
-    cl_we = 1'b0;
-    cl_addr = 0;
-    cl_din = 0;
-    qh_we = 1'b0;
-    qh_addr = 0;
-    qh_din = 0;
-    qm_we = 1'b0;
-    qm_addr = 0;
-    qm_din = 0;
-    ql_we = 1'b0;
-    ql_addr = 0;
-    ql_din = 0;
-    if (state == 0) begin
-      // IDLE: enqueue data if valid
-      if (data_valid) begin
-        if (data_priority == 3) begin
-          qh_we = 1'b1;
-          qh_addr = qh_wptr;
-          qh_din = data_in;
-        end else if (data_priority == 2) begin
-          qm_we = 1'b1;
-          qm_addr = qm_wptr;
-          qm_din = data_in;
-        end else begin
-          ql_we = 1'b1;
-          ql_addr = ql_wptr;
-          ql_din = data_in;
-        end
-      end
-    end else if (state == 1) begin
-      // PREPARE: read from highest priority queue
-      if (qh_rptr != qh_wptr) begin
-        qh_addr = qh_rptr;
-      end else if (qm_rptr != qm_wptr) begin
-        qm_addr = qm_rptr;
-      end else if (ql_rptr != ql_wptr) begin
-        ql_addr = ql_rptr;
-      end
-    end else if (state == 2) begin
-      // CHECK_UPDATE
-      ht_addr = upd_symbol;
-      cl_addr = upd_symbol;
-    end else if (state == 3) begin
-      // ENCODE: read huffman table for current symbol
-      ht_addr = cur_symbol;
-      cl_addr = cur_symbol;
-    end else if (state == 6) begin
-      // UPDATE_TABLE: write new code and length
-      ht_we = 1'b1;
-      ht_addr = upd_symbol;
-      ht_din = upd_code;
-      cl_we = 1'b1;
-      cl_addr = upd_symbol;
-      cl_din = upd_length;
-    end
-  end
-  // FSM sequential logic
-  always_ff @(posedge clk or posedge reset) begin
-    if (reset) begin
-      code_valid <= 1'b0;
-      cur_symbol <= 0;
-      error_flag <= 1'b0;
-      huffman_code_out <= 0;
-      qh_rptr <= 0;
-      qh_wptr <= 0;
-      ql_rptr <= 0;
-      ql_wptr <= 0;
-      qm_rptr <= 0;
-      qm_wptr <= 0;
-      state <= 0;
-      upd_code <= 0;
-      upd_length <= 0;
-      upd_pending <= 1'b0;
-      upd_symbol <= 0;
-    end else begin
-      if (state == 0) begin
-        // IDLE
-        code_valid <= 1'b0;
-        error_flag <= 1'b0;
-        if (update_enable) begin
-          upd_symbol <= config_symbol;
-          upd_code <= config_code;
-          upd_length <= config_length;
-          upd_pending <= 1'b1;
-          state <= 2;
-        end else if (data_valid) begin
-          if (data_priority == 3) begin
-            qh_wptr <= 4'(qh_wptr + 1);
-          end else if (data_priority == 2) begin
-            qm_wptr <= 4'(qm_wptr + 1);
-          end else begin
-            ql_wptr <= 4'(ql_wptr + 1);
-          end
-          state <= 1;
-        end
-      end else if (state == 1) begin
-        // PREPARE
-        if (qh_rptr != qh_wptr) begin
-          cur_symbol <= qh_dout;
-          qh_rptr <= 4'(qh_rptr + 1);
-          state <= 3;
-        end else if (qm_rptr != qm_wptr) begin
-          cur_symbol <= qm_dout;
-          qm_rptr <= 4'(qm_rptr + 1);
-          state <= 3;
-        end else if (ql_rptr != ql_wptr) begin
-          cur_symbol <= ql_dout;
-          ql_rptr <= 4'(ql_rptr + 1);
-          state <= 3;
-        end else begin
-          state <= 0;
-        end
-      end else if (state == 2) begin
-        // CHECK_UPDATE
-        if (upd_length == 0) begin
-          error_flag <= 1'b1;
-          state <= 5;
-        end else begin
-          state <= 6;
-        end
-      end else if (state == 3) begin
-        // ENCODE
-        state <= 4;
-      end else if (state == 4) begin
-        // OUTPUT
-        huffman_code_out <= ht_dout;
-        code_valid <= 1'b1;
-        state <= 0;
-      end else if (state == 5) begin
-        // HANDLE_ERROR
-        state <= 0;
-      end else if (state == 6) begin
-        // UPDATE_TABLE
-        upd_pending <= 1'b0;
-        state <= 0;
-      end
-    end
-  end
+  huffman_encoder_core core (
+    .clk(clk),
+    .reset(reset),
+    .data_valid(data_valid),
+    .data_in(data_in),
+    .data_priority(data_priority),
+    .update_enable(update_enable),
+    .config_symbol(config_symbol),
+    .config_code(config_code),
+    .config_length(config_length),
+    .huffman_code_out(huffman_code_out),
+    .code_valid(code_valid),
+    .error_flag(error_flag),
+    .ht_we(ht_we),
+    .ht_addr(ht_addr),
+    .ht_din(ht_din),
+    .ht_dout(ht_dout),
+    .cl_we(cl_we),
+    .cl_addr(cl_addr),
+    .cl_din(cl_din),
+    .cl_dout(cl_dout),
+    .qh_we(qh_we),
+    .qh_addr(qh_addr),
+    .qh_din(qh_din),
+    .qh_dout(qh_dout),
+    .qm_we(qm_we),
+    .qm_addr(qm_addr),
+    .qm_din(qm_din),
+    .qm_dout(qm_dout),
+    .ql_we(ql_we),
+    .ql_addr(ql_addr),
+    .ql_din(ql_din),
+    .ql_dout(ql_dout)
+  );
 
 endmodule
 


### PR DESCRIPTION
Refactor the Huffman encoder using the canonical "fsm core inside a wrapper module" pattern, since `fsm` bodies can't host `inst` declarations directly.

- **`fsm huffman_encoder_core`**: 7 named states (`IDLE`, `PREPARE`, `CHECK_UPDATE`, `ENCODE`, `OUTPUT`, `HANDLE_ERROR`, `UPDATE_TABLE`), per-state `comb` / `seq` blocks, and explicit `-> Target when cond;` transition arrows. RAM driver outputs become first-class fsm ports; defaults live in `default comb`, per-state `comb` overrides only what each state needs.
- **`module huffman_encoder`**: instantiates 5 `single_port_ram` cells + 1 `huffman_encoder_core`, wiring fsm-output drivers to RAM ports and RAM `dout`s back to the fsm.

Replaces the hand-rolled state encoding (`state == 0 / elsif state == 1 ...` in two parallel if/elsif chains across `comb` and `seq`) with named-state semantics. CVDP cocotb test still PASS.