### PR TITLE
[codex] Use default clock in HARC TLM test

### DIFF
--- a/tests/axi_dma_tlm/TlmMm2sBurstVec_test.harc
+++ b/tests/axi_dma_tlm/TlmMm2sBurstVec_test.harc
@@ -5,10 +5,6 @@
 // second response first, and checks that out_of_order tag routing lands each
 // Vec payload in the right destination register.
 
-domain SysDomain
-  freq_mhz: 100
-end domain SysDomain
-
 testbench TlmMm2sBurstVecTb
     dut : TlmMm2sBurstVec
 end testbench TlmMm2sBurstVecTb
@@ -25,8 +21,6 @@ function clear_rsp_vec(dut: TlmMm2sBurstVec)
 end function clear_rsp_vec
 
 impl TlmMm2sBurstVecHarcTest for TlmMm2sBurstVecTb
-    clock clk = SysDomain
-
     run
         log(info, "TlmMm2sBurstVec HARC test")
 


### PR DESCRIPTION
## Summary
- remove the explicit `SysDomain` declaration from the single-clock HARC AXI DMA TLM test
- remove the explicit `clock clk = SysDomain` binding so the fixture uses HARC default single-clock behavior

## Validation
- `/Users/shuqingzhao/github/harc-com/target/debug/harc check tests/axi_dma_tlm/TlmMm2sBurstVec_test.harc`
- `/Users/shuqingzhao/github/harc-com/target/debug/harc sim --dut tests/axi_dma_tlm/TlmMm2sBurstVec.arch tests/axi_dma_tlm/TlmMm2sBurstVec_test.harc --top TlmMm2sBurstVec --outdir /private/tmp/harc_tlm_mm2s_burst_vec_single_clock`
