### PR TITLE
Allow compute-only if in TLM initiator threads

### DIFF
--- a/src/elaborate.rs
+++ b/src/elaborate.rs
@@ -6550,6 +6550,61 @@ fn build_tlm_init_thread_plan(
         span: Span,
         current_lock: Option<&str>,
     ) -> Result<(), CompileError> {
+        fn compute_only_thread_stmts_to_seq(
+            stmts: Vec<ThreadStmt>,
+            port_buses: &std::collections::HashMap<String, String>,
+            bus_methods: &std::collections::HashMap<String, Vec<TlmMethodMeta>>,
+            span: Span,
+        ) -> Result<Vec<Stmt>, CompileError> {
+            let mut out = Vec::new();
+            for stmt in stmts {
+                match stmt {
+                    ThreadStmt::SeqAssign(ra) => {
+                        if contains_tlm_call(&ra.value, port_buses, bus_methods)
+                            || contains_tlm_call(&ra.target, port_buses, bus_methods)
+                        {
+                            return Err(CompileError::general(
+                                "TLM method calls inside `if` branches are not supported in v1 initiator lowering",
+                                ra.span,
+                            ));
+                        }
+                        out.push(Stmt::Assign(ra));
+                    }
+                    ThreadStmt::IfElse(ie) => {
+                        let then_stmts = compute_only_thread_stmts_to_seq(
+                            ie.then_stmts,
+                            port_buses,
+                            bus_methods,
+                            ie.span,
+                        )?;
+                        let else_stmts = compute_only_thread_stmts_to_seq(
+                            ie.else_stmts,
+                            port_buses,
+                            bus_methods,
+                            ie.span,
+                        )?;
+                        out.push(Stmt::IfElse(IfElseOf {
+                            cond: ie.cond,
+                            then_stmts,
+                            else_stmts,
+                            unique: false,
+                            span: ie.span,
+                        }));
+                    }
+                    other => {
+                        return Err(CompileError::general(
+                            &format!(
+                                "v1 TLM initiator compute-only `if` branches only support SeqAssign statements and nested compute-only `if` blocks (found {:?}).",
+                                std::mem::discriminant(&other),
+                            ),
+                            span,
+                        ));
+                    }
+                }
+            }
+            Ok(out)
+        }
+
         for stmt in stmts {
             match stmt {
                 ThreadStmt::SeqAssign(ra) => {
@@ -6593,6 +6648,33 @@ fn build_tlm_init_thread_plan(
                 }
                 ThreadStmt::Lock { resource, body, .. } => {
                     lower_stmts(body, states, pending_seq, port_buses, bus_methods, span, Some(&resource.name))?;
+                }
+                ThreadStmt::IfElse(ie) => {
+                    if thread_body_has_tlm_call(&ie.then_stmts, port_buses, bus_methods)
+                        || thread_body_has_tlm_call(&ie.else_stmts, port_buses, bus_methods)
+                    {
+                        return Err(CompileError::general(
+                            "TLM method calls inside `if` branches are not supported in v1 initiator lowering",
+                            ie.span,
+                        ));
+                    }
+                    pending_seq.push(Stmt::IfElse(IfElseOf {
+                        cond: ie.cond,
+                        then_stmts: compute_only_thread_stmts_to_seq(
+                            ie.then_stmts,
+                            port_buses,
+                            bus_methods,
+                            ie.span,
+                        )?,
+                        else_stmts: compute_only_thread_stmts_to_seq(
+                            ie.else_stmts,
+                            port_buses,
+                            bus_methods,
+                            ie.span,
+                        )?,
+                        unique: false,
+                        span: ie.span,
+                    }));
                 }
                 ThreadStmt::For { var, start, end, body, span: for_span } => {
                     let start_v = literal_expr_u64(&start).ok_or_else(|| {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -7421,6 +7421,46 @@ fn test_tlm_initiator_call_inside_lock_lowers() {
 }
 
 #[test]
+fn test_tlm_initiator_compute_only_if_lowers_between_calls() {
+    let source = "
+        bus Mem
+          tlm_method read(addr: UInt<8>) -> UInt<32>: blocking;
+        end bus Mem
+
+        use Mem;
+
+        module M
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync>;
+          port m:   initiator Mem;
+          reg d: UInt<32> reset rst => 0;
+          reg acc0: UInt<32> reset rst => 0;
+          reg acc1: UInt<32> reset rst => 0;
+
+          thread driver on clk rising, rst high
+            for i in 0..3
+              d <= m.read(i.zext<8>());
+              if i[0] == 1'b0
+                acc0 <= acc0 +% d;
+              else
+                acc1 <= acc1 +% d;
+              end if
+            end for
+          end thread driver
+        end module M
+    ";
+    let sv = compile_to_sv(source);
+    assert!(
+        sv.contains("_tlm_init_driver_state"),
+        "TLM initiator should still lower to a state machine:\n{sv}"
+    );
+    assert!(
+        sv.contains("acc0 <= 32'(acc0 + d);") && sv.contains("acc1 <= 32'(acc1 + d);"),
+        "compute-only if branches should remain in the lowered thread FSM:\n{sv}"
+    );
+}
+
+#[test]
 fn test_locked_tlm_generated_workers_share_one_method_driver() {
     let source = "
         bus Mem


### PR DESCRIPTION
## Summary
- allow compute-only if/else blocks in TLM initiator thread lowering
- keep TLM method calls inside if branches rejected for v1 lowering
- add a regression covering a looped initiator call followed by per-iteration score accumulation

## Validation
- cargo test test_tlm_initiator_compute_only_if_lowers_between_calls --test integration_test
- cargo check
- git diff --check
- make arch-tlm-build / make arch-tlm-cosim in fpt26-accel against this branch