### PR TITLE
[codex] Fix literal bit selects after TLM loop unroll

### DIFF
--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -4792,6 +4792,11 @@ impl<'a> Codegen<'a> {
                 }
             }
             ExprKind::Index(base, idx) => {
+                if let (Some(v), Some(idx_v)) = (literal_expr_u64(base), literal_expr_u64(idx)) {
+                    if idx_v < 64 {
+                        return format!("1'd{}", (v >> idx_v) & 1);
+                    }
+                }
                 // Vec-of-const param `B[i]`: rewrite to packed part-select
                 // `B[i*W +: W]` since iverilog rejects unpacked-array params.
                 if let ExprKind::Ident(name) = &base.kind {
@@ -4812,6 +4817,19 @@ impl<'a> Codegen<'a> {
                 format!("{b}[{i}]")
             }
             ExprKind::BitSlice(base, hi, lo) => {
+                if let (Some(v), Some(hi_v), Some(lo_v)) =
+                    (literal_expr_u64(base), literal_expr_u64(hi), literal_expr_u64(lo))
+                {
+                    if hi_v >= lo_v && hi_v < 64 {
+                        let width = (hi_v - lo_v + 1) as u32;
+                        let mask = if width >= 64 {
+                            u64::MAX
+                        } else {
+                            (1u64 << width) - 1
+                        };
+                        return format!("{width}'d{}", (v >> lo_v) & mask);
+                    }
+                }
                 let b = self.emit_expr_str(base);
                 // Parenthesize complex base expressions to avoid precedence issues.
                 // SynthIdent is a compiler-renamed bare identifier with the same
@@ -5226,4 +5244,14 @@ impl<'a> Codegen<'a> {
     // ── Synchronizer ─────────────────────────────────────────────────────────
     // ── RAM ───────────────────────────────────────────────────────────────────
 
+}
+
+fn literal_expr_u64(expr: &Expr) -> Option<u64> {
+    match &expr.kind {
+        ExprKind::Literal(LitKind::Dec(v))
+        | ExprKind::Literal(LitKind::Hex(v))
+        | ExprKind::Literal(LitKind::Bin(v))
+        | ExprKind::Literal(LitKind::Sized(_, v)) => Some(*v),
+        _ => None,
+    }
 }

--- a/src/elaborate.rs
+++ b/src/elaborate.rs
@@ -1652,6 +1652,19 @@ fn fold_literal_bit_slices_expr(expr: Expr) -> Expr {
     let span = expr.span;
     let parenthesized = expr.parenthesized;
     let kind = match expr.kind {
+        ExprKind::Index(base, idx) => {
+            let base = fold_literal_bit_slices_expr(*base);
+            let idx = fold_literal_bit_slices_expr(*idx);
+            if let (Some(v), Some(idx_v)) = (literal_expr_u64(&base), literal_expr_u64(&idx)) {
+                if idx_v < 64 {
+                    ExprKind::Literal(LitKind::Sized(1, (v >> idx_v) & 1))
+                } else {
+                    ExprKind::Index(Box::new(base), Box::new(idx))
+                }
+            } else {
+                ExprKind::Index(Box::new(base), Box::new(idx))
+            }
+        }
         ExprKind::BitSlice(base, hi, lo) => {
             let base = fold_literal_bit_slices_expr(*base);
             let hi = fold_literal_bit_slices_expr(*hi);
@@ -1689,10 +1702,6 @@ fn fold_literal_bit_slices_expr(expr: Expr) -> Expr {
             Box::new(fold_literal_bit_slices_expr(*e)),
             m,
             args.into_iter().map(fold_literal_bit_slices_expr).collect(),
-        ),
-        ExprKind::Index(base, idx) => ExprKind::Index(
-            Box::new(fold_literal_bit_slices_expr(*base)),
-            Box::new(fold_literal_bit_slices_expr(*idx)),
         ),
         ExprKind::Cast(e, ty) => ExprKind::Cast(Box::new(fold_literal_bit_slices_expr(*e)), ty),
         ExprKind::Concat(exprs) => {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -9119,6 +9119,34 @@ fn test_fpt26_runtime_loop_tlm_initiator_compiles() {
 }
 
 #[test]
+fn test_thread_loop_const_bit_select_folds_after_unroll() {
+    // Regression for issue #444: TLM initiator lowering unrolls literal
+    // thread `for` loops by substituting the loop variable with a literal.
+    // A single-bit select on that variable (`kv_group[0]`) used to survive
+    // as invalid SV (`0[0]`, `1[0]`, ...). Literal bit-selects must fold
+    // to valid sized constants.
+    let source = include_str!(
+        "regression/issues/thread_loop_const_bit_select/ThreadLoopConstBitSelect.arch"
+    );
+    let sv = compile_to_sv(source);
+    assert!(
+        sv.contains("module ThreadLoopConstBitSelect"),
+        "expected issue #444 regression module:\n{sv}"
+    );
+    for i in 0..=3 {
+        let bad = format!("{i}[0] == 1'd0");
+        assert!(
+            !sv.contains(&bad),
+            "literal bit-select should have folded instead of emitting `{bad}`:\n{sv}",
+        );
+    }
+    assert!(
+        sv.contains("1'd0 == 1'd0") && sv.contains("1'd1 == 1'd0"),
+        "expected folded single-bit constants in the unrolled branch conditions:\n{sv}",
+    );
+}
+
+#[test]
 fn test_fpt26_runtime_loop_tlm_arch_sim_behavior() {
     let td = tempfile::tempdir().expect("tempdir");
     let arch_bin = env!("CARGO_BIN_EXE_arch");

--- a/tests/regression/issues/thread_loop_const_bit_select/ThreadLoopConstBitSelect.arch
+++ b/tests/regression/issues/thread_loop_const_bit_select/ThreadLoopConstBitSelect.arch
@@ -1,0 +1,49 @@
+//! ---
+//! tags: [tlm_method, thread_loop, constant_fold, bit_select, issue_444]
+//! refs:
+//!   - "arch-com#444"
+//! ---
+//!
+//! Regression for literal thread-loop unrolling inside TLM initiator lowering.
+//! A compile-time loop variable used as the base of a bit-select must fold to
+//! a sized constant instead of emitting invalid SV such as `0[0]`.
+
+/// Minimal blocking TLM service used to force initiator-call lowering.
+bus Issue444Svc
+  tlm_method read(idx: UInt<3>) -> UInt<8>: blocking;
+end bus Issue444Svc
+
+/// Bring the issue-444 service bus into scope for module ports.
+use Issue444Svc;
+
+/// TLM initiator whose compile-time thread loop branches on a loop-variable bit.
+module ThreadLoopConstBitSelect
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port svc: initiator Issue444Svc;
+  port even_sum: out UInt<16>;
+  port odd_sum: out UInt<16>;
+
+  reg tmp: UInt<8> reset rst => 0;
+  reg even_r: UInt<16> reset rst => 0;
+  reg odd_r: UInt<16> reset rst => 0;
+
+  comb
+    even_sum = even_r;
+    odd_sum = odd_r;
+  end comb
+
+  thread driver on clk rising, rst high
+    even_r <= 0;
+    odd_r <= 0;
+
+    for kv_group in 0..3
+      tmp <= svc.read(kv_group[2:0]);
+      if kv_group[0] == 1'd0
+        even_r <= even_r +% tmp.zext<16>();
+      else
+        odd_r <= odd_r +% tmp.zext<16>();
+      end if
+    end for
+  end thread driver
+end module ThreadLoopConstBitSelect


### PR DESCRIPTION
## Summary

Fixes #444.

TLM initiator lowering already unrolls literal thread `for` loops and folds literal bit-slices like `kv_group[2:0]`. The single-bit form `kv_group[0]` is represented as `ExprKind::Index`, so after loop-variable substitution it could reach SV emission as invalid constant bit-selects such as `0[0]`.

This PR folds literal `Index` selects in the post-unroll constant folding pass, and adds a defensive SV codegen fallback for literal index/bit-slice bases so future lowering paths do not emit invalid numeric literal selects.

## Validation

- `cargo test test_thread_loop_const_bit_select_folds_after_unroll --test integration_test`
- `cargo test test_fpt26_runtime_loop_tlm_initiator_compiles --test integration_test`
- `cargo check`
- From `/Users/shuqingzhao/github/fpt26-accel` on `codex/full-gqa-arch-tlm`: `make arch-tlm-build`
  - `arch check rtl/tlm/AttentionDecodeStage1Tlm.arch`: OK
  - `arch build --no-inline-deps`: wrote `rtl/generated_tlm/AttentionDecodeStage1Tlm.sv`
  - `verilator --lint-only -Wno-fatal --top-module AttentionDecodeStage1Tlm rtl/generated_tlm/AttentionDecodeStage1Tlm.sv`: passed
- `rg "\\b[0-9]+\\[[0-9]+\\]" rtl/generated_tlm/AttentionDecodeStage1Tlm.sv` found no invalid numeric literal selects.
