### PR TITLE
Emit Tier-2 protocol SVA for arbiter handshake_channel ports

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -139,6 +139,14 @@ pub struct HandshakeMeta {
     /// for documentation in generated SV comments — directions/types are
     /// already materialized as PortDecls in BusDecl::signals.
     pub payload_names: Vec<Ident>,
+    /// When this `handshake_channel` was declared inside a *construct*
+    /// (arbiter today) port list with an explicit `[N]` array shape, the
+    /// count expression that drives the SV generate-for vectorization.
+    /// `None` for the bus-body path (which has no array shape) and for
+    /// non-array channels inside an arbiter port list. Codegen wraps SVA
+    /// in `generate for (genvar i ...) ... end endgenerate` when this is
+    /// `Some(...)` and emits the bare property otherwise.
+    pub array_count: Option<Expr>,
     pub span: Span,
 }
 
@@ -1762,6 +1770,16 @@ pub struct ArbiterDecl {
     pub policy: ArbiterPolicy,
     pub hook: Option<ArbiterHookDecl>,
     pub latency: u32,
+    /// Metadata for each `handshake_channel` declared in this arbiter's
+    /// port list. Parallels `BusDecl::handshakes`: the underlying valid /
+    /// ready / payload signals already live in `common.ports` (non-array
+    /// channels) or `port_arrays` (channels with an `[N]` shape); this
+    /// list preserves the grouping so codegen can emit Tier-2 SVA
+    /// protocol assertions, wrapped in `generate for` blocks for the
+    /// array form. Populated by `parse_arbiter`; empty for arbiters
+    /// declared with the pre-PR#343 hand-rolled `port` / `ports[N]`
+    /// shape.
+    pub handshakes: Vec<HandshakeMeta>,
 }
 impl std::ops::Deref for ArbiterDecl {
     type Target = ConstructCommon;

--- a/src/codegen/arbiter.rs
+++ b/src/codegen/arbiter.rs
@@ -205,6 +205,15 @@ impl<'a> Codegen<'a> {
             self.emit_asserts_for_construct(&asserts, &aname, &clk);
         }
 
+        // Tier-2 protocol SVA for any `handshake_channel` declared in the
+        // arbiter's port list. Skips silently when the arbiter was
+        // declared with the pre-PR#343 hand-rolled `port` / `ports[N]`
+        // shape (which carries no HandshakeMeta), preserving today's
+        // emission byte-for-byte for those arbiters. The blank-line
+        // separator lives inside the emitter so it is also elided when
+        // every channel's variant has no Tier-2 v1 property to emit.
+        self.emit_arbiter_handshake_asserts(a);
+
         self.indent -= 1;
         self.line("");
         self.line("endmodule");

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -2473,48 +2473,176 @@ impl<'a> Codegen<'a> {
                 TypeExpr::Reset(_, ResetLevel::Low) => format!("!{}", p.name.name),
                 _ => p.name.name.clone(),
             });
-        let disable = rst_active.as_ref()
-            .map(|r| format!(" disable iff ({r})"))
-            .unwrap_or_default();
 
         self.line("// synopsys translate_off");
         self.line("// Auto-generated handshake protocol assertions (Tier 2)");
