### PR TITLE
stdlib/BusApb: decouple pslverr from pprot + refresh header

### DIFF
--- a/stdlib/BusApb.arch
+++ b/stdlib/BusApb.arch
@@ -1,55 +1,66 @@
-// ARM AMBA APB (Advanced Peripheral Bus) — initiator perspective. The
-// target perspective flips directions so peripherals see psel/penable/
-// paddr/pwrite/pwdata (plus optional pprot/pstrb) as inputs and drive
-// prdata/pready (plus optional pslverr) as outputs.
-//
-// Spec lineage (which signals belong to which revision):
-//   • APB v2.0 (IHI 0024, 1998): baseline — psel, penable, paddr,
-//     pwrite, pwdata, prdata, pready. No sidebands.
-//   • APB v3 (IHI 0024B, 2008): adds pslverr — slave/completer can
-//     signal an error response on the access phase.
-//   • APB v4 (IHI 0024C, 2010): adds pprot (3-bit protection
-//     attribute) and pstrb (DATA_W/8-bit write byte enables).
-//   • APB v5 (IHI 0024E, 2021) sideband (e.g. pwakeup, pnse, pauser)
-//     is NOT modelled here.
-//
-// Three-state transfer protocol (enforced by the initiator state
-// machine, not the bus itself):
-//   • Idle:   psel=0, penable=0. No transfer in flight.
-//   • Setup: psel=1, penable=0 for one cycle. paddr, pwrite, pwdata,
-//     (pprot, pstrb when enabled) must be driven valid and held
-//     stable. Setup is always exactly one cycle.
-//   • Access: psel=1, penable=1. All setup-phase signals continue to
-//     be held stable. Target samples the request and drives pready
-//     (and pslverr/prdata) — the access phase persists until pready=1,
-//     at which point the transfer completes and the initiator either
-//     returns to Idle or starts a back-to-back Setup.
-//
-// Toggle parameters (nonzero = include the signal, zero = omit):
-//   USE_PSLVERR — APB3 error-response signal (target → initiator).
-//   USE_PPROT   — APB4 3-bit protection attribute (initiator →
-//                 target). pprot[0]=privileged, pprot[1]=non-secure,
-//                 pprot[2]=instruction.
-//   USE_PSTRB   — APB4 write byte enables, DATA_W/8 bits (initiator →
-//                 target). Only meaningful on pwrite=1.
-//
-// Default for every toggle is 0 so a bare instantiation
-// (`BusApb<ADDR_W=12, DATA_W=32>`) yields an APB v2.0-shaped bundle.
-//
-// Consolidated user: tests/nic400/Nic400ApbBridge.arch and
-// tests/nic400/Nic400System.arch instantiate this bus as
-// `BusApb<..., USE_PSLVERR=1, USE_PPROT=1, USE_PSTRB=1>` to model the
-// NIC-400 reference's APB4-with-error initiator port.
-//
-// Reference: ARM IHI 0024 "AMBA APB Protocol Specification".
-//
-// Example:
-//   use BusApb;
-//   module CsrBank
-//     port s_apb: target BusApb<ADDR_W=12, DATA_W=32>;  // APB2-shaped
-//     ...
-//   end module CsrBank
+//! ---
+//! tags: [bus, apb, amba, peripheral, control_status]
+//! refs:
+//!   - "ARM IHI 0024 'AMBA APB Protocol Specification' (revisions 2.0 / v3 / v4 / v5)"
+//! ---
+//!
+//! ARM AMBA APB (Advanced Peripheral Bus) — initiator perspective. The
+//! target perspective flips directions so peripherals see psel/penable/
+//! paddr/pwrite/pwdata (plus optional pprot/pstrb) as inputs and drive
+//! prdata/pready (plus optional pslverr) as outputs.
+//!
+//! Spec lineage (which signals belong to which revision):
+//!   • APB v2.0 (IHI 0024, 1998): baseline — psel, penable, paddr,
+//!     pwrite, pwdata, prdata, pready. No sidebands.
+//!   • APB v3 (IHI 0024B, 2008): adds pslverr — slave/completer can
+//!     signal an error response on the access phase.
+//!   • APB v4 (IHI 0024C, 2010): adds pprot (3-bit protection
+//!     attribute) and pstrb (DATA_W/8-bit write byte enables).
+//!   • APB v5 (IHI 0024E, 2021) sideband (e.g. pwakeup, pnse, pauser)
+//!     is NOT modelled here.
+//!
+//! Three-state transfer protocol (enforced by the initiator state
+//! machine, not the bus itself):
+//!   • Idle:   psel=0, penable=0. No transfer in flight.
+//!   • Setup: psel=1, penable=0 for one cycle. paddr, pwrite, pwdata,
+//!     (pprot, pstrb when enabled) must be driven valid and held
+//!     stable. Setup is always exactly one cycle.
+//!   • Access: psel=1, penable=1. All setup-phase signals continue to
+//!     be held stable. Target samples the request and drives pready
+//!     (and pslverr/prdata) — the access phase persists until pready=1,
+//!     at which point the transfer completes and the initiator either
+//!     returns to Idle or starts a back-to-back Setup.
+//!
+//! Toggle parameters (nonzero = include the signal, zero = omit):
+//!   USE_PSLVERR — APB3 error-response signal (target → initiator).
+//!   USE_PPROT   — APB4 3-bit protection attribute (initiator →
+//!                 target). pprot[0]=privileged, pprot[1]=non-secure,
+//!                 pprot[2]=instruction.
+//!   USE_PSTRB   — APB4 write byte enables, DATA_W/8 bits (initiator →
+//!                 target). Only meaningful on pwrite=1.
+//!
+//! Default for every toggle is 0 so a bare instantiation
+//! (`BusApb<ADDR_W=12, DATA_W=32>`) yields an APB v2.0-shaped bundle.
+//!
+//! Consolidated user: tests/nic400/Nic400ApbBridge.arch and
+//! tests/nic400/Nic400System.arch instantiate this bus as
+//! `BusApb<..., USE_PSLVERR=1, USE_PPROT=1, USE_PSTRB=1>` to model the
+//! NIC-400 reference's APB4-with-error initiator port.
+//!
+//! Example:
+//!
+//! ```arch
+//!   use BusApb;
+//!   module CsrBank
+//!     port s_apb: target BusApb<ADDR_W=12, DATA_W=32>;  // APB2-shaped
+//!     ...
+//!   end module CsrBank
+//! ```
 
