### PR TITLE
nic400: per-edge register slices via Nic400FabricRs1 wrapper

### DIFF
--- a/tests/nic400/Nic400EdgeRegSlice.arch
+++ b/tests/nic400/Nic400EdgeRegSlice.arch
@@ -1,0 +1,198 @@
+// Per-edge AXI4 register slice for the NIC-400 fabric.
+//
+// Wraps 5 generic `RegSliceChannel` instances — one per AXI4 channel
+// (AR, R, AW, W, B) — that each break the combinational valid+payload
+// path on that channel while leaving the ready path combinational.
+//
+// Latency: +1 cycle on every channel handshake (sustained 1 transfer/cycle).
+// Use:     drop in between a master and the fabric to relax timing on
+//          long routes; integrators get to choose per-edge insertion.
+//
+// Direction:
+//   `up`   = master-facing side (target perspective — flips signal directions
+//            from the bus definition, so e.g. `up.ar_valid` is an INPUT here).
+//   `dn`   = fabric-facing side (initiator perspective — this module drives
+//            outgoing AXI signals onto the fabric).
+//
+// Per-channel field pack widths:
+//   AR / AW: addr(ADDR_WIDTH) + id(ID_W) + len(8) + size(3) + burst(2)
+//          + lock(1) + cache(4) + prot(3) + qos(4) + region(4)
+//   R      : data(DATA_WIDTH) + id(ID_W) + resp(2) + last(1)
+//   W      : data(DATA_WIDTH) + strb(STRB_WIDTH) + last(1)
+//   B      : id(ID_W) + resp(2)
+//
+// For the AR/AW/W channels the data flows master→fabric, so the slice's
+// "up" port is wired to the master side. For the R/B channels the data
+// flows fabric→master, so the slice's "up" port is wired to the FABRIC
+// side instead. From the slice's point of view, "up" always means "the
+// side that issues the transfer"; the EdgeRegSlice's external `up` /
+// `dn` ports name the AXI roles (M-facing / S-facing), not the per-channel
+// transfer direction.
+module Nic400EdgeRegSlice
+  param ADDR_WIDTH:    const = 32;
+  param DATA_WIDTH:    const = 32;
+  param STRB_WIDTH:    const = 4;
+  // ID_W matches the master-facing AXI4 id width (NOT the wider slave-side
+  // id the fabric uses internally). The Nic400FabricRs1 wrapper drops
+  // these slices upstream of `Nic400MasterPort.m`, so the bus shape here
+  // mirrors that port's `ID_W = MASTER_ID_W`.
+  param ID_W:          const = 3;
+
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Async, Low>;
+
+  // Master-facing target / fabric-facing initiator. The aliases below
+  // bind the bus params once so we don't repeat the long parameter list
+  // at every reference.
+  type EdgeBus = BusAxi4<ADDR_W=ADDR_WIDTH, DATA_W=DATA_WIDTH, STRB_W=STRB_WIDTH,
+                          ID_W=ID_W, READ=1, WRITE=1>;
+  port up: target    EdgeBus;
+  port dn: initiator EdgeBus;
+
+  // Packed payload widths per channel.
+  param AR_PAYLOAD_W: const = ADDR_WIDTH + ID_W + 8 + 3 + 2 + 1 + 4 + 3 + 4 + 4;
+  param R_PAYLOAD_W:  const = DATA_WIDTH + ID_W + 2 + 1;
+  param AW_PAYLOAD_W: const = ADDR_WIDTH + ID_W + 8 + 3 + 2 + 1 + 4 + 3 + 4 + 4;
+  param W_PAYLOAD_W:  const = DATA_WIDTH + STRB_WIDTH + 1;
+  param B_PAYLOAD_W:  const = ID_W + 2;
+
+  // ── AR channel (master → fabric) ───────────────────────────────────────
+  // Pack master-side AR fields into a single UInt for the slice input;
+  // unpack the slice output back into fabric-side AR fields.
+  let ar_pack: UInt<AR_PAYLOAD_W> =
+      {up.ar_addr, up.ar_id, up.ar_len, up.ar_size, up.ar_burst,
+       up.ar_lock, up.ar_cache, up.ar_prot, up.ar_qos, up.ar_region};
+  wire ar_unpack: UInt<AR_PAYLOAD_W>;
+
+  inst rs_ar: RegSliceChannel
+    param PAYLOAD_W = AR_PAYLOAD_W;
+    clk        <- clk;
+    rst        <- rst;
+    up_valid   <- up.ar_valid;
+    up_payload <- ar_pack;
+    up_ready   -> up.ar_ready;
+    dn_valid   -> dn.ar_valid;
+    dn_payload -> ar_unpack;
+    dn_ready   <- dn.ar_ready;
+  end inst rs_ar
+
+  // ── R channel (fabric → master) ────────────────────────────────────────
+  let r_pack: UInt<R_PAYLOAD_W> =
+      {dn.r_data, dn.r_id, dn.r_resp, dn.r_last};
+  wire r_unpack: UInt<R_PAYLOAD_W>;
+
+  inst rs_r: RegSliceChannel
+    param PAYLOAD_W = R_PAYLOAD_W;
+    clk        <- clk;
+    rst        <- rst;
+    up_valid   <- dn.r_valid;
+    up_payload <- r_pack;
+    up_ready   -> dn.r_ready;
+    dn_valid   -> up.r_valid;
+    dn_payload -> r_unpack;
+    dn_ready   <- up.r_ready;
+  end inst rs_r
+
+  // ── AW channel (master → fabric) ───────────────────────────────────────
+  let aw_pack: UInt<AW_PAYLOAD_W> =
+      {up.aw_addr, up.aw_id, up.aw_len, up.aw_size, up.aw_burst,
+       up.aw_lock, up.aw_cache, up.aw_prot, up.aw_qos, up.aw_region};
+  wire aw_unpack: UInt<AW_PAYLOAD_W>;
+
+  inst rs_aw: RegSliceChannel
+    param PAYLOAD_W = AW_PAYLOAD_W;
+    clk        <- clk;
+    rst        <- rst;
+    up_valid   <- up.aw_valid;
+    up_payload <- aw_pack;
+    up_ready   -> up.aw_ready;
+    dn_valid   -> dn.aw_valid;
+    dn_payload -> aw_unpack;
+    dn_ready   <- dn.aw_ready;
+  end inst rs_aw
+
+  // ── W channel (master → fabric) ────────────────────────────────────────
+  let w_pack: UInt<W_PAYLOAD_W> =
+      {up.w_data, up.w_strb, up.w_last};
+  wire w_unpack: UInt<W_PAYLOAD_W>;
+
+  inst rs_w: RegSliceChannel
+    param PAYLOAD_W = W_PAYLOAD_W;
+    clk        <- clk;
+    rst        <- rst;
+    up_valid   <- up.w_valid;
+    up_payload <- w_pack;
+    up_ready   -> up.w_ready;
+    dn_valid   -> dn.w_valid;
+    dn_payload -> w_unpack;
+    dn_ready   <- dn.w_ready;
+  end inst rs_w
+
+  // ── B channel (fabric → master) ────────────────────────────────────────
+  let b_pack: UInt<B_PAYLOAD_W> =
+      {dn.b_id, dn.b_resp};
+  wire b_unpack: UInt<B_PAYLOAD_W>;
+
+  inst rs_b: RegSliceChannel
+    param PAYLOAD_W = B_PAYLOAD_W;
+    clk        <- clk;
+    rst        <- rst;
+    up_valid   <- dn.b_valid;
+    up_payload <- b_pack;
+    up_ready   -> dn.b_ready;
+    dn_valid   -> up.b_valid;
+    dn_payload -> b_unpack;
+    dn_ready   <- up.b_ready;
+  end inst rs_b
+
+  // ── Unpack the registered payloads into fabric / master signals ────────
+  //
+  // Field layouts (MSB-first, mirroring the {...} concat order above):
+  //   AR/AW : [addr][id][len][size][burst][lock][cache][prot][qos][region]
+  //   R     : [data][id][resp][last]
+  //   W     : [data][strb][last]
+  //   B     : [id][resp]
+  //
+  // Bit ranges are spelled out inline using ADDR_WIDTH / DATA_WIDTH / ID_W
+  // so the arithmetic stays auditable.
+  comb
+    // ── AR unpack → dn ──
+    dn.ar_addr   = ar_unpack[AR_PAYLOAD_W-1                  : AR_PAYLOAD_W-ADDR_WIDTH];
+    dn.ar_id     = ar_unpack[AR_PAYLOAD_W-ADDR_WIDTH-1       : AR_PAYLOAD_W-ADDR_WIDTH-ID_W];
+    dn.ar_len    = ar_unpack[AR_PAYLOAD_W-ADDR_WIDTH-ID_W-1  : AR_PAYLOAD_W-ADDR_WIDTH-ID_W-8];
+    dn.ar_size   = ar_unpack[AR_PAYLOAD_W-ADDR_WIDTH-ID_W-8-1: AR_PAYLOAD_W-ADDR_WIDTH-ID_W-8-3];
+    dn.ar_burst  = ar_unpack[AR_PAYLOAD_W-ADDR_WIDTH-ID_W-8-3-1 : AR_PAYLOAD_W-ADDR_WIDTH-ID_W-8-3-2];
+    dn.ar_lock   = ar_unpack[AR_PAYLOAD_W-ADDR_WIDTH-ID_W-8-3-2-1 : AR_PAYLOAD_W-ADDR_WIDTH-ID_W-8-3-2-1] != 0;
+    dn.ar_cache  = ar_unpack[AR_PAYLOAD_W-ADDR_WIDTH-ID_W-8-3-2-1-1 : AR_PAYLOAD_W-ADDR_WIDTH-ID_W-8-3-2-1-4];
+    dn.ar_prot   = ar_unpack[AR_PAYLOAD_W-ADDR_WIDTH-ID_W-8-3-2-1-4-1 : AR_PAYLOAD_W-ADDR_WIDTH-ID_W-8-3-2-1-4-3];
+    dn.ar_qos    = ar_unpack[AR_PAYLOAD_W-ADDR_WIDTH-ID_W-8-3-2-1-4-3-1 : AR_PAYLOAD_W-ADDR_WIDTH-ID_W-8-3-2-1-4-3-4];
+    dn.ar_region = ar_unpack[3:0];
+
+    // ── R unpack → up ──
+    up.r_data = r_unpack[R_PAYLOAD_W-1                : R_PAYLOAD_W-DATA_WIDTH];
+    up.r_id   = r_unpack[R_PAYLOAD_W-DATA_WIDTH-1     : R_PAYLOAD_W-DATA_WIDTH-ID_W];
+    up.r_resp = r_unpack[R_PAYLOAD_W-DATA_WIDTH-ID_W-1: R_PAYLOAD_W-DATA_WIDTH-ID_W-2];
+    up.r_last = r_unpack[0:0] != 0;
+
+    // ── AW unpack → dn ──
+    dn.aw_addr   = aw_unpack[AW_PAYLOAD_W-1                  : AW_PAYLOAD_W-ADDR_WIDTH];
+    dn.aw_id     = aw_unpack[AW_PAYLOAD_W-ADDR_WIDTH-1       : AW_PAYLOAD_W-ADDR_WIDTH-ID_W];
+    dn.aw_len    = aw_unpack[AW_PAYLOAD_W-ADDR_WIDTH-ID_W-1  : AW_PAYLOAD_W-ADDR_WIDTH-ID_W-8];
+    dn.aw_size   = aw_unpack[AW_PAYLOAD_W-ADDR_WIDTH-ID_W-8-1: AW_PAYLOAD_W-ADDR_WIDTH-ID_W-8-3];
+    dn.aw_burst  = aw_unpack[AW_PAYLOAD_W-ADDR_WIDTH-ID_W-8-3-1 : AW_PAYLOAD_W-ADDR_WIDTH-ID_W-8-3-2];
+    dn.aw_lock   = aw_unpack[AW_PAYLOAD_W-ADDR_WIDTH-ID_W-8-3-2-1 : AW_PAYLOAD_W-ADDR_WIDTH-ID_W-8-3-2-1] != 0;
+    dn.aw_cache  = aw_unpack[AW_PAYLOAD_W-ADDR_WIDTH-ID_W-8-3-2-1-1 : AW_PAYLOAD_W-ADDR_WIDTH-ID_W-8-3-2-1-4];
+    dn.aw_prot   = aw_unpack[AW_PAYLOAD_W-ADDR_WIDTH-ID_W-8-3-2-1-4-1 : AW_PAYLOAD_W-ADDR_WIDTH-ID_W-8-3-2-1-4-3];
+    dn.aw_qos    = aw_unpack[AW_PAYLOAD_W-ADDR_WIDTH-ID_W-8-3-2-1-4-3-1 : AW_PAYLOAD_W-ADDR_WIDTH-ID_W-8-3-2-1-4-3-4];
+    dn.aw_region = aw_unpack[3:0];
+
+    // ── W unpack → dn ──
+    dn.w_data = w_unpack[W_PAYLOAD_W-1                : W_PAYLOAD_W-DATA_WIDTH];
+    dn.w_strb = w_unpack[W_PAYLOAD_W-DATA_WIDTH-1     : W_PAYLOAD_W-DATA_WIDTH-STRB_WIDTH];
+    dn.w_last = w_unpack[0:0] != 0;
+
+    // ── B unpack → up ──
+    up.b_id   = b_unpack[B_PAYLOAD_W-1     : B_PAYLOAD_W-ID_W];
+    up.b_resp = b_unpack[1:0];
+  end comb
+end module Nic400EdgeRegSlice

