### PR TITLE
fix(codegen): rewrite `wait until` refs to inst outputs with stage prefix

### DIFF
--- a/src/codegen/pipeline.rs
+++ b/src/codegen/pipeline.rs
@@ -623,7 +623,7 @@ impl<'a> Codegen<'a> {
         self.line(&format!("{bits}'d0: begin"));
         self.indent += 1;
         if let Some(g) = groups.first() {
-            let cond = self.emit_pipeline_expr_str(g.cond, stage_names, stage_regs, port_names);
+            let cond = self.emit_pipeline_stage_expr_str(g.cond, prefix, si, stage_names, stage_regs, port_names);
 
             // Run pre-assigns (fire once on entry to the wait)
             // For state 0 these only fire when upstream has valid data
@@ -668,7 +668,7 @@ impl<'a> Codegen<'a> {
             self.line(&format!("{bits}'d{state_num}: begin"));
             self.indent += 1;
 
-            let cond = self.emit_pipeline_expr_str(g.cond, stage_names, stage_regs, port_names);
+            let cond = self.emit_pipeline_stage_expr_str(g.cond, prefix, si, stage_names, stage_regs, port_names);
 
             // Emit hold assigns (for do..until, every cycle)
             for a in &g.hold_assigns {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1586,6 +1586,99 @@ end pipeline AluPipe
 }
 
 #[test]
+fn test_pipeline_stage_inst_in_wait_until() {
+    // Regression: a `wait until` condition inside a stage that also
+    // hosts an `inst` block must reference the inst's output via the
+    // stage-prefixed wire name (the same name the inst lowering
+    // emits), not the bare local name. Previously the wait FSM
+    // codegen used the cross-stage `emit_pipeline_expr_str`, which
+    // did not apply the current stage's prefix to local idents,
+    // emitting a dangling `worker_done` reference that Verilator
+    // rejected with "Can't find definition of variable".
+    let source = r#"
+domain SysDomain
+  freq_mhz: 100
+end domain SysDomain
+
+module Worker
+  port clk_i: in Clock<SysDomain>;
+  port rst_ni: in Reset<Sync, Low>;
+  port req_i: in Bool;
+  port done_o: out Bool;
+  reg state_q: UInt<2> reset rst_ni => 0;
+  seq on clk_i rising
+    if state_q == 2'd0
+      if req_i
+        state_q <= 2'd1;
+      end if
+    else
+      if state_q == 2'd2
+        state_q <= 2'd0;
+      else
+        state_q <= (state_q + 1).trunc<2>();
+      end if
+    end if
+  end seq
+  comb
+    done_o = state_q == 2'd2;
+  end comb
+end module Worker
+
+pipeline WorkerPipe
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync, Low>;
+  port go: in Bool;
+  port out_valid: out Bool;
+
+  stage Capture
+    reg seen: Bool reset rst => false;
+    seq on clk rising
+      seen <= go;
+    end seq
+  end stage Capture
+
+  stage Process
+    reg result: Bool reset rst => false;
+    seq on clk rising
+      wait until worker_done;
+      result <= true;
+    end seq
+    inst worker: Worker
+      clk_i <- clk;
+      rst_ni <- rst;
+      req_i <- Capture.seen;
+      done_o -> worker_done;
+    end inst worker
+    comb
+      out_valid = result;
+    end comb
+  end stage Process
+
+end pipeline WorkerPipe
+"#;
+    let sv = compile_to_sv(source);
+    // The `wait until worker_done` inside Process stage must resolve
+    // to the stage-prefixed wire name. Both the `inst` connection
+    // and the wait-FSM condition must agree on `process_worker_done`.
+    assert!(
+        sv.contains(".done_o(process_worker_done)"),
+        "inst output connection should target stage-prefixed wire"
+    );
+    // The bare unprefixed name must NOT appear as a free variable
+    // reference (it would cause Verilator UNDEFINED). The prefixed
+    // form `process_worker_done` is the only legal reference.
+    assert!(
+        !sv.contains("if (worker_done)"),
+        "wait condition must use stage-prefixed reference, not bare ident"
+    );
+    assert!(
+        sv.contains("if (process_worker_done)"),
+        "wait condition must reference the stage-prefixed inst output wire"
+    );
+    insta::assert_snapshot!(sv);
+}
+
+#[test]
 fn test_clog2_in_type_args() {
     // $clog2(DEPTH) in type width expressions
     let source = r#"

--- a/tests/snapshots/integration_test__pipeline_stage_inst_in_wait_until.snap
+++ b/tests/snapshots/integration_test__pipeline_stage_inst_in_wait_until.snap
@@ -1,0 +1,112 @@
+---
+source: tests/integration_test.rs
+assertion_line: 1678
+expression: sv
+---
+// domain SysDomain
+//   freq_mhz: 100
+
+module Worker (
+  input logic clk_i,
+  input logic rst_ni,
+  input logic req_i,
+  output logic done_o
+);
+
+  logic [1:0] state_q;
+  always_ff @(posedge clk_i) begin
+    if ((!rst_ni)) begin
+      state_q <= 0;
+    end else begin
+      if (state_q == 2'd0) begin
+        if (req_i) begin
+          state_q <= 2'd1;
+        end
+      end else if (state_q == 2'd2) begin
+        state_q <= 2'd0;
+      end else begin
+        state_q <= 2'(state_q + 1);
+      end
+    end
+  end
+  assign done_o = state_q == 2'd2;
+
+endmodule
+
+module WorkerPipe (
+  input logic clk,
+  input logic rst,
+  input logic go,
+  output logic out_valid
+);
+
+  // ── Stage valid registers ──
+  logic capture_valid_r;
+  logic process_valid_r;
+  
+  // ── Stage data registers ──
+  logic capture_seen = 1'b0;
+  logic process_result = 1'b0;
+  logic process_worker_done;
+  
+  // ── Wait-stage FSM registers ──
+  logic [0:0] process_fsm_state;
+  logic process_fsm_busy;
+  
+  // ── Stall signals ──
+  logic capture_stall;
+  logic process_stall;
+  assign process_stall = process_fsm_busy;
+  assign capture_stall = process_stall;
+  
+  assign process_fsm_busy = (process_fsm_state != '0);
+  
+  // ── Stage register updates ──
+  always_ff @(posedge clk) begin
+    if ((!rst)) begin
+      capture_valid_r <= 1'b0;
+      capture_seen <= 1'b0;
+      process_valid_r <= 1'b0;
+      process_fsm_state <= '0;
+      process_result <= 1'b0;
+    end else begin
+      if (!capture_stall) begin
+        capture_valid_r <= 1'b1;
+        capture_seen <= go;
+      end
+      // Wait-stage FSM: process
+      case (process_fsm_state)
+        1'd0: begin
+          if (capture_valid_r) begin
+            if (process_worker_done) begin
+              process_result <= 1'b1;
+              process_valid_r <= capture_valid_r;
+            end else begin
+              process_fsm_state <= 1'd1;
+            end
+          end
+        end
+        1'd1: begin
+          if (process_worker_done) begin
+            process_result <= 1'b1;
+            process_fsm_state <= '0;
+            process_valid_r <= 1'b1;
+          end
+        end
+        default: begin
+          process_fsm_state <= '0;
+        end
+      endcase
+    end
+  end
+  
+  // ── Combinational outputs ──
+  Worker worker (
+    .clk_i(clk),
+    .rst_ni(rst),
+    .req_i(capture_seen),
+    .done_o(process_worker_done)
+  );
+  assign out_valid = process_result;
+
+endmodule


### PR DESCRIPTION
## Summary
- Pipeline stage with `inst SubModule` + `wait until <sub_out>` emitted SV that Verilator rejected: the wait-FSM condition used the bare local name (`worker_done`) while the inst connection used the stage-prefixed wire (`process_worker_done`).
- Two-line fix in `emit_pipeline_wait_stage_ff` to use `emit_pipeline_stage_expr_str` (stage-aware) instead of `emit_pipeline_expr_str` (cross-stage only) for the wait condition.
- Regression test `test_pipeline_stage_inst_in_wait_until` exercises the failing shape end-to-end.

## Why this matters
This is the shape needed for `arch-ibex` Phase C — `pipeline IbexCore` will instantiate the already-ported B-phase sub-modules (IfStage, IdStage, ExBlock, LSU, WbStage) inside stages and use `wait until <sub_signal>` to bind variable-latency operations like LSU response and multdiv to the framework's stall machinery. Surfaced and verified by a 2-stage spike (`spike/c1-pipeline` in arch-ibex `spike/c1-pipeline-stateful-inst` branch): with this fix the spike compiles, lints, and passes 3 cocotb tests covering dataflow through the inst boundary, stall propagation while the sub-module is busy, and flush composition (parent's `flush Stage when ...` + user-wired `sub.flush_i <- flush_in`).

## Backwards-compat check
The existing `tests/pipeline_wait_stage.sv` golden output is byte-identical after the fix (its wait condition references a port `mem_valid`, not a local inst output, so the prefix-rewrite is a no-op there). Full integration suite: 312 passed (was 311 before; +1 new test, 0 regressions).

## Test plan
- [x] `cargo test --release --test integration_test` → 312 passed, 0 failed
- [x] arch-ibex C1 spike (`spike/c1-pipeline`) compiles + lints + 3/3 cocotb tests pass with this fix
- [x] `tests/pipeline_wait_stage.sv` regenerates byte-identical to checked-in golden

🤖 Generated with [Claude Code](https://claude.com/claude-code)