### PR TITLE
test: add expect_verilator_fatal harness for "should-fatal" assertion coverage

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,134 @@
+//! Shared helpers for arch-com integration tests.
+//!
+//! Lives under `tests/common/` (not `tests/common.rs`) so cargo doesn't
+//! treat it as an integration test target — a bare `tests/common.rs`
+//! would be compiled and run as its own test binary with zero tests.
+//! Modules under a subdirectory are only built when imported via
+//! `mod common;` from a sibling integration test file.
+
+/// Build an .arch source through `arch build`, verilate the resulting
+/// SV with `--assert`, run the simulation, and assert that it aborts
+/// with a non-zero exit *and* that `expected_substr` appears somewhere
+/// in the run's combined stdout + stderr.
+///
+/// This is the inverse of the success-path pattern used by
+/// `test_axi_dma_tlm_indexed_burst_target_verilator_behavior` and
+/// friends in `tests/integration_test.rs`: same build / verilate
+/// plumbing, but the final assertions are flipped to catch a fatal
+/// instead of a PASS marker.
+///
+/// `expected_substr` should name the *specific* SVA label that is
+/// expected to trip (e.g. `"BOUNDS VIOLATION: Probe._auto_bound_vec_0"`
+/// or `"ASSERTION FAILED: ar_burst_supported"`) so that a rename
+/// regresses the test loudly rather than silently passing on some
+/// unrelated fatal.
+///
+/// If `verilator --version` fails we print a skip message and return,
+/// matching the convention of the rest of the suite.
+///
+/// All inputs are paths relative to the crate root.
+pub fn expect_verilator_fatal(
+    arch_src_path: &str,
+    tb_cpp_path: &str,
+    top_module: &str,
+    expected_substr: &str,
+) {
+    expect_verilator_fatal_multi(&[arch_src_path], tb_cpp_path, top_module, expected_substr);
+}
+
+/// Variant of [`expect_verilator_fatal`] that accepts multiple `.arch`
+/// sources — required for designs whose top module references a bus or
+/// helper construct defined in a sibling file (e.g. `BusAxi4.arch` for
+/// `Nic400WidthAdapter.arch`). The first entry is treated as the top
+/// design; the rest are dependencies passed to `arch build` on the same
+/// command line so the type checker can resolve cross-file references
+/// without relying on pre-existing `.archi` artifacts (which are
+/// gitignored).
+pub fn expect_verilator_fatal_multi(
+    arch_src_paths: &[&str],
+    tb_cpp_path: &str,
+    top_module: &str,
+    expected_substr: &str,
+) {
+    assert!(
+        !arch_src_paths.is_empty(),
+        "expect_verilator_fatal_multi requires at least one .arch source"
+    );
+    if std::process::Command::new("verilator")
+        .arg("--version")
+        .output()
+        .is_err()
+    {
+        eprintln!(
+            "skipping expect_verilator_fatal({top_module}, {expected_substr:?}): \
+             verilator not found"
+        );
+        return;
+    }
+
+    let td = tempfile::tempdir().expect("tempdir");
+    let sv_out = td.path().join(format!("{top_module}.sv"));
+    let obj_dir = td.path().join("obj_dir");
+    let arch_bin = env!("CARGO_BIN_EXE_arch");
+
+    let mut build_cmd = std::process::Command::new(arch_bin);
+    build_cmd.arg("build");
+    for src in arch_src_paths {
+        build_cmd.arg(src);
+    }
+    build_cmd.arg("-o").arg(&sv_out);
+    let build = build_cmd.output().expect("invoke arch build");
+    assert!(
+        build.status.success(),
+        "arch build should succeed for {arch_src_paths:?}\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&build.stdout),
+        String::from_utf8_lossy(&build.stderr)
+    );
+
+    let verilate = std::process::Command::new("verilator")
+        .arg("--cc")
+        .arg("--exe")
+        .arg("--build")
+        .arg("--sv")
+        .arg("--assert")
+        .arg("-Wno-fatal")
+        .arg("-Wno-WIDTH")
+        .arg("-Wno-DECLFILENAME")
+        .arg("--top-module")
+        .arg(top_module)
+        .arg("-Mdir")
+        .arg(&obj_dir)
+        .arg(&sv_out)
+        .arg(tb_cpp_path)
+        .output()
+        .expect("invoke verilator");
+    assert!(
+        verilate.status.success(),
+        "verilator build should succeed for {top_module}\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&verilate.stdout),
+        String::from_utf8_lossy(&verilate.stderr)
+    );
+
+    let exe = obj_dir.join(format!("V{top_module}"));
+    let run = std::process::Command::new(&exe)
+        .output()
+        .unwrap_or_else(|e| panic!("invoke V{top_module}: {e}"));
+
+    // Verilator may route `$fatal` to either stdout or stderr depending
+    // on version + build flags, so concatenate before searching.
+    let stdout = String::from_utf8_lossy(&run.stdout);
+    let stderr = String::from_utf8_lossy(&run.stderr);
+    let combined = format!("{stdout}{stderr}");
+
+    assert!(
+        !run.status.success(),
+        "V{top_module} was expected to ABORT (non-zero exit) but exited with success.\n\
+         Looking for substring: {expected_substr:?}\n\
+         stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        combined.contains(expected_substr),
+        "V{top_module} aborted as expected, but the fatal message did not contain \
+         {expected_substr:?}.\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+}

--- a/tests/expect_fatal_smoke/Probe.arch
+++ b/tests/expect_fatal_smoke/Probe.arch
@@ -1,0 +1,27 @@
+// Minimal fixture for the `expect_verilator_fatal` harness self-test.
+//
+// `vec[idx] <= d` lives inside a `seq` block, so the codegen auto-emits
+// a concurrent SVA bounds assertion `_auto_bound_vec_0`. The Vec holds
+// 4 elements, but `idx: UInt<3>` permits values 0..7 — so driving
+// `idx == 5` (or any value >= 4) for at least one rising edge after
+// reset will trip `$fatal(1, "BOUNDS VIOLATION: Probe._auto_bound_vec_0")`
+// under Verilator `--assert`.
+domain SysDomain
+  freq_mhz: 100
+end domain SysDomain
+
+module Probe
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port we:  in Bool;
+  port idx: in UInt<3>;
+  port d:   in UInt<8>;
+
+  reg vec: Vec<UInt<8>, 4> reset rst => 8'd0;
+
+  seq on clk rising
+    if we
+      vec[idx] <= d;
+    end if
+  end seq
+end module Probe

--- a/tests/expect_fatal_smoke/tb.cpp
+++ b/tests/expect_fatal_smoke/tb.cpp
@@ -1,0 +1,52 @@
+// Testbench for the `expect_verilator_fatal` harness self-test.
+//
+// We hold the design in reset for a few cycles, deassert reset, then
+// drive `we=1, idx=5` for one rising edge. `idx == 5` is out of bounds
+// for `Vec<UInt<8>, 4>` and the codegen-emitted SVA
+// `_auto_bound_vec_0` must trip on that edge — Verilator `--assert`
+// turns the failure into `$fatal(1, "BOUNDS VIOLATION: ...")`, which
+// terminates the simulation with a non-zero exit status.
+//
+// The harness asserts on (a) non-zero exit AND (b) the substring
+// "BOUNDS VIOLATION" appearing in the combined stdout+stderr.
+
+#include "VProbe.h"
+
+#include <cstdio>
+#include <cstdlib>
+
+static VProbe dut;
+
+static void tick() {
+    dut.clk = 0;
+    dut.eval();
+    dut.clk = 1;
+    dut.eval();
+}
+
+int main() {
+    // Hold reset.
+    dut.rst = 1;
+    dut.we  = 0;
+    dut.idx = 0;
+    dut.d   = 0;
+    for (int i = 0; i < 4; ++i) {
+        tick();
+    }
+    dut.rst = 0;
+    tick();
+
+    // Now drive an out-of-bounds index. The SVA fires on the next
+    // rising edge while `we && rst` are not both gating it out, so
+    // the simulation aborts before reaching the print below.
+    dut.we  = 1;
+    dut.idx = 5;
+    dut.d   = 0xAB;
+    tick();
+
+    // Defensive — if we reach here the SVA didn't fire and the
+    // harness should treat the run as a failure (zero exit, no
+    // "BOUNDS VIOLATION" substring).
+    std::printf("FAIL: simulation did not abort on out-of-bounds Vec write\n");
+    return 0;
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -5,6 +5,8 @@ use arch::parser::Parser;
 use arch::resolve;
 use arch::typecheck::TypeChecker;
 
+mod common;
+
 fn compile_to_sv(source: &str) -> String {
     compile_to_sv_with_opts(source, &elaborate::ThreadLowerOpts::default())
 }
@@ -17249,5 +17251,23 @@ fn test_native_sim_vec_inst_input_wire_param_sized_fanout() {
         String::from_utf8_lossy(&out.stdout).contains("PASS native Vec inst input wire"),
         "expected PASS marker in stdout:\n{}",
         String::from_utf8_lossy(&out.stdout)
+    );
+}
+
+#[test]
+fn test_expect_fatal_harness_catches_bounds_violation() {
+    // Smoke test for the `expect_verilator_fatal` helper in
+    // `tests/common/mod.rs`. The Probe.arch fixture writes to a
+    // `Vec<UInt<8>, 4>` from a 3-bit input index — values 4..7 are
+    // out of bounds, so the codegen-emitted SVA `_auto_bound_vec_0`
+    // must trip under Verilator `--assert`. We pin the substring to
+    // the specific label so a future rename / regression of the
+    // bounds-emission code regresses this test loudly rather than
+    // silently passing on some unrelated fatal.
+    common::expect_verilator_fatal(
+        "tests/expect_fatal_smoke/Probe.arch",
+        "tests/expect_fatal_smoke/tb.cpp",
+        "Probe",
+        "BOUNDS VIOLATION: Probe._auto_bound_vec_0",
     );
 }


### PR DESCRIPTION
## Summary

- Add `tests/common/mod.rs::expect_verilator_fatal(arch_src, tb_cpp, top, expected_substr)` — the inverse-of-PASS-marker counterpart to the success-path Verilator smoke tests already in `tests/integration_test.rs`. Builds the `.arch` through `arch build`, verilates with `--assert`, runs the sim, and asserts the run aborted (non-zero exit) AND that the caller-supplied substring appears in the combined stdout+stderr (Verilator's `$fatal` routing varies across versions / build flags, so both streams are concatenated before searching).
- Add a sibling `expect_verilator_fatal_multi(&[arch_srcs], tb_cpp, top, expected_substr)` — same shape, but accepts multiple `.arch` sources on the `arch build` command line. Required for designs whose top module references a bus or helper construct defined in a sibling file (e.g. `BusAxi4.arch` for `Nic400WidthAdapter.arch`); the per-build `.archi` interface artifacts are gitignored so a single-source build can't resolve cross-file references on a fresh checkout. `expect_verilator_fatal` is a thin forwarder over the multi-source variant.
- Add a self-test using the auto-emitted Vec bounds SVA: `tests/expect_fatal_smoke/Probe.arch` writes to a `Vec<UInt<8>, 4>` from a 3-bit input index — values 4..7 are out of bounds, so `_auto_bound_vec_0` must trip under `--assert`. `test_expect_fatal_harness_catches_bounds_violation` calls the harness with `expected_substr = "BOUNDS VIOLATION: Probe._auto_bound_vec_0"`.

## Motivation

arch-com auto-emits a growing set of SVA properties — bounds, divide-by-zero, handshake protocol, thread spec contracts, bus protocol checks — but currently has zero CI coverage that any of them actually *fire* under Verilator when violated. Every existing Verilator test checks for a PASS marker, so an SVA that silently stops emitting wouldn't regress anything.

The harness pins on the *specific* assertion label (e.g. `_auto_bound_vec_0`) rather than a generic substring, so a rename / reorder of the SVA emission regresses the test loudly rather than silently passing on some unrelated fatal.

## Why PR A / PR B split

PR B (arch-com#454) uses this harness to land `test_nic400_width_adapter_fixed_burst_is_rejected_by_sva`, deferred from arch-com#450. Landing the harness on its own keeps PR B reviewable as "here is exactly the SVA fire we want to assert" rather than mixing infrastructure with the regression target.

The `_multi` variant was discovered while writing PR B's first real consumer (Nic400WidthAdapter pulls in BusAxi4) and was backported here so PR B can stay pure-consumer.

## Test plan

- [x] `cargo build --release` clean
- [x] `cargo test --release --test integration_test test_expect_fatal_harness` passes
- [x] Full `cargo test --release --test integration_test` — 491 passed, 0 failed
- [x] `cargo clippy --release --tests --no-deps` — no new diagnostics (count identical to `origin/main`)
- [x] Skip path verified by code inspection: `verilator --version` failure returns early with an `eprintln!`, mirroring existing convention