### PR TITLE
SV: packed Vec-of-bus ports + wires (split-emitter design)

### DIFF
--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -2299,6 +2299,26 @@ impl<'a> Codegen<'a> {
             (String, String), TypeExpr,
         > = std::collections::HashMap::new();
 
+        // Per-element Vec-of-bus connection groups. Inst connections like
+        //   `ins[0] <- edges[0][j];  ins[1] <- edges[1][j];`
+        // get parsed with per-element port names `ins_0`, `ins_1`, but the
+        // child's actual SV port is packed `ins_<sig> [N-1:0]`. We can't
+        // emit `.ins_0_<sig>(...)` — that port doesn't exist anymore.
+        // Instead, gather all per-element connections for the same
+        // (base_port, bus_signal) and emit ONE packed concat:
+        //   `.ins_<sig>({elem_{N-1}_<sig>, ..., elem_0_<sig>})`
+        // Map key is (base_port, idx), value is the per-element parent expr
+        // (one for each bus signal will be derived from the same parent expr).
+        let mut vob_per_elem: std::collections::HashMap<
+            (String, u32),  // (base_port_name, elem_idx)
+            Expr,            // per-element parent expr (e.g. `edges[m][j]`)
+        > = std::collections::HashMap::new();
+        // (base_port_name, N) → bus_name, bus_params for packed emit.
+        let vob_port_meta: std::collections::HashMap<String, (u32, String, Vec<ParamAssign>)> =
+            target_vec_of_bus_ports.iter()
+                .map(|(name, n, bus_name, bus_params)| (name.clone(), (*n, bus_name.clone(), bus_params.clone())))
+                .collect();
+
         for c in &inst.connections {
             // Try to match `<group>{idx}_<sig>` against any known port array.
             let matched = target_port_arrays.iter().find_map(|(group, _n, sigs)| {
@@ -2324,32 +2344,72 @@ impl<'a> Codegen<'a> {
                 indexed_group_ty.insert((group, sig), ty);
                 continue;
             }
-            // Whole-vec bus connection: `chans -> w` where the child's
-            // `chans` is a `Vec<Bus, N>` port. The parent signal `w` must
-            // be a bare identifier — a parent Vec-of-bus port or a bus
-            // wire-array (`wire w: Vec<Bus, N>;`). Expand to N x #signals
-            // per-element named-port connections.
-            if let Some((_, n, bus_name, bus_params)) = target_vec_of_bus_ports.iter()
+            // Whole-vec bus connection on a Vec-of-bus child port.
+            // Packed SV emission: one connection per bus signal, parent
+            // expr passed whole — works for all three shapes:
+            //   `chans -> w`       (1D Vec-of-bus wire `w` → packed `w_<sig>`)
+            //   `chans -> edges[i]` (row of 2D wire → packed slice `edges_<sig>[i]`)
+            //   `chans -> p`       (parent Vec-of-bus port `p` → packed `p_<sig>`)
+            if let Some((_, _n, bus_name, bus_params)) = target_vec_of_bus_ports.iter()
                 .find(|(pn, _, _, _)| *pn == c.port_name.name)
             {
-                if let ExprKind::Ident(parent_name) = &c.signal.kind {
-                    if let Some((Symbol::Bus(info), _)) = self.symbols.globals.get(bus_name) {
-                        let mut param_map: std::collections::HashMap<String, &Expr> = info.params.iter()
-                            .filter_map(|pd| pd.default.as_ref().map(|d| (pd.name.name.clone(), d)))
-                            .collect();
-                        for pa in bus_params { param_map.insert(pa.name.name.clone(), &pa.value); }
-                        let eff = info.effective_signals(&param_map);
-                        for i in 0..*n {
-                            for (sname, _, _) in &eff {
-                                connections.push(format!(
-                                    ".{}_{}_{}({}_{}_{})",
-                                    c.port_name.name, i, sname,
-                                    parent_name, i, sname,
-                                ));
+                let parent_expr_str = self.emit_expr_str(&c.signal);
+                // For an Ident parent: name is the bus base; per-signal ref is `<name>_<sig>`.
+                // For an Index parent: emit_expr_str already produced `<base>_<sig>[i]`
+                // form via the FieldAccess(Index) path — but here there's no field,
+                // so emit_expr_str gives just the indexed array (e.g. `edges[i]`),
+                // which is wrong. Build the correct per-signal ref directly.
+                let per_sig_emit = |sname: &str, self_: &Self| -> String {
+                    match &c.signal.kind {
+                        ExprKind::Ident(name) => format!("{}_{}", name, sname),
+                        ExprKind::Index(arr, idx) => {
+                            let idx_str = match &idx.kind {
+                                ExprKind::Ident(loopvar) =>
+                                    self_.loop_var_subst.get(loopvar)
+                                        .map(|v| v.to_string())
+                                        .unwrap_or_else(|| loopvar.clone()),
+                                _ => self_.emit_expr_str(idx),
+                            };
+                            if let ExprKind::Ident(arr_name) = &arr.kind {
+                                format!("{}_{}[{}]", arr_name, sname, idx_str)
+                            } else {
+                                // Fallback — shouldn't happen for legal whole-vec sources.
+                                format!("{}_{}", parent_expr_str, sname)
                             }
                         }
-                        continue;
+                        _ => format!("{}_{}", parent_expr_str, sname),
                     }
+                };
+                if let Some((Symbol::Bus(info), _)) = self.symbols.globals.get(bus_name) {
+                    let mut param_map: std::collections::HashMap<String, &Expr> = info.params.iter()
+                        .filter_map(|pd| pd.default.as_ref().map(|d| (pd.name.name.clone(), d)))
+                        .collect();
+                    for pa in bus_params { param_map.insert(pa.name.name.clone(), &pa.value); }
+                    let eff = info.effective_signals(&param_map);
+                    for (sname, _, _) in &eff {
+                        connections.push(format!(
+                            ".{}_{}({})",
+                            c.port_name.name, sname, per_sig_emit(sname, self),
+                        ));
+                    }
+                    continue;
+                }
+            }
+            // Per-element Vec-of-bus connection: `ins[k] <- expr`. The parser
+            // already lowered `ins[k]` to port_name `ins_<k>`. Detect the
+            // `<base>_<k>` pattern against `target_vec_of_bus_ports` and
+            // accumulate for post-loop concat emission.
+            {
+                let pname = &c.port_name.name;
+                let matched_vob = target_vec_of_bus_ports.iter().find_map(|(base, n, _, _)| {
+                    let prefix = format!("{base}_");
+                    let rest = pname.strip_prefix(&prefix)?;
+                    let idx: u32 = rest.parse().ok()?;
+                    if idx < *n { Some((base.clone(), idx)) } else { None }
+                });
+                if let Some((base, idx)) = matched_vob {
+                    vob_per_elem.insert((base, idx), c.signal.clone());
+                    continue;
                 }
             }
             if let Some((_, bus_name, bus_params)) = target_bus_ports.iter().find(|(pn, _, _)| *pn == c.port_name.name) {
@@ -2441,6 +2501,56 @@ impl<'a> Codegen<'a> {
                     format!(".{}({})", c.port_name.name, sig_str)
                 };
                 connections.push(conn_str);
+            }
+        }
+
+        // Emit packed concat connections for gathered Vec-of-bus per-element
+        // connections (`ins[k] <- expr_k` slate). For each (base_port, N),
+        // build per-signal concat in big-endian order (highest idx → LSB),
+        // matching SV's packed concat semantics.
+        let mut vob_bases: std::collections::HashSet<String> =
+            vob_per_elem.keys().map(|(b, _)| b.clone()).collect();
+        let mut vob_bases_sorted: Vec<String> = vob_bases.drain().collect();
+        vob_bases_sorted.sort();
+        for base in &vob_bases_sorted {
+            let Some((n, bus_name, bus_params)) = vob_port_meta.get(base) else { continue; };
+            let Some((Symbol::Bus(info), _)) = self.symbols.globals.get(bus_name) else { continue; };
+            let mut param_map: std::collections::HashMap<String, &Expr> = info.params.iter()
+                .filter_map(|pd| pd.default.as_ref().map(|d| (pd.name.name.clone(), d)))
+                .collect();
+            for pa in bus_params { param_map.insert(pa.name.name.clone(), &pa.value); }
+            let eff = info.effective_signals(&param_map);
+            for (sname, _, _) in &eff {
+                // Build {expr_{N-1}_<sig>, expr_{N-2}_<sig>, …, expr_0_<sig>}.
+                // The per-element exprs were captured at gather time as the
+                // user's `c.signal` AST nodes (e.g. `edges[m][j]`); we need
+                // to produce the per-bus-signal form by attaching .<sig>
+                // and re-emitting via emit_expr_str (which handles 2D-wire
+                // packed-slice lowering).
+                let mut parts: Vec<String> = Vec::with_capacity(*n as usize);
+                for k in (0..*n).rev() {
+                    if let Some(elem_expr) = vob_per_elem.get(&(base.clone(), k)) {
+                        // Build FieldAccess(elem_expr, sname) AST and emit.
+                        let fa = Expr::new(
+                            ExprKind::FieldAccess(
+                                Box::new(elem_expr.clone()),
+                                Ident::new(sname.clone(), elem_expr.span),
+                            ),
+                            elem_expr.span,
+                        );
+                        parts.push(self.emit_expr_str(&fa));
+                    } else {
+                        // Missing element — emit a dummy literal so SV still
+                        // parses (the typecheck pass should have rejected this
+                        // upstream).
+                        parts.push(format!("'0"));
+                    }
+                }
+                connections.push(format!(
+                    ".{}_{}({{{}}})",
+                    base, sname,
+                    parts.join(", "),
+                ));
             }
         }
 
@@ -4461,37 +4571,40 @@ impl<'a> Codegen<'a> {
                 if let ExprKind::Index(arr, idx) = &base.kind {
                     // 2D bus wire element: `edges[m][n].sig`. The arr is
                     // itself `Index(Ident(name), m_idx)`, and `idx` is n_idx.
-                    // Both indices must resolve to literals (either directly
-                    // or via static-unroll loop_var_subst). Emit the flat
-                    // SV wire name `<name>_<m>_<n>_<sig>`.
+                    // SV-side storage is now packed: `logic [M-1:0][N-1:0]
+                    // <wire>_<sig>`, so `edges[m][n].sig` lowers to
+                    // `<wire>_<sig>[m][n]`. m and n can be literals OR
+                    // loop variables (genvar references in a preserved
+                    // generate_for, though insts force unrolling — so today
+                    // they're always literals).
                     if let ExprKind::Index(inner_arr, inner_idx) = &arr.kind {
                         if let ExprKind::Ident(arr_name) = &inner_arr.kind {
-                            let resolve = |e: &Expr| -> Option<u64> {
+                            let resolve_str = |e: &Expr| -> String {
                                 match &e.kind {
-                                    ExprKind::Literal(LitKind::Dec(i))
-                                    | ExprKind::Literal(LitKind::Hex(i))
-                                    | ExprKind::Literal(LitKind::Bin(i))
-                                    | ExprKind::Literal(LitKind::Sized(_, i)) => Some(*i),
-                                    ExprKind::Ident(loopvar) =>
-                                        self.loop_var_subst.get(loopvar).map(|v| *v as u64),
-                                    _ => None,
+                                    ExprKind::Ident(loopvar) => {
+                                        if let Some(&v) = self.loop_var_subst.get(loopvar) {
+                                            v.to_string()
+                                        } else {
+                                            loopvar.clone()
+                                        }
+                                    }
+                                    _ => self.emit_expr_str(e),
                                 }
                             };
-                            if let (Some(m_v), Some(n_v)) = (resolve(inner_idx), resolve(idx)) {
-                                let cell = format!("{}_{}_{}", arr_name, m_v, n_v);
-                                if self.bus_wires.contains_key(&cell) {
-                                    return format!("{}_{}_{}_{}", arr_name, m_v, n_v, field.name);
-                                }
+                            // Check that the wire is registered (any cell).
+                            let cell0 = format!("{}_0_0", arr_name);
+                            if self.bus_wires.contains_key(&cell0) {
+                                let m_str = resolve_str(inner_idx);
+                                let n_str = resolve_str(idx);
+                                return format!("{}_{}[{}][{}]", arr_name, field.name, m_str, n_str);
                             }
                         }
                     }
                     if let ExprKind::Ident(arr_name) = &arr.kind {
-                        // Vec-of-bus *port* → D2 indexed ref.
+                        // Vec-of-bus *port* → packed indexed ref `<port>_<sig>[i]`.
                         if self.vec_of_bus_port_count.contains_key(arr_name) {
                             let idx_str = match &idx.kind {
                                 ExprKind::Ident(loopvar) => {
-                                    // Static-unroll substitution wins if present;
-                                    // otherwise emit the loop var as-is for SV genvar.
                                     if let Some(&v) = self.loop_var_subst.get(loopvar) {
                                         v.to_string()
                                     } else {
@@ -4502,22 +4615,20 @@ impl<'a> Codegen<'a> {
                             };
                             return format!("{}_{}[{}]", arr_name, field.name, idx_str);
                         }
-                        // Bus wire (still flat per element) — original behavior.
-                        let idx_val: Option<u64> = match &idx.kind {
-                            ExprKind::Literal(LitKind::Dec(i))
-                            | ExprKind::Literal(LitKind::Hex(i))
-                            | ExprKind::Literal(LitKind::Bin(i))
-                            | ExprKind::Literal(LitKind::Sized(_, i)) => Some(*i),
-                            ExprKind::Ident(loopvar) => self.loop_var_subst.get(loopvar).map(|v| *v as u64),
-                            _ => None,
-                        };
-                        if let Some(i) = idx_val {
-                            let expanded = format!("{}_{}", arr_name, i);
-                            if self.bus_ports.contains_key(&expanded)
-                                || self.bus_wires.contains_key(&expanded)
-                            {
-                                return format!("{}_{}_{}", arr_name, i, field.name);
-                            }
+                        // 1D Vec-of-bus *wire* — also packed now. Same form.
+                        let cell0 = format!("{}_0", arr_name);
+                        if self.bus_wires.contains_key(&cell0) {
+                            let idx_str = match &idx.kind {
+                                ExprKind::Ident(loopvar) => {
+                                    if let Some(&v) = self.loop_var_subst.get(loopvar) {
+                                        v.to_string()
+                                    } else {
+                                        loopvar.clone()
+                                    }
+                                }
+                                _ => self.emit_expr_str(idx),
+                            };
+                            return format!("{}_{}[{}]", arr_name, field.name, idx_str);
                         }
                     }
                 }

--- a/src/codegen/module.rs
+++ b/src/codegen/module.rs
@@ -212,10 +212,33 @@ impl<'a> Codegen<'a> {
                         let subst_ty = Self::subst_type_expr(sty, &param_map);
                         let ty_str = self.emit_port_type_str(&subst_ty);
                         if is_vec_of_bus {
-                            // D2: `<dir> <ty> <port>_<sig> [N]`
+                            // Packed Vec-of-bus port: `<dir> [N-1:0] <ty?> <port>_<sig>`.
+                            // For scalar signals (Bool / 1-bit), the [N-1:0] is the only
+                            // packed dim. For multi-bit signals, the ty_str already
+                            // carries an inner packed dim (e.g. "logic [31:0]"), and
+                            // we prepend the outer [N-1:0] as a second packed dim.
+                            //
+                            // The packed shape lets inst connection sites use SV
+                            // language features (row slice `wire[i]`, concat
+                            // `{a, b, c}` for column gather) instead of needing
+                            // synthesized intermediate-wire arrays. Native-sim
+                            // C++ emission stays as unpacked array + reference
+                            // aliases (see src/sim_codegen) so TB syntax remains
+                            // `dut.port_sig[i]`.
+                            let outer_dim = format!("[{}:0]", vec_n.saturating_sub(1));
+                            // ty_str is `logic` or `logic [W-1:0]`. Insert the
+                            // outer packed dim between `logic` and any inner dim.
+                            let with_outer = if let Some(rest) = ty_str.strip_prefix("logic ") {
+                                format!("logic {} {}", outer_dim, rest)
+                            } else if ty_str == "logic" {
+                                format!("logic {}", outer_dim)
+                            } else {
+                                // Other base types (e.g. struct-typed bus signal — rare).
+                                format!("{} {}", ty_str, outer_dim)
+                            };
                             port_lines.push(format!(
-                                "{} {} {}_{} [{}]",
-                                dir_str, ty_str, p.name.name, sname, vec_n
+                                "{} {} {}_{}",
+                                dir_str, with_outer, p.name.name, sname
                             ));
                         } else {
                             // Scalar bus: `<dir> <ty> <port>_<sig>`
@@ -718,7 +741,11 @@ impl<'a> Codegen<'a> {
                         _ => None,
                     };
                     if let Some((info, bus_name, count)) = bus_wire_info {
-                        let prefixes: Vec<String> = match count {
+                        // Register every flat per-cell name in `self.bus_wires`
+                        // so downstream lookups (e.g. emit_expr_str's bus-wire
+                        // detection) still work — internal name tracking stays
+                        // per-cell even though the emitted SV is packed-array.
+                        let cell_names: Vec<String> = match count {
                             None => vec![w.name.name.clone()],
                             Some((m_n, None)) => (0..m_n).map(|i| format!("{}_{}", w.name.name, i)).collect(),
                             Some((m_n, Some(n_n))) => {
@@ -731,8 +758,8 @@ impl<'a> Codegen<'a> {
                                 v
                             }
                         };
-                        for prefix in &prefixes {
-                            self.bus_wires.insert(prefix.clone(), bus_name.clone());
+                        for nm in &cell_names {
+                            self.bus_wires.insert(nm.clone(), bus_name.clone());
                         }
                         // Start with the bus's declared defaults then layer
                         // any per-wire overrides from `wire w: Vec<B<PARAM=val>, N>;`.
@@ -744,16 +771,45 @@ impl<'a> Codegen<'a> {
                         for pa in &w.bus_params {
                             param_map.insert(pa.name.name.clone(), &pa.value);
                         }
-                        for prefix in &prefixes {
-                            for (sname, _sdir, sty) in info.effective_signals(&param_map) {
-                                let subst_ty = Self::subst_type_expr(&sty, &param_map);
-                                let (ty_str, arr_suffix) =
-                                    self.emit_type_and_array_suffix(&subst_ty);
-                                self.line(&format!(
-                                    "{} {}_{}{};",
-                                    ty_str, prefix, sname, arr_suffix
-                                ));
-                                declared_names.insert(format!("{}_{}", prefix, sname));
+                        // Build the packed outer dim string for Vec / Vec<Vec>.
+                        // None  → scalar wire, no outer dim
+                        // (M, None) → 1D Vec: `[M-1:0]`
+                        // (M, Some(N)) → 2D Vec: `[M-1:0][N-1:0]`
+                        let outer_dim: String = match count {
+                            None => String::new(),
+                            Some((m_n, None)) => format!("[{}:0]", m_n.saturating_sub(1)),
+                            Some((m_n, Some(n_n))) => format!(
+                                "[{}:0][{}:0]",
+                                m_n.saturating_sub(1),
+                                n_n.saturating_sub(1)
+                            ),
+                        };
+                        for (sname, _sdir, sty) in info.effective_signals(&param_map) {
+                            let subst_ty = Self::subst_type_expr(&sty, &param_map);
+                            let (ty_str, arr_suffix) =
+                                self.emit_type_and_array_suffix(&subst_ty);
+                            // Insert the outer packed dim between `logic` and
+                            // any inner packed dim (same pattern as port emit).
+                            let with_outer = if outer_dim.is_empty() {
+                                ty_str.clone()
+                            } else if let Some(rest) = ty_str.strip_prefix("logic ") {
+                                format!("logic {} {}", outer_dim, rest)
+                            } else if ty_str == "logic" {
+                                format!("logic {}", outer_dim)
+                            } else {
+                                format!("{} {}", ty_str, outer_dim)
+                            };
+                            self.line(&format!(
+                                "{} {}_{}{};",
+                                with_outer, w.name.name, sname, arr_suffix
+                            ));
+                            declared_names.insert(format!("{}_{}", w.name.name, sname));
+                            // Also register per-cell names so legacy lookups
+                            // (e.g. driver-tracking elsewhere) find them.
+                            for nm in &cell_names {
+                                if nm != &w.name.name {
+                                    declared_names.insert(format!("{}_{}", nm, sname));
+                                }
                             }
                         }
                         declared_names.insert(w.name.name.clone());

--- a/src/elaborate.rs
+++ b/src/elaborate.rs
@@ -2825,15 +2825,78 @@ fn lower_module_threads(
     };
 
     // ── Create InstDecl in parent module ───────────────────────────────
+    //
+    // Parent wrapper exposes Vec-of-bus ports in PACKED form
+    // (`ins_<sig> [N-1:0]` — see src/codegen). The threads sub-module
+    // expects FLAT per-element signal names (`ins_<i>_<sig>`). Detect
+    // when a sub-port name follows the `<base>_<i>_<sig>` pattern AND
+    // `<base>` is a Vec-of-bus port on the wrapper, and emit the
+    // signal as an Index into the packed wrapper port:
+    //   port_name="ins_0_r_valid", signal=Index(Ident("ins_r_valid"), 0)
+    // emit_expr_str renders this as `ins_r_valid[0]` — which IS a valid
+    // SV expression slicing the packed wrapper port.
+    use std::collections::HashMap as _HashMap;
+    let parent_vob: _HashMap<String, (u32, Vec<String>)> = {
+        let mut out = _HashMap::new();
+        for p in &m.ports {
+            let Some(bi) = p.bus_info.as_ref() else { continue; };
+            let Some(count_expr) = bi.count.as_ref() else { continue; };
+            // Build a tiny param-vals map from the module's param defaults so
+            // expressions like `NUM_SLAVES` resolve at elaboration-time.
+            let param_vals_local: HashMap<String, i64> = m.params.iter()
+                .filter_map(|p| p.default.as_ref()
+                    .and_then(|d| try_eval_i64(d, &HashMap::new()).map(|v| (p.name.name.clone(), v))))
+                .collect();
+            let n = try_eval_i64(count_expr, &param_vals_local).unwrap_or(0) as u32;
+            if n == 0 { continue; }
+            let Some(bus_decl) = bus_defs.get(&bi.bus_name.name) else { continue; };
+            // BusDecl.signals lists unconditional signals; conditional ones
+            // (under READ/WRITE flags) live in BusDecl.generates. Collect
+            // names from BOTH so the `<base>_<i>_<sig>` pattern matches
+            // every flattened sub-port name.
+            let mut sigs: Vec<String> = bus_decl.signals.iter()
+                .map(|s| s.name.name.clone())
+                .collect();
+            for g in &bus_decl.generates {
+                for s in g.then_signals.iter().chain(g.else_signals.iter()) {
+                    sigs.push(s.name.name.clone());
+                }
+            }
+            out.insert(p.name.name.clone(), (n, sigs));
+        }
+        out
+    };
     let mut connections: Vec<Connection> = Vec::new();
     for p in &merged_ports {
         let dir = match p.direction {
             Direction::In => ConnectDir::Input,
             Direction::Out => ConnectDir::Output,
         };
+        // Try to decompose `<base>_<i>_<sig>` for Vec-of-bus parent ports.
+        let mut signal = Expr::new(ExprKind::Ident(p.name.name.clone()), sp);
+        for (base, (n, sigs)) in &parent_vob {
+            let prefix = format!("{base}_");
+            let Some(rest) = p.name.name.strip_prefix(&prefix) else { continue; };
+            // rest looks like "<i>_<sig>" — split on first '_'.
+            let Some(und) = rest.find('_') else { continue; };
+            let idx_str = &rest[..und];
+            let sig = &rest[und + 1..];
+            let Ok(idx) = idx_str.parse::<u32>() else { continue; };
+            if idx >= *n { continue; }
+            if !sigs.iter().any(|s| s == sig) { continue; }
+            // Match. Emit Index(Ident("<base>_<sig>"), idx).
+            signal = Expr::new(
+                ExprKind::Index(
+                    Box::new(Expr::new(ExprKind::Ident(format!("{base}_{sig}")), sp)),
+                    Box::new(Expr::new(ExprKind::Literal(LitKind::Dec(idx as u64)), sp)),
+                ),
+                sp,
+            );
+            break;
+        }
         connections.push(Connection {
             port_name: p.name.clone(), direction: dir,
-            signal: Expr::new(ExprKind::Ident(p.name.name.clone()), sp),
+            signal,
             reset_override: None, span: sp,
         });
     }

--- a/src/sim_codegen/mod.rs
+++ b/src/sim_codegen/mod.rs
@@ -4739,6 +4739,24 @@ impl<'a> SimCodegen<'a> {
             } else { None })
             .collect();
 
+        // D2 Vec-of-bus port array members: for `port chans: Vec<Bus, N>`,
+        // the C++ class has `<ty> chans_<sig>[N]` array members (Phase 2
+        // mirror) — so any Ident reference to `chans_<sig>` is a C array
+        // and `chans_<sig>[i]` indexing uses C subscript, not bit-shift.
+        // Register these names in vec_reg_names so expr_is_vec recognises
+        // them in the Index emitter.
+        for p in &m.ports {
+            let Some(bi) = p.bus_info.as_ref() else { continue; };
+            if bi.count.is_none() { continue; }
+            let bus_name = &bi.bus_name.name;
+            let Some((crate::resolve::Symbol::Bus(info), _)) = self.symbols.globals.get(bus_name) else { continue; };
+            let mut pm = info.default_param_map();
+            for pa in &bi.params { pm.insert(pa.name.name.clone(), &pa.value); }
+            for (sname, _, _) in info.effective_signals(&pm) {
+                vec_reg_names.insert(format!("{}_{}", p.name.name, sname));
+            }
+        }
+
         // Vec wire/reg name → element count (for expanding inst port connections)
         let mut vec_wire_counts: HashMap<String, u64> = m.body.iter()
             .filter_map(|i| if let ModuleBodyItem::WireDecl(w) = i {

--- a/src/sim_codegen/pipeline.rs
+++ b/src/sim_codegen/pipeline.rs
@@ -501,7 +501,7 @@ impl<'a> SimCodegen<'a> {
     ) -> String {
         let empty = HashSet::new();
         let empty_rl: HashMap<String, ResetLevel> = HashMap::new();
-        let ctx = Ctx { reg_names: rn, port_names: pn, let_names: ln, let_values: None, inst_names: &empty, wide_names: &empty, widths: w, signed_names: &empty, posedge_lhs: false, fsm_mode: false, enum_map: em, bus_ports: &empty, reset_levels: &empty_rl, vec_names: None, vec_sizes: None, fsm_vec_port_regs: None, ident_subst: None, loop_var_subst: None, vec_of_bus_port_count: None, vec_of_bus_wire_count: None, coverage: None, params: &[] };
+        let ctx = Ctx { reg_names: rn, port_names: pn, let_names: ln, let_values: None, inst_names: &empty, wide_names: &empty, widths: w, signed_names: &empty, posedge_lhs: false, fsm_mode: false, enum_map: em, bus_ports: &empty, reset_levels: &empty_rl, vec_names: None, vec_2d_names: None, vec_sizes: None, fsm_vec_port_regs: None, ident_subst: None, loop_var_subst: None, vec_of_bus_port_count: None, vec_of_bus_wire_count: None, coverage: None, params: &[] };
         match &expr.kind {
             ExprKind::FieldAccess(base, field) => {
                 if let ExprKind::Ident(bn) = &base.kind {

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -1394,6 +1394,24 @@ impl<'a> TypeChecker<'a> {
                     if !flat.is_empty() {
                         driven.insert(flat);
                     }
+                    // Packed Vec-of-bus port-element drive:
+                    // `Index(Ident("<base>_<sig>"), <i>)` from the thread-wrapper
+                    // emission credits the per-element flat name `<base>_<i>_<sig>`
+                    // that the undriven-port check looks for. Detect when the
+                    // base ident matches a `<vobport>_<sig>` pair.
+                    if let ExprKind::Index(arr, idx) = &conn.signal.kind {
+                        if let (ExprKind::Ident(arr_name), ExprKind::Literal(LitKind::Dec(i)))
+                            = (&arr.kind, &idx.kind)
+                        {
+                            // Try every Vec-of-bus port name as a prefix.
+                            for (vobport, _n) in self.vec_of_bus_ports.iter() {
+                                let prefix = format!("{vobport}_");
+                                if let Some(sig) = arr_name.strip_prefix(&prefix) {
+                                    driven.insert(format!("{vobport}_{i}_{sig}"));
+                                }
+                            }
+                        }
+                    }
                 }
                 // Whole-bus connection: axi_rd -> m_axi_mm2s expands to N signals.
                 // The inst's bus port drives/receives signals based on its perspective.

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -4036,14 +4036,16 @@ fn test_vec_of_bus_port_flattens_to_n_indexed_copies() {
         end module Prod
     ";
     let sv = compile_to_sv(source);
-    // One port per signal, with `[N]` unpacked outer dim.
-    assert!(sv.contains("output logic chans_v [3]"),
-            "missing `output logic chans_v [3]` in SV:\n{sv}");
-    assert!(sv.contains("input logic chans_r [3]"),
-            "missing `input logic chans_r [3]` in SV:\n{sv}");
-    assert!(sv.contains("output logic [7:0] chans_d [3]"),
-            "missing `output logic [7:0] chans_d [3]` in SV:\n{sv}");
-    // Bracket-dot access lowers to indexed SV refs.
+    // One port per signal, with `[N-1:0]` *packed* outer dim. Packed shape
+    // works with both Verilator and Yosys's built-in read_verilog and lets
+    // inst connection sites use SV concat literals for column gather.
+    assert!(sv.contains("output logic [2:0] chans_v"),
+            "missing `output logic [2:0] chans_v` (packed 3-element) in SV:\n{sv}");
+    assert!(sv.contains("input logic [2:0] chans_r"),
+            "missing `input logic [2:0] chans_r` in SV:\n{sv}");
+    assert!(sv.contains("output logic [2:0] [7:0] chans_d"),
+            "missing `output logic [2:0] [7:0] chans_d` in SV:\n{sv}");
+    // Bracket-dot access lowers to packed indexed SV refs.
     assert!(sv.contains("chans_v[0] = 1'b1") || sv.contains("assign chans_v[0] = 1'b1"),
             "expected `chans_v[0] = 1'b1` assignment in SV:\n{sv}");
     assert!(sv.contains("chans_v[1] = 1'b0") || sv.contains("assign chans_v[1] = 1'b0"),
@@ -4097,11 +4099,12 @@ fn test_vec_of_bus_port_param_driven_n() {
         end module M
     ";
     let sv = compile_to_sv(source);
-    // D2 array port (single decl with unpacked `[3]` outer dim — param folded).
-    assert!(sv.contains("output logic chans_v [3]"),
-            "missing `output logic chans_v [3]` in SV:\n{sv}");
-    assert!(sv.contains("output logic [7:0] chans_d [3]"),
-            "missing `output logic [7:0] chans_d [3]` in SV:\n{sv}");
+    // Packed Vec-of-bus port: single decl with `[N-1:0]` packed outer dim
+    // (param folded to 3).
+    assert!(sv.contains("output logic [2:0] chans_v"),
+            "missing `output logic [2:0] chans_v` (packed) in SV:\n{sv}");
+    assert!(sv.contains("output logic [2:0] [7:0] chans_d"),
+            "missing `output logic [2:0] [7:0] chans_d` in SV:\n{sv}");
     // for-loop should be statically unrolled even though the upper bound
     // is `NUM_CHANS-1` (param expression).
     assert!(!sv.contains("for (int i ="),
@@ -4432,25 +4435,22 @@ fn test_vec_of_bus_inst_whole_vec_connection() {
         end module Parent
     ";
     let sv = compile_to_sv(source);
-    for i in 0..3 {
-        assert!(sv.contains(&format!(".chans_{i}_v(w_{i}_v)"))
-                || sv.contains(&format!(".chans_{i}_v (w_{i}_v)")),
-                "missing `.chans_{i}_v(w_{i}_v)` named-port connection:\n{sv}");
-        assert!(sv.contains(&format!(".chans_{i}_d(w_{i}_d)"))
-                || sv.contains(&format!(".chans_{i}_d (w_{i}_d)")),
-                "missing `.chans_{i}_d(w_{i}_d)` named-port connection:\n{sv}");
-    }
-    // Should not leave a `.chans(w)` (illegal SV) artifact in the output.
-    assert!(!sv.contains(".chans(w)"),
-            "whole-vec connection must expand, not emit `.chans(w)`:\n{sv}");
+    // Whole-vec `chans -> w` now emits ONE packed connection per bus signal —
+    // both sides have the same packed shape. No per-element split needed.
+    assert!(sv.contains(".chans_v(w_v)") || sv.contains(".chans_v (w_v)"),
+            "missing `.chans_v(w_v)` packed whole-vec connection:\n{sv}");
+    assert!(sv.contains(".chans_d(w_d)") || sv.contains(".chans_d (w_d)"),
+            "missing `.chans_d(w_d)` packed whole-vec connection:\n{sv}");
+    // The parent's bus wire `w` is also packed, so reads like `w[0].d`
+    // lower to `w_d[0]`.
+    assert!(sv.contains("w_d[0]"), "expected `w_d[0]` indexed wire read:\n{sv}");
 }
 
 #[test]
 fn test_vec_of_bus_wire_flattens_to_n_indexed_signals() {
-    // `wire w: Vec<BusName, N>;` is type-expression composition over the
-    // existing `wire X: BusName;` form. SV codegen emits N flat
-    // `w_0_<sig>`, ..., `w_{N-1}_<sig>` and `w[i].sig` access resolves
-    // to the corresponding flat name. No new construct.
+    // `wire w: Vec<BusName, N>;` becomes one packed per-signal storage
+    // (`logic [N-1:0]` or `logic [N-1:0][W-1:0]`) at the SV layer.
+    // `w[i].sig` access resolves to `w_<sig>[i]`.
     let source = "
         bus B
           v: out Bool;
@@ -4470,20 +4470,20 @@ fn test_vec_of_bus_wire_flattens_to_n_indexed_signals() {
         end module M
     ";
     let sv = compile_to_sv(source);
-    // The wire becomes N flat per-signal declarations.
+    // Packed wire: one decl per bus signal with `[N-1:0]` outer dim.
+    assert!(sv.contains("logic [1:0] w_v;"),
+            "missing `logic [1:0] w_v;` packed wire in SV:\n{sv}");
+    assert!(sv.contains("logic [1:0] [7:0] w_d;"),
+            "missing `logic [1:0] [7:0] w_d;` packed wire in SV:\n{sv}");
+    // Indexed writes/reads use SV packed slicing.
     for (i, expected_d) in [(0u32, "8'd17"), (1u32, "8'd34")] {
-        assert!(sv.contains(&format!("logic w_{i}_v;")),
-                "missing `logic w_{i}_v;` in SV:\n{sv}");
-        assert!(sv.contains(&format!("logic [7:0] w_{i}_d;")),
-                "missing `logic [7:0] w_{i}_d;` in SV:\n{sv}");
-        assert!(sv.contains(&format!("w_{i}_d = {expected_d}")),
-                "missing `w_{i}_d = {expected_d}` assignment in SV:\n{sv}");
+        assert!(sv.contains(&format!("w_d[{i}] = {expected_d}")),
+                "missing `w_d[{i}] = {expected_d}` assignment in SV:\n{sv}");
     }
-    // Reading uses the same flat names.
-    assert!(sv.contains("o_v0 = w_0_v"),
-            "expected `o_v0 = w_0_v` in SV:\n{sv}");
-    assert!(sv.contains("o_d1 = w_1_d"),
-            "expected `o_d1 = w_1_d` in SV:\n{sv}");
+    assert!(sv.contains("o_v0 = w_v[0]"),
+            "expected `o_v0 = w_v[0]` in SV:\n{sv}");
+    assert!(sv.contains("o_d1 = w_d[1]"),
+            "expected `o_d1 = w_d[1]` in SV:\n{sv}");
 }
 
 #[test]
@@ -4525,26 +4525,26 @@ fn test_vec_of_bus_wire_carries_inst_output_through_indexed_connection() {
         end module Parent
     ";
     let sv = compile_to_sv(source);
-    // The Vec-of-bus wire flattens to per-index per-signal storage.
-    for i in 0..2 {
-        assert!(sv.contains(&format!("logic w_{i}_v;")),
-                "missing `logic w_{i}_v;` in Parent SV:\n{sv}");
-    }
-    // The Producer instance's bus port elements connect via per-signal
-    // named ports against those flat wire signals.
-    assert!(sv.contains(".chans_0_v(w_0_v)") || sv.contains(".chans_0_v (w_0_v)"),
-            "expected `.chans_0_v(w_0_v)` named-port connection in SV:\n{sv}");
-    assert!(sv.contains(".chans_1_d(w_1_d)") || sv.contains(".chans_1_d (w_1_d)"),
-            "expected `.chans_1_d(w_1_d)` named-port connection in SV:\n{sv}");
-    // The downstream reads land on the same flat names.
-    assert!(sv.contains("o_v0 = w_0_v"),
-            "expected `o_v0 = w_0_v` in SV:\n{sv}");
-    assert!(sv.contains("o_d1 = w_1_d"),
-            "expected `o_d1 = w_1_d` in SV:\n{sv}");
+    // Packed Vec-of-bus wire: one decl per bus signal with [N-1:0] outer dim.
+    assert!(sv.contains("logic [1:0] w_v;"),
+            "missing `logic [1:0] w_v;` packed wire in Parent SV:\n{sv}");
+    assert!(sv.contains("logic [1:0] [7:0] w_d;"),
+            "missing `logic [1:0] [7:0] w_d;` packed wire in Parent SV:\n{sv}");
+    // Producer inst's Vec-of-bus port connects via packed concat from the
+    // per-element parent expressions.
+    // `chans[0] -> w[0]; chans[1] -> w[1];` gathers into `.chans_<sig>({w[1].sig, w[0].sig})`.
+    assert!(sv.contains(".chans_v({w_v[1], w_v[0]})") || sv.contains(".chans_v ({w_v[1], w_v[0]})"),
+            "expected `.chans_v({{w_v[1], w_v[0]}})` packed concat connection in SV:\n{sv}");
+    assert!(sv.contains(".chans_d({w_d[1], w_d[0]})") || sv.contains(".chans_d ({w_d[1], w_d[0]})"),
+            "expected `.chans_d({{w_d[1], w_d[0]}})` packed concat connection in SV:\n{sv}");
+    // Downstream reads use packed indexed access.
+    assert!(sv.contains("o_v0 = w_v[0]"),
+            "expected `o_v0 = w_v[0]` in SV:\n{sv}");
+    assert!(sv.contains("o_d1 = w_d[1]"),
+            "expected `o_d1 = w_d[1]` in SV:\n{sv}");
 }
 
 #[test]
-#[ignore = "D2 rollout: per-element `chans[i] -> scalar_wire_i` requires SV array-literal grouping (`'{w0_v, w1_v}`), not yet emitted. Whole-vec `chans -> vec_wire` works."]
 fn test_vec_of_bus_inst_connection_uses_bracket_index_syntax() {
     // Parent instantiates a Child whose port is `Vec<B, N>`. Each index is
     // connected via the bracket form `chans[i] -> wire;`, matching the
@@ -4583,19 +4583,17 @@ fn test_vec_of_bus_inst_connection_uses_bracket_index_syntax() {
         end module Parent
     ";
     let sv = compile_to_sv(source);
-    // Child exposes one D2 array port per (Vec-of-bus signal).
-    assert!(sv.contains("output logic chans_v [2]"),
-            "child should expose `output logic chans_v [2]`:\n{sv}");
-    assert!(sv.contains("output logic [7:0] chans_d [2]"),
-            "child should expose `output logic [7:0] chans_d [2]`:\n{sv}");
-    // Inst connects each index by its array-indexed parent-side ref.
-    // Parent-side `w0`, `w1` are scalar bus wires, still flat.
-    assert!(sv.contains(".chans_v(w0_v)") || sv.contains(".chans_v (w0_v)")
-            || sv.contains(".chans_v(w0_v[0])"),
-            "expected `.chans_v(w0_v)` (or array) named-port connection in SV:\n{sv}");
-    assert!(sv.contains(".chans_d(w1_d)") || sv.contains(".chans_d (w1_d)")
-            || sv.contains(".chans_d(w1_d[0])"),
-            "expected `.chans_d(w1_d)` named-port connection in SV:\n{sv}");
+    // Child exposes one packed port per Vec-of-bus signal.
+    assert!(sv.contains("output logic [1:0] chans_v"),
+            "child should expose `output logic [1:0] chans_v` (packed):\n{sv}");
+    assert!(sv.contains("output logic [1:0] [7:0] chans_d"),
+            "child should expose `output logic [1:0] [7:0] chans_d`:\n{sv}");
+    // Per-element scalar wire connections gather into a packed concat
+    // at the inst boundary — big-endian, so chans[1] is the MSB.
+    assert!(sv.contains(".chans_v({w1_v, w0_v})") || sv.contains(".chans_v ({w1_v, w0_v})"),
+            "expected `.chans_v({{w1_v, w0_v}})` packed concat connection in SV:\n{sv}");
+    assert!(sv.contains(".chans_d({w1_d, w0_d})") || sv.contains(".chans_d ({w1_d, w0_d})"),
+            "expected `.chans_d({{w1_d, w0_d}})` packed concat connection in SV:\n{sv}");
 }
 
 #[test]


### PR DESCRIPTION
Switches SV-side Vec-of-bus port + wire emission from unpacked `[N]` to packed `[N-1:0]` (or `[N-1:0][W-1:0]` for multi-bit). Native sim codegen stays untouched: V<Module>.h keeps the unpacked C array + reference alias members it had since PR #393, so C++ TBs continue to use `dut.m_ar_valid[0]` syntax — no testbench rewrites needed.

## Why split

Phase 1 (PR #393) chose unpacked `[N]` for SV ports because that gave Verilator-based C++ TBs a clean `dut.m_ar_valid[0]` interface — Verilator emits unpacked arrays as native C arrays, packed multi-dim as a single wide integer (`uint64_t`) needing bit-shift access.

The unpacked choice has been steadily fighting us downstream:
- Yosys's built-in `read_verilog` frontend rejects unpacked-array ports → needed sv2v in the `arch formal` toolchain.
- Inst-site connections at the parent boundary can't be expressed cleanly when the inst's port is unpacked but the parent's wire is per-cell scalars — would need synthesized intermediate-wire arrays (the `indexed_group_conns` template from arbiter port arrays).
- Whole-row binding from a 2D bus wire requires a packed shape on at least one side for SV to slice cleanly.

Packed solves all three. But Phase 1's TB-ergonomics concern is real — and *only* matters for the Verilator-based-TB path. ARCH's native sim already emits its own V<Module>.h independently, and we control what shape it uses there.

**Split:** SV emitter goes packed; native sim emitter stays unpacked. They never share their on-the-wire representation — only the source-level Vec<Bus, N> semantics.

## What the new SV looks like

```sv
// Vec-of-bus port — one decl per bus signal, packed [N-1:0] outer dim
output logic [1:0]       m_ar_valid;
output logic [1:0][31:0] m_ar_addr;

// 2D bus wire — packed [M-1:0][N-1:0] outer dims, one per signal
logic [1:0][1:0][3:0] edges_ar_region;

// Inst connections — direct slice for whole-row,
// SV concat literal for column gather:
Nic400MasterPort__I_0 mp_0 (
  .outs_ar_valid (edges_ar_valid[0])              // row of 2D = packed [N-1:0]
);
Nic400SlavePort__J_1 sp_1 (
  .ins_ar_region({edges_ar_region[1][1],          // column gather
                  edges_ar_region[0][1]})         // (big-endian order)
);
```

## Native sim — unchanged TB syntax

```cpp
// Same as PR #393. Both forms still work via the alias:
dut.m_ar_valid[0] = 1;        // unpacked array access (recommended)
dut.m_0_ar_valid = 1;         // historical flat alias
```

## Tool support (verified on NIC-400 Fabric output)

| Tool | Before (unpacked) | After (packed) |
|---|---|---|
| Verilator `--lint-only` | ✓ | ✓ |
| Yosys built-in `read_verilog -sv` | ✗ rejects unpacked port | ✓ 0 problems |
| sv2v 0.0.13 → Yosys | ✓ (needed) | ✓ (no longer needed) |
| Synthesis (Vivado/Quartus/DC) | mixed | ✓ native shape |
| C++ TB syntax (native sim) | `dut.x[i]` | `dut.x[i]` (unchanged) |

## Compiler changes

- **`src/codegen/module.rs`** — Vec-of-bus port emission: `logic [N-1:0] <port>_<sig>` (or `[N-1:0][W-1:0]`). 1D/2D Vec-of-bus wire emission: same packed shape per bus signal.
- **`src/codegen/mod.rs`** — `emit_expr_str` lowers `chans[i].sig` → `chans_sig[i]` (packed indexed) and `edges[m][n].sig` → `edges_sig[m][n]`. Inst-connection emitter gathers per-element `ins[k] <- expr_k` connections by `(base_port, bus_signal)` and emits SV packed concat `.ins_sig({elem_{N-1}, ..., elem_0})` (big-endian). Whole-vec connections emit one packed-slice connection per bus signal.
- **`src/elaborate.rs`** — thread-wrapper instantiation rewrites sub-port signal `Ident("ins_<i>_<sig>")` → `Index(Ident("ins_<sig>"), <i>)`, matching the packed wrapper port shape.
- **`src/typecheck.rs`** — driver tracker credits per-element flat names when seeing the new `Index(Ident("<vobport>_<sig>"), <i>)` output shape.
- **`src/sim_codegen/mod.rs`** — registers D2 Vec-of-bus port array names in `vec_reg_names` so sim-side indexed access uses C array `[i]` instead of bit-shift.

## Tests

- **457 pass; 0 ignored.** The previously-`#[ignore]`d `test_vec_of_bus_inst_connection_uses_bracket_index_syntax` now passes — packed concat is exactly the SV form it was waiting for.
- 5 existing tests updated to expect packed shape (one decl per bus signal, `[N-1:0]` prefix, indexed reads, concat for column gather).
- NIC-400 Fabric verified end-to-end:
  - `arch sim` smoke: M0→S0, M0→S1, M1→S1 routings + ID-prefix remap + R return ✓
  - `arch sim` latency: AR=0 cyc, R=0 cyc, 9/9 throughput ✓
  - `arch build` → Verilator lint clean ✓
  - `arch build` → Yosys `read_verilog -sv` 0 problems ✓