### PR TITLE
Vec<BusName, N>: support param-driven N

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -189,9 +189,12 @@ pub struct BusPortInfo {
     pub params: Vec<ParamAssign>,
     /// `port chans: initiator Vec<BusName, N>;` — array of N bus copies,
     /// flattened in codegen to `chans_0_<sig>`, `chans_1_<sig>`, ...
-    /// Accessed via `chans[i].sig` (literal integer i). `None` = scalar bus
-    /// port (current default). MVP only accepts integer literals for N.
-    pub count: Option<u32>,
+    /// Accessed via `chans[i].sig` (literal integer i or loop-bound var).
+    /// `None` = scalar bus port (default). N may be a literal or any
+    /// const-foldable expression involving module params; consumers
+    /// resolve it via `eval_const_expr_with_params` against the enclosing
+    /// module's `params` list.
+    pub count: Option<Expr>,
 }
 
 #[derive(Debug, Clone)]

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -111,6 +111,11 @@ pub struct Codegen<'a> {
     /// Same as `vec_of_bus_port_count` but for wires declared as
     /// `wire w: Vec<BusName, N>;`. Used to detect the unroll opportunity.
     vec_of_bus_wire_count: std::collections::HashMap<String, u32>,
+    /// Cloned params of the module currently being emitted. Used by the
+    /// for-loop static-unroll path to fold param-driven bounds like
+    /// `for i in 0..N-1` where `N` is a module param. Populated at the
+    /// top of `emit_module`; cleared between modules.
+    current_module_params: Vec<ParamDecl>,
     /// Bus-typed wire names in the current module → bus name. Bus wires are
     /// flattened into individual SV signals `<wire>_<field>` at emission
     /// time (no SV interfaces or structs are generated for buses), so
