### PR TITLE
fix(sim_codegen): param-aware Vec wire/reg count for inst port fan-out

### DIFF
--- a/src/sim_codegen/mod.rs
+++ b/src/sim_codegen/mod.rs
@@ -4883,19 +4883,23 @@ impl<'a> SimCodegen<'a> {
             }
         }
 
-        // Vec wire/reg name → element count (for expanding inst port connections)
+        // Vec wire/reg name → element count (for expanding inst port connections).
+        // Must use the param-aware evaluator so `wire/reg Vec<T, PARAM>` resolves
+        // to the param's literal value. Without this, a param-sized parent Vec
+        // wire connected to a sub-inst Vec input port silently emits zero
+        // fan-out lines (loop `for i in 0..0`), leaving the sub-inst's inputs
+        // permanently default-constructed.
         let mut vec_wire_counts: HashMap<String, u64> = m.body.iter()
             .filter_map(|i| if let ModuleBodyItem::WireDecl(w) = i {
                 if let TypeExpr::Vec(_, count_expr) = &w.ty {
-                    Some((w.name.name.clone(), eval_const_expr(count_expr)))
+                    Some((w.name.name.clone(), eval_const_expr_with_params(count_expr, &m.params)))
                 } else { None }
             } else { None })
             .collect();
-        // Also include Vec regs (for inst port connections like Vec reg → inst Vec output)
         for item in &m.body {
             if let ModuleBodyItem::RegDecl(r) = item {
                 if let TypeExpr::Vec(_, count_expr) = &r.ty {
-                    vec_wire_counts.insert(r.name.name.clone(), eval_const_expr(count_expr));
+                    vec_wire_counts.insert(r.name.name.clone(), eval_const_expr_with_params(count_expr, &m.params));
                 }
             }
         }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -17131,3 +17131,38 @@ fn test_native_sim_vec_inst_output_wire_feeds_indexed_let() {
         String::from_utf8_lossy(&out.stdout)
     );
 }
