### PR TITLE
Bump compiler version and fix RDC reset casts

### DIFF
--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -4042,8 +4042,13 @@ impl<'a> TypeChecker<'a> {
                 let Some(port) = port else { continue; };
                 if !matches!(&port.ty, TypeExpr::Reset(_, _)) { continue; }
                 if conn.direction != ConnectDir::Input { continue; }
-                // Direct ident → trust. Anything else → glitch source.
-                if matches!(&conn.signal.kind, ExprKind::Ident(_)) { continue; }
+                // Direct reset source → trust. A reset-type cast such as
+                // `rst as Reset<Async, Low>` is an instantiation-time reset
+                // annotation, not reset-combining logic; peel through it so
+                // legacy reset-override examples stay legal. Real logic under
+                // the cast, e.g. `(rst_a | rst_b) as Reset<Async>`, remains a
+                // combiner and is still rejected.
+                if Self::is_direct_reset_inst_signal(&conn.signal) { continue; }
                 self.errors.push(CompileError::general(
                     &format!(
                         "RDC violation: inst `{inst_name}` (instance of `{sub}`) has its \
@@ -4060,6 +4065,16 @@ impl<'a> TypeChecker<'a> {
                     conn.span,
                 ));
             }
+        }
+    }
+
+    fn is_direct_reset_inst_signal(expr: &Expr) -> bool {
+        match &expr.kind {
+            ExprKind::Ident(_) | ExprKind::SynthIdent(_, _) => true,
+            ExprKind::Cast(inner, ty) if matches!(ty.as_ref(), TypeExpr::Reset(_, _)) => {
+                Self::is_direct_reset_inst_signal(inner)
+            }
+            _ => false,
         }
     }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -7686,6 +7686,13 @@ end module M
 }
 
 #[test]
+fn rdc_reset_type_cast_at_inst_is_direct_reset_ok() {
+    // `rst <- rst_async_n as Reset<Async, Low>` is a reset type override at
+    // the inst boundary. It should not be classified as reset-combining logic.
+    assert_rdc_ok("reset-cast-inst", include_str!("../examples/param_reset.arch"));
+}
+
+#[test]
 fn rdc_a2_diff_async_direct_fails() {
     // ra (rst_a, async) → rb (rst_b, async); different async domains → FAIL.
     assert_rdc_fails("A2", r#"


### PR DESCRIPTION
## Summary
- bump compiler/docs version to 0.60.0 after the TLM thread-cohort merge
- treat reset casts at inst boundaries as direct reset sources for RDC phase 2d
- add a regression using examples/param_reset.arch so reset override casts keep building while real reset combiners remain rejected

## Tests
- cargo test
- cargo test rdc_
- cargo test rdc_reset_type_cast_at_inst_is_direct_reset_ok
- cargo run -- build -o /private/tmp/param_reset.gen.sv examples/param_reset.arch