### PR TITLE
nic400: 3x4 R/W fabric + AHB-Lite bridge + PMU

### DIFF
--- a/tests/nic400/BusAhbLite.arch
+++ b/tests/nic400/BusAhbLite.arch
@@ -1,0 +1,35 @@
+// AHB-Lite bus (initiator = master). Slave/target perspective flips directions.
+//
+// Signal set is the standard AMBA AHB-Lite v1.0 master interface. HREADY here
+// is the slave's HREADYOUT (in a single-slave system there is no decoder mux
+// so HREADYOUT == HREADY at the master). For multi-slave systems an external
+// HREADY mux + HSEL decoder would sit between the master and the bridge.
+//
+// Encodings (informative, enforced by the bridge module, not the bus):
+//   HTRANS:  0=IDLE   1=BUSY   2=NONSEQ   3=SEQ
+//   HBURST:  0=SINGLE 1=INCR   2=WRAP4 3=INCR4 4=WRAP8 5=INCR8 6=WRAP16 7=INCR16
+//   HSIZE:   0=byte   1=hword  2=word   3=dword ...
+//   HRESP:   0=OKAY   1=ERROR  (AHB-Lite collapses the 2-cycle ERROR sequence
+//                               to a 1-bit signal asserted in the data phase)
+bus BusAhbLite
+  param ADDR_W: const = 32;
+  param DATA_W: const = 32;
+
+  // Address-phase signals (master drives, held stable while HREADY=0).
+  hsel:      out Bool;
+  haddr:     out UInt<ADDR_W>;
+  hwrite:    out Bool;
+  hsize:     out UInt<3>;
+  hburst:    out UInt<3>;
+  hprot:     out UInt<4>;
+  htrans:    out UInt<2>;
+  hmastlock: out Bool;
+
+  // Data-phase signals.
+  hwdata:    out UInt<DATA_W>;
+  hrdata:    in  UInt<DATA_W>;
+
+  // Slave-driven status.
+  hready:    in  Bool;     // HREADYOUT from the slave (in single-slave systems == HREADY)
+  hresp:     in  Bool;
+end bus BusAhbLite

--- a/tests/nic400/Nic400AhbBridge.arch
+++ b/tests/nic400/Nic400AhbBridge.arch
@@ -137,10 +137,34 @@ module Nic400AhbBridge
     end lock h_resp_lock
   end thread ReadXact
 
-  // ── Write thread ─────────────────────────────────────────────────────
-  // Wait for AHB write address phase. Issue AW; stall hready until aw_ready;
-  // then pulse hready=1 in the cycle when HWDATA is on the bus and forward
-  // it as a single AXI W beat; then wait for B and signal HRESP back to AHB.
+  // ── Write thread (multi-beat, fixed-length bursts) ──────────────────
+  // Sequence for an HBURST=INCR4 example:
+  //   • Cycle 0: AHB master drives NONSEQ+A0+HWRITE=1. Bridge sees this in
+  //     its wait state and enters AW phase with hready=0 (stall the AHB
+  //     master at the address phase boundary).
+  //   • Cycle K: aw_ready=1 captured; lock body exits. Bridge moves to a
+  //     1-cycle "gap" state with hready=1 (default comb). In this cycle the
+  //     master samples hready=1 and prepares to advance to data phase next.
+  //   • Cycle K+2 … K+5 (INCR4): bridge in W-loop iteration b=0..3. Each
+  //     iteration: hready=axi.w_ready, axi.w_valid=true, axi.w_data=
+  //     h.hwdata (combinational pickup of whatever the master placed),
+  //     axi.w_last = (b == axlen). On w_ready=1, lock body exits and the
+  //     loop advances to the next beat.
+  //   • Backpressure: when axi.w_ready=0, h.hready=0 — AHB master holds
+  //     the current HWDATA stable on the bus, AXI side is freely back-
+  //     pressurable.
+  //   • Cycle K+6 onward: B-wait. hready=axi.b_valid (i.e. 0 until B
+  //     arrives). When axi.b_valid=1, drive hready=1 + hresp from b_resp.
+  //
+  // INCR-undef (HBURST=1) is degraded to single-beat per AHB beat — the
+  // bridge can't know the length in advance and the v2 design doesn't
+  // include the HWDATA FIFO needed to buffer and forward the whole burst
+  // after detecting end-of-INCR. v3 will add the buffer.
+  //
+  // HBURST stable assumption: AHB-Lite requires the master to hold HBURST/
+  // HSIZE/HMASTLOCK stable across all beats of a burst. The bridge reads
+  // h.hburst directly in the loop bound and w_last comparison; no need to
+  // latch it.
   thread WriteXact on clk rising, rst low
     default comb
       h.hready  = true;
@@ -179,18 +203,24 @@ module Nic400AhbBridge
         axi.aw_prot   = h.hprot[2:0];
       until axi.aw_ready;
     end lock h_resp_lock
-    // W phase: now release AHB (hready=1) so HWDATA appears on the bus the
-    // next cycle. The lock body holds while we wait for w_ready, capturing
-    // HWDATA combinationally. STRB is fully on for single-beat at full width.
-    lock h_resp_lock
-      do
-        h.hready    = true;       // accept the data phase from AHB master
-        axi.w_valid = true;
-        axi.w_data  = h.hwdata;
-        axi.w_strb  = 15;
-        axi.w_last  = true;       // single-beat: every W beat is last
-      until axi.w_ready;
-    end lock h_resp_lock
+    // Spinup gap: AHB master needs one cycle after sampling hready=1 in the
+    // addr phase before HWDATA appears on the bus. Default comb in this state
+    // has h.hready=true (no lock), which is exactly what we need.
+    wait 1 cycle;
+    // W phase: forward axlen+1 beats. For HBURST=SINGLE, axlen=0 → loop
+    // iterates once. For HBURST=INCR4, axlen=3 → 4 iterations. STRB is fully
+    // on (every byte lane enabled at the full data width).
+    for b in 0..ahb_to_axi_len(h.hburst)
+      lock h_resp_lock
+        do
+          h.hready    = axi.w_ready;
+          axi.w_valid = true;
+          axi.w_data  = h.hwdata;
+          axi.w_strb  = 15;
+          axi.w_last  = (b == ahb_to_axi_len(h.hburst));
+        until axi.w_ready;
+      end lock h_resp_lock
+    end for
     // B phase: stall AHB, wait for B response, pulse hready=1 with HRESP.
     lock h_resp_lock
       do

