### PR TITLE
feat(mcp): doc-comment + spec-provenance directive (PR-doc-2)

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -73,7 +73,9 @@ session loads the server and exposes the MCP resources and tools.
 | Resource | Description |
 |----------|-------------|
 | `arch://reference-card` | Full ARCH HDL AI Reference Card — language syntax and examples |
+| `arch://specification` | Full ARCH HDL Language Specification |
 | `arch://compiler-status` | Current compiler feature status and changelog |
+| `arch://doc-comments` | V1 spec for `///` / `//!` doc comments and the `//! ---` YAML frontmatter that captures spec→RTL provenance |
 
 ## Available Tools
 
@@ -97,7 +99,12 @@ session loads the server and exposes the MCP resources and tools.
 An AI assistant using this MCP server can:
 
 1. Read `arch://reference-card` to learn the ARCH language
-2. Use `write_arch_file` to create a design from natural language
-3. Use `arch_check` to validate — fix errors from diagnostics
-4. Use `arch_build` to emit SystemVerilog
-5. Use `arch_sim` to run simulation with a testbench
+2. Call `get_construct_syntax("doc_comments")` to learn the spec-provenance shape
+3. Use `write_arch_file` (or `write_and_check`) to create a design from natural language — capture the user's design spec in front matter (`//! ---`) + per-construct `///` blocks per the directive in `instructions.md`
+4. Use `arch_check` to validate — fix errors from diagnostics
+5. Use `arch_build_and_lint` to emit SystemVerilog and verify with Verilator
+6. Use `arch_sim` to run simulation with a testbench
+
+Spec preservation: when editing an existing `.arch` file, agents are
+instructed to preserve all `///`, `//!`, and front-matter content
+unless the user explicitly asks to change it.

--- a/mcp/arch_mcp_server.py
+++ b/mcp/arch_mcp_server.py
@@ -79,6 +79,64 @@ def _load_construct_syntax() -> dict[str, str]:
 
 CONSTRUCT_SYNTAX = _load_construct_syntax()
 