+        let mod_name = m.name.name.clone();
         for (port_name, hs) in &emissions {
-            let ch = &hs.name.name;
-            let variant = hs.variant.name.as_str();
-            let sig = |s: &str| format!("{}_{}_{}", port_name, ch, s);
-            let mod_name = &m.name.name;
-            let emit_property = |cg: &mut Codegen, rule: &str, predicate: String, message: &str| {
-                let label = format!("_auto_hs_{}_{}_{}", port_name, ch, rule);
-                cg.line(&format!(
-                    "{label}: assert property (@(posedge {clk}){disable} {predicate})"
+            let label_stem = format!("{}_{}", port_name, hs.name.name);
+            let sig_prefix = format!("{}_{}", port_name, hs.name.name);
+            self.emit_handshake_channel_asserts(
+                &hs,
+                &clk,
+                rst_active.as_deref(),
+                &sig_prefix,
+                &label_stem,
+                &mod_name,
+            );
+        }
+        self.line("// synopsys translate_on");
+    }
+
+    /// Construct-agnostic helper: emit Tier-2 protocol-SVA for a single
+    /// `handshake_channel`. Shared between the bus-port path
+    /// (`emit_handshake_asserts`) and the arbiter port-list path
+    /// (`emit_arbiter_handshake_asserts`).
+    ///
+    /// Parameters:
+    /// - `hs`        — channel metadata (variant, name, array shape).
+    /// - `clk`       — already-resolved clock signal name (no edge keyword).
+    /// - `rst_active`— already-resolved active-level reset expression
+    ///                 (e.g. `rst` or `!rst_n`); `None` skips `disable iff`.
+    /// - `sig_prefix`— prefix for the per-variant control signals; the
+    ///                 helper appends `_valid`/`_ready`/etc. For the bus
+    ///                 path this is `<port>_<chname>`; for arbiters it is
+    ///                 just `<chname>` (signals are top-level).
+    /// - `label_stem`— middle of `_auto_hs_<stem>_<rule>` for SV labels.
+    ///                 Bus-path stem is `<port>_<chname>`; arbiter is
+    ///                 `<chname>` (plus a per-lane suffix when arrayed).
+    /// - `mod_name`  — enclosing construct name for the `$fatal` message.
+    ///
+    /// When `hs.array_count` is `Some(expr)`, the property is wrapped in
+    /// an SV `generate for (genvar i = 0; i < <expr>; i++) ... end
+    /// endgenerate` block and signal references are indexed with `[i]`,
+    /// so the assertion fires once per request lane. The bus path never
+    /// sets `array_count`, so the bare-signal form is preserved
+    /// byte-for-byte with prior emission.
+    fn emit_handshake_channel_asserts(
+        &mut self,
+        hs: &crate::ast::HandshakeMeta,
+        clk: &str,
+        rst_active: Option<&str>,
+        sig_prefix: &str,
+        label_stem: &str,
+        mod_name: &str,
+    ) {
+        let variant = hs.variant.name.as_str();
+        let disable = rst_active
+            .map(|r| format!(" disable iff ({r})"))
+            .unwrap_or_default();
+
+        // Vector channels (arbiter `handshake_channel name[N]: ...`) get a
+        // genvar-indexed wrapper. The bus-body path always passes
+        // `array_count = None`, so this branch is dead for buses and the
+        // emitted SV is byte-identical to pre-refactor behaviour.
+        let (open_gen, close_gen, idx, lane_label_suffix) = match &hs.array_count {
+            Some(count_expr) => {
+                let count_str = self.emit_expr_str(count_expr);
+                self.line(&format!(
+                    "generate for (genvar i = 0; i < {count_str}; i++) begin: g_auto_hs_{label_stem}"
                 ));
-                cg.line(&format!(
-                    "  else $fatal(1, \"HANDSHAKE VIOLATION ({message}): {mod_name}.{label}\");"
-                ));
-            };
-            match variant {
-                "valid_ready" => {
-                    let v = sig("valid"); let r = sig("ready");
-                    emit_property(self, "valid_stable",
-                        format!("({v} && !{r}) |=> {v}"),
-                        "valid must stay asserted until ready");
-                }
-                "valid_stall" => {
-                    let v = sig("valid"); let s = sig("stall");
-                    emit_property(self, "valid_stable_while_stall",
-                        format!("({v} && {s}) |=> {v}"),
-                        "valid must not change while stalled");
-                }
-                "req_ack_4phase" => {
-                    let rq = sig("req"); let ak = sig("ack");
-                    emit_property(self, "req_holds_until_ack",
-                        format!("({rq} && !{ak}) |=> {rq}"),
-                        "req must stay asserted until ack");
-                }
-                // Variants with no Tier-2 v1 property are silently skipped.
-                _ => {}
+                self.indent += 1;
+                ("", "", "[i]", "__lane")
             }
+            None => ("", "", "", ""),
+        };
+        let _ = (open_gen, close_gen); // generate-for header already emitted
+
+        let sig = |s: &str| format!("{}_{}{}", sig_prefix, s, idx);
+        let mk_label = |rule: &str| {
+            format!("_auto_hs_{}{}_{}", label_stem, lane_label_suffix, rule)
+        };
+        let emit_property = |cg: &mut Codegen, rule: &str, predicate: String, message: &str| {
+            let label = mk_label(rule);
+            cg.line(&format!(
+                "{label}: assert property (@(posedge {clk}){disable} {predicate})"
+            ));
+            cg.line(&format!(
+                "  else $fatal(1, \"HANDSHAKE VIOLATION ({message}): {mod_name}.{label}\");"
+            ));
+        };
+        match variant {
+            "valid_ready" => {
+                let v = sig("valid"); let r = sig("ready");
+                emit_property(self, "valid_stable",
+                    format!("({v} && !{r}) |=> {v}"),
+                    "valid must stay asserted until ready");
+            }
+            "valid_stall" => {
+                let v = sig("valid"); let s = sig("stall");
+                emit_property(self, "valid_stable_while_stall",
+                    format!("({v} && {s}) |=> {v}"),
+                    "valid must not change while stalled");
+            }
+            "req_ack_4phase" => {
+                let rq = sig("req"); let ak = sig("ack");
+                emit_property(self, "req_holds_until_ack",
+                    format!("({rq} && !{ak}) |=> {rq}"),
+                    "req must stay asserted until ack");
+            }
+            // Variants with no Tier-2 v1 property are silently skipped.
+            _ => {}
+        }
+
+        if hs.array_count.is_some() {
+            self.indent -= 1;
+            self.line("end endgenerate");
+        }
+    }
+
+    /// Tier 2 of the handshake primitive for `arbiter` constructs: for
+    /// every `handshake_channel` declared in the arbiter's port list,
+    /// emit the same per-variant SVA the bus path emits, wrapped in
+    /// `generate for` blocks when the channel has an explicit `[N]`
+    /// array shape (the typical `request[NUM_REQ]` case).
+    ///
+    /// PR #343 desugars `handshake_channel` to underlying valid/ready/
+    /// payload ports — the same Tier-2 property templates apply, only
+    /// the signal-name convention differs: top-level `<chname>_<sig>`
+    /// (or array-element `<chname>_<sig>[i]`) instead of bus-port
+    /// `<port>_<chname>_<sig>`. Labels follow `_auto_hs_<chname>_<rule>`
+    /// (with `__lane` appended inside generate blocks).
+    pub(crate) fn emit_arbiter_handshake_asserts(&mut self, a: &crate::ast::ArbiterDecl) {
+        if a.handshakes.is_empty() { return; }
+
+        // Pick clock/reset the same way emit_arbiter does.
+        let clk = a.ports.iter()
+            .find(|p| matches!(&p.ty, TypeExpr::Clock(_)))
+            .map(|p| p.name.name.clone());
+        let Some(clk) = clk else { return; };
+        let rst_active = a.ports.iter()
+            .find(|p| matches!(&p.ty, TypeExpr::Reset(_, _)))
+            .map(|p| match &p.ty {
+                TypeExpr::Reset(_, ResetLevel::Low) => format!("!{}", p.name.name),
+                _ => p.name.name.clone(),
+            });
+
+        // Filter to variants the shared helper actually emits property
+        // text for, so we don't emit a translate-off block whose body is
+        // empty (matches the bus side, which skips the wrapper when no
+        // emission would land).
+        let any_emits = a.handshakes.iter().any(|hs| matches!(
+            hs.variant.name.as_str(),
+            "valid_ready" | "valid_stall" | "req_ack_4phase"
+        ));
+        if !any_emits { return; }
+
+        self.line("");
+        self.line("// synopsys translate_off");
+        self.line("// Auto-generated handshake protocol assertions (Tier 2)");
+        let mod_name = a.name.name.clone();
+        let handshakes = a.handshakes.clone();
+        for hs in &handshakes {
+            let label_stem = hs.name.name.clone();
+            let sig_prefix = hs.name.name.clone();
+            self.emit_handshake_channel_asserts(
+                hs,
+                &clk,
+                rst_active.as_deref(),
+                &sig_prefix,
+                &label_stem,
+                &mod_name,
+            );
         }
         self.line("// synopsys translate_on");
     }

--- a/src/elaborate.rs
+++ b/src/elaborate.rs
@@ -2758,6 +2758,7 @@ fn synthesize_lock_arbiter(
         policy,
         hook,
         latency: 1,
+        handshakes: Vec::new(),
     }
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -694,6 +694,7 @@ impl Parser {
             variant: variant_ident,
             role_dir: dir,
             payload_names,
+            array_count: None,
             span: block_span,
             legacy_handshake_kw: is_legacy,
         };
@@ -727,7 +728,7 @@ impl Parser {
     /// machinery exists; today arbiter ports have no such concept).
     ///
     /// See doc/plan_handshake_construct.md for the variant catalog.
-    fn parse_handshake_channel_construct_port(&mut self) -> Result<(Vec<PortDecl>, Option<PortArrayDecl>), CompileError> {
+    fn parse_handshake_channel_construct_port(&mut self) -> Result<(Vec<PortDecl>, Option<PortArrayDecl>, HandshakeMeta), CompileError> {
         let is_legacy = self.check(TokenKind::Handshake);
         let opening_tok = if is_legacy { TokenKind::Handshake } else { TokenKind::HandshakeChannel };
         let start = self.expect(opening_tok)?.span;
@@ -856,6 +857,37 @@ impl Parser {
             signals.push(mk_port(port_name, dir, ty, f_span));
         }
 
+        // Build the HandshakeMeta so callers (arbiter today) can drive
+        // Tier-2 protocol-SVA emission. Mirrors the bus-body path's
+        // HandshakeMeta exactly, with `array_count` set for the `[N]`
+        // shape so codegen can wrap the assertion in `generate for`.
+        let payload_names: Vec<Ident> = signals.iter()
+            // Skip the control signals (valid/ready/stall/req/ack) — those
+            // are unconditionally added by the variant arms above. Anything
+            // beyond that is a user-declared payload field.
+            .filter(|p| {
+                let bare = if prefix.is_empty() { p.name.name.as_str() } else {
+                    p.name.name.strip_prefix(&prefix).unwrap_or(p.name.name.as_str())
+                };
+                !matches!(bare, "valid" | "ready" | "stall" | "req" | "ack")
+            })
+            .map(|p| {
+                let bare = if prefix.is_empty() { p.name.name.clone() } else {
+                    p.name.name.strip_prefix(&prefix).unwrap_or(&p.name.name).to_string()
+                };
+                Ident { name: bare, span: p.span }
+            })
+            .collect();
+        let meta = HandshakeMeta {
+            name: ch_name.clone(),
+            variant: variant_ident,
+            role_dir: dir,
+            payload_names,
+            array_count: array_count.clone(),
+            span: block_span,
+            legacy_handshake_kw: is_legacy,
+        };
+
         if let Some(count_expr) = array_count {
             let arr = PortArrayDecl {
                 count_expr,
@@ -863,9 +895,9 @@ impl Parser {
                 signals,
                 span: block_span,
             };
-            Ok((Vec::new(), Some(arr)))
+            Ok((Vec::new(), Some(arr), meta))
         } else {
-            Ok((signals, None))
+            Ok((signals, None, meta))
         }
     }
 
@@ -4850,6 +4882,7 @@ impl Parser {
         let mut params = Vec::new();
         let mut ports = Vec::new();
         let mut port_arrays = Vec::new();
+        let mut handshakes: Vec<HandshakeMeta> = Vec::new();
         let mut policy: Option<ArbiterPolicy> = None;
         let mut hook: Option<crate::ast::ArbiterHookDecl> = None;
         let mut latency: u32 = 1;
@@ -4918,11 +4951,12 @@ impl Parser {
                     // PortDecls (no `[N]`) or a PortArrayDecl (with `[N]`).
                     // Reuses the same payload/variant/direction parser as the
                     // bus-body path; see doc/plan_handshake_construct.md.
-                    let (decls, opt_array) = self.parse_handshake_channel_construct_port()?;
+                    let (decls, opt_array, meta) = self.parse_handshake_channel_construct_port()?;
                     ports.extend(decls);
                     if let Some(arr) = opt_array {
                         port_arrays.push(arr);
                     }
+                    handshakes.push(meta);
                 }
                 Some(TokenKind::Hook) => {
                     hook = Some(self.parse_arbiter_hook()?);
@@ -4952,6 +4986,7 @@ impl Parser {
             policy: policy.unwrap_or(ArbiterPolicy::RoundRobin),
             hook,
             latency,
+            handshakes,
         })
     }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -9,6 +9,52 @@ fn compile_to_sv(source: &str) -> String {
     compile_to_sv_with_opts(source, &elaborate::ThreadLowerOpts::default())
 }
 
+/// Strip every `// synopsys translate_off ... // synopsys translate_on`
+/// block from emitted SV. Used by structural equivalence tests that
+/// compare a hand-rolled arbiter (no HandshakeMeta → no auto-SVA)
+/// against the `handshake_channel` form (HandshakeMeta present → Tier-2
+/// SVA emitted). Both forms must match in port + arbiter-logic shape;
+/// the SVA-only delta is expected. Applied to both sides so any
+/// incidental translate-off blocks (auto-bounds, etc.) cancel out.
+fn strip_auto_handshake_sva(sv: &str) -> String {
+    let lines: Vec<&str> = sv.lines().collect();
+    let mut out = String::with_capacity(sv.len());
+    let mut i = 0;
+    while i < lines.len() {
+        let line = lines[i];
+        let trimmed = line.trim_start();
+        if trimmed == "// synopsys translate_off" {
+            // Skip the entire block (translate_off..translate_on).
+            while i < lines.len()
+                && lines[i].trim_start() != "// synopsys translate_on"
+            {
+                i += 1;
+            }
+            // Consume the translate_on line too.
+            if i < lines.len() { i += 1; }
+            // Retroactively swallow exactly one leading blank-ish line
+            // (whitespace only — `Codegen::line("")` at indent>0 emits a
+            // fully-indented empty line). The corresponding leading
+            // blank is emitted by the auto-handshake helper just before
+            // the block; the trailing blank lives outside the helper.
+            let bytes = out.as_bytes();
+            if !bytes.is_empty() && bytes.last() == Some(&b'\n') {
+                let without_nl = &out[..out.len() - 1];
+                let last_nl = without_nl.rfind('\n').map(|p| p + 1).unwrap_or(0);
+                let last_line = &without_nl[last_nl..];
+                if last_line.trim().is_empty() && !without_nl.is_empty() {
+                    out.truncate(last_nl);
+                }
+            }
+            continue;
+        }
+        out.push_str(line);
+        out.push('\n');
+        i += 1;
+    }
+    out
+}
+
 fn compile_to_sv_with_opts(source: &str, opts: &elaborate::ThreadLowerOpts) -> String {
     let tokens = lexer::tokenize(source).expect("lexer error");
     let mut parser = Parser::new(tokens, source);
@@ -566,7 +612,12 @@ end arbiter HsArbA
 "#;
     let sv_h = compile_to_sv(hand_rolled);
     let sv_n = compile_to_sv(hs_form);
-    assert_eq!(sv_h, sv_n, "handshake_channel array port shape must match hand-rolled ports[N] form");
+    // The `handshake_channel` form now additionally emits Tier-2 protocol
+    // SVA (the hand-rolled `ports[N]` form has no HandshakeMeta so emits
+    // nothing). Compare structural SV with the auto-SVA block elided so
+    // the port-shape equivalence claim still holds.
+    assert_eq!(strip_auto_handshake_sva(&sv_h), strip_auto_handshake_sva(&sv_n),
+        "handshake_channel array port shape must match hand-rolled ports[N] form (modulo Tier-2 SVA)");
     // Sanity: ensure we actually went through the new path by checking shape.
     assert!(sv_n.contains("input logic [NUM_REQ-1:0] request_valid"));
     assert!(sv_n.contains("output logic [NUM_REQ-1:0] request_ready"));
@@ -603,6 +654,201 @@ end arbiter HsArbB
     assert!(sv.contains("request_qos"),
         "expected request_qos payload port:\n{sv}");
 }
+
+// ── Tier-2 auto-SVA for arbiter handshake_channel ────────────────────────────
+
+/// A `valid_ready` `handshake_channel[N]` in an arbiter port list must
+/// emit the same `valid_stable` SVA the bus side emits, vectorized once
+/// per request lane via an SV `generate for (genvar i ...)` block. The
+/// block must be wrapped in `synopsys translate_off / on` so synthesis
+/// tools elide it. Mirrors `test_handshake_tier2_valid_ready_assertion`.
+#[test]
+fn test_arbiter_handshake_channel_array_emits_sva_generate() {
+    let source = r#"
+domain SysDomain
+  freq_mhz: 100
+end domain SysDomain
+
+arbiter HsArbSvaArr
+  policy round_robin;
+  param NUM_REQ: const = 4;
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  handshake_channel request[NUM_REQ]: receive kind: valid_ready
+  end handshake_channel request
+  port grant_valid: out Bool;
+  port grant_requester: out UInt<2>;
+end arbiter HsArbSvaArr
+"#;
+    let sv = compile_to_sv(source);
+    // Wrapper + structural shape.
+    assert!(sv.contains("// synopsys translate_off"),
+        "expected translate_off wrapper:\n{sv}");
+    assert!(sv.contains("// synopsys translate_on"),
+        "expected translate_on wrapper:\n{sv}");
+    assert!(sv.contains("// Auto-generated handshake protocol assertions"),
+        "expected Tier-2 header comment:\n{sv}");
+    assert!(sv.contains("generate for (genvar i = 0; i < NUM_REQ; i++) begin: g_auto_hs_request"),
+        "expected genvar-indexed generate block over NUM_REQ:\n{sv}");
+    assert!(sv.contains("end endgenerate"),
+        "expected generate block close:\n{sv}");
+    // Property uses lane-indexed signals + disable iff (rst) + the same
+    // `(v && !r) |=> v` predicate as the bus-side emitter.
+    assert!(sv.contains("_auto_hs_request__lane_valid_stable"),
+        "expected per-lane valid_stable label:\n{sv}");
+    assert!(sv.contains("disable iff (rst)"),
+        "expected reset-disable clause:\n{sv}");
+    assert!(sv.contains("(request_valid[i] && !request_ready[i]) |=> request_valid[i]"),
+        "expected lane-indexed valid-stable predicate:\n{sv}");
+}
+
+/// A non-array `handshake_channel` (no `[N]` shape, e.g. an arbiter's
+/// `grant` output) must emit the SVA at the top level — *not* wrapped
+/// in a `generate for` block — because there's only one channel
+/// instance. The bare-signal form is also what the bus-side path
+/// emits today.
+#[test]
+fn test_arbiter_handshake_channel_non_array_emits_sva_bare() {
+    let source = r#"
+domain SysDomain
+  freq_mhz: 100
+end domain SysDomain
+
+arbiter HsArbSvaBare
+  policy round_robin;
+  param NUM_REQ: const = 4;
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  ports[NUM_REQ] request
+    valid: in Bool;
+    ready: out Bool;
+  end ports request
+  handshake_channel grant: send kind: valid_ready
+    requester: UInt<2>;
+  end handshake_channel grant
+end arbiter HsArbSvaBare
+"#;
+    let sv = compile_to_sv(source);
+    assert!(sv.contains("_auto_hs_grant_valid_stable"),
+        "expected bare grant valid_stable label:\n{sv}");
+    // Crucially, no generate-for wrapper for the non-array channel.
+    assert!(!sv.contains("g_auto_hs_grant"),
+        "non-array handshake_channel must not be wrapped in generate-for:\n{sv}");
+    // And the predicate uses unindexed signal names.
+    assert!(sv.contains("(grant_valid && !grant_ready) |=> grant_valid"),
+        "expected unindexed grant valid-stable predicate:\n{sv}");
+}
+
+/// A `valid_only` `handshake_channel` has no ready signal to gate
+/// stability on. The bus-side Tier-2 emitter (current v1) emits nothing
+/// for `valid_only`; the arbiter path must mirror that — no
+/// `valid_stable` property, no `_auto_hs_*` label for the channel.
+#[test]
+fn test_arbiter_handshake_channel_valid_only_omits_ready_gate() {
+    let source = r#"
+domain SysDomain
+  freq_mhz: 100
+end domain SysDomain
+
+arbiter HsArbSvaVOnly
+  policy round_robin;
+  param NUM_REQ: const = 4;
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  ports[NUM_REQ] request
+    valid: in Bool;
+    ready: out Bool;
+  end ports request
+  handshake_channel grant: send kind: valid_only
+    requester: UInt<2>;
+  end handshake_channel grant
+end arbiter HsArbSvaVOnly
+"#;
+    let sv = compile_to_sv(source);
+    // No SVA label for `grant` should appear — mirrors the bus side's
+    // v1 silent-skip for variants without a back-signal.
+    assert!(!sv.contains("_auto_hs_grant"),
+        "valid_only handshake_channel must not emit Tier-2 SVA:\n{sv}");
+    // The Tier-2 wrapper itself must be elided too when no channel
+    // produced any property (matches bus-side emit_handshake_asserts).
+    assert!(!sv.contains("Auto-generated handshake protocol assertions"),
+        "Tier-2 wrapper must not be emitted when no property applies:\n{sv}");
+}
+
+/// A `valid_ready` `handshake_channel` declared *without* any payload
+/// fields must still emit the control-signal `valid_stable` property
+/// (the protocol invariant binds on valid/ready alone). This mirrors
+/// the bus side: Tier-2 v1 emits *only* the control-signal property —
+/// it never emits per-payload `$stable` checks, regardless of whether
+/// payload fields are present. The test pins that contract: payload
+/// presence/absence doesn't change the emitted SVA shape, only the
+/// declared port set.
+#[test]
+fn test_arbiter_handshake_channel_no_payload_emits_only_valid_stability() {
+    let source = r#"
+domain SysDomain
+  freq_mhz: 100
+end domain SysDomain
+
+arbiter HsArbSvaNoPL
+  policy round_robin;
+  param NUM_REQ: const = 4;
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  handshake_channel request[NUM_REQ]: receive kind: valid_ready
+  end handshake_channel request
+  port grant_valid: out Bool;
+  port grant_requester: out UInt<2>;
+end arbiter HsArbSvaNoPL
+"#;
+    let sv = compile_to_sv(source);
+    // Exactly one property — valid_stable — for the channel, lane-indexed.
+    assert!(sv.contains("_auto_hs_request__lane_valid_stable"),
+        "expected valid_stable property:\n{sv}");
+    // No `$stable` payload-stability check (Tier-2 v1 scope explicitly
+    // doesn't include payload-stability, matching bus-side behaviour).
+    assert!(!sv.contains("$stable"),
+        "Tier-2 v1 must not emit payload-stability $stable checks:\n{sv}");
+}
+
+/// Regression: the bus-side handshake_channel Tier-2 SVA path is
+/// unaffected by the arbiter-side addition. The shared helper still
+/// produces the exact same label / predicate / wrapper text the
+/// dedicated bus path produced before the refactor.
+#[test]
+fn test_existing_bus_handshake_sva_unaffected() {
+    // Same source as test_handshake_tier2_valid_ready_assertion.
+    let source = "
+        bus BusLite
+          handshake aw: send kind: valid_ready
+            addr: UInt<32>;
+          end handshake aw
+        end bus BusLite
+
+        module Producer
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync>;
+          port bus_p: initiator BusLite;
+          comb
+            bus_p.aw_valid = 1'b0;
+            bus_p.aw_addr  = 32'h0;
+          end comb
+        end module Producer
+    ";
+    let sv = compile_to_sv(source);
+    // Same checks as the original bus-side test.
+    assert!(sv.contains("// Auto-generated handshake protocol assertions"));
+    assert!(sv.contains("_auto_hs_bus_p_aw_valid_stable"));
+    assert!(sv.contains("(bus_p_aw_valid && !bus_p_aw_ready) |=> bus_p_aw_valid"));
+    assert!(sv.contains("disable iff (rst)"));
+    assert!(sv.contains("synopsys translate_off"));
+    assert!(sv.contains("synopsys translate_on"));
+    // Bus path is non-array, so no generate-for wrapper.
+    assert!(!sv.contains("g_auto_hs_aw"),
+        "bus-path Tier-2 SVA must remain non-generate-wrapped:\n{sv}");
+}
+
+// ── (Existing) handshake_channel port-shape tests ────────────────────────────
 
 /// A `valid_only` handshake_channel as a non-array port should expand to
 /// just the valid wire + payload wires, both at the top level (no array
@@ -646,8 +892,11 @@ end arbiter HsArbC
 "#;
     let sv_h = compile_to_sv(hand_rolled);
     let sv_n = compile_to_sv(hs_form);
-    assert_eq!(sv_h, sv_n,
-        "valid_only handshake_channel + receive valid_ready array must match hand-rolled shape");
+    // Same caveat as test_arbiter_handshake_channel_port_shape: the
+    // handshake_channel form now emits Tier-2 SVA the hand-rolled form
+    // can't see (no HandshakeMeta). Strip it before structural compare.
+    assert_eq!(strip_auto_handshake_sva(&sv_h), strip_auto_handshake_sva(&sv_n),
+        "valid_only handshake_channel + receive valid_ready array must match hand-rolled shape (modulo Tier-2 SVA)");
     assert!(sv_n.contains("output logic grant_valid"),
         "expected grant_valid top-level port:\n{sv_n}");
     assert!(sv_n.contains("output logic [2-1:0] grant_requester")

--- a/tests/snapshots/integration_test__bus_arbiter.snap
+++ b/tests/snapshots/integration_test__bus_arbiter.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/integration_test.rs
+assertion_line: 473
 expression: sv
 ---
 module BusArbiter #(
@@ -36,5 +37,13 @@ module BusArbiter #(
       end
     end
   end
+  
+  // synopsys translate_off
+  // Auto-generated handshake protocol assertions (Tier 2)
+  generate for (genvar i = 0; i < NUM_REQ; i++) begin: g_auto_hs_request
+    _auto_hs_request__lane_valid_stable: assert property (@(posedge clk) disable iff (rst) (request_valid[i] && !request_ready[i]) |=> request_valid[i])
+      else $fatal(1, "HANDSHAKE VIOLATION (valid must stay asserted until ready): BusArbiter._auto_hs_request__lane_valid_stable");
+  end endgenerate
+  // synopsys translate_on
 
 endmodule


### PR DESCRIPTION
## Summary

- Extends the auto-SVA emitter to fire for `handshake_channel` declarations inside `arbiter` constructs (landed in #343), not just inside `bus` bodies. Previously the arbiter path was uncovered.
- For the typical array form `handshake_channel name[N]: ...`, the property is wrapped in an SV `generate for (genvar i ...)` block and signal references are indexed with `[i]` so the assertion fires once per request lane. Non-array channels emit the bare property at the top level.
- Factors the property core into a construct-agnostic helper (`emit_handshake_channel_asserts`) so the bus and arbiter paths share the predicate text, label scheme, and `translate_off`/`on` wrapping. The bus path's emission is byte-identical to pre-refactor (the shared helper's array branch is dead for buses).

## Implementation notes

- `HandshakeMeta` gains `array_count: Option<Expr>` — set only when a `handshake_channel` was declared with an `[N]` shape inside a construct port list. The bus-body parser always sets it to `None`.
- `ArbiterDecl` gains `handshakes: Vec<HandshakeMeta>` paralleling `BusDecl::handshakes`. Populated by `parse_arbiter` as each `handshake_channel` port is parsed; empty for hand-rolled `port` / `ports[N]` arbiters, preserving today's emission for those callers (incl. arch-ibex's `FbAgeArb` / `RamPortArb`) byte-for-byte.
- New emission hook lives in `src/codegen/arbiter.rs`'s `emit_arbiter`, after the user-asserts block and before `endmodule`. The blank-line separator lives inside the helper so it's elided when no channel's variant has a Tier-2 v1 property.

## Variant coverage

Matches the bus side's v1 exactly:
- `valid_ready` → `(v && !r) |=> v` (`_auto_hs_<stem>_valid_stable`)
- `valid_stall` → `(v && s) |=> v`
- `req_ack_4phase` → `(rq && !ak) |=> rq`
- `valid_only`, `ready_only`, `req_ack_2phase` → silently skipped (no v1 property)

## Test plan

- [x] `cargo test --release`: baseline 388 → 393 with 5 new tests (all passing)
  - `test_arbiter_handshake_channel_array_emits_sva_generate`
  - `test_arbiter_handshake_channel_non_array_emits_sva_bare`
  - `test_arbiter_handshake_channel_valid_only_omits_ready_gate`
  - `test_arbiter_handshake_channel_no_payload_emits_only_valid_stability`
  - `test_existing_bus_handshake_sva_unaffected`
- [x] `target/release/arch build examples/bus_arbiter.arch` succeeds
- [x] `verilator --lint-only /tmp/bus_arbiter.sv` lint-clean
- [x] arch-ibex `make build` succeeds with this branch's `arch` — no new auto-handshake SVA appears in any arch-ibex build output (none of its arbiters use `handshake_channel`)
- [x] Existing shape-equivalence tests (`test_arbiter_handshake_channel_port_shape`, `test_arbiter_handshake_channel_grant_output`) now compare with auto-SVA blocks elided; the new SVA emission is the expected delta between hand-rolled `ports[N]` and `handshake_channel[N]` forms
- [x] `tests/snapshots/integration_test__bus_arbiter.snap` updated to include the new auto-SVA block

🤖 Generated with [Claude Code](https://claude.com/claude-code)