### PR TITLE
nic400: AXI4 -> APB target bridge

### DIFF
--- a/tests/nic400/BusApb.arch
+++ b/tests/nic400/BusApb.arch
@@ -1,0 +1,32 @@
+// APB v2.0 bus (initiator = bridge / master). Target perspective flips
+// directions so peripherals see psel/penable/paddr/pwrite/pwdata/pstrb/pprot
+// as inputs and drive prdata/pready/pslverr as outputs.
+//
+// Signal set is the standard AMBA APB v2.0 (IHI 0024C) master interface.
+// The two-phase setup/access protocol is enforced by the initiator's state
+// machine, not the bus:
+//   • Idle:   psel=0, penable=0
+//   • Setup:  psel=1, penable=0 (paddr/pwrite/pwdata/pstrb/pprot stable)
+//   • Access: psel=1, penable=1 (signals held stable; sampled by target;
+//                                advances to next phase when pready=1)
+//
+// APB v3 sideband (pwakeup, etc.) is not modelled — NIC-400 emits v2.0.
+bus BusApb
+  param ADDR_W: const = 32;
+  param DATA_W: const = 32;
+  param STRB_W: const = 4;            // = DATA_W/8 caller-set
+
+  // Control / address (initiator drives).
+  psel:    out Bool;
+  penable: out Bool;
+  paddr:   out UInt<ADDR_W>;
+  pwrite:  out Bool;
+  pwdata:  out UInt<DATA_W>;
+  pstrb:   out UInt<STRB_W>;
+  pprot:   out UInt<3>;
+
+  // Response (target drives).
+  prdata:  in  UInt<DATA_W>;
+  pready:  in  Bool;
+  pslverr: in  Bool;
+end bus BusApb

