### PR TITLE
nic400: AHB bridge v3 — chunked-burst HBURST=INCR

### DIFF
--- a/tests/nic400/Nic400AhbBridge.arch
+++ b/tests/nic400/Nic400AhbBridge.arch
@@ -42,6 +42,11 @@ module Nic400AhbBridge
   param DATA_WIDTH: const = 32;
   param STRB_WIDTH: const = 4;        // = DATA_WIDTH/8
   param ID_WIDTH:   const = 3;
+  // v3: chunk length for HBURST=INCR (undefined-length) writes.
+  // Bridge speculatively issues an AXI burst of MAX_INCR_BEATS, pads with
+  // strb=0 if master stops early. Bursts longer than MAX_INCR_BEATS will
+  // hang the master (multi-chunk extension is the v4 step).
+  param MAX_INCR_BEATS: const = 16;
 
   port clk: in Clock<SysDomain>;
   port rst: in Reset<Async, Low>;
@@ -187,7 +192,9 @@ module Nic400AhbBridge
       axi.w_last    = false;
       axi.b_ready   = false;
     end default
-    wait 0+ cycle until h.hsel and (h.htrans == 2) and h.hwrite;
+    // Wake only on fixed-length HBURST values. HBURST=1 (INCR undefined-length)
+    // is handled by the WriteXactIncr thread below.
+    wait 0+ cycle until h.hsel and (h.htrans == 2) and h.hwrite and (h.hburst != 1);
     // AW phase: stall the AHB data phase while we set up AW.
     lock h_resp_lock
       do
@@ -230,4 +237,116 @@ module Nic400AhbBridge
       until axi.b_valid;
     end lock h_resp_lock
   end thread WriteXact
