### PR TITLE
interface: per-output comb_dep_on(...) annotations in .archi (#246 Phase 2)

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -303,6 +303,22 @@ pub struct PortDecl {
     /// (`name[i]`) is unchanged — `0` is always the first element. Only
     /// legal when `unpacked` is also set.
     pub unpacked_ascending: bool,
+    /// Per-output combinational-dependency annotation (issue #246
+    /// Phase 2). Only legal on output ports without `reg_info` (i.e.
+    /// comb-driven outputs). Three states:
+    ///   - `None`           — no annotation. Analyzer falls back to
+    ///                        the opaque "every comb input feeds this
+    ///                        output" over-approximation.
+    ///   - `Some(vec![])`   — pure: comb-driven but depends on no
+    ///                        inputs (e.g. constant). No incoming
+    ///                        comb edges.
+    ///   - `Some(vec![..])` — precise: depends only on the listed
+    ///                        input port names.
+    /// Carried verbatim through `.archi` emit / parse so consumers
+    /// (`comb_graph::expand_inst`) can synthesize precise cross-
+    /// boundary edges instead of the opaque every-in-feeds-every-out
+    /// shape.
+    pub comb_deps: Option<Vec<Ident>>,
     pub span: Span,
 }
 

--- a/src/comb_graph.rs
+++ b/src/comb_graph.rs
@@ -284,6 +284,151 @@ fn comb_info_for_module(m: &ModuleDecl) -> CombInfo {
     CombInfo { comb_outputs: driven, comb_dep_inputs: read }
 }
 
+/// Per-output combinational dependencies for a module.
+///
+/// For each output port that is combinationally driven (i.e. appears as LHS
+/// in any comb block, or is directly bound via a let binding whose name
+/// matches an output port), returns the set of input port names that
+/// transitively feed it through let/wire intermediates inside the body.
+///
+/// This is the precise version of `comb_info_for_module`, which only
+/// tracks aggregate `{driven, read_inputs}` sets and so over-approximates
+/// every driven output as depending on every read input.
+///
+/// Used by `.archi` interface emit (`interface::emit_ports`) to attach a
+/// `comb_dep_on(...)` annotation to each comb-driven output, and by
+/// `expand_inst` (whole-design analyzer) when the inst's child module has
+/// a body available.
+///
+/// Returns a map keyed by **output port name** (only — wire / let
+/// intermediates are not exposed). Returns an empty map for modules with
+/// no comb-driven outputs. Issue #246 Phase 2.
+pub fn per_output_comb_deps(m: &ModuleDecl) -> HashMap<String, HashSet<String>> {
+    use crate::ast::Direction;
+
+    // 1. Identify input and output port names (clk/rst excluded — those
+    //    are seq-only).
+    let mut input_names: HashSet<String> = HashSet::new();
+    let mut output_names: HashSet<String> = HashSet::new();
+    for p in &m.ports {
+        if is_clk_or_rst(&p.ty) { continue; }
+        match p.direction {
+            Direction::In  => { input_names.insert(p.name.name.clone()); }
+            Direction::Out => {
+                // Skip registered outputs — they're flopped, not comb.
+                if p.reg_info.is_none() {
+                    output_names.insert(p.name.name.clone());
+                }
+            }
+        }
+    }
+
+    // 2. Walk the body building a direct-dep map: LHS → set of RHS idents.
+    //    Multiple assignments to the same LHS union their deps (covers
+    //    conditional-branch shapes — same LHS in then + else).
+    let mut direct: HashMap<String, HashSet<String>> = HashMap::new();
+    for item in &m.body {
+        match item {
+            ModuleBodyItem::CombBlock(cb) => {
+                collect_comb_deps(&cb.stmts, &mut direct, &mut Vec::new());
+            }
+            ModuleBodyItem::LetBinding(lb) => {
+                let mut ids = HashSet::new();
+                collect_expr_idents(&lb.value, &mut ids);
+                direct.entry(lb.name.name.clone())
+                    .or_default()
+                    .extend(ids);
+            }
+            _ => {}
+        }
+    }
+
+    // 3. Transitive closure from inputs to each output, restricted to
+    //    input port names. For each output, BFS over `direct` chasing
+    //    deps until we hit fixpoint, collecting visited names that are
+    //    in `input_names`.
+    let mut out: HashMap<String, HashSet<String>> = HashMap::new();
+    for out_name in &output_names {
+        // Only emit an entry if this output is actually comb-driven
+        // (i.e. appears as LHS in `direct`). Outputs that never appear
+        // as LHS are not comb-driven (could be unconnected — emit
+        // empty, meaning "no inputs feed me").
+        if !direct.contains_key(out_name) {
+            // Unconnected output — treat as pure (no deps).
+            out.insert(out_name.clone(), HashSet::new());
+            continue;
+        }
+
+        let mut deps: HashSet<String> = HashSet::new();
+        let mut visited: HashSet<String> = HashSet::new();
+        let mut stack: Vec<String> = vec![out_name.clone()];
+        while let Some(cur) = stack.pop() {
+            if !visited.insert(cur.clone()) { continue; }
+            if let Some(rhs_ids) = direct.get(&cur) {
+                for id in rhs_ids {
+                    if input_names.contains(id) {
+                        deps.insert(id.clone());
+                    } else if direct.contains_key(id) {
+                        // Intermediate (wire / let / another driven sig).
+                        stack.push(id.clone());
+                    }
+                    // Else: probably a reg / param / unknown — ignore.
+                }
+            }
+        }
+        out.insert(out_name.clone(), deps);
+    }
+    out
+}
+
+/// Helper for `per_output_comb_deps`: walk a list of comb statements,
+/// updating `direct[LHS] |= rhs idents | enclosing-condition idents`.
+fn collect_comb_deps(
+    stmts: &[Stmt],
+    direct: &mut HashMap<String, HashSet<String>>,
+    cond_stack: &mut Vec<HashSet<String>>,
+) {
+    for stmt in stmts {
+        match stmt {
+            Stmt::Assign(a) => {
+                let lhs = match lhs_base_name(&a.target) {
+                    Some(n) => n,
+                    None => continue,
+                };
+                let mut rhs = HashSet::new();
+                collect_expr_idents(&a.value, &mut rhs);
+                // LHS index/slice expressions also read identifiers.
+                collect_lhs_index_reads(&a.target, &mut rhs);
+                for conds in cond_stack.iter() {
+                    for id in conds { rhs.insert(id.clone()); }
+                }
+                direct.entry(lhs).or_default().extend(rhs);
+            }
+            Stmt::IfElse(ife) => {
+                let mut cond_ids = HashSet::new();
+                collect_expr_idents(&ife.cond, &mut cond_ids);
+                cond_stack.push(cond_ids);
+                collect_comb_deps(&ife.then_stmts, direct, cond_stack);
+                collect_comb_deps(&ife.else_stmts, direct, cond_stack);
+                cond_stack.pop();
+            }
+            Stmt::Match(m) => {
+                let mut scrut_ids = HashSet::new();
+                collect_expr_idents(&m.scrutinee, &mut scrut_ids);
+                cond_stack.push(scrut_ids);
+                for arm in &m.arms {
+                    collect_comb_deps(&arm.body, direct, cond_stack);
+                }
+                cond_stack.pop();
+            }
+            Stmt::For(f) => {
+                collect_comb_deps(&f.body, direct, cond_stack);
+            }
+            _ => {}
+        }
+    }
+}
+
 /// Compute CombInfo for a RAM declaration.
 fn comb_info_for_ram(ram: &RamDecl) -> CombInfo {
     // latency = 0 (async): read data output is combinationally driven by
@@ -842,6 +987,23 @@ impl GraphBuilder {
                 .collect())
             .unwrap_or_default();
 
+        // Per-output comb-dep annotations from the child module's port
+        // decls (issue #246 Phase 2). Carried verbatim through `.archi`,
+        // populated by the parser when reading `comb_dep_on(...)`.
+        //   `Some(set)` — precise: out depends only on the listed inputs.
+        //                  Empty set = PURE (no incoming comb edges).
+        //   `None`      — opaque: fall back to every-input over-approx.
+        let per_output_deps: HashMap<&str, Option<HashSet<&str>>> = child_mod
+            .map(|cm| cm.ports.iter()
+                .filter(|p| p.direction == crate::ast::Direction::Out && p.reg_info.is_none())
+                .map(|p| {
+                    let set = p.comb_deps.as_ref().map(|v|
+                        v.iter().map(|i| i.name.as_str()).collect::<HashSet<&str>>());
+                    (p.name.name.as_str(), set)
+                })
+                .collect())
+            .unwrap_or_default();
+
         let comb_outs: Vec<&String> = if treat_as_opaque {
             // Opaque: every declared output port that's connected AND not
             // flopped via `port reg` / `pipe_reg<T,N>`. Without the
@@ -879,7 +1041,18 @@ impl GraphBuilder {
                 self.add_edge(child_q, to);
             }
 
+            // Per-output precision: if the child's port-decl carries a
+            // `comb_dep_on(...)` annotation, restrict incoming edges
+            // exactly to that input set (empty set = no incoming edges).
+            // Otherwise fall back to the broad `comb_ins` list.
+            let precise_deps: Option<&HashSet<&str>> = per_output_deps
+                .get(out_port.as_str())
+                .and_then(|opt| opt.as_ref());
+
             for in_port in &comb_ins {
+                if let Some(allow) = precise_deps {
+                    if !allow.contains(in_port.as_str()) { continue; }
+                }
                 let in_sig = match input_conn.get(in_port.as_str()) {
                     Some(s) => s.clone(),
                     None => continue,

--- a/src/elaborate.rs
+++ b/src/elaborate.rs
@@ -1031,6 +1031,7 @@ fn subst_port(p: &PortDecl, var: &str, val: i64) -> PortDecl {
         shared: p.shared,
         unpacked: p.unpacked,
         unpacked_ascending: p.unpacked_ascending,
+        comb_deps: p.comb_deps.clone(),
         span: p.span,
     }
 }
@@ -1687,12 +1688,12 @@ fn lower_module_threads(m: ModuleDecl, opts: &ThreadLowerOpts) -> Result<(Module
             name: t.clock.clone(), direction: Direction::In,
             ty: type_map.get(&t.clock.name).map(|si| si.ty.clone())
                 .unwrap_or(TypeExpr::Clock(Ident::new("SysDomain".to_string(), sp))),
-            default: None, reg_info: None, bus_info: None, shared: None, unpacked: false, unpacked_ascending: false, span: sp,
+            default: None, reg_info: None, bus_info: None, shared: None, unpacked: false, unpacked_ascending: false, comb_deps: None, span: sp,
         });
         merged_ports.push(PortDecl {
             name: t.reset.clone(), direction: Direction::In,
             ty: TypeExpr::Reset(rk, t.reset_level),
-            default: None, reg_info: None, bus_info: None, shared: None, unpacked: false, unpacked_ascending: false, span: sp,
+            default: None, reg_info: None, bus_info: None, shared: None, unpacked: false, unpacked_ascending: false, comb_deps: None, span: sp,
         });
         (t.clock.name.clone(), t.reset.name.clone(), t.reset_level)
     };
@@ -1724,6 +1725,7 @@ fn lower_module_threads(m: ModuleDecl, opts: &ThreadLowerOpts) -> Result<(Module
                 default: None, reg_info: None, bus_info: None, shared: None,
                 unpacked: info.unpacked,
                 unpacked_ascending: info.unpacked_ascending,
+                comb_deps: None,
                 span: sp,
             });
         }
