### PR TITLE
codegen: extern-pkg per-type imports + auto-cast at inst boundaries

### DIFF
--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -1342,17 +1342,50 @@ impl<'a> Codegen<'a> {
         // Expand bus port connections: one bus connect → N signal connects
         let mut connections: Vec<String> = Vec::new();
         // Find the target construct's ports to detect bus ports (modules and FSMs)
-        let target_bus_ports: Vec<(String, String, Vec<ParamAssign>)> = {
-            let target_ports: Option<&[PortDecl]> = self.source.items.iter()
-                .find_map(|item| match item {
-                    Item::Module(m) if m.name.name == inst.module_name.name => Some(m.ports.as_slice()),
-                    Item::Fsm(f) if f.name.name == inst.module_name.name => Some(f.ports.as_slice()),
-                    _ => None,
-                });
-            target_ports.map(|ports| ports.iter()
+        let target_ports_ref: Option<&[PortDecl]> = self.source.items.iter()
+            .find_map(|item| match item {
+                Item::Module(m) if m.name.name == inst.module_name.name => Some(m.ports.as_slice()),
+                Item::Fsm(f) if f.name.name == inst.module_name.name => Some(f.ports.as_slice()),
+                _ => None,
+            });
+        let target_bus_ports: Vec<(String, String, Vec<ParamAssign>)> = target_ports_ref
+            .map(|ports| ports.iter()
                 .filter_map(|p| p.bus_info.as_ref().map(|bi| (p.name.name.clone(), bi.bus_name.name.clone(), bi.params.clone())))
                 .collect())
-                .unwrap_or_default()
+            .unwrap_or_default();
+
+        // Per-port enum-cast lookup. For each input port whose type is
+        // an extern-package enum (declared via `extern package Pkg ...
+        // type enum_t; ...`), record the package + type name so the
+        // inst-connect emission below can wrap the connected signal in
+        // an explicit `Pkg::enum_t'(sig)` cast. yosys-slang rejects
+        // implicit `logic[N] -> enum_t` conversion at port boundaries
+        // (the source-level `wire NAME: UInt<N>;` declaration in the
+        // arch source means the connected signal is `logic[N]`, not the
+        // enum); the cast keeps strict elaborators happy.
+        // Verilator and iverilog accept the implicit conversion either
+        // way.
+        let port_enum_casts: std::collections::HashMap<String, (String, String)> = {
+            let mut m = std::collections::HashMap::new();
+            if let Some(ports) = target_ports_ref {
+                for p in ports {
+                    if let TypeExpr::Named(id) = &p.ty {
+                        if let Some((Symbol::ExternEnum(_), _)) = self.symbols.globals.get(&id.name) {
+                            // Find the owning extern-package by scanning
+                            // Item::ExternPackage entries — the resolve
+                            // table records only the type name, not its
+                            // owning package.
+                            let pkg_name = self.source.items.iter().find_map(|it| match it {
+                                Item::ExternPackage(ep) if ep.types.iter().any(|t| t.name == id.name) =>
+                                    Some(ep.name.name.clone()),
+                                _ => None,
+                            }).unwrap_or_else(|| id.name.clone());
+                            m.insert(p.name.name.clone(), (pkg_name, id.name.clone()));
+                        }
+                    }
+                }
+            }
+            m
         };
 
         // ── Collect target's per-requester ports[N] groups (arbiter / regfile) ──
@@ -1445,7 +1478,16 @@ impl<'a> Codegen<'a> {
                     }
                 }
             } else {
-                connections.push(format!(".{}({})", c.port_name.name, self.emit_expr_str(&c.signal)));
+                let sig_str = self.emit_expr_str(&c.signal);
+                let conn_str = if let Some((pkg, ty_name)) = port_enum_casts.get(&c.port_name.name) {
+                    // Wrap in explicit cast to the destination port's
+                    // extern-enum type so yosys-slang accepts the
+                    // boundary. No-op for verilator / iverilog.
+                    format!(".{}({}::{}'({}))", c.port_name.name, pkg, ty_name, sig_str)
+                } else {
+                    format!(".{}({})", c.port_name.name, sig_str)
+                };
+                connections.push(conn_str);
             }
         }
 

--- a/src/codegen/module.rs
+++ b/src/codegen/module.rs
@@ -18,27 +18,42 @@ impl<'a> Codegen<'a> {
             return;
         }
         self.current_construct = m.name.name.clone();
