### PR TITLE
fix(sim_codegen): align round-robin arbiter first-cycle grant with SV

### DIFF
--- a/src/sim_codegen/mod.rs
+++ b/src/sim_codegen/mod.rs
@@ -8416,7 +8416,15 @@ impl<'a> SimCodegen<'a> {
         }
         all_port_inits.push("_clk_prev(0)".to_string());
         if needs_rr_state {
-            all_port_inits.push("_last_grant(0)".to_string());
+            // Initialize `_last_grant` to N-1 so the first-cycle scan
+            // formula `(_last_grant + 1 + _i) % N` starts at index 0,
+            // matching the SV emitter's `(rr_ptr_r + arb_i) % N` with
+            // `rr_ptr_r` reset to 0. Without this, the sim grants
+            // index 1 on the first contending cycle while SV grants
+            // index 0 — a 1-slot divergence at t=0 that only resolves
+            // after the first successful grant updates `_last_grant`
+            // to the actual grantee.
+            all_port_inits.push(format!("_last_grant({})", num_req.saturating_sub(1)));
         }
 
         h.push_str(&format!("  {class}() : {} {{}}\n", all_port_inits.join(", ")));
@@ -8462,7 +8470,12 @@ impl<'a> SimCodegen<'a> {
         cpp.push_str(&format!("  _clk_prev = {clk_port};\n"));
         cpp.push_str("  if (!_rising) return;\n");
         if needs_rr_state {
-            cpp.push_str(&format!("  if ({rst_cond}) {{\n    _last_grant = 0;\n  }} else {{\n"));
+            // Reset value is N-1 (not 0): see the constructor-init
+            // comment above. The scan formula treats `_last_grant + 1`
+            // as the first index to test, so `_last_grant = N-1`
+            // makes the first post-reset cycle scan from index 0.
+            let rst_val = num_req.saturating_sub(1);
+            cpp.push_str(&format!("  if ({rst_cond}) {{\n    _last_grant = {rst_val};\n  }} else {{\n"));
             cpp.push_str("    if (grant_valid) _last_grant = grant_requester;\n");
             cpp.push_str("  }\n");
         }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -551,6 +551,63 @@ end arbiter BadArb
     assert!(result.is_err(), "expected error for hook param shadowing port");
 }
 
+/// Round-robin arbiter sim must grant index 0 on the first
+/// post-reset cycle when all requesters contend, matching the SV
+/// emitter (which starts the scan AT `rr_ptr_r = 0`).
+///
+/// Pre-fix: the sim initialized `_last_grant = 0` and scanned from
+/// `(_last_grant + 1 + _i) % N`, so it started at index 1 on cycle 1
+/// — diverging from SV by one slot. Steady-state matched because
+/// both designs advance the pointer to `(grant + 1) % N` after a
+/// grant; only the first cycle was off.
+///
+/// Fix: initialize `_last_grant = N - 1` at reset, so
+/// `(N-1 + 1 + 0) % N = 0` and the first scan matches SV.
+///
+/// Surfaced in arch-hdl-lang/arch-com#447 §2.
+#[test]
+fn test_arbiter_round_robin_sim_inits_last_grant_to_n_minus_one() {
+    let source = r#"
+domain SysDomain
+  freq_mhz: 100
+end domain SysDomain
+
+arbiter RRArb4
+  policy round_robin;
+  param NUM_REQ: const = 4;
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  ports[NUM_REQ] request
+    valid: in Bool;
+    ready: out Bool;
+  end ports request
+  port grant_valid: out Bool;
+  port grant_requester: out UInt<2>;
+end arbiter RRArb4
+"#;
+    let sim = compile_to_sim_h(source, false);
+    assert!(
+        sim.contains("_last_grant(3)"),
+        "expected `_last_grant(3)` (NUM_REQ - 1 = 3) in the emitted \
+         arbiter constructor init list so the first-cycle scan starts \
+         at index 0; got:\n{sim}"
+    );
+    assert!(
+        !sim.contains("_last_grant(0)"),
+        "found pre-fix `_last_grant(0)` init in the emitted arbiter; \
+         the first-cycle scan would start at index 1 and diverge \
+         from the SV emitter:\n{sim}"
+    );
+    // Steady-state behaviour unchanged: still set _last_grant to the
+    // current grantee on every successful grant. The reset clause is
+    // what we changed.
+    assert!(
+        sim.contains("if (grant_valid) _last_grant = grant_requester;"),
+        "expected steady-state pointer update to remain `if (grant_valid) \
+         _last_grant = grant_requester;`; got:\n{sim}"
+    );
+}
+
 #[test]
 fn test_arbiter_latency2() {
     let source = include_str!("../examples/arbiter_latency2.arch");


### PR DESCRIPTION
## Summary

Native-sim `arbiter` with `policy round_robin` (or `lru`) diverged
from the SV emitter by one slot on the first cycle after reset.

- SV (`src/codegen/arbiter.rs:276`): resets `rr_ptr_r <= '0`, scans
  `(rr_ptr_r + arb_i) % N` — `arb_i = 0` tests index 0 first.
- Sim (`src/sim_codegen/mod.rs:8419`): initialized `_last_grant = 0`,
  scans `(_last_grant + 1 + _i) % N` — `_i = 0` tests index 1 first.

With request bits 0 and 1 both asserted on cycle 1, SV grants
index 0 and sim grants index 1. Steady-state matches because both
designs advance the pointer to `(grant + 1) % N` after every
successful grant.

## Fix

Initialize `_last_grant = N - 1` at both the constructor init list
and the sync-reset clause. `(N-1 + 1 + 0) % N = 0` matches SV.

## Test

Adds `test_arbiter_round_robin_sim_inits_last_grant_to_n_minus_one`
in `tests/integration_test.rs`. Asserts the emitted C++ constructor
has `_last_grant(3)` (NUM_REQ=4, so N-1=3) and that the steady-state
clause `if (grant_valid) _last_grant = grant_requester;` is unchanged.

All 490 integration tests pass locally.

## Out of scope

For **non-power-of-2** `NUM_REQ` the SV emitter has a separate
fairness issue: the pointer update `rr_ptr_r <= rr_ptr_r + 1` lacks
a `% num_req`, *and* it advances the scan-start pointer instead of
`grant_requester + 1`. Combined, those mean a 3-master arbiter with
all three asserting steady-state grants index 0 twice as often as
index 1 or 2. That bug is real but distinct from the cycle-1
mismatch this PR fixes — it touches user-visible behaviour and the
language-level "fair round-robin" guarantee, so it deserves its own
PR with maintainer sign-off. Flagged in arch-com#447 §2.

## Context

Surfaced in the 2026-05-27 daily code-review pass, arch-com#447 §2.

## Test plan

- [x] `cargo test --test integration_test test_arbiter_round_robin_sim_inits_last_grant` passes locally.
- [x] `cargo test --test integration_test arbiter` — 16 arbiter tests pass.
- [x] `cargo test --test integration_test` — full suite 490 pass.
- [ ] CI green.