### PR TITLE
Bump compiler version to 0.60.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,7 +75,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arch"
-version = "0.50.1"
+version = "0.60.0"
 dependencies = [
  "clap",
  "insta",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arch"
-version = "0.50.1"
+version = "0.60.0"
 edition = "2021"
 description = "Compiler for the ARCH hardware description language"
 license = "LGPL-3.0-or-later"

--- a/doc/ARCH_HDL_Specification.md
+++ b/doc/ARCH_HDL_Specification.md
@@ -2,7 +2,7 @@
 
 Hardware Description Language
 
-Language Specification · v0.43.0+ · May 2026
+Language Specification · v0.60.0 · May 2026
 
 *A purpose-built micro-architecture HDL --- clean RTL semantics, strong types, and first-class pipelines, FSMs, FIFOs, and arbiters. Incorrect design patterns --- multiple drivers, undriven ports, clock-domain crossings, width mismatches --- are compile-time errors, never runtime surprises. Designed to be generated correctly by AI without prior training.*
 

--- a/doc/Arch_AI_Reference_Card.md
+++ b/doc/Arch_AI_Reference_Card.md
@@ -1,6 +1,6 @@
 # Arch HDL — AI Reference Card
 
-*Compact AI context for hardware generation · v0.43.0+ · Put this in context, add design intent, paste compiler errors to self-correct.*
+*Compact AI context for hardware generation · v0.60.0 · Put this in context, add design intent, paste compiler errors to self-correct.*
 
 ---
 

--- a/doc/COMPILER_STATUS.md
+++ b/doc/COMPILER_STATUS.md
@@ -1,9 +1,9 @@
 # ARCH Compiler — Status & Roadmap
 
 > Last updated: 2026-04-25
-> Compiler version: 0.43.0+
+> Compiler version: 0.60.0
 >
-> **Recent (post-0.43.0, unversioned):**
+> **0.60.0 release highlights:**
 > - **TLM thread cohorts** — `tlm_method` supports blocking calls plus tagged `out_of_order tags N`; direct worker threads, `generate_for` worker threads, and direct-call `fork ... and ... join` cohorts lower to request arbitration and response routing. `arch sim --thread-sim parallel` handles TLM-lowered modules by falling back to regular sim codegen for modules whose TLM threads were consumed.
 > - **`arch sim --coverage`** — full 6-phase coverage rollout: (1) branch coverage, (2) block-execution coverage for branchless seq/comb, (3) FSM state + transition coverage, (4) toggle coverage for scalar regs, (4b) Vec reg toggle, (5) Verilator-compatible `coverage.dat` alongside text report, (6) construct port toggle (sub-instance interface ports counted from the consumer side via `_prev_<inst>_<port>` shadow + popcount XOR).
 > - **`arch sim --thread-sim parallel --threads N`** — pre-lowering thread sim with multi-OS-thread parallel execution. Per-user-thread C++20 coroutine scheduler; cache-line-padded atomic spin-wait `Barrier`; deterministic for owned-output designs (10-run trace identity verified, TSan-clean). `--thread-sim both` runs fsm-lowered + native paths and diffs `--debug` traces for cross-check. Cycle batching API `dut.run_cycles(K)` cuts per-tick overhead — `named_thread` at N=2/batch hits 14.3 Mcyc/s (~2.2× the fsm path; ~15× Verilator at N=2 per-cycle).

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ use arch::sim_codegen::SimCodegen;
 use arch::typecheck::TypeChecker;
 
 #[derive(Parser)]
-#[command(name = "arch", about = "ARCH HDL compiler")]
+#[command(name = "arch", version, about = "ARCH HDL compiler")]
 struct Cli {
     #[command(subcommand)]
     command: Command,


### PR DESCRIPTION
## Summary
- bump the crate and lockfile from 0.50.1 to 0.60.0 after the TLM thread cohort merge
- update the compiler status, ARCH spec, and AI reference card version headers
- expose the Cargo package version through 

## Tests
- cargo check
- cargo run -- --version
- cargo test