### PR TITLE
[codex] support conditional tlm initiator calls

### DIFF
--- a/doc/ARCH_HDL_Specification.md
+++ b/doc/ARCH_HDL_Specification.md
@@ -5094,7 +5094,7 @@ Full design history and the broader roadmap are in `doc/plan_credit_channel.md` 
 
 TLM call sites are deliberately restricted to `thread` bodies. An initiator call is legal only as the direct RHS of a thread assignment (`dst <= port.method(args);`) or as a nonblocking RHS-fork issue (`dst <= fork port.method(args);`). TLM calls are not general expressions and are rejected in `comb`, `seq`, module-level `let`, module-local `function`, `pipeline`, and `fsm` contexts.
 
-TLM calls are legal inside initiator `for` loops when the call is a serialized direct blocking assignment. Literal-bounded loops are unrolled before TLM lowering; non-literal/runtime loops lower to a generated loop counter plus request/response issue/wait states. For independent compile-time worker replication or multiple outstanding requests, use `generate_for` worker threads or RHS-fork groups.
+TLM calls are legal inside initiator `for` loops and `if`/`elsif`/`else` branches when the call is a serialized direct blocking assignment. Literal-bounded loops are unrolled before TLM lowering; non-literal/runtime loops lower to a generated loop counter plus request/response issue/wait states. Conditional branches lower to branch and join states, so only the selected branch issues its TLM calls before control rejoins. For independent compile-time worker replication or multiple outstanding requests, use `generate_for` worker threads or RHS-fork groups.
 
 **18d.1 Declaration**
 

--- a/doc/Arch_AI_Reference_Card.md
+++ b/doc/Arch_AI_Reference_Card.md
@@ -1103,6 +1103,22 @@ end thread driver
 
 Runtime-loop TLM calls are serialized in this slice. Use `generate_for` worker threads or RHS-fork groups when you need independent workers or multiple outstanding requests.
 
