### PR TITLE
fix(codegen): emit concat-with-bit-select without wrapping parens

### DIFF
--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -3072,10 +3072,13 @@ impl<'a> Codegen<'a> {
                 // Parenthesize complex base expressions to avoid precedence issues.
                 // SynthIdent is a compiler-renamed bare identifier with the same
                 // semantics as Ident — no parens needed (Verilator rejects
-                // `(__name)[hi:lo]` as a syntax error).
+                // `(__name)[hi:lo]` as a syntax error). Concat is also accepted
+                // bare per SV-2009 §11.4.12 (concatenation with bit-select):
+                // Verilator rejects `({a, b})[hi:lo]` for the same reason.
                 let b = if matches!(base.kind, ExprKind::Ident(_) | ExprKind::SynthIdent(_, _)
                     | ExprKind::Literal(_)
-                    | ExprKind::Index(_, _) | ExprKind::FieldAccess(_, _)) { b }
+                    | ExprKind::Index(_, _) | ExprKind::FieldAccess(_, _)
+                    | ExprKind::Concat(_)) { b }
                     else { format!("({})", b) };
                 // Try to emit indexed part-select: base[lo +: width]
                 if let Some(width) = Self::try_indexed_part_select(hi, lo) {


### PR DESCRIPTION
## Summary

\`{a, b}[hi:lo]\` is valid SystemVerilog (SV-2009 §11.4.12, concatenation with bit-select). The BitSlice emitter was wrapping any non-whitelisted base in parens, producing \`({a, b})[hi:lo]\` — Verilator (and the SV LRM grammar generally) reject that form because bit-select doesn't compose with parenthesized expressions.

Adding \`ExprKind::Concat(_)\` to the existing no-parens whitelist (which already covers \`Ident\`, \`SynthIdent\`, \`Literal\`, \`Index\`, \`FieldAccess\`) makes the emission round-trip through Verilator.

Before:
\`\`\`sv
counter_q[CounterWidth - 1:0] <= ({counter_val_i, counter_q[31:0]})[CounterWidth - 1:0];
//                              ^                                  ^
// Verilator: syntax error, unexpected '['
\`\`\`

After:
\`\`\`sv
counter_q[CounterWidth - 1:0] <= {counter_val_i, counter_q[31:0]}[CounterWidth - 1:0];
\`\`\`

## Real-consumer

arch-ibex's \`IbexCounter.arch\` (A3 swap, the parameterizable up-counter) uses inline concat-then-slice to compute the half-word write next-state. Without this fix, the swap required a \`let next_h: UInt<64> = {a, b};\` indirection purely to dodge the emitter quirk.

## Test plan
- [x] \`cargo test\` — 224/224 passing on this branch.
- [x] arch-ibex 14/14 gate green with \`IbexCounter.arch\` using inline concat-slice form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)