### PR TITLE
lower_module_threads: clone parent params into `_<mod>_threads` submodule

### DIFF
--- a/src/elaborate.rs
+++ b/src/elaborate.rs
@@ -1549,6 +1549,12 @@ fn lower_module_threads(m: ModuleDecl, opts: &ThreadLowerOpts) -> Result<(Module
     // that calls a parent-module function emits as an unresolved
     // task/function reference inside the threads submodule.
     let mut parent_functions: Vec<ModuleBodyItem> = Vec::new();
+    // Module-scope params (e.g. `local param X[W-1:0]: const = N`) are
+    // similarly visible to thread bodies. Without cloning them into the
+    // submodule, any thread-body reference (match arm, concat, comparison)
+    // emits as an unresolved identifier in the threads codegen. Clone the
+    // whole list — params are cheap, and any unused ones are inert.
+    let parent_params: Vec<ParamDecl> = m.params.clone();
 
     for item in m.body {
         match item {
@@ -2480,7 +2486,7 @@ fn lower_module_threads(m: ModuleDecl, opts: &ThreadLowerOpts) -> Result<(Module
 
     let merged_module = ModuleDecl {
         name: Ident::new(merged_name.clone(), sp),
-        params: Vec::new(),
+        params: parent_params,
         ports: merged_ports.clone(),
         body: merged_body,
         implements: None,

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -8879,6 +8879,58 @@ fn test_sim_codegen_concat_with_local_param_uses_declared_width() {
 }
 
 #[test]
+fn test_lower_threads_clones_parent_params_into_threads_submodule() {
+    // Regression: pre-fix, `lower_module_threads` built the synthetic
+    // `_<mod>_threads` submodule with `params: Vec::new()`, so parent-
+    // module `local param`s were invisible inside thread bodies. Any
+    // thread reference to a parent constant (match arm, comparison,
+    // concat) emitted as `use of undeclared identifier <NAME>` in the
+    // standalone threads compilation unit.
+    //
+    // Bug origin: arch-ibex IbexMultdivFast attempting `local param
+    // MD_OP_DIV[1:0]: const = 2'd2` — every thread-body `operator_i ==
+    // MD_OP_DIV` comparison broke the threads cpp build. The let-form
+    // sidesteps this because lets are local to a body and get inlined
+    // before any submodule lift.
+    //
+    // Post-fix the lowering pass clones parent params into the
+    // submodule's `params`, so SV emit and archsim see them.
+    let source = r#"
+        module M
+          local param OP_GO[1:0]: const = 2'd2;
+          port clk:    in Clock<SysDomain>;
+          port rst:    in Reset<Sync, High>;
+          port op_i:   in UInt<2>;
+          port reg phase: out UInt<4> reset rst => 4'd0;
+
+          thread on clk rising, rst high
+            wait until op_i == OP_GO;
+            phase <= 4'd1;
+            wait 1 cycle;
+          end thread
+        end module M
+    "#;
+    // The full module compiles end-to-end. Pre-fix this raised a
+    // compile error because the synthetic `_M_threads` SV referenced
+    // `OP_GO` without a declaration. Post-fix the submodule has its
+    // own `localparam [1:0] OP_GO = 2'd2`.
+    let sv = compile_to_sv(source);
+    // Parent module still declares OP_GO.
+    assert!(sv.contains("localparam [1:0] OP_GO = 2'd2"),
+        "parent module must keep its localparam OP_GO:\n{sv}");
+    // Synthetic threads submodule should ALSO declare OP_GO, not refer
+    // to an undeclared identifier. The emit places submodule decls
+    // ahead of the parent module, but both must contain it.
+    let occurrences = sv.matches("localparam [1:0] OP_GO = 2'd2").count();
+    assert!(occurrences >= 2,
+        "both parent and `_M_threads` submodule should declare OP_GO; only {occurrences} occurrence(s):\n{sv}");
+    // And the thread body's predicate must reference OP_GO (proves the
+    // identifier survived lowering).
+    assert!(sv.contains("OP_GO") && sv.matches("OP_GO").count() >= 3,
+        "thread body should compare op_i against OP_GO:\n{sv}");
+}
+
+#[test]
 fn test_sim_codegen_bit_slice_lhs_compiles_and_uses_param_width() {
     // Regression: pre-fix, `name[hi:lo] = val` in a seq block lowered to
     // the read-side bit-slice form `((name >> lo) & MASK) = val`, an


### PR DESCRIPTION
## Summary

Completes the param-visibility trio for thread-using modules. PRs #328 (match-arm fold) and #329 (build_widths) covered the codegen sites; this PR fixes the **elaboration** site that creates the synthetic threads submodule.

\`lower_module_threads\` already clones parent functions into the submodule body (so thread-body calls resolve), but constructed it with \`params: Vec::new()\`. Any thread-body reference to a parent \`local param\` (match arm, comparison, concat) emitted as \`use of undeclared identifier\` in the standalone threads compilation unit — both SV and archsim C++.

Fix: capture \`m.params.clone()\` before consuming \`m.body\`, thread it into the submodule's \`params\` field. Params are cheap to clone and unused ones are inert.

## How this surfaced

arch-ibex IbexMultdivFast uses \`thread\` and declares \`MD_OP_{MULL,MULH,DIV,REM}\` encoding constants. The \`let\` form sidestepped the bug because lets inline at use-site before the submodule lift. Converting to \`local param\` (preferred for non-overridability) broke the threads cpp build with 20 \`undeclared identifier\` errors. With this PR, IbexMultdivFast cleanly compiles in both SV and archsim using \`local param MD_OP_*\`.

## Test plan

- [x] New \`test_lower_threads_clones_parent_params_into_threads_submodule\` covers a \`wait until op_i == OP_GO\` shape; asserts both parent and \`_M_threads\` declare \`localparam [1:0] OP_GO = 2'd2\`.
- [x] \`cargo test --release\` — 353 passes / 0 failures (was 352, +1 new test).
- [x] arch-ibex: IbexMultdivFast archsim test passes with \`local param MD_OP_*\` (was failing pre-fix with 20 cpp errors).
- [x] arch-ibex full SoC gate: 127 pass, 3 pre-existing failures unrelated to this change.

## Trilogy

This is the third piece. Combined effect:
- PR #328: \`Pattern::Ident\` arms resolve to \`case <lit>:\` in match.
- PR #329: \`local param X[W-1:0]\` carries width into concat / shift expressions.
- This PR: thread bodies see parent module params.

After this lands, \`local param\` is fully usable for module-scope encoding constants, including in modules that use \`thread\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)