### PR TITLE
fix(sim_codegen): thread params to bus-flat width fold in pybind + FSM sites

### DIFF
--- a/src/sim_codegen/fsm.rs
+++ b/src/sim_codegen/fsm.rs
@@ -457,9 +457,15 @@ impl<'a> SimCodegen<'a> {
             ("state_r".to_string(), "_state_r".to_string(), state_bits as u32),
         ];
         extra_sigs_owned.extend(fsm_flat_vec_traces);
-        // Add flattened bus port signals to trace
+        // Add flattened bus port signals to trace. Use the param-aware
+        // width evaluator (issue #427 sibling site): if a bus's per-signal
+        // width depends on a bus param bound to an enclosing-construct
+        // param Ident (e.g. `port up: target MiniAxi<ID_W=ID_W>` with
+        // `param ID_W: const = N` on the FSM), bare `type_bits_te` cannot
+        // resolve the Ident and falls back to 32, producing wrong VCD lane
+        // widths.
         for (flat_name, flat_ty) in &bus_flat {
-            let bits = type_bits_te(flat_ty);
+            let bits = type_bits_te_with_params(flat_ty, &f.common.params);
             extra_sigs_owned.push((flat_name.clone(), flat_name.clone(), bits));
         }
         let extra_sigs_ref: Vec<(&str, &str, u32)> = extra_sigs_owned.iter()

--- a/src/sim_codegen/mod.rs
+++ b/src/sim_codegen/mod.rs
@@ -444,9 +444,17 @@ impl<'a> SimCodegen<'a> {
             }
         }
 
