### PR TITLE
feat(typecheck): `pragma rdc_safe;` per-module RDC opt-out

### DIFF
--- a/doc/ARCH_HDL_Specification.md
+++ b/doc/ARCH_HDL_Specification.md
@@ -1308,7 +1308,7 @@ A reset's domain is **inferred from usage** — there is no explicit `Domain` an
 
 **RDC violations detected at compile time (shipped):**
 
-1. **Cross-clock-domain async reset (structural, phase 1).** An `Reset<Async, ...>` signal appears in the reset clause of registers in two different clock domains. An async reset signal is *bound to one clock domain* — the one its deassertion edge was synchronised to. Reusing it in a second domain re-creates the original RDC hazard there, regardless of whether the data paths in the two domains interact. The check is data-flow-insensitive because the rule applies even when each domain's flop subset is independent. The same rule applies when the upstream signal is itself a synchroniser output: a `synchronizer kind reset` for clock A is *not* valid as a reset source for clock B's flops — synchronisation is per-destination-domain. The fix is one synchroniser instance per receiving clock domain, each driving its own per-domain `Reset<Async>` port. Suppress with `pragma cdc_safe;`.
+1. **Cross-clock-domain async reset (structural, phase 1).** An `Reset<Async, ...>` signal appears in the reset clause of registers in two different clock domains. An async reset signal is *bound to one clock domain* — the one its deassertion edge was synchronised to. Reusing it in a second domain re-creates the original RDC hazard there, regardless of whether the data paths in the two domains interact. The check is data-flow-insensitive because the rule applies even when each domain's flop subset is independent. The same rule applies when the upstream signal is itself a synchroniser output: a `synchronizer kind reset` for clock A is *not* valid as a reset source for clock B's flops — synchronisation is per-destination-domain. The fix is one synchroniser instance per receiving clock domain, each driving its own per-domain `Reset<Async>` port. Suppress with `pragma cdc_safe;` or `pragma rdc_safe;` (either alone disables this structural rule).
 
 2. **Cross-async-reset-domain data path (data-flow, phase 2a).** Per-flop reach-set analysis. Sync and reset-none flops are *transparent* — they originate no domain, just propagate whatever async domains reach their data input. The textbook strict rule applies: a flop downstream of an async-reset flop must itself be async-reset by the **same** signal (or have a synchroniser in between). Sync and reset-none flops can't gate their data input on the source's async reset event, so they capture mid-deassert transients and propagate metastability downstream.
 
@@ -1329,7 +1329,7 @@ A reset's domain is **inferred from usage** — there is no explicit `Domain` an
    - **Async → reset-none** — async-reset flop driving any reset-less flop. Same hazard, no reset gate at all.
    - **Convergent reset-less / sync paths** — multiple async-reset flops feeding a non-async-reset flop. Even when the upstream domains agree (single source), the receiver still flags because it can't gate on the async event.
 
-   Tests live in `tests/rdc/` (also in `tests/integration_test.rs` `rdc_*` functions). The fix is to either reset the receiving flop async-by the same signal as the source, or insert a `synchronizer kind reset` between them. Phase 2a is intentionally **not** gated by `pragma cdc_safe;` — that pragma silences CDC and the phase-1 cross-clock structural RDC check, but the data-path hazard is structurally distinct (single-clock multi-reset trips it without any CDC concern). A future `pragma rdc_safe;` will be the dedicated opt-out.
+   Tests live in `tests/rdc/` (also in `tests/integration_test.rs` `rdc_*` functions). The fix is to either reset the receiving flop async-by the same signal as the source, or insert a `synchronizer kind reset` between them. Phase 2a is intentionally **not** gated by `pragma cdc_safe;` — that pragma silences CDC and the phase-1 cross-clock structural RDC check, but the data-path hazard is structurally distinct (single-clock multi-reset trips it without any CDC concern). The dedicated opt-out is `pragma rdc_safe;`, which suppresses every RDC phase (1 + 2a–2d).
 
 3. **Reset-driven clock gating (phase 2b).** Logic reaching a `clkgate` instance's `enable` input from an async-reset flop causes the gate to glitch on async reset events — `enable` toggles to its reset value mid-cycle, producing partial clock pulses on `clk_out`. The check walks every inst whose target construct is a `clkgate` and reuses phase 2a's reach map: if any async domain reaches the parent-side signal driving `enable`, the inst is flagged. The fix is to drive `enable` from a synchronously-clean source — typically a flop reset by a signal already synchronised to the gated clock's domain, or directly via a `synchronizer kind reset` upstream. Test scenarios live in `tests/rdc/rdc_g*.arch`.
 
