### PR TITLE
nic400 Fabric: use type alias for parameterized BusAxi4 shapes

### DIFF
--- a/tests/nic400/Nic400Fabric.arch
+++ b/tests/nic400/Nic400Fabric.arch
@@ -19,16 +19,26 @@ module Nic400Fabric
   port clk: in Clock<SysDomain>;
   port rst: in Reset<Async, Low>;
 
-  // System-facing master buses (one per master, parent perspective is target).
-  port m: target Vec<BusAxi4<ADDR_W=ADDR_WIDTH, DATA_W=DATA_WIDTH,
-                              ID_W=MASTER_ID_W, READ=1, WRITE=0>, NUM_MASTERS>;
-  // System-facing slave buses.
-  port s: initiator Vec<BusAxi4<ADDR_W=ADDR_WIDTH, DATA_W=DATA_WIDTH,
-                                  ID_W=SLAVE_ID_W, READ=1, WRITE=0>, NUM_SLAVES>;
+  // Two parameterized bus shapes — fully spelled out at top-level so the
+  // deeply-nested `Vec<Vec<BusAxi4<...>, N>, M>` form doesn't fight the
+  // grammar at use sites. Every port and wire below references the alias
+  // as a bare identifier; the alias resolver inlines the full type before
+  // any downstream pass sees it. Master-side IDs are MASTER_ID_W wide;
+  // slave-side IDs are SLAVE_ID_W = MASTER_ID_W + ceil(log2(NUM_MASTERS))
+  // wide, since the MasterPort prepends the master_idx prefix.
+  type MasterBus = BusAxi4<ADDR_W=ADDR_WIDTH, DATA_W=DATA_WIDTH,
+                            ID_W=MASTER_ID_W, READ=1, WRITE=0>;
+  type SlaveBus  = BusAxi4<ADDR_W=ADDR_WIDTH, DATA_W=DATA_WIDTH,
+                            ID_W=SLAVE_ID_W,  READ=1, WRITE=0>;
 
-  // 2D bus wire: edges[i][j] is the master_i ↔ slave_j edge bus.
-  // M × N = total edges.
-  wire edges: Vec<Vec<BusAxi4, NUM_SLAVES>, NUM_MASTERS>;
+  // System-facing master buses (parent perspective is target).
+  port m: target Vec<MasterBus, NUM_MASTERS>;
+  // System-facing slave buses.
+  port s: initiator Vec<SlaveBus, NUM_SLAVES>;
+
+  // 2D bus wire: edges[i][j] is the master_i ↔ slave_j edge bus, already
+  // carrying the prefixed (slave-perspective) ID.
+  wire edges: Vec<Vec<SlaveBus, NUM_SLAVES>, NUM_MASTERS>;
 
   // ── M MasterPort instances ────────────────────────────────────────────
   generate_for i in 0..NUM_MASTERS-1


### PR DESCRIPTION
Replaces the three inline `BusAxi4<ADDR_W=..., DATA_W=..., ID_W=..., ...>` spellings in `Nic400Fabric.arch` with two named aliases declared at the top of the module — using the `type Name = <TypeExpr>;` feature from PR #400.

## Before

\`\`\`arch
// Master port — full bus parameterization inline
port m: target Vec<BusAxi4<ADDR_W=ADDR_WIDTH, DATA_W=DATA_WIDTH,
                            ID_W=MASTER_ID_W, READ=1, WRITE=0>, NUM_MASTERS>;
// Slave port — same shape repeated with different ID_W
port s: initiator Vec<BusAxi4<ADDR_W=ADDR_WIDTH, DATA_W=DATA_WIDTH,
                                ID_W=SLAVE_ID_W, READ=1, WRITE=0>, NUM_SLAVES>;
// 2D bus wire — couldn't carry inner bus params at all (parser limitation
// with deeply-nested <>), so relied on BusAxi4 defaults matching SLAVE_ID_W
wire edges: Vec<Vec<BusAxi4, NUM_SLAVES>, NUM_MASTERS>;
\`\`\`

## After

\`\`\`arch
// Two parameterized bus shapes — fully spelled out at top-level so the
// deeply-nested Vec<Vec<BusAxi4<...>, N>, M> form doesn't fight the
// grammar at use sites.
type MasterBus = BusAxi4<ADDR_W=ADDR_WIDTH, DATA_W=DATA_WIDTH,
                          ID_W=MASTER_ID_W, READ=1, WRITE=0>;
type SlaveBus  = BusAxi4<ADDR_W=ADDR_WIDTH, DATA_W=DATA_WIDTH,
                          ID_W=SLAVE_ID_W,  READ=1, WRITE=0>;

port m: target    Vec<MasterBus, NUM_MASTERS>;
port s: initiator Vec<SlaveBus,  NUM_SLAVES>;

// 2D bus wire now explicitly carries SlaveBus (slave-perspective ID
// width, since MasterPort prepends the master_idx prefix before driving
// outs[]) — no more reliance on bus-default matching.
wire edges: Vec<Vec<SlaveBus, NUM_SLAVES>, NUM_MASTERS>;
\`\`\`

## Why this is a win

1. **Single source for each bus shape.** Changing `ADDR_WIDTH` or any other parameter now only requires updating the alias, not three inline spellings.
2. **Removes the implicit defaults reliance** on the `edges` wire. Previously the wire compiled because `BusAxi4`'s default `ID_W` happened to match `SLAVE_ID_W`; now the intent is explicit.
3. **Demonstrates the type-alias feature end-to-end** on a real design (NIC-400 was the original motivation for PR #400).

## Verification

- All 465 unit tests pass; 0 ignored.
- `arch sim` smoke: M0→S0, M0→S1, M1→S1 routings + ID-prefix remap + R return ✓
- `arch sim` latency: AR=0 cyc, R=0 cyc, AR throughput 9/9 cyc ✓ (unchanged from pre-refactor)