### PR TITLE
refactor(ast): drop CombStmt enum (Phase 5b part 1)

### DIFF
--- a/doc/plan_phase_5b_stmt_merge.md
+++ b/doc/plan_phase_5b_stmt_merge.md
@@ -1,0 +1,154 @@
+# Phase 5b — Collapse `CombStmt` into `Stmt`
+
+**Status (2026-04-28): part 1 DONE.** The AST-level merge — drop `CombStmt`, `CombIfElse`, `CombMatch`; unify all references to `Stmt`; `CombBlock.stmts` is now `Vec<Stmt>` — is shipped in PR #TBD on `refactor/stmt-merge-5b`. 218/218 tests green, zero snapshot drift.
+
+Part 2 (the `BlockKind` typecheck plumbing and `AssignCtx` codegen consolidation) is **queued** but kept separate so the AST merge can land cleanly. Sketch in the "Migration steps" section below — the mechanical work now is collapsing the 13 parallel walker functions that already operate on the same type into single dispatchers gated by the new context enums.
+
+---
+
+
+Follow-up to phase 5a (merged in PR #202, [doc/plan_compiler_refactor.md](doc/plan_compiler_refactor.md) item #5). Phase 5a generalized `ForLoop<S>` / `MatchArm<S>` / `MatchStmt<S>` so that comb For/Match bodies type-check under comb semantics. Phase 5b finishes the merge: drop `CombStmt` entirely; have one `Stmt` enum that's valid in both comb and seq blocks; thread a `BlockKind` context through typecheck and codegen so the right rules and operators apply per block.
+
+`ThreadStmt` stays separate. Its variants (fork/join, wait until, wait cycles, lock, do-until, return) are domain-specific and after `lower_threads` it's gone — no payoff in merging.
+
+Status snapshot (2026-04-28): 13 parallel walker functions across typecheck, codegen, sim_codegen, formal, elaborate, comb_graph; 221 sites that dispatch on `CombStmt::` / `Stmt::`; ~85% variant overlap.
+
+---
+
+## Decisions to make first
+
+These are the design choices Phase 5b commits to. My recommendation for each is in **bold**; the alternatives are recorded so reviewers can push back.
+
+### D1. How does codegen know to emit `=` vs `<=`?
+
+After the merge, `Stmt::Assign(Assign)` is the only assign variant. SV codegen needs to pick blocking `=` or non-blocking `<=` somehow.
+
+- **(a) From enclosing block context.** Codegen calls `emit_stmt(stmt, ctx: AssignCtx::{Blocking, NonBlocking, ...})`. The parser already enforces `=` in `comb { }` and `<=` in `seq { }`, so the context is unambiguous. **Recommended** — keeps the AST clean (the syntactic distinction is *where* it lives, not *what* it carries).
+- (b) Explicit `is_blocking: bool` field on `Assign`. Rejected: redundant with parser context, easy to set wrong, still requires context to validate.
+- (c) Two enum variants `Stmt::CombAssign(Assign)` / `Stmt::SeqAssign(Assign)`. Rejected: this is exactly the split we're trying to remove.
+
+### D2. Where do `Init`, `WaitUntil`, `DoUntil` live?
+
+These three variants are seq-only or pipeline-stage-only. After the merge:
+
+- **(a) Keep as variants of unified `Stmt`; reject in `BlockKind::Comb` at typecheck.** **Recommended.** Single source of truth; rejection is one line in `check_stmt`.
+- (b) Hoist them into `SeqStmt` that wraps `Stmt + extras`. Rejected — reintroduces the split this phase is removing.
+
+### D3. How does `BlockKind` propagate through the type checker?
+
+`BlockKind { Comb, Seq, PipelineStage }` decides:
+- Whether `reg` targets are valid (allowed in `Seq`/`PipelineStage`, error in `Comb`).
+- Whether `wire` targets are valid (allowed in `Comb`, error in `Seq`).
+- Whether `Init` / `WaitUntil` / `DoUntil` are legal.
+- Whether the assignment operator is blocking or not (used by codegen, not typecheck).
+
+Two threading options:
+
+- **(a) Explicit parameter:** `check_stmt(stmt, ..., block_kind: BlockKind)` — every recursive walk passes it through. **Recommended.** Functional, obvious at every site, no hidden state. Adds ~30 function signature changes, but mechanical.
+- (b) Stack on `&mut TypeChecker`. Push on block entry, pop on exit. Less plumbing, but easy to forget pop on early return.
+
+### D4. Does the parser produce `Stmt` directly, or keep a thin parse-time discriminator?
+
+After the merge there's only one `Stmt`. The parser still has separate paths because syntax differs (comb uses `=`, seq uses `<=`):
+
+- **(a) `parse_seq_stmt` / `parse_comb_stmt` both return `Stmt`. The seq path accepts `<=`, the comb path accepts `=`. Both produce the same enum.** **Recommended.** Mirrors current shape; reuses generic `parse_for_loop_generic` from phase 5a; minimal churn.
+- (b) One `parse_stmt(block_kind)` function. Rejected — the operator dispatch in the parser body is awkward to thread through `parse_assign` and friends.
+
+### D5. Migration in one PR or two?
+
+- **(a) One-shot.** Big diff (~750 LOC removed, ~150 added) but coherent. **Recommended.** Test coverage is solid (218 tests), snapshot tests catch SV drift, the dispatch is mechanical.
+- (b) Stepwise. Introduce `Stmt2`, migrate consumers one-by-one with adapters, then rename and delete. More PRs to review, more total work, but each PR is small.
+
+### D6. Should `CombMatch` / `CombIfElse` / `CombAssign` aliases survive the merge?
+
+- **(a) Delete all three.** `CombMatch` becomes `MatchStmt`; `CombIfElse` becomes `IfElse`; `CombAssign` becomes `Assign`. **Recommended** — the whole point is one source of truth.
+- (b) Keep aliases for source compat at call sites. Rejected — postpones the cleanup.
+
+---
+
+## Migration steps (assuming the recommended decisions)
+
+### Step 1 — AST surface
+- Drop `CombStmt`, `CombIfElse`, `CombMatch`, `CombAssign` aliases.
+- Keep `Stmt`, `IfElse = IfElseOf<Stmt>`, `MatchStmt<S = Stmt>`, `ForLoop<S = Stmt>`, `MatchArm<S = Stmt>`. `ThreadStmt` and friends stay.
+- Add `pub enum BlockKind { Comb, Seq, PipelineStage }` to `ast.rs` (or a small new module — TBD by the executor).
+- `CombBlock.stmts: Vec<CombStmt>` becomes `CombBlock.stmts: Vec<Stmt>`. (`CombBlock` itself stays — it's the enclosing wrapper that tags "these are comb".)
+
+### Step 2 — Parser
+- `parse_comb_stmt -> Stmt` (was `CombStmt`). The `=` parser path produces `Stmt::Assign` directly.
+- `parse_comb_for_loop` returns `Stmt::For(ForLoop<Stmt>)` (no longer `CombStmt::For(ForLoop<CombStmt>)`).
+- `parse_comb_match` builds `MatchStmt<Stmt>` arms.
+- Generic `parse_for_loop_generic` from phase 5a stays — its `S` is now always `Stmt`. Could be inlined back into `parse_seq_for_loop` / `parse_comb_for_loop`, but harmless to keep generic.
+- Reject `<=` in `comb { }` and `=` in `seq { }` at parse time (already enforced — verify still enforced).
+
+### Step 3 — Typecheck
+- `check_reg_stmt` and `check_comb_stmt` collapse into `check_stmt(stmt, ..., block_kind)`. The body of the new function:
+  - `Stmt::Assign`: target must be a valid LHS for `block_kind` (reg in Seq, wire/port in Comb).
+  - `Stmt::Init`/`WaitUntil`/`DoUntil`: legal only in `Seq` or `PipelineStage`.
+  - `Stmt::IfElse`/`Match`/`For`: recurse with the same `block_kind`.
+- `collect_comb_stmt_reads` / `collect_comb_stmt_targets` and the seq equivalents collapse. New: `collect_stmt_reads(stmts: &[Stmt], block_kind, out)`.
+- The driven-set / latch-targets / handshake-payload walkers all unify the same way.
+
+### Step 4 — Codegen
+- `emit_reg_stmt` and `emit_comb_stmt` collapse into `emit_stmt(stmt, ctx: AssignCtx)`. `AssignCtx::Blocking` for comb; `AssignCtx::NonBlocking` for seq; `AssignCtx::PipelineComb` retains the pipeline-stage prefix-rewriting variant currently in `emit_pipeline_comb_stmt`.
+- `emit_reg_stmt_as_comb` (introduced as a fix for the comb For body bug pre-5a) is now redundant — delete.
+- `emit_for_loop_sv<S>` becomes `emit_for_loop_sv(f: &ForLoop, body_emit)` (no longer generic over S). Kept generic over the closure.
+
+### Step 5 — Sim codegen
+- `emit_reg_stmt` and `emit_comb_stmt` in `sim_codegen/mod.rs` collapse. The C++ assignment operator is `=` in both cases, so the merge is even simpler than for SV codegen — just unify the dispatch.
+- `sim_codegen/thread_sim.rs::emit_seq_stmt` / `emit_comb_stmt` collapse the same way.
+
+### Step 6 — Formal, elaborate, comb_graph
+- `formal::walk_reg_stmt` / `walk_comb_stmt` → single `walk_stmt`.
+- `elaborate::rewrite_reg_stmt_cc` / `rewrite_comb_stmt_cc` → single `rewrite_stmt_cc`.
+- `comb_graph::scan_comb_stmt` already only walks `CombStmt`. After merge, it's `scan_stmt` and walks `Stmt` from inside `CombBlock` only — same behavior, smaller surface.
+
+### Step 7 — Tests
+- Add a focused test: `<=` in a `comb` block → parse error.
+- Add a focused test: `=` in a `seq` block → parse error.
+- Add: `init on rst.asserted` inside a `comb` block → typecheck error (currently caught by it being a `Stmt`-only variant; after merge needs explicit `BlockKind::Comb` check).
+- Run full suite + snapshot diff. Expect zero behavioral changes.
+
+---
+
+## Risk assessment
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| Wrong assign operator emitted (`=` vs `<=` flipped at a call site) | Medium | Snapshot tests catch SV drift on every existing module |
+| `BlockKind` not propagated correctly into nested scopes | Medium | Phase 5a's regression test covers nested for-loop bodies; expand to nested if/match |
+| Pipeline-stage seq stmts (`WaitUntil`, `DoUntil`) misrouted | Low | `BlockKind::PipelineStage` variant carries the distinction; existing pipeline tests cover lowering |
+| `parse_comb_match` arm-body parse drift | Low | Phase 5a already fixed body type; this PR only changes the wrapping enum |
+| Snapshot drift not caught locally | Low | `cargo test` runs all 218 tests including 34 snapshot tests; CI catches anything else |
+| Sim semantics drift (NBA shadow vs immediate) | Low | Sim codegen uses `=` for both; merge doesn't change the actual C++ shape |
+
+The biggest non-obvious risk is **step 4**: the SV emitter has more comb/seq divergence than the sim emitter (sensitivity lists, `always_comb` vs `always_ff`, blocking vs non-blocking). The unified `emit_stmt` has to take `AssignCtx` *and* know whether it's inside an `always_ff` for the assertion-emit path.
+
+---
+
+## Effort & success criteria
+
+**Effort:** 1 day for an experienced reviewer of this codebase. Two-thirds of the diff is mechanical search-and-replace; the design work is concentrated in step 4 (codegen) and the `BlockKind` plumbing in step 3.
+
+**Success criteria (no negotiating):**
+- `cargo test` — 218/218 pass with zero snapshot drift.
+- `wc -l src/codegen.rs src/sim_codegen/mod.rs` — net decrease of ~600 lines combined (the duplicated walkers).
+- `grep -c CombStmt src/ -r` — zero (modulo doc comments referencing the historical name).
+- New tests cover the rejected-by-context cases (D2/D3): `<=` in comb, `=` in seq, `init` in comb.
+
+**Out of scope:**
+- `ThreadStmt` merge.
+- Full `BlockKind`-aware refactor of pipeline-stage timing analysis.
+- Renaming `CombBlock` (it's still meaningful — the *block* wrapper distinguishes comb from seq even when the *statement* type is unified).
+
+---
+
+## Open questions for the user
+
+Before executing, I want to confirm:
+
+1. **D1 (assign-operator dispatch)**: Implicit-from-context (a) or explicit field (b)?
+2. **D3 (`BlockKind` threading)**: Explicit param (a) or stack on `TypeChecker` (b)?
+3. **D5 (migration)**: One-shot PR (a) or stepwise (b)?
+
+Defaults are (a, a, a) — say "yes" if you want all three, or override individually.

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -607,26 +607,37 @@ pub struct ResourceDecl {
     pub span: Span,
 }
 
-#[derive(Debug, Clone)]
-pub struct CombBlock {
-    pub stmts: Vec<CombStmt>,
-    pub span: Span,
+/// Block context — propagated through typecheck and codegen so a single
+/// `Stmt` enum covers both comb (`=`) and seq (`<=`) blocks. The
+/// distinction is *where* the statement lives, not *what* it carries:
+/// the parser already enforces `=` only inside `comb { }` and `<=` only
+/// inside `seq { }`, so the AST node is unbiased and the context decides
+/// the rules at use sites.
+///
+/// - `Comb`: stmts inside a `comb` block. Assigns to `wire`/port targets only;
+///   blocking `=` in SV.
+/// - `Seq`: stmts inside a `seq on clk` block. Assigns to `reg` targets only;
+///   non-blocking `<=` in SV.
+/// - `PipelineStage`: a pipeline-stage seq block — same rules as `Seq` plus
+///   `wait until` / `do until` are legal here only.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BlockKind {
+    Comb,
+    Seq,
+    PipelineStage,
 }
 
 #[derive(Debug, Clone)]
-pub enum CombStmt {
-    Assign(CombAssign),
-    IfElse(CombIfElse),
-    MatchExpr(CombMatch),
-    Log(LogStmt),
-    For(ForLoop<CombStmt>),
+pub struct CombBlock {
+    pub stmts: Vec<Stmt>,
+    pub span: Span,
 }
 
 /// Assignment statement: `target = expr;` (combinational, in `comb` blocks)
 /// or `target <= expr;` (sequential, in `seq` blocks / thread seq-assigns).
-/// The assignment kind (blocking vs non-blocking) is determined by which
-/// enum wraps it: `CombStmt::Assign` is blocking, `Stmt::Assign` and
-/// `ThreadStmt::SeqAssign` are non-blocking.
+/// Pre-5b this was wrapped in `CombStmt::Assign` vs `Stmt::Assign` to encode
+/// blocking vs non-blocking; that distinction now lives in the enclosing
+/// block context (`BlockKind` for typecheck, `AssignCtx` for codegen).
 #[derive(Debug, Clone)]
 pub struct Assign {
     pub target: Expr,
@@ -634,19 +645,11 @@ pub struct Assign {
     pub span: Span,
 }
 
-// CombAssign and RegAssign are aliases for Assign — previously three
-// identical structs; now unified. Both names kept for readability at
-// call sites (CombAssign for blocking `=`, RegAssign for non-blocking `<=`).
+/// Readability alias for `Assign` used at thread/sites where the *blocking*
+/// (combinational) form is the intent — `target = expr;`. The struct itself
+/// is unbiased; the enclosing context (or the wrapping enum variant)
+/// decides emit semantics.
 pub type CombAssign = Assign;
-
-pub type CombIfElse = IfElseOf<CombStmt>;
-
-/// `comb`-block match. A type alias for `MatchStmt<CombStmt>` — the arm
-/// bodies are comb statements (use `=`), not seq statements. Previously
-/// declared as a separate struct with `Vec<MatchArm>` (seq-typed bodies),
-/// which forced the comb typecheck to delegate match-arm bodies to
-/// `check_reg_stmt`. Now the arms parametrically carry comb stmts.
-pub type CombMatch = MatchStmt<CombStmt>;
 
 #[derive(Debug, Clone)]
 pub struct LetBinding {
@@ -1150,7 +1153,7 @@ pub struct FsmDecl {
     /// The reset / default state
     pub default_state: Ident,
     /// Default block: comb and seq statements applied before the state case
-    pub default_comb: Vec<CombStmt>,
+    pub default_comb: Vec<Stmt>,
     pub default_seq: Vec<Stmt>,
     /// State bodies (`state Foo ... end state Foo`)
     pub states: Vec<StateBody>,
@@ -1167,7 +1170,7 @@ impl std::ops::DerefMut for FsmDecl {
 pub struct StateBody {
     pub name: Ident,
     /// Combinational output assignments for this state
-    pub comb_stmts: Vec<CombStmt>,
+    pub comb_stmts: Vec<Stmt>,
     /// Sequential register assignments for this state
     pub seq_stmts: Vec<Stmt>,
     pub transitions: Vec<Transition>,

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -17,13 +17,19 @@ fn stmt_span_start(stmt: &Stmt) -> usize {
     }
 }
 
-fn comb_stmt_span_start(stmt: &CombStmt) -> usize {
+fn comb_stmt_span_start(stmt: &Stmt) -> usize {
     match stmt {
-        CombStmt::Assign(a) => a.span.start,
-        CombStmt::IfElse(i) => i.span.start,
-        CombStmt::MatchExpr(m) => m.span.start,
-        CombStmt::Log(l) => l.span.start,
-        CombStmt::For(f) => f.span.start,
+        Stmt::Assign(a) => a.span.start,
+        Stmt::IfElse(i) => i.span.start,
+        Stmt::Match(m) => m.span.start,
+        Stmt::Log(l) => l.span.start,
+        Stmt::For(f) => f.span.start,
+        // Seq-only variants — typecheck rejects these in `comb` context, so
+        // a comb-only walker should never see them. Keep the arm for the
+        // exhaustiveness checker; the panic is a defensive belt-and-suspenders.
+        Stmt::Init(ib) => ib.span.start,
+        Stmt::WaitUntil(_, sp) => sp.start,
+        Stmt::DoUntil { span, .. } => span.start,
     }
 }
 
@@ -1108,22 +1114,22 @@ impl<'a> Codegen<'a> {
     fn collect_log_files(body: &[ModuleBodyItem]) -> Vec<String> {
         let mut files = Vec::new();
         let mut seen = std::collections::HashSet::new();
-        fn collect_from_comb(stmts: &[CombStmt], files: &mut Vec<String>, seen: &mut std::collections::HashSet<String>) {
+        fn collect_from_comb(stmts: &[Stmt], files: &mut Vec<String>, seen: &mut std::collections::HashSet<String>) {
             for stmt in stmts {
                 match stmt {
-                    CombStmt::Log(l) => {
+                    Stmt::Log(l) => {
                         if let Some(ref path) = l.file {
                             if seen.insert(path.clone()) { files.push(path.clone()); }
                         }
                     }
-                    CombStmt::IfElse(ie) => {
+                    Stmt::IfElse(ie) => {
                         collect_from_comb(&ie.then_stmts, files, seen);
                         collect_from_comb(&ie.else_stmts, files, seen);
                     }
-                    CombStmt::MatchExpr(m) => {
+                    Stmt::Match(m) => {
                         for arm in &m.arms { collect_from_comb(&arm.body, files, seen); }
                     }
-                    CombStmt::For(f) => {
+                    Stmt::For(f) => {
                         collect_from_comb(&f.body, files, seen);
                     }
                     _ => {}
@@ -1252,12 +1258,12 @@ impl<'a> Codegen<'a> {
         // Simple assign form only when every statement is a plain assign with
         // no match-expression RHS (those need always_comb for the case block).
         let all_simple = cb.stmts.iter().all(|s| match s {
-            CombStmt::Assign(a) => !matches!(a.value.kind, ExprKind::ExprMatch(..)),
+            Stmt::Assign(a) => !matches!(a.value.kind, ExprKind::ExprMatch(..)),
             _ => false,
         });
         if all_simple {
             for stmt in &cb.stmts {
-                if let CombStmt::Assign(a) = stmt {
+                if let Stmt::Assign(a) = stmt {
                     let val = self.emit_expr_str(&a.value);
                     let tgt = self.emit_expr_str(&a.target);
                     self.line(&format!("assign {} = {};", tgt, val));
@@ -1279,7 +1285,7 @@ impl<'a> Codegen<'a> {
     fn module_has_log(body: &[ModuleBodyItem]) -> bool {
         body.iter().any(|item| match item {
             ModuleBodyItem::RegBlock(rb) => rb.stmts.iter().any(Self::stmt_has_log),
-            ModuleBodyItem::CombBlock(cb) => cb.stmts.iter().any(Self::comb_stmt_has_log),
+            ModuleBodyItem::CombBlock(cb) => cb.stmts.iter().any(Self::stmt_has_log),
             _ => false,
         })
     }
@@ -1295,17 +1301,6 @@ impl<'a> Codegen<'a> {
             Stmt::Init(ib) => ib.body.iter().any(Self::stmt_has_log),
             Stmt::WaitUntil(_, _) => false,
             Stmt::DoUntil { body, .. } => body.iter().any(Self::stmt_has_log),
-        }
-    }
-
-    fn comb_stmt_has_log(s: &CombStmt) -> bool {
-        match s {
-            CombStmt::Log(_) => true,
-            CombStmt::IfElse(ie) => ie.then_stmts.iter().any(Self::comb_stmt_has_log)
-                || ie.else_stmts.iter().any(Self::comb_stmt_has_log),
-            CombStmt::Assign(_) => false,
-            CombStmt::MatchExpr(m) => m.arms.iter().any(|a| a.body.iter().any(Self::comb_stmt_has_log)),
-            CombStmt::For(f) => f.body.iter().any(Self::comb_stmt_has_log),
         }
     }
 
@@ -1372,10 +1367,10 @@ impl<'a> Codegen<'a> {
         format!("_log_fd_{clean}")
     }
 
-    fn emit_comb_stmt(&mut self, stmt: &CombStmt) {
+    fn emit_comb_stmt(&mut self, stmt: &Stmt) {
         self.emit_comments_before(comb_stmt_span_start(stmt));
         match stmt {
-            CombStmt::Assign(a) => {
+            Stmt::Assign(a) => {
                 // Match-expression RHS: emit as a case block for readability
                 if let ExprKind::ExprMatch(scrutinee, arms) = &a.value.kind {
                     let s = self.emit_expr_str(scrutinee);
@@ -1403,10 +1398,10 @@ impl<'a> Codegen<'a> {
                     self.line(&format!("{} = {};", tgt, val));
                 }
             }
-            CombStmt::IfElse(ie) => {
+            Stmt::IfElse(ie) => {
                 self.emit_comb_if_else(ie);
             }
-            CombStmt::MatchExpr(m) => {
+            Stmt::Match(m) => {
                 let scrut = self.emit_expr_str(&m.scrutinee);
                 let u = if m.unique { "unique " } else { "" };
                 self.line(&format!("{}case ({})", u, scrut));
@@ -1424,18 +1419,23 @@ impl<'a> Codegen<'a> {
                 self.indent -= 1;
                 self.line("endcase");
             }
-            CombStmt::Log(l) => { self.emit_log_stmt(l); }
-            CombStmt::For(f) => {
+            Stmt::Log(l) => { self.emit_log_stmt(l); }
+            Stmt::For(f) => {
                 self.emit_for_loop_sv(f, |s, stmt| s.emit_comb_stmt(stmt));
+            }
+            // Seq-only variants are rejected in `comb` context by typecheck;
+            // a comb-only walker should never see them.
+            Stmt::Init(_) | Stmt::WaitUntil(..) | Stmt::DoUntil { .. } => {
+                unreachable!("seq-only Stmt variant inside comb block — typecheck bug");
             }
         }
     }
 
-    fn emit_comb_if_else(&mut self, ie: &CombIfElse) {
+    fn emit_comb_if_else(&mut self, ie: &IfElse) {
         self.emit_comb_if_else_inner(ie, false);
     }
 
-    fn emit_comb_if_else_inner(&mut self, ie: &CombIfElse, is_chain: bool) {
+    fn emit_comb_if_else_inner(&mut self, ie: &IfElse, is_chain: bool) {
         let cond = self.emit_expr_str(&ie.cond);
         let u = if ie.unique && !is_chain { "unique " } else { "" };
         if is_chain {
@@ -1449,7 +1449,7 @@ impl<'a> Codegen<'a> {
         }
         self.indent -= 1;
         if ie.else_stmts.len() == 1 {
-            if let CombStmt::IfElse(nested) = &ie.else_stmts[0] {
+            if let Stmt::IfElse(nested) = &ie.else_stmts[0] {
                 self.emit_comb_if_else_inner(nested, true);
                 return;
             }
@@ -4434,10 +4434,10 @@ impl<'a> Codegen<'a> {
             let prefix = stage.name.name.to_lowercase();
             for item in &stage.body {
                 if let ModuleBodyItem::CombBlock(cb) = item {
-                    let all_simple = cb.stmts.iter().all(|s| matches!(s, CombStmt::Assign(_)));
+                    let all_simple = cb.stmts.iter().all(|s| matches!(s, Stmt::Assign(_)));
                     if all_simple {
                         for stmt in &cb.stmts {
-                            if let CombStmt::Assign(a) = stmt {
+                            if let Stmt::Assign(a) = stmt {
                                 let val = self.emit_pipeline_stage_expr_str(&a.value, &prefix, si, &stage_names, &stage_regs, &port_names);
                                 let target = if let ExprKind::Ident(name) = &a.target.kind {
                                     if port_names.contains(name) {
@@ -4779,18 +4779,18 @@ impl<'a> Codegen<'a> {
     }
 
     /// Collect all unique comb assign targets from a list of comb statements (recursive).
-    fn collect_comb_targets(stmts: &[CombStmt]) -> Vec<String> {
+    fn collect_comb_targets(stmts: &[Stmt]) -> Vec<String> {
         let mut targets = Vec::new();
         for stmt in stmts {
             match stmt {
-                CombStmt::Assign(a) => {
+                Stmt::Assign(a) => {
                     if let ExprKind::Ident(name) = &a.target.kind {
                         if !targets.contains(name) {
                             targets.push(name.clone());
                         }
                     }
                 }
-                CombStmt::IfElse(ie) => {
+                Stmt::IfElse(ie) => {
                     for t in Self::collect_comb_targets(&ie.then_stmts) {
                         if !targets.contains(&t) { targets.push(t); }
                     }
@@ -4798,16 +4798,18 @@ impl<'a> Codegen<'a> {
                         if !targets.contains(&t) { targets.push(t); }
                     }
                 }
-                CombStmt::MatchExpr(_) | CombStmt::Log(_) => {}
-                CombStmt::For(f) => {
-                    // Comb for-loop body is Vec<CombStmt>; collect ident targets from assigns.
+                Stmt::Match(_) | Stmt::Log(_) => {}
+                Stmt::For(f) => {
                     for s in &f.body {
-                        if let CombStmt::Assign(a) = s {
+                        if let Stmt::Assign(a) = s {
                             if let ExprKind::Ident(name) = &a.target.kind {
                                 if !targets.contains(name) { targets.push(name.clone()); }
                             }
                         }
                     }
+                }
+                Stmt::Init(_) | Stmt::WaitUntil(..) | Stmt::DoUntil { .. } => {
+                    unreachable!("seq-only Stmt variant inside comb-context walker");
                 }
             }
         }
@@ -4847,14 +4849,14 @@ impl<'a> Codegen<'a> {
     /// Looks for known registers (local or cross-stage) in assignment RHS.
     fn resolve_comb_wire_type(
         target: &str,
-        stmts: &[CombStmt],
+        stmts: &[Stmt],
         current_stage_idx: usize,
         stage_regs: &[Vec<(String, String, String)>],
         stage_names: &[&str],
     ) -> Option<String> {
         for stmt in stmts {
             match stmt {
-                CombStmt::Assign(a) if matches!(&a.target.kind, ExprKind::Ident(n) if n == target) => {
+                Stmt::Assign(a) if matches!(&a.target.kind, ExprKind::Ident(n) if n == target) => {
                     // Check if RHS is a bare identifier (local register)
                     if let ExprKind::Ident(name) = &a.value.kind {
                         if let Some(r) = stage_regs[current_stage_idx].iter()
@@ -4876,7 +4878,7 @@ impl<'a> Codegen<'a> {
                         }
                     }
                 }
-                CombStmt::IfElse(ie) => {
+                Stmt::IfElse(ie) => {
                     if let Some(ty) = Self::resolve_comb_wire_type(target, &ie.then_stmts, current_stage_idx, stage_regs, stage_names) {
                         return Some(ty);
                     }
@@ -4894,7 +4896,7 @@ impl<'a> Codegen<'a> {
     /// Handles Assign, IfElse with pipeline name rewriting.
     fn emit_pipeline_comb_stmt(
         &mut self,
-        stmt: &CombStmt,
+        stmt: &Stmt,
         current_prefix: &str,
         current_stage_idx: usize,
         stage_names: &[&str],
@@ -4902,7 +4904,7 @@ impl<'a> Codegen<'a> {
         port_names: &std::collections::HashSet<String>,
     ) {
         match stmt {
-            CombStmt::Assign(a) => {
+            Stmt::Assign(a) => {
                 let val = self.emit_pipeline_stage_expr_str(&a.value, current_prefix, current_stage_idx, stage_names, stage_regs, port_names);
                 let target = if let ExprKind::Ident(name) = &a.target.kind {
                     if port_names.contains(name) {
@@ -4915,16 +4917,17 @@ impl<'a> Codegen<'a> {
                 };
                 self.line(&format!("{} = {};", target, val));
             }
-            CombStmt::IfElse(ie) => {
+            Stmt::IfElse(ie) => {
                 self.emit_pipeline_comb_if_else(ie, current_prefix, current_stage_idx, stage_names, stage_regs, port_names, false);
             }
-            CombStmt::MatchExpr(_) => {} // TODO if needed
-            CombStmt::Log(l) => { self.emit_log_stmt(l); }
-            CombStmt::For(f) => {
+            Stmt::Match(_) => {} // TODO if needed
+            Stmt::Log(l) => { self.emit_log_stmt(l); }
+            Stmt::For(f) => {
                 self.emit_for_loop_sv(f, |s, stmt| {
                     s.emit_pipeline_comb_stmt(stmt, current_prefix, current_stage_idx, stage_names, stage_regs, port_names);
                 });
             }
+                Stmt::Init(_) | Stmt::WaitUntil(..) | Stmt::DoUntil { .. } => unreachable!("seq-only Stmt variant inside comb-context walker"),
         }
     }
 
@@ -4968,7 +4971,7 @@ impl<'a> Codegen<'a> {
 
     fn emit_pipeline_comb_if_else(
         &mut self,
-        ie: &CombIfElse,
+        ie: &IfElse,
         current_prefix: &str,
         current_stage_idx: usize,
         stage_names: &[&str],
@@ -4988,7 +4991,7 @@ impl<'a> Codegen<'a> {
         }
         self.indent -= 1;
         if ie.else_stmts.len() == 1 {
-            if let CombStmt::IfElse(nested) = &ie.else_stmts[0] {
+            if let Stmt::IfElse(nested) = &ie.else_stmts[0] {
                 self.emit_pipeline_comb_if_else(nested, current_prefix, current_stage_idx, stage_names, stage_regs, port_names, true);
                 return;
             }

--- a/src/comb_graph.rs
+++ b/src/comb_graph.rs
@@ -8,7 +8,7 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 
 use crate::ast::{
-    ConnectDir, CombStmt, ExprKind, FsmDecl, InsideMember, InstDecl, Item,
+    ConnectDir, Stmt, ExprKind, FsmDecl, InsideMember, InstDecl, Item,
     ModuleBodyItem, ModuleDecl, PortDecl, RamDecl, SourceFile, TypeExpr,
 };
 use crate::diagnostics::CompileError;
@@ -132,17 +132,17 @@ fn lhs_base_name(expr: &crate::ast::Expr) -> Option<String> {
 
 // ── Scanning helpers ──────────────────────────────────────────────────────────
 
-/// Recursively scan a single `CombStmt` and accumulate driven outputs and
+/// Recursively scan a single `Stmt` and accumulate driven outputs and
 /// read inputs.
 fn scan_comb_stmt(
-    stmt: &CombStmt,
+    stmt: &Stmt,
     input_names: &HashSet<String>,
     output_names: &HashSet<String>,
     driven: &mut HashSet<String>,
     read: &mut HashSet<String>,
 ) {
     match stmt {
-        CombStmt::Assign(a) => {
+        Stmt::Assign(a) => {
             if let Some(lhs) = lhs_base_name(&a.target) {
                 if output_names.contains(&lhs) {
                     driven.insert(lhs);
@@ -154,7 +154,7 @@ fn scan_comb_stmt(
                 if input_names.contains(id) { read.insert(id.clone()); }
             }
         }
-        CombStmt::IfElse(ife) => {
+        Stmt::IfElse(ife) => {
             // Condition reads count as comb deps
             let mut cond = HashSet::new();
             collect_expr_idents(&ife.cond, &mut cond);
@@ -164,7 +164,7 @@ fn scan_comb_stmt(
             for s in &ife.then_stmts { scan_comb_stmt(s, input_names, output_names, driven, read); }
             for s in &ife.else_stmts { scan_comb_stmt(s, input_names, output_names, driven, read); }
         }
-        CombStmt::MatchExpr(m) => {
+        Stmt::Match(m) => {
             // Scrutinee
             let mut scrut = HashSet::new();
             collect_expr_idents(&m.scrutinee, &mut scrut);
@@ -177,17 +177,18 @@ fn scan_comb_stmt(
                 }
             }
         }
-        CombStmt::For(f) => {
+        Stmt::For(f) => {
             for s in &f.body {
                 scan_comb_stmt(s, input_names, output_names, driven, read);
             }
         }
-        CombStmt::Log(_) => {}
+            Stmt::Init(_) | Stmt::WaitUntil(..) | Stmt::DoUntil { .. } => unreachable!("seq-only Stmt variant inside comb-context walker"),
+        Stmt::Log(_) => {}
     }
 }
 
 fn scan_comb_stmts(
-    stmts: &[CombStmt],
+    stmts: &[Stmt],
     input_names: &HashSet<String>,
     output_names: &HashSet<String>,
     driven: &mut HashSet<String>,

--- a/src/elaborate.rs
+++ b/src/elaborate.rs
@@ -595,19 +595,20 @@ fn check_gen_for_reg_stmts(stmts: &[Stmt], var: &str, errors: &mut Vec<CompileEr
     }
 }
 
-fn check_gen_for_comb_stmts(stmts: &[CombStmt], var: &str, errors: &mut Vec<CompileError>) {
+fn check_gen_for_comb_stmts(stmts: &[Stmt], var: &str, errors: &mut Vec<CompileError>) {
     for s in stmts {
         match s {
-            CombStmt::Assign(a) => reject_bad_lhs(&a.target, var, errors),
-            CombStmt::IfElse(ie) => {
+            Stmt::Assign(a) => reject_bad_lhs(&a.target, var, errors),
+            Stmt::IfElse(ie) => {
                 check_gen_for_comb_stmts(&ie.then_stmts, var, errors);
                 check_gen_for_comb_stmts(&ie.else_stmts, var, errors);
             }
-            CombStmt::MatchExpr(m) => {
+            Stmt::Match(m) => {
                 for arm in &m.arms { check_gen_for_comb_stmts(&arm.body, var, errors); }
             }
-            CombStmt::For(f) => check_gen_for_comb_stmts(&f.body, var, errors),
-            CombStmt::Log(_) => {}
+            Stmt::For(f) => check_gen_for_comb_stmts(&f.body, var, errors),
+                Stmt::Init(_) | Stmt::WaitUntil(..) | Stmt::DoUntil { .. } => unreachable!("seq-only Stmt variant inside comb-context walker"),
+            Stmt::Log(_) => {}
         }
     }
 }
@@ -665,14 +666,14 @@ fn subst_comb_block(cb: &CombBlock, var: &str, val: i64) -> CombBlock {
     }
 }
 
-fn subst_comb_stmt(s: &CombStmt, var: &str, val: i64) -> CombStmt {
+fn subst_comb_stmt(s: &Stmt, var: &str, val: i64) -> Stmt {
     match s {
-        CombStmt::Assign(a) => CombStmt::Assign(Assign {
+        Stmt::Assign(a) => Stmt::Assign(Assign {
             target: subst_expr_names(a.target.clone(), var, val),
             value:  subst_expr_names(a.value.clone(),  var, val),
             span:   a.span,
         }),
-        CombStmt::IfElse(ie) => CombStmt::IfElse(IfElseOf {
+        Stmt::IfElse(ie) => Stmt::IfElse(IfElseOf {
             cond:       subst_expr_names(ie.cond.clone(), var, val),
             then_stmts: ie.then_stmts.iter().map(|x| subst_comb_stmt(x, var, val)).collect(),
             else_stmts: ie.else_stmts.iter().map(|x| subst_comb_stmt(x, var, val)).collect(),
@@ -1469,10 +1470,10 @@ fn lower_module_threads(m: ModuleDecl, opts: &ThreadLowerOpts) -> Result<(Module
         }));
 
         // Pack/unpack between scalar wires and packed vectors.
-        let mut pack_stmts: Vec<CombStmt> = Vec::new();
+        let mut pack_stmts: Vec<Stmt> = Vec::new();
         for ti in 0..n_threads {
             // _packed[ti] = _req_ti
-            pack_stmts.push(CombStmt::Assign(CombAssign {
+            pack_stmts.push(Stmt::Assign(CombAssign {
                 target: Expr::new(ExprKind::Index(
                     Box::new(Expr::new(ExprKind::Ident(req_packed.clone()), sp)),
                     Box::new(Expr::new(ExprKind::Literal(LitKind::Dec(ti as u64)), sp)),
@@ -1481,7 +1482,7 @@ fn lower_module_threads(m: ModuleDecl, opts: &ThreadLowerOpts) -> Result<(Module
                 span: sp,
             }));
             // _grant_ti = _grant_packed[ti]
-            pack_stmts.push(CombStmt::Assign(CombAssign {
+            pack_stmts.push(Stmt::Assign(CombAssign {
                 target: Expr::new(ExprKind::Ident(format!("_{}_grant_{}", res_name, ti)), sp),
                 value: Expr::new(ExprKind::Index(
                     Box::new(Expr::new(ExprKind::Ident(grant_packed.clone()), sp)),
@@ -1608,7 +1609,7 @@ fn lower_module_threads(m: ModuleDecl, opts: &ThreadLowerOpts) -> Result<(Module
     }
 
     // ── Per-thread state machines ──────────────────────────────────────
-    let mut all_thread_comb: Vec<CombStmt> = Vec::new();
+    let mut all_thread_comb: Vec<Stmt> = Vec::new();
     let mut all_thread_seq: Vec<Stmt> = Vec::new();
     // Auto-emitted SVA spec-contract properties (gated by `opts.auto_asserts`).
     // Reset-guarded antecedent so they don't fire during reset.
@@ -1975,7 +1976,7 @@ fn lower_module_threads(m: ModuleDecl, opts: &ThreadLowerOpts) -> Result<(Module
             // This state's own comb outputs
             if !raw.comb_stmts.is_empty() {
                 let transformed_stmts = transform_shared_or_assigns(&raw.comb_stmts, &shared_or_signals, sp);
-                all_thread_comb.push(CombStmt::IfElse(CombIfElse {
+                all_thread_comb.push(Stmt::IfElse(IfElse {
                     cond: state_cond.clone(),
                     then_stmts: transformed_stmts,
                     else_stmts: Vec::new(),
@@ -2037,11 +2038,11 @@ fn lower_module_threads(m: ModuleDecl, opts: &ThreadLowerOpts) -> Result<(Module
     }
 
     // ── Merged comb block: defaults + all per-thread comb stmts ──────
-    let mut merged_comb: Vec<CombStmt> = Vec::new();
+    let mut merged_comb: Vec<Stmt> = Vec::new();
     // Defaults: all comb outputs = 0
     for p in &merged_ports {
         if p.direction == Direction::Out && p.default.is_some() {
-            merged_comb.push(CombStmt::Assign(CombAssign {
+            merged_comb.push(Stmt::Assign(CombAssign {
                 target: Expr::new(ExprKind::Ident(p.name.name.clone()), sp),
                 value: p.default.as_ref().unwrap().clone(),
                 span: sp,
@@ -2051,7 +2052,7 @@ fn lower_module_threads(m: ModuleDecl, opts: &ThreadLowerOpts) -> Result<(Module
     // Default lock req = 0
     for res_name in &all_resources {
         for ti in 0..threads.len() {
-            merged_comb.push(CombStmt::Assign(CombAssign {
+            merged_comb.push(Stmt::Assign(CombAssign {
                 target: Expr::new(ExprKind::Ident(format!("_{}_req_{}", res_name, ti)), sp),
                 value: Expr::new(ExprKind::Bool(false), sp),
                 span: sp,
@@ -2061,7 +2062,7 @@ fn lower_module_threads(m: ModuleDecl, opts: &ThreadLowerOpts) -> Result<(Module
     // Default shared(or) seq per-thread input wires = 0
     for sig_name in &shared_or_seq {
         for ti in 0..n_threads {
-            merged_comb.push(CombStmt::Assign(CombAssign {
+            merged_comb.push(Stmt::Assign(CombAssign {
                 target: Expr::new(ExprKind::Ident(format!("_{}_in_{}", sig_name, ti)), sp),
                 value: make_zero_expr(sp),
                 span: sp,
@@ -2470,7 +2471,7 @@ fn collect_expr_index_reads(e: &Expr, out: &mut HashSet<String>) {
 /// A single FSM state derived from thread body partitioning.
 struct ThreadFsmState {
     /// Combinational assignments active in this state.
-    comb_stmts: Vec<CombStmt>,
+    comb_stmts: Vec<Stmt>,
     /// Sequential assignments that fire on the transition out of this state.
     seq_stmts: Vec<Stmt>,
     /// Transition condition (from `wait until`).  None = unconditional.
@@ -2659,13 +2660,13 @@ fn partition_thread_body(
     cnt_width: u32,
 ) -> Result<Vec<ThreadFsmState>, CompileError> {
     let mut states: Vec<ThreadFsmState> = Vec::new();
-    let mut cur_comb: Vec<CombStmt> = Vec::new();
+    let mut cur_comb: Vec<Stmt> = Vec::new();
     let mut cur_seq: Vec<Stmt> = Vec::new();
 
     for stmt in body {
         match stmt {
             ThreadStmt::CombAssign(ca) => {
-                cur_comb.push(CombStmt::Assign(ca.clone()));
+                cur_comb.push(Stmt::Assign(ca.clone()));
             }
             ThreadStmt::SeqAssign(ra) => {
                 cur_seq.push(Stmt::Assign(ra.clone()));
@@ -2833,7 +2834,7 @@ fn partition_thread_body(
                         (neg_cond, else_target),
                     ];
                 } else {
-                    // Same-state conditional: convert to CombIfElse / IfElse for comb and seq
+                    // Same-state conditional: convert to IfElse / IfElse for comb and seq
                     let (comb_if, seq_if) = thread_if_to_fsm_stmts(ie);
                     if let Some(c) = comb_if { cur_comb.push(c); }
                     if let Some(s) = seq_if { cur_seq.push(s); }
@@ -2957,12 +2958,12 @@ fn partition_thread_body(
                     });
                 }
                 // Collect the do-body's assigns: comb stays in-state, seq stays in-state
-                let mut do_comb: Vec<CombStmt> = Vec::new();
+                let mut do_comb: Vec<Stmt> = Vec::new();
                 let mut do_seq: Vec<Stmt> = Vec::new();
                 for s in body {
                     match s {
                         ThreadStmt::CombAssign(ca) => {
-                            do_comb.push(CombStmt::Assign(ca.clone()));
+                            do_comb.push(Stmt::Assign(ca.clone()));
                         }
                         ThreadStmt::SeqAssign(ra) => {
                             do_seq.push(Stmt::Assign(ra.clone()));
@@ -3362,7 +3363,7 @@ fn lower_thread_lock(
     let grant_signal = format!("_{}_grant", resource_name);
 
     let make_grant = || Expr::new(ExprKind::Ident(grant_signal.clone()), span);
-    let req_assign = CombStmt::Assign(CombAssign {
+    let req_assign = Stmt::Assign(CombAssign {
         target: Expr::new(ExprKind::Ident(req_signal.clone()), span),
         value: Expr::new(ExprKind::Literal(LitKind::Dec(1)), span),
         span,
@@ -3379,9 +3380,9 @@ fn lower_thread_lock(
     // Without grant gating, all contending threads would drive outputs simultaneously.
     if let Some(first) = body_states.first_mut() {
         // Wrap ALL comb outputs (except req) in `if (grant) { ... }`
-        let non_req_comb: Vec<CombStmt> = first.comb_stmts.iter()
+        let non_req_comb: Vec<Stmt> = first.comb_stmts.iter()
             .filter(|s| {
-                if let CombStmt::Assign(a) = s {
+                if let Stmt::Assign(a) = s {
                     if let ExprKind::Ident(ref n) = a.target.kind {
                         return *n != req_signal;
                     }
@@ -3392,7 +3393,7 @@ fn lower_thread_lock(
             .collect();
         // Keep only req assign at top level
         first.comb_stmts.retain(|s| {
-            if let CombStmt::Assign(a) = s {
+            if let Stmt::Assign(a) = s {
                 if let ExprKind::Ident(ref n) = a.target.kind {
                     return *n == req_signal;
                 }
@@ -3401,7 +3402,7 @@ fn lower_thread_lock(
         });
         // Add grant-gated outputs
         if !non_req_comb.is_empty() {
-            first.comb_stmts.push(CombStmt::IfElse(CombIfElse {
+            first.comb_stmts.push(Stmt::IfElse(IfElse {
                 cond: make_grant(),
                 then_stmts: non_req_comb,
                 else_stmts: Vec::new(),
@@ -3554,16 +3555,16 @@ fn rewrite_var_expr(expr: Expr, var: &str, replacement: &str) -> Expr {
 }
 
 /// Convert a ThreadIfElse (no waits) into FSM comb and seq statements.
-fn thread_if_to_fsm_stmts(ie: &ThreadIfElse) -> (Option<CombStmt>, Option<Stmt>) {
+fn thread_if_to_fsm_stmts(ie: &ThreadIfElse) -> (Option<Stmt>, Option<Stmt>) {
     let mut then_comb = Vec::new();
     let mut then_seq = Vec::new();
     let mut else_comb = Vec::new();
     let mut else_seq = Vec::new();
 
-    fn partition_stmts(stmts: &[ThreadStmt], comb: &mut Vec<CombStmt>, seq: &mut Vec<Stmt>) {
+    fn partition_stmts(stmts: &[ThreadStmt], comb: &mut Vec<Stmt>, seq: &mut Vec<Stmt>) {
         for s in stmts {
             match s {
-                ThreadStmt::CombAssign(ca) => comb.push(CombStmt::Assign(ca.clone())),
+                ThreadStmt::CombAssign(ca) => comb.push(Stmt::Assign(ca.clone())),
                 ThreadStmt::SeqAssign(ra) => seq.push(Stmt::Assign(ra.clone())),
                 ThreadStmt::Log(l) => seq.push(Stmt::Log(l.clone())),
                 ThreadStmt::IfElse(nested) => {
@@ -3580,7 +3581,7 @@ fn thread_if_to_fsm_stmts(ie: &ThreadIfElse) -> (Option<CombStmt>, Option<Stmt>)
     partition_stmts(&ie.else_stmts, &mut else_comb, &mut else_seq);
 
     let comb_if = if !then_comb.is_empty() || !else_comb.is_empty() {
-        Some(CombStmt::IfElse(CombIfElse {
+        Some(Stmt::IfElse(IfElse {
             cond: ie.cond.clone(),
             then_stmts: then_comb,
             else_stmts: else_comb,
@@ -3611,7 +3612,7 @@ fn rewrite_shared_or_seq_stmts(
     shared_or_seq: &HashSet<String>,
     thread_idx: usize,
     sp: Span,
-    out_comb: &mut Vec<CombStmt>,
+    out_comb: &mut Vec<Stmt>,
 ) -> Vec<Stmt> {
     let mut kept = Vec::new();
     for stmt in stmts {
@@ -3620,7 +3621,7 @@ fn rewrite_shared_or_seq_stmts(
                 if let Some(name) = expr_root_name(&ra.target) {
                     if shared_or_seq.contains(&name) {
                         let shadow = format!("_{}_in_{}", name, thread_idx);
-                        out_comb.push(CombStmt::Assign(CombAssign {
+                        out_comb.push(Stmt::Assign(CombAssign {
                             target: Expr::new(ExprKind::Ident(shadow), sp),
                             value: ra.value.clone(),
                             span: ra.span,
@@ -3639,7 +3640,7 @@ fn rewrite_shared_or_seq_stmts(
                     &ie.else_stmts, shared_or_seq, thread_idx, sp, &mut else_comb);
                 // Push rewritten comb assigns under the same if guard
                 if !then_comb.is_empty() || !else_comb.is_empty() {
-                    out_comb.push(CombStmt::IfElse(CombIfElse {
+                    out_comb.push(Stmt::IfElse(IfElse {
                         cond: ie.cond.clone(),
                         then_stmts: then_comb,
                         else_stmts: else_comb,
@@ -3666,13 +3667,13 @@ fn rewrite_shared_or_seq_stmts(
 /// Transform comb assigns for shared(or) signals: `sig = val` → `sig = sig | val`.
 /// This ensures multiple threads OR-accumulate rather than last-writer-wins.
 fn transform_shared_or_assigns(
-    stmts: &[CombStmt],
+    stmts: &[Stmt],
     shared_or: &HashSet<String>,
     sp: Span,
-) -> Vec<CombStmt> {
+) -> Vec<Stmt> {
     stmts.iter().map(|stmt| {
         match stmt {
-            CombStmt::Assign(a) => {
+            Stmt::Assign(a) => {
                 let target_name = match &a.target.kind {
                     ExprKind::Ident(n) => Some(n.clone()),
                     _ => None,
@@ -3680,7 +3681,7 @@ fn transform_shared_or_assigns(
                 if let Some(ref name) = target_name {
                     if shared_or.contains(name) {
                         // sig = sig | val
-                        return CombStmt::Assign(CombAssign {
+                        return Stmt::Assign(CombAssign {
                             target: a.target.clone(),
                             value: Expr::new(ExprKind::Binary(
                                 BinOp::BitOr,
@@ -3693,8 +3694,8 @@ fn transform_shared_or_assigns(
                 }
                 stmt.clone()
             }
-            CombStmt::IfElse(ie) => {
-                CombStmt::IfElse(CombIfElse {
+            Stmt::IfElse(ie) => {
+                Stmt::IfElse(IfElse {
                     cond: ie.cond.clone(),
                     then_stmts: transform_shared_or_assigns(&ie.then_stmts, shared_or, sp),
                     else_stmts: transform_shared_or_assigns(&ie.else_stmts, shared_or, sp),
@@ -3740,11 +3741,11 @@ fn rename_ident_in_stmts(stmts: &mut [Stmt], old: &str, new: &str) {
     }
 }
 
-fn rename_ident_in_comb_stmts(stmts: &mut [CombStmt], old: &str, new: &str) {
+fn rename_ident_in_comb_stmts(stmts: &mut [Stmt], old: &str, new: &str) {
     for s in stmts {
         match s {
-            CombStmt::Assign(ca) => { rename_ident_in_expr(&mut ca.target, old, new); rename_ident_in_expr(&mut ca.value, old, new); }
-            CombStmt::IfElse(ie) => {
+            Stmt::Assign(ca) => { rename_ident_in_expr(&mut ca.target, old, new); rename_ident_in_expr(&mut ca.value, old, new); }
+            Stmt::IfElse(ie) => {
                 rename_ident_in_expr(&mut ie.cond, old, new);
                 rename_ident_in_comb_stmts(&mut ie.then_stmts, old, new);
                 rename_ident_in_comb_stmts(&mut ie.else_stmts, old, new);
@@ -4032,7 +4033,7 @@ fn validate_rhs_latency_with_depths(
 }
 
 fn validate_comb_pipe_refs(
-    stmts: &[CombStmt],
+    stmts: &[Stmt],
     pipe_ports: &[PipePortInfoLocal],
     all_ports: &[PortDecl],
     pipe_depths: &std::collections::HashMap<String, u32>,
@@ -4040,7 +4041,7 @@ fn validate_comb_pipe_refs(
 ) {
     for s in stmts {
         match s {
-            CombStmt::Assign(a) => {
+            Stmt::Assign(a) => {
                 // LHS @0 on a plain (non-pipe_reg) port is an error.
                 if let ExprKind::LatencyAt(inner, n) = &a.target.kind {
                     if let ExprKind::Ident(name) = &inner.kind {
@@ -4055,11 +4056,12 @@ fn validate_comb_pipe_refs(
                 }
                 validate_rhs_latency_with_depths(&a.value, pipe_depths, errors);
             }
-            CombStmt::IfElse(ie) => {
+            Stmt::IfElse(ie) => {
                 validate_comb_pipe_refs(&ie.then_stmts, pipe_ports, all_ports, pipe_depths, errors);
                 validate_comb_pipe_refs(&ie.else_stmts, pipe_ports, all_ports, pipe_depths, errors);
             }
-            CombStmt::MatchExpr(_) | CombStmt::For(_) | CombStmt::Log(_) => {}
+                Stmt::Init(_) | Stmt::WaitUntil(..) | Stmt::DoUntil { .. } => unreachable!("seq-only Stmt variant inside comb-context walker"),
+            Stmt::Match(_) | Stmt::For(_) | Stmt::Log(_) => {}
         }
     }
 }
@@ -4224,18 +4226,18 @@ fn rewrite_body_item_cc(bi: &mut ModuleBodyItem, ctx: &CcDispatchCtx, errors: &m
     }
 }
 
-fn rewrite_comb_stmt_cc(s: &mut CombStmt, ctx: &CcDispatchCtx, errors: &mut Vec<CompileError>) {
+fn rewrite_comb_stmt_cc(s: &mut Stmt, ctx: &CcDispatchCtx, errors: &mut Vec<CompileError>) {
     match s {
-        CombStmt::Assign(a) => { rewrite_expr_cc(&mut a.target, ctx, errors); rewrite_expr_cc(&mut a.value, ctx, errors); }
-        CombStmt::IfElse(ie) => {
+        Stmt::Assign(a) => { rewrite_expr_cc(&mut a.target, ctx, errors); rewrite_expr_cc(&mut a.value, ctx, errors); }
+        Stmt::IfElse(ie) => {
             rewrite_expr_cc(&mut ie.cond, ctx, errors);
             for s in &mut ie.then_stmts { rewrite_comb_stmt_cc(s, ctx, errors); }
             for s in &mut ie.else_stmts { rewrite_comb_stmt_cc(s, ctx, errors); }
         }
-        CombStmt::For(fl) => {
+        Stmt::For(fl) => {
             for s in &mut fl.body { rewrite_comb_stmt_cc(s, ctx, errors); }
         }
-        CombStmt::MatchExpr(m) => {
+        Stmt::Match(m) => {
             rewrite_expr_cc(&mut m.scrutinee, ctx, errors);
             for arm in &mut m.arms {
                 for s in &mut arm.body { rewrite_comb_stmt_cc(s, ctx, errors); }
@@ -5003,7 +5005,7 @@ fn inline_lower_tlm_initiator(
     // Build comb drives: one unconditional CombAssign per wire, with
     // state-dependent RHS. OR-of-state-eq for booleans; ternary-mux for
     // argument values (default 0 when not in an issue state).
-    let mut comb_stmts: Vec<CombStmt> = Vec::new();
+    let mut comb_stmts: Vec<Stmt> = Vec::new();
     let or_of_states = |indices: &[u64]| -> Expr {
         if indices.is_empty() {
             return Expr::new(ExprKind::Literal(LitKind::Sized(1, 0)), span);
@@ -5020,7 +5022,7 @@ fn inline_lower_tlm_initiator(
     for (_, agg) in &aggs {
         // req_valid = OR of issue states
         let issue_idxs: Vec<u64> = agg.issues.iter().map(|(i, _)| *i).collect();
-        comb_stmts.push(CombStmt::Assign(CombAssign {
+        comb_stmts.push(Stmt::Assign(CombAssign {
             target: mk_port_member(&agg.port, format!("{}_req_valid", agg.method)),
             value: or_of_states(&issue_idxs),
             span,
@@ -5040,7 +5042,7 @@ fn inline_lower_tlm_initiator(
                     );
                 }
             }
-            comb_stmts.push(CombStmt::Assign(CombAssign {
+            comb_stmts.push(Stmt::Assign(CombAssign {
                 target: mk_port_member(&agg.port, format!("{}_{}", agg.method, arg_ident.name)),
                 value: value_expr,
                 span,
@@ -5048,7 +5050,7 @@ fn inline_lower_tlm_initiator(
             let _ = agg.ret_ty;
         }
         // rsp_ready = OR of wait states
-        comb_stmts.push(CombStmt::Assign(CombAssign {
+        comb_stmts.push(Stmt::Assign(CombAssign {
             target: mk_port_member(&agg.port, format!("{}_rsp_ready", agg.method)),
             value: or_of_states(&agg.waits),
             span,
@@ -5169,12 +5171,12 @@ fn inline_lower_tlm_target(
     // walk and becomes the respond state.
     struct UserState {
         seq_on_exit: Vec<Stmt>,       // fires on transition out of this state
-        comb_in_state: Vec<CombStmt>, // active during this state
+        comb_in_state: Vec<Stmt>, // active during this state
         transition_cond: Expr,
     }
     let mut user_states: Vec<UserState> = Vec::new();
     let mut cur_seq: Vec<Stmt> = Vec::new();
-    let mut cur_comb: Vec<CombStmt> = Vec::new();
+    let mut cur_comb: Vec<Stmt> = Vec::new();
     let mut return_expr: Option<Expr> = None;
 
     // Arg renames: user-bound arg name → latched reg name.
@@ -5212,7 +5214,7 @@ fn inline_lower_tlm_target(
                 }));
             }
             ThreadStmt::CombAssign(ca) => {
-                cur_comb.push(CombStmt::Assign(CombAssign {
+                cur_comb.push(Stmt::Assign(CombAssign {
                     target: rename_args(ca.target, &arg_renames),
                     value: rename_args(ca.value, &arg_renames),
                     span: ca.span,
@@ -5388,15 +5390,15 @@ fn inline_lower_tlm_target(
     };
 
     // ── Comb block: drive req_ready / rsp_valid / rsp_data ──────────────
-    let mut comb_stmts: Vec<CombStmt> = Vec::new();
+    let mut comb_stmts: Vec<Stmt> = Vec::new();
     // req_ready = (state == 0)
-    comb_stmts.push(CombStmt::Assign(CombAssign {
+    comb_stmts.push(Stmt::Assign(CombAssign {
         target: mk_port_member(format!("{method_name}_req_ready")),
         value: state_eq(entry_idx),
         span,
     }));
     // rsp_valid = (state == respond)
-    comb_stmts.push(CombStmt::Assign(CombAssign {
+    comb_stmts.push(Stmt::Assign(CombAssign {
         target: mk_port_member(format!("{method_name}_rsp_valid")),
         value: state_eq(respond_idx),
         span,
@@ -5404,7 +5406,7 @@ fn inline_lower_tlm_target(
     // rsp_data = <return expr> (always driven; only observed when rsp_valid).
     if let Some(expr) = return_expr {
         if method.ret.is_some() {
-            comb_stmts.push(CombStmt::Assign(CombAssign {
+            comb_stmts.push(Stmt::Assign(CombAssign {
                 target: mk_port_member(format!("{method_name}_rsp_data")),
                 value: expr,
                 span,
@@ -5415,7 +5417,7 @@ fn inline_lower_tlm_target(
     for (i, us) in user_states.iter().enumerate() {
         let state_idx = (i + 1) as u64;
         if !us.comb_in_state.is_empty() {
-            comb_stmts.push(CombStmt::IfElse(CombIfElse {
+            comb_stmts.push(Stmt::IfElse(IfElse {
                 cond: state_eq(state_idx),
                 then_stmts: us.comb_in_state.clone(),
                 else_stmts: Vec::new(),
@@ -5425,7 +5427,7 @@ fn inline_lower_tlm_target(
         }
     }
     if !final_comb_in_state.is_empty() {
-        comb_stmts.push(CombStmt::IfElse(CombIfElse {
+        comb_stmts.push(Stmt::IfElse(IfElse {
             cond: state_eq(pre_respond_idx),
             then_stmts: final_comb_in_state,
             else_stmts: Vec::new(),

--- a/src/formal.rs
+++ b/src/formal.rs
@@ -331,7 +331,7 @@ fn flatten_for_formal(
                             }
                         }
                         ModuleBodyItem::CombBlock(cb) => {
-                            let new_stmts: Vec<CombStmt> = cb.stmts.iter()
+                            let new_stmts: Vec<Stmt> = cb.stmts.iter()
                                 .map(|s| subst_comb_stmt_for_formal(
                                     s, &port_map, &locals, &prefix,
                                 ))
@@ -434,15 +434,15 @@ fn rewrite_synth_idents_in_body_item(
 }
 
 fn rewrite_synth_idents_in_comb_stmt(
-    s: &mut CombStmt,
+    s: &mut Stmt,
     remap: &std::collections::HashMap<String, String>,
 ) {
     match s {
-        CombStmt::Assign(a) => {
+        Stmt::Assign(a) => {
             rewrite_synth_idents_in_expr(&mut a.target, remap);
             rewrite_synth_idents_in_expr(&mut a.value, remap);
         }
-        CombStmt::IfElse(ie) => {
+        Stmt::IfElse(ie) => {
             rewrite_synth_idents_in_expr(&mut ie.cond, remap);
             for st in &mut ie.then_stmts { rewrite_synth_idents_in_comb_stmt(st, remap); }
             for st in &mut ie.else_stmts { rewrite_synth_idents_in_comb_stmt(st, remap); }
@@ -547,26 +547,26 @@ fn rewrite_synth_idents_in_expr(
 }
 
 fn subst_comb_stmt_for_formal(
-    s: &CombStmt,
+    s: &Stmt,
     port_map: &std::collections::HashMap<String, Expr>,
     locals: &std::collections::HashSet<String>,
     prefix: &str,
-) -> Result<CombStmt, CompileError> {
+) -> Result<Stmt, CompileError> {
     match s {
-        CombStmt::Assign(a) => {
+        Stmt::Assign(a) => {
             let target = subst_expr_for_formal(&a.target, port_map, locals, prefix);
             let value = subst_expr_for_formal(&a.value, port_map, locals, prefix);
-            Ok(CombStmt::Assign(Assign { target, value, span: a.span }))
+            Ok(Stmt::Assign(Assign { target, value, span: a.span }))
         }
-        CombStmt::IfElse(ie) => {
+        Stmt::IfElse(ie) => {
             let cond = subst_expr_for_formal(&ie.cond, port_map, locals, prefix);
-            let then_stmts: Vec<CombStmt> = ie.then_stmts.iter()
+            let then_stmts: Vec<Stmt> = ie.then_stmts.iter()
                 .map(|s| subst_comb_stmt_for_formal(s, port_map, locals, prefix))
                 .collect::<Result<_, _>>()?;
-            let else_stmts: Vec<CombStmt> = ie.else_stmts.iter()
+            let else_stmts: Vec<Stmt> = ie.else_stmts.iter()
                 .map(|s| subst_comb_stmt_for_formal(s, port_map, locals, prefix))
                 .collect::<Result<_, _>>()?;
-            Ok(CombStmt::IfElse(IfElseOf {
+            Ok(Stmt::IfElse(IfElseOf {
                 cond,
                 then_stmts,
                 else_stmts,
@@ -576,9 +576,9 @@ fn subst_comb_stmt_for_formal(
         }
         other => {
             let sp = match other {
-                CombStmt::For(f) => f.span,
-                CombStmt::MatchExpr(m) => m.span,
-                CombStmt::Log(l) => l.span,
+                Stmt::For(f) => f.span,
+                Stmt::Match(m) => m.span,
+                Stmt::Log(l) => l.span,
                 _ => Span { start: 0, end: 0 },
             };
             Err(CompileError::general(
@@ -720,7 +720,7 @@ fn resolve_port_ident_for_formal(
     Ok(id.clone())
 }
 
-/// Substitute a seq-block Stmt. Mirrors the CombStmt substituter but
+/// Substitute a seq-block Stmt. Mirrors the Stmt substituter but
 /// over the Stmt variants.
 fn subst_stmt_for_formal(
     s: &Stmt,
@@ -1580,9 +1580,9 @@ impl<'a> FormalCtx<'a> {
         Ok(())
     }
 
-    fn walk_comb_stmt(&mut self, s: &CombStmt, path: &[Expr]) -> Result<(), CompileError> {
+    fn walk_comb_stmt(&mut self, s: &Stmt, path: &[Expr]) -> Result<(), CompileError> {
         match s {
-            CombStmt::Assign(a) => {
+            Stmt::Assign(a) => {
                 let name = match target_root_ident(&a.target) {
                     Some(n) => n,
                     None => return Err(CompileError::general(
@@ -1596,7 +1596,7 @@ impl<'a> FormalCtx<'a> {
                     value: a.value.clone(),
                 });
             }
-            CombStmt::IfElse(ie) => {
+            Stmt::IfElse(ie) => {
                 let mut then_path = path.to_vec();
                 then_path.push(ie.cond.clone());
                 for c in &ie.then_stmts { self.walk_comb_stmt(c, &then_path)?; }
@@ -1604,19 +1604,20 @@ impl<'a> FormalCtx<'a> {
                 else_path.push(not_expr(ie.cond.clone()));
                 for c in &ie.else_stmts { self.walk_comb_stmt(c, &else_path)?; }
             }
-            CombStmt::MatchExpr(m) => {
+            Stmt::Match(m) => {
                 return Err(CompileError::general(
                     "`match` inside `comb` blocks is not supported by `arch formal` v1 (rewrite as if/else or expression-level match)",
                     m.span,
                 ));
             }
-            CombStmt::For(fl) => {
+            Stmt::For(fl) => {
                 return Err(CompileError::general(
                     "`for` inside `comb` blocks is not supported by `arch formal` v1 (unroll manually)",
                     fl.span,
                 ));
             }
-            CombStmt::Log(_) => { /* ignore */ }
+                Stmt::Init(_) | Stmt::WaitUntil(..) | Stmt::DoUntil { .. } => unreachable!("seq-only Stmt variant inside comb-context walker"),
+            Stmt::Log(_) => { /* ignore */ }
         }
         Ok(())
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2109,9 +2109,9 @@ impl Parser {
         Ok(Stmt::For(fl))
     }
 
-    fn parse_comb_for_loop(&mut self) -> Result<CombStmt, CompileError> {
+    fn parse_comb_for_loop(&mut self) -> Result<Stmt, CompileError> {
         let fl = self.parse_for_loop_generic(|p| p.parse_comb_stmt())?;
-        Ok(CombStmt::For(fl))
+        Ok(Stmt::For(fl))
     }
 
     /// Parse `init on RST.asserted \n body \n end init`
@@ -2141,7 +2141,7 @@ impl Parser {
         }))
     }
 
-    fn parse_comb_stmt(&mut self) -> Result<CombStmt, CompileError> {
+    fn parse_comb_stmt(&mut self) -> Result<Stmt, CompileError> {
         let unique = self.eat(TokenKind::Unique);
         if self.check(TokenKind::If) {
             return self.parse_comb_if(unique);
@@ -2156,7 +2156,7 @@ impl Parser {
             ));
         }
         if self.check(TokenKind::Log) {
-            return Ok(CombStmt::Log(self.parse_log_stmt()?));
+            return Ok(Stmt::Log(self.parse_log_stmt()?));
         }
         if self.check(TokenKind::For) {
             return self.parse_comb_for_loop();
@@ -2174,14 +2174,14 @@ impl Parser {
         let value = self.parse_expr()?;
         self.expect(TokenKind::Semi)?;
         let span = target.span.merge(value.span);
-        Ok(CombStmt::Assign(CombAssign {
+        Ok(Stmt::Assign(CombAssign {
             target,
             value,
             span,
         }))
     }
 
-    fn parse_comb_if(&mut self, unique: bool) -> Result<CombStmt, CompileError> {
+    fn parse_comb_if(&mut self, unique: bool) -> Result<Stmt, CompileError> {
         let start = self.expect(TokenKind::If)?.span;
         let cond = self.parse_expr()?;
         let mut then_stmts = Vec::new();
@@ -2207,7 +2207,7 @@ impl Parser {
         }
 
         let end_span = self.tokens.get(self.pos.saturating_sub(1)).map(|t| t.span).unwrap_or(start);
-        Ok(CombStmt::IfElse(CombIfElse {
+        Ok(Stmt::IfElse(IfElse {
             cond,
             then_stmts,
             else_stmts,
@@ -2216,7 +2216,7 @@ impl Parser {
         }))
     }
 
-    fn parse_comb_match(&mut self, unique: bool) -> Result<CombStmt, CompileError> {
+    fn parse_comb_match(&mut self, unique: bool) -> Result<Stmt, CompileError> {
         let start = self.expect(TokenKind::Match)?.span;
         let scrutinee = self.parse_expr()?;
         let mut arms = Vec::new();
@@ -2224,7 +2224,7 @@ impl Parser {
             let pattern = self.parse_pattern()?;
             self.expect(TokenKind::FatArrow)?;
             // Comb match-arm body is a single comb statement (kept as
-            // CombStmt — previously cast to Stmt for `Vec<MatchArm<Stmt>>`,
+            // Stmt — previously cast to Stmt for `Vec<MatchArm<Stmt>>`,
             // which forced the typecheck to recheck under seq semantics).
             let comb_stmt = self.parse_comb_stmt()?;
             arms.push(MatchArm { pattern, body: vec![comb_stmt] });
@@ -2232,7 +2232,7 @@ impl Parser {
         self.expect(TokenKind::End)?;
         self.expect(TokenKind::Match)?;
         let end_span = self.tokens.get(self.pos.saturating_sub(1)).map(|t| t.span).unwrap_or(start);
-        Ok(CombStmt::MatchExpr(MatchStmt {
+        Ok(Stmt::Match(MatchStmt {
             scrutinee,
             arms,
             unique,
@@ -3296,7 +3296,7 @@ impl Parser {
         let mut wires = Vec::new();
         let mut state_names: Vec<Ident> = Vec::new();
         let mut default_state: Option<Ident> = None;
-        let mut default_comb: Vec<CombStmt> = Vec::new();
+        let mut default_comb: Vec<Stmt> = Vec::new();
         let mut default_seq: Vec<Stmt> = Vec::new();
         let mut states: Vec<StateBody> = Vec::new();
         let mut asserts: Vec<AssertDecl> = Vec::new();
@@ -3446,7 +3446,7 @@ impl Parser {
                 Some(TokenKind::Let) => {
                     // `let x = expr;` inside state — shorthand for comb assignment
                     let l = self.parse_let_binding()?;
-                    comb_stmts.push(CombStmt::Assign(crate::ast::CombAssign {
+                    comb_stmts.push(Stmt::Assign(crate::ast::CombAssign {
                         target: Expr { kind: ExprKind::Ident(l.name.name.clone()), span: l.name.span, parenthesized: false },
                         value: l.value,
                         span: l.span,
@@ -5201,20 +5201,20 @@ fn desugar_cc_method_call_assigns(expr: &Expr) -> Option<Vec<CombAssign>> {
     }
 }
 
-/// Desugar a credit_channel method-call statement into a single CombStmt.
+/// Desugar a credit_channel method-call statement into a single Stmt.
 /// Multi-assign cases (`.send(x)`) wrap the two assigns in an `if (1'b1)`
 /// block so the caller always gets exactly one statement — avoids
 /// threading a mutation-buffer through every stmt-list-collection loop.
 /// SV synthesis trivially flattens the always-true guard.
-fn desugar_cc_method_call_comb_stmt(expr: &Expr) -> Option<CombStmt> {
+fn desugar_cc_method_call_comb_stmt(expr: &Expr) -> Option<Stmt> {
     let assigns = desugar_cc_method_call_assigns(expr)?;
     if assigns.len() == 1 {
-        return Some(CombStmt::Assign(assigns.into_iter().next().unwrap()));
+        return Some(Stmt::Assign(assigns.into_iter().next().unwrap()));
     }
     let span = expr.span;
-    Some(CombStmt::IfElse(CombIfElse {
+    Some(Stmt::IfElse(IfElse {
         cond: Expr::new(ExprKind::Literal(LitKind::Sized(1, 1)), span),
-        then_stmts: assigns.into_iter().map(CombStmt::Assign).collect(),
+        then_stmts: assigns.into_iter().map(Stmt::Assign).collect(),
         else_stmts: Vec::new(),
         unique: false,
         span,

--- a/src/sim_codegen/mod.rs
+++ b/src/sim_codegen/mod.rs
@@ -2592,15 +2592,15 @@ fn emit_reg_if_else(ie: &IfElse, ctx: &Ctx, out: &mut String, indent: usize, is_
     out.push_str(&format!("{}}}\n", ind(indent)));
 }
 
-fn emit_comb_stmts(stmts: &[CombStmt], ctx: &Ctx, out: &mut String, indent: usize) {
+fn emit_comb_stmts(stmts: &[Stmt], ctx: &Ctx, out: &mut String, indent: usize) {
     for stmt in stmts {
         emit_comb_stmt(stmt, ctx, out, indent);
     }
 }
 
-fn emit_comb_stmt(stmt: &CombStmt, ctx: &Ctx, out: &mut String, indent: usize) {
+fn emit_comb_stmt(stmt: &Stmt, ctx: &Ctx, out: &mut String, indent: usize) {
     match stmt {
-        CombStmt::Assign(a) => {
+        Stmt::Assign(a) => {
             // Scalar bit-indexed LHS: name[idx] = val where name is NOT a Vec
             // Emit mask-and-OR: base = (base & ~(1ULL << idx)) | (uint64_t(val & 1) << idx)
             if let ExprKind::Index(base, idx_expr) = &a.target.kind {
@@ -2635,8 +2635,8 @@ fn emit_comb_stmt(stmt: &CombStmt, ctx: &Ctx, out: &mut String, indent: usize) {
                 out.push_str(&format!("{}{}  = {};\n", ind(indent), resolved_target, rhs));
             }
         }
-        CombStmt::IfElse(ie) => emit_comb_if_else(ie, ctx, out, indent, false),
-        CombStmt::MatchExpr(m) => {
+        Stmt::IfElse(ie) => emit_comb_if_else(ie, ctx, out, indent, false),
+        Stmt::Match(m) => {
             let scrut = cpp_expr(&m.scrutinee, ctx);
             out.push_str(&format!("{}switch ({}) {{\n", ind(indent), scrut));
             for arm in &m.arms {
@@ -2658,7 +2658,7 @@ fn emit_comb_stmt(stmt: &CombStmt, ctx: &Ctx, out: &mut String, indent: usize) {
                     out.push_str(&format!("{}  _arch_cov[{cidx}]++;\n", ind(indent + 1)));
                 }
                 for s in &arm.body {
-                    if let CombStmt::Assign(a) = s {
+                    if let Stmt::Assign(a) = s {
                         let rhs = cpp_expr(&a.value, ctx);
                         let lhs = cpp_expr(&a.target, ctx);
                         out.push_str(&format!("{}{} = {};\n", ind(indent + 2), lhs, rhs));
@@ -2669,8 +2669,8 @@ fn emit_comb_stmt(stmt: &CombStmt, ctx: &Ctx, out: &mut String, indent: usize) {
             }
             out.push_str(&format!("{}}}\n", ind(indent)));
         }
-        CombStmt::Log(l) => emit_log_stmt(l, ctx, out, indent),
-        CombStmt::For(f) => {
+        Stmt::Log(l) => emit_log_stmt(l, ctx, out, indent),
+        Stmt::For(f) => {
             let var = &f.var.name;
             match &f.range {
                 ForRange::Range(rs, re) => {
@@ -2691,10 +2691,11 @@ fn emit_comb_stmt(stmt: &CombStmt, ctx: &Ctx, out: &mut String, indent: usize) {
                 }
             }
         }
+            Stmt::Init(_) | Stmt::WaitUntil(..) | Stmt::DoUntil { .. } => unreachable!("seq-only Stmt variant inside comb-context walker"),
     }
 }
 
-fn emit_comb_if_else(ie: &CombIfElse, ctx: &Ctx, out: &mut String, indent: usize, is_chain: bool) {
+fn emit_comb_if_else(ie: &IfElse, ctx: &Ctx, out: &mut String, indent: usize, is_chain: bool) {
     let cond = cpp_expr(&ie.cond, ctx);
     if is_chain {
         out.push_str(&format!("{}}} else if ({}) {{\n", ind(indent), cond));
@@ -2714,7 +2715,7 @@ fn emit_comb_if_else(ie: &CombIfElse, ctx: &Ctx, out: &mut String, indent: usize
     }
     emit_comb_stmts(&ie.then_stmts, ctx, out, indent + 1);
     if ie.else_stmts.len() == 1 {
-        if let CombStmt::IfElse(nested) = &ie.else_stmts[0] {
+        if let Stmt::IfElse(nested) = &ie.else_stmts[0] {
             emit_comb_if_else(nested, ctx, out, indent, true);
             return;
         }
@@ -2770,13 +2771,13 @@ fn log_fd_name(path: &str) -> String {
 fn collect_log_files(body: &[ModuleBodyItem]) -> Vec<String> {
     let mut files = Vec::new();
     let mut seen = HashSet::new();
-    fn from_comb(stmts: &[CombStmt], files: &mut Vec<String>, seen: &mut HashSet<String>) {
+    fn from_comb(stmts: &[Stmt], files: &mut Vec<String>, seen: &mut HashSet<String>) {
         for s in stmts {
             match s {
-                CombStmt::Log(l) => { if let Some(ref p) = l.file { if seen.insert(p.clone()) { files.push(p.clone()); } } }
-                CombStmt::IfElse(ie) => { from_comb(&ie.then_stmts, files, seen); from_comb(&ie.else_stmts, files, seen); }
-                CombStmt::MatchExpr(m) => { for arm in &m.arms { from_comb(&arm.body, files, seen); } }
-                CombStmt::For(f) => from_comb(&f.body, files, seen),
+                Stmt::Log(l) => { if let Some(ref p) = l.file { if seen.insert(p.clone()) { files.push(p.clone()); } } }
+                Stmt::IfElse(ie) => { from_comb(&ie.then_stmts, files, seen); from_comb(&ie.else_stmts, files, seen); }
+                Stmt::Match(m) => { for arm in &m.arms { from_comb(&arm.body, files, seen); } }
+                Stmt::For(f) => from_comb(&f.body, files, seen),
                 _ => {}
             }
         }
@@ -2850,22 +2851,23 @@ fn collect_pipe_reg_names(body: &[ModuleBodyItem]) -> HashSet<String> {
 }
 
 /// Collect all identifiers read in a comb statement (RHS of assignments).
-fn collect_comb_reads(stmt: &CombStmt, out: &mut std::collections::BTreeSet<String>) {
+fn collect_comb_reads(stmt: &Stmt, out: &mut std::collections::BTreeSet<String>) {
     match stmt {
-        CombStmt::Assign(a) => collect_expr_idents(&a.value, out),
-        CombStmt::IfElse(ie) => {
+        Stmt::Assign(a) => collect_expr_idents(&a.value, out),
+        Stmt::IfElse(ie) => {
             collect_expr_idents(&ie.cond, out);
             for s in &ie.then_stmts { collect_comb_reads(s, out); }
             for s in &ie.else_stmts { collect_comb_reads(s, out); }
         }
-        CombStmt::Log(_) => {}
-        CombStmt::MatchExpr(m) => {
+        Stmt::Log(_) => {}
+        Stmt::Match(m) => {
             collect_expr_idents(&m.scrutinee, out);
             for arm in &m.arms { for s in &arm.body { collect_comb_reads(s, out); } }
         }
-        CombStmt::For(f) => {
+        Stmt::For(f) => {
             for s in &f.body { collect_comb_reads(s, out); }
         }
+            Stmt::Init(_) | Stmt::WaitUntil(..) | Stmt::DoUntil { .. } => unreachable!("seq-only Stmt variant inside comb-context walker"),
     }
 }
 
@@ -2986,22 +2988,23 @@ fn collect_inst_output_signals(body: &[ModuleBodyItem]) -> HashSet<String> {
 
 /// Collect all LHS targets from comb blocks (recursing into if/else/match arms).
 fn collect_comb_targets(body: &[ModuleBodyItem]) -> HashSet<String> {
-    fn collect_stmt_targets(stmt: &CombStmt, out: &mut HashSet<String>) {
+    fn collect_stmt_targets(stmt: &Stmt, out: &mut HashSet<String>) {
         match stmt {
-            CombStmt::Assign(a) => { if let ExprKind::Ident(name) = &a.target.kind { out.insert(name.clone()); } }
-            CombStmt::IfElse(ie) => {
+            Stmt::Assign(a) => { if let ExprKind::Ident(name) = &a.target.kind { out.insert(name.clone()); } }
+            Stmt::IfElse(ie) => {
                 for s in &ie.then_stmts { collect_stmt_targets(s, out); }
                 for s in &ie.else_stmts { collect_stmt_targets(s, out); }
             }
-            CombStmt::MatchExpr(m) => {
+            Stmt::Match(m) => {
                 for arm in &m.arms {
                     for s in &arm.body { collect_stmt_targets(s, out); }
                 }
             }
-            CombStmt::Log(_) => {}
-            CombStmt::For(f) => {
+            Stmt::Log(_) => {}
+            Stmt::For(f) => {
                 for s in &f.body { collect_stmt_targets(s, out); }
             }
+                Stmt::Init(_) | Stmt::WaitUntil(..) | Stmt::DoUntil { .. } => unreachable!("seq-only Stmt variant inside comb-context walker"),
         }
     }
     let mut targets = HashSet::new();

--- a/src/sim_codegen/pipeline.rs
+++ b/src/sim_codegen/pipeline.rs
@@ -254,21 +254,21 @@ impl<'a> SimCodegen<'a> {
     }
 
     fn emit_pipeline_sim_comb_stmt(
-        &self, cpp: &mut String, stmt: &CombStmt, prefix: &str, si: usize,
+        &self, cpp: &mut String, stmt: &Stmt, prefix: &str, si: usize,
         sn: &[String], sp: &[String], srn: &[HashSet<String>],
         pn: &HashSet<String>, rn: &HashSet<String>, ln: &HashSet<String>,
         w: &HashMap<String, u32>, em: &HashMap<String, Vec<(String, u64)>>, indent: usize,
     ) {
         let pad = " ".repeat(indent);
         match stmt {
-            CombStmt::Assign(a) => {
+            Stmt::Assign(a) => {
                 let tgt = if let ExprKind::Ident(n) = &a.target.kind {
                     if pn.contains(n) { n.clone() } else { format!("{}_{}", prefix, n) }
                 } else { self.pipeline_sim_expr(&a.target, prefix, si, sn, sp, srn, pn, rn, ln, w, em) };
                 let val = self.pipeline_sim_expr(&a.value, prefix, si, sn, sp, srn, pn, rn, ln, w, em);
                 cpp.push_str(&format!("{pad}{tgt} = {val};\n"));
             }
-            CombStmt::IfElse(ie) => {
+            Stmt::IfElse(ie) => {
                 let cond = self.pipeline_sim_expr(&ie.cond, prefix, si, sn, sp, srn, pn, rn, ln, w, em);
                 cpp.push_str(&format!("{pad}if ({cond}) {{\n"));
                 for s in &ie.then_stmts { self.emit_pipeline_sim_comb_stmt(cpp, s, prefix, si, sn, sp, srn, pn, rn, ln, w, em, indent+2); }

--- a/src/sim_codegen/thread_sim.rs
+++ b/src/sim_codegen/thread_sim.rs
@@ -29,7 +29,7 @@
 //   - Predicate / expression shapes: idents, literals, !/~, all binops
 
 use crate::ast::{
-    ArbiterPolicy, BinOp, CombAssign, CombStmt, Direction, Expr, ExprKind, IfElseOf,
+    ArbiterPolicy, BinOp, CombAssign, Stmt, Direction, Expr, ExprKind, IfElseOf,
     LitKind, ModuleBodyItem, ModuleDecl, RegAssign, ResetLevel,
     ThreadBlock, ThreadStmt, TypeExpr, UnaryOp,
 };
@@ -46,7 +46,7 @@ struct Segment {
     entry_seq_if: Vec<IfElseOf<ThreadStmt>>,
     /// CombAssigns held while in this segment. Re-evaluated each
     /// `eval()` so they track input changes during the wait.
-    hold_comb: Vec<CombStmt>,
+    hold_comb: Vec<Stmt>,
     /// SeqAssigns / IfElses-of-SeqAssigns that fire ONCE when the wait
     /// completes (i.e., right after the co_await returns). Used by
     /// `do { ... } until cond;` where the body's seq updates fire on
@@ -959,7 +959,7 @@ fn partition(body: &[ThreadStmt], branches: &mut Vec<Branch>, thread_id: usize) 
     for s in body {
         match s {
             ThreadStmt::CombAssign(a) => {
-                cur.hold_comb.push(CombStmt::Assign(a.clone()));
+                cur.hold_comb.push(Stmt::Assign(a.clone()));
             }
             ThreadStmt::SeqAssign(a) => {
                 cur.entry_seq.push(a.clone());
@@ -972,7 +972,7 @@ fn partition(body: &[ThreadStmt], branches: &mut Vec<Branch>, thread_id: usize) 
                 match kind {
                     IfKind::PureComb => {
                         let comb_ie = lower_thread_ifelse_to_comb(ie)?;
-                        cur.hold_comb.push(CombStmt::IfElse(comb_ie));
+                        cur.hold_comb.push(Stmt::IfElse(comb_ie));
                     }
                     IfKind::PureSeq => {
                         cur.entry_seq_if.push(ie.clone());
@@ -1073,18 +1073,18 @@ fn partition(body: &[ThreadStmt], branches: &mut Vec<Branch>, thread_id: usize) 
                 if contains_wait(body) {
                     return Err("`do until` body containing nested `wait` not yet supported".into());
                 }
-                let mut hold_comb: Vec<CombStmt> = Vec::new();
+                let mut hold_comb: Vec<Stmt> = Vec::new();
                 let mut post_seq: Vec<RegAssign> = Vec::new();
                 let mut post_seq_if: Vec<IfElseOf<ThreadStmt>> = Vec::new();
                 for s in body {
                     match s {
-                        ThreadStmt::CombAssign(a) => hold_comb.push(CombStmt::Assign(a.clone())),
+                        ThreadStmt::CombAssign(a) => hold_comb.push(Stmt::Assign(a.clone())),
                         ThreadStmt::SeqAssign(a) => post_seq.push(a.clone()),
                         ThreadStmt::IfElse(ie) => {
                             match classify_ifelse(ie) {
                                 IfKind::PureComb => {
                                     let comb_ie = lower_thread_ifelse_to_comb(ie)?;
-                                    hold_comb.push(CombStmt::IfElse(comb_ie));
+                                    hold_comb.push(Stmt::IfElse(comb_ie));
                                 }
                                 IfKind::PureSeq => post_seq_if.push(ie.clone()),
                                 IfKind::Mixed => return Err(
@@ -1178,14 +1178,14 @@ fn classify_ifelse(ie: &IfElseOf<ThreadStmt>) -> IfKind {
     }
 }
 
-fn lower_thread_ifelse_to_comb(ie: &IfElseOf<ThreadStmt>) -> Result<IfElseOf<CombStmt>, String> {
-    fn lower_stmts(stmts: &[ThreadStmt]) -> Result<Vec<CombStmt>, String> {
+fn lower_thread_ifelse_to_comb(ie: &IfElseOf<ThreadStmt>) -> Result<IfElseOf<Stmt>, String> {
+    fn lower_stmts(stmts: &[ThreadStmt]) -> Result<Vec<Stmt>, String> {
         let mut out = Vec::new();
         for s in stmts {
             match s {
-                ThreadStmt::CombAssign(a) => out.push(CombStmt::Assign(a.clone())),
+                ThreadStmt::CombAssign(a) => out.push(Stmt::Assign(a.clone())),
                 ThreadStmt::IfElse(inner) => {
-                    out.push(CombStmt::IfElse(lower_thread_ifelse_to_comb(inner)?));
+                    out.push(Stmt::IfElse(lower_thread_ifelse_to_comb(inner)?));
                 }
                 _ => return Err("non-comb stmt inside pure-comb IfElse (shouldn't happen)".into()),
             }
@@ -1228,15 +1228,15 @@ fn emit_seq_stmt(s: &crate::ast::Stmt, out: &mut String, indent: usize) -> Resul
     Ok(())
 }
 
-fn emit_comb_stmt(cs: &CombStmt, out: &mut String, indent: usize) {
+fn emit_comb_stmt(cs: &Stmt, out: &mut String, indent: usize) {
     let pad = " ".repeat(indent);
     match cs {
-        CombStmt::Assign(a) => {
+        Stmt::Assign(a) => {
             let lhs = expr_to_cpp(&a.target).unwrap_or_else(|e| format!("/* err: {e} */"));
             let rhs = expr_to_cpp(&a.value).unwrap_or_else(|e| format!("/* err: {e} */"));
             out.push_str(&format!("{pad}{lhs} = {rhs};\n"));
         }
-        CombStmt::IfElse(ie) => {
+        Stmt::IfElse(ie) => {
             let cond = expr_to_cpp_bool(&ie.cond).unwrap_or_else(|e| format!("/* err: {e} */"));
             out.push_str(&format!("{pad}if ({cond}) {{\n"));
             for s in &ie.then_stmts { emit_comb_stmt(s, out, indent + 2); }
@@ -1246,7 +1246,7 @@ fn emit_comb_stmt(cs: &CombStmt, out: &mut String, indent: usize) {
             }
             out.push_str(&format!("{pad}}}\n"));
         }
-        _ => out.push_str(&format!("{pad}/* unsupported CombStmt */\n")),
+        _ => out.push_str(&format!("{pad}/* unsupported Stmt */\n")),
     }
 }
 

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -1215,15 +1215,15 @@ impl<'a> TypeChecker<'a> {
 
     fn walk_comb_for_hs_reads(
         &mut self,
-        stmt: &CombStmt,
+        stmt: &Stmt,
         enclosing: &[&Expr],
         info: &std::collections::HashMap<String, Vec<(String, String, Vec<String>)>>,
     ) {
         match stmt {
-            CombStmt::Assign(a) => {
+            Stmt::Assign(a) => {
                 self.check_expr_for_unguarded_payload(&a.value, enclosing, info, a.span);
             }
-            CombStmt::IfElse(ie) => {
+            Stmt::IfElse(ie) => {
                 // Expressions inside the condition itself don't get the
                 // condition as a guard — they're evaluated before the branch.
                 self.check_expr_for_unguarded_payload(&ie.cond, enclosing, info, ie.span);
@@ -1237,7 +1237,7 @@ impl<'a> TypeChecker<'a> {
                     self.walk_comb_for_hs_reads(s, enclosing, info);
                 }
             }
-            CombStmt::MatchExpr(mm) => {
+            Stmt::Match(mm) => {
                 self.check_expr_for_unguarded_payload(&mm.scrutinee, enclosing, info, mm.span);
                 for arm in &mm.arms {
                     for s in &arm.body {
@@ -1245,12 +1245,13 @@ impl<'a> TypeChecker<'a> {
                     }
                 }
             }
-            CombStmt::For(fl) => {
+            Stmt::For(fl) => {
                 for s in &fl.body {
                     self.walk_comb_for_hs_reads(s, enclosing, info);
                 }
             }
-            CombStmt::Log(_) => {}
+                Stmt::Init(_) | Stmt::WaitUntil(..) | Stmt::DoUntil { .. } => unreachable!("seq-only Stmt variant inside comb-context walker"),
+            Stmt::Log(_) => {}
         }
     }
 
@@ -2197,14 +2198,14 @@ impl<'a> TypeChecker<'a> {
 
     fn check_comb_stmt(
         &mut self,
-        stmt: &CombStmt,
+        stmt: &Stmt,
         module_name: &str,
         local_types: &HashMap<String, Ty>,
         driven: &mut HashSet<String>,
         reg_names: &HashSet<String>,
     ) {
         match stmt {
-            CombStmt::Assign(a) => {
+            Stmt::Assign(a) => {
                 let target_name = Self::expr_root_name_tc(&a.target);
                 let target_name = if target_name.is_empty() { format!("{:?}", a.target.kind) } else { target_name };
                 // Regs must be assigned in seq blocks, not comb blocks
@@ -2247,7 +2248,7 @@ impl<'a> TypeChecker<'a> {
                     }
                 }
             }
-            CombStmt::IfElse(ie) => {
+            Stmt::IfElse(ie) => {
                 let _cond_ty = self.resolve_expr_type(&ie.cond, module_name, local_types);
                 // Each branch gets its own copy of driven — signals assigned
                 // in mutually exclusive branches are not multiple drivers.
@@ -2265,7 +2266,7 @@ impl<'a> TypeChecker<'a> {
                     driven.insert(name.clone());
                 }
             }
-            CombStmt::MatchExpr(m) => {
+            Stmt::Match(m) => {
                 let patterns: Vec<Pattern> = m.arms.iter().map(|a| a.pattern.clone()).collect();
                 self.check_match_exhaustive(&m.scrutinee, &patterns, m.span, module_name, local_types);
                 for arm in &m.arms {
@@ -2274,35 +2275,36 @@ impl<'a> TypeChecker<'a> {
                     }
                 }
             }
-            CombStmt::Log(l) => {
+            Stmt::Log(l) => {
                 for arg in &l.args {
                     self.resolve_expr_type(arg, module_name, local_types);
                 }
             }
-            CombStmt::For(f) => {
+            Stmt::For(f) => {
                 for s in &f.body {
                     self.check_comb_stmt(s, module_name, local_types, driven, reg_names);
                 }
             }
+                Stmt::Init(_) | Stmt::WaitUntil(..) | Stmt::DoUntil { .. } => unreachable!("seq-only Stmt variant inside comb-context walker"),
         }
     }
 
     /// Check for latches: signals assigned on some but not all paths in a comb block.
     /// Returns (all_assigned, fully_assigned) for the statement list.
-    fn comb_latch_targets(stmts: &[CombStmt], symbols: &crate::resolve::SymbolTable) -> (HashSet<String>, HashSet<String>) {
+    fn comb_latch_targets(stmts: &[Stmt], symbols: &crate::resolve::SymbolTable) -> (HashSet<String>, HashSet<String>) {
         let mut all = HashSet::new();
         let mut full = HashSet::new();
 
         for stmt in stmts {
             match stmt {
-                CombStmt::Assign(a) => {
+                Stmt::Assign(a) => {
                     let name = Self::expr_flat_name_tc(&a.target);
                     if !name.is_empty() {
                         all.insert(name.clone());
                         full.insert(name);
                     }
                 }
-                CombStmt::IfElse(ie) => {
+                Stmt::IfElse(ie) => {
                     let (then_all, then_full) = Self::comb_latch_targets(&ie.then_stmts, symbols);
                     let (else_all, else_full) = Self::comb_latch_targets(&ie.else_stmts, symbols);
                     all.extend(then_all); all.extend(else_all);
@@ -2322,15 +2324,15 @@ impl<'a> TypeChecker<'a> {
                         }
                     }
                 }
-                CombStmt::MatchExpr(m) => {
+                Stmt::Match(m) => {
                     let has_wildcard = m.arms.iter().any(|a| matches!(a.pattern, Pattern::Wildcard));
                     let arm_results: Vec<(HashSet<String>, HashSet<String>)> = m.arms.iter()
                         .map(|arm| {
-                            // Comb match arm bodies are Vec<CombStmt> — extract assign targets.
+                            // Comb match arm bodies are Vec<Stmt> — extract assign targets.
                             let mut arm_all = HashSet::new();
                             let mut arm_full = HashSet::new();
                             for s in &arm.body {
-                                if let CombStmt::Assign(a) = s {
+                                if let Stmt::Assign(a) = s {
                                     let name = Self::expr_flat_name_tc(&a.target);
                                     if !name.is_empty() {
                                         arm_all.insert(name.clone());
@@ -2368,10 +2370,10 @@ impl<'a> TypeChecker<'a> {
                         }
                     }
                 }
-                CombStmt::For(f) => {
-                    // Comb for-loop body is Vec<CombStmt> — treat assigns as fully driven.
+                Stmt::For(f) => {
+                    // Comb for-loop body is Vec<Stmt> — treat assigns as fully driven.
                     for s in &f.body {
-                        if let CombStmt::Assign(a) = s {
+                        if let Stmt::Assign(a) = s {
                             let name = Self::expr_flat_name_tc(&a.target);
                             if !name.is_empty() {
                                 all.insert(name.clone());
@@ -2380,14 +2382,15 @@ impl<'a> TypeChecker<'a> {
                         }
                     }
                 }
-                CombStmt::Log(_) => {}
+                    Stmt::Init(_) | Stmt::WaitUntil(..) | Stmt::DoUntil { .. } => unreachable!("seq-only Stmt variant inside comb-context walker"),
+                Stmt::Log(_) => {}
             }
         }
         (all, full)
     }
 
     /// Check a comb block for latch-inducing patterns and emit warnings.
-    fn check_comb_latch(&mut self, stmts: &[CombStmt], span: Span) {
+    fn check_comb_latch(&mut self, stmts: &[Stmt], span: Span) {
         let (all_assigned, fully_assigned) = Self::comb_latch_targets(stmts, self.symbols);
         for name in &all_assigned {
             if !fully_assigned.contains(name) {
@@ -3682,45 +3685,47 @@ impl<'a> TypeChecker<'a> {
     }
 
     /// Collect all identifier names read in comb statements.
-    fn collect_comb_stmt_reads(stmts: &[CombStmt], out: &mut HashSet<String>) {
+    fn collect_comb_stmt_reads(stmts: &[Stmt], out: &mut HashSet<String>) {
         for stmt in stmts {
             match stmt {
-                CombStmt::Assign(a) => Self::collect_expr_reads(&a.value, out),
-                CombStmt::IfElse(ie) => {
+                Stmt::Assign(a) => Self::collect_expr_reads(&a.value, out),
+                Stmt::IfElse(ie) => {
                     Self::collect_expr_reads(&ie.cond, out);
                     Self::collect_comb_stmt_reads(&ie.then_stmts, out);
                     Self::collect_comb_stmt_reads(&ie.else_stmts, out);
                 }
-                CombStmt::MatchExpr(m) => {
+                Stmt::Match(m) => {
                     Self::collect_expr_reads(&m.scrutinee, out);
                     for arm in &m.arms { Self::collect_comb_stmt_reads(&arm.body, out); }
                 }
-                CombStmt::Log(l) => {
+                Stmt::Log(l) => {
                     for arg in &l.args { Self::collect_expr_reads(arg, out); }
                 }
-                CombStmt::For(f) => {
+                Stmt::For(f) => {
                     Self::collect_comb_stmt_reads(&f.body, out);
                 }
+                    Stmt::Init(_) | Stmt::WaitUntil(..) | Stmt::DoUntil { .. } => unreachable!("seq-only Stmt variant inside comb-context walker"),
             }
         }
     }
 
     /// Collect all target names assigned in comb statements.
-    fn collect_comb_stmt_targets(stmts: &[CombStmt], out: &mut HashSet<String>) {
+    fn collect_comb_stmt_targets(stmts: &[Stmt], out: &mut HashSet<String>) {
         for stmt in stmts {
             match stmt {
-                CombStmt::Assign(a) => { let name = Self::expr_root_name_tc(&a.target); if !name.is_empty() { out.insert(name); } }
-                CombStmt::IfElse(ie) => {
+                Stmt::Assign(a) => { let name = Self::expr_root_name_tc(&a.target); if !name.is_empty() { out.insert(name); } }
+                Stmt::IfElse(ie) => {
                     Self::collect_comb_stmt_targets(&ie.then_stmts, out);
                     Self::collect_comb_stmt_targets(&ie.else_stmts, out);
                 }
-                CombStmt::MatchExpr(m) => {
+                Stmt::Match(m) => {
                     for arm in &m.arms { Self::collect_comb_stmt_targets(&arm.body, out); }
                 }
-                CombStmt::Log(_) => {}
-                CombStmt::For(f) => {
+                Stmt::Log(_) => {}
+                Stmt::For(f) => {
                     Self::collect_comb_stmt_targets(&f.body, out);
                 }
+                    Stmt::Init(_) | Stmt::WaitUntil(..) | Stmt::DoUntil { .. } => unreachable!("seq-only Stmt variant inside comb-context walker"),
             }
         }
     }
@@ -4277,14 +4282,14 @@ impl<'a> TypeChecker<'a> {
     }
 
     fn walk_pipeline_comb_stmt(
-        &mut self, s: &CombStmt, cur_idx: usize,
+        &mut self, s: &Stmt, cur_idx: usize,
         stage_idx: &HashMap<&str, usize>, cur_name: &str,
     ) {
         match s {
-            CombStmt::Assign(a) => {
+            Stmt::Assign(a) => {
                 self.check_pipeline_cross_stage_expr(&a.value, cur_idx, stage_idx, cur_name);
             }
-            CombStmt::IfElse(ie) => {
+            Stmt::IfElse(ie) => {
                 self.check_pipeline_cross_stage_expr(&ie.cond, cur_idx, stage_idx, cur_name);
                 for s in &ie.then_stmts { self.walk_pipeline_comb_stmt(s, cur_idx, stage_idx, cur_name); }
                 for s in &ie.else_stmts { self.walk_pipeline_comb_stmt(s, cur_idx, stage_idx, cur_name); }
@@ -4469,7 +4474,7 @@ impl<'a> TypeChecker<'a> {
             for item in &stage.body {
                 if let ModuleBodyItem::CombBlock(cb) = item {
                     for stmt in &cb.stmts {
-                        if let CombStmt::Assign(a) = stmt {
+                        if let Stmt::Assign(a) = stmt {
                             if let ExprKind::Ident(name) = &a.target.kind { driven.insert(name.clone()); }
                         }
                     }
@@ -5053,27 +5058,27 @@ fn check_precedence_in_item(item: &Item, errors: &mut Vec<CompileError>) {
         }
     }
 
-    fn walk_comb(cs: &CombStmt, errors: &mut Vec<CompileError>) {
+    fn walk_comb(cs: &Stmt, errors: &mut Vec<CompileError>) {
         match cs {
-            CombStmt::Assign(a) => {
+            Stmt::Assign(a) => {
                 check_precedence_expr(&a.target, errors);
                 check_precedence_expr(&a.value, errors);
             }
-            CombStmt::IfElse(ie) => {
+            Stmt::IfElse(ie) => {
                 check_precedence_expr(&ie.cond, errors);
                 for s in &ie.then_stmts { walk_comb(s, errors); }
                 for s in &ie.else_stmts { walk_comb(s, errors); }
             }
-            CombStmt::MatchExpr(m) => {
+            Stmt::Match(m) => {
                 check_precedence_expr(&m.scrutinee, errors);
                 for arm in &m.arms {
                     for s in &arm.body { walk_comb(s, errors); }
                 }
             }
-            CombStmt::Log(l) => {
+            Stmt::Log(l) => {
                 for a in &l.args { check_precedence_expr(a, errors); }
             }
-            CombStmt::For(fl) => {
+            Stmt::For(fl) => {
                 match &fl.range {
                     ForRange::Range(s, e) => {
                         check_precedence_expr(s, errors);
@@ -5085,6 +5090,7 @@ fn check_precedence_in_item(item: &Item, errors: &mut Vec<CompileError>) {
                 }
                 for s in &fl.body { walk_comb(s, errors); }
             }
+                Stmt::Init(_) | Stmt::WaitUntil(..) | Stmt::DoUntil { .. } => unreachable!("seq-only Stmt variant inside comb-context walker"),
         }
     }
 


### PR DESCRIPTION
Stacks on PR #202 (`refactor/stmt-bodies-generic`). Merge that one first; this PR will rebase cleanly onto main once it lands.

## Summary
- Phase 5b part 1 of the compiler refactor backlog ([doc/plan_phase_5b_stmt_merge.md](doc/plan_phase_5b_stmt_merge.md)).
- Drops the `CombStmt` enum entirely. All variants now live as `Stmt::*` (with `MatchExpr` renamed to `Match` to match the existing seq variant). `CombIfElse` and `CombMatch` type aliases are gone too.
- `CombBlock.stmts: Vec<CombStmt>` becomes `Vec<Stmt>`. The wrapper struct stays — the *block* (a `comb { ... }` enclosure) is the meaningful unit; the *statement* type no longer needs to encode it.
- Adds `BlockKind { Comb, Seq, PipelineStage }` to `ast.rs`, ready for Phase 5b part 2 to consume in typecheck.

## What's deferred to Phase 5b part 2
- Collapse `check_reg_stmt` + `check_comb_stmt` → `check_stmt(stmt, ..., block_kind)` per design choice D3.
- Collapse `emit_reg_stmt` + `emit_comb_stmt` → `emit_stmt(stmt, ctx: AssignCtx)` per D1.
- Delete `emit_reg_stmt_as_comb` (a workaround now redundant).
- Same merge for sim_codegen / formal / elaborate / comb_graph parallel walker pairs.

The split keeps this PR reviewable — the AST-level merge is mostly mechanical renames and lands cleanly. The walker consolidation has subtle behavioral differences (driven-set tracking, branch-aware merging, pipeline-stage prefix rewriting) that need careful merging and warrant their own PR.

## Test plan
- [x] `cargo test` — 218/218 pass (no test changes needed)
- [x] Zero snapshot drift across 34 SV-emission snapshots
- [x] `cargo build` clean

## Notes
- Walker functions across typecheck / codegen / sim_codegen / formal / elaborate / comb_graph all now operate on the unified `Stmt`. Sites that were previously comb-only get defensive `Stmt::Init | WaitUntil | DoUntil => unreachable!(...)` arms — the parser still routes seq-only variants to seq blocks only, so these arms are belt-and-suspenders pending the `BlockKind` enforcement in part 2.
- Net diff in `src/`: +305/-286 across 10 files.