### PR TITLE
codegen: restore SV genvar for safe inst-bearing generate_for

### DIFF
--- a/examples/tb_generate_for_genvar.cpp
+++ b/examples/tb_generate_for_genvar.cpp
@@ -1,0 +1,34 @@
+// Sim TB for the shape-stable SV-genvar `generate_for + inst` form.
+//
+// Verifies that arch sim's local unroll of preserved Generate(For) blocks
+// produces the same wire-through behavior as the pre-#399 always-unroll-at-
+// elaboration path: each pt_i forwards req[i] to gnt[i].
+
+#include "VGenDemo.h"
+#include <cstdio>
+
+int main() {
+    VGenDemo dut;
+
+    auto check = [&](int r0, int r1) {
+        dut.req[0] = r0;
+        dut.req[1] = r1;
+        dut.eval();
+        if (dut.gnt[0] != r0 || dut.gnt[1] != r1) {
+            printf("FAIL: req={%d,%d} gnt={%d,%d}\n",
+                   r0, r1, dut.gnt[0], dut.gnt[1]);
+            return false;
+        }
+        printf("OK: req={%d,%d} gnt={%d,%d}\n",
+               r0, r1, dut.gnt[0], dut.gnt[1]);
+        return true;
+    };
+
+    if (!check(0, 0)) return 1;
+    if (!check(1, 0)) return 1;
+    if (!check(0, 1)) return 1;
+    if (!check(1, 1)) return 1;
+
+    printf("PASS generate_for genvar sim\n");
+    return 0;
+}

