### PR TITLE
cleanup(counter): drop `param MAX` — use `port max` only

### DIFF
--- a/examples/dma_engine.arch
+++ b/examples/dma_engine.arch
@@ -88,11 +88,11 @@ counter BeatCounter
   kind       wrap;
   direction: up;
   init: 0;
-  param MAX: const = 255;
   port clk:    in Clock<SysDomain>;
   port rst:    in Reset<Sync>;
   port inc:    in Bool;
   port clear:  in Bool;
+  port max:    in UInt<8>;
   port value:  out UInt<8>;
   port at_max: out Bool;
 end counter BeatCounter
@@ -257,6 +257,7 @@ module DmaEngine
     rst    <- rst;
     inc    <- read_fired;
     clear  <- read_done;
+    max    <- 8'd255;
     value  -> read_val;
     at_max -> read_at_max_r;
   end inst read_ctr
@@ -266,6 +267,7 @@ module DmaEngine
     rst    <- rst;
     inc    <- beat_fired;
     clear  <- all_done;
+    max    <- 8'd255;
     value  -> beat_val;
     at_max -> at_max_r;
   end inst beat

--- a/examples/wrap_counter.arch
+++ b/examples/wrap_counter.arch
@@ -6,10 +6,10 @@ counter WrapCounter
   kind wrap;
   direction: up;
   init: 0;
-  param MAX: const = 15;
   port clk: in Clock<SysDomain>;
   port rst: in Reset<Sync>;
   port inc: in Bool;