+/// ARM AMBA APB bus, initiator perspective. Toggleable APB3
+/// (`USE_PSLVERR`) and APB4 (`USE_PPROT`, `USE_PSTRB`) sidebands; bare
+/// instantiation yields an APB v2.0-shaped bundle. See file-level docs
+/// for the Idle / Setup / Access protocol and signal-to-revision map.
 bus BusApb
   param ADDR_W:      const = 32;
   param DATA_W:      const = 32;

--- a/stdlib/BusApb.arch
+++ b/stdlib/BusApb.arch
@@ -1,35 +1,61 @@
-// APB3 / APB4 peripheral bus — ARM AMBA Advanced Peripheral Bus.
+// ARM AMBA APB (Advanced Peripheral Bus) — initiator perspective. The
+// target perspective flips directions so peripherals see psel/penable/
+// paddr/pwrite/pwdata (plus optional pprot/pstrb) as inputs and drive
+// prdata/pready (plus optional pslverr) as outputs.
 //
-// Classic low-bandwidth control/status bus used to access peripheral
-// registers. A transfer takes 2–3 cycles:
-//   - SETUP (psel high, penable low)
-//   - ACCESS (psel high, penable high) — completer asserts pready when done
+// Spec lineage (which signals belong to which revision):
+//   • APB v2.0 (IHI 0024, 1998): baseline — psel, penable, paddr,
+//     pwrite, pwdata, prdata, pready. No sidebands.
+//   • APB v3 (IHI 0024B, 2008): adds pslverr — slave/completer can
+//     signal an error response on the access phase.
+//   • APB v4 (IHI 0024C, 2010): adds pprot (3-bit protection
+//     attribute) and pstrb (DATA_W/8-bit write byte enables).
+//   • APB v5 (IHI 0024E, 2021) sideband (e.g. pwakeup, pnse, pauser)
+//     is NOT modelled here.
 //
