### PR TITLE
test(nic400): cover asymmetric-load M↔M starvation scenario (S4)

### DIFF
--- a/tests/nic400/Nic400FabricHotSlave_test.harc
+++ b/tests/nic400/Nic400FabricHotSlave_test.harc
@@ -27,6 +27,13 @@
 //   S3. Contender dropout: M0 monopolises slave 0 for 4 ARs (M1 absent),
 //       then drops permanently.  M1 must sustain ≥ 0.9 t/c for 6 tail
 //       ARs with no dead cycle on the dropout event.
+//   S4. Asymmetric-load starvation guard: M0 valid=1 continuously while
+//       M1 toggles valid=1 once every 5 cycles.  Catches the canonical
+//       round-robin failure mode where the pointer advances every cycle
+//       instead of advancing on grant — under that bug the low-frequency
+//       requester is starved (window between M1 grants > 15 cycles).
+//       Fair round-robin must grant M1 at least once in every 15-cycle
+//       window during M1's valid epochs.
 //
 // Address mapping (both masters → slave 0):
 //   M0: 0x0000_1000  (addr[29:28] = 0b00)
@@ -347,6 +354,90 @@ impl Nic400FabricHotSlaveTest for Nic400FabricHotSlaveTb
         assert (m1_tail * 10) >= (last_p2_cyc * 9)
             else fail("S3: M1 tail throughput too low: ${m1_tail} ARs in ${last_p2_cyc} phase-2 cycles")
         log(info, "PASS S3: contender dropout — M0=${seen_s3_m0} ARs solo, M1 tail=${m1_tail} ARs in ${last_p2_cyc} cycles")
