### PR TITLE
fix(signal_flow): include default comb reads in dead-skid lint

### DIFF
--- a/src/signal_flow.rs
+++ b/src/signal_flow.rs
@@ -367,12 +367,13 @@ fn collect_one_thread_comb_stmt(stmt: &ThreadStmt, out: &mut HashMap<String, Spa
 }
 
 /// Collect the set of signal names a thread reads (read set), with the span of
-/// the first read of each.  Reads come from RHS values, `wait until` / `do
-/// until` conditions, `if` conditions, loop bounds, and LHS index/slice
-/// expressions.
+/// the first read of each. Reads come from RHS values in the body and
+/// `default comb`, `wait until` / `do until` conditions, `if` conditions, loop
+/// bounds, and LHS index/slice expressions.
 pub fn thread_read_set(t: &ThreadBlock) -> HashMap<String, Span> {
     let mut out = HashMap::new();
     collect_thread_reads(&t.body, &mut out);
+    collect_stmt_reads(&t.default_comb, &mut out);
     if let Some((cond, body)) = &t.default_when {
         add_expr_reads(cond, t.span, &mut out);
         collect_thread_reads(body, &mut out);
@@ -415,6 +416,56 @@ fn collect_lhs_index_reads(target: &Expr, span: Span, out: &mut HashMap<String, 
 fn collect_thread_reads(stmts: &[ThreadStmt], out: &mut HashMap<String, Span>) {
     for s in stmts {
         collect_one_thread_read(s, out);
+    }
+}
+
+fn collect_stmt_reads(stmts: &[Stmt], out: &mut HashMap<String, Span>) {
+    for s in stmts {
+        collect_one_stmt_read(s, out);
+    }
+}
+
+fn collect_one_stmt_read(stmt: &Stmt, out: &mut HashMap<String, Span>) {
+    match stmt {
+        Stmt::Assign(a) => {
+            add_expr_reads(&a.value, a.span, out);
+            collect_lhs_index_reads(&a.target, a.span, out);
+        }
+        Stmt::IfElse(ie) => {
+            add_expr_reads(&ie.cond, ie.span, out);
+            collect_stmt_reads(&ie.then_stmts, out);
+            collect_stmt_reads(&ie.else_stmts, out);
+        }
+        Stmt::Match(ms) => {
+            add_expr_reads(&ms.scrutinee, ms.span, out);
+            for arm in &ms.arms {
+                if let Pattern::Literal(e) = &arm.pattern {
+                    add_expr_reads(e, ms.span, out);
+                }
+                collect_stmt_reads(&arm.body, out);
+            }
+        }
+        Stmt::For(fl) => {
+            match &fl.range {
+                ForRange::Range(start, end) => {
+                    add_expr_reads(start, fl.span, out);
+                    add_expr_reads(end, fl.span, out);
+                }
+                ForRange::ValueList(vals) => {
+                    for v in vals {
+                        add_expr_reads(v, fl.span, out);
+                    }
+                }
+            }
+            collect_stmt_reads(&fl.body, out);
+        }
+        Stmt::Init(ib) => collect_stmt_reads(&ib.body, out),
+        Stmt::DoUntil { body, cond, span } => {
+            collect_stmt_reads(body, out);
+            add_expr_reads(cond, *span, out);
+        }
+        Stmt::WaitUntil(cond, span) => add_expr_reads(cond, *span, out),
+        Stmt::Log(_) => {}
     }
 }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -19453,6 +19453,52 @@ end module IntraTop
     );
 }
 
+/// The read can also live in `default comb`, not just in `wait until` or an
+/// RHS inside the thread body. During dead-skid cycles the comb-driven source
+/// still collapses to its default, so a default output that mirrors the routed
+/// comb feedback is hazardous and must be reported.
+#[test]
+fn test_dead_skid_default_comb_read_hazard() {
+    let source = r#"
+domain SysDomain
+  freq_mhz: 100
+end domain SysDomain
+
+module Alu
+  port a: in UInt<8>;
+  port z: out Bool;
+  comb
+    z = (a == 0);
+  end comb
+end module Alu
+
+module Top
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port done: out Bool;
+  port go: in Bool;
+  wire a_drv: UInt<8>;
+  wire z_w: Bool;
+  inst alu: Alu
+    a <- a_drv;
+    z -> z_w;
+  end inst alu
+  thread Worker on clk rising, rst high
+    default comb
+      done = z_w;
+    end default
+    a_drv = 8'd1;
+    wait until go;
+  end thread Worker
+end module Top
+"#;
+    let hz = dead_skid_hazards(source, "Top");
+    assert!(
+        hz.iter().any(|h| h.read_signal == "z_w" && h.driven_signal == "a_drv"),
+        "expected default-comb read hazard `a_drv -> z_w`, got {hz:?}"
+    );
+}
+
 /// A module with no threads yields no hazards (cheap early-out path).
 #[test]
 fn test_dead_skid_no_threads_no_hazard() {


### PR DESCRIPTION
## Summary
- include `default comb` RHS reads in the dead-skid read-set collector
- add a regression that covers the missed default-comb feedback shape
- keep the existing dead-skid hazard/negative tests green

## Why
PR #486's dead-skid lint currently scans thread-body reads and `default_when`, but it skips reads that happen inside a thread's `default comb`. That misses a real hazard shape: a thread can mirror a routed combinational feedback signal into an output from `default comb`, and that read is still exposed to dead-skid collapse.

## Test plan
- `cargo test dead_skid -- --nocapture`

## Context
Follow-up fix for #486.
