### PR TITLE
[codex] Prove fast-gate lock equivalence

### DIFF
--- a/src/elaborate.rs
+++ b/src/elaborate.rs
@@ -4789,6 +4789,29 @@ fn collect_single_state_thread_body(
     (comb_stmts, seq_stmts)
 }
 
+fn mealy_gate_first_lock_state(lock_states: &mut [ThreadFsmState], cond: &Expr, span: Span) {
+    if let Some(first) = lock_states.first_mut() {
+        let existing = std::mem::take(&mut first.comb_stmts);
+        first.comb_stmts.push(Stmt::IfElse(IfElse {
+            cond: cond.clone(),
+            then_stmts: existing,
+            else_stmts: Vec::new(),
+            unique: false,
+            span,
+        }));
+        if let Some(existing_cond) = first.transition_cond.take() {
+            first.transition_cond = Some(Expr::new(
+                ExprKind::Binary(
+                    BinOp::And,
+                    Box::new(cond.clone()),
+                    Box::new(existing_cond),
+                ),
+                span,
+            ));
+        }
+    }
+}
+
 /// Optimize the common micro-architecture shape:
 ///
 ///   wait until req;
@@ -5191,29 +5214,10 @@ fn partition_thread_body_impl(
                         // where the lock-arbitration's `if (grant)` wrapper
                         // also lives. Wrap its existing comb in `if (cond)`
                         // (req gate too — only request the lock when our
-                        // condition is true).
-                        if let Some(first) = lock_states.first_mut() {
-                            let existing = std::mem::take(&mut first.comb_stmts);
-                            first.comb_stmts.push(Stmt::IfElse(IfElseOf {
-                                cond: cond.clone(),
-                                then_stmts: existing,
-                                else_stmts: Vec::new(),
-                                unique: false,
-                                span: *sp,
-                            }));
-                            // AND cond into the transition guard so the
-                            // state stays in S0 if cond drops mid-flight.
-                            if let Some(existing_cond) = first.transition_cond.take() {
-                                first.transition_cond = Some(Expr::new(
-                                    ExprKind::Binary(
-                                        BinOp::And,
-                                        Box::new(cond.clone()),
-                                        Box::new(existing_cond),
-                                    ),
-                                    *sp,
-                                ));
-                            }
-                        }
+                        // condition is true), and AND cond into the transition
+                        // guard so the state stays in S0 if cond drops
+                        // mid-flight.
+                        mealy_gate_first_lock_state(&mut lock_states, cond, *sp);
                         states.extend(lock_states);
                         skip_next = true;
                     }
@@ -5533,6 +5537,26 @@ fn partition_thread_body_impl(
                     ));
                 }
                 // Flush pending statements
+                if cur_comb.is_empty()
+                    && cur_seq.is_empty()
+                    && fast_region.is_some()
+                    && matches!(body.first(), Some(ThreadStmt::DoUntil { .. }))
+                {
+                    let (fast_idx, wait_cond) = fast_region.take().unwrap();
+                    if fast_idx + 1 == states.len() {
+                        states.pop();
+                    }
+                    let mut lock_states = lower_thread_lock(
+                        &resource.name,
+                        body,
+                        *span,
+                        cnt_width,
+                        loop_id_gen,
+                    )?;
+                    mealy_gate_first_lock_state(&mut lock_states, &wait_cond, *span);
+                    states.extend(lock_states);
+                    continue;
+                }
                 flush_pending_thread_state(
                     &mut states,
                     &mut fast_region,

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -4697,6 +4697,70 @@ fn test_if_not_wait_until_do_until_matches_wait_0plus_lowering() {
 }
 
 #[test]
+fn test_if_not_wait_until_lock_do_until_matches_wait_0plus_lowering() {
+    let old_source = "
+        module M
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Async, Low>;
+          port req: in Bool;
+          port ack: in Bool;
+          port out_v: out Bool shared(or);
+          reg captured: Bool reset rst => false;
+
+          resource bus_lk: mutex<priority>;
+
+          thread T on clk rising, rst low
+            default comb
+              out_v = false;
+            end default
+            wait 0+ cycle until req;
+            lock bus_lk
+              do
+                out_v = true;
+                captured <= true;
+              until ack;
+            end lock bus_lk
+          end thread T
+        end module M
+    ";
+    let new_source = "
+        module M
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Async, Low>;
+          port req: in Bool;
+          port ack: in Bool;
+          port out_v: out Bool shared(or);
+          reg captured: Bool reset rst => false;
+
+          resource bus_lk: mutex<priority>;
+
+          thread T on clk rising, rst low
+            default comb
+              out_v = false;
+            end default
+            if not req
+              wait until req;
+            end if
+            lock bus_lk
+              do
+                out_v = true;
+                captured <= true;
+              until ack;
+            end lock bus_lk
+          end thread T
+        end module M
+    ";
+
+    let old_sv = compile_to_sv(old_source);
+    let new_sv = compile_to_sv(new_source);
+    assert_eq!(
+        old_sv, new_sv,
+        "`if not X; wait until X; end if; lock R do ... until Y; end lock R;` \
+         should lower exactly like `wait 0+ cycle until X; lock R do ... until Y; end lock R;`"
+    );
+}
+
+#[test]
 fn test_nested_for_in_thread_uses_distinct_loop_counters() {
     // Regression for issue #414: nested `for` loops in a thread used to
     // share a single `_loop_cnt` register, so the inner loop's increment


### PR DESCRIPTION
## Summary

- prove the canonical fast-gate form followed by `lock ... do ... until` lowers exactly like the legacy `wait 0+ cycle until ...; lock ... do ... until` form
- share the Mealy lock-state gating helper between the legacy `wait 0+` path and the new fast-gate path
- add a byte-for-byte generated SV equivalence regression test

## Why

PR #468 proved equivalence for the plain `do ... until` form, but the lock form still emitted an extra wait state before arbitration when written with the new syntax. That meant we could not safely convert all `wait 0+` lock handshakes to the canonical `if not X; wait until X; end if` form.

This PR closes that gap. The new form now fuses into the first lock state just like the old Mealy wait form.

## Validation

- `cargo check`
- `cargo test test_if_not_wait_until_lock_do_until_matches_wait_0plus_lowering --test integration_test`
- `cargo test --test integration_test` (`523 passed`)
- from `fpt26-accel`: `make ARCH_HOME=../arch-com-latest attention-tile-engine-cosim`
  - `PASS: integrated AttentionTileEngine native cosim matched 4 scalar outputs`