-// This bus is modeled as a single bidirectional transaction channel plus
-// the APB4 sideband signals (pprot, pstrb, pslverr) gated by toggle
-// parameters. APB3 users leave USE_PPROT / USE_PSTRB at 0.
+// Three-state transfer protocol (enforced by the initiator state
+// machine, not the bus itself):
+//   • Idle:   psel=0, penable=0. No transfer in flight.
+//   • Setup: psel=1, penable=0 for one cycle. paddr, pwrite, pwdata,
+//     (pprot, pstrb when enabled) must be driven valid and held
+//     stable. Setup is always exactly one cycle.
+//   • Access: psel=1, penable=1. All setup-phase signals continue to
+//     be held stable. Target samples the request and drives pready
+//     (and pslverr/prdata) — the access phase persists until pready=1,
+//     at which point the transfer completes and the initiator either
+//     returns to Idle or starts a back-to-back Setup.
 //
-// Toggles (nonzero = include, zero = omit):
-//   USE_PPROT — 3-bit protection attribute (APB4)
-//   USE_PSTRB — DATA_W/8-bit byte enables on writes (APB4)
+// Toggle parameters (nonzero = include the signal, zero = omit):
+//   USE_PSLVERR — APB3 error-response signal (target → initiator).
+//   USE_PPROT   — APB4 3-bit protection attribute (initiator →
+//                 target). pprot[0]=privileged, pprot[1]=non-secure,
+//                 pprot[2]=instruction.
+//   USE_PSTRB   — APB4 write byte enables, DATA_W/8 bits (initiator →
+//                 target). Only meaningful on pwrite=1.
 //
-// Non-conditional signals follow the direction convention: everything
-// from initiator → completer except prdata + pready + pslverr.
+// Default for every toggle is 0 so a bare instantiation
+// (`BusApb<ADDR_W=12, DATA_W=32>`) yields an APB v2.0-shaped bundle.
+//
+// Consolidated user: tests/nic400/Nic400ApbBridge.arch and
+// tests/nic400/Nic400System.arch instantiate this bus as
+// `BusApb<..., USE_PSLVERR=1, USE_PPROT=1, USE_PSTRB=1>` to model the
+// NIC-400 reference's APB4-with-error initiator port.
 //
 // Reference: ARM IHI 0024 "AMBA APB Protocol Specification".
 //
 // Example:
 //   use BusApb;
 //   module CsrBank
-//     port s_apb: target BusApb<ADDR_W=12, DATA_W=32>;
+//     port s_apb: target BusApb<ADDR_W=12, DATA_W=32>;  // APB2-shaped
 //     ...
 //   end module CsrBank
 
 bus BusApb
-  param ADDR_W:    const = 32;
-  param DATA_W:    const = 32;
-  param USE_PPROT: const = 0;
-  param USE_PSTRB: const = 0;
+  param ADDR_W:      const = 32;
+  param DATA_W:      const = 32;
+  param USE_PSLVERR: const = 0;
+  param USE_PPROT:   const = 0;
+  param USE_PSTRB:   const = 0;
 
   // Initiator → completer
   psel:    out Bool;
@@ -42,13 +68,13 @@ bus BusApb
   pready:  in  Bool;
   prdata:  in  UInt<DATA_W>;
 
+  generate_if USE_PSLVERR
+    pslverr: in Bool;
+  end generate_if
   generate_if USE_PPROT
     pprot:   out UInt<3>;
   end generate_if
   generate_if USE_PSTRB
     pstrb:   out UInt<DATA_W / 8>;
-  end generate_if
-  generate_if USE_PPROT
-    pslverr: in Bool;
   end generate_if
 end bus BusApb

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -5805,6 +5805,75 @@ fn test_stdlib_bus_apb_discovery_apb3_minimal() {
 }
 
 #[test]
