### PR TITLE
test: ignore stale test_implement_initiator_multi_implementer_rejected

### DIFF
--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -6776,7 +6776,13 @@ fn test_implement_initiator_single_compiles_end_to_end() {
         "bus signals should be driven:\n{sv}");
 }
 
+// TODO: stale after PR #348 (codex/tlm-mux-balanced-trees) added multi-
+// implementer support — the rejection this test asserted no longer
+// fires (`lower_tlm_initiator_calls` now succeeds for the multi-impl
+// case). Ignored to unblock CI on subsequent PRs; either delete this
+// test or rewrite it to assert the new mux-tree behavior.
 #[test]
+#[ignore]
 fn test_implement_initiator_multi_implementer_rejected() {
     // PR-tlm-i3: multi-implementer initiator → targeted error pointing
     // at PR-tlm-i4.


### PR DESCRIPTION
## Summary

PR #348 (codex/tlm-mux-balanced-trees) added multi-implementer support to \`lower_tlm_initiator_calls\`. The test \`test_implement_initiator_multi_implementer_rejected\` (added in the PR-tlm-i3 era) asserted that multi-implementer initiators would error out "until PR-tlm-i4". That capability has effectively landed, so the rejection no longer fires and the test now panics on \`assert!(r.is_err())\`.

CI on every subsequent open PR (#346, #349, #350) has been failing because of this.

## Fix

Mark the test \`#[ignore]\` with a TODO. Two follow-ups for whoever next touches TLM lowering:

- (a) **Delete this test** if rejection is no longer wanted at all.
- (b) **Rewrite it** against the new mux-tree behavior — confirm the lowering succeeds and produces the expected balanced-mux topology.

## Test plan

- [x] \`cargo test --release\` — 403 passed / 0 failed / 1 ignored (was 403 / 1 / 0 on main).
- [ ] CI green on this PR's checks.

After merge, CI on #346, #349, #350 should unblock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)