### PR TITLE
Add Vec<BusName, N> ports + wires; NIC-400 example uses it

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -187,6 +187,11 @@ pub struct BusPortInfo {
     pub bus_name: Ident,
     pub perspective: BusPerspective,
     pub params: Vec<ParamAssign>,
+    /// `port chans: initiator Vec<BusName, N>;` — array of N bus copies,
+    /// flattened in codegen to `chans_0_<sig>`, `chans_1_<sig>`, ...
+    /// Accessed via `chans[i].sig` (literal integer i). `None` = scalar bus
+    /// port (current default). MVP only accepts integer literals for N.
+    pub count: Option<u32>,
 }
 
 #[derive(Debug, Clone)]

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -99,7 +99,18 @@ pub struct Codegen<'a> {
     /// Maps call-site span.start → overload index (for overloaded functions only).
     overload_map: std::collections::HashMap<usize, usize>,
     /// Bus port names in the current module → bus name (for FieldAccess rewriting).
+    /// For Vec-of-bus ports, entries are keyed by the indexed names
+    /// (`<port>_0`, `<port>_1`, ...); the parent port name itself is in
+    /// `vec_of_bus_port_count`.
     bus_ports: std::collections::HashMap<String, String>,
+    /// Map of Vec-of-bus port name → element count N. Used by
+    /// `emit_for_loop_sv` to statically unroll loops whose body accesses
+    /// the port via a non-literal index. Populated per-module from
+    /// `BusPortInfo.count`.
+    vec_of_bus_port_count: std::collections::HashMap<String, u32>,
+    /// Same as `vec_of_bus_port_count` but for wires declared as
+    /// `wire w: Vec<BusName, N>;`. Used to detect the unroll opportunity.
+    vec_of_bus_wire_count: std::collections::HashMap<String, u32>,
     /// Bus-typed wire names in the current module → bus name. Bus wires are
     /// flattened into individual SV signals `<wire>_<field>` at emission
     /// time (no SV interfaces or structs are generated for buses), so
@@ -115,6 +126,13 @@ pub struct Codegen<'a> {
     /// `index` to per-iteration expressions (e.g. `vec[3]`, `2'd3`).
     /// Checked first in `emit_expr_str`'s Ident branch; empty otherwise.
     ident_subst: std::collections::HashMap<String, String>,
+    /// Loop-variable → integer-value substitutions, pushed during static
+    /// unrolling of `for` loops over Vec-of-bus indexed access. The
+    /// bracket-dot resolver for `Index(Ident(arr), Ident(loopvar)).field`
+    /// consults this when `loopvar` is in the map and treats the access
+    /// like a literal-index one (so `chans[i].v` resolves to
+    /// `chans_<value>_v`). Empty outside an unrolled body.
+    loop_var_subst: std::collections::HashMap<String, u32>,
     /// Map of Vec-typed signal name → element count N.
     /// Populated per-module at emit time so Vec method lowerings
     /// (`any`/`all`/`count`/etc.) can unroll over N iterations.
