### PR TITLE
fix(signal_flow): drop dead WaitUntilMealy arm — main is red

### DIFF
--- a/src/signal_flow.rs
+++ b/src/signal_flow.rs
@@ -111,7 +111,6 @@ fn collect_one_thread_stmt(stmt: &ThreadStmt, out: &mut HashMap<String, Span>) {
         ThreadStmt::Lock { body, .. } => collect_thread_stmts(body, out),
         ThreadStmt::DoUntil { body, .. } => collect_thread_stmts(body, out),
         ThreadStmt::WaitUntil(_, _)
-        | ThreadStmt::WaitUntilMealy(_, _)
         | ThreadStmt::WaitCycles(_, _)
         | ThreadStmt::JoinAll(_)
         | ThreadStmt::Log(_)


### PR DESCRIPTION
## ⚠️ main does not compile — this unblocks CI on every open PR

Two PRs that were green individually broke `main` when merged in sequence:

- **#470** (`20b63d5`, SFG Check 1 multi-driver detection) added a `collect_thread_stmts` match arm in `src/signal_flow.rs:114` referencing `ThreadStmt::WaitUntilMealy`.
- **#471** (`2b22c56`, "Retire wait 0+ thread syntax") removed the `WaitUntilMealy` variant from `ThreadStmt` in `src/ast.rs`.

Neither PR's CI saw the other's change, so the second merge left a reference to a deleted variant:

```
error[E0599]: no variant or associated item named `WaitUntilMealy`
found for enum `ast::ThreadStmt`
   --> src/signal_flow.rs:114:23
```

## Fix

The arm was a no-op catch-all (wait-like statements don't drive signals), so the fix is to drop the dead `WaitUntilMealy` line. The remaining `WaitUntil` / `WaitCycles` / `JoinAll` / `Log` / `Return` arm still covers every non-driving thread statement.

Internal compiler pass only — no user-facing syntax or semantics change (`wait 0+` was already retired by #471), so per `CLAUDE.md` this is an autonomous internal fix.

## Verification

- [x] `cargo build --release` clean (was: E0599).
- [x] `cargo test --release` — 529 integration + 44 lib tests pass, including all 6 `multi_driver` SFG-check tests from #470.

Please merge ahead of other open PRs — they all currently fail CI against this broken main.