### PR TITLE
fix(deps): extend is_interface archi-stub support to fsm

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1101,6 +1101,58 @@ impl Item {
             Item::Use(u) => u,
         }
     }
+
+    /// True when this item was loaded from a `.archi` interface stub
+    /// (port-only, no body). Set by the post-parse tagger in `main.rs`
+    /// based on the source-file extension. Body-only passes (codegen,
+    /// sim model emission, .archi re-emit, body-driven typecheck)
+    /// short-circuit on this so the stub doesn't shadow the real
+    /// implementation that lives in a separately-built `.sv`/`.cpp`.
+    /// Only the construct variants that can be instantiated across
+    /// `.archi` boundaries carry the flag — `module` (via
+    /// `ModuleDecl.is_interface`) and the `ConstructCommon`-bearing
+    /// variants (`fsm`, `fifo`, `ram`, `cam`, `counter`, `arbiter`,
+    /// `regfile`, `pipeline`, `linklist`).
+    pub fn is_interface(&self) -> bool {
+        match self {
+            Item::Module(m)        => m.is_interface,
+            Item::Fsm(f)           => f.common.is_interface,
+            Item::Fifo(f)          => f.common.is_interface,
+            Item::Ram(r)           => r.common.is_interface,
+            Item::Cam(c)           => c.common.is_interface,
+            Item::Counter(c)       => c.common.is_interface,
+            Item::Arbiter(a)       => a.common.is_interface,
+            Item::Regfile(r)       => r.common.is_interface,
+            Item::Pipeline(p)      => p.common.is_interface,
+            Item::Linklist(l)      => l.common.is_interface,
+            // The remaining variants (Domain, Struct, Enum, Function,
+            // Template, Synchronizer, Clkgate, Bus, Package, Use)
+            // either don't get instantiated across `.archi` boundaries
+            // or aren't `ConstructCommon`-bearing. No is_interface for
+            // them today; extend if/when a new case appears.
+            _ => false,
+        }
+    }
+
+    /// Set the interface-stub flag. Mirror of [`Self::is_interface`].
+    /// Used by the post-parse tagger in `main.rs` to mark items loaded
+    /// from `.archi` files. Returns `true` if the variant supports the
+    /// flag (and the assignment took effect); `false` otherwise.
+    pub fn set_is_interface(&mut self, val: bool) -> bool {
+        match self {
+            Item::Module(m)        => { m.is_interface = val; true }
+            Item::Fsm(f)           => { f.common.is_interface = val; true }
+            Item::Fifo(f)          => { f.common.is_interface = val; true }
+            Item::Ram(r)           => { r.common.is_interface = val; true }
+            Item::Cam(c)           => { c.common.is_interface = val; true }
+            Item::Counter(c)       => { c.common.is_interface = val; true }
+            Item::Arbiter(a)       => { a.common.is_interface = val; true }
+            Item::Regfile(r)       => { r.common.is_interface = val; true }
+            Item::Pipeline(p)      => { p.common.is_interface = val; true }
+            Item::Linklist(l)      => { l.common.is_interface = val; true }
+            _ => false,
+        }
+    }
 }
 
 /// Centralizing trait for all top-level constructs (every `Item::*`
