### PR TITLE
feat(nic400): assert WRAP axlen/alignment preconditions on APB bridge and WidthAdapter

### DIFF
--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -17573,3 +17573,82 @@ fn test_elaborate_440_rename_ident_in_function_call() {
          args so the per-thread rename didn't fire (site 3). SV:\n{sv}"
     );
 }
+
+/// Verifies the `ar_wrap_len_legal_apb` concurrent SVA at
+/// Nic400ApbBridge.arch fires under Verilator `--assert` when a WRAP
+/// burst is issued with an illegal 3-beat `ar_len = 2` (AXI4 §A3.4.1
+/// requires WRAP `ax_len ∈ {1, 3, 7, 15}`). Follow-up to arch-com#447
+/// §4 — earlier WRAP support (#440) only checked the reserved
+/// `ar_burst == 3` code; legal-shape checks beyond that were missing.
+#[test]
+fn test_nic400_apb_bridge_wrap_illegal_len_is_rejected_by_sva() {
+    common::expect_verilator_fatal_multi(
+        &[
+            "tests/nic400/Nic400ApbBridge.arch",
+            "tests/nic400/BusAxi4.arch",
+            "stdlib/BusApb.arch",
+        ],
+        "tests/nic400/tb_nic400_apb_bridge_wrap_len_illegal.cpp",
+        "Nic400ApbBridge",
+        "ASSERTION FAILED: Nic400ApbBridge.ar_wrap_len_legal_apb",
+    );
+}
+
+/// Verifies the `ar_wrap_addr_aligned_apb` concurrent SVA at
+/// Nic400ApbBridge.arch fires under Verilator `--assert` when a WRAP
+/// burst is issued with a base address misaligned to `(1 << ar_size)`
+/// (AXI4 §A3.4.1). We drive `ar_addr = 0x8003, ar_size = 2` — the
+/// low 2 bits must be clear for a 4-byte access. Follow-up to
+/// arch-com#447 §4.
+#[test]
+fn test_nic400_apb_bridge_wrap_unaligned_addr_is_rejected_by_sva() {
+    common::expect_verilator_fatal_multi(
+        &[
+            "tests/nic400/Nic400ApbBridge.arch",
+            "tests/nic400/BusAxi4.arch",
+            "stdlib/BusApb.arch",
+        ],
+        "tests/nic400/tb_nic400_apb_bridge_wrap_addr_unaligned.cpp",
+        "Nic400ApbBridge",
+        "ASSERTION FAILED: Nic400ApbBridge.ar_wrap_addr_aligned_apb",
+    );
+}
+
+/// Verifies the `ar_wrap_len_legal_widthadapter` concurrent SVA at
+/// Nic400WidthAdapter.arch fires under Verilator `--assert` when a
+/// WRAP burst is issued with an illegal 3-beat `ar_len = 2`. The
+/// width-adapter's downsizing path would otherwise forward an
+/// out-of-spec slave burst whose byte-count-preserved scaling no
+/// longer wraps at the expected window boundary. Follow-up to
+/// arch-com#447 §4 — earlier WRAP support (#441) only checked the
+/// burst-type code, not the burst shape.
+#[test]
+fn test_nic400_width_adapter_wrap_illegal_len_is_rejected_by_sva() {
+    common::expect_verilator_fatal_multi(
+        &[
+            "tests/nic400/Nic400WidthAdapter.arch",
+            "tests/nic400/BusAxi4.arch",
+        ],
+        "tests/nic400/tb_nic400_width_adapter_wrap_len_illegal.cpp",
+        "Nic400WidthAdapter",
+        "ASSERTION FAILED: Nic400WidthAdapter.ar_wrap_len_legal_widthadapter",
+    );
+}
+
+/// Verifies the `ar_wrap_addr_aligned_widthadapter` concurrent SVA
+/// at Nic400WidthAdapter.arch fires under Verilator `--assert` when a
+/// WRAP burst is issued with a base address misaligned to
+/// `(1 << ar_size)` (AXI4 §A3.4.1). We drive
+/// `ar_addr = 0x8003, ar_size = 2`. Follow-up to arch-com#447 §4.
+#[test]
+fn test_nic400_width_adapter_wrap_unaligned_addr_is_rejected_by_sva() {
+    common::expect_verilator_fatal_multi(
+        &[
+            "tests/nic400/Nic400WidthAdapter.arch",
+            "tests/nic400/BusAxi4.arch",
+        ],
+        "tests/nic400/tb_nic400_width_adapter_wrap_addr_unaligned.cpp",
+        "Nic400WidthAdapter",
+        "ASSERTION FAILED: Nic400WidthAdapter.ar_wrap_addr_aligned_widthadapter",
+    );
+}

