### PR TITLE
feat(param): Vec-of-const params (param B: Vec<T, N> = {…})

### DIFF
--- a/doc/ARCH_HDL_Specification.md
+++ b/doc/ARCH_HDL_Specification.md
@@ -627,6 +627,10 @@ A module is the fundamental unit of design in Arch. Every module follows the sam
 |                                                                                |
 | // param NAME: EnumName = EnumName::Variant; // enum-typed — emits `parameter EnumName` |
 |                                                                                |
+| // param NAME: Vec<T, N> = {a, b, c, ...}; // fixed-length array of consts;  |
+| //                                  emits packed `parameter logic [N*W-1:0]`,  |
+| //                                  `NAME[i]` reads as a packed part-select.   |
+|                                                                                |
 | // local param NAME: const = expr;  // derived — emits `localparam` (not overridable) |
 |                                                                                |
 | //                                                                             |

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -203,6 +203,12 @@ pub enum ParamKind {
     Type(TypeExpr),
     /// Enum-typed const: `param MODE: EnumName = EnumName::Variant`
     EnumConst(String),
+    /// Vec-of-const: `param NAME: Vec<T, N> = {a, b, c};` — fixed-length
+    /// array of compile-time constants. Emits SV
+    /// `parameter logic [W-1:0] NAME [0:N-1] = '{a, b, c, ...}`.
+    /// Indexable as `NAME[i]` returning `T`. Inst-site overrides via
+    /// `param NAME = {…};`.
+    ConstVec(TypeExpr),
 }
 
 #[derive(Debug, Clone)]

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -67,6 +67,11 @@ pub struct Codegen<'a> {
     /// to the right SV intermediate signal: `q@0` → source, `q@K` for
     /// 1≤K<N → `q_stg{K}`, `q@N` → `q` (= bare q).
     pipe_regs: std::collections::HashMap<String, (String, u32)>,
+    /// Vec-of-const param name → (element TypeExpr) for the current
+    /// module. iverilog rejects unpacked-array params, so codegen emits
+    /// the param packed and rewrites `B[i]` reads to `B[i*W +: W]`
+    /// part-selects. Lookup populated per-module at emit time.
+    vec_params: std::collections::HashMap<String, TypeExpr>,
     /// Set of index widths used by `.find_first(...)` calls in this file.
     /// Drives emission of one `typedef struct packed ... __ArchFindResult_<W>;`
     /// per unique W at the top of the generated SV. Interior-mutability
@@ -97,6 +102,7 @@ impl<'a> Codegen<'a> {
             ident_subst: std::collections::HashMap::new(),
             vec_sizes: std::collections::HashMap::new(),
             pipe_regs: std::collections::HashMap::new(),
+            vec_params: std::collections::HashMap::new(),
             find_first_widths: std::cell::RefCell::new(std::collections::BTreeSet::new()),
         }
     }
