### PR TITLE
codegen: preserve width qualifier on package-scoped params

### DIFF
--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -484,6 +484,15 @@ impl<'a> Codegen<'a> {
         self.line(&format!("package {};", pkg.name.name));
         self.indent += 1;
 
+        // Typedefs must precede params: an `EnumConst` param references its
+        // enum type, which SV requires forward-declared.
+        for e in &pkg.enums {
+            self.emit_enum(e);
+        }
+        for s in &pkg.structs {
+            self.emit_struct(s);
+        }
+
         // Dispatch on ParamKind: width-qualified params must emit
         // `localparam [hi:lo]`, not `int` (truncates >32-bit values).
         for p in &pkg.params {
@@ -503,16 +512,6 @@ impl<'a> Codegen<'a> {
                     }
                 }
             }
-        }
-
-        // enums
-        for e in &pkg.enums {
-            self.emit_enum(e);
-        }
-
-        // structs
-        for s in &pkg.structs {
-            self.emit_struct(s);
         }
 
         // functions

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -484,11 +484,24 @@ impl<'a> Codegen<'a> {
         self.line(&format!("package {};", pkg.name.name));
         self.indent += 1;
 
-        // params → localparam
+        // Dispatch on ParamKind: width-qualified params must emit
+        // `localparam [hi:lo]`, not `int` (truncates >32-bit values).
         for p in &pkg.params {
             if let Some(d) = &p.default {
                 let val = self.emit_expr_str(d);
-                self.line(&format!("localparam int {} = {};", p.name.name, val));
+                match &p.kind {
+                    ParamKind::WidthConst(hi, lo) => {
+                        let hi_s = self.emit_expr_str(hi);
+                        let lo_s = self.emit_expr_str(lo);
+                        self.line(&format!("localparam [{}:{}] {} = {};", hi_s, lo_s, p.name.name, val));
+                    }
+                    ParamKind::EnumConst(enum_name) => {
+                        self.line(&format!("localparam {} {} = {};", enum_name, p.name.name, val));
+                    }
+                    _ => {
+                        self.line(&format!("localparam int {} = {};", p.name.name, val));
+                    }
+                }
             }
         }
 

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -507,7 +507,7 @@ impl<'a> Codegen<'a> {
                     ParamKind::EnumConst(enum_name) => {
                         self.line(&format!("localparam {} {} = {};", enum_name, p.name.name, val));
                     }
-                    _ => {
+                    ParamKind::Const | ParamKind::Type(_) | ParamKind::ConstVec(_) => {
                         self.line(&format!("localparam int {} = {};", p.name.name, val));
                     }
                 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -7998,3 +7998,36 @@ fn rdc_j4_mixed_reset_and_data_sync_same_source_fails() {
         .expect("read J4");
     assert_rdc_fails("J4", &src, &["RDC/CDC", "shared", "Dst"]);
 }
+
+#[test]
+fn package_width_qualified_param_emits_bracket_form() {
+    // Regression: package-scoped `param NAME[hi:lo]: const = …;` must emit
+    // `localparam [hi:lo] NAME = …;`, not `localparam int NAME = …;`.
+    // The latter silently truncates values wider than 32 bits (Verilator
+    // WIDTHTRUNC). Spec §29.1 + lines 1101–1105.
+    let source = "
+        package WidthPkg
+          param NARROW: const = 42;
+          param WIDE32[31:0]: const = 42;
+          param WIDE64[63:0]: const = 24314014034;
+        end package WidthPkg
+
+        use WidthPkg;
+
+        module M
+          port o: out UInt<32>;
+          comb
+            o = NARROW;
+          end comb
+        end module M
+    ";
+    let sv = compile_to_sv(source);
+    // Untyped const stays `localparam int`.
+    assert!(sv.contains("localparam int NARROW = 42;"),
+            "untyped const must keep `int`:\n{sv}");
+    // Width-qualified params must keep the [hi:lo] qualifier.
+    assert!(sv.contains("localparam [31:0] WIDE32 = 42;"),
+            "32-bit width qualifier dropped:\n{sv}");
+    assert!(sv.contains("localparam [63:0] WIDE64 = 24314014034;"),
+            "64-bit width qualifier dropped (would truncate):\n{sv}");
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -8031,3 +8031,37 @@ fn package_width_qualified_param_emits_bracket_form() {
     assert!(sv.contains("localparam [63:0] WIDE64 = 24314014034;"),
             "64-bit width qualifier dropped (would truncate):\n{sv}");
 }
+
+#[test]
+fn package_enum_typed_param_emits_typedef_before_localparam() {
+    // Regression: an EnumConst package param references its enum type,
+    // which SV requires forward-declared. The package's `typedef enum`
+    // must appear before the `localparam` that uses it.
+    let source = "
+        package OpPkg
+          enum Op
+            ADD,
+            SUB,
+          end enum Op
+          param DEFAULT_OP: Op = Op::ADD;
+        end package OpPkg
+
+        use OpPkg;
+
+        module M
+          port o: out Op;
+          comb
+            o = DEFAULT_OP;
+          end comb
+        end module M
+    ";
+    let sv = compile_to_sv(source);
+    let typedef_pos = sv.find("typedef enum")
+        .expect("typedef enum missing");
+    let param_pos = sv.find("DEFAULT_OP")
+        .expect("DEFAULT_OP localparam missing");
+    assert!(typedef_pos < param_pos,
+        "enum typedef must precede localparam that references it:\n{sv}");
+    assert!(sv.contains("localparam Op DEFAULT_OP = "),
+        "EnumConst must emit typed `localparam Op …`:\n{sv}");
+}


### PR DESCRIPTION
## Summary

`emit_package` in `src/codegen/mod.rs` unconditionally emits `localparam int NAME = …;` for package params, ignoring `ParamKind`. Width-qualified package params (`param NAME[hi:lo]: const = …;`) lose the `[hi:lo]` qualifier in the generated SV. Values wider than 32 bits silently truncate; Verilator flags WIDTHTRUNC.

## Repro

```arch
package ReproPkg
  param NARROW: const = 42;
  param WIDE_OK[31:0]: const = 42;
  param F_LARGE[63:0]: const = 24314014034;
  param F_NEGATIVE[63:0]: const = -1030320848;
end package ReproPkg
```

**Before:**

```sv
package ReproPkg;
  localparam int NARROW = 42;
  localparam int WIDE_OK = 42;                 // [31:0] dropped
  localparam int F_LARGE = 24314014034;         // 35 bits → silently truncated
  localparam int F_NEGATIVE = -1030320848;      // fits int32 by accident
endpackage
```

**After:**

```sv
package ReproPkg;
  localparam int NARROW = 42;
  localparam [31:0] WIDE_OK = 42;
  localparam [63:0] F_LARGE = 24314014034;
  localparam [63:0] F_NEGATIVE = -1030320848;
endpackage
```

## Fix

Dispatch on `ParamKind` inside `emit_package`, mirroring what `emit_param_decl` already does for module-scoped params. `WidthConst(hi, lo)` → `localparam [hi:lo] NAME = …;`. `EnumConst(name)` → `localparam <enum> NAME = …;`. Other kinds (untyped `Const`, `Type`, `ConstVec`) keep the existing emission unchanged. `ConstVec` at package scope was already broken before this PR and is out of scope here.

## Test plan

- [x] `cargo build --release` clean
- [x] `cargo test --release` — 255/255 passed, no regressions
- [x] Repro above produces correct SV output after the fix
- [x] Verilator no longer flags WIDTHTRUNC on a downstream consumer using the package's wide constants
