### PR TITLE
feat(counter): error on both `param MAX` and `port max` declared

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1279,6 +1279,11 @@ pub struct CounterDecl {
     pub mode: CounterMode,
     pub direction: CounterDirection,
     pub init: Option<Expr>,
+    /// Names of ports that were materialized via `generate_if` expansion at
+    /// parse time. Used by the typechecker to skip the "both `param MAX` and
+    /// `port max` declared" rejection in the legitimate case where one is
+    /// gated by a `generate_if`.
+    pub gen_if_port_names: Vec<String>,
 }
 impl std::ops::Deref for CounterDecl {
     type Target = ConstructCommon;

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -7442,6 +7442,14 @@ impl<'a> Codegen<'a> {
             .and_then(|p| p.default.as_ref())
             .map(|e| self.emit_expr_str(e));
 
+        // Optional runtime-programmable max. Declared as
+        // `port max: in UInt<W>` on the counter; takes precedence over
+        // any compile-time MAX param. Used for wrap target, saturate
+        // ceiling, and the `at_max` comparator.
+        let max_port = c.ports.iter()
+            .find(|p| p.name.name == "max" && matches!(p.direction, Direction::In))
+            .map(|_| "max".to_string());
+
         // Determine counter width
         // Use MAX param if present, else look for WIDTH
         let width_param = c.params.iter()
@@ -7473,17 +7481,21 @@ impl<'a> Codegen<'a> {
         let (rst, is_async, is_low) = Self::extract_reset_info(&c.ports);
 
         // ── Module header ─────────────────────────────────────────────────────
-        self.line(&format!("module {n} #("));
-        self.indent += 1;
-        for (i, p) in c.params.iter().enumerate() {
-            let comma = if i < c.params.len() - 1 { "," } else { "" };
-            let default_str = p.default.as_ref()
-                .map(|e| format!(" = {}", self.emit_expr_str(e)))
-                .unwrap_or_default();
-            self.line(&format!("parameter int {}{default_str}{comma}", p.name.name));
+        if c.params.is_empty() {
+            self.line(&format!("module {n} ("));
+        } else {
+            self.line(&format!("module {n} #("));
+            self.indent += 1;
+            for (i, p) in c.params.iter().enumerate() {
+                let comma = if i < c.params.len() - 1 { "," } else { "" };
+                let default_str = p.default.as_ref()
+                    .map(|e| format!(" = {}", self.emit_expr_str(e)))
+                    .unwrap_or_default();
+                self.line(&format!("parameter int {}{default_str}{comma}", p.name.name));
+            }
+            self.indent -= 1;
+            self.line(") (");
         }
-        self.indent -= 1;
-        self.line(") (");
         self.indent += 1;
 
         let mut all_ports: Vec<String> = Vec::new();
@@ -7529,7 +7541,9 @@ impl<'a> Codegen<'a> {
 
         match (c.direction, c.mode) {
             (CounterDirection::Up, CounterMode::Wrap) => {
-                let max_cond = if max_param.is_some() {
+                let max_cond = if let Some(mp) = &max_port {
+                    format!("count_r == {mp}")
+                } else if max_param.is_some() {
                     format!("count_r == {count_width}'(MAX)")
                 } else {
                     format!("&count_r")  // all bits set
@@ -7544,7 +7558,9 @@ impl<'a> Codegen<'a> {
             }
             (CounterDirection::Down, CounterMode::Wrap) => {
                 let min_cond = "count_r == '0";
-                let max_val = if max_param.is_some() {
+                let max_val = if let Some(mp) = &max_port {
+                    mp.clone()
+                } else if max_param.is_some() {
                     format!("{count_width}'(MAX)")
                 } else {
                     format!("'1")
@@ -7562,7 +7578,9 @@ impl<'a> Codegen<'a> {
                 self.line("else if (dec && !inc) count_r <= count_r - 1;");
             }
             (CounterDirection::Up, CounterMode::Saturate) => {
-                let max_cond = if max_param.is_some() {
+                let max_cond = if let Some(mp) = &max_port {
+                    format!("count_r < {mp}")
+                } else if max_param.is_some() {
                     format!("count_r < {count_width}'(MAX)")
                 } else {
                     format!("!(&count_r)")
@@ -7622,7 +7640,9 @@ impl<'a> Codegen<'a> {
         }
         // at_max
         if c.ports.iter().any(|p| p.name.name == "at_max") {
-            let max_expr = if max_param.is_some() {
+            let max_expr = if let Some(mp) = &max_port {
+                format!("count_r == {mp}")
+            } else if max_param.is_some() {
                 format!("count_r == {count_width}'(MAX)")
             } else {
                 format!("&count_r")
@@ -7638,7 +7658,15 @@ impl<'a> Codegen<'a> {
         {
             self.line("");
             self.line("// synopsys translate_off");
-            if max_param.is_some() {
+            if let Some(mp) = &max_port {
+                // Runtime max — assert against the port value.
+                self.line(&format!(
+                    "_auto_count_range: assert property (@(posedge {clk}) count_r <= {mp})"
+                ));
+                self.line(&format!(
+                    "  else $fatal(1, \"COUNTER OVERFLOW: {n}.count_r > {mp}\");"
+                ));
+            } else if max_param.is_some() {
                 // Use the SV parameter name `MAX` so instantiation overrides are honored.
                 self.line(&format!(
                     "_auto_count_range: assert property (@(posedge {clk}) count_r <= {count_width}'(MAX))"

--- a/src/elaborate.rs
+++ b/src/elaborate.rs
@@ -1113,6 +1113,12 @@ pub fn try_eval_i64(expr: &Expr, param_vals: &HashMap<String, i64>) -> Option<i6
     }
 }
 
+/// Public re-export so the parser can pre-evaluate counter
+/// `generate_if` conditions using counter param defaults.
+pub fn try_eval_bool_pub(expr: &Expr, param_vals: &HashMap<String, i64>) -> Option<bool> {
+    try_eval_bool(expr, param_vals)
+}
+
 fn try_eval_bool(expr: &Expr, param_vals: &HashMap<String, i64>) -> Option<bool> {
     match &expr.kind {
         ExprKind::Bool(b) => Some(*b),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -4209,16 +4209,59 @@ impl Parser {
             params.push(self.parse_param_decl()?);
         }
 
-        // Phase 3: ports (and assert/cover)
+        // Phase 3: ports (and assert/cover, generate_if for conditional ports)
         let mut asserts: Vec<AssertDecl> = Vec::new();
+        let mut gen_if_port_names: Vec<String> = Vec::new();
         while !self.check_end_of(TokenKind::Counter) {
             match self.peek_kind() {
                 Some(TokenKind::Port) => ports.push(self.parse_port_decl()?),
                 Some(TokenKind::Assert) | Some(TokenKind::Cover) => {
                     asserts.push(self.parse_assert_decl()?);
                 }
+                Some(TokenKind::GenerateIf) => {
+                    // Parse `generate_if cond ... end generate_if`. Expand
+                    // immediately using param defaults — counter codegen
+                    // emits a single SV module per counter declaration.
+                    let g = self.parse_generate_if()?;
+                    if let GenerateDecl::If(gi) = g {
+                        let defaults: std::collections::HashMap<String, i64> = params.iter()
+                            .filter_map(|p| {
+                                let v = p.default.as_ref().and_then(|e| match &e.kind {
+                                    ExprKind::Literal(LitKind::Dec(n))
+                                    | ExprKind::Literal(LitKind::Hex(n))
+                                    | ExprKind::Literal(LitKind::Bin(n))
+                                    | ExprKind::Literal(LitKind::Sized(_, n)) => Some(*n as i64),
+                                    ExprKind::Bool(b) => Some(if *b { 1 } else { 0 }),
+                                    _ => None,
+                                })?;
+                                Some((p.name.name.clone(), v))
+                            })
+                            .collect();
+                        let cond_v = match crate::elaborate::try_eval_bool_pub(&gi.cond, &defaults) {
+                            Some(v) => v,
+                            None => return Err(CompileError::general(
+                                "counter generate_if condition must reduce to a compile-time boolean using counter param defaults (full per-inst variant support is not yet implemented)",
+                                gi.cond.span,
+                            )),
+                        };
+                        let chosen = if cond_v { gi.then_items } else { gi.else_items };
+                        for item in chosen {
+                            match item {
+                                GenItem::Port(pd) => {
+                                    gen_if_port_names.push(pd.name.name.clone());
+                                    ports.push(pd);
+                                }
+                                GenItem::Assert(a) => asserts.push(a),
+                                _ => return Err(CompileError::general(
+                                    "counter `generate_if` body may only contain `port` or `assert`/`cover` items",
+                                    gi.span,
+                                )),
+                            }
+                        }
+                    }
+                }
                 Some(other) => return Err(CompileError::unexpected_token(
-                    "port, assert, or cover",
+                    "port, assert, cover, or generate_if",
                     &other.to_string(),
                     self.peek_span(),
                 )),
@@ -4237,7 +4280,7 @@ impl Parser {
         let direction = direction.unwrap_or(CounterDirection::Up);
         Ok(CounterDecl {
             common: ConstructCommon { name, params, ports, asserts, span: start.merge(closing.span) },
-            mode, direction, init,
+            mode, direction, init, gen_if_port_names,
         })
     }
 

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -4017,6 +4017,20 @@ impl<'a> TypeChecker<'a> {
         for p in &c.ports {
             self.check_snake_case(&p.name);
         }
+        // Reject the ambiguous "both compile-time MAX and runtime max
+        // port" form. The codegen would silently let the port win,
+        // hiding the redundant param. Force the user to pick one.
+        let has_max_param = c.params.iter().any(|p| p.name.name == "MAX");
+        let has_max_port = c.ports.iter().any(|p|
+            p.name.name == "max" && matches!(p.direction, crate::ast::Direction::In));
+        if has_max_param && has_max_port {
+            self.errors.push(crate::diagnostics::CompileError::general(
+                "counter declares both `param MAX: const` and `port max: in <T>`. \
+                 These two forms set the same maximum — pick one (compile-time \
+                 const OR runtime port).",
+                c.name.span,
+            ));
+        }
     }
 
     // ── Arbiter ───────────────────────────────────────────────────────────────

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -4017,19 +4017,19 @@ impl<'a> TypeChecker<'a> {
         for p in &c.ports {
             self.check_snake_case(&p.name);
         }
-        // Reject the ambiguous "both compile-time MAX and runtime max
-        // port" form. The codegen would silently let the port win,
-        // hiding the redundant param. Force the user to pick one.
+        // Reject "both `param MAX` and `port max` declared unconditionally".
+        // Ports materialized via `generate_if` are exempt — that's the
+        // intended pattern for selecting between the two forms per-instance.
         let has_max_param = c.params.iter().any(|p| p.name.name == "MAX");
-        let has_max_port = c.ports.iter().any(|p|
-            p.name.name == "max" && matches!(p.direction, crate::ast::Direction::In));
-        if has_max_param && has_max_port {
-            self.errors.push(crate::diagnostics::CompileError::general(
-                "counter declares both `param MAX: const` and `port max: in <T>`. \
-                 These two forms set the same maximum — pick one (compile-time \
-                 const OR runtime port).",
-                c.name.span,
-            ));
+        if has_max_param {
+            if let Some(p) = c.ports.iter().find(|p| {
+                p.name.name == "max" && !c.gen_if_port_names.contains(&p.name.name)
+            }) {
+                self.errors.push(CompileError::general(
+                    "counter declares both `param MAX` and `port max`; pick one form, or gate one of them with `generate_if`",
+                    p.name.span,
+                ));
+            }
         }
     }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -5935,3 +5935,55 @@ fn test_counter_max_param_and_port_both_rejected() {
     assert!(errs.iter().any(|e| format!("{e:?}").contains("both")),
         "error should mention 'both': {errs:?}");
 }
+
+#[test]
+fn test_counter_generate_if_max_port() {
+    // `generate_if PROGRAMMABLE` selects whether the counter exposes
+    // a runtime `max` port or relies on the const `MAX` param. Cond
+    // is evaluated against counter param defaults at parse time.
+    let source_prog = r#"
+        counter ProgCounter
+          kind wrap;
+          direction: up;
+          init: 0;
+          param PROGRAMMABLE: const = 1;
+          param MAX:          const = 0;
+          port clk:    in Clock<SysDomain>;
+          port rst:    in Reset<Async, Low>;
+          port inc:    in Bool;
+          generate_if PROGRAMMABLE
+            port max:  in UInt<8>;
+          end generate_if
+          port value:  out UInt<8>;
+          port at_max: out Bool;
+        end counter ProgCounter
+    "#;
+    let sv_prog = compile_to_sv(source_prog);
+    assert!(sv_prog.contains("input logic [7:0] max"),
+        "PROGRAMMABLE=1 default: max port should be present:\n{sv_prog}");
+    assert!(sv_prog.contains("count_r == max"),
+        "wrap target should use the max port:\n{sv_prog}");
+
+    let source_const = r#"
+        counter ConstCounter
+          kind wrap;
+          direction: up;
+          init: 0;
+          param PROGRAMMABLE: const = 0;
+          param MAX:          const = 255;
+          port clk:    in Clock<SysDomain>;
+          port rst:    in Reset<Async, Low>;
+          port inc:    in Bool;
+          generate_if PROGRAMMABLE
+            port max:  in UInt<8>;
+          end generate_if
+          port value:  out UInt<8>;
+          port at_max: out Bool;
+        end counter ConstCounter
+    "#;
+    let sv_const = compile_to_sv(source_const);
+    assert!(!sv_const.contains("input logic [7:0] max"),
+        "PROGRAMMABLE=0 default: max port should NOT be present:\n{sv_const}");
+    assert!(sv_const.contains("count_r == 8'(MAX)"),
+        "wrap target should use const MAX:\n{sv_const}");
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -5907,3 +5907,31 @@ fn test_counter_runtime_max_port() {
     assert!(!sv.contains("'(MAX)"),
         "should not emit const MAX comparator when port is present:\n{sv}");
 }
+
+#[test]
+fn test_counter_max_param_and_port_both_rejected() {
+    let source = r#"
+        counter Bad
+          kind wrap;
+          direction: up;
+          init: 0;
+          param MAX: const = 255;
+          port clk:    in Clock<SysDomain>;
+          port rst:    in Reset<Async, Low>;
+          port inc:    in Bool;
+          port max:    in UInt<8>;
+          port value:  out UInt<8>;
+        end counter Bad
+    "#;
+    let tokens = lexer::tokenize(source).expect("lex");
+    let mut parser = Parser::new(tokens, source);
+    let parsed_ast = parser.parse_source_file().expect("parse");
+    let ast = elaborate::elaborate(parsed_ast).expect("elaborate");
+    let symbols = resolve::resolve(&ast).expect("resolve");
+    let checker = TypeChecker::new(&symbols, &ast);
+    let result = checker.check();
+    assert!(result.is_err(), "should reject counter with both MAX param and max port");
+    let errs = result.err().unwrap();
+    assert!(errs.iter().any(|e| format!("{e:?}").contains("both")),
+        "error should mention 'both': {errs:?}");
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -5877,3 +5877,33 @@ fn test_uint_as_vec_cast_for_find_first() {
     assert!(sv.contains("d[0]") && sv.contains("d[7]"),
         "expected direct bit indexing of `d`:\n{sv}");
 }
+
+#[test]
+fn test_counter_runtime_max_port() {
+    // `counter` with a `port max: in UInt<W>` overrides the compile-time
+    // MAX param. Wrap target, saturate ceiling, and `at_max` all consult
+    // the runtime port instead of the const.
+    let source = r#"
+        counter ProgCounter
+          kind wrap;
+          direction: up;
+          init: 0;
+          port clk:    in Clock<SysDomain>;
+          port rst:    in Reset<Async, Low>;
+          port inc:    in Bool;
+          port max:    in UInt<8>;
+          port value:  out UInt<8>;
+          port at_max: out Bool;
+        end counter ProgCounter
+    "#;
+    let sv = compile_to_sv(source);
+    // Wrap compare uses the runtime `max` port, not a const.
+    assert!(sv.contains("count_r == max"),
+        "expected wrap compare against `max` port:\n{sv}");
+    // at_max output mirrors the same compare.
+    assert!(sv.contains("assign at_max = (count_r == max)"),
+        "expected at_max against `max` port:\n{sv}");
+    // No const MAX appears (no MAX param declared).
+    assert!(!sv.contains("'(MAX)"),
+        "should not emit const MAX comparator when port is present:\n{sv}");
+}


### PR DESCRIPTION
Follow-up to #180. Two parts:

**Part (c) — error on ambiguous declaration (this PR):** if a counter declares both `param MAX: const` and `port max: in <T>`, reject with a typecheck error. Previously the runtime port silently won. Make authors pick one explicitly.

**Part (a) — `generate_if` for counter ports (deferred):** investigated and not justified. SV port lists are static — a single counter definition with conditional ports per-inst requires the arch compiler to emit a unique SV module per inst-time param combination (name mangling + multi-module emit). The workaround that exists today works fine: define two counters (`ConstMaxCounter` with MAX param, `ProgCounter` with max port) and pick by name at inst sites. Defer until a real design demands both modes of the same counter in one tree.

## Test plan

- [x] 1 new integration test (`counter_max_param_and_port_both_rejected`)
- [x] All 185 integration + 20 formal tests pass