### PR TITLE
fix: reject nested control flow inside `do ... until` body (#410)

### DIFF
--- a/src/elaborate.rs
+++ b/src/elaborate.rs
@@ -4649,6 +4649,65 @@ fn partition_thread_body(
     partition_thread_body_impl(body, span, cnt_width, None)
 }
 
+/// Validate the body of a `do … until cond;` statement.
+///
+/// `do … until` is a SINGLE-STATE hold construct: the body's comb/seq
+/// assigns fire every cycle while the FSM is parked in this state, and
+/// the FSM advances when `cond` becomes true. It is *not* a loop; for a
+/// real loop use `for c in S..E { ... }` (which generates a `_loop_cnt`
+/// register and proper back-edge transitions).
+///
+/// Bodies are restricted to `CombAssign`, `SeqAssign`, `IfElse`, and `Log`.
+/// Any other `ThreadStmt` variant — `Lock`, `For`, `WaitUntil`,
+/// `WaitUntilMealy`, `WaitCycles`, `ForkJoin`, nested `DoUntil`, `Return`,
+/// `ForkTlmAssign`, `JoinAll` — cannot be lowered as a hold-state and was
+/// historically silently dropped, producing FSMs that miscompiled to an
+/// infinite-loop (see issue #410). Reject those constructs with a precise
+/// error pointing at the offending inner statement.
+///
+/// `IfElse` is allowed at the top level but its own then/else bodies are
+/// recursively constrained the same way — a nested `wait` inside an `if`
+/// inside a `do … until` would otherwise be silently dropped by
+/// `thread_if_to_fsm_stmts`.
+fn disallow_nested_control_in_do_until(
+    body: &[ThreadStmt],
+    do_span: Span,
+) -> Result<(), CompileError> {
+    for s in body {
+        let bad = match s {
+            ThreadStmt::CombAssign(_)
+            | ThreadStmt::SeqAssign(_)
+            | ThreadStmt::Log(_) => None,
+            ThreadStmt::IfElse(ie) => {
+                disallow_nested_control_in_do_until(&ie.then_stmts, do_span)?;
+                disallow_nested_control_in_do_until(&ie.else_stmts, do_span)?;
+                None
+            }
+            ThreadStmt::Lock { .. } => Some("`lock`"),
+            ThreadStmt::For { .. } => Some("`for`"),
+            ThreadStmt::WaitUntil(..) => Some("`wait until`"),
+            ThreadStmt::WaitUntilMealy(..) => Some("`wait 0+ cycle until`"),
+            ThreadStmt::WaitCycles(..) => Some("`wait N cycle`"),
+            ThreadStmt::ForkJoin(..) => Some("`fork`/`join`"),
+            ThreadStmt::DoUntil { .. } => Some("a nested `do ... until`"),
+            ThreadStmt::Return(..) => Some("`return`"),
+            ThreadStmt::ForkTlmAssign(_) => Some("a TLM `fork` call"),
+            ThreadStmt::JoinAll(_) => Some("`join all`"),
+        };
+        if let Some(what) = bad {
+            return Err(CompileError::general(
+                &format!(
+                    "{} is not allowed inside `do ... until` — that construct is a single-cycle-per-iteration hold state (drive comb + seq while waiting for the exit condition), not a loop. \
+                    Use `for c in 0..N-1 ... end for` for a bounded iteration, or split the work into multiple `wait until` / `do ... until` statements at thread top level.",
+                    what,
+                ),
+                thread_stmt_span(s).merge(do_span),
+            ));
+        }
+    }
+    Ok(())
+}
+
 fn partition_tlm_target_thread_body(
     body: &[ThreadStmt],
     span: Span,
@@ -4751,7 +4810,14 @@ fn partition_thread_body_impl(
                                 if let Some(s) = seq_if { do_seq.push(s); }
                             }
                             ThreadStmt::Log(l) => do_seq.push(Stmt::Log(l.clone())),
-                            _ => {}
+                            _ => {
+                                // Unreachable: the caller (Mealy-fusion path)
+                                // routes through partition_thread_body's
+                                // `DoUntil` arm, which calls
+                                // `disallow_nested_control_in_do_until`
+                                // before reaching here.
+                                unreachable!("Mealy-fused do..until body contained an unexpected statement");
+                            }
                         }
                     }
                     let gated_comb = if do_comb.is_empty() {
@@ -4792,7 +4858,14 @@ fn partition_thread_body_impl(
 
                 match next {
                     // Form (a): direct do/until.
-                    Some(ThreadStmt::DoUntil { body: do_body, cond: exit_cond, span: _ }) => {
+                    Some(ThreadStmt::DoUntil { body: do_body, cond: exit_cond, span: do_sp }) => {
+                        // Same nested-control restriction as the standalone
+                        // `DoUntil` arm of `partition_thread_body_impl`: the
+                        // Mealy-fused state is still a single-state hold,
+                        // and any nested wait/lock/for/etc. inside the do-body
+                        // would be silently dropped by `build_fused` (issue
+                        // #410).
+                        disallow_nested_control_in_do_until(do_body, *do_sp)?;
                         flush();
                         let (gated_comb, do_seq, fused_cond) = build_fused(cond, *sp, do_body, exit_cond);
                         states.push(ThreadFsmState {
@@ -5160,7 +5233,17 @@ fn partition_thread_body_impl(
                 let lock_states = lower_thread_lock(&resource.name, body, *span, cnt_width)?;
                 states.extend(lock_states);
             }
-            ThreadStmt::DoUntil { body, cond, span: _ } => {
+            ThreadStmt::DoUntil { body, cond, span: do_sp } => {
+                // `do { … } until cond;` is a SINGLE-STATE hold: the body's
+                // comb/seq drives fire every cycle while waiting for `cond`.
+                // It is NOT a loop construct. Nested control flow inside the
+                // body (lock, for, wait, fork, do-until, return) cannot be
+                // lowered as a hold-state and was historically silently
+                // dropped — producing FSMs that looked plausible but ran
+                // forever (issue #410). Reject those constructs up-front so
+                // the user sees a precise error pointing at the offending
+                // inner statement instead of an infinite-loop miscompile.
+                disallow_nested_control_in_do_until(body, *do_sp)?;
                 // Flush pending assigns into a prior state
                 if !cur_comb.is_empty() || !cur_seq.is_empty() {
                     states.push(ThreadFsmState {
@@ -5192,8 +5275,9 @@ fn partition_thread_body_impl(
                             do_seq.push(Stmt::Log(l.clone()));
                         }
                         _ => {
-                            // do..until body should only contain simple assigns
-                            // (no waits, forks, loops — those go in the outer thread)
+                            // Unreachable: disallow_nested_control_in_do_until above
+                            // already rejects every other ThreadStmt variant.
+                            unreachable!("do..until body contained an unexpected statement that should have been rejected");
                         }
                     }
                 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -10229,6 +10229,137 @@ fn test_thread_with_do_until_only_is_accepted() {
 }
 
 #[test]
+fn test_do_until_rejects_nested_lock() {
+    // Regression for issue #410: a `do … until` body that contained a
+    // nested `lock` (or `for` / `wait` / `fork` / `do…until` / `return`)
+    // was previously silently dropped at lowering and produced an
+    // infinite-loop FSM. The elaborator must now reject this with a
+    // diagnostic pointing at the offending inner construct and at the
+    // enclosing `do … until`.
+    let source = r#"
+        module M
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Async, Low>;
+          port start:       in Bool;
+          port should_loop: in Bool;
+          port body_count: out UInt<8>;
+          resource lk: mutex<priority>;
+          reg body_count_r: UInt<8> reset rst => 0;
+          thread T on clk rising, rst low
+            default comb
+              body_count = body_count_r;
+            end default
+            wait until start;
+            do
+              lock lk
+                do
+                until true;
+              end lock lk
+              body_count_r <= (body_count_r + 1).trunc<8>();
+            until not should_loop;
+          end thread T
+        end module M
+    "#;
+    let tokens = arch::lexer::tokenize(source).expect("lex");
+    let mut parser = arch::parser::Parser::new(tokens, source);
+    let ast = parser.parse_source_file().expect("parse");
+    let err = arch::elaborate::lower_threads(ast).expect_err("expected lowering error");
+    let msg = err.iter().map(|e| format!("{e:?}")).collect::<String>();
+    assert!(msg.contains("`lock`") && msg.contains("`do ... until`"),
+            "expected do-until-rejects-lock diagnostic, got: {msg}");
+}
+
+#[test]
+fn test_do_until_rejects_nested_wait() {
+    // Companion to the lock case: a `do … until` body containing a
+    // `wait until` must also be rejected — the wait cannot lower as
+    // a hold-state body.
+    let source = r#"
+        module M
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Async, Low>;
+          port go: in Bool;
+          port hit: in Bool;
+          port reg flag: out Bool reset rst => false;
+          thread T on clk rising, rst low
+            do
+              wait until hit;
+              flag <= true;
+            until go;
+          end thread T
+        end module M
+    "#;
+    let tokens = arch::lexer::tokenize(source).expect("lex");
+    let mut parser = arch::parser::Parser::new(tokens, source);
+    let ast = parser.parse_source_file().expect("parse");
+    let err = arch::elaborate::lower_threads(ast).expect_err("expected lowering error");
+    let msg = err.iter().map(|e| format!("{e:?}")).collect::<String>();
+    assert!(msg.contains("`wait until`") && msg.contains("`do ... until`"),
+            "expected do-until-rejects-nested-wait diagnostic, got: {msg}");
+}
+
+#[test]
+fn test_do_until_rejects_nested_for() {
+    // `for` inside `do … until` body — same silent-drop trap pre-#410.
+    let source = r#"
+        module M
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Async, Low>;
+          port go: in Bool;
+          port done: in Bool;
+          port reg ctr: out UInt<8> reset rst => 0;
+          thread T on clk rising, rst low
+            wait until go;
+            do
+              for i in 0..3
+                ctr <= (ctr + 1).trunc<8>();
+              end for
+            until done;
+          end thread T
+        end module M
+    "#;
+    let tokens = arch::lexer::tokenize(source).expect("lex");
+    let mut parser = arch::parser::Parser::new(tokens, source);
+    let ast = parser.parse_source_file().expect("parse");
+    let err = arch::elaborate::lower_threads(ast).expect_err("expected lowering error");
+    let msg = err.iter().map(|e| format!("{e:?}")).collect::<String>();
+    assert!(msg.contains("`for`") && msg.contains("`do ... until`"),
+            "expected do-until-rejects-nested-for diagnostic, got: {msg}");
+}
+
+#[test]
+fn test_do_until_allows_nested_ifelse_with_simple_assigns() {
+    // Regression boundary: `if/else` inside a `do … until` body is fine
+    // as long as every branch contains only comb/seq assigns and `log`
+    // — i.e. nothing that would need a fresh FSM state. This keeps the
+    // legitimate per-cycle protocol-drive use case working.
+    let source = r#"
+        module M
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Async, Low>;
+          port go:   in Bool;
+          port pick: in Bool;
+          port done: in Bool;
+          port reg a: out Bool reset rst => false;
+          port reg b: out Bool reset rst => false;
+          thread T on clk rising, rst low
+            wait until go;
+            do
+              if pick
+                a <= true;
+              else
+                b <= true;
+              end if
+            until done;
+          end thread T
+        end module M
+    "#;
+    let sv = compile_to_sv(source);
+    assert!(sv.contains("always_ff"),
+            "do/until with simple if/else body should compile:\n{sv}");
+}
+
+#[test]
 fn test_thread_wait_ifelse_fuses_dispatch_and_first_branch_action() {
     // Micro-architecture pattern from arch-ibex multdiv: a thread waits for
     // a request, dispatches on an opcode, then performs the first cycle of

--- a/tests/regression/issues/do_until_top_level/DoUntilRepro.arch
+++ b/tests/regression/issues/do_until_top_level/DoUntilRepro.arch
@@ -1,0 +1,55 @@
+// Regression for issue #410: outer `do BODY until cond;` at thread top
+// level used to silently lower to an infinite-loop FSM whenever the body
+// contained anything that the lowering's `DoUntil` arm could not encode
+// as a hold-state — `lock`, `for`, `wait*`, `fork`/`join`, nested
+// `do…until`, or `return`. Those statements were dropped on the floor,
+// leaving the surrounding seq assigns to fire every cycle for the
+// lifetime of the FSM.
+//
+// Resolution: `do … until` is now a *single-state* hold (its documented
+// shape — "drive comb + seq while waiting; advance when cond is true"),
+// and the elaborator rejects nested control flow in its body with a
+// pointer to `for c in S..E … end for` for real loops.
+//
+// This file is therefore an **expected-failure** test: `arch check` must
+// report a diagnostic that mentions both ``lock`` and ``do ... until``.
+// The integration tests `test_do_until_rejects_nested_lock`,
+// `test_do_until_rejects_nested_wait`, and `test_do_until_rejects_nested_for`
+// in `tests/integration_test.rs` are the authoritative regression
+// coverage — this .arch file is preserved for human-readable context.
+module DoUntilRepro
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Async, Low>;
+  port start:       in Bool;
+  port should_loop: in Bool;
+  port body_count: out UInt<8>;
+  port lock_drove: out Bool;
+  port done:       out Bool;
+
+  resource lk: mutex<priority>;
+  reg body_count_r: UInt<8> reset rst => 0;
+  reg lock_drove_r: Bool reset rst => false;
+  reg done_r:       Bool reset rst => false;
+
+  thread T on clk rising, rst low
+    default comb
+      body_count = body_count_r;
+      lock_drove = lock_drove_r;
+      done       = done_r;
+    end default
+    wait 0+ cycle until start;
+    // The outer `do … until` body contains a nested `lock` (and a seq
+    // assign). Pre-#410 this lowered to a single hold-state that ran the
+    // seq assigns forever. The compiler now rejects with a diagnostic
+    // that points at this `do` token.
+    do
+      lock lk
+        do
+        until true;
+      end lock lk
+      lock_drove_r <= true;
+      body_count_r <= (body_count_r + 1).trunc<8>();
+    until not should_loop;
+    done_r <= true;
+  end thread T
+end module DoUntilRepro

--- a/tests/regression/issues/do_until_top_level/tb_do_until.cpp
+++ b/tests/regression/issues/do_until_top_level/tb_do_until.cpp
@@ -1,0 +1,17 @@
+// Placeholder TB for the issue #410 repro.
+//
+// Pre-fix: the design lowered to an infinite-loop FSM and this TB was
+// used to observe `body_count_r` incrementing forever while `done_r`
+// also asserted from cycle 0.
+//
+// Post-fix: `DoUntilRepro.arch` no longer compiles — the elaborator
+// rejects `do … until` bodies that contain nested control flow (here,
+// the inner `lock lk`). The Rust integration tests
+//   `test_do_until_rejects_nested_lock`
+//   `test_do_until_rejects_nested_wait`
+//   `test_do_until_rejects_nested_for`
+// (in `tests/integration_test.rs`) are the authoritative regression
+// coverage for the rejection diagnostic. This file is kept so the
+// directory remains self-contained.
+
+int main() { return 0; }


### PR DESCRIPTION
Fixes #410.

## Summary

`do … until cond;` is a single-state hold (drive comb + seq while waiting, advance when cond fires) — *not* a loop. Pre-fix, the `DoUntil` arm of `partition_thread_body` (and the parallel arm in the `wait 0+ cycle until …; do … until …;` Mealy fusion) silently dropped any nested `lock`, `for`, `wait`, `fork`, nested `do…until`, `return`, or TLM `fork`/`join all` inside the body. Combined with `t.once = false` wrap-to-state-0 semantics, that left a one-state FSM whose seq assigns fired every cycle — the bridge v4 hang reported in the issue.

The fix is to validate the body up-front in `disallow_nested_control_in_do_until` and emit a precise diagnostic naming both the offending inner construct and the enclosing `do … until`, pointing the user at `for c in S..E … end for` for real loops. `if/else` remains allowed and is recursively constrained the same way.

## Resolution chosen

**Option (c) — reject at elaboration time** (from the three options listed in the issue). The "while" and "do-while" rewrites both require synthesising a back-edge state and merging the exit-cond evaluation with the body lowering, which is out of scope for the issue and would change the meaning of every existing call site. Rejection is the safe minimum.

For loop-like semantics the user can:
- Use `for c in 0..MAX_CHUNKS-1 … end for` with an `if exit_now` inside, or
- Split the work into multiple `wait until` / `do … until` top-level statements (the natural shape now that the v3 bridge already uses).

## Files touched

- `src/elaborate.rs`: new `disallow_nested_control_in_do_until` helper; wired into the standalone `DoUntil` arm of `partition_thread_body_impl` and the Mealy-fusion `WaitUntilMealy → DoUntil` arm.
- `tests/integration_test.rs`: four new tests — three rejection cases (`lock`, `wait until`, `for`) and one acceptance case (nested `if/else` with simple assigns).
- `tests/regression/issues/do_until_top_level/`: pre-fix repro updated to document the new expected-rejection behavior; TB stub kept so the directory stays self-contained.

## Test plan

- [x] `cargo test --release` — 477 + 4 new = 481 passing.
- [x] `arch sim` of Nic400AhbBridge v1, v2, v3 TBs — all pass.
- [x] Legitimate in-tree users (`Nic400MasterPort.arch`, `Nic400SlavePort.arch`, `ThreadMm2s.arch`, `Nic400AhbBridge.arch`) still type-check.

## Caveats / follow-up

- The bridge v4 multi-chunk INCR-undef shape mentioned in the issue is still unimplemented — this PR only fixes the silent miscompile; the user will need to express v4 as `for c in 0..MAX-1 { if not master_stopped_r { ... } }` or a two-thread+FIFO design.
- A "real" loop primitive (a structural `while … end while` that lowers like a `for` with a non-constant bound) remains a possible language extension but is out of scope here.