### PR TITLE
AGENTS.md: document //! /// // comment-style convention

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -235,6 +235,26 @@ The parse in the "Bad" column is what Verilog/ARCH produces, but rarely what the
 | Clock ports | `Clock<Domain>` | `clk: in Clock<SysDomain>` |
 | Reset ports | `Reset<Sync\|Async, High\|Low>` | `rst: in Reset<Sync>` (High default) |
 
+### Comment Style (recommended, not compiler-enforced)
+`///` and `//!` are doc comments the learning indexer and `arch doc` consume; plain `//` is for inline notes the indexer should skip.
+
+| Marker | Attaches to | Use for |
+|---|---|---|
+| `//!` | Enclosing file/construct | File-level header prose at the top of a `.arch` file. |
+| `///` | The next construct | One-line summary above a `module` / `bus` / `fsm` / etc. |
+| `//`  | Nothing (plain comment) | Inline notes inside a body — not picked up by the indexer. |
+
+```arch
+//! ARM AMBA APB bus — initiator perspective. (file-level prose...)
+
+/// APB initiator bundle with toggleable v3/v4 sidebands.
+bus BusApb
+  // Initiator → completer  (plain // — not a doc comment)
+  psel: out Bool;
+  ...
+end bus BusApb
+```
+
 ### `todo!` Escape Hatch
 Any expression or block body may be replaced with `todo!` to produce a compilable, type-checked skeleton. The compiler emits a warning per site; simulation aborts if a `todo!` site is reached at runtime.
 


### PR DESCRIPTION
## Summary
- Adds a `Comment Style` subsection to `AGENTS.md`, sitting next to the existing `Naming Conventions` subsection in the **Coding style** area.
- Records the three lexical surfaces agents should use when writing `.arch` source:
  - `//!` — file-level header prose (attaches to the enclosing file/construct)
  - `///` — one-line summary above the next construct
  - `//`  — inline notes the learning indexer / `arch doc` should skip
- Includes a short snippet so agents can pattern-match without reading the deeper plan doc.

Motivation: agent-generated `.arch` files were defaulting to plain `//` even for file-level prose, which means the learning indexer / RAG harvester misses the header text. Picking the right marker is a stylistic choice the compiler doesn't enforce — same status as the naming-convention table — so it belongs in the agent-facing style guide.

## Test plan
- [x] Markdown renders (no fenced-block / table syntax breakage)
- [ ] Confirm an agent reading `AGENTS.md` picks up the convention on the next fresh task