### PR TITLE
Add ARCH backend regression runner

### DIFF
--- a/doc/arch_regression_runner.md
+++ b/doc/arch_regression_runner.md
@@ -1,0 +1,100 @@
+# ARCH Regression Runner
+
+`tools/run_arch_regression.py` is a broad backend regression gate for `.arch`
+files under `tests/`.
+
+The runner first copies `tests/` into a scratch directory, because
+`arch build` emits `.archi` side files next to the input sources. It then
+discovers regression units:
+
+- directories whose `.arch` files pass `arch check` together are run as one
+  unit, which covers multi-file designs such as AXI DMA;
+- directories that do not pass as a group fall back to one unit per `.arch`;
+- units that fail `arch check` are reported as `skip_check_failed`;
+- package/domain-only units with no generated `module` skip Verilator and
+  arch-sim smoke compile after `arch build` succeeds.
+
+For each passing unit, the runner executes:
+
+1. `arch check`
+2. `arch build -o <unit>.sv`
+3. `verilator --lint-only --sv --assert ... <unit>.sv`
+4. `arch sim --tb ...` when the unit has an entry in
+   `tests/arch_sim_manifest.json`; otherwise `arch sim --outdir ...`
+5. a generated C++ smoke compile of the arch-sim models when no real C++ TB
+   exists for that unit
+
+The smoke compile is intentionally not a behavioral testbench. Its job is to
+catch simulator-codegen regressions where generated C++ no longer compiles.
+Add entries to `tests/arch_sim_manifest.json` when an existing C++ testbench
+should be run as part of the broad backend gate.
+
+## Common Commands
+
+Run the normal Rust test baseline:
+
+```bash
+tools/run_cargo_test_baseline.py
+```
+
+Run the current known-good baseline:
+
+```bash
+tools/run_arch_regression.py \
+  --baseline tests/arch_regression_baseline.json \
+  --work-dir /tmp/arch-regression \
+  --jobs 8
+```
+
+Refresh the baseline after intentionally improving backend coverage:
+
+```bash
+tools/run_arch_regression.py \
+  --work-dir /tmp/arch-regression-refresh \
+  --jobs 8 \
+  --update-baseline tests/arch_regression_baseline.json \
+  --allow-failures
+```
+
+Run one area while developing:
+
+```bash
+tools/run_arch_regression.py \
+  --pattern 'axi_dma_tlm/*.arch' \
+  --work-dir /tmp/arch-regression-tlm \
+  --jobs 4
+```
+
+Run top-level single-file tests with their manifest TBs instead of the default
+grouped `tests_root` unit:
+
+```bash
+tools/run_arch_regression.py \
+  --pattern 'cam_*.arch' \
+  --no-group-dirs \
+  --work-dir /tmp/arch-regression-cam \
+  --jobs 4
+```
+
+List discovered units without running backend checks:
+
+```bash
+tools/run_arch_regression.py --list
+```
+
+Every run writes `summary.json` plus per-step stdout/stderr logs under the
+work directory.
+
+## Rust Test Inventory Baseline
+
+`tools/run_cargo_test_baseline.py` records the current `cargo test -- --list`
+inventory in `tests/cargo_test_baseline.json`, then runs `cargo test`. This is
+useful because a plain `cargo test` still exits successfully if a test was
+accidentally deleted or renamed.
+
+Refresh the Rust test baseline after intentionally adding, deleting, or renaming
+tests:
+
+```bash
+tools/run_cargo_test_baseline.py --update-baseline --list-only
+```

