### PR TITLE
Fix linklist .archi emitter and regen_and_diff script

### DIFF
--- a/examples/regen_and_diff.sh
+++ b/examples/regen_and_diff.sh
@@ -54,12 +54,14 @@ fi
 cp "$EX_DIR"/*.arch "$WORK"/ 2>/dev/null
 
 # Known pre-existing data issues (not caused by refactors):
-#   clk_div_counter         needs cross-file inst from clk_divider.arch
 #   dma_engine              examples/DmaRegs.archi duplicates inline regfile
-#   pkt_queue               examples/TaskQueue.archi uses removed `track_tail;` syntax
 #   synchronizer_handshake  uses `kind handshake;` but `handshake` is reserved
 # These show up as BUILD_FAIL; treat them as expected until the source is fixed.
-KNOWN_BAD=( clk_div_counter dma_engine pkt_queue synchronizer_handshake )
+KNOWN_BAD=( dma_engine synchronizer_handshake )
+
+# Cross-file instantiation dependencies: when building X, also pass Y.arch etc.
+declare -A BUILD_DEPS
+BUILD_DEPS[clk_div_counter]="clk_divider.arch"
 is_known_bad() {
   local b="$1"
   for k in "${KNOWN_BAD[@]}"; do [[ "$k" == "$b" ]] && return 0; done
@@ -81,7 +83,9 @@ for arch_src in "$EX_DIR"/*.arch; do
   gen_sv="$WORK/${base}.gen.sv"
 
   build_log="$WORK/${base}.log"
-  ( cd "$WORK" && "$ARCH_BIN" build -o "$gen_sv" "${base}.arch" ) >"$build_log" 2>&1
+  deps="${BUILD_DEPS[$base]:-}"
+  rm -f "$WORK"/*.archi
+  ( cd "$WORK" && "$ARCH_BIN" build -o "$gen_sv" "${base}.arch" $deps ) >"$build_log" 2>&1
   rc=$?
 
   if [[ $rc -ne 0 ]]; then

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -169,10 +169,10 @@ pub(crate) fn emit_linklist_interface(l: &LinklistDecl) -> String {
     let mut s = format!("linklist {name}\n");
     s.push_str(&format!("  kind {kind};\n"));
     if l.track_tail {
-        s.push_str("  track_tail;\n");
+        s.push_str("  track tail: true;\n");
     }
     if l.track_length {
-        s.push_str("  track_length;\n");
+        s.push_str("  track length: true;\n");
     }
     emit_params(&mut s, &l.params);
     emit_ports(&mut s, &l.ports);


### PR DESCRIPTION
## Summary
- Fix `.archi` emitter for linklist to write `track tail: true;` / `track length: true;` instead of old `track_tail;` / `track_length;` syntax that the parser rejects
- Clean `.archi` files between builds in `regen_and_diff.sh` so inline definitions from one build don't conflict with the next
- Add cross-file build dependency for `clk_div_counter` (needs `clk_divider.arch`)
- Remove `clk_div_counter` and `pkt_queue` from KNOWN_BAD; both now build successfully

## Test plan
- [x] `examples/regen_and_diff.sh` runs clean: KNOWN_FAIL 1→0, BUILD_FAIL=0
- [x] `pkt_queue.arch` builds and diffs against committed `.sv`
- [x] `clk_div_counter.arch` builds and diffs against committed `.sv`
- [x] `linklist_basic.arch` still builds correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)