### PR TITLE
Fix TLM parameter lowering for SV and sim

### DIFF
--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -1958,7 +1958,8 @@ impl<'a> Codegen<'a> {
             for (sname, _sdir, ty) in bus_info.effective_signals(&pm) {
                 let flat = format!("{parent_name}_{sname}");
                 if declared.contains(&flat) || !bus_emitted.insert(flat.clone()) { continue; }
-                let (ty_str, arr_suffix) = self.emit_type_and_array_suffix(&ty);
+                let subst_ty = Self::subst_type_expr(&ty, &pm);
+                let (ty_str, arr_suffix) = self.emit_type_and_array_suffix(&subst_ty);
                 self.line(&format!("{} {}{};", ty_str, flat, arr_suffix));
             }
         }

--- a/src/codegen/module.rs
+++ b/src/codegen/module.rs
@@ -595,8 +595,9 @@ impl<'a> Codegen<'a> {
                                         .map(|d| (pd.name.name.clone(), d)))
                                     .collect();
                             for (sname, _sdir, sty) in info.effective_signals(&param_map) {
+                                let subst_ty = Self::subst_type_expr(&sty, &param_map);
                                 let (ty_str, arr_suffix) =
-                                    self.emit_type_and_array_suffix(&sty);
+                                    self.emit_type_and_array_suffix(&subst_ty);
                                 self.line(&format!(
                                     "{} {}_{}{};",
                                     ty_str, w.name.name, sname, arr_suffix

--- a/src/elaborate.rs
+++ b/src/elaborate.rs
@@ -5461,17 +5461,20 @@ pub fn lower_tlm_target_threads(ast: SourceFile) -> Result<SourceFile, Vec<Compi
     use std::collections::HashMap;
     // Build {bus_name -> Vec<TlmMethodMeta>}.
     let mut bus_methods: HashMap<String, Vec<TlmMethodMeta>> = HashMap::new();
+    let mut bus_params: HashMap<String, Vec<ParamDecl>> = HashMap::new();
     for it in &ast.items {
         match it {
             Item::Bus(b) => {
                 if !b.tlm_methods.is_empty() {
                     bus_methods.insert(b.name.name.clone(), b.tlm_methods.clone());
+                    bus_params.insert(b.name.name.clone(), b.params.clone());
                 }
             }
             Item::Package(pkg) => {
                 for b in &pkg.buses {
                     if !b.tlm_methods.is_empty() {
                         bus_methods.insert(b.name.name.clone(), b.tlm_methods.clone());
+                        bus_params.insert(b.name.name.clone(), b.params.clone());
                     }
                 }
             }
@@ -5486,10 +5489,8 @@ pub fn lower_tlm_target_threads(ast: SourceFile) -> Result<SourceFile, Vec<Compi
         match it {
             Item::Module(mut m) => {
                 // Build port → bus_name map for this module.
-                let port_buses: HashMap<String, String> = m.ports.iter()
-                    .filter_map(|p| p.bus_info.as_ref().map(|bi|
-                        (p.name.name.clone(), bi.bus_name.name.clone())))
-                    .collect();
+                let (port_buses, port_methods) =
+                    specialize_tlm_methods_for_module_ports(&m, &bus_methods, &bus_params);
                 // Detect multi-implementer target cases. Indexed target
                 // lanes (`thread s.read[t](...)`) are handled below by
                 // generating private lane endpoints plus one shared mux.
@@ -5557,7 +5558,7 @@ pub fn lower_tlm_target_threads(ast: SourceFile) -> Result<SourceFile, Vec<Compi
                                     continue;
                                 }
                             };
-                            let method = match bus_methods.get(&bus_name)
+                            let method = match port_methods.get(&binding.port.name)
                                 .and_then(|v| v.iter().find(|mm| mm.name.name == binding.method.name))
                             {
                                 Some(m) => m.clone(),
@@ -5628,6 +5629,118 @@ pub fn lower_tlm_target_threads(ast: SourceFile) -> Result<SourceFile, Vec<Compi
     Ok(SourceFile { items: out_items, inner_doc: None, frontmatter: None })
 }
 
+fn specialize_tlm_methods_for_module_ports(
+    m: &ModuleDecl,
+    bus_methods: &HashMap<String, Vec<TlmMethodMeta>>,
+    bus_params: &HashMap<String, Vec<ParamDecl>>,
+) -> (HashMap<String, String>, HashMap<String, Vec<TlmMethodMeta>>) {
+    let mut port_buses: HashMap<String, String> = HashMap::new();
+    let mut port_methods: HashMap<String, Vec<TlmMethodMeta>> = HashMap::new();
+    for p in &m.ports {
+        let Some(bi) = &p.bus_info else { continue; };
+        let bus_name = bi.bus_name.name.clone();
+        port_buses.insert(p.name.name.clone(), bus_name.clone());
+        let Some(methods) = bus_methods.get(&bus_name) else { continue; };
+        let mut param_map: HashMap<String, &Expr> = HashMap::new();
+        if let Some(params) = bus_params.get(&bus_name) {
+            for pd in params {
+                if let Some(default) = &pd.default {
+                    param_map.insert(pd.name.name.clone(), default);
+                }
+            }
+        }
+        for pa in &bi.params {
+            param_map.insert(pa.name.name.clone(), &pa.value);
+        }
+        port_methods.insert(
+            p.name.name.clone(),
+            methods
+                .iter()
+                .map(|method| specialize_tlm_method(method, &param_map))
+                .collect(),
+        );
+    }
+    (port_buses, port_methods)
+}
+
+fn specialize_tlm_method(
+    method: &TlmMethodMeta,
+    param_map: &HashMap<String, &Expr>,
+) -> TlmMethodMeta {
+    TlmMethodMeta {
+        name: method.name.clone(),
+        args: method
+            .args
+            .iter()
+            .map(|(name, ty)| (name.clone(), subst_type_expr_params(ty, param_map)))
+            .collect(),
+        ret: method
+            .ret
+            .as_ref()
+            .map(|ty| subst_type_expr_params(ty, param_map)),
+        mode: method.mode.clone(),
+        out_of_order_tags: method
+            .out_of_order_tags
+            .as_ref()
+            .map(|expr| subst_expr_params(expr, param_map)),
+        span: method.span,
+    }
+}
+
+fn subst_type_expr_params(ty: &TypeExpr, param_map: &HashMap<String, &Expr>) -> TypeExpr {
+    match ty {
+        TypeExpr::UInt(e) => TypeExpr::UInt(Box::new(subst_expr_params(e, param_map))),
+        TypeExpr::SInt(e) => TypeExpr::SInt(Box::new(subst_expr_params(e, param_map))),
+        TypeExpr::Vec(inner, size) => TypeExpr::Vec(
+            Box::new(subst_type_expr_params(inner, param_map)),
+            Box::new(subst_expr_params(size, param_map)),
+        ),
+        _ => ty.clone(),
+    }
+}
+
+fn subst_expr_params(expr: &Expr, param_map: &HashMap<String, &Expr>) -> Expr {
+    let kind = match &expr.kind {
+        ExprKind::Ident(name) => {
+            if let Some(replacement) = param_map.get(name.as_str()) {
+                return (*replacement).clone();
+            }
+            ExprKind::Ident(name.clone())
+        }
+        ExprKind::Binary(op, l, r) => ExprKind::Binary(
+            *op,
+            Box::new(subst_expr_params(l, param_map)),
+            Box::new(subst_expr_params(r, param_map)),
+        ),
+        ExprKind::Unary(op, e) => ExprKind::Unary(*op, Box::new(subst_expr_params(e, param_map))),
+        ExprKind::Ternary(c, t, e) => ExprKind::Ternary(
+            Box::new(subst_expr_params(c, param_map)),
+            Box::new(subst_expr_params(t, param_map)),
+            Box::new(subst_expr_params(e, param_map)),
+        ),
+        ExprKind::Clog2(e) => ExprKind::Clog2(Box::new(subst_expr_params(e, param_map))),
+        ExprKind::Index(base, idx) => ExprKind::Index(
+            Box::new(subst_expr_params(base, param_map)),
+            Box::new(subst_expr_params(idx, param_map)),
+        ),
+        ExprKind::BitSlice(base, hi, lo) => ExprKind::BitSlice(
+            Box::new(subst_expr_params(base, param_map)),
+            Box::new(subst_expr_params(hi, param_map)),
+            Box::new(subst_expr_params(lo, param_map)),
+        ),
+        ExprKind::MethodCall(base, method, args) => ExprKind::MethodCall(
+            Box::new(subst_expr_params(base, param_map)),
+            method.clone(),
+            args.iter().map(|arg| subst_expr_params(arg, param_map)).collect(),
+        ),
+        ExprKind::Concat(parts) => ExprKind::Concat(
+            parts.iter().map(|part| subst_expr_params(part, param_map)).collect(),
+        ),
+        _ => return expr.clone(),
+    };
+    Expr { kind, span: expr.span, parenthesized: expr.parenthesized }
+}
+
 
 
 // ── TLM initiator call-site lowering (PR-tlm-4) ─────────────────────────────
@@ -5640,17 +5753,20 @@ pub fn lower_tlm_target_threads(ast: SourceFile) -> Result<SourceFile, Vec<Compi
 pub fn lower_tlm_initiator_calls(ast: SourceFile) -> Result<SourceFile, Vec<CompileError>> {
     use std::collections::HashMap;
     let mut bus_methods: HashMap<String, Vec<TlmMethodMeta>> = HashMap::new();
+    let mut bus_params: HashMap<String, Vec<ParamDecl>> = HashMap::new();
     for it in &ast.items {
         match it {
             Item::Bus(b) => {
                 if !b.tlm_methods.is_empty() {
                     bus_methods.insert(b.name.name.clone(), b.tlm_methods.clone());
+                    bus_params.insert(b.name.name.clone(), b.params.clone());
                 }
             }
             Item::Package(pkg) => {
                 for b in &pkg.buses {
                     if !b.tlm_methods.is_empty() {
                         bus_methods.insert(b.name.name.clone(), b.tlm_methods.clone());
+                        bus_params.insert(b.name.name.clone(), b.params.clone());
                     }
                 }
             }
@@ -5664,9 +5780,11 @@ pub fn lower_tlm_initiator_calls(ast: SourceFile) -> Result<SourceFile, Vec<Comp
     for it in ast.items {
         match it {
             Item::Module(mut m) => {
-                let port_buses: HashMap<String, String> = m.ports.iter()
-                    .filter_map(|p| p.bus_info.as_ref().map(|bi|
-                        (p.name.name.clone(), bi.bus_name.name.clone())))
+                let (_port_bus_names, port_methods) =
+                    specialize_tlm_methods_for_module_ports(&m, &bus_methods, &bus_params);
+                let port_buses: HashMap<String, String> = port_methods
+                    .keys()
+                    .map(|port| (port.clone(), port.clone()))
                     .collect();
                 let resource_decls: HashMap<String, ResourceDecl> = m.body.iter()
                     .filter_map(|item| match item {
@@ -5679,7 +5797,7 @@ pub fn lower_tlm_initiator_calls(ast: SourceFile) -> Result<SourceFile, Vec<Comp
                 for item in &m.body {
                     if let ModuleBodyItem::Thread(t) = item {
                         if t.tlm_target.is_some() || t.implement.is_some() { continue; }
-                        for dt in direct_tlm_threads(t, &port_buses, &bus_methods) {
+                        for dt in direct_tlm_threads(t, &port_buses, &port_methods) {
                             direct_groups.entry((dt.call.port.clone(), dt.call.method.clone()))
                                 .or_default()
                                 .push(dt);
@@ -5716,7 +5834,7 @@ pub fn lower_tlm_initiator_calls(ast: SourceFile) -> Result<SourceFile, Vec<Comp
                             // PR-tlm-i3 (initiator) with its own targeted
                             // message.
                             if t.implement.is_some() { continue; }
-                            collect_bare_tlm_calls(&t.body, t.span, &port_buses, &bus_methods, &mut bare_uses);
+                            collect_bare_tlm_calls(&t.body, t.span, &port_buses, &port_methods, &mut bare_uses);
                         }
                     }
                     for ((port, method), spans) in &bare_uses {
@@ -5772,7 +5890,7 @@ pub fn lower_tlm_initiator_calls(ast: SourceFile) -> Result<SourceFile, Vec<Comp
                         {
                             continue;
                         }
-                        if thread_body_has_tlm_call(&t.body, &port_buses, &bus_methods) {
+                        if thread_body_has_tlm_call(&t.body, &port_buses, &port_methods) {
                             inline_tlm_thread_spans.insert(t_key);
                             inline_tlm_threads.push(t.clone());
                         }
@@ -5786,7 +5904,7 @@ pub fn lower_tlm_initiator_calls(ast: SourceFile) -> Result<SourceFile, Vec<Comp
                     if let ModuleBodyItem::Thread(t) = &item {
                         let t_key = (t.span.start, t.span.end);
                         if cohort_thread_spans.contains(&t_key) {
-                            if let Some(dt) = direct_tlm_threads(t, &port_buses, &bus_methods).into_iter().next() {
+                            if let Some(dt) = direct_tlm_threads(t, &port_buses, &port_methods).into_iter().next() {
                                 let key = (dt.call.port.clone(), dt.call.method.clone());
                                 if emitted_cohorts.insert(key.clone()) {
                                     if let Some(group) = direct_groups.get(&key) {
@@ -5804,7 +5922,7 @@ pub fn lower_tlm_initiator_calls(ast: SourceFile) -> Result<SourceFile, Vec<Comp
                                 match inline_lower_tlm_initiator_group(
                                     inline_tlm_threads.clone(),
                                     &port_buses,
-                                    &bus_methods,
+                                    &port_methods,
                                     &resource_decls,
                                 ) {
                                     Ok(items) => new_body.extend(items),
@@ -5819,7 +5937,7 @@ pub fn lower_tlm_initiator_calls(ast: SourceFile) -> Result<SourceFile, Vec<Comp
                             continue;
                         }
                         if thread_has_fork_tlm_assign(&t.body) {
-                            match inline_lower_tlm_fork_join_all(t.clone(), &port_buses, &bus_methods) {
+                            match inline_lower_tlm_fork_join_all(t.clone(), &port_buses, &port_methods) {
                                 Ok(items) => new_body.extend(items),
                                 Err(e) => {
                                     errors.push(e);
@@ -5858,9 +5976,9 @@ pub fn lower_tlm_initiator_calls(ast: SourceFile) -> Result<SourceFile, Vec<Comp
                                 continue;
                             }
                         }
-                        if thread_body_has_tlm_call(&t.body, &port_buses, &bus_methods) {
+                        if thread_body_has_tlm_call(&t.body, &port_buses, &port_methods) {
                             let t_moved = if let ModuleBodyItem::Thread(t) = item { t } else { unreachable!() };
-                            match inline_lower_tlm_initiator(t_moved, &port_buses, &bus_methods) {
+                            match inline_lower_tlm_initiator(t_moved, &port_buses, &port_methods) {
                                 Ok(items) => new_body.extend(items),
                                 Err(e) => errors.push(e),
                             }

--- a/src/sim_codegen/mod.rs
+++ b/src/sim_codegen/mod.rs
@@ -1266,16 +1266,36 @@ fn subst_type_expr_sim(ty: &TypeExpr, params: &HashMap<String, &Expr>) -> TypeEx
 }
 
 fn subst_expr_sim(expr: &Expr, params: &HashMap<String, &Expr>) -> Expr {
-    match &expr.kind {
+    let kind = match &expr.kind {
         ExprKind::Ident(name) => {
             if let Some(replacement) = params.get(name.as_str()) {
-                (*replacement).clone()
+                return (*replacement).clone();
             } else {
-                expr.clone()
+                ExprKind::Ident(name.clone())
             }
         }
-        _ => expr.clone(),
-    }
+        ExprKind::Binary(op, l, r) => ExprKind::Binary(
+            *op,
+            Box::new(subst_expr_sim(l, params)),
+            Box::new(subst_expr_sim(r, params)),
+        ),
+        ExprKind::Unary(op, e) => ExprKind::Unary(
+            *op,
+            Box::new(subst_expr_sim(e, params)),
+        ),
+        ExprKind::Ternary(c, t, e) => ExprKind::Ternary(
+            Box::new(subst_expr_sim(c, params)),
+            Box::new(subst_expr_sim(t, params)),
+            Box::new(subst_expr_sim(e, params)),
+        ),
+        ExprKind::Clog2(e) => ExprKind::Clog2(Box::new(subst_expr_sim(e, params))),
+        ExprKind::Index(b, i) => ExprKind::Index(
+            Box::new(subst_expr_sim(b, params)),
+            Box::new(subst_expr_sim(i, params)),
+        ),
+        _ => return expr.clone(),
+    };
+    Expr { kind, span: expr.span, parenthesized: expr.parenthesized }
 }
 
 /// Return flattened bus port signals with direction: Vec<(flat_name, Direction, TypeExpr)>.
@@ -4347,7 +4367,8 @@ impl<'a> SimCodegen<'a> {
                 let mut pm = info.default_param_map();
                 for pa in &bi.params { pm.insert(pa.name.name.clone(), &pa.value); }
                 for (sname, _sdir, ty) in info.effective_signals(&pm) {
-                    let bits = type_bits_te(&ty);
+                    let subst_ty = subst_type_expr_sim(&ty, &pm);
+                    let bits = type_bits_te_with_params(&subst_ty, &m.params);
                     widths.entry(format!("{parent_name}_{sname}")).or_insert(bits);
                 }
             }
@@ -4830,7 +4851,8 @@ impl<'a> SimCodegen<'a> {
                     }
                     let flat = format!("{}_{}", p.name.name, sname);
                     if !uninit_inputs.contains(&flat) { continue; }
-                    let ty = cpp_port_type_with_params(&sty, &m.params);
+                    let subst_ty = subst_type_expr_sim(&sty, &param_map);
+                    let ty = cpp_port_type_with_params(&subst_ty, &m.params);
                     h.push_str(&format!(
                         "  void set_{flat}({ty} v) {{ {flat} = v; _{flat}_vinit = true; }}\n"
                     ));

--- a/src/sim_codegen/thread_sim.rs
+++ b/src/sim_codegen/thread_sim.rs
@@ -31,7 +31,7 @@
 use crate::ast::{
     ArbiterPolicy, BinOp, CombAssign, Stmt, Direction, Expr, ExprKind, IfElseOf,
     LitKind, ModuleBodyItem, ModuleDecl, RegAssign, ResetLevel,
-    ThreadBlock, ThreadStmt, TypeExpr, UnaryOp,
+    ParamDecl, ThreadBlock, ThreadStmt, TypeExpr, UnaryOp,
 };
 use crate::sim_codegen::SimModel;
 
@@ -178,8 +178,18 @@ pub fn gen_module_thread(m: &ModuleDecl, debug: bool, wave: bool, num_os_threads
     header.push_str("#include \"verilated.h\"\n\n");
     header.push_str(&format!("class {} {{\npublic:\n", class));
 
+    for p in &m.params {
+        if let Some(def) = &p.default {
+            let val = eval_const_with_params(def, &m.params);
+            header.push_str(&format!("  static constexpr uint64_t {} = {}ULL;\n", p.name.name, val));
+        }
+    }
+    if !m.params.is_empty() {
+        header.push('\n');
+    }
+
     for p in &m.ports {
-        let cpp_ty = port_or_reg_cpp_ty(&p.ty)
+        let cpp_ty = port_or_reg_cpp_ty_with_params(&p.ty, &m.params)
             .map_err(|e| format!("module `{}` port `{}`: {}", class, p.name.name, e))?;
         header.push_str(&format!("  {} {} = 0;\n", cpp_ty, p.name.name));
     }
@@ -189,16 +199,16 @@ pub fn gen_module_thread(m: &ModuleDecl, debug: bool, wave: bool, num_os_threads
     for item in &m.body {
         if let ModuleBodyItem::RegDecl(r) = item {
             if let TypeExpr::Vec(elem, count_expr) = &r.ty {
-                let elem_ty = port_or_reg_cpp_ty(elem)
+                let elem_ty = port_or_reg_cpp_ty_with_params(elem, &m.params)
                     .map_err(|e| format!("module `{}` reg `{}` element: {}", class, r.name.name, e))?;
-                let count = eval_const(count_expr);
+                let count = eval_const_with_params(count_expr, &m.params);
                 if count == 0 {
                     return Err(format!("module `{}` reg `{}`: Vec count = 0 (param resolution not yet supported)", class, r.name.name));
                 }
                 header.push_str(&format!("  {} {}[{}] = {{}};\n", elem_ty, r.name.name, count));
                 vec_reg_info.push((r.name.name.clone(), elem_ty, count));
             } else {
-                let cpp_ty = port_or_reg_cpp_ty(&r.ty)
+                let cpp_ty = port_or_reg_cpp_ty_with_params(&r.ty, &m.params)
                     .map_err(|e| format!("module `{}` reg `{}`: {}", class, r.name.name, e))?;
                 header.push_str(&format!("  {} {} = 0;\n", cpp_ty, r.name.name));
             }
@@ -217,7 +227,7 @@ pub fn gen_module_thread(m: &ModuleDecl, debug: bool, wave: bool, num_os_threads
             // For typed lets, infer width; for untyped (target=port),
             // the previous filter already skipped them.
             let cpp_ty = match &lb.ty {
-                Some(t) => port_or_reg_cpp_ty(t)
+                Some(t) => port_or_reg_cpp_ty_with_params(t, &m.params)
                     .map_err(|e| format!("module `{}` let `{}`: {}", class, lb.name.name, e))?,
                 None => continue, // untyped lets must alias a port — handled by the filter above
             };
@@ -395,7 +405,7 @@ pub fn gen_module_thread(m: &ModuleDecl, debug: bool, wave: bool, num_os_threads
     for item in &m.body {
         if let ModuleBodyItem::RegDecl(r) = item {
             if let TypeExpr::Vec(_, count_expr) = &r.ty {
-                let count = eval_const(count_expr);
+                let count = eval_const_with_params(count_expr, &m.params);
                 header.push_str(&format!("      for (uint64_t _i = 0; _i < {count}; _i++) {} [_i] = 0;\n", r.name.name));
             } else {
                 header.push_str(&format!("      {} = 0;\n", r.name.name));
@@ -513,7 +523,7 @@ pub fn gen_module_thread(m: &ModuleDecl, debug: bool, wave: bool, num_os_threads
             let dir = match p.direction { Direction::In => "in", Direction::Out => "out" };
             let bits = match &p.ty {
                 TypeExpr::Bool | TypeExpr::Bit | TypeExpr::Reset(..) => 1,
-                TypeExpr::UInt(w) => eval_const(w),
+                TypeExpr::UInt(w) => eval_const_with_params(w, &m.params),
                 _ => continue,  // Vec / wide / bus skipped in Phase 5 spike
             };
             if bits == 0 || bits > 64 { continue; }
@@ -541,7 +551,7 @@ pub fn gen_module_thread(m: &ModuleDecl, debug: bool, wave: bool, num_os_threads
         for p in &m.ports {
             let width = match &p.ty {
                 TypeExpr::Clock(_) | TypeExpr::Bool | TypeExpr::Bit | TypeExpr::Reset(..) => 1,
-                TypeExpr::UInt(w) => eval_const(w) as u32,
+                TypeExpr::UInt(w) => eval_const_with_params(w, &m.params) as u32,
                 _ => continue,
             };
             if width == 0 || width > 64 { continue; }
@@ -562,11 +572,11 @@ pub fn gen_module_thread(m: &ModuleDecl, debug: bool, wave: bool, num_os_threads
                 if let TypeExpr::Vec(elem, count_expr) = &r.ty {
                     let elem_width = match elem.as_ref() {
                         TypeExpr::Bool | TypeExpr::Bit => 1,
-                        TypeExpr::UInt(w) => eval_const(w) as u32,
+                        TypeExpr::UInt(w) => eval_const_with_params(w, &m.params) as u32,
                         _ => continue,
                     };
                     if elem_width == 0 || elem_width > 64 { continue; }
-                    let count = eval_const(count_expr);
+                    let count = eval_const_with_params(count_expr, &m.params);
                     for i in 0..count {
                         signals.push(crate::sim_codegen::TraceSignal {
                             vcd_name: format!("{}[{}]", r.name.name, i),
@@ -578,7 +588,7 @@ pub fn gen_module_thread(m: &ModuleDecl, debug: bool, wave: bool, num_os_threads
                 } else {
                     let width = match &r.ty {
                         TypeExpr::Bool | TypeExpr::Bit => 1,
-                        TypeExpr::UInt(w) => eval_const(w) as u32,
+                        TypeExpr::UInt(w) => eval_const_with_params(w, &m.params) as u32,
                         _ => continue,
                     };
                     if width == 0 || width > 64 { continue; }
@@ -665,7 +675,7 @@ pub fn gen_module_thread(m: &ModuleDecl, debug: bool, wave: bool, num_os_threads
         header.push_str("  uint64_t _dbg_cycle = 0;\n");
         for p in &m.ports {
             if matches!(&p.ty, TypeExpr::Clock(_)) { continue; }
-            let cpp_ty = port_or_reg_cpp_ty(&p.ty)
+            let cpp_ty = port_or_reg_cpp_ty_with_params(&p.ty, &m.params)
                 .map_err(|e| format!("module `{}` port `{}`: {}", class, p.name.name, e))?;
             header.push_str(&format!("  {cpp_ty} _dbg_prev_{} = 0;\n", p.name.name));
         }
@@ -752,11 +762,7 @@ pub fn gen_module_thread(m: &ModuleDecl, debug: bool, wave: bool, num_os_threads
                     ));
                 }
                 WaitKind::Cycles(n) => {
-                    let n_str = match &n.kind {
-                        ExprKind::Literal(LitKind::Dec(v)) => format!("{}", v),
-                        ExprKind::Literal(LitKind::Sized(_, v)) => format!("{}", v),
-                        _ => return Err("wait <N> cycle: only literal N supported".into()),
-                    };
+                    let n_str = expr_to_cpp(n)?;
                     body_cpp.push_str(&format!(
                         "{pad2}co_await arch_rt::wait_cycles(&_slot_{ti}, {n_str});\n"
                     ));
@@ -1333,6 +1339,8 @@ fn expr_to_cpp(e: &Expr) -> Result<String, String> {
                 BinOp::Add | BinOp::AddWrap => "+",
                 BinOp::Sub | BinOp::SubWrap => "-",
                 BinOp::Mul | BinOp::MulWrap => "*",
+                BinOp::Div => "/",
+                BinOp::Mod => "%",
                 BinOp::Eq => "==", BinOp::Neq => "!=",
                 BinOp::Lt => "<",  BinOp::Gt => ">",
                 BinOp::Lte => "<=", BinOp::Gte => ">=",
@@ -1365,20 +1373,57 @@ fn expr_to_cpp_bool(e: &Expr) -> Result<String, String> {
     }
 }
 
-fn port_or_reg_cpp_ty(ty: &TypeExpr) -> Result<String, String> {
+fn port_or_reg_cpp_ty_with_params(ty: &TypeExpr, params: &[ParamDecl]) -> Result<String, String> {
     match ty {
         TypeExpr::Clock(_) | TypeExpr::Reset(..) | TypeExpr::Bool | TypeExpr::Bit => Ok("uint8_t".to_string()),
-        TypeExpr::UInt(w) => uint_cpp_ty(eval_const(w)),
+        TypeExpr::UInt(w) => uint_cpp_ty(eval_const_with_params(w, params)),
         other => Err(format!("type {:?} not supported", other)),
     }
 }
 
-fn eval_const(e: &Expr) -> u64 {
+fn eval_const_with_params(e: &Expr, params: &[ParamDecl]) -> u64 {
     match &e.kind {
         ExprKind::Literal(LitKind::Dec(v)) => *v,
         ExprKind::Literal(LitKind::Hex(v)) => *v,
         ExprKind::Literal(LitKind::Bin(v)) => *v,
         ExprKind::Literal(LitKind::Sized(_, v)) => *v,
+        ExprKind::Ident(name) => {
+            params.iter()
+                .find(|p| p.name.name == *name)
+                .and_then(|p| p.default.as_ref())
+                .map(|d| eval_const_with_params(d, params))
+                .unwrap_or(0)
+        }
+        ExprKind::Clog2(a) => {
+            let v = eval_const_with_params(a, params);
+            if v <= 1 { 0 } else { 64 - (v - 1).leading_zeros() as u64 }
+        }
+        ExprKind::Unary(op, a) => {
+            let v = eval_const_with_params(a, params);
+            match op {
+                UnaryOp::Not => !v,
+                UnaryOp::BitNot => !v,
+                UnaryOp::Neg => v.wrapping_neg(),
+                UnaryOp::RedAnd | UnaryOp::RedOr | UnaryOp::RedXor => 0,
+            }
+        }
+        ExprKind::Binary(op, l, r) => {
+            let lv = eval_const_with_params(l, params);
+            let rv = eval_const_with_params(r, params);
+            match op {
+                BinOp::Add | BinOp::AddWrap => lv.wrapping_add(rv),
+                BinOp::Sub | BinOp::SubWrap => lv.wrapping_sub(rv),
+                BinOp::Mul | BinOp::MulWrap => lv.wrapping_mul(rv),
+                BinOp::Div => if rv == 0 { 0 } else { lv / rv },
+                BinOp::Mod => if rv == 0 { 0 } else { lv % rv },
+                BinOp::Shl => lv.wrapping_shl(rv as u32),
+                BinOp::Shr => lv.wrapping_shr(rv as u32),
+                BinOp::BitAnd => lv & rv,
+                BinOp::BitOr => lv | rv,
+                BinOp::BitXor => lv ^ rv,
+                _ => 0,
+            }
+        }
         _ => 0,
     }
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -3384,6 +3384,34 @@ fn compile_to_sim_h(source: &str, inputs_start_uninit: bool) -> String {
         .join("\n// ---\n")
 }
 
+fn compile_to_thread_sim_h(source: &str) -> String {
+    let tokens = arch::lexer::tokenize(source).expect("lexer error");
+    let mut parser = arch::parser::Parser::new(tokens, source);
+    let parsed_ast = parser.parse_source_file().expect("parse error");
+    let ast = arch::elaborate::elaborate(parsed_ast).expect("elaborate error");
+    let ast = arch::elaborate::lower_tlm_target_threads(ast).expect("tlm target lowering");
+    let ast = arch::elaborate::lower_tlm_initiator_calls(ast).expect("tlm initiator lowering");
+    let ast = arch::elaborate::lower_pipe_reg_ports(ast).expect("lower pipe_reg error");
+    let ast = arch::elaborate::lower_credit_channel_dispatch(ast).expect("cc dispatch error");
+    let symbols = arch::resolve::resolve(&ast).expect("resolve error");
+    let checker = arch::typecheck::TypeChecker::new(&symbols, &ast);
+    checker.check().expect("type check error");
+
+    ast.items.iter()
+        .filter_map(|item| match item {
+            arch::ast::Item::Module(m)
+                if m.body.iter().any(|i| matches!(i, arch::ast::ModuleBodyItem::Thread(_))) =>
+            {
+                Some(arch::sim_codegen::thread_sim::gen_module_thread(m, false, false, 1)
+                    .expect("thread sim codegen"))
+            }
+            _ => None,
+        })
+        .map(|m| format!("{}\n// ---\n{}", m.header, m.impl_))
+        .collect::<Vec<_>>()
+        .join("\n// ---\n")
+}
+
 #[test]
 fn test_inputs_start_uninit_bus_flattened() {
     // --inputs-start-uninit should now emit shadow vinit bits and setters
@@ -5737,6 +5765,123 @@ fn test_tlm_method_wires_flatten_at_bus_port() {
         "rsp_data should appear with declared ret type:\n{sv}");
     assert!(sv.contains("output logic m_read_rsp_ready"),
         "rsp_ready flows back from initiator to target:\n{sv}");
+}
+
+#[test]
+fn test_tlm_method_param_widths_substitute_in_implicit_bus_wires() {
+    // arch-com#352: TLM method arg/ret/tag widths may be bus params.
+    // A parent instantiating a child bus port through an undeclared
+    // parent-side bus signal exercises the implicit bus-wire declaration
+    // path; pre-fix it emitted `logic [TILE_W-1:0] link_read_tile;`
+    // without declaring TILE_W in the parent SV module.
+    let source = "
+        bus Mem
+          param KV_HEAD_W: const = 2;
+          param TILE_W: const = 4;
+          param TOKEN_W: const = 8;
+          tlm_method read(tile: UInt<TILE_W>) -> UInt<TOKEN_W>: out_of_order tags KV_HEAD_W;
+        end bus Mem
+
+        use Mem;
+
+        module Child
+          port m: initiator Mem<KV_HEAD_W=3, TILE_W=5, TOKEN_W=17>;
+          comb
+            m.read_req_valid = 1'b0;
+            m.read_req_tag = 3'h0;
+            m.read_tile = 5'h0;
+            m.read_rsp_ready = 1'b0;
+          end comb
+        end module Child
+
+        module Parent
+          inst c: Child
+            m -> link;
+          end inst c
+        end module Parent
+    ";
+    let sv = compile_to_sv(source);
+    assert!(sv.contains("logic [2:0] link_read_req_tag;"),
+        "implicit req tag wire should use overridden KV_HEAD_W:\n{sv}");
+    assert!(sv.contains("logic [4:0] link_read_tile;"),
+        "implicit arg wire should use overridden TILE_W:\n{sv}");
+    assert!(sv.contains("logic [16:0] link_read_rsp_data;"),
+        "implicit response wire should use overridden TOKEN_W:\n{sv}");
+    assert!(!sv.contains("KV_HEAD_W") && !sv.contains("TILE_W") && !sv.contains("TOKEN_W"),
+        "generated SV should not leak bus param identifiers into Parent plumbing:\n{sv}");
+}
+
+#[test]
+fn test_tlm_method_param_widths_substitute_in_lowered_target_and_initiator() {
+    // arch-com#352 original shape: TLM target/initiator lowering creates
+    // latch regs and request mux plumbing from method arg/return types.
+    // Those generated declarations must see bus params too, not emit
+    // dangling identifiers such as TILE_W or TOKEN_W into SV.
+    let source = "
+        bus Mem
+          param TILE_W: const = 4;
+          param TOKEN_W: const = 8;
+          tlm_method read(tile: UInt<TILE_W>) -> UInt<TOKEN_W>: blocking;
+        end bus Mem
+
+        use Mem;
+
+        module Target
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync>;
+          port m: target Mem<TILE_W=5, TOKEN_W=17>;
+
+          thread m.read(tile) on clk rising, rst high
+            wait 1 cycle;
+            return {12'd0, tile};
+          end thread m.read
+        end module Target
+
+        module Driver
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync>;
+          port m: initiator Mem<TILE_W=5, TOKEN_W=17>;
+          port data_out: out UInt<17>;
+
+          reg data: UInt<17> reset rst => 0;
+
+          thread on clk rising, rst high
+            data <= m.read(5'd3);
+          end thread
+
+          comb
+            data_out = data;
+          end comb
+        end module Driver
+
+        module Top
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync>;
+          port data_out: out UInt<17>;
+
+          inst d: Driver
+            clk <- clk;
+            rst <- rst;
+            m -> link;
+            data_out -> data_out;
+          end inst d
+
+          inst t: Target
+            clk <- clk;
+            rst <- rst;
+            m -> link;
+          end inst t
+        end module Top
+    ";
+    let sv = compile_to_sv(source);
+    assert!(sv.contains("logic [4:0] _tlm_m_read_tile_latched;"),
+        "target latch reg should use substituted TILE_W:\n{sv}");
+    assert!(sv.contains("output logic [16:0] m_read_rsp_data"),
+        "target response data should use substituted TOKEN_W:\n{sv}");
+    assert!(sv.contains("assign m_read_tile = _tlm_init_m_read_grant_0 ? 5'd3 : 0;"),
+        "initiator request drive should use substituted TILE_W:\n{sv}");
+    assert!(!sv.contains("TILE_W") && !sv.contains("TOKEN_W"),
+        "lowered generated SV should not leak bus param identifiers:\n{sv}");
 }
 
 #[test]
@@ -9718,6 +9863,40 @@ fn test_lower_threads_clones_parent_params_into_threads_submodule() {
     // identifier survived lowering).
     assert!(sv.contains("OP_GO") && sv.matches("OP_GO").count() >= 3,
         "thread body should compare op_i against OP_GO:\n{sv}");
+}
+
+#[test]
+fn test_thread_sim_declares_module_params_used_by_thread_body() {
+    // arch-com#352: the ARCH-native coroutine thread sim path skips
+    // lower_threads, so parent params are not cloned into a synthetic FSM
+    // module. The thread sim emitter must make them visible to generated
+    // C++ methods instead of emitting undeclared identifiers like
+    // SCHEDULED_CORE_CYCLES.
+    let source = r#"
+        module M
+          param SCHEDULED_CORE_CYCLES: const = 7;
+          param DONE_W: const = SCHEDULED_CORE_CYCLES + 1;
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync, High>;
+          port done: out UInt<DONE_W>;
+
+          thread on clk rising, rst high
+            wait SCHEDULED_CORE_CYCLES cycle;
+            done = DONE_W;
+          end thread
+        end module M
+    "#;
+    let h = compile_to_thread_sim_h(source);
+    assert!(h.contains("static constexpr uint64_t SCHEDULED_CORE_CYCLES = 7ULL;"),
+        "thread sim header should declare module param constants:\n{h}");
+    assert!(h.contains("static constexpr uint64_t DONE_W = 8ULL;"),
+        "derived module params should be folded for C++ visibility:\n{h}");
+    assert!(h.contains("co_await arch_rt::wait_cycles(&_slot_0, SCHEDULED_CORE_CYCLES);"),
+        "wait-cycle expression should keep using the declared constexpr param:\n{h}");
+    assert!(h.contains("done = DONE_W;"),
+        "thread body should use the declared constexpr param:\n{h}");
+    assert!(h.contains("uint8_t done = 0;"),
+        "param-derived port widths should resolve in thread sim C++ types:\n{h}");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- substitute bus params before emitting TLM flattened SV/C++ plumbing
- specialize TLM method metadata per module bus port before target/initiator lowering, so generated latch and mux declarations do not leak bus param identifiers
- emit module params as constexprs in ARCH-native thread sim and resolve param-derived thread sim widths/waits
- add regressions for arch-com#352 covering implicit bus wires, lowered TLM target/initiator paths, and thread-visible module params

Fixes #352.

## Validation
- cargo test test_tlm_method_param_widths_substitute_in_implicit_bus_wires
- cargo test test_tlm_method_param_widths_substitute_in_lowered_target_and_initiator
- cargo test test_thread_sim_declares_module_params_used_by_thread_body
- cargo test test_tlm_method_wires_flatten_at_bus_port
- cargo check
- git diff --check

Note: cargo fmt --check still reports broad pre-existing rustfmt drift across the repository, so I did not apply rustfmt churn in this PR.