### PR TITLE
cleanup(iir_filter): collapse delay regs into pipe_reg taps

### DIFF
--- a/tests/cvdp/iir_filter.arch
+++ b/tests/cvdp/iir_filter.arch
@@ -20,81 +20,44 @@ module iir_filter
 
   default seq on clk rising;
 
-  reg x1: SInt<16> reset none;
-  reg x2: SInt<16> reset none;
-  reg x3: SInt<16> reset none;
-  reg x4: SInt<16> reset none;
-  reg x5: SInt<16> reset none;
-  reg x6: SInt<16> reset none;
-  reg y1: SInt<16> reset none;
-  reg y2: SInt<16> reset none;
-  reg y3: SInt<16> reset none;
-  reg y4: SInt<16> reset none;
-  reg y5: SInt<16> reset none;
-  reg y6: SInt<16> reset none;
-  reg y_reg: SInt<16> reset none;
+  // x_pipe@0 = x (current input), x_pipe@K = x delayed by K cycles.
+  pipe_reg x_pipe: x stages 6;
+  // y_reg captures the current filter output. y_pipe@K reads y_reg
+  // from K cycles ago (so y_reg itself = y at lag 0, y_pipe@1 = lag 1, …).
+  reg y_reg: SInt<16> reset rst=>0;
+  pipe_reg y_pipe: y_reg stages 5;
 
-  // b*x terms
-  let t0: SInt<48> = (x.sext<48>()  * b0.zext<48>() as SInt<48>).trunc<48>();
-  let t1: SInt<48> = (x1.sext<48>() * b1.zext<48>() as SInt<48>).trunc<48>();
-  let t2: SInt<48> = (x2.sext<48>() * b2.zext<48>() as SInt<48>).trunc<48>();
-  let t3: SInt<48> = (x3.sext<48>() * b3.zext<48>() as SInt<48>).trunc<48>();
-  let t4: SInt<48> = (x4.sext<48>() * b4.zext<48>() as SInt<48>).trunc<48>();
-  let t5: SInt<48> = (x5.sext<48>() * b5.zext<48>() as SInt<48>).trunc<48>();
-  let t6: SInt<48> = (x6.sext<48>() * b6.zext<48>() as SInt<48>).trunc<48>();
-  // a*y terms
-  let u1: SInt<48> = (y1.sext<48>() * a1.zext<48>() as SInt<48>).trunc<48>();
-  let u2: SInt<48> = (y2.sext<48>() * a2.zext<48>() as SInt<48>).trunc<48>();
-  let u3: SInt<48> = (y3.sext<48>() * a3.zext<48>() as SInt<48>).trunc<48>();
-  let u4: SInt<48> = (y4.sext<48>() * a4.zext<48>() as SInt<48>).trunc<48>();
-  let u5: SInt<48> = (y5.sext<48>() * a5.zext<48>() as SInt<48>).trunc<48>();
-  let u6: SInt<48> = (y6.sext<48>() * a6.zext<48>() as SInt<48>).trunc<48>();
-  // sum feedforward
+  // b*x terms — the K-th tap multiplied by b_K.
+  let t0: SInt<48> = (x_pipe@0.sext<48>() * b0.zext<48>() as SInt<48>).trunc<48>();
+  let t1: SInt<48> = (x_pipe@1.sext<48>() * b1.zext<48>() as SInt<48>).trunc<48>();
+  let t2: SInt<48> = (x_pipe@2.sext<48>() * b2.zext<48>() as SInt<48>).trunc<48>();
+  let t3: SInt<48> = (x_pipe@3.sext<48>() * b3.zext<48>() as SInt<48>).trunc<48>();
+  let t4: SInt<48> = (x_pipe@4.sext<48>() * b4.zext<48>() as SInt<48>).trunc<48>();
+  let t5: SInt<48> = (x_pipe@5.sext<48>() * b5.zext<48>() as SInt<48>).trunc<48>();
+  let t6: SInt<48> = (x_pipe@6.sext<48>() * b6.zext<48>() as SInt<48>).trunc<48>();
+  // a*y terms — y1 = y_reg, y2..y6 = y_pipe@1..@5.
+  let u1: SInt<48> = (y_reg.sext<48>()    * a1.zext<48>() as SInt<48>).trunc<48>();
+  let u2: SInt<48> = (y_pipe@1.sext<48>() * a2.zext<48>() as SInt<48>).trunc<48>();
+  let u3: SInt<48> = (y_pipe@2.sext<48>() * a3.zext<48>() as SInt<48>).trunc<48>();
+  let u4: SInt<48> = (y_pipe@3.sext<48>() * a4.zext<48>() as SInt<48>).trunc<48>();
+  let u5: SInt<48> = (y_pipe@4.sext<48>() * a5.zext<48>() as SInt<48>).trunc<48>();
+  let u6: SInt<48> = (y_pipe@5.sext<48>() * a6.zext<48>() as SInt<48>).trunc<48>();
+  // Sum feedforward.
   let ff01: SInt<48> = (t0 + t1).trunc<48>();
   let ff23: SInt<48> = (t2 + t3).trunc<48>();
   let ff45: SInt<48> = (t4 + t5).trunc<48>();
   let ff_b: SInt<48> = ((ff01 + ff23).trunc<48>() + (ff45 + t6).trunc<48>()).trunc<48>();