--- a/tests/nic400/Nic400ApbBridge.arch
+++ b/tests/nic400/Nic400ApbBridge.arch
@@ -1,0 +1,224 @@
+// AXI4 ↔ APB v2.0 target bridge.
+//
+// Presents an AXI4 target on `axi` (so the NIC-400 fabric can hang this off
+// one of its SlavePort downstreams as a peripheral-class slave) and drives an
+// APB v2.0 initiator on `apb` for the actual peripheral. Sized for the same
+// DATA_W/ADDR_W as the fabric (32/32 default) so it drops in alongside the
+// AHB bridge.
+//
+// What v1 implements:
+//   • AXI4 reads with arbitrary axlen (axlen+1 beats) → axlen+1 sequential
+//     APB read phases. Address increments by (1 << ar_size) per beat (AXI
+//     INCR semantics; WRAP not modelled — bridge treats every burst as INCR).
+//   • AXI4 writes with arbitrary axlen → axlen+1 sequential APB write
+//     phases. Each AXI W beat is married 1:1 with one APB access cycle:
+//     w_ready is held low through APB Setup and asserted on the pready=1
+//     cycle, so the master sees one combined handshake per beat.
+//   • APB v2.0 two-phase protocol: Setup (psel=1, penable=0) for exactly
+//     one cycle, then Access (psel=1, penable=1) until pready=1. Idle
+//     between bursts is psel=0, penable=0.
+//   • Error reporting: pslverr asserted on any beat → AXI b_resp = SLVERR
+//     (2) for writes, or AXI r_resp = SLVERR for that specific R beat.
+//     pslverr is accumulated across the burst for the final B response on
+//     writes; reads report per-beat.
+//   • Backpressure: APB pready=0 stretches the Access phase indefinitely;
+//     paddr/pwdata/pstrb/pprot/pwrite are held stable by the comb drive
+//     reading from captured registers.
+//
+// Concurrency: only one outstanding AXI transaction is supported at a time
+// per channel pair (R or W), but the read and write paths run as
+// independent threads. The APB bus only has a single initiator port, so
+// the two threads serialise their APB drives via the apb_lock resource.
+// In practice an AXI master will not have a read and a write to the same
+// peripheral in flight simultaneously through this single-target bridge,
+// but if both threads do contend, the priority mutex picks one and the
+// other waits.
+//
+// Protocol timing (single-beat AXI read, axlen=0):
+//   Cycle 0: master drives ar_valid + ar_addr. Bridge sees ar_valid in
+//            its wait state, asserts ar_ready=1 for one cycle and captures
+//            into ar_addr_r / ar_len_r / ar_size_r.
+//   Cycle 1: APB Setup — psel=1, penable=0, paddr=ar_addr_r, pwrite=0.
+//   Cycle 2+: APB Access — penable=1. Held until pready=1. On pready=1,
+//            prdata_r <= apb.prdata, rerr_r <= apb.pslverr.
+//   Cycle 3+: AXI R beat — r_valid=1, r_data=prdata_r, r_last=1. Held
+//            until r_ready=1.
+//
+// Limitations:
+//   • No AXI exclusive access (ar_lock / aw_lock are ignored).
+//   • APB v3 sideband (pwakeup) not modelled — see BusApb.arch.
+//   • AXI BURST type ignored — bridge always increments by (1 << size).
+//   • Only one outstanding R and one outstanding W at a time.
+module Nic400ApbBridge
+  param ADDR_WIDTH: const = 32;
+  param DATA_WIDTH: const = 32;
+  param STRB_WIDTH: const = 4;         // = DATA_WIDTH/8
+  param ID_WIDTH:   const = 3;
+
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Async, Low>;
+
+  // AXI4 target — bridge sees AR/AW/W as IN, drives R/B and the *_ready
+  // backpressure signals.
+  port axi: target    BusAxi4<ADDR_W=ADDR_WIDTH, DATA_W=DATA_WIDTH, STRB_W=STRB_WIDTH,
+                              ID_W=ID_WIDTH, READ=1, WRITE=1>;
+  // APB v2.0 initiator — bridge drives control/address/data, samples response.
+  port apb: initiator BusApb<ADDR_W=ADDR_WIDTH, DATA_W=DATA_WIDTH, STRB_W=STRB_WIDTH>;
+
+  // Mutex to serialise the multi-thread comb drives on apb.*. In steady
+  // state the two threads do not contend (one AXI master rarely has both
+  // a read and a write in flight to the same peripheral), but the lock
+  // keeps the multi-driver legal in the lowered FSM.
+  resource apb_lock: mutex<priority>;
+
+  // ── Read-path captured state ────────────────────────────────────────
+  reg ar_addr_r: UInt<ADDR_WIDTH> reset rst => 0;
+  reg ar_len_r:  UInt<8>          reset rst => 0;
+  reg ar_size_r: UInt<3>          reset rst => 0;
+  reg ar_prot_r: UInt<3>          reset rst => 0;
+  reg ar_id_r:   UInt<ID_WIDTH>   reset rst => 0;
+  reg prdata_r:  UInt<DATA_WIDTH> reset rst => 0;
+  reg rerr_r:    Bool             reset rst => false;
+
+  // ── Write-path captured state ───────────────────────────────────────
+  reg aw_addr_r: UInt<ADDR_WIDTH> reset rst => 0;
+  reg aw_len_r:  UInt<8>          reset rst => 0;
+  reg aw_size_r: UInt<3>          reset rst => 0;
+  reg aw_prot_r: UInt<3>          reset rst => 0;
+  reg aw_id_r:   UInt<ID_WIDTH>   reset rst => 0;
+  reg werr_r:    Bool             reset rst => false;
+
+  // ── Read thread ──────────────────────────────────────────────────────
+  // For each AXI AR: capture, then loop axlen+1 APB read phases, returning
+  // one AXI R beat per APB phase.
+  thread ReadXact on clk rising, rst low
+    default comb
+      axi.ar_ready = false;
+      axi.r_valid  = false;
+      axi.r_data   = 0;
+      axi.r_id     = 0;
+      axi.r_resp   = 0;
+      axi.r_last   = false;
+      apb.psel     = false;
+      apb.penable  = false;
+      apb.paddr    = 0;
+      apb.pwrite   = false;
+      apb.pwdata   = 0;
+      apb.pstrb    = 0;
+      apb.pprot    = 0;
+    end default
+    // Wait for an AR handshake. Mealy-fuse the capture into the wake state:
+    // assert ar_ready while ar_valid is high (loop exits next cycle).
+    wait 0+ cycle until axi.ar_valid;
+    do
+      axi.ar_ready = true;
+      ar_addr_r <= axi.ar_addr;
+      ar_len_r  <= axi.ar_len;
+      ar_size_r <= axi.ar_size;
+      ar_prot_r <= axi.ar_prot;
+      ar_id_r   <= axi.ar_id;
+    until true;
+    // For each beat: Setup → Access (captures prdata) → AXI R beat.
+    for b in 0..ar_len_r
+      // APB Setup phase — psel=1, penable=0 for exactly one cycle.
+      lock apb_lock
+        do
+          apb.psel    = true;
+          apb.penable = false;
+          apb.paddr   = (ar_addr_r + (b.zext<ADDR_WIDTH>() << ar_size_r)).trunc<ADDR_WIDTH>();
+          apb.pwrite  = false;
+          apb.pprot   = ar_prot_r;
+        until true;
+      end lock apb_lock
+      // APB Access phase — penable=1, hold until pready. Capture data+err.
+      lock apb_lock
+        do
+          apb.psel    = true;
+          apb.penable = true;
+          apb.paddr   = (ar_addr_r + (b.zext<ADDR_WIDTH>() << ar_size_r)).trunc<ADDR_WIDTH>();
+          apb.pwrite  = false;
+          apb.pprot   = ar_prot_r;
+          prdata_r <= apb.prdata;
+          rerr_r   <= apb.pslverr;
+        until apb.pready;
+      end lock apb_lock
+      // AXI R beat — drive r_valid=1 with captured prdata. Held until r_ready.
+      do
+        axi.r_valid = true;
+        axi.r_data  = prdata_r;
+        axi.r_id    = ar_id_r;
+        axi.r_resp  = rerr_r ? 2 : 0;
+        axi.r_last  = (b == ar_len_r);
+      until axi.r_ready;
+    end for
+  end thread ReadXact
+
+  // ── Write thread ─────────────────────────────────────────────────────
+  // For each AXI AW: capture, then loop axlen+1 APB write phases, each
+  // married 1:1 with one AXI W beat handshake. After all beats, drive B.
+  thread WriteXact on clk rising, rst low
+    default comb
+      axi.aw_ready = false;
+      axi.w_ready  = false;
+      axi.b_valid  = false;
+      axi.b_id     = 0;
+      axi.b_resp   = 0;
+      apb.psel     = false;
+      apb.penable  = false;
+      apb.paddr    = 0;
+      apb.pwrite   = false;
+      apb.pwdata   = 0;
+      apb.pstrb    = 0;
+      apb.pprot    = 0;
+    end default
+    // AW handshake — capture and clear werr_r for the new burst.
+    wait 0+ cycle until axi.aw_valid;
+    do
+      axi.aw_ready = true;
+      aw_addr_r <= axi.aw_addr;
+      aw_len_r  <= axi.aw_len;
+      aw_size_r <= axi.aw_size;
+      aw_prot_r <= axi.aw_prot;
+      aw_id_r   <= axi.aw_id;
+      werr_r    <= false;
+    until true;
+    // For each beat: Setup (no W consumption) → Access (consume W on pready).
+    for b in 0..aw_len_r
+      // APB Setup phase. w_ready stays low — the W beat must remain on the
+      // bus until the APB access completes.
+      lock apb_lock
+        do
+          apb.psel    = true;
+          apb.penable = false;
+          apb.paddr   = (aw_addr_r + (b.zext<ADDR_WIDTH>() << aw_size_r)).trunc<ADDR_WIDTH>();
+          apb.pwrite  = true;
+          apb.pwdata  = axi.w_data;
+          apb.pstrb   = axi.w_strb;
+          apb.pprot   = aw_prot_r;
+        until true;
+      end lock apb_lock
+      // APB Access phase. Hold pwdata/pstrb from the AXI W bus until
+      // pready=1, then assert w_ready=1 (same cycle) so the AXI handshake
+      // completes simultaneously with the APB access.
+      lock apb_lock
+        do
+          apb.psel    = true;
+          apb.penable = true;
+          apb.paddr   = (aw_addr_r + (b.zext<ADDR_WIDTH>() << aw_size_r)).trunc<ADDR_WIDTH>();
+          apb.pwrite  = true;
+          apb.pwdata  = axi.w_data;
+          apb.pstrb   = axi.w_strb;
+          apb.pprot   = aw_prot_r;
+          axi.w_ready = apb.pready;
+          werr_r <= werr_r or apb.pslverr;
+        until apb.pready;
+      end lock apb_lock
+    end for
+    // B response — drive once burst is fully drained.
+    do
+      axi.b_valid = true;
+      axi.b_id    = aw_id_r;
+      axi.b_resp  = werr_r ? 2 : 0;
+    until axi.b_ready;
+  end thread WriteXact
+end module Nic400ApbBridge

