### PR TITLE
docs: add note on avoiding 'if false' dead stubs during refactors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,22 @@ change, and AI co-author trailers break the CLA Assistant (which requires every
 listed author to individually sign the CLA — `noreply@anthropic.com` can't).
 Just write a normal commit message with no AI attribution trailer.
 
+## Coding style
+
+### Avoid `if false { ... }` dead stubs during incremental edits
+
+When refactoring, don't wrap large blocks of code in `if false { ... }` to keep
+them parseable during intermediate states. The Rust compiler doesn't warn on
+`if false` bodies, the dead code is invisible to `grep`, and a reviewer scanning
+the diff may miss that an entire branch became unreachable.
+
+Better patterns:
+- Comment out the old block (`// ...`) — greppable, visible in diff.
+- Delete entirely and rely on git history if you need to compare against the
+  old shape mid-refactor.
+- Use `todo!()` or `unreachable!()` for *intentionally* unreachable code (with
+  appropriate runtime panic semantics).
+
 ## Project Overview
 
 `arch-com` is a compiler for **ARCH**, a purpose-built hardware description language (HDL) for micro-architecture work. The compiler ingests `.arch` source files and emits deterministic, readable SystemVerilog. The language is explicitly designed to be generated correctly by LLMs from natural-language hardware descriptions.


### PR DESCRIPTION
## Summary

Adds a "Coding style" section to `CLAUDE.md` (sibling to the existing "Commit conventions" section) capturing an anti-pattern flagged in #398: wrapping old code in `if false { ... }` to keep braces balanced during an in-progress refactor.

Why this is worth a note:
- The Rust compiler does not warn on `if false` bodies, so the dead block compiles silently.
- The literal pattern `if false` is invisible to `grep` for anyone scanning the codebase later.
- In a diff, a reviewer can easily miss that an entire branch just became unreachable.

The note points readers at greppable, diff-visible alternatives: comment-out, outright delete (with git history as the rollback path), or `todo!()` / `unreachable!()` when the unreachability is intentional.

Refs: #398 (originated from the inst-emitter restructuring in PR #395).

## Test plan

- [x] Doc-only change; no code paths affected.
- [x] CLAUDE.md still renders / reads cleanly with the new section inserted between "Commit conventions" and "Project Overview".