### PR TITLE
docs(sva): document `|->` / `|=>` + `implies` deprecation

### DIFF
--- a/doc/ARCH_HDL_Specification.md
+++ b/doc/ARCH_HDL_Specification.md
@@ -9076,7 +9076,7 @@ Arch includes three verification constructs built directly into the language. Th
 
 **12.4 Scope --- Same-Cycle Safety Today, Temporal Sugar on the Roadmap**
 
-In the current compiler, `assert` and `cover` bodies are *combinational expressions* evaluated at every clock edge under the construct's `posedge clk` with `disable iff (rst)`. This covers all same-cycle safety properties, including implication via the built-in `implies` operator (`a implies b` ≡ SVA's overlapping implication `a |-> b`, lowered to `(!a || b)` at each cycle). For multi-cycle properties, users currently bind the temporal state into explicit shadow registers and assert on them:
+In the current compiler, `assert` and `cover` bodies are *combinational expressions* evaluated at every clock edge under the construct's `posedge clk` with `disable iff (rst)`. This covers all same-cycle safety properties, including implication via the symbolic `|->` operator (SVA overlap implication, emitted directly as SV `|->`). The legacy `implies` keyword is a deprecated alias for `|->` (v0.49.0+) — still accepted, but each use prints a stderr deprecation warning. Both forms are restricted to `assert`/`cover` bodies; for plain Boolean implication outside SVA contexts, use `(!a) || b`. For multi-cycle properties, users currently bind the temporal state into explicit shadow registers and assert on them:
 
 +--------------------------------------------------------------------+
 | *shadow_reg_idiom.arch*                                            |
@@ -9091,7 +9091,7 @@ In the current compiler, `assert` and `cover` bodies are *combinational expressi
 |                                                                    |
 | **end seq**                                                        |
 |                                                                    |
-| **assert** next_cycle_ack: req_d1 **implies** ack;                 |
+| **assert** next_cycle_ack: req_d1 \|-\> ack;                       |
 +--------------------------------------------------------------------+
 
 Planned (post-v0.41 roadmap) — lightweight temporal sugar that desugars to the same shadow-register idiom for `arch build` and to direct cycle-shifted term references for `arch formal`:

--- a/doc/Arch_AI_Reference_Card.md
+++ b/doc/Arch_AI_Reference_Card.md
@@ -280,6 +280,11 @@ Wrapping:    +% -% *%    (no-widen; result width = max(W(a),W(b)))
 Comparison:  == != < > <= >=
 Logical:     and or not
 Bitwise:     & | ^ ~ << >>
+SVA-only:    |->  (overlap implication, same-cycle)
+             |=>  (next-cycle implication)
+             // both legal only inside `assert`/`cover` bodies; outside SVA,
+             // use `(!a) || b` for plain Boolean implication.
+             // The legacy `implies` keyword is a deprecated alias for `|->`.
 Ternary:     cond ? a : b      // right-associative; chains for priority muxes
 Match:       match x { E::A => val1, E::B => val2, _ => default }
 Set member:  expr inside {val1, val2, lo..hi}   // returns Bool, emits SV inside

--- a/mcp/instructions.md
+++ b/mcp/instructions.md
@@ -50,6 +50,7 @@ Common mistakes to avoid:
 - .trunc<N>() errors if N >= source width (not truncating); .zext<N>()/.sext<N>() error if N <= source width (not extending)
 - signed(x) / unsigned(x): same-width reinterpret cast (no width arg needed); prefer signed(x) over x.sext<N>() when entering signed arithmetic chains
 - Wrapping arithmetic operators +%, -%, *% give result width = max(W(a),W(b)) with no widening — prefer these over .trunc<N>() when the intent is modular arithmetic: 'let x: UInt<8> = a +% b;' instead of 'let x: UInt<8> = (a + b).trunc<8>();'
+- SVA implication operators (v0.49.0+): use '|->' for overlap (same-cycle) and '|=>' for next-cycle implication inside 'assert' / 'cover' bodies. The legacy 'implies' keyword is a deprecated alias for '|->' — accepted but emits a stderr warning per use; new code should use '|->'. Both are restricted to SVA contexts; for plain Boolean implication outside 'assert'/'cover', write '(!a) || b'.
 
 DESIGN SPEC PROVENANCE — when generating .arch from a user-supplied design spec, you MUST capture the spec inline so it rides with the code:
 


### PR DESCRIPTION
## Summary
Follow-on to #197 (the implementation). Brings the user-facing docs and MCP agent prompt in sync with v0.49.0's SVA-implication operator changes.

### What was stale
- **`doc/ARCH_HDL_Specification.md` §12.4** — described the `implies` keyword as "lowered to `(!a || b)` at each cycle." That hasn't been true since v0.49.0; `implies` is now an SVA-only deprecated alias for `|->`.
- **`doc/Arch_AI_Reference_Card.md` §3 Operators** — listed Boolean operators but never mentioned `|->` or `|=>` at all.
- **`mcp/instructions.md`** — no mention of either operator; agents had no signal to prefer `|->` over `implies`.

### What changed
1. Spec §12.4 prose rewritten to describe the actual v0.49.0 contract; the shadow-register-idiom example switches `implies` → `|->`.
2. Reference Card operator table now lists `|->` / `|=>` with the SVA-only restriction and the keyword-deprecation note.
3. MCP agent instructions get a one-line bullet directing new code to `|->`.

The MCP server's `get_construct_syntax("expressions")` loads its content verbatim from the Reference Card section, so agents pick up the updated operator table on next server restart — no MCP code changes needed.

## Test plan
- [x] No code changes — pure docs.
- [x] Verified MCP server still loads cleanly and `get_construct_syntax("expressions")` returns the updated text including `SVA-only:` block.