### PR TITLE
sim: hoist package/module const params into VFunctions.h

### DIFF
--- a/src/sim_codegen/mod.rs
+++ b/src/sim_codegen/mod.rs
@@ -4065,6 +4065,42 @@ impl<'a> SimCodegen<'a> {
         let mut h = String::new();
         h.push_str("#pragma once\n#include \"verilated.h\"\n\n");
 
+        // Hoist package- and module-level const params as `#define`s so that
+        // function bodies referencing them (e.g. `x >> REGION_BITS` where
+        // `REGION_BITS` is a `package` param) compile. The SV path resolves
+        // this via `import Pkg::*`; the sim path has no equivalent scope —
+        // module-internal functions get hoisted to free C++ functions, and
+        // VFunctions.h is included from each V{Module}.h *before* the
+        // per-module `#define`s, so without this block the identifier is
+        // simply undeclared. `#ifndef`-guarded so re-definitions in
+        // per-module headers are harmless.
+        let mut emitted_param_defines: HashSet<String> = HashSet::new();
+        for item in &self.source.items {
+            let (params, _ctx_label): (&[ParamDecl], &str) = match item {
+                Item::Package(pkg) => (&pkg.params, "package"),
+                Item::Module(m) => (&m.params, "module"),
+                _ => continue,
+            };
+            for p in params {
+                if !emitted_param_defines.insert(p.name.name.clone()) {
+                    continue;
+                }
+                match &p.kind {
+                    ParamKind::Const | ParamKind::WidthConst(..) | ParamKind::Logic(_) => {
+                        if let Some(ref def) = p.default {
+                            let val = eval_const_expr_with_params(def, params);
+                            h.push_str(&format!(
+                                "#ifndef {}\n#define {} {val}ULL\n#endif\n",
+                                p.name.name, p.name.name
+                            ));
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+        h.push('\n');
+
         for f in fns {
             let ret_ty = cpp_internal_type(&f.ret_ty);
             let args_str: Vec<String> = f.args.iter()

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -15751,3 +15751,33 @@ end fsm F
     assert!(sdc.contains("set_multicycle_path 4 -hold -to [get_cells -hierarchical {*slow_r_reg*}]"),
         "got:\n{}", sdc);
 }
+
+/// Regression: a module-internal `function` whose body references a
+/// `package` param (e.g. `x >> REGION_BITS`) used to fail C++ compile in
+/// arch_sim_build/VFunctions.h with `use of undeclared identifier
+/// 'REGION_BITS'` — module-internal functions are hoisted to free
+/// functions in VFunctions.h, which is included from V{Module}.h
+/// *before* the per-module `#define`s. The fix hoists package- and
+/// module-level const params as `#define`s at the top of VFunctions.h.
+#[test]
+fn test_sim_function_uses_package_param() {
+    let td = tempfile::tempdir().expect("tempdir");
+    let arch_bin = env!("CARGO_BIN_EXE_arch");
+    let out = std::process::Command::new(arch_bin)
+        .arg("sim")
+        .arg("tests/pkg_param_in_function/PkgFoo.arch")
+        .arg("tests/pkg_param_in_function/Probe.arch")
+        .arg("--tb")
+        .arg("tests/pkg_param_in_function/tb.cpp")
+        .arg("--outdir")
+        .arg(td.path())
+        .output()
+        .expect("run arch sim for pkg_param_in_function repro");
+    assert!(out.status.success(),
+        "pkg_param_in_function sim should compile + run\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr));
+    assert!(String::from_utf8_lossy(&out.stdout).contains("PASS pkg_param_in_function"),
+        "expected PASS marker in stdout:\n{}",
+        String::from_utf8_lossy(&out.stdout));
+}

--- a/tests/pkg_param_in_function/PkgFoo.arch
+++ b/tests/pkg_param_in_function/PkgFoo.arch
@@ -1,0 +1,4 @@
+package PkgFoo
+  param ADDR_W:      const = 32;
+  param REGION_BITS: const = 28;
+end package PkgFoo

--- a/tests/pkg_param_in_function/Probe.arch
+++ b/tests/pkg_param_in_function/Probe.arch
@@ -1,0 +1,10 @@
+use PkgFoo;
+module Probe
+  port a:   in  UInt<ADDR_W>;
+  port out: out UInt<4>;
+  function shift_decode(x: UInt<ADDR_W>) -> UInt<4>
+    let s: UInt<ADDR_W> = x >> REGION_BITS;
+    return s.trunc<4>();
+  end function shift_decode
+  comb out = shift_decode(a); end comb
+end module Probe

--- a/tests/pkg_param_in_function/tb.cpp
+++ b/tests/pkg_param_in_function/tb.cpp
@@ -1,0 +1,22 @@
+#include <cstdio>
+#include <cstdlib>
+#include "VProbe.h"
+
+int main() {
+    VProbe dut;
+    // a = 0x80000000 → top 4 bits = 0x8 after shift by REGION_BITS=28.
+    dut.a = 0x80000000u;
+    dut.eval();
+    if (dut.out != 0x8) {
+        std::fprintf(stderr, "FAIL: out=0x%x expected 0x8\n", (unsigned)dut.out);
+        return 1;
+    }
+    dut.a = 0x10000000u;
+    dut.eval();
+    if (dut.out != 0x1) {
+        std::fprintf(stderr, "FAIL: out=0x%x expected 0x1\n", (unsigned)dut.out);
+        return 1;
+    }
+    std::printf("PASS pkg_param_in_function\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary

- Fix `arch sim` failing to compile generated `arch_sim_build/VFunctions.h` when a module-internal `function` body references a package-level `const` param (e.g. `x >> REGION_BITS`).
- Hoist package- and module-level const params as `#ifndef`-guarded `#define`s at the top of `VFunctions.h`. `V{Module}.h` includes `VFunctions.h` *before* its own per-module `#define`s, so without this fix the param identifier is simply undeclared at the function definition site.
- The SV path resolves this via `import Pkg::*`; the sim path has no equivalent scope (module-internal functions get hoisted to free C++ functions), so we substitute literals here.

## Repro (was failing, now passes)

```arch
// PkgFoo.arch
package PkgFoo
  param ADDR_W:      const = 32;
  param REGION_BITS: const = 28;
end package PkgFoo
```

```arch
// Probe.arch
use PkgFoo;
module Probe
  port a:   in  UInt<ADDR_W>;
  port out: out UInt<4>;
  function shift_decode(x: UInt<ADDR_W>) -> UInt<4>
    let s: UInt<ADDR_W> = x >> REGION_BITS;
    return s.trunc<4>();
  end function shift_decode
  comb out = shift_decode(a); end comb
end module Probe
```

Before: clang `error: use of undeclared identifier 'REGION_BITS'` inside `arch_sim_build/VFunctions.h`.
After: compiles and runs.

## Test plan

- [x] `cargo test --release --test integration_test test_sim_function_uses_package_param`
- [x] Full integration test suite (`cargo test --release --test integration_test`) — all 454 tests pass.