@@ -178,10 +196,13 @@ impl<'a> Codegen<'a> {
             pending_functions: Vec::new(),
             overload_map,
             bus_ports: std::collections::HashMap::new(),
+            vec_of_bus_port_count: std::collections::HashMap::new(),
+            vec_of_bus_wire_count: std::collections::HashMap::new(),
             bus_wires: std::collections::HashMap::new(),
             reset_ports: std::collections::HashMap::new(),
             current_construct: String::new(),
             ident_subst: std::collections::HashMap::new(),
+            loop_var_subst: std::collections::HashMap::new(),
             vec_sizes: std::collections::HashMap::new(),
             pipe_regs: std::collections::HashMap::new(),
             vec_params: std::collections::HashMap::new(),
@@ -1195,8 +1216,32 @@ impl<'a> Codegen<'a> {
         self.line("");
     }
 
-    fn emit_for_loop_sv<S>(&mut self, f: &ForLoop<S>, mut emit_body_stmt: impl FnMut(&mut Self, &S)) {
+    fn emit_for_loop_sv(&mut self, f: &ForLoop<Stmt>, mut emit_body_stmt: impl FnMut(&mut Self, &Stmt)) {
         let var = &f.var.name;
+        // Static unrolling for Vec-of-bus indexed access: the SV signature
+        // exposes only the flattened `<port>_<i>_<sig>` names, with no
+        // SV-level array of buses. A behavioral `for` loop indexing the
+        // bus by the loop variable would emit `chans[i].sig`, which is
+        // not legal SV. Detect the case and inline the body N times
+        // with the loop variable bound to each literal index via
+        // `loop_var_subst`.
+        if let ForRange::Range(rs, re) = &f.range {
+            if let (Some(start_lit), Some(end_lit)) =
+                (Self::expr_to_u32(rs), Self::expr_to_u32(re))
+            {
+                let body_touches_vob = f.body.iter().any(|s| Self::stmt_indexes_vob_with_var(
+                    s, var, &self.vec_of_bus_port_count, &self.vec_of_bus_wire_count,
+                ));
+                if body_touches_vob {
+                    for i in start_lit..=end_lit {
+                        self.loop_var_subst.insert(var.clone(), i);
+                        for s in &f.body { emit_body_stmt(self, s); }
+                    }
+                    self.loop_var_subst.remove(var);
+                    return;
+                }
+            }
+        }
         match &f.range {
             ForRange::Range(rs, re) => {
                 let start = self.emit_expr_str(rs);
@@ -1219,6 +1264,82 @@ impl<'a> Codegen<'a> {
                     self.line("end");
                 }
             }
+        }
+    }
+
+    /// Compile-time reducer for `for-loop` bound expressions used by the
+    /// Vec-of-bus static-unroll path. Only handles bare integer literals
+    /// for now; param-aware bounds remain a follow-up.
+    fn expr_to_u32(e: &Expr) -> Option<u32> {
+        match &e.kind {
+            ExprKind::Literal(LitKind::Dec(n))
+            | ExprKind::Literal(LitKind::Hex(n))
+            | ExprKind::Literal(LitKind::Bin(n))
+            | ExprKind::Literal(LitKind::Sized(_, n)) => Some(*n as u32),
+            _ => None,
+        }
+    }
+
+    /// Does `stmt` contain any expression of the form
+    /// `Index(Ident(name), Ident(var))` where `name` is a known Vec-of-bus
+    /// port or wire? Used by `emit_for_loop_sv` to decide whether to
+    /// statically unroll the loop. Recurses into nested ifs/matches/fors
+    /// and into LHS-of-assign targets as well as RHS values.
+    fn stmt_indexes_vob_with_var(
+        stmt: &Stmt,
+        var: &str,
+        ports: &std::collections::HashMap<String, u32>,
+        wires: &std::collections::HashMap<String, u32>,
+    ) -> bool {
+        fn walk_expr(
+            e: &Expr,
+            var: &str,
+            ports: &std::collections::HashMap<String, u32>,
+            wires: &std::collections::HashMap<String, u32>,
+        ) -> bool {
+            if let ExprKind::Index(arr, idx) = &e.kind {
+                if let (ExprKind::Ident(arr_name), ExprKind::Ident(idx_name)) = (&arr.kind, &idx.kind) {
+                    if idx_name == var && (ports.contains_key(arr_name) || wires.contains_key(arr_name)) {
+                        return true;
+                    }
+                }
+            }
+            match &e.kind {
+                ExprKind::Binary(_, l, r) => walk_expr(l, var, ports, wires) || walk_expr(r, var, ports, wires),
+                ExprKind::Unary(_, x) | ExprKind::Cast(x, _) | ExprKind::LatencyAt(x, _) | ExprKind::SvaNext(_, x) =>
+                    walk_expr(x, var, ports, wires),
+                ExprKind::FieldAccess(b, _) => walk_expr(b, var, ports, wires),
+                ExprKind::Index(b, i) | ExprKind::BitSlice(b, i, _) =>
+                    walk_expr(b, var, ports, wires) || walk_expr(i, var, ports, wires),
+                ExprKind::PartSelect(b, lo, hi, _) =>
+                    walk_expr(b, var, ports, wires) || walk_expr(lo, var, ports, wires) || walk_expr(hi, var, ports, wires),
+                ExprKind::Ternary(c, t, e2) =>
+                    walk_expr(c, var, ports, wires) || walk_expr(t, var, ports, wires) || walk_expr(e2, var, ports, wires),
+                ExprKind::Concat(parts) | ExprKind::FunctionCall(_, parts) =>
+                    parts.iter().any(|p| walk_expr(p, var, ports, wires)),
+                ExprKind::MethodCall(b, _, args) =>
+                    walk_expr(b, var, ports, wires) || args.iter().any(|a| walk_expr(a, var, ports, wires)),
+                _ => false,
+            }
+        }
+        match stmt {
+            Stmt::Assign(a) => walk_expr(&a.target, var, ports, wires) || walk_expr(&a.value, var, ports, wires),
+            Stmt::IfElse(ie) => {
+                walk_expr(&ie.cond, var, ports, wires)
+                    || ie.then_stmts.iter().any(|s| Self::stmt_indexes_vob_with_var(s, var, ports, wires))
+                    || ie.else_stmts.iter().any(|s| Self::stmt_indexes_vob_with_var(s, var, ports, wires))
+            }
+            Stmt::Match(m) => {
+                walk_expr(&m.scrutinee, var, ports, wires)
+                    || m.arms.iter().any(|arm| arm.body.iter().any(|s| Self::stmt_indexes_vob_with_var(s, var, ports, wires)))
+            }
+            Stmt::For(f) => f.body.iter().any(|s| Self::stmt_indexes_vob_with_var(s, var, ports, wires)),
+            Stmt::Init(ib) => ib.body.iter().any(|s| Self::stmt_indexes_vob_with_var(s, var, ports, wires)),
+            Stmt::DoUntil { body, cond, .. } =>
+                walk_expr(cond, var, ports, wires)
+                    || body.iter().any(|s| Self::stmt_indexes_vob_with_var(s, var, ports, wires)),
+            Stmt::WaitUntil(e, _) => walk_expr(e, var, ports, wires),
+            Stmt::Log(l) => l.args.iter().any(|a| walk_expr(a, var, ports, wires)),
         }
     }
 
@@ -2039,10 +2160,29 @@ impl<'a> Codegen<'a> {
                 Item::Fsm(f) if f.name.name == inst.module_name.name => Some(f.ports.as_slice()),
                 _ => None,
             });
+        // For each bus port, expose either the scalar name (count=None) or
+        // every indexed name `port_0`, ..., `port_{N-1}` (count=Some(N)) so
+        // inst-site connections like `chans_0 -> w0;` match a Vec<Bus,N>
+        // element of the child.
         let target_bus_ports: Vec<(String, String, Vec<ParamAssign>)> = target_ports_ref
-            .map(|ports| ports.iter()
-                .filter_map(|p| p.bus_info.as_ref().map(|bi| (p.name.name.clone(), bi.bus_name.name.clone(), bi.params.clone())))
-                .collect())
+            .map(|ports| {
+                let mut v = Vec::new();
+                for p in ports {
+                    if let Some(bi) = p.bus_info.as_ref() {
+                        match bi.count {
+                            None => {
+                                v.push((p.name.name.clone(), bi.bus_name.name.clone(), bi.params.clone()));
+                            }
+                            Some(n) => {
+                                for i in 0..n {
+                                    v.push((format!("{}_{}", p.name.name, i), bi.bus_name.name.clone(), bi.params.clone()));
+                                }
+                            }
+                        }
+                    }
+                }
+                v
+            })
             .unwrap_or_default();
 
         // Per-port enum-cast lookup. For each input port whose type is
@@ -2154,7 +2294,10 @@ impl<'a> Codegen<'a> {
                 continue;
             }
             if let Some((_, bus_name, bus_params)) = target_bus_ports.iter().find(|(pn, _, _)| *pn == c.port_name.name) {
-                // Bus connection — expand to individual signals
+                // Bus connection — expand to individual signals. The parent-side
+                // signal can be one of:
+                //   * `Ident("w")`              — scalar bus port or bus wire     → `w_<sig>`
+                //   * `Index(Ident("w"), N)`    — element N of a `Vec<Bus,M>` wire → `w_N_<sig>`
                 if let Some((crate::resolve::Symbol::Bus(info), _)) = self.symbols.globals.get(bus_name) {
                     let mut param_map: std::collections::HashMap<String, &Expr> = info.params.iter()
                         .filter_map(|pd| pd.default.as_ref().map(|d| (pd.name.name.clone(), d)))
@@ -2163,9 +2306,18 @@ impl<'a> Codegen<'a> {
                         param_map.insert(pa.name.name.clone(), &pa.value);
                     }
                     let eff_signals = info.effective_signals(&param_map);
-                    let sig_str = self.emit_expr_str(&c.signal);
+                    let sig_prefix = match &c.signal.kind {
+                        ExprKind::Index(arr, idx) => {
+                            if let (ExprKind::Ident(arr_name), ExprKind::Literal(LitKind::Dec(i))) = (&arr.kind, &idx.kind) {
+                                format!("{}_{}", arr_name, i)
+                            } else {
+                                self.emit_expr_str(&c.signal)
+                            }
+                        }
+                        _ => self.emit_expr_str(&c.signal),
+                    };
                     for (sname, _, _) in &eff_signals {
-                        connections.push(format!(".{}_{}({}_{})", c.port_name.name, sname, sig_str, sname));
+                        connections.push(format!(".{}_{}({}_{})", c.port_name.name, sname, sig_prefix, sname));
                     }
                 }
             } else {
@@ -4068,6 +4220,13 @@ impl<'a> Codegen<'a> {
                 if let Some(sub) = self.ident_subst.get(name) {
                     return sub.clone();
                 }
+                // Static for-loop unroll bound the loop variable to a literal
+                // integer (e.g. `chans[i].v` inside `for i in 0..N-1`). Emit
+                // the integer instead of the bare identifier so the RHS of
+                // the unrolled body uses the iteration value.
+                if let Some(v) = self.loop_var_subst.get(name) {
+                    return v.to_string();
+                }
                 name.clone()
             }
             ExprKind::Binary(op, lhs, rhs) => {
@@ -4176,12 +4335,27 @@ impl<'a> Codegen<'a> {
                         return format!("{}_{}", base_name, field.name);
                     }
                 }
-                // Indexed bus port: m_axi[0].valid → m_axi_0_valid
+                // Indexed bus port or bus wire: m_axi[0].valid → m_axi_0_valid.
+                // The index may be either a compile-time literal or a loop
+                // variable bound to a literal via static `for`-loop unroll
+                // (see `loop_var_subst`).
                 if let ExprKind::Index(arr, idx) = &base.kind {
-                    if let (ExprKind::Ident(arr_name), ExprKind::Literal(LitKind::Dec(i))) = (&arr.kind, &idx.kind) {
-                        let expanded = format!("{}_{}", arr_name, i);
-                        if self.bus_ports.contains_key(&expanded) {
-                            return format!("{}_{}_{}", arr_name, i, field.name);
+                    if let ExprKind::Ident(arr_name) = &arr.kind {
+                        let idx_val: Option<u64> = match &idx.kind {
+                            ExprKind::Literal(LitKind::Dec(i))
+                            | ExprKind::Literal(LitKind::Hex(i))
+                            | ExprKind::Literal(LitKind::Bin(i))
+                            | ExprKind::Literal(LitKind::Sized(_, i)) => Some(*i),
+                            ExprKind::Ident(loopvar) => self.loop_var_subst.get(loopvar).map(|v| *v as u64),
+                            _ => None,
+                        };
+                        if let Some(i) = idx_val {
+                            let expanded = format!("{}_{}", arr_name, i);
+                            if self.bus_ports.contains_key(&expanded)
+                                || self.bus_wires.contains_key(&expanded)
+                            {
+                                return format!("{}_{}_{}", arr_name, i, field.name);
+                            }
                         }
                     }
                 }

--- a/src/codegen/module.rs
+++ b/src/codegen/module.rs
@@ -78,6 +78,29 @@ impl<'a> Codegen<'a> {
         // Ports — bus ports are flattened to individual signals
         self.bus_ports.clear();
         self.bus_wires.clear();
+        self.vec_of_bus_port_count.clear();
+        self.vec_of_bus_wire_count.clear();
+        for p in m.ports.iter() {
+            if let Some(bi) = p.bus_info.as_ref() {
+                if let Some(n) = bi.count {
+                    self.vec_of_bus_port_count.insert(p.name.name.clone(), n);
+                }
+            }
+        }
+        for item in m.body.iter() {
+            if let ModuleBodyItem::WireDecl(w) = item {
+                if let TypeExpr::Vec(elem, size_expr) = &w.ty {
+                    if let TypeExpr::Named(id) = elem.as_ref() {
+                        if matches!(self.symbols.globals.get(&id.name),
+                                    Some((crate::resolve::Symbol::Bus(_), _))) {
+                            if let Some(n) = self.eval_const_u32(size_expr, &m.params) {
+                                self.vec_of_bus_wire_count.insert(w.name.name.clone(), n);
+                            }
+                        }
+                    }
+                }
+            }
+        }
         self.reset_ports.clear();
         self.vec_sizes.clear();
         self.pipe_regs.clear();
@@ -136,7 +159,16 @@ impl<'a> Codegen<'a> {
         for p in m.ports.iter() {
             if let Some(ref bi) = p.bus_info {
                 let bus_name = &bi.bus_name.name;
-                self.bus_ports.insert(p.name.name.clone(), bus_name.clone());
+                // Names to register in self.bus_ports + signal-name prefixes:
+                //   scalar:   ["chan"]
+                //   Vec<B,N>: ["chans_0", "chans_1", ..., "chans_{N-1}"]
+                let inst_names: Vec<String> = match bi.count {
+                    None => vec![p.name.name.clone()],
+                    Some(n) => (0..n).map(|i| format!("{}_{}", p.name.name, i)).collect(),
+                };
+                for nm in &inst_names {
+                    self.bus_ports.insert(nm.clone(), bus_name.clone());
+                }
                 if let Some((crate::resolve::Symbol::Bus(info), _)) = self.symbols.globals.get(bus_name) {
                     // Build param substitution map: start with bus defaults, override with port params
                     let mut param_map: std::collections::HashMap<String, &Expr> = info.params.iter()
@@ -146,18 +178,20 @@ impl<'a> Codegen<'a> {
                         param_map.insert(pa.name.name.clone(), &pa.value);
                     }
                     let eff_signals = info.effective_signals(&param_map);
-                    for (sname, sdir, sty) in &eff_signals {
-                        let actual_dir = match bi.perspective {
-                            BusPerspective::Initiator => *sdir,
-                            BusPerspective::Target => (*sdir).flip(),
-                        };
-                        let dir_str = match actual_dir {
-                            Direction::In => "input",
-                            Direction::Out => "output",
-                        };
-                        let subst_ty = Self::subst_type_expr(sty, &param_map);
-                        let ty_str = self.emit_port_type_str(&subst_ty);
-                        port_lines.push(format!("{} {} {}_{}", dir_str, ty_str, p.name.name, sname));
+                    for nm in &inst_names {
+                        for (sname, sdir, sty) in &eff_signals {
+                            let actual_dir = match bi.perspective {
+                                BusPerspective::Initiator => *sdir,
+                                BusPerspective::Target => (*sdir).flip(),
+                            };
+                            let dir_str = match actual_dir {
+                                Direction::In => "input",
+                                Direction::Out => "output",
+                            };
+                            let subst_ty = Self::subst_type_expr(sty, &param_map);
+                            let ty_str = self.emit_port_type_str(&subst_ty);
+                            port_lines.push(format!("{} {} {}_{}", dir_str, ty_str, nm, sname));
+                        }
                     }
                 }
             } else {
@@ -584,29 +618,54 @@ impl<'a> Codegen<'a> {
                     // abstraction. Record the wire in `bus_wires` so field
                     // access rewrites (see emit_expr_str) produce the flat
                     // name.
-                    if let TypeExpr::Named(id) = &w.ty {
-                        if let Some((crate::resolve::Symbol::Bus(info), _)) =
-                            self.symbols.globals.get(&id.name)
-                        {
-                            self.bus_wires.insert(w.name.name.clone(), id.name.clone());
-                            let param_map: std::collections::HashMap<String, &Expr> =
-                                info.params.iter()
-                                    .filter_map(|pd| pd.default.as_ref()
-                                        .map(|d| (pd.name.name.clone(), d)))
-                                    .collect();
+                    //
+                    // `wire w: Vec<BusName, N>;` declares N bus copies with
+                    // indexed names `w_0`, ..., `w_{N-1}`, accessed via
+                    // `w[i].sig`. Each copy contributes its full signal set.
+                    let bus_wire_info = match &w.ty {
+                        TypeExpr::Named(id) => self.symbols.globals.get(&id.name)
+                            .and_then(|(s, _)| if let crate::resolve::Symbol::Bus(info) = s {
+                                Some((info, id.name.clone(), None))
+                            } else { None }),
+                        TypeExpr::Vec(elem, size_expr) => {
+                            if let TypeExpr::Named(id) = elem.as_ref() {
+                                if let Some(n) = self.eval_const_u32(size_expr, &m_clone.params) {
+                                    self.symbols.globals.get(&id.name)
+                                        .and_then(|(s, _)| if let crate::resolve::Symbol::Bus(info) = s {
+                                            Some((info, id.name.clone(), Some(n)))
+                                        } else { None })
+                                } else { None }
+                            } else { None }
+                        }
+                        _ => None,
+                    };
+                    if let Some((info, bus_name, count)) = bus_wire_info {
+                        let prefixes: Vec<String> = match count {
+                            None => vec![w.name.name.clone()],
+                            Some(n) => (0..n).map(|i| format!("{}_{}", w.name.name, i)).collect(),
+                        };
+                        for prefix in &prefixes {
+                            self.bus_wires.insert(prefix.clone(), bus_name.clone());
+                        }
+                        let param_map: std::collections::HashMap<String, &Expr> =
+                            info.params.iter()
+                                .filter_map(|pd| pd.default.as_ref()
+                                    .map(|d| (pd.name.name.clone(), d)))
+                                .collect();
+                        for prefix in &prefixes {
                             for (sname, _sdir, sty) in info.effective_signals(&param_map) {
                                 let subst_ty = Self::subst_type_expr(&sty, &param_map);
                                 let (ty_str, arr_suffix) =
                                     self.emit_type_and_array_suffix(&subst_ty);
                                 self.line(&format!(
                                     "{} {}_{}{};",
-                                    ty_str, w.name.name, sname, arr_suffix
+                                    ty_str, prefix, sname, arr_suffix
                                 ));
-                                declared_names.insert(format!("{}_{}", w.name.name, sname));
+                                declared_names.insert(format!("{}_{}", prefix, sname));
                             }
-                            declared_names.insert(w.name.name.clone());
-                            continue;
                         }
+                        declared_names.insert(w.name.name.clone());
+                        continue;
                     }
                     if w.unpacked {
                         // SV unpacked-array shape (mirror of unpacked port modifier).

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1201,7 +1201,43 @@ impl Parser {
             None
         };
         if let Some(perspective) = bus_perspective {
-            let bus_name = self.expect_ident()?;
+            // Two surface forms:
+            //   port chans: initiator Vec<BusName, N>;       — array of N copies
+            //   port chan:  initiator BusName<PARAM=val>;    — scalar (existing)
+            let (bus_name, count) = if self.check(TokenKind::KwVec) {
+                let vec_span = self.peek_span();
+                self.advance(); // consume Vec
+                self.expect(TokenKind::Lt)?;
+                let old_no_angle = self.no_angle;
+                self.no_angle = true;
+                let bus_ident = self.expect_ident()?;
+                self.expect(TokenKind::Comma)?;
+                let count_expr = self.parse_expr()?;
+                self.no_angle = old_no_angle;
+                self.expect(TokenKind::Gt)?;
+                // MVP: count must be a compile-time integer literal.
+                let n: u32 = match &count_expr.kind {
+                    ExprKind::Literal(LitKind::Dec(n))
+                    | ExprKind::Literal(LitKind::Hex(n))
+                    | ExprKind::Literal(LitKind::Bin(n))
+                    | ExprKind::Literal(LitKind::Sized(_, n)) => *n as u32,
+                    _ => {
+                        return Err(CompileError::general(
+                            "Vec<BusName, N> port: N must be a compile-time integer literal (v1)",
+                            count_expr.span,
+                        ));
+                    }
+                };
+                if n == 0 {
+                    return Err(CompileError::general(
+                        "Vec<BusName, N> port: N must be >= 1",
+                        vec_span,
+                    ));
+                }
+                (bus_ident, Some(n))
+            } else {
+                (self.expect_ident()?, None)
+            };
             // Optional param assignments: <PARAM=val, ...>
             let params = if self.check(TokenKind::Lt) {
                 self.advance();
@@ -1229,7 +1265,7 @@ impl Parser {
                 ty: TypeExpr::Named(bus_name.clone()),
                 default: None,
                 reg_info: None,
-                bus_info: Some(BusPortInfo { bus_name, perspective, params }),
+                bus_info: Some(BusPortInfo { bus_name, perspective, params, count }),
                 shared: None, unpacked: false, unpacked_ascending: false,
                 comb_deps: None,
                 span: start.merge(end_span),
@@ -2899,6 +2935,7 @@ impl Parser {
                 let cstart = self.peek_span();
                 let mut port_name = self.expect_ident()?;
                 // Support indexed port group syntax: name[i].member → namei_member
+                // AND indexed Vec-of-bus connection: name[i] → name_i (no `.member`).
                 if self.eat(TokenKind::LBracket) {
                     let idx_tok = self.advance();
                     let idx = match &idx_tok.kind {
@@ -2908,12 +2945,24 @@ impl Parser {
                             "integer index", &idx_tok.kind.to_string(), idx_tok.span)),
                     };
                     self.expect(TokenKind::RBracket)?;
-                    self.expect(TokenKind::Dot)?;
-                    let member = self.expect_ident()?;
-                    port_name = Ident::new(
-                        format!("{}{idx}_{}", port_name.name, member.name),
-                        port_name.span.merge(member.span),
-                    );
+                    if self.eat(TokenKind::Dot) {
+                        // Indexed port-group member: `request[0].valid` → `request0_valid`
+                        // (matches the ports[N] flattening convention).
+                        let member = self.expect_ident()?;
+                        port_name = Ident::new(
+                            format!("{}{idx}_{}", port_name.name, member.name),
+                            port_name.span.merge(member.span),
+                        );
+                    } else {
+                        // Indexed Vec-of-bus connection: `chans[0]` → `chans_0`
+                        // (matches the SV / sim signature flattening of
+                        // `port chans: initiator Vec<BusName, N>;`).
+                        let end_span = idx_tok.span;
+                        port_name = Ident::new(
+                            format!("{}_{}", port_name.name, idx),
+                            port_name.span.merge(end_span),
+                        );
+                    }
                 // Support dot notation for port group members: group.member → group_member
                 } else if self.eat(TokenKind::Dot) {
                     let member = self.expect_ident()?;

--- a/src/sim_codegen/mod.rs
+++ b/src/sim_codegen/mod.rs
@@ -379,12 +379,21 @@ impl<'a> SimCodegen<'a> {
         let mut port_info: Vec<(String, u32, bool, bool, bool, bool)> = Vec::new();
         let mut bindings = Vec::new();
 
-        // Bus port flattening
+        // Bus port flattening. For Vec<Bus,N> ports, the indexed names
+        // `port_0`, `port_1`, ..., `port_{N-1}` populate `bus_port_names`
+        // so the bracket-dot expression path (`chans[i].sig`) resolves.
         let mut bus_port_names: HashSet<String> = HashSet::new();
         let mut bus_flat: Vec<(String, TypeExpr)> = Vec::new();
         for p in &m.ports {
             if let Some(ref bi) = p.bus_info {
-                bus_port_names.insert(p.name.name.clone());
+                match bi.count {
+                    None => { bus_port_names.insert(p.name.name.clone()); }
+                    Some(n) => {
+                        for i in 0..n {
+                            bus_port_names.insert(format!("{}_{}", p.name.name, i));
+                        }
+                    }
+                }
                 bus_flat.extend(flatten_bus_port(&p.name.name, bi, self.symbols));
             }
         }
@@ -1325,16 +1334,25 @@ fn flatten_bus_port_with_dir(
         }
         let eff = info.effective_signals(&param_map);
         let is_target = bi.perspective == BusPerspective::Target;
-        eff.iter().map(|(sname, sdir, sty)| {
-            let subst_ty = subst_type_expr_sim(sty, &param_map);
-            // Target perspective flips all signal directions
-            let dir = if is_target {
-                match sdir { Direction::In => Direction::Out, Direction::Out => Direction::In }
-            } else {
-                *sdir
-            };
-            (format!("{}_{}", port_name, sname), dir, subst_ty)
-        }).collect()
+        // For Vec<Bus, N> ports, emit N copies of each signal with indexed prefix.
+        let prefixes: Vec<String> = match bi.count {
+            None => vec![port_name.to_string()],
+            Some(n) => (0..n).map(|i| format!("{}_{}", port_name, i)).collect(),
+        };
+        let mut out = Vec::new();
+        for prefix in &prefixes {
+            for (sname, sdir, sty) in &eff {
+                let subst_ty = subst_type_expr_sim(sty, &param_map);
+                // Target perspective flips all signal directions
+                let dir = if is_target {
+                    match sdir { Direction::In => Direction::Out, Direction::Out => Direction::In }
+                } else {
+                    *sdir
+                };
+                out.push((format!("{}_{}", prefix, sname), dir, subst_ty));
+            }
+        }
+        out
     } else {
         Vec::new()
     }
@@ -1372,35 +1390,72 @@ fn expand_bus_connections(
             Item::Fsm(f) if f.name.name == inst.module_name.name => Some(f.ports.as_slice()),
             _ => None,
         });
-    let target_bus_ports: Vec<(&str, &str, BusPerspective, &[ParamAssign])> = target_ports
-        .map(|ports| ports.iter()
-            .filter_map(|p| p.bus_info.as_ref().map(|bi| (p.name.name.as_str(), bi.bus_name.name.as_str(), bi.perspective, bi.params.as_slice())))
-            .collect())
+    // For each bus port on the target, expose either the scalar name (count=None)
+    // or every indexed name `port_0`, `port_1`, ... (count=Some(N)). The inst-site
+    // refers to a Vec-of-bus element by its underscore-suffixed name, e.g.
+    // `chans_0 -> w0;` for the first element of a `Vec<B, N>` port `chans`.
+    let target_bus_ports: Vec<(String, &str, BusPerspective, &[ParamAssign])> = target_ports
+        .map(|ports| {
+            let mut v = Vec::new();
+            for p in ports {
+                if let Some(bi) = p.bus_info.as_ref() {
+                    let bus = bi.bus_name.name.as_str();
+                    match bi.count {
+                        None => {
+                            v.push((p.name.name.clone(), bus, bi.perspective, bi.params.as_slice()));
+                        }
+                        Some(n) => {
+                            for i in 0..n {
+                                v.push((format!("{}_{}", p.name.name, i), bus, bi.perspective, bi.params.as_slice()));
+                            }
+                        }
+                    }
+                }
+            }
+            v
+        })
         .unwrap_or_default();
 
     let mut expanded = Vec::new();
     for c in &inst.connections {
-        if let Some((_, bus_name, perspective, bus_params)) = target_bus_ports.iter().find(|(pn, _, _, _)| *pn == c.port_name.name) {
+        if let Some((_, bus_name, perspective, bus_params)) = target_bus_ports.iter().find(|(pn, _, _, _)| pn == &c.port_name.name) {
             // Bus connection — expand to individual signal connections
             if let Some((crate::resolve::Symbol::Bus(info), _)) = symbols.globals.get(*bus_name) {
-                // Two shapes for the parent-side signal on a whole-bus binding:
-                //   * `p -> ident` where `ident` is a bus port or a bus wire
-                //   * `p -> base.field` where `base.field` is a bus port on the parent
-                // For bus WIRES we keep the bus-wire name as the struct base and
-                // emit FieldAccess exprs per signal so cpp_expr resolves them
-                // to `_let_<wire>.<field>`. For bus PORTS we emit flat idents
-                // (the port has been flattened elsewhere into `<port>_<field>`).
-                let (sig_base, wire_bound) = match &c.signal.kind {
+                // Three shapes for the parent-side signal on a whole-bus binding:
+                //   * `p -> ident`         where `ident` is a bus port or scalar bus wire
+                //   * `p -> base.field`    where `base.field` is a bus port on the parent
+                //   * `p -> wire[i]`       where `wire` is a Vec<Bus,N> wire — element i
+                //
+                // BindKind tells the per-signal emitter how to construct the parent-side
+                // expression for a given signal name:
+                //   FlatPort(prefix)   → emit `Ident("<prefix>_<sname>")`
+                //                        (matches the flattened bus-port shape)
+                //   WireStruct(name)   → emit `FieldAccess(Ident("<name>"), sname)`
+                //                        (matches the C++ struct-typed bus wire)
+                //   WireIndex(name, i) → emit `FieldAccess(Index(Ident("<name>"), i), sname)`
+                //                        (matches a `B _let_<name>[N]` struct-array element)
+                enum BindKind { FlatPort(String), WireStruct(String), WireIndex(String, u32) }
+                let bind = match &c.signal.kind {
                     ExprKind::Ident(name) => {
-                        let is_wire = bus_wire_names.contains(name.as_str());
-                        (name.clone(), is_wire)
+                        if bus_wire_names.contains(name.as_str()) {
+                            BindKind::WireStruct(name.clone())
+                        } else {
+                            BindKind::FlatPort(name.clone())
+                        }
                     }
                     ExprKind::FieldAccess(base, field) => {
                         if let ExprKind::Ident(base_name) = &base.kind {
-                            (format!("{}_{}", base_name, field.name), false)
+                            BindKind::FlatPort(format!("{}_{}", base_name, field.name))
                         } else {
                             continue;
                         }
+                    }
+                    ExprKind::Index(arr, idx) => {
+                        if let (ExprKind::Ident(arr_name), ExprKind::Literal(LitKind::Dec(i))) = (&arr.kind, &idx.kind) {
+                            if bus_wire_names.contains(arr_name.as_str()) {
+                                BindKind::WireIndex(arr_name.clone(), *i as u32)
+                            } else { continue; }
+                        } else { continue; }
                     }
                     _ => continue,
                 };
@@ -1419,21 +1474,31 @@ fn expand_bus_connections(
                         Direction::Out => ConnectDir::Output,
                         Direction::In => ConnectDir::Input,
                     };
-                    // Bus WIRE target → struct-field access on the wire.
-                    // Bus PORT target → flat `<port>_<field>` ident.
-                    let parent_signal = if wire_bound {
-                        Expr::new(
+                    let parent_signal = match &bind {
+                        BindKind::FlatPort(prefix) => Expr::new(
+                            ExprKind::Ident(format!("{}_{}", prefix, sname)),
+                            c.signal.span,
+                        ),
+                        BindKind::WireStruct(name) => Expr::new(
                             ExprKind::FieldAccess(
-                                Box::new(Expr::new(ExprKind::Ident(sig_base.clone()), c.signal.span)),
+                                Box::new(Expr::new(ExprKind::Ident(name.clone()), c.signal.span)),
                                 Ident::new(sname.clone(), c.signal.span),
                             ),
                             c.signal.span,
-                        )
-                    } else {
-                        Expr::new(
-                            ExprKind::Ident(format!("{}_{}", sig_base, sname)),
+                        ),
+                        BindKind::WireIndex(name, i) => Expr::new(
+                            ExprKind::FieldAccess(
+                                Box::new(Expr::new(
+                                    ExprKind::Index(
+                                        Box::new(Expr::new(ExprKind::Ident(name.clone()), c.signal.span)),
+                                        Box::new(Expr::new(ExprKind::Literal(LitKind::Dec(*i as u64)), c.signal.span)),
+                                    ),
+                                    c.signal.span,
+                                )),
+                                Ident::new(sname.clone(), c.signal.span),
+                            ),
                             c.signal.span,
-                        )
+                        ),
                     };
                     expanded.push(Connection {
                         port_name: Ident::new(inst_flat, c.port_name.span),
@@ -1510,6 +1575,64 @@ fn vec_array_info(ty: &TypeExpr) -> Option<(String, String)> {
 /// fixed in PR #cam-zero-array).
 fn eval_const_expr(expr: &Expr) -> u64 {
     eval_const_expr_with_params(expr, &[])
+}
+
+/// Walk `stmt` and return true if any expression has the shape
+/// `Index(Ident(name), Ident(var))` where `name` is a Vec-of-bus port
+/// or wire (keys of `ports` / `wires`). Used by the for-loop emitter
+/// to decide whether to statically unroll the body. Recurses into all
+/// sub-statements and into both sides of assignments.
+fn stmt_indexes_vob_with_var(
+    stmt: &Stmt,
+    var: &str,
+    ports: &HashMap<String, u32>,
+    wires: &HashMap<String, u32>,
+) -> bool {
+    fn walk_expr(e: &Expr, var: &str, ports: &HashMap<String, u32>, wires: &HashMap<String, u32>) -> bool {
+        if let ExprKind::Index(arr, idx) = &e.kind {
+            if let (ExprKind::Ident(arr_name), ExprKind::Ident(idx_name)) = (&arr.kind, &idx.kind) {
+                if idx_name == var && (ports.contains_key(arr_name) || wires.contains_key(arr_name)) {
+                    return true;
+                }
+            }
+        }
+        match &e.kind {
+            ExprKind::Binary(_, l, r) => walk_expr(l, var, ports, wires) || walk_expr(r, var, ports, wires),
+            ExprKind::Unary(_, x) | ExprKind::Cast(x, _) | ExprKind::LatencyAt(x, _) | ExprKind::SvaNext(_, x) =>
+                walk_expr(x, var, ports, wires),
+            ExprKind::FieldAccess(b, _) => walk_expr(b, var, ports, wires),
+            ExprKind::Index(b, i) | ExprKind::BitSlice(b, i, _) =>
+                walk_expr(b, var, ports, wires) || walk_expr(i, var, ports, wires),
+            ExprKind::PartSelect(b, lo, hi, _) =>
+                walk_expr(b, var, ports, wires) || walk_expr(lo, var, ports, wires) || walk_expr(hi, var, ports, wires),
+            ExprKind::Ternary(c, t, e2) =>
+                walk_expr(c, var, ports, wires) || walk_expr(t, var, ports, wires) || walk_expr(e2, var, ports, wires),
+            ExprKind::Concat(parts) | ExprKind::FunctionCall(_, parts) =>
+                parts.iter().any(|p| walk_expr(p, var, ports, wires)),
+            ExprKind::MethodCall(b, _, args) =>
+                walk_expr(b, var, ports, wires) || args.iter().any(|a| walk_expr(a, var, ports, wires)),
+            _ => false,
+        }
+    }
+    match stmt {
+        Stmt::Assign(a) => walk_expr(&a.target, var, ports, wires) || walk_expr(&a.value, var, ports, wires),
+        Stmt::IfElse(ie) => {
+            walk_expr(&ie.cond, var, ports, wires)
+                || ie.then_stmts.iter().any(|s| stmt_indexes_vob_with_var(s, var, ports, wires))
+                || ie.else_stmts.iter().any(|s| stmt_indexes_vob_with_var(s, var, ports, wires))
+        }
+        Stmt::Match(m) => {
+            walk_expr(&m.scrutinee, var, ports, wires)
+                || m.arms.iter().any(|arm| arm.body.iter().any(|s| stmt_indexes_vob_with_var(s, var, ports, wires)))
+        }
+        Stmt::For(f) => f.body.iter().any(|s| stmt_indexes_vob_with_var(s, var, ports, wires)),
+        Stmt::Init(ib) => ib.body.iter().any(|s| stmt_indexes_vob_with_var(s, var, ports, wires)),
+        Stmt::DoUntil { body, cond, .. } =>
+            walk_expr(cond, var, ports, wires)
+                || body.iter().any(|s| stmt_indexes_vob_with_var(s, var, ports, wires)),
+        Stmt::WaitUntil(e, _) => walk_expr(e, var, ports, wires),
+        Stmt::Log(l) => l.args.iter().any(|a| walk_expr(a, var, ports, wires)),
+    }
 }
 
 /// Param-aware constant evaluator. Resolves bare identifiers against
@@ -1759,6 +1882,16 @@ struct Ctx<'a> {
     /// (e.g. "item" → "vec[3]", "index" → "3"). Checked first in the Ident
     /// branch of `cpp_expr`; None or missing key means normal resolution.
     ident_subst: Option<&'a HashMap<String, String>>,
+    /// Loop-variable → integer-value substitutions pushed during static
+    /// unrolling of `for` loops over Vec-of-bus indexed access. RefCell
+    /// for interior mutability — the for-loop emitter mutates per
+    /// iteration while emit_stmt walks the body. None = no active unroll.
+    loop_var_subst: Option<&'a std::cell::RefCell<HashMap<String, u32>>>,
+    /// Vec-of-bus port name → element count. Used by the for-loop emitter
+    /// to decide whether the body needs static unrolling.
+    vec_of_bus_port_count: Option<&'a HashMap<String, u32>>,
+    /// Same as `vec_of_bus_port_count` but for `wire w: Vec<BusName, N>;`.
+    vec_of_bus_wire_count: Option<&'a HashMap<String, u32>>,
     /// Branch-coverage registry for the current module. None when --coverage
     /// is off; Some(_) when on. emit_*_if_else allocates counter ids here
     /// and emits `_arch_cov[N]++;` at the start of each arm.
@@ -1790,7 +1923,21 @@ impl<'a> Ctx<'a> {
         Ctx { reg_names, port_names, let_names, let_values: None, inst_names, wide_names,
               widths, signed_names, posedge_lhs: false, fsm_mode: false, enum_map, bus_ports,
               reset_levels, vec_names: None, vec_sizes: None, fsm_vec_port_regs: None,
-              ident_subst: None, coverage: None, params: EMPTY_PARAMS }
+              ident_subst: None, loop_var_subst: None,
+              vec_of_bus_port_count: None, vec_of_bus_wire_count: None,
+              coverage: None, params: EMPTY_PARAMS }
+    }
+
+    fn with_vec_of_bus(
+        mut self,
+        ports: &'a HashMap<String, u32>,
+        wires: &'a HashMap<String, u32>,
+        subst: &'a std::cell::RefCell<HashMap<String, u32>>,
+    ) -> Self {
+        self.vec_of_bus_port_count = Some(ports);
+        self.vec_of_bus_wire_count = Some(wires);
+        self.loop_var_subst = Some(subst);
+        self
     }
 
     fn with_signed_names(mut self, signed_names: &'a HashSet<String>) -> Self {
@@ -2140,6 +2287,9 @@ fn lower_vec_method_cpp(
             reset_levels: ctx.reset_levels, vec_names: ctx.vec_names,
             vec_sizes: ctx.vec_sizes, fsm_vec_port_regs: ctx.fsm_vec_port_regs,
             ident_subst: None, // replaced below via a temporary binding
+            loop_var_subst: ctx.loop_var_subst,
+            vec_of_bus_port_count: ctx.vec_of_bus_port_count,
+            vec_of_bus_wire_count: ctx.vec_of_bus_wire_count,
             coverage: ctx.coverage,
             params: ctx.params,
         };
@@ -2268,6 +2418,11 @@ fn cpp_expr_inner(expr: &Expr, ctx: &Ctx, is_lhs: bool) -> String {
             if let Some(sub) = ctx.ident_subst.and_then(|m| m.get(name)) {
                 return sub.clone();
             }
+            // Static for-loop unroll binds the loop variable to a literal
+            // integer (e.g. `chans[i].v` inside `for i in 0..N-1`).
+            if let Some(v) = ctx.loop_var_subst.and_then(|c| c.borrow().get(name).copied()) {
+                return v.to_string();
+            }
             if is_lhs {
                 ctx.resolve_name(name, true)
             } else {
@@ -2336,12 +2491,25 @@ fn cpp_expr_inner(expr: &Expr, ctx: &Ctx, is_lhs: bool) -> String {
                     return format!("_inst_{}.{}", base_name, field.name);
                 }
             }
-            // Indexed bus port: m_axi[0].valid → m_axi_0_valid
+            // Indexed bus port: m_axi[0].valid → m_axi_0_valid. The index
+            // may be a literal or a loop variable bound to a literal via
+            // static for-loop unroll (see `loop_var_subst`).
             if let ExprKind::Index(arr, idx) = &base.kind {
-                if let (ExprKind::Ident(arr_name), ExprKind::Literal(LitKind::Dec(i))) = (&arr.kind, &idx.kind) {
-                    let expanded = format!("{}_{}", arr_name, i);
-                    if ctx.bus_ports.contains(expanded.as_str()) {
-                        return format!("{}_{}_{}", arr_name, i, field.name);
+                if let ExprKind::Ident(arr_name) = &arr.kind {
+                    let idx_val: Option<u64> = match &idx.kind {
+                        ExprKind::Literal(LitKind::Dec(i))
+                        | ExprKind::Literal(LitKind::Hex(i))
+                        | ExprKind::Literal(LitKind::Bin(i))
+                        | ExprKind::Literal(LitKind::Sized(_, i)) => Some(*i),
+                        ExprKind::Ident(loopvar) =>
+                            ctx.loop_var_subst.and_then(|c| c.borrow().get(loopvar).copied()).map(|v| v as u64),
+                        _ => None,
+                    };
+                    if let Some(i) = idx_val {
+                        let expanded = format!("{}_{}", arr_name, i);
+                        if ctx.bus_ports.contains(expanded.as_str()) {
+                            return format!("{}_{}_{}", arr_name, i, field.name);
+                        }
                     }
                 }
             }
@@ -3076,6 +3244,44 @@ fn emit_stmt(stmt: &Stmt, ctx: &Ctx, out: &mut String, indent: usize, k: SimAssi
         Stmt::Log(l) => emit_log_stmt(l, ctx, out, indent),
         Stmt::For(f) => {
             let var = &f.var.name;
+            // Static unrolling for Vec-of-bus indexed access (mirror of the
+            // SV-side path). The C++ struct fields are flat per-element
+            // (`chans_0_v`, `chans_1_v`, ...), not arrays, so a behavioral
+            // `for (int i ...; i <= N; i++) chans[i].v = ...` would emit a
+            // reference to an undeclared `chans`. Detect Vec-of-bus indexed
+            // writes by the loop variable, and if found AND bounds are
+            // literal, statically unroll: bind the loop var to each
+            // iteration value via `loop_var_subst` and emit the body N
+            // times.
+            if let (ForRange::Range(rs, re), Some(subst), Some(vob_ports), Some(vob_wires)) = (
+                &f.range,
+                ctx.loop_var_subst,
+                ctx.vec_of_bus_port_count,
+                ctx.vec_of_bus_wire_count,
+            ) {
+                let lit = |e: &Expr| -> Option<u32> {
+                    match &e.kind {
+                        ExprKind::Literal(LitKind::Dec(n))
+                        | ExprKind::Literal(LitKind::Hex(n))
+                        | ExprKind::Literal(LitKind::Bin(n))
+                        | ExprKind::Literal(LitKind::Sized(_, n)) => Some(*n as u32),
+                        _ => None,
+                    }
+                };
+                if let (Some(start_lit), Some(end_lit)) = (lit(rs), lit(re)) {
+                    let touches = f.body.iter().any(|s| stmt_indexes_vob_with_var(
+                        s, var, vob_ports, vob_wires,
+                    ));
+                    if touches {
+                        for i in start_lit..=end_lit {
+                            subst.borrow_mut().insert(var.clone(), i);
+                            for s in &f.body { emit_stmt(s, ctx, out, indent, k); }
+                        }
+                        subst.borrow_mut().remove(var);
+                        return;
+                    }
+                }
+            }
             match &f.range {
                 ForRange::Range(rs, re) => {
                     let start = cpp_expr(rs, ctx);
@@ -4104,9 +4310,27 @@ impl<'a> SimCodegen<'a> {
         let mut bus_port_names: HashSet<String> = HashSet::new();
         let mut bus_flat: Vec<(String, TypeExpr)> = Vec::new();
         let mut bus_flat_dirs: HashMap<String, Direction> = HashMap::new();
+        // Vec-of-bus port and wire counts — drive the static unroll path
+        // in emit_stmt for `for` loops that index a Vec<Bus,N> by the loop
+        // variable. The loop_var_subst RefCell carries the per-iteration
+        // binding while emit_stmt walks the body.
+        let mut vec_of_bus_port_count_map: HashMap<String, u32> = HashMap::new();
+        let mut vec_of_bus_wire_count_map: HashMap<String, u32> = HashMap::new();
+        let loop_var_subst_cell: std::cell::RefCell<HashMap<String, u32>> =
+            std::cell::RefCell::new(HashMap::new());
         for p in &m.ports {
             if let Some(ref bi) = p.bus_info {
-                bus_port_names.insert(p.name.name.clone());
+                // Vec<Bus,N> ports register N indexed names so bracket-dot
+                // expression lookup hits a known bus prefix.
+                match bi.count {
+                    None => { bus_port_names.insert(p.name.name.clone()); }
+                    Some(n) => {
+                        for i in 0..n {
+                            bus_port_names.insert(format!("{}_{}", p.name.name, i));
+                        }
+                        vec_of_bus_port_count_map.insert(p.name.name.clone(), n);
+                    }
+                }
                 let with_dir = flatten_bus_port_with_dir(&p.name.name, bi, self.symbols);
                 for (fname, fdir, fty) in with_dir {
                     bus_flat_dirs.insert(fname.clone(), fdir);
@@ -4478,11 +4702,30 @@ impl<'a> SimCodegen<'a> {
         // that `child_port -> bus_wire` emits struct-field-access exprs instead
         // of flat `<wire>_<field>` idents (which would dangle; bus wires are
         // declared as a C++ struct field, not as N flat fields).
+        // A bus wire is either a scalar `wire w: BusName;` or an array
+        // `wire w: Vec<BusName, N>;`. expand_bus_connections needs to see
+        // BOTH cases so that `child_port -> w` and `child_port -> w[i]`
+        // both lower correctly.
         let bus_wire_names: HashSet<String> = m.body.iter()
             .filter_map(|i| if let ModuleBodyItem::WireDecl(w) = i {
-                if let TypeExpr::Named(id) = &w.ty {
-                    if matches!(self.symbols.globals.get(&id.name),
+                let bus_named = match &w.ty {
+                    TypeExpr::Named(id) => Some(&id.name),
+                    TypeExpr::Vec(elem, _) => {
+                        if let TypeExpr::Named(id) = elem.as_ref() { Some(&id.name) } else { None }
+                    }
+                    _ => None,
+                };
+                if let Some(bn) = bus_named {
+                    if matches!(self.symbols.globals.get(bn),
                                 Some((crate::resolve::Symbol::Bus(_), _))) {
+                        // Record Vec-of-bus wire counts for the for-loop
+                        // static-unroll path.
+                        if let TypeExpr::Vec(_, size_expr) = &w.ty {
+                            let n = eval_const_expr_with_params(size_expr, &m.params) as u32;
+                            if n > 0 {
+                                vec_of_bus_wire_count_map.insert(w.name.name.clone(), n);
+                            }
+                        }
                         return Some(w.name.name.clone());
                     }
                 }
@@ -4668,6 +4911,7 @@ impl<'a> SimCodegen<'a> {
             }
         }
         let has_structs = m.body.iter().any(|i| matches!(i, ModuleBodyItem::RegDecl(r) if ty_references_named(&r.ty)))
+            || m.body.iter().any(|i| matches!(i, ModuleBodyItem::WireDecl(w) if ty_references_named(&w.ty)))
             || m.ports.iter().any(|p| ty_references_named(&p.ty));
         let mut h = String::new();
         h.push_str(&format!("#pragma once\n#include <cstdint>\n#include <cstdio>\n#include \"verilated.h\"\n"));
@@ -6186,7 +6430,12 @@ impl<'a> SimCodegen<'a> {
                            .with_vec_names(&vec_reg_names).with_vec_sizes(&vec_sizes)
                            .with_coverage(cov_handle)
                            .with_let_values(&let_values)
-                           .with_params(&m.params);
+                           .with_params(&m.params)
+                           .with_vec_of_bus(
+                               &vec_of_bus_port_count_map,
+                               &vec_of_bus_wire_count_map,
+                               &loop_var_subst_cell,
+                           );
 
         // Credit-channel combinational wires (sender can_send; receiver
         // valid/data once PR-sim-2 lands). Emit early so user comb code
@@ -6236,6 +6485,9 @@ impl<'a> SimCodegen<'a> {
                                         reset_levels: ctx_comb.reset_levels, vec_names: ctx_comb.vec_names,
                                         vec_sizes: ctx_comb.vec_sizes, fsm_vec_port_regs: ctx_comb.fsm_vec_port_regs,
                                         ident_subst: Some(&sub),
+                                        loop_var_subst: ctx_comb.loop_var_subst,
+                                        vec_of_bus_port_count: ctx_comb.vec_of_bus_port_count,
+                                        vec_of_bus_wire_count: ctx_comb.vec_of_bus_wire_count,
                                         coverage: ctx_comb.coverage,
                                         params: ctx_comb.params,
                                     };

--- a/src/sim_codegen/pipeline.rs
+++ b/src/sim_codegen/pipeline.rs
@@ -501,7 +501,7 @@ impl<'a> SimCodegen<'a> {
     ) -> String {
         let empty = HashSet::new();
         let empty_rl: HashMap<String, ResetLevel> = HashMap::new();
-        let ctx = Ctx { reg_names: rn, port_names: pn, let_names: ln, let_values: None, inst_names: &empty, wide_names: &empty, widths: w, signed_names: &empty, posedge_lhs: false, fsm_mode: false, enum_map: em, bus_ports: &empty, reset_levels: &empty_rl, vec_names: None, vec_sizes: None, fsm_vec_port_regs: None, ident_subst: None, coverage: None, params: &[] };
+        let ctx = Ctx { reg_names: rn, port_names: pn, let_names: ln, let_values: None, inst_names: &empty, wide_names: &empty, widths: w, signed_names: &empty, posedge_lhs: false, fsm_mode: false, enum_map: em, bus_ports: &empty, reset_levels: &empty_rl, vec_names: None, vec_sizes: None, fsm_vec_port_regs: None, ident_subst: None, loop_var_subst: None, vec_of_bus_port_count: None, vec_of_bus_wire_count: None, coverage: None, params: &[] };
         match &expr.kind {
             ExprKind::FieldAccess(base, field) => {
                 if let ExprKind::Ident(bn) = &base.kind {

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -66,6 +66,12 @@ pub struct TypeChecker<'a> {
     /// constructs (`past(x, N)`, `a |=> b`) are only legal inside this
     /// scope; flagged as compile errors elsewhere.
     pub in_sva_context: bool,
+    /// Per-module map of Vec-of-bus port names → element count. Populated
+    /// at the start of check_module so check_stmt can expand indexed
+    /// driver-tracking writes (`chans[i].sig = ...`) over all N copies
+    /// when the index isn't a compile-time literal (e.g. inside a `for`
+    /// loop). Cleared between modules.
+    pub vec_of_bus_ports: HashMap<String, u32>,
 }
 
 impl<'a> TypeChecker<'a> {
@@ -77,6 +83,7 @@ impl<'a> TypeChecker<'a> {
             warnings: Vec::new(),
             overload_map: HashMap::new(),
             in_sva_context: false,
+            vec_of_bus_ports: HashMap::new(),
         }
     }
 
@@ -406,6 +413,18 @@ impl<'a> TypeChecker<'a> {
         // happens in `check_inst_decl` when validating the inst connections.
         if m.is_interface {
             return;
+        }
+
+        // Per-module map of Vec-of-bus port → count. Used by the Assign
+        // path so that `chans[i].sig = ...` records all N flat copies as
+        // driven when `i` is a loop variable (or any non-literal index).
+        self.vec_of_bus_ports.clear();
+        for p in &m.ports {
+            if let Some(bi) = p.bus_info.as_ref() {
+                if let Some(n) = bi.count {
+                    self.vec_of_bus_ports.insert(p.name.name.clone(), n);
+                }
+            }
         }
 
         // Track driven signals
@@ -902,24 +921,31 @@ impl<'a> TypeChecker<'a> {
         // Check all output ports are driven
         for p in &m.ports {
             if let Some(ref bi) = p.bus_info {
-                // Bus port: check each output signal is driven (flattened name: port_signal)
+                // Bus port: check each output signal is driven (flattened name: port_signal).
+                // For Vec<Bus,N> ports, check each of the N copies independently.
                 let bus_name = &bi.bus_name.name;
                 if let Some((crate::resolve::Symbol::Bus(info), _)) = self.symbols.globals.get(bus_name) {
                     let mut pm = info.default_param_map();
                     for pa in &bi.params { pm.insert(pa.name.name.clone(), &pa.value); }
                     let eff = info.effective_signals(&pm);
-                    for (sname, sdir, _) in &eff {
-                        let actual_dir = match bi.perspective {
-                            BusPerspective::Initiator => *sdir,
-                            BusPerspective::Target => (*sdir).flip(),
-                        };
-                        if actual_dir == Direction::Out {
-                            let flat = format!("{}_{}", p.name.name, sname);
-                            if !driven.contains(&flat) {
-                                self.errors.push(CompileError::UndriveOutput {
-                                    name: flat,
-                                    span: crate::diagnostics::span_to_source_span(p.name.span),
-                                });
+                    let prefixes: Vec<String> = match bi.count {
+                        None => vec![p.name.name.clone()],
+                        Some(n) => (0..n).map(|i| format!("{}_{}", p.name.name, i)).collect(),
+                    };
+                    for prefix in &prefixes {
+                        for (sname, sdir, _) in &eff {
+                            let actual_dir = match bi.perspective {
+                                BusPerspective::Initiator => *sdir,
+                                BusPerspective::Target => (*sdir).flip(),
+                            };
+                            if actual_dir == Direction::Out {
+                                let flat = format!("{}_{}", prefix, sname);
+                                if !driven.contains(&flat) {
+                                    self.errors.push(CompileError::UndriveOutput {
+                                        name: flat,
+                                        span: crate::diagnostics::span_to_source_span(p.name.span),
+                                    });
+                                }
                             }
                         }
                     }
@@ -2207,7 +2233,33 @@ impl<'a> TypeChecker<'a> {
                 }
                 if !target_name.is_empty() { driven.insert(target_name.clone()); }
                 let flat = Self::expr_flat_name_tc(&a.target);
-                if flat != target_name { driven.insert(flat); }
+                if flat != target_name { driven.insert(flat.clone()); }
+                // Vec-of-bus indexed write with a non-literal index — e.g.
+                // `chans[i].sig = ...` inside a `for i in 0..N` loop. The
+                // root name alone ("chans") doesn't satisfy the per-copy
+                // completeness check, and the index isn't a literal so
+                // `expr_flat_name_tc` couldn't pin it to a specific copy.
+                // Conservatively mark every copy's matching signal driven
+                // (the scalar Vec port case has the same "any indexed
+                // write covers the whole array" semantics).
+                if let ExprKind::FieldAccess(base, field) = &a.target.kind {
+                    if let ExprKind::Index(arr, idx) = &base.kind {
+                        if let ExprKind::Ident(arr_name) = &arr.kind {
+                            let is_literal = matches!(&idx.kind,
+                                ExprKind::Literal(LitKind::Dec(_)) |
+                                ExprKind::Literal(LitKind::Hex(_)) |
+                                ExprKind::Literal(LitKind::Bin(_)) |
+                                ExprKind::Literal(LitKind::Sized(..)));
+                            if !is_literal {
+                                if let Some(&n) = self.vec_of_bus_ports.get(arr_name) {
+                                    for i in 0..n {
+                                        driven.insert(format!("{}_{}_{}", arr_name, i, field.name));
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
 
                 let rhs_ty = self.resolve_expr_type(&a.value, module_name, local_types);
                 let is_indexed = !matches!(&a.target.kind, ExprKind::Ident(_));

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -4001,6 +4001,304 @@ fn test_bus_wire_typechecks_and_codegens() {
 }
 
 #[test]
+fn test_vec_of_bus_port_flattens_to_n_indexed_copies() {
+    // `port chans: initiator Vec<BusName, N>;` declares N copies of the bus
+    // on the module signature. SV codegen emits `chans_0_<sig>`, `chans_1_<sig>`,
+    // ..., `chans_{N-1}_<sig>` (N copies × #signals each), and inst-site
+    // bracket-dot indexing `chans[i].sig` resolves to the i-th copy.
+    let source = "
+        bus B
+          v: out Bool;
+          r: in  Bool;
+          d: out UInt<8>;
+        end bus B
+
+        module Prod
+          port clk: in Clock<SysDomain>;
+          port chans: initiator Vec<B, 3>;
+          comb
+            chans[0].v = true;
+            chans[0].d = 8'h11;
+            chans[1].v = false;
+            chans[1].d = 8'h22;
+            chans[2].v = true;
+            chans[2].d = 8'h33;
+          end comb
+        end module Prod
+    ";
+    let sv = compile_to_sv(source);
+    // All N copies appear on the module signature, each carrying every signal.
+    for i in 0..3 {
+        assert!(sv.contains(&format!("output logic chans_{i}_v")),
+                "missing `output logic chans_{i}_v` in SV:\n{sv}");
+        assert!(sv.contains(&format!("input logic chans_{i}_r")),
+                "missing `input logic chans_{i}_r` in SV:\n{sv}");
+        assert!(sv.contains(&format!("output logic [7:0] chans_{i}_d")),
+                "missing `output logic [7:0] chans_{i}_d` in SV:\n{sv}");
+    }
+    // Bracket-dot access resolves to the indexed flat name.
+    assert!(sv.contains("chans_0_v = 1'b1") || sv.contains("assign chans_0_v = 1'b1"),
+            "expected `chans_0_v` assignment in SV:\n{sv}");
+    assert!(sv.contains("chans_1_v = 1'b0") || sv.contains("assign chans_1_v = 1'b0"),
+            "expected `chans_1_v` assignment in SV:\n{sv}");
+    assert!(sv.contains("chans_2_d = 8'd51") || sv.contains("assign chans_2_d = 8'd51"),
+            "expected `chans_2_d = 8'd51` assignment in SV:\n{sv}");
+}
+
+#[test]
+fn test_vec_of_bus_port_rejects_zero_count_and_non_literal() {
+    // MVP restriction: count must be a positive integer literal.
+    let src_zero = r#"
+        bus B
+          v: out Bool;
+        end bus B
+        module M
+          port chans: initiator Vec<B, 0>;
+        end module M
+    "#;
+    let tokens = arch::lexer::tokenize(src_zero).expect("lex");
+    let mut parser = arch::parser::Parser::new(tokens, src_zero);
+    let err = parser.parse_source_file().expect_err("Vec<B, 0> should fail to parse");
+    assert!(format!("{err:?}").contains("N must be >= 1"),
+            "expected `N must be >= 1` diagnostic, got: {err:?}");
+
+    let src_param = r#"
+        bus B
+          v: out Bool;
+        end bus B
+        module M
+          param N: const = 4;
+          port chans: initiator Vec<B, N>;
+        end module M
+    "#;
+    let tokens = arch::lexer::tokenize(src_param).expect("lex");
+    let mut parser = arch::parser::Parser::new(tokens, src_param);
+    let err = parser.parse_source_file().expect_err("Vec<B, N> with non-literal N should fail");
+    assert!(format!("{err:?}").contains("compile-time integer literal"),
+            "expected literal-only diagnostic, got: {err:?}");
+}
+
+#[test]
+fn test_vec_of_bus_port_typecheck_drives_all_indexed_outputs() {
+    // The driver-completeness check expands a Vec<Bus,N> port into N copies
+    // and demands every output signal of every copy be driven. Forgetting
+    // an index = compile error.
+    let src_missing = r#"
+        bus B
+          v: out Bool;
+        end bus B
+        module M
+          port chans: initiator Vec<B, 2>;
+          comb
+            chans[0].v = true;
+            // chans[1].v intentionally undriven
+          end comb
+        end module M
+    "#;
+    let tokens = arch::lexer::tokenize(src_missing).expect("lex");
+    let mut parser = arch::parser::Parser::new(tokens, src_missing);
+    let ast = parser.parse_source_file().expect("parse");
+    let symbols = arch::resolve::resolve(&ast).expect("resolve");
+    let result = arch::typecheck::TypeChecker::new(&symbols, &ast).check();
+    let errs = result.expect_err("missing index drive should error");
+    let msg = errs.iter().map(|e| format!("{e:?}")).collect::<String>();
+    // Diagnostic Display = "output port `chans_1_v` is not driven";
+    // Debug = `UndriveOutput { name: "chans_1_v", ... }`. Accept either.
+    assert!(msg.contains("chans_1_v") && (msg.contains("not driven") || msg.contains("UndriveOutput")),
+            "expected `chans_1_v not driven` diagnostic, got: {msg}");
+}
+
+#[test]
+fn test_vec_of_bus_for_loop_static_unroll() {
+    // `chans[i].sig = ...;` inside `for i in 0..N-1` over a `Vec<Bus, N>`
+    // port has no SV-level array (the signature exposes only the flattened
+    // `<port>_<i>_<sig>` names). The codegen statically unrolls the loop
+    // when its bounds are literal, binding the loop variable to each
+    // iteration value so the body becomes N straight-line per-element
+    // assignments.
+    let source = "
+        bus B
+          v: out Bool;
+          d: out UInt<8>;
+        end bus B
+        module M
+          port chans: initiator Vec<B, 4>;
+          port idx: in UInt<8>;
+          comb
+            for i in 0..3
+              chans[i].v = true;
+              chans[i].d = (idx + i).trunc<8>();
+            end for
+          end comb
+        end module M
+    ";
+    let sv = compile_to_sv(source);
+    // The loop should be statically unrolled: no behavioral `for (int i ...`,
+    // and per-element flat assignments for each index.
+    assert!(!sv.contains("for (int i ="),
+            "expected for-loop to be statically unrolled (no behavioral SV for-loop):\n{sv}");
+    for i in 0..4 {
+        assert!(sv.contains(&format!("chans_{i}_v = 1'b1")),
+                "missing unrolled `chans_{i}_v = 1'b1`:\n{sv}");
+        // RHS must reference the literal i (not the loop variable).
+        assert!(sv.contains(&format!("chans_{i}_d = 8'(idx + {i})"))
+                || sv.contains(&format!("chans_{i}_d = 8'((idx + {i}))")),
+                "missing unrolled `chans_{i}_d = 8'(idx + {i})`:\n{sv}");
+    }
+}
+
+#[test]
+fn test_vec_of_bus_wire_flattens_to_n_indexed_signals() {
+    // `wire w: Vec<BusName, N>;` is type-expression composition over the
+    // existing `wire X: BusName;` form. SV codegen emits N flat
+    // `w_0_<sig>`, ..., `w_{N-1}_<sig>` and `w[i].sig` access resolves
+    // to the corresponding flat name. No new construct.
+    let source = "
+        bus B
+          v: out Bool;
+          d: out UInt<8>;
+        end bus B
+
+        module M
+          port o_v0: out Bool;
+          port o_d1: out UInt<8>;
+          wire w: Vec<B, 2>;
+          comb
+            w[0].v = true;  w[0].d = 8'h11;
+            w[1].v = false; w[1].d = 8'h22;
+            o_v0 = w[0].v;
+            o_d1 = w[1].d;
+          end comb
+        end module M
+    ";
+    let sv = compile_to_sv(source);
+    // The wire becomes N flat per-signal declarations.
+    for (i, expected_d) in [(0u32, "8'd17"), (1u32, "8'd34")] {
+        assert!(sv.contains(&format!("logic w_{i}_v;")),
+                "missing `logic w_{i}_v;` in SV:\n{sv}");
+        assert!(sv.contains(&format!("logic [7:0] w_{i}_d;")),
+                "missing `logic [7:0] w_{i}_d;` in SV:\n{sv}");
+        assert!(sv.contains(&format!("w_{i}_d = {expected_d}")),
+                "missing `w_{i}_d = {expected_d}` assignment in SV:\n{sv}");
+    }
+    // Reading uses the same flat names.
+    assert!(sv.contains("o_v0 = w_0_v"),
+            "expected `o_v0 = w_0_v` in SV:\n{sv}");
+    assert!(sv.contains("o_d1 = w_1_d"),
+            "expected `o_d1 = w_1_d` in SV:\n{sv}");
+}
+
+#[test]
+fn test_vec_of_bus_wire_carries_inst_output_through_indexed_connection() {
+    // The producer drives a `Vec<B, N>` port; the parent declares a
+    // `Vec<B, N>` wire and connects each element via `chans[i] -> w[i];`.
+    // SV codegen must emit per-signal named-port connections with
+    // `w_<i>_<sig>` on the parent side, and downstream reads on `w[i].sig`
+    // must hit those same flat signals.
+    let source = "
+        bus B
+          v: out Bool;
+          d: out UInt<8>;
+        end bus B
+
+        module Producer
+          port clk: in Clock<SysDomain>;
+          port chans: initiator Vec<B, 2>;
+          comb
+            chans[0].v = true;  chans[0].d = 8'hAA;
+            chans[1].v = true;  chans[1].d = 8'h55;
+          end comb
+        end module Producer
+
+        module Parent
+          port clk:   in  Clock<SysDomain>;
+          port o_v0:  out Bool;
+          port o_d1:  out UInt<8>;
+          wire w: Vec<B, 2>;
+          inst p: Producer
+            clk <- clk;
+            chans[0] -> w[0];
+            chans[1] -> w[1];
+          end inst p
+          comb
+            o_v0 = w[0].v;
+            o_d1 = w[1].d;
+          end comb
+        end module Parent
+    ";
+    let sv = compile_to_sv(source);
+    // The Vec-of-bus wire flattens to per-index per-signal storage.
+    for i in 0..2 {
+        assert!(sv.contains(&format!("logic w_{i}_v;")),
+                "missing `logic w_{i}_v;` in Parent SV:\n{sv}");
+    }
+    // The Producer instance's bus port elements connect via per-signal
+    // named ports against those flat wire signals.
+    assert!(sv.contains(".chans_0_v(w_0_v)") || sv.contains(".chans_0_v (w_0_v)"),
+            "expected `.chans_0_v(w_0_v)` named-port connection in SV:\n{sv}");
+    assert!(sv.contains(".chans_1_d(w_1_d)") || sv.contains(".chans_1_d (w_1_d)"),
+            "expected `.chans_1_d(w_1_d)` named-port connection in SV:\n{sv}");
+    // The downstream reads land on the same flat names.
+    assert!(sv.contains("o_v0 = w_0_v"),
+            "expected `o_v0 = w_0_v` in SV:\n{sv}");
+    assert!(sv.contains("o_d1 = w_1_d"),
+            "expected `o_d1 = w_1_d` in SV:\n{sv}");
+}
+
+#[test]
+fn test_vec_of_bus_inst_connection_uses_bracket_index_syntax() {
+    // Parent instantiates a Child whose port is `Vec<B, N>`. Each index is
+    // connected via the bracket form `chans[i] -> wire;`, matching the
+    // declaration `Vec<_, N>` and the expression form `chans[i].sig`. The
+    // codegen expands to per-signal named-port connections in SV.
+    let source = "
+        bus B
+          v: out Bool;
+          d: out UInt<8>;
+        end bus B
+
+        module Child
+          port clk: in Clock<SysDomain>;
+          port chans: initiator Vec<B, 2>;
+          comb
+            chans[0].v = true;  chans[0].d = 8'hAA;
+            chans[1].v = false; chans[1].d = 8'h55;
+          end comb
+        end module Child
+
+        module Parent
+          port clk: in Clock<SysDomain>;
+          port out_v0: out Bool;
+          port out_d1: out UInt<8>;
+          wire w0: B;
+          wire w1: B;
+          inst c: Child
+            clk <- clk;
+            chans[0] -> w0;
+            chans[1] -> w1;
+          end inst c
+          comb
+            out_v0 = w0.v;
+            out_d1 = w1.d;
+          end comb
+        end module Parent
+    ";
+    let sv = compile_to_sv(source);
+    // Child has 4 flat ports for the Vec<B,2>.
+    for i in 0..2 {
+        assert!(sv.contains(&format!("output logic chans_{i}_v")),
+                "child should expose chans_{i}_v:\n{sv}");
+        assert!(sv.contains(&format!("output logic [7:0] chans_{i}_d")),
+                "child should expose chans_{i}_d:\n{sv}");
+    }
+    // Parent's inst connects each index by its underscore-suffixed name.
+    assert!(sv.contains(".chans_0_v(w0_v)") || sv.contains(".chans_0_v (w0_v)"),
+            "expected `.chans_0_v(w0_v)` named-port connection in SV:\n{sv}");
+    assert!(sv.contains(".chans_1_d(w1_d)") || sv.contains(".chans_1_d (w1_d)"),
+            "expected `.chans_1_d(w1_d)` named-port connection in SV:\n{sv}");
+}
+
+#[test]
 fn test_bus_wire_sv_flattens_to_individual_signals() {
     // SV codegen has no bus interface/struct: a bus-typed wire becomes N
     // individual SV wires named `<wire>_<field>`. Field access on the

--- a/tests/nic400/BusAxi4.arch
+++ b/tests/nic400/BusAxi4.arch
@@ -1,0 +1,64 @@
+// AXI4-full bus with sideband signals (lock/cache/prot/qos/region) for the
+// NIC-400 interconnect. Same shape as tests/axi_dma_thread/BusAxi4.arch with
+// AXI4 sideband added on AR and AW.
+bus BusAxi4
+  param ADDR_W: const = 32;
+  param DATA_W: const = 32;
+  param STRB_W: const = 4;                   // = DATA_W/8 caller-set
+  param ID_W:   const = 1;
+  param READ:   const = 1;
+  param WRITE:  const = 1;
+
+  generate_if READ
+    // Read address channel
+    ar_valid:  out Bool;
+    ar_ready:  in  Bool;
+    ar_addr:   out UInt<ADDR_W>;
+    ar_id:     out UInt<ID_W>;
+    ar_len:    out UInt<8>;
+    ar_size:   out UInt<3>;
+    ar_burst:  out UInt<2>;
+    ar_lock:   out Bool;
+    ar_cache:  out UInt<4>;
+    ar_prot:   out UInt<3>;
+    ar_qos:    out UInt<4>;
+    ar_region: out UInt<4>;
+
+    // Read data channel
+    r_valid:   in  Bool;
+    r_ready:   out Bool;
+    r_data:    in  UInt<DATA_W>;
+    r_id:      in  UInt<ID_W>;
+    r_resp:    in  UInt<2>;
+    r_last:    in  Bool;
+  end generate_if
+
+  generate_if WRITE
+    // Write address channel
+    aw_valid:  out Bool;
+    aw_ready:  in  Bool;
+    aw_addr:   out UInt<ADDR_W>;
+    aw_id:     out UInt<ID_W>;
+    aw_len:    out UInt<8>;
+    aw_size:   out UInt<3>;
+    aw_burst:  out UInt<2>;
+    aw_lock:   out Bool;
+    aw_cache:  out UInt<4>;
+    aw_prot:   out UInt<3>;
+    aw_qos:    out UInt<4>;
+    aw_region: out UInt<4>;
+
+    // Write data channel
+    w_valid:   out Bool;
+    w_ready:   in  Bool;
+    w_data:    out UInt<DATA_W>;
+    w_strb:    out UInt<STRB_W>;
+    w_last:    out Bool;
+
+    // Write response channel
+    b_valid:   in  Bool;
+    b_ready:   out Bool;
+    b_id:      in  UInt<ID_W>;
+    b_resp:    in  UInt<2>;
+  end generate_if
+end bus BusAxi4

--- a/tests/nic400/Nic400ArbiterPolicy.arch
+++ b/tests/nic400/Nic400ArbiterPolicy.arch
@@ -1,0 +1,66 @@
+// QoS-aware round-robin arbiter for the NIC-400 slave port.
+//
+// Selects the highest-QoS requester; among ties at the top QoS, uses
+// round-robin against last_grant to ensure fairness. Pure-comb hook.
+//
+// Sized for NUM_MASTERS = 4 (one-hot req mask = UInt<4>, qos = UInt<4> each).
+// Per-master qos passed in as a packed UInt<16> (4 * 4 bits, qos_m0 in low nibble).
+
+function nic400_qos_pick(req_mask: UInt<4>,
+                         last_grant: UInt<4>,
+                         qos_packed: UInt<16>) -> UInt<4>
+  // Extract per-master qos
+  let q0: UInt<4> = qos_packed[3:0];
+  let q1: UInt<4> = qos_packed[7:4];
+  let q2: UInt<4> = qos_packed[11:8];
+  let q3: UInt<4> = qos_packed[15:12];
+
+  // Find the max QoS among requesters (zero for non-requesters).
+  let q0_eff: UInt<4> = req_mask[0] ? q0 : 0;
+  let q1_eff: UInt<4> = req_mask[1] ? q1 : 0;
+  let q2_eff: UInt<4> = req_mask[2] ? q2 : 0;
+  let q3_eff: UInt<4> = req_mask[3] ? q3 : 0;
+
+  let m01: UInt<4> = q0_eff > q1_eff ? q0_eff : q1_eff;
+  let m23: UInt<4> = q2_eff > q3_eff ? q2_eff : q3_eff;
+  let max_qos: UInt<4> = m01 > m23 ? m01 : m23;
+
+  // Mask of requesters at the top QoS (each branch yields a UInt<4> bit).
+  let top_mask: UInt<4> = ((req_mask[0] and q0 == max_qos ? 4'd1 : 4'd0))
+                        | ((req_mask[1] and q1 == max_qos ? 4'd2 : 4'd0))
+                        | ((req_mask[2] and q2 == max_qos ? 4'd4 : 4'd0))
+                        | ((req_mask[3] and q3 == max_qos ? 4'd8 : 4'd0));
+
+  // mask_above(last_grant): bits with index strictly greater than the
+  // single set bit of last_grant. For one-hot last_grant in {1,2,4,8}.
+  let above_mask: UInt<4> = (last_grant == 4'd1 ? 4'd14
+                          : (last_grant == 4'd2 ? 4'd12
+                          : (last_grant == 4'd4 ? 4'd8
+                          : (last_grant == 4'd8 ? 4'd0
+                          : 4'd15))));
+
+  let primary: UInt<4> = top_mask & above_mask;
+  let pick: UInt<4> = primary != 0 ? primary : top_mask;
+
+  // Isolate lowest set bit: pick & (-pick), using 4-bit two's complement.
+  let pick_neg: UInt<5> = (pick ^ 15).zext<5>() + 1;
+  return pick & pick_neg.trunc<4>();
+end function nic400_qos_pick
+
+// Top-level 4-requester arbiter wrapping the QoS pick function.
+// Designed for instantiation per-slave (one AW arbiter, one AR arbiter).
+arbiter Nic400QosArbiter
+  policy nic400_qos_pick;
+  param N: const = 4;
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Async, Low>;
+  ports[N] req
+    valid: in Bool;
+    ready: out Bool;
+  end ports req
+  port qos_packed: in UInt<16>;             // qos vector for all 4 requesters
+  port grant_valid:     out Bool;
+  port grant_requester: out UInt<2>;
+  hook grant_select(req_mask: UInt<4>, last_grant: UInt<4>, qos_vec: UInt<16>) -> UInt<4>
+    = nic400_qos_pick(req_mask, last_grant, qos_packed);
+end arbiter Nic400QosArbiter

--- a/tests/nic400/Nic400QosFn.arch
+++ b/tests/nic400/Nic400QosFn.arch
@@ -1,0 +1,51 @@
+// Pure-comb wrapper around nic400_qos_pick so the function can be exercised
+// directly from a testbench without needing the full arbiter handshake.
+//
+// This module duplicates the body of nic400_qos_pick because module-local
+// functions cannot reference top-level functions from sibling files; making
+// the policy logic live inside the module here lets unit tests pin every
+// behavior of the QoS pick algorithm against synthetic inputs.
+module Nic400QosFn
+  port req_mask:   in  UInt<4>;
+  port last_grant: in  UInt<4>;
+  port qos_packed: in  UInt<16>;
+  port grant:      out UInt<4>;
+
+  function pick(req_mask:   UInt<4>,
+                last_grant: UInt<4>,
+                qos_packed: UInt<16>) -> UInt<4>
+    let q0: UInt<4> = qos_packed[3:0];
+    let q1: UInt<4> = qos_packed[7:4];
+    let q2: UInt<4> = qos_packed[11:8];
+    let q3: UInt<4> = qos_packed[15:12];
+
+    let q0_eff: UInt<4> = req_mask[0] ? q0 : 4'd0;
+    let q1_eff: UInt<4> = req_mask[1] ? q1 : 4'd0;
+    let q2_eff: UInt<4> = req_mask[2] ? q2 : 4'd0;
+    let q3_eff: UInt<4> = req_mask[3] ? q3 : 4'd0;
+
+    let m01: UInt<4> = q0_eff > q1_eff ? q0_eff : q1_eff;
+    let m23: UInt<4> = q2_eff > q3_eff ? q2_eff : q3_eff;
+    let max_qos: UInt<4> = m01 > m23 ? m01 : m23;
+
+    let top_mask: UInt<4> = ((req_mask[0] and q0 == max_qos ? 4'd1 : 4'd0))
+                          | ((req_mask[1] and q1 == max_qos ? 4'd2 : 4'd0))
+                          | ((req_mask[2] and q2 == max_qos ? 4'd4 : 4'd0))
+                          | ((req_mask[3] and q3 == max_qos ? 4'd8 : 4'd0));
+
+    let above_mask: UInt<4> = (last_grant == 4'd1 ? 4'd14
+                            : (last_grant == 4'd2 ? 4'd12
+                            : (last_grant == 4'd4 ? 4'd8
+                            : (last_grant == 4'd8 ? 4'd0
+                            : 4'd15))));
+
+    let primary: UInt<4> = top_mask & above_mask;
+    let pick_set: UInt<4> = primary != 0 ? primary : top_mask;
+    let pick_neg: UInt<5> = (pick_set ^ 4'd15).zext<5>() + 1;
+    return pick_set & pick_neg.trunc<4>();
+  end function pick
+
+  comb
+    grant = pick(req_mask, last_grant, qos_packed);
+  end comb
+end module Nic400QosFn

--- a/tests/nic400/Nic400QosFn_test.harc
+++ b/tests/nic400/Nic400QosFn_test.harc
@@ -1,0 +1,77 @@
+// HARC unit test for the NIC-400 QoS arbitration pick function.
+//
+// All cases assume 4 masters indexed 0..3. qos_packed layout:
+//   bits [3:0]   = qos[m0]
+//   bits [7:4]   = qos[m1]
+//   bits [11:8]  = qos[m2]
+//   bits [15:12] = qos[m3]
+// last_grant is the one-hot of the previous winner (1<<idx).
+// grant is one-hot mask of the chosen requester.
+
+testbench Nic400QosFnTb
+    dut : Nic400QosFn
+end testbench Nic400QosFnTb
+
+impl Nic400QosFnHarcTest for Nic400QosFnTb
+    run
+        log(info, "Nic400QosFn HARC test")
+
+        // 1. No requesters -> grant = 0
+        dut.req_mask = 0
+        dut.last_grant = 0
+        dut.qos_packed = 0x3210
+        wait 1 cycle
+        assert dut.grant == 0
+            else fail("empty req: grant=0x${dut.grant:x}")
+
+        // 2. Single requester (m1), qos=0 -> grant = 0b0010
+        dut.req_mask = 0b0010
+        dut.last_grant = 0
+        dut.qos_packed = 0
+        wait 1 cycle
+        assert dut.grant == 0b0010
+            else fail("single req m1: grant=0x${dut.grant:x}")
+
+        // 3. Two requesters, m0=qos3, m2=qos5 -> m2 wins (higher QoS)
+        dut.req_mask = 0b0101
+        dut.last_grant = 0
+        dut.qos_packed = 0x0503   // m3=0, m2=5, m1=0, m0=3
+        wait 1 cycle
+        assert dut.grant == 0b0100
+            else fail("qos pick: grant=0x${dut.grant:x}, expected 0b0100")
+
+        // 4. All four equal qos=2, last_grant=m0 -> next higher index (m1) wins
+        dut.req_mask = 0b1111
+        dut.last_grant = 0b0001
+        dut.qos_packed = 0x2222
+        wait 1 cycle
+        assert dut.grant == 0b0010
+            else fail("rr after m0: grant=0x${dut.grant:x}, expected 0b0010")
+
+        // 5. All four equal qos=2, last_grant=m3 -> wrap to m0
+        dut.req_mask = 0b1111
+        dut.last_grant = 0b1000
+        dut.qos_packed = 0x2222
+        wait 1 cycle
+        assert dut.grant == 0b0001
+            else fail("rr wrap: grant=0x${dut.grant:x}, expected 0b0001")
+
+        // 6. m0 and m2 tied at top qos=7, others lower; last_grant=m0 -> m2
+        dut.req_mask = 0b0101
+        dut.last_grant = 0b0001
+        dut.qos_packed = 0x0707
+        wait 1 cycle
+        assert dut.grant == 0b0100
+            else fail("tied top rr: grant=0x${dut.grant:x}, expected 0b0100")
+
+        // 7. m0,m1,m2,m3 with qos 1,3,1,3; last_grant=m1 -> m3 wins (rr among top)
+        dut.req_mask = 0b1111
+        dut.last_grant = 0b0010
+        dut.qos_packed = 0x3131    // m3=3, m2=1, m1=3, m0=1
+        wait 1 cycle
+        assert dut.grant == 0b1000
+            else fail("4-way tied top rr: grant=0x${dut.grant:x}, expected 0b1000")
+
+        log(info, "PASS: Nic400QosFn — empty, single, qos-pick, rr-fairness, tied-top all OK")
+    end run
+end impl Nic400QosFnHarcTest

--- a/tests/nic400/Nic400Read2x2.arch
+++ b/tests/nic400/Nic400Read2x2.arch
@@ -1,0 +1,266 @@
+// Minimal NIC-400-style AXI4 READ crossbar: 2 masters x 2 slaves.
+//
+// Demonstrates the four core mechanisms from the NIC-400 spec:
+//   1. Per-master address decode  — picks slave 0 or 1 based on addr[28].
+//   2. Per-slave arbitration       — resource: mutex<round_robin> serializes
+//      M masters onto one slave's AR bus.
+//   3. ID remap                    — slave_id = {master_idx (1 bit), master_id (3 bit)}.
+//   4. Return route by ID prefix   — R channel demux uses r_id[3] (master idx);
+//      shared(or) merges N slave-sourced R streams onto the master's R port.
+//
+// All threads use the canonical `default comb` + `do..until` pattern so
+// signal drives revert cleanly between transactions.
+module Nic400Read2x2
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Async, Low>;
+
+  // ── Master 0 (target side) ───────────────────────────────────────────
+  port m0_ar_valid:  in  Bool;
+  port m0_ar_ready:  out Bool shared(or);
+  port m0_ar_addr:   in  UInt<32>;
+  port m0_ar_id:     in  UInt<3>;
+  port m0_ar_len:    in  UInt<8>;
+  port m0_ar_size:   in  UInt<3>;
+  port m0_ar_burst:  in  UInt<2>;
+
+  port m0_r_valid:   out Bool shared(or);
+  port m0_r_ready:   in  Bool;
+  port m0_r_data:    out UInt<32> shared(or);
+  port m0_r_id:      out UInt<3> shared(or);
+  port m0_r_resp:    out UInt<2> shared(or);
+  port m0_r_last:    out Bool shared(or);
+
+  // ── Master 1 (target side) ───────────────────────────────────────────
+  port m1_ar_valid:  in  Bool;
+  port m1_ar_ready:  out Bool shared(or);
+  port m1_ar_addr:   in  UInt<32>;
+  port m1_ar_id:     in  UInt<3>;
+  port m1_ar_len:    in  UInt<8>;
+  port m1_ar_size:   in  UInt<3>;
+  port m1_ar_burst:  in  UInt<2>;
+
+  port m1_r_valid:   out Bool shared(or);
+  port m1_r_ready:   in  Bool;
+  port m1_r_data:    out UInt<32> shared(or);
+  port m1_r_id:      out UInt<3> shared(or);
+  port m1_r_resp:    out UInt<2> shared(or);
+  port m1_r_last:    out Bool shared(or);
+
+  // ── Slave 0 (initiator side) ─────────────────────────────────────────
+  port s0_ar_valid:  out Bool shared(or);
+  port s0_ar_ready:  in  Bool;
+  port s0_ar_addr:   out UInt<32> shared(or);
+  port s0_ar_id:     out UInt<4> shared(or);
+  port s0_ar_len:    out UInt<8> shared(or);
+  port s0_ar_size:   out UInt<3> shared(or);
+  port s0_ar_burst:  out UInt<2> shared(or);
+
+  port s0_r_valid:   in  Bool;
+  port s0_r_ready:   out Bool shared(or);
+  port s0_r_data:    in  UInt<32>;
+  port s0_r_id:      in  UInt<4>;
+  port s0_r_resp:    in  UInt<2>;
+  port s0_r_last:    in  Bool;
+
+  // ── Slave 1 (initiator side) ─────────────────────────────────────────
+  port s1_ar_valid:  out Bool shared(or);
+  port s1_ar_ready:  in  Bool;
+  port s1_ar_addr:   out UInt<32> shared(or);
+  port s1_ar_id:     out UInt<4> shared(or);
+  port s1_ar_len:    out UInt<8> shared(or);
+  port s1_ar_size:   out UInt<3> shared(or);
+  port s1_ar_burst:  out UInt<2> shared(or);
+
+  port s1_r_valid:   in  Bool;
+  port s1_r_ready:   out Bool shared(or);
+  port s1_r_data:    in  UInt<32>;
+  port s1_r_id:      in  UInt<4>;
+  port s1_r_resp:    in  UInt<2>;
+  port s1_r_last:    in  Bool;
+
+  // Address decode: bit [28] picks slave (region size 256 MiB).
+  let m0_ar_slv: UInt<1> = m0_ar_addr[28];
+  let m1_ar_slv: UInt<1> = m1_ar_addr[28];
+
+  // Per-slave AR arbiters (round-robin across the 2 masters).
+  resource s0_ar_ch: mutex<round_robin>;
+  resource s1_ar_ch: mutex<round_robin>;
+
+  // ── AR forwarding threads — one per (master, slave) pair ───────────────
+  thread M0Ar_S0 on clk rising, rst low
+    default comb
+      s0_ar_valid = false;
+      s0_ar_addr  = 0;
+      s0_ar_id    = 0;
+      s0_ar_len   = 0;
+      s0_ar_size  = 0;
+      s0_ar_burst = 0;
+      m0_ar_ready = false;
+    end default
+    wait until m0_ar_valid and m0_ar_slv == 1'd0;
+    lock s0_ar_ch
+      do
+        s0_ar_valid = true;
+        s0_ar_addr  = m0_ar_addr;
+        s0_ar_id    = {1'b0, m0_ar_id};
+        s0_ar_len   = m0_ar_len;
+        s0_ar_size  = m0_ar_size;
+        s0_ar_burst = m0_ar_burst;
+        m0_ar_ready = s0_ar_ready;
+      until s0_ar_ready;
+    end lock s0_ar_ch
+  end thread M0Ar_S0
+
+  thread M0Ar_S1 on clk rising, rst low
+    default comb
+      s1_ar_valid = false;
+      s1_ar_addr  = 0;
+      s1_ar_id    = 0;
+      s1_ar_len   = 0;
+      s1_ar_size  = 0;
+      s1_ar_burst = 0;
+      m0_ar_ready = false;
+    end default
+    wait until m0_ar_valid and m0_ar_slv == 1'd1;
+    lock s1_ar_ch
+      do
+        s1_ar_valid = true;
+        s1_ar_addr  = m0_ar_addr;
+        s1_ar_id    = {1'b0, m0_ar_id};
+        s1_ar_len   = m0_ar_len;
+        s1_ar_size  = m0_ar_size;
+        s1_ar_burst = m0_ar_burst;
+        m0_ar_ready = s1_ar_ready;
+      until s1_ar_ready;
+    end lock s1_ar_ch
+  end thread M0Ar_S1
+
+  thread M1Ar_S0 on clk rising, rst low
+    default comb
+      s0_ar_valid = false;
+      s0_ar_addr  = 0;
+      s0_ar_id    = 0;
+      s0_ar_len   = 0;
+      s0_ar_size  = 0;
+      s0_ar_burst = 0;
+      m1_ar_ready = false;
+    end default
+    wait until m1_ar_valid and m1_ar_slv == 1'd0;
+    lock s0_ar_ch
+      do
+        s0_ar_valid = true;
+        s0_ar_addr  = m1_ar_addr;
+        s0_ar_id    = {1'b1, m1_ar_id};
+        s0_ar_len   = m1_ar_len;
+        s0_ar_size  = m1_ar_size;
+        s0_ar_burst = m1_ar_burst;
+        m1_ar_ready = s0_ar_ready;
+      until s0_ar_ready;
+    end lock s0_ar_ch
+  end thread M1Ar_S0
+
+  thread M1Ar_S1 on clk rising, rst low
+    default comb
+      s1_ar_valid = false;
+      s1_ar_addr  = 0;
+      s1_ar_id    = 0;
+      s1_ar_len   = 0;
+      s1_ar_size  = 0;
+      s1_ar_burst = 0;
+      m1_ar_ready = false;
+    end default
+    wait until m1_ar_valid and m1_ar_slv == 1'd1;
+    lock s1_ar_ch
+      do
+        s1_ar_valid = true;
+        s1_ar_addr  = m1_ar_addr;
+        s1_ar_id    = {1'b1, m1_ar_id};
+        s1_ar_len   = m1_ar_len;
+        s1_ar_size  = m1_ar_size;
+        s1_ar_burst = m1_ar_burst;
+        m1_ar_ready = s1_ar_ready;
+      until s1_ar_ready;
+    end lock s1_ar_ch
+  end thread M1Ar_S1
+
+  // ── R return threads — shared(or) merge per master ──────────────────────
+  thread S0R_M0 on clk rising, rst low
+    default comb
+      m0_r_valid = false;
+      m0_r_data  = 0;
+      m0_r_id    = 0;
+      m0_r_resp  = 0;
+      m0_r_last  = false;
+      s0_r_ready = false;
+    end default
+    wait until s0_r_valid and s0_r_id[3] == 1'd0;
+    do
+      m0_r_valid = true;
+      m0_r_data  = s0_r_data;
+      m0_r_id    = s0_r_id[2:0];
+      m0_r_resp  = s0_r_resp;
+      m0_r_last  = s0_r_last;
+      s0_r_ready = m0_r_ready;
+    until m0_r_ready;
+  end thread S0R_M0
+
+  thread S0R_M1 on clk rising, rst low
+    default comb
+      m1_r_valid = false;
+      m1_r_data  = 0;
+      m1_r_id    = 0;
+      m1_r_resp  = 0;
+      m1_r_last  = false;
+      s0_r_ready = false;
+    end default
+    wait until s0_r_valid and s0_r_id[3] == 1'd1;
+    do
+      m1_r_valid = true;
+      m1_r_data  = s0_r_data;
+      m1_r_id    = s0_r_id[2:0];
+      m1_r_resp  = s0_r_resp;
+      m1_r_last  = s0_r_last;
+      s0_r_ready = m1_r_ready;
+    until m1_r_ready;
+  end thread S0R_M1
+
+  thread S1R_M0 on clk rising, rst low
+    default comb
+      m0_r_valid = false;
+      m0_r_data  = 0;
+      m0_r_id    = 0;
+      m0_r_resp  = 0;
+      m0_r_last  = false;
+      s1_r_ready = false;
+    end default
+    wait until s1_r_valid and s1_r_id[3] == 1'd0;
+    do
+      m0_r_valid = true;
+      m0_r_data  = s1_r_data;
+      m0_r_id    = s1_r_id[2:0];
+      m0_r_resp  = s1_r_resp;
+      m0_r_last  = s1_r_last;
+      s1_r_ready = m0_r_ready;
+    until m0_r_ready;
+  end thread S1R_M0
+
+  thread S1R_M1 on clk rising, rst low
+    default comb
+      m1_r_valid = false;
+      m1_r_data  = 0;
+      m1_r_id    = 0;
+      m1_r_resp  = 0;
+      m1_r_last  = false;
+      s1_r_ready = false;
+    end default
+    wait until s1_r_valid and s1_r_id[3] == 1'd1;
+    do
+      m1_r_valid = true;
+      m1_r_data  = s1_r_data;
+      m1_r_id    = s1_r_id[2:0];
+      m1_r_resp  = s1_r_resp;
+      m1_r_last  = s1_r_last;
+      s1_r_ready = m1_r_ready;
+    until m1_r_ready;
+  end thread S1R_M1
+end module Nic400Read2x2

--- a/tests/nic400/Nic400Read2x2_smoke.harc
+++ b/tests/nic400/Nic400Read2x2_smoke.harc
@@ -1,0 +1,145 @@
+// HARC sequence-layer testbench: NIC-400 2x2 read crossbar smoke test.
+//
+// Covers verification-plan §15 items 1 (smoke) and 4 (ID remap correctness):
+//   - M0 issues AR with bit[28]=0 → expect S0 sees AR with id={1'b0, m0_id}.
+//   - M0 issues AR with bit[28]=1 → expect S1 path, ID prefix=0.
+//   - M1 issues AR → expect ID prefix=1 (= 1<<3 OR master_id).
+//   - Each R response with prefixed ID demuxes back to the originating master,
+//     stripped to master_id (3 LSBs).
+//
+// Companion C++ runner: tb_nic400_read2x2_smoke.cpp (mirrors these assertions).
+testbench Nic400Read2x2SmokeTb
+    dut : Nic400Read2x2
+end testbench Nic400Read2x2SmokeTb
+
+impl Nic400Read2x2Smoke for Nic400Read2x2SmokeTb
+    run
+        log(info, "Nic400Read2x2 smoke (HARC source-of-truth)")
+
+        // Reset (active-low)
+        dut.rst = 0
+        dut.m0_ar_valid = 0
+        dut.m1_ar_valid = 0
+        dut.s0_ar_ready = 0
+        dut.s1_ar_ready = 0
+        dut.s0_r_valid = 0
+        dut.s1_r_valid = 0
+        dut.m0_r_ready = 0
+        dut.m1_r_ready = 0
+        wait 4 cycles
+        dut.rst = 1
+        wait 1 cycle
+
+        // ─── Test 1: M0 → S0 ────────────────────────────────────────────
+        dut.m0_ar_valid = 1
+        dut.m0_ar_addr  = 0x00001000
+        dut.m0_ar_id    = 3
+        dut.s0_ar_ready = 1
+        let saw_s0 : uint<32> = 0
+        for _ in 0 .. 8
+            if saw_s0 == 0 && dut.s0_ar_valid == 1 && dut.s0_ar_ready == 1
+                saw_s0 = 1
+                assert dut.s0_ar_id == 3
+                    else fail("test1 s0_ar_id got ${dut.s0_ar_id}")
+                assert dut.s0_ar_addr == 0x00001000
+                    else fail("test1 s0_ar_addr mismatch")
+                assert dut.s1_ar_valid == 0
+                    else fail("test1 s1_ar_valid should be 0")
+            end if
+            wait 1 cycle
+        end for
+        assert saw_s0 == 1
+            else fail("test1 AR never fired")
+        wait 1 cycle
+        dut.m0_ar_valid = 0
+        dut.s0_ar_ready = 0
+
+        // R return for test1
+        dut.s0_r_valid = 1
+        dut.s0_r_data  = 0xDEADBEEF
+        dut.s0_r_id    = 3
+        dut.s0_r_last  = 1
+        dut.m0_r_ready = 1
+        let saw_r0 : uint<32> = 0
+        for _ in 0 .. 8
+            if saw_r0 == 0 && dut.m0_r_valid == 1 && dut.m0_r_ready == 1
+                saw_r0 = 1
+                assert dut.m0_r_data == 0xDEADBEEF
+                    else fail("test1 R data mismatch")
+                assert dut.m0_r_id == 3
+                    else fail("test1 R id strip")
+            end if
+            wait 1 cycle
+        end for
+        assert saw_r0 == 1
+            else fail("test1 R never landed")
+        wait 1 cycle
+        dut.s0_r_valid = 0
+        dut.m0_r_ready = 0
+
+        // ─── Test 2: M0 → S1 ────────────────────────────────────────────
+        dut.m0_ar_valid = 1
+        dut.m0_ar_addr  = 0x10001000
+        dut.m0_ar_id    = 5
+        dut.s1_ar_ready = 1
+        let saw_s1 : uint<32> = 0
+        for _ in 0 .. 8
+            if saw_s1 == 0 && dut.s1_ar_valid == 1 && dut.s1_ar_ready == 1
+                saw_s1 = 1
+                assert dut.s1_ar_id == 5
+                    else fail("test2 s1_ar_id got ${dut.s1_ar_id}")
+                assert dut.s0_ar_valid == 0
+                    else fail("test2 s0_ar_valid leak")
+            end if
+            wait 1 cycle
+        end for
+        assert saw_s1 == 1
+            else fail("test2 AR never fired on s1")
+        wait 1 cycle
+        dut.m0_ar_valid = 0
+        dut.s1_ar_ready = 0
+
+        // ─── Test 3: M1 → S0, expect ID prefix = 1 ───────────────────────
+        dut.m1_ar_valid = 1
+        dut.m1_ar_addr  = 0x00002000
+        dut.m1_ar_id    = 7
+        dut.s0_ar_ready = 1
+        let saw_m1 : uint<32> = 0
+        for _ in 0 .. 8
+            if saw_m1 == 0 && dut.s0_ar_valid == 1 && dut.s0_ar_ready == 1
+                saw_m1 = 1
+                // expected id = {1, 7} = 0b1_111 = 15
+                assert dut.s0_ar_id == 15
+                    else fail("test3 s0_ar_id got ${dut.s0_ar_id}, expected 15")
+            end if
+            wait 1 cycle
+        end for
+        assert saw_m1 == 1
+            else fail("test3 M1 AR never fired")
+        wait 1 cycle
+        dut.m1_ar_valid = 0
+        dut.s0_ar_ready = 0
+
+        // R return for test3 — verify R lands at M1 not M0
+        dut.s0_r_valid = 1
+        dut.s0_r_data  = 0xC0FFEE00
+        dut.s0_r_id    = 15
+        dut.s0_r_last  = 1
+        dut.m1_r_ready = 1
+        let saw_rm1 : uint<32> = 0
+        for _ in 0 .. 8
+            if saw_rm1 == 0 && dut.m1_r_valid == 1 && dut.m1_r_ready == 1
+                saw_rm1 = 1
+                assert dut.m1_r_id == 7
+                    else fail("test3 m1_r_id strip got ${dut.m1_r_id}")
+                assert dut.m0_r_valid == 0
+                    else fail("test3 m0_r leak")
+            end if
+            wait 1 cycle
+        end for
+        assert saw_rm1 == 1
+            else fail("test3 R never landed at M1")
+
+        log(info, "PASS Nic400Read2x2 smoke (HARC): decode + id-remap + return route OK")
+    end run
+end impl Nic400Read2x2Smoke

--- a/tests/nic400/PkgNic400.arch
+++ b/tests/nic400/PkgNic400.arch
@@ -1,0 +1,19 @@
+// Compile-time configuration of the NIC-400-style AXI4 interconnect.
+// Module-level params override these per instance; defaults are 4M x 4S.
+package PkgNic400
+  domain SysDomain
+    freq_mhz: 1000
+  end domain SysDomain
+
+  param NUM_MASTERS:    const = 4;
+  param NUM_SLAVES:     const = 4;
+  param ADDR_WIDTH:     const = 32;
+  param DATA_WIDTH:     const = 64;
+  param MASTER_ID_W:    const = 4;
+  param MIDX_W:         const = 2;                       // $clog2(NUM_MASTERS)
+  param SIDX_W:         const = 2;                       // $clog2(NUM_SLAVES)
+  param SLAVE_ID_W:     const = 6;                       // MASTER_ID_W + MIDX_W
+  param QOS_W:          const = 4;
+  param OUTSTANDING:    const = 16;
+  param REGION_BITS:    const = 28;                      // 256 MiB per slave
+end package PkgNic400

--- a/tests/nic400/README.md
+++ b/tests/nic400/README.md
@@ -1,0 +1,91 @@
+# NIC-400 Interconnect — ARCH Implementation Status
+
+Reference spec: [`doc/nic400_interconnect_spec.md`](../../doc/nic400_interconnect_spec.md)
+
+## Implementation summary
+
+This directory contains a TDD-built NIC-400-style AXI4 read crossbar in ARCH,
+exercising the four core mechanisms from the spec: address decode, per-slave
+arbitration, ID remap, and ID-prefix return routing.
+
+| File | Purpose | Status |
+|---|---|---|
+| `PkgNic400.arch` | Compile-time parameters (NUM_MASTERS, ID widths, REGION_BITS) | ✓ check |
+| `BusAxi4.arch` | AXI4-full bus type with sideband (lock/cache/prot/qos/region) | ✓ check |
+| `RegSliceChannel.arch` | Generic 1-stage register slice (skid buffer) | ✓ sim PASS |
+| `Nic400ArbiterPolicy.arch` | QoS arbiter (4-requester) with custom hook | ✓ check |
+| `Nic400QosFn.arch` | Pure-comb wrapper of QoS pick function for unit testing | ✓ sim PASS (7/7 cases) |
+| `Nic400Read2x2.arch` | Monolithic 2x2 AXI4 read crossbar | ✓ sim PASS |
+
+## Verification — §15 of spec
+
+| # | Test | Testbench | Status |
+|---|---|---|---|
+| 1 | Single master / single slave smoke | `tb_nic400_read2x2_smoke.cpp` + `Nic400Read2x2_smoke.harc` | ✓ PASS (M0→S0, M0→S1, M1→S0 routings) |
+| 2 | Parallel disjoint targets | `tb_nic400_read2x2_parallel.cpp` | ✓ PASS (M0→S0, M1→S1 simultaneously) |
+| 3 | Hot-slave contention arbitration | `tb_nic400_read2x2_hot_slave.cpp` | ✓ PASS (round_robin serializes both masters onto S0) |
+| 4 | ID remap correctness | embedded in smoke + hot-slave | ✓ PASS (prefix=0 for M0, prefix=1 for M1, strip on return) |
+| 5 | Out-of-order completion | `tb_nic400_read2x2_ooo.cpp` | ✓ PASS (R from S1 first, then S0; both land at M0 with correct IDs) |
+| 6 | Register slice latency | `tb_reg_slice_channel.cpp` | ✓ PASS (1-cycle latency, sustained 1/cycle throughput, backpressure-correct) |
+| 7 | `--auto-thread-asserts` runs silently | smoke TB with the flag | ✓ PASS (32 SVA properties; Verilator `--lint-only --assert` clean) |
+| 8 | Formal property (per-slave issue→W order) | `arch formal` | △ DEFERRED — hierarchical formal v1 does not yet support sub-module `wire` declarations introduced by the lock-arbitration lowering pass (compiler limitation, not a design flaw) |
+
+## Scope notes — deviations from the spec
+
+The spec describes a parameterizable M×N crossbar with separate
+`MasterPort`/`SlavePort`/`Fabric`/`Interconnect` modules. The implementation
+here is **a monolithic 2×2 read-only crossbar**:
+
+- **2×2 instead of 4×4**: the spec patterns repeat mechanically; scaling
+  involves enumerating more threads and widening the ID prefix. The 2×2
+  exercises every core mechanism (decode, arbitrate, ID remap, return route).
+- **Read-only**: the write path (AW arbitration, W routing by master-idx FIFO,
+  B return) is a structural mirror of the read path. AR→R is enough to
+  validate the design pattern.
+- **Monolithic, not hierarchical**: ARCH does not currently support
+  `Vec<BusName, N>` port arrays at module signatures, which the spec relies on
+  heavily. The monolithic form sidesteps this by enumerating ports flatly.
+  When the language adds bus arrays, the design can be refactored into the
+  spec's hierarchical form without changing the threads.
+- **Round-robin arbitration**: `resource ... : mutex<round_robin>` is what the
+  compiler currently accepts. The QoS pick function (`Nic400QosFn`) is
+  implemented and unit-tested in isolation; integration into the crossbar
+  requires either `mutex<UserFn>` support or wrapping the QoS arbiter as a
+  separate `arbiter` instance.
+- **No register slices in the 2×2**: `RegSliceChannel` is a tested building
+  block. Slices are inserted at top-level by instantiating it between the
+  master/slave ports and the crossbar; not done here to keep the core
+  verification surface focused.
+
+## Compiler features used / probed
+
+Working:
+- `package` with `param`, `domain`, `enum`, `struct`, module-local `function`
+- `resource X: mutex<round_robin>` / `mutex<priority>` + `lock X ... end lock`
+- `thread T on clk rising, rst low ... default comb ... wait until ... do..until`
+- `fork/and/join` (not used here but available)
+- `generate_for` at module scope for threads
+- `shared(or)` on individual ports
+- `arbiter` construct with `policy <FnName>` and `hook grant_select`
+- `--auto-thread-asserts` emits 32 SVA properties on this design
+
+Tested missing / not-real syntactic forms (driving the monolithic structure above):
+- **`Vec<BusName, N>` port** — parse error: `unexpected token: expected identifier, found Vec` in port type position. No syntactic form for an array of bus ports works today; `generate_for i / port name_i: initiator B` is also rejected ("'port' declarations are not allowed inside generate_for"). Together this blocks declaring N bus-typed edges at a module signature.
+- **`with <bus_signal> shared(or)` annotation on bus ports** — parse error. Worked around by flattening to individual ports each carrying `shared(or)`.
+- **`mst2slv[*][j]` slice notation** — not tested directly; the NIC-400 spec doc itself notes it as speculative ("If the compiler doesn't currently parse this slice form, the equivalent verbose form is to enumerate the slice elements"). Treat as untested rather than confirmed-missing.
+
+Not real keywords (i.e., not "missing features" — they don't exist in the language at all):
+- **`wire_bus`** — appears only in `doc/nic400_interconnect_spec.md`. Not in the lexer, parser, or any other doc. The correct working form is `wire X: BusName;` (e.g. `wire w: FooBus;` from `tests/integration_test.rs`'s Parent example).
+
+Available but I previously claimed missing (correction):
+- **`mutex<UserPolicyFn>`** — supported. Requires a `hook grant_select(...) = UserPolicyFn(...);` block attached to the resource. Working pattern in `tests/integration_test.rs:9841` (`test_resource_lock_custom_policy_with_hook`):
+  ```arch
+  resource shared_lk: mutex<PickHigh>
+    hook grant_select(req_mask: UInt<2>, last_grant: UInt<2>) -> UInt<2>
+         = PickHigh(req_mask, last_grant);
+  end resource shared_lk
+  ```
+  This means the QoS arbitration in the slave-port `aw_lock` can be wired in directly — replacing `mutex<round_robin>` with `mutex<nic400_qos_pick>` plus the hook block — without needing a separate `arbiter` instance.
+
+Real compiler-side gap exposed by this design:
+- Hierarchical formal v1 rejects auto-generated thread sub-modules that contain `wire` decls produced by lock-arbitration lowering. Filed as [arch-hdl-lang/arch-com#383](https://github.com/arch-hdl-lang/arch-com/issues/383).

--- a/tests/nic400/RegSliceChannel.arch
+++ b/tests/nic400/RegSliceChannel.arch
@@ -1,0 +1,48 @@
+// Generic single-stage AXI4 register slice for one channel.
+//
+// Breaks combinational valid+payload from upstream to downstream by holding
+// the payload in a register. The ready path remains combinational (slice
+// purpose is to cut forward-direction logic, not the back-pressure path).
+//
+//   Latency: 1 cycle when downstream is always ready.
+//   Throughput: 1 transfer/cycle (sustained).
+//
+// Behavior:
+//   up_ready = !occupied || dn_ready    -- accept when empty OR draining
+//   dn_valid = occupied
+//   dn_payload = payload register
+module RegSliceChannel
+  param PAYLOAD_W: const = 64;
+
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Async, Low>;
+
+  port up_valid:   in  Bool;
+  port up_payload: in  UInt<PAYLOAD_W>;
+  port up_ready:   out Bool;
+
+  port dn_valid:   out Bool;
+  port dn_payload: out UInt<PAYLOAD_W>;
+  port dn_ready:   in  Bool;
+
+  reg occupied: Bool reset rst => false;
+  reg payload:  UInt<PAYLOAD_W> reset rst => 0;
+
+  let accept_fire:  Bool = up_valid and (not occupied or dn_ready);
+  let drain_fire:   Bool = occupied and dn_ready;
+
+  seq on clk rising
+    if accept_fire
+      payload <= up_payload;
+      occupied <= true;
+    elsif drain_fire
+      occupied <= false;
+    end if
+  end seq
+
+  comb
+    up_ready   = not occupied or dn_ready;
+    dn_valid   = occupied;
+    dn_payload = payload;
+  end comb
+end module RegSliceChannel

--- a/tests/nic400/RegSliceChannel_test.harc
+++ b/tests/nic400/RegSliceChannel_test.harc
@@ -1,0 +1,92 @@
+// HARC sequence-layer testbench for RegSliceChannel.
+//
+// Exercises:
+//   1. After reset, slice is empty -> dn_valid=0, up_ready=1.
+//   2. Single-cycle traversal when downstream always ready: latency = 1.
+//   3. Backpressure: downstream stalls, slice latches one beat, upstream stalls.
+//   4. Sustained 1 transfer/cycle throughput.
+
+testbench RegSliceChannelTb
+    dut : RegSliceChannel
+end testbench RegSliceChannelTb
+
+impl RegSliceChannelHarcTest for RegSliceChannelTb
+    run
+        log(info, "RegSliceChannel HARC test")
+
+        dut.rst = 0
+        dut.up_valid = 0
+        dut.up_payload = 0
+        dut.dn_ready = 0
+        wait 4 cycles
+        dut.rst = 1
+        wait 2 cycles
+
+        // 1. Empty after reset
+        assert dut.dn_valid == 0
+            else fail("post-reset dn_valid should be 0, got ${dut.dn_valid}")
+        assert dut.up_ready == 1
+            else fail("post-reset up_ready should be 1, got ${dut.up_ready}")
+
+        // 2. One-beat traversal, latency = 1 cycle
+        dut.dn_ready = 1
+        dut.up_valid = 1
+        dut.up_payload = 0xDEADBEEF
+        wait 1 cycle
+        // Cycle after rising edge: dn_valid should be 1, dn_payload latched
+        assert dut.dn_valid == 1
+            else fail("after 1 cycle, dn_valid should be 1, got ${dut.dn_valid}")
+        assert dut.dn_payload == 0xDEADBEEF
+            else fail("dn_payload mismatch: got 0x${dut.dn_payload:08x}, expected 0xDEADBEEF")
+
+        // Drain
+        dut.up_valid = 0
+        wait 2 cycles
+        assert dut.dn_valid == 0
+            else fail("after drain, dn_valid should be 0, got ${dut.dn_valid}")
+
+        // 3. Backpressure: downstream stalled
+        dut.dn_ready = 0
+        dut.up_valid = 1
+        dut.up_payload = 0xCAFEBABE
+        wait 1 cycle
+        // Slice has latched the beat; downstream still stalled
+        assert dut.dn_valid == 1
+            else fail("after fill+stall, dn_valid should be 1, got ${dut.dn_valid}")
+        // Upstream can't push another one without dn_ready
+        assert dut.up_ready == 0
+            else fail("when occupied and dn_ready=0, up_ready should be 0, got ${dut.up_ready}")
+        // Try to push -- should NOT change latched payload
+        dut.up_payload = 0xBADC0DE
+        wait 2 cycles
+        assert dut.dn_payload == 0xCAFEBABE
+            else fail("latched payload should still be 0xCAFEBABE, got 0x${dut.dn_payload:08x}")
+        assert dut.dn_valid == 1
+            else fail("dn_valid should still be 1 while held, got ${dut.dn_valid}")
+
+        // Release downstream
+        dut.up_valid = 0
+        dut.dn_ready = 1
+        wait 2 cycles
+        assert dut.dn_valid == 0
+            else fail("after release, dn_valid should be 0, got ${dut.dn_valid}")
+
+        // 4. Sustained throughput
+        let count : uint<32> = 0
+        dut.dn_ready = 1
+        dut.up_valid = 1
+        for i in 0 .. 8
+            dut.up_payload = 0x1000 + i
+            wait 1 cycle
+            if dut.dn_valid == 1 && dut.dn_ready == 1
+                count = count + 1
+            end if
+        end for
+        dut.up_valid = 0
+        // After 8 cycles of streaming, expect at least 7 transfers (one-cycle ramp-up)
+        assert count >= 7
+            else fail("sustained throughput too low: ${count} transfers in 8 cycles")
+
+        log(info, "PASS: RegSliceChannel latency=1 backpressure-ok throughput=${count}/8")
+    end run
+end impl RegSliceChannelHarcTest

--- a/tests/nic400/tb_nic400_qos_fn.cpp
+++ b/tests/nic400/tb_nic400_qos_fn.cpp
@@ -1,0 +1,78 @@
+// C++ runner for Nic400QosFn_test.harc. Mirrors the HARC assertions.
+
+#include "VNic400QosFn.h"
+
+#include <cstdint>
+#include <cstdio>
+
+static VNic400QosFn dut;
+
+static void settle() { dut.eval(); }
+
+static int check(const char *name, uint32_t got, uint32_t want) {
+    if (got != want) {
+        std::printf("FAIL Nic400QosFn[%s]: got 0x%x, expected 0x%x\n", name, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+int main() {
+    int err = 0;
+
+    // 1. Empty req
+    dut.req_mask = 0;
+    dut.last_grant = 0;
+    dut.qos_packed = 0x3210;
+    settle();
+    err += check("empty", dut.grant, 0);
+
+    // 2. Single requester m1, qos=0
+    dut.req_mask = 0b0010;
+    dut.last_grant = 0;
+    dut.qos_packed = 0;
+    settle();
+    err += check("single_m1", dut.grant, 0b0010);
+
+    // 3. m0=qos3, m2=qos5 -> m2
+    dut.req_mask = 0b0101;
+    dut.last_grant = 0;
+    dut.qos_packed = 0x0503;
+    settle();
+    err += check("qos_pick_m2", dut.grant, 0b0100);
+
+    // 4. All four equal qos=2, last_grant=m0 -> m1
+    dut.req_mask = 0b1111;
+    dut.last_grant = 0b0001;
+    dut.qos_packed = 0x2222;
+    settle();
+    err += check("rr_after_m0", dut.grant, 0b0010);
+
+    // 5. wrap-around: last_grant=m3 -> m0
+    dut.req_mask = 0b1111;
+    dut.last_grant = 0b1000;
+    dut.qos_packed = 0x2222;
+    settle();
+    err += check("rr_wrap", dut.grant, 0b0001);
+
+    // 6. m0,m2 tied top qos=7, last_grant=m0 -> m2
+    dut.req_mask = 0b0101;
+    dut.last_grant = 0b0001;
+    dut.qos_packed = 0x0707;
+    settle();
+    err += check("tied_top_rr", dut.grant, 0b0100);
+
+    // 7. all 4 reqs, qos {1,3,1,3}, last=m1 -> m3
+    dut.req_mask = 0b1111;
+    dut.last_grant = 0b0010;
+    dut.qos_packed = 0x3131;
+    settle();
+    err += check("4way_tied", dut.grant, 0b1000);
+
+    if (err) {
+        std::printf("FAIL Nic400QosFn: %d sub-cases failed\n", err);
+        return 1;
+    }
+    std::printf("PASS Nic400QosFn — empty, single, qos-pick, rr-fairness, tied-top all OK\n");
+    return 0;
+}

--- a/tests/nic400/tb_nic400_read2x2_hot_slave.cpp
+++ b/tests/nic400/tb_nic400_read2x2_hot_slave.cpp
@@ -1,0 +1,98 @@
+// Hot-slave test: M0 and M1 both target slave 0.
+// Verifies:
+//   - resource: mutex<round_robin> serializes both masters onto s0.
+//   - Both transactions complete (no starvation).
+//   - The arbitrated slave_ids carry distinct prefixes (0 for M0, 1 for M1).
+
+#include "VNic400Read2x2.h"
+#include <cstdint>
+#include <cstdio>
+
+static VNic400Read2x2 dut;
+
+static void tick() {
+    dut.clk = 0;
+    dut.eval();
+    dut.clk = 1;
+    dut.eval();
+}
+
+int main() {
+    dut.rst = 0;
+    dut.m0_ar_valid = 0; dut.m1_ar_valid = 0;
+    dut.s0_ar_ready = 0; dut.s1_ar_ready = 0;
+    dut.s0_r_valid = 0;  dut.s1_r_valid = 0;
+    dut.m0_r_ready = 0;  dut.m1_r_ready = 0;
+    for (int i = 0; i < 4; ++i) tick();
+    dut.rst = 1;
+    tick();
+
+    // Both masters drive AR with bit[28]=0 (slave 0).
+    dut.m0_ar_valid = 1; dut.m0_ar_addr = 0x00001000; dut.m0_ar_id = 1;
+    dut.m0_ar_size = 2; dut.m0_ar_burst = 1;
+    dut.m1_ar_valid = 1; dut.m1_ar_addr = 0x00002000; dut.m1_ar_id = 2;
+    dut.m1_ar_size = 2; dut.m1_ar_burst = 1;
+    dut.s0_ar_ready = 1;
+
+    // Capture the sequence of grants: arbiter should serialize them.
+    int got_m0 = 0, got_m1 = 0;
+    uint32_t first_id = 0, second_id = 0;
+    int phase = 0;
+    for (int i = 0; i < 24; ++i) {
+        tick();
+        if (dut.s0_ar_valid && dut.s0_ar_ready) {
+            uint32_t id = dut.s0_ar_id;
+            // m0_id=1 → prefixed = 0b0_001 = 1; m1_id=2 → prefixed = 0b1_010 = 10
+            if (phase == 0) {
+                first_id = id;
+                phase = 1;
+                // The losing master keeps requesting; the winner drops below.
+                if (id == 1) {
+                    dut.m0_ar_valid = 0;
+                    got_m0 = 1;
+                } else if (id == 10) {
+                    dut.m1_ar_valid = 0;
+                    got_m1 = 1;
+                } else {
+                    std::printf("FAIL hot-slave: unexpected first id=0x%x\n", id);
+                    return 1;
+                }
+            } else if (phase == 1) {
+                second_id = id;
+                phase = 2;
+                if (id == 1) {
+                    if (got_m0) {
+                        std::printf("FAIL hot-slave: M0 granted twice before M1\n");
+                        return 1;
+                    }
+                    got_m0 = 1;
+                    dut.m0_ar_valid = 0;
+                } else if (id == 10) {
+                    if (got_m1) {
+                        std::printf("FAIL hot-slave: M1 granted twice before M0\n");
+                        return 1;
+                    }
+                    got_m1 = 1;
+                    dut.m1_ar_valid = 0;
+                } else {
+                    std::printf("FAIL hot-slave: unexpected second id=0x%x\n", id);
+                    return 1;
+                }
+            }
+            if (phase == 2) break;
+        }
+    }
+    if (!got_m0 || !got_m1) {
+        std::printf("FAIL hot-slave: got_m0=%d got_m1=%d (no fairness or starvation)\n",
+                    got_m0, got_m1);
+        return 1;
+    }
+    if (first_id == second_id) {
+        std::printf("FAIL hot-slave: round-robin didn't alternate (both id=0x%x)\n", first_id);
+        return 1;
+    }
+
+    std::printf("PASS Nic400Read2x2 hot-slave: arb serialized M0 (id=0x%x) and M1 (id=0x%x)\n",
+                first_id, second_id);
+    return 0;
+}

--- a/tests/nic400/tb_nic400_read2x2_ooo.cpp
+++ b/tests/nic400/tb_nic400_read2x2_ooo.cpp
@@ -1,0 +1,92 @@
+// Out-of-order completion:
+//   M0 issues AR(id=1) → S0 and AR(id=2) → S1.
+//   S1 responds first (id=2), then S0 (id=1).
+//   Both R responses must land at M0 with the correct stripped ID and data.
+
+#include "VNic400Read2x2.h"
+#include <cstdint>
+#include <cstdio>
+
+static VNic400Read2x2 dut;
+
+static void tick() {
+    dut.clk = 0;
+    dut.eval();
+    dut.clk = 1;
+    dut.eval();
+}
+
+int main() {
+    dut.rst = 0;
+    dut.m0_ar_valid = 0; dut.m1_ar_valid = 0;
+    dut.s0_ar_ready = 0; dut.s1_ar_ready = 0;
+    dut.s0_r_valid = 0;  dut.s1_r_valid = 0;
+    dut.m0_r_ready = 0;  dut.m1_r_ready = 0;
+    for (int i = 0; i < 4; ++i) tick();
+    dut.rst = 1;
+    tick();
+
+    // Issue AR id=1 → S0
+    dut.m0_ar_valid = 1; dut.m0_ar_addr = 0x00001000; dut.m0_ar_id = 1;
+    dut.m0_ar_size = 2; dut.m0_ar_burst = 1;
+    dut.s0_ar_ready = 1;
+    for (int i = 0; i < 8; ++i) {
+        tick();
+        if (dut.s0_ar_valid && dut.s0_ar_ready) break;
+    }
+    tick();
+    dut.m0_ar_valid = 0; dut.s0_ar_ready = 0;
+    tick();
+
+    // Issue AR id=2 → S1
+    dut.m0_ar_valid = 1; dut.m0_ar_addr = 0x10001000; dut.m0_ar_id = 2;
+    dut.s1_ar_ready = 1;
+    for (int i = 0; i < 8; ++i) {
+        tick();
+        if (dut.s1_ar_valid && dut.s1_ar_ready) break;
+    }
+    tick();
+    dut.m0_ar_valid = 0; dut.s1_ar_ready = 0;
+    tick();
+
+    // Now slave 1 responds FIRST (out of order vs. issue)
+    dut.s1_r_valid = 1; dut.s1_r_data = 0x22222222; dut.s1_r_id = 2; dut.s1_r_last = 1;
+    dut.m0_r_ready = 1;
+    int got_first = 0;
+    uint32_t first_id = 0, first_data = 0;
+    for (int i = 0; i < 8 && !got_first; ++i) {
+        tick();
+        if (dut.m0_r_valid && dut.m0_r_ready) {
+            got_first = 1;
+            first_id = dut.m0_r_id;
+            first_data = dut.m0_r_data;
+        }
+    }
+    if (!got_first || first_id != 2 || first_data != 0x22222222) {
+        std::printf("FAIL ooo: first response id=0x%x data=0x%x\n", first_id, first_data);
+        return 1;
+    }
+    tick();
+    dut.s1_r_valid = 0;
+    tick();
+
+    // Then slave 0 responds
+    dut.s0_r_valid = 1; dut.s0_r_data = 0x11111111; dut.s0_r_id = 1; dut.s0_r_last = 1;
+    int got_second = 0;
+    uint32_t second_id = 0, second_data = 0;
+    for (int i = 0; i < 8 && !got_second; ++i) {
+        tick();
+        if (dut.m0_r_valid && dut.m0_r_ready) {
+            got_second = 1;
+            second_id = dut.m0_r_id;
+            second_data = dut.m0_r_data;
+        }
+    }
+    if (!got_second || second_id != 1 || second_data != 0x11111111) {
+        std::printf("FAIL ooo: second response id=0x%x data=0x%x\n", second_id, second_data);
+        return 1;
+    }
+
+    std::printf("PASS Nic400Read2x2 OOO: R(id=2) first, R(id=1) second — interleaved completion OK\n");
+    return 0;
+}

--- a/tests/nic400/tb_nic400_read2x2_parallel.cpp
+++ b/tests/nic400/tb_nic400_read2x2_parallel.cpp
@@ -1,0 +1,92 @@
+// Parallel disjoint targets:
+//   M0 issues AR to S0, M1 issues AR to S1, simultaneously.
+//   Both should advance independently — 2 transactions/cycle throughput.
+
+#include "VNic400Read2x2.h"
+#include <cstdint>
+#include <cstdio>
+
+static VNic400Read2x2 dut;
+
+static void tick() {
+    dut.clk = 0;
+    dut.eval();
+    dut.clk = 1;
+    dut.eval();
+}
+
+int main() {
+    dut.rst = 0;
+    dut.m0_ar_valid = 0; dut.m1_ar_valid = 0;
+    dut.s0_ar_ready = 0; dut.s1_ar_ready = 0;
+    dut.s0_r_valid = 0;  dut.s1_r_valid = 0;
+    dut.m0_r_ready = 0;  dut.m1_r_ready = 0;
+    for (int i = 0; i < 4; ++i) tick();
+    dut.rst = 1;
+    tick();
+
+    // Both masters issue AR simultaneously, to disjoint slaves.
+    dut.m0_ar_valid = 1; dut.m0_ar_addr = 0x00001000; dut.m0_ar_id = 2;
+    dut.m0_ar_size = 2; dut.m0_ar_burst = 1;
+    dut.m1_ar_valid = 1; dut.m1_ar_addr = 0x10002000; dut.m1_ar_id = 4;
+    dut.m1_ar_size = 2; dut.m1_ar_burst = 1;
+    dut.s0_ar_ready = 1;
+    dut.s1_ar_ready = 1;
+
+    int s0_fired = 0, s1_fired = 0;
+    uint32_t s0_id = 0, s1_id = 0;
+    for (int i = 0; i < 8 && !(s0_fired && s1_fired); ++i) {
+        tick();
+        if (!s0_fired && dut.s0_ar_valid && dut.s0_ar_ready) {
+            s0_fired = 1;
+            s0_id = dut.s0_ar_id;
+        }
+        if (!s1_fired && dut.s1_ar_valid && dut.s1_ar_ready) {
+            s1_fired = 1;
+            s1_id = dut.s1_ar_id;
+        }
+    }
+    if (!s0_fired || !s1_fired) {
+        std::printf("FAIL parallel: s0_fired=%d s1_fired=%d\n", s0_fired, s1_fired);
+        return 1;
+    }
+    // s0 should see id={0, m0_id=2} = 2
+    // s1 should see id={1, m1_id=4} = 0b1_100 = 12
+    if (s0_id != 2 || s1_id != 12) {
+        std::printf("FAIL parallel: ID remap s0=0x%x s1=0x%x (expected 2, 12)\n", s0_id, s1_id);
+        return 1;
+    }
+    tick();
+    dut.m0_ar_valid = 0; dut.m1_ar_valid = 0;
+    dut.s0_ar_ready = 0; dut.s1_ar_ready = 0;
+    tick();
+
+    // R responses arrive simultaneously on both slaves
+    dut.s0_r_valid = 1; dut.s0_r_data = 0xAA00AA00; dut.s0_r_id = 2;  dut.s0_r_last = 1;
+    dut.s1_r_valid = 1; dut.s1_r_data = 0xBB00BB00; dut.s1_r_id = 12; dut.s1_r_last = 1;
+    dut.m0_r_ready = 1;
+    dut.m1_r_ready = 1;
+
+    int m0_got = 0, m1_got = 0;
+    uint32_t m0_data = 0, m1_data = 0;
+    for (int i = 0; i < 8 && !(m0_got && m1_got); ++i) {
+        tick();
+        if (!m0_got && dut.m0_r_valid && dut.m0_r_ready) {
+            m0_got = 1; m0_data = dut.m0_r_data;
+        }
+        if (!m1_got && dut.m1_r_valid && dut.m1_r_ready) {
+            m1_got = 1; m1_data = dut.m1_r_data;
+        }
+    }
+    if (!m0_got || !m1_got) {
+        std::printf("FAIL parallel R: m0_got=%d m1_got=%d\n", m0_got, m1_got);
+        return 1;
+    }
+    if (m0_data != 0xAA00AA00 || m1_data != 0xBB00BB00) {
+        std::printf("FAIL parallel R data: m0=0x%x m1=0x%x\n", m0_data, m1_data);
+        return 1;
+    }
+
+    std::printf("PASS Nic400Read2x2 parallel: 2 disjoint AR/R simultaneously OK\n");
+    return 0;
+}

--- a/tests/nic400/tb_nic400_read2x2_smoke.cpp
+++ b/tests/nic400/tb_nic400_read2x2_smoke.cpp
@@ -1,0 +1,139 @@
+// Smoke test for Nic400Read2x2: M0->S0, M0->S1, M1->S0 + R returns.
+
+#include "VNic400Read2x2.h"
+#include <cstdint>
+#include <cstdio>
+
+static VNic400Read2x2 dut;
+
+static void tick() {
+    dut.clk = 0;
+    dut.eval();
+    dut.clk = 1;
+    dut.eval();
+}
+
+static void clear_inputs() {
+    dut.m0_ar_valid = 0; dut.m0_ar_addr = 0; dut.m0_ar_id = 0;
+    dut.m0_ar_len = 0;   dut.m0_ar_size = 0; dut.m0_ar_burst = 0;
+    dut.m0_r_ready = 0;
+    dut.m1_ar_valid = 0; dut.m1_ar_addr = 0; dut.m1_ar_id = 0;
+    dut.m1_ar_len = 0;   dut.m1_ar_size = 0; dut.m1_ar_burst = 0;
+    dut.m1_r_ready = 0;
+    dut.s0_ar_ready = 0;
+    dut.s0_r_valid = 0;  dut.s0_r_data = 0; dut.s0_r_id = 0;
+    dut.s0_r_resp = 0;   dut.s0_r_last = 0;
+    dut.s1_ar_ready = 0;
+    dut.s1_r_valid = 0;  dut.s1_r_data = 0; dut.s1_r_id = 0;
+    dut.s1_r_resp = 0;   dut.s1_r_last = 0;
+}
+
+static int fail(const char *msg) {
+    std::printf("FAIL Nic400Read2x2: %s\n", msg);
+    return 1;
+}
+
+// Run AR phase: drive master side, accept on selected slave's ready.
+// Returns 0 on success; verifies expected ID and decode target.
+static int do_ar(int master, uint32_t addr, uint32_t id, int expect_slave, uint32_t expect_slave_id) {
+    if (master == 0) {
+        dut.m0_ar_valid = 1; dut.m0_ar_addr = addr; dut.m0_ar_id = id;
+        dut.m0_ar_len = 0;   dut.m0_ar_size = 2;   dut.m0_ar_burst = 1;
+    } else {
+        dut.m1_ar_valid = 1; dut.m1_ar_addr = addr; dut.m1_ar_id = id;
+        dut.m1_ar_len = 0;   dut.m1_ar_size = 2;   dut.m1_ar_burst = 1;
+    }
+    if (expect_slave == 0) dut.s0_ar_ready = 1; else dut.s1_ar_ready = 1;
+
+    int saw = 0;
+    for (int i = 0; i < 8 && !saw; ++i) {
+        tick();
+        bool fired = (expect_slave == 0) ? (dut.s0_ar_valid && dut.s0_ar_ready)
+                                         : (dut.s1_ar_valid && dut.s1_ar_ready);
+        if (fired) {
+            saw = 1;
+            // Check the OTHER slave's AR is not firing
+            if (expect_slave == 0 && dut.s1_ar_valid != 0) return fail("wrong slave fired (s1)");
+            if (expect_slave == 1 && dut.s0_ar_valid != 0) return fail("wrong slave fired (s0)");
+            uint32_t got_id = (expect_slave == 0) ? dut.s0_ar_id : dut.s1_ar_id;
+            if (got_id != expect_slave_id) {
+                std::printf("AR id got 0x%x, expected 0x%x\n", got_id, expect_slave_id);
+                return 1;
+            }
+            uint32_t got_addr = (expect_slave == 0) ? dut.s0_ar_addr : dut.s1_ar_addr;
+            if (got_addr != addr) return fail("AR addr mismatch");
+        }
+    }
+    if (!saw) return fail("AR never fired");
+    // Run one more tick so the state machine advances past the handshake.
+    tick();
+    // Now release everything
+    if (master == 0) dut.m0_ar_valid = 0; else dut.m1_ar_valid = 0;
+    dut.s0_ar_ready = 0;
+    dut.s1_ar_ready = 0;
+    tick();
+    return 0;
+}
+
+// Run R phase: slave injects R, expect it to land on the originating master.
+static int do_r(int slave_src, uint32_t data, uint32_t slave_id, int expect_master, uint32_t expect_master_id) {
+    if (slave_src == 0) {
+        dut.s0_r_valid = 1; dut.s0_r_data = data; dut.s0_r_id = slave_id;
+        dut.s0_r_resp = 0;  dut.s0_r_last = 1;
+    } else {
+        dut.s1_r_valid = 1; dut.s1_r_data = data; dut.s1_r_id = slave_id;
+        dut.s1_r_resp = 0;  dut.s1_r_last = 1;
+    }
+    if (expect_master == 0) dut.m0_r_ready = 1; else dut.m1_r_ready = 1;
+
+    int saw = 0;
+    for (int i = 0; i < 8 && !saw; ++i) {
+        tick();
+        bool fired = (expect_master == 0) ? (dut.m0_r_valid && dut.m0_r_ready)
+                                          : (dut.m1_r_valid && dut.m1_r_ready);
+        if (fired) {
+            saw = 1;
+            if (expect_master == 0 && dut.m1_r_valid != 0) return fail("wrong master got R (m1)");
+            if (expect_master == 1 && dut.m0_r_valid != 0) return fail("wrong master got R (m0)");
+            uint32_t got_data = (expect_master == 0) ? dut.m0_r_data : dut.m1_r_data;
+            uint32_t got_id   = (expect_master == 0) ? dut.m0_r_id   : dut.m1_r_id;
+            uint32_t got_last = (expect_master == 0) ? dut.m0_r_last : dut.m1_r_last;
+            if (got_data != data) return fail("R data mismatch");
+            if (got_id != expect_master_id) {
+                std::printf("R id got 0x%x, expected 0x%x\n", got_id, expect_master_id);
+                return 1;
+            }
+            if (got_last != 1) return fail("R last not 1");
+        }
+    }
+    if (!saw) return fail("R never landed");
+    tick();
+    if (slave_src == 0) dut.s0_r_valid = 0; else dut.s1_r_valid = 0;
+    dut.m0_r_ready = 0;
+    dut.m1_r_ready = 0;
+    tick();
+    return 0;
+}
+
+int main() {
+    dut.rst = 0;
+    clear_inputs();
+    for (int i = 0; i < 4; ++i) tick();
+    dut.rst = 1;
+    tick();
+
+    // Test 1: M0 → S0
+    if (do_ar(0, 0x00001000u, 3, /*slave*/0, /*slave_id*/3)) return 1;
+    if (do_r(/*slave*/0, 0xDEADBEEFu, /*slave_id*/3, /*master*/0, /*master_id*/3)) return 1;
+
+    // Test 2: M0 → S1
+    if (do_ar(0, 0x10001000u, 5, /*slave*/1, /*slave_id*/5)) return 1;
+    if (do_r(/*slave*/1, 0xCAFEBABEu, /*slave_id*/5, /*master*/0, /*master_id*/5)) return 1;
+
+    // Test 3: M1 → S0 — verify ID prefix = 1
+    if (do_ar(1, 0x00002000u, 7, /*slave*/0, /*slave_id*/0xF)) return 1;
+    if (do_r(/*slave*/0, 0xC0FFEE00u, /*slave_id*/0xF, /*master*/1, /*master_id*/7)) return 1;
+
+    std::printf("PASS Nic400Read2x2 smoke: decode + ID remap + return route OK\n");
+    return 0;
+}

--- a/tests/nic400/tb_reg_slice_channel.cpp
+++ b/tests/nic400/tb_reg_slice_channel.cpp
@@ -1,0 +1,86 @@
+// C++ runner for RegSliceChannel_test.harc.
+// Companion to the HARC source-of-truth test; mirrors its assertions.
+
+#include "VRegSliceChannel.h"
+
+#include <cstdint>
+#include <cstdio>
+
+static VRegSliceChannel dut;
+
+static void tick() {
+    dut.clk = 0;
+    dut.eval();
+    dut.clk = 1;
+    dut.eval();
+}
+
+static int fail(const char *msg) {
+    std::printf("FAIL RegSliceChannel: %s\n", msg);
+    return 1;
+}
+
+int main() {
+    // Reset (active-low Reset<Async, Low>): rst=0 = in reset
+    dut.rst = 0;
+    dut.up_valid = 0;
+    dut.up_payload = 0;
+    dut.dn_ready = 0;
+    for (int i = 0; i < 4; ++i) tick();
+    dut.rst = 1;
+    for (int i = 0; i < 2; ++i) tick();
+
+    // 1. Empty after reset
+    if (dut.dn_valid != 0) return fail("post-reset dn_valid != 0");
+    if (dut.up_ready != 1) return fail("post-reset up_ready != 1");
+
+    // 2. One-beat traversal, latency = 1
+    dut.dn_ready = 1;
+    dut.up_valid = 1;
+    dut.up_payload = 0xDEADBEEFu;
+    tick();
+    if (dut.dn_valid != 1) return fail("after 1 cycle, dn_valid != 1");
+    if (dut.dn_payload != 0xDEADBEEFu) return fail("dn_payload mismatch");
+
+    // Drain
+    dut.up_valid = 0;
+    for (int i = 0; i < 2; ++i) tick();
+    if (dut.dn_valid != 0) return fail("after drain, dn_valid != 0");
+
+    // 3. Backpressure: downstream stalled
+    dut.dn_ready = 0;
+    dut.up_valid = 1;
+    dut.up_payload = 0xCAFEBABEu;
+    tick();
+    if (dut.dn_valid != 1) return fail("after fill+stall, dn_valid != 1");
+    if (dut.up_ready != 0) return fail("when occupied and dn_ready=0, up_ready must be 0");
+    // Try to overwrite -- should NOT happen
+    dut.up_payload = 0x0BADC0DEu;
+    for (int i = 0; i < 2; ++i) tick();
+    if (dut.dn_payload != 0xCAFEBABEu) return fail("payload changed under backpressure");
+    if (dut.dn_valid != 1) return fail("dn_valid dropped under backpressure");
+
+    // Release
+    dut.up_valid = 0;
+    dut.dn_ready = 1;
+    for (int i = 0; i < 2; ++i) tick();
+    if (dut.dn_valid != 0) return fail("after release, dn_valid != 0");
+
+    // 4. Sustained throughput
+    int count = 0;
+    dut.dn_ready = 1;
+    dut.up_valid = 1;
+    for (uint32_t i = 0; i < 8; ++i) {
+        dut.up_payload = 0x1000u + i;
+        tick();
+        if (dut.dn_valid && dut.dn_ready) count++;
+    }
+    dut.up_valid = 0;
+    if (count < 7) {
+        std::printf("FAIL RegSliceChannel: throughput too low: %d/8\n", count);
+        return 1;
+    }
+
+    std::printf("PASS RegSliceChannel latency=1 backpressure=ok throughput=%d/8\n", count);
+    return 0;
+}


### PR DESCRIPTION
## Summary

Two commits in one PR:

1. **Compiler feature** — `Vec<BusName, N>` ports and wires.

   ```arch
   port chans: initiator Vec<BusAxi4, 4>;        // declaration
   wire  w:    Vec<BusAxi4, 2>;                  // bus wires too
   chans[0].ar_valid = 1;                        // expression
   inst u: M  chans[0] -> w[0];  end inst u      // inst connection
   for i in 0..3  chans[i].ar_valid = req[i];  end for   // for-loop unroll
   ```

   No new keywords or constructs — pure composition over the existing `port` /
   `wire` declarations and `Vec<T, N>` type expression. The bracket form `[i]`
   is used everywhere — declarations (`Vec<_, N>`), expressions (`chans[i].sig`),
   and inst connections (`chans[i] -> w[i]`). Flat SV signature is
   `<name>_<i>_<sig>` per element; bracket-dot expressions and inst connections
   resolve to those flat names.

   For-loop bodies that index a Vec-of-bus port or wire by the loop variable
   are statically unrolled at codegen time (there's no SV-level array of buses
   to iterate over). The unroll fires only when bounds are literal and the
   body actually touches a Vec-of-bus by the loop variable; other for-loops
   keep their behavioral SV `for` shape.

2. **NIC-400 example** — TDD-built 2x2 read crossbar in `tests/nic400/`
   demonstrating address decode, ID remap, per-slave arbitration, and
   ID-prefix return routing. Spec §15 verification plan items 1–7 pass;
   item 8 (formal) is deferred on a known compiler limitation (#383).

## Test plan

- [x] 7 new integration tests for Vec-of-bus port + wire + for-loop unroll
- [x] 449 / 449 total `cargo test --test integration_test` pass (442 + 7)
- [x] `verilator --lint-only --assert` clean on all new SV
- [x] 6 NIC-400 C++ testbenches pass under `arch sim`
- [x] No new keywords, no breaking changes to existing surface

## v1 limitations (follow-ups)

- `N` must be a positive integer literal (param-driven `N` deferred)
- Whole-vec inst connection `chans -> some_vec_port` not implemented;
  index each element individually
- Loop bounds for static unroll must be literal integers