+fn test_stdlib_bus_apb_pslverr_decoupled_from_pprot() {
+    // pslverr (APB3 baseline, IHI 0024B 2008) used to be gated under
+    // USE_PPROT (APB4 protection, IHI 0024C 2010). They're now
+    // independent toggles. This test exercises the four combinations
+    // and asserts the generated SV port list matches each.
+    let td = tempfile::tempdir().expect("tempdir");
+    let arch_bin = env!("CARGO_BIN_EXE_arch");
+
+    // Helper: build a target-side stub for each toggle pair, run
+    // `arch build`, return the generated SV text.
+    let cases: &[(u32, u32)] = &[(0, 0), (1, 0), (0, 1), (1, 1)];
+    for (use_pslverr, use_pprot) in cases {
+        let name = format!("Stub_v{use_pslverr}_p{use_pprot}");
+        let src = td.path().join(format!("{name}.arch"));
+        // Target side: pslverr direction flips to `out`, so we must
+        // drive it whenever USE_PSLVERR=1.
+        let pslverr_drive = if *use_pslverr == 1 {
+            "s_apb.pslverr = 1'b0;\n            "
+        } else { "" };
+        std::fs::write(&src, format!("\
+            use BusApb;\n\
+            module {name}\n\
+              port clk: in Clock<SysDomain>;\n\
+              port rst: in Reset<Sync>;\n\
+              port s_apb: target BusApb<ADDR_W=12, DATA_W=32, USE_PSLVERR={use_pslverr}, USE_PPROT={use_pprot}>;\n\
+              comb\n\
+                s_apb.pready = 1'b1;\n\
+                s_apb.prdata = 32'h0;\n\
+                {pslverr_drive}\
+              end comb\n\
+            end module {name}\n\
+        ")).unwrap();
+
+        // arch check should succeed for every combination.
+        let chk = std::process::Command::new(arch_bin)
+            .arg("check").arg(&src).output().expect("run arch check");
+        assert!(chk.status.success(),
+            "arch check failed for USE_PSLVERR={use_pslverr} USE_PPROT={use_pprot}; stderr:\n{}",
+            String::from_utf8_lossy(&chk.stderr));
+
+        // Build SV and inspect the generated port list.
+        let sv_out = td.path().join(format!("{name}.sv"));
+        let bld = std::process::Command::new(arch_bin)
+            .arg("build").arg(&src).arg("-o").arg(&sv_out)
+            .output().expect("run arch build");
+        assert!(bld.status.success(),
+            "arch build failed for USE_PSLVERR={use_pslverr} USE_PPROT={use_pprot}; stderr:\n{}",
+            String::from_utf8_lossy(&bld.stderr));
+        let sv = std::fs::read_to_string(&sv_out).expect("read sv");
+
+        // Baseline APB v2 signals always present.
+        for s in ["s_apb_psel", "s_apb_penable", "s_apb_pwrite",
+                  "s_apb_paddr", "s_apb_pwdata", "s_apb_pready",
+                  "s_apb_prdata"] {
+            assert!(sv.contains(s),
+                "missing baseline signal {s} for USE_PSLVERR={use_pslverr} USE_PPROT={use_pprot}\nSV:\n{sv}");
+        }
+        // pslverr gated solely by USE_PSLVERR.
+        let has_pslverr = sv.contains("s_apb_pslverr");
+        assert_eq!(has_pslverr, *use_pslverr == 1,
+            "pslverr presence mismatch for USE_PSLVERR={use_pslverr} USE_PPROT={use_pprot}\nSV:\n{sv}");
+        // pprot gated solely by USE_PPROT.
+        let has_pprot = sv.contains("s_apb_pprot");
+        assert_eq!(has_pprot, *use_pprot == 1,
+            "pprot presence mismatch for USE_PSLVERR={use_pslverr} USE_PPROT={use_pprot}\nSV:\n{sv}");
+    }
+}
+
+#[test]
 fn test_port_reg_deprecation_warning_fires() {
     // Legacy `port reg` should produce a deprecation warning pointing
     // users at `port q: out pipe_reg<T, 1>`.

--- a/tests/nic400/Nic400ApbBridge.arch
+++ b/tests/nic400/Nic400ApbBridge.arch
@@ -63,13 +63,15 @@ module Nic400ApbBridge
   port axi: target    BusAxi4<ADDR_W=ADDR_WIDTH, DATA_W=DATA_WIDTH, STRB_W=STRB_WIDTH,
                               ID_W=ID_WIDTH, READ=1, WRITE=1>;
   // APB initiator — bridge drives control/address/data, samples response.
-  // Uses stdlib/BusApb with the APB3/APB4 sidebands enabled (USE_PPROT=1
-  // brings in pprot + pslverr, USE_PSTRB=1 brings in pstrb sized DATA_W/8).
-  // The NIC-400-local BusApb that originally backed this module has been
-  // removed in favour of the stdlib def — there's no semantic difference
-  // for DATA_W=32, and consolidating avoids two competing bus shapes.
+  // Uses stdlib/BusApb with the APB3/APB4 sidebands enabled
+  // (USE_PSLVERR=1 brings in the APB3 error-response signal, USE_PPROT=1
+  // brings in the APB4 protection attribute, USE_PSTRB=1 brings in pstrb
+  // sized DATA_W/8). The NIC-400-local BusApb that originally backed this
+  // module has been removed in favour of the stdlib def — there's no
+  // semantic difference for DATA_W=32, and consolidating avoids two
+  // competing bus shapes.
   port apb: initiator BusApb<ADDR_W=ADDR_WIDTH, DATA_W=DATA_WIDTH,
-                              USE_PPROT=1, USE_PSTRB=1>;
+                              USE_PSLVERR=1, USE_PPROT=1, USE_PSTRB=1>;
 
   // Mutex to serialise the multi-thread comb drives on apb.*. In steady
   // state the two threads do not contend (one AXI master rarely has both

--- a/tests/nic400/Nic400System.arch
+++ b/tests/nic400/Nic400System.arch
@@ -65,7 +65,7 @@ module Nic400System
   port ahb_h: target BusAhbLite<ADDR_W=ADDR_WIDTH, DATA_W=DATA_WIDTH>;
   // Peripheral-side APB initiator interface.
   port apb_p: initiator BusApb<ADDR_W=ADDR_WIDTH, DATA_W=DATA_WIDTH,
-                                USE_PPROT=1, USE_PSTRB=1>;
+                                USE_PSLVERR=1, USE_PPROT=1, USE_PSTRB=1>;
 
   // PMU counter outputs, observable by the TB.
   port ar_count: out Vec<UInt<32>, NUM_MASTERS>;


### PR DESCRIPTION
## Summary

Decouples `pslverr` from `USE_PPROT` in `stdlib/BusApb.arch` and rewrites the file header with a more thorough protocol explanation (adapted from the recently-deleted NIC-400-local `BusApb` consolidated in PR #433).

### AMBA APB spec mapping

| Signal | Revision | Spec doc |
|---|---|---|
| psel, penable, paddr, pwrite, pwdata, prdata, pready | APB v2.0 (1998) | IHI 0024 (baseline) |
| **pslverr** | **APB v3 (2008)** | **IHI 0024B** |
| pprot, pstrb | APB v4 (2010) | IHI 0024C |
| pwakeup, pnse, pauser | APB v5 (2021) | IHI 0024E (NOT modelled) |

Previously `pslverr` was gated under `USE_PPROT`, forcing APB3-only users wanting the error-response signal to also opt into the APB4 protection attribute. Now each sideband has its own toggle:

```
param USE_PSLVERR: const = 0;   // APB3 baseline error response
param USE_PPROT:   const = 0;   // APB4 protection attribute
param USE_PSTRB:   const = 0;   // APB4 byte strobes
```

### Back-compat

`USE_PSLVERR` defaults to `0` so a bare `BusApb<ADDR_W=12, DATA_W=32>` instantiation remains APB v2.0-shaped — no undriven `pslverr` port appears. The existing `test_stdlib_bus_apb_discovery_apb3_minimal` integration test passes unchanged.

### Consumers updated

- `tests/nic400/Nic400ApbBridge.arch`: now `BusApb<…, USE_PSLVERR=1, USE_PPROT=1, USE_PSTRB=1>` (bridge consumes `apb.pslverr` for AXI `b_resp = SLVERR`).
- `tests/nic400/Nic400System.arch`: same.

### Header rewrite

Replaces the 27-line header with a richer block that:
- Maps each signal to its spec revision (v2.0 / v3 / v4).
- Explains the three-state Idle/Setup/Access protocol with stability requirements per phase.
- Documents the three toggles and which spec revision each corresponds to.
- Notes APB v5 sideband is not modelled.
- Points at the consolidated user (NIC-400 bridge).

## Test plan

- [x] `cargo test --release test_stdlib_bus_apb_discovery_apb3_minimal` — back-compat (APB2-shaped default) ✅
- [x] New `test_stdlib_bus_apb_pslverr_decoupled_from_pprot` covers all four `(USE_PSLVERR, USE_PPROT)` combinations; asserts the generated SV port list contains/omits `pslverr` and `pprot` based solely on their independent toggles ✅
- [x] `tests/nic400/tb_nic400_apb_bridge.cpp`: 6/6 scenarios PASS (single R/W, burst R/W ×4, slverr write, backpressure) ✅
- [x] `tests/nic400/tb_nic400_system.cpp`: AHB ↔ fabric ↔ APB end-to-end + PMU instantiated PASS ✅
- [x] `cargo test --release`: **484/484 PASS** (483 prior + 1 new regression test) ✅

## Caveats

None — change was small and surgical. No compiler changes needed.