### PR TITLE
fix(typecheck): scope check_port_reg_timing to legacy `port reg` form only

### DIFF
--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -1809,14 +1809,24 @@ impl<'a> TypeChecker<'a> {
         }
     }
 
-    /// Warn when registered output ports are assigned inside state-dependent
-    /// if/elsif chains in seq blocks. This indicates the output has register
-    /// latency relative to the state that drives it — a common timing mismatch
-    /// with testbench models.
+    /// Warn when **deprecated** `port reg` outputs are assigned inside
+    /// state-dependent if/elsif chains in seq blocks. The motivation is the
+    /// implicit 1-cycle latency the legacy `port reg` form hides — a common
+    /// timing mismatch with testbench models that expect same-cycle outputs.
+    ///
+    /// Filter is `ri.legacy_port_reg` (not just `reg_info.is_some()`) so that:
+    ///   * user-written `port: out pipe_reg<T, N>` is silent — the user has
+    ///     explicitly opted into the N-cycle latency by writing the type, so
+    ///     the foot-gun the warning was designed to catch doesn't apply;
+    ///   * thread-lowering synthesizes port-regs with `legacy_port_reg: false`
+    ///     (see `src/elaborate.rs::lower_threads`), so internal artifacts the
+    ///     user can't act on are silent automatically — no separate
+    ///     `synthesized` flag needed.
     pub(crate) fn check_port_reg_timing(&mut self, m: &ModuleDecl) {
-        // Collect registered output port names.
+        // Collect names of *legacy-form* registered output ports only.
         let port_reg_names: HashSet<String> = m.ports.iter()
-            .filter(|p| p.reg_info.is_some() && p.direction == Direction::Out)
+            .filter(|p| p.direction == Direction::Out
+                     && p.reg_info.as_ref().is_some_and(|ri| ri.legacy_port_reg))
             .map(|p| p.name.name.clone())
             .collect();
         if port_reg_names.is_empty() {
@@ -1834,7 +1844,8 @@ impl<'a> TypeChecker<'a> {
 
         // Collect registered output spans for warning locations.
         let port_reg_spans: HashMap<String, Span> = m.ports.iter()
-            .filter(|p| p.reg_info.is_some() && p.direction == Direction::Out)
+            .filter(|p| p.direction == Direction::Out
+                     && p.reg_info.as_ref().is_some_and(|ri| ri.legacy_port_reg))
             .map(|p| (p.name.name.clone(), p.span))
             .collect();
 
@@ -1879,9 +1890,11 @@ impl<'a> TypeChecker<'a> {
                                 if let Some(&span) = port_reg_spans.get(&target) {
                                     self.warnings.push(CompileWarning {
                                         message: format!(
-                                            "`{target}` is a registered output (`pipe_reg<T, N>`) assigned inside a state-dependent \
-                                             branch — output value appears after the declared output latency. \
-                                             Use a plain `out T` port driven by `comb` for same-cycle outputs"
+                                            "`{target}` is a deprecated `port reg` output assigned inside a state-dependent \
+                                             branch — the implicit 1-cycle latency makes the output appear one cycle after \
+                                             the state that drives it. Migrate to either `port {target}: out T` driven by \
+                                             `comb` (same-cycle output) or `port {target}: out pipe_reg<T, N>` (explicit \
+                                             N-cycle registered output)"
                                         ),
                                         span,
                                     });

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -3934,6 +3934,134 @@ fn test_handshake_tier15_guarded_payload_silent() {
 }
 
 #[test]
+fn test_check_port_reg_timing_fires_on_legacy_port_reg() {
+    // Positive control: when a user *writes* the deprecated `port reg`
+    // form and assigns it inside a state-dependent if/elsif branch in a
+    // seq block, the timing-mismatch warning must fire. The implicit
+    // 1-cycle latency the legacy form hides is exactly the foot-gun the
+    // warning was designed to catch — testbench models that expect a
+    // same-cycle output from the state register see one-cycle-old data.
+    let source = "
+        module Foo
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync>;
+          port reg out_reg: out UInt<8> reset rst => 0;
+          reg state: UInt<2> reset rst => 0;
+          default seq on clk rising;
+          seq
+            if state == 0
+              out_reg <= 8'd1;
+            end if
+          end seq
+        end module Foo
+    ";
+    let ws = warnings_from(source);
+    assert!(
+        ws.iter().any(|m|
+            m.contains("out_reg")
+            && m.contains("deprecated `port reg`")
+            && m.contains("state-dependent")
+        ),
+        "expected check_port_reg_timing warning for legacy `port reg` \
+         output; got: {:?}",
+        ws,
+    );
+}
+
+#[test]
+fn test_check_port_reg_timing_skips_modern_pipe_reg() {
+    // Negative control: when a user writes the modern `port: out pipe_reg<T, N>`
+    // form, they have *explicitly* opted into the N-cycle latency by
+    // declaring it in the port signature. The foot-gun the warning is
+    // designed to catch (latency hidden behind the `port reg` keyword)
+    // doesn't apply — the latency is visible in the port type. The
+    // warning must NOT fire, even when the port is assigned inside a
+    // state-dependent branch.
+    let source = "
+        module Foo
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync>;
+          port out_reg: out pipe_reg<UInt<8>, 1> reset rst => 0;
+          reg state: UInt<2> reset rst => 0;
+          default seq on clk rising;
+          seq
+            if state == 0
+              out_reg@1 <= 8'd1;
+            end if
+          end seq
+        end module Foo
+    ";
+    let ws = warnings_from(source);
+    assert!(
+        !ws.iter().any(|m|
+            m.contains("out_reg")
+            && (m.contains("state-dependent") || m.contains("deprecated `port reg`"))
+        ),
+        "did not expect check_port_reg_timing warning for modern \
+         `pipe_reg<T, N>` output (user opted into the N-cycle latency \
+         explicitly); got: {:?}",
+        ws,
+    );
+}
+
+#[test]
+fn test_check_port_reg_timing_skips_synthesized_thread_lowered_regs() {
+    // Negative control: when thread lowering manufactures port regs on
+    // the synthesized `_threads` submodule, the user did NOT write those
+    // port regs — the warning would point at a declaration that doesn't
+    // exist in user source. The synthesized port regs use
+    // `legacy_port_reg: false` (see `src/elaborate.rs::lower_threads`),
+    // which is the same gate the modern `pipe_reg<T, N>` form satisfies,
+    // so the timing check is silent on them automatically — no separate
+    // `synthesized` flag needed. Repro pattern matches
+    // `Nic400WidthAdapter.arch`: a thread with `wait until` / `wait`
+    // (creating FSM states) that does seq assignments inside
+    // state-dependent branches.
+    let source = "
+        module Foo
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync, High>;
+          port start: in Bool;
+          port reg out_data: out UInt<8> reset rst => 0;
+          thread on clk rising, rst high
+            wait until start;
+            out_data <= 8'd1;
+            wait 1 cycle;
+            out_data <= 8'd2;
+          end thread
+        end module Foo
+    ";
+    // Drive the full lowering pipeline (threads → port regs synthesized
+    // on the merged threads submodule) before typecheck, matching the
+    // `arch check` driver.
+    let tokens = arch::lexer::tokenize(source).expect("lexer error");
+    let mut parser = arch::parser::Parser::new(tokens, source);
+    let parsed_ast = parser.parse_source_file().expect("parse error");
+    let ast = arch::elaborate::elaborate(parsed_ast).expect("elaborate error");
+    let ast = arch::elaborate::lower_tlm_target_threads(ast)
+        .expect("tlm target lowering");
+    let ast = arch::elaborate::lower_tlm_initiator_calls(ast)
+        .expect("tlm initiator lowering");
+    let ast = arch::elaborate::lower_threads(ast).expect("thread lowering");
+    let ast = arch::elaborate::lower_pipe_reg_ports(ast)
+        .expect("pipe_reg lowering");
+    let ast = arch::elaborate::lower_credit_channel_dispatch(ast)
+        .expect("credit_channel lowering");
+    let symbols = arch::resolve::resolve(&ast).expect("resolve");
+    let checker = arch::typecheck::TypeChecker::new(&symbols, &ast);
+    let (warnings, _) = checker.check().expect("typecheck");
+    let msgs: Vec<String> = warnings.into_iter().map(|w| w.message).collect();
+    assert!(
+        !msgs.iter().any(|m|
+            m.contains("state-dependent") || m.contains("deprecated `port reg`")
+        ),
+        "expected NO check_port_reg_timing warning on synthesized \
+         thread-lowered port regs; got: {:?}",
+        msgs,
+    );
+}
+
+#[test]
 fn test_handshake_tier15_guard_via_compound_and_silent() {
     let source = "
         bus BusHS


### PR DESCRIPTION
## Summary

Closes the false positive on `Nic400WidthAdapter.arch` (`rd_axlen_r`, `wr_axlen_r`, `r_pack_r`, `r_resp_r`) that motivated this PR by scoping `check_port_reg_timing` to the **legacy `port reg`** keyword form only, using the existing `PortRegInfo::legacy_port_reg` flag.

This replaces the earlier `synthesized: bool` approach (see commit history). The earlier approach worked but added a new AST field for what is really a semantic distinction already encoded in `legacy_port_reg`.

## Rationale

The timing-mismatch warning exists to catch the **implicit 1-cycle latency** the legacy `port reg` keyword hides. The modern form `port: out pipe_reg<T, N>` makes the latency visible in the port signature — when a user writes `pipe_reg<T, 1>`, they have explicitly opted into the N-cycle latency, so the foot-gun the warning was designed to catch doesn't apply.

The parser at `src/parser.rs:1405` already distinguishes the two surfaces:

```rust
Some(PortRegInfo {
    // ...
    legacy_port_reg: pipe_reg_latency.is_none(),
})
```

Thread lowering at `src/elaborate.rs:2378` already emits its synthesized port regs with `legacy_port_reg: false` (matching the modern form):

```rust
Some(PortRegInfo {
    // ...
    legacy_port_reg: false,
})
```

Gating the timing check on `ri.legacy_port_reg` therefore silences in one line:

- the four false positives on `Nic400WidthAdapter.arch` — synthesized port regs are already non-legacy.
- user-written `port: out pipe_reg<T, N>` ports — semantically correct, the latency is declared.

…and continues to fire on legacy `port reg` outputs assigned inside state-dependent branches — the case the check exists to catch.

## Comparison to prior approach

| | `synthesized: bool` (old) | `legacy_port_reg` (this PR) |
|---|---|---|
| Files touched | 5 (ast, parser, elaborate, typecheck, tests) | 2 (typecheck, tests) |
| New AST field | yes | no |
| Silences thread-synthesized port regs | yes | yes |
| Silences user-written `pipe_reg<T, N>` | no | **yes** (correctly — explicit opt-in) |
| Semantic clarity of the gate | provenance marker | matches user-visible distinction |

## Warning message update

Tightened to mention both modern escapes:

> ``out_reg`` is a deprecated ``port reg`` output assigned inside a state-dependent branch — the implicit 1-cycle latency makes the output appear one cycle after the state that drives it. Migrate to either ``port out_reg: out T`` driven by ``comb`` (same-cycle output) or ``port out_reg: out pipe_reg<T, N>`` (explicit N-cycle registered output)

## Tests

Three regression tests pin the new gate:

- `test_check_port_reg_timing_fires_on_legacy_port_reg` — positive control. Legacy `port reg` assigned in state-dependent branch still fires.
- `test_check_port_reg_timing_skips_modern_pipe_reg` — **new**. User-written `pipe_reg<T, N>` is silent even when assigned in a state-dependent branch.
- `test_check_port_reg_timing_skips_synthesized_thread_lowered_regs` — same shape as the prior PR. Thread-lowering synthesized port regs are silent automatically.

## Verification

- [x] `arch check tests/nic400/Nic400WidthAdapter.arch tests/nic400/BusAxi4.arch` now prints `OK: no errors` with no warnings (was: 4 spurious warnings).
- [x] `cargo test --release` clean — 504/504 integration tests pass (3 new), 24 + 20 lib tests pass.
- [x] `cargo build --release` clean.

Pure internal typecheck pass scope tightening — no spec change, no AST surface change, no codegen change.

## Refs

- arch-com#447 §A — false positive surfaced
- arch-com#440 — where the warning first fired
- arch-com#463 — 2026-05-28 findings note; same spirit applied here (don't accept a paper-over flag when there's a tighter, already-encoded semantic gate)