### PR TITLE
nic400: AXI4 data-width downsize adapter (64→32)

### DIFF
--- a/tests/nic400/Nic400WidthAdapter.arch
+++ b/tests/nic400/Nic400WidthAdapter.arch
@@ -1,0 +1,287 @@
+// AXI4 data-width downsize adapter.
+//
+// Bridges a wide AXI4 master port (m, DATA_W = M_DATA_W) to a narrow AXI4
+// slave port (s, DATA_W = S_DATA_W). For each master beat the adapter
+// emits / consumes RATIO = M_DATA_W / S_DATA_W slave beats, packing R
+// returns and splitting W beats with little-endian ordering — the low
+// S_DATA_W bits of the master beat correspond to the FIRST slave beat.
+//
+// Constraints (caller must satisfy):
+//   • M_DATA_W % S_DATA_W == 0
+//   • M_DATA_W > S_DATA_W              (downsize-only — upsize is a larger
+//                                       design requiring an accumulation
+//                                       buffer and is out of scope here)
+//   • RATIO ≥ 2 and is a power of two in practice (axsize encodes 1/2/4/…)
+//
+// AXI semantics enforced by the adapter:
+//   • Master AR axlen=N (N+1 master beats) ⇒ slave axlen = (N+1)*RATIO - 1.
+//   • Slave ax_size is forced to log2(S_DATA_W/8); the adapter does not
+//     attempt to honour a narrower master ax_size (i.e. partial-lane
+//     accesses are out of scope in v1 — TB always issues full-width).
+//   • For R: r_resp is OR-reduced across the RATIO sub-beats inside one
+//     master beat (so SLVERR on any sub-beat surfaces as SLVERR on the
+//     containing master beat). r_last on master fires on the final beat.
+//   • For W: w_strb is split into RATIO slices of S_STRB_W bits each,
+//     least-significant slice goes out first.
+//   • B: 1:1 forwarded.
+//
+// Per-channel locks serialise the multi-thread comb drives on the shared
+// m.* / s.* output signals; the AHB bridge uses the same pattern and the
+// rationale carries over — at most one thread is in a lock body at a time
+// in steady state, the lock just keeps the codegen's multi-driver legal.
+//
+// Implementation note: the R thread uses the nested-for + if/else + lock-
+// per-branch shape that previously hit compiler bug #422 (lower_threads
+// dropped the outer-for continuation transition on the if-branch's
+// terminal state). Issue #422 was fixed in PR #430; this module relies on
+// that fix.
+module Nic400WidthAdapter
+  param M_DATA_W: const = 64;
+  param S_DATA_W: const = 32;
+  param ADDR_W:   const = 32;
+  param ID_W:     const = 4;
+  // Derived. Caller is expected to keep M_DATA_W % S_DATA_W == 0 and the
+  // ratio ≥ 2. The compiler folds these expressions in const positions.
+  param RATIO:    const = M_DATA_W / S_DATA_W;
+  param M_STRB_W: const = M_DATA_W / 8;
+  param S_STRB_W: const = S_DATA_W / 8;
+  // axsize encoding for S_DATA_W bytes. For 32-bit slave (S_STRB_W=4) ⇒ 2.
+  param S_AX_SIZE: const = $clog2(S_STRB_W);
+
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Async, Low>;
+
+  // Wide master-facing port (adapter is the target — drives ready/resp).
+  port m: target BusAxi4<ADDR_W=ADDR_W, DATA_W=M_DATA_W, STRB_W=M_STRB_W,
+                          ID_W=ID_W, READ=1, WRITE=1>;
+  // Narrow slave-facing port (adapter is the initiator — drives valid/data).
+  port s: initiator BusAxi4<ADDR_W=ADDR_W, DATA_W=S_DATA_W, STRB_W=S_STRB_W,
+                              ID_W=ID_W, READ=1, WRITE=1>;
+
+  // Per-channel arb locks — see Nic400AhbBridge for the rationale.
+  resource ar_lock: mutex<priority>;
+  resource r_lock:  mutex<priority>;
+  resource aw_lock: mutex<priority>;
+  resource w_lock:  mutex<priority>;
+  resource b_lock:  mutex<priority>;
+
+  // Latched master axlen for the R thread's outer-loop bound. The master
+  // holds m.ar_len only during the AR handshake; R-side beats can arrive
+  // many cycles later, by which point the master may have moved on.
+  reg rd_axlen_r:  UInt<8> reset rst => 0;
+  // Latched master axlen for the W thread's outer-loop bound. Same reason.
+  reg wr_axlen_r:  UInt<8> reset rst => 0;
+
+  // Packing accumulator for R beats. At sub-beat k (0..RATIO-2) we OR the
+  // slave's r_data into bits [k*S_DATA_W +: S_DATA_W]. At k == RATIO-1 we
+  // OR the last slave beat in *combinationally* and drive m.r_valid with
+  // the assembled wide word; on m.r_ready the loop clears the reg for the
+  // next master beat.
+  reg r_pack_r:    UInt<M_DATA_W> reset rst => 0;
+  // OR-accumulated response across sub-beats; surfaced on m.r_resp at the
+  // terminal sub-beat.
+  reg r_resp_r:    UInt<2> reset rst => 0;
+
+  // ── AR thread ─────────────────────────────────────────────────────────
+  // Forward master AR to slave, scaling axlen and forcing axsize.
+  thread Ar on clk rising, rst low
+    default comb
+      s.ar_valid  = false;
+      s.ar_addr   = 0;
+      s.ar_id     = 0;
+      s.ar_len    = 0;
+      s.ar_size   = 0;
+      s.ar_burst  = 0;
+      s.ar_lock   = false;
+      s.ar_cache  = 0;
+      s.ar_prot   = 0;
+      s.ar_qos    = 0;
+      s.ar_region = 0;
+      m.ar_ready  = false;
+    end default
+    wait 0+ cycle until m.ar_valid;
+    lock ar_lock
+      do
+        s.ar_valid  = true;
+        s.ar_addr   = m.ar_addr;
+        s.ar_id     = m.ar_id;
+        // (master_axlen + 1) * RATIO - 1, all in 8-bit AXI axlen space.
+        s.ar_len    = (((m.ar_len.zext<16>() + 1) * RATIO) - 1).trunc<8>();
+        s.ar_size   = S_AX_SIZE;
+        s.ar_burst  = m.ar_burst;
+        s.ar_lock   = m.ar_lock;
+        s.ar_cache  = m.ar_cache;
+        s.ar_prot   = m.ar_prot;
+        s.ar_qos    = m.ar_qos;
+        s.ar_region = m.ar_region;
+        m.ar_ready  = s.ar_ready;
+        // Latch master axlen for the R thread before the master can drop it.
+        rd_axlen_r <= m.ar_len;
+      until s.ar_ready;
+    end lock ar_lock
+  end thread Ar
+
+  // ── R thread ─────────────────────────────────────────────────────────
+  // For each master beat (0..rd_axlen_r), pack RATIO slave R beats into one
+  // wide master beat. Inner loop has three structurally-distinct branches:
+  //   • k == 0           : capture into low slot
+  //   • 0 < k < RATIO-1  : OR into middle slot
+  //   • k == RATIO-1     : OR last slot in combinationally and present the
+  //                        packed beat to the master with m.r_valid=1
+  //
+  // This is the nested-for + if/elsif/else + lock-per-branch shape that
+  // tripped #422 before PR #430 landed.
+  thread R on clk rising, rst low
+    default comb
+      m.r_valid = false;
+      m.r_data  = 0;
+      m.r_id    = 0;
+      m.r_resp  = 0;
+      m.r_last  = false;
+      s.r_ready = false;
+    end default
+    wait until s.r_valid;
+    for b in 0..rd_axlen_r
+      for k in 0..RATIO - 1
+        if k == 0
+          // Low slot: overwrite (clears any leftover bits from a previous
+          // master beat too).
+          lock r_lock
+            do
+              s.r_ready = true;
+            until s.r_valid;
+          end lock r_lock
+          r_pack_r <= s.r_data.zext<M_DATA_W>();
+          r_resp_r <= s.r_resp;
+        elsif k == RATIO - 1
+          // Terminal sub-beat: combine accumulated low slots with the
+          // current slave beat (shifted into the top slot) and drive the
+          // master with the full wide word.
+          lock r_lock
+            do
+              s.r_ready = m.r_ready;
+              m.r_valid = s.r_valid;
+              m.r_data  = r_pack_r | (s.r_data.zext<M_DATA_W>() << (k * S_DATA_W));
+              m.r_id    = s.r_id;
+              m.r_resp  = r_resp_r | s.r_resp;
+              m.r_last  = s.r_last;
+            until s.r_valid and m.r_ready;
+          end lock r_lock
+          // Clear accumulator for the next master beat.
+          r_pack_r <= 0;
+          r_resp_r <= 0;
+        else
+          // Middle slot: OR new slave data into bits [k*S_DATA_W +: S_DATA_W].
+          lock r_lock
+            do
+              s.r_ready = true;
+            until s.r_valid;
+          end lock r_lock
+          r_pack_r <= r_pack_r | (s.r_data.zext<M_DATA_W>() << (k * S_DATA_W));
+          r_resp_r <= r_resp_r | s.r_resp;
+        end if
+      end for
+    end for
+  end thread R
+
+  // ── AW thread ─────────────────────────────────────────────────────────
+  thread Aw on clk rising, rst low
+    default comb
+      s.aw_valid  = false;
+      s.aw_addr   = 0;
+      s.aw_id     = 0;
+      s.aw_len    = 0;
+      s.aw_size   = 0;
+      s.aw_burst  = 0;
+      s.aw_lock   = false;
+      s.aw_cache  = 0;
+      s.aw_prot   = 0;
+      s.aw_qos    = 0;
+      s.aw_region = 0;
+      m.aw_ready  = false;
+    end default
+    wait 0+ cycle until m.aw_valid;
+    lock aw_lock
+      do
+        s.aw_valid  = true;
+        s.aw_addr   = m.aw_addr;
+        s.aw_id     = m.aw_id;
+        s.aw_len    = (((m.aw_len.zext<16>() + 1) * RATIO) - 1).trunc<8>();
+        s.aw_size   = S_AX_SIZE;
+        s.aw_burst  = m.aw_burst;
+        s.aw_lock   = m.aw_lock;
+        s.aw_cache  = m.aw_cache;
+        s.aw_prot   = m.aw_prot;
+        s.aw_qos    = m.aw_qos;
+        s.aw_region = m.aw_region;
+        m.aw_ready  = s.aw_ready;
+        wr_axlen_r <= m.aw_len;
+      until s.aw_ready;
+    end lock aw_lock
+  end thread Aw
+
+  // ── W thread ─────────────────────────────────────────────────────────
+  // For each master beat (0..wr_axlen_r), split the wide w_data/w_strb into
+  // RATIO slave sub-beats, least-significant slice first. Master w_ready
+  // pulses high ONLY on the last sub-beat (k == RATIO-1) so the master
+  // advances by one wide beat per RATIO slave beats.
+  //
+  // w_last on the slave fires on the very last sub-beat of the very last
+  // master beat: (b == wr_axlen_r) and (k == RATIO-1).
+  thread W on clk rising, rst low
+    default comb
+      s.w_valid = false;
+      s.w_data  = 0;
+      s.w_strb  = 0;
+      s.w_last  = false;
+      m.w_ready = false;
+    end default
+    wait until m.w_valid;
+    for b in 0..wr_axlen_r
+      for k in 0..RATIO - 1
+        if k == RATIO - 1
+          lock w_lock
+            do
+              s.w_valid = m.w_valid;
+              s.w_data  = m.w_data[k * S_DATA_W +: S_DATA_W];
+              s.w_strb  = m.w_strb[k * S_STRB_W +: S_STRB_W];
+              s.w_last  = (b == wr_axlen_r) and m.w_last;
+              // Master advances after the last sub-beat consumes the wide beat.
+              m.w_ready = s.w_ready;
+            until m.w_valid and s.w_ready;
+          end lock w_lock
+        else
+          lock w_lock
+            do
+              s.w_valid = m.w_valid;
+              s.w_data  = m.w_data[k * S_DATA_W +: S_DATA_W];
+              s.w_strb  = m.w_strb[k * S_STRB_W +: S_STRB_W];
+              s.w_last  = false;
+              // Hold master w_ready=0 until the last sub-beat.
+              m.w_ready = false;
+            until m.w_valid and s.w_ready;
+          end lock w_lock
+        end if
+      end for
+    end for
+  end thread W
+
+  // ── B thread ─────────────────────────────────────────────────────────
+  thread B on clk rising, rst low
+    default comb
+      m.b_valid = false;
+      m.b_id    = 0;
+      m.b_resp  = 0;
+      s.b_ready = false;
+    end default
+    wait 0+ cycle until s.b_valid;
+    lock b_lock
+      do
+        m.b_valid = s.b_valid;
+        m.b_id    = s.b_id;
+        m.b_resp  = s.b_resp;
+        s.b_ready = m.b_ready;
+      until s.b_valid and m.b_ready;
+    end lock b_lock
+  end thread B
+end module Nic400WidthAdapter

