### PR TITLE
fix(nic400): MasterPort — restore if-not/wait-until pattern after retired-syntax regression in #485

### DIFF
--- a/tests/nic400/Nic400MasterPort.arch
+++ b/tests/nic400/Nic400MasterPort.arch
@@ -68,7 +68,9 @@ module Nic400MasterPort
         outs[j].ar_region = 0;
         m.ar_ready      = false;
       end default
-      wait 0+ cycle until m.ar_valid and m_ar_slv == j;
+      if not (m.ar_valid and m_ar_slv == j)
+        wait until m.ar_valid and m_ar_slv == j;
+      end if
       lock ar_ch
         do
           outs[j].ar_valid  = true;
@@ -99,7 +101,9 @@ module Nic400MasterPort
         m.r_last  = false;
         outs[j].r_ready = false;
       end default
-      wait 0+ cycle until outs[j].r_valid and outs[j].r_id[SLAVE_ID_W-1:MASTER_ID_W] == I;
+      if not (outs[j].r_valid and outs[j].r_id[SLAVE_ID_W-1:MASTER_ID_W] == I)
+        wait until outs[j].r_valid and outs[j].r_id[SLAVE_ID_W-1:MASTER_ID_W] == I;
+      end if
       lock r_ch
         do
           m.r_valid = true;
@@ -143,7 +147,9 @@ module Nic400MasterPort
         m.b_resp   = 0;
       end default
       // AW phase: wait for master's AW and address-decode match.
-      wait 0+ cycle until m.aw_valid and m_aw_slv == j;
+      if not (m.aw_valid and m_aw_slv == j)
+        wait until m.aw_valid and m_aw_slv == j;
+      end if
       lock aw_ch
         do
           outs[j].aw_valid  = true;


### PR DESCRIPTION
## Summary

PR #485 (commit dc47366) reverted three sites in
[`tests/nic400/Nic400MasterPort.arch`](tests/nic400/Nic400MasterPort.arch)
back to the `wait 0+ cycle until <cond>;` form that was retired in
commit 2b22c56 (\"Retire wait 0+ thread syntax\", 2026-05-28).

After that merge, `arch check tests/nic400/Nic400MasterPort.arch` fails:

```
× `wait 0+ cycle until <cond>;` has been retired; use
  `if not <cond> ... wait until <cond>; ... end if`
  for zero-or-more-cycle fast-path waiting
   71 │       wait 0+ cycle until m.ar_valid and m_ar_slv == j;
```

…and every downstream `harc sim` of `Nic400Fabric` fails to build.

The actual point of #485 — moving the `if not / wait until / end if`
guard outside `b_ch` for OOO B delivery — is correct and untouched.
This PR restores the same pattern for the AR/R/AW phases at lines 71,
102, and 146.

CI on #485 (https://github.com/arch-hdl-lang/arch-com/actions/runs/26728450799/job/78767719816)
ran only the CLA check, so the regression slipped through.

## Test plan

- [x] `arch check tests/nic400/Nic400MasterPort.arch` — **OK**
- [x] `harc sim Nic400OooCompletion_test.harc` — **ALL TESTS PASSED**
      (\"PASS OOO: B(id=1) from slave1 arrived before B(id=0)\")
- [x] Hot-slave fairness failures reproduce on pre-#485 baseline too,
      so they are pre-existing and out of scope.