### PR TITLE
typecheck/rdc: waive reset-none violation when reg has async-reset guard (closes #260)

### DIFF
--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -3495,10 +3495,15 @@ impl<'a> TypeChecker<'a> {
         // 1. Build flop info (reset signal name + kind) for every flop in
         //    the module. Both inline `reg` decls and `port reg` decls
         //    participate. Flops carry a span we point at on violation.
+        //    `guard_sig` is the optional `guard <NAME>` annotation (issue
+        //    #260) — recognized as a flop-granular RDC waiver when the
+        //    guard signal is itself async-reset on the same domain whose
+        //    crossing would otherwise be flagged.
         struct FlopInfo {
             reset_sig: Option<String>,
             reset_kind: Option<ResetKind>,
             decl_span: crate::lexer::Span,
+            guard_sig: Option<String>,
         }
 
         let async_resets: HashSet<String> = m.ports.iter()
@@ -3533,6 +3538,7 @@ impl<'a> TypeChecker<'a> {
                     reset_sig: sig,
                     reset_kind: kind,
                     decl_span: rd.name.span,
+                    guard_sig: rd.guard.as_ref().map(|g| g.name.clone()),
                 });
             }
         }
@@ -3544,6 +3550,7 @@ impl<'a> TypeChecker<'a> {
                     reset_sig: sig,
                     reset_kind: kind,
                     decl_span: p.name.span,
+                    guard_sig: ri.guard.as_ref().map(|g| g.name.clone()),
                 });
             }
         }
