### PR TITLE
[codex] document TLM refinement to explicit threads

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -264,6 +264,12 @@ No current `Future<T>`, `await`, user-visible `Token<T>`, `pipelined`, or
 first-class `burst` API. Bounded burst-like payloads use a fixed-size
 `Vec<T, MAX>` or response struct with `data`, `len`, and `resp` fields.
 
+Treat `tlm_method` as a synthesizable transaction contract and refinement
+bridge. When a design needs channel-level control, rewrite the method boundary
+as explicit bus signals plus ordinary `thread` bodies while preserving the same
+args, return payload, ordering/tag behavior, and golden tests. Use `arch sim`,
+`arch sim --thread-sim both`, and Verilator simulation as the equivalence path.
+
 ---
 
 ## Compiler Architecture (to build)

--- a/doc/ARCH_HDL_Specification.md
+++ b/doc/ARCH_HDL_Specification.md
@@ -7103,6 +7103,79 @@ simulator/preprocessor limits such as Verilator's per-line token cap.
 
 `Future<T>`, `await`, user-visible `Token<T>`, `pipelined`, and `burst` are not part of the current language surface. Current RTL-backed TLM intentionally uses worker threads, RHS-fork groups, and hidden compiler-managed tags instead.
 
+**22.2.6 Refining TLM into Explicit Threads**
+
+Synthesizable TLM is intended to be a refinement bridge, not a separate
+simulation world. A useful development flow is:
+
+1. Write the early model as `tlm_method` calls to lock down the transaction
+   contract: method name, argument types, return type, ordering, tag width,
+   latency assumptions, and payload checksum behavior.
+2. Validate that contract with `arch sim`, `arch sim --thread-sim both`, and
+   Verilator simulation.
+3. When a protocol needs channel-level optimization, rewrite the method boundary
+   into an explicit `bus` signal bundle and ordinary `thread` bodies that drive
+   those signals.
+4. Keep the same C++/Python golden checks at the module boundary while replacing
+   the internal TLM call with explicit handshake logic.
+
+The explicit-thread version should preserve the observable method contract:
+
+- Request payload fields become bus signals driven under `req_valid &&
+  req_ready`.
+- Return values become response payload signals sampled under `rsp_valid &&
+  rsp_ready`.
+- `out_of_order tags N` becomes an explicit request ID and response ID with the
+  same width and routing rule.
+- A blocking call becomes a caller thread that issues one request and waits for
+  its matching response before continuing.
+- An RHS-fork group or worker cohort becomes multiple explicit worker threads
+  plus arbitration and response routing.
+- A target method body becomes a target thread that latches request args,
+  performs waits/compute, and later drives the response channel.
+
+Abbreviated contract-mapping sketch:
+
+```arch
+bus MemReqRsp
+  signal req_valid: out Bool;
+  signal req_ready: in Bool;
+  signal req_addr: out UInt<32>;
+  signal rsp_valid: in Bool;
+  signal rsp_ready: out Bool;
+  signal rsp_data: in UInt<64>;
+end bus MemReqRsp
+
+module ExplicitLoad
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port mem: initiator MemReqRsp;
+  reg data_r: UInt<64> reset rst => 0;
+
+  thread load_once on clk rising, rst high
+    wait until mem.req_ready;
+    // In the real explicit implementation, separate comb/default-comb logic
+    // drives req_valid and req_addr and keeps them stable until req_ready.
+    wait until mem.rsp_valid;
+    data_r <= mem.rsp_data;
+  end thread load_once
+end module ExplicitLoad
+```
+
+In real code, drive the request/response valid/ready defaults from `comb` or
+default-comb logic and keep all payload stability rules explicit. The generated
+TLM SVA (`_auto_tlm_*_stable`) is a useful reference for what the explicit
+protocol should preserve.
+
+Use explicit threads instead of `tlm_method` when any of these become central to
+the design:
+
+- Separate request/address/data/response channels with independent backpressure.
+- Beat-by-beat burst interleaving or per-beat arbitration.
+- Timing closure around registered ready/valid paths.
+- Protocol-specific error, retry, cancellation, or ordering rules.
+- Area/power work where the generated generic TLM driver is too conservative.
+
 **22.3 Concurrency Mode Comparison**
 
   ----------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/doc/Arch_AI_Reference_Card.md
+++ b/doc/Arch_AI_Reference_Card.md
@@ -1196,6 +1196,19 @@ completed transaction response drives the shared channel.
 
 Generated code shape: grouped/looped initiator call sites emit one generated driver per TLM method signal. Large request-valid reductions, response-ready reductions, payload muxes, default-priority grants, and round-robin grant terms are split into intermediate wires so generated SV lines stay bounded.
 
+Refining TLM into explicit threads:
+
+- Start with `tlm_method` to define the transaction contract: args, return type, ordering, tag width, latency, and payload checksum/golden behavior.
+- Preserve that contract when rewriting to explicit `bus` signals and ordinary `thread` code.
+- Map request args to payload signals held stable under `req_valid && !req_ready`.
+- Map return data to response payload sampled under `rsp_valid && rsp_ready`.
+- Map `out_of_order tags N` to explicit request/response IDs of the same width.
+- Map blocking calls to a caller thread that issues one request and waits for its matching response.
+- Map worker/RHS-fork concurrency to explicit worker threads plus arbitration and response routing.
+- Keep the same arch sim, `--thread-sim both`, Verilator, and golden checksum tests while replacing the internal TLM method boundary.
+
+Use explicit threads when the protocol needs separate channels, beat-by-beat burst interleaving, registered ready paths for timing closure, protocol-specific retry/error/cancel rules, or area/power tuning beyond the generic TLM driver.
+
 Current restrictions: thread-body call sites only; direct RHS call only (`dst <= m.method(args);` or `dst <= fork m.method(args);`); runtime-loop and conditional-branch TLM calls are serialized direct blocking assignments; one call per worker/forked issue; same clock/reset per cohort; literal tag count only; RHS-fork offsets require literal `wait N cycle;`; RHS-fork tails after `join all;` are compute-only; no nested/composed TLM calls; no dynamic-length TLM return types; no `pipelined`; no first-class `burst`; no `Future<T>`/`await`.
 
 Full spec: `doc/ARCH_HDL_Specification.md` §18d and §22. Design history / remaining work: `doc/plan_tlm_method.md`.

