### PR TITLE
inst: nested for-loop unrolls connections at elaboration

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -816,7 +816,30 @@ pub struct InstDecl {
     pub module_name: Ident,
     pub param_assigns: Vec<ParamAssign>,
     pub connections: Vec<Connection>,
+    /// `for k in 0..N-1 ... end for` blocks inside the inst body whose
+    /// body is a list of connections. Each loop unrolls at elaboration
+    /// into N flat `Connection`s appended to `connections`. After
+    /// `flatten_inst_for_loops` runs, this is empty and downstream
+    /// passes see only `connections`.
+    pub for_loops: Vec<InstForLoop>,
     pub span: Span,
+}
+
+/// `for VAR in START..END  body  end for` inside an inst body.
+/// Body items are either direct connections or nested for-loops.
+#[derive(Debug, Clone)]
+pub struct InstForLoop {
+    pub var: Ident,
+    pub start: Expr,
+    pub end: Expr,
+    pub body: Vec<InstBodyItem>,
+    pub span: Span,
+}
+
+#[derive(Debug, Clone)]
+pub enum InstBodyItem {
+    Connection(Connection),
+    For(InstForLoop),
 }
 
 #[derive(Debug, Clone)]

--- a/src/elaborate.rs
+++ b/src/elaborate.rs
@@ -322,8 +322,30 @@ fn elaborate_module_variant(
         return Err(errors);
     }
 
+    // Flatten any `for` loops inside inst bodies. The loop is a parse-time
+    // wiring macro — its body is a list of Connections that gets unrolled
+    // here, with the loop var substituted into each Connection's signal
+    // expression and port_name suffix. After this pass every inst has
+    // `for_loops` empty and all wiring lives in `connections`, so downstream
+    // passes see the same shape as a hand-enumerated inst.
+    let mut flattened: Vec<ModuleBodyItem> = Vec::with_capacity(pre_rewrite.len());
+    for item in pre_rewrite {
+        match item {
+            ModuleBodyItem::Inst(inst) => {
+                match flatten_inst_for_loops(inst, &param_vals) {
+                    Ok(inst) => flattened.push(ModuleBodyItem::Inst(inst)),
+                    Err(mut errs) => errors.append(&mut errs),
+                }
+            }
+            other => flattened.push(other),
+        }
+    }
+    if !errors.is_empty() {
+        return Err(errors);
+    }
+
     // Rewrite inst module-names → variant names
