### PR TITLE
[codex] Fix Vec TLM payload sim connect

### DIFF
--- a/src/sim_codegen/mod.rs
+++ b/src/sim_codegen/mod.rs
@@ -4326,6 +4326,27 @@ impl<'a> SimCodegen<'a> {
                 }
             }
         }
+        // Bus-typed wires are emitted as C++ structs. If a bus field is Vec
+        // typed (notably TLM response payloads), record the `<wire>.<field>`
+        // path so instance wiring copies the array element-by-element.
+        for item in &m.body {
+            let ModuleBodyItem::WireDecl(w) = item else { continue; };
+            let TypeExpr::Named(id) = &w.ty else { continue; };
+            let Some((crate::resolve::Symbol::Bus(info), _)) =
+                self.symbols.globals.get(&id.name)
+            else { continue; };
+            let pm = info.default_param_map();
+            for (sname, _sdir, sty) in info.effective_signals(&pm) {
+                if let TypeExpr::Vec(_, count_expr) = &sty {
+                    let count = eval_const_expr_with_params(count_expr, &m.params);
+                    if count > 0 {
+                        let path = format!("{}.{}", w.name.name, sname);
+                        vec_reg_names.insert(path.clone());
+                        vec_sizes.insert(path, count);
+                    }
+                }
+            }
+        }
 
         // Collect reset-none reg names for --check-uninit + any guarded reg (regardless
         // of reset) so Check A can use _<name>_vinit to detect producer bugs.
