### PR TITLE
refactor(ast): add Construct::emit_sim, drop sim_codegen match (item #6 phase 5)

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1124,6 +1124,15 @@ pub trait Construct {
     /// inside each module body, `template` is compile-time-only,
     /// `bus` flattens at port sites, and `use` is an import directive.
     fn emit_sv(&self, _codegen: &mut crate::codegen::Codegen) {}
+
+    /// Emit a C++ simulation model for this construct. Returns
+    /// `Some(model)` for constructs that have a sim emitter (counter,
+    /// fsm, regfile, ram, cam, fifo, synchronizer, clkgate, linklist,
+    /// arbiter, pipeline). Returns `None` for everything else
+    /// (Module is handled specially by the caller because it needs the
+    /// debug-module set; Domain / Struct / Enum / Function / Template
+    /// / Bus / Package / Use don't generate sim code).
+    fn emit_sim(&self, _simgen: &crate::sim_codegen::SimCodegen) -> Option<crate::sim_codegen::SimModel> { None }
 }
 
 // ── Construct trait impls ────────────────────────────────────────────────────
@@ -1141,7 +1150,7 @@ pub trait Construct {
 /// optional in any order. Without them, the trait defaults apply
 /// (`emit_interface` returns `None`, `typecheck` is a no-op).
 macro_rules! impl_construct_via_common {
-    ($ty:ty, $label:expr $(, iface = $iface:path)? $(, check = $check:ident)? $(, emit_sv = $emit_sv:ident)?) => {
+    ($ty:ty, $label:expr $(, iface = $iface:path)? $(, check = $check:ident)? $(, emit_sv = $emit_sv:ident)? $(, emit_sim = $emit_sim:ident)?) => {
         impl Construct for $ty {
             fn kind_label(&self) -> &'static str { $label }
             fn name(&self)      -> &Ident         { &self.common.name }
@@ -1151,6 +1160,7 @@ macro_rules! impl_construct_via_common {
             $(fn emit_interface(&self) -> Option<String> { Some($iface(self)) })?
             $(fn typecheck(&self, c: &mut crate::typecheck::TypeChecker) { c.$check(self); })?
             $(fn emit_sv(&self, c: &mut crate::codegen::Codegen) { c.$emit_sv(self); })?
+            $(fn emit_sim(&self, c: &crate::sim_codegen::SimCodegen) -> Option<crate::sim_codegen::SimModel> { Some(c.$emit_sim(self)) })?
         }
     };
 }
@@ -1159,7 +1169,7 @@ macro_rules! impl_construct_via_common {
 /// `doc` / `inner_doc` directly. Same optional-arg pattern as the
 /// via-common variant.
 macro_rules! impl_construct_direct {
-    ($ty:ty, $label:expr $(, iface = $iface:path)? $(, check = $check:ident)? $(, emit_sv = $emit_sv:ident)?) => {
+    ($ty:ty, $label:expr $(, iface = $iface:path)? $(, check = $check:ident)? $(, emit_sv = $emit_sv:ident)? $(, emit_sim = $emit_sim:ident)?) => {
         impl Construct for $ty {
             fn kind_label(&self) -> &'static str { $label }
             fn name(&self)      -> &Ident         { &self.name }
@@ -1169,27 +1179,28 @@ macro_rules! impl_construct_direct {
             $(fn emit_interface(&self) -> Option<String> { Some($iface(self)) })?
             $(fn typecheck(&self, c: &mut crate::typecheck::TypeChecker) { c.$check(self); })?
             $(fn emit_sv(&self, c: &mut crate::codegen::Codegen) { c.$emit_sv(self); })?
+            $(fn emit_sim(&self, c: &crate::sim_codegen::SimCodegen) -> Option<crate::sim_codegen::SimModel> { Some(c.$emit_sim(self)) })?
         }
     };
 }
 
 impl_construct_direct!(ModuleDecl,           "module",       iface = crate::interface::emit_module_interface,       check = check_module,       emit_sv = emit_module);
-impl_construct_via_common!(FsmDecl,          "fsm",          iface = crate::interface::emit_fsm_interface,          check = check_fsm,          emit_sv = emit_fsm);
-impl_construct_via_common!(FifoDecl,         "fifo",         iface = crate::interface::emit_fifo_interface,         check = check_fifo,         emit_sv = emit_fifo);
-impl_construct_via_common!(RamDecl,          "ram",          iface = crate::interface::emit_ram_interface,          check = check_ram,          emit_sv = emit_ram);
-impl_construct_via_common!(CamDecl,          "cam",                                                                 check = check_cam,          emit_sv = emit_cam);
-impl_construct_via_common!(CounterDecl,      "counter",      iface = crate::interface::emit_counter_interface,      check = check_counter,      emit_sv = emit_counter);
-impl_construct_via_common!(ArbiterDecl,      "arbiter",      iface = crate::interface::emit_arbiter_interface,      check = check_arbiter,      emit_sv = emit_arbiter);
-impl_construct_via_common!(RegfileDecl,      "regfile",      iface = crate::interface::emit_regfile_interface,      check = check_regfile,      emit_sv = emit_regfile);
-impl_construct_via_common!(PipelineDecl,     "pipeline",     iface = crate::interface::emit_pipeline_interface,     check = check_pipeline,     emit_sv = emit_pipeline);
-impl_construct_via_common!(LinklistDecl,     "linklist",     iface = crate::interface::emit_linklist_interface,     check = check_linklist,     emit_sv = emit_linklist);
+impl_construct_via_common!(FsmDecl,          "fsm",          iface = crate::interface::emit_fsm_interface,          check = check_fsm,          emit_sv = emit_fsm,          emit_sim = gen_fsm);
+impl_construct_via_common!(FifoDecl,         "fifo",         iface = crate::interface::emit_fifo_interface,         check = check_fifo,         emit_sv = emit_fifo,         emit_sim = gen_fifo);
+impl_construct_via_common!(RamDecl,          "ram",          iface = crate::interface::emit_ram_interface,          check = check_ram,          emit_sv = emit_ram,          emit_sim = gen_ram);
+impl_construct_via_common!(CamDecl,          "cam",                                                                 check = check_cam,          emit_sv = emit_cam,          emit_sim = gen_cam);
+impl_construct_via_common!(CounterDecl,      "counter",      iface = crate::interface::emit_counter_interface,      check = check_counter,      emit_sv = emit_counter,      emit_sim = gen_counter);
+impl_construct_via_common!(ArbiterDecl,      "arbiter",      iface = crate::interface::emit_arbiter_interface,      check = check_arbiter,      emit_sv = emit_arbiter,      emit_sim = gen_arbiter);
+impl_construct_via_common!(RegfileDecl,      "regfile",      iface = crate::interface::emit_regfile_interface,      check = check_regfile,      emit_sv = emit_regfile,      emit_sim = gen_regfile);
+impl_construct_via_common!(PipelineDecl,     "pipeline",     iface = crate::interface::emit_pipeline_interface,     check = check_pipeline,     emit_sv = emit_pipeline,     emit_sim = gen_pipeline);
+impl_construct_via_common!(LinklistDecl,     "linklist",     iface = crate::interface::emit_linklist_interface,     check = check_linklist,     emit_sv = emit_linklist,     emit_sim = gen_linklist);
 
 impl_construct_direct!(DomainDecl,           "domain",                                                              check = check_domain,       emit_sv = emit_domain);
 impl_construct_direct!(StructDecl,           "struct",       iface = crate::interface::emit_struct,                 check = check_struct,       emit_sv = emit_struct);
 impl_construct_direct!(EnumDecl,             "enum",         iface = crate::interface::emit_enum,                   check = check_enum,         emit_sv = emit_enum);
 impl_construct_direct!(FunctionDecl,         "function",                                                            check = check_function);
-impl_construct_direct!(SynchronizerDecl,     "synchronizer", iface = crate::interface::emit_synchronizer_interface, check = check_synchronizer, emit_sv = emit_synchronizer);
-impl_construct_direct!(ClkGateDecl,          "clkgate",      iface = crate::interface::emit_clkgate_interface,      check = check_clkgate,      emit_sv = emit_clkgate);
+impl_construct_direct!(SynchronizerDecl,     "synchronizer", iface = crate::interface::emit_synchronizer_interface, check = check_synchronizer, emit_sv = emit_synchronizer, emit_sim = gen_synchronizer);
+impl_construct_direct!(ClkGateDecl,          "clkgate",      iface = crate::interface::emit_clkgate_interface,      check = check_clkgate,      emit_sv = emit_clkgate,      emit_sim = gen_clkgate);
 impl_construct_direct!(BusDecl,              "bus",          iface = crate::interface::emit_bus_interface,          check = check_bus);
 impl_construct_direct!(PackageDecl,          "package",      iface = crate::interface::emit_package_interface,      check = check_package,      emit_sv = emit_package);
 impl_construct_direct!(TemplateDecl,         "template",                                                            check = check_template);

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1117,6 +1117,13 @@ pub trait Construct {
     /// construct that has type rules overrides this to call its
     /// specific `TypeChecker::check_*` method.
     fn typecheck(&self, _checker: &mut crate::typecheck::TypeChecker) {}
+
+    /// Emit SystemVerilog for this construct. Default is a no-op,
+    /// matching the original `Item::Function(_) | Item::Template(_) |
+    /// Item::Bus(_) | Item::Use(_) => {}` arms — `function` is emitted
+    /// inside each module body, `template` is compile-time-only,
+    /// `bus` flattens at port sites, and `use` is an import directive.
+    fn emit_sv(&self, _codegen: &mut crate::codegen::Codegen) {}
 }
 
 // ── Construct trait impls ────────────────────────────────────────────────────
@@ -1134,7 +1141,7 @@ pub trait Construct {
 /// optional in any order. Without them, the trait defaults apply
 /// (`emit_interface` returns `None`, `typecheck` is a no-op).
 macro_rules! impl_construct_via_common {
-    ($ty:ty, $label:expr $(, iface = $iface:path)? $(, check = $check:ident)?) => {
+    ($ty:ty, $label:expr $(, iface = $iface:path)? $(, check = $check:ident)? $(, emit_sv = $emit_sv:ident)?) => {
         impl Construct for $ty {
             fn kind_label(&self) -> &'static str { $label }
             fn name(&self)      -> &Ident         { &self.common.name }
@@ -1143,6 +1150,7 @@ macro_rules! impl_construct_via_common {
             fn inner_doc(&self) -> Option<&str>   { self.common.inner_doc.as_deref() }
             $(fn emit_interface(&self) -> Option<String> { Some($iface(self)) })?
             $(fn typecheck(&self, c: &mut crate::typecheck::TypeChecker) { c.$check(self); })?
+            $(fn emit_sv(&self, c: &mut crate::codegen::Codegen) { c.$emit_sv(self); })?
         }
     };
 }
@@ -1151,7 +1159,7 @@ macro_rules! impl_construct_via_common {
 /// `doc` / `inner_doc` directly. Same optional-arg pattern as the
 /// via-common variant.
 macro_rules! impl_construct_direct {
-    ($ty:ty, $label:expr $(, iface = $iface:path)? $(, check = $check:ident)?) => {
+    ($ty:ty, $label:expr $(, iface = $iface:path)? $(, check = $check:ident)? $(, emit_sv = $emit_sv:ident)?) => {
         impl Construct for $ty {
             fn kind_label(&self) -> &'static str { $label }
             fn name(&self)      -> &Ident         { &self.name }
@@ -1160,29 +1168,30 @@ macro_rules! impl_construct_direct {
             fn inner_doc(&self) -> Option<&str>   { self.inner_doc.as_deref() }
             $(fn emit_interface(&self) -> Option<String> { Some($iface(self)) })?
             $(fn typecheck(&self, c: &mut crate::typecheck::TypeChecker) { c.$check(self); })?
+            $(fn emit_sv(&self, c: &mut crate::codegen::Codegen) { c.$emit_sv(self); })?
         }
     };
 }
 
-impl_construct_direct!(ModuleDecl,           "module",       iface = crate::interface::emit_module_interface,       check = check_module);
-impl_construct_via_common!(FsmDecl,          "fsm",          iface = crate::interface::emit_fsm_interface,          check = check_fsm);
-impl_construct_via_common!(FifoDecl,         "fifo",         iface = crate::interface::emit_fifo_interface,         check = check_fifo);
-impl_construct_via_common!(RamDecl,          "ram",          iface = crate::interface::emit_ram_interface,          check = check_ram);
-impl_construct_via_common!(CamDecl,          "cam",                                                                 check = check_cam);
-impl_construct_via_common!(CounterDecl,      "counter",      iface = crate::interface::emit_counter_interface,      check = check_counter);
-impl_construct_via_common!(ArbiterDecl,      "arbiter",      iface = crate::interface::emit_arbiter_interface,      check = check_arbiter);
-impl_construct_via_common!(RegfileDecl,      "regfile",      iface = crate::interface::emit_regfile_interface,      check = check_regfile);
-impl_construct_via_common!(PipelineDecl,     "pipeline",     iface = crate::interface::emit_pipeline_interface,     check = check_pipeline);
-impl_construct_via_common!(LinklistDecl,     "linklist",     iface = crate::interface::emit_linklist_interface,     check = check_linklist);
+impl_construct_direct!(ModuleDecl,           "module",       iface = crate::interface::emit_module_interface,       check = check_module,       emit_sv = emit_module);
+impl_construct_via_common!(FsmDecl,          "fsm",          iface = crate::interface::emit_fsm_interface,          check = check_fsm,          emit_sv = emit_fsm);
+impl_construct_via_common!(FifoDecl,         "fifo",         iface = crate::interface::emit_fifo_interface,         check = check_fifo,         emit_sv = emit_fifo);
+impl_construct_via_common!(RamDecl,          "ram",          iface = crate::interface::emit_ram_interface,          check = check_ram,          emit_sv = emit_ram);
+impl_construct_via_common!(CamDecl,          "cam",                                                                 check = check_cam,          emit_sv = emit_cam);
+impl_construct_via_common!(CounterDecl,      "counter",      iface = crate::interface::emit_counter_interface,      check = check_counter,      emit_sv = emit_counter);
+impl_construct_via_common!(ArbiterDecl,      "arbiter",      iface = crate::interface::emit_arbiter_interface,      check = check_arbiter,      emit_sv = emit_arbiter);
+impl_construct_via_common!(RegfileDecl,      "regfile",      iface = crate::interface::emit_regfile_interface,      check = check_regfile,      emit_sv = emit_regfile);
+impl_construct_via_common!(PipelineDecl,     "pipeline",     iface = crate::interface::emit_pipeline_interface,     check = check_pipeline,     emit_sv = emit_pipeline);
+impl_construct_via_common!(LinklistDecl,     "linklist",     iface = crate::interface::emit_linklist_interface,     check = check_linklist,     emit_sv = emit_linklist);
 
-impl_construct_direct!(DomainDecl,           "domain",                                                              check = check_domain);
-impl_construct_direct!(StructDecl,           "struct",       iface = crate::interface::emit_struct,                 check = check_struct);
-impl_construct_direct!(EnumDecl,             "enum",         iface = crate::interface::emit_enum,                   check = check_enum);
+impl_construct_direct!(DomainDecl,           "domain",                                                              check = check_domain,       emit_sv = emit_domain);
+impl_construct_direct!(StructDecl,           "struct",       iface = crate::interface::emit_struct,                 check = check_struct,       emit_sv = emit_struct);
+impl_construct_direct!(EnumDecl,             "enum",         iface = crate::interface::emit_enum,                   check = check_enum,         emit_sv = emit_enum);
 impl_construct_direct!(FunctionDecl,         "function",                                                            check = check_function);
-impl_construct_direct!(SynchronizerDecl,     "synchronizer", iface = crate::interface::emit_synchronizer_interface, check = check_synchronizer);
-impl_construct_direct!(ClkGateDecl,          "clkgate",      iface = crate::interface::emit_clkgate_interface,      check = check_clkgate);
+impl_construct_direct!(SynchronizerDecl,     "synchronizer", iface = crate::interface::emit_synchronizer_interface, check = check_synchronizer, emit_sv = emit_synchronizer);
+impl_construct_direct!(ClkGateDecl,          "clkgate",      iface = crate::interface::emit_clkgate_interface,      check = check_clkgate,      emit_sv = emit_clkgate);
 impl_construct_direct!(BusDecl,              "bus",          iface = crate::interface::emit_bus_interface,          check = check_bus);
-impl_construct_direct!(PackageDecl,          "package",      iface = crate::interface::emit_package_interface,      check = check_package);
+impl_construct_direct!(PackageDecl,          "package",      iface = crate::interface::emit_package_interface,      check = check_package,      emit_sv = emit_package);
 impl_construct_direct!(TemplateDecl,         "template",                                                            check = check_template);
 
 // `Use` has only `doc` — no inner doc (single-line decl).

--- a/src/codegen/arbiter.rs
+++ b/src/codegen/arbiter.rs
@@ -7,7 +7,7 @@
 use super::*;
 
 impl<'a> Codegen<'a> {
-    pub(super) fn emit_arbiter(&mut self, a: &crate::ast::ArbiterDecl) {
+    pub(crate) fn emit_arbiter(&mut self, a: &crate::ast::ArbiterDecl) {
         use crate::ast::ArbiterPolicy;
 
         let n = &a.name.name.clone();

--- a/src/codegen/cam.rs
+++ b/src/codegen/cam.rs
@@ -7,7 +7,7 @@
 use super::*;
 
 impl<'a> Codegen<'a> {
-    pub(super) fn emit_cam(&mut self, c: &crate::ast::CamDecl) {
+    pub(crate) fn emit_cam(&mut self, c: &crate::ast::CamDecl) {
         let n = c.name.name.clone();
 
         // Required params (validated by typecheck): DEPTH, KEY_W

--- a/src/codegen/clkgate.rs
+++ b/src/codegen/clkgate.rs
@@ -4,7 +4,7 @@
 use super::*;
 
 impl<'a> Codegen<'a> {
-    pub(super) fn emit_clkgate(&mut self, c: &crate::ast::ClkGateDecl) {
+    pub(crate) fn emit_clkgate(&mut self, c: &crate::ast::ClkGateDecl) {
         let n = &c.name.name;
 
         // Find port names

--- a/src/codegen/counter.rs
+++ b/src/codegen/counter.rs
@@ -7,7 +7,7 @@
 use super::*;
 
 impl<'a> Codegen<'a> {
-    pub(super) fn emit_counter(&mut self, c: &crate::ast::CounterDecl) {
+    pub(crate) fn emit_counter(&mut self, c: &crate::ast::CounterDecl) {
         use crate::ast::{CounterMode, CounterDirection};
 
         let n = &c.name.name.clone();

--- a/src/codegen/fifo.rs
+++ b/src/codegen/fifo.rs
@@ -7,7 +7,7 @@
 use super::*;
 
 impl<'a> Codegen<'a> {
-    pub(super) fn emit_fifo(&mut self, f: &FifoDecl) {
+    pub(crate) fn emit_fifo(&mut self, f: &FifoDecl) {
         use crate::resolve::detect_async_fifo;
         let is_async = detect_async_fifo(&f.ports);
 

--- a/src/codegen/fsm.rs
+++ b/src/codegen/fsm.rs
@@ -7,7 +7,7 @@
 use super::*;
 
 impl<'a> Codegen<'a> {
-    pub(super) fn emit_fsm(&mut self, f: &FsmDecl) {
+    pub(crate) fn emit_fsm(&mut self, f: &FsmDecl) {
         self.current_construct = f.name.name.clone();
         // Built-in `state` identifier inside fsm scope: read of the current
         // encoded state register. SV emission lowers to `state_r` (the enum

--- a/src/codegen/linklist.rs
+++ b/src/codegen/linklist.rs
@@ -7,7 +7,7 @@
 use super::*;
 
 impl<'a> Codegen<'a> {
-    pub(super) fn emit_linklist(&mut self, l: &crate::ast::LinklistDecl) {
+    pub(crate) fn emit_linklist(&mut self, l: &crate::ast::LinklistDecl) {
         use crate::ast::LinklistKind;
         let n = &l.name.name;
         let is_doubly = matches!(l.kind, LinklistKind::Doubly | LinklistKind::CircularDoubly);

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -168,29 +168,12 @@ impl<'a> Codegen<'a> {
             .collect();
         for item in items {
             self.emit_comments_before(item.span().start);
-            match item {
-                Item::Domain(d) => self.emit_domain(d),
-                Item::Struct(s) => self.emit_struct(s),
-                Item::Enum(e) => self.emit_enum(e),
-                Item::Module(m) => self.emit_module(m),
-                Item::Fsm(f) => self.emit_fsm(f),
-                Item::Fifo(f) => self.emit_fifo(f),
-                Item::Ram(r) => self.emit_ram(r),
-                Item::Cam(c) => self.emit_cam(c),
-
-                Item::Counter(c) => self.emit_counter(c),
-                Item::Arbiter(a) => self.emit_arbiter(a),
-                Item::Regfile(r) => self.emit_regfile(r),
-                Item::Pipeline(p) => self.emit_pipeline(p),
-                Item::Function(_) => {} // emitted inside modules
-                Item::Linklist(l) => self.emit_linklist(l),
-                Item::Template(_) => {} // compile-time only
-                Item::Bus(_) => {} // compile-time only; flattened at port sites
-                Item::Synchronizer(s) => self.emit_synchronizer(s),
-                Item::Clkgate(c) => self.emit_clkgate(c),
-                Item::Package(p) => self.emit_package(p),
-                Item::Use(_) => {} // import emitted inside modules
-            }
+            // Function / Template / Bus / Use have no top-level SV emit
+            // (Function is emitted inside each module body, Template is
+            // compile-time only, Bus is flattened at port sites, Use is
+            // an import emitted inside modules) — their `Construct::emit_sv`
+            // impl is the trait default no-op.
+            item.as_construct().emit_sv(self);
         }
         // Flush any trailing comments after the last item.
         let end = usize::MAX;
@@ -320,7 +303,7 @@ impl<'a> Codegen<'a> {
         }
     }
 
-    fn emit_domain(&mut self, d: &DomainDecl) {
+    pub(crate) fn emit_domain(&mut self, d: &DomainDecl) {
         self.line(&format!("// domain {}", d.name.name));
         for field in &d.fields {
             self.line(&format!("//   {}: {}", field.name.name, self.emit_expr_str(&field.value)));
@@ -497,7 +480,7 @@ impl<'a> Codegen<'a> {
         self.line("end");
     }
 
-    fn emit_package(&mut self, pkg: &PackageDecl) {
+    pub(crate) fn emit_package(&mut self, pkg: &PackageDecl) {
         self.line(&format!("package {};", pkg.name.name));
         self.indent += 1;
 
@@ -529,7 +512,7 @@ impl<'a> Codegen<'a> {
         self.line("");
     }
 
-    fn emit_struct(&mut self, s: &StructDecl) {
+    pub(crate) fn emit_struct(&mut self, s: &StructDecl) {
         // Canonical ARCH packed-struct bit layout: first-declared field = MSB,
         // last-declared field = LSB — matching SV's `struct packed` convention
         // (fields listed top-to-bottom inside `struct packed { ... }` are emitted
@@ -545,7 +528,7 @@ impl<'a> Codegen<'a> {
         self.line("");
     }
 
-    fn emit_enum(&mut self, e: &EnumDecl) {
+    pub(crate) fn emit_enum(&mut self, e: &EnumDecl) {
         // Compute effective values: explicit where provided, auto-sequential otherwise
         let effective_values: Vec<u64> = e.values.iter().enumerate().map(|(i, v)| {
             v.as_ref().and_then(|expr| match &expr.kind {

--- a/src/codegen/module.rs
+++ b/src/codegen/module.rs
@@ -7,7 +7,7 @@
 use super::*;
 
 impl<'a> Codegen<'a> {
-    pub(super) fn emit_module(&mut self, m: &ModuleDecl) {
+    pub(crate) fn emit_module(&mut self, m: &ModuleDecl) {
         self.current_construct = m.name.name.clone();
         // Emit SV `import NAME::*;` only for `use NAME;` whose target is an
         // actual `package` — package contents become an SV package and need

--- a/src/codegen/pipeline.rs
+++ b/src/codegen/pipeline.rs
@@ -59,7 +59,7 @@ impl<'a> Codegen<'a> {
 
     // ── FSM ───────────────────────────────────────────────────────────────────
 
-    pub(super) fn emit_pipeline(&mut self, p: &PipelineDecl) {
+    pub(crate) fn emit_pipeline(&mut self, p: &PipelineDecl) {
         self.current_construct = p.name.name.clone();
         let n = &p.name.name;
 

--- a/src/codegen/ram.rs
+++ b/src/codegen/ram.rs
@@ -7,7 +7,7 @@
 use super::*;
 
 impl<'a> Codegen<'a> {
-    pub(super) fn emit_ram(&mut self, r: &RamDecl) {
+    pub(crate) fn emit_ram(&mut self, r: &RamDecl) {
         use crate::ast::{RamKind, RamInit};
 
         // Resolve DATA_WIDTH from WIDTH type param

--- a/src/codegen/regfile.rs
+++ b/src/codegen/regfile.rs
@@ -10,7 +10,7 @@
 use super::*;
 
 impl<'a> Codegen<'a> {
-    pub(super) fn emit_regfile(&mut self, r: &crate::ast::RegfileDecl) {
+    pub(crate) fn emit_regfile(&mut self, r: &crate::ast::RegfileDecl) {
         use crate::ast::ParamKind;
         let n = &r.name.name.clone();
 

--- a/src/codegen/synchronizer.rs
+++ b/src/codegen/synchronizer.rs
@@ -4,7 +4,7 @@
 use super::*;
 
 impl<'a> Codegen<'a> {
-    pub(super) fn emit_synchronizer(&mut self, s: &SynchronizerDecl) {
+    pub(crate) fn emit_synchronizer(&mut self, s: &SynchronizerDecl) {
         let n = &s.name.name;
 
         // Resolve STAGES (default 2)

--- a/src/sim_codegen/cam.rs
+++ b/src/sim_codegen/cam.rs
@@ -9,7 +9,7 @@ use super::{SimCodegen, SimModel};
 use super::*;
 
 impl<'a> SimCodegen<'a> {
-    pub(super) fn gen_cam(&self, c: &CamDecl) -> SimModel {
+    pub(crate) fn gen_cam(&self, c: &CamDecl) -> SimModel {
         let name = &c.name.name;
         let class = format!("V{name}");
 

--- a/src/sim_codegen/fifo.rs
+++ b/src/sim_codegen/fifo.rs
@@ -5,7 +5,7 @@ use super::{SimCodegen, SimModel};
 use super::*;
 
 impl<'a> SimCodegen<'a> {
-    pub(super) fn gen_fifo(&self, f: &FifoDecl) -> SimModel {
+    pub(crate) fn gen_fifo(&self, f: &FifoDecl) -> SimModel {
         let name = &f.name.name;
         let class = format!("V{name}");
         let is_lifo = f.kind == FifoKind::Lifo;

--- a/src/sim_codegen/fsm.rs
+++ b/src/sim_codegen/fsm.rs
@@ -11,7 +11,7 @@ use super::{SimCodegen, SimModel};
 use super::*;
 
 impl<'a> SimCodegen<'a> {
-    pub(super) fn gen_fsm(&self, f: &FsmDecl) -> SimModel {
+    pub(crate) fn gen_fsm(&self, f: &FsmDecl) -> SimModel {
         let name = &f.name.name;
         let class = format!("V{name}");
         let enum_map = build_enum_map(self.symbols);

--- a/src/sim_codegen/linklist.rs
+++ b/src/sim_codegen/linklist.rs
@@ -5,7 +5,7 @@ use super::{SimCodegen, SimModel};
 use super::*;
 
 impl<'a> SimCodegen<'a> {
-    pub(super) fn gen_linklist(&self, l: &crate::ast::LinklistDecl) -> SimModel {
+    pub(crate) fn gen_linklist(&self, l: &crate::ast::LinklistDecl) -> SimModel {
         use crate::ast::{LinklistKind, Direction};
 
         let name  = &l.name.name;

--- a/src/sim_codegen/mod.rs
+++ b/src/sim_codegen/mod.rs
@@ -249,24 +249,20 @@ impl<'a> SimCodegen<'a> {
         };
 
         for item in &self.source.items {
-            match item {
-                Item::Module(m)      => models.push(self.gen_module(
+            // Module is special — it needs the debug-module set passed
+            // through so each emitted class can wire its own debug
+            // instrumentation. All other sim-emitting constructs go
+            // through the uniform `Construct::emit_sim` dispatch, which
+            // returns `Some(model)` for the 11 sim-emitting variants
+            // and `None` for the rest.
+            if let Item::Module(m) = item {
+                models.push(self.gen_module(
                     m,
                     debug_module_set.contains(m.name.name.as_str()),
                     &debug_module_set,
-                )),
-                Item::Counter(c)     => models.push(self.gen_counter(c)),
-                Item::Fsm(f)         => models.push(self.gen_fsm(f)),
-                Item::Regfile(r)     => models.push(self.gen_regfile(r)),
-                Item::Linklist(l)    => models.push(self.gen_linklist(l)),
-                Item::Ram(r)         => models.push(self.gen_ram(r)),
-                Item::Cam(c)         => models.push(self.gen_cam(c)),
-                Item::Synchronizer(s) => models.push(self.gen_synchronizer(s)),
-                Item::Clkgate(c)     => models.push(self.gen_clkgate(c)),
-                Item::Fifo(f)        => models.push(self.gen_fifo(f)),
-                Item::Arbiter(a)     => models.push(self.gen_arbiter(a)),
-                Item::Pipeline(p)    => models.push(self.gen_pipeline(p)),
-                _ => {}
+                ));
+            } else if let Some(model) = item.as_construct().emit_sim(self) {
+                models.push(model);
             }
         }
         models
@@ -3360,7 +3356,7 @@ impl<'a> SimCodegen<'a> {
         Vec::new()
     }
 
-    fn gen_module(&self, m: &ModuleDecl, emit_debug: bool, debug_module_set: &std::collections::HashSet<String>) -> SimModel {
+    pub(crate) fn gen_module(&self, m: &ModuleDecl, emit_debug: bool, debug_module_set: &std::collections::HashSet<String>) -> SimModel {
         let name = &m.name.name;
         let class = format!("V{name}");
         let enum_map = build_enum_map(self.symbols);
@@ -5737,7 +5733,7 @@ impl<'a> SimCodegen<'a> {
 // ── Counter codegen ───────────────────────────────────────────────────────────
 
 impl<'a> SimCodegen<'a> {
-    fn gen_counter(&self, c: &CounterDecl) -> SimModel {
+    pub(crate) fn gen_counter(&self, c: &CounterDecl) -> SimModel {
         let name = &c.name.name;
         let class = format!("V{name}");
 
@@ -5903,7 +5899,7 @@ impl<'a> SimCodegen<'a> {
 // ── Regfile codegen ───────────────────────────────────────────────────────────
 
 impl<'a> SimCodegen<'a> {
-    fn gen_regfile(&self, r: &RegfileDecl) -> SimModel {
+    pub(crate) fn gen_regfile(&self, r: &RegfileDecl) -> SimModel {
         let name  = &r.name.name;
         let class = format!("V{name}");
 
@@ -6078,7 +6074,7 @@ impl<'a> SimCodegen<'a> {
     }
 
 
-    fn gen_synchronizer(&self, s: &crate::ast::SynchronizerDecl) -> SimModel {
+    pub(crate) fn gen_synchronizer(&self, s: &crate::ast::SynchronizerDecl) -> SimModel {
         use crate::ast::SyncKind;
 
         let class = s.name.name.clone();
@@ -6306,7 +6302,7 @@ impl<'a> SimCodegen<'a> {
         SimModel { class_name: class, header: h, impl_: cpp }
     }
 
-    fn gen_clkgate(&self, c: &crate::ast::ClkGateDecl) -> SimModel {
+    pub(crate) fn gen_clkgate(&self, c: &crate::ast::ClkGateDecl) -> SimModel {
         let class = format!("V{}", c.name.name);
 
         let clk_in = c.ports.iter().find(|p| matches!(&p.ty, TypeExpr::Clock(_)) && p.direction == Direction::In)
@@ -6488,7 +6484,7 @@ impl<'a> SimCodegen<'a> {
     }
 
 
-    fn gen_arbiter(&self, a: &ArbiterDecl) -> SimModel {
+    pub(crate) fn gen_arbiter(&self, a: &ArbiterDecl) -> SimModel {
         let name = &a.name.name;
         let class = format!("V{name}");
 

--- a/src/sim_codegen/pipeline.rs
+++ b/src/sim_codegen/pipeline.rs
@@ -10,7 +10,7 @@ use super::{SimCodegen, SimModel};
 use super::*;
 
 impl<'a> SimCodegen<'a> {
-    pub(super) fn gen_pipeline(&self, p: &PipelineDecl) -> SimModel {
+    pub(crate) fn gen_pipeline(&self, p: &PipelineDecl) -> SimModel {
         let name = &p.name.name;
         let class = format!("V{name}");
         let _enum_map = build_enum_map(self.symbols);

--- a/src/sim_codegen/ram.rs
+++ b/src/sim_codegen/ram.rs
@@ -9,7 +9,7 @@ use super::{SimCodegen, SimModel};
 use super::*;
 
 impl<'a> SimCodegen<'a> {
-    pub(super) fn gen_ram(&self, r: &RamDecl) -> SimModel {
+    pub(crate) fn gen_ram(&self, r: &RamDecl) -> SimModel {
         let name = &r.name.name;
         let class = format!("V{name}");
 


### PR DESCRIPTION
**Stacks on PRs #216, #217, #218, #219.** Merge those first; this PR rebases cleanly onto main once they land.

## Summary
Phase 5 of item #6 (approach a):
- Add `fn emit_sim(&self, simgen: &SimCodegen) -> Option<SimModel>` to the `Construct` trait, default `None`. Returns `Some` for the 11 sim-emitting constructs (counter, fsm, regfile, ram, cam, fifo, synchronizer, clkgate, linklist, arbiter, pipeline); `None` for everything else.
- Extend the `impl_construct_*` macros with a fourth optional arg, `emit_sim = method_name`. Order: `iface`, `check`, `emit_sv`, `emit_sim`.
- Bump every per-construct `pub(super) fn gen_*` in `src/sim_codegen/<X>.rs` to `pub(crate)`. Same for the in-`mod.rs` ones (`gen_module`, `gen_counter`, `gen_regfile`, `gen_synchronizer`, `gen_clkgate`, `gen_arbiter`).

## Module is special
`gen_module` takes the debug-module set as an extra arg (used to wire per-module debug instrumentation). Its branch stays explicit; everything else goes through trait dispatch:

```rust
for item in &self.source.items {
    if let Item::Module(m) = item {
        models.push(self.gen_module(m, ..., &debug_module_set));
    } else if let Some(model) = item.as_construct().emit_sim(self) {
        models.push(model);
    }
}
```

## Test plan
- [x] 221/221 integration tests pass
- [x] 24 lib unit tests pass
- [x] Zero snapshot drift across 34 SV-emission snapshots
- [x] `cargo build` clean
- Net diff: **+47/-40** across 8 files (visibility bumps + macro arg + dispatch site)

## Remaining phase
- `build_symbols()` → migrate `resolve.rs`