### PR TITLE
Bump to 0.60.1 and fix async reset seq-body gating

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,7 +75,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arch"
-version = "0.60.0"
+version = "0.60.1"
 dependencies = [
  "clap",
  "insta",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arch"
-version = "0.60.0"
+version = "0.60.1"
 edition = "2021"
 description = "Compiler for the ARCH hardware description language"
 license = "LGPL-3.0-or-later"

--- a/src/sim_codegen/mod.rs
+++ b/src/sim_codegen/mod.rs
@@ -5033,8 +5033,16 @@ impl<'a> SimCodegen<'a> {
                     false
                 };
 
-                // Guard each seq block on its specific clock's rising edge
-                cpp.push_str(&format!("  if (_rising_{}) {{\n", rb.clock.name));
+                // Guard each seq block on its specific clock's rising edge.
+                // For async reset: use `else if` so the seq body is skipped
+                // when reset was active — the reset arm already cleared the
+                // regs; executing the seq body (e.g. toggle) would overwrite.
+                let rising_gate = if async_reset_emitted {
+                    format!("  else if (_rising_{}) {{\n", rb.clock.name)
+                } else {
+                    format!("  if (_rising_{}) {{\n", rb.clock.name)
+                };
+                cpp.push_str(&rising_gate);
                 let base_indent: usize = 2;
                 // --coverage phase 2: count seq-block entries (rising
                 // edges seen). One counter per top-level seq block;
@@ -5046,13 +5054,9 @@ impl<'a> SimCodegen<'a> {
                 }
 
                 if async_reset_emitted {
-                    // Already cleared regs above; just emit the seq body
-                    // unconditionally inside the rising-clk gate. If reset
-                    // was asserted, the seq body's RHS reads see the cleared
-                    // _q/_n_q values; the resulting writes are then themselves
-                    // overwritten on the NEXT eval() call where the async
-                    // reset arm fires again before the seq body re-runs.
-                    // Net effect under continuous async reset: regs stay 0.
+                    // Seq body: reset already cleared regs above; any
+                    // read-modify-write patterns (e.g. toggle) now see
+                    // the reset-cleared value.
                     let mut body = String::new();
                     emit_reg_stmts(&rb.stmts, &ctx, &mut body, base_indent);
                     cpp.push_str(&body);


### PR DESCRIPTION
## Summary
- Fix `sim_codegen`: use `else if` instead of `if` for the rising-clock gate when async reset was emitted, so the seq body is skipped when reset is active. Prevents read-modify-write patterns (toggle, counter) from recomputing `_n_reg` from the reset-cleared value and defeating the reset on the next eval.
- Bump version to 0.60.1

## Bug details
PR #241's async-reset fix moved the reset arm outside the rising-edge gate on eval_posedge, but the seq body still ran unconditionally inside `if (_rising_clock)`. When reset was active on a rising clock edge, the reset cleared `_reg=0` and `_n_reg=0`, but then the seq body recomputed `_n_reg` (e.g. `_n_reg = !_reg` = 1), defeating the reset.

```cpp
// Before (broken):                     // After (fixed):
if ((!rst_n)) {                         if ((!rst_n)) {
    _reg = 0; _n_reg = 0;                   _reg = 0; _n_reg = 0;
}                                       }
if (_rising_clk) {                      else if (_rising_clk) {
    _n_reg = !_reg;                         _n_reg = !_reg;
}                                       }
```

Only module-level `ClkDiv2` was affected in the examples suite (`clk_div_counter` test).

## Test plan
- [x] `examples/run_sims.sh`: 30/30 PASS
- [x] `cargo test`: 281/281 passed
- [x] `examples/regen_and_diff.sh`: 0 BUILD_FAIL, 0 KNOWN_FAIL

🤖 Generated with [Claude Code](https://claude.com/claude-code)