### PR TITLE
test(elaborate): regression coverage for #440's tree-walker arms

### DIFF
--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -17438,3 +17438,138 @@ fn test_nic400_width_adapter_fixed_burst_is_rejected_by_sva() {
         "ASSERTION FAILED: Nic400WidthAdapter.ar_burst_supported",
     );
 }
+
+// ────────────────────────────────────────────────────────────────────
+// PR #440 — three `src/elaborate.rs` tree-walker arms (issue #447 §5)
+// ────────────────────────────────────────────────────────────────────
+//
+// PR #440 landed three tree-walker completeness fixes inside a nic400
+// demo PR without isolated test coverage. Each fix added a missing
+// recursive arm to a walker that synthesizes lowered-thread SV.
+// arch-com#447 §5 flagged the missing isolated tests; these three
+// regressions pin the exact shapes so a future tree-walker regression
+// trips a dedicated test rather than a nic400 system test failure.
+//
+// All three were verified against the pre-#440 commit (1973d92) — each
+// fixture distinguishes pre/post #440 behaviour by inspecting a
+// specific token in the lowered SV (see per-test fingerprint).
+
+#[test]
+fn test_elaborate_440_bus_port_type_param_binary() {
+    // Site 1: `src/elaborate.rs::subst_type_expr_for_lower` (around line
+    // 3623) gained recursion into Binary/Unary/Ternary/Clog2 so that
+    // bus-port widths like `UInt<DATA_W / 8>` substitute every operand
+    // when `lower_threads` synthesizes the `_<mod>_threads` sub-module.
+    // Pre-#440, the inner `DATA_W` ident leaked into the sub-module's
+    // port list (which only knows the outer module's `DATA_WIDTH`).
+    let source = include_str!(
+        "regression/issues/elaborate_440/bus_port_type_param_binary/Probe.arch"
+    );
+    let sv = compile_to_sv(source);
+
+    // The lowered `_Probe_threads` sub-module is the one that exercises
+    // `subst_type_expr_for_lower`. Locate its body and verify the strb
+    // port width substituted the bus's local `DATA_W` to the outer
+    // module's caller-bound `DATA_WIDTH`.
+    let threads_start = sv.find("module _Probe_threads").expect(
+        "expected lowered sub-module `_Probe_threads` in SV (the thread \
+         lowering is what exercises `subst_type_expr_for_lower`):\n{sv}",
+    );
+    let threads_end = sv[threads_start..].find("endmodule").map(|e| threads_start + e).unwrap_or(sv.len());
+    let threads_body = &sv[threads_start..threads_end];
+
+    assert!(
+        threads_body.contains("[DATA_WIDTH / 8-1:0] up_strb"),
+        "expected lowered `_Probe_threads` sub-module to declare \
+         `up_strb` with the outer module's param-bound width \
+         (DATA_WIDTH / 8); `subst_type_expr_for_lower` must recurse \
+         into the Binary expression `DATA_W / 8` so the inner ident \
+         substitutes. Got sub-module body:\n{threads_body}"
+    );
+    assert!(
+        !threads_body.contains("[DATA_W / 8-1:0]")
+            && !threads_body.contains("[DATA_W /8-1:0]")
+            && !threads_body.contains("DATA_W-1:0] up_strb"),
+        "found buggy unresolved `DATA_W` in `_Probe_threads` strb port \
+         width — `subst_type_expr_for_lower` failed to recurse into the \
+         Binary arithmetic shape. Sub-module body:\n{threads_body}"
+    );
+}
+
+#[test]
+fn test_elaborate_440_for_loop_iter_in_function_call() {
+    // Site 2: `src/elaborate.rs::rewrite_var_expr` (around line 6274)
+    // gained an `ExprKind::FunctionCall` arm so a for-loop iter
+    // referenced inside a function-call argument substitutes to the
+    // per-loop counter ident. Pre-#440, the raw `b` leaked into the
+    // lowered SV as an undeclared variable.
+    let source = include_str!(
+        "regression/issues/elaborate_440/for_loop_iter_in_function_call/Probe.arch"
+    );
+    let sv = compile_to_sv(source);
+
+    // Single thread → ti=0 → counter ident = `_t0_loop_cnt_0`.
+    // The function call `step(b.zext<8>())` must substitute `b` into
+    // `_t0_loop_cnt_0` inside the argument.
+    assert!(
+        sv.contains("step_8(8'($unsigned(_t0_loop_cnt_0)))"),
+        "expected `step_8` function call to receive the per-thread loop \
+         counter `_t0_loop_cnt_0` as its argument — `rewrite_var_expr` \
+         must recurse into FunctionCall args to substitute the iter var \
+         `b`. Got SV:\n{sv}"
+    );
+    // The raw iter ident `b` must NOT appear as a function-call arg.
+    // Look for the specific buggy shape from pre-#440.
+    assert!(
+        !sv.contains("step_8(8'($unsigned(b)))"),
+        "found buggy unresolved iter var `b` in `step_8(...)` argument \
+         — `rewrite_var_expr` failed to recurse into FunctionCall args. \
+         SV:\n{sv}"
+    );
+}
+
+#[test]
+fn test_elaborate_440_rename_ident_in_function_call() {
+    // Site 3: `src/elaborate.rs::rename_ident_in_expr` (around line
+    // 6464) gained an `ExprKind::FunctionCall` arm so the per-thread
+    // counter rename (`_loop_cnt_{id}` → `_t{ti}_loop_cnt_{id}`)
+    // descends into function-call args. Sites 2 and 3 form a pair: 2
+    // substitutes the user-written iter var into `_loop_cnt_{id}`, 3
+    // renames `_loop_cnt_{id}` to its per-thread form. A multi-thread
+    // fixture exercises the rename for both ti=0 and ti=1.
+    let source = include_str!(
+        "regression/issues/elaborate_440/rename_ident_in_function_call/Probe.arch"
+    );
+    let sv = compile_to_sv(source);
+
+    // Both threads' function-call args must carry the per-thread
+    // renamed counter, not the bare `_loop_cnt_0` (rename failure) and
+    // not the raw user `a`/`b` (substitution failure).
+    assert!(
+        sv.contains("step_8(8'($unsigned(_t0_loop_cnt_0)))"),
+        "expected thread 0 to call `step_8(_t0_loop_cnt_0)` — \
+         `rename_ident_in_expr` must descend into FunctionCall args to \
+         rename `_loop_cnt_0` for ti=0. Got SV:\n{sv}"
+    );
+    assert!(
+        sv.contains("step_8(8'($unsigned(_t1_loop_cnt_0)))"),
+        "expected thread 1 to call `step_8(_t1_loop_cnt_0)` — \
+         `rename_ident_in_expr` must descend into FunctionCall args to \
+         rename `_loop_cnt_0` for ti=1. Got SV:\n{sv}"
+    );
+    // Pre-#440 buggy fingerprints: raw `a`/`b` (site 2 missing the
+    // FunctionCall arm) or bare `_loop_cnt_0` (site 3 missing it).
+    assert!(
+        !sv.contains("step_8(8'($unsigned(a)))")
+            && !sv.contains("step_8(8'($unsigned(b)))"),
+        "found buggy raw iter var (`a` or `b`) in `step_8(...)` \
+         argument — `rewrite_var_expr` failed to recurse into \
+         FunctionCall args (site 2 paired with site 3). SV:\n{sv}"
+    );
+    assert!(
+        !sv.contains("step_8(8'($unsigned(_loop_cnt_0)))"),
+        "found bare `_loop_cnt_0` in `step_8(...)` argument — \
+         `rename_ident_in_expr` failed to recurse into FunctionCall \
+         args so the per-thread rename didn't fire (site 3). SV:\n{sv}"
+    );
+}

