### PR TITLE
feat(params): cross-package qualified enum types for SV-side enums

### DIFF
--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -3293,7 +3293,20 @@ impl<'a> Codegen<'a> {
                     format!("'{{{}}}", field_strs.join(", "))
                 }
             }
-            ExprKind::EnumVariant(_, variant) => variant.name.to_uppercase(),
+            ExprKind::EnumVariant(enum_name, variant) => {
+                // Known ARCH-side enum → emit just the variant name in
+                // uppercase (the SV typedef gives variants their type
+                // implicitly via context). Cross-package qualified refs
+                // (e.g. `ibex_pkg::RV32MFast`) — recognised by the
+                // enum side NOT being a known ARCH enum — preserve the
+                // package prefix and original case so they resolve in
+                // upstream SV.
+                if matches!(self.symbols.globals.get(&enum_name.name), Some((Symbol::Enum(_), _))) {
+                    variant.name.to_uppercase()
+                } else {
+                    format!("{}::{}", enum_name.name, variant.name)
+                }
+            }
             ExprKind::Todo => {
                 "'0 /* TODO: todo! placeholder */".to_string()
             }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -880,9 +880,21 @@ impl Parser {
             let ty = self.parse_type_expr()?;
             ParamKind::ConstVec(ty)
         } else if matches!(self.peek_kind(), Some(TokenKind::Ident(_))) {
-            // Enum-typed const: param MODE: EnumName = EnumName::Variant
-            let enum_name = self.expect_ident()?;
-            ParamKind::EnumConst(enum_name.name)
+            // Enum-typed const: `param MODE: EnumName = EnumName::Variant;`
+            // OR cross-package qualified form for SV-side enums:
+            // `param MODE: pkg::EnumName = pkg::Variant;` (e.g.
+            // `ibex_pkg::rv32m_e`). The qualified path is held as a single
+            // string since arch-com treats cross-package SV enums opaquely
+            // (no value resolution; codegen emits the pkg-prefixed name
+            // verbatim into SV).
+            let first = self.expect_ident()?;
+            let enum_name = if self.eat(TokenKind::ColonColon) {
+                let second = self.expect_ident()?;
+                format!("{}::{}", first.name, second.name)
+            } else {
+                first.name
+            };
+            ParamKind::EnumConst(enum_name)
         } else {
             ParamKind::Const
         };

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1725,6 +1725,48 @@ end pipeline P2
 }
 
 #[test]
+fn test_qualified_enum_param_for_external_package() {
+    // Native ARCH syntax for forwarding upstream-SV typed params:
+    // `param NAME: pkg::EnumName = pkg::Variant;` — the qualified
+    // path on both type and default value emits unchanged into SV
+    // so the param can be wired across an ARCH-to-upstream-SV
+    // module boundary without a cast (e.g. ARCH IbexCore forwarding
+    // RV32M to upstream-SV ibex_cs_registers, both seeing
+    // `ibex_pkg::rv32m_e`). The qualified enum side isn't a known
+    // ARCH enum, so codegen preserves the `pkg::Variant` form
+    // verbatim instead of uppercasing the variant.
+    let source = r#"
+domain SysDomain
+  freq_mhz: 100
+end domain SysDomain
+
+module ExternalEnumParam
+  param RV32M: ibex_pkg::rv32m_e = ibex_pkg::RV32MFast;
+  param RV32B: ibex_pkg::rv32b_e = ibex_pkg::RV32BNone;
+
+  port clk_i:  in Clock<SysDomain>;
+  port rst_ni: in Reset<Sync, Low>;
+  port d:      in UInt<32>;
+  port q:      out UInt<32>;
+
+  comb
+    q = d;
+  end comb
+end module ExternalEnumParam
+"#;
+    let sv = compile_to_sv(source);
+    assert!(
+        sv.contains("parameter ibex_pkg::rv32m_e RV32M = ibex_pkg::RV32MFast"),
+        "qualified enum type + default should emit verbatim: {sv}"
+    );
+    assert!(
+        sv.contains("parameter ibex_pkg::rv32b_e RV32B = ibex_pkg::RV32BNone"),
+        "second qualified-enum param should also emit verbatim"
+    );
+    insta::assert_snapshot!(sv);
+}
+
+#[test]
 fn test_pipeline_stage_inst_in_wait_until() {
     // Regression: a `wait until` condition inside a stage that also
     // hosts an `inst` block must reference the inst's output via the

--- a/tests/snapshots/integration_test__qualified_enum_param_for_external_package.snap
+++ b/tests/snapshots/integration_test__qualified_enum_param_for_external_package.snap
@@ -1,0 +1,21 @@
+---
+source: tests/integration_test.rs
+assertion_line: 1766
+expression: sv
+---
+// domain SysDomain
+//   freq_mhz: 100
+
+module ExternalEnumParam #(
+  parameter ibex_pkg::rv32m_e RV32M = ibex_pkg::RV32MFast,
+  parameter ibex_pkg::rv32b_e RV32B = ibex_pkg::RV32BNone
+) (
+  input logic clk_i,
+  input logic rst_ni,
+  input logic [31:0] d,
+  output logic [31:0] q
+);
+
+  assign q = d;
+
+endmodule


### PR DESCRIPTION
## Summary
Native ARCH syntax for declaring a `param` whose type is an SV enum from an external package:

```arch
param RV32M: ibex_pkg::rv32m_e = ibex_pkg::RV32MFast;
param RV32B: ibex_pkg::rv32b_e = ibex_pkg::RV32BNone;
```

Emits SV verbatim:
```sv
parameter ibex_pkg::rv32m_e RV32M = ibex_pkg::RV32MFast,
parameter ibex_pkg::rv32b_e RV32B = ibex_pkg::RV32BNone,
```

## Why
arch-ibex C1 (IbexCore swap) sits between upstream `ibex_top.sv` (passes typed values down) and upstream `ibex_cs_registers.sv` (expects typed values). With the prior `param RV32M: const = 2;` form arch-com emitted `parameter int RV32M = 2`, and Verilator rejected the int→`ibex_pkg::rv32m_e` implicit conversion at the cs_registers pin connection (ENUMVALUE error).

The clean fix is a real syntax extension: let ARCH express the qualified type natively, both at decl and at default. No SV-string passthrough.

## Implementation
- **Parser** (`src/parser.rs`): after the first ident in a param-type position, optionally consume `:: <ident>`. The qualified path is held as a single `pkg::name` string in the existing `EnumConst(String)` so no AST break.
- **Codegen** (`src/codegen/mod.rs`): at the `ExprKind::EnumVariant` emission, look up the enum side in `self.symbols.globals`. Known ARCH enum → existing uppercase-variant emit. Unknown → preserve the `pkg::Variant` form verbatim (the only meaningful case for cross-package refs).

The default expression already parses as `ExprKind::EnumVariant` via the existing `Ident::Ident` path syntax — no parser change needed there.

## Test plan
- [x] `cargo test --release --test integration_test` → 315 passed (was 314; +1 new test, 0 regressions)
- [x] `test_qualified_enum_param_for_external_package` — two qualified-enum params, asserts both type + default emit verbatim
- [x] arch-ibex C1: with this fix landed, IbexCore.arch declares `RV32M`/`RV32B` typed and forwards to `ibex_cs_registers` without a cast. The Verilator ENUMVALUE error at the cs_registers pin is resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)