@@ -1352,6 +1352,18 @@ With phase 2d landed, all five article-3 RDC bug classes catalogued in mainstrea
   | 2b  | Reset-driven clock gating                    | ✅ |
   | 2c  | Reconvergent synchronisers (RDC + CDC)       | ✅ |
   | 2d  | Combiner-derived reset glitches at inst      | ✅ |
+
+**Per-module opt-out pragmas:**
+
+```
+module M
+  pragma cdc_safe;     // suppress CDC checks + RDC phase 1
+  pragma rdc_safe;     // suppress every RDC phase (1 + 2a–2d)
+  ...
+end module M
+```
+
+`pragma cdc_safe;` is the long-standing CDC opt-out and incidentally suppresses the structural cross-clock RDC rule (phase 1) because the two checks overlap. `pragma rdc_safe;` is the dedicated RDC opt-out — it suppresses *every* RDC phase, including 2a–2d which `cdc_safe` does not touch. Either pragma alone is enough to silence phase 1; both can coexist on the same module. Use these only when the design has been externally analysed (Synopsys SpyGlass, Cadence Conformal) and the violations are provably safe in the surrounding integration. Unknown pragma names error at parse time, so a typo on `rdc_safe` is caught before compile.
 
 **5.5 Tristate and Bidirectional I/O** *(planned)*
 

--- a/doc/COMPILER_STATUS.md
+++ b/doc/COMPILER_STATUS.md
@@ -279,7 +279,7 @@
 
 | # | Feature | Description |
 |---|---------|-------------|
-| 1 | **`pragma rdc_safe;`** | Per-module opt-out parallel to `pragma cdc_safe;`. Tiny polish (~30 LOC); no real demand yet but tidy. |
+| ~~1~~ | ~~**`pragma rdc_safe;`**~~ | **DONE** — per-module opt-out shipped. `pragma rdc_safe;` suppresses every RDC phase (1 + 2a–2d); independent of `pragma cdc_safe;` (which still gates CDC + phase 1 RDC). Both can coexist; unknown pragmas are a parse error. Tests in `tests/rdc/rdc_l*.arch`. |
 | 2 | **Tristate / bidirectional I/O** | `Tristate<T>` type + `tristate` block for pad-level I/O; SV codegen emits `inout` with Z-driver; sim decomposes to `_out/_oe/_in` (2-state); type checker restricts to top-level modules; supports open-drain (wire-AND) resolution for I2C/GPIO |
 | 3 | **FIFO `latency 1` (registered output + FWFT)** | Registered `pop_data` with first-word fall-through prefetch; consumer interface identical to `latency 0` but `pop_data` comes from a flop, not memory mux — timing-clean for deep FIFOs; explicit designer choice, no auto-selection; see spec §8.2b |
 | 4 | **Package-scoped modules** | Allow hardware constructs (module, fsm, etc.) inside `package`; `inst a: PkgName::ModuleName` for namespace-qualified instantiation; SV codegen flattens to `PkgName_ModuleName`; resolves name collisions without tool-specific library mapping (SV limitation: modules are always global) |

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -200,6 +200,11 @@ pub struct ModuleDecl {
     pub implements: Option<Ident>,
     pub hooks: Vec<ModuleHookDecl>,
     pub cdc_safe: bool,
+    /// `pragma rdc_safe;` — suppress all RDC checks (phases 1 + 2a–2d)
+    /// for this module. Independent of `cdc_safe`; either pragma alone
+    /// disables phase 1's structural cross-clock async-reset rule
+    /// (which sits at the CDC/RDC boundary).
+    pub rdc_safe: bool,
     pub span: Span,
     /// Outer doc comment from `///` lines preceding the `module` keyword.
     /// See `doc/plan_arch_doc_comments.md`.

--- a/src/elaborate.rs
+++ b/src/elaborate.rs
@@ -374,7 +374,7 @@ fn elaborate_module_variant(
         p
     }).collect();
 
