### PR TITLE
docs(status): list SFG Check 1 (multi-driver) as shipped

### DIFF
--- a/doc/COMPILER_STATUS.md
+++ b/doc/COMPILER_STATUS.md
@@ -172,7 +172,7 @@
 | Duplicate definitions | ✅ |
 | Undefined name references | ✅ |
 | Output ports must be driven | ✅ |
-| Single driver per signal | ✅ |
+| Single driver per signal | ✅ | **SFG-based multi-driver check** (PR #470, v0.60.1+, spec §3.4): `src/signal_flow.rs` builds a per-module signal flow graph and rejects two distinct block-level constructs both driving the same signal. **Currently covers**: two `comb` blocks on the same wire/output (C2), `comb` + `inst` output, two `inst` scalar outputs on one wire (C7). **Exemptions handled correctly**: multiple assignments within the same block (default + if/else override pattern), bus-typed wires connected from both initiator and target inst items, implicit bus wires where the child port is a bus port, `shared(or)`/`shared(and)` ports. **Deferred surface** (tracked in `ideas/2026-05-28-signal-flow-graph.md`): `RegBlock` (two `seq` blocks writing the same reg) — TLM indexed-target lowering generates multiple `RegBlock`s that share register assignments via state-gating, so a naive check fires false positives; a follow-up needs to distinguish user-written from lowering-generated blocks. `LatchBlock` deferred for the same reason. `Thread` multi-driver in `--thread-sim parallel` mode is intentional (threads combine into one FSM in normal lowering) and stays exempt. |
 | `todo!` site warning | ✅ |
 | Binary op result widths (IEEE 1800-2012 §11.6) | ✅ |
 | Width mismatch at assignment | ✅ Any RHS wider than LHS errors in both `always` and `comb` blocks; arithmetic widening hint included |

--- a/ideas/2026-05-28-signal-flow-graph.md
+++ b/ideas/2026-05-28-signal-flow-graph.md
@@ -70,7 +70,21 @@ This mirrors what Verilator does when it builds its elaborated netlist, but at t
 
 ## Checks enabled
 
-### Check 1 — Multi-driver detection (fixes #375)
+### Check 1 — Multi-driver detection (fixes #375) — **DONE (PR #470, v0.60.1+)**
+
+Shipped in `src/signal_flow.rs` as `collect_module_drivers` + `check_multi_driver`,
+called from `arch check`. Catches the `CombBlock` × `CombBlock`,
+`CombBlock` × `Inst`, and `Inst` × `Inst` cases from #375 (C2, C7).
+Exempts intra-block default+override, bus-wire dual-drive (initiator +
+target), and `shared(or)`/`shared(and)` ports. **Deferred for follow-up:**
+`RegBlock` (C-seq), `LatchBlock`, and unlowered `Thread` items — the TLM
+indexed-target lowering generates multiple `RegBlock`s that legitimately
+share register assignments via state-gating, so the naive count check
+fires false positives there. A future PR needs to distinguish
+user-written from compiler-generated blocks before turning those
+contexts on.
+
+
 
 For each signal, collect all `DriveEdge` records targeting it. If there are 2+
 edges from **distinct source identities** (different `CombBlock` indices, different
@@ -139,7 +153,7 @@ mechanically checkable condition.
 
 Two PRs, in order:
 
-### PR A — SFG builder + multi-driver check (closes #375)
+### PR A — SFG builder + multi-driver check (closes #375) — **SHIPPED (PR #470)**
 
 | Sub-task | File(s) | Estimate |
 |----------|---------|----------|


### PR DESCRIPTION
## Summary

Closes Finding 3 from arch-com#477 (2026-05-29 daily code-review pass).

The existing `doc/COMPILER_STATUS.md` row "Single driver per signal" predated PR #470 — which is when the formal SFG-based multi-driver check actually landed — and gave no signal about scope or limitations. A new ARCH user / LLM reading the status doc to learn what `arch check` enforces would not learn that "two `comb` blocks driving the same wire" or "two `inst` outputs on the same wire" became a hard static error in v0.60.1+.

## Changes

- `doc/COMPILER_STATUS.md`: Expand the "Single driver per signal" row to reference PR #470 and spec §3.4 (`doc/ARCH_HDL_Specification.md:485`), list the catch cases (CombBlock x CombBlock, CombBlock x Inst, Inst x Inst from issue #375 C2/C7), the exemptions handled correctly (intra-block default+override, bus-typed wires with initiator+target, implicit bus wires, `shared(or)`/`shared(and)`), and the deferred surface (`RegBlock`, `LatchBlock`, unlowered `Thread`).
- `ideas/2026-05-28-signal-flow-graph.md`: Mark Check 1 and PR A as DONE / SHIPPED with a pointer to PR #470. Phase 2/3 work (Check 2 dead-skid comb-feedback lint, Check 3 sole-writer query) is untouched.

## Deferred-surface call-out for reviewers

`src/signal_flow.rs` currently checks only `CombBlock` and `Inst` items — `RegBlock`, `LatchBlock`, and unlowered `Thread` items are intentionally skipped (the TLM indexed-target lowering generates multiple `RegBlock`s that legitimately share register assignments via state-gating, so a naive count check fires false positives). The status doc and the ideas doc both now say so explicitly, so the next reviewer hunting for the C-seq repro from issue #375 lands on the right comment instead of debugging a false-negative.

## Test plan

- [x] `cargo build --release` clean (doc-only change; verified nothing leaked into a code file)
- [x] No `.arch`, `.sv`, or `src/` files touched