### PR TITLE
multdiv multicycle: two-pass selective resynthesis (Path A)

### DIFF
--- a/doc/multdiv_multicycle_vs_fsm.md
+++ b/doc/multdiv_multicycle_vs_fsm.md
@@ -407,27 +407,31 @@ Honest framing of when Path A pays off:
 - **OpenROAD** consumes SDC and runs delay-driven mapping internally;
   the two-pass workaround is mostly a yosys-standalone band-aid.
 
-### Open SDC compat issue (4th, file as arch-com follow-up)
+### SDC `-hierarchical` flag (fixed in this PR)
 
-The two-pass hier flow surfaced a new SDC compat wrinkle. arch-com's
-post-PR-#349 emission `[get_cells {*mul_r_reg*}]` is correct for
-**flat** netlists but fails for **hierarchical** netlists: OpenSTA's
-`get_cells` is non-recursive, so the `*` glob does not descend into
-instance subhierarchies. Cells living at `dp/mul_r_reg*` are missed
-by the bare `*mul_r_reg*` glob.
+The two-pass hier flow originally surfaced a 4th SDC compat issue:
+the post-PR-#349 emission `[get_cells {*mul_r_reg*}]` was correct for
+**flat** netlists but failed for **hierarchical** netlists. OpenSTA's
+`get_cells` *was* non-recursive by default, so the `*` glob did not
+descend into instance subhierarchies — cells living at `dp/mul_r_reg*`
+were missed by the bare `*mul_r_reg*` glob, and the multicycle path
+silently failed to attach (treated as single-cycle).
 
-Workaround in `multdiv_multicycle_sta.tcl`: rewrite `[get_cells {...}]`
-→ `[get_cells -hierarchical {...}]` before sourcing. The
-`-hierarchical` flag walks the full instance tree.
+This PR's codegen fix (`src/codegen/mod.rs::emit_sdc`) now emits the
+`-hierarchical` flag unconditionally:
 
-Possible upstream fixes:
-1. Always emit `-hierarchical` in the SDC: `[get_cells -hierarchical
-   {*<reg>_reg*}]`. Works for both flat and hierarchical OpenSTA
-   linkage. Likely the smallest patch.
-2. Emit two parallel forms guarded by a `catch`. Most correct, most
-   verbose.
+```sdc
+set_multicycle_path 3 -setup -to [get_cells -hierarchical {*mul_r_reg*}]
+set_multicycle_path 2 -hold  -to [get_cells -hierarchical {*mul_r_reg*}]
+```
 
-Recommendation: option 1.
+`-hierarchical` is harmless for flat netlists (returns the same cells
+either way) and is standard SDC across DC / Genus / Vivado / Quartus /
+OpenSTA. With this fix, the consumer STA driver sources the emitted
+SDC verbatim — no regsub needed for either the flat or the
+hierarchy-split variant. Verified end-to-end: both `mul_with_mc` and
+`hier_with_mc` STA flows report WNS = 0 at the real clock with
+multicycle paths cleanly attached.
 
 ## Caveats
 

--- a/doc/multdiv_multicycle_vs_fsm.md
+++ b/doc/multdiv_multicycle_vs_fsm.md
@@ -166,11 +166,13 @@ OpenSTA 3.1.0 at `~/OpenSTA/build/sta`. Driver:
 `examples/multdiv_multicycle_sta.{tcl,sh}`. Each design was swept to
 find the smallest target clock period that still produces WNS = 0.
 
