### PR TITLE
fix(codegen/arbiter): fair round-robin for non-power-of-2 NUM_REQ

### DIFF
--- a/src/codegen/arbiter.rs
+++ b/src/codegen/arbiter.rs
@@ -274,7 +274,15 @@ impl<'a> Codegen<'a> {
         self.line(&format!("always_ff @({ff_sens}) begin"));
         self.indent += 1;
         self.line(&format!("if ({rst_cond}) rr_ptr_r <= '0;"));
-        self.line(&format!("else if ({grant_valid_sig}) rr_ptr_r <= rr_ptr_r + 1;"));
+        // Advance from the *actual grantee* (grant_requester), not from the scan
+        // start (rr_ptr_r). The scan may walk past non-asserting requesters, so
+        // grant_requester can be > rr_ptr_r; advancing rr_ptr_r alone would
+        // re-prioritize the just-granted slot. Explicit modulo at NUM_REQ keeps
+        // rr_ptr_r in [0, NUM_REQ) for non-power-of-2 NUM_REQ — otherwise the
+        // clog2-width register can hold values >= NUM_REQ and skew fairness.
+        self.line(&format!(
+            "else if ({grant_valid_sig}) rr_ptr_r <= ({grant_requester_sig} == {req_width}'({num_req} - 1)) ? '0 : {grant_requester_sig} + 1'b1;"
+        ));
         self.indent -= 1;
         self.line("end");
         self.line("");

--- a/tests/arbiter_rr_nonpow2/RRArb3.arch
+++ b/tests/arbiter_rr_nonpow2/RRArb3.arch
@@ -1,0 +1,28 @@
+// Round-robin arbiter with NUM_REQ = 3 — the canonical non-power-of-2 case.
+//
+// Used by the `test_arbiter_round_robin_sv_nonpow2_verilator_behavior`
+// integration test to verify the SV emitter advances the round-robin
+// pointer from the actual grantee (not the scan-start) and wraps
+// explicitly at NUM_REQ.
+//
+// Pre-fix, NUM_REQ=3 with all three requesters always asserting produced
+// the unfair grant pattern 0,1,2,0,0,1,2,0,... (idx 0 won 50% of cycles).
+// After the fix, the pattern is strict 0,1,2,0,1,2,... and each idx wins
+// exactly 1/3 of cycles.
+
+domain SysDomain
+  freq_mhz: 100
+end domain SysDomain
+
+arbiter RRArb3
+  policy round_robin;
+  param NUM_REQ: const = 3;
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  ports[NUM_REQ] request
+    valid: in Bool;
+    ready: out Bool;
+  end ports request
+  port grant_valid: out Bool;
+  port grant_requester: out UInt<2>;
+end arbiter RRArb3

--- a/tests/arbiter_rr_nonpow2/tb_rr_arb3.cpp
+++ b/tests/arbiter_rr_nonpow2/tb_rr_arb3.cpp
@@ -1,0 +1,79 @@
+// Verilator testbench for RRArb3 (round-robin, NUM_REQ=3).
+//
+// Drives all three requesters always-asserted and captures the
+// grant_requester sequence for 24 cycles. Expects strict round-robin
+// (each idx wins exactly 8/24 = 1/3 of cycles) — the documented
+// "fair distribution" guarantee for `policy round_robin`.
+//
+// Pre-fix (rr_ptr_r <= rr_ptr_r + 1, no explicit %): NUM_REQ=3 produced
+// the unfair sequence 0,1,2,0,0,1,2,0,... with idx 0 winning 50%.
+//
+// Prints "PASS rr_arb3" to stdout on success; non-zero exit on any
+// mismatch.
+
+#include "VRRArb3.h"
+#include <cstdio>
+#include <cstdlib>
+
+int main() {
+    VRRArb3 dut;
+
+    // Reset the design for a few cycles. Drive nothing during reset.
+    dut.clk = 0;
+    dut.rst = 1;
+    dut.request_valid = 0;
+    for (int i = 0; i < 4; i++) {
+        dut.clk = 0; dut.eval();
+        dut.clk = 1; dut.eval();
+    }
+
+    // Release reset; assert all three requesters every cycle.
+    dut.rst = 0;
+    dut.request_valid = 0b111;
+
+    // Capture 24 grant_requester values, one per posedge.
+    int grants[24];
+    for (int cyc = 0; cyc < 24; cyc++) {
+        dut.clk = 0; dut.eval();
+        dut.clk = 1; dut.eval();
+        if (!dut.grant_valid) {
+            fprintf(stdout, "FAIL: grant_valid de-asserted at cycle %d\n", cyc);
+            return 1;
+        }
+        grants[cyc] = (int)dut.grant_requester;
+    }
+
+    // Strict round-robin: the per-cycle sequence is (start + i) % 3 for
+    // some start in {0, 1, 2}. Determine start from cycle 0 and verify.
+    int start = grants[0];
+    if (start < 0 || start > 2) {
+        fprintf(stdout, "FAIL: invalid grant idx at cycle 0: %d\n", start);
+        return 1;
+    }
+    for (int i = 0; i < 24; i++) {
+        int expected = (start + i) % 3;
+        if (grants[i] != expected) {
+            fprintf(stdout,
+                "FAIL: cycle %d granted %d, expected %d (strict RR seq)\n",
+                i, grants[i], expected);
+            fprintf(stdout, "grant sequence: ");
+            for (int j = 0; j < 24; j++) fprintf(stdout, "%d ", grants[j]);
+            fprintf(stdout, "\n");
+            return 1;
+        }
+    }
+
+    // Each idx must win exactly 8 of 24 cycles. The pre-fix pattern is
+    // not strict RR (caught above) AND is unfair on counts — this check
+    // is redundant but documents intent.
+    int count[3] = {0, 0, 0};
+    for (int i = 0; i < 24; i++) count[grants[i]]++;
+    if (count[0] != 8 || count[1] != 8 || count[2] != 8) {
+        fprintf(stdout, "FAIL: unfair distribution: 0=%d 1=%d 2=%d\n",
+                count[0], count[1], count[2]);
+        return 1;
+    }
+
+    fprintf(stdout, "PASS rr_arb3 (strict round-robin, idx-fair)\n");
+    return 0;
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -608,6 +608,134 @@ end arbiter RRArb4
     );
 }
 