--- a/tests/nic400/tb_nic400_apb_bridge.cpp
+++ b/tests/nic400/tb_nic400_apb_bridge.cpp
@@ -1,0 +1,344 @@
+// AXI4 ↔ APB bridge testbench.
+//
+// The TB plays the AXI master AND the APB slave. For each scenario it drives
+// an AXI AR/AW phase and, on the peripheral side, watches for the APB Setup
+// (psel=1, penable=0) → Access (psel=1, penable=1) sequence, returns pready
+// (+ optional pslverr / prdata), and finally collects the AXI R or B beat.
+//
+// As with the AHB bridge TB, we sample on pre_edge() to observe the Mealy
+// comb drives BEFORE the lowered thread FSM advances past the handshake
+// state. The 2-state ARCH sim has no NBA region, so a write to an input
+// followed by eval() takes effect immediately.
+//
+// AXI resp encoding: 0 = OKAY, 2 = SLVERR.
+
+#include "VNic400ApbBridge.h"
+#include <cstdint>
+#include <cstdio>
+
+static VNic400ApbBridge dut;
+static uint64_t cycle = 0;
+
+static void tick() { dut.clk = 0; dut.eval(); dut.clk = 1; dut.eval(); cycle++; }
+static void pre_edge()  { dut.clk = 0; dut.eval(); }
+static void post_edge() { dut.clk = 1; dut.eval(); cycle++; }
+
+static void clear_inputs() {
+    // AXI master-driven (TB drives, bridge sees IN).
+    dut.axi_ar_valid = 0; dut.axi_ar_addr = 0; dut.axi_ar_id = 0;
+    dut.axi_ar_len = 0; dut.axi_ar_size = 0; dut.axi_ar_burst = 0;
+    dut.axi_ar_lock = 0; dut.axi_ar_cache = 0; dut.axi_ar_prot = 0;
+    dut.axi_ar_qos = 0; dut.axi_ar_region = 0;
+    dut.axi_r_ready = 0;
+    dut.axi_aw_valid = 0; dut.axi_aw_addr = 0; dut.axi_aw_id = 0;
+    dut.axi_aw_len = 0; dut.axi_aw_size = 0; dut.axi_aw_burst = 0;
+    dut.axi_aw_lock = 0; dut.axi_aw_cache = 0; dut.axi_aw_prot = 0;
+    dut.axi_aw_qos = 0; dut.axi_aw_region = 0;
+    dut.axi_w_valid = 0; dut.axi_w_data = 0; dut.axi_w_strb = 0; dut.axi_w_last = 0;
+    dut.axi_b_ready = 0;
+    // APB slave-driven (TB drives, bridge sees IN).
+    dut.apb_prdata = 0; dut.apb_pready = 0; dut.apb_pslverr = 0;
+}
+
+static int fail(const char* m) {
+    std::printf("FAIL %s (cycle=%llu)\n", m, (unsigned long long)cycle);
+    return 1;
+}
+
+// Wait up to `limit` cycles for `cond` to hold at pre_edge. Returns the
+// cycle index it was first seen, or -1 on timeout. Caller still owns the
+// dut state — this just advances clocks.
+static int wait_for(int limit, bool (*cond)()) {
+    for (int i = 0; i < limit; ++i) {
+        pre_edge();
+        if (cond()) return i;
+        post_edge();
+    }
+    return -1;
+}
+
+// ── APB slave model ────────────────────────────────────────────────────
+// Watches for one APB phase: spin on pre_edge until we see (psel && !penable)
+// for the Setup phase, then (psel && penable) for the Access phase, then
+// return pready (with optional pslverr and prdata for reads). Returns 0 on
+// success. The caller is responsible for driving AXI handshake side.
+struct ApbPhase {
+    uint32_t expect_paddr;
+    bool     expect_pwrite;
+    uint32_t expect_pwdata;     // ignored when !expect_pwrite
+    unsigned expect_pstrb;      // ignored when !expect_pwrite
+    uint32_t return_prdata;     // used when !expect_pwrite
+    bool     return_pslverr;
+    int      pready_delay;      // extra access cycles before asserting pready
+};
+
+static int run_apb_phase(const ApbPhase& p) {
+    // ── Setup phase: psel=1, penable=0, addresses+control valid ──
+    int setup_seen = 0;
+    for (int i = 0; i < 64 && !setup_seen; ++i) {
+        pre_edge();
+        if (dut.apb_psel && !dut.apb_penable) {
+            setup_seen = 1;
+            if ((uint32_t)dut.apb_paddr != p.expect_paddr) return fail("APB setup paddr mismatch");
+            if ((unsigned)dut.apb_pwrite != (p.expect_pwrite ? 1u : 0u)) return fail("APB setup pwrite mismatch");
+            if (p.expect_pwrite) {
+                if ((uint32_t)dut.apb_pwdata != p.expect_pwdata) return fail("APB setup pwdata mismatch");
+                if ((unsigned)dut.apb_pstrb  != p.expect_pstrb)  return fail("APB setup pstrb mismatch");
+            }
+        }
+        post_edge();
+    }
+    if (!setup_seen) return fail("APB setup phase never observed");
+
+    // ── Access phase: psel=1, penable=1. Hold pready=0 for `pready_delay`
+    // cycles to test backpressure, then assert pready (+ optional data/err).
+    // Bridge must hold paddr/pwdata stable across the stall. ──
+    int access_seen = 0;
+    for (int i = 0; i < 64 && !access_seen; ++i) {
+        pre_edge();
+        if (dut.apb_psel && dut.apb_penable) {
+            access_seen = 1;
+            // Stability check during stall.
+            if ((uint32_t)dut.apb_paddr != p.expect_paddr) return fail("APB access paddr drift");
+            if (p.expect_pwrite) {
+                if ((uint32_t)dut.apb_pwdata != p.expect_pwdata) return fail("APB access pwdata drift");
+            }
+        }
+        post_edge();
+    }
+    if (!access_seen) return fail("APB access phase never observed");
+
+    // Apply stall.
+    for (int i = 0; i < p.pready_delay; ++i) {
+        // pready stays low.
+        pre_edge();
+        if (!dut.apb_psel || !dut.apb_penable) return fail("APB phase aborted during stall");
+        if ((uint32_t)dut.apb_paddr != p.expect_paddr) return fail("APB paddr drift under stall");
+        if (p.expect_pwrite && (uint32_t)dut.apb_pwdata != p.expect_pwdata) return fail("APB pwdata drift under stall");
+        post_edge();
+    }
+
+    // Drive pready high (with prdata / pslverr as requested) until bridge
+    // exits the Access phase (psel falls or penable falls). Typically the
+    // bridge consumes it in one cycle.
+    dut.apb_pready = 1;
+    if (!p.expect_pwrite) dut.apb_prdata = p.return_prdata;
+    dut.apb_pslverr = p.return_pslverr ? 1 : 0;
+
+    int done = 0;
+    for (int i = 0; i < 8 && !done; ++i) {
+        post_edge();
+        pre_edge();
+        if (!dut.apb_penable) done = 1;     // bridge moved past Access
+    }
+    if (!done) return fail("APB access never released after pready=1");
+    dut.apb_pready = 0; dut.apb_prdata = 0; dut.apb_pslverr = 0;
+    return 0;
+}
+
+// ── AXI master helpers ─────────────────────────────────────────────────
+
+// Drive an AR phase and wait for ar_ready handshake. Address/len/size/prot
+// are held on the bus until the bridge captures them.
+static int issue_ar(uint32_t addr, unsigned len, unsigned size, unsigned prot, unsigned id) {
+    dut.axi_ar_valid = 1; dut.axi_ar_addr = addr; dut.axi_ar_len = len;
+    dut.axi_ar_size = size; dut.axi_ar_burst = 1; dut.axi_ar_prot = prot;
+    dut.axi_ar_id = id;
+
+    int handshake = 0;
+    for (int i = 0; i < 32 && !handshake; ++i) {
+        pre_edge();
+        if (dut.axi_ar_ready && dut.axi_ar_valid) handshake = 1;
+        post_edge();
+    }
+    if (!handshake) return fail("AR never accepted");
+    dut.axi_ar_valid = 0; dut.axi_ar_addr = 0; dut.axi_ar_len = 0;
+    dut.axi_ar_size = 0; dut.axi_ar_burst = 0; dut.axi_ar_prot = 0; dut.axi_ar_id = 0;
+    return 0;
+}
+
+static int issue_aw(uint32_t addr, unsigned len, unsigned size, unsigned prot, unsigned id) {
+    dut.axi_aw_valid = 1; dut.axi_aw_addr = addr; dut.axi_aw_len = len;
+    dut.axi_aw_size = size; dut.axi_aw_burst = 1; dut.axi_aw_prot = prot;
+    dut.axi_aw_id = id;
+
+    int handshake = 0;
+    for (int i = 0; i < 32 && !handshake; ++i) {
+        pre_edge();
+        if (dut.axi_aw_ready && dut.axi_aw_valid) handshake = 1;
+        post_edge();
+    }
+    if (!handshake) return fail("AW never accepted");
+    dut.axi_aw_valid = 0; dut.axi_aw_addr = 0; dut.axi_aw_len = 0;
+    dut.axi_aw_size = 0; dut.axi_aw_burst = 0; dut.axi_aw_prot = 0; dut.axi_aw_id = 0;
+    return 0;
+}
+
+// Capture one AXI R beat: drive r_ready=1, observe r_valid + r_data/r_resp.
+static int capture_r(uint32_t expect_data, unsigned expect_resp, bool expect_last) {
+    dut.axi_r_ready = 1;
+    int seen = 0;
+    for (int i = 0; i < 64 && !seen; ++i) {
+        pre_edge();
+        if (dut.axi_r_valid && dut.axi_r_ready) {
+            seen = 1;
+            if ((uint32_t)dut.axi_r_data != expect_data) return fail("R data mismatch");
+            if ((unsigned)dut.axi_r_resp != expect_resp) return fail("R resp mismatch");
+            if ((bool)dut.axi_r_last != expect_last)     return fail("R last mismatch");
+        }
+        post_edge();
+    }
+    if (!seen) return fail("R beat never delivered");
+    dut.axi_r_ready = 0;
+    return 0;
+}
+
+// Drive one AXI W beat and wait for w_ready.
+static int drive_w(uint32_t data, unsigned strb, bool last) {
+    dut.axi_w_valid = 1; dut.axi_w_data = data; dut.axi_w_strb = strb;
+    dut.axi_w_last = last ? 1 : 0;
+    int seen = 0;
+    for (int i = 0; i < 64 && !seen; ++i) {
+        pre_edge();
+        if (dut.axi_w_valid && dut.axi_w_ready) seen = 1;
+        post_edge();
+    }
+    if (!seen) return fail("W never accepted");
+    dut.axi_w_valid = 0; dut.axi_w_data = 0; dut.axi_w_strb = 0; dut.axi_w_last = 0;
+    return 0;
+}
+
+static int capture_b(unsigned expect_resp) {
+    dut.axi_b_ready = 1;
+    int seen = 0;
+    for (int i = 0; i < 64 && !seen; ++i) {
+        pre_edge();
+        if (dut.axi_b_valid && dut.axi_b_ready) {
+            seen = 1;
+            if ((unsigned)dut.axi_b_resp != expect_resp) return fail("B resp mismatch");
+        }
+        post_edge();
+    }
+    if (!seen) return fail("B never delivered");
+    dut.axi_b_ready = 0;
+    return 0;
+}
+
+// ── Scenarios ──────────────────────────────────────────────────────────
+
+static int scenario_single_read() {
+    if (issue_ar(0x1000, /*len*/0, /*size*/2, /*prot*/0x3, /*id*/1)) return 1;
+    ApbPhase ph = { 0x1000, false, 0, 0, 0xDEADBEEFu, false, 0 };
+    if (run_apb_phase(ph)) return 1;
+    if (capture_r(0xDEADBEEFu, 0, true)) return 1;
+    tick();
+    std::printf("PASS scenario_single_read\n");
+    return 0;
+}
+
+static int scenario_single_write() {
+    // AW + W race: drive both in lock-step. The bridge accepts AW first, then
+    // enters Setup; we drive W during the Setup phase so pwdata appears on
+    // axi.w_data when the bridge enters the Access state.
+    if (issue_aw(0x2000, /*len*/0, /*size*/2, /*prot*/0x7, /*id*/2)) return 1;
+    // Hold W on the bus from now — bridge will accept it during APB Access.
+    dut.axi_w_valid = 1; dut.axi_w_data = 0xCAFEBABEu;
+    dut.axi_w_strb = 0xF; dut.axi_w_last = 1;
+    ApbPhase ph = { 0x2000, true, 0xCAFEBABEu, 0xF, 0, false, 0 };
+    if (run_apb_phase(ph)) return 1;
+    // After pready=1, the bridge should have asserted w_ready in the same
+    // cycle as APB pready. Confirm w_valid/w_ready handshake completed.
+    // (run_apb_phase advanced past the access state; w handshake fired then.)
+    dut.axi_w_valid = 0; dut.axi_w_data = 0; dut.axi_w_strb = 0; dut.axi_w_last = 0;
+    if (capture_b(0)) return 1;
+    tick();
+    std::printf("PASS scenario_single_write\n");
+    return 0;
+}
+
+static int scenario_burst_read_4() {
+    if (issue_ar(0x3000, /*len*/3, /*size*/2, /*prot*/0, /*id*/3)) return 1;
+    uint32_t expected_data[4] = { 0x11111111u, 0x22222222u, 0x33333333u, 0x44444444u };
+    uint32_t expected_addr[4] = { 0x3000, 0x3004, 0x3008, 0x300C };
+    for (int b = 0; b < 4; ++b) {
+        ApbPhase ph = { expected_addr[b], false, 0, 0, expected_data[b], false, 0 };
+        if (run_apb_phase(ph)) return 1;
+        if (capture_r(expected_data[b], 0, b == 3)) return 1;
+    }
+    tick();
+    std::printf("PASS scenario_burst_read_4\n");
+    return 0;
+}
+
+// 4-beat write burst: drive W beats back-to-back. The bridge sequences
+// Setup → Access for each beat; the AXI W handshake fires inside Access
+// at the cycle pready=1. We keep w_valid asserted across the whole burst
+// and just swap w_data/w_last between beats, so the next Setup phase sees
+// the next beat's data on the bus.
+static int scenario_burst_write_4() {
+    if (issue_aw(0x4000, /*len*/3, /*size*/2, /*prot*/0, /*id*/4)) return 1;
+    uint32_t wdata[4] = { 0xAAAA0000u, 0xBBBB0001u, 0xCCCC0002u, 0xDDDD0003u };
+    uint32_t addrs[4] = { 0x4000, 0x4004, 0x4008, 0x400C };
+    // Present beat 0 immediately; subsequent beats are loaded at the bottom
+    // of each iteration.
+    dut.axi_w_valid = 1; dut.axi_w_data = wdata[0];
+    dut.axi_w_strb = 0xF; dut.axi_w_last = 0;
+    for (int b = 0; b < 4; ++b) {
+        dut.axi_w_data = wdata[b];
+        dut.axi_w_last = (b == 3) ? 1 : 0;
+        ApbPhase ph = { addrs[b], true, wdata[b], 0xF, 0, false, 0 };
+        if (run_apb_phase(ph)) return 1;
+    }
+    dut.axi_w_valid = 0; dut.axi_w_data = 0; dut.axi_w_strb = 0; dut.axi_w_last = 0;
+    if (capture_b(0)) return 1;
+    tick();
+    std::printf("PASS scenario_burst_write_4\n");
+    return 0;
+}
+
+static int scenario_slverr_write() {
+    if (issue_aw(0x5000, /*len*/0, /*size*/2, /*prot*/0, /*id*/5)) return 1;
+    dut.axi_w_valid = 1; dut.axi_w_data = 0x5A5A5A5Au;
+    dut.axi_w_strb = 0xF; dut.axi_w_last = 1;
+    ApbPhase ph = { 0x5000, true, 0x5A5A5A5Au, 0xF, 0, /*pslverr*/true, 0 };
+    if (run_apb_phase(ph)) return 1;
+    dut.axi_w_valid = 0; dut.axi_w_data = 0; dut.axi_w_strb = 0; dut.axi_w_last = 0;
+    if (capture_b(2)) return 1;   // SLVERR
+    tick();
+    std::printf("PASS scenario_slverr_write\n");
+    return 0;
+}
+
+// Backpressure: APB pready held low for several cycles mid-access. Bridge
+// must hold paddr / pwdata / pstrb stable. run_apb_phase enforces this via
+// stability checks during the stall.
+static int scenario_backpressure() {
+    if (issue_aw(0x6000, /*len*/0, /*size*/2, /*prot*/0, /*id*/6)) return 1;
+    dut.axi_w_valid = 1; dut.axi_w_data = 0x12345678u;
+    dut.axi_w_strb = 0xF; dut.axi_w_last = 1;
+    ApbPhase ph = { 0x6000, true, 0x12345678u, 0xF, 0, false, /*pready_delay*/5 };
+    if (run_apb_phase(ph)) return 1;
+    dut.axi_w_valid = 0; dut.axi_w_data = 0; dut.axi_w_strb = 0; dut.axi_w_last = 0;
+    if (capture_b(0)) return 1;
+    tick();
+    std::printf("PASS scenario_backpressure (5-cycle APB stall)\n");
+    return 0;
+}
+
+int main() {
+    dut.rst = 0;
+    clear_inputs();
+    for (int i = 0; i < 4; ++i) tick();
+    dut.rst = 1;
+    for (int i = 0; i < 3; ++i) tick();
+
+    if (scenario_single_read())   return 1;
+    if (scenario_single_write())  return 1;
+    if (scenario_burst_read_4())  return 1;
+    if (scenario_burst_write_4()) return 1;
+    if (scenario_slverr_write())  return 1;
+    if (scenario_backpressure())  return 1;
+
+    std::printf("PASS Nic400ApbBridge: 6/6 scenarios\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary

Adds an AXI4 -> APB v2.0 target bridge for the NIC-400 demo, allowing the
fabric to drive peripheral-class slaves (GPIO/UART/timers/etc.) without
needing a full AXI4 endpoint per peripheral.

**Files added (`tests/nic400/`):**
- `BusApb.arch` - AMBA APB v2.0 bus definition (32b addr/data default, +pstrb/pprot/pslverr).
- `Nic400ApbBridge.arch` - bridge module. AXI4 target on `axi`, APB initiator on `apb`. Two threads (read + write) sharing the APB-side comb drives via an `apb_lock: mutex<priority>` resource, mirroring the AHB bridge structure on main.
- `tb_nic400_apb_bridge.cpp` - C++ TB acting as AXI master + APB slave.

**Implementation:**
- AXI bursts of arbitrary `axlen` are split into `axlen+1` sequential APB phases.
- Each APB phase is Setup (psel=1, penable=0, 1 cycle) -> Access (psel=1, penable=1, hold until pready=1).
- Per-beat paddr increments by `(b << ar_size)` / `(b << aw_size)` (AXI INCR semantics).
- Reads: prdata/pslverr captured into a reg at pready=1, then driven on the AXI R channel (one beat per APB phase, with r_last on the final beat).
- Writes: AXI W beat is married 1:1 with one APB Access cycle - w_ready is held low through Setup and asserted on the pready=1 cycle, so master sees a combined handshake per beat. pslverr is OR-accumulated across the burst for the final B response.
- Backpressure: APB pready=0 stretches the Access phase; paddr/pwdata/pstrb/pwrite/pprot are driven combinationally from captured registers, so they remain stable.

## TB scenarios (all pass)

- [x] **Single-beat read** (axlen=0): 1 APB read phase, paddr=0x1000, prdata=0xDEADBEEF returned as r_data.
- [x] **Single-beat write** (axlen=0): 1 APB write phase, paddr/pwdata/pstrb checked, b_resp=OKAY.
- [x] **4-beat read burst** (axlen=3): 4 sequential APB reads at 0x3000/0x3004/0x3008/0x300C, distinct prdata per beat, r_last on beat 3.
- [x] **4-beat write burst** (axlen=3): 4 sequential APB writes at 0x4000+, distinct pwdata per beat.
- [x] **SLVERR write**: APB pslverr=1 mid-access -> AXI b_resp=2 (SLVERR).
- [x] **Backpressure**: APB pready held low for 5 cycles mid-access; paddr/pwdata stability checked across the stall.

## Known limitations

- No AXI exclusive access (ar_lock / aw_lock are ignored).
- APB v3 sideband (pwakeup) not modelled - BusApb is v2.0 only.
- AXI BURST type is ignored - bridge always increments paddr by `(b << size)` (INCR semantics). Compliant with the common case for peripheral access; WRAP/FIXED bursts are unusual targets for APB peripherals anyway.
- Only one outstanding R and one outstanding W at a time. AXI ordering across R/W within a single ID is naturally preserved.

## Verification

- `cargo run --bin arch -- sim tests/nic400/Nic400ApbBridge.arch tests/nic400/BusAxi4.arch tests/nic400/BusApb.arch --tb tests/nic400/tb_nic400_apb_bridge.cpp -o /tmp/apb_sim` -> `PASS Nic400ApbBridge: 6/6 scenarios`.
- `cargo test --release` -> `479 passed; 0 failed`.
- `cargo run --bin arch -- check tests/nic400/Nic400AhbBridge.arch tests/nic400/BusAhbLite.arch tests/nic400/BusAxi4.arch` -> clean (AHB bridge unchanged).

## Test plan

- [x] arch sim native passes 6/6 scenarios.
- [x] cargo test --release green.
- [x] arch check for the prior AHB bridge unchanged.