### PR TITLE
Nic400Fabric refactor: generate_for over M and N + 2D bus wires

### DIFF
--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -2399,8 +2399,25 @@ impl<'a> Codegen<'a> {
                         }
                     } else {
                         let sig_prefix = match &c.signal.kind {
+                            // 2D bus wire element: `edges[m][n]`. Both indices
+                            // resolve to literals (or static-unrolled loop
+                            // vars); emit `edges_<m>_<n>` as the prefix.
                             ExprKind::Index(arr, idx) => {
-                                if let (ExprKind::Ident(arr_name), ExprKind::Literal(LitKind::Dec(i))) = (&arr.kind, &idx.kind) {
+                                let resolve = |e: &Expr| -> Option<u64> {
+                                    match &e.kind {
+                                        ExprKind::Literal(LitKind::Dec(i)) => Some(*i),
+                                        ExprKind::Ident(loopvar) =>
+                                            self.loop_var_subst.get(loopvar).map(|v| *v as u64),
+                                        _ => None,
+                                    }
+                                };
+                                if let ExprKind::Index(inner_arr, inner_idx) = &arr.kind {
+                                    if let ExprKind::Ident(arr_name) = &inner_arr.kind {
+                                        if let (Some(m_v), Some(n_v)) = (resolve(inner_idx), resolve(idx)) {
+                                            format!("{}_{}_{}", arr_name, m_v, n_v)
+                                        } else { self.emit_expr_str(&c.signal) }
+                                    } else { self.emit_expr_str(&c.signal) }
+                                } else if let (ExprKind::Ident(arr_name), Some(i)) = (&arr.kind, resolve(idx)) {
                                     format!("{}_{}", arr_name, i)
                                 } else {
                                     self.emit_expr_str(&c.signal)
@@ -4442,6 +4459,32 @@ impl<'a> Codegen<'a> {
                 // wire — because they're internal to the module body and
                 // their consumers haven't been migrated yet.
                 if let ExprKind::Index(arr, idx) = &base.kind {
+                    // 2D bus wire element: `edges[m][n].sig`. The arr is
+                    // itself `Index(Ident(name), m_idx)`, and `idx` is n_idx.
+                    // Both indices must resolve to literals (either directly
+                    // or via static-unroll loop_var_subst). Emit the flat
+                    // SV wire name `<name>_<m>_<n>_<sig>`.
+                    if let ExprKind::Index(inner_arr, inner_idx) = &arr.kind {
+                        if let ExprKind::Ident(arr_name) = &inner_arr.kind {
+                            let resolve = |e: &Expr| -> Option<u64> {
+                                match &e.kind {
+                                    ExprKind::Literal(LitKind::Dec(i))
+                                    | ExprKind::Literal(LitKind::Hex(i))
+                                    | ExprKind::Literal(LitKind::Bin(i))
+                                    | ExprKind::Literal(LitKind::Sized(_, i)) => Some(*i),
+                                    ExprKind::Ident(loopvar) =>
+                                        self.loop_var_subst.get(loopvar).map(|v| *v as u64),
+                                    _ => None,
+                                }
+                            };
+                            if let (Some(m_v), Some(n_v)) = (resolve(inner_idx), resolve(idx)) {
+                                let cell = format!("{}_{}_{}", arr_name, m_v, n_v);
+                                if self.bus_wires.contains_key(&cell) {
+                                    return format!("{}_{}_{}_{}", arr_name, m_v, n_v, field.name);
+                                }
+                            }
+                        }
+                    }
                     if let ExprKind::Ident(arr_name) = &arr.kind {
                         // Vec-of-bus *port* → D2 indexed ref.
                         if self.vec_of_bus_port_count.contains_key(arr_name) {

--- a/src/codegen/module.rs
+++ b/src/codegen/module.rs
@@ -688,22 +688,48 @@ impl<'a> Codegen<'a> {
                             .and_then(|(s, _)| if let crate::resolve::Symbol::Bus(info) = s {
                                 Some((info, id.name.clone(), None))
                             } else { None }),
-                        TypeExpr::Vec(elem, size_expr) => {
-                            if let TypeExpr::Named(id) = elem.as_ref() {
+                        TypeExpr::Vec(elem, size_expr) => match elem.as_ref() {
+                            TypeExpr::Named(id) => {
                                 if let Some(n) = self.eval_const_u32(size_expr, &m_clone.params) {
                                     self.symbols.globals.get(&id.name)
                                         .and_then(|(s, _)| if let crate::resolve::Symbol::Bus(info) = s {
-                                            Some((info, id.name.clone(), Some(n)))
+                                            Some((info, id.name.clone(), Some((n, None))))
                                         } else { None })
                                 } else { None }
-                            } else { None }
-                        }
+                            }
+                            // 2D bus wire: `wire edges: Vec<Vec<B, N>, M>;` →
+                            // emit M*N*per_signal flat wires named
+                            // `edges_<m>_<n>_<sig>`.
+                            TypeExpr::Vec(inner_elem, inner_size) => {
+                                if let TypeExpr::Named(id) = inner_elem.as_ref() {
+                                    if let (Some(m_n), Some(n_n)) = (
+                                        self.eval_const_u32(size_expr, &m_clone.params),
+                                        self.eval_const_u32(inner_size, &m_clone.params),
+                                    ) {
+                                        self.symbols.globals.get(&id.name)
+                                            .and_then(|(s, _)| if let crate::resolve::Symbol::Bus(info) = s {
+                                                Some((info, id.name.clone(), Some((m_n, Some(n_n)))))
+                                            } else { None })
+                                    } else { None }
+                                } else { None }
+                            }
+                            _ => None,
+                        },
                         _ => None,
                     };
                     if let Some((info, bus_name, count)) = bus_wire_info {
                         let prefixes: Vec<String> = match count {
                             None => vec![w.name.name.clone()],
-                            Some(n) => (0..n).map(|i| format!("{}_{}", w.name.name, i)).collect(),
+                            Some((m_n, None)) => (0..m_n).map(|i| format!("{}_{}", w.name.name, i)).collect(),
+                            Some((m_n, Some(n_n))) => {
+                                let mut v = Vec::with_capacity((m_n * n_n) as usize);
+                                for i in 0..m_n {
+                                    for j in 0..n_n {
+                                        v.push(format!("{}_{}_{}", w.name.name, i, j));
+                                    }
+                                }
+                                v
+                            }
                         };
                         for prefix in &prefixes {
                             self.bus_wires.insert(prefix.clone(), bus_name.clone());

--- a/src/elaborate.rs
+++ b/src/elaborate.rs
@@ -67,7 +67,8 @@ pub fn elaborate(ast: SourceFile) -> Result<SourceFile, Vec<CompileError>> {
     let mut inst_raw: HashMap<String, Vec<HashMap<String, i64>>> = HashMap::new();
     for item in &ast.items {
         if let Item::Module(m) = item {
-            collect_raw_overrides_from_body(&m.body, &mut inst_raw);
+            let param_vals = module_defaults.get(&m.name.name).cloned().unwrap_or_default();
+            collect_raw_overrides_from_body(&m.body, &mut inst_raw, &param_vals);
         }
     }
 
@@ -117,19 +118,42 @@ pub fn elaborate(ast: SourceFile) -> Result<SourceFile, Vec<CompileError>> {
 fn collect_raw_overrides_from_body(
     body: &[ModuleBodyItem],
     out: &mut HashMap<String, Vec<HashMap<String, i64>>>,
+    enclosing_params: &HashMap<String, i64>,
 ) {
     for item in body {
         match item {
             ModuleBodyItem::Inst(inst) => record_inst(inst, out),
-            ModuleBodyItem::Generate(gen) => {
-                let all_items: Vec<&GenItem> = match gen {
-                    GenerateDecl::For(gf) => gf.items.iter().collect(),
-                    GenerateDecl::If(gi) => gi.then_items.iter()
-                        .chain(gi.else_items.iter()).collect(),
-                };
-                for item in all_items {
-                    if let GenItem::Inst(inst) = item {
-                        record_inst(inst, out);
+            ModuleBodyItem::Generate(gen) => match gen {
+                // `generate_for i in start..end { inst foo: M; param P = i; ... }`:
+                // each unrolled iteration produces a specialized variant; we must
+                // record one (loop-var-substituted) override per (i, inst) so
+                // module_variants matches the post-unroll AST. Range bounds may
+                // reference the enclosing module's params (e.g. `NUM_MASTERS-1`),
+                // so eval with those.
+                GenerateDecl::For(gf) => {
+                    let start = try_eval_i64(&gf.start, enclosing_params);
+                    let end   = try_eval_i64(&gf.end,   enclosing_params);
+                    let var_name = &gf.var.name;
+                    for it in &gf.items {
+                        if let GenItem::Inst(inst) = it {
+                            if let (Some(s), Some(e)) = (start, end) {
+                                for v in s..=e {
+                                    let inst_subst = subst_inst(inst, var_name, v);
+                                    record_inst(&inst_subst, out);
+                                }
+                            } else {
+                                // Non-literal range — record once with the loop var
+                                // unresolved (matches pre-unroll behavior).
+                                record_inst(inst, out);
+                            }
+                        }
+                    }
+                }
+                GenerateDecl::If(gi) => {
+                    for it in gi.then_items.iter().chain(gi.else_items.iter()) {
+                        if let GenItem::Inst(inst) = it {
+                            record_inst(inst, out);
+                        }
                     }
                 }
             }

--- a/src/sim_codegen/mod.rs
+++ b/src/sim_codegen/mod.rs
@@ -1469,6 +1469,27 @@ fn expand_bus_connections(
             None
         } else { None })
         .collect();
+    // 2D bus wires: `wire edges: Vec<Vec<B, N>, M>;` → (M, N).
+    // Used by the whole-row inst connection expansion `outs -> edges[i]`,
+    // where `edges[i]` is a row (Vec<B,N>) inside a 2D wire.
+    let parent_vec_of_bus_wires_2d: HashMap<String, (u32, u32)> = m.body.iter()
+        .filter_map(|i| if let ModuleBodyItem::WireDecl(w) = i {
+            if let TypeExpr::Vec(outer_elem, outer_size) = &w.ty {
+                if let TypeExpr::Vec(inner_elem, inner_size) = outer_elem.as_ref() {
+                    if let TypeExpr::Named(id) = inner_elem.as_ref() {
+                        if matches!(symbols.globals.get(&id.name), Some((crate::resolve::Symbol::Bus(_), _))) {
+                            let m_n = eval_const_expr_with_params(outer_size, &m.params) as u32;
+                            let n_n = eval_const_expr_with_params(inner_size, &m.params) as u32;
+                            if m_n > 0 && n_n > 0 {
+                                return Some((w.name.name.clone(), (m_n, n_n)));
+                            }
+                        }
+                    }
+                }
+            }
+            None
+        } else { None })
+        .collect();
     let parent_vec_of_bus_ports: HashMap<String, u32> = m.ports.iter()
         .filter_map(|p| {
             let bi = p.bus_info.as_ref()?;
@@ -1484,6 +1505,43 @@ fn expand_bus_connections(
     let inst_connections: Vec<crate::ast::Connection> = inst.connections.iter()
         .flat_map(|c| {
             if let Some((_, n)) = target_vec_of_bus_ports.iter().find(|(pn, _)| pn == &c.port_name.name) {
+                // Whole-row connection into a 2D bus wire: `outs -> edges[m]`,
+                // where outs is Vec<B,N>, edges is Vec<Vec<B,N>,M>, m is a
+                // literal (or static-unrolled loop var). Expand to N per-element
+                // connections `outs[j] -> edges[m][j]`.
+                if let ExprKind::Index(arr, idx) = &c.signal.kind {
+                    if let ExprKind::Ident(parent_name) = &arr.kind {
+                        if let Some((_m_n, n_n)) = parent_vec_of_bus_wires_2d.get(parent_name).copied() {
+                            if let ExprKind::Literal(LitKind::Dec(m_idx)) = &idx.kind {
+                                if (n_n as u32) == *n {
+                                    return (0..*n).map(|j| {
+                                        let port_j = Ident::new(format!("{}_{}", c.port_name.name, j), c.port_name.span);
+                                        let parent_expr = Expr::new(
+                                            ExprKind::Index(
+                                                Box::new(Expr::new(
+                                                    ExprKind::Index(
+                                                        Box::new(Expr::new(ExprKind::Ident(parent_name.clone()), c.signal.span)),
+                                                        Box::new(Expr::new(ExprKind::Literal(LitKind::Dec(*m_idx)), c.signal.span)),
+                                                    ),
+                                                    c.signal.span,
+                                                )),
+                                                Box::new(Expr::new(ExprKind::Literal(LitKind::Dec(j as u64)), c.signal.span)),
+                                            ),
+                                            c.signal.span,
+                                        );
+                                        crate::ast::Connection {
+                                            port_name: port_j,
+                                            direction: c.direction,
+                                            signal: parent_expr,
+                                            reset_override: None,
+                                            span: c.span,
+                                        }
+                                    }).collect::<Vec<_>>();
+                                }
+                            }
+                        }
+                    }
+                }
                 if let ExprKind::Ident(parent_name) = &c.signal.kind {
                     let parent_is_vob_wire = parent_vec_of_bus_wires.contains_key(parent_name);
                     let parent_is_vob_port = parent_vec_of_bus_ports.contains_key(parent_name);
@@ -1537,7 +1595,14 @@ fn expand_bus_connections(
                 //                        (matches the C++ struct-typed bus wire)
                 //   WireIndex(name, i) → emit `FieldAccess(Index(Ident("<name>"), i), sname)`
                 //                        (matches a `B _let_<name>[N]` struct-array element)
-                enum BindKind { FlatPort(String), WireStruct(String), WireIndex(String, u32) }
+                enum BindKind {
+                    FlatPort(String),
+                    WireStruct(String),
+                    WireIndex(String, u32),
+                    /// 2D bus wire element: `wire edges: Vec<Vec<B,N>,M>;` →
+                    /// `edges[m][n]` lowers to `_let_edges[m][n].<sig>`.
+                    Wire2DIndex(String, u32, u32),
+                }
                 let bind = match &c.signal.kind {
                     ExprKind::Ident(name) => {
                         if bus_wire_names.contains(name.as_str()) {
@@ -1554,7 +1619,17 @@ fn expand_bus_connections(
                         }
                     }
                     ExprKind::Index(arr, idx) => {
-                        if let (ExprKind::Ident(arr_name), ExprKind::Literal(LitKind::Dec(i))) = (&arr.kind, &idx.kind) {
+                        // 2D bus wire element: `edges[m][n]` → arr is itself
+                        // an Index(Ident, literal_m), idx is literal_n.
+                        if let ExprKind::Index(inner_arr, inner_idx) = &arr.kind {
+                            if let (
+                                ExprKind::Ident(arr_name),
+                                ExprKind::Literal(LitKind::Dec(m)),
+                                ExprKind::Literal(LitKind::Dec(n)),
+                            ) = (&inner_arr.kind, &inner_idx.kind, &idx.kind) {
+                                BindKind::Wire2DIndex(arr_name.clone(), *m as u32, *n as u32)
+                            } else { continue; }
+                        } else if let (ExprKind::Ident(arr_name), ExprKind::Literal(LitKind::Dec(i))) = (&arr.kind, &idx.kind) {
                             if bus_wire_names.contains(arr_name.as_str()) {
                                 BindKind::WireIndex(arr_name.clone(), *i as u32)
                             } else if parent_vec_of_bus_ports.contains_key(arr_name.as_str()) {
@@ -1601,6 +1676,25 @@ fn expand_bus_connections(
                                     ExprKind::Index(
                                         Box::new(Expr::new(ExprKind::Ident(name.clone()), c.signal.span)),
                                         Box::new(Expr::new(ExprKind::Literal(LitKind::Dec(*i as u64)), c.signal.span)),
+                                    ),
+                                    c.signal.span,
+                                )),
+                                Ident::new(sname.clone(), c.signal.span),
+                            ),
+                            c.signal.span,
+                        ),
+                        BindKind::Wire2DIndex(name, m_idx, n_idx) => Expr::new(
+                            ExprKind::FieldAccess(
+                                Box::new(Expr::new(
+                                    ExprKind::Index(
+                                        Box::new(Expr::new(
+                                            ExprKind::Index(
+                                                Box::new(Expr::new(ExprKind::Ident(name.clone()), c.signal.span)),
+                                                Box::new(Expr::new(ExprKind::Literal(LitKind::Dec(*m_idx as u64)), c.signal.span)),
+                                            ),
+                                            c.signal.span,
+                                        )),
+                                        Box::new(Expr::new(ExprKind::Literal(LitKind::Dec(*n_idx as u64)), c.signal.span)),
                                     ),
                                     c.signal.span,
                                 )),
@@ -1982,6 +2076,12 @@ struct Ctx<'a> {
     /// Reg/wire names whose type is Vec<T,N> — these use C array subscript `[i]`.
     /// All other subscripts on scalar UInt/SInt use bit extraction `(x >> i) & 1`.
     vec_names:   Option<&'a HashSet<String>>,
+    /// Names of *2D* Vec<Vec<_,_>,_> wires/regs (today: Vec-of-Vec-of-bus
+    /// `wire edges: Vec<Vec<B, N>, M>`). When the outer Index returns
+    /// `_let_edges[m]`, the result is still a Vec — the inner subscript
+    /// must keep using C array indexing `[n]`, NOT fall into the bit-shift
+    /// path for scalar types.
+    vec_2d_names: Option<&'a HashSet<String>>,
     /// Vec<T,N> sizes by name (element count). Used for runtime bounds-check codegen.
     vec_sizes:   Option<&'a HashMap<String, u64>>,
     /// FSM Vec port-regs: always resolve to `_name` (internal C array), regardless of fsm_mode.
@@ -2031,7 +2131,8 @@ impl<'a> Ctx<'a> {
         static EMPTY_PARAMS: &[ParamDecl] = &[];
         Ctx { reg_names, port_names, let_names, let_values: None, inst_names, wide_names,
               widths, signed_names, posedge_lhs: false, fsm_mode: false, enum_map, bus_ports,
-              reset_levels, vec_names: None, vec_sizes: None, fsm_vec_port_regs: None,
+              reset_levels, vec_names: None, vec_2d_names: None, vec_sizes: None,
+              fsm_vec_port_regs: None,
               ident_subst: None, loop_var_subst: None,
               vec_of_bus_port_count: None, vec_of_bus_wire_count: None,
               coverage: None, params: EMPTY_PARAMS }
@@ -2076,6 +2177,11 @@ impl<'a> Ctx<'a> {
 
     fn with_vec_names(mut self, vec_names: &'a HashSet<String>) -> Self {
         self.vec_names = Some(vec_names);
+        self
+    }
+
+    fn with_vec_2d_names(mut self, vec_2d_names: &'a HashSet<String>) -> Self {
+        self.vec_2d_names = Some(vec_2d_names);
         self
     }
 
@@ -2170,6 +2276,18 @@ impl<'a> Ctx<'a> {
                 } else {
                     None
                 }
+            }
+            // Outer index of a 2D Vec (e.g. `Vec<Vec<Bus,N>,M>`): the result
+            // is still a Vec, so propagate the base name. Used by
+            // `expr_is_vec` so the *inner* subscript stays as C array
+            // indexing instead of falling into bit-shift extraction.
+            ExprKind::Index(base, _) => {
+                if let ExprKind::Ident(name) = &base.kind {
+                    if self.vec_2d_names.map_or(false, |s| s.contains(name.as_str())) {
+                        return Some(name.clone());
+                    }
+                }
+                None
             }
             _ => None,
         }
@@ -2394,6 +2512,7 @@ fn lower_vec_method_cpp(
             posedge_lhs: ctx.posedge_lhs, fsm_mode: ctx.fsm_mode,
             enum_map: ctx.enum_map, bus_ports: ctx.bus_ports,
             reset_levels: ctx.reset_levels, vec_names: ctx.vec_names,
+            vec_2d_names: ctx.vec_2d_names,
             vec_sizes: ctx.vec_sizes, fsm_vec_port_regs: ctx.fsm_vec_port_regs,
             ident_subst: None, // replaced below via a temporary binding
             loop_var_subst: ctx.loop_var_subst,
@@ -4606,6 +4725,20 @@ impl<'a> SimCodegen<'a> {
             .collect();
         vec_reg_names.extend(vec_wire_names.iter().cloned());
 
+        // 2D Vec names (today: `wire edges: Vec<Vec<Bus,N>,M>`). Outer
+        // indexing returns another Vec, so the inner subscript must stay
+        // as C array indexing instead of bit-extraction.
+        let vec_2d_names: HashSet<String> = m.body.iter()
+            .filter_map(|i| if let ModuleBodyItem::WireDecl(w) = i {
+                if let TypeExpr::Vec(elem, _) = &w.ty {
+                    if matches!(elem.as_ref(), TypeExpr::Vec(_, _)) {
+                        return Some(w.name.name.clone());
+                    }
+                }
+                None
+            } else { None })
+            .collect();
+
         // Vec wire/reg name → element count (for expanding inst port connections)
         let mut vec_wire_counts: HashMap<String, u64> = m.body.iter()
             .filter_map(|i| if let ModuleBodyItem::WireDecl(w) = i {
@@ -5542,6 +5675,25 @@ impl<'a> SimCodegen<'a> {
                     h.push_str(&format!("  {ty} _let_{};\n", l.name.name));
                 }
                 ModuleBodyItem::WireDecl(w) => {
+                    // 2D bus wire: `wire edges: Vec<Vec<B, N>, M>;` →
+                    //   B _let_edges[M][N];
+                    // Emitted *before* the generic vec_array_info path, which
+                    // would otherwise treat the outer Vec's element as
+                    // `uint32_t` and silently flatten the 2D-bus shape into
+                    // a 1D scalar array.
+                    if let TypeExpr::Vec(outer_elem, outer_count) = &w.ty {
+                        if let TypeExpr::Vec(inner_elem, inner_count) = outer_elem.as_ref() {
+                            if let TypeExpr::Named(bus_id) = inner_elem.as_ref() {
+                                let m_count = eval_const_expr_with_params(outer_count, &m.params);
+                                let n_count = eval_const_expr_with_params(inner_count, &m.params);
+                                h.push_str(&format!(
+                                    "  {} _let_{}[{}][{}];\n",
+                                    bus_id.name, w.name.name, m_count, n_count
+                                ));
+                                continue;
+                            }
+                        }
+                    }
                     if let Some((elem_ty, count)) = vec_array_info_with_params(&w.ty, &m.params) {
                         h.push_str(&format!("  {elem_ty} _let_{}[{count}];\n", w.name.name));
                     } else {
@@ -5696,7 +5848,7 @@ impl<'a> SimCodegen<'a> {
                            &wide_names, &widths, &enum_map, &bus_port_names)
                       .with_signed_names(&signed_names)
                       .with_reset_levels(&reset_levels)
-                      .with_vec_names(&vec_reg_names).with_vec_sizes(&vec_sizes)
+                      .with_vec_names(&vec_reg_names).with_vec_2d_names(&vec_2d_names).with_vec_sizes(&vec_sizes)
                       .with_let_values(&let_values)
                       .with_params(&m.params);
 
@@ -6221,7 +6373,7 @@ impl<'a> SimCodegen<'a> {
             let ctx = Ctx::new(&reg_names, &port_names, &let_names, &inst_names,
                                &wide_names, &widths, &enum_map, &bus_port_names)
                           .with_signed_names(&signed_names)
-                          .with_vec_names(&vec_reg_names).with_vec_sizes(&vec_sizes).posedge()
+                          .with_vec_names(&vec_reg_names).with_vec_2d_names(&vec_2d_names).with_vec_sizes(&vec_sizes).posedge()
                           .with_coverage(cov_handle)
                           .with_let_values(&let_values)
                           .with_params(&m.params);
@@ -6414,7 +6566,7 @@ impl<'a> SimCodegen<'a> {
                     let ctx_pe = Ctx::new(&reg_names, &port_names, &let_names, &inst_names,
                                            &wide_names, &widths, &enum_map, &bus_port_names)
                                        .with_signed_names(&signed_names)
-                                       .with_vec_names(&vec_reg_names).with_vec_sizes(&vec_sizes)
+                                       .with_vec_names(&vec_reg_names).with_vec_2d_names(&vec_2d_names).with_vec_sizes(&vec_sizes)
                                        .with_let_values(&let_values)
                                        .with_params(&m.params);
                     let src = ctx_pe.resolve_name(&p.source.name, false);
@@ -6639,7 +6791,7 @@ impl<'a> SimCodegen<'a> {
         let ctx_comb = Ctx::new(&reg_names, &port_names, &let_names, &inst_names,
                                 &wide_names, &widths, &enum_map, &bus_port_names)
                            .with_signed_names(&signed_names)
-                           .with_vec_names(&vec_reg_names).with_vec_sizes(&vec_sizes)
+                           .with_vec_names(&vec_reg_names).with_vec_2d_names(&vec_2d_names).with_vec_sizes(&vec_sizes)
                            .with_coverage(cov_handle)
                            .with_let_values(&let_values)
                            .with_params(&m.params)
@@ -6695,6 +6847,7 @@ impl<'a> SimCodegen<'a> {
                                         posedge_lhs: ctx_comb.posedge_lhs, fsm_mode: ctx_comb.fsm_mode,
                                         enum_map: ctx_comb.enum_map, bus_ports: ctx_comb.bus_ports,
                                         reset_levels: ctx_comb.reset_levels, vec_names: ctx_comb.vec_names,
+                                        vec_2d_names: ctx_comb.vec_2d_names,
                                         vec_sizes: ctx_comb.vec_sizes, fsm_vec_port_regs: ctx_comb.fsm_vec_port_regs,
                                         ident_subst: Some(&sub),
                                         loop_var_subst: ctx_comb.loop_var_subst,

--- a/tests/nic400/Nic400Fabric.arch
+++ b/tests/nic400/Nic400Fabric.arch
@@ -1,13 +1,13 @@
 // Wiring harness — M MasterPort × N SlavePort.
 //
 // Spec §9: pure wiring; all real work lives in the per-master / per-slave
-// modules. Each (master_i, slave_j) edge is one bus carried by element
-// `[j]` of master_i's outgoing `Vec<Bus, NUM_SLAVES>` wire — that same
-// wire element appears as element `[i]` on slave_j's incoming
-// `Vec<Bus, NUM_MASTERS>` port.
+// modules. Each (master_i, slave_j) edge is one bus carried by `edges[i][j]`
+// in a single 2D bus wire — the same wire cell that appears as
+// `mp_i.outs[j]` from the master side and `sp_j.ins[i]` from the slave side.
 //
-// 2x2 v1: explicit enumeration of the 2 master + 2 slave instances.
-// Larger configurations are mechanical extensions of the same pattern.
+// Scaled via `generate_for` over both M and N. For M=N=2 today this
+// emits 2+2 = 4 inst declarations; for M=N=8 it would emit 16, all
+// from the same source.
 module Nic400Fabric
   param NUM_MASTERS:   const = 2;
   param NUM_SLAVES:    const = 2;
@@ -26,46 +26,31 @@ module Nic400Fabric
   port s: initiator Vec<BusAxi4<ADDR_W=ADDR_WIDTH, DATA_W=DATA_WIDTH,
                                   ID_W=SLAVE_ID_W, READ=1, WRITE=0>, NUM_SLAVES>;
 
-  // Per-master outgoing edge buses (N copies each = M×N edges total).
-  wire m0_outs: Vec<BusAxi4<ADDR_W=ADDR_WIDTH, DATA_W=DATA_WIDTH,
-                              ID_W=SLAVE_ID_W, READ=1, WRITE=0>, NUM_SLAVES>;
-  wire m1_outs: Vec<BusAxi4<ADDR_W=ADDR_WIDTH, DATA_W=DATA_WIDTH,
-                              ID_W=SLAVE_ID_W, READ=1, WRITE=0>, NUM_SLAVES>;
+  // 2D bus wire: edges[i][j] is the master_i ↔ slave_j edge bus.
+  // M × N = total edges.
+  wire edges: Vec<Vec<BusAxi4, NUM_SLAVES>, NUM_MASTERS>;
 
   // ── M MasterPort instances ────────────────────────────────────────────
-  inst mp_0: Nic400MasterPort
-    param I = 0;
-    clk <- clk;
-    rst <- rst;
-    m   <- m[0];
-    outs -> m0_outs;
-  end inst mp_0
-
-  inst mp_1: Nic400MasterPort
-    param I = 1;
-    clk <- clk;
-    rst <- rst;
-    m   <- m[1];
-    outs -> m1_outs;
-  end inst mp_1
+  generate_for i in 0..NUM_MASTERS-1
+    inst mp_i: Nic400MasterPort
+      param I = i;
+      clk <- clk;
+      rst <- rst;
+      m   <- m[i];
+      outs -> edges[i];
+    end inst mp_i
+  end generate_for
 
   // ── N SlavePort instances ─────────────────────────────────────────────
-  // Each slave_j takes element [j] from every master's outgoing array.
-  inst sp_0: Nic400SlavePort
-    param J = 0;
-    clk <- clk;
-    rst <- rst;
-    s   -> s[0];
-    ins[0] <- m0_outs[0];
-    ins[1] <- m1_outs[0];
-  end inst sp_0
-
-  inst sp_1: Nic400SlavePort
-    param J = 1;
-    clk <- clk;
-    rst <- rst;
-    s   -> s[1];
-    ins[0] <- m0_outs[1];
-    ins[1] <- m1_outs[1];
-  end inst sp_1
+  // Each slave_j gathers element [j] from every master's row of edges.
+  generate_for j in 0..NUM_SLAVES-1
+    inst sp_j: Nic400SlavePort
+      param J = j;
+      clk <- clk;
+      rst <- rst;
+      s   -> s[j];
+      ins[0] <- edges[0][j];
+      ins[1] <- edges[1][j];
+    end inst sp_j
+  end generate_for
 end module Nic400Fabric


### PR DESCRIPTION
Completes the Fabric refactor that started this thread — replaces M+N hand-enumerated `inst` blocks with two `generate_for` loops over a single 2D bus wire.

Before (after PR #393 — still hand-enumerated):

```arch
wire m0_outs: Vec<BusAxi4<...>, NUM_SLAVES>;
wire m1_outs: Vec<BusAxi4<...>, NUM_SLAVES>;
inst mp_0: Nic400MasterPort  param I = 0;  ... outs -> m0_outs;  end inst mp_0
inst mp_1: Nic400MasterPort  param I = 1;  ... outs -> m1_outs;  end inst mp_1
inst sp_0: Nic400SlavePort   param J = 0;  ... ins[0] <- m0_outs[0]; ins[1] <- m1_outs[0]; end inst sp_0
inst sp_1: Nic400SlavePort   param J = 1;  ... ins[0] <- m0_outs[1]; ins[1] <- m1_outs[1]; end inst sp_1
```

After:

```arch
wire edges: Vec<Vec<BusAxi4, NUM_SLAVES>, NUM_MASTERS>;
generate_for i in 0..NUM_MASTERS-1
  inst mp_i: Nic400MasterPort
    param I = i;
    m <- m[i];  outs -> edges[i];
  end inst mp_i
end generate_for
generate_for j in 0..NUM_SLAVES-1
  inst sp_j: Nic400SlavePort
    param J = j;
    s -> s[j];
    ins[0] <- edges[0][j];
    ins[1] <- edges[1][j];
  end inst sp_j
end generate_for
```

For `NUM_MASTERS = NUM_SLAVES = 8`, the same source emits 16 inst declarations from elaborate's static unroll — what motivated this thread.

## Compiler changes

### Sim codegen: `Vec<Vec<Bus, N>, M>` wires

- Emit `B _let_<wire>[M][N]` as a 2D struct array, not the broken packed-bit-vector default that `cpp_internal_type` falls back to for nested Vec.
- Track 2D Vec names in a new `vec_2d_names` Ctx field. Extend `vec_path_of_expr` so `Index(Ident(2d), m)` is still recognized as "this is a Vec" — the inner subscript stays C-array `[n]` instead of falling into the scalar bit-shift path.
- New inst-connection bind variant `Wire2DIndex(name, m, n)` covers `inst.port -> edges[m][n]` shapes after whole-row pre-expansion.
- Pre-expand whole-row `outs -> edges[i]` connections into N per-element connections `outs[j] -> edges[i][j]` for each j. Used by the MasterPort loop.

### SV codegen: `Vec<Vec<Bus, N>, M>` wires

- Flatten 2D bus wire to M×N×per-signal scalar SV wires `<wire>_<m>_<n>_<sig>` (mirrors existing 1D Vec-of-bus-wire flattening).
- `emit_expr_str` for `edges[m][n].field` lowers to `<wire>_<m>_<n>_<field>` with literal/static-unroll index resolution.
- Inst-connection sig_prefix builder handles `inst.port -> edges[m][n]` with the same resolution.

### Elaborate: variant discovery walks generate_for range

The variant-specialization pass (emits `VFoo__I_0`, `VFoo__I_1`, ...) walks every inst site to discover distinct param values. For generate_for insts, those values reference the loop variable at variant-discovery time — non-literal — so every iteration's inst was landing on the default-param variant (silent miscompile: routing went through master 0 regardless of which master the request originated from).

Fix: in `collect_raw_overrides_from_body`, when a `Generate::For` block contains inst items, iterate the literal range (resolved against the enclosing module's params, so `0..NUM_MASTERS-1` works) and call `subst_inst` per iteration to record each substituted variant. Mirrors what `expand_generate_for` does during the actual unroll.

## Tests

- ✅ All 456 unit tests pass; 1 intentionally ignored.
- ✅ NIC-400 `tb_nic400_fabric_smoke.cpp` passes: M0→S0, M0→S1, M1→S1 routings + ID-prefix remap + R return.
- ✅ NIC-400 `tb_nic400_fabric_latency.cpp` passes: AR=0 cyc, R=0 cyc, 9/9 throughput unchanged.

## Known limitation (queued follow-up)

`arch build` SV emit has one remaining gap on the refactored Fabric: when a slave inst's per-element `ins[k] <- edges[m][j]` connection meets the D2 outer-port shape `ins_<sig> [N]`, SV needs an array-literal grouping (`.ins_<sig>('{edges_0_j_<sig>, edges_1_j_<sig>})`) which isn't emitted today. Same root cause as the previously-`#[ignore]`d `test_vec_of_bus_inst_connection_uses_bracket_index_syntax` test.

The sim path is unaffected — `arch sim` works end-to-end, which is what NIC-400 verification uses. The synthesis path will need either the array-literal grouping or an intermediate-wire-array workaround (similar to the existing `__<inst>_<group>_<sig>` synthesis used for arbiter port arrays).