### PR TITLE
elaborate: emit per-thread state-name localparams (issue #247)

### DIFF
--- a/src/elaborate.rs
+++ b/src/elaborate.rs
@@ -1954,6 +1954,13 @@ fn lower_module_threads(m: ModuleDecl, opts: &ThreadLowerOpts) -> Result<(Module
     // ── Per-thread state machines ──────────────────────────────────────
     let mut all_thread_comb: Vec<Stmt> = Vec::new();
     let mut all_thread_seq: Vec<Stmt> = Vec::new();
+    // Per-state `localparam` decls (one set per thread). Issue #247: make
+    // thread-lowered FSMs debuggable by giving each state a descriptive
+    // SV-level name (e.g. `_t0_S2_wait_until`) and emitting state
+    // comparisons / assignments as `_t0_state == _t0_S2_wait_until`
+    // instead of bare `_t0_state == 2`. Appended to the merged-threads
+    // module's `params` list at construction time.
+    let mut state_name_params: Vec<ParamDecl> = Vec::new();
     // Auto-emitted SVA spec-contract properties (gated by `opts.auto_asserts`).
     // Reset-guarded antecedent so they don't fire during reset.
     let mut auto_asserts: Vec<AssertDecl> = Vec::new();
@@ -2052,6 +2059,64 @@ fn lower_module_threads(m: ModuleDecl, opts: &ThreadLowerOpts) -> Result<(Module
         let n_states = raw_states.len();
         let state_reg = format!("_t{}_state", ti);
         let state_bits = crate::width::index_width(n_states as u64) as u64;
+
+        // Derive a descriptive name per state from structural shape (issue #247).
+        // Role categories (checked in order, first match wins):
+        //   - dispatch:    >1 multi_transitions  (fork/join product or if-dispatch)
+        //   - wait_cycles: counter-driven stay-then-advance (`wait N cycle`)
+        //   - wait_until:  transition_cond is Some (`wait until cond`)
+        //   - entry:       state 0 with none of the above (clean entry state)
+        //   - action:      everything else (unconditional advance with body work)
+        // Per-thread prefix `_t{ti}_` keeps the names unique within the
+        // merged-threads module across multiple threads; the state register
+        // itself is also `_t{ti}_state`.
+        let state_names: Vec<String> = (0..n_states)
+            .map(|si| {
+                let s = &raw_states[si];
+                let role = if s.multi_transitions.len() > 1 {
+                    "dispatch"
+                } else if s.wait_cycles.is_some() {
+                    "wait_cycles"
+                } else if s.transition_cond.is_some() {
+                    "wait_until"
+                } else if si == 0 {
+                    "entry"
+                } else {
+                    "action"
+                };
+                format!("_t{}_S{}_{}", ti, si, role)
+            })
+            .collect();
+
+        // Emit one `localparam [W-1:0] _t{ti}_S{N}_<role> = N;` per state, so
+        // SV waveform viewers and source readers can decode the state register
+        // by name. The width matches the state register's UInt<W> type; W is
+        // `state_bits.max(1)` (clog2-of-N with a floor of 1 for the
+        // single-state edge case).
+        let w_hi = if state_bits == 0 { 0 } else { state_bits - 1 };
+        for si in 0..n_states {
+            let hi_lit = Expr::new(ExprKind::Literal(LitKind::Dec(w_hi)), sp);
+            let lo_lit = Expr::new(ExprKind::Literal(LitKind::Dec(0)), sp);
+            state_name_params.push(ParamDecl {
+                name: Ident::new(state_names[si].clone(), sp),
+                kind: ParamKind::WidthConst(hi_lit, lo_lit),
+                default: Some(Expr::new(ExprKind::Literal(LitKind::Dec(si as u64)), sp)),
+                is_local: true,
+                span: sp,
+                unpacked_size: None,
+            });
+        }
+
+        // Helper: build an Expr that references the state-N localparam by name
+        // instead of emitting a bare numeric literal. Replaces the previous
+        // `ExprKind::Literal(LitKind::Dec(N))` pattern at every state-reference
+        // site below — state == N comparisons, state <= N transition assigns,
+        // and the SVA auto-assert state_lit closure. Bare literals would still
+        // be correct SV (the localparam evaluates to the same N) but the
+        // name-form is the whole point of #247.
+        let state_name_expr = |id: usize| -> Expr {
+            Expr::new(ExprKind::Ident(state_names[id].clone()), sp)
+        };
 
         // State register
         merged_body.push(ModuleBodyItem::RegDecl(RegDecl {
@@ -2153,7 +2218,7 @@ fn lower_module_threads(m: ModuleDecl, opts: &ThreadLowerOpts) -> Result<(Module
             let state_cond = Expr::new(ExprKind::Binary(
                 BinOp::Eq,
                 Box::new(Expr::new(ExprKind::Ident(state_reg.clone()), sp)),
-                Box::new(Expr::new(ExprKind::Literal(LitKind::Dec(si as u64)), sp)),
+                Box::new(state_name_expr(si)),
             ), sp);
 
             let mut body: Vec<Stmt> = Vec::new();
@@ -2202,7 +2267,7 @@ fn lower_module_threads(m: ModuleDecl, opts: &ThreadLowerOpts) -> Result<(Module
                         cond: cond.clone(),
                         then_stmts: vec![Stmt::Assign(RegAssign {
                             target: Expr::new(ExprKind::Ident(state_reg.clone()), sp),
-                            value: Expr::new(ExprKind::Literal(LitKind::Dec(tgt as u64)), sp),
+                            value: state_name_expr(tgt),
                             span: sp,
                         })],
                         else_stmts: Vec::new(), unique: false, span: sp,
@@ -2213,7 +2278,7 @@ fn lower_module_threads(m: ModuleDecl, opts: &ThreadLowerOpts) -> Result<(Module
                     cond: cond.clone(),
                     then_stmts: vec![Stmt::Assign(RegAssign {
                         target: Expr::new(ExprKind::Ident(state_reg.clone()), sp),
-                        value: Expr::new(ExprKind::Literal(LitKind::Dec(next_state as u64)), sp),
+                        value: state_name_expr(next_state),
                         span: sp,
                     })],
                     else_stmts: Vec::new(), unique: false, span: sp,
@@ -2230,7 +2295,7 @@ fn lower_module_threads(m: ModuleDecl, opts: &ThreadLowerOpts) -> Result<(Module
                     cond: cnt_zero,
                     then_stmts: vec![Stmt::Assign(RegAssign {
                         target: Expr::new(ExprKind::Ident(state_reg.clone()), sp),
-                        value: Expr::new(ExprKind::Literal(LitKind::Dec(next_state as u64)), sp),
+                        value: state_name_expr(next_state),
                         span: sp,
                     })],
                     else_stmts: Vec::new(), unique: false, span: sp,
@@ -2239,7 +2304,7 @@ fn lower_module_threads(m: ModuleDecl, opts: &ThreadLowerOpts) -> Result<(Module
                 // Unconditional transition
                 body.push(Stmt::Assign(RegAssign {
                     target: Expr::new(ExprKind::Ident(state_reg.clone()), sp),
-                    value: Expr::new(ExprKind::Literal(LitKind::Dec(next_state as u64)), sp),
+                    value: state_name_expr(next_state),
                     span: sp,
                 }));
             }
@@ -2256,7 +2321,7 @@ fn lower_module_threads(m: ModuleDecl, opts: &ThreadLowerOpts) -> Result<(Module
                 let mk_bin = |op: BinOp, a: Expr, b: Expr| -> Expr {
                     Expr::new(ExprKind::Binary(op, Box::new(a), Box::new(b)), sp)
                 };
-                let state_lit = |id: usize| Expr::new(ExprKind::Literal(LitKind::Dec(id as u64)), sp);
+                let state_lit = |id: usize| state_name_expr(id);
                 let state_id = || Expr::new(ExprKind::Ident(state_reg.clone()), sp);
                 let state_eq = |id: usize| mk_bin(BinOp::Eq, state_id(), state_lit(id));
                 let rst_g = rst_inactive.clone().unwrap();
@@ -2334,10 +2399,10 @@ fn lower_module_threads(m: ModuleDecl, opts: &ThreadLowerOpts) -> Result<(Module
                     }
                 })
                 .collect();
-            // Reset state to 0
+            // Reset state to 0 (the entry state — name-form for #247).
             dw_then.push(Stmt::Assign(RegAssign {
                 target: Expr::new(ExprKind::Ident(state_reg.clone()), sp),
-                value: make_zero_expr(sp),
+                value: state_name_expr(0),
                 span: sp,
             }));
             all_thread_seq.push(Stmt::IfElse(IfElse {
@@ -2357,7 +2422,7 @@ fn lower_module_threads(m: ModuleDecl, opts: &ThreadLowerOpts) -> Result<(Module
             let state_cond = Expr::new(ExprKind::Binary(
                 BinOp::Eq,
                 Box::new(Expr::new(ExprKind::Ident(state_reg.clone()), sp)),
-                Box::new(Expr::new(ExprKind::Literal(LitKind::Dec(si as u64)), sp)),
+                Box::new(state_name_expr(si)),
             ), sp);
 
             // This state's own comb outputs
@@ -2503,9 +2568,17 @@ fn lower_module_threads(m: ModuleDecl, opts: &ThreadLowerOpts) -> Result<(Module
         merged_body.push(ModuleBodyItem::Assert(a));
     }
 
+    // Append per-thread state-name localparams (issue #247) AFTER parent
+    // params so the inst-site parameter override order (which matches
+    // parent's param list) is preserved. The state-name params are all
+    // `is_local: true` → emit as SV `localparam`, not overridable from
+    // the inst site, so they don't appear in the connection list anyway.
+    let mut merged_params = parent_params;
+    merged_params.extend(state_name_params);
+
     let merged_module = ModuleDecl {
         name: Ident::new(merged_name.clone(), sp),
-        params: parent_params,
+        params: merged_params,
         ports: merged_ports.clone(),
         body: merged_body,
         implements: None,

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -7481,12 +7481,15 @@ fn test_wait_1_cycle_between_seq_writes_takes_one_cycle() {
         "should not emit counter-decrement state for `wait 1 cycle`:\n{sv}");
     // Three phase writes appear, each transitioning to the next state.
     // State numbering after elision: 0=initial wait, 1=phase=1,
-    // 2=phase=2, 3=phase=3, then loop back to 0.
+    // 2=phase=2, 3=phase=3, then loop back to 0. Issue #247 changed
+    // state assignments to reference per-state `localparam` names
+    // (`_t0_S<N>_<role>`) instead of bare numeric literals.
     assert!(sv.contains("phase <= 2'd1;") && sv.contains("phase <= 2'd2;")
             && sv.contains("phase <= 2'd3;"),
         "expected three phase writes:\n{sv}");
-    assert!(sv.contains("_t0_state <= 2;") && sv.contains("_t0_state <= 3;"),
-        "expected state transitions 1->2 and 2->3:\n{sv}");
+    assert!(sv.contains("_t0_state <= _t0_S2_action;")
+            && sv.contains("_t0_state <= _t0_S3_action;"),
+        "expected state transitions 1->2 and 2->3 via state-name localparams:\n{sv}");
 }
 
 #[test]
@@ -7545,11 +7548,13 @@ fn test_auto_thread_asserts_wait_cycles_and_until() {
     let opts = elaborate::ThreadLowerOpts { auto_asserts: true };
     let sv = compile_to_sv_with_opts(source, &opts);
 
-    // Wait-until: state 0 transitions on `start`.
+    // Wait-until: state 0 transitions on `start`. Issue #247 changed
+    // state comparisons in auto-asserts to reference per-state
+    // `localparam` names (`_t0_S<N>_<role>`) instead of bare literals.
     assert!(sv.contains("_auto_thread_t0_wait_until_s0:"),
         "expected wait_until property at state 0:\n{sv}");
-    assert!(sv.contains("|=> _t0_state == 1"),
-        "expected next-cycle implication to state 1:\n{sv}");
+    assert!(sv.contains("|=> _t0_state == _t0_S1_wait_cycles"),
+        "expected next-cycle implication to state 1 (wait_cycles) via state-name localparam:\n{sv}");
 
     // Wait-cycles: stay + done assertions.
     assert!(sv.contains("_auto_thread_t0_wait_stay_s1:"),
@@ -11600,4 +11605,105 @@ fn test_uint_48_literal_width_emits_uint64_storage() {
             "UInt<48> reg should be uint64_t; got:\n{out}");
     assert!(out.contains("0xFFFFFFFFFFFFULL"),
             "expected 48-bit mask; got:\n{out}");
+}
+
+// ── Thread state-name localparams (issue #247) ──────────────────────────────
+
+#[test]
+fn test_thread_state_localparams_emitted() {
+    // Issue #247: thread lowering emits one `localparam [W-1:0] _t{ti}_S{N}_<role>`
+    // per state and rewrites every state comparison / state-register assignment
+    // to reference the name instead of a bare numeric literal.
+    let source = r#"
+        module M
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync, High>;
+          port req: in Bool;
+          port reg done: out Bool reset rst => false;
+          thread on clk rising, rst high
+            wait until req;
+            done <= true;
+            wait 2 cycle;
+            done <= false;
+          end thread
+        end module M
+    "#;
+    let sv = compile_to_sv(source);
+
+    // (1) One `localparam` per state with the expected role suffix.
+    //     S0 = wait_until (transition_cond = `req`), S1 = action (seq write),
+    //     S2 = wait_cycles (wait 2 cycle), S3 = action (final seq write).
+    assert!(sv.contains("localparam [1:0] _t0_S0_wait_until = 0"),
+        "expected S0 wait_until localparam:\n{sv}");
+    assert!(sv.contains("localparam [1:0] _t0_S1_action = 1"),
+        "expected S1 action localparam:\n{sv}");
+    assert!(sv.contains("localparam [1:0] _t0_S2_wait_cycles = 2"),
+        "expected S2 wait_cycles localparam:\n{sv}");
+    assert!(sv.contains("localparam [1:0] _t0_S3_action = 3"),
+        "expected S3 action localparam:\n{sv}");
+
+    // (2) Localparams declared in the merged threads module's parameter list,
+    //     not inside the procedural block.
+    assert!(sv.contains("module _M_threads #("),
+        "merged threads module should have a parameter list:\n{sv}");
+
+    // (3) State comparisons use the name, not a bare literal.
+    assert!(sv.contains("_t0_state == _t0_S0_wait_until"),
+        "expected name-form state comparison for S0:\n{sv}");
+    assert!(sv.contains("_t0_state == _t0_S2_wait_cycles"),
+        "expected name-form state comparison for S2:\n{sv}");
+
+    // (4) State-register assignments use the name, not a bare literal.
+    assert!(sv.contains("_t0_state <= _t0_S1_action"),
+        "expected name-form state assignment to S1:\n{sv}");
+    assert!(sv.contains("_t0_state <= _t0_S2_wait_cycles"),
+        "expected name-form state assignment to S2:\n{sv}");
+
+    // (5) No bare `_t0_state == N` or `_t0_state <= N` numeric-literal forms
+    //     should remain. The synchronous-reset path emits `_t0_state <= 0`
+    //     as the reset value (not a state-transition); that one stays as 0.
+    for n in 0..4 {
+        let bad_cmp = format!("_t0_state == {}", n);
+        let bad_assign = format!("_t0_state <= {};", n);
+        // Reset assigns to literal 0 (acceptable). All other uses must be name-form.
+        if n != 0 {
+            assert!(!sv.contains(&bad_cmp),
+                "state comparison should use name-form, found bare `{}`:\n{}", bad_cmp, sv);
+            assert!(!sv.contains(&bad_assign),
+                "state assignment should use name-form, found bare `{}`:\n{}", bad_assign, sv);
+        }
+    }
+}
+
+#[test]
+fn test_thread_state_names_distinguish_wait_until_vs_wait_cycles() {
+    // Issue #247: the structural classification must produce distinct role
+    // suffixes for a `wait until cond` state vs a `wait 1 cycle` state, so
+    // the localparam names are diagnostic (not just unique).
+    let source = r#"
+        module M
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync, High>;
+          port go: in Bool;
+          port done: out Bool;
+          thread on clk rising, rst high
+            wait until go;
+            done = 1;
+            wait 2 cycle;
+            done = 0;
+          end thread
+        end module M
+    "#;
+    let sv = compile_to_sv(source);
+    // The wait-until state and the wait-cycles state must carry distinct
+    // role suffixes so a waveform reader can tell at a glance what kind
+    // of wait the FSM is sitting in.
+    assert!(sv.contains("_t0_S0_wait_until"),
+        "expected wait_until role suffix on S0:\n{sv}");
+    assert!(sv.contains("_wait_cycles"),
+        "expected wait_cycles role suffix on the wait-cycles state:\n{sv}");
+    // Sanity: the two roles are NOT collapsed to the same name.
+    assert!(sv.matches("_t0_S0_wait_until").count() >= 1
+            && sv.matches("_wait_cycles =").count() >= 1,
+        "wait_until and wait_cycles must produce distinct localparam decls:\n{sv}");
 }


### PR DESCRIPTION
## Summary

Implements parts 1 + 2 of issue #247 (the localparam-emission portion). Thread lowering now emits one SV `localparam` per FSM state with a descriptive `_t{ti}_S{N}_<role>` name, and rewrites all state comparisons / state-register assignments to reference those names instead of bare numeric literals.

Example before vs after, for a `wait until req; done<=1; wait 2 cycle; done<=0` thread:

```sv
// Before:
if (_t0_state == 0) begin
  if (req) begin _t0_state <= 1; end
end
// ...
if (_t0_state == 2) begin
  if (_t0_cnt == 0) begin _t0_state <= 3; end
end

// After:
module _M_threads #(
  localparam [1:0] _t0_S0_wait_until = 0,
  localparam [1:0] _t0_S1_action = 1,
  localparam [1:0] _t0_S2_wait_cycles = 2,
  localparam [1:0] _t0_S3_action = 3
)
// ...
if (_t0_state == _t0_S0_wait_until) begin
  if (req) begin _t0_state <= _t0_S1_action; end
end
// ...
if (_t0_state == _t0_S2_wait_cycles) begin
  if (_t0_cnt == 0) begin _t0_state <= _t0_S3_action; end
end
```

## Naming scheme

`_t{ti}_S{N}_<role>` where role is derived structurally (first match wins):
- `dispatch`    — `multi_transitions.len() > 1` (fork/join product or if-dispatch)
- `wait_cycles` — `wait N cycle` (counter-driven stay-then-advance)
- `wait_until`  — `wait until cond` (`transition_cond` is `Some`)
- `entry`       — state 0 with none of the above (clean entry state)
- `action`      — everything else (unconditional advance with body work)

The `_t{ti}_` prefix matches the state register's own `_t{ti}_state` naming so multi-thread modules stay unambiguous.

## Scope

- Part 1 (localparam decls): done.
- Part 2 (comment header): **skipped**. `RegDecl` has no `doc` field — adding one is a structural AST change touching many sites for marginal additional value, since the localparam list itself is the id→role map. Documented as a follow-up.
- Part 3 (typedef enum): out of scope per the issue.
- TLM target/initiator FSM lowering paths untouched (separate enhancement).

## Test plan

- [x] `cargo test --release`: 358 → 360 passes (two new integration tests; two pre-existing tests updated to match the new name-form output).
- [x] Smoke test: hand-written `M.arch` produces the expected localparams + name-form comparisons (shown above).
- [x] `arch-ibex` full SoC gate (`make build && make test`): 130 passed / 0 fail / 75 skipped — matches baseline. Verified `_ibex_multdiv_fast_threads.sv` carries `_t0_S0_entry`/`_t0_S1_dispatch`/`...` localparams.

🤖 Generated with [Claude Code](https://claude.com/claude-code)