### PR TITLE
sim: fix silent truncation of nested-Vec reg/wire storage

### DIFF
--- a/src/sim_codegen/mod.rs
+++ b/src/sim_codegen/mod.rs
@@ -1759,11 +1759,23 @@ fn cpp_field_decl(name: &str, ty: &TypeExpr, params: &[ParamDecl]) -> String {
 }
 
 /// If `ty` is Vec<T, N>, return (elem_cpp_type, count_string).
+///
+/// Nested Vecs (e.g. `Vec<Vec<UInt<32>, 4>, 8>`) recurse: the innermost
+/// non-Vec element type is returned as `elem_cpp_type`, and the count
+/// string is the C-array dimension chain in source order separated by
+/// `"]["` so a caller emitting `<elem>[<count>]` ends up with the
+/// correct multi-dim C array (`uint32_t name[8][4]`).
 fn vec_array_info(ty: &TypeExpr) -> Option<(String, String)> {
     if let TypeExpr::Vec(elem, count_expr) = ty {
-        let elem_type = cpp_internal_type(elem);
-        let count_str = eval_const_expr(count_expr).to_string();
-        Some((elem_type, count_str))
+        let outer_count = eval_const_expr(count_expr).to_string();
+        // Recursively descend nested Vecs to gather inner dimensions.
+        if let Some((inner_elem, inner_dims)) = vec_array_info(elem) {
+            Some((inner_elem, format!("{outer_count}][{inner_dims}")))
+        } else {
+            // Innermost level — element is a scalar (UInt/SInt/Bool/Named).
+            let elem_type = cpp_internal_type(elem);
+            Some((elem_type, outer_count))
+        }
     } else {
         None
     }
@@ -1912,9 +1924,14 @@ fn eval_const_expr_with_params_seen(
 /// surrounding stack on memcpy/index).
 fn vec_array_info_with_params(ty: &TypeExpr, params: &[ParamDecl]) -> Option<(String, String)> {
     if let TypeExpr::Vec(elem, count_expr) = ty {
-        let elem_type = cpp_internal_type(elem);
-        let count_str = eval_const_expr_with_params(count_expr, params).to_string();
-        Some((elem_type, count_str))
+        let outer_count = eval_const_expr_with_params(count_expr, params).to_string();
+        // Recursively descend nested Vecs — see vec_array_info docs.
+        if let Some((inner_elem, inner_dims)) = vec_array_info_with_params(elem, params) {
+            Some((inner_elem, format!("{outer_count}][{inner_dims}")))
+        } else {
+            let elem_type = cpp_internal_type_with_params(elem, params);
+            Some((elem_type, outer_count))
+        }
     } else {
         None
     }
@@ -4725,18 +4742,30 @@ impl<'a> SimCodegen<'a> {
             .collect();
         vec_reg_names.extend(vec_wire_names.iter().cloned());
 
-        // 2D Vec names (today: `wire edges: Vec<Vec<Bus,N>,M>`). Outer
-        // indexing returns another Vec, so the inner subscript must stay
-        // as C array indexing instead of bit-extraction.
+        // 2D Vec names — outer indexing returns another Vec, so the inner
+        // subscript must stay as C array indexing instead of bit-extraction.
+        // Covers:
+        //   - `wire edges: Vec<Vec<Bus,N>,M>;` (the 2D bus wire case from PR #394)
+        //   - `reg rf: Vec<Vec<UInt<W>,N>,M>;` (nested-Vec regs — the case
+        //     this PR newly handles, paired with the recursive
+        //     `vec_array_info` fix that emits `uint32_t _rf[M][N]` rather
+        //     than truncating the inner dim to a scalar)
+        //   - same shape for wires whose elem is a non-bus Vec (e.g.
+        //     `Vec<Vec<UInt<W>, N>, M>`)
         let vec_2d_names: HashSet<String> = m.body.iter()
-            .filter_map(|i| if let ModuleBodyItem::WireDecl(w) = i {
-                if let TypeExpr::Vec(elem, _) = &w.ty {
+            .filter_map(|i| {
+                let (name, ty) = match i {
+                    ModuleBodyItem::WireDecl(w) => (&w.name.name, &w.ty),
+                    ModuleBodyItem::RegDecl(r)  => (&r.name.name, &r.ty),
+                    _ => return None,
+                };
+                if let TypeExpr::Vec(elem, _) = ty {
                     if matches!(elem.as_ref(), TypeExpr::Vec(_, _)) {
-                        return Some(w.name.name.clone());
+                        return Some(name.clone());
                     }
                 }
                 None
-            } else { None })
+            })
             .collect();
 
         // D2 Vec-of-bus port array members: for `port chans: Vec<Bus, N>`,
@@ -6469,7 +6498,24 @@ impl<'a> SimCodegen<'a> {
                         if vec_reg_names.contains(*reg_name) {
                             let count = vec_sizes.get(*reg_name).copied().unwrap_or(0);
                             if count > 0 {
-                                cpp.push_str(&format!("    for (size_t _i = 0; _i < {count}; ++_i) {{ _{reg_name}[_i] = {init}; _n_{reg_name}[_i] = {init}; }}\n"));
+                                // For nested-Vec regs the inner dim is a C array,
+                                // not a scalar — a per-element scalar assign
+                                // `_rf[_i] = 0` fails to compile. memset zeroes
+                                // the whole storage in one shot regardless of
+                                // dimensionality; the spec's reset broadcast
+                                // semantics (scalar distributed across every
+                                // element) collapse to the zero case in
+                                // practice. For non-zero broadcasts, fall back
+                                // to the per-element-loop form (correct for
+                                // 1D, generates a compile error for nested-
+                                // Vec the user must resolve by writing the
+                                // reset by hand).
+                                if init == "0" {
+                                    cpp.push_str(&format!("    memset(_{reg_name}, 0, sizeof(_{reg_name}));\n"));
+                                    cpp.push_str(&format!("    memset(_n_{reg_name}, 0, sizeof(_n_{reg_name}));\n"));
+                                } else {
+                                    cpp.push_str(&format!("    for (size_t _i = 0; _i < {count}; ++_i) {{ _{reg_name}[_i] = {init}; _n_{reg_name}[_i] = {init}; }}\n"));
+                                }
                             }
                         } else if wide_names.contains(*reg_name) {
                             let bits = widths.get(*reg_name).copied().unwrap_or(0);
@@ -6528,7 +6574,13 @@ impl<'a> SimCodegen<'a> {
                         if vec_reg_names.contains(*reg_name) {
                             let count = vec_sizes.get(*reg_name).copied().unwrap_or(0);
                             if count > 0 {
-                                cpp.push_str(&format!("{}for (size_t _i = 0; _i < {count}; ++_i) {{ _n_{reg_name}[_i] = {init}; }}\n", "  ".repeat(base_indent + 1)));
+                                // memset for zero (covers nested-Vec); per-element
+                                // loop for non-zero broadcasts (works for 1D).
+                                if init == "0" {
+                                    cpp.push_str(&format!("{}memset(_n_{reg_name}, 0, sizeof(_n_{reg_name}));\n", "  ".repeat(base_indent + 1)));
+                                } else {
+                                    cpp.push_str(&format!("{}for (size_t _i = 0; _i < {count}; ++_i) {{ _n_{reg_name}[_i] = {init}; }}\n", "  ".repeat(base_indent + 1)));
+                                }
                             }
                         } else if wide_names.contains(*reg_name) {
                             let bits = widths.get(*reg_name).copied().unwrap_or(0);

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -16412,3 +16412,36 @@ fn test_generate_if_variant_discovery_with_default_branch_values() {
     assert!(sv.contains("module Inner__I_7"),
             "missing `Inner__I_7` variant (active branch's param):\n{sv}");
 }
+
+#[test]
+fn test_sim_nested_vec_reg_round_trips_all_cells() {
+    // Regression: `reg rf: Vec<Vec<UInt<W>, N>, M>;` used to emit
+    // `uint32_t _rf[M]` — silently truncating the inner dim to a
+    // 32-bit scalar. Reads/writes via `rf[i][j]` then aliased into
+    // bit-positions of the outer element. The fix recursively
+    // descends vec_array_info to emit the proper multi-dim C array
+    // (`uint32_t _rf[M][N]`) and updates the expr emitter to chain
+    // C subscripts for the inner index.
+    //
+    // This test writes 32 distinct values across an 8×4 Vec-of-Vec
+    // reg, then reads every cell back. Any silent aliasing would
+    // scramble values — a pre-fix run would fail the readback.
+    let td = tempfile::tempdir().expect("tempdir");
+    let arch_bin = env!("CARGO_BIN_EXE_arch");
+    let out = std::process::Command::new(arch_bin)
+        .arg("sim")
+        .arg("tests/nested_vec_sim/Probe.arch")
+        .arg("--tb")
+        .arg("tests/nested_vec_sim/tb.cpp")
+        .arg("--outdir")
+        .arg(td.path())
+        .output()
+        .expect("run arch sim for nested_vec_sim probe");
+    assert!(out.status.success(),
+        "nested-Vec sim should compile + run\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr));
+    assert!(String::from_utf8_lossy(&out.stdout).contains("PASS nested-Vec storage"),
+        "expected PASS marker in stdout:\n{}",
+        String::from_utf8_lossy(&out.stdout));
+}

--- a/tests/nested_vec_sim/Probe.arch
+++ b/tests/nested_vec_sim/Probe.arch
@@ -1,0 +1,25 @@
+module Probe
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Async, Low>;
+  port idx_outer: in UInt<3>;
+  port idx_inner: in UInt<2>;
+  port wdata: in UInt<32>;
+  port we:    in Bool;
+  port out:   out UInt<32>;
+
+  // Nested Vec — the case PR #404 fixed: outer 8 × inner 4 × 32-bit.
+  // Pre-fix, the inner dim got silently dropped (`uint32_t _rf[8]`);
+  // the fix emits `uint32_t _rf[8][4]` and routes indexed access via
+  // C array subscript on both dims.
+  reg rf: Vec<Vec<UInt<32>, 4>, 8> reset rst => 0;
+
+  seq on clk rising
+    if we
+      rf[idx_outer][idx_inner] <= wdata;
+    end if
+  end seq
+
+  comb
+    out = rf[idx_outer][idx_inner];
+  end comb
+end module Probe

--- a/tests/nested_vec_sim/tb.cpp
+++ b/tests/nested_vec_sim/tb.cpp
@@ -1,0 +1,37 @@
+#include "VProbe.h"
+#include <cstdio>
+static VProbe dut;
+static void tick() { dut.clk = 0; dut.eval(); dut.clk = 1; dut.eval(); }
+static void write_cell(unsigned o, unsigned i, unsigned v) {
+    dut.we = 1; dut.idx_outer = o; dut.idx_inner = i; dut.wdata = v;
+    tick();
+    dut.we = 0;
+}
+static unsigned read_cell(unsigned o, unsigned i) {
+    dut.idx_outer = o; dut.idx_inner = i;
+    dut.eval();
+    return (unsigned)dut.out;
+}
+int main() {
+    dut.rst = 0; dut.we = 0; dut.idx_outer = 0; dut.idx_inner = 0; dut.wdata = 0;
+    for (int i = 0; i < 4; ++i) tick();
+    dut.rst = 1;
+    // Distinct values across all 8*4 = 32 cells confirm the inner dim
+    // isn't being silently aliased to bit-extraction.
+    for (unsigned o = 0; o < 8; ++o)
+        for (unsigned i = 0; i < 4; ++i)
+            write_cell(o, i, 0xCAFE0000u | (o << 4) | i);
+    // Read every cell back; any aliasing would scramble values.
+    for (unsigned o = 0; o < 8; ++o) {
+        for (unsigned i = 0; i < 4; ++i) {
+            unsigned got = read_cell(o, i);
+            unsigned want = 0xCAFE0000u | (o << 4) | i;
+            if (got != want) {
+                std::printf("FAIL rf[%u][%u] = 0x%X (expected 0x%X)\n", o, i, got, want);
+                return 1;
+            }
+        }
+    }
+    std::printf("PASS nested-Vec storage: 32 distinct cells round-trip\n");
+    return 0;
+}


### PR DESCRIPTION
## The bug

`vec_array_info` extracted the C++ element type via `cpp_internal_type(elem)` — which returns `\"uint32_t\"` for any `TypeExpr::Vec(_, _)` (fallback). For `reg rf: Vec<Vec<UInt<32>, 4>, 8>;`:

\`\`\`
elem = Vec<UInt<32>, 4>             ← inner Vec
cpp_internal_type(elem) = \"uint32_t\"  ← silent truncation
vec_array_info → (\"uint32_t\", \"8\")    ← outer dim only
emitted C++: `uint32_t _rf[8]`         ← inner dim dropped
\`\`\`

Every `rf[i][j]` access then bit-extracted from `_rf[i]` instead of indexing a second dim. Cells aliased into the same bit positions of the outer element — total data corruption.

**Reproducing probe** (pre-fix, write 32 distinct values to an 8×4 reg, read them back): many cells return values written to OTHER cells.

## Fix

Two coordinated changes in `src/sim_codegen/mod.rs`:

1. **`vec_array_info` + `vec_array_info_with_params` recurse** to gather all dimensions of nested Vecs, returning the innermost scalar element type plus a multi-dim chain string. For `Vec<Vec<UInt<32>, 4>, 8>` the result is `(\"uint32_t\", \"8][4\")` so `cpp_field_decl` emits `uint32_t _rf[8][4]` — correct C 2D array.

2. **`vec_2d_names` extended to cover RegDecls** (was wire-only after PR #394). The expression emitter checks this set to decide whether indexing a Vec returns another Vec (use C subscript) or a scalar (use bit-extraction). Without the reg variant, `rf[idx_outer]` on a 2D Vec reg fell into bit-extraction.

Reset-emission also fixed in two places: `_rf[_i] = 0` is invalid C when `_rf[_i]` is itself an array. Switched to `memset` for the common zero-broadcast case (covers nested-Vec); non-zero broadcasts still use the per-element loop (correct for 1D, produces a clear C compile error for nested-Vec which users resolve by writing the reset explicitly).

## Test

**`test_sim_nested_vec_reg_round_trips_all_cells`** — runs `arch sim` end-to-end on an 8×4 nested-Vec reg, writes 32 distinct values covering every cell, reads them all back. Fails if any value is scrambled by silent aliasing.

Pre-fix: test fails (data corruption from inner-dim truncation).
Post-fix: PASSes — 32 distinct cells round-trip correctly.

**All 471 unit tests pass (470 pre-existing + 1 new); 0 ignored.**

## Scope notes

- Wires of nested-Vec type (`wire grid: Vec<Vec<UInt<8>, 4>, 4>;`) are also covered — same `vec_2d_names` registry now picks up RegDecls and WireDecls.
- Non-zero reset broadcasts on nested-Vec regs (e.g. `reset rst => 7`) intentionally produce a C compile error today, with the spec's broadcast semantics being ambiguous for nested storage. Users can write the reset explicitly via per-element assigns. Filed as a follow-up if anyone needs it.
- This is the 5th and last item from the post-D2 audit list. Audit complete.