### PR TITLE
refactor: ConstructCommon::param_int + resolve_count_expr

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1119,6 +1119,9 @@ pub struct FunctionAssign {
 /// construct.  Each construct embeds this as `pub common: ConstructCommon` and
 /// implements `Deref<Target = ConstructCommon>` so that existing code such as
 /// `fsm.name`, `fsm.ports`, `fsm.asserts` continues to compile unchanged.
+///
+/// See `impl ConstructCommon` below for shared param-resolution helpers
+/// (`param_int`, `resolve_count_expr`).
 #[derive(Debug, Clone)]
 pub struct ConstructCommon {
     pub name:    Ident,
@@ -1135,6 +1138,39 @@ pub struct ConstructCommon {
     /// downstream tooling can tell "from the outside" prose apart from
     /// "from the inside" prose.
     pub inner_doc: Option<String>,
+}
+
+impl ConstructCommon {
+    /// Resolve a param by name to its default integer literal value.
+    /// Returns `default` if the param is missing, has no default, or its
+    /// default isn't a `LitKind::Dec` (the only literal form param defaults
+    /// take in practice — derived expressions like `XLEN/8` are out of
+    /// scope; full const-eval is its own future refactor item).
+    ///
+    /// Replaces the same 5-line `let param_int = |...|` closure that was
+    /// duplicated in `codegen::emit_regfile`, `sim_codegen::gen_regfile`,
+    /// and `sim_codegen/linklist.rs`.
+    pub fn param_int(&self, name: &str, default: u64) -> u64 {
+        self.params.iter()
+            .find(|p| p.name.name == name)
+            .and_then(|p| p.default.as_ref())
+            .and_then(|e| if let ExprKind::Literal(LitKind::Dec(v)) = &e.kind { Some(*v) } else { None })
+            .unwrap_or(default)
+    }
+
+    /// Resolve a port-array `count_expr` (`ports[N]` / `ports[PARAM]`):
+    /// integer literal returns directly; bare param-name reference falls
+    /// back to that param's default via [`Self::param_int`] with a default
+    /// of 1 (a port array of length 0 makes no sense and shouldn't reach
+    /// here). Anything more complex (arithmetic on params, etc.) returns
+    /// 1 — same conservative fallback the duplicated closures used.
+    pub fn resolve_count_expr(&self, expr: &Expr) -> u64 {
+        match &expr.kind {
+            ExprKind::Literal(LitKind::Dec(v)) => *v,
+            ExprKind::Ident(name) => self.param_int(name, 1),
+            _ => 1,
+        }
+    }
 }
 
 // ── FSM ──────────────────────────────────────────────────────────────────────

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -7947,28 +7947,10 @@ impl<'a> Codegen<'a> {
     // ── Regfile ───────────────────────────────────────────────────────────────
 
     fn emit_regfile(&mut self, r: &crate::ast::RegfileDecl) {
-        use crate::ast::{ParamKind, ExprKind, LitKind};
+        use crate::ast::ParamKind;
         let n = &r.name.name.clone();
 
-        // Helper: resolve a param by name to its default integer value.
-        let param_int = |name: &str, default: u64| -> u64 {
-            r.params.iter()
-                .find(|p| p.name.name == name)
-                .and_then(|p| p.default.as_ref())
-                .and_then(|e| if let ExprKind::Literal(LitKind::Dec(v)) = &e.kind { Some(*v) } else { None })
-                .unwrap_or(default)
-        };
-
-        // Helper: resolve a count_expr — literal or param-name reference.
-        let resolve_count = |expr: &crate::ast::Expr| -> u64 {
-            match &expr.kind {
-                ExprKind::Literal(LitKind::Dec(v)) => *v,
-                ExprKind::Ident(name) => param_int(name, 1),
-                _ => 1,
-            }
-        };
-
-        let nregs = param_int("NREGS", 32);
+        let nregs = r.param_int("NREGS", 32);
 
         // Data width: prefer the UInt<N> type of the data signal in the write port,
         // then fall back to XLEN/WIDTH/DATA_WIDTH params.
@@ -7990,10 +7972,10 @@ impl<'a> Codegen<'a> {
 
         // Read/write port counts — resolve param references
         let nread = r.read_ports.as_ref()
-            .map(|rp| resolve_count(&rp.count_expr))
+            .map(|rp| r.resolve_count_expr(&rp.count_expr))
             .unwrap_or(1);
         let nwrite = r.write_ports.as_ref()
-            .map(|wp| resolve_count(&wp.count_expr))
+            .map(|wp| r.resolve_count_expr(&wp.count_expr))
             .unwrap_or(1);
 
         let clk = r.ports.iter()

--- a/src/sim_codegen/linklist.rs
+++ b/src/sim_codegen/linklist.rs
@@ -6,19 +6,12 @@ use super::*;
 
 impl<'a> SimCodegen<'a> {
     pub(super) fn gen_linklist(&self, l: &crate::ast::LinklistDecl) -> SimModel {
-        use crate::ast::{ExprKind, LitKind, LinklistKind, Direction};
+        use crate::ast::{LinklistKind, Direction};
 
         let name  = &l.name.name;
         let class = format!("V{name}");
 
-        let param_int = |pname: &str, default: u64| -> u64 {
-            l.params.iter()
-                .find(|p| p.name.name == pname)
-                .and_then(|p| p.default.as_ref())
-                .and_then(|e| if let ExprKind::Literal(LitKind::Dec(v)) = &e.kind { Some(*v) } else { None })
-                .unwrap_or(default)
-        };
-        let depth = param_int("DEPTH", 8) as usize;
+        let depth = l.param_int("DEPTH", 8) as usize;
         let handle_mask = (1u64 << crate::width::clog2(depth as u64)) - 1;
         let cnt_mask    = (1u64 << crate::width::clog2((depth + 1) as u64)) - 1;
 

--- a/src/sim_codegen/mod.rs
+++ b/src/sim_codegen/mod.rs
@@ -5947,30 +5947,12 @@ impl<'a> SimCodegen<'a> {
 
 impl<'a> SimCodegen<'a> {
     fn gen_regfile(&self, r: &RegfileDecl) -> SimModel {
-        use crate::ast::{ExprKind, LitKind};
-
         let name  = &r.name.name;
         let class = format!("V{name}");
 
-        // Resolve a param by name to its default integer value
-        let param_int = |pname: &str, default: u64| -> u64 {
-            r.params.iter()
-                .find(|p| p.name.name == pname)
-                .and_then(|p| p.default.as_ref())
-                .and_then(|e| if let ExprKind::Literal(LitKind::Dec(v)) = &e.kind { Some(*v) } else { None })
-                .unwrap_or(default)
-        };
-        let resolve_count = |expr: &Expr| -> u64 {
-            match &expr.kind {
-                ExprKind::Literal(LitKind::Dec(v)) => *v,
-                ExprKind::Ident(n) => param_int(n, 1),
-                _ => 1,
-            }
-        };
-
-        let nregs  = param_int("NREGS", 32) as usize;
-        let nread  = r.read_ports.as_ref().map(|rp| resolve_count(&rp.count_expr)).unwrap_or(1) as usize;
-        let nwrite = r.write_ports.as_ref().map(|wp| resolve_count(&wp.count_expr)).unwrap_or(1) as usize;
+        let nregs  = r.param_int("NREGS", 32) as usize;
+        let nread  = r.read_ports.as_ref().map(|rp| r.resolve_count_expr(&rp.count_expr)).unwrap_or(1) as usize;
+        let nwrite = r.write_ports.as_ref().map(|wp| r.resolve_count_expr(&wp.count_expr)).unwrap_or(1) as usize;
 
         // C++ type for one register element (from the write data signal type)
         let elem_cpp = r.write_ports.as_ref()


### PR DESCRIPTION
## Summary
Item #3 from [doc/plan_compiler_refactor.md](doc/plan_compiler_refactor.md). The same 5-line `param_int` closure was defined three times across the compiler — `codegen::emit_regfile`, `sim_codegen::gen_regfile`, `sim_codegen/linklist.rs::gen_linklist` — to resolve a construct param's default integer literal. The 4-line `resolve_count` closure (which delegates to `param_int`) was also duplicated in the two regfile sites.

Move both onto `impl ConstructCommon`:

```rust
pub fn param_int(&self, name: &str, default: u64) -> u64
pub fn resolve_count_expr(&self, expr: &Expr) -> u64
```

Every construct already embeds `pub common: ConstructCommon` with `Deref<Target = ConstructCommon>`, so call sites just work via auto-deref:

```rust
let nregs = r.param_int("NREGS", 32);                              // was closure
let nread = rp.map(|p| r.resolve_count_expr(&p.count_expr));       // was closure
```

## Behavior preserved exactly
- `param_int` returns `default` when the param is missing, has no default, or its default isn't a `LitKind::Dec` literal — same conservative fallback the closures used. Full const-eval (derived param expressions like `XLEN/8`) is a separate future item.
- `resolve_count_expr` returns the literal directly, falls back to `param_int(ident, 1)` for bare ident references, and returns 1 for anything more complex.

## Test plan
- [x] 220/220 integration tests pass (no behavior change)
- [x] 24 lib unit tests (no new tests; methods are direct extractions)
- [x] Zero snapshot drift across 34 SV-emission snapshots
- [x] `cargo build` clean (removed 2 now-unused `ExprKind` / `LitKind` imports along the way)

## Notes
Net diff: **−7 lines** across 4 src files (36-line method block + doc on ConstructCommon vs 43 lines of removed closures and the unused imports they pulled in).

The methods sit alongside ConstructCommon's struct definition in `ast.rs`. Future shared-helper additions (e.g. for type-param resolution, or doc-comment lookups) can land in the same `impl` block.