### PR TITLE
Fix lower_threads: thread writes to bus signals propagate to flat outputs

### DIFF
--- a/src/codegen/module.rs
+++ b/src/codegen/module.rs
@@ -263,7 +263,36 @@ impl<'a> Codegen<'a> {
         // Collect names already declared as ports, regs, or lets so we can
         // auto-declare inst output wires that aren't otherwise declared.
         let mut declared_names: std::collections::HashSet<String> = std::collections::HashSet::new();
-        for p in &m.ports { declared_names.insert(p.name.name.clone()); }
+        for p in &m.ports {
+            declared_names.insert(p.name.name.clone());
+            // Bus ports flatten to `<port>_<sig>` (or `<port>_<i>_<sig>` for
+            // Vec-of-bus) at SV signature emission. Pre-populate those flat
+            // names so the inst auto-wire-decl pass doesn't emit a redundant
+            // `logic <port>_<sig>;` declaration that would duplicate the
+            // signature line. Important for designs whose threads write to
+            // bus signals and get an inst-output connection back from the
+            // synthesized `_<mod>_threads` sub-module.
+            if let Some(bi) = p.bus_info.as_ref() {
+                if let Some((Symbol::Bus(info), _)) = self.symbols.globals.get(&bi.bus_name.name) {
+                    let mut pm = info.default_param_map();
+                    for pa in &bi.params { pm.insert(pa.name.name.clone(), &pa.value); }
+                    let prefixes: Vec<String> = match bi.count.as_ref() {
+                        None => vec![p.name.name.clone()],
+                        Some(count_expr) => {
+                            match self.eval_const_u32(count_expr, &m.params) {
+                                Some(n) => (0..n).map(|i| format!("{}_{}", p.name.name, i)).collect(),
+                                None => vec![p.name.name.clone()],
+                            }
+                        }
+                    };
+                    for prefix in &prefixes {
+                        for (sname, _, _) in info.effective_signals(&pm) {
+                            declared_names.insert(format!("{prefix}_{sname}"));
+                        }
+                    }
+                }
+            }
+        }
         for item in &m.body {
             match item {
                 ModuleBodyItem::RegDecl(r) => { declared_names.insert(r.name.name.clone()); }

--- a/src/elaborate.rs
+++ b/src/elaborate.rs
@@ -1636,6 +1636,15 @@ pub fn lower_threads_with_opts(
     let mut extra_fsms: Vec<Item> = Vec::new();
     let mut errors: Vec<CompileError> = Vec::new();
 
+    // Pre-collect bus definitions so lower_module_threads can resolve
+    // bus port FieldAccess targets in thread bodies to flattened signal
+    // names (e.g. `b.v = true;` → drives `b_v`). Without this, threads
+    // that write to bus signals leave the corresponding flat output
+    // undriven post-lowering.
+    let bus_defs: HashMap<String, BusDecl> = ast.items.iter()
+        .filter_map(|it| if let Item::Bus(b) = it { Some((b.name.name.clone(), b.clone())) } else { None })
+        .collect();
+
     for item in ast.items {
         match item {
             Item::Module(m) => {
@@ -1644,7 +1653,7 @@ pub fn lower_threads_with_opts(
                     new_items.push(Item::Module(m));
                     continue;
                 }
-                match lower_module_threads(m, opts) {
+                match lower_module_threads(m, opts, &bus_defs) {
                     Ok((new_module, fsms)) => {
                         new_items.push(Item::Module(new_module));
                         extra_fsms.extend(fsms);
@@ -1671,9 +1680,19 @@ pub fn lower_threads_with_opts(
 /// All threads become per-thread state machines within one module.
 /// Shared registers, lock arbitration, and output muxing are all
 /// handled internally — no multi-driver issues.
-fn lower_module_threads(m: ModuleDecl, opts: &ThreadLowerOpts) -> Result<(ModuleDecl, Vec<Item>), Vec<CompileError>> {
+fn lower_module_threads(
+    m: ModuleDecl,
+    opts: &ThreadLowerOpts,
+    bus_defs: &HashMap<String, BusDecl>,
+) -> Result<(ModuleDecl, Vec<Item>), Vec<CompileError>> {
     let sp = m.span;
-    let type_map = build_module_type_map(&m);
+    let type_map = build_module_type_map_with_buses(&m, bus_defs);
+    // Mapping bus port name → bus name. Used to resolve `b.v = ...` thread
+    // targets to the flat signal name `b_v` so the lowering registers
+    // them as outputs of the synthesized `_<mod>_threads` sub-module.
+    let bus_port_map: HashMap<String, String> = m.ports.iter()
+        .filter_map(|p| p.bus_info.as_ref().map(|bi| (p.name.name.clone(), bi.bus_name.name.clone())))
+        .collect();
     let _reg_map = build_module_reg_map(&m);
     let mut errors: Vec<CompileError> = Vec::new();
 
@@ -1778,21 +1797,26 @@ fn lower_module_threads(m: ModuleDecl, opts: &ThreadLowerOpts) -> Result<(Module
     let mut all_seq_driven: HashSet<String> = HashSet::new();
     let mut all_read: HashSet<String> = HashSet::new();
     for (_, t) in &threads {
-        let (cd, sd, ar) = collect_thread_signals(&t.body);
+        let (cd, sd, ar) = collect_thread_signals_with_buses(&t.body, &bus_port_map);
         all_comb_driven.extend(cd);
         all_seq_driven.extend(sd);
         all_read.extend(ar);
+        // Also seed flat bus-signal read names (`b.r` → `b_r`) so the
+        // sub-module declares them as inputs.
+        collect_thread_bus_reads(&t.body, &bus_port_map, &mut all_read);
         // Also collect signals referenced in the `default when` clause
         if let Some((dw_cond, dw_stmts)) = &t.default_when {
-            let (dw_cd, dw_sd, dw_ar) = collect_thread_signals(dw_stmts);
+            let (dw_cd, dw_sd, dw_ar) = collect_thread_signals_with_buses(dw_stmts, &bus_port_map);
             all_comb_driven.extend(dw_cd);
             all_seq_driven.extend(dw_sd);
             all_read.extend(dw_ar);
+            collect_thread_bus_reads(dw_stmts, &bus_port_map, &mut all_read);
             collect_expr_reads(dw_cond, &mut all_read);
+            collect_expr_bus_reads(dw_cond, &bus_port_map, &mut all_read);
         }
     }
     for (_, t) in &threads {
-        let (dc_targets, dc_reads) = collect_comb_stmt_signals(&t.default_comb);
+        let (dc_targets, dc_reads) = collect_comb_stmt_signals_with_buses(&t.default_comb, &bus_port_map);
         for target in &dc_targets {
             if all_seq_driven.contains(target) {
                 return Err(vec![CompileError::general(
@@ -1838,13 +1862,19 @@ fn lower_module_threads(m: ModuleDecl, opts: &ThreadLowerOpts) -> Result<(Module
         }
     }
 
-    // Input ports (read-only signals, excluding internal lock signals)
+    // Input ports (read-only signals, excluding internal lock signals).
+    // Bus port roots (like `b` for `port b: initiator B`) are filtered
+    // out because the sub-module surfaces only the flattened signals
+    // (`b_v`, `b_r`, ...) — never the bus name itself. The bus-aware
+    // collectors emit both root and flat entries; the rewrite pass
+    // converts in-body references to flat names so the root would dangle.
     let read_only: HashSet<String> = all_read.iter()
         .filter(|n| !all_comb_driven.contains(*n) && !all_seq_driven.contains(*n)
                 && **n != clk_name && **n != rst_name
                 && !n.starts_with("_t") // per-thread counters (_t0_cnt, _t0_loop_cnt, etc.)
                 && **n != "_cnt" && **n != "_loop_cnt"
-                && !lock_internal.contains(*n))
+                && !lock_internal.contains(*n)
+                && !bus_port_map.contains_key(*n))
         .cloned().collect();
     let mut sorted_reads: Vec<&String> = read_only.iter().collect();
     sorted_reads.sort();
@@ -2736,6 +2766,13 @@ fn lower_module_threads(m: ModuleDecl, opts: &ThreadLowerOpts) -> Result<(Module
     let mut merged_params = parent_params;
     merged_params.extend(state_name_params);
 
+    // Rewrite bus-port `FieldAccess(Ident(b), v)` → `Ident("b_v")` everywhere
+    // in the synthesized sub-module body. Required because the sub-module
+    // doesn't carry the bus ports themselves (only the flattened signal
+    // outputs `b_v`, ...), so the original thread-body references to
+    // `b.v` need to land on the flat names.
+    rewrite_bus_targets_in_body(&mut merged_body, &bus_port_map);
+
     let merged_module = ModuleDecl {
         name: Ident::new(merged_name.clone(), sp),
         params: merged_params,
@@ -2924,6 +2961,269 @@ struct SignalInfo {
     unpacked_ascending: bool,
 }
 
+/// Wrapper around `build_module_type_map` that ALSO seeds entries for the
+/// flattened bus-port signals: `port b: target B` with `B { v: out Bool; }`
+/// gets an entry `b_v` → Bool. Lets the thread-lowering pass treat
+/// `b.v = true;` inside a thread body the same as a write to a bare flat
+/// output port — without this, the synthesized `_<mod>_threads` sub-module
+/// fails to expose `b_v` and the parent's driver-completeness check
+/// reports it as undriven.
+///
+/// `bus_defs` is the top-level item index; consulted to resolve each bus
+/// port's effective signal list (including the `target` perspective flip).
+fn build_module_type_map_with_buses(
+    m: &ModuleDecl,
+    bus_defs: &HashMap<String, BusDecl>,
+) -> HashMap<String, SignalInfo> {
+    let mut map = build_module_type_map(m);
+    for p in &m.ports {
+        let Some(bi) = p.bus_info.as_ref() else { continue; };
+        let Some(bd) = bus_defs.get(&bi.bus_name.name) else { continue; };
+        // Effective signals (with `generate_if READ`/`WRITE` resolved). Use the
+        // bus port's own param overrides + bus defaults so width-bearing types
+        // like `UInt<DATA_W>` substitute correctly.
+        let mut param_map: HashMap<String, &Expr> = bd.params.iter()
+            .filter_map(|pd| pd.default.as_ref().map(|d| (pd.name.name.clone(), d)))
+            .collect();
+        for pa in &bi.params { param_map.insert(pa.name.name.clone(), &pa.value); }
+        let eff = bus_effective_signals(bd, &param_map);
+        // For Vec-of-bus ports, register entries for each indexed copy.
+        let prefixes: Vec<String> = match bi.count.as_ref() {
+            None => vec![p.name.name.clone()],
+            Some(count_expr) => {
+                let n = eval_const_expr_for_lower(count_expr, &m.params) as u32;
+                (0..n).map(|i| format!("{}_{}", p.name.name, i)).collect()
+            }
+        };
+        for prefix in &prefixes {
+            for (sname, _sdir, sty) in &eff {
+                let subst_ty = subst_type_expr_for_lower(sty, &param_map);
+                map.entry(format!("{prefix}_{sname}")).or_insert(SignalInfo {
+                    ty: subst_ty,
+                    reg_reset: RegReset::None,
+                    reg_init: None,
+                    shared: None,
+                    unpacked: false,
+                    unpacked_ascending: false,
+                });
+            }
+        }
+    }
+    map
+}
+
+/// Minimal `effective_signals` walker for `BusDecl`. Inlines bus-level
+/// `generate_if` gates by folding their condition against the param map;
+/// signals inside a falsy branch are dropped. Mirrors the resolve-pass
+/// `BusInfo::effective_signals` but runs pre-resolve (lower_threads is
+/// invoked before `resolve::resolve`).
+fn bus_effective_signals(
+    bd: &BusDecl,
+    param_map: &HashMap<String, &Expr>,
+) -> Vec<(String, Direction, TypeExpr)> {
+    let mut out: Vec<(String, Direction, TypeExpr)> = bd.signals.iter()
+        .map(|s| (s.name.name.clone(), s.direction, s.ty.clone()))
+        .collect();
+    for gi in &bd.generates {
+        let cond_v = eval_const_expr_for_lower(&gi.cond, &[]);
+        // Resolve any param references in the cond by substituting from
+        // param_map; fall back to the bare const eval otherwise.
+        let cond = if cond_v != 0 { true } else {
+            param_map.get(&format!("{:?}", gi.cond.kind)).is_some()
+        };
+        // Simpler: re-evaluate cond by walking param_map for Ident matches.
+        let cond = cond || gen_if_cond_truthy(&gi.cond, param_map);
+        let branch = if cond { &gi.then_signals } else { &gi.else_signals };
+        for s in branch {
+            out.push((s.name.name.clone(), s.direction, s.ty.clone()));
+        }
+    }
+    out
+}
+
+fn gen_if_cond_truthy(e: &Expr, params: &HashMap<String, &Expr>) -> bool {
+    match &e.kind {
+        ExprKind::Literal(LitKind::Dec(n))
+        | ExprKind::Literal(LitKind::Hex(n))
+        | ExprKind::Literal(LitKind::Bin(n))
+        | ExprKind::Literal(LitKind::Sized(_, n)) => *n != 0,
+        ExprKind::Bool(b) => *b,
+        ExprKind::Ident(name) => params.get(name).map_or(false, |v| gen_if_cond_truthy(v, params)),
+        _ => false,
+    }
+}
+
+/// Param-aware constant folder for the pre-resolve thread-lowering pass.
+/// A trimmed copy of the sim_codegen variant — handles literals, plain
+/// param-ident lookups, and the small arithmetic subset that surfaces in
+/// `Vec<Bus, N>` counts and bus param expressions.
+fn eval_const_expr_for_lower(expr: &Expr, params: &[ParamDecl]) -> u64 {
+    match &expr.kind {
+        ExprKind::Literal(LitKind::Dec(n))
+        | ExprKind::Literal(LitKind::Hex(n))
+        | ExprKind::Literal(LitKind::Bin(n))
+        | ExprKind::Literal(LitKind::Sized(_, n)) => *n,
+        ExprKind::Ident(name) => params.iter()
+            .find(|p| p.name.name == *name)
+            .and_then(|p| p.default.as_ref())
+            .map(|d| eval_const_expr_for_lower(d, params))
+            .unwrap_or(0),
+        ExprKind::Binary(op, l, r) => {
+            let lv = eval_const_expr_for_lower(l, params);
+            let rv = eval_const_expr_for_lower(r, params);
+            match op {
+                BinOp::Add => lv.wrapping_add(rv),
+                BinOp::Sub => lv.wrapping_sub(rv),
+                BinOp::Mul => lv.wrapping_mul(rv),
+                BinOp::Div if rv != 0 => lv / rv,
+                BinOp::Mod if rv != 0 => lv % rv,
+                BinOp::Shl => lv << (rv & 63),
+                BinOp::Shr => lv >> (rv & 63),
+                _ => 0,
+            }
+        }
+        _ => 0,
+    }
+}
+
+/// Substitute param-ident references in a type expression, walking
+/// Vec<T,N> recursively and folding width-bearing UInt/SInt N expressions.
+fn subst_type_expr_for_lower(ty: &TypeExpr, params: &HashMap<String, &Expr>) -> TypeExpr {
+    fn subst(e: &Expr, params: &HashMap<String, &Expr>) -> Expr {
+        match &e.kind {
+            ExprKind::Ident(name) => params.get(name).map(|v| (*v).clone()).unwrap_or_else(|| e.clone()),
+            _ => e.clone(),
+        }
+    }
+    match ty {
+        TypeExpr::UInt(w) => TypeExpr::UInt(Box::new(subst(w, params))),
+        TypeExpr::SInt(w) => TypeExpr::SInt(Box::new(subst(w, params))),
+        TypeExpr::Vec(elem, n) => TypeExpr::Vec(
+            Box::new(subst_type_expr_for_lower(elem, params)),
+            Box::new(subst(n, params)),
+        ),
+        _ => ty.clone(),
+    }
+}
+
+/// Like `expr_root_name` but for assignment targets: returns the
+/// `<port>_<sig>` flat name when the target is a `FieldAccess` on a known
+/// bus port. Falls back to the root name otherwise. Index-on-bus-port
+/// (`chans[i].sig`) returns `<port>_<i>_<sig>` for literal `i`; non-literal
+/// `i` (loop variable) returns just the root name and the caller is
+/// responsible for the wildcard expansion against the Vec-of-bus count map.
+fn expr_target_flat_name(e: &Expr, bus_port_map: &HashMap<String, String>) -> Option<String> {
+    match &e.kind {
+        ExprKind::FieldAccess(base, field) => {
+            if let ExprKind::Ident(base_name) = &base.kind {
+                if bus_port_map.contains_key(base_name) {
+                    return Some(format!("{}_{}", base_name, field.name));
+                }
+            }
+            if let ExprKind::Index(arr, idx) = &base.kind {
+                if let (ExprKind::Ident(arr_name), ExprKind::Literal(LitKind::Dec(i))) = (&arr.kind, &idx.kind) {
+                    if bus_port_map.contains_key(arr_name) {
+                        return Some(format!("{}_{}_{}", arr_name, i, field.name));
+                    }
+                }
+            }
+            expr_root_name(base)
+        }
+        _ => expr_root_name(e),
+    }
+}
+
+/// Walk every `Stmt` in the synthesized thread sub-module body and
+/// replace bus-port FieldAccess expressions (`b.v`) with the flat ident
+/// (`b_v`) on both LHS and RHS. The sub-module exposes the flat signals
+/// as ports — `b` itself was never carried over — so any reference to
+/// the bus name must be rewritten before SV codegen.
+fn rewrite_bus_targets_in_body(body: &mut Vec<ModuleBodyItem>, bus_port_map: &HashMap<String, String>) {
+    fn rw_expr(e: &mut Expr, bus_port_map: &HashMap<String, String>) {
+        // Bottom-up: rewrite children first.
+        match &mut e.kind {
+            ExprKind::Binary(_, l, r) => { rw_expr(l, bus_port_map); rw_expr(r, bus_port_map); }
+            ExprKind::Unary(_, x) | ExprKind::Cast(x, _) | ExprKind::LatencyAt(x, _) | ExprKind::SvaNext(_, x) =>
+                rw_expr(x, bus_port_map),
+            ExprKind::Index(b, i) | ExprKind::BitSlice(b, i, _) => {
+                rw_expr(b, bus_port_map);
+                rw_expr(i, bus_port_map);
+            }
+            ExprKind::PartSelect(b, lo, hi, _) => {
+                rw_expr(b, bus_port_map); rw_expr(lo, bus_port_map); rw_expr(hi, bus_port_map);
+            }
+            ExprKind::Ternary(c, t, e2) => {
+                rw_expr(c, bus_port_map); rw_expr(t, bus_port_map); rw_expr(e2, bus_port_map);
+            }
+            ExprKind::Concat(parts) | ExprKind::FunctionCall(_, parts) => {
+                for p in parts { rw_expr(p, bus_port_map); }
+            }
+            ExprKind::MethodCall(b, _, args) => {
+                rw_expr(b, bus_port_map);
+                for a in args { rw_expr(a, bus_port_map); }
+            }
+            ExprKind::FieldAccess(b, _) => rw_expr(b, bus_port_map),
+            _ => {}
+        }
+        // Now check if THIS node is a bus-port FieldAccess to rewrite.
+        let replacement = match &e.kind {
+            ExprKind::FieldAccess(base, field) => {
+                if let ExprKind::Ident(base_name) = &base.kind {
+                    if bus_port_map.contains_key(base_name) {
+                        Some(ExprKind::Ident(format!("{}_{}", base_name, field.name)))
+                    } else { None }
+                } else if let ExprKind::Index(arr, idx) = &base.kind {
+                    if let (ExprKind::Ident(arr_name), ExprKind::Literal(LitKind::Dec(i)))
+                        = (&arr.kind, &idx.kind)
+                    {
+                        if bus_port_map.contains_key(arr_name) {
+                            Some(ExprKind::Ident(format!("{}_{}_{}", arr_name, i, field.name)))
+                        } else { None }
+                    } else { None }
+                } else { None }
+            }
+            _ => None,
+        };
+        if let Some(new_kind) = replacement {
+            e.kind = new_kind;
+        }
+    }
+    fn rw_stmt(s: &mut Stmt, bus_port_map: &HashMap<String, String>) {
+        match s {
+            Stmt::Assign(a) => { rw_expr(&mut a.target, bus_port_map); rw_expr(&mut a.value, bus_port_map); }
+            Stmt::IfElse(ie) => {
+                rw_expr(&mut ie.cond, bus_port_map);
+                for s in &mut ie.then_stmts { rw_stmt(s, bus_port_map); }
+                for s in &mut ie.else_stmts { rw_stmt(s, bus_port_map); }
+            }
+            Stmt::Match(m) => {
+                rw_expr(&mut m.scrutinee, bus_port_map);
+                for arm in &mut m.arms { for s in &mut arm.body { rw_stmt(s, bus_port_map); } }
+            }
+            Stmt::For(f) => { for s in &mut f.body { rw_stmt(s, bus_port_map); } }
+            Stmt::Init(ib) => { for s in &mut ib.body { rw_stmt(s, bus_port_map); } }
+            Stmt::DoUntil { body, cond, .. } => {
+                rw_expr(cond, bus_port_map);
+                for s in body { rw_stmt(s, bus_port_map); }
+            }
+            Stmt::WaitUntil(e, _) => rw_expr(e, bus_port_map),
+            Stmt::Log(l) => { for a in &mut l.args { rw_expr(a, bus_port_map); } }
+        }
+    }
+    for item in body.iter_mut() {
+        match item {
+            ModuleBodyItem::CombBlock(cb) => { for s in &mut cb.stmts { rw_stmt(s, bus_port_map); } }
+            ModuleBodyItem::RegBlock(rb) => { for s in &mut rb.stmts { rw_stmt(s, bus_port_map); } }
+            ModuleBodyItem::LatchBlock(lb) => { for s in &mut lb.stmts { rw_stmt(s, bus_port_map); } }
+            ModuleBodyItem::LetBinding(lb) => rw_expr(&mut lb.value, bus_port_map),
+            ModuleBodyItem::RegDecl(r) => {
+                if let Some(init) = r.init.as_mut() { rw_expr(init, bus_port_map); }
+            }
+            _ => {}
+        }
+    }
+}
+
 fn build_module_type_map(m: &ModuleDecl) -> HashMap<String, SignalInfo> {
     let mut map = HashMap::new();
     for p in &m.ports {
@@ -2984,6 +3284,86 @@ fn build_module_reg_map(m: &ModuleDecl) -> HashMap<String, RegDecl> {
 }
 
 // ── Signal analysis ─────────────────────────────────────────────────────────
+
+fn collect_comb_stmt_signals_with_buses(
+    stmts: &[Stmt],
+    bus_port_map: &HashMap<String, String>,
+) -> (HashSet<String>, HashSet<String>) {
+    let (mut comb_driven, all_read) = collect_comb_stmt_signals(stmts);
+    // Replace bus-port root names ("b") with their flattened equivalents
+    // ("b_v"). The underlying expr_root_name walker can't distinguish them
+    // since it doesn't know which signals are bus ports.
+    comb_driven.retain(|n| !bus_port_map.contains_key(n));
+    fn walk(stmts: &[Stmt], comb_driven: &mut HashSet<String>, bus_port_map: &HashMap<String, String>) {
+        for s in stmts {
+            match s {
+                Stmt::Assign(a) => {
+                    if let Some(name) = expr_target_flat_name(&a.target, bus_port_map) {
+                        if !bus_port_map.contains_key(&name) {
+                            comb_driven.insert(name);
+                        }
+                    }
+                }
+                Stmt::IfElse(ie) => {
+                    walk(&ie.then_stmts, comb_driven, bus_port_map);
+                    walk(&ie.else_stmts, comb_driven, bus_port_map);
+                }
+                Stmt::Match(m) => { for arm in &m.arms { walk(&arm.body, comb_driven, bus_port_map); } }
+                Stmt::For(f) => walk(&f.body, comb_driven, bus_port_map),
+                Stmt::Init(ib) => walk(&ib.body, comb_driven, bus_port_map),
+                Stmt::DoUntil { body, .. } => walk(body, comb_driven, bus_port_map),
+                _ => {}
+            }
+        }
+    }
+    walk(stmts, &mut comb_driven, bus_port_map);
+    (comb_driven, all_read)
+}
+
+fn collect_thread_signals_with_buses(
+    body: &[ThreadStmt],
+    bus_port_map: &HashMap<String, String>,
+) -> (HashSet<String>, HashSet<String>, HashSet<String>) {
+    let (mut comb_driven, mut seq_driven, all_read) = collect_thread_signals(body);
+    comb_driven.retain(|n| !bus_port_map.contains_key(n));
+    seq_driven.retain(|n| !bus_port_map.contains_key(n));
+    fn walk(stmts: &[ThreadStmt],
+            comb_driven: &mut HashSet<String>,
+            seq_driven: &mut HashSet<String>,
+            bus_port_map: &HashMap<String, String>) {
+        for s in stmts {
+            match s {
+                ThreadStmt::CombAssign(a) => {
+                    if let Some(name) = expr_target_flat_name(&a.target, bus_port_map) {
+                        if !bus_port_map.contains_key(&name) {
+                            comb_driven.insert(name);
+                        }
+                    }
+                }
+                ThreadStmt::SeqAssign(a) | ThreadStmt::ForkTlmAssign(a) => {
+                    if let Some(name) = expr_target_flat_name(&a.target, bus_port_map) {
+                        if !bus_port_map.contains_key(&name) {
+                            seq_driven.insert(name);
+                        }
+                    }
+                }
+                ThreadStmt::IfElse(ie) => {
+                    walk(&ie.then_stmts, comb_driven, seq_driven, bus_port_map);
+                    walk(&ie.else_stmts, comb_driven, seq_driven, bus_port_map);
+                }
+                ThreadStmt::For { body, .. }
+                | ThreadStmt::Lock { body, .. }
+                | ThreadStmt::DoUntil { body, .. } => walk(body, comb_driven, seq_driven, bus_port_map),
+                ThreadStmt::ForkJoin(branches, _) => {
+                    for b in branches { walk(b, comb_driven, seq_driven, bus_port_map); }
+                }
+                _ => {}
+            }
+        }
+    }
+    walk(body, &mut comb_driven, &mut seq_driven, bus_port_map);
+    (comb_driven, seq_driven, all_read)
+}
 
 fn collect_comb_stmt_signals(stmts: &[Stmt]) -> (HashSet<String>, HashSet<String>) {
     let mut comb_driven = HashSet::new();
@@ -3123,6 +3503,81 @@ fn expr_root_name(e: &Expr) -> Option<String> {
 }
 
 /// Collect all identifier reads from an expression.
+/// Walk an expression and add flat bus-signal names for any bus-port
+/// FieldAccess it contains. `b.r` (a bus signal read) → adds `b_r` to
+/// `out`. Used after the underlying `collect_expr_reads` to seed the
+/// flattened input names into the sub-module's port list.
+fn collect_expr_bus_reads(e: &Expr, bus_port_map: &HashMap<String, String>, out: &mut HashSet<String>) {
+    if let ExprKind::FieldAccess(base, field) = &e.kind {
+        if let ExprKind::Ident(base_name) = &base.kind {
+            if bus_port_map.contains_key(base_name) {
+                out.insert(format!("{}_{}", base_name, field.name));
+            }
+        }
+        if let ExprKind::Index(arr, idx) = &base.kind {
+            if let (ExprKind::Ident(arr_name), ExprKind::Literal(LitKind::Dec(i)))
+                = (&arr.kind, &idx.kind)
+            {
+                if bus_port_map.contains_key(arr_name) {
+                    out.insert(format!("{}_{}_{}", arr_name, i, field.name));
+                }
+            }
+        }
+    }
+    // Recurse into children.
+    match &e.kind {
+        ExprKind::Binary(_, l, r) => { collect_expr_bus_reads(l, bus_port_map, out); collect_expr_bus_reads(r, bus_port_map, out); }
+        ExprKind::Unary(_, x) | ExprKind::Cast(x, _) | ExprKind::LatencyAt(x, _) | ExprKind::SvaNext(_, x) =>
+            collect_expr_bus_reads(x, bus_port_map, out),
+        ExprKind::Index(b, i) | ExprKind::BitSlice(b, i, _) => {
+            collect_expr_bus_reads(b, bus_port_map, out); collect_expr_bus_reads(i, bus_port_map, out);
+        }
+        ExprKind::PartSelect(b, lo, hi, _) => {
+            collect_expr_bus_reads(b, bus_port_map, out); collect_expr_bus_reads(lo, bus_port_map, out); collect_expr_bus_reads(hi, bus_port_map, out);
+        }
+        ExprKind::Ternary(c, t, e2) => {
+            collect_expr_bus_reads(c, bus_port_map, out); collect_expr_bus_reads(t, bus_port_map, out); collect_expr_bus_reads(e2, bus_port_map, out);
+        }
+        ExprKind::Concat(parts) | ExprKind::FunctionCall(_, parts) => {
+            for p in parts { collect_expr_bus_reads(p, bus_port_map, out); }
+        }
+        ExprKind::MethodCall(b, _, args) => {
+            collect_expr_bus_reads(b, bus_port_map, out);
+            for a in args { collect_expr_bus_reads(a, bus_port_map, out); }
+        }
+        ExprKind::FieldAccess(b, _) => collect_expr_bus_reads(b, bus_port_map, out),
+        _ => {}
+    }
+}
+
+/// Walk a thread body (recursively) and add flat bus-signal read names
+/// to `out`. Companion to `collect_expr_bus_reads` for the statement
+/// shape.
+fn collect_thread_bus_reads(body: &[ThreadStmt], bus_port_map: &HashMap<String, String>, out: &mut HashSet<String>) {
+    for s in body {
+        match s {
+            ThreadStmt::CombAssign(a) | ThreadStmt::SeqAssign(a) | ThreadStmt::ForkTlmAssign(a) => {
+                collect_expr_bus_reads(&a.value, bus_port_map, out);
+                collect_expr_bus_reads(&a.target, bus_port_map, out);
+            }
+            ThreadStmt::WaitUntil(c, _) => collect_expr_bus_reads(c, bus_port_map, out),
+            ThreadStmt::IfElse(ie) => {
+                collect_expr_bus_reads(&ie.cond, bus_port_map, out);
+                collect_thread_bus_reads(&ie.then_stmts, bus_port_map, out);
+                collect_thread_bus_reads(&ie.else_stmts, bus_port_map, out);
+            }
+            ThreadStmt::For { body, .. } | ThreadStmt::Lock { body, .. } => collect_thread_bus_reads(body, bus_port_map, out),
+            ThreadStmt::DoUntil { body, cond, .. } => {
+                collect_expr_bus_reads(cond, bus_port_map, out);
+                collect_thread_bus_reads(body, bus_port_map, out);
+            }
+            ThreadStmt::ForkJoin(branches, _) => { for b in branches { collect_thread_bus_reads(b, bus_port_map, out); } }
+            ThreadStmt::Return(e, _) => collect_expr_bus_reads(e, bus_port_map, out),
+            _ => {}
+        }
+    }
+}
+
 fn collect_expr_reads(e: &Expr, out: &mut HashSet<String>) {
     match &e.kind {
         ExprKind::Ident(name) => { out.insert(name.clone()); }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1201,16 +1201,35 @@ impl Parser {
             None
         };
         if let Some(perspective) = bus_perspective {
-            // Two surface forms:
-            //   port chans: initiator Vec<BusName, N>;       — array of N copies
-            //   port chan:  initiator BusName<PARAM=val>;    — scalar (existing)
-            let (bus_name, count) = if self.check(TokenKind::KwVec) {
+            // Three surface forms:
+            //   port chans: initiator Vec<BusName, N>;                  — array, default params
+            //   port chans: initiator Vec<BusName<PARAM=val>, N>;       — array, params inside Vec
+            //   port chan:  initiator BusName<PARAM=val>;               — scalar (existing)
+            let (bus_name, count, inner_params) = if self.check(TokenKind::KwVec) {
                 let vec_span = self.peek_span();
                 self.advance(); // consume Vec
                 self.expect(TokenKind::Lt)?;
                 let old_no_angle = self.no_angle;
                 self.no_angle = true;
                 let bus_ident = self.expect_ident()?;
+                // Optional bus-param assignments INSIDE the Vec, e.g.
+                // `Vec<BusAxi4<ADDR_W=32>, N>`. Same shape as the scalar
+                // `BusAxi4<...>` form just after the bus name.
+                let inner_params = if self.check(TokenKind::Lt) {
+                    self.advance();
+                    let mut assigns = Vec::new();
+                    loop {
+                        let pname = self.expect_ident()?;
+                        self.expect(TokenKind::Eq)?;
+                        let pval = self.parse_expr()?;
+                        assigns.push(ParamAssign { name: pname, value: pval, ty: None });
+                        if !self.eat(TokenKind::Comma) { break; }
+                    }
+                    self.expect(TokenKind::Gt)?;
+                    assigns
+                } else {
+                    Vec::new()
+                };
                 self.expect(TokenKind::Comma)?;
                 let count_expr = self.parse_expr()?;
                 self.no_angle = old_no_angle;
@@ -1227,12 +1246,16 @@ impl Parser {
                         vec_span,
                     ));
                 }
-                (bus_ident, Some(count_expr))
+                (bus_ident, Some(count_expr), inner_params)
             } else {
-                (self.expect_ident()?, None)
+                (self.expect_ident()?, None, Vec::new())
             };
-            // Optional param assignments: <PARAM=val, ...>
-            let params = if self.check(TokenKind::Lt) {
+            // Optional param assignments OUTSIDE the form: `<PARAM=val, ...>`
+            // for the scalar `port: initiator BusName<...>` shape, OR the
+            // legacy post-Vec form `Vec<B, N><...>`. Inner-Vec params take
+            // precedence over outer when both are written (same key wins
+            // last by the assignment ordering below).
+            let mut params = if self.check(TokenKind::Lt) {
                 self.advance();
                 let old_no_angle = self.no_angle;
                 self.no_angle = true;
@@ -1250,6 +1273,7 @@ impl Parser {
             } else {
                 Vec::new()
             };
+            params.extend(inner_params);
             self.expect(TokenKind::Semi)?;
             let end_span = self.tokens.get(self.pos.saturating_sub(1)).map(|t| t.span).unwrap_or(start);
             return Ok(PortDecl {

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -852,40 +852,68 @@ impl<'a> TypeChecker<'a> {
                     // single-driver check sees them. Full typecheck of thread
                     // bodies is light in Phase 1 (the spike emitter rejects
                     // unsupported shapes itself).
-                    fn walk_thread(stmts: &[crate::ast::ThreadStmt], driven: &mut HashSet<String>) {
+                    let vob_ports = self.vec_of_bus_ports.clone();
+                    fn mark_target(target: &crate::ast::Expr, driven: &mut HashSet<String>,
+                                   vob_ports: &HashMap<String, u32>) {
+                        // Bare Ident, `bus.sig`, `arr[i].sig`, `arr[i]` all flow
+                        // through expr_flat_name_tc / expr_root_name_tc the same
+                        // way they do for comb-block targets — ensures bus-port
+                        // outputs assigned inside thread bodies satisfy the
+                        // driver-completeness check.
+                        let root = TypeChecker::expr_root_name_tc(target);
+                        if !root.is_empty() { driven.insert(root.clone()); }
+                        let flat = TypeChecker::expr_flat_name_tc(target);
+                        if !flat.is_empty() && flat != root { driven.insert(flat.clone()); }
+                        // Indexed Vec-of-bus target with a non-literal idx —
+                        // mirror the comb-block handling: mark every flat copy.
+                        if let crate::ast::ExprKind::FieldAccess(base, field) = &target.kind {
+                            if let crate::ast::ExprKind::Index(arr, idx) = &base.kind {
+                                if let crate::ast::ExprKind::Ident(arr_name) = &arr.kind {
+                                    let is_lit = matches!(&idx.kind,
+                                        crate::ast::ExprKind::Literal(_));
+                                    if !is_lit {
+                                        if let Some(&n) = vob_ports.get(arr_name) {
+                                            for i in 0..n {
+                                                driven.insert(format!("{}_{}_{}", arr_name, i, field.name));
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    fn walk_thread(stmts: &[crate::ast::ThreadStmt], driven: &mut HashSet<String>,
+                                   vob_ports: &HashMap<String, u32>) {
                         use crate::ast::ThreadStmt;
                         for s in stmts {
                             match s {
-                                ThreadStmt::CombAssign(a) => {
-                                    if let crate::ast::ExprKind::Ident(n) = &a.target.kind {
-                                        driven.insert(n.clone());
-                                    }
-                                }
-                                ThreadStmt::SeqAssign(a) => {
-                                    if let crate::ast::ExprKind::Ident(n) = &a.target.kind {
-                                        driven.insert(n.clone());
-                                    }
-                                }
-                                ThreadStmt::ForkTlmAssign(a) => {
-                                    if let crate::ast::ExprKind::Ident(n) = &a.target.kind {
-                                        driven.insert(n.clone());
-                                    }
-                                }
+                                ThreadStmt::CombAssign(a) => mark_target(&a.target, driven, vob_ports),
+                                ThreadStmt::SeqAssign(a)  => mark_target(&a.target, driven, vob_ports),
+                                ThreadStmt::ForkTlmAssign(a) => mark_target(&a.target, driven, vob_ports),
                                 ThreadStmt::IfElse(ie) => {
-                                    walk_thread(&ie.then_stmts, driven);
-                                    walk_thread(&ie.else_stmts, driven);
+                                    walk_thread(&ie.then_stmts, driven, vob_ports);
+                                    walk_thread(&ie.else_stmts, driven, vob_ports);
                                 }
                                 ThreadStmt::For { body, .. }
                                 | ThreadStmt::Lock { body, .. }
-                                | ThreadStmt::DoUntil { body, .. } => walk_thread(body, driven),
+                                | ThreadStmt::DoUntil { body, .. } => walk_thread(body, driven, vob_ports),
                                 ThreadStmt::ForkJoin(branches, _) => {
-                                    for b in branches { walk_thread(b, driven); }
+                                    for b in branches { walk_thread(b, driven, vob_ports); }
                                 }
                                 _ => {}
                             }
                         }
                     }
-                    walk_thread(&t.body, &mut driven);
+                    walk_thread(&t.body, &mut driven, &vob_ports);
+                    // `default comb ... end default` targets — these drive
+                    // bus signals between active states; they also satisfy
+                    // the driver-completeness check (every output port has
+                    // at least a default value).
+                    for s in &t.default_comb {
+                        if let Stmt::Assign(a) = s {
+                            mark_target(&a.target, &mut driven, &vob_ports);
+                        }
+                    }
                 }
                 ModuleBodyItem::Resource(_) => {
                     // Resources are lowered before typecheck.

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -4134,6 +4134,54 @@ fn test_vec_of_bus_port_typecheck_drives_all_indexed_outputs() {
 }
 
 #[test]
+fn test_thread_writing_bus_signals_lowers_correctly() {
+    // Regression: previously a `thread T ... b.v = ...; ... end thread T`
+    // where `b: initiator B;` is a bus port would lower without exposing
+    // `b_v` as an output of the synthesized `_<mod>_threads` sub-module.
+    // The parent's driver-completeness check then reported
+    // `output port "b_v" is not driven`. Fixed by teaching the
+    // signal-collection + body-rewrite passes about bus-port FieldAccess
+    // targets, and by widening `declared_names` to include flattened bus
+    // signals so the inst auto-wire-decl pass doesn't duplicate them.
+    let source = "
+        bus B
+          v: out Bool;
+          d: out UInt<8>;
+          r: in  Bool;
+        end bus B
+        module M
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Async, Low>;
+          port b: initiator B;
+          port start: in Bool;
+          thread T on clk rising, rst low
+            default comb
+              b.v = false;
+              b.d = 0;
+            end default
+            wait until start;
+            do
+              b.v = true;
+              b.d = 8'hA5;
+            until b.r;
+          end thread T
+        end module M
+    ";
+    let sv = compile_to_sv(source);
+    // Sub-module exposes flat bus signals as ports.
+    assert!(sv.contains("output logic b_v")
+            && sv.contains("output logic [7:0] b_d")
+            && sv.contains("input logic b_r"),
+            "expected sub-module flat bus signals in SV:\n{sv}");
+    // Sub-inst connects them through to parent's flat ports — and the
+    // parent's signature must NOT have duplicate `logic b_v;` decls.
+    assert!(sv.matches("logic b_v").count() <= 2,
+            "expected at most one `logic b_v` decl per module:\n{sv}");
+    assert!(sv.contains(".b_v(b_v)") || sv.contains(".b_v (b_v)"),
+            "expected `.b_v(b_v)` inst-output connection:\n{sv}");
+}
+
+#[test]
 fn test_vec_of_bus_for_loop_static_unroll() {
     // `chans[i].sig = ...;` inside `for i in 0..N-1` over a `Vec<Bus, N>`
     // port has no SV-level array (the signature exposes only the flattened


### PR DESCRIPTION
## Bug

A thread body that writes to a bus port field doesn't survive `lower_threads`. The synthesized `_<mod>_threads` sub-module fails to expose the corresponding flat signal as an output, so the parent's driver-completeness check reports it as undriven.

**Minimal reproducer (failed before this PR):**

```arch
bus B
  v: out Bool;
end bus B
module M
  port clk: in Clock<SysDomain>;
  port rst: in Reset<Async, Low>;
  port b: initiator B;
  port start: in Bool;
  thread T on clk rising, rst low
    default comb b.v = false; end default
    wait until start;
    do  b.v = true;  until true;
  end thread T
end module M
```

→ `output port "b_v" is not driven`. Same module with `comb b.v = true;` or with a bare `port b_v: out Bool;` works — only the thread-body × bus-port-target combination was broken.

This blocked the spec-hierarchical NIC-400 rewrite (every thread in the spec MasterPort/SlavePort writes to bus signals via `to[j].ar_valid = ...`, `m.r_data = ...` etc.).

## Root cause

The signal-collection helpers in `lower_threads` (`collect_thread_signals`, `collect_comb_stmt_signals`) used `expr_root_name`, which returns the bus port root `"b"` for any FieldAccess target. The lowered sub-module then listed `"b"` (the bus type — illegal SV) instead of `"b_v"` (the flat output that the parent needs).

## Fix (4 parts)

| File | What |
|---|---|
| `src/elaborate.rs` | Thread sub-module construction now knows about bus ports. Pass top-level bus defs in; populate the type map with flattened `<port>_<sig>` entries (per-element for `Vec<Bus,N>`); replace bus-port FieldAccess targets in collected drive sets with their flat names via new `expr_target_flat_name`. New `rewrite_bus_targets_in_body` post-pass rewrites every `FieldAccess(Ident(busport), field)` in the sub-module body to `Ident("<busport>_<field>")` so in-body references match the sub-module's flat outputs. New `collect_expr_bus_reads` / `collect_thread_bus_reads` seed input-side flat reads (`b.r` → `b_r`) so the sub-module declares them as input ports. |
| `src/codegen/module.rs` | Pre-populate `declared_names` with flattened bus port signals (including Vec-of-bus per-element copies) so the inst auto-wire-decl pass doesn't duplicate them, avoiding Verilator's "Variable defined more than once" error. |
| `src/typecheck.rs` | Thread-pass driver tracking widens to FieldAccess/Index targets (mirrors the comb walker). Needed for the `--thread-sim parallel` path where threads aren't lowered. |
| `src/parser.rs` | Tangential cleanup: parse params *inside* the Vec form (`Vec<BusAxi4<ADDR_W=32>, N>`) in addition to the post-Vec form (`Vec<B, N><ADDR_W=32>`). Matches the spec syntax. Inner params merge with outer. |

## Test plan

- [x] New `test_thread_writing_bus_signals_lowers_correctly` integration test covers the regression directly
- [x] **452 / 452 integration tests pass** (451 pre-existing + 1 new)
- [x] Verilator `--lint-only` clean on the emitted SV
- [x] Confirmed the NIC-400 spec-hierarchical MasterPort (which previously triggered the bug on every `to[j].ar_valid = ...` thread write) now compiles + lints clean

## Unlocked downstream work

This is the last missing piece for the NIC-400 hierarchical rewrite — every MasterPort / SlavePort thread can now use bus-port FieldAccess targets directly, matching the spec design. The v2 design will be a separate PR on top of this.