### PR TITLE
refactor(ast): introduce Construct trait + Item::as_construct (item #6 phase 1)

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1032,29 +1032,141 @@ impl Ident {
 
 impl Item {
     pub fn span(&self) -> Span {
+        self.as_construct().span()
+    }
+
+    /// Centralized accessor that converts an `Item` to its trait object —
+    /// the single match site that replaces the historical N-arm dispatch
+    /// in every consumer pass.
+    ///
+    /// Approach (a) of refactor plan item #6: the `Item` enum stays, but
+    /// every pass that previously did `match item { Item::Counter(c) =>
+    /// emit_counter(c), ... }` can now do `item.as_construct().<method>()`
+    /// — the trait dispatch goes through this one match.
+    pub fn as_construct(&self) -> &dyn Construct {
         match self {
-            Item::Domain(d) => d.span,
-            Item::Struct(s) => s.span,
-            Item::Enum(e) => e.span,
-            Item::Module(m) => m.span,
-            Item::Fsm(f) => f.span,
-            Item::Fifo(f) => f.span,
-            Item::Ram(r) => r.span,
-            Item::Cam(c) => c.span,
-            Item::Counter(c) => c.span,
-            Item::Arbiter(a) => a.span,
-            Item::Regfile(r) => r.span,
-            Item::Pipeline(p) => p.span,
-            Item::Function(f) => f.span,
-            Item::Linklist(l) => l.span,
-            Item::Template(t) => t.span,
-            Item::Synchronizer(s) => s.span,
-            Item::Clkgate(c) => c.span,
-            Item::Bus(b) => b.span,
-            Item::Package(p) => p.span,
-            Item::Use(u) => u.span,
+            Item::Domain(d) => d,
+            Item::Struct(s) => s,
+            Item::Enum(e) => e,
+            Item::Module(m) => m,
+            Item::Fsm(f) => f,
+            Item::Fifo(f) => f,
+            Item::Ram(r) => r,
+            Item::Cam(c) => c,
+            Item::Counter(c) => c,
+            Item::Arbiter(a) => a,
+            Item::Regfile(r) => r,
+            Item::Pipeline(p) => p,
+            Item::Function(f) => f,
+            Item::Linklist(l) => l,
+            Item::Template(t) => t,
+            Item::Synchronizer(s) => s,
+            Item::Clkgate(c) => c,
+            Item::Bus(b) => b,
+            Item::Package(p) => p,
+            Item::Use(u) => u,
         }
     }
+}
+
+/// Centralizing trait for all top-level constructs (every `Item::*`
+/// variant). Phase 1 (this PR) covers only the always-applicable
+/// accessors — `name`, `span`, `doc`, `inner_doc`, `kind_label`. Future
+/// PRs will add pass methods (`typecheck`, `emit_sv`, `emit_sim`, …) one
+/// at a time, each replacing one N-arm `match item { Item::* => self.X }`
+/// dispatch with `item.as_construct().X(...)`.
+///
+/// Item #6 of `doc/plan_compiler_refactor.md`, approach (a): the `Item`
+/// enum stays; this trait provides a single dispatch point via
+/// [`Item::as_construct`] so consumer passes don't have to keep their
+/// own variant-by-variant matches.
+pub trait Construct {
+    /// The lowercase keyword that introduces this construct in source
+    /// (`"module"`, `"counter"`, `"fsm"`, `"struct"`, `"use"`, etc.).
+    /// Used by `arch advise` doc-event emission and diagnostics.
+    fn kind_label(&self) -> &'static str;
+
+    /// The construct's name as declared (e.g. `Counter` in
+    /// `counter Counter ... end counter Counter`).
+    fn name(&self) -> &Ident;
+
+    /// Source span covering the construct from opening keyword to closing
+    /// `end <keyword> <Name>` (or single-line span for `use` / inline
+    /// constructs).
+    fn span(&self) -> Span;
+
+    /// Outer doc comment from `///` lines immediately preceding the
+    /// construct. `None` if no doc-comment block was attached.
+    fn doc(&self) -> Option<&str>;
+
+    /// Inner doc comment from `//!` lines that appear between the opening
+    /// keyword and the first body item. `None` if absent. Some constructs
+    /// (`Use`) have no body and always return `None`.
+    fn inner_doc(&self) -> Option<&str>;
+}
+
+// ── Construct trait impls ────────────────────────────────────────────────────
+// Every `*Decl` that appears as an `Item::*` variant impls `Construct` so
+// the central `Item::as_construct` accessor can return `&dyn Construct`.
+// Constructs that embed `ConstructCommon` (Module, Fsm, Fifo, Ram, Cam,
+// Counter, Arbiter, Regfile, Pipeline, Linklist) get all five methods via
+// the embedded common fields. Constructs without `ConstructCommon`
+// (Domain, Struct, Enum, Function, Synchronizer, Clkgate, Bus, Package,
+// Use, Template) carry their own `name` / `span` / `doc` / `inner_doc`
+// fields directly.
+
+macro_rules! impl_construct_via_common {
+    ($ty:ty, $label:expr) => {
+        impl Construct for $ty {
+            fn kind_label(&self) -> &'static str { $label }
+            fn name(&self)      -> &Ident         { &self.common.name }
+            fn span(&self)      -> Span           { self.common.span }
+            fn doc(&self)       -> Option<&str>   { self.common.doc.as_deref() }
+            fn inner_doc(&self) -> Option<&str>   { self.common.inner_doc.as_deref() }
+        }
+    };
+}
+
+macro_rules! impl_construct_direct {
+    ($ty:ty, $label:expr) => {
+        impl Construct for $ty {
+            fn kind_label(&self) -> &'static str { $label }
+            fn name(&self)      -> &Ident         { &self.name }
+            fn span(&self)      -> Span           { self.span }
+            fn doc(&self)       -> Option<&str>   { self.doc.as_deref() }
+            fn inner_doc(&self) -> Option<&str>   { self.inner_doc.as_deref() }
+        }
+    };
+}
+
+impl_construct_direct!(ModuleDecl,           "module");
+impl_construct_via_common!(FsmDecl,          "fsm");
+impl_construct_via_common!(FifoDecl,         "fifo");
+impl_construct_via_common!(RamDecl,          "ram");
+impl_construct_via_common!(CamDecl,          "cam");
+impl_construct_via_common!(CounterDecl,      "counter");
+impl_construct_via_common!(ArbiterDecl,      "arbiter");
+impl_construct_via_common!(RegfileDecl,      "regfile");
+impl_construct_via_common!(PipelineDecl,     "pipeline");
+impl_construct_via_common!(LinklistDecl,     "linklist");
+
+impl_construct_direct!(DomainDecl,           "domain");
+impl_construct_direct!(StructDecl,           "struct");
+impl_construct_direct!(EnumDecl,             "enum");
+impl_construct_direct!(FunctionDecl,         "function");
+impl_construct_direct!(SynchronizerDecl,     "synchronizer");
+impl_construct_direct!(ClkGateDecl,          "clkgate");
+impl_construct_direct!(BusDecl,              "bus");
+impl_construct_direct!(PackageDecl,          "package");
+impl_construct_direct!(TemplateDecl,         "template");
+
+// `Use` has only `doc` — no inner doc (single-line decl).
+impl Construct for UseDecl {
+    fn kind_label(&self) -> &'static str { "use" }
+    fn name(&self)      -> &Ident         { &self.name }
+    fn span(&self)      -> Span           { self.span }
+    fn doc(&self)       -> Option<&str>   { self.doc.as_deref() }
+    fn inner_doc(&self) -> Option<&str>   { None }
 }
 
 // ── Function ──────────────────────────────────────────────────────────────────

--- a/src/learn.rs
+++ b/src/learn.rs
@@ -338,36 +338,16 @@ where
 }
 
 /// Pull `(construct_kind_str, name, outer_doc, inner_doc)` from an `Item`
-/// when it carries doc text; `None` if the variant has no doc to harvest.
+/// via the central [`Construct`](crate::ast::Construct) trait. Pre-trait
+/// this was a 20-arm match that hand-pulled the same shape per variant.
 fn extract_doc(item: &crate::ast::Item) -> Option<(&'static str, String, String, String)> {
-    use crate::ast::Item;
-    let pull = |kind: &'static str, name: String,
-                doc: &Option<String>, inner: &Option<String>| {
-        Some((kind, name, doc.clone().unwrap_or_default(), inner.clone().unwrap_or_default()))
-    };
-    match item {
-        Item::Module(m)       => pull("module",       m.name.name.clone(), &m.doc, &m.inner_doc),
-        Item::Fsm(f)          => pull("fsm",          f.common.name.name.clone(), &f.common.doc, &f.common.inner_doc),
-        Item::Fifo(f)         => pull("fifo",         f.common.name.name.clone(), &f.common.doc, &f.common.inner_doc),
-        Item::Ram(r)          => pull("ram",          r.common.name.name.clone(), &r.common.doc, &r.common.inner_doc),
-        Item::Counter(c)      => pull("counter",      c.common.name.name.clone(), &c.common.doc, &c.common.inner_doc),
-        Item::Arbiter(a)      => pull("arbiter",      a.common.name.name.clone(), &a.common.doc, &a.common.inner_doc),
-        Item::Pipeline(p)     => pull("pipeline",     p.common.name.name.clone(), &p.common.doc, &p.common.inner_doc),
-        Item::Cam(c)          => pull("cam",          c.common.name.name.clone(), &c.common.doc, &c.common.inner_doc),
-        Item::Linklist(l)     => pull("linklist",     l.common.name.name.clone(), &l.common.doc, &l.common.inner_doc),
-        Item::Regfile(r)      => pull("regfile",      r.common.name.name.clone(), &r.common.doc, &r.common.inner_doc),
-        Item::Synchronizer(s) => pull("synchronizer", s.name.name.clone(), &s.doc, &s.inner_doc),
-        Item::Clkgate(c)      => pull("clkgate",      c.name.name.clone(), &c.doc, &c.inner_doc),
-        Item::Domain(d)       => pull("domain",       d.name.name.clone(), &d.doc, &d.inner_doc),
-        Item::Struct(s)       => pull("struct",       s.name.name.clone(), &s.doc, &s.inner_doc),
-        Item::Enum(e)         => pull("enum",         e.name.name.clone(), &e.doc, &e.inner_doc),
-        Item::Function(f)     => pull("function",     f.name.name.clone(), &f.doc, &f.inner_doc),
-        Item::Package(p)      => pull("package",      p.name.name.clone(), &p.doc, &p.inner_doc),
-        Item::Bus(b)          => pull("bus",          b.name.name.clone(), &b.doc, &b.inner_doc),
-        Item::Template(t)     => pull("template",     t.name.name.clone(), &t.doc, &t.inner_doc),
-        // `Use` is a single-line decl with only `doc`; treat inner as empty.
-        Item::Use(u)          => Some(("use", u.name.name.clone(), u.doc.clone().unwrap_or_default(), String::new())),
-    }
+    let c = item.as_construct();
+    Some((
+        c.kind_label(),
+        c.name().name.clone(),
+        c.doc().unwrap_or("").to_string(),
+        c.inner_doc().unwrap_or("").to_string(),
+    ))
 }
 
 /// Remove all feature events whose `file_path` matches any of `files`.

--- a/src/main.rs
+++ b/src/main.rs
@@ -505,24 +505,7 @@ fn main() -> miette::Result<()> {
             // Emit .archi interface files alongside .sv (for separate compilation)
             for item in &ast.items {
                 if let Some(content) = arch::interface::emit_interface(item) {
-                    let name = match item {
-                        Item::Module(m) => &m.name.name,
-                        Item::Fsm(f) => &f.name.name,
-                        Item::Counter(c) => &c.name.name,
-                        Item::Pipeline(p) => &p.name.name,
-                        Item::Bus(b) => &b.name.name,
-                        Item::Struct(s) => &s.name.name,
-                        Item::Enum(e) => &e.name.name,
-                        Item::Package(p) => &p.name.name,
-                        Item::Synchronizer(s) => &s.name.name,
-                        Item::Fifo(f) => &f.name.name,
-                        Item::Ram(r) => &r.name.name,
-                        Item::Arbiter(a) => &a.name.name,
-                        Item::Regfile(r) => &r.name.name,
-                        Item::Clkgate(c) => &c.name.name,
-                        Item::Linklist(l) => &l.name.name,
-                        _ => continue,
-                    };
+                    let name = &item.as_construct().name().name;
                     // Write .archi next to the .sv output
                     let archi_dir = files[0].parent()
                         .unwrap_or(std::path::Path::new(".")).to_path_buf();


### PR DESCRIPTION
## Summary
Item #6 of [doc/plan_compiler_refactor.md](doc/plan_compiler_refactor.md), approach (a) per the recent review. The `Item` enum stays; a new `Construct` trait centralizes the shared accessors so consumer passes can stop hand-rolling 20-arm matches.

## What this PR delivers (the foundation)
- New `pub trait Construct` in `src/ast.rs` with the always-applicable accessors: `kind_label`, `name`, `span`, `doc`, `inner_doc`.
- Implemented for every `*Decl` that appears as an `Item` variant. Two short macros (`impl_construct_via_common!` for constructs that embed `ConstructCommon`, `impl_construct_direct!` for those carrying their own `name`/`span`/`doc` fields directly). `UseDecl` gets a manual impl since it has no `inner_doc`.
- New `Item::as_construct(&self) -> &dyn Construct` — **the single match site** that converts a variant to its trait object. Every consumer that previously did `match item { Item::X(x) => self.do_X(x), ... }` can now do `item.as_construct().method(...)` and the trait dispatch goes through this one place.

## Migrations in this PR (validates the pattern)
| Site | Before | After |
|---|---|---|
| `Item::span()` | 20-arm match | `self.as_construct().span()` |
| `learn::extract_doc()` | 20-arm match pulling 4-tuple per variant | 4 trait method calls (30 → 8 lines) |
| `main.rs` interface-naming | 16-arm match for `&item.<X>.name.name` | `&item.as_construct().name().name` |

## Future PRs (one per pass)
- `emit_interface()` → `src/interface.rs`'s 16-arm dispatch
- `typecheck()` → `src/typecheck.rs`'s 13-arm `check_module` dispatch
- `emit_sv()` → `src/codegen/mod.rs`'s 13-arm dispatch
- `emit_sim()` → `src/sim_codegen/mod.rs`'s 14-arm dispatch
- `build_symbols()` → `src/resolve.rs`

Each is one extension to the trait + one consumer migration.

## Test plan
- [x] 221/221 integration tests pass
- [x] 24 lib unit tests pass
- [x] Zero snapshot drift across 34 SV-emission snapshots (no behavior change, only dispatch shape)
- [x] `cargo build` clean

## Notes
Net diff: **+142/-67** across 3 files. The trait + 20 impls (mostly one-line via macros) live alongside `Item` in `src/ast.rs`.