--- a/tests/nic400/Nic400ApbBridge.arch
+++ b/tests/nic400/Nic400ApbBridge.arch
@@ -271,4 +271,31 @@ module Nic400ApbBridge
   // burst code it doesn't know how to honour.
   assert ar_burst_legal: (axi.ar_valid and axi.ar_ready) |-> (axi.ar_burst != 3);
   assert aw_burst_legal: (axi.aw_valid and axi.aw_ready) |-> (axi.aw_burst != 3);
+
+  // AXI4 §A3.4.1 WRAP preconditions. The legal-FIXED-INCR-WRAP filter
+  // above keeps reserved 0b11 out, but it doesn't constrain the *shape*
+  // of a WRAP burst. WRAP further requires:
+  //   1. axlen ∈ {1, 3, 7, 15} (i.e. 2/4/8/16-beat bursts only). A
+  //      3-beat WRAP (axlen=2) would compute burst_bytes=12, wrap_mask
+  //      =0xB inside calc_paddr — UNPREDICTABLE per the spec and visibly
+  //      wrong on the bus.
+  //   2. Base address must be aligned to (1 << ax_size). An unaligned
+  //      WRAP base produces a bogus wrap window that doesn't match what
+  //      the master expects.
+  // Both fire on the handshake cycle, before capture, matching the
+  // burst_legal style above.
+  assert ar_wrap_len_legal_apb: (axi.ar_valid and axi.ar_ready and axi.ar_burst == 2)
+    |-> (axi.ar_len == 1 or axi.ar_len == 3 or axi.ar_len == 7 or axi.ar_len == 15);
+  assert aw_wrap_len_legal_apb: (axi.aw_valid and axi.aw_ready and axi.aw_burst == 2)
+    |-> (axi.aw_len == 1 or axi.aw_len == 3 or axi.aw_len == 7 or axi.aw_len == 15);
+  assert ar_wrap_addr_aligned_apb: (axi.ar_valid and axi.ar_ready and axi.ar_burst == 2)
+    |-> ((axi.ar_size == 0)
+         or (axi.ar_size == 1 and axi.ar_addr[0] == 0)
+         or (axi.ar_size == 2 and axi.ar_addr[1:0] == 0)
+         or (axi.ar_size == 3 and axi.ar_addr[2:0] == 0));
+  assert aw_wrap_addr_aligned_apb: (axi.aw_valid and axi.aw_ready and axi.aw_burst == 2)
+    |-> ((axi.aw_size == 0)
+         or (axi.aw_size == 1 and axi.aw_addr[0] == 0)
+         or (axi.aw_size == 2 and axi.aw_addr[1:0] == 0)
+         or (axi.aw_size == 3 and axi.aw_addr[2:0] == 0));
 end module Nic400ApbBridge

--- a/tests/nic400/Nic400WidthAdapter.arch
+++ b/tests/nic400/Nic400WidthAdapter.arch
@@ -298,4 +298,29 @@ module Nic400WidthAdapter
   // per wide master beat — out of scope here. Reserved (11) is illegal.
   assert ar_burst_supported: (m.ar_valid and m.ar_ready) |-> (m.ar_burst == 1 or m.ar_burst == 2);
   assert aw_burst_supported: (m.aw_valid and m.aw_ready) |-> (m.aw_burst == 1 or m.aw_burst == 2);
