### PR TITLE
[codex] Retire wait 0+ thread syntax

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -689,16 +689,6 @@ pub enum ThreadStmt {
     /// Lower bound on wait time = 1 cycle even if `cond` is already
     /// true when entering this stmt.
     WaitUntil(Expr, Span),
-    /// `wait 0+ cycle until cond;` — Mealy-style wait. Must be
-    /// immediately followed by `do ... until ...;`. The lowering fuses
-    /// the two into a single state whose comb drives are gated by the
-    /// mealy condition, and whose state-transition guard is the
-    /// conjunction `(wait cond) && (do-until exit cond)`. Result: when
-    /// both conditions are true on the same posedge, the thread
-    /// progresses with zero added cycles — eliminating the 1-cycle
-    /// "I'm in the entry wait state with defaults active" bubble that
-    /// the standard `wait until` form imposes.
-    WaitUntilMealy(Expr, Span),
     /// `wait N cycle;`
     WaitCycles(Expr, Span),
     /// `if cond ... elsif ... else ... end if`

--- a/src/elaborate.rs
+++ b/src/elaborate.rs
@@ -1530,9 +1530,6 @@ fn subst_thread_stmt(stmt: &ThreadStmt, var: &str, val: i64) -> ThreadStmt {
         ThreadStmt::WaitUntil(cond, sp) => {
             ThreadStmt::WaitUntil(subst_expr_names(cond.clone(), var, val), *sp)
         }
-        ThreadStmt::WaitUntilMealy(cond, sp) => {
-            ThreadStmt::WaitUntilMealy(subst_expr_names(cond.clone(), var, val), *sp)
-        }
         ThreadStmt::WaitCycles(n, sp) => {
             ThreadStmt::WaitCycles(subst_expr_names(n.clone(), var, val), *sp)
         }
@@ -1588,9 +1585,6 @@ fn fold_literal_bit_slices_thread_stmt(stmt: ThreadStmt) -> ThreadStmt {
         }),
         ThreadStmt::WaitUntil(cond, sp) => {
             ThreadStmt::WaitUntil(fold_literal_bit_slices_expr(cond), sp)
-        }
-        ThreadStmt::WaitUntilMealy(cond, sp) => {
-            ThreadStmt::WaitUntilMealy(fold_literal_bit_slices_expr(cond), sp)
         }
         ThreadStmt::WaitCycles(n, sp) => {
             ThreadStmt::WaitCycles(fold_literal_bit_slices_expr(n), sp)
@@ -4007,7 +4001,7 @@ fn collect_thread_signals(body: &[ThreadStmt]) -> (HashSet<String>, HashSet<Stri
                     collect_expr_reads(&ra.value, all_read);
                     collect_expr_index_reads(&ra.target, all_read);
                 }
-                ThreadStmt::WaitUntil(cond, _) | ThreadStmt::WaitUntilMealy(cond, _) => {
+                ThreadStmt::WaitUntil(cond, _) => {
                     collect_expr_reads(cond, all_read);
                 }
                 ThreadStmt::WaitCycles(_, _) => {}
@@ -4114,7 +4108,7 @@ fn collect_thread_bus_reads(body: &[ThreadStmt], bus_port_map: &HashMap<String, 
                 collect_expr_bus_reads(&a.value, bus_port_map, out);
                 collect_expr_bus_reads(&a.target, bus_port_map, out);
             }
-            ThreadStmt::WaitUntil(c, _) | ThreadStmt::WaitUntilMealy(c, _) => collect_expr_bus_reads(c, bus_port_map, out),
+            ThreadStmt::WaitUntil(c, _) => collect_expr_bus_reads(c, bus_port_map, out),
             ThreadStmt::IfElse(ie) => {
                 collect_expr_bus_reads(&ie.cond, bus_port_map, out);
                 collect_thread_bus_reads(&ie.then_stmts, bus_port_map, out);
@@ -4943,9 +4937,8 @@ fn partition_thread_body_with_loop_ids(
 /// register and proper back-edge transitions).
 ///
 /// Bodies are restricted to `CombAssign`, `SeqAssign`, `IfElse`, and `Log`.
-/// Any other `ThreadStmt` variant — `Lock`, `For`, `WaitUntil`,
-/// `WaitUntilMealy`, `WaitCycles`, `ForkJoin`, nested `DoUntil`, `Return`,
-/// `ForkTlmAssign`, `JoinAll` — cannot be lowered as a hold-state and was
+/// Any other `ThreadStmt` variant — `Lock`, `For`, `WaitUntil`, `WaitCycles`,
+/// `ForkJoin`, nested `DoUntil`, `Return`, `ForkTlmAssign`, `JoinAll` — cannot be lowered as a hold-state and was
 /// historically silently dropped, producing FSMs that miscompiled to an
 /// infinite-loop (see issue #410). Reject those constructs with a precise
 /// error pointing at the offending inner statement.
@@ -4971,7 +4964,6 @@ fn disallow_nested_control_in_do_until(
             ThreadStmt::Lock { .. } => Some("`lock`"),
             ThreadStmt::For { .. } => Some("`for`"),
             ThreadStmt::WaitUntil(..) => Some("`wait until`"),
-            ThreadStmt::WaitUntilMealy(..) => Some("`wait 0+ cycle until`"),
             ThreadStmt::WaitCycles(..) => Some("`wait N cycle`"),
             ThreadStmt::ForkJoin(..) => Some("`fork`/`join`"),
             ThreadStmt::DoUntil { .. } => Some("a nested `do ... until`"),
@@ -5019,14 +5011,7 @@ fn partition_thread_body_impl(
     let mut cur_seq: Vec<Stmt> = Vec::new();
     let mut fast_region: Option<(usize, Expr)> = None;
     let mut no_trailing_merge_from: Option<usize> = None;
-    // Set when the previous iteration was a `wait 0+ cycle until ...;` that
-    // consumed the next `do ... until ...;` as part of its Mealy fusion;
-    // skips one iteration of this loop to avoid emitting the do-body as a
-    // separate state.
-    let mut skip_next = false;
-
     for (stmt_idx, stmt) in body.iter().enumerate() {
-        if skip_next { skip_next = false; continue; }
         match stmt {
             ThreadStmt::CombAssign(ca) => {
                 cur_comb.push(Stmt::Assign(ca.clone()));
@@ -5079,155 +5064,6 @@ fn partition_thread_body_impl(
                         terminal_return: None,
                 });
                 let _ = sp; // span retained for parity with the prior arm
-            }
-            ThreadStmt::WaitUntilMealy(cond, sp) => {
-                // Fuse with either:
-                //   (a) `do BODY until exit;`                   — no lock
-                //   (b) `lock R do BODY until exit end lock R;` — with lock
-                // into a single Mealy-gated state. Body drives are gated by
-                // `cond`; for the lock variant, the existing lock-lowering's
-                // `if (grant) { ... }` wrapper is layered on top so the
-                // outer gate is `cond` and the inner gate is `grant`.
-                // Transition out: `cond && exit` (and `&& grant` in the lock
-                // variant — applied by the lock lowering itself).
-                let next = body.get(stmt_idx + 1);
-                // Helper closure: take a Vec<ThreadStmt> body and a Y cond,
-                // produce (gated_comb, gated_seq, fused_transition_cond).
-                fn build_fused(
-                    cond: &Expr,
-                    sp: Span,
-                    do_body: &[ThreadStmt],
-                    exit_cond: &Expr,
-                ) -> (Vec<Stmt>, Vec<Stmt>, Expr) {
-                    let mut do_comb: Vec<Stmt> = Vec::new();
-                    let mut do_seq: Vec<Stmt> = Vec::new();
-                    for s in do_body {
-                        match s {
-                            ThreadStmt::CombAssign(ca) => do_comb.push(Stmt::Assign(ca.clone())),
-                            ThreadStmt::SeqAssign(ra) => do_seq.push(Stmt::Assign(ra.clone())),
-                            ThreadStmt::IfElse(ie) => {
-                                let (comb_if, seq_if) = thread_if_to_fsm_stmts(ie);
-                                if let Some(c) = comb_if { do_comb.push(c); }
-                                if let Some(s) = seq_if { do_seq.push(s); }
-                            }
-                            ThreadStmt::Log(l) => do_seq.push(Stmt::Log(l.clone())),
-                            _ => {
-                                // Unreachable: the caller (Mealy-fusion path)
-                                // routes through partition_thread_body's
-                                // `DoUntil` arm, which calls
-                                // `disallow_nested_control_in_do_until`
-                                // before reaching here.
-                                unreachable!("Mealy-fused do..until body contained an unexpected statement");
-                            }
-                        }
-                    }
-                    let gated_comb = if do_comb.is_empty() {
-                        Vec::new()
-                    } else {
-                        vec![Stmt::IfElse(IfElseOf {
-                            cond: cond.clone(),
-                            then_stmts: do_comb,
-                            else_stmts: Vec::new(),
-                            unique: false,
-                            span: sp,
-                        })]
-                    };
-                    // Issue #412: seq assigns from the do-body must also be
-                    // gated by the Mealy wake condition. Without this gate the
-                    // FSM is sitting in S0 holding for `cond`, but every cycle
-                    // it fires the do-body's reg writes — turning what the
-                    // user wrote as "pulse start_r when req asserts" into
-                    // "drive start_r every cycle until req asserts". The
-                    // comb stmts above are already gated; mirror that here.
-                    let gated_seq = if do_seq.is_empty() {
-                        Vec::new()
-                    } else {
-                        vec![Stmt::IfElse(IfElseOf {
-                            cond: cond.clone(),
-                            then_stmts: do_seq,
-                            else_stmts: Vec::new(),
-                            unique: false,
-                            span: sp,
-                        })]
-                    };
-                    let fused_cond = Expr::new(
-                        ExprKind::Binary(
-                            BinOp::And,
-                            Box::new(cond.clone()),
-                            Box::new(exit_cond.clone()),
-                        ),
-                        sp,
-                    );
-                    (gated_comb, gated_seq, fused_cond)
-                }
-
-                // Flush any pending assigns first.
-                let mut flush = || {
-                    flush_pending_thread_state(
-                        &mut states,
-                        &mut fast_region,
-                        &mut cur_comb,
-                        &mut cur_seq,
-                        *sp,
-                    );
-                };
-
-                match next {
-                    // Form (a): direct do/until.
-                    Some(ThreadStmt::DoUntil { body: do_body, cond: exit_cond, span: do_sp }) => {
-                        // Same nested-control restriction as the standalone
-                        // `DoUntil` arm of `partition_thread_body_impl`: the
-                        // Mealy-fused state is still a single-state hold,
-                        // and any nested wait/lock/for/etc. inside the do-body
-                        // would be silently dropped by `build_fused` (issue
-                        // #410).
-                        disallow_nested_control_in_do_until(do_body, *do_sp)?;
-                        flush();
-                        let (gated_comb, do_seq, fused_cond) = build_fused(cond, *sp, do_body, exit_cond);
-                        states.push(ThreadFsmState {
-                            comb_stmts: gated_comb,
-                            seq_stmts: do_seq,
-                            transition_cond: Some(fused_cond),
-                            wait_cycles: None,
-                            multi_transitions: Vec::new(),
-                            terminal_return: None,
-                        });
-                        skip_next = true;
-                    }
-                    // Form (b): lock R { do BODY until Y } — fuse Mealy +
-                    // lock + do. Reuse the existing lock lowering for the
-                    // inner do/until, then wrap its first state's body
-                    // drives in `if (cond)` and AND cond into its transition.
-                    Some(ThreadStmt::Lock { resource, body: lock_body, span: lock_sp }) => {
-                        // Inside the lock we expect a single DoUntil — the
-                        // canonical AXI handshake shape.
-                        let Some(ThreadStmt::DoUntil { .. }) = lock_body.first() else {
-                            return Err(CompileError::general(
-                                "`wait 0+ cycle until <cond>; lock R; ...` requires the lock body to start with `do ... until <cond>;` for Mealy fusion",
-                                *sp,
-                            ));
-                        };
-                        flush();
-                        // Lower the lock+do into states first.
-                        let mut lock_states = lower_thread_lock(&resource.name, lock_body, *lock_sp, cnt_width, loop_id_gen)?;
-                        // Layer Mealy gating on the FIRST state — that's
-                        // where the lock-arbitration's `if (grant)` wrapper
-                        // also lives. Wrap its existing comb in `if (cond)`
-                        // (req gate too — only request the lock when our
-                        // condition is true), and AND cond into the transition
-                        // guard so the state stays in S0 if cond drops
-                        // mid-flight.
-                        mealy_gate_first_lock_state(&mut lock_states, cond, *sp);
-                        states.extend(lock_states);
-                        skip_next = true;
-                    }
-                    _ => {
-                        return Err(CompileError::general(
-                            "`wait 0+ cycle until <cond>;` must be immediately followed by `do ... until <cond>;` or `lock R ... do ... until ... end lock R;` (single-state Mealy fusion)",
-                            *sp,
-                        ));
-                    }
-                }
             }
             ThreadStmt::WaitCycles(count, _) => {
                 // Same: pure boundary, flush all pending assigns
@@ -6427,9 +6263,6 @@ fn rewrite_loop_var(stmt: &ThreadStmt, var: &str, replacement: &str) -> ThreadSt
         ThreadStmt::JoinAll(sp) => ThreadStmt::JoinAll(*sp),
         ThreadStmt::WaitUntil(cond, sp) => {
             ThreadStmt::WaitUntil(rewrite_var_expr(cond.clone(), var, replacement), *sp)
-        }
-        ThreadStmt::WaitUntilMealy(cond, sp) => {
-            ThreadStmt::WaitUntilMealy(rewrite_var_expr(cond.clone(), var, replacement), *sp)
         }
         ThreadStmt::WaitCycles(n, sp) => {
             ThreadStmt::WaitCycles(rewrite_var_expr(n.clone(), var, replacement), *sp)
@@ -8376,7 +8209,6 @@ fn thread_stmt_span(stmt: &ThreadStmt) -> Span {
     match stmt {
         ThreadStmt::SeqAssign(a) | ThreadStmt::CombAssign(a) | ThreadStmt::ForkTlmAssign(a) => a.span,
         ThreadStmt::WaitUntil(_, sp)
-        | ThreadStmt::WaitUntilMealy(_, sp)
         | ThreadStmt::WaitCycles(_, sp)
         | ThreadStmt::ForkJoin(_, sp)
         | ThreadStmt::JoinAll(sp)

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2211,11 +2211,18 @@ impl Parser {
                 let semi_span = self.expect(TokenKind::Semi)?.span;
                 return Ok(ThreadStmt::WaitUntil(cond, wait_start.merge(semi_span)));
             }
-            // `wait 0+ cycle until expr;` — Mealy-style (≥0 cycle). `0+` is
-            // a single user-facing token, so the lexed `0` and `+` must be
-            // textually adjacent (zero source distance). `wait 0 + cycle`
-            // is NOT accepted — the form is `0+`, not the binary expression
-            // `0 plus cycle`.
+            // Retired syntax: `wait 0+ cycle until expr;`.
+            //
+            // `0+` used to request Mealy-style wait fusion. The canonical
+            // spelling is now:
+            //
+            //   if not <expr>
+            //     wait until <expr>;
+            //   end if
+            //
+            // Keep a targeted parse error for the old adjacent-token spelling
+            // so users get a migration hint instead of a confusing `wait N
+            // cycle` parse failure.
             let saved_pos = self.pos;
             if matches!(self.peek_kind(), Some(TokenKind::DecLiteral(s)) if s == "0") {
                 let zero_end = self.tokens[self.pos].span.end;
@@ -2223,12 +2230,11 @@ impl Parser {
                 let plus_adjacent = self.check(TokenKind::Plus)
                     && self.tokens[self.pos].span.start == zero_end;
                 if plus_adjacent {
-                    self.advance(); // consume +
-                    self.expect_contextual("cycle")?;
-                    self.expect_contextual("until")?;
-                    let cond = self.parse_expr()?;
-                    let semi_span = self.expect(TokenKind::Semi)?.span;
-                    return Ok(ThreadStmt::WaitUntilMealy(cond, wait_start.merge(semi_span)));
+                    let plus_span = self.advance().span; // consume +
+                    return Err(CompileError::general(
+                        "`wait 0+ cycle until <cond>;` has been retired; use `if not <cond> ... wait until <cond>; ... end if` for zero-or-more-cycle fast-path waiting",
+                        wait_start.merge(plus_span),
+                    ));
                 }
                 // Not the Mealy form — backtrack so the numeric `wait N cycle`
                 // path below handles the `0` we already consumed.

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -4570,10 +4570,10 @@ fn test_vec_of_bus_port_typecheck_drives_all_indexed_outputs() {
 }
 
 #[test]
-fn test_wait_0plus_cycle_until_mealy_fusion() {
-    // `wait 0+ cycle until X;` immediately followed by `do BODY until Y;`
-    // fuses into a single Mealy-style state. The SV codegen output for
-    // this design should:
+fn test_fast_gate_do_until_mealy_fusion() {
+    // `if not X; wait until X; end if` immediately followed by
+    // `do BODY until Y;` fuses into a single Mealy-style state. The SV
+    // codegen output for this design should:
     //   * NOT emit a separate entry-wait state.
     //   * Gate the body's comb drives by `X` (`if (X) { ... }`).
     //   * Transition with `X && Y` as the guard.
@@ -4599,7 +4599,9 @@ fn test_wait_0plus_cycle_until_mealy_fusion() {
               b.d = 0;
               m_rdy = false;
             end default
-            wait 0+ cycle until m_val;
+            if not (m_val)
+              wait until m_val;
+            end if
             do
               b.v   = true;
               b.d   = m_dat;
@@ -4623,8 +4625,8 @@ fn test_wait_0plus_cycle_until_mealy_fusion() {
 }
 
 #[test]
-fn test_if_not_wait_until_do_until_matches_wait_0plus_lowering() {
-    let old_source = "
+fn test_fast_gate_do_until_paren_and_bare_not_lower_the_same() {
+    let paren_source = "
         bus B
           v: out Bool;
           d: out UInt<8>;
@@ -4644,7 +4646,9 @@ fn test_if_not_wait_until_do_until_matches_wait_0plus_lowering() {
               b.d = 0;
               m_rdy = false;
             end default
-            wait 0+ cycle until m_val;
+            if not (m_val)
+              wait until m_val;
+            end if
             do
               b.v   = true;
               b.d   = m_dat;
@@ -4654,7 +4658,7 @@ fn test_if_not_wait_until_do_until_matches_wait_0plus_lowering() {
           end thread T
         end module Drv
     ";
-    let new_source = "
+    let bare_source = "
         bus B
           v: out Bool;
           d: out UInt<8>;
@@ -4687,18 +4691,18 @@ fn test_if_not_wait_until_do_until_matches_wait_0plus_lowering() {
         end module Drv
     ";
 
-    let old_sv = compile_to_sv(old_source);
-    let new_sv = compile_to_sv(new_source);
+    let paren_sv = compile_to_sv(paren_source);
+    let bare_sv = compile_to_sv(bare_source);
     assert_eq!(
-        old_sv, new_sv,
-        "`if not X; wait until X; end if; do ... until Y;` should lower exactly like \
-         `wait 0+ cycle until X; do ... until Y;`"
+        paren_sv, bare_sv,
+        "`if not (X); wait until X; end if` should lower like \
+         `if not X; wait until X; end if` before a `do ... until` body"
     );
 }
 
 #[test]
-fn test_if_not_wait_until_lock_do_until_matches_wait_0plus_lowering() {
-    let old_source = "
+fn test_fast_gate_lock_do_until_paren_and_bare_not_lower_the_same() {
+    let paren_source = "
         module M
           port clk: in Clock<SysDomain>;
           port rst: in Reset<Async, Low>;
@@ -4713,7 +4717,9 @@ fn test_if_not_wait_until_lock_do_until_matches_wait_0plus_lowering() {
             default comb
               out_v = false;
             end default
-            wait 0+ cycle until req;
+            if not (req)
+              wait until req;
+            end if
             lock bus_lk
               do
                 out_v = true;
@@ -4723,7 +4729,7 @@ fn test_if_not_wait_until_lock_do_until_matches_wait_0plus_lowering() {
           end thread T
         end module M
     ";
-    let new_source = "
+    let bare_source = "
         module M
           port clk: in Clock<SysDomain>;
           port rst: in Reset<Async, Low>;
@@ -4751,12 +4757,12 @@ fn test_if_not_wait_until_lock_do_until_matches_wait_0plus_lowering() {
         end module M
     ";
 
-    let old_sv = compile_to_sv(old_source);
-    let new_sv = compile_to_sv(new_source);
+    let paren_sv = compile_to_sv(paren_source);
+    let bare_sv = compile_to_sv(bare_source);
     assert_eq!(
-        old_sv, new_sv,
-        "`if not X; wait until X; end if; lock R do ... until Y; end lock R;` \
-         should lower exactly like `wait 0+ cycle until X; lock R do ... until Y; end lock R;`"
+        paren_sv, bare_sv,
+        "`if not (X); wait until X; end if` should lower like \
+         `if not X; wait until X; end if` before a `lock R do ... until` body"
     );
 }
 
@@ -5176,9 +5182,11 @@ fn test_fsm_param_vec_scalar_widths_resolve_through_sibling_helpers() {
 }
 
 #[test]
-fn test_wait_0plus_cycle_until_mealy_fusion_gates_seq_assigns() {
+fn test_fast_gate_do_until_mealy_fusion_gates_seq_assigns() {
     // Regression for issue #412: the Mealy-fusion lowering for
-    //   wait 0+ cycle until X;
+    //   if not X
+    //     wait until X;
+    //   end if
     //   do
     //     <seq>r <= value;
     //   until Y;
@@ -5198,7 +5206,9 @@ fn test_wait_0plus_cycle_until_mealy_fusion_gates_seq_assigns() {
           thread T on clk rising, rst low
             default comb
             end default
-            wait 0+ cycle until go;
+            if not (go)
+              wait until go;
+            end if
             do
               started <= true;
             until done;
@@ -5221,11 +5231,10 @@ fn test_wait_0plus_cycle_until_mealy_fusion_gates_seq_assigns() {
 }
 
 #[test]
-fn test_wait_0plus_requires_immediate_do_until() {
-    // The Mealy fusion only handles `wait 0+ cycle until X;` followed
-    // immediately by `do ... until ...;` (with or without a wrapping
-    // `lock R ... end lock R`). A plain assign between them is rejected
-    // with a clear diagnostic.
+fn test_wait_0plus_is_retired_with_migration_hint() {
+    // The legacy Mealy spelling is retired. The parser should reject it
+    // directly and tell users to spell the fast path with `if not X` plus
+    // a normal `wait until X`.
     let source = r#"
         bus B
           v: out Bool;
@@ -5240,17 +5249,24 @@ fn test_wait_0plus_requires_immediate_do_until() {
               b.v = false;
             end default
             wait 0+ cycle until go;
-            wait 1 cycle;             // not a do/until or lock+do — should error
+            do
+              b.v = true;
+            until go;
           end thread T
         end module M
     "#;
     let tokens = arch::lexer::tokenize(source).expect("lex");
     let mut parser = arch::parser::Parser::new(tokens, source);
-    let ast = parser.parse_source_file().expect("parse");
-    let err = arch::elaborate::lower_threads(ast).expect_err("expected lowering error");
-    let msg = err.iter().map(|e| format!("{e:?}")).collect::<String>();
-    assert!(msg.contains("Mealy fusion") || msg.contains("0+ cycle"),
-            "expected Mealy-fusion-restriction diagnostic, got: {msg}");
+    let err = parser
+        .parse_source_file()
+        .expect_err("retired wait 0+ syntax should be a parse error");
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("retired")
+            && msg.contains("if not")
+            && msg.contains("wait until"),
+        "expected wait-0+ retirement diagnostic with migration hint, got: {msg}"
+    );
 }
 
 #[test]
@@ -15010,7 +15026,7 @@ end module M
 }
 
 #[test]
-fn test_thread_if_not_wait_until_fast_path_followed_by_wait_0plus() {
+fn test_thread_if_not_wait_until_fast_path_followed_by_second_fast_gate_do_until() {
     let source = r#"
 module M
   port clk: in Clock<SysDomain>;
@@ -15025,7 +15041,9 @@ module M
     if not start
       wait until start;
     end if
-    wait 0+ cycle until go;
+    if not (go)
+      wait until go;
+    end if
     do
       phase_r <= 8'd1;
     until done;
@@ -15041,12 +15059,12 @@ end module M
 
     assert!(
         trimmed.contains("_t0_state == _t0_S0_wait_until) begin if (start) begin _t0_state <= _t0_S1_wait_until"),
-        "S0 should wait for start before entering the following wait-0+ fused state:\n{sv}"
+        "S0 should wait for start before entering the following fast-gate fused state:\n{sv}"
     );
     assert!(
         trimmed.contains("_t0_state == _t0_S1_wait_until) begin if (go) begin phase_r <= 8'd1")
             && sv.contains("go && done"),
-        "following wait-0+/do-until should keep its Mealy gating after the fast start gate:\n{sv}"
+        "following fast-gate/do-until should keep its Mealy gating after the fast start gate:\n{sv}"
     );
 }
 

--- a/tests/nic400/Nic400AhbBridge.arch
+++ b/tests/nic400/Nic400AhbBridge.arch
@@ -120,7 +120,9 @@ module Nic400AhbBridge
       axi.ar_region = 0;
       axi.r_ready   = false;
     end default
-    wait 0+ cycle until h.hsel and (h.htrans == 2) and (not h.hwrite);
+    if not (h.hsel and (h.htrans == 2) and (not h.hwrite))
+      wait until h.hsel and (h.htrans == 2) and (not h.hwrite);
+    end if
     // AR phase: drive AR, stall the AHB data phase with hready=false until
     // the AXI slave starts returning data.
     lock h_resp_lock
@@ -201,7 +203,9 @@ module Nic400AhbBridge
     end default
     // Wake only on fixed-length HBURST values. HBURST=1 (INCR undefined-length)
     // is handled by the WriteXactIncr thread below.
-    wait 0+ cycle until h.hsel and (h.htrans == 2) and h.hwrite and (h.hburst != 1);
+    if not (h.hsel and (h.htrans == 2) and h.hwrite and (h.hburst != 1))
+      wait until h.hsel and (h.htrans == 2) and h.hwrite and (h.hburst != 1);
+    end if
     // AW phase: stall the AHB data phase while we set up AW.
     lock h_resp_lock
       do
@@ -332,7 +336,9 @@ module Nic400AhbBridge
     // master_done_r in its final HRESP state; until then, the previous burst
     // is still in flight (e.g. draining phantom chunks). Without this gate,
     // back-to-back bursts could clobber burst_addr_r etc. mid-burst.
-    wait 0+ cycle until h.hsel and (h.htrans == 2) and h.hwrite and (h.hburst == 1) and (not master_done_r);
+    if not (h.hsel and (h.htrans == 2) and h.hwrite and (h.hburst == 1) and (not master_done_r))
+      wait until h.hsel and (h.htrans == 2) and h.hwrite and (h.hburst == 1) and (not master_done_r);
+    end if
     do
       h.hready          = false;
       burst_addr_r      <= h.haddr;

--- a/tests/nic400/Nic400ApbBridge.arch
+++ b/tests/nic400/Nic400ApbBridge.arch
@@ -150,7 +150,9 @@ module Nic400ApbBridge
     end default
     // Wait for an AR handshake. Mealy-fuse the capture into the wake state:
     // assert ar_ready while ar_valid is high (loop exits next cycle).
-    wait 0+ cycle until axi.ar_valid;
+    if not (axi.ar_valid)
+      wait until axi.ar_valid;
+    end if
     do
       axi.ar_ready = true;
       ar_addr_r  <= axi.ar_addr;
@@ -214,7 +216,9 @@ module Nic400ApbBridge
       apb.pprot    = 0;
     end default
     // AW handshake — capture and clear werr_r for the new burst.
-    wait 0+ cycle until axi.aw_valid;
+    if not (axi.aw_valid)
+      wait until axi.aw_valid;
+    end if
     do
       axi.aw_ready = true;
       aw_addr_r  <= axi.aw_addr;

--- a/tests/nic400/Nic400MasterPort.arch
+++ b/tests/nic400/Nic400MasterPort.arch
@@ -68,7 +68,9 @@ module Nic400MasterPort
         outs[j].ar_region = 0;
         m.ar_ready      = false;
       end default
-      wait 0+ cycle until m.ar_valid and m_ar_slv == j;
+      if not (m.ar_valid and m_ar_slv == j)
+        wait until m.ar_valid and m_ar_slv == j;
+      end if
       lock ar_ch
         do
           outs[j].ar_valid  = true;
@@ -99,7 +101,9 @@ module Nic400MasterPort
         m.r_last  = false;
         outs[j].r_ready = false;
       end default
-      wait 0+ cycle until outs[j].r_valid and outs[j].r_id[SLAVE_ID_W-1:MASTER_ID_W] == I;
+      if not (outs[j].r_valid and outs[j].r_id[SLAVE_ID_W-1:MASTER_ID_W] == I)
+        wait until outs[j].r_valid and outs[j].r_id[SLAVE_ID_W-1:MASTER_ID_W] == I;
+      end if
       lock r_ch
         do
           m.r_valid = true;
@@ -143,7 +147,9 @@ module Nic400MasterPort
         m.b_resp   = 0;
       end default
       // AW phase: wait for master's AW and address-decode match.
-      wait 0+ cycle until m.aw_valid and m_aw_slv == j;
+      if not (m.aw_valid and m_aw_slv == j)
+        wait until m.aw_valid and m_aw_slv == j;
+      end if
       lock aw_ch
         do
           outs[j].aw_valid  = true;

--- a/tests/nic400/Nic400SlavePort.arch
+++ b/tests/nic400/Nic400SlavePort.arch
@@ -57,7 +57,9 @@ module Nic400SlavePort
         s.ar_region = 0;
         ins[i].ar_ready = false;
       end default
-      wait 0+ cycle until ins[i].ar_valid;
+      if not (ins[i].ar_valid)
+        wait until ins[i].ar_valid;
+      end if
       lock ar_lock
         do
           s.ar_valid  = true;
@@ -89,7 +91,9 @@ module Nic400SlavePort
         ins[i].r_last  = false;
         s.r_ready = false;
       end default
-      wait 0+ cycle until s.r_valid and s.r_id[SLAVE_ID_W-1:MASTER_ID_W] == i;
+      if not (s.r_valid and s.r_id[SLAVE_ID_W-1:MASTER_ID_W] == i)
+        wait until s.r_valid and s.r_id[SLAVE_ID_W-1:MASTER_ID_W] == i;
+      end if
       lock r_demux_lock
         do
           ins[i].r_valid = true;
@@ -135,7 +139,9 @@ module Nic400SlavePort
         ins[i].b_resp   = 0;
       end default
       // AW phase
-      wait 0+ cycle until ins[i].aw_valid;
+      if not (ins[i].aw_valid)
+        wait until ins[i].aw_valid;
+      end if
       lock aw_lock
         do
           s.aw_valid  = true;

--- a/tests/nic400/Nic400WidthAdapter.arch
+++ b/tests/nic400/Nic400WidthAdapter.arch
@@ -107,7 +107,9 @@ module Nic400WidthAdapter
       s.ar_region = 0;
       m.ar_ready  = false;
     end default
-    wait 0+ cycle until m.ar_valid;
+    if not (m.ar_valid)
+      wait until m.ar_valid;
+    end if
     lock ar_lock
       do
         s.ar_valid  = true;
@@ -208,7 +210,9 @@ module Nic400WidthAdapter
       s.aw_region = 0;
       m.aw_ready  = false;
     end default
-    wait 0+ cycle until m.aw_valid;
+    if not (m.aw_valid)
+      wait until m.aw_valid;
+    end if
     lock aw_lock
       do
         s.aw_valid  = true;
@@ -282,7 +286,9 @@ module Nic400WidthAdapter
       m.b_resp  = 0;
       s.b_ready = false;
     end default
-    wait 0+ cycle until s.b_valid;
+    if not (s.b_valid)
+      wait until s.b_valid;
+    end if
     lock b_lock
       do
         m.b_valid = s.b_valid;

--- a/tests/nic400/README.md
+++ b/tests/nic400/README.md
@@ -136,18 +136,25 @@ Nic400Read2x2 — older 2×2 read-only crossbar (predates Nic400Fabric).
 
 Measured via `tb_nic400_fabric_latency.cpp` and `tb_nic400_fabric_throughput.cpp`:
 
-| Path | Spec target | Observed (Mealy `wait 0+`) | Observed (Moore `wait`) |
+| Path | Spec target | Observed (fast-gate wait) | Observed (Moore `wait`) |
 |------|-------------|----------------------------|--------------------------|
 | AR forward (M → S, uncontested) | 0 cycles | **0 cycles ✓** | 1 cycle |
 | R return (S → M, uncontested) | 0 cycles | **0 cycles ✓** | 1 cycle |
 | AR throughput (back-to-back) | 1 txn/cycle | **1.00 t/c** (9/9) | 0.32 t/c (8/25) |
 | 3M→3S concurrent aggregate | linear M scaling | **3.00 t/c** (18/6) | — |
 
-The MasterPort/SlavePort threads use the **`wait 0+ cycle until X;`**
-form (Mealy-style), which fuses with the immediately-following
-`do BODY until Y;` into a single state — both the comb drives and the
-transition guard live in one posedge, collapsing the entry-wait bubble
-that the Moore form imposes.
+The MasterPort/SlavePort threads use the fast-gate form:
+
+```arch
+if not X
+  wait until X;
+end if
+```
+
+When immediately followed by `do BODY until Y;` or `lock R do BODY until
+Y; end lock R;`, this fuses into a single Mealy-style state — both the
+comb drives and the transition guard live in one posedge, collapsing the
+entry-wait bubble that the Moore form imposes.
 
 ### Multi-outstanding (no design change required)
 
@@ -184,7 +191,7 @@ Patterns that work and are exercised in this demo:
 - Nested `for` loops inside threads (each gets its own loop counter; see #414's fix).
 - AXI bus aliases bound by module params and referenced from `generate_if` bodies (see #423's fix).
 - Whole-Vec<Bus,N> inst port forwarding `m <- m_top` (see #424's fix).
-- Mealy fusion of `wait 0+ cycle until X; lock R do BODY until Y; end lock R;` for zero-overhead handshake throughput.
+- Mealy fusion of `if not X; wait until X; end if; lock R do BODY until Y; end lock R;` for zero-overhead handshake throughput.
 - `Concat({addr, id, len, …})` over bus port signals with module-param-bound bus alias params (see #427's fix).
 - Inner-for body ending in if/else with lock-per-branch, where each branch advances state (see #422's fix; used by `Nic400WidthAdapter`'s R thread).
 
@@ -203,7 +210,7 @@ Building this demo uncovered **eight** thread-lowering / elaboration-scope issue
 | Issue | Fix PR | Topic |
 |-------|--------|-------|
 | #410 | #411 | top-level `do BODY until cond` looped infinitely; reject nested control flow |
-| #412 | #413 | Mealy-fused `wait 0+ … ; do … until …;` seq assigns ungated by wake condition |
+| #412 | #413 | Mealy-fused fast-gate `do … until …;` seq assigns ungated by wake condition |
 | #414 | #415 | nested `for` loops shared a single `_loop_cnt` register |
 | #422 | #430 | inner-for + if/else with lock-per-branch lost outer-for continuation transitions |
 | #423 | #425 | type alias inside `generate_if` lost bound bus params |

--- a/tests/regression/issues/do_until_top_level/DoUntilRepro.arch
+++ b/tests/regression/issues/do_until_top_level/DoUntilRepro.arch
@@ -37,7 +37,9 @@ module DoUntilRepro
       lock_drove = lock_drove_r;
       done       = done_r;
     end default
-    wait 0+ cycle until start;
+    if not (start)
+      wait until start;
+    end if
     // The outer `do … until` body contains a nested `lock` (and a seq
     // assign). Pre-#410 this lowered to a single hold-state that ran the
     // seq assigns forever. The compiler now rejects with a diagnostic


### PR DESCRIPTION
## Summary

Retires the legacy `wait 0+ cycle until <cond>;` thread syntax. The parser now emits a hard error with a migration hint, and the old `WaitUntilMealy` AST/lowering path is removed so the canonical fast-gate lowering is the only implementation path.

Migrates NIC400/regression examples and integration tests to the supported spelling:

```arch
if not <cond>
  wait until <cond>;
end if
```

## Why

The `wait 0+` form had awkward grammar and required special immediate-following-statement rules. The fast-gate spelling supports arbitrary following thread statements while preserving the zero-or-more-cycle behavior.

## Validation

- `cargo check`
- `cargo test --test integration_test`
- `make ARCH_HOME=../arch-com-latest attention-tile-engine-cosim` from `fpt26-accel`
- `rg "wait 0\+ cycle until|wait 0\+|WaitUntilMealy"` across `arch-com-latest` and `fpt26-accel` leaves only the intended parser diagnostic/test strings
