### PR TITLE
refactor: extract clog2 / index_width into src/width.rs

### DIFF
--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -845,7 +845,7 @@ impl<'a> Codegen<'a> {
                                     _ => None,
                                 };
                                 if let Some(n) = n {
-                                    let idx_w = std::cmp::max(1, (n as f64).log2().ceil() as u32);
+                                    let idx_w = crate::width::index_width(n as u64);
                                     // Record width so the typedef still emits
                                     // (field access paths may still reference
                                     // the struct type).
@@ -4093,7 +4093,7 @@ impl<'a> Codegen<'a> {
                 if !wait_stage_flags[si] { continue; }
                 let prefix = stage.name.name.to_lowercase();
                 let n_states = Self::count_wait_fsm_states(stage);
-                let bits = if n_states <= 2 { 1 } else { ((n_states as f64).log2().ceil()) as usize };
+                let bits = crate::width::index_width(n_states as u64) as usize;
                 self.line(&format!("logic [{}:0] {prefix}_fsm_state;", bits - 1));
                 self.line(&format!("logic {prefix}_fsm_busy;"));
             }
@@ -4482,7 +4482,7 @@ impl<'a> Codegen<'a> {
         // State 0 is special: checks upstream valid, fast-paths.
         // Total states = 1 (idle) + number of wait groups
         let n_states = 1 + groups.len();
-        let bits = if n_states <= 2 { 1 } else { ((n_states as f64).log2().ceil()) as usize };
+        let bits = crate::width::index_width(n_states as u64) as usize;
 
         self.line(&format!("// Wait-stage FSM: {prefix}"));
         self.line(&format!("case ({prefix}_fsm_state)"));
@@ -5408,7 +5408,7 @@ impl<'a> Codegen<'a> {
                     }
                 } else if let Some((crate::resolve::Symbol::Enum(info), _)) = self.symbols.globals.get(&ident.name) {
                     let n = info.variants.len();
-                    let bits = if n <= 1 { 1 } else { (n as f64).log2().ceil() as u32 };
+                    let bits = crate::width::index_width(n as u64);
                     Some(bits.to_string())
                 } else {
                     None
@@ -5809,7 +5809,7 @@ impl<'a> Codegen<'a> {
             return format!("{recv_b}.{}()", method.name);
         };
         let n_usize = n as usize;
-        let idx_w = std::cmp::max(1, (n as f64).log2().ceil() as u32);
+        let idx_w = crate::width::index_width(n as u64);
 
         // Helper: emit an expression with `item` bound to recv[i] and
         // `index` bound to a sized literal. `ident_subst` is a field of
@@ -5848,7 +5848,7 @@ impl<'a> Codegen<'a> {
             }
             "count" => {
                 if n_usize == 0 { return "0".to_string(); }
-                let w = std::cmp::max(1, ((n + 1) as f64).log2().ceil() as u32);
+                let w = crate::width::index_width((n + 1) as u64);
                 // Sum of bool conversions. SV auto-widens `+` per 1800-2012 §11.6.
                 let terms: Vec<String> = (0..n)
                     .map(|i| format!("{w}'({} ? 1 : 0)", emit_at(i)))
@@ -7574,7 +7574,7 @@ impl<'a> Codegen<'a> {
 
         // Parse NUM_REQ as integer for bit width calculations
         let num_req_int: u64 = num_req_default.parse().unwrap_or(4);
-        let req_width = if num_req_int <= 1 { 1 } else { (num_req_int as f64).log2().ceil() as u32 };
+        let req_width = crate::width::index_width(num_req_int as u64);
 
         let clk = a.ports.iter()
             .find(|p| matches!(&p.ty, TypeExpr::Clock(_)))
@@ -7986,7 +7986,7 @@ impl<'a> Codegen<'a> {
             .unwrap_or_else(|| "32".to_string());
 
         // Determine addr width: ceil(log2(NREGS))
-        let addr_width = if nregs <= 1 { 1u32 } else { (nregs as f64).log2().ceil() as u32 };
+        let addr_width = crate::width::index_width(nregs);
 
         // Read/write port counts — resolve param references
         let nread = r.read_ports.as_ref()

--- a/src/elaborate.rs
+++ b/src/elaborate.rs
@@ -1458,7 +1458,7 @@ fn lower_module_threads(m: ModuleDecl, opts: &ThreadLowerOpts) -> Result<(Module
         // index/valid).
         let gv_sink = format!("_{}_grant_valid", res_name);
         let gr_sink = format!("_{}_grant_requester", res_name);
-        let gr_width = if n_threads <= 1 { 1u32 } else { (n_threads as f64).log2().ceil() as u32 };
+        let gr_width = crate::width::index_width(n_threads as u64);
         merged_body.push(ModuleBodyItem::WireDecl(WireDecl {
             name: Ident::new(gv_sink.clone(), sp),
             ty: TypeExpr::Bool, span: sp,
@@ -1689,7 +1689,7 @@ fn lower_module_threads(m: ModuleDecl, opts: &ThreadLowerOpts) -> Result<(Module
 
         let n_states = raw_states.len();
         let state_reg = format!("_t{}_state", ti);
-        let state_bits = if n_states <= 2 { 1u64 } else { ((n_states as f64).log2().ceil()) as u64 };
+        let state_bits = crate::width::index_width(n_states as u64) as u64;
 
         // State register
         merged_body.push(ModuleBodyItem::RegDecl(RegDecl {
@@ -2164,7 +2164,7 @@ fn synthesize_lock_arbiter(
     let clk_ty = TypeExpr::Clock(Ident::new("SysDomain".to_string(), sp));
     let n_threads_expr = Expr::new(
         ExprKind::Literal(LitKind::Dec(n_threads as u64)), sp);
-    let gr_width = if n_threads <= 1 { 1u32 } else { (n_threads as f64).log2().ceil() as u32 };
+    let gr_width = crate::width::index_width(n_threads as u64);
 
     // The arbiter is an internal synthesized module; its port names are
     // canonical (`clk` / `rst`) regardless of the parent's reset signal name.
@@ -5462,7 +5462,7 @@ fn inline_lower_tlm_target(
     Ok(items)
 }
 
-/// Ceiling log2 helper for state width.
+/// Width-of-state helper. Compatibility shim — delegates to [`crate::width::index_width`].
 fn clog2_width(n: u64) -> u32 {
-    if n <= 1 { 1 } else { (n - 1).ilog2() + 1 }
+    crate::width::index_width(n)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,3 +12,4 @@ pub mod resolve;
 pub mod sim_codegen;
 pub mod sim_credit_channel;
 pub mod typecheck;
+pub mod width;

--- a/src/sim_codegen/linklist.rs
+++ b/src/sim_codegen/linklist.rs
@@ -19,8 +19,8 @@ impl<'a> SimCodegen<'a> {
                 .unwrap_or(default)
         };
         let depth = param_int("DEPTH", 8) as usize;
-        let handle_mask = (1u64 << ((depth as f64).log2().ceil() as u32)) - 1;
-        let cnt_mask    = (1u64 << (((depth + 1) as f64).log2().ceil() as u32)) - 1;
+        let handle_mask = (1u64 << crate::width::clog2(depth as u64)) - 1;
+        let cnt_mask    = (1u64 << crate::width::clog2((depth + 1) as u64)) - 1;
 
         // Multi-head linklist support — mirror of the SV codegen in
         // src/codegen.rs::emit_linklist. When NUM_HEADS > 1, head/tail

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -2786,7 +2786,7 @@ impl<'a> TypeChecker<'a> {
                             ));
                             return Ty::Error;
                         }
-                        let idx_w = std::cmp::max(1, (n as f64).log2().ceil() as u32);
+                        let idx_w = crate::width::index_width(n as u64);
                         let pred_needed = !matches!(method.name.as_str(),
                             "reduce_or" | "reduce_and" | "reduce_xor" | "contains");
 
@@ -2869,7 +2869,7 @@ impl<'a> TypeChecker<'a> {
                             }
                             "count" => {
                                 // clog2(N+1) for popcount result width.
-                                let w = std::cmp::max(1, ((n + 1) as f64).log2().ceil() as u32);
+                                let w = crate::width::index_width((n + 1) as u64);
                                 Ty::UInt(w)
                             }
                             "reduce_or" | "reduce_and" | "reduce_xor" => {
@@ -5181,7 +5181,7 @@ pub fn enum_width(num_variants: usize) -> u32 {
     if num_variants <= 1 {
         1
     } else {
-        (num_variants as f64).log2().ceil() as u32
+        crate::width::clog2(num_variants as u64)
     }
 }
 
@@ -5202,7 +5202,7 @@ pub fn linklist_num_heads(l: &crate::ast::LinklistDecl) -> u32 {
     }
 }
 
-/// ceil_log2 for u32. `clog2_u32(1) = 0`, `clog2_u32(2) = 1`, `clog2_u32(16) = 4`.
+/// ceil_log2 for u32. Compatibility shim — delegates to [`crate::width::clog2`].
 pub fn clog2_u32(n: u32) -> u32 {
-    if n <= 1 { 0 } else { (n - 1).ilog2() + 1 }
+    crate::width::clog2(n as u64)
 }

--- a/src/width.rs
+++ b/src/width.rs
@@ -1,0 +1,73 @@
+//! Width / index-bit-count helpers shared across codegen, sim_codegen,
+//! typecheck, and elaborate. Replaces ~14 copies of
+//! `(n as f64).log2().ceil() as u32` (and ~3 variations with `<= 1` /
+//! `<= 2` / `max(1, _)` floors) that had drifted across the compiler.
+//!
+//! Float arithmetic is avoided — these are compile-time integer
+//! computations and should be exact at every input.
+
+/// Pure ceiling log₂.
+/// Edge cases: `clog2(0) = 0`, `clog2(1) = 0`, `clog2(2) = 1`,
+/// `clog2(3) = 2`, `clog2(4) = 2`, `clog2(5) = 3`.
+///
+/// Equivalent to "number of bits to *distinguish* `n` values" (which
+/// is 0 for n=0 or n=1 — degenerate; most callers want
+/// [`index_width`] instead, which floors to 1).
+pub fn clog2(n: u64) -> u32 {
+    if n <= 1 { 0 } else { (n - 1).ilog2() + 1 }
+}
+
+/// Width in bits to *address* an array of `n` items, with a 1-bit
+/// floor: `index_width(0) = index_width(1) = index_width(2) = 1`,
+/// `index_width(3) = 2`, `index_width(5) = 3`. Equivalent to
+/// `max(1, clog2(n))`.
+///
+/// This matches the historical `if n <= 1 { 1 } else { clog2(n) }`
+/// and `if n <= 2 { 1 } else { clog2(n) }` patterns scattered through
+/// the compiler (both produce the same width for every input — the
+/// `<= 1` form was sloppy at n=2 in fewer places, but `clog2(2) = 1`
+/// either way).
+pub fn index_width(n: u64) -> u32 {
+    clog2(n).max(1)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clog2_edge_cases() {
+        assert_eq!(clog2(0), 0);
+        assert_eq!(clog2(1), 0);
+        assert_eq!(clog2(2), 1);
+        assert_eq!(clog2(3), 2);
+        assert_eq!(clog2(4), 2);
+        assert_eq!(clog2(5), 3);
+        assert_eq!(clog2(8), 3);
+        assert_eq!(clog2(9), 4);
+        assert_eq!(clog2(255), 8);
+        assert_eq!(clog2(256), 8);
+        assert_eq!(clog2(257), 9);
+    }
+
+    #[test]
+    fn index_width_floors_at_1() {
+        assert_eq!(index_width(0), 1);
+        assert_eq!(index_width(1), 1);
+        assert_eq!(index_width(2), 1);
+        assert_eq!(index_width(3), 2);
+        assert_eq!(index_width(4), 2);
+        assert_eq!(index_width(5), 3);
+        assert_eq!(index_width(32), 5);
+    }
+
+    #[test]
+    fn matches_float_log2_ceil_for_n_geq_2() {
+        // Sanity: for n >= 2, integer clog2 matches the historical
+        // float-arithmetic shape `(n as f64).log2().ceil() as u32`.
+        for n in 2u64..=1024 {
+            let float_form = (n as f64).log2().ceil() as u32;
+            assert_eq!(clog2(n), float_form, "mismatch at n={n}");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Item #1 from the compiler refactor plan ([doc/plan_compiler_refactor.md](doc/plan_compiler_refactor.md)). The `(n as f64).log2().ceil() as u32` shape — and three variations with `<= 1` / `<= 2` / `max(1, _)` floors — appeared inline in 16 places across codegen, sim_codegen, typecheck, and elaborate. Float arithmetic for compile-time integer math is a small smell; the divergence among floor variants is a bigger one (every new author reinvents the special case slightly differently).

## API
Two helpers in `src/width.rs`:

```rust
pub fn clog2(n: u64) -> u32          // pure ceiling log2 (n<=1 -> 0)
pub fn index_width(n: u64) -> u32    // max(1, clog2(n))
```

Both use `u64::ilog2` — exact integer arithmetic. Behavior matches the float-arithmetic shape for n ≥ 2 (verified by a sanity test that compares the two for n in 2..=1024); the integer form is also correct at n=0 / n=1 where the float form was already hand-floored.

## Replaces
- 16 inline call sites across `codegen.rs` (8), `elaborate.rs` (3), `typecheck.rs` (3), `sim_codegen/linklist.rs` (2).
- 2 nearly-identical helpers (`typecheck::clog2_u32`, `elaborate::clog2_width`) kept as 1-line shims for callers that prefer the local name.

## Test plan
- [x] `cargo test` — 220/220 integration pass (no behavioral change)
- [x] 24 lib unit tests — 21 baseline + 3 new in `width.rs` (edge cases at 0/1/2, sanity match against float form for n in 2..=1024, `index_width` 1-bit floor)
- [x] Zero snapshot drift across 34 SV-emission snapshots
- [x] `cargo build` clean

## Notes
The new module also documents which floor convention each call site needed (`clog2` for pure log₂ semantics like enum-variant width; `index_width` for indexing into N-element arrays), so future additions can pick correctly without reinventing the wheel.