@@ -1743,6 +1745,7 @@ fn lower_module_threads(m: ModuleDecl, opts: &ThreadLowerOpts) -> Result<(Module
                 reg_info: None, bus_info: None, shared: info.shared,
                 unpacked: info.unpacked,
                 unpacked_ascending: info.unpacked_ascending,
+                comb_deps: None,
                 span: sp,
             });
         }
@@ -1763,7 +1766,7 @@ fn lower_module_threads(m: ModuleDecl, opts: &ThreadLowerOpts) -> Result<(Module
                     // don't deprecate internal artifacts.
                     legacy_port_reg: false,
                 }),
-                bus_info: None, shared: None, unpacked: false, unpacked_ascending: false, span: sp,
+                bus_info: None, shared: None, unpacked: false, unpacked_ascending: false, comb_deps: None, span: sp,
             });
         }
     }
@@ -2694,24 +2697,24 @@ fn synthesize_lock_arbiter(
         PortDecl {
             name: Ident::new("clk".to_string(), sp),
             direction: Direction::In, ty: clk_ty, default: None,
-            reg_info: None, bus_info: None, shared: None, unpacked: false, unpacked_ascending: false, span: sp,
+            reg_info: None, bus_info: None, shared: None, unpacked: false, unpacked_ascending: false, comb_deps: None, span: sp,
         },
         PortDecl {
             name: Ident::new("rst".to_string(), sp),
             direction: Direction::In, ty: rst_ty, default: None,
-            reg_info: None, bus_info: None, shared: None, unpacked: false, unpacked_ascending: false, span: sp,
+            reg_info: None, bus_info: None, shared: None, unpacked: false, unpacked_ascending: false, comb_deps: None, span: sp,
         },
         PortDecl {
             name: Ident::new("grant_valid".to_string(), sp),
             direction: Direction::Out, ty: TypeExpr::Bool, default: None,
-            reg_info: None, bus_info: None, shared: None, unpacked: false, unpacked_ascending: false, span: sp,
+            reg_info: None, bus_info: None, shared: None, unpacked: false, unpacked_ascending: false, comb_deps: None, span: sp,
         },
         PortDecl {
             name: Ident::new("grant_requester".to_string(), sp),
             direction: Direction::Out,
             ty: TypeExpr::UInt(Box::new(Expr::new(
                 ExprKind::Literal(LitKind::Dec(gr_width as u64)), sp))),
-            default: None, reg_info: None, bus_info: None, shared: None, unpacked: false, unpacked_ascending: false, span: sp,
+            default: None, reg_info: None, bus_info: None, shared: None, unpacked: false, unpacked_ascending: false, comb_deps: None, span: sp,
         },
     ];
 
