### PR TITLE
codegen: hoist module-scope decls so identifiers declare before use

### DIFF
--- a/src/codegen/arbiter.rs
+++ b/src/codegen/arbiter.rs
@@ -337,8 +337,13 @@ impl<'a> Codegen<'a> {
     ) {
         let fn_name = &fn_ident.name;
 
-        // last_grant_r register for fairness state
+        // last_grant_r register for fairness state. grant_onehot is
+        // declared up-front (before the always_ff that reads it) so
+        // strict SV frontends like yosys-slang see the wire declared
+        // before any read; the always_comb that drives it stays in
+        // its source-order position below.
         self.line(&format!("logic [{}:0] last_grant_r;", num_req - 1));
+        self.line(&format!("logic [{}:0] grant_onehot;", num_req - 1));
         self.line("");
 
         let ff_sens = Self::ff_sensitivity(clk, rst, is_async, is_low);
@@ -372,9 +377,9 @@ impl<'a> Codegen<'a> {
         }).collect();
         let args_str = args.join(", ");
 
-        // Call the function to get one-hot grant mask
-        self.line(&format!("logic [{}:0] grant_onehot;", num_req - 1));
-        self.line("");
+        // grant_onehot decl was hoisted above (next to last_grant_r)
+        // so the always_ff can read it without slang flagging
+        // declaration-order. Drive it from the always_comb here.
         self.line("always_comb begin");
         self.indent += 1;
         self.line(&format!("grant_onehot = {fn_name}({args_str});"));

--- a/src/codegen/module.rs
+++ b/src/codegen/module.rs
@@ -230,11 +230,92 @@ impl<'a> Codegen<'a> {
             }
         }
 
-        // Single pass in source order; interleave comments by byte position.
-        // We need a clone of m to satisfy the borrow checker when calling
-        // emit_reg_block (which takes &ModuleDecl) while also mutating self.
-        let body_items: Vec<ModuleBodyItem> = m.body.clone();
+        // Two-bucket preorder: declarations + let-bindings first, then
+        // the rest (CombBlock, RegBlock, LatchBlock, Inst, Generate,
+        // Function, Assert) in source order.
+        //
+        // Why: SystemVerilog LRM permits forward references for net
+        // declarations within a module, but yosys-slang and other
+        // strict frontends enforce decl-before-use. Source-order
+        // emission would put a `let foo: T = ...` after an `inst u_x`
+        // that connects `foo` to a port — and the strict frontend
+        // rejects that as identifier-used-before-declaration. Hoisting
+        // all RegDecl/WireDecl/PipeRegDecl/LetBinding ahead of insts
+        // and behavior blocks fixes this without changing semantics
+        // (continuous assigns and always blocks evaluate based on
+        // signal values regardless of textual order).
+        //
+        // Verilator and iverilog accept either ordering.
+        //
+        // Comments interleaved with body items are emitted at their
+        // original byte positions (`emit_comments_before`), which now
+        // means a comment may land just before the bucket boundary
+        // rather than next to its original target item. The comments
+        // are still all present and in source order; only their
+        // proximity to specific items shifts when buckets reorder.
         let m_clone = m.clone();