--- a/tests/nic400/Nic400FabricRs1.arch
+++ b/tests/nic400/Nic400FabricRs1.arch
@@ -1,0 +1,83 @@
+// 3×4 NIC-400 fabric wrapper with per-master register slices.
+//
+// Drops a 1-stage `Nic400EdgeRegSlice` on every (master → fabric) edge,
+// so each master's AXI4 handshake to the inner fabric absorbs one cycle
+// of pipeline latency. The slave side is forwarded straight through —
+// integrators typically place slave-side reg slices upstream of the
+// memory controllers / peripherals rather than inside the interconnect.
+//
+// External port shape is identical to `Nic400Fabric` — drop-in
+// replacement at the system level.
+//
+// Wiring strategy:
+//   • `inner: Nic400Fabric` — full 3×4 crossbar, no internal pipelining.
+//   • The slave side uses whole-Vec bus forwarding (compiler fix #424):
+//       inner.s -> s;
+//     so the parent's `s: initiator Vec<SlaveBus, NUM_SLAVES>` directly
+//     drives `inner.s` with no per-slave gasket.
+//   • The master side cannot whole-Vec forward because we insert a
+//     slice on each edge. We declare a `Vec<MasterBus, NUM_MASTERS>`
+//     wire `m_int[]` that bridges the slices' fabric-facing `dn` ports
+//     into `inner.m[i]`, and a `generate_for` instantiates one
+//     `Nic400EdgeRegSlice` per master.
+//
+// Caveats:
+//   • STAGES=1 only. Multi-stage slicing would require a parameter on
+//     the wrapper plus chained instances of `Nic400EdgeRegSlice`.
+//   • The slice's `dn` is `initiator` perspective, so its out-typed
+//     signals drive `m_int[i]` (a wire), and its in-typed signals are
+//     driven by `m_int[i]` — that's the same shape the MasterPort
+//     uses for its `outs[j]` initiator port against the `edges[i][j]`
+//     wire in `Nic400Fabric`.
+module Nic400FabricRs1
+  param NUM_MASTERS:   const = 3;
+  param NUM_SLAVES:    const = 4;
+  param ADDR_WIDTH:    const = 32;
+  param DATA_WIDTH:    const = 32;
+  param STRB_WIDTH:    const = 4;            // = DATA_WIDTH / 8
+  param MASTER_ID_W:   const = 3;
+  param SLAVE_ID_W:    const = 5;            // MASTER_ID_W + ceil(log2(NUM_MASTERS))
+  param NS_W:          const = 2;            // ceil(log2(NUM_SLAVES))
+
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Async, Low>;
+
+  // Same bus aliases as `Nic400Fabric` so the external port shape is
+  // bit-identical to the un-sliced fabric.
+  type MasterBus = BusAxi4<ADDR_W=ADDR_WIDTH, DATA_W=DATA_WIDTH, STRB_W=STRB_WIDTH,
+                            ID_W=MASTER_ID_W, READ=1, WRITE=1>;
+  type SlaveBus  = BusAxi4<ADDR_W=ADDR_WIDTH, DATA_W=DATA_WIDTH, STRB_W=STRB_WIDTH,
+                            ID_W=SLAVE_ID_W,  READ=1, WRITE=1>;
+
+  port m: target    Vec<MasterBus, NUM_MASTERS>;
+  port s: initiator Vec<SlaveBus, NUM_SLAVES>;
+
+  // Internal wire carrying the fabric-facing side of each per-master
+  // register slice. `inner.m[i]` will be driven by `m_int[i]`.
+  wire m_int: Vec<MasterBus, NUM_MASTERS>;
+
+  // ── Inner crossbar ───────────────────────────────────────────────────
+  // Slave side is forwarded directly (relies on fix #424); master side
+  // is wired through `m_int[]` so the per-master slices can sit in
+  // between.
+  inst inner: Nic400Fabric
+    clk <- clk;
+    rst <- rst;
+    for i in 0..NUM_MASTERS-1
+      m[i] <- m_int[i];
+    end for
+    s -> s;
+  end inst inner
+
+  // ── Per-master register slices ───────────────────────────────────────
+  // EdgeRegSlice's defaults (ID_W=3) match the master-facing AXI4 width,
+  // so we don't need to override params here.
+  generate_for i in 0..NUM_MASTERS-1
+    inst rs_i: Nic400EdgeRegSlice
+      clk <- clk;
+      rst <- rst;
+      up <- m[i];
+      dn -> m_int[i];
+    end inst rs_i
+  end generate_for
+end module Nic400FabricRs1

