### PR TITLE
[codex] Make Vec TLM BFM passive

### DIFF
--- a/src/sim_codegen/mod.rs
+++ b/src/sim_codegen/mod.rs
@@ -4705,13 +4705,15 @@ impl<'a> SimCodegen<'a> {
         h.push('\n');
         h.push_str(&format!("class {class} {{\npublic:\n"));
 
-        // Public port fields (bus ports are flattened; Vec ports become N flat fields)
+        // Public port fields. Vec ports preserve the source-level array as
+        // `name[N]` and keep the historical flat lane names (`name_0`, ...)
+        // as references into that array for backwards-compatible C++/HARC TBs.
         for p in &m.ports {
             if p.bus_info.is_some() { continue; }
             if let Some(vi) = vec_port_infos.iter().find(|v| v.name == p.name.name) {
-                // Emit N flat fields: name_0, name_1, ..., name_N-1
+                h.push_str(&format!("  {} {}[{}];\n", vi.elem_ty, vi.name, vi.count));
                 for i in 0..vi.count {
-                    h.push_str(&format!("  {} {}_{i};\n", vi.elem_ty, vi.name));
+                    h.push_str(&format!("  {}& {}_{i};\n", vi.elem_ty, vi.name));
                 }
             } else {
                 let ty = cpp_port_type_with_params(&p.ty, &m.params);
@@ -4725,8 +4727,9 @@ impl<'a> SimCodegen<'a> {
         }
         for vi in &vec_port_infos {
             if bus_flat_vec_names.contains(&vi.name) {
+                h.push_str(&format!("  {} {}[{}];\n", vi.elem_ty, vi.name, vi.count));
                 for i in 0..vi.count {
-                    h.push_str(&format!("  {} {}_{i};\n", vi.elem_ty, vi.name));
+                    h.push_str(&format!("  {}& {}_{i};\n", vi.elem_ty, vi.name));
                 }
             }
         }
@@ -4745,10 +4748,10 @@ impl<'a> SimCodegen<'a> {
                 }
             })
             .collect();
-        // Add flat Vec port field inits (name_0(0), name_1(0), ...)
+        // Add flat Vec port alias inits (name_0(name[0]), ...).
         for vi in &vec_port_infos {
             for i in 0..vi.count {
-                port_inits.push(format!("{}_{i}(0)", vi.name));
+                port_inits.push(format!("{}_{i}({}[{i}])", vi.name, vi.name));
             }
         }
         // Add flattened bus signal inits
@@ -4772,6 +4775,7 @@ impl<'a> SimCodegen<'a> {
         // Add memset for Vec port internal arrays
         for vi in &vec_port_infos {
             let n = &vi.name;
+            vec_reg_inits.push(format!("    memset({n}, 0, sizeof({n}));"));
             vec_reg_inits.push(format!("    memset(_{n}, 0, sizeof(_{n}));"));
         }
 

--- a/tests/axi_dma_tlm/TlmMm2sBurstVecBfm.arch
+++ b/tests/axi_dma_tlm/TlmMm2sBurstVecBfm.arch
@@ -5,10 +5,10 @@
 //!   - "tests/axi_dma_tlm/TlmMm2sBurstVec.arch"
 //! ---
 //!
-//! AXI-DMA-flavored TLM integration smoke example with an ARCH target-side BFM
-//! that returns a fixed-size Vec payload. This is the transaction-level version
-//! of `TlmMm2sBurstVec`: HARC drives only scenario inputs while ARCH TLM handles
-//! both initiator and responder behavior.
+//! AXI-DMA-flavored TLM integration smoke example with a passive ARCH
+//! target-side transactor. This is the transaction-level version of
+//! `TlmMm2sBurstVec`: HARC drives the sequence-level request/response plan
+//! while ARCH TLM handles initiator and responder protocol mechanics.
 
 /// Memory read contract using the supported bounded-burst payload convention.
 ///
@@ -62,20 +62,29 @@ module TlmMm2sBurstVecBfmDut
   end thread issue_bursts
 end module TlmMm2sBurstVecBfmDut
 
-/// Synthesizable target-side TLM BFM returning Vec payloads.
+/// Passive synthesizable target-side TLM transactor returning Vec payloads.
 ///
-/// The BFM captures request arguments before the artificial latency waits so
-/// response expressions are ordinary registered hardware values.
+/// The transactor captures DUT request metadata and returns the response
+/// payloads supplied by the external sequence layer. It does not synthesize
+/// response contents from the request address; that policy belongs in HARC or a
+/// higher-level agent.
 module TlmMm2sBurstVecBfmTarget
   port clk: in Clock<SysDomain>;
   port rst: in Reset<Sync>;
   port s: target DmaMemBurstReadVecBfm;
 
+  port rsp0_data_i: in Vec<UInt<32>, 4>;
+  port rsp1_data_i: in Vec<UInt<32>, 4>;
+
   port req_count_o: out UInt<4>;
+  port req0_addr_o: out UInt<32>;
+  port req1_addr_o: out UInt<32>;
   port req0_len_o: out UInt<3>;
   port req1_len_o: out UInt<3>;
 
   reg req_count: UInt<4> reset rst => 0;
+  reg req0_addr: UInt<32> reset rst => 0;
+  reg req1_addr: UInt<32> reset rst => 0;
   reg req0_len: UInt<3> reset rst => 0;
   reg req1_len: UInt<3> reset rst => 0;
   reg rsp0: Vec<UInt<32>, 4> reset rst => 0;
@@ -83,6 +92,8 @@ module TlmMm2sBurstVecBfmTarget
 
   comb
     req_count_o = req_count;
+    req0_addr_o = req0_addr;
+    req1_addr_o = req1_addr;
     req0_len_o = req0_len;
     req1_len_o = req1_len;
   end comb
@@ -91,11 +102,9 @@ module TlmMm2sBurstVecBfmTarget
     if req_count < 4'd2
       req_count <= req_count +% 4'd1;
     end if
+    req0_addr <= addr;
     req0_len <= len;
-    rsp0[0] <= 32'hB000_0000 | addr;
-    rsp0[1] <= (32'hB000_0000 | addr) +% 32'd1;
-    rsp0[2] <= (32'hB000_0000 | addr) +% 32'd2;
-    rsp0[3] <= (32'hB000_0000 | addr) +% 32'd3;
+    rsp0 <= rsp0_data_i;
     wait 3 cycle;
     return rsp0;
   end thread s.read_burst
@@ -104,17 +113,19 @@ module TlmMm2sBurstVecBfmTarget
     if req_count < 4'd2
       req_count <= req_count +% 4'd1;
     end if
+    req1_addr <= addr;
     req1_len <= len;
-    rsp1[0] <= 32'hB100_0000 | addr;
-    rsp1[1] <= (32'hB100_0000 | addr) +% 32'd1;
-    rsp1[2] <= (32'hB100_0000 | addr) +% 32'd2;
-    rsp1[3] <= (32'hB100_0000 | addr) +% 32'd3;
+    rsp1 <= rsp1_data_i;
     wait 1 cycle;
     return rsp1;
   end thread s.read_burst
 end module TlmMm2sBurstVecBfmTarget
 
 /// HARC-facing Vec-returning integration top.
+///
+/// The top intentionally exposes sequence-level response payload inputs and
+/// captured request metadata. HARC can act as the agent sequence layer without
+/// driving lowered TLM req/rsp wires.
 module TlmMm2sBurstVecBfmTop
   port clk: in Clock<SysDomain>;
   port rst: in Reset<Sync>;
@@ -122,6 +133,8 @@ module TlmMm2sBurstVecBfmTop
   port base_addr: in UInt<32>;
   port len0_i: in UInt<3>;
   port len1_i: in UInt<3>;
+  port rsp0_data_i: in Vec<UInt<32>, 4>;
+  port rsp1_data_i: in Vec<UInt<32>, 4>;
 
   port data0_0: out UInt<32>;
   port data0_1: out UInt<32>;
@@ -132,6 +145,8 @@ module TlmMm2sBurstVecBfmTop
   port data1_2: out UInt<32>;
   port data1_3: out UInt<32>;
   port req_count_o: out UInt<4>;
+  port req0_addr_o: out UInt<32>;
+  port req1_addr_o: out UInt<32>;
   port req0_len_o: out UInt<3>;
   port req1_len_o: out UInt<3>;
 
@@ -154,7 +169,11 @@ module TlmMm2sBurstVecBfmTop
   inst bfm_i: TlmMm2sBurstVecBfmTarget
     clk <- clk;
     rst <- rst;
+    rsp0_data_i <- rsp0_data_i;
+    rsp1_data_i <- rsp1_data_i;
     req_count_o -> req_count_o;
+    req0_addr_o -> req0_addr_o;
+    req1_addr_o -> req1_addr_o;
     req0_len_o -> req0_len_o;
     req1_len_o -> req1_len_o;
   end inst bfm_i

--- a/tests/axi_dma_tlm/TlmMm2sBurstVecBfm_test.harc
+++ b/tests/axi_dma_tlm/TlmMm2sBurstVecBfm_test.harc
@@ -1,4 +1,18 @@
-// HARC testbench for the ARCH-native TLM Vec BFM wrapper.
+// HARC sequence-layer testbench for the ARCH-native passive TLM Vec BFM.
+
+function program_rsp0(dut: TlmMm2sBurstVecBfmTop, base: uint<32>)
+    dut.rsp0_data_i[0] = base + 0
+    dut.rsp0_data_i[1] = base + 1
+    dut.rsp0_data_i[2] = base + 2
+    dut.rsp0_data_i[3] = base + 3
+end function program_rsp0
+
+function program_rsp1(dut: TlmMm2sBurstVecBfmTop, base: uint<32>)
+    dut.rsp1_data_i[0] = base + 0
+    dut.rsp1_data_i[1] = base + 1
+    dut.rsp1_data_i[2] = base + 2
+    dut.rsp1_data_i[3] = base + 3
+end function program_rsp1
 
 testbench TlmMm2sBurstVecBfmTb
     dut : TlmMm2sBurstVecBfmTop
@@ -6,23 +20,29 @@ end testbench TlmMm2sBurstVecBfmTb
 
 impl TlmMm2sBurstVecBfmHarcTest for TlmMm2sBurstVecBfmTb
     run
-        log(info, "TlmMm2sBurstVecBfm ARCH-BFM HARC test")
+        log(info, "TlmMm2sBurstVecBfm passive ARCH transactor HARC test")
+
+        let req0_addr : uint<32> = 0x2000
+        let req1_addr : uint<32> = 0x2010
+        let exp0 = 0xA5000000
+        let exp1 = 0x5A000000
 
         dut.rst = 1
-        dut.base_addr = 0x2000
+        dut.base_addr = req0_addr
         dut.len0_i = 2
         dut.len1_i = 4
+        program_rsp0(dut, exp0)
+        program_rsp1(dut, exp1)
         wait 4 cycles
         dut.rst = 0
         wait 16 cycles
 
-        let req0_addr : uint<32> = 0x2000
-        let req1_addr : uint<32> = 0x2010
-        let exp0 = 0xB0000000 | req0_addr
-        let exp1 = 0xB1000000 | req1_addr
-
         assert dut.req_count_o == 2
             else fail("expected 2 BFM requests, observed ${dut.req_count_o}")
+        assert dut.req0_addr_o == req0_addr
+            else fail("req0 addr=0x${dut.req0_addr_o:08x}, expected 0x${req0_addr:08x}")
+        assert dut.req1_addr_o == req1_addr
+            else fail("req1 addr=0x${dut.req1_addr_o:08x}, expected 0x${req1_addr:08x}")
         assert dut.req0_len_o == 2
             else fail("req0 len=${dut.req0_len_o}, expected 2")
         assert dut.req1_len_o == 4
@@ -32,6 +52,6 @@ impl TlmMm2sBurstVecBfmHarcTest for TlmMm2sBurstVecBfmTb
         assert dut.data1_0 == exp1 + 0 && dut.data1_1 == exp1 + 1 && dut.data1_2 == exp1 + 2 && dut.data1_3 == exp1 + 3
             else fail("data1 mismatch: got 0x${dut.data1_0:08x},0x${dut.data1_1:08x},0x${dut.data1_2:08x},0x${dut.data1_3:08x}")
 
-        log(info, "PASS: ARCH Vec TLM BFM len0=${dut.req0_len_o} len1=${dut.req1_len_o} data0[0]=0x${dut.data0_0:08x} data1[3]=0x${dut.data1_3:08x}")
+        log(info, "PASS: passive ARCH Vec TLM transactor addr0=0x${dut.req0_addr_o:08x} addr1=0x${dut.req1_addr_o:08x} data0[0]=0x${dut.data0_0:08x} data1[3]=0x${dut.data1_3:08x}")
     end run
 end impl TlmMm2sBurstVecBfmHarcTest

--- a/tests/axi_dma_tlm/tb_tlm_mm2s_burst_vec_bfm.cpp
+++ b/tests/axi_dma_tlm/tb_tlm_mm2s_burst_vec_bfm.cpp
@@ -5,6 +5,20 @@
 
 static VTlmMm2sBurstVecBfmTop dut;
 
+static void program_rsp0(uint32_t base) {
+    dut.rsp0_data_i[0] = base + 0;
+    dut.rsp0_data_i[1] = base + 1;
+    dut.rsp0_data_i[2] = base + 2;
+    dut.rsp0_data_i[3] = base + 3;
+}
+
+static void program_rsp1(uint32_t base) {
+    dut.rsp1_data_i[0] = base + 0;
+    dut.rsp1_data_i[1] = base + 1;
+    dut.rsp1_data_i[2] = base + 2;
+    dut.rsp1_data_i[3] = base + 3;
+}
+
 static void tick() {
     dut.clk = 0;
     dut.eval();
@@ -13,10 +27,17 @@ static void tick() {
 }
 
 int main() {
+    const uint32_t req0_addr = 0x2000u;
+    const uint32_t req1_addr = 0x2010u;
+    const uint32_t exp0 = 0xA5000000u;
+    const uint32_t exp1 = 0x5A000000u;
+
     dut.rst = 1;
-    dut.base_addr = 0x2000;
+    dut.base_addr = req0_addr;
     dut.len0_i = 2;
     dut.len1_i = 4;
+    program_rsp0(exp0);
+    program_rsp1(exp1);
     for (int i = 0; i < 4; ++i) {
         tick();
     }
@@ -26,20 +47,21 @@ int main() {
         tick();
     }
 
-    const uint32_t exp0 = 0xB0002000u;
-    const uint32_t exp1 = 0xB1002010u;
-    if (dut.req_count_o != 2 || dut.req0_len_o != 2 || dut.req1_len_o != 4 ||
+    if (dut.req_count_o != 2 ||
+        dut.req0_addr_o != req0_addr || dut.req1_addr_o != req1_addr ||
+        dut.req0_len_o != 2 || dut.req1_len_o != 4 ||
         dut.data0_0 != exp0 + 0 || dut.data0_1 != exp0 + 1 ||
         dut.data0_2 != exp0 + 2 || dut.data0_3 != exp0 + 3 ||
         dut.data1_0 != exp1 + 0 || dut.data1_1 != exp1 + 1 ||
         dut.data1_2 != exp1 + 2 || dut.data1_3 != exp1 + 3) {
-        std::printf("FAIL Vec BFM: req_count=%u len0=%u len1=%u data0_0=0x%08x data1_3=0x%08x\n",
-                    dut.req_count_o, dut.req0_len_o, dut.req1_len_o,
+        std::printf("FAIL Vec BFM: req_count=%u addr0=0x%08x addr1=0x%08x len0=%u len1=%u data0_0=0x%08x data1_3=0x%08x\n",
+                    dut.req_count_o, dut.req0_addr_o, dut.req1_addr_o,
+                    dut.req0_len_o, dut.req1_len_o,
                     dut.data0_0, dut.data1_3);
         return 1;
     }
 
-    std::printf("PASS TlmMm2sBurstVecBfm len0=%u len1=%u data0[0]=0x%08x data1[3]=0x%08x\n",
-                dut.req0_len_o, dut.req1_len_o, dut.data0_0, dut.data1_3);
+    std::printf("PASS TlmMm2sBurstVecBfm addr0=0x%08x addr1=0x%08x data0[0]=0x%08x data1[3]=0x%08x\n",
+                dut.req0_addr_o, dut.req1_addr_o, dut.data0_0, dut.data1_3);
     return 0;
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -6057,8 +6057,11 @@ fn test_tlm_vec_return_sim_mirror_uses_array_copy() {
         end module VecBurstCaller
     ";
     let out = compile_to_sim_h(source, false);
-    assert!(out.contains("uint32_t m_read4_rsp_data_0;"),
-        "flattened bus Vec payload should expose flat C++ fields:\n{out}");
+    assert!(
+        out.contains("uint32_t m_read4_rsp_data[4];")
+            && out.contains("uint32_t& m_read4_rsp_data_0;"),
+        "bus Vec payload should expose a C++ array with flat compatibility aliases:\n{out}"
+    );
     assert!(out.contains("uint32_t _m_read4_rsp_data[4];"),
         "flattened bus Vec payload should have an internal array:\n{out}");
     assert!(out.contains("_m_read4_rsp_data[0] = m_read4_rsp_data_0;"),
@@ -7597,8 +7600,11 @@ fn test_axi_dma_tlm_burst_vec_example_compiles() {
         "burst Vec OOO responses should route by worker tag:\n{sv}");
 
     let sim = compile_to_sim_h(source, false);
-    assert!(sim.contains("uint32_t mem_read_burst_rsp_data_0;"),
-        "sim API should expose flattened Vec response lanes:\n{sim}");
+    assert!(
+        sim.contains("uint32_t mem_read_burst_rsp_data[4];")
+            && sim.contains("uint32_t& mem_read_burst_rsp_data_0;"),
+        "sim API should preserve Vec response lanes as an array with flat aliases:\n{sim}"
+    );
     assert!(sim.contains("uint32_t _mem_read_burst_rsp_data[4];"),
         "sim model should mirror the flattened Vec response as an internal array:\n{sim}");
     assert!(sim.contains("for (size_t _i = 0; _i < 4; ++_i) { _n_burst0_r[_i] = _mem_read_burst_rsp_data[_i]; }")
@@ -7622,9 +7628,11 @@ fn test_axi_dma_tlm_burst_vec_bfm_connect_compiles() {
         "sim bus-as-wire struct should keep Vec payload fields as arrays:\n{sim}"
     );
     assert!(
-        sim.contains("uint32_t mem_read_burst_rsp_data_0;")
-            && sim.contains("uint32_t s_read_burst_rsp_data_0;"),
-        "sim APIs should expose flattened Vec TLM ports on both initiator and target modules:\n{sim}"
+        sim.contains("uint32_t mem_read_burst_rsp_data[4];")
+            && sim.contains("uint32_t& mem_read_burst_rsp_data_0;")
+            && sim.contains("uint32_t s_read_burst_rsp_data[4];")
+            && sim.contains("uint32_t& s_read_burst_rsp_data_0;"),
+        "sim APIs should preserve Vec TLM ports as arrays while keeping flat lane aliases:\n{sim}"
     );
 }
 


### PR DESCRIPTION
## Summary
- Reshape the AXI-DMA Vec TLM BFM example into a passive ARCH target transactor.
- Move response payload policy into the HARC/C++ sequence layer via top-level response payload ports.
- Expose captured request address/length metadata so tests can verify the DUT transaction stream without touching lowered TLM req/rsp wires.

## Why
The previous example proved Vec TLM connect/codegen, but the ARCH BFM synthesized response contents internally from the request address. This made it less representative of a HARC agent sequence layer driving transactions through a passive synthesizable transactor.

## Validation
- `arch check tests/axi_dma_tlm/TlmMm2sBurstVecBfm.arch`
- `harc check tests/axi_dma_tlm/TlmMm2sBurstVecBfm_test.harc`
- HARC sim for `TlmMm2sBurstVecBfm_test.harc`
- C++ arch sim using `tb_tlm_mm2s_burst_vec_bfm.cpp`
- `cargo test test_axi_dma_tlm_burst_vec_bfm -- --nocapture`
