### PR TITLE
Fix typed params in native sim codegen

### DIFF
--- a/src/sim_codegen/mod.rs
+++ b/src/sim_codegen/mod.rs
@@ -474,14 +474,24 @@ impl<'a> SimCodegen<'a> {
         let enum_map = build_enum_map(self.symbols);
         for p in &m.params {
             match &p.kind {
-                ParamKind::Const | ParamKind::WidthConst(..) => {
+                ParamKind::Const | ParamKind::WidthConst(..) | ParamKind::Logic(_) => {
                     if let Some(ref def) = p.default {
-                        let val = eval_const_expr(def);
+                        let val = eval_const_expr_with_params(def, &m.params);
                         let pname = &p.name.name;
                         bindings.push(format!(
                             "        .def_property_readonly_static(\"{pname}\", [](py::object) {{ return {val}ULL; }})"
                         ));
-                        port_info.push((pname.clone(), 32, false, false, true, false));
+                        let width = match &p.kind {
+                            ParamKind::Logic(ty) => type_bits_te_with_params(ty, &m.params),
+                            ParamKind::WidthConst(hi, lo) => {
+                                let h = eval_const_expr_with_params(hi, &m.params);
+                                let l = eval_const_expr_with_params(lo, &m.params);
+                                (h - l + 1) as u32
+                            }
+                            _ => 32,
+                        };
+                        let is_signed = matches!(&p.kind, ParamKind::Logic(TypeExpr::SInt(_)));
+                        port_info.push((pname.clone(), width, is_signed, false, true, false));
                     }
                 }
                 ParamKind::EnumConst(enum_name) => {
@@ -3488,7 +3498,7 @@ fn build_widths(ports: &[PortDecl], body: &[ModuleBodyItem], params: &[ParamDecl
                 let l = eval_width(lo);
                 h - l + 1
             }
-            ParamKind::Logic(ty) | ParamKind::Type(ty) => type_bits_te(ty),
+            ParamKind::Logic(ty) | ParamKind::Type(ty) => type_bits_te_with_params(ty, params),
             // `param X: const = N` (untyped). Pre-existing call sites treat
             // this as an int-typed parameter (32 bits), so match.
             ParamKind::Const => 32,
@@ -4486,9 +4496,9 @@ impl<'a> SimCodegen<'a> {
         // Emit param constants as #define
         for p in &m.params {
             match &p.kind {
-                ParamKind::Const | ParamKind::WidthConst(..) => {
+                ParamKind::Const | ParamKind::WidthConst(..) | ParamKind::Logic(_) => {
                     if let Some(ref def) = p.default {
-                        let val = eval_const_expr(def);
+                        let val = eval_const_expr_with_params(def, &m.params);
                         h.push_str(&format!("#ifndef {}\n#define {} {val}ULL\n#endif\n", p.name.name, p.name.name));
                     }
                 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -9900,6 +9900,41 @@ fn test_thread_sim_declares_module_params_used_by_thread_body() {
 }
 
 #[test]
+fn test_sim_codegen_declares_typed_module_params_used_by_lowered_thread_body() {
+    // Typed value params (`param X: UInt<W> = ...`) are valid ARCH params and
+    // SV codegen emits them, but the native C++ sim header also has to expose
+    // them because lowered thread/TLM bodies may reference the param name.
+    let source = r#"
+        module M
+          param SCHEDULED_CORE_CYCLES: UInt<32> = 32'd7;
+          param DONE_W: UInt<32> = SCHEDULED_CORE_CYCLES + 32'd1;
+          param CALLS: UInt<16> = 16'd3;
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync, High>;
+          port done: out UInt<DONE_W>;
+          reg calls_r: UInt<16> reset rst => 0;
+
+          thread on clk rising, rst high
+            wait SCHEDULED_CORE_CYCLES cycle;
+            done = 8'd8;
+            calls_r <= CALLS;
+          end thread
+        end module M
+    "#;
+    let cpp = compile_to_sim_h(source, false);
+    assert!(cpp.contains("#define SCHEDULED_CORE_CYCLES 7ULL"),
+        "sim header should define typed module params for lowered thread bodies:\n{cpp}");
+    assert!(cpp.contains("#define DONE_W 8ULL"),
+        "derived typed module params should be folded for C++ visibility:\n{cpp}");
+    assert!(cpp.contains("#define CALLS 3ULL"),
+        "narrow typed module params should also be emitted:\n{cpp}");
+    assert!(cpp.contains("uint8_t done;"),
+        "param-derived port widths should resolve in normal sim C++ types:\n{cpp}");
+    assert!(cpp.contains("_n_calls_r  = CALLS;"),
+        "lowered thread body should keep using the declared C++ param constant:\n{cpp}");
+}
+
+#[test]
 fn test_sim_codegen_bit_slice_lhs_compiles_and_uses_param_width() {
     // Regression: pre-fix, `name[hi:lo] = val` in a seq block lowered to
     // the read-side bit-slice form `((name >> lo) & MASK) = val`, an


### PR DESCRIPTION
## Summary
- emit Logic-typed module params as C++ constants in native sim headers
- evaluate derived param defaults with module params when exposing sim constants
- add regression coverage for typed params referenced from lowered thread bodies

## Validation
- cargo test test_sim_codegen_declares_typed_module_params_used_by_lowered_thread_body
- cargo test test_thread_sim_declares_module_params_used_by_thread_body
- cargo check
- git diff --check
- FPT downstream proof: make arch-tlm-build; make arch-tlm-cosim; make decode-tlm-check