@@ -240,6 +246,48 @@ impl<'a> Codegen<'a> {
             }
             ParamKind::EnumConst(enum_name) => {
                 self.line(&format!("{kw} {} {}{}{}", enum_name, p.name.name, default_str, comma));
+            }
+            ParamKind::ConstVec(ty) => {
+                // Vec<T, N> param. iverilog rejects unpacked-array parameters,
+                // so emit a packed `parameter logic [N*W-1:0] NAME = {…}` and
+                // expose a sibling `wire NAME_arr [0:N-1]` (driven elsewhere
+                // in the module body) for `NAME[i]` indexing.
+                //
+                // Default `{a, b, c, …}` (parsed as ExprKind::Concat) packs
+                // with reversed ordering so `NAME[0]` lands at the LSB and
+                // matches the user's literal index — `parts[0]` = LSB chunk.
+                let (elem_ty, size_expr) = match ty {
+                    TypeExpr::Vec(elem, size) => (elem.as_ref().clone(), (**size).clone()),
+                    _ => {
+                        self.line(&format!("{kw} int {}{}{}", p.name.name, default_str, comma));
+                        return;
+                    }
+                };
+                let elem_w_expr = match &elem_ty {
+                    TypeExpr::UInt(w) | TypeExpr::SInt(w) => (**w).clone(),
+                    _ => Expr::new(ExprKind::Literal(LitKind::Dec(1)), p.span),
+                };
+                let elem_w_s = self.emit_expr_str(&elem_w_expr);
+                let signed = matches!(&elem_ty, TypeExpr::SInt(_));
+                let signed_kw = if signed { "signed " } else { "" };
+                let size_s = self.emit_expr_str(&size_expr);
+                let default_packed = if let Some(d) = &p.default {
+                    if let ExprKind::Concat(parts) = &d.kind {
+                        // Reverse so parts[0] is the LSB chunk → NAME[0] reads parts[0].
+                        let mut rev: Vec<&Expr> = parts.iter().collect();
+                        rev.reverse();
+                        let chunks: Vec<String> = rev.iter()
+                            .map(|e| format!("({})'({})", elem_w_s, self.emit_expr_str(e)))
+                            .collect();
+                        format!(" = {{{}}}", chunks.join(", "))
+                    } else {
+                        format!(" = {}", self.emit_expr_str(d))
+                    }
+                } else { String::new() };
+                self.line(&format!(
+                    "{kw} logic {signed_kw}[({size_s})*({elem_w_s})-1:0] {}{default_packed}{comma}",
+                    p.name.name
+                ));
             }
             _ => {
                 self.line(&format!("{kw} int {}{}{}", p.name.name, default_str, comma));
@@ -546,9 +594,17 @@ impl<'a> Codegen<'a> {
         self.reset_ports.clear();
         self.vec_sizes.clear();
         self.pipe_regs.clear();
+        self.vec_params.clear();
         for bi in &m.body {
             if let ModuleBodyItem::PipeRegDecl(p) = bi {
                 self.pipe_regs.insert(p.name.name.clone(), (p.source.name.clone(), p.stages));
+            }
+        }
+        for p in m.params.iter() {
+            if let ParamKind::ConstVec(ty) = &p.kind {
+                if let TypeExpr::Vec(elem, _) = ty {
+                    self.vec_params.insert(p.name.name.clone(), (**elem).clone());
+                }
             }
         }
         for p in m.ports.iter() {
@@ -6338,6 +6394,21 @@ impl<'a> Codegen<'a> {
                 }
             }
             ExprKind::Index(base, idx) => {
+                // Vec-of-const param `B[i]`: rewrite to packed part-select
+                // `B[i*W +: W]` since iverilog rejects unpacked-array params.
+                if let ExprKind::Ident(name) = &base.kind {
+                    if let Some(elem_ty) = self.vec_params.get(name) {
+                        let w = match elem_ty {
+                            TypeExpr::UInt(w) | TypeExpr::SInt(w) => self.emit_expr_str(w),
+                            _ => "1".to_string(),
+                        };
+                        let i = self.emit_expr_str(idx);
+                        // The packed param is declared `signed` for SInt
+                        // elements, so the part-select inherits signedness
+                        // without an explicit `$signed()` wrap.
+                        return format!("{name}[({i}) * ({w}) +: ({w})]");
+                    }
+                }
                 let b = self.emit_expr_str(base);
                 let i = self.emit_expr_str(idx);
                 format!("{b}[{i}]")

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -278,6 +278,15 @@ fn emit_params(s: &mut String, params: &[ParamDecl]) {
                     "  {local}param {name}: {enum_name}{default_str};\n"
                 ));
             }
+            ParamKind::ConstVec(ty) => {
+                let default_str = p.default.as_ref()
+                    .map(|d| format!(" = {}", expr_str(d)))
+                    .unwrap_or_default();
+                s.push_str(&format!(
+                    "  {local}param {name}: {}{default_str};\n",
+                    type_str(ty)
+                ));
+            }
         }
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -761,6 +761,10 @@ impl Parser {
             self.expect(TokenKind::Eq)?;
             let ty = self.parse_type_expr()?;
             ParamKind::Type(ty)
+        } else if matches!(self.peek_kind(), Some(TokenKind::KwVec)) {
+            // Vec-of-const: param NAME: Vec<T, N> = {...};
+            let ty = self.parse_type_expr()?;
+            ParamKind::ConstVec(ty)
         } else if matches!(self.peek_kind(), Some(TokenKind::Ident(_))) {
             // Enum-typed const: param MODE: EnumName = EnumName::Variant
             let enum_name = self.expect_ident()?;

--- a/tests/cvdp/iir_filter.arch
+++ b/tests/cvdp/iir_filter.arch
@@ -1,17 +1,8 @@
 module iir_filter
-  param b0: const = 1;
-  param b1: const = 0;
-  param b2: const = 0;
-  param b3: const = 0;
-  param b4: const = 0;
-  param b5: const = 0;
-  param b6: const = 0;
-  param a1: const = 0;
-  param a2: const = 0;
-  param a3: const = 0;
-  param a4: const = 0;
-  param a5: const = 0;
-  param a6: const = 0;
+  // Feedforward (b) coefficients, indexed b[0..6].
+  param b: Vec<SInt<16>, 7> = {1, 0, 0, 0, 0, 0, 0};
+  // Feedback (a) coefficients, indexed a[1..6]; a[0] is unused.
+  param a: Vec<SInt<16>, 7> = {0, 0, 0, 0, 0, 0, 0};
 
   port clk: in Clock<SysDomain>;
   port rst: in Reset<Sync, High>;
@@ -23,36 +14,36 @@ module iir_filter
   // x_pipe@0 = x (current input), x_pipe@K = x delayed by K cycles.
   pipe_reg x_pipe: x stages 6;
   // y_reg captures the current filter output. y_pipe@K reads y_reg
-  // from K cycles ago (so y_reg itself = y at lag 0, y_pipe@1 = lag 1, …).
+  // from K cycles ago (y_reg = y at lag 0, y_pipe@1 = lag 1, …).
   reg y_reg: SInt<16> reset rst=>0;
   pipe_reg y_pipe: y_reg stages 5;
 
-  // b*x terms — the K-th tap multiplied by b_K.
-  let t0: SInt<48> = (x_pipe@0.sext<48>() * b0.zext<48>() as SInt<48>).trunc<48>();
-  let t1: SInt<48> = (x_pipe@1.sext<48>() * b1.zext<48>() as SInt<48>).trunc<48>();
-  let t2: SInt<48> = (x_pipe@2.sext<48>() * b2.zext<48>() as SInt<48>).trunc<48>();
-  let t3: SInt<48> = (x_pipe@3.sext<48>() * b3.zext<48>() as SInt<48>).trunc<48>();
-  let t4: SInt<48> = (x_pipe@4.sext<48>() * b4.zext<48>() as SInt<48>).trunc<48>();
-  let t5: SInt<48> = (x_pipe@5.sext<48>() * b5.zext<48>() as SInt<48>).trunc<48>();
-  let t6: SInt<48> = (x_pipe@6.sext<48>() * b6.zext<48>() as SInt<48>).trunc<48>();
-  // a*y terms — y1 = y_reg, y2..y6 = y_pipe@1..@5.
-  let u1: SInt<48> = (y_reg.sext<48>()    * a1.zext<48>() as SInt<48>).trunc<48>();
-  let u2: SInt<48> = (y_pipe@1.sext<48>() * a2.zext<48>() as SInt<48>).trunc<48>();
-  let u3: SInt<48> = (y_pipe@2.sext<48>() * a3.zext<48>() as SInt<48>).trunc<48>();
-  let u4: SInt<48> = (y_pipe@3.sext<48>() * a4.zext<48>() as SInt<48>).trunc<48>();
-  let u5: SInt<48> = (y_pipe@4.sext<48>() * a5.zext<48>() as SInt<48>).trunc<48>();
-  let u6: SInt<48> = (y_pipe@5.sext<48>() * a6.zext<48>() as SInt<48>).trunc<48>();
-  // Sum feedforward.
-  let ff01: SInt<48> = (t0 + t1).trunc<48>();
-  let ff23: SInt<48> = (t2 + t3).trunc<48>();
-  let ff45: SInt<48> = (t4 + t5).trunc<48>();
-  let ff_b: SInt<48> = ((ff01 + ff23).trunc<48>() + (ff45 + t6).trunc<48>()).trunc<48>();
-  // Sum feedback.
-  let fb12: SInt<48> = (u1 + u2).trunc<48>();
-  let fb34: SInt<48> = (u3 + u4).trunc<48>();
-  let fb56: SInt<48> = (u5 + u6).trunc<48>();
-  let fb_a: SInt<48> = ((fb12 + fb34).trunc<48>() + fb56).trunc<48>();
-  // Final accumulator.
+  // Per-tap multiply-accumulate. The K-th input tap multiplies b[K];
+  // the K-th output tap (lag K, with lag 0 = y_reg) multiplies a[K].
+  wire t: Vec<SInt<48>, 7>;
+  wire u: Vec<SInt<48>, 7>;
+  comb
+    t[0] = (x_pipe@0.sext<48>() * b[0].sext<48>()).trunc<48>();
+    t[1] = (x_pipe@1.sext<48>() * b[1].sext<48>()).trunc<48>();
+    t[2] = (x_pipe@2.sext<48>() * b[2].sext<48>()).trunc<48>();
+    t[3] = (x_pipe@3.sext<48>() * b[3].sext<48>()).trunc<48>();
+    t[4] = (x_pipe@4.sext<48>() * b[4].sext<48>()).trunc<48>();
+    t[5] = (x_pipe@5.sext<48>() * b[5].sext<48>()).trunc<48>();
+    t[6] = (x_pipe@6.sext<48>() * b[6].sext<48>()).trunc<48>();
+    u[0] = 0.zext<48>() as SInt<48>;  // a[0] unused; pad so indices align with b
+    u[1] = (y_reg.sext<48>()    * a[1].sext<48>()).trunc<48>();
+    u[2] = (y_pipe@1.sext<48>() * a[2].sext<48>()).trunc<48>();
+    u[3] = (y_pipe@2.sext<48>() * a[3].sext<48>()).trunc<48>();
+    u[4] = (y_pipe@3.sext<48>() * a[4].sext<48>()).trunc<48>();
+    u[5] = (y_pipe@4.sext<48>() * a[5].sext<48>()).trunc<48>();
+    u[6] = (y_pipe@5.sext<48>() * a[6].sext<48>()).trunc<48>();
+  end comb
+
+  // Sum trees + final accumulator.
+  let ff_b: SInt<48> = (((t[0] + t[1]).trunc<48>() + (t[2] + t[3]).trunc<48>()).trunc<48>()
+                      + ((t[4] + t[5]).trunc<48>() + t[6]).trunc<48>()).trunc<48>();
+  let fb_a: SInt<48> = (((u[1] + u[2]).trunc<48>() + (u[3] + u[4]).trunc<48>()).trunc<48>()
+                      + (u[5] + u[6]).trunc<48>()).trunc<48>();
   let acc:  SInt<48> = (ff_b - fb_a).trunc<48>();
 
   let y = y_reg;

--- a/tests/cvdp/iir_filter.sv
+++ b/tests/cvdp/iir_filter.sv
@@ -1,17 +1,6 @@
 module iir_filter #(
-  parameter int b0 = 1,
-  parameter int b1 = 0,
-  parameter int b2 = 0,
-  parameter int b3 = 0,
-  parameter int b4 = 0,
-  parameter int b5 = 0,
-  parameter int b6 = 0,
-  parameter int a1 = 0,
-  parameter int a2 = 0,
-  parameter int a3 = 0,
-  parameter int a4 = 0,
-  parameter int a5 = 0,
-  parameter int a6 = 0
+  parameter logic signed [(7)*(16)-1:0] b = {(16)'(0), (16)'(0), (16)'(0), (16)'(0), (16)'(0), (16)'(0), (16)'(1)},
+  parameter logic signed [(7)*(16)-1:0] a = {(16)'(0), (16)'(0), (16)'(0), (16)'(0), (16)'(0), (16)'(0), (16)'(0)}
 ) (
   input logic clk,
   input logic rst,
@@ -19,6 +8,8 @@ module iir_filter #(
   output logic signed [15:0] y
 );
 
+  // Feedforward (b) coefficients, indexed b[0..6].
+  // Feedback (a) coefficients, indexed a[1..6]; a[0] is unused.
   // x_pipe@0 = x (current input), x_pipe@K = x delayed by K cycles.
   logic signed [15:0] x_pipe_stg1;
   logic signed [15:0] x_pipe_stg2;
@@ -44,7 +35,7 @@ module iir_filter #(
     end
   end
   // y_reg captures the current filter output. y_pipe@K reads y_reg
-  // from K cycles ago (so y_reg itself = y at lag 0, y_pipe@1 = lag 1, …).
+  // from K cycles ago (y_reg = y at lag 0, y_pipe@1 = lag 1, …).
   logic signed [15:0] y_reg;
   logic signed [15:0] y_pipe_stg1;
   logic signed [15:0] y_pipe_stg2;
@@ -66,53 +57,30 @@ module iir_filter #(
       y_pipe <= y_pipe_stg4;
     end
   end
-  // b*x terms — the K-th tap multiplied by b_K.
-  logic signed [47:0] t0;
-  assign t0 = 48'({{(48-$bits(x)){x[$bits(x)-1]}}, x} * $signed(48'($unsigned(b0))));
-  logic signed [47:0] t1;
-  assign t1 = 48'({{(48-$bits(x_pipe_stg1)){x_pipe_stg1[$bits(x_pipe_stg1)-1]}}, x_pipe_stg1} * $signed(48'($unsigned(b1))));
-  logic signed [47:0] t2;
-  assign t2 = 48'({{(48-$bits(x_pipe_stg2)){x_pipe_stg2[$bits(x_pipe_stg2)-1]}}, x_pipe_stg2} * $signed(48'($unsigned(b2))));
-  logic signed [47:0] t3;
-  assign t3 = 48'({{(48-$bits(x_pipe_stg3)){x_pipe_stg3[$bits(x_pipe_stg3)-1]}}, x_pipe_stg3} * $signed(48'($unsigned(b3))));
-  logic signed [47:0] t4;
-  assign t4 = 48'({{(48-$bits(x_pipe_stg4)){x_pipe_stg4[$bits(x_pipe_stg4)-1]}}, x_pipe_stg4} * $signed(48'($unsigned(b4))));
-  logic signed [47:0] t5;
-  assign t5 = 48'({{(48-$bits(x_pipe_stg5)){x_pipe_stg5[$bits(x_pipe_stg5)-1]}}, x_pipe_stg5} * $signed(48'($unsigned(b5))));
-  logic signed [47:0] t6;
-  assign t6 = 48'({{(48-$bits(x_pipe)){x_pipe[$bits(x_pipe)-1]}}, x_pipe} * $signed(48'($unsigned(b6))));
-  // a*y terms — y1 = y_reg, y2..y6 = y_pipe@1..@5.
-  logic signed [47:0] u1;
-  assign u1 = 48'({{(48-$bits(y_reg)){y_reg[$bits(y_reg)-1]}}, y_reg} * $signed(48'($unsigned(a1))));
-  logic signed [47:0] u2;
-  assign u2 = 48'({{(48-$bits(y_pipe_stg1)){y_pipe_stg1[$bits(y_pipe_stg1)-1]}}, y_pipe_stg1} * $signed(48'($unsigned(a2))));
-  logic signed [47:0] u3;
-  assign u3 = 48'({{(48-$bits(y_pipe_stg2)){y_pipe_stg2[$bits(y_pipe_stg2)-1]}}, y_pipe_stg2} * $signed(48'($unsigned(a3))));
-  logic signed [47:0] u4;
-  assign u4 = 48'({{(48-$bits(y_pipe_stg3)){y_pipe_stg3[$bits(y_pipe_stg3)-1]}}, y_pipe_stg3} * $signed(48'($unsigned(a4))));
-  logic signed [47:0] u5;
-  assign u5 = 48'({{(48-$bits(y_pipe_stg4)){y_pipe_stg4[$bits(y_pipe_stg4)-1]}}, y_pipe_stg4} * $signed(48'($unsigned(a5))));
-  logic signed [47:0] u6;
-  assign u6 = 48'({{(48-$bits(y_pipe)){y_pipe[$bits(y_pipe)-1]}}, y_pipe} * $signed(48'($unsigned(a6))));
-  // Sum feedforward.
-  logic signed [47:0] ff01;
-  assign ff01 = 48'(t0 + t1);
-  logic signed [47:0] ff23;
-  assign ff23 = 48'(t2 + t3);
-  logic signed [47:0] ff45;
-  assign ff45 = 48'(t4 + t5);
+  // Per-tap multiply-accumulate. The K-th input tap multiplies b[K];
+  // the K-th output tap (lag K, with lag 0 = y_reg) multiplies a[K].
+  logic signed [6:0] [47:0] t;
+  logic signed [6:0] [47:0] u;
+  assign t[0] = 48'({{(48-$bits(x)){x[$bits(x)-1]}}, x} * {{(48-$bits(b[(0) * (16) +: (16)])){b[(0) * (16) +: (16)][$bits(b[(0) * (16) +: (16)])-1]}}, b[(0) * (16) +: (16)]});
+  assign t[1] = 48'({{(48-$bits(x_pipe_stg1)){x_pipe_stg1[$bits(x_pipe_stg1)-1]}}, x_pipe_stg1} * {{(48-$bits(b[(1) * (16) +: (16)])){b[(1) * (16) +: (16)][$bits(b[(1) * (16) +: (16)])-1]}}, b[(1) * (16) +: (16)]});
+  assign t[2] = 48'({{(48-$bits(x_pipe_stg2)){x_pipe_stg2[$bits(x_pipe_stg2)-1]}}, x_pipe_stg2} * {{(48-$bits(b[(2) * (16) +: (16)])){b[(2) * (16) +: (16)][$bits(b[(2) * (16) +: (16)])-1]}}, b[(2) * (16) +: (16)]});
+  assign t[3] = 48'({{(48-$bits(x_pipe_stg3)){x_pipe_stg3[$bits(x_pipe_stg3)-1]}}, x_pipe_stg3} * {{(48-$bits(b[(3) * (16) +: (16)])){b[(3) * (16) +: (16)][$bits(b[(3) * (16) +: (16)])-1]}}, b[(3) * (16) +: (16)]});
+  assign t[4] = 48'({{(48-$bits(x_pipe_stg4)){x_pipe_stg4[$bits(x_pipe_stg4)-1]}}, x_pipe_stg4} * {{(48-$bits(b[(4) * (16) +: (16)])){b[(4) * (16) +: (16)][$bits(b[(4) * (16) +: (16)])-1]}}, b[(4) * (16) +: (16)]});
+  assign t[5] = 48'({{(48-$bits(x_pipe_stg5)){x_pipe_stg5[$bits(x_pipe_stg5)-1]}}, x_pipe_stg5} * {{(48-$bits(b[(5) * (16) +: (16)])){b[(5) * (16) +: (16)][$bits(b[(5) * (16) +: (16)])-1]}}, b[(5) * (16) +: (16)]});
+  assign t[6] = 48'({{(48-$bits(x_pipe)){x_pipe[$bits(x_pipe)-1]}}, x_pipe} * {{(48-$bits(b[(6) * (16) +: (16)])){b[(6) * (16) +: (16)][$bits(b[(6) * (16) +: (16)])-1]}}, b[(6) * (16) +: (16)]});
+  assign u[0] = $signed(48'($unsigned(0)));
+  assign u[1] = 48'({{(48-$bits(y_reg)){y_reg[$bits(y_reg)-1]}}, y_reg} * {{(48-$bits(a[(1) * (16) +: (16)])){a[(1) * (16) +: (16)][$bits(a[(1) * (16) +: (16)])-1]}}, a[(1) * (16) +: (16)]});
+  assign u[2] = 48'({{(48-$bits(y_pipe_stg1)){y_pipe_stg1[$bits(y_pipe_stg1)-1]}}, y_pipe_stg1} * {{(48-$bits(a[(2) * (16) +: (16)])){a[(2) * (16) +: (16)][$bits(a[(2) * (16) +: (16)])-1]}}, a[(2) * (16) +: (16)]});
+  assign u[3] = 48'({{(48-$bits(y_pipe_stg2)){y_pipe_stg2[$bits(y_pipe_stg2)-1]}}, y_pipe_stg2} * {{(48-$bits(a[(3) * (16) +: (16)])){a[(3) * (16) +: (16)][$bits(a[(3) * (16) +: (16)])-1]}}, a[(3) * (16) +: (16)]});
+  assign u[4] = 48'({{(48-$bits(y_pipe_stg3)){y_pipe_stg3[$bits(y_pipe_stg3)-1]}}, y_pipe_stg3} * {{(48-$bits(a[(4) * (16) +: (16)])){a[(4) * (16) +: (16)][$bits(a[(4) * (16) +: (16)])-1]}}, a[(4) * (16) +: (16)]});
+  assign u[5] = 48'({{(48-$bits(y_pipe_stg4)){y_pipe_stg4[$bits(y_pipe_stg4)-1]}}, y_pipe_stg4} * {{(48-$bits(a[(5) * (16) +: (16)])){a[(5) * (16) +: (16)][$bits(a[(5) * (16) +: (16)])-1]}}, a[(5) * (16) +: (16)]});
+  assign u[6] = 48'({{(48-$bits(y_pipe)){y_pipe[$bits(y_pipe)-1]}}, y_pipe} * {{(48-$bits(a[(6) * (16) +: (16)])){a[(6) * (16) +: (16)][$bits(a[(6) * (16) +: (16)])-1]}}, a[(6) * (16) +: (16)]});
+  // a[0] unused; pad so indices align with b
+  // Sum trees + final accumulator.
   logic signed [47:0] ff_b;
-  assign ff_b = 48'(48'(ff01 + ff23) + 48'(ff45 + t6));
-  // Sum feedback.
-  logic signed [47:0] fb12;
-  assign fb12 = 48'(u1 + u2);
-  logic signed [47:0] fb34;
-  assign fb34 = 48'(u3 + u4);
-  logic signed [47:0] fb56;
-  assign fb56 = 48'(u5 + u6);
+  assign ff_b = 48'(48'(48'(t[0] + t[1]) + 48'(t[2] + t[3])) + 48'(48'(t[4] + t[5]) + t[6]));
   logic signed [47:0] fb_a;
