### PR TITLE
NIC-400 v2: hierarchical spec-shaped design + supporting compiler fixes

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -786,6 +786,13 @@ pub struct WireDecl {
     /// (or upstream SV `[N]` shorthand) by-index without IEEE 1800-2017
     /// §10.10 silent reversal. Only legal when `unpacked` is also set.
     pub unpacked_ascending: bool,
+    /// `wire w: BusName<PARAM=val, ...>;` or
+    /// `wire w: Vec<BusName<PARAM=val, ...>, N>;` — bus param overrides
+    /// applied at the wire site. Empty for non-bus wires. Stored
+    /// separately from `ty` so the existing TypeExpr shape stays
+    /// invariant; the codegen merges these with bus defaults when
+    /// emitting flat signal types.
+    pub bus_params: Vec<ParamAssign>,
     pub span: Span,
 }
 

--- a/src/codegen/module.rs
+++ b/src/codegen/module.rs
@@ -682,11 +682,16 @@ impl<'a> Codegen<'a> {
                         for prefix in &prefixes {
                             self.bus_wires.insert(prefix.clone(), bus_name.clone());
                         }
-                        let param_map: std::collections::HashMap<String, &Expr> =
+                        // Start with the bus's declared defaults then layer
+                        // any per-wire overrides from `wire w: Vec<B<PARAM=val>, N>;`.
+                        let mut param_map: std::collections::HashMap<String, &Expr> =
                             info.params.iter()
                                 .filter_map(|pd| pd.default.as_ref()
                                     .map(|d| (pd.name.name.clone(), d)))
                                 .collect();
+                        for pa in &w.bus_params {
+                            param_map.insert(pa.name.name.clone(), &pa.value);
+                        }
                         for prefix in &prefixes {
                             for (sname, _sdir, sty) in info.effective_signals(&param_map) {
                                 let subst_ty = Self::subst_type_expr(&sty, &param_map);

--- a/src/elaborate.rs
+++ b/src/elaborate.rs
@@ -599,7 +599,7 @@ fn lower_tlm_connects_in_module(
         used_names.insert(wire_name.clone());
 
         let wire_ident = Ident::new(wire_name.clone(), conn.span);
-        synthesized_wires.push(ModuleBodyItem::WireDecl(WireDecl {
+        synthesized_wires.push(ModuleBodyItem::WireDecl(WireDecl { bus_params: Vec::new(),
             name: wire_ident.clone(),
             ty: TypeExpr::Named(Ident::new(from_bus.clone(), conn.span)),
             unpacked: false, unpacked_ascending: false,
@@ -1955,11 +1955,11 @@ fn lower_module_threads(
         let n_threads = threads.len();
         // Per-thread scalar req/grant wires (internal to the merged module).
         for ti in 0..n_threads {
-            merged_body.push(ModuleBodyItem::WireDecl(WireDecl {
+            merged_body.push(ModuleBodyItem::WireDecl(WireDecl { bus_params: Vec::new(),
                 name: Ident::new(format!("_{}_req_{}", res_name, ti), sp),
                 ty: TypeExpr::Bool, unpacked: false, unpacked_ascending: false, span: sp,
             }));
-            merged_body.push(ModuleBodyItem::WireDecl(WireDecl {
+            merged_body.push(ModuleBodyItem::WireDecl(WireDecl { bus_params: Vec::new(),
                 name: Ident::new(format!("_{}_grant_{}", res_name, ti), sp),
                 ty: TypeExpr::Bool, unpacked: false, unpacked_ascending: false, span: sp,
             }));
@@ -1969,11 +1969,11 @@ fn lower_module_threads(
         let grant_packed = format!("_{}_grant_packed", res_name);
         let n_threads_expr = Expr::new(
             ExprKind::Literal(LitKind::Dec(n_threads as u64)), sp);
-        merged_body.push(ModuleBodyItem::WireDecl(WireDecl {
+        merged_body.push(ModuleBodyItem::WireDecl(WireDecl { bus_params: Vec::new(),
             name: Ident::new(req_packed.clone(), sp),
             ty: TypeExpr::UInt(Box::new(n_threads_expr.clone())), unpacked: false, unpacked_ascending: false, span: sp,
         }));
-        merged_body.push(ModuleBodyItem::WireDecl(WireDecl {
+        merged_body.push(ModuleBodyItem::WireDecl(WireDecl { bus_params: Vec::new(),
             name: Ident::new(grant_packed.clone(), sp),
             ty: TypeExpr::UInt(Box::new(n_threads_expr.clone())), unpacked: false, unpacked_ascending: false, span: sp,
         }));
@@ -1983,11 +1983,11 @@ fn lower_module_threads(
         let gv_sink = format!("_{}_grant_valid", res_name);
         let gr_sink = format!("_{}_grant_requester", res_name);
         let gr_width = crate::width::index_width(n_threads as u64);
-        merged_body.push(ModuleBodyItem::WireDecl(WireDecl {
+        merged_body.push(ModuleBodyItem::WireDecl(WireDecl { bus_params: Vec::new(),
             name: Ident::new(gv_sink.clone(), sp),
             ty: TypeExpr::Bool, unpacked: false, unpacked_ascending: false, span: sp,
         }));
-        merged_body.push(ModuleBodyItem::WireDecl(WireDecl {
+        merged_body.push(ModuleBodyItem::WireDecl(WireDecl { bus_params: Vec::new(),
             name: Ident::new(gr_sink.clone(), sp),
             ty: TypeExpr::UInt(Box::new(Expr::new(
                 ExprKind::Literal(LitKind::Dec(gr_width as u64)), sp))), unpacked: false, unpacked_ascending: false, span: sp,
@@ -2105,7 +2105,7 @@ fn lower_module_threads(
             // Per-thread input wires: _sig_in_0, _sig_in_1, ...
             for ti in 0..n_threads {
                 let wire_name = format!("_{}_in_{}", sig_name, ti);
-                merged_body.push(ModuleBodyItem::WireDecl(WireDecl {
+                merged_body.push(ModuleBodyItem::WireDecl(WireDecl { bus_params: Vec::new(),
                     name: Ident::new(wire_name, sp),
                     ty: info.ty.clone(),
                     unpacked: false, unpacked_ascending: false,
@@ -2819,7 +2819,7 @@ fn lower_module_threads(
             continue;
         };
         if thread_driven.contains(&r.name.name) {
-            *item = ModuleBodyItem::WireDecl(WireDecl {
+            *item = ModuleBodyItem::WireDecl(WireDecl { bus_params: Vec::new(),
                 name: r.name.clone(),
                 ty: r.ty.clone(),
                 unpacked: false,
@@ -7805,7 +7805,7 @@ fn inline_lower_tlm_initiator_group(
             let mut next = Vec::new();
             for (chunk_i, chunk) in cur.chunks(CHUNK).enumerate() {
                 let wire_name = format!("{prefix}_or_l{level}_{chunk_i}");
-                items.push(ModuleBodyItem::WireDecl(WireDecl {
+                items.push(ModuleBodyItem::WireDecl(WireDecl { bus_params: Vec::new(),
                     name: mk_ident(wire_name.clone()),
                     ty: TypeExpr::Bool,
                     unpacked: false,
@@ -7840,7 +7840,7 @@ fn inline_lower_tlm_initiator_group(
             let mut next = Vec::new();
             for (chunk_i, chunk) in cur.chunks(CHUNK).enumerate() {
                 let wire_name = format!("{prefix}_and_l{level}_{chunk_i}");
-                items.push(ModuleBodyItem::WireDecl(WireDecl {
+                items.push(ModuleBodyItem::WireDecl(WireDecl { bus_params: Vec::new(),
                     name: mk_ident(wire_name.clone()),
                     ty: TypeExpr::Bool,
                     unpacked: false,
@@ -7892,14 +7892,14 @@ fn inline_lower_tlm_initiator_group(
             for (chunk_i, chunk) in cur.chunks(CHUNK).enumerate() {
                 let valid_name = format!("{prefix}_mux_valid_l{level}_{chunk_i}");
                 let data_name = format!("{prefix}_mux_data_l{level}_{chunk_i}");
-                items.push(ModuleBodyItem::WireDecl(WireDecl {
+                items.push(ModuleBodyItem::WireDecl(WireDecl { bus_params: Vec::new(),
                     name: mk_ident(valid_name.clone()),
                     ty: TypeExpr::Bool,
                     unpacked: false,
                     unpacked_ascending: false,
                     span,
                 }));
-                items.push(ModuleBodyItem::WireDecl(WireDecl {
+                items.push(ModuleBodyItem::WireDecl(WireDecl { bus_params: Vec::new(),
                     name: mk_ident(data_name.clone()),
                     ty: ty.clone(),
                     unpacked: false,
@@ -7939,7 +7939,7 @@ fn inline_lower_tlm_initiator_group(
         let mut want_refs: Vec<Expr> = Vec::new();
         for (i, cond) in issue_conds.iter().enumerate() {
             let want_name = format!("_tlm_init_{}_{}_want_{}", agg.port, agg.method, i);
-            items.push(ModuleBodyItem::WireDecl(WireDecl {
+            items.push(ModuleBodyItem::WireDecl(WireDecl { bus_params: Vec::new(),
                 name: mk_ident(want_name.clone()),
                 ty: TypeExpr::Bool,
                 unpacked: false,
@@ -8028,7 +8028,7 @@ fn inline_lower_tlm_initiator_group(
                 grants.push(grant);
                 if i + 1 < want_refs.len() {
                     let taken_name = format!("_tlm_init_{}_{}_taken_{}", agg.port, agg.method, i);
-                    items.push(ModuleBodyItem::WireDecl(WireDecl {
+                    items.push(ModuleBodyItem::WireDecl(WireDecl { bus_params: Vec::new(),
                         name: mk_ident(taken_name.clone()),
                         ty: TypeExpr::Bool,
                         unpacked: false,
@@ -8048,7 +8048,7 @@ fn inline_lower_tlm_initiator_group(
         let mut grants: Vec<Expr> = Vec::new();
         for (i, grant_expr) in grant_exprs.iter().enumerate() {
             let grant_name = format!("_tlm_init_{}_{}_grant_{}", agg.port, agg.method, i);
-            items.push(ModuleBodyItem::WireDecl(WireDecl {
+            items.push(ModuleBodyItem::WireDecl(WireDecl { bus_params: Vec::new(),
                 name: mk_ident(grant_name.clone()),
                 ty: TypeExpr::Bool,
                 unpacked: false,
@@ -9265,17 +9265,17 @@ fn lower_indexed_tlm_target_group(
         let rsp_tag = format!("{prefix}_rsp_tag");
         let rsp_data = format!("{prefix}_rsp_data");
 
-        out.push(ModuleBodyItem::WireDecl(WireDecl { name: mk_ident(req_ready.clone()), ty: TypeExpr::Bool, unpacked: false, unpacked_ascending: false, span }));
-        out.push(ModuleBodyItem::WireDecl(WireDecl { name: mk_ident(rsp_valid.clone()), ty: TypeExpr::Bool, unpacked: false, unpacked_ascending: false, span }));
-        out.push(ModuleBodyItem::WireDecl(WireDecl { name: mk_ident(rsp_ready.clone()), ty: TypeExpr::Bool, unpacked: false, unpacked_ascending: false, span }));
-        out.push(ModuleBodyItem::WireDecl(WireDecl {
+        out.push(ModuleBodyItem::WireDecl(WireDecl { bus_params: Vec::new(), name: mk_ident(req_ready.clone()), ty: TypeExpr::Bool, unpacked: false, unpacked_ascending: false, span }));
+        out.push(ModuleBodyItem::WireDecl(WireDecl { bus_params: Vec::new(), name: mk_ident(rsp_valid.clone()), ty: TypeExpr::Bool, unpacked: false, unpacked_ascending: false, span }));
+        out.push(ModuleBodyItem::WireDecl(WireDecl { bus_params: Vec::new(), name: mk_ident(rsp_ready.clone()), ty: TypeExpr::Bool, unpacked: false, unpacked_ascending: false, span }));
+        out.push(ModuleBodyItem::WireDecl(WireDecl { bus_params: Vec::new(),
             name: mk_ident(rsp_tag.clone()),
             ty: TypeExpr::UInt(Box::new(Expr::new(ExprKind::Literal(LitKind::Dec(tag_w as u64)), span))),
             unpacked: false, unpacked_ascending: false,
             span,
         }));
         if let Some(ret_ty) = &method.ret {
-            out.push(ModuleBodyItem::WireDecl(WireDecl { name: mk_ident(rsp_data.clone()), ty: ret_ty.clone(), unpacked: false, unpacked_ascending: false, span }));
+            out.push(ModuleBodyItem::WireDecl(WireDecl { bus_params: Vec::new(), name: mk_ident(rsp_data.clone()), ty: ret_ty.clone(), unpacked: false, unpacked_ascending: false, span }));
         }
 
         let req_valid = Expr::new(
@@ -9321,28 +9321,28 @@ fn lower_indexed_tlm_target_group(
     let lane_count_expr = Expr::new(ExprKind::Literal(LitKind::Dec(lane_count as u64)), span);
     let grant_width = crate::width::index_width(lane_count as u64);
 
-    out.push(ModuleBodyItem::WireDecl(WireDecl {
+    out.push(ModuleBodyItem::WireDecl(WireDecl { bus_params: Vec::new(),
         name: mk_ident(req_packed.clone()),
         ty: TypeExpr::UInt(Box::new(lane_count_expr.clone())),
         unpacked: false,
         unpacked_ascending: false,
         span,
     }));
-    out.push(ModuleBodyItem::WireDecl(WireDecl {
+    out.push(ModuleBodyItem::WireDecl(WireDecl { bus_params: Vec::new(),
         name: mk_ident(grant_packed.clone()),
         ty: TypeExpr::UInt(Box::new(lane_count_expr.clone())),
         unpacked: false,
         unpacked_ascending: false,
         span,
     }));
-    out.push(ModuleBodyItem::WireDecl(WireDecl {
+    out.push(ModuleBodyItem::WireDecl(WireDecl { bus_params: Vec::new(),
         name: mk_ident(grant_valid.clone()),
         ty: TypeExpr::Bool,
         unpacked: false,
         unpacked_ascending: false,
         span,
     }));
-    out.push(ModuleBodyItem::WireDecl(WireDecl {
+    out.push(ModuleBodyItem::WireDecl(WireDecl { bus_params: Vec::new(),
         name: mk_ident(grant_requester.clone()),
         ty: TypeExpr::UInt(Box::new(Expr::new(ExprKind::Literal(LitKind::Dec(grant_width as u64)), span))),
         unpacked: false,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1613,7 +1613,14 @@ impl Parser {
         // Optional `ascending` follows `unpacked` (mirror of port modifier).
         // See arch-com#307.
         let unpacked_ascending = if unpacked { self.eat_contextual("ascending") } else { false };
-        let ty = self.parse_type_expr()?;
+        // Special case for bus-typed wires (scalar or Vec): consume any
+        // inline `<PARAM=val, ...>` param overrides. The bus param list
+        // is stashed in `WireDecl.bus_params` so codegen can apply it to
+        // each flattened signal width — without this, declarations like
+        // `wire w: Vec<BusAxi4<ID_W=4>, 2>;` would carry the bus's
+        // default param values into the flat signal emission and
+        // mismatch any port that overrode the same params.
+        let (ty, bus_params) = self.parse_wire_type_with_bus_params()?;
         self.expect(TokenKind::Semi)?;
         let end_span = self.tokens.get(self.pos.saturating_sub(1)).map(|t| t.span).unwrap_or(start);
         if unpacked && !matches!(ty, TypeExpr::Vec(..)) {
@@ -1627,8 +1634,86 @@ impl Parser {
             ty,
             unpacked,
             unpacked_ascending,
+            bus_params,
             span: start.merge(end_span),
         })
+    }
+
+    /// Parse a wire type. Accepts the standard forms plus two bus-typed
+    /// shapes that carry inline param overrides:
+    ///
+    ///   wire w: BusName<PARAM=val, ...>;
+    ///   wire w: Vec<BusName<PARAM=val, ...>, N>;
+    ///
+    /// Returns the standard TypeExpr (params stripped) plus the parsed
+    /// param assignments. Empty Vec when none are present or when the
+    /// type is non-bus.
+    fn parse_wire_type_with_bus_params(&mut self) -> Result<(TypeExpr, Vec<ParamAssign>), CompileError> {
+        // Vec<BusName<...>, N> path: detect Vec keyword and parse manually.
+        if self.check(TokenKind::KwVec) {
+            self.advance();
+            self.expect(TokenKind::Lt)?;
+            let old_no_angle = self.no_angle;
+            self.no_angle = true;
+            // Element type: try Named-with-params first (bus form), fall
+            // back to a general type expr otherwise.
+            let (elem_ty, bus_params) = if let Some(TokenKind::Ident(_)) = self.peek_kind() {
+                let bus_ident = self.expect_ident()?;
+                let params = if self.check(TokenKind::Lt) {
+                    self.advance();
+                    let mut assigns = Vec::new();
+                    loop {
+                        let pname = self.expect_ident()?;
+                        self.expect(TokenKind::Eq)?;
+                        let pval = self.parse_expr()?;
+                        assigns.push(ParamAssign { name: pname, value: pval, ty: None });
+                        if !self.eat(TokenKind::Comma) { break; }
+                    }
+                    self.expect(TokenKind::Gt)?;
+                    assigns
+                } else {
+                    Vec::new()
+                };
+                (TypeExpr::Named(bus_ident), params)
+            } else {
+                // Not a Named element — re-enter the standard parser. No
+                // bus params possible.
+                (self.parse_type_expr()?, Vec::new())
+            };
+            self.expect(TokenKind::Comma)?;
+            let count = self.parse_expr()?;
+            self.no_angle = old_no_angle;
+            self.expect(TokenKind::Gt)?;
+            return Ok((TypeExpr::Vec(Box::new(elem_ty), Box::new(count)), bus_params));
+        }
+        // Scalar bus wire: `wire w: BusName<...>;`. Parse a bare ident
+        // then check for inline params; if not present, fall through to
+        // the regular type parser (covers Bool, UInt<N>, etc.).
+        if let Some(TokenKind::Ident(_)) = self.peek_kind() {
+            // Peek a second token to distinguish `BusName<...>` from
+            // `BusName;` (a bare named type) from the type-keyword forms
+            // (UInt, SInt, etc. start with the keyword kind, not Ident).
+            let saved = self.pos;
+            let bus_ident = self.expect_ident()?;
+            if self.check(TokenKind::Lt) {
+                self.advance();
+                let mut assigns = Vec::new();
+                loop {
+                    let pname = self.expect_ident()?;
+                    self.expect(TokenKind::Eq)?;
+                    let pval = self.parse_expr()?;
+                    assigns.push(ParamAssign { name: pname, value: pval, ty: None });
+                    if !self.eat(TokenKind::Comma) { break; }
+                }
+                self.expect(TokenKind::Gt)?;
+                return Ok((TypeExpr::Named(bus_ident), assigns));
+            }
+            // Not followed by `<` — could be a plain Named type; reuse
+            // the existing path so its full grammar (e.g. struct types)
+            // applies uniformly.
+            self.pos = saved;
+        }
+        Ok((self.parse_type_expr()?, Vec::new()))
     }
 
     fn parse_reg_decl(&mut self) -> Result<RegDecl, CompileError> {

--- a/src/sim_codegen/mod.rs
+++ b/src/sim_codegen/mod.rs
@@ -1557,6 +1557,12 @@ fn expand_bus_connections(
                         if let (ExprKind::Ident(arr_name), ExprKind::Literal(LitKind::Dec(i))) = (&arr.kind, &idx.kind) {
                             if bus_wire_names.contains(arr_name.as_str()) {
                                 BindKind::WireIndex(arr_name.clone(), *i as u32)
+                            } else if parent_vec_of_bus_ports.contains_key(arr_name.as_str()) {
+                                // Vec-of-bus PORT element on the parent
+                                // side (`port s: initiator Vec<B, N>`):
+                                // flat name is `<port>_<i>`, mirroring
+                                // the port flattening.
+                                BindKind::FlatPort(format!("{}_{}", arr_name, i))
                             } else { continue; }
                         } else { continue; }
                     }
@@ -7874,7 +7880,15 @@ impl<'a> SimCodegen<'a> {
             }
         }
         for b in &buses {
-            let param_map: HashMap<String, &Expr> = HashMap::new();
+            // Seed with each bus param's declared default so `generate_if`
+            // gates (e.g. `generate_if READ` / `WRITE`) evaluate as the
+            // bus author intended for the "no overrides" struct. Without
+            // this, the param_map is empty and every conditional branch
+            // folds to false, producing an empty struct that breaks any
+            // sim consumer that touches a bus field.
+            let param_map: HashMap<String, &Expr> = b.params.iter()
+                .filter_map(|p| p.default.as_ref().map(|d| (p.name.name.clone(), d)))
+                .collect();
             let effective = crate::resolve::BusInfo {
                 name: b.name.name.clone(),
                 params: b.params.clone(),

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -1337,7 +1337,19 @@ impl<'a> TypeChecker<'a> {
                 // We need to mark parent signals as "driven" when the inst OUTPUTS them.
                 if let Some((_, bus_name)) = target_bus_ports.iter().find(|(pn, _)| *pn == conn.port_name.name) {
                     if let Some((crate::resolve::Symbol::Bus(info), _)) = self.symbols.globals.get(bus_name) {
-                        if let ExprKind::Ident(sig_base) = &conn.signal.kind {
+                        // Resolve the parent-side base prefix:
+                        //   * `Ident("w")`           → `w`         (scalar wire/port)
+                        //   * `Index(Ident("v"), i)` → `v_<i>`     (Vec-of-bus element)
+                        let sig_base_owned: Option<String> = match &conn.signal.kind {
+                            ExprKind::Ident(n) => Some(n.clone()),
+                            ExprKind::Index(arr, idx) => {
+                                if let (ExprKind::Ident(arr_name), ExprKind::Literal(LitKind::Dec(i))) = (&arr.kind, &idx.kind) {
+                                    Some(format!("{}_{}", arr_name, i))
+                                } else { None }
+                            }
+                            _ => None,
+                        };
+                        if let Some(sig_base) = sig_base_owned.as_ref() {
                             // Find the inst's bus port perspective and params
                             let inst_bus_info = self.source.items.iter()
                                 .find_map(|item| match item {

--- a/tests/nic400/Nic400Fabric.arch
+++ b/tests/nic400/Nic400Fabric.arch
@@ -1,0 +1,71 @@
+// Wiring harness — M MasterPort × N SlavePort.
+//
+// Spec §9: pure wiring; all real work lives in the per-master / per-slave
+// modules. Each (master_i, slave_j) edge is one bus carried by element
+// `[j]` of master_i's outgoing `Vec<Bus, NUM_SLAVES>` wire — that same
+// wire element appears as element `[i]` on slave_j's incoming
+// `Vec<Bus, NUM_MASTERS>` port.
+//
+// 2x2 v1: explicit enumeration of the 2 master + 2 slave instances.
+// Larger configurations are mechanical extensions of the same pattern.
+module Nic400Fabric
+  param NUM_MASTERS:   const = 2;
+  param NUM_SLAVES:    const = 2;
+  param ADDR_WIDTH:    const = 32;
+  param DATA_WIDTH:    const = 32;
+  param MASTER_ID_W:   const = 3;
+  param SLAVE_ID_W:    const = 4;        // MASTER_ID_W + ceil(log2(NUM_MASTERS))
+
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Async, Low>;
+
+  // System-facing master buses (one per master, parent perspective is target).
+  port m: target Vec<BusAxi4<ADDR_W=ADDR_WIDTH, DATA_W=DATA_WIDTH,
+                              ID_W=MASTER_ID_W, READ=1, WRITE=0>, NUM_MASTERS>;
+  // System-facing slave buses.
+  port s: initiator Vec<BusAxi4<ADDR_W=ADDR_WIDTH, DATA_W=DATA_WIDTH,
+                                  ID_W=SLAVE_ID_W, READ=1, WRITE=0>, NUM_SLAVES>;
+
+  // Per-master outgoing edge buses (N copies each = M×N edges total).
+  wire m0_outs: Vec<BusAxi4<ADDR_W=ADDR_WIDTH, DATA_W=DATA_WIDTH,
+                              ID_W=SLAVE_ID_W, READ=1, WRITE=0>, NUM_SLAVES>;
+  wire m1_outs: Vec<BusAxi4<ADDR_W=ADDR_WIDTH, DATA_W=DATA_WIDTH,
+                              ID_W=SLAVE_ID_W, READ=1, WRITE=0>, NUM_SLAVES>;
+
+  // ── M MasterPort instances ────────────────────────────────────────────
+  inst mp_0: Nic400MasterPort
+    param I = 0;
+    clk <- clk;
+    rst <- rst;
+    m   <- m[0];
+    outs -> m0_outs;
+  end inst mp_0
+
+  inst mp_1: Nic400MasterPort
+    param I = 1;
+    clk <- clk;
+    rst <- rst;
+    m   <- m[1];
+    outs -> m1_outs;
+  end inst mp_1
+
+  // ── N SlavePort instances ─────────────────────────────────────────────
+  // Each slave_j takes element [j] from every master's outgoing array.
+  inst sp_0: Nic400SlavePort
+    param J = 0;
+    clk <- clk;
+    rst <- rst;
+    s   -> s[0];
+    ins[0] <- m0_outs[0];
+    ins[1] <- m1_outs[0];
+  end inst sp_0
+
+  inst sp_1: Nic400SlavePort
+    param J = 1;
+    clk <- clk;
+    rst <- rst;
+    s   -> s[1];
+    ins[0] <- m0_outs[1];
+    ins[1] <- m1_outs[1];
+  end inst sp_1
+end module Nic400Fabric

--- a/tests/nic400/Nic400MasterPort.arch
+++ b/tests/nic400/Nic400MasterPort.arch
@@ -1,0 +1,105 @@
+// Per-master decode + route block (read-only AR/R path).
+//
+// Spec §7 shape: one M-facing bus target port + NUM_SLAVES outbound bus
+// initiator ports (Vec). On AR, the address decoder picks a slave; on R,
+// the high-bit of the returned slave-side id selects which slave's
+// return path drives the master.
+//
+// The per-master R-channel resource lock serialises the N return threads
+// onto the single master R bus (at most one slave responds per cycle by
+// AXI ID uniqueness, but the lock keeps the multi-driver legal).
+module Nic400MasterPort
+  param I:             const = 0;        // this master's index, 0..NUM_MASTERS-1
+  param NUM_SLAVES:    const = 2;
+  param ADDR_WIDTH:    const = 32;
+  param DATA_WIDTH:    const = 32;
+  param MASTER_ID_W:   const = 3;
+  param SLAVE_ID_W:    const = 4;        // MASTER_ID_W + ceil(log2(NUM_MASTERS))
+  param MIDX_W:        const = 1;        // ceil(log2(NUM_MASTERS))
+  param REGION_BITS:   const = 28;
+
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Async, Low>;
+
+  // System-facing master port (target perspective).
+  port m:  target BusAxi4<ADDR_W=ADDR_WIDTH, DATA_W=DATA_WIDTH,
+                          ID_W=MASTER_ID_W, READ=1, WRITE=0>;
+
+  // Fabric-facing outbound buses, one per slave.
+  port outs: initiator Vec<BusAxi4<ADDR_W=ADDR_WIDTH, DATA_W=DATA_WIDTH,
+                                  ID_W=SLAVE_ID_W,  READ=1, WRITE=0>, NUM_SLAVES>;
+
+  // Address decode: bit [REGION_BITS] picks slave (256 MiB regions in v1).
+  let m_ar_slv: UInt<1> = m.ar_addr[28];
+
+  // Per-master R-channel arbiter — N slave-return threads serialise here.
+  resource r_ch: mutex<priority>;
+  // Per-master AR-driver arbiter — N AR forwarding threads (one per slave)
+  // are mutually exclusive on the address decode, but the multi-driver
+  // legality check still wants a single owner per cycle. The lock is
+  // structural; in steady state only one thread is in the body at a time.
+  resource ar_ch: mutex<priority>;
+
+  // ── AR forwarding threads — one per slave ──────────────────────────────
+  generate_for j in 0..NUM_SLAVES-1
+    thread Ar_j on clk rising, rst low
+      default comb
+        outs[j].ar_valid  = false;
+        outs[j].ar_addr   = 0;
+        outs[j].ar_id     = 0;
+        outs[j].ar_len    = 0;
+        outs[j].ar_size   = 0;
+        outs[j].ar_burst  = 0;
+        outs[j].ar_lock   = false;
+        outs[j].ar_cache  = 0;
+        outs[j].ar_prot   = 0;
+        outs[j].ar_qos    = 0;
+        outs[j].ar_region = 0;
+        m.ar_ready      = false;
+      end default
+      wait until m.ar_valid and m_ar_slv == j;
+      lock ar_ch
+        do
+          outs[j].ar_valid  = true;
+          outs[j].ar_addr   = m.ar_addr;
+          outs[j].ar_id     = (I.zext<SLAVE_ID_W>() << MASTER_ID_W) | m.ar_id.zext<SLAVE_ID_W>();
+          outs[j].ar_len    = m.ar_len;
+          outs[j].ar_size   = m.ar_size;
+          outs[j].ar_burst  = m.ar_burst;
+          // AXI4 sideband — pass through unchanged.
+          outs[j].ar_lock   = m.ar_lock;
+          outs[j].ar_cache  = m.ar_cache;
+          outs[j].ar_prot   = m.ar_prot;
+          outs[j].ar_qos    = m.ar_qos;
+          outs[j].ar_region = m.ar_region;
+          m.ar_ready      = outs[j].ar_ready;
+        until outs[j].ar_ready;
+      end lock ar_ch
+    end thread Ar_j
+  end generate_for
+
+  // ── R return threads — one per slave, serialise via r_ch lock ──────────
+  generate_for j in 0..NUM_SLAVES-1
+    thread R_j on clk rising, rst low
+      default comb
+        m.r_valid = false;
+        m.r_data  = 0;
+        m.r_id    = 0;
+        m.r_resp  = 0;
+        m.r_last  = false;
+        outs[j].r_ready = false;
+      end default
+      wait until outs[j].r_valid and outs[j].r_id[SLAVE_ID_W-1:MASTER_ID_W] == I;
+      lock r_ch
+        do
+          m.r_valid = true;
+          m.r_data  = outs[j].r_data;
+          m.r_id    = outs[j].r_id[MASTER_ID_W-1:0];
+          m.r_resp  = outs[j].r_resp;
+          m.r_last  = outs[j].r_last;
+          outs[j].r_ready = m.r_ready;
+        until m.r_ready and m.r_last;
+      end lock r_ch
+    end thread R_j
+  end generate_for
+end module Nic400MasterPort

--- a/tests/nic400/Nic400SlavePort.arch
+++ b/tests/nic400/Nic400SlavePort.arch
@@ -1,0 +1,97 @@
+// Per-slave arbitration + return block (read-only AR/R path).
+//
+// Spec §8 shape: one S-facing bus initiator port + NUM_MASTERS inbound
+// bus target ports (Vec). M AR-arbiter threads (one per master) contend
+// on a shared lock to drive the slave's AR; M R-return threads (one
+// per master) decode the slave's r_id high bits and route the beat back
+// to the matching master.
+module Nic400SlavePort
+  param J:             const = 0;        // this slave's index, 0..NUM_SLAVES-1
+  param NUM_MASTERS:   const = 2;
+  param ADDR_WIDTH:    const = 32;
+  param DATA_WIDTH:    const = 32;
+  param MASTER_ID_W:   const = 3;
+  param SLAVE_ID_W:    const = 4;        // MASTER_ID_W + ceil(log2(NUM_MASTERS))
+
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Async, Low>;
+
+  // System-facing slave port (initiator perspective — this module drives s.ar_valid etc.).
+  port s: initiator BusAxi4<ADDR_W=ADDR_WIDTH, DATA_W=DATA_WIDTH,
+                            ID_W=SLAVE_ID_W, READ=1, WRITE=0>;
+
+  // Fabric-facing inbound buses, one per master.
+  port ins: target Vec<BusAxi4<ADDR_W=ADDR_WIDTH, DATA_W=DATA_WIDTH,
+                                  ID_W=SLAVE_ID_W, READ=1, WRITE=0>, NUM_MASTERS>;
+
+  // AR arbiter — M masters serialise onto s.ar_*. Priority for now;
+  // arch sim's `--thread-sim parallel` path supports priority only in v1.
+  // Switch to round_robin when the parallel sim extends its policy set.
+  resource ar_lock: mutex<priority>;
+  // R demux serializer — at most one master matches the slave's r_id prefix
+  // per cycle by AXI ID uniqueness; the lock keeps the multi-driver legal.
+  resource r_demux_lock: mutex<priority>;
+
+  // ── AR arbiter — one thread per master ─────────────────────────────────
+  generate_for i in 0..NUM_MASTERS-1
+    thread ArArb_i on clk rising, rst low
+      default comb
+        s.ar_valid  = false;
+        s.ar_addr   = 0;
+        s.ar_id     = 0;
+        s.ar_len    = 0;
+        s.ar_size   = 0;
+        s.ar_burst  = 0;
+        s.ar_lock   = false;
+        s.ar_cache  = 0;
+        s.ar_prot   = 0;
+        s.ar_qos    = 0;
+        s.ar_region = 0;
+        ins[i].ar_ready = false;
+      end default
+      wait until ins[i].ar_valid;
+      lock ar_lock
+        do
+          s.ar_valid  = true;
+          s.ar_addr   = ins[i].ar_addr;
+          s.ar_id     = ins[i].ar_id;     // already prefixed by master port
+          s.ar_len    = ins[i].ar_len;
+          s.ar_size   = ins[i].ar_size;
+          s.ar_burst  = ins[i].ar_burst;
+          s.ar_lock   = ins[i].ar_lock;
+          s.ar_cache  = ins[i].ar_cache;
+          s.ar_prot   = ins[i].ar_prot;
+          s.ar_qos    = ins[i].ar_qos;
+          s.ar_region = ins[i].ar_region;
+          ins[i].ar_ready = s.ar_ready;
+        until s.ar_ready;
+      end lock ar_lock
+    end thread ArArb_i
+  end generate_for
+
+  // ── R return — one demux thread per master ─────────────────────────────
+  // Match on the high MIDX bits of s.r_id (= the originating master idx).
+  generate_for i in 0..NUM_MASTERS-1
+    thread RDemux_i on clk rising, rst low
+      default comb
+        ins[i].r_valid = false;
+        ins[i].r_data  = 0;
+        ins[i].r_id    = 0;
+        ins[i].r_resp  = 0;
+        ins[i].r_last  = false;
+        s.r_ready = false;
+      end default
+      wait until s.r_valid and s.r_id[SLAVE_ID_W-1:MASTER_ID_W] == i;
+      lock r_demux_lock
+        do
+          ins[i].r_valid = true;
+          ins[i].r_data  = s.r_data;
+          ins[i].r_id    = s.r_id;          // master port strips the prefix on receive
+          ins[i].r_resp  = s.r_resp;
+          ins[i].r_last  = s.r_last;
+          s.r_ready = ins[i].r_ready;
+        until ins[i].r_ready and ins[i].r_last;
+      end lock r_demux_lock
+    end thread RDemux_i
+  end generate_for
+end module Nic400SlavePort

--- a/tests/nic400/README.md
+++ b/tests/nic400/README.md
@@ -15,7 +15,10 @@ arbitration, ID remap, and ID-prefix return routing.
 | `RegSliceChannel.arch` | Generic 1-stage register slice (skid buffer) | ✓ sim PASS |
 | `Nic400ArbiterPolicy.arch` | QoS arbiter (4-requester) with custom hook | ✓ check |
 | `Nic400QosFn.arch` | Pure-comb wrapper of QoS pick function for unit testing | ✓ sim PASS (7/7 cases) |
-| `Nic400Read2x2.arch` | Monolithic 2x2 AXI4 read crossbar | ✓ sim PASS |
+| `Nic400Read2x2.arch` | Monolithic 2x2 AXI4 read crossbar (v1) | ✓ sim PASS |
+| `Nic400MasterPort.arch` | Per-master decode + route (v2, spec §7) | ✓ check + Verilator clean |
+| `Nic400SlavePort.arch` | Per-slave arbitration + return (v2, spec §8) | ✓ check + Verilator clean |
+| `Nic400Fabric.arch` | Hierarchical wiring harness — M MasterPort × N SlavePort (v2, spec §9) | ✓ check + Verilator clean; arch-sim has hierarchical-inst comb-feedback issue (follow-up) |
 
 ## Verification — §15 of spec
 

--- a/tests/nic400/tb_nic400_fabric_smoke.cpp
+++ b/tests/nic400/tb_nic400_fabric_smoke.cpp
@@ -1,0 +1,122 @@
+// Smoke test for the hierarchical Nic400Fabric — read-only 2x2 crossbar.
+// Drives master 0 → slave 0, master 1 → slave 1, master 0 → slave 1 in
+// sequence. Verifies decode + ID prefix encoding + return-route demux all
+// work end-to-end through the MasterPort/SlavePort modules.
+
+#include "VNic400Fabric.h"
+#include <cstdint>
+#include <cstdio>
+
+static VNic400Fabric dut;
+
+static void tick() {
+    dut.clk = 0;
+    dut.eval();
+    dut.clk = 1;
+    dut.eval();
+}
+
+static int fail(const char *msg) {
+    std::printf("FAIL Nic400Fabric: %s\n", msg);
+    return 1;
+}
+
+// Drive AR phase. master 0..1, addr (bit 28 picks slave 0|1), id (3-bit).
+// Returns 0 on success after observing the AR handshake at the expected slave.
+static int do_ar(int master, uint32_t addr, uint32_t id, int expect_slave, uint32_t expect_slave_id) {
+    if (master == 0) {
+        dut.m_0_ar_valid = 1; dut.m_0_ar_addr = addr; dut.m_0_ar_id = id;
+        dut.m_0_ar_len = 0; dut.m_0_ar_size = 2; dut.m_0_ar_burst = 1;
+    } else {
+        dut.m_1_ar_valid = 1; dut.m_1_ar_addr = addr; dut.m_1_ar_id = id;
+        dut.m_1_ar_len = 0; dut.m_1_ar_size = 2; dut.m_1_ar_burst = 1;
+    }
+    if (expect_slave == 0) dut.s_0_ar_ready = 1; else dut.s_1_ar_ready = 1;
+
+    for (int i = 0; i < 8; ++i) {
+        tick();
+        uint8_t v = (expect_slave == 0) ? dut.s_0_ar_valid : dut.s_1_ar_valid;
+        uint8_t r = (expect_slave == 0) ? dut.s_0_ar_ready : dut.s_1_ar_ready;
+        if (v && r) {
+            uint32_t got_id = (expect_slave == 0) ? dut.s_0_ar_id : dut.s_1_ar_id;
+            if (got_id != expect_slave_id) {
+                std::printf("AR id got 0x%x, expected 0x%x\n", got_id, expect_slave_id);
+                return 1;
+            }
+            // The OTHER slave's AR must NOT fire.
+            uint8_t other = (expect_slave == 0) ? dut.s_1_ar_valid : dut.s_0_ar_valid;
+            if (other != 0) return fail("wrong slave fired");
+            tick();
+            if (master == 0) dut.m_0_ar_valid = 0; else dut.m_1_ar_valid = 0;
+            dut.s_0_ar_ready = 0;
+            dut.s_1_ar_ready = 0;
+            tick();
+            return 0;
+        }
+    }
+    return fail("AR never fired");
+}
+
+// Drive R return from one slave; expect it to land at the originating
+// master with the stripped ID.
+static int do_r(int slave_src, uint32_t data, uint32_t slave_id, int expect_master, uint32_t expect_master_id) {
+    if (slave_src == 0) {
+        dut.s_0_r_valid = 1; dut.s_0_r_data = data; dut.s_0_r_id = slave_id;
+        dut.s_0_r_resp = 0;  dut.s_0_r_last = 1;
+    } else {
+        dut.s_1_r_valid = 1; dut.s_1_r_data = data; dut.s_1_r_id = slave_id;
+        dut.s_1_r_resp = 0;  dut.s_1_r_last = 1;
+    }
+    if (expect_master == 0) dut.m_0_r_ready = 1; else dut.m_1_r_ready = 1;
+
+    for (int i = 0; i < 16; ++i) {
+        tick();
+        uint8_t v = (expect_master == 0) ? dut.m_0_r_valid : dut.m_1_r_valid;
+        uint8_t r = (expect_master == 0) ? dut.m_0_r_ready : dut.m_1_r_ready;
+        if (v && r) {
+            uint32_t got_data = (expect_master == 0) ? dut.m_0_r_data : dut.m_1_r_data;
+            uint32_t got_id   = (expect_master == 0) ? dut.m_0_r_id   : dut.m_1_r_id;
+            if (got_data != data) return fail("R data mismatch");
+            if (got_id != expect_master_id) {
+                std::printf("R id got 0x%x, expected 0x%x\n", got_id, expect_master_id);
+                return 1;
+            }
+            uint8_t other = (expect_master == 0) ? dut.m_1_r_valid : dut.m_0_r_valid;
+            if (other != 0) return fail("wrong master got R");
+            tick();
+            if (slave_src == 0) dut.s_0_r_valid = 0; else dut.s_1_r_valid = 0;
+            dut.m_0_r_ready = 0;
+            dut.m_1_r_ready = 0;
+            tick();
+            return 0;
+        }
+    }
+    return fail("R never landed");
+}
+
+int main() {
+    // Reset (active-low)
+    dut.rst = 0;
+    dut.m_0_ar_valid = 0; dut.m_1_ar_valid = 0;
+    dut.s_0_ar_ready = 0; dut.s_1_ar_ready = 0;
+    dut.s_0_r_valid = 0;  dut.s_1_r_valid = 0;
+    dut.m_0_r_ready = 0;  dut.m_1_r_ready = 0;
+    for (int i = 0; i < 4; ++i) tick();
+    dut.rst = 1;
+    tick();
+
+    // M0 → S0 (id=3 → slave-side id={0, 3} = 3)
+    if (do_ar(0, 0x00001000, 3, /*slave*/0, /*slave_id*/3)) return 1;
+    if (do_r(/*slave*/0, 0xDEADBEEF, /*slave_id*/3, /*master*/0, /*master_id*/3)) return 1;
+
+    // M1 → S1 (id=5 → slave-side id={1, 5} = 0b1_101 = 13)
+    if (do_ar(1, 0x10002000, 5, /*slave*/1, /*slave_id*/13)) return 1;
+    if (do_r(/*slave*/1, 0xCAFEBABE, /*slave_id*/13, /*master*/1, /*master_id*/5)) return 1;
+
+    // M0 → S1 (cross-slave route, id=2 → slave-side id={0, 2} = 2)
+    if (do_ar(0, 0x10001000, 2, /*slave*/1, /*slave_id*/2)) return 1;
+    if (do_r(/*slave*/1, 0xC0FFEE00, /*slave_id*/2, /*master*/0, /*master_id*/2)) return 1;
+
+    std::printf("PASS Nic400Fabric smoke: hierarchical 2x2 decode + ID remap + return route OK\n");
+    return 0;
+}


### PR DESCRIPTION
Builds on the merged Vec-of-bus work (#384/#385/#386) and the merged thread-bus-signal fix (#387) to rewrite the NIC-400 example into the spec §6 module hierarchy.

## Design (matches spec §6 / §7 / §8 / §9)

```
Nic400Fabric                   — wiring harness, M × N
├─ Nic400MasterPort × M         — per-master decode + route (§7)
│   port m:    target BusAxi4<ID_W=MASTER_ID_W>
│   port outs: initiator Vec<BusAxi4<ID_W=SLAVE_ID_W>, NUM_SLAVES>
└─ Nic400SlavePort × N           — per-slave arbitration + return (§8)
    port s:   initiator BusAxi4<ID_W=SLAVE_ID_W>
    port ins: target Vec<BusAxi4<ID_W=SLAVE_ID_W>, NUM_MASTERS>
```

Cross-fabric edges live as `wire mN_outs: Vec<BusAxi4<ID_W=SLAVE_ID_W>, NUM_SLAVES>;` (one per master); slave inst connections take element `[j]` from each master's outgoing array.

Threads use bus-typed targets directly (`outs[j].ar_valid = ...`, `m.r_data = ...`, `ins[i].ar_ready = ...`). The fix from #387 lets these propagate through `lower_threads` into the lowered sub-module's flat outputs.

## Status

- `arch check` + `arch build` — clean
- `verilator --lint-only` — clean on the whole hierarchical SV
- 452 / 452 integration tests pass (no regressions)
- `arch sim` builds + runs but the simple smoke testbench hits a hierarchical-inst comb-feedback edge case where AR/R handshake signals pulse 1 → 0 within one settle iteration of the parent's `eval()`. The SV path simulates correctly under Verilator; the in-process arch-sim fix is queued as a follow-up.

## Supporting compiler changes (made along the way)

| File | What |
|---|---|
| `src/parser.rs` | Wire decl accepts inline bus param overrides (`wire w: Vec<BusAxi4<ID_W=4>, N>;`). Stashed in `WireDecl.bus_params`. |
| `src/ast.rs` | `WireDecl.bus_params: Vec<ParamAssign>` (default empty). |
| `src/codegen/module.rs` | Bus-typed wire emission overlays `wire.bus_params` on bus defaults — fixes width-mismatch warnings when a `Vec<Bus, N>` wire bridges an instance whose port overrides `ID_W` (etc.). |
| `src/typecheck.rs` | Inst-side driver tracking handles `Index(Ident(v), Lit(i))` signal RHS, not just bare `Ident(v)`. Required so `m <- m[0]` style indexed-bus connections correctly mark the parent's flat `m_0_<sig>` outputs as driven. |
| `src/sim_codegen/mod.rs` | Two fixes: (1) bus struct emitter seeds the param map with each bus param's declared default — previously every `generate_if` gate folded to false and `BusAxi4` emitted as an empty struct. (2) `expand_bus_connections` recognises `Index(Ident(arr), Lit(i))` where `arr` is a parent Vec-of-bus PORT (not just a wire). |

## Spec deltas (still on the v1 → v2 path)

The v2 design now matches the spec closely; remaining v1 limitations:

- The spec's `shared(or)` on bus signals isn't supported. v2 uses per-master / per-slave resource locks (`mutex<priority>` / `mutex<round_robin>`) to keep the multi-driver legal — the lock has the same structural effect since only one thread fires per cycle by the address-decode / id-prefix invariant.
- arch-sim hierarchical-feedback issue noted above.
- Write-path (AW/W/B) is the structural mirror of the read path; v2 still ships read-only as the v1 did.

## Test plan

- [x] `cargo test --test integration_test` → 452 / 452
- [x] Verilator lint clean on Nic400Fabric SV
- [x] V1 monolithic Nic400Read2x2 still simulates pass (no regression)
- [ ] arch sim Fabric smoke — known hierarchical-feedback issue, deferred