--- a/tests/regression/issues/elaborate_440/bus_port_type_param_binary/Probe.arch
+++ b/tests/regression/issues/elaborate_440/bus_port_type_param_binary/Probe.arch
@@ -1,0 +1,42 @@
+// Regression for PR #440 (compiler tree-walker site 1):
+// `src/elaborate.rs::subst_type_expr_for_lower` previously only matched
+// bare `ExprKind::Ident` and did NOT recurse through arithmetic. When a
+// `bus` port's signal width is a non-trivial expression (here
+// `UInt<DATA_W / 8>` on `strb`), the synthesized `_<mod>_threads`
+// sub-module emitted by `lower_threads` ended up with the bus's local
+// param name (DATA_W) leaking into its port list instead of the
+// enclosing module's caller-bound name (DATA_WIDTH). Verilator lint
+// then rejected the sub-module with "DATA_W: Variable not declared".
+//
+// After the fix, the walker recurses into Binary/Unary/Ternary/Clog2,
+// so `DATA_W / 8` substitutes to `DATA_WIDTH / 8` (or the literal 4
+// after caller-bind) in the lowered sub-module's port declarations.
+//
+// Trigger conditions (all required):
+//   1. a `bus` whose signal width is a binary expression on a bus param
+//   2. an outer module that instantiates that bus AND owns a `thread`
+//      — the thread is what causes `lower_threads` to synthesize the
+//      sub-module that exercises `subst_type_expr_for_lower`.
+bus StrbBus
+  param DATA_W: const = 32;
+  data: out UInt<DATA_W>;
+  strb: out UInt<DATA_W / 8>;
+  valid: out Bool;
+end bus StrbBus
+
+module Probe
+  param DATA_WIDTH: const = 32;
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Async, Low>;
+  port go: in Bool;
+  port up: initiator StrbBus<DATA_W=DATA_WIDTH>;
+
+  thread T on clk rising, rst low
+    default comb
+    end default
+    wait until go;
+    up.data  <= 1;
+    up.strb  <= 1;
+    up.valid <= true;
+  end thread T
+end module Probe