--- a/tests/arch_regression_baseline.json
+++ b/tests/arch_regression_baseline.json
@@ -1,0 +1,1114 @@
+{
+  "description": "ARCH regression units that passed check/build/verilator/arch-sim smoke when this baseline was refreshed.",
+  "units": [
+    {
+      "name": "aes__aes_inv_sbox",
+      "files": [
+        "tests/aes/aes_inv_sbox.arch"
+      ]
+    },
+    {
+      "name": "aes__aes_key_expand_128",
+      "files": [
+        "tests/aes/aes_key_expand_128.arch"
+      ]
+    },
+    {
+      "name": "aes__aes_rcon",
+      "files": [
+        "tests/aes/aes_rcon.arch"
+      ]
+    },
+    {
+      "name": "aes__aes_rcon_mod",
+      "files": [
+        "tests/aes/aes_rcon_mod.arch"
+      ]
+    },
+    {
+      "name": "aes__aes_sbox",
+      "files": [
+        "tests/aes/aes_sbox.arch"
+      ]
+    },
+    {
+      "name": "aes__domain",
+      "files": [
+        "tests/aes/domain.arch"
+      ]
+    },
+    {
+      "name": "axi_dma_tlm__TlmIndexedBurstTarget",
+      "files": [
+        "tests/axi_dma_tlm/TlmIndexedBurstTarget.arch"
+      ]
+    },
+    {
+      "name": "axi_dma_tlm__TlmMm2sBurstVec",
+      "files": [
+        "tests/axi_dma_tlm/TlmMm2sBurstVec.arch"
+      ]
+    },
+    {
+      "name": "axi_dma_tlm__TlmMm2sReadPair",
+      "files": [
+        "tests/axi_dma_tlm/TlmMm2sReadPair.arch"
+      ]
+    },
+    {
+      "name": "axi_dma_tlm__TlmOneToMany",
+      "files": [
+        "tests/axi_dma_tlm/TlmOneToMany.arch"
+      ]
+    },
+    {
+      "name": "axi_dma_tlm__TlmOneToManyOoo",
+      "files": [
+        "tests/axi_dma_tlm/TlmOneToManyOoo.arch"
+      ]
+    },
+    {
+      "name": "axi_dma_tlm__TlmOneToManyResp",
+      "files": [
+        "tests/axi_dma_tlm/TlmOneToManyResp.arch"
+      ]
+    },
+    {
+      "name": "axi_dma_tlm__TlmOneToOne",
+      "files": [
+        "tests/axi_dma_tlm/TlmOneToOne.arch"
+      ]
+    },
+    {
+      "name": "buf_mgr__domain",
+      "files": [
+        "tests/buf_mgr/domain.arch"
+      ]
+    },
+    {
+      "name": "buf_mgr__setup_counter",
+      "files": [
+        "tests/buf_mgr/setup_counter.arch"
+      ]
+    },
+    {
+      "name": "bus_genif_bug__BusGenIf",
+      "files": [
+        "tests/bus_genif_bug/BusGenIf.arch"
+      ]
+    },
+    {
+      "name": "cvdp__SecureRegBankPkg",
+      "files": [
+        "tests/cvdp/SecureRegBankPkg.arch"
+      ]
+    },
+    {
+      "name": "cvdp__VgaPhase",
+      "files": [
+        "tests/cvdp/VgaPhase.arch"
+      ]
+    },
+    {
+      "name": "cvdp__VgaPkg",
+      "files": [
+        "tests/cvdp/VgaPkg.arch"
+      ]
+    },
+    {
+      "name": "debug_demo",
+      "files": [
+        "tests/debug_demo/Accumulator.arch",
+        "tests/debug_demo/DmaEngine.arch"
+      ]
+    },
+    {
+      "name": "e203__e203_itcm_icb_bus",
+      "files": [
+        "tests/e203/e203_itcm_icb_bus.arch"
+      ]
+    },
+    {
+      "name": "formal__counter_bounded",
+      "files": [
+        "tests/formal/counter_bounded.arch"
+      ]
+    },
+    {
+      "name": "formal__counter_overflow",
+      "files": [
+        "tests/formal/counter_overflow.arch"
+      ]
+    },
+    {
+      "name": "formal__counter_simple",
+      "files": [
+        "tests/formal/counter_simple.arch"
+      ]
+    },
+    {
+      "name": "formal__cover_hit",
+      "files": [
+        "tests/formal/cover_hit.arch"
+      ]
+    },
+    {
+      "name": "formal__guard_fail",
+      "files": [
+        "tests/formal/guard_fail.arch"
+      ]
+    },
+    {
+      "name": "formal__guard_pass",
+      "files": [
+        "tests/formal/guard_pass.arch"
+      ]
+    },
+    {
+      "name": "formal__hier_adder_proves",
+      "files": [
+        "tests/formal/hier_adder_proves.arch"
+      ]
+    },
+    {
+      "name": "formal__hier_adder_refutes",
+      "files": [
+        "tests/formal/hier_adder_refutes.arch"
+      ]
+    },
+    {
+      "name": "formal__hier_counter_proves",
+      "files": [
+        "tests/formal/hier_counter_proves.arch"
+      ]
+    },
+    {
+      "name": "formal__hier_multi_inst_proves",
+      "files": [
+        "tests/formal/hier_multi_inst_proves.arch"
+      ]
+    },
+    {
+      "name": "formal__sva_phase2_refutes",
+      "files": [
+        "tests/formal/sva_phase2_refutes.arch"
+      ]
+    },
+    {
+      "name": "formal__sva_temporal_proves",
+      "files": [
+        "tests/formal/sva_temporal_proves.arch"
+      ]
+    },
+    {
+      "name": "formal__sva_temporal_refutes",
+      "files": [
+        "tests/formal/sva_temporal_refutes.arch"
+      ]
+    },
+    {
+      "name": "noc_credit__noc_credit",
+      "files": [
+        "tests/noc_credit/noc_credit.arch"
+      ]
+    },
+    {
+      "name": "rdc__rdc_a1_same_async_direct_ok",
+      "files": [
+        "tests/rdc/rdc_a1_same_async_direct_ok.arch"
+      ]
+    },
+    {
+      "name": "rdc__rdc_a5_sync_source_ok",
+      "files": [
+        "tests/rdc/rdc_a5_sync_source_ok.arch"
+      ]
+    },
+    {
+      "name": "rdc__rdc_e1_self_loop_same_domain_ok",
+      "files": [
+        "tests/rdc/rdc_e1_self_loop_same_domain_ok.arch"
+      ]
+    },
+    {
+      "name": "rdc__rdc_f1_single_async_domain_ok",
+      "files": [
+        "tests/rdc/rdc_f1_single_async_domain_ok.arch"
+      ]
+    },
+    {
+      "name": "rdc__rdc_f2_no_async_flops_ok",
+      "files": [
+        "tests/rdc/rdc_f2_no_async_flops_ok.arch"
+      ]
+    },
+    {
+      "name": "rdc__rdc_k3_direct_reset_at_inst_ok",
+      "files": [
+        "tests/rdc/rdc_k3_direct_reset_at_inst_ok.arch"
+      ]
+    },
+    {
+      "name": "rdc__rdc_l1_pragma_rdc_safe_suppresses_phase2a_ok",
+      "files": [
+        "tests/rdc/rdc_l1_pragma_rdc_safe_suppresses_phase2a_ok.arch"
+      ]
+    },
+    {
+      "name": "rdc__rdc_l3_pragma_rdc_safe_suppresses_phase2d_ok",
+      "files": [
+        "tests/rdc/rdc_l3_pragma_rdc_safe_suppresses_phase2d_ok.arch"
+      ]
+    },
+    {
+      "name": "rdc__rdc_l4_pragma_rdc_safe_suppresses_phase1_ok",
+      "files": [
+        "tests/rdc/rdc_l4_pragma_rdc_safe_suppresses_phase1_ok.arch"
+      ]
+    },
+    {
+      "name": "sdc__sd_clock_divider",
+      "files": [
+        "tests/sdc/sd_clock_divider.arch"
+      ]
+    },
+    {
+      "name": "sdc__sd_controller_wb",
+      "files": [
+        "tests/sdc/sd_controller_wb.arch"
+      ]
+    },
+    {
+      "name": "sdc__sd_crc_16",
+      "files": [
+        "tests/sdc/sd_crc_16.arch"
+      ]
+    },
+    {
+      "name": "sdc__sd_crc_7",
+      "files": [
+        "tests/sdc/sd_crc_7.arch"
+      ]
+    },
+    {
+      "name": "sdc__sd_data_serial_host",
+      "files": [
+        "tests/sdc/sd_data_serial_host.arch"
+      ]
+    },
+    {
+      "name": "sdc__sd_rx_fifo",
+      "files": [
+        "tests/sdc/sd_rx_fifo.arch"
+      ]
+    },
+    {
+      "name": "sdc__sd_tx_fifo",
+      "files": [
+        "tests/sdc/sd_tx_fifo.arch"
+      ]
+    },
+    {
+      "name": "tests_root",
+      "files": [
+        "tests/cam_basic.arch",
+        "tests/cam_dual_basic.arch",
+        "tests/cam_value_basic.arch",
+        "tests/if_wait_for_in_then.arch",
+        "tests/inst_vec_port_regression.arch",
+        "tests/mac_table.arch",
+        "tests/operator_precedence_test.arch",
+        "tests/operator_type_test.arch",
+        "tests/pipeline_wait_stage.arch",
+        "tests/sim_bool_not_regression.arch",
+        "tests/unpacked_port_emit.arch"
+      ]
+    },
+    {
+      "name": "thread__basic_thread",
+      "files": [
+        "tests/thread/basic_thread.arch"
+      ]
+    },
+    {
+      "name": "thread__fork_join",
+      "files": [
+        "tests/thread/fork_join.arch"
+      ]
+    },
+    {
+      "name": "thread__generate_thread",
+      "files": [
+        "tests/thread/generate_thread.arch"
+      ]
+    },
+    {
+      "name": "thread__named_thread",
+      "files": [
+        "tests/thread/named_thread.arch"
+      ]
+    },
+    {
+      "name": "thread__resource_lock",
+      "files": [
+        "tests/thread/resource_lock.arch"
+      ]
+    },
+    {
+      "name": "thread__shared_reduction",
+      "files": [
+        "tests/thread/shared_reduction.arch"
+      ]
+    },
+    {
+      "name": "thread__thread_for_loop",
+      "files": [
+        "tests/thread/thread_for_loop.arch"
+      ]
+    },
+    {
+      "name": "thread__thread_if_else",
+      "files": [
+        "tests/thread/thread_if_else.arch"
+      ]
+    },
+    {
+      "name": "thread__thread_once",
+      "files": [
+        "tests/thread/thread_once.arch"
+      ]
+    },
+    {
+      "name": "thread__wait_cycles",
+      "files": [
+        "tests/thread/wait_cycles.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob001_zero",
+      "files": [
+        "tests/verilog_eval/Prob001_zero.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob002_m2014_q4i",
+      "files": [
+        "tests/verilog_eval/Prob002_m2014_q4i.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob003_step_one",
+      "files": [
+        "tests/verilog_eval/Prob003_step_one.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob004_vector2",
+      "files": [
+        "tests/verilog_eval/Prob004_vector2.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob005_notgate",
+      "files": [
+        "tests/verilog_eval/Prob005_notgate.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob006_vectorr",
+      "files": [
+        "tests/verilog_eval/Prob006_vectorr.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob007_wire",
+      "files": [
+        "tests/verilog_eval/Prob007_wire.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob008_m2014_q4h",
+      "files": [
+        "tests/verilog_eval/Prob008_m2014_q4h.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob009_popcount3",
+      "files": [
+        "tests/verilog_eval/Prob009_popcount3.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob010_mt2015_q4a",
+      "files": [
+        "tests/verilog_eval/Prob010_mt2015_q4a.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob011_norgate",
+      "files": [
+        "tests/verilog_eval/Prob011_norgate.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob012_xnorgate",
+      "files": [
+        "tests/verilog_eval/Prob012_xnorgate.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob013_m2014_q4e",
+      "files": [
+        "tests/verilog_eval/Prob013_m2014_q4e.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob014_andgate",
+      "files": [
+        "tests/verilog_eval/Prob014_andgate.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob015_vector1",
+      "files": [
+        "tests/verilog_eval/Prob015_vector1.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob016_m2014_q4j",
+      "files": [
+        "tests/verilog_eval/Prob016_m2014_q4j.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob017_mux2to1v",
+      "files": [
+        "tests/verilog_eval/Prob017_mux2to1v.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob019_m2014_q4f",
+      "files": [
+        "tests/verilog_eval/Prob019_m2014_q4f.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob020_mt2015_eq2",
+      "files": [
+        "tests/verilog_eval/Prob020_mt2015_eq2.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob022_mux2to1",
+      "files": [
+        "tests/verilog_eval/Prob022_mux2to1.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob024_hadd",
+      "files": [
+        "tests/verilog_eval/Prob024_hadd.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob025_reduction",
+      "files": [
+        "tests/verilog_eval/Prob025_reduction.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob026_alwaysblock1",
+      "files": [
+        "tests/verilog_eval/Prob026_alwaysblock1.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob027_fadd",
+      "files": [
+        "tests/verilog_eval/Prob027_fadd.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob028_m2014_q4a",
+      "files": [
+        "tests/verilog_eval/Prob028_m2014_q4a.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob029_m2014_q4g",
+      "files": [
+        "tests/verilog_eval/Prob029_m2014_q4g.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob031_dff",
+      "files": [
+        "tests/verilog_eval/Prob031_dff.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob032_vector0",
+      "files": [
+        "tests/verilog_eval/Prob032_vector0.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob033_ece241_2014_q1c",
+      "files": [
+        "tests/verilog_eval/Prob033_ece241_2014_q1c.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob034_dff8",
+      "files": [
+        "tests/verilog_eval/Prob034_dff8.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob035_count1to10",
+      "files": [
+        "tests/verilog_eval/Prob035_count1to10.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob036_ringer",
+      "files": [
+        "tests/verilog_eval/Prob036_ringer.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob037_review2015_count1k",
+      "files": [
+        "tests/verilog_eval/Prob037_review2015_count1k.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob038_count15",
+      "files": [
+        "tests/verilog_eval/Prob038_count15.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob039_always_if",
+      "files": [
+        "tests/verilog_eval/Prob039_always_if.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob040_count10",
+      "files": [
+        "tests/verilog_eval/Prob040_count10.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob041_dff8r",
+      "files": [
+        "tests/verilog_eval/Prob041_dff8r.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob042_vector4",
+      "files": [
+        "tests/verilog_eval/Prob042_vector4.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob043_vector5",
+      "files": [
+        "tests/verilog_eval/Prob043_vector5.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob044_vectorgates",
+      "files": [
+        "tests/verilog_eval/Prob044_vectorgates.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob045_edgedetect2",
+      "files": [
+        "tests/verilog_eval/Prob045_edgedetect2.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob046_dff8p",
+      "files": [
+        "tests/verilog_eval/Prob046_dff8p.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob047_dff8ar",
+      "files": [
+        "tests/verilog_eval/Prob047_dff8ar.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob048_m2014_q4c",
+      "files": [
+        "tests/verilog_eval/Prob048_m2014_q4c.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob049_m2014_q4b",
+      "files": [
+        "tests/verilog_eval/Prob049_m2014_q4b.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob050_kmap1",
+      "files": [
+        "tests/verilog_eval/Prob050_kmap1.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob051_gates4",
+      "files": [
+        "tests/verilog_eval/Prob051_gates4.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob052_gates100",
+      "files": [
+        "tests/verilog_eval/Prob052_gates100.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob053_m2014_q4d",
+      "files": [
+        "tests/verilog_eval/Prob053_m2014_q4d.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob054_edgedetect",
+      "files": [
+        "tests/verilog_eval/Prob054_edgedetect.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob055_conditional",
+      "files": [
+        "tests/verilog_eval/Prob055_conditional.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob056_ece241_2013_q7",
+      "files": [
+        "tests/verilog_eval/Prob056_ece241_2013_q7.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob057_kmap2",
+      "files": [
+        "tests/verilog_eval/Prob057_kmap2.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob058_alwaysblock2",
+      "files": [
+        "tests/verilog_eval/Prob058_alwaysblock2.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob059_wire4",
+      "files": [
+        "tests/verilog_eval/Prob059_wire4.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob060_m2014_q4k",
+      "files": [
+        "tests/verilog_eval/Prob060_m2014_q4k.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob061_2014_q4a",
+      "files": [
+        "tests/verilog_eval/Prob061_2014_q4a.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob062_bugs_mux2",
+      "files": [
+        "tests/verilog_eval/Prob062_bugs_mux2.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob063_review2015_shiftcount",
+      "files": [
+        "tests/verilog_eval/Prob063_review2015_shiftcount.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob064_vector3",
+      "files": [
+        "tests/verilog_eval/Prob064_vector3.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob065_7420",
+      "files": [
+        "tests/verilog_eval/Prob065_7420.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob066_edgecapture",
+      "files": [
+        "tests/verilog_eval/Prob066_edgecapture.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob067_countslow",
+      "files": [
+        "tests/verilog_eval/Prob067_countslow.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob068_countbcd",
+      "files": [
+        "tests/verilog_eval/Prob068_countbcd.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob069_truthtable1",
+      "files": [
+        "tests/verilog_eval/Prob069_truthtable1.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob070_ece241_2013_q2",
+      "files": [
+        "tests/verilog_eval/Prob070_ece241_2013_q2.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob071_always_casez",
+      "files": [
+        "tests/verilog_eval/Prob071_always_casez.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob072_thermostat",
+      "files": [
+        "tests/verilog_eval/Prob072_thermostat.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob073_dff16e",
+      "files": [
+        "tests/verilog_eval/Prob073_dff16e.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob074_ece241_2014_q4",
+      "files": [
+        "tests/verilog_eval/Prob074_ece241_2014_q4.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob075_counter_2bc",
+      "files": [
+        "tests/verilog_eval/Prob075_counter_2bc.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob076_always_case",
+      "files": [
+        "tests/verilog_eval/Prob076_always_case.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob077_wire_decl",
+      "files": [
+        "tests/verilog_eval/Prob077_wire_decl.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob078_dualedge",
+      "files": [
+        "tests/verilog_eval/Prob078_dualedge.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob079_fsm3onehot",
+      "files": [
+        "tests/verilog_eval/Prob079_fsm3onehot.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob080_timer",
+      "files": [
+        "tests/verilog_eval/Prob080_timer.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob081_7458",
+      "files": [
+        "tests/verilog_eval/Prob081_7458.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob082_lfsr32",
+      "files": [
+        "tests/verilog_eval/Prob082_lfsr32.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob083_mt2015_q4b",
+      "files": [
+        "tests/verilog_eval/Prob083_mt2015_q4b.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob085_shift4",
+      "files": [
+        "tests/verilog_eval/Prob085_shift4.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob086_lfsr5",
+      "files": [
+        "tests/verilog_eval/Prob086_lfsr5.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob087_gates",
+      "files": [
+        "tests/verilog_eval/Prob087_gates.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob088_ece241_2014_q5b",
+      "files": [
+        "tests/verilog_eval/Prob088_ece241_2014_q5b.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob090_circuit1",
+      "files": [
+        "tests/verilog_eval/Prob090_circuit1.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob091_2012_q2b",
+      "files": [
+        "tests/verilog_eval/Prob091_2012_q2b.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob093_ece241_2014_q3",
+      "files": [
+        "tests/verilog_eval/Prob093_ece241_2014_q3.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob094_gatesv",
+      "files": [
+        "tests/verilog_eval/Prob094_gatesv.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob097_mux9to1v",
+      "files": [
+        "tests/verilog_eval/Prob097_mux9to1v.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob098_circuit7",
+      "files": [
+        "tests/verilog_eval/Prob098_circuit7.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob099_m2014_q6c",
+      "files": [
+        "tests/verilog_eval/Prob099_m2014_q6c.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob100_fsm3comb",
+      "files": [
+        "tests/verilog_eval/Prob100_fsm3comb.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob101_circuit4",
+      "files": [
+        "tests/verilog_eval/Prob101_circuit4.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob102_circuit3",
+      "files": [
+        "tests/verilog_eval/Prob102_circuit3.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob103_circuit2",
+      "files": [
+        "tests/verilog_eval/Prob103_circuit2.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob104_mt2015_muxdff",
+      "files": [
+        "tests/verilog_eval/Prob104_mt2015_muxdff.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob106_always_nolatches",
+      "files": [
+        "tests/verilog_eval/Prob106_always_nolatches.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob107_fsm1s",
+      "files": [
+        "tests/verilog_eval/Prob107_fsm1s.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob109_fsm1",
+      "files": [
+        "tests/verilog_eval/Prob109_fsm1.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob110_fsm2",
+      "files": [
+        "tests/verilog_eval/Prob110_fsm2.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob111_fsm2s",
+      "files": [
+        "tests/verilog_eval/Prob111_fsm2s.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob112_always_case2",
+      "files": [
+        "tests/verilog_eval/Prob112_always_case2.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob113_2012_q1g",
+      "files": [
+        "tests/verilog_eval/Prob113_2012_q1g.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob114_bugs_case",
+      "files": [
+        "tests/verilog_eval/Prob114_bugs_case.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob116_m2014_q3",
+      "files": [
+        "tests/verilog_eval/Prob116_m2014_q3.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob117_circuit9",
+      "files": [
+        "tests/verilog_eval/Prob117_circuit9.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob118_history_shift",
+      "files": [
+        "tests/verilog_eval/Prob118_history_shift.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob122_kmap4",
+      "files": [
+        "tests/verilog_eval/Prob122_kmap4.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob123_bugs_addsubz",
+      "files": [
+        "tests/verilog_eval/Prob123_bugs_addsubz.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob125_kmap3",
+      "files": [
+        "tests/verilog_eval/Prob125_kmap3.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob126_circuit6",
+      "files": [
+        "tests/verilog_eval/Prob126_circuit6.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob130_circuit5",
+      "files": [
+        "tests/verilog_eval/Prob130_circuit5.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob131_mt2015_q4",
+      "files": [
+        "tests/verilog_eval/Prob131_mt2015_q4.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob132_always_if2",
+      "files": [
+        "tests/verilog_eval/Prob132_always_if2.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob134_2014_q3c",
+      "files": [
+        "tests/verilog_eval/Prob134_2014_q3c.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob135_m2014_q6b",
+      "files": [
+        "tests/verilog_eval/Prob135_m2014_q6b.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob141_count_clock",
+      "files": [
+        "tests/verilog_eval/Prob141_count_clock.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob143_fsm_onehot",
+      "files": [
+        "tests/verilog_eval/Prob143_fsm_onehot.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob145_circuit8",
+      "files": [
+        "tests/verilog_eval/Prob145_circuit8.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob147_circuit10",
+      "files": [
+        "tests/verilog_eval/Prob147_circuit10.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob150_review2015_fsmonehot",
+      "files": [
+        "tests/verilog_eval/Prob150_review2015_fsmonehot.arch"
+      ]
+    },
+    {
+      "name": "verilog_eval__Prob153_gshare",
+      "files": [
+        "tests/verilog_eval/Prob153_gshare.arch"
+      ]
+    }
+  ]
+}

--- a/tests/arch_sim_manifest.json
+++ b/tests/arch_sim_manifest.json
@@ -1,0 +1,131 @@
+{
+  "description": "Known C++ testbench mappings for real `arch sim --tb` runs. Unit names match tools/run_arch_regression.py discovery names.",
+  "entries": [
+    {
+      "name": "cam_basic",
+      "arch_files": [
+        "tests/cam_basic.arch"
+      ],
+      "tb_files": [
+        "tests/cam_basic_tb.cpp"
+      ]
+    },
+    {
+      "name": "cam_dual_basic",
+      "arch_files": [
+        "tests/cam_dual_basic.arch"
+      ],
+      "tb_files": [
+        "tests/cam_dual_basic_tb.cpp"
+      ]
+    },
+    {
+      "name": "cam_value_basic",
+      "arch_files": [
+        "tests/cam_value_basic.arch"
+      ],
+      "tb_files": [
+        "tests/cam_value_basic_tb.cpp"
+      ]
+    },
+    {
+      "name": "if_wait_for_in_then",
+      "arch_files": [
+        "tests/if_wait_for_in_then.arch"
+      ],
+      "tb_files": [
+        "tests/if_wait_for_in_then_tb.cpp"
+      ]
+    },
+    {
+      "name": "inst_vec_port_regression",
+      "arch_files": [
+        "tests/inst_vec_port_regression.arch"
+      ],
+      "tb_files": [
+        "tests/inst_vec_port_regression_tb.cpp"
+      ]
+    },
+    {
+      "name": "mac_table",
+      "arch_files": [
+        "tests/mac_table.arch"
+      ],
+      "tb_files": [
+        "tests/mac_table_tb.cpp"
+      ]
+    },
+    {
+      "name": "pipeline_wait_stage",
+      "arch_files": [
+        "tests/pipeline_wait_stage.arch"
+      ],
+      "tb_files": [
+        "tests/tb_pipeline_wait_stage.cpp"
+      ]
+    },
+    {
+      "name": "sim_bool_not_regression",
+      "arch_files": [
+        "tests/sim_bool_not_regression.arch"
+      ],
+      "tb_files": [
+        "tests/sim_bool_not_regression_tb.cpp"
+      ]
+    },
+    {
+      "name": "thread__basic_thread",
+      "arch_files": [
+        "tests/thread/basic_thread.arch"
+      ],
+      "tb_files": [
+        "tests/thread/tb_basic_thread.cpp"
+      ]
+    },
+    {
+      "name": "axi_dma_tlm__TlmMm2sBurstVec",
+      "arch_files": [
+        "tests/axi_dma_tlm/TlmMm2sBurstVec.arch"
+      ],
+      "tb_files": [
+        "tests/axi_dma_tlm/tb_tlm_mm2s_burst_vec.cpp"
+      ]
+    },
+    {
+      "name": "axi_dma_tlm__TlmMm2sReadPair",
+      "arch_files": [
+        "tests/axi_dma_tlm/TlmMm2sReadPair.arch"
+      ],
+      "tb_files": [
+        "tests/axi_dma_tlm/tb_tlm_mm2s_read_pair.cpp"
+      ]
+    },
+    {
+      "name": "axi_dma_tlm__TlmOneToMany",
+      "arch_files": [
+        "tests/axi_dma_tlm/TlmOneToMany.arch"
+      ],
+      "tb_files": [
+        "tests/axi_dma_tlm/tb_tlm_one_to_many.cpp"
+      ]
+    },
+    {
+      "name": "axi_dma_tlm__TlmOneToManyOoo",
+      "arch_files": [
+        "tests/axi_dma_tlm/TlmOneToManyOoo.arch"
+      ],
+      "tb_files": [
+        "tests/axi_dma_tlm/tb_tlm_one_to_many_ooo.cpp"
+      ]
+    },
+    {
+      "name": "axi_dma_tlm__TlmOneToManyResp",
+      "arch_files": [
+        "tests/axi_dma_tlm/TlmOneToManyResp.arch"
+      ],
+      "tb_files": [
+        "tests/axi_dma_tlm/tb_tlm_one_to_many_resp.cpp"
+      ]
+    }
+  ]
+}

--- a/tests/cargo_test_baseline.json
+++ b/tests/cargo_test_baseline.json
@@ -1,0 +1,1425 @@
+{
+  "description": "Rust tests discovered by `cargo test -- --list` when this baseline was refreshed.",
+  "tests": [
+    {
+      "target": "tests/formal_test.rs",
+      "name": "formal_counter_bounded_proves"
+    },
+    {
+      "target": "tests/formal_test.rs",
+      "name": "formal_counter_overflow_refutes"
+    },
+    {
+      "target": "tests/formal_test.rs",
+      "name": "formal_counter_simple_proves"
+    },
+    {
+      "target": "tests/formal_test.rs",
+      "name": "formal_cover_hit"
+    },
+    {
+      "target": "tests/formal_test.rs",
+      "name": "formal_cover_not_reached"
+    },
+    {
+      "target": "tests/formal_test.rs",
+      "name": "formal_credit_channel_active_proves"
+    },
+    {
+      "target": "tests/formal_test.rs",
+      "name": "formal_credit_channel_invariant_proves"
+    },
+    {
+      "target": "tests/formal_test.rs",
+      "name": "formal_emit_smt_file"
+    },
+    {
+      "target": "tests/formal_test.rs",
+      "name": "formal_guard_fail"
+    },
+    {
+      "target": "tests/formal_test.rs",
+      "name": "formal_guard_pass"
+    },
+    {
+      "target": "tests/formal_test.rs",
+      "name": "formal_hier_adder_proves"
+    },
+    {
+      "target": "tests/formal_test.rs",
+      "name": "formal_hier_adder_refutes"
+    },
+    {
+      "target": "tests/formal_test.rs",
+      "name": "formal_hier_counter_proves"
+    },
+    {
+      "target": "tests/formal_test.rs",
+      "name": "formal_hier_multi_inst_proves"
+    },
+    {
+      "target": "tests/formal_test.rs",
+      "name": "formal_solver_parity_bitwuzla"
+    },
+    {
+      "target": "tests/formal_test.rs",
+      "name": "formal_solver_parity_boolector"
+    },
+    {
+      "target": "tests/formal_test.rs",
+      "name": "formal_sva_phase2_proves"
+    },
+    {
+      "target": "tests/formal_test.rs",
+      "name": "formal_sva_phase2_refutes"
+    },
+    {
+      "target": "tests/formal_test.rs",
+      "name": "formal_sva_temporal_proves"
+    },
+    {
+      "target": "tests/formal_test.rs",
+      "name": "formal_sva_temporal_refutes"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "package_enum_typed_param_emits_typedef_before_localparam"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "package_width_qualified_param_emits_bracket_form"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "rdc_a1_same_async_direct_ok"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "rdc_a2_diff_async_direct_fails"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "rdc_a3_async_to_sync_fails"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "rdc_a4_async_to_none_fails"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "rdc_a5_sync_source_ok"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "rdc_b1_async_none_async_diff_fails"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "rdc_b2_async_none_async_same_fails"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "rdc_b3_async_sync_async_diff_fails"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "rdc_c1_two_async_converge_at_none_fails"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "rdc_c2_two_same_domain_converge_fails"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "rdc_c3_async_plus_port_at_none_fails"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "rdc_d1_same_async_two_clocks_no_data_path_phase1_flags"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "rdc_d2_diff_async_diff_clocks_with_path_fails"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "rdc_e1_self_loop_same_domain_ok"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "rdc_e2_mutual_feedback_diff_domains_fails"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "rdc_f1_single_async_domain_ok"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "rdc_f2_no_async_flops_ok"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "rdc_g1_clkgate_enable_from_async_flop_fails"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "rdc_g2_clkgate_enable_from_port_ok"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "rdc_g3_clkgate_enable_from_sync_flop_ok"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "rdc_h1_reconvergent_two_syncs_same_domain_fails"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "rdc_h2_single_reset_sync_ok"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "rdc_h3_reset_syncs_to_diff_domains_ok"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "rdc_h4_reconvergent_three_syncs_same_domain_fails"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "rdc_j1_cdc_reconvergent_two_ff_syncs_same_domain_fails"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "rdc_j2_cdc_single_ff_sync_ok"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "rdc_j3_cdc_syncs_to_diff_domains_ok"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "rdc_j4_mixed_reset_and_data_sync_same_source_fails"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "rdc_k1_combiner_or_at_inst_fails"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "rdc_k2_negation_at_inst_fails"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "rdc_k3_direct_reset_at_inst_ok"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "rdc_k4_sync_output_to_reset_ok"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "rdc_l1_pragma_rdc_safe_suppresses_phase2a"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "rdc_l2_pragma_rdc_safe_suppresses_phase2c"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "rdc_l3_pragma_rdc_safe_suppresses_phase2d"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "rdc_l4_pragma_rdc_safe_suppresses_phase1"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "rdc_l5_unknown_pragma_rejected"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "rdc_m1_cdc_bit_slice_same_source_fails"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "rdc_m2_cdc_part_select_same_source_fails"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "rdc_m3_cdc_common_source_via_comb_fails"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "rdc_m4_cdc_let_alias_same_source_fails"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "rdc_m5_cdc_distinct_sources_ok"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "rdc_m6_cdc_bit_slice_distinct_vecs_ok"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "rdc_reset_type_cast_at_inst_is_direct_reset_ok"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_active_low_reset"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_arbiter_custom_hook"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_arbiter_custom_hook_missing_error"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_arbiter_latency2"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_archi_interface_stub_for_fsm_skips_body_only_passes"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_archi_interface_stub_skips_body_only_passes"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_async_fifo"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_auto_thread_asserts_active_high_reset"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_auto_thread_asserts_fork_join_branches"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_auto_thread_asserts_off_by_default"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_auto_thread_asserts_wait_cycles_and_until"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_axi_dma_tlm_burst_vec_example_compiles"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_axi_dma_tlm_indexed_burst_target_example_compiles"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_axi_dma_tlm_read_pair_example_compiles"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_bus_arbiter"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_bus_declaration_inside_package_parses"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_bus_port_connected_via_per_field_bindings_no_warning"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_bus_port_unconnected_still_warns"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_bus_wire_sv_flattens_to_individual_signals"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_bus_wire_typechecks_and_codegens"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_cc_dispatch_rewrites_seq_match_scrutinee"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_clog2_in_type_args"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_comb_for_loop_body_type_checked_as_comb"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_connect_indexed_member"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_counter_runtime_max_port"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_cpu_pipeline"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_credit_channel_can_send_default_is_combinational"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_credit_channel_can_send_method_dispatch"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_credit_channel_can_send_registered_emits_flop"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_credit_channel_emits_sender_counter_state"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_credit_channel_emits_target_fifo"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_credit_channel_end_to_end_noc_producer_consumer"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_credit_channel_mismatched_closing_keyword_errors"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_credit_channel_no_counter_on_receive_role"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_credit_channel_no_target_fifo_on_send_role"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_credit_channel_parses_as_bus_sub_construct"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_credit_channel_pop_sugar"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_credit_channel_send_sugar"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_credit_channel_sim_emits_receiver_state"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_credit_channel_sim_emits_sender_state"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_credit_channel_tier2_receiver_assertion"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_credit_channel_tier2_sender_assertions"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_credit_channel_valid_and_data_method_dispatch_on_receiver"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_credit_channel_wires_flatten_at_bus_port"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_credit_channel_wires_flip_on_target_perspective"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_doc_above_port_silently_ignored"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_doc_above_reg_wire_inst_silently_ignored"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_doc_inner_attaches_to_module"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_doc_outer_attaches_to_module"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_doc_outer_on_bus_synchronizer_clkgate"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_doc_outer_on_counter"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_doc_outer_on_struct_enum_function"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_doc_outer_on_use_decl"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_fifo_missing_port_errors"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_file_inner_doc_and_frontmatter"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_find_first_destructure_basic"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_find_first_partial_destructure"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_find_first_unknown_binding_errors"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_four_slashes_dropped_as_regular_comment"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_fsm_missing_default_state_errors"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_fsm_sint_uses_arithmetic_shift"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_fsm_traffic_light"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_fsm_use_non_package_does_not_emit_import"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_fsm_use_package_emits_sv_import"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_generate_for"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_generate_if_false_excludes_port"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_generate_if_inst_override_disables_port"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_generate_if_inst_override_enables_port"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_generate_if_param_comparison"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_generate_if_param_default_true"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_generate_if_param_zero_excludes_port"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_generate_if_true"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_generate_monomorphize_different_port_lists"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_generate_monomorphize_two_variants"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_handshake_all_variants_parse"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_handshake_channel_no_deprecation_warning"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_handshake_channel_parses_new_keyword"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_handshake_generate_if_nested_in_bus_genif_errors"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_handshake_generate_if_payload_toggle"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_handshake_legacy_keyword_emits_deprecation_warning"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_handshake_mismatched_closing_keyword_errors"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_handshake_payload_guard_via_short_circuit_and"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_handshake_payload_guard_via_ternary_condition"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_handshake_payload_truly_unguarded_still_warns"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_handshake_target_flip"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_handshake_tier15_else_branch_warns"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_handshake_tier15_guard_via_compound_and_silent"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_handshake_tier15_guarded_payload_silent"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_handshake_tier15_payload_warning_gated_on_valid"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_handshake_tier15_req_ack_4phase_uses_req_as_guard"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_handshake_tier15_req_ack_uses_req_as_guard"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_handshake_tier15_unguarded_payload_warns"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_handshake_tier2_multiple_variants"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_handshake_tier2_no_clock_no_assertions"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_handshake_tier2_valid_ready_assertion"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_handshake_valid_ready_expansion"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_if_wait_both_branches"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_if_wait_else_only"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_if_wait_for_in_then_branch"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_if_wait_nested"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_if_wait_then_only"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_if_wait_with_auto_asserts"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_implement_initiator_multi_implementer_rejected"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_implement_initiator_parses"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_implement_initiator_single_compiles_end_to_end"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_implement_initiator_with_args_in_parens_errors"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_implement_target_multi_implementer_rejected"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_implement_target_parses"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_implement_target_single_compiles_end_to_end"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_implicit_truncation_is_error"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_implies_next_outside_assert_rejected"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_inner_doc_inside_body_silently_ignored"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_inner_doc_on_counter_and_arbiter"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_inputs_start_uninit_bus_flattened"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_inputs_start_uninit_bus_skips_output_direction"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_inputs_start_uninit_without_flag_emits_nothing"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_inst_site_type_param_override_translates_to_data_width"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_int_regs"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_let_bindings"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_let_destructure_basic"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_let_destructure_non_struct_errors"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_let_destructure_partial"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_let_destructure_unknown_field_errors"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_lifo"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_lifo_async_error"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_linklist_basic_compiles"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_linklist_doubly_compiles"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_linklist_inst_in_module"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_linklist_multi_head_compiles"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_linklist_multi_head_full_ops_sim_shape"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_linklist_multi_head_full_ops_sv_shape"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_linklist_multi_head_rejects_missing_head_idx"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_linklist_multi_head_sim_shape"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_linklist_prev_on_singly_is_error"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_linklist_single_head_rejects_stray_head_idx"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_lte_in_expression_contexts"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_mixed_reset_and_no_reset"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_package_nested_bus_used_as_wire_and_port"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_past_arity_errors"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_past_n_must_be_positive_const"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_past_outside_assert_rejected"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_phase2_fell_emits_dollar_fell"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_phase2_hashhash_emits_sva_delay"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_phase2_hashhash_outside_assert_rejected"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_phase2_rose_emits_dollar_rose"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_phase2_rose_outside_assert_rejected"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_pipe_reg"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_pipe_reg_depth_zero_errors"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_pipe_reg_port_bare_assign_ambiguous_errors"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_pipe_reg_port_depth_mismatch_errors"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_pipe_reg_port_n1_equivalent_to_port_reg"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_pipe_reg_port_n3_emits_cascade"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_pipe_reg_port_no_deprecation_warning"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_pipe_reg_tap_out_of_range_errors"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_pipe_reg_tap_reads_q_at_k"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_pipeline_bad_flush_target_error"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_pipeline_comb_only_stage_error"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_pipeline_cross_stage_skip_rejected"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_pipeline_flush_clear_emits_data_reset"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_pipeline_forward_reference_allowed"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_pipeline_instantiation"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_pipeline_stage_inst"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_port_reg_deprecation_warning_fires"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_pybind_struct_bindings_are_scoped_to_module"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_pybind_struct_bindings_transitive_closure"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_ram_missing_port_group_errors"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_rdc_clean_two_resets_per_domain"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_rdc_single_domain_no_violation"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_rdc_violation_one_reset_two_domains"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_real_fsm_still_requires_default_state"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_reentrant_thread_parses_with_max"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_reentrant_thread_parses_without_max"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_reentrant_thread_rejected_in_lower_threads"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_regfile_flop_default_unchanged"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_regfile_latch_emits_always_latch_per_row"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_regfile_latch_external_sim_codegen_uses_comb_latch"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_regfile_latch_internal_emits_sample_flops_and_gated_latches"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_regfile_latch_internal_sim_codegen_emits_sample_flops_and_gated_capture"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_regfile_latch_internal_skips_flop_source_check"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_regfile_latch_rejects_let_source"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_reset_consistency_error_mixed_signals"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_reset_consistency_error_mixed_sync_async"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_reset_only_reg_alongside_seq_block"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_reset_only_reg_is_driven"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_resource_lock_custom_policy_with_hook"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_resource_lock_priority_default"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_resource_lock_round_robin"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_return_in_regular_thread_errors_in_lower_threads"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_rom_lut"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_seq_for_loop_bare_assign_rejected"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_seq_for_loop_indexed_assign_allowed"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_sim_codegen_async_reset_fires_outside_rising_edge"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_sim_codegen_bit_slice_lhs_compiles_and_uses_param_width"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_sim_codegen_collect_assigns_walks_indexed_lhs"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_sim_codegen_comb_match_arm_recurses_into_nested_for"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_simple_dual_ram"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_simple_pipeline"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_single_port_ram"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_stdlib_bus_apb_discovery_apb3_minimal"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_stdlib_bus_axi_stream_discovery"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_stdlib_disabled_via_env"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_struct_and_enum"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_struct_literal_concat_sizes_field_literals"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_struct_packed_declaration_first_is_msb"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_struct_vec_field_sim_mirror_uses_array_field"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_sync_fifo"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_template_basic"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_template_missing_port_error"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_temporal_sva_implies_next_emits_pipe_arrow"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_temporal_sva_past_emits_dollar_past"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_thread_inter_yield_seq_assigns_get_dead_skid"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_tlm_call_rejected_outside_seq_assign_rhs"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_tlm_canonical_end_to_end_initiator_plus_target"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_tlm_cohort_multi_arg_method"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_tlm_fork_join_workers_share_method"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_tlm_generate_for_workers_share_method"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_tlm_indexed_target_generate_for_lowers_tag_lanes"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_tlm_initiator_call_site_end_to_end_sv"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_tlm_initiator_sim_mirror_works"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_tlm_method_out_of_order_tags_parse_and_flatten"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_tlm_method_parses_as_bus_sub_construct"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_tlm_method_target_perspective_flips"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_tlm_method_unsupported_modes_rejected"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_tlm_method_void_omits_rsp_data"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_tlm_method_wires_flatten_at_bus_port"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_tlm_multi_thread_direct_calls_lower_to_in_order_pool"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_tlm_one_initiator_many_targets_ooo_router_arch_sim_behavior"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_tlm_one_initiator_many_targets_ooo_router_example_compiles"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_tlm_one_initiator_many_targets_response_router_arch_sim_behavior"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_tlm_one_initiator_many_targets_response_router_example_compiles"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_tlm_one_initiator_many_targets_router_arch_sim_behavior"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_tlm_one_initiator_many_targets_router_example_compiles"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_tlm_ooo_protocol_asserts_track_tags"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_tlm_out_of_order_fork_join_routes_by_tag"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_tlm_out_of_order_target_echoes_tag"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_tlm_rhs_fork_join_all_workers_share_method"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_tlm_rhs_fork_out_of_order_routes_by_tag"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_tlm_rhs_fork_requires_join_all"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_tlm_struct_vec_response_sim_mirror_compiles_shape"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_tlm_target_sim_mirror_works_via_inlined_state_machine"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_tlm_target_thread_accepts_matched_closing_method_name"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_tlm_target_thread_lowers_inline_to_state_machine"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_tlm_target_thread_parses_return_stmt"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_tlm_target_thread_parses_with_dotted_name"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_tlm_unsupported_fork_join_call_errors"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_tlm_vec_return_sim_mirror_uses_array_copy"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_todo_placeholder"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_top_counter_compiles"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_trace_skips_struct_typed_let_and_wire"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_trunc_bit_range"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_typecheck_branch_aware_driven_tracking_in_comb"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_uint_as_vec_cast_for_find_first"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_unpacked_on_non_vec_is_rejected"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_unpacked_on_port_reg_is_rejected"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_unpacked_port_emits_unpacked_sv_shape"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_unpacked_wire_modifier_emits_unpacked_sv"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_unpacked_wire_rejected_on_non_vec"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_use_bus_does_not_emit_sv_import"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_use_package_still_emits_sv_import"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_vec_methods_any_all_expand_to_reduction"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_vec_methods_count_and_contains"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_vec_methods_index_binder"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_vec_methods_reduce_or_and_xor"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_vec_of_const_param_emits_packed_and_indexes"
+    },
+    {
+      "target": "tests/integration_test.rs",
+      "name": "test_wrap_counter"
+    },
+    {
+      "target": "unittests src/lib.rs",
+      "name": "learn::tests::classify_examples"
+    },
+    {
+      "target": "unittests src/lib.rs",
+      "name": "learn::tests::event_roundtrip"
+    },
+    {
+      "target": "unittests src/lib.rs",
+      "name": "learn::tests::purge_features_keeps_unrelated_events"
+    },
+    {
+      "target": "unittests src/lib.rs",
+      "name": "learn::tests::tokenize_basic"
+    },
+    {
+      "target": "unittests src/lib.rs",
+      "name": "lexer::tests::test_basic_tokens"
+    },
+    {
+      "target": "unittests src/lib.rs",
+      "name": "lexer::tests::test_comments_skipped"
+    },
+    {
+      "target": "unittests src/lib.rs",
+      "name": "lexer::tests::test_doc_inner_token"
+    },
+    {
+      "target": "unittests src/lib.rs",
+      "name": "lexer::tests::test_doc_outer_attaches_to_construct"
+    },
+    {
+      "target": "unittests src/lib.rs",
+      "name": "lexer::tests::test_doc_outer_strips_one_leading_space"
+    },
+    {
+      "target": "unittests src/lib.rs",
+      "name": "lexer::tests::test_four_slashes_is_regular_comment"
+    },
+    {
+      "target": "unittests src/lib.rs",
+      "name": "lexer::tests::test_literals"
+    },
+    {
+      "target": "unittests src/lib.rs",
+      "name": "lexer::tests::test_operators"
+    },
+    {
+      "target": "unittests src/lib.rs",
+      "name": "lexer::tests::test_todo"
+    },
+    {
+      "target": "unittests src/lib.rs",
+      "name": "lexer::tests::test_two_slashes_remains_skipped"
+    },
+    {
+      "target": "unittests src/lib.rs",
+      "name": "lexer::tests::test_type_keywords"
+    },
+    {
+      "target": "unittests src/lib.rs",
+      "name": "parser::tests::test_mismatched_closing"
+    },
+    {
+      "target": "unittests src/lib.rs",
+      "name": "parser::tests::test_parse_domain"
+    },
+    {
+      "target": "unittests src/lib.rs",
+      "name": "parser::tests::test_parse_enum"
+    },
+    {
+      "target": "unittests src/lib.rs",
+      "name": "parser::tests::test_parse_expr_arithmetic"
+    },
+    {
+      "target": "unittests src/lib.rs",
+      "name": "parser::tests::test_parse_simple_module"
+    },
+    {
+      "target": "unittests src/lib.rs",
+      "name": "parser::tests::test_parse_struct"
+    },
+    {
+      "target": "unittests src/lib.rs",
+      "name": "width::tests::clog2_edge_cases"
+    },
+    {
+      "target": "unittests src/lib.rs",
+      "name": "width::tests::index_width_floors_at_1"
+    },
+    {
+      "target": "unittests src/lib.rs",
+      "name": "width::tests::matches_float_log2_ceil_for_n_geq_2"
+    }
+  ]
+}

--- a/tools/run_arch_regression.py
+++ b/tools/run_arch_regression.py
@@ -1,0 +1,597 @@
+#!/usr/bin/env python3
+"""Run broad ARCH compiler regression checks over tests/*.arch.
+
+The runner treats "passing .arch files" as sources that pass `arch check`.
+For each passing unit it runs:
+
+  1. `arch build` to emit SystemVerilog
+  2. Verilator lint on the emitted SystemVerilog
+  3. `arch sim` with a real C++ TB when mapped in the sim manifest, otherwise
+     `arch sim` model generation plus a generated C++ smoke compile
+
+`arch build` writes `.archi` files next to inputs, so this script copies the
+test tree into a scratch work directory before invoking the compiler.
+"""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import dataclasses
+import fnmatch
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from typing import Iterable
+
+
+DEFAULT_VERILATOR_FLAGS = [
+    "--lint-only",
+    "--sv",
+    "--assert",
+    "--timing",
+    "-Wno-fatal",
+    "-Wno-DECLFILENAME",
+    "-Wno-UNUSEDSIGNAL",
+    "-Wno-UNUSEDPARAM",
+    "-Wno-BLKANDNBLK",
+    "-Wno-CASEINCOMPLETE",
+    "-Wno-WIDTH",
+]
+
+
+@dataclasses.dataclass(frozen=True)
+class Unit:
+    name: str
+    files: tuple[Path, ...]
+    original_files: tuple[Path, ...]
+
+
+@dataclasses.dataclass
+class StepResult:
+    name: str
+    status: str
+    seconds: float
+    command: list[str]
+    stdout: str = ""
+    stderr: str = ""
+
+
+@dataclasses.dataclass
+class UnitResult:
+    name: str
+    files: list[str]
+    status: str
+    seconds: float
+    steps: list[StepResult]
+
+
+@dataclasses.dataclass(frozen=True)
+class SimManifestEntry:
+    name: str
+    arch_files: tuple[Path, ...]
+    tb_files: tuple[Path, ...]
+    args: tuple[str, ...] = ()
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def run_cmd(
+    command: list[str],
+    cwd: Path,
+    timeout: float | None,
+    log_dir: Path,
+    step_name: str,
+) -> StepResult:
+    start = time.monotonic()
+    try:
+        proc = subprocess.run(
+            command,
+            cwd=cwd,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=timeout,
+        )
+        status = "pass" if proc.returncode == 0 else "fail"
+        stdout = proc.stdout
+        stderr = proc.stderr
+    except subprocess.TimeoutExpired as exc:
+        status = "timeout"
+        stdout = exc.stdout or ""
+        stderr = exc.stderr or ""
+    seconds = time.monotonic() - start
+
+    log_dir.mkdir(parents=True, exist_ok=True)
+    (log_dir / f"{step_name}.cmd").write_text(" ".join(command) + "\n")
+    (log_dir / f"{step_name}.stdout").write_text(stdout)
+    (log_dir / f"{step_name}.stderr").write_text(stderr)
+    return StepResult(step_name, status, seconds, command, stdout, stderr)
+
+
+def ensure_arch_bin(root: Path, explicit: str | None, release: bool) -> Path:
+    if explicit:
+        arch_bin = Path(explicit).expanduser()
+        if not arch_bin.exists():
+            raise SystemExit(f"--arch-bin does not exist: {arch_bin}")
+        return arch_bin.resolve()
+
+    profile = "release" if release else "debug"
+    arch_bin = root / "target" / profile / "arch"
+    if arch_bin.exists():
+        return arch_bin
+
+    cargo_cmd = ["cargo", "build"]
+    if release:
+        cargo_cmd.append("--release")
+    print(f"[setup] building compiler: {' '.join(cargo_cmd)}", flush=True)
+    subprocess.run(cargo_cmd, cwd=root, check=True)
+    return arch_bin
+
+
+def copy_tests_tree(root: Path, work_dir: Path, tests_dir: Path) -> Path:
+    source = root / tests_dir
+    copied = work_dir / "src" / tests_dir
+    if copied.exists():
+        shutil.rmtree(copied)
+    copied.parent.mkdir(parents=True, exist_ok=True)
+
+    def ignore(_dir: str, names: list[str]) -> set[str]:
+        return {
+            name
+            for name in names
+            if name in {"obj_dir", "sim_build", "arch_sim_build", "__pycache__"}
+            or name.endswith(".archi")
+            or name.endswith(".vcd")
+            or name.endswith(".fst")
+        }
+
+    shutil.copytree(source, copied, ignore=ignore)
+    return copied
+
+
+def safe_unit_name(path: Path) -> str:
+    if str(path) in {"", "."}:
+        return "tests_root"
+    raw = "__".join(path.parts)
+    return "".join(ch if ch.isalnum() or ch in "._-" else "_" for ch in raw)
+
+
+def rel_tuple(paths: Iterable[Path], base: Path) -> tuple[Path, ...]:
+    return tuple(sorted(p.relative_to(base) for p in paths))
+
+
+def matches_any(path: Path, patterns: list[str]) -> bool:
+    text = path.as_posix()
+    return any(fnmatch.fnmatch(text, pat) for pat in patterns)
+
+
+def discover_units(
+    arch_bin: Path,
+    root: Path,
+    copied_tests: Path,
+    original_tests: Path,
+    patterns: list[str],
+    timeout: float | None,
+    logs_root: Path,
+    no_group_dirs: bool,
+) -> tuple[list[Unit], list[UnitResult]]:
+    all_arch = sorted(copied_tests.rglob("*.arch"))
+    if patterns:
+        all_arch = [p for p in all_arch if matches_any(p.relative_to(copied_tests), patterns)]
+
+    by_dir: dict[Path, list[Path]] = {}
+    for path in all_arch:
+        by_dir.setdefault(path.parent, []).append(path)
+
+    units: list[Unit] = []
+    skipped: list[UnitResult] = []
+
+    for directory, files in sorted(by_dir.items()):
+        rel_dir = directory.relative_to(copied_tests)
+        if len(files) > 1 and not no_group_dirs:
+            log_dir = logs_root / "_discover" / safe_unit_name(rel_dir)
+            cmd = [str(arch_bin), "check", *[str(p) for p in sorted(files)]]
+            step = run_cmd(cmd, root, timeout, log_dir, "check_group")
+            if step.status == "pass":
+                rel_files = rel_tuple(files, copied_tests)
+                orig = tuple(original_tests / p for p in rel_files)
+                units.append(Unit(safe_unit_name(rel_dir), tuple(sorted(files)), orig))
+                continue
+
+        for path in sorted(files):
+            rel = path.relative_to(copied_tests)
+            orig = original_tests / rel
+            units.append(Unit(safe_unit_name(rel.with_suffix("")), (path,), (orig,)))
+
+    return units, skipped
+
+
+def write_sim_smoke_tb(sim_dir: Path) -> Path | None:
+    headers = sorted(
+        p for p in sim_dir.glob("V*.h")
+        if p.name not in {"VStructs.h"} and not p.name.startswith("verilated")
+    )
+    if not headers:
+        return None
+
+    lines = [
+        "#include <cstdint>",
+        "",
+    ]
+    for header in headers:
+        lines.append(f'#include "{header.name}"')
+    lines.extend(["", "int main() {"])
+    for idx, header in enumerate(headers):
+        cls = header.stem
+        lines.append(f"  {cls} dut_{idx};")
+        lines.append(f"  dut_{idx}.eval();")
+    lines.extend(["  return 0;", "}", ""])
+
+    tb = sim_dir / "__arch_sim_smoke_tb.cpp"
+    tb.write_text("\n".join(lines))
+    return tb
+
+
+def compile_sim_smoke(sim_dir: Path, log_dir: Path, timeout: float | None) -> StepResult:
+    tb = write_sim_smoke_tb(sim_dir)
+    if tb is None:
+        return StepResult("sim_compile", "skip", 0.0, [], "", "no generated V*.h headers\n")
+
+    cpp_files = [sim_dir / "verilated.cpp", *sorted(sim_dir.glob("V*.cpp")), tb]
+    cmd = [
+        "g++",
+        "-std=c++17",
+        "-O0",
+        "-fbracket-depth=4096",
+        "-Wno-unused-variable",
+        "-Wno-unused-parameter",
+        "-Wno-parentheses-equality",
+        "-I",
+        str(sim_dir),
+        *[str(p) for p in cpp_files if p.exists()],
+        "-o",
+        str(sim_dir / "sim_smoke"),
+    ]
+    return run_cmd(cmd, sim_dir, timeout, log_dir, "sim_compile")
+
+
+def sv_has_module(path: Path) -> bool:
+    text = path.read_text(errors="ignore")
+    return re.search(r"(?m)^\s*module\s+\w+", text) is not None
+
+
+def sibling_sv_deps(unit: Unit) -> list[Path]:
+    """Existing same-directory SV files needed to lint standalone ARCH tops.
+
+    Some legacy tests keep submodules as checked-in `.sv` while only the top is
+    represented as `.arch`. Exclude stems generated by this unit to avoid module
+    redefinition when the unit itself contains the matching ARCH source.
+    """
+    generated_stems = {path.stem for path in unit.files}
+    deps: set[Path] = set()
+    for arch_file in unit.files:
+        for sv in arch_file.parent.glob("*.sv"):
+            if sv.stem not in generated_stems:
+                deps.add(sv)
+    return sorted(deps)
+
+
+def load_baseline(path: Path) -> set[str]:
+    data = json.loads(path.read_text())
+    units = data.get("units", data if isinstance(data, list) else [])
+    names: set[str] = set()
+    for item in units:
+        if isinstance(item, str):
+            names.add(item)
+        elif isinstance(item, dict) and "name" in item:
+            names.add(str(item["name"]))
+    return names
+
+
+def resolve_scratch_path(root: Path, scratch_root: Path, rel_path: str) -> Path:
+    path = Path(rel_path)
+    if path.is_absolute():
+        return path
+    scratch_path = scratch_root / path
+    if scratch_path.exists():
+        return scratch_path
+    return root / path
+
+
+def load_sim_manifest(path: Path | None, root: Path, scratch_root: Path) -> dict[str, SimManifestEntry]:
+    if path is None:
+        return {}
+    manifest_path = path if path.is_absolute() else root / path
+    if not manifest_path.exists():
+        return {}
+    data = json.loads(manifest_path.read_text())
+    entries = data.get("entries", data if isinstance(data, list) else [])
+    manifest: dict[str, SimManifestEntry] = {}
+    for item in entries:
+        name = str(item["name"])
+        arch_files = tuple(resolve_scratch_path(root, scratch_root, str(p)) for p in item.get("arch_files", []))
+        tb_files = tuple(resolve_scratch_path(root, scratch_root, str(p)) for p in item.get("tb_files", []))
+        args = tuple(str(arg) for arg in item.get("args", []))
+        manifest[name] = SimManifestEntry(name, arch_files, tb_files, args)
+    return manifest
+
+
+def write_baseline(path: Path, results: list[UnitResult]) -> None:
+    root = repo_root()
+
+    def portable_files(files: list[str]) -> list[str]:
+        portable: list[str] = []
+        for file in files:
+            file_path = Path(file)
+            try:
+                portable.append(str(file_path.resolve().relative_to(root)))
+            except ValueError:
+                portable.append(file)
+        return portable
+
+    passing = [
+        {
+            "name": result.name,
+            "files": portable_files(result.files),
+        }
+        for result in sorted(results, key=lambda r: r.name)
+        if result.status == "pass"
+    ]
+    payload = {
+        "description": "ARCH regression units that passed check/build/verilator/arch-sim smoke when this baseline was refreshed.",
+        "units": passing,
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n")
+
+
+def run_unit(
+    unit: Unit,
+    arch_bin: Path,
+    root: Path,
+    work_dir: Path,
+    timeout: float | None,
+    verilator_flags: list[str],
+    skip_verilator: bool,
+    skip_sim: bool,
+    skip_sim_compile: bool,
+    sim_manifest: dict[str, SimManifestEntry],
+) -> UnitResult:
+    start = time.monotonic()
+    unit_dir = work_dir / "units" / unit.name
+    log_dir = unit_dir / "logs"
+    unit_dir.mkdir(parents=True, exist_ok=True)
+
+    steps: list[StepResult] = []
+    files = [str(p) for p in unit.files]
+
+    check = run_cmd([str(arch_bin), "check", *files], root, timeout, log_dir, "check")
+    steps.append(check)
+    if check.status != "pass":
+        return UnitResult(unit.name, [str(p) for p in unit.original_files], "skip_check_failed", time.monotonic() - start, steps)
+
+    sv_out = unit_dir / f"{unit.name}.sv"
+    build = run_cmd([str(arch_bin), "build", *files, "-o", str(sv_out)], root, timeout, log_dir, "build")
+    steps.append(build)
+    if build.status != "pass":
+        return UnitResult(unit.name, [str(p) for p in unit.original_files], "fail", time.monotonic() - start, steps)
+
+    has_module = sv_has_module(sv_out)
+    if not skip_verilator:
+        if has_module:
+            vl = run_cmd(
+                ["verilator", *verilator_flags, str(sv_out), *[str(p) for p in sibling_sv_deps(unit)]],
+                root,
+                timeout,
+                log_dir,
+                "verilator_lint",
+            )
+        else:
+            vl = StepResult("verilator_lint", "skip", 0.0, [], "", "generated SV has no module declarations\n")
+        steps.append(vl)
+        if vl.status not in {"pass", "skip"}:
+            return UnitResult(unit.name, [str(p) for p in unit.original_files], "fail", time.monotonic() - start, steps)
+
+    if not skip_sim:
+        if has_module:
+            sim_dir = unit_dir / "arch_sim"
+            manifest_entry = sim_manifest.get(unit.name)
+            if manifest_entry is not None:
+                sim_cmd = [
+                    str(arch_bin),
+                    "sim",
+                    *[str(path) for path in manifest_entry.arch_files],
+                    "--tb",
+                    *[str(path) for path in manifest_entry.tb_files],
+                    "--outdir",
+                    str(sim_dir),
+                    *manifest_entry.args,
+                ]
+            else:
+                sim_cmd = [str(arch_bin), "sim", *files, "--outdir", str(sim_dir)]
+            sim = run_cmd(sim_cmd, root, timeout, log_dir, "arch_sim")
+            steps.append(sim)
+            if sim.status != "pass":
+                return UnitResult(unit.name, [str(p) for p in unit.original_files], "fail", time.monotonic() - start, steps)
+
+            if manifest_entry is None and not skip_sim_compile:
+                sim_compile = compile_sim_smoke(sim_dir, log_dir, timeout)
+                steps.append(sim_compile)
+                if sim_compile.status not in {"pass", "skip"}:
+                    return UnitResult(unit.name, [str(p) for p in unit.original_files], "fail", time.monotonic() - start, steps)
+        else:
+            steps.append(StepResult("arch_sim", "skip", 0.0, [], "", "generated SV has no module declarations\n"))
+
+    return UnitResult(unit.name, [str(p) for p in unit.original_files], "pass", time.monotonic() - start, steps)
+
+
+def result_to_json(result: UnitResult) -> dict:
+    return {
+        "name": result.name,
+        "files": result.files,
+        "status": result.status,
+        "seconds": result.seconds,
+        "steps": [
+            {
+                "name": step.name,
+                "status": step.status,
+                "seconds": step.seconds,
+                "command": step.command,
+            }
+            for step in result.steps
+        ],
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--arch-bin", help="Path to an existing arch binary. Defaults to target/debug/arch, building it if needed.")
+    parser.add_argument("--release", action="store_true", help="Use/build target/release/arch by default.")
+    parser.add_argument("--tests-dir", default="tests", type=Path, help="Tests tree to scan, relative to the repo root.")
+    parser.add_argument("--work-dir", type=Path, help="Scratch directory. Defaults to a new /tmp directory.")
+    parser.add_argument("--pattern", action="append", default=[], help="Only run units whose tests-dir-relative path matches this glob. Repeatable.")
+    parser.add_argument("--jobs", type=int, default=max(1, min(4, (os.cpu_count() or 2) // 2)), help="Number of units to run concurrently.")
+    parser.add_argument("--timeout", type=float, default=120.0, help="Per-step timeout in seconds. Use 0 for no timeout.")
+    parser.add_argument("--limit", type=int, help="Run at most N discovered units.")
+    parser.add_argument("--list", action="store_true", help="List discovered units and exit after check-based grouping.")
+    parser.add_argument("--baseline", type=Path, help="Run only unit names listed in a JSON baseline.")
+    parser.add_argument("--update-baseline", type=Path, help="Write a JSON baseline containing units that passed this run.")
+    parser.add_argument("--sim-manifest", type=Path, default=Path("tests/arch_sim_manifest.json"), help="JSON manifest mapping unit names to C++ arch-sim testbenches.")
+    parser.add_argument("--allow-failures", action="store_true", help="Exit 0 even if backend failures are found. Useful when refreshing a baseline.")
+    parser.add_argument("--no-group-dirs", action="store_true", help="Do not collapse directories whose .arch files pass together into one unit.")
+    parser.add_argument("--skip-verilator", action="store_true", help="Skip Verilator lint.")
+    parser.add_argument("--skip-sim", action="store_true", help="Skip arch sim model generation.")
+    parser.add_argument("--skip-sim-compile", action="store_true", help="Skip generated C++ smoke compile for arch sim models.")
+    parser.add_argument("--verilator-flag", action="append", default=[], help="Append an extra Verilator flag. Repeatable.")
+    parser.add_argument("--keep-work-dir", action="store_true", help="Keep the auto-created scratch directory after success.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    root = repo_root()
+    timeout = None if args.timeout == 0 else args.timeout
+    arch_bin = ensure_arch_bin(root, args.arch_bin, args.release)
+
+    auto_work_dir = args.work_dir is None
+    work_dir = args.work_dir or Path(tempfile.mkdtemp(prefix="arch-regression-"))
+    work_dir = work_dir.resolve()
+    work_dir.mkdir(parents=True, exist_ok=True)
+    logs_root = work_dir / "logs"
+
+    copied_tests = copy_tests_tree(root, work_dir, args.tests_dir)
+    scratch_root = work_dir / "src"
+    sim_manifest = load_sim_manifest(args.sim_manifest, root, scratch_root)
+    original_tests = root / args.tests_dir
+    units, skipped = discover_units(
+        arch_bin,
+        root,
+        copied_tests,
+        original_tests,
+        args.pattern,
+        timeout,
+        logs_root,
+        args.no_group_dirs,
+    )
+    if args.limit is not None:
+        units = units[: args.limit]
+    if args.baseline:
+        baseline_names = load_baseline(args.baseline)
+        before = len(units)
+        units = [unit for unit in units if unit.name in baseline_names]
+        missing = sorted(baseline_names - {unit.name for unit in units})
+        print(f"[setup] baseline={args.baseline} selected={len(units)}/{before}")
+        if missing:
+            print(f"[setup] warning: {len(missing)} baseline units were not discovered; first few: {', '.join(missing[:5])}")
+
+    print(f"[setup] repo={root}")
+    print(f"[setup] arch={arch_bin}")
+    print(f"[setup] work_dir={work_dir}")
+    print(f"[setup] sim_manifest_entries={len(sim_manifest)}")
+    print(f"[setup] units={len(units)} jobs={args.jobs}")
+
+    if args.list:
+        for unit in units:
+            print(f"{unit.name}:")
+            for path in unit.original_files:
+                print(f"  {path.relative_to(root)}")
+        return 0
+
+    verilator_flags = [*DEFAULT_VERILATOR_FLAGS, *args.verilator_flag]
+    results: list[UnitResult] = [*skipped]
+    start = time.monotonic()
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=max(1, args.jobs)) as pool:
+        future_map = {
+            pool.submit(
+                run_unit,
+                unit,
+                arch_bin,
+                root,
+                work_dir,
+                timeout,
+                verilator_flags,
+                args.skip_verilator,
+                args.skip_sim,
+                args.skip_sim_compile,
+                sim_manifest,
+            ): unit
+            for unit in units
+        }
+        done_count = 0
+        for future in concurrent.futures.as_completed(future_map):
+            unit = future_map[future]
+            done_count += 1
+            try:
+                result = future.result()
+            except Exception as exc:  # pragma: no cover - defensive runner guard.
+                result = UnitResult(unit.name, [str(p) for p in unit.original_files], "error", 0.0, [
+                    StepResult("runner", "error", 0.0, [], "", repr(exc)),
+                ])
+            results.append(result)
+            print(f"[{done_count:4d}/{len(units):4d}] {result.status:18s} {result.name} ({result.seconds:.2f}s)", flush=True)
+
+    summary = {
+        "repo": str(root),
+        "arch_bin": str(arch_bin),
+        "work_dir": str(work_dir),
+        "seconds": time.monotonic() - start,
+        "counts": {},
+        "results": [result_to_json(r) for r in results],
+    }
+    for result in results:
+        summary["counts"][result.status] = summary["counts"].get(result.status, 0) + 1
+
+    summary_path = work_dir / "summary.json"
+    summary_path.write_text(json.dumps(summary, indent=2) + "\n")
+    print(f"[summary] {summary['counts']}")
+    print(f"[summary] wrote {summary_path}")
+    if args.update_baseline:
+        write_baseline(args.update_baseline, results)
+        print(f"[summary] wrote baseline {args.update_baseline}")
+
+    failures = [r for r in results if r.status not in {"pass", "skip_check_failed"}]
+    if failures and not args.allow_failures:
+        print("[failures]")
+        for result in failures[:25]:
+            failed_steps = [s for s in result.steps if s.status not in {"pass", "skip"}]
+            step_name = failed_steps[-1].name if failed_steps else "runner"
+            print(f"  {result.name}: {result.status} at {step_name}")
+        return 1
+
+    if auto_work_dir and not args.keep_work_dir:
+        print(f"[cleanup] keeping {work_dir} for logs; remove it when no longer needed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/run_cargo_test_baseline.py
+++ b/tools/run_cargo_test_baseline.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Run `cargo test` while guarding the expected Rust test inventory."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import re
+import subprocess
+import sys
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def run(command: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        command,
+        cwd=cwd,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def list_tests(root: Path) -> list[dict[str, str]]:
+    proc = subprocess.run(
+        ["cargo", "test", "--", "--list"],
+        cwd=root,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    if proc.returncode != 0:
+        sys.stderr.write(proc.stdout)
+        raise SystemExit(proc.returncode)
+
+    tests: list[dict[str, str]] = []
+    target = "unknown"
+    for line in proc.stdout.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("Running "):
+            match = re.match(r"Running\s+(.+?)\s+\(", stripped)
+            target = match.group(1) if match else stripped
+            continue
+        if stripped.startswith("Doc-tests "):
+            target = stripped
+            continue
+        if stripped.endswith(": test"):
+            name = stripped.removesuffix(": test")
+            tests.append({"target": target, "name": name})
+    return tests
+
+
+def load_baseline(path: Path) -> set[tuple[str, str]]:
+    data = json.loads(path.read_text())
+    entries = data.get("tests", data if isinstance(data, list) else [])
+    return {(str(item["target"]), str(item["name"])) for item in entries}
+
+
+def write_baseline(path: Path, tests: list[dict[str, str]]) -> None:
+    payload = {
+        "description": "Rust tests discovered by `cargo test -- --list` when this baseline was refreshed.",
+        "tests": sorted(tests, key=lambda item: (item["target"], item["name"])),
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--baseline",
+        type=Path,
+        default=Path("tests/cargo_test_baseline.json"),
+        help="JSON baseline to compare against.",
+    )
+    parser.add_argument(
+        "--update-baseline",
+        action="store_true",
+        help="Refresh the baseline from the current `cargo test -- --list` output.",
+    )
+    parser.add_argument(
+        "--allow-new",
+        action="store_true",
+        help="Allow tests not yet listed in the baseline. Missing baseline tests still fail.",
+    )
+    parser.add_argument(
+        "--list-only",
+        action="store_true",
+        help="Only compare/update the inventory; do not run `cargo test`.",
+    )
+    parser.add_argument(
+        "--",
+        dest="cargo_args",
+        nargs=argparse.REMAINDER,
+        help="Extra arguments passed to `cargo test`.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    root = repo_root()
+    baseline = (root / args.baseline).resolve() if not args.baseline.is_absolute() else args.baseline
+    tests = list_tests(root)
+    current = {(item["target"], item["name"]) for item in tests}
+
+    if args.update_baseline:
+        write_baseline(baseline, tests)
+        print(f"[baseline] wrote {baseline} with {len(tests)} tests")
+    elif baseline.exists():
+        expected = load_baseline(baseline)
+        missing = sorted(expected - current)
+        new = sorted(current - expected)
+        print(f"[baseline] expected={len(expected)} current={len(current)}")
+        if missing:
+            print("[baseline] missing tests:")
+            for target, name in missing[:50]:
+                print(f"  {target} :: {name}")
+            if len(missing) > 50:
+                print(f"  ... and {len(missing) - 50} more")
+            return 1
+        if new and not args.allow_new:
+            print("[baseline] new tests not in baseline:")
+            for target, name in new[:50]:
+                print(f"  {target} :: {name}")
+            if len(new) > 50:
+                print(f"  ... and {len(new) - 50} more")
+            print("[baseline] rerun with --update-baseline after reviewing the new tests")
+            return 1
+        if new:
+            print(f"[baseline] warning: {len(new)} new tests are not in the baseline")
+    else:
+        print(f"[baseline] {baseline} does not exist; run with --update-baseline")
+        return 1
+
+    if args.list_only:
+        return 0
+
+    command = ["cargo", "test", *(args.cargo_args or [])]
+    print(f"[run] {' '.join(command)}", flush=True)
+    proc = subprocess.run(command, cwd=root)
+    return proc.returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add tools/run_arch_regression.py to discover tests/*.arch units and run arch check, arch build, Verilator lint, arch sim model generation, and generated C++ smoke compile
- copy tests/ into a scratch workdir so arch build .archi side files do not dirty the source tree
- add a checked-in baseline of 183 units that pass the stronger backend gate on current main, plus docs for running and refreshing it

## Validation
- python3 -m py_compile tools/run_arch_regression.py
- tools/run_arch_regression.py --pattern 'thread/*.arch' --jobs 2 --timeout 60 --work-dir /private/tmp/arch-regression-smoke-thread
- tools/run_arch_regression.py --pattern 'axi_dma_tlm/*.arch' --jobs 2 --timeout 90 --work-dir /private/tmp/arch-regression-smoke-tlm
- tools/run_arch_regression.py --jobs 8 --timeout 180 --work-dir /private/tmp/arch-regression-full-baseline-rel --update-baseline tests/arch_regression_baseline.json --allow-failures
- tools/run_arch_regression.py --baseline tests/arch_regression_baseline.json --jobs 8 --timeout 180 --work-dir /private/tmp/arch-regression-baseline-final-rel

Baseline-only run passed 183/183 units. Full discovery on current main found 603 units: 183 pass, 71 skip_check_failed, 349 existing backend failures under the stronger gate.