### PR TITLE
fix(codegen): size struct-field literals inside positional concat (closes #277)

### DIFF
--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -2527,6 +2527,60 @@ impl<'a> Codegen<'a> {
         self.emit_expr_prec(expr, 0)
     }
 
+    /// Bit-width of a `TypeExpr` resolved through the symbol table for
+    /// named struct/enum types. Returns `None` if any width sub-expression
+    /// is non-literal (parametric) or the named type is unresolved.
+    ///
+    /// Mirrors `typecheck::TypeChecker::type_expr_width`. Kept private to
+    /// codegen for now — promote to a shared util if a third caller appears.
+    fn type_expr_width(&self, ty: &TypeExpr) -> Option<u32> {
+        let eval = |e: &Expr| match &e.kind {
+            ExprKind::Literal(LitKind::Dec(n)) | ExprKind::Literal(LitKind::Hex(n)) => Some(*n as u32),
+            _ => None,
+        };
+        match ty {
+            TypeExpr::UInt(w) | TypeExpr::SInt(w) => eval(w),
+            TypeExpr::Bool | TypeExpr::Bit | TypeExpr::Clock(_) | TypeExpr::Reset(_, _) => Some(1),
+            TypeExpr::Vec(inner, size) => {
+                let iw = self.type_expr_width(inner)?;
+                let n = eval(size)?;
+                Some(iw * n)
+            }
+            TypeExpr::Named(ident) => match self.symbols.globals.get(&ident.name) {
+                Some((Symbol::Struct(info), _)) => {
+                    let mut total = 0u32;
+                    for (_, field_ty) in &info.fields {
+                        total = total.checked_add(self.type_expr_width(field_ty)?)?;
+                    }
+                    Some(total)
+                }
+                Some((Symbol::Enum(info), _)) => Some(enum_width(info.variants.len())),
+                _ => None,
+            },
+        }
+    }
+
+    /// Emit a struct-field value sized to the field's declared width.
+    ///
+    /// Inside an SV positional concatenation `{a, b, c}`, IEEE 1800
+    /// §11.4.12 requires every operand to be sized — bare unsized
+    /// numeric literals (`0`, `42`) are illegal and Verilator rejects
+    /// them with `WIDTHCONCAT`. Named identifiers, slices, casts, etc.
+    /// already carry a declared width and pass through unchanged.
+    fn emit_field_value_sized(&self, value: &Expr, field_ty: &TypeExpr) -> String {
+        let w = match self.type_expr_width(field_ty) {
+            Some(w) => w,
+            None => return self.emit_expr_str(value),
+        };
+        match &value.kind {
+            ExprKind::Literal(LitKind::Dec(n)) => format!("{w}'d{n}"),
+            ExprKind::Literal(LitKind::Hex(n)) => format!("{w}'h{n:x}"),
+            ExprKind::Literal(LitKind::Bin(n)) => format!("{w}'b{n:b}"),
+            ExprKind::Bool(b) => format!("1'b{}", *b as u8),
+            _ => self.emit_expr_str(value),
+        }
+    }
+
     /// Best-effort struct name for an expression. Walks a small set of
     /// expression shapes that typically produce a struct value in ARCH
     /// today (method calls returning structs, function calls, struct
@@ -3217,9 +3271,9 @@ impl<'a> Codegen<'a> {
                     self.symbols.globals.get(&name.name)
                 {
                     let mut vals = Vec::new();
-                    for (field_name, _) in &info.fields {
+                    for (field_name, field_ty) in &info.fields {
                         if let Some(f) = fields.iter().find(|f| f.name.name == *field_name) {
-                            vals.push(self.emit_expr_str(&f.value));
+                            vals.push(self.emit_field_value_sized(&f.value, field_ty));
                         }
                     }
                     if vals.len() == info.fields.len() {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -2200,6 +2200,46 @@ end struct Foo
     );
 }
 
+/// Regression for issue #277: when a struct literal is emitted as a positional
+/// concatenation `{a, b}` (the form chosen so iverilog accepts struct-literal
+/// RHS in continuous-assignment contexts), each numeric-literal field value
+/// must be sized to the field's declared width. Bare unsized `0` inside a
+/// concat is illegal per IEEE 1800 §11.4.12 and Verilator rejects it with
+/// `WIDTHCONCAT`.
+#[test]
+fn test_struct_literal_concat_sizes_field_literals() {
+    let source = r#"
+struct PriorityReg
+  value:    UInt<3>;
+  reserved: UInt<29>;
+end struct PriorityReg
+
+module ReproStruct
+  port clk: in Clock<MyDomain>;
+  port rst: in Reset<Async, Low>;
+  port out_data: out Vec<PriorityReg, 2>;
+
+  reg priority_r: Vec<PriorityReg, 2> reset rst => PriorityReg { value: 0, reserved: 0 };
+
+  default seq on clk rising;
+  seq
+    out_data[0] <= priority_r[0];
+    out_data[1] <= priority_r[1];
+  end seq
+
+end module ReproStruct
+"#;
+    let sv = compile_to_sv(source);
+    assert!(
+        sv.contains("{3'd0, 29'd0}"),
+        "expected sized literals `{{3'd0, 29'd0}}` in struct-literal concat (issue #277), got:\n{sv}"
+    );
+    assert!(
+        !sv.contains("{0, 0}"),
+        "unsized `{{0, 0}}` is illegal inside an SV concat (Verilator WIDTHCONCAT); got:\n{sv}"
+    );
+}
+
 /// Regression: `<=` must be accepted as less-than-or-equal in expression context
 /// (assert/cover RHS, comb RHS, let RHS, if conditions, ternary branches), while
 /// still working as the non-blocking-assignment token at the statement level.


### PR DESCRIPTION
## Summary

- Closes #277.
- After `5ca54ba` switched struct-literal SV emission to a positional concat `{a, b}`, numeric-literal field values (e.g. `value: 0`) were emitted as bare unsized `0` inside the concat. Verilator rejects this with `WIDTHCONCAT` per IEEE 1800 §11.4.12, breaking arch-ibex's SoC lint on every RDL-generated PLIC/CLINT/CSR `.sv` reset block.
- Fix: size each numeric-literal field value to the field's declared width using `StructInfo.fields`. `value: 0` for a `UInt<3>` field now emits `3'd0` instead of `0`.

## Changes

- `src/codegen/mod.rs`
  - New `Codegen::type_expr_width(&TypeExpr) -> Option<u32>` (mirrors `TypeChecker::type_expr_width`, scoped private to codegen for now).
  - New `Codegen::emit_field_value_sized(value, field_ty)` — sizes `Literal::{Dec,Hex,Bin}` and `Bool` to the field width; falls back to `emit_expr_str` for all other expressions (identifiers, slices, casts, etc., which already carry a declared width).
  - Plumbed into the positional-concat branch of `ExprKind::StructLiteral`. The `'{f: v}` fallback path is unchanged — SV assignment patterns accept unsized literals.

- `tests/integration_test.rs`
  - New `test_struct_literal_concat_sizes_field_literals` regression test: builds the issue's minimal `PriorityReg{value:0, reserved:0}` repro, asserts the SV contains `{3'd0, 29'd0}` and *not* `{0, 0}`.

## Why not also `sim_codegen`?

`sim_codegen/mod.rs::2221` lowers struct literals via field-by-field assignment in an immediately-invoked lambda (`_t.value = 0; _t.reserved = 0;`), which has no width-sensitivity at the C++ level. Unaffected.

## Test plan

- [x] `cargo test --release` — 307 (was 306) + 1 new regression test, all green
- [x] arch-ibex `port/b3-if-stage` full gate against the patched binary: 38 passed in 100.16s
- [x] arch-ibex `tests/test_soc_lint.py` (the original failure) clears

🤖 Generated with [Claude Code](https://claude.com/claude-code)