### PR TITLE
fix(sim): regfile cpp model honors init[k]=v write guard

### DIFF
--- a/examples/int_regs.sv
+++ b/examples/int_regs.sv
@@ -3,20 +3,20 @@
 
 module IntRegs #(
   parameter int NREGS = 32,
-  parameter int WIDTH = 0
+  parameter int T = 0
 ) (
   input logic clk,
   input logic rst,
-  input logic [5-1:0] read0_addr,
-  output logic [8-1:0] read0_data,
-  input logic [5-1:0] read1_addr,
-  output logic [8-1:0] read1_data,
+  input logic [4:0] read0_addr,
+  output logic [7:0] read0_data,
+  input logic [4:0] read1_addr,
+  output logic [7:0] read1_data,
   input logic write_en,
-  input logic [5-1:0] write_addr,
-  input logic [8-1:0] write_data
+  input logic [4:0] write_addr,
+  input logic [7:0] write_data
 );
 
-  logic [8-1:0] rf_data [0:NREGS-1];
+  logic [7:0] rf_data [0:NREGS-1];
   
   always_ff @(posedge clk) begin
     if (write_en && write_addr != 0)

--- a/examples/regfile_tb.cpp
+++ b/examples/regfile_tb.cpp
@@ -25,8 +25,10 @@ int main(int argc, char** argv) {
     tick(); tick();
     dut->rst = 0;
 
-    // ── Write values to registers ─────────────────────────────────────────────
-    for (int i = 0; i < 8; i++) {
+    // ── Write values to registers 1..7 ────────────────────────────────────────
+    // Skip addr 0 — `init [0] = 0;` in int_regs.arch hardwires register 0 to
+    // zero, so writes there are dropped (RISC-V x0 style).
+    for (int i = 1; i < 8; i++) {
         dut->write_en   = 1;
         dut->write_addr = (uint8_t)i;
         dut->write_data = (uint8_t)((i * 11 + 5) & 0xFF);
@@ -37,22 +39,33 @@ int main(int argc, char** argv) {
 
     // ── Read back via both read ports ─────────────────────────────────────────
     int read_errors = 0;
-    for (int i = 0; i < 4; i++) {
-        dut->read0_addr = (uint8_t)(i * 2);
-        dut->read1_addr = (uint8_t)(i * 2 + 1);
+    for (int i = 0; i < 3; i++) {
+        dut->read0_addr = (uint8_t)(i * 2 + 1);   // 1, 3, 5
+        dut->read1_addr = (uint8_t)(i * 2 + 2);   // 2, 4, 6
         dut->eval();
         uint8_t got0 = (uint8_t)dut->read0_data;
         uint8_t got1 = (uint8_t)dut->read1_data;
-        uint8_t exp0 = (uint8_t)((i * 2 * 11 + 5) & 0xFF);
-        uint8_t exp1 = (uint8_t)(((i * 2 + 1) * 11 + 5) & 0xFF);
+        uint8_t exp0 = (uint8_t)(((i * 2 + 1) * 11 + 5) & 0xFF);
+        uint8_t exp1 = (uint8_t)(((i * 2 + 2) * 11 + 5) & 0xFF);
         if (got0 != exp0 || got1 != exp1) {
             printf("FAIL: read[%d]: port0 got %d exp %d, port1 got %d exp %d\n",
                    i, (int)got0, (int)exp0, (int)got1, (int)exp1);
             read_errors++;
         }
     }
+    // Confirm reg[0] stays zero through write attempts.
+    dut->read0_addr = 7; dut->read1_addr = 0;
+    dut->eval();
+    if (dut->read0_data != (uint8_t)((7 * 11 + 5) & 0xFF)) {
+        printf("FAIL: read[7]: got %d\n", (int)dut->read0_data);
+        read_errors++;
+    }
+    if (dut->read1_data != 0) {
+        printf("FAIL: reg[0] should be hardwired zero, got %d\n", (int)dut->read1_data);
+        read_errors++;
+    }
     if (read_errors == 0) {
-        printf("PASS: all 8 registers read correctly via 2 read ports\n");
+        printf("PASS: regs 1..7 read correctly, reg[0] stays zero\n");
     } else {
         errors += read_errors;
     }

--- a/examples/traffic_light.sv
+++ b/examples/traffic_light.sv
@@ -1,6 +1,17 @@
+//! ---
+//! tags: [fsm, traffic_light, tutorial]
+//! ---
+//!
+//! Classic traffic-light FSM tutorial — three-state Red → Green → Yellow
+//! → Red rotation, advances when an external `timer` reaches 0.
 // domain SysDomain
 //   freq_mhz: 100
 
+/// Three-state traffic-light FSM (Red → Green → Yellow → Red).
+///
+/// State advances when the external `timer` input hits 0. Output ports
+/// (`red` / `yellow` / `green`) default to `false` and are asserted from
+/// the matching state's comb block.
 module TrafficLight #(
   parameter int TIMER_W = 8
 ) (
@@ -45,6 +56,9 @@ module TrafficLight #(
   end
   
   always_comb begin
+    red = 1'b0;
+    yellow = 1'b0;
+    green = 1'b0;
     case (state_r)
       RED: begin
         red = 1'b1;
@@ -58,6 +72,17 @@ module TrafficLight #(
       default: ;
     endcase
   end
+  
+  // synopsys translate_off
+  _auto_legal_state: assert property (@(posedge clk) !rst |-> state_r < 3)
+    else $fatal(1, "FSM ILLEGAL STATE: TrafficLight.state_r = %0d", state_r);
+  _auto_reach_Red: cover property (@(posedge clk) state_r == RED);
+  _auto_reach_Yellow: cover property (@(posedge clk) state_r == YELLOW);
+  _auto_reach_Green: cover property (@(posedge clk) state_r == GREEN);
+  _auto_tr_RED_to_GREEN: cover property (@(posedge clk) state_r == RED && state_next == GREEN);
+  _auto_tr_GREEN_to_YELLOW: cover property (@(posedge clk) state_r == GREEN && state_next == YELLOW);
+  _auto_tr_YELLOW_to_RED: cover property (@(posedge clk) state_r == YELLOW && state_next == RED);
+  // synopsys translate_on
 
 endmodule
 

--- a/src/sim_codegen/mod.rs
+++ b/src/sim_codegen/mod.rs
@@ -6607,11 +6607,27 @@ impl<'a> SimCodegen<'a> {
         cpp.push_str(&format!("  _clk_prev = {clk_port};\n"));
         cpp.push_str("  if (!_rising) return;\n");
         if !is_latch {
+            // Init-protected addresses are immutable (mirrors SV emitter:
+            // `init [k] = v;` lowers to a `waddr != k` write guard).
+            let guarded_addrs: Vec<u64> = r.inits.iter()
+                .filter_map(|init| match &init.index.kind {
+                    ExprKind::Literal(LitKind::Dec(v)) => Some(*v),
+                    _ => None,
+                })
+                .collect();
             for wi in 0..nwrite {
                 let wen   = flat(&write_pfx, wi, nwrite, "en");
                 let waddr = flat(&write_pfx, wi, nwrite, "addr");
                 let wdata = flat(&write_pfx, wi, nwrite, "data");
-                cpp.push_str(&format!("  if ({wen})\n    _rf[{waddr}] = {wdata};\n"));
+                let guard = if guarded_addrs.is_empty() {
+                    wen.clone()
+                } else {
+                    let parts: Vec<String> = guarded_addrs.iter()
+                        .map(|k| format!("{waddr} != {k}"))
+                        .collect();
+                    format!("{wen} && {}", parts.join(" && "))
+                };
+                cpp.push_str(&format!("  if ({guard})\n    _rf[{waddr}] = {wdata};\n"));
             }
         } else if is_internal {
             // Single-port sample (write port 0).


### PR DESCRIPTION
## Summary

Fixes a divergence between the regfile **SV emitter** and the **cpp simulation model emitter** that masked real bugs in `arch sim --tb` runs:

- **The bug**: `init [k] = v;` in a regfile decl lowers in SV to a `waddr != k` guard in the write `always_ff` (RISC-V x0 hardwire style), but the cpp model at \`src/sim_codegen/mod.rs\` had no equivalent guard. Writes to guarded addrs went through in the cpp model.
- **Why it matters**: TBs run via \`arch sim --tb\` use the cpp model and silently passed; the same TBs run on the SV through real Verilator failed.

## How it surfaced

Discovered while running HARC-generated TBs against Verilator-compiled DUTs from \`examples/int_regs.arch\`:

- \`arch sim examples/int_regs.arch --tb examples/regfile_tb.cpp\` → **PASS** (cpp model)
- HARC + Verilator on the same SV with equivalent logic → **FAIL: read[0] got 0 expected 5**

## Changes

**Commit 1 — \`fix(sim): regfile cpp model honors init[k]=v write guard\`**
- \`src/sim_codegen/mod.rs\`: collect literal-Dec init indices and emit \`if (write_en && waddr != k1 && waddr != k2 ...)\` to mirror the SV. Falls back to existing behavior for non-literal indices (no examples use them today; would need a cpp expr emitter for the general case).
- \`examples/regfile_tb.cpp\`: write/read addrs 1..7 and confirm reg[0] stays zero through write attempts.

**Commit 2 — \`examples: regenerate stale SVs\`**
- \`examples/traffic_light.sv\`: regenerated to pick up default-zero output assignments at the top of the output \`always_comb\` (the FSM emitter at \`src/codegen/fsm.rs:309\` already emits these for ports declared with \`default false\`, but the checked-in SV predated that fix and inferred latches). Also picks up doc comments and auto-emitted FSM assertions / covers.
- \`examples/int_regs.sv\`: regenerated; param renamed \`WIDTH\` → \`T\` (matches \`param T: type = UInt<8>;\` in \`int_regs.arch\`), \`[5-1:0]\` → \`[4:0]\` simplification.

## Test plan

- [x] \`cargo test\` (357 + 9 + 20 = 386 tests passing)
- [x] \`arch sim examples/int_regs.arch --tb examples/regfile_tb.cpp\` — PASS
- [x] \`arch sim examples/traffic_light.arch --tb examples/traffic_light_tb.cpp\` — PASS
- [x] HARC \`int_regs_test.harc\` against Verilator-compiled \`int_regs.sv\` — PASS
- [x] HARC \`traffic_light_test.harc\` with strict r/y/g asserts against \`traffic_light.sv\` — PASS, coverage 6/6 (100%)

## Caveats

- Non-literal init indices in \`init [expr] = v;\` won't get the cpp guard (no examples use this form). A general fix would need an expression emitter at the cpp model layer.
- The \`int_regs.sv\` parameter rename is a binary-incompatible change for any external instantiation that still uses \`#(.WIDTH(8))\`. Since the \`.arch\` source has always declared the param as \`T\`, this is the correct name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)