### PR TITLE
feat(linklist): multi-head support for insert_head / insert_after / delete

### DIFF
--- a/src/codegen/linklist.rs
+++ b/src/codegen/linklist.rs
@@ -366,16 +366,16 @@ impl<'a> Codegen<'a> {
 
         self.line(&format!("// ── {on} ─────────────────────────────────────────"));
 
-        // Phase-B scope: multi-head supports insert_tail + delete_head
-        // only. Other head-addressed ops need wiring the latched head_idx
-        // into their branching / pointer-patch paths; deferred to a
-        // follow-up phase.
-        if multi_head && matches!(on.as_str(), "insert_head" | "insert_after" | "delete") {
+        // Multi-head `insert_head` falls back to a $fatal only on the
+        // latency-1 fast path — that path doesn't carry a busy register,
+        // so per-head bookkeeping has nowhere to land. The latency≥2
+        // path below threads `_ctrl_<op>_head_idx` through normally.
+        if multi_head && on == "insert_head" && op.latency < 2 {
             self.line(&format!(
-                "// NOTE: op `{on}` is not yet supported for multi-head linklist (Phase B)."
+                "// NOTE: latency-1 `insert_head` is not supported for multi-head (NUM_HEADS > 1)."
             ));
             self.line(&format!(
-                "initial $fatal(1, \"linklist: op `{on}` not yet implemented for multi-head (NUM_HEADS > 1)\");"
+                "initial $fatal(1, \"linklist: latency-1 `{on}` not supported for multi-head\");"
             ));
             return;
         }
@@ -421,19 +421,30 @@ impl<'a> Codegen<'a> {
                     }
                     self.line("_fl_rdp <= _fl_rdp + 1'b1;");
                     self.line("_fl_cnt <= _fl_cnt - 1'b1;");
-                    self.line(&format!("_ctrl_{on}_was_empty <= (_fl_cnt == CNT_W'(DEPTH));"));
+                    // Empty check: single-head uses pool occupancy; multi-head
+                    // uses the per-head length counter so chains from other
+                    // heads don't mask this head's emptiness.
+                    if multi_head {
+                        self.line(&format!("_ctrl_{on}_was_empty <= (_length_r[{on}_req_head_idx] == '0);"));
+                        self.line(&format!("_ctrl_{on}_head_idx  <= {on}_req_head_idx;"));
+                    } else {
+                        self.line(&format!("_ctrl_{on}_was_empty <= (_fl_cnt == CNT_W'(DEPTH));"));
+                    }
                     self.line(&format!("_ctrl_{on}_busy <= 1'b1;"));
                     self.indent -= 1;
                     self.line(&format!("end else if (_ctrl_{on}_busy) begin"));
                     self.indent += 1;
-                    self.line(&format!("_next_mem[_ctrl_{on}_resp_handle] <= _head_r;"));
+                    self.line(&format!("_next_mem[_ctrl_{on}_resp_handle] <= {head_r_busy};"));
                     if is_doubly {
                         // old head.prev = new node; new node.prev = sentinel (0)
-                        self.line(&format!("_prev_mem[_head_r] <= _ctrl_{on}_resp_handle;"));
+                        self.line(&format!("_prev_mem[{head_r_busy}] <= _ctrl_{on}_resp_handle;"));
                     }
-                    self.line(&format!("_head_r <= _ctrl_{on}_resp_handle;"));
+                    self.line(&format!("{head_r_busy} <= _ctrl_{on}_resp_handle;"));
                     if track_tail {
-                        self.line(&format!("if (_ctrl_{on}_was_empty) _tail_r <= _ctrl_{on}_resp_handle;"));
+                        self.line(&format!("if (_ctrl_{on}_was_empty) {tail_r_busy} <= _ctrl_{on}_resp_handle;"));
+                    }
+                    if multi_head {
+                        self.line(&format!("_length_r[_ctrl_{on}_head_idx] <= _length_r[_ctrl_{on}_head_idx] + 1'b1;"));
                     }
                     if has_resp_valid { self.line(&format!("_ctrl_{on}_resp_v <= 1'b1;")); }
                     self.line(&format!("_ctrl_{on}_busy <= 1'b0;"));
@@ -592,6 +603,9 @@ impl<'a> Codegen<'a> {
                 self.line(&format!("_next_mem[{slot}] <= _next_mem[{on}_req_handle];"));
                 self.line("_fl_rdp <= _fl_rdp + 1'b1;");
                 self.line("_fl_cnt <= _fl_cnt - 1'b1;");
+                if multi_head {
+                    self.line(&format!("_ctrl_{on}_head_idx <= {on}_req_head_idx;"));
+                }
                 self.line(&format!("_ctrl_{on}_busy <= 1'b1;"));
                 self.indent -= 1;
                 self.line(&format!("end else if (_ctrl_{on}_busy) begin"));
@@ -603,6 +617,9 @@ impl<'a> Codegen<'a> {
                     self.line(&format!("_prev_mem[_ctrl_{on}_resp_handle] <= _ctrl_{on}_after_handle;"));
                     // successor.prev = new  (new.next is already committed from cycle 1)
                     self.line(&format!("_prev_mem[_next_mem[_ctrl_{on}_resp_handle]] <= _ctrl_{on}_resp_handle;"));
+                }
+                if multi_head {
+                    self.line(&format!("_length_r[_ctrl_{on}_head_idx] <= _length_r[_ctrl_{on}_head_idx] + 1'b1;"));
                 }
                 if has_resp_valid { self.line(&format!("_ctrl_{on}_resp_v <= 1'b1;")); }
                 self.line(&format!("_ctrl_{on}_busy <= 1'b0;"));
@@ -617,6 +634,9 @@ impl<'a> Codegen<'a> {
                 if has_req_handle {
                     self.line(&format!("_ctrl_{on}_slot <= {on}_req_handle;"));
                 }
+                if multi_head {
+                    self.line(&format!("_ctrl_{on}_head_idx <= {on}_req_head_idx;"));
+                }
                 self.line(&format!("_ctrl_{on}_busy <= 1'b1;"));
                 self.indent -= 1;
                 self.line(&format!("end else if (_ctrl_{on}_busy) begin"));
@@ -624,6 +644,9 @@ impl<'a> Codegen<'a> {
                 self.line(&format!("_fl_mem[_fl_wrp[HANDLE_W-1:0]] <= _ctrl_{on}_slot;"));
                 self.line("_fl_wrp <= _fl_wrp + 1'b1;");
                 self.line("_fl_cnt <= _fl_cnt + 1'b1;");
+                if multi_head {
+                    self.line(&format!("_length_r[_ctrl_{on}_head_idx] <= _length_r[_ctrl_{on}_head_idx] - 1'b1;"));
+                }
                 if has_resp_valid { self.line(&format!("_ctrl_{on}_resp_v <= 1'b1;")); }
                 self.line(&format!("_ctrl_{on}_busy <= 1'b0;"));
                 self.indent -= 1;

--- a/src/sim_codegen/linklist.rs
+++ b/src/sim_codegen/linklist.rs
@@ -270,16 +270,6 @@ impl<'a> SimCodegen<'a> {
         for op in &l.ops {
             let on = &op.name.name;
             cpp.push_str(&format!("    // ── {on}\n"));
-            // Phase-B / Phase-C scope: multi-head supports insert_tail +
-            // delete_head only. Other head-addressed ops need the same
-            // per-head plumbing wired through their pointer-patch paths;
-            // stage for a follow-up.
-            if multi_head && matches!(on.as_str(), "insert_head" | "insert_after" | "delete") {
-                cpp.push_str(&format!(
-                    "    if ({on}_req_valid) {{ fprintf(stderr, \"ARCH-SIM: linklist op `{on}` is not yet implemented for multi-head (NUM_HEADS > 1)\\n\"); abort(); }}\n"
-                ));
-                continue;
-            }
             match on.as_str() {
                 "alloc" => cpp.push_str(&format!(
                     "    if ({on}_req_valid && _fl_cnt != 0) {{\n\
@@ -321,41 +311,62 @@ impl<'a> SimCodegen<'a> {
                          \n      {inc_len}_ctrl_{on}_resp_v = 1; _ctrl_{on}_busy = 0;\n    }}\n"
                     ));
                 }
-                "insert_head" => cpp.push_str(&format!(
-                    "    if (!_ctrl_{on}_busy && {on}_req_valid && _fl_cnt != 0) {{\n\
-                     \n      uint8_t _slot = _fl_mem[_fl_rdp & {handle_mask:#x}];\n\
-                     \n      _ctrl_{on}_resp_handle = _slot; _data_mem[_slot] = {on}_req_data;\n\
-                     \n      _ctrl_{on}_was_empty = (_fl_cnt == {depth});\n\
-                     \n      _fl_rdp = (uint8_t)((_fl_rdp + 1) & {cnt_mask:#x}); _fl_cnt--; _ctrl_{on}_busy = 1;\n\
-                     \n    }} else if (_ctrl_{on}_busy) {{\n\
-                     \n      _next_mem[_ctrl_{on}_resp_handle] = _head_r;\n\
-                     \n      {doubly_insert_head}\
-                     \n      _head_r = _ctrl_{on}_resp_handle;\n\
-                     \n      if (_ctrl_{on}_was_empty) _tail_r = _ctrl_{on}_resp_handle;\n\
-                     \n      _ctrl_{on}_resp_v = 1; _ctrl_{on}_busy = 0;\n    }}\n",
-                    doubly_insert_head = if has_doubly {
-                        format!("_prev_mem[_head_r] = _ctrl_{on}_resp_handle;\n      ")
-                    } else { String::new() }
-                )),
-                "insert_after" => cpp.push_str(&format!(
-                    "    if (!_ctrl_{on}_busy && {on}_req_valid && _fl_cnt != 0) {{\n\
-                     \n      uint8_t _slot = _fl_mem[_fl_rdp & {handle_mask:#x}];\n\
-                     \n      _ctrl_{on}_resp_handle = _slot; _data_mem[_slot] = {on}_req_data;\n\
-                     \n      _ctrl_{on}_after_handle = {on}_req_handle;\n\
-                     \n      _next_mem[_slot] = _next_mem[{on}_req_handle];\n\
-                     \n      _fl_rdp = (uint8_t)((_fl_rdp + 1) & {cnt_mask:#x}); _fl_cnt--; _ctrl_{on}_busy = 1;\n\
-                     \n    }} else if (_ctrl_{on}_busy) {{\n\
-                     \n      uint8_t _after = _ctrl_{on}_after_handle;\n\
-                     \n      _next_mem[_after] = _ctrl_{on}_resp_handle;\n\
-                     \n      {doubly_insert_after}\
-                     \n      _ctrl_{on}_resp_v = 1; _ctrl_{on}_busy = 0;\n    }}\n",
-                    doubly_insert_after = if has_doubly {
+                "insert_head" => {
+                    let head_busy = head_r_at(&format!("_ctrl_{on}_head_idx"));
+                    let tail_busy = tail_r_at(&format!("_ctrl_{on}_head_idx"));
+                    let empty_accept = if multi_head {
+                        format!("(_length_r[{on}_req_head_idx] == 0)")
+                    } else { format!("(_fl_cnt == {depth})") };
+                    let latch_idx = if multi_head {
+                        format!(" _ctrl_{on}_head_idx = {on}_req_head_idx;")
+                    } else { String::new() };
+                    let inc_len = if multi_head {
+                        format!("_length_r[_ctrl_{on}_head_idx]++; ")
+                    } else { String::new() };
+                    let doubly_insert_head = if has_doubly {
+                        format!("_prev_mem[{head_busy}] = _ctrl_{on}_resp_handle;\n      ")
+                    } else { String::new() };
+                    cpp.push_str(&format!(
+                        "    if (!_ctrl_{on}_busy && {on}_req_valid && _fl_cnt != 0) {{\n\
+                         \n      uint8_t _slot = _fl_mem[_fl_rdp & {handle_mask:#x}];\n\
+                         \n      _ctrl_{on}_resp_handle = _slot; _data_mem[_slot] = {on}_req_data;\n\
+                         \n      _ctrl_{on}_was_empty = {empty_accept};{latch_idx}\n\
+                         \n      _fl_rdp = (uint8_t)((_fl_rdp + 1) & {cnt_mask:#x}); _fl_cnt--; _ctrl_{on}_busy = 1;\n\
+                         \n    }} else if (_ctrl_{on}_busy) {{\n\
+                         \n      _next_mem[_ctrl_{on}_resp_handle] = {head_busy};\n\
+                         \n      {doubly_insert_head}\
+                         \n      {head_busy} = _ctrl_{on}_resp_handle;\n\
+                         \n      if (_ctrl_{on}_was_empty) {tail_busy} = _ctrl_{on}_resp_handle;\n\
+                         \n      {inc_len}_ctrl_{on}_resp_v = 1; _ctrl_{on}_busy = 0;\n    }}\n"
+                    ));
+                }
+                "insert_after" => {
+                    let latch_idx = if multi_head {
+                        format!(" _ctrl_{on}_head_idx = {on}_req_head_idx;")
+                    } else { String::new() };
+                    let inc_len = if multi_head {
+                        format!("_length_r[_ctrl_{on}_head_idx]++; ")
+                    } else { String::new() };
+                    let doubly_insert_after = if has_doubly {
                         format!(
                             "_prev_mem[_ctrl_{on}_resp_handle] = _after;\n\
                              \n      _prev_mem[_next_mem[_ctrl_{on}_resp_handle]] = _ctrl_{on}_resp_handle;\n      "
                         )
-                    } else { String::new() }
-                )),
+                    } else { String::new() };
+                    cpp.push_str(&format!(
+                        "    if (!_ctrl_{on}_busy && {on}_req_valid && _fl_cnt != 0) {{\n\
+                         \n      uint8_t _slot = _fl_mem[_fl_rdp & {handle_mask:#x}];\n\
+                         \n      _ctrl_{on}_resp_handle = _slot; _data_mem[_slot] = {on}_req_data;\n\
+                         \n      _ctrl_{on}_after_handle = {on}_req_handle;{latch_idx}\n\
+                         \n      _next_mem[_slot] = _next_mem[{on}_req_handle];\n\
+                         \n      _fl_rdp = (uint8_t)((_fl_rdp + 1) & {cnt_mask:#x}); _fl_cnt--; _ctrl_{on}_busy = 1;\n\
+                         \n    }} else if (_ctrl_{on}_busy) {{\n\
+                         \n      uint8_t _after = _ctrl_{on}_after_handle;\n\
+                         \n      _next_mem[_after] = _ctrl_{on}_resp_handle;\n\
+                         \n      {doubly_insert_after}\
+                         \n      {inc_len}_ctrl_{on}_resp_v = 1; _ctrl_{on}_busy = 0;\n    }}\n"
+                    ));
+                }
                 "delete_head" => {
                     let head_acc = head_r_at(&format!("{on}_req_head_idx"));
                     let head_busy = head_r_at(&format!("_ctrl_{on}_head_idx"));
@@ -382,6 +393,22 @@ impl<'a> SimCodegen<'a> {
                          \n      _fl_mem[_fl_wrp & {handle_mask:#x}] = _ctrl_{on}_slot;\n\
                          \n      _fl_wrp = (uint8_t)((_fl_wrp + 1) & {cnt_mask:#x}); _fl_cnt++;\n\
                          \n      {head_busy} = _next_mem[_ctrl_{on}_slot];\n\
+                         \n      {dec_len}_ctrl_{on}_resp_v = 1; _ctrl_{on}_busy = 0;\n    }}\n"
+                    ));
+                }
+                "delete" => {
+                    let latch_idx = if multi_head {
+                        format!(" _ctrl_{on}_head_idx = {on}_req_head_idx;")
+                    } else { String::new() };
+                    let dec_len = if multi_head {
+                        format!("_length_r[_ctrl_{on}_head_idx]--; ")
+                    } else { String::new() };
+                    cpp.push_str(&format!(
+                        "    if (!_ctrl_{on}_busy && {on}_req_valid) {{\n\
+                         \n      _ctrl_{on}_slot = {on}_req_handle;{latch_idx} _ctrl_{on}_busy = 1;\n\
+                         \n    }} else if (_ctrl_{on}_busy) {{\n\
+                         \n      _fl_mem[_fl_wrp & {handle_mask:#x}] = _ctrl_{on}_slot;\n\
+                         \n      _fl_wrp = (uint8_t)((_fl_wrp + 1) & {cnt_mask:#x}); _fl_cnt++;\n\
                          \n      {dec_len}_ctrl_{on}_resp_v = 1; _ctrl_{on}_busy = 0;\n    }}\n"
                     ));
                 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1845,6 +1845,142 @@ end linklist MhQ
 }
 
 #[test]
+fn test_linklist_multi_head_full_ops_sv_shape() {
+    // Multi-head SV codegen for the remaining head-addressed ops:
+    // insert_head, insert_after, delete. Each must latch req_head_idx
+    // at accept, route head/tail reads/writes through the latched idx
+    // at the busy cycle, and bump _length_r[idx] ±1.
+    let source = r#"
+linklist MhFull
+  param DEPTH: const = 16;
+  param NUM_HEADS: const = 2;
+  param DATA: type = UInt<8>;
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  kind doubly;
+  track tail: true;
+  op insert_head
+    latency: 2;
+    port req_valid:    in Bool;
+    port req_ready:    out Bool;
+    port req_head_idx: in UInt<1>;
+    port req_data:     in UInt<8>;
+    port resp_valid:   out Bool;
+    port resp_handle:  out UInt<4>;
+  end op insert_head
+  op insert_after
+    latency: 2;
+    port req_valid:    in Bool;
+    port req_ready:    out Bool;
+    port req_head_idx: in UInt<1>;
+    port req_handle:   in UInt<4>;
+    port req_data:     in UInt<8>;
+    port resp_valid:   out Bool;
+    port resp_handle:  out UInt<4>;
+  end op insert_after
+  op delete
+    latency: 2;
+    port req_valid:    in Bool;
+    port req_ready:    out Bool;
+    port req_head_idx: in UInt<1>;
+    port req_handle:   in UInt<4>;
+    port resp_valid:   out Bool;
+  end op delete
+end linklist MhFull
+"#;
+    let sv = compile_to_sv(source);
+    // No $fatal stub anywhere — all three ops are now wired.
+    assert!(!sv.contains("not yet implemented for multi-head"),
+            "stub message should be gone:\n{sv}");
+    // insert_head: head_idx latch + busy-cycle uses latched idx + length++
+    assert!(sv.contains("_ctrl_insert_head_head_idx  <= insert_head_req_head_idx"),
+            "missing insert_head idx latch:\n{sv}");
+    assert!(sv.contains("_head_r[_ctrl_insert_head_head_idx] <= _ctrl_insert_head_resp_handle"),
+            "missing insert_head busy-cycle head update");
+    assert!(sv.contains("_length_r[_ctrl_insert_head_head_idx] <= _length_r[_ctrl_insert_head_head_idx] + 1'b1"),
+            "missing insert_head length increment");
+    assert!(sv.contains("_ctrl_insert_head_was_empty <= (_length_r[insert_head_req_head_idx] == '0)"),
+            "missing per-head was_empty check on insert_head");
+    // insert_after: head_idx latch + length++ (pointer patches stay shared)
+    assert!(sv.contains("_ctrl_insert_after_head_idx <= insert_after_req_head_idx"),
+            "missing insert_after idx latch");
+    assert!(sv.contains("_length_r[_ctrl_insert_after_head_idx] <= _length_r[_ctrl_insert_after_head_idx] + 1'b1"),
+            "missing insert_after length increment");
+    // delete: head_idx latch + length-- + per-head ready gate
+    assert!(sv.contains("_ctrl_delete_head_idx <= delete_req_head_idx"),
+            "missing delete idx latch");
+    assert!(sv.contains("_length_r[_ctrl_delete_head_idx] <= _length_r[_ctrl_delete_head_idx] - 1'b1"),
+            "missing delete length decrement");
+    assert!(sv.contains("_length_r[delete_req_head_idx] != '0"),
+            "missing per-head delete ready gate");
+}
+
+#[test]
+fn test_linklist_multi_head_full_ops_sim_shape() {
+    // Sim-codegen mirror of the same three new multi-head ops.
+    let source = r#"
+linklist MhFull
+  param DEPTH: const = 8;
+  param NUM_HEADS: const = 2;
+  param DATA: type = UInt<8>;
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  kind doubly;
+  track tail: true;
+  op insert_head
+    latency: 2;
+    port req_valid:    in Bool;
+    port req_ready:    out Bool;
+    port req_head_idx: in UInt<1>;
+    port req_data:     in UInt<8>;
+    port resp_valid:   out Bool;
+    port resp_handle:  out UInt<3>;
+  end op insert_head
+  op insert_after
+    latency: 2;
+    port req_valid:    in Bool;
+    port req_ready:    out Bool;
+    port req_head_idx: in UInt<1>;
+    port req_handle:   in UInt<3>;
+    port req_data:     in UInt<8>;
+    port resp_valid:   out Bool;
+    port resp_handle:  out UInt<3>;
+  end op insert_after
+  op delete
+    latency: 2;
+    port req_valid:    in Bool;
+    port req_ready:    out Bool;
+    port req_head_idx: in UInt<1>;
+    port req_handle:   in UInt<3>;
+    port resp_valid:   out Bool;
+  end op delete
+end linklist MhFull
+"#;
+    let sim = compile_to_sim_h(source, false);
+    assert!(!sim.contains("is not yet implemented for multi-head"),
+            "stub message should be gone:\n{sim}");
+    // insert_head: head_idx latch + length++ + per-head head update
+    assert!(sim.contains("_ctrl_insert_head_head_idx = insert_head_req_head_idx"),
+            "missing insert_head idx latch:\n{sim}");
+    assert!(sim.contains("_head_r[_ctrl_insert_head_head_idx] = _ctrl_insert_head_resp_handle"),
+            "missing insert_head busy head update");
+    assert!(sim.contains("_length_r[_ctrl_insert_head_head_idx]++"),
+            "missing insert_head length increment");
+    // insert_after: idx latch + length++
+    assert!(sim.contains("_ctrl_insert_after_head_idx = insert_after_req_head_idx"),
+            "missing insert_after idx latch");
+    assert!(sim.contains("_length_r[_ctrl_insert_after_head_idx]++"),
+            "missing insert_after length increment");
+    // delete: idx latch + length-- + per-head ready gate
+    assert!(sim.contains("_ctrl_delete_head_idx = delete_req_head_idx"),
+            "missing delete idx latch");
+    assert!(sim.contains("_length_r[_ctrl_delete_head_idx]--"),
+            "missing delete length decrement");
+    assert!(sim.contains("_length_r[delete_req_head_idx] != 0"),
+            "missing per-head delete ready gate");
+}
+
+#[test]
 fn test_linklist_multi_head_rejects_missing_head_idx() {
     // NUM_HEADS > 1 but per-head op omits req_head_idx → typecheck error
     let source = r#"


### PR DESCRIPTION
## Summary

Lifts the `\$fatal` (SV) and `abort()` (sim) stubs on the three remaining head-addressed ops so a multi-head linklist (`NUM_HEADS > 1`) supports the full set: `insert_head`, `insert_tail`, `insert_after`, `delete_head`, `delete`.

Each newly-lifted op follows the pattern already proven on `insert_tail` / `delete_head`:
- latch `req_head_idx` into `_ctrl_<op>_head_idx` at accept
- index `_head_r` / `_tail_r` by the latched idx at the busy cycle
- bump `_length_r[idx]` ±1

`insert_head` empty-detection switches to per-head `_length_r[idx] == 0` (matching insert_tail). The latency-1 `insert_head` fast path stays single-head only — it has no busy register to carry per-head state and multi-head + latency-1 now emits a clear `\$fatal`.

Sim-codegen `delete` was previously a no-op even for single-head (only the ready/valid wiring existed). This branch adds the missing eval arm to match the SV codegen.

Closes the multi-head codegen gap noted in the project memory.

## Constraints preserved (existing single-head behavior)

- `delete` does not patch prev/next pointers — caller is responsible for pointer hygiene before invoking. The `req_ready` handshake gates on `_length_r[idx] != 0` so users can't decrement past zero.
- `insert_after` does not update tail when after_handle == tail — caller must use `insert_tail` for end-of-list inserts.

## Test plan

- [x] `cargo test --release` — 285 integration tests pass (was 283 before; +2 for new anchors)
- [x] All 8 prior `test_linklist_*` tests still green, including snapshot tests `test_linklist_basic_compiles` and `test_linklist_doubly_compiles` — single-head SV is byte-identical
- [x] New anchors: `test_linklist_multi_head_full_ops_sv_shape` and `test_linklist_multi_head_full_ops_sim_shape`

## Follow-ups (not in this PR)

- Phase D: port `tests/cvdp/cache_mshr.arch` to multi-head for real-workload validation.
- Phase E: spec §7-ish (linklist) and reference card — document the multi-head op set.