-| Design                                  | Critical path (ns) | Fmax (MHz) | Critical-path endpoint                              |
-|-----------------------------------------|--------------------|------------|-----------------------------------------------------|
-| `ibex_multdiv_fast` (FSM)               | 11.372             |    ~87     | `op_b_i[1]` → `imd_val_d_o[32]` (combinational out) |
-| `MultdivMulticycle`, multicycle honored | 1.447 (control)    |   ~264     | `start` → `op_is_mul_reg` flop                      |
-| `MultdivMulticycle`, NO multicycle      | 136.235            |     ~7.3   | `operand_b[17]` → `div_result_reg_0` flop           |
+| Design                                       | Critical path (ns) | Fmax (MHz) | Critical-path endpoint                              |
+|----------------------------------------------|--------------------|------------|-----------------------------------------------------|
+| `ibex_multdiv_fast` (FSM)                    | 11.372             |    ~87     | `op_b_i[1]` → `imd_val_d_o[32]` (combinational out) |
+| `MultdivMulticycle`, multicycle honored      | 1.447 (control)    |   ~264     | `start` → `op_is_mul_reg` flop                      |
+| `MultdivMulticycle`, NO multicycle           | 136.235            |     ~7.3   | `operand_b[17]` → `div_result_reg_0` flop           |
+| `MultdivMulticycleHier` two-pass, mc honored | 1.454 (control)    |   ~270     | `cnt_reg_0` → `cnt_reg_1` flop                      |
+| `MultdivMulticycleHier` two-pass, NO mc      | 130.633            |     ~7.7   | `operand_b[3]` → `dp/div_r_reg_0` flop              |
 
 (Bracket period sweeps: FSM passes at 11.5 ns and fails at 11.4 ns;
 multicycle-honored passes at 3.79 ns and fails at 3.78 ns;
@@ -268,6 +270,164 @@ Three possible upstream fixes (file as arch-com follow-up):
 
 Recommendation: option 2 (`*` prefix) is the least invasive and
 widest-compatible.
+
+## Two-pass selective resynthesis (Path A)
+
+The single-pass numbers above show that yosys + ABC produce roughly
+the same area whether you give them a relaxed clock (3.8 ns, what the
+multicycle annotation buys you) or a real clock (5.0 ns) — they don't
+respond to the multicycle SDC at all because vanilla ABC isn't
+SDC-aware.
+
+The research note `~/.claude/uploads/.../yosys_multicycle.html`
+("Selective Resynthesis for Multicycle Paths in Yosys/ABC") proposes a
+**two-pass workflow** to approximate commercial multicycle-honoring
+synthesis using only Yosys + OpenSTA:
+
+1. **Pass 1**: synthesize the multicycle cone at a *relaxed* clock
+   target (3.8 ns, the multicycle budget). The hypothesis is that ABC
+   will not over-optimize this cone for a tight constraint it doesn't
+   need to meet.
+2. **Pass 2**: freeze the pass-1 mapped cone and resynthesize the
+   *rest of the design* at the real clock target (5.0 ns).
+3. **Verify**: OpenSTA with the original multicycle SDC.
+
+### Freeze strategy
+
+We use a **hierarchy-boundary** freeze (the research note's preferred
+option). A new sibling .arch file
+`examples/multdiv_multicycle_hier.arch` carries the same arithmetic
+but split into two modules:
+
+- `MultdivMulticycleDatapath` — owns `mul_r` and `div_r` (the two
+  `multicycle`-annotated regs) and their feeding arithmetic.
+- `MultdivMulticycleHier` — owns the countdown counter, `op_is_mul`,
+  and the output mux; instantiates the datapath as `dp`.
+
+The two-pass script `examples/multdiv_multicycle_two_pass.sh`:
+
+- Pass 1 invokes yosys with `hierarchy -top MultdivMulticycleDatapath`
+  (synth the child standalone), `dfflibmap` + `abc -liberty -D
+  3800000`. Output: `pass1_child_only.v`.
+- Pass 2 reads parent RTL, `delete MultdivMulticycleDatapath` (drop
+  the RTL form), reads `pass1_child_only.v` (the mapped form), runs
+  `setattr -mod -set keep_hierarchy 1 MultdivMulticycleDatapath`,
+  then `select -module MultdivMulticycleHier; abc -liberty -D
+  5000000`. ABC sees only the parent. Output: `MultdivMulticycleHier_synth.v`.
+
+A simpler approach — `setattr -mod -set keep_hierarchy 1 <child>` on
+the full RTL design and a single `synth` invocation — does NOT
+freeze the child. ABC visits every module in scope; `keep_hierarchy`
+only prevents `flatten`, not module-local ABC remapping. The two
+explicit invocations are needed.
+
+### Results — two-pass vs single-pass
+
+| Design / flow                                                         | Total cells | Area (µm²) | Flops | Critical path (ns) | Fmax (MHz) |
+|-----------------------------------------------------------------------|------------:|-----------:|------:|-------------------:|-----------:|
+| `ibex_multdiv_fast` (FSM, single-pass, no SDC)                        |       7,206 |    49,818  |   74  |            11.372  |        87  |
+| `MultdivMulticycle` (flat, single-pass, NO multicycle)                |       6,047 |    39,208  |   71  |           136.235  |       7.3  |
+| `MultdivMulticycle` (flat, single-pass, multicycle honored)           |       6,047 |    39,208  |   71  | 1.447 / 3.79 (mc)  |       264  |
+| **`MultdivMulticycleHier` (two-pass, multicycle honored)**            |   **6,031** |  **39,221** | **71** | **1.454 / 3.7 (mc)** | **~270**   |
+
+The two-pass row is essentially **tied** with the single-pass row:
+−16 cells (−0.26%), +13 µm² (+0.03%), +6 MHz (+2.3%). The differences
+are within run-to-run noise. The hypothesis ("smaller area from
+relaxed pass") is **not confirmed** on this benchmark.
+
+### Why no QoR delta — honest interpretation
+
+The research note's hypothesis was that the relaxed-clock pass would
+let ABC produce smaller logic for the multicycle cone (no need to
+spend area shrinking critical-path depth that isn't actually
+critical). Empirically, on this benchmark, **vanilla Yosys 0.64 + ABC
+produces identical area for clock targets spanning 1.0 ns to 50.0 ns**:
+
+```
+abc -D 1000000  → 39,175 µm²
+abc -D 2000000  → 39,175 µm²
+abc -D 3800000  → 39,175 µm²
+abc -D 5000000  → 39,175 µm²
+abc -D 10000000 → 39,175 µm²
+abc -D 50000000 → 39,175 µm²
+```
+
+ABC's default mapping script (`&map -a`) isn't aggressively
+delay-driven on a design like this — it produces the area-floor
+netlist regardless of `-D`. So the relaxed pass and the tight pass
+generate the *same* mapped netlist, and the two-pass flow becomes a
+no-op QoR-wise.
+
+This is **a property of yosys-ABC on this benchmark**, not a refutation
+of the methodology. The two-pass machinery works:
+
+- Pass 1 produces a mapped child with `keep_hierarchy` preserved.
+- Pass 2 ABC log shows `Extracting gate netlist of module
+  '\MultdivMulticycleHier'` — only the parent, the child is
+  untouched.
+- The final netlist passes STA at the real clock with multicycle
+  honored (WNS = 0 at 5.0 ns; min period 3.7 ns).
+
+The methodology would likely matter more on designs where:
+- ABC actually responds to `-D` (deeper combinational pipelines, or
+  with `synth -auto-top -mappers cls/lib3` style scripts).
+- The multicycle cone has non-trivial structural sharing opportunities
+  (e.g. a Wallace-tree multiplier where ABC genuinely picks different
+  AOI cells per delay target).
+
+### Reproducing the two-pass flow
+
+```
+$ cd ~/github/arch-com
+$ cargo build --release
+$ bash examples/multdiv_multicycle_two_pass.sh
+$ DESIGN=hier_with_mc OUT_DIR=/tmp/multdiv-two-pass \
+    sta -no_splash -exit examples/multdiv_multicycle_sta.tcl
+```
+
+Outputs:
+- `/tmp/multdiv-two-pass/multdiv_multicycle_hier.{sv,sdc}`
+- `/tmp/multdiv-two-pass/pass1_child_only.v` (mapped child after relaxed-clock pass)
+- `/tmp/multdiv-two-pass/MultdivMulticycleHier_synth.v` (final two-pass netlist)
+- `/tmp/multdiv-two-pass/{pass1,pass2}.{ys,log}` (yosys script + log)
+
+### When two-pass is worth the complexity
+
+Honest framing of when Path A pays off:
+
+- **Don't use it on yosys + Sky130 + this multdiv shape.** Same
+  netlist, two synth runs, slightly more script complexity. No win.
+- **Consider it if** (a) your ABC script is delay-aggressive (e.g.
+  custom `abc -script ...` with `&dch -C 500; &if -K 6` flavor) and
+  (b) the multicycle cone is large enough that the area-vs-delay
+  trade-off curve actually has slope at the relaxed point.
+- **Don't substitute for commercial synth** (DC, Genus) when you have
+  it. Commercial tools consume the SDC directly and don't need a
+  two-pass workaround.
+- **OpenROAD** consumes SDC and runs delay-driven mapping internally;
+  the two-pass workaround is mostly a yosys-standalone band-aid.
+
+### Open SDC compat issue (4th, file as arch-com follow-up)
+
+The two-pass hier flow surfaced a new SDC compat wrinkle. arch-com's
+post-PR-#349 emission `[get_cells {*mul_r_reg*}]` is correct for
+**flat** netlists but fails for **hierarchical** netlists: OpenSTA's
+`get_cells` is non-recursive, so the `*` glob does not descend into
+instance subhierarchies. Cells living at `dp/mul_r_reg*` are missed
+by the bare `*mul_r_reg*` glob.
+
+Workaround in `multdiv_multicycle_sta.tcl`: rewrite `[get_cells {...}]`
+→ `[get_cells -hierarchical {...}]` before sourcing. The
+`-hierarchical` flag walks the full instance tree.
+
+Possible upstream fixes:
+1. Always emit `-hierarchical` in the SDC: `[get_cells -hierarchical
+   {*<reg>_reg*}]`. Works for both flat and hierarchical OpenSTA
+   linkage. Likely the smallest patch.
+2. Emit two parallel forms guarded by a `catch`. Most correct, most
+   verbose.
+
+Recommendation: option 1.
 
 ## Caveats
 

--- a/examples/multdiv_multicycle_hier.arch
+++ b/examples/multdiv_multicycle_hier.arch
@@ -1,0 +1,115 @@
+//! ---
+//! tags: [multicycle, multdiv, sdc, alu, retime, hierarchy, two-pass]
+//! refs:
+//!   - "examples/multdiv_multicycle.arch (single-flat variant, PR #346)"
+//!   - "Research note: Selective Resynthesis for Multicycle Paths in Yosys/ABC"
+//! ---
+//!
+//! HIERARCHY-SPLIT variant of `multdiv_multicycle.arch`. Functionally
+//! identical to the original (same ports, same timing contract, same
+//! SDC), but the heavy arithmetic regs (`mul_result`, `div_result`)
+//! live in a child module `MultdivMulticycleDatapath`. The parent
+//! `MultdivMulticycleHier` keeps the lightweight control (countdown,
+//! op-select, output muxes).
+//!
+//! Why split: enables Path A of the two-pass selective-resynthesis
+//! flow described in the research note. With a hierarchy boundary in
+//! place, Yosys can be told `keep_hierarchy 1 MultdivMulticycleDatapath`
+//! so that pass 1 maps the datapath at a relaxed clock target (3.8 ns,
+//! the multicycle window) and pass 2 maps the control logic at the
+//! real single-cycle clock (5.0 ns), without ABC re-optimizing the
+//! datapath cone.
+//!
+//! Inherits all scope limits from the parent: unsigned only, low-32
+//! multiply only, no divide-by-zero handling. See the original example
+//! for the rationale.
+
+domain SysDomain
+  freq_mhz: 100
+end domain SysDomain
+
+/// Heavy-arithmetic datapath. Two regs with `multicycle` annotations
+/// drive the SDC; the parent muxes between them. This module is
+/// `keep_hierarchy`-protected during the two-pass synth flow so its
+/// post-pass-1 mapped cells are not re-optimized at the real clock.
+module MultdivMulticycleDatapath
+  param XLEN: const = 32;
+
+  port clk:        in Clock<SysDomain>;
+  port rst:        in Reset<Sync>;
+  port start:      in Bool;
+  port is_mul:     in Bool;
+  port operand_a:  in UInt<XLEN>;
+  port operand_b:  in UInt<XLEN>;
+  port mul_result: out UInt<XLEN>;
+  port div_result: out UInt<XLEN>;
+
+  reg mul_r: UInt<XLEN> multicycle 3  reset rst => 0;
+  reg div_r: UInt<XLEN> multicycle 36 reset rst => 0;
+
+  seq on clk rising
+    if start
+      if is_mul
+        mul_r <= (operand_a.zext<64>() * operand_b.zext<64>()).trunc<XLEN>();
+      else
+        div_r <= operand_a / operand_b;
+      end if
+    end if
+  end seq
+
+  comb
+    mul_result = mul_r;
+    div_result = div_r;
+  end comb
+end module MultdivMulticycleDatapath
+
+/// Top-level wrapper. Same port shape as the flat `MultdivMulticycle`,
+/// same observable timing. Instantiates the datapath child + owns the
+/// countdown / op-select control.
+module MultdivMulticycleHier
+  param XLEN: const = 32;
+
+  port clk:       in Clock<SysDomain>;
+  port rst:       in Reset<Sync>;
+  port start:     in Bool;
+  port is_mul:    in Bool;
+  port operand_a: in UInt<XLEN>;
+  port operand_b: in UInt<XLEN>;
+  port valid_o:   out Bool;
+  port result_o:  out UInt<XLEN>;
+
+  wire mul_w: UInt<XLEN>;
+  wire div_w: UInt<XLEN>;
+
+  inst dp: MultdivMulticycleDatapath
+    clk        <- clk;
+    rst        <- rst;
+    start      <- start;
+    is_mul     <- is_mul;
+    operand_a  <- operand_a;
+    operand_b  <- operand_b;
+    mul_result -> mul_w;
+    div_result -> div_w;
+  end inst dp
+
+  reg op_is_mul: Bool   reset rst => false;
+  reg cnt:       UInt<6> reset rst => 0;
+
+  seq on clk rising
+    if start
+      op_is_mul <= is_mul;
+      if is_mul
+        cnt <= 6'd3;
+      else
+        cnt <= 6'd36;
+      end if
+    elsif cnt != 6'd0
+      cnt <= (cnt - 1).trunc<6>();
+    end if
+  end seq
+
+  comb
+    valid_o  = (cnt == 6'd0);
+    result_o = op_is_mul ? mul_w : div_w;
+  end comb
+end module MultdivMulticycleHier

--- a/examples/multdiv_multicycle_sta.tcl
+++ b/examples/multdiv_multicycle_sta.tcl
@@ -11,6 +11,10 @@
 #                            with a small flat-prefix translation; see
 #                            note below)
 #   DESIGN=fsm            — ibex_multdiv_fast FSM netlist, no SDC
+#   DESIGN=hier_nosdc     — two-pass hierarchy-split netlist, no SDC
+#   DESIGN=hier_with_mc   — two-pass hierarchy-split netlist, multicycle
+#                            SDC applied (the post-PR-#349 wildcard form
+#                            resolves directly, no prefix rewrite needed)
 #
 # CLOCK_NS picks the target clock period.
 
@@ -43,6 +47,12 @@ switch -- $design {
         read_verilog $out_dir/ibex_multdiv_fast_synth.v
         link_design ibex_multdiv_fast
         set clk_port [get_ports clk_i]
+    }
+    "hier_nosdc" -
+    "hier_with_mc" {
+        read_verilog $out_dir/MultdivMulticycleHier_synth.v
+        link_design MultdivMulticycleHier
+        set clk_port [get_ports clk]
     }
     default { error "Unknown DESIGN=$design" }
 }
@@ -79,6 +89,37 @@ if {$design eq "mul_with_mc"} {
     close $tmpfp
     puts "=== Sourcing arch-com SDC (flat-prefix translated) ==="
     source "$out_dir/multdiv_multicycle.sdc.flat"
+}
+
+# For the two-pass hier variant, the SDC arch-com emits is in the
+# post-PR-#349 wildcard form `*<wire>_reg*`. That form works for FLAT
+# netlists but NOT for hierarchical: OpenSTA's `get_cells <glob>` is
+# non-recursive — the wildcard does not descend into instance
+# subhierarchies. The two-pass synth preserves the `dp/` child
+# boundary, so the multicycle cells live at `dp/mul_r_reg*` /
+# `dp/div_r_reg*` and the bare `*mul_r_reg*` glob misses them.
+#
+# Workaround: rewrite `[get_cells {*<reg>*}]` -> `[get_cells
+# -hierarchical {*<reg>*}]` before sourcing. The -hierarchical flag
+# makes OpenSTA walk the full instance tree. This is a 4th open
+# arch-com SDC compat issue (after PR #347's get_cells syntax, PR
+# #349's wildcard prefix, and the standalone-prefix workaround for
+# the flat variant). Filed as TODO in
+# doc/multdiv_multicycle_vs_fsm.md.
+if {$design eq "hier_with_mc"} {
+    set sdc_path "$out_dir/multdiv_multicycle_hier.sdc"
+    if {![file exists $sdc_path]} {
+        error "arch-com SDC not at $sdc_path; run multdiv_multicycle_two_pass.sh first"
+    }
+    set fp [open $sdc_path]
+    set sdc [read $fp]
+    close $fp
+    set sdc_hier [regsub -all {\[get_cells\s+\{} $sdc {[get_cells -hierarchical \{}]
+    set tmpfp [open "$out_dir/multdiv_multicycle_hier.sdc.hierarchical" w]
+    puts $tmpfp $sdc_hier
+    close $tmpfp
+    puts "=== Sourcing arch-com SDC (two-pass hier, -hierarchical rewrite) ==="
+    source "$out_dir/multdiv_multicycle_hier.sdc.hierarchical"
 }
 
 puts "=== DESIGN=$design  CLOCK_NS=$clk_ns ==="

--- a/examples/multdiv_multicycle_sta.tcl
+++ b/examples/multdiv_multicycle_sta.tcl
@@ -91,35 +91,19 @@ if {$design eq "mul_with_mc"} {
     source "$out_dir/multdiv_multicycle.sdc.flat"
 }
 
-# For the two-pass hier variant, the SDC arch-com emits is in the
-# post-PR-#349 wildcard form `*<wire>_reg*`. That form works for FLAT
-# netlists but NOT for hierarchical: OpenSTA's `get_cells <glob>` is
-# non-recursive — the wildcard does not descend into instance
-# subhierarchies. The two-pass synth preserves the `dp/` child
-# boundary, so the multicycle cells live at `dp/mul_r_reg*` /
-# `dp/div_r_reg*` and the bare `*mul_r_reg*` glob misses them.
-#
-# Workaround: rewrite `[get_cells {*<reg>*}]` -> `[get_cells
-# -hierarchical {*<reg>*}]` before sourcing. The -hierarchical flag
-# makes OpenSTA walk the full instance tree. This is a 4th open
-# arch-com SDC compat issue (after PR #347's get_cells syntax, PR
-# #349's wildcard prefix, and the standalone-prefix workaround for
-# the flat variant). Filed as TODO in
-# doc/multdiv_multicycle_vs_fsm.md.
+# For the two-pass hier variant, arch-com's SDC now emits
+# `[get_cells -hierarchical {*<reg>_reg*}]` directly (post this PR's
+# codegen fix). The `-hierarchical` flag makes OpenSTA's `get_cells`
+# descend into instance subhierarchies, so the multicycle cells inside
+# `dp/` (the datapath child instance) resolve cleanly with no
+# rewriting needed. Source the SDC verbatim.
 if {$design eq "hier_with_mc"} {
     set sdc_path "$out_dir/multdiv_multicycle_hier.sdc"
     if {![file exists $sdc_path]} {
         error "arch-com SDC not at $sdc_path; run multdiv_multicycle_two_pass.sh first"
     }
-    set fp [open $sdc_path]
-    set sdc [read $fp]
-    close $fp
-    set sdc_hier [regsub -all {\[get_cells\s+\{} $sdc {[get_cells -hierarchical \{}]
-    set tmpfp [open "$out_dir/multdiv_multicycle_hier.sdc.hierarchical" w]
-    puts $tmpfp $sdc_hier
-    close $tmpfp
-    puts "=== Sourcing arch-com SDC (two-pass hier, -hierarchical rewrite) ==="
-    source "$out_dir/multdiv_multicycle_hier.sdc.hierarchical"
+    puts "=== Sourcing arch-com SDC (two-pass hier) ==="
+    source $sdc_path
 }
 
 puts "=== DESIGN=$design  CLOCK_NS=$clk_ns ==="

--- a/examples/multdiv_multicycle_two_pass.sh
+++ b/examples/multdiv_multicycle_two_pass.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# Two-pass selective resynthesis driver for MultdivMulticycleHier
+# (the hierarchy-split variant of multdiv_multicycle.arch). Implements
+# Path A of the research note "Selective Resynthesis for Multicycle
+# Paths in Yosys/ABC".
+#
+# Strategy: hierarchy-boundary freeze + selection exclusion.
+#   Pass 1: synthesize ONLY the datapath child (with `hierarchy -top
+#           MultdivMulticycleDatapath`), mapping at a RELAXED clock
+#           period (the multicycle 3-cycle window of ~3.8 ns). Output:
+#           pass1_child_only.v — a mapped Sky130 netlist for the child.
+#   Pass 2: read the parent RTL + the pass-1 mapped child, synthesize
+#           only the PARENT (`select -module MultdivMulticycleHier`)
+#           at the REAL single-cycle clock period (5.0 ns / 200 MHz).
+#           The child's mapped cells are not touched.
+#
+# WHY two yosys invocations and not one? `setattr -mod -set
+# keep_hierarchy 1 <child>` keeps the module as a separate scope
+# through `synth`, but it does NOT prevent `abc` from re-mapping the
+# child when given a list of modules. Experimentally, abc visits both
+# modules and produces identical output. The robust freeze is to read
+# the child as already-mapped netlist and `select` only the parent for
+# pass-2 abc.
+#
+# Requirements: yosys (any recent version), sv2v, Sky130 PDK Liberty.
+#
+# Outputs land under $OUT_DIR (default /tmp/multdiv-two-pass).
+
+set -euo pipefail
+
+OUT_DIR="${OUT_DIR:-/tmp/multdiv-two-pass}"
+ARCH_COM_DIR="${ARCH_COM_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+LIB="${LIB:-$HOME/.volare/sky130A/libs.ref/sky130_fd_sc_hd/lib/sky130_fd_sc_hd__tt_025C_1v80.lib}"
+
+# Timing targets (in ps for `abc -D`).
+# RELAXED_PS = 3.8 ns × 1000 — the multicycle multiplier's required
+#              cycle time when honored (divide_delay / 36 ≈ 3.79 ns).
+# REAL_PS    = 5.0 ns × 1000 — the original 200 MHz single-cycle goal.
+RELAXED_PS="${RELAXED_PS:-3800000}"
+REAL_PS="${REAL_PS:-5000000}"
+
+TOP="MultdivMulticycleHier"
+CHILD="MultdivMulticycleDatapath"
+
+mkdir -p "$OUT_DIR"
+
+if [[ ! -f "$LIB" ]]; then
+  echo "ERROR: Liberty $LIB not found." >&2
+  echo "Set LIB=/path/to/sky130_fd_sc_hd__tt_025C_1v80.lib" >&2
+  exit 1
+fi
+
+# 1. Emit the hierarchy-split design (regenerates the SV + SDC).
+"$ARCH_COM_DIR/target/release/arch" build \
+  "$ARCH_COM_DIR/examples/multdiv_multicycle_hier.arch" \
+  -o "$OUT_DIR/multdiv_multicycle_hier.sv"
+
+# Yosys 0.64's built-in SV parser rejects some idioms the arch-com SV
+# emitter uses; sv2v converts to plain Verilog-2005.
+sv2v "$OUT_DIR/multdiv_multicycle_hier.sv" > "$OUT_DIR/multdiv_multicycle_hier.v"
+
+# ----------------------------------------------------------------------
+# Pass 1: child-only synthesis at relaxed clock target.
+# `hierarchy -top $CHILD` tells yosys to discard the parent and treat
+# the child as the standalone top. `splitnets` after dfflibmap gives
+# each Q-bit its own wire so flop cells get `<name>_reg_<bit>` names.
+# ----------------------------------------------------------------------
+echo "=== Pass 1: child '$CHILD' standalone @ ${RELAXED_PS} ps (~$(echo "scale=2; $RELAXED_PS/1000000" | bc) ns) ==="
+cat > "$OUT_DIR/pass1.ys" <<EOF
+read_verilog $OUT_DIR/multdiv_multicycle_hier.v
+hierarchy -check -top $CHILD
+proc; opt
+fsm; opt
+memory; opt
+techmap; opt
+dfflibmap -liberty $LIB
+abc -liberty $LIB -D $RELAXED_PS
+clean
+splitnets
+tcl $ARCH_COM_DIR/examples/multdiv_multicycle_two_pass_rename.tcl
+stat -liberty $LIB
+write_verilog -noattr $OUT_DIR/pass1_child_only.v
+EOF
+yosys -s "$OUT_DIR/pass1.ys" 2>&1 | tee "$OUT_DIR/pass1.log" | \
+  grep -E "(Chip area for|cells$|Executing ABC|Executing SPLITNETS|Renaming cell.*reg)" | tail -15
+
+# ----------------------------------------------------------------------
+# Pass 2: parent resynthesis at real clock, child preserved.
+#   - read parent + child RTL
+#   - `delete $CHILD` to remove the RTL form of the child
+#   - read pass1 mapped child (now the child is in netlist form)
+#   - `setattr -mod -set keep_hierarchy 1 $CHILD` keeps the boundary
+#   - `select -module $TOP` restricts abc to the parent
+# ----------------------------------------------------------------------
+echo "=== Pass 2: parent '$TOP' only @ ${REAL_PS} ps (~$(echo "scale=2; $REAL_PS/1000000" | bc) ns) ==="
+cat > "$OUT_DIR/pass2.ys" <<EOF
+read_verilog $OUT_DIR/multdiv_multicycle_hier.v
+delete $CHILD
+read_verilog $OUT_DIR/pass1_child_only.v
+read_liberty -lib $LIB
+hierarchy -check -top $TOP
+setattr -mod -set keep_hierarchy 1 $CHILD
+proc; opt
+fsm; opt
+memory; opt
+techmap; opt
+dfflibmap -liberty $LIB
+select -module $TOP
+abc -liberty $LIB -D $REAL_PS
+select -clear
+clean
+splitnets
+tcl $ARCH_COM_DIR/examples/multdiv_multicycle_two_pass_rename.tcl
+stat -liberty $LIB
+write_verilog -noattr $OUT_DIR/${TOP}_synth.v
+EOF
+yosys -s "$OUT_DIR/pass2.ys" 2>&1 | tee "$OUT_DIR/pass2.log" | \
+  grep -E "(Chip area for|cells$|Executing ABC|Extracting gate|Renaming cell.*reg)" | tail -20
+
+echo
+echo "=== Two-pass summary ==="
+echo "Pass 1 (child, relaxed clock):"
+grep -E "Chip area for top|Chip area for module" "$OUT_DIR/pass1.log" | tail -3
+echo "Pass 2 (parent, real clock) — final design:"
+grep -E "Chip area for top|Chip area for module" "$OUT_DIR/pass2.log" | tail -3
+echo
+echo "To run OpenSTA on the final netlist:"
+echo "  DESIGN=hier_with_mc OUT_DIR=$OUT_DIR \\"
+echo "    sta -no_splash -exit $ARCH_COM_DIR/examples/multdiv_multicycle_sta.tcl"

--- a/examples/multdiv_multicycle_two_pass_rename.tcl
+++ b/examples/multdiv_multicycle_two_pass_rename.tcl
@@ -1,0 +1,54 @@
+# yosys-tcl helper for the two-pass synthesis flow. Renames DFF cells
+# in BOTH modules of MultdivMulticycleHier so arch-com's emitted SDC
+# `*<wire>_reg*` glob resolves cleanly against the post-synth netlist.
+#
+# Differs from multdiv_multicycle_yosys_rename.tcl in two ways:
+#   1. Handles two modules (parent + datapath child), not one.
+#   2. Uses arch-com's PR #349 wildcard SDC prefix `*<wire>_reg*`, so
+#      the cells can live in either module scope and still match.
+#
+# Must run AFTER `splitnets`. See multdiv_multicycle_yosys_rename.tcl
+# for rationale on why we do this in TCL rather than `rename -wire`.
+
+proc rename_dffs_in_module {modname} {
+    # Tolerate missing module: pass 1 of the two-pass flow synthesizes
+    # only the child (`MultdivMulticycleDatapath`); pass 2 has both.
+    # Same tcl runs in both, so silently skip if module isn't present.
+    if {[catch {yosys cd $modname} err]} {
+        puts "rename_dffs_in_module: skipping $modname (not present)"
+        return
+    }
+    if {[info exists ::env(OUT_DIR)]} {
+        set tmp_dump "$::env(OUT_DIR)/dff_dump_${modname}.txt"
+    } else {
+        set tmp_dump "/tmp/dff_dump_${modname}.txt"
+    }
+    yosys dump -o $tmp_dump t:sky130_fd_sc_hd__dfxtp_1
+    set fp [open $tmp_dump]
+    set content [read $fp]
+    close $fp
+    set cell ""
+    foreach line [split $content "\n"] {
+        if {[regexp {^\s*cell \\\S+\s+(\$\S+)} $line _ cellpriv]} {
+            set cell $cellpriv
+        } elseif {$cell ne "" && [regexp {^\s*connect \\Q\s+(.+)\s*$} $line _ qval]} {
+            set qclean [string trim $qval]
+            if {[string index $qclean 0] eq "\\"} {
+                set qclean [string range $qclean 1 end]
+            }
+            if {[regexp {^(\S+)\[(\d+)\]$} $qclean _ base bit]} {
+                set target "${base}_reg_${bit}"
+            } else {
+                set target "${qclean}_reg"
+            }
+            if {[catch {yosys rename $cell $target} err]} {
+                puts "FAIL: $cell -> $target : $err"
+            }
+            set cell ""
+        }
+    }
+    yosys cd ..
+}
+
+rename_dffs_in_module MultdivMulticycleDatapath
+rename_dffs_in_module MultdivMulticycleHier

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -227,19 +227,27 @@ impl<'a> Codegen<'a> {
                 "# Module {}: multicycle reg {}\n",
                 mc.module_name, mc.reg_name
             ));
-            // `[get_cells {*<reg>_reg*}]` is the largest common subset across
-            // OpenSTA, DC, Genus, Vivado, and Quartus. Bare-path `[*]` only
-            // works on DC/Genus; `get_registers` is missing from OpenSTA. The
-            // leading `*` glob handles both flat synth (reg at top level, no
-            // module instance prefix) and hierarchical synth (the wildcard
-            // absorbs `top/.../<module>/`). The module name remains in the
-            // header comment above for human readers.
+            // `[get_cells -hierarchical {*<reg>_reg*}]` is the largest
+            // common subset across OpenSTA, DC, Genus, Vivado, and Quartus.
+            // Bare-path `[*]` only works on DC/Genus; `get_registers` is
+            // missing from OpenSTA. The leading `*` glob handles both flat
+            // synth (reg at top level, no module instance prefix) and
+            // hierarchical synth (the wildcard absorbs `top/.../<module>/`).
+            // The `-hierarchical` flag is required for hierarchical netlists
+            // under OpenSTA — without it, `get_cells` is non-recursive and
+            // the `*` glob does not descend into instance subhierarchies,
+            // so the multicycle constraint silently attaches to zero cells
+            // and the path is treated as single-cycle. `-hierarchical` is
+            // harmless for flat netlists (returns the same cells either
+            // way) and is standard SDC across DC/Genus/Vivado/Quartus.
+            // The module name remains in the header comment above for
+            // human readers.
             s.push_str(&format!(
-                "set_multicycle_path {} -setup -to [get_cells {{*{}_reg*}}]\n",
+                "set_multicycle_path {} -setup -to [get_cells -hierarchical {{*{}_reg*}}]\n",
                 mc.latency, mc.reg_name
             ));
             s.push_str(&format!(
-                "set_multicycle_path {} -hold -to [get_cells {{*{}_reg*}}]\n",
+                "set_multicycle_path {} -hold -to [get_cells -hierarchical {{*{}_reg*}}]\n",
                 mc.latency.saturating_sub(1), mc.reg_name
             ));
             s.push('\n');

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -14535,9 +14535,9 @@ end module M
 "#;
     let (_sv, sdc) = compile_to_sv_with_sdc(source);
     let sdc = sdc.expect(".sdc expected when multicycle reg is present");
-    assert!(sdc.contains("set_multicycle_path 3 -setup -to [get_cells {*result_reg*}]"),
+    assert!(sdc.contains("set_multicycle_path 3 -setup -to [get_cells -hierarchical {*result_reg*}]"),
         "expected setup constraint with N=3; got:\n{}", sdc);
-    assert!(sdc.contains("set_multicycle_path 2 -hold -to [get_cells {*result_reg*}]"),
+    assert!(sdc.contains("set_multicycle_path 2 -hold -to [get_cells -hierarchical {*result_reg*}]"),
         "expected hold constraint with N-1=2; got:\n{}", sdc);
     assert!(sdc.contains("Module M: multicycle reg result"),
         "expected per-reg header comment; got:\n{}", sdc);
@@ -14546,10 +14546,18 @@ end module M
     // synth (any number of `top/.../<Module>/` levels). A regression that
     // re-introduces the `<Module>/` prefix would silently fail to attach
     // under flat / standalone synth (OpenSTA warns `instance not found`).
-    assert!(sdc.contains("[get_cells {*result_reg*}]"),
-        "expected wildcard-prefix glob `*result_reg*`; got:\n{}", sdc);
+    assert!(sdc.contains("[get_cells -hierarchical {*result_reg*}]"),
+        "expected wildcard-prefix glob `*result_reg*` with -hierarchical; got:\n{}", sdc);
     assert!(!sdc.contains("{M/result_reg"),
         "expected NO hierarchical `M/result_reg` prefix in glob; got:\n{}", sdc);
+    // `-hierarchical` is mandatory: under hierarchical synth (parent +
+    // child module), OpenSTA's `get_cells` is non-recursive by default, so
+    // the `*` glob does not descend into instance subhierarchies. Without
+    // the flag the multicycle constraint silently attaches to zero cells
+    // and the path is treated as single-cycle (verified with the
+    // MultdivMulticycleHier two-pass example).
+    assert!(sdc.contains("get_cells -hierarchical"),
+        "expected `-hierarchical` flag on get_cells; got:\n{}", sdc);
 }
 
 #[test]
@@ -14602,9 +14610,9 @@ end module M
 "#;
     let (_sv, sdc) = compile_to_sv_with_sdc(source);
     let sdc = sdc.expect("unused multicycle reg still emits SDC");
-    assert!(sdc.contains("set_multicycle_path 4 -setup -to [get_cells {*_unused_reg*}]"),
+    assert!(sdc.contains("set_multicycle_path 4 -setup -to [get_cells -hierarchical {*_unused_reg*}]"),
         "got:\n{}", sdc);
-    assert!(sdc.contains("set_multicycle_path 3 -hold -to [get_cells {*_unused_reg*}]"),
+    assert!(sdc.contains("set_multicycle_path 3 -hold -to [get_cells -hierarchical {*_unused_reg*}]"),
         "got:\n{}", sdc);
 }
 
@@ -14673,8 +14681,8 @@ end fsm F
 "#;
     let (_sv, sdc) = compile_to_sv_with_sdc(source);
     let sdc = sdc.expect(".sdc expected for multicycle reg inside fsm");
-    assert!(sdc.contains("set_multicycle_path 5 -setup -to [get_cells {*slow_r_reg*}]"),
+    assert!(sdc.contains("set_multicycle_path 5 -setup -to [get_cells -hierarchical {*slow_r_reg*}]"),
         "got:\n{}", sdc);
-    assert!(sdc.contains("set_multicycle_path 4 -hold -to [get_cells {*slow_r_reg*}]"),
+    assert!(sdc.contains("set_multicycle_path 4 -hold -to [get_cells -hierarchical {*slow_r_reg*}]"),
         "got:\n{}", sdc);
 }


### PR DESCRIPTION
## Summary

Two consolidated changes:

1. **Two-pass synth scaffold + parent/child example restructure** (Path A of the research note `~/.claude/uploads/.../yosys_multicycle.html`). A two-pass yosys flow that gives the multicycle multdiv cone a relaxed delay budget during synthesis, then re-synthesizes the rest of the design at the real clock target. Uses **hierarchy-boundary freeze** (the research note's preferred strategy).
2. **SDC emit `-hierarchical` flag fix** (consolidated into this PR, was originally a follow-up). arch-com's `emit_sdc` now produces `[get_cells -hierarchical {*<reg>_reg*}]` so multicycle paths attach cleanly on both flat AND hierarchical netlists.

Builds on `examples/multdiv_multicycle.arch` from PR #346; existing single-pass example is unchanged.

## Files

- `src/codegen/mod.rs::emit_sdc` — add `-hierarchical` flag to `get_cells`.
- `tests/integration_test.rs` — golden assertions updated for new emission format.
- `examples/multdiv_multicycle_hier.arch` — hierarchy-split sibling (`MultdivMulticycleDatapath` child + `MultdivMulticycleHier` parent). Same observable timing.
- `examples/multdiv_multicycle_two_pass.sh` — two-yosys-invocation driver (pass 1 = child at 3.8 ns; pass 2 = parent at 5.0 ns).
- `examples/multdiv_multicycle_two_pass_rename.tcl` — flop-rename helper for both modules.
- `examples/multdiv_multicycle_sta.tcl` — added `hier_with_mc` / `hier_nosdc` DESIGN modes; dropped the per-driver `-hierarchical` regsub workaround (now redundant).
- `doc/multdiv_multicycle_vs_fsm.md` — new "Two-pass selective resynthesis (Path A)" section + comparison table + SDC fix note.

## Sample SDC output (post-fix)

```sdc
# Module MultdivMulticycleDatapath: multicycle reg mul_r
set_multicycle_path 3 -setup -to [get_cells -hierarchical {*mul_r_reg*}]
set_multicycle_path 2 -hold  -to [get_cells -hierarchical {*mul_r_reg*}]
```

## Comparison

| Design / flow | Cells | Area | Crit path | Fmax |
|---|--:|--:|--:|--:|
| `MultdivMulticycle` (flat, single-pass, mc honored) | 6,047 | 39,208 µm² | 1.45 / 3.79 (mc) ns | 264 MHz |
| **`MultdivMulticycleHier` two-pass, mc honored**     | **6,031** | **39,221 µm²** | **1.45 / 3.7 (mc) ns** | **~270 MHz** |

Two-pass is **statistically tied** with single-pass (−0.26% cells, +0.03% area). The research note's hypothesis ("relaxed-clock pass produces smaller area") is **not confirmed** on this benchmark.

## Honest interpretation (two-pass)

Vanilla yosys 0.64 + ABC produces identical area for clock targets spanning 1.0 ns to 50.0 ns on this design — ABC's default mapping isn't aggressive enough about delay for `-D` to matter. The two-pass methodology works correctly (verified via ABC logs + STA), but produces no QoR delta on this benchmark.

Documented as a valid negative result: the workflow is sound, but yosys-ABC + Sky130 + this benchmark shape doesn't benefit. Likely matters more on designs where ABC actually responds to `-D` (custom delay-aggressive ABC scripts) and the multicycle cone has structural sharing opportunities.

## Test plan

- [x] `cargo test --release` — 425 passed / 0 failed (matches main).
- [x] `bash examples/multdiv_multicycle_two_pass.sh` runs end-to-end clean.
- [x] `DESIGN=hier_with_mc CLOCK_NS=5.0 sta ... multdiv_multicycle_sta.tcl` reports WNS=0 / slack MET / multicycle paths matched — *no regsub workaround needed*.
- [x] `DESIGN=mul_with_mc CLOCK_NS=5.0 sta ...` (flat variant) also reports WNS=0 / multicycle paths matched — `-hierarchical` is harmless for flat netlists.
- [x] Min-period sweeps: flat 3.79 ns (264 MHz), hier 3.7 ns (~270 MHz).
- [x] Existing single-pass example (`examples/multdiv_multicycle.arch` and friends) untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)