### PR TITLE
Fix native sim Vec output wire updates

### DIFF
--- a/src/sim_codegen/mod.rs
+++ b/src/sim_codegen/mod.rs
@@ -6182,6 +6182,7 @@ impl<'a> SimCodegen<'a> {
                                     }
                                 } else {
                                     let prefix = if reg_names.contains(sig_name.as_str()) { "_" }
+                                        else if let_names.contains(sig_name.as_str()) { "_let_" }
                                         else if inst_out.contains(sig_name.as_str()) { "" }
                                         else { "_let_" };
                                     for i in 0..n {
@@ -6351,6 +6352,7 @@ impl<'a> SimCodegen<'a> {
                                     }
                                 } else {
                                     let prefix = if reg_names.contains(sig_name.as_str()) { "_" }
+                                        else if let_names.contains(sig_name.as_str()) { "_let_" }
                                         else if inst_out.contains(sig_name.as_str()) { "" }
                                         else { "_let_" };
                                     for i in 0..n {
@@ -7149,6 +7151,7 @@ impl<'a> SimCodegen<'a> {
                                     }
                                 } else {
                                     let prefix = if reg_names.contains(sig_name.as_str()) { "_" }
+                                        else if let_names.contains(sig_name.as_str()) { "_let_" }
                                         else if inst_out.contains(sig_name.as_str()) { "" }
                                         else { "_let_" };
                                     for i in 0..n {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -17031,3 +17031,34 @@ fn test_sim_nested_vec_reg_round_trips_all_cells() {
         "expected PASS marker in stdout:\n{}",
         String::from_utf8_lossy(&out.stdout));
 }
+
+#[test]
+fn test_native_sim_vec_inst_output_wire_feeds_indexed_let() {
+    // Regression for arch-com#437: a sub-instance Vec output connected to a
+    // declared Vec wire must update the wire's `_let_` storage, because parent
+    // expressions such as `values[idx]` read that storage. The broken native
+    // sim path wrote a separate implicit inst-output array instead, so indexed
+    // lets observed stale zeroes.
+    let td = tempfile::tempdir().expect("tempdir");
+    let arch_bin = env!("CARGO_BIN_EXE_arch");
+    let out = std::process::Command::new(arch_bin)
+        .arg("sim")
+        .arg("tests/native_vec_inst_output_wire/Probe.arch")
+        .arg("--tb")
+        .arg("tests/native_vec_inst_output_wire/tb.cpp")
+        .arg("--outdir")
+        .arg(td.path())
+        .output()
+        .expect("run arch sim for native Vec inst output wire probe");
+    assert!(
+        out.status.success(),
+        "native Vec inst output wire sim should compile + run\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&out.stdout).contains("PASS native Vec inst output wire"),
+        "expected PASS marker in stdout:\n{}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+}

--- a/tests/native_vec_inst_output_wire/Probe.arch
+++ b/tests/native_vec_inst_output_wire/Probe.arch
@@ -1,0 +1,35 @@
+//! ---
+//! tags: [native-sim, vec, inst-output, regression]
+//! refs:
+//!   - "arch-com#437"
+//! ---
+//!
+//! Regression for native C++ simulation of a sub-instance Vec output connected
+//! to a declared parent Vec wire and then read through an indexed let binding.
+
+/// Constant Vec producer used to expose parent-side Vec output wiring.
+module NativeVecProducer
+  port values: out Vec<UInt<32>, 2>;
+
+  comb
+    values[0] = 32'd37;
+    values[1] = 32'd99;
+  end comb
+end module NativeVecProducer
+
+/// Parent probe that indexes a Vec wire driven by a sub-instance output.
+module NativeVecInstOutputWireProbe
+  port select_in: in UInt<1>;
+  port selected_out: out UInt<32>;
+
+  wire values: Vec<UInt<32>, 2>;
+  let selected: UInt<32> = values[select_in];
+
+  inst producer: NativeVecProducer
+    values -> values;
+  end inst producer
+
+  comb
+    selected_out = selected;
+  end comb
+end module NativeVecInstOutputWireProbe

--- a/tests/native_vec_inst_output_wire/tb.cpp
+++ b/tests/native_vec_inst_output_wire/tb.cpp
@@ -1,0 +1,25 @@
+#include "VNativeVecInstOutputWireProbe.h"
+
+#include <cstdint>
+#include <iostream>
+
+int main() {
+  VNativeVecInstOutputWireProbe dut;
+
+  dut.select_in = 0;
+  dut.eval();
+  if (dut.selected_out != 37u) {
+    std::cerr << "select 0 got " << dut.selected_out << ", expected 37\n";
+    return 1;
+  }
+
+  dut.select_in = 1;
+  dut.eval();
+  if (dut.selected_out != 99u) {
+    std::cerr << "select 1 got " << dut.selected_out << ", expected 99\n";
+    return 1;
+  }
+
+  std::cout << "PASS native Vec inst output wire\n";
+  return 0;
+}


### PR DESCRIPTION
## Summary
- fix native C++ sim Vec sub-instance output wiring so declared Vec wires update their _let storage
- add a reduced arch-com#437 regression where a parent indexes a Vec wire driven by a child output
- verified the FPT SoftmaxEngine native repro now emits the expected first weight instead of zero

## Validation
- cargo test test_native_sim_vec_inst_output_wire_feeds_indexed_let -- --nocapture
- cargo run --manifest-path ../arch-com/Cargo.toml -- sim rtl/arch/SoftmaxExpLut.arch rtl/arch/SoftmaxEngine.arch --tb cosim/softmax_engine_arch_native_repro.cpp --outdir build/arch/softmax_native_repro_fixed
- git diff --check