### PR TITLE
fix(elaborate): preserve declared width in width-typed param defaults

### DIFF
--- a/src/elaborate.rs
+++ b/src/elaborate.rs
@@ -345,8 +345,28 @@ fn elaborate_module_variant(
             } else if p.default.as_ref().map_or(false, |d| expr_references_params(d, &param_names)) {
                 // Preserve original expression for derived params
             } else {
+                // Width-typed params (`param NAME[hi:lo]: const = ...`) emit
+                // SV `parameter [hi:lo] NAME = <default>`. If we replaced
+                // the default with a bare `LitKind::Dec(val)`, the SV
+                // initializer would be unsized (32-bit by default) and
+                // Verilator's WIDTHTRUNC fires on the parameter init when
+                // the typed width is narrower. Emit a sized literal that
+                // matches the declared width so the init is width-clean.
+                let lit = if let ParamKind::WidthConst(hi, lo) = &p.kind {
+                    let hi_val = try_eval_i64(hi, &param_vals);
+                    let lo_val = try_eval_i64(lo, &param_vals);
+                    match (hi_val, lo_val) {
+                        (Some(h), Some(l)) if h >= l => {
+                            let width = (h - l + 1) as u32;
+                            LitKind::Sized(width, val as u64)
+                        }
+                        _ => LitKind::Dec(val as u64),
+                    }
+                } else {
+                    LitKind::Dec(val as u64)
+                };
                 p.default = Some(Expr::new(
-                    ExprKind::Literal(LitKind::Dec(val as u64)),
+                    ExprKind::Literal(lit),
                     p.name.span,
                 ));
             }


### PR DESCRIPTION
## Summary

Width-typed const params (\`param NAME[hi:lo]: const = ...\`) were emitting unsized SV initializers because the post-monomorphization pass in \`elaborate_module_variant\` replaced the AST default with a bare \`LitKind::Dec(val)\`. The emitter then rendered it as plain \`1\`, which Verilator flags WIDTHTRUNC against the typed declaration:

\`\`\`sv
parameter [0:0] ProvideValUpd = 1   // <- WIDTHTRUNC: 1 is 32-bit, [0:0] is 1-bit
\`\`\`

Fix: when the param is \`WidthConst(hi, lo)\` and both bounds const-evaluate, build a \`LitKind::Sized(width, val)\` so the emitter renders \`width'd<val>\`. Falls back to \`LitKind::Dec\` for parameter-derived bounds (where the width can't be folded at this stage). After the fix:

\`\`\`sv
parameter [0:0] ProvideValUpd = 1'd1 // width-clean
\`\`\`

## Real-consumer

\`arch-ibex/src/IbexCounter.arch\` declares \`param ProvideValUpd[0:0]: const = 1'b1\` and uses the param directly as a ternary condition. Without this fix the SV linted with WIDTHTRUNC on every counter instance, forcing a \`let upd_enable: Bool = ProvideValUpd != 0\` indirection. With the fix, the indirection is gone.

## Test plan
- [x] \`cargo test\` — 224/224 passing on \`fix/width-typed-param-default\`.
- [x] arch-ibex 14/14 gate (1 SoC lint + 4 ISR + 8 unit + 1 counter basic) green with \`IbexCounter.arch\` simplified to use the param directly as ternary condition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)