+/// Round-robin SV pointer-advance must wrap explicitly at NUM_REQ and
+/// advance from the actual grantee — not from the scan-start `rr_ptr_r`.
+/// Two prior bugs combined for non-power-of-2 NUM_REQ:
+///
+/// 1. `rr_ptr_r <= rr_ptr_r + 1` (no explicit `% NUM_REQ`). The
+///    `clog2(NUM_REQ)`-bit register could hold values >= NUM_REQ, e.g.
+///    `rr_ptr_r=3` with NUM_REQ=3 — the scan formula's explicit
+///    `% NUM_REQ` masked the comparison, so idx 0 won twice in a row
+///    whenever the pointer happened to land on 3.
+///
+/// 2. Advancing the scan-start, not the grantee. When the scan walked
+///    past non-asserting requesters, `grant_requester` could be > the
+///    starting `rr_ptr_r`; the next-cycle scan would then re-start
+///    earlier than the just-granted slot and re-prioritize it.
+///
+/// For NUM_REQ=3 with all reqs asserted: pre-fix grants the sequence
+/// `0,1,2,0,0,1,2,0,...` (idx 0 = 50%, idxs 1,2 = 25% each). After
+/// fix: strict `0,1,2,0,1,2,...` round-robin, idx-fair.
+///
+/// Power-of-2 NUM_REQ was unaffected — bit-width truncation
+/// coincidentally implemented the right thing.
+///
+/// See arch-hdl-lang/arch-com#451 (cycle-1 sim fix) and #447 §2.
+#[test]
+fn test_arbiter_round_robin_sv_advances_from_grantee_with_explicit_wrap() {
+    // NUM_REQ=3 is the canonical non-power-of-2 case that exposes both
+    // sub-bugs simultaneously.
+    let source = r#"
+domain SysDomain
+  freq_mhz: 100
+end domain SysDomain
+
+arbiter RRArb3
+  policy round_robin;
+  param NUM_REQ: const = 3;
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  ports[NUM_REQ] request
+    valid: in Bool;
+    ready: out Bool;
+  end ports request
+  port grant_valid: out Bool;
+  port grant_requester: out UInt<2>;
+end arbiter RRArb3
+"#;
+    let sv = compile_to_sv(source);
+    // Pointer advance must reference grant_requester (the actual grantee),
+    // not rr_ptr_r (the scan-start). With explicit wrap at NUM_REQ - 1.
+    assert!(
+        sv.contains("rr_ptr_r <= (grant_requester == 2'(3 - 1)) ? '0 : grant_requester + 1'b1;"),
+        "expected grantee-based pointer advance with explicit NUM_REQ wrap; got:\n{sv}"
+    );
+    // The pre-fix shape must be gone.
+    assert!(
+        !sv.contains("rr_ptr_r <= rr_ptr_r + 1;"),
+        "found pre-fix `rr_ptr_r <= rr_ptr_r + 1;` — the scan-start-based \
+         advance is incorrect for non-power-of-2 NUM_REQ:\n{sv}"
+    );
+}
+
+/// End-to-end Verilator test for the SV round-robin fairness fix.
+///
+/// Builds RRArb3 (NUM_REQ=3, the canonical non-power-of-2 case) to SV,
+/// runs it under Verilator with all three requesters always asserted,
+/// and checks that the grant_requester sequence is strict
+/// round-robin (each idx wins exactly 1/3 of cycles).
+///
+/// Pre-fix grant pattern was `0,1,2,0,0,1,2,0,...` (idx 0 at 50%).
+/// After fix: `0,1,2,0,1,2,...`, idx-fair.
+#[test]
+fn test_arbiter_round_robin_sv_nonpow2_verilator_behavior() {
+    if std::process::Command::new("verilator").arg("--version").output().is_err() {
+        eprintln!("skipping Verilator RR NUM_REQ=3 fairness smoke: verilator not found");
+        return;
+    }
+
+    let td = tempfile::tempdir().expect("tempdir");
+    let sv_out = td.path().join("RRArb3.sv");
+    let obj_dir = td.path().join("obj_dir");
+    let arch_bin = env!("CARGO_BIN_EXE_arch");
+
+    let build = std::process::Command::new(arch_bin)
+        .arg("build")
+        .arg("tests/arbiter_rr_nonpow2/RRArb3.arch")
+        .arg("-o")
+        .arg(&sv_out)
+        .output()
+        .expect("build RRArb3 SV");
+    assert!(build.status.success(),
+        "arch build should pass\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&build.stdout),
+        String::from_utf8_lossy(&build.stderr));
+
+    let verilate = std::process::Command::new("verilator")
+        .arg("--cc")
+        .arg("--exe")
+        .arg("--build")
+        .arg("--sv")
+        .arg("--assert")
+        .arg("-Wno-fatal")
+        .arg("-Wno-WIDTH")
+        .arg("-Wno-DECLFILENAME")
+        .arg("--top-module")
+        .arg("RRArb3")
+        .arg("-Mdir")
+        .arg(&obj_dir)
+        .arg(&sv_out)
+        .arg("tests/arbiter_rr_nonpow2/tb_rr_arb3.cpp")
+        .output()
+        .expect("verilate RRArb3");
+    assert!(verilate.status.success(),
+        "Verilator build should pass\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&verilate.stdout),
+        String::from_utf8_lossy(&verilate.stderr));
+
+    let exe = obj_dir.join("VRRArb3");
+    let run = std::process::Command::new(&exe)
+        .output()
+        .expect("run Verilator RRArb3");
+    assert!(run.status.success(),
+        "Verilator sim should pass\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr));
+    assert!(String::from_utf8_lossy(&run.stdout).contains("PASS rr_arb3"),
+        "expected PASS marker in Verilator stdout:\n{}",
+        String::from_utf8_lossy(&run.stdout));
+}
+
 #[test]
 fn test_arbiter_latency2() {
     let source = include_str!("../examples/arbiter_latency2.arch");
@@ -8024,7 +8152,12 @@ fn test_tlm_indexed_target_response_lock_uses_resource_policy() {
     let sv = compile_to_sv(source);
     assert!(sv.contains("module _arb_MemTarget_read_rsp"),
         "response lock should synthesize a policy arbiter module:\n{sv}");
-    assert!(sv.contains("rr_ptr_r <= rr_ptr_r + 1"),
+    // Round-robin pointer-advance shape inside the synthesized
+    // `_arb_MemTarget_read_rsp` arbiter module — uses the bare
+    // `grant_requester` port. The bare `rr_ptr_r + 1` form was incorrect
+    // for non-power-of-2 NUM_REQ.
+    assert!(sv.contains("rr_ptr_r <= (grant_requester ==")
+         && sv.contains("? '0 : grant_requester + 1'b1;"),
         "response arbiter should use the resource's round-robin policy:\n{sv}");
     assert!(sv.contains("_tlm_s_read_rsp_arb_req_packed[0] = !_tlm_s_read_rsp_arb_hold_valid_r && _tlm_s_read_tag0_rsp_valid")
          && sv.contains("_tlm_s_read_rsp_arb_req_packed[3] = !_tlm_s_read_rsp_arb_hold_valid_r && _tlm_s_read_tag3_rsp_valid"),
@@ -11159,8 +11292,12 @@ fn test_resource_lock_round_robin() {
     let sv = compile_to_sv(source);
     assert!(sv.contains("logic [0:0] rr_ptr_r;"),
         "round_robin should emit rr_ptr_r register:\n{sv}");
-    assert!(sv.contains("rr_ptr_r <= rr_ptr_r + 1"),
-        "round_robin should increment pointer on grant:\n{sv}");
+    // Pointer advances from the actual grantee (not the scan start) and wraps
+    // explicitly at NUM_REQ; the bare `rr_ptr_r + 1` form was incorrect for
+    // non-power-of-2 NUM_REQ. See `emit_arbiter_round_robin`.
+    assert!(sv.contains("rr_ptr_r <= (grant_requester ==")
+        && sv.contains("? '0 : grant_requester + 1'b1;"),
+        "round_robin should advance from grant_requester with explicit wrap:\n{sv}");
 }
 
 #[test]

--- a/tests/snapshots/integration_test__arbiter_latency2.snap
+++ b/tests/snapshots/integration_test__arbiter_latency2.snap
@@ -23,7 +23,7 @@ module LatencyArbiter #(
   
   always_ff @(posedge clk) begin
     if (rst) rr_ptr_r <= '0;
-    else if (grant_valid_comb) rr_ptr_r <= rr_ptr_r + 1;
+    else if (grant_valid_comb) rr_ptr_r <= (grant_requester_comb == 2'(4 - 1)) ? '0 : grant_requester_comb + 1'b1;
   end
   
   always_comb begin

--- a/tests/snapshots/integration_test__bus_arbiter.snap
+++ b/tests/snapshots/integration_test__bus_arbiter.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/integration_test.rs
-assertion_line: 473
 expression: sv
 ---
 module BusArbiter #(
@@ -20,7 +19,7 @@ module BusArbiter #(
   
   always_ff @(posedge clk) begin
     if (rst) rr_ptr_r <= '0;
-    else if (grant_valid) rr_ptr_r <= rr_ptr_r + 1;
+    else if (grant_valid) rr_ptr_r <= (grant_requester == 2'(4 - 1)) ? '0 : grant_requester + 1'b1;
   end
   
   always_comb begin


### PR DESCRIPTION
## Summary

The SV emitter for `arbiter ... policy round_robin` had two combined
bugs that broke the documented *fair distribution* guarantee whenever
`NUM_REQ` was not a power of 2. Power-of-2 NUM_REQ happened to work
because bit-width truncation coincidentally implemented `% NUM_REQ`.

For `NUM_REQ=3` with all three masters asserted, the **pre-fix** grant
sequence was `0,1,2,0,0,1,2,0,...` — idx 0 won **50%** of cycles, idxs
1 and 2 won **25%** each. **After** fix: strict `0,1,2,0,1,2,...`,
idx-fair (each slot exactly 1/3 of grants).

### The two sub-bugs

1. `rr_ptr_r <= rr_ptr_r + 1` had **no explicit `% NUM_REQ`**.
   `rr_ptr_r` is `clog2(NUM_REQ)` bits wide, so for non-pow2 NUM_REQ it
   could hold values `>= NUM_REQ`. The scan formula's explicit
   `% NUM_REQ` masked the comparison, but the *stored* value drifted
   (NUM_REQ=3, 2-bit ptr: 0→1→2→3→0→1→...) — `rr_ptr_r=3` started the
   scan at the same place as `rr_ptr_r=0`, letting idx 0 win two
   cycles in a row.

2. **Advanced the scan-start instead of the grantee.** After granting
   index G via a scan from `rr_ptr_r=P` (G may be > P because the scan
   walked past non-asserting requesters), `rr_ptr_r += 1` landed on
   `P+1` — not `G+1`. The next-cycle scan started *earlier* than the
   just-granted slot and re-prioritized it.

### Fix

Replace `rr_ptr_r <= rr_ptr_r + 1;` with a grantee-based ternary that
explicitly wraps at NUM_REQ:

```sv
else if (grant_valid) rr_ptr_r <= (grant_requester == REQ_W'(NUM_REQ - 1))
                                    ? '0
                                    : grant_requester + 1'b1;
```

This fixes both sub-bugs at once: the pointer advances from the actual
grantee (so the next-cycle scan starts *past* the granted slot, not at
the scan-start), and the explicit modulo keeps `rr_ptr_r` strictly in
`[0, NUM_REQ)`.

### Native sim unaffected

The native simulator (`src/sim_codegen/mod.rs`) was already correct for
non-pow2 N — it does `if (grant_valid) _last_grant = grant_requester;`
and scans `(_last_grant + 1 + i) % N`, so it naturally advanced from
the grantee and explicit-modulo'd. After #451 brought SV and sim into
agreement for power-of-2 N at cycle 1, this PR brings them into
agreement for non-pow2 N too. Native sim is **not** touched here.

## Snapshot updates

- `tests/snapshots/integration_test__arbiter_latency2.snap`
- `tests/snapshots/integration_test__bus_arbiter.snap`

Both have the exact single-line replacement of the old
`rr_ptr_r <= rr_ptr_r + 1;` with the new ternary. Both fixtures use
`NUM_REQ=4` (power-of-2), so the *observable* SV behaviour is
unchanged — only the textual form differs. Eyeballed the diffs.

Two pre-existing substring assertions also needed updating:
- `test_resource_lock_round_robin`
- `test_tlm_indexed_target_response_lock_uses_resource_policy`

Both were checking for the literal string `rr_ptr_r <= rr_ptr_r + 1`
and have been updated to match the new pointer-advance shape.

## New tests

- `test_arbiter_round_robin_sv_advances_from_grantee_with_explicit_wrap`
  — compile-to-SV substring check for `NUM_REQ=3`. Pins the exact
  emitted form `(grant_requester == 2'(3 - 1)) ? '0 :
  grant_requester + 1'b1` and asserts the pre-fix shape is gone.
- `test_arbiter_round_robin_sv_nonpow2_verilator_behavior`
  — end-to-end Verilator behavioural test. Builds
  `tests/arbiter_rr_nonpow2/RRArb3.arch` (NUM_REQ=3) to SV, runs under
  Verilator with all three masters always-asserted for 24 cycles,
  verifies the grant sequence is strict round-robin `(start+i)%3` and
  the per-idx counts are exactly 8/8/8.

## Refs

- #451 — cycle-1 sim fix (made this gap between SV and sim visible)
- #447 §2 — original surfacing of the SV/sim divergence

## Test plan

- [x] `cargo test --release` — 492 integration + 24 + 20 unit tests, all green
- [x] New Verilator behavioural test passes locally (`Verilator 5.048`)
- [x] Snapshot diffs eyeballed: exactly the expected one-line replacement