@@ -5286,6 +5307,16 @@ impl<'a> SimCodegen<'a> {
                 let conns = &expanded_conns[inst_idx];
                 for conn in conns {
                     if conn.direction == ConnectDir::Input && is_invariant(conn) {
+                        if !matches!(conn.signal.kind, ExprKind::Ident(_)) {
+                            if let Some(n) = ctx.expr_vec_size(&conn.signal) {
+                                let sig = cpp_expr(&conn.signal, &ctx);
+                                for i in 0..n {
+                                    cpp.push_str(&format!("  _inst_{}.{}_{i} = {sig}[{i}];\n",
+                                        inst.name.name, conn.port_name.name));
+                                }
+                                continue;
+                            }
+                        }
                         if let crate::ast::ExprKind::Ident(src_name) = &conn.signal.kind {
                             if let Some(&n) = vec_wire_counts.get(src_name.as_str()) {
                                 for i in 0..n {
@@ -5325,6 +5356,16 @@ impl<'a> SimCodegen<'a> {
                 cpp.push('\n');
                 for conn in conns {
                     if conn.direction == ConnectDir::Input && !is_invariant(conn) {
+                        if !matches!(conn.signal.kind, ExprKind::Ident(_)) {
+                            if let Some(n) = ctx.expr_vec_size(&conn.signal) {
+                                let sig = cpp_expr(&conn.signal, &ctx);
+                                for i in 0..n {
+                                    cpp.push_str(&format!("    _inst_{}.{}_{i} = {sig}[{i}];\n",
+                                        inst.name.name, conn.port_name.name));
+                                }
+                                continue;
+                            }
+                        }
                         if let crate::ast::ExprKind::Ident(src_name) = &conn.signal.kind {
                             // Vec wire/reg → inst Vec port: expand element-by-element
                             if let Some(&n) = vec_wire_counts.get(src_name.as_str()) {
@@ -5362,6 +5403,16 @@ impl<'a> SimCodegen<'a> {
                 cpp.push_str(&format!("    _inst_{}.eval_comb();\n", inst.name.name));
                 for conn in conns {
                     if conn.direction == ConnectDir::Output {
+                        if !matches!(conn.signal.kind, ExprKind::Ident(_)) {
+                            if let Some(n) = ctx.expr_vec_size(&conn.signal) {
+                                let sig = cpp_expr(&conn.signal, &ctx);
+                                for i in 0..n {
+                                    cpp.push_str(&format!("    {sig}[{i}] = _inst_{}.{}_{i};\n",
+                                        inst.name.name, conn.port_name.name));
+                                }
+                                continue;
+                            }
+                        }
                         // inst Vec port → Vec wire/reg: expand element-by-element
                         if let ExprKind::Ident(sig_name) = &conn.signal.kind {
                             if let Some(&n) = vec_wire_counts.get(sig_name.as_str()) {
@@ -5431,6 +5482,16 @@ impl<'a> SimCodegen<'a> {
                 let conns = &expanded_conns[inst_idx];
                 for conn in conns {
                     if conn.direction == ConnectDir::Input && is_invariant(conn) {
+                        if !matches!(conn.signal.kind, ExprKind::Ident(_)) {
+                            if let Some(n) = ctx.expr_vec_size(&conn.signal) {
+                                let sig = cpp_expr(&conn.signal, &ctx);
+                                for i in 0..n {
+                                    cpp.push_str(&format!("  _inst_{}.{}_{i} = {sig}[{i}];\n",
+                                        inst.name.name, conn.port_name.name));
+                                }
+                                continue;
+                            }
+                        }
                         if let crate::ast::ExprKind::Ident(src_name) = &conn.signal.kind {
                             if let Some(&n) = vec_wire_counts.get(src_name.as_str()) {
                                 for i in 0..n {
@@ -5469,6 +5530,16 @@ impl<'a> SimCodegen<'a> {
                 // Re-set sub-inst inputs (may have changed after posedge)
                 for conn in conns {
                     if conn.direction == ConnectDir::Input && !is_invariant(conn) {
+                        if !matches!(conn.signal.kind, ExprKind::Ident(_)) {
+                            if let Some(n) = ctx.expr_vec_size(&conn.signal) {
+                                let sig = cpp_expr(&conn.signal, &ctx);
+                                for i in 0..n {
+                                    cpp.push_str(&format!("    _inst_{}.{}_{i} = {sig}[{i}];\n",
+                                        inst.name.name, conn.port_name.name));
+                                }
+                                continue;
+                            }
+                        }
                         if let crate::ast::ExprKind::Ident(src_name) = &conn.signal.kind {
                             // Vec wire/reg → inst Vec port: expand element-by-element
                             if let Some(&n) = vec_wire_counts.get(src_name.as_str()) {
@@ -5506,6 +5577,16 @@ impl<'a> SimCodegen<'a> {
                 cpp.push_str(&format!("    _inst_{}.eval_comb();\n", inst.name.name));
                 for conn in conns {
                     if conn.direction == ConnectDir::Output {
+                        if !matches!(conn.signal.kind, ExprKind::Ident(_)) {
+                            if let Some(n) = ctx.expr_vec_size(&conn.signal) {
+                                let sig = cpp_expr(&conn.signal, &ctx);
+                                for i in 0..n {
+                                    cpp.push_str(&format!("    {sig}[{i}] = _inst_{}.{}_{i};\n",
+                                        inst.name.name, conn.port_name.name));
+                                }
+                                continue;
+                            }
+                        }
                         // inst Vec port → Vec wire/reg: expand element-by-element
                         if let ExprKind::Ident(sig_name) = &conn.signal.kind {
                             if let Some(&n) = vec_wire_counts.get(sig_name.as_str()) {
@@ -6210,6 +6291,16 @@ impl<'a> SimCodegen<'a> {
                 let conns = &expanded_conns[inst_i];
                 for conn in conns {
                     if conn.direction == ConnectDir::Input {
+                        if !matches!(conn.signal.kind, ExprKind::Ident(_)) {
+                            if let Some(n) = ctx_comb.expr_vec_size(&conn.signal) {
+                                let sig = cpp_expr(&conn.signal, &ctx_comb);
+                                for i in 0..n {
+                                    cpp.push_str(&format!("  _inst_{}.{}_{i} = {sig}[{i}];\n",
+                                        inst.name.name, conn.port_name.name));
+                                }
+                                continue;
+                            }
+                        }
                         if let crate::ast::ExprKind::Ident(src_name) = &conn.signal.kind {
                             // Vec wire/reg → inst Vec port: expand element-by-element
                             if let Some(&n) = vec_wire_counts.get(src_name.as_str()) {
@@ -6254,6 +6345,16 @@ impl<'a> SimCodegen<'a> {
                 cpp.push_str(&format!("  _inst_{}.eval_comb();\n", inst.name.name));
                 for conn in conns {
                     if conn.direction == ConnectDir::Output {
+                        if !matches!(conn.signal.kind, ExprKind::Ident(_)) {
+                            if let Some(n) = ctx_comb.expr_vec_size(&conn.signal) {
+                                let sig = cpp_expr(&conn.signal, &ctx_comb);
+                                for i in 0..n {
+                                    cpp.push_str(&format!("  {sig}[{i}] = _inst_{}.{}_{i};\n",
+                                        inst.name.name, conn.port_name.name));
+                                }
+                                continue;
+                            }
+                        }
                         // inst Vec port → Vec wire/reg: expand element-by-element
                         if let ExprKind::Ident(sig_name) = &conn.signal.kind {
                             if let Some(&n) = vec_wire_counts.get(sig_name.as_str()) {
@@ -7418,19 +7519,29 @@ impl<'a> SimCodegen<'a> {
             }.effective_signals(&param_map);
             h.push_str(&format!("struct {} {{\n", b.name.name));
             let mut field_inits = Vec::new();
+            let mut ctor_body = Vec::new();
             for (sname, _dir, sty) in &effective {
-                let ty = cpp_internal_type(sty);
-                h.push_str(&format!("  {} {};\n", ty, sname));
-                if matches!(sty, TypeExpr::Named(_)) {
-                    field_inits.push(format!("{}()", sname));
+                if vec_array_info(sty).is_some() {
+                    h.push_str(&format!("  {};\n", cpp_field_decl(sname, sty, &[])));
+                    ctor_body.push(format!("std::memset({}, 0, sizeof({}));", sname, sname));
                 } else {
-                    field_inits.push(format!("{}(0)", sname));
+                    let ty = cpp_internal_type(sty);
+                    h.push_str(&format!("  {} {};\n", ty, sname));
+                    if matches!(sty, TypeExpr::Named(_)) {
+                        field_inits.push(format!("{}()", sname));
+                    } else {
+                        field_inits.push(format!("{}(0)", sname));
+                    }
                 }
             }
-            if field_inits.is_empty() {
+            if field_inits.is_empty() && ctor_body.is_empty() {
                 h.push_str(&format!("  {}() {{}}\n", b.name.name));
-            } else {
+            } else if field_inits.is_empty() {
+                h.push_str(&format!("  {}() {{ {} }}\n", b.name.name, ctor_body.join(" ")));
+            } else if ctor_body.is_empty() {
                 h.push_str(&format!("  {}() : {} {{}}\n", b.name.name, field_inits.join(", ")));
+            } else {
+                h.push_str(&format!("  {}() : {} {{ {} }}\n", b.name.name, field_inits.join(", "), ctor_body.join(" ")));
             }
             h.push_str("};\n\n");
         }

--- a/tests/axi_dma_tlm/TlmMm2sBurstVecBfm.arch
+++ b/tests/axi_dma_tlm/TlmMm2sBurstVecBfm.arch
@@ -1,0 +1,163 @@
+//! ---
+//! spec_md: doc/axi_dma_case_study.md
+//! tags: [dma, axi4, mm2s, tlm_method, rhs_fork, target_bfm, burst_vec]
+//! refs:
+//!   - "tests/axi_dma_tlm/TlmMm2sBurstVec.arch"
+//! ---
+//!
+//! AXI-DMA-flavored TLM integration smoke example with an ARCH target-side BFM
+//! that returns a fixed-size Vec payload. This is the transaction-level version
+//! of `TlmMm2sBurstVec`: HARC drives only scenario inputs while ARCH TLM handles
+//! both initiator and responder behavior.
+
+/// Memory read contract using the supported bounded-burst payload convention.
+///
+/// The method returns the maximum static beat vector and carries runtime `len`
+/// as an argument. The tagged out-of-order mode lets the BFM return request 1
+/// before request 0.
+bus DmaMemBurstReadVecBfm
+  tlm_method read_burst(addr: UInt<32>, len: UInt<3>) -> Vec<UInt<32>, 4>: out_of_order tags 2;
+end bus DmaMemBurstReadVecBfm
+
+use DmaMemBurstReadVecBfm;
+
+/// MM2S initiator that issues two outstanding Vec-returning burst-like reads.
+module TlmMm2sBurstVecBfmDut
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+
+  port base_addr: in UInt<32>;
+  port len0_i: in UInt<3>;
+  port len1_i: in UInt<3>;
+  port mem: initiator DmaMemBurstReadVecBfm;
+
+  port data0_0: out UInt<32>;
+  port data0_1: out UInt<32>;
+  port data0_2: out UInt<32>;
+  port data0_3: out UInt<32>;
+  port data1_0: out UInt<32>;
+  port data1_1: out UInt<32>;
+  port data1_2: out UInt<32>;
+  port data1_3: out UInt<32>;
+
+  reg burst0_r: Vec<UInt<32>, 4> reset rst => 0;
+  reg burst1_r: Vec<UInt<32>, 4> reset rst => 0;
+
+  comb
+    data0_0 = burst0_r[0];
+    data0_1 = burst0_r[1];
+    data0_2 = burst0_r[2];
+    data0_3 = burst0_r[3];
+    data1_0 = burst1_r[0];
+    data1_1 = burst1_r[1];
+    data1_2 = burst1_r[2];
+    data1_3 = burst1_r[3];
+  end comb
+
+  thread issue_bursts on clk rising, rst high
+    burst0_r <= fork mem.read_burst(base_addr, len0_i);
+    wait 1 cycle;
+    burst1_r <= fork mem.read_burst((base_addr + 32'd16).trunc<32>(), len1_i);
+    join all;
+  end thread issue_bursts
+end module TlmMm2sBurstVecBfmDut
+
+/// Synthesizable target-side TLM BFM returning Vec payloads.
+///
+/// The BFM captures request arguments before the artificial latency waits so
+/// response expressions are ordinary registered hardware values.
+module TlmMm2sBurstVecBfmTarget
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port s: target DmaMemBurstReadVecBfm;
+
+  port req_count_o: out UInt<4>;
+  port req0_len_o: out UInt<3>;
+  port req1_len_o: out UInt<3>;
+
+  reg req_count: UInt<4> reset rst => 0;
+  reg req0_len: UInt<3> reset rst => 0;
+  reg req1_len: UInt<3> reset rst => 0;
+  reg rsp0: Vec<UInt<32>, 4> reset rst => 0;
+  reg rsp1: Vec<UInt<32>, 4> reset rst => 0;
+
+  comb
+    req_count_o = req_count;
+    req0_len_o = req0_len;
+    req1_len_o = req1_len;
+  end comb
+
+  thread s.read_burst[0](addr, len) on clk rising, rst high
+    if req_count < 4'd2
+      req_count <= req_count +% 4'd1;
+    end if
+    req0_len <= len;
+    rsp0[0] <= 32'hB000_0000 | addr;
+    rsp0[1] <= (32'hB000_0000 | addr) +% 32'd1;
+    rsp0[2] <= (32'hB000_0000 | addr) +% 32'd2;
+    rsp0[3] <= (32'hB000_0000 | addr) +% 32'd3;
+    wait 3 cycle;
+    return rsp0;
+  end thread s.read_burst
+
+  thread s.read_burst[1](addr, len) on clk rising, rst high
+    if req_count < 4'd2
+      req_count <= req_count +% 4'd1;
+    end if
+    req1_len <= len;
+    rsp1[0] <= 32'hB100_0000 | addr;
+    rsp1[1] <= (32'hB100_0000 | addr) +% 32'd1;
+    rsp1[2] <= (32'hB100_0000 | addr) +% 32'd2;
+    rsp1[3] <= (32'hB100_0000 | addr) +% 32'd3;
+    wait 1 cycle;
+    return rsp1;
+  end thread s.read_burst
+end module TlmMm2sBurstVecBfmTarget
+
+/// HARC-facing Vec-returning integration top.
+module TlmMm2sBurstVecBfmTop
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+
+  port base_addr: in UInt<32>;
+  port len0_i: in UInt<3>;
+  port len1_i: in UInt<3>;
+
+  port data0_0: out UInt<32>;
+  port data0_1: out UInt<32>;
+  port data0_2: out UInt<32>;
+  port data0_3: out UInt<32>;
+  port data1_0: out UInt<32>;
+  port data1_1: out UInt<32>;
+  port data1_2: out UInt<32>;
+  port data1_3: out UInt<32>;
+  port req_count_o: out UInt<4>;
+  port req0_len_o: out UInt<3>;
+  port req1_len_o: out UInt<3>;
+
+  inst dut_i: TlmMm2sBurstVecBfmDut
+    clk <- clk;
+    rst <- rst;
+    base_addr <- base_addr;
+    len0_i <- len0_i;
+    len1_i <- len1_i;
+    data0_0 -> data0_0;
+    data0_1 -> data0_1;
+    data0_2 -> data0_2;
+    data0_3 -> data0_3;
+    data1_0 -> data1_0;
+    data1_1 -> data1_1;
+    data1_2 -> data1_2;
+    data1_3 -> data1_3;
+  end inst dut_i
+
+  inst bfm_i: TlmMm2sBurstVecBfmTarget
+    clk <- clk;
+    rst <- rst;
+    req_count_o -> req_count_o;
+    req0_len_o -> req0_len_o;
+    req1_len_o -> req1_len_o;
+  end inst bfm_i
+
+  connect dut_i.mem -> bfm_i.s;
+end module TlmMm2sBurstVecBfmTop

--- a/tests/axi_dma_tlm/TlmMm2sBurstVecBfm_test.harc
+++ b/tests/axi_dma_tlm/TlmMm2sBurstVecBfm_test.harc
@@ -1,0 +1,37 @@
+// HARC testbench for the ARCH-native TLM Vec BFM wrapper.
+
+testbench TlmMm2sBurstVecBfmTb
+    dut : TlmMm2sBurstVecBfmTop
+end testbench TlmMm2sBurstVecBfmTb
+
+impl TlmMm2sBurstVecBfmHarcTest for TlmMm2sBurstVecBfmTb
+    run
+        log(info, "TlmMm2sBurstVecBfm ARCH-BFM HARC test")
+
+        dut.rst = 1
+        dut.base_addr = 0x2000
+        dut.len0_i = 2
+        dut.len1_i = 4
+        wait 4 cycles
+        dut.rst = 0
+        wait 16 cycles
+
+        let req0_addr : uint<32> = 0x2000
+        let req1_addr : uint<32> = 0x2010
+        let exp0 = 0xB0000000 | req0_addr
+        let exp1 = 0xB1000000 | req1_addr
+
+        assert dut.req_count_o == 2
+            else fail("expected 2 BFM requests, observed ${dut.req_count_o}")
+        assert dut.req0_len_o == 2
+            else fail("req0 len=${dut.req0_len_o}, expected 2")
+        assert dut.req1_len_o == 4
+            else fail("req1 len=${dut.req1_len_o}, expected 4")
+        assert dut.data0_0 == exp0 + 0 && dut.data0_1 == exp0 + 1 && dut.data0_2 == exp0 + 2 && dut.data0_3 == exp0 + 3
+            else fail("data0 mismatch: got 0x${dut.data0_0:08x},0x${dut.data0_1:08x},0x${dut.data0_2:08x},0x${dut.data0_3:08x}")
+        assert dut.data1_0 == exp1 + 0 && dut.data1_1 == exp1 + 1 && dut.data1_2 == exp1 + 2 && dut.data1_3 == exp1 + 3
+            else fail("data1 mismatch: got 0x${dut.data1_0:08x},0x${dut.data1_1:08x},0x${dut.data1_2:08x},0x${dut.data1_3:08x}")
+
+        log(info, "PASS: ARCH Vec TLM BFM len0=${dut.req0_len_o} len1=${dut.req1_len_o} data0[0]=0x${dut.data0_0:08x} data1[3]=0x${dut.data1_3:08x}")
+    end run
+end impl TlmMm2sBurstVecBfmHarcTest

--- a/tests/axi_dma_tlm/tb_tlm_mm2s_burst_vec_bfm.cpp
+++ b/tests/axi_dma_tlm/tb_tlm_mm2s_burst_vec_bfm.cpp
@@ -1,0 +1,45 @@
+#include "VTlmMm2sBurstVecBfmTop.h"
+
+#include <cstdint>
+#include <cstdio>
+
+static VTlmMm2sBurstVecBfmTop dut;
+
+static void tick() {
+    dut.clk = 0;
+    dut.eval();
+    dut.clk = 1;
+    dut.eval();
+}
+
+int main() {
+    dut.rst = 1;
+    dut.base_addr = 0x2000;
+    dut.len0_i = 2;
+    dut.len1_i = 4;
+    for (int i = 0; i < 4; ++i) {
+        tick();
+    }
+
+    dut.rst = 0;
+    for (int i = 0; i < 16; ++i) {
+        tick();
+    }
+
+    const uint32_t exp0 = 0xB0002000u;
+    const uint32_t exp1 = 0xB1002010u;
+    if (dut.req_count_o != 2 || dut.req0_len_o != 2 || dut.req1_len_o != 4 ||
+        dut.data0_0 != exp0 + 0 || dut.data0_1 != exp0 + 1 ||
+        dut.data0_2 != exp0 + 2 || dut.data0_3 != exp0 + 3 ||
+        dut.data1_0 != exp1 + 0 || dut.data1_1 != exp1 + 1 ||
+        dut.data1_2 != exp1 + 2 || dut.data1_3 != exp1 + 3) {
+        std::printf("FAIL Vec BFM: req_count=%u len0=%u len1=%u data0_0=0x%08x data1_3=0x%08x\n",
+                    dut.req_count_o, dut.req0_len_o, dut.req1_len_o,
+                    dut.data0_0, dut.data1_3);
+        return 1;
+    }
+
+    std::printf("PASS TlmMm2sBurstVecBfm len0=%u len1=%u data0[0]=0x%08x data1[3]=0x%08x\n",
+                dut.req0_len_o, dut.req1_len_o, dut.data0_0, dut.data1_3);
+    return 0;
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -7607,6 +7607,134 @@ fn test_axi_dma_tlm_burst_vec_example_compiles() {
 }
 
 #[test]
+fn test_axi_dma_tlm_burst_vec_bfm_connect_compiles() {
+    let source = include_str!("axi_dma_tlm/TlmMm2sBurstVecBfm.arch");
+    let sv = compile_to_sv(source);
+    assert!(sv.contains("module TlmMm2sBurstVecBfmTop"));
+    assert!(
+        sv.contains("_tlm_conn_dut_i_mem_bfm_i_s_read_burst_rsp_data"),
+        "SV connect should materialize Vec response bus wire:\n{sv}"
+    );
+
+    let sim = compile_to_sim_h(source, false);
+    assert!(
+        sim.contains("uint32_t read_burst_rsp_data[4];"),
+        "sim bus-as-wire struct should keep Vec payload fields as arrays:\n{sim}"
+    );
+    assert!(
+        sim.contains("uint32_t mem_read_burst_rsp_data_0;")
+            && sim.contains("uint32_t s_read_burst_rsp_data_0;"),
+        "sim APIs should expose flattened Vec TLM ports on both initiator and target modules:\n{sim}"
+    );
+}
+
+#[test]
+fn test_axi_dma_tlm_burst_vec_bfm_arch_sim_behavior() {
+    let td = tempfile::tempdir().expect("tempdir");
+    let arch_bin = env!("CARGO_BIN_EXE_arch");
+    let out = std::process::Command::new(arch_bin)
+        .arg("sim")
+        .arg("tests/axi_dma_tlm/TlmMm2sBurstVecBfm.arch")
+        .arg("--tb")
+        .arg("tests/axi_dma_tlm/tb_tlm_mm2s_burst_vec_bfm.cpp")
+        .arg("--outdir")
+        .arg(td.path())
+        .output()
+        .expect("run arch sim for Vec TLM BFM");
+    assert!(
+        out.status.success(),
+        "Vec TLM BFM arch sim should pass\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&out.stdout).contains("PASS TlmMm2sBurstVecBfm"),
+        "expected PASS marker in stdout:\n{}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+}
+
+#[test]
+fn test_axi_dma_tlm_burst_vec_bfm_thread_sim_both() {
+    run_tlm_thread_sim_both(
+        "tests/axi_dma_tlm/TlmMm2sBurstVecBfm.arch",
+        "tests/axi_dma_tlm/tb_tlm_mm2s_burst_vec_bfm.cpp",
+        "PASS TlmMm2sBurstVecBfm",
+    );
+}
+
+#[test]
+fn test_axi_dma_tlm_burst_vec_bfm_verilator_behavior() {
+    if std::process::Command::new("verilator")
+        .arg("--version")
+        .output()
+        .is_err()
+    {
+        eprintln!("skipping Verilator Vec TLM BFM smoke: verilator not found");
+        return;
+    }
+
+    let td = tempfile::tempdir().expect("tempdir");
+    let sv_out = td.path().join("TlmMm2sBurstVecBfm.sv");
+    let obj_dir = td.path().join("obj_dir");
+    let arch_bin = env!("CARGO_BIN_EXE_arch");
+
+    let build = std::process::Command::new(arch_bin)
+        .arg("build")
+        .arg("tests/axi_dma_tlm/TlmMm2sBurstVecBfm.arch")
+        .arg("-o")
+        .arg(&sv_out)
+        .output()
+        .expect("build Vec TLM BFM SV");
+    assert!(
+        build.status.success(),
+        "arch build should pass\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&build.stdout),
+        String::from_utf8_lossy(&build.stderr)
+    );
+
+    let verilate = std::process::Command::new("verilator")
+        .arg("--cc")
+        .arg("--exe")
+        .arg("--build")
+        .arg("--sv")
+        .arg("--assert")
+        .arg("-Wno-fatal")
+        .arg("-Wno-WIDTH")
+        .arg("-Wno-DECLFILENAME")
+        .arg("--top-module")
+        .arg("TlmMm2sBurstVecBfmTop")
+        .arg("-Mdir")
+        .arg(&obj_dir)
+        .arg(&sv_out)
+        .arg("tests/axi_dma_tlm/tb_tlm_mm2s_burst_vec_bfm.cpp")
+        .output()
+        .expect("verilate Vec TLM BFM");
+    assert!(
+        verilate.status.success(),
+        "Verilator build should pass\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&verilate.stdout),
+        String::from_utf8_lossy(&verilate.stderr)
+    );
+
+    let exe = obj_dir.join("VTlmMm2sBurstVecBfmTop");
+    let run = std::process::Command::new(&exe)
+        .output()
+        .expect("run Verilator Vec TLM BFM");
+    assert!(
+        run.status.success(),
+        "Verilator sim should pass\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&run.stdout).contains("PASS TlmMm2sBurstVecBfm"),
+        "expected PASS marker in Verilator stdout:\n{}",
+        String::from_utf8_lossy(&run.stdout)
+    );
+}
+
+#[test]
 fn test_tlm_out_of_order_target_echoes_tag() {
     let source = "
         bus Mem


### PR DESCRIPTION
## Summary
- Fix sim codegen for Vec-valued TLM payloads carried through ARCH `connect` bus wires.
- Preserve Vec bus fields as C++ arrays in bus-as-wire structs and copy non-ident Vec connection expressions element-by-element.
- Add an AXI-DMA-style Vec-return ARCH TLM BFM example with HARC and C++ smoke tests.

## Root Cause
Vec-return TLM ports were flattened correctly at module boundaries, but the intermediate bus wire used by `connect` treated the response payload as a scalar field. Generated C++ then tried to assign `mem_read_burst_rsp_data` / `s_read_burst_rsp_data` as whole scalar members even though the actual module APIs expose `_0.._3` flattened Vec lanes.

## Validation
- `cargo check`
- `cargo test test_axi_dma_tlm_burst_vec_bfm -- --nocapture`
- `cargo test tlm -- --nocapture`
- HARC sim for `tests/axi_dma_tlm/TlmMm2sBurstVecBfm_test.harc`
- Verilator sim covered by `test_axi_dma_tlm_burst_vec_bfm_verilator_behavior`
