### PR TITLE
feat(counter): runtime-programmable max via `port max`

### DIFF
--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -7442,6 +7442,14 @@ impl<'a> Codegen<'a> {
             .and_then(|p| p.default.as_ref())
             .map(|e| self.emit_expr_str(e));
 
+        // Optional runtime-programmable max. Declared as
+        // `port max: in UInt<W>` on the counter; takes precedence over
+        // any compile-time MAX param. Used for wrap target, saturate
+        // ceiling, and the `at_max` comparator.
+        let max_port = c.ports.iter()
+            .find(|p| p.name.name == "max" && matches!(p.direction, Direction::In))
+            .map(|_| "max".to_string());
+
         // Determine counter width
         // Use MAX param if present, else look for WIDTH
         let width_param = c.params.iter()
@@ -7473,17 +7481,21 @@ impl<'a> Codegen<'a> {
         let (rst, is_async, is_low) = Self::extract_reset_info(&c.ports);
 
         // ── Module header ─────────────────────────────────────────────────────
-        self.line(&format!("module {n} #("));
-        self.indent += 1;
-        for (i, p) in c.params.iter().enumerate() {
-            let comma = if i < c.params.len() - 1 { "," } else { "" };
-            let default_str = p.default.as_ref()
-                .map(|e| format!(" = {}", self.emit_expr_str(e)))
-                .unwrap_or_default();
-            self.line(&format!("parameter int {}{default_str}{comma}", p.name.name));
+        if c.params.is_empty() {
+            self.line(&format!("module {n} ("));
+        } else {
+            self.line(&format!("module {n} #("));
+            self.indent += 1;
+            for (i, p) in c.params.iter().enumerate() {
+                let comma = if i < c.params.len() - 1 { "," } else { "" };
+                let default_str = p.default.as_ref()
+                    .map(|e| format!(" = {}", self.emit_expr_str(e)))
+                    .unwrap_or_default();
+                self.line(&format!("parameter int {}{default_str}{comma}", p.name.name));
+            }
+            self.indent -= 1;
+            self.line(") (");
         }
-        self.indent -= 1;
-        self.line(") (");
         self.indent += 1;
 
         let mut all_ports: Vec<String> = Vec::new();
@@ -7529,7 +7541,9 @@ impl<'a> Codegen<'a> {
 
         match (c.direction, c.mode) {
             (CounterDirection::Up, CounterMode::Wrap) => {
-                let max_cond = if max_param.is_some() {
+                let max_cond = if let Some(mp) = &max_port {
+                    format!("count_r == {mp}")
+                } else if max_param.is_some() {
                     format!("count_r == {count_width}'(MAX)")
                 } else {
                     format!("&count_r")  // all bits set
@@ -7544,7 +7558,9 @@ impl<'a> Codegen<'a> {
             }
             (CounterDirection::Down, CounterMode::Wrap) => {
                 let min_cond = "count_r == '0";
-                let max_val = if max_param.is_some() {
+                let max_val = if let Some(mp) = &max_port {
+                    mp.clone()
+                } else if max_param.is_some() {
                     format!("{count_width}'(MAX)")
                 } else {
                     format!("'1")
@@ -7562,7 +7578,9 @@ impl<'a> Codegen<'a> {
                 self.line("else if (dec && !inc) count_r <= count_r - 1;");
             }
             (CounterDirection::Up, CounterMode::Saturate) => {
-                let max_cond = if max_param.is_some() {
+                let max_cond = if let Some(mp) = &max_port {
+                    format!("count_r < {mp}")
+                } else if max_param.is_some() {
                     format!("count_r < {count_width}'(MAX)")
                 } else {
                     format!("!(&count_r)")
@@ -7622,7 +7640,9 @@ impl<'a> Codegen<'a> {
         }
         // at_max
         if c.ports.iter().any(|p| p.name.name == "at_max") {
-            let max_expr = if max_param.is_some() {
+            let max_expr = if let Some(mp) = &max_port {
+                format!("count_r == {mp}")
+            } else if max_param.is_some() {
                 format!("count_r == {count_width}'(MAX)")
             } else {
                 format!("&count_r")
@@ -7638,7 +7658,15 @@ impl<'a> Codegen<'a> {
         {
             self.line("");
             self.line("// synopsys translate_off");
-            if max_param.is_some() {
+            if let Some(mp) = &max_port {
+                // Runtime max — assert against the port value.
+                self.line(&format!(
+                    "_auto_count_range: assert property (@(posedge {clk}) count_r <= {mp})"
+                ));
+                self.line(&format!(
+                    "  else $fatal(1, \"COUNTER OVERFLOW: {n}.count_r > {mp}\");"
+                ));
+            } else if max_param.is_some() {
                 // Use the SV parameter name `MAX` so instantiation overrides are honored.
                 self.line(&format!(
                     "_auto_count_range: assert property (@(posedge {clk}) count_r <= {count_width}'(MAX))"

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -5877,3 +5877,33 @@ fn test_uint_as_vec_cast_for_find_first() {
     assert!(sv.contains("d[0]") && sv.contains("d[7]"),
         "expected direct bit indexing of `d`:\n{sv}");
 }
+
+#[test]
+fn test_counter_runtime_max_port() {
+    // `counter` with a `port max: in UInt<W>` overrides the compile-time
+    // MAX param. Wrap target, saturate ceiling, and `at_max` all consult
+    // the runtime port instead of the const.
+    let source = r#"
+        counter ProgCounter
+          kind wrap;
+          direction: up;
+          init: 0;
+          port clk:    in Clock<SysDomain>;
+          port rst:    in Reset<Async, Low>;
+          port inc:    in Bool;
+          port max:    in UInt<8>;
+          port value:  out UInt<8>;
+          port at_max: out Bool;
+        end counter ProgCounter
+    "#;
+    let sv = compile_to_sv(source);
+    // Wrap compare uses the runtime `max` port, not a const.
+    assert!(sv.contains("count_r == max"),
+        "expected wrap compare against `max` port:\n{sv}");
+    // at_max output mirrors the same compare.
+    assert!(sv.contains("assign at_max = (count_r == max)"),
+        "expected at_max against `max` port:\n{sv}");
+    // No const MAX appears (no MAX param declared).
+    assert!(!sv.contains("'(MAX)"),
+        "should not emit const MAX comparator when port is present:\n{sv}");
+}


### PR DESCRIPTION
Adds an optional `port max: in UInt<W>` to the `counter` construct. When present, the runtime port takes precedence over any compile-time `MAX: const` param. Wrap target, saturate ceiling, and `at_max` output all consult the runtime value. The auto-emitted `_auto_count_range` SVA mirrors the bound.

  ```
  counter ProgCounter
    kind wrap;
    direction: up;
    init: 0;
    port clk:    in Clock<SysDomain>;
    port rst:    in Reset<Async, Low>;
    port inc:    in Bool;
    port max:    in UInt<W>;
    port value:  out UInt<W>;
    port at_max: out Bool;
  end counter ProgCounter
  ```

Use case: register-block style designs where software writes the counter ceiling (AHB clock counters, watchdog timers, etc.) — no more hand-rolled cnt+1 increment + comparator.

Drive-by fix: `emit_counter` no longer emits an empty `#()` parameter block when the counter has zero params (iverilog rejects empty parens as a syntax error).

## Test plan

- [x] 1 new integration test (`counter_runtime_max_port`)
- [x] All 184 integration + 20 formal tests pass
- [x] Existing counters (compile-time MAX) emit identical SV — no regression

## Out of scope

The investigation that prompted this — refactoring `tests/cvdp/ahb_clock_counter.arch` — turned out NOT to fit `counter`'s wrap/saturate semantics: the original is a free-running counter (max only triggers a sticky overflow flag, doesn't bound the count). `counter` always wraps or saturates at max. Adding a `kind plain` mode for free-running counters would be a separate change and isn't motivated by enough designs yet. The compiler enhancement here is still useful on its own for genuine wrap/saturate counters with software-programmable ceilings.