--- a/doc/bus_spec_section.md
+++ b/doc/bus_spec_section.md
@@ -320,3 +320,28 @@ The `bus` construct provides better source-level ergonomics with 100% portable R
 The current compiler does not have a file-scope `implement BusName.method rtl` block. The accepted `implement` syntax is a thread-header annotation: `thread driver implement m.read() ...` on the initiator side, or `thread name implement target s.read(addr) ...` as target-side sugar for the dotted-name form. It uses the same call-site/cohort lowering as ordinary TLM threads; it is not a separate pool API.
 
 Users writing protocol logic inside a module should prefer ordinary `thread` over a manual `fsm` when the logic is naturally sequential. For high-performance protocols that need channel-level control, explicit threads over raw bus signals remain the recommended form.
+
+### 19.7  Refining TLM to Explicit Thread Protocols
+
+Use `tlm_method` to establish the synthesizable transaction contract first:
+method arguments, return payload, ordering, tag width, target latency, and
+golden checksum behavior. When the design needs protocol-specific channel
+control, refine that method boundary into explicit bus signals and ordinary
+`thread` code.
+
+Preserve the method contract during the rewrite:
+
+- Method arguments become request payload signals held stable until the request
+  handshake completes.
+- The return value becomes response payload sampled on the response handshake.
+- `out_of_order tags N` becomes explicit request/response ID signals of the
+  same width.
+- Worker cohorts and RHS-fork groups become explicit worker threads plus
+  arbitration and response routing.
+- Target method bodies become target threads that latch args, run the same
+  waits/compute, then drive the response channel.
+
+Keep the same external smoke test while swapping the implementation underneath:
+run `arch sim`, `arch sim --thread-sim both` where applicable, and Verilator
+simulation against the generated SV. See `doc/ARCH_HDL_Specification.md`
+§22.2.6 for the fuller refinement checklist.

--- a/doc/plan_tlm_method.md
+++ b/doc/plan_tlm_method.md
@@ -444,3 +444,43 @@ Three auto-emitted properties labeled
 - Not designing separate LT/AT simulation modes. `tlm_method` compiles to
   ordinary RTL-shaped state machines and runs under existing `arch sim`,
   `arch sim --thread-sim both`, `arch sim --pybind --test`, and Verilator.
+
+## Refinement Guidance: TLM to Explicit Threads
+
+`tlm_method` should be the first executable hardware contract for a transaction
+API. It is not meant to hide the eventual protocol forever. Once the design
+needs channel-level control, refine the method boundary into explicit bus
+signals and ordinary `thread` code.
+
+Recommended sequence:
+
+1. Keep the `tlm_method` model as the golden contract until the explicit thread
+   version passes the same checks.
+2. Name the explicit bus signals after the generated method protocol:
+   `req_valid`, arg payload fields, `req_ready`, `rsp_valid`, optional
+   `rsp_data`, optional `rsp_tag`, and `rsp_ready`.
+3. Port the initiator call sequence into a caller thread:
+   - direct blocking call -> issue request, wait for response, capture result;
+   - worker cohort -> one explicit worker per lane plus request arbitration;
+   - RHS-fork group -> timed issue threads plus a join/scoreboard condition.
+4. Port the target method body into a target thread:
+   latch request args, run the same waits/compute/control flow, then drive a
+   response beat.
+5. Copy the generated TLM stable-payload assertions into explicit protocol SVA,
+   or write equivalent asserts against the new bus signals.
+6. Run the same golden C++/Python smoke test through `arch sim`, then run
+   `arch sim --thread-sim both` where applicable, and finish with Verilator
+   simulation of the generated SV.
+
+Refine to explicit threads when:
+
+- the protocol has independent address/data/response channels;
+- burst beats need per-beat interleaving or arbitration;
+- ready/valid timing requires deliberate register placement;
+- response IDs, error codes, retry, cancellation, or ordering rules are
+  protocol-specific enough that generated TLM is too generic;
+- area/power work needs manual state sharing, gating, or channel pruning.
+
+The goal of the refinement is behavioral continuity: the top-level transaction
+golden should not change merely because the implementation crossed from
+`tlm_method` syntax to explicit thread protocol code.


### PR DESCRIPTION
## Summary

Adds guidance for refining synthesizable TLM models into explicit bus-signal protocols implemented with ordinary `thread` bodies.

## Details

- Adds a new spec section describing the TLM-to-explicit-thread refinement flow.
- Documents how to preserve the transaction contract while exposing request/response signals.
- Captures when to switch from `tlm_method` to explicit threads: independent channels, beat interleaving, timing closure, protocol-specific rules, and area/power tuning.
- Adds compact checklist guidance to the AI reference card, bus spec, TLM plan, and AGENTS guidance.

## Validation

- `cargo test test_tlm_method_unsupported_modes_rejected -- --nocapture`