-  assign fb_a = 48'(48'(fb12 + fb34) + fb56);
-  // Final accumulator.
+  assign fb_a = 48'(48'(48'(u[1] + u[2]) + 48'(u[3] + u[4])) + 48'(u[5] + u[6]));
   logic signed [47:0] acc;
   assign acc = 48'(ff_b - fb_a);
   assign y = y_reg;

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -5828,3 +5828,26 @@ fn test_fsm_sint_uses_arithmetic_shift() {
     assert!(!sv.contains("a >> 1"),
         "should not emit `>>` (logical) for SInt:\n{sv}");
 }
+
+#[test]
+fn test_vec_of_const_param_emits_packed_and_indexes() {
+    // `param NAME: Vec<T, N> = {a, b, c, ...};` emits a packed SV
+    // `parameter logic [N*W-1:0] NAME = {chunks_reversed}` plus `NAME[i]`
+    // reads rewrite to `NAME[(i)*(W) +: (W)]` part-selects.
+    let source = r#"
+        module M
+          param coeffs: Vec<UInt<8>, 4> = {1, 2, 3, 4};
+          port out: out UInt<8>;
+          let out = coeffs[0] + coeffs[1] + coeffs[2] + coeffs[3];
+        end module M
+    "#;
+    let sv = compile_to_sv(source);
+    assert!(sv.contains("parameter logic [(4)*(8)-1:0] coeffs"),
+        "expected packed parameter:\n{sv}");
+    // Default packed in reverse so coeffs[0] = parts[0] = 1 (LSB).
+    assert!(sv.contains("(8)'(4), (8)'(3), (8)'(2), (8)'(1)"),
+        "expected reversed default chunks (MSB-first packing):\n{sv}");
+    // Indexing rewritten to part-select.
+    assert!(sv.contains("coeffs[(0) * (8) +: (8)]"),
+        "expected coeffs[0] → coeffs[(0) * (8) +: (8)]:\n{sv}");
+}