-        // Bus port flattened fields
+        // Bus port flattened fields. Use the param-aware width evaluator
+        // (issue #427): when a bus's per-signal width depends on a bus param
+        // that the call site binds to an enclosing-module param Ident (e.g.
+        // `up: target MiniAxi<ID_W=ID_W>` with `param ID_W: const = 3`), the
+        // substituted `flat_ty` still contains the module-param Ident;
+        // resolving it requires the enclosing module's params. Bare
+        // `type_bits_te` would mis-classify a >64b signal as scalar and
+        // emit a corrupted `def_readwrite` instead of the wide binding,
+        // and the downstream `port_info` width would be wrong too.
         for (flat_name, flat_ty) in &bus_flat {
-            let width = type_bits_te(flat_ty);
+            let width = type_bits_te_with_params(flat_ty, &m.params);
             let is_signed = matches!(flat_ty, TypeExpr::SInt(_));
             if wide_names.contains(flat_name) {
                 bindings.push(self.emit_wide_binding(&class, flat_name, width));

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -4536,6 +4536,75 @@ fn test_concat_bus_field_width_uses_module_param_binding() {
 }
 
 #[test]
+fn test_pybind_bus_flat_width_uses_module_param_binding() {
+    // Regression for issue #427 sibling site (PR #428 covered the
+    // main-sim path at sim_codegen/mod.rs:4750; the pybind binding
+    // emitter at sim_codegen/mod.rs:449 had the same latent bug).
+    //
+    // When a bus's per-signal width is bound through a module-param-
+    // substituted bus-alias param, the pybind `_port_info` tuple must
+    // report the real width, not the legacy `eval_width` 32-bit
+    // fallback that bare `type_bits_te` produced for an unresolved
+    // module-param Ident.
+    let source = include_str!(
+        "regression/issues/pybind_bus_flat_param_width/PybindBusFlatParamWidth.arch"
+    );
+    let pybinds = compile_to_pybind_cpps(source);
+    let cpp = pybinds.iter().find(|(n, _)| n.contains("PybindBusFlatParamWidth"))
+        .expect("PybindBusFlatParamWidth pybind wrapper").1.clone();
+    // _port_info tuple for `up_data` must carry the param-substituted
+    // width (128), not the conservative 32-bit fallback.
+    assert!(
+        cpp.contains("py::make_tuple(\"up_data\", 128,"),
+        "expected `_port_info` tuple `(\"up_data\", 128, ...)` (param-bound \
+         width); bus-flat width fold dropped back to the legacy 32-bit \
+         fallback:\n{cpp}"
+    );
+    assert!(
+        !cpp.contains("py::make_tuple(\"up_data\", 32,"),
+        "found buggy `_port_info` tuple `(\"up_data\", 32, ...)`; the \
+         bus-flat width lookup for `up_data` resolved to 32 instead of the \
+         param-bound 128:\n{cpp}"
+    );
+}
+
+#[test]
+fn test_fsm_bus_flat_trace_width_uses_construct_param_binding() {
+    // Regression for issue #427 sibling site: `src/sim_codegen/fsm.rs`
+    // also used bare `type_bits_te` to derive per-signal widths for the
+    // waveform trace of FSM-owned bus ports. When the bus's per-signal
+    // width is bound through an FSM-param-substituted bus-alias param,
+    // the VCD `$var wire <width> ... <name> $end` header line must
+    // announce the real lane width.
+    let source = include_str!(
+        "regression/issues/fsm_bus_flat_param_width/FsmBusFlatParamWidth.arch"
+    );
+    let sim = compile_to_sim_h(source, false);
+    // VCD declaration for `up_data` must carry the param-substituted
+    // width (96), not the conservative 32-bit fallback.
+    let up_data_lines: Vec<&str> = sim.lines()
+        .filter(|l| l.contains("up_data $end") && l.contains("$var wire"))
+        .collect();
+    assert_eq!(
+        up_data_lines.len(), 1,
+        "expected exactly one VCD `$var wire ... up_data $end` declaration \
+         line; found {} in:\n{sim}", up_data_lines.len()
+    );
+    let line = up_data_lines[0];
+    assert!(
+        line.contains("$var wire 96 "),
+        "expected VCD declaration for `up_data` to be 96 bits wide \
+         (param-bound DATA_W=96); got:\n  {line}\nin:\n{sim}"
+    );
+    assert!(
+        !line.contains("$var wire 32 "),
+        "found buggy 32-bit VCD declaration for `up_data`; the FSM \
+         bus-flat trace width lookup resolved to 32 instead of the \
+         param-bound 96:\n  {line}"
+    );
+}
+
+#[test]
 fn test_wait_0plus_cycle_until_mealy_fusion_gates_seq_assigns() {
     // Regression for issue #412: the Mealy-fusion lowering for
     //   wait 0+ cycle until X;

--- a/tests/regression/issues/fsm_bus_flat_param_width/FsmBusFlatParamWidth.arch
+++ b/tests/regression/issues/fsm_bus_flat_param_width/FsmBusFlatParamWidth.arch
@@ -1,0 +1,47 @@
+// Regression for issue #427 sibling site: the FSM sim codegen
+// (`src/sim_codegen/fsm.rs`) used bare `type_bits_te(flat_ty)` to
+// derive waveform trace widths for bus-flat ports. When a bus's per-
+// signal width is bound through an FSM-param-substituted bus-alias
+// param, the width Ident cannot be resolved and falls through to the
+// legacy conservative 32-bit fallback. The VCD `$var wire <width> ...`
+// header line then announces the wrong lane width, even though the
+// underlying C++ field is correctly sized.
+//
+// After the fix, the bus-flat trace width fold uses
+// `type_bits_te_with_params(&f.common.params)`, so `up.data` resolves
+// to its real param-bound width.
+bus PayloadBus
+  param DATA_W: const = 8;
+  data:  out UInt<DATA_W>;
+  valid: out Bool;
+end bus PayloadBus
+
+fsm FsmBusFlatParamWidth
+  param DATA_W: const = 96;
+
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port up: initiator PayloadBus<DATA_W=DATA_W>;
+
+  state [Idle, Send]
+  default state Idle;
+  default seq on clk rising;
+
+  default
+    comb
+      up.data  = 0;
+      up.valid = false;
+    end comb
+  end default
+
+  state Idle
+    -> Send;
+  end state Idle
+
+  state Send
+    comb
+      up.valid = true;
+    end comb
+    -> Idle;
+  end state Send
+end fsm FsmBusFlatParamWidth

--- a/tests/regression/issues/pybind_bus_flat_param_width/PybindBusFlatParamWidth.arch
+++ b/tests/regression/issues/pybind_bus_flat_param_width/PybindBusFlatParamWidth.arch
@@ -1,0 +1,30 @@
+// Regression for issue #427 sibling site: the pybind binding emitter
+// (`emit_pybind_module` in `src/sim_codegen/mod.rs`) used bare
+// `type_bits_te(flat_ty)` for bus-flat ports, which has no enclosing-
+// module-param context. When a bus's per-signal width is bound through
+// a module-param-substituted bus-alias param, the width Ident cannot be
+// resolved and falls through to the legacy conservative 32-bit
+// fallback. The exposed pybind `_port_info` tuple then reports the
+// wrong width to the Python harness, even though the SV path is fine.
+//
+// After the fix, the bus-flat width fold uses
+// `type_bits_te_with_params(&m.params)`, so `up.data` resolves to its
+// real param-bound width.
+bus WideBus
+  param DATA_W: const = 8;
+  data:  out UInt<DATA_W>;
+  valid: out Bool;
+end bus WideBus
+
+module PybindBusFlatParamWidth
+  param DATA_W: const = 128;
+
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port up: initiator WideBus<DATA_W=DATA_W>;
+
+  comb
+    up.data  = 0;
+    up.valid = false;
+  end comb
+end module PybindBusFlatParamWidth


### PR DESCRIPTION
## Summary

PR #428 fixed [src/sim_codegen/mod.rs:4750](src/sim_codegen/mod.rs#L4750) (`gen_module`) to use `type_bits_te_with_params(flat_ty, &m.params)` so bus-flat signal widths fold correctly when bound through a module-param-substituted bus-alias param (issue #427). Two sibling sites had the same latent bug and were missed:

- **[src/sim_codegen/mod.rs:449](src/sim_codegen/mod.rs#L449)** — pybind binding emitter. Bare `type_bits_te(flat_ty)` fed the `_port_info` tuple exposed to the Python harness; a param-bound bus-flat width silently collapsed to the legacy `eval_width` 32-bit fallback. SV codegen unaffected; `--pybind --test` harness saw the wrong width.
- **[src/sim_codegen/fsm.rs:462](src/sim_codegen/fsm.rs#L462)** — FSM waveform trace signal list. FSMs **do** own bus ports (see `fsm.rs:30-35`). Bus-flat widths feed `add_trace_to_simple_construct`, which controls VCD `$var wire <width> ... <name> $end` lane sizes — wrong lane width for any param-bound bus signal on an FSM.

Fix at both sites is structurally identical to #428: switch to `type_bits_te_with_params` and thread the enclosing construct's params (`&m.params` for the pybind path, `&f.common.params` for the FSM path).

**Out of scope:** the pybind path also has a separate pre-existing gap — `wide_names` is never augmented with bus-flat names (unlike `gen_module` at `mod.rs:4753`), so wide bus-flat signals fall through to `def_readwrite` regardless of width. Left for a follow-up; this PR addresses only the `_port_info` width that #427 directly spans.

Refs #427.

## Test plan

- [x] New regression: `tests/regression/issues/pybind_bus_flat_param_width/` — module with `port up: initiator WideBus<DATA_W=DATA_W>` and `param DATA_W = 128`. Asserts the pybind cpp emits `py::make_tuple("up_data", 128, ...)` and not `... 32, ...`.
- [x] New regression: `tests/regression/issues/fsm_bus_flat_param_width/` — FSM with a bus port whose flat width is bound to `param DATA_W = 96`. Asserts exactly one VCD `$var wire ... up_data $end` declaration and that its width is 96, not 32.
- [x] Both tests verified to **fail at HEAD~ without the fix** (`up_data` came out as 32 in both the pybind tuple and the VCD lane).
- [x] Both tests **pass with the fix**.
- [x] `cargo test`: **487/487 pass**.