### PR TITLE
typecheck: whole-design combinational feedback-loop analysis (#246 MVP)

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -208,6 +208,12 @@ pub struct ModuleDecl {
     /// disables phase 1's structural cross-clock async-reset rule
     /// (which sits at the CDC/RDC boundary).
     pub rdc_safe: bool,
+    /// `pragma comb_loops_allowed;` — suppress whole-design combinational
+    /// feedback-cycle warnings emitted by the cross-instance comb-graph
+    /// analyzer (issue #246). When set, any SCC that passes through an
+    /// instance OWNED by this module (i.e. this module is the parent that
+    /// declares the inst) is treated as blessed and suppressed.
+    pub comb_loops_allowed: bool,
     pub span: Span,
     /// Outer doc comment from `///` lines preceding the `module` keyword.
     /// See `doc/plan_arch_doc_comments.md`.

--- a/src/comb_graph.rs
+++ b/src/comb_graph.rs
@@ -501,3 +501,556 @@ pub fn analyze_module(
     Ok(ModuleAnalysis { sorted_inst_indices: sorted, settle_depth })
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Whole-design comb-loop analysis (issue #246, MVP)
+//
+// Builds ONE directed combinational-dependency graph that spans the entire
+// elaborated design starting from each top-level module (modules that are
+// never instantiated anywhere). Nodes are keyed by `(inst_path, signal)` so
+// signals at different hierarchy levels are distinct.
+//
+// Tarjan's SCC is then run over the graph and any SCC with size > 1 (or a
+// single-node SCC with a self-loop) is reported as a combinational feedback
+// cycle. SCCs that pass through any instance OWNED by a module with
+// `pragma comb_loops_allowed;` are suppressed.
+//
+// Limitations of this MVP (deferred to a follow-up PR):
+//   - Extern / interface-only modules (`.archi` stubs) are treated as
+//     opaque: every output is assumed to depend on every input. This is the
+//     safe over-approximation and may produce spurious cycle reports when
+//     the SV-side body is actually pipelined.
+//   - Module-level CombInfo is the existing port-set over-approximation
+//     (any comb-driven output is assumed to depend on every comb-read
+//     input). Per-output dep precision is left to a follow-up.
+//   - Per-signal-pair blessing (e.g. `pragma comb_loop a, b;`) is not
+//     supported; only the module-level pragma is.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Path through the instance hierarchy from a top-level module to a
+/// particular instance. Empty vec = top-level module itself.
+pub type InstPath = Vec<String>;
+
+/// Identifier for a node in the whole-design comb graph:
+///   - `path`: instance path (parent inst names, from top-level)
+///   - `signal`: signal name at the given level (port / wire / let / inst-output)
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct NodeKey {
+    pub path: InstPath,
+    pub signal: String,
+}
+
+impl NodeKey {
+    pub fn display(&self) -> String {
+        if self.path.is_empty() {
+            self.signal.clone()
+        } else {
+            format!("{}.{}", self.path.join("."), self.signal)
+        }
+    }
+}
+
+/// One combinational SCC found in the whole-design graph.
+pub struct CombScc {
+    /// Nodes in the SCC (declaration / discovery order — Tarjan emits them
+    /// in reverse-finish order which is fine for diagnostic display).
+    pub nodes: Vec<NodeKey>,
+    /// Owning-parent inst paths (i.e. each unique `path` of nodes in the
+    /// SCC). Used by the suppression rule: if any owning-parent module has
+    /// `pragma comb_loops_allowed;`, the SCC is suppressed.
+    pub owning_paths: HashSet<InstPath>,
+    /// Owning module name per `owning_path` — populated during graph build
+    /// so the pragma lookup doesn't have to re-walk the hierarchy. The
+    /// path with `vec![]` maps to the top-level module name.
+    pub owning_modules: HashSet<String>,
+}
+
+/// Result of running whole-design comb-loop analysis on a source file.
+pub struct WholeDesignAnalysis {
+    pub sccs: Vec<CombScc>,
+    /// Number of SCCs after running Tarjan (size > 1, OR size==1-with-self-loop).
+    pub total_sccs: usize,
+    /// Number of SCCs suppressed by `pragma comb_loops_allowed;` on at
+    /// least one owning module.
+    pub suppressed: usize,
+}
+
+/// Run whole-design comb-loop analysis.
+///
+/// 1. Identify top-level modules (modules not instantiated anywhere).
+/// 2. For each top-level, recursively flatten the instance hierarchy into
+///    a directed node-and-edge set, where each node is `(inst_path, signal)`.
+/// 3. Run Tarjan's SCC.
+/// 4. Tag each non-trivial SCC with the set of owning-parent paths;
+///    classify as suppressed if any owning module has the pragma.
+pub fn analyze_whole_design(
+    source: &SourceFile,
+    symbols: &SymbolTable,
+) -> WholeDesignAnalysis {
+    // ── Step 1: collect inst counts to find top-level modules ─────────────
+    let mut inst_count: HashMap<String, usize> = HashMap::new();
+    let mut module_by_name: HashMap<&str, &ModuleDecl> = HashMap::new();
+    for item in &source.items {
+        if let Item::Module(m) = item {
+            module_by_name.insert(m.name.name.as_str(), m);
+            // Pre-seed so "never instantiated" still appears
+            inst_count.entry(m.name.name.clone()).or_insert(0);
+        }
+    }
+    for item in &source.items {
+        if let Item::Module(m) = item {
+            for sub in collect_insts(m) {
+                *inst_count.entry(sub.module_name.name.clone()).or_insert(0) += 1;
+            }
+        }
+    }
+
+    let top_levels: Vec<&ModuleDecl> = module_by_name
+        .iter()
+        .filter(|(name, _)| inst_count.get(**name).copied().unwrap_or(0) == 0)
+        .map(|(_, m)| *m)
+        .collect();
+
+    // ── Step 2: build the flat graph ──────────────────────────────────────
+    let mut builder = GraphBuilder::default();
+    for top in &top_levels {
+        builder.expand_module(top, vec![], symbols, source);
+    }
+
+    // ── Step 3: Tarjan SCC ────────────────────────────────────────────────
+    let sccs_raw = tarjan_scc(&builder.adj, builder.next_id);
+
+    // ── Step 4: classify SCCs ─────────────────────────────────────────────
+    let mut out_sccs: Vec<CombScc> = Vec::new();
+    let mut suppressed = 0usize;
+    let mut total = 0usize;
+    for scc in sccs_raw {
+        // Filter: size > 1 OR (size == 1 with self-loop)
+        let is_cycle = scc.len() > 1
+            || (scc.len() == 1 && builder.adj[scc[0]].contains(&scc[0]));
+        if !is_cycle {
+            continue;
+        }
+        total += 1;
+
+        let mut owning_paths: HashSet<InstPath> = HashSet::new();
+        let mut owning_modules: HashSet<String> = HashSet::new();
+        let mut nodes: Vec<NodeKey> = Vec::with_capacity(scc.len());
+        for nid in &scc {
+            let key = builder.node_by_id[*nid].clone();
+            owning_paths.insert(key.path.clone());
+            if let Some(mname) = builder.owning_module(&key.path) {
+                owning_modules.insert(mname);
+            }
+            nodes.push(key);
+        }
+        // Suppression: any owning module has `pragma comb_loops_allowed;`.
+        let blessed = owning_modules
+            .iter()
+            .any(|mn| module_by_name.get(mn.as_str())
+                .map(|m| m.comb_loops_allowed)
+                .unwrap_or(false));
+        if blessed {
+            suppressed += 1;
+            continue;
+        }
+        out_sccs.push(CombScc { nodes, owning_paths, owning_modules });
+    }
+
+    WholeDesignAnalysis {
+        sccs: out_sccs,
+        total_sccs: total,
+        suppressed,
+    }
+}
+
+// ── GraphBuilder ─────────────────────────────────────────────────────────────
+
+#[derive(Default)]
+struct GraphBuilder {
+    node_id: HashMap<NodeKey, usize>,
+    node_by_id: Vec<NodeKey>,
+    adj: Vec<Vec<usize>>,
+    next_id: usize,
+    /// path → owning module name. `vec![]` is special-cased per top entry.
+    path_owner: HashMap<InstPath, String>,
+}
+
+impl GraphBuilder {
+    fn intern(&mut self, key: NodeKey) -> usize {
+        if let Some(id) = self.node_id.get(&key) {
+            return *id;
+        }
+        let id = self.next_id;
+        self.next_id += 1;
+        self.node_id.insert(key.clone(), id);
+        self.node_by_id.push(key);
+        self.adj.push(Vec::new());
+        id
+    }
+
+    fn add_edge(&mut self, from: usize, to: usize) {
+        // Tarjan tolerates parallel edges, but dedupe for cleaner display.
+        if !self.adj[from].contains(&to) {
+            self.adj[from].push(to);
+        }
+    }
+
+    fn owning_module(&self, path: &InstPath) -> Option<String> {
+        self.path_owner.get(path).cloned()
+    }
+
+    /// Recursively build the graph for `m` at the given instance path.
+    fn expand_module(
+        &mut self,
+        m: &ModuleDecl,
+        path: InstPath,
+        symbols: &SymbolTable,
+        source: &SourceFile,
+    ) {
+        self.path_owner.insert(path.clone(), m.name.name.clone());
+
+        // Helper to make a node at the current path.
+        let mk = |gb: &mut GraphBuilder, name: &str| -> usize {
+            gb.intern(NodeKey { path: path.clone(), signal: name.to_string() })
+        };
+
+        // Ensure all port/wire/let/reg/inst-output names exist as nodes.
+        // We don't strictly need to pre-intern, but having them helps when
+        // a wire is read but never written (still appears as an isolated
+        // node — harmless for SCC).
+        for p in &m.ports {
+            // Skip clock/reset — they participate only in seq logic.
+            if is_clk_or_rst(&p.ty) { continue; }
+            mk(self, &p.name.name);
+        }
+
+        // 1) Parent-level comb blocks + let bindings + wire decls
+        let (input_names, output_names) = port_sets(&m.ports);
+        for item in &m.body {
+            match item {
+                ModuleBodyItem::WireDecl(w) => { mk(self, &w.name.name); }
+                ModuleBodyItem::RegDecl(_) => {
+                    // Regs are seq-driven; skip — they break comb cycles.
+                }
+                ModuleBodyItem::PipeRegDecl(_) => {
+                    // pipe_reg outputs are registered.
+                }
+                ModuleBodyItem::CombBlock(cb) => {
+                    self.scan_assignments(&cb.stmts, &path, &input_names, &output_names);
+                }
+                ModuleBodyItem::LetBinding(lb) => {
+                    // Edge: each RHS ident → lb.name
+                    let lhs = mk(self, &lb.name.name);
+                    let mut ids = HashSet::new();
+                    collect_expr_idents(&lb.value, &mut ids);
+                    for id in &ids {
+                        let from = mk(self, id);
+                        self.add_edge(from, lhs);
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        // 2) Sub-instances
+        for inst in collect_insts(m) {
+            self.expand_inst(inst, &path, symbols, source);
+        }
+    }
+
+    /// Add edges and recurse for one sub-instance.
+    fn expand_inst(
+        &mut self,
+        inst: &InstDecl,
+        parent_path: &InstPath,
+        symbols: &SymbolTable,
+        source: &SourceFile,
+    ) {
+        let child_path = {
+            let mut p = parent_path.clone();
+            p.push(inst.name.name.clone());
+            p
+        };
+
+        // Look up the child module (if any) and its CombInfo.
+        let child_mod: Option<&ModuleDecl> = source.items.iter().find_map(|it| {
+            if let Item::Module(cm) = it {
+                if cm.name.name == inst.module_name.name {
+                    return Some(cm);
+                }
+            }
+            None
+        });
+
+        // CombInfo for the sub-instance's construct (any kind).
+        let info = comb_info_for_symbol(&inst.module_name.name, symbols, source);
+
+        // Map each connection's port-name → parent signal name (if a bare ident).
+        // Direction is "from the parent's perspective" via ConnectDir.
+        let mut input_conn: HashMap<String, String> = HashMap::new();  // port → parent signal (signal feeds INTO inst)
+        let mut output_conn: HashMap<String, String> = HashMap::new(); // port → parent signal (inst drives this signal)
+        for conn in &inst.connections {
+            let parent_sig = match &conn.signal.kind {
+                ExprKind::Ident(n) => n.clone(),
+                _ => continue, // complex connection expression — skip
+            };
+            match conn.direction {
+                ConnectDir::Input  => { input_conn.insert(conn.port_name.name.clone(), parent_sig); }
+                ConnectDir::Output => { output_conn.insert(conn.port_name.name.clone(), parent_sig); }
+            }
+        }
+
+        // Recurse into the child if it is a regular module.
+        // Interface-only / opaque modules are treated as fully cross-connected
+        // (any output depends on any input) — that's already the shape of
+        // `comb_info_for_module` over interface stubs (empty body → empty
+        // CombInfo), so we explicitly OVERRIDE here to the conservative
+        // every-out-depends-on-every-in interpretation when the module is
+        // an interface stub OR is missing entirely (extern).
+        let treat_as_opaque = match child_mod {
+            None => true,
+            Some(cm) => cm.is_interface,
+        };
+
+        if let Some(cm) = child_mod {
+            if !treat_as_opaque {
+                self.expand_module(cm, child_path.clone(), symbols, source);
+            }
+        }
+
+        // Add cross-boundary edges from sub-inst's CombInfo to parent signals.
+        //
+        // For each comb output port `q` connected to parent signal `out_sig`:
+        //   For each comb input port `p` connected to parent signal `in_sig`:
+        //     If `q` depends on `p` (in the child's CombInfo) → add edge in_sig → out_sig.
+        //
+        // For the MVP we use the existing CombInfo over-approximation: any
+        // output port in `comb_outputs` is assumed to depend on every input
+        // in `comb_dep_inputs`.
+        let comb_outs: Vec<&String> = if treat_as_opaque {
+            // Opaque: every declared output port that's connected.
+            output_conn.keys().collect()
+        } else {
+            info.comb_outputs.iter().collect()
+        };
+        let comb_ins: Vec<&String> = if treat_as_opaque {
+            input_conn.keys().collect()
+        } else {
+            info.comb_dep_inputs.iter().collect()
+        };
+
+        for out_port in &comb_outs {
+            let out_sig = match output_conn.get(out_port.as_str()) {
+                Some(s) => s.clone(),
+                None => continue,
+            };
+            // Parent-side node receiving the inst's output.
+            let to = self.intern(NodeKey { path: parent_path.clone(), signal: out_sig });
+
+            // Also: if we DID recurse, link the deeper inst-internal output port
+            // node to the parent-side wire so cycles that close via the
+            // hierarchy show the full path. We add edge child.q → parent.out_sig.
+            if !treat_as_opaque {
+                let child_q = self.intern(NodeKey { path: child_path.clone(), signal: (*out_port).clone() });
+                self.add_edge(child_q, to);
+            }
+
+            for in_port in &comb_ins {
+                let in_sig = match input_conn.get(in_port.as_str()) {
+                    Some(s) => s.clone(),
+                    None => continue,
+                };
+                let from = self.intern(NodeKey { path: parent_path.clone(), signal: in_sig });
+
+                // Direct over-approximation edge in_sig → out_sig at parent level.
+                // (Captures the loop even when we don't recurse into the child.)
+                self.add_edge(from, to);
+
+                // And, if we recursed, also link parent.in_sig → child.in_port
+                // so the cycle path display shows the descent.
+                if !treat_as_opaque {
+                    let child_p = self.intern(NodeKey { path: child_path.clone(), signal: (*in_port).clone() });
+                    self.add_edge(from, child_p);
+                }
+            }
+        }
+    }
+
+    /// Walk a comb-block's statements and add edges from RHS identifiers to
+    /// LHS base names. Conditions count as reads of every then/else target.
+    fn scan_assignments(
+        &mut self,
+        stmts: &[Stmt],
+        path: &InstPath,
+        _input_names: &HashSet<String>,
+        _output_names: &HashSet<String>,
+    ) {
+        let mut cond_stack: Vec<HashSet<String>> = Vec::new();
+        self.scan_assignments_inner(stmts, path, &mut cond_stack);
+    }
+
+    fn scan_assignments_inner(
+        &mut self,
+        stmts: &[Stmt],
+        path: &InstPath,
+        cond_stack: &mut Vec<HashSet<String>>,
+    ) {
+        for stmt in stmts {
+            match stmt {
+                Stmt::Assign(a) => {
+                    let lhs = match lhs_base_name(&a.target) {
+                        Some(n) => n,
+                        None => continue,
+                    };
+                    let mut rhs = HashSet::new();
+                    collect_expr_idents(&a.value, &mut rhs);
+                    // RHS for index/bit-slice on LHS also contributes to deps.
+                    collect_lhs_index_reads(&a.target, &mut rhs);
+                    let to = self.intern(NodeKey {
+                        path: path.clone(),
+                        signal: lhs,
+                    });
+                    for id in &rhs {
+                        let from = self.intern(NodeKey {
+                            path: path.clone(),
+                            signal: id.clone(),
+                        });
+                        self.add_edge(from, to);
+                    }
+                    for conds in cond_stack.iter() {
+                        for id in conds {
+                            let from = self.intern(NodeKey {
+                                path: path.clone(),
+                                signal: id.clone(),
+                            });
+                            self.add_edge(from, to);
+                        }
+                    }
+                }
+                Stmt::IfElse(ife) => {
+                    let mut cond_ids = HashSet::new();
+                    collect_expr_idents(&ife.cond, &mut cond_ids);
+                    cond_stack.push(cond_ids);
+                    self.scan_assignments_inner(&ife.then_stmts, path, cond_stack);
+                    self.scan_assignments_inner(&ife.else_stmts, path, cond_stack);
+                    cond_stack.pop();
+                }
+                Stmt::Match(m) => {
+                    let mut scrut_ids = HashSet::new();
+                    collect_expr_idents(&m.scrutinee, &mut scrut_ids);
+                    cond_stack.push(scrut_ids);
+                    for arm in &m.arms {
+                        self.scan_assignments_inner(&arm.body, path, cond_stack);
+                    }
+                    cond_stack.pop();
+                }
+                Stmt::For(f) => {
+                    self.scan_assignments_inner(&f.body, path, cond_stack);
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
+/// LHS index/slice expressions can read other signals (e.g. `x[i] = ...`
+/// reads `i`). Collect those identifier reads so they become dep edges.
+fn collect_lhs_index_reads(target: &crate::ast::Expr, out: &mut HashSet<String>) {
+    use ExprKind::*;
+    match &target.kind {
+        Ident(_) => {}
+        BitSlice(base, hi, lo) => {
+            collect_lhs_index_reads(base, out);
+            collect_expr_idents(hi, out);
+            collect_expr_idents(lo, out);
+        }
+        PartSelect(base, start, width, _) => {
+            collect_lhs_index_reads(base, out);
+            collect_expr_idents(start, out);
+            collect_expr_idents(width, out);
+        }
+        Index(base, idx) => {
+            collect_lhs_index_reads(base, out);
+            collect_expr_idents(idx, out);
+        }
+        FieldAccess(base, _) => collect_lhs_index_reads(base, out),
+        _ => {}
+    }
+}
+
+// ── Tarjan's SCC algorithm ───────────────────────────────────────────────────
+
+/// Iterative Tarjan's strongly-connected-components algorithm.
+/// Returns SCCs in reverse topological order (sink components first), each
+/// SCC being a Vec<NodeId>.
+fn tarjan_scc(adj: &[Vec<usize>], n: usize) -> Vec<Vec<usize>> {
+    // Iterative variant to avoid blowing the stack on large designs.
+    let mut index_of: Vec<i64> = vec![-1; n];
+    let mut lowlink: Vec<i64> = vec![-1; n];
+    let mut on_stack: Vec<bool> = vec![false; n];
+    let mut stack: Vec<usize> = Vec::new();
+    let mut sccs: Vec<Vec<usize>> = Vec::new();
+    let mut index: i64 = 0;
+
+    // Frame holds the recursion state for one node.
+    struct Frame {
+        v: usize,
+        iter_pos: usize, // next adj index to visit
+    }
+    let mut call_stack: Vec<Frame> = Vec::new();
+
+    for v_start in 0..n {
+        if index_of[v_start] != -1 { continue; }
+        // Push initial frame
+        call_stack.push(Frame { v: v_start, iter_pos: 0 });
+        index_of[v_start] = index;
+        lowlink[v_start] = index;
+        index += 1;
+        stack.push(v_start);
+        on_stack[v_start] = true;
+
+        while let Some(frame) = call_stack.last_mut() {
+            let v = frame.v;
+            let neighbors = &adj[v];
+            if frame.iter_pos < neighbors.len() {
+                let w = neighbors[frame.iter_pos];
+                frame.iter_pos += 1;
+                if index_of[w] == -1 {
+                    // Recurse
+                    index_of[w] = index;
+                    lowlink[w] = index;
+                    index += 1;
+                    stack.push(w);
+                    on_stack[w] = true;
+                    call_stack.push(Frame { v: w, iter_pos: 0 });
+                } else if on_stack[w] {
+                    if index_of[w] < lowlink[v] {
+                        lowlink[v] = index_of[w];
+                    }
+                }
+            } else {
+                // All neighbors processed — possibly emit SCC.
+                if lowlink[v] == index_of[v] {
+                    let mut comp: Vec<usize> = Vec::new();
+                    loop {
+                        let w = stack.pop().expect("tarjan stack underflow");
+                        on_stack[w] = false;
+                        comp.push(w);
+                        if w == v { break; }
+                    }
+                    sccs.push(comp);
+                }
+                call_stack.pop();
+                // Propagate lowlink up to parent.
+                if let Some(parent) = call_stack.last_mut() {
+                    if lowlink[v] < lowlink[parent.v] {
+                        lowlink[parent.v] = lowlink[v];
+                    }
+                }
+            }
+        }
+    }
+
+    sccs
+}
+

--- a/src/elaborate.rs
+++ b/src/elaborate.rs
@@ -375,7 +375,7 @@ fn elaborate_module_variant(
         p
     }).collect();
 
-    Ok(ModuleDecl { name: new_name, params: new_params, ports: all_ports, body: new_body, implements: m.implements, hooks: m.hooks, cdc_safe: m.cdc_safe, rdc_safe: m.rdc_safe, span: m.span, doc: m.doc, inner_doc: m.inner_doc, is_interface: m.is_interface })
+    Ok(ModuleDecl { name: new_name, params: new_params, ports: all_ports, body: new_body, implements: m.implements, hooks: m.hooks, cdc_safe: m.cdc_safe, rdc_safe: m.rdc_safe, comb_loops_allowed: m.comb_loops_allowed, span: m.span, doc: m.doc, inner_doc: m.inner_doc, is_interface: m.is_interface })
 }
 
 /// Rewrite an inst's `module_name` to the correct variant name.
@@ -2610,6 +2610,7 @@ fn lower_module_threads(m: ModuleDecl, opts: &ThreadLowerOpts) -> Result<(Module
         hooks: Vec::new(),
         cdc_safe: false,
         rdc_safe: false,
+        comb_loops_allowed: false,
         span: sp,
         doc: None,
         inner_doc: None,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -766,6 +766,7 @@ impl Parser {
         let mut hooks: Vec<crate::ast::ModuleHookDecl> = Vec::new();
         let mut cdc_safe = false;
         let mut rdc_safe = false;
+        let mut comb_loops_allowed = false;
 
         while !self.check_end_keyword() {
             match self.peek_kind() {
@@ -778,6 +779,7 @@ impl Parser {
                     match pragma_name.name.as_str() {
                         "cdc_safe" => cdc_safe = true,
                         "rdc_safe" => rdc_safe = true,
+                        "comb_loops_allowed" => comb_loops_allowed = true,
                         _ => {
                             return Err(CompileError::general(
                                 &format!("unknown pragma `{}`", pragma_name.name),
@@ -882,6 +884,7 @@ impl Parser {
             hooks,
             cdc_safe,
             rdc_safe,
+            comb_loops_allowed,
             // `doc` is populated by `attach_outer_doc` from `parse_item`;
             // `inner_doc` was harvested above right after the name.
             doc: None,

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -99,10 +99,83 @@ impl<'a> TypeChecker<'a> {
                 self.check_latch_regfile_writes(m);
             }
         }
+        // Whole-design comb-loop analysis (issue #246). Walks the full
+        // instance hierarchy starting from top-level modules and runs
+        // Tarjan's SCC over a unified `(inst_path, signal)` graph. The
+        // existing per-module analyzer (`comb_graph::analyze_module`)
+        // only catches sibling-instance cycles within one parent and
+        // silently absorbs them as settle_depth=2; this surfaces them
+        // as warnings and also catches cycles that span hierarchy.
+        self.check_whole_design_comb_loops();
         if self.errors.is_empty() {
             Ok((self.warnings, self.overload_map))
         } else {
             Err(self.errors)
+        }
+    }
+
+    /// Issue #246 MVP: warn on every comb-feedback SCC found in the
+    /// whole-design instance-flat graph. Blessed-by-pragma SCCs are
+    /// silently suppressed.
+    fn check_whole_design_comb_loops(&mut self) {
+        let analysis = crate::comb_graph::analyze_whole_design(self.source, self.symbols);
+        if analysis.sccs.is_empty() && analysis.total_sccs == 0 {
+            return;
+        }
+        for scc in &analysis.sccs {
+            // Pick a span for the warning: the span of the first owning
+            // module in the SCC (top-level module if vec![]). Fall back
+            // to the first item's span.
+            let span: Span = scc.owning_modules.iter()
+                .filter_map(|mn| {
+                    self.source.items.iter().find_map(|it| {
+                        if let Item::Module(m) = it {
+                            if &m.name.name == mn { return Some(m.span); }
+                        }
+                        None
+                    })
+                })
+                .next()
+                .unwrap_or_else(|| {
+                    self.source.items.first()
+                        .map(|it| it.span())
+                        .unwrap_or(Span { start: 0, end: 0 })
+                });
+
+            let path_str: Vec<String> = scc.nodes.iter().map(|n| n.display()).collect();
+            let module_list: Vec<String> = {
+                let mut v: Vec<String> = scc.owning_modules.iter().cloned().collect();
+                v.sort();
+                v
+            };
+            let msg = format!(
+                "whole-design combinational feedback cycle ({} nodes) involving modules [{}]; cycle: {}{}",
+                scc.nodes.len(),
+                module_list.join(", "),
+                path_str.join(" -> "),
+                if path_str.is_empty() { String::new() } else { format!(" -> {}", path_str[0]) },
+            );
+            self.warnings.push(CompileWarning {
+                message: msg,
+                span,
+            });
+        }
+        // Summary line emitted as a single warning so it shows up in the
+        // standard warning stream.
+        if analysis.total_sccs > 0 {
+            let span = self.source.items.first()
+                .map(|it| it.span())
+                .unwrap_or(Span { start: 0, end: 0 });
+            let summary = format!(
+                "arch check: {} comb SCC(s) found; {} suppressed by pragma; {} unblessed (warnings)",
+                analysis.total_sccs,
+                analysis.suppressed,
+                analysis.sccs.len(),
+            );
+            self.warnings.push(CompileWarning {
+                message: summary,
+                span,
+            });
         }
     }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -11780,3 +11780,225 @@ fn test_thread_state_names_distinguish_wait_until_vs_wait_cycles() {
             && sv.matches("_wait_cycles =").count() >= 1,
         "wait_until and wait_cycles must produce distinct localparam decls:\n{sv}");
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Issue #246: whole-design combinational feedback-loop detection (MVP).
+// ─────────────────────────────────────────────────────────────────────────────
+
+fn comb_loop_warnings(source: &str) -> Vec<String> {
+    warnings_from(source)
+        .into_iter()
+        .filter(|m| m.contains("combinational feedback cycle")
+                 || m.starts_with("arch check:"))
+        .collect()
+}
+
+#[test]
+fn test_comb_loop_within_module_detected() {
+    // Self-driving comb cycle inside a single module: a depends on b,
+    // b depends on a. The whole-design check should surface it as a
+    // warning.
+    let source = r#"
+        module M
+          port i: in UInt<1>;
+          port o: out UInt<1>;
+          wire a: UInt<1>;
+          wire b: UInt<1>;
+          comb
+            a = b or i;
+            b = a;
+            o = a;
+          end comb
+        end module M
+    "#;
+    let ws = comb_loop_warnings(source);
+    assert!(ws.iter().any(|m| m.contains("combinational feedback cycle")),
+        "expected a comb-loop warning, got: {:?}", ws);
+}
+
+#[test]
+fn test_comb_loop_across_two_instances_detected() {
+    // Cross-instance loop: A.out -> B.in -> B.out -> A.in.
+    // The current per-module analyzer silently absorbs this as
+    // settle_depth=2; the new whole-design analyzer should warn.
+    let source = r#"
+        module Cell
+          port i: in UInt<1>;
+          port o: out UInt<1>;
+          comb
+            o = i;
+          end comb
+        end module Cell
+
+        module Top
+          port s: in UInt<1>;
+          port q: out UInt<1>;
+          wire w1: UInt<1>;
+          wire w2: UInt<1>;
+
+          inst a: Cell
+            i <- w2;
+            o -> w1;
+          end inst a
+
+          inst b: Cell
+            i <- w1;
+            o -> w2;
+          end inst b
+
+          comb
+            q = w1;
+          end comb
+        end module Top
+    "#;
+    let ws = comb_loop_warnings(source);
+    assert!(ws.iter().any(|m| m.contains("combinational feedback cycle")),
+        "expected a comb-loop warning, got: {:?}", ws);
+}
+
+#[test]
+fn test_comb_loop_suppressed_by_pragma() {
+    // Same setup as cross-instance test, but parent has the bless pragma.
+    let source = r#"
+        module Cell
+          port i: in UInt<1>;
+          port o: out UInt<1>;
+          comb
+            o = i;
+          end comb
+        end module Cell
+
+        module Top
+          pragma comb_loops_allowed;
+          port s: in UInt<1>;
+          port q: out UInt<1>;
+          wire w1: UInt<1>;
+          wire w2: UInt<1>;
+
+          inst a: Cell
+            i <- w2;
+            o -> w1;
+          end inst a
+
+          inst b: Cell
+            i <- w1;
+            o -> w2;
+          end inst b
+
+          comb
+            q = w1;
+          end comb
+        end module Top
+    "#;
+    let ws = comb_loop_warnings(source);
+    // No cycle warnings should remain; the summary line MAY still fire
+    // mentioning suppression — but no "combinational feedback cycle (…)"
+    // node-listing warning should be present.
+    let cycle_msgs: Vec<_> = ws.iter().filter(|m| m.contains("combinational feedback cycle (")).collect();
+    assert!(cycle_msgs.is_empty(),
+        "expected pragma to suppress cycle warning, got: {:?}", ws);
+    // Sanity: the summary should report 1 SCC found / 1 suppressed.
+    let summary: Vec<_> = ws.iter().filter(|m| m.starts_with("arch check:")).collect();
+    assert!(summary.iter().any(|m| m.contains("1 comb SCC(s) found") && m.contains("1 suppressed")),
+        "expected suppression-summary line, got: {:?}", ws);
+}
+
+#[test]
+fn test_comb_loop_through_register_not_flagged() {
+    // Cycle goes a -> reg -> b -> a. The register breaks the comb path,
+    // so no warning should fire.
+    let source = r#"
+        domain SysDomain
+          freq_mhz: 100
+        end domain SysDomain
+
+        module M
+          port clk:  in Clock<SysDomain>;
+          port rst:  in Reset<Async, Low>;
+          port i:    in UInt<1>;
+          port o:    out UInt<1>;
+          wire a: UInt<1>;
+          wire b: UInt<1>;
+          reg r: UInt<1> reset rst => 0;
+          comb
+            a = r or i;
+            b = a;
+            o = b;
+          end comb
+          seq on clk rising
+            r <= b;
+          end seq
+        end module M
+    "#;
+    let ws = comb_loop_warnings(source);
+    let cycle_msgs: Vec<_> = ws.iter().filter(|m| m.contains("combinational feedback cycle (")).collect();
+    assert!(cycle_msgs.is_empty(),
+        "register should break the cycle, but got: {:?}", ws);
+}
+
+#[test]
+fn test_interface_module_treated_as_opaque() {
+    // A module loaded purely as an `.archi` interface stub (no body) is
+    // treated as opaque: every output assumed to depend on every input.
+    // We simulate that here by setting `is_interface` post-parse on the
+    // stub-like declaration.
+    //
+    // Setup: Stub has ports (i, o). The user's "stub" module body is
+    // present in source but we will mark it as interface to mimic the
+    // .archi path. With Stub opaque, the wire path through it closes a
+    // cycle: a -> Stub.in -> Stub.out -> a.
+    let source = r#"
+        module Stub
+          port i: in UInt<1>;
+          port o: out UInt<1>;
+        end module Stub
+
+        module Top
+          port s: in UInt<1>;
+          port q: out UInt<1>;
+          wire w1: UInt<1>;
+          wire w2: UInt<1>;
+
+          inst a: Stub
+            i <- w2;
+            o -> w1;
+          end inst a
+
+          inst b: Stub
+            i <- w1;
+            o -> w2;
+          end inst b
+
+          comb
+            q = w1;
+          end comb
+        end module Top
+    "#;
+    // Manually run the pipeline and mark Stub as interface.
+    let tokens = arch::lexer::tokenize(source).expect("lexer error");
+    let mut parser = arch::parser::Parser::new(tokens, source);
+    let mut parsed_ast = parser.parse_source_file().expect("parse error");
+    for item in parsed_ast.items.iter_mut() {
+        if let arch::ast::Item::Module(m) = item {
+            if m.name.name == "Stub" {
+                m.is_interface = true;
+            }
+        }
+    }
+    let ast = arch::elaborate::elaborate(parsed_ast).expect("elaborate error");
+    // Re-mark after elaborate (variant rewrites may have renamed).
+    let mut ast = ast;
+    for item in ast.items.iter_mut() {
+        if let arch::ast::Item::Module(m) = item {
+            if m.name.name.starts_with("Stub") {
+                m.is_interface = true;
+            }
+        }
+    }
+    let symbols = arch::resolve::resolve(&ast).expect("resolve error");
+    let checker = arch::typecheck::TypeChecker::new(&symbols, &ast);
+    let (warnings, _) = checker.check().expect("type check error");
+    let ws: Vec<String> = warnings.into_iter().map(|w| w.message).collect();
+    assert!(ws.iter().any(|m| m.contains("combinational feedback cycle")),
+        "expected opaque-interface module to participate in a detected cycle; warnings: {:?}", ws);
+}


### PR DESCRIPTION
## Summary

Refs #246.

MVP for whole-design combinational feedback-loop analysis. The existing `comb_graph::analyze_module` only sees one parent's `inst` graph at a time, so intentional or unintentional comb cycles that close across module-instance boundaries (e.g. arch-ibex's `IbexAlu` ↔ `IbexMultdivFast` adder-share path inside `ibex_ex_block`) are invisible to `arch check`.

This PR adds `comb_graph::analyze_whole_design`, hooked into `TypeChecker::check`, that:

- Identifies top-level modules (modules never instantiated anywhere).
- Walks the instance hierarchy from each top, flattens into a single directed dep graph keyed on `(InstPath, signal)`.
- Runs Tarjan's SCC (iterative).
- Emits one `CompileWarning` per non-trivial SCC with the cycle path + summary line `arch check: N comb SCC(s) found; M suppressed by pragma; K unblessed (warnings)`.

New blessing pragma, parallel to existing `cdc_safe` / `rdc_safe`:

```
module Foo
  pragma comb_loops_allowed;
  // ...
end module Foo
```

Suppresses any SCC that passes through an instance owned by a module bearing the pragma.

## Design notes

- **Node key**: `NodeKey { path: Vec<String>, signal: String }`. `path` is the inst-name chain from the top-level module; `vec![]` is the top itself. Stringified as `inst_a.inst_b.signal` for display.
- **Algorithm**: Tarjan's SCC (single-pass, memory-local), iterative implementation so deep hierarchies don't blow the stack.
- **Edges**: at each parent level, comb blocks / let bindings / wire decls add LHS-from-RHS edges; condition/scrutinee reads contribute too. Sub-instance connections contribute `parent_in_sig → parent_out_sig` cross-boundary edges using the sub-instance's `CombInfo` (`comb_outputs × comb_dep_inputs`). When the sub-module is also hierarchical, the analyzer recurses so the cycle path display descends through the levels.
- **Regs break cycles**: `RegDecl` / `PipeRegDecl` / `RegBlock` are intentionally NOT scanned for edges, so any cycle that goes through a register is broken at the seq boundary.

## Out-of-scope (deferred to Phase 2)

- **Extern / interface-stub signature support.** Currently `.archi`-loaded stubs (`is_interface == true`) are treated as **opaque**: every output is assumed to depend on every input. This is the safe over-approximation noted in the issue, and matches the design constraint. It produces spurious large-SCC false positives on hierarchical top-levels that consume many `.archi` stubs (in arch-ibex: `ibex_core`, `ibex_top`, `ibex_id_stage`); those need the new pragma as a stopgap until extern signatures land.
- **Per-output dep precision.** The existing `CombInfo` over-approximates leaf modules as "any comb output depends on every comb-read input". Refining to a per-output dep matrix would tighten the SCCs.
- **Per-signal-pair blessing** (`pragma comb_loop a, b;`). Module-level only.
- **Loop classification** (intended / racy / bug). MVP just reports.

## Test plan

- [x] `cargo test --release` (workspace): **360 → 365 passes / 0 failures**.
- [x] New unit tests:
  - `test_comb_loop_within_module_detected` — self-feeding comb in one module flagged.
  - `test_comb_loop_across_two_instances_detected` — A.out → B.in → B.out → A.in flagged (the headline MVP case).
  - `test_comb_loop_suppressed_by_pragma` — same setup, parent has `pragma comb_loops_allowed;`, no cycle warning + summary shows 1 suppressed.
  - `test_comb_loop_through_register_not_flagged` — cycle broken by a reg, no warning.
  - `test_interface_module_treated_as_opaque` — `.archi`-style stubs participate as opaque, real cycle flagged.
- [x] Full arch-ibex SoC gate (130 passes / 75 skipped, baseline = 130/75) with companion PR adding the pragma to `IbexExBlock` + 3 over-approximation hot-spots.

## Companion PR

arch-ibex will need a companion PR to add `pragma comb_loops_allowed;` to the affected modules (`IbexExBlock` for the real intentional ALU↔multdiv loop; `IbexCore`, `IbexIdStage`, `IbexTop` for MVP over-approximation suppression until extern signatures land).

## Follow-up TODO (Phase 2)

- [ ] Design `extern module Foo where output = f(input_a, input_b)` comb-signature syntax for `.archi` stubs.
- [ ] Add `pragma comb_loop signal_a, signal_b;` per-signal-pair blessing.
- [ ] Refine `CombInfo` to a per-output dep matrix to reduce false-positive SCC sizes.
- [ ] Loop classification (intended / racy / bug — see issue body).

🤖 Generated with [Claude Code](https://claude.com/claude-code)