--- a/tests/regression/issues/elaborate_440/for_loop_iter_in_function_call/Probe.arch
+++ b/tests/regression/issues/elaborate_440/for_loop_iter_in_function_call/Probe.arch
@@ -1,0 +1,41 @@
+// Regression for PR #440 (compiler tree-walker site 2):
+// `src/elaborate.rs::rewrite_var_expr` walks an expression tree and
+// substitutes a for-loop iteration variable with a per-thread-iteration
+// replacement (e.g. `_loop_cnt_0`). Before #440 the walker had no
+// `ExprKind::FunctionCall` arm: a function call inside a thread `for`
+// body whose argument list referenced the iter variable left the raw
+// iter ident in place after lowering. Verilator then rejected the SV
+// with "b: Variable not declared".
+//
+// After the fix, `FunctionCall(name, args)` recurses through every
+// argument, mirroring the existing `MethodCall` arm.
+//
+// Minimal trigger:
+//   • a `function` declared in the module
+//   • a `thread` containing `for b in 0..N` whose body passes `b` into
+//     a `function` call (here `step(b)`)
+module Probe
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Async, Low>;
+  port go: in Bool;
+  port acc: out UInt<8>;
+
+  reg acc_r: UInt<8> reset rst => 0;
+
+  function step(idx: UInt<8>) -> UInt<8>
+    return (idx + 1).trunc<8>();
+  end function step
+
+  comb
+    acc = acc_r;
+  end comb
+
+  thread T on clk rising, rst low
+    default comb
+    end default
+    wait until go;
+    for b in 0..3
+      acc_r <= step(b.zext<8>());
+    end for
+  end thread T
+end module Probe

--- a/tests/regression/issues/elaborate_440/rename_ident_in_function_call/Probe.arch
+++ b/tests/regression/issues/elaborate_440/rename_ident_in_function_call/Probe.arch
@@ -1,0 +1,62 @@
+// Regression for PR #440 (compiler tree-walker site 3):
+// `src/elaborate.rs::rename_ident_in_expr` walks an expression tree
+// and renames a counter ident from its bare form (`_loop_cnt_0`) to
+// the per-thread form (`_t{ti}_loop_cnt_0`). Before #440 the walker
+// had no `ExprKind::FunctionCall` arm — when a function call argument
+// references the (already-substituted) counter ident, the rename
+// failed to descend into the args. The lowered SV emitted a bare
+// `_loop_cnt_0` that was undeclared at the module scope (each thread
+// allocates its OWN `_t{ti}_loop_cnt_0` reg).
+//
+// This regression needs two threads each with a `for` loop calling a
+// function on the loop variable. Both ti=0 and ti=1 must rename the
+// counter ident — the bug surfaces as `_loop_cnt_0` leaking past the
+// rename for the FunctionCall-arg site even though it was correctly
+// substituted from the loop var `b` by `rewrite_var_expr`.
+//
+// Sites 2 and 3 form a pair: site 2 (`rewrite_var_expr` FunctionCall
+// arm) substitutes the user-written `b` into `_loop_cnt_0` inside the
+// FunctionCall args; site 3 then renames `_loop_cnt_0` to
+// `_t{ti}_loop_cnt_0` inside those same args. A regression on either
+// arm trips the same assertion: a stale ident (`b` or `_loop_cnt_0`)
+// appears inside a `step(...)` function call argument in the lowered
+// SV. The multi-thread fixture also catches regressions where only
+// the first thread's rename works (ti=0 == `_t0_…`).
+module Probe
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Async, Low>;
+  port go_a: in Bool;
+  port go_b: in Bool;
+  port acc_a: out UInt<8>;
+  port acc_b: out UInt<8>;
+
+  reg acc_a_r: UInt<8> reset rst => 0;
+  reg acc_b_r: UInt<8> reset rst => 0;
+
+  function step(idx: UInt<8>) -> UInt<8>
+    return (idx + 1).trunc<8>();
+  end function step
+
+  comb
+    acc_a = acc_a_r;
+    acc_b = acc_b_r;
+  end comb
+
+  thread Ta on clk rising, rst low
+    default comb
+    end default
+    wait until go_a;
+    for a in 0..3
+      acc_a_r <= step(a.zext<8>());
+    end for
+  end thread Ta
+
+  thread Tb on clk rising, rst low
+    default comb
+    end default
+    wait until go_b;
+    for b in 0..3
+      acc_b_r <= step(b.zext<8>());
+    end for
+  end thread Tb
+end module Probe


