### PR TITLE
Bump version to 0.70.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,7 +75,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arch"
-version = "0.60.1"
+version = "0.70.0"
 dependencies = [
  "clap",
  "insta",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arch"
-version = "0.60.1"
+version = "0.70.0"
 edition = "2021"
 description = "Compiler for the ARCH hardware description language"
 license = "LGPL-3.0-or-later"


### PR DESCRIPTION
Reflects the language + codegen surface accumulated since the prior 0.60.x line:

- Whole-design comb-loop analysis + per-output \`comb_dep_on\` annotations (#336, #337, #338, #339, #340)
- \`handshake_channel\` accepted in arbiter port lists (#343) with Tier-2 auto-SVA (#344)
- Thread-state name localparams (#334)
- \`multicycle\` reg annotation + SDC emit (#345 + follow-ups #347/#349)
- Thread-no-wait error, FSM no-wait check, encoding-let migration helpers (#328, #329, #331, #332, #333)
- Arbiter and pragma cleanup feature work

## Test plan

- [x] \`cargo build --release\` — clean.
- [ ] Reviewer: confirm version-only change; no behavioral delta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)