+
+  // AXI4 §A3.4.1 WRAP preconditions on the wide master port. The
+  // burst_supported asserts above keep FIXED and reserved out, but
+  // don't constrain the *shape* of a WRAP burst. WRAP further requires:
+  //   1. axlen ∈ {1, 3, 7, 15} — 2/4/8/16-beat bursts only. An illegal
+  //      3-beat WRAP forwards as an out-of-spec slave burst whose
+  //      byte-count-preserved scaling no longer wraps at the expected
+  //      window boundary on the slave side.
+  //   2. Base address must be aligned to (1 << ax_size). An unaligned
+  //      WRAP base produces a bogus wrap window on the downstream slave.
+  // Both fire on the wide-master AR/AW handshake cycle.
+  assert ar_wrap_len_legal_widthadapter: (m.ar_valid and m.ar_ready and m.ar_burst == 2)
+    |-> (m.ar_len == 1 or m.ar_len == 3 or m.ar_len == 7 or m.ar_len == 15);
+  assert aw_wrap_len_legal_widthadapter: (m.aw_valid and m.aw_ready and m.aw_burst == 2)
+    |-> (m.aw_len == 1 or m.aw_len == 3 or m.aw_len == 7 or m.aw_len == 15);
+  assert ar_wrap_addr_aligned_widthadapter: (m.ar_valid and m.ar_ready and m.ar_burst == 2)
+    |-> ((m.ar_size == 0)
+         or (m.ar_size == 1 and m.ar_addr[0] == 0)
+         or (m.ar_size == 2 and m.ar_addr[1:0] == 0)
+         or (m.ar_size == 3 and m.ar_addr[2:0] == 0));
+  assert aw_wrap_addr_aligned_widthadapter: (m.aw_valid and m.aw_ready and m.aw_burst == 2)
+    |-> ((m.aw_size == 0)
+         or (m.aw_size == 1 and m.aw_addr[0] == 0)
+         or (m.aw_size == 2 and m.aw_addr[1:0] == 0)
+         or (m.aw_size == 3 and m.aw_addr[2:0] == 0));
 end module Nic400WidthAdapter

--- a/tests/nic400/tb_nic400_apb_bridge_wrap_addr_unaligned.cpp
+++ b/tests/nic400/tb_nic400_apb_bridge_wrap_addr_unaligned.cpp
@@ -1,0 +1,67 @@
+// WRAP-address alignment rejection TB for Nic400ApbBridge.
+//
+// AXI4 §A3.4.1 requires the WRAP base address to be aligned to
+// (1 << ax_size). The `ar_wrap_addr_aligned_apb` concurrent SVA at
+// Nic400ApbBridge.arch fires on any AR handshake where
+// `ar_burst == WRAP (2)` and the low bits of `ar_addr` aren't zero
+// for the declared size. We drive `ar_addr = 0x8003, ar_size = 2`
+// (size=2 ⇒ 4-byte access, requires low 2 bits == 0) to trip it.
+//
+// Under Verilator `--assert`:
+//   %Error: ASSERTION FAILED: Nic400ApbBridge.ar_wrap_addr_aligned_apb
+//
+// Reset polarity is `Reset<Async, Low>` (Nic400ApbBridge.arch:64).
+
+#include "VNic400ApbBridge.h"
+
+#include <cstdint>
+#include <cstdio>
+
+static VNic400ApbBridge dut;
+
+static void tick() {
+    dut.clk = 0;
+    dut.eval();
+    dut.clk = 1;
+    dut.eval();
+}
+
+static void clear_inputs() {
+    dut.axi_ar_valid = 0; dut.axi_ar_addr = 0; dut.axi_ar_id = 0;
+    dut.axi_ar_len = 0; dut.axi_ar_size = 0; dut.axi_ar_burst = 0;
+    dut.axi_ar_lock = 0; dut.axi_ar_cache = 0; dut.axi_ar_prot = 0;
+    dut.axi_ar_qos = 0; dut.axi_ar_region = 0;
+    dut.axi_r_ready = 0;
+    dut.axi_aw_valid = 0; dut.axi_aw_addr = 0; dut.axi_aw_id = 0;
+    dut.axi_aw_len = 0; dut.axi_aw_size = 0; dut.axi_aw_burst = 0;
+    dut.axi_aw_lock = 0; dut.axi_aw_cache = 0; dut.axi_aw_prot = 0;
+    dut.axi_aw_qos = 0; dut.axi_aw_region = 0;
+    dut.axi_w_valid = 0; dut.axi_w_data = 0; dut.axi_w_strb = 0; dut.axi_w_last = 0;
+    dut.axi_b_ready = 0;
+    dut.apb_prdata = 0; dut.apb_pready = 0; dut.apb_pslverr = 0;
+}
+
+int main() {
+    dut.rst = 0;
+    clear_inputs();
+    for (int i = 0; i < 4; ++i) tick();
+    dut.rst = 1;
+    for (int i = 0; i < 3; ++i) tick();
+
+    // AR handshake with burst=WRAP (2), ar_size=2 (4-byte access), and
+    // ar_addr=0x8003 — base is NOT 4-byte aligned. The legal-len value
+    // ar_len=3 keeps `ar_wrap_len_legal_apb` happy so we trip the
+    // alignment SVA specifically, not the length SVA.
+    dut.axi_ar_valid = 1;
+    dut.axi_ar_addr  = 0x8003;   // low 2 bits non-zero — alignment violation
+    dut.axi_ar_id    = 0;
+    dut.axi_ar_len   = 3;        // legal 4-beat WRAP
+    dut.axi_ar_size  = 2;        // 4-byte access — requires ar_addr[1:0] == 0
+    dut.axi_ar_burst = 2;        // WRAP
+
+    for (int i = 0; i < 8; ++i) tick();
+
+    std::printf("FAIL: WRAP unaligned-addr SVA ar_wrap_addr_aligned_apb did not fatal "
+                "(was Verilator built with --assert?)\n");
+    return 0;
+}

