### PR TITLE
Fix #412: gate Mealy-fused do-until seq assigns by wake condition

### DIFF
--- a/src/elaborate.rs
+++ b/src/elaborate.rs
@@ -4831,6 +4831,24 @@ fn partition_thread_body_impl(
                             span: sp,
                         })]
                     };
+                    // Issue #412: seq assigns from the do-body must also be
+                    // gated by the Mealy wake condition. Without this gate the
+                    // FSM is sitting in S0 holding for `cond`, but every cycle
+                    // it fires the do-body's reg writes — turning what the
+                    // user wrote as "pulse start_r when req asserts" into
+                    // "drive start_r every cycle until req asserts". The
+                    // comb stmts above are already gated; mirror that here.
+                    let gated_seq = if do_seq.is_empty() {
+                        Vec::new()
+                    } else {
+                        vec![Stmt::IfElse(IfElseOf {
+                            cond: cond.clone(),
+                            then_stmts: do_seq,
+                            else_stmts: Vec::new(),
+                            unique: false,
+                            span: sp,
+                        })]
+                    };
                     let fused_cond = Expr::new(
                         ExprKind::Binary(
                             BinOp::And,
@@ -4839,7 +4857,7 @@ fn partition_thread_body_impl(
                         ),
                         sp,
                     );
-                    (gated_comb, do_seq, fused_cond)
+                    (gated_comb, gated_seq, fused_cond)
                 }
 
                 // Flush any pending assigns first.

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -4278,6 +4278,51 @@ fn test_wait_0plus_cycle_until_mealy_fusion() {
 }
 
 #[test]
+fn test_wait_0plus_cycle_until_mealy_fusion_gates_seq_assigns() {
+    // Regression for issue #412: the Mealy-fusion lowering for
+    //   wait 0+ cycle until X;
+    //   do
+    //     <seq>r <= value;
+    //   until Y;
+    // must gate the do-body's seq assigns by X, just like it already
+    // gates the comb assigns. Before the fix, only the comb side and
+    // the state transition were gated; the seq assigns fired every
+    // cycle the FSM sat in the wait state, regardless of X. That
+    // turned "pulse r when X asserts" into "drive r every cycle until
+    // X asserts".
+    let source = "
+        module Drv
+          port clk:   in  Clock<SysDomain>;
+          port rst:   in  Reset<Async, Low>;
+          port go:    in  Bool;
+          port done:  in  Bool;
+          reg started: Bool reset rst => false;
+          thread T on clk rising, rst low
+            default comb
+            end default
+            wait 0+ cycle until go;
+            do
+              started <= true;
+            until done;
+          end thread T
+        end module Drv
+    ";
+    let sv = compile_to_sv(source);
+    // The seq assign for `started` must appear under an `if (go)` guard.
+    // Find the assignment to `_n_started` (or `started <=` in SV) and
+    // verify it sits within the `if (go)` block. Search for the gate
+    // followed by the assignment within a few lines.
+    // Generated SV uses `if (go) begin ... started <= 1'b1 ... end`.
+    let trimmed: String = sv.split_whitespace().collect::<Vec<_>>().join(" ");
+    assert!(
+        trimmed.contains("if (go) begin started <= 1'b1")
+            || trimmed.contains("if (go) started <= 1'b1"),
+        "expected do-body seq assign `started <= true` to be wrapped in `if (go)` \
+         (issue #412 Mealy-fusion seq-gating). Got SV:\n{sv}",
+    );
+}
+
+#[test]
 fn test_wait_0plus_requires_immediate_do_until() {
     // The Mealy fusion only handles `wait 0+ cycle until X;` followed
     // immediately by `do ... until ...;` (with or without a wrapping


### PR DESCRIPTION
## Summary

Fixes #412.

The Mealy-fusion lowering of

```arch
wait 0+ cycle until X;
do
  r <= value;
until Y;
```

was wrapping the do-body's comb assigns in `if (X) { ... }` and ANDing X into the state transition guard, but emitting the do-body's seq assigns **unconditionally**. Because the FSM sits in `S0` every cycle until X asserts, that meant `r <= value` fired every cycle of the hold — turning "pulse `r` when X asserts" into "drive `r` every cycle until X asserts".

The fix is one symmetric change in `src/elaborate.rs::partition_thread_body_impl`'s `build_fused` helper: mirror the existing comb gating to the seq side by wrapping `do_seq` in `if (cond)` before pushing it into the state's `seq_stmts`.

## Scope check (per issue body)

* **Mealy-fusion path** (`wait 0+ cycle until X; do BODY until Y;`): FIXED — both `comb` and `seq` drives now gated by X.
* **Mealy-fusion + lock path** (`wait 0+ cycle until X; lock R do BODY until Y end lock R;`): unchanged — lock lowering already wraps the first state's comb in `if (X)` and ANDs X into the transition guard. The seq side of the lock path was not affected by this bug because lock lowering produces its own gated structure.
* **Standalone `do BODY until cond;`** (not preceded by `wait 0+`): intentionally unchanged. That form is documented as a single-state hold where the body's drives (both `comb` and `seq`) fire every cycle while waiting for `cond` — the unconditional seq fire is the correct semantics there.

## Test plan

- [x] New unit regression `test_wait_0plus_cycle_until_mealy_fusion_gates_seq_assigns` asserts the generated SV wraps the do-body's `started <= true` in `if (go)`.
- [x] In-tree repro `tests/regression/issues/TwoThreadStartR.arch` (on branch `repro/issue-412-mealy-wait-do-until`): `count` now stays 0 forever as expected, instead of incrementing every cycle.
- [x] Full `cargo test --release` — 477 passed, 0 failed.
- [x] NIC-400 AHB bridge regressions (v1 single-beat, v2 fixed-length burst, v3 INCR-undef chunked) all PASS — no functional regression in production use of the Mealy-fusion path.

## Caveats / follow-up

* The cosmetic `req && 1'b1` artifact in the transition guard (visible in the generated SV) is unrelated to this bug — it's how the existing transition-cond builder folds the `WaitCycles(1)` literal. Worth a separate cleanup if it bothers anyone.