### PR TITLE
test(nic400): CI coverage for WidthAdapter FIXED-burst SVA fire

### DIFF
--- a/doc/nic400_interconnect_spec.md
+++ b/doc/nic400_interconnect_spec.md
@@ -1013,6 +1013,13 @@ Backpressure: when a master fills its `aw_route_fifo`, the `AwDecode` thread sta
 
 ### 15.1 Manual repro — `Nic400WidthAdapter` FIXED-burst SVA fire
 
+> Automated CI now covers this case via the Rust test
+> `test_nic400_width_adapter_fixed_burst_is_rejected_by_sva` in
+> `tests/integration_test.rs` (consumes the `expect_verilator_fatal`
+> harness from PR #453; standalone TB at
+> `tests/nic400/tb_nic400_width_adapter_fixed_reject.cpp`). The manual
+> recipe below is retained for ad-hoc investigation.
+
 `Nic400WidthAdapter.arch` carries two concurrent SVAs (PR #441) that reject
 the unsupported FIXED-burst encoding on a wide master AR/AW handshake:
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -17271,3 +17271,33 @@ fn test_expect_fatal_harness_catches_bounds_violation() {
         "BOUNDS VIOLATION: Probe._auto_bound_vec_0",
     );
 }
+
+/// Verifies the concurrent SVA at Nic400WidthAdapter.arch:299-300
+/// (`ar_burst_supported`) actually fires under Verilator `--assert`
+/// when a FIXED-burst AR handshake reaches the adapter's wide master
+/// port. Consumes the `expect_verilator_fatal_multi` harness landed
+/// in arch-com#453 (multi-source variant — the WidthAdapter depends
+/// on `BusAxi4.arch`, which arch build resolves on the same command
+/// line because `.archi` artifacts are gitignored).
+///
+/// Surfaced as the missing CI coverage in arch-com#447 §4 follow-up
+/// to arch-com#441 (which added the SVAs) and arch-com#450 (which
+/// shipped only a manual repro because no expect-fatal harness
+/// existed yet).
+#[test]
+fn test_nic400_width_adapter_fixed_burst_is_rejected_by_sva() {
+    common::expect_verilator_fatal_multi(
+        &[
+            "tests/nic400/Nic400WidthAdapter.arch",
+            "tests/nic400/BusAxi4.arch",
+        ],
+        "tests/nic400/tb_nic400_width_adapter_fixed_reject.cpp",
+        "Nic400WidthAdapter",
+        // Matches the $fatal string emitted by `assert ar_burst_supported:`
+        // at Nic400WidthAdapter.arch:299. Verifying the exact SV codegen
+        // shape ("ar_burst_supported: assert property (...) else $fatal(1,
+        // \"ASSERTION FAILED: Nic400WidthAdapter.ar_burst_supported\")")
+        // means a rename or codegen regression trips this test loudly.
+        "ASSERTION FAILED: Nic400WidthAdapter.ar_burst_supported",
+    );
+}

--- a/tests/nic400/tb_nic400_width_adapter.cpp
+++ b/tests/nic400/tb_nic400_width_adapter.cpp
@@ -532,56 +532,15 @@ static int test_wrap4_read() {
     return 0;
 }
 
