### PR TITLE
fix(typecheck): error when fsm port/signal is named state

### DIFF
--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -4507,6 +4507,43 @@ impl<'a> TypeChecker<'a> {
             return;
         }
 
+        // `state` is reserved — the codegen maps it to the internal
+        // `state_r` register via ident_subst. A user port/signal named
+        // `state` would have its assignments rewritten to the enum-typed
+        // register, producing SV ENUMVALUE errors.
+        for p in &f.ports {
+            if p.name.name == "state" {
+                self.errors.push(CompileError::general(
+                    "'state' is reserved in fsm (the codegen maps it to the internal state_r register). Rename the port (e.g. 'state_o').",
+                    p.name.span,
+                ));
+            }
+        }
+        for r in &f.regs {
+            if r.name.name == "state" {
+                self.errors.push(CompileError::general(
+                    "'state' is reserved in fsm. Rename the signal (e.g. 'state_r').",
+                    r.name.span,
+                ));
+            }
+        }
+        for w in &f.wires {
+            if w.name.name == "state" {
+                self.errors.push(CompileError::general(
+                    "'state' is reserved in fsm. Rename the signal.",
+                    w.name.span,
+                ));
+            }
+        }
+        for l in &f.lets {
+            if l.name.name == "state" {
+                self.errors.push(CompileError::general(
+                    "'state' is reserved in fsm. Rename the binding.",
+                    l.name.span,
+                ));
+            }
+        }
+
         let _state_names: Vec<&str> = f.state_names.iter().map(|s| s.name.as_str()).collect();
 
         // Every declared state must have a state body

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -163,6 +163,40 @@ end fsm Broken
     assert!(resolve::resolve(&ast).is_err());
 }
 
+#[test]
+fn test_fsm_port_named_state_errors() {
+    // `state` is reserved in fsm — the codegen maps it to state_r.
+    // A user port named `state` would collide.
+    let source = r#"
+fsm BadFsm
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port state: out UInt<2>;
+  state [A, B]
+  default state A;
+  state A
+    comb
+      state = 2'd0;
+    end comb
+    -> B when true;
+  end state A
+  state B
+    comb
+      state = 2'd1;
+    end comb
+    -> A when true;
+  end state B
+end fsm BadFsm
+"#;
+    let tokens = lexer::tokenize(source).expect("lex");
+    let mut parser = Parser::new(tokens, source);
+    let ast = parser.parse_source_file().expect("parse");
+    let symbols = resolve::resolve(&ast).expect("resolve");
+    let checker = TypeChecker::new(&symbols, &ast);
+    let result = checker.check();
+    assert!(result.is_err(), "fsm with port named 'state' should error");
+}
+
 // ── FIFO ──────────────────────────────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary
Fixes #302. `state` is reserved in FSM — the codegen maps it to `state_r` via ident_subst. A user port named `state` would have assignments rewritten to the enum-typed register, producing SV ENUMVALUE errors.

Now rejected at typecheck time with: `state is reserved in fsm. Rename the port (e.g. state_o).`

## Test plan
- [x] New test: FSM with port `state` → typecheck error
- [x] `cargo test --release` — 336/336 pass