### PR TITLE
Vec<BusName, N>: support whole-vec inst connection

### DIFF
--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -2195,6 +2195,26 @@ impl<'a> Codegen<'a> {
                 v
             })
             .unwrap_or_default();
+        // Separate index: Vec-of-bus port → (count, bus, params). Lets a
+        // whole-vec inst connection `chans -> w` (where both child port
+        // and parent signal are `Vec<Bus, N>`) expand to N per-element
+        // per-signal named-port connections without requiring the user
+        // to enumerate `chans[0] -> w[0]; chans[1] -> w[1]; ...`.
+        let target_vec_of_bus_ports: Vec<(String, u32, String, Vec<ParamAssign>)> = target_ports_ref
+            .map(|ports| {
+                let mut v = Vec::new();
+                for p in ports {
+                    if let Some(bi) = p.bus_info.as_ref() {
+                        if let Some(count_expr) = bi.count.as_ref() {
+                            if let Some(n) = self.eval_const_u32(count_expr, &child_params_overridden) {
+                                v.push((p.name.name.clone(), n, bi.bus_name.name.clone(), bi.params.clone()));
+                            }
+                        }
+                    }
+                }
+                v
+            })
+            .unwrap_or_default();
 
         // Per-port enum-cast lookup. For each input port whose type is
         // an extern-package enum (declared via `extern package Pkg ...
