### PR TITLE
fix(thread): for-loop-in-then-branch redirect + proof update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,7 +75,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arch"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "clap",
  "insta",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arch"
-version = "0.45.0"
+version = "0.46.0"
 edition = "2021"
 description = "Compiler for the ARCH hardware description language"
 license = "LGPL-3.0-or-later"

--- a/doc/thread_lowering_proof.md
+++ b/doc/thread_lowering_proof.md
@@ -824,16 +824,24 @@ internal waits is encountered:
    ```
 3. **Recursively partition** `then_stmts` and append at index `then_base`.
 4. **Recursively partition** `else_stmts` and append at index `else_base`.
-5. **Redirect each branch's exit** to the rejoin index `rejoin_idx =
+5. **Pre-redirect rewrite (since v0.46.0).**  Walk the then-branch states
+   and rewrite any `multi_transitions` target equal to `then_base + then_len
+   = else_base` to `rejoin_idx`.  This catches sentinel-resolved targets
+   (for-loop exits, nested if/else rejoin points) that landed at
+   `else_base` after outer shifting.  The else-branch is symmetric and
+   self-correcting — its `else_base + else_len = rejoin_idx` already.
+
+6. **Redirect each branch's exit** to the rejoin index `rejoin_idx =
    states.len()`.  Concretely, `redirect_fallthrough_to(branch, rejoin_idx)`
    modifies the *last* state of the branch so that its natural advance lands
    at `rejoin_idx`.  As implemented in `src/elaborate.rs::redirect_fallthrough_to`,
    four cases are handled in this priority order:
    - **(A) M-state** (`M ≠ ∅`): append `(true, rejoin_idx)` to `M` only if
      no existing `t_j` already equals `rejoin_idx`; otherwise no change.
-     ⚠️ This case has a **known corner-case bug** when an existing target
-     points at the position immediately after the branch (for-loop sentinel
-     in then-branch with non-empty else); see §II.10.4.
+     After step 5, any target that *would* have pointed past the branch
+     into the else-branch's start has been rewritten to `rejoin_idx`, so
+     the no-change path is taken whenever the branch ends with a for-loop
+     or nested if/else.
    - **(B) τ-state** (`τ = c`, `M = ∅`): take `c`, replace with
      `M = [(c, rejoin_idx)]` (clears `τ`).
    - **(C) wait_cycles state** (`w = n`, `τ = ⊥`, `M = ∅`): replace with
@@ -843,7 +851,7 @@ internal waits is encountered:
      "Counter-decrement hoist").
    - **(D) unconditional advance** (`τ = ⊥`, `w = ⊥`, `M = ∅`): replace
      with `M = [(true, rejoin_idx)]`.
-6. The dispatch state itself does not advance via the default `next = s+1`;
+7. The dispatch state itself does not advance via the default `next = s+1`;
    `transition_logic` recognises that a state with `M ≠ ∅` always uses the
    `M`-list, so `S_disp.M` overrides any default.
 
@@ -915,25 +923,30 @@ step 5):
   the partitioning invariant (§II.4) the predecessor state preloads
   `_cnt ← n − 1`; the decrement (hoisted out — see §II.10.5) fires every
   cycle in the wait state.
-- **(A) Last state already had `M`**: append `(true, rejoin_idx)` only if
-  no existing `t_j` equals `rejoin_idx`.  This case arises when:
-  - The branch ends with a `for` loop *whose `usize::MAX` exit-sentinel
-    was resolved to `rejoin_idx` directly*.  This holds when the for-loop
-    is at the end of the **else** branch, because `else_base + else_len =
-    rejoin_idx`.  In this case the existing `(exit_cond, rejoin_idx)`
-    arm already targets `rejoin_idx`, the redirect is a no-op, and the
-    for-exit naturally lands at `rejoin_idx`.  Source: for-loop exit on
-    the last iteration falls through to the post-`if` statements.  Target:
-    same.
-  - The branch ends with a `for` loop *in the **then** branch with a
-    non-empty else branch*.  Here the sentinel resolves to
-    `then_base + then_len = else_base ≠ rejoin_idx`, so the redirect
-    appends `(true, rejoin_idx)`.  ⚠️ **This case is currently broken in
-    the implementation** — see §II.10.4 "for-loop-in-then-branch
-    asymmetry".
+- **(A) Last state already had `M`** (e.g. for-loop exit, nested if/else
+  rejoin): the pre-redirect rewrite (§II.10.2 step 5) has already
+  rewritten any target equal to `else_base` (the natural "next position
+  after the then-branch") to `rejoin_idx`.  After this rewrite, at least
+  one `M`-entry already targets `rejoin_idx`, so `redirect_fallthrough_to`
+  case (A) takes the no-change path.
+  - **Symmetric for-loop case (else branch)**: `else_base + else_len =
+    rejoin_idx`, so the for-loop's `(exit_cond, usize::MAX)` sentinel
+    naturally resolves to `rejoin_idx` and the pre-redirect rewrite is
+    a no-op for the else-branch.
+  - **Asymmetric for-loop case (then branch)**: as described above, the
+    sentinel resolves to `else_base` after outer shifting; the
+    pre-redirect rewrite catches this and remaps to `rejoin_idx`.
+  - **Nested if/else case**: the inner if/else's redirect rewrites its
+    own branches' last states to point at the inner `rejoin_idx`.  When
+    the inner if/else is the last stmt of the outer then-branch, the
+    inner `rejoin_idx` (relative) lands at `else_base` (absolute) after
+    outer shifting; same fix applies.
 
-For sub-cases (D), (B), (C), and the well-behaved part of (A), `≈_if` is
-preserved across the rejoin transition.
+  Source semantics: in all three sub-cases the branch ends and control
+  flows to the post-`if` statements.  Target semantics with the
+  pre-redirect rewrite: same.
+
+In all four sub-cases, `≈_if` is preserved across the rejoin transition.
 
 **Case (Eq) — outside the if/else.** Steps before reaching the dispatch
 barrier and after rejoin are governed by Lemma 2 of §II.3 unchanged
@@ -968,10 +981,11 @@ on the *post-flush* register values, matching the source semantics where
 effect at the previous clock edge."  Without this flush, `cond` would read
 stale register values, breaking equivalence.
 
-**⚠️ For-loop-in-then-branch asymmetry (known bug as of v0.45.0).**  When
-a `for` loop is the *last* statement of the **then** branch and the
-**else** branch is non-empty, the dispatch-and-rejoin lowering produces
-incorrect SV.  The mechanism:
+**For-loop-in-then-branch asymmetry (resolved in v0.46.0).**  Earlier
+versions (v0.45.0) had a corner-case bug: when a `for` loop was the
+*last* statement of the **then** branch and the **else** branch was
+non-empty, the dispatch-and-rejoin lowering produced incorrect SV.  The
+mechanism:
 
 - Inside the recursive `partition_thread_body(then_stmts)` call,
   `lower_thread_for` emits the for-loop's last state with
@@ -980,41 +994,38 @@ incorrect SV.  The mechanism:
   `usize::MAX → for_base + for_len`, which equals the position right after
   the for-loop within the recursive call's frame.
 - The outer IfElse handler then shifts every target by `then_base`, so the
-  exit target becomes `then_base + then_len = else_base` (the start of the
+  exit target became `then_base + then_len = else_base` (the start of the
   else branch).
-- `redirect_fallthrough_to` inspects the for-loop's last state, sees
-  `M = [(loop_cond, then_base), (exit_cond, else_base)]`, and finds no
-  existing target equals `rejoin_idx`.  Per case (A), it appends
-  `(true, rejoin_idx)`.
-- The resulting M is `[(loop_cond, then_base), (exit_cond, else_base),
-  (true, rejoin_idx)]`.  Under ARCH `seq` last-write-wins semantics, the
-  unconditional `(true, rejoin_idx)` arm always overrides the loop-back,
-  so the for-loop body executes exactly once and control jumps to the
-  post-`if` regardless of `loop_cnt`.
+- `redirect_fallthrough_to` (case A) appended `(true, rejoin_idx)` because
+  no existing target equalled `rejoin_idx`.  Under ARCH `seq`
+  last-write-wins, the unconditional arm always overrode the loop-back,
+  so the for-loop body executed exactly once.
 
-Symmetric case: a for-loop at the end of the **else** branch is handled
-correctly because `else_base + else_len = rejoin_idx`, so the existing
-`(exit_cond, rejoin_idx)` arm matches the redirect's target check and no
-spurious arm is appended.
+The else-branch is symmetric and self-correcting because
+`else_base + else_len = rejoin_idx`, so its sentinels naturally land at
+`rejoin_idx`.
 
-**Suggested fix** (out of scope for this proof; flagged for the
-implementation to address): in the IfElse handler, after computing
-`rejoin_idx`, walk all targets in `then_states` (and `else_states`) that
-equal `then_base + then_len` (resp. `else_base + else_len`) and rewrite
-them to `rejoin_idx`.  This eliminates the asymmetry: any sentinel-derived
-"next state after this branch" target lands directly at the post-`if`
-position.  The `redirect_fallthrough_to` case (A) then becomes a true
-no-op because the for-exit is already correctly routed.
+**The fix (v0.46.0).**  §II.10.2 step 5 (the pre-redirect rewrite) walks
+the then-branch states *after* outer shifting and rewrites any target
+equal to `else_base` to `rejoin_idx`.  Any sentinel-derived "next state
+after this branch" target then lands directly at the post-`if` position,
+and `redirect_fallthrough_to` case (A) becomes a no-op for branches that
+end with a for-loop (or nested if/else, which has the same symptom for
+the same reason).  Same-level recursion at every nesting depth means the
+fix composes through arbitrarily deep nested if/else and for-loops.
 
-**Empirical confirmation.**  A minimal reproducer
-(`tests/check_if_wait_for.arch` during proof review) generates state-4 SV
-of the form:
+**Empirical confirmation (post-fix).**  The reproducer
+`tests/if_wait_for_in_then.arch` plus testbench
+`tests/if_wait_for_in_then_tb.cpp` (used during the bug review and fix
+verification) produce 4 `done` pulses for `burst = 4`, matching the
+expected loop-iteration count, with state-4 SV of the form:
 ```sv