+
+        dut.m_ar_valid[0] = 0
+        dut.m_ar_valid[1] = 0
+        dut.s_ar_ready[0] = 0
+        wait 2 cycles
+
+        // ── S4: Asymmetric-load starvation guard ─────────────────────────
+        // M0 holds valid=1 continuously throughout the 50-cycle window.
+        // M1 raises a fresh request every 5 cycles: valid goes high and
+        // stays high until granted, then drops for the remainder of the
+        // 5-cycle slot.  This is the canonical asymmetric-load pattern
+        // that exposes a broken round-robin pointer that advances every
+        // cycle instead of advancing on grant — under that bug M0 (held
+        // valid continuously) would keep winning and M1 would be starved
+        // because the pointer never settles on M1's slot when M1 actually
+        // asserts.  Fair RR must grant M1 within at most 15 cycles of
+        // every M1 valid epoch.
+        dut.s_ar_ready[0] = 1
+        dut.m_r_ready[0]  = 1
+        dut.m_r_ready[1]  = 1
+        dut.m_ar_addr[0]  = 0x00001000
+        dut.m_ar_size[0]  = 2
+        dut.m_ar_burst[0] = 1
+        dut.m_ar_addr[1]  = 0x00002000
+        dut.m_ar_size[1]  = 2
+        dut.m_ar_burst[1] = 1
+        dut.m_ar_valid[0] = 1    // M0 always valid
+        dut.m_ar_valid[1] = 0
+
+        let seen_s4_m0       : uint<32> = 0
+        let seen_s4_m1       : uint<32> = 0
+        let cyc_s4           : uint<32> = 0
+        let last_m1_grant    : uint<32> = 0   // cyc_s4 at last M1 grant
+        let worst_m1_gap     : uint<32> = 0   // max cycles between consecutive M1 grants
+        let m1_epoch_starts  : uint<32> = 0   // count of cycles where M1 rose valid
+        let m1_pending       : uint<32> = 0   // 1 = M1 valid currently held, 0 = M1 idle slot
+
+        for _ in 0 .. 50
+            // Start a new M1 valid epoch every 5 cycles.
+            if (cyc_s4 % 5) == 0
+                dut.m_ar_valid[1] = 1
+                m1_pending      = 1
+                m1_epoch_starts = m1_epoch_starts + 1
+            end if
+            dut.m_ar_id[0] = (seen_s4_m0 & 7)
+            dut.m_ar_id[1] = (seen_s4_m1 & 7)
+            wait 1 cycle
+            cyc_s4 = cyc_s4 + 1
+            if dut.s_ar_valid[0] == 1
+                let mid = ((dut.s_ar_id[0] >> 3) & 3)
+                if mid == 0
+                    seen_s4_m0 = seen_s4_m0 + 1
+                elsif mid == 1
+                    seen_s4_m1 = seen_s4_m1 + 1
+                    let gap = cyc_s4 - last_m1_grant
+                    if gap > worst_m1_gap
+                        worst_m1_gap = gap
+                    end if
+                    last_m1_grant = cyc_s4
+                    // M1 served — drop valid until next epoch.
+                    dut.m_ar_valid[1] = 0
+                    m1_pending = 0
+                end if
+            end if
+        end for
+
+        // Starvation guard: M1 must receive a grant within every 15-cycle
+        // window across the 50-cycle test.  Under fair RR with M1
+        // re-arming every 5 cycles, the actual gap should be ≤ 5 cycles;
+        // we leave 3× slack to absorb arbiter-pointer phase relative to
+        // M1 epochs.
+        assert seen_s4_m1 >= m1_epoch_starts
+            else fail("S4: M1 starved — only ${seen_s4_m1}/${m1_epoch_starts} epoch grants in ${cyc_s4} cycles (m0=${seen_s4_m0})")
+        assert worst_m1_gap <= 15
+            else fail("S4: M1 starvation — worst gap=${worst_m1_gap} cycles between consecutive M1 grants (expected ≤ 15; m1=${seen_s4_m1}, m0=${seen_s4_m0})")
+        // Sanity: M0 should still get most grants given it's always valid.
+        assert seen_s4_m0 > seen_s4_m1
+            else fail("S4: unexpected — M1 (${seen_s4_m1}) >= M0 (${seen_s4_m0}); M0 was held valid continuously")
+        log(info, "PASS S4: asymmetric load — m0=${seen_s4_m0} m1=${seen_s4_m1}/${m1_epoch_starts}epochs ${cyc_s4}cyc worst_m1_gap=${worst_m1_gap}")
+
+        dut.m_ar_valid[0] = 0
+        dut.m_ar_valid[1] = 0
+        dut.s_ar_ready[0] = 0
+        wait 2 cycles
 
         log(info, "PASS Nic400Fabric hot-slave throughput: zero-cycle M↔M handoff confirmed")
     end run

--- a/tests/nic400/tb_nic400_fabric_hot_slave_throughput.cpp
+++ b/tests/nic400/tb_nic400_fabric_hot_slave_throughput.cpp
@@ -43,6 +43,12 @@
 //   3. Contender dropout: M0 monopolises for a few ARs, then drops
 //      permanently. M1 should grant on the very next cycle (no bubble
 //      on the contender-disappears event) and continue at 1.00 t/c.
+//   4. Asymmetric-load starvation guard: M0 valid=1 continuously while
+//      M1 toggles valid once every 5 cycles for 50 cycles. Catches the
+//      canonical round-robin failure mode where the pointer advances
+//      every cycle instead of advancing on grant — under that bug the
+//      low-frequency requester is starved. Fair RR must grant M1 within
+//      a bounded number of cycles of every M1 valid epoch.
 
 #include "VNic400Fabric.h"
 #include <cstdint>
@@ -314,6 +320,93 @@ static int scenario_contender_dropout() {
     return 0;
 }
 
