### PR TITLE
nic400: explain why PMU master-0 handshakes are observable

### DIFF
--- a/tests/nic400/tb_nic400_system.cpp
+++ b/tests/nic400/tb_nic400_system.cpp
@@ -190,6 +190,19 @@ int main() {
     // see exactly one handshake. After S2 (single-beat AHB read) the AR/R
     // channels each see one. Masters 1 and 2 are tied off and must stay
     // at zero on every channel.
+    //
+    // Note for future maintainers: handshake pulses on `ahb_axi.*_valid &&
+    // *_ready` ARE observable by the PMU's `seq on clk rising` block, even
+    // when produced by the AHB bridge's `wait 0+ cycle until …;` Mealy
+    // fusion. The pulse is a comb signal that holds across the rising edge
+    // until the consumer asserts `ready` — exactly when the sampling edge
+    // fires — so the PMU's `if aw_event[i] cnt <= cnt +% 1;` increments
+    // correctly. An earlier version of this TB skipped master-0 exact-
+    // count checks with an "unobservable Mealy pulse" rationale; the true
+    // cause of the zero counts was a sim_codegen bug (PR #442 /
+    // de35faa) where param-sized `wire Vec<T, PARAM>` connections to
+    // sub-inst Vec input ports emitted zero fan-out lines, leaving the
+    // PMU's inputs default-constructed. Do not reintroduce that apology.
     for (int i = 0; i < 10; ++i) tick();   // settle PMU regs
     unsigned ar0 = (unsigned)dut.ar_count[0];
     unsigned r0  = (unsigned)dut.r_count[0];


### PR DESCRIPTION
## Summary

Follow-up to #442. That PR re-enabled master-0 PMU exact-count checks in `tb_nic400_system.cpp` and dropped a long apologetic comment that claimed Mealy-fused bridge handshakes were unobservable. This PR adds a short note in the TB making it explicit *why* those handshakes ARE observable, so the next person debugging PMU counts doesn't re-introduce the apology.

## Verdict

The "Mealy fusion pulse unobservable" rationale was **always wrong**. The true cause of the zero PMU counts was a sim_codegen bug (commit `de35faa`, fixed in #442) where `vec_wire_counts` used `eval_const_expr` instead of `eval_const_expr_with_params`. Param-sized `wire Vec<T, PARAM>` connections to sub-inst Vec input ports collapsed to `count=0`, so the per-element fan-out loop iterated zero times and silently emitted nothing — leaving the PMU's `aw_event`/`ar_event`/etc. inputs default-constructed (all zero) regardless of what the parent's `comb` block computed.

PR #442's commit message already calls this out clearly, and ships a targeted regression test at `tests/native_vec_inst_input_wire/Probe.arch` exercising the param-sized Vec wire → sub-inst input fan-out. The only gap left is in the TB itself: the brief replacement comment from #442 documents what is being checked but not why it works, leaving room for the apology to creep back.

This PR is comment-only — no code change.

## Test plan

- [x] `cargo build --release` clean
- [x] Comment-only change; existing #442 regression test covers the underlying invariant