### PR TITLE
elaborate: fix silent variant-discovery miscompile under generate_if

### DIFF
--- a/src/elaborate.rs
+++ b/src/elaborate.rs
@@ -128,7 +128,7 @@ fn collect_raw_overrides_from_body(
 ) {
     for item in body {
         match item {
-            ModuleBodyItem::Inst(inst) => record_inst(inst, out),
+            ModuleBodyItem::Inst(inst) => record_inst(inst, out, enclosing_params),
             ModuleBodyItem::Generate(gen) => match gen {
                 // `generate_for i in start..end { inst foo: M; param P = i; ... }`:
                 // each unrolled iteration produces a specialized variant; we must
@@ -145,20 +145,29 @@ fn collect_raw_overrides_from_body(
                             if let (Some(s), Some(e)) = (start, end) {
                                 for v in s..=e {
                                     let inst_subst = subst_inst(inst, var_name, v);
-                                    record_inst(&inst_subst, out);
+                                    record_inst(&inst_subst, out, enclosing_params);
                                 }
                             } else {
                                 // Non-literal range — record once with the loop var
                                 // unresolved (matches pre-unroll behavior).
-                                record_inst(inst, out);
+                                record_inst(inst, out, enclosing_params);
                             }
                         }
                     }
                 }
+                // `generate_if cond { inst f: M; param I = SOMETHING; }`:
+                // walk BOTH branches conservatively (over-recording produces
+                // extra variants that compute_all_variants simply emits and
+                // doesn't hurt correctness). The important fix: record_inst
+                // must see the enclosing module's params so a param value
+                // like `param I = NUM_FOO - 1` evaluates correctly — without
+                // this, every iteration's inst silently lands on the
+                // default-param variant. Same shape as the generate_for fix
+                // earlier in this function.
                 GenerateDecl::If(gi) => {
                     for it in gi.then_items.iter().chain(gi.else_items.iter()) {
                         if let GenItem::Inst(inst) = it {
-                            record_inst(inst, out);
+                            record_inst(inst, out, enclosing_params);
                         }
                     }
                 }
@@ -169,10 +178,20 @@ fn collect_raw_overrides_from_body(
     }
 }
 
-fn record_inst(inst: &InstDecl, out: &mut HashMap<String, Vec<HashMap<String, i64>>>) {
+fn record_inst(
+    inst: &InstDecl,
+    out: &mut HashMap<String, Vec<HashMap<String, i64>>>,
+    enclosing_params: &HashMap<String, i64>,
+) {
     let mut overrides = HashMap::new();
     for pa in &inst.param_assigns {
-        if let Some(v) = try_eval_i64(&pa.value, &HashMap::new()) {
+        // Evaluate the inst's param value against the enclosing module's
+        // param map. Without these, a param value like `param I = NUM_FOO`
+        // that references a module param can't resolve at variant-discovery
+        // time, and every inst silently lands on the default-param variant
+        // (the bug the PR-394 fix and this audit address — same shape for
+        // both generate_for and generate_if cases).
+        if let Some(v) = try_eval_i64(&pa.value, enclosing_params) {
             overrides.insert(pa.name.name.clone(), v);
         }
     }
@@ -355,7 +374,7 @@ fn elaborate_module_variant(
         .into_iter()
         .map(|item| match item {
             ModuleBodyItem::Inst(inst) => {
-                ModuleBodyItem::Inst(rewrite_inst(inst, module_variants, module_defaults))
+                ModuleBodyItem::Inst(rewrite_inst(inst, module_variants, module_defaults, &param_vals))
             }
             other => other,
         })
@@ -435,20 +454,25 @@ fn rewrite_inst(
     inst: InstDecl,
     module_variants: &HashMap<String, Vec<(HashMap<String, i64>, String)>>,
     module_defaults: &HashMap<String, HashMap<String, i64>>,
+    enclosing_params: &HashMap<String, i64>,
 ) -> InstDecl {
     let variants = match module_variants.get(&inst.module_name.name) {
         Some(v) if v.len() > 1 => v,
         _ => return inst, // single variant → name unchanged
     };
 
-    // Compute effective params for this inst (regular + reset-override synthetic params)
+    // Compute effective params for this inst (regular + reset-override synthetic params).
+    // Param values must evaluate against the enclosing module's params so an
+    // expression like `param I = NUM_FOO - 1` resolves to a literal that
+    // matches one of the discovered variants. Same shape as the
+    // record_inst fix.
     let defaults = module_defaults
         .get(&inst.module_name.name)
         .cloned()
         .unwrap_or_default();
     let mut effective = defaults;
     for pa in &inst.param_assigns {
-        if let Some(v) = try_eval_i64(&pa.value, &HashMap::new()) {
+        if let Some(v) = try_eval_i64(&pa.value, enclosing_params) {
             effective.insert(pa.name.name.clone(), v);
         }
     }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -16303,3 +16303,112 @@ fn test_generate_for_wire_param_size() {
     assert!(sv.contains("logic [W-1:0] bus_1;") || sv.contains("logic [15:0] bus_1;"),
             "missing `logic [W-1:0] bus_1;` (param-driven width wire):\n{sv}");
 }
+
+#[test]
+fn test_generate_if_variant_discovery_with_param_expr() {
+    // Regression: when `generate_if` contains an inst whose param value
+    // references the enclosing module's params (rather than a literal),
+    // variant discovery must evaluate the value against those params.
+    // Before the fix, every inst in a `generate_if` silently landed on
+    // the default-param variant — a silent miscompile.
+    //
+    // This source sets `param I = TEN` and `param I = TWENTY` on two
+    // Inner insts via different `generate_if 1` blocks. Each should
+    // produce its own specialized VInner__I_10 / VInner__I_20 in the
+    // native sim. Behavior check: out0 = idx + 10, out1 = idx + 20.
+    let source = "
+        module Inner
+          param I: const = 8;
+          port idx: in  UInt<8>;
+          port out: out UInt<8>;
+          let pad: UInt<8> = I.zext<8>();
+          comb
+            out = idx +% pad;
+          end comb
+        end module Inner
+
+        module Top
+          param TEN: const = 10;
+          param TWENTY: const = 20;
+          port idx: in UInt<8>;
+          port out0: out UInt<8>;
+          port out1: out UInt<8>;
+          generate_if 1
+            inst inner_a: Inner
+              param I = TEN;
+              idx <- idx;
+              out -> out0;
+            end inst inner_a
+          end generate_if
+          generate_if 1
+            inst inner_b: Inner
+              param I = TWENTY;
+              idx <- idx;
+              out -> out1;
+            end inst inner_b
+          end generate_if
+        end module Top
+    ";
+    let sv = compile_to_sv(source);
+    // Two specialized variants must be emitted, one per distinct
+    // `param I = <expr>` value resolved against enclosing module params.
+    assert!(sv.contains("module Inner__I_10"),
+            "missing `Inner__I_10` specialized variant — variant discovery \
+             didn't resolve `param I = TEN` against enclosing module's params:\n{sv}");
+    assert!(sv.contains("module Inner__I_20"),
+            "missing `Inner__I_20` specialized variant — variant discovery \
+             didn't resolve `param I = TWENTY` against enclosing module's params:\n{sv}");
+    // Inst sites should reference the specialized variant by name.
+    assert!(sv.contains("Inner__I_10 inner_a")
+            || sv.contains("Inner__I_10 #") && sv.contains("inner_a"),
+            "expected sp_0 to reference Inner__I_10 variant:\n{sv}");
+    assert!(sv.contains("Inner__I_20 inner_b")
+            || sv.contains("Inner__I_20 #") && sv.contains("inner_b"),
+            "expected sp_1 to reference Inner__I_20 variant:\n{sv}");
+}
+
+#[test]
+fn test_generate_if_variant_discovery_with_default_branch_values() {
+    // Even when both then- and else-branches of `generate_if` contain
+    // insts with module-param-referencing values, variant discovery
+    // walks both conservatively and records each. Over-recording is
+    // benign — extra unused variants are deduped at codegen time.
+    let source = "
+        module Inner
+          param I: const = 0;
+          port idx: in  UInt<8>;
+          port out: out UInt<8>;
+          let pad: UInt<8> = I.zext<8>();
+          comb
+            out = idx +% pad;
+          end comb
+        end module Inner
+
+        module Top
+          param SEVEN: const = 7;
+          param NINE:  const = 9;
+          port idx: in UInt<8>;
+          port out: out UInt<8>;
+          generate_if 1
+            inst chosen: Inner
+              param I = SEVEN;
+              idx <- idx;
+              out -> out;
+            end inst chosen
+          end generate_if
+          generate_if 0
+            inst unused: Inner
+              param I = NINE;
+              idx <- idx;
+              out -> out;
+            end inst unused
+          end generate_if
+        end module Top
+    ";
+    let sv = compile_to_sv(source);
+    // Both branches' values get discovered. The cond=1 branch's inst
+    // actually survives; the cond=0 branch's variant is emitted but
+    // never instantiated — synthesis tools dead-code it.
+    assert!(sv.contains("module Inner__I_7"),
+            "missing `Inner__I_7` variant (active branch's param):\n{sv}");
+}


### PR DESCRIPTION
## The bug (confirmed by probe)

An inst declared inside `generate_if` whose `param X = <expr>` references the enclosing module's params silently landed on the default-param variant of the child module — a real miscompile.

**Reproducing probe:**

\`\`\`arch
module Inner
  param I: const = 8;
  port idx: in UInt<8>;
  port out: out UInt<8>;
  let pad: UInt<8> = I.zext<8>();
  comb out = idx +% pad; end comb
end module Inner

module Top
  param TEN: const = 10;
  param TWENTY: const = 20;
  port idx: in UInt<8>;
  port out0: out UInt<8>;
  port out1: out UInt<8>;
  generate_if 1
    inst inner_a: Inner  param I = TEN;     idx <- idx; out -> out0;  end inst inner_a
  end generate_if
  generate_if 1
    inst inner_b: Inner  param I = TWENTY;  idx <- idx; out -> out1;  end inst inner_b
  end generate_if
end module Top
\`\`\`

Drive `idx = 5`. Expected `out0 = 15` (5+10), `out1 = 25` (5+20).
**Before fix:** `out0 = 13`, `out1 = 13` — both inst sites silently resolved to the I=8 default. The TEN/TWENTY param values were dropped at variant-discovery time.

## Root cause

Two sites in `src/elaborate.rs` evaluated inst param values against an empty param map:

1. **`record_inst`** (called by `collect_raw_overrides_from_body`) — the `generate_for` branch already passed enclosing params through (per PR #394), but the `generate_if` branch dropped them. Worse, `record_inst` itself called `try_eval_i64(&pa.value, &HashMap::new())` — even when called from the generate_for path it was implicitly relying on the substitute-then-eval flow that worked only for loop-var substitutions.
2. **`rewrite_inst`** (matches an inst to its specialized variant) — same `try_eval_i64(&pa.value, &HashMap::new())` pattern. Even if variants WERE discovered correctly, this would still fail to look them up.

Without enclosing_params, `param I = TEN` couldn't resolve (TEN is a module param). The variant set never saw the per-inst values; every inst matched only the default-param variant.

## Fix

Thread `enclosing_params: &HashMap<String, i64>` through both functions:

- `record_inst` takes `enclosing_params`; existing `generate_for` callers pass through unchanged, new `generate_if` callers pass them in (over-recording from walking both then/else branches is benign — `compute_all_variants` dedupes).
- `rewrite_inst` takes `enclosing_params` and uses them computing the effective param set.
- Caller in `elaborate_module_variant` passes the variant's `param_vals` down through both.

## After fix

Same probe: `out0 = 15`, `out1 = 25`. Two specialized variants `VInner__I_10` and `VInner__I_20` are emitted; each inst site references the correct one.

## Tests

- `test_generate_if_variant_discovery_with_param_expr` — exact regression of the probe above; asserts both `module Inner__I_10` and `module Inner__I_20` appear in SV.
- `test_generate_if_variant_discovery_with_default_branch_values` — conservative walk of both then/else branches; param values in both branches get recorded (the unused-branch variant gets dead-coded by synthesis).

**All 470 unit tests pass (468 pre-existing + 2 new); 0 ignored.**

## Audit context

This is the third instance of the same bug shape now found in elaborate:
- PR #394 fixed `collect_raw_overrides_from_body` for the `generate_for` case.
- This PR fixes it for `generate_if` AND for `rewrite_inst` (which was the matching downstream consumer all along).

The `rewrite_inst` site has been silently wrong since module-variant specialization was added — it just happened to coincide with the empty-params-also-broken `record_inst` path. The two together produced the same "default-variant" result, so the bug didn't surface until the `record_inst` fix in PR #394 unmasked it.