### PR TITLE
fix(sim): use balanced-parens check for if-condition wrapping

### DIFF
--- a/src/sim_codegen/mod.rs
+++ b/src/sim_codegen/mod.rs
@@ -2029,11 +2029,32 @@ fn cpp_expr(expr: &Expr, ctx: &Ctx) -> String {
 
 fn cpp_condition(expr: &Expr, ctx: &Ctx) -> String {
     let cond = cpp_expr(expr, ctx);
-    if cond.trim_start().starts_with('(') {
+    if is_fully_wrapped_in_parens(&cond) {
         cond
     } else {
         format!("({cond})")
     }
+}
+
+/// Check if `s` is fully wrapped in a single balanced pair of outer parens.
+/// Returns true for `(!busy)` and `(a + b)`, false for `(uint8_t)(!busy)` where
+/// the first `)` closes the cast, not the whole expression.
+fn is_fully_wrapped_in_parens(s: &str) -> bool {
+    let s = s.trim();
+    if !s.starts_with('(') || !s.ends_with(')') {
+        return false;
+    }
+    let mut depth = 0u32;
+    for (i, c) in s.char_indices() {
+        if c == '(' { depth += 1; }
+        else if c == ')' {
+            depth -= 1;
+            if depth == 0 && i < s.len() - 1 {
+                return false; // closed before the end — not fully wrapped
+            }
+        }
+    }
+    depth == 0
 }
 
 fn cpp_expr_lhs(expr: &Expr, ctx: &Ctx) -> String {


### PR DESCRIPTION
## Summary
Fixed a sim codegen bug where C-style cast expressions like `(uint8_t)(!busy)` broke `if` conditions in generated C++.

## Root cause
`cpp_condition` used `starts_with('(')` to decide whether an expression was already parenthesized, but C-style casts like `(uint8_t)(!busy)` also start with `(` — the first `)` closes the cast, not the whole expression. This caused `if (uint8_t)(!(busy))` instead of `if ((uint8_t)(!(busy)))`, which is syntactically invalid C.

## Fix
Replaced the `starts_with('(')` heuristic with `is_fully_wrapped_in_parens()` which walks the string and verifies the opening `(` matches a closing `)` at the very end of the string. This correctly:

- Keeps `(!busy)` unwrapped → `if (!busy)` (no double parens)
- Wraps `(uint8_t)(!busy)` → `if ((uint8_t)(!busy))` (valid C)

## Test plan
- [x] `bash examples/run_sims.sh` — 30/30 PASS (dma_engine was the failing one)
- [x] `cargo test --release` — 314/314 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)