### PR TITLE
[codex] tlm: split generated initiator mux trees

### DIFF
--- a/doc/ARCH_HDL_Specification.md
+++ b/doc/ARCH_HDL_Specification.md
@@ -6898,7 +6898,7 @@ Achievable speedup depends on the design\'s inherent parallelism --- the ratio o
 
 **22. Transaction Level Modeling (TLM)**
 
-> **Compiler-supported subset (2026-05-02).** Current ARCH TLM is a cycle-accurate RTL-lowered method interface, not a separate LT/AT simulation API. The implemented syntax is `tlm_method name(args) -> Ret: blocking;` and `tlm_method name(args) -> Ret: out_of_order tags N;` inside `bus`. Initiator calls appear only inside `thread` bodies as direct RHS assignments (`dst <= port.method(args);`) or RHS-fork issues (`dst <= fork port.method(args); ... join all;`). Multiple direct worker threads, `generate_for` workers, direct-call `fork ... and ... join` cohorts, and RHS-fork groups lower to request arbitration and response routing. There is no supported `Future<T>`, `await`, user-visible `Token<T>`, `pipelined`, or `burst` API today.
+> **Compiler-supported subset (2026-05-13).** Current ARCH TLM is a cycle-accurate RTL-lowered method interface, not a separate LT/AT simulation API. The implemented syntax is `tlm_method name(args) -> Ret: blocking;` and `tlm_method name(args) -> Ret: out_of_order tags N;` inside `bus`. Initiator calls appear only inside `thread` bodies as direct RHS assignments (`dst <= port.method(args);`) or RHS-fork issues (`dst <= fork port.method(args); ... join all;`). Literal counted `for` loops inside initiator threads may contain direct TLM assignments; the compiler unrolls them during lowering. Multiple direct worker threads, `generate_for` workers, direct-call `fork ... and ... join` cohorts, RHS-fork groups, and `lock`-protected TLM calls lower to one generated method driver with request arbitration and response routing. There is no supported `Future<T>`, `await`, user-visible `Token<T>`, `pipelined`, or `burst` API today.
 
 Arch supports Transaction Level Modeling (TLM) as a first-class abstraction layer above RTL. At the TLM level, modules communicate by calling methods on typed interfaces rather than by driving individual signals cycle by cycle. A memory read is membus.read(addr) → data --- one call, one response --- rather than a sequence of valid/ready handshake cycles. TLM enables fast architectural simulation, software/hardware co-simulation, and performance modeling, all from the same Arch source as the RTL implementation.
 
@@ -6973,6 +6973,42 @@ The current compiler keeps each returned value direct (`T`, not `Future<T>`) and
 
 The same cohort lowering is available for multiple direct named worker threads and for `generate_for` worker arrays. Current shape restriction: each worker/branch is exactly one assignment, `dst <= port.method(args);`, and all workers use the same clock/reset.
 
+Literal counted loops inside one initiator thread are unrolled before TLM
+state-machine lowering:
+
+```
+thread driver on clk rising, rst high
+  for i in 0..7
+    ack <= mem.read(i.zext<32>());
+  end for
+end thread driver
+```
+
+The unrolled call sites still drive one physical request/response interface for
+`mem.read`. They do not create multiple SystemVerilog drivers. If the call
+sites are in one sequential thread, they are normally mutually exclusive FSM
+states and the compiler's default priority selection is only the generated mux
+shape.
+
+For independent workers sharing one method, a `lock` block plus a matching
+`resource` declaration makes the request-side arbitration policy explicit:
+
+```
+resource mem_ch: mutex<round_robin>;
+
+generate_for lane in 0..3
+  thread Worker_lane on clk rising, rst high
+    lock mem_ch
+      ack[lane] <= mem.read(lane.zext<32>());
+    end lock mem_ch
+  end thread Worker_lane
+end generate_for
+```
+
+`mutex<round_robin>` emits a rotating grant pointer. Other grouped direct
+initiator call sites that do not name a resource are still electrically
+single-driver, but use the compiler's default priority selection.
+
 RHS-fork groups express timed issue inside one thread without introducing `Future<T>`:
 
 ```
@@ -7017,7 +7053,16 @@ end thread driver
 
 For `out_of_order tags N`, the bus flattens two extra wires per method: `<method>_req_tag` and `<method>_rsp_tag`. The initiator cohort assigns one tag per worker and routes response data by `rsp_tag`. A target TLM thread latches `req_tag` with the method arguments and echoes it on `rsp_tag`.
 
-**22.2.4 Unsupported APIs**
+**22.2.4 Generated Code Shape**
+
+Grouped/looped initiator call sites are lowered to one generated driver per
+TLM method signal. The compiler splits large request-valid reductions,
+response-ready reductions, payload muxes, default-priority grants, and
+round-robin grant terms into intermediate wires. This keeps generated
+SystemVerilog line lengths bounded for large unrolled TLM traces and avoids
+simulator/preprocessor limits such as Verilator's per-line token cap.
+
+**22.2.5 Unsupported APIs**
 
 `Future<T>`, `await`, user-visible `Token<T>`, `pipelined`, and `burst` are not part of the current language surface. Current RTL-backed TLM intentionally uses worker threads, RHS-fork groups, and hidden compiler-managed tags instead.
 
@@ -7041,6 +7086,8 @@ Use the implemented forms above for all current RTL-backed TLM work:
 - Declare `tlm_method ... : blocking;` or `tlm_method ... : out_of_order tags N;` inside a `bus`.
 - Implement a target as `thread port.method(args) on clk rising, rst high ... return expr; end thread port.method`.
 - Call from an initiator only inside a `thread`, as `dst <= port.method(args);` or `dst <= fork port.method(args); ... join all;`.
+- Use literal counted `for` loops for repeated direct call sites inside one initiator thread; non-literal/runtime TLM loops are rejected.
+- Use `lock RESOURCE ... end lock RESOURCE` plus `resource RESOURCE: mutex<round_robin>;` when independent workers share a TLM method and require round-robin request arbitration.
 - Express multiple outstanding requests with worker threads, `generate_for` workers, direct-call `fork ... and ... join`, or RHS-fork groups.
 
 **25. AI-Assisted Hardware Design Workflow**

--- a/doc/Arch_AI_Reference_Card.md
+++ b/doc/Arch_AI_Reference_Card.md
@@ -1087,7 +1087,33 @@ This elaborates to a private bus wire plus ordinary whole-bus inst connections. 
 
 TLM calls are not general expressions. They are legal only in `thread` bodies as `dst <= port.method(args);` or `dst <= fork port.method(args);`; `comb`, `seq`, module-level `let`, module-local `function`, `pipeline`, and `fsm` contexts reject them.
 
-Do not put TLM calls inside runtime `for` loops. Use `generate_for` worker threads for compile-time replication.
+Literal counted `for` loops inside initiator threads may contain direct TLM assignments; the compiler unrolls them before TLM lowering:
+
+```
+thread driver on clk rising, rst high
+  for i in 0..7
+    ack <= m.read(i.zext<32>());
+  end for
+end thread driver
+```
+
+Do not put TLM calls inside non-literal/runtime `for` loops. Use `generate_for` worker threads for compile-time replication of independent workers.
+
+Shared method call sites lower to one physical method driver, not multiple SV drivers. Use `lock` plus `resource ... mutex<round_robin>;` when independent workers share a method and require round-robin request arbitration:
+
+```
+resource mem_ch: mutex<round_robin>;
+
+generate_for lane in 0..3
+  thread Worker_lane on clk rising, rst high
+    lock mem_ch
+      ack[lane] <= m.read(lane.zext<32>());
+    end lock mem_ch
+  end thread Worker_lane
+end generate_for
+```
+
+Unprotected grouped call sites are still electrically single-driver, but use the compiler's default priority selection. In one sequential thread they are normally mutually exclusive FSM states.
 
 **Concurrent initiator cohorts** — multiple direct worker calls on one method lower to an arbiter plus response router:
 
@@ -1128,9 +1154,11 @@ Bounded burst-like payloads: use a static max vector return and a runtime length
 
 `arch build` emits TLM protocol SVA in `translate_off/on`: request payload/tag must stay stable while `req_valid && !req_ready`; response payload/tag must stay stable while `rsp_valid && !rsp_ready`. Validate these with Verilator `--assert`.
 
-Current restrictions: thread-body call sites only; direct RHS call only (`dst <= m.method(args);` or `dst <= fork m.method(args);`); no TLM calls inside runtime `for` loops; one call per worker/branch/forked issue; same clock/reset per cohort; literal tag count only; RHS-fork offsets require literal `wait N cycle;`; no nested/composed TLM calls; no dynamic-length TLM return types; no `pipelined`; no first-class `burst`; no `Future<T>`/`await`.
+Generated code shape: grouped/looped initiator call sites emit one generated driver per TLM method signal. Large request-valid reductions, response-ready reductions, payload muxes, default-priority grants, and round-robin grant terms are split into intermediate wires so generated SV lines stay bounded.
 
-Full spec: `doc/ARCH_HDL_Specification.md` §18d. Design + v2 roadmap: `doc/plan_tlm_method.md`.
+Current restrictions: thread-body call sites only; direct RHS call only (`dst <= m.method(args);` or `dst <= fork m.method(args);`); TLM calls in `for` loops require literal bounds and direct assignments; one call per worker/branch/forked issue; same clock/reset per cohort; literal tag count only; RHS-fork offsets require literal `wait N cycle;`; no nested/composed TLM calls; no dynamic-length TLM return types; no `pipelined`; no first-class `burst`; no `Future<T>`/`await`.
+
+Full spec: `doc/ARCH_HDL_Specification.md` §22. Design + v2 roadmap: `doc/plan_tlm_method.md`.
 
 ### Standard bus library (zero-setup `use`)
 
@@ -1289,7 +1317,7 @@ Levels: `Always`, `Low`, `Medium`, `High`, `Full`, `Debug`
 
 | Mode | Return type | Use case |
 |------|-------------|----------|
-| `blocking` | `ret: T` directly | Caller waits for one response. Multiple workers can still be in flight via thread cohorts; responses route by issue-order FIFO. |
+| `blocking` | `ret: T` directly | Caller waits for one response. Multiple workers or literal looped call sites can still be in flight via thread cohorts; responses route by issue-order FIFO. |
 | `out_of_order tags N` | `ret: T` directly + hidden tag wires | Multiple direct workers can complete out of order; compiler assigns worker tags and routes responses by `<method>_rsp_tag`. |
 
 ```