@@ -2722,12 +2725,12 @@ fn synthesize_lock_arbiter(
             PortDecl {
                 name: Ident::new("valid".to_string(), sp),
                 direction: Direction::In, ty: TypeExpr::Bool, default: None,
-                reg_info: None, bus_info: None, shared: None, unpacked: false, unpacked_ascending: false, span: sp,
+                reg_info: None, bus_info: None, shared: None, unpacked: false, unpacked_ascending: false, comb_deps: None, span: sp,
             },
             PortDecl {
                 name: Ident::new("ready".to_string(), sp),
                 direction: Direction::Out, ty: TypeExpr::Bool, default: None,
-                reg_info: None, bus_info: None, shared: None, unpacked: false, unpacked_ascending: false, span: sp,
+                reg_info: None, bus_info: None, shared: None, unpacked: false, unpacked_ascending: false, comb_deps: None, span: sp,
             },
         ],
         span: sp,

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -4,6 +4,7 @@
 //! (params + ports, no body) for use in separate compilation.
 
 use crate::ast::*;
+use std::collections::{HashMap, HashSet};
 
 /// Emit `.archi` content for a single AST item.
 /// Returns `Some(content)` for items that have an external interface
@@ -25,7 +26,12 @@ pub(crate) fn emit_module_interface(m: &ModuleDecl) -> String {
     let name = &m.name.name;
     let mut s = format!("module {name}\n");
     emit_params(&mut s, &m.params);
-    emit_ports(&mut s, &m.ports);
+    // Compute precise per-output comb-dep sets from the module body so
+    // the .archi reflects the actual dataflow shape (issue #246 Phase 2).
+    // The opaque "every comb input feeds every comb output" over-
+    // approximation is avoided as long as the module has a body.
+    let deps = crate::comb_graph::per_output_comb_deps(m);
+    emit_ports_with_deps(&mut s, &m.ports, Some(&deps));
     s.push_str(&format!("end module {name}\n"));
     s
 }
