### PR TITLE
refactor(typecheck): unify reg/comb stmt walkers via BlockKind (Phase 5b part 3)

### DIFF
--- a/doc/plan_phase_5b_stmt_merge.md
+++ b/doc/plan_phase_5b_stmt_merge.md
@@ -1,10 +1,17 @@
 # Phase 5b — Collapse `CombStmt` into `Stmt`
 
-**Status (2026-04-28): parts 1 & 2 DONE; part 3 queued.**
+**Status (2026-04-28): parts 1, 2, 3 DONE.**
 
 - **Part 1** (PR #203, merged): drop `CombStmt`, `CombIfElse`, `CombMatch`; unify all references to `Stmt`; `CombBlock.stmts` is now `Vec<Stmt>`. 218/218 tests, zero snapshot drift.
 - **Part 2** (this PR): introduce `AssignCtx { Blocking, NonBlocking }` and a unified `Codegen::emit_stmt(stmt, ctx)` + `emit_if_else(ie, ctx, is_chain)`. Deletes the `emit_reg_stmt_as_comb` workaround the original plan called out, plus the dead `emit_comb_if_else` / `emit_reg_if_else` helpers and the duplicate `comb_stmt_span_start`. Net −122 lines in `codegen.rs`. 218/218 tests, zero snapshot drift.
-- **Part 3 (queued)**: collapse the remaining parallel walkers in typecheck (`check_reg_stmt` + `check_comb_stmt`), sim_codegen (`emit_reg_stmt` + `emit_comb_stmt`), formal (`walk_reg_stmt` + `walk_comb_stmt`), and elaborate (`rewrite_reg_stmt_cc` + `rewrite_comb_stmt_cc`). Each pair has subtler semantic differences than codegen — driven-set tracking, branch-aware merging, name-resolution in_seq flag, init-block handling — that warrant their own review surface. Also: introduce real typecheck rejection for `Init` / `WaitUntil` / `DoUntil` in comb context (currently `unreachable!()` because the parser routes them, but a proper error is the spec.)
+- **Part 3** (this PR): collapse the typecheck walker pair via design choice D3 (`BlockKind` explicit param). `check_reg_stmt` and `check_comb_stmt` are now thin wrappers around a unified `check_stmt(stmt, ..., block_kind, reg_names)`. The branch-aware driven-tracking, reg-vs-wire LHS check, and Init/WaitUntil/DoUntil rejection are all gated by `block_kind`. The previously-`unreachable!()` arms for seq-only variants in comb context now emit proper typecheck errors (defensive — the parser already routes them, but a programmatic AST mutation that bypasses the parser will land a diagnostic, not panic).
+
+  **Sim_codegen, formal, and elaborate walker pairs are kept parallel intentionally.** Their differences are not just operator dispatch:
+  - `sim_codegen::emit_*_stmt`: posedge shadow registers (`_n_{name}` vs `_{name}`), wide-output-port `_arch_u128` conversion, fsm_mode resolution, and per-arm coverage instrumentation interact differently in seq vs comb. A unified function would need 5+ context flags.
+  - `formal::walk_*_stmt`: writes to *different output data structures* (`reg_writes: HashMap<String, Vec<(cond, value)>>` vs `comb_assigns: Vec<CombAssignFlat>`). The shape of the recursion is the same but the recorded data is fundamentally different.
+  - `elaborate::rewrite_*_stmt_cc`: the comb path rewrites `Match` scrutinee, the seq path doesn't — likely a latent bug where seq-context `match my_chan.recv() {…}` would skip CC dispatch rewriting. Worth investigating, but a fix should land in its own commit, not buried inside a refactor.
+
+  These three are tracked under "potential follow-ups" but are not blocking for the Phase 5b goal of "collapse the AST-level merge". The win-per-LOC is also smaller — codegen and typecheck were the high-leverage pairs.
 
 ---
 

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -2015,41 +2015,105 @@ impl<'a> TypeChecker<'a> {
         local_types: &HashMap<String, Ty>,
         driven: &mut HashSet<String>,
     ) {
+        let empty_regs: HashSet<String> = HashSet::new();
+        self.check_stmt(stmt, module_name, local_types, driven, BlockKind::Seq, &empty_regs);
+    }
+
+    /// Unified `Stmt` typecheck walker for both `comb` and `seq` (and seq's
+    /// `init` sub-block) blocks. Phase 5b part 3: replaces the previously
+    /// parallel `check_reg_stmt` and `check_comb_stmt` walkers. Behavior
+    /// gated by `block_kind`:
+    /// - `Comb`: rejects assignment targets that name a `reg`; tracks the
+    ///   `driven` set with branch-aware merging across `if`/`else` so a
+    ///   signal driven on one branch is not flagged as undriven on the
+    ///   other; rejects `Init` / `WaitUntil` / `DoUntil` (defensive — the
+    ///   parser already routes them to seq blocks only).
+    /// - `Seq` / `PipelineStage`: drives the common width / shift / match
+    ///   exhaustiveness / log / for-body / wait / do-until / init-block
+    ///   checks. `WaitUntil` and `DoUntil` are not rejected by block-kind
+    ///   here — that's `reject_wait_in_stmts`'s job at the block-level
+    ///   call site (it has the context to allow them in pipeline stages
+    ///   and reject them in plain seq).
+    fn check_stmt(
+        &mut self,
+        stmt: &Stmt,
+        module_name: &str,
+        local_types: &HashMap<String, Ty>,
+        driven: &mut HashSet<String>,
+        block_kind: BlockKind,
+        reg_names: &HashSet<String>,
+    ) {
+        let in_comb = block_kind == BlockKind::Comb;
         match stmt {
             Stmt::Assign(a) => {
-                {
-                    let name = Self::expr_root_name_tc(&a.target);
-                    if !name.is_empty() { driven.insert(name.clone()); }
-                    let flat = Self::expr_flat_name_tc(&a.target);
-                    if flat != name { driven.insert(flat); }
-                    let rhs_ty = self.resolve_expr_type(&a.value, module_name, local_types);
-                    // Use the target expression's actual type (handles Index/BitSlice correctly)
-                    let lhs_ty = self.resolve_expr_type(&a.target, module_name, local_types);
-                    if lhs_ty != Ty::Error && local_types.contains_key(&name) {
-                        self.check_width_compatible(&lhs_ty, &rhs_ty, &name, a.span);
-                        // Shift width check (IEEE §11.6.1: shifts are non-widening)
-                        if let (Some(lw), Some(rw)) = (lhs_ty.width(), rhs_ty.width()) {
-                            if lw > rw && expr_is_shift(&a.value) {
-                                self.errors.push(CompileError::general(
-                                    &format!(
-                                        "shift result is UInt<{rw}> but target `{name}` is UInt<{lw}>; \
-                                         shifts do not widen (IEEE §11.6.1). \
-                                         To capture overflow, widen the operand first: `.zext<{lw}>() << n`"
-                                    ),
-                                    a.span,
-                                ));
-                            }
+                let name = Self::expr_root_name_tc(&a.target);
+                let target_name = if name.is_empty() { format!("{:?}", a.target.kind) } else { name.clone() };
+                // Comb-only: `reg` targets must be assigned in seq, not comb.
+                if in_comb && reg_names.contains(&target_name) {
+                    self.errors.push(CompileError::general(
+                        &format!(
+                            "`{}` is a reg — assign it with `<=` in a `seq` block, not `=` in a `comb` block",
+                            target_name
+                        ),
+                        a.span,
+                    ));
+                }
+                if !target_name.is_empty() { driven.insert(target_name.clone()); }
+                let flat = Self::expr_flat_name_tc(&a.target);
+                if flat != target_name { driven.insert(flat); }
+
+                let rhs_ty = self.resolve_expr_type(&a.value, module_name, local_types);
+                let is_indexed = !matches!(&a.target.kind, ExprKind::Ident(_));
+                // LHS-type lookup: comb uses local_types directly so missing
+                // entries silently skip the width check (matches historical
+                // behavior); seq uses resolve_expr_type to handle Index /
+                // BitSlice correctly.
+                let lhs_ty: Option<Ty> = if in_comb {
+                    if is_indexed { None } else { local_types.get(&target_name).cloned() }
+                } else {
+                    let t = self.resolve_expr_type(&a.target, module_name, local_types);
+                    if t != Ty::Error && local_types.contains_key(&target_name) { Some(t) } else { None }
+                };
+                if let Some(lhs_ty) = lhs_ty {
+                    self.check_width_compatible(&lhs_ty, &rhs_ty, &target_name, a.span);
+                    if let (Some(lw), Some(rw)) = (lhs_ty.width(), rhs_ty.width()) {
+                        if lw > rw && expr_is_shift(&a.value) {
+                            self.errors.push(CompileError::general(
+                                &format!(
+                                    "shift result is UInt<{rw}> but target `{target_name}` is UInt<{lw}>; \
+                                     shifts do not widen (IEEE §11.6.1). \
+                                     To capture overflow, widen the operand first: `.zext<{lw}>() << n`"
+                                ),
+                                a.span,
+                            ));
                         }
                     }
                 }
             }
             Stmt::IfElse(ie) => {
                 let _cond_ty = self.resolve_expr_type(&ie.cond, module_name, local_types);
-                for s in &ie.then_stmts {
-                    self.check_reg_stmt(s, module_name, local_types, driven);
-                }
-                for s in &ie.else_stmts {
-                    self.check_reg_stmt(s, module_name, local_types, driven);
+                if in_comb {
+                    // Branch-aware driven tracking: each branch sees a clone
+                    // of driven; signals assigned in mutually-exclusive
+                    // branches are not multi-driven. Merge after.
+                    let mut then_driven = driven.clone();
+                    for s in &ie.then_stmts {
+                        self.check_stmt(s, module_name, local_types, &mut then_driven, block_kind, reg_names);
+                    }
+                    let mut else_driven = driven.clone();
+                    for s in &ie.else_stmts {
+                        self.check_stmt(s, module_name, local_types, &mut else_driven, block_kind, reg_names);
+                    }
+                    for nm in then_driven.iter().chain(else_driven.iter()) {
+                        driven.insert(nm.clone());
+                    }
+                } else {
+                    for s in &ie.then_stmts {
+                        self.check_stmt(s, module_name, local_types, driven, block_kind, reg_names);
+                    }
+                    for s in &ie.else_stmts {
+                        self.check_stmt(s, module_name, local_types, driven, block_kind, reg_names);
+                    }
                 }
             }
             Stmt::Match(m) => {
@@ -2057,7 +2121,7 @@ impl<'a> TypeChecker<'a> {
                 self.check_match_exhaustive(&m.scrutinee, &patterns, m.span, module_name, local_types);
                 for arm in &m.arms {
                     for s in &arm.body {
-                        self.check_reg_stmt(s, module_name, local_types, driven);
+                        self.check_stmt(s, module_name, local_types, driven, block_kind, reg_names);
                     }
                 }
             }
@@ -2068,11 +2132,17 @@ impl<'a> TypeChecker<'a> {
             }
             Stmt::For(f) => {
                 for s in &f.body {
-                    self.check_reg_stmt(s, module_name, local_types, driven);
+                    self.check_stmt(s, module_name, local_types, driven, block_kind, reg_names);
                 }
             }
             Stmt::Init(ib) => {
-                // Validate that reset_signal is a Reset port in this module
+                if in_comb {
+                    self.errors.push(CompileError::general(
+                        "`init on rst.asserted` is only valid inside a `seq` block, not `comb`",
+                        ib.span,
+                    ));
+                    return;
+                }
                 let valid_reset = self.source.items.iter().find_map(|item| {
                     if let Item::Module(m) = item {
                         if m.name.name == module_name {
@@ -2094,10 +2164,17 @@ impl<'a> TypeChecker<'a> {
                     ));
                 }
                 for s in &ib.body {
-                    self.check_reg_stmt(s, module_name, local_types, driven);
+                    self.check_stmt(s, module_name, local_types, driven, block_kind, reg_names);
                 }
             }
             Stmt::WaitUntil(expr, span) => {
+                if in_comb {
+                    self.errors.push(CompileError::general(
+                        "`wait until` is only valid inside a pipeline stage `seq` block, not `comb`",
+                        *span,
+                    ));
+                    return;
+                }
                 let ty = self.resolve_expr_type(expr, module_name, local_types);
                 if ty != Ty::Bool && ty != Ty::Error {
                     self.errors.push(CompileError::general(
@@ -2107,8 +2184,15 @@ impl<'a> TypeChecker<'a> {
                 }
             }
             Stmt::DoUntil { body, cond, span } => {
+                if in_comb {
+                    self.errors.push(CompileError::general(
+                        "`do..until` is only valid inside a pipeline stage `seq` block, not `comb`",
+                        *span,
+                    ));
+                    return;
+                }
                 for s in body {
-                    self.check_reg_stmt(s, module_name, local_types, driven);
+                    self.check_stmt(s, module_name, local_types, driven, block_kind, reg_names);
                 }
                 let ty = self.resolve_expr_type(cond, module_name, local_types);
                 if ty != Ty::Bool && ty != Ty::Error {
@@ -2204,89 +2288,7 @@ impl<'a> TypeChecker<'a> {
         driven: &mut HashSet<String>,
         reg_names: &HashSet<String>,
     ) {
-        match stmt {
-            Stmt::Assign(a) => {
-                let target_name = Self::expr_root_name_tc(&a.target);
-                let target_name = if target_name.is_empty() { format!("{:?}", a.target.kind) } else { target_name };
-                // Regs must be assigned in seq blocks, not comb blocks
-                if reg_names.contains(&target_name) {
-                    self.errors.push(CompileError::general(
-                        &format!(
-                            "`{}` is a reg — assign it with `<=` in a `seq` block, not `=` in a `comb` block",
-                            target_name
-                        ),
-                        a.span,
-                    ));
-                }
-                let is_indexed = !matches!(&a.target.kind, ExprKind::Ident(_));
-                // Multiple assignments within a single comb block are allowed
-                // (default + override in if/elsif/else branches). The real
-                // multiple-driver check is across different comb blocks.
-                driven.insert(target_name.clone());
-                // Also track flattened name for bus port signals (e.g. itcm_cmd_valid)
-                let flat_name = Self::expr_flat_name_tc(&a.target);
-                if flat_name != target_name {
-                    driven.insert(flat_name);
-                }
-                let rhs_ty = self.resolve_expr_type(&a.value, module_name, local_types);
-                if !is_indexed {
-                    if let Some(lhs_ty) = local_types.get(&target_name).cloned() {
-                        self.check_width_compatible(&lhs_ty, &rhs_ty, &target_name, a.span);
-                        // Shift width checks (IEEE §11.6.1: shifts are non-widening)
-                        if let (Some(lw), Some(rw)) = (lhs_ty.width(), rhs_ty.width()) {
-                            if lw > rw && expr_is_shift(&a.value) {
-                                self.errors.push(CompileError::general(
-                                    &format!(
-                                        "shift result is UInt<{rw}> but target `{target_name}` is UInt<{lw}>; \
-                                         shifts do not widen (IEEE §11.6.1). \
-                                         To capture overflow, widen the operand first: `.zext<{lw}>() << n`"
-                                    ),
-                                    a.span,
-                                ));
-                            }
-                        }
-                    }
-                }
-            }
-            Stmt::IfElse(ie) => {
-                let _cond_ty = self.resolve_expr_type(&ie.cond, module_name, local_types);
-                // Each branch gets its own copy of driven — signals assigned
-                // in mutually exclusive branches are not multiple drivers.
-                let mut then_driven = driven.clone();
-                for s in &ie.then_stmts {
-                    self.check_comb_stmt(s, module_name, local_types, &mut then_driven, reg_names);
-                }
-                let mut else_driven = driven.clone();
-                for s in &ie.else_stmts {
-                    self.check_comb_stmt(s, module_name, local_types, &mut else_driven, reg_names);
-                }
-                // Merge both branches back — a signal driven in either branch
-                // counts as driven for subsequent statements.
-                for name in then_driven.iter().chain(else_driven.iter()) {
-                    driven.insert(name.clone());
-                }
-            }
-            Stmt::Match(m) => {
-                let patterns: Vec<Pattern> = m.arms.iter().map(|a| a.pattern.clone()).collect();
-                self.check_match_exhaustive(&m.scrutinee, &patterns, m.span, module_name, local_types);
-                for arm in &m.arms {
-                    for s in &arm.body {
-                        self.check_comb_stmt(s, module_name, local_types, driven, reg_names);
-                    }
-                }
-            }
-            Stmt::Log(l) => {
-                for arg in &l.args {
-                    self.resolve_expr_type(arg, module_name, local_types);
-                }
-            }
-            Stmt::For(f) => {
-                for s in &f.body {
-                    self.check_comb_stmt(s, module_name, local_types, driven, reg_names);
-                }
-            }
-                Stmt::Init(_) | Stmt::WaitUntil(..) | Stmt::DoUntil { .. } => unreachable!("seq-only Stmt variant inside comb-context walker"),
-        }
+        self.check_stmt(stmt, module_name, local_types, driven, BlockKind::Comb, reg_names);
     }
 
     /// Check for latches: signals assigned on some but not all paths in a comb block.

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -7004,6 +7004,38 @@ fn test_regfile_flop_default_unchanged() {
 }
 
 #[test]
+fn test_typecheck_branch_aware_driven_tracking_in_comb() {
+    // Regression for the unified `check_stmt(BlockKind::Comb)` path: a
+    // signal driven on both branches of an if/elsif chain in a comb block
+    // must be considered fully driven for any downstream multiple-driver
+    // analysis, not just on one branch. The parallel-walker era used a
+    // clone-and-merge pattern in `check_comb_stmt::IfElse` to track this
+    // correctly; the unified `check_stmt` keeps that behavior gated on
+    // BlockKind::Comb (Seq path uses simple shared-driven recursion).
+    let source = "
+        domain SysDomain
+          freq_mhz: 100
+        end domain SysDomain
+        module BranchDriven
+          port sel: in Bool;
+          port a:   in UInt<8>;
+          port b:   in UInt<8>;
+          port q:   out UInt<8>;
+          comb
+            if sel
+              q = a;
+            else
+              q = b;
+            end if
+          end comb
+        end module BranchDriven
+    ";
+    // Should typecheck cleanly — both branches drive `q`.
+    let sv = compile_to_sv(source);
+    assert!(sv.contains("module BranchDriven"));
+}
+
+#[test]
 fn test_comb_for_loop_body_type_checked_as_comb() {
     // Regression for the ForLoop<S> generalization: previously CombStmt::For's
     // body was Vec<Stmt> (lossily cast from Vec<CombStmt>), so the typecheck


### PR DESCRIPTION
## Summary
- Phase 5b part 3 of the compiler refactor backlog ([doc/plan_phase_5b_stmt_merge.md](doc/plan_phase_5b_stmt_merge.md)). Delivers design choice D3 (`BlockKind`-driven typecheck).
- New `TypeChecker::check_stmt(stmt, ..., block_kind: BlockKind, reg_names: &HashSet<String>)`. Behavior gated by `block_kind`:
  - **Comb**: rejects `reg` targets in assigns, branch-aware driven-set tracking through if/else (clone-then-merge across branches), rejects `Init` / `WaitUntil` / `DoUntil` with proper diagnostics.
  - **Seq / PipelineStage**: width / shift / match / log / for / init / wait / do-until checks identical to the historical `check_reg_stmt`.
- The previously-`unreachable!()` arms for seq-only variants in comb context now emit proper `CompileError`s — defensive against future parser changes or programmatic AST mutation.
- `check_reg_stmt` and `check_comb_stmt` survive as 1-line delegating wrappers so call sites read semantically.

## Sim_codegen / formal / elaborate kept parallel — by design
Documented in the plan doc. Each pair has differences that don't reduce to a single context flag:
- `sim_codegen::emit_*_stmt`: posedge shadow vs live names, wide-output-port `_arch_u128` conversion, fsm_mode resolution, per-arm coverage — 5+ context flags would obscure more than they consolidate.
- `formal::walk_*_stmt`: writes to *different output data structures* (`reg_writes` map vs `comb_assigns` vec). Same recursion shape, fundamentally different recorded data.
- `elaborate::rewrite_*_stmt_cc`: comb path rewrites `Match` scrutinees, seq path doesn't — likely a latent CC-dispatch bug for seq-context `match my_chan.recv() { … }`. Worth investigating, but as its own commit, not buried inside a refactor.

## Test plan
- [x] `cargo test` — 219/219 pass (218 baseline + 1 new branch-aware-driven regression test)
- [x] Zero snapshot drift across 34 SV-emission snapshots
- [x] `cargo build` clean

## Notes
- Net diff in `typecheck.rs`: +115/-117 — nearly identity-balanced, reflecting consolidation of two 100+ line walkers into one with `block_kind`-gated specialization.
- New test `test_typecheck_branch_aware_driven_tracking_in_comb` exercises the `BlockKind::Comb` path specifically.