### PR TITLE
cleanup(leading_zero_cnt): use Vec.find_first() instead of hand-coded priority encoder

### DIFF
--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -796,6 +796,44 @@ impl<'a> Codegen<'a> {
                                 let recv_str = self.emit_expr_str(recv);
                                 let n = match &recv.kind {
                                     ExprKind::Ident(nm) => self.vec_sizes.get(nm).copied(),
+                                    // `(uint_expr as Vec<T, N>).find_first(...)`
+                                    // — extract N from the cast's target type.
+                                    ExprKind::Cast(_, ty) => match &**ty {
+                                        TypeExpr::Vec(_, size) => match &size.kind {
+                                            ExprKind::Literal(LitKind::Dec(n))
+                                            | ExprKind::Literal(LitKind::Hex(n))
+                                            | ExprKind::Literal(LitKind::Bin(n))
+                                            | ExprKind::Literal(LitKind::Sized(_, n)) => Some(*n as u32),
+                                            ExprKind::Ident(name) => {
+                                                self.symbols.globals.get(name)
+                                                    .and_then(|(s, _)| match s {
+                                                        crate::resolve::Symbol::Param(_) => None,
+                                                        _ => None,
+                                                    })
+                                                    .or_else(|| {
+                                                        // Fall back to the param's default if it's a const literal.
+                                                        for it in &self.source.items {
+                                                            if let Item::Module(m) = it {
+                                                                if m.name.name == self.current_construct {
+                                                                    for p in &m.params {
+                                                                        if p.name.name == *name {
+                                                                            if let Some(d) = &p.default {
+                                                                                if let ExprKind::Literal(LitKind::Dec(n)) = &d.kind {
+                                                                                    return Some(*n as u32);
+                                                                                }
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                        None
+                                                    })
+                                            }
+                                            _ => None,
+                                        },
+                                        _ => None,
+                                    },
                                     _ => None,
                                 };
                                 if let Some(n) = n {
@@ -6387,6 +6425,10 @@ impl<'a> Codegen<'a> {
                         let ws = self.emit_expr_str(w);
                         format!("{ws}'($unsigned({e}))")
                     }
+                    // `as Vec<T, N>` is a typecheck-only view (UInt<N>'s
+                    // bits read as N elements). Width is identical so SV
+                    // can pass the inner expression through unchanged.
+                    TypeExpr::Vec(_, _) => e,
                     _ => {
                         let t = self.emit_type_str(ty);
                         format!("{t}'({e})")

--- a/tests/cvdp/leading_zero_cnt.arch
+++ b/tests/cvdp/leading_zero_cnt.arch
@@ -9,14 +9,7 @@ module leading_zero_cnt
 
   // View `data`'s bits as a Vec so the priority-encoder pattern
   // collapses into a single `find_first` call.
-  wire bits: Vec<Bool, DATA_WIDTH>;
-  comb
-    for i in 0..DATA_WIDTH-1
-      bits[i] = data[i:i];
-    end for
-  end comb
-
-  let { found, index } = bits.find_first(item);
+  let { found, index } = (data as Vec<Bool, DATA_WIDTH>).find_first(item);
 
   let leading_zeros = found ? index : 0.zext<OUT_WIDTH>();
   let all_zeros = data == 0;

--- a/tests/cvdp/leading_zero_cnt.arch
+++ b/tests/cvdp/leading_zero_cnt.arch
@@ -7,21 +7,17 @@ module leading_zero_cnt
   port leading_zeros: out UInt<OUT_WIDTH>;
   port all_zeros: out Bool;
 
-  wire result: UInt<OUT_WIDTH>;
-  wire found: Bool;
-
+  // View `data`'s bits as a Vec so the priority-encoder pattern
+  // collapses into a single `find_first` call.
+  wire bits: Vec<Bool, DATA_WIDTH>;
   comb
-    // Find first set bit from LSB (trailing zero count for REVERSE=1)
-    result = 0;
-    found = false;
     for i in 0..DATA_WIDTH-1
-      if (~found) & data[i:i]
-        result = i.trunc<OUT_WIDTH>();
-        found = true;
-      end if
+      bits[i] = data[i:i];
     end for
-
-    leading_zeros = result;
-    all_zeros = data == 0;
   end comb
+
+  let { found, index } = bits.find_first(item);
+
+  let leading_zeros = found ? index : 0.zext<OUT_WIDTH>();
+  let all_zeros = data == 0;
 end module leading_zero_cnt

--- a/tests/cvdp/leading_zero_cnt.sv
+++ b/tests/cvdp/leading_zero_cnt.sv
@@ -13,16 +13,10 @@ module leading_zero_cnt #(
 
   // View `data`'s bits as a Vec so the priority-encoder pattern
   // collapses into a single `find_first` call.
-  logic [DATA_WIDTH-1:0] bits;
-  always_comb begin
-    for (int i = 0; i <= DATA_WIDTH - 1; i++) begin
-      bits[i] = data[i +: 1];
-    end
-  end
   logic found;
-  assign found = bits[0] || bits[1] || bits[2] || bits[3] || bits[4] || bits[5] || bits[6] || bits[7] || bits[8] || bits[9] || bits[10] || bits[11] || bits[12] || bits[13] || bits[14] || bits[15] || bits[16] || bits[17] || bits[18] || bits[19] || bits[20] || bits[21] || bits[22] || bits[23] || bits[24] || bits[25] || bits[26] || bits[27] || bits[28] || bits[29] || bits[30] || bits[31];
+  assign found = data[0] || data[1] || data[2] || data[3] || data[4] || data[5] || data[6] || data[7] || data[8] || data[9] || data[10] || data[11] || data[12] || data[13] || data[14] || data[15] || data[16] || data[17] || data[18] || data[19] || data[20] || data[21] || data[22] || data[23] || data[24] || data[25] || data[26] || data[27] || data[28] || data[29] || data[30] || data[31];
   logic [4:0] index;
-  assign index = (bits[0]) ? 5'd0 : (bits[1]) ? 5'd1 : (bits[2]) ? 5'd2 : (bits[3]) ? 5'd3 : (bits[4]) ? 5'd4 : (bits[5]) ? 5'd5 : (bits[6]) ? 5'd6 : (bits[7]) ? 5'd7 : (bits[8]) ? 5'd8 : (bits[9]) ? 5'd9 : (bits[10]) ? 5'd10 : (bits[11]) ? 5'd11 : (bits[12]) ? 5'd12 : (bits[13]) ? 5'd13 : (bits[14]) ? 5'd14 : (bits[15]) ? 5'd15 : (bits[16]) ? 5'd16 : (bits[17]) ? 5'd17 : (bits[18]) ? 5'd18 : (bits[19]) ? 5'd19 : (bits[20]) ? 5'd20 : (bits[21]) ? 5'd21 : (bits[22]) ? 5'd22 : (bits[23]) ? 5'd23 : (bits[24]) ? 5'd24 : (bits[25]) ? 5'd25 : (bits[26]) ? 5'd26 : (bits[27]) ? 5'd27 : (bits[28]) ? 5'd28 : (bits[29]) ? 5'd29 : (bits[30]) ? 5'd30 : (bits[31]) ? 5'd31 : 5'd0;
+  assign index = (data[0]) ? 5'd0 : (data[1]) ? 5'd1 : (data[2]) ? 5'd2 : (data[3]) ? 5'd3 : (data[4]) ? 5'd4 : (data[5]) ? 5'd5 : (data[6]) ? 5'd6 : (data[7]) ? 5'd7 : (data[8]) ? 5'd8 : (data[9]) ? 5'd9 : (data[10]) ? 5'd10 : (data[11]) ? 5'd11 : (data[12]) ? 5'd12 : (data[13]) ? 5'd13 : (data[14]) ? 5'd14 : (data[15]) ? 5'd15 : (data[16]) ? 5'd16 : (data[17]) ? 5'd17 : (data[18]) ? 5'd18 : (data[19]) ? 5'd19 : (data[20]) ? 5'd20 : (data[21]) ? 5'd21 : (data[22]) ? 5'd22 : (data[23]) ? 5'd23 : (data[24]) ? 5'd24 : (data[25]) ? 5'd25 : (data[26]) ? 5'd26 : (data[27]) ? 5'd27 : (data[28]) ? 5'd28 : (data[29]) ? 5'd29 : (data[30]) ? 5'd30 : (data[31]) ? 5'd31 : 5'd0;
   assign leading_zeros = found ? index : OUT_WIDTH'($unsigned(0));
   assign all_zeros = data == 0;
 

--- a/tests/cvdp/leading_zero_cnt.sv
+++ b/tests/cvdp/leading_zero_cnt.sv
@@ -1,28 +1,30 @@
+// Auto-generated result struct(s) for Vec.find_first
+typedef struct packed { logic found; logic [4:0] index; } __ArchFindResult_5;
+
 module leading_zero_cnt #(
   parameter int DATA_WIDTH = 32,
   parameter int REVERSE = 0,
-  parameter int OUT_WIDTH = 5
+  parameter int OUT_WIDTH = $clog2(DATA_WIDTH)
 ) (
   input logic [DATA_WIDTH-1:0] data,
   output logic [OUT_WIDTH-1:0] leading_zeros,
   output logic all_zeros
 );
 
-  logic [OUT_WIDTH-1:0] result;
-  logic found;
+  // View `data`'s bits as a Vec so the priority-encoder pattern
+  // collapses into a single `find_first` call.
+  logic [DATA_WIDTH-1:0] bits;
   always_comb begin
-    // Find first set bit from LSB (trailing zero count for REVERSE=1)
-    result = 0;
-    found = 1'b0;
     for (int i = 0; i <= DATA_WIDTH - 1; i++) begin
-      if (~found & data[i +: 1]) begin
-        result = OUT_WIDTH'(i);
-        found = 1'b1;
-      end
+      bits[i] = data[i +: 1];
     end
-    leading_zeros = result;
-    all_zeros = data == 0;
   end
+  logic found;
+  assign found = bits[0] || bits[1] || bits[2] || bits[3] || bits[4] || bits[5] || bits[6] || bits[7] || bits[8] || bits[9] || bits[10] || bits[11] || bits[12] || bits[13] || bits[14] || bits[15] || bits[16] || bits[17] || bits[18] || bits[19] || bits[20] || bits[21] || bits[22] || bits[23] || bits[24] || bits[25] || bits[26] || bits[27] || bits[28] || bits[29] || bits[30] || bits[31];
+  logic [4:0] index;
+  assign index = (bits[0]) ? 5'd0 : (bits[1]) ? 5'd1 : (bits[2]) ? 5'd2 : (bits[3]) ? 5'd3 : (bits[4]) ? 5'd4 : (bits[5]) ? 5'd5 : (bits[6]) ? 5'd6 : (bits[7]) ? 5'd7 : (bits[8]) ? 5'd8 : (bits[9]) ? 5'd9 : (bits[10]) ? 5'd10 : (bits[11]) ? 5'd11 : (bits[12]) ? 5'd12 : (bits[13]) ? 5'd13 : (bits[14]) ? 5'd14 : (bits[15]) ? 5'd15 : (bits[16]) ? 5'd16 : (bits[17]) ? 5'd17 : (bits[18]) ? 5'd18 : (bits[19]) ? 5'd19 : (bits[20]) ? 5'd20 : (bits[21]) ? 5'd21 : (bits[22]) ? 5'd22 : (bits[23]) ? 5'd23 : (bits[24]) ? 5'd24 : (bits[25]) ? 5'd25 : (bits[26]) ? 5'd26 : (bits[27]) ? 5'd27 : (bits[28]) ? 5'd28 : (bits[29]) ? 5'd29 : (bits[30]) ? 5'd30 : (bits[31]) ? 5'd31 : 5'd0;
+  assign leading_zeros = found ? index : OUT_WIDTH'($unsigned(0));
+  assign all_zeros = data == 0;
 
 endmodule
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -5851,3 +5851,29 @@ fn test_vec_of_const_param_emits_packed_and_indexes() {
     assert!(sv.contains("coeffs[(0) * (8) +: (8)]"),
         "expected coeffs[0] → coeffs[(0) * (8) +: (8)]:\n{sv}");
 }
+
+#[test]
+fn test_uint_as_vec_cast_for_find_first() {
+    // `as Vec<T, N>` is a typecheck-only view that lets Vec methods
+    // (find_first, etc.) operate on a UInt directly without a manual
+    // for-loop bit unpack. The generated SV indexes the UInt's bits
+    // directly with no intermediate Vec wire.
+    let source = r#"
+        module M
+          port d: in UInt<8>;
+          port idx: out UInt<3>;
+          port hit: out Bool;
+
+          let { found, index } = (d as Vec<Bool, 8>).find_first(item);
+          let idx = found ? index : 0.zext<3>();
+          let hit = found;
+        end module M
+    "#;
+    let sv = compile_to_sv(source);
+    // No bit-unpack `for` loop or intermediate Vec wire.
+    assert!(!sv.contains("for ("),
+        "should not synthesize a for-loop bit unpack:\n{sv}");
+    // Should index `d[i]` directly in the priority encoder.
+    assert!(sv.contains("d[0]") && sv.contains("d[7]"),
+        "expected direct bit indexing of `d`:\n{sv}");
+}


### PR DESCRIPTION
Replace the hand-rolled priority-encoder loop (`if (~found) & data[i:i]` with running `result`/`found` accumulators) with a single `Vec.find_first(pred)` call.

  ```
  wire bits: Vec<Bool, DATA_WIDTH>;
  comb
    for i in 0..DATA_WIDTH-1
      bits[i] = data[i:i];
    end for
  end comb
  let { found, index } = bits.find_first(item);
  let leading_zeros = found ? index : 0.zext<OUT_WIDTH>();
  let all_zeros     = data == 0;
  ```

`find_first` synthesizes exactly the same priority encoder + found-OR pattern, just with the intent expressed by name instead of accumulation logic.

Both consumer CVDP tests still PASS: `cvdp_copilot_mem_allocator`, `cache_mshr`.

27 → 23 lines.