@@ -327,6 +333,20 @@ pub(crate) fn emit_params(s: &mut String, params: &[ParamDecl]) {
 }
 
 pub(crate) fn emit_ports(s: &mut String, ports: &[PortDecl]) {
+    emit_ports_with_deps(s, ports, None)
+}
+
+/// Like `emit_ports` but augments comb-driven output ports with an
+/// optional `comb_dep_on(...)` annotation computed by
+/// `comb_graph::per_output_comb_deps`. Module-shaped constructs pass
+/// `Some(&deps)`; constructs without a comb-driven body shape (counter,
+/// arbiter, regfile, ...) pass `None`, in which case the annotation is
+/// not emitted (so consumers fall back to the opaque interpretation).
+pub(crate) fn emit_ports_with_deps(
+    s: &mut String,
+    ports: &[PortDecl],
+    per_output_deps: Option<&HashMap<String, HashSet<String>>>,
+) {
     for p in ports {
         let dir = match p.direction {
             Direction::In => "in",
@@ -368,7 +388,40 @@ pub(crate) fn emit_ports(s: &mut String, ports: &[PortDecl]) {
                     }
                 }
             } else {
-                s.push_str(&format!("  port {name}: {dir} {unpacked_kw}{ty};\n"));
+                // Compute comb_dep_on(...) annotation for comb-driven
+                // outputs when a per-output dep map is available.
+                // Priority: caller-supplied (computed) map > preserved
+                // user-written `p.comb_deps`. The preserved field path
+                // covers .archi round-trip (parse → re-emit) without
+                // recomputing.
+                let dep_suffix = if p.direction == Direction::Out {
+                    if let Some(map) = per_output_deps {
+                        if let Some(set) = map.get(name) {
+                            let mut sorted: Vec<&String> = set.iter().collect();
+                            sorted.sort();
+                            let inner: String = sorted.iter()
+                                .map(|s| s.as_str())
+                                .collect::<Vec<_>>()
+                                .join(", ");
+                            format!(" comb_dep_on({inner})")
+                        } else {
+                            String::new()
+                        }
+                    } else if let Some(deps) = &p.comb_deps {
+                        let mut sorted: Vec<&String> = deps.iter().map(|i| &i.name).collect();
+                        sorted.sort();
+                        let inner: String = sorted.iter()
+                            .map(|s| s.as_str())
+                            .collect::<Vec<_>>()
+                            .join(", ");
+                        format!(" comb_dep_on({inner})")
+                    } else {
+                        String::new()
+                    }
+                } else {
+                    String::new()
+                };
+                s.push_str(&format!("  port {name}: {dir} {unpacked_kw}{ty}{dep_suffix};\n"));
             }
         }
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -438,6 +438,7 @@ impl Parser {
             reg_info: None,
             bus_info: None,
             shared: None, unpacked: false, unpacked_ascending: false,
+            comb_deps: None,
             span: parent_span.merge(end_span),
         })
     }
