### PR TITLE
Fix #423: propagate type-alias bus params into generate_if/for wires

### DIFF
--- a/src/type_alias.rs
+++ b/src/type_alias.rs
@@ -358,13 +358,23 @@ fn substitute_in_gen_items(
             GenItem::Seq(b) => substitute_in_stmts(&mut b.stmts, aliases, errors),
             GenItem::Comb(b) => substitute_in_stmts(&mut b.stmts, aliases, errors),
             GenItem::Wire(w) => {
-                // Substitute any alias references in the wire's type tree
-                // and its bus_params overrides. Same treatment as a
-                // top-level WireDecl (see the ModuleBodyItem::WireDecl arm
-                // above), minus the alias-bus-param propagation — for
-                // generate_for-of-wire we keep things simple: the wire
-                // type is taken verbatim from source and substituted by
-                // subst_wire_decl per iteration in elaborate.rs.
+                // Propagate alias-carried bus_params onto the wire's
+                // bus_params slot before substituting the type tree — same
+                // treatment as the top-level ModuleBodyItem::WireDecl arm.
+                // Without this, a `wire w: AliasedBus;` inside a
+                // generate_if (or generate_for) body would lose the alias's
+                // bound bus args and fall back to the bus's defaults
+                // (issue #423).
+                let extra = alias_bus_params(&w.ty, aliases);
+                if !extra.is_empty() {
+                    // Wire's own bus_params (explicit) take precedence on
+                    // collision — append alias params first, then the
+                    // wire's existing params, so the wire's params win
+                    // last-wins. Matches the top-level WireDecl arm.
+                    let mut merged = extra;
+                    merged.append(&mut w.bus_params);
+                    w.bus_params = merged;
+                }
                 substitute_type(&mut w.ty, aliases, errors);
                 for pa in w.bus_params.iter_mut() {
                     substitute_in_expr(&mut pa.value, aliases, errors);

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -4374,6 +4374,42 @@ fn test_vec_bus_whole_vec_forward_to_child_inst() {
 }
 
 #[test]
+fn test_type_alias_bus_params_propagate_into_generate_if() {
+    // Regression for issue #423: a module-scope `type` alias that binds a
+    // bus's params used to lose those bindings when the alias was
+    // referenced from a `wire` inside a `generate_if` body. The bus then
+    // expanded with its declared param defaults instead of the alias's
+    // bound values — silently producing wrong-width signals in the
+    // generated SV.
+    //
+    // The fix propagates the alias's stored `bus_params` onto each
+    // `GenItem::Wire` the same way the top-level `WireDecl` substitution
+    // path already did. After the fix, both the module-scope wire and the
+    // generate_if wire must emit with the alias's `ID_W = 5`.
+    let source = include_str!(
+        "regression/issues/alias_in_generate_if/AliasInGenif.arch"
+    );
+    let sv = compile_to_sv(source);
+    // Both wires must be 5 bits wide. Before the fix, `bad_bus_ar_id` was
+    // 1 bit (BusAxi4's default ID_W).
+    assert!(
+        sv.contains("logic [4:0] ok_bus_ar_id"),
+        "module-scope alias use should expand with ID_W=5 (5-bit ar_id):\n{sv}",
+    );
+    assert!(
+        sv.contains("logic [4:0] bad_bus_ar_id"),
+        "alias use inside generate_if should also expand with ID_W=5 \
+         (issue #423 regression — used to fall back to bus default ID_W=1):\n{sv}",
+    );
+    // Defensive: the buggy shape must not reappear.
+    assert!(
+        !sv.contains("logic [0:0] bad_bus_ar_id")
+            && !sv.contains("logic bad_bus_ar_id"),
+        "found buggy 1-bit / scalar `bad_bus_ar_id` (issue #423 regression):\n{sv}",
+    );
+}
+
+#[test]
 fn test_wait_0plus_cycle_until_mealy_fusion_gates_seq_assigns() {
     // Regression for issue #412: the Mealy-fusion lowering for
     //   wait 0+ cycle until X;

--- a/tests/regression/issues/alias_in_generate_if/AliasInGenif.arch
+++ b/tests/regression/issues/alias_in_generate_if/AliasInGenif.arch
@@ -1,0 +1,44 @@
+// Regression for issue #423: a module-scope `type` alias that binds a
+// bus's params used to lose those bindings when referenced from inside a
+// `generate_if` body — the bus expanded with its declared param defaults
+// instead of the alias's bound values. The fix propagates the alias's
+// stored `bus_params` onto each `wire` GenItem the same way the top-level
+// `WireDecl` substitution path already did.
+
+bus BusAxi4
+  param ADDR_W: const = 32;
+  param ID_W:   const = 1;
+
+  ar_valid: out Bool;
+  ar_ready: in  Bool;
+  ar_addr:  out UInt<ADDR_W>;
+  ar_id:    out UInt<ID_W>;
+end bus BusAxi4
+
+module AliasInGenif
+  param FLAG: const = 1;
+
+  type WideBus = BusAxi4<ADDR_W=32, ID_W=5>;
+
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Async, Low>;
+
+  // Module-scope use: ok_bus_ar_id must be 5 bits (alias's ID_W=5).
+  wire ok_bus: WideBus;
+
+  // Inside a true generate_if: bad_bus_ar_id used to be 1 bit (bus
+  // default). With the fix, it must also be 5 bits.
+  generate_if FLAG > 0
+    wire bad_bus: WideBus;
+  end generate_if
+
+  // Drive every signal so single-driver / no-floating-port checks pass.
+  comb
+    ok_bus.ar_valid = true;
+    ok_bus.ar_addr  = 32'd0;
+    ok_bus.ar_id    = 5'd0;
+    bad_bus.ar_valid = true;
+    bad_bus.ar_addr  = 32'd0;
+    bad_bus.ar_id    = 5'd0;
+  end comb
+end module AliasInGenif


### PR DESCRIPTION
## Summary

Fixes #423. A module-scope `type WideBus = BusAxi4<ID_W=5, ...>;` alias lost its bound bus params when referenced from a `wire` inside a `generate_if` body — the bus expanded with its declared defaults (e.g. `ID_W=1`) instead.

Root cause: `substitute_in_body_item` (in `src/type_alias.rs`) calls `alias_bus_params(...)` for the top-level `ModuleBodyItem::WireDecl` arm to splice the alias's stored args onto the wire's `bus_params` slot. The parallel `GenItem::Wire` arm in `substitute_in_gen_items` did not. After the fix, the two paths are symmetric.

## What changed

- `src/type_alias.rs` — `GenItem::Wire` arm of `substitute_in_gen_items` now calls `alias_bus_params(&w.ty, aliases)` and merges the result into `w.bus_params` (alias params first, wire's explicit params last → wire wins on key collision), matching the top-level `WireDecl` arm.
- `tests/regression/issues/alias_in_generate_if/AliasInGenif.arch` — minimal self-contained repro: 2-param `BusAxi4`-shaped bus, alias bound to `ID_W=5`, used both at module scope and inside a true `generate_if FLAG > 0` block.
- `tests/integration_test.rs` — `test_type_alias_bus_params_propagate_into_generate_if`: asserts both `ok_bus_ar_id` (module scope) and `bad_bus_ar_id` (inside `generate_if`) emit as `logic [4:0]` in the generated SV, and that the buggy 1-bit shape does not reappear.

## Verification

- New regression test passes; full suite: **480 passed, 0 failed** (`cargo test --release`).
- Original repro now emits 5-bit `bad_bus_ar_id` (was 1-bit).
- `arch sim` of `tests/nic400/Nic400Fabric.arch` (which uses `generate_for` over aliased bus wires) still passes the smoke test — the same fix also covers the `generate_for` wire path, but the existing fabric didn't hit it because its alias use happens at port-level (`GenItem::Port`), which was already correct.

## Test plan

- [x] `cargo test --release` → 480 passed
- [x] Original repro (`/tmp/repro_alias_in_genif.arch`) emits `logic [4:0] bad_bus_ar_id`
- [x] `arch sim tests/nic400/Nic400Fabric.arch ...` smoke test still PASSes