### PR DESCRIPTION
Adds a fourth value-param shape — `ParamKind::ConstVec(TypeExpr)` — for fixed-length arrays of compile-time constants. Common use cases: FIR/IIR coefficients, lookup tables, init arrays.

  ```
  param coeffs: Vec<UInt<8>, 4> = {1, 2, 3, 4};
  port out: out UInt<8>;
  let out = coeffs[0] + coeffs[1] + coeffs[2] + coeffs[3];
  ```

## SV codegen

iverilog rejects unpacked-array `parameter`s ('sorry: unpacked array parameters are not supported yet'), so the codegen emits the param **packed**:

  `parameter logic [N*W-1:0] coeffs = {(W)'(4), (W)'(3), (W)'(2), (W)'(1)}`

The literal is reversed so `coeffs[0]` lands at the LSB chunk → matches the user's index-zero element. Reads rewrite to packed part-selects:

  `coeffs[i]` → `coeffs[(i) * (W) +: (W)]`

Sign for SInt elements comes from the param's `signed` declaration; no extra `$signed()` wrap (which iverilog rejects when followed by a bit-select).

## Demo

`tests/cvdp/iir_filter.arch` — replace 13 individual `param a/b` decls with two `Vec<SInt<16>, 7>` params and index them. Combined with the earlier pipe_reg refactor, the file is now ~50 LOC vs the original 100. CVDP cocotb test still PASS.

## Test plan

- [x] 1 new integration test (`vec_of_const_param_emits_packed_and_indexes`)
- [x] CVDP `iir_filter` cocotb test still PASS
- [x] All 182 integration + 20 formal tests pass

## Out of scope (follow-ups)

- Inst-site override (`inst sub: Foo; param B = {…};`) — works for the value-expr Concat path but the inst-emit doesn't yet pack reverse the override. Add when a multi-instance design demands it.
- Sim codegen — current `arch sim` doesn't process Vec params (no test in the corpus uses one in sim yet); add when a simulated design requires it.
- Loop iteration with a non-constant index over pipe_reg taps remains a separate gap; for-loops in comb still emit SV `for`, which is runtime, while `pipe_reg@K` requires compile-time K.