--- a/tests/nic400/Nic400AhbBridge.arch
+++ b/tests/nic400/Nic400AhbBridge.arch
@@ -1,0 +1,203 @@
+// AHB-Lite ↔ AXI4 bridge module.
+//
+// Plugs an AHB-Lite master into the AXI4 fabric: the bridge presents an AHB
+// target on `h` and an AXI initiator on `axi`. Sized for the same DATA_W/
+// ADDR_W as the NIC-400 fabric so it can drop in as one of the fabric's
+// MasterPort upstreams (an AHB CPU port) or — by swapping `target`/`initiator`
+// — as one of the SlavePort downstreams (an AHB peripheral). v1 wires up the
+// AHB-master-side case; the slave-side mirror is a future extension.
+//
+// What v1 implements (verified):
+//   • Single-beat transfers (HBURST=SINGLE).
+//   • Independent read and write paths (two threads, no in-flight collision —
+//     AHB itself only allows one outstanding transaction so the threads
+//     time-share `h.hready`/`h.hrdata`/`h.hresp` through their default-comb
+//     drives + an h_resp_lock mutex on the active body).
+//   • HSIZE → AXI axsize (direct copy).
+//   • HPROT → AXI axprot (low 3 bits) and axcache (full 4 bits — close enough
+//     for the NIC-400 demo; ARM's real bridge has a configurable remap table).
+//   • HMASTLOCK → AXI axlock.
+//   • HBURST decoded on the AHB side via a module-local function so larger
+//     HBURST encodings are accepted on the wire (no protocol violation), but
+//     v1 only verifies SINGLE end-to-end. Multi-beat writes need additional
+//     HWDATA streaming + HREADY pacing logic that doesn't fit cleanly in a
+//     single thread state machine; tracked as a follow-on.
+//   • HRESP from AXI b_resp / r_resp: OKAY/EXOKAY → 0, SLVERR/DECERR → 1.
+//
+// Protocol timing (single-beat write):
+//   Cycle 0:   master drives NONSEQ+addr+HWRITE=1. Bridge sees this in its
+//              wait state and holds h.hready=false (stall the data phase).
+//   Cycle 0+: bridge issues AXI AW. Forks AW and W: AW finishes when
+//              axi.aw_ready=1; W requires HWDATA to have arrived, which can't
+//              happen until h.hready=1, so the sequence is AW first then a
+//              one-cycle h.hready=1 pulse to advance master to data phase,
+//              then W with HWDATA capture.
+//
+// Simplification (v1): we collapse the AW→W ordering by holding h.hready=true
+// in the *post*-AW state and capturing HWDATA combinationally — this works
+// because AHB master drives HWDATA the cycle after HREADY=1 in the addr
+// phase, and the bridge's lowered FSM has comb+seq within one state.
+module Nic400AhbBridge
+  param ADDR_WIDTH: const = 32;
+  param DATA_WIDTH: const = 32;
+  param STRB_WIDTH: const = 4;        // = DATA_WIDTH/8
+  param ID_WIDTH:   const = 3;
+
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Async, Low>;
+
+  // AHB-Lite target — bridge sees address/control as IN, drives status OUT.
+  port h:   target    BusAhbLite<ADDR_W=ADDR_WIDTH, DATA_W=DATA_WIDTH>;
+  // AXI initiator — bridge drives AR/AW/W, samples R/B.
+  port axi: initiator BusAxi4<ADDR_W=ADDR_WIDTH, DATA_W=DATA_WIDTH, STRB_W=STRB_WIDTH,
+                              ID_W=ID_WIDTH, READ=1, WRITE=1>;
+
+  // Mutex to serialise the multi-thread comb drives on h.hready/hrdata/hresp.
+  // The two threads can never both be active (AHB only has one outstanding),
+  // so contention is zero in steady state; the lock just keeps the
+  // multi-driver legal in the lowered FSM.
+  resource h_resp_lock: mutex<priority>;
+
+  // HBURST → AXI axlen mapping. Undefined-length INCR is degraded to single
+  // beat (axlen=0) — see file-level comment.
+  function ahb_to_axi_len(hburst: UInt<3>) -> UInt<8>
+    if (hburst == 0) or (hburst == 1)
+      return 0;
+    elsif (hburst == 2) or (hburst == 3)
+      return 3;
+    elsif (hburst == 4) or (hburst == 5)
+      return 7;
+    else
+      return 15;
+    end if
+  end function ahb_to_axi_len
+
+  // HBURST → AXI axburst (WRAP for HBURST=WRAP*, INCR otherwise).
+  function ahb_to_axi_burst(hburst: UInt<3>) -> UInt<2>
+    if (hburst == 2) or (hburst == 4) or (hburst == 6)
+      return 2;     // WRAP
+    else
+      return 1;     // INCR (SINGLE is also encoded as INCR with len=0 on AXI)
+    end if
+  end function ahb_to_axi_burst
+
+  // AXI {b,r}_resp → AHB HRESP. AXI OKAY=0, EXOKAY=1 → HRESP=0 (OKAY);
+  // SLVERR=2, DECERR=3 → HRESP=1 (ERROR).
+  function axi_resp_to_ahb(rsp: UInt<2>) -> Bool
+    return rsp[1];
+  end function axi_resp_to_ahb
+
+  // ── Read thread ──────────────────────────────────────────────────────
+  // Wait for AHB read address phase (HSEL && NONSEQ && !HWRITE), launch AR,
+  // forward R beats back as HRDATA pulses with HREADY.
+  thread ReadXact on clk rising, rst low
+    default comb
+      h.hready  = true;     // idle: ready (no transaction in flight)
+      h.hresp   = false;
+      h.hrdata  = 0;
+      axi.ar_valid  = false;
+      axi.ar_addr   = 0;
+      axi.ar_id     = 0;
+      axi.ar_len    = 0;
+      axi.ar_size   = 0;
+      axi.ar_burst  = 0;
+      axi.ar_lock   = false;
+      axi.ar_cache  = 0;
+      axi.ar_prot   = 0;
+      axi.ar_qos    = 0;
+      axi.ar_region = 0;
+      axi.r_ready   = false;
+    end default
+    wait 0+ cycle until h.hsel and (h.htrans == 2) and (not h.hwrite);
+    // AR phase: drive AR, stall the AHB data phase with hready=false until
+    // the AXI slave starts returning data.
+    lock h_resp_lock
+      do
+        h.hready      = false;
+        axi.ar_valid  = true;
+        axi.ar_addr   = h.haddr;
+        axi.ar_id     = 0;
+        axi.ar_size   = h.hsize;
+        axi.ar_len    = ahb_to_axi_len(h.hburst);
+        axi.ar_burst  = ahb_to_axi_burst(h.hburst);
+        axi.ar_lock   = h.hmastlock;
+        axi.ar_cache  = h.hprot;
+        axi.ar_prot   = h.hprot[2:0];
+      until axi.ar_ready;
+    end lock h_resp_lock
+    // R phase: each cycle r_valid=1, deliver one HRDATA beat with HREADY=1.
+    // Hold until r_last && r_ready (= r_valid here since we drive r_ready=1).
+    lock h_resp_lock
+      do
+        axi.r_ready = true;
+        h.hready    = axi.r_valid;
+        h.hrdata    = axi.r_data;
+        h.hresp     = axi_resp_to_ahb(axi.r_resp);
+      until axi.r_valid and axi.r_last;
+    end lock h_resp_lock
+  end thread ReadXact
+
+  // ── Write thread ─────────────────────────────────────────────────────
+  // Wait for AHB write address phase. Issue AW; stall hready until aw_ready;
+  // then pulse hready=1 in the cycle when HWDATA is on the bus and forward
+  // it as a single AXI W beat; then wait for B and signal HRESP back to AHB.
+  thread WriteXact on clk rising, rst low
+    default comb
+      h.hready  = true;
+      h.hresp   = false;
+      h.hrdata  = 0;
+      axi.aw_valid  = false;
+      axi.aw_addr   = 0;
+      axi.aw_id     = 0;
+      axi.aw_len    = 0;
+      axi.aw_size   = 0;
+      axi.aw_burst  = 0;
+      axi.aw_lock   = false;
+      axi.aw_cache  = 0;
+      axi.aw_prot   = 0;
+      axi.aw_qos    = 0;
+      axi.aw_region = 0;
+      axi.w_valid   = false;
+      axi.w_data    = 0;
+      axi.w_strb    = 0;
+      axi.w_last    = false;
+      axi.b_ready   = false;
+    end default
+    wait 0+ cycle until h.hsel and (h.htrans == 2) and h.hwrite;
+    // AW phase: stall the AHB data phase while we set up AW.
+    lock h_resp_lock
+      do
+        h.hready      = false;
+        axi.aw_valid  = true;
+        axi.aw_addr   = h.haddr;
+        axi.aw_id     = 0;
+        axi.aw_size   = h.hsize;
+        axi.aw_len    = ahb_to_axi_len(h.hburst);
+        axi.aw_burst  = ahb_to_axi_burst(h.hburst);
+        axi.aw_lock   = h.hmastlock;
+        axi.aw_cache  = h.hprot;
+        axi.aw_prot   = h.hprot[2:0];
+      until axi.aw_ready;
+    end lock h_resp_lock
+    // W phase: now release AHB (hready=1) so HWDATA appears on the bus the
+    // next cycle. The lock body holds while we wait for w_ready, capturing
+    // HWDATA combinationally. STRB is fully on for single-beat at full width.
+    lock h_resp_lock
+      do
+        h.hready    = true;       // accept the data phase from AHB master
+        axi.w_valid = true;
+        axi.w_data  = h.hwdata;
+        axi.w_strb  = 15;
+        axi.w_last  = true;       // single-beat: every W beat is last
+      until axi.w_ready;
+    end lock h_resp_lock
+    // B phase: stall AHB, wait for B response, pulse hready=1 with HRESP.
+    lock h_resp_lock
+      do
+        h.hready    = axi.b_valid;
+        h.hresp     = axi_resp_to_ahb(axi.b_resp);
+        axi.b_ready = true;
+      until axi.b_valid;
+    end lock h_resp_lock
+  end thread WriteXact
+end module Nic400AhbBridge

--- a/tests/nic400/Nic400Fabric.arch
+++ b/tests/nic400/Nic400Fabric.arch
@@ -1,20 +1,25 @@
-// Wiring harness — M MasterPort × N SlavePort.
+// Wiring harness — M MasterPort × N SlavePort (3×4 read/write).
 //
 // Spec §9: pure wiring; all real work lives in the per-master / per-slave
 // modules. Each (master_i, slave_j) edge is one bus carried by `edges[i][j]`
 // in a single 2D bus wire — the same wire cell that appears as
 // `mp_i.outs[j]` from the master side and `sp_j.ins[i]` from the slave side.
 //
-// Scaled via `generate_for` over both M and N. For M=N=2 today this
-// emits 2+2 = 4 inst declarations; for M=N=8 it would emit 16, all
-// from the same source.
+// Scaled via `generate_for` over both M and N. M=3, N=4 emits 3+4 = 7
+// inst declarations from the same source. Bumping to larger M/N is a
+// one-line change.
+//
+// Read/write enabled via `WRITE=1` on the bus type aliases. MasterPort
+// and SlavePort each carry full AR/R + AW/W/B thread sets.
 module Nic400Fabric
-  param NUM_MASTERS:   const = 2;
-  param NUM_SLAVES:    const = 2;
+  param NUM_MASTERS:   const = 3;
+  param NUM_SLAVES:    const = 4;
   param ADDR_WIDTH:    const = 32;
   param DATA_WIDTH:    const = 32;
+  param STRB_WIDTH:    const = 4;            // = DATA_WIDTH / 8
   param MASTER_ID_W:   const = 3;
-  param SLAVE_ID_W:    const = 4;        // MASTER_ID_W + ceil(log2(NUM_MASTERS))
+  param SLAVE_ID_W:    const = 5;            // MASTER_ID_W + ceil(log2(NUM_MASTERS))
+  param NS_W:          const = 2;            // ceil(log2(NUM_SLAVES))
 
   port clk: in Clock<SysDomain>;
   port rst: in Reset<Async, Low>;
@@ -23,13 +28,11 @@ module Nic400Fabric
   // deeply-nested `Vec<Vec<BusAxi4<...>, N>, M>` form doesn't fight the
   // grammar at use sites. Every port and wire below references the alias
   // as a bare identifier; the alias resolver inlines the full type before
-  // any downstream pass sees it. Master-side IDs are MASTER_ID_W wide;
-  // slave-side IDs are SLAVE_ID_W = MASTER_ID_W + ceil(log2(NUM_MASTERS))
-  // wide, since the MasterPort prepends the master_idx prefix.
-  type MasterBus = BusAxi4<ADDR_W=ADDR_WIDTH, DATA_W=DATA_WIDTH,
-                            ID_W=MASTER_ID_W, READ=1, WRITE=0>;
-  type SlaveBus  = BusAxi4<ADDR_W=ADDR_WIDTH, DATA_W=DATA_WIDTH,
-                            ID_W=SLAVE_ID_W,  READ=1, WRITE=0>;
+  // any downstream pass sees it.
+  type MasterBus = BusAxi4<ADDR_W=ADDR_WIDTH, DATA_W=DATA_WIDTH, STRB_W=STRB_WIDTH,
+                            ID_W=MASTER_ID_W, READ=1, WRITE=1>;
+  type SlaveBus  = BusAxi4<ADDR_W=ADDR_WIDTH, DATA_W=DATA_WIDTH, STRB_W=STRB_WIDTH,
+                            ID_W=SLAVE_ID_W,  READ=1, WRITE=1>;
 
   // System-facing master buses (parent perspective is target).
   port m: target Vec<MasterBus, NUM_MASTERS>;