@@ -3719,6 +3726,30 @@ impl<'a> TypeChecker<'a> {
                     // in this flop and metastability propagates downstream.
                     let r = reach.get(name).cloned().unwrap_or_default();
                     if !r.is_empty() {
+                        // Issue #260: `guard VALID_SIG` waiver — when the
+                        // flop carries a guard annotation AND the guard
+                        // signal is itself async-reset, downstream readers
+                        // structurally gate the data on the guard, so the
+                        // metastability hazard is contained without
+                        // requiring this flop to be reset. The guard's
+                        // async-reset domain must cover all reach domains
+                        // for the waiver to apply (the guard goes off in
+                        // those domains, gating the unreset data).
+                        let waived_by_guard = info.guard_sig.as_ref().and_then(|g| {
+                            let gi = flop_info.get(g)?;
+                            if !matches!(gi.reset_kind, Some(ResetKind::Async)) { return None; }
+                            let g_reset = gi.reset_sig.as_ref()?;
+                            // Every reach domain must equal the guard's
+                            // reset signal — otherwise the guard doesn't
+                            // protect the foreign domain(s) we cross.
+                            if r.iter().all(|d| d == g_reset) {
+                                Some((g.clone(), g_reset.clone()))
+                            } else { None }
+                        });
+                        if waived_by_guard.is_some() {
+                            continue;
+                        }
+
                         let mut domains: Vec<String> = r.into_iter().collect();
                         domains.sort();
                         let kind_label = match info.reset_kind {
@@ -3732,6 +3763,19 @@ impl<'a> TypeChecker<'a> {
                             format!("multiple async reset domains ({})",
                                 domains.iter().map(|d| format!("`{d}`")).collect::<Vec<_>>().join(", "))
                         };
+                        // Hint about the issue-#260 waiver path when the
+                        // user has a guard but it doesn't qualify (so they
+                        // can fix the guard's reset rather than reaching
+                        // for `pragma rdc_safe`).
+                        let guard_hint = match (&info.guard_sig, info.guard_sig.as_ref().and_then(|g| flop_info.get(g))) {
+                            (Some(g), Some(gi)) if !matches!(gi.reset_kind, Some(ResetKind::Async)) => {
+                                format!(" (Note: `guard {g}` is present but `{g}` is not async-reset, so the guard waiver does not apply.)")
+                            }
+                            (Some(g), None) => {
+                                format!(" (Note: `guard {g}` is present but `{g}` is not a register in this module, so the guard waiver does not apply.)")
+                            }
+                            _ => String::new(),
+                        };
                         self.errors.push(CompileError::general(
                             &format!(
                                 "RDC violation: {kind_label} register `{name}` captures data \
@@ -3739,7 +3783,8 @@ impl<'a> TypeChecker<'a> {
                                  gated on the upstream's async reset event, so mid-deassert \
                                  transients metastabilise and propagate downstream. Either \
                                  reset `{name}` async-by the same signal, or insert a \
-                                 `synchronizer kind reset` upstream."
+                                 `synchronizer kind reset` upstream, or annotate `{name}` \
+                                 with `guard <VALID_SIG>` where `<VALID_SIG>` is async-reset.{guard_hint}"
                             ),
                             info.decl_span,
                         ));

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -9191,6 +9191,193 @@ end module GoodRdc
 }
 
 #[test]
+fn test_rdc_guard_waiver_async_same_domain_passes() {
+    // Issue #260: a reset-none data register annotated with `guard
+    // VALID_SIG`, where VALID_SIG is async-reset on the same domain
+    // whose data the reset-none reg captures, should NOT raise an
+    // RDC violation. Downstream readers structurally ignore the data
+    // when VALID_SIG is low, so the metastability hazard during reset
+    // deassertion is contained.
+    let source = r#"
+domain D
+  freq_mhz: 100
+end domain D
+module M
+  port clk: in Clock<D>;
+  port rst: in Reset<Async, Low>;
+  port d:   in UInt<8>;
+  port q:   out UInt<8>;
+  port v_in: in Bool;
+  // valid_q is async-reset to false (off-value); data_q is unreset
+  // and guarded by valid_q. RDC waiver applies.
+  reg valid_q: Bool reset rst => false;
+  reg data_q: UInt<8> guard valid_q reset none;
+  seq on clk rising
+    valid_q <= v_in;
+    data_q  <= d;
+  end seq
+  let q = data_q;
+end module M
+"#;
+    let tokens = lexer::tokenize(source).expect("lex");
+    let mut parser = Parser::new(tokens, source);
+    let parsed = parser.parse_source_file().expect("parse");
+    let ast = elaborate::elaborate(parsed).expect("elaborate");
+    let symbols = resolve::resolve(&ast).expect("resolve");
+    let checker = TypeChecker::new(&symbols, &ast);
+    let result = checker.check();
+    assert!(result.is_ok(),
+        "expected guard-waivered RDC to pass, got: {:?}", result.err());
+}
+
+#[test]
+fn test_rdc_guard_waiver_does_not_apply_when_guard_is_sync_reset() {
+    // The guard waiver requires the guard signal to be ASYNC-reset.
+    // A sync-reset guard doesn't structurally gate the deassertion
+    // window, so the metastability hazard remains. The error should
+    // include a hint pointing at the qualifying-guard form.
+    let source = r#"
+domain D
+  freq_mhz: 100
+end domain D
+module M
+  port clk: in Clock<D>;
+  port rst_async: in Reset<Async, Low>;
+  port rst_sync:  in Reset<Sync,  Low>;
+  port d:   in UInt<8>;
+  port q:   out UInt<8>;
+  port v_in: in Bool;
+  // Async source flop; reset-none data with a SYNC-reset guard ⇒
+  // waiver shouldn't apply.
+  reg src_q: UInt<8> reset rst_async => 0;
+  reg valid_q: Bool reset rst_sync => false;
+  reg data_q: UInt<8> guard valid_q reset none;
+  seq on clk rising
+    src_q <= d;
+    valid_q <= v_in;
+    data_q  <= src_q;
+  end seq
+  let q = data_q;
+end module M
+"#;
+    let tokens = lexer::tokenize(source).expect("lex");
+    let mut parser = Parser::new(tokens, source);
+    let parsed = parser.parse_source_file().expect("parse");
+    let ast = elaborate::elaborate(parsed).expect("elaborate");
+    let symbols = resolve::resolve(&ast).expect("resolve");
+    let checker = TypeChecker::new(&symbols, &ast);
+    let result = checker.check();
+    assert!(result.is_err(), "expected RDC error (sync guard doesn't qualify)");
+    let errs = result.unwrap_err();
+    assert!(
+        errs.iter().any(|e| {
+            let s = e.to_string();
+            s.contains("RDC violation") && s.contains("data_q")
+                && s.contains("not async-reset")
+        }),
+        "expected hint about non-async guard, got: {:?}", errs
+    );
+}
+
+#[test]
+fn test_rdc_guard_waiver_does_not_apply_when_guard_is_port_input() {
+    // The guard waiver requires the guard signal to be a register in
+    // THIS module — a port input doesn't carry a known reset behavior
+    // for the local checker (cross-module verification is out of
+    // scope per issue #260). Should still fail with a hint.
+    let source = r#"
+domain D
+  freq_mhz: 100
+end domain D
+module M
+  port clk: in Clock<D>;
+  port rst: in Reset<Async, Low>;
+  port d:   in UInt<8>;
+  port valid_in: in Bool;
+  port q:   out UInt<8>;
+  reg src_q: UInt<8> reset rst => 0;
+  reg data_q: UInt<8> guard valid_in reset none;
+  seq on clk rising
+    src_q  <= d;
+    data_q <= src_q;
+  end seq
+  let q = data_q;
+end module M
+"#;
+    let tokens = lexer::tokenize(source).expect("lex");
+    let mut parser = Parser::new(tokens, source);
+    let parsed = parser.parse_source_file().expect("parse");
+    let ast = elaborate::elaborate(parsed).expect("elaborate");
+    let symbols = resolve::resolve(&ast).expect("resolve");
+    let checker = TypeChecker::new(&symbols, &ast);
+    let result = checker.check();
+    assert!(result.is_err(), "expected RDC error (port guard doesn't qualify)");
+    let errs = result.unwrap_err();
+    assert!(
+        errs.iter().any(|e| {
+            let s = e.to_string();
+            s.contains("RDC violation") && s.contains("data_q")
+                && s.contains("not a register in this module")
+        }),
+        "expected hint about port-input guard, got: {:?}", errs
+    );
+}
+
+#[test]
+fn test_rdc_guard_waiver_does_not_apply_when_guard_is_diff_domain() {
+    // The guard waiver waives only the SAME async reset domain. If
+    // the data path crosses a different async domain, the local
+    // guard's reset doesn't help — should still fail.
+    let source = r#"
+domain DomA
+  freq_mhz: 100
+end domain DomA
+domain DomB
+  freq_mhz: 200
+end domain DomB
+module M
+  port clk_a: in Clock<DomA>;
+  port clk_b: in Clock<DomB>;
+  port rst_a: in Reset<Async, Low>;
+  port rst_b: in Reset<Async, Low>;
+  port d:     in UInt<8>;
+  port v_in:  in Bool;
+  port q:     out UInt<8>;
+  // src_q is in rst_b's domain; valid_q is async-reset on rst_a;
+  // data_q reads src_q (rst_b domain) → guard rst_a doesn't cover
+  // this crossing.
+  reg src_q: UInt<8> reset rst_b => 0;
+  reg valid_q: Bool reset rst_a => false;
+  reg data_q: UInt<8> guard valid_q reset none;
+  seq on clk_b rising
+    src_q <= d;
+  end seq
+  seq on clk_a rising
+    valid_q <= v_in;
+    data_q  <= src_q;
+  end seq
+  let q = data_q;
+end module M
+"#;
+    let tokens = lexer::tokenize(source).expect("lex");
+    let mut parser = Parser::new(tokens, source);
+    let parsed = parser.parse_source_file().expect("parse");
+    let ast = elaborate::elaborate(parsed).expect("elaborate");
+    let symbols = resolve::resolve(&ast).expect("resolve");
+    let checker = TypeChecker::new(&symbols, &ast);
+    let result = checker.check();
+    assert!(result.is_err(), "expected RDC error (cross-domain guard doesn't waive)");
+    let errs = result.unwrap_err();
+    assert!(
+        errs.iter().any(|e| {
+            let s = e.to_string();
+            s.contains("RDC violation") && s.contains("data_q")
+        }),
+        "expected RDC error on data_q, got: {:?}", errs
+    );
+}
+
+#[test]
 fn test_rdc_single_domain_no_violation() {
     // Single clock domain — RDC check is gated on multi-domain, so even
     // multiple registers sharing a reset must not trigger.


### PR DESCRIPTION
## Summary

Closes #260. Recognize the existing `guard VALID_SIG` clause as a flop-granular RDC waiver: when a reset-none / sync-reset register is annotated `guard valid_q` AND `valid_q` is itself async-reset on the same domain whose data the register captures, the violation is waived.

## Why
The strict RDC check correctly flags reset-none registers that capture data crossing async-reset boundaries. The existing escape hatch is `pragma rdc_safe`, which is module-wide and silently accepts every future RDC violation in the module. This change adds a flop-granular waiver: downstream readers structurally ignore the data while the guard signal is low, so the metastability hazard during reset deassertion is contained without requiring the data flop to be reset.

## Implementation

Extend `FlopInfo` in `typecheck::check_rdc_phase2a` with `guard_sig` (read from `RegDecl.guard` / `PortRegInfo.guard`). At violation-emit time:
1. Reg has a guard annotation?
2. Guard signal is in `flop_info` with `reset_kind == Async`?
3. Guard's reset signal covers ALL domains in the reach set?

If all three hold, skip the violation. Otherwise emit — with a hint pointing at the qualifying-guard form when a guard is present but doesn't qualify (sync-reset guard or port-input guard).

## Test plan
- [x] `cargo test --release` — 344 passed (4 new tests covering positive + 3 negative cases).
- [x] Motivating downstream use case (arch-ibex `IbexPrefetchBuffer`) verified to compile cleanly with the waiver — `pragma rdc_safe` can be dropped in a follow-up.

## Out of scope (per #260)
- Cross-module gate verification (downstream consumer's reset behavior).
- Per-flop annotation for non-guard cases (e.g. `unsafe(rdc, gates=[...])`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)