### PR TITLE
docs(thread): refresh lowering algorithm for v0.46.0 policy menu

### DIFF
--- a/doc/thread_lowering_algorithm.md
+++ b/doc/thread_lowering_algorithm.md
@@ -481,38 +481,93 @@ end
 
 ### Arbiter structure
 
-For each resource the compiler generates a **fixed-priority combinational arbiter**:
+Each resource lowers to a synthesized `arbiter` Item named `_arb_<Mod>_<res>`,
+instantiated inside the merged threads module (v0.46.0+).  The arbiter's policy
+is taken from the resource declaration; every policy supported by the standalone
+`arbiter` construct is available to `lock`-block arbitration without duplicate
+codegen.  Per-thread request signals are packed into `request_valid[N]`; the
+arbiter drives `request_ready[N]`, which is unpacked back into per-thread
+`grant[i]` wires consumed by the lock-entry stall logic.
 
-```
-grant[0] = req[0]
-grant[1] = req[1] && !grant[0]
-grant[i] = req[i] && !grant[0] && … && !grant[i-1]
-```
+Supported policies and their grant equations (N requesters, indices 0..N-1):
 
-Thread index 0 has the highest priority.  The arbiter is purely combinational —
-it resolves in the same cycle with no flops of its own.
+| Policy | Grant rule | State |
+|---|---|---|
+| `priority` *(default)* | lowest-indexed asserted requester wins | none |
+| `round_robin` | scan from `(rr_ptr + i) mod N`, grant first asserted; on grant, `rr_ptr <= (grantee + 1) mod N` | `rr_ptr` |
+| `lru` | scan from least-recently-granted | per-requester recency vector |
+| `weighted<W>` | each thread gets a credit count `W`; deplete-and-refill | per-requester credit reg |
+| custom (`hook grant_select(...)`) | user function returns one-hot grant mask | hook-defined |
 
-### Deadlock freedom (proof)
+For the priority policy, the arbiter is purely combinational — it resolves in
+the same cycle with no flops of its own.  The other policies carry the state
+listed in the third column, updated once per posedge under the grant condition.
 
-**Definition**: thread Ti *waits-for* Tj when Ti is blocked at lock body state 0
-(`grant_i && cond` is false) and Tj has `req_j = 1` with `j < i`, causing
-`grant_i = 0`.
+### Liveness per policy
 
-**Claim**: the waits-for relation is acyclic, so no deadlock can form.
+**Definition.** Thread Ti *waits-for* Tj when Ti is blocked at lock body
+state 0 (its `grant_i && cond` is false) and Tj currently holds the resource
+(`grant_j = 1`).
 
-**Proof**: from the arbiter equations, `grant[i] = 0` only when some `grant[j]`
-with `j < i` is 1.  Therefore:
+**Priority** *(default)*.  `grant[i] = 0` only when some `grant[j]` with
+`j < i` is 1, so every waits-for edge points from a higher-indexed thread to a
+lower-indexed one:
 
 > Ti waits-for Tj  ⟹  index(Tj) < index(Ti)
 
-All waits-for edges point from higher-indexed threads toward lower-indexed ones.
-A cycle would require some thread to appear on both ends of the edge ordering —
-its index would need to be both strictly less than and strictly greater than
-itself, which is impossible.  No cycle ⟹ no deadlock. ∎
+The waits-for relation is acyclic (any cycle would need a thread index strictly
+less than and strictly greater than itself), so no deadlock can form.
+Corollary: thread 0 always makes progress, which unblocks thread 1, etc. — the
+system is **starvation-free** for all threads as long as every thread's lock
+body eventually terminates.
 