@@ -41,6 +44,15 @@ module Nic400Fabric
   wire edges: Vec<Vec<SlaveBus, NUM_SLAVES>, NUM_MASTERS>;
 
   // ── M MasterPort instances ────────────────────────────────────────────
+  //
+  // Param-pass note: passing `param NUM_SLAVES = NUM_SLAVES` would alias the
+  // parent's param name through to the child, which the inst param-eval
+  // resolver can't unwind (it'd see the child's NUM_SLAVES default replaced
+  // by an Ident("NUM_SLAVES") and fail to evaluate `count_expr` for the
+  // child's Vec-of-bus port count). The child's defaults already match the
+  // Fabric's params, so we rely on them implicitly. If you bump the Fabric
+  // params, also bump the per-port defaults in Nic400MasterPort.arch /
+  // Nic400SlavePort.arch.
   generate_for i in 0..NUM_MASTERS-1
     inst mp_i: Nic400MasterPort
       param I = i;
@@ -52,11 +64,9 @@ module Nic400Fabric
   end generate_for
 
   // ── N SlavePort instances ─────────────────────────────────────────────
-  // Each slave_j gathers element [j] from every master's row of edges.
-  // The inner `for k in 0..NUM_MASTERS-1` is an inst-body unroll macro:
-  // at elaboration each iteration produces one `ins[k] <- edges[k][j]`
-  // Connection (AST-identical to the hand-enumerated form). Scales to
-  // arbitrary M without source changes.
+  // Each slave_j gathers element [j] from every master's row of edges via
+  // a nested for-loop that unrolls at elaboration into M `ins[k] <- edges[k][j]`
+  // connections.
   generate_for j in 0..NUM_SLAVES-1
     inst sp_j: Nic400SlavePort
       param J = j;

--- a/tests/nic400/Nic400MasterPort.arch
+++ b/tests/nic400/Nic400MasterPort.arch
@@ -1,44 +1,55 @@
-// Per-master decode + route block (read-only AR/R path).
+// Per-master decode + route block (full AR/R + AW/W/B path).
 //
 // Spec §7 shape: one M-facing bus target port + NUM_SLAVES outbound bus
 // initiator ports (Vec). On AR, the address decoder picks a slave; on R,
-// the high-bit of the returned slave-side id selects which slave's
-// return path drives the master.
+// the high MIDX_W bits of the returned slave-side id select which slave's
+// return path drives the master. Symmetric structure for AW/W/B.
 //
-// The per-master R-channel resource lock serialises the N return threads
-// onto the single master R bus (at most one slave responds per cycle by
-// AXI ID uniqueness, but the lock keeps the multi-driver legal).
+// Per-channel resource locks (ar_ch, r_ch, aw_ch, w_ch, b_ch) serialise
+// the multi-driver write to the shared m.* signals: with N per-slave
+// threads each driving the same master-side handshake outputs, the lock
+// keeps the multi-driver legal even though only one thread is in the
+// body at a time in steady state.
+//
+// W routing simplification (v1): each per-slave thread handles AW → W → B
+// for a transaction as one sequential chunk. The master sees back-pressure
+// (m.aw_ready=0) if a second AW for the same slave arrives before the
+// first completes. Cross-slave concurrency works (different threads),
+// but the same-slave pipeline depth is 1. The locks enforce W-beat
+// ordering when multiple slaves' threads contend.
 module Nic400MasterPort
   param I:             const = 0;        // this master's index, 0..NUM_MASTERS-1
-  param NUM_SLAVES:    const = 2;
+  param NUM_SLAVES:    const = 4;
   param ADDR_WIDTH:    const = 32;
   param DATA_WIDTH:    const = 32;
+  param STRB_WIDTH:    const = 4;
   param MASTER_ID_W:   const = 3;
-  param SLAVE_ID_W:    const = 4;        // MASTER_ID_W + ceil(log2(NUM_MASTERS))
-  param MIDX_W:        const = 1;        // ceil(log2(NUM_MASTERS))
+  param SLAVE_ID_W:    const = 5;        // MASTER_ID_W + ceil(log2(NUM_MASTERS))
+  param NS_W:          const = 2;        // ceil(log2(NUM_SLAVES))
   param REGION_BITS:   const = 28;
 
   port clk: in Clock<SysDomain>;
   port rst: in Reset<Async, Low>;
 
   // System-facing master port (target perspective).
-  port m:  target BusAxi4<ADDR_W=ADDR_WIDTH, DATA_W=DATA_WIDTH,
-                          ID_W=MASTER_ID_W, READ=1, WRITE=0>;
+  port m:  target BusAxi4<ADDR_W=ADDR_WIDTH, DATA_W=DATA_WIDTH, STRB_W=STRB_WIDTH,
+                          ID_W=MASTER_ID_W, READ=1, WRITE=1>;
 
   // Fabric-facing outbound buses, one per slave.
-  port outs: initiator Vec<BusAxi4<ADDR_W=ADDR_WIDTH, DATA_W=DATA_WIDTH,
-                                  ID_W=SLAVE_ID_W,  READ=1, WRITE=0>, NUM_SLAVES>;
+  port outs: initiator Vec<BusAxi4<ADDR_W=ADDR_WIDTH, DATA_W=DATA_WIDTH, STRB_W=STRB_WIDTH,
+                                  ID_W=SLAVE_ID_W,  READ=1, WRITE=1>, NUM_SLAVES>;
 
-  // Address decode: bit [REGION_BITS] picks slave (256 MiB regions in v1).
-  let m_ar_slv: UInt<1> = m.ar_addr[28];
+  // Address decode for AR/AW: top NS_W bits of the REGION_BITS-aligned page.
+  // For 4 slaves: ar_addr[29:28] picks 0..3. For 2 slaves: ar_addr[28] picks 0..1.
+  let m_ar_slv: UInt<NS_W> = m.ar_addr[REGION_BITS+NS_W-1:REGION_BITS];
+  let m_aw_slv: UInt<NS_W> = m.aw_addr[REGION_BITS+NS_W-1:REGION_BITS];
 
-  // Per-master R-channel arbiter — N slave-return threads serialise here.
-  resource r_ch: mutex<priority>;
-  // Per-master AR-driver arbiter — N AR forwarding threads (one per slave)
-  // are mutually exclusive on the address decode, but the multi-driver
-  // legality check still wants a single owner per cycle. The lock is
-  // structural; in steady state only one thread is in the body at a time.
+  // Per-channel arbiters — N per-slave threads contend on shared m.* drives.
   resource ar_ch: mutex<priority>;
+  resource r_ch:  mutex<priority>;
+  resource aw_ch: mutex<priority>;
+  resource w_ch:  mutex<priority>;
+  resource b_ch:  mutex<priority>;
 
   // ── AR forwarding threads — one per slave ──────────────────────────────
   generate_for j in 0..NUM_SLAVES-1
@@ -66,7 +77,6 @@ module Nic400MasterPort
           outs[j].ar_len    = m.ar_len;
           outs[j].ar_size   = m.ar_size;
           outs[j].ar_burst  = m.ar_burst;
-          // AXI4 sideband — pass through unchanged.
           outs[j].ar_lock   = m.ar_lock;
           outs[j].ar_cache  = m.ar_cache;
           outs[j].ar_prot   = m.ar_prot;
@@ -101,5 +111,74 @@ module Nic400MasterPort
         until m.r_ready and m.r_last;
       end lock r_ch
     end thread R_j
+  end generate_for
+
+  // ── AW → W → B threads — one per slave ────────────────────────────────
+  // Each thread handles a complete write transaction targeted at slave j.
+  // The aw_ch / w_ch / b_ch locks serialise multi-driver writes to the
+  // shared m.* signals across the N per-slave threads of this master.
+  generate_for j in 0..NUM_SLAVES-1
+    thread AwWb_j on clk rising, rst low
+      default comb
+        outs[j].aw_valid  = false;
+        outs[j].aw_addr   = 0;
+        outs[j].aw_id     = 0;
+        outs[j].aw_len    = 0;
+        outs[j].aw_size   = 0;
+        outs[j].aw_burst  = 0;
+        outs[j].aw_lock   = false;
+        outs[j].aw_cache  = 0;
+        outs[j].aw_prot   = 0;
+        outs[j].aw_qos    = 0;
+        outs[j].aw_region = 0;
+        outs[j].w_valid   = false;
+        outs[j].w_data    = 0;
+        outs[j].w_strb    = 0;
+        outs[j].w_last    = false;
+        outs[j].b_ready   = false;
+        m.aw_ready = false;
+        m.w_ready  = false;
+        m.b_valid  = false;
+        m.b_id     = 0;
+        m.b_resp   = 0;
+      end default
+      // AW phase: wait for master's AW and address-decode match.
+      wait 0+ cycle until m.aw_valid and m_aw_slv == j;
+      lock aw_ch
+        do
+          outs[j].aw_valid  = true;
+          outs[j].aw_addr   = m.aw_addr;
+          outs[j].aw_id     = (I.zext<SLAVE_ID_W>() << MASTER_ID_W) | m.aw_id.zext<SLAVE_ID_W>();
+          outs[j].aw_len    = m.aw_len;
+          outs[j].aw_size   = m.aw_size;
+          outs[j].aw_burst  = m.aw_burst;
+          outs[j].aw_lock   = m.aw_lock;
+          outs[j].aw_cache  = m.aw_cache;
+          outs[j].aw_prot   = m.aw_prot;
+          outs[j].aw_qos    = m.aw_qos;
+          outs[j].aw_region = m.aw_region;
+          m.aw_ready      = outs[j].aw_ready;
+        until outs[j].aw_ready;
+      end lock aw_ch
+      // W phase: forward each beat until w_last handshake fires.
+      lock w_ch
+        do
+          outs[j].w_valid = m.w_valid;
+          outs[j].w_data  = m.w_data;
+          outs[j].w_strb  = m.w_strb;
+          outs[j].w_last  = m.w_last;
+          m.w_ready     = outs[j].w_ready;
+        until m.w_valid and m.w_last and outs[j].w_ready;
+      end lock w_ch
+      // B phase: forward response back to master.
+      lock b_ch
+        do
+          m.b_valid = outs[j].b_valid;
+          m.b_id    = outs[j].b_id[MASTER_ID_W-1:0];
+          m.b_resp  = outs[j].b_resp;
+          outs[j].b_ready = m.b_ready;
+        until outs[j].b_valid and m.b_ready;
+      end lock b_ch
+    end thread AwWb_j
   end generate_for
 end module Nic400MasterPort

