### PR TITLE
[codex] add beat interleaving thread example

### DIFF
--- a/tests/axi_dma_thread/ThreadAxiReadBeatInterleave.arch
+++ b/tests/axi_dma_thread/ThreadAxiReadBeatInterleave.arch
@@ -1,0 +1,63 @@
+//! ---
+//! spec_md: doc/thread_multi_outstanding_spec.md
+//! tags: [axi4, read, thread, lock, interleave]
+//! refs:
+//!   - "AXI4 read data channel interleaving by ID"
+//! ---
+//!
+//! Beat-by-beat AXI read response interleaving example. Two static response
+//! lanes share one R channel mutex; each lane locks only long enough to send a
+//! single beat, then releases the channel so the arbiter may grant another
+//! lane on the next beat.
+
+/// Two-lane AXI read response target that interleaves beats on a shared R channel.
+///
+/// This is intentionally a thread/resource example rather than a TLM method
+/// example: it shows the lower-level arbitration shape that a future richer TLM
+/// burst target can lower toward when the protocol wants beat-level response
+/// interleaving instead of whole-burst locking.
+module ThreadAxiReadBeatInterleave
+  param NUM_LANES: const = 2;
+  param BURST_LEN: const = 4;
+
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+
+  port start: in Bool;
+  port r_ready: in Bool;
+
+  port r_valid: out Bool;
+  port r_id: out UInt<2>;
+  port r_data: out UInt<32>;
+  port r_last: out Bool;
+
+  /// Shared read response channel. Round-robin policy makes the two active
+  /// lanes alternate grants when both have a beat ready.
+  resource r_ch: mutex<round_robin>;
+
+  generate_for lane in 0..NUM_LANES-1
+    thread ReadRspLane_lane on clk rising, rst high
+      default comb
+        r_valid = false;
+        r_id    = 2'd0;
+        r_data  = 32'h0000_0000;
+        r_last  = false;
+      end default
+
+      wait until start;
+
+      for beat in 0..BURST_LEN-1
+        lock r_ch
+          do
+            r_valid = true;
+            r_id    = lane;
+            r_data  = ((lane << 8) + beat).zext<32>();
+            r_last  = (beat == BURST_LEN-1);
+          until r_ready;
+        end lock r_ch
+      end for
+
+      wait 1 cycle;
+    end thread ReadRspLane_lane
+  end generate_for
+end module ThreadAxiReadBeatInterleave