-    let new_body = pre_rewrite
+    let new_body = flattened
         .into_iter()
         .map(|item| match item {
             ModuleBodyItem::Inst(inst) => {
@@ -1065,6 +1087,86 @@ fn subst_port(p: &PortDecl, var: &str, val: i64) -> PortDecl {
     }
 }
 
+/// Unroll any `for VAR in S..E ... end for` blocks inside `inst.for_loops`
+/// into flat `Connection`s appended to `inst.connections`. Loop ranges may
+/// reference the enclosing module's params (passed via `param_vals`). After
+/// this pass `for_loops` is empty.
+///
+/// Substitution semantics match the rest of the elaborator: bare-ident
+/// matches of the loop variable become literals, and `signal_VAR` →
+/// `signal_<val>` suffix rewrites also happen — same as `subst_expr_names`.
+/// This means a hand-enumerated form and the loop-unrolled form produce
+/// byte-identical `InstDecl.connections` lists.
+pub(crate) fn flatten_inst_for_loops(
+    mut inst: InstDecl,
+    param_vals: &HashMap<String, i64>,
+) -> Result<InstDecl, Vec<CompileError>> {
+    if inst.for_loops.is_empty() {
+        return Ok(inst);
+    }
+    let loops = std::mem::take(&mut inst.for_loops);
+    let mut errors: Vec<CompileError> = Vec::new();
+    for fl in loops {
+        match unroll_inst_for_loop(&fl, param_vals) {
+            Ok(conns) => inst.connections.extend(conns),
+            Err(mut errs) => errors.append(&mut errs),
+        }
+    }
+    if errors.is_empty() {
+        Ok(inst)
+    } else {
+        Err(errors)
+    }
+}
+
+fn unroll_inst_for_loop(
+    fl: &InstForLoop,
+    param_vals: &HashMap<String, i64>,
+) -> Result<Vec<Connection>, Vec<CompileError>> {
+    let start = try_eval_i64(&fl.start, param_vals).ok_or_else(|| {
+        vec![CompileError::general(
+            "inst body `for`: start expression must be a compile-time constant",
+            fl.start.span,
+        )]
+    })?;
+    let end = try_eval_i64(&fl.end, param_vals).ok_or_else(|| {
+        vec![CompileError::general(
+            "inst body `for`: end expression must be a compile-time constant",
+            fl.end.span,
+        )]
+    })?;
+    if end < start {
+        return Ok(Vec::new());
+    }
+    let var = &fl.var.name;
+    let mut out: Vec<Connection> = Vec::new();
+    for i in start..=end {
+        for item in &fl.body {
+            match item {
+                InstBodyItem::Connection(c) => {
+                    out.push(Connection {
+                        port_name: subst_ident(&c.port_name, var, i),
+                        direction: c.direction,
+                        signal: subst_expr_names(c.signal.clone(), var, i),
+                        reset_override: c.reset_override,
+                        span: c.span,
+                    });
+                }
+                InstBodyItem::For(inner) => {
+                    // Recurse with the outer loop var substituted into the
+                    // inner range/body, then evaluate the inner loop in the
+                    // same param scope (loop vars don't pollute param_vals;
+                    // they're applied via subst).
+                    let inner_subst = subst_inst_for_loop(inner, var, i);
+                    let mut inner_conns = unroll_inst_for_loop(&inner_subst, param_vals)?;
+                    out.append(&mut inner_conns);
+                }
+            }
+        }
+    }
+    Ok(out)
+}
+
 fn subst_inst(inst: &InstDecl, var: &str, val: i64) -> InstDecl {
     InstDecl {
         name: subst_ident(&inst.name, var, val),
@@ -1096,7 +1198,47 @@ fn subst_inst(inst: &InstDecl, var: &str, val: i64) -> InstDecl {
                 span: c.span,
             })
             .collect(),
+        // Inst-body for-loops may also reference the outer loop var in their
+        // range bounds or body. Substitute through them so that
+        // `flatten_inst_for_loops` later sees a fully-resolved-w.r.t.-outer-vars
+        // form. The inner loop var itself is *not* substituted (it shadows).
+        for_loops: inst
+            .for_loops
+            .iter()
+            .map(|fl| subst_inst_for_loop(fl, var, val))
+            .collect(),
         span: inst.span,
+    }
+}
+
+/// Substitute an outer loop var into an inst-body for-loop's range bounds
+/// and body. If the inner loop's variable shadows the outer name, the body
+/// is left untouched (the inner binding wins).
+fn subst_inst_for_loop(fl: &InstForLoop, var: &str, val: i64) -> InstForLoop {
+    let shadowed = fl.var.name == var;
+    InstForLoop {
+        var: fl.var.clone(),
+        start: subst_expr_names(fl.start.clone(), var, val),
+        end:   subst_expr_names(fl.end.clone(),   var, val),
+        body: if shadowed {
+            fl.body.clone()
+        } else {
+            fl.body.iter().map(|it| subst_inst_body_item(it, var, val)).collect()
+        },
+        span: fl.span,
+    }
+}
+
+fn subst_inst_body_item(it: &InstBodyItem, var: &str, val: i64) -> InstBodyItem {
+    match it {
+        InstBodyItem::Connection(c) => InstBodyItem::Connection(Connection {
+            port_name: subst_ident(&c.port_name, var, val),
+            direction: c.direction,
+            signal: subst_expr_names(c.signal.clone(), var, val),
+            reset_override: c.reset_override,
+            span: c.span,
+        }),
+        InstBodyItem::For(inner) => InstBodyItem::For(subst_inst_for_loop(inner, var, val)),
     }
 }
 
@@ -2114,6 +2256,7 @@ fn lower_module_threads(
                     reset_override: None, span: sp,
                 },
             ],
+            for_loops: Vec::new(),
             span: sp,
         }));
     }
@@ -2904,7 +3047,9 @@ fn lower_module_threads(
         name: Ident::new("_threads".to_string(), sp),
         module_name: Ident::new(merged_name, sp),
         param_assigns: Vec::new(),
-        connections, span: sp,
+        connections,
+        for_loops: Vec::new(),
+        span: sp,
     };
     new_body.push(ModuleBodyItem::Inst(inst));
 