+Serialized direct blocking calls may also appear inside ordinary thread
+`if`/`elsif`/`else` branches. The branch condition is sampled when the lowered
+initiator FSM reaches the branch state; only the selected branch issues its TLM
+calls, then both branches rejoin before later thread statements:
+
+```
+thread driver on clk rising, rst high
+  if use_hi
+    data <= mem.read(32'h2000);
+  else
+    data <= mem.read(32'h1000);
+  end if
+  checksum <= checksum +% data;
+end thread driver
+```
+
 Shared method call sites lower to one physical method driver, not multiple SV drivers. Use `lock` plus `resource ... mutex<round_robin>;` when independent workers share a method and require round-robin request arbitration:
 
 ```
@@ -1180,7 +1196,7 @@ completed transaction response drives the shared channel.
 
 Generated code shape: grouped/looped initiator call sites emit one generated driver per TLM method signal. Large request-valid reductions, response-ready reductions, payload muxes, default-priority grants, and round-robin grant terms are split into intermediate wires so generated SV lines stay bounded.
 
-Current restrictions: thread-body call sites only; direct RHS call only (`dst <= m.method(args);` or `dst <= fork m.method(args);`); runtime-loop TLM calls are serialized direct blocking assignments; one call per worker/branch/forked issue; same clock/reset per cohort; literal tag count only; RHS-fork offsets require literal `wait N cycle;`; no nested/composed TLM calls; no dynamic-length TLM return types; no `pipelined`; no first-class `burst`; no `Future<T>`/`await`.
+Current restrictions: thread-body call sites only; direct RHS call only (`dst <= m.method(args);` or `dst <= fork m.method(args);`); runtime-loop and conditional-branch TLM calls are serialized direct blocking assignments; one call per worker/forked issue; same clock/reset per cohort; literal tag count only; RHS-fork offsets require literal `wait N cycle;`; no nested/composed TLM calls; no dynamic-length TLM return types; no `pipelined`; no first-class `burst`; no `Future<T>`/`await`.
 
 Full spec: `doc/ARCH_HDL_Specification.md` §18d and §22. Design history / remaining work: `doc/plan_tlm_method.md`.
 

--- a/doc/bus_spec_section.md
+++ b/doc/bus_spec_section.md
@@ -174,11 +174,13 @@ Supported cohort shapes:
 - One direct-call `fork ... and ... join` thread.
 - Literal-bounded `for` loops inside one initiator thread; these are unrolled before TLM lowering.
 - Runtime-bounded `for` loops inside one initiator thread when calls are serialized direct blocking assignments.
+- `if`/`elsif`/`else` branches inside one initiator thread when calls are serialized direct blocking assignments; only the selected branch issues requests, then branches rejoin.
 - Timed RHS-fork groups (`dst <= fork m.read(...); wait N cycle; ... join all;`) for multiple outstanding issue inside one thread.
 
 Current restrictions:
 
-- Each worker/branch body is exactly one direct assignment: `dst <= port.method(args);`.
+- Each worker/forked issue is exactly one direct assignment: `dst <= port.method(args);`.
+- Conditional initiator branches may contain serialized direct blocking TLM assignments plus ordinary compute assignments.
 - RHS-fork groups may contain only direct forked TLM assignments, literal `wait N cycle;` offsets, and a final `join all;`.
 - All workers in the cohort use the same clock/reset.
 - `out_of_order tags N` requires a literal tag count and enough tags for all workers.

--- a/doc/plan_tlm_method.md
+++ b/doc/plan_tlm_method.md
@@ -404,9 +404,10 @@ Three auto-emitted properties labeled
   current compiler supports bounded burst-like payloads through static
   `Vec<T, MAX>` returns or response structs carrying `data`, returned
   `len`, and `resp`; this is not a dynamic-length return type.
-- Richer TLM initiator control flow remains deferred. Today, call sites must
-  stay direct RHS assignments or RHS-fork assignments. Runtime-loop calls are
-  supported only for serialized direct blocking assignments.
+- Richer TLM initiator control flow beyond serialized `for` loops and
+  `if`/`elsif`/`else` branches remains deferred. Today, call sites must stay
+  direct RHS assignments or RHS-fork assignments; nested/composed TLM
+  expressions are still rejected.
 - One-to-many decoded interconnect remains explicit router code. `connect
   a.m -> b.s;` is point-to-point sugar; address decode and decode-error
   response ownership belong in a router module.

--- a/src/elaborate.rs
+++ b/src/elaborate.rs
@@ -6620,6 +6620,10 @@ fn thread_body_has_tlm_call(
             || contains_tlm_call(&ca.target, port_buses, bus_methods),
         ThreadStmt::WaitUntil(e, _) =>
             contains_tlm_call(e, port_buses, bus_methods),
+        ThreadStmt::IfElse(ie) =>
+            contains_tlm_call(&ie.cond, port_buses, bus_methods)
+            || thread_body_has_tlm_call(&ie.then_stmts, port_buses, bus_methods)
+            || thread_body_has_tlm_call(&ie.else_stmts, port_buses, bus_methods),
         ThreadStmt::ForkJoin(branches, _) =>
             branches.iter().any(|branch| thread_body_has_tlm_call(branch, port_buses, bus_methods)),
         ThreadStmt::For { body, .. }
@@ -6664,6 +6668,16 @@ enum TlmInitGroupStateKind {
 
 enum TlmInitGroupNext {
     Fallthrough,
+    Goto {
+        target: usize,
+        span: Span,
+    },
+    Branch {
+        cond: Expr,
+        then_start: usize,
+        else_start: usize,
+        span: Span,
+    },
     LoopBack {
         counter: String,
         end: Expr,
@@ -6817,31 +6831,105 @@ fn build_tlm_init_thread_plan(
                     )?;
                 }
                 ThreadStmt::IfElse(ie) => {
-                    if thread_body_has_tlm_call(&ie.then_stmts, port_buses, bus_methods)
-                        || thread_body_has_tlm_call(&ie.else_stmts, port_buses, bus_methods)
-                    {
-                        return Err(CompileError::general(
-                            "TLM method calls inside `if` branches are not supported in v1 initiator lowering",
-                            ie.span,
-                        ));
+                    let then_has_tlm = thread_body_has_tlm_call(&ie.then_stmts, port_buses, bus_methods);
+                    let else_has_tlm = thread_body_has_tlm_call(&ie.else_stmts, port_buses, bus_methods);
+                    if !then_has_tlm && !else_has_tlm {
+                        pending_seq.push(Stmt::IfElse(IfElseOf {
+                            cond: ie.cond,
+                            then_stmts: compute_only_thread_stmts_to_seq(
+                                ie.then_stmts,
+                                port_buses,
+                                bus_methods,
+                                ie.span,
+                            )?,
+                            else_stmts: compute_only_thread_stmts_to_seq(
+                                ie.else_stmts,
+                                port_buses,
+                                bus_methods,
+                                ie.span,
+                            )?,
+                            unique: false,
+                            span: ie.span,
+                        }));
+                        continue;
                     }
-                    pending_seq.push(Stmt::IfElse(IfElseOf {
-                        cond: ie.cond,
-                        then_stmts: compute_only_thread_stmts_to_seq(
-                            ie.then_stmts,
-                            port_buses,
-                            bus_methods,
-                            ie.span,
-                        )?,
-                        else_stmts: compute_only_thread_stmts_to_seq(
-                            ie.else_stmts,
-                            port_buses,
-                            bus_methods,
-                            ie.span,
-                        )?,
-                        unique: false,
-                        span: ie.span,
-                    }));
+
+                    if !pending_seq.is_empty() {
+                        push_state(states, TlmInitGroupStateKind::Compute {
+                            seq_on_exit: std::mem::take(pending_seq),
+                        });
+                    }
+
+                    let branch_idx = states.len();
+                    push_state(states, TlmInitGroupStateKind::Compute { seq_on_exit: Vec::new() });
+
+                    let then_start = states.len();
+                    let mut then_pending = Vec::new();
+                    lower_stmts(
+                        ie.then_stmts,
+                        states,
+                        &mut then_pending,
+                        loop_counters,
+                        tag,
+                        port_buses,
+                        bus_methods,
+                        span,
+                        current_lock,
+                    )?;
+                    if !then_pending.is_empty() {
+                        push_state(states, TlmInitGroupStateKind::Compute {
+                            seq_on_exit: std::mem::take(&mut then_pending),
+                        });
+                    }
+                    let then_end = states.len();
+
+                    let else_start = states.len();
+                    let mut else_pending = Vec::new();
+                    lower_stmts(
+                        ie.else_stmts,
+                        states,
+                        &mut else_pending,
+                        loop_counters,
+                        tag,
+                        port_buses,
+                        bus_methods,
+                        span,
+                        current_lock,
+                    )?;
+                    if !else_pending.is_empty() {
+                        push_state(states, TlmInitGroupStateKind::Compute {
+                            seq_on_exit: std::mem::take(&mut else_pending),
+                        });
+                    }
+                    let else_end = states.len();
+
+                    let join_idx = states.len();
+                    push_state(states, TlmInitGroupStateKind::Compute { seq_on_exit: Vec::new() });
+
+                    if let Some(branch_state) = states.get_mut(branch_idx) {
+                        branch_state.next = TlmInitGroupNext::Branch {
+                            cond: ie.cond,
+                            then_start: if then_end > then_start { then_start } else { join_idx },
+                            else_start: if else_end > else_start { else_start } else { join_idx },
+                            span: ie.span,
+                        };
+                    }
+                    if then_end > then_start {
+                        if let Some(last_then) = states.get_mut(then_end - 1) {
+                            last_then.next = TlmInitGroupNext::Goto {
+                                target: join_idx,
+                                span: ie.span,
+                            };
+                        }
+                    }
+                    if else_end > else_start {
+                        if let Some(last_else) = states.get_mut(else_end - 1) {
+                            last_else.next = TlmInitGroupNext::Goto {
+                                target: join_idx,
+                                span: ie.span,
+                            };
+                        }
+                    }
                 }
                 ThreadStmt::For { var, start, end, body, span: for_span } => {
                     match (literal_expr_u64(&start), literal_expr_u64(&end)) {
@@ -7063,6 +7151,28 @@ fn inline_lower_tlm_initiator_group(
                     value: state_lit(normal_next_idx),
                     span,
                 })],
+                TlmInitGroupNext::Goto { target, span: goto_span } => vec![Stmt::Assign(RegAssign {
+                    target: state_expr,
+                    value: state_lit(*target as u64),
+                    span: *goto_span,
+                })],
+                TlmInitGroupNext::Branch { cond, then_start, else_start, span: branch_span } => {
+                    vec![Stmt::IfElse(IfElseOf {
+                        cond: cond.clone(),
+                        then_stmts: vec![Stmt::Assign(RegAssign {
+                            target: state_expr.clone(),
+                            value: state_lit(*then_start as u64),
+                            span: *branch_span,
+                        })],
+                        else_stmts: vec![Stmt::Assign(RegAssign {
+                            target: state_expr,
+                            value: state_lit(*else_start as u64),
+                            span: *branch_span,
+                        })],
+                        unique: false,
+                        span: *branch_span,
+                    })]
+                }
                 TlmInitGroupNext::LoopBack { counter, end, body_start, span: loop_span } => {
                     let counter_expr = id(counter.clone());
                     let inc_expr = bin(BinOp::AddWrap, counter_expr.clone(), sized(32, 1));

--- a/tests/axi_dma_tlm/TlmConditionalInitiator.arch
+++ b/tests/axi_dma_tlm/TlmConditionalInitiator.arch
@@ -1,0 +1,51 @@
+//! ---
+//! spec_md: doc/plan_tlm_method.md
+//! tags: [tlm_method, initiator, if, control_flow]
+//! refs:
+//!   - "doc/plan_tlm_method.md"
+//! ---
+//!
+//! TLM initiator conditional-control smoke test. The driver chooses one of two
+//! serialized blocking method calls with an ordinary thread `if` statement.
+
+/// Simple memory-like TLM bus used by the conditional initiator example.
+bus CondMem
+  tlm_method read(addr: UInt<32>) -> UInt<32>: blocking;
+end bus CondMem
+
+/// Bring the TLM bus into scope for module ports.
+use CondMem;
+
+/// Initiator that selects between two TLM reads based on `sel`.
+///
+/// This exercises richer initiator control flow: each branch contains an
+/// ordinary blocking TLM call, and both branches rejoin before the thread
+/// loops back to sample `sel` again.
+module TlmConditionalInitiator
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port sel: in Bool;
+  port m: initiator CondMem;
+
+  port data_out: out UInt<32>;
+  port then_seen_out: out Bool;
+  port else_seen_out: out Bool;
+
+  reg data_r: UInt<32> reset rst => 0;
+  reg then_seen_r: Bool reset rst => false;
+  reg else_seen_r: Bool reset rst => false;
+
+  let data_out = data_r;
+  let then_seen_out = then_seen_r;
+  let else_seen_out = else_seen_r;
+
+  thread driver on clk rising, rst high
+    if sel
+      data_r <= m.read(32'h0000_1000);
+      then_seen_r <= true;
+    else
+      data_r <= m.read(32'h0000_2000);
+      else_seen_r <= true;
+    end if
+  end thread driver
+end module TlmConditionalInitiator

--- a/tests/axi_dma_tlm/tb_tlm_conditional_initiator.cpp
+++ b/tests/axi_dma_tlm/tb_tlm_conditional_initiator.cpp
@@ -1,0 +1,99 @@
+#include "VTlmConditionalInitiator.h"
+
+#include <cstdint>
+#include <cstdio>
+
+static VTlmConditionalInitiator dut;
+static int cycle_count = 0;
+
+static void eval_comb() {
+    dut.eval();
+}
+
+static void tick() {
+    dut.clk = 0;
+    dut.eval();
+    dut.clk = 1;
+    dut.eval();
+    cycle_count++;
+}
+
+static void reset() {
+    dut.rst = 1;
+    dut.sel = 0;
+    dut.m_read_req_ready = 0;
+    dut.m_read_rsp_valid = 0;
+    dut.m_read_rsp_data = 0;
+    for (int i = 0; i < 4; ++i) {
+        tick();
+    }
+    dut.rst = 0;
+    tick();
+}
+
+static uint32_t response_for(uint32_t addr) {
+    return 0xC0000000u | (addr & 0x0000FFFFu);
+}
+
+int main() {
+    reset();
+
+    bool pending = false;
+    uint32_t pending_rsp = 0;
+    bool saw_else_req = false;
+    bool saw_then_req = false;
+
+    for (int c = 0; c < 80; ++c) {
+        dut.sel = saw_else_req ? 1 : 0;
+        dut.m_read_req_ready = 1;
+        dut.m_read_rsp_valid = pending ? 1 : 0;
+        dut.m_read_rsp_data = pending_rsp;
+
+        eval_comb();
+
+        if (dut.m_read_req_valid && dut.m_read_req_ready) {
+            if (pending) {
+                std::printf("FAIL: overlapping conditional request at cycle %d\n", cycle_count);
+                return 1;
+            }
+            const uint32_t addr = dut.m_read_addr;
+            if (!saw_else_req) {
+                if (addr != 0x00002000u) {
+                    std::printf("FAIL: first branch addr=0x%08x expected else addr\n", addr);
+                    return 1;
+                }
+                saw_else_req = true;
+            } else if (!saw_then_req) {
+                if (addr != 0x00001000u) {
+                    std::printf("FAIL: second branch addr=0x%08x expected then addr\n", addr);
+                    return 1;
+                }
+                saw_then_req = true;
+            }
+            pending_rsp = response_for(addr);
+            pending = true;
+        }
+
+        if (dut.m_read_rsp_valid && dut.m_read_rsp_ready) {
+            pending = false;
+        }
+
+        tick();
+        eval_comb();
+
+        if (saw_else_req && saw_then_req
+            && dut.else_seen_out
+            && dut.then_seen_out
+            && dut.data_out == response_for(0x00001000u)) {
+            std::printf("PASS TlmConditionalInitiator data=0x%08x\n", dut.data_out);
+            return 0;
+        }
+    }
+
+    std::printf("FAIL timeout else_req=%d then_req=%d else_seen=%u then_seen=%u data=0x%08x\n",
+                saw_else_req, saw_then_req,
+                static_cast<unsigned>(dut.else_seen_out),
+                static_cast<unsigned>(dut.then_seen_out),
+                static_cast<unsigned>(dut.data_out));
+    return 1;
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -7607,6 +7607,109 @@ fn test_tlm_initiator_compute_only_if_lowers_between_calls() {
 }
 
 #[test]
+fn test_tlm_initiator_if_branches_with_calls_compile() {
+    let source = include_str!("axi_dma_tlm/TlmConditionalInitiator.arch");
+    let sv = compile_to_sv(source);
+    assert!(
+        sv.contains("_tlm_init_driver_state"),
+        "conditional TLM initiator should lower to a state machine:\n{sv}"
+    );
+    assert!(
+        sv.contains("if (sel)"),
+        "branch state should sample the source-level if condition:\n{sv}"
+    );
+    assert!(
+        sv.contains("32'h1000") || sv.contains("32'd4096"),
+        "then branch TLM call should drive the 0x1000 request address:\n{sv}"
+    );
+    assert!(
+        sv.contains("32'h2000") || sv.contains("32'd8192"),
+        "else branch TLM call should drive the 0x2000 request address:\n{sv}"
+    );
+}
+
+#[test]
+fn test_tlm_conditional_initiator_arch_sim_behavior() {
+    let td = tempfile::tempdir().expect("tempdir");
+    let arch_bin = env!("CARGO_BIN_EXE_arch");
+    let out = std::process::Command::new(arch_bin)
+        .arg("sim")
+        .arg("tests/axi_dma_tlm/TlmConditionalInitiator.arch")
+        .arg("--tb")
+        .arg("tests/axi_dma_tlm/tb_tlm_conditional_initiator.cpp")
+        .arg("--outdir")
+        .arg(td.path())
+        .output()
+        .expect("run arch sim for conditional TLM initiator");
+    assert!(out.status.success(),
+        "conditional TLM initiator arch sim should pass\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr));
+    assert!(String::from_utf8_lossy(&out.stdout).contains("PASS TlmConditionalInitiator"),
+        "expected PASS marker in stdout:\n{}",
+        String::from_utf8_lossy(&out.stdout));
+}
+
+#[test]
+fn test_tlm_conditional_initiator_verilator_behavior() {
+    if std::process::Command::new("verilator").arg("--version").output().is_err() {
+        eprintln!("skipping Verilator conditional TLM smoke: verilator not found");
+        return;
+    }
+
+    let td = tempfile::tempdir().expect("tempdir");
+    let sv_out = td.path().join("TlmConditionalInitiator.sv");
+    let obj_dir = td.path().join("obj_dir");
+    let arch_bin = env!("CARGO_BIN_EXE_arch");
+
+    let build = std::process::Command::new(arch_bin)
+        .arg("build")
+        .arg("tests/axi_dma_tlm/TlmConditionalInitiator.arch")
+        .arg("-o")
+        .arg(&sv_out)
+        .output()
+        .expect("build conditional TLM initiator SV");
+    assert!(build.status.success(),
+        "arch build should pass\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&build.stdout),
+        String::from_utf8_lossy(&build.stderr));
+
+    let verilate = std::process::Command::new("verilator")
+        .arg("--cc")
+        .arg("--exe")
+        .arg("--build")
+        .arg("--sv")
+        .arg("--assert")
+        .arg("-Wno-fatal")
+        .arg("-Wno-WIDTH")
+        .arg("-Wno-DECLFILENAME")
+        .arg("--top-module")
+        .arg("TlmConditionalInitiator")
+        .arg("-Mdir")
+        .arg(&obj_dir)
+        .arg(&sv_out)
+        .arg("tests/axi_dma_tlm/tb_tlm_conditional_initiator.cpp")
+        .output()
+        .expect("verilate conditional TLM initiator");
+    assert!(verilate.status.success(),
+        "Verilator build should pass\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&verilate.stdout),
+        String::from_utf8_lossy(&verilate.stderr));
+
+    let exe = obj_dir.join("VTlmConditionalInitiator");
+    let run = std::process::Command::new(&exe)
+        .output()
+        .expect("run Verilator conditional TLM initiator");
+    assert!(run.status.success(),
+        "Verilator sim should pass\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr));
+    assert!(String::from_utf8_lossy(&run.stdout).contains("PASS TlmConditionalInitiator"),
+        "expected PASS marker in Verilator stdout:\n{}",
+        String::from_utf8_lossy(&run.stdout));
+}
+
+#[test]
 fn test_fpt26_runtime_loop_tlm_initiator_compiles() {
     let source = include_str!("fpt26_tlm/Fpt26RuntimeLoopTlm.arch");
     let sv = compile_to_sv(source);


### PR DESCRIPTION
## Summary

Adds support for serialized blocking TLM initiator calls inside ordinary thread `if` / `elsif` / `else` branches.

The initiator planner now emits explicit branch and join states, so only the selected branch issues its TLM requests and both paths rejoin before later thread statements. This keeps the direct-RHS TLM call rule intact while allowing useful control flow around blocking calls.

## Included example

- `tests/axi_dma_tlm/TlmConditionalInitiator.arch`
- `tests/axi_dma_tlm/tb_tlm_conditional_initiator.cpp`

The smoke test exercises both branch paths and verifies the selected request address plus returned data under native arch sim and Verilator.

## Validation

- `cargo test tlm -- --nocapture`

Result: 75 TLM tests passed, including arch sim and Verilator TLM tests.
