### PR TITLE
cleanup(alu_seq): use unique match for opcode dispatch

### DIFF
--- a/tests/cvdp/alu_seq.arch
+++ b/tests/cvdp/alu_seq.arch
@@ -20,23 +20,16 @@ module alu_seq
 
   seq on i_clk rising
     if key_match
-      if i_opcode == 0
-        result <= (i_operand_a.zext<9>() + i_operand_b.zext<9>()).trunc<8>();
-      elsif i_opcode == 1
-        result <= (i_operand_a.zext<9>() - i_operand_b.zext<9>()).trunc<8>();
-      elsif i_opcode == 2
-        result <= (i_operand_a.zext<8>() * i_operand_b.zext<8>()).trunc<8>();
-      elsif i_opcode == 3
-        result <= i_operand_a.zext<8>() & i_operand_b.zext<8>();
-      elsif i_opcode == 4
-        result <= i_operand_a.zext<8>() | i_operand_b.zext<8>();
-      elsif i_opcode == 5
-        result <= (~i_operand_a).zext<8>();
-      elsif i_opcode == 6
-        result <= i_operand_a.zext<8>() ^ i_operand_b.zext<8>();
-      else
-        result <= (~(i_operand_a ^ i_operand_b)).zext<8>();
-      end if
+      unique match i_opcode
+        0 => result <= (i_operand_a.zext<9>() + i_operand_b.zext<9>()).trunc<8>();
+        1 => result <= (i_operand_a.zext<9>() - i_operand_b.zext<9>()).trunc<8>();
+        2 => result <= (i_operand_a.zext<8>() * i_operand_b.zext<8>()).trunc<8>();
+        3 => result <= i_operand_a.zext<8>() & i_operand_b.zext<8>();
+        4 => result <= i_operand_a.zext<8>() | i_operand_b.zext<8>();
+        5 => result <= (~i_operand_a).zext<8>();
+        6 => result <= i_operand_a.zext<8>() ^ i_operand_b.zext<8>();
+        _ => result <= (~(i_operand_a ^ i_operand_b)).zext<8>();
+      end match
     else
       result <= 0;
     end if

--- a/tests/cvdp/alu_seq.sv
+++ b/tests/cvdp/alu_seq.sv
@@ -19,23 +19,32 @@ module alu_seq #(
       result <= 0;
     end else begin
       if (key_match) begin
-        if (i_opcode == 0) begin
-          result <= 8'(9'($unsigned(i_operand_a)) + 9'($unsigned(i_operand_b)));
-        end else if (i_opcode == 1) begin
-          result <= 8'(9'($unsigned(i_operand_a)) - 9'($unsigned(i_operand_b)));
-        end else if (i_opcode == 2) begin
-          result <= 8'(8'($unsigned(i_operand_a)) * 8'($unsigned(i_operand_b)));
-        end else if (i_opcode == 3) begin
-          result <= 8'($unsigned(i_operand_a)) & 8'($unsigned(i_operand_b));
-        end else if (i_opcode == 4) begin
-          result <= 8'($unsigned(i_operand_a)) | 8'($unsigned(i_operand_b));
-        end else if (i_opcode == 5) begin
-          result <= 8'($unsigned(~i_operand_a));
-        end else if (i_opcode == 6) begin
-          result <= 8'($unsigned(i_operand_a)) ^ 8'($unsigned(i_operand_b));
-        end else begin
-          result <= 8'($unsigned(~(i_operand_a ^ i_operand_b)));
-        end
+        unique case (i_opcode)
+          0: begin
+            result <= 8'(9'($unsigned(i_operand_a)) + 9'($unsigned(i_operand_b)));
+          end
+          1: begin
+            result <= 8'(9'($unsigned(i_operand_a)) - 9'($unsigned(i_operand_b)));
+          end
+          2: begin
+            result <= 8'(8'($unsigned(i_operand_a)) * 8'($unsigned(i_operand_b)));
+          end
+          3: begin
+            result <= 8'($unsigned(i_operand_a)) & 8'($unsigned(i_operand_b));
+          end
+          4: begin
+            result <= 8'($unsigned(i_operand_a)) | 8'($unsigned(i_operand_b));
+          end
+          5: begin
+            result <= 8'($unsigned(~i_operand_a));
+          end
+          6: begin
+            result <= 8'($unsigned(i_operand_a)) ^ 8'($unsigned(i_operand_b));
+          end
+          default: begin
+            result <= 8'($unsigned(~(i_operand_a ^ i_operand_b)));
+          end
+        endcase
       end else begin
         result <= 0;
       end


### PR DESCRIPTION
Replace the 8-arm if/elsif chain in `alu_seq.arch` with `unique match i_opcode` — opcode arms are mutually exclusive, so the `unique` hint promotes SV emit from `case` to `unique case` (parallel mux license, not a priority encoder). Source flattens to a table.

44 → 37 lines. CVDP cocotb test still PASS.