-        // Emit SV `import NAME::*;` only for `use NAME;` whose target is an
-        // actual `package` — package contents become an SV package and need
-        // the import for typedef/enum/struct visibility. Other `use` targets
-        // (bus, module, fsm, ...) are pure compile-time references that the
-        // ARCH compiler resolves before codegen; emitting `import` for them
-        // breaks Verilator/iverilog since no corresponding SV package exists.
+
+        // File-scope imports for `use Pkg;`:
+        //   - arch `package` Pkg → `import Pkg::*;` (wildcard).
+        //     arch packages are first-class arch artifacts; the
+        //     user manages their namespace.
+        //   - `extern package` Pkg → per-TYPE `import Pkg::T;`
+        //     for each declared type. Avoid the `import Pkg::*;`
+        //     wildcard for extern packages because the upstream SV
+        //     package usually contains many enum items and
+        //     parameters (e.g. `IC_NUM_WAYS`, `IbexMuBiOn`,
+        //     `WB_INSTR_OTHER`) that would pollute every
+        //     compilation-unit-visible scope and conflict with
+        //     identically-named locals.
+        // Both kinds emit at file scope so module-header parameter
+        // types like `parameter rv32m_e RV32M` resolve.
         for item in &self.source.items {
             if let Item::Use(u) = item {
-                let is_package = self.source.items.iter().any(|i| {
+                let arch_pkg = self.source.items.iter().any(|i| {
                     matches!(i, Item::Package(p) if p.name.name == u.name.name)
                 });
-                let is_extern = self.source.items.iter().any(|i| {
-                    matches!(i, Item::ExternPackage(ep) if ep.name.name == u.name.name)
+                let extern_pkg = self.source.items.iter().find_map(|i| {
+                    if let Item::ExternPackage(ep) = i {
+                        if ep.name.name == u.name.name { return Some(ep); }
+                    }
+                    None
                 });
-                if is_package || is_extern {
+                if arch_pkg {
                     self.out.push_str(&format!("import {}::*;\n", u.name.name));
+                } else if let Some(ep) = extern_pkg {
+                    for ty in &ep.types {
+                        self.out.push_str(&format!("import {}::{};\n", u.name.name, ty.name));
+                    }
                 }
             }
         }
 
-        // Module header with parameters
         if m.params.is_empty() {
             self.out.push_str(&format!("module {} (\n", m.name.name));
         } else {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -2922,8 +2922,16 @@ module IbexCore
 end module IbexCore
 "#;
     let sv = compile_to_sv(source);
-    assert!(sv.contains("import ibex_pkg::*;"),
-            "expected SV `import ibex_pkg::*;` for extern package:\n{sv}");
+    // extern packages emit per-TYPE imports (`import Pkg::T;`)
+    // rather than wildcard `import Pkg::*;` so unrelated enum
+    // items / parameters from the upstream SV package don't pollute
+    // the compilation unit and conflict with locally-named signals.
+    assert!(sv.contains("import ibex_pkg::rv32m_e;"),
+            "expected SV `import ibex_pkg::rv32m_e;` for extern package:\n{sv}");
+    assert!(sv.contains("import ibex_pkg::rv32b_e;"),
+            "expected SV `import ibex_pkg::rv32b_e;` for extern package:\n{sv}");
+    assert!(!sv.contains("import ibex_pkg::*;"),
+            "extern packages must NOT emit wildcard `import ibex_pkg::*;`:\n{sv}");
     assert!(sv.contains("parameter rv32m_e RV32M = RV32MFast"),
             "expected bare `rv32m_e` type and `RV32MFast` variant:\n{sv}");
     assert!(sv.contains("parameter rv32b_e RV32B = RV32BNone"),

--- a/tests/snapshots/integration_test__arbiter_custom_hook.snap
+++ b/tests/snapshots/integration_test__arbiter_custom_hook.snap
@@ -22,13 +22,12 @@ module QosArbiter #(
   endfunction
   
   logic [3:0] last_grant_r;
+  logic [3:0] grant_onehot;
   
   always_ff @(posedge clk) begin
     if (rst) last_grant_r <= '0;
     else if (grant_valid) last_grant_r <= grant_onehot;
   end
-  
-  logic [3:0] grant_onehot;
   
   always_comb begin
     grant_onehot = QosGrant(request_valid, last_grant_r, qos_in);

--- a/tests/snapshots/integration_test__let_bindings.snap
+++ b/tests/snapshots/integration_test__let_bindings.snap
@@ -13,8 +13,8 @@ module LetDemo (
 );
 
   logic [7:0] mask;
-  assign mask = a & b;
   logic same;
+  assign mask = a & b;
   assign same = a == b;
   assign masked = mask;
   assign equal = same;


### PR DESCRIPTION
## Summary

Two coupled codegen changes that together let arch-com-emitted SV pass through yosys-slang (and other strict static elaborators) end-to-end when arch modules instantiate upstream-SV modules whose port types are enums declared in an external SV package.

## 1. Per-type imports for `extern package` (was: wildcard)

**Was:** `use ExternPkg;` emitted `import ExternPkg::*;` at file scope.

The wildcard form pulls EVERY symbol from the upstream SV package into compilation-unit visibility. For real-world packages like `ibex_pkg` that include parameters (`IC_NUM_WAYS`, `SCRAMBLE_KEY_W`, ...), enum items (`IbexMuBiOn`, `WB_INSTR_OTHER`, ...), and other types — each of which can collide with a localparam or local signal in any module compiled in the same unit, generating verilator VARHIDDEN warnings.

**Now:** `use ExternPkg;` emits one `import ExternPkg::T;` line per type explicitly declared in the corresponding `extern package ExternPkg ... end` block. Only the types the user listed enter scope. Same file-scope placement so module-header parameter types (`parameter pkg_type_e P = pkg_value`) still resolve.

`use ArchPkg;` (arch-defined `package`, not extern) keeps its wildcard `import ArchPkg::*;` — arch packages are first-class arch artifacts and the user manages their namespace.

## 2. Auto-cast at inst-port-connect when port type is extern-enum

**Was:** `inst u_x: TargetMod { csr_addr_i <- csr_addr; }` where TargetMod's port type is an extern-enum and `csr_addr` is `UInt<N>` emitted `.csr_addr_i(csr_addr)`. Verilator/iverilog accept the implicit `logic[N] -> enum_t` conversion at port boundaries; slang rejects it: `error: no implicit conversion from 'logic[N]' to 'enum_t'; explicit conversion exists, are you missing a cast?`.

**Now:** arch-com looks up the target port's type at inst-emit time, detects `Symbol::ExternEnum`, finds the owning `extern package` to recover the package name, and emits an explicit cast: `.csr_addr_i(ibex_pkg::csr_num_e'(csr_addr))`. The cast is visible to all SV elaborators (no-op for verilator/iverilog, required by slang).

## Why now

Surfaced when running real yosys+OpenSTA synthesis on arch-ibex via the yosys-slang frontend (sky130 area/timing comparison vs upstream). The connections to upstream `ibex_cs_registers` for `csr_addr_i (csr_num_e)`, `csr_op_i (csr_op_e)`, `debug_cause_i (dbg_cause_e)` were the last 3 hand-patches needed in the generated `ibex_core.sv`. With these codegen changes those patches go away — arch-ibex builds clean from arch source all the way through synth.

## Verification

- `cargo test --release` → **340 passed, 0 failed** (snapshot diffs for `arbiter_custom_hook` and `let_bindings` are the expected ordering changes from PR #312's decl-hoist; updated via `cargo insta accept`).
- arch-ibex full gate (`pytest -n auto --dist=loadfile`) → **129 passed, 74 skipped, 0 failed**.
- yosys-slang elaborates arch-ibex from `build/*.sv` directly (no hand-patch) and synthesizes to a sky130 netlist: `Chip area for module '\ibex_top': 204882.748800`.
- New extern-package test asserts per-type import shape and explicitly forbids wildcard.

## Caveat

The cast detection is currently scoped to direct inst-connect sites (the `.PORT(SIG)` emission in `emit_inst`). Bus connections (`bus_info`-mapped flattened signals) and per-requester ports arrays (arbiter-style) don't go through the same path; they would need an analogous cast pass if a bus signal type ever resolves to an extern-enum. Filed as a follow-up note.

## Test plan

- [x] `cargo test --release` (340/0)
- [x] `test_extern_package_emits_sv_import_and_bare_names` updated for per-type import shape
- [x] arch-ibex full gate green (129/74/0)
- [x] yosys-slang synth of arch-ibex builds clean from `build/*.sv` (no hand-patch)
- [x] Verilator soc lint still passes (no VARHIDDEN regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)