+
+  // ── Write thread (HBURST=INCR, undefined-length, chunked-burst v3) ──
+  // AHB-Lite HBURST=INCR is unbounded — the master streams SEQ beats and
+  // signals end-of-burst by transitioning HTRANS to IDLE (or to NONSEQ for
+  // a different burst). AXI4 requires axlen at AW time and a launched burst
+  // can't be cancelled.
+  //
+  // Strategy: speculatively issue an AXI burst of MAX_INCR_BEATS, drain the
+  // master's HWDATA stream as W beats. When the master stops mid-chunk,
+  // pad the remaining AXI W beats with w_strb=0 (legal sparse-write per
+  // AXI4) so the AXI slave sees a clean axlen-length burst with the trailing
+  // bytes effectively no-op.
+  //
+  // Master-stop detection: at each forwarded W beat, sample h.htrans on
+  // the cycle the W handshake completes. The HTRANS of that cycle is the
+  // master's drive for the NEXT beat's *address* phase — if it's IDLE,
+  // the master is stopping, but THIS beat's HWDATA (already on the bus)
+  // is still valid and must be forwarded. Subsequent beats (b+1..MAX-1)
+  // get padded.
+  //
+  // BUSY handling: not supported in v3. Assumes AHB master uses SEQ
+  // exclusively for INCR (the common cache-line-fill case). HTRANS=BUSY
+  // would be misinterpreted as "still streaming" and forward stale HWDATA.
+  //
+  // Long-burst limitation: AHB INCR bursts longer than MAX_INCR_BEATS
+  // beats hang the master (no inter-chunk handoff in v3). v4 adds a
+  // HWDATA FIFO + multi-chunk for true unbounded INCR support.
+  //
+  // master_stopped_r is module-scope (declared below) so it persists across
+  // the for-loop iterations within a single thread state lowering.
+  reg master_stopped_r: Bool reset rst => false;
+
+  thread WriteXactIncr on clk rising, rst low
+    default comb
+      h.hready  = true;
+      h.hresp   = false;
+      h.hrdata  = 0;
+      axi.aw_valid  = false;
+      axi.aw_addr   = 0;
+      axi.aw_id     = 0;
+      axi.aw_len    = 0;
+      axi.aw_size   = 0;
+      axi.aw_burst  = 0;
+      axi.aw_lock   = false;
+      axi.aw_cache  = 0;
+      axi.aw_prot   = 0;
+      axi.aw_qos    = 0;
+      axi.aw_region = 0;
+      axi.w_valid   = false;
+      axi.w_data    = 0;
+      axi.w_strb    = 0;
+      axi.w_last    = false;
+      axi.b_ready   = false;
+    end default
+    // Wake only on HBURST=1 (INCR undefined-length). master_stopped_r is
+    // cleared at the end of each burst (after the B phase below), so on
+    // wake-up it's already false.
+    wait 0+ cycle until h.hsel and (h.htrans == 2) and h.hwrite and (h.hburst == 1);
+    // AW phase — speculative axlen = MAX_INCR_BEATS - 1.
+    lock h_resp_lock
+      do
+        h.hready      = false;
+        axi.aw_valid  = true;
+        axi.aw_addr   = h.haddr;
+        axi.aw_id     = 0;
+        axi.aw_size   = h.hsize;
+        axi.aw_len    = MAX_INCR_BEATS - 1;
+        axi.aw_burst  = 1;                  // INCR
+        axi.aw_lock   = h.hmastlock;
+        axi.aw_cache  = h.hprot;
+        axi.aw_prot   = h.hprot[2:0];
+      until axi.aw_ready;
+    end lock h_resp_lock
+    // Spinup gap for master to advance into data phase 0.
+    wait 1 cycle;
+    // W loop — drain up to MAX_INCR_BEATS beats from the master, pad the
+    // tail if master stops early.
+    for b in 0..MAX_INCR_BEATS - 1
+      lock h_resp_lock
+        do
+          if master_stopped_r
+            // Padding tail: master has signalled end-of-burst on a prior
+            // iteration. Forward a strb=0 dummy beat to drain the AXI burst.
+            h.hready    = false;
+            axi.w_valid = true;
+            axi.w_data  = 0;
+            axi.w_strb  = 0;
+            axi.w_last  = (b == MAX_INCR_BEATS - 1);
+          else
+            // Streaming: forward current HWDATA from the master's data phase.
+            h.hready    = axi.w_ready;
+            axi.w_valid = true;
+            axi.w_data  = h.hwdata;
+            axi.w_strb  = 15;
+            axi.w_last  = (b == MAX_INCR_BEATS - 1);
+          end if
+        until axi.w_ready;
+      end lock h_resp_lock
+      // Sample HTRANS at handshake-complete cycle. If master drove IDLE in
+      // this cycle's address phase, no more real beats will follow.
+      master_stopped_r <= h.htrans == 0;
+    end for
+    // B phase.
+    lock h_resp_lock
+      do
+        h.hready    = axi.b_valid;
+        h.hresp     = axi_resp_to_ahb(axi.b_resp);
+        axi.b_ready = true;
+      until axi.b_valid;
+    end lock h_resp_lock
+    master_stopped_r <= false;
+  end thread WriteXactIncr
 end module Nic400AhbBridge

