### PR TITLE
fix(nic400): preserve burst length on DECERR reads

### DIFF
--- a/tests/nic400/Nic400DefaultSlave.arch
+++ b/tests/nic400/Nic400DefaultSlave.arch
@@ -32,6 +32,7 @@ module Nic400DefaultSlave
   // cycle so the response echoes the correct ID after ar_valid / aw_valid
   // may be de-asserted.
   reg rd_id: Vec<UInt<SLAVE_ID_W>, NUM_MASTERS> reset rst => 0;
+  reg rd_len: Vec<UInt<8>, NUM_MASTERS> reset rst => 0;
   reg wr_id: Vec<UInt<SLAVE_ID_W>, NUM_MASTERS> reset rst => 0;
 
   generate_for i in 0..NUM_MASTERS-1
@@ -40,6 +41,7 @@ module Nic400DefaultSlave
     seq on clk rising
       if m[i].ar_valid and m[i].ar_ready
         rd_id[i] <= m[i].ar_id;
+        rd_len[i] <= m[i].ar_len;
       end if
       if m[i].aw_valid and m[i].aw_ready
         wr_id[i] <= m[i].aw_id;
@@ -64,14 +66,17 @@ module Nic400DefaultSlave
         m[i].ar_ready = true;
       until m[i].ar_valid;
 
-      // Single RRESP=DECERR (0b11) beat with RLAST.
-      do
-        m[i].r_valid = true;
-        m[i].r_id    = rd_id[i];
-        m[i].r_resp  = 3;
-        m[i].r_data  = 0;
-        m[i].r_last  = true;
-      until m[i].r_ready;
+      // Return one DECERR beat per requested transfer so burst reads keep
+      // AXI beat count and RLAST semantics intact.
+      for b in 0..rd_len[i]
+        do
+          m[i].r_valid = true;
+          m[i].r_id    = rd_id[i];
+          m[i].r_resp  = 3;
+          m[i].r_data  = 0;
+          m[i].r_last  = (b == rd_len[i]);
+        until m[i].r_ready;
+      end for
     end thread Rd_i
 
     // ── Wr_i: accept AW → drain W → return BRESP=DECERR ────────────────

--- a/tests/nic400/Nic400DefaultSlave_test.harc
+++ b/tests/nic400/Nic400DefaultSlave_test.harc
@@ -19,9 +19,11 @@
 // Scenarios:
 //   S1. OOR read:  M0 issues AR with addr=0x8000_0000 (bit31 set → OOR).
 //       Expect RRESP=DECERR (0b11), RLAST=1, R-id echoes the AR-id.
-//   S2. OOR write: M1 issues AW+W with addr=0xC000_0000 (OOR).
+//   S2. OOR burst read: M0 issues ARLEN=3 to an OOR address.
+//       Expect 4 DECERR beats, echoed id on every beat, RLAST only on beat 3.
+//   S3. OOR write: M1 issues AW+W with addr=0xC000_0000 (OOR).
 //       Expect BRESP=DECERR (0b11), B-id echoes the AW-id.
-//   S3. Valid read still works (regression): M2 → slave2 (0x2000_0000),
+//   S4. Valid read still works (regression): M2 → slave2 (0x2000_0000),
 //       confirms the OOR path didn't break normal decode.
 
 testbench Nic400DefaultSlaveTb
@@ -179,7 +181,57 @@ impl Nic400DefaultSlaveTest for Nic400DefaultSlaveTb
         dut.m_r_ready[0]  = 0
         wait 3 cycles
 
-        // ── S2: OOR write → DECERR ────────────────────────────────────────
+        // ── S2: OOR burst read → 4x DECERR beats ─────────────────────────
+        dut.m_ar_valid[0] = 1
+        dut.m_ar_addr[0]  = 0xC0001000
+        dut.m_ar_id[0]    = 6
+        dut.m_ar_size[0]  = 2
+        dut.m_ar_burst[0] = 1
+        dut.m_ar_len[0]   = 3
+        dut.m_r_ready[0]  = 1
+
+        let s2_beats     : uint<32> = 0
+        let s2_last_seen : uint<32> = 99
+        let s2_id_ok     : uint<32> = 1
+        let s2_resp_ok   : uint<32> = 1
+
+        for _ in 0 .. 50
+            wait 1 cycle
+            if dut.m_ar_ready[0] == 1
+                dut.m_ar_valid[0] = 0
+            end if
+            if dut.m_r_valid[0] == 1
+                if (dut.m_r_id[0] & 7) != 6
+                    s2_id_ok = 0
+                end if
+                if dut.m_r_resp[0] != 3
+                    s2_resp_ok = 0
+                end if
+                if s2_beats == 3
+                    s2_last_seen = dut.m_r_last[0]
+                elsif dut.m_r_last[0] != 0
+                    s2_last_seen = 77
+                end if
+                s2_beats = s2_beats + 1
+            end if
+        end for
+
+        assert s2_beats == 4
+            else fail("S2: OOR burst read saw ${s2_beats} beats (expected 4)")
+        assert s2_id_ok == 1
+            else fail("S2: OOR burst read did not echo AR-id on every beat")
+        assert s2_resp_ok == 1
+            else fail("S2: OOR burst read did not return DECERR on every beat")
+        assert s2_last_seen == 1
+            else fail("S2: OOR burst read RLAST handling wrong (${s2_last_seen})")
+        log(info, "PASS S2: OOR burst read → 4x DECERR beats with final RLAST")
+
+        dut.m_ar_valid[0] = 0
+        dut.m_r_ready[0]  = 0
+        dut.m_ar_len[0]   = 0
+        wait 3 cycles
+
+        // ── S3: OOR write → DECERR ────────────────────────────────────────
         // M1 issues AW+W to 0xC000_0000 (bits[31:30]=0b11 → out of range).
         dut.m_aw_valid[1] = 1
         dut.m_aw_addr[1]  = 0xC0000000