--- a/src/elaborate.rs
+++ b/src/elaborate.rs
@@ -81,6 +81,18 @@ pub fn elaborate(ast: SourceFile) -> Result<SourceFile, Vec<CompileError>> {
     // Step 3 — distinct effective-param sets and variant names per module
     let module_variants = compute_all_variants(&ast.items, &module_defaults, &inst_raw);
 
+    // Child-module port info: needed by expand_generate_for to detect
+    // Vec-of-bus child ports that disqualify the SV-genvar preservation.
+    // Built once for the whole file (mirrors the lower_tlm_connects map).
+    let child_module_ports: HashMap<String, Vec<PortDecl>> = ast.items.iter()
+        .filter_map(|item| match item {
+            Item::Module(m) => Some((m.name.name.clone(), m.ports.clone())),
+            Item::Fsm(f) => Some((f.name.name.clone(), f.ports.clone())),
+            Item::Pipeline(p) => Some((p.name.name.clone(), p.ports.clone())),
+            _ => None,
+        })
+        .collect();
+
     // Step 4 — elaborate and emit
     let mut new_items: Vec<Item> = Vec::new();
     let mut errors: Vec<CompileError> = Vec::new();
@@ -99,6 +111,7 @@ pub fn elaborate(ast: SourceFile) -> Result<SourceFile, Vec<CompileError>> {
                         variant_name,
                         &module_variants,
                         &module_defaults,
+                        &child_module_ports,
                     ) {
                         Ok(elaborated) => new_items.push(Item::Module(elaborated)),
                         Err(mut errs) => errors.append(&mut errs),
@@ -324,7 +337,13 @@ fn elaborate_module_variant(
     variant_name: String,
     module_variants: &HashMap<String, Vec<(HashMap<String, i64>, String)>>,
     module_defaults: &HashMap<String, HashMap<String, i64>>,
+    child_module_ports: &HashMap<String, Vec<PortDecl>>,
 ) -> Result<ModuleDecl, Vec<CompileError>> {
+    // Build the parent module's shape info BEFORE we move m.body — used
+    // by expand_generate_for to classify inst-bearing bodies as shape-
+    // stable (SV-genvar-preservable) or needing per-iteration unroll.
+    let parent_shape = ParentShapeInfo::from_module(&m);
+
     // Expand generate blocks
     let mut extra_ports: Vec<PortDecl> = Vec::new();
     let mut pre_rewrite: Vec<ModuleBodyItem> = Vec::new();
@@ -332,7 +351,7 @@ fn elaborate_module_variant(
 
     for item in m.body {
         match item {
-            ModuleBodyItem::Generate(gen) => match expand_generate(gen, &param_vals) {
+            ModuleBodyItem::Generate(gen) => match expand_generate(gen, &param_vals, &parent_shape, child_module_ports) {
                 Ok((ports, items)) => {
                     extra_ports.extend(ports);
                     pre_rewrite.extend(items);
@@ -765,12 +784,78 @@ fn tlm_connect_endpoint_bus(
 
 // ── Generate expansion ────────────────────────────────────────────────────────
 
+/// Read-only view of the *parent* module's port + wire shapes, used by
+/// `expand_generate_for` to classify inst-bearing bodies as "shape-stable"
+/// (SV-genvar-preservable) vs needing per-iteration unroll. We only need
+/// the per-name Vec-of-bus shape — full TypeExpr isn't required.
+#[derive(Default)]
+pub(crate) struct ParentShapeInfo {
+    /// Parent ports/wires that are Vec-of-bus (either `Vec<Bus,N>` port
+    /// directly via `bus_info.count.is_some()`, OR a non-bus port/wire
+    /// whose type is `Vec<Named, _>` / `Vec<Vec<Named, _>, _>` and so on,
+    /// where `Named` *might* be a bus — see `type_expr_contains_bus` for
+    /// why we conservatively treat all Named types as potential buses).
+    /// Indexing one of these by the loop variable produces a per-iteration
+    /// bus-shape reference that the SV genvar form can't emit cleanly.
+    vec_of_bus_names: HashSet<String>,
+}
+
+impl ParentShapeInfo {
+    fn from_module(m: &ModuleDecl) -> Self {
+        let mut vec_of_bus_names = HashSet::new();
+        for p in &m.ports {
+            if let Some(bi) = &p.bus_info {
+                if bi.count.is_some() {
+                    vec_of_bus_names.insert(p.name.name.clone());
+                }
+            } else if matches!(p.ty, TypeExpr::Vec(..)) && type_expr_contains_bus(&p.ty) {
+                // Defensive: bus type wrapped in Vec without bus_info
+                // shouldn't happen for ports today, but cover it anyway.
+                vec_of_bus_names.insert(p.name.name.clone());
+            }
+        }
+        for item in &m.body {
+            if let ModuleBodyItem::WireDecl(w) = item {
+                if matches!(w.ty, TypeExpr::Vec(..)) && type_expr_contains_bus(&w.ty) {
+                    vec_of_bus_names.insert(w.name.name.clone());
+                }
+            }
+        }
+        ParentShapeInfo { vec_of_bus_names }
+    }
+}
+
+/// Conservative recursive check: does this TypeExpr contain a `Named`
+/// type that *might* be a bus? The symbol table isn't available at this
+/// elaboration pass, so we can't distinguish bus-typed Named from
+/// struct/enum-typed Named. Treating all `Named` as potentially-bus
+/// over-approximates: a Vec-of-struct port/wire gets classified as
+/// Vec-of-bus and falls back to elaboration-time unroll if an inst-
+/// bearing generate_for reads it via `arr[i]`. That's a conservative
+/// loss of compactness for one rare shape (positional Vec-of-struct
+/// through an inst connection), not a correctness regression.
+///
+/// For bus wires the parser records the bus reference as
+/// `Named(BusName)` plus `bus_params` for per-site overrides, so
+/// `Vec<BusName, N>` becomes `Vec(Named(BusName), N)`. This catches the
+/// NIC-400 `wire edges: Vec<Vec<SlaveBus, N>, M>` case — exactly what
+/// the unsafe path must keep unrolling.
+fn type_expr_contains_bus(ty: &TypeExpr) -> bool {
+    match ty {
+        TypeExpr::Named(_) => true,
+        TypeExpr::Vec(inner, _) => type_expr_contains_bus(inner),
+        _ => false,
+    }
+}
+
 fn expand_generate(
     gen: GenerateDecl,
     param_vals: &HashMap<String, i64>,
+    parent_shape: &ParentShapeInfo,
+    child_module_ports: &HashMap<String, Vec<PortDecl>>,
 ) -> Result<(Vec<PortDecl>, Vec<ModuleBodyItem>), Vec<CompileError>> {
     match gen {
-        GenerateDecl::For(gf) => expand_generate_for(gf, param_vals),
+        GenerateDecl::For(gf) => expand_generate_for(gf, param_vals, parent_shape, child_module_ports),
         GenerateDecl::If(gi) => expand_generate_if(gi, param_vals),
     }
 }
@@ -794,6 +879,8 @@ fn expr_references_param(expr: &Expr, param_names: &[String]) -> bool {
 fn expand_generate_for(
     gf: GenerateFor,
     param_vals: &HashMap<String, i64>,
+    parent_shape: &ParentShapeInfo,
+    child_module_ports: &HashMap<String, Vec<PortDecl>>,
 ) -> Result<(Vec<PortDecl>, Vec<ModuleBodyItem>), Vec<CompileError>> {
     // Collect param names from param_vals
     let param_names: Vec<String> = param_vals.keys().cloned().collect();
@@ -810,22 +897,49 @@ fn expand_generate_for(
     let start_val = try_eval_i64(&gf.start, param_vals);
     let end_val = try_eval_i64(&gf.end, param_vals);
 
+    // Classify inst-bearing bodies: even when the body has only `inst`
+    // items, we may still be able to preserve the SV genvar form if every
+    // connection is "shape-stable" — i.e. doesn't index a Vec-of-bus
+    // parent port/wire and doesn't drive a Vec-of-bus child port. Those
+    // shapes need per-iteration flat-name expansion that SV genvar can't
+    // express, and elaboration must unroll them.
+    let only_inst_items = has_inst_items
+        && !has_port_items
+        && !has_thread_items
+        && !has_connect_items
+        && !has_wire_items;
+    let inst_items_shape_stable = only_inst_items
+        && gf.items.iter().all(|item| {
+            if let GenItem::Inst(inst) = item {
+                inst_is_shape_stable_for_genvar(inst, parent_shape, child_module_ports)
+            } else {
+                true
+            }
+        });
+
     // Preserve the generate block as a SV genvar `for` loop only when the
     // range references a module param AND the body has no items that
     // require elaboration-time unrolling:
     //   - port items: SV `for` can't introduce new ports at the boundary
     //   - thread items: threads lower to FSMs at elaboration time
     //   - TLM connect items: elaborate to private bus wires
-    //   - inst items: sim codegen has no SV-genvar equivalent, and bus
-    //     port connections need per-iteration loop-var substitution to
-    //     produce flat per-element wiring. Always-unroll insts is what
-    //     makes the sim path work for `generate_for + inst`.
-    //   - wire items: same as inst — SV genvars can't introduce new
-    //     wire identifiers per iteration (would need hierarchical
-    //     `gen_i.w` access, which we don't want at the SV boundary).
-    if range_depends_on_param && !has_port_items && !has_thread_items
-        && !has_connect_items && !has_inst_items && !has_wire_items
-    {
+    //   - wire items: SV genvars can't introduce new wire identifiers per
+    //     iteration (would need hierarchical `gen_i.w` access, which we
+    //     don't want at the SV boundary).
+    //   - inst items: only preserve when every connection is shape-stable.
+    //     "Shape-stable" means the inst's connections are pure scalar or
+    //     simple `Ident` / `Index(Ident, loop_var)` references against
+    //     parent ports/wires that are NOT Vec-of-bus, AND the child
+    //     module's ports themselves are not Vec-of-bus. In that safe case
+    //     SV emits `gen_i.foo_i.port(arr[i])` cleanly; sim codegen runs
+    //     its own local unroll pass to keep both backends in sync.
+    let body_preservable = !has_port_items
+        && !has_thread_items
+        && !has_connect_items
+        && !has_wire_items
+        && (!has_inst_items || inst_items_shape_stable);
+
+    if range_depends_on_param && body_preservable {
         return Ok((
             Vec::new(),
             vec![ModuleBodyItem::Generate(GenerateDecl::For(gf))],
@@ -886,6 +1000,95 @@ fn expand_generate_for(
     }
 
     Ok((ports, body))
+}
+
+// ── generate_for shape-stable inst classification ─────────────────────────────
+//
+// SV genvar form survives if every connection in every inst inside the
+// generate_for body satisfies all of:
+//
+//   1. The connection's signal expression doesn't reference a Vec-of-bus
+//      parent port/wire. We allow plain idents (`clk`, `rst`) and
+//      `Index(Ident, loop_var)` against non-bus parent ports/wires
+//      (e.g. `req[i]` on `port req: in Vec<Bool, N>`).
+//
+//   2. The child module's matched port is not itself a Vec-of-bus port
+//      (`bus_info.count.is_some()`). Vec-of-bus child ports need per-
+//      iteration packed-slice assembly that SV genvar can't express.
+//
+// The conservative default is "unsafe" — if we can't classify, fall back
+// to the existing unroll-at-elaboration path. Inst-body for-loops (the
+// `for k in ... ins[k] <- edges[k][j]` macro inside an inst body) are
+// also unsafe by design: they generate per-iteration flat connection
+// names that SV genvar can't carry.
+fn inst_is_shape_stable_for_genvar(
+    inst: &InstDecl,
+    parent_shape: &ParentShapeInfo,
+    child_module_ports: &HashMap<String, Vec<PortDecl>>,
+) -> bool {
+    // Inst-body for-loops produce per-iteration flat wiring — always unsafe.
+    if !inst.for_loops.is_empty() {
+        return false;
+    }
+
+    // Look up child module ports; if we don't have them, be conservative.
+    let child_ports = match child_module_ports.get(&inst.module_name.name) {
+        Some(p) => p,
+        None => return false,
+    };
+
+    for conn in &inst.connections {
+        // Child-side: Vec-of-bus port? Unsafe.
+        if let Some(p) = child_ports.iter().find(|p| p.name.name == conn.port_name.name) {
+            if let Some(bi) = &p.bus_info {
+                if bi.count.is_some() {
+                    return false;
+                }
+            }
+            // Vec ports on the child side: scalar Vec is fine (e.g.
+            // `port a: in Bool` driven by `req[i]`). But if the child
+            // port itself is a Vec type AND not a bus, that's still
+            // fine for SV genvar — the genvar substitution turns it
+            // into `pt_<i>.a(req[i])` which is unambiguous.
+        }
+
+        // Parent signal-side: indexing a Vec-of-bus port/wire by the
+        // loop var produces a per-iteration bus shape. Unsafe.
+        if signal_indexes_vec_of_bus(&conn.signal, parent_shape) {
+            return false;
+        }
+    }
+
+    true
+}
+
+/// True iff the connection signal references a Vec-of-bus parent
+/// port/wire by indexing (e.g. `m[i]`, `edges[i]`) — exactly the shape
+/// that needs per-iteration flat-name expansion. Plain ident references
+/// to non-Vec-of-bus signals (`clk`, `rst`) and plain idents to scalar
+/// Vec ports (`req`) are both fine for SV genvar.
+fn signal_indexes_vec_of_bus(expr: &Expr, parent_shape: &ParentShapeInfo) -> bool {
+    match &expr.kind {
+        // `name[idx]` — check if `name` is Vec-of-bus.
+        ExprKind::Index(base, _) => {
+            if let ExprKind::Ident(n) = &base.kind {
+                if parent_shape.vec_of_bus_names.contains(n) {
+                    return true;
+                }
+            }
+            // Recurse: e.g. `edges[i][j]` — outer `Index(Index(Ident, _), _)`.
+            signal_indexes_vec_of_bus(base, parent_shape)
+        }
+        // Plain ident: not an indexed Vec-of-bus reference.
+        ExprKind::Ident(_) => false,
+        // Field access on a bus is fine (`bus.signal`) and won't appear
+        // at the top of an inst connection signal anyway. Recurse just
+        // in case.
+        ExprKind::FieldAccess(b, _) => signal_indexes_vec_of_bus(b, parent_shape),
+        // Casts (`x as Reset<...>`) — recurse on inner.
+        ExprKind::Cast(b, _) => signal_indexes_vec_of_bus(b, parent_shape),
+        _ => false,
+    }
 }
 
 // ── generate_for seq/comb write-target check (Reading B) ──────────────────────
@@ -1206,7 +1409,7 @@ fn unroll_inst_for_loop(
     Ok(out)
 }
 
-fn subst_inst(inst: &InstDecl, var: &str, val: i64) -> InstDecl {
+pub(crate) fn subst_inst(inst: &InstDecl, var: &str, val: i64) -> InstDecl {
     InstDecl {
         name: subst_ident(&inst.name, var, val),
         module_name: inst.module_name.clone(),

--- a/src/sim_codegen/mod.rs
+++ b/src/sim_codegen/mod.rs
@@ -1848,6 +1848,70 @@ fn eval_const_expr_with_params(expr: &Expr, params: &[ParamDecl]) -> u64 {
     eval_const_expr_with_params_seen(expr, params, &mut HashSet::new())
 }
 
+/// Return true if the module body contains a preserved `Generate(For)`
+/// block — these survive elaboration when the for-loop's range
+/// depends on a module param and the body is shape-stable. Sim codegen
+/// has no SV-genvar concept, so we run a local unroll pass before
+/// walking the body.
+fn module_body_has_preserved_generate(body: &[ModuleBodyItem]) -> bool {
+    body.iter().any(|it| matches!(it, ModuleBodyItem::Generate(GenerateDecl::For(_))))
+}
+
+/// Sim-local unroll for preserved `Generate(For)` blocks. Walks the
+/// module body, expands each `For` loop's `Inst` items (and any other
+/// generate-item kinds the elaborator's "shape-stable" gate may admit
+/// in the future) into flat ModuleBodyItem entries. The expansion is
+/// purely sim-local — the source AST is not mutated.
+///
+/// The elaborator's preservation gate only admits ranges that
+/// `eval_const_expr_with_params` can resolve against the parent module's
+/// param defaults. If we hit a range we can't evaluate, we leave the
+/// generate intact (which would silently drop the body in downstream
+/// sim walks); that case shouldn't occur given the preservation gate,
+/// but we'd rather notice it as a broken sim than crash.
+fn flatten_preserved_generates_for_sim(
+    body: &[ModuleBodyItem],
+    params: &[ParamDecl],
+) -> Vec<ModuleBodyItem> {
+    let mut out = Vec::with_capacity(body.len());
+    for item in body {
+        match item {
+            ModuleBodyItem::Generate(GenerateDecl::For(gf)) => {
+                // Resolve range bounds against the module's param defaults.
+                let start = eval_const_expr_with_params(&gf.start, params) as i64;
+                let end = eval_const_expr_with_params(&gf.end, params) as i64;
+                if end < start {
+                    // Empty range — emit nothing.
+                    continue;
+                }
+                let var = &gf.var.name;
+                for i in start..=end {
+                    for git in &gf.items {
+                        match git {
+                            GenItem::Inst(inst) => {
+                                out.push(ModuleBodyItem::Inst(crate::elaborate::subst_inst(inst, var, i)));
+                            }
+                            // The elaborator's preservation gate today
+                            // restricts preserved generate_for bodies
+                            // to inst-only (with shape-stable connections).
+                            // Other GenItem kinds would have been unrolled
+                            // at elaboration time. If a future expansion
+                            // of the gate admits more kinds, extend here.
+                            _ => {
+                                // Conservative: ignore (matches pre-#399
+                                // sim behavior for these kinds; the
+                                // elaborator wouldn't reach here today).
+                            }
+                        }
+                    }
+                }
+            }
+            other => out.push(other.clone()),
+        }
+    }
+    out
+}
+
 fn eval_const_expr_with_params_seen(
     expr: &Expr,
     params: &[ParamDecl],
@@ -4565,6 +4629,23 @@ impl<'a> SimCodegen<'a> {
     }
 
     pub(crate) fn gen_module(&self, m: &ModuleDecl, emit_debug: bool, debug_module_set: &std::collections::HashSet<String>) -> SimModel {
+        // Sim-local flatten: SV genvar `generate_for` blocks (which the
+        // elaborator preserves when an inst-bearing body's connections
+        // are shape-stable) have no sim equivalent. Unroll any preserved
+        // `Generate(For)` here so the rest of sim codegen sees a flat
+        // body — same shape it saw before issue #399 restored the
+        // SV-genvar optimization. The expansion is local to gen_module;
+        // the AST passed in by `generate()` is unchanged.
+        let m_flat_holder;
+        let m: &ModuleDecl = if module_body_has_preserved_generate(&m.body) {
+            let mut clone = m.clone();
+            clone.body = flatten_preserved_generates_for_sim(&m.body, &m.params);
+            m_flat_holder = clone;
+            &m_flat_holder
+        } else {
+            m
+        };
+
         let name = &m.name.name;
         let class = format!("V{name}");
         let enum_map = build_enum_map(self.symbols);

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1045,15 +1045,96 @@ fn test_generate_for() {
     // a single packed vector per direction, not N separately-named scalars.
     assert!(sv.contains("input logic [N-1:0] req"), "expected Vec req port, got:\n{sv}");
     assert!(sv.contains("output logic [N-1:0] gnt"), "expected Vec gnt port, got:\n{sv}");
-    // generate_for over `inst` items always unrolls at elaboration time (no SV
-    // genvar `gen_i` block) — sim codegen has no genvar equivalent, and
-    // unrolling keeps both backends in sync. The unrolled insts are named
-    // `pt_<i>` for each iteration value.
-    assert!(sv.contains("pt_0") && sv.contains("pt_1"),
-            "expected unrolled `pt_0`, `pt_1` insts, got:\n{sv}");
-    assert!(!sv.contains("genvar i;") && !sv.contains("begin : gen_i"),
-            "expected no SV genvar `for` for inst-bearing generate_for, got:\n{sv}");
+    // generate_for over `inst` items with shape-stable connections (scalar
+    // child ports + `Index(Ident, loop_var)` against a Vec parent port,
+    // no Vec-of-bus shapes) preserves the SV genvar `for begin gen_i end`
+    // form. One compact block, scales to any N.
+    assert!(sv.contains("genvar i;"),
+            "expected `genvar i;` for shape-stable inst-bearing generate_for, got:\n{sv}");
+    assert!(sv.contains("begin : gen_i"),
+            "expected `begin : gen_i` block, got:\n{sv}");
+    // Inside the gen_i block the inst is named `pt_i` (the loop-var-
+    // bearing source name) — substitution to `pt_0`/`pt_1` happens at
+    // SV-elaboration time, not at arch-com elaboration.
+    assert!(sv.contains("PassThrough pt_i"),
+            "expected `PassThrough pt_i` instance in the gen_i block, got:\n{sv}");
+    assert!(!sv.contains("PassThrough pt_0"),
+            "shape-stable case should NOT emit flat `pt_0`, got:\n{sv}");
     insta::assert_snapshot!(sv);
+}
+
+#[test]
+fn test_generate_for_inst_genvar_sim_behavior() {
+    // arch sim's local unroll of preserved Generate(For) blocks must
+    // produce the same wire-through behavior as the pre-#399 unroll-at-
+    // elaboration path. Without the sim-side flatten pass, eval_comb()
+    // would silently skip the Generate block and gnt would never assert.
+    let td = tempfile::tempdir().expect("tempdir");
+    let arch_bin = env!("CARGO_BIN_EXE_arch");
+    let out = std::process::Command::new(arch_bin)
+        .arg("sim")
+        .arg("examples/generate_for.arch")
+        .arg("--tb")
+        .arg("examples/tb_generate_for_genvar.cpp")
+        .arg("--outdir")
+        .arg(td.path())
+        .output()
+        .expect("run arch sim for generate_for genvar probe");
+    assert!(out.status.success(),
+        "generate_for genvar sim should pass\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr));
+    assert!(String::from_utf8_lossy(&out.stdout).contains("PASS generate_for genvar sim"),
+        "expected PASS marker in stdout:\n{}",
+        String::from_utf8_lossy(&out.stdout));
+}
+
+#[test]
+fn test_generate_for_inst_genvar_large_n() {
+    // Probe at N=8 to demonstrate compact SV genvar form. Without the
+    // shape-stable preservation this would emit 8 flat inst blocks.
+    let source = r#"
+domain SysDomain
+  freq_mhz: 100
+end domain SysDomain
+
+module PassThrough
+  port a: in  Bool;
+  port b: out Bool;
+
+  comb
+    b = a;
+  end comb
+end module PassThrough
+
+module Big
+  param N: const = 8;
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port req: in  Vec<Bool, N>;
+  port gnt: out Vec<Bool, N>;
+
+  generate_for i in 0..N-1
+    inst pt_i: PassThrough
+      a <- req[i];
+      b -> gnt[i];
+    end inst pt_i
+  end generate_for
+end module Big
+"#;
+    let sv = compile_to_sv(source);
+    // Exactly ONE genvar block, not 8 flat insts.
+    assert!(sv.contains("genvar i;"), "expected `genvar i;`, got:\n{sv}");
+    assert!(sv.contains("for (i = 0; i <= N - 1; i = i + 1) begin : gen_i"),
+            "expected SV genvar `for` loop, got:\n{sv}");
+    // No literal-i instance names — substitution is deferred to SV elaboration.
+    assert!(!sv.contains("PassThrough pt_0"),
+            "did not expect literal `pt_0` flat inst, got:\n{sv}");
+    assert!(!sv.contains("PassThrough pt_7"),
+            "did not expect literal `pt_7` flat inst, got:\n{sv}");
+    // Single instantiation in the source body.
+    let pt_count = sv.matches("PassThrough pt_i").count();
+    assert_eq!(pt_count, 1, "expected exactly one `PassThrough pt_i`, got {pt_count}:\n{sv}");
 }
 
 #[test]

--- a/tests/snapshots/integration_test__generate_for.snap
+++ b/tests/snapshots/integration_test__generate_for.snap
@@ -23,13 +23,12 @@ module GenDemo #(
   output logic [N-1:0] gnt
 );
 
-  PassThrough pt_0 (
-    .a(req[0]),
-    .b(gnt[0])
-  );
-  PassThrough pt_1 (
-    .a(req[1]),
-    .b(gnt[1])
-  );
+  genvar i;
+  for (i = 0; i <= N - 1; i = i + 1) begin : gen_i
+    PassThrough pt_i (
+      .a(req[i]),
+      .b(gnt[i])
+    );
+  end
 
 endmodule


### PR DESCRIPTION
## Summary

Closes #399.

After PR #394, every inst-bearing `generate_for` was force-unrolled at elaboration time so sim codegen (which has no SV-genvar concept) wouldn't silently drop the body. For shape-stable cases this is needless verbosity — `generate_for i in 0..N-1 { inst pt_i: Pass; a <- req[i]; b -> gnt[i]; }` expanded to N flat `Pass pt_<i>` insts even when one clean `for (genvar i; ...) begin : gen_i ... end` block would work.

This PR restores the SV genvar form for the safe case while keeping the unrolled fallback for shapes that genuinely need per-iteration packed-slice assembly (NIC-400 Vec-of-bus).

## Classification

In `expand_generate_for` (via `inst_is_shape_stable_for_genvar`):

- **SAFE → preserve as SV genvar:**
  - Connection signals are plain idents or `Index(Ident, _)` against parent ports/wires that are not Vec-of-bus.
  - Child module's matched port is not Vec-of-bus (`bus_info.count.is_none()`).
  - No inst-body for-loops.
- **UNSAFE → keep elaboration-time unroll:**
  - Connection signal indexes a parent Vec-of-bus port/wire (e.g. NIC-400's `m <- m[i]`, `outs -> edges[i]`).
  - Child has a Vec-of-bus port the connection drives.
  - Inst-body for-loop macros (`for k in ... ins[k] <- edges[k][j]`).
  - Conservative on `Vec<Named, N>` (struct/enum vs bus indistinguishable without symbol table).

The classification is parent-side. We examine the parent module's port + wire shapes (built once into `ParentShapeInfo`) plus the child module's port list (built once for the whole file, mirroring the existing `lower_tlm_connects` map). No symbol-table threading required.

## Sim-side

`gen_module` now runs a local unroll pass over preserved `Generate(For)` blocks before walking the body. Uses the same `subst_inst` helper the elaborator uses, so the post-unroll body shape is byte-identical to the pre-#399 always-unroll path. No other sim code touched — the existing 60+ `m.body` walks see the same flat body they did before.

## Tradeoffs

- SV output for large-N safe cases collapses to one compact genvar block (was N flat inst blocks).
- Sim path picks up a small local expansion pass — purely local to `gen_module`, no AST mutation.
- The "is this shape-stable?" decision becomes a maintenance surface: future Vec-of-bus features must update `inst_is_shape_stable_for_genvar`. Conservative default (unroll) means a missed case is a missed optimization, not a correctness bug.

## Test plan

- [x] `test_generate_for` (existing): snapshot updated to SV genvar form; assertions check `genvar i;`, `begin : gen_i`, pre-substitution `pt_i` inst name.
- [x] `test_generate_for_inst_genvar_large_n` (new): N=8 probe verifies exactly one genvar block, no flat `pt_0..pt_7`.
- [x] `test_generate_for_inst_genvar_sim_behavior` (new): runs `arch sim` on the genvar form with a C++ TB that probes `req[i] → gnt[i]` forwarding for all 4 input combinations. Without the sim-side flatten pass, `eval_comb()` would silently skip the Generate block and `gnt` would never assert.
- [x] All 472 integration tests + 20 formal tests pass.
- [x] NIC-400 fabric (Vec-of-bus shapes) still unrolls at elaboration — `Nic400MasterPort__I_0 mp_0 (...)`, `..._I_1 mp_1 (...)`, etc. Zero `genvar`/`gen_i` blocks in the NIC-400 SV output.
- [x] Verilator 5.034 `--binary` accepts the new genvar SV form and runs it; arch sim's local unroll matches behavior.