+// ── Scenario 4: asymmetric-load starvation guard ────────────────────────
+// M0 drives ar_valid=1 continuously across 50 cycles. M1 re-arms a fresh
+// request every 5 cycles: valid goes high and stays high until granted,
+// then drops for the rest of the 5-cycle slot. Canonical asymmetric-load
+// pattern that exposes a broken round-robin pointer that advances every
+// cycle (instead of advancing on grant) — under that bug, M0 (always
+// valid) would keep winning and M1 would be starved. Fair RR must grant
+// M1 within at most 15 cycles of every M1 valid epoch.
+static int scenario_asymmetric_load() {
+    const int N_CYCLES = 50;
+    const int M1_PERIOD = 5;
+    const int M1_MAX_GAP = 15;
+
+    clear_inputs();
+    dut.s_ar_ready[0] = 1;
+    dut.m_r_ready[0]  = 1;
+    dut.m_r_ready[1]  = 1;
+    dut.m_ar_addr[0]  = 0x00001000;
+    dut.m_ar_size[0]  = 2;
+    dut.m_ar_burst[0] = 1;
+    dut.m_ar_addr[1]  = 0x00002000;
+    dut.m_ar_size[1]  = 2;
+    dut.m_ar_burst[1] = 1;
+    dut.m_ar_valid[0] = 1;   // M0 always valid
+    dut.m_ar_valid[1] = 0;
+
+    int seen_m0 = 0, seen_m1 = 0;
+    int cyc = 0;
+    int last_m1_grant = 0;
+    int worst_m1_gap = 0;
+    int m1_epoch_starts = 0;
+    for (int t = 0; t < N_CYCLES; ++t) {
+        // Re-arm M1 valid every M1_PERIOD cycles; hold until granted.
+        if ((cyc % M1_PERIOD) == 0) {
+            dut.m_ar_valid[1] = 1;
+            m1_epoch_starts++;
+        }
+        dut.m_ar_id[0] = (uint8_t)(seen_m0 & 0x7);
+        dut.m_ar_id[1] = (uint8_t)(seen_m1 & 0x7);
+        tick();
+        cyc++;
+        if (dut.s_ar_valid[0] && dut.s_ar_ready[0]) {
+            uint32_t prefix = (dut.s_ar_id[0]) >> 3;
+            if (prefix == 0) {
+                seen_m0++;
+            } else if (prefix == 1) {
+                seen_m1++;
+                int gap = cyc - last_m1_grant;
+                if (gap > worst_m1_gap) worst_m1_gap = gap;
+                last_m1_grant = cyc;
+                // M1 served — drop valid until next epoch.
+                dut.m_ar_valid[1] = 0;
+            }
+        }
+    }
+
+    std::printf("INFO  S4 (asymmetric load): %d cycles, m0=%d m1=%d/%d epochs, "
+                "worst_m1_gap=%d\n",
+                cyc, seen_m0, seen_m1, m1_epoch_starts, worst_m1_gap);
+
+    if (seen_m1 < m1_epoch_starts) {
+        std::printf("FAIL S4: M1 starved — only %d/%d epoch grants in %d cycles "
+                    "(m0=%d)\n", seen_m1, m1_epoch_starts, cyc, seen_m0);
+        return 1;
+    }
+    if (worst_m1_gap > M1_MAX_GAP) {
+        std::printf("FAIL S4: M1 starvation — worst gap=%d cycles between "
+                    "consecutive M1 grants (expected <= %d)\n",
+                    worst_m1_gap, M1_MAX_GAP);
+        return 1;
+    }
+    // Sanity: M0 should still receive most grants (always valid).
+    if (seen_m0 <= seen_m1) {
+        std::printf("FAIL S4: unexpected — M1 (%d) >= M0 (%d); M0 was held "
+                    "valid continuously\n", seen_m1, seen_m0);
+        return 1;
+    }
+    std::printf("PASS S4: asymmetric load — m0=%d m1=%d/%d epochs worst_m1_gap=%d "
+                "(round-robin grants low-frequency requester within window)\n",
+                seen_m0, seen_m1, m1_epoch_starts, worst_m1_gap);
+
+    dut.m_ar_valid[0] = 0;
+    dut.m_ar_valid[1] = 0;
+    for (int i = 0; i < 2; ++i) tick();
+    return 0;
+}
+
 int main(int argc, char **argv) {
     Verilated::commandArgs(argc, argv);
     do_reset();
@@ -327,6 +420,10 @@ int main(int argc, char **argv) {
     for (int i = 0; i < 2; ++i) tick();
 
     if (scenario_contender_dropout())     return 1;
+    clear_inputs();
+    for (int i = 0; i < 2; ++i) tick();
+
+    if (scenario_asymmetric_load())       return 1;
 
     std::printf("PASS Nic400Fabric hot-slave throughput: zero-cycle M↔M handoff\n");
     return 0;


### PR DESCRIPTION
## Summary

Closes Finding 5 from the 2026-05-29 daily code-review pass (PR #477).

`tests/nic400/Nic400FabricHotSlave_test.harc` had three scenarios — strict M0↔M1 alternation (S1), symmetric continuous contention (S2), and monopolise-then-dropout (S3) — none of which match the canonical round-robin starvation pattern: one master valid every cycle, the other valid once every K cycles. A buggy round-robin pointer that *advances on every cycle* (instead of advancing on grant) would silently starve the low-frequency requester in that scenario but would pass S1/S2/S3.

This PR adds **S4** to plug that coverage gap:

- M0 holds `ar_valid = 1` continuously across 50 cycles.
- M1 re-arms a fresh request every 5 cycles — `ar_valid` goes high and stays high until granted, then drops for the rest of the 5-cycle slot.
- Asserts `seen_m1 >= m1_epoch_starts` (every M1 epoch granted), `worst_m1_gap <= 15` cycles (bounded service window), and the asymmetric-load sanity check `seen_m0 > seen_m1`.

S4 is mirrored in `tb_nic400_fabric_hot_slave_throughput.cpp` so the scenario actually runs locally via `arch sim` — the `.harc` file is the canonical source but the C++ TB is what executes here today (HARC's own tool is a separate repo).

## Mutation-verified

S4 is load-bearing. To prove it catches the failure class the finding flagged:

**Pre-mutation (this branch):**
```
INFO  S4 (asymmetric load): 50 cycles, m0=40 m1=10/10 epochs, worst_m1_gap=6
PASS  S4: asymmetric load — m0=40 m1=10/10 epochs worst_m1_gap=6
```

**Mutation in `src/sim_codegen/mod.rs`** — change the per-cycle update of the round-robin `_last_grant` pointer from \"advance on grant\" to \"advance every cycle\":

```diff
-    if (grant_valid) _last_grant = grant_requester;
+    _last_grant = (_last_grant + 1) % num_req;
```

**Post-mutation:**
```
INFO  S4 (asymmetric load): 50 cycles, m0=44 m1=6/10 epochs, worst_m1_gap=9
FAIL  S4: M1 starved — only 6/10 epoch grants in 50 cycles (m0=44)
```

S1, S2, S3 all stay PASS under the same mutation (S2 skews to `m0=15/m1=1` but its assertions only require non-zero grants on both, which is still met because both masters are always valid). Confirms S4 is the unique guard for this failure class. Mutation reverted before commit; only the new test scenarios are in the diff.

## Test plan

- [x] `cargo build --release`
- [x] `arch sim tests/nic400/Nic400Fabric.arch tests/nic400/Nic400MasterPort.arch tests/nic400/Nic400SlavePort.arch tests/nic400/BusAxi4.arch tests/nic400/PkgNic400.arch --tb tests/nic400/tb_nic400_fabric_hot_slave_throughput.cpp` — S1/S2/S3/S4 all PASS on baseline
- [x] Same incantation under the mutation — S4 FAILS, S1/S2/S3 PASS
- [ ] HARC-side execution of the `.harc` file deferred (HARC tooling lives in the separate `harc-com` repo; not available in this checkout)