### PR TITLE
refactor(ast): add Construct::emit_sv, drop codegen match (item #6 phase 4)

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1117,6 +1117,13 @@ pub trait Construct {
     /// construct that has type rules overrides this to call its
     /// specific `TypeChecker::check_*` method.
     fn typecheck(&self, _checker: &mut crate::typecheck::TypeChecker) {}
+
+    /// Emit SystemVerilog for this construct. Default is a no-op,
+    /// matching the original `Item::Function(_) | Item::Template(_) |
+    /// Item::Bus(_) | Item::Use(_) => {}` arms — `function` is emitted
+    /// inside each module body, `template` is compile-time-only,
+    /// `bus` flattens at port sites, and `use` is an import directive.
+    fn emit_sv(&self, _codegen: &mut crate::codegen::Codegen) {}
 }
 
 // ── Construct trait impls ────────────────────────────────────────────────────
@@ -1134,7 +1141,7 @@ pub trait Construct {
 /// optional in any order. Without them, the trait defaults apply
 /// (`emit_interface` returns `None`, `typecheck` is a no-op).
 macro_rules! impl_construct_via_common {
-    ($ty:ty, $label:expr $(, iface = $iface:path)? $(, check = $check:ident)?) => {
+    ($ty:ty, $label:expr $(, iface = $iface:path)? $(, check = $check:ident)? $(, emit_sv = $emit_sv:ident)?) => {
         impl Construct for $ty {
             fn kind_label(&self) -> &'static str { $label }
             fn name(&self)      -> &Ident         { &self.common.name }
@@ -1143,6 +1150,7 @@ macro_rules! impl_construct_via_common {
             fn inner_doc(&self) -> Option<&str>   { self.common.inner_doc.as_deref() }
             $(fn emit_interface(&self) -> Option<String> { Some($iface(self)) })?
             $(fn typecheck(&self, c: &mut crate::typecheck::TypeChecker) { c.$check(self); })?
+            $(fn emit_sv(&self, c: &mut crate::codegen::Codegen) { c.$emit_sv(self); })?
         }
     };
 }
@@ -1151,7 +1159,7 @@ macro_rules! impl_construct_via_common {
 /// `doc` / `inner_doc` directly. Same optional-arg pattern as the
 /// via-common variant.
 macro_rules! impl_construct_direct {
-    ($ty:ty, $label:expr $(, iface = $iface:path)? $(, check = $check:ident)?) => {
+    ($ty:ty, $label:expr $(, iface = $iface:path)? $(, check = $check:ident)? $(, emit_sv = $emit_sv:ident)?) => {
         impl Construct for $ty {
             fn kind_label(&self) -> &'static str { $label }
             fn name(&self)      -> &Ident         { &self.name }
@@ -1160,29 +1168,30 @@ macro_rules! impl_construct_direct {
             fn inner_doc(&self) -> Option<&str>   { self.inner_doc.as_deref() }
             $(fn emit_interface(&self) -> Option<String> { Some($iface(self)) })?
             $(fn typecheck(&self, c: &mut crate::typecheck::TypeChecker) { c.$check(self); })?
+            $(fn emit_sv(&self, c: &mut crate::codegen::Codegen) { c.$emit_sv(self); })?
         }
     };
 }
 
-impl_construct_direct!(ModuleDecl,           "module",       iface = crate::interface::emit_module_interface,       check = check_module);
-impl_construct_via_common!(FsmDecl,          "fsm",          iface = crate::interface::emit_fsm_interface,          check = check_fsm);
-impl_construct_via_common!(FifoDecl,         "fifo",         iface = crate::interface::emit_fifo_interface,         check = check_fifo);
-impl_construct_via_common!(RamDecl,          "ram",          iface = crate::interface::emit_ram_interface,          check = check_ram);
-impl_construct_via_common!(CamDecl,          "cam",                                                                 check = check_cam);
-impl_construct_via_common!(CounterDecl,      "counter",      iface = crate::interface::emit_counter_interface,      check = check_counter);
-impl_construct_via_common!(ArbiterDecl,      "arbiter",      iface = crate::interface::emit_arbiter_interface,      check = check_arbiter);
-impl_construct_via_common!(RegfileDecl,      "regfile",      iface = crate::interface::emit_regfile_interface,      check = check_regfile);
-impl_construct_via_common!(PipelineDecl,     "pipeline",     iface = crate::interface::emit_pipeline_interface,     check = check_pipeline);
-impl_construct_via_common!(LinklistDecl,     "linklist",     iface = crate::interface::emit_linklist_interface,     check = check_linklist);
+impl_construct_direct!(ModuleDecl,           "module",       iface = crate::interface::emit_module_interface,       check = check_module,       emit_sv = emit_module);
+impl_construct_via_common!(FsmDecl,          "fsm",          iface = crate::interface::emit_fsm_interface,          check = check_fsm,          emit_sv = emit_fsm);
+impl_construct_via_common!(FifoDecl,         "fifo",         iface = crate::interface::emit_fifo_interface,         check = check_fifo,         emit_sv = emit_fifo);
+impl_construct_via_common!(RamDecl,          "ram",          iface = crate::interface::emit_ram_interface,          check = check_ram,          emit_sv = emit_ram);
+impl_construct_via_common!(CamDecl,          "cam",                                                                 check = check_cam,          emit_sv = emit_cam);
+impl_construct_via_common!(CounterDecl,      "counter",      iface = crate::interface::emit_counter_interface,      check = check_counter,      emit_sv = emit_counter);
+impl_construct_via_common!(ArbiterDecl,      "arbiter",      iface = crate::interface::emit_arbiter_interface,      check = check_arbiter,      emit_sv = emit_arbiter);
+impl_construct_via_common!(RegfileDecl,      "regfile",      iface = crate::interface::emit_regfile_interface,      check = check_regfile,      emit_sv = emit_regfile);
+impl_construct_via_common!(PipelineDecl,     "pipeline",     iface = crate::interface::emit_pipeline_interface,     check = check_pipeline,     emit_sv = emit_pipeline);
+impl_construct_via_common!(LinklistDecl,     "linklist",     iface = crate::interface::emit_linklist_interface,     check = check_linklist,     emit_sv = emit_linklist);
 
-impl_construct_direct!(DomainDecl,           "domain",                                                              check = check_domain);
-impl_construct_direct!(StructDecl,           "struct",       iface = crate::interface::emit_struct,                 check = check_struct);
-impl_construct_direct!(EnumDecl,             "enum",         iface = crate::interface::emit_enum,                   check = check_enum);
+impl_construct_direct!(DomainDecl,           "domain",                                                              check = check_domain,       emit_sv = emit_domain);
+impl_construct_direct!(StructDecl,           "struct",       iface = crate::interface::emit_struct,                 check = check_struct,       emit_sv = emit_struct);
+impl_construct_direct!(EnumDecl,             "enum",         iface = crate::interface::emit_enum,                   check = check_enum,         emit_sv = emit_enum);
 impl_construct_direct!(FunctionDecl,         "function",                                                            check = check_function);
-impl_construct_direct!(SynchronizerDecl,     "synchronizer", iface = crate::interface::emit_synchronizer_interface, check = check_synchronizer);
-impl_construct_direct!(ClkGateDecl,          "clkgate",      iface = crate::interface::emit_clkgate_interface,      check = check_clkgate);
+impl_construct_direct!(SynchronizerDecl,     "synchronizer", iface = crate::interface::emit_synchronizer_interface, check = check_synchronizer, emit_sv = emit_synchronizer);
+impl_construct_direct!(ClkGateDecl,          "clkgate",      iface = crate::interface::emit_clkgate_interface,      check = check_clkgate,      emit_sv = emit_clkgate);
 impl_construct_direct!(BusDecl,              "bus",          iface = crate::interface::emit_bus_interface,          check = check_bus);
-impl_construct_direct!(PackageDecl,          "package",      iface = crate::interface::emit_package_interface,      check = check_package);
+impl_construct_direct!(PackageDecl,          "package",      iface = crate::interface::emit_package_interface,      check = check_package,      emit_sv = emit_package);
 impl_construct_direct!(TemplateDecl,         "template",                                                            check = check_template);
 
 // `Use` has only `doc` — no inner doc (single-line decl).

--- a/src/codegen/arbiter.rs
+++ b/src/codegen/arbiter.rs
@@ -7,7 +7,7 @@
 use super::*;
 
 impl<'a> Codegen<'a> {
-    pub(super) fn emit_arbiter(&mut self, a: &crate::ast::ArbiterDecl) {
+    pub(crate) fn emit_arbiter(&mut self, a: &crate::ast::ArbiterDecl) {
         use crate::ast::ArbiterPolicy;
 
         let n = &a.name.name.clone();

--- a/src/codegen/cam.rs
+++ b/src/codegen/cam.rs
@@ -7,7 +7,7 @@
 use super::*;
 
 impl<'a> Codegen<'a> {
-    pub(super) fn emit_cam(&mut self, c: &crate::ast::CamDecl) {
+    pub(crate) fn emit_cam(&mut self, c: &crate::ast::CamDecl) {
         let n = c.name.name.clone();
 
         // Required params (validated by typecheck): DEPTH, KEY_W

--- a/src/codegen/clkgate.rs
+++ b/src/codegen/clkgate.rs
@@ -4,7 +4,7 @@
 use super::*;
 
 impl<'a> Codegen<'a> {
-    pub(super) fn emit_clkgate(&mut self, c: &crate::ast::ClkGateDecl) {
+    pub(crate) fn emit_clkgate(&mut self, c: &crate::ast::ClkGateDecl) {
         let n = &c.name.name;
 
         // Find port names

--- a/src/codegen/counter.rs
+++ b/src/codegen/counter.rs
@@ -7,7 +7,7 @@
 use super::*;
 
 impl<'a> Codegen<'a> {
-    pub(super) fn emit_counter(&mut self, c: &crate::ast::CounterDecl) {
+    pub(crate) fn emit_counter(&mut self, c: &crate::ast::CounterDecl) {
         use crate::ast::{CounterMode, CounterDirection};
 
         let n = &c.name.name.clone();

--- a/src/codegen/fifo.rs
+++ b/src/codegen/fifo.rs
@@ -7,7 +7,7 @@
 use super::*;
 
 impl<'a> Codegen<'a> {
-    pub(super) fn emit_fifo(&mut self, f: &FifoDecl) {
+    pub(crate) fn emit_fifo(&mut self, f: &FifoDecl) {
         use crate::resolve::detect_async_fifo;
         let is_async = detect_async_fifo(&f.ports);
 

--- a/src/codegen/fsm.rs
+++ b/src/codegen/fsm.rs
@@ -7,7 +7,7 @@
 use super::*;
 
 impl<'a> Codegen<'a> {
-    pub(super) fn emit_fsm(&mut self, f: &FsmDecl) {
+    pub(crate) fn emit_fsm(&mut self, f: &FsmDecl) {
         self.current_construct = f.name.name.clone();
         // Built-in `state` identifier inside fsm scope: read of the current
         // encoded state register. SV emission lowers to `state_r` (the enum

--- a/src/codegen/linklist.rs
+++ b/src/codegen/linklist.rs
@@ -7,7 +7,7 @@
 use super::*;
 
 impl<'a> Codegen<'a> {
-    pub(super) fn emit_linklist(&mut self, l: &crate::ast::LinklistDecl) {
+    pub(crate) fn emit_linklist(&mut self, l: &crate::ast::LinklistDecl) {
         use crate::ast::LinklistKind;
         let n = &l.name.name;
         let is_doubly = matches!(l.kind, LinklistKind::Doubly | LinklistKind::CircularDoubly);

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -168,29 +168,12 @@ impl<'a> Codegen<'a> {
             .collect();
         for item in items {
             self.emit_comments_before(item.span().start);
-            match item {
-                Item::Domain(d) => self.emit_domain(d),
-                Item::Struct(s) => self.emit_struct(s),
-                Item::Enum(e) => self.emit_enum(e),
-                Item::Module(m) => self.emit_module(m),
-                Item::Fsm(f) => self.emit_fsm(f),
-                Item::Fifo(f) => self.emit_fifo(f),
-                Item::Ram(r) => self.emit_ram(r),
-                Item::Cam(c) => self.emit_cam(c),
-
-                Item::Counter(c) => self.emit_counter(c),
-                Item::Arbiter(a) => self.emit_arbiter(a),
-                Item::Regfile(r) => self.emit_regfile(r),
-                Item::Pipeline(p) => self.emit_pipeline(p),
-                Item::Function(_) => {} // emitted inside modules
-                Item::Linklist(l) => self.emit_linklist(l),
-                Item::Template(_) => {} // compile-time only
-                Item::Bus(_) => {} // compile-time only; flattened at port sites
-                Item::Synchronizer(s) => self.emit_synchronizer(s),
-                Item::Clkgate(c) => self.emit_clkgate(c),
-                Item::Package(p) => self.emit_package(p),
-                Item::Use(_) => {} // import emitted inside modules
-            }
+            // Function / Template / Bus / Use have no top-level SV emit
+            // (Function is emitted inside each module body, Template is
+            // compile-time only, Bus is flattened at port sites, Use is
+            // an import emitted inside modules) — their `Construct::emit_sv`
+            // impl is the trait default no-op.
+            item.as_construct().emit_sv(self);
         }
         // Flush any trailing comments after the last item.
         let end = usize::MAX;
@@ -320,7 +303,7 @@ impl<'a> Codegen<'a> {
         }
     }
 
-    fn emit_domain(&mut self, d: &DomainDecl) {
+    pub(crate) fn emit_domain(&mut self, d: &DomainDecl) {
         self.line(&format!("// domain {}", d.name.name));
         for field in &d.fields {
             self.line(&format!("//   {}: {}", field.name.name, self.emit_expr_str(&field.value)));
@@ -497,7 +480,7 @@ impl<'a> Codegen<'a> {
         self.line("end");
     }
 
-    fn emit_package(&mut self, pkg: &PackageDecl) {
+    pub(crate) fn emit_package(&mut self, pkg: &PackageDecl) {
         self.line(&format!("package {};", pkg.name.name));
         self.indent += 1;
 
@@ -529,7 +512,7 @@ impl<'a> Codegen<'a> {
         self.line("");
     }
 
-    fn emit_struct(&mut self, s: &StructDecl) {
+    pub(crate) fn emit_struct(&mut self, s: &StructDecl) {
         // Canonical ARCH packed-struct bit layout: first-declared field = MSB,
         // last-declared field = LSB — matching SV's `struct packed` convention
         // (fields listed top-to-bottom inside `struct packed { ... }` are emitted
@@ -545,7 +528,7 @@ impl<'a> Codegen<'a> {
         self.line("");
     }
 
-    fn emit_enum(&mut self, e: &EnumDecl) {
+    pub(crate) fn emit_enum(&mut self, e: &EnumDecl) {
         // Compute effective values: explicit where provided, auto-sequential otherwise
         let effective_values: Vec<u64> = e.values.iter().enumerate().map(|(i, v)| {
             v.as_ref().and_then(|expr| match &expr.kind {

--- a/src/codegen/module.rs
+++ b/src/codegen/module.rs
@@ -7,7 +7,7 @@
 use super::*;
 
 impl<'a> Codegen<'a> {
-    pub(super) fn emit_module(&mut self, m: &ModuleDecl) {
+    pub(crate) fn emit_module(&mut self, m: &ModuleDecl) {
         self.current_construct = m.name.name.clone();
         // Emit SV `import NAME::*;` only for `use NAME;` whose target is an
         // actual `package` — package contents become an SV package and need

--- a/src/codegen/pipeline.rs
+++ b/src/codegen/pipeline.rs
@@ -59,7 +59,7 @@ impl<'a> Codegen<'a> {
 
     // ── FSM ───────────────────────────────────────────────────────────────────
 
-    pub(super) fn emit_pipeline(&mut self, p: &PipelineDecl) {
+    pub(crate) fn emit_pipeline(&mut self, p: &PipelineDecl) {
         self.current_construct = p.name.name.clone();
         let n = &p.name.name;
 

--- a/src/codegen/ram.rs
+++ b/src/codegen/ram.rs
@@ -7,7 +7,7 @@
 use super::*;
 
 impl<'a> Codegen<'a> {
-    pub(super) fn emit_ram(&mut self, r: &RamDecl) {
+    pub(crate) fn emit_ram(&mut self, r: &RamDecl) {
         use crate::ast::{RamKind, RamInit};
 
         // Resolve DATA_WIDTH from WIDTH type param

--- a/src/codegen/regfile.rs
+++ b/src/codegen/regfile.rs
@@ -10,7 +10,7 @@
 use super::*;
 
 impl<'a> Codegen<'a> {
-    pub(super) fn emit_regfile(&mut self, r: &crate::ast::RegfileDecl) {
+    pub(crate) fn emit_regfile(&mut self, r: &crate::ast::RegfileDecl) {
         use crate::ast::ParamKind;
         let n = &r.name.name.clone();
 

--- a/src/codegen/synchronizer.rs
+++ b/src/codegen/synchronizer.rs
@@ -4,7 +4,7 @@
 use super::*;
 
 impl<'a> Codegen<'a> {
-    pub(super) fn emit_synchronizer(&mut self, s: &SynchronizerDecl) {
+    pub(crate) fn emit_synchronizer(&mut self, s: &SynchronizerDecl) {
         let n = &s.name.name;
 
         // Resolve STAGES (default 2)


### PR DESCRIPTION
**Stacks on PRs #216, #217, #218.** Merge those first; this PR rebases cleanly onto main once they land.

## Summary
Phase 4 of item #6 (approach a):
- Add `fn emit_sv(&self, codegen: &mut Codegen)` to the `Construct` trait, default no-op (matches the original `Function` / `Template` / `Bus` / `Use` arms — none emit top-level SV).
- Extend the `impl_construct_*` macros with an additional optional `emit_sv = method_name` arg. Order: `iface`, `check`, `emit_sv`.
- Bump every per-construct `pub(super) fn emit_*` in `src/codegen/<X>.rs` to `pub(crate)` so the trait impls in `ast.rs` can call them. Same for in-`mod.rs` `emit_domain` / `emit_struct` / `emit_enum` / `emit_package`.

Migrate `Codegen::emit`'s 18-arm match to:
```rust
for item in items {
    self.emit_comments_before(item.span().start);
    item.as_construct().emit_sv(self);
}
```

The four no-emit arms (Function / Template / Bus / Use) fall through to the trait default — no explicit `_ => {}` needed.

## Test plan
- [x] 221/221 integration tests pass
- [x] 24 lib unit tests pass
- [x] Zero snapshot drift across 34 SV-emission snapshots
- [x] `cargo build` clean
- Net diff: **+50/-58** across 14 files (most are 2-line visibility bumps)

## Remaining phases
- `emit_sim()` → migrate `sim_codegen/mod.rs`'s 14-arm dispatch
- `build_symbols()` → migrate `resolve.rs`