### PR TITLE
Emit pipe_reg in generated interfaces

### DIFF
--- a/src/interface.rs
+++ b/src/interface.rs
@@ -381,16 +381,20 @@ pub(crate) fn emit_ports_with_deps(
                 (true, false) => "unpacked ",
                 _             => "",
             };
-            // For port reg with reset, include reset clause
+            // Registered output ports are emitted in the canonical
+            // `pipe_reg<T, N>` spelling. This includes legacy `port reg`
+            // source declarations and compiler-synthesized thread ports;
+            // `.archi` files should expose latency in the port signature.
             if let Some(ref ri) = p.reg_info {
+                let reg_ty = format!("pipe_reg<{unpacked_kw}{ty}, {}>", ri.latency);
                 match &ri.reset {
                     RegReset::Inherit(rst, val) | RegReset::Explicit(rst, _, _, val) => {
                         let rst_name = &rst.name;
                         let rst_val = expr_str(val);
-                        s.push_str(&format!("  port reg {name}: {dir} {unpacked_kw}{ty} reset {rst_name} => {rst_val};\n"));
+                        s.push_str(&format!("  port {name}: {dir} {reg_ty} reset {rst_name} => {rst_val};\n"));
                     }
                     RegReset::None => {
-                        s.push_str(&format!("  port reg {name}: {dir} {unpacked_kw}{ty};\n"));
+                        s.push_str(&format!("  port {name}: {dir} {reg_ty};\n"));
                     }
                 }
             } else {

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -1620,11 +1620,12 @@ impl<'a> TypeChecker<'a> {
         }
     }
 
-    /// Warn when `port reg` outputs are assigned inside state-dependent if/elsif
-    /// chains in seq blocks. This indicates the output has 1-cycle latency relative
-    /// to the state that drives it — a common timing mismatch with testbench models.
+    /// Warn when registered output ports are assigned inside state-dependent
+    /// if/elsif chains in seq blocks. This indicates the output has register
+    /// latency relative to the state that drives it — a common timing mismatch
+    /// with testbench models.
     pub(crate) fn check_port_reg_timing(&mut self, m: &ModuleDecl) {
-        // Collect port reg output names
+        // Collect registered output port names.
         let port_reg_names: HashSet<String> = m.ports.iter()
             .filter(|p| p.reg_info.is_some() && p.direction == Direction::Out)
             .map(|p| p.name.name.clone())
@@ -1642,13 +1643,13 @@ impl<'a> TypeChecker<'a> {
             })
             .collect();
 
-        // Collect port reg spans for warning locations
+        // Collect registered output spans for warning locations.
         let port_reg_spans: HashMap<String, Span> = m.ports.iter()
             .filter(|p| p.reg_info.is_some() && p.direction == Direction::Out)
             .map(|p| (p.name.name.clone(), p.span))
             .collect();
 
-        // Scan seq blocks for state-dependent port reg assignments
+        // Scan seq blocks for state-dependent registered-output assignments.
         let mut warned: HashSet<String> = HashSet::new();
         for item in &m.body {
             if let ModuleBodyItem::RegBlock(rb) = item {
@@ -1662,7 +1663,7 @@ impl<'a> TypeChecker<'a> {
         }
     }
 
-    /// Recursively scan a seq statement for port reg assignments inside
+    /// Recursively scan a seq statement for registered-output assignments inside
     /// state-dependent if/elsif chains.
     fn find_state_dependent_port_reg_assigns(
         &mut self,
@@ -1689,9 +1690,9 @@ impl<'a> TypeChecker<'a> {
                                 if let Some(&span) = port_reg_spans.get(&target) {
                                     self.warnings.push(CompileWarning {
                                         message: format!(
-                                            "`{target}` is a `port reg` output assigned inside a state-dependent \
-                                             branch — output value appears 1 cycle after the state transition. \
-                                             Use `port` + `comb` for same-cycle outputs"
+                                            "`{target}` is a registered output (`pipe_reg<T, N>`) assigned inside a state-dependent \
+                                             branch — output value appears after the declared output latency. \
+                                             Use a plain `out T` port driven by `comb` for same-cycle outputs"
                                         ),
                                         span,
                                     });

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -10327,6 +10327,44 @@ end module AscIface
 }
 
 #[test]
+fn test_archi_registered_output_emits_pipe_reg_signature() {
+    // `.archi` is the cross-file contract, so registered output latency should
+    // be visible there even when the source used the deprecated `port reg`
+    // spelling.
+    let source = "
+domain SysDomain
+  freq_mhz: 100
+end domain SysDomain
+
+module PipeIface
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port reg legacy_q: out UInt<8> reset rst => 0;
+  port modern_q: out pipe_reg<SInt<16>, 2> reset rst => 0;
+end module PipeIface
+";
+    let tokens = lexer::tokenize(source).expect("lexer error");
+    let mut parser = Parser::new(tokens, source);
+    let parsed = parser.parse_source_file().expect("parse error");
+    let item = parsed.items.iter()
+        .find(|i| matches!(i, arch::ast::Item::Module(_)))
+        .expect("expected a module item");
+    let body = arch::interface::emit_interface(item).expect("emit_interface");
+    assert!(
+        body.contains("port legacy_q: out pipe_reg<UInt<8>, 1> reset rst => 0;"),
+        ".archi should canonicalize legacy port reg to pipe_reg<T,1>: {body}"
+    );
+    assert!(
+        body.contains("port modern_q: out pipe_reg<SInt<16>, 2> reset rst => 0;"),
+        ".archi should preserve pipe_reg latency: {body}"
+    );
+    assert!(
+        !body.contains("port reg"),
+        ".archi should not emit deprecated port reg spelling: {body}"
+    );
+}
+
+#[test]
 fn test_unpacked_on_non_vec_is_rejected() {
     let source = r#"
 module unpacked_neg


### PR DESCRIPTION
## Summary
- emit registered output ports in generated .archi files as pipe_reg<T,N> instead of deprecated port reg
- canonicalize legacy port reg source declarations in interface stubs
- update registered-output timing warning wording to use pipe_reg<T,N>

## Validation
- cargo test test_archi_registered_output_emits_pipe_reg_signature --test integration_test
- cargo test port_reg_deprecation --test integration_test
- cargo test pipe_reg_port_no_deprecation --test integration_test
- cargo check
- git diff --check
- make arch-check / make arch-build in fpt26-accel, confirming no generated interface still contains port reg