### PR TITLE
feat: SFG Check 1 — multi-driver detection (closes #375)

### DIFF
--- a/ideas/2026-05-28-signal-flow-graph.md
+++ b/ideas/2026-05-28-signal-flow-graph.md
@@ -1,0 +1,199 @@
+# Enhancement: module-level signal flow graph for `arch check`
+
+**Date:** 2026-05-28
+**Status:** Proposal — needs team discussion before implementation
+**Related issues:** #375 (multi-driver), #245 (dead-skid comb-feedback lint),
+  #306 (thread wait-exit timing), #368 (coverage suppression), #383 (formal wire-to-let)
+
+---
+
+## Problem
+
+Three open issues stem from the same root gap: `arch check` has no unified model
+of *who drives what, and who reads what* across a module's constructs.
+
+| Issue | Symptom | Why the current checker misses it |
+|-------|---------|----------------------------------|
+| **#375** | Two `seq` blocks / two `thread` bodies / two `inst` outputs driving the same signal — passes silently | No per-signal write-set is maintained |
+| **#245** | Thread reads a comb function of its own outputs; silent wrong values during dead-skid cycles | No transitive comb-reachability from thread output set |
+| **#306** | `wait until cond; X <= Y;` fires `X` one cycle late | Lowering can't safely fold the assignment into the wait-exit arm without knowing whether the thread is the sole writer to `X` |
+
+Each could be fixed with a dedicated ad-hoc check. But they share a common
+need: a directed dataflow graph where nodes are signals and edges carry
+context (which `comb`/`seq`/`thread`/`inst` block produced this drive). Building
+that graph once, as a reusable compiler pass, makes all three tractable
+simultaneously and avoids tripling the maintenance surface as new constructs are
+added (e.g. `rule` from issue #379).
+
+---
+
+## Proposed signal flow graph (SFG)
+
+```rust
+/// One directed edge: a named signal drives another, in a specific block context.
+pub struct DriveEdge {
+    pub source: SignalId,
+    pub target: SignalId,
+    pub context: DriveContext,
+    pub span:    Span,
+}
+
+pub enum DriveContext {
+    CombBlock(usize),                              // index into module.body
+    SeqBlock(usize),
+    ThreadState { thread_idx: usize, state: u32 },
+    InstConn { inst: String, port: String },       // child-module output drives a wire
+    LetBinding,
+    RegDefault,                                    // reset value
+}
+
+pub struct SignalFlowGraph {
+    pub signals: IndexMap<SignalId, SignalInfo>,
+    pub drives:  Vec<DriveEdge>,
+}
+```
+
+### Build pass
+
+One traversal of `module.body` after elaboration:
+
+- **`CombBlock(b)`** — for each `lhs = rhs` statement: add `DriveEdge { CombBlock(i) }` from each
+  signal mentioned in `rhs` to `lhs`; also record a reverse "uses" edge (needed for check 2).
+- **`SeqBlock(b)`** — same, with `SeqBlock(i)` context.
+- **Thread-lowered states** — walk each synthesized FSM state; emit `ThreadState` edges.
+- **`InstConn`** — for each `.port(wire)`: input connections add `wire → port`; output connections add
+  `port → wire`.
+
+This mirrors what Verilator does when it builds its elaborated netlist, but at the ARCH IR level.
+
+---
+
+## Checks enabled
+
+### Check 1 — Multi-driver detection (fixes #375)
+
+For each signal, collect all `DriveEdge` records targeting it. If there are 2+
+edges from **distinct source identities** (different `CombBlock` indices, different
+`SeqBlock` indices, different `ThreadState.thread_idx`, different `InstConn.inst`
+names), report a multi-driver error with all contributing source spans.
+
+Exception: multiple edges from the *same* block (e.g. a `comb` block with a
+`default` and an `if`-override) are a single logical driver — no error.
+
+This directly covers the repro patterns in issue #375:
+
+- **C1–C2** Two `comb` blocks / two statements in one `comb` block driving the same wire → caught
+- **C3** Two unconditional `<=` to one `reg` in the same `seq` block → caught
+- **C7** Two `inst` outputs connected to the same `wire` → caught
+- **C-seq** Two separate `seq on clk rising` blocks writing the same reg → caught
+- **C-thread** Two `tlm_method` thread bodies writing the same reg → caught
+
+### Check 2 — Dead-skid comb-feedback lint (enables #245)
+
+For each thread `t`:
+
+1. `writes_t` = all signals with a `DriveEdge` from any `ThreadState { thread_idx: t.idx }`.
+2. **Comb-only reachability**: BFS through `CombBlock` edges only, starting from `writes_t`.
+3. `reads_t` = all signals referenced in read position within thread states.
+4. If `comb_reachable(writes_t) ∩ reads_t ≠ ∅`, emit a warning:
+
+   ```
+   warning: thread `T` reads `X`, which is a combinational function of `Y`
+            that `T` itself drives. During dead-skid cycles `T`'s outputs
+            fall to their default value; `X` may see a stale result.
+   
+   note: drive path: T writes Y → comb block → ... → X
+   note: workaround: read the upstream input directly instead of the
+         routed combinational output (see issue #245 for examples)
+   ```
+
+This surface is exactly the "most expensive single class of bug" in the
+arch-ibex Phase A work documented in #245.
+
+### Check 3 — Thread sole-writer query (unlocks exit-fold for #306)
+
+The fix for issue #306 (fold `wait until cond; X <= Y;` into a single
+`always_ff` arm rather than an extra state) is **safe only when the thread is
+the sole writer to `X`**. With the SFG, that becomes a simple query:
+
+```
+is_sole_writer(thread_idx, signal) =
+    drives.filter(|e| e.target == signal).all(|e| matches!(e.context, ThreadState { thread_idx }))
+```
+
+If true, the lowering pass can fold the assignment into the wait-exit guard.
+This turns an "unclear if it's safe to change semantics" problem into a
+mechanically checkable condition.
+
+### Future checks the SFG enables
+
+| Check | Uses | Benefit |
+|-------|------|---------|
+| Wire-to-let promotion for formal (#383) | Are all `DriveEdge`s into this `wire` from `CombBlock`? | Promotes wire to `let`, unblocking hierarchical formal v1 for lock-based designs |
+| Exhaustive-match coverage suppression (#368) | Is the `match` arm set a partition of the scrutinee type domain? | Emit `/* verilator coverage_off */` on compiler-generated default only |
+| Future UNOPTFLAT guidance | Detect comb cycles the designer intends (e.g. ring buffers) vs accidental ones | Suggest `/* verilator lint_off UNOPTFLAT */` at the right scope |
+
+---
+
+## Implementation plan
+
+Two PRs, in order:
+
+### PR A — SFG builder + multi-driver check (closes #375)
+
+| Sub-task | File(s) | Estimate |
+|----------|---------|----------|
+| Define `SignalId`, `SignalInfo`, `DriveEdge`, `DriveContext`, `SignalFlowGraph` | new `src/signal_flow.rs` | ~120 LoC |
+| Build pass: `CombBlock`, `SeqBlock`, `LetBinding`, `RegDefault` | `src/signal_flow.rs` | ~250 LoC |
+| Build pass: `InstConn` (output ports drive parent wires) | `src/signal_flow.rs` | ~100 LoC |
+| Build pass: thread-lowered states | `src/signal_flow.rs` | ~150 LoC |
+| Call `build_signal_flow_graph` from `arch check` | `src/typecheck.rs` | ~20 LoC |
+| Multi-driver check + error reporting | `src/typecheck.rs` | ~60 LoC |
+| Tests: 7 repros from #375 (C1–C7, C-seq, C-thread) | `tests/` | ~7 test cases |
+| **Total** | | **~700 LoC** |
+
+### PR B — Comb-feedback lint (enables #245)
+
+| Sub-task | File(s) | Estimate |
+|----------|---------|----------|
+| BFS comb-only reachability from thread write-set | `src/signal_flow.rs` | ~80 LoC |
+| Thread read-set collection | `src/signal_flow.rs` | ~50 LoC |
+| Intersection check + warning emission with path | `src/typecheck.rs` | ~80 LoC |
+| Tests: 2–3 repros from #245 + one arch-ibex-style example | `tests/` | ~3 test cases |
+| **Total** | | **~210 LoC** |
+
+The sole-writer query (Check 3) feeds the thread lowering fix for #306 and is a
+follow-up to PR A — no additional graph infrastructure needed.
+
+---
+
+## What this does not do
+
+- Does not change language semantics or the emitted SV.
+- Does not replace Verilator's net elaboration.
+- Does not require `arch build` to run — lint only.
+- Does not track dataflow *inside* expressions (signal-level granularity only).
+  Bit-level tracking is a separate, much larger effort.
+- Check 3 enables, but does not implement, the actual timing fix for #306. That
+  fix is a separate PR to the thread lowering pass.
+
+---
+
+## Rationale: unified graph vs. three ad-hoc passes
+
+Adding three independent ad-hoc passes would work, but:
+
+1. **Maintenance surface multiplies.** A new construct (`rule`, `tlm_method :
+   atomic`, pipeline blocks) needs to be handled in each pass separately. With a
+   shared SFG, only the build pass grows.
+2. **Incomplete coverage by construction.** Each ad-hoc check sees only the
+   constructs its author thought to enumerate. The SFG build pass iterates all
+   `ModuleBodyItem` variants exhaustively — a missing variant is a compile-time
+   pattern-match error in Rust, not a silent false-negative.
+3. **Reuse.** The formal wire-to-let promotion (#383) and coverage suppression
+   (#368) both want answers to "what drives this signal and how?" — the same
+   graph query, already built.
+
+The cost is ~700 LoC up front for the builder. The payoff is that #375, #245,
+and the prerequisite for #306 all land in two focused PRs instead of three
+independent feature slabs.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ pub mod learn;
 pub mod lexer;
 pub mod parser;
 pub mod resolve;
+pub mod signal_flow;
 pub mod sim_codegen;
 pub mod sim_credit_channel;
 pub mod type_alias;

--- a/src/signal_flow.rs
+++ b/src/signal_flow.rs
@@ -1,0 +1,267 @@
+use std::collections::HashMap;
+
+use crate::ast::*;
+use crate::diagnostics::{span_to_source_span, CompileError};
+use crate::lexer::Span;
+
+/// Returns true when `port_name` is a bus port (has `bus_info`) in the
+/// named module/fsm/pipeline found in `source`.  Used to skip bus-port
+/// output connections from the multi-driver check — both sides (initiator
+/// and target) of a bus wire have `ConnectDir::Output` connections but
+/// drive *disjoint* sets of flat signals, so no real conflict exists.
+fn is_bus_port_in_child(
+    module_name: &str,
+    port_name: &str,
+    source: &SourceFile,
+) -> bool {
+    source.items.iter().find_map(|item| match item {
+        Item::Module(m) if m.name.name == module_name => Some(m.ports.as_slice()),
+        Item::Fsm(f) if f.name.name == module_name => Some(f.ports.as_slice()),
+        _ => None,
+    })
+    .and_then(|ports| ports.iter().find(|p| p.name.name == port_name))
+    .map(|p| p.bus_info.is_some())
+    .unwrap_or(false)
+}
+
+/// One block-level drive record for a signal.
+pub struct DriveEntry {
+    pub span: Span,
+}
+
+/// Extracts the signal name from an LHS expression.
+///
+/// Bit-slices, part-selects, index accesses, and latency annotations are
+/// stripped (they all write to the same underlying register/wire).  Field
+/// accesses are *preserved* — `bus_wire.cmd` and `bus_wire.resp` are
+/// distinct flat signals in the generated SV, so driving both from
+/// different blocks is legal and must not trigger a multi-driver error.
+fn lhs_base_name(expr: &Expr) -> Option<String> {
+    match &expr.kind {
+        ExprKind::Ident(name) => Some(name.clone()),
+        ExprKind::BitSlice(base, _, _)
+        | ExprKind::PartSelect(base, _, _, _)
+        | ExprKind::Index(base, _)
+        | ExprKind::LatencyAt(base, _) => lhs_base_name(base),
+        ExprKind::FieldAccess(base, field) => {
+            lhs_base_name(base).map(|b| format!("{}.{}", b, field.name))
+        }
+        _ => None,
+    }
+}
+
+/// Collect every distinct signal name driven by `stmts`, storing the
+/// span of the first assignment to each name.
+fn collect_stmts(stmts: &[Stmt], out: &mut HashMap<String, Span>) {
+    for s in stmts {
+        collect_one_stmt(s, out);
+    }
+}
+
+fn collect_one_stmt(stmt: &Stmt, out: &mut HashMap<String, Span>) {
+    match stmt {
+        Stmt::Assign(a) => {
+            if let Some(name) = lhs_base_name(&a.target) {
+                out.entry(name).or_insert(a.span);
+            }
+        }
+        Stmt::IfElse(ie) => {
+            collect_stmts(&ie.then_stmts, out);
+            collect_stmts(&ie.else_stmts, out);
+        }
+        Stmt::Match(ms) => {
+            for arm in &ms.arms {
+                collect_stmts(&arm.body, out);
+            }
+        }
+        Stmt::For(fl) => collect_stmts(&fl.body, out),
+        Stmt::Init(ib) => collect_stmts(&ib.body, out),
+        Stmt::DoUntil { body, .. } => collect_stmts(body, out),
+        Stmt::Log(_) | Stmt::WaitUntil(_, _) => {}
+    }
+}
+
+#[allow(dead_code)]
+fn collect_thread_stmts(stmts: &[ThreadStmt], out: &mut HashMap<String, Span>) {
+    for s in stmts {
+        collect_one_thread_stmt(s, out);
+    }
+}
+
+#[allow(dead_code)]
+fn collect_one_thread_stmt(stmt: &ThreadStmt, out: &mut HashMap<String, Span>) {
+    match stmt {
+        ThreadStmt::CombAssign(a)
+        | ThreadStmt::SeqAssign(a)
+        | ThreadStmt::ForkTlmAssign(a) => {
+            if let Some(name) = lhs_base_name(&a.target) {
+                out.entry(name).or_insert(a.span);
+            }
+        }
+        ThreadStmt::IfElse(ie) => {
+            collect_thread_stmts(&ie.then_stmts, out);
+            collect_thread_stmts(&ie.else_stmts, out);
+        }
+        ThreadStmt::ForkJoin(branches, _) => {
+            for b in branches {
+                collect_thread_stmts(b, out);
+            }
+        }
+        ThreadStmt::For { body, .. } => collect_thread_stmts(body, out),
+        ThreadStmt::Lock { body, .. } => collect_thread_stmts(body, out),
+        ThreadStmt::DoUntil { body, .. } => collect_thread_stmts(body, out),
+        ThreadStmt::WaitUntil(_, _)
+        | ThreadStmt::WaitUntilMealy(_, _)
+        | ThreadStmt::WaitCycles(_, _)
+        | ThreadStmt::JoinAll(_)
+        | ThreadStmt::Log(_)
+        | ThreadStmt::Return(_, _) => {}
+    }
+}
+
+/// Build a per-signal driver map for `m`.
+///
+/// Each entry is the ordered list of block-level drivers for that signal.
+/// Multiple assignments *within the same block* collapse to a single
+/// `DriveEntry` — a `comb` block with a `default` + an `if`-override is
+/// one logical driver, not two.  Conflicts arise only between *different*
+/// blocks (e.g. two `inst` outputs, or two `comb` blocks).
+///
+/// `source` is used to look up child module port declarations so that
+/// bus-port connections (which are legitimately present on both the
+/// initiator and target sides of a bus wire) can be excluded.
+pub fn collect_module_drivers(m: &ModuleDecl, source: &SourceFile) -> HashMap<String, Vec<DriveEntry>> {
+    let mut drivers: HashMap<String, Vec<DriveEntry>> = HashMap::new();
+
+    // Bus and struct wires (TypeExpr::Named) are legitimately connected from
+    // multiple inst items — e.g. `wire link: Mem` is connected from both the
+    // initiator (`m -> link`) and the target (`s -> link`), each driving a
+    // disjoint subset of the bus fields.  Tracking these through inst output
+    // connections would produce false-positive multi-driver errors, so we
+    // build a skip-set of their names.
+    let named_wire_names: std::collections::HashSet<&str> = m
+        .body
+        .iter()
+        .filter_map(|item| {
+            if let ModuleBodyItem::WireDecl(w) = item {
+                if matches!(&w.ty, TypeExpr::Named(_)) {
+                    return Some(w.name.name.as_str());
+                }
+            }
+            None
+        })
+        .collect();
+
+    for item in &m.body {
+        // Collect signals driven by this block (one entry per signal —
+        // deduplicates repeated assignments inside the same block).
+        let block_targets: HashMap<String, Span> = match item {
+            ModuleBodyItem::CombBlock(b) => {
+                let mut t = HashMap::new();
+                collect_stmts(&b.stmts, &mut t);
+                t
+            }
+            // RegBlock (seq) multi-driver checking is deferred: the TLM
+            // target-thread inline lowering generates multiple RegBlocks that
+            // legitimately share register assignments (gated by state
+            // conditions), so a naive count-of-writers check produces false
+            // positives here.  The C-seq repro from issue #375 needs a
+            // follow-up PR that can distinguish user-written from
+            // compiler-generated blocks before this check is safe to enable.
+            ModuleBodyItem::RegBlock(_) => HashMap::new(),
+            // Latch blocks are similarly deferred.
+            ModuleBodyItem::LatchBlock(_) => HashMap::new(),
+            // Thread items are only present at typecheck time when threads
+            // have NOT been lowered (e.g. `--thread-sim parallel` mode).
+            // Two threads driving the same signal is intentional (the FSM
+            // combines them into one always_ff), so skip this context too.
+            ModuleBodyItem::Thread(_) => HashMap::new(),
+            ModuleBodyItem::Inst(inst) => {
+                let mut t = HashMap::new();
+                for conn in &inst.connections {
+                    if conn.direction == ConnectDir::Output {
+                        if let Some(name) = lhs_base_name(&conn.signal) {
+                            // Skip connections to explicitly-declared bus/struct
+                            // wires — these are driven by multiple inst items by
+                            // design.
+                            if named_wire_names.contains(name.as_str()) {
+                                continue;
+                            }
+                            // Skip connections where the child port is a bus
+                            // port — both initiator and target instances connect
+                            // their bus ports as Output to the same (possibly
+                            // implicit) bus wire, driving disjoint subsets of
+                            // its flat signals.
+                            if is_bus_port_in_child(
+                                &inst.module_name.name,
+                                &conn.port_name.name,
+                                source,
+                            ) {
+                                continue;
+                            }
+                            t.entry(name).or_insert(conn.span);
+                        }
+                    }
+                }
+                t
+            }
+            // The items below don't generate drive edges in the parent module.
+            ModuleBodyItem::RegDecl(_)
+            | ModuleBodyItem::WireDecl(_)
+            | ModuleBodyItem::PipeRegDecl(_)
+            | ModuleBodyItem::LetBinding(_)
+            | ModuleBodyItem::Generate(_)
+            | ModuleBodyItem::Resource(_)
+            | ModuleBodyItem::Assert(_)
+            | ModuleBodyItem::Function(_)
+            | ModuleBodyItem::TlmConnect(_)
+            | ModuleBodyItem::TypeAlias(_) => continue,
+        };
+
+        for (name, span) in block_targets {
+            drivers.entry(name).or_default().push(DriveEntry { span });
+        }
+    }
+
+    drivers
+}
+
+/// Check for multi-driver conflicts.
+///
+/// Returns one `CompileError::MultipleDrivers` per signal that is driven
+/// by two or more distinct blocks.  Signals annotated `shared(or)` or
+/// `shared(and)` on the enclosing module's port list are exempt — they are
+/// intentionally multi-driven with compiler-synthesized reduction logic.
+pub fn check_multi_driver(
+    m: &ModuleDecl,
+    drivers: &HashMap<String, Vec<DriveEntry>>,
+) -> Vec<CompileError> {
+    let shared: std::collections::HashSet<&str> = m
+        .ports
+        .iter()
+        .filter(|p| p.shared.is_some())
+        .map(|p| p.name.name.as_str())
+        .collect();
+
+    let mut errors: Vec<CompileError> = Vec::new();
+    for (name, entries) in drivers {
+        if entries.len() < 2 {
+            continue;
+        }
+        if shared.contains(name.as_str()) {
+            continue;
+        }
+        errors.push(CompileError::MultipleDrivers {
+            name: name.clone(),
+            span: span_to_source_span(entries[1].span),
+        });
+    }
+    errors.sort_by_key(|e| {
+        if let CompileError::MultipleDrivers { span, .. } = e {
+            span.offset()
+        } else {
+            0
+        }
+    });
+    errors
+}

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -1020,6 +1020,10 @@ impl<'a> TypeChecker<'a> {
             }
         }
 
+        // Multi-driver check (SFG Check 1, closes #375)
+        let sfg_drivers = crate::signal_flow::collect_module_drivers(m, self.source);
+        self.errors.extend(crate::signal_flow::check_multi_driver(m, &sfg_drivers));
+
         // Check all output ports are driven
         for p in &m.ports {
             if let Some(ref bi) = p.bus_info {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -17652,3 +17652,205 @@ fn test_nic400_width_adapter_wrap_unaligned_addr_is_rejected_by_sva() {
         "ASSERTION FAILED: Nic400WidthAdapter.ar_wrap_addr_aligned_widthadapter",
     );
 }
+
+// ── Multi-driver detection (SFG Check 1, issue #375) ─────────────────────────
+
+/// Run through all compile stages up to typecheck and return any errors.
+fn typecheck_source(source: &str) -> Result<(), Vec<arch::diagnostics::CompileError>> {
+    let tokens = lexer::tokenize(source).expect("lex");
+    let mut parser = Parser::new(tokens, source);
+    let ast = parser.parse_source_file().expect("parse");
+    let ast = elaborate::elaborate(ast).expect("elaborate");
+    let ast = elaborate::lower_tlm_target_threads(ast).expect("tlm_target");
+    let ast = elaborate::lower_tlm_initiator_calls(ast).expect("tlm_initiator");
+    let ast = elaborate::lower_threads_with_opts(ast, &elaborate::ThreadLowerOpts::default())
+        .expect("lower_threads");
+    let ast = elaborate::lower_pipe_reg_ports(ast).expect("lower_pipe_reg");
+    let ast = elaborate::lower_credit_channel_dispatch(ast).expect("credit_channel");
+    let symbols = resolve::resolve(&ast).expect("resolve");
+    let checker = TypeChecker::new(&symbols, &ast);
+    checker.check().map(|_| ())
+}
+
+fn has_multi_driver_error(source: &str, signal: &str) -> bool {
+    match typecheck_source(source) {
+        Err(errs) => errs.iter().any(|e| {
+            matches!(e, arch::diagnostics::CompileError::MultipleDrivers { name, .. }
+                if name == signal)
+        }),
+        Ok(_) => false,
+    }
+}
+
+/// Repro C2: two separate `comb` blocks driving the same output wire.
+/// Each `comb` becomes a distinct `always_comb` in SV — a genuine multi-driver.
+#[test]
+fn test_multi_driver_two_comb_blocks_same_output() {
+    let source = r#"
+module TwoCombBlocks
+  port a: in Bool;
+  port out: out Bool;
+  comb
+    out = a;
+  end comb
+  comb
+    out = false;
+  end comb
+end module TwoCombBlocks
+"#;
+    assert!(
+        has_multi_driver_error(source, "out"),
+        "expected MultipleDrivers for `out` (two comb blocks)"
+    );
+}
+
+/// Within a single `comb` block, multiple conditional writes to the same
+/// wire (default + if-override) are ONE logical driver — no error.
+#[test]
+fn test_multi_driver_single_comb_block_conditional_no_error() {
+    let source = r#"
+module SingleCombConditional
+  port sel: in Bool;
+  port out: out Bool;
+  comb
+    out = false;
+    if sel
+      out = true;
+    end if
+  end comb
+end module SingleCombConditional
+"#;
+    assert!(
+        typecheck_source(source).is_ok(),
+        "single comb block with conditional write should NOT be a multi-driver"
+    );
+}
+
+/// Repro C7: two separate `inst` scalar outputs connected to the same parent wire.
+/// Both child instances drive `result` — a genuine multi-driver.
+#[test]
+fn test_multi_driver_two_inst_scalar_outputs_same_wire() {
+    let source = r#"
+module DriverA
+  port out_val: out Bool;
+  comb
+    out_val = true;
+  end comb
+end module DriverA
+
+module DriverB
+  port out_val: out Bool;
+  comb
+    out_val = false;
+  end comb
+end module DriverB
+
+module ParentC7
+  port result: out Bool;
+  inst a: DriverA
+    out_val -> result;
+  end inst a
+  inst b: DriverB
+    out_val -> result;
+  end inst b
+end module ParentC7
+"#;
+    assert!(
+        has_multi_driver_error(source, "result"),
+        "expected MultipleDrivers for `result` (two inst scalar outputs)"
+    );
+}
+
+/// A `comb` block and an `inst` scalar output both driving the same wire.
+#[test]
+fn test_multi_driver_comb_and_inst_same_wire() {
+    let source = r#"
+module Src
+  port val: out Bool;
+  comb
+    val = true;
+  end comb
+end module Src
+
+module ParentCombInst
+  port out: out Bool;
+  comb
+    out = false;
+  end comb
+  inst s: Src
+    val -> out;
+  end inst s
+end module ParentCombInst
+"#;
+    assert!(
+        has_multi_driver_error(source, "out"),
+        "expected MultipleDrivers for `out` (comb block + inst output)"
+    );
+}
+
+/// `shared(or)` ports are intentionally multi-driven and must be exempt.
+#[test]
+fn test_multi_driver_shared_or_port_exempt() {
+    let source = r#"
+module SharedOrPort
+  port a: in Bool;
+  port b: in Bool;
+  port out: out Bool shared(or);
+  comb
+    out = a;
+  end comb
+  comb
+    out = b;
+  end comb
+end module SharedOrPort
+"#;
+    // shared(or) ports are exempt — typecheck should succeed
+    assert!(
+        typecheck_source(source).is_ok(),
+        "shared(or) port driven from two comb blocks should NOT be a multi-driver error"
+    );
+}
+
+/// Bus-typed wires connected from both initiator and target insts must NOT
+/// trigger multi-driver.  This is the canonical TLM bus wire pattern.
+#[test]
+fn test_multi_driver_bus_wire_two_inst_connections_no_error() {
+    let source = r#"
+bus Msg
+  data: out UInt<8>;
+  ack:  in  Bool;
+end bus Msg
+
+module Sender
+  port m: initiator Msg;
+  comb
+    m.data = 8'h42;
+  end comb
+end module Sender
+
+module Receiver
+  port m: target Msg;
+  port ack_out: out Bool;
+  comb
+    m.ack   = true;
+    ack_out = m.data[0];
+  end comb
+end module Receiver
+
+module BusWireTop
+  port ack_out: out Bool;
+  wire link: Msg;
+  inst tx: Sender
+    m -> link;
+  end inst tx
+  inst rx: Receiver
+    m    -> link;
+    ack_out -> ack_out;
+  end inst rx
+end module BusWireTop
+"#;
+    assert!(
+        typecheck_source(source).is_ok(),
+        "bus wire connected from initiator + target insts must NOT be a multi-driver error"
+    );
+}


### PR DESCRIPTION
## Summary

First PR of the Signal Flow Graph proposal (`ideas/2026-05-28-signal-flow-graph.md`).
Implements Check 1: per-module multi-driver detection, closing #375.

A new `src/signal_flow.rs` module exposes:
- `collect_module_drivers(m, source)` — builds a per-signal map of distinct block-level drivers (assignments within one block collapse to a single driver entry, so a `comb` block with `default` + `if`-override stays one logical driver).
- `check_multi_driver(m, drivers)` — emits `CompileError::MultipleDrivers` for signals driven by 2+ distinct constructs.

Hooked into `TypeChecker::check_module` right before the existing undriven-output pass.

## What this catches

- Two `comb` blocks driving the same wire/output (issue #375 C2)
- A `comb` block and an `inst` scalar output both driving the same wire
- Two `inst` scalar outputs connected to the same parent wire (issue #375 C7)

## Exemptions handled correctly

- Multiple assignments within the *same* block (default + if-override pattern)
- Bus-typed wires (`wire w: BusName`) connected from initiator + target inst items — both sides drive disjoint flat signals
- Implicit bus wires (no explicit `wire` declaration) where the child port is a bus port — detected via source-file port lookup
- `shared(or)` / `shared(and)` ports — intentionally multi-driven with reduction logic

## Deferred to follow-up PRs

- **`RegBlock` (seq) multi-driver:** the TLM indexed-target inline lowering generates multiple `RegBlock` items that share register assignments via state-gating. A naive check fires false positives on valid compiler-generated code. A future PR needs to distinguish user-written blocks from lowering-generated ones before this is safe to enable.
- **`Thread` multi-driver in `--thread-sim parallel` mode:** threads combine into a single FSM in normal lowering, so two threads driving the same reg is intentional in this surviving form.
- **SFG Check 2** (comb-feedback lint for #245) and **Check 3** (sole-writer query for #306) are independent follow-up PRs as described in the proposal.

## Test plan

- [x] 6 new integration tests in `tests/integration_test.rs`:
  - `test_multi_driver_two_comb_blocks_same_output` — catches C2
  - `test_multi_driver_single_comb_block_conditional_no_error` — exemption
  - `test_multi_driver_two_inst_scalar_outputs_same_wire` — catches C7
  - `test_multi_driver_comb_and_inst_same_wire` — catches mixed case
  - `test_multi_driver_shared_or_port_exempt` — `shared(or)` exemption
  - `test_multi_driver_bus_wire_two_inst_connections_no_error` — bus-wire exemption
- [x] Full test suite: 507 passed, 0 failed
- [x] No new clippy warnings

https://claude.ai/code/session_01Hi3GDE4BoqWdnTkcidswe6

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hi3GDE4BoqWdnTkcidswe6)_