### PR TITLE
fix(sim_codegen): fold bus-flat signal widths through module params (#427)

### DIFF
--- a/src/sim_codegen/mod.rs
+++ b/src/sim_codegen/mod.rs
@@ -4737,9 +4737,17 @@ impl<'a> SimCodegen<'a> {
         let mut widths      = build_widths(&m.ports, &m.body, &m.params);
         let mut signed_names = build_signed_names(&m.ports, &m.body);
 
-        // Add bus flattened signals to wide_names and widths
+        // Add bus flattened signals to wide_names and widths.
+        // Use the param-aware width evaluator (issue #427): when a bus's
+        // per-signal width depends on a bus param that the call site binds
+        // to an enclosing-module param Ident (e.g. `up: target MiniAxi<ID_W=ID_W>`
+        // where the module declares `param ID_W: const = 3`), the
+        // substituted `flat_ty` still contains the module-param Ident;
+        // resolving it requires the enclosing module's params. Without this,
+        // the param-aware fold fails and the legacy `eval_width` fallback
+        // returns the conservative 32, corrupting concat shift offsets.
         for (flat_name, flat_ty) in &bus_flat {
-            let bits = type_bits_te(flat_ty);
+            let bits = type_bits_te_with_params(flat_ty, &m.params);
             widths.insert(flat_name.clone(), bits);
             if type_is_signed_scalar(flat_ty) { signed_names.insert(flat_name.clone()); }
             if bits > 64 { wide_names.insert(flat_name.clone()); }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -4410,6 +4410,46 @@ fn test_type_alias_bus_params_propagate_into_generate_if() {
 }
 
 #[test]
+fn test_concat_bus_field_width_uses_module_param_binding() {
+    // Regression for issue #427: sim codegen's Concat pack expression
+    // used wrong shift offsets when operands were bus-port FieldAccess
+    // and one of the bus's per-signal widths was bound by a
+    // module-param-substituted bus-alias param.
+    //
+    // The minimal repro declares `bus MiniAxi` with `param ID_W = 1` and
+    // `ar_id: out UInt<ID_W>`, then a module that does
+    // `port up: target MiniAxi<ID_W=ID_W>` with `param ID_W: const = 3`.
+    // Inside the module a concat `{up.ar_addr, up.ar_id}` packs the two
+    // fields. Before the fix the bus-flat width entry for `up_ar_id` was
+    // built by `type_bits_te` with no module-param context, so the
+    // substituted `UInt<ID_W>` width Ident fell through the param-aware
+    // fold to the legacy conservative `eval_width = 32` — and the concat
+    // shifted `up_ar_addr` by 32 bits instead of 3.
+    //
+    // After the fix, the bus-flat width fold uses
+    // `type_bits_te_with_params(&m.params)`, so `up_ar_id`'s width
+    // resolves correctly to 3 and the concat shift is `<< 3`.
+    let source = include_str!(
+        "regression/issues/concat_bus_field_width/ConcatBusFieldWidth.arch"
+    );
+    let cpp = compile_to_sim_h(source, false);
+    // The pack expression must shift `up_ar_addr` by 3 (the width of
+    // `up_ar_id`), not 32.
+    assert!(
+        cpp.contains("((uint64_t)(up_ar_addr) << 3)"),
+        "expected pack shift `(up_ar_addr) << 3` (width of up.ar_id = 3) \
+         in sim cpp (issue #427 regression):\n{cpp}"
+    );
+    // The buggy 32-bit shift must be gone.
+    assert!(
+        !cpp.contains("((uint64_t)(up_ar_addr) << 32)"),
+        "found buggy `(up_ar_addr) << 32` pack shift (issue #427 regression); \
+         the bus-flat width lookup for `up_ar_id` resolved to 32 instead \
+         of 3:\n{cpp}"
+    );
+}
+
+#[test]
 fn test_wait_0plus_cycle_until_mealy_fusion_gates_seq_assigns() {
     // Regression for issue #412: the Mealy-fusion lowering for
     //   wait 0+ cycle until X;

--- a/tests/regression/issues/concat_bus_field_width/ConcatBusFieldWidth.arch
+++ b/tests/regression/issues/concat_bus_field_width/ConcatBusFieldWidth.arch
@@ -1,0 +1,43 @@
+// Regression for issue #427: sim codegen's `Concat` pack expression
+// used wrong shift offsets when operands were bus-port `FieldAccess`es
+// AND one of the bus's per-signal widths was bound by a
+// module-param-substituted bus-alias param.
+//
+// Before fix: width of `up.ar_id` (declared `UInt<ID_W>` inside the bus
+// with `ID_W` bound to the enclosing module's `param ID_W = 3`) inferred
+// as 32 (the legacy `eval_width` conservative fallback). The concat
+// emitted `(up_ar_addr) << 32` instead of `<< 3`. SV codegen was
+// unaffected.
+//
+// After fix: bus-flat signal widths fold through the enclosing module's
+// params via `type_bits_te_with_params`, so `up.ar_id` is correctly 3
+// and the concat shifts `up_ar_addr` by 3.
+bus MiniAxi
+  param ADDR_W: const = 32;
+  param ID_W:   const = 1;
+
+  ar_valid: out Bool;
+  ar_ready: in  Bool;
+  ar_addr:  out UInt<ADDR_W>;
+  ar_id:    out UInt<ID_W>;
+end bus MiniAxi
+
+module ConcatBusFieldWidth
+  param ADDR_WIDTH: const = 32;
+  param ID_W: const = 3;
+
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Async, Low>;
+  port up: target MiniAxi<ADDR_W=ADDR_WIDTH, ID_W=ID_W>;
+
+  param PAYLOAD_W: const = ADDR_WIDTH + ID_W;
+
+  let p: UInt<PAYLOAD_W> = {up.ar_addr, up.ar_id};
+  wire u_addr: UInt<ADDR_WIDTH>;
+  wire u_id:   UInt<ID_W>;
+  comb
+    u_addr = p[PAYLOAD_W-1 : PAYLOAD_W-ADDR_WIDTH];
+    u_id   = p[ID_W-1 : 0];
+    up.ar_ready = true;
+  end comb
+end module ConcatBusFieldWidth


### PR DESCRIPTION
## Summary

When a bus param is bound at the port site to an enclosing-module-param Ident (e.g. `port up: target MiniAxi<ID_W=ID_W>` with the module's `param ID_W: const = 3`), sim codegen registered every flat bus signal's width via `type_bits_te(flat_ty)` with no module-param context. After bus-param substitution, the flat `TypeExpr` still contained the module-level `Ident("ID_W")`; without enclosing-module params the param-aware fold returned 0 and fell through to the legacy `eval_width`, which conservatively returns **32** for any non-literal shape.

Downstream effect: `up.ar_id` (declared `UInt<ID_W>`, ID_W=3) got width=32 in `widths`. The concat-shift pass packed `{up.ar_addr, up.ar_id}` as `up_ar_addr << 32` instead of `<< 3`. SV codegen was unaffected — it resolves widths through a different path. It happened to work for params bound to 32 (e.g. `ADDR_WIDTH`) because `eval_width`'s fallback is 32.

This is the seventh thread/codegen-lowering issue uncovered through NIC-400 work; #423 had the same shape (bus-param substitution that works in some emitters drops out in another).

## Fix

One-line: pass module params to the width fold —
`type_bits_te_with_params(flat_ty, &m.params)` at `src/sim_codegen/mod.rs:4742`.

## Test plan

- [x] New regression `test_concat_bus_field_width_uses_module_param_binding` — asserts sim cpp contains `(up_ar_addr) << 3)` and not the buggy `(up_ar_addr) << 32)`.
- [x] Full `cargo test --release` passes (482 integration tests, +1 = 483).
- [x] NIC-400 fabric smoke sim still PASS.
- [x] NIC-400 AHB bridge sim still PASS.

Fixes #427