### PR TITLE
fix(codegen): emit .resize<N>() without $signed/$unsigned wrapper

### DIFF
--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -2997,15 +2997,23 @@ impl<'a> Codegen<'a> {
                     "resize" => {
                         if let Some(width) = args.first() {
                             let w = self.emit_expr_str(width);
-                            // Direction-agnostic resize: pads or truncates, preserving signedness.
-                            // e.g. x.resize<16>() on UInt<8> → 16'($unsigned(x))
-                            // e.g. x.resize<4>()  on SInt<8> → 4'($signed(x))
+                            // Direction-agnostic resize: pads or truncates, preserving
+                            // signedness. SV's `N'(expr)` size cast inherits the
+                            // signedness of `expr` and — critically — forwards
+                            // context-determined evaluation through arithmetic
+                            // operators inside it. Earlier emission used
+                            // `N'($signed(expr))` / `N'($unsigned(expr))`, but
+                            // `$signed`/`$unsigned` evaluate their argument in
+                            // self-determined context (LRM §11.6.1, §20.5), which
+                            // truncates a multiply like `a * b` to operand width
+                            // BEFORE the outer cast widens — silently losing the
+                            // upper bits of any product. Dropping the wrapper lets
+                            // `N'(a * b)` widen both operands to N before the
+                            // multiply. For non-arithmetic `expr` (idents, slices),
+                            // the cast still preserves signedness from the
+                            // underlying declaration, so no behaviour changes.
                             let wp = Self::paren_width(&w);
-                            if self.expr_is_signed(base) {
-                                format!("{wp}'($signed({b}))")
-                            } else {
-                                format!("{wp}'($unsigned({b}))")
-                            }
+                            format!("{wp}'({b})")
                         } else {
                             b
                         }


### PR DESCRIPTION
## Summary

\`(a * b).resize<N>()\` was lowered to \`N'(\$signed(a * b))\`, but SV's \`\$signed(arg)\` evaluates \`arg\` in **self-determined context** (LRM §11.6.1, §20.5). For a multiplication that means the operands' max declared width — typically W bits — so the multiply truncates to W bits BEFORE the outer \`N'(...)\` cast widens to N. Silently loses the upper bits of any product.

### Real-consumer

arch-ibex's A6 multdiv swap has

\`\`\`arch
let mac_res_signed: SInt<35> =
  (mult_a_ext * mult_b_ext).resize<35>() +% accum_signed.resize<35>();
\`\`\`

with both operands SInt<17>. Without this fix the kernel multiply was self-determined to 17 bits, dropping the upper half of every partial product and producing \`(a*b) mod 2^17\` on \`multdiv_result_o\`. Three of twelve A6 unit tests failed with values exactly matching that signature; with this fix all 12 + the 28-scenario full regression pass.

### Fix

Drop the \`\$signed(...)\` / \`\$unsigned(...)\` wrapper. SV's \`N'(expr)\` size cast inherits signedness from \`expr\` and forwards context-determined evaluation through arithmetic operators inside it. For a non-arithmetic \`expr\` (idents, slices) the cast still preserves signedness from the underlying declaration — no behaviour changes.

Before:
\`\`\`sv
mac_res_signed = 35'(\$signed(mult_a_ext * mult_b_ext)) + ...;
\`\`\`

After:
\`\`\`sv
mac_res_signed = 35'(mult_a_ext * mult_b_ext) + ...;
\`\`\`

## Test plan
- [x] \`cargo test\` — 238/238 passing on this branch.
- [x] arch-ibex 20/20 gate green with the multdiv swap producing correct MUL/MULH/MULHSU/MULHU low-32 / high-32 products plus all DIV/REM variants and constant-time mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)