### PR TITLE
Preserve thread-driven reg wire types

### DIFF
--- a/src/elaborate.rs
+++ b/src/elaborate.rs
@@ -2782,15 +2782,24 @@ fn lower_module_threads(m: ModuleDecl, opts: &ThreadLowerOpts) -> Result<(Module
     };
     new_body.push(ModuleBodyItem::Inst(inst));
 
-    // Remove RegDecls for thread-driven regs (now inside merged module)
+    // Thread-driven regs live inside the synthesized threads module. Keep a
+    // typed parent-side wire for each moved reg so ordinary parent logic can
+    // still read the instance output with the original signedness/width.
     let thread_driven: HashSet<String> = all_seq_driven.iter().chain(all_comb_driven.iter()).cloned().collect();
-    new_body.retain(|item| {
-        if let ModuleBodyItem::RegDecl(r) = item {
-            !thread_driven.contains(&r.name.name)
-        } else {
-            true
+    for item in &mut new_body {
+        let ModuleBodyItem::RegDecl(r) = item else {
+            continue;
+        };
+        if thread_driven.contains(&r.name.name) {
+            *item = ModuleBodyItem::WireDecl(WireDecl {
+                name: r.name.clone(),
+                ty: r.ty.clone(),
+                unpacked: false,
+                unpacked_ascending: false,
+                span: r.span,
+            });
         }
-    });
+    }
 
     let new_module = ModuleDecl { body: new_body, ..m };
     let mut extras = synthesized_arbiters;

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -12566,6 +12566,50 @@ fn test_sint_40_param_width_emits_int64_storage_and_signed_trunc() {
 }
 
 #[test]
+fn test_thread_driven_sint_reg_keeps_parent_wire_type() {
+    let source = r#"
+        domain SysDomain
+          freq_mhz: 250
+        end domain SysDomain
+
+        module SignedThread
+          local param A: const = 21;
+          local param B: const = 16;
+          local param P: const = A + B;
+          local param W: const = P + 8;
+
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync>;
+          port start: in Bool;
+          port weight: in UInt<A>;
+          port val: in SInt<B>;
+          port y: out SInt<W>;
+
+          reg acc: SInt<W> reset rst => 0;
+          let weight_signed: SInt<A> = signed(weight);
+          let product_raw: SInt<P> = weight_signed * val;
+          let product_ext: SInt<W> = product_raw.sext<W>();
+          let next_acc: SInt<W> = (acc + product_ext).trunc<W>();
+
+          thread T on clk rising, rst high
+            wait until start;
+            acc <= next_acc;
+          end thread T
+
+          comb
+            y = next_acc;
+          end comb
+        end module SignedThread
+    "#;
+
+    let sv = compile_to_sv(source);
+    assert!(sv.contains("logic signed [W-1:0] acc;"),
+            "parent-side wire for thread-driven SInt reg should keep signedness/width:\n{sv}");
+    assert!(sv.contains("assign next_acc = W'(acc + product_ext);"),
+            "parent expression should see typed signed acc/product_ext and emit the trunc assignment:\n{sv}");
+}
+
+#[test]
 fn test_sint_40_inst_output_wire_keeps_signed_storage() {
     let source = r#"
         module Bf16DotEngine


### PR DESCRIPTION
## Summary
- keep a typed parent-side wire when thread lowering moves a thread-driven reg into the synthesized thread module
- preserve signedness and param-derived width for parent expressions that read thread-driven regs
- add a regression for a signed param-derived accumulator feeding a lowered thread

## Validation
- cargo test test_thread_driven_sint_reg_keeps_parent_wire_type --test integration_test
- cargo test test_sint_40 --test integration_test
- cargo check

Note: rustfmt --check src/elaborate.rs tests/integration_test.rs still reports the repo's existing broad formatting churn, so I did not apply formatting changes.