### PR TITLE
feat(parser,codegen): allow `unpacked` modifier on wire declarations (#267)

### DIFF
--- a/doc/ARCH_HDL_Specification.md
+++ b/doc/ARCH_HDL_Specification.md
@@ -621,9 +621,17 @@ Effect:
 Restrictions:
 - Only legal on `Vec<T, N>` types (non-Vec usage rejected at parse time).
 - Incompatible with `port reg ... unpacked` and `pipe_reg<T, N>` ports (no use case; rejected at parse time).
-- Use is intended for **leaf-module port boundaries that face external SV**. ARCH-to-ARCH instantiation across an unpacked port is not validated by the compiler in v1; if both parent and child are ARCH-emitted, the parent's wire will be packed-Vec and Verilator will reject the connection. Restructure to keep both sides packed when the entire path is ARCH.
+- Use is intended for **leaf-module port boundaries that face external SV**, or for ARCH-to-ARCH connections where both sides are unpacked. For ARCH-to-ARCH instantiation across an `unpacked` port, the parent's connecting wire must also carry the `unpacked` modifier (see below) — otherwise the parent emits a packed wire, the child emits an unpacked port, and Verilator rejects the shape mismatch.
 
-Why this is opt-in: unpacked arrays are Yosys-unfriendly during synthesis and historically caused Icarus portability issues. The default packed shape preserves these guarantees; `unpacked` is a deliberate interop hatch for ports that face external SV.
+The same modifier is permitted on internal `wire` declarations to support that ARCH-to-ARCH-unpacked case:
+
+```arch
+wire bridge: unpacked Vec<UInt<32>, 2>;
+```
+
+Effect mirrors the port form: SV emission flips to unpacked-array shape (`logic [W-1:0] bridge [N-1:0]`); ARCH-internal semantics (lane indexing, lane-by-lane assignment) are unchanged. The same restrictions apply (only legal on `Vec<T, N>`).
+
+Why this is opt-in: unpacked arrays are Yosys-unfriendly during synthesis and historically caused Icarus portability issues. The default packed shape preserves these guarantees; `unpacked` is a deliberate interop hatch for ports and wires that face external SV or that need to mate with an unpacked port across an `inst` connection.
 
 **4. Modules**
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -698,6 +698,12 @@ pub struct LetBinding {
 pub struct WireDecl {
     pub name: Ident,
     pub ty: TypeExpr,
+    /// `wire name: unpacked Vec<T,N>;` flips SV emission to unpacked-array
+    /// shape (`logic [W-1:0] name [N-1:0]`) so the wire can mate with an
+    /// `unpacked Vec<T,N>` port across an `inst` connection without
+    /// Verilator rejecting the packed/unpacked shape mismatch. Mirrors the
+    /// `unpacked` modifier on port declarations (§3.7).
+    pub unpacked: bool,
     pub span: Span,
 }
 

--- a/src/codegen/module.rs
+++ b/src/codegen/module.rs
@@ -471,8 +471,17 @@ impl<'a> Codegen<'a> {
                             continue;
                         }
                     }
-                    let (ty_str, arr_suffix) = self.emit_type_and_array_suffix(&w.ty);
-                    self.line(&format!("{} {}{};", ty_str, w.name.name, arr_suffix));
+                    if w.unpacked {
+                        // SV unpacked-array shape (mirror of unpacked port modifier).
+                        // Lets this wire mate with an `unpacked Vec<T,N>` port across
+                        // an `inst` connection without Verilator rejecting the
+                        // packed/unpacked shape mismatch.
+                        let (base_ty, suffix) = self.emit_type_and_unpacked_suffix(&w.ty);
+                        self.line(&format!("{} {}{};", base_ty, w.name.name, suffix));
+                    } else {
+                        let (ty_str, arr_suffix) = self.emit_type_and_array_suffix(&w.ty);
+                        self.line(&format!("{} {}{};", ty_str, w.name.name, arr_suffix));
+                    }
                     declared_names.insert(w.name.name.clone());
                 }
                 ModuleBodyItem::Generate(ref gen) => {

--- a/src/elaborate.rs
+++ b/src/elaborate.rs
@@ -1483,11 +1483,11 @@ fn lower_module_threads(m: ModuleDecl, opts: &ThreadLowerOpts) -> Result<(Module
         for ti in 0..n_threads {
             merged_body.push(ModuleBodyItem::WireDecl(WireDecl {
                 name: Ident::new(format!("_{}_req_{}", res_name, ti), sp),
-                ty: TypeExpr::Bool, span: sp,
+                ty: TypeExpr::Bool, unpacked: false, span: sp,
             }));
             merged_body.push(ModuleBodyItem::WireDecl(WireDecl {
                 name: Ident::new(format!("_{}_grant_{}", res_name, ti), sp),
-                ty: TypeExpr::Bool, span: sp,
+                ty: TypeExpr::Bool, unpacked: false, span: sp,
             }));
         }
         // Build packed req/grant vectors used by the arbiter inst.
@@ -1497,11 +1497,11 @@ fn lower_module_threads(m: ModuleDecl, opts: &ThreadLowerOpts) -> Result<(Module
             ExprKind::Literal(LitKind::Dec(n_threads as u64)), sp);
         merged_body.push(ModuleBodyItem::WireDecl(WireDecl {
             name: Ident::new(req_packed.clone(), sp),
-            ty: TypeExpr::UInt(Box::new(n_threads_expr.clone())), span: sp,
+            ty: TypeExpr::UInt(Box::new(n_threads_expr.clone())), unpacked: false, span: sp,
         }));
         merged_body.push(ModuleBodyItem::WireDecl(WireDecl {
             name: Ident::new(grant_packed.clone(), sp),
-            ty: TypeExpr::UInt(Box::new(n_threads_expr.clone())), span: sp,
+            ty: TypeExpr::UInt(Box::new(n_threads_expr.clone())), unpacked: false, span: sp,
         }));
         // Throwaway sinks for arbiter scalar outputs (the lock idiom only
         // consumes the per-thread grant ready bits, not the scalar grant
@@ -1511,12 +1511,12 @@ fn lower_module_threads(m: ModuleDecl, opts: &ThreadLowerOpts) -> Result<(Module
         let gr_width = crate::width::index_width(n_threads as u64);
         merged_body.push(ModuleBodyItem::WireDecl(WireDecl {
             name: Ident::new(gv_sink.clone(), sp),
-            ty: TypeExpr::Bool, span: sp,
+            ty: TypeExpr::Bool, unpacked: false, span: sp,
         }));
         merged_body.push(ModuleBodyItem::WireDecl(WireDecl {
             name: Ident::new(gr_sink.clone(), sp),
             ty: TypeExpr::UInt(Box::new(Expr::new(
-                ExprKind::Literal(LitKind::Dec(gr_width as u64)), sp))), span: sp,
+                ExprKind::Literal(LitKind::Dec(gr_width as u64)), sp))), unpacked: false, span: sp,
         }));
 
         // Pack/unpack between scalar wires and packed vectors.
