### PR TITLE
fix(codegen): emit `disable iff` on user assert/cover SVA, per spec

### DIFF
--- a/src/codegen/arbiter.rs
+++ b/src/codegen/arbiter.rs
@@ -202,7 +202,8 @@ impl<'a> Codegen<'a> {
             self.line("");
             let asserts = a.asserts.clone();
             let aname = a.name.name.clone();
-            self.emit_asserts_for_construct(&asserts, &aname, &clk);
+            let rst_active = Codegen::rst_active_from_ports(&a.ports);
+            self.emit_asserts_for_construct(&asserts, &aname, &clk, rst_active.as_deref());
         }
 
         // Tier-2 protocol SVA for any `handshake_channel` declared in the

--- a/src/codegen/cam.rs
+++ b/src/codegen/cam.rs
@@ -172,7 +172,8 @@ impl<'a> Codegen<'a> {
 
         if !c.asserts.is_empty() {
             let asserts = c.asserts.clone();
-            self.emit_asserts_for_construct(&asserts, &n, &clk);
+            let rst_active = Codegen::rst_active_from_ports(&c.ports);
+            self.emit_asserts_for_construct(&asserts, &n, &clk, rst_active.as_deref());
         }
 
         self.indent -= 1;

--- a/src/codegen/counter.rs
+++ b/src/codegen/counter.rs
@@ -238,7 +238,8 @@ impl<'a> Codegen<'a> {
             self.line("");
             let asserts = c.asserts.clone();
             let cname = c.name.name.clone();
-            self.emit_asserts_for_construct(&asserts, &cname, &clk);
+            let rst_active = Codegen::rst_active_from_ports(&c.ports);
+            self.emit_asserts_for_construct(&asserts, &cname, &clk, rst_active.as_deref());
         }
 
         self.indent -= 1;

--- a/src/codegen/fifo.rs
+++ b/src/codegen/fifo.rs
@@ -148,7 +148,8 @@ impl<'a> Codegen<'a> {
             self.line("");
             let asserts = f.asserts.clone();
             let fname = f.name.name.clone();
-            self.emit_asserts_for_construct(&asserts, &fname, &clk);
+            let rst_active = Codegen::rst_active_from_ports(&f.ports);
+            self.emit_asserts_for_construct(&asserts, &fname, &clk, rst_active.as_deref());
         }
 
         self.indent -= 1;

--- a/src/codegen/fsm.rs
+++ b/src/codegen/fsm.rs
@@ -405,7 +405,8 @@ self.line("unique case (state_r)");
             self.line("");
             let asserts = f.asserts.clone();
             let fname = f.name.name.clone();
-            self.emit_asserts_for_construct(&asserts, &fname, &clk);
+            let rst_active = Codegen::rst_active_from_ports(&f.ports);
+            self.emit_asserts_for_construct(&asserts, &fname, &clk, rst_active.as_deref());
         }
 
         self.indent -= 1;

--- a/src/codegen/linklist.rs
+++ b/src/codegen/linklist.rs
@@ -306,7 +306,8 @@ impl<'a> Codegen<'a> {
             self.line("");
             let asserts = l.asserts.clone();
             let lname = l.name.name.clone();
-            self.emit_asserts_for_construct(&asserts, &lname, &clk);
+            let rst_active = Codegen::rst_active_from_ports(&l.ports);
+            self.emit_asserts_for_construct(&asserts, &lname, &clk, rst_active.as_deref());
         }
 
         self.indent -= 1;

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -2766,17 +2766,41 @@ impl<'a> Codegen<'a> {
         }
     }
 