@@ -2303,6 +2323,34 @@ impl<'a> Codegen<'a> {
                 indexed_group_dir.insert((group.clone(), sig.clone()), dir);
                 indexed_group_ty.insert((group, sig), ty);
                 continue;
+            }
+            // Whole-vec bus connection: `chans -> w` where the child's
+            // `chans` is a `Vec<Bus, N>` port. The parent signal `w` must
+            // be a bare identifier — a parent Vec-of-bus port or a bus
+            // wire-array (`wire w: Vec<Bus, N>;`). Expand to N x #signals
+            // per-element named-port connections.
+            if let Some((_, n, bus_name, bus_params)) = target_vec_of_bus_ports.iter()
+                .find(|(pn, _, _, _)| *pn == c.port_name.name)
+            {
+                if let ExprKind::Ident(parent_name) = &c.signal.kind {
+                    if let Some((Symbol::Bus(info), _)) = self.symbols.globals.get(bus_name) {
+                        let mut param_map: std::collections::HashMap<String, &Expr> = info.params.iter()
+                            .filter_map(|pd| pd.default.as_ref().map(|d| (pd.name.name.clone(), d)))
+                            .collect();
+                        for pa in bus_params { param_map.insert(pa.name.name.clone(), &pa.value); }
+                        let eff = info.effective_signals(&param_map);
+                        for i in 0..*n {
+                            for (sname, _, _) in &eff {
+                                connections.push(format!(
+                                    ".{}_{}_{}({}_{}_{})",
+                                    c.port_name.name, i, sname,
+                                    parent_name, i, sname,
+                                ));
+                            }
+                        }
+                        continue;
+                    }
+                }
             }
             if let Some((_, bus_name, bus_params)) = target_bus_ports.iter().find(|(pn, _, _)| *pn == c.port_name.name) {
                 // Bus connection — expand to individual signals. The parent-side

--- a/src/sim_codegen/mod.rs
+++ b/src/sim_codegen/mod.rs
@@ -1387,10 +1387,12 @@ fn flatten_bus_port(
 /// Non-bus connections are returned unchanged.
 fn expand_bus_connections(
     inst: &InstDecl,
+    parent_module: &ModuleDecl,
     source: &SourceFile,
     symbols: &crate::resolve::SymbolTable,
     bus_wire_names: &HashSet<String>,
 ) -> Vec<Connection> {
+    let m = parent_module;
     // Find the target construct's ports + params. Vec-of-bus counts are
     // resolved against the child module's params (with this inst's
     // `param NAME = ...` overrides applied) so that
@@ -1433,9 +1435,92 @@ fn expand_bus_connections(
             v
         })
         .unwrap_or_default();
+    // Whole Vec-of-bus port lookup, keyed by the bare name (no `_<i>` suffix).
+    // Lets `chans -> w` (whole-vec inst connection) match against the child's
+    // bare Vec<Bus,N> port name; we then expand it to N per-element bus
+    // connections fed back into the standard expansion loop below.
+    let target_vec_of_bus_ports: Vec<(String, u32)> = target_ports
+        .map(|ports| {
+            let mut v = Vec::new();
+            for p in ports {
+                if let Some(bi) = p.bus_info.as_ref() {
+                    if let Some(count_expr) = bi.count.as_ref() {
+                        let n = eval_const_expr_with_params(count_expr, &child_params_overridden) as u32;
+                        if n > 0 { v.push((p.name.name.clone(), n)); }
+                    }
+                }
+            }
+            v
+        })
+        .unwrap_or_default();
+    // Parent-side Vec<Bus,N> port and wire names → counts. Used together
+    // with `target_vec_of_bus_ports` to detect a whole-vec connection
+    // `chans -> w` where both sides are arrays.
+    let parent_vec_of_bus_wires: HashMap<String, u32> = m.body.iter()
+        .filter_map(|i| if let ModuleBodyItem::WireDecl(w) = i {
+            if let TypeExpr::Vec(elem, size_expr) = &w.ty {
+                if let TypeExpr::Named(id) = elem.as_ref() {
+                    if matches!(symbols.globals.get(&id.name), Some((crate::resolve::Symbol::Bus(_), _))) {
+                        let n = eval_const_expr_with_params(size_expr, &m.params) as u32;
+                        if n > 0 { return Some((w.name.name.clone(), n)); }
+                    }
+                }
+            }
+            None
+        } else { None })
+        .collect();
+    let parent_vec_of_bus_ports: HashMap<String, u32> = m.ports.iter()
+        .filter_map(|p| {
+            let bi = p.bus_info.as_ref()?;
+            let count_expr = bi.count.as_ref()?;
+            let n = eval_const_expr_with_params(count_expr, &m.params) as u32;
+            if n > 0 { Some((p.name.name.clone(), n)) } else { None }
+        })
+        .collect();
+    // Pre-expand whole-vec inst connections (`chans -> w`) into N per-element
+    // bus connections (`chans_0 -> w[0]; chans_1 -> w[1]; ...`). The body
+    // loop below then expands each of those into per-signal connections via
+    // the existing scalar+indexed paths.
+    let inst_connections: Vec<crate::ast::Connection> = inst.connections.iter()
+        .flat_map(|c| {
+            if let Some((_, n)) = target_vec_of_bus_ports.iter().find(|(pn, _)| pn == &c.port_name.name) {
+                if let ExprKind::Ident(parent_name) = &c.signal.kind {
+                    let parent_is_vob_wire = parent_vec_of_bus_wires.contains_key(parent_name);
+                    let parent_is_vob_port = parent_vec_of_bus_ports.contains_key(parent_name);
+                    if parent_is_vob_wire || parent_is_vob_port {
+                        return (0..*n).map(|i| {
+                            let port_i = Ident::new(format!("{}_{}", c.port_name.name, i), c.port_name.span);
+                            // Wire: emit Index(Ident(w), i) so downstream sees a
+                            // bus-wire-array element. Port: emit Ident("w_<i>") so
+                            // it lands at the flat per-element port name on the parent.
+                            let parent_expr = if parent_is_vob_wire {
+                                Expr::new(
+                                    ExprKind::Index(
+                                        Box::new(Expr::new(ExprKind::Ident(parent_name.clone()), c.signal.span)),
+                                        Box::new(Expr::new(ExprKind::Literal(LitKind::Dec(i as u64)), c.signal.span)),
+                                    ),
+                                    c.signal.span,
+                                )
+                            } else {
+                                Expr::new(ExprKind::Ident(format!("{}_{}", parent_name, i)), c.signal.span)
+                            };
+                            crate::ast::Connection {
+                                port_name: port_i,
+                                direction: c.direction,
+                                signal: parent_expr,
+                                reset_override: None,
+                                span: c.span,
+                            }
+                        }).collect::<Vec<_>>();
+                    }
+                }
+            }
+            vec![c.clone()]
+        })
+        .collect();
 
     let mut expanded = Vec::new();
-    for c in &inst.connections {
+    for c in &inst_connections {
         if let Some((_, bus_name, perspective, bus_params)) = target_bus_ports.iter().find(|(pn, _, _, _)| pn == &c.port_name.name) {
             // Bus connection — expand to individual signal connections
             if let Some((crate::resolve::Symbol::Bus(info), _)) = symbols.globals.get(*bus_name) {
@@ -4764,7 +4849,7 @@ impl<'a> SimCodegen<'a> {
         // Pre-expand bus connections: whole-bus connections like `axi_rd -> m_axi_mm2s`
         // are expanded to per-signal connections using the bus definition.
         let expanded_conns: Vec<Vec<Connection>> = insts.iter()
-            .map(|inst| expand_bus_connections(inst, self.source, self.symbols, &bus_wire_names))
+            .map(|inst| expand_bus_connections(inst, m, self.source, self.symbols, &bus_wire_names))
             .collect();
 
         // Augment `inst_out` with output signals discovered through bus

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -4173,6 +4173,52 @@ fn test_vec_of_bus_for_loop_static_unroll() {
 }
 
 #[test]
+fn test_vec_of_bus_inst_whole_vec_connection() {
+    // `chans -> w;` (whole-vec) where both child port and parent wire/port
+    // are `Vec<Bus, N>` expands to N per-element per-signal named-port
+    // connections in SV — saves the user from writing
+    // `chans[0] -> w[0]; chans[1] -> w[1]; ...` N times.
+    let source = "
+        bus B
+          v: out Bool;
+          d: out UInt<8>;
+        end bus B
+        module Producer
+          port chans: initiator Vec<B, 3>;
+          comb
+            chans[0].v = true;  chans[0].d = 8'h11;
+            chans[1].v = false; chans[1].d = 8'h22;
+            chans[2].v = true;  chans[2].d = 8'h33;
+          end comb
+        end module Producer
+        module Parent
+          port out_d0: out UInt<8>;
+          port out_d2: out UInt<8>;
+          wire w: Vec<B, 3>;
+          inst p: Producer
+            chans -> w;
+          end inst p
+          comb
+            out_d0 = w[0].d;
+            out_d2 = w[2].d;
+          end comb
+        end module Parent
+    ";
+    let sv = compile_to_sv(source);
+    for i in 0..3 {
+        assert!(sv.contains(&format!(".chans_{i}_v(w_{i}_v)"))
+                || sv.contains(&format!(".chans_{i}_v (w_{i}_v)")),
+                "missing `.chans_{i}_v(w_{i}_v)` named-port connection:\n{sv}");
+        assert!(sv.contains(&format!(".chans_{i}_d(w_{i}_d)"))
+                || sv.contains(&format!(".chans_{i}_d (w_{i}_d)")),
+                "missing `.chans_{i}_d(w_{i}_d)` named-port connection:\n{sv}");
+    }
+    // Should not leave a `.chans(w)` (illegal SV) artifact in the output.
+    assert!(!sv.contains(".chans(w)"),
+            "whole-vec connection must expand, not emit `.chans(w)`:\n{sv}");
+}
+
+#[test]
 fn test_vec_of_bus_wire_flattens_to_n_indexed_signals() {
     // `wire w: Vec<BusName, N>;` is type-expression composition over the
     // existing `wire X: BusName;` form. SV codegen emits N flat


### PR DESCRIPTION
Follow-up to #384 / #385.

Lifts the per-element-only restriction on Vec-of-bus inst connections. A parent can now write the whole array in one connection:

```arch
inst p: Producer
  chans -> w;          // whole-vec — both child port and parent are Vec<Bus, N>
end inst p
```

instead of having to enumerate every index:

```arch
inst p: Producer
  chans[0] -> w[0];
  chans[1] -> w[1];
  chans[2] -> w[2];
  // ...
end inst p
```

The codegen expands the whole-vec connection to N × #signals per-element named-port bindings.

## Where it lands

**SV codegen (`src/codegen/mod.rs`)** — adds a `target_vec_of_bus_ports` index keyed by the bare port name (no `_<i>` suffix), separate from the per-element `target_bus_ports`. When a connection's port name matches the bare-name index AND the parent signal is a plain `Ident`, emits N × #signals `.<port>_<i>_<sig>(<parent>_<i>_<sig>)` lines.

**Sim codegen (`src/sim_codegen/mod.rs`)** — pre-expands the whole-vec connection in `expand_bus_connections` into N per-element connections (`chans_<i> -> w[<i>]` for wire targets, `chans_<i> -> parent_chans_<i>` for parent-port targets) before the main expansion loop runs, so downstream sim machinery sees the already-expanded form. `expand_bus_connections` now takes a `&ModuleDecl` to resolve the parent's Vec-of-bus wires/ports during the pre-expansion.

## Test plan

- [x] New `test_vec_of_bus_inst_whole_vec_connection` — confirms the SV expansion produces the N × #signals named-port lines and that no `.chans(w)` (illegal SV) leaks
- [x] 451 / 451 integration tests pass (442 pre-existing + 9 Vec-of-bus)
- [x] Verilator `--lint-only` clean on the emitted SV
- [x] `arch sim` smoke runs against the whole-vec design

## With this PR, the Vec-of-bus surface is complete

| Form | Status |
|---|---|
| `port chans: initiator Vec<B, N>;` | ✓ (#384) |
| `wire w: Vec<B, N>;`               | ✓ (#384) |
| `chans[i].sig` in expressions      | ✓ (#384) |
| `chans[i] -> w[i]` per-element     | ✓ (#384) |
| `for i in 0..N-1` body access      | ✓ (#384) |
| param-driven N                     | ✓ (#385) |
| `chans -> w;` whole-vec            | ✓ (this PR) |