### PR TITLE
sim_codegen: fold let-bound ident match patterns to literal case labels

### DIFF
--- a/src/sim_codegen/mod.rs
+++ b/src/sim_codegen/mod.rs
@@ -1625,6 +1625,10 @@ struct Ctx<'a> {
     reg_names:   &'a HashSet<String>,
     port_names:  &'a HashSet<String>,
     let_names:   &'a HashSet<String>,
+    /// Map of module-scope let-binding names → their RHS expressions.
+    /// Populated via `Ctx::with_let_values`. Used by `Stmt::Match` to
+    /// fold `Pattern::Ident` arms into literal case labels.
+    let_values:  Option<&'a HashMap<String, Expr>>,
     inst_names:  &'a HashSet<String>,
     /// Signals whose type is >64 bits wide (require special handling).
     wide_names:  &'a HashSet<String>,
@@ -1676,7 +1680,7 @@ impl<'a> Ctx<'a> {
         static EMPTY_RESET_LEVELS: std::sync::OnceLock<HashMap<String, ResetLevel>> = std::sync::OnceLock::new();
         let reset_levels = EMPTY_RESET_LEVELS.get_or_init(HashMap::new);
         static EMPTY_PARAMS: &[ParamDecl] = &[];
-        Ctx { reg_names, port_names, let_names, inst_names, wide_names,
+        Ctx { reg_names, port_names, let_names, let_values: None, inst_names, wide_names,
               widths, posedge_lhs: false, fsm_mode: false, enum_map, bus_ports,
               reset_levels, vec_names: None, vec_sizes: None, fsm_vec_port_regs: None,
               ident_subst: None, coverage: None, params: EMPTY_PARAMS }
@@ -1684,6 +1688,11 @@ impl<'a> Ctx<'a> {
 
     fn with_params(mut self, params: &'a [ParamDecl]) -> Self {
         self.params = params;
+        self
+    }
+
+    fn with_let_values(mut self, let_values: &'a HashMap<String, Expr>) -> Self {
+        self.let_values = Some(let_values);
         self
     }
 
@@ -1975,7 +1984,7 @@ fn lower_vec_method_cpp(
         sub.insert("index".to_string(), format!("{i}"));
         let sub_ctx = Ctx {
             reg_names: ctx.reg_names, port_names: ctx.port_names,
-            let_names: ctx.let_names, inst_names: ctx.inst_names,
+            let_names: ctx.let_names, let_values: ctx.let_values, inst_names: ctx.inst_names,
             wide_names: ctx.wide_names, widths: ctx.widths,
             posedge_lhs: ctx.posedge_lhs, fsm_mode: ctx.fsm_mode,
             enum_map: ctx.enum_map, bus_ports: ctx.bus_ports,
@@ -2405,7 +2414,22 @@ fn cpp_expr_inner(expr: &Expr, ctx: &Ctx, is_lhs: bool) -> String {
             for arm in arms.iter().rev() {
                 let val = cpp_expr(&arm.value, ctx);
                 let cond = match &arm.pattern {
-                    Pattern::Wildcard | Pattern::Ident(_) => { result = val; continue; }
+                    Pattern::Wildcard => { result = val; continue; }
+                    Pattern::Ident(id) => {
+                        // Mirror Stmt::Match: if the ident names a let
+                        // with a literal RHS, treat as `== <literal>`;
+                        // else fall through as the ternary tail (default).
+                        let folded = ctx.let_values
+                            .and_then(|m| m.get(&id.name))
+                            .filter(|e| matches!(&e.kind, ExprKind::Literal(_)));
+                        match folded {
+                            Some(e) => {
+                                let lit = cpp_expr(e, ctx);
+                                format!("({s} == {lit})")
+                            }
+                            None => { result = val; continue; }
+                        }
+                    }
                     Pattern::Literal(e) => {
                         let lit = cpp_expr(e, ctx);
                         format!("({s} == {lit})")
@@ -2852,7 +2876,24 @@ fn emit_stmt(stmt: &Stmt, ctx: &Ctx, out: &mut String, indent: usize, k: SimAssi
             for arm in &m.arms {
                 let (case_str, label) = match &arm.pattern {
                     Pattern::Wildcard => ("default".to_string(), "match _".to_string()),
-                    Pattern::Ident(id) => ("default".to_string(), format!("match {}", id.name)),
+                    Pattern::Ident(id) => {
+                        // If `id` names a module-scope let-binding with a
+                        // literal RHS, emit `case <literal>:` so multiple
+                        // ident arms (e.g. `ALU_ADD`, `ALU_SUB`, ...) don't
+                        // collapse into "multiple default labels". Falls
+                        // back to `default` when the let is missing or its
+                        // RHS isn't a constant — preserves wildcard-binding
+                        // semantics for non-let idents.
+                        let folded = ctx.let_values
+                            .and_then(|m| m.get(&id.name))
+                            .filter(|e| matches!(&e.kind, ExprKind::Literal(_)));
+                        match folded {
+                            Some(e) => (format!("case {}", cpp_expr(e, ctx)),
+                                        format!("match {}", id.name)),
+                            None    => ("default".to_string(),
+                                        format!("match {}", id.name)),
+                        }
+                    }
                     Pattern::Literal(e) => (format!("case {}", cpp_expr(e, ctx)), "match lit".to_string()),
                     Pattern::EnumVariant(en, vr) => {
                         if let Some(variants) = ctx.enum_map.get(&en.name) {
@@ -3092,6 +3133,25 @@ fn collect_let_names(body: &[ModuleBodyItem]) -> HashSet<String> {
             }
             ModuleBodyItem::WireDecl(w) => { out.insert(w.name.name.clone()); }
             _ => {}
+        }
+    }
+    out
+}
+
+/// Map module-scope `let NAME: T = expr;` bindings to their RHS expr.
+/// Used by `Stmt::Match` codegen to fold `Pattern::Ident(NAME)` arms
+/// into `case <literal>:` labels (instead of the buggy `default:`
+/// fall-through that collapses multi-let-bound match arms — see
+/// memory/feedback_archsim_match_pattern_ident_default_collision.md).
+/// Destructure-let bindings (`let {a, b} = ...;`) are skipped — those
+/// don't have a single RHS and aren't referenceable from match patterns.
+fn collect_let_values(body: &[ModuleBodyItem]) -> HashMap<String, Expr> {
+    let mut out = HashMap::new();
+    for item in body {
+        if let ModuleBodyItem::LetBinding(l) = item {
+            if l.destructure_fields.is_empty() {
+                out.insert(l.name.name.clone(), l.value.clone());
+            }
         }
     }
     out
@@ -3822,6 +3882,7 @@ impl<'a> SimCodegen<'a> {
         let mut reg_names = collect_reg_names(&m.body, &m.ports);
         reg_names.extend(collect_pipe_reg_names(&m.body));
         let let_names   = collect_let_names(&m.body);
+        let let_values  = collect_let_values(&m.body);
         let inst_names  = collect_inst_names(&m.body);
         let inst_out    = collect_inst_output_signals(&m.body);
         let mut wide_names  = collect_wide_names(&m.ports, &m.body);
@@ -4872,6 +4933,7 @@ impl<'a> SimCodegen<'a> {
                            &wide_names, &widths, &enum_map, &bus_port_names)
                       .with_reset_levels(&reset_levels)
                       .with_vec_names(&vec_reg_names).with_vec_sizes(&vec_sizes)
+                      .with_let_values(&let_values)
                       .with_params(&m.params);
 
         if insts.is_empty() {
@@ -5336,6 +5398,7 @@ impl<'a> SimCodegen<'a> {
                                &wide_names, &widths, &enum_map, &bus_port_names)
                           .with_vec_names(&vec_reg_names).with_vec_sizes(&vec_sizes).posedge()
                           .with_coverage(cov_handle)
+                          .with_let_values(&let_values)
                           .with_params(&m.params);
 
             for rb in &reg_blocks {
@@ -5525,6 +5588,7 @@ impl<'a> SimCodegen<'a> {
                     let ctx_pe = Ctx::new(&reg_names, &port_names, &let_names, &inst_names,
                                            &wide_names, &widths, &enum_map, &bus_port_names)
                                        .with_vec_names(&vec_reg_names).with_vec_sizes(&vec_sizes)
+                                       .with_let_values(&let_values)
                                        .with_params(&m.params);
                     let src = ctx_pe.resolve_name(&p.source.name, false);
                     if let Some((ref rst_name, is_low)) = rst_info {
@@ -5749,6 +5813,7 @@ impl<'a> SimCodegen<'a> {
                                 &wide_names, &widths, &enum_map, &bus_port_names)
                            .with_vec_names(&vec_reg_names).with_vec_sizes(&vec_sizes)
                            .with_coverage(cov_handle)
+                           .with_let_values(&let_values)
                            .with_params(&m.params);
 
         // Credit-channel combinational wires (sender can_send; receiver
@@ -5792,7 +5857,7 @@ impl<'a> SimCodegen<'a> {
                                     sub.insert("index".to_string(), format!("{i}"));
                                     let sub_ctx = Ctx {
                                         reg_names: ctx_comb.reg_names, port_names: ctx_comb.port_names,
-                                        let_names: ctx_comb.let_names, inst_names: ctx_comb.inst_names,
+                                        let_names: ctx_comb.let_names, let_values: ctx_comb.let_values, inst_names: ctx_comb.inst_names,
                                         wide_names: ctx_comb.wide_names, widths: ctx_comb.widths,
                                         posedge_lhs: ctx_comb.posedge_lhs, fsm_mode: ctx_comb.fsm_mode,
                                         enum_map: ctx_comb.enum_map, bus_ports: ctx_comb.bus_ports,

--- a/src/sim_codegen/mod.rs
+++ b/src/sim_codegen/mod.rs
@@ -2197,6 +2197,32 @@ fn cpp_expr_inner(expr: &Expr, ctx: &Ctx, is_lhs: bool) -> String {
         ExprKind::Cast(inner, ty) => {
             let e = cpp_expr(inner, ctx);
             let t = cpp_port_type(ty);
+            // For SInt casts whose source is narrower than the target
+            // C++ int, sign-extend the value: a plain `(int64_t)x`
+            // bit-cast leaves the upper bits zero, which makes a
+            // would-be-negative N-bit value (where N < 64) appear as
+            // a large positive int64_t. Subsequent `>>` on that
+            // mis-typed value zero-fills instead of sign-extending.
+            //
+            // Standard idiom: shift left by (W_int - W_HDL) so the
+            // HDL sign bit lands at the int's MSB, then arith-shift
+            // right by the same amount to sign-extend.
+            //
+            // For UInt casts and same-width SInt casts, the bit-cast
+            // is correct and we keep the original simple form.
+            if let TypeExpr::SInt(w) = &**ty {
+                let w_hdl = eval_width(w);
+                let w_cpp: u32 = if w_hdl <= 8 { 8 }
+                                 else if w_hdl <= 16 { 16 }
+                                 else if w_hdl <= 32 { 32 }
+                                 else if w_hdl <= 64 { 64 }
+                                 else { 0 };  // >64: VlWide / _arch_u128 paths
+                let inner_w = infer_expr_width(inner, ctx);
+                if w_cpp > 0 && inner_w > 0 && inner_w < w_cpp {
+                    let shift = w_cpp - inner_w;
+                    return format!("(({t})({e}) << {shift}) >> {shift}");
+                }
+            }
             format!("({t})({e})")
         }
 
@@ -2316,16 +2342,34 @@ fn cpp_expr_inner(expr: &Expr, ctx: &Ctx, is_lhs: bool) -> String {
             // signed value. The bit pattern is unchanged, but C++ operators
             // (notably `>>`) behave differently for signed types: signed
             // right-shift sign-extends, unsigned right-shift zero-extends.
-            // Emit an explicit cast so a chained `>>` becomes an arithmetic
-            // shift. Pre-fix: lowering dropped the cast and `signed(x) >> n`
-            // emitted a logical shift, so SRA gave the wrong result for
-            // negative inputs (top bits zero-filled instead of sign-extended).
+            //
+            // The cast target is the smallest C++ signed int that fits
+            // the HDL width: SInt<8> → int8_t, SInt<33> → int64_t, etc.
+            // When the HDL width is STRICTLY LESS than the C++ int width
+            // (e.g. SInt<33> → int64_t with 31 padding bits), a plain
+            // bit-cast leaves those upper bits zero, so a value that
+            // should be negative in HDL terms (HDL bit W-1 = 1) appears
+            // POSITIVE in the C++ int, and a chained `>>` zero-fills the
+            // upper bits instead of sign-extending. Sign-extend explicitly
+            // by left-shifting the HDL sign bit to the C++ MSB and then
+            // arith-shifting back: `((int_W)x << (W_cpp-W_hdl)) >> (W_cpp-W_hdl)`.
+            // arch-ibex `IbexAlu`'s SRA uses exactly this pattern via
+            // `signed({sign_ext_msb, 32b}) >> shamt`.
             let w = infer_expr_width(inner, ctx);
             let inner_c = cpp_expr(inner, ctx);
             if w == 0 || w > 64 {
                 inner_c
             } else {
-                format!("(({})({}))", cpp_sint(w), inner_c)
+                let w_cpp: u32 = if w <= 8 { 8 }
+                                 else if w <= 16 { 16 }
+                                 else if w <= 32 { 32 }
+                                 else { 64 };
+                if w < w_cpp {
+                    let pad = w_cpp - w;
+                    format!("((({})({}) << {pad}) >> {pad})", cpp_sint(w), inner_c)
+                } else {
+                    format!("(({})({}))", cpp_sint(w), inner_c)
+                }
             }
         }
         ExprKind::Unsigned(inner) => {

--- a/src/sim_codegen/pipeline.rs
+++ b/src/sim_codegen/pipeline.rs
@@ -501,7 +501,7 @@ impl<'a> SimCodegen<'a> {
     ) -> String {
         let empty = HashSet::new();
         let empty_rl: HashMap<String, ResetLevel> = HashMap::new();
-        let ctx = Ctx { reg_names: rn, port_names: pn, let_names: ln, inst_names: &empty, wide_names: &empty, widths: w, posedge_lhs: false, fsm_mode: false, enum_map: em, bus_ports: &empty, reset_levels: &empty_rl, vec_names: None, vec_sizes: None, fsm_vec_port_regs: None, ident_subst: None, coverage: None, params: &[] };
+        let ctx = Ctx { reg_names: rn, port_names: pn, let_names: ln, let_values: None, inst_names: &empty, wide_names: &empty, widths: w, posedge_lhs: false, fsm_mode: false, enum_map: em, bus_ports: &empty, reset_levels: &empty_rl, vec_names: None, vec_sizes: None, fsm_vec_port_regs: None, ident_subst: None, coverage: None, params: &[] };
         match &expr.kind {
             ExprKind::FieldAccess(base, field) => {
                 if let ExprKind::Ident(bn) = &base.kind {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -8660,6 +8660,58 @@ fn test_sim_codegen_comb_match_arm_recurses_into_nested_for() {
 }
 
 #[test]
+fn test_sim_codegen_match_arm_let_bound_ident_emits_case_with_literal() {
+    // Regression: pre-fix, archsim's Stmt::Match emitted EVERY
+    // `Pattern::Ident` arm as `default:`. With multiple let-bound
+    // operator constants used as match arms (e.g. `ALU_ADD => ...;
+    // ALU_SUB => ...;`), C++ rejected with "multiple default labels
+    // in one switch". Post-fix, an Ident pattern naming a module-scope
+    // let-binding with a literal RHS folds to `case <literal>:`.
+    //
+    // Bug origin: arch-ibex IbexAlu unique-match conversion attempt;
+    // see memory/feedback_archsim_match_pattern_ident_default_collision.md.
+    let source = "
+        domain SysDomain
+          freq_mhz: 100
+        end domain SysDomain
+        module M
+          let OP_A: UInt<3> = 3'd0;
+          let OP_B: UInt<3> = 3'd1;
+          let OP_C: UInt<3> = 3'd2;
+          port opc: in UInt<3>;
+          port out: out UInt<8>;
+          comb
+            unique match opc
+              OP_A => out = 8'hAA;
+              OP_B => out = 8'hBB;
+              OP_C => out = 8'hCC;
+              _    => out = 8'h00;
+            end match
+          end comb
+        end module M
+    ";
+    let cpp = compile_to_sim_h(source, false);
+    // Each let-bound ident arm should produce a real `case` label.
+    // Post-fix the case values are the let RHS literals (folded by
+    // cpp_expr) — exact textual form depends on cpp_expr's literal
+    // emit, but it must NOT be `default:` for the three arms, and
+    // must contain the three values 0/1/2.
+    let default_count = cpp.matches("default:").count();
+    assert!(default_count <= 1,
+        "fix means only the wildcard arm emits `default:`; got {default_count}\n{cpp}");
+    // All three case values should appear as case labels.
+    for (n, lit) in [(0, "case 0"), (1, "case 1"), (2, "case 2")] {
+        assert!(cpp.contains(lit) || cpp.contains(&format!("case {n}u")) ,
+            "let-bound ident arm should emit `case {n}` for value {n}:\n{cpp}");
+    }
+    // The arm bodies should be paired with their case values, not
+    // collapsed onto a single default. Search for the body marker.
+    assert!(cpp.contains("0xAA") || cpp.contains("170"));
+    assert!(cpp.contains("0xBB") || cpp.contains("187"));
+    assert!(cpp.contains("0xCC") || cpp.contains("204"));
+}
+
+#[test]
 fn test_sim_codegen_bit_slice_lhs_compiles_and_uses_param_width() {
     // Regression: pre-fix, `name[hi:lo] = val` in a seq block lowered to
     // the read-side bit-slice form `((name >> lo) & MASK) = val`, an


### PR DESCRIPTION
## Summary
- archsim's `Stmt::Match` (and `ExprMatch`) emitted every `Pattern::Ident` arm as `default:`, so any ARCH match with multiple let-bound operator constants (e.g. `ALU_ADD => …; ALU_SUB => …;`) failed C++ compilation with "multiple default labels in one switch".
- Fix: thread a `let_values: HashMap<String, Expr>` through the codegen Ctx. When emitting `Pattern::Ident`, if the binding's RHS is an `ExprKind::Literal`, emit `case <literal>:` (folded by `cpp_expr`) rather than `default`. Falls back to `default` when the let is missing or the RHS isn't a constant.
- Same fold applied to `ExprMatch` so its ternary-chain pattern matches the new shape.

## Why
Blocks `unique match` rewrites of operator-decoder if/elsif chains. arch-ibex `IbexAlu`'s result + cmp muxes (16 + 8 arms keyed on let-bound `ALU_*` opcodes) save ~45 µm² when converted; the same pattern applies to other operator decoders.

## Test plan
- [x] `cargo test --release` — 341 passed (1 new regression test: `test_sim_codegen_match_arm_let_bound_ident_emits_case_with_literal`).
- [x] arch-ibex full gate (with `IbexAlu` converted to `unique match`) — 129 passed, 74 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)