--- a/tests/nic400/tb_nic400_width_adapter.cpp
+++ b/tests/nic400/tb_nic400_width_adapter.cpp
@@ -1,0 +1,475 @@
+// AXI4 width-adapter TB. Default ratio is 64→32 (RATIO=2).
+//
+// The TB plays both the wide AXI4 master (driving the adapter's `m` target
+// port) and the narrow AXI4 slave (acking the adapter's `s` initiator
+// port). Six scenarios:
+//   1) Single-beat write — verify 1 master W (64b) splits into 2 slave W
+//      beats (low half first).
+//   2) Single-beat read — verify 2 slave R beats pack into 1 master R
+//      beat (low half from first slave beat, high half from second), and
+//      r_last fires exactly once on the master.
+//   3) 4-beat INCR write (master axlen=3 → slave axlen=7).
+//   4) 4-beat INCR read (master axlen=3 → slave axlen=7). This is the
+//      scenario that hit compiler bug #422 before PR #430 landed.
+//   5) Write with non-trivial w_strb — master strb=0xA5 splits to
+//      [0xA, 0x5] on the two slave beats (little-endian).
+//   6) SLVERR propagation — slave returns SLVERR (resp=2) on one R
+//      sub-beat; master r_resp must surface SLVERR for the containing beat.
+//
+// Like the other NIC-400 TBs, we sample on pre_edge() (clk low) so we see
+// Mealy combinational drives BEFORE the lowered FSM advances past the
+// handshake state.
+
+#include "VNic400WidthAdapter.h"
+#include <cstdint>
+#include <cstdio>
+
+static VNic400WidthAdapter dut;
+static uint64_t cycle = 0;
+
+static void tick()      { dut.clk = 0; dut.eval(); dut.clk = 1; dut.eval(); cycle++; }
+static void pre_edge()  { dut.clk = 0; dut.eval(); }
+static void post_edge() { dut.clk = 1; dut.eval(); cycle++; }
+
+static void clear_inputs() {
+    // Master side (TB drives master-style requests INTO adapter).
+    dut.m_ar_valid = 0; dut.m_ar_addr = 0; dut.m_ar_id = 0; dut.m_ar_len = 0;
+    dut.m_ar_size = 0;  dut.m_ar_burst = 0; dut.m_ar_lock = 0;
+    dut.m_ar_cache = 0; dut.m_ar_prot = 0;  dut.m_ar_qos = 0; dut.m_ar_region = 0;
+    dut.m_r_ready = 0;
+    dut.m_aw_valid = 0; dut.m_aw_addr = 0; dut.m_aw_id = 0; dut.m_aw_len = 0;
+    dut.m_aw_size = 0;  dut.m_aw_burst = 0; dut.m_aw_lock = 0;
+    dut.m_aw_cache = 0; dut.m_aw_prot = 0;  dut.m_aw_qos = 0; dut.m_aw_region = 0;
+    dut.m_w_valid = 0; dut.m_w_data = 0; dut.m_w_strb = 0; dut.m_w_last = 0;
+    dut.m_b_ready = 0;
+    // Slave side (TB plays the downstream slave — drives ready/response).
+    dut.s_ar_ready = 0;
+    dut.s_r_valid = 0; dut.s_r_data = 0; dut.s_r_id = 0; dut.s_r_resp = 0; dut.s_r_last = 0;
+    dut.s_aw_ready = 0;
+    dut.s_w_ready = 0;
+    dut.s_b_valid = 0; dut.s_b_id = 0; dut.s_b_resp = 0;
+}
+
+static int fail(const char* m) {
+    std::printf("FAIL %s (cycle=%llu)\n", m, (unsigned long long)cycle);
+    return 1;
+}
+
+// Wait for a condition (sampled on pre_edge) for up to `limit` cycles.
+// Returns 0 if matched; -1 on timeout.
+template <typename F>
+static int wait_until(F cond, int limit, const char* what) {
+    for (int i = 0; i < limit; ++i) {
+        pre_edge();
+        if (cond()) return 0;
+        post_edge();
+    }
+    (void)what;
+    return -1;
+}
+
+// ── Scenario 1: single-beat write ─────────────────────────────────────
+// master axlen=0 ⇒ 1 master W beat (64b) ⇒ slave axlen=1, 2 slave W beats.
+// The low 32 bits of the master beat go out FIRST.
+static int test_single_write() {
+    const uint64_t wdata = 0xCAFEBABE12345678ULL;
+    const uint32_t exp_lo = 0x12345678u;
+    const uint32_t exp_hi = 0xCAFEBABEu;
+    const uint32_t addr = 0x1000;
+
+    // Drive AW.
+    dut.m_aw_valid = 1; dut.m_aw_addr = addr; dut.m_aw_id = 0; dut.m_aw_len = 0;
+    dut.m_aw_size = 3;  dut.m_aw_burst = 1;  // size=3 means 8 bytes (matches M_DATA_W=64)
+    dut.s_aw_ready = 1;
+
+    int aw_seen = 0; uint32_t s_aw_len = 0xff; uint32_t s_aw_size = 0xff;
+    for (int i = 0; i < 32 && !aw_seen; ++i) {
+        pre_edge();
+        if (dut.s_aw_valid && dut.s_aw_ready) {
+            aw_seen = 1; s_aw_len = dut.s_aw_len; s_aw_size = dut.s_aw_size;
+            if (dut.s_aw_addr != addr) return fail("s1: slave AW addr");
+        }
+        post_edge();
+    }
+    if (!aw_seen) return fail("s1: slave AW never observed");
+    if (s_aw_len != 1) return fail("s1: slave AW len (expect 1 for ratio=2)");
+    if (s_aw_size != 2) return fail("s1: slave AW size (expect 2 for S_DATA_W=32)");
+    dut.m_aw_valid = 0; dut.s_aw_ready = 0;
+
+    // Drive the wide W beat.
+    dut.m_w_valid = 1; dut.m_w_data = wdata; dut.m_w_strb = 0xFF; dut.m_w_last = 1;
+    dut.s_w_ready = 1;
+
+    // Expect first slave beat: low half, w_last=0, w_strb=0xF.
+    int beat = 0; uint32_t got_lo = 0, got_hi = 0;
+    for (int i = 0; i < 32 && beat < 2; ++i) {
+        pre_edge();
+        if (dut.s_w_valid && dut.s_w_ready) {
+            if (beat == 0) {
+                got_lo = dut.s_w_data;
+                if (dut.s_w_last) return fail("s1: slave w_last should be 0 on beat 0");
+                if (dut.s_w_strb != 0xF) return fail("s1: slave w_strb beat 0");
+                if (dut.m_w_ready) return fail("s1: m_w_ready must stay LOW on beat 0 (sub-beat)");
+            } else if (beat == 1) {
+                got_hi = dut.s_w_data;
+                if (!dut.s_w_last) return fail("s1: slave w_last should be 1 on beat 1");
+                if (dut.s_w_strb != 0xF) return fail("s1: slave w_strb beat 1");
+                if (!dut.m_w_ready) return fail("s1: m_w_ready must be HIGH on last sub-beat");
+            }
+            beat++;
+        }
+        post_edge();
+    }
+    if (beat != 2) return fail("s1: did not see 2 slave W beats");
+    if (got_lo != exp_lo) return fail("s1: slave beat 0 data != master low half");
+    if (got_hi != exp_hi) return fail("s1: slave beat 1 data != master high half");
+    dut.m_w_valid = 0; dut.m_w_data = 0; dut.m_w_strb = 0; dut.m_w_last = 0;
+    dut.s_w_ready = 0;
+
+    // B response.
+    dut.s_b_valid = 1; dut.s_b_resp = 0;
+    dut.m_b_ready = 1;
+    if (wait_until([&]{ return dut.m_b_valid && dut.s_b_ready; }, 32, "m B") != 0)
+        return fail("s1: master B never seen");
+    if (dut.m_b_resp != 0) return fail("s1: master b_resp not OKAY");
+    post_edge();
+    dut.s_b_valid = 0; dut.m_b_ready = 0;
+
+    std::printf("PASS s1: single-beat write (64b → 2x32b, little-endian)\n");
+    return 0;
+}
+
+// ── Scenario 2: single-beat read ───────────────────────────────────────
+static int test_single_read() {
+    const uint32_t slave_lo = 0x01020304u;
+    const uint32_t slave_hi = 0x55667788u;
+    const uint64_t exp = ((uint64_t)slave_hi << 32) | slave_lo;
+    const uint32_t addr = 0x2000;
+
+    dut.m_ar_valid = 1; dut.m_ar_addr = addr; dut.m_ar_len = 0;
+    dut.m_ar_size = 3;  dut.m_ar_burst = 1;
+    dut.s_ar_ready = 1;
+
+    int ar_seen = 0; uint32_t s_ar_len = 0xff; uint32_t s_ar_size = 0xff;
+    for (int i = 0; i < 32 && !ar_seen; ++i) {
+        pre_edge();
+        if (dut.s_ar_valid && dut.s_ar_ready) {
+            ar_seen = 1; s_ar_len = dut.s_ar_len; s_ar_size = dut.s_ar_size;
+            if (dut.s_ar_addr != addr) return fail("s2: slave AR addr");
+        }
+        post_edge();
+    }
+    if (!ar_seen) return fail("s2: slave AR never seen");
+    if (s_ar_len != 1) return fail("s2: slave AR len (expect 1 for ratio=2)");
+    if (s_ar_size != 2) return fail("s2: slave AR size (expect 2)");
+    dut.m_ar_valid = 0; dut.s_ar_ready = 0;
+
+    // Drive the 2 slave R beats. Sub-beat 0 = low; sub-beat 1 = high + r_last.
+    dut.m_r_ready = 1;
+
+    // Beat 0: capture phase — adapter drives s_r_ready=1, master should NOT see r_valid yet.
+    dut.s_r_valid = 1; dut.s_r_data = slave_lo; dut.s_r_resp = 0; dut.s_r_last = 0;
+
+    int beat0_done = 0;
+    for (int i = 0; i < 32 && !beat0_done; ++i) {
+        pre_edge();
+        if (dut.s_r_valid && dut.s_r_ready) {
+            beat0_done = 1;
+            if (dut.m_r_valid) return fail("s2: master must not see r_valid on first sub-beat");
+        }
+        post_edge();
+    }
+    if (!beat0_done) return fail("s2: first sub-beat not consumed");
+
+    // Beat 1: terminal — drive r_last=1; master should see r_valid + assembled data + r_last.
+    dut.s_r_data = slave_hi; dut.s_r_last = 1;
+
+    int m_seen = 0;
+    for (int i = 0; i < 32 && !m_seen; ++i) {
+        pre_edge();
+        if (dut.m_r_valid && dut.m_r_ready) {
+            m_seen = 1;
+            uint64_t got = ((uint64_t)dut.m_r_data);
+            if (got != exp) {
+                std::printf("  got=0x%016llx exp=0x%016llx\n",
+                            (unsigned long long)got, (unsigned long long)exp);
+                return fail("s2: master r_data assembly");
+            }
+            if (!dut.m_r_last) return fail("s2: master r_last must be 1");
+            if (dut.m_r_resp != 0) return fail("s2: master r_resp not OKAY");
+        }
+        post_edge();
+    }
+    if (!m_seen) return fail("s2: master R never seen");
+    dut.s_r_valid = 0; dut.s_r_last = 0; dut.m_r_ready = 0;
+
+    std::printf("PASS s2: single-beat read (2x32b → 64b packed, little-endian)\n");
+    return 0;
+}
+
+// ── Scenario 3: 4-beat INCR write ─────────────────────────────────────
+static int test_incr4_write() {
+    const uint64_t wd[4] = {
+        0x0000000111111111ULL,
+        0x0000000222222222ULL,
+        0x0000000333333333ULL,
+        0x0000000444444444ULL,
+    };
+    const uint32_t addr = 0x3000;
+
+    dut.m_aw_valid = 1; dut.m_aw_addr = addr; dut.m_aw_len = 3;
+    dut.m_aw_size = 3;  dut.m_aw_burst = 1;
+    dut.s_aw_ready = 1;
+
+    int aw_seen = 0; uint32_t s_aw_len = 0xff;
+    for (int i = 0; i < 32 && !aw_seen; ++i) {
+        pre_edge();
+        if (dut.s_aw_valid && dut.s_aw_ready) { aw_seen = 1; s_aw_len = dut.s_aw_len; }
+        post_edge();
+    }
+    if (!aw_seen) return fail("s3: slave AW never seen");
+    if (s_aw_len != 7) return fail("s3: slave AW len (expect 7 for master len=3, ratio=2)");
+    dut.m_aw_valid = 0; dut.s_aw_ready = 0;
+
+    // Feed 4 master W beats, expect 8 slave W beats.
+    dut.s_w_ready = 1;
+    int m_beat = 0;
+    int s_beat = 0;
+    uint32_t slave_data[8] = {0};
+    int last_seen = -1;
+
+    dut.m_w_valid = 1; dut.m_w_data = wd[0]; dut.m_w_strb = 0xFF; dut.m_w_last = 0;
+
+    for (int i = 0; i < 200 && (m_beat < 4 || s_beat < 8); ++i) {
+        pre_edge();
+        if (dut.s_w_valid && dut.s_w_ready && s_beat < 8) {
+            slave_data[s_beat] = dut.s_w_data;
+            if (dut.s_w_last) last_seen = s_beat;
+            s_beat++;
+        }
+        // Master beat advance: m_w_ready high during the last sub-beat of each master beat.
+        if (dut.m_w_valid && dut.m_w_ready && m_beat < 4) {
+            m_beat++;
+            if (m_beat < 4) {
+                dut.m_w_data = wd[m_beat];
+                dut.m_w_last = (m_beat == 3) ? 1 : 0;
+            }
+        }
+        post_edge();
+    }
+    if (m_beat != 4) return fail("s3: master never advanced 4 wide beats");
+    if (s_beat != 8) return fail("s3: did not see 8 slave W beats");
+    if (last_seen != 7) return fail("s3: s_w_last must fire on slave beat 7");
+    dut.m_w_valid = 0; dut.s_w_ready = 0; dut.m_w_data = 0; dut.m_w_last = 0;
+
+    // Verify slave beats are in order: lo, hi, lo, hi, ...
+    for (int b = 0; b < 4; ++b) {
+        uint32_t exp_lo = (uint32_t)(wd[b] & 0xffffffff);
+        uint32_t exp_hi = (uint32_t)(wd[b] >> 32);
+        if (slave_data[2*b] != exp_lo) {
+            std::printf("  beat %d.lo got=0x%08x exp=0x%08x\n", b, slave_data[2*b], exp_lo);
+            return fail("s3: slave low-half mismatch");
+        }
+        if (slave_data[2*b+1] != exp_hi) {
+            std::printf("  beat %d.hi got=0x%08x exp=0x%08x\n", b, slave_data[2*b+1], exp_hi);
+            return fail("s3: slave high-half mismatch");
+        }
+    }
+
+    dut.s_b_valid = 1; dut.s_b_resp = 0; dut.m_b_ready = 1;
+    if (wait_until([&]{ return dut.m_b_valid && dut.s_b_ready; }, 32, "m B") != 0)
+        return fail("s3: master B never seen");
+    post_edge();
+    dut.s_b_valid = 0; dut.m_b_ready = 0;
+
+    std::printf("PASS s3: 4-beat INCR write (4x64b → 8x32b, ordered)\n");
+    return 0;
+}
+
+// ── Scenario 4: 4-beat INCR read (this hit compiler bug #422) ─────────
+static int test_incr4_read() {
+    const uint32_t addr = 0x4000;
+    // 8 narrow beats — assembled as 4 wide beats.
+    const uint32_t sd[8] = {
+        0x11111111u, 0x22222222u,   // → 0x22222222_11111111
+        0x33333333u, 0x44444444u,   // → 0x44444444_33333333
+        0x55555555u, 0x66666666u,   // → 0x66666666_55555555
+        0x77777777u, 0x88888888u,   // → 0x88888888_77777777
+    };
+
+    dut.m_ar_valid = 1; dut.m_ar_addr = addr; dut.m_ar_len = 3;
+    dut.m_ar_size = 3;  dut.m_ar_burst = 1;
+    dut.s_ar_ready = 1;
+
+    int ar_seen = 0; uint32_t s_ar_len = 0xff;
+    for (int i = 0; i < 32 && !ar_seen; ++i) {
+        pre_edge();
+        if (dut.s_ar_valid && dut.s_ar_ready) { ar_seen = 1; s_ar_len = dut.s_ar_len; }
+        post_edge();
+    }
+    if (!ar_seen) return fail("s4: slave AR never seen");
+    if (s_ar_len != 7) return fail("s4: slave AR len (expect 7)");
+    dut.m_ar_valid = 0; dut.s_ar_ready = 0;
+
+    dut.m_r_ready = 1;
+
+    int s_beat = 0;
+    int m_beat = 0;
+    int m_last_beat = -1;
+
+    dut.s_r_valid = 1; dut.s_r_data = sd[0]; dut.s_r_resp = 0; dut.s_r_last = 0;
+
+    for (int i = 0; i < 400 && (s_beat < 8 || m_beat < 4); ++i) {
+        pre_edge();
+        bool s_fire = dut.s_r_valid && dut.s_r_ready;
+        bool m_fire = dut.m_r_valid && dut.m_r_ready;
+
+        if (m_fire && m_beat < 4) {
+            int b = m_beat;
+            uint64_t got = (uint64_t)dut.m_r_data;
+            uint64_t exp = ((uint64_t)sd[2*b+1] << 32) | sd[2*b];
+            if (got != exp) {
+                std::printf("  s4 beat %d got=0x%016llx exp=0x%016llx\n",
+                            b, (unsigned long long)got, (unsigned long long)exp);
+                return fail("s4: master beat assembly");
+            }
+            if (dut.m_r_last) m_last_beat = b;
+            m_beat++;
+        }
+        // Hold s_r_data stable through the clock edge — only advance AFTER post_edge.
+        post_edge();
+        if (s_fire && s_beat < 8) {
+            s_beat++;
+            if (s_beat < 8) {
+                dut.s_r_data = sd[s_beat];
+                dut.s_r_last = (s_beat == 7) ? 1 : 0;
+            }
+        }
+    }
+    if (s_beat != 8) return fail("s4: did not consume 8 slave R beats");
+    if (m_beat != 4) return fail("s4: did not deliver 4 master R beats");
+    if (m_last_beat != 3) return fail("s4: master r_last must fire on beat 3 only");
+    dut.s_r_valid = 0; dut.s_r_last = 0; dut.m_r_ready = 0;
+
+    std::printf("PASS s4: 4-beat INCR read (8x32b → 4x64b packed, nested-for + lock-per-branch — issue #422 path)\n");
+    return 0;
+}
+
+// ── Scenario 5: write with non-trivial w_strb ─────────────────────────
+// Master strb = 0xA5 (= 1010_0101). Low slave beat strb = 0x5; high = 0xA.
+static int test_strb_write() {
+    const uint32_t addr = 0x5000;
+    const uint64_t wdata = 0xAABBCCDDEEFF0011ULL;
+    const uint32_t exp_lo = 0xEEFF0011u;
+    const uint32_t exp_hi = 0xAABBCCDDu;
+
+    dut.m_aw_valid = 1; dut.m_aw_addr = addr; dut.m_aw_len = 0;
+    dut.m_aw_size = 3;  dut.m_aw_burst = 1;
+    dut.s_aw_ready = 1;
+    if (wait_until([&]{ return dut.s_aw_valid && dut.s_aw_ready; }, 32, "s AW") != 0)
+        return fail("s5: slave AW never seen");
+    post_edge();
+    dut.m_aw_valid = 0; dut.s_aw_ready = 0;
+
+    dut.m_w_valid = 1; dut.m_w_data = wdata; dut.m_w_strb = 0xA5; dut.m_w_last = 1;
+    dut.s_w_ready = 1;
+
+    int beat = 0;
+    uint32_t got_lo = 0, got_hi = 0;
+    uint32_t strb_lo = 0xff, strb_hi = 0xff;
+    for (int i = 0; i < 32 && beat < 2; ++i) {
+        pre_edge();
+        if (dut.s_w_valid && dut.s_w_ready) {
+            if (beat == 0) { got_lo = dut.s_w_data; strb_lo = dut.s_w_strb; }
+            else           { got_hi = dut.s_w_data; strb_hi = dut.s_w_strb; }
+            beat++;
+        }
+        post_edge();
+    }
+    if (beat != 2) return fail("s5: did not see 2 slave W beats");
+    if (got_lo != exp_lo || got_hi != exp_hi) return fail("s5: data mismatch");
+    if (strb_lo != 0x5) return fail("s5: low-beat strb should be 0x5");
+    if (strb_hi != 0xA) return fail("s5: high-beat strb should be 0xA");
+    dut.m_w_valid = 0; dut.s_w_ready = 0; dut.m_w_data = 0; dut.m_w_strb = 0; dut.m_w_last = 0;
+
+    dut.s_b_valid = 1; dut.s_b_resp = 0; dut.m_b_ready = 1;
+    if (wait_until([&]{ return dut.m_b_valid && dut.s_b_ready; }, 32, "m B") != 0)
+        return fail("s5: master B never seen");
+    post_edge();
+    dut.s_b_valid = 0; dut.m_b_ready = 0;
+
+    std::printf("PASS s5: w_strb split (master 0xA5 → slave [0x5, 0xA])\n");
+    return 0;
+}
+
+// ── Scenario 6: SLVERR propagation on read ────────────────────────────
+// Slave returns SLVERR (resp=2) on the low sub-beat. Master r_resp must
+// surface SLVERR on the containing wide beat.
+static int test_slverr_read() {
+    const uint32_t addr = 0x6000;
+
+    dut.m_ar_valid = 1; dut.m_ar_addr = addr; dut.m_ar_len = 0;
+    dut.m_ar_size = 3;  dut.m_ar_burst = 1;
+    dut.s_ar_ready = 1;
+    if (wait_until([&]{ return dut.s_ar_valid && dut.s_ar_ready; }, 32, "s AR") != 0)
+        return fail("s6: slave AR never seen");
+    post_edge();
+    dut.m_ar_valid = 0; dut.s_ar_ready = 0;
+
+    dut.m_r_ready = 1;
+
+    // Sub-beat 0: SLVERR (resp=2).
+    dut.s_r_valid = 1; dut.s_r_data = 0xDEADBEEFu; dut.s_r_resp = 2; dut.s_r_last = 0;
+    int beat0 = 0;
+    for (int i = 0; i < 32 && !beat0; ++i) {
+        pre_edge();
+        if (dut.s_r_valid && dut.s_r_ready) beat0 = 1;
+        post_edge();
+    }
+    if (!beat0) return fail("s6: first slave sub-beat not consumed");
+
+    // Sub-beat 1: OKAY (resp=0) + r_last.
+    dut.s_r_data = 0xCAFEBABEu; dut.s_r_resp = 0; dut.s_r_last = 1;
+
+    int m_seen = 0;
+    for (int i = 0; i < 32 && !m_seen; ++i) {
+        pre_edge();
+        if (dut.m_r_valid && dut.m_r_ready) {
+            m_seen = 1;
+            if (dut.m_r_resp != 2) {
+                std::printf("  m_r_resp=%u expected 2 (SLVERR)\n", (unsigned)dut.m_r_resp);
+                return fail("s6: master r_resp should reflect SLVERR");
+            }
+            if (!dut.m_r_last) return fail("s6: master r_last must be 1");
+        }
+        post_edge();
+    }
+    if (!m_seen) return fail("s6: master R never seen");
+    dut.s_r_valid = 0; dut.s_r_last = 0; dut.s_r_resp = 0; dut.m_r_ready = 0;
+
+    std::printf("PASS s6: SLVERR propagation (slave resp=2 OR-reduces into master beat)\n");
+    return 0;
+}
+
+int main() {
+    dut.rst = 0;
+    clear_inputs();
+    for (int i = 0; i < 4; ++i) tick();
+    dut.rst = 1;
+    for (int i = 0; i < 3; ++i) tick();
+
+    if (test_single_write()) return 1;
+    for (int i = 0; i < 3; ++i) tick();
+    if (test_single_read())  return 1;
+    for (int i = 0; i < 3; ++i) tick();
+    if (test_incr4_write())  return 1;
+    for (int i = 0; i < 3; ++i) tick();
+    if (test_incr4_read())   return 1;
+    for (int i = 0; i < 3; ++i) tick();
+    if (test_strb_write())   return 1;
+    for (int i = 0; i < 3; ++i) tick();
+    if (test_slverr_read())  return 1;
+
+    std::printf("ALL PASS Nic400WidthAdapter: 6/6 scenarios\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary
Adds a per-port AXI4 width adapter so the NIC-400 demo can host mixed-width masters and slaves. **Downsize only** in v1 (M_DATA_W > S_DATA_W); upsize requires an accumulation buffer and is out of scope.

For default `M_DATA_W=64`, `S_DATA_W=32` → `RATIO=2`:
- **AR/AW**: forward the master burst with `axlen` scaled to `(master_axlen + 1) * RATIO - 1` and `axsize` forced to `log2(S_DATA_W/8)`.
- **W**: split each master wide beat into `RATIO` little-endian slave beats; master `w_ready` pulses only on the last sub-beat of each wide beat.
- **R**: pack `RATIO` consecutive slave beats into one master wide beat (little-endian); `r_resp` OR-reduces across sub-beats; `r_last` fires once per master beat.
- **B**: 1:1 forwarded.

Per-channel `mutex<priority>` locks serialise the multi-thread comb drives on the shared `m.*` / `s.*` outputs, same idiom as `Nic400MasterPort` / `Nic400SlavePort` / `Nic400AhbBridge`.

The R thread is the nested-`for` + `if`/`elsif`/`else` + lock-per-branch shape that previously tripped compiler bug **#422** (the codegen dropped the outer-`for` loop-continuation transition from the if-branch's terminal state). That fix landed in PR **#430** — this adapter is the first in-tree consumer that exercises the now-fixed path under a realistic AXI workload.

## Test plan
`tb_nic400_width_adapter.cpp` covers 6 scenarios at the default 64→32 ratio:

- [x] **s1 — single-beat write** (axlen=0 → axlen=1, 1 wide beat → 2 narrow beats, low half first).
- [x] **s2 — single-beat read** (2 narrow beats → 1 wide beat packed; master `r_last` fires once).
- [x] **s3 — 4-beat INCR write** (axlen=3 → axlen=7, 4 wide → 8 narrow in order).
- [x] **s4 — 4-beat INCR read** (axlen=3 → axlen=7, 8 narrow → 4 wide packed). *This is the #422 path that PR #430 unblocked.*
- [x] **s5 — non-trivial w_strb** (master `0xA5` → slave `[0x5, 0xA]` little-endian).
- [x] **s6 — SLVERR propagation** (slave `resp=2` on any sub-beat surfaces as SLVERR on the containing master beat).

```
$ cargo run --quiet --bin arch -- sim tests/nic400/Nic400WidthAdapter.arch \
    tests/nic400/BusAxi4.arch --tb tests/nic400/tb_nic400_width_adapter.cpp -o /tmp/wa_sim
...
ALL PASS Nic400WidthAdapter: 6/6 scenarios
```

- [x] `cargo test --release` — full unit-test suite still passes (483 + ancillary tests, 0 failures).
- [x] `tb_nic400_fabric_write.cpp` sanity check — existing fabric write TB still PASSes (no regressions).

## Known limitations
- **Downsize only.** Upsize (S_DATA_W > M_DATA_W) needs a data accumulation buffer to assemble narrow beats into a wide one and isn't designed yet.
- **Full-width master `ax_size` only.** A master driving `ax_size < log2(M_DATA_W/8)` (narrow-lane access into a wide port) isn't split intelligently — the adapter still emits `RATIO` slave beats with full slave-width strobes derived from the master-side strb. Real ARM NIC-400 has a finer-grained byte-lane router for this case; out of scope here.
- **Aligned addresses only.** The address is forwarded verbatim; AXI's INCR-burst per-beat address advance is handled by the downstream slave. Unaligned start addresses that would cross a wide-beat boundary mid-burst aren't tested.
- **One outstanding transaction per channel.** AR/AW/W/B threads are each single-state machines that serialise on per-channel locks — matches `Nic400AhbBridge` and `Nic400MasterPort` v1 simplification. Cross-channel concurrency works; same-channel pipelining depth is 1.

## References
- Compiler fix that enabled this design: PR #430 (issue #422). Minimal repro at `tests/regression/issues/nested_if_lock_outer_for_continuation/IfLockOuterForRepro.arch`.
- Reference idiom: `tests/nic400/Nic400AhbBridge.arch` for the per-channel default-comb + lock pattern, `tests/nic400/Nic400MasterPort.arch` for the per-channel thread layout.