### PR TITLE
feat(lang): add `ascending` modifier for unpacked Vec ports/wires

### DIFF
--- a/doc/ARCH_HDL_Specification.md
+++ b/doc/ARCH_HDL_Specification.md
@@ -633,6 +633,34 @@ Effect mirrors the port form: SV emission flips to unpacked-array shape (`logic 
 
 Why this is opt-in: unpacked arrays are Yosys-unfriendly during synthesis and historically caused Icarus portability issues. The default packed shape preserves these guarantees; `unpacked` is a deliberate interop hatch for ports and wires that face external SV or that need to mate with an unpacked port across an `inst` connection.
 
+**3.7.1 Ascending Unpacked Dimension (`ascending` modifier)**
+
+The default `unpacked Vec<T, N>` emits the unpacked dimension as `[N-1:0]` (descending). To interop with upstream SystemVerilog declared with the bare `[N]` shorthand (= `[0:N-1]` ascending), add the `ascending` modifier after `unpacked`:
+
+```arch
+port csr_pmp_cfg_i:  in  unpacked ascending Vec<UInt<6>, PMPNumRegions>;
+port csr_pmp_addr_i: in  unpacked ascending Vec<UInt<34>, PMPNumRegions>;
+wire bridge:              unpacked ascending Vec<UInt<6>, PMPNumRegions>;
+```
+
+Emits:
+```sv
+input logic [5:0]  csr_pmp_cfg_i  [0:PMPNumRegions-1]
+input logic [33:0] csr_pmp_addr_i [0:PMPNumRegions-1]
+logic [5:0]        bridge         [0:PMPNumRegions-1]
+```
+
+**Why this matters:** IEEE 1800-2017 §10.10 maps unpacked-array port connections **element-by-position**, not element-by-index. When a `[N]`-declared SV array (positions 0..N-1, indices 0..N-1) connects to a `[N-1:0]` ARCH-emitted port (positions 0..N-1, indices N-1..0), the indices are **silently reversed**: caller's index `i` connects to callee's index `N-1-i`. There is no compiler warning. The `ascending` modifier flips the ARCH-side emission to match upstream's `[0:N-1]`, so position-based mapping aligns indices on both sides.
+
+ARCH-side indexing (`name[i]`) is **unchanged** — `name[0]` is always the first element regardless of SV emission direction. The keyword affects only the SV declaration.
+
+Restrictions:
+- Only legal when `unpacked` is also set (`ascending` alone, or on a packed Vec, has no meaning).
+- All other `unpacked` restrictions apply (Vec-only, no `port reg`, no `pipe_reg`).
+- For ARCH-to-ARCH connections across `ascending` ports, the connecting wire must also be `ascending` — otherwise the position-based mapping reverses inside our codebase too.
+
+**Rule of thumb:** if you're connecting to upstream SV and its port is declared `logic [W-1:0] x [N]` (no explicit range), use `unpacked ascending`. If the upstream port is `logic [W-1:0] x [N-1:0]` (explicit descending), use plain `unpacked`. If both arch-side endpoints are ARCH-generated and you have no SV-interop constraint, plain `unpacked` is fine.
+
 **4. Modules**
 
 A module is the fundamental unit of design in Arch. Every module follows the same four-section schema --- params, ports, body, optional verification. This regularity is intentional: an AI encountering any Arch construct can immediately orient itself using the same mental model.

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -287,6 +287,15 @@ pub struct PortDecl {
     /// modules whose port shape is fixed unpacked. Has no effect on
     /// ARCH-internal semantics. Only legal on `Vec<T,N>` types.
     pub unpacked: bool,
+    /// `ascending` modifier on an `unpacked Vec<T,N>` port: flips the
+    /// SV unpacked dimension to `[0:N-1]` (ascending) instead of the
+    /// default `[N-1:0]` (descending). For interop with upstream SV
+    /// declared with the bare `[N]` shorthand (= `[0:N-1]`). Without
+    /// this, IEEE 1800-2017 §10.10 element-by-position port mapping
+    /// silently reverses the index correspondence. ARCH-side indexing
+    /// (`name[i]`) is unchanged — `0` is always the first element. Only
+    /// legal when `unpacked` is also set.
+    pub unpacked_ascending: bool,
     pub span: Span,
 }
 
@@ -736,6 +745,11 @@ pub struct WireDecl {
     /// Verilator rejecting the packed/unpacked shape mismatch. Mirrors the
     /// `unpacked` modifier on port declarations (§3.7).
     pub unpacked: bool,
+    /// `wire name: unpacked ascending Vec<T,N>;` — emit the unpacked dim
+    /// as `[0:N-1]` ascending so the wire mates with an ascending port
+    /// (or upstream SV `[N]` shorthand) by-index without IEEE 1800-2017
+    /// §10.10 silent reversal. Only legal when `unpacked` is also set.
+    pub unpacked_ascending: bool,
     pub span: Span,
 }
 

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -3753,11 +3753,22 @@ impl<'a> Codegen<'a> {
     /// arrays are fine in Verilator but Yosys-unfriendly in synthesis,
     /// so all internal nets/regs/signals continue to use the packed shape
     /// from `emit_type_and_array_suffix`.
-    fn emit_type_and_unpacked_suffix(&self, ty: &TypeExpr) -> (String, String) {
+    /// Emit the SV unpacked-array form for a Vec<T,N>: returns
+    /// (base type string, suffix). When `ascending` is true, the unpacked
+    /// dim is emitted as `[0:N-1]` instead of the default `[N-1:0]`.
+    /// Required for interop with upstream SV that declares the connecting
+    /// array as `logic [W-1:0] x [N]` shorthand (= `[0:N-1]`); without
+    /// this, IEEE 1800-2017 §10.10 element-by-position port mapping
+    /// silently reverses the indices. See arch-com#307.
+    fn emit_type_and_unpacked_suffix_dir(&self, ty: &TypeExpr, ascending: bool) -> (String, String) {
         let mut dims = Vec::new();
         let mut cur = ty;
         while let TypeExpr::Vec(inner, size) = cur {
-            let range = self.emit_width_range(size);
+            let range = if ascending {
+                self.emit_width_range_ascending(size)
+            } else {
+                self.emit_width_range(size)
+            };
             dims.push(format!("[{range}]"));
             cur = inner;
         }
@@ -3767,6 +3778,22 @@ impl<'a> Codegen<'a> {
         let base_ty = self.emit_type_str(cur);
         let suffix: String = dims.iter().map(|d| format!(" {d}")).collect();
         (base_ty, suffix)
+    }
+
+    /// Emit an unpacked array dim as `0:N-1` (ascending). Mirrors
+    /// `emit_width_range` but flips the direction. The packed Vec dim
+    /// (controlled by `emit_width_range`) is always descending — only
+    /// the unpacked dim ever needs ascending.
+    fn emit_width_range_ascending(&self, w: &Expr) -> String {
+        match &w.kind {
+            ExprKind::Literal(LitKind::Dec(n)) => {
+                format!("0:{}", n.saturating_sub(1))
+            }
+            _ => {
+                let ws = self.emit_expr_str(w);
+                format!("0:{ws}-1")
+            }
+        }
     }
 
     // ── Synchronizer ─────────────────────────────────────────────────────────

--- a/src/codegen/module.rs
+++ b/src/codegen/module.rs
@@ -150,7 +150,7 @@ impl<'a> Codegen<'a> {
                         .map(|e| format!(" = {}", self.emit_expr_str(e)))
                         .unwrap_or_default();
                     if p.unpacked {
-                        let (base_ty, suffix) = self.emit_type_and_unpacked_suffix(&p.ty);
+                        let (base_ty, suffix) = self.emit_type_and_unpacked_suffix_dir(&p.ty, p.unpacked_ascending);
                         port_lines.push(format!("{} {} {}{}{}", dir, base_ty, p.name.name, suffix, init_str));
                     } else {
                         let (base_ty, suffix) = self.emit_type_and_array_suffix(&p.ty);
@@ -476,7 +476,7 @@ impl<'a> Codegen<'a> {
                         // Lets this wire mate with an `unpacked Vec<T,N>` port across
                         // an `inst` connection without Verilator rejecting the
                         // packed/unpacked shape mismatch.
-                        let (base_ty, suffix) = self.emit_type_and_unpacked_suffix(&w.ty);
+                        let (base_ty, suffix) = self.emit_type_and_unpacked_suffix_dir(&w.ty, w.unpacked_ascending);
                         self.line(&format!("{} {}{};", base_ty, w.name.name, suffix));
                     } else {
                         let (ty_str, arr_suffix) = self.emit_type_and_array_suffix(&w.ty);

--- a/src/elaborate.rs
+++ b/src/elaborate.rs
@@ -602,7 +602,7 @@ fn lower_tlm_connects_in_module(
         synthesized_wires.push(ModuleBodyItem::WireDecl(WireDecl {
             name: wire_ident.clone(),
             ty: TypeExpr::Named(Ident::new(from_bus.clone(), conn.span)),
-            unpacked: false,
+            unpacked: false, unpacked_ascending: false,
             span: conn.span,
         }));
 
@@ -1030,6 +1030,7 @@ fn subst_port(p: &PortDecl, var: &str, val: i64) -> PortDecl {
         bus_info: p.bus_info.clone(),
         shared: p.shared,
         unpacked: p.unpacked,
+        unpacked_ascending: p.unpacked_ascending,
         span: p.span,
     }
 }
@@ -1662,12 +1663,12 @@ fn lower_module_threads(m: ModuleDecl, opts: &ThreadLowerOpts) -> Result<(Module
             name: t.clock.clone(), direction: Direction::In,
             ty: type_map.get(&t.clock.name).map(|si| si.ty.clone())
                 .unwrap_or(TypeExpr::Clock(Ident::new("SysDomain".to_string(), sp))),
-            default: None, reg_info: None, bus_info: None, shared: None, unpacked: false, span: sp,
+            default: None, reg_info: None, bus_info: None, shared: None, unpacked: false, unpacked_ascending: false, span: sp,
         });
         merged_ports.push(PortDecl {
             name: t.reset.clone(), direction: Direction::In,
             ty: TypeExpr::Reset(rk, t.reset_level),
-            default: None, reg_info: None, bus_info: None, shared: None, unpacked: false, span: sp,
+            default: None, reg_info: None, bus_info: None, shared: None, unpacked: false, unpacked_ascending: false, span: sp,
         });
         (t.clock.name.clone(), t.reset.name.clone(), t.reset_level)
     };
@@ -1698,6 +1699,7 @@ fn lower_module_threads(m: ModuleDecl, opts: &ThreadLowerOpts) -> Result<(Module
                 ty: info.ty.clone(),
                 default: None, reg_info: None, bus_info: None, shared: None,
                 unpacked: info.unpacked,
+                unpacked_ascending: info.unpacked_ascending,
                 span: sp,
             });
         }
@@ -1716,6 +1718,7 @@ fn lower_module_threads(m: ModuleDecl, opts: &ThreadLowerOpts) -> Result<(Module
                 default: Some(make_zero_expr(sp)),
                 reg_info: None, bus_info: None, shared: info.shared,
                 unpacked: info.unpacked,
+                unpacked_ascending: info.unpacked_ascending,
                 span: sp,
             });
         }
@@ -1736,7 +1739,7 @@ fn lower_module_threads(m: ModuleDecl, opts: &ThreadLowerOpts) -> Result<(Module
                     // don't deprecate internal artifacts.
                     legacy_port_reg: false,
                 }),
-                bus_info: None, shared: None, unpacked: false, span: sp,
+                bus_info: None, shared: None, unpacked: false, unpacked_ascending: false, span: sp,
             });
         }
     }
@@ -1766,11 +1769,11 @@ fn lower_module_threads(m: ModuleDecl, opts: &ThreadLowerOpts) -> Result<(Module
         for ti in 0..n_threads {
             merged_body.push(ModuleBodyItem::WireDecl(WireDecl {
                 name: Ident::new(format!("_{}_req_{}", res_name, ti), sp),
-                ty: TypeExpr::Bool, unpacked: false, span: sp,
+                ty: TypeExpr::Bool, unpacked: false, unpacked_ascending: false, span: sp,
             }));
             merged_body.push(ModuleBodyItem::WireDecl(WireDecl {
                 name: Ident::new(format!("_{}_grant_{}", res_name, ti), sp),
-                ty: TypeExpr::Bool, unpacked: false, span: sp,
+                ty: TypeExpr::Bool, unpacked: false, unpacked_ascending: false, span: sp,
             }));
         }
         // Build packed req/grant vectors used by the arbiter inst.
@@ -1780,11 +1783,11 @@ fn lower_module_threads(m: ModuleDecl, opts: &ThreadLowerOpts) -> Result<(Module
             ExprKind::Literal(LitKind::Dec(n_threads as u64)), sp);
         merged_body.push(ModuleBodyItem::WireDecl(WireDecl {
             name: Ident::new(req_packed.clone(), sp),
-            ty: TypeExpr::UInt(Box::new(n_threads_expr.clone())), unpacked: false, span: sp,
+            ty: TypeExpr::UInt(Box::new(n_threads_expr.clone())), unpacked: false, unpacked_ascending: false, span: sp,
         }));
         merged_body.push(ModuleBodyItem::WireDecl(WireDecl {
             name: Ident::new(grant_packed.clone(), sp),
-            ty: TypeExpr::UInt(Box::new(n_threads_expr.clone())), unpacked: false, span: sp,
+            ty: TypeExpr::UInt(Box::new(n_threads_expr.clone())), unpacked: false, unpacked_ascending: false, span: sp,
         }));
         // Throwaway sinks for arbiter scalar outputs (the lock idiom only
         // consumes the per-thread grant ready bits, not the scalar grant
@@ -1794,12 +1797,12 @@ fn lower_module_threads(m: ModuleDecl, opts: &ThreadLowerOpts) -> Result<(Module
         let gr_width = crate::width::index_width(n_threads as u64);
         merged_body.push(ModuleBodyItem::WireDecl(WireDecl {
             name: Ident::new(gv_sink.clone(), sp),
-            ty: TypeExpr::Bool, unpacked: false, span: sp,
+            ty: TypeExpr::Bool, unpacked: false, unpacked_ascending: false, span: sp,
         }));
         merged_body.push(ModuleBodyItem::WireDecl(WireDecl {
             name: Ident::new(gr_sink.clone(), sp),
             ty: TypeExpr::UInt(Box::new(Expr::new(
-                ExprKind::Literal(LitKind::Dec(gr_width as u64)), sp))), unpacked: false, span: sp,
+                ExprKind::Literal(LitKind::Dec(gr_width as u64)), sp))), unpacked: false, unpacked_ascending: false, span: sp,
         }));
 
         // Pack/unpack between scalar wires and packed vectors.
@@ -1917,7 +1920,7 @@ fn lower_module_threads(m: ModuleDecl, opts: &ThreadLowerOpts) -> Result<(Module
                 merged_body.push(ModuleBodyItem::WireDecl(WireDecl {
                     name: Ident::new(wire_name, sp),
                     ty: info.ty.clone(),
-                    unpacked: false,
+                    unpacked: false, unpacked_ascending: false,
                     span: sp,
                 }));
             }
@@ -2542,24 +2545,24 @@ fn synthesize_lock_arbiter(
         PortDecl {
             name: Ident::new("clk".to_string(), sp),
             direction: Direction::In, ty: clk_ty, default: None,
-            reg_info: None, bus_info: None, shared: None, unpacked: false, span: sp,
+            reg_info: None, bus_info: None, shared: None, unpacked: false, unpacked_ascending: false, span: sp,
         },
         PortDecl {
             name: Ident::new("rst".to_string(), sp),
             direction: Direction::In, ty: rst_ty, default: None,
-            reg_info: None, bus_info: None, shared: None, unpacked: false, span: sp,
+            reg_info: None, bus_info: None, shared: None, unpacked: false, unpacked_ascending: false, span: sp,
         },
         PortDecl {
             name: Ident::new("grant_valid".to_string(), sp),
             direction: Direction::Out, ty: TypeExpr::Bool, default: None,
-            reg_info: None, bus_info: None, shared: None, unpacked: false, span: sp,
+            reg_info: None, bus_info: None, shared: None, unpacked: false, unpacked_ascending: false, span: sp,
         },
         PortDecl {
             name: Ident::new("grant_requester".to_string(), sp),
             direction: Direction::Out,
             ty: TypeExpr::UInt(Box::new(Expr::new(
                 ExprKind::Literal(LitKind::Dec(gr_width as u64)), sp))),
-            default: None, reg_info: None, bus_info: None, shared: None, unpacked: false, span: sp,
+            default: None, reg_info: None, bus_info: None, shared: None, unpacked: false, unpacked_ascending: false, span: sp,
         },
     ];
 
@@ -2570,12 +2573,12 @@ fn synthesize_lock_arbiter(
             PortDecl {
                 name: Ident::new("valid".to_string(), sp),
                 direction: Direction::In, ty: TypeExpr::Bool, default: None,
-                reg_info: None, bus_info: None, shared: None, unpacked: false, span: sp,
+                reg_info: None, bus_info: None, shared: None, unpacked: false, unpacked_ascending: false, span: sp,
             },
             PortDecl {
                 name: Ident::new("ready".to_string(), sp),
                 direction: Direction::Out, ty: TypeExpr::Bool, default: None,
-                reg_info: None, bus_info: None, shared: None, unpacked: false, span: sp,
+                reg_info: None, bus_info: None, shared: None, unpacked: false, unpacked_ascending: false, span: sp,
             },
         ],
         span: sp,
@@ -2620,6 +2623,11 @@ struct SignalInfo {
     /// instantiation in the parent gets a packed-vs-unpacked port
     /// connection mismatch.
     unpacked: bool,
+    /// Mirror of `unpacked_ascending` for the same reason — synthesized
+    /// sub-module ports must inherit the dimension direction or
+    /// SV port-boundary index reversal silently corrupts cross-module
+    /// arrays. See arch-com#307.
+    unpacked_ascending: bool,
 }
 
 fn build_module_type_map(m: &ModuleDecl) -> HashMap<String, SignalInfo> {
@@ -2631,6 +2639,7 @@ fn build_module_type_map(m: &ModuleDecl) -> HashMap<String, SignalInfo> {
             reg_init: p.reg_info.as_ref().and_then(|ri| ri.init.clone()),
             shared: p.shared,
             unpacked: p.unpacked,
+        unpacked_ascending: p.unpacked_ascending,
         });
     }
     for item in &m.body {
@@ -2641,7 +2650,7 @@ fn build_module_type_map(m: &ModuleDecl) -> HashMap<String, SignalInfo> {
                     reg_reset: r.reset.clone(),
                     reg_init: r.init.clone(),
                     shared: None,
-                    unpacked: false,
+                    unpacked: false, unpacked_ascending: false,
                 });
             }
             ModuleBodyItem::WireDecl(w) => {
@@ -2650,7 +2659,7 @@ fn build_module_type_map(m: &ModuleDecl) -> HashMap<String, SignalInfo> {
                     reg_reset: RegReset::None,
                     reg_init: None,
                     shared: None,
-                    unpacked: false,
+                    unpacked: false, unpacked_ascending: false,
                 });
             }
             ModuleBodyItem::LetBinding(l) => {
@@ -2660,7 +2669,7 @@ fn build_module_type_map(m: &ModuleDecl) -> HashMap<String, SignalInfo> {
                         reg_reset: RegReset::None,
                         reg_init: None,
                         shared: None,
-                        unpacked: false,
+                        unpacked: false, unpacked_ascending: false,
                     });
                 }
             }
@@ -6678,17 +6687,17 @@ fn lower_indexed_tlm_target_group(
         let rsp_tag = format!("{prefix}_rsp_tag");
         let rsp_data = format!("{prefix}_rsp_data");
 
-        out.push(ModuleBodyItem::WireDecl(WireDecl { name: mk_ident(req_ready.clone()), ty: TypeExpr::Bool, unpacked: false, span }));
-        out.push(ModuleBodyItem::WireDecl(WireDecl { name: mk_ident(rsp_valid.clone()), ty: TypeExpr::Bool, unpacked: false, span }));
-        out.push(ModuleBodyItem::WireDecl(WireDecl { name: mk_ident(rsp_ready.clone()), ty: TypeExpr::Bool, unpacked: false, span }));
+        out.push(ModuleBodyItem::WireDecl(WireDecl { name: mk_ident(req_ready.clone()), ty: TypeExpr::Bool, unpacked: false, unpacked_ascending: false, span }));
+        out.push(ModuleBodyItem::WireDecl(WireDecl { name: mk_ident(rsp_valid.clone()), ty: TypeExpr::Bool, unpacked: false, unpacked_ascending: false, span }));
+        out.push(ModuleBodyItem::WireDecl(WireDecl { name: mk_ident(rsp_ready.clone()), ty: TypeExpr::Bool, unpacked: false, unpacked_ascending: false, span }));
         out.push(ModuleBodyItem::WireDecl(WireDecl {
             name: mk_ident(rsp_tag.clone()),
             ty: TypeExpr::UInt(Box::new(Expr::new(ExprKind::Literal(LitKind::Dec(tag_w as u64)), span))),
-            unpacked: false,
+            unpacked: false, unpacked_ascending: false,
             span,
         }));
         if let Some(ret_ty) = &method.ret {
-            out.push(ModuleBodyItem::WireDecl(WireDecl { name: mk_ident(rsp_data.clone()), ty: ret_ty.clone(), unpacked: false, span }));
+            out.push(ModuleBodyItem::WireDecl(WireDecl { name: mk_ident(rsp_data.clone()), ty: ret_ty.clone(), unpacked: false, unpacked_ascending: false, span }));
         }
 
         let req_valid = Expr::new(

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -350,7 +350,11 @@ pub(crate) fn emit_ports(s: &mut String, ports: &[PortDecl]) {
             // port shape would silently see packed-Vec when the source
             // is unpacked-Vec, causing port-shape mismatches at the
             // SV inst boundary.
-            let unpacked_kw = if p.unpacked { "unpacked " } else { "" };
+            let unpacked_kw = match (p.unpacked, p.unpacked_ascending) {
+                (true, true)  => "unpacked ascending ",
+                (true, false) => "unpacked ",
+                _             => "",
+            };
             // For port reg with reset, include reset clause
             if let Some(ref ri) = p.reg_info {
                 match &ri.reset {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -400,7 +400,7 @@ impl Parser {
             default: None,
             reg_info: None,
             bus_info: None,
-            shared: None, unpacked: false,
+            shared: None, unpacked: false, unpacked_ascending: false,
             span: parent_span.merge(end_span),
         })
     }
@@ -601,7 +601,7 @@ impl Parser {
             default: None,
             reg_info: None,
             bus_info: None,
-            shared: None, unpacked: false,
+            shared: None, unpacked: false, unpacked_ascending: false,
             span: sp,
         };
         // Control signals (payload-direction = `dir`, back-signal = `opposite`).
@@ -984,7 +984,7 @@ impl Parser {
                 default: None,
                 reg_info: None,
                 bus_info: Some(BusPortInfo { bus_name, perspective, params }),
-                shared: None, unpacked: false,
+                shared: None, unpacked: false, unpacked_ascending: false,
                 span: start.merge(end_span),
             });
         }
@@ -1011,6 +1011,11 @@ impl Parser {
         // Flips SV port emission to unpacked-array shape. Only legal on Vec<T,N>
         // and incompatible with `port reg` / `pipe_reg<T,N>`. Validated below.
         let unpacked = self.eat_contextual("unpacked");
+        // Optional `ascending` modifier: `port ... in unpacked ascending Vec<T,N>;`
+        // Only meaningful (and only legal) with `unpacked`. Flips the SV
+        // unpacked dim to `[0:N-1]` for interop with upstream SV declared as
+        // `logic [W-1:0] x [N]`. See arch-com#307.
+        let unpacked_ascending = if unpacked { self.eat_contextual("ascending") } else { false };
         if unpacked && is_reg {
             return Err(CompileError::general(
                 "`unpacked` is not allowed on `port reg` / pipe_reg<T,N> ports",
@@ -1144,6 +1149,7 @@ impl Parser {
             bus_info: None,
             shared,
             unpacked,
+            unpacked_ascending,
             span: start.merge(end_span),
         })
     }
@@ -1252,6 +1258,9 @@ impl Parser {
         // Optional `unpacked` modifier: `wire name: unpacked Vec<T,N>;`
         // Mirrors the port modifier (§3.7); only legal on Vec<T,N>.
         let unpacked = self.eat_contextual("unpacked");
+        // Optional `ascending` follows `unpacked` (mirror of port modifier).
+        // See arch-com#307.
+        let unpacked_ascending = if unpacked { self.eat_contextual("ascending") } else { false };
         let ty = self.parse_type_expr()?;
         self.expect(TokenKind::Semi)?;
         let end_span = self.tokens.get(self.pos.saturating_sub(1)).map(|t| t.span).unwrap_or(start);
@@ -1265,6 +1274,7 @@ impl Parser {
             name,
             ty,
             unpacked,
+            unpacked_ascending,
             span: start.merge(end_span),
         })
     }
@@ -4280,7 +4290,7 @@ impl Parser {
         let ty = self.parse_type_expr()?;
         self.expect(TokenKind::Semi)?;
         let end_span = self.tokens.get(self.pos.saturating_sub(1)).map(|t| t.span).unwrap_or(start);
-        Ok(PortDecl { name, direction, ty, default: None, reg_info: None, bus_info: None, shared: None, unpacked: false, span: start.merge(end_span) })
+        Ok(PortDecl { name, direction, ty, default: None, reg_info: None, bus_info: None, shared: None, unpacked: false, unpacked_ascending: false, span: start.merge(end_span) })
     }
 
     fn parse_ram_init(&mut self) -> Result<RamInit, CompileError> {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -8860,6 +8860,89 @@ end module unpacked_demo
 }
 
 #[test]
+fn test_unpacked_ascending_emits_ascending_sv_dim() {
+    // `unpacked ascending Vec<T,N>` flips the SV unpacked dim to `[0:N-1]`
+    // (vs the default `[N-1:0]` for `unpacked`). Required for interop with
+    // upstream SV declared as `logic [W-1:0] x [N]` shorthand (= `[0:N-1]`)
+    // — without this, IEEE 1800-2017 §10.10 element-by-position port
+    // mapping silently reverses indices at the connection. See arch-com#307.
+    let source = r#"
+module unpacked_asc_demo
+  port asc_in:    in  unpacked ascending Vec<UInt<6>, 4>;
+  port asc_out:   out unpacked ascending Vec<UInt<6>, 4>;
+  port desc_in:   in  unpacked Vec<UInt<6>, 4>;
+  comb
+    asc_out[0] = asc_in[0];
+    asc_out[3] = asc_in[3];
+  end comb
+end module unpacked_asc_demo
+"#;
+    let sv = compile_to_sv(source);
+    // `ascending` flips both directions.
+    assert!(sv.contains("input logic [5:0] asc_in [0:3]"),
+            "ascending unpacked input should emit [0:N-1], got: {sv}");
+    assert!(sv.contains("output logic [5:0] asc_out [0:3]"),
+            "ascending unpacked output should emit [0:N-1], got: {sv}");
+    // Plain `unpacked` (no `ascending`) keeps default descending.
+    assert!(sv.contains("input logic [5:0] desc_in [3:0]"),
+            "plain unpacked stays descending, got: {sv}");
+    // ARCH-side indexing is unchanged — `asc_in[0]` is still the first
+    // element regardless of SV dim direction.
+    assert!(sv.contains("assign asc_out[0] = asc_in[0]"));
+    assert!(sv.contains("assign asc_out[3] = asc_in[3]"));
+}
+
+#[test]
+fn test_unpacked_ascending_wire_emits_ascending() {
+    // `wire ... unpacked ascending Vec<T,N>;` — same flip on a wire
+    // declaration so the wire mates with an ascending port (or upstream
+    // SV `[N]` array) by-index without reversal. arch-com#307.
+    let source = r#"
+module asc_wire_demo
+  port out_o: out unpacked ascending Vec<UInt<6>, 4>;
+  wire w: unpacked ascending Vec<UInt<6>, 4>;
+  comb
+    w[0]     = 6'd1;
+    w[1]     = 6'd2;
+    w[2]     = 6'd3;
+    w[3]     = 6'd4;
+    out_o[0] = w[0];
+    out_o[1] = w[1];
+    out_o[2] = w[2];
+    out_o[3] = w[3];
+  end comb
+end module asc_wire_demo
+"#;
+    let sv = compile_to_sv(source);
+    assert!(sv.contains("logic [5:0] w [0:3]"),
+            "ascending unpacked wire should emit [0:N-1], got: {sv}");
+}
+
+#[test]
+fn test_unpacked_ascending_archi_emit() {
+    // `.archi` interface stub must preserve the `ascending` keyword so
+    // downstream consumers see the same shape as the .sv. arch-com#307.
+    let source = "
+domain SysDomain
+  freq_mhz: 100
+end domain SysDomain
+
+module AscIface
+  port asc_in: in unpacked ascending Vec<UInt<6>, 4>;
+end module AscIface
+";
+    let tokens = lexer::tokenize(source).expect("lexer error");
+    let mut parser = Parser::new(tokens, source);
+    let parsed = parser.parse_source_file().expect("parse error");
+    let item = parsed.items.iter()
+        .find(|i| matches!(i, arch::ast::Item::Module(_)))
+        .expect("expected a module item");
+    let body = arch::interface::emit_interface(item).expect("emit_interface");
+    assert!(body.contains("port asc_in: in unpacked ascending Vec"),
+            ".archi should preserve `unpacked ascending`: {body}");
+}
+
+#[test]
 fn test_unpacked_on_non_vec_is_rejected() {
     let source = r#"
 module unpacked_neg


### PR DESCRIPTION
Closes #307.

## Summary

Adds an `ascending` modifier on `unpacked Vec<T,N>` port and wire declarations so the SV unpacked dim emits as `[0:N-1]` instead of the default `[N-1:0]`. Required for interop with upstream SV declared via the bare `[N]` shorthand (= `[0:N-1]`); without it, IEEE 1800-2017 §10.10 element-by-position port mapping silently reverses indices at the connection.

```arch
port csr_pmp_cfg_i: in unpacked ascending Vec<UInt<6>, PMPNumRegions>;
wire bridge:             unpacked ascending Vec<UInt<6>, PMPNumRegions>;
```

Emits:
```sv
input logic [5:0] csr_pmp_cfg_i [0:PMPNumRegions-1]
logic [5:0] bridge [0:PMPNumRegions-1]
```

ARCH-side indexing (`name[i]`) is unchanged — `0` is always the first element. The keyword affects only SV declaration. `ascending` is only legal when `unpacked` is also set; default remains descending so all existing code is unaffected.

## Surfacing context

Issue #307 has the full runtime evidence from arch-ibex pmp_exec_isr (D2-followup). End-to-end verified after this PR is consumed: PMP CSR writes now land at the correct cs_registers index (`csr_pmp_cfg[0] = 0x28`, `csr_pmp_addr[0] = 0x100148` for a `pmpcfg0=0x88` + `pmpaddr0=forbidden_func>>2` write — previously they landed at index 3 due to the silent reversal).

## Changes

- `ast`: add `unpacked_ascending: bool` to `PortDecl` and `WireDecl`.
- `parser`: optionally eat `ascending` after `unpacked` (contextual keyword).
- `codegen`: `emit_type_and_unpacked_suffix_dir(ty, ascending)` — ascending emits `[0:N-1]` via new `emit_width_range_ascending`. Module port + wire emitters thread the flag through.
- `interface`: `.archi` round-trips `unpacked ascending`.
- `elaborate`: propagate the flag through synthesized port/wire decls (threads-submodule sync etc.) so SV-side direction stays consistent across compiler-generated modules.
- `doc`: §3.7.1 added with semantics, rationale, restrictions, and rule-of-thumb interop guidance.
- `tests`: 3 integration tests (port emit, wire emit, .archi round-trip); existing 7 unpacked tests unaffected.

## Test plan

- [x] `cargo build` clean (no warnings)
- [x] `cargo test` — 337/337 pass; the 3 new + 7 existing unpacked tests all green
- [x] End-to-end smoke on arch-ibex: built `IbexCore.arch` + `IbexPmp.arch` with `unpacked ascending` on the PMP CSR cfg/addr surfaces, verified via runtime introspection that `pmpcfg0`/`pmpaddr0` writes land at IbexPmp region 0 (no longer flipped to region 3)

## Follow-up

arch-ibex consumer changes will land in a separate PR after this merges, since the `ascending` keyword would parse-error against the current arch-com binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)