@@ -213,19 +265,19 @@ impl Nic400DefaultSlaveTest for Nic400DefaultSlaveTb
         end for
 
         assert s2_done == 1
-            else fail("S2: OOR write got no B response")
+            else fail("S3: OOR write got no B response")
         assert s2_resp == 3
-            else fail("S2: OOR write BRESP=${s2_resp} (expected 3=DECERR)")
+            else fail("S3: OOR write BRESP=${s2_resp} (expected 3=DECERR)")
         assert s2_id == 2
-            else fail("S2: OOR write B-id=${s2_id} (expected 2, echoed AW-id)")
-        log(info, "PASS S2: OOR write → DECERR (BRESP=3, B-id=2)")
+            else fail("S3: OOR write B-id=${s2_id} (expected 2, echoed AW-id)")
+        log(info, "PASS S3: OOR write → DECERR (BRESP=3, B-id=2)")
 
         dut.m_aw_valid[1] = 0
         dut.m_w_valid[1]  = 0
         dut.m_b_ready[1]  = 0
         wait 3 cycles
 
-        // ── S3: Valid read regression ─────────────────────────────────────
+        // ── S4: Valid read regression ─────────────────────────────────────
         // M2 reads slave2 (0x2000_0000). The TB plays slave2: accept AR,
         // return one OKAY R beat. Confirms OOR path didn't break decode.
         dut.m_ar_valid[2] = 1
@@ -263,11 +315,11 @@ impl Nic400DefaultSlaveTest for Nic400DefaultSlaveTb
         end for
 
         assert s3_done == 1
-            else fail("S3: valid read got no R response")
+            else fail("S4: valid read got no R response")
         assert s3_resp == 0
-            else fail("S3: valid read RRESP=${s3_resp} (expected 0=OKAY)")
-        log(info, "PASS S3: valid read → OKAY (decode path intact)")
+            else fail("S4: valid read RRESP=${s3_resp} (expected 0=OKAY)")
+        log(info, "PASS S4: valid read → OKAY (decode path intact)")
 
-        log(info, "PASS Nic400Fabric default-slave: OOR read+write DECERR, valid decode intact")
+        log(info, "PASS Nic400Fabric default-slave: OOR read/burst/write DECERR, valid decode intact")
     end run
 end impl Nic400DefaultSlaveTest


### PR DESCRIPTION
## Summary
- latch `ar_len` in `Nic400DefaultSlave`
- emit one DECERR read beat per requested transfer instead of always a single beat
- assert `r_last` only on the final DECERR beat
- extend the HARC regression with a 4-beat out-of-range read case

## Why
PR #487 fixed out-of-range decode by routing misses to `Nic400DefaultSlave`, but the read responder still returned exactly one DECERR beat with `RLAST=1` for every request. That truncates burst reads when `ARLEN > 0`.

This follow-up preserves the requested burst length on the DECERR path so the fabric remains protocol-consistent for out-of-range reads.

## Test plan
- `cargo test test_sim_vec_reg_forwarded_to_thread_inst_uses_reg_storage -- --exact`
- `cargo run -- check tests/nic400/BusAxi4.arch tests/nic400/Nic400DefaultSlave.arch tests/nic400/Nic400Fabric.arch tests/nic400/Nic400MasterPort.arch tests/nic400/Nic400SlavePort.arch`
- `cargo run -- sim --dut ... Nic400DefaultSlave_test.harc --test Nic400DefaultSlaveTest --compile-scope test --arch-bin /tmp/arch-com-pr487-fix/target/debug/arch --outdir /tmp/harc-nic400-default-slave` via harc-com

## Context
Follow-up fix for #487.