-  // sum feedback
+  // Sum feedback.
   let fb12: SInt<48> = (u1 + u2).trunc<48>();
   let fb34: SInt<48> = (u3 + u4).trunc<48>();
   let fb56: SInt<48> = (u5 + u6).trunc<48>();
   let fb_a: SInt<48> = ((fb12 + fb34).trunc<48>() + fb56).trunc<48>();
-  // final accumulator
+  // Final accumulator.
   let acc:  SInt<48> = (ff_b - fb_a).trunc<48>();
-
-  let zero16: SInt<16> = 0.zext<16>() as SInt<16>;
 
   let y = y_reg;
 
   seq
-    if rst
-      x1    <= zero16;
-      x2    <= zero16;
-      x3    <= zero16;
-      x4    <= zero16;
-      x5    <= zero16;
-      x6    <= zero16;
-      y1    <= zero16;
-      y2    <= zero16;
-      y3    <= zero16;
-      y4    <= zero16;
-      y5    <= zero16;
-      y6    <= zero16;
-      y_reg <= zero16;
-    else
-      x1    <= x;
-      x2    <= x1;
-      x3    <= x2;
-      x4    <= x3;
-      x5    <= x4;
-      x6    <= x5;
-      y_reg <= acc.trunc<16>();
-      y1    <= acc.trunc<16>();
-      y2    <= y1;
-      y3    <= y2;
-      y4    <= y3;
-      y5    <= y4;
-      y6    <= y5;
-    end if
+    y_reg <= acc.trunc<16>();
   end seq
 end module iir_filter

--- a/tests/cvdp/iir_filter.sv
+++ b/tests/cvdp/iir_filter.sv
@@ -19,48 +19,82 @@ module iir_filter #(
   output logic signed [15:0] y
 );
 
-  logic signed [15:0] x1;
-  logic signed [15:0] x2;
-  logic signed [15:0] x3;
-  logic signed [15:0] x4;
-  logic signed [15:0] x5;
-  logic signed [15:0] x6;
-  logic signed [15:0] y1;
-  logic signed [15:0] y2;
-  logic signed [15:0] y3;
-  logic signed [15:0] y4;
-  logic signed [15:0] y5;
-  logic signed [15:0] y6;
+  // x_pipe@0 = x (current input), x_pipe@K = x delayed by K cycles.
+  logic signed [15:0] x_pipe_stg1;
+  logic signed [15:0] x_pipe_stg2;
+  logic signed [15:0] x_pipe_stg3;
+  logic signed [15:0] x_pipe_stg4;
+  logic signed [15:0] x_pipe_stg5;
+  logic signed [15:0] x_pipe;
+  always_ff @(posedge clk) begin
+    if (rst) begin
+      x_pipe_stg1 <= '0;
+      x_pipe_stg2 <= '0;
+      x_pipe_stg3 <= '0;
+      x_pipe_stg4 <= '0;
+      x_pipe_stg5 <= '0;
+      x_pipe <= '0;
+    end else begin
+      x_pipe_stg1 <= x;
+      x_pipe_stg2 <= x_pipe_stg1;
+      x_pipe_stg3 <= x_pipe_stg2;
+      x_pipe_stg4 <= x_pipe_stg3;
+      x_pipe_stg5 <= x_pipe_stg4;
+      x_pipe <= x_pipe_stg5;
+    end
+  end
+  // y_reg captures the current filter output. y_pipe@K reads y_reg
+  // from K cycles ago (so y_reg itself = y at lag 0, y_pipe@1 = lag 1, …).
   logic signed [15:0] y_reg;