@@ -9681,6 +9826,7 @@ fn lower_indexed_tlm_target_group(
                 span,
             },
         ],
+        for_loops: Vec::new(),
         span,
     }));
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3037,8 +3037,13 @@ impl Parser {
 
         let mut param_assigns = Vec::new();
         let mut connections = Vec::new();
+        let mut for_loops = Vec::new();
 
         while !self.check_end_inst() {
+            if self.check(TokenKind::For) {
+                for_loops.push(self.parse_inst_for_loop()?);
+                continue;
+            }
             if self.check_param() {
                 self.advance();
                 let pname = self.expect_ident()?;
@@ -3181,6 +3186,110 @@ impl Parser {
             module_name,
             param_assigns,
             connections,
+            for_loops,
+        })
+    }
+
+    /// Parse a single connection statement (e.g. `port <- signal;`).
+    /// Used inside inst body for-loops.
+    fn parse_inst_connection(&mut self) -> Result<Connection, CompileError> {
+        let cstart = self.peek_span();
+        let mut port_name = self.expect_ident()?;
+        if self.eat(TokenKind::LBracket) {
+            // Inside an inst-body for-loop, the index can be either a literal
+            // (e.g. `ins[0]`) or an identifier referring to the loop variable
+            // (e.g. `ins[k]`). After elaboration substitution the ident becomes
+            // a literal, so we accept either at parse time.
+            let idx_tok = self.advance();
+            let idx_str = match &idx_tok.kind {
+                TokenKind::DecLiteral(s) => s.clone(),
+                TokenKind::Ident(s) => s.clone(),
+                _ => return Err(CompileError::unexpected_token(
+                    "integer index or loop variable",
+                    &idx_tok.kind.to_string(),
+                    idx_tok.span,
+                )),
+            };
+            self.expect(TokenKind::RBracket)?;
+            if self.eat(TokenKind::Dot) {
+                let member = self.expect_ident()?;
+                port_name = Ident::new(
+                    format!("{}{idx_str}_{}", port_name.name, member.name),
+                    port_name.span.merge(member.span),
+                );
+            } else {
+                let end_span = idx_tok.span;
+                port_name = Ident::new(
+                    format!("{}_{}", port_name.name, idx_str),
+                    port_name.span.merge(end_span),
+                );
+            }
+        } else if self.eat(TokenKind::Dot) {
+            let member = self.expect_ident()?;
+            port_name = Ident::new(
+                format!("{}_{}", port_name.name, member.name),
+                port_name.span.merge(member.span),
+            );
+        }
+        let direction = if self.eat(TokenKind::LArrow) {
+            ConnectDir::Input
+        } else if self.eat(TokenKind::RArrow) {
+            ConnectDir::Output
+        } else {
+            return Err(CompileError::unexpected_token(
+                "<- or ->",
+                &self.peek_kind().map(|k| k.to_string()).unwrap_or("EOF".into()),
+                self.peek_span(),
+            ));
+        };
+        let signal = self.parse_expr()?;
+        self.expect(TokenKind::Semi)?;
+        let end_span = self.tokens.get(self.pos.saturating_sub(1)).map(|t| t.span).unwrap_or(cstart);
+        Ok(Connection {
+            port_name,
+            direction,
+            signal,
+            reset_override: None,
+            span: cstart.merge(end_span),
+        })
+    }
+
+    /// Parse a `for VAR in START..END  body  end for` block whose body
+    /// consists of inst connection statements (possibly with nested
+    /// for-loops). Used inside `parse_inst`.
+    fn parse_inst_for_loop(&mut self) -> Result<InstForLoop, CompileError> {
+        let start_tok = self.expect(TokenKind::For)?.span;
+        let var = self.expect_ident()?;
+        self.expect_contextual("in")?;
+        let range_start = self.parse_expr()?;
+        self.expect(TokenKind::DotDot)?;
+        let range_end = self.parse_expr()?;
+
+        let mut body = Vec::new();
+        while !(self.check(TokenKind::End)
+            && self.pos + 1 < self.tokens.len()
+            && self.tokens[self.pos + 1].kind == TokenKind::For)
+        {
+            if self.check(TokenKind::For) {
+                body.push(InstBodyItem::For(self.parse_inst_for_loop()?));
+            } else if matches!(self.peek_kind(), Some(TokenKind::Ident(_))) {
+                body.push(InstBodyItem::Connection(self.parse_inst_connection()?));
+            } else {
+                return Err(CompileError::unexpected_token(
+                    "port connection or nested `for`",
+                    &self.peek_kind().map(|k| k.to_string()).unwrap_or("EOF".into()),
+                    self.peek_span(),
+                ));
+            }
+        }
+        self.expect(TokenKind::End)?;
+        let end_span = self.expect(TokenKind::For)?.span;
+        Ok(InstForLoop {
+            var,
+            start: range_start,
+            end: range_end,
+            body,
+            span: start_tok.merge(end_span),
         })
     }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -15908,3 +15908,153 @@ fn test_sim_function_uses_package_param() {
         "expected PASS marker in stdout:\n{}",
         String::from_utf8_lossy(&out.stdout));
 }
