### PR TITLE
[codex] Fix RAM type param SV lowering

### DIFF
--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -264,14 +264,21 @@ impl<'a> Codegen<'a> {
             return format!(".{}({})", pa.name.name, self.emit_expr_str(&pa.value));
         };
         let width = self.type_expr_data_width(te).unwrap_or_else(|| "0".to_string());
-        // Map T → DATA_WIDTH for fifo children.
+        // Map T → DATA_WIDTH for constructs that erase type params into a
+        // synthesized packed payload width.
         let is_fifo_type_param = self.source.items.iter().any(|it| match it {
             Item::Fifo(f) if f.name.name == child => f.params.iter().any(|p|
                 p.name.name == pa.name.name
                 && matches!(p.kind, crate::ast::ParamKind::Type(_))),
             _ => false,
         });
-        if is_fifo_type_param {
+        let is_ram_type_param = self.source.items.iter().any(|it| match it {
+            Item::Ram(r) if r.name.name == child => r.params.iter().any(|p|
+                p.name.name == pa.name.name
+                && matches!(p.kind, crate::ast::ParamKind::Type(_))),
+            _ => false,
+        });
+        if is_fifo_type_param || is_ram_type_param {
             format!(".DATA_WIDTH({width})")
         } else {
             format!(".{}({width})", pa.name.name)

--- a/src/codegen/ram.rs
+++ b/src/codegen/ram.rs
@@ -9,6 +9,24 @@ use super::*;
 impl<'a> Codegen<'a> {
     pub(crate) fn emit_ram(&mut self, r: &RamDecl) {
         use crate::ast::{RamKind, RamInit};
+        use std::collections::HashMap;
+
+        let type_params: HashMap<String, TypeExpr> = r.params.iter()
+            .filter_map(|p| match &p.kind {
+                crate::ast::ParamKind::Type(ty) => Some((p.name.name.clone(), ty.clone())),
+                _ => None,
+            })
+            .collect();
+
+        let resolve_type_param = |ty: TypeExpr| -> TypeExpr {
+            match ty {
+                TypeExpr::Named(ident) => type_params
+                    .get(&ident.name)
+                    .cloned()
+                    .unwrap_or(TypeExpr::Named(ident)),
+                other => other,
+            }
+        };
 
         // Resolve DATA_WIDTH. Three sources, in priority order:
         //   1. `param WIDTH: type = T` — legacy explicit element type.
@@ -18,13 +36,15 @@ impl<'a> Codegen<'a> {
         //   3. Fallback to `[7:0]` / "8" so legacy ram declarations
         //      that omit both still emit something compilable.
         let store_elem_ty: Option<TypeExpr> = r.store_vars.first().and_then(|sv| match &sv.ty {
-            TypeExpr::Vec(elem, _) => Some((**elem).clone()),
+            TypeExpr::Vec(elem, _) => Some(resolve_type_param((**elem).clone())),
             _ => None,
         });
         let data_width_ty = r.params.iter()
             .find(|p| p.name.name == "WIDTH")
             .and_then(|p| match &p.kind {
-                crate::ast::ParamKind::Type(ty) => Some(self.emit_port_type_str(ty)),
+                crate::ast::ParamKind::Type(ty) => {
+                    Some(self.emit_port_type_str(&resolve_type_param(ty.clone())))
+                }
                 _ => None,
             })
             .or_else(|| store_elem_ty.as_ref().map(|ty| self.emit_port_type_str(ty)))
@@ -34,7 +54,9 @@ impl<'a> Codegen<'a> {
         let data_width_num = r.params.iter()
             .find(|p| p.name.name == "WIDTH")
             .and_then(|p| match &p.kind {
-                crate::ast::ParamKind::Type(ty) => self.type_expr_data_width(ty),
+                crate::ast::ParamKind::Type(ty) => {
+                    self.type_expr_data_width(&resolve_type_param(ty.clone()))
+                }
                 _ => None,
             })
             .or_else(|| store_elem_ty.as_ref().and_then(|ty| self.type_expr_data_width(ty)))
@@ -109,7 +131,7 @@ impl<'a> Codegen<'a> {
         for pg in &r.port_groups {
             for s in &pg.signals {
                 let dir = match s.direction { Direction::In => "input", Direction::Out => "output" };
-                let ty_str = self.emit_ram_signal_type(&s.ty);
+                let ty_str = self.emit_ram_signal_type(&s.ty, &type_params);
                 all_ports.push(format!("{dir} {ty_str} {}_{}", pg.name.name, s.name.name));
             }
         }
@@ -195,9 +217,12 @@ impl<'a> Codegen<'a> {
 
     // ── Counter ───────────────────────────────────────────────────────────────
 
-    fn emit_ram_signal_type(&self, ty: &TypeExpr) -> String {
+    fn emit_ram_signal_type(&self, ty: &TypeExpr, type_params: &std::collections::HashMap<String, TypeExpr>) -> String {
         match ty {
             TypeExpr::Named(ident) if ident.name == "WIDTH" => {
+                "logic [DATA_WIDTH-1:0]".to_string()
+            }
+            TypeExpr::Named(ident) if type_params.contains_key(&ident.name) => {
                 "logic [DATA_WIDTH-1:0]".to_string()
             }
             other => self.emit_port_type_str(other),

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -346,6 +346,41 @@ fn test_rom_lut() {
 }
 
 #[test]
+fn test_rom_lut_type_param_ports_lower_to_data_width() {
+    let source = r#"
+domain CoreDomain
+  freq_mhz: 100
+end domain CoreDomain
+
+ram TypedRom
+  kind rom;
+  latency 1;
+  init: [0x00000000, 0x00000001, 0x00000002, 0x00000003];
+
+  param DEPTH: const = 4;
+  param T: type = UInt<32>;
+
+  port clk: in Clock<CoreDomain>;
+
+  store
+    data: Vec<T, DEPTH>;
+  end store
+
+  ports rd
+    addr: in UInt<2>;
+    en:   in Bool;
+    data: out T;
+  end ports rd
+end ram TypedRom
+"#;
+    let sv = compile_to_sv(source);
+    assert!(sv.contains("parameter int DATA_WIDTH = 32"));
+    assert!(sv.contains("output logic [DATA_WIDTH-1:0] rd_data"));
+    assert!(sv.contains("logic [DATA_WIDTH-1:0] mem [0:DEPTH-1]"));
+    assert!(!sv.contains("output T rd_data"));
+}
+
+#[test]
 fn test_simple_dual_ram() {
     let source = include_str!("../examples/simple_dual_ram.arch");
     let sv = compile_to_sv(source);

--- a/tests/snapshots/integration_test__simple_dual_ram.snap
+++ b/tests/snapshots/integration_test__simple_dual_ram.snap
@@ -12,10 +12,10 @@ module DualMem #(
   input logic clk,
   input logic rd_port_en,
   input logic [6:0] rd_port_addr,
-  output T rd_port_data,
+  output logic [DATA_WIDTH-1:0] rd_port_data,
   input logic wr_port_en,
   input logic [6:0] wr_port_addr,
-  input T wr_port_data
+  input logic [DATA_WIDTH-1:0] wr_port_data
 );
 
   logic [DATA_WIDTH-1:0] mem [0:DEPTH-1];

--- a/tests/snapshots/integration_test__single_port_ram.snap
+++ b/tests/snapshots/integration_test__single_port_ram.snap
@@ -13,8 +13,8 @@ module SimpleMem #(
   input logic access_en,
   input logic access_wen,
   input logic [7:0] access_addr,
-  input T access_wdata,
-  output T access_rdata
+  input logic [DATA_WIDTH-1:0] access_wdata,
+  output logic [DATA_WIDTH-1:0] access_rdata
 );
 
   logic [DATA_WIDTH-1:0] mem [0:DEPTH-1];


### PR DESCRIPTION
## Summary

Fix RAM/ROM SystemVerilog codegen when a RAM uses a type parameter for its store element and grouped port payloads, for example:

```arch
param T: type = UInt<32>;
store
  data: Vec<T, DEPTH>;
end store
ports rd
  data: out T;
end ports rd
```

Previously `arch check` accepted this shape, but `arch build` could emit invalid SV such as `output T rd_data` and default `DATA_WIDTH = 8`. Verilator then treated `T` like an unresolved interface name.

## Changes

- Resolve RAM type parameters before computing the synthesized `DATA_WIDTH`.
- Lower RAM grouped port signals that reference a type parameter to `logic [DATA_WIDTH-1:0]`.
- Map RAM inst-site type parameter overrides to `.DATA_WIDTH(...)`, matching the existing FIFO convention.
- Add a ROM regression test that covers `Vec<T, DEPTH>` plus `data: out T`.
- Update existing RAM snapshots now that raw `T` no longer leaks into emitted SV ports.

## Validation

- `cargo test --test integration_test ram -- --nocapture`
- `cargo test`
- `git diff --check`

Note: `cargo fmt --check` currently reports broad pre-existing formatting differences across the repo, so this PR leaves formatting untouched outside the functional patch.