--- a/tests/nic400/tb_nic400_apb_bridge_wrap_len_illegal.cpp
+++ b/tests/nic400/tb_nic400_apb_bridge_wrap_len_illegal.cpp
@@ -1,0 +1,70 @@
+// WRAP-axlen rejection TB for Nic400ApbBridge.
+//
+// AXI4 §A3.4.1 requires WRAP bursts to have ax_len ∈ {1, 3, 7, 15}
+// (i.e. 2/4/8/16-beat bursts). The `ar_wrap_len_legal_apb` concurrent
+// SVA at Nic400ApbBridge.arch fires on any AR handshake where
+// `ar_burst == WRAP (2)` and `ar_len ∉ {1, 3, 7, 15}`. We drive a
+// 3-beat WRAP (ar_len = 2) to trip it.
+//
+// Under Verilator `--assert` the SVA surfaces as
+//   %Error: ASSERTION FAILED: Nic400ApbBridge.ar_wrap_len_legal_apb
+// followed by `$fatal(1, ...)` and non-zero exit. The
+// `expect_verilator_fatal_multi` harness in `tests/common/mod.rs`
+// pins the substring to the exact SVA label.
+//
+// Reset polarity is `Reset<Async, Low>` (Nic400ApbBridge.arch:64),
+// so rst=0 holds, rst=1 releases.
+
+#include "VNic400ApbBridge.h"
+
+#include <cstdint>
+#include <cstdio>
+
+static VNic400ApbBridge dut;
+
+static void tick() {
+    dut.clk = 0;
+    dut.eval();
+    dut.clk = 1;
+    dut.eval();
+}
+
+static void clear_inputs() {
+    dut.axi_ar_valid = 0; dut.axi_ar_addr = 0; dut.axi_ar_id = 0;
+    dut.axi_ar_len = 0; dut.axi_ar_size = 0; dut.axi_ar_burst = 0;
+    dut.axi_ar_lock = 0; dut.axi_ar_cache = 0; dut.axi_ar_prot = 0;
+    dut.axi_ar_qos = 0; dut.axi_ar_region = 0;
+    dut.axi_r_ready = 0;
+    dut.axi_aw_valid = 0; dut.axi_aw_addr = 0; dut.axi_aw_id = 0;
+    dut.axi_aw_len = 0; dut.axi_aw_size = 0; dut.axi_aw_burst = 0;
+    dut.axi_aw_lock = 0; dut.axi_aw_cache = 0; dut.axi_aw_prot = 0;
+    dut.axi_aw_qos = 0; dut.axi_aw_region = 0;
+    dut.axi_w_valid = 0; dut.axi_w_data = 0; dut.axi_w_strb = 0; dut.axi_w_last = 0;
+    dut.axi_b_ready = 0;
+    dut.apb_prdata = 0; dut.apb_pready = 0; dut.apb_pslverr = 0;
+}
+
+int main() {
+    dut.rst = 0;
+    clear_inputs();
+    for (int i = 0; i < 4; ++i) tick();
+    dut.rst = 1;
+    for (int i = 0; i < 3; ++i) tick();
+
+    // AR handshake with burst=WRAP (2) and len=2 (3-beat — illegal).
+    // The bridge's read thread waits on ar_valid and asserts ar_ready
+    // unconditionally for one cycle, so the SVA fires on the very next
+    // rising edge.
+    dut.axi_ar_valid = 1;
+    dut.axi_ar_addr  = 0x8000;   // aligned (size=2 → 4B → low 2 bits clear)
+    dut.axi_ar_id    = 0;
+    dut.axi_ar_len   = 2;        // 3-beat WRAP — illegal per AXI4 §A3.4.1
+    dut.axi_ar_size  = 2;
+    dut.axi_ar_burst = 2;        // WRAP
+
+    for (int i = 0; i < 8; ++i) tick();
+
+    std::printf("FAIL: WRAP ar_len=2 SVA ar_wrap_len_legal_apb did not fatal "
+                "(was Verilator built with --assert?)\n");
+    return 0;
+}

