### PR TITLE
docs: do-until nested-control rejection + per-instance nested-for counters

### DIFF
--- a/doc/ARCH_HDL_Specification.md
+++ b/doc/ARCH_HDL_Specification.md
@@ -1709,8 +1709,8 @@ Expands to `NUM` independent threads, each with its own state register `_t{N}_st
 | `if/else (with wait inside)` | Yes (dispatch + rejoin) | Branches lower to disjoint state ranges; rejoin at exit |
 | `wait until cond;` | Yes | Advance when condition true |
 | `wait N cycle;` | Yes | Stall exactly N clock cycles (counter-based) |
-| `do { … } until cond;` | Yes | Hold state: drive comb outputs until condition fires |
-| `for i in s..e { … } end for` | Yes (per iteration) | Runtime bound; `i` becomes `_loop_cnt` register |
+| `do { … } until cond;` | Yes | Hold state: drive comb outputs until condition fires. Nested `lock` / `wait*` / `for` / `fork`/`join` / `return` inside the body are rejected at elaboration time; nested `if/else` (no waits) is permitted. |
+| `for i in s..e { … } end for` | Yes (per iteration) | Runtime bound; `i` becomes per-instance `_t{ti}_loop_cnt_{id}` register (nested `for` loops each get a distinct counter). |
 | `lock res { … } end lock res` | Yes (per body state) | Acquire mutex; zero-cycle if uncontended |
 | `fork … and … join` | Yes (product expansion) | Parallel branches; compiler generates product-state FSM |
 

--- a/doc/Arch_AI_Reference_Card.md
+++ b/doc/Arch_AI_Reference_Card.md
@@ -571,7 +571,7 @@ end module M
 | `wait until cond` | Block until condition true | Yes — new state |
 | `wait N cycle` | Stall exactly N clock cycles | Yes — new state |
 | `do … until cond` | Drive comb + seq while condition false | Yes — hold state |
-| `for i in s..e { … }` | Loop body; `i` replaced by `_loop_cnt` reg | Yes — per-body |
+| `for i in s..e { … }` | Loop body; per-instance `_t{ti}_loop_cnt_{id}` reg (nested `for` supported) | Yes — per-body |
 | `lock res { … } end lock res` | Acquire mutex, execute body, release | Yes — per-body |
 | `fork … and … join` | Execute branches in parallel (product-state FSM) | Yes — product |
 | `if/else` (no waits) | Same-state conditional comb/seq | No |
@@ -581,6 +581,8 @@ end module M
 - `default comb … end default` must appear **before** the thread body; it may drive only comb outputs, not signals also assigned with `<=`
 - `default when cond … end default` must appear **before** the thread body; only seq assigns inside
 - `lock` blocks must **not** be nested — compile error (mutual exclusion guarantee)
+- `do … until cond` bodies must **not** contain nested control flow (`lock`, `wait until`, `wait N cycle`, `for`, `fork`/`join`, or `return`) — compile error. The body is a single-state hold, not a loop; nested control would be silently dropped. Nested `if/else` (no waits inside) is permitted. Use a top-level `for c in 0..N-1` or split into multiple top-level `wait until`/`do … until` statements when iteration is needed.
+- Nested `for` loops in a thread each get their own per-instance counter register (`_t{ti}_loop_cnt_{id}`) — the outer loop's index is no longer clobbered by the inner loop.
 - `thread once` — FSM holds in terminal state instead of looping back to S0
 - `generate_for i in 0..N-1 / thread T_i … end thread T_i / end generate_for` — N identical threads
 - Multiple threads in one module share one `always_ff` — no multi-driver conflicts


### PR DESCRIPTION
## Summary

Two thread-lowering rules that landed in the last 24 hours of PRs are not yet reflected in the language docs. This PR adds short, targeted notes so the spec and the AI reference card match the compiler's behavior.

- **PR #411** (fix: reject nested control flow inside `do … until` body) — `do … until cond` now rejects nested `lock`, `wait*`, `for`, `fork`/`join`, and `return`. Nested `if/else` (no waits inside) is still permitted. The body is a single-state hold; nested control would otherwise be silently dropped.
- **PR #415** (fix(elaborate): per-instance loop counters for nested `for` in threads) — nested `for` loops in a thread now allocate distinct `_t{ti}_loop_cnt_{id}` registers per loop instance, so the outer index is no longer clobbered by the inner loop.

Both notes are added inline next to the existing statement-summary tables in:
- `doc/Arch_AI_Reference_Card.md` — table row + new rule bullet
- `doc/ARCH_HDL_Specification.md` §7a — table row notes

Total diff: 5 lines added, 3 lines changed.

## Test plan

- [x] `grep do.*until doc/*.md` reflects the new constraint
- [x] `grep loop_cnt doc/*.md` reflects per-instance counter naming
- [ ] Maintainer eyeballs the wording for tone consistency with the rest of the table entries