### PR TITLE
fix(elaborate): CC dispatch now rewrites every expression in seq stmts

### DIFF
--- a/src/elaborate.rs
+++ b/src/elaborate.rs
@@ -4216,52 +4216,63 @@ struct CcDispatchCtx<'a> {
 fn rewrite_body_item_cc(bi: &mut ModuleBodyItem, ctx: &CcDispatchCtx, errors: &mut Vec<CompileError>) {
     match bi {
         ModuleBodyItem::CombBlock(cb) => {
-            for s in &mut cb.stmts { rewrite_comb_stmt_cc(s, ctx, errors); }
+            for s in &mut cb.stmts { rewrite_stmt_cc(s, ctx, errors); }
         }
         ModuleBodyItem::RegBlock(rb) => {
-            for s in &mut rb.stmts { rewrite_reg_stmt_cc(s, ctx, errors); }
+            for s in &mut rb.stmts { rewrite_stmt_cc(s, ctx, errors); }
         }
         ModuleBodyItem::LetBinding(l) => { rewrite_expr_cc(&mut l.value, ctx, errors); }
         _ => {}
     }
 }
 
-fn rewrite_comb_stmt_cc(s: &mut Stmt, ctx: &CcDispatchCtx, errors: &mut Vec<CompileError>) {
+/// Rewrite credit-channel field access (`port.ch.data`, `port.ch.valid`,
+/// `port.ch.can_send`) into the synthetic identifier the SV codegen emits
+/// (`__{port}_{ch}_{suffix}`). Walks every expression position in `Stmt`
+/// recursively. The reg/comb/pipeline-stage block context doesn't affect
+/// the rewrite — the same field access is invalid for the same reason in
+/// every block, and the synthesized identifier is the same.
+///
+/// History: pre-unification this was two near-identical functions
+/// (`rewrite_reg_stmt_cc`, `rewrite_comb_stmt_cc`) — but the seq variant
+/// silently skipped scrutinees of `Stmt::Match`, the bodies of
+/// `Stmt::Init`, and the cond/body of `Stmt::WaitUntil` / `DoUntil`,
+/// leaving CC field accesses inside those positions for the resolver to
+/// trip over with a misleading "bus has no signal X" error. Unifying
+/// (and exhaustively covering all expression positions) closes that gap.
+fn rewrite_stmt_cc(s: &mut Stmt, ctx: &CcDispatchCtx, errors: &mut Vec<CompileError>) {
     match s {
-        Stmt::Assign(a) => { rewrite_expr_cc(&mut a.target, ctx, errors); rewrite_expr_cc(&mut a.value, ctx, errors); }
+        Stmt::Assign(a) => {
+            rewrite_expr_cc(&mut a.target, ctx, errors);
+            rewrite_expr_cc(&mut a.value, ctx, errors);
+        }
         Stmt::IfElse(ie) => {
             rewrite_expr_cc(&mut ie.cond, ctx, errors);
-            for s in &mut ie.then_stmts { rewrite_comb_stmt_cc(s, ctx, errors); }
-            for s in &mut ie.else_stmts { rewrite_comb_stmt_cc(s, ctx, errors); }
+            for s in &mut ie.then_stmts { rewrite_stmt_cc(s, ctx, errors); }
+            for s in &mut ie.else_stmts { rewrite_stmt_cc(s, ctx, errors); }
         }
         Stmt::For(fl) => {
-            for s in &mut fl.body { rewrite_comb_stmt_cc(s, ctx, errors); }
+            for s in &mut fl.body { rewrite_stmt_cc(s, ctx, errors); }
         }
         Stmt::Match(m) => {
             rewrite_expr_cc(&mut m.scrutinee, ctx, errors);
             for arm in &mut m.arms {
-                for s in &mut arm.body { rewrite_comb_stmt_cc(s, ctx, errors); }
+                for s in &mut arm.body { rewrite_stmt_cc(s, ctx, errors); }
             }
         }
-        _ => {}
-    }
-}
-
-fn rewrite_reg_stmt_cc(s: &mut Stmt, ctx: &CcDispatchCtx, errors: &mut Vec<CompileError>) {
-    match s {
-        Stmt::Assign(a) => { rewrite_expr_cc(&mut a.target, ctx, errors); rewrite_expr_cc(&mut a.value, ctx, errors); }
-        Stmt::IfElse(ie) => {
-            rewrite_expr_cc(&mut ie.cond, ctx, errors);
-            for s in &mut ie.then_stmts { rewrite_reg_stmt_cc(s, ctx, errors); }
-            for s in &mut ie.else_stmts { rewrite_reg_stmt_cc(s, ctx, errors); }
+        Stmt::Init(ib) => {
+            for s in &mut ib.body { rewrite_stmt_cc(s, ctx, errors); }
         }
-        Stmt::For(fl) => { for s in &mut fl.body { rewrite_reg_stmt_cc(s, ctx, errors); } }
-        Stmt::Match(m) => {
-            for arm in &mut m.arms {
-                for s in &mut arm.body { rewrite_reg_stmt_cc(s, ctx, errors); }
-            }
+        Stmt::WaitUntil(expr, _) => {
+            rewrite_expr_cc(expr, ctx, errors);
         }
-        _ => {}
+        Stmt::DoUntil { body, cond, .. } => {
+            for s in body { rewrite_stmt_cc(s, ctx, errors); }
+            rewrite_expr_cc(cond, ctx, errors);
+        }
+        Stmt::Log(l) => {
+            for arg in &mut l.args { rewrite_expr_cc(arg, ctx, errors); }
+        }
     }
 }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -7004,6 +7004,60 @@ fn test_regfile_flop_default_unchanged() {
 }
 
 #[test]
+fn test_cc_dispatch_rewrites_seq_match_scrutinee() {
+    // Regression for the elaborate CC-dispatch asymmetry: the reg-block
+    // walker used to skip `Stmt::Match` scrutinees (only the comb walker
+    // rewrote them), so `match port.ch.data { ... }` inside a `seq` block
+    // would slip through to the resolver, which fails with the misleading
+    // "bus has no signal X" error. After the fix, both contexts rewrite
+    // every expression position uniformly.
+    let source = "
+        domain SysDomain
+          freq_mhz: 100
+        end domain SysDomain
+
+        bus DmaCh
+          credit_channel data: send
+            param T:     type  = UInt<8>;
+            param DEPTH: const = 4;
+          end credit_channel data
+        end bus DmaCh
+
+        use DmaCh;
+
+        module Cons
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync>;
+          port p:   target DmaCh;
+          port classified: out UInt<2>;
+
+          reg cls_r: UInt<2> reset rst => 0;
+
+          comb
+            p.data.credit_return = p.data.valid;
+            classified = cls_r;
+          end comb
+
+          seq on clk rising
+            if p.data.valid
+              match p.data.data
+                0 => cls_r <= 2'd0;
+                1 => cls_r <= 2'd1;
+                2 => cls_r <= 2'd2;
+                _ => cls_r <= 2'd3;
+              end match
+            end if
+          end seq
+        end module Cons
+    ";
+    let sv = compile_to_sv(source);
+    // Scrutinee must be rewritten — pre-fix this would compile-error in the
+    // resolver because `p.data.data` was untouched.
+    assert!(sv.contains("case (__p_data_data)"),
+        "seq-block match scrutinee should rewrite to __p_data_data:\n{sv}");
+}
+
+#[test]
 fn test_typecheck_branch_aware_driven_tracking_in_comb() {
     // Regression for the unified `check_stmt(BlockKind::Comb)` path: a
     // signal driven on both branches of an if/elsif chain in a comb block


### PR DESCRIPTION
## Summary
Closes the elaborate CC-dispatch asymmetry flagged during Phase 5b part 3 review.

`rewrite_comb_stmt_cc::Match` rewrote `m.scrutinee` via `rewrite_expr_cc`, but `rewrite_reg_stmt_cc::Match` didn't. The bug also extended to other Stmt variants the seq walker dropped with `_ => {}`: `Init` body, `WaitUntil` cond, `DoUntil` body/cond, and `Log` args (in both walkers).

## Repro
```arch
seq on clk rising
  if p.data.valid
    match p.data.data       // <-- scrutinee silently skipped by CC dispatch
      0 => cls_r <= 2'd0;
      ...
    end match
  end if
end seq
```

Pre-fix, this fails compilation with the **misleading** downstream resolver error: `bus DmaCh has no signal data`. The resolver treats `p.data.data` as a literal field access because CC dispatch left it untouched; in reality the SV codegen emits a synthesized `__p_data_data` wire that the comb walker would have rewritten the scrutinee to. Post-fix, the snippet compiles cleanly and emits `case (__p_data_data)` in `always_ff`.

## Fix
Collapse `rewrite_reg_stmt_cc` and `rewrite_comb_stmt_cc` into one exhaustive `rewrite_stmt_cc` that visits every expression position in every Stmt variant. Block context (reg vs comb) doesn't affect the rewrite — the same field access expands to the same synthesized identifier in both contexts.

This is also the elaborate-walker collapse Phase 5b part 3 declined to do. Now justified by the fix: the two walkers weren't just stylistic duplication but a place where one path silently dropped expressions the other handled. Unifying makes the gap impossible.

## Test plan
- [x] `cargo test` — 220/220 pass (219 baseline + 1 new regression test `test_cc_dispatch_rewrites_seq_match_scrutinee`)
- [x] Zero snapshot drift across 34 SV-emission snapshots
- [x] `cargo build` clean

## Notes
Net diff in `elaborate.rs`: **+36/-25** — slightly larger than the strict scrutinee-only fix because the unified function explicitly handles every Stmt variant (no more `_ => {}` swallowing CC references in seq context). The plan doc's "kept parallel intentionally" entry for elaborate is now obsolete; the latent-bug story justified the unify.