### PR TITLE
Add AXI DMA TLM read-pair example

### DIFF
--- a/src/elaborate.rs
+++ b/src/elaborate.rs
@@ -5657,7 +5657,11 @@ fn inline_lower_tlm_fork_join_all(
     let mut grants: Vec<Expr> = Vec::new();
     for (i, issue) in issues.iter().enumerate() {
         let pending = bin(BinOp::Eq, id(state_name(i)), sized(2, 0));
-        let aged = bin(BinOp::Gte, id(age_name.clone()), sized(age_w, issue.delay));
+        let aged = if issue.delay == 0 {
+            bool_lit(true)
+        } else {
+            bin(BinOp::Gte, id(age_name.clone()), sized(age_w, issue.delay))
+        };
         let want_i = bin(BinOp::And, bin(BinOp::And, pending, aged), occ_not_full.clone());
         let mut grant_i = want_i.clone();
         for prev in &wants {

--- a/tests/axi_dma_tlm/TlmMm2sReadPair.arch
+++ b/tests/axi_dma_tlm/TlmMm2sReadPair.arch
@@ -1,0 +1,47 @@
+//! ---
+//! spec_md: doc/axi_dma_case_study.md
+//! tags: [dma, axi4, mm2s, tlm_method, rhs_fork, multi_outstanding]
+//! refs:
+//!   - "tests/axi_dma_thread/ThreadMm2s.arch"
+//! ---
+//!
+//! AXI-DMA-flavored TLM smoke example.
+//!
+//! This is intentionally smaller than the full thread MM2S engine. Current
+//! TLM supports scalar method returns, direct thread-body call sites, and
+//! RHS-fork issue groups; it does not model AXI bursts as a first-class TLM
+//! mode. This example therefore tests the implemented lowering shape that
+//! maps cleanly to MM2S: two outstanding memory read transactions issued
+//! one cycle apart, with responses routed by compiler-managed tags.
+
+bus DmaMemRead
+  tlm_method read(addr: UInt<32>) -> UInt<32>: out_of_order tags 2;
+end bus DmaMemRead
+
+use DmaMemRead;
+
+module TlmMm2sReadPair
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+
+  port base_addr: in UInt<32>;
+  port mem: initiator DmaMemRead;
+
+  port data0: out UInt<32>;
+  port data1: out UInt<32>;
+
+  reg d0_r: UInt<32> reset rst => 0;
+  reg d1_r: UInt<32> reset rst => 0;
+
+  comb
+    data0 = d0_r;
+    data1 = d1_r;
+  end comb
+
+  thread issue_pair on clk rising, rst high
+    d0_r <= fork mem.read(base_addr);
+    wait 1 cycle;
+    d1_r <= fork mem.read((base_addr + 32'd4).trunc<32>());
+    join all;
+  end thread issue_pair
+end module TlmMm2sReadPair

--- a/tests/axi_dma_tlm/tb_tlm_mm2s_read_pair.cpp
+++ b/tests/axi_dma_tlm/tb_tlm_mm2s_read_pair.cpp
@@ -1,0 +1,95 @@
+#include "VTlmMm2sReadPair.h"
+
+#include <cstdint>
+#include <cstdio>
+
+static VTlmMm2sReadPair dut;
+static int cycle_count = 0;
+
+static void eval_comb() {
+    dut.eval();
+}
+
+static void tick() {
+    dut.clk = 0;
+    dut.eval();
+    dut.clk = 1;
+    dut.eval();
+    cycle_count++;
+}
+
+static void reset() {
+    dut.rst = 1;
+    dut.base_addr = 0x1000;
+    dut.mem_read_req_ready = 0;
+    dut.mem_read_rsp_valid = 0;
+    dut.mem_read_rsp_data = 0;
+    dut.mem_read_rsp_tag = 0;
+    for (int i = 0; i < 4; ++i) {
+        tick();
+    }
+    dut.rst = 0;
+    tick();
+}
+
+int main() {
+    reset();
+
+    uint32_t req_addr[2] = {0, 0};
+    uint32_t req_tag[2] = {0, 0};
+    int req_count = 0;
+    bool sent_tag1 = false;
+    bool sent_tag0 = false;
+
+    for (int c = 0; c < 40; ++c) {
+        dut.mem_read_req_ready = 1;
+
+        // Return responses out of order to prove tag routing, not FIFO order.
+        if (req_count >= 2 && !sent_tag1) {
+            dut.mem_read_rsp_valid = 1;
+            dut.mem_read_rsp_tag = req_tag[1];
+            dut.mem_read_rsp_data = 0xD1000000u | req_addr[1];
+        } else if (req_count >= 2 && !sent_tag0) {
+            dut.mem_read_rsp_valid = 1;
+            dut.mem_read_rsp_tag = req_tag[0];
+            dut.mem_read_rsp_data = 0xD0000000u | req_addr[0];
+        } else {
+            dut.mem_read_rsp_valid = 0;
+            dut.mem_read_rsp_data = 0;
+            dut.mem_read_rsp_tag = 0;
+        }
+
+        eval_comb();
+
+        if (dut.mem_read_req_valid && dut.mem_read_req_ready && req_count < 2) {
+            req_addr[req_count] = dut.mem_read_addr;
+            req_tag[req_count] = dut.mem_read_req_tag;
+            std::printf("[cycle %2d] req%d addr=0x%08x tag=%u\n",
+                        cycle_count, req_count, req_addr[req_count], req_tag[req_count]);
+            req_count++;
+        }
+
+        if (dut.mem_read_rsp_valid && dut.mem_read_rsp_ready) {
+            std::printf("[cycle %2d] rsp tag=%u data=0x%08x\n",
+                        cycle_count, dut.mem_read_rsp_tag, dut.mem_read_rsp_data);
+            if (!sent_tag1 && dut.mem_read_rsp_tag == req_tag[1]) {
+                sent_tag1 = true;
+            } else if (!sent_tag0 && dut.mem_read_rsp_tag == req_tag[0]) {
+                sent_tag0 = true;
+            }
+        }
+
+        tick();
+
+        if (sent_tag0 && sent_tag1 && dut.data0 == (0xD0000000u | req_addr[0])
+            && dut.data1 == (0xD1000000u | req_addr[1])) {
+            std::printf("PASS: TlmMm2sReadPair req0=0x%08x req1=0x%08x data0=0x%08x data1=0x%08x\n",
+                        req_addr[0], req_addr[1], dut.data0, dut.data1);
+            return 0;
+        }
+    }
+
+    std::printf("FAIL: req_count=%d sent_tag0=%d sent_tag1=%d data0=0x%08x data1=0x%08x\n",
+                req_count, sent_tag0, sent_tag1, dut.data0, dut.data1);
+    return 1;
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -5697,6 +5697,16 @@ fn test_tlm_rhs_fork_out_of_order_routes_by_tag() {
 }
 
 #[test]
+fn test_axi_dma_tlm_read_pair_example_compiles() {
+    let source = include_str!("axi_dma_tlm/TlmMm2sReadPair.arch");
+    let sv = compile_to_sv(source);
+    assert!(sv.contains("module TlmMm2sReadPair"));
+    assert!(sv.contains("mem_read_req_tag"));
+    assert!(sv.contains("mem_read_rsp_tag"));
+    assert!(sv.contains("_tlm_fork_issue_pair_mem_read"));
+}
+
+#[test]
 fn test_tlm_out_of_order_target_echoes_tag() {
     let source = "
         bus Mem


### PR DESCRIPTION
## Summary
- add a small AXI-DMA-flavored MM2S TLM example using RHS-fork reads one cycle apart
- add a C++ arch-sim TB that returns responses out of order to verify tag routing
- compile-cover the example in integration tests
- elide zero-delay RHS-fork age comparisons so generated SV is clean under Verilator lint

## Tests
- cargo test
- cargo test test_tlm_rhs_fork -- --nocapture
- cargo test test_axi_dma_tlm_read_pair_example_compiles -- --nocapture
- cargo run -- sim tests/axi_dma_tlm/TlmMm2sReadPair.arch --tb tests/axi_dma_tlm/tb_tlm_mm2s_read_pair.cpp --outdir /private/tmp/tlm_mm2s_read_pair_build2
- cargo run -- sim tests/axi_dma_tlm/TlmMm2sReadPair.arch --tb tests/axi_dma_tlm/tb_tlm_mm2s_read_pair.cpp --outdir /private/tmp/tlm_mm2s_read_pair_parallel_build2 --thread-sim parallel
- cargo run -- build tests/axi_dma_tlm/TlmMm2sReadPair.arch -o /private/tmp/TlmMm2sReadPair.sv
- iverilog -g2012 -gsupported-assertions -t null /private/tmp/TlmMm2sReadPair.sv
- verilator --lint-only --sv /private/tmp/TlmMm2sReadPair.sv
- git diff --check