--- a/tests/nic400/tb_nic400_width_adapter_wrap_addr_unaligned.cpp
+++ b/tests/nic400/tb_nic400_width_adapter_wrap_addr_unaligned.cpp
@@ -1,0 +1,70 @@
+// WRAP-address alignment rejection TB for Nic400WidthAdapter.
+//
+// AXI4 §A3.4.1 requires the WRAP base address to be aligned to
+// (1 << ax_size). The `ar_wrap_addr_aligned_widthadapter` concurrent
+// SVA at Nic400WidthAdapter.arch fires on any wide-master AR
+// handshake where `m.ar_burst == WRAP (2)` and the low bits of
+// `m.ar_addr` aren't zero for the declared size. We drive
+// `ar_addr = 0x8003, ar_size = 2` (size=2 ⇒ 4-byte access, requires
+// low 2 bits == 0) to trip it.
+//
+// Under Verilator `--assert`:
+//   %Error: ASSERTION FAILED: Nic400WidthAdapter.ar_wrap_addr_aligned_widthadapter
+//
+// Reset polarity is `Reset<Async, Low>` (Nic400WidthAdapter.arch:60).
+
+#include "VNic400WidthAdapter.h"
+
+#include <cstdint>
+#include <cstdio>
+
+static VNic400WidthAdapter dut;
+
+static void tick() {
+    dut.clk = 0;
+    dut.eval();
+    dut.clk = 1;
+    dut.eval();
+}
+
+static void clear_inputs() {
+    dut.m_ar_valid = 0; dut.m_ar_addr = 0; dut.m_ar_id = 0; dut.m_ar_len = 0;
+    dut.m_ar_size = 0;  dut.m_ar_burst = 0; dut.m_ar_lock = 0;
+    dut.m_ar_cache = 0; dut.m_ar_prot = 0;  dut.m_ar_qos = 0; dut.m_ar_region = 0;
+    dut.m_r_ready = 0;
+    dut.m_aw_valid = 0; dut.m_aw_addr = 0; dut.m_aw_id = 0; dut.m_aw_len = 0;
+    dut.m_aw_size = 0;  dut.m_aw_burst = 0; dut.m_aw_lock = 0;
+    dut.m_aw_cache = 0; dut.m_aw_prot = 0;  dut.m_aw_qos = 0; dut.m_aw_region = 0;
+    dut.m_w_valid = 0; dut.m_w_data = 0; dut.m_w_strb = 0; dut.m_w_last = 0;
+    dut.m_b_ready = 0;
+    dut.s_ar_ready = 0;
+    dut.s_r_valid = 0; dut.s_r_data = 0; dut.s_r_id = 0; dut.s_r_resp = 0; dut.s_r_last = 0;
+    dut.s_aw_ready = 0;
+    dut.s_w_ready = 0;
+    dut.s_b_valid = 0; dut.s_b_id = 0; dut.s_b_resp = 0;
+}
+
+int main() {
+    dut.rst = 0;
+    clear_inputs();
+    for (int i = 0; i < 4; ++i) tick();
+    dut.rst = 1;
+    for (int i = 0; i < 3; ++i) tick();
+
+    // AR with burst=WRAP, ar_size=2 (4-byte), ar_addr=0x8003 — base is
+    // NOT 4-byte aligned. The legal ar_len=3 keeps the length SVA happy
+    // so we trip the alignment SVA specifically.
+    dut.m_ar_valid = 1;
+    dut.m_ar_addr  = 0x8003;     // low 2 bits non-zero
+    dut.m_ar_id    = 0;
+    dut.m_ar_len   = 3;          // legal 4-beat WRAP
+    dut.m_ar_size  = 2;          // 4-byte — requires ar_addr[1:0] == 0
+    dut.m_ar_burst = 2;          // WRAP
+    dut.s_ar_ready = 1;
+
+    for (int i = 0; i < 8; ++i) tick();
+
+    std::printf("FAIL: WRAP unaligned-addr SVA ar_wrap_addr_aligned_widthadapter did not fatal "
+                "(was Verilator built with --assert?)\n");
+    return 0;
+}

