### PR TITLE
[codex] Fix thread fast-path lowering

### DIFF
--- a/src/elaborate.rs
+++ b/src/elaborate.rs
@@ -4599,6 +4599,196 @@ fn guarded_stmt(cond: Expr, stmts: Vec<Stmt>, span: Span) -> Option<Stmt> {
     }
 }
 
+fn lit_same_shape(a: &LitKind, b: &LitKind) -> bool {
+    match (a, b) {
+        (LitKind::Dec(a), LitKind::Dec(b))
+        | (LitKind::Hex(a), LitKind::Hex(b))
+        | (LitKind::Bin(a), LitKind::Bin(b)) => a == b,
+        (LitKind::Sized(aw, av), LitKind::Sized(bw, bv)) => aw == bw && av == bv,
+        _ => false,
+    }
+}
+
+fn inside_member_same_shape(a: &InsideMember, b: &InsideMember) -> bool {
+    match (a, b) {
+        (InsideMember::Single(a), InsideMember::Single(b)) => expr_same_shape(a, b),
+        (InsideMember::Range(alo, ahi), InsideMember::Range(blo, bhi)) => {
+            expr_same_shape(alo, blo) && expr_same_shape(ahi, bhi)
+        }
+        _ => false,
+    }
+}
+
+fn expr_slice_same_shape(a: &[Expr], b: &[Expr]) -> bool {
+    a.len() == b.len()
+        && a.iter()
+            .zip(b.iter())
+            .all(|(a_expr, b_expr)| expr_same_shape(a_expr, b_expr))
+}
+
+fn expr_same_shape(a: &Expr, b: &Expr) -> bool {
+    match (&a.kind, &b.kind) {
+        (ExprKind::Literal(a), ExprKind::Literal(b)) => lit_same_shape(a, b),
+        (ExprKind::Ident(a), ExprKind::Ident(b)) => a == b,
+        (ExprKind::SynthIdent(a, _), ExprKind::SynthIdent(b, _)) => a == b,
+        (ExprKind::Binary(a_op, a_l, a_r), ExprKind::Binary(b_op, b_l, b_r)) => {
+            a_op == b_op && expr_same_shape(a_l, b_l) && expr_same_shape(a_r, b_r)
+        }
+        (ExprKind::Unary(a_op, a_e), ExprKind::Unary(b_op, b_e)) => {
+            a_op == b_op && expr_same_shape(a_e, b_e)
+        }
+        (ExprKind::FieldAccess(a_base, a_field), ExprKind::FieldAccess(b_base, b_field)) => {
+            a_field.name == b_field.name && expr_same_shape(a_base, b_base)
+        }
+        (ExprKind::MethodCall(a_base, a_name, a_args), ExprKind::MethodCall(b_base, b_name, b_args)) => {
+            a_name.name == b_name.name
+                && expr_same_shape(a_base, b_base)
+                && expr_slice_same_shape(a_args, b_args)
+        }
+        (ExprKind::Index(a_base, a_idx), ExprKind::Index(b_base, b_idx)) => {
+            expr_same_shape(a_base, b_base) && expr_same_shape(a_idx, b_idx)
+        }
+        (ExprKind::BitSlice(a_base, a_hi, a_lo), ExprKind::BitSlice(b_base, b_hi, b_lo)) => {
+            expr_same_shape(a_base, b_base)
+                && expr_same_shape(a_hi, b_hi)
+                && expr_same_shape(a_lo, b_lo)
+        }
+        (
+            ExprKind::PartSelect(a_base, a_start, a_width, a_dir),
+            ExprKind::PartSelect(b_base, b_start, b_width, b_dir),
+        ) => {
+            a_dir == b_dir
+                && expr_same_shape(a_base, b_base)
+                && expr_same_shape(a_start, b_start)
+                && expr_same_shape(a_width, b_width)
+        }
+        (ExprKind::EnumVariant(a_enum, a_var), ExprKind::EnumVariant(b_enum, b_var)) => {
+            a_enum.name == b_enum.name && a_var.name == b_var.name
+        }
+        (ExprKind::Todo, ExprKind::Todo) => true,
+        (ExprKind::Bool(a), ExprKind::Bool(b)) => a == b,
+        (ExprKind::Concat(a), ExprKind::Concat(b)) => expr_slice_same_shape(a, b),
+        (ExprKind::Repeat(a_count, a_expr), ExprKind::Repeat(b_count, b_expr)) => {
+            expr_same_shape(a_count, b_count) && expr_same_shape(a_expr, b_expr)
+        }
+        (ExprKind::Clog2(a), ExprKind::Clog2(b))
+        | (ExprKind::Onehot(a), ExprKind::Onehot(b))
+        | (ExprKind::Signed(a), ExprKind::Signed(b))
+        | (ExprKind::Unsigned(a), ExprKind::Unsigned(b)) => expr_same_shape(a, b),
+        (ExprKind::LatencyAt(a, a_n), ExprKind::LatencyAt(b, b_n)) => {
+            a_n == b_n && expr_same_shape(a, b)
+        }
+        (ExprKind::SvaNext(a_n, a), ExprKind::SvaNext(b_n, b)) => {
+            a_n == b_n && expr_same_shape(a, b)
+        }
+        (ExprKind::FunctionCall(a_name, a_args), ExprKind::FunctionCall(b_name, b_args)) => {
+            a_name == b_name && expr_slice_same_shape(a_args, b_args)
+        }
+        (ExprKind::Inside(a_expr, a_members), ExprKind::Inside(b_expr, b_members)) => {
+            expr_same_shape(a_expr, b_expr)
+                && a_members.len() == b_members.len()
+                && a_members
+                    .iter()
+                    .zip(b_members.iter())
+                    .all(|(a_member, b_member)| inside_member_same_shape(a_member, b_member))
+        }
+        (ExprKind::Ternary(a_c, a_t, a_f), ExprKind::Ternary(b_c, b_t, b_f)) => {
+            expr_same_shape(a_c, b_c)
+                && expr_same_shape(a_t, b_t)
+                && expr_same_shape(a_f, b_f)
+        }
+        _ => false,
+    }
+}
+
+fn fast_wait_if_condition(ie: &ThreadIfElse) -> Option<Expr> {
+    if !ie.else_stmts.is_empty() || ie.then_stmts.len() != 1 {
+        return None;
+    }
+
+    let ThreadStmt::WaitUntil(wait_cond, _) = &ie.then_stmts[0] else {
+        return None;
+    };
+    let ExprKind::Unary(UnaryOp::Not, if_cond_inner) = &ie.cond.kind else {
+        return None;
+    };
+    if expr_same_shape(if_cond_inner, wait_cond) {
+        Some(wait_cond.clone())
+    } else {
+        None
+    }
+}
+
+fn merge_fast_region_assigns(
+    states: &mut [ThreadFsmState],
+    fast_region: &mut Option<(usize, Expr)>,
+    cur_comb: &mut Vec<Stmt>,
+    cur_seq: &mut Vec<Stmt>,
+    span: Span,
+) -> bool {
+    let Some((state_idx, guard)) = fast_region.take() else {
+        return false;
+    };
+    if let Some(stmt) = guarded_stmt(guard.clone(), std::mem::take(cur_comb), span) {
+        states[state_idx].comb_stmts.push(stmt);
+    }
+    if let Some(stmt) = guarded_stmt(guard, std::mem::take(cur_seq), span) {
+        states[state_idx].seq_stmts.push(stmt);
+    }
+    true
+}
+
+fn flush_pending_thread_state(
+    states: &mut Vec<ThreadFsmState>,
+    fast_region: &mut Option<(usize, Expr)>,
+    cur_comb: &mut Vec<Stmt>,
+    cur_seq: &mut Vec<Stmt>,
+    span: Span,
+) -> bool {
+    if cur_comb.is_empty() && cur_seq.is_empty() {
+        return fast_region.take().is_some();
+    }
+    if merge_fast_region_assigns(states, fast_region, cur_comb, cur_seq, span) {
+        return true;
+    }
+    states.push(ThreadFsmState {
+        comb_stmts: std::mem::take(cur_comb),
+        seq_stmts: std::mem::take(cur_seq),
+        transition_cond: None,
+        wait_cycles: None,
+        multi_transitions: Vec::new(),
+        terminal_return: None,
+    });
+    true
+}
+
+fn collect_single_state_thread_body(
+    body: &[ThreadStmt],
+) -> (Vec<Stmt>, Vec<Stmt>) {
+    let mut comb_stmts = Vec::new();
+    let mut seq_stmts = Vec::new();
+    for stmt in body {
+        match stmt {
+            ThreadStmt::CombAssign(ca) => comb_stmts.push(Stmt::Assign(ca.clone())),
+            ThreadStmt::SeqAssign(ra) => seq_stmts.push(Stmt::Assign(ra.clone())),
+            ThreadStmt::IfElse(ie) => {
+                let (comb_if, seq_if) = thread_if_to_fsm_stmts(ie);
+                if let Some(stmt) = comb_if {
+                    comb_stmts.push(stmt);
+                }
+                if let Some(stmt) = seq_if {
+                    seq_stmts.push(stmt);
+                }
+            }
+            ThreadStmt::Log(l) => seq_stmts.push(Stmt::Log(l.clone())),
+            _ => {
+                unreachable!("single-state thread body contained an unexpected statement");
+            }
+        }
+    }
+    (comb_stmts, seq_stmts)
+}
+
 /// Optimize the common micro-architecture shape:
 ///
 ///   wait until req;