+
+        // Stage 1: emit module-scope `function` items FIRST. Functions
+        // come before any `let`/`wire`/`reg` declaration so that a
+        // function's input parameter (e.g. `spimm`) doesn't VARHIDDEN-
+        // shadow a module-scope identifier of the same name. (Once the
+        // outer `logic spimm;` exists, the function param shadows it
+        // and verilator lints out.)
+        for it in m.body.iter() {
+            if let ModuleBodyItem::Function(f) = it {
+                self.emit_function(f);
+            }
+        }
+
+        // Stage 2: bucket-sorted main body — decls, then everything
+        // else. Functions are excluded (already emitted in stage 1).
+        let body_items: Vec<ModuleBodyItem> = {
+            let mut decls: Vec<ModuleBodyItem> = Vec::new();
+            let mut rest:  Vec<ModuleBodyItem> = Vec::new();
+            for it in m.body.iter() {
+                match it {
+                    ModuleBodyItem::Function(_) => {} // already emitted in stage 1
+                    ModuleBodyItem::RegDecl(_)
+                    | ModuleBodyItem::WireDecl(_)
+                    | ModuleBodyItem::PipeRegDecl(_)
+                    | ModuleBodyItem::LetBinding(_) => decls.push(it.clone()),
+                    _ => rest.push(it.clone()),
+                }
+            }
+            decls.into_iter().chain(rest.into_iter()).collect()
+        };
+
+        // Stage 3: LetBinding decl pre-emit. Simple typed `let foo: T = expr;`
+        // bindings get split — the `T foo;` declaration is hoisted here
+        // (above all `assign` and `inst` lines), and the `assign foo =
+        // expr;` stays in the main-loop emission below. This makes the
+        // decl visible before any other LetBinding's RHS or any inst
+        // port connection that references `foo`.
+        //
+        // Destructure (`let {a, b} = ...`) and large match-expr lets
+        // are NOT split here — their decl + body emission is too
+        // intertwined to safely separate without a deeper refactor.
+        // Those names continue to use source-order emission and may
+        // still trip strict frontends if forward-referenced; in
+        // practice the current arch-ibex codebase doesn't hit that
+        // case.
+        let mut pre_emitted_let_names: std::collections::HashSet<String> =
+            std::collections::HashSet::new();
+        for item in &body_items {
+            if let ModuleBodyItem::LetBinding(l) = item {
+                if l.ty.is_none() { continue; }
+                if !l.destructure_fields.is_empty() { continue; }
+                if let ExprKind::ExprMatch(_, arms) = &l.value.kind {
+                    if arms.len() >= 3 { continue; }
+                }
+                if let Some(ty) = &l.ty {
+                    let (ty_str, arr_suffix) = self.emit_type_and_array_suffix(ty);
+                    self.line(&format!("{} {}{};", ty_str, l.name.name, arr_suffix));
+                    pre_emitted_let_names.insert(l.name.name.clone());
+                }
+            }
+        }
+
         for item in &body_items {
             self.emit_comments_before(item.span().start);
             match item {
@@ -400,8 +481,14 @@ impl<'a> Codegen<'a> {
                     }
                     let val_str = self.emit_expr_str(&l.value);
                     if let Some(ty) = &l.ty {
-                        let (ty_str, arr_suffix) = self.emit_type_and_array_suffix(ty);
-                        self.line(&format!("{} {}{};", ty_str, l.name.name, arr_suffix));
+                        // Skip the decl line if it was hoisted in the
+                        // pre-emit pass above — but still emit the
+                        // `assign` here in source position.
+                        if !pre_emitted_let_names.contains(&l.name.name) {
+                            let (ty_str, arr_suffix) = self.emit_type_and_array_suffix(ty);
+                            self.line(&format!("{} {}{};", ty_str, l.name.name, arr_suffix));
+                        }
+                        let _ = ty;
                         self.line(&format!("assign {} = {};", l.name.name, val_str));
                     } else {
                         // ty=None: assignment to existing port or wire — no logic declaration


### PR DESCRIPTION
## Summary

Reorder the per-module SV body emission so declarations precede any reference. This makes the generated SV pass through strict static elaborators (yosys-slang) without changing simulation semantics or breaking any existing gate.

## Background

While running yosys synthesis on arch-ibex via the yosys-slang frontend (for a real area/timing comparison vs upstream Ibex), slang rejected every forward-referenced identifier as a build error: `error: identifier 'foo' used before its declaration`. Verilator and iverilog accept the old interleaved order, so all existing simulation gates were green and the issue was invisible until a strict static elaborator parsed the same SV.

The pattern that triggered it: a typed `let foo: T = ...;` in arch source emits as `T foo; assign foo = ...;`. If `foo` is also referenced in an `inst u_x` connection earlier in the same module, the inst's port reference precedes the `T foo;` decl in the emitted SV. LRM-permitted (nets can be forward-declared) but slang flags it as an error.

Same issue surfaced for arbiter codegen: `grant_onehot` was used in an `always_ff` block before its declaration appeared a few lines later.

## Changes

**`src/codegen/module.rs`** — three-stage emission:

1. **Stage 1 — Functions first.** Module-scope `function` items emit at the top, before any `let`/`wire`/`reg`. Reason: a function's input parameter (e.g. `spimm`) would VARHIDDEN-shadow a same-named module-scope `let`/`wire` if functions came after — verilator lints this out.

2. **Stage 2 — Decl bucket.** `RegDecl`, `WireDecl`, `PipeRegDecl`, and `LetBinding` items emit before everything else (insts, comb/seq blocks, generate, asserts).

3. **Stage 3 — Let-binding decl split.** Simple typed `let foo: T = expr;` bindings get split: the `T foo;` declaration is hoisted to the top of stage 2 (above ALL `assign` and `inst` lines), and the `assign foo = expr;` stays in source position. Handles the case where one let-binding's RHS references another that's declared later in source.

   Destructure (`let {a, b} = ...`) and large match-expr lets are NOT split — their decl + body emission is too intertwined to safely separate without a deeper refactor. Current arch-ibex codebase doesn't trip on those.

**`src/codegen/arbiter.rs`** — hoist `grant_onehot` decl above the always_ff that reads it. Same root issue, different codegen path.

## Comment placement

Comments interleaved with body items still emit at their original byte positions (`emit_comments_before`). With the bucket reorder, a comment may now land near a bucket boundary rather than next to its original target item. Comments are all still present and in source order; only their proximity to specific items shifts when buckets reorder.

## Verification

- `cargo test --release` → 340 passed, 0 failed.
- arch-ibex full gate (`pytest -n auto --dist=loadfile`) → **129 passed, 74 skipped, 0 failed** (no regression vs main).
- yosys-slang now accepts every arch-ibex `build/*.sv` end-to-end. The arch-ibex swap synthesizes cleanly:
  ```
  Chip area for module '\ibex_top': 204882.748800
  ```

## Follow-up (not in this PR)

One residual codegen gap remains for the strict-elaborator path: when an `inst` port type is an upstream-defined enum (e.g. `ibex_pkg::csr_num_e`, `ibex_pkg::csr_op_e`, `ibex_pkg::dbg_cause_e`) and the connected wire is a plain `logic[N]`, slang requires an explicit `pkg::enum_t'(sig)` cast. That's a separate codegen change.

## Test plan

- [x] `cargo test --release` (arch-com unit tests, 340/0)
- [x] arch-ibex full gate (`pytest -n auto --dist=loadfile`, 129/74/0)
- [x] yosys-slang elaboration of arch-ibex swap (`yosys -c run_swap_synth_slang.tcl`, builds clean past slang)
- [x] yosys-slang elaboration of upstream Ibex (sanity — same flow, no swap, builds clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)