@@ -1303,7 +1331,7 @@ let f = m.read(addr);           // no Future<T>
 await f;                        // no await
 ```
 
-`pipelined` and `burst` are not current TLM modes. Use worker threads, `generate_for` workers, direct-call `fork ... and ... join`, or RHS-fork groups for multiple outstanding requests.
+`pipelined` and `burst` are not current TLM modes. Use worker threads, `generate_for` workers, direct-call `fork ... and ... join`, RHS-fork groups, or literal looped call sites for multiple outstanding requests. Use `lock`/`resource mutex<round_robin>` when independent workers share a method and need fair request arbitration.
 
 ---
 

--- a/doc/plan_tlm_method.md
+++ b/doc/plan_tlm_method.md
@@ -1,6 +1,6 @@
 # Plan: `tlm_method` — transaction-level bus sub-construct
 
-*Author: session of 2026-04-22. Status: implemented in stages; updated 2026-05-02 for RHS-fork issue groups and implemented-only call-site documentation.*
+*Author: session of 2026-04-22. Status: implemented in stages; updated 2026-05-13 for looped/locked initiator call-site lowering and bounded generated mux trees.*
 
 > **Implemented surface.** Current `tlm_method` syntax is only:
 > `tlm_method name(args) -> Ret: blocking;` or
@@ -9,12 +9,18 @@
 > `thread port.method(args) on clk rising, rst high ... return expr; end thread port.method`.
 > Initiator calls are legal only inside `thread` bodies as a direct RHS
 > assignment (`dst <= port.method(args);`) or as an RHS-fork issue
-> (`dst <= fork port.method(args); ... join all;`). The compiler rejects TLM
-> calls in `comb`, `seq`, module-level `let`, module-local `function`,
-> `pipeline`, `fsm`, and runtime `for` loop contexts. Use `generate_for`
-> worker threads when a compile-time number of TLM calls is needed. There is
-> no current `Future<T>`, `await`, user-visible `Token<T>`, `pipelined`, or
-> `burst` API.
+> (`dst <= fork port.method(args); ... join all;`). Literal counted `for`
+> loops inside initiator threads may contain direct TLM assignments; the
+> compiler unrolls them during lowering. `lock RESOURCE ... end lock RESOURCE`
+> is accepted around initiator TLM calls and uses the matching
+> `resource RESOURCE: mutex<POLICY>;` declaration for shared-method
+> arbitration (`mutex<round_robin>` emits a rotating grant pointer; otherwise
+> the compiler uses default priority). The compiler rejects TLM calls in
+> `comb`, `seq`, module-level `let`, module-local `function`, `pipeline`,
+> `fsm`, and non-literal/runtime `for` loop contexts. Use `generate_for`
+> worker threads when a compile-time number of independent workers is needed.
+> There is no current `Future<T>`, `await`, user-visible `Token<T>`,
+> `pipelined`, or `burst` API.
 
 Cross-refs:
 - `doc/plan_bus_unification.md` — sets the unified-bus frame. `tlm_method` is
@@ -166,6 +172,40 @@ declared `tlm_method` on that bus. Inside a thread, the call lowers to
 a state-machine fragment that blocks on the request-ready and
 response-valid handshakes.
 
+Literal counted loops are unrolled before this state-machine lowering:
+
+```
+thread driver on clk rising, rst high
+  for i in 0..7
+    ack <= m.read(i.zext<32>());
+  end for
+end thread driver
+```
+
+The unrolled call sites still drive one physical request/response interface
+for `m.read`; they do not create multiple SystemVerilog drivers.
+
+When multiple thread call sites share a method, use `lock` plus a `resource`
+declaration to make the arbitration policy explicit:
+
+```
+resource mem_ch: mutex<round_robin>;
+
+generate_for lane in 0..3
+  thread Worker_lane on clk rising, rst high
+    lock mem_ch
+      ack[lane] <= m.read(lane.zext<32>());
+    end lock mem_ch
+  end thread Worker_lane
+end generate_for
+```
+
+The compiler emits a single method driver and selects the active call site.
+`mutex<round_robin>` emits round-robin arbitration for simultaneous workers.
+Unprotected grouped call sites are still electrically single-driver, but use
+the compiler's default priority selection; in a single sequential thread those
+call sites are normally mutually exclusive FSM states.
+
 ## Wire protocol (v1, blocking)
 
 Per `tlm_method name(args...) -> ret: blocking;` the compiler flattens
@@ -216,6 +256,12 @@ WAIT_method_N:
 Each call site gets a monotonically-numbered pair of states. The
 existing `wait until` machinery is reused, so no new scheduling
 primitive is needed.
+
+For grouped/looped initiator call sites, the generated request-valid,
+response-ready, payload mux, and arbitration expressions are split into
+intermediate wires. This keeps generated SystemVerilog line lengths bounded
+for large unrolled TLM traces and avoids simulator/preprocessor limits such
+as Verilator's per-line token cap.
 
 ### Target side
 

--- a/src/elaborate.rs
+++ b/src/elaborate.rs
@@ -1171,28 +1171,51 @@ fn fold_literal_bit_slices_thread_stmt(stmt: ThreadStmt) -> ThreadStmt {
             value: fold_literal_bit_slices_expr(ra.value),
             span: ra.span,
         }),
-        ThreadStmt::WaitUntil(cond, sp) => ThreadStmt::WaitUntil(fold_literal_bit_slices_expr(cond), sp),
-        ThreadStmt::WaitCycles(n, sp) => ThreadStmt::WaitCycles(fold_literal_bit_slices_expr(n), sp),
+        ThreadStmt::WaitUntil(cond, sp) => {
+            ThreadStmt::WaitUntil(fold_literal_bit_slices_expr(cond), sp)
+        }
+        ThreadStmt::WaitCycles(n, sp) => {
+            ThreadStmt::WaitCycles(fold_literal_bit_slices_expr(n), sp)
+        }
         ThreadStmt::IfElse(mut ie) => {
             ie.cond = fold_literal_bit_slices_expr(ie.cond);
-            ie.then_stmts = ie.then_stmts.into_iter().map(fold_literal_bit_slices_thread_stmt).collect();
-            ie.else_stmts = ie.else_stmts.into_iter().map(fold_literal_bit_slices_thread_stmt).collect();
+            ie.then_stmts = ie
+                .then_stmts
+                .into_iter()
+                .map(fold_literal_bit_slices_thread_stmt)
+                .collect();
+            ie.else_stmts = ie
+                .else_stmts
+                .into_iter()
+                .map(fold_literal_bit_slices_thread_stmt)
+                .collect();
             ThreadStmt::IfElse(ie)
         }
         ThreadStmt::ForkJoin(branches, sp) => ThreadStmt::ForkJoin(
-            branches.into_iter()
+            branches
+                .into_iter()
                 .map(|br| br.into_iter().map(fold_literal_bit_slices_thread_stmt).collect())
                 .collect(),
             sp,
         ),
-        ThreadStmt::For { var, start, end, body, span } => ThreadStmt::For {
+        ThreadStmt::For {
+            var,
+            start,
+            end,
+            body,
+            span,
+        } => ThreadStmt::For {
             var,
             start: fold_literal_bit_slices_expr(start),
             end: fold_literal_bit_slices_expr(end),
             body: body.into_iter().map(fold_literal_bit_slices_thread_stmt).collect(),
             span,
         },
-        ThreadStmt::Lock { resource, body, span } => ThreadStmt::Lock {
+        ThreadStmt::Lock {
+            resource,
+            body,
+            span,
+        } => ThreadStmt::Lock {
             resource,
             body: body.into_iter().map(fold_literal_bit_slices_thread_stmt).collect(),
             span,
@@ -1220,7 +1243,11 @@ fn fold_literal_bit_slices_expr(expr: Expr) -> Expr {
             {
                 if hi_v >= lo_v && hi_v < 64 {
                     let width = (hi_v - lo_v + 1) as u32;
-                    let mask = if width >= 64 { u64::MAX } else { (1u64 << width) - 1 };
+                    let mask = if width >= 64 {
+                        u64::MAX
+                    } else {
+                        (1u64 << width) - 1
+                    };
                     ExprKind::Literal(LitKind::Sized(width, (v >> lo_v) & mask))
                 } else {
                     ExprKind::BitSlice(Box::new(base), Box::new(hi), Box::new(lo))
@@ -1234,8 +1261,12 @@ fn fold_literal_bit_slices_expr(expr: Expr) -> Expr {
             Box::new(fold_literal_bit_slices_expr(*l)),
             Box::new(fold_literal_bit_slices_expr(*r)),
         ),
-        ExprKind::Unary(op, e) => ExprKind::Unary(op, Box::new(fold_literal_bit_slices_expr(*e))),
-        ExprKind::FieldAccess(e, f) => ExprKind::FieldAccess(Box::new(fold_literal_bit_slices_expr(*e)), f),
+        ExprKind::Unary(op, e) => {
+            ExprKind::Unary(op, Box::new(fold_literal_bit_slices_expr(*e)))
+        }
+        ExprKind::FieldAccess(e, f) => {
+            ExprKind::FieldAccess(Box::new(fold_literal_bit_slices_expr(*e)), f)
+        }
         ExprKind::MethodCall(e, m, args) => ExprKind::MethodCall(
             Box::new(fold_literal_bit_slices_expr(*e)),
             m,
@@ -1246,7 +1277,9 @@ fn fold_literal_bit_slices_expr(expr: Expr) -> Expr {
             Box::new(fold_literal_bit_slices_expr(*idx)),
         ),
         ExprKind::Cast(e, ty) => ExprKind::Cast(Box::new(fold_literal_bit_slices_expr(*e)), ty),
-        ExprKind::Concat(exprs) => ExprKind::Concat(exprs.into_iter().map(fold_literal_bit_slices_expr).collect()),
+        ExprKind::Concat(exprs) => {
+            ExprKind::Concat(exprs.into_iter().map(fold_literal_bit_slices_expr).collect())
+        }
         ExprKind::Ternary(c, t, f) => ExprKind::Ternary(
             Box::new(fold_literal_bit_slices_expr(*c)),
             Box::new(fold_literal_bit_slices_expr(*t)),
@@ -1254,7 +1287,11 @@ fn fold_literal_bit_slices_expr(expr: Expr) -> Expr {
         ),
         other => other,
     };
-    Expr { kind, span, parenthesized }
+    Expr {
+        kind,
+        span,
+        parenthesized,
+    }
 }
 
 /// Like `subst_expr` but also applies `subst_name` to all identifiers (for thread
@@ -6578,31 +6615,48 @@ fn inline_lower_tlm_initiator_group(
                         span,
                     }));
                 }
-                TlmInitGroupStateKind::TlmIssue { port, method, args, method_meta, lock_resource } => {
-                    aggs.entry(format!("{port}.{method}")).or_insert_with(|| GroupAgg {
-                        port: port.clone(),
-                        method: method.clone(),
-                        arg_decls: method_meta.args.clone(),
-                        tag_width: method_meta.out_of_order_tags.clone(),
-                        issues: Vec::new(),
-                        waits: Vec::new(),
-                    }).issues.push((
-                        state_eq(cur_idx),
-                        args.clone(),
-                        state_expr.clone(),
-                        state_lit(next_idx),
-                        lock_resource.clone(),
-                    ));
+                TlmInitGroupStateKind::TlmIssue {
+                    port,
+                    method,
+                    args,
+                    method_meta,
+                    lock_resource,
+                } => {
+                    aggs.entry(format!("{port}.{method}"))
+                        .or_insert_with(|| GroupAgg {
+                            port: port.clone(),
+                            method: method.clone(),
+                            arg_decls: method_meta.args.clone(),
+                            tag_width: method_meta.out_of_order_tags.clone(),
+                            issues: Vec::new(),
+                            waits: Vec::new(),
+                        })
+                        .issues
+                        .push((
+                            state_eq(cur_idx),
+                            args.clone(),
+                            state_expr.clone(),
+                            state_lit(next_idx),
+                            lock_resource.clone(),
+                        ));
                 }
-                TlmInitGroupStateKind::TlmWait { port, method, method_meta, dest } => {
-                    aggs.entry(format!("{port}.{method}")).or_insert_with(|| GroupAgg {
-                        port: port.clone(),
-                        method: method.clone(),
-                        arg_decls: method_meta.args.clone(),
-                        tag_width: method_meta.out_of_order_tags.clone(),
-                        issues: Vec::new(),
-                        waits: Vec::new(),
-                    }).waits.push(state_eq(cur_idx));
+                TlmInitGroupStateKind::TlmWait {
+                    port,
+                    method,
+                    method_meta,
+                    dest,
+                } => {
+                    aggs.entry(format!("{port}.{method}"))
+                        .or_insert_with(|| GroupAgg {
+                            port: port.clone(),
+                            method: method.clone(),
+                            arg_decls: method_meta.args.clone(),
+                            tag_width: method_meta.out_of_order_tags.clone(),
+                            issues: Vec::new(),
+                            waits: Vec::new(),
+                        })
+                        .waits
+                        .push(state_eq(cur_idx));
                     let mut then_stmts = Vec::new();
                     if let Some(dest_expr) = dest {
                         then_stmts.push(Stmt::Assign(RegAssign {
@@ -6619,14 +6673,20 @@ fn inline_lower_tlm_initiator_group(
                     let mut advance_rhs = port_member(port, format!("{method}_rsp_valid"));
                     if let Some(tag_w_expr) = &method_meta.out_of_order_tags {
                         let tag_w = literal_expr_u64(tag_w_expr)
-                            .ok_or_else(|| CompileError::general(
-                                "`out_of_order tags` must be a literal width in the first implementation",
-                                tag_w_expr.span,
-                            ))? as u32;
+                            .ok_or_else(|| {
+                                CompileError::general(
+                                    "`out_of_order tags` must be a literal width in the first implementation",
+                                    tag_w_expr.span,
+                                )
+                            })? as u32;
                         advance_rhs = bin(
                             BinOp::And,
                             advance_rhs,
-                            bin(BinOp::Eq, port_member(port, format!("{method}_rsp_tag")), sized(tag_w, 0)),
+                            bin(
+                                BinOp::Eq,
+                                port_member(port, format!("{method}_rsp_tag")),
+                                sized(tag_w, 0),
+                            ),
                         );
                     }
                     seq_body.push(Stmt::IfElse(IfElseOf {
@@ -6642,9 +6702,15 @@ fn inline_lower_tlm_initiator_group(
     }
 
     let or_expr = |exprs: &[Expr]| -> Expr {
-        let mut acc = exprs.first().cloned().unwrap_or_else(|| Expr::new(ExprKind::Bool(false), span));
+        let mut acc = exprs
+            .first()
+            .cloned()
+            .unwrap_or_else(|| Expr::new(ExprKind::Bool(false), span));
         for e in &exprs[1..] {
-            acc = Expr::new(ExprKind::Binary(BinOp::Or, Box::new(acc), Box::new(e.clone())), span);
+            acc = Expr::new(
+                ExprKind::Binary(BinOp::Or, Box::new(acc), Box::new(e.clone())),
+                span,
+            );
         }
         acc
     };
@@ -6706,7 +6772,10 @@ fn inline_lower_tlm_initiator_group(
                     unpacked_ascending: false,
                     span,
                 }));
-                let mut value = chunk.first().cloned().unwrap_or_else(|| Expr::new(ExprKind::Bool(true), span));
+                let mut value = chunk
+                    .first()
+                    .cloned()
+                    .unwrap_or_else(|| Expr::new(ExprKind::Bool(true), span));
                 for e in &chunk[1..] {
                     value = bin(BinOp::And, value, e.clone());
                 }
@@ -6720,7 +6789,10 @@ fn inline_lower_tlm_initiator_group(
             cur = next;
             level += 1;
         }
-        let mut value = cur.first().cloned().unwrap_or_else(|| Expr::new(ExprKind::Bool(true), span));
+        let mut value = cur
+            .first()
+            .cloned()
+            .unwrap_or_else(|| Expr::new(ExprKind::Bool(true), span));
         for e in &cur[1..] {
             value = bin(BinOp::And, value, e.clone());
         }
@@ -6806,11 +6878,16 @@ fn inline_lower_tlm_initiator_group(
             }));
             want_refs.push(id(want_name));
         }
-        let rr_resource = agg.issues.iter()
+        let rr_resource = agg
+            .issues
+            .iter()
             .filter_map(|(_, _, _, _, r)| r.as_ref())
-            .find(|name| resource_decls.get(*name)
-                .map(|rd| matches!(rd.policy, ArbiterPolicy::RoundRobin))
-                .unwrap_or(false));
+            .find(|name| {
+                resource_decls
+                    .get(*name)
+                    .map(|rd| matches!(rd.policy, ArbiterPolicy::RoundRobin))
+                    .unwrap_or(false)
+            });
         let use_round_robin = rr_resource.is_some() && agg.issues.len() > 1;
         let grant_exprs: Vec<Expr> = if use_round_robin {
             let n = agg.issues.len();
@@ -6834,11 +6911,17 @@ fn inline_lower_tlm_initiator_group(
                     let mut term_inputs = vec![rr_eq_start.clone(), want_refs[i].clone()];
                     let mut j = start;
                     while j != i {
-                        term_inputs.push(Expr::new(ExprKind::Unary(UnaryOp::Not, Box::new(want_refs[j].clone())), span));
+                        term_inputs.push(Expr::new(
+                            ExprKind::Unary(UnaryOp::Not, Box::new(want_refs[j].clone())),
+                            span,
+                        ));
                         j = (j + 1) % n;
                     }
                     let term = emit_bool_and_tree(
-                        &format!("_tlm_init_{}_{}_rr_s{}_g{}", agg.port, agg.method, start, i),
+                        &format!(
+                            "_tlm_init_{}_{}_rr_s{}_g{}",
+                            agg.port, agg.method, start, i
+                        ),
                         &term_inputs,
                         &mut items,
                         &mut comb_stmts,
@@ -6846,13 +6929,17 @@ fn inline_lower_tlm_initiator_group(
                     grant_terms_by_i[i].push(term);
                 }
             }
-            grant_terms_by_i.into_iter().enumerate()
-                .map(|(i, terms)| emit_bool_or_tree(
-                    &format!("_tlm_init_{}_{}_rr_grant_{}", agg.port, agg.method, i),
-                    &terms,
-                    &mut items,
-                    &mut comb_stmts,
-                ))
+            grant_terms_by_i
+                .into_iter()
+                .enumerate()
+                .map(|(i, terms)| {
+                    emit_bool_or_tree(
+                        &format!("_tlm_init_{}_{}_rr_grant_{}", agg.port, agg.method, i),
+                        &terms,
+                        &mut items,
+                        &mut comb_stmts,
+                    )
+                })
                 .collect()
         } else {
             let mut grants = Vec::new();
@@ -6905,7 +6992,11 @@ fn inline_lower_tlm_initiator_group(
             let ptr_w = clog2_width(n as u64);
             let rr_name = format!("_tlm_init_{}_{}_rr_ptr", agg.port, agg.method);
             let rr_id = id(rr_name);
-            let req_fire = bin(BinOp::And, or_expr(&grants), port_member(&agg.port, format!("{}_req_ready", agg.method)));
+            let req_fire = bin(
+                BinOp::And,
+                or_expr(&grants),
+                port_member(&agg.port, format!("{}_req_ready", agg.method)),
+            );
             let mut rr_then = Vec::new();
             for (i, grant) in grants.iter().enumerate() {
                 let next = if i + 1 == n { 0 } else { i + 1 };
@@ -6959,7 +7050,8 @@ fn inline_lower_tlm_initiator_group(
             span,
         }));
         for (arg_i, (arg_ident, arg_ty)) in agg.arg_decls.iter().enumerate() {
-            let pairs: Vec<(Expr, Expr)> = grants.iter()
+            let pairs: Vec<(Expr, Expr)> = grants
+                .iter()
                 .zip(agg.issues.iter())
                 .filter_map(|(grant, (_, args, _, _, _))| {
                     args.get(arg_i).map(|arg| (grant.clone(), arg.clone()))
@@ -7006,7 +7098,10 @@ fn inline_lower_tlm_initiator_group(
         stmts: seq_body,
         span,
     }));
-    items.push(ModuleBodyItem::CombBlock(CombBlock { stmts: comb_stmts, span }));
+    items.push(ModuleBodyItem::CombBlock(CombBlock {
+        stmts: comb_stmts,
+        span,
+    }));
     Ok(items)
 }
 

--- a/src/elaborate.rs
+++ b/src/elaborate.rs
@@ -1154,6 +1154,109 @@ fn subst_thread_stmt(stmt: &ThreadStmt, var: &str, val: i64) -> ThreadStmt {
     }
 }
 
+fn fold_literal_bit_slices_thread_stmt(stmt: ThreadStmt) -> ThreadStmt {
+    match stmt {
+        ThreadStmt::CombAssign(ca) => ThreadStmt::CombAssign(CombAssign {
+            target: fold_literal_bit_slices_expr(ca.target),
+            value: fold_literal_bit_slices_expr(ca.value),
+            span: ca.span,
+        }),
+        ThreadStmt::SeqAssign(ra) => ThreadStmt::SeqAssign(RegAssign {
+            target: fold_literal_bit_slices_expr(ra.target),
+            value: fold_literal_bit_slices_expr(ra.value),
+            span: ra.span,
+        }),
+        ThreadStmt::ForkTlmAssign(ra) => ThreadStmt::ForkTlmAssign(RegAssign {
+            target: fold_literal_bit_slices_expr(ra.target),
+            value: fold_literal_bit_slices_expr(ra.value),
+            span: ra.span,
+        }),
+        ThreadStmt::WaitUntil(cond, sp) => ThreadStmt::WaitUntil(fold_literal_bit_slices_expr(cond), sp),
+        ThreadStmt::WaitCycles(n, sp) => ThreadStmt::WaitCycles(fold_literal_bit_slices_expr(n), sp),
+        ThreadStmt::IfElse(mut ie) => {
+            ie.cond = fold_literal_bit_slices_expr(ie.cond);
+            ie.then_stmts = ie.then_stmts.into_iter().map(fold_literal_bit_slices_thread_stmt).collect();
+            ie.else_stmts = ie.else_stmts.into_iter().map(fold_literal_bit_slices_thread_stmt).collect();
+            ThreadStmt::IfElse(ie)
+        }
+        ThreadStmt::ForkJoin(branches, sp) => ThreadStmt::ForkJoin(
+            branches.into_iter()
+                .map(|br| br.into_iter().map(fold_literal_bit_slices_thread_stmt).collect())
+                .collect(),
+            sp,
+        ),
+        ThreadStmt::For { var, start, end, body, span } => ThreadStmt::For {
+            var,
+            start: fold_literal_bit_slices_expr(start),
+            end: fold_literal_bit_slices_expr(end),
+            body: body.into_iter().map(fold_literal_bit_slices_thread_stmt).collect(),
+            span,
+        },
+        ThreadStmt::Lock { resource, body, span } => ThreadStmt::Lock {
+            resource,
+            body: body.into_iter().map(fold_literal_bit_slices_thread_stmt).collect(),
+            span,
+        },
+        ThreadStmt::DoUntil { body, cond, span } => ThreadStmt::DoUntil {
+            body: body.into_iter().map(fold_literal_bit_slices_thread_stmt).collect(),
+            cond: fold_literal_bit_slices_expr(cond),
+            span,
+        },
+        ThreadStmt::Return(e, sp) => ThreadStmt::Return(fold_literal_bit_slices_expr(e), sp),
+        other => other,
+    }
+}
+
+fn fold_literal_bit_slices_expr(expr: Expr) -> Expr {
+    let span = expr.span;
+    let parenthesized = expr.parenthesized;
+    let kind = match expr.kind {
+        ExprKind::BitSlice(base, hi, lo) => {
+            let base = fold_literal_bit_slices_expr(*base);
+            let hi = fold_literal_bit_slices_expr(*hi);
+            let lo = fold_literal_bit_slices_expr(*lo);
+            if let (Some(v), Some(hi_v), Some(lo_v)) =
+                (literal_expr_u64(&base), literal_expr_u64(&hi), literal_expr_u64(&lo))
+            {
+                if hi_v >= lo_v && hi_v < 64 {
+                    let width = (hi_v - lo_v + 1) as u32;
+                    let mask = if width >= 64 { u64::MAX } else { (1u64 << width) - 1 };
+                    ExprKind::Literal(LitKind::Sized(width, (v >> lo_v) & mask))
+                } else {
+                    ExprKind::BitSlice(Box::new(base), Box::new(hi), Box::new(lo))
+                }
+            } else {
+                ExprKind::BitSlice(Box::new(base), Box::new(hi), Box::new(lo))
+            }
+        }
+        ExprKind::Binary(op, l, r) => ExprKind::Binary(
+            op,
+            Box::new(fold_literal_bit_slices_expr(*l)),
+            Box::new(fold_literal_bit_slices_expr(*r)),
+        ),
+        ExprKind::Unary(op, e) => ExprKind::Unary(op, Box::new(fold_literal_bit_slices_expr(*e))),
+        ExprKind::FieldAccess(e, f) => ExprKind::FieldAccess(Box::new(fold_literal_bit_slices_expr(*e)), f),
+        ExprKind::MethodCall(e, m, args) => ExprKind::MethodCall(
+            Box::new(fold_literal_bit_slices_expr(*e)),
+            m,
+            args.into_iter().map(fold_literal_bit_slices_expr).collect(),
+        ),
+        ExprKind::Index(base, idx) => ExprKind::Index(
+            Box::new(fold_literal_bit_slices_expr(*base)),
+            Box::new(fold_literal_bit_slices_expr(*idx)),
+        ),
+        ExprKind::Cast(e, ty) => ExprKind::Cast(Box::new(fold_literal_bit_slices_expr(*e)), ty),
+        ExprKind::Concat(exprs) => ExprKind::Concat(exprs.into_iter().map(fold_literal_bit_slices_expr).collect()),
+        ExprKind::Ternary(c, t, f) => ExprKind::Ternary(
+            Box::new(fold_literal_bit_slices_expr(*c)),
+            Box::new(fold_literal_bit_slices_expr(*t)),
+            Box::new(fold_literal_bit_slices_expr(*f)),
+        ),
+        other => other,
+    };
+    Expr { kind, span, parenthesized }
+}
+
 /// Like `subst_expr` but also applies `subst_name` to all identifiers (for thread
 /// signal name substitution: `valid_i` → `valid_0`).
 fn subst_expr_names(expr: Expr, var: &str, val: i64) -> Expr {
@@ -5350,7 +5453,6 @@ pub fn lower_tlm_target_threads(ast: SourceFile) -> Result<SourceFile, Vec<Compi
                     .filter_map(|p| p.bus_info.as_ref().map(|bi|
                         (p.name.name.clone(), bi.bus_name.name.clone())))
                     .collect();
-
                 // Detect multi-implementer target cases. Indexed target
                 // lanes (`thread s.read[t](...)`) are handled below by
                 // generating private lane endpoints plus one shared mux.
@@ -5476,6 +5578,9 @@ pub fn lower_tlm_target_threads(ast: SourceFile) -> Result<SourceFile, Vec<Compi
                 // CombBlock items directly into new_body; no additional
                 // accumulation needed.
                 let _ = latch_regs;
+                if !new_body.iter().any(|item| matches!(item, ModuleBodyItem::Thread(_))) {
+                    new_body.retain(|item| !matches!(item, ModuleBodyItem::Resource(_)));
+                }
                 m.body = new_body;
                 out_items.push(Item::Module(m));
             }
@@ -5525,6 +5630,12 @@ pub fn lower_tlm_initiator_calls(ast: SourceFile) -> Result<SourceFile, Vec<Comp
                 let port_buses: HashMap<String, String> = m.ports.iter()
                     .filter_map(|p| p.bus_info.as_ref().map(|bi|
                         (p.name.name.clone(), bi.bus_name.name.clone())))
+                    .collect();
+                let resource_decls: HashMap<String, ResourceDecl> = m.body.iter()
+                    .filter_map(|item| match item {
+                        ModuleBodyItem::Resource(r) => Some((r.name.name.clone(), r.clone())),
+                        _ => None,
+                    })
                     .collect();
 
                 let mut direct_groups: HashMap<(String, String), Vec<DirectTlmThread>> = HashMap::new();
@@ -5612,8 +5723,28 @@ pub fn lower_tlm_initiator_calls(ast: SourceFile) -> Result<SourceFile, Vec<Comp
                     }
                 }
 
+                let mut inline_tlm_threads: Vec<ThreadBlock> = Vec::new();
+                let mut inline_tlm_thread_spans: std::collections::HashSet<(usize, usize)> =
+                    std::collections::HashSet::new();
+                for item in &m.body {
+                    if let ModuleBodyItem::Thread(t) = item {
+                        let t_key = (t.span.start, t.span.end);
+                        if t.tlm_target.is_some()
+                            || cohort_thread_spans.contains(&t_key)
+                            || thread_has_fork_tlm_assign(&t.body)
+                        {
+                            continue;
+                        }
+                        if thread_body_has_tlm_call(&t.body, &port_buses, &bus_methods) {
+                            inline_tlm_thread_spans.insert(t_key);
+                            inline_tlm_threads.push(t.clone());
+                        }
+                    }
+                }
+
                 let mut new_body: Vec<ModuleBodyItem> = Vec::new();
                 let mut emitted_cohorts: std::collections::HashSet<(String, String)> = std::collections::HashSet::new();
+                let mut emitted_inline_tlm_group = false;
                 for item in std::mem::take(&mut m.body) {
                     if let ModuleBodyItem::Thread(t) = &item {
                         let t_key = (t.span.start, t.span.end);
@@ -5628,6 +5759,21 @@ pub fn lower_tlm_initiator_calls(ast: SourceFile) -> Result<SourceFile, Vec<Comp
                                         }
                                     }
                                 }
+                            }
+                            continue;
+                        }
+                        if inline_tlm_thread_spans.contains(&t_key) {
+                            if !emitted_inline_tlm_group {
+                                match inline_lower_tlm_initiator_group(
+                                    inline_tlm_threads.clone(),
+                                    &port_buses,
+                                    &bus_methods,
+                                    &resource_decls,
+                                ) {
+                                    Ok(items) => new_body.extend(items),
+                                    Err(e) => errors.push(e),
+                                }
+                                emitted_inline_tlm_group = true;
                             }
                             continue;
                         }
@@ -5685,6 +5831,14 @@ pub fn lower_tlm_initiator_calls(ast: SourceFile) -> Result<SourceFile, Vec<Comp
                         }
                     }
                     new_body.push(item);
+                }
+                // If every TLM-bearing thread in this module was consumed
+                // by the in-place initiator lowering, any resource
+                // declarations that only existed for those locks must not
+                // leak to codegen. Regular thread lowering consumes
+                // resources only when Thread items remain.
+                if !new_body.iter().any(|item| matches!(item, ModuleBodyItem::Thread(_))) {
+                    new_body.retain(|item| !matches!(item, ModuleBodyItem::Resource(_)));
                 }
                 m.body = new_body;
                 out_items.push(Item::Module(m));
@@ -6172,6 +6326,10 @@ fn thread_body_has_tlm_call(
             contains_tlm_call(e, port_buses, bus_methods),
         ThreadStmt::ForkJoin(branches, _) =>
             branches.iter().any(|branch| thread_body_has_tlm_call(branch, port_buses, bus_methods)),
+        ThreadStmt::For { body, .. }
+        | ThreadStmt::Lock { body, .. }
+        | ThreadStmt::DoUntil { body, .. } =>
+            thread_body_has_tlm_call(body, port_buses, bus_methods),
         _ => false,
     })
 }
@@ -6187,6 +6345,669 @@ fn thread_has_fork_tlm_assign(stmts: &[ThreadStmt]) -> bool {
         | ThreadStmt::DoUntil { body, .. } => thread_has_fork_tlm_assign(body),
         _ => false,
     })
+}
+
+enum TlmInitGroupStateKind {
+    Compute {
+        seq_on_exit: Vec<Stmt>,
+    },
+    TlmIssue {
+        port: String,
+        method: String,
+        args: Vec<Expr>,
+        method_meta: TlmMethodMeta,
+        lock_resource: Option<String>,
+    },
+    TlmWait {
+        port: String,
+        method: String,
+        method_meta: TlmMethodMeta,
+        dest: Option<Expr>,
+    },
+}
+
+struct TlmInitThreadPlan {
+    thread: ThreadBlock,
+    tag: String,
+    states: Vec<TlmInitGroupStateKind>,
+}
+
+fn build_tlm_init_thread_plan(
+    t: ThreadBlock,
+    port_buses: &std::collections::HashMap<String, String>,
+    bus_methods: &std::collections::HashMap<String, Vec<TlmMethodMeta>>,
+) -> Result<TlmInitThreadPlan, CompileError> {
+    fn lower_stmts(
+        stmts: Vec<ThreadStmt>,
+        states: &mut Vec<TlmInitGroupStateKind>,
+        pending_seq: &mut Vec<Stmt>,
+        port_buses: &std::collections::HashMap<String, String>,
+        bus_methods: &std::collections::HashMap<String, Vec<TlmMethodMeta>>,
+        span: Span,
+        current_lock: Option<&str>,
+    ) -> Result<(), CompileError> {
+        for stmt in stmts {
+            match stmt {
+                ThreadStmt::SeqAssign(ra) => {
+                    if match_tlm_call(&ra.value, port_buses, bus_methods).is_none()
+                        && contains_tlm_call(&ra.value, port_buses, bus_methods)
+                    {
+                        return Err(CompileError::general(
+                            "TLM method call must be the direct right-hand side of `<=` in a thread body — nested or composed uses are not supported in v1",
+                            ra.span,
+                        ));
+                    }
+                    if contains_tlm_call(&ra.target, port_buses, bus_methods) {
+                        return Err(CompileError::general(
+                            "TLM method calls cannot appear on the LHS of an assignment",
+                            ra.span,
+                        ));
+                    }
+                    if let Some(call) = match_tlm_call(&ra.value, port_buses, bus_methods) {
+                        if !pending_seq.is_empty() {
+                            states.push(TlmInitGroupStateKind::Compute {
+                                seq_on_exit: std::mem::take(pending_seq),
+                            });
+                        }
+                        let has_ret = call.method_meta.ret.is_some();
+                        states.push(TlmInitGroupStateKind::TlmIssue {
+                            port: call.port.clone(),
+                            method: call.method.clone(),
+                            args: call.args.clone(),
+                            method_meta: call.method_meta.clone(),
+                            lock_resource: current_lock.map(|s| s.to_string()),
+                        });
+                        states.push(TlmInitGroupStateKind::TlmWait {
+                            port: call.port,
+                            method: call.method,
+                            method_meta: call.method_meta.clone(),
+                            dest: if has_ret { Some(ra.target) } else { None },
+                        });
+                    } else {
+                        pending_seq.push(Stmt::Assign(ra));
+                    }
+                }
+                ThreadStmt::Lock { resource, body, .. } => {
+                    lower_stmts(body, states, pending_seq, port_buses, bus_methods, span, Some(&resource.name))?;
+                }
+                ThreadStmt::For { var, start, end, body, span: for_span } => {
+                    let start_v = literal_expr_u64(&start).ok_or_else(|| {
+                        CompileError::general(
+                            "v1 TLM initiator `for` loops require a literal start bound",
+                            start.span,
+                        )
+                    })?;
+                    let end_v = literal_expr_u64(&end).ok_or_else(|| {
+                        CompileError::general(
+                            "v1 TLM initiator `for` loops require a literal end bound",
+                            end.span,
+                        )
+                    })?;
+                    if end_v < start_v {
+                        return Err(CompileError::general(
+                            "v1 TLM initiator `for` loop end must be >= start",
+                            for_span,
+                        ));
+                    }
+                    for i in start_v..=end_v {
+                        let expanded: Vec<ThreadStmt> = body
+                            .iter()
+                            .map(|s| subst_thread_stmt(s, &var.name, i as i64))
+                            .map(fold_literal_bit_slices_thread_stmt)
+                            .collect();
+                        lower_stmts(expanded, states, pending_seq, port_buses, bus_methods, span, current_lock)?;
+                    }
+                }
+                other => {
+                    return Err(CompileError::general(
+                        &format!(
+                            "v1 TLM initiator thread body only supports SeqAssign statements, literal `for` loops, and `lock` blocks around them (found {:?}). Refactor more complex control flow into a `thread` without TLM calls.",
+                            std::mem::discriminant(&other),
+                        ),
+                        span,
+                    ));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    let span = t.span;
+    let tag = t.name.as_ref().map(|n| n.name.clone()).unwrap_or_else(|| "tlm_init".to_string());
+    let mut states = Vec::new();
+    let mut pending_seq = Vec::new();
+    lower_stmts(t.body.clone(), &mut states, &mut pending_seq, port_buses, bus_methods, span, None)?;
+    if !pending_seq.is_empty() {
+        states.push(TlmInitGroupStateKind::Compute {
+            seq_on_exit: std::mem::take(&mut pending_seq),
+        });
+    }
+    Ok(TlmInitThreadPlan { thread: t, tag, states })
+}
+
+fn inline_lower_tlm_initiator_group(
+    threads: Vec<ThreadBlock>,
+    port_buses: &std::collections::HashMap<String, String>,
+    bus_methods: &std::collections::HashMap<String, Vec<TlmMethodMeta>>,
+    resource_decls: &std::collections::HashMap<String, ResourceDecl>,
+) -> Result<Vec<ModuleBodyItem>, CompileError> {
+    let mut plans = Vec::new();
+    for t in threads {
+        plans.push(build_tlm_init_thread_plan(t, port_buses, bus_methods)?);
+    }
+    plans.retain(|p| !p.states.is_empty());
+    if plans.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let span = plans[0].thread.span;
+    let clk = plans[0].thread.clock.clone();
+    let rst = plans[0].thread.reset.clone();
+    let clock_edge = plans[0].thread.clock_edge;
+    let reset_level = plans[0].thread.reset_level;
+    for p in &plans {
+        if p.thread.clock.name != clk.name
+            || p.thread.reset.name != rst.name
+            || p.thread.clock_edge != clock_edge
+            || p.thread.reset_level != reset_level
+        {
+            return Err(CompileError::general(
+                "TLM initiator thread group must use one clock/reset domain",
+                p.thread.span,
+            ));
+        }
+    }
+
+    let mk_ident = |name: String| Ident { name, span };
+    let id = |name: String| Expr::new(ExprKind::Ident(name), span);
+    let dec = |v: u64| Expr::new(ExprKind::Literal(LitKind::Dec(v)), span);
+    let sized = |w: u32, v: u64| Expr::new(ExprKind::Literal(LitKind::Sized(w, v)), span);
+    let bin = |op: BinOp, l: Expr, r: Expr| Expr::new(ExprKind::Binary(op, Box::new(l), Box::new(r)), span);
+    let tern = |c: Expr, t: Expr, e: Expr| Expr::new(ExprKind::Ternary(Box::new(c), Box::new(t), Box::new(e)), span);
+    let port_member = |port: &str, member: String| Expr::new(
+        ExprKind::FieldAccess(Box::new(id(port.to_string())), mk_ident(member)),
+        span,
+    );
+
+    struct GroupAgg {
+        port: String,
+        method: String,
+        arg_decls: Vec<(Ident, TypeExpr)>,
+        tag_width: Option<Expr>,
+        issues: Vec<(Expr, Vec<Expr>, Expr, Expr, Option<String>)>,
+        waits: Vec<Expr>,
+    }
+
+    let mut items = Vec::new();
+    let mut seq_body = Vec::new();
+    let mut aggs: std::collections::BTreeMap<String, GroupAgg> = std::collections::BTreeMap::new();
+
+    for plan in &plans {
+        let total_states = plan.states.len();
+        let state_width = clog2_width(total_states as u64);
+        let state_reg_name = format!("_tlm_init_{}_state", plan.tag);
+        items.push(ModuleBodyItem::RegDecl(RegDecl {
+            name: mk_ident(state_reg_name.clone()),
+            ty: TypeExpr::UInt(Box::new(dec(state_width as u64))),
+            init: None,
+            reset: RegReset::Inherit(rst.clone(), dec(0)),
+            guard: None,
+            multicycle: None,
+            span,
+        }));
+        let state_expr = id(state_reg_name.clone());
+        let state_lit = |v: u64| sized(state_width, v);
+        let state_eq = |v: u64| bin(BinOp::Eq, state_expr.clone(), state_lit(v));
+
+        for (i, sk) in plan.states.iter().enumerate() {
+            let cur_idx = i as u64;
+            let next_idx = ((i + 1) % total_states) as u64;
+            match sk {
+                TlmInitGroupStateKind::Compute { seq_on_exit } => {
+                    let mut then_stmts = seq_on_exit.clone();
+                    then_stmts.push(Stmt::Assign(RegAssign {
+                        target: state_expr.clone(),
+                        value: state_lit(next_idx),
+                        span,
+                    }));
+                    seq_body.push(Stmt::IfElse(IfElseOf {
+                        cond: state_eq(cur_idx),
+                        then_stmts,
+                        else_stmts: Vec::new(),
+                        unique: false,
+                        span,
+                    }));
+                }
+                TlmInitGroupStateKind::TlmIssue { port, method, args, method_meta, lock_resource } => {
+                    aggs.entry(format!("{port}.{method}")).or_insert_with(|| GroupAgg {
+                        port: port.clone(),
+                        method: method.clone(),
+                        arg_decls: method_meta.args.clone(),
+                        tag_width: method_meta.out_of_order_tags.clone(),
+                        issues: Vec::new(),
+                        waits: Vec::new(),
+                    }).issues.push((
+                        state_eq(cur_idx),
+                        args.clone(),
+                        state_expr.clone(),
+                        state_lit(next_idx),
+                        lock_resource.clone(),
+                    ));
+                }
+                TlmInitGroupStateKind::TlmWait { port, method, method_meta, dest } => {
+                    aggs.entry(format!("{port}.{method}")).or_insert_with(|| GroupAgg {
+                        port: port.clone(),
+                        method: method.clone(),
+                        arg_decls: method_meta.args.clone(),
+                        tag_width: method_meta.out_of_order_tags.clone(),
+                        issues: Vec::new(),
+                        waits: Vec::new(),
+                    }).waits.push(state_eq(cur_idx));
+                    let mut then_stmts = Vec::new();
+                    if let Some(dest_expr) = dest {
+                        then_stmts.push(Stmt::Assign(RegAssign {
+                            target: dest_expr.clone(),
+                            value: port_member(port, format!("{method}_rsp_data")),
+                            span,
+                        }));
+                    }
+                    then_stmts.push(Stmt::Assign(RegAssign {
+                        target: state_expr.clone(),
+                        value: state_lit(next_idx),
+                        span,
+                    }));
+                    let mut advance_rhs = port_member(port, format!("{method}_rsp_valid"));
+                    if let Some(tag_w_expr) = &method_meta.out_of_order_tags {
+                        let tag_w = literal_expr_u64(tag_w_expr)
+                            .ok_or_else(|| CompileError::general(
+                                "`out_of_order tags` must be a literal width in the first implementation",
+                                tag_w_expr.span,
+                            ))? as u32;
+                        advance_rhs = bin(
+                            BinOp::And,
+                            advance_rhs,
+                            bin(BinOp::Eq, port_member(port, format!("{method}_rsp_tag")), sized(tag_w, 0)),
+                        );
+                    }
+                    seq_body.push(Stmt::IfElse(IfElseOf {
+                        cond: bin(BinOp::And, state_eq(cur_idx), advance_rhs),
+                        then_stmts,
+                        else_stmts: Vec::new(),
+                        unique: false,
+                        span,
+                    }));
+                }
+            }
+        }
+    }
+
+    let or_expr = |exprs: &[Expr]| -> Expr {
+        let mut acc = exprs.first().cloned().unwrap_or_else(|| Expr::new(ExprKind::Bool(false), span));
+        for e in &exprs[1..] {
+            acc = Expr::new(ExprKind::Binary(BinOp::Or, Box::new(acc), Box::new(e.clone())), span);
+        }
+        acc
+    };
+    let emit_bool_or_tree = |
+        prefix: &str,
+        exprs: &[Expr],
+        items: &mut Vec<ModuleBodyItem>,
+        comb_stmts: &mut Vec<Stmt>,
+    | -> Expr {
+        const CHUNK: usize = 8;
+        if exprs.is_empty() {
+            return Expr::new(ExprKind::Bool(false), span);
+        }
+        let mut level = 0usize;
+        let mut cur = exprs.to_vec();
+        while cur.len() > CHUNK {
+            let mut next = Vec::new();
+            for (chunk_i, chunk) in cur.chunks(CHUNK).enumerate() {
+                let wire_name = format!("{prefix}_or_l{level}_{chunk_i}");
+                items.push(ModuleBodyItem::WireDecl(WireDecl {
+                    name: mk_ident(wire_name.clone()),
+                    ty: TypeExpr::Bool,
+                    unpacked: false,
+                    unpacked_ascending: false,
+                    span,
+                }));
+                comb_stmts.push(Stmt::Assign(CombAssign {
+                    target: id(wire_name.clone()),
+                    value: or_expr(chunk),
+                    span,
+                }));
+                next.push(id(wire_name));
+            }
+            cur = next;
+            level += 1;
+        }
+        or_expr(&cur)
+    };
+    let emit_bool_and_tree = |
+        prefix: &str,
+        exprs: &[Expr],
+        items: &mut Vec<ModuleBodyItem>,
+        comb_stmts: &mut Vec<Stmt>,
+    | -> Expr {
+        const CHUNK: usize = 8;
+        if exprs.is_empty() {
+            return Expr::new(ExprKind::Bool(true), span);
+        }
+        let mut level = 0usize;
+        let mut cur = exprs.to_vec();
+        while cur.len() > CHUNK {
+            let mut next = Vec::new();
+            for (chunk_i, chunk) in cur.chunks(CHUNK).enumerate() {
+                let wire_name = format!("{prefix}_and_l{level}_{chunk_i}");
+                items.push(ModuleBodyItem::WireDecl(WireDecl {
+                    name: mk_ident(wire_name.clone()),
+                    ty: TypeExpr::Bool,
+                    unpacked: false,
+                    unpacked_ascending: false,
+                    span,
+                }));
+                let mut value = chunk.first().cloned().unwrap_or_else(|| Expr::new(ExprKind::Bool(true), span));
+                for e in &chunk[1..] {
+                    value = bin(BinOp::And, value, e.clone());
+                }
+                comb_stmts.push(Stmt::Assign(CombAssign {
+                    target: id(wire_name.clone()),
+                    value,
+                    span,
+                }));
+                next.push(id(wire_name));
+            }
+            cur = next;
+            level += 1;
+        }
+        let mut value = cur.first().cloned().unwrap_or_else(|| Expr::new(ExprKind::Bool(true), span));
+        for e in &cur[1..] {
+            value = bin(BinOp::And, value, e.clone());
+        }
+        value
+    };
+    let emit_mux_tree = |
+        prefix: &str,
+        ty: &TypeExpr,
+        pairs: &[(Expr, Expr)],
+        default: Expr,
+        items: &mut Vec<ModuleBodyItem>,
+        comb_stmts: &mut Vec<Stmt>,
+    | -> Expr {
+        const CHUNK: usize = 8;
+        if pairs.is_empty() {
+            return default;
+        }
+        let mut level = 0usize;
+        let mut cur = pairs.to_vec();
+        while cur.len() > CHUNK {
+            let mut next = Vec::new();
+            for (chunk_i, chunk) in cur.chunks(CHUNK).enumerate() {
+                let valid_name = format!("{prefix}_mux_valid_l{level}_{chunk_i}");
+                let data_name = format!("{prefix}_mux_data_l{level}_{chunk_i}");
+                items.push(ModuleBodyItem::WireDecl(WireDecl {
+                    name: mk_ident(valid_name.clone()),
+                    ty: TypeExpr::Bool,
+                    unpacked: false,
+                    unpacked_ascending: false,
+                    span,
+                }));
+                items.push(ModuleBodyItem::WireDecl(WireDecl {
+                    name: mk_ident(data_name.clone()),
+                    ty: ty.clone(),
+                    unpacked: false,
+                    unpacked_ascending: false,
+                    span,
+                }));
+                let valid_inputs: Vec<Expr> = chunk.iter().map(|(sel, _)| sel.clone()).collect();
+                comb_stmts.push(Stmt::Assign(CombAssign {
+                    target: id(valid_name.clone()),
+                    value: or_expr(&valid_inputs),
+                    span,
+                }));
+                let mut value = default.clone();
+                for (sel, data) in chunk.iter().rev() {
+                    value = tern(sel.clone(), data.clone(), value);
+                }
+                comb_stmts.push(Stmt::Assign(CombAssign {
+                    target: id(data_name.clone()),
+                    value,
+                    span,
+                }));
+                next.push((id(valid_name), id(data_name)));
+            }
+            cur = next;
+            level += 1;
+        }
+        let mut value = default;
+        for (sel, data) in cur.iter().rev() {
+            value = tern(sel.clone(), data.clone(), value);
+        }
+        value
+    };
+
+    let mut comb_stmts = Vec::new();
+    for (_, agg) in &aggs {
+        let issue_conds: Vec<Expr> = agg.issues.iter().map(|(c, _, _, _, _)| c.clone()).collect();
+        let mut want_refs: Vec<Expr> = Vec::new();
+        for (i, cond) in issue_conds.iter().enumerate() {
+            let want_name = format!("_tlm_init_{}_{}_want_{}", agg.port, agg.method, i);
+            items.push(ModuleBodyItem::WireDecl(WireDecl {
+                name: mk_ident(want_name.clone()),
+                ty: TypeExpr::Bool,
+                unpacked: false,
+                unpacked_ascending: false,
+                span,
+            }));
+            comb_stmts.push(Stmt::Assign(CombAssign {
+                target: id(want_name.clone()),
+                value: cond.clone(),
+                span,
+            }));
+            want_refs.push(id(want_name));
+        }
+        let rr_resource = agg.issues.iter()
+            .filter_map(|(_, _, _, _, r)| r.as_ref())
+            .find(|name| resource_decls.get(*name)
+                .map(|rd| matches!(rd.policy, ArbiterPolicy::RoundRobin))
+                .unwrap_or(false));
+        let use_round_robin = rr_resource.is_some() && agg.issues.len() > 1;
+        let grant_exprs: Vec<Expr> = if use_round_robin {
+            let n = agg.issues.len();
+            let ptr_w = clog2_width(n as u64);
+            let rr_name = format!("_tlm_init_{}_{}_rr_ptr", agg.port, agg.method);
+            items.push(ModuleBodyItem::RegDecl(RegDecl {
+                name: mk_ident(rr_name.clone()),
+                ty: TypeExpr::UInt(Box::new(dec(ptr_w as u64))),
+                init: None,
+                reset: RegReset::Inherit(rst.clone(), dec(0)),
+                guard: None,
+                multicycle: None,
+                span,
+            }));
+            let rr_id = id(rr_name.clone());
+            let mut grant_terms_by_i: Vec<Vec<Expr>> = vec![Vec::new(); n];
+            for start in 0..n {
+                let rr_eq_start = bin(BinOp::Eq, rr_id.clone(), sized(ptr_w, start as u64));
+                for offset in 0..n {
+                    let i = (start + offset) % n;
+                    let mut term_inputs = vec![rr_eq_start.clone(), want_refs[i].clone()];
+                    let mut j = start;
+                    while j != i {
+                        term_inputs.push(Expr::new(ExprKind::Unary(UnaryOp::Not, Box::new(want_refs[j].clone())), span));
+                        j = (j + 1) % n;
+                    }
+                    let term = emit_bool_and_tree(
+                        &format!("_tlm_init_{}_{}_rr_s{}_g{}", agg.port, agg.method, start, i),
+                        &term_inputs,
+                        &mut items,
+                        &mut comb_stmts,
+                    );
+                    grant_terms_by_i[i].push(term);
+                }
+            }
+            grant_terms_by_i.into_iter().enumerate()
+                .map(|(i, terms)| emit_bool_or_tree(
+                    &format!("_tlm_init_{}_{}_rr_grant_{}", agg.port, agg.method, i),
+                    &terms,
+                    &mut items,
+                    &mut comb_stmts,
+                ))
+                .collect()
+        } else {
+            let mut grants = Vec::new();
+            let mut prev_taken = Expr::new(ExprKind::Bool(false), span);
+            for (i, want) in want_refs.iter().enumerate() {
+                let grant = bin(
+                    BinOp::And,
+                    want.clone(),
+                    Expr::new(ExprKind::Unary(UnaryOp::Not, Box::new(prev_taken.clone())), span),
+                );
+                grants.push(grant);
+                if i + 1 < want_refs.len() {
+                    let taken_name = format!("_tlm_init_{}_{}_taken_{}", agg.port, agg.method, i);
+                    items.push(ModuleBodyItem::WireDecl(WireDecl {
+                        name: mk_ident(taken_name.clone()),
+                        ty: TypeExpr::Bool,
+                        unpacked: false,
+                        unpacked_ascending: false,
+                        span,
+                    }));
+                    comb_stmts.push(Stmt::Assign(CombAssign {
+                        target: id(taken_name.clone()),
+                        value: bin(BinOp::Or, prev_taken, want.clone()),
+                        span,
+                    }));
+                    prev_taken = id(taken_name);
+                }
+            }
+            grants
+        };
+        let mut grants: Vec<Expr> = Vec::new();
+        for (i, grant_expr) in grant_exprs.iter().enumerate() {
+            let grant_name = format!("_tlm_init_{}_{}_grant_{}", agg.port, agg.method, i);
+            items.push(ModuleBodyItem::WireDecl(WireDecl {
+                name: mk_ident(grant_name.clone()),
+                ty: TypeExpr::Bool,
+                unpacked: false,
+                unpacked_ascending: false,
+                span,
+            }));
+            comb_stmts.push(Stmt::Assign(CombAssign {
+                target: id(grant_name.clone()),
+                value: grant_expr.clone(),
+                span,
+            }));
+            grants.push(id(grant_name));
+        }
+        if use_round_robin {
+            let n = agg.issues.len();
+            let ptr_w = clog2_width(n as u64);
+            let rr_name = format!("_tlm_init_{}_{}_rr_ptr", agg.port, agg.method);
+            let rr_id = id(rr_name);
+            let req_fire = bin(BinOp::And, or_expr(&grants), port_member(&agg.port, format!("{}_req_ready", agg.method)));
+            let mut rr_then = Vec::new();
+            for (i, grant) in grants.iter().enumerate() {
+                let next = if i + 1 == n { 0 } else { i + 1 };
+                rr_then.push(Stmt::IfElse(IfElseOf {
+                    cond: grant.clone(),
+                    then_stmts: vec![Stmt::Assign(RegAssign {
+                        target: rr_id.clone(),
+                        value: sized(ptr_w, next as u64),
+                        span,
+                    })],
+                    else_stmts: Vec::new(),
+                    unique: false,
+                    span,
+                }));
+            }
+            seq_body.push(Stmt::IfElse(IfElseOf {
+                cond: req_fire,
+                then_stmts: rr_then,
+                else_stmts: Vec::new(),
+                unique: false,
+                span,
+            }));
+        }
+        for (grant, (_, _, state_expr, next_state, _)) in grants.iter().zip(agg.issues.iter()) {
+            let advance_cond = bin(
+                BinOp::And,
+                grant.clone(),
+                port_member(&agg.port, format!("{}_req_ready", agg.method)),
+            );
+            seq_body.push(Stmt::IfElse(IfElseOf {
+                cond: advance_cond,
+                then_stmts: vec![Stmt::Assign(RegAssign {
+                    target: state_expr.clone(),
+                    value: next_state.clone(),
+                    span,
+                })],
+                else_stmts: Vec::new(),
+                unique: false,
+                span,
+            }));
+        }
+        let req_valid_value = emit_bool_or_tree(
+            &format!("_tlm_init_{}_{}_req_valid", agg.port, agg.method),
+            &grants,
+            &mut items,
+            &mut comb_stmts,
+        );
+        comb_stmts.push(Stmt::Assign(CombAssign {
+            target: port_member(&agg.port, format!("{}_req_valid", agg.method)),
+            value: req_valid_value,
+            span,
+        }));
+        for (arg_i, (arg_ident, arg_ty)) in agg.arg_decls.iter().enumerate() {
+            let pairs: Vec<(Expr, Expr)> = grants.iter()
+                .zip(agg.issues.iter())
+                .filter_map(|(grant, (_, args, _, _, _))| {
+                    args.get(arg_i).map(|arg| (grant.clone(), arg.clone()))
+                })
+                .collect();
+            let arg_value = emit_mux_tree(
+                &format!("_tlm_init_{}_{}_{}", agg.port, agg.method, arg_ident.name),
+                arg_ty,
+                &pairs,
+                dec(0),
+                &mut items,
+                &mut comb_stmts,
+            );
+            comb_stmts.push(Stmt::Assign(CombAssign {
+                target: port_member(&agg.port, format!("{}_{}", agg.method, arg_ident.name)),
+                value: arg_value,
+                span,
+            }));
+        }
+        if let Some(tag_w_expr) = &agg.tag_width {
+            let tag_w = literal_expr_u64(tag_w_expr).unwrap_or(1) as u32;
+            comb_stmts.push(Stmt::Assign(CombAssign {
+                target: port_member(&agg.port, format!("{}_req_tag", agg.method)),
+                value: sized(tag_w, 0),
+                span,
+            }));
+        }
+        let rsp_ready_value = emit_bool_or_tree(
+            &format!("_tlm_init_{}_{}_rsp_ready", agg.port, agg.method),
+            &agg.waits,
+            &mut items,
+            &mut comb_stmts,
+        );
+        comb_stmts.push(Stmt::Assign(CombAssign {
+            target: port_member(&agg.port, format!("{}_rsp_ready", agg.method)),
+            value: rsp_ready_value,
+            span,
+        }));
+    }
+
+    items.push(ModuleBodyItem::RegBlock(RegBlock {
+        clock: clk,
+        clock_edge,
+        stmts: seq_body,
+        span,
+    }));
+    items.push(ModuleBodyItem::CombBlock(CombBlock { stmts: comb_stmts, span }));
+    Ok(items)
 }
 
 #[derive(Clone)]
@@ -6652,8 +7473,16 @@ fn inline_lower_tlm_initiator(
     let mut states: Vec<StateKind> = Vec::new();
     let mut pending_seq: Vec<Stmt> = Vec::new();
 
-    for stmt in t.body {
-        match stmt {
+    fn lower_initiator_stmts(
+        stmts: Vec<ThreadStmt>,
+        states: &mut Vec<StateKind>,
+        pending_seq: &mut Vec<Stmt>,
+        port_buses: &std::collections::HashMap<String, String>,
+        bus_methods: &std::collections::HashMap<String, Vec<TlmMethodMeta>>,
+        span: Span,
+    ) -> Result<(), CompileError> {
+        for stmt in stmts {
+            match stmt {
             ThreadStmt::SeqAssign(ra) => {
                 // Reject nested TLM calls in either side (composed RHS
                 // like `d <= m.read(a) + 1;` or LHS ref).
@@ -6675,7 +7504,7 @@ fn inline_lower_tlm_initiator(
                     // Flush any pending non-TLM seq assigns as a Compute state.
                     if !pending_seq.is_empty() {
                         states.push(StateKind::Compute {
-                            seq_on_exit: std::mem::take(&mut pending_seq),
+                            seq_on_exit: std::mem::take(pending_seq),
                         });
                     }
                     let has_ret = call.method_meta.ret.is_some();
@@ -6695,10 +7524,28 @@ fn inline_lower_tlm_initiator(
                     pending_seq.push(Stmt::Assign(ra));
                 }
             }
+            ThreadStmt::Lock { body, .. } => {
+                // TLM initiator lowering is responsible for consuming any
+                // TLM call before the generic thread pass sees it. Recurse
+                // through `lock` so the lock idiom recommended by the
+                // multi-driver diagnostic is accepted for TLM methods. The
+                // actual TLM method drives are still emitted once per lowered
+                // thread by the method aggregator below, so the call site
+                // stays on the TLM path instead of falling into ordinary
+                // thread lowering.
+                lower_initiator_stmts(
+                    body,
+                    states,
+                    pending_seq,
+                    port_buses,
+                    bus_methods,
+                    span,
+                )?;
+            }
             other => {
                 return Err(CompileError::general(
                     &format!(
-                        "v1 TLM initiator thread body only supports SeqAssign statements (found {:?}). Refactor more complex control flow into a `thread` without TLM calls.",
+                        "v1 TLM initiator thread body only supports SeqAssign statements and `lock` blocks around them (found {:?}). Refactor more complex control flow into a `thread` without TLM calls.",
                         std::mem::discriminant(&other),
                     ),
                     span,
@@ -6706,6 +7553,17 @@ fn inline_lower_tlm_initiator(
             }
         }
     }
+        Ok(())
+    }
+
+    lower_initiator_stmts(
+        t.body,
+        &mut states,
+        &mut pending_seq,
+        port_buses,
+        bus_methods,
+        span,
+    )?;
     // Trailing pending seq becomes a Compute state too.
     if !pending_seq.is_empty() {
         states.push(StateKind::Compute { seq_on_exit: std::mem::take(&mut pending_seq) });
@@ -7294,6 +8152,7 @@ fn inline_lower_tlm_target_with_io(
         seq_on_exit: Vec<Stmt>,       // fires on transition out of this state
         comb_in_state: Vec<Stmt>, // active during this state
         transition_cond: Expr,
+        wait_cycles: Option<Expr>,
     }
     let mut user_states: Vec<UserState> = Vec::new();
     let mut cur_seq: Vec<Stmt> = Vec::new();
@@ -7360,6 +8219,15 @@ fn inline_lower_tlm_target_with_io(
                     seq_on_exit: std::mem::take(&mut cur_seq),
                     comb_in_state: std::mem::take(&mut cur_comb),
                     transition_cond: rename_args(cond, &arg_renames),
+                    wait_cycles: None,
+                });
+            }
+            ThreadStmt::WaitCycles(count, _) => {
+                user_states.push(UserState {
+                    seq_on_exit: std::mem::take(&mut cur_seq),
+                    comb_in_state: std::mem::take(&mut cur_comb),
+                    transition_cond: Expr::new(ExprKind::Bool(true), span),
+                    wait_cycles: Some(rename_args(count, &arg_renames)),
                 });
             }
             ThreadStmt::Return(e, _) => {
@@ -7368,7 +8236,7 @@ fn inline_lower_tlm_target_with_io(
             }
             other => {
                 return Err(CompileError::general(
-                    &format!("TLM target thread body statement not supported in v1 (only SeqAssign / CombAssign / WaitUntil / Return allowed inline). Offender: {:?}", std::mem::discriminant(&other)),
+                    &format!("TLM target thread body statement not supported in v1 (only SeqAssign / CombAssign / WaitUntil / WaitCycles / Return allowed inline). Offender: {:?}", std::mem::discriminant(&other)),
                     span,
                 ));
             }
@@ -7414,6 +8282,39 @@ fn inline_lower_tlm_target_with_io(
         multicycle: None,
         span,
     };
+    let has_wait_cycles = user_states.iter().any(|s| s.wait_cycles.is_some());
+    let wait_cnt_name = format!("_tlm_{port}_{method_name}{}_wait_cnt", io.suffix);
+    let wait_cnt_ident = Expr::new(ExprKind::Ident(wait_cnt_name.clone()), span);
+    let wait_count_init = |count: &Expr| -> Expr {
+        if let Some(v) = literal_expr_u64(count) {
+            Expr::new(ExprKind::Literal(LitKind::Sized(32, v.saturating_sub(1))), span)
+        } else {
+            count.clone()
+        }
+    };
+    let wait_cnt_zero = Expr::new(
+        ExprKind::Binary(
+            BinOp::Eq,
+            Box::new(wait_cnt_ident.clone()),
+            Box::new(Expr::new(ExprKind::Literal(LitKind::Sized(32, 0)), span)),
+        ),
+        span,
+    );
+    let wait_cnt_dec = Expr::new(
+        ExprKind::MethodCall(
+            Box::new(Expr::new(
+                ExprKind::Binary(
+                    BinOp::Sub,
+                    Box::new(wait_cnt_ident.clone()),
+                    Box::new(Expr::new(ExprKind::Literal(LitKind::Sized(32, 1)), span)),
+                ),
+                span,
+            )),
+            mk_ident("trunc".to_string()),
+            vec![Expr::new(ExprKind::Literal(LitKind::Dec(32)), span)],
+        ),
+        span,
+    );
 
     // ── Seq block: state transitions + arg latches + user seq assigns ──
     // Build nested if/elsif over state_reg.
@@ -7433,6 +8334,13 @@ fn inline_lower_tlm_target_with_io(
         entry_then.push(Stmt::Assign(RegAssign {
             target: Expr::new(ExprKind::Ident(latch_name.clone()), span),
             value: mk_port_member(format!("{method_name}_req_tag")),
+            span,
+        }));
+    }
+    if let Some(first_wait) = user_states.first().and_then(|s| s.wait_cycles.as_ref()) {
+        entry_then.push(Stmt::Assign(RegAssign {
+            target: wait_cnt_ident.clone(),
+            value: wait_count_init(first_wait),
             span,
         }));
     }
@@ -7460,18 +8368,52 @@ fn inline_lower_tlm_target_with_io(
         let state_idx = (i + 1) as u64;
         let next_idx = (i + 2) as u64;
         let mut then_stmts: Vec<Stmt> = us.seq_on_exit.clone();
+        if let Some(next_wait) = user_states.get(i + 1).and_then(|s| s.wait_cycles.as_ref()) {
+            then_stmts.push(Stmt::Assign(RegAssign {
+                target: wait_cnt_ident.clone(),
+                value: wait_count_init(next_wait),
+                span,
+            }));
+        }
         then_stmts.push(Stmt::Assign(RegAssign {
             target: state_ident.clone(),
             value: mk_state_lit(next_idx),
             span,
         }));
-        let branch_cond = Expr::new(
+        let mut branch_cond = Expr::new(
             ExprKind::Binary(BinOp::And,
                 Box::new(state_eq(state_idx)),
                 Box::new(us.transition_cond.clone()),
             ),
             span,
         );
+        if us.wait_cycles.is_some() {
+            seq_body.push(Stmt::IfElse(IfElseOf {
+                cond: Expr::new(
+                    ExprKind::Binary(
+                        BinOp::And,
+                        Box::new(state_eq(state_idx)),
+                        Box::new(Expr::new(
+                            ExprKind::Unary(UnaryOp::Not, Box::new(wait_cnt_zero.clone())),
+                            span,
+                        )),
+                    ),
+                    span,
+                ),
+                then_stmts: vec![Stmt::Assign(RegAssign {
+                    target: wait_cnt_ident.clone(),
+                    value: wait_cnt_dec.clone(),
+                    span,
+                })],
+                else_stmts: Vec::new(),
+                unique: false,
+                span,
+            }));
+            branch_cond = Expr::new(
+                ExprKind::Binary(BinOp::And, Box::new(branch_cond), Box::new(wait_cnt_zero.clone())),
+                span,
+            );
+        }
         seq_body.push(Stmt::IfElse(IfElseOf {
             cond: branch_cond,
             then_stmts,
@@ -7594,6 +8536,17 @@ fn inline_lower_tlm_target_with_io(
     // ── Assemble output items ────────────────────────────────────────────
     let mut items: Vec<ModuleBodyItem> = Vec::new();
     items.push(ModuleBodyItem::RegDecl(state_reg));
+    if has_wait_cycles {
+        items.push(ModuleBodyItem::RegDecl(RegDecl {
+            name: mk_ident(wait_cnt_name),
+            ty: TypeExpr::UInt(Box::new(Expr::new(ExprKind::Literal(LitKind::Dec(32)), span))),
+            init: None,
+            reset: RegReset::Inherit(t.reset.clone(), Expr::new(ExprKind::Literal(LitKind::Dec(0)), span)),
+            guard: None,
+            multicycle: None,
+            span,
+        }));
+    }
     for r in latch_regs { items.push(ModuleBodyItem::RegDecl(r)); }
     items.push(ModuleBodyItem::RegBlock(reg_block));
     items.push(ModuleBodyItem::CombBlock(comb_block));

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -7255,12 +7255,18 @@ fn test_tlm_initiator_call_inside_lock_lowers() {
         end module M
     ";
     let sv = compile_to_sv(source);
-    assert!(sv.contains("_tlm_init_driver_state"),
-        "locked TLM call should lower to the inline initiator FSM:\n{sv}");
-    assert!(sv.contains("m_read_req_valid"),
-        "locked TLM call should still drive request valid:\n{sv}");
-    assert!(sv.contains("m_read_rsp_ready"),
-        "locked TLM call should still drive response ready:\n{sv}");
+    assert!(
+        sv.contains("_tlm_init_driver_state"),
+        "locked TLM call should lower to the inline initiator FSM:\n{sv}"
+    );
+    assert!(
+        sv.contains("m_read_req_valid"),
+        "locked TLM call should still drive request valid:\n{sv}"
+    );
+    assert!(
+        sv.contains("m_read_rsp_ready"),
+        "locked TLM call should still drive response ready:\n{sv}"
+    );
 }
 
 #[test]
@@ -7293,15 +7299,25 @@ fn test_locked_tlm_generated_workers_share_one_method_driver() {
     let req_valid_drives = sv.matches("assign m_read_req_valid").count();
     let tile_drives = sv.matches("assign m_read_tile").count();
     let rsp_ready_drives = sv.matches("assign m_read_rsp_ready").count();
-    assert_eq!(req_valid_drives, 1, "expected one shared req_valid driver:\n{sv}");
+    assert_eq!(
+        req_valid_drives, 1,
+        "expected one shared req_valid driver:\n{sv}"
+    );
     assert_eq!(tile_drives, 1, "expected one shared payload driver:\n{sv}");
-    assert_eq!(rsp_ready_drives, 1, "expected one shared rsp_ready driver:\n{sv}");
-    assert!(sv.contains("_tlm_init_Worker_0_state")
-        && sv.contains("_tlm_init_Worker_1_state")
-        && sv.contains("_tlm_init_Worker_2_state"),
-        "each generated worker should keep its own state register:\n{sv}");
-    assert!(sv.contains("_tlm_init_m_read_rr_ptr"),
-        "round-robin locked TLM sharing should emit a rotating grant pointer:\n{sv}");
+    assert_eq!(
+        rsp_ready_drives, 1,
+        "expected one shared rsp_ready driver:\n{sv}"
+    );
+    assert!(
+        sv.contains("_tlm_init_Worker_0_state")
+            && sv.contains("_tlm_init_Worker_1_state")
+            && sv.contains("_tlm_init_Worker_2_state"),
+        "each generated worker should keep its own state register:\n{sv}"
+    );
+    assert!(
+        sv.contains("_tlm_init_m_read_rr_ptr"),
+        "round-robin locked TLM sharing should emit a rotating grant pointer:\n{sv}"
+    );
 }
 
 #[test]
@@ -7331,13 +7347,19 @@ fn test_round_robin_tlm_grants_split_into_intermediate_wires() {
         end module M
     ";
     let sv = compile_to_sv(source);
-    assert!(sv.contains("_tlm_init_m_read_rr_s0_g"),
-        "round-robin grant terms should be emitted as intermediate wires:\n{sv}");
-    assert!(sv.contains("_tlm_init_m_read_rr_grant_0_or_l0_"),
-        "round-robin per-grant OR reductions should be chunked:\n{sv}");
+    assert!(
+        sv.contains("_tlm_init_m_read_rr_s0_g"),
+        "round-robin grant terms should be emitted as intermediate wires:\n{sv}"
+    );
+    assert!(
+        sv.contains("_tlm_init_m_read_rr_grant_0_or_l0_"),
+        "round-robin per-grant OR reductions should be chunked:\n{sv}"
+    );
     let longest = sv.lines().map(str::len).max().unwrap_or(0);
-    assert!(longest < 6000,
-        "round-robin TLM grants should not emit Verilator-hostile long lines; longest was {longest}");
+    assert!(
+        longest < 6000,
+        "round-robin TLM grants should not emit Verilator-hostile long lines; longest was {longest}"
+    );
 }
 
 #[test]
@@ -7363,13 +7385,19 @@ fn test_looped_tlm_initiator_muxes_split_into_intermediate_wires() {
         end module M
     ";
     let sv = compile_to_sv(source);
-    assert!(sv.contains("_tlm_init_m_read_req_valid_or_l0_"),
-        "large request-valid reduction should be chunked into intermediate wires:\n{sv}");
-    assert!(sv.contains("_tlm_init_m_read_a_mux_data_l0_"),
-        "large payload mux should be chunked into intermediate wires:\n{sv}");
+    assert!(
+        sv.contains("_tlm_init_m_read_req_valid_or_l0_"),
+        "large request-valid reduction should be chunked into intermediate wires:\n{sv}"
+    );
+    assert!(
+        sv.contains("_tlm_init_m_read_a_mux_data_l0_"),
+        "large payload mux should be chunked into intermediate wires:\n{sv}"
+    );
     let longest = sv.lines().map(str::len).max().unwrap_or(0);
-    assert!(longest < 6000,
-        "looped TLM initiator should not emit Verilator-hostile long lines; longest was {longest}");
+    assert!(
+        longest < 6000,
+        "looped TLM initiator should not emit Verilator-hostile long lines; longest was {longest}"
+    );
 }
 
 #[test]

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -7229,6 +7229,150 @@ fn test_tlm_call_rejected_outside_seq_assign_rhs() {
 }
 
 #[test]
+fn test_tlm_initiator_call_inside_lock_lowers() {
+    // TLM calls wrapped in `lock` should still be consumed by initiator
+    // lowering instead of falling through to generic thread lowering.
+    let source = "
+        bus Mem
+          tlm_method read(addr: UInt<32>) -> UInt<64>: blocking;
+        end bus Mem
+
+        use Mem;
+
+        module M
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync>;
+          port m:   initiator Mem;
+          reg   d:  UInt<64> reset rst => 0;
+
+          resource mem_ch: mutex<round_robin>;
+
+          thread driver on clk rising, rst high
+            lock mem_ch
+              d <= m.read(32'h1000);
+            end lock mem_ch
+          end thread driver
+        end module M
+    ";
+    let sv = compile_to_sv(source);
+    assert!(sv.contains("_tlm_init_driver_state"),
+        "locked TLM call should lower to the inline initiator FSM:\n{sv}");
+    assert!(sv.contains("m_read_req_valid"),
+        "locked TLM call should still drive request valid:\n{sv}");
+    assert!(sv.contains("m_read_rsp_ready"),
+        "locked TLM call should still drive response ready:\n{sv}");
+}
+
+#[test]
+fn test_locked_tlm_generated_workers_share_one_method_driver() {
+    let source = "
+        bus Mem
+          tlm_method read(tile: UInt<4>) -> Bool: blocking;
+        end bus Mem
+
+        use Mem;
+
+        module M
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync>;
+          port m:   initiator Mem;
+          reg ack: Vec<Bool, 3> reset rst => 0;
+
+          resource mem_ch: mutex<round_robin>;
+
+          generate_for tile in 0..2
+            thread Worker_tile on clk rising, rst high
+              lock mem_ch
+                ack[tile] <= m.read(tile.zext<4>());
+              end lock mem_ch
+            end thread Worker_tile
+          end generate_for
+        end module M
+    ";
+    let sv = compile_to_sv(source);
+    let req_valid_drives = sv.matches("assign m_read_req_valid").count();
+    let tile_drives = sv.matches("assign m_read_tile").count();
+    let rsp_ready_drives = sv.matches("assign m_read_rsp_ready").count();
+    assert_eq!(req_valid_drives, 1, "expected one shared req_valid driver:\n{sv}");
+    assert_eq!(tile_drives, 1, "expected one shared payload driver:\n{sv}");
+    assert_eq!(rsp_ready_drives, 1, "expected one shared rsp_ready driver:\n{sv}");
+    assert!(sv.contains("_tlm_init_Worker_0_state")
+        && sv.contains("_tlm_init_Worker_1_state")
+        && sv.contains("_tlm_init_Worker_2_state"),
+        "each generated worker should keep its own state register:\n{sv}");
+    assert!(sv.contains("_tlm_init_m_read_rr_ptr"),
+        "round-robin locked TLM sharing should emit a rotating grant pointer:\n{sv}");
+}
+
+#[test]
+fn test_round_robin_tlm_grants_split_into_intermediate_wires() {
+    let source = "
+        bus Mem
+          tlm_method read(tile: UInt<5>) -> Bool: blocking;
+        end bus Mem
+
+        use Mem;
+
+        module M
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync>;
+          port m:   initiator Mem;
+          reg ack: Vec<Bool, 16> reset rst => 0;
+
+          resource mem_ch: mutex<round_robin>;
+
+          generate_for tile in 0..15
+            thread Worker_tile on clk rising, rst high
+              lock mem_ch
+                ack[tile] <= m.read(tile.zext<5>());
+              end lock mem_ch
+            end thread Worker_tile
+          end generate_for
+        end module M
+    ";
+    let sv = compile_to_sv(source);
+    assert!(sv.contains("_tlm_init_m_read_rr_s0_g"),
+        "round-robin grant terms should be emitted as intermediate wires:\n{sv}");
+    assert!(sv.contains("_tlm_init_m_read_rr_grant_0_or_l0_"),
+        "round-robin per-grant OR reductions should be chunked:\n{sv}");
+    let longest = sv.lines().map(str::len).max().unwrap_or(0);
+    assert!(longest < 6000,
+        "round-robin TLM grants should not emit Verilator-hostile long lines; longest was {longest}");
+}
+
+#[test]
+fn test_looped_tlm_initiator_muxes_split_into_intermediate_wires() {
+    let source = "
+        bus Mem
+          tlm_method read(a: UInt<8>, b: UInt<8>) -> Bool: blocking;
+        end bus Mem
+
+        use Mem;
+
+        module M
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync>;
+          port m:   initiator Mem;
+          reg ack: Bool reset rst => false;
+
+          thread driver on clk rising, rst high
+            for i in 0..63
+              ack <= m.read(i.zext<8>(), i[2:0].zext<8>());
+            end for
+          end thread driver
+        end module M
+    ";
+    let sv = compile_to_sv(source);
+    assert!(sv.contains("_tlm_init_m_read_req_valid_or_l0_"),
+        "large request-valid reduction should be chunked into intermediate wires:\n{sv}");
+    assert!(sv.contains("_tlm_init_m_read_a_mux_data_l0_"),
+        "large payload mux should be chunked into intermediate wires:\n{sv}");
+    let longest = sv.lines().map(str::len).max().unwrap_or(0);
+    assert!(longest < 6000,
+        "looped TLM initiator should not emit Verilator-hostile long lines; longest was {longest}");
+}
+
+#[test]
 fn test_tlm_target_thread_lowers_inline_to_state_machine() {
     // PR-tlm-4b: TLM target thread lowers in-place to a state-reg +
     // RegBlock + CombBlock in the parent module body (no sub-module
@@ -7260,6 +7404,32 @@ fn test_tlm_target_thread_lowers_inline_to_state_machine() {
         "req_ready driver should appear in SV:\n{sv}");
     assert!(sv.contains("s_read_rsp_valid"),
         "rsp_valid driver should appear in SV:\n{sv}");
+}
+
+#[test]
+fn test_tlm_target_thread_accepts_wait_cycles_before_return() {
+    let source = "
+        bus Mem
+          tlm_method read(addr: UInt<32>) -> UInt<64>: blocking;
+        end bus Mem
+
+        use Mem;
+
+        module MemTarget
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync>;
+          port s:   target Mem;
+          thread s.read(addr) on clk rising, rst high
+            wait 7 cycle;
+            return 64'h42;
+          end thread s.read
+        end module MemTarget
+    ";
+    let sv = compile_to_sv(source);
+    assert!(sv.contains("_tlm_s_read_wait_cnt"),
+        "wait-cycle target should allocate a counter:\n{sv}");
+    assert!(sv.contains("32'd6"),
+        "wait 7 cycle should initialize the counter to 6:\n{sv}");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

This PR cleans up generated TLM initiator lowering for large looped/grouped call sites. The compiler now emits intermediate wires for large request-valid reductions, response-ready reductions, payload muxes, default-priority grants, and round-robin grant terms instead of producing very long flattened expressions.

## Why

Large generated TLM traces can create Verilator-hostile one-line mux/reduction expressions. In the attention TLM model, expanding the representative trace to the full 8-KV-head event trace previously produced giant generated lines and tripped Verilator's preprocessor token limit. Splitting the logic into bounded intermediate wires keeps the generated SV readable and simulator-friendly.

## Changes

- Add grouped inline TLM initiator lowering support for literal `for` loops and `lock` blocks around TLM calls.
- Fold literal bit-slices during TLM loop unrolling so generated expressions like `0[4:2]` become sized literals.
- Emit chunked intermediate wires for large TLM request-valid / response-ready OR trees.
- Emit chunked intermediate wires for large TLM payload mux trees.
- Emit bounded default-priority grant logic with prefix `taken` wires.
- Emit bounded round-robin grant logic with intermediate per-start/per-grant wires.
- Add regression coverage for looped TLM mux splitting and round-robin grant splitting.
- Update TLM docs in `doc/plan_tlm_method.md`, full spec §22, and `doc/Arch_AI_Reference_Card.md`.

## Validation

- `cargo test tlm --test integration_test`
- `git diff --check -- src/elaborate.rs tests/integration_test.rs`
- `git diff --check -- doc/plan_tlm_method.md`
- `git diff --check -- doc/ARCH_HDL_Specification.md doc/Arch_AI_Reference_Card.md`
- `make arch-tlm-build` in `fpt26-accel`
- `make arch-tlm-cosim` in `fpt26-accel`

The full 8-KV-head temporary attention TLM trace also passes Verilator lint with max generated SV line length around 800 chars.