-  // b*x terms
+  logic signed [15:0] y_pipe_stg1;
+  logic signed [15:0] y_pipe_stg2;
+  logic signed [15:0] y_pipe_stg3;
+  logic signed [15:0] y_pipe_stg4;
+  logic signed [15:0] y_pipe;
+  always_ff @(posedge clk) begin
+    if (rst) begin
+      y_pipe_stg1 <= '0;
+      y_pipe_stg2 <= '0;
+      y_pipe_stg3 <= '0;
+      y_pipe_stg4 <= '0;
+      y_pipe <= '0;
+    end else begin
+      y_pipe_stg1 <= y_reg;
+      y_pipe_stg2 <= y_pipe_stg1;
+      y_pipe_stg3 <= y_pipe_stg2;
+      y_pipe_stg4 <= y_pipe_stg3;
+      y_pipe <= y_pipe_stg4;
+    end
+  end
+  // b*x terms — the K-th tap multiplied by b_K.
   logic signed [47:0] t0;
   assign t0 = 48'({{(48-$bits(x)){x[$bits(x)-1]}}, x} * $signed(48'($unsigned(b0))));
   logic signed [47:0] t1;
-  assign t1 = 48'({{(48-$bits(x1)){x1[$bits(x1)-1]}}, x1} * $signed(48'($unsigned(b1))));
+  assign t1 = 48'({{(48-$bits(x_pipe_stg1)){x_pipe_stg1[$bits(x_pipe_stg1)-1]}}, x_pipe_stg1} * $signed(48'($unsigned(b1))));
   logic signed [47:0] t2;
-  assign t2 = 48'({{(48-$bits(x2)){x2[$bits(x2)-1]}}, x2} * $signed(48'($unsigned(b2))));
+  assign t2 = 48'({{(48-$bits(x_pipe_stg2)){x_pipe_stg2[$bits(x_pipe_stg2)-1]}}, x_pipe_stg2} * $signed(48'($unsigned(b2))));
   logic signed [47:0] t3;
-  assign t3 = 48'({{(48-$bits(x3)){x3[$bits(x3)-1]}}, x3} * $signed(48'($unsigned(b3))));
+  assign t3 = 48'({{(48-$bits(x_pipe_stg3)){x_pipe_stg3[$bits(x_pipe_stg3)-1]}}, x_pipe_stg3} * $signed(48'($unsigned(b3))));
   logic signed [47:0] t4;
-  assign t4 = 48'({{(48-$bits(x4)){x4[$bits(x4)-1]}}, x4} * $signed(48'($unsigned(b4))));
+  assign t4 = 48'({{(48-$bits(x_pipe_stg4)){x_pipe_stg4[$bits(x_pipe_stg4)-1]}}, x_pipe_stg4} * $signed(48'($unsigned(b4))));
   logic signed [47:0] t5;
-  assign t5 = 48'({{(48-$bits(x5)){x5[$bits(x5)-1]}}, x5} * $signed(48'($unsigned(b5))));
+  assign t5 = 48'({{(48-$bits(x_pipe_stg5)){x_pipe_stg5[$bits(x_pipe_stg5)-1]}}, x_pipe_stg5} * $signed(48'($unsigned(b5))));
   logic signed [47:0] t6;
-  assign t6 = 48'({{(48-$bits(x6)){x6[$bits(x6)-1]}}, x6} * $signed(48'($unsigned(b6))));
-  // a*y terms
+  assign t6 = 48'({{(48-$bits(x_pipe)){x_pipe[$bits(x_pipe)-1]}}, x_pipe} * $signed(48'($unsigned(b6))));
+  // a*y terms — y1 = y_reg, y2..y6 = y_pipe@1..@5.
   logic signed [47:0] u1;
-  assign u1 = 48'({{(48-$bits(y1)){y1[$bits(y1)-1]}}, y1} * $signed(48'($unsigned(a1))));
+  assign u1 = 48'({{(48-$bits(y_reg)){y_reg[$bits(y_reg)-1]}}, y_reg} * $signed(48'($unsigned(a1))));
   logic signed [47:0] u2;
-  assign u2 = 48'({{(48-$bits(y2)){y2[$bits(y2)-1]}}, y2} * $signed(48'($unsigned(a2))));
+  assign u2 = 48'({{(48-$bits(y_pipe_stg1)){y_pipe_stg1[$bits(y_pipe_stg1)-1]}}, y_pipe_stg1} * $signed(48'($unsigned(a2))));
   logic signed [47:0] u3;