@@ -639,6 +640,7 @@ impl Parser {
             reg_info: None,
             bus_info: None,
             shared: None, unpacked: false, unpacked_ascending: false,
+            comb_deps: None,
             span: sp,
         };
         // Control signals (payload-direction = `dir`, back-signal = `opposite`).
@@ -1029,6 +1031,7 @@ impl Parser {
                 reg_info: None,
                 bus_info: Some(BusPortInfo { bus_name, perspective, params }),
                 shared: None, unpacked: false, unpacked_ascending: false,
+                comb_deps: None,
                 span: start.merge(end_span),
             });
         }
@@ -1176,6 +1179,49 @@ impl Parser {
         } else {
             None
         };
+        // Optional `comb_dep_on(in_a, in_b, ...)` per-output combinational
+        // dependency annotation. Carries through .archi files to give
+        // downstream consumers (whole-design comb-loop analyzer) precise
+        // input → output edges instead of the opaque every-in-feeds-
+        // every-out over-approximation. Issue #246 Phase 2.
+        //
+        // Constraints:
+        //   - Only legal on `out` ports.
+        //   - Not legal on registered outputs (`port reg ...` or
+        //     `port X: out pipe_reg<T,N> ...`) — those don't have a
+        //     combinational dep relationship; their outputs are flopped.
+        //   - Body is a comma-separated list of bare identifiers naming
+        //     this module's own input ports. Empty list (`comb_dep_on()`)
+        //     means PURE — comb-driven but reads no inputs.
+        let comb_deps = if self.check_ident("comb_dep_on") {
+            let kw_span = self.peek_span();
+            self.advance();
+            if direction != Direction::Out {
+                return Err(CompileError::general(
+                    "`comb_dep_on(...)` is only valid on output ports",
+                    kw_span,
+                ));
+            }
+            if is_reg {
+                return Err(CompileError::general(
+                    "`comb_dep_on(...)` is not valid on registered outputs (`port reg ...` / `port X: out pipe_reg<T,N> ...`); registered outputs are not combinationally driven",
+                    kw_span,
+                ));
+            }
+            self.expect(TokenKind::LParen)?;
+            let mut deps: Vec<Ident> = Vec::new();
+            if !self.check(TokenKind::RParen) {
+                loop {
+                    let dep_id = self.expect_ident()?;
+                    deps.push(dep_id);
+                    if !self.eat(TokenKind::Comma) { break; }
+                }
+            }
+            self.expect(TokenKind::RParen)?;
+            Some(deps)
+        } else {
+            None
+        };
         self.expect(TokenKind::Semi)?;
         let end_span = self.tokens.get(self.pos.saturating_sub(1)).map(|t| t.span).unwrap_or(start);
         if unpacked && !matches!(ty, TypeExpr::Vec(..)) {
@@ -1194,6 +1240,7 @@ impl Parser {
             shared,
             unpacked,
             unpacked_ascending,
+            comb_deps,
             span: start.merge(end_span),
         })
     }