@@ -4804,6 +4994,8 @@ fn partition_thread_body_impl(
     let mut states: Vec<ThreadFsmState> = Vec::new();
     let mut cur_comb: Vec<Stmt> = Vec::new();
     let mut cur_seq: Vec<Stmt> = Vec::new();
+    let mut fast_region: Option<(usize, Expr)> = None;
+    let mut no_trailing_merge_from: Option<usize> = None;
     // Set when the previous iteration was a `wait 0+ cycle until ...;` that
     // consumed the next `do ... until ...;` as part of its Mealy fusion;
     // skips one iteration of this loop to avoid emitting the do-body as a
@@ -4823,6 +5015,14 @@ fn partition_thread_body_impl(
                 cur_seq.push(Stmt::Log(l.clone()));
             }
             ThreadStmt::WaitUntil(cond, sp) => {
+                if let Some((state_idx, guard)) = fast_region.take() {
+                    if let Some(stmt) = guarded_stmt(guard.clone(), cur_comb.clone(), *sp) {
+                        states[state_idx].comb_stmts.push(stmt);
+                    }
+                    if let Some(stmt) = guarded_stmt(guard, std::mem::take(&mut cur_seq), *sp) {
+                        states[state_idx].seq_stmts.push(stmt);
+                    }
+                }
                 // Per spec §7a.2: only TRAILING seq assigns (after the last
                 // wait in the body) may merge into the preceding state's
                 // exit. Inter-yield seq assigns — assigns sitting BETWEEN
@@ -4940,16 +5140,13 @@ fn partition_thread_body_impl(
 
                 // Flush any pending assigns first.
                 let mut flush = || {
-                    if !cur_comb.is_empty() || !cur_seq.is_empty() {
-                        states.push(ThreadFsmState {
-                            comb_stmts: std::mem::take(&mut cur_comb),
-                            seq_stmts: std::mem::take(&mut cur_seq),
-                            transition_cond: None,
-                            wait_cycles: None,
-                            multi_transitions: Vec::new(),
-                            terminal_return: None,
-                        });
-                    }
+                    flush_pending_thread_state(
+                        &mut states,
+                        &mut fast_region,
+                        &mut cur_comb,
+                        &mut cur_seq,
+                        *sp,
+                    );
                 };
 
                 match next {
@@ -5030,17 +5227,14 @@ fn partition_thread_body_impl(
             }
             ThreadStmt::WaitCycles(count, _) => {
                 // Same: pure boundary, flush all pending assigns
-                let had_flush = !cur_comb.is_empty() || !cur_seq.is_empty();
-                if had_flush {
-                    states.push(ThreadFsmState {
-                        comb_stmts: std::mem::take(&mut cur_comb),
-                        seq_stmts: std::mem::take(&mut cur_seq),
-                        transition_cond: None,
-                        wait_cycles: None,
-                        multi_transitions: Vec::new(),
-                        terminal_return: None,
-                    });
-                }
+                let merged_fast_idx = fast_region.as_ref().map(|(idx, _)| *idx);
+                let had_flush = flush_pending_thread_state(
+                    &mut states,
+                    &mut fast_region,
+                    &mut cur_comb,
+                    &mut cur_seq,
+                    span,
+                );
                 // `wait 1 cycle` between two seq-write boundaries is a no-op
                 // structurally — the natural state transition from the
                 // flushed prior state to whatever state comes next already
@@ -5070,9 +5264,26 @@ fn partition_thread_body_impl(
                         multi_transitions: Vec::new(),
                         terminal_return: None,
                     });
+                } else if let Some(idx) = merged_fast_idx {
+                    no_trailing_merge_from = Some(idx);
                 }
             }
             ThreadStmt::IfElse(ie) => {
+                if cur_comb.is_empty() && cur_seq.is_empty() {
+                    if let Some(cond) = fast_wait_if_condition(ie) {
+                        let fast_idx = states.len();
+                        states.push(ThreadFsmState {
+                            comb_stmts: Vec::new(),
+                            seq_stmts: Vec::new(),
+                            transition_cond: Some(cond.clone()),
+                            wait_cycles: None,
+                            multi_transitions: Vec::new(),
+                            terminal_return: None,
+                        });
+                        fast_region = Some((fast_idx, cond));
+                        continue;
+                    }
+                }
                 let then_has_wait = contains_wait(&ie.then_stmts);
                 let else_has_wait = contains_wait(&ie.else_stmts);
                 let then_has_return = contains_return(&ie.then_stmts);
@@ -5084,22 +5295,20 @@ fn partition_thread_body_impl(
                         && !else_has_return
                         && try_fuse_wait_ifelse(&mut states, ie, cnt_width, loop_id_gen)?
                     {
+                        fast_region.take();
                         continue;
                     }
 
                     // Dispatch-and-rejoin (see doc/thread_lowering_proof.md §II.10).
                     // Step 1: flush pending comb/seq into a predecessor state so
                     // `cond` reads post-flush register values.
-                    if !cur_comb.is_empty() || !cur_seq.is_empty() {
-                        states.push(ThreadFsmState {
-                            comb_stmts: std::mem::take(&mut cur_comb),
-                            seq_stmts: std::mem::take(&mut cur_seq),
-                            transition_cond: None,
-                            wait_cycles: None,
-                            multi_transitions: Vec::new(),
-                        terminal_return: None,
-                        });
-                    }
+                    flush_pending_thread_state(
+                        &mut states,
+                        &mut fast_region,
+                        &mut cur_comb,
+                        &mut cur_seq,
+                        ie.span,
+                    );
                     // Step 2: insert dispatch state placeholder; M filled below
                     // once branch base indices are known.
                     let dispatch_idx = states.len();
@@ -5220,16 +5429,13 @@ fn partition_thread_body_impl(
             }
             ThreadStmt::ForkJoin(branches, sp) => {
                 // Flush pending statements into a state before fork
-                if !cur_comb.is_empty() || !cur_seq.is_empty() {
-                    states.push(ThreadFsmState {
-                        comb_stmts: std::mem::take(&mut cur_comb),
-                        seq_stmts: std::mem::take(&mut cur_seq),
-                        transition_cond: None,
-                        wait_cycles: None,
-                        multi_transitions: Vec::new(),
-                        terminal_return: None,
-                    });
-                }
+                flush_pending_thread_state(
+                    &mut states,
+                    &mut fast_region,
+                    &mut cur_comb,
+                    &mut cur_seq,
+                    *sp,
+                );
                 // Lower fork/join via product-state expansion
                 let mut fork_states = lower_fork_join(branches, *sp, cnt_width, loop_id_gen)?;
                 // Adjust multi_transitions targets: product indices → global state indices
@@ -5262,8 +5468,16 @@ fn partition_thread_body_impl(
                     // No pending assigns — merge counter init into last state.
                     // The init fires on the same edge as the state's transition,
                     // so the counter is ready when the for-body starts.
-                    if let Some(last) = states.last_mut() {
-                        if last.multi_transitions.is_empty() {
+                    if let Some((fast_idx, guard)) = fast_region.take() {
+                        if let Some(stmt) = guarded_stmt(guard, vec![cnt_init.clone()], *span) {
+                            states[fast_idx].seq_stmts.push(stmt);
+                        }
+                        true
+                    } else if let Some(last_idx) = states.len().checked_sub(1) {
+                        let last = &mut states[last_idx];
+                        if last.multi_transitions.is_empty()
+                            && no_trailing_merge_from != Some(last_idx)
+                        {
                             last.seq_stmts.push(cnt_init.clone());
                             true
                         } else {
@@ -5277,16 +5491,13 @@ fn partition_thread_body_impl(
                 };
                 if !merged {
                     cur_seq.push(cnt_init.clone());
-                    if !cur_comb.is_empty() || !cur_seq.is_empty() {
-                        states.push(ThreadFsmState {
-                            comb_stmts: std::mem::take(&mut cur_comb),
-                            seq_stmts: std::mem::take(&mut cur_seq),
-                            transition_cond: None,
-                            wait_cycles: None,
-                            multi_transitions: Vec::new(),
-                        terminal_return: None,
-                        });
-                    }
+                    flush_pending_thread_state(
+                        &mut states,
+                        &mut fast_region,
+                        &mut cur_comb,
+                        &mut cur_seq,
+                        *span,
+                    );
                 }
                 let mut for_states = lower_thread_for(var, start, end, body, *span, cnt_width, loop_id_gen)?;
                 // Adjust multi_transitions targets (relative → absolute)
@@ -5322,16 +5533,13 @@ fn partition_thread_body_impl(
                     ));
                 }
                 // Flush pending statements
-                if !cur_comb.is_empty() || !cur_seq.is_empty() {
-                    states.push(ThreadFsmState {
-                        comb_stmts: std::mem::take(&mut cur_comb),
-                        seq_stmts: std::mem::take(&mut cur_seq),
-                        transition_cond: None,
-                        wait_cycles: None,
-                        multi_transitions: Vec::new(),
-                        terminal_return: None,
-                    });
-                }
+                flush_pending_thread_state(
+                    &mut states,
+                    &mut fast_region,
+                    &mut cur_comb,
+                    &mut cur_seq,
+                    *span,
+                );
                 let lock_states = lower_thread_lock(&resource.name, body, *span, cnt_width, loop_id_gen)?;
                 states.extend(lock_states);
             }
@@ -5346,43 +5554,33 @@ fn partition_thread_body_impl(
                 // the user sees a precise error pointing at the offending
                 // inner statement instead of an infinite-loop miscompile.
                 disallow_nested_control_in_do_until(body, *do_sp)?;
-                // Flush pending assigns into a prior state
-                if !cur_comb.is_empty() || !cur_seq.is_empty() {
-                    states.push(ThreadFsmState {
-                        comb_stmts: std::mem::take(&mut cur_comb),
-                        seq_stmts: std::mem::take(&mut cur_seq),
-                        transition_cond: None,
-                        wait_cycles: None,
-                        multi_transitions: Vec::new(),
-                        terminal_return: None,
-                    });
-                }
-                // Collect the do-body's assigns: comb stays in-state, seq stays in-state
-                let mut do_comb: Vec<Stmt> = Vec::new();
-                let mut do_seq: Vec<Stmt> = Vec::new();
-                for s in body {
-                    match s {
-                        ThreadStmt::CombAssign(ca) => {
-                            do_comb.push(Stmt::Assign(ca.clone()));
+                if cur_comb.is_empty() && cur_seq.is_empty() {
+                    if let Some((fast_idx, wait_cond)) = fast_region.take() {
+                        let (do_comb, do_seq) = collect_single_state_thread_body(body);
+                        if let Some(stmt) = guarded_stmt(wait_cond.clone(), do_comb, *do_sp) {
+                            states[fast_idx].comb_stmts.push(stmt);
                         }
-                        ThreadStmt::SeqAssign(ra) => {
-                            do_seq.push(Stmt::Assign(ra.clone()));
+                        if let Some(stmt) = guarded_stmt(wait_cond.clone(), do_seq, *do_sp) {
+                            states[fast_idx].seq_stmts.push(stmt);
                         }
-                        ThreadStmt::IfElse(ie) => {
-                            let (comb_if, seq_if) = thread_if_to_fsm_stmts(ie);
-                            if let Some(c) = comb_if { do_comb.push(c); }
-                            if let Some(s) = seq_if { do_seq.push(s); }
-                        }
-                        ThreadStmt::Log(l) => {
-                            do_seq.push(Stmt::Log(l.clone()));
-                        }
-                        _ => {
-                            // Unreachable: disallow_nested_control_in_do_until above
-                            // already rejects every other ThreadStmt variant.
-                            unreachable!("do..until body contained an unexpected statement that should have been rejected");
-                        }
+                        states[fast_idx].transition_cond = Some(expr_and(
+                            wait_cond,
+                            cond.clone(),
+                            *do_sp,
+                        ));
+                        continue;
                     }
                 }
+                // Flush pending assigns into a prior state
+                flush_pending_thread_state(
+                    &mut states,
+                    &mut fast_region,
+                    &mut cur_comb,
+                    &mut cur_seq,
+                    *do_sp,
+                );
+                // Collect the do-body's assigns: comb stays in-state, seq stays in-state
+                let (do_comb, do_seq) = collect_single_state_thread_body(body);
                 states.push(ThreadFsmState {
                     comb_stmts: do_comb,
                     seq_stmts: do_seq,
@@ -5397,14 +5595,27 @@ fn partition_thread_body_impl(
                     let return_idx = rets.len();
                     rets.push(e.clone());
                     if !cur_comb.is_empty() || !cur_seq.is_empty() {
-                        states.push(ThreadFsmState {
-                            comb_stmts: std::mem::take(&mut cur_comb),
-                            seq_stmts: std::mem::take(&mut cur_seq),
-                            transition_cond: None,
-                            wait_cycles: None,
-                            multi_transitions: Vec::new(),
-                            terminal_return: Some(return_idx),
-                        });
+                        let merged_fast_idx = fast_region.as_ref().map(|(idx, _)| *idx);
+                        if merge_fast_region_assigns(
+                            &mut states,
+                            &mut fast_region,
+                            &mut cur_comb,
+                            &mut cur_seq,
+                            *ret_span,
+                        ) {
+                            if let Some(idx) = merged_fast_idx {
+                                states[idx].terminal_return = Some(return_idx);
+                            }
+                        } else {
+                            states.push(ThreadFsmState {
+                                comb_stmts: std::mem::take(&mut cur_comb),
+                                seq_stmts: std::mem::take(&mut cur_seq),
+                                transition_cond: None,
+                                wait_cycles: None,
+                                multi_transitions: Vec::new(),
+                                terminal_return: Some(return_idx),
+                            });
+                        }
                     } else {
                         redirect_fallthrough_to_return(&mut states, return_idx, *ret_span);
                     }
@@ -5450,10 +5661,22 @@ fn partition_thread_body_impl(
     // exit) and the remaining stmts are just seq assigns, merge them into
     // the exit transition's seq (guarded by exit condition) to avoid a
     // dead cycle.
+    if fast_region.is_some() {
+        flush_pending_thread_state(
+            &mut states,
+            &mut fast_region,
+            &mut cur_comb,
+            &mut cur_seq,
+            span,
+        );
+    }
     if !cur_comb.is_empty() || !cur_seq.is_empty() {
         let merged_into_exit = if cur_comb.is_empty() && !cur_seq.is_empty() {
-            if let Some(last) = states.last_mut() {
-                if last.multi_transitions.len() == 2 {
+            if let Some(last_idx) = states.len().checked_sub(1) {
+                let last = &mut states[last_idx];
+                if no_trailing_merge_from == Some(last_idx) {
+                    false
+                } else if last.multi_transitions.len() == 2 {
                     // For-loop exit: guard trailing seq assigns by exit condition.
                     // Fires on the same clock edge as the for-loop's exit transition.
                     let exit_cond = last.multi_transitions[1].0.clone();

--- a/src/sim_codegen/mod.rs
+++ b/src/sim_codegen/mod.rs
@@ -5232,8 +5232,37 @@ impl<'a> SimCodegen<'a> {
         // member then default-initializes to 0, giving the desired idle
         // tie-off behaviour.
         let mut inst_out = inst_out;
-        for conns in &expanded_conns {
-            for conn in conns {
+        for (inst_idx, inst) in insts.iter().enumerate() {
+            let mut bus_flat_port_names: HashSet<String> = HashSet::new();
+            let mut sub_params = self.lookup_inst_params(&inst.module_name.name);
+            for pa in &inst.param_assigns {
+                if let Some(p) = sub_params.iter_mut().find(|p| p.name.name == pa.name.name) {
+                    p.default = Some(pa.value.clone());
+                }
+            }
+            for port in self.lookup_inst_ports(&inst.module_name.name) {
+                let Some(bi) = port.bus_info.as_ref() else { continue; };
+                let Some((crate::resolve::Symbol::Bus(info), _)) =
+                    self.symbols.globals.get(&bi.bus_name.name) else { continue; };
+                let prefixes: Vec<String> = match bi.count.as_ref() {
+                    None => vec![port.name.name.clone()],
+                    Some(count_expr) => {
+                        let n = eval_const_expr_with_params(count_expr, &sub_params);
+                        (0..n).map(|i| format!("{}_{}", port.name.name, i)).collect()
+                    }
+                };
+                let mut pm = info.default_param_map();
+                for pa in &bi.params { pm.insert(pa.name.name.clone(), &pa.value); }
+                for (sname, _, _) in info.effective_signals(&pm) {
+                    for prefix in &prefixes {
+                        bus_flat_port_names.insert(format!("{}_{}", prefix, sname));
+                    }
+                }
+            }
+            for conn in &expanded_conns[inst_idx] {
+                if !bus_flat_port_names.contains(&conn.port_name.name) {
+                    continue;
+                }
                 if let ExprKind::Ident(name) = &conn.signal.kind {
                     inst_out.insert(name.clone());
                 }

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -72,6 +72,12 @@ pub struct TypeChecker<'a> {
     /// when the index isn't a compile-time literal (e.g. inside a `for`
     /// loop). Cleared between modules.
     pub vec_of_bus_ports: HashMap<String, u32>,
+    /// Parameter scope for the construct currently being typechecked.
+    ///
+    /// Constant-width expressions must resolve `local param` names within the
+    /// current construct first. Falling back directly to the whole source file
+    /// lets unrelated modules with the same local-param name collide.
+    active_params: Vec<ParamDecl>,
 }
 
 impl<'a> TypeChecker<'a> {
@@ -84,6 +90,7 @@ impl<'a> TypeChecker<'a> {
             overload_map: HashMap::new(),
             in_sva_context: false,
             vec_of_bus_ports: HashMap::new(),
+            active_params: Vec::new(),
         }
     }
 
@@ -93,7 +100,9 @@ impl<'a> TypeChecker<'a> {
         // Runs before per-item checks so reported errors sort naturally.
         self.check_const_div_zero();
         for item in self.source.items.clone().iter() {
+            let saved_params = std::mem::replace(&mut self.active_params, Self::item_params(item));
             item.as_construct().typecheck(&mut self);
+            self.active_params = saved_params;
         }
         // Cross-item check: every `inst foo: SomeRegfile` whose target
         // regfile has `kind: latch` must drive its write-port `addr` /
@@ -118,6 +127,25 @@ impl<'a> TypeChecker<'a> {
             Ok((self.warnings, self.overload_map))
         } else {
             Err(self.errors)
+        }
+    }
+
+    fn item_params(item: &Item) -> Vec<ParamDecl> {
+        match item {
+            Item::Module(m)       => m.params.clone(),
+            Item::Fsm(f)          => f.params.clone(),
+            Item::Fifo(f)         => f.params.clone(),
+            Item::Ram(r)          => r.params.clone(),
+            Item::Cam(c)          => c.params.clone(),
+            Item::Counter(c)      => c.params.clone(),
+            Item::Arbiter(a)      => a.params.clone(),
+            Item::Regfile(r)      => r.params.clone(),
+            Item::Pipeline(p)     => p.params.clone(),
+            Item::Linklist(l)     => l.params.clone(),
+            Item::Synchronizer(s) => s.params.clone(),
+            Item::Clkgate(c)      => c.params.clone(),
+            Item::Package(p)      => p.params.clone(),
+            _ => Vec::new(),
         }
     }
 
@@ -3722,8 +3750,18 @@ impl<'a> TypeChecker<'a> {
             ExprKind::Literal(LitKind::Bin(v)) => Some(*v),
             ExprKind::Literal(LitKind::Sized(_, v)) => Some(*v),
             ExprKind::Ident(name) => {
-                // Try to resolve param value from symbol table
-                // For MVP, check if it's a known param with a default
+                // Resolve local params in the current construct before
+                // consulting the whole source. Multiple unrelated modules can
+                // legitimately use the same local-param name with different
+                // values.
+                if let Some(p) = self.active_params.iter().find(|p| p.name.name == *name) {
+                    if let Some(default) = &p.default {
+                        return self.eval_const_expr(default, local_types);
+                    }
+                }
+
+                // Legacy fallback for contexts that do not enter a construct
+                // scope, such as package-level scans.
                 for item in &self.source.items {
                     if let Item::Module(m) = item {
                         for p in &m.params {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -4465,6 +4465,80 @@ fn test_wait_0plus_cycle_until_mealy_fusion() {
 }
 
 #[test]
+fn test_if_not_wait_until_do_until_matches_wait_0plus_lowering() {
+    let old_source = "
+        bus B
+          v: out Bool;
+          d: out UInt<8>;
+          r: in  Bool;
+        end bus B
+        module Drv
+          port clk:   in  Clock<SysDomain>;
+          port rst:   in  Reset<Async, Low>;
+          port m_val: in  Bool;
+          port m_dat: in  UInt<8>;
+          port m_rdy: out Bool;
+          reg started: Bool reset rst => false;
+          port b:     initiator B;
+          thread T on clk rising, rst low
+            default comb
+              b.v = false;
+              b.d = 0;
+              m_rdy = false;
+            end default
+            wait 0+ cycle until m_val;
+            do
+              b.v   = true;
+              b.d   = m_dat;
+              m_rdy = b.r;
+              started <= true;
+            until b.r;
+          end thread T
+        end module Drv
+    ";
+    let new_source = "
+        bus B
+          v: out Bool;
+          d: out UInt<8>;
+          r: in  Bool;
+        end bus B
+        module Drv
+          port clk:   in  Clock<SysDomain>;
+          port rst:   in  Reset<Async, Low>;
+          port m_val: in  Bool;
+          port m_dat: in  UInt<8>;
+          port m_rdy: out Bool;
+          reg started: Bool reset rst => false;
+          port b:     initiator B;
+          thread T on clk rising, rst low
+            default comb
+              b.v = false;
+              b.d = 0;
+              m_rdy = false;
+            end default
+            if not m_val
+              wait until m_val;
+            end if
+            do
+              b.v   = true;
+              b.d   = m_dat;
+              m_rdy = b.r;
+              started <= true;
+            until b.r;
+          end thread T
+        end module Drv
+    ";
+
+    let old_sv = compile_to_sv(old_source);
+    let new_sv = compile_to_sv(new_source);
+    assert_eq!(
+        old_sv, new_sv,
+        "`if not X; wait until X; end if; do ... until Y;` should lower exactly like \
+         `wait 0+ cycle until X; do ... until Y;`"
+    );
+}
+
+#[test]
 fn test_nested_for_in_thread_uses_distinct_loop_counters() {
     // Regression for issue #414: nested `for` loops in a thread used to
     // share a single `_loop_cnt` register, so the inner loop's increment
@@ -14366,6 +14440,430 @@ end module M
 }
 
 #[test]
+fn test_thread_if_not_wait_until_fast_path_fuses_next_action() {
+    // Canonical fast-path idiom:
+    //
+    //   if not start
+    //     wait until start;
+    //   end if
+    //   phase <= 1;
+    //
+    // If `start` is already high while the thread is in S0, the assignment
+    // must fire on that same edge. Pre-fix lowering skipped the wait state but
+    // still emitted a separate S1 action state, inserting a one-cycle bubble.
+    let source = r#"
+module M
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync, High>;
+  port start: in Bool;
+  port phase: out UInt<8>;
+  reg phase_r: UInt<8> reset rst => 8'd0;
+
+  thread on clk rising, rst high
+    if not start
+      wait until start;
+    end if
+    phase_r <= 8'd1;
+    wait 1 cycle;
+    phase_r <= 8'd2;
+  end thread
+
+  comb
+    phase = phase_r;
+  end comb
+end module M
+"#;
+    let sv = compile_to_sv(source);
+
+    assert!(
+        !sv.contains("_t0_S0_dispatch"),
+        "fast-path if/wait should lower as a wait state, not dispatch around a wait:\n{sv}"
+    );
+    assert!(
+        sv.contains("localparam [0:0] _t0_S0_wait_until = 0"),
+        "expected canonical fast-path state to remain a wait_until state:\n{sv}"
+    );
+    assert!(
+        sv.contains("localparam [0:0] _t0_S1_action = 1"),
+        "expected post-wait action state for work after `wait 1 cycle`:\n{sv}"
+    );
+
+    let s0_marker = "if (_t0_state == _t0_S0_wait_until) begin";
+    let s0_start = sv.find(s0_marker).unwrap_or_else(|| {
+        panic!("missing S0 wait branch in SV:\n{sv}");
+    });
+    let after_s0 = &sv[s0_start + s0_marker.len()..];
+    let s1_rel = after_s0.find("if (_t0_state == _t0_S1_action) begin").unwrap_or_else(|| {
+        panic!("missing S1 action branch after S0 in SV:\n{sv}");
+    });
+    let s0_branch = &sv[s0_start..s0_start + s0_marker.len() + s1_rel];
+
+    assert!(
+        s0_branch.contains("if (start) begin") && s0_branch.contains("phase_r <= 8'd1"),
+        "phase_r <= 1 must fire in the S0/start transition branch:\n{s0_branch}\nFull SV:\n{sv}"
+    );
+    assert!(
+        !s0_branch.contains("phase_r <= 8'd2"),
+        "`wait 1 cycle` after the fast-path action must keep the next action out of S0:\n{s0_branch}\nFull SV:\n{sv}"
+    );
+}
+
+#[test]
+fn test_thread_if_not_wait_until_fast_path_followed_by_wait_cycle() {
+    let source = r#"
+module M
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync, High>;
+  port start: in Bool;
+  port phase: out UInt<8>;
+  reg phase_r: UInt<8> reset rst => 8'd0;
+
+  thread on clk rising, rst high
+    if not start
+      wait until start;
+    end if
+    wait 1 cycle;
+    phase_r <= 8'd1;
+  end thread
+
+  comb
+    phase = phase_r;
+  end comb
+end module M
+"#;
+    let sv = compile_to_sv(source);
+    let trimmed: String = sv.split_whitespace().collect::<Vec<_>>().join(" ");
+
+    assert!(
+        sv.contains("_t0_S0_wait_until") && sv.contains("_t0_S1_action"),
+        "fast gate followed by `wait 1 cycle` should keep the fast wait and emit a later action state:\n{sv}"
+    );
+    assert!(
+        !trimmed.contains("_t0_state == _t0_S0_wait_until) begin if (start) begin phase_r <= 8'd1"),
+        "`wait 1 cycle` after the fast gate must prevent the trailing assign from merging into S0:\n{sv}"
+    );
+}
+
+#[test]
+fn test_thread_if_not_wait_until_fast_path_followed_by_plain_wait_until() {
+    let source = r#"
+module M
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync, High>;
+  port start: in Bool;
+  port ready: in Bool;
+  port phase: out UInt<8>;
+  reg phase_r: UInt<8> reset rst => 8'd0;
+
+  thread on clk rising, rst high
+    if not start
+      wait until start;
+    end if
+    wait until ready;
+    phase_r <= 8'd1;
+  end thread
+
+  comb
+    phase = phase_r;
+  end comb
+end module M
+"#;
+    let sv = compile_to_sv(source);
+
+    assert!(
+        sv.contains("localparam [1:0] _t0_S0_wait_until = 0")
+            || sv.contains("localparam [0:0] _t0_S0_wait_until = 0"),
+        "expected S0 fast wait state:\n{sv}"
+    );
+    assert!(
+        sv.contains("_t0_S1_wait_until"),
+        "fast gate followed by an ordinary `wait until` should emit a second wait state:\n{sv}"
+    );
+    assert!(
+        sv.contains("if (ready) begin\n          phase_r <= 8'd1"),
+        "trailing assignment should merge into the second wait's ready edge:\n{sv}"
+    );
+    assert!(
+        !sv.contains("start && ready"),
+        "the following ordinary `wait until ready` should not be fused into the fast gate:\n{sv}"
+    );
+}
+
+#[test]
+fn test_thread_if_not_wait_until_fast_path_followed_by_same_state_if() {
+    let source = r#"
+module M
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync, High>;
+  port start: in Bool;
+  port sel: in Bool;
+  port phase: out UInt<8>;
+  reg phase_r: UInt<8> reset rst => 8'd0;
+
+  thread on clk rising, rst high
+    if not start
+      wait until start;
+    end if
+    if sel
+      phase_r <= 8'd1;
+    else
+      phase_r <= 8'd2;
+    end if
+    wait 1 cycle;
+  end thread
+
+  comb
+    phase = phase_r;
+  end comb
+end module M
+"#;
+    let sv = compile_to_sv(source);
+    let trimmed: String = sv.split_whitespace().collect::<Vec<_>>().join(" ");
+
+    assert!(
+        trimmed.contains("_t0_state == _t0_S0_wait_until) begin if (start) begin if (sel) begin phase_r <= 8'd1")
+            && trimmed.contains("end else begin phase_r <= 8'd2"),
+        "same-state if/else after fast gate should execute in the S0/start transition branch:\n{sv}"
+    );
+}
+
+#[test]
+fn test_thread_if_not_wait_until_fast_path_followed_by_comb_assign() {
+    let source = r#"
+module M
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync, High>;
+  port start: in Bool;
+  port done: out Bool shared(or);
+
+  thread on clk rising, rst high
+    default comb
+      done = false;
+    end default
+    if not start
+      wait until start;
+    end if
+    done = true;
+    wait 1 cycle;
+  end thread
+end module M
+"#;
+    let sv = compile_to_sv(source);
+    let trimmed: String = sv.split_whitespace().collect::<Vec<_>>().join(" ");
+
+    assert!(
+        trimmed.contains("if (_t0_state == _t0_S0_wait_until) begin if (start) begin done = done | 1'b1"),
+        "comb assign after fast gate should be gated by start in the S0 comb block:\n{sv}"
+    );
+}
+
+#[test]
+fn test_thread_if_not_wait_until_fast_path_followed_by_if_with_waits() {
+    let source = r#"
+module M
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync, High>;
+  port start: in Bool;
+  port sel: in Bool;
+  port phase: out UInt<8>;
+  reg phase_r: UInt<8> reset rst => 8'd0;
+
+  thread on clk rising, rst high
+    if not start
+      wait until start;
+    end if
+    if sel
+      phase_r <= 8'd1;
+      wait 1 cycle;
+    else
+      phase_r <= 8'd2;
+      wait 1 cycle;
+    end if
+    phase_r <= 8'd3;
+  end thread
+
+  comb
+    phase = phase_r;
+  end comb
+end module M
+"#;
+    let sv = compile_to_sv(source);
+
+    assert!(
+        sv.contains("start && sel") && sv.contains("phase_r <= 8'd1"),
+        "then-branch first action should fuse onto the start edge under start && sel:\n{sv}"
+    );
+    assert!(
+        sv.contains("start && !sel") && sv.contains("phase_r <= 8'd2"),
+        "else-branch first action should fuse onto the start edge under start && !sel:\n{sv}"
+    );
+}
+
+#[test]
+fn test_thread_if_not_wait_until_fast_path_followed_by_wait_0plus() {
+    let source = r#"
+module M
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync, High>;
+  port start: in Bool;
+  port go: in Bool;
+  port done: in Bool;
+  port phase: out UInt<8>;
+  reg phase_r: UInt<8> reset rst => 8'd0;
+
+  thread on clk rising, rst high
+    if not start
+      wait until start;
+    end if
+    wait 0+ cycle until go;
+    do
+      phase_r <= 8'd1;
+    until done;
+  end thread
+
+  comb
+    phase = phase_r;
+  end comb
+end module M
+"#;
+    let sv = compile_to_sv(source);
+    let trimmed: String = sv.split_whitespace().collect::<Vec<_>>().join(" ");
+
+    assert!(
+        trimmed.contains("_t0_state == _t0_S0_wait_until) begin if (start) begin _t0_state <= _t0_S1_wait_until"),
+        "S0 should wait for start before entering the following wait-0+ fused state:\n{sv}"
+    );
+    assert!(
+        trimmed.contains("_t0_state == _t0_S1_wait_until) begin if (go) begin phase_r <= 8'd1")
+            && sv.contains("go && done"),
+        "following wait-0+/do-until should keep its Mealy gating after the fast start gate:\n{sv}"
+    );
+}
+
+#[test]
+fn test_thread_if_not_wait_until_fast_path_followed_by_for_loop() {
+    let source = r#"
+module M
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync, High>;
+  port start: in Bool;
+  port phase: out UInt<8>;
+  reg phase_r: UInt<8> reset rst => 8'd0;
+
+  thread on clk rising, rst high
+    if not start
+      wait until start;
+    end if
+    for i in 0..1
+      phase_r <= i.zext<8>();
+      wait 1 cycle;
+    end for
+    phase_r <= 8'd9;
+  end thread
+
+  comb
+    phase = phase_r;
+  end comb
+end module M
+"#;
+    let sv = compile_to_sv(source);
+    let trimmed: String = sv.split_whitespace().collect::<Vec<_>>().join(" ");
+
+    assert!(
+        trimmed.contains("_t0_state == _t0_S0_wait_until) begin if (start) begin _t0_loop_cnt_0 <="),
+        "for-loop counter init after fast gate should happen on the S0/start transition edge:\n{sv}"
+    );
+    assert!(
+        !trimmed.contains("_t0_state == _t0_S0_wait_until) begin if (start) begin phase_r <="),
+        "for-loop body should remain in later loop states, not collapse into the fast gate:\n{sv}"
+    );
+}
+
+#[test]
+fn test_thread_if_not_wait_until_fast_path_followed_by_lock() {
+    let source = r#"
+module M
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Async, Low>;
+  port start: in Bool;
+  port done: out Bool shared(or);
+
+  resource shared_lk: mutex<priority>;
+
+  thread on clk rising, rst low
+    if not start
+      wait until start;
+    end if
+    lock shared_lk
+      done = true;
+      wait 1 cycle;
+    end lock shared_lk
+  end thread
+end module M
+"#;
+    let sv = compile_to_sv(source);
+    let trimmed: String = sv.split_whitespace().collect::<Vec<_>>().join(" ");
+
+    assert!(
+        sv.contains("_t0_S0_wait_until") && sv.contains("_t0_S1_wait_until"),
+        "lock after fast gate should preserve the start wait before entering lock arbitration:\n{sv}"
+    );
+    assert!(
+        trimmed.contains("_t0_state == _t0_S0_wait_until) begin if (start) begin _t0_state <= _t0_S1_wait_until"),
+        "S0 should transition into the lock state only when start is true:\n{sv}"
+    );
+}
+
+#[test]
+fn test_thread_if_not_wait_until_fast_path_followed_by_fork_join() {
+    let source = r#"
+module M
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync, High>;
+  port start: in Bool;
+  port out_a: out Bool;
+  port out_b: out Bool;
+  reg a_r: Bool reset rst => false;
+  reg b_r: Bool reset rst => false;
+
+  thread on clk rising, rst high
+    if not start
+      wait until start;
+    end if
+    fork
+      a_r <= true;
+      wait 1 cycle;
+    and
+      b_r <= true;
+      wait 1 cycle;
+    join
+  end thread
+
+  comb
+    out_a = a_r;
+    out_b = b_r;
+  end comb
+end module M
+"#;
+    let sv = compile_to_sv(source);
+    let trimmed: String = sv.split_whitespace().collect::<Vec<_>>().join(" ");
+
+    assert!(
+        sv.contains("_t0_S0_wait_until") && sv.contains("_t0_S1_action"),
+        "fork/join after fast gate should preserve the start wait and enter fork product states after it:\n{sv}"
+    );
+    assert!(
+        trimmed.contains("_t0_state == _t0_S0_wait_until) begin if (start) begin _t0_state <= _t0_S1_action"),
+        "S0 should transition into fork/join lowering only when start is true:\n{sv}"
+    );
+    assert!(
+        !trimmed.contains("_t0_state == _t0_S0_wait_until) begin if (start) begin a_r <= 1'b1")
+            && !trimmed.contains("_t0_state == _t0_S0_wait_until) begin if (start) begin b_r <= 1'b1"),
+        "fork branch bodies should remain in fork product states, not collapse into S0:\n{sv}"
+    );
+}
+
+#[test]
 fn test_unpacked_wire_modifier_emits_unpacked_sv() {
     // Issue #267: `unpacked` modifier on internal wire/let declarations.
     // A `wire foo: unpacked Vec<T,N>` mirrors the existing `unpacked Vec`
@@ -15160,6 +15658,95 @@ fn test_sint_40_inst_output_wire_keeps_signed_storage() {
             "SInt<40> child output wire must not use unsigned storage; got:\n{out}");
     assert!(out.contains("score  = _let_score_wire"),
             "wrapper should forward the signed child output to its public port; got:\n{out}");
+}
+
+#[test]
+fn test_local_param_names_are_scoped_per_instantiated_module() {
+    let source = r#"
+        module MulA
+          local param A_WIDTH: const = 16;
+          local param B_WIDTH: const = 16;
+          local param PRODUCT_WIDTH: const = A_WIDTH + B_WIDTH;
+
+          port x: in SInt<A_WIDTH>;
+          port y: in SInt<B_WIDTH>;
+          port z: out SInt<PRODUCT_WIDTH>;
+
+          let product_raw: SInt<PRODUCT_WIDTH> = x * y;
+          let z = product_raw;
+        end module MulA
+
+        module MulB
+          local param A_WIDTH: const = 22;
+          local param B_WIDTH: const = 16;
+          local param PRODUCT_WIDTH: const = A_WIDTH + B_WIDTH;
+
+          port x: in SInt<A_WIDTH>;
+          port y: in SInt<B_WIDTH>;
+          port z: out SInt<PRODUCT_WIDTH>;
+
+          let product_raw: SInt<PRODUCT_WIDTH> = x * y;
+          let z = product_raw;
+        end module MulB
+
+        module Top
+          port a_x: in SInt<16>;
+          port a_y: in SInt<16>;
+          port b_x: in SInt<22>;
+          port b_y: in SInt<16>;
+          port a_z: out SInt<32>;
+          port b_z: out SInt<38>;
+
+          inst mul_a: MulA
+            x <- a_x;
+            y <- a_y;
+            z -> a_z;
+          end inst mul_a
+
+          inst mul_b: MulB
+            x <- b_x;
+            y <- b_y;
+            z -> b_z;
+          end inst mul_b
+        end module Top
+    "#;
+
+    let sv = compile_to_sv(source);
+    assert!(
+        sv.contains("output logic signed [37:0] b_z"),
+        "Top's MulB output should remain 38 bits after MulB's PRODUCT_WIDTH resolves locally:\n{sv}"
+    );
+}
+
+#[test]
+fn test_native_sim_does_not_emit_fields_for_param_inst_inputs() {
+    let source = r#"
+        module Child
+          param LEN_WIDTH: const = 8;
+          port len: in UInt<LEN_WIDTH>;
+          port out: out Bool;
+
+          comb
+            out = false;
+          end comb
+        end module Child
+
+        module Parent
+          param HEAD_DIM: const = 16;
+          port out: out Bool;
+
+          inst child: Child
+            len <- HEAD_DIM;
+            out -> out;
+          end inst child
+        end module Parent
+    "#;
+
+    let sim = compile_to_sim_h(source, false);
+    assert!(
+        !sim.contains("uint32_t HEAD_DIM;"),
+        "param-valued scalar inst inputs must not be emitted as simulator fields:\n{sim}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- fix the `if not X; wait until X; end if` thread fast-path lowering so following work can execute on the same wake edge
- make the new fast-path form equivalent to `wait 0+ cycle until X; do ... until Y;` when followed by `do ... until`
- add a regression matrix for fast-path lowering followed by comb/seq work, if/else, waits, do-until, for, lock, fork/join, and wait-0+
- fix local parameter resolution so identical local param names are scoped to the active construct
- fix native sim codegen so scalar param inst inputs are not emitted as nonexistent C++ fields

## Root Cause

The thread partitioner could recognize some wait-fusion patterns, but the canonical fast path:

```arch
if not X
  wait until X;
end if
```

was lowered through dispatch/action states or unguarded pending statements in several follow-on cases. That meant the fast path either inserted a one-cycle bubble, fired seq work while still waiting, or mishandled follow-on constructs such as `for` counter initialization.

Separately, local params were resolved by scanning constructs globally instead of consulting the current construct scope first, and native sim's scalar param inst inputs were being treated like real object fields.

## Validation

- `cargo check`
- `cargo test --test integration_test` (`514 passed`)
- from `fpt26-accel`: `make ARCH_HOME=../arch-com-latest attention-tile-engine-cosim`
  - `PASS: integrated AttentionTileEngine native cosim matched 4 scalar outputs`