--- a/tests/axi_dma_thread/tb_axi_read_beat_interleave.cpp
+++ b/tests/axi_dma_thread/tb_axi_read_beat_interleave.cpp
@@ -1,0 +1,103 @@
+#include "VThreadAxiReadBeatInterleave.h"
+
+#include <array>
+#include <cstdio>
+#include <cstdlib>
+
+static VThreadAxiReadBeatInterleave dut;
+
+static void eval_low() {
+    dut.clk = 0;
+    dut.eval();
+}
+
+static void tick() {
+    dut.clk = 0;
+    dut.eval();
+    dut.clk = 1;
+    dut.eval();
+}
+
+static void reset() {
+    dut.rst = 1;
+    dut.start = 0;
+    dut.r_ready = 0;
+    for (int i = 0; i < 4; ++i) {
+        tick();
+    }
+    dut.rst = 0;
+    tick();
+}
+
+int main() {
+    reset();
+
+    dut.r_ready = 1;
+    dut.start = 1;
+    tick();
+    dut.start = 0;
+
+    std::array<unsigned, 8> ids{};
+    std::array<unsigned, 8> last{};
+    std::array<unsigned, 8> data{};
+    int beats = 0;
+
+    for (int cycle = 0; cycle < 80; ++cycle) {
+        eval_low();
+        if (dut.r_valid && dut.r_ready) {
+            if (beats >= 8) {
+                std::printf("FAIL: extra beat id=%u last=%u data=0x%08x\n",
+                            static_cast<unsigned>(dut.r_id),
+                            static_cast<unsigned>(dut.r_last),
+                            static_cast<unsigned>(dut.r_data));
+                return 1;
+            }
+            ids[beats] = static_cast<unsigned>(dut.r_id);
+            last[beats] = static_cast<unsigned>(dut.r_last);
+            data[beats] = static_cast<unsigned>(dut.r_data);
+            ++beats;
+        }
+        if (beats == 8) {
+            break;
+        }
+        tick();
+    }
+
+    if (beats != 8) {
+        std::printf("FAIL: beats=%d\n", beats);
+        return 1;
+    }
+
+    unsigned per_id_beat[2] = {0, 0};
+    for (int i = 0; i < 8; ++i) {
+        if (ids[i] > 1) {
+            std::printf("FAIL: beat %d has unexpected id=%u\n", i, ids[i]);
+            return 1;
+        }
+        if (i != 0 && ids[i] == ids[i - 1]) {
+            std::printf("FAIL: beat %d did not interleave, ids[%d]=ids[%d]=%u\n",
+                        i, i - 1, i, ids[i]);
+            return 1;
+        }
+        unsigned expected_beat = per_id_beat[ids[i]]++;
+        unsigned expected_data = (ids[i] << 8) + expected_beat;
+        unsigned expected_last = (expected_beat == 3) ? 1u : 0u;
+        if (data[i] != expected_data || last[i] != expected_last) {
+            std::printf("FAIL: beat %d got id=%u data=0x%08x last=%u; expected data=0x%08x last=%u\n",
+                        i, ids[i], data[i], last[i],
+                        expected_data, expected_last);
+            return 1;
+        }
+    }
+    if (per_id_beat[0] != 4 || per_id_beat[1] != 4) {
+        std::printf("FAIL: lane counts id0=%u id1=%u\n", per_id_beat[0], per_id_beat[1]);
+        return 1;
+    }
+
+    std::printf("PASS beat interleave alternating ids=");
+    for (int i = 0; i < 8; ++i) {
+        std::printf("%u", ids[i]);
+    }
+    std::printf("\n");
+    return 0;
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -6955,6 +6955,99 @@ fn test_axi_dma_tlm_indexed_burst_target_verilator_behavior() {
 }
 
 #[test]
+fn test_axi_read_beat_interleave_example_compiles() {
+    let source = include_str!("axi_dma_thread/ThreadAxiReadBeatInterleave.arch");
+    let sv = compile_to_sv(source);
+    assert!(sv.contains("module ThreadAxiReadBeatInterleave"),
+        "beat-interleaving thread example should build:\n{sv}");
+    assert!(sv.contains("_arb_ThreadAxiReadBeatInterleave_r_ch"),
+        "response channel mutex should lower to a generated arbiter:\n{sv}");
+    assert!(sv.contains("r_id = 1"),
+        "generate_for lanes should become concrete response IDs:\n{sv}");
+}
+
+#[test]
+fn test_axi_read_beat_interleave_arch_sim_behavior() {
+    let td = tempfile::tempdir().expect("tempdir");
+    let arch_bin = env!("CARGO_BIN_EXE_arch");
+    let out = std::process::Command::new(arch_bin)
+        .arg("sim")
+        .arg("tests/axi_dma_thread/ThreadAxiReadBeatInterleave.arch")
+        .arg("--tb")
+        .arg("tests/axi_dma_thread/tb_axi_read_beat_interleave.cpp")
+        .arg("--outdir")
+        .arg(td.path())
+        .output()
+        .expect("run arch sim for beat-interleaving response target");
+    assert!(out.status.success(),
+        "beat-interleaving arch sim should pass\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr));
+    assert!(String::from_utf8_lossy(&out.stdout).contains("PASS beat interleave alternating"),
+        "expected PASS marker in stdout:\n{}",
+        String::from_utf8_lossy(&out.stdout));
+}
+
+#[test]
+fn test_axi_read_beat_interleave_verilator_behavior() {
+    if std::process::Command::new("verilator").arg("--version").output().is_err() {
+        eprintln!("skipping Verilator beat-interleaving smoke: verilator not found");
+        return;
+    }
+
+    let td = tempfile::tempdir().expect("tempdir");
+    let sv_out = td.path().join("ThreadAxiReadBeatInterleave.sv");
+    let obj_dir = td.path().join("obj_dir");
+    let arch_bin = env!("CARGO_BIN_EXE_arch");
+
+    let build = std::process::Command::new(arch_bin)
+        .arg("build")
+        .arg("tests/axi_dma_thread/ThreadAxiReadBeatInterleave.arch")
+        .arg("-o")
+        .arg(&sv_out)
+        .output()
+        .expect("build beat-interleaving SV");
+    assert!(build.status.success(),
+        "arch build should pass\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&build.stdout),
+        String::from_utf8_lossy(&build.stderr));
+
+    let verilate = std::process::Command::new("verilator")
+        .arg("--cc")
+        .arg("--exe")
+        .arg("--build")
+        .arg("--sv")
+        .arg("--assert")
+        .arg("-Wno-fatal")
+        .arg("-Wno-WIDTH")
+        .arg("-Wno-DECLFILENAME")
+        .arg("--top-module")
+        .arg("ThreadAxiReadBeatInterleave")
+        .arg("-Mdir")
+        .arg(&obj_dir)
+        .arg(&sv_out)
+        .arg("tests/axi_dma_thread/tb_axi_read_beat_interleave.cpp")
+        .output()
+        .expect("verilate beat-interleaving response target");
+    assert!(verilate.status.success(),
+        "Verilator build should pass\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&verilate.stdout),
+        String::from_utf8_lossy(&verilate.stderr));
+
+    let exe = obj_dir.join("VThreadAxiReadBeatInterleave");
+    let run = std::process::Command::new(&exe)
+        .output()
+        .expect("run Verilator beat-interleaving response target");
+    assert!(run.status.success(),
+        "Verilator sim should pass\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr));
+    assert!(String::from_utf8_lossy(&run.stdout).contains("PASS beat interleave alternating"),
+        "expected PASS marker in Verilator stdout:\n{}",
+        String::from_utf8_lossy(&run.stdout));
+}
+
+#[test]
 fn test_implement_initiator_single_compiles_end_to_end() {
     // PR-tlm-i3: single-implementer initiator routes through the
     // existing v1 inline lowering. End-to-end SV compiles.


### PR DESCRIPTION
## Summary

Adds a small AXI read response example that demonstrates beat-by-beat interleaving with existing ARCH thread primitives.

The example creates two static response lanes with `generate_for`. Each lane locks the shared `R` channel resource for one beat, drives `r_valid/r_id/r_data/r_last`, then releases the lock so round-robin arbitration can grant another lane on the next beat.

## Validation

- `cargo test axi_read_beat_interleave -- --nocapture`

This targeted test covers ARCH compilation, native arch sim, and Verilator simulation for the new example.
