### PR TITLE
fix(deps): skip body-only passes for `.archi` interface stubs

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -214,6 +214,12 @@ pub struct ModuleDecl {
     /// Inner doc comment from `//!` lines after `module Name` and before
     /// any other body item.
     pub inner_doc: Option<String>,
+    /// True when this declaration was loaded from a `.archi` interface
+    /// stub (port-only, no body). Set post-parse from the source-file
+    /// extension. Body-only passes (output-driven check, codegen,
+    /// .archi re-emit) skip these to avoid spurious diagnostics and
+    /// duplicate output.
+    pub is_interface: bool,
 }
 
 #[derive(Debug, Clone)]

--- a/src/codegen/module.rs
+++ b/src/codegen/module.rs
@@ -8,6 +8,15 @@ use super::*;
 
 impl<'a> Codegen<'a> {
     pub(crate) fn emit_module(&mut self, m: &ModuleDecl) {
+        // Interface stubs loaded from `.archi` files have no body and
+        // exist only to expose the port signature to typecheck. The real
+        // SV for these modules lives in a separately-built `.sv` file
+        // alongside the `.archi` — emitting an empty stub here would
+        // produce a duplicate module declaration that clashes with the
+        // real SV at Verilator link time.
+        if m.is_interface {
+            return;
+        }
         self.current_construct = m.name.name.clone();
         // Emit SV `import NAME::*;` only for `use NAME;` whose target is an
         // actual `package` — package contents become an SV package and need

--- a/src/elaborate.rs
+++ b/src/elaborate.rs
@@ -374,7 +374,7 @@ fn elaborate_module_variant(
         p
     }).collect();
 
-    Ok(ModuleDecl { name: new_name, params: new_params, ports: all_ports, body: new_body, implements: m.implements, hooks: m.hooks, cdc_safe: m.cdc_safe, rdc_safe: m.rdc_safe, span: m.span, doc: m.doc, inner_doc: m.inner_doc })
+    Ok(ModuleDecl { name: new_name, params: new_params, ports: all_ports, body: new_body, implements: m.implements, hooks: m.hooks, cdc_safe: m.cdc_safe, rdc_safe: m.rdc_safe, span: m.span, doc: m.doc, inner_doc: m.inner_doc, is_interface: m.is_interface })
 }
 
 /// Rewrite an inst's `module_name` to the correct variant name.
@@ -2168,6 +2168,7 @@ fn lower_module_threads(m: ModuleDecl, opts: &ThreadLowerOpts) -> Result<(Module
         span: sp,
         doc: None,
         inner_doc: None,
+        is_interface: false,
     };
 
     // ── Create InstDecl in parent module ───────────────────────────────

