### PR TITLE
fix: forward target Vec<Bus,N> port to child inst (issue #424)

### DIFF
--- a/src/codegen/module.rs
+++ b/src/codegen/module.rs
@@ -339,6 +339,17 @@ impl<'a> Codegen<'a> {
                             declared_names.insert(format!("{prefix}_{sname}"));
                         }
                     }
+                    // Vec-of-bus ports also emit at the SV signature with a
+                    // packed-array shape and the bare `<port>_<sig>` name
+                    // (no per-element suffix). Record those names too so the
+                    // inst auto-wire-decl pass treats `m_top -> m` whole-Vec
+                    // forwarding as already-declared and doesn't shadow the
+                    // SV ports with redundant `logic <port>_<sig>;` decls.
+                    if bi.count.is_some() {
+                        for (sname, _, _) in info.effective_signals(&pm) {
+                            declared_names.insert(format!("{}_{}", p.name.name, sname));
+                        }
+                    }
                 }
             }
         }

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -1424,46 +1424,74 @@ impl<'a> TypeChecker<'a> {
                 // We need to mark parent signals as "driven" when the inst OUTPUTS them.
                 if let Some((_, bus_name)) = target_bus_ports.iter().find(|(pn, _)| *pn == conn.port_name.name) {
                     if let Some((crate::resolve::Symbol::Bus(info), _)) = self.symbols.globals.get(bus_name) {
-                        // Resolve the parent-side base prefix:
-                        //   * `Ident("w")`           → `w`         (scalar wire/port)
-                        //   * `Index(Ident("v"), i)` → `v_<i>`     (Vec-of-bus element)
-                        let sig_base_owned: Option<String> = match &conn.signal.kind {
-                            ExprKind::Ident(n) => Some(n.clone()),
+                        // Find the inst's bus port perspective, params, and Vec count.
+                        let inst_bus_info = self.source.items.iter()
+                            .find_map(|item| match item {
+                                Item::Module(m2) if m2.name.name == inst.module_name.name => Some(m2.ports.as_slice()),
+                                Item::Fsm(f2) if f2.name.name == inst.module_name.name => Some(f2.ports.as_slice()),
+                                _ => None,
+                            })
+                            .and_then(|ports| ports.iter()
+                                .find(|p| p.name.name == conn.port_name.name)
+                                .and_then(|p| p.bus_info.as_ref()));
+                        let inst_perspective = inst_bus_info.map(|bi| bi.perspective);
+                        // Inst port's Vec count (Some(N) means `port: ... Vec<Bus, N>`).
+                        let inst_vec_count: Option<u32> = inst_bus_info
+                            .and_then(|bi| bi.count.as_ref())
+                            .and_then(|ce| {
+                                let empty: HashMap<String, Ty> = HashMap::new();
+                                self.eval_const_expr(ce, &empty).map(|v| v as u32)
+                            });
+
+                        // Resolve the parent-side base prefix(es):
+                        //   * `Ident("w")`           → `w`            (scalar bus wire/port)
+                        //                              or when inst port is Vec<Bus,N> and
+                        //                              `w` is also Vec<Bus,N>: expand to
+                        //                              `w_0`, `w_1`, ..., `w_{N-1}`.
+                        //   * `Index(Ident("v"), i)` → `v_<i>`        (Vec-of-bus element)
+                        let sig_bases: Vec<String> = match &conn.signal.kind {
+                            ExprKind::Ident(n) => {
+                                // Whole-Vec forwarding: child port `m: ... Vec<Bus,N>`
+                                // wired to parent ident `n` that is itself a Vec-of-Bus
+                                // port. Expand to N per-element prefixes so the
+                                // undriven-port check sees `n_0_<sig>`, `n_1_<sig>`, ...
+                                // (which is what the prefixes loop at the module-level
+                                // undriven check produces for a Vec<Bus,N> parent port).
+                                if let Some(n_count) = inst_vec_count {
+                                    if self.vec_of_bus_ports.get(n).copied() == Some(n_count) {
+                                        (0..n_count).map(|i| format!("{}_{}", n, i)).collect()
+                                    } else {
+                                        vec![n.clone()]
+                                    }
+                                } else {
+                                    vec![n.clone()]
+                                }
+                            }
                             ExprKind::Index(arr, idx) => {
                                 if let (ExprKind::Ident(arr_name), ExprKind::Literal(LitKind::Dec(i))) = (&arr.kind, &idx.kind) {
-                                    Some(format!("{}_{}", arr_name, i))
-                                } else { None }
+                                    vec![format!("{}_{}", arr_name, i)]
+                                } else { Vec::new() }
                             }
-                            _ => None,
+                            _ => Vec::new(),
                         };
-                        if let Some(sig_base) = sig_base_owned.as_ref() {
-                            // Find the inst's bus port perspective and params
-                            let inst_bus_info = self.source.items.iter()
-                                .find_map(|item| match item {
-                                    Item::Module(m2) if m2.name.name == inst.module_name.name => Some(m2.ports.as_slice()),
-                                    Item::Fsm(f2) if f2.name.name == inst.module_name.name => Some(f2.ports.as_slice()),
-                                    _ => None,
-                                })
-                                .and_then(|ports| ports.iter()
-                                    .find(|p| p.name.name == conn.port_name.name)
-                                    .and_then(|p| p.bus_info.as_ref()));
-                            let inst_perspective = inst_bus_info.map(|bi| bi.perspective);
-
+                        if !sig_bases.is_empty() {
                             let mut pm = info.default_param_map();
                             if let Some(bi) = inst_bus_info {
                                 for pa in &bi.params { pm.insert(pa.name.name.clone(), &pa.value); }
                             }
                             let eff = info.effective_signals(&pm);
-                            for (sname, sdir, _) in &eff {
-                                // Determine actual direction from inst's perspective
-                                let inst_dir = match inst_perspective {
-                                    Some(BusPerspective::Initiator) => *sdir,
-                                    Some(BusPerspective::Target) => (*sdir).flip(),
-                                    None => *sdir,
-                                };
-                                // If signal is an output FROM the inst, it drives the parent wire/port
-                                if inst_dir == Direction::Out {
-                                    driven.insert(format!("{}_{}", sig_base, sname));
+                            for sig_base in &sig_bases {
+                                for (sname, sdir, _) in &eff {
+                                    // Determine actual direction from inst's perspective
+                                    let inst_dir = match inst_perspective {
+                                        Some(BusPerspective::Initiator) => *sdir,
+                                        Some(BusPerspective::Target) => (*sdir).flip(),
+                                        None => *sdir,
+                                    };
+                                    // If signal is an output FROM the inst, it drives the parent wire/port
+                                    if inst_dir == Direction::Out {
+                                        driven.insert(format!("{}_{}", sig_base, sname));
+                                    }
                                 }
                             }
                         }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -4333,6 +4333,47 @@ fn test_nested_for_in_thread_uses_distinct_loop_counters() {
 }
 
 #[test]
+fn test_vec_bus_whole_vec_forward_to_child_inst() {
+    // Regression for issue #424: forwarding a `target Vec<Bus, N>`
+    // parent port to a child instance via a whole-Vec connection
+    // (`m <- m_top`) failed with `output port m_top_0_<sig> is not
+    // driven`, even though the child's body drives every `m[i].<sig>`.
+    //
+    // The undriven-port check expands a parent `Vec<Bus,N>` port into N
+    // per-element prefixes `m_top_0_<sig>`, …, `m_top_{N-1}_<sig>` —
+    // but the inst driver-tracking only credited the bare `m_top_<sig>`
+    // for the `Ident("m_top")` parent expression. The fix detects
+    // whole-Vec forwarding (child port and parent port both `Vec<Bus,N>`
+    // with matching N) and seeds the per-element prefixes.
+    //
+    // SV codegen sibling fix: declared_names now includes the packed
+    // `<port>_<sig>` form for Vec-of-bus ports so the inst auto-wire-decl
+    // pass doesn't emit redundant `logic <port>_<sig>;` lines that would
+    // shadow the actual SV port declarations.
+    let source = include_str!("regression/issues/vec_bus_forward/VecBusForward.arch");
+    let sv = compile_to_sv(source);
+    // Both modules must be emitted.
+    assert!(sv.contains("module Inner"), "expected Inner module in SV:\n{sv}");
+    assert!(sv.contains("module Wrapper"), "expected Wrapper module in SV:\n{sv}");
+    // The Vec-of-bus port should emit as packed signals on Wrapper.
+    assert!(sv.contains("m_top_v_valid"), "expected m_top_v_valid port:\n{sv}");
+    assert!(sv.contains("m_top_v_ready"), "expected m_top_v_ready port:\n{sv}");
+    assert!(sv.contains("m_top_v_data"), "expected m_top_v_data port:\n{sv}");
+    // Inner inst should forward each bus signal whole.
+    assert!(sv.contains("Inner inner"), "expected inst `Inner inner` in SV:\n{sv}");
+    assert!(sv.contains(".m_v_ready(m_top_v_ready)"),
+        "expected whole-Vec packed forwarding `.m_v_ready(m_top_v_ready)`:\n{sv}");
+    assert!(sv.contains(".m_v_valid(m_top_v_valid)"),
+        "expected whole-Vec packed forwarding `.m_v_valid(m_top_v_valid)`:\n{sv}");
+    // The pre-fix bug emitted shadowing wires like `logic m_top_v_ready;` —
+    // assert none of those slipped in.
+    assert!(!sv.contains("logic m_top_v_ready;"),
+        "redundant `logic m_top_v_ready;` declaration shadows the SV port (issue #424):\n{sv}");
+    assert!(!sv.contains("logic m_top_v_valid;"),
+        "redundant `logic m_top_v_valid;` declaration shadows the SV port (issue #424):\n{sv}");
+}
+
+#[test]
 fn test_wait_0plus_cycle_until_mealy_fusion_gates_seq_assigns() {
     // Regression for issue #412: the Mealy-fusion lowering for
     //   wait 0+ cycle until X;

--- a/tests/regression/issues/vec_bus_forward/VecBusForward.arch
+++ b/tests/regression/issues/vec_bus_forward/VecBusForward.arch
@@ -1,0 +1,50 @@
+// Regression for issue #424: forwarding a `target Vec<Bus, N>` parent
+// port to a child instance via whole-Vec connection (`m <- m_top`) used
+// to fail with "output port `m_top_0_<sig>` is not driven", even though
+// the child's body drives every `m[i].<sig>` in a `comb` block.
+//
+// Root cause: in `check_inst_decl`'s driver-tracking, when the parent
+// signal was an `Ident` whose name referred to a `Vec<Bus,N>` port and
+// the child's bus port was itself `Vec<Bus,N>`, only the bare prefix
+// `<n>_<sig>` was credited — but the parent's undriven-port check
+// expects the per-element prefixes `<n>_0_<sig>`, …, `<n>_{N-1}_<sig>`.
+// The fix expands whole-Vec forwarding into N per-element driver
+// records under the hood. A companion fix in `src/codegen/module.rs`
+// records the SV-side packed `<port>_<sig>` names in `declared_names`
+// so the inst auto-wire-decl pass doesn't shadow the actual port decls
+// with `logic <port>_<sig>;` redundant declarations.
+bus MiniBus
+  param W: const = 8;
+
+  v_valid:  out Bool;
+  v_ready:  in  Bool;
+  v_data:   out UInt<W>;
+end bus MiniBus
+
+module Inner
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Async, Low>;
+  port m: target Vec<MiniBus<W=8>, 3>;
+
+  // Target perspective flips signal directions, so Inner must drive
+  // every `in`-typed signal from the bus def (here just v_ready). The
+  // `out`-typed signals (v_valid, v_data) are driven by the *initiator*
+  // upstream — Wrapper forwards them in via `m <- m_top`.
+  comb
+    for i in 0..2
+      m[i].v_ready = true;
+    end for
+  end comb
+end module Inner
+
+module Wrapper
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Async, Low>;
+  port m_top: target Vec<MiniBus<W=8>, 3>;
+
+  inst inner: Inner
+    clk <- clk;
+    rst <- rst;
+    m   <- m_top;
+  end inst inner
+end module Wrapper


### PR DESCRIPTION
## Summary

Fixes #424.

Forwarding a `target Vec<Bus, N>` parent port to a child instance via a whole-Vec connection (`m <- m_top` where both sides are matching `Vec<Bus,N>`) failed with `output port m_top_0_<sig> is not driven`, even though the child's body drove every `m[i].<sig>` in a `comb` block.

Two small fixes:

- **`src/typecheck.rs`** — `check_inst_decl` driver tracking: when the inst's bus port is `Vec<Bus,N>` and the parent signal is `Ident(n)` where `n` is itself a `Vec<Bus,N>` port with matching count, expand to N per-element prefixes `n_0_<sig>`, …, `n_{N-1}_<sig>` — which is what the module-level undriven-port check expects. The pre-existing per-element `Index(Ident, i)` path is unchanged.

- **`src/codegen/module.rs`** — `declared_names` for Vec-of-bus ports also records the packed `<port>_<sig>` form (alongside the existing `<port>_<i>_<sig>` per-element entries). The SV emission for Vec-of-bus ports uses the packed shape, so without this the inst auto-wire-decl pass emitted shadowing `logic <port>_<sig>;` lines that duplicated the SV port declarations.

This is the sixth elaboration-pass / driver-tracking issue uncovered by the user's NIC-400 work (after #410, #412, #414, #422, #423).

## Test plan

- [x] `cargo test --release` — 524 tests pass
- [x] New regression test `test_vec_bus_whole_vec_forward_to_child_inst` (and `tests/regression/issues/vec_bus_forward/VecBusForward.arch`) covers the minimal Inner + Wrapper whole-Vec forwarding shape and asserts SV is clean of shadowing wire decls.
- [x] `arch check` and `arch build` on the repro both succeed.
- [x] `verilator --lint-only` on the generated SV is clean.
- [x] NIC-400 fabric smoke sim still PASSes (existing fabric uses per-element `<- edges[i][j]`; unaffected).
- [x] NIC-400 AHB bridge sim still PASSes.