--- a/tests/nic400/tb_nic400_fabric_regslice.cpp
+++ b/tests/nic400/tb_nic400_fabric_regslice.cpp
@@ -1,0 +1,199 @@
+// 3x4 write-path smoke test for the Nic400FabricRs1 (per-master reg slices).
+//
+// Mirrors tb_nic400_fabric_write.cpp but targets the wrapper module
+// `Nic400FabricRs1`, which inserts a 1-stage `Nic400EdgeRegSlice` on
+// every (master → inner-fabric) edge. The external port shape is
+// identical to the un-sliced fabric (drop-in replacement), so the
+// per-handshake checks are the same — the only behavioural delta is
+// that each phase (AW, W, B) takes one extra cycle of latency through
+// the slice, plus a similar +1-cycle hop on the response path. We
+// bump the per-phase observation watchdog from 32 → 64 cycles to
+// absorb that.
+//
+// Coverage (5 (master, slave) pairs):
+//   M0 → S0, M1 → S1, M2 → S2, M0 → S3, M2 → S0.
+
+#include "VNic400FabricRs1.h"
+#include <cstdint>
+#include <cstdio>
+
+static VNic400FabricRs1 dut;
+static uint64_t cycle = 0;
+
+static void tick() {
+    dut.clk = 0; dut.eval();
+    dut.clk = 1; dut.eval();
+    cycle++;
+}
+
+// Pre-edge sample / post-edge advance, so the TB can observe Mealy
+// handshake combos BEFORE the rising edge fuses them into next-state.
+static void pre_edge() {
+    dut.clk = 0; dut.eval();
+}
+static void post_edge() {
+    dut.clk = 1; dut.eval();
+    cycle++;
+}
+
+static void clear_inputs() {
+    for (int i = 0; i < 3; ++i) {
+        dut.m_ar_valid[i] = 0; dut.m_ar_addr[i] = 0; dut.m_ar_id[i] = 0;
+        dut.m_ar_len[i] = 0;   dut.m_ar_size[i] = 0; dut.m_ar_burst[i] = 0;
+        dut.m_r_ready[i] = 0;
+        dut.m_aw_valid[i] = 0; dut.m_aw_addr[i] = 0; dut.m_aw_id[i] = 0;
+        dut.m_aw_len[i] = 0;   dut.m_aw_size[i] = 0; dut.m_aw_burst[i] = 0;
+        dut.m_w_valid[i] = 0;  dut.m_w_data[i] = 0;  dut.m_w_strb[i] = 0;
+        dut.m_w_last[i] = 0;
+        dut.m_b_ready[i] = 0;
+    }
+    for (int j = 0; j < 4; ++j) {
+        dut.s_ar_ready[j] = 0;
+        dut.s_r_valid[j] = 0; dut.s_r_data[j] = 0; dut.s_r_id[j] = 0;
+        dut.s_r_resp[j] = 0;  dut.s_r_last[j] = 0;
+        dut.s_aw_ready[j] = 0;
+        dut.s_w_ready[j] = 0;
+        dut.s_b_valid[j] = 0; dut.s_b_id[j] = 0; dut.s_b_resp[j] = 0;
+    }
+}
+
+static int fail(const char* msg) {
+    std::printf("FAIL %s (cycle=%llu)\n", msg, (unsigned long long)cycle);
+    return 1;
+}
+
+static int do_write(unsigned master, unsigned addr_high_bits,
+                    unsigned slave, unsigned master_id, uint32_t data) {
+    uint32_t addr = (slave << 28) | (addr_high_bits << 12) | 0x0;
+    unsigned expect_slave_id = ((master & 0x3) << 3) | (master_id & 0x7);
+
+    dut.m_aw_addr[master]  = addr;
+    dut.m_aw_id[master]    = master_id;
+    dut.m_aw_len[master]   = 0;
+    dut.m_aw_size[master]  = 2;
+    dut.m_aw_burst[master] = 1;
+    dut.m_aw_valid[master] = 1;
+
+    dut.m_w_valid[master] = 1;
+    dut.m_w_data[master]  = data;
+    dut.m_w_strb[master]  = 0xF;
+    dut.m_w_last[master]  = 1;
+
+    dut.s_aw_ready[slave] = 1;
+    dut.s_w_ready[slave]  = 1;
+
+    int aw_seen_m = 0, w_seen_m = 0;     // master-side handshake (when slice accepts)
+    int aw_seen_s = 0, w_seen_s = 0;     // slave-side handshake (for routing check + data check)
+    int aw_id_correct = -1;
+    int w_data_correct = -1;
+
+    // Watchdog: 64 cycles (vs 32 in the un-sliced TB) — each handshake
+    // walks through one reg slice + the inner fabric thread.
+    //
+    // Critical: with a reg slice on the master side, AXI protocol says the
+    // master must drop aw_valid as soon as it observes its OWN aw_ready=1
+    // (slice's up-side handshake). If we wait for the slave-side handshake
+    // to clear m_aw_valid, the still-held m_aw_valid causes the slice to
+    // accept-while-drain → phantom second AW reaches the slave → SlavePort
+    // gets stuck on the second AW waiting for an s_aw_ready that we already
+    // cleared.
+    //
+    // So: track master-side handshake separately and clear m_aw_valid as
+    // soon as the slice accepts it. Track slave-side independently for the
+    // routing-correctness assertions.
+    for (int i = 0; i < 64; ++i) {
+        pre_edge();
+        // Master-side: clear m_aw_valid the moment the slice accepts.
+        if (!aw_seen_m && dut.m_aw_valid[master] && dut.m_aw_ready[master]) {
+            aw_seen_m = 1;
+        }
+        if (!w_seen_m && dut.m_w_valid[master] && dut.m_w_ready[master]) {
+            w_seen_m = 1;
+        }
+        // Slave-side: assert routing + capture data.
+        if (!aw_seen_s && dut.s_aw_valid[slave] && dut.s_aw_ready[slave]) {
+            aw_seen_s = 1;
+            aw_id_correct = (dut.s_aw_id[slave] == expect_slave_id) ? 1 : 0;
+            for (unsigned other_s = 0; other_s < 4; ++other_s) {
+                if (other_s != slave && dut.s_aw_valid[other_s]) {
+                    return fail("AW leaked to wrong slave");
+                }
+            }
+        }
+        if (!w_seen_s && dut.s_w_valid[slave] && dut.s_w_ready[slave]) {
+            w_seen_s = 1;
+            w_data_correct = (dut.s_w_data[slave] == data && dut.s_w_last[slave]) ? 1 : 0;
+        }
+        post_edge();
+        // Clear master-side drives as soon as the slice accepts them.
+        if (aw_seen_m) dut.m_aw_valid[master] = 0;
+        if (w_seen_m)  dut.m_w_valid[master]  = 0;
+        if (aw_seen_s && w_seen_s) {
+            dut.s_aw_ready[slave]  = 0;
+            dut.s_w_ready[slave]   = 0;
+            break;
+        }
+    }
+    int aw_seen = aw_seen_s;
+    int w_seen  = w_seen_s;
+    if (!aw_seen) return fail("AW handshake never observed");
+    if (!w_seen)  return fail("W handshake never observed");
+    if (aw_id_correct == 0) {
+        std::printf("FAIL AW id wrong at slave %u (expected 0x%x)\n", slave, expect_slave_id);
+        return 1;
+    }
+    if (w_data_correct == 0) {
+        std::printf("FAIL W data or last wrong at slave %u (expected data 0x%x, last=1)\n", slave, data);
+        return 1;
+    }
+
+    // ── B phase ─────────────────────────────────────────────────────────
+    dut.m_b_ready[master] = 1;
+    dut.s_b_valid[slave]  = 1;
+    dut.s_b_id[slave]     = expect_slave_id;
+    dut.s_b_resp[slave]   = 0;
+
+    int b_seen = 0;
+    for (int i = 0; i < 64; ++i) {
+        pre_edge();
+        if (dut.m_b_valid[master] && dut.m_b_ready[master]) {
+            if ((dut.m_b_id[master] & 0x7) != (master_id & 0x7)) {
+                std::printf("FAIL B id strip at master %u: got 0x%x, expected 0x%x\n",
+                            master, (unsigned)dut.m_b_id[master], master_id);
+                return 1;
+            }
+            for (unsigned other_m = 0; other_m < 3; ++other_m) {
+                if (other_m != master && dut.m_b_valid[other_m]) {
+                    return fail("B leaked to wrong master");
+                }
+            }
+            b_seen = 1;
+            post_edge();
+            break;
+        }
+        post_edge();
+    }
+    if (!b_seen) return fail("B handshake never observed at master");
+
+    dut.s_b_valid[slave]  = 0;
+    dut.m_b_ready[master] = 0;
+    tick();
+    return 0;
+}
+
+int main() {
+    dut.rst = 0;
+    clear_inputs();
+    for (int i = 0; i < 4; ++i) tick();
+    dut.rst = 1;
+    for (int i = 0; i < 3; ++i) tick();
+
+    if (do_write(0, 0x100, 0, 3, 0xDEAD0000u)) return 1;
+    if (do_write(1, 0x200, 1, 5, 0xCAFE1111u)) return 1;
+    if (do_write(2, 0x300, 2, 7, 0xB00B2222u)) return 1;
+    if (do_write(0, 0x400, 3, 1, 0xFEED3333u)) return 1;
+    if (do_write(2, 0x500, 0, 2, 0xABCD4444u)) return 1;
+
+    std::printf("PASS Nic400FabricRs1 write 3x4: AW + W + B route through per-master reg slices across 5 (M,S) pairs\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary

Drops a single-stage AXI4 register slice on every (master → fabric) edge so each master's handshake to the inner fabric absorbs +1 cycle of pipeline latency. ARM's NIC-400 ships per-edge reg slices as a configurable feature for timing closure; this PR gives the demo the same capability via a thin wrapper module.

## Files

- **`Nic400EdgeRegSlice.arch`** — per-edge AXI4 reg slice. Wraps 5 instances of the existing `RegSliceChannel` (one per AR/R/AW/W/B), each on a packed `UInt<PAYLOAD_W>` payload. Direction is per-channel: AR/AW/W use up→dn (master→fabric), R/B use dn→up (fabric→master).
- **`Nic400FabricRs1.arch`** — wrapper around `Nic400Fabric`. Forwards `s` to the inner via whole-Vec forwarding (#424). One `Nic400EdgeRegSlice` per master between external `m[i]` and `inner.m[i]` via a `Vec<MasterBus, NUM_MASTERS>` wire.
- **`tb_nic400_fabric_regslice.cpp`** — exercises the 5 (master, slave) write scenarios with a 64-cycle watchdog absorbing the slice latency.

## Compiler-fix dependencies (all merged)

- #425 (PR #425) — type aliases inside `generate_if` bodies propagate alias-bound bus params correctly.
- #426 (PR #426) — whole-Vec<Bus,N> port forwarding from parent to inst (enables `inner.s -> s`).
- #428 (PR #428) — `sim_codegen` Concat width through module-substituted bus-alias params (the `Concat({addr, id, len, …})` payload pack now uses correct shift offsets).

## TB observation note

With a reg slice on the master side, the master must drop `aw_valid`/`w_valid` as soon as it observes its **own** ready signal (`m_aw_ready=1`), not when the slave-side handshake fires several cycles later. If we wait for the slave-side handshake to clear `m_aw_valid`, the still-held valid causes the slice's accept-while-drain logic to correctly accept a phantom second copy → SlavePort hangs waiting for an `s_aw_ready` that's already been cleared. The TB tracks master-side and slave-side handshakes separately.

## Test plan

- [x] `arch sim tb_nic400_fabric_regslice.cpp` against `Nic400FabricRs1` — 5 (master, slave) write pairs through reg slices, AW+W+B routing + ID-prefix correctness — PASS
- [x] `tb_nic400_fabric_smoke.cpp` against `Nic400Fabric` — unchanged, PASS
- [x] `tb_nic400_fabric_latency.cpp` — unchanged, PASS (1.00 transfers/cycle)
- [x] `tb_nic400_fabric_write.cpp` — unchanged, PASS

## Limitations

- STAGES=1 only. Multi-stage slicing would need a parameter on the wrapper plus chained `Nic400EdgeRegSlice` instances.
- Slave-side reg slices not inserted (integrators typically place those upstream of memory controllers / peripherals).