### PR TITLE
fix(lower_threads): apply for-loop continuation to all if/else terminal arms (#422)

### DIFF
--- a/src/elaborate.rs
+++ b/src/elaborate.rs
@@ -5426,7 +5426,7 @@ fn partition_thread_body_impl(
                     // For-loop exit: guard trailing seq assigns by exit condition.
                     // Fires on the same clock edge as the for-loop's exit transition.
                     let exit_cond = last.multi_transitions[1].0.clone();
-                    for s in cur_seq.drain(..) {
+                    for s in cur_seq.iter().cloned() {
                         last.seq_stmts.push(Stmt::IfElse(IfElse {
                             cond: exit_cond.clone(),
                             then_stmts: vec![s],
@@ -5435,6 +5435,59 @@ fn partition_thread_body_impl(
                             span,
                         }));
                     }
+                    // Issue #422: when the for-body's last statement is an
+                    // if/else (or any multi-arm dispatch) with each arm
+                    // independently falling off the end, the for-loop's
+                    // "exit" arm sits not only in `last` but also in the
+                    // sibling terminal states. Apply the same trailing-seq
+                    // merge to every such state so all arms fire the
+                    // outer-block trailing assigns (e.g. the outer
+                    // counter's data update).
+                    //
+                    // The marker for "this transition leaves the body" is
+                    // `target == states.len()` (i.e. the not-yet-existing
+                    // index just past the for-group, which our
+                    // unconditional-advance flush would land on). This is
+                    // distinct from `THREAD_TARGET_NEXT`, which by this
+                    // point has been resolved.
+                    let exit_pos = states.len();
+                    let n = states.len();
+                    if n >= 2 {
+                        for si in 0..n - 1 {
+                            // Determine the OR of all conditions targeting exit_pos.
+                            let mut exit_arm_conds: Vec<Expr> = Vec::new();
+                            for (cond, target) in &states[si].multi_transitions {
+                                if *target == exit_pos && !thread_target_is_special(*target) {
+                                    exit_arm_conds.push(cond.clone());
+                                }
+                            }
+                            if exit_arm_conds.is_empty() {
+                                continue;
+                            }
+                            let arm_cond = if exit_arm_conds.len() == 1 {
+                                exit_arm_conds.pop().unwrap()
+                            } else {
+                                let mut acc = exit_arm_conds.remove(0);
+                                for c in exit_arm_conds {
+                                    acc = Expr::new(
+                                        ExprKind::Binary(BinOp::Or, Box::new(acc), Box::new(c)),
+                                        span,
+                                    );
+                                }
+                                acc
+                            };
+                            for s in cur_seq.iter().cloned() {
+                                states[si].seq_stmts.push(Stmt::IfElse(IfElse {
+                                    cond: arm_cond.clone(),
+                                    then_stmts: vec![s],
+                                    else_stmts: Vec::new(),
+                                    unique: false,
+                                    span,
+                                }));
+                            }
+                        }
+                    }
+                    cur_seq.clear();
                     true
                 } else if last.transition_cond.is_some() && last.multi_transitions.is_empty() {
                     // State with a conditional transition (e.g. do..until, wait until):
@@ -5759,7 +5812,7 @@ fn lower_thread_for(
                     // normally happen for a nested-for shape, but be
                     // robust if a future construct produces a non-empty
                     // multi_transitions with only intra-body targets.
-                    last.seq_stmts.push(cnt_inc);
+                    last.seq_stmts.push(cnt_inc.clone());
                     last.multi_transitions = new_trans;
                     last.multi_transitions.push((
                         Expr::new(ExprKind::Binary(BinOp::Lt, Box::new(cnt_ident.clone()), Box::new(end_w.clone())), span),
@@ -5786,7 +5839,7 @@ fn lower_thread_for(
             // ticks once per completed inner iteration.
             last.seq_stmts.push(Stmt::IfElse(IfElse {
                 cond: inner_exit,
-                then_stmts: vec![cnt_inc],
+                then_stmts: vec![cnt_inc.clone()],
                 else_stmts: Vec::new(),
                 unique: false,
                 span,
@@ -5834,7 +5887,7 @@ fn lower_thread_for(
             // only increment when a beat is actually accepted
             last.seq_stmts.push(Stmt::IfElse(IfElse {
                 cond: body_cond_clone,
-                then_stmts: vec![cnt_inc],
+                then_stmts: vec![cnt_inc.clone()],
                 else_stmts: Vec::new(),
                 unique: false,
                 span,
@@ -5855,11 +5908,88 @@ fn lower_thread_for(
                 ExprKind::Binary(BinOp::Gte, Box::new(cnt_ident.clone()), Box::new(end_w.clone())),
                 span,
             );
-            last.seq_stmts.push(cnt_inc);
+            last.seq_stmts.push(cnt_inc.clone());
             last.multi_transitions = vec![
                 (loop_cond, loop_back_target),
                 (exit_cond, usize::MAX),
             ];
+        }
+    }
+
+    // Issue #422: the body's last statement might be an if/else (or any
+    // multi-arm dispatch) where each arm independently falls off the end of
+    // the for body. The transformation above patches only `result.last_mut()`
+    // (one terminal arm); other arms have their own "off-the-end" transitions
+    // sitting in non-last states. Without patching them too, they jump
+    // unconditionally past the for group on every iteration, skipping the
+    // loop-continuation cascade (counter increment / loop-back / exit). Apply
+    // the same cascade to every such state so all terminal arms participate.
+    //
+    // An "off-the-end" transition is one with `target >= result_len` and not
+    // a special sentinel (THREAD_TARGET_NEXT, return). Skip the last state
+    // (already handled above).
+    let n = result.len();
+    if n >= 2 {
+        for si in 0..n - 1 {
+            let prev = std::mem::take(&mut result[si].multi_transitions);
+            if prev.is_empty() {
+                continue;
+            }
+            let mut new_trans: Vec<(Expr, usize)> = Vec::with_capacity(prev.len() + 1);
+            let mut off_end_conds: Vec<Expr> = Vec::new();
+            for (cond, target) in prev {
+                if target >= result_len && !thread_target_is_special(target) {
+                    off_end_conds.push(cond);
+                } else {
+                    new_trans.push((cond, target));
+                }
+            }
+            if off_end_conds.is_empty() {
+                result[si].multi_transitions = new_trans;
+                continue;
+            }
+            let off_end = if off_end_conds.len() == 1 {
+                off_end_conds.pop().unwrap()
+            } else {
+                let mut acc = off_end_conds.remove(0);
+                for c in off_end_conds {
+                    acc = Expr::new(ExprKind::Binary(BinOp::Or, Box::new(acc), Box::new(c)), span);
+                }
+                acc
+            };
+            let off_end_for_inc = off_end.clone();
+            let off_end_for_loop = off_end.clone();
+            let off_end_for_exit = off_end;
+            // Counter increment guarded by the off-the-end condition.
+            result[si].seq_stmts.push(Stmt::IfElse(IfElse {
+                cond: off_end_for_inc,
+                then_stmts: vec![cnt_inc.clone()],
+                else_stmts: Vec::new(),
+                unique: false,
+                span,
+            }));
+            // Replace off-the-end transitions with loop-back + exit cascade.
+            new_trans.push((
+                Expr::new(ExprKind::Binary(
+                    BinOp::And,
+                    Box::new(off_end_for_loop),
+                    Box::new(Expr::new(ExprKind::Binary(
+                        BinOp::Lt, Box::new(cnt_ident.clone()), Box::new(end_w.clone()),
+                    ), span)),
+                ), span),
+                loop_back_target,
+            ));
+            new_trans.push((
+                Expr::new(ExprKind::Binary(
+                    BinOp::And,
+                    Box::new(off_end_for_exit),
+                    Box::new(Expr::new(ExprKind::Binary(
+                        BinOp::Gte, Box::new(cnt_ident.clone()), Box::new(end_w.clone()),
+                    ), span)),
+                ), span),
+                usize::MAX,
+            ));
+            result[si].multi_transitions = new_trans;
         }
     }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -4410,6 +4410,92 @@ fn test_type_alias_bus_params_propagate_into_generate_if() {
 }
 
 #[test]
+fn test_outer_for_advances_when_inner_if_else_lock_terminates() {
+    // Regression for issue #422: when an inner `for` loop's body ends in an
+    // `if`/`else` where each branch contains its own `lock do ... until ...`
+    // (with DIFFERENT bodies so the codegen doesn't fuse them into one
+    // terminal state), the codegen used to attach the outer-loop
+    // continuation cascade only to the else-branch's terminal state. The
+    // if-branch's terminal state still carried a bare `(true → past-the-end)`
+    // transition, which after outer-frame translation jumped unconditionally
+    // back to the thread entry state — resetting both inner and outer loop
+    // counters instead of advancing the outer iteration.
+    //
+    // The fix replicates the loop-continuation cascade (counter increment,
+    // loop-back, exit) onto every state that has an "off-the-end" transition
+    // (i.e. target == result.len()), not just `result.last_mut()`. The
+    // trailing-seq-merge that attaches the outer-block's trailing assigns
+    // (e.g. `outer_r <= +1`) to the exit arm is also extended to fire on
+    // every sibling terminal arm.
+    //
+    // The repro is committed at
+    // `tests/regression/issues/nested_if_lock_outer_for_continuation/`. The
+    // companion C++ TB exercises the full simulator end-to-end and is
+    // invoked via `arch sim` (out of scope for the SV-level integration
+    // test); here we assert on the generated thread SV directly.
+    let source = include_str!(
+        "regression/issues/nested_if_lock_outer_for_continuation/IfLockOuterForRepro.arch"
+    );
+    let sv = compile_to_sv(source);
+
+    // The inner-for's terminal arms live in two separate states (one per
+    // branch of the if/else). Both must advance the outer loop:
+    //
+    //   - increment `_t0_loop_cnt_0` (outer counter) when the inner-for
+    //     completes its last sub-beat,
+    //   - bump `outer_r` (trailing-seq from the outer-for body),
+    //   - transition either back to the inner-for dispatch (more outer
+    //     iters to do) or to the thread-entry state (outer-for done).
+    //
+    // Before the fix, only ONE of the two terminal arm states carried this
+    // cascade — the other fell through to the thread-entry state, so the
+    // outer counter never ticked when the if-branch took the last sub-beat.
+    //
+    // We count occurrences of the outer-counter increment expression in
+    // the per-state SV blocks; the bug shape has exactly one, the fix has
+    // two.
+    let outer_cnt_inc_hits = sv.matches("_t0_loop_cnt_0 + 2'd1").count();
+    assert!(
+        outer_cnt_inc_hits >= 2,
+        "expected the outer-counter increment `_t0_loop_cnt_0 + 2'd1` to \
+         appear in BOTH terminal arms of the if/else (issue #422 regression — \
+         only one arm carried the cascade in the buggy shape); got \
+         {outer_cnt_inc_hits} occurrence(s):\n{sv}",
+    );
+
+    // The outer-block trailing assign `outer_r <= +1` must also fire on
+    // both terminal arms.
+    let outer_r_inc_hits = sv.matches("outer_r + 1").count();
+    assert!(
+        outer_r_inc_hits >= 2,
+        "expected the outer-block trailing assign `outer_r + 1` to \
+         appear in BOTH terminal arms of the if/else (issue #422 regression); \
+         got {outer_r_inc_hits} occurrence(s):\n{sv}",
+    );
+
+    // Defensive: the if-branch's terminal state must NOT have a bare
+    // unconditional jump back to the thread-entry state `_t0_S0_wait_until`
+    // — that's the buggy shape (the arm bypassed the loop-continuation
+    // cascade entirely). The fixed shape only jumps to S0_wait_until under
+    // the outer-exit guard `cnt_0 >= 2`.
+    //
+    // Use a simple shape check: every transition to `_t0_S0_wait_until`
+    // (other than from S0 itself) must be guarded by a `>=` test on
+    // `_t0_loop_cnt_0`.
+    let trimmed: String = sv.split_whitespace().collect::<Vec<_>>().join(" ");
+    // After whitespace-collapse, every `_t0_state <= _t0_S0_wait_until`
+    // should be preceded somewhere upstream by the outer-exit guard.
+    // Count bare unguarded jumps: pattern `1'b1 begin _t0_state <= _t0_S0_wait_until`.
+    assert!(
+        !trimmed.contains("&& 1'b1) begin _t0_state <= _t0_S0_wait_until"),
+        "found an UNGUARDED jump back to _t0_S0_wait_until from an inner \
+         terminal arm (issue #422 regression — the if-branch lock-exit \
+         state used to jump to thread-entry, resetting both loop counters \
+         instead of advancing the outer loop):\n{sv}",
+    );
+}
+
+#[test]
 fn test_concat_bus_field_width_uses_module_param_binding() {
     // Regression for issue #427: sim codegen's Concat pack expression
     // used wrong shift offsets when operands were bus-port FieldAccess

--- a/tests/regression/issues/nested_if_lock_outer_for_continuation/IfLockOuterForRepro.arch
+++ b/tests/regression/issues/nested_if_lock_outer_for_continuation/IfLockOuterForRepro.arch
@@ -1,0 +1,57 @@
+// Minimal repro: an inner `for` whose body ends in an `if`/`else` with a
+// `lock` in each branch corrupts the OUTER `for`'s loop-continuation
+// transition. Specifically, the codegen emits the outer-for "go to next
+// iter / exit" transition only out of the else-branch's terminal state;
+// the if-branch's terminal state falls back to the thread entry (S0_entry)
+// instead, so the outer counter advances correctly only when the if branch
+// is NOT taken on the last sub-beat.
+//
+// Expected (with bug fixed):
+//   outer_r ends at 3,  inner_r ends at 6  (3 outer iters × 2 inner sub-beats)
+// Actual (current bug):
+//   outer_r stays at 0 (or some wrong value) and the thread restarts at the
+//   top `wait until go;` instead of completing the outer loop.
+module IfLockOuterForRepro
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Async, Low>;
+  port go: in Bool;
+  port outer_count: out UInt<8>;
+  port inner_count: out UInt<8>;
+
+  resource lk: mutex<priority>;
+  reg outer_r: UInt<8> reset rst => 0;
+  reg inner_r: UInt<8> reset rst => 0;
+
+  thread T on clk rising, rst low
+    default comb
+      outer_count = outer_r;
+      inner_count = inner_r;
+    end default
+    wait until go;
+    // Outer: 3 iterations.
+    for c in 0..2
+      // Inner: 2 sub-beats per outer iteration. The body ends in an
+      // if/else where each branch has its own `lock` body — the two
+      // branches differ (different seq-side effects inside the lock body),
+      // so the codegen does NOT fuse them into a shared follow-up state.
+      for k in 0..1
+        if k == 1
+          // Last sub-beat: the lock body bumps inner_r itself.
+          lock lk
+            do
+              inner_r <= (inner_r + 2).trunc<8>();
+            until true;
+          end lock lk
+        else
+          // Earlier sub-beat: bump inner_r differently inside the lock.
+          lock lk
+            do
+              inner_r <= (inner_r + 1).trunc<8>();
+            until true;
+          end lock lk
+        end if
+      end for
+      outer_r <= (outer_r + 1).trunc<8>();
+    end for
+  end thread T
+end module IfLockOuterForRepro

--- a/tests/regression/issues/nested_if_lock_outer_for_continuation/tb_if_lock_outer_for.cpp
+++ b/tests/regression/issues/nested_if_lock_outer_for_continuation/tb_if_lock_outer_for.cpp
@@ -1,0 +1,54 @@
+// Testbench for IfLockOuterForRepro.
+//
+// Pulses `go` for one cycle, then watches `outer_count` and `inner_count`
+// for ~50 cycles. The thread should:
+//   - take 3 outer iterations (outer_count: 0 → 1 → 2 → 3),
+//   - run 2 inner sub-beats per outer iteration (inner_count: 0 → 6),
+// and then park back at `wait until go;` with both counters frozen.
+//
+// With the bug: the inner-for's if-branch state transitions to S0_entry
+// instead of the outer-for loop-continuation state, so on the very first
+// outer iteration the thread restarts at the top (`wait until go;`). With
+// go=0 by then, the thread sits forever; outer_count never reaches 3.
+#include "VIfLockOuterForRepro.h"
+#include <cstdio>
+#include <cstdlib>
+
+static VIfLockOuterForRepro dut;
+static void tick() {
+    dut.clk = 0; dut.eval();
+    dut.clk = 1; dut.eval();
+}
+
+int main() {
+    dut.rst = 0;
+    dut.go  = 0;
+    for (int i = 0; i < 4; ++i) tick();   // hold in reset
+    dut.rst = 1;                          // deassert async-low reset
+    dut.go  = 1;
+    tick();
+    dut.go  = 0;                          // single-cycle pulse
+
+    int max_outer = 0, max_inner = 0;
+    for (int i = 0; i < 60; ++i) {
+        std::printf("cyc=%d  outer=%d  inner=%d\n",
+                    i, dut.outer_count, dut.inner_count);
+        if (dut.outer_count > max_outer) max_outer = dut.outer_count;
+        if (dut.inner_count > max_inner) max_inner = dut.inner_count;
+        tick();
+    }
+    std::printf("max_outer=%d max_inner=%d\n", max_outer, max_inner);
+
+    // Expected once the codegen bug is fixed:
+    //   max_outer == 3, max_inner == 6
+    // Current buggy behaviour: max_outer is stuck below 3 (likely 0 or 1).
+    // Inner branches add 1 (k==0) and 2 (k==1) — per outer iter inner += 3.
+    if (max_outer != 3 || max_inner != 9) {
+        std::fprintf(stderr,
+            "FAIL: expected max_outer=3, max_inner=9 (got %d, %d)\n",
+            max_outer, max_inner);
+        return 1;
+    }
+    std::printf("PASS\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary

- When an inner `for` loop's body ends in an `if`/`else` where each branch contains its own `lock do ... until ...` (with distinct bodies, so the codegen doesn't fuse them into one terminal state), the codegen attached the outer-loop continuation cascade only to the else-branch's terminal state. The if-branch's terminal state jumped unconditionally back to the thread entry, resetting both loop counters instead of advancing the outer iteration.
- `lower_thread_for` in `src/elaborate.rs` only inspected `result.last_mut()` for "inner-exit" transitions. Extend the cascade to every non-last state with an off-the-end transition (`target >= result_len && !special`), so all terminal arms of a multi-arm dispatch participate in counter increment / loop-back / exit.
- Sibling fix in the body-level trailing-seq-merge: extend the merge to every sibling state with a transition targeting the for-body's exit position, so trailing assigns (e.g. `outer_r <= +1`) fire on every terminal arm, not just `states.last_mut()`.

Fixes #422.

## Test plan

- [x] `cargo test --release` (527 tests pass)
- [x] New regression `test_outer_for_advances_when_inner_if_else_lock_terminates` checks both terminal arms carry the outer-counter increment, the outer trailing assign, and that no unguarded jump back to `_t0_S0_wait_until` remains.
- [x] Minimal repro (committed under `tests/regression/issues/nested_if_lock_outer_for_continuation/`) now PASS: `outer_r=3, inner_r=9` as expected (was stuck at `outer_r=0, inner_r=3` before the fix).
- [x] NIC-400 fabric smoke (`Nic400Fabric` + masters + slaves + `BusAxi4`) PASS.
- [x] NIC-400 AHB bridge smoke (`Nic400AhbBridge` + `BusAhbLite` + `BusAxi4` + `IncrHwdataFifo`) PASS.