--- a/src/main.rs
+++ b/src/main.rs
@@ -504,6 +504,11 @@ fn main() -> miette::Result<()> {
 
             // Emit .archi interface files alongside .sv (for separate compilation)
             for item in &ast.items {
+                // Don't re-emit .archi for an interface stub we just loaded
+                // — we'd be overwriting the source file we read.
+                if let Item::Module(m) = item {
+                    if m.is_interface { continue; }
+                }
                 if let Some(content) = arch::interface::emit_interface(item) {
                     let name = &item.as_construct().name().name;
                     // Write .archi next to the .sv output
@@ -1428,9 +1433,24 @@ fn run_check_multi_opts(
 
     // Parse
     let mut p = parser::Parser::new(tokens, source);
-    let parsed_ast = p.parse_source_file().map_err(|err| {
+    let mut parsed_ast = p.parse_source_file().map_err(|err| {
         ms.report_error(err)
     })?;
+
+    // Tag items loaded from `.archi` interface stubs (port-only, no body).
+    // Body-only downstream passes — typecheck's output-driven check, SV
+    // codegen, and `.archi` re-emission — skip these to avoid spurious
+    // diagnostics and duplicate output. Only `ModuleDecl` carries the flag
+    // for now; extend to other constructs (Fsm, Fifo, …) when they too
+    // start being instantiated across `.archi` boundaries.
+    for item in parsed_ast.items.iter_mut() {
+        if let Item::Module(m) = item {
+            let (filename, _, _) = ms.locate(m.span.start);
+            if filename.ends_with(".archi") {
+                m.is_interface = true;
+            }
+        }
+    }
 
     // Surface any deprecated-`implies`-keyword usages as a single stderr
     // warning (one line per site). The symbolic `|->` form is the

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -842,6 +842,8 @@ impl Parser {
             // `inner_doc` was harvested above right after the name.
             doc: None,
             inner_doc,
+            // Default false; set post-parse for items loaded from `.archi`.
+            is_interface: false,
         })
     }
 

--- a/src/sim_codegen/mod.rs
+++ b/src/sim_codegen/mod.rs
@@ -279,6 +279,9 @@ impl<'a> SimCodegen<'a> {
             // returns `Some(model)` for the 11 sim-emitting variants
             // and `None` for the rest.
             if let Item::Module(m) = item {
+                // Interface stubs from `.archi`: real sim model lives
+                // alongside the .archi as a separately-built artifact.
+                if m.is_interface { continue; }
                 models.push(self.gen_module(
                     m,
                     debug_module_set.contains(m.name.name.as_str()),
@@ -299,6 +302,9 @@ impl<'a> SimCodegen<'a> {
         for item in &self.source.items {
             match item {
                 Item::Module(m) => {
+                    // Skip interface stubs from `.archi`: the pybind wrapper
+                    // for the real implementation is built separately.
+                    if m.is_interface { continue; }
                     if let Some(w) = self.emit_pybind_module(m) {
                         wrappers.push(w);
                     }

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -326,6 +326,15 @@ impl<'a> TypeChecker<'a> {
     pub(crate) fn check_module(&mut self, m: &ModuleDecl) {
         self.check_pascal_case(&m.name);
 
+        // Interface stub loaded from a `.archi` file — body is empty by
+        // construction. Skip body-driven checks (output-driven, CDC/RDC,
+        // body item validation) entirely; the stub exists only to provide
+        // the port signature for parent-side instantiation checking, which
+        // happens in `check_inst_decl` when validating the inst connections.
+        if m.is_interface {
+            return;
+        }
+
         // Track driven signals
         let mut driven: HashSet<String> = HashSet::new();
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -8745,3 +8745,67 @@ end module M
     assert!(msg.contains("unknown pragma") && msg.contains("totally_unsafe"),
         "expected unknown-pragma diagnostic, got: {msg}");
 }
+
+#[test]
+fn test_archi_interface_stub_skips_body_only_passes() {
+    // Mimics the multi-file dep-loader case: a parent module instantiates
+    // a child whose source came from a `.archi` interface stub (port-only,
+    // no body). Pre-fix, typecheck reported "output port `out_o` is not
+    // driven" because `check_module` ran the body-driven check on the
+    // empty stub. Codegen would also emit a duplicate empty `module
+    // ChildStub` clashing with the real SV at link time. With the
+    // `is_interface` flag set (post-parse, normally done in main.rs from
+    // the source-file extension), both passes skip the stub.
+    let source = r#"
+domain Sys
+  freq_mhz: 100
+end domain Sys
+
+module ChildStub
+  port clk_i: in Clock<Sys>;
+  port rst_ni: in Reset<Async, Low>;
+  port in_i: in UInt<8>;
+  port out_o: out UInt<8>;
+end module ChildStub
+
+module Parent
+  port clk_i: in Clock<Sys>;
+  port rst_ni: in Reset<Async, Low>;
+  port result: out UInt<8>;
+
+  wire w: UInt<8>;
+  inst c: ChildStub
+    clk_i <- clk_i;
+    rst_ni <- rst_ni;
+    in_i <- 8'd0;
+    out_o -> w;
+  end inst c
+
+  let result = w;
+end module Parent
+"#;
+    let tokens = lexer::tokenize(source).expect("lex");
+    let mut parser = Parser::new(tokens, source);
+    let mut parsed_ast = parser.parse_source_file().expect("parse");
+    for item in parsed_ast.items.iter_mut() {
+        if let arch::ast::Item::Module(m) = item {
+            if m.name.name == "ChildStub" { m.is_interface = true; }
+        }
+    }
+    let ast = elaborate::elaborate(parsed_ast).expect("elaborate");
+    let ast = elaborate::lower_tlm_target_threads(ast).expect("tlm_target lowering");
+    let ast = elaborate::lower_tlm_initiator_calls(ast).expect("tlm_initiator lowering");
+    let ast = elaborate::lower_threads_with_opts(ast, &elaborate::ThreadLowerOpts::default())
+        .expect("lower_threads");
+    let ast = elaborate::lower_pipe_reg_ports(ast).expect("lower_pipe_reg_ports");
+    let ast = elaborate::lower_credit_channel_dispatch(ast).expect("credit_channel dispatch");
+    let symbols = resolve::resolve(&ast).expect("resolve");
+    let checker = TypeChecker::new(&symbols, &ast);
+    let (_warnings, overload_map) = checker.check()
+        .expect("typecheck must not report 'output port out_o is not driven' on interface stub");
+    let codegen = Codegen::new(&symbols, &ast, overload_map);
+    let sv = codegen.generate();
+    assert!(sv.contains("module Parent"), "parent module should be emitted");
+    assert!(!sv.contains("module ChildStub"),
+        "interface stub must not be emitted to SV (real impl lives in a separately-built file)");
+}


### PR DESCRIPTION
## Summary

- Tag items loaded from `.archi` interface stubs (port-only, no body) with a new `ModuleDecl.is_interface` flag, set post-parse from the source-file extension via the `MultiSource` segment table.
- Short-circuit body-only passes (`typecheck::check_module`, SV `codegen::emit_module`, `sim_codegen` model + pybind generation, the `arch build` `.archi` re-emit loop) when the flag is set.
- Cross-module connection checking is unaffected — the parent's `check_inst_decl` consults the stub's port signature via the symbol table, which is populated regardless of the flag.

## Bug

When a parent `.arch` instantiates a module whose source is a `.archi` interface stub, the dep loader pulls the stub into the AST as a regular `ModuleDecl`. Pre-fix, two passes mistreated it:

1. **typecheck** ran the "all output ports driven" check on the stub and failed — the body is empty, so nothing in the stub drives its outputs. The user-visible diagnostic was a spurious `output port \`<name>\` is not driven` at the stub's port site, even though the parent's inst-decl wired the output into a parent wire correctly.
2. **codegen** would emit an empty `module <name>` clashing with the real SV (built separately and linked into the same Verilator job). `sim_codegen` would do the same for the `arch sim` path.
3. The `.archi` re-emit loop in `arch build` overwrote the stub file with itself (benign but unnecessary).

The bug didn't surface earlier because no prior swap in arch-ibex (Phase A swaps A1–A7) instantiated a previously-ported swap via `.archi`. As soon as A8 (`port-prefetch_buffer`) added `inst fifo_i: ibex_fetch_fifo`, every `arch build` of the parent failed at typecheck.

## Minimal repro (pre-fix)

```sh
mkdir t && cd t
cat > child.archi <<EOF2
module child
  port clk: in Clock<Sys>;
  port rst: in Reset<Async, Low>;
  port out_o: out UInt<8>;
end module child
EOF2
cat > parent.arch <<EOF2
domain Sys freq_mhz: 100 end domain Sys
module parent
  port clk: in Clock<Sys>;
  port rst: in Reset<Async, Low>;
  port result: out UInt<8>;
  wire w: UInt<8>;
  inst c: child
    clk <- clk;
    rst <- rst;
    out_o -> w;
  end inst c
  let result = w;
end module parent
EOF2
arch build parent.arch
# pre-fix:  Error: × output port `out_o` is not driven (at child.archi)
# post-fix: Wrote parent.sv / parent.archi
```

## Test plan

- [x] `cargo test --release` — 330 tests pass (was 329 + 1 new regression test `test_archi_interface_stub_skips_body_only_passes`).
- [x] Minimal-repro pair compiles and produces SV containing only the parent (no duplicate empty stub).
- [x] Pre-existing repro where a `.arch` sits next to a `.archi` (the dep loader prefers `.arch`) still works — no regression on the masked-by-luck path.
- [x] End-to-end: `arch build src/IbexPrefetchBuffer.arch` in arch-ibex's A8 worktree now compiles past this point. (Surfaces an unrelated RDC diagnostic on a `reset none` register — A8 design issue, separate from this fix.)

## Scope / follow-up

Other archi-emittable constructs (`fsm`, `fifo`, `ram`, `cam`, `linklist`, `regfile`, `arbiter`, `counter`, `pipeline`, `synchronizer`) don't yet carry the `is_interface` flag. The Phase A arch-ibex swaps only instantiate `module`s, so this is sufficient to unblock A8/A9 + the rest of Phase A. Extension to other constructs is a follow-up the first time a `.archi` stub of a non-`module` construct gets instantiated across files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)