### PR TITLE
fix(resolve): dedupe `.archi` stub when real `.arch` is loaded

### DIFF
--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -378,8 +378,32 @@ pub fn resolve(source_file: &SourceFile) -> Result<SymbolTable, Vec<CompileError
         (Symbol::Domain(DomainInfo { name: "SysDomain".to_string(), freq_mhz: None }), Span { start: 0, end: 0 }),
     );
 
+    // Build the set of names that have a real (non-interface) definition
+    // in this compilation unit. Interface stubs from `.archi` files for
+    // those same names are silently dropped below — they exist only to
+    // expose port signatures across `.archi` boundaries, and the real
+    // `.arch` definition supersedes them when both are loaded together.
+    //
+    // Without this, passing `clk_divider.arch clk_div_counter.arch` to
+    // `arch sim` errors with `duplicate definition: ClkDiv2` because the
+    // `.archi` stub auto-loaded by the inst-resolver and the `.arch` real
+    // module both register as separate globals.
+    let real_names: std::collections::HashSet<String> = source_file.items.iter()
+        .filter_map(|it| {
+            if it.is_interface() { None }
+            else { Some(it.as_construct().name().name.clone()) }
+        })
+        .collect();
+
     // First pass: register all global items
     for item in &source_file.items {
+        // Drop interface stubs that have a real definition somewhere in
+        // this unit. The stub's only job was to expose the port signature
+        // for `.archi`-based separate compilation; the real definition
+        // carries the same ports plus the body.
+        if item.is_interface() && real_names.contains(&item.as_construct().name().name) {
+            continue;
+        }
         match item {
             Item::Domain(d) => {
                 // Allow duplicate domain definitions (common in multi-file projects)

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -11082,3 +11082,78 @@ fn test_codegen_vec_uint1_collapses_inner_zero_dim() {
     assert!(sv.contains("output logic [3:0] mask"),
         "Vec<Bool, 4> should still emit as `logic [3:0]`:\n{sv}");
 }
+
+/// Loading both an `.archi` interface stub *and* the real `.arch`
+/// definition for the same module name in a single compilation unit
+/// must not error with `duplicate definition`. This covers the
+/// natural workflow `arch sim sub.arch top.arch --tb top_tb.cpp`,
+/// where `top.arch` references `sub` via `inst` and the inst
+/// resolver auto-loads `sub.archi` on top of the explicitly-passed
+/// `sub.arch` — both register as `Item::Module`, only one as
+/// interface stub.
+#[test]
+fn test_archi_stub_dedupes_with_real_arch() {
+    use arch::ast::Item;
+
+    // Concatenated source: interface stub followed by real definition.
+    // Both define `module Sub` with identical port signatures; the
+    // first will be tagged as an interface stub before resolve, just
+    // like main.rs does for items loaded from `.archi` files.
+    let source = r#"
+domain SysDomain
+  freq_mhz: 100
+end domain SysDomain
+
+module Sub
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port a: in UInt<8>;
+  port b: out UInt<8>;
+end module Sub
+
+module Sub
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port a: in UInt<8>;
+  port b: out UInt<8>;
+
+  comb
+    b = a;
+  end comb
+end module Sub
+
+module Top
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port x: in UInt<8>;
+  port y: out UInt<8>;
+
+  inst s: Sub
+    clk <- clk;
+    rst <- rst;
+    a   <- x;
+    b   -> y;
+  end inst s
+end module Top
+"#;
+    let tokens = lexer::tokenize(source).expect("lexer error");
+    let mut parser = Parser::new(tokens, source);
+    let mut parsed_ast = parser.parse_source_file().expect("parse error");
+
+    // Tag the first `Sub` as an interface stub (mirrors main.rs's
+    // filename-based tagging when items are parsed from a `.archi`).
+    let mut tagged_one = false;
+    for item in parsed_ast.items.iter_mut() {
+        if let Item::Module(m) = item {
+            if m.name.name == "Sub" && !tagged_one {
+                item.set_is_interface(true);
+                tagged_one = true;
+            }
+        }
+    }
+    assert!(tagged_one, "expected to tag the first Sub as interface");
+
+    let ast = elaborate::elaborate(parsed_ast).expect("elaborate error");
+    let _symbols = resolve::resolve(&ast)
+        .expect("resolve should succeed when an .archi stub coexists with the real .arch");
+}


### PR DESCRIPTION
## Summary

\`arch sim sub.arch top.arch --tb top_tb.cpp\` previously errored \`duplicate definition: <name>\` whenever both an \`.archi\` interface stub and the real \`.arch\` definition for the same module ended up in one compilation unit. This blocked the natural multi-file workflow for designs whose sub-modules live in separate \`.arch\` files (e.g. \`examples/clk_div_counter.arch\` instantiating \`examples/clk_divider.arch\`'s \`ClkDiv2\`).

## How it surfaced

While porting \`examples/clk_div_counter.arch\` to a HARC test in [harc-com](https://github.com/arch-hdl-lang/harc-com), I needed the canonical workflow:

\`\`\`
arch sim examples/clk_divider.arch examples/clk_div_counter.arch \\
  --tb examples/clk_div_counter_tb.cpp
\`\`\`

This errored with \`duplicate definition: ClkDiv2\` because:

1. The user explicitly passes \`clk_divider.arch\` (real definition of \`ClkDiv2\`).
2. The inst-resolver auto-loads \`examples/ClkDiv2.archi\` (interface stub) on top of that, since \`clk_div_counter.arch\` references \`inst div: ClkDiv2\`.
3. Both items parse as \`Item::Module\` and land in \`source.items\`. \`resolve()\`'s symbol-table dedupe treats them as two genuine collisions.

The interface stub exists only to expose the port signature for typecheck across \`.archi\` boundaries — the real definition carries the same ports plus the body. So when both are present, the stub is redundant and should be silently dropped.

## Implementation

A small pre-pass in \`resolve()\` builds the set of names with a real (non-interface) definition. The main item-loop silently skips any interface item whose name is in that set. Covers all 10 \`Item::is_interface()\`-bearing variants (module + the \`ConstructCommon\` family — fsm, fifo, ram, cam, counter, arbiter, regfile, pipeline, linklist) without touching their per-construct duplicate checks.

## Test plan

- [x] \`cargo test\` — 348 tests passing (was 347, +1 new regression test)
- [x] New test \`test_archi_stub_dedupes_with_real_arch\` constructs a synthetic stub-plus-real scenario and asserts \`resolve\` succeeds.
- [x] Manual e2e: \`arch sim examples/clk_divider.arch examples/clk_div_counter.arch --tb examples/clk_div_counter_tb.cpp\` → \`ClkDivCounter: 9/9 passed\`.
- [x] HARC's \`clk_div_counter_test\` fixture continues to pass against Verilator-compiled SV.

## Out of scope

A natural follow-on would be **single-file invocation** (\`arch sim clk_div_counter.arch --tb foo.cpp\`) — auto-discover the real \`.arch\` for any \`inst\`-referenced sub-module without making the user list every dependency. I sketched a directory-scan implementation but backed it out because the example tree has more than one file defining the same module name (\`ClkDiv2\` exists in both \`clk_divider.arch\` and \`clk_out_test.arch\` with different signatures); the scan picked the wrong one. Doing this safely needs port-signature matching against the \`.archi\` and is worth its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)