--- a/tests/nic400/tb_nic400_ahb_bridge_incr.cpp
+++ b/tests/nic400/tb_nic400_ahb_bridge_incr.cpp
@@ -1,0 +1,205 @@
+// HBURST=INCR (undefined-length) chunked-burst test for the Nic400AhbBridge
+// v3 chunked-burst path.
+//
+// MAX_INCR_BEATS = 16 (compile-time param). The bridge speculatively issues
+// an AXI burst of axlen=15 and forwards master HWDATA as W beats. When the
+// master signals end-of-burst by transitioning HTRANS to IDLE, the bridge
+// pads remaining W beats with w_strb=0 (sparse-write).
+//
+// Coverage:
+//   • INCR with 1 SEQ then IDLE: just 1 real beat (D0), 15 padded.
+//   • INCR with 4 SEQ beats: 4 real (D0..D3), 12 padded.
+//   • INCR with 16 SEQ beats: full chunk, no padding.
+//
+// The TB models the AHB master pipeline (addr_idx + data_idx) and counts
+// "intended beats". After the last intended beat, master drives HTRANS=IDLE.
+//
+// Bridge-side acceptance criteria:
+//   • Exactly MAX_INCR_BEATS = 16 W beats arrive on AXI (any combination of
+//     real + padded), w_last on the 16th.
+//   • Real beats have w_strb = 0xF and w_data = the intended D_i.
+//   • Padded beats have w_strb = 0 (sparse). Data is don't-care.
+//   • B response propagates back as HREADY=1 + HRESP pulse to AHB.
+
+#include "VNic400AhbBridge.h"
+#include <cstdint>
+#include <cstdio>
+
+#define MAX_BEATS 16
+
+static VNic400AhbBridge dut;
+static uint64_t cycle = 0;
+
+static void tick() { dut.clk = 0; dut.eval(); dut.clk = 1; dut.eval(); cycle++; }
+static void pre_edge()  { dut.clk = 0; dut.eval(); }
+static void post_edge() { dut.clk = 1; dut.eval(); cycle++; }
+
+static void clear_inputs() {
+    dut.h_hsel = 0; dut.h_haddr = 0; dut.h_hwrite = 0;
+    dut.h_hsize = 0; dut.h_hburst = 0; dut.h_hprot = 0;
+    dut.h_htrans = 0; dut.h_hmastlock = 0; dut.h_hwdata = 0;
+    dut.axi_ar_ready = 0;
+    dut.axi_r_valid = 0; dut.axi_r_data = 0; dut.axi_r_id = 0;
+    dut.axi_r_resp = 0; dut.axi_r_last = 0;
+    dut.axi_aw_ready = 0; dut.axi_w_ready = 0;
+    dut.axi_b_valid = 0; dut.axi_b_id = 0; dut.axi_b_resp = 0;
+}
+
+static int fail(const char* m) { std::printf("FAIL %s (cycle=%llu)\n", m, (unsigned long long)cycle); return 1; }
+
+// Drive AHB master for an INCR (HBURST=1) burst with `n_real` SEQ beats then
+// IDLE. addr_idx tracks the master's next addr-phase beat index; data_idx
+// tracks the data-phase beat index.
+//   addr_idx in [0..n_real]   → drive NONSEQ or SEQ for that beat
+//   addr_idx == n_real + 1+   → drive IDLE (master is done)
+//   data_idx in [0..n_real-1] → HWDATA = data[data_idx]
+//   data_idx ≥ n_real         → HWDATA don't care (master in IDLE data phase)
+static void drive_master_incr(uint32_t addr_base, unsigned hsize,
+                              const uint32_t* data, unsigned n_real,
+                              int addr_idx, int data_idx) {
+    if (addr_idx == 0) {
+        dut.h_hsel = 1; dut.h_haddr = addr_base; dut.h_hwrite = 1;
+        dut.h_hsize = hsize; dut.h_hburst = 1; dut.h_hprot = 0;
+        dut.h_htrans = 2;       // NONSEQ
+        dut.h_hmastlock = 0;
+    } else if (addr_idx < (int)n_real) {
+        dut.h_hsel = 1; dut.h_haddr = addr_base + addr_idx * 4; dut.h_hwrite = 1;
+        dut.h_hsize = hsize; dut.h_hburst = 1; dut.h_hprot = 0;
+        dut.h_htrans = 3;       // SEQ
+        dut.h_hmastlock = 0;
+    } else {
+        // Past last intended addr phase — master is done.
+        dut.h_hsel = 0; dut.h_htrans = 0;
+    }
+    if (data_idx >= 0 && data_idx < (int)n_real) {
+        dut.h_hwdata = data[data_idx];
+    } else {
+        dut.h_hwdata = 0xDEADDEADu;   // would-be undef
+    }
+}
+
+static int do_incr_burst(uint32_t addr_base, unsigned hsize,
+                         const uint32_t* data, unsigned n_real, unsigned bresp) {
+    int addr_idx = 0;
+    int data_idx = -1;
+    int aw_acked = 0;
+    unsigned beats_received = 0;
+    int w_last_seen_on = -1;
+    uint32_t w_data_log[MAX_BEATS];
+    uint8_t  w_strb_log[MAX_BEATS];
+    int b_phase_done = 0;
+
+    dut.axi_aw_ready = 1;
+    dut.axi_w_ready  = 1;
+
+    for (int c = 0; c < 512 && !b_phase_done; ++c) {
+        drive_master_incr(addr_base, hsize, data, n_real, addr_idx, data_idx);
+
+        if (beats_received == MAX_BEATS && !dut.axi_b_valid) {
+            dut.axi_b_valid = 1;
+            dut.axi_b_resp  = bresp;
+        }
+
+        pre_edge();
+        int hready_now = dut.h_hready ? 1 : 0;
+
+        if (!aw_acked && dut.axi_aw_valid && dut.axi_aw_ready) {
+            aw_acked = 1;
+            if (dut.axi_aw_addr != addr_base) return fail("AW addr mismatch");
+            if (dut.axi_aw_len  != MAX_BEATS - 1) return fail("AW len != MAX-1");
+            if (dut.axi_aw_burst != 1) return fail("AW burst != INCR");
+        }
+        if (dut.axi_w_valid && dut.axi_w_ready) {
+            if (beats_received >= MAX_BEATS) return fail("more W beats than MAX_BEATS");
+            w_data_log[beats_received] = (uint32_t)dut.axi_w_data;
+            w_strb_log[beats_received] = (uint8_t) dut.axi_w_strb;
+            if (dut.axi_w_last) w_last_seen_on = (int)beats_received;
+            beats_received++;
+        }
+        if (beats_received == MAX_BEATS && dut.axi_b_valid && hready_now) {
+            unsigned expect_hresp = (bresp >> 1) & 1;
+            if ((unsigned)dut.h_hresp != expect_hresp) return fail("HRESP mismatch");
+            b_phase_done = 1;
+        }
+
+        post_edge();
+
+        if (hready_now) {
+            if (data_idx >= 0) data_idx++;
+            // addr_idx advances as long as the master is still presenting
+            // addr-phase beats. After addr_idx reaches n_real, addr phase
+            // transitions to IDLE — done.
+            if (data_idx < 0) data_idx = 0;
+            addr_idx++;
+        }
+    }
+
+    if (!b_phase_done) return fail("INCR burst never completed");
+    if (beats_received != MAX_BEATS) return fail("not MAX_BEATS W beats received");
+    if (w_last_seen_on != MAX_BEATS - 1) return fail("w_last not on the final beat");
+
+    // Validate beat shape:
+    //   beats [0..n_real-1] must have strb=0xF and data=intended.
+    //   beats [n_real..MAX-1] must have strb=0 (padded).
+    for (unsigned i = 0; i < n_real; ++i) {
+        if (w_strb_log[i] != 0xF) {
+            std::printf("FAIL real beat %u: strb=0x%x, expected 0xF\n", i, w_strb_log[i]);
+            return 1;
+        }
+        if (w_data_log[i] != data[i]) {
+            std::printf("FAIL real beat %u: data=0x%x, expected 0x%x\n", i, w_data_log[i], data[i]);
+            return 1;
+        }
+    }
+    for (unsigned i = n_real; i < MAX_BEATS; ++i) {
+        if (w_strb_log[i] != 0) {
+            std::printf("FAIL pad beat %u: strb=0x%x, expected 0\n", i, w_strb_log[i]);
+            return 1;
+        }
+    }
+
+    dut.axi_b_valid = 0; dut.axi_w_ready = 0; dut.axi_aw_ready = 0;
+    dut.h_hsel = 0; dut.h_htrans = 0;
+    tick();
+    return 0;
+}
+
+int main() {
+    dut.rst = 0;
+    clear_inputs();
+    for (int i = 0; i < 4; ++i) tick();
+    dut.rst = 1;
+    for (int i = 0; i < 3; ++i) tick();
+
+    // 4-beat INCR-undef: 4 real, 12 padded.
+    {
+        uint32_t data[4] = { 0x10101010u, 0x20202020u, 0x30303030u, 0x40404040u };
+        if (do_incr_burst(0x1000, 2, data, 4, 0)) return 1;
+        std::printf("  OK INCR-undef 4 beats (12 padded)\n");
+    }
+
+    // 1-beat INCR (just NONSEQ then IDLE — degenerate case).
+    {
+        uint32_t data[1] = { 0xFFEE0001u };
+        if (do_incr_burst(0x2000, 2, data, 1, 0)) return 1;
+        std::printf("  OK INCR-undef 1 beat (15 padded)\n");
+    }
+
+    // 16-beat INCR (full chunk, no padding).
+    {
+        uint32_t data[16];
+        for (int i = 0; i < 16; ++i) data[i] = 0xC0DE0000u | i;
+        if (do_incr_burst(0x3000, 2, data, 16, 0)) return 1;
+        std::printf("  OK INCR-undef 16 beats (no padding)\n");
+    }
+
+    // 4-beat INCR with SLVERR.
+    {
+        uint32_t data[4] = { 0xBEEFAAAAu, 0xBEEFBBBBu, 0xBEEFCCCCu, 0xBEEFDDDDu };
+        if (do_incr_burst(0x4000, 2, data, 4, 2)) return 1;
+        std::printf("  OK INCR-undef 4 beats SLVERR\n");
+    }
+
+    std::printf("PASS Nic400AhbBridge INCR-undef: 1/4/16-beat + SLVERR\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary

Follow-on to #408. Adds a parallel `WriteXactIncr` thread that handles HBURST=INCR (3'b001), the AHB-Lite undefined-length burst.

AXI4 requires `axlen` at AW time and launched bursts can't be cancelled, so this implements the **chunked-burst** strategy: speculatively issue an AXI burst of `MAX_INCR_BEATS` (default 16), forward HWDATA beats as W beats, and pad the tail with `w_strb=0` (legal AXI sparse-write) when the master signals end-of-burst before the chunk fills.

### Master-stop detection
At each forwarded W beat, sample `h.htrans` on the cycle the W handshake completes. The HTRANS of that cycle is the master's drive for the *next* beat's address phase — if it's IDLE, the master is stopping, but THIS beat's HWDATA (already on the bus) is still valid and must be forwarded. Subsequent beats get padded.

### Excluded from the existing thread
`WriteXact` (fixed-length bursts) now waits with `... and (h.hburst != 1)` so the two threads never both wake on the same transaction.

### v3 limitations (documented)
- Bursts longer than `MAX_INCR_BEATS` will hang the master — no inter-chunk handoff. Multi-chunk + HWDATA FIFO is the v4 step.
- HTRANS=BUSY not supported (assumes SEQ-exclusive INCR, the common cache-line-fill case).

## Test plan

- [x] `arch sim tb_nic400_ahb_bridge_incr.cpp` (new): 1-beat INCR (degenerate), 4-beat INCR, 16-beat INCR (full chunk, no padding), 4-beat INCR with SLVERR — all PASS
- [x] Per-beat shape validation: real beats have `w_strb=0xF` and `w_data` matches the master's drive; padded beats have `w_strb=0`; `w_last` on the 16th beat; HRESP propagates from `b_resp[1]`
- [x] v1 single-beat regression (`tb_nic400_ahb_bridge.cpp`) — PASS
- [x] v2 fixed-length burst regression (`tb_nic400_ahb_bridge_burst.cpp`) — PASS
- [ ] v4 follow-on: multi-chunk with HWDATA FIFO for true unbounded INCR