### PR TITLE
sim: sign-extend signed() cast when HDL width < C++ int width

### DIFF
--- a/src/sim_codegen/mod.rs
+++ b/src/sim_codegen/mod.rs
@@ -2197,6 +2197,32 @@ fn cpp_expr_inner(expr: &Expr, ctx: &Ctx, is_lhs: bool) -> String {
         ExprKind::Cast(inner, ty) => {
             let e = cpp_expr(inner, ctx);
             let t = cpp_port_type(ty);
+            // For SInt casts whose source is narrower than the target
+            // C++ int, sign-extend the value: a plain `(int64_t)x`
+            // bit-cast leaves the upper bits zero, which makes a
+            // would-be-negative N-bit value (where N < 64) appear as
+            // a large positive int64_t. Subsequent `>>` on that
+            // mis-typed value zero-fills instead of sign-extending.
+            //
+            // Standard idiom: shift left by (W_int - W_HDL) so the
+            // HDL sign bit lands at the int's MSB, then arith-shift
+            // right by the same amount to sign-extend.
+            //
+            // For UInt casts and same-width SInt casts, the bit-cast
+            // is correct and we keep the original simple form.
+            if let TypeExpr::SInt(w) = &**ty {
+                let w_hdl = eval_width(w);
+                let w_cpp: u32 = if w_hdl <= 8 { 8 }
+                                 else if w_hdl <= 16 { 16 }
+                                 else if w_hdl <= 32 { 32 }
+                                 else if w_hdl <= 64 { 64 }
+                                 else { 0 };  // >64: VlWide / _arch_u128 paths
+                let inner_w = infer_expr_width(inner, ctx);
+                if w_cpp > 0 && inner_w > 0 && inner_w < w_cpp {
+                    let shift = w_cpp - inner_w;
+                    return format!("(({t})({e}) << {shift}) >> {shift}");
+                }
+            }
             format!("({t})({e})")
         }
 
@@ -2316,16 +2342,34 @@ fn cpp_expr_inner(expr: &Expr, ctx: &Ctx, is_lhs: bool) -> String {
             // signed value. The bit pattern is unchanged, but C++ operators
             // (notably `>>`) behave differently for signed types: signed
             // right-shift sign-extends, unsigned right-shift zero-extends.
-            // Emit an explicit cast so a chained `>>` becomes an arithmetic
-            // shift. Pre-fix: lowering dropped the cast and `signed(x) >> n`
-            // emitted a logical shift, so SRA gave the wrong result for
-            // negative inputs (top bits zero-filled instead of sign-extended).
+            //
+            // The cast target is the smallest C++ signed int that fits
+            // the HDL width: SInt<8> → int8_t, SInt<33> → int64_t, etc.
+            // When the HDL width is STRICTLY LESS than the C++ int width
+            // (e.g. SInt<33> → int64_t with 31 padding bits), a plain
+            // bit-cast leaves those upper bits zero, so a value that
+            // should be negative in HDL terms (HDL bit W-1 = 1) appears
+            // POSITIVE in the C++ int, and a chained `>>` zero-fills the
+            // upper bits instead of sign-extending. Sign-extend explicitly
+            // by left-shifting the HDL sign bit to the C++ MSB and then
+            // arith-shifting back: `((int_W)x << (W_cpp-W_hdl)) >> (W_cpp-W_hdl)`.
+            // arch-ibex `IbexAlu`'s SRA uses exactly this pattern via
+            // `signed({sign_ext_msb, 32b}) >> shamt`.
             let w = infer_expr_width(inner, ctx);
             let inner_c = cpp_expr(inner, ctx);
             if w == 0 || w > 64 {
                 inner_c
             } else {
-                format!("(({})({}))", cpp_sint(w), inner_c)
+                let w_cpp: u32 = if w <= 8 { 8 }
+                                 else if w <= 16 { 16 }
+                                 else if w <= 32 { 32 }
+                                 else { 64 };
+                if w < w_cpp {
+                    let pad = w_cpp - w;
+                    format!("((({})({}) << {pad}) >> {pad})", cpp_sint(w), inner_c)
+                } else {
+                    format!("(({})({}))", cpp_sint(w), inner_c)
+                }
             }
         }
         ExprKind::Unsigned(inner) => {


### PR DESCRIPTION
## Summary

Fix a sign-extension bug in archsim's C++ codegen for `signed(EXPR)` where EXPR's HDL bit-width is strictly less than the host C++ int width (e.g. SInt<33> → int64_t with 31 padding bits). The bit-cast left padding bits zero, so HDL-negative values became C++-positive, and chained `>>` did the wrong thing.

## Diagnostic

Surfaced in arch-ibex `IbexAlu` when re-implementing the shifter to mirror upstream's single-barrel + bit-reverse design (one shifter shared by SLL/SRL/SRA, ~13% area savings on sky130). The standard idiom is:

```arch
let shift_in_signed: SInt<33> = signed({sign_msb, 32_bit_value});
let shift_out_signed: SInt<33> = shift_in_signed >> shamt;
```

For SRA of `0x80000000 >> 4`, archsim emitted:

```c
_let_shift_in_signed = (int64_t)(0x80000000 | (1ULL << 32));
                     // = 0x180000000  (POSITIVE in int64_t — bit 63 = 0)
_let_shift_out_signed = _let_shift_in_signed >> _let_shamt;
                     // 0x180000000 >> 4 = 0x18000000 (logical, since +ve)
```

The `>>` was technically arith-shift (LHS is `int64_t`), but the operand was wrongly treated as positive. Fix sign-extends so:

```c
_let_shift_in_signed = ((int64_t)(0x180000000) << 31) >> 31;
                     // = -2^31 in int64_t (correctly negative)
_let_shift_out_signed = -2^31 >> 4 = -2^27
                     // bits[31:0] after mask = 0xF8000000 ✓
```

Verilator + yosys-slang both got the SRA right under the same ARCH source (their sign-ext is implicit in the SV `signed`/`>>>` semantics); only archsim's sim_codegen had the gap.

## Fix

In `src/sim_codegen/mod.rs::ExprKind::Signed`: when HDL width < C++ int width, emit `((int_W)x << pad) >> pad` instead of `(int_W)x`. The left-shift moves the HDL sign bit to the C++ MSB; the right-shift on the now-properly-typed signed int is arith-shift (sign-extending).

Same defensive fix for the analogous `ExprKind::Cast → SInt` path (not currently reachable from arch source but matches the semantic).

## Verification

- `cargo test --release` → **340 passed, 0 failed**.
- arch-ibex full gate (`pytest -n auto --dist=loadfile`) → **129 passed, 74 skipped, 0 failed**.
- arch-ibex `IbexAlu` archsim unit suite (`test_archsim_units.py`, 10 cocotb tests under archsim) — passes including the `standard_shifts` SRA case on `0x80000000 >> 4` → `0xF8000000`.
- Direct probe via `Vibex_alu_pybind`: `operator=ALU_SRA, op_a=0x80000000, op_b=4 → result_o=0xF8000000` ✓.
- arch-ibex synth-side: rewriting `IbexAlu`'s shifter to the single-shifter SInt<33> form drops the ALU from 6,211 → 5,439 µm² on sky130 (-12%), now within +118 µm² (+2%) of upstream `ibex_alu` — depends on this fix to keep archsim correct.

## Test plan

- [x] arch-com `cargo test --release` — 340/0
- [x] arch-ibex full gate — 129/74/0
- [x] `IbexAlu` archsim test passes for SRA on negative inputs
- [x] No regression in any test that previously exercised `signed()` of equal-width values (e.g. `signed(UInt<32>) → SInt<32>` continues using the original simple cast)

🤖 Generated with [Claude Code](https://claude.com/claude-code)