-if (loop_cnt < end) state <= 3;     // loop-back
-if (loop_cnt >= end) state <= 5;    // → else_base, NOT rejoin
-if (1'b1) state <= 6;               // → rejoin (always overrides above)
+if (loop_cnt < burst-1) state <= 3;    // loop-back
+if (loop_cnt >= burst-1) state <= 6;   // → rejoin (CORRECT)
 ```
-The for-loop body executes exactly once instead of `end` times.
+Regression test: `tests/integration_test.rs::test_if_wait_for_in_then_branch`
+asserts the absence of the buggy `if (1'b1) state <= …` arm and presence
+of the correct exit comparison.
 
 **Empty branches.** If `then_stmts = []` (vacuous then), the recursive
 `partition_thread_body([])` returns no states; `then_base = else_base` and
@@ -1055,11 +1066,14 @@ Tests covering: (a) wait in then-branch only, (b) wait in else-branch only,
 (`test_if_wait_*` family).  End-to-end Verilator `--assert` golden + mutation
 runs confirm the dispatch-state branch assertions are load-bearing.
 
-**Coverage gap.** The current test suite does **not** cover the
-for-loop-in-then-branch case described in §II.10.4.  This is the case where
-the `redirect_fallthrough_to` case-(A) handling produces an unconditional
-override that defeats the for-loop's loop-back arm.  A regression test
-exercising this combination is needed alongside the implementation fix.
+**Regression coverage.** The for-loop-in-then-branch case described in
+§II.10.4 is covered by `tests/integration_test.rs::test_if_wait_for_in_then_branch`,
+which compiles a thread with a for-loop in the then-branch + non-empty
+else-branch and asserts that the buggy unconditional `(true, rejoin_idx)`
+arm is **not** emitted.  An end-to-end Verilator simulation
+(`tests/if_wait_for_in_then.arch` + `tests/if_wait_for_in_then_tb.cpp`,
+run during the v0.46.0 fix verification) confirmed that the for-loop
+iterates the expected number of times.
 
 ### II.11  Auto-emitted spec-contract SVA (`--auto-thread-asserts`)
 
@@ -1201,12 +1215,8 @@ The thread-to-FSM lowering is correct in the following precise sense:
 6. **Shared(or) reduction faithfulness** (Lemma S, II.9).
 7. **If/else with internal waits faithfulness** (Lemma I, II.10) —
    *implemented in v0.45.0 via the dispatch-and-rejoin scheme proved sound
-   here.* ⚠️ A known corner-case bug remains in `redirect_fallthrough_to`
-   case (A): a `for` loop at the end of the **then** branch with a
-   non-empty else branch produces an extra `(true, rejoin_idx)` arm that
-   overrides the loop-back, so the for-loop body executes exactly once.
-   See §II.10.4 "for-loop-in-then-branch asymmetry" for the mechanism and
-   suggested fix.
+   here; corner-case fix in v0.46.0 added a pre-redirect rewrite (step 5)
+   for the for-loop-in-then-branch asymmetry.*
 8. **Auto-emitted spec-contract SVA correctness** (Corollaries W/C/B, II.11)
    — the `--auto-thread-asserts` properties hold by construction in any
    accepted source program, so an `ASSERTION FAILED` from one of them

--- a/doc/thread_lowering_proof.md
+++ b/doc/thread_lowering_proof.md
@@ -827,13 +827,22 @@ internal waits is encountered:
 5. **Redirect each branch's exit** to the rejoin index `rejoin_idx =
    states.len()`.  Concretely, `redirect_fallthrough_to(branch, rejoin_idx)`
    modifies the *last* state of the branch so that its natural advance lands
-   at `rejoin_idx`:
-   - If the last state has `M = ∅` and `τ = ⊥` (unconditional advance):
-     replace with `M = [(true, rejoin_idx)]`.
-   - If the last state has `τ = c`: replace with `M = [(c, rejoin_idx)]`.
-   - If the last state already has `M = [(c_0, t_0), …]`: append
-     `(true, rejoin_idx)` only if no `t_j` already targets `rejoin_idx`;
-     otherwise no change (e.g. for-loop exit already routed correctly).
+   at `rejoin_idx`.  As implemented in `src/elaborate.rs::redirect_fallthrough_to`,
+   four cases are handled in this priority order:
+   - **(A) M-state** (`M ≠ ∅`): append `(true, rejoin_idx)` to `M` only if
+     no existing `t_j` already equals `rejoin_idx`; otherwise no change.
+     ⚠️ This case has a **known corner-case bug** when an existing target
+     points at the position immediately after the branch (for-loop sentinel
+     in then-branch with non-empty else); see §II.10.4.
+   - **(B) τ-state** (`τ = c`, `M = ∅`): take `c`, replace with
+     `M = [(c, rejoin_idx)]` (clears `τ`).
+   - **(C) wait_cycles state** (`w = n`, `τ = ⊥`, `M = ∅`): replace with
+     `M = [(_cnt == 0, rejoin_idx)]`.  The counter decrement is hoisted out
+     of the transition emitter so it still fires unconditionally for every
+     wait_cycles state even after this rewrite (see §II.10.5,
+     "Counter-decrement hoist").
+   - **(D) unconditional advance** (`τ = ⊥`, `w = ⊥`, `M = ∅`): replace
+     with `M = [(true, rejoin_idx)]`.
 6. The dispatch state itself does not advance via the default `next = s+1`;
    `transition_logic` recognises that a state with `M ≠ ∅` always uses the
    `M`-list, so `S_disp.M` overrides any default.
@@ -889,25 +898,42 @@ each branch.  All conditions inside a branch reference the *same* register
 valuation in source and target (by `≈_if`), so the same paths fire.
 
 **Case (R) — branch exit / rejoin.** The last state of branch `b` has been
-modified by `redirect_fallthrough_to` to advance to `rejoin_idx`.  Three
-sub-cases:
+modified by `redirect_fallthrough_to` to advance to `rejoin_idx`.  Four
+sub-cases (matching the four arms of `redirect_fallthrough_to` in §II.10.2
+step 5):
 
-- **Last state had unconditional advance** (`M = ∅`, `τ = ⊥`): replaced with
-  `M = [(true, rejoin_idx)]`.  Source semantics: branch `b`'s last segment
-  completes unconditionally, i.e. `(b, j_max) → (post, 0)`.  Target
-  semantics: `_state <= rejoin_idx`.  Match.
-- **Last state had `τ = c`**: replaced with `M = [(c, rejoin_idx)]`.  Source:
-  branch's last wait-until exits to `(post, 0)` when `c` fires.  Target:
-  same.
-- **Last state already had `M`** (e.g. for-loop exit at end of branch):
-  exactly one of the existing `M`-entries already targeted "next state after
-  the for group" via the sentinel `usize::MAX`, which the parent
-  `partition_thread_body` resolved to `rejoin_idx` (because that's
-  `states.len()` after the for-states are appended).  So no edit is needed,
-  and the for-exit already lands at `rejoin_idx`.  Source: for-loop exit on
-  the last iteration falls through to the post-if statements.  Target: same.
+- **(D) Last state had unconditional advance** (`M = ∅`, `τ = ⊥`, `w = ⊥`):
+  replaced with `M = [(true, rejoin_idx)]`.  Source semantics: branch `b`'s
+  last segment completes unconditionally, i.e. `(b, j_max) → (post, 0)`.
+  Target semantics: `_state <= rejoin_idx`.  Match.
+- **(B) Last state had `τ = c`**: replaced with `M = [(c, rejoin_idx)]`.
+  Source: branch's last wait-until exits to `(post, 0)` when `c` fires.
+  Target: same.
+- **(C) Last state had `w = n` (wait_cycles)**: replaced with
+  `M = [(_cnt == 0, rejoin_idx)]`.  Source: branch's last wait_N_cycle
+  exits to `(post, 0)` when the counter reaches zero.  Target: same.  By
+  the partitioning invariant (§II.4) the predecessor state preloads
+  `_cnt ← n − 1`; the decrement (hoisted out — see §II.10.5) fires every
+  cycle in the wait state.
+- **(A) Last state already had `M`**: append `(true, rejoin_idx)` only if
+  no existing `t_j` equals `rejoin_idx`.  This case arises when:
+  - The branch ends with a `for` loop *whose `usize::MAX` exit-sentinel
+    was resolved to `rejoin_idx` directly*.  This holds when the for-loop
+    is at the end of the **else** branch, because `else_base + else_len =
+    rejoin_idx`.  In this case the existing `(exit_cond, rejoin_idx)`
+    arm already targets `rejoin_idx`, the redirect is a no-op, and the
+    for-exit naturally lands at `rejoin_idx`.  Source: for-loop exit on
+    the last iteration falls through to the post-`if` statements.  Target:
+    same.
+  - The branch ends with a `for` loop *in the **then** branch with a
+    non-empty else branch*.  Here the sentinel resolves to
+    `then_base + then_len = else_base ≠ rejoin_idx`, so the redirect
+    appends `(true, rejoin_idx)`.  ⚠️ **This case is currently broken in
+    the implementation** — see §II.10.4 "for-loop-in-then-branch
+    asymmetry".
 
-In all three sub-cases `≈_if` is preserved across the rejoin transition.
+For sub-cases (D), (B), (C), and the well-behaved part of (A), `≈_if` is
+preserved across the rejoin transition.
 
 **Case (Eq) — outside the if/else.** Steps before reaching the dispatch
 barrier and after rejoin are governed by Lemma 2 of §II.3 unchanged
@@ -941,6 +967,54 @@ on the *post-flush* register values, matching the source semantics where
 "the if statement evaluates `cond` after preceding seq updates have taken
 effect at the previous clock edge."  Without this flush, `cond` would read
 stale register values, breaking equivalence.
+
+**⚠️ For-loop-in-then-branch asymmetry (known bug as of v0.45.0).**  When
+a `for` loop is the *last* statement of the **then** branch and the
+**else** branch is non-empty, the dispatch-and-rejoin lowering produces
+incorrect SV.  The mechanism:
+
+- Inside the recursive `partition_thread_body(then_stmts)` call,
+  `lower_thread_for` emits the for-loop's last state with
+  `M = [(loop_cond, 0), (exit_cond, usize::MAX)]`.
+- The recursive call resolves the sentinel relative to its own state list:
+  `usize::MAX → for_base + for_len`, which equals the position right after
+  the for-loop within the recursive call's frame.
+- The outer IfElse handler then shifts every target by `then_base`, so the
+  exit target becomes `then_base + then_len = else_base` (the start of the
+  else branch).
+- `redirect_fallthrough_to` inspects the for-loop's last state, sees
+  `M = [(loop_cond, then_base), (exit_cond, else_base)]`, and finds no
+  existing target equals `rejoin_idx`.  Per case (A), it appends
+  `(true, rejoin_idx)`.
+- The resulting M is `[(loop_cond, then_base), (exit_cond, else_base),
+  (true, rejoin_idx)]`.  Under ARCH `seq` last-write-wins semantics, the
+  unconditional `(true, rejoin_idx)` arm always overrides the loop-back,
+  so the for-loop body executes exactly once and control jumps to the
+  post-`if` regardless of `loop_cnt`.
+
+Symmetric case: a for-loop at the end of the **else** branch is handled
+correctly because `else_base + else_len = rejoin_idx`, so the existing
+`(exit_cond, rejoin_idx)` arm matches the redirect's target check and no
+spurious arm is appended.
+
+**Suggested fix** (out of scope for this proof; flagged for the
+implementation to address): in the IfElse handler, after computing
+`rejoin_idx`, walk all targets in `then_states` (and `else_states`) that
+equal `then_base + then_len` (resp. `else_base + else_len`) and rewrite
+them to `rejoin_idx`.  This eliminates the asymmetry: any sentinel-derived
+"next state after this branch" target lands directly at the post-`if`
+position.  The `redirect_fallthrough_to` case (A) then becomes a true
+no-op because the for-exit is already correctly routed.
+
+**Empirical confirmation.**  A minimal reproducer
+(`tests/check_if_wait_for.arch` during proof review) generates state-4 SV
+of the form:
+```sv
+if (loop_cnt < end) state <= 3;     // loop-back
+if (loop_cnt >= end) state <= 5;    // → else_base, NOT rejoin
+if (1'b1) state <= 6;               // → rejoin (always overrides above)
+```
+The for-loop body executes exactly once instead of `end` times.
 
 **Empty branches.** If `then_stmts = []` (vacuous then), the recursive
 `partition_thread_body([])` returns no states; `then_base = else_base` and
@@ -980,6 +1054,12 @@ Tests covering: (a) wait in then-branch only, (b) wait in else-branch only,
 (e) auto-thread-asserts integration — see `tests/integration_test.rs`
 (`test_if_wait_*` family).  End-to-end Verilator `--assert` golden + mutation
 runs confirm the dispatch-state branch assertions are load-bearing.
+
+**Coverage gap.** The current test suite does **not** cover the
+for-loop-in-then-branch case described in §II.10.4.  This is the case where
+the `redirect_fallthrough_to` case-(A) handling produces an unconditional
+override that defeats the for-loop's loop-back arm.  A regression test
+exercising this combination is needed alongside the implementation fix.
 
 ### II.11  Auto-emitted spec-contract SVA (`--auto-thread-asserts`)
 
@@ -1121,7 +1201,12 @@ The thread-to-FSM lowering is correct in the following precise sense:
 6. **Shared(or) reduction faithfulness** (Lemma S, II.9).
 7. **If/else with internal waits faithfulness** (Lemma I, II.10) —
    *implemented in v0.45.0 via the dispatch-and-rejoin scheme proved sound
-   here.*
+   here.* ⚠️ A known corner-case bug remains in `redirect_fallthrough_to`
+   case (A): a `for` loop at the end of the **then** branch with a
+   non-empty else branch produces an extra `(true, rejoin_idx)` arm that
+   overrides the loop-back, so the for-loop body executes exactly once.
+   See §II.10.4 "for-loop-in-then-branch asymmetry" for the mechanism and
+   suggested fix.
 8. **Auto-emitted spec-contract SVA correctness** (Corollaries W/C/B, II.11)
    — the `--auto-thread-asserts` properties hold by construction in any
    accepted source program, so an `ASSERTION FAILED` from one of them

--- a/src/elaborate.rs
+++ b/src/elaborate.rs
@@ -2556,6 +2556,36 @@ fn partition_thread_body(
                         states.extend(else_states);
                     }
                     let rejoin_idx = states.len();
+
+                    // Fix for the for-loop-in-then-branch asymmetry (see
+                    // doc/thread_lowering_proof.md §II.10.4).  In the
+                    // then-branch, the natural "next state past this branch"
+                    // is `else_base` (= `then_base + then_len`).  When a
+                    // recursive `partition_thread_body` call resolves a
+                    // `usize::MAX` sentinel (e.g. for-loop exit, nested
+                    // if/else rejoin), the result after outer shifting is
+                    // `else_base`, NOT `rejoin_idx`.  Walk the then-branch
+                    // states and rewrite any such targets to `rejoin_idx`.
+                    //
+                    // The else-branch is symmetric and self-correcting:
+                    // `else_base + else_len = rejoin_idx`, so its sentinels
+                    // naturally land at `rejoin_idx`.  No rewrite needed.
+                    //
+                    // Without this rewrite, `redirect_fallthrough_to` case
+                    // (A) appends `(true, rejoin_idx)` after the existing
+                    // `(exit_cond, else_base)` arm, which under last-write-
+                    // wins always fires and overrides the for-loop's
+                    // loop-back arm — making the body execute exactly once.
+                    if then_base < else_base {
+                        for s_idx in then_base..else_base {
+                            for (_, t) in &mut states[s_idx].multi_transitions {
+                                if *t == else_base {
+                                    *t = rejoin_idx;
+                                }
+                            }
+                        }
+                    }
+
                     // Step 5: redirect each branch's natural exit to rejoin_idx.
                     if then_base < else_base {
                         redirect_fallthrough_to(&mut states, else_base - 1, rejoin_idx, ie.span);

--- a/tests/if_wait_for_in_then.arch
+++ b/tests/if_wait_for_in_then.arch
@@ -1,0 +1,21 @@
+module M
+  port clk:        in Clock<SysDomain>;
+  port rst:        in Reset<Async, Low>;
+  port go:         in Bool;
+  port doit:       in Bool;
+  port ack:        in Bool;
+  port burst:      in UInt<16>;
+  port done:       out Bool;
+  thread on clk rising, rst low
+    wait until go;
+    if doit
+      for i in 0..burst-1
+        wait until ack;
+        done = 1;
+      end for
+    else
+      wait 1 cycle;
+    end if
+    wait 1 cycle;
+  end thread
+end module M

--- a/tests/if_wait_for_in_then_tb.cpp
+++ b/tests/if_wait_for_in_then_tb.cpp
@@ -1,0 +1,78 @@
+// Testbench for tests/if_wait_for_in_then.arch
+//
+// Verifies that the for-loop-in-then-branch correctly iterates burst_len
+// times, asserting `done` once per iteration. Before the bugfix, the
+// for-loop body executed exactly once and control jumped to the post-if
+// wait, so `done` would only pulse once.
+
+#include <cstdio>
+#include <cstdint>
+#include <cstdlib>
+#include "VM.h"
+#include "verilated.h"
+
+int main(int argc, char** argv) {
+    Verilated::commandArgs(argc, argv);
+    auto* dut = new VM;
+
+    auto tick = [&]() {
+        dut->clk = 0; dut->eval();
+        dut->clk = 1; dut->eval();
+    };
+
+    // Reset (active-low, async)
+    dut->rst = 0;
+    dut->clk = 0;
+    dut->go = 0;
+    dut->doit = 0;
+    dut->ack = 0;
+    dut->burst = 4;     // expect 4 done pulses
+    dut->eval();
+    tick(); tick();
+    dut->rst = 1;
+    tick();
+
+    // Trigger: go + doit (take the then-branch with the for-loop)
+    dut->go = 1;
+    dut->doit = 1;
+    tick();
+    dut->go = 0;
+
+    // Now the thread should be in the for-loop. Each iteration waits for
+    // ack, then asserts done for one cycle. Count `done` pulses.
+    //
+    // burst_len = 4, so the loop runs for i in 0..3 (4 iterations) and
+    // expect 4 `done` pulses across the run.
+    constexpr int EXPECTED_DONE_PULSES = 4;
+    int done_pulses = 0;
+    int prev_done = 0;
+    int max_cycles = 100;
+    int cycles_since_last_done = 0;
+
+    for (int c = 0; c < max_cycles; c++) {
+        // Pulse ack every couple of cycles to drive the wait_until.
+        dut->ack = (c % 3 == 0) ? 1 : 0;
+        tick();
+        if (dut->done && !prev_done) {
+            done_pulses++;
+            cycles_since_last_done = 0;
+        } else {
+            cycles_since_last_done++;
+        }
+        prev_done = dut->done;
+        // If we've seen the expected pulses and waited ~10 idle cycles,
+        // the post-if wait_cycles has had time to fire — break out.
+        if (done_pulses >= EXPECTED_DONE_PULSES && cycles_since_last_done > 10) break;
+    }
+
+    printf("done_pulses=%d (expected %d)\n", done_pulses, EXPECTED_DONE_PULSES);
+    int rc = (done_pulses == EXPECTED_DONE_PULSES) ? 0 : 1;
+    if (rc != 0) {
+        printf("FAIL: for-loop did not iterate the expected number of times\n");
+    } else {
+        printf("PASS: for-loop iterated %d times correctly\n", done_pulses);
+    }
+
+    delete dut;
+    return rc;
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -6156,3 +6156,62 @@ fn test_if_wait_nested() {
         "nested if/else with waits should compile:\n{sv}");
 }
 
+#[test]
+fn test_if_wait_for_in_then_branch() {
+    // Regression test for the for-loop-in-then-branch asymmetry bug
+    // (see doc/thread_lowering_proof.md §II.10.4).
+    //
+    // Before the fix, the for-loop's exit-sentinel (usize::MAX) resolved
+    // to `then_base + then_len = else_base`, and `redirect_fallthrough_to`
+    // then appended `(true, rejoin_idx)` which always overrode the
+    // for-loop's loop-back arm under last-write-wins. The for-loop body
+    // executed exactly once instead of N times.
+    //
+    // After the fix, any target equal to `else_base` in the then-branch
+    // states is rewritten to `rejoin_idx` before the redirect, so the
+    // for-exit naturally lands at rejoin_idx and no spurious append
+    // occurs.
+    let source = r#"
+        module M
+          param burst_len: const = 4;
+          port clk:  in Clock<SysDomain>;
+          port rst:  in Reset<Async, Low>;
+          port go:   in Bool;
+          port doit: in Bool;
+          port ack:  in Bool;
+          port done: out Bool;
+          thread on clk rising, rst low
+            wait until go;
+            if doit
+              for i in 0..burst_len-1
+                wait until ack;
+                done = 1;
+              end for
+            else
+              wait 1 cycle;
+            end if
+            wait 1 cycle;
+          end thread
+        end module M
+    "#;
+    let sv = compile_to_sv(source);
+    assert!(sv.contains("module _M_threads"),
+        "for-loop in then-branch should compile:\n{sv}");
+    // Bug witness: the buggy lowering emitted `if (1'b1) _t0_state <= <rejoin>`
+    // inside the for-loop's last state, causing the body to execute exactly once.
+    // The fix removes this unconditional override, so the only state-write
+    // arms inside state 4 (for-loop last) should be the loop-back and exit
+    // arms — both guarded by `_t0_loop_cnt` comparisons against `burst_len - 1`.
+    assert!(!sv.contains("if (1'b1) begin\n          _t0_state"),
+        "buggy unconditional override should not be emitted:\n{sv}");
+    // The for-loop's exit arm should land at the rejoin state (post-if
+    // wait_cycles), not at the start of the else branch.
+    // The else branch is `wait 1 cycle` (one state); the rejoin is the
+    // post-if `wait 1 cycle` (one state). With the fix, `_t0_loop_cnt >=
+    // (burst_len - 1)` should write the rejoin state, not else_base.
+    let exit_arm = sv.contains("if (_t0_loop_cnt >= 16'(burst_len - 1)) begin")
+        || sv.contains("if (_t0_loop_cnt >= 16'(burst_len-1)) begin");
+    assert!(exit_arm,
+        "for-loop exit arm should compare loop_cnt against burst_len-1:\n{sv}");
+}
+


### PR DESCRIPTION
## Summary

This PR now contains both the **proof corrections** (initial commit) and the **implementation fix** (follow-up commit) for the corner-case bug discovered while reviewing the v0.45.0 if-wait implementation against §II.10 of the proof.

## The bug

When a `for` loop is the *last* statement of the **then** branch and the **else** branch is non-empty, the dispatch-and-rejoin lowering produced incorrect SV: the for-loop body executed exactly once and control jumped straight to the post-`if` regardless of `loop_cnt`.

**Mechanism** (pre-fix):
- Inside the recursive `partition_thread_body(then_stmts)` call, the for-loop's `usize::MAX` exit-sentinel is resolved to `for_base + for_len` within its own state list.
- The outer IfElse handler shifts every target by `then_base`, so the exit lands at `then_base + then_len = else_base` (the start of the else branch).
- `redirect_fallthrough_to` case (A) then appends `(true, rejoin_idx)` because no existing target equals `rejoin_idx`.
- Under ARCH `seq` last-write-wins semantics, the unconditional arm always overrides the loop-back arm.

The else-branch is symmetric and self-correcting because `else_base + else_len = rejoin_idx`.

## The fix

In the IfElse handler (`src/elaborate.rs::partition_thread_body` ThreadStmt::IfElse arm), after appending both branches and computing `rejoin_idx`, walk the then-branch states and rewrite any `multi_transitions` target equal to `else_base` (= `then_base + then_len`) to `rejoin_idx`. This catches sentinel-resolved targets uniformly: for-loop exits, nested if/else rejoin points, anything else.

The fix is local, ~14 lines, and preserves correctness for all existing cases (else-branch sentinels are already correct, no rewrite needed there).

## End-to-end verification

- **Regression test**: `tests/integration_test.rs::test_if_wait_for_in_then_branch` asserts the absence of the buggy `if (1'b1) _t0_state <= …` arm and presence of the correct `loop_cnt >= burst-1` exit comparison.
- **Verilator simulation**: `tests/if_wait_for_in_then.arch` + `tests/if_wait_for_in_then_tb.cpp` produce **4 done pulses for burst=4** (was 1 pulse before the fix).
- **Full test suite**: 195 + 15 + 20 + 0 tests pass; no regressions.

## Proof updates (carried over from initial commit, with §II.10.4 reframed)

- **§II.10.2**: new step 5 "Pre-redirect rewrite"; old step 5 (redirect) → 6, step 6 (dispatch deferred) → 7. ⚠️ symbols removed.
- **§II.10.3 case (R)**: 4 sub-cases (D), (B), (C), (A); for-loop and nested if/else cases merged under (A) and described as preserving `≈_if`.
- **§II.10.4**: "for-loop-in-then-branch asymmetry" reframed as **resolved in v0.46.0**, with mechanism + fix + post-fix empirical confirmation.
- **§II.10.5**: "Coverage gap" → "Regression coverage" with file references.
- **Part III bullet 7**: ⚠️ dropped.

## Files changed

| File | Change |
|------|--------|
| `src/elaborate.rs` | `+14 -0`: pre-redirect rewrite loop in the IfElse handler |
| `tests/integration_test.rs` | `+58 -0`: `test_if_wait_for_in_then_branch` regression test |
| `tests/if_wait_for_in_then.arch` | new: minimal reproducer for end-to-end Verilator simulation |
| `tests/if_wait_for_in_then_tb.cpp` | new: testbench counting `done` pulses |
| `doc/thread_lowering_proof.md` | proof corrections + fix-landed status |
| `Cargo.toml`, `Cargo.lock` | version bump 0.45.0 → 0.46.0 |

## Test plan

- [x] `cargo build` clean
- [x] `cargo test --release` passes (195 + 15 + 20 + 0)
- [x] `cargo test --release test_if_wait` — 6 tests pass including the new regression
- [x] Verilator end-to-end: 4 done pulses for burst=4 ✓
- [x] No stale ⚠️ markers in proof doc

🤖 Generated with [Claude Code](https://claude.com/claude-code)