### PR TITLE
refactor(ast): generalize ForLoop<S> / MatchArm<S> / MatchStmt<S>

### DIFF
--- a/doc/plan_compiler_refactor.md
+++ b/doc/plan_compiler_refactor.md
@@ -1,0 +1,231 @@
+# Compiler refactor backlog (2026-04-28)
+
+Captured from the tech-debt review on `feature/regfile-latch-flops-config`. Six
+refactors, ordered by ROI / risk. Items 1–3 are pure cleanup (no design
+choices); items 4–6 want a design discussion before scheduling.
+
+## Status snapshot
+
+`src/codegen.rs` 9.3k lines, `src/sim_codegen/mod.rs` 6.7k, `parser.rs` 5.7k,
+`elaborate.rs` 5.4k, `typecheck.rs` 5.2k. Six functions over 400 lines (largest:
+`sim_codegen::gen_module` at 2376 lines). 273 `Item::*` match sites across 11
+files. Recent regfile work touched 5 files for one feature — that's the cost
+the refactors below should reduce.
+
+---
+
+## #1 — Shared `clog2` + width helpers (`src/width.rs`)
+
+**Why.** `if n <= 1 { 1 } else { (n as f64).log2().ceil() as u32 }` appears
+verbatim in 14 places across `codegen.rs`, `sim_codegen/`, and `typecheck.rs`.
+Width inference for arithmetic ops is also duplicated between `codegen.rs` and
+`sim_codegen/mod.rs` — the `+%` wrapping-op bug had to be fixed twice. Float
+arithmetic for compile-time integer math is a small smell on its own.
+
+**Scope.**
+- New `src/width.rs` with:
+  - `pub fn clog2(n: u64) -> u32` — exact integer (`n.next_power_of_two().trailing_zeros()`).
+  - `pub fn infer_expr_width(expr: &Expr, ctx: &WidthCtx) -> Option<u64>` —
+    one source of truth for IEEE 1800-2012 §11.6 widening rules and `+%` / `-%`
+    / `*%` non-widening rules.
+- Replace 14 `clog2`-shaped sites and the duplicated width inference at
+  `codegen::infer_expr_width_internal` and `sim_codegen::*` width helpers.
+
+**Risk.** Low. Pure substitution + one new function; behavior preserved by
+existing tests.
+
+**Effort.** 1 hour for `clog2`; 4 hours for `infer_expr_width` (depends on how
+much of typecheck's `resolve_expr_type` overlaps).
+
+**Success criteria.** No `(_ as f64).log2()` outside `width.rs`. Both
+`codegen.rs` and `sim_codegen/mod.rs` width helpers replaced. 217/217 tests
+green.
+
+---
+
+## #2 — Split `codegen.rs` into per-construct files
+
+**Why.** 9.3k-line monolith. `sim_codegen/` has already proven the split
+works — it has `mod.rs` + `fsm.rs` / `pipeline.rs` / `linklist.rs` / `ram.rs` /
+`fifo.rs` / `cam.rs` / `thread_sim.rs`. `codegen.rs` deserves the same shape.
+
+**Scope.**
+- New `src/codegen/{module,fsm,fifo,ram,cam,counter,arbiter,regfile,pipeline,linklist,synchronizer,clkgate,bus}.rs`.
+- Move `emit_<construct>` and tightly-scoped helpers (e.g. `emit_fifo_port_type`,
+  `emit_ram_signal_type`, `emit_ll_port_type`) into the construct's file.
+- Keep shared helpers (`emit_expr_str`, `emit_type_str`, `extract_reset_info`,
+  `ff_sensitivity`, `rst_condition`, `fold_width_str`) in `codegen/mod.rs` or
+  the new `width.rs`.
+- Per-file `pub(super) fn` extension methods on `impl Codegen` mirror the
+  sim_codegen pattern.
+
+**Risk.** Low. Pure mechanical move; no behavior change.
+
+**Effort.** 1 day. The blocker is making sure nothing depends on private
+visibility within `codegen.rs` — quick `cargo check` after each file move.
+
+**Success criteria.** `wc -l src/codegen/*.rs` — no file over 1500 lines.
+Identical SV output for all 217 tests. Snapshot tests unchanged.
+
+**Dependency.** Item #1 lands first or at the same time; otherwise width
+helpers move twice.
+
+---
+
+## #3 — `param_int` / `resolve_count` on `ConstructCommon`
+
+**Why.** The same 5-line closure is re-defined in `codegen::emit_regfile`,
+`sim_codegen::gen_regfile`, and `sim_codegen/linklist.rs`. The pattern (and a
+similar `resolve_count`) belongs on the shared base struct.
+
+**Scope.**
+- Add to `impl ConstructCommon`:
+  ```rust
+  pub fn param_int(&self, name: &str, default: u64) -> u64;
+  pub fn param_int_opt(&self, name: &str) -> Option<u64>;
+  pub fn resolve_count_expr(&self, expr: &Expr) -> u64;
+  ```
+- Replace the duplicated closures.
+
+**Risk.** Low. Trivial method extraction.
+
+**Effort.** 2 hours.
+
+**Success criteria.** No `let param_int = |...|` closures in `codegen.rs` or
+`sim_codegen/`. No regression.
+
+---
+
+## #4 — Split mega-functions by match arm
+
+**Why.** Six functions over 400 lines, four over 700. They are flat dispatch
+trees on `Item` / `TypeExpr` / `ExprKind` / `Stmt` and are read top-to-bottom
+so often that splits are pure ergonomics. Targets:
+
+| Function | Lines | File |
+|---|---:|---|
+| `sim_codegen::gen_module` | 2376 | `sim_codegen/mod.rs` |
+| `elaborate::lower_module_threads` | 932 | `elaborate.rs` |
+| `typecheck::check_module` | 778 | `typecheck.rs` |
+| `typecheck::resolve_expr_type` | 743 | `typecheck.rs` |
+| `sim_codegen::cpp_expr_inner` | 550 | `sim_codegen/mod.rs` |
+| `codegen::emit_module` | 549 | `codegen.rs` |
+
+**Scope.** Each function gets one `match` arm extracted per private helper.
+No behavior change; no new abstractions.
+
+**Risk.** Medium. Big diffs; reviewer fatigue. Do one function per PR so
+mistakes localize.
+
+**Effort.** 1–2 days, mostly mechanical.
+
+**Success criteria.** No function over 300 lines outside hand-written match
+arms. Tests green.
+
+**Dependency.** Item #2 makes `emit_module` smaller for free; do that first.
+
+---
+
+## #5 — Merge `Stmt` / `CombStmt` (`ThreadStmt` stays separate)
+
+**Phase 5a status (2026-04-28): DONE.** `ForLoop<S>`, `MatchArm<S>`, `MatchStmt<S>` are now generic; `CombStmt::For` carries `ForLoop<CombStmt>` and `CombStmt::MatchExpr` carries `MatchStmt<CombStmt>`. The cross-delegation in `check_comb_stmt` is gone — comb For / Match bodies now type-check under comb semantics. Caught a real regression: assigning to a `reg` from a comb-block for-loop now fails type-check (it used to slip through and only get caught by Verilator's "blocking assign to reg in always_comb" warning). Phase 5b (full enum collapse) is queued but not blocking.
+
+
+**Why.** `Stmt` (seq blocks) and `CombStmt` (comb blocks) share ~85% of their
+variants. The shared types `ForLoop` and `MatchArm` carry `body: Vec<Stmt>`,
+which forces `check_comb_stmt` to delegate to `check_reg_stmt` for for-loop and
+match-arm bodies — comb code gets type-checked as if it were seq code in
+nested contexts. This is currently latent (matching shape happens to be
+compatible), but it means the comb-vs-seq distinction is enforced at the
+*outermost* statement only.
+
+`ThreadStmt` is genuinely a different domain (procedural with fork/join, wait,
+lock, do-until). Its variants don't generalize cleanly into a comb/seq shape,
+and after `lower_threads` it's gone — backends never see ThreadStmt. Merging
+it would just bloat the unified enum with variants illegal everywhere except
+in threads.
+
+**The "log missing in threads" motivation in the original plan is stale** —
+`ThreadStmt::Log` already exists, parses, and lowers. The remaining motivation
+is the body-type duplication and the cross-delegation in typecheck.
+
+**Scope.**
+1. Generalize `ForLoop<S>` and `MatchArm<S>` (also `MatchStmt<S>`,
+   `CombMatch<S>`) parametrically over the statement type.
+2. Merge `Stmt` + `CombStmt` into one `Stmt` enum:
+   - Variants: `Assign(Assign)`, `IfElse(IfElse)`, `Match(MatchStmt<Stmt>)`,
+     `Log(LogStmt)`, `For(ForLoop<Stmt>)`, `Init(InitBlock)`,
+     `WaitUntil(Expr, Span)`, `DoUntil { ... }`.
+   - The parser already stores `=` and `<=` in the same `Assign` struct; the
+     merged enum keeps that — block context (comb vs seq) determines the
+     emitted operator.
+3. Add `BlockKind { Comb, Seq, PipelineStage }` to typecheck. Reject:
+   - `Stmt::Init` outside `Seq`.
+   - `Stmt::WaitUntil` / `Stmt::DoUntil` outside `PipelineStage` seq.
+   - Assignments to `reg`-typed targets in `Comb` context (existing rule).
+   - Assignments to `wire`-typed targets in `Seq` context (existing rule).
+4. `ThreadStmt::Log`-like variants: keep ThreadStmt as-is. Re-evaluate after
+   the lowering pass if any thread-specific concerns surface.
+
+**Risk.** Medium. ~30 match sites grow. The `Vec<Stmt>` ↔ `Vec<CombStmt>` swap
+in shared types affects everything that constructs or walks `ForLoop` /
+`MatchArm`. Mitigation: fix in one PR; rely on the test suite (217 tests).
+
+**Effort.** 1 day. Two phases:
+- Phase 5a (this branch): generalize `ForLoop<S>` / `MatchArm<S>`,
+  introduce `BlockKind` typecheck, keep the two enum names for now via
+  type aliases. Verifies the generalization in isolation.
+- Phase 5b (follow-up): collapse `CombStmt` into `Stmt` proper.
+
+**Success criteria.** `check_comb_stmt` no longer delegates to
+`check_reg_stmt` for For/Match bodies. `Stmt` and `CombStmt` are either one
+type or thin aliases. 217/217 tests green.
+
+---
+
+## #6 — `trait Construct` to centralize the per-construct dispatch
+
+**Why.** 273 `Item::*` match sites across 11 files. 69 functions named
+`(parse|emit|gen|check)_<construct>`. Adding a new construct (or a new variant
+in `kind:`) means 5 file edits at minimum. This is the biggest long-term cost
+in the codebase and the one most resistant to incremental fixes.
+
+**Scope.**
+- New `trait Construct` with associated methods `parse(parser) -> Self`,
+  `typecheck(checker)`, `emit_sv(codegen)`, `emit_sim(simgen)`,
+  `emit_formal(formal)`.
+- Each construct moves to its own file under `src/constructs/{name}.rs`,
+  implementing the trait. The top-level passes (`parser::parse_source_file`,
+  `typecheck::check`, etc.) iterate over a registry of `dyn Construct` rather
+  than `match`-ing on `Item`.
+- Migration: do this construct-by-construct. Start with simple ones
+  (`counter`, `synchronizer`) to validate the trait shape; then port complex
+  ones (`pipeline`, `thread`).
+
+**Risk.** High. This is a redesign, not a refactor. The trait API has to
+accommodate every existing construct's quirks (TLM bus methods, generate
+expansion, thread lowering) and we won't know all of them until we hit them.
+
+**Effort.** 1 week realistically. 2 weeks if surprises.
+
+**Success criteria.** A new construct lands as one file. `Item::*` match
+sites drop from 273 to under 50 (the residual being the registry itself and
+debug/learn passes).
+
+**Recommendation.** Do this *last*. Items 1–5 will reduce the cost of #6 by
+trimming the per-construct surface area; doing #6 first means re-doing parts
+of it after each later refactor.
+
+---
+
+## Recommended order
+
+1. (today) **#1 + #3** — clog2/width + param_int methods. ~6 hours combined.
+2. (this week) **#5a** — generalize `ForLoop<S>` / `MatchArm<S>` + `BlockKind`.
+3. (next week) **#2** — split codegen.rs.
+4. (after) **#5b** — collapse `CombStmt` into `Stmt`.
+5. (after) **#4** — split mega-functions one-PR-at-a-time.
+6. (later) **#6** — `trait Construct` redesign.
+
+Items 1–5 unblock #6 by reducing the per-construct surface. Items 1, 3, 5a
+touch shared types and should land before any new construct work.

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -619,7 +619,7 @@ pub enum CombStmt {
     IfElse(CombIfElse),
     MatchExpr(CombMatch),
     Log(LogStmt),
-    For(ForLoop),
+    For(ForLoop<CombStmt>),
 }
 
 /// Assignment statement: `target = expr;` (combinational, in `comb` blocks)
@@ -641,13 +641,12 @@ pub type CombAssign = Assign;
 
 pub type CombIfElse = IfElseOf<CombStmt>;
 
-#[derive(Debug, Clone)]
-pub struct CombMatch {
-    pub scrutinee: Expr,
-    pub arms: Vec<MatchArm>,
-    pub unique: bool,
-    pub span: Span,
-}
+/// `comb`-block match. A type alias for `MatchStmt<CombStmt>` — the arm
+/// bodies are comb statements (use `=`), not seq statements. Previously
+/// declared as a separate struct with `Vec<MatchArm>` (seq-typed bodies),
+/// which forced the comb typecheck to delegate match-arm bodies to
+/// `check_reg_stmt`. Now the arms parametrically carry comb stmts.
+pub type CombMatch = MatchStmt<CombStmt>;
 
 #[derive(Debug, Clone)]
 pub struct LetBinding {
@@ -771,10 +770,16 @@ pub enum ForRange {
 }
 
 #[derive(Debug, Clone)]
-pub struct ForLoop {
+/// `for VAR in RANGE ... end for` — generic over the body statement type.
+/// `ForLoop<Stmt>` for seq-block / pipeline-stage for loops; `ForLoop<CombStmt>`
+/// for comb-block for loops. Previously hard-coded to `Vec<Stmt>`, which
+/// forced comb-context for-loop bodies to be wrapped as seq stmts and then
+/// re-checked under seq semantics in typecheck — the bug this generalization
+/// removes.
+pub struct ForLoop<S = Stmt> {
     pub var: Ident,
     pub range: ForRange,
-    pub body: Vec<Stmt>,
+    pub body: Vec<S>,
     pub span: Span,
 }
 
@@ -792,18 +797,23 @@ pub type RegAssign = Assign;
 
 pub type IfElse = IfElseOf<Stmt>;
 
+/// `match SCRUTINEE ... end match` — generic over the arm-body statement type.
+/// `MatchStmt<Stmt>` for seq-block matches; `MatchStmt<CombStmt>` for
+/// comb-block matches (aliased as `CombMatch`). Previously hard-coded to
+/// `Vec<MatchArm>` (i.e. `Vec<MatchArm<Stmt>>`), forcing comb match-arm
+/// bodies to be wrapped as seq stmts.
 #[derive(Debug, Clone)]
-pub struct MatchStmt {
+pub struct MatchStmt<S = Stmt> {
     pub scrutinee: Expr,
-    pub arms: Vec<MatchArm>,
+    pub arms: Vec<MatchArm<S>>,
     pub unique: bool,
     pub span: Span,
 }
 
 #[derive(Debug, Clone)]
-pub struct MatchArm {
+pub struct MatchArm<S = Stmt> {
     pub pattern: Pattern,
-    pub body: Vec<Stmt>,
+    pub body: Vec<S>,
 }
 
 #[derive(Debug, Clone)]

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -1121,7 +1121,10 @@ impl<'a> Codegen<'a> {
                         collect_from_comb(&ie.else_stmts, files, seen);
                     }
                     CombStmt::MatchExpr(m) => {
-                        for arm in &m.arms { collect_from_seq(&arm.body, files, seen); }
+                        for arm in &m.arms { collect_from_comb(&arm.body, files, seen); }
+                    }
+                    CombStmt::For(f) => {
+                        collect_from_comb(&f.body, files, seen);
                     }
                     _ => {}
                 }
@@ -1300,13 +1303,14 @@ impl<'a> Codegen<'a> {
             CombStmt::Log(_) => true,
             CombStmt::IfElse(ie) => ie.then_stmts.iter().any(Self::comb_stmt_has_log)
                 || ie.else_stmts.iter().any(Self::comb_stmt_has_log),
-            CombStmt::Assign(_) | CombStmt::MatchExpr(_) => false,
-            CombStmt::For(f) => f.body.iter().any(Self::stmt_has_log),
+            CombStmt::Assign(_) => false,
+            CombStmt::MatchExpr(m) => m.arms.iter().any(|a| a.body.iter().any(Self::comb_stmt_has_log)),
+            CombStmt::For(f) => f.body.iter().any(Self::comb_stmt_has_log),
         }
     }
 
     /// Emit a for-loop (Range or ValueList) as SV.
-    fn emit_for_loop_sv(&mut self, f: &ForLoop, mut emit_body_stmt: impl FnMut(&mut Self, &Stmt)) {
+    fn emit_for_loop_sv<S>(&mut self, f: &ForLoop<S>, mut emit_body_stmt: impl FnMut(&mut Self, &S)) {
         let var = &f.var.name;
         match &f.range {
             ForRange::Range(rs, re) => {
@@ -1412,7 +1416,7 @@ impl<'a> Codegen<'a> {
                     self.line(&format!("{}: begin", pat));
                     self.indent += 1;
                     for s in &arm.body {
-                        self.emit_reg_stmt_as_comb(s);
+                        self.emit_comb_stmt(s);
                     }
                     self.indent -= 1;
                     self.line("end");
@@ -1422,7 +1426,7 @@ impl<'a> Codegen<'a> {
             }
             CombStmt::Log(l) => { self.emit_log_stmt(l); }
             CombStmt::For(f) => {
-                self.emit_for_loop_sv(f, |s, stmt| s.emit_reg_stmt_as_comb(stmt));
+                self.emit_for_loop_sv(f, |s, stmt| s.emit_comb_stmt(stmt));
             }
         }
     }
@@ -4796,9 +4800,9 @@ impl<'a> Codegen<'a> {
                 }
                 CombStmt::MatchExpr(_) | CombStmt::Log(_) => {}
                 CombStmt::For(f) => {
-                    // ForLoop body is Vec<Stmt>; collect ident targets from assigns
+                    // Comb for-loop body is Vec<CombStmt>; collect ident targets from assigns.
                     for s in &f.body {
-                        if let Stmt::Assign(a) = s {
+                        if let CombStmt::Assign(a) = s {
                             if let ExprKind::Ident(name) = &a.target.kind {
                                 if !targets.contains(name) { targets.push(name.clone()); }
                             }
@@ -4917,7 +4921,9 @@ impl<'a> Codegen<'a> {
             CombStmt::MatchExpr(_) => {} // TODO if needed
             CombStmt::Log(l) => { self.emit_log_stmt(l); }
             CombStmt::For(f) => {
-                self.emit_for_loop_sv(f, |s, stmt| s.emit_reg_stmt_as_comb(stmt));
+                self.emit_for_loop_sv(f, |s, stmt| {
+                    s.emit_pipeline_comb_stmt(stmt, current_prefix, current_stage_idx, stage_names, stage_regs, port_names);
+                });
             }
         }
     }

--- a/src/comb_graph.rs
+++ b/src/comb_graph.rs
@@ -9,7 +9,7 @@ use std::collections::{HashMap, HashSet, VecDeque};
 
 use crate::ast::{
     ConnectDir, CombStmt, ExprKind, FsmDecl, InsideMember, InstDecl, Item,
-    ModuleBodyItem, ModuleDecl, PortDecl, RamDecl, SourceFile, Stmt, TypeExpr,
+    ModuleBodyItem, ModuleDecl, PortDecl, RamDecl, SourceFile, TypeExpr,
 };
 use crate::diagnostics::CompileError;
 use crate::resolve::{Symbol, SymbolTable};
@@ -132,28 +132,6 @@ fn lhs_base_name(expr: &crate::ast::Expr) -> Option<String> {
 
 // ── Scanning helpers ──────────────────────────────────────────────────────────
 
-/// Helper: scan a `Stmt::Assign` (used inside CombMatch / CombFor arm bodies).
-fn scan_stmt_assign(
-    stmt: &Stmt,
-    input_names: &HashSet<String>,
-    output_names: &HashSet<String>,
-    driven: &mut HashSet<String>,
-    read: &mut HashSet<String>,
-) {
-    if let Stmt::Assign(a) = stmt {
-        if let Some(lhs) = lhs_base_name(&a.target) {
-            if output_names.contains(&lhs) {
-                driven.insert(lhs);
-            }
-        }
-        let mut rhs = HashSet::new();
-        collect_expr_idents(&a.value, &mut rhs);
-        for id in &rhs {
-            if input_names.contains(id) { read.insert(id.clone()); }
-        }
-    }
-}
-
 /// Recursively scan a single `CombStmt` and accumulate driven outputs and
 /// read inputs.
 fn scan_comb_stmt(
@@ -193,17 +171,15 @@ fn scan_comb_stmt(
             for id in &scrut {
                 if input_names.contains(id) { read.insert(id.clone()); }
             }
-            // Arm bodies contain Stmt::Assign items
             for arm in &m.arms {
                 for s in &arm.body {
-                    scan_stmt_assign(s, input_names, output_names, driven, read);
+                    scan_comb_stmt(s, input_names, output_names, driven, read);
                 }
             }
         }
         CombStmt::For(f) => {
-            // For-loop body contains Stmt::Assign items in comb context
             for s in &f.body {
-                scan_stmt_assign(s, input_names, output_names, driven, read);
+                scan_comb_stmt(s, input_names, output_names, driven, read);
             }
         }
         CombStmt::Log(_) => {}

--- a/src/elaborate.rs
+++ b/src/elaborate.rs
@@ -603,9 +603,10 @@ fn check_gen_for_comb_stmts(stmts: &[CombStmt], var: &str, errors: &mut Vec<Comp
                 check_gen_for_comb_stmts(&ie.then_stmts, var, errors);
                 check_gen_for_comb_stmts(&ie.else_stmts, var, errors);
             }
-            // MatchExpr arms are value-producing (no further LHS to check).
-            CombStmt::MatchExpr(_) => {}
-            CombStmt::For(f) => check_gen_for_reg_stmts(&f.body, var, errors),
+            CombStmt::MatchExpr(m) => {
+                for arm in &m.arms { check_gen_for_comb_stmts(&arm.body, var, errors); }
+            }
+            CombStmt::For(f) => check_gen_for_comb_stmts(&f.body, var, errors),
             CombStmt::Log(_) => {}
         }
     }
@@ -4232,7 +4233,13 @@ fn rewrite_comb_stmt_cc(s: &mut CombStmt, ctx: &CcDispatchCtx, errors: &mut Vec<
             for s in &mut ie.else_stmts { rewrite_comb_stmt_cc(s, ctx, errors); }
         }
         CombStmt::For(fl) => {
-            for s in &mut fl.body { rewrite_reg_stmt_cc(s, ctx, errors); }
+            for s in &mut fl.body { rewrite_comb_stmt_cc(s, ctx, errors); }
+        }
+        CombStmt::MatchExpr(m) => {
+            rewrite_expr_cc(&mut m.scrutinee, ctx, errors);
+            for arm in &mut m.arms {
+                for s in &mut arm.body { rewrite_comb_stmt_cc(s, ctx, errors); }
+            }
         }
         _ => {}
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1888,7 +1888,7 @@ impl Parser {
             return Ok(Stmt::Log(self.parse_log_stmt()?));
         }
         if self.check(TokenKind::For) {
-            return self.parse_for_loop(true);
+            return self.parse_seq_for_loop();
         }
         if self.check(TokenKind::Init) {
             return self.parse_init_block();
@@ -2065,35 +2065,14 @@ impl Parser {
             && self.tokens[self.pos + 1].kind == TokenKind::Comb
     }
 
-    /// Convert a CombStmt to a Stmt for use in for-loop bodies.
-    fn comb_stmt_to_stmt(cs: CombStmt) -> Stmt {
-        match cs {
-            CombStmt::Assign(a) => Stmt::Assign(RegAssign {
-                target: a.target,
-                value: a.value,
-                span: a.span,
-            }),
-            CombStmt::IfElse(ie) => Stmt::IfElse(IfElse {
-                cond: ie.cond,
-                then_stmts: ie.then_stmts.into_iter().map(Self::comb_stmt_to_stmt).collect(),
-                else_stmts: ie.else_stmts.into_iter().map(Self::comb_stmt_to_stmt).collect(),
-                unique: ie.unique,
-                span: ie.span,
-            }),
-            CombStmt::Log(l) => Stmt::Log(l),
-            CombStmt::For(f) => Stmt::For(f),
-            CombStmt::MatchExpr(m) => Stmt::Match(MatchStmt {
-                scrutinee: m.scrutinee,
-                arms: m.arms,
-                unique: m.unique,
-                span: m.span,
-            }),
-        }
-    }
-
-    /// Parse `for VAR in START..END ... end for`
-    /// `is_seq`: true = body uses `parse_reg_stmt`, false = body uses `parse_comb_stmt` (wrapped)
-    fn parse_for_loop(&mut self, is_seq: bool) -> Result<Stmt, CompileError> {
+    /// Parse `for VAR in RANGE ... end for` — the surrounding scaffolding,
+    /// generic over the body statement type. Caller passes the body parser
+    /// (`parse_reg_stmt` for seq, `parse_comb_stmt` for comb), and wraps the
+    /// returned `ForLoop<S>` in the right enum variant.
+    fn parse_for_loop_generic<S>(
+        &mut self,
+        mut parse_body: impl FnMut(&mut Self) -> Result<S, CompileError>,
+    ) -> Result<ForLoop<S>, CompileError> {
         let start = self.expect(TokenKind::For)?.span;
         let var = self.expect_ident()?;
         self.expect_contextual("in")?;
@@ -2118,22 +2097,21 @@ impl Parser {
         while !(self.check(TokenKind::End)
             && self.pos + 1 < self.tokens.len()
             && self.tokens[self.pos + 1].kind == TokenKind::For) {
-            if is_seq {
-                body.push(self.parse_reg_stmt()?);
-            } else {
-                // Wrap CombStmt into Stmt for unified ForLoop body
-                let cs = self.parse_comb_stmt()?;
-                body.push(Self::comb_stmt_to_stmt(cs));
-            }
+            body.push(parse_body(self)?);
         }
         self.expect(TokenKind::End)?;
         let end_span = self.expect(TokenKind::For)?.span;
-        Ok(Stmt::For(ForLoop {
-            var,
-            range,
-            body,
-            span: start.merge(end_span),
-        }))
+        Ok(ForLoop { var, range, body, span: start.merge(end_span) })
+    }
+
+    fn parse_seq_for_loop(&mut self) -> Result<Stmt, CompileError> {
+        let fl = self.parse_for_loop_generic(|p| p.parse_reg_stmt())?;
+        Ok(Stmt::For(fl))
+    }
+
+    fn parse_comb_for_loop(&mut self) -> Result<CombStmt, CompileError> {
+        let fl = self.parse_for_loop_generic(|p| p.parse_comb_stmt())?;
+        Ok(CombStmt::For(fl))
     }
 
     /// Parse `init on RST.asserted \n body \n end init`
@@ -2181,11 +2159,7 @@ impl Parser {
             return Ok(CombStmt::Log(self.parse_log_stmt()?));
         }
         if self.check(TokenKind::For) {
-            let fl = self.parse_for_loop(false)?;
-            if let Stmt::For(f) = fl {
-                return Ok(CombStmt::For(f));
-            }
-            unreachable!();
+            return self.parse_comb_for_loop();
         }
         // target = expr;   OR   bare method-call statement (credit_channel sugar).
         let target = self.parse_expr()?;
@@ -2249,17 +2223,16 @@ impl Parser {
         while !self.check_end_match() {
             let pattern = self.parse_pattern()?;
             self.expect(TokenKind::FatArrow)?;
-            // Parse comb-style statements (with =) and convert to Stmt for MatchArm
+            // Comb match-arm body is a single comb statement (kept as
+            // CombStmt — previously cast to Stmt for `Vec<MatchArm<Stmt>>`,
+            // which forced the typecheck to recheck under seq semantics).
             let comb_stmt = self.parse_comb_stmt()?;
-            arms.push(MatchArm {
-                pattern,
-                body: vec![Self::comb_stmt_to_stmt(comb_stmt)],
-            });
+            arms.push(MatchArm { pattern, body: vec![comb_stmt] });
         }
         self.expect(TokenKind::End)?;
         self.expect(TokenKind::Match)?;
         let end_span = self.tokens.get(self.pos.saturating_sub(1)).map(|t| t.span).unwrap_or(start);
-        Ok(CombStmt::MatchExpr(CombMatch {
+        Ok(CombStmt::MatchExpr(MatchStmt {
             scrutinee,
             arms,
             unique,

--- a/src/sim_codegen/mod.rs
+++ b/src/sim_codegen/mod.rs
@@ -2658,7 +2658,7 @@ fn emit_comb_stmt(stmt: &CombStmt, ctx: &Ctx, out: &mut String, indent: usize) {
                     out.push_str(&format!("{}  _arch_cov[{cidx}]++;\n", ind(indent + 1)));
                 }
                 for s in &arm.body {
-                    if let Stmt::Assign(a) = s {
+                    if let CombStmt::Assign(a) = s {
                         let rhs = cpp_expr(&a.value, ctx);
                         let lhs = cpp_expr(&a.target, ctx);
                         out.push_str(&format!("{}{} = {};\n", ind(indent + 2), lhs, rhs));
@@ -2677,7 +2677,7 @@ fn emit_comb_stmt(stmt: &CombStmt, ctx: &Ctx, out: &mut String, indent: usize) {
                     let start = cpp_expr(rs, ctx);
                     let end = cpp_expr(re, ctx);
                     out.push_str(&format!("{}for (int {var} = {start}; {var} <= {end}; {var}++) {{\n", ind(indent)));
-                    for s in &f.body { emit_reg_stmt(s, ctx, out, indent + 1); }
+                    for s in &f.body { emit_comb_stmt(s, ctx, out, indent + 1); }
                     out.push_str(&format!("{}}}\n", ind(indent)));
                 }
                 ForRange::ValueList(vals) => {
@@ -2685,7 +2685,7 @@ fn emit_comb_stmt(stmt: &CombStmt, ctx: &Ctx, out: &mut String, indent: usize) {
                         let val = cpp_expr(v, ctx);
                         out.push_str(&format!("{}{{\n", ind(indent)));
                         out.push_str(&format!("{}int {var} = {val};\n", ind(indent + 1)));
-                        for s in &f.body { emit_reg_stmt(s, ctx, out, indent + 1); }
+                        for s in &f.body { emit_comb_stmt(s, ctx, out, indent + 1); }
                         out.push_str(&format!("{}}}\n", ind(indent)));
                     }
                 }
@@ -2775,7 +2775,8 @@ fn collect_log_files(body: &[ModuleBodyItem]) -> Vec<String> {
             match s {
                 CombStmt::Log(l) => { if let Some(ref p) = l.file { if seen.insert(p.clone()) { files.push(p.clone()); } } }
                 CombStmt::IfElse(ie) => { from_comb(&ie.then_stmts, files, seen); from_comb(&ie.else_stmts, files, seen); }
-                CombStmt::MatchExpr(m) => { for arm in &m.arms { from_seq(&arm.body, files, seen); } }
+                CombStmt::MatchExpr(m) => { for arm in &m.arms { from_comb(&arm.body, files, seen); } }
+                CombStmt::For(f) => from_comb(&f.body, files, seen),
                 _ => {}
             }
         }
@@ -2857,13 +2858,13 @@ fn collect_comb_reads(stmt: &CombStmt, out: &mut std::collections::BTreeSet<Stri
             for s in &ie.then_stmts { collect_comb_reads(s, out); }
             for s in &ie.else_stmts { collect_comb_reads(s, out); }
         }
-        CombStmt::MatchExpr(_) | CombStmt::Log(_) => {}
+        CombStmt::Log(_) => {}
+        CombStmt::MatchExpr(m) => {
+            collect_expr_idents(&m.scrutinee, out);
+            for arm in &m.arms { for s in &arm.body { collect_comb_reads(s, out); } }
+        }
         CombStmt::For(f) => {
-            for s in &f.body {
-                if let Stmt::Assign(a) = s {
-                    collect_expr_idents(&a.value, out);
-                }
-            }
+            for s in &f.body { collect_comb_reads(s, out); }
         }
     }
 }
@@ -2994,24 +2995,12 @@ fn collect_comb_targets(body: &[ModuleBodyItem]) -> HashSet<String> {
             }
             CombStmt::MatchExpr(m) => {
                 for arm in &m.arms {
-                    for s in &arm.body {
-                        if let Stmt::Assign(a) = s {
-                            if let ExprKind::Ident(name) = &a.target.kind {
-                                out.insert(name.clone());
-                            }
-                        }
-                    }
+                    for s in &arm.body { collect_stmt_targets(s, out); }
                 }
             }
             CombStmt::Log(_) => {}
             CombStmt::For(f) => {
-                for s in &f.body {
-                    if let Stmt::Assign(a) = s {
-                        if let ExprKind::Ident(name) = &a.target.kind {
-                            out.insert(name.clone());
-                        }
-                    }
-                }
+                for s in &f.body { collect_stmt_targets(s, out); }
             }
         }
     }

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -1241,14 +1241,13 @@ impl<'a> TypeChecker<'a> {
                 self.check_expr_for_unguarded_payload(&mm.scrutinee, enclosing, info, mm.span);
                 for arm in &mm.arms {
                     for s in &arm.body {
-                        self.walk_seq_for_hs_reads(s, enclosing, info);
+                        self.walk_comb_for_hs_reads(s, enclosing, info);
                     }
                 }
             }
             CombStmt::For(fl) => {
-                // ForLoop.body is Vec<Stmt>, reused from seq semantics.
                 for s in &fl.body {
-                    self.walk_seq_for_hs_reads(s, enclosing, info);
+                    self.walk_comb_for_hs_reads(s, enclosing, info);
                 }
             }
             CombStmt::Log(_) => {}
@@ -2271,7 +2270,7 @@ impl<'a> TypeChecker<'a> {
                 self.check_match_exhaustive(&m.scrutinee, &patterns, m.span, module_name, local_types);
                 for arm in &m.arms {
                     for s in &arm.body {
-                        self.check_reg_stmt(s, module_name, local_types, driven);
+                        self.check_comb_stmt(s, module_name, local_types, driven, reg_names);
                     }
                 }
             }
@@ -2282,7 +2281,7 @@ impl<'a> TypeChecker<'a> {
             }
             CombStmt::For(f) => {
                 for s in &f.body {
-                    self.check_reg_stmt(s, module_name, local_types, driven);
+                    self.check_comb_stmt(s, module_name, local_types, driven, reg_names);
                 }
             }
         }
@@ -2327,11 +2326,11 @@ impl<'a> TypeChecker<'a> {
                     let has_wildcard = m.arms.iter().any(|a| matches!(a.pattern, Pattern::Wildcard));
                     let arm_results: Vec<(HashSet<String>, HashSet<String>)> = m.arms.iter()
                         .map(|arm| {
-                            // Match arm bodies are Vec<Stmt> — extract assign targets
+                            // Comb match arm bodies are Vec<CombStmt> — extract assign targets.
                             let mut arm_all = HashSet::new();
                             let mut arm_full = HashSet::new();
                             for s in &arm.body {
-                                if let Stmt::Assign(a) = s {
+                                if let CombStmt::Assign(a) = s {
                                     let name = Self::expr_flat_name_tc(&a.target);
                                     if !name.is_empty() {
                                         arm_all.insert(name.clone());
@@ -2370,9 +2369,9 @@ impl<'a> TypeChecker<'a> {
                     }
                 }
                 CombStmt::For(f) => {
-                    // For-loop body uses Stmt — treat assigns as fully driven
+                    // Comb for-loop body is Vec<CombStmt> — treat assigns as fully driven.
                     for s in &f.body {
-                        if let Stmt::Assign(a) = s {
+                        if let CombStmt::Assign(a) = s {
                             let name = Self::expr_flat_name_tc(&a.target);
                             if !name.is_empty() {
                                 all.insert(name.clone());
@@ -3694,13 +3693,13 @@ impl<'a> TypeChecker<'a> {
                 }
                 CombStmt::MatchExpr(m) => {
                     Self::collect_expr_reads(&m.scrutinee, out);
-                    for arm in &m.arms { Self::collect_stmt_reads(&arm.body, out); }
+                    for arm in &m.arms { Self::collect_comb_stmt_reads(&arm.body, out); }
                 }
                 CombStmt::Log(l) => {
                     for arg in &l.args { Self::collect_expr_reads(arg, out); }
                 }
                 CombStmt::For(f) => {
-                    Self::collect_stmt_reads(&f.body, out);
+                    Self::collect_comb_stmt_reads(&f.body, out);
                 }
             }
         }
@@ -3716,11 +3715,11 @@ impl<'a> TypeChecker<'a> {
                     Self::collect_comb_stmt_targets(&ie.else_stmts, out);
                 }
                 CombStmt::MatchExpr(m) => {
-                    for arm in &m.arms { Self::collect_stmt_targets(&arm.body, out); }
+                    for arm in &m.arms { Self::collect_comb_stmt_targets(&arm.body, out); }
                 }
                 CombStmt::Log(_) => {}
                 CombStmt::For(f) => {
-                    Self::collect_stmt_targets(&f.body, out);
+                    Self::collect_comb_stmt_targets(&f.body, out);
                 }
             }
         }
@@ -5068,15 +5067,7 @@ fn check_precedence_in_item(item: &Item, errors: &mut Vec<CompileError>) {
             CombStmt::MatchExpr(m) => {
                 check_precedence_expr(&m.scrutinee, errors);
                 for arm in &m.arms {
-                    for s in &arm.body {
-                        match s {
-                            Stmt::Assign(a) => {
-                                check_precedence_expr(&a.target, errors);
-                                check_precedence_expr(&a.value, errors);
-                            }
-                            _ => walk_stmt(s, errors),
-                        }
-                    }
+                    for s in &arm.body { walk_comb(s, errors); }
                 }
             }
             CombStmt::Log(l) => {
@@ -5092,8 +5083,7 @@ fn check_precedence_in_item(item: &Item, errors: &mut Vec<CompileError>) {
                         for v in vs { check_precedence_expr(v, errors); }
                     }
                 }
-                // CombStmt::For's body is Vec<Stmt>, not Vec<CombStmt>
-                for s in &fl.body { walk_stmt(s, errors); }
+                for s in &fl.body { walk_comb(s, errors); }
             }
         }
     }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -7002,3 +7002,40 @@ fn test_regfile_flop_default_unchanged() {
     assert!(!sv.contains("always_latch"),
         "default kind:flop should not emit always_latch:\n{sv}");
 }
+
+#[test]
+fn test_comb_for_loop_body_type_checked_as_comb() {
+    // Regression for the ForLoop<S> generalization: previously CombStmt::For's
+    // body was Vec<Stmt> (lossily cast from Vec<CombStmt>), so the typecheck
+    // walked comb for-loop bodies via `check_reg_stmt` and missed the
+    // "reg assigned in comb block" rule. After making ForLoop generic, the
+    // comb For body stays as Vec<CombStmt> and `check_comb_stmt` runs — which
+    // catches reg assigns in comb context as the spec requires.
+    let source = "
+        domain SysDomain
+          freq_mhz: 100
+        end domain SysDomain
+        module Bad
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync>;
+          reg arr_r: Vec<UInt<8>, 4> reset rst => 0;
+          comb
+            for i in 0..3
+              arr_r[i] = 8'h00;
+            end for
+          end comb
+        end module Bad
+    ";
+    let tokens = lexer::tokenize(source).expect("lex");
+    let mut parser = Parser::new(tokens, source);
+    let ast = parser.parse_source_file().expect("parse");
+    let ast = elaborate::elaborate(ast).expect("elaborate");
+    let ast = elaborate::lower_threads(ast).expect("lower threads");
+    let symbols = resolve::resolve(&ast).expect("resolve");
+    let result = TypeChecker::new(&symbols, &ast).check();
+    assert!(result.is_err(),
+        "assigning to a `reg` in a comb-block for-loop body must be a typecheck error");
+    let err_msg = format!("{:?}", result.err().unwrap());
+    assert!(err_msg.contains("`arr_r` is a reg") && err_msg.contains("seq"),
+        "diagnostic should explain reg-vs-seq rule; got: {err_msg}");
+}


### PR DESCRIPTION
## Summary
- Phase 5a of the compiler refactor backlog ([doc/plan_compiler_refactor.md](doc/plan_compiler_refactor.md)).
- Generalizes `ForLoop<S>`, `MatchArm<S>`, `MatchStmt<S>` parametrically over the body statement type. `CombStmt::For` now carries `ForLoop<CombStmt>` and `CombStmt::MatchExpr` carries `MatchStmt<CombStmt>` (aliased as `CombMatch`).
- Removes the lossy comb→seq cast in the parser and the `check_reg_stmt` delegation in `check_comb_stmt`. Comb-context rules now apply uniformly — including inside for-loop and match-arm bodies.

## Why
Previously, `ForLoop.body` and `MatchArm.body` were hard-coded to `Vec<Stmt>`. Parsing a comb-block for-loop converted each `CombStmt` into a `Stmt` to fit, and the typecheck had to recheck those bodies as if they were seq stmts. Comb-context rules (e.g. "regs must be assigned in seq, not comb") were enforced at the outermost statement only — anything nested inside slipped through.

## Regression caught
The new `test_comb_for_loop_body_type_checked_as_comb` exercises the fix. Assigning to a `reg` from inside a comb-block for-loop now fails type-check with the proper diagnostic. Pre-fix, this code slipped through and surfaced later as Verilator's "blocking assign to reg in always_comb" warning.

## Scope
- `ast.rs`: `ForLoop<S = Stmt>`, `MatchArm<S = Stmt>`, `MatchStmt<S = Stmt>`. `CombMatch` is now `type CombMatch = MatchStmt<CombStmt>`.
- `parser.rs`: `parse_for_loop_generic` + `parse_seq_for_loop` / `parse_comb_for_loop`. Removed `comb_stmt_to_stmt`.
- `typecheck.rs`: `check_comb_stmt` recurses into For / Match arms via itself; collect_comb_stmt_reads / targets follow suit.
- `codegen.rs`: `emit_for_loop_sv<S>` is generic; pipeline-stage and standalone comb For now use comb-typed body emission.
- `sim_codegen/mod.rs`: matching cleanup in C++ emission.
- `elaborate.rs`, `comb_graph.rs`: cleaned up the residual `Vec<Stmt>` walks.

ThreadStmt stays separate by design (different domain — fork/join, wait, lock, etc.). Phase 5b (collapsing `CombStmt` into `Stmt` with a `BlockKind` typecheck context flag) is queued in the plan doc.

## Test plan
- [x] `cargo test` — 218/218 pass (was 217; +1 regression test for the bug class this fix closes)
- [x] No snapshot drift
- [x] `cargo build` clean