### PR TITLE
Add TLM router behavioral sims

### DIFF
--- a/tests/axi_dma_tlm/TlmOneToMany.arch
+++ b/tests/axi_dma_tlm/TlmOneToMany.arch
@@ -86,11 +86,22 @@ module OneToManyInitiator
   port clk: in Clock<SysDomain>;
   port rst: in Reset<Sync>;
   port m: initiator Mem;
+  port lo_data_o: out UInt<64>;
+  port hi_data_o: out UInt<64>;
+  port lo_ack_o: out Bool;
+  port hi_ack_o: out Bool;
 
   reg lo_data: UInt<64> reset rst => 0;
   reg hi_data: UInt<64> reset rst => 0;
   reg lo_ack: Bool reset rst => false;
   reg hi_ack: Bool reset rst => false;
+
+  comb
+    lo_data_o = lo_data;
+    hi_data_o = hi_data;
+    lo_ack_o = lo_ack;
+    hi_ack_o = hi_ack;
+  end comb
 
   thread driver on clk rising, rst high
     lo_data <= m.read(32'h0000_1000);
@@ -103,6 +114,10 @@ end module OneToManyInitiator
 module TlmOneToManyTop
   port clk: in Clock<SysDomain>;
   port rst: in Reset<Sync>;
+  port lo_data_o: out UInt<64>;
+  port hi_data_o: out UInt<64>;
+  port lo_ack_o: out Bool;
+  port hi_ack_o: out Bool;
 
   wire cpu_link: Mem;
   wire lo_link: Mem;
@@ -112,6 +127,10 @@ module TlmOneToManyTop
     clk <- clk;
     rst <- rst;
     m -> cpu_link;
+    lo_data_o -> lo_data_o;
+    hi_data_o -> hi_data_o;
+    lo_ack_o -> lo_ack_o;
+    hi_ack_o -> hi_ack_o;
   end inst i
 
   inst x: TlmAddrRouter2

--- a/tests/axi_dma_tlm/TlmOneToManyOoo.arch
+++ b/tests/axi_dma_tlm/TlmOneToManyOoo.arch
@@ -71,9 +71,16 @@ module OneToManyOooInitiator
   port clk: in Clock<SysDomain>;
   port rst: in Reset<Sync>;
   port m: initiator MemOoo;
+  port lo_data_o: out UInt<64>;
+  port hi_data_o: out UInt<64>;
 
   reg lo_data: UInt<64> reset rst => 0;
   reg hi_data: UInt<64> reset rst => 0;
+
+  comb
+    lo_data_o = lo_data;
+    hi_data_o = hi_data;
+  end comb
 
   thread driver on clk rising, rst high
     lo_data <= fork m.read(32'h0000_1000);
@@ -85,6 +92,8 @@ end module OneToManyOooInitiator
 module TlmOneToManyOooTop
   port clk: in Clock<SysDomain>;
   port rst: in Reset<Sync>;
+  port lo_data_o: out UInt<64>;
+  port hi_data_o: out UInt<64>;
 
   wire cpu_link: MemOoo;
   wire lo_link: MemOoo;
@@ -94,6 +103,8 @@ module TlmOneToManyOooTop
     clk <- clk;
     rst <- rst;
     m -> cpu_link;
+    lo_data_o -> lo_data_o;
+    hi_data_o -> hi_data_o;
   end inst i
 
   inst x: TlmOooAddrRouter2

--- a/tests/axi_dma_tlm/tb_tlm_one_to_many.cpp
+++ b/tests/axi_dma_tlm/tb_tlm_one_to_many.cpp
@@ -1,0 +1,49 @@
+#include "VTlmOneToManyTop.h"
+
+#include <cstdint>
+#include <cstdio>
+
+static VTlmOneToManyTop dut;
+
+static void tick() {
+    dut.clk = 0;
+    dut.eval();
+    dut.clk = 1;
+    dut.eval();
+}
+
+static void reset() {
+    dut.rst = 1;
+    for (int i = 0; i < 4; ++i) {
+        tick();
+    }
+    dut.rst = 0;
+    tick();
+}
+
+int main() {
+    reset();
+
+    constexpr uint64_t lo_expected = 0x1111000000000000ull;
+    constexpr uint64_t hi_expected = 0x2222000000000000ull;
+
+    for (int cycle = 0; cycle < 80; ++cycle) {
+        tick();
+        if (dut.lo_data_o == lo_expected
+            && dut.hi_data_o == hi_expected
+            && dut.lo_ack_o == 1
+            && dut.hi_ack_o == 1) {
+            std::printf("PASS one-to-many blocking: lo=0x%016llx hi=0x%016llx\n",
+                        static_cast<unsigned long long>(dut.lo_data_o),
+                        static_cast<unsigned long long>(dut.hi_data_o));
+            return 0;
+        }
+    }
+
+    std::printf("FAIL one-to-many blocking: lo=0x%016llx hi=0x%016llx lo_ack=%u hi_ack=%u\n",
+                static_cast<unsigned long long>(dut.lo_data_o),
+                static_cast<unsigned long long>(dut.hi_data_o),
+                static_cast<unsigned>(dut.lo_ack_o),
+                static_cast<unsigned>(dut.hi_ack_o));
+    return 1;
+}

--- a/tests/axi_dma_tlm/tb_tlm_one_to_many_ooo.cpp
+++ b/tests/axi_dma_tlm/tb_tlm_one_to_many_ooo.cpp
@@ -1,0 +1,44 @@
+#include "VTlmOneToManyOooTop.h"
+
+#include <cstdint>
+#include <cstdio>
+
+static VTlmOneToManyOooTop dut;
+
+static void tick() {
+    dut.clk = 0;
+    dut.eval();
+    dut.clk = 1;
+    dut.eval();
+}
+
+static void reset() {
+    dut.rst = 1;
+    for (int i = 0; i < 4; ++i) {
+        tick();
+    }
+    dut.rst = 0;
+    tick();
+}
+
+int main() {
+    reset();
+
+    constexpr uint64_t lo_expected = 0x1111000000000000ull;
+    constexpr uint64_t hi_expected = 0x2222000000000000ull;
+
+    for (int cycle = 0; cycle < 80; ++cycle) {
+        tick();
+        if (dut.lo_data_o == lo_expected && dut.hi_data_o == hi_expected) {
+            std::printf("PASS one-to-many OOO: lo=0x%016llx hi=0x%016llx\n",
+                        static_cast<unsigned long long>(dut.lo_data_o),
+                        static_cast<unsigned long long>(dut.hi_data_o));
+            return 0;
+        }
+    }
+
+    std::printf("FAIL one-to-many OOO: lo=0x%016llx hi=0x%016llx\n",
+                static_cast<unsigned long long>(dut.lo_data_o),
+                static_cast<unsigned long long>(dut.hi_data_o));
+    return 1;
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -5211,6 +5211,50 @@ fn test_tlm_one_initiator_many_targets_ooo_router_example_compiles() {
 }
 
 #[test]
+fn test_tlm_one_initiator_many_targets_router_arch_sim_behavior() {
+    let td = tempfile::tempdir().expect("tempdir");
+    let arch_bin = env!("CARGO_BIN_EXE_arch");
+    let out = std::process::Command::new(arch_bin)
+        .arg("sim")
+        .arg("tests/axi_dma_tlm/TlmOneToMany.arch")
+        .arg("--tb")
+        .arg("tests/axi_dma_tlm/tb_tlm_one_to_many.cpp")
+        .arg("--outdir")
+        .arg(td.path())
+        .output()
+        .expect("run arch sim for one-to-many router");
+    assert!(out.status.success(),
+        "one-to-many router sim should pass\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr));
+    assert!(String::from_utf8_lossy(&out.stdout).contains("PASS one-to-many blocking"),
+        "expected PASS marker in stdout:\n{}",
+        String::from_utf8_lossy(&out.stdout));
+}
+
+#[test]
+fn test_tlm_one_initiator_many_targets_ooo_router_arch_sim_behavior() {
+    let td = tempfile::tempdir().expect("tempdir");
+    let arch_bin = env!("CARGO_BIN_EXE_arch");
+    let out = std::process::Command::new(arch_bin)
+        .arg("sim")
+        .arg("tests/axi_dma_tlm/TlmOneToManyOoo.arch")
+        .arg("--tb")
+        .arg("tests/axi_dma_tlm/tb_tlm_one_to_many_ooo.cpp")
+        .arg("--outdir")
+        .arg(td.path())
+        .output()
+        .expect("run arch sim for OOO one-to-many router");
+    assert!(out.status.success(),
+        "OOO one-to-many router sim should pass\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr));
+    assert!(String::from_utf8_lossy(&out.stdout).contains("PASS one-to-many OOO"),
+        "expected PASS marker in stdout:\n{}",
+        String::from_utf8_lossy(&out.stdout));
+}
+
+#[test]
 fn test_reentrant_thread_parses_with_max() {
     // PR-tlm-p1: `reentrant max N` clause parses into
     // ThreadBlock.reentrant = Some(Some(Expr::Literal(N))).


### PR DESCRIPTION
## Summary
- expose observable data/ack outputs on the one-to-many TLM router examples
- add Verilator C++ testbenches for blocking and out-of-order one-to-many routing
- wire both examples into integration tests so arch sim proves the expected target responses

## Tests
- cargo test
- cargo run -- check tests/axi_dma_tlm/TlmOneToMany.arch
- cargo run -- check tests/axi_dma_tlm/TlmOneToManyOoo.arch
- cargo run -- sim tests/axi_dma_tlm/TlmOneToMany.arch --tb tests/axi_dma_tlm/tb_tlm_one_to_many.cpp --outdir /private/tmp/tlm_one_to_many_sim
- cargo run -- sim tests/axi_dma_tlm/TlmOneToManyOoo.arch --tb tests/axi_dma_tlm/tb_tlm_one_to_many_ooo.cpp --outdir /private/tmp/tlm_one_to_many_ooo_sim
- iverilog -g2012 -gsupported-assertions -t null /private/tmp/TlmOneToMany.sv
- iverilog -g2012 -gsupported-assertions -t null /private/tmp/TlmOneToManyOoo.sv
- verilator --lint-only --sv /private/tmp/TlmOneToMany.sv
- verilator --lint-only --sv /private/tmp/TlmOneToManyOoo.sv
- git diff --check