-    fn emit_assert_sva(&mut self, a: &AssertDecl, construct_name: &str, clk: &str) {
+    /// Resolve a construct's `Reset<Kind, Polarity>` port to the active-level
+    /// SV expression used inside `disable iff (...)`. Returns `None` if the
+    /// construct has no reset port (the SVA then has no `disable iff` clause).
+    /// Active-low becomes `!rst`; active-high becomes the bare port name.
+    /// Mirrors the inline pattern used by `_auto_bound_*` / `_auto_div0_*`
+    /// emitters in this file.
+    pub(crate) fn rst_active_from_ports(ports: &[PortDecl]) -> Option<String> {
+        ports.iter()
+            .find(|p| matches!(&p.ty, TypeExpr::Reset(_, _)))
+            .map(|p| match &p.ty {
+                TypeExpr::Reset(_, ResetLevel::Low) => format!("!{}", p.name.name),
+                _ => p.name.name.clone(),
+            })
+    }
+
+    fn emit_assert_sva(
+        &mut self,
+        a: &AssertDecl,
+        construct_name: &str,
+        clk: &str,
+        rst_active: Option<&str>,
+    ) {
         let expr_str = self.emit_expr_str(&a.expr);
         let label = a.name.as_ref().map(|n| n.name.as_str().to_string())
             .unwrap_or_else(|| match a.kind {
                 AssertKind::Assert => "_assert_anon".to_string(),
                 AssertKind::Cover  => "_cover_anon".to_string(),
             });
+        let disable = rst_active
+            .map(|r| format!(" disable iff ({r})"))
+            .unwrap_or_default();
         match a.kind {
             AssertKind::Assert => {
                 self.line(&format!(
-                    "{label}: assert property (@(posedge {clk}) {expr_str})"
+                    "{label}: assert property (@(posedge {clk}){disable} {expr_str})"
                 ));
                 self.line(&format!(
                     "  else $fatal(1, \"ASSERTION FAILED: {construct_name}.{label}\");"
@@ -2784,7 +2808,7 @@ impl<'a> Codegen<'a> {
             }
             AssertKind::Cover => {
                 self.line(&format!(
-                    "{label}: cover property (@(posedge {clk}) {expr_str});"
+                    "{label}: cover property (@(posedge {clk}){disable} {expr_str});"
                 ));
             }
         }
@@ -2792,11 +2816,20 @@ impl<'a> Codegen<'a> {
 
     /// Emit assert/cover SVA for construct-level assert declarations (FSM, FIFO, etc.)
     /// Wrapped in translate_off/on so synthesis tools and Yosys ignore the SVA.
-    fn emit_asserts_for_construct(&mut self, asserts: &[AssertDecl], name: &str, clk: &str) {
+    /// `rst_active` is the construct's active-level reset expression
+    /// (`Some("!rst")` for active-low, `Some("rst")` for active-high, `None`
+    /// for clockless / reset-less constructs).
+    fn emit_asserts_for_construct(
+        &mut self,
+        asserts: &[AssertDecl],
+        name: &str,
+        clk: &str,
+        rst_active: Option<&str>,
+    ) {
         if asserts.is_empty() { return; }
         self.line("// synopsys translate_off");
         for a in asserts {
-            self.emit_assert_sva(a, name, clk);
+            self.emit_assert_sva(a, name, clk, rst_active);
         }
         self.line("// synopsys translate_on");
     }

--- a/src/codegen/module.rs
+++ b/src/codegen/module.rs
@@ -871,7 +871,8 @@ impl<'a> Codegen<'a> {
                     .map(|p| p.name.name.clone())
                     .unwrap_or_else(|| "clk".to_string());
                 let owned: Vec<AssertDecl> = module_asserts.into_iter().cloned().collect();
-                self.emit_asserts_for_construct(&owned, &m_clone.name.name, &clk_name);
+                let rst_active = Codegen::rst_active_from_ports(&m_clone.ports);
+                self.emit_asserts_for_construct(&owned, &m_clone.name.name, &clk_name, rst_active.as_deref());
             }
         }
 

--- a/src/codegen/pipeline.rs
+++ b/src/codegen/pipeline.rs
@@ -531,7 +531,8 @@ impl<'a> Codegen<'a> {
             self.line("");
             let asserts = p.asserts.clone();
             let pname = p.name.name.clone();
-            self.emit_asserts_for_construct(&asserts, &pname, &clk);
+            let rst_active = Codegen::rst_active_from_ports(&p.ports);
+            self.emit_asserts_for_construct(&asserts, &pname, &clk, rst_active.as_deref());
         }
 
         self.indent -= 1;

--- a/src/codegen/ram.rs
+++ b/src/codegen/ram.rs
@@ -206,7 +206,8 @@ impl<'a> Codegen<'a> {
             self.line("");
             let asserts = r.asserts.clone();
             let rname = r.name.name.clone();
-            self.emit_asserts_for_construct(&asserts, &rname, &clk);
+            let rst_active = Codegen::rst_active_from_ports(&r.ports);
+            self.emit_asserts_for_construct(&asserts, &rname, &clk, rst_active.as_deref());
         }
 
         self.indent -= 1;

--- a/src/codegen/regfile.rs
+++ b/src/codegen/regfile.rs
@@ -297,7 +297,8 @@ impl<'a> Codegen<'a> {
             self.line("");
             let asserts = r.asserts.clone();
             let rname = r.name.name.clone();
-            self.emit_asserts_for_construct(&asserts, &rname, &clk);
+            let rst_active = Codegen::rst_active_from_ports(&r.ports);
+            self.emit_asserts_for_construct(&asserts, &rname, &clk, rst_active.as_deref());
         }
 
         self.indent -= 1;

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -19130,3 +19130,110 @@ fn test_nic400_apb_bridge_excl_len_illegal_is_rejected_by_sva() {
         "ASSERTION FAILED: Nic400ApbBridge.ar_excl_len_legal_apb",
     );
 }
+
+// ────────────────────────────────────────────────────────────────────
+// User-written `assert` SVA reset gating
+// ────────────────────────────────────────────────────────────────────
+//
+// `doc/ARCH_HDL_Specification.md:7783` states that user-written
+// `assert`/`cover` bodies are evaluated "at every clock edge under
+// the construct's `posedge clk` with `disable iff (rst)`". The
+// auto-emitted SVA family (`_auto_bound_*`, `_auto_div0_*`,
+// `_auto_hs_*`, `_auto_thread_*`) already honours this — emission
+// goes through the same `rst_active` extraction logic. User-written
+// `assert` bodies were the outlier: `emit_assert_sva` ignored the
+// module's reset polarity and produced bare `@(posedge clk)` SVAs.
+//
+// These tests pin the spec-aligned behaviour. Surfaced in the
+// 2026-05-29 daily code-review pass — Finding 7 in
+// `ideas/2026-05-29-code-review-findings.md` (originally
+// mis-described as a nic400-local gap; the real fix is here in the
+// compiler).
+
+/// Active-low reset (`Reset<Async, Low>` → `!rst` in `disable iff`).
+/// This is the nic400 convention — every nic400 module uses it.
+#[test]
+fn test_user_assert_sva_disables_iff_active_low_reset() {
+    let source = r#"
+module UserAssertActiveLow
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Async, Low>;
+  port a: in Bool;
+  port b: in Bool;
+  assert ab_consistent: a |-> b;
+end module UserAssertActiveLow
+"#;
+    let sv = compile_to_sv(source);
+    assert!(
+        sv.contains("ab_consistent: assert property (@(posedge clk) disable iff (!rst) a |-> b)"),
+        "expected user assert to carry `disable iff (!rst)` (active-low \
+         reset); got:\n{sv}"
+    );
+}
+
+/// Active-high reset (`Reset<Sync>` defaults to High → bare `rst` in
+/// `disable iff`).
+#[test]
+fn test_user_assert_sva_disables_iff_active_high_reset() {
+    let source = r#"
+module UserAssertActiveHigh
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync, High>;
+  port a: in Bool;
+  port b: in Bool;
+  assert ab_consistent: a |-> b;
+end module UserAssertActiveHigh
+"#;
+    let sv = compile_to_sv(source);
+    assert!(
+        sv.contains("ab_consistent: assert property (@(posedge clk) disable iff (rst) a |-> b)"),
+        "expected user assert to carry `disable iff (rst)` (active-high \
+         reset); got:\n{sv}"
+    );
+}
+
+/// `cover` bodies must be gated the same way as `assert` — both share
+/// the same lowering path.
+#[test]
+fn test_user_cover_sva_disables_iff_reset() {
+    let source = r#"
+module UserCoverReset
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Async, Low>;
+  port a: in Bool;
+  cover seen_a: a;
+end module UserCoverReset
+"#;
+    let sv = compile_to_sv(source);
+    assert!(
+        sv.contains("seen_a: cover property (@(posedge clk) disable iff (!rst) a);"),
+        "expected user cover to carry `disable iff (!rst)`; got:\n{sv}"
+    );
+}
+
+/// A clock-only module with no reset port must NOT emit a bogus
+/// `disable iff` clause. The existing `_auto_bound_*` emitters skip
+/// `disable iff` when no reset port is found; user asserts must follow
+/// suit.
+#[test]
+fn test_user_assert_sva_no_reset_no_disable_iff() {
+    let source = r#"
+module UserAssertNoReset
+  port clk: in Clock<SysDomain>;
+  port a: in Bool;
+  port b: in Bool;
+  assert ab_consistent: a |-> b;
+end module UserAssertNoReset
+"#;
+    let sv = compile_to_sv(source);
+    assert!(
+        sv.contains("ab_consistent: assert property (@(posedge clk) a |-> b)"),
+        "expected user assert to omit `disable iff` when no reset port \
+         is declared; got:\n{sv}"
+    );
+    assert!(
+        !sv.contains("disable iff"),
+        "no `disable iff` should appear anywhere in a reset-less module's \
+         user-assert SVA; got:\n{sv}"
+    );
+}


### PR DESCRIPTION
## Summary

`doc/ARCH_HDL_Specification.md:7783` states that user-written `assert` and
`cover` bodies are evaluated *"at every clock edge under the construct's
`posedge clk` with `disable iff (rst)`."* The auto-emitted SVA family
(`_auto_bound_*`, `_auto_div0_*`, `_auto_hs_*`, `_auto_thread_*`) already
honours this — each emitter pulls the module's `Reset<Kind, Polarity>`
port and threads the active-level expression into a `disable iff (...)`
clause.

`emit_assert_sva` was the outlier: it took only the clock name and emitted
bare `assert property (@(posedge clk) ...)` with no `disable iff`. A clean
reset glitch on any input feeding a user assertion could therefore fire
the SVA spuriously, against the documented contract.

This PR brings `emit_assert_sva` and `emit_asserts_for_construct` in line
with the auto-emitted family.

## What changed

- New helper `Codegen::rst_active_from_ports(&[PortDecl]) -> Option<String>`
  resolves the active-level reset expression from a port list (`!rst` for
  `Reset<_, Low>`, bare `rst` for `Reset<_, High>`, `None` when there is
  no reset port).
- `emit_assert_sva` and `emit_asserts_for_construct` take a new
  `rst_active: Option<&str>` parameter and splice it into the
  `disable iff (...)` slot between `@(posedge clk)` and the body
  expression. `cover` bodies follow the same path.
- All 10 call sites (`arbiter` / `cam` / `counter` / `fifo` / `fsm` /
  `linklist` / `module` / `pipeline` / `ram` / `regfile`) compute
  `rst_active` from the construct's ports and pass it through. Modules
  with no reset port emit no `disable iff`, matching the pre-existing
  `_auto_bound_*` behaviour for reset-less modules.

## Tests added (`tests/integration_test.rs`)

- `test_user_assert_sva_disables_iff_active_low_reset` — `Reset<Async, Low>` → `disable iff (!rst)`.
- `test_user_assert_sva_disables_iff_active_high_reset` — `Reset<Sync, High>` → `disable iff (rst)`.
- `test_user_cover_sva_disables_iff_reset` — `cover` follows the same path.
- `test_user_assert_sva_no_reset_no_disable_iff` — clockless / reset-less modules omit the clause.

## Verification

- [x] `cargo build --release` — clean.
- [x] `cargo test --release` — 539 passed, 0 failed. Every nic400
      expect-fatal Verilator test still trips the right `$fatal` because
      the violations occur outside reset.

## Context

Surfaced in the 2026-05-29 daily code-review pass —
[arch-com#477](https://github.com/arch-hdl-lang/arch-com/pull/477)
Finding 7. The finding was originally mis-described as a nic400-local gap
(my misread); the real fix is the compiler-side patch in this PR. PR #477's
Finding 7 will be amended in a sibling commit on that branch.