-Corollary: thread 0 always makes progress (no thread can block it), which
-unblocks thread 1, which unblocks thread 2, etc. — the system is **starvation-free**
-for all threads as long as every thread's lock body eventually terminates.
+Note: the safety argument here makes thread 0 unconditionally win contention
+with thread N-1.  Designs whose access patterns rely on fairness should declare
+`mutex<round_robin>` or `mutex<lru>` instead of accepting the default
+`mutex<priority>`.
+
+**Round-robin and LRU.**  Both policies grant the highest-priority asserted
+requester *under a rotating priority order* — round_robin advances by 1 after
+every grant; LRU advances to whichever requester was least recently served.
+The safety argument is the same shape per cycle: the policy picks a single
+winner from the asserted set, so mutual exclusion holds and the
+just-not-granted threads remain stalled at lock entry.  Liveness is stronger
+than priority: as long as every lock body terminates in bounded time, every
+asserted requester is granted within at most N grant-events of asserting.
+Acyclicity of the waits-for relation is no longer per-cycle (the priority
+order itself rotates), but the grant-counter argument still rules out
+deadlock cycles.
+
+**Weighted.**  Each requester carries a credit count.  A requester is eligible
+only while its credit is non-zero; once all eligible requesters' credits are
+exhausted, credits refill.  Mutual exclusion is identical; liveness depends on
+the requester actually carrying enough credit to make forward progress, which
+is the user's responsibility when choosing the weight.
+
+**Custom (`hook grant_select`).**  The grant function is opaque to the
+compiler — the synthesized arbiter trusts whatever one-hot mask the hook
+returns.  Mutual exclusion still holds (the arbiter enforces one-hot regardless
+of what the hook says), but liveness is **only as good as the hook**.  A hook
+that returns the all-zeros mask while requests are asserted creates an
+arbiter-side deadlock; a hook that consistently picks the same thread starves
+others.  Custom-policy users carry the liveness obligation.
+
+### Simulation-vs-build divergence — `--thread-sim` policy downgrade
+
+`arch sim --thread-sim` runs the parallel thread scheduler (`src/sim_codegen/thread_sim.rs`)
+instead of the FSM-lowered codegen.  As of v0.51.0, that scheduler accepts
+`RoundRobin` and `Lru` policies (it previously rejected them) but its internal
+"free or already mine" gating resolves contention as lowest-thread-index-wins,
+which is observationally identical to `priority`.  Until the scheduler honours
+the requested policy:
+
+- Tests that compare `arch sim` (FSM-lowered) against
+  `arch sim --thread-sim both` on a design using `mutex<round_robin>` or
+  `mutex<lru>` may surface as false-PASS — the FSM-lowered path observes the
+  declared policy, the `--thread-sim` path observes priority order.
+- Verilator and the default arch sim path are unaffected.
+
+This is tracked in [arch-com#447](https://github.com/arch-hdl-lang/arch-com/pull/447) §3.
 
 ### Mutual exclusion
 

--- a/doc/thread_spec_section.md
+++ b/doc/thread_spec_section.md
@@ -6,6 +6,8 @@ A `thread` block is a sequential block that may span multiple clock cycles.  The
 
 `seq` remains stateless (one clock edge, no implicit state).  `thread` is explicitly stateful.
 
+> **For compiler contributors:** the algorithm that turns `thread` blocks into FSMs, arbiters, and a synthesized `_<Module>_threads` submodule lives in [`thread_lowering_algorithm.md`](thread_lowering_algorithm.md).  This section defines what users write and what they observe; the lowering doc defines how the compiler implements those guarantees.
+
 ## 20.1  Basic Syntax
 
 ```
@@ -210,6 +212,8 @@ end resource bus
 ```
 
 If a `lock` references a resource that has no explicit `resource` declaration, the compiler defaults to `mutex<priority>`.
+
+> **`--thread-sim` caveat.** `arch sim --thread-sim` runs the parallel thread scheduler instead of the FSM-lowered codegen.  That scheduler currently resolves contention by lowest-thread-index — observationally identical to `priority` — even when the resource is declared `mutex<round_robin>` or `mutex<lru>`.  Equivalence checks under `arch sim --thread-sim both` against the default path will silently pass on designs that depend on fair scheduling; use the default `arch sim` or Verilator when validating fairness-sensitive behaviour.  Tracked in [arch-com#447](https://github.com/arch-hdl-lang/arch-com/pull/447) §3; see [`thread_lowering_algorithm.md`](thread_lowering_algorithm.md#liveness-per-policy) for the per-policy lowering details.
 
 ### 20.8.2  Lock Block
 


### PR DESCRIPTION
## Summary

Three small focused doc edits resolving #447 §3 follow-up. No code
change.

### 1. `doc/thread_lowering_algorithm.md` §Arbiter structure

Was stale since v0.46.0 — described only fixed-priority arbiters with
a single-paragraph deadlock-freedom proof anchored on
`grant[i] = req[i] && !grant[0..i-1]`. v0.46.0 replaced that with a
synthesized `arbiter` Item per resource carrying any
`arbiter`-supported policy. Replace the stale section with:

- A policy table covering `priority` / `round_robin` / `lru` /
  `weighted<W>` / custom-via-hook, with grant rule and per-policy
  state.
- Per-policy liveness treatment. Priority keeps the existing acyclic
  waits-for proof. round_robin / lru get a bounded-by-N-grants
  fairness argument. weighted notes user-carried liveness obligation.
  Custom-via-hook explicitly flags that liveness is only as good as
  the hook (a hook returning all-zeros while requests are asserted
  deadlocks the arbiter side).
- Explicit note that the priority default unconditionally favours
  thread 0 — designs needing fairness should pick `mutex<round_robin>`
  or `mutex<lru>` rather than accepting the default.

### 2. `doc/thread_spec_section.md` §20.8.1

Adds a callout documenting that `arch sim --thread-sim` resolves
contention by lowest-thread-index regardless of declared policy
(observationally identical to `priority`), and that equivalence
checks under `--thread-sim both` will silently pass on
fairness-sensitive designs. Tracked in #447 §3.

### 3. Cross-references

Both docs gain a one-line pointer to each other. They stay as
separate files — the spec is user-facing (what users write and
observe), the lowering doc is compiler-internal (how the compiler
implements the guarantees). Merging would have inflated the spec
section by 170%.

## Test plan

- [x] Markdown renders correctly in preview
- [x] Cross-reference anchors resolve
- [ ] CI green (markdown-only change)