### PR TITLE
refactor(ast): add Construct::emit_interface, drop interface.rs match (item #6 phase 2)

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1103,6 +1103,14 @@ pub trait Construct {
     /// keyword and the first body item. `None` if absent. Some constructs
     /// (`Use`) have no body and always return `None`.
     fn inner_doc(&self) -> Option<&str>;
+
+    /// Emit the `.archi` interface — the public-facing construct signature
+    /// without the body. Returns `Some(content)` for constructs that have
+    /// an external interface (module, fsm, counter, pipeline, fifo, ram,
+    /// arbiter, regfile, synchronizer, clkgate, linklist, bus, struct,
+    /// enum, package); `None` for the rest. Default returns `None`,
+    /// matching the original `_ => None` arm in `interface::emit_interface`.
+    fn emit_interface(&self) -> Option<String> { None }
 }
 
 // ── Construct trait impls ────────────────────────────────────────────────────
@@ -1115,6 +1123,9 @@ pub trait Construct {
 // Use, Template) carry their own `name` / `span` / `doc` / `inner_doc`
 // fields directly.
 
+/// Implement `Construct` for a `*Decl` that embeds `ConstructCommon`.
+/// `iface = path::to::emit_X_interface` adds an `emit_interface`
+/// override; without it the trait's default `None` is used.
 macro_rules! impl_construct_via_common {
     ($ty:ty, $label:expr) => {
         impl Construct for $ty {
@@ -1125,8 +1136,21 @@ macro_rules! impl_construct_via_common {
             fn inner_doc(&self) -> Option<&str>   { self.common.inner_doc.as_deref() }
         }
     };
+    ($ty:ty, $label:expr, iface = $iface:path) => {
+        impl Construct for $ty {
+            fn kind_label(&self) -> &'static str { $label }
+            fn name(&self)      -> &Ident         { &self.common.name }
+            fn span(&self)      -> Span           { self.common.span }
+            fn doc(&self)       -> Option<&str>   { self.common.doc.as_deref() }
+            fn inner_doc(&self) -> Option<&str>   { self.common.inner_doc.as_deref() }
+            fn emit_interface(&self) -> Option<String> { Some($iface(self)) }
+        }
+    };
 }
 
+/// Implement `Construct` for a `*Decl` that carries `name` / `span` /
+/// `doc` / `inner_doc` directly. `iface = ...` is optional, same as
+/// the via-common variant.
 macro_rules! impl_construct_direct {
     ($ty:ty, $label:expr) => {
         impl Construct for $ty {
@@ -1137,27 +1161,37 @@ macro_rules! impl_construct_direct {
             fn inner_doc(&self) -> Option<&str>   { self.inner_doc.as_deref() }
         }
     };
+    ($ty:ty, $label:expr, iface = $iface:path) => {
+        impl Construct for $ty {
+            fn kind_label(&self) -> &'static str { $label }
+            fn name(&self)      -> &Ident         { &self.name }
+            fn span(&self)      -> Span           { self.span }
+            fn doc(&self)       -> Option<&str>   { self.doc.as_deref() }
+            fn inner_doc(&self) -> Option<&str>   { self.inner_doc.as_deref() }
+            fn emit_interface(&self) -> Option<String> { Some($iface(self)) }
+        }
+    };
 }
 
-impl_construct_direct!(ModuleDecl,           "module");
-impl_construct_via_common!(FsmDecl,          "fsm");
-impl_construct_via_common!(FifoDecl,         "fifo");
-impl_construct_via_common!(RamDecl,          "ram");
+impl_construct_direct!(ModuleDecl,           "module",       iface = crate::interface::emit_module_interface);
+impl_construct_via_common!(FsmDecl,          "fsm",          iface = crate::interface::emit_fsm_interface);
+impl_construct_via_common!(FifoDecl,         "fifo",         iface = crate::interface::emit_fifo_interface);
+impl_construct_via_common!(RamDecl,          "ram",          iface = crate::interface::emit_ram_interface);
 impl_construct_via_common!(CamDecl,          "cam");
-impl_construct_via_common!(CounterDecl,      "counter");
-impl_construct_via_common!(ArbiterDecl,      "arbiter");
-impl_construct_via_common!(RegfileDecl,      "regfile");
-impl_construct_via_common!(PipelineDecl,     "pipeline");
-impl_construct_via_common!(LinklistDecl,     "linklist");
+impl_construct_via_common!(CounterDecl,      "counter",      iface = crate::interface::emit_counter_interface);
+impl_construct_via_common!(ArbiterDecl,      "arbiter",      iface = crate::interface::emit_arbiter_interface);
+impl_construct_via_common!(RegfileDecl,      "regfile",      iface = crate::interface::emit_regfile_interface);
+impl_construct_via_common!(PipelineDecl,     "pipeline",     iface = crate::interface::emit_pipeline_interface);
+impl_construct_via_common!(LinklistDecl,     "linklist",     iface = crate::interface::emit_linklist_interface);
 
 impl_construct_direct!(DomainDecl,           "domain");
-impl_construct_direct!(StructDecl,           "struct");
-impl_construct_direct!(EnumDecl,             "enum");
+impl_construct_direct!(StructDecl,           "struct",       iface = crate::interface::emit_struct);
+impl_construct_direct!(EnumDecl,             "enum",         iface = crate::interface::emit_enum);
 impl_construct_direct!(FunctionDecl,         "function");
-impl_construct_direct!(SynchronizerDecl,     "synchronizer");
-impl_construct_direct!(ClkGateDecl,          "clkgate");
-impl_construct_direct!(BusDecl,              "bus");
-impl_construct_direct!(PackageDecl,          "package");
+impl_construct_direct!(SynchronizerDecl,     "synchronizer", iface = crate::interface::emit_synchronizer_interface);
+impl_construct_direct!(ClkGateDecl,          "clkgate",      iface = crate::interface::emit_clkgate_interface);
+impl_construct_direct!(BusDecl,              "bus",          iface = crate::interface::emit_bus_interface);
+impl_construct_direct!(PackageDecl,          "package",      iface = crate::interface::emit_package_interface);
 impl_construct_direct!(TemplateDecl,         "template");
 
 // `Use` has only `doc` — no inner doc (single-line decl).

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -7,29 +7,21 @@ use crate::ast::*;
 
 /// Emit `.archi` content for a single AST item.
 /// Returns `Some(content)` for items that have an external interface
-/// (module, fsm, counter, pipeline), `None` otherwise.
+/// (module, fsm, counter, pipeline, fifo, ram, arbiter, regfile, …),
+/// `None` for the rest. Dispatch goes through `Item::as_construct().emit_interface()`
+/// which is implemented per-construct in `src/ast.rs`.
 pub fn emit_interface(item: &Item) -> Option<String> {
-    match item {
-        Item::Module(m) => Some(emit_module_interface(m)),
-        Item::Fsm(f) => Some(emit_fsm_interface(f)),
-        Item::Counter(c) => Some(emit_counter_interface(c)),
-        Item::Pipeline(p) => Some(emit_pipeline_interface(p)),
-        Item::Bus(b) => Some(emit_bus_interface(b)),
-        Item::Struct(s) => Some(emit_struct(s)),
-        Item::Enum(e) => Some(emit_enum(e)),
-        Item::Package(p) => Some(emit_package_interface(p)),
-        Item::Synchronizer(s) => Some(emit_synchronizer_interface(s)),
-        Item::Fifo(f) => Some(emit_fifo_interface(f)),
-        Item::Ram(r) => Some(emit_ram_interface(r)),
-        Item::Arbiter(a) => Some(emit_arbiter_interface(a)),
-        Item::Regfile(r) => Some(emit_generic("regfile", &r.name.name, &r.params, &r.ports)),
-        Item::Clkgate(c) => Some(emit_clkgate_interface(c)),
-        Item::Linklist(l) => Some(emit_linklist_interface(l)),
-        _ => None,
-    }
+    item.as_construct().emit_interface()
 }
 
-fn emit_module_interface(m: &ModuleDecl) -> String {
+/// Regfile uses the generic shape (no construct-specific fields beyond
+/// params + ports). Wrapper kept here so the trait impl can take a
+/// uniform `fn(&RegfileDecl) -> String`.
+pub(crate) fn emit_regfile_interface(r: &RegfileDecl) -> String {
+    emit_generic("regfile", &r.name.name, &r.params, &r.ports)
+}
+
+pub(crate) fn emit_module_interface(m: &ModuleDecl) -> String {
     let name = &m.name.name;
     let mut s = format!("module {name}\n");
     emit_params(&mut s, &m.params);
@@ -38,7 +30,7 @@ fn emit_module_interface(m: &ModuleDecl) -> String {
     s
 }
 
-fn emit_fsm_interface(f: &FsmDecl) -> String {
+pub(crate) fn emit_fsm_interface(f: &FsmDecl) -> String {
     let name = &f.name.name;
     let mut s = format!("fsm {name}\n");
     emit_params(&mut s, &f.params);
@@ -47,7 +39,7 @@ fn emit_fsm_interface(f: &FsmDecl) -> String {
     s
 }
 
-fn emit_counter_interface(c: &CounterDecl) -> String {
+pub(crate) fn emit_counter_interface(c: &CounterDecl) -> String {
     let name = &c.name.name;
     let mut s = format!("counter {name}\n");
     emit_params(&mut s, &c.params);
@@ -56,7 +48,7 @@ fn emit_counter_interface(c: &CounterDecl) -> String {
     s
 }
 
-fn emit_pipeline_interface(p: &PipelineDecl) -> String {
+pub(crate) fn emit_pipeline_interface(p: &PipelineDecl) -> String {
     let name = &p.name.name;
     let mut s = format!("pipeline {name}\n");
     emit_params(&mut s, &p.params);
@@ -65,7 +57,7 @@ fn emit_pipeline_interface(p: &PipelineDecl) -> String {
     s
 }
 
-fn emit_bus_interface(b: &BusDecl) -> String {
+pub(crate) fn emit_bus_interface(b: &BusDecl) -> String {
     let name = &b.name.name;
     let mut s = format!("bus {name}\n");
     emit_params(&mut s, &b.params);
@@ -77,7 +69,7 @@ fn emit_bus_interface(b: &BusDecl) -> String {
 /// Generic emitter for constructs with name + params + ports (regfile, etc.)
 /// Constructs with additional semantic fields (kind, policy, latency) use
 /// their own per-type emitter instead — see emit_synchronizer_interface etc.
-fn emit_generic(keyword: &str, name: &str, params: &[ParamDecl], ports: &[PortDecl]) -> String {
+pub(crate) fn emit_generic(keyword: &str, name: &str, params: &[ParamDecl], ports: &[PortDecl]) -> String {
     let mut s = format!("{keyword} {name}\n");
     emit_params(&mut s, params);
     emit_ports(&mut s, ports);
@@ -85,7 +77,7 @@ fn emit_generic(keyword: &str, name: &str, params: &[ParamDecl], ports: &[PortDe
     s
 }
 
-fn emit_synchronizer_interface(sync: &SynchronizerDecl) -> String {
+pub(crate) fn emit_synchronizer_interface(sync: &SynchronizerDecl) -> String {
     let name = &sync.name.name;
     let kind = match sync.kind {
         SyncKind::Ff => "ff",
@@ -102,7 +94,7 @@ fn emit_synchronizer_interface(sync: &SynchronizerDecl) -> String {
     s
 }
 
-fn emit_fifo_interface(f: &FifoDecl) -> String {
+pub(crate) fn emit_fifo_interface(f: &FifoDecl) -> String {
     let name = &f.name.name;
     let mut s = format!("fifo {name}\n");
     // FifoKind::Fifo is the default (sync/async detected from clock ports); only emit `kind lifo`
@@ -115,7 +107,7 @@ fn emit_fifo_interface(f: &FifoDecl) -> String {
     s
 }
 
-fn emit_ram_interface(r: &RamDecl) -> String {
+pub(crate) fn emit_ram_interface(r: &RamDecl) -> String {
     let name = &r.name.name;
     let kind = match r.kind {
         RamKind::Single => "single",
@@ -132,7 +124,7 @@ fn emit_ram_interface(r: &RamDecl) -> String {
     s
 }
 
-fn emit_arbiter_interface(a: &ArbiterDecl) -> String {
+pub(crate) fn emit_arbiter_interface(a: &ArbiterDecl) -> String {
     let name = &a.name.name;
     let policy = match &a.policy {
         ArbiterPolicy::RoundRobin => "round_robin".to_string(),
@@ -152,7 +144,7 @@ fn emit_arbiter_interface(a: &ArbiterDecl) -> String {
     s
 }
 
-fn emit_clkgate_interface(c: &ClkGateDecl) -> String {
+pub(crate) fn emit_clkgate_interface(c: &ClkGateDecl) -> String {
     let name = &c.name.name;
     let kind = match c.kind {
         ClkGateKind::Latch => "latch",
@@ -166,7 +158,7 @@ fn emit_clkgate_interface(c: &ClkGateDecl) -> String {
     s
 }
 
-fn emit_linklist_interface(l: &LinklistDecl) -> String {
+pub(crate) fn emit_linklist_interface(l: &LinklistDecl) -> String {
     let name = &l.name.name;
     let kind = match l.kind {
         LinklistKind::Singly => "singly",
@@ -188,7 +180,7 @@ fn emit_linklist_interface(l: &LinklistDecl) -> String {
     s
 }
 
-fn emit_struct(s: &StructDecl) -> String {
+pub(crate) fn emit_struct(s: &StructDecl) -> String {
     let name = &s.name.name;
     let mut out = format!("struct {name}\n");
     for f in &s.fields {
@@ -198,7 +190,7 @@ fn emit_struct(s: &StructDecl) -> String {
     out
 }
 
-fn emit_enum(e: &EnumDecl) -> String {
+pub(crate) fn emit_enum(e: &EnumDecl) -> String {
     let name = &e.name.name;
     let mut out = format!("enum {name}\n");
     for (i, v) in e.variants.iter().enumerate() {
@@ -212,7 +204,7 @@ fn emit_enum(e: &EnumDecl) -> String {
     out
 }
 
-fn emit_package_interface(p: &PackageDecl) -> String {
+pub(crate) fn emit_package_interface(p: &PackageDecl) -> String {
     let name = &p.name.name;
     let mut out = format!("package {name}\n");
     // Params
@@ -243,7 +235,7 @@ fn indent(s: &str) -> String {
     s.lines().map(|l| format!("  {l}\n")).collect()
 }
 
-fn emit_params(s: &mut String, params: &[ParamDecl]) {
+pub(crate) fn emit_params(s: &mut String, params: &[ParamDecl]) {
     for p in params {
         let local = if p.is_local { "local " } else { "" };
         let name = &p.name.name;
@@ -291,7 +283,7 @@ fn emit_params(s: &mut String, params: &[ParamDecl]) {
     }
 }
 
-fn emit_ports(s: &mut String, ports: &[PortDecl]) {
+pub(crate) fn emit_ports(s: &mut String, ports: &[PortDecl]) {
     for p in ports {
         let dir = match p.direction {
             Direction::In => "in",


### PR DESCRIPTION
**Stacks on PR #216.** Merge that one first; this PR will rebase cleanly onto main once it lands.

## Summary
Phase 2 of item #6 (approach a):

- Add `fn emit_interface(&self) -> Option<String>` to the `Construct` trait, default `None`. Constructs that emit an interface override.
- Extend `impl_construct_via_common!` / `impl_construct_direct!` macros with an optional `iface = path::to::emit_X_interface` arg. Without it, the trait default applies; with it, the impl overrides to `Some($iface(self))`.
- Bump every `fn emit_*_interface` (and `emit_struct` / `emit_enum`) in `src/interface.rs` to `pub(crate)` so the trait impls in `ast.rs` can call them.
- Add a small `emit_regfile_interface` wrapper around the generic emission so the trait impl can use the same `iface = ...` form (regfile's interface is the generic shape).
- Migrate `interface::emit_interface(item)` from a 16-arm match to one line:

```rust
pub fn emit_interface(item: &Item) -> Option<String> {
    item.as_construct().emit_interface()
}
```

## Behavior preserved
Each `iface = ...` invocation routes to exactly the same per-construct function the old match arm called. The default `None` covers the same set the old `_ => None` arm did (Domain, Function, Use, Template, Cam — same as before).

## Test plan
- [x] 221/221 integration tests pass
- [x] 24 lib unit tests pass
- [x] Zero snapshot drift across 34 SV-emission snapshots
- [x] `cargo build` clean
- Net diff: **+77/-51** across 2 files

## Remaining phases
- `typecheck()` → migrate `typecheck.rs`'s 13-arm dispatch
- `emit_sv()` → migrate `codegen/mod.rs`'s 13-arm dispatch
- `emit_sim()` → migrate `sim_codegen/mod.rs`'s 14-arm dispatch
- `build_symbols()` → migrate `resolve.rs`