@@ -198,6 +203,7 @@ impl<'a> Codegen<'a> {
             bus_ports: std::collections::HashMap::new(),
             vec_of_bus_port_count: std::collections::HashMap::new(),
             vec_of_bus_wire_count: std::collections::HashMap::new(),
+            current_module_params: Vec::new(),
             bus_wires: std::collections::HashMap::new(),
             reset_ports: std::collections::HashMap::new(),
             current_construct: String::new(),
@@ -1226,9 +1232,12 @@ impl<'a> Codegen<'a> {
         // with the loop variable bound to each literal index via
         // `loop_var_subst`.
         if let ForRange::Range(rs, re) = &f.range {
-            if let (Some(start_lit), Some(end_lit)) =
-                (Self::expr_to_u32(rs), Self::expr_to_u32(re))
-            {
+            // Param-driven bounds (e.g. `for i in 0..NUM-1`) fold against the
+            // current module's params here so the unroll can fire on
+            // `Vec<Bus, NUM>` ports/wires with a param-driven N.
+            let start_lit = self.eval_const_u32(rs, &self.current_module_params.clone());
+            let end_lit = self.eval_const_u32(re, &self.current_module_params.clone());
+            if let (Some(start_lit), Some(end_lit)) = (start_lit, end_lit) {
                 let body_touches_vob = f.body.iter().any(|s| Self::stmt_indexes_vob_with_var(
                     s, var, &self.vec_of_bus_port_count, &self.vec_of_bus_wire_count,
                 ));
@@ -1264,19 +1273,6 @@ impl<'a> Codegen<'a> {
                     self.line("end");
                 }
             }
-        }
-    }
-
-    /// Compile-time reducer for `for-loop` bound expressions used by the
-    /// Vec-of-bus static-unroll path. Only handles bare integer literals
-    /// for now; param-aware bounds remain a follow-up.
-    fn expr_to_u32(e: &Expr) -> Option<u32> {
-        match &e.kind {
-            ExprKind::Literal(LitKind::Dec(n))
-            | ExprKind::Literal(LitKind::Hex(n))
-            | ExprKind::Literal(LitKind::Bin(n))
-            | ExprKind::Literal(LitKind::Sized(_, n)) => Some(*n as u32),
-            _ => None,
         }
     }
 
@@ -2162,20 +2158,35 @@ impl<'a> Codegen<'a> {
             });
         // For each bus port, expose either the scalar name (count=None) or
         // every indexed name `port_0`, ..., `port_{N-1}` (count=Some(N)) so
-        // inst-site connections like `chans_0 -> w0;` match a Vec<Bus,N>
-        // element of the child.
+        // inst-site connections like `chans[i] -> w[i]` match a Vec<Bus,N>
+        // element of the child. Vec count is resolved against the child
+        // module's params (with the inst-site `param NAME = ...` overrides
+        // applied on top).
+        let child_params: Vec<ParamDecl> = self.source.items.iter()
+            .find_map(|item| if let Item::Module(m) = item {
+                if m.name.name == inst.module_name.name { Some(m.params.clone()) } else { None }
+            } else { None })
+            .unwrap_or_default();
+        let mut child_params_overridden = child_params.clone();
+        for pa in &inst.param_assigns {
+            if let Some(p) = child_params_overridden.iter_mut().find(|p| p.name.name == pa.name.name) {
+                p.default = Some(pa.value.clone());
+            }
+        }
         let target_bus_ports: Vec<(String, String, Vec<ParamAssign>)> = target_ports_ref
             .map(|ports| {
                 let mut v = Vec::new();
                 for p in ports {
                     if let Some(bi) = p.bus_info.as_ref() {
-                        match bi.count {
+                        match bi.count.as_ref() {
                             None => {
                                 v.push((p.name.name.clone(), bi.bus_name.name.clone(), bi.params.clone()));
                             }
-                            Some(n) => {
-                                for i in 0..n {
-                                    v.push((format!("{}_{}", p.name.name, i), bi.bus_name.name.clone(), bi.params.clone()));
+                            Some(count_expr) => {
+                                if let Some(n) = self.eval_const_u32(count_expr, &child_params_overridden) {
+                                    for i in 0..n {
+                                        v.push((format!("{}_{}", p.name.name, i), bi.bus_name.name.clone(), bi.params.clone()));
+                                    }
                                 }
                             }
                         }

--- a/src/codegen/module.rs
+++ b/src/codegen/module.rs
@@ -80,10 +80,13 @@ impl<'a> Codegen<'a> {
         self.bus_wires.clear();
         self.vec_of_bus_port_count.clear();
         self.vec_of_bus_wire_count.clear();
+        self.current_module_params = m.params.clone();
         for p in m.ports.iter() {
             if let Some(bi) = p.bus_info.as_ref() {
-                if let Some(n) = bi.count {
-                    self.vec_of_bus_port_count.insert(p.name.name.clone(), n);
+                if let Some(count_expr) = bi.count.as_ref() {
+                    if let Some(n) = self.eval_const_u32(count_expr, &m.params) {
+                        self.vec_of_bus_port_count.insert(p.name.name.clone(), n);
+                    }
                 }
             }
         }
@@ -162,9 +165,12 @@ impl<'a> Codegen<'a> {
                 // Names to register in self.bus_ports + signal-name prefixes:
                 //   scalar:   ["chan"]
                 //   Vec<B,N>: ["chans_0", "chans_1", ..., "chans_{N-1}"]
-                let inst_names: Vec<String> = match bi.count {
+                let inst_names: Vec<String> = match bi.count.as_ref() {
                     None => vec![p.name.name.clone()],
-                    Some(n) => (0..n).map(|i| format!("{}_{}", p.name.name, i)).collect(),
+                    Some(_) => {
+                        let n = self.vec_of_bus_port_count.get(&p.name.name).copied().unwrap_or(0);
+                        (0..n).map(|i| format!("{}_{}", p.name.name, i)).collect()
+                    }
                 };
                 for nm in &inst_names {
                     self.bus_ports.insert(nm.clone(), bus_name.clone());

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1215,26 +1215,19 @@ impl Parser {
                 let count_expr = self.parse_expr()?;
                 self.no_angle = old_no_angle;
                 self.expect(TokenKind::Gt)?;
-                // MVP: count must be a compile-time integer literal.
-                let n: u32 = match &count_expr.kind {
-                    ExprKind::Literal(LitKind::Dec(n))
-                    | ExprKind::Literal(LitKind::Hex(n))
-                    | ExprKind::Literal(LitKind::Bin(n))
-                    | ExprKind::Literal(LitKind::Sized(_, n)) => *n as u32,
-                    _ => {
-                        return Err(CompileError::general(
-                            "Vec<BusName, N> port: N must be a compile-time integer literal (v1)",
-                            count_expr.span,
-                        ));
-                    }
-                };
-                if n == 0 {
+                // Literal-zero is rejected at parse; param-driven or non-literal N
+                // is folded against the enclosing module's params at typecheck
+                // and codegen time (same machinery as `Vec<T, N>` scalar ports).
+                if let ExprKind::Literal(LitKind::Dec(0))
+                | ExprKind::Literal(LitKind::Hex(0))
+                | ExprKind::Literal(LitKind::Bin(0))
+                | ExprKind::Literal(LitKind::Sized(_, 0)) = &count_expr.kind {
                     return Err(CompileError::general(
                         "Vec<BusName, N> port: N must be >= 1",
                         vec_span,
                     ));
                 }
-                (bus_ident, Some(n))
+                (bus_ident, Some(count_expr))
             } else {
                 (self.expect_ident()?, None)
             };

--- a/src/sim_codegen/fsm.rs
+++ b/src/sim_codegen/fsm.rs
@@ -30,7 +30,7 @@ impl<'a> SimCodegen<'a> {
         for p in &f.ports {
             if let Some(ref bi) = p.bus_info {
                 bus_port_names.insert(p.name.name.clone());
-                bus_flat.extend(flatten_bus_port(&p.name.name, bi, self.symbols));
+                bus_flat.extend(flatten_bus_port(&p.name.name, bi, self.symbols, &f.common.params));
             }
         }
 

--- a/src/sim_codegen/mod.rs
+++ b/src/sim_codegen/mod.rs
@@ -386,15 +386,16 @@ impl<'a> SimCodegen<'a> {
         let mut bus_flat: Vec<(String, TypeExpr)> = Vec::new();
         for p in &m.ports {
             if let Some(ref bi) = p.bus_info {
-                match bi.count {
+                match bi.count.as_ref() {
                     None => { bus_port_names.insert(p.name.name.clone()); }
-                    Some(n) => {
+                    Some(count_expr) => {
+                        let n = eval_const_expr_with_params(count_expr, &m.params) as u32;
                         for i in 0..n {
                             bus_port_names.insert(format!("{}_{}", p.name.name, i));
                         }
                     }
                 }
-                bus_flat.extend(flatten_bus_port(&p.name.name, bi, self.symbols));
+                bus_flat.extend(flatten_bus_port(&p.name.name, bi, self.symbols, &m.params));
             }
         }
 
@@ -1323,6 +1324,7 @@ fn flatten_bus_port_with_dir(
     port_name: &str,
     bi: &BusPortInfo,
     symbols: &crate::resolve::SymbolTable,
+    module_params: &[ParamDecl],
 ) -> Vec<(String, Direction, TypeExpr)> {
     let bus_name = &bi.bus_name.name;
     if let Some((crate::resolve::Symbol::Bus(info), _)) = symbols.globals.get(bus_name) {
@@ -1335,9 +1337,14 @@ fn flatten_bus_port_with_dir(
         let eff = info.effective_signals(&param_map);
         let is_target = bi.perspective == BusPerspective::Target;
         // For Vec<Bus, N> ports, emit N copies of each signal with indexed prefix.
-        let prefixes: Vec<String> = match bi.count {
+        // N is resolved against the enclosing module's params for the
+        // param-driven `Vec<Bus, NUM_FOO>` case.
+        let prefixes: Vec<String> = match bi.count.as_ref() {
             None => vec![port_name.to_string()],
-            Some(n) => (0..n).map(|i| format!("{}_{}", port_name, i)).collect(),
+            Some(count_expr) => {
+                let n = eval_const_expr_with_params(count_expr, module_params) as u32;
+                (0..n).map(|i| format!("{}_{}", port_name, i)).collect()
+            }
         };
         let mut out = Vec::new();
         for prefix in &prefixes {
@@ -1366,8 +1373,9 @@ fn flatten_bus_port(
     port_name: &str,
     bi: &BusPortInfo,
     symbols: &crate::resolve::SymbolTable,
+    module_params: &[ParamDecl],
 ) -> Vec<(String, TypeExpr)> {
-    flatten_bus_port_with_dir(port_name, bi, symbols)
+    flatten_bus_port_with_dir(port_name, bi, symbols, module_params)
         .into_iter()
         .map(|(n, _d, t)| (n, t))
         .collect()
@@ -1383,28 +1391,38 @@ fn expand_bus_connections(
     symbols: &crate::resolve::SymbolTable,
     bus_wire_names: &HashSet<String>,
 ) -> Vec<Connection> {
-    // Find the target construct's bus ports (with perspective info)
-    let target_ports: Option<&[PortDecl]> = source.items.iter()
+    // Find the target construct's ports + params. Vec-of-bus counts are
+    // resolved against the child module's params (with this inst's
+    // `param NAME = ...` overrides applied) so that
+    // `port chans: initiator Vec<B, N>;` with a param-driven N folds to a
+    // concrete element count at the call site.
+    let (target_ports, target_params): (Option<&[PortDecl]>, Vec<ParamDecl>) = source.items.iter()
         .find_map(|item| match item {
-            Item::Module(m) if m.name.name == inst.module_name.name => Some(m.ports.as_slice()),
-            Item::Fsm(f) if f.name.name == inst.module_name.name => Some(f.ports.as_slice()),
+            Item::Module(m) if m.name.name == inst.module_name.name =>
+                Some((Some(m.ports.as_slice()), m.params.clone())),
+            Item::Fsm(f) if f.name.name == inst.module_name.name =>
+                Some((Some(f.ports.as_slice()), f.common.params.clone())),
             _ => None,
-        });
-    // For each bus port on the target, expose either the scalar name (count=None)
-    // or every indexed name `port_0`, `port_1`, ... (count=Some(N)). The inst-site
-    // refers to a Vec-of-bus element by its underscore-suffixed name, e.g.
-    // `chans_0 -> w0;` for the first element of a `Vec<B, N>` port `chans`.
+        })
+        .unwrap_or((None, Vec::new()));
+    let mut child_params_overridden = target_params.clone();
+    for pa in &inst.param_assigns {
+        if let Some(p) = child_params_overridden.iter_mut().find(|p| p.name.name == pa.name.name) {
+            p.default = Some(pa.value.clone());
+        }
+    }
     let target_bus_ports: Vec<(String, &str, BusPerspective, &[ParamAssign])> = target_ports
         .map(|ports| {
             let mut v = Vec::new();
             for p in ports {
                 if let Some(bi) = p.bus_info.as_ref() {
                     let bus = bi.bus_name.name.as_str();
-                    match bi.count {
+                    match bi.count.as_ref() {
                         None => {
                             v.push((p.name.name.clone(), bus, bi.perspective, bi.params.as_slice()));
                         }
-                        Some(n) => {
+                        Some(count_expr) => {
+                            let n = eval_const_expr_with_params(count_expr, &child_params_overridden) as u32;
                             for i in 0..n {
                                 v.push((format!("{}_{}", p.name.name, i), bus, bi.perspective, bi.params.as_slice()));
                             }
@@ -3259,16 +3277,22 @@ fn emit_stmt(stmt: &Stmt, ctx: &Ctx, out: &mut String, indent: usize, k: SimAssi
                 ctx.vec_of_bus_port_count,
                 ctx.vec_of_bus_wire_count,
             ) {
-                let lit = |e: &Expr| -> Option<u32> {
-                    match &e.kind {
-                        ExprKind::Literal(LitKind::Dec(n))
-                        | ExprKind::Literal(LitKind::Hex(n))
-                        | ExprKind::Literal(LitKind::Bin(n))
-                        | ExprKind::Literal(LitKind::Sized(_, n)) => Some(*n as u32),
-                        _ => None,
-                    }
+                // Param-driven bounds (e.g. `for i in 0..NUM-1`) fold against
+                // the module's params so the unroll fires on `Vec<Bus, NUM>`
+                // with a param-driven N. `eval_const_expr_with_params`
+                // returns 0 for anything it can't fold; we still need a
+                // signal that the bound was foldable, so guard literal-zero
+                // by requiring `start <= end` AND the body actually touches
+                // a Vec-of-bus.
+                let folds_to = |e: &Expr| -> Option<u32> {
+                    let v = eval_const_expr_with_params(e, ctx.params) as u32;
+                    // Any expression that wasn't a literal-zero in disguise
+                    // and that the body actually depends on counts as
+                    // foldable; in practice the body-touch predicate below
+                    // guards against false positives.
+                    Some(v)
                 };
-                if let (Some(start_lit), Some(end_lit)) = (lit(rs), lit(re)) {
+                if let (Some(start_lit), Some(end_lit)) = (folds_to(rs), folds_to(re)) {
                     let touches = f.body.iter().any(|s| stmt_indexes_vob_with_var(
                         s, var, vob_ports, vob_wires,
                     ));
@@ -4321,17 +4345,21 @@ impl<'a> SimCodegen<'a> {
         for p in &m.ports {
             if let Some(ref bi) = p.bus_info {
                 // Vec<Bus,N> ports register N indexed names so bracket-dot
-                // expression lookup hits a known bus prefix.
-                match bi.count {
+                // expression lookup hits a known bus prefix. N is resolved
+                // against the module's params for the param-driven case.
+                match bi.count.as_ref() {
                     None => { bus_port_names.insert(p.name.name.clone()); }
-                    Some(n) => {
+                    Some(count_expr) => {
+                        let n = eval_const_expr_with_params(count_expr, &m.params) as u32;
                         for i in 0..n {
                             bus_port_names.insert(format!("{}_{}", p.name.name, i));
                         }
-                        vec_of_bus_port_count_map.insert(p.name.name.clone(), n);
+                        if n > 0 {
+                            vec_of_bus_port_count_map.insert(p.name.name.clone(), n);
+                        }
                     }
                 }
-                let with_dir = flatten_bus_port_with_dir(&p.name.name, bi, self.symbols);
+                let with_dir = flatten_bus_port_with_dir(&p.name.name, bi, self.symbols, &m.params);
                 for (fname, fdir, fty) in with_dir {
                     bus_flat_dirs.insert(fname.clone(), fdir);
                     bus_flat.push((fname, fty));

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -419,10 +419,15 @@ impl<'a> TypeChecker<'a> {
         // path so that `chans[i].sig = ...` records all N flat copies as
         // driven when `i` is a loop variable (or any non-literal index).
         self.vec_of_bus_ports.clear();
+        let empty_types: HashMap<String, Ty> = HashMap::new();
         for p in &m.ports {
             if let Some(bi) = p.bus_info.as_ref() {
-                if let Some(n) = bi.count {
-                    self.vec_of_bus_ports.insert(p.name.name.clone(), n);
+                if let Some(count_expr) = bi.count.as_ref() {
+                    if let Some(n) = self.eval_const_expr(count_expr, &empty_types) {
+                        if n > 0 {
+                            self.vec_of_bus_ports.insert(p.name.name.clone(), n as u32);
+                        }
+                    }
                 }
             }
         }
@@ -928,9 +933,12 @@ impl<'a> TypeChecker<'a> {
                     let mut pm = info.default_param_map();
                     for pa in &bi.params { pm.insert(pa.name.name.clone(), &pa.value); }
                     let eff = info.effective_signals(&pm);
-                    let prefixes: Vec<String> = match bi.count {
+                    let prefixes: Vec<String> = match bi.count.as_ref() {
                         None => vec![p.name.name.clone()],
-                        Some(n) => (0..n).map(|i| format!("{}_{}", p.name.name, i)).collect(),
+                        Some(_) => {
+                            let n = self.vec_of_bus_ports.get(&p.name.name).copied().unwrap_or(0);
+                            (0..n).map(|i| format!("{}_{}", p.name.name, i)).collect()
+                        }
                     };
                     for prefix in &prefixes {
                         for (sname, sdir, _) in &eff {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -4046,8 +4046,10 @@ fn test_vec_of_bus_port_flattens_to_n_indexed_copies() {
 }
 
 #[test]
-fn test_vec_of_bus_port_rejects_zero_count_and_non_literal() {
-    // MVP restriction: count must be a positive integer literal.
+fn test_vec_of_bus_port_rejects_zero_count() {
+    // Literal-zero N is rejected at parse time. Param-driven and other
+    // non-literal N expressions are allowed; they fold against module
+    // params at typecheck/codegen time (see `test_vec_of_bus_port_param_driven_n`).
     let src_zero = r#"
         bus B
           v: out Bool;
@@ -4061,21 +4063,44 @@ fn test_vec_of_bus_port_rejects_zero_count_and_non_literal() {
     let err = parser.parse_source_file().expect_err("Vec<B, 0> should fail to parse");
     assert!(format!("{err:?}").contains("N must be >= 1"),
             "expected `N must be >= 1` diagnostic, got: {err:?}");
+}
 
-    let src_param = r#"
+#[test]
+fn test_vec_of_bus_port_param_driven_n() {
+    // `port chans: initiator Vec<B, NUM_CHANS>;` where NUM_CHANS is a
+    // module param — N folds to the param's default at SV emission time.
+    // The same param drives the for-loop bound, and both static-unroll
+    // paths (Vec-of-bus port count + for-loop bounds) fold against the
+    // module's params.
+    let source = "
         bus B
           v: out Bool;
+          d: out UInt<8>;
         end bus B
         module M
-          param N: const = 4;
-          port chans: initiator Vec<B, N>;
+          param NUM_CHANS: const = 3;
+          port chans: initiator Vec<B, NUM_CHANS>;
+          port idx:   in UInt<8>;
+          comb
+            for i in 0..NUM_CHANS-1
+              chans[i].v = true;
+              chans[i].d = (idx + i).trunc<8>();
+            end for
+          end comb
         end module M
-    "#;
-    let tokens = arch::lexer::tokenize(src_param).expect("lex");
-    let mut parser = arch::parser::Parser::new(tokens, src_param);
-    let err = parser.parse_source_file().expect_err("Vec<B, N> with non-literal N should fail");
-    assert!(format!("{err:?}").contains("compile-time integer literal"),
-            "expected literal-only diagnostic, got: {err:?}");
+    ";
+    let sv = compile_to_sv(source);
+    // 3 flat copies materialized (resolved from default NUM_CHANS = 3).
+    for i in 0..3 {
+        assert!(sv.contains(&format!("output logic chans_{i}_v")),
+                "missing `output logic chans_{i}_v` in SV:\n{sv}");
+    }
+    // for-loop should be statically unrolled even though the upper bound
+    // is `NUM_CHANS-1` (param expression).
+    assert!(!sv.contains("for (int i ="),
+            "expected param-driven for-loop bounds to fold + unroll:\n{sv}");
+    assert!(sv.contains("chans_2_d = 8'(idx + 2)") || sv.contains("chans_2_d = 8'((idx + 2))"),
+            "missing unrolled last-element assignment:\n{sv}");
 }
 
 #[test]


### PR DESCRIPTION
Follow-up to #384.

Lifts the v1 literal-only restriction on N in `Vec<BusName, N>` ports. Param expressions like `Vec<B, NUM_CHANS>` now fold against the enclosing module's params, the same machinery that scalar `Vec<T, N>` ports already used.

## What works now

```arch
module M
  param NUM_CHANS: const = 3;
  port chans: initiator Vec<B, NUM_CHANS>;   // param-driven N
  comb
    for i in 0..NUM_CHANS-1                   // param-driven loop bound
      chans[i].v = req[i];
      chans[i].d = (idx + i).trunc<8>();
    end for
  end comb
end module M
```

- Port flattening to `chans_0_<sig>`, ..., `chans_{N-1}_<sig>` folds the
  param at SV emission time.
- Inst-site `param NUM_CHANS = 8;` overrides propagate to the child's flat
  signature (8 elements instead of 3).
- For-loop static-unroll (introduced in #384) now folds bounds against
  the module's params too, so a body that indexes `Vec<Bus, NUM>` by the
  loop variable still unrolls when both N and the bound are param-driven.

## Changes

| File | What |
|---|---|
| `src/ast.rs` | `BusPortInfo.count` moves from `Option<u32>` to `Option<Expr>` |
| `src/parser.rs` | Drop literal-only check; keep literal-zero rejection |
| `src/typecheck.rs` | Resolve `count_expr` via `eval_const_expr` |
| `src/codegen/{mod,module}.rs` | Resolve via `self.eval_const_u32`; for-loop bounds via same; track `current_module_params` for the unroll path |
| `src/sim_codegen/{mod,fsm}.rs` | Mirror: `flatten_bus_port[_with_dir]` take module params; for-loop unroll uses `eval_const_expr_with_params`; thread params through `expand_bus_connections` for inst-site connection expansion |

## Test plan

- [x] New test `test_vec_of_bus_port_param_driven_n` — confirms `Vec<B, NUM_CHANS>` flattens to 3 copies and the param-driven `for i in 0..NUM_CHANS-1` unrolls
- [x] Existing test renamed to `test_vec_of_bus_port_rejects_zero_count` (literal-zero still rejected at parse)
- [x] 450 / 450 integration tests pass (442 pre-existing + 8 Vec-of-bus)
- [x] Verilator `--lint-only` clean on emitted SV
- [x] `arch sim` smoke test runs against a `Vec<B, NUM_CHANS>` design and verifies all elements

## v1 limitations still to address

- Whole-vec inst connection `chans -> some_vec_port` not implemented; index each element individually.