### PR TITLE
[codex] Fix native sim pipe_reg thread outputs

### DIFF
--- a/src/signal_flow.rs
+++ b/src/signal_flow.rs
@@ -111,7 +111,6 @@ fn collect_one_thread_stmt(stmt: &ThreadStmt, out: &mut HashMap<String, Span>) {
         ThreadStmt::Lock { body, .. } => collect_thread_stmts(body, out),
         ThreadStmt::DoUntil { body, .. } => collect_thread_stmts(body, out),
         ThreadStmt::WaitUntil(_, _)
-        | ThreadStmt::WaitUntilMealy(_, _)
         | ThreadStmt::WaitCycles(_, _)
         | ThreadStmt::JoinAll(_)
         | ThreadStmt::Log(_)

--- a/src/sim_codegen/mod.rs
+++ b/src/sim_codegen/mod.rs
@@ -3838,6 +3838,34 @@ fn collect_reg_names(body: &[ModuleBodyItem], ports: &[PortDecl]) -> HashSet<Str
         .collect()
 }
 
+fn collect_port_reg_names(ports: &[PortDecl]) -> HashSet<String> {
+    ports.iter()
+        .filter_map(|p| if p.reg_info.is_some() { Some(p.name.name.clone()) } else { None })
+        .collect()
+}
+
+fn emit_port_reg_public_copy(
+    cpp: &mut String,
+    name: &str,
+    widths: &HashMap<String, u32>,
+    vec_count: Option<u64>,
+    indent: &str,
+) {
+    if let Some(count) = vec_count {
+        for i in 0..count {
+            cpp.push_str(&format!("{indent}{name}_{i} = _{name}[{i}];\n"));
+        }
+        return;
+    }
+
+    let bits = widths.get(name).copied().unwrap_or(0);
+    if bits > 64 && bits <= 128 {
+        cpp.push_str(&format!("{indent}_arch_u128_to_vl(_{name}, {name}._data);\n"));
+    } else {
+        cpp.push_str(&format!("{indent}{name} = _{name};\n"));
+    }
+}
+
 fn collect_let_names(body: &[ModuleBodyItem]) -> HashSet<String> {
     let mut out = HashSet::new();
     for i in body {
@@ -4823,6 +4851,7 @@ impl<'a> SimCodegen<'a> {
 
         let mut reg_names = collect_reg_names(&m.body, &m.ports);
         reg_names.extend(collect_pipe_reg_names(&m.body));
+        let port_reg_names = collect_port_reg_names(&m.ports);
         let let_names   = collect_let_names(&m.body);
         let let_values  = collect_let_values(&m.body, &m.params);
         let inst_names  = collect_inst_names(&m.body);
@@ -6307,6 +6336,9 @@ impl<'a> SimCodegen<'a> {
                                         cpp.push_str(&format!("    _{sig_name}[{i}] = _inst_{}.{}_{i};\n",
                                             inst.name.name, conn.port_name.name));
                                     }
+                                    if port_reg_names.contains(sig_name.as_str()) {
+                                        emit_port_reg_public_copy(&mut cpp, sig_name, &widths, Some(n), "    ");
+                                    }
                                 } else {
                                     let prefix = vec_storage_prefix(sig_name.as_str(), &reg_names, &let_names, &inst_out);
                                     for i in 0..n {
@@ -6328,6 +6360,11 @@ impl<'a> SimCodegen<'a> {
                         } else {
                             cpp.push_str(&format!("    {} = _inst_{}.{};\n",
                                 sig, inst.name.name, conn.port_name.name));
+                        }
+                        if let ExprKind::Ident(name) = &conn.signal.kind {
+                            if port_reg_names.contains(name.as_str()) {
+                                emit_port_reg_public_copy(&mut cpp, name, &widths, None, "    ");
+                            }
                         }
                         // --check-uninit: mark inst output as initialized
                         if let ExprKind::Ident(name) = &conn.signal.kind {
@@ -6474,6 +6511,9 @@ impl<'a> SimCodegen<'a> {
                                         cpp.push_str(&format!("    _{sig_name}[{i}] = _inst_{}.{}_{i};\n",
                                             inst.name.name, conn.port_name.name));
                                     }
+                                    if port_reg_names.contains(sig_name.as_str()) {
+                                        emit_port_reg_public_copy(&mut cpp, sig_name, &widths, Some(n), "    ");
+                                    }
                                 } else {
                                     let prefix = vec_storage_prefix(sig_name.as_str(), &reg_names, &let_names, &inst_out);
                                     for i in 0..n {
@@ -6495,6 +6535,11 @@ impl<'a> SimCodegen<'a> {
                         } else {
                             cpp.push_str(&format!("    {} = _inst_{}.{};\n",
                                 sig, inst.name.name, conn.port_name.name));
+                        }
+                        if let ExprKind::Ident(name) = &conn.signal.kind {
+                            if port_reg_names.contains(name.as_str()) {
+                                emit_port_reg_public_copy(&mut cpp, name, &widths, None, "    ");
+                            }
                         }
                         // --check-uninit: mark inst output as initialized
                         if let ExprKind::Ident(name) = &conn.signal.kind {
@@ -7270,6 +7315,9 @@ impl<'a> SimCodegen<'a> {
                                         cpp.push_str(&format!("  _{sig_name}[{i}] = _inst_{}.{}_{i};\n",
                                             inst.name.name, conn.port_name.name));
                                     }
+                                    if port_reg_names.contains(sig_name.as_str()) {
+                                        emit_port_reg_public_copy(&mut cpp, sig_name, &widths, Some(n), "  ");
+                                    }
                                 } else {
                                     let prefix = vec_storage_prefix(sig_name.as_str(), &reg_names, &let_names, &inst_out);
                                     for i in 0..n {
@@ -7290,6 +7338,11 @@ impl<'a> SimCodegen<'a> {
                         } else {
                             cpp.push_str(&format!("  {} = _inst_{}.{};\n",
                                 sig, inst.name.name, conn.port_name.name));
+                        }
+                        if let ExprKind::Ident(name) = &conn.signal.kind {
+                            if port_reg_names.contains(name.as_str()) {
+                                emit_port_reg_public_copy(&mut cpp, name, &widths, None, "  ");
+                            }
                         }
                     }
                 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -18307,6 +18307,38 @@ fn test_native_sim_vec_inst_input_wire_param_sized_fanout() {
 }
 
 #[test]
+fn test_native_sim_thread_driven_top_pipe_reg_output_is_public() {
+    // Regression for arch-com#472: lower_threads rewrites a thread-driven
+    // top-level `port q: out pipe_reg<T,1>` into a registered output on the
+    // synthesized `_threads` submodule, connected back to the parent's
+    // registered output port. Native sim already copied the submodule value
+    // into the parent's private shadow `_q`, but failed to update public
+    // field `q`, so C++ testbenches polling `dut.q` saw stale zeroes.
+    let td = tempfile::tempdir().expect("tempdir");
+    let arch_bin = env!("CARGO_BIN_EXE_arch");
+    let out = std::process::Command::new(arch_bin)
+        .arg("sim")
+        .arg("tests/native_pipe_reg_thread_output/Probe.arch")
+        .arg("--tb")
+        .arg("tests/native_pipe_reg_thread_output/tb.cpp")
+        .arg("--outdir")
+        .arg(td.path())
+        .output()
+        .expect("run arch sim for native pipe_reg thread output probe");
+    assert!(
+        out.status.success(),
+        "native pipe_reg thread output sim should compile + run\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&out.stdout).contains("PASS native pipe_reg thread output"),
+        "expected PASS marker in stdout:\n{}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+}
+
+#[test]
 fn test_expect_fatal_harness_catches_bounds_violation() {
     // Smoke test for the `expect_verilator_fatal` helper in
     // `tests/common/mod.rs`. The Probe.arch fixture writes to a

--- a/tests/native_pipe_reg_thread_output/Probe.arch
+++ b/tests/native_pipe_reg_thread_output/Probe.arch
@@ -1,0 +1,27 @@
+//! ---
+//! tags: [native-sim, pipe-reg, threads, regression]
+//! refs:
+//!   - "arch-com#472"
+//! ---
+//!
+//! Regression for native C++ simulation of top-level pipe_reg outputs driven
+//! by a lowered thread submodule.
+
+/// Thread-lowered producer whose registered output ports are top-level
+/// pipe_reg outputs in the parent wrapper.
+module NativePipeRegThreadOutputProbe
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync, High>;
+  port start: in Bool;
+  port payload_in: in UInt<8>;
+  port payload_out: out pipe_reg<UInt<8>, 1> reset rst => 0;
+  port valid_out: out pipe_reg<Bool, 1> reset rst => false;
+
+  thread on clk rising, rst high
+    wait until start;
+    payload_out <= payload_in;
+    valid_out <= true;
+    wait 1 cycle;
+    valid_out <= false;
+  end thread
+end module NativePipeRegThreadOutputProbe

--- a/tests/native_pipe_reg_thread_output/tb.cpp
+++ b/tests/native_pipe_reg_thread_output/tb.cpp
@@ -1,0 +1,43 @@
+#include "VNativePipeRegThreadOutputProbe.h"
+
+#include <cstdio>
+
+static VNativePipeRegThreadOutputProbe dut;
+
+static void tick() {
+    dut.clk = 0;
+    dut.eval();
+    dut.clk = 1;
+    dut.eval();
+}
+
+int main() {
+    dut.rst = 1;
+    dut.start = 0;
+    dut.payload_in = 0;
+    tick();
+
+    dut.rst = 0;
+    tick();
+
+    dut.payload_in = 0x5a;
+    dut.start = 1;
+    tick();
+    tick();
+
+    if (!dut.valid_out || dut.payload_out != 0x5a) {
+        std::printf("FAIL: public pipe_reg outputs valid=%u payload=0x%02x, expected valid=1 payload=0x5a\n",
+                    (unsigned)dut.valid_out, (unsigned)dut.payload_out);
+        return 1;
+    }
+
+    dut.start = 0;
+    tick();
+    if (dut.valid_out) {
+        std::printf("FAIL: valid_out stayed asserted after one-cycle pulse\n");
+        return 1;
+    }
+
+    std::printf("PASS native pipe_reg thread output\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary

Fixes arch-hdl-lang/arch-com#472 by making native C++ sim expose top-level `pipe_reg`/port-reg outputs when they are driven through a lowered thread submodule.

The generated parent wrapper already copied sub-instance output values into private backing fields like `_output_valid_out`, but public testbench-visible fields like `output_valid_out` stayed stale. This adds a small public-copy helper and calls it on sub-instance output reads that target registered parent ports, covering scalar, Vec, and 65-128 bit wide cases.

After rebasing onto current `main`, the PR merge also picked up `src/signal_flow.rs`, which still had a dead `ThreadStmt::WaitUntilMealy` match arm even though that AST variant was removed. CI failed at `cargo build --release`; the PR now includes the one-line stale-arm removal matching the existing upstream fix branch.

## Tests

- `cargo check`
- `cargo build --release`
- `cargo test test_native_sim_thread_driven_top_pipe_reg_output_is_public --test integration_test -- --nocapture`
- `cargo test test_native_sim_vec_inst --test integration_test -- --nocapture`
- `make ARCH_HOME=../arch-com-latest attention-tile-engine-cosim` in `fpt26-accel`
- GitHub Actions: `cla`, `examples/run_sims.sh`