--- a/tests/nic400/Nic400Pmu.arch
+++ b/tests/nic400/Nic400Pmu.arch
@@ -1,0 +1,92 @@
+// NIC-400 performance monitor — per-master AR/AW/R/W/B handshake counters.
+//
+// Stand-alone instrumentation block. Inputs are pre-qualified handshake
+// "event" pulses — one Bool per master per channel that asserts on a single
+// clock cycle when the corresponding handshake fires (valid && ready). The
+// PMU just integrates these pulses into wide-counter regs and exposes them
+// as Vec outputs.
+//
+// To wire it into the existing Nic400Fabric, the caller computes per-master
+// event signals from the top-level master-side handshakes, e.g.:
+//
+//     let ar_event_i = m[i].ar_valid and m[i].ar_ready;
+//     inst pmu: Nic400Pmu
+//       param NUM_MASTERS = NUM_MASTERS;
+//       clk <- clk;
+//       rst <- rst;
+//       ar_event[i] <- ar_event_i;
+//       ...
+//     end inst pmu
+//
+// Stand-alone testability: a TB that drives synthetic event pulses on the
+// event_in ports validates the counter logic without needing a full fabric.
+//
+// Notes:
+//   • Counters saturate at 2^COUNTER_W-1 (no rollover suppression) — for a
+//     32-bit counter that's ~4.3B handshakes, more than enough for any
+//     verification run. Wrapping (`+%`) is used so the type-checker is happy
+//     about the +1 not producing a wider intermediate.
+//   • R counts beats (one per r_valid && r_ready cycle), so a 16-beat read
+//     burst increments r_count by 16. Same for W. AR/AW/B increment per
+//     transaction.
+//   • No clear/reset register interface in v1 — counters reset only on the
+//     module's `rst` line. A future revision could add a per-counter clear.
+module Nic400Pmu
+  param NUM_MASTERS: const = 3;
+  param COUNTER_W:   const = 32;
+
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Async, Low>;
+
+  // Per-master handshake event pulses (one cycle high when the corresponding
+  // valid && ready fires on the master-facing side of the fabric).
+  port ar_event: in Vec<Bool, NUM_MASTERS>;
+  port r_event:  in Vec<Bool, NUM_MASTERS>;
+  port aw_event: in Vec<Bool, NUM_MASTERS>;
+  port w_event:  in Vec<Bool, NUM_MASTERS>;
+  port b_event:  in Vec<Bool, NUM_MASTERS>;
+
+  // Per-master counter outputs.
+  port ar_count: out Vec<UInt<COUNTER_W>, NUM_MASTERS>;
+  port r_count:  out Vec<UInt<COUNTER_W>, NUM_MASTERS>;
+  port aw_count: out Vec<UInt<COUNTER_W>, NUM_MASTERS>;
+  port w_count:  out Vec<UInt<COUNTER_W>, NUM_MASTERS>;
+  port b_count:  out Vec<UInt<COUNTER_W>, NUM_MASTERS>;
+
+  reg default: reset rst => 0;
+  reg ar_cnt_r: Vec<UInt<COUNTER_W>, NUM_MASTERS>;
+  reg r_cnt_r:  Vec<UInt<COUNTER_W>, NUM_MASTERS>;
+  reg aw_cnt_r: Vec<UInt<COUNTER_W>, NUM_MASTERS>;
+  reg w_cnt_r:  Vec<UInt<COUNTER_W>, NUM_MASTERS>;
+  reg b_cnt_r:  Vec<UInt<COUNTER_W>, NUM_MASTERS>;
+
+  seq on clk rising
+    for i in 0..NUM_MASTERS-1
+      if ar_event[i]
+        ar_cnt_r[i] <= ar_cnt_r[i] +% 1;
+      end if
+      if r_event[i]
+        r_cnt_r[i] <= r_cnt_r[i] +% 1;
+      end if
+      if aw_event[i]
+        aw_cnt_r[i] <= aw_cnt_r[i] +% 1;
+      end if
+      if w_event[i]
+        w_cnt_r[i] <= w_cnt_r[i] +% 1;
+      end if
+      if b_event[i]
+        b_cnt_r[i] <= b_cnt_r[i] +% 1;
+      end if
+    end for
+  end seq
+
+  comb
+    for i in 0..NUM_MASTERS-1
+      ar_count[i] = ar_cnt_r[i];
+      r_count[i]  = r_cnt_r[i];
+      aw_count[i] = aw_cnt_r[i];
+      w_count[i]  = w_cnt_r[i];
+      b_count[i]  = b_cnt_r[i];
+    end for
+  end comb
+end module Nic400Pmu

--- a/tests/nic400/Nic400SlavePort.arch
+++ b/tests/nic400/Nic400SlavePort.arch
@@ -1,36 +1,43 @@
-// Per-slave arbitration + return block (read-only AR/R path).
+// Per-slave arbitration + return block (full AR/R + AW/W/B path).
 //
 // Spec §8 shape: one S-facing bus initiator port + NUM_MASTERS inbound
 // bus target ports (Vec). M AR-arbiter threads (one per master) contend
 // on a shared lock to drive the slave's AR; M R-return threads (one
 // per master) decode the slave's r_id high bits and route the beat back
-// to the matching master.
+// to the matching master. Symmetric structure for AW/W/B.
+//
+// W routing simplification (v1): each per-master thread handles
+// AW → W → B for a transaction as one sequential chunk. With the
+// MasterPort doing the same on its side, the (master, slave) pair
+// processes one outstanding write at a time. Per-master concurrency
+// across different slaves works (independent threads); same-slave
+// pipelining is depth 1.
 module Nic400SlavePort
   param J:             const = 0;        // this slave's index, 0..NUM_SLAVES-1
-  param NUM_MASTERS:   const = 2;
+  param NUM_MASTERS:   const = 3;
   param ADDR_WIDTH:    const = 32;
   param DATA_WIDTH:    const = 32;
+  param STRB_WIDTH:    const = 4;
   param MASTER_ID_W:   const = 3;
-  param SLAVE_ID_W:    const = 4;        // MASTER_ID_W + ceil(log2(NUM_MASTERS))
+  param SLAVE_ID_W:    const = 5;        // MASTER_ID_W + ceil(log2(NUM_MASTERS))
 
   port clk: in Clock<SysDomain>;
   port rst: in Reset<Async, Low>;
 
   // System-facing slave port (initiator perspective — this module drives s.ar_valid etc.).
-  port s: initiator BusAxi4<ADDR_W=ADDR_WIDTH, DATA_W=DATA_WIDTH,
-                            ID_W=SLAVE_ID_W, READ=1, WRITE=0>;
+  port s: initiator BusAxi4<ADDR_W=ADDR_WIDTH, DATA_W=DATA_WIDTH, STRB_W=STRB_WIDTH,
+                            ID_W=SLAVE_ID_W, READ=1, WRITE=1>;
 
   // Fabric-facing inbound buses, one per master.
-  port ins: target Vec<BusAxi4<ADDR_W=ADDR_WIDTH, DATA_W=DATA_WIDTH,
-                                  ID_W=SLAVE_ID_W, READ=1, WRITE=0>, NUM_MASTERS>;
+  port ins: target Vec<BusAxi4<ADDR_W=ADDR_WIDTH, DATA_W=DATA_WIDTH, STRB_W=STRB_WIDTH,
+                                  ID_W=SLAVE_ID_W, READ=1, WRITE=1>, NUM_MASTERS>;
 
-  // AR arbiter — M masters serialise onto s.ar_*. Priority for now;
-  // arch sim's `--thread-sim parallel` path supports priority only in v1.
-  // Switch to round_robin when the parallel sim extends its policy set.
-  resource ar_lock: mutex<priority>;
-  // R demux serializer — at most one master matches the slave's r_id prefix
-  // per cycle by AXI ID uniqueness; the lock keeps the multi-driver legal.
-  resource r_demux_lock: mutex<priority>;
+  // Per-channel arbiters — M per-master threads contend on shared s.* drives.
+  resource ar_lock:       mutex<priority>;
+  resource r_demux_lock:  mutex<priority>;
+  resource aw_lock:       mutex<priority>;
+  resource w_lock:        mutex<priority>;
+  resource b_demux_lock:  mutex<priority>;
 
   // ── AR arbiter — one thread per master ─────────────────────────────────
   generate_for i in 0..NUM_MASTERS-1