--- a/tests/nic400/tb_nic400_width_adapter_wrap_len_illegal.cpp
+++ b/tests/nic400/tb_nic400_width_adapter_wrap_len_illegal.cpp
@@ -1,0 +1,68 @@
+// WRAP-axlen rejection TB for Nic400WidthAdapter.
+//
+// AXI4 §A3.4.1 requires WRAP bursts to have ax_len ∈ {1, 3, 7, 15}.
+// The `ar_wrap_len_legal_widthadapter` concurrent SVA at
+// Nic400WidthAdapter.arch fires on any wide-master AR handshake where
+// `m.ar_burst == WRAP (2)` and `m.ar_len ∉ {1, 3, 7, 15}`. We drive
+// a 3-beat WRAP (ar_len = 2) to trip it.
+//
+// Under Verilator `--assert`:
+//   %Error: ASSERTION FAILED: Nic400WidthAdapter.ar_wrap_len_legal_widthadapter
+//
+// Reset polarity is `Reset<Async, Low>` (Nic400WidthAdapter.arch:60).
+
+#include "VNic400WidthAdapter.h"
+
+#include <cstdint>
+#include <cstdio>
+
+static VNic400WidthAdapter dut;
+
+static void tick() {
+    dut.clk = 0;
+    dut.eval();
+    dut.clk = 1;
+    dut.eval();
+}
+
+static void clear_inputs() {
+    dut.m_ar_valid = 0; dut.m_ar_addr = 0; dut.m_ar_id = 0; dut.m_ar_len = 0;
+    dut.m_ar_size = 0;  dut.m_ar_burst = 0; dut.m_ar_lock = 0;
+    dut.m_ar_cache = 0; dut.m_ar_prot = 0;  dut.m_ar_qos = 0; dut.m_ar_region = 0;
+    dut.m_r_ready = 0;
+    dut.m_aw_valid = 0; dut.m_aw_addr = 0; dut.m_aw_id = 0; dut.m_aw_len = 0;
+    dut.m_aw_size = 0;  dut.m_aw_burst = 0; dut.m_aw_lock = 0;
+    dut.m_aw_cache = 0; dut.m_aw_prot = 0;  dut.m_aw_qos = 0; dut.m_aw_region = 0;
+    dut.m_w_valid = 0; dut.m_w_data = 0; dut.m_w_strb = 0; dut.m_w_last = 0;
+    dut.m_b_ready = 0;
+    dut.s_ar_ready = 0;
+    dut.s_r_valid = 0; dut.s_r_data = 0; dut.s_r_id = 0; dut.s_r_resp = 0; dut.s_r_last = 0;
+    dut.s_aw_ready = 0;
+    dut.s_w_ready = 0;
+    dut.s_b_valid = 0; dut.s_b_id = 0; dut.s_b_resp = 0;
+}
+
+int main() {
+    dut.rst = 0;
+    clear_inputs();
+    for (int i = 0; i < 4; ++i) tick();
+    dut.rst = 1;
+    for (int i = 0; i < 3; ++i) tick();
+
+    // AR with burst=WRAP, len=2 (3-beat — illegal). Aligned addr keeps
+    // the alignment SVA happy so we trip the length SVA specifically.
+    // s_ar_ready=1 closes the wide-master handshake on the next edge.
+    dut.m_ar_valid = 1;
+    dut.m_ar_addr  = 0x100;      // size=3 (8B) aligned
+    dut.m_ar_id    = 0;
+    dut.m_ar_len   = 2;          // 3-beat WRAP — illegal
+    dut.m_ar_size  = 3;
+    dut.m_ar_burst = 2;          // WRAP
+    dut.s_ar_ready = 1;
+
+    for (int i = 0; i < 8; ++i) tick();
+
+    std::printf("FAIL: WRAP ar_len=2 SVA ar_wrap_len_legal_widthadapter did not fatal "
+                "(was Verilator built with --assert?)\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary

AXI4 §A3.4.1 imposes two preconditions on WRAP bursts that the earlier WRAP support (#440 for the APB bridge, #441 for the WidthAdapter) didn't check:

1. **axlen ∈ {1, 3, 7, 15}** — WRAP supports only 2/4/8/16-beat bursts. An illegal 3-beat WRAP (`axlen=2`) silently computes `burst_bytes=12, wrap_mask=0xB` inside the APB bridge's `calc_paddr` — UNPREDICTABLE per the spec, visibly wrong on the bus.
2. **Base address aligned to `(1 << ax_size)`** — an unaligned WRAP base produces a bogus wrap window.

Both bridges previously only asserted that `ar_burst != reserved-3`. This PR adds four new concurrent SVAs per module covering both AR and AW handshakes:

- `Nic400ApbBridge`: `{ar,aw}_wrap_len_legal_apb`, `{ar,aw}_wrap_addr_aligned_apb`
- `Nic400WidthAdapter`: `{ar,aw}_wrap_len_legal_widthadapter`, `{ar,aw}_wrap_addr_aligned_widthadapter`

Module-suffixed labels keep each SVA's `\$fatal` string unique so the expect-fatal harness can pin to the exact assertion.

## New expect-fatal tests

Four Rust tests in `tests/integration_test.rs`, mirroring the FIXED-rejection pattern from #454 and using the `expect_verilator_fatal_multi` harness from #453:

- `test_nic400_apb_bridge_wrap_illegal_len_is_rejected_by_sva`
- `test_nic400_apb_bridge_wrap_unaligned_addr_is_rejected_by_sva`
- `test_nic400_width_adapter_wrap_illegal_len_is_rejected_by_sva`
- `test_nic400_width_adapter_wrap_unaligned_addr_is_rejected_by_sva`

Each TB drives a single illegal WRAP handshake and pins the fatal substring to `ASSERTION FAILED: <Module>.<exact_label>` — a future rename / codegen regression trips the test loudly.

## References

- arch-com#447 §4 — surfaced the missing checks
- arch-com#440 — added APB bridge WRAP support
- arch-com#441 — added WidthAdapter WRAP support
- arch-com#453 — `expect_verilator_fatal_multi` harness
- arch-com#454 — FIXED-rejection test pattern this PR mirrors
- AMBA AXI4 §A3.4.1 (IHI 0022D)

## Test plan

- [x] `cargo build --release` clean
- [x] `cargo test --release` — 498 passed, 0 failed
- [x] All 4 new expect-fatal tests pass under Verilator `--assert`
- [x] Pre-existing 10/10 APB bridge scenarios still pass (`tb_nic400_apb_bridge.cpp` — uses `axlen=3` WRAPs at aligned bases)
- [x] Pre-existing 7/7 WidthAdapter scenarios still pass (`tb_nic400_width_adapter.cpp` — uses `axlen=3` WRAP at aligned base)
- [x] Existing FIXED-rejection test (`test_nic400_width_adapter_fixed_burst_is_rejected_by_sva`) still passes — labels stayed distinct