@@ -1329,6 +1381,16 @@ pub struct ConstructCommon {
     /// downstream tooling can tell "from the outside" prose apart from
     /// "from the inside" prose.
     pub inner_doc: Option<String>,
+    /// True when this construct was loaded from a `.archi` interface
+    /// stub (port-only, no body). Set post-parse from the source-file
+    /// extension (see `main.rs` post-parse tagger). Body-only passes
+    /// (output-driven check, codegen, .archi re-emit, sim model
+    /// emission) skip these to avoid spurious diagnostics and duplicate
+    /// output. Mirrors the same flag on `ModuleDecl`. Module isn't
+    /// folded into `ConstructCommon` yet — see `feedback_*` for
+    /// background — so that flag is duplicated; both feed the same
+    /// post-parse tagger and downstream-skip pattern.
+    pub is_interface: bool,
 }
 
 impl ConstructCommon {
@@ -1377,8 +1439,13 @@ pub struct FsmDecl {
     pub wires: Vec<WireDecl>,
     /// Flat list of declared state names (`state A, B, C;`)
     pub state_names: Vec<Ident>,
-    /// The reset / default state
-    pub default_state: Ident,
+    /// The reset / default state. `None` is only valid for an interface
+    /// stub loaded from a `.archi` file (`common.is_interface == true`);
+    /// real `fsm` declarations require an explicit `default state Name;`
+    /// — that requirement is now enforced in `resolve.rs` rather than
+    /// `parser.rs`, so the parser can accept body-less stubs that the
+    /// post-parse tagger flips to `is_interface = true`.
+    pub default_state: Option<Ident>,
     /// Default block: comb and seq statements applied before the state case
     pub default_comb: Vec<Stmt>,
     pub default_seq: Vec<Stmt>,

--- a/src/codegen/fsm.rs
+++ b/src/codegen/fsm.rs
@@ -8,6 +8,15 @@ use super::*;
 
 impl<'a> Codegen<'a> {
     pub(crate) fn emit_fsm(&mut self, f: &FsmDecl) {
+        // Interface stubs from `.archi` files have no body and exist
+        // only to expose the port signature to typecheck. The real SV
+        // for these fsms lives in a separately-built `.sv` file
+        // alongside the `.archi` — emitting an empty stub would
+        // produce a duplicate module that clashes with the real SV at
+        // Verilator link time. Mirrors the same skip in `emit_module`.
+        if f.common.is_interface {
+            return;
+        }
         self.current_construct = f.name.name.clone();
         // Built-in `state` identifier inside fsm scope: read of the current
         // encoded state register. SV emission lowers to `state_r` (the enum
@@ -147,7 +156,14 @@ impl<'a> Codegen<'a> {
         self.indent += 1;
         self.line(&format!("if ({rst_cond}) begin"));
         self.indent += 1;
-        self.line(&format!("state_r <= {};", f.default_state.name.to_uppercase()));
+        // `default_state` is `Some(_)` here because codegen only runs for
+        // non-interface fsms (interface stubs are filtered out earlier);
+        // resolve.rs already errored on the `None` case for real fsms.
+        let default_state_name = f.default_state.as_ref()
+            .expect("codegen: fsm without default_state — should have been rejected by resolve")
+            .name
+            .clone();
+        self.line(&format!("state_r <= {};", default_state_name.to_uppercase()));
         // Reset datapath registers
         for reg in &f.regs {
             let reset_expr = Self::reset_value_expr(&reg.reset)

--- a/src/elaborate.rs
+++ b/src/elaborate.rs
@@ -2313,6 +2313,7 @@ fn synthesize_lock_arbiter(
             span: sp,
             doc: None,
             inner_doc: None,
+            is_interface: false,
         },
         port_arrays: vec![request_array],
         policy,

--- a/src/main.rs
+++ b/src/main.rs
@@ -504,11 +504,11 @@ fn main() -> miette::Result<()> {
 
             // Emit .archi interface files alongside .sv (for separate compilation)
             for item in &ast.items {
-                // Don't re-emit .archi for an interface stub we just loaded
-                // — we'd be overwriting the source file we read.
-                if let Item::Module(m) = item {
-                    if m.is_interface { continue; }
-                }
+                // Don't re-emit .archi for an interface stub we just
+                // loaded — we'd be overwriting the source file we
+                // read. Covers module + every ConstructCommon-bearing
+                // variant via `Item::is_interface`.
+                if item.is_interface() { continue; }
                 if let Some(content) = arch::interface::emit_interface(item) {
                     let name = &item.as_construct().name().name;
                     // Write .archi next to the .sv output
@@ -1438,17 +1438,20 @@ fn run_check_multi_opts(
     })?;
 
     // Tag items loaded from `.archi` interface stubs (port-only, no body).
-    // Body-only downstream passes — typecheck's output-driven check, SV
-    // codegen, and `.archi` re-emission — skip these to avoid spurious
-    // diagnostics and duplicate output. Only `ModuleDecl` carries the flag
-    // for now; extend to other constructs (Fsm, Fifo, …) when they too
-    // start being instantiated across `.archi` boundaries.
+    // Body-only downstream passes — typecheck's output-driven check /
+    // body validation, SV codegen, sim model emission, and `.archi`
+    // re-emission — skip these to avoid spurious diagnostics and
+    // duplicate output. `Item::set_is_interface` covers `module` plus
+    // every `ConstructCommon`-bearing variant that can appear in an
+    // `.archi` (fsm, fifo, ram, cam, counter, arbiter, regfile,
+    // pipeline, linklist). Variants that can't appear in an `.archi`
+    // (domain, struct, enum, function, template, package, use, ...)
+    // silently no-op via `set_is_interface`'s `_ => false` arm.
     for item in parsed_ast.items.iter_mut() {
-        if let Item::Module(m) = item {
-            let (filename, _, _) = ms.locate(m.span.start);
-            if filename.ends_with(".archi") {
-                m.is_interface = true;
-            }
+        let span = item.span();
+        let (filename, _, _) = ms.locate(span.start);
+        if filename.ends_with(".archi") {
+            item.set_is_interface(true);
         }
     }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3476,17 +3476,21 @@ impl Parser {
             return Err(CompileError::mismatched_closing(&name.name, &closing.name, closing.span));
         }
 
-        let ds = default_state.ok_or_else(|| {
-            CompileError::general("fsm requires `default state Name;`", name.span)
-        })?;
+        // `default state Name;` is required for real `fsm` declarations
+        // but NOT for `.archi` interface stubs (which have no body). The
+        // parser accepts a missing default_state here and lets the
+        // post-parse tagger decide whether this turned out to be an
+        // interface stub. The "real fsm needs default_state" rule moved
+        // into resolve.rs (see `Item::Fsm` arm: emits the diagnostic
+        // when `!common.is_interface && default_state.is_none()`).
 
         Ok(FsmDecl {
-            common: ConstructCommon { name, params, ports, asserts, span: start.merge(closing.span), doc: None, inner_doc },
+            common: ConstructCommon { name, params, ports, asserts, span: start.merge(closing.span), doc: None, inner_doc, is_interface: false },
             regs,
             lets,
             wires,
             state_names,
-            default_state: ds,
+            default_state,
             default_comb,
             default_seq,
             states,
@@ -3626,7 +3630,7 @@ impl Parser {
         }
 
         Ok(PipelineDecl {
-            common: ConstructCommon { name, params, ports, asserts, span: start.merge(closing.span), doc: None, inner_doc },
+            common: ConstructCommon { name, params, ports, asserts, span: start.merge(closing.span), doc: None, inner_doc, is_interface: false },
             stages,
             stall_conds,
             flush_directives,
@@ -3816,7 +3820,7 @@ impl Parser {
         }
 
         Ok(FifoDecl {
-            common: ConstructCommon { name, params, ports, asserts, span: start.merge(closing.span), doc: None, inner_doc },
+            common: ConstructCommon { name, params, ports, asserts, span: start.merge(closing.span), doc: None, inner_doc, is_interface: false },
             kind: kind.unwrap_or(FifoKind::Fifo),
         })
     }
@@ -4121,7 +4125,7 @@ impl Parser {
         }
 
         Ok(RamDecl {
-            common: ConstructCommon { name, params, ports, asserts, span: start.merge(closing.span), doc: None, inner_doc },
+            common: ConstructCommon { name, params, ports, asserts, span: start.merge(closing.span), doc: None, inner_doc, is_interface: false },
             kind: k,
             latency: lat,
             write_mode,
@@ -4341,6 +4345,7 @@ impl Parser {
                 asserts,
                 span: Span { start: start.start, end: end.end },
                 doc: None, inner_doc,
+                is_interface: false,
             },
         })
     }
@@ -4437,7 +4442,7 @@ impl Parser {
         let mode = mode.unwrap_or(CounterMode::Wrap);
         let direction = direction.unwrap_or(CounterDirection::Up);
         Ok(CounterDecl {
-            common: ConstructCommon { name, params, ports, asserts, span: start.merge(closing.span), doc: None, inner_doc },
+            common: ConstructCommon { name, params, ports, asserts, span: start.merge(closing.span), doc: None, inner_doc, is_interface: false },
             mode, direction, init,
         })
     }
@@ -4544,7 +4549,7 @@ impl Parser {
         }
 
         Ok(ArbiterDecl {
-            common: ConstructCommon { name, params, ports, asserts, span: start.merge(closing.span), doc: None, inner_doc },
+            common: ConstructCommon { name, params, ports, asserts, span: start.merge(closing.span), doc: None, inner_doc, is_interface: false },
             port_arrays,
             policy: policy.unwrap_or(ArbiterPolicy::RoundRobin),
             hook,
@@ -4857,7 +4862,7 @@ impl Parser {
         }
 
         Ok(RegfileDecl {
-            common: ConstructCommon { name, params, ports, asserts, span: start.merge(closing.span), doc: None, inner_doc },
+            common: ConstructCommon { name, params, ports, asserts, span: start.merge(closing.span), doc: None, inner_doc, is_interface: false },
             read_ports,
             write_ports,
             inits,
@@ -5136,7 +5141,7 @@ impl Parser {
         }
 
         Ok(LinklistDecl {
-            common: ConstructCommon { name, params, ports, asserts, span: start.merge(closing.span), doc: None, inner_doc },
+            common: ConstructCommon { name, params, ports, asserts, span: start.merge(closing.span), doc: None, inner_doc, is_interface: false },
             kind: kind.unwrap_or(LinklistKind::Singly),
             track_tail,
             track_length,
@@ -5205,7 +5210,7 @@ impl Parser {
         }
 
         Ok(OpDecl {
-            common: ConstructCommon { name, params: Vec::new(), ports, asserts, span: start.merge(closing.span), doc: None, inner_doc: None },
+            common: ConstructCommon { name, params: Vec::new(), ports, asserts, span: start.merge(closing.span), doc: None, inner_doc: None, is_interface: false },
             latency,
             pipelined,
         })

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -450,15 +450,42 @@ pub fn resolve(source_file: &SourceFile) -> Result<SymbolTable, Vec<CompileError
             Item::Fsm(f) => {
                 if table.globals.contains_key(&f.name.name) {
                     errors.push(CompileError::duplicate(&f.name.name, f.name.span));
+                } else if f.common.is_interface {
+                    // Interface stub from a `.archi` file — body is empty
+                    // by construction, so default_state / state_names /
+                    // transitions are not present and not validatable.
+                    // The stub exists only to expose the port signature
+                    // so a parent's inst-decl can typecheck against it.
+                    let info = FsmInfo {
+                        name: f.name.name.clone(),
+                        ports: f.ports.clone(),
+                        state_names: Vec::new(),
+                        default_state: String::new(),
+                    };
+                    table.globals.insert(f.name.name.clone(), (Symbol::Fsm(info), f.name.span));
                 } else {
-                    // Validate default_state is declared
+                    // Real fsm: enforce `default state Name;` (was a parse
+                    // error pre-PR for `fsm`-stub support; moved here so
+                    // the parser can accept body-less `.archi` stubs).
                     let declared: Vec<String> = f.state_names.iter().map(|s| s.name.clone()).collect();
-                    if !declared.contains(&f.default_state.name) {
-                        errors.push(CompileError::general(
-                            &format!("default state `{}` not declared", f.default_state.name),
-                            f.default_state.span,
-                        ));
-                    }
+                    let default_state_name = match &f.default_state {
+                        Some(ds) => {
+                            if !declared.contains(&ds.name) {
+                                errors.push(CompileError::general(
+                                    &format!("default state `{}` not declared", ds.name),
+                                    ds.span,
+                                ));
+                            }
+                            ds.name.clone()
+                        }
+                        None => {
+                            errors.push(CompileError::general(
+                                "fsm requires `default state Name;`",
+                                f.name.span,
+                            ));
+                            String::new()
+                        }
+                    };
                     // Validate transition targets exist
                     for sb in &f.states {
                         for tr in &sb.transitions {
@@ -471,7 +498,7 @@ pub fn resolve(source_file: &SourceFile) -> Result<SymbolTable, Vec<CompileError
                         name: f.name.name.clone(),
                         ports: f.ports.clone(),
                         state_names: declared,
-                        default_state: f.default_state.name.clone(),
+                        default_state: default_state_name,
                     };
                     table.globals.insert(f.name.name.clone(), (Symbol::Fsm(info), f.name.span));
                 }

--- a/src/sim_codegen/fsm.rs
+++ b/src/sim_codegen/fsm.rs
@@ -54,7 +54,11 @@ impl<'a> SimCodegen<'a> {
 
         let state_idx: HashMap<String, usize> = f.state_names.iter()
             .enumerate().map(|(i, s)| (s.name.clone(), i)).collect();
-        let default_idx = state_idx.get(&f.default_state.name).copied().unwrap_or(0);
+        // sim_codegen only runs for non-interface fsms; `default_state`
+        // is `Some(_)` here. Interface stubs are filtered out earlier.
+        let default_idx = f.default_state.as_ref()
+            .and_then(|ds| state_idx.get(&ds.name).copied())
+            .unwrap_or(0);
 
         let (rst_name, _is_async, is_low) = extract_reset_info(&f.ports);
         let rst_cond = if is_low { format!("(!{})", rst_name) } else { rst_name.clone() };

--- a/src/sim_codegen/mod.rs
+++ b/src/sim_codegen/mod.rs
@@ -287,8 +287,15 @@ impl<'a> SimCodegen<'a> {
                     debug_module_set.contains(m.name.name.as_str()),
                     &debug_module_set,
                 ));
-            } else if let Some(model) = item.as_construct().emit_sim(self) {
-                models.push(model);
+            } else {
+                // Skip interface stubs from `.archi` for any
+                // ConstructCommon-bearing variant (Fsm, Fifo, Ram, …).
+                // Same reason as Module: real sim model is built
+                // separately alongside the `.archi`.
+                if item.is_interface() { continue; }
+                if let Some(model) = item.as_construct().emit_sim(self) {
+                    models.push(model);
+                }
             }
         }
         models
@@ -310,11 +317,15 @@ impl<'a> SimCodegen<'a> {
                     }
                 }
                 Item::Fsm(f) => {
+                    // Skip interface stubs from `.archi`: pybind wrapper
+                    // for the real implementation is built separately.
+                    if f.common.is_interface { continue; }
                     if let Some(w) = self.emit_pybind_fsm(f) {
                         wrappers.push(w);
                     }
                 }
                 Item::Counter(c) => {
+                    if c.common.is_interface { continue; }
                     if let Some(w) = self.emit_pybind_counter(c) {
                         wrappers.push(w);
                     }

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -4487,6 +4487,16 @@ impl<'a> TypeChecker<'a> {
             self.check_snake_case(&p.name);
         }
 
+        // Interface stub from a `.archi` file — body is empty by
+        // construction. Skip body-driven checks (state coverage,
+        // transition validation, output-driven, etc.) entirely; the
+        // stub exists only to expose the port signature to parent-side
+        // instantiation typechecking. Mirrors the same short-circuit in
+        // `check_module`.
+        if f.common.is_interface {
+            return;
+        }
+
         let _state_names: Vec<&str> = f.state_names.iter().map(|s| s.name.as_str()).collect();
 
         // Every declared state must have a state body

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -9272,6 +9272,111 @@ end module Parent
 }
 
 #[test]
+fn test_archi_interface_stub_for_fsm_skips_body_only_passes() {
+    // Same scenario as `test_archi_interface_stub_skips_body_only_passes`
+    // but for an `fsm`-typed sub-instance (B5 arch-ibex case: a parent
+    // module instantiates a previously-ported `fsm`, so the dep loader
+    // pulls in the `fsm Name ... end fsm Name` body-less stub from
+    // `<name>.archi`). Pre-fix, the parser rejected the stub with
+    // "fsm requires `default state Name;`" (the rule only the real fsm
+    // needs); post-fix the parser accepts a missing default_state, the
+    // post-parse tagger sets `is_interface = true`, and resolve /
+    // typecheck / codegen / sim_codegen all skip body-only passes.
+    let source = r#"
+domain Sys
+  freq_mhz: 100
+end domain Sys
+
+fsm ChildFsm
+  port clk_i: in Clock<Sys>;
+  port rst_ni: in Reset<Async, Low>;
+  port in_i: in UInt<8>;
+  port out_o: out UInt<8>;
+end fsm ChildFsm
+
+module Parent
+  port clk_i: in Clock<Sys>;
+  port rst_ni: in Reset<Async, Low>;
+  port result: out UInt<8>;
+
+  wire w: UInt<8>;
+  inst c: ChildFsm
+    clk_i <- clk_i;
+    rst_ni <- rst_ni;
+    in_i <- 8'd0;
+    out_o -> w;
+  end inst c
+
+  let result = w;
+end module Parent
+"#;
+    let tokens = lexer::tokenize(source).expect("lex");
+    let mut parser = Parser::new(tokens, source);
+    let mut parsed_ast = parser.parse_source_file()
+        .expect("parser must accept body-less fsm (interface stub)");
+    // Mimic main.rs's post-parse tagger: items loaded from `.archi` get
+    // is_interface = true. Here we tag the FSM by name to simulate
+    // "loaded from <name>.archi".
+    for item in parsed_ast.items.iter_mut() {
+        if let arch::ast::Item::Fsm(f) = item {
+            if f.name.name == "ChildFsm" { f.common.is_interface = true; }
+        }
+    }
+    let ast = elaborate::elaborate(parsed_ast).expect("elaborate");
+    let ast = elaborate::lower_tlm_target_threads(ast).expect("tlm_target lowering");
+    let ast = elaborate::lower_tlm_initiator_calls(ast).expect("tlm_initiator lowering");
+    let ast = elaborate::lower_threads_with_opts(ast, &elaborate::ThreadLowerOpts::default())
+        .expect("lower_threads");
+    let ast = elaborate::lower_pipe_reg_ports(ast).expect("lower_pipe_reg_ports");
+    let ast = elaborate::lower_credit_channel_dispatch(ast).expect("credit_channel dispatch");
+    let symbols = resolve::resolve(&ast)
+        .expect("resolve must accept fsm interface stub (no default_state validation)");
+    let checker = TypeChecker::new(&symbols, &ast);
+    let (_warnings, overload_map) = checker.check()
+        .expect("typecheck must skip body checks on fsm interface stub");
+    let codegen = Codegen::new(&symbols, &ast, overload_map);
+    let sv = codegen.generate();
+    assert!(sv.contains("module Parent"), "parent module should be emitted");
+    assert!(!sv.contains("module ChildFsm"),
+        "fsm interface stub must not be emitted to SV (real impl lives in a separately-built file)");
+}
+
+#[test]
+fn test_real_fsm_still_requires_default_state() {
+    // Mirror to the stub test: a *real* (non-interface) fsm without
+    // `default state Name;` must still be rejected. Pre-fix the error
+    // came from parser; post-fix it comes from `resolve.rs`. The user
+    // diagnostic is preserved verbatim.
+    let source = r#"
+domain Sys
+  freq_mhz: 100
+end domain Sys
+
+fsm BrokenFsm
+  port clk_i: in Clock<Sys>;
+  port rst_ni: in Reset<Async, Low>;
+  state [Idle, Run]
+  state Idle
+    -> Run when 1'b1;
+  end state Idle
+  state Run
+    -> Idle when 1'b1;
+  end state Run
+end fsm BrokenFsm
+"#;
+    let tokens = lexer::tokenize(source).expect("lex");
+    let mut parser = Parser::new(tokens, source);
+    let parsed_ast = parser.parse_source_file()
+        .expect("parser accepts body-less fsm now; default-state check moved to resolve");
+    let ast = elaborate::elaborate(parsed_ast).expect("elaborate");
+    let resolve_err = resolve::resolve(&ast).err()
+        .expect("real fsm without default_state must still error");
+    let msg = format!("{resolve_err:?}");
+    assert!(msg.contains("default state"),
+        "expected `default state` diagnostic, got: {msg}");
+}
+
+#[test]
 fn test_thread_inter_yield_seq_assigns_get_dead_skid() {
     // Spec §7a.2 line 1677: only TRAILING seq assigns (after the last wait
     // in the body) may merge into the preceding state's exit logic.


### PR DESCRIPTION
## Summary
- Follow-up to #278: extends the `.archi` interface-stub flag from `module` to `fsm` (and to every `ConstructCommon`-bearing variant in one shot via the shared field), so a parent module that instantiates a previously-ported `fsm` can re-use its emitted `<name>.archi`.
- Hits in arch-ibex B5 — IbexIdStage instantiates ibex_controller (ported in B4 as `fsm ibex_controller`); `arch build` of the parent fails at parse-time with `× fsm requires default state Name;` on the body-less stub.
- Mirrors #278's pattern: parser accepts body-less stubs, post-parse tagger sets `is_interface=true` from `.archi` extension, body-only passes (resolve / typecheck / codegen / sim_codegen / .archi re-emit) short-circuit on the flag.
- Two new regression tests; the "real fsm needs `default state`" diagnostic moved from parser to resolve and is preserved verbatim.

## Test plan
- [x] `cargo test --release` — 309 pass (was 307 + 2 new)
- [x] End-to-end: `arch build` on the arch-ibex B5 IbexIdStage composite (which instantiates the B4-ported `fsm ibex_controller`) progresses past the controller `.archi` import that hard-failed pre-fix.
- [x] No-regression: existing `module`-stub test (`test_archi_interface_stub_skips_body_only_passes`) still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)