-  assign u3 = 48'({{(48-$bits(y3)){y3[$bits(y3)-1]}}, y3} * $signed(48'($unsigned(a3))));
+  assign u3 = 48'({{(48-$bits(y_pipe_stg2)){y_pipe_stg2[$bits(y_pipe_stg2)-1]}}, y_pipe_stg2} * $signed(48'($unsigned(a3))));
   logic signed [47:0] u4;
-  assign u4 = 48'({{(48-$bits(y4)){y4[$bits(y4)-1]}}, y4} * $signed(48'($unsigned(a4))));
+  assign u4 = 48'({{(48-$bits(y_pipe_stg3)){y_pipe_stg3[$bits(y_pipe_stg3)-1]}}, y_pipe_stg3} * $signed(48'($unsigned(a4))));
   logic signed [47:0] u5;
-  assign u5 = 48'({{(48-$bits(y5)){y5[$bits(y5)-1]}}, y5} * $signed(48'($unsigned(a5))));
+  assign u5 = 48'({{(48-$bits(y_pipe_stg4)){y_pipe_stg4[$bits(y_pipe_stg4)-1]}}, y_pipe_stg4} * $signed(48'($unsigned(a5))));
   logic signed [47:0] u6;
-  assign u6 = 48'({{(48-$bits(y6)){y6[$bits(y6)-1]}}, y6} * $signed(48'($unsigned(a6))));
-  // sum feedforward
+  assign u6 = 48'({{(48-$bits(y_pipe)){y_pipe[$bits(y_pipe)-1]}}, y_pipe} * $signed(48'($unsigned(a6))));
+  // Sum feedforward.
   logic signed [47:0] ff01;
   assign ff01 = 48'(t0 + t1);
   logic signed [47:0] ff23;
@@ -69,7 +103,7 @@ module iir_filter #(
   assign ff45 = 48'(t4 + t5);
   logic signed [47:0] ff_b;
   assign ff_b = 48'(48'(ff01 + ff23) + 48'(ff45 + t6));
-  // sum feedback
+  // Sum feedback.
   logic signed [47:0] fb12;
   assign fb12 = 48'(u1 + u2);
   logic signed [47:0] fb34;
@@ -78,41 +112,15 @@ module iir_filter #(
   assign fb56 = 48'(u5 + u6);
   logic signed [47:0] fb_a;
   assign fb_a = 48'(48'(fb12 + fb34) + fb56);
-  // final accumulator
+  // Final accumulator.
   logic signed [47:0] acc;
   assign acc = 48'(ff_b - fb_a);
-  logic signed [15:0] zero16;
-  assign zero16 = $signed(16'($unsigned(0)));
   assign y = y_reg;
   always_ff @(posedge clk) begin
     if (rst) begin
-      x1 <= zero16;
-      x2 <= zero16;
-      x3 <= zero16;
-      x4 <= zero16;
-      x5 <= zero16;
-      x6 <= zero16;
-      y1 <= zero16;
-      y2 <= zero16;
-      y3 <= zero16;
-      y4 <= zero16;
-      y5 <= zero16;
-      y6 <= zero16;
-      y_reg <= zero16;
+      y_reg <= 0;
     end else begin
-      x1 <= x;
-      x2 <= x1;
-      x3 <= x2;
-      x4 <= x3;
-      x5 <= x4;
-      x6 <= x5;
       y_reg <= 16'(acc);
-      y1 <= 16'(acc);
-      y2 <= y1;
-      y3 <= y2;
-      y4 <= y3;
-      y5 <= y4;
-      y6 <= y5;
     end
   end
 


### PR DESCRIPTION
Replace 13 hand-rolled delay regs (`x1..x6`, `y1..y6`, `y_reg`) and 13 explicit seq cascade assignments with two `pipe_reg` declarations indexed via `@K` tap reads.

  - `pipe_reg x_pipe: x stages 6;` — `x_pipe@K` = x delayed by K cycles.
  - `pipe_reg y_pipe: y_reg stages 5;` — `y_pipe@K` = y_reg from K cycles ago.

The original separately maintained `y_reg` AND `y1` even though they held identical values every cycle (both `<= acc.trunc<16>()`). Cleanup collapses them to just `y_reg`, then the y_pipe taps cover lags 1..5.

**100 → 63 lines.** CVDP cocotb test still PASS.