@@ -4375,7 +4422,7 @@ impl Parser {
         let ty = self.parse_type_expr()?;
         self.expect(TokenKind::Semi)?;
         let end_span = self.tokens.get(self.pos.saturating_sub(1)).map(|t| t.span).unwrap_or(start);
-        Ok(PortDecl { name, direction, ty, default: None, reg_info: None, bus_info: None, shared: None, unpacked: false, unpacked_ascending: false, span: start.merge(end_span) })
+        Ok(PortDecl { name, direction, ty, default: None, reg_info: None, bus_info: None, shared: None, unpacked: false, unpacked_ascending: false, comb_deps: None, span: start.merge(end_span) })
     }
 
     fn parse_ram_init(&mut self) -> Result<RamInit, CompileError> {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -11347,7 +11347,9 @@ end module UpkPort
     let body = arch::interface::emit_interface(item).expect("emit_interface");
     assert!(body.contains("port a: in unpacked Vec<UInt<W>, N>;"),
             "unpacked input port should round-trip into .archi: {body}");
-    assert!(body.contains("port b: out unpacked Vec<UInt<W>, N>;"),
+    // Issue #246 Phase 2: output ports may pick up a `comb_dep_on(...)`
+    // suffix listing the precise input ports that feed each output.
+    assert!(body.contains("port b: out unpacked Vec<UInt<W>, N>"),
             "unpacked output port should round-trip into .archi: {body}");
     // Packed Vec port (no `unpacked` modifier) still emits without it.
     assert!(body.contains("port c: in Vec<UInt<W>, N>;"),
@@ -12081,4 +12083,309 @@ fn test_opaque_interface_pipe_reg_output_does_not_close_cycle() {
     assert!(cycle_msgs.is_empty(),
         "pipe_reg / port reg outputs on an opaque stub must not close a comb cycle; got: {:?}",
         cycle_msgs);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Issue #246 Phase 2: per-output `comb_dep_on(...)` annotation.
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_archi_comb_dep_annotation_parses() {
+    // A `.archi`-shaped module declaration carrying `comb_dep_on(...)`
+    // on an output port. The parser should populate the new
+    // `PortDecl::comb_deps` field with the listed input idents.
+    let source = "
+        module Stub
+          port a: in  UInt<8>;
+          port b: in  UInt<8>;
+          port x: out UInt<8> comb_dep_on(a);
+          port y: out UInt<8> comb_dep_on(a, b);
+          port z: out UInt<8> comb_dep_on();
+          port w: out UInt<8>;
+        end module Stub
+    ";
+    let tokens = lexer::tokenize(source).expect("lexer");
+    let mut parser = Parser::new(tokens, source);
+    let parsed = parser.parse_source_file().expect("parse");
+    let m = parsed.items.iter().find_map(|i| match i {
+        arch::ast::Item::Module(m) => Some(m),
+        _ => None,
+    }).expect("module");
+
+    let by_name: std::collections::HashMap<&str, &arch::ast::PortDecl> =
+        m.ports.iter().map(|p| (p.name.name.as_str(), p)).collect();
+
+    let x_deps: Vec<&str> = by_name["x"].comb_deps.as_ref()
+        .expect("x must carry comb_deps")
+        .iter().map(|i| i.name.as_str()).collect();
+    assert_eq!(x_deps, vec!["a"], "x deps");
+
+    let y_deps: Vec<&str> = by_name["y"].comb_deps.as_ref()
+        .expect("y must carry comb_deps")
+        .iter().map(|i| i.name.as_str()).collect();
+    assert_eq!(y_deps, vec!["a", "b"], "y deps");
+
+    let z_deps: &Vec<arch::ast::Ident> = by_name["z"].comb_deps.as_ref()
+        .expect("z must carry comb_deps (empty list = pure)");
+    assert!(z_deps.is_empty(), "z must be pure (empty deps)");
+
+    assert!(by_name["w"].comb_deps.is_none(),
+        "w must carry no annotation (opaque fallback)");
+}
+
+#[test]
+fn test_archi_comb_dep_annotation_round_trip() {
+    // Compile a module body that drives `x` only from input `a` and
+    // `y` from both `a` and `b`. The `.archi` emit should reflect that
+    // precise per-output dependency shape via `comb_dep_on(...)`.
+    let source = "
+        module M
+          port a: in  UInt<8>;
+          port b: in  UInt<8>;
+          port x: out UInt<8>;
+          port y: out UInt<8>;
+          port z: out UInt<8>;
+          comb
+            x = a;
+            y = a + b;
+            z = 8'd0;
+          end comb
+        end module M
+    ";
+    let tokens = lexer::tokenize(source).expect("lexer");
+    let mut parser = Parser::new(tokens, source);
+    let parsed = parser.parse_source_file().expect("parse");
+    let item = parsed.items.iter()
+        .find(|i| matches!(i, arch::ast::Item::Module(_)))
+        .expect("module");
+    let body = arch::interface::emit_interface(item).expect("emit_interface");
+    assert!(body.contains("port x: out UInt<8> comb_dep_on(a);"),
+        "x must depend only on a: {body}");
+    assert!(body.contains("port y: out UInt<8> comb_dep_on(a, b);"),
+        "y must depend on a and b: {body}");
+    assert!(body.contains("port z: out UInt<8> comb_dep_on();"),
+        "z is pure (constant): {body}");
+}
+
+#[test]
+fn test_archi_comb_dep_precise_eliminates_false_positive() {
+    // Two stubs cross-wired through TWO separate input/output port pairs.
+    // The `comb_dep_on(...)` annotation says `out_x` depends only on `in_a`
+    // (NOT in_b). The cross-wired cycle would only close THROUGH `in_b`,
+    // so no SCC should fire. Without the annotation (opaque fallback)
+    // the analyzer would treat every out as depending on every in and
+    // would flag this as a comb cycle.
+    let source = r#"
+        module Stub
+          port in_a: in  UInt<1>;
+          port in_b: in  UInt<1>;
+          port out_x: out UInt<1> comb_dep_on(in_a);
+          port out_y: out UInt<1> comb_dep_on(in_a);
+        end module Stub
+
+        module Top
+          port a: in UInt<1>;
+          port q: out UInt<1>;
+          wire w1: UInt<1>;
+          wire w2: UInt<1>;
+          wire w3: UInt<1>;
+          wire w4: UInt<1>;
+
+          inst u1: Stub
+            in_a  <- a;
+            in_b  <- w2;
+            out_x -> w1;
+            out_y -> w3;
+          end inst u1
+
+          inst u2: Stub
+            in_a  <- a;
+            in_b  <- w1;
+            out_x -> w2;
+            out_y -> w4;
+          end inst u2
+
+          comb
+            q = w1;
+          end comb
+        end module Top
+    "#;
+    let tokens = arch::lexer::tokenize(source).expect("lexer");
+    let mut parser = arch::parser::Parser::new(tokens, source);
+    let mut parsed_ast = parser.parse_source_file().expect("parse");
+    // Mark `Stub` as an interface to mimic the .archi path.
+    for item in parsed_ast.items.iter_mut() {
+        if let arch::ast::Item::Module(m) = item {
+            if m.name.name == "Stub" { m.is_interface = true; }
+        }
+    }
+    let ast = arch::elaborate::elaborate(parsed_ast).expect("elaborate");
+    let mut ast = ast;
+    for item in ast.items.iter_mut() {
+        if let arch::ast::Item::Module(m) = item {
+            if m.name.name.starts_with("Stub") { m.is_interface = true; }
+        }
+    }
+    let symbols = arch::resolve::resolve(&ast).expect("resolve");
+    let checker = arch::typecheck::TypeChecker::new(&symbols, &ast);
+    let (warnings, _) = checker.check().expect("type check");
+    let ws: Vec<String> = warnings.into_iter().map(|w| w.message).collect();
+    let cycle_msgs: Vec<_> = ws.iter()
+        .filter(|m| m.contains("combinational feedback cycle ("))
+        .collect();
+    assert!(cycle_msgs.is_empty(),
+        "comb_dep_on(in_a) should restrict edges so no cycle fires; got: {:?}", cycle_msgs);
+}
+
+#[test]
+fn test_archi_comb_dep_empty_marks_output_pure() {
+    // A stub whose output port is marked `comb_dep_on()` (empty) should
+    // contribute NO incoming comb edges. Cross-wiring two such stubs
+    // through their inputs cannot close a cycle.
+    let source = r#"
+        module Stub
+          port i: in  UInt<1>;
+          port o: out UInt<1> comb_dep_on();
+        end module Stub
+
+        module Top
+          port a: in UInt<1>;
+          port q: out UInt<1>;
+          wire w1: UInt<1>;
+          wire w2: UInt<1>;
+
+          inst u1: Stub
+            i <- w2;
+            o -> w1;
+          end inst u1
+          inst u2: Stub
+            i <- w1;
+            o -> w2;
+          end inst u2
+
+          comb
+            q = w1;
+          end comb
+        end module Top
+    "#;
+    let tokens = arch::lexer::tokenize(source).expect("lexer");
+    let mut parser = arch::parser::Parser::new(tokens, source);
+    let mut parsed_ast = parser.parse_source_file().expect("parse");
+    for item in parsed_ast.items.iter_mut() {
+        if let arch::ast::Item::Module(m) = item {
+            if m.name.name == "Stub" { m.is_interface = true; }
+        }
+    }
+    let ast = arch::elaborate::elaborate(parsed_ast).expect("elaborate");
+    let mut ast = ast;
+    for item in ast.items.iter_mut() {
+        if let arch::ast::Item::Module(m) = item {
+            if m.name.name.starts_with("Stub") { m.is_interface = true; }
+        }
+    }
+    let symbols = arch::resolve::resolve(&ast).expect("resolve");
+    let checker = arch::typecheck::TypeChecker::new(&symbols, &ast);
+    let (warnings, _) = checker.check().expect("type check");
+    let ws: Vec<String> = warnings.into_iter().map(|w| w.message).collect();
+    let cycle_msgs: Vec<_> = ws.iter()
+        .filter(|m| m.contains("combinational feedback cycle ("))
+        .collect();
+    assert!(cycle_msgs.is_empty(),
+        "comb_dep_on() (pure) must produce no incoming comb edges; got: {:?}", cycle_msgs);
+}
+
+#[test]
+fn test_archi_comb_dep_absent_falls_back_to_opaque() {
+    // A stub WITHOUT the annotation must keep today's opaque "every
+    // output depends on every input" behavior. Two such stubs cross-
+    // wired should fire the cycle warning (regression guard for the
+    // pre-annotation behavior).
+    let source = r#"
+        module Stub
+          port i: in  UInt<1>;
+          port o: out UInt<1>;
+        end module Stub
+
+        module Top
+          port a: in UInt<1>;
+          port q: out UInt<1>;
+          wire w1: UInt<1>;
+          wire w2: UInt<1>;
+
+          inst u1: Stub
+            i <- w2;
+            o -> w1;
+          end inst u1
+          inst u2: Stub
+            i <- w1;
+            o -> w2;
+          end inst u2
+
+          comb
+            q = w1;
+          end comb
+        end module Top
+    "#;
+    let tokens = arch::lexer::tokenize(source).expect("lexer");
+    let mut parser = arch::parser::Parser::new(tokens, source);
+    let mut parsed_ast = parser.parse_source_file().expect("parse");
+    for item in parsed_ast.items.iter_mut() {
+        if let arch::ast::Item::Module(m) = item {
+            if m.name.name == "Stub" { m.is_interface = true; }
+        }
+    }
+    let ast = arch::elaborate::elaborate(parsed_ast).expect("elaborate");
+    let mut ast = ast;
+    for item in ast.items.iter_mut() {
+        if let arch::ast::Item::Module(m) = item {
+            if m.name.name.starts_with("Stub") { m.is_interface = true; }
+        }
+    }
+    let symbols = arch::resolve::resolve(&ast).expect("resolve");
+    let checker = arch::typecheck::TypeChecker::new(&symbols, &ast);
+    let (warnings, _) = checker.check().expect("type check");
+    let ws: Vec<String> = warnings.into_iter().map(|w| w.message).collect();
+    assert!(ws.iter().any(|m| m.contains("combinational feedback cycle")),
+        "absent annotation must keep opaque fallback that fires cycle: {:?}", ws);
+}
+
+#[test]
+fn test_archi_comb_dep_on_registered_output_rejected_at_parse() {
+    // `port reg out_x: ... comb_dep_on(in_a);` is illegal — registered
+    // outputs are not combinationally driven. The parser must reject.
+    let source = "
+        domain SysDomain
+          freq_mhz: 100
+        end domain SysDomain
+        module M
+          port clk:  in Clock<SysDomain>;
+          port rst:  in Reset<Async, Low>;
+          port in_a: in UInt<1>;
+          port reg out_x: out UInt<1> reset rst => 1'd0 comb_dep_on(in_a);
+        end module M
+    ";
+    let tokens = lexer::tokenize(source).expect("lexer");
+    let mut parser = Parser::new(tokens, source);
+    let err = parser.parse_source_file()
+        .expect_err("must reject comb_dep_on on registered output");
+    let msg = format!("{:?}", err);
+    assert!(msg.contains("comb_dep_on") && msg.contains("registered"),
+        "error should mention comb_dep_on + registered; got: {}", msg);
+}
+
+#[test]
+fn test_archi_comb_dep_on_input_port_rejected_at_parse() {
+    // `comb_dep_on(...)` is only legal on output ports.
+    let source = "
+        module M
+          port in_a: in UInt<1> comb_dep_on(in_a);
+        end module M
+    ";
+    let tokens = lexer::tokenize(source).expect("lexer");
+    let mut parser = Parser::new(tokens, source);
+    let err = parser.parse_source_file()
+        .expect_err("must reject comb_dep_on on input port");
+    let msg = format!("{:?}", err);
+    assert!(msg.contains("comb_dep_on"),
+        "error should mention comb_dep_on; got: {}", msg);
 }


### PR DESCRIPTION
## Summary

- Adds `port out X: ... comb_dep_on(in_a, in_b);` syntax for declaring precise per-output comb dependencies on `.archi` interface stubs.
- The whole-design comb-loop analyzer (#246) consumes the annotation to drop spurious cross-boundary edges, eliminating the over-approximation SCCs that opaque stubs produced.
- Three states: no annotation = opaque (backwards compat), `comb_dep_on()` = pure (no incoming comb edges), `comb_dep_on(a,b)` = precise.

## arch-ibex impact (regenerated `.archi`)

| | SCCs | total nodes |
| --- | --- | --- |
| before (main) | 4 | 165 (18 + 5 + 118 + 24) |
| after (this PR) | 2 | 22 (18 + 4) |

The 5-node `ibex_ex_block`, 118-node `ibex_core`, and 24-node `ibex_top` SCCs all disappear. The residual 18-node SCC is intra-`IbexIdStage` body and the 4-node SCC is intra-`IbexCore` body — both unrelated to `.archi` boundaries. Those are Phase 3 (per-output edges inside module bodies) territory.

arch-ibex `make test` stays 130 passed / 0 failed.

## Pieces

- `PortDecl::comb_deps: Option<Vec<Ident>>` (`src/ast.rs`).
- Parser accepts the clause after the type; rejects on input ports + registered outputs (`src/parser.rs`).
- `comb_graph::per_output_comb_deps` walks comb-block + let bodies, transitively closing through let/wire intermediates to compute output→input dep sets (`src/comb_graph.rs`).
- `interface::emit_module_interface` calls the helper and attaches `comb_dep_on(<sorted inputs>)` to every comb-driven output (`src/interface.rs`).
- `comb_graph::expand_inst` reads `child_mod.ports[*].comb_deps` and restricts cross-boundary edges accordingly; `None` → today's opaque fallback (`src/comb_graph.rs`).

## Test plan

- [x] `cargo test --release` 368 → 375 (7 new).
- [x] arch-ibex full SoC gate: `make build` succeeds, `make test` 130 passed / 0 failed.
- [x] SCC node count drops from 165 → 22 across arch-ibex `.archi` regen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)