@@ -93,5 +100,76 @@ module Nic400SlavePort
         until ins[i].r_ready and ins[i].r_last;
       end lock r_demux_lock
     end thread RDemux_i
+  end generate_for
+
+  // ── AW → W → B threads — one per master ────────────────────────────────
+  // Each thread handles a complete write transaction originating from
+  // master i. The aw_lock / w_lock / b_demux_lock resources serialise
+  // multi-master contention on the shared s.* signals; cross-master
+  // pipelining works because each master's thread runs independently
+  // until it grabs a contended lock.
+  generate_for i in 0..NUM_MASTERS-1
+    thread AwWb_i on clk rising, rst low
+      default comb
+        s.aw_valid  = false;
+        s.aw_addr   = 0;
+        s.aw_id     = 0;
+        s.aw_len    = 0;
+        s.aw_size   = 0;
+        s.aw_burst  = 0;
+        s.aw_lock   = false;
+        s.aw_cache  = 0;
+        s.aw_prot   = 0;
+        s.aw_qos    = 0;
+        s.aw_region = 0;
+        s.w_valid   = false;
+        s.w_data    = 0;
+        s.w_strb    = 0;
+        s.w_last    = false;
+        s.b_ready   = false;
+        ins[i].aw_ready = false;
+        ins[i].w_ready  = false;
+        ins[i].b_valid  = false;
+        ins[i].b_id     = 0;
+        ins[i].b_resp   = 0;
+      end default
+      // AW phase
+      wait 0+ cycle until ins[i].aw_valid;
+      lock aw_lock
+        do
+          s.aw_valid  = true;
+          s.aw_addr   = ins[i].aw_addr;
+          s.aw_id     = ins[i].aw_id;     // already prefixed by master port
+          s.aw_len    = ins[i].aw_len;
+          s.aw_size   = ins[i].aw_size;
+          s.aw_burst  = ins[i].aw_burst;
+          s.aw_lock   = ins[i].aw_lock;
+          s.aw_cache  = ins[i].aw_cache;
+          s.aw_prot   = ins[i].aw_prot;
+          s.aw_qos    = ins[i].aw_qos;
+          s.aw_region = ins[i].aw_region;
+          ins[i].aw_ready = s.aw_ready;
+        until s.aw_ready;
+      end lock aw_lock
+      // W phase: forward each beat until w_last handshake fires.
+      lock w_lock
+        do
+          s.w_valid = ins[i].w_valid;
+          s.w_data  = ins[i].w_data;
+          s.w_strb  = ins[i].w_strb;
+          s.w_last  = ins[i].w_last;
+          ins[i].w_ready = s.w_ready;
+        until ins[i].w_valid and ins[i].w_last and s.w_ready;
+      end lock w_lock
+      // B phase: demux back to the originating master by id prefix match.
+      lock b_demux_lock
+        do
+          ins[i].b_valid = s.b_valid and s.b_id[SLAVE_ID_W-1:MASTER_ID_W] == i;
+          ins[i].b_id    = s.b_id;
+          ins[i].b_resp  = s.b_resp;
+          s.b_ready = ins[i].b_ready;
+        until s.b_valid and s.b_id[SLAVE_ID_W-1:MASTER_ID_W] == i and ins[i].b_ready;
+      end lock b_demux_lock
+    end thread AwWb_i
   end generate_for
 end module Nic400SlavePort

--- a/tests/nic400/tb_nic400_ahb_bridge.cpp
+++ b/tests/nic400/tb_nic400_ahb_bridge.cpp
@@ -1,0 +1,176 @@
+// AHB-Lite ↔ AXI4 bridge smoke test.
+//
+// Single-beat read and write. The TB plays the AHB master AND the AXI slave,
+// drives a NONSEQ address phase, and checks that:
+//   • The bridge launches AR (or AW) with HSIZE/HBURST/HMASTLOCK forwarded.
+//   • For reads: when the TB returns an R beat from the AXI side, the bridge
+//     pulses HREADY=1 with HRDATA = the returned data.
+//   • For writes: when the bridge sees HWDATA, it issues a W beat; the TB
+//     captures it, returns a B response, and the bridge pulses HREADY=1
+//     with HRESP from b_resp.
+//
+// As with the fabric write TB, we sample on pre_edge() so we observe Mealy
+// drives BEFORE the lowered FSM advances past the handshake state.
+
+#include "VNic400AhbBridge.h"
+#include <cstdint>
+#include <cstdio>
+
+static VNic400AhbBridge dut;
+static uint64_t cycle = 0;
+
+static void tick() { dut.clk = 0; dut.eval(); dut.clk = 1; dut.eval(); cycle++; }
+static void pre_edge()  { dut.clk = 0; dut.eval(); }
+static void post_edge() { dut.clk = 1; dut.eval(); cycle++; }
+
+static void clear_inputs() {
+    // AHB master-driven (TB drives, bridge sees IN).
+    dut.h_hsel = 0; dut.h_haddr = 0; dut.h_hwrite = 0;
+    dut.h_hsize = 0; dut.h_hburst = 0; dut.h_hprot = 0;
+    dut.h_htrans = 0; dut.h_hmastlock = 0; dut.h_hwdata = 0;
+    // AXI slave-driven (TB drives, bridge sees IN).
+    dut.axi_ar_ready = 0;
+    dut.axi_r_valid = 0; dut.axi_r_data = 0; dut.axi_r_id = 0;
+    dut.axi_r_resp = 0; dut.axi_r_last = 0;
+    dut.axi_aw_ready = 0;
+    dut.axi_w_ready = 0;
+    dut.axi_b_valid = 0; dut.axi_b_id = 0; dut.axi_b_resp = 0;
+}
+
+static int fail(const char* m) { std::printf("FAIL %s (cycle=%llu)\n", m, (unsigned long long)cycle); return 1; }
+
+// Single-beat AHB read: TB drives NONSEQ+!HWRITE+addr, plays AXI slave.
+// expect: bridge issues AR (we ack), then drives one R beat back from us, and
+// pulses HREADY=1 with HRDATA. HSIZE forwarded to ar_size; HMASTLOCK to ar_lock.
+static int do_read(uint32_t addr, unsigned hsize, unsigned hburst,
+                   unsigned hprot, bool hmastlock, uint32_t rdata) {
+    // Cycle 0: drive AHB address phase.
+    dut.h_hsel = 1; dut.h_haddr = addr; dut.h_hwrite = 0;
+    dut.h_hsize = hsize; dut.h_hburst = hburst; dut.h_hprot = hprot;
+    dut.h_htrans = 2; dut.h_hmastlock = hmastlock ? 1 : 0;
+
+    // Be ready to ack AR immediately.
+    dut.axi_ar_ready = 1;
+
+    int ar_seen = 0;
+    for (int i = 0; i < 32 && !ar_seen; ++i) {
+        pre_edge();
+        if (dut.axi_ar_valid && dut.axi_ar_ready) {
+            ar_seen = 1;
+            if (dut.axi_ar_addr != addr) return fail("AR addr mismatch");
+            if (dut.axi_ar_size != hsize) return fail("AR size mismatch");
+            if ((unsigned)dut.axi_ar_lock != (hmastlock ? 1u : 0u)) return fail("AR lock mismatch");
+            if (dut.axi_ar_cache != hprot) return fail("AR cache (=hprot) mismatch");
+            if (dut.h_hready) return fail("HREADY should be low during AR stall");
+        }
+        post_edge();
+    }
+    if (!ar_seen) return fail("AR never observed");
+    dut.axi_ar_ready = 0;
+
+    // Drop AHB address phase signals; master moves to data phase / idle.
+    dut.h_hsel = 0; dut.h_htrans = 0;
+
+    // Drive the AXI R beat with the requested data.
+    dut.axi_r_valid = 1; dut.axi_r_data = rdata; dut.axi_r_resp = 0; dut.axi_r_last = 1;
+
+    int r_seen = 0;
+    for (int i = 0; i < 32 && !r_seen; ++i) {
+        pre_edge();
+        if (dut.h_hready && (uint32_t)dut.h_hrdata == rdata && !dut.h_hresp) {
+            r_seen = 1;
+        }
+        post_edge();
+    }
+    if (!r_seen) return fail("R beat never delivered to AHB master with correct data");
+    dut.axi_r_valid = 0; dut.axi_r_data = 0; dut.axi_r_last = 0;
+    tick();
+    return 0;
+}
+
+// Single-beat AHB write: TB drives NONSEQ+HWRITE+addr, holds HWDATA next cycle,
+// plays AXI slave (acks AW, captures W, returns B).
+static int do_write(uint32_t addr, unsigned hsize, unsigned hburst,
+                    unsigned hprot, bool hmastlock, uint32_t wdata, unsigned bresp) {
+    dut.h_hsel = 1; dut.h_haddr = addr; dut.h_hwrite = 1;
+    dut.h_hsize = hsize; dut.h_hburst = hburst; dut.h_hprot = hprot;
+    dut.h_htrans = 2; dut.h_hmastlock = hmastlock ? 1 : 0;
+
+    dut.axi_aw_ready = 1;
+    dut.axi_w_ready  = 1;
+
+    int aw_seen = 0;
+    for (int i = 0; i < 32 && !aw_seen; ++i) {
+        pre_edge();
+        if (dut.axi_aw_valid && dut.axi_aw_ready) {
+            aw_seen = 1;
+            if (dut.axi_aw_addr != addr) return fail("AW addr mismatch");
+            if (dut.axi_aw_size != hsize) return fail("AW size mismatch");
+            if ((unsigned)dut.axi_aw_lock != (hmastlock ? 1u : 0u)) return fail("AW lock mismatch");
+        }
+        post_edge();
+    }
+    if (!aw_seen) return fail("AW never observed");
+    dut.axi_aw_ready = 0;
+
+    // AW done — bridge now pulses HREADY=1 to advance master into data phase.
+    // Master places HWDATA on the bus the cycle after sampling HREADY=1, so
+    // we model the same: drop HSEL/HTRANS now (no further AHB request) and
+    // present HWDATA.
+    dut.h_hsel = 0; dut.h_htrans = 0;
+    dut.h_hwdata = wdata;
+
+    int w_seen = 0;
+    for (int i = 0; i < 32 && !w_seen; ++i) {
+        pre_edge();
+        if (dut.axi_w_valid && dut.axi_w_ready) {
+            w_seen = 1;
+            if (dut.axi_w_data != wdata) return fail("W data mismatch");
+            if (!dut.axi_w_last) return fail("W last must be 1 for single-beat");
+            if (dut.axi_w_strb != 0xF) return fail("W strb mismatch (expected 0xF for full-width)");
+        }
+        post_edge();
+    }
+    if (!w_seen) return fail("W never observed");
+    dut.axi_w_ready = 0;
+    dut.h_hwdata = 0;
+
+    // Drive B response.
+    dut.axi_b_valid = 1; dut.axi_b_resp = bresp;
+
+    int b_to_ahb = 0;
+    for (int i = 0; i < 32 && !b_to_ahb; ++i) {
+        pre_edge();
+        if (dut.h_hready) {
+            // Expect HRESP to mirror bresp[1] (0/1 → 0 (OKAY), 2/3 → 1 (ERROR)).
+            unsigned expect_hresp = (bresp >> 1) & 1;
+            if (((unsigned)dut.h_hresp & 1) != expect_hresp) return fail("HRESP mismatch");
+            b_to_ahb = 1;
+        }
+        post_edge();
+    }
+    if (!b_to_ahb) return fail("B response never propagated to AHB HREADY");
+    dut.axi_b_valid = 0; dut.axi_b_resp = 0;
+    tick();
+    return 0;
+}
+
+int main() {
+    dut.rst = 0;
+    clear_inputs();
+    for (int i = 0; i < 4; ++i) tick();
+    dut.rst = 1;
+    for (int i = 0; i < 3; ++i) tick();
+
+    // Read: hsize=2 (word), hburst=0 (SINGLE), hprot=0xB, hmastlock=0.
+    if (do_read(0x1000, 2, 0, 0xB, false, 0xDEADBEEFu)) return 1;
+    // Read with HMASTLOCK=1.
+    if (do_read(0x2004, 2, 0, 0x3, true,  0xCAFE0001u)) return 1;
+    // Write OKAY.
+    if (do_write(0x3000, 2, 0, 0x7, false, 0xA5A5A5A5u, 0)) return 1;
+    // Write SLVERR (bresp=2 → HRESP=1).
+    if (do_write(0x4000, 2, 0, 0x7, false, 0x5A5A5A5Au, 2)) return 1;
+
+    std::printf("PASS Nic400AhbBridge: 2 reads + 2 writes (1 OKAY, 1 SLVERR) round-trip\n");
+    return 0;
+}