+
+#[test]
+fn test_native_sim_vec_inst_input_wire_param_sized_fanout() {
+    // Regression for arch-com#432 (Nic400 PMU integration). A parent
+    // `wire Vec<T, PARAM>` driven in `comb` and connected to a sub-instance
+    // Vec input port must emit per-element fan-out assignments. The native
+    // sim codegen built its vec-wire-count map with the non-param-aware
+    // `eval_const_expr`, which collapsed param-sized vecs to count=0; the
+    // input fan-out loop then iterated zero times, silently leaving the
+    // sub-instance's inputs default-constructed. Symptom that surfaced this:
+    // Nic400Pmu counters stuck at zero in Nic400System integration even
+    // though pulses were correctly computed in the parent's `comb` block.
+    let td = tempfile::tempdir().expect("tempdir");
+    let arch_bin = env!("CARGO_BIN_EXE_arch");
+    let out = std::process::Command::new(arch_bin)
+        .arg("sim")
+        .arg("tests/native_vec_inst_input_wire/Probe.arch")
+        .arg("--tb")
+        .arg("tests/native_vec_inst_input_wire/tb.cpp")
+        .arg("--outdir")
+        .arg(td.path())
+        .output()
+        .expect("run arch sim for native Vec inst input wire probe");
+    assert!(
+        out.status.success(),
+        "native Vec inst input wire sim should compile + run\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&out.stdout).contains("PASS native Vec inst input wire"),
+        "expected PASS marker in stdout:\n{}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+}

--- a/tests/native_vec_inst_input_wire/Probe.arch
+++ b/tests/native_vec_inst_input_wire/Probe.arch
@@ -1,0 +1,71 @@
+//! ---
+//! tags: [native-sim, vec, inst-input, regression]
+//! refs:
+//!   - "arch-com#432"
+//! ---
+//!
+//! Regression: a parent `wire Vec<T, PARAM>` driven in `comb` and connected to
+//! a sub-instance Vec input port must produce per-element fan-out assignments.
+//! The native sim codegen built its vec-wire-count map with the non-param-aware
+//! `eval_const_expr`, so a Vec sized by a param identifier (e.g. `NUM_LANES`)
+//! collapsed to count=0 and the input fan-out loop emitted nothing — leaving
+//! the sub-instance's Vec input permanently default-constructed (zero).
+//!
+//! Symptom that surfaced this: Nic400System wired `wire pmu_aw_event:
+//! Vec<Bool, NUM_MASTERS>` into Nic400Pmu's `aw_event` input. The PMU counter
+//! stayed at zero across real AHB→AXI traffic because no pulses ever reached
+//! the sub-instance.
+
+/// Per-lane pulse counter. One increment per cycle when pulse[i] is high.
+module NativeVecInputCounter
+  param N: const = 3;
+  port clk:   in  Clock<SysDomain>;
+  port rst:   in  Reset<Async, Low>;
+  port pulse: in  Vec<Bool, N>;
+  port count: out Vec<UInt<8>, N>;
+
+  reg default: reset rst => 0;
+  reg cnt_r: Vec<UInt<8>, N>;
+
+  seq on clk rising
+    for i in 0..N-1
+      if pulse[i]
+        cnt_r[i] <= cnt_r[i] +% 1;
+      end if
+    end for
+  end seq
+
+  comb
+    for i in 0..N-1
+      count[i] = cnt_r[i];
+    end for
+  end comb
+end module NativeVecInputCounter
+
+/// Parent that drives a `wire Vec<Bool, PARAM>` into a sub-inst Vec input.
+/// The param-sized wire is the codegen path that used to break.
+module NativeVecInstInputWireProbe
+  param N: const = 3;
+  port clk:   in  Clock<SysDomain>;
+  port rst:   in  Reset<Async, Low>;
+  port drive: in  Vec<Bool, N>;
+  port count: out Vec<UInt<8>, N>;
+
+  // Parameterized Vec wire driven in `comb`, fanned out to a sub-inst Vec
+  // input port. This is the shape that silently dropped the fan-out before
+  // the eval_const_expr_with_params fix.
+  wire pulse_w: Vec<Bool, N>;
+
+  inst cnt: NativeVecInputCounter
+    clk   <- clk;
+    rst   <- rst;
+    pulse <- pulse_w;
+    count -> count;
+  end inst cnt
+
+  comb
+    for i in 0..N-1
+      pulse_w[i] = drive[i];
+    end for
+  end comb
+end module NativeVecInstInputWireProbe

--- a/tests/native_vec_inst_input_wire/tb.cpp
+++ b/tests/native_vec_inst_input_wire/tb.cpp
@@ -1,0 +1,28 @@
+#include "VNativeVecInstInputWireProbe.h"
+
+#include <cstdio>
+
+static VNativeVecInstInputWireProbe dut;
+
+static void tick() { dut.clk = 0; dut.eval(); dut.clk = 1; dut.eval(); }
+
+int main() {
+    dut.rst = 0;
+    dut.drive[0] = 0; dut.drive[1] = 0; dut.drive[2] = 0;
+    for (int i = 0; i < 3; ++i) tick();
+    dut.rst = 1;
+    for (int i = 0; i < 2; ++i) tick();
+
+    // Lane 0: 3 pulses. Lane 1: 1 pulse. Lane 2: 0 pulses.
+    for (int i = 0; i < 3; ++i) { dut.drive[0] = 1; tick(); dut.drive[0] = 0; tick(); }
+    dut.drive[1] = 1; tick(); dut.drive[1] = 0;
+    for (int i = 0; i < 3; ++i) tick();
+
+    if (dut.count[0] != 3 || dut.count[1] != 1 || dut.count[2] != 0) {
+        std::printf("FAIL: count = [%u, %u, %u], expected [3, 1, 0]\n",
+                    (unsigned)dut.count[0], (unsigned)dut.count[1], (unsigned)dut.count[2]);
+        return 1;
+    }
+    std::printf("PASS native Vec inst input wire\n");
+    return 0;
+}

--- a/tests/nic400/tb_nic400_system.cpp
+++ b/tests/nic400/tb_nic400_system.cpp
@@ -14,8 +14,8 @@
 //   2. Single-beat AHB read → APB read. AHB master drives NONSEQ +
 //      HWRITE=0. TB-as-peripheral returns prdata on pready=1. Verify
 //      AHB master sees HRDATA matching the returned value.
-//   3. PMU sanity: ar_count[0] and aw_count[0] each increment by 1
-//      after the two transactions; counts for masters 1/2 stay 0.
+//   3. PMU exact-count: after S1 (write) and S2 (read), master 0's
+//      ar/r/aw/w/b counters each equal 1; masters 1 and 2 stay at 0.
 //
 // Addressing
 // ──────────
@@ -185,20 +185,22 @@ int main() {
     }
     std::printf("  OK [S2] AHB read 0x%x ← APB prdata 0x%x → HRDATA matches\n", addr2, prdata2);
 
-    // ── Scenario 3: PMU instantiated and idle masters stay at zero ────
-    // The PMU is wired in and observable, but exact-count testing of the
-    // Mealy-fused bridge handshakes is left to the dedicated tb_nic400_
-    // pmu.cpp — the AHB bridge's `wait 0+ cycle until …;` Mealy fusion
-    // produces ar_valid pulses that go 0→1→0 within a single eval pass,
-    // so by the time the PMU's seq block samples at the rising edge the
-    // pulse has settled back to 0. Counting Mealy comb pulses requires
-    // a registered event-detect (a small piece of glue between the AXI
-    // bridge and the PMU) which the dedicated PMU TB exercises by
-    // driving event pulses directly. For the integrated demo here we
-    // assert the structural property: idle masters (1 and 2) record no
-    // events, and the PMU module is instantiated + wired without
-    // elaboration error.
+    // ── Scenario 3: PMU exact-count check on master 0 + idle on m1/m2 ─
+    // After S1 (single-beat AHB write) the master-0 AW/W/B channels each
+    // see exactly one handshake. After S2 (single-beat AHB read) the AR/R
+    // channels each see one. Masters 1 and 2 are tied off and must stay
+    // at zero on every channel.
     for (int i = 0; i < 10; ++i) tick();   // settle PMU regs
+    unsigned ar0 = (unsigned)dut.ar_count[0];
+    unsigned r0  = (unsigned)dut.r_count[0];
+    unsigned aw0 = (unsigned)dut.aw_count[0];
+    unsigned w0  = (unsigned)dut.w_count[0];
+    unsigned b0  = (unsigned)dut.b_count[0];
+    if (ar0 != 1 || r0 != 1 || aw0 != 1 || w0 != 1 || b0 != 1) {
+        std::printf("FAIL PMU m0: ar=%u r=%u aw=%u w=%u b=%u, expected all=1\n",
+                    ar0, r0, aw0, w0, b0);
+        return 1;
+    }
     unsigned ar1 = (unsigned)dut.ar_count[1];
     unsigned ar2 = (unsigned)dut.ar_count[2];
     unsigned aw1 = (unsigned)dut.aw_count[1];
@@ -208,8 +210,8 @@ int main() {
                     ar1, ar2, aw1, aw2);
         return 1;
     }
-    std::printf("  OK [S3] PMU wired in; idle masters 1/2 have ar=aw=0 as expected\n");
+    std::printf("  OK [S3] PMU m0 ar=r=aw=w=b=1; idle masters 1/2 stay 0\n");
 
-    std::printf("PASS Nic400System: AHB ↔ fabric ↔ APB end-to-end + PMU instantiated\n");
+    std::printf("PASS Nic400System: AHB ↔ fabric ↔ APB end-to-end + PMU counts\n");
     return 0;
 }