@@ -1634,6 +1634,7 @@ fn lower_module_threads(m: ModuleDecl, opts: &ThreadLowerOpts) -> Result<(Module
                 merged_body.push(ModuleBodyItem::WireDecl(WireDecl {
                     name: Ident::new(wire_name, sp),
                     ty: info.ty.clone(),
+                    unpacked: false,
                     span: sp,
                 }));
             }
@@ -6369,16 +6370,17 @@ fn lower_indexed_tlm_target_group(
         let rsp_tag = format!("{prefix}_rsp_tag");
         let rsp_data = format!("{prefix}_rsp_data");
 
-        out.push(ModuleBodyItem::WireDecl(WireDecl { name: mk_ident(req_ready.clone()), ty: TypeExpr::Bool, span }));
-        out.push(ModuleBodyItem::WireDecl(WireDecl { name: mk_ident(rsp_valid.clone()), ty: TypeExpr::Bool, span }));
-        out.push(ModuleBodyItem::WireDecl(WireDecl { name: mk_ident(rsp_ready.clone()), ty: TypeExpr::Bool, span }));
+        out.push(ModuleBodyItem::WireDecl(WireDecl { name: mk_ident(req_ready.clone()), ty: TypeExpr::Bool, unpacked: false, span }));
+        out.push(ModuleBodyItem::WireDecl(WireDecl { name: mk_ident(rsp_valid.clone()), ty: TypeExpr::Bool, unpacked: false, span }));
+        out.push(ModuleBodyItem::WireDecl(WireDecl { name: mk_ident(rsp_ready.clone()), ty: TypeExpr::Bool, unpacked: false, span }));
         out.push(ModuleBodyItem::WireDecl(WireDecl {
             name: mk_ident(rsp_tag.clone()),
             ty: TypeExpr::UInt(Box::new(Expr::new(ExprKind::Literal(LitKind::Dec(tag_w as u64)), span))),
+            unpacked: false,
             span,
         }));
         if let Some(ret_ty) = &method.ret {
-            out.push(ModuleBodyItem::WireDecl(WireDecl { name: mk_ident(rsp_data.clone()), ty: ret_ty.clone(), span }));
+            out.push(ModuleBodyItem::WireDecl(WireDecl { name: mk_ident(rsp_data.clone()), ty: ret_ty.clone(), unpacked: false, span }));
         }
 
         let req_valid = Expr::new(

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1179,12 +1179,22 @@ impl Parser {
         let start = self.expect(TokenKind::Wire)?.span;
         let name = self.expect_ident()?;
         self.expect(TokenKind::Colon)?;
+        // Optional `unpacked` modifier: `wire name: unpacked Vec<T,N>;`
+        // Mirrors the port modifier (§3.7); only legal on Vec<T,N>.
+        let unpacked = self.eat_contextual("unpacked");
         let ty = self.parse_type_expr()?;
         self.expect(TokenKind::Semi)?;
         let end_span = self.tokens.get(self.pos.saturating_sub(1)).map(|t| t.span).unwrap_or(start);
+        if unpacked && !matches!(ty, TypeExpr::Vec(..)) {
+            return Err(CompileError::general(
+                "`unpacked` is only valid on `Vec<T,N>` wires",
+                start.merge(end_span),
+            ));
+        }
         Ok(WireDecl {
             name,
             ty,
+            unpacked,
             span: start.merge(end_span),
         })
     }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -9162,3 +9162,60 @@ end module M
          behavior, which conflicts with spec §7a.2 (only TRAILING assigns merge). \
          Enclosing begin-line was: {:?}\nFull SV:\n{}", begin_line, sv);
 }
+
+#[test]
+fn test_unpacked_wire_modifier_emits_unpacked_sv() {
+    // Issue #267: `unpacked` modifier on internal wire/let declarations.
+    // A `wire foo: unpacked Vec<T,N>` mirrors the existing `unpacked Vec`
+    // port modifier (§3.7) — emits SV unpacked-array shape so the wire can
+    // mate with an `unpacked Vec` port across an `inst` connection without
+    // Verilator rejecting the packed/unpacked shape mismatch.
+    let source = "
+        module Leaf
+          port q: in unpacked Vec<UInt<32>, 2>;
+          port o: out UInt<32>;
+          comb
+            o = q[0] ^ q[1];
+          end comb
+        end module Leaf
+
+        module Parent
+          port pq: in unpacked Vec<UInt<32>, 2>;
+          port po: out UInt<32>;
+          wire bridge: unpacked Vec<UInt<32>, 2>;
+          comb
+            bridge[0] = pq[0];
+            bridge[1] = pq[1];
+          end comb
+          inst leaf: Leaf
+            q <- bridge;
+            o -> po;
+          end inst leaf
+        end module Parent
+    ";
+    let sv = compile_to_sv(source);
+    // Wire emits unpacked-array shape, not packed multi-dim.
+    assert!(sv.contains("logic [31:0] bridge [1:0]") || sv.contains("logic [31:0] bridge [0:1]"),
+        "expected unpacked wire shape `logic [31:0] bridge [N-1:0]`, got:\n{}", sv);
+    assert!(!sv.contains("logic [1:0][31:0] bridge"),
+        "must NOT emit packed multi-dim for `unpacked` wire, got:\n{}", sv);
+    // Parent's port still uses unpacked (sanity).
+    assert!(sv.contains("input logic [31:0] pq [1:0]") || sv.contains("input logic [31:0] pq [0:1]"),
+        "expected unpacked port shape on parent, got:\n{}", sv);
+}
+
+#[test]
+fn test_unpacked_wire_rejected_on_non_vec() {
+    // The modifier is only valid on `Vec<T,N>`. Other types must error.
+    let source = "
+        module M
+          wire bad: unpacked UInt<32>;
+        end module M
+    ";
+    let tokens = lexer::tokenize(source).expect("lexer");
+    let mut parser = Parser::new(tokens, source);
+    let err = parser.parse_source_file().expect_err("must reject `unpacked UInt<32>`");
+    let msg = format!("{:?}", err);
+    assert!(msg.contains("unpacked") && msg.contains("Vec"),
+        "error should mention the `unpacked` + Vec constraint, got: {}", msg);
+}


### PR DESCRIPTION
## Summary

Closes #267. Mirrors the existing port `unpacked` modifier (§3.7) on internal `wire` declarations, closing the ARCH-to-ARCH-unpacked gap that §624 punted on. Previously, an ARCH parent connecting to an ARCH child's `unpacked Vec<T,N>` port had to either restructure both sides to packed or emit a manual lane-copy bridge, because the parent's wire was always emitted packed.

## Syntax

```arch
wire bridge: unpacked Vec<UInt<32>, 2>;
```

## Emission

- **SV**: `logic [31:0] bridge [1:0]` (unpacked-array shape, mirror of the port form).
- **C++ sim**: unchanged. Internal storage was already `uint64_t[N]`; the modifier only affects the SV boundary.

Restrictions: only legal on `Vec<T,N>`, matching the port modifier (rejected at parse time otherwise).

## Validation

- Two new integration tests:
  - `test_unpacked_wire_modifier_emits_unpacked_sv` — full parse → codegen → SV chain on a parent-with-unpacked-wire / child-with-unpacked-port pair.
  - `test_unpacked_wire_rejected_on_non_vec` — parser-side validation.
- arch-com cargo: **344 passed** (was 342, +2 from the new tests).
- arch-ibex full SoC gate: **36 passed in 97s** with the new binary (no regressions on B1's existing packed-restructure path).

## Spec update

§3.7 extended to document the wire form. The §624 "keep both sides packed when the entire path is ARCH" workaround caveat is replaced with the unpacked-wire option.

## Test plan

- [x] arch-com unit tests pass.
- [x] arch-ibex full gate green.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)