### PR TITLE
Avoid double-wrapped sim if conditions

### DIFF
--- a/src/sim_codegen/mod.rs
+++ b/src/sim_codegen/mod.rs
@@ -2016,6 +2016,15 @@ fn cpp_expr(expr: &Expr, ctx: &Ctx) -> String {
     cpp_expr_inner(expr, ctx, false)
 }
 
+fn cpp_condition(expr: &Expr, ctx: &Ctx) -> String {
+    let cond = cpp_expr(expr, ctx);
+    if cond.trim_start().starts_with('(') {
+        cond
+    } else {
+        format!("({cond})")
+    }
+}
+
 fn cpp_expr_lhs(expr: &Expr, ctx: &Ctx) -> String {
     cpp_expr_inner(expr, ctx, true)
 }
@@ -2824,11 +2833,11 @@ fn emit_stmt(stmt: &Stmt, ctx: &Ctx, out: &mut String, indent: usize, k: SimAssi
 }
 
 fn emit_if_else(ie: &IfElse, ctx: &Ctx, out: &mut String, indent: usize, is_chain: bool, k: SimAssignKind) {
-    let cond = cpp_expr(&ie.cond, ctx);
+    let cond = cpp_condition(&ie.cond, ctx);
     if is_chain {
-        out.push_str(&format!("{}}} else if ({}) {{\n", ind(indent), cond));
+        out.push_str(&format!("{}}} else if {} {{\n", ind(indent), cond));
     } else {
-        out.push_str(&format!("{}if ({}) {{\n", ind(indent), cond));
+        out.push_str(&format!("{}if {} {{\n", ind(indent), cond));
     }
     // --coverage: count entries to this arm. Phase 1 records branch
     // coverage for seq if/elsif/else; phase 1b/c adds comb. Counter id

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -5233,6 +5233,10 @@ fn test_tlm_one_initiator_many_targets_response_router_example_compiles() {
     assert!(sim.contains("class VTlmAddrRouter4Resp")
          && sim.contains("MemResp64 up_read_rsp_data"),
         "sim C++ should include struct response router mirror:\n{sim}");
+    assert!(sim.contains("if (_let_read_mapped == 0)"),
+        "sim C++ if conditions should not double-wrap comparison expressions:\n{sim}");
+    assert!(!sim.contains("if ((_let_read_mapped == 0))"),
+        "sim C++ should avoid Clang -Wparentheses-equality noise:\n{sim}");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- avoid adding another pair of parentheses around sim-codegen if/else conditions that are already parenthesized
- add a regression assertion on the TLM response-router generated C++ so Clang's -Wparentheses-equality warning does not return

## Tests
- cargo run -- sim tests/axi_dma_tlm/TlmOneToManyResp.arch --tb tests/axi_dma_tlm/tb_tlm_one_to_many_resp.cpp --outdir /private/tmp/tlm_resp_archsim_no_paren_warn
- cargo test test_tlm_one_initiator_many_targets_response_router_example_compiles -- --nocapture
- cargo test
- cargo run -- build tests/axi_dma_tlm/TlmOneToManyResp.arch -o /private/tmp/TlmOneToManyResp_no_paren_warn.sv
- iverilog -g2012 -gsupported-assertions -t null /private/tmp/TlmOneToManyResp_no_paren_warn.sv
- verilator --cc --exe --build --sv --top-module TlmOneToManyRespTop /private/tmp/TlmOneToManyResp_no_paren_warn.sv /private/tmp/tb_tlm_one_to_many_resp_verilator_nowarn.cpp --Mdir /private/tmp/verilator_tlm_resp_nowarn_obj
- /private/tmp/verilator_tlm_resp_nowarn_obj/VTlmOneToManyRespTop
- git diff --check