### PR TITLE
sim_codegen: include params in build_widths / collect_wide_names

### DIFF
--- a/src/sim_codegen/mod.rs
+++ b/src/sim_codegen/mod.rs
@@ -404,7 +404,7 @@ impl<'a> SimCodegen<'a> {
         let vec_port_names: HashSet<String> = vec_port_infos.iter().map(|v| v.0.clone()).collect();
 
         // Wide signal names
-        let wide_names = collect_wide_names(&m.ports, &m.body);
+        let wide_names = collect_wide_names(&m.ports, &m.body, &m.params);
 
         // Regular scalar ports
         for p in &m.ports {
@@ -3411,10 +3411,32 @@ fn resolve_enum_variant(
 }
 
 /// Build a name→width map from module ports, regs, and lets.
-fn build_widths(ports: &[PortDecl], body: &[ModuleBodyItem]) -> HashMap<String, u32> {
+fn build_widths(ports: &[PortDecl], body: &[ModuleBodyItem], params: &[ParamDecl]) -> HashMap<String, u32> {
     let mut m = HashMap::new();
     for p in ports {
         m.insert(p.name.name.clone(), type_bits_te(&p.ty));
+    }
+    // Compile-time-constant params participate in width inference the same
+    // way let bindings do. Without this, `infer_expr_width` falls back to
+    // its 8-bit default for any concat / shift expression that names a
+    // param, silently producing 1-bit-off bit positions in emitted C++.
+    for p in params {
+        let bits = match &p.kind {
+            ParamKind::WidthConst(hi, lo) => {
+                let h = eval_width(hi);
+                let l = eval_width(lo);
+                h - l + 1
+            }
+            ParamKind::Logic(ty) | ParamKind::Type(ty) => type_bits_te(ty),
+            // `param X: const = N` (untyped). Pre-existing call sites treat
+            // this as an int-typed parameter (32 bits), so match.
+            ParamKind::Const => 32,
+            // Enum / Vec params: width depends on the underlying type. Skip
+            // — concat-of-enum isn't a valid construct; concat-of-Vec is
+            // handled elsewhere via vec_array_info_with_params.
+            ParamKind::EnumConst(_) | ParamKind::ConstVec(_) => continue,
+        };
+        m.insert(p.name.name.clone(), bits);
     }
     for item in body {
         match item {
@@ -3467,7 +3489,7 @@ fn type_bits_te(ty: &TypeExpr) -> u32 {
 }
 
 /// Collect names whose bit width exceeds 64 (require wide handling).
-fn collect_wide_names(ports: &[PortDecl], body: &[ModuleBodyItem]) -> HashSet<String> {
+fn collect_wide_names(ports: &[PortDecl], body: &[ModuleBodyItem], params: &[ParamDecl]) -> HashSet<String> {
     let mut s = HashSet::new();
     for p in ports {
         if type_bits_te(&p.ty) > 64 { s.insert(p.name.name.clone()); }
@@ -3486,7 +3508,7 @@ fn collect_wide_names(ports: &[PortDecl], body: &[ModuleBodyItem]) -> HashSet<St
         }
     }
     // Resolve pipe_reg wide from source
-    let widths = build_widths(ports, body);
+    let widths = build_widths(ports, body, params);
     for item in body {
         if let ModuleBodyItem::PipeRegDecl(p) = item {
             let w = widths.get(&p.source.name).copied().unwrap_or(32);
@@ -3896,8 +3918,8 @@ impl<'a> SimCodegen<'a> {
         let let_values  = collect_let_values(&m.body, &m.params);
         let inst_names  = collect_inst_names(&m.body);
         let inst_out    = collect_inst_output_signals(&m.body);
-        let mut wide_names  = collect_wide_names(&m.ports, &m.body);
-        let mut widths      = build_widths(&m.ports, &m.body);
+        let mut wide_names  = collect_wide_names(&m.ports, &m.body, &m.params);
+        let mut widths      = build_widths(&m.ports, &m.body, &m.params);
 
         // Add bus flattened signals to wide_names and widths
         for (flat_name, flat_ty) in &bus_flat {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -8842,6 +8842,43 @@ fn test_sim_codegen_match_arm_local_param_const_emits_case_with_literal() {
 }
 
 #[test]
+fn test_sim_codegen_concat_with_local_param_uses_declared_width() {
+    // Companion to the match-arm `local param` test. Pre-fix, `build_widths`
+    // and `collect_wide_names` only walked ports + regs + wires + let
+    // bindings — module-level params were excluded. `infer_expr_width`
+    // then fell back to its 8-bit default for any concat / shift
+    // expression that named a param, emitting bit offsets one position
+    // wider than the param's declared width. The result was a silent
+    // 1-bit gap in the emitted C++ where the next concat element
+    // should start.
+    //
+    // Bug origin: arch-ibex IbexCompressedDecoder OPCODE_* conversion
+    // from `let` to `local param` produced wrong `instr_o` values for
+    // every compressed-instruction expansion that placed an opcode in
+    // an `instr_d = {imm, rs1, funct3, rd, OPCODE_X}` concat.
+    let source = "
+        domain SysDomain
+          freq_mhz: 100
+        end domain SysDomain
+        module M
+          local param OPCODE[6:0]: const = 7'h13;
+          port instr_o: out UInt<32>;
+          let instr_d: UInt<32> = {20'h12345, 5'h7, OPCODE};
+          let instr_o = instr_d;
+        end module M
+    ";
+    let cpp = compile_to_sim_h(source, false);
+    // The next concat element after OPCODE (7 bits) must shift by 7,
+    // not 8. Look for `<< 7` in the concat — pre-fix it was `<< 8`.
+    assert!(cpp.contains("<< 7"),
+        "param OPCODE[6:0] must be treated as 7 bits wide in concat offsets; cpp lacks `<< 7`:\n{cpp}");
+    // And the 7+5=12-bit boundary should produce `<< 12` for the 20-bit
+    // imm field, not `<< 13`.
+    assert!(cpp.contains("<< 12"),
+        "7-bit OPCODE + 5-bit rd must place 20-bit imm at offset 12, not 13:\n{cpp}");
+}
+
+#[test]
 fn test_sim_codegen_bit_slice_lhs_compiles_and_uses_param_width() {
     // Regression: pre-fix, `name[hi:lo] = val` in a seq block lowered to
     // the read-side bit-slice form `((name >> lo) & MASK) = val`, an


### PR DESCRIPTION
## Summary

Follow-on to #328. That PR fixed \`Pattern::Ident\` match arms so \`local param X: const = N\` arms resolve to \`case <literal>:\`. This PR addresses the parallel issue in **expression-position** param refs (concat, shift, binary op).

\`infer_expr_width\` consults \`ctx.widths\` to compute concat shift offsets and binary-op widths. \`build_widths\` only walked ports + regs + wires + let bindings — params were silently excluded. For a param ident inside a concat \`{imm, rs1, funct3, rd, OPCODE}\`, the fallback returned 8 (with a stderr warning), and cumulative shift offsets placed every subsequent field one bit higher than its true SV position. Wrong values in emitted C++ only (the SV emit path was already correct because \`localparam [W-1:0]\` carries declared width into the SV slot it occupies).

## How this surfaced

arch-ibex converted IbexCompressedDecoder operator constants from \`let OPCODE_OP_IMM: UInt<7> = 7'h13\` to \`local param OPCODE_OP_IMM[6:0]: const = 7'h13\`. Every q*_c_* archsim test failed with \`instr_o\` off by a 1-bit gap inside the instruction word.

## Fix

Extends \`build_widths\` and \`collect_wide_names\` to also walk \`m.params\`, deriving each param's bit width from its \`ParamKind\`:
- \`WidthConst(hi, lo)\` → hi - lo + 1
- \`Logic(ty)\` / \`Type(ty)\` → \`type_bits_te(ty)\`
- \`Const\` → 32 (matches pre-existing default int treatment)
- \`EnumConst\` / \`ConstVec\` → skipped (no scalar width)

## Test plan

- [x] New \`test_sim_codegen_concat_with_local_param_uses_declared_width\` covers the OPCODE-in-concat shape from IbexCompressedDecoder (asserts \`<< 7\` and \`<< 12\` appear, not the buggy \`<< 8\` / \`<< 13\`).
- [x] \`cargo test --release\` — 352 passes / 0 failures (was 351, +1 new test).
- [x] arch-ibex full archsim: 6/6 pass with this fix (IbexCompressedDecoder was failing pre-fix even with PR #328 alone).

## Known limitation (separate issue)

Thread-helper compilation units (\`_<mod>_threads.cpp\`) do not inherit parent-module params — a thread body referencing a parent's \`local param\` emits \`use of undeclared identifier\`. Tracked outside this PR; arch-ibex's IbexMultdivFast keeps \`let MD_OP_*\` until this is addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)