### PR TITLE
[codex] Add thread map HTML sidecar

### DIFF
--- a/src/elaborate.rs
+++ b/src/elaborate.rs
@@ -16,7 +16,9 @@
 //!    param map, rewrite inner inst module-names to point at the correct
 //!    variant of the instantiated module, and rename the module itself.
 
+use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
+use std::rc::Rc;
 
 use crate::ast::*;
 use crate::diagnostics::CompileError;
@@ -2076,6 +2078,9 @@ pub struct ThreadLowerOpts {
     /// branch transitions). Wrapped in `synopsys translate_off/on` so they
     /// don't reach synthesis. CLI: `--auto-thread-asserts`.
     pub auto_asserts: bool,
+    /// Optional sidecar collection populated with source-to-state metadata
+    /// for `arch build --emit-thread-map`. Normal lowering leaves this unset.
+    pub thread_map: Option<Rc<RefCell<crate::thread_map::ThreadMap>>>,
 }
 
 pub fn lower_threads_with_opts(
@@ -2587,6 +2592,7 @@ fn lower_module_threads(
     // ── Per-thread state machines ──────────────────────────────────────
     let mut all_thread_comb: Vec<Stmt> = Vec::new();
     let mut all_thread_seq: Vec<Stmt> = Vec::new();
+    let mut thread_map_threads: Vec<crate::thread_map::ThreadMapThread> = Vec::new();
     // Per-state `localparam` decls (one set per thread). Issue #247: make
     // thread-lowered FSMs debuggable by giving each state a descriptive
     // SV-level name (e.g. `_t0_S2_wait_until`) and emitting state
@@ -2715,17 +2721,7 @@ fn lower_module_threads(
         let state_names: Vec<String> = (0..n_states)
             .map(|si| {
                 let s = &raw_states[si];
-                let role = if s.multi_transitions.len() > 1 {
-                    "dispatch"
-                } else if s.wait_cycles.is_some() {
-                    "wait_cycles"
-                } else if s.transition_cond.is_some() {
-                    "wait_until"
-                } else if si == 0 {
-                    "entry"
-                } else {
-                    "action"
-                };
+                let role = thread_map_state_role(si, s);
                 format!("_t{}_S{}_{}", ti, si, role)
             })
             .collect();
@@ -2822,19 +2818,20 @@ fn lower_module_threads(
         }
         for (si, count_expr, cond) in counter_loads {
             // cnt <= (count - 32'd1).trunc<32>()
+            let count_span = count_expr.span;
             let sub = Expr::new(ExprKind::Binary(
                 BinOp::Sub,
                 Box::new(count_expr.clone()),
-                Box::new(Expr::new(ExprKind::Literal(LitKind::Sized(32, 1)), sp)),
-            ), sp);
+                Box::new(Expr::new(ExprKind::Literal(LitKind::Sized(32, 1)), count_span)),
+            ), count_span);
             let load = Stmt::Assign(RegAssign {
-                target: Expr::new(ExprKind::Ident(cnt_name.clone()), sp),
+                target: Expr::new(ExprKind::Ident(cnt_name.clone()), count_span),
                 value: Expr::new(ExprKind::MethodCall(
                     Box::new(sub),
-                    Ident::new("trunc".to_string(), sp),
-                    vec![Expr::new(ExprKind::Literal(LitKind::Dec(32)), sp)],
-                ), sp),
-                span: sp,
+                    Ident::new("trunc".to_string(), count_span),
+                    vec![Expr::new(ExprKind::Literal(LitKind::Dec(32)), count_span)],
+                ), count_span),
+                span: count_span,
             });
             if let Some(guard) = cond {
                 raw_states[si].seq_stmts.push(Stmt::IfElse(IfElse {
@@ -2844,6 +2841,68 @@ fn lower_module_threads(
             } else {
                 raw_states[si].seq_stmts.push(load);
             }
+        }
+
+        if opts.thread_map.is_some() {
+            let mut states = Vec::new();
+            for (si, raw) in raw_states.iter().enumerate() {
+                let next_state = if si + 1 < n_states {
+                    si + 1
+                } else if t.once {
+                    si
+                } else {
+                    0
+                };
+                let transitions = if !raw.multi_transitions.is_empty() {
+                    raw.multi_transitions
+                        .iter()
+                        .map(|(cond, target)| {
+                            let tgt = if *target >= n_states {
+                                if t.once { n_states - 1 } else { 0 }
+                            } else {
+                                *target
+                            };
+                            crate::thread_map::ThreadMapTransition {
+                                condition: crate::thread_map::expr_label(cond),
+                                target_index: tgt,
+                                target_name: state_names[tgt].clone(),
+                            }
+                        })
+                        .collect()
+                } else if let Some(cond) = &raw.transition_cond {
+                    vec![crate::thread_map::ThreadMapTransition {
+                        condition: crate::thread_map::expr_label(cond),
+                        target_index: next_state,
+                        target_name: state_names[next_state].clone(),
+                    }]
+                } else if raw.wait_cycles.is_some() {
+                    vec![crate::thread_map::ThreadMapTransition {
+                        condition: format!("_t{}_cnt == 0", ti),
+                        target_index: next_state,
+                        target_name: state_names[next_state].clone(),
+                    }]
+                } else {
+                    vec![crate::thread_map::ThreadMapTransition {
+                        condition: "always".to_string(),
+                        target_index: next_state,
+                        target_name: state_names[next_state].clone(),
+                    }]
+                };
+                states.push(crate::thread_map::ThreadMapState {
+                    index: si,
+                    state_name: state_names[si].clone(),
+                    role: thread_map_state_role(si, raw).to_string(),
+                    span: thread_fsm_state_span(raw, t.span),
+                    labels: thread_map_state_labels(raw),
+                    transitions,
+                });
+            }
+            thread_map_threads.push(crate::thread_map::ThreadMapThread {
+                name: _tname.clone(),
+                index: ti,
+                span: t.span,
+                states,
+            });
         }
 
         // State transition always_ff
@@ -3107,6 +3166,15 @@ fn lower_module_threads(
 
     if !errors.is_empty() {
         return Err(errors);
+    }
+
+    if let Some(map) = &opts.thread_map {
+        map.borrow_mut().modules.push(crate::thread_map::ThreadMapModule {
+            module_name: m.name.name.clone(),
+            generated_module_name: merged_name.clone(),
+            span: m.span,
+            threads: thread_map_threads,
+        });
     }
 
     // ── Per-thread counter registers ─────────────────────────────────────
@@ -4237,6 +4305,71 @@ struct ThreadFsmState {
     /// Target-side TLM only: this state exits to a generated response state
     /// carrying the indexed return expression instead of falling through.
     terminal_return: Option<usize>,
+}
+
+fn thread_map_state_role(si: usize, state: &ThreadFsmState) -> &'static str {
+    if state.multi_transitions.len() > 1 {
+        "dispatch"
+    } else if state.wait_cycles.is_some() {
+        "wait_cycles"
+    } else if state.transition_cond.is_some() {
+        "wait_until"
+    } else if si == 0 {
+        "entry"
+    } else {
+        "action"
+    }
+}
+
+fn merge_span(acc: &mut Option<Span>, span: Span) {
+    *acc = Some(match *acc {
+        Some(existing) => existing.merge(span),
+        None => span,
+    });
+}
+
+fn thread_fsm_state_span(state: &ThreadFsmState, fallback: Span) -> Span {
+    let mut span = None;
+    for stmt in &state.comb_stmts {
+        merge_span(&mut span, crate::thread_map::stmt_span(stmt));
+    }
+    for stmt in &state.seq_stmts {
+        merge_span(&mut span, crate::thread_map::stmt_span(stmt));
+    }
+    if let Some(cond) = &state.transition_cond {
+        merge_span(&mut span, cond.span);
+    }
+    if let Some(count) = &state.wait_cycles {
+        merge_span(&mut span, count.span);
+    }
+    for (cond, _) in &state.multi_transitions {
+        merge_span(&mut span, cond.span);
+    }
+    span.unwrap_or(fallback)
+}
+
+fn thread_map_state_labels(state: &ThreadFsmState) -> Vec<String> {
+    let mut labels = Vec::new();
+    if !state.comb_stmts.is_empty() {
+        labels.push(format!("comb: {} stmt{}", state.comb_stmts.len(), plural_s(state.comb_stmts.len())));
+    }
+    if !state.seq_stmts.is_empty() {
+        labels.push(format!("seq: {} stmt{}", state.seq_stmts.len(), plural_s(state.seq_stmts.len())));
+    }
+    if let Some(cond) = &state.transition_cond {
+        labels.push(format!("wait until {}", crate::thread_map::expr_label(cond)));
+    }
+    if let Some(count) = &state.wait_cycles {
+        labels.push(format!("wait {} cycle", crate::thread_map::expr_label(count)));
+    }
+    if !state.multi_transitions.is_empty() {
+        labels.push(format!("branches: {}", state.multi_transitions.len()));
+    }
+    labels
+}
+
+fn plural_s(n: usize) -> &'static str {
+    if n == 1 { "" } else { "s" }
 }
 
 const THREAD_TARGET_NEXT: usize = usize::MAX;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ pub mod parser;
 pub mod resolve;
 pub mod sim_codegen;
 pub mod sim_credit_channel;
+pub mod thread_map;
 pub mod type_alias;
 pub mod typecheck;
 pub mod width;

--- a/src/main.rs
+++ b/src/main.rs
@@ -95,6 +95,11 @@ enum Command {
         /// Output .sv file
         #[arg(short, long)]
         o: Option<PathBuf>,
+        /// Emit a static HTML thread lowering map. Bare flag writes
+        /// `<sv-output-stem>.thread.html`; `--emit-thread-map=PATH` writes
+        /// the explicit path. The optional value requires `=`.
+        #[arg(long, num_args = 0..=1, require_equals = true)]
+        emit_thread_map: Option<Option<PathBuf>>,
         /// Auto-emit SVA properties from `thread` lowering (wait_until / wait
         /// N cycle progress, fork-join branch transitions). Wrapped in
         /// `synopsys translate_off/on` so they don't reach synthesis. Off by
@@ -281,6 +286,28 @@ impl MultiSource {
             .with_source_code(NamedSource::new(filename.to_string(), file_source.to_string()))
     }
 
+}
+
+fn thread_map_sources_from_multi(ms: &MultiSource) -> Vec<arch::thread_map::ThreadMapSource> {
+    ms.segments.iter()
+        .map(|(start, end, filename, source)| arch::thread_map::ThreadMapSource {
+            start: *start,
+            end: *end,
+            filename: filename.clone(),
+            source: source.clone(),
+        })
+        .collect()
+}
+
+fn filter_thread_map_by_ranges(
+    map: &arch::thread_map::ThreadMap,
+    ranges: &[(usize, usize)],
+) -> arch::thread_map::ThreadMap {
+    let modules = map.modules.iter()
+        .filter(|module| ranges.iter().any(|(start, end)| module.span.start >= *start && module.span.start < *end))
+        .cloned()
+        .collect();
+    arch::thread_map::ThreadMap { modules }
 }
 
 /// Run a compiler-command body and record its success/failure into the
@@ -483,12 +510,26 @@ fn main() -> miette::Result<()> {
                 other => return Err(miette::miette!("--thread-sim: expected `fsm`, `parallel`, or `both`, got `{}`", other)),
             }
         }
-        Command::Build { files, o, auto_thread_asserts, no_inline_deps } => {
+        Command::Build { files, o, emit_thread_map, auto_thread_asserts, no_inline_deps } => {
             let files_for_learn = files.clone();
             learn_wrap(&files_for_learn, move || {
+            if matches!(emit_thread_map, Some(Some(_))) && files.len() > 1 && o.is_none() {
+                return Err(miette::miette!(
+                    "--emit-thread-map=PATH requires a single combined build output; pass -o or use bare --emit-thread-map for per-file maps"
+                ));
+            }
             let all_files = resolve_use_imports(&files)?;
             let ms = MultiSource::from_files(&all_files)?;
-            let (ast, symbols, overload_map) = run_check_multi_opts(&ms, false, auto_thread_asserts)?;
+            let thread_map_store = emit_thread_map
+                .as_ref()
+                .map(|_| std::rc::Rc::new(std::cell::RefCell::new(arch::thread_map::ThreadMap::default())));
+            let (ast, symbols, overload_map) = run_check_multi_opts_with_thread_map(
+                &ms,
+                false,
+                auto_thread_asserts,
+                thread_map_store.clone(),
+            )?;
+            let thread_map_sources = thread_map_sources_from_multi(&ms);
 
             let comments = lexer::extract_comments(&ms.combined);
 
@@ -531,6 +572,28 @@ fn main() -> miette::Result<()> {
                 let out_path = o.unwrap_or_else(|| files[0].with_extension("sv"));
                 fs::write(&out_path, &sv).into_diagnostic()?;
                 eprintln!("Wrote {}", out_path.display());
+                if let (Some(req), Some(map_store)) = (&emit_thread_map, &thread_map_store) {
+                    let html_path = req
+                        .clone()
+                        .unwrap_or_else(|| out_path.with_extension("thread.html"));
+                    let map = if no_inline_deps {
+                        let keep: Vec<(usize, usize)> = ms.segments.iter()
+                            .filter_map(|(start, end, filename, _)| {
+                                if original_names.contains(filename) { Some((*start, *end)) } else { None }
+                            })
+                            .collect();
+                        filter_thread_map_by_ranges(&map_store.borrow(), &keep)
+                    } else {
+                        map_store.borrow().clone()
+                    };
+                    let html = arch::thread_map::render_html(
+                        &map,
+                        &thread_map_sources,
+                        &format!("Thread map for {}", out_path.display()),
+                    );
+                    fs::write(&html_path, html).into_diagnostic()?;
+                    eprintln!("Wrote {}", html_path.display());
+                }
                 // Companion .sdc file: only written if any module contained
                 // a `multicycle <N>` reg. No-op for legacy `.arch` sources.
                 if let Some(sdc_text) = sdc {
@@ -570,6 +633,17 @@ fn main() -> miette::Result<()> {
                     let out_path = std::path::Path::new(filename).with_extension("sv");
                     fs::write(&out_path, &sv).into_diagnostic()?;
                     eprintln!("Wrote {}", out_path.display());
+                    if let (Some(None), Some(map_store)) = (&emit_thread_map, &thread_map_store) {
+                        let map = filter_thread_map_by_ranges(&map_store.borrow(), &[(*seg_start, *seg_end)]);
+                        let html_path = out_path.with_extension("thread.html");
+                        let html = arch::thread_map::render_html(
+                            &map,
+                            &thread_map_sources,
+                            &format!("Thread map for {}", out_path.display()),
+                        );
+                        fs::write(&html_path, html).into_diagnostic()?;
+                        eprintln!("Wrote {}", html_path.display());
+                    }
                     // Companion .sdc per-file: only if this file's items
                     // declared `multicycle <N>` regs.
                     if let Some(sdc_text) = codegen.emit_sdc(&out_path.to_string_lossy()) {
@@ -1523,6 +1597,15 @@ fn run_check_multi_opts(
     skip_lower_threads: bool,
     auto_thread_asserts: bool,
 ) -> miette::Result<(arch::ast::SourceFile, resolve::SymbolTable, std::collections::HashMap<usize, usize>)> {
+    run_check_multi_opts_with_thread_map(ms, skip_lower_threads, auto_thread_asserts, None)
+}
+
+fn run_check_multi_opts_with_thread_map(
+    ms: &MultiSource,
+    skip_lower_threads: bool,
+    auto_thread_asserts: bool,
+    thread_map: Option<std::rc::Rc<std::cell::RefCell<arch::thread_map::ThreadMap>>>,
+) -> miette::Result<(arch::ast::SourceFile, resolve::SymbolTable, std::collections::HashMap<usize, usize>)> {
     let source = &ms.combined;
 
     // Lex
@@ -1630,6 +1713,7 @@ fn run_check_multi_opts(
     } else {
         let opts = elaborate::ThreadLowerOpts {
             auto_asserts: auto_thread_asserts,
+            thread_map,
         };
         elaborate::lower_threads_with_opts(ast, &opts).map_err(|errs| {
             let err = errs.into_iter().next().unwrap();

--- a/src/thread_map.rs
+++ b/src/thread_map.rs
@@ -1,0 +1,428 @@
+use crate::ast::{BinOp, Expr, ExprKind, InsideMember, LitKind, Stmt, UnaryOp};
+use crate::lexer::Span;
+
+#[derive(Debug, Clone, Default)]
+pub struct ThreadMap {
+    pub modules: Vec<ThreadMapModule>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ThreadMapModule {
+    pub module_name: String,
+    pub generated_module_name: String,
+    pub span: Span,
+    pub threads: Vec<ThreadMapThread>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ThreadMapThread {
+    pub name: String,
+    pub index: usize,
+    pub span: Span,
+    pub states: Vec<ThreadMapState>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ThreadMapState {
+    pub index: usize,
+    pub state_name: String,
+    pub role: String,
+    pub span: Span,
+    pub labels: Vec<String>,
+    pub transitions: Vec<ThreadMapTransition>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ThreadMapTransition {
+    pub condition: String,
+    pub target_index: usize,
+    pub target_name: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct ThreadMapSource {
+    pub start: usize,
+    pub end: usize,
+    pub filename: String,
+    pub source: String,
+}
+
+pub fn stmt_span(stmt: &Stmt) -> Span {
+    match stmt {
+        Stmt::Assign(a) => a.span,
+        Stmt::IfElse(ie) => ie.span,
+        Stmt::Match(m) => m.span,
+        Stmt::Log(l) => l.span,
+        Stmt::For(f) => f.span,
+        Stmt::Init(i) => i.span,
+        Stmt::WaitUntil(_, sp) => *sp,
+        Stmt::DoUntil { span, .. } => *span,
+    }
+}
+
+pub fn expr_label(expr: &Expr) -> String {
+    match &expr.kind {
+        ExprKind::Ident(name) => name.clone(),
+        ExprKind::SynthIdent(name, _) => name.clone(),
+        ExprKind::Literal(lit) => lit_label(lit),
+        ExprKind::Bool(v) => v.to_string(),
+        ExprKind::EnumVariant(en, v) => format!("{}::{}", en.name, v.name),
+        ExprKind::Unary(op, e) => match op {
+            UnaryOp::Not => format!("!{}", paren_expr(e)),
+            UnaryOp::BitNot => format!("~{}", paren_expr(e)),
+            UnaryOp::Neg => format!("-{}", paren_expr(e)),
+            UnaryOp::RedAnd => format!("&{}", paren_expr(e)),
+            UnaryOp::RedOr => format!("|{}", paren_expr(e)),
+            UnaryOp::RedXor => format!("^{}", paren_expr(e)),
+        },
+        ExprKind::Binary(op, l, r) => {
+            format!("{} {} {}", paren_expr(l), binop_label(*op), paren_expr(r))
+        }
+        ExprKind::Ternary(c, t, f) => {
+            format!("{} ? {} : {}", expr_label(c), expr_label(t), expr_label(f))
+        }
+        ExprKind::Index(base, idx) => format!("{}[{}]", expr_label(base), expr_label(idx)),
+        ExprKind::BitSlice(base, hi, lo) => {
+            format!(
+                "{}[{}:{}]",
+                expr_label(base),
+                expr_label(hi),
+                expr_label(lo)
+            )
+        }
+        ExprKind::PartSelect(base, start, width, up) => {
+            let dir = if *up { "+:" } else { "-:" };
+            format!(
+                "{}[{} {} {}]",
+                expr_label(base),
+                expr_label(start),
+                dir,
+                expr_label(width)
+            )
+        }
+        ExprKind::FieldAccess(base, field) => format!("{}.{}", expr_label(base), field.name),
+        ExprKind::MethodCall(base, name, args) => {
+            let args = args.iter().map(expr_label).collect::<Vec<_>>().join(", ");
+            format!("{}.{}({})", expr_label(base), name.name, args)
+        }
+        ExprKind::FunctionCall(name, args) => {
+            let args = args.iter().map(expr_label).collect::<Vec<_>>().join(", ");
+            format!("{}({})", name, args)
+        }
+        ExprKind::Concat(parts) => {
+            let parts = parts.iter().map(expr_label).collect::<Vec<_>>().join(", ");
+            format!("{{{parts}}}")
+        }
+        ExprKind::Repeat(n, e) => format!("{{{}{{{}}}}}", expr_label(n), expr_label(e)),
+        ExprKind::Cast(e, ty) => format!("cast<{ty:?}>({})", expr_label(e)),
+        ExprKind::StructLiteral(name, fields) => {
+            let fields = fields
+                .iter()
+                .map(|f| format!("{}: {}", f.name.name, expr_label(&f.value)))
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!("{}{{{}}}", name.name, fields)
+        }
+        ExprKind::Match(scrutinee, _) => format!("match {}", expr_label(scrutinee)),
+        ExprKind::ExprMatch(scrutinee, _) => format!("match {}", expr_label(scrutinee)),
+        ExprKind::Signed(e) => format!("signed({})", expr_label(e)),
+        ExprKind::Unsigned(e) => format!("unsigned({})", expr_label(e)),
+        ExprKind::Clog2(e) => format!("$clog2({})", expr_label(e)),
+        ExprKind::Onehot(e) => format!("onehot({})", expr_label(e)),
+        ExprKind::LatencyAt(e, n) => format!("{}@{}", expr_label(e), n),
+        ExprKind::SvaNext(n, e) => format!("##{} {}", n, expr_label(e)),
+        ExprKind::Inside(e, members) => {
+            let members = members
+                .iter()
+                .map(inside_member_label)
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!("{} inside {{{}}}", expr_label(e), members)
+        }
+        ExprKind::Todo => "todo!".to_string(),
+    }
+}
+
+pub fn render_html(map: &ThreadMap, sources: &[ThreadMapSource], title: &str) -> String {
+    let mut out = String::new();
+    out.push_str("<!doctype html>\n<html lang=\"en\">\n<head>\n<meta charset=\"utf-8\">\n");
+    out.push_str("<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\n");
+    out.push_str(&format!("<title>{}</title>\n", html_escape(title)));
+    out.push_str("<style>\n");
+    out.push_str(
+        r#"
+:root { color-scheme: light; --bg: #f7f8fb; --ink: #18202f; --muted: #607086; --line: #d9e0ea; --panel: #ffffff; }
+* { box-sizing: border-box; }
+body { margin: 0; font: 14px/1.45 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; color: var(--ink); background: var(--bg); }
+header { padding: 18px 24px 12px; border-bottom: 1px solid var(--line); background: #fff; }
+h1 { margin: 0 0 4px; font-size: 20px; font-weight: 700; letter-spacing: 0; }
+.sub { color: var(--muted); font-size: 13px; }
+.layout { display: grid; grid-template-columns: minmax(360px, 1.1fr) minmax(360px, .9fr); gap: 16px; padding: 16px; align-items: start; }
+.pane { background: var(--panel); border: 1px solid var(--line); border-radius: 8px; overflow: hidden; }
+.pane h2 { margin: 0; padding: 12px 14px; font-size: 14px; border-bottom: 1px solid var(--line); background: #fbfcfe; }
+.source-file { border-bottom: 1px solid var(--line); }
+.source-file:last-child { border-bottom: 0; }
+.file-title { padding: 10px 14px; font-weight: 650; color: #324157; background: #f2f5f9; border-bottom: 1px solid var(--line); }
+pre { margin: 0; overflow: auto; }
+.src-line { display: grid; grid-template-columns: 56px 92px minmax(0, 1fr); min-height: 22px; font: 12px/22px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+.ln { color: #7d8ca1; text-align: right; padding-right: 12px; user-select: none; border-right: 1px solid #eef2f6; }
+.bands { display: flex; gap: 3px; padding: 2px 8px; overflow: hidden; }
+.band { min-width: 18px; height: 18px; border-radius: 4px; text-align: center; line-height: 18px; font-size: 10px; font-weight: 700; color: #1f2c3d; }
+.code { white-space: pre; padding: 0 10px; min-width: 0; }
+.c0 { background: #d7ebff; } .c1 { background: #d9f2df; } .c2 { background: #ffe6c7; } .c3 { background: #eadcff; }
+.c4 { background: #d8f3f0; } .c5 { background: #ffe0e6; } .c6 { background: #edf0b9; } .c7 { background: #dde5f8; }
+.module { padding: 12px 14px 4px; border-bottom: 1px solid var(--line); }
+.module:last-child { border-bottom: 0; }
+h3 { margin: 0 0 8px; font-size: 15px; }
+h4 { margin: 12px 0 8px; font-size: 13px; color: #34445d; }
+table { width: 100%; border-collapse: collapse; table-layout: fixed; margin-bottom: 12px; }
+th, td { border-top: 1px solid #edf1f6; padding: 7px 8px; vertical-align: top; text-align: left; overflow-wrap: anywhere; }
+th { color: #53647c; font-size: 12px; font-weight: 650; background: #fbfcfe; }
+.state-chip { display: inline-block; padding: 2px 6px; border-radius: 5px; font: 11px/16px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-weight: 700; }
+.role { color: #5f6f84; font-size: 12px; }
+.labels { color: #2d3b50; }
+.trans { color: #364860; font: 12px/1.4 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+.empty { padding: 20px 24px; color: var(--muted); }
+@media (max-width: 900px) { .layout { grid-template-columns: 1fr; } }
+"#,
+    );
+    out.push_str("</style>\n</head>\n<body>\n");
+    out.push_str(&format!(
+        "<header><h1>{}</h1><div class=\"sub\">ARCH thread lowering map</div></header>\n",
+        html_escape(title)
+    ));
+
+    if map.modules.is_empty() {
+        out.push_str("<main class=\"empty\">No lowered thread states were recorded.</main>\n</body>\n</html>\n");
+        return out;
+    }
+
+    out.push_str("<main class=\"layout\">\n<section class=\"pane\"><h2>Source Partitions</h2>\n");
+    for src in sources.iter().filter(|src| source_has_map(map, src)) {
+        render_source_file(&mut out, map, src);
+    }
+    out.push_str("</section>\n<section class=\"pane\"><h2>Lowered States</h2>\n");
+    for module in &map.modules {
+        out.push_str("<div class=\"module\">");
+        out.push_str(&format!(
+            "<h3>{} <span class=\"role\">→ {}</span></h3>",
+            html_escape(&module.module_name),
+            html_escape(&module.generated_module_name)
+        ));
+        for thread in &module.threads {
+            out.push_str(&format!(
+                "<h4>thread {} <span class=\"role\">index {}</span></h4>",
+                html_escape(&thread.name),
+                thread.index
+            ));
+            out.push_str("<table><thead><tr><th style=\"width:22%\">State</th><th style=\"width:13%\">Lines</th><th style=\"width:25%\">Labels</th><th>Transitions</th></tr></thead><tbody>");
+            for state in &thread.states {
+                let lines = find_line_range(sources, state.span)
+                    .map(|(_, a, b)| {
+                        if a == b {
+                            a.to_string()
+                        } else {
+                            format!("{a}-{b}")
+                        }
+                    })
+                    .unwrap_or_else(|| "-".to_string());
+                out.push_str("<tr>");
+                out.push_str(&format!(
+                    "<td><span class=\"state-chip c{}\">S{}</span><br>{}<br><span class=\"role\">{}</span></td>",
+                    state.index % 8,
+                    state.index,
+                    html_escape(&state.state_name),
+                    html_escape(&state.role)
+                ));
+                out.push_str(&format!("<td>{}</td>", html_escape(&lines)));
+                out.push_str("<td class=\"labels\">");
+                if state.labels.is_empty() {
+                    out.push_str("&nbsp;");
+                } else {
+                    out.push_str(&html_escape(&state.labels.join("; ")));
+                }
+                out.push_str("</td><td class=\"trans\">");
+                if state.transitions.is_empty() {
+                    out.push_str("&nbsp;");
+                } else {
+                    for (i, tr) in state.transitions.iter().enumerate() {
+                        if i > 0 {
+                            out.push_str("<br>");
+                        }
+                        out.push_str(&format!(
+                            "{} → S{} {}",
+                            html_escape(&tr.condition),
+                            tr.target_index,
+                            html_escape(&tr.target_name)
+                        ));
+                    }
+                }
+                out.push_str("</td></tr>");
+            }
+            out.push_str("</tbody></table>");
+        }
+        out.push_str("</div>");
+    }
+    out.push_str("</section>\n</main>\n</body>\n</html>\n");
+    out
+}
+
+fn render_source_file(out: &mut String, map: &ThreadMap, src: &ThreadMapSource) {
+    out.push_str("<div class=\"source-file\">");
+    out.push_str(&format!(
+        "<div class=\"file-title\">{}</div><pre>",
+        html_escape(&src.filename)
+    ));
+    let mut offset = src.start;
+    for (idx, raw_line) in src.source.split_inclusive('\n').enumerate() {
+        let line_no = idx + 1;
+        let line_text = raw_line.strip_suffix('\n').unwrap_or(raw_line);
+        let line_start = offset;
+        let line_end = offset + raw_line.len().max(1);
+        offset += raw_line.len();
+        let states = states_overlapping_line(map, src, line_start, line_end);
+        out.push_str("<div class=\"src-line\">");
+        out.push_str(&format!(
+            "<span class=\"ln\">{line_no}</span><span class=\"bands\">"
+        ));
+        for state in states.iter().take(4) {
+            out.push_str(&format!(
+                "<span class=\"band c{}\">S{}</span>",
+                state.index % 8,
+                state.index
+            ));
+        }
+        out.push_str("</span>");
+        out.push_str(&format!(
+            "<span class=\"code\">{}</span></div>",
+            html_escape(line_text)
+        ));
+    }
+    out.push_str("</pre></div>");
+}
+
+fn source_has_map(map: &ThreadMap, src: &ThreadMapSource) -> bool {
+    map.modules.iter().any(|m| {
+        span_overlaps(m.span, src.start, src.end)
+            || m.threads.iter().any(|t| {
+                span_overlaps(t.span, src.start, src.end)
+                    || t.states
+                        .iter()
+                        .any(|s| span_overlaps(s.span, src.start, src.end))
+            })
+    })
+}
+
+fn states_overlapping_line<'a>(
+    map: &'a ThreadMap,
+    src: &ThreadMapSource,
+    line_start: usize,
+    line_end: usize,
+) -> Vec<&'a ThreadMapState> {
+    let mut states = Vec::new();
+    for module in &map.modules {
+        if !span_overlaps(module.span, src.start, src.end) {
+            continue;
+        }
+        for thread in &module.threads {
+            for state in &thread.states {
+                if span_overlaps(state.span, line_start, line_end) {
+                    states.push(state);
+                }
+            }
+        }
+    }
+    states
+}
+
+fn find_line_range(sources: &[ThreadMapSource], span: Span) -> Option<(&str, usize, usize)> {
+    let src = sources
+        .iter()
+        .find(|src| span.start >= src.start && span.start <= src.end)?;
+    let start = line_for_offset(&src.source, span.start.saturating_sub(src.start));
+    let end = line_for_offset(&src.source, span.end.saturating_sub(src.start));
+    Some((&src.filename, start, end.max(start)))
+}
+
+fn line_for_offset(source: &str, local_offset: usize) -> usize {
+    let mut line = 1;
+    for (idx, b) in source.as_bytes().iter().enumerate() {
+        if idx >= local_offset {
+            break;
+        }
+        if *b == b'\n' {
+            line += 1;
+        }
+    }
+    line
+}
+
+fn span_overlaps(span: Span, start: usize, end: usize) -> bool {
+    span.start < end && span.end > start
+}
+
+fn html_escape(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for ch in s.chars() {
+        match ch {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            '\'' => out.push_str("&#39;"),
+            _ => out.push(ch),
+        }
+    }
+    out
+}
+
+fn paren_expr(expr: &Expr) -> String {
+    match expr.kind {
+        ExprKind::Binary(..) | ExprKind::Ternary(..) => format!("({})", expr_label(expr)),
+        _ => expr_label(expr),
+    }
+}
+
+fn lit_label(lit: &LitKind) -> String {
+    match lit {
+        LitKind::Dec(v) => v.to_string(),
+        LitKind::Hex(v) => format!("0x{v:x}"),
+        LitKind::Bin(v) => format!("0b{v:b}"),
+        LitKind::Sized(w, v) => format!("{w}'d{v}"),
+    }
+}
+
+fn binop_label(op: BinOp) -> &'static str {
+    match op {
+        BinOp::Add => "+",
+        BinOp::Sub => "-",
+        BinOp::Mul => "*",
+        BinOp::Div => "/",
+        BinOp::Mod => "%",
+        BinOp::Eq => "==",
+        BinOp::Neq => "!=",
+        BinOp::Lt => "<",
+        BinOp::Lte => "<=",
+        BinOp::Gt => ">",
+        BinOp::Gte => ">=",
+        BinOp::And => "&&",
+        BinOp::Or => "||",
+        BinOp::BitAnd => "&",
+        BinOp::BitOr => "|",
+        BinOp::BitXor => "^",
+        BinOp::Shl => "<<",
+        BinOp::Shr => ">>",
+        BinOp::Implies => "|->",
+        BinOp::ImpliesNext => "|=>",
+        BinOp::AddWrap => "+%",
+        BinOp::SubWrap => "-%",
+        BinOp::MulWrap => "*%",
+    }
+}
+
+fn inside_member_label(member: &InsideMember) -> String {
+    match member {
+        InsideMember::Single(e) => expr_label(e),
+        InsideMember::Range(lo, hi) => format!("{}..{}", expr_label(lo), expr_label(hi)),
+    }
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -74,6 +74,23 @@ fn compile_to_sv_with_opts(source: &str, opts: &elaborate::ThreadLowerOpts) -> S
     codegen.generate()
 }
 
+fn collect_thread_map(source: &str) -> arch::thread_map::ThreadMap {
+    let tokens = lexer::tokenize(source).expect("lexer error");
+    let mut parser = Parser::new(tokens, source);
+    let parsed_ast = parser.parse_source_file().expect("parse error");
+    let ast = elaborate::elaborate(parsed_ast).expect("elaborate error");
+    let ast = elaborate::lower_tlm_target_threads(ast).expect("tlm_target lowering error");
+    let ast = elaborate::lower_tlm_initiator_calls(ast).expect("tlm_initiator lowering error");
+    let map = std::rc::Rc::new(std::cell::RefCell::new(arch::thread_map::ThreadMap::default()));
+    let opts = elaborate::ThreadLowerOpts {
+        thread_map: Some(map.clone()),
+        ..Default::default()
+    };
+    let _ast = elaborate::lower_threads_with_opts(ast, &opts).expect("lower_threads error");
+    let collected = map.borrow().clone();
+    collected
+}
+
 #[test]
 fn test_top_counter_compiles() {
     let source = include_str!("../examples/top_counter.arch");
@@ -10885,7 +10902,7 @@ fn test_auto_thread_asserts_wait_cycles_and_until() {
     // emit, wrapped in `synopsys translate_off/on`, with reset-guarded
     // antecedents.
     let source = include_str!("../tests/thread/wait_cycles.arch");
-    let opts = elaborate::ThreadLowerOpts { auto_asserts: true };
+    let opts = elaborate::ThreadLowerOpts { auto_asserts: true, ..Default::default() };
     let sv = compile_to_sv_with_opts(source, &opts);
 
     // Wait-until: state 0 transitions on `start`. Issue #247 changed
@@ -10918,7 +10935,7 @@ fn test_auto_thread_asserts_fork_join_branches() {
     // fork/join produces multi_transitions. Each branch transition gets
     // an `_auto_thread_t{i}_branch_s{s}_b{b}` assertion.
     let source = include_str!("../tests/thread/fork_join.arch");
-    let opts = elaborate::ThreadLowerOpts { auto_asserts: true };
+    let opts = elaborate::ThreadLowerOpts { auto_asserts: true, ..Default::default() };
     let sv = compile_to_sv_with_opts(source, &opts);
     assert!(sv.contains("_auto_thread_t0_branch_s"),
         "expected at least one fork/join branch assertion:\n{sv}");
@@ -10941,12 +10958,156 @@ fn test_auto_thread_asserts_active_high_reset() {
           end thread
         end module M
     "#;
-    let opts = elaborate::ThreadLowerOpts { auto_asserts: true };
+    let opts = elaborate::ThreadLowerOpts { auto_asserts: true, ..Default::default() };
     let sv = compile_to_sv_with_opts(source, &opts);
     assert!(sv.contains("!rst &&"),
         "expected `!rst` guard for active-high reset:\n{sv}");
     assert!(!sv.contains("(rst) &&"),
         "should not use bare `rst` as guard for active-high:\n{sv}");
+}
+
+// ── Thread map HTML sidecar ──────────────────────────────────────────────────
+
+fn thread_map_smoke_source(module_name: &str) -> String {
+    format!(r#"
+        module {module_name}
+          port clk:  in Clock<SysDomain>;
+          port rst:  in Reset<Async, Low>;
+          port go:   in Bool;
+          port done: out Bool;
+          thread T on clk rising, rst low
+            done = 0;
+            wait until go;
+            done = 1;
+            wait 2 cycle;
+          end thread T
+        end module {module_name}
+    "#)
+}
+
+#[test]
+fn test_build_emit_thread_map_bare_path() {
+    let td = tempfile::tempdir().expect("tempdir");
+    let src = td.path().join("Flow.arch");
+    let sv_out = td.path().join("Flow.sv");
+    let html_out = td.path().join("Flow.thread.html");
+    std::fs::write(&src, thread_map_smoke_source("Flow")).expect("write source");
+
+    let out = std::process::Command::new(env!("CARGO_BIN_EXE_arch"))
+        .env("ARCH_NO_LEARN", "1")
+        .arg("build")
+        .arg(&src)
+        .arg("-o")
+        .arg(&sv_out)
+        .arg("--emit-thread-map")
+        .output()
+        .expect("run arch build --emit-thread-map");
+    assert!(out.status.success(),
+        "build should pass\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr));
+    assert!(html_out.exists(), "expected bare flag to write {}", html_out.display());
+    let html = std::fs::read_to_string(&html_out).expect("read thread map");
+    assert!(html.contains("_t0_S0_wait_until"), "expected generated state name in HTML:\n{html}");
+    assert!(html.contains("wait until go"), "expected source line in HTML:\n{html}");
+    assert!(html.contains("done = 1"), "expected source assignment in HTML:\n{html}");
+}
+
+#[test]
+fn test_build_emit_thread_map_explicit_path() {
+    let td = tempfile::tempdir().expect("tempdir");
+    let src = td.path().join("Flow.arch");
+    let sv_out = td.path().join("Flow.sv");
+    let html_out = td.path().join("custom_map.html");
+    std::fs::write(&src, thread_map_smoke_source("Flow")).expect("write source");
+
+    let out = std::process::Command::new(env!("CARGO_BIN_EXE_arch"))
+        .env("ARCH_NO_LEARN", "1")
+        .arg("build")
+        .arg(&src)
+        .arg("-o")
+        .arg(&sv_out)
+        .arg(format!("--emit-thread-map={}", html_out.display()))
+        .output()
+        .expect("run arch build --emit-thread-map=path");
+    assert!(out.status.success(),
+        "build should pass\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr));
+    assert!(html_out.exists(), "expected explicit map path to be written");
+}
+
+#[test]
+fn test_build_emit_thread_map_multifile_paths_and_explicit_error() {
+    let td = tempfile::tempdir().expect("tempdir");
+    let a = td.path().join("A.arch");
+    let b = td.path().join("B.arch");
+    std::fs::write(&a, thread_map_smoke_source("A")).expect("write A");
+    std::fs::write(&b, thread_map_smoke_source("B")).expect("write B");
+
+    let ok = std::process::Command::new(env!("CARGO_BIN_EXE_arch"))
+        .env("ARCH_NO_LEARN", "1")
+        .arg("build")
+        .arg(&a)
+        .arg(&b)
+        .arg("--emit-thread-map")
+        .output()
+        .expect("run multi-file build");
+    assert!(ok.status.success(),
+        "multi-file bare map should pass\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&ok.stdout),
+        String::from_utf8_lossy(&ok.stderr));
+    assert!(td.path().join("A.thread.html").exists(), "expected A.thread.html");
+    assert!(td.path().join("B.thread.html").exists(), "expected B.thread.html");
+
+    let explicit = td.path().join("all.html");
+    let err = std::process::Command::new(env!("CARGO_BIN_EXE_arch"))
+        .env("ARCH_NO_LEARN", "1")
+        .arg("build")
+        .arg(&a)
+        .arg(&b)
+        .arg(format!("--emit-thread-map={}", explicit.display()))
+        .output()
+        .expect("run multi-file explicit map build");
+    assert!(!err.status.success(), "explicit map without -o should fail");
+    let stderr = String::from_utf8_lossy(&err.stderr);
+    assert!(stderr.contains("--emit-thread-map=PATH requires"),
+        "expected explicit multi-file diagnostic, got:\n{stderr}");
+}
+
+#[test]
+fn test_thread_map_metadata_records_dispatch_and_wait_roles() {
+    let simple = collect_thread_map(&thread_map_smoke_source("Simple"));
+    let simple_thread = &simple.modules[0].threads[0];
+    assert!(simple_thread.states.iter().any(|s| s.role == "wait_until" && s.labels.iter().any(|l| l.contains("go"))),
+        "expected simple wait_until state labelled with go: {simple_thread:#?}");
+
+    let source = r#"
+        module M
+          port clk:  in Clock<SysDomain>;
+          port rst:  in Reset<Async, Low>;
+          port go:   in Bool;
+          port sel:  in Bool;
+          port ack:  in Bool;
+          port done: out Bool;
+          thread T on clk rising, rst low
+            wait until go;
+            if sel
+              wait until ack;
+            else
+              wait 2 cycle;
+            end if
+            done = 1;
+            wait 1 cycle;
+          end thread T
+        end module M
+    "#;
+    let map = collect_thread_map(source);
+    let thread = &map.modules[0].threads[0];
+    assert!(thread.states.iter().any(|s| s.role == "wait_cycles"),
+        "expected wait_cycles state: {thread:#?}");
+    assert!(thread.states.iter().any(|s| s.role == "dispatch" && s.transitions.iter().any(|t| t.condition.contains("sel"))),
+        "expected dispatch state with sel transition: {thread:#?}");
 }
 
 // ── If/else with internal waits — dispatch-and-rejoin ─────────────────────────
@@ -11450,7 +11611,7 @@ fn test_if_wait_with_auto_asserts() {
           end thread
         end module M
     "#;
-    let opts = elaborate::ThreadLowerOpts { auto_asserts: true };
+    let opts = elaborate::ThreadLowerOpts { auto_asserts: true, ..Default::default() };
     let sv = compile_to_sv_with_opts(source, &opts);
     assert!(sv.contains("_auto_thread_t0_branch_"),
         "expected dispatch-state branch assertions:\n{sv}");


### PR DESCRIPTION
## Summary

- add `arch build --emit-thread-map[=HTML]` for static thread-lowering HTML sidecars
- collect source-to-state metadata during thread lowering without changing normal SV output
- render a split source/state table view and cover single-file, explicit-path, and multi-file behavior in tests

## Validation

- `cargo test thread_map`
- `cargo test`
