### PR TITLE
comb_graph: filter pipe_reg / port reg outputs from cross-boundary edges

### DIFF
--- a/src/comb_graph.rs
+++ b/src/comb_graph.rs
@@ -827,11 +827,35 @@ impl GraphBuilder {
         // For the MVP we use the existing CombInfo over-approximation: any
         // output port in `comb_outputs` is assumed to depend on every input
         // in `comb_dep_inputs`.
+        // Build a set of registered output port names from the child module's
+        // declarations. Ports declared `port reg ... : out T` or
+        // `port X: out pipe_reg<T, N>` carry `reg_info: Some(_)` and produce
+        // flopped outputs — they break combinational cycles at the seq
+        // boundary and must not contribute parent-level comb edges. This
+        // filter applies in BOTH the opaque and non-opaque branches
+        // (defensive: comb_info_for_module already excludes them, but make
+        // the rule explicit so future regressions don't leak in).
+        let registered_outs: HashSet<&str> = child_mod
+            .map(|cm| cm.ports.iter()
+                .filter(|p| p.reg_info.is_some())
+                .map(|p| p.name.name.as_str())
+                .collect())
+            .unwrap_or_default();
+
         let comb_outs: Vec<&String> = if treat_as_opaque {
-            // Opaque: every declared output port that's connected.
-            output_conn.keys().collect()
+            // Opaque: every declared output port that's connected AND not
+            // flopped via `port reg` / `pipe_reg<T,N>`. Without the
+            // registered-out filter, every comb-input → pipe_reg-output
+            // edge becomes a phantom comb-dep that closes false cycles
+            // through any module that exposes registered outputs (e.g.
+            // arch-ibex's IbexCore decoded fields, IbexIdStage outputs).
+            output_conn.keys()
+                .filter(|k| !registered_outs.contains(k.as_str()))
+                .collect()
         } else {
-            info.comb_outputs.iter().collect()
+            info.comb_outputs.iter()
+                .filter(|k| !registered_outs.contains(k.as_str()))
+                .collect()
         };
         let comb_ins: Vec<&String> = if treat_as_opaque {
             input_conn.keys().collect()

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -12002,3 +12002,83 @@ fn test_interface_module_treated_as_opaque() {
     assert!(ws.iter().any(|m| m.contains("combinational feedback cycle")),
         "expected opaque-interface module to participate in a detected cycle; warnings: {:?}", ws);
 }
+
+#[test]
+fn test_opaque_interface_pipe_reg_output_does_not_close_cycle() {
+    // Regression: in the opaque-stub path the MVP treated EVERY output of
+    // an interface stub as combinationally driven, even outputs that
+    // carry `reg_info: Some(_)` (i.e. `port reg out`/`port out pipe_reg<T,N>`).
+    // Two stubs with `pipe_reg` outputs cross-wired through their inputs
+    // do NOT form a comb cycle — the registers break the path at the seq
+    // boundary. The filter on `registered_outs` excludes them from the
+    // parent-level comb-edge synthesis.
+    //
+    // Without the filter, every arch-ibex module that exposes pipe_reg
+    // outputs through an `.archi` stub (IbexCore, IbexIdStage, IbexTop)
+    // gets flagged with massive over-approximation SCCs (126 nodes etc.).
+    // With the filter, only modules with actually-comb outputs participate.
+    let source = r#"
+        module Stub
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Async, Low>;
+          port i:   in  UInt<1>;
+          port reg o: out UInt<1> reset rst => 1'd0;
+        end module Stub
+
+        module Top
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Async, Low>;
+          port s:   in  UInt<1>;
+          port q:   out UInt<1>;
+          wire w1: UInt<1>;
+          wire w2: UInt<1>;
+
+          inst a: Stub
+            clk <- clk;
+            rst <- rst;
+            i   <- w2;
+            o   -> w1;
+          end inst a
+
+          inst b: Stub
+            clk <- clk;
+            rst <- rst;
+            i   <- w1;
+            o   -> w2;
+          end inst b
+
+          comb
+            q = w1;
+          end comb
+        end module Top
+    "#;
+    let tokens = arch::lexer::tokenize(source).expect("lexer error");
+    let mut parser = arch::parser::Parser::new(tokens, source);
+    let mut parsed_ast = parser.parse_source_file().expect("parse error");
+    for item in parsed_ast.items.iter_mut() {
+        if let arch::ast::Item::Module(m) = item {
+            if m.name.name == "Stub" {
+                m.is_interface = true;
+            }
+        }
+    }
+    let ast = arch::elaborate::elaborate(parsed_ast).expect("elaborate error");
+    let mut ast = ast;
+    for item in ast.items.iter_mut() {
+        if let arch::ast::Item::Module(m) = item {
+            if m.name.name.starts_with("Stub") {
+                m.is_interface = true;
+            }
+        }
+    }
+    let symbols = arch::resolve::resolve(&ast).expect("resolve error");
+    let checker = arch::typecheck::TypeChecker::new(&symbols, &ast);
+    let (warnings, _) = checker.check().expect("type check error");
+    let ws: Vec<String> = warnings.into_iter().map(|w| w.message).collect();
+    let cycle_msgs: Vec<_> = ws.iter()
+        .filter(|m| m.contains("combinational feedback cycle ("))
+        .collect();
+    assert!(cycle_msgs.is_empty(),
+        "pipe_reg / port reg outputs on an opaque stub must not close a comb cycle; got: {:?}",
+        cycle_msgs);
+}


### PR DESCRIPTION
## Summary

Follow-up to #336. The MVP whole-design comb-loop check treated every output of an opaque interface stub as combinationally driven. For a stub with \`port reg out\`/\`port out pipe_reg<T,N>\` outputs, this synthesized phantom comb edges from inputs → registered outputs, contributing false-positive nodes to any SCC that closes through those outputs.

\`PortDecl.reg_info: Option<PortRegInfo>\` already distinguishes flopped outputs at the AST level (both \`port reg\` and \`pipe_reg<T,N>\` set it). This PR builds a \`registered_outs\` set from the child module's ports and filters those names from cross-boundary edge synthesis. No new syntax needed — leverages existing type info.

## Honest impact assessment

I initially overclaimed the impact. Reality:

| Module | SCC size before #337 | SCC size after #337 |
|---|--:|--:|
| \`IbexCore\` (118-node)* | 126 | 118 |
| \`IbexIdStage\` | 18 | 18 |
| \`IbexTop\` | 24 | (untested in isolation; pragma kept) |
| \`IbexExBlock\` | 5 | 5 (real loop) |

\* arch check on \`src/IbexCore.arch\` alone (other modules loaded as \`.archi\` opaque stubs).

The filter mechanically removes pipe_reg-derived false-positive **nodes**, but the over-approximation SCCs survive because they also route through **truly comb outputs** (e.g. \`id_in_ready_o\`, \`stall_alu\`, \`lsu_*_err_o\`). Eliminating those requires per-output dep precision (Phase 2 — \`.archi\` annotations recording which inputs each comb output actually depends on).

So:
- This PR is a structural correctness fix (we shouldn't be synthesizing comb edges through flopped outputs at all).
- It does NOT obviate the \`pragma comb_loops_allowed;\` blesses in arch-ibex's IbexCore / IbexIdStage / IbexTop — those still need Phase 2.

## Test plan

- [x] New \`test_opaque_interface_pipe_reg_output_does_not_close_cycle\`: two \`port reg\`-output stubs cross-wired through their inputs; asserts no cycle warning. Verifies the filter works in a controlled setting where there are NO truly comb outputs in the path.
- [x] \`test_interface_module_treated_as_opaque\` (pre-existing): unchanged — pure-comb stubs still produce SCCs as expected. The filter doesn't over-correct.
- [x] \`cargo test --release\` — 368 passes / 0 failures (was 367 + 1 new test).
- [x] arch-ibex full SoC gate: 130 passed / 0 failed (unchanged; pragmas stay where they were).

## Refs

Refs #246. (Issue stays open for Phase 2: \`.archi\` per-output dep annotations + per-loop blessing syntax. Phase 2 is what would let arch-ibex drop the false-positive pragmas.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)