-// ── Scenario 8 (manual repro): FIXED-burst AR must trip the
-// `ar_burst_supported` concurrent SVA.
-//
-// PR #441 added these two SVAs to the module:
-//   assert ar_burst_supported: (m.ar_valid and m.ar_ready) |-> (m.ar_burst == 1 or m.ar_burst == 2);
-//   assert aw_burst_supported: (m.aw_valid and m.aw_ready) |-> (m.aw_burst == 1 or m.aw_burst == 2);
-//
-// A concurrent SVA that no harness exercises is effectively dead — the only
-// way to keep it honest is to drive an illegal handshake and watch
-// Verilator's `--assert` actually fatal.
-//
-// This is left as a *manual repro* (not wired into main()) because the
-// arch-com test harness currently has no infrastructure to assert that a
-// simulation aborts with a specific message — every existing TB exits 0 on
-// success. Introducing a one-off "expected-fatal" harness for a single SVA
-// would be more weight than the assertion warrants. Maintainer recipe:
-//
-//   1. Add `if (test_fixed_burst_rejected()) return 1;` to main() AND
-//      flip the body's `return 0;` to `return 0;` (the test is already
-//      structured to just drive the handshake — Verilator fatals from the
-//      SVA before the TB sees control again).
-//   2. Rebuild and run; expect Verilator to print
-//
-//        %Error: ASSERTION FAILED: Nic400WidthAdapter._auto_..._ar_burst_supported
-//
-//      and exit non-zero. (See doc/nic400_interconnect_spec.md §17.x for
-//      the canonical invocation.)
-//
-// Without `--assert` on the Verilator command line the SVA is compiled but
-// not evaluated; the body below would then proceed quietly. This is the
-// other reason the scenario stays opt-in — adding it to the default run
-// silently passes on builds that don't enable assertion evaluation.
-#if 0
-static int test_fixed_burst_rejected() {
-    // Drive an AR with burst=FIXED (0). The adapter handshakes ar_valid &&
-    // ar_ready unconditionally in its AR thread, so the concurrent SVA
-    // fires on the very first matching posedge.
-    const uint32_t addr = 0xF000;
-    dut.m_ar_valid = 1; dut.m_ar_addr = addr; dut.m_ar_id = 0; dut.m_ar_len = 3;
-    dut.m_ar_size = 3;  dut.m_ar_burst = 0;   // FIXED — must be rejected
-    dut.s_ar_ready = 1;
-
-    // One handshake cycle is enough for the SVA to evaluate. If Verilator
-    // was built with `--assert`, this never returns — $fatal aborts the sim.
-    for (int i = 0; i < 8; ++i) { pre_edge(); post_edge(); }
-
-    // Reaching this point means the SVA did NOT fire — that's a regression.
-    return fail("s8: FIXED-burst SVA did not fatal (was Verilator built with --assert?)");
-}
-#endif
+// FIXED-burst rejection (ar_burst_supported / aw_burst_supported, PR #441)
+// is exercised by a standalone TB with its own `main` whose exit-code
+// semantics are "must abort" — see
+// `tests/nic400/tb_nic400_width_adapter_fixed_reject.cpp` and the Rust
+// test `test_nic400_width_adapter_fixed_burst_is_rejected_by_sva` in
+// `tests/integration_test.rs` (consumes the `expect_verilator_fatal`
+// harness from PR #453). The manual repro recipe in
+// `doc/nic400_interconnect_spec.md` §15.1 is still useful for ad-hoc
+// investigation.
 
 int main() {
     dut.rst = 0;

--- a/tests/nic400/tb_nic400_width_adapter_fixed_reject.cpp
+++ b/tests/nic400/tb_nic400_width_adapter_fixed_reject.cpp
@@ -1,0 +1,92 @@
+// FIXED-burst rejection TB for Nic400WidthAdapter.
+//
+// Nic400WidthAdapter.arch:299-300 carries two concurrent SVAs:
+//   ar_burst_supported: (m.ar_valid && m.ar_ready) |-> (m.ar_burst == 1 || m.ar_burst == 2)
+//   aw_burst_supported: (m.aw_valid && m.aw_ready) |-> (m.aw_burst == 1 || m.aw_burst == 2)
+//
+// They reject FIXED (`burst == 0`) and the reserved code (`burst == 3`).
+// Under Verilator `--assert` a violation surfaces as
+//   %Error: ASSERTION FAILED: Nic400WidthAdapter.ar_burst_supported
+// followed by `$fatal(1, ...)` and a non-zero exit. The
+// `expect_verilator_fatal` harness in `tests/common/mod.rs` matches on
+// the SVA label substring to keep the test pinned to the *specific*
+// assertion rather than any unrelated fatal.
+//
+// This TB is the auto-CI counterpart to the manual repro recipe in
+// `doc/nic400_interconnect_spec.md` §15.1 — kept as a standalone
+// binary (own `main`) so its exit-code semantics (must abort) stay
+// orthogonal to the regular `tb_nic400_width_adapter.cpp` which exits
+// 0 on success.
+//
+// Reset polarity is `Reset<Async, Low>` (Nic400WidthAdapter.arch:60),
+// so the design is OUT of reset when `rst == 1` and held in reset
+// when `rst == 0`.
+
+#include "VNic400WidthAdapter.h"
+
+#include <cstdint>
+#include <cstdio>
+
+static VNic400WidthAdapter dut;
+
+static void tick() {
+    dut.clk = 0;
+    dut.eval();
+    dut.clk = 1;
+    dut.eval();
+}
+
+static void clear_inputs() {
+    // Master side (TB drives master-style requests INTO the adapter).
+    dut.m_ar_valid = 0; dut.m_ar_addr = 0; dut.m_ar_id = 0; dut.m_ar_len = 0;
+    dut.m_ar_size = 0;  dut.m_ar_burst = 0; dut.m_ar_lock = 0;
+    dut.m_ar_cache = 0; dut.m_ar_prot = 0;  dut.m_ar_qos = 0; dut.m_ar_region = 0;
+    dut.m_r_ready = 0;
+    dut.m_aw_valid = 0; dut.m_aw_addr = 0; dut.m_aw_id = 0; dut.m_aw_len = 0;
+    dut.m_aw_size = 0;  dut.m_aw_burst = 0; dut.m_aw_lock = 0;
+    dut.m_aw_cache = 0; dut.m_aw_prot = 0;  dut.m_aw_qos = 0; dut.m_aw_region = 0;
+    dut.m_w_valid = 0; dut.m_w_data = 0; dut.m_w_strb = 0; dut.m_w_last = 0;
+    dut.m_b_ready = 0;
+    // Slave side (TB plays the downstream slave).
+    dut.s_ar_ready = 0;
+    dut.s_r_valid = 0; dut.s_r_data = 0; dut.s_r_id = 0; dut.s_r_resp = 0; dut.s_r_last = 0;
+    dut.s_aw_ready = 0;
+    dut.s_w_ready = 0;
+    dut.s_b_valid = 0; dut.s_b_id = 0; dut.s_b_resp = 0;
+}
+
+int main() {
+    // Active-low async reset: drive rst=0 to hold, rst=1 to release.
+    dut.rst = 0;
+    clear_inputs();
+    for (int i = 0; i < 4; ++i) tick();
+    dut.rst = 1;
+    for (int i = 0; i < 3; ++i) tick();
+
+    // Drive an AR handshake with burst=FIXED (00). The adapter's AR
+    // thread waits for `m.ar_valid`, then drives `s.ar_valid = true`
+    // and `m.ar_ready = s.ar_ready`. Holding `s_ar_ready=1` closes the
+    // master-side handshake unconditionally, regardless of burst code,
+    // so the concurrent SVA fires on the very next rising edge.
+    dut.m_ar_valid = 1;
+    dut.m_ar_addr  = 0xF000;
+    dut.m_ar_id    = 0;
+    dut.m_ar_len   = 3;
+    dut.m_ar_size  = 3;
+    dut.m_ar_burst = 0;   // FIXED — must be rejected by ar_burst_supported.
+    dut.s_ar_ready = 1;
+
+    // A handful of cycles is more than enough for the SVA to evaluate.
+    // If Verilator was built with `--assert`, this loop never completes
+    // — `$fatal(1, "ASSERTION FAILED: Nic400WidthAdapter.ar_burst_supported")`
+    // aborts the sim first.
+    for (int i = 0; i < 8; ++i) tick();
+
+    // Reaching this point means the SVA did NOT fire. Print a
+    // distinctive marker so the harness's `expected_substr` check has
+    // something to *not* match — and return 0 so the harness's
+    // `non-zero exit` assertion catches the regression loudly.
+    std::printf("FAIL: FIXED-burst SVA ar_burst_supported did not fatal "
+                "(was Verilator built with --assert?)\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary

PR B of a 2-PR sequence. Converts the `#if 0`-gated
`test_fixed_burst_rejected` scenario shipped in #450 into an automated
Rust integration test backed by the `expect_verilator_fatal_multi`
harness from #453 (PR A).

- New standalone TB `tests/nic400/tb_nic400_width_adapter_fixed_reject.cpp`
  (92 lines) with its own `main` whose exit-code semantics are
  *must abort*. Drives one AR handshake with `m_ar_burst = 0` (FIXED)
  and ticks the clock; Verilator `--assert` resolves
  `assert ar_burst_supported:` (Nic400WidthAdapter.arch:299) into
  `$fatal(1, "ASSERTION FAILED: Nic400WidthAdapter.ar_burst_supported")`
  on the next rising edge.
- New Rust test `test_nic400_width_adapter_fixed_burst_is_rejected_by_sva`
  in `tests/integration_test.rs`, pinned to the exact SVA-label substring
  so a codegen rename regresses the test loudly. Calls
  `expect_verilator_fatal_multi(&["tests/nic400/Nic400WidthAdapter.arch", "stdlib/BusAxi4.arch"], ...)`
  — Nic400WidthAdapter pulls in BusAxi4, and per-build `.archi` artifacts
  are gitignored, so the multi-source variant is required.
- Removed the `#if 0` block from `tb_nic400_width_adapter.cpp` (608 → 568
  lines) and replaced it with a pointer comment to the new TB + Rust
  test. Manual repro recipe in `doc/nic400_interconnect_spec.md` §15.1
  is retained (still useful for ad-hoc work) but now opens with a note
  that automated CI covers the case.

This PR is now a pure consumer of the harness — the `_multi` helper
itself was backported into PR A (#453) so the API surface lives in
one place.

References:
- #441 added the two `ar_burst_supported` / `aw_burst_supported`
  concurrent SVAs.
- #450 shipped the manual recipe + `#if 0` scenario, gated on the
  absence of an expect-fatal harness.
- #453 (PR A) built `expect_verilator_fatal` + `expect_verilator_fatal_multi` — this PR consumes them.
- #447 §4 surfaced the coverage gap originally.

This PR is targeted at PR A's branch (`claude/tests-expect-fatal-harness`)
so the diff is clean. Retarget to `main` once PR A merges.

## Test plan

- [x] `cargo build --release` clean.
- [x] `cargo test --release --test integration_test test_nic400_width_adapter_fixed_burst_is_rejected_by_sva` passes (the fatal substring matches Verilator's `[0] %Fatal: ... ASSERTION FAILED: Nic400WidthAdapter.ar_burst_supported`).
- [x] `cargo test --release --test integration_test` — 492/492 ok, no regressions.
- [x] Default `tb_nic400_width_adapter.cpp` still ships 7/7 PASS under Verilator without `--assert` (sanity-checked the `#if 0` removal didn't break the happy path).