+
+#[test]
+fn test_inst_for_loop_unrolls_connections() {
+    // A `for k in 0..N-1 ... end for` block inside an inst body unrolls at
+    // elaboration into N flat `Connection`s — AST-identical to the hand-
+    // enumerated form, so the generated SV must contain the per-index
+    // named-port connections produced by the loop body. This is the core
+    // NIC-400 Fabric use case: scaling a master/slave dimension without
+    // hand-enumerating connections.
+    let source = "
+        bus B
+          v: out Bool;
+          d: out UInt<8>;
+        end bus B
+
+        module Producer
+          port clk: in Clock<SysDomain>;
+          port chans: initiator Vec<B, 2>;
+          comb
+            chans[0].v = true;  chans[0].d = 8'hAA;
+            chans[1].v = true;  chans[1].d = 8'h55;
+          end comb
+        end module Producer
+
+        module Parent
+          port clk: in Clock<SysDomain>;
+          port o0: out Bool;
+          port o1: out Bool;
+          wire w_0: B;
+          wire w_1: B;
+          inst p: Producer
+            clk <- clk;
+            for k in 0..1
+              chans[k] -> w_k;
+            end for
+          end inst p
+          comb
+            o0 = w_0.v;
+            o1 = w_1.v;
+          end comb
+        end module Parent
+    ";
+    let sv = compile_to_sv(source);
+    // The for-loop body `chans[k] -> w_k;` unrolls to:
+    //   chans[0] -> w_0;   chans[1] -> w_1;
+    // which gathers into the packed-concat form at the inst boundary
+    // (big-endian, so chans[1] is the MSB).
+    assert!(sv.contains(".chans_v({w_1_v, w_0_v})") || sv.contains(".chans_v ({w_1_v, w_0_v})"),
+            "expected `.chans_v({{w_1_v, w_0_v}})` packed concat from unrolled inst-for-loop in SV:\n{sv}");
+    assert!(sv.contains(".chans_d({w_1_d, w_0_d})") || sv.contains(".chans_d ({w_1_d, w_0_d})"),
+            "expected `.chans_d({{w_1_d, w_0_d}})` packed concat in SV:\n{sv}");
+}
+
+#[test]
+fn test_inst_for_loop_matches_hand_enumerated_form() {
+    // The contract of inst-body `for k in 0..N-1` unroll is: the resulting
+    // AST must be byte-identical to the hand-enumerated form. We compile
+    // both shapes and compare the emitted SV directly. Exercises:
+    //   - 2-D bus wire (`Vec<Vec<B, NS>, NM>`) — the NIC-400 Fabric shape.
+    //   - Outer `generate_for j` substitution flowing into the inst-body
+    //     for-loop's body expressions (`edges[k][j]`).
+    //   - Range bound `0..NM-1` that references an enclosing param.
+    let bus_and_slave = "
+        bus B
+          v: out Bool;
+          d: out UInt<8>;
+        end bus B
+
+        module Slave
+          param J: const = 0;
+          param NMC: const = 2;
+          port clk: in Clock<SysDomain>;
+          port ins: target Vec<B, NMC>;
+          port o_v: out Bool;
+          comb
+            o_v = ins[0].v;
+          end comb
+        end module Slave
+    ";
+
+    let fabric_handw = format!("{bus_and_slave}
+        module Fabric
+          param NM: const = 2;
+          param NS: const = 2;
+          port clk: in Clock<SysDomain>;
+          port o_0: out Bool;
+          port o_1: out Bool;
+          wire edges: Vec<Vec<B, NS>, NM>;
+          comb
+            edges[0][0].v = true;  edges[0][0].d = 8'h22;
+            edges[0][1].v = true;  edges[0][1].d = 8'h33;
+            edges[1][0].v = true;  edges[1][0].d = 8'h44;
+            edges[1][1].v = true;  edges[1][1].d = 8'h55;
+          end comb
+          generate_for j in 0..NS-1
+            inst sp_j: Slave
+              param J = j;
+              param NMC = NM;
+              clk <- clk;
+              o_v -> o_j;
+              ins[0] <- edges[0][j];
+              ins[1] <- edges[1][j];
+            end inst sp_j
+          end generate_for
+        end module Fabric
+    ");
+
+    let fabric_loop = format!("{bus_and_slave}
+        module Fabric
+          param NM: const = 2;
+          param NS: const = 2;
+          port clk: in Clock<SysDomain>;
+          port o_0: out Bool;
+          port o_1: out Bool;
+          wire edges: Vec<Vec<B, NS>, NM>;
+          comb
+            edges[0][0].v = true;  edges[0][0].d = 8'h22;
+            edges[0][1].v = true;  edges[0][1].d = 8'h33;
+            edges[1][0].v = true;  edges[1][0].d = 8'h44;
+            edges[1][1].v = true;  edges[1][1].d = 8'h55;
+          end comb
+          generate_for j in 0..NS-1
+            inst sp_j: Slave
+              param J = j;
+              param NMC = NM;
+              clk <- clk;
+              o_v -> o_j;
+              for k in 0..NM-1
+                ins[k] <- edges[k][j];
+              end for
+            end inst sp_j
+          end generate_for
+        end module Fabric
+    ");
+
+    let sv_handw = compile_to_sv(&fabric_handw);
+    let sv_loop  = compile_to_sv(&fabric_loop);
+    assert_eq!(sv_handw, sv_loop,
+        "inst-body for-loop must produce byte-identical SV to the \
+         hand-enumerated form. Diff:\n\
+         === hand-enumerated ===\n{sv_handw}\n\
+         === loop-unrolled ===\n{sv_loop}");
+
+    // Sanity: the SV actually contains the expected per-index connections
+    // (so this isn't just `equal-but-empty`).
+    assert!(sv_loop.contains("sp_0") && sv_loop.contains("sp_1"),
+            "expected sp_0 and sp_1 instances in SV:\n{sv_loop}");
+    assert!(sv_loop.contains("edges[0][0]") && sv_loop.contains("edges[1][1]"),
+            "expected per-index edges refs in SV:\n{sv_loop}");
+}

--- a/tests/nic400/Nic400Fabric.arch
+++ b/tests/nic400/Nic400Fabric.arch
@@ -43,14 +43,19 @@ module Nic400Fabric
 
   // ── N SlavePort instances ─────────────────────────────────────────────
   // Each slave_j gathers element [j] from every master's row of edges.
+  // The inner `for k in 0..NUM_MASTERS-1` is an inst-body unroll macro:
+  // at elaboration each iteration produces one `ins[k] <- edges[k][j]`
+  // Connection (AST-identical to the hand-enumerated form). Scales to
+  // arbitrary M without source changes.
   generate_for j in 0..NUM_SLAVES-1
     inst sp_j: Nic400SlavePort
       param J = j;
       clk <- clk;
       rst <- rst;
       s   -> s[j];
-      ins[0] <- edges[0][j];
-      ins[1] <- edges[1][j];
+      for k in 0..NUM_MASTERS-1
+        ins[k] <- edges[k][j];
+      end for
     end inst sp_j
   end generate_for
 end module Nic400Fabric


### PR DESCRIPTION
## Motivation

The recent NIC-400 Fabric work (PRs #392–#395) scaled the master and slave dimensions via module-level `generate_for`, but the slave inst still had to hand-enumerate the M masters:

```arch
generate_for j in 0..NUM_SLAVES-1
  inst sp_j: Nic400SlavePort
    param J = j;
    clk <- clk;
    rst <- rst;
    s   -> s[j];
    ins[0] <- edges[0][j];   // ← hand-enumerated
    ins[1] <- edges[1][j];   // ← breaks for M > 2
  end inst sp_j
end generate_for
```

This PR adds the missing piece: a `for` macro inside the inst body.

```arch
generate_for j in 0..NUM_SLAVES-1
  inst sp_j: Nic400SlavePort
    param J = j;
    clk <- clk;
    rst <- rst;
    s   -> s[j];
    for k in 0..NUM_MASTERS-1
      ins[k] <- edges[k][j];
    end for
  end inst sp_j
end generate_for
```

Scales to arbitrary `NUM_MASTERS` × `NUM_SLAVES` with no source changes.

## Syntax chosen

`for VAR in S..E ... end for` — matches the existing static-unroll `for` already used inside `comb` and `seq` blocks. Semantics are the same: "statically expand this body N times, substituting VAR into the body expressions." Reusing `for` (instead of introducing `generate_for` here) keeps the keyword count low and the meaning consistent across contexts.

## Implementation

- **AST** (`src/ast.rs`): new `InstForLoop` struct and `InstBodyItem` enum (`Connection | For`). `InstDecl` gains a `for_loops: Vec<InstForLoop>` field; after elaboration this is always empty.
- **Parser** (`src/parser.rs`): `parse_inst` peeks for `for` and dispatches to `parse_inst_for_loop`. Index expressions in the loop body may be literals (`ins[0]`) or identifiers (`ins[k]`); the parser reuses the existing flatten-on-suffix convention so `ins[k]` becomes port_name `ins_k` and the substitution turns it into `ins_0`, `ins_1`, …
- **Elaboration** (`src/elaborate.rs`): `flatten_inst_for_loops` runs right after generate-block expansion in `elaborate_module_variant`, where the module's `param_vals` are fully known. Range bounds may reference enclosing params (`0..NUM_MASTERS-1`). Uses the existing `subst_expr_names` / `subst_ident` substitution machinery — same semantics as comb/seq for-loops, so the loop-unrolled source produces byte-identical AST (and hence byte-identical SV/sim) to the hand-enumerated source. `subst_inst` recurses into `for_loops` so outer `generate_for` loop vars get substituted through the inner-loop body before flatten runs. Inner-loop var shadowing is honored. Nested inst-body for-loops are supported.

The 34 downstream callsites that walk `inst.connections` are untouched — they see the same `Vec<Connection>` after flatten as they would for a hand-enumerated inst.

## NIC-400 refactor

`tests/nic400/Nic400Fabric.arch` slave-side `inst sp_j` now uses the for-loop form. Verified:

- Generated SV is byte-identical to the prior hand-enumerated output (modulo a pre-existing `_*_lock_req_*` default-init ordering non-determinism that reproduces on plain `main` across two runs).
- NIC-400 fabric latency TB still reports `AR=0 cyc, R=0 cyc, AR throughput 9/9 cyc`.

## Tests

- `cargo test --release`: **459 passed** (was 457; +2 new). All formal tests pass.
- `test_inst_for_loop_unrolls_connections`: minimal Vec-of-bus inst, asserts the unrolled packed-concat shape `.chans_v({w_1_v, w_0_v})`.
- `test_inst_for_loop_matches_hand_enumerated_form`: 2-D bus wire (`Vec<Vec<B,NS>,NM>`) inside a `generate_for j` parent. Compiles both the hand-enumerated form and the loop form, asserts emitted SV is byte-for-byte identical.

## Out of scope

This PR does **not** address a pre-existing infinite recursion that triggers when an inst passes `param X = X` to a child with a like-named param. That bug reproduces on `main` and is unrelated; the safe workaround (used by NIC-400 and now by the new tests) is to use distinct names. Worth filing a separate issue.

## Test plan

- [x] `cargo test --release` — 459 tests pass
- [x] `cargo test --release --test formal_test` — 20 tests pass
- [x] NIC-400 Fabric latency TB — perf unchanged (AR=0, R=0, 9/9 throughput)
- [x] NIC-400 Fabric SV diff vs main — byte-identical except added comment + pre-existing non-deterministic ordering