### PR DESCRIPTION
## Summary

PR #440 (nic400 APB bridge — full FIXED/INCR/WRAP burst-type decode)
bundled three `src/elaborate.rs` tree-walker completeness fixes that
the demo's `calc_paddr` factoring exposed, but never carried isolated
test coverage. arch-com#447 §5 flagged the missing tests; this PR
adds three targeted regressions so a future tree-walker regression
on these shapes trips a dedicated test rather than a nic400 system
test failure.

The three sites and their fixtures:

| Site | `src/elaborate.rs` | Fix | Fixture |
|---|---|---|---|
| 1 | `subst_type_expr_for_lower` (≈ line 3623) | Recurse into Binary / Unary / Ternary / Clog2 so bus-port widths like `UInt<DATA_W / 8>` substitute every operand in the lowered `_<mod>_threads` sub-module | `tests/regression/issues/elaborate_440/bus_port_type_param_binary/Probe.arch` |
| 2 | `rewrite_var_expr` (≈ line 6274) | Add `ExprKind::FunctionCall` arm so `for b in 0..N ... fn(b)` substitutes `b` into the per-iteration counter inside function-call args | `tests/regression/issues/elaborate_440/for_loop_iter_in_function_call/Probe.arch` |
| 3 | `rename_ident_in_expr` (≈ line 6464) | Parallel `FunctionCall` arm so the per-thread counter rename (`_loop_cnt_{id}` → `_t{ti}_loop_cnt_{id}`) descends into function-call args | `tests/regression/issues/elaborate_440/rename_ident_in_function_call/Probe.arch` (multi-thread) |

Sites 2 and 3 form a pair — site 2 substitutes the user-written iter
var into `_loop_cnt_{id}`, site 3 renames `_loop_cnt_{id}` to its
per-thread form. The pair shows up most clearly in the multi-thread
fixture (3), but the single-thread fixture (2) gives a sharper
"site-2-only failure" fingerprint.

## Verification

Each fixture was verified to distinguish pre/post #440 behaviour by
running it against commit `1973d92` (parent of #440):

| Fixture | Pre-#440 SV fingerprint | Post-#440 SV fingerprint |
|---|---|---|
| 1 | `[DATA_W / 8-1:0] up_strb` in `_Probe_threads` (undeclared `DATA_W`) | `[DATA_WIDTH / 8-1:0] up_strb` |
| 2 | `step_8(8'($unsigned(b)))` (raw iter var leaked) | `step_8(8'($unsigned(_t0_loop_cnt_0)))` |
| 3 | raw `a` / `b` in both threads' `step_8(...)` args | `_t0_loop_cnt_0` / `_t1_loop_cnt_0` in their respective threads |

The asserts pin both the post-#440 expected token and the absence of
the pre-#440 buggy token, so a regression on either the substitution
arm or the rename arm trips a specific message naming the elaborate.rs
site.

Pure test additions — no compiler change, no spec change.

## Test plan

- [x] `cargo test --release --test integration_test elaborate_440` — 3/3 PASS
- [x] `cargo test --release --test integration_test` — 497/497 PASS, no regressions
- [x] Fixtures verified against pre-#440 commit (1973d92) — all three trip the expected pre-fix fingerprint

Refs: arch-com#440 (which landed the fix), arch-com#447 §5 (which
flagged the missing isolated coverage).