+  port max: in UInt<4>;
   port value: out UInt<4>;
   port at_max: out Bool;
 end counter WrapCounter

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1279,11 +1279,6 @@ pub struct CounterDecl {
     pub mode: CounterMode,
     pub direction: CounterDirection,
     pub init: Option<Expr>,
-    /// Names of ports that were materialized via `generate_if` expansion at
-    /// parse time. Used by the typechecker to skip the "both `param MAX` and
-    /// `port max` declared" rejection in the legitimate case where one is
-    /// gated by a `generate_if`.
-    pub gen_if_port_names: Vec<String>,
 }
 impl std::ops::Deref for CounterDecl {
     type Target = ConstructCommon;

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -7436,16 +7436,11 @@ impl<'a> Codegen<'a> {
 
         let n = &c.name.name.clone();
 
-        // Find relevant params
-        let max_param = c.params.iter()
-            .find(|p| p.name.name == "MAX")
-            .and_then(|p| p.default.as_ref())
-            .map(|e| self.emit_expr_str(e));
-
-        // Optional runtime-programmable max. Declared as
-        // `port max: in UInt<W>` on the counter; takes precedence over
-        // any compile-time MAX param. Used for wrap target, saturate
-        // ceiling, and the `at_max` comparator.
+        // Optional max signal. Declared as `port max: in UInt<W>` on the
+        // counter; used for wrap target, saturate ceiling, and the `at_max`
+        // comparator. Callers tie it off to a constant for fixed-max counters
+        // (synthesis folds it). When absent, the counter wraps at the natural
+        // width bound (all-ones).
         let max_port = c.ports.iter()
             .find(|p| p.name.name == "max" && matches!(p.direction, Direction::In))
             .map(|_| "max".to_string());
@@ -7543,8 +7538,6 @@ impl<'a> Codegen<'a> {
             (CounterDirection::Up, CounterMode::Wrap) => {
                 let max_cond = if let Some(mp) = &max_port {
                     format!("count_r == {mp}")
-                } else if max_param.is_some() {
-                    format!("count_r == {count_width}'(MAX)")
                 } else {
                     format!("&count_r")  // all bits set
                 };
@@ -7560,8 +7553,6 @@ impl<'a> Codegen<'a> {
                 let min_cond = "count_r == '0";
                 let max_val = if let Some(mp) = &max_port {
                     mp.clone()
-                } else if max_param.is_some() {
-                    format!("{count_width}'(MAX)")
                 } else {
                     format!("'1")
                 };
@@ -7580,8 +7571,6 @@ impl<'a> Codegen<'a> {
             (CounterDirection::Up, CounterMode::Saturate) => {
                 let max_cond = if let Some(mp) = &max_port {
                     format!("count_r < {mp}")
-                } else if max_param.is_some() {
-                    format!("count_r < {count_width}'(MAX)")
                 } else {
                     format!("!(&count_r)")
                 };
@@ -7642,8 +7631,6 @@ impl<'a> Codegen<'a> {
         if c.ports.iter().any(|p| p.name.name == "at_max") {
             let max_expr = if let Some(mp) = &max_port {
                 format!("count_r == {mp}")
-            } else if max_param.is_some() {
-                format!("count_r == {count_width}'(MAX)")
             } else {
                 format!("&count_r")
             };
@@ -7659,20 +7646,11 @@ impl<'a> Codegen<'a> {
             self.line("");
             self.line("// synopsys translate_off");
             if let Some(mp) = &max_port {
-                // Runtime max — assert against the port value.
                 self.line(&format!(
                     "_auto_count_range: assert property (@(posedge {clk}) count_r <= {mp})"
                 ));
                 self.line(&format!(
                     "  else $fatal(1, \"COUNTER OVERFLOW: {n}.count_r > {mp}\");"
-                ));
-            } else if max_param.is_some() {
-                // Use the SV parameter name `MAX` so instantiation overrides are honored.
-                self.line(&format!(
-                    "_auto_count_range: assert property (@(posedge {clk}) count_r <= {count_width}'(MAX))"
-                ));
-                self.line(&format!(
-                    "  else $fatal(1, \"COUNTER OVERFLOW: {n}.count_r > MAX\");"
                 ));
             }
             self.line("// synopsys translate_on");

--- a/src/elaborate.rs
+++ b/src/elaborate.rs
@@ -1113,12 +1113,6 @@ pub fn try_eval_i64(expr: &Expr, param_vals: &HashMap<String, i64>) -> Option<i6
     }
 }
 
-/// Public re-export so the parser can pre-evaluate counter
-/// `generate_if` conditions using counter param defaults.
-pub fn try_eval_bool_pub(expr: &Expr, param_vals: &HashMap<String, i64>) -> Option<bool> {
-    try_eval_bool(expr, param_vals)
-}
-
 fn try_eval_bool(expr: &Expr, param_vals: &HashMap<String, i64>) -> Option<bool> {
     match &expr.kind {
         ExprKind::Bool(b) => Some(*b),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -4209,59 +4209,16 @@ impl Parser {
             params.push(self.parse_param_decl()?);
         }
 
-        // Phase 3: ports (and assert/cover, generate_if for conditional ports)
+        // Phase 3: ports (and assert/cover)
         let mut asserts: Vec<AssertDecl> = Vec::new();
-        let mut gen_if_port_names: Vec<String> = Vec::new();
         while !self.check_end_of(TokenKind::Counter) {
             match self.peek_kind() {
                 Some(TokenKind::Port) => ports.push(self.parse_port_decl()?),
                 Some(TokenKind::Assert) | Some(TokenKind::Cover) => {
                     asserts.push(self.parse_assert_decl()?);
                 }
-                Some(TokenKind::GenerateIf) => {
-                    // Parse `generate_if cond ... end generate_if`. Expand
-                    // immediately using param defaults — counter codegen
-                    // emits a single SV module per counter declaration.
-                    let g = self.parse_generate_if()?;
-                    if let GenerateDecl::If(gi) = g {
-                        let defaults: std::collections::HashMap<String, i64> = params.iter()
-                            .filter_map(|p| {
-                                let v = p.default.as_ref().and_then(|e| match &e.kind {
-                                    ExprKind::Literal(LitKind::Dec(n))
-                                    | ExprKind::Literal(LitKind::Hex(n))
-                                    | ExprKind::Literal(LitKind::Bin(n))
-                                    | ExprKind::Literal(LitKind::Sized(_, n)) => Some(*n as i64),
-                                    ExprKind::Bool(b) => Some(if *b { 1 } else { 0 }),
-                                    _ => None,
-                                })?;
-                                Some((p.name.name.clone(), v))
-                            })
-                            .collect();
-                        let cond_v = match crate::elaborate::try_eval_bool_pub(&gi.cond, &defaults) {
-                            Some(v) => v,
-                            None => return Err(CompileError::general(
-                                "counter generate_if condition must reduce to a compile-time boolean using counter param defaults (full per-inst variant support is not yet implemented)",
-                                gi.cond.span,
-                            )),
-                        };
-                        let chosen = if cond_v { gi.then_items } else { gi.else_items };
-                        for item in chosen {
-                            match item {
-                                GenItem::Port(pd) => {
-                                    gen_if_port_names.push(pd.name.name.clone());
-                                    ports.push(pd);
-                                }
-                                GenItem::Assert(a) => asserts.push(a),
-                                _ => return Err(CompileError::general(
-                                    "counter `generate_if` body may only contain `port` or `assert`/`cover` items",
-                                    gi.span,
-                                )),
-                            }
-                        }
-                    }
-                }
                 Some(other) => return Err(CompileError::unexpected_token(
-                    "port, assert, cover, or generate_if",
+                    "port, assert, or cover",
                     &other.to_string(),
                     self.peek_span(),
                 )),
@@ -4280,7 +4237,7 @@ impl Parser {
         let direction = direction.unwrap_or(CounterDirection::Up);
         Ok(CounterDecl {
             common: ConstructCommon { name, params, ports, asserts, span: start.merge(closing.span) },
-            mode, direction, init, gen_if_port_names,
+            mode, direction, init,
         })
     }
 

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -4017,20 +4017,6 @@ impl<'a> TypeChecker<'a> {
         for p in &c.ports {
             self.check_snake_case(&p.name);
         }
-        // Reject "both `param MAX` and `port max` declared unconditionally".
-        // Ports materialized via `generate_if` are exempt — that's the
-        // intended pattern for selecting between the two forms per-instance.
-        let has_max_param = c.params.iter().any(|p| p.name.name == "MAX");
-        if has_max_param {
-            if let Some(p) = c.ports.iter().find(|p| {
-                p.name.name == "max" && !c.gen_if_port_names.contains(&p.name.name)
-            }) {
-                self.errors.push(CompileError::general(
-                    "counter declares both `param MAX` and `port max`; pick one form, or gate one of them with `generate_if`",
-                    p.name.span,
-                ));
-            }
-        }
     }
 
     // ── Arbiter ───────────────────────────────────────────────────────────────

--- a/tests/buf_mgr/buf_mgr.arch
+++ b/tests/buf_mgr/buf_mgr.arch
@@ -62,6 +62,7 @@ module BufMgr
     clk   <- clk;
     rst   <- rst or setup_at_max;
     inc   <- fl_do_prefetch;
+    max   <- 14'd16383;
     value -> fl_rd_ptr_val;
   end inst fl_rd_ctr
 
@@ -69,6 +70,7 @@ module BufMgr
     clk   <- clk;
     rst   <- rst or (setup_at_max and not setup_done);
     inc   <- dq2_valid;
+    max   <- 14'd16383;
     value -> fl_wr_ptr_val;
   end inst fl_wr_ctr
 
@@ -166,6 +168,7 @@ module BufMgr
     clk    <- clk;
     rst    <- rst;
     inc    <- not setup_done;
+    max    <- 14'd16383;
     value  -> setup_ctr_val;
     at_max -> setup_at_max;
   end inst setup_ctr

--- a/tests/buf_mgr/setup_counter.arch
+++ b/tests/buf_mgr/setup_counter.arch
@@ -4,10 +4,10 @@ counter SetupCounter
   kind wrap;
   direction: up;
   init: 0;
-  param MAX: const = 16383;
   port clk: in Clock<SysDomain>;
   port rst: in Reset<Sync>;
   port inc: in Bool;
+  port max: in UInt<14>;
   port value: out UInt<14>;
   port at_max: out Bool;
 end counter SetupCounter

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -330,7 +330,7 @@ fn test_wrap_counter() {
     let source = include_str!("../examples/wrap_counter.arch");
     let sv = compile_to_sv(source);
     assert!(sv.contains("module WrapCounter"));
-    assert!(sv.contains("parameter int MAX = 15"));
+    assert!(sv.contains("input logic [3:0] max"));
     assert!(sv.contains("logic [3:0] count_r"));
     assert!(sv.contains("always_ff @(posedge clk)"));
     assert!(sv.contains("assign value = count_r"));
@@ -5908,82 +5908,3 @@ fn test_counter_runtime_max_port() {
         "should not emit const MAX comparator when port is present:\n{sv}");
 }
 
-#[test]
-fn test_counter_max_param_and_port_both_rejected() {
-    let source = r#"
-        counter Bad
-          kind wrap;
-          direction: up;
-          init: 0;
-          param MAX: const = 255;
-          port clk:    in Clock<SysDomain>;
-          port rst:    in Reset<Async, Low>;
-          port inc:    in Bool;
-          port max:    in UInt<8>;
-          port value:  out UInt<8>;
-        end counter Bad
-    "#;
-    let tokens = lexer::tokenize(source).expect("lex");
-    let mut parser = Parser::new(tokens, source);
-    let parsed_ast = parser.parse_source_file().expect("parse");
-    let ast = elaborate::elaborate(parsed_ast).expect("elaborate");
-    let symbols = resolve::resolve(&ast).expect("resolve");
-    let checker = TypeChecker::new(&symbols, &ast);
-    let result = checker.check();
-    assert!(result.is_err(), "should reject counter with both MAX param and max port");
-    let errs = result.err().unwrap();
-    assert!(errs.iter().any(|e| format!("{e:?}").contains("both")),
-        "error should mention 'both': {errs:?}");
-}
-
-#[test]
-fn test_counter_generate_if_max_port() {
-    // `generate_if PROGRAMMABLE` selects whether the counter exposes
-    // a runtime `max` port or relies on the const `MAX` param. Cond
-    // is evaluated against counter param defaults at parse time.
-    let source_prog = r#"
-        counter ProgCounter
-          kind wrap;
-          direction: up;
-          init: 0;
-          param PROGRAMMABLE: const = 1;
-          param MAX:          const = 0;
-          port clk:    in Clock<SysDomain>;
-          port rst:    in Reset<Async, Low>;
-          port inc:    in Bool;
-          generate_if PROGRAMMABLE
-            port max:  in UInt<8>;
-          end generate_if
-          port value:  out UInt<8>;
-          port at_max: out Bool;
-        end counter ProgCounter
-    "#;
-    let sv_prog = compile_to_sv(source_prog);
-    assert!(sv_prog.contains("input logic [7:0] max"),
-        "PROGRAMMABLE=1 default: max port should be present:\n{sv_prog}");
-    assert!(sv_prog.contains("count_r == max"),
-        "wrap target should use the max port:\n{sv_prog}");
-
-    let source_const = r#"
-        counter ConstCounter
-          kind wrap;
-          direction: up;
-          init: 0;
-          param PROGRAMMABLE: const = 0;
-          param MAX:          const = 255;
-          port clk:    in Clock<SysDomain>;
-          port rst:    in Reset<Async, Low>;
-          port inc:    in Bool;
-          generate_if PROGRAMMABLE
-            port max:  in UInt<8>;
-          end generate_if
-          port value:  out UInt<8>;
-          port at_max: out Bool;
-        end counter ConstCounter
-    "#;
-    let sv_const = compile_to_sv(source_const);
-    assert!(!sv_const.contains("input logic [7:0] max"),
-        "PROGRAMMABLE=0 default: max port should NOT be present:\n{sv_const}");
-    assert!(sv_const.contains("count_r == 8'(MAX)"),
-        "wrap target should use const MAX:\n{sv_const}");
-}

--- a/tests/snapshots/integration_test__wrap_counter.snap
+++ b/tests/snapshots/integration_test__wrap_counter.snap
@@ -5,12 +5,11 @@ expression: sv
 // domain SysDomain
 //   freq_mhz: 100
 
-module WrapCounter #(
-  parameter int MAX = 15
-) (
+module WrapCounter (
   input logic clk,
   input logic rst,
   input logic inc,
+  input logic [3:0] max,
   output logic [3:0] value,
   output logic at_max
 );
@@ -19,16 +18,16 @@ module WrapCounter #(
   always_ff @(posedge clk) begin
     if (rst) count_r <= 0;
     else if (inc) begin
-      if (count_r == 4'(MAX)) count_r <= 0;
+      if (count_r == max) count_r <= 0;
       else count_r <= count_r + 1;
     end
   end
   assign value = count_r;
-  assign at_max = (count_r == 4'(MAX));
+  assign at_max = (count_r == max);
   
   // synopsys translate_off
-  _auto_count_range: assert property (@(posedge clk) count_r <= 4'(MAX))
-    else $fatal(1, "COUNTER OVERFLOW: WrapCounter.count_r > MAX");
+  _auto_count_range: assert property (@(posedge clk) count_r <= max)
+    else $fatal(1, "COUNTER OVERFLOW: WrapCounter.count_r > max");
   // synopsys translate_on
 
 endmodule


### PR DESCRIPTION
## Summary
- Removes dual-form counter max (`param MAX` vs `port max`); callers always wire `port max`, synthesis folds constant tie-offs identically to a `localparam`.
- Collapses three special cases: `param MAX` codegen branches, the "both forms declared" typecheck error, and the `generate_if`-in-counter plumbing that existed only to disambiguate the two forms.
- Migrates the 3 `.arch` files using `param MAX` (examples/wrap_counter, examples/dma_engine, tests/buf_mgr/setup_counter) and their inst sites.

Net **−188 / +23 lines**.

## Test plan
- [x] `cargo test --test integration_test` — 185/185 pass
- [x] Snapshot for `wrap_counter` updated