### PR TITLE
Improve TLM connect diagnostics

### DIFF
--- a/src/elaborate.rs
+++ b/src/elaborate.rs
@@ -494,25 +494,53 @@ fn lower_tlm_connects_in_module(
 
     let mut synthesized_wires = Vec::new();
     let mut synthesized_conns: HashMap<String, Vec<Connection>> = HashMap::new();
+    let mut connected_endpoints: HashMap<(String, String), Span> = HashMap::new();
     for conn in connects {
-        let Some((from_bus, from_persp, from_span)) =
-            tlm_connect_endpoint_bus(&conn.from_inst, &conn.from_port, &inst_modules, module_ports)
-        else {
-            errors.push(CompileError::general(
-                &format!("unknown TLM connect endpoint `{}.{}`", conn.from_inst.name, conn.from_port.name),
-                conn.from_inst.span.merge(conn.from_port.span),
-            ));
-            continue;
+        let from = match tlm_connect_endpoint_bus(
+            &conn.from_inst,
+            &conn.from_port,
+            &inst_modules,
+            module_ports,
+        ) {
+            Ok(endpoint) => endpoint,
+            Err(err) => {
+                errors.push(err);
+                continue;
+            }
         };
-        let Some((to_bus, to_persp, to_span)) =
-            tlm_connect_endpoint_bus(&conn.to_inst, &conn.to_port, &inst_modules, module_ports)
-        else {
-            errors.push(CompileError::general(
-                &format!("unknown TLM connect endpoint `{}.{}`", conn.to_inst.name, conn.to_port.name),
-                conn.to_inst.span.merge(conn.to_port.span),
-            ));
-            continue;
+        let to = match tlm_connect_endpoint_bus(
+            &conn.to_inst,
+            &conn.to_port,
+            &inst_modules,
+            module_ports,
+        ) {
+            Ok(endpoint) => endpoint,
+            Err(err) => {
+                errors.push(err);
+                continue;
+            }
         };
+        let (from_bus, from_persp, from_span) = from;
+        let (to_bus, to_persp, to_span) = to;
+
+        let error_count_before_endpoint_checks = errors.len();
+        for endpoint in [(&conn.from_inst, &conn.from_port), (&conn.to_inst, &conn.to_port)] {
+            let key = (endpoint.0.name.clone(), endpoint.1.name.clone());
+            if let Some(first_span) = connected_endpoints.get(&key) {
+                errors.push(CompileError::general(
+                    &format!(
+                        "TLM connect endpoint `{}.{}` is connected more than once",
+                        endpoint.0.name, endpoint.1.name
+                    ),
+                    first_span.merge(conn.span),
+                ));
+            } else {
+                connected_endpoints.insert(key, conn.span);
+            }
+        }
+        if errors.len() != error_count_before_endpoint_checks {
+            continue;
+        }
         if from_bus != to_bus {
             errors.push(CompileError::general(
                 &format!(
@@ -525,11 +553,21 @@ fn lower_tlm_connects_in_module(
         }
         if from_persp != BusPerspective::Initiator || to_persp != BusPerspective::Target {
             errors.push(CompileError::general(
-                "TLM connect prototype requires `connect initiator_inst.initiator_port -> target_inst.target_port;`",
+                &format!(
+                    "TLM connect requires `connect initiator_inst.initiator_port -> target_inst.target_port;` \
+                     but `{}.{}` is {:?} and `{}.{}` is {:?}",
+                    conn.from_inst.name,
+                    conn.from_port.name,
+                    from_persp,
+                    conn.to_inst.name,
+                    conn.to_port.name,
+                    to_persp
+                ),
                 from_span.merge(to_span),
             ));
             continue;
         }
+        let error_count_before_duplicate_checks = errors.len();
         for (inst_name, port_name) in [(&conn.from_inst, &conn.from_port), (&conn.to_inst, &conn.to_port)] {
             if let Some(existing) = m.body.iter().find_map(|item| match item {
                 ModuleBodyItem::Inst(inst) if inst.name.name == inst_name.name => Some(inst),
@@ -544,7 +582,7 @@ fn lower_tlm_connects_in_module(
                 ));
             }
         }
-        if !errors.is_empty() {
+        if errors.len() != error_count_before_duplicate_checks {
             continue;
         }
 
@@ -612,12 +650,41 @@ fn tlm_connect_endpoint_bus(
     port: &Ident,
     inst_modules: &HashMap<String, String>,
     module_ports: &HashMap<String, Vec<PortDecl>>,
-) -> Option<(String, BusPerspective, Span)> {
-    let module_name = inst_modules.get(&inst.name)?;
-    let ports = module_ports.get(module_name)?;
-    let p = ports.iter().find(|p| p.name.name == port.name)?;
-    let bi = p.bus_info.as_ref()?;
-    Some((bi.bus_name.name.clone(), bi.perspective, p.span))
+) -> Result<(String, BusPerspective, Span), CompileError> {
+    let Some(module_name) = inst_modules.get(&inst.name) else {
+        return Err(CompileError::general(
+            &format!("unknown TLM connect instance `{}`", inst.name),
+            inst.span,
+        ));
+    };
+    let Some(ports) = module_ports.get(module_name) else {
+        return Err(CompileError::general(
+            &format!(
+                "TLM connect instance `{}` has construct type `{}` whose ports are not supported by connect",
+                inst.name, module_name
+            ),
+            inst.span,
+        ));
+    };
+    let Some(p) = ports.iter().find(|p| p.name.name == port.name) else {
+        return Err(CompileError::general(
+            &format!(
+                "module `{}` has no port `{}` for TLM connect endpoint `{}.{}`",
+                module_name, port.name, inst.name, port.name
+            ),
+            port.span,
+        ));
+    };
+    let Some(bi) = p.bus_info.as_ref() else {
+        return Err(CompileError::general(
+            &format!(
+                "TLM connect endpoint `{}.{}` names non-bus port `{}` on module `{}`",
+                inst.name, port.name, port.name, module_name
+            ),
+            p.span,
+        ));
+    };
+    Ok((bi.bus_name.name.clone(), bi.perspective, p.span))
 }
 
 // ── Generate expansion ────────────────────────────────────────────────────────

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -5536,6 +5536,201 @@ fn test_tlm_connect_one_to_one_sugar_lowers_to_bus_wire() {
         "sim C++ should include the connect-sugar top");
 }
 
+fn tlm_connect_elaborate_error(source: &str) -> String {
+    let tokens = arch::lexer::tokenize(source).expect("lexer");
+    let mut parser = arch::parser::Parser::new(tokens, source);
+    let ast = parser.parse_source_file().expect("parse");
+    let err = arch::elaborate::elaborate(ast).expect_err("expected elaborate error");
+    err.iter().map(|e| format!("{e:?}")).collect::<String>()
+}
+
+#[test]
+fn test_tlm_connect_unknown_instance_diagnostic() {
+    let msg = tlm_connect_elaborate_error(r#"
+bus Mem
+  tlm_method read(addr: UInt<32>) -> UInt<64>: blocking;
+end bus Mem
+use Mem;
+module Initiator
+  port m: initiator Mem;
+end module Initiator
+module Target
+  port s: target Mem;
+end module Target
+module Top
+  inst t: Target
+  end inst t
+  connect missing.m -> t.s;
+end module Top
+"#);
+    assert!(msg.contains("unknown TLM connect instance `missing`"),
+        "expected unknown-instance diagnostic, got: {msg}");
+}
+
+#[test]
+fn test_tlm_connect_unknown_port_diagnostic() {
+    let msg = tlm_connect_elaborate_error(r#"
+bus Mem
+  tlm_method read(addr: UInt<32>) -> UInt<64>: blocking;
+end bus Mem
+use Mem;
+module Initiator
+  port m: initiator Mem;
+end module Initiator
+module Target
+  port s: target Mem;
+end module Target
+module Top
+  inst i: Initiator
+  end inst i
+  inst t: Target
+  end inst t
+  connect i.nope -> t.s;
+end module Top
+"#);
+    assert!(msg.contains("module `Initiator` has no port `nope`"),
+        "expected unknown-port diagnostic, got: {msg}");
+}
+
+#[test]
+fn test_tlm_connect_non_bus_port_diagnostic() {
+    let msg = tlm_connect_elaborate_error(r#"
+bus Mem
+  tlm_method read(addr: UInt<32>) -> UInt<64>: blocking;
+end bus Mem
+use Mem;
+module Initiator
+  port scalar: out Bool;
+  port m: initiator Mem;
+end module Initiator
+module Target
+  port s: target Mem;
+end module Target
+module Top
+  inst i: Initiator
+  end inst i
+  inst t: Target
+  end inst t
+  connect i.scalar -> t.s;
+end module Top
+"#);
+    assert!(msg.contains("non-bus port `scalar`"),
+        "expected non-bus-port diagnostic, got: {msg}");
+}
+
+#[test]
+fn test_tlm_connect_direction_mismatch_diagnostic() {
+    let msg = tlm_connect_elaborate_error(r#"
+bus Mem
+  tlm_method read(addr: UInt<32>) -> UInt<64>: blocking;
+end bus Mem
+use Mem;
+module Initiator
+  port m: initiator Mem;
+end module Initiator
+module Target
+  port s: target Mem;
+end module Target
+module Top
+  inst i: Initiator
+  end inst i
+  inst t: Target
+  end inst t
+  connect t.s -> i.m;
+end module Top
+"#);
+    assert!(msg.contains("requires `connect initiator_inst.initiator_port -> target_inst.target_port;`")
+         && msg.contains("t.s") && msg.contains("Target")
+         && msg.contains("i.m") && msg.contains("Initiator"),
+        "expected direction-mismatch diagnostic, got: {msg}");
+}
+
+#[test]
+fn test_tlm_connect_bus_mismatch_diagnostic() {
+    let msg = tlm_connect_elaborate_error(r#"
+bus MemA
+  tlm_method read(addr: UInt<32>) -> UInt<64>: blocking;
+end bus MemA
+bus MemB
+  tlm_method read(addr: UInt<32>) -> UInt<64>: blocking;
+end bus MemB
+use MemA;
+use MemB;
+module Initiator
+  port m: initiator MemA;
+end module Initiator
+module Target
+  port s: target MemB;
+end module Target
+module Top
+  inst i: Initiator
+  end inst i
+  inst t: Target
+  end inst t
+  connect i.m -> t.s;
+end module Top
+"#);
+    assert!(msg.contains("TLM connect bus mismatch")
+         && msg.contains("MemA") && msg.contains("MemB"),
+        "expected bus-mismatch diagnostic, got: {msg}");
+}
+
+#[test]
+fn test_tlm_connect_duplicate_explicit_connection_diagnostic() {
+    let msg = tlm_connect_elaborate_error(r#"
+bus Mem
+  tlm_method read(addr: UInt<32>) -> UInt<64>: blocking;
+end bus Mem
+use Mem;
+module Initiator
+  port m: initiator Mem;
+end module Initiator
+module Target
+  port s: target Mem;
+end module Target
+module Top
+  wire explicit: Mem;
+  inst i: Initiator
+    m -> explicit;
+  end inst i
+  inst t: Target
+  end inst t
+  connect i.m -> t.s;
+end module Top
+"#);
+    assert!(msg.contains("duplicates an explicit connection")
+         && msg.contains("i.m"),
+        "expected duplicate-explicit-connection diagnostic, got: {msg}");
+}
+
+#[test]
+fn test_tlm_connect_endpoint_reuse_diagnostic() {
+    let msg = tlm_connect_elaborate_error(r#"
+bus Mem
+  tlm_method read(addr: UInt<32>) -> UInt<64>: blocking;
+end bus Mem
+use Mem;
+module Initiator
+  port m: initiator Mem;
+end module Initiator
+module Target
+  port s: target Mem;
+end module Target
+module Top
+  inst i: Initiator
+  end inst i
+  inst t0: Target
+  end inst t0
+  inst t1: Target
+  end inst t1
+  connect i.m -> t0.s;
+  connect i.m -> t1.s;
+end module Top
+"#);
+    assert!(msg.contains("TLM connect endpoint `i.m` is connected more than once"),
+        "expected endpoint-reuse diagnostic, got: {msg}");
+}
+
 #[test]
 fn test_tlm_one_initiator_many_targets_router_example_compiles() {
     let source = include_str!("axi_dma_tlm/TlmOneToMany.arch");


### PR DESCRIPTION
## Summary
- split TLM connect endpoint resolution errors into unknown instance, unknown port, and non-bus port diagnostics
- report initiator/target perspective mismatches with both endpoint perspectives
- reject duplicate explicit bus connections and multiple connect bindings to the same endpoint
- add focused integration tests for each diagnostic case

## Validation
- `cargo test tlm_connect`
- `cargo check`
- `tools/run_arch_regression.py --pattern 'axi_dma_tlm/TlmConnectOneToOne.arch' --jobs 1 --timeout 120 --work-dir /private/tmp/arch-regression-tlm-connect-diag`