### PR TITLE
fix(interface,parser): preserve unpacked in .archi + accept doc comment on local param

### DIFF
--- a/src/interface.rs
+++ b/src/interface.rs
@@ -319,20 +319,27 @@ pub(crate) fn emit_ports(s: &mut String, ports: &[PortDecl]) {
             s.push_str(&format!("  port {name}: {persp} {bus_name};\n"));
         } else {
             let ty = type_str(&p.ty);
+            // Preserve the `unpacked` modifier (SV unpacked-array port
+            // shape) so .archi reflects the same SV emit as .sv. Without
+            // this, downstream consumers reading the .archi to decide
+            // port shape would silently see packed-Vec when the source
+            // is unpacked-Vec, causing port-shape mismatches at the
+            // SV inst boundary.
+            let unpacked_kw = if p.unpacked { "unpacked " } else { "" };
             // For port reg with reset, include reset clause
             if let Some(ref ri) = p.reg_info {
                 match &ri.reset {
                     RegReset::Inherit(rst, val) | RegReset::Explicit(rst, _, _, val) => {
                         let rst_name = &rst.name;
                         let rst_val = expr_str(val);
-                        s.push_str(&format!("  port reg {name}: {dir} {ty} reset {rst_name} => {rst_val};\n"));
+                        s.push_str(&format!("  port reg {name}: {dir} {unpacked_kw}{ty} reset {rst_name} => {rst_val};\n"));
                     }
                     RegReset::None => {
-                        s.push_str(&format!("  port reg {name}: {dir} {ty};\n"));
+                        s.push_str(&format!("  port reg {name}: {dir} {unpacked_kw}{ty};\n"));
                     }
                 }
             } else {
-                s.push_str(&format!("  port {name}: {dir} {ty};\n"));
+                s.push_str(&format!("  port {name}: {dir} {unpacked_kw}{ty};\n"));
             }
         }
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -5039,8 +5039,25 @@ impl Parser {
     fn check_param(&self) -> bool {
         if self.check(TokenKind::Param) { return true; }
         if self.check_ident("local") {
-            if let Some(t) = self.tokens.get(self.pos + 1) {
-                return t.kind == TokenKind::Param;
+            // Find the position of `local` after skipping any leading
+            // doc comments (matching `peek_kind`'s skip semantics), then
+            // look at the next non-doc token to see if it's `param`.
+            // Without the doc-skip, `local param` declarations preceded
+            // by a `///` comment fail to be recognized.
+            let mut i = self.pos;
+            while let Some(t) = self.tokens.get(i) {
+                if matches!(&t.kind, TokenKind::DocOuter(_) | TokenKind::DocInner(_)) {
+                    i += 1;
+                } else { break; }
+            }
+            // i now points at `local`; look at the next non-doc token.
+            let mut j = i + 1;
+            while let Some(t) = self.tokens.get(j) {
+                if matches!(&t.kind, TokenKind::DocOuter(_) | TokenKind::DocInner(_)) {
+                    j += 1;
+                } else {
+                    return t.kind == TokenKind::Param;
+                }
             }
         }
         false

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -10120,6 +10120,82 @@ fn test_unpacked_wire_modifier_emits_unpacked_sv() {
 }
 
 #[test]
+fn test_doc_comment_above_local_param_parses() {
+    // Regression: arch-ibex C2 surfaced that a `///` doc comment
+    // immediately preceding a `local param` declaration confused the
+    // parser's `check_param` lookahead — it didn't skip doc-comment
+    // tokens when looking past `local` for the `param` keyword, so
+    // the body-item dispatcher rejected `local` as an unknown item.
+    // After the fix, doc comments attach cleanly to `local param`s
+    // the same way they attach to plain `param`s.
+    let source = "
+domain SysDomain
+  freq_mhz: 100
+end domain SysDomain
+
+module DocLocal
+  param Foo: const = 32;
+  /// Doc comment that should attach to the `local param` below.
+  /// Multi-line is also fine.
+  local param Bar: const = 64;
+  port clk: in Clock<SysDomain>;
+  port d: in UInt<32>;
+  port q: out UInt<32>;
+  comb
+    q = d;
+  end comb
+end module DocLocal
+";
+    let sv = compile_to_sv(source);
+    assert!(sv.contains("parameter int Foo = 32"),
+            "regular param should still emit: {sv}");
+    assert!(sv.contains("localparam int Bar = 64"),
+            "local param after doc comment should still emit: {sv}");
+}
+
+#[test]
+fn test_unpacked_modifier_preserved_in_archi_emit() {
+    // Regression: arch-ibex C2 surfaced that the `.archi` interface
+    // emit for `port name: in unpacked Vec<T, N>` dropped the
+    // `unpacked` keyword, so downstream consumers reading the
+    // `.archi` to resolve port shape silently saw packed-Vec when
+    // the source was unpacked. The .sv emit was correct; the .archi
+    // was the one that was wrong.
+    let source = "
+domain SysDomain
+  freq_mhz: 100
+end domain SysDomain
+
+module UpkPort
+  param N: const = 4;
+  param W: const = 8;
+  port a: in  unpacked Vec<UInt<W>, N>;
+  port b: out unpacked Vec<UInt<W>, N>;
+  port c: in  Vec<UInt<W>, N>;
+  comb
+    b = a;
+  end comb
+end module UpkPort
+";
+    let tokens = lexer::tokenize(source).expect("lexer error");
+    let mut parser = Parser::new(tokens, source);
+    let parsed = parser.parse_source_file().expect("parse error");
+    let item = parsed.items.iter()
+        .find(|i| matches!(i, arch::ast::Item::Module(_)))
+        .expect("expected a module item");
+    let body = arch::interface::emit_interface(item).expect("emit_interface");
+    assert!(body.contains("port a: in unpacked Vec<UInt<W>, N>;"),
+            "unpacked input port should round-trip into .archi: {body}");
+    assert!(body.contains("port b: out unpacked Vec<UInt<W>, N>;"),
+            "unpacked output port should round-trip into .archi: {body}");
+    // Packed Vec port (no `unpacked` modifier) still emits without it.
+    assert!(body.contains("port c: in Vec<UInt<W>, N>;"),
+            "packed Vec port must NOT gain the `unpacked` keyword: {body}");
+    assert!(!body.contains("port c: in unpacked Vec"),
+            "packed Vec port must NOT gain the `unpacked` keyword: {body}");
+}
+
+#[test]
 fn test_unpacked_wire_rejected_on_non_vec() {
     // The modifier is only valid on `Vec<T,N>`. Other types must error.
     let source = "


### PR DESCRIPTION
## Summary
Two small arch-com gaps surfaced during arch-ibex C-phase port. Both were one-off papercuts that compounded across implementer-agent iterations.

### 1. `.archi` divergence on `unpacked` modifier

`emit_ports` ignored `PortDecl.unpacked` — so `.archi` interface stubs emitted `port a: in Vec<UInt<W>, N>;` even when the source was `port a: in unpacked Vec<UInt<W>, N>;`. The `.sv` emit was correct; only the `.archi` was wrong. Downstream consumers reading the `.archi` to resolve port shape (e.g. an outer wrapper deciding whether to use packed or unpacked Vec on its tieoff side) would silently get the wrong shape.

Surfaced in arch-ibex C2: implementer was briefly misled by IbexCore's `.archi` for `ic_*_rdata_i` / `rvfi_ext_mhpmcounters[h]` ports until they read the `.sv` directly.

Fix: emit `unpacked ` prefix when `p.unpacked == true`. Mirrors source syntax.

### 2. `///` doc comment above `local param` rejected

`check_param`'s lookahead-past-`local` did `self.tokens.get(self.pos + 1)` without skipping doc-comment tokens. When the parser was positioned at a `///`, pos+1 landed on `local` itself; the `t.kind == Param` check failed; body-item dispatcher rejected `local` as unknown.

Surfaced in arch-ibex C2 IbexTop: implementer had to convert ~15 doc comments to plain `//` before each `local param`, mid-build, costing fix-pass round-trips.

Fix: skip doc-comment tokens both before `local` and after, mirroring `peek_kind`'s skip semantics.

## Test plan
- [x] `cargo test --release --test integration_test` → 326 passed (was 324; +2 new, 0 regressions)
- [x] `test_unpacked_modifier_preserved_in_archi_emit` — three ports (unpacked-in, unpacked-out, packed-in) round-trip through .archi
- [x] `test_doc_comment_above_local_param_parses` — multi-line doc comment + local param parses + emits correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)