--- a/tests/nic400/tb_nic400_ahb_bridge_burst.cpp
+++ b/tests/nic400/tb_nic400_ahb_bridge_burst.cpp
@@ -1,0 +1,205 @@
+// Multi-beat AHB-Lite write burst test for the Nic400AhbBridge v2.
+//
+// Models the AHB master pipeline (addr_idx, data_idx) and drives HSEL/
+// HTRANS/HADDR/HWDATA accordingly each cycle, advancing on HREADY=1 sampled
+// at the end of the cycle. Plays the AXI slave too: acks AW, captures W
+// beats, returns a B response after the last W beat.
+//
+// Coverage:
+//   • INCR4 (4-beat burst): no backpressure. Verifies axlen=3, ascending
+//     HWDATA streams as ascending AXI W beats, w_last on the 4th.
+//   • INCR4 with mid-burst AXI backpressure (w_ready=0 for 2 cycles in the
+//     middle): verifies that the AHB master gets stalled (HWDATA stays
+//     stable) and resumes correctly.
+//   • INCR8 (8-beat) clean: verifies axlen=7.
+//
+// Same pre_edge/post_edge split-tick pattern as the other TBs so we observe
+// Mealy drives before the lowered FSM advances past them.
+
+#include "VNic400AhbBridge.h"
+#include <cstdint>
+#include <cstdio>
+
+static VNic400AhbBridge dut;
+static uint64_t cycle = 0;
+
+static void tick() { dut.clk = 0; dut.eval(); dut.clk = 1; dut.eval(); cycle++; }
+static void pre_edge()  { dut.clk = 0; dut.eval(); }
+static void post_edge() { dut.clk = 1; dut.eval(); cycle++; }
+
+static void clear_inputs() {
+    dut.h_hsel = 0; dut.h_haddr = 0; dut.h_hwrite = 0;
+    dut.h_hsize = 0; dut.h_hburst = 0; dut.h_hprot = 0;
+    dut.h_htrans = 0; dut.h_hmastlock = 0; dut.h_hwdata = 0;
+    dut.axi_ar_ready = 0;
+    dut.axi_r_valid = 0; dut.axi_r_data = 0; dut.axi_r_id = 0;
+    dut.axi_r_resp = 0; dut.axi_r_last = 0;
+    dut.axi_aw_ready = 0; dut.axi_w_ready = 0;
+    dut.axi_b_valid = 0; dut.axi_b_id = 0; dut.axi_b_resp = 0;
+}
+
+static int fail(const char* m) { std::printf("FAIL %s (cycle=%llu)\n", m, (unsigned long long)cycle); return 1; }
+
+// Drive AHB master signals given the current pipeline indices.
+//   addr_idx: index of the beat currently in the address phase (0..n_beats);
+//             == n_beats means "no more addr phases to drive" (IDLE).
+//   data_idx: index of the beat currently in the data phase (-1 before first
+//             advance, then 0..n_beats-1 during streaming, == n_beats after
+//             last beat).
+static void drive_master(uint32_t addr_base, unsigned hburst, unsigned hsize,
+                         const uint32_t* data, unsigned n_beats,
+                         int addr_idx, int data_idx) {
+    if (addr_idx < (int)n_beats) {
+        dut.h_hsel    = 1;
+        dut.h_haddr   = addr_base + addr_idx * 4;
+        dut.h_hwrite  = 1;
+        dut.h_hsize   = hsize;
+        dut.h_hburst  = hburst;
+        dut.h_hprot   = 0;
+        dut.h_htrans  = (addr_idx == 0) ? 2 : 3;   // NONSEQ first, then SEQ
+        dut.h_hmastlock = 0;
+    } else {
+        dut.h_hsel    = 0;
+        dut.h_htrans  = 0;
+    }
+    dut.h_hwdata = (data_idx >= 0 && data_idx < (int)n_beats) ? data[data_idx] : 0;
+}
+
+// Run a multi-beat write burst. `backpressure_at_beat` (-1 to disable) holds
+// axi.w_ready=0 for `backpressure_cycles` cycles when the bridge is in the
+// W loop for that beat index. Returns 0 on success.
+static int do_write_burst(uint32_t addr_base, unsigned hburst, unsigned hsize,
+                          const uint32_t* data, unsigned n_beats,
+                          unsigned expect_axlen, unsigned bresp,
+                          int backpressure_at_beat, int backpressure_cycles) {
+    int addr_idx = 0;
+    int data_idx = -1;
+    int aw_acked = 0;
+    unsigned beats_received = 0;
+    int w_last_seen_on = -1;
+    uint32_t w_data_log[32];
+    int b_phase_done = 0;
+    int bp_remaining = 0;
+
+    dut.axi_aw_ready = 1;
+    dut.axi_w_ready  = 1;
+
+    for (int c = 0; c < 256 && !b_phase_done; ++c) {
+        drive_master(addr_base, hburst, hsize, data, n_beats, addr_idx, data_idx);
+
+        // Backpressure controller: if we're at the target beat and w_valid is
+        // about to be asserted, drop w_ready for the configured cycle count.
+        if (backpressure_at_beat >= 0 && (int)beats_received == backpressure_at_beat && bp_remaining == 0 && backpressure_cycles > 0) {
+            // Trigger only once.
+            bp_remaining = backpressure_cycles;
+            backpressure_cycles = 0;
+        }
+        if (bp_remaining > 0) {
+            dut.axi_w_ready = 0;
+        } else {
+            dut.axi_w_ready = 1;
+        }
+
+        // Drive B after the last W beat is sent (so the bridge picks it up in
+        // the B-wait state on a later cycle).
+        if (beats_received == n_beats && !dut.axi_b_valid) {
+            dut.axi_b_valid = 1;
+            dut.axi_b_resp  = bresp;
+        }
+
+        pre_edge();
+
+        // Sample bridge outputs (pre-edge: comb settled with current state).
+        int hready_now = dut.h_hready ? 1 : 0;
+
+        if (!aw_acked && dut.axi_aw_valid && dut.axi_aw_ready) {
+            aw_acked = 1;
+            if (dut.axi_aw_addr != addr_base) return fail("AW addr mismatch");
+            if (dut.axi_aw_len  != expect_axlen) return fail("AW len mismatch");
+            if (dut.axi_aw_size != hsize) return fail("AW size mismatch");
+        }
+        if (dut.axi_w_valid && dut.axi_w_ready) {
+            if (beats_received >= 32) return fail("more W beats than expected");
+            w_data_log[beats_received] = (uint32_t)dut.axi_w_data;
+            if (dut.axi_w_last) w_last_seen_on = (int)beats_received;
+            beats_received++;
+        }
+        if (beats_received == n_beats && dut.axi_b_valid && hready_now) {
+            // Bridge has pulsed hready in B phase — check HRESP.
+            unsigned expect_hresp = (bresp >> 1) & 1;
+            if ((unsigned)dut.h_hresp != expect_hresp) return fail("HRESP mismatch");
+            b_phase_done = 1;
+        }
+
+        post_edge();
+
+        // Advance AHB pipeline based on HREADY observed during the cycle.
+        if (hready_now) {
+            if (data_idx >= 0) data_idx++;
+            if (addr_idx < (int)n_beats) {
+                if (data_idx < 0) data_idx = 0;
+                addr_idx++;
+            }
+        }
+        if (bp_remaining > 0) bp_remaining--;
+    }
+
+    if (!b_phase_done) return fail("burst never completed");
+    if (beats_received != n_beats) return fail("wrong number of W beats");
+    if (w_last_seen_on != (int)n_beats - 1) {
+        std::printf("FAIL w_last fired on beat %d, expected %u\n", w_last_seen_on, n_beats - 1);
+        return 1;
+    }
+    for (unsigned i = 0; i < n_beats; ++i) {
+        if (w_data_log[i] != data[i]) {
+            std::printf("FAIL W beat %u: got 0x%x, expected 0x%x\n", i, w_data_log[i], data[i]);
+            return 1;
+        }
+    }
+
+    // Cleanup.
+    dut.axi_b_valid = 0; dut.axi_w_ready = 0; dut.axi_aw_ready = 0;
+    dut.h_hsel = 0; dut.h_htrans = 0; dut.h_hwdata = 0;
+    tick();
+    return 0;
+}
+
+int main() {
+    dut.rst = 0;
+    clear_inputs();
+    for (int i = 0; i < 4; ++i) tick();
+    dut.rst = 1;
+    for (int i = 0; i < 3; ++i) tick();
+
+    // INCR4 clean (no backpressure). HBURST=3 → axlen=3 (4 beats).
+    {
+        uint32_t data[4] = { 0x11111111u, 0x22222222u, 0x33333333u, 0x44444444u };
+        if (do_write_burst(0x1000, 3, 2, data, 4, 3, 0, -1, 0)) return 1;
+        std::printf("  OK INCR4 clean\n");
+    }
+
+    // INCR4 with backpressure at beat 1 (w_ready=0 for 2 cycles).
+    {
+        uint32_t data[4] = { 0xAAAA0000u, 0xAAAA1111u, 0xAAAA2222u, 0xAAAA3333u };
+        if (do_write_burst(0x2000, 3, 2, data, 4, 3, 0, 1, 2)) return 1;
+        std::printf("  OK INCR4 with backpressure at beat 1 (2 cyc)\n");
+    }
+
+    // INCR8 clean (HBURST=5 → axlen=7, 8 beats).
+    {
+        uint32_t data[8];
+        for (int i = 0; i < 8; ++i) data[i] = 0xC0DE0000u | i;
+        if (do_write_burst(0x3000, 5, 2, data, 8, 7, 0, -1, 0)) return 1;
+        std::printf("  OK INCR8 clean\n");
+    }
+
+    // INCR4 with SLVERR.
+    {
+        uint32_t data[4] = { 0xBEEF0000u, 0xBEEF1111u, 0xBEEF2222u, 0xBEEF3333u };
+        if (do_write_burst(0x4000, 3, 2, data, 4, 3, 2, -1, 0)) return 1;
+        std::printf("  OK INCR4 SLVERR\n");
+    }
+
+    std::printf("PASS Nic400AhbBridge burst: INCR4 + backpressure + INCR8 + SLVERR\n");
+    return 0;
+}

