### PR TITLE
fix(parser): clear error when Vec::splat used in reset clause

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1236,6 +1236,14 @@ impl Parser {
 
         // Parse `=> VALUE` — required reset value
         self.expect(TokenKind::FatArrow)?;
+        // Catch `Vec::splat(...)` — SV broadcasts scalars to arrays
+        // natively, so a plain scalar value is all that's needed.
+        if self.check(TokenKind::KwVec) {
+            return Err(CompileError::general(
+                "SV broadcasts scalars to all array elements natively — use a plain scalar value (e.g. `0`) instead",
+                self.peek_span(),
+            ));
+        }
         let reset_value = self.parse_expr()?;
 
         // Accept token (Sync/Async) or lowercase ident (sync/async).


### PR DESCRIPTION
## Summary
Fixes #248. Gives a clear error when `Vec::splat(...)` is used in a reset clause — SV broadcasts scalars to arrays natively, so a plain scalar is all that is needed.

Before: `unexpected token: expected expression, found Vec`
After: `SV broadcasts scalars to all array elements natively — use a plain scalar value (e.g. 0) instead`

## Test plan
- [x] `reset rst => Vec::splat(0)` → clear error
- [x] `reset rst => 0` → works as before
- [x] `cargo test --release` — 348/348 pass