### PR TITLE
comb_graph: per-output precision for fsm bodies (#246 Phase 4)

### DIFF
--- a/src/comb_graph.rs
+++ b/src/comb_graph.rs
@@ -220,6 +220,7 @@ fn port_sets(ports: &[PortDecl]) -> (HashSet<String>, HashSet<String>) {
 
 /// Compute CombInfo for an FSM declaration.
 fn comb_info_for_fsm(fsm: &FsmDecl) -> CombInfo {
+    use crate::ast::Direction;
     let (inputs, outputs) = port_sets(&fsm.ports);
     let mut driven = HashSet::new();
     let mut read   = HashSet::new();
@@ -232,6 +233,26 @@ fn comb_info_for_fsm(fsm: &FsmDecl) -> CombInfo {
         collect_expr_idents(&lb.value, &mut ids);
         for id in &ids {
             if inputs.contains(id) { read.insert(id.clone()); }
+        }
+    }
+
+    // Output port `default <expr>`: the FSM codegen emits this as the
+    // comb-block default before the state case, so an output WITH a
+    // default expression is comb-driven (even if no state assigns it),
+    // and identifier reads in the default expression are real comb
+    // deps. Issue #246 Phase 4.
+    for p in &fsm.ports {
+        if p.direction != Direction::Out { continue; }
+        if p.reg_info.is_some() { continue; }
+        if let Some(def_expr) = &p.default {
+            if outputs.contains(&p.name.name) {
+                driven.insert(p.name.name.clone());
+            }
+            let mut ids = HashSet::new();
+            collect_expr_idents(def_expr, &mut ids);
+            for id in &ids {
+                if inputs.contains(id) { read.insert(id.clone()); }
+            }
         }
     }
 
@@ -379,6 +400,153 @@ pub fn per_output_comb_deps(m: &ModuleDecl) -> HashMap<String, HashSet<String>> 
         out.insert(out_name.clone(), deps);
     }
     out
+}
+
+/// Per-output combinational dependencies for an FSM declaration.
+///
+/// Same shape and contract as [`per_output_comb_deps`] for modules, but
+/// the body walk covers FSM-shaped scopes:
+///   - `fsm.default_comb` (default block applied before the state case)
+///   - each `fsm.states[*].comb_stmts` (per-state comb assignments)
+///   - `fsm.lets` (FSM-scope `let` bindings)
+///   - each output port's `default <expr>` (the FSM codegen emits these
+///     as the comb-block default before the state case, so identifier
+///     reads in the default expression are real comb dependencies on
+///     that output).
+///
+/// Per-output union policy: any state that drives an output contributes
+/// to that output's dep set, and the port-default expression contributes
+/// too. State transitions read inputs but only affect `state_r` (a
+/// register), so they do NOT propagate into any output's comb deps.
+///
+/// Returns a map keyed by **output port name** (only — wire / let
+/// intermediates are not exposed). Used by `.archi` interface emit for
+/// FSMs (`interface::emit_fsm_interface`) and by `expand_inst` when the
+/// child symbol is a bodied `Symbol::Fsm`. Issue #246 Phase 4.
+pub fn per_output_comb_deps_fsm(fsm: &FsmDecl) -> HashMap<String, HashSet<String>> {
+    use crate::ast::Direction;
+
+    // 1. Identify input and output port names (clk/rst excluded — those
+    //    are seq-only).
+    let mut input_names: HashSet<String> = HashSet::new();
+    let mut output_names: HashSet<String> = HashSet::new();
+    for p in &fsm.ports {
+        if is_clk_or_rst(&p.ty) { continue; }
+        match p.direction {
+            Direction::In  => { input_names.insert(p.name.name.clone()); }
+            Direction::Out => {
+                if p.reg_info.is_none() {
+                    output_names.insert(p.name.name.clone());
+                }
+            }
+        }
+    }
+
+    // 2. Walk all comb-shaped sources building a direct-dep map.
+    //    LHS → set of RHS idents. Multiple assignments union (covers
+    //    per-state branches that drive the same output).
+    let mut direct: HashMap<String, HashSet<String>> = HashMap::new();
+
+    // 2a. FSM-scope let bindings.
+    for lb in &fsm.lets {
+        let mut ids = HashSet::new();
+        collect_expr_idents(&lb.value, &mut ids);
+        direct.entry(lb.name.name.clone())
+            .or_default()
+            .extend(ids);
+    }
+
+    // 2b. Output port defaults — emitted by `codegen::fsm` as the
+    //     comb-block default before the state case, so their identifier
+    //     reads ARE real comb deps for the output.
+    for p in &fsm.ports {
+        if p.direction != Direction::Out { continue; }
+        if p.reg_info.is_some() { continue; }
+        if let Some(def_expr) = &p.default {
+            let mut ids = HashSet::new();
+            collect_expr_idents(def_expr, &mut ids);
+            direct.entry(p.name.name.clone())
+                .or_default()
+                .extend(ids);
+        }
+    }
+
+    // 2c. default_comb.
+    collect_comb_deps(&fsm.default_comb, &mut direct, &mut Vec::new());
+
+    // 2d. Per-state comb_stmts. Transition conditions are excluded —
+    //     they feed `state_r` (a register), not any comb output.
+    for state in &fsm.states {
+        collect_comb_deps(&state.comb_stmts, &mut direct, &mut Vec::new());
+    }
+
+    // 3. Transitive closure from inputs to each output, restricted to
+    //    input port names. Same shape as `per_output_comb_deps`.
+    let mut out: HashMap<String, HashSet<String>> = HashMap::new();
+    for out_name in &output_names {
+        if !direct.contains_key(out_name) {
+            out.insert(out_name.clone(), HashSet::new());
+            continue;
+        }
+
+        let mut deps: HashSet<String> = HashSet::new();
+        let mut visited: HashSet<String> = HashSet::new();
+        let mut stack: Vec<String> = vec![out_name.clone()];
+        while let Some(cur) = stack.pop() {
+            if !visited.insert(cur.clone()) { continue; }
+            if let Some(rhs_ids) = direct.get(&cur) {
+                for id in rhs_ids {
+                    if input_names.contains(id) {
+                        deps.insert(id.clone());
+                    } else if direct.contains_key(id) {
+                        stack.push(id.clone());
+                    }
+                }
+            }
+        }
+        out.insert(out_name.clone(), deps);
+    }
+    out
+}
+
+/// Per-output comb-dep map for any bodied symbol (module / fsm) by name.
+/// Returns an empty map for unknown symbols and for symbol kinds without
+/// a body-shaped comb path (counter, arbiter, ram, ...). Issue #246
+/// Phase 4: shared dispatch between Phase 3 (`Module`) and Phase 4
+/// (`Fsm`) so the analyzer's per-symbol cache can store either via one
+/// uniform key.
+pub fn per_output_comb_deps_for_symbol(
+    sym_name: &str,
+    symbols: &SymbolTable,
+    source: &SourceFile,
+) -> HashMap<String, HashSet<String>> {
+    let sym = match symbols.globals.get(sym_name) {
+        Some((s, _)) => s,
+        None => return HashMap::new(),
+    };
+    match sym {
+        Symbol::Module(_) => {
+            for item in &source.items {
+                if let Item::Module(m) = item {
+                    if m.name.name == sym_name {
+                        return per_output_comb_deps(m);
+                    }
+                }
+            }
+            HashMap::new()
+        }
+        Symbol::Fsm(_) => {
+            for item in &source.items {
+                if let Item::Fsm(f) = item {
+                    if f.name.name == sym_name {
+                        return per_output_comb_deps_fsm(f);
+                    }
+                }
+            }
+            HashMap::new()
+        }
+        _ => HashMap::new(),
+    }
 }
 
 /// Helper for `per_output_comb_deps`: walk a list of comb statements,
@@ -864,6 +1032,17 @@ impl GraphBuilder {
         &self.per_output_cache[&m.name.name]
     }
 
+    /// FSM analog of `per_output_for`. Same memoization keyed by the
+    /// FSM's name (names are globally unique across symbol kinds, so
+    /// sharing `per_output_cache` is safe). Issue #246 Phase 4.
+    fn per_output_for_fsm(&mut self, f: &FsmDecl) -> &HashMap<String, HashSet<String>> {
+        if !self.per_output_cache.contains_key(&f.name.name) {
+            let map = per_output_comb_deps_fsm(f);
+            self.per_output_cache.insert(f.name.name.clone(), map);
+        }
+        &self.per_output_cache[&f.name.name]
+    }
+
     /// Recursively build the graph for `m` at the given instance path.
     fn expand_module(
         &mut self,
@@ -937,7 +1116,11 @@ impl GraphBuilder {
             p
         };
 
-        // Look up the child module (if any) and its CombInfo.
+        // Look up the child construct (module or FSM) by name. Both
+        // shapes expose ports + an `is_interface` flag and can carry
+        // per-output comb-dep precision; treat them uniformly below
+        // via `child_ports` / `child_is_interface`. Issue #246 Phase 4
+        // adds the FSM branch alongside the Phase 3 module branch.
         let child_mod: Option<&ModuleDecl> = source.items.iter().find_map(|it| {
             if let Item::Module(cm) = it {
                 if cm.name.name == inst.module_name.name {
@@ -946,6 +1129,24 @@ impl GraphBuilder {
             }
             None
         });
+        let child_fsm: Option<&FsmDecl> = if child_mod.is_some() {
+            None
+        } else {
+            source.items.iter().find_map(|it| {
+                if let Item::Fsm(cf) = it {
+                    if cf.name.name == inst.module_name.name {
+                        return Some(cf);
+                    }
+                }
+                None
+            })
+        };
+        let child_ports: Option<&[PortDecl]> = child_mod
+            .map(|cm| cm.ports.as_slice())
+            .or_else(|| child_fsm.map(|cf| cf.ports.as_slice()));
+        let child_is_interface: Option<bool> = child_mod
+            .map(|cm| cm.is_interface)
+            .or_else(|| child_fsm.map(|cf| cf.common.is_interface));
 
         // CombInfo for the sub-instance's construct (any kind).
         let info = comb_info_for_symbol(&inst.module_name.name, symbols, source);
@@ -965,23 +1166,37 @@ impl GraphBuilder {
             }
         }
 
-        // Recurse into the child if it is a regular module.
-        // Interface-only / opaque modules are treated as fully cross-connected
-        // (any output depends on any input) — that's already the shape of
-        // `comb_info_for_module` over interface stubs (empty body → empty
-        // CombInfo), so we explicitly OVERRIDE here to the conservative
-        // every-out-depends-on-every-in interpretation when the module is
-        // an interface stub OR is missing entirely (extern).
-        let treat_as_opaque = match child_mod {
-            None => true,
-            Some(cm) => cm.is_interface,
+        // Treat the child as opaque (every-out-depends-on-every-in,
+        // modulo any port-level `comb_dep_on(...)` annotations) when
+        // either: (1) we couldn't find a declaration for it at all
+        // (extern), or (2) the declaration we found is an interface
+        // stub (no body, no per-output dep info beyond port-level
+        // annotations). For a real bodied module or fsm, we have a
+        // walker that produces precise per-output deps. Issue #246
+        // Phase 3 = bodied module, Phase 4 = bodied fsm.
+        let treat_as_opaque = match child_is_interface {
+            None => true,            // extern — no decl found
+            Some(is_iface) => is_iface,
         };
 
+        // Track whether we actually recursed into a child body. The
+        // "link inner-node ↔ parent-wire" edges below only make sense
+        // when there ARE inner nodes (a Module body has comb-block and
+        // let-binding edges that connect inner ports; an FSM body
+        // currently doesn't get expanded into inner nodes — its per-
+        // output dep map already captures every cross-boundary edge).
+        let mut recursed_into_body = false;
         if let Some(cm) = child_mod {
             if !treat_as_opaque {
                 self.expand_module(cm, child_path.clone(), symbols, source);
+                recursed_into_body = true;
             }
         }
+        // FSMs are not recursively expanded into inner nodes; their
+        // per-output dep map fully captures cross-boundary edges and
+        // they have no sub-instances. Cycle detection at the parent
+        // level still fires via the direct in_sig → out_sig edges
+        // added below. Issue #246 Phase 4.
 
         // Add cross-boundary edges from sub-inst's CombInfo to parent signals.
         //
@@ -1000,8 +1215,8 @@ impl GraphBuilder {
         // filter applies in BOTH the opaque and non-opaque branches
         // (defensive: comb_info_for_module already excludes them, but make
         // the rule explicit so future regressions don't leak in).
-        let registered_outs: HashSet<&str> = child_mod
-            .map(|cm| cm.ports.iter()
+        let registered_outs: HashSet<&str> = child_ports
+            .map(|ports| ports.iter()
                 .filter(|p| p.reg_info.is_some())
                 .map(|p| p.name.name.as_str())
                 .collect())
@@ -1036,8 +1251,11 @@ impl GraphBuilder {
         //   degrades gracefully rather than silently dropping edges.
         let per_output_deps: HashMap<String, Option<HashSet<String>>> =
             if treat_as_opaque {
-                child_mod
-                    .map(|cm| cm.ports.iter()
+                // Opaque branch (extern stub or `is_interface` declaration):
+                // precision comes from port-level `comb_dep_on(...)`
+                // annotations. Works uniformly for module + fsm shapes.
+                child_ports
+                    .map(|ports| ports.iter()
                         .filter(|p| p.direction == crate::ast::Direction::Out
                                     && p.reg_info.is_none())
                         .map(|p| {
@@ -1049,6 +1267,7 @@ impl GraphBuilder {
                         .collect())
                     .unwrap_or_default()
             } else if let Some(cm) = child_mod {
+                // Bodied module — Phase 3.
                 let map = self.per_output_for(cm);
                 let mut out: HashMap<String, Option<HashSet<String>>> =
                     HashMap::with_capacity(map.len());
@@ -1060,6 +1279,19 @@ impl GraphBuilder {
                 // virtually never trigger given `per_output_comb_deps`'s
                 // current "always emit an entry per non-registered output"
                 // contract, but cheap to encode defensively.
+                for o in &info.comb_outputs {
+                    out.entry(o.clone()).or_insert(None);
+                }
+                out
+            } else if let Some(cf) = child_fsm {
+                // Bodied FSM — Phase 4. Same Option C fallback policy
+                // as the bodied-module branch.
+                let map = self.per_output_for_fsm(cf);
+                let mut out: HashMap<String, Option<HashSet<String>>> =
+                    HashMap::with_capacity(map.len());
+                for (k, v) in map {
+                    out.insert(k.clone(), Some(v.clone()));
+                }
                 for o in &info.comb_outputs {
                     out.entry(o.clone()).or_insert(None);
                 }
@@ -1100,7 +1332,7 @@ impl GraphBuilder {
             // Also: if we DID recurse, link the deeper inst-internal output port
             // node to the parent-side wire so cycles that close via the
             // hierarchy show the full path. We add edge child.q → parent.out_sig.
-            if !treat_as_opaque {
+            if recursed_into_body {
                 let child_q = self.intern(NodeKey { path: child_path.clone(), signal: (*out_port).clone() });
                 self.add_edge(child_q, to);
             }
@@ -1132,7 +1364,7 @@ impl GraphBuilder {
 
                 // And, if we recursed, also link parent.in_sig → child.in_port
                 // so the cycle path display shows the descent.
-                if !treat_as_opaque {
+                if recursed_into_body {
                     let child_p = self.intern(NodeKey { path: child_path.clone(), signal: (*in_port).clone() });
                     self.add_edge(from, child_p);
                 }

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -40,7 +40,13 @@ pub(crate) fn emit_fsm_interface(f: &FsmDecl) -> String {
     let name = &f.name.name;
     let mut s = format!("fsm {name}\n");
     emit_params(&mut s, &f.params);
-    emit_ports(&mut s, &f.ports);
+    // Compute precise per-output comb-dep sets from the FSM body so
+    // the .archi reflects the actual dataflow shape (issue #246 Phase 4,
+    // mirror of the module path in `emit_module_interface`). The
+    // opaque "every comb input feeds every comb output" over-
+    // approximation is avoided as long as the fsm has a body.
+    let deps = crate::comb_graph::per_output_comb_deps_fsm(f);
+    emit_ports_with_deps(&mut s, &f.ports, Some(&deps));
     s.push_str(&format!("end fsm {name}\n"));
     s
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -12630,3 +12630,344 @@ fn test_comb_loop_bodied_per_output_cache_handles_repeated_insts() {
         "per-output precision must hold across 3 cross-wired insts; got: {:?}",
         cycle_msgs);
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Issue #246 Phase 4: per-output comb-dep precision for `fsm` bodies.
+// Phase 2 (PR #338) added the precision for `module` body emit + .archi parse
+// of `comb_dep_on(...)`. Phase 3 (PR #339) wired the bodied-module branch of
+// the whole-design analyzer to consume the same per-output map. Phase 4
+// extends both pieces to FSMs (bodied + .archi emit) so an FSM child no
+// longer collapses to the aggregate-every-out-feeds-every-in shape that
+// was closing arch-ibex's residual `ibex_id_stage` SCC through the
+// `ibex_controller` fsm.
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_comb_loop_fsm_per_output_precision_eliminates_false_positive() {
+    // FSM with two independent comb paths: out_a depends only on in_x;
+    // out_b depends only on in_y. Aggregate-only analysis would close a
+    // phantom cycle through `w1 → w2 → w1` because every out is treated
+    // as depending on every in. Per-output FSM precision must eliminate
+    // it.
+    let source = r#"
+        fsm Cell
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync>;
+          port in_x: in  UInt<1>;
+          port in_y: in  UInt<1>;
+          port out_a: out UInt<1> default 1'd0;
+          port out_b: out UInt<1> default 1'd0;
+          state [S0]
+          default state S0;
+          state S0
+            comb
+              out_a = in_x;
+              out_b = in_y;
+            end comb
+            -> S0 when true;
+          end state S0
+        end fsm Cell
+
+        module Top
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync>;
+          port a: in UInt<1>;
+          port q: out UInt<1>;
+          wire w1: UInt<1>;
+          wire w2: UInt<1>;
+          wire dead1: UInt<1>;
+          wire dead2: UInt<1>;
+
+          inst u1: Cell
+            clk   <- clk;
+            rst   <- rst;
+            in_x  <- a;
+            in_y  <- w2;
+            out_a -> w1;
+            out_b -> dead1;
+          end inst u1
+
+          inst u2: Cell
+            clk   <- clk;
+            rst   <- rst;
+            in_x  <- w1;
+            in_y  <- a;
+            out_a -> dead2;
+            out_b -> w2;
+          end inst u2
+
+          comb
+            q = w1;
+          end comb
+        end module Top
+    "#;
+    let ws = comb_loop_warnings(source);
+    let cycle_msgs: Vec<_> = ws.iter()
+        .filter(|m| m.contains("combinational feedback cycle ("))
+        .collect();
+    assert!(cycle_msgs.is_empty(),
+        "fsm per-output precision must eliminate the aggregate-only \
+         phantom cycle; got: {:?}", cycle_msgs);
+}
+
+#[test]
+fn test_comb_loop_fsm_real_cycle_still_detected() {
+    // Same shape, but now out_b genuinely reads in_x too — the real
+    // cycle u1.out_b (← in_y = w2) and u2.out_b (← in_x = w1, in_y = a)
+    // closes w1 → w2 → w1 via u2.out_b's true dep on in_x.
+    let source = r#"
+        fsm Cell
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync>;
+          port in_x: in  UInt<1>;
+          port in_y: in  UInt<1>;
+          port out_a: out UInt<1> default 1'd0;
+          port out_b: out UInt<1> default 1'd0;
+          state [S0]
+          default state S0;
+          state S0
+            comb
+              out_a = in_x;
+              out_b = in_x or in_y;
+            end comb
+            -> S0 when true;
+          end state S0
+        end fsm Cell
+
+        module Top
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync>;
+          port a: in UInt<1>;
+          port q: out UInt<1>;
+          wire w1: UInt<1>;
+          wire w2: UInt<1>;
+          wire dead1: UInt<1>;
+          wire dead2: UInt<1>;
+
+          inst u1: Cell
+            clk   <- clk;
+            rst   <- rst;
+            in_x  <- w2;
+            in_y  <- a;
+            out_a -> w1;
+            out_b -> dead1;
+          end inst u1
+
+          inst u2: Cell
+            clk   <- clk;
+            rst   <- rst;
+            in_x  <- w1;
+            in_y  <- a;
+            out_a -> dead2;
+            out_b -> w2;
+          end inst u2
+
+          comb
+            q = w1;
+          end comb
+        end module Top
+    "#;
+    let ws = comb_loop_warnings(source);
+    let cycle_msgs: Vec<_> = ws.iter()
+        .filter(|m| m.contains("combinational feedback cycle ("))
+        .collect();
+    assert!(!cycle_msgs.is_empty(),
+        "real cycle (u1.out_a ← w2; u2.out_b ← w1) through fsm \
+         must still fire; warnings: {:?}", ws);
+}
+
+#[test]
+fn test_archi_fsm_emit_includes_comb_dep_on() {
+    // Compile a small FSM body and assert `.archi` carries per-output
+    // `comb_dep_on(...)` annotations (mirror of the module emit path).
+    let source = r#"
+        fsm M
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync>;
+          port a: in  UInt<8>;
+          port b: in  UInt<8>;
+          port x: out UInt<8> default 8'd0;
+          port y: out UInt<8> default 8'd0;
+          port z: out UInt<8> default 8'd0;
+          state [S0]
+          default state S0;
+          state S0
+            comb
+              x = a;
+              y = a + b;
+              z = 8'd0;
+            end comb
+            -> S0 when true;
+          end state S0
+        end fsm M
+    "#;
+    let tokens = lexer::tokenize(source).expect("lexer");
+    let mut parser = Parser::new(tokens, source);
+    let parsed = parser.parse_source_file().expect("parse");
+    let item = parsed.items.iter()
+        .find(|i| matches!(i, arch::ast::Item::Fsm(_)))
+        .expect("fsm");
+    let body = arch::interface::emit_interface(item).expect("emit_interface");
+    assert!(body.contains("port x: out UInt<8> comb_dep_on(a);"),
+        "x must depend only on a: {body}");
+    assert!(body.contains("port y: out UInt<8> comb_dep_on(a, b);"),
+        "y must depend on a and b: {body}");
+    assert!(body.contains("port z: out UInt<8> comb_dep_on();"),
+        "z is pure (constant): {body}");
+}
+
+#[test]
+fn test_comb_loop_fsm_default_comb_deps_included() {
+    // `default_comb` is applied before the state case (the FSM codegen
+    // emits it as part of the comb block). Any input reads in
+    // `default_comb` must contribute to per-output deps.
+    //
+    // Here out_a's only assignment is in `default_comb`, sourced from
+    // in_z. A cross-wire from out_a → another inst's in_y_other_inst
+    // does NOT close a cycle (out_a doesn't read in_y). But a cross-
+    // wire through in_z DOES — exercise the legitimate path.
+    let source = r#"
+        fsm Cell
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync>;
+          port in_y: in  UInt<1>;
+          port in_z: in  UInt<1>;
+          port out_a: out UInt<1> default 1'd0;
+          default
+            comb
+              out_a = in_z;
+            end comb
+          end default
+          state [S0]
+          default state S0;
+          state S0
+            -> S0 when true;
+          end state S0
+        end fsm Cell
+
+        module Top
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync>;
+          port a: in UInt<1>;
+          port q: out UInt<1>;
+          wire w1: UInt<1>;
+
+          inst u1: Cell
+            clk   <- clk;
+            rst   <- rst;
+            in_y  <- a;
+            in_z  <- w1;
+            out_a -> w1;
+          end inst u1
+
+          comb
+            q = w1;
+          end comb
+        end module Top
+    "#;
+    // The cross-wire w1 → in_z → out_a → w1 is a legitimate cycle.
+    // Per-output FSM walker must include in_z in out_a's dep set.
+    let ws = comb_loop_warnings(source);
+    let cycle_msgs: Vec<_> = ws.iter()
+        .filter(|m| m.contains("combinational feedback cycle ("))
+        .collect();
+    assert!(!cycle_msgs.is_empty(),
+        "default_comb reads in_z driving out_a; w1 → in_z → out_a → w1 \
+         must fire as a comb cycle; warnings: {:?}", ws);
+}
+
+#[test]
+fn test_comb_loop_fsm_output_default_expr_deps_included() {
+    // FSM output port default expression (`default in_x + in_y`) is
+    // emitted by the FSM codegen as the comb-block default before the
+    // state case. Identifier reads in the default expression are real
+    // comb deps for that output and must appear in the per-output map.
+    //
+    // Here out_a's value is the default expression `in_x + in_y` (and
+    // S0 has no per-state assignment to out_a). Wire w1 → in_y → out_a
+    // → w1 must close as a real cycle.
+    let source = r#"
+        fsm Cell
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync>;
+          port in_x: in  UInt<1>;
+          port in_y: in  UInt<1>;
+          port out_a: out UInt<1> default in_x or in_y;
+          state [S0]
+          default state S0;
+          state S0
+            -> S0 when true;
+          end state S0
+        end fsm Cell
+
+        module Top
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync>;
+          port a: in UInt<1>;
+          port q: out UInt<1>;
+          wire w1: UInt<1>;
+
+          inst u1: Cell
+            clk   <- clk;
+            rst   <- rst;
+            in_x  <- a;
+            in_y  <- w1;
+            out_a -> w1;
+          end inst u1
+
+          comb
+            q = w1;
+          end comb
+        end module Top
+    "#;
+    let ws = comb_loop_warnings(source);
+    let cycle_msgs: Vec<_> = ws.iter()
+        .filter(|m| m.contains("combinational feedback cycle ("))
+        .collect();
+    assert!(!cycle_msgs.is_empty(),
+        "out_a's default expression reads in_y; w1 → in_y → out_a → w1 \
+         must fire as a comb cycle; warnings: {:?}", ws);
+
+    // And the dual: with cross-wire through in_a (NOT a dep), no cycle.
+    let source2 = r#"
+        fsm Cell
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync>;
+          port in_x: in  UInt<1>;
+          port in_y: in  UInt<1>;
+          port out_a: out UInt<1> default in_x;
+          state [S0]
+          default state S0;
+          state S0
+            -> S0 when true;
+          end state S0
+        end fsm Cell
+
+        module Top
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync>;
+          port a: in UInt<1>;
+          port q: out UInt<1>;
+          wire w1: UInt<1>;
+
+          inst u1: Cell
+            clk   <- clk;
+            rst   <- rst;
+            in_x  <- a;
+            in_y  <- w1;
+            out_a -> w1;
+          end inst u1
+
+          comb
+            q = w1;
+          end comb
+        end module Top
+    "#;
+    let ws2 = comb_loop_warnings(source2);
+    let cycle_msgs2: Vec<_> = ws2.iter()
+        .filter(|m| m.contains("combinational feedback cycle ("))
+        .collect();
+    assert!(cycle_msgs2.is_empty(),
+        "out_a's default reads only in_x; w1 → in_y is NOT a dep, \
+         so no cycle should fire; got: {:?}", cycle_msgs2);
+}


### PR DESCRIPTION
## Summary

- Adds `per_output_comb_deps_fsm` and a `_for_symbol` dispatcher; extends `expand_inst` and `emit_fsm_interface` to consume the precise per-output map.
- Mirror of #338 (module .archi emit) + #339 (bodied-module analyzer) for `fsm` declarations.
- Eliminates the residual 18-node `ibex_id_stage` SCC that closed through the `ibex_controller` FSM by aggregate-every-out-feeds-every-in over-approximation.

## What changed

`src/comb_graph.rs`:
- New `per_output_comb_deps_fsm(&FsmDecl)` walks `fsm.lets`, output port `default <expr>`, `default_comb`, and per-state `comb_stmts`. Returns the same shape as `per_output_comb_deps`.
- New `per_output_comb_deps_for_symbol(name, ...)` dispatcher.
- New `GraphBuilder::per_output_for_fsm` memoized accessor (shared cache key with the module accessor; names are globally unique).
- `expand_inst` looks up an FSM child alongside the module child, exposes uniform `child_ports` / `child_is_interface` views, adds a bodied-FSM precision branch.
- `comb_info_for_fsm` (aggregate) now also accounts for output-port `default <expr>` reads + drives — was missed and would otherwise hide the new Phase 4 edges.

`src/interface.rs`:
- `emit_fsm_interface` now calls `emit_ports_with_deps` with the per-output map.

`tests/integration_test.rs`: +5 FSM-specific tests covering false-positive elimination, real-cycle detection, .archi annotation emission, `default_comb` dep inclusion, and output-port-default-expression dep inclusion.

## Test plan

- [x] `cargo test --release`: 379 → 384 (+5), 0 failed.
- [x] arch-ibex `rm -rf build/ && make build`: residual `ibex_id_stage` SCC goes from 18 nodes to 0; companion PR drops `pragma comb_loops_allowed;` from `IbexIdStage.arch`.
- [x] arch-ibex `make test`: 130 passed, 75 skipped (unchanged from baseline).
- [x] `ibex_core` 4-node SCC (closing through opaque hand-authored `ibex_cs_registers.archi`) remains — intentionally not annotated by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)