### PR DESCRIPTION
## Summary
- `vec_wire_counts` was built with `eval_const_expr` (no param resolution). A parent `wire/reg Vec<T, PARAM>` connected to a sub-instance Vec input port collapsed to count=0; the per-element fan-out loop emitted nothing and the sub-instance's Vec input stayed default-constructed forever. Fix: use `eval_const_expr_with_params(_, &m.params)` at both call sites.
- Surfaced as a Nic400 integration bug. `Nic400System` wires `wire pmu_aw_event: Vec<Bool, NUM_MASTERS>` into `Nic400Pmu`'s event input. PMU counters stayed at zero across real AHB→AXI traffic, which #432 attributed (incorrectly) to Mealy-fused bridge handshakes. Output direction was unaffected because a separate path (`inst_vec_out` override) inspects sub-port types with the param-aware `vec_array_info_with_params`.
- Re-enables the master-0 exact-count assertion in `tb_nic400_system.cpp` (now `ar=r=aw=w=b=1` after the S1 write + S2 read) and drops the stale apologetic comment block.

## Test plan
- [x] `cargo test --release --test integration_test` — 488 passed, 0 failed
- [x] `arch sim` on the new `tests/native_vec_inst_input_wire/Probe.arch` → `PASS native Vec inst input wire`
- [x] `arch sim` on `tests/nic400/tb_nic400_system.cpp` → `OK [S3] PMU m0 ar=r=aw=w=b=1; idle masters 1/2 stay 0`
- [x] `arch sim` on `tests/nic400/tb_nic400_pmu.cpp` (standalone) — still passes

## Follow-up (not in this PR)
- Inst param override with same-named parent identifier (`inst foo: Sub  param N = N;`) creates a circular self-reference in `sub_params` that `eval_const_expr_with_params` short-circuits to 0 via its seen-set. Breaks both directions of Vec port fan-out in that specific case. Workaround today: drop the redundant override when both modules already share the same literal default. Nic400 isn't affected — it never does this.