-    Ok(ModuleDecl { name: new_name, params: new_params, ports: all_ports, body: new_body, implements: m.implements, hooks: m.hooks, cdc_safe: m.cdc_safe, span: m.span, doc: m.doc, inner_doc: m.inner_doc })
+    Ok(ModuleDecl { name: new_name, params: new_params, ports: all_ports, body: new_body, implements: m.implements, hooks: m.hooks, cdc_safe: m.cdc_safe, rdc_safe: m.rdc_safe, span: m.span, doc: m.doc, inner_doc: m.inner_doc })
 }
 
 /// Rewrite an inst's `module_name` to the correct variant name.
@@ -2164,6 +2164,7 @@ fn lower_module_threads(m: ModuleDecl, opts: &ThreadLowerOpts) -> Result<(Module
         implements: None,
         hooks: Vec::new(),
         cdc_safe: false,
+        rdc_safe: false,
         span: sp,
         doc: None,
         inner_doc: None,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -715,20 +715,25 @@ impl Parser {
         let mut body = Vec::new();
         let mut hooks: Vec<crate::ast::ModuleHookDecl> = Vec::new();
         let mut cdc_safe = false;
+        let mut rdc_safe = false;
 
         while !self.check_end_keyword() {
             match self.peek_kind() {
-                // `pragma cdc_safe;` — suppress CDC checks for this module
+                // `pragma cdc_safe;` — suppress CDC checks for this module.
+                // `pragma rdc_safe;` — suppress all RDC checks (phases 1
+                //   + 2a–2d) for this module.
                 Some(TokenKind::Ident(ref s)) if s == "pragma" => {
                     self.advance();
                     let pragma_name = self.expect_ident()?;
-                    if pragma_name.name == "cdc_safe" {
-                        cdc_safe = true;
-                    } else {
-                        return Err(CompileError::general(
-                            &format!("unknown pragma `{}`", pragma_name.name),
-                            pragma_name.span,
-                        ));
+                    match pragma_name.name.as_str() {
+                        "cdc_safe" => cdc_safe = true,
+                        "rdc_safe" => rdc_safe = true,
+                        _ => {
+                            return Err(CompileError::general(
+                                &format!("unknown pragma `{}`", pragma_name.name),
+                                pragma_name.span,
+                            ));
+                        }
                     }
                     self.expect(TokenKind::Semi)?;
                     continue;
@@ -819,6 +824,7 @@ impl Parser {
             implements,
             hooks,
             cdc_safe,
+            rdc_safe,
             // `doc` is populated by `attach_outer_doc` from `parse_item`;
             // `inner_doc` was harvested above right after the name.
             doc: None,

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -839,7 +839,10 @@ impl<'a> TypeChecker<'a> {
             } else { None })
             .collect();
 
-        if clk_domain.len() >= 2 && !m.cdc_safe {
+        // Phase 1 RDC + the surrounding CDC pass share this gate.
+        // `pragma cdc_safe;` opts out of CDC + phase 1 (legacy);
+        // `pragma rdc_safe;` opts out of phase 1 too (unified RDC opt-out).
+        if clk_domain.len() >= 2 && !m.cdc_safe && !m.rdc_safe {
             // Build reg → domain map (which domain drives each register)
             let mut reg_domain: HashMap<String, String> = HashMap::new();
             for item in &m.body {
@@ -1017,9 +1020,14 @@ impl<'a> TypeChecker<'a> {
         // concern). A future `pragma rdc_safe;` annotation will be the
         // dedicated opt-out; for now, fix the design or refactor the
         // resets through synchronizers.
-        self.check_rdc_phase2a(m);
-        self.check_reconvergent_syncs(m);
-        self.check_rdc_combiner_at_inst(m);
+        // `pragma rdc_safe;` blanket-suppresses every data-flow / boundary
+        // RDC check (phases 2a–2d). The cross-clock structural rule
+        // (phase 1, gated above) honours this pragma too.
+        if !m.rdc_safe {
+            self.check_rdc_phase2a(m);
+            self.check_reconvergent_syncs(m);
+            self.check_rdc_combiner_at_inst(m);
+        }
 
         // Validate `implements` template conformance
         if let Some(ref tmpl_name) = m.implements {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -8030,3 +8030,66 @@ fn rdc_k4_sync_output_to_reset_ok() {
         .expect("read K4");
     assert_rdc_ok("K4", &src);
 }
+
+// ── Group L: Phase polish — `pragma rdc_safe;` per-module opt-out ─────────
+// Mirror of `pragma cdc_safe;` for the RDC-specific phases. Either pragma
+// alone suppresses phase 1 (the structural cross-clock rule). Phases 2a-2d
+// are gated only by `rdc_safe`.
+
+#[test]
+fn rdc_l1_pragma_rdc_safe_suppresses_phase2a() {
+    let src = std::fs::read_to_string("tests/rdc/rdc_l1_pragma_rdc_safe_suppresses_phase2a_ok.arch")
+        .expect("read L1");
+    assert_rdc_ok("L1", &src);
+}
+
+#[test]
+fn rdc_l2_pragma_rdc_safe_suppresses_phase2c() {
+    let src = std::fs::read_to_string("tests/rdc/rdc_l2_pragma_rdc_safe_suppresses_phase2c_ok.arch")
+        .expect("read L2");
+    assert_rdc_ok("L2", &src);
+}
+
+#[test]
+fn rdc_l3_pragma_rdc_safe_suppresses_phase2d() {
+    let src = std::fs::read_to_string("tests/rdc/rdc_l3_pragma_rdc_safe_suppresses_phase2d_ok.arch")
+        .expect("read L3");
+    assert_rdc_ok("L3", &src);
+}
+
+#[test]
+fn rdc_l4_pragma_rdc_safe_suppresses_phase1() {
+    let src = std::fs::read_to_string("tests/rdc/rdc_l4_pragma_rdc_safe_suppresses_phase1_ok.arch")
+        .expect("read L4");
+    assert_rdc_ok("L4", &src);
+}
+
+#[test]
+fn rdc_l5_unknown_pragma_rejected() {
+    // Defensive: a typo or unknown pragma name still errors at parse
+    // time, so users notice when they mistype `rdc_safe`.
+    let src = r#"
+domain D
+  freq_mhz: 100
+end domain D
+module M
+  pragma totally_unsafe;
+  port clk: in Clock<D>;
+  port rst: in Reset<Sync>;
+  port d:   in UInt<8>;
+  port q:   out UInt<8>;
+  reg r: UInt<8> reset rst => 0;
+  seq on clk rising
+    r <= d;
+  end seq
+  let q = r;
+end module M
+"#;
+    let tokens = lexer::tokenize(src).expect("lex");
+    let mut parser = Parser::new(tokens, src);
+    let result = parser.parse_source_file();
+    assert!(result.is_err(), "unknown pragma should be a parse error");
+    let msg = format!("{:?}", result.err().unwrap());
+    assert!(msg.contains("unknown pragma") && msg.contains("totally_unsafe"),
+        "expected unknown-pragma diagnostic, got: {msg}");
+}

--- a/tests/rdc/README.md
+++ b/tests/rdc/README.md
@@ -77,6 +77,10 @@ violation:
 | `rdc_k2_negation_at_inst_fail.arch` | sub's Reset input driven by `not rst_a` at inst boundary | fail | PASS (phase 2d) |
 | `rdc_k3_direct_reset_at_inst_ok.arch` | sub's Reset input driven directly by a parent Reset port | ok | PASS |
 | `rdc_k4_sync_output_to_reset_ok.arch` | sub's Reset input driven by a `synchronizer kind reset` output (direct ident) | ok | PASS |
+| `rdc_l1_pragma_rdc_safe_suppresses_phase2a_ok.arch` | `pragma rdc_safe;` opts the module out of phase 2a | ok | PASS |
+| `rdc_l2_pragma_rdc_safe_suppresses_phase2c_ok.arch` | `pragma rdc_safe;` opts the module out of phase 2c | ok | PASS |
+| `rdc_l3_pragma_rdc_safe_suppresses_phase2d_ok.arch` | `pragma rdc_safe;` opts the module out of phase 2d | ok | PASS |
+| `rdc_l4_pragma_rdc_safe_suppresses_phase1_ok.arch` | `pragma rdc_safe;` opts the module out of phase 1 | ok | PASS |
 
 ## Why D1 still flags (phase 1 backstop)
 

--- a/tests/rdc/rdc_l1_pragma_rdc_safe_suppresses_phase2a_ok.arch
+++ b/tests/rdc/rdc_l1_pragma_rdc_safe_suppresses_phase2a_ok.arch
@@ -1,0 +1,26 @@
+// L1: `pragma rdc_safe;` suppresses phase 2a (data-path RDC). Without
+// the pragma this would flag — async ra → sync rb is the canonical
+// strict-rule violation. The pragma documents that the design has
+// been externally analysed and the writer accepts the risk.
+
+domain D
+  freq_mhz: 100
+end domain D
+
+module M
+  pragma rdc_safe;
+  port clk:   in Clock<D>;
+  port rst_a: in Reset<Async>;
+  port rst_b: in Reset<Sync>;
+  port d:     in UInt<8>;
+  port q:     out UInt<8>;
+  reg ra: UInt<8> reset rst_a => 0;
+  reg rb: UInt<8> reset rst_b => 0;
+  seq on clk rising
+    ra <= d;
+  end seq
+  seq on clk rising
+    rb <= ra;
+  end seq
+  let q = rb;
+end module M

--- a/tests/rdc/rdc_l2_pragma_rdc_safe_suppresses_phase2c_ok.arch
+++ b/tests/rdc/rdc_l2_pragma_rdc_safe_suppresses_phase2c_ok.arch
@@ -1,0 +1,45 @@
+// L2: `pragma rdc_safe;` suppresses phase 2c (reconvergent reset
+// synchronisers). Without it H1's pattern would flag.
+
+domain Src
+  freq_mhz: 100
+end domain Src
+
+domain Dst
+  freq_mhz: 200
+end domain Dst
+
+synchronizer RstSync
+  kind reset;
+  param STAGES: const = 2;
+  port src_clk:  in Clock<Src>;
+  port dst_clk:  in Clock<Dst>;
+  port data_in:  in Bool;
+  port data_out: out Bool;
+end synchronizer RstSync
+
+module M
+  pragma rdc_safe;
+  port src_clk: in Clock<Src>;
+  port dst_clk: in Clock<Dst>;
+  port raw_rst: in Bool;
+  port out_a:   out Bool;
+  port out_b:   out Bool;
+
+  inst sync_a: RstSync
+    src_clk  <- src_clk;
+    dst_clk  <- dst_clk;
+    data_in  <- raw_rst;
+    data_out -> rst_a;
+  end inst sync_a
+
+  inst sync_b: RstSync
+    src_clk  <- src_clk;
+    dst_clk  <- dst_clk;
+    data_in  <- raw_rst;
+    data_out -> rst_b;
+  end inst sync_b
+
+  let out_a = rst_a;
+  let out_b = rst_b;
+end module M

--- a/tests/rdc/rdc_l3_pragma_rdc_safe_suppresses_phase2d_ok.arch
+++ b/tests/rdc/rdc_l3_pragma_rdc_safe_suppresses_phase2d_ok.arch
@@ -1,0 +1,34 @@
+// L3: `pragma rdc_safe;` suppresses phase 2d (combiner glitches at
+// inst boundary). Without it K1's `rst <- rst_a | rst_b` would flag.
+
+domain D
+  freq_mhz: 100
+end domain D
+
+module Sub
+  port clk: in Clock<D>;
+  port rst: in Reset<Async>;
+  port d:   in UInt<8>;
+  port q:   out UInt<8>;
+  reg r: UInt<8> reset rst => 0;
+  seq on clk rising
+    r <= d;
+  end seq
+  let q = r;
+end module Sub
+
+module Top
+  pragma rdc_safe;
+  port clk:   in Clock<D>;
+  port rst_a: in Reset<Async>;
+  port rst_b: in Reset<Async>;
+  port d:     in UInt<8>;
+  port q:     out UInt<8>;
+
+  inst sub: Sub
+    clk <- clk;
+    rst <- rst_a | rst_b;
+    d   <- d;
+    q   -> q;
+  end inst sub
+end module Top

--- a/tests/rdc/rdc_l4_pragma_rdc_safe_suppresses_phase1_ok.arch
+++ b/tests/rdc/rdc_l4_pragma_rdc_safe_suppresses_phase1_ok.arch
@@ -1,0 +1,30 @@
+// L4: `pragma rdc_safe;` also suppresses phase 1 (cross-clock async
+// reset). This is the same suppression `pragma cdc_safe;` provides
+// for the structural rule, available now via the dedicated pragma.
+
+domain DA
+  freq_mhz: 100
+end domain DA
+domain DB
+  freq_mhz: 200
+end domain DB
+module M
+  pragma rdc_safe;
+  port clk_a: in Clock<DA>;
+  port clk_b: in Clock<DB>;
+  port rst:   in Reset<Async>;
+  port da: in UInt<8>;
+  port db: in UInt<8>;
+  port qa: out UInt<8>;
+  port qb: out UInt<8>;
+  reg ra: UInt<8> reset rst => 0;
+  reg rb: UInt<8> reset rst => 0;
+  seq on clk_a rising
+    ra <= da;
+  end seq
+  seq on clk_b rising
+    rb <= db;
+  end seq
+  let qa = ra;
+  let qb = rb;
+end module M


### PR DESCRIPTION
## Summary

Polish PR. Adds a dedicated RDC opt-out pragma parallel to the existing \`pragma cdc_safe;\`. The two coexist:

| Pragma | Scope |
|---|---|
| \`pragma cdc_safe;\` | CDC checks + RDC phase 1 (legacy behaviour) |
| \`pragma rdc_safe;\` | Every RDC phase (1 + 2a + 2b + 2c + 2d) |

Phase 1's structural cross-clock async-reset rule sits at the CDC/RDC boundary; **either pragma alone disables it**. Phases 2a–2d are gated **only** by \`rdc_safe\` (the original \`cdc_safe\` semantic for those was "not gated" — \`rdc_safe\` is the dedicated knob).

## Wiring

- \`ast::ModuleDecl\`: new \`rdc_safe: bool\` field, mirrors \`cdc_safe\`.
- parser: \`pragma rdc_safe;\` parsed alongside \`pragma cdc_safe;\`. Unknown pragma names still error at parse time, so typos on either name are caught before compile.
- elaborate: the two \`ModuleDecl\`-construction sites updated to thread the new field through.
- typecheck::check_module: phase 1 gate widened to \`!m.cdc_safe && !m.rdc_safe\`; phases 2a/2c/2d are wrapped in \`if !m.rdc_safe { ... }\`.

## Test scenarios (group L)

| File | Pattern | Expected |
|---|---|---|
| \`rdc_l1_pragma_rdc_safe_suppresses_phase2a_ok.arch\` | A3-shape async→sync + \`pragma rdc_safe;\` | ok |
| \`rdc_l2_pragma_rdc_safe_suppresses_phase2c_ok.arch\` | H1-shape reconvergent reset syncs + pragma | ok |
| \`rdc_l3_pragma_rdc_safe_suppresses_phase2d_ok.arch\` | K1-shape combiner-at-inst + pragma | ok |
| \`rdc_l4_pragma_rdc_safe_suppresses_phase1_ok.arch\` | D1-shape shared async, two clocks + pragma | ok |
| \`rdc_l5_unknown_pragma_rejected\` (Rust-only) | \`pragma totally_unsafe;\` | parse error |

## Spec / docs

- Spec §5.4 gains a "Per-module opt-out pragmas" subsection that documents both pragmas and their scope, the typo-protection rationale, and the recommended usage (only after external SpyGlass / Conformal sign-off).
- Phase 1's description updated: "Suppress with \`pragma cdc_safe;\` or \`pragma rdc_safe;\` (either alone disables this structural rule)."
- Phase 2a's "future \`pragma rdc_safe;\` will be the dedicated opt-out" note flipped to present-tense.
- \`COMPILER_STATUS\` planned-features list strikes through and marks DONE.

## Test plan

- [x] \`cargo test --release rdc_\` — 40 passed (was 35 + 5 new), 0 failed
- [x] \`cargo test --release\` — 264 passed, 0 failed
- [x] \`tests/rdc/run_rdc.sh\` — 32 PASS, 0 FAIL
- [x] \`examples/run_sims.sh -j8\` — 30/30 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)