--- a/tests/nic400/tb_nic400_fabric_write.cpp
+++ b/tests/nic400/tb_nic400_fabric_write.cpp
@@ -1,0 +1,186 @@
+// 3x4 write-path smoke test for the Nic400Fabric.
+//
+// Covers the AW → W → B path on the new 3×4 R/W fabric. Strategy: drive
+// AW, W, and slave-side ready/b_valid/b_id all at once (AXI4 permits W
+// to race AR/AW), and observe the master-side B handshake as the proof
+// that the AW + W phases completed correctly. Direct observation of the
+// AW/W mid-cycle is awkward because the Mealy thread fuses the handshake
+// + transition into a single eval; the TB sees post-handshake state by
+// the time it polls.
+//
+// Per-handshake checks:
+//   1. s.aw_id has the master_idx prefix in the high MIDX_W bits.
+//   2. s.w_data is the value the master drove.
+//   3. m.b_id has the prefix stripped (returns the original master_id).
+//   4. No other slave's s.aw_valid or master's m.b_valid was asserted.
+
+#include "VNic400Fabric.h"
+#include <cstdint>
+#include <cstdio>
+
+static VNic400Fabric dut;
+static uint64_t cycle = 0;
+
+static void tick() {
+    dut.clk = 0; dut.eval();
+    dut.clk = 1; dut.eval();
+    cycle++;
+}
+
+// Pre-edge sample: settle comb with clk=0 so the TB can observe Mealy-style
+// handshake signals (s.aw_valid && s.aw_ready etc.) BEFORE the rising edge
+// advances state into the next phase. Pair with post_edge() to complete one
+// full clock cycle.
+static void pre_edge() {
+    dut.clk = 0; dut.eval();
+}
+static void post_edge() {
+    dut.clk = 1; dut.eval();
+    cycle++;
+}
+
+static void clear_inputs() {
+    for (int i = 0; i < 3; ++i) {
+        dut.m_ar_valid[i] = 0; dut.m_ar_addr[i] = 0; dut.m_ar_id[i] = 0;
+        dut.m_ar_len[i] = 0;   dut.m_ar_size[i] = 0; dut.m_ar_burst[i] = 0;
+        dut.m_r_ready[i] = 0;
+        dut.m_aw_valid[i] = 0; dut.m_aw_addr[i] = 0; dut.m_aw_id[i] = 0;
+        dut.m_aw_len[i] = 0;   dut.m_aw_size[i] = 0; dut.m_aw_burst[i] = 0;
+        dut.m_w_valid[i] = 0;  dut.m_w_data[i] = 0;  dut.m_w_strb[i] = 0;
+        dut.m_w_last[i] = 0;
+        dut.m_b_ready[i] = 0;
+    }
+    for (int j = 0; j < 4; ++j) {
+        dut.s_ar_ready[j] = 0;
+        dut.s_r_valid[j] = 0; dut.s_r_data[j] = 0; dut.s_r_id[j] = 0;
+        dut.s_r_resp[j] = 0;  dut.s_r_last[j] = 0;
+        dut.s_aw_ready[j] = 0;
+        dut.s_w_ready[j] = 0;
+        dut.s_b_valid[j] = 0; dut.s_b_id[j] = 0; dut.s_b_resp[j] = 0;
+    }
+}
+
+static int fail(const char* msg) {
+    std::printf("FAIL %s (cycle=%llu)\n", msg, (unsigned long long)cycle);
+    return 1;
+}
+
+// Issue one single-beat write from `master` to `slave` (address chooses slave
+// via address bits [REGION_BITS+NS_W-1:REGION_BITS]). The slave-side b_id
+// must come back with the master-idx prefix; the master must see b_id with
+// the prefix stripped.
+//
+// Drive AW, W, and slave-side ready/b_valid all together. Track which side
+// of the handshake we've observed via flags. When the master sees its B
+// handshake, the entire AW → W → B sequence has completed.
+static int do_write(unsigned master, unsigned addr_high_bits,
+                    unsigned slave, unsigned master_id, uint32_t data) {
+    uint32_t addr = (slave << 28) | (addr_high_bits << 12) | 0x0;
+    unsigned expect_slave_id = ((master & 0x3) << 3) | (master_id & 0x7);
+
+    dut.m_aw_addr[master]  = addr;
+    dut.m_aw_id[master]    = master_id;
+    dut.m_aw_len[master]   = 0;
+    dut.m_aw_size[master]  = 2;
+    dut.m_aw_burst[master] = 1;
+    dut.m_aw_valid[master] = 1;
+
+    dut.m_w_valid[master] = 1;
+    dut.m_w_data[master]  = data;
+    dut.m_w_strb[master]  = 0xF;
+    dut.m_w_last[master]  = 1;
+
+    dut.s_aw_ready[slave] = 1;
+    dut.s_w_ready[slave]  = 1;
+
+    int aw_seen = 0, w_seen = 0;
+    int aw_id_correct = -1;
+    int w_data_correct = -1;
+
+    // Split tick into pre-edge sample / post-edge advance so we can observe
+    // AW/W handshakes BEFORE the rising edge fuses them away into next-state.
+    for (int i = 0; i < 32; ++i) {
+        pre_edge();   // comb settles with current state; handshake visible here
+        if (!aw_seen && dut.s_aw_valid[slave] && dut.s_aw_ready[slave]) {
+            aw_seen = 1;
+            aw_id_correct = (dut.s_aw_id[slave] == expect_slave_id) ? 1 : 0;
+            for (unsigned other_s = 0; other_s < 4; ++other_s) {
+                if (other_s != slave && dut.s_aw_valid[other_s]) {
+                    return fail("AW leaked to wrong slave");
+                }
+            }
+        }
+        if (!w_seen && dut.s_w_valid[slave] && dut.s_w_ready[slave]) {
+            w_seen = 1;
+            w_data_correct = (dut.s_w_data[slave] == data && dut.s_w_last[slave]) ? 1 : 0;
+        }
+        post_edge();  // rising edge advances state
+        if (aw_seen && w_seen) {
+            dut.m_aw_valid[master] = 0;
+            dut.m_w_valid[master]  = 0;
+            dut.s_aw_ready[slave]  = 0;
+            dut.s_w_ready[slave]   = 0;
+            break;
+        }
+    }
+    if (!aw_seen) return fail("AW handshake never observed");
+    if (!w_seen)  return fail("W handshake never observed");
+    if (aw_id_correct == 0) {
+        std::printf("FAIL AW id wrong at slave %u (expected 0x%x)\n", slave, expect_slave_id);
+        return 1;
+    }
+    if (w_data_correct == 0) {
+        std::printf("FAIL W data or last wrong at slave %u (expected data 0x%x, last=1)\n", slave, data);
+        return 1;
+    }
+
+    // ── B phase ─────────────────────────────────────────────────────────
+    dut.m_b_ready[master] = 1;
+    dut.s_b_valid[slave]  = 1;
+    dut.s_b_id[slave]     = expect_slave_id;
+    dut.s_b_resp[slave]   = 0;
+
+    int b_seen = 0;
+    for (int i = 0; i < 32; ++i) {
+        pre_edge();
+        if (dut.m_b_valid[master] && dut.m_b_ready[master]) {
+            if ((dut.m_b_id[master] & 0x7) != (master_id & 0x7)) {
+                std::printf("FAIL B id strip at master %u: got 0x%x, expected 0x%x\n",
+                            master, (unsigned)dut.m_b_id[master], master_id);
+                return 1;
+            }
+            for (unsigned other_m = 0; other_m < 3; ++other_m) {
+                if (other_m != master && dut.m_b_valid[other_m]) {
+                    return fail("B leaked to wrong master");
+                }
+            }
+            b_seen = 1;
+            post_edge();
+            break;
+        }
+        post_edge();
+    }
+    if (!b_seen) return fail("B handshake never observed at master");
+
+    dut.s_b_valid[slave]  = 0;
+    dut.m_b_ready[master] = 0;
+    tick();
+    return 0;
+}
+
+int main() {
+    dut.rst = 0;
+    clear_inputs();
+    for (int i = 0; i < 4; ++i) tick();
+    dut.rst = 1;
+    for (int i = 0; i < 3; ++i) tick();
+
+    if (do_write(0, 0x100, 0, 3, 0xDEAD0000u)) return 1;
+    if (do_write(1, 0x200, 1, 5, 0xCAFE1111u)) return 1;
+    if (do_write(2, 0x300, 2, 7, 0xB00B2222u)) return 1;
+    if (do_write(0, 0x400, 3, 1, 0xFEED3333u)) return 1;
+    if (do_write(2, 0x500, 0, 2, 0xABCD4444u)) return 1;
+
+    std::printf("PASS Nic400Fabric write 3x4: AW + W + B routes correctly across 5 (M,S) pairs\n");
+    return 0;
+}

