### PR TITLE
fix(elaborate): Vec output zero-default uses per-lane assignment (#264)

### DIFF
--- a/src/elaborate.rs
+++ b/src/elaborate.rs
@@ -2091,30 +2091,29 @@ fn lower_module_threads(m: ModuleDecl, opts: &ThreadLowerOpts) -> Result<(Module
     let mut merged_comb: Vec<Stmt> = Vec::new();
     // Defaults: all comb outputs = 0
     //
-    // Unpacked-array ports (`unpacked Vec<T,N>`) need `'{default: 0}` rather
-    // than a bare `0` literal — SV rejects scalar-to-unpacked-array assignment.
-    // For each unpacked port, emit per-element zeros instead so the literal-0
-    // path (which lowers to a sized scalar) doesn't collide with the unpacked
-    // shape. The element count and width are derived from the port type.
+    // Vec<T,N> ports need per-element zeros, not a bare `0` literal:
+    //   - unpacked SV emission rejects scalar-to-unpacked-array assignment.
+    //   - packed SV accepts `0` but the sim_codegen C++ path lowers the port
+    //     to `uint64_t[N]`, which is not assignable as a whole array
+    //     (`_foo = 0;` → "array type 'uint64_t[N]' is not assignable").
+    // Per-lane assignment (`foo[i] = 0;`) is valid for both shapes on both
+    // backends, so we apply it to any Vec output regardless of the
+    // `unpacked` modifier.
     for p in &merged_ports {
         if p.direction == Direction::Out && p.default.is_some() {
-            if p.unpacked {
-                // Pull out the Vec element count from `Vec<T, N>`. Drive
-                // each lane individually with a zero of the element type.
-                if let TypeExpr::Vec(_, size_expr) = &p.ty {
-                    if let Some(n) = try_eval_i64(size_expr, &HashMap::new()) {
-                        for i in 0..(n as u64) {
-                            merged_comb.push(Stmt::Assign(CombAssign {
-                                target: Expr::new(ExprKind::Index(
-                                    Box::new(Expr::new(ExprKind::Ident(p.name.name.clone()), sp)),
-                                    Box::new(Expr::new(ExprKind::Literal(LitKind::Dec(i)), sp)),
-                                ), sp),
-                                value: make_zero_expr(sp),
-                                span: sp,
-                            }));
-                        }
-                        continue;
+            if let TypeExpr::Vec(_, size_expr) = &p.ty {
+                if let Some(n) = try_eval_i64(size_expr, &HashMap::new()) {
+                    for i in 0..(n as u64) {
+                        merged_comb.push(Stmt::Assign(CombAssign {
+                            target: Expr::new(ExprKind::Index(
+                                Box::new(Expr::new(ExprKind::Ident(p.name.name.clone()), sp)),
+                                Box::new(Expr::new(ExprKind::Literal(LitKind::Dec(i)), sp)),
+                            ), sp),
+                            value: make_zero_expr(sp),
+                            span: sp,
+                        }));
                     }
+                    continue;
                 }
                 // Fall through (unknown shape) — let the codegen lint catch it.
             }


### PR DESCRIPTION
## Summary

Closes #264. The synthesized `_<Name>_threads` merged module zeros every comb-driven output port at the top of `eval_comb()` via a default-value comb statement. The existing code special-cased `unpacked Vec<T,N>` to emit per-lane zeros and fell through to a bare `port = 0;` for everything else — which is broken for **packed** `Vec<T,N>` outputs because `sim_codegen` lowers a packed Vec port to a private `uint64_t[N]` field, and clang rejects whole-array assignment.

The fix extends the existing per-lane expansion to any `Vec<T,N>` output regardless of the `unpacked` modifier. Per-lane is valid SV for both shapes and the only thing the C++ codegen accepts.

## Reproducer

Any module with `port foo: out Vec<UInt<N>, M>;` driven from a `thread`:

```cpp
// V_<name>_threads.cpp (before)
void V_<name>_threads::eval_comb() {
  ...
  _foo = 0;  // ← error: array type 'uint64_t[M]' is not assignable
  ...
}
```

After fix:

```cpp
void V_<name>_threads::eval_comb() {
  ...
  _foo[0] = 0;
  _foo[1] = 0;
  ...
}
```

## Validation

- arch-com cargo tests: 341/341 pass.
- arch-ibex `IbexMultdivFast` archsim (packed `imd_val_d_o: out Vec<UInt<34>, 2>`): all 12 cases pass (was carried as `xfail(strict=True)` for #264).
- arch-ibex full gate: `36 passed in 139s` (was `35 passed + 1 xfailed`).

## Test plan

- [x] arch-com unit tests pass.
- [x] arch-ibex per-module + SoC gate passes.
- [ ] CI green.

## Notes

No focused arch-com unit test added: a minimal repro requires a thread that drives a packed Vec output unconditionally, which trips typecheck's per-lane-coverage rule before the `merged_comb` path is reached. The arch-ibex `IbexMultdivFast` archsim suite is a faithful regression test and runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)