### PR TITLE
[codex] Clean up TLM implement initiator test

### DIFF
--- a/src/elaborate.rs
+++ b/src/elaborate.rs
@@ -1737,7 +1737,8 @@ fn lower_module_threads(m: ModuleDecl, opts: &ThreadLowerOpts) -> Result<(Module
                     }
                     return Err(vec![CompileError::general(
                         &format!(
-                            "initiator-side `implement {}.{}()` thread lowering is not yet implemented — tracked in doc/plan_tlm_implement_thread.md PR-tlm-i3/i4.",
+                            "initiator-side `implement {}.{}()` reached ordinary thread lowering. `implement` is an annotation over TLM call-site lowering, so the thread body must contain supported direct calls to `{}.{}(...)`.",
+                            b.port.name, b.method.name,
                             b.port.name, b.method.name
                         ),
                         t.span,
@@ -5828,10 +5829,8 @@ pub fn lower_tlm_initiator_calls(ast: SourceFile) -> Result<SourceFile, Vec<Comp
                             if t.tlm_target.is_some() { continue; }
                             // Threads carrying `implement` are the opt-in
                             // mechanism for multi-thread TLM — skip the
-                            // lock-idiom diagnostic on them. Multi-
-                            // implementer rejection is handled below by
-                            // PR-tlm-i3 (initiator) with its own targeted
-                            // message.
+                            // lock-idiom diagnostic on them; the TLM
+                            // lowering pass groups/cohorts them below.
                             if t.implement.is_some() { continue; }
                             collect_bare_tlm_calls(&t.body, t.span, &port_buses, &port_methods, &mut bare_uses);
                         }
@@ -5861,22 +5860,6 @@ pub fn lower_tlm_initiator_calls(ast: SourceFile) -> Result<SourceFile, Vec<Comp
                 }
 
                 // Identify threads that contain TLM calls and inline them.
-                // PR-tlm-i3: count initiator-side `implement m.method()`
-                // threads per (port, method). Single-implementer routes
-                // through existing inline lowering (equivalent to v1
-                // single-thread); multi-implementer is PR-tlm-i4.
-                let mut init_impl_counts: HashMap<(String, String), usize> = HashMap::new();
-                for item in &m.body {
-                    if let ModuleBodyItem::Thread(t) = item {
-                        if let Some(ib) = &t.implement {
-                            if ib.kind == TlmImplementKind::Initiator {
-                                *init_impl_counts.entry((ib.port.name.clone(), ib.method.name.clone()))
-                                    .or_insert(0) += 1;
-                            }
-                        }
-                    }
-                }
-
                 let mut inline_tlm_threads: Vec<ThreadBlock> = Vec::new();
                 let mut inline_tlm_thread_spans: std::collections::HashSet<(usize, usize)> =
                     std::collections::HashSet::new();
@@ -5950,23 +5933,10 @@ pub fn lower_tlm_initiator_calls(ast: SourceFile) -> Result<SourceFile, Vec<Comp
                         // so anything reaching here is initiator (if set).
                         if let Some(ib) = &t.implement {
                             if ib.kind == TlmImplementKind::Initiator {
-                                let count = init_impl_counts
-                                    .get(&(ib.port.name.clone(), ib.method.name.clone()))
-                                    .copied().unwrap_or(0);
-                                if count > 1 {
-                                    // Multi-implementer — PR-tlm-i4.
-                                    errors.push(CompileError::general(
-                                        &format!(
-                                            "multi-implementer initiator for `{}.{}()` is not yet implemented — {count} threads carry `implement` on this method. id-tagged request arbitration ships in PR-tlm-i4 (see doc/plan_tlm_implement_thread.md).",
-                                            ib.port.name, ib.method.name,
-                                        ),
-                                        t.span,
-                                    ));
-                                    new_body.push(item);
-                                    continue;
-                                }
-                                // Single-implementer initiator — fall through
-                                // to the inline lowering (v1 equivalent).
+                                // Initiator-side `implement m.method()` is an
+                                // annotation over ordinary call-site/cohort
+                                // lowering; fall through to the same path as
+                                // non-`implement` TLM worker threads.
                             } else {
                                 // Target kind here is unexpected (should've
                                 // been consumed earlier). Leave for the

--- a/tests/cargo_test_baseline.json
+++ b/tests/cargo_test_baseline.json
@@ -675,7 +675,7 @@
     },
     {
       "target": "tests/integration_test.rs",
-      "name": "test_implement_initiator_multi_implementer_rejected"
+      "name": "test_implement_initiator_multi_implementer_compiles_end_to_end"
     },
     {
       "target": "tests/integration_test.rs",

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -6747,8 +6747,8 @@ fn test_implement_target_single_compiles_end_to_end() {
 
 #[test]
 fn test_implement_target_multi_implementer_rejected() {
-    // PR-tlm-i2: multi-implementer target case produces a targeted
-    // error pointing at PR-tlm-i4.
+    // Non-indexed multiple target implementers are ambiguous. Use indexed
+    // target lanes on an `out_of_order tags N` method for this shape.
     let source = "
         bus Mem
           tlm_method read(addr: UInt<32>) -> UInt<64>: blocking;
@@ -6776,7 +6776,7 @@ fn test_implement_target_multi_implementer_rejected() {
     let ast = parser.parse_source_file().expect("parse");
     let ast = arch::elaborate::elaborate(ast).expect("elaborate");
     let r = arch::elaborate::lower_tlm_target_threads(ast);
-    assert!(r.is_err(), "multi-implementer target should error until PR-tlm-i4");
+    assert!(r.is_err(), "non-indexed multi-implementer target should error");
     let msg = format!("{:?}", r.unwrap_err());
     assert!(msg.contains("multi-implementer target") && msg.contains("s.read"),
         "expected targeted error, got: {msg}");
@@ -6858,16 +6858,11 @@ fn test_implement_initiator_single_compiles_end_to_end() {
         "bus signals should be driven:\n{sv}");
 }
 
-// TODO: stale after PR #348 (codex/tlm-mux-balanced-trees) added multi-
-// implementer support — the rejection this test asserted no longer
-// fires (`lower_tlm_initiator_calls` now succeeds for the multi-impl
-// case). Ignored to unblock CI on subsequent PRs; either delete this
-// test or rewrite it to assert the new mux-tree behavior.
 #[test]
-#[ignore]
-fn test_implement_initiator_multi_implementer_rejected() {
-    // PR-tlm-i3: multi-implementer initiator → targeted error pointing
-    // at PR-tlm-i4.
+fn test_implement_initiator_multi_implementer_compiles_end_to_end() {
+    // Initiator-side `implement m.read()` is now an annotation over the
+    // ordinary call-site/cohort lowering. Multiple implementer threads
+    // share the same generated method driver instead of being rejected.
     let source = "
         bus Mem
           tlm_method read(addr: UInt<32>) -> UInt<64>: blocking;
@@ -6889,16 +6884,13 @@ fn test_implement_initiator_multi_implementer_rejected() {
           end thread w1
         end module M
     ";
-    let tokens = arch::lexer::tokenize(source).expect("lexer");
-    let mut parser = arch::parser::Parser::new(tokens, source);
-    let ast = parser.parse_source_file().expect("parse");
-    let ast = arch::elaborate::elaborate(ast).expect("elaborate");
-    let ast = arch::elaborate::lower_tlm_target_threads(ast).expect("tlm target");
-    let r = arch::elaborate::lower_tlm_initiator_calls(ast);
-    assert!(r.is_err(), "multi-implementer initiator should error until PR-tlm-i4");
-    let msg = format!("{:?}", r.unwrap_err());
-    assert!(msg.contains("multi-implementer initiator") && msg.contains("m.read"),
-        "expected targeted error, got: {msg}");
+    let sv = compile_to_sv(source);
+    assert!(sv.contains("_tlm_init_w0_state")
+         && sv.contains("_tlm_init_w1_state"),
+        "multi-implementer initiator should lower both workers:\n{sv}");
+    assert!(sv.contains("m_read_req_valid")
+         && sv.contains("m_read_rsp_ready"),
+        "shared method driver should still drive req/rsp handshake:\n{sv}");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- replace the stale ignored multi-implementer initiator rejection test with an active compile/lowering test
- update the cargo test baseline for the renamed test
- remove obsolete PR-tlm-i4 rejection/counting plumbing and update the defensive `implement` diagnostic to describe current annotation semantics

## Validation

- cargo test test_implement_ -- --nocapture
- cargo test tlm -- --nocapture