--- a/tests/nic400/tb_nic400_pmu.cpp
+++ b/tests/nic400/tb_nic400_pmu.cpp
@@ -1,0 +1,95 @@
+// Nic400Pmu smoke test — drive synthetic AR/AW/R/W/B event pulses on each
+// master's input lanes and check that the corresponding counters integrate
+// the pulses correctly. NUM_MASTERS=3, COUNTER_W=32.
+//
+// Test pattern:
+//   master 0:  3 AR, 8 R (e.g. a 1+7 burst), 2 AW, 2 W, 2 B (single-beat ×2)
+//   master 1:  1 AR, 4 R (burst-of-4), 0 writes
+//   master 2:  0 reads, 5 AW, 5 W, 5 B (5 single-beat writes)
+//
+// Each pulse is a one-cycle assertion of the corresponding event_in[i] bit.
+
+#include "VNic400Pmu.h"
+#include <cstdint>
+#include <cstdio>
+
+static VNic400Pmu dut;
+static uint64_t cycle = 0;
+
+static void tick() { dut.clk = 0; dut.eval(); dut.clk = 1; dut.eval(); cycle++; }
+
+static void clear_events() {
+    for (int i = 0; i < 3; ++i) {
+        dut.ar_event[i] = 0;
+        dut.r_event[i]  = 0;
+        dut.aw_event[i] = 0;
+        dut.w_event[i]  = 0;
+        dut.b_event[i]  = 0;
+    }
+}
+
+// Drive a one-cycle pulse on event_in[master_idx] and advance the clock.
+// All other event lines are 0 for that cycle.
+static void pulse_ar(unsigned m) { clear_events(); dut.ar_event[m] = 1; tick(); clear_events(); }
+static void pulse_r(unsigned m)  { clear_events(); dut.r_event[m]  = 1; tick(); clear_events(); }
+static void pulse_aw(unsigned m) { clear_events(); dut.aw_event[m] = 1; tick(); clear_events(); }
+static void pulse_w(unsigned m)  { clear_events(); dut.w_event[m]  = 1; tick(); clear_events(); }
+static void pulse_b(unsigned m)  { clear_events(); dut.b_event[m]  = 1; tick(); clear_events(); }
+
+static int check(const char* label, uint32_t got, uint32_t expect) {
+    if (got != expect) {
+        std::printf("FAIL %s: got %u, expected %u\n", label, got, expect);
+        return 1;
+    }
+    return 0;
+}
+
+int main() {
+    dut.rst = 0;
+    clear_events();
+    for (int i = 0; i < 4; ++i) tick();
+    dut.rst = 1;
+    for (int i = 0; i < 3; ++i) tick();
+
+    // Master 0: 3 AR, 8 R beats, 2 AW, 2 W, 2 B.
+    for (int i = 0; i < 3; ++i) pulse_ar(0);
+    for (int i = 0; i < 8; ++i) pulse_r(0);
+    for (int i = 0; i < 2; ++i) pulse_aw(0);
+    for (int i = 0; i < 2; ++i) pulse_w(0);
+    for (int i = 0; i < 2; ++i) pulse_b(0);
+
+    // Master 1: 1 AR, 4 R beats.
+    pulse_ar(1);
+    for (int i = 0; i < 4; ++i) pulse_r(1);
+
+    // Master 2: 5 AW, 5 W, 5 B.
+    for (int i = 0; i < 5; ++i) pulse_aw(2);
+    for (int i = 0; i < 5; ++i) pulse_w(2);
+    for (int i = 0; i < 5; ++i) pulse_b(2);
+
+    // Settle one more tick so combinational outputs reflect the latest reg state.
+    tick();
+
+    int err = 0;
+    err |= check("m0.ar", dut.ar_count[0], 3);
+    err |= check("m0.r",  dut.r_count[0],  8);
+    err |= check("m0.aw", dut.aw_count[0], 2);
+    err |= check("m0.w",  dut.w_count[0],  2);
+    err |= check("m0.b",  dut.b_count[0],  2);
+
+    err |= check("m1.ar", dut.ar_count[1], 1);
+    err |= check("m1.r",  dut.r_count[1],  4);
+    err |= check("m1.aw", dut.aw_count[1], 0);
+    err |= check("m1.w",  dut.w_count[1],  0);
+    err |= check("m1.b",  dut.b_count[1],  0);
+
+    err |= check("m2.ar", dut.ar_count[2], 0);
+    err |= check("m2.r",  dut.r_count[2],  0);
+    err |= check("m2.aw", dut.aw_count[2], 5);
+    err |= check("m2.w",  dut.w_count[2],  5);
+    err |= check("m2.b",  dut.b_count[2],  5);
+
+    if (err) return 1;
+    std::printf("PASS Nic400Pmu: per-master AR/AW/R/W/B counters integrate event pulses correctly\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary

Three independent NIC-400 demo extensions, each with its own arch sim TB.

### 1. 3×4 full read/write fabric
Bumps the existing 2×2 read-only fabric to NUM_MASTERS=3, NUM_SLAVES=4 and flips `WRITE=1` on both bus shapes. MasterPort/SlavePort each gain per-channel mutex resources serialising the multi-driver writes that the N per-slave / M per-master threads make to the shared bus signals. Same ID-prefix routing strategy as the read path (master injects high bits on AW; slave-side B demux matches the prefix; master-side B forward strips it). Write pipeline depth is 1 per (master, slave) pair; full cross-slave concurrency.

### 2. AHB-Lite ↔ AXI4 bridge (single-beat v1)
`BusAhbLite.arch` + `Nic400AhbBridge.arch`. Two threads (read, write) sharing the AHB target signals via an `h_resp_lock` mutex. Module-local functions handle HBURST → {axlen, axburst}, HSIZE → axsize, HPROT → axprot/axcache, HMASTLOCK → axlock, and AXI b_resp/r_resp → HRESP. Known v1 limitation: undefined-length INCR and multi-beat write HWDATA streaming are deferred (single-beat is exercised end-to-end).

### 3. Per-master AR/AW/R/W/B PMU
`Nic400Pmu.arch` integrates per-channel handshake event pulses into 32-bit (parametric) counters per master. Standalone module — caller wires the event pulses from the fabric's `m[i].x_valid && m[i].x_ready` signals (one-liner in the module comment). Verilator-clean.

## Test plan

- [x] `arch sim` on `tb_nic400_fabric_smoke.cpp` (existing 2×2 read TB reused against 3×4 fabric) — PASS
- [x] `arch sim` on `tb_nic400_fabric_latency.cpp` (existing read-throughput TB) — AR=0 cyc, R=0 cyc, 9/9 transfers/cycle, PASS
- [x] `arch sim` on `tb_nic400_fabric_write.cpp` (new) — 5 (M,S) write pairs with AW/W ID-prefix + B-strip cross-checks, PASS
- [x] `arch sim` on `tb_nic400_ahb_bridge.cpp` (new) — 2 reads (incl. HMASTLOCK forwarding) + 2 writes (OKAY + SLVERR) with HSIZE/HMASTLOCK/HRESP checks, PASS
- [x] `arch sim` on `tb_nic400_pmu.cpp` (new) — mixed event patterns across 3 masters integrate correctly across 15 counters, PASS
- [x] `arch build` + `verilator --lint-only` on the PMU — clean
- [ ] Verilator UNOPTFLAT on `Nic400AhbBridge` lock arbiter — follow-on (same pattern as MasterPort/SlavePort)
- [ ] Multi-beat write HWDATA streaming in the AHB bridge — follow-on