### PR TITLE
fix(typecheck): error when arbiter hook param shadows port name

### DIFF
--- a/examples/arbiter_custom_hook.arch
+++ b/examples/arbiter_custom_hook.arch
@@ -37,6 +37,6 @@ arbiter QosArbiter
   end ports request
   port grant_valid: out Bool;
   port grant_requester: out UInt<2>;
-  hook grant_select(req_mask: UInt<4>, last_grant: UInt<4>, qos: UInt<8>) -> UInt<4>
-    = QosGrant(req_mask, last_grant, qos);
+  hook grant_select(req_mask: UInt<4>, last_grant: UInt<4>, qos_in: UInt<8>) -> UInt<4>
+    = QosGrant(req_mask, last_grant, qos_in);
 end arbiter QosArbiter

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -4977,6 +4977,21 @@ impl<'a> TypeChecker<'a> {
             let port_names: Vec<&str> = a.ports.iter().map(|p| p.name.name.as_str()).collect();
             let param_names: Vec<&str> = a.params.iter().map(|p| p.name.name.as_str()).collect();
             let hook_param_names: Vec<&str> = hook.params.iter().map(|p| p.name.name.as_str()).collect();
+            // Hook parameter names must not shadow arbiter port names — the
+            // codegen emits the function inside the module, so a name collision
+            // produces SV VARHIDDEN warnings.
+            for hp in &hook.params {
+                if port_names.contains(&hp.name.name.as_str()) {
+                    self.errors.push(CompileError::general(
+                        &format!(
+                            "hook parameter `{}` shadows arbiter port of the same name. \
+                             Rename the hook parameter (e.g. `{}s`) or the port.",
+                            hp.name.name, hp.name.name,
+                        ),
+                        hp.name.span,
+                    ));
+                }
+            }
             for arg in &hook.fn_args {
                 if !hook_param_names.contains(&arg.name.as_str())
                     && !port_names.contains(&arg.name.as_str())

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -398,7 +398,7 @@ fn test_arbiter_custom_hook() {
     let sv = compile_to_sv(source);
     assert!(sv.contains("module QosArbiter"));
     assert!(sv.contains("function automatic"));
-    assert!(sv.contains("QosGrant(request_valid, last_grant_r, qos)"));
+    assert!(sv.contains("QosGrant(request_valid, last_grant_r, qos_in)"));
     assert!(sv.contains("last_grant_r"));
     assert!(sv.contains("grant_onehot"));
     insta::assert_snapshot!(sv);
@@ -433,6 +433,41 @@ end arbiter BadArb
     let checker = TypeChecker::new(&symbols, &ast);
     let result = checker.check();
     assert!(result.is_err(), "expected error for custom policy without hook");
+}
+
+#[test]
+fn test_arbiter_hook_param_shadows_port_errors() {
+    // Hook parameter names must not shadow arbiter port names — codegen
+    // emits the function inside the module, causing SV VARHIDDEN.
+    let source = r#"
+domain SysDomain
+  freq_mhz: 100
+end domain SysDomain
+
+arbiter BadArb
+  policy ShadowFn;
+  param NUM_REQ: const = 4;
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port age: in UInt<8>;
+  ports[NUM_REQ] request
+    valid: in Bool;
+    ready: out Bool;
+  end ports request
+  port grant_valid: out Bool;
+  port grant_requester: out UInt<2>;
+  hook grant_select(req_mask: UInt<4>, age: UInt<8>) -> UInt<4>
+    = ShadowFn(req_mask, age);
+end arbiter BadArb
+"#;
+    let tokens = lexer::tokenize(source).expect("lexer error");
+    let mut parser = Parser::new(tokens, source);
+    let parsed_ast = parser.parse_source_file().expect("parse error");
+    let ast = elaborate::elaborate(parsed_ast).expect("elaborate error");
+    let symbols = resolve::resolve(&ast).expect("resolve error");
+    let checker = TypeChecker::new(&symbols, &ast);
+    let result = checker.check();
+    assert!(result.is_err(), "expected error for hook param shadowing port");
 }
 
 #[test]

--- a/tests/snapshots/integration_test__arbiter_custom_hook.snap
+++ b/tests/snapshots/integration_test__arbiter_custom_hook.snap
@@ -31,7 +31,7 @@ module QosArbiter #(
   logic [3:0] grant_onehot;
   
   always_comb begin
-    grant_onehot = QosGrant(request_valid, last_grant_r, qos);
+    grant_onehot = QosGrant(request_valid, last_grant_r, qos_in);
     grant_valid = |grant_onehot;
     request_ready = grant_onehot;
     grant_requester = '0;


### PR DESCRIPTION
## Summary
Fixes #301. Hook parameters sharing names with arbiter ports cause SV VARHIDDEN because codegen emits the function inside the module. Rejected at typecheck with:

`hook parameter age shadows arbiter port of the same name. Rename the hook parameter (e.g. ages) or the port.`

## Changes
- `check_arbiter`: new collision check between hook params and port names
- `examples/arbiter_custom_hook.arch`: renamed hook param `qos` → `qos_in` (was the repro case)
- Updated snapshot and test assertion

## Test plan
- [x] New test: hook param `age` shadows port `age` → typecheck error
- [x] `cargo test --release` — 337/337 pass