+# Inject a synthetic "doc_comments" entry so agents who reach for
+# get_construct_syntax() before writing code learn the front-matter +
+# `///` + `//!` shape without a second round-trip.
+CONSTRUCT_SYNTAX["doc_comments"] = """\
+ARCH supports three doc-comment surfaces for capturing design intent
+inline. The compiler stores them on the AST verbatim; downstream tooling
+(RAG indexer, formal-tool feeders) consumes them.
+
+`///` outer doc — attaches to the next construct, similar to Rust:
+```
+/// 4-channel round-robin AXI write arbiter.
+///
+/// Picks among DMA channels using a rotating priority pointer.
+arbiter AxiWrArb
+  ...
+end arbiter AxiWrArb
+```
+
+`//!` inner doc — attaches to the enclosing item; legal at file-top
+(documents the file as a whole) or immediately after a construct's
+opening keyword + name:
+```
+arbiter AxiWrArb
+  //! Round-robin chosen because all 4 channels are equal-priority;
+  //! see ticket FOO-1234 for the QoS-aware variant proposed for v2.
+  policy round_robin;
+```
+
+YAML front matter — embedded in the leading `//!` block at the top of
+the file, delimited by `//! ---` lines. Compiler does NOT parse the
+YAML; it stores the text verbatim.
+```
+//! ---
+//! spec_md: doc/specs/dma_engine.md
+//! tags: [dma, axi]
+//! refs: ["AXI4 §A3.3.1"]
+//! ---
+//!
+//! Multi-channel DMA engine. See spec_md for the channel state diagram.
+```
+
+Recognized field semantics (interpreted by tooling, not the compiler):
+- `spec_md`: relative path to an external markdown spec, optional `#anchor`.
+- `tags`: 3-6 short feature tags for retrieval.
+- `refs`: citations — datasheet sections, ticket IDs, URLs.
+
+Escape hatch: `////` (4 or more slashes) is a regular comment, NOT a
+doc comment — use it for ASCII banners or notes you don't want indexed.
+
+When generating .arch code from a user-supplied design spec, capture the
+spec across all three surfaces. When editing an existing file, preserve
+all `///`, `//!`, and front matter unless the user explicitly asks to
+change them — they're the project's spec→RTL provenance trail.
+
+Full V1 spec: `arch://doc-comments` resource (or
+`doc/plan_arch_doc_comments.md`).
+"""
+
 # ── Reserved keywords (for syntax hints) ────────────────────────────────
 
 RESERVED_KEYWORDS = {
@@ -115,6 +173,16 @@ def specification() -> str:
 def compiler_status() -> str:
     """Current compiler feature status and changelog."""
     return (PROJECT_ROOT / "doc" / "COMPILER_STATUS.md").read_text()
+
+
+@mcp.resource("arch://doc-comments")
+def doc_comments_spec() -> str:
+    """V1 spec for ARCH doc comments (`///`, `//!`) and the YAML-style
+    frontmatter block that captures spec→RTL provenance. Read this when
+    generating new .arch code to learn the exact attachment rules and
+    field semantics; the compiler stores the YAML verbatim — downstream
+    tooling parses it."""
+    return (PROJECT_ROOT / "doc" / "plan_arch_doc_comments.md").read_text()
 
 
 # ── Helpers ──────────────────────────────────────────────────────────────
@@ -162,7 +230,11 @@ def get_construct_syntax(construct: str) -> str:
 
     Available constructs: module, function, pipeline, fsm, fifo, synchronizer,
     ram, counter, arbiter, regfile, linklist, generate, bus, template, package,
-    types, expressions
+    types, expressions, doc_comments
+
+    `doc_comments` documents the `///` outer / `//!` inner / `//! ---`
+    front-matter syntax — call it once before writing a new .arch file
+    so the design spec gets captured inline.
 
     Also returns reserved keywords to avoid as signal/register names.
     Note: 'in', 'out', 'state' are contextual — safe to use as port/signal names.

--- a/mcp/instructions.md
+++ b/mcp/instructions.md
@@ -50,3 +50,44 @@ Common mistakes to avoid:
 - .trunc<N>() errors if N >= source width (not truncating); .zext<N>()/.sext<N>() error if N <= source width (not extending)
 - signed(x) / unsigned(x): same-width reinterpret cast (no width arg needed); prefer signed(x) over x.sext<N>() when entering signed arithmetic chains
 - Wrapping arithmetic operators +%, -%, *% give result width = max(W(a),W(b)) with no widening — prefer these over .trunc<N>() when the intent is modular arithmetic: 'let x: UInt<8> = a +% b;' instead of 'let x: UInt<8> = (a + b).trunc<8>();'
+
+DESIGN SPEC PROVENANCE — when generating .arch from a user-supplied design spec, you MUST capture the spec inline so it rides with the code:
+
+1. FILE FRONT MATTER. Open the file with a YAML-style block embedded in '//!' lines, delimited by '//! ---' on its own line:
+
+   //! ---
+   //! spec_md: doc/specs/<name>.md            (when an external spec file exists or you create one)
+   //! tags: [<feature_tag>, <feature_tag>]    (3-6 short tags derived from the spec — e.g. arbitration, axi, axi4)
+   //! refs:                                   (citations the spec mentions — datasheet sections, ticket IDs, URLs)
+   //!   - "AXI4 spec §A3.3.1"
+   //!   - "FOO-1234"
+   //! ---
+   //!
+   //! <1-3 sentence file-level summary in plain prose>
+
+   The compiler stores the YAML verbatim — it does not parse it. Downstream tooling (RAG indexer, formal-tool feeders) consumes it.
+
+2. PER-CONSTRUCT OUTER DOC. Place a '///' block above EVERY top-level construct (module, fsm, fifo, ram, counter, arbiter, pipeline, regfile, synchronizer, clkgate, bus, struct, enum, function, package, use). Capture the construct's role in the design — 1-3 sentences, not implementation details.
+
+   Example:
+     /// 4-channel round-robin AXI write arbiter.
+     ///
+     /// Picks among DMA channels using a rotating priority pointer.
+     arbiter AxiWrArb
+       ...
+     end arbiter AxiWrArb
+
+3. CONSTRUCT INNER DOC (optional). When the construct has design intent that's specific to the body — policy choice, trade-off, ticket reference — place a '//!' block immediately after the opening keyword + name:
+
+     arbiter AxiWrArb
+       //! Round-robin chosen because all 4 channels are equal-priority;
+       //! see ticket FOO-1234 for the QoS-aware variant proposed for v2.
+
+       policy round_robin;
+       ...
+
+4. PRESERVATION ON EDIT. When modifying an existing .arch file, NEVER strip or rewrite '///', '//!', or '//! ---' content unless the user explicitly asks to change it. Treat doc text as load-bearing — it's the project's spec→RTL provenance trail.
+
+5. ESCAPE HATCH. '////+' (4 or more slashes) is a regular comment, not a doc comment — use it for ASCII banners or notes you don't want indexed.
+
+You are responsible for sourcing the design spec from the conversation context. The MCP server does not. If the user has not provided a design spec, write a brief plain-prose '//!' file-level summary based on the user's request and a concise '///' line per construct — do not invent ref/tag fields you can't justify.


### PR DESCRIPTION
## Summary
Final slice of [doc/plan_arch_doc_comments.md](doc/plan_arch_doc_comments.md). Wires the ARCH MCP server prompt to instruct agents to capture user-supplied design specs as in-source doc comments using the surface PR-doc-1 / PR-doc-1.5 already shipped.

Skips the deferred PR-doc-1.6 (member-level decls — `port` / `reg` / `wire` / `let` / `inst` / `resource`); top-level coverage is sufficient for the spec→RTL provenance use case the MCP integration cares about, and member-level can be added later without retrofitting agent behavior.

### What lands
1. **instructions.md** — new "DESIGN SPEC PROVENANCE" section directing agents to insert:
   - YAML front matter (`//! ---` block) with `spec_md` / `tags` / `refs`.
   - 1-3 sentence file-level `//!` summary.
   - `///` outer-doc block per top-level construct.
   - Optional `//!` inner-doc block where body-specific intent matters.
   - Preserve existing `///` / `//!` / front matter on edit unless explicitly asked.
   - `////+` escape hatch.

2. **`arch://doc-comments` resource** — serves the V1 spec (\`doc/plan_arch_doc_comments.md\`) so agents have the canonical reference one fetch away.

3. **`get_construct_syntax("doc_comments")`** — returns the front-matter + `///` + `//!` shape with examples, mirroring how agents consult construct syntax before writing code.

### Not in this PR
- Compiler / lexer changes — none needed; this is purely an MCP-server prompt update.
- Member-level decls — deferred to PR-doc-1.6 (or later; not blocking the MCP workflow).

## Test plan
- [x] `python3 -c "import ast; ast.parse(open('mcp/arch_mcp_server.py').read())"` — syntax clean
- [x] Server module imports successfully and `CONSTRUCT_SYNTAX["doc_comments"]` is populated (smoke-tested)
- [x] `get_construct_syntax("doc_comments")` returns 2.5 KB containing `//! ---`, `///`, and `//!` examples