### PR TITLE
[codex] add thread default comb

### DIFF
--- a/doc/Arch_AI_Reference_Card.md
+++ b/doc/Arch_AI_Reference_Card.md
@@ -513,6 +513,13 @@ module M
   resource ar_ch;                       // mutex resource for lock blocks
 
   thread MyThread on clk rising, rst high
+    // Optional comb defaults — applied in every lowered state before
+    // state-specific comb assigns; useful for protocol outputs.
+    default comb
+      ar_valid = false;
+      ar_addr  = 0;
+    end default
+
     // Optional soft-reset clause — fires from ANY state, resets to S0.
     // Only seq assigns allowed inside default when.
     default when start and not active_r
@@ -571,6 +578,7 @@ end module M
 
 **Rules:**
 - `thread Name on clk rising, rst high` — clock edge and reset polarity required
+- `default comb … end default` must appear **before** the thread body; it may drive only comb outputs, not signals also assigned with `<=`
 - `default when cond … end default` must appear **before** the thread body; only seq assigns inside
 - `lock` blocks must **not** be nested — compile error (mutual exclusion guarantee)
 - `thread once` — FSM holds in terminal state instead of looping back to S0

--- a/doc/thread_lowering_algorithm.md
+++ b/doc/thread_lowering_algorithm.md
@@ -335,7 +335,14 @@ if (_t{ti}_state == si) begin
 end
 ```
 
-All outputs default to `0` before the per-thread blocks.
+All outputs default to `0` before the per-thread blocks. If a thread declares
+`default comb ... end default`, those comb statements are emitted after the
+compiler zero defaults and before the state-guarded comb statements. A
+state-specific comb assignment therefore overrides the thread default in the
+active state, while compiler-inserted empty/dead-skid states still get explicit
+protocol defaults instead of only zero. The lowering rejects `default comb`
+targets that are also assigned with `<=` in any thread; use it only for
+combinational thread outputs.
 
 ### always_ff (merged, single block)
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -537,6 +537,10 @@ pub struct ThreadBlock {
     /// When `cond` is true in any state, the listed seq assigns fire and the
     /// thread returns to state 0, taking priority over normal transitions.
     pub default_when: Option<(Expr, Vec<ThreadStmt>)>,
+    /// `default comb ... end default` — comb assignments active in every
+    /// lowered thread state before state-specific comb assignments. This gives
+    /// protocol outputs explicit defaults during compiler-inserted skid states.
+    pub default_comb: Vec<Stmt>,
     /// Set when the thread is a TLM method target body:
     ///   `thread PORT.METHOD(ARG1, ARG2, ...) on clk rising, rst high`.
     /// Captured at parse time (PR-tlm-3); lowering to an FSM (entry gate

--- a/src/elaborate.rs
+++ b/src/elaborate.rs
@@ -1082,6 +1082,7 @@ fn subst_thread(t: &ThreadBlock, var: &str, val: i64) -> ThreadBlock {
             subst_expr_names(cond.clone(), var, val),
             stmts.iter().map(|s| subst_thread_stmt(s, var, val)).collect(),
         )),
+        default_comb: t.default_comb.iter().map(|s| subst_comb_stmt(s, var, val)).collect(),
         tlm_target: t.tlm_target.as_ref().map(|tb| TlmTargetBinding {
             port: tb.port.clone(),
             method: tb.method.clone(),
@@ -1657,6 +1658,23 @@ fn lower_module_threads(m: ModuleDecl, opts: &ThreadLowerOpts) -> Result<(Module
             all_read.extend(dw_ar);
             collect_expr_reads(dw_cond, &mut all_read);
         }
+    }
+    for (_, t) in &threads {
+        let (dc_targets, dc_reads) = collect_comb_stmt_signals(&t.default_comb);
+        for target in &dc_targets {
+            if all_seq_driven.contains(target) {
+                return Err(vec![CompileError::general(
+                    &format!(
+                        "thread `default comb` drives `{target}`, but that signal is also \
+                         assigned with `<=` in a thread. Use `default comb` only for \
+                         combinational thread outputs."
+                    ),
+                    t.span,
+                )]);
+            }
+        }
+        all_comb_driven.extend(dc_targets);
+        all_read.extend(dc_reads);
     }
 
     // Clock and reset ports (from first thread)
@@ -2546,6 +2564,13 @@ fn lower_module_threads(m: ModuleDecl, opts: &ThreadLowerOpts) -> Result<(Module
             }));
         }
     }
+    // Thread-level `default comb` assignments run unconditionally before
+    // state-specific comb assignments. This preserves explicit protocol
+    // defaults during compiler-inserted dead-skid states while still letting
+    // the active state override them later in the same always_comb block.
+    for (_, t) in &threads {
+        merged_comb.extend(t.default_comb.iter().cloned());
+    }
     // Per-thread state-guarded comb assigns
     merged_comb.extend(all_thread_comb);
     if !merged_comb.is_empty() {
@@ -2813,6 +2838,66 @@ fn build_module_reg_map(m: &ModuleDecl) -> HashMap<String, RegDecl> {
 }
 
 // ── Signal analysis ─────────────────────────────────────────────────────────
+
+fn collect_comb_stmt_signals(stmts: &[Stmt]) -> (HashSet<String>, HashSet<String>) {
+    let mut comb_driven = HashSet::new();
+    let mut all_read = HashSet::new();
+
+    fn walk(stmts: &[Stmt], comb_driven: &mut HashSet<String>, all_read: &mut HashSet<String>) {
+        for stmt in stmts {
+            match stmt {
+                Stmt::Assign(a) => {
+                    if let Some(name) = expr_root_name(&a.target) {
+                        comb_driven.insert(name);
+                    }
+                    collect_expr_reads(&a.value, all_read);
+                    collect_expr_index_reads(&a.target, all_read);
+                }
+                Stmt::IfElse(ie) => {
+                    collect_expr_reads(&ie.cond, all_read);
+                    walk(&ie.then_stmts, comb_driven, all_read);
+                    walk(&ie.else_stmts, comb_driven, all_read);
+                }
+                Stmt::Match(m) => {
+                    collect_expr_reads(&m.scrutinee, all_read);
+                    for arm in &m.arms {
+                        walk(&arm.body, comb_driven, all_read);
+                    }
+                }
+                Stmt::Log(l) => {
+                    for arg in &l.args {
+                        collect_expr_reads(arg, all_read);
+                    }
+                }
+                Stmt::For(f) => {
+                    match &f.range {
+                        ForRange::Range(start, end) => {
+                            collect_expr_reads(start, all_read);
+                            collect_expr_reads(end, all_read);
+                        }
+                        ForRange::ValueList(values) => {
+                            for value in values {
+                                collect_expr_reads(value, all_read);
+                            }
+                        }
+                    }
+                    walk(&f.body, comb_driven, all_read);
+                }
+                Stmt::Init(ib) => {
+                    walk(&ib.body, comb_driven, all_read);
+                }
+                Stmt::WaitUntil(expr, _) => collect_expr_reads(expr, all_read),
+                Stmt::DoUntil { body, cond, .. } => {
+                    walk(body, comb_driven, all_read);
+                    collect_expr_reads(cond, all_read);
+                }
+            }
+        }
+    }
+
+    walk(stmts, &mut comb_driven, &mut all_read);
+    (comb_driven, all_read)
+}
 
 fn collect_thread_signals(body: &[ThreadStmt]) -> (HashSet<String>, HashSet<String>, HashSet<String>) {
     let mut comb_driven = HashSet::new();
@@ -5627,7 +5712,7 @@ fn direct_tlm_threads(
     port_buses: &std::collections::HashMap<String, String>,
     bus_methods: &std::collections::HashMap<String, Vec<TlmMethodMeta>>,
 ) -> Vec<DirectTlmThread> {
-    if t.default_when.is_some() || t.once || t.body.len() != 1 {
+    if t.default_when.is_some() || !t.default_comb.is_empty() || t.once || t.body.len() != 1 {
         return Vec::new();
     }
     match &t.body[0] {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1579,24 +1579,56 @@ impl Parser {
             None
         };
 
-        // Optional `default when <cond> ... end default` — must come first in the body.
-        let default_when = if self.check(TokenKind::Default) {
-            let _kw = self.advance(); // consume `default`
-            self.expect(TokenKind::When)?;
-            let cond = self.parse_expr()?;
-            let mut dw_stmts = Vec::new();
-            while !(self.pos + 1 < self.tokens.len()
-                && self.tokens[self.pos].kind == TokenKind::End
-                && self.tokens[self.pos + 1].kind == TokenKind::Default)
-            {
-                dw_stmts.push(self.parse_thread_stmt()?);
+        // Optional leading default clauses. `default when` is the thread's
+        // soft-reset escape; `default comb` is an unconditional comb prelude
+        // applied in every lowered state before state-specific comb assigns.
+        let mut default_when = None;
+        let mut default_comb = Vec::new();
+        while self.check(TokenKind::Default) {
+            let default_span = self.advance().span;
+            if self.check(TokenKind::When) {
+                if default_when.is_some() {
+                    return Err(CompileError::general(
+                        "thread may contain at most one `default when` clause",
+                        default_span,
+                    ));
+                }
+                self.advance(); // consume `when`
+                let cond = self.parse_expr()?;
+                let mut dw_stmts = Vec::new();
+                while !(self.pos + 1 < self.tokens.len()
+                    && self.tokens[self.pos].kind == TokenKind::End
+                    && self.tokens[self.pos + 1].kind == TokenKind::Default)
+                {
+                    dw_stmts.push(self.parse_thread_stmt()?);
+                }
+                self.expect(TokenKind::End)?;
+                self.expect(TokenKind::Default)?;
+                default_when = Some((cond, dw_stmts));
+            } else if self.check(TokenKind::Comb) {
+                if !default_comb.is_empty() {
+                    return Err(CompileError::general(
+                        "thread may contain at most one `default comb` clause",
+                        default_span,
+                    ));
+                }
+                self.advance(); // consume `comb`
+                while !(self.pos + 1 < self.tokens.len()
+                    && self.tokens[self.pos].kind == TokenKind::End
+                    && self.tokens[self.pos + 1].kind == TokenKind::Default)
+                {
+                    default_comb.push(self.parse_comb_stmt()?);
+                }
+                self.expect(TokenKind::End)?;
+                self.expect(TokenKind::Default)?;
+            } else {
+                return Err(CompileError::unexpected_token(
+                    "`when` or `comb` after thread `default`",
+                    &self.peek_kind().map(|k| k.to_string()).unwrap_or("EOF".into()),
+                    self.peek_span(),
+                ));
             }
-            self.expect(TokenKind::End)?;
-            self.expect(TokenKind::Default)?;
-            Some((cond, dw_stmts))
-        } else {
-            None
-        };
+        }
 
         // Body
         let mut body = Vec::new();
@@ -1647,6 +1679,7 @@ impl Parser {
             reset_level,
             once,
             default_when,
+            default_comb,
             tlm_target,
             reentrant,
             implement,

--- a/tests/axi_dma_thread/ThreadMm2s.arch
+++ b/tests/axi_dma_thread/ThreadMm2s.arch
@@ -102,6 +102,14 @@ module ThreadMm2s
       xfer_ctr_r     <= 0;
       next_ar_addr_r <= base_addr;
     end default
+    default comb
+      ar_valid = false;
+      ar_addr  = 32'h0000_0000;
+      ar_id    = 2'd0;
+      ar_len   = 8'd0;
+      ar_size  = 3'd0;
+      ar_burst = 2'd0;
+    end default
     wait until active and xfer_ctr_r < total_xfers_r;
     do
       ar_valid = 1;
@@ -132,6 +140,10 @@ module ThreadMm2s
 
       default when start and not active_r
         thread_complete[i] <= 0;
+      end default
+      default comb
+        r_ready    = false;
+        push_valid = false;
       end default
       wait until active and ((thread_complete[i] << 2) + i < xfer_ctr_r);
       for b in 0..burst_len_r-1

--- a/tests/axi_dma_thread/ThreadMm2s.sv
+++ b/tests/axi_dma_thread/ThreadMm2s.sv
@@ -1,15 +1,29 @@
-// Thread-based multi-outstanding MM2S read engine.
-//
-// Architecture: single ArIssuer thread + 4 RCollect threads.
-//   - ArIssuer: single state machine drives all AR outputs — no 4-way mux needed.
-//     Address maintained in next_ar_addr_r (increment-only, no multiply).
-//   - RCollect_i: each thread collects R beats for its assigned ID.
-//     Only drives 1-bit r_ready/push_valid — narrow mux overhead.
-//   - push_data = r_data unconditionally (all threads push same source).
-//
-// Work assignment: xfer k → AR ID k%4, handled by RCollect_{k%4}.
-// Done when sum of thread_complete[i] == total_xfers.
-module _ThreadMm2s_threads (
+//! ---
+//! spec_md: doc/axi_dma_case_study.md
+//! tags: [dma, axi4, mm2s, multi_outstanding, thread]
+//! refs:
+//!   - "AXI4 spec ARM IHI 0022, §A3 Single Interface Requirements"
+//!   - "Xilinx PG021 (LogiCORE IP AXI DMA) — MM2S read path"
+//! ---
+//!
+//! Multi-outstanding AXI4 MM2S (read) engine — issues up to NUM_OUTSTANDING
+//! parallel AR transactions and collects R beats per AXI ID, pushing data to
+//! a downstream FIFO. The thread-based decomposition replaces what would be
+//! a 4-state hand-written FSM in the FsmMm2sMulti.arch baseline.
+/// Multi-outstanding AXI4 MM2S read engine.
+///
+/// Architecture: a single `ArIssuer` thread owns the AR channel and a
+/// `generate_for` block spawns NUM_OUTSTANDING `RCollect_i` threads, one
+/// per AXI ID. The single-issuer + per-ID-collector split is the central
+/// design choice — see the inner doc on `ArIssuer` and on the `RCollect_i`
+/// generate for the rationale.
+///
+/// Work assignment: transfer `k` is issued with `ar_id = k % NUM_OUTSTANDING`
+/// and collected by `RCollect_{k % NUM_OUTSTANDING}`. The engine is "done"
+/// when `Σ thread_complete[i] == total_xfers`.
+module _ThreadMm2s_threads #(
+  parameter int NUM_OUTSTANDING = 4
+) (
   input logic clk,
   input logic rst,
   input logic active,
@@ -37,6 +51,15 @@ module _ThreadMm2s_threads (
   output logic [15:0] xfer_ctr_r
 );
 
+  logic [0:0] _t0_state = 0;
+  logic [0:0] _t1_state = 0;
+  logic [0:0] _t2_state = 0;
+  logic [0:0] _t3_state = 0;
+  logic [0:0] _t4_state = 0;
+  logic [7:0] _t1_loop_cnt = 0;
+  logic [7:0] _t2_loop_cnt = 0;
+  logic [7:0] _t3_loop_cnt = 0;
+  logic [7:0] _t4_loop_cnt = 0;
   always_comb begin
     ar_addr = 0;
     ar_burst = 0;
@@ -46,13 +69,44 @@ module _ThreadMm2s_threads (
     ar_valid = 0;
     push_valid = 0;
     r_ready = 0;
+    // Control latches — owned by ArIssuer (reset via default when)
+    // AR issuer state: xfer_ctr_r counts issued ARs; next_ar_addr_r is current address.
+    // Per-thread completion counts — each owned exclusively by RCollect_i
+    // Completion handler — clears active when all responses received
+    // ── AR issuer ─────────────────────────────────────────────────────────────
+    //! Single thread drives all AR outputs — no resource lock, no 4-way
+    //! mux. Address is maintained in `next_ar_addr_r` (increment-only, no
+    //! multiply); ID rotates via `xfer_ctr_r[1:0]` so transfer `k` lands
+    //! on AXI ID `k % 4`. The `default when start and not active_r` clause
+    //! is the soft-reset arm — kicks off a new run synchronously without
+    //! a separate idle state.
+    ar_valid = 1'b0;
+    ar_addr = 32'd0;
+    ar_id = 2'd0;
+    ar_len = 8'd0;
+    ar_size = 3'd0;
+    ar_burst = 2'd0;
+    // ── R collectors ─────────────────────────────────────────────────────────
+    //! Per-ID R-channel collector. Only drives 1-bit `r_ready` and
+    //! `push_valid` (both `shared(or)` — collector `i` asserts only
+    //! when `r_id == i`), so the OR-reduction in the merged comb block
+    //! is a narrow mux. `push_data = r_data` unconditionally (all
+    //! collectors source the same wire), which is why `push_data` is
+    //! NOT `shared(or)` — see the comb block above for the
+    //! unconditional drive.
+    //!
+    //! Backpressure: each collector waits for its `(thread_complete[i]
+    //! << 2) + i < xfer_ctr_r` window to open before consuming a beat.
+    //! This couples to the issuer's round-robin ID rotation.
+    r_ready = 1'b0;
+    push_valid = 1'b0;
+    r_ready = 1'b0;
+    push_valid = 1'b0;
+    r_ready = 1'b0;
+    push_valid = 1'b0;
+    r_ready = 1'b0;
+    push_valid = 1'b0;
     if (_t0_state == 1) begin
-      // Control latches — owned by ArIssuer (reset via default when)
-      // AR issuer state: xfer_ctr_r counts issued ARs; next_ar_addr_r is current address.
-      // Per-thread completion counts — each owned exclusively by RCollect_i
-      // Completion handler — clears active when all responses received
-      // ── AR issuer ─────────────────────────────────────────────────────────────
-      // Single thread drives all AR outputs — no resource lock, no 4-way mux.
       ar_valid = 1;
       ar_addr = next_ar_addr_r;
       ar_id = xfer_ctr_r[1:0];
@@ -61,7 +115,6 @@ module _ThreadMm2s_threads (
       ar_burst = 2'd1;
     end
     if (_t1_state == 1) begin
-      // ── R collectors ─────────────────────────────────────────────────────────
       r_ready = r_ready | 1;
       push_valid = push_valid | (r_valid && r_id == 0);
     end
@@ -78,11 +131,6 @@ module _ThreadMm2s_threads (
       push_valid = push_valid | (r_valid && r_id == 3);
     end
   end
-  logic [0:0] _t0_state = 0;
-  logic [0:0] _t1_state = 0;
-  logic [0:0] _t2_state = 0;
-  logic [0:0] _t3_state = 0;
-  logic [0:0] _t4_state = 0;
   always_ff @(posedge clk) begin
     if (rst) begin
       _t0_state <= 0;
@@ -129,15 +177,11 @@ module _ThreadMm2s_threads (
         _t1_state <= 0;
       end else begin
         if (_t1_state == 0) begin
-          _t1_loop_cnt <= 0;
           if (active && (thread_complete[0] << 2) + 0 < xfer_ctr_r) begin
             _t1_state <= 1;
           end
         end
         if (_t1_state == 1) begin
-          if (r_valid && r_id == 0 && push_ready) begin
-            _t1_loop_cnt <= 8'(_t1_loop_cnt + 8'd1);
-          end
           if (r_valid && r_id == 0 && push_ready && _t1_loop_cnt >= 8'(burst_len_r - 1)) begin
             thread_complete[0] <= 16'(thread_complete[0] + 1);
           end
@@ -154,15 +198,11 @@ module _ThreadMm2s_threads (
         _t2_state <= 0;
       end else begin
         if (_t2_state == 0) begin
-          _t2_loop_cnt <= 0;
           if (active && (thread_complete[1] << 2) + 1 < xfer_ctr_r) begin
             _t2_state <= 1;
           end
         end
         if (_t2_state == 1) begin
-          if (r_valid && r_id == 1 && push_ready) begin
-            _t2_loop_cnt <= 8'(_t2_loop_cnt + 8'd1);
-          end
           if (r_valid && r_id == 1 && push_ready && _t2_loop_cnt >= 8'(burst_len_r - 1)) begin
             thread_complete[1] <= 16'(thread_complete[1] + 1);
           end
@@ -179,15 +219,11 @@ module _ThreadMm2s_threads (
         _t3_state <= 0;
       end else begin
         if (_t3_state == 0) begin
-          _t3_loop_cnt <= 0;
           if (active && (thread_complete[2] << 2) + 2 < xfer_ctr_r) begin
             _t3_state <= 1;
           end
         end
         if (_t3_state == 1) begin
-          if (r_valid && r_id == 2 && push_ready) begin
-            _t3_loop_cnt <= 8'(_t3_loop_cnt + 8'd1);
-          end
           if (r_valid && r_id == 2 && push_ready && _t3_loop_cnt >= 8'(burst_len_r - 1)) begin
             thread_complete[2] <= 16'(thread_complete[2] + 1);
           end
@@ -204,15 +240,11 @@ module _ThreadMm2s_threads (
         _t4_state <= 0;
       end else begin
         if (_t4_state == 0) begin
-          _t4_loop_cnt <= 0;
           if (active && (thread_complete[3] << 2) + 3 < xfer_ctr_r) begin
             _t4_state <= 1;
           end
         end
         if (_t4_state == 1) begin
-          if (r_valid && r_id == 3 && push_ready) begin
-            _t4_loop_cnt <= 8'(_t4_loop_cnt + 8'd1);
-          end
           if (r_valid && r_id == 3 && push_ready && _t4_loop_cnt >= 8'(burst_len_r - 1)) begin
             thread_complete[3] <= 16'(thread_complete[3] + 1);
           end
@@ -226,10 +258,52 @@ module _ThreadMm2s_threads (
       end
     end
   end
-  logic [7:0] _t1_loop_cnt = 0;
-  logic [7:0] _t2_loop_cnt = 0;
-  logic [7:0] _t3_loop_cnt = 0;
-  logic [7:0] _t4_loop_cnt = 0;
+  always_ff @(posedge clk) begin
+    if (start && !active_r) begin
+    end else begin
+      if (_t1_state == 0) begin
+        _t1_loop_cnt <= 0;
+      end
+      if (_t1_state == 1) begin
+        if (r_valid && r_id == 0 && push_ready) begin
+          _t1_loop_cnt <= 8'(_t1_loop_cnt + 8'd1);
+        end
+      end
+    end
+    if (start && !active_r) begin
+    end else begin
+      if (_t2_state == 0) begin
+        _t2_loop_cnt <= 0;
+      end
+      if (_t2_state == 1) begin
+        if (r_valid && r_id == 1 && push_ready) begin
+          _t2_loop_cnt <= 8'(_t2_loop_cnt + 8'd1);
+        end
+      end
+    end
+    if (start && !active_r) begin
+    end else begin
+      if (_t3_state == 0) begin
+        _t3_loop_cnt <= 0;
+      end
+      if (_t3_state == 1) begin
+        if (r_valid && r_id == 2 && push_ready) begin
+          _t3_loop_cnt <= 8'(_t3_loop_cnt + 8'd1);
+        end
+      end
+    end
+    if (start && !active_r) begin
+    end else begin
+      if (_t4_state == 0) begin
+        _t4_loop_cnt <= 0;
+      end
+      if (_t4_state == 1) begin
+        if (r_valid && r_id == 3 && push_ready) begin
+          _t4_loop_cnt <= 8'(_t4_loop_cnt + 8'd1);
+        end
+      end
+    end
+  end
 
 endmodule
 
@@ -263,10 +337,10 @@ module ThreadMm2s #(
 );
 
   logic [15:0] total_complete;
-  assign total_complete = 16'(16'(16'(thread_complete[0] + thread_complete[1]) + thread_complete[2]) + thread_complete[3]);
   logic all_done;
-  assign all_done = active_r && total_xfers_r != 0 && total_complete == total_xfers_r;
   logic active;
+  assign total_complete = 16'((16'((16'(thread_complete[0] + thread_complete[1])) + thread_complete[2])) + thread_complete[3]);
+  assign all_done = active_r && total_xfers_r != 0 && total_complete == total_xfers_r;
   assign active = active_r || start && !active_r;
   assign halted = 1'b0;
   assign idle_out = !active;

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -7883,6 +7883,79 @@ fn test_thread_wait_elsif_chain_fuses_to_single_dispatch() {
 }
 
 #[test]
+fn test_thread_default_comb_applies_before_state_comb_and_collects_reads() {
+    let source = r#"
+        module M
+          port clk:     in Clock<SysDomain>;
+          port rst:     in Reset<Async, Low>;
+          port start:   in Bool;
+          port ready:   in Bool;
+          port done_i:  in Bool;
+          port kill:    in Bool;
+          port payload: in UInt<8>;
+          port valid:   out Bool;
+          port data:    out UInt<8>;
+          port reg phase: out UInt<4> reset rst => 4'd0;
+
+          thread on clk rising, rst low
+            default comb
+              valid = false;
+              data = payload;
+            end default
+            default when kill
+              phase <= 4'd0;
+            end default
+
+            wait until start;
+            phase <= 4'd1;
+            wait until ready;
+            valid = true;
+            data = 8'hff;
+            wait until done_i;
+          end thread
+        end module M
+    "#;
+    let sv = compile_to_sv(source);
+    assert!(sv.contains("input logic [7:0] payload"),
+        "`default comb` RHS-only signal must be wired into the lowered thread module:\n{sv}");
+    let default_pos = sv.find("data = payload;")
+        .expect("expected unconditional default data assignment");
+    let state_pos = sv.find("if (_t0_state")
+        .expect("expected state-guarded comb assignments");
+    assert!(default_pos < state_pos,
+        "`default comb` assignments must precede state-specific comb assignments:\n{sv}");
+    assert!(sv.contains("data = 8'd255;"),
+        "state-specific comb assignment should still override the default later in the block:\n{sv}");
+}
+
+#[test]
+fn test_thread_default_comb_rejects_seq_driven_target() {
+    let source = r#"
+        module M
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Async, Low>;
+          port reg done: out Bool reset rst => false;
+
+          thread on clk rising, rst low
+            default comb
+              done = false;
+            end default
+            done <= true;
+            wait 1 cycle;
+          end thread
+        end module M
+    "#;
+    let tokens = lexer::tokenize(source).expect("lexer error");
+    let mut parser = Parser::new(tokens, source);
+    let parsed_ast = parser.parse_source_file().expect("parse error");
+    let ast = elaborate::elaborate(parsed_ast).expect("elaborate error");
+    let err = elaborate::lower_threads(ast).expect_err("default comb must not drive seq target");
+    let msg = format!("{err:?}");
+    assert!(msg.contains("default comb") && msg.contains("done") && msg.contains("<="),
+        "expected targeted diagnostic for default-comb/seq-driver conflict, got: {msg}");
+}
+
+#[test]
 fn test_if_wait_with_auto_asserts() {
     // Verify --auto-thread-asserts still emits a coherent set of properties
     // when the thread contains a wait-bearing if/else. The dispatch state's


### PR DESCRIPTION
## Summary

Adds `default comb ... end default` support for `thread` blocks so thread-owned combinational defaults can be written once and emitted before state-specific comb actions.

This PR updates the AST, parser, elaboration/lowering, diagnostics, docs, and tests. It also rewrites the `ThreadMm2s` example to use `default comb` for AR-channel and R-collector protocol defaults, with regenerated SystemVerilog.

## Validation

- `cargo build`
- `cargo test test_thread_default_comb -- --nocapture`
- `target/debug/arch sim tests/axi_dma_thread/ThreadMm2s.arch --tb tests/axi_dma_thread/tb_mm2s_thread.cpp -o /tmp/archsim_threadmm2s_pr`
- `verilator -Wall -Wno-fatal --cc --exe --build tests/axi_dma_thread/ThreadMm2s.sv tests/axi_dma_thread/tb_mm2s_thread.cpp --top-module ThreadMm2s -Mdir /tmp/vlt_threadmm2s_pr && /tmp/vlt_threadmm2s_pr/VThreadMm2s`

Notes: Verilator emits existing DECLFILENAME/UNUSED warnings for the generated DMA example; the simulation passes.
