### PR TITLE
[codex] Fix native Bool not lowering

### DIFF
--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -204,8 +204,10 @@ pub enum TokenKind {
     #[token("as")]
     As,
     #[token("and")]
+    #[token("&&")]
     And,
     #[token("or")]
+    #[token("||")]
     Or,
     #[token("not")]
     Not,
@@ -681,7 +683,7 @@ mod tests {
 
     #[test]
     fn test_operators() {
-        let tokens = tokenize("+ - * == != <= >= <- -> => << >>").unwrap();
+        let tokens = tokenize("+ - * == != <= >= <- -> => << >> && ||").unwrap();
         assert_eq!(tokens[0].kind, TokenKind::Plus);
         assert_eq!(tokens[1].kind, TokenKind::Minus);
         assert_eq!(tokens[2].kind, TokenKind::Star);
@@ -694,6 +696,8 @@ mod tests {
         assert_eq!(tokens[9].kind, TokenKind::FatArrow);
         assert_eq!(tokens[10].kind, TokenKind::Shl);
         assert_eq!(tokens[11].kind, TokenKind::Shr);
+        assert_eq!(tokens[12].kind, TokenKind::And);
+        assert_eq!(tokens[13].kind, TokenKind::Or);
     }
 
     #[test]

--- a/src/sim_codegen/mod.rs
+++ b/src/sim_codegen/mod.rs
@@ -2452,6 +2452,7 @@ fn infer_expr_width(expr: &Expr, ctx: &Ctx) -> u32 {
                 8
             }
         }
+        ExprKind::LatencyAt(inner, _) | ExprKind::SvaNext(_, inner) => infer_expr_width(inner, ctx),
         ExprKind::Literal(LitKind::Sized(w, _)) => *w,
         ExprKind::Literal(_) => 32,
         ExprKind::Bool(_) => 1,
@@ -2525,7 +2526,7 @@ fn infer_expr_width(expr: &Expr, ctx: &Ctx) -> u32 {
                 }
             }
         }
-        ExprKind::Unary(UnaryOp::Not, inner) => infer_expr_width(inner, ctx),
+        ExprKind::Unary(UnaryOp::Not, _) => 1,
         ExprKind::Unary(UnaryOp::RedAnd, _)
         | ExprKind::Unary(UnaryOp::RedOr, _)
         | ExprKind::Unary(UnaryOp::RedXor, _) => 1,

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -18498,6 +18498,49 @@ fn test_native_sim_vec_inst_input_wire_param_sized_fanout() {
 }
 
 #[test]
+fn test_native_sim_bool_not_pipe_reg_outputs_and_ampamp() {
+    // Regression for arch-com#492. Native sim used to tokenize `&&` as
+    // bitwise `&` plus reduction `&` on the RHS, then infer
+    // `not result_valid_out@0` as 8 bits. That emitted a reduction-AND
+    // over `!result_valid_out`, so `not false` collapsed back to false
+    // for byte-backed Bool values.
+    let td = tempfile::tempdir().expect("tempdir");
+    let arch_bin = env!("CARGO_BIN_EXE_arch");
+    let out = std::process::Command::new(arch_bin)
+        .arg("sim")
+        .arg("tests/native_bool_not/Probe.arch")
+        .arg("--tb")
+        .arg("tests/native_bool_not/tb.cpp")
+        .arg("--outdir")
+        .arg(td.path())
+        .output()
+        .expect("run arch sim for native Bool not pipe_reg probe");
+    assert!(
+        out.status.success(),
+        "native Bool not pipe_reg sim should compile + run\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("PASS native Bool not pipe_reg"),
+        "expected PASS marker in stdout:\n{stdout}"
+    );
+
+    let generated_cpp = std::fs::read_to_string(td.path().join("VNativeBoolNotProbe.cpp"))
+        .expect("read generated native sim C++");
+    assert!(
+        generated_cpp.contains("idle_ampamp")
+            && generated_cpp.contains("((!_busy_out) && (!_result_valid_out))"),
+        "symbolic `&&` should lower to C++ logical &&, not bitwise/reduction glue:\n{generated_cpp}"
+    );
+    assert!(
+        !generated_cpp.contains("0xffULL") && !generated_cpp.contains("0xFFULL"),
+        "Bool `not` should not be reduced as an 8-bit all-ones value:\n{generated_cpp}"
+    );
+}
+
+#[test]
 fn test_native_sim_thread_driven_top_pipe_reg_output_is_public() {
     // Regression for arch-com#472: lower_threads rewrites a thread-driven
     // top-level `port q: out pipe_reg<T,1>` into a registered output on the

--- a/tests/native_bool_not/Probe.arch
+++ b/tests/native_bool_not/Probe.arch
@@ -1,0 +1,34 @@
+//! ---
+//! tags: [native-sim, bool, not, pipe-reg]
+//! ---
+//!
+//! Regression fixture for native C++ Bool `not` lowering on byte-backed
+//! Bool pipe_reg outputs. It mirrors the fpt26 shape where two registered
+//! Bool outputs are read with `@0` and negated in a logical conjunction.
+
+/// Probes Bool `not` semantics on registered Bool outputs in native sim.
+module NativeBoolNotProbe
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync, High>;
+
+  port busy_in: in Bool;
+  port result_valid_in: in Bool;
+
+  port busy_out: out pipe_reg<Bool, 1> reset rst => false;
+  port result_valid_out: out pipe_reg<Bool, 1> reset rst => false;
+
+  port not_result_valid: out Bool;
+  port idle_ampamp: out Bool;
+  port idle_keyword: out Bool;
+
+  seq on clk rising
+    busy_out <= busy_in;
+    result_valid_out <= result_valid_in;
+  end seq
+
+  comb
+    not_result_valid = not result_valid_out@0;
+    idle_ampamp = not busy_out@0 && not result_valid_out@0;
+    idle_keyword = (busy_out@0 == false) and (result_valid_out@0 == false);
+  end comb
+end module NativeBoolNotProbe

--- a/tests/native_bool_not/tb.cpp
+++ b/tests/native_bool_not/tb.cpp
@@ -1,0 +1,48 @@
+#include "VNativeBoolNotProbe.h"
+#include <cstdio>
+
+static int pass = 0;
+static int fail = 0;
+
+#define CHECK(cond, msg, ...) do { \
+    if (cond) { std::printf("  PASS: " msg "\n", ##__VA_ARGS__); ++pass; } \
+    else { std::printf("  FAIL: " msg "\n", ##__VA_ARGS__); ++fail; } \
+} while (0)
+
+static void tick(VNativeBoolNotProbe& dut) {
+    dut.clk = 0;
+    dut.eval();
+    dut.clk = 1;
+    dut.eval();
+    dut.clk = 0;
+    dut.eval();
+}
+
+int main() {
+    VNativeBoolNotProbe dut;
+
+    dut.rst = 1;
+    dut.busy_in = 0;
+    dut.result_valid_in = 0;
+    tick(dut);
+
+    dut.rst = 0;
+    dut.busy_in = 0;
+    dut.result_valid_in = 0;
+    tick(dut);
+    CHECK(dut.result_valid_out == 0, "pipe_reg result_valid_out reset/sample is false");
+    CHECK(dut.not_result_valid == 1, "not false is true on a Bool pipe_reg @0 read");
+    CHECK(dut.idle_ampamp == 1, "symbolic && preserves not false && not false");
+    CHECK(dut.idle_keyword == 1, "keyword and matches symbolic &&");
+
+    dut.busy_in = 0;
+    dut.result_valid_in = 1;
+    tick(dut);
+    CHECK(dut.result_valid_out == 1, "pipe_reg result_valid_out sampled true");
+    CHECK(dut.not_result_valid == 0, "not true is false on a Bool pipe_reg @0 read");
+    CHECK(dut.idle_ampamp == 0, "symbolic && observes not true as false");
+    CHECK(dut.idle_keyword == 0, "keyword and matches symbolic && when false");
+
+    std::printf("PASS native Bool not pipe_reg: %d pass / %d fail\n", pass, fail);
+    return fail == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary
- Fix native C++ width inference so logical `not` is treated as a 1-bit Bool result.
- Make latency/SVA-next wrappers transparent to native width inference, covering `pipe_reg@0` reads.
- Tokenize `&&` and `||` as logical `and`/`or` instead of letting them parse as bitwise/reduction operators.
- Add a native sim regression for Bool `not` over pipe_reg outputs, including symbolic `&&`.

Fixes #492.

## Validation
- `cargo test lexer::tests::test_operators -- --nocapture`
- `cargo test test_native_sim_bool_not_pipe_reg_outputs_and_ampamp -- --nocapture`
- `cargo run --quiet -- sim tests/native_bool_not/Probe.arch --tb tests/native_bool_not/tb.cpp --outdir /tmp/arch-bool-not-probe`
- `cargo run --quiet -- build tests/cvdp/serial_line_code_converter.arch -o /tmp/serial_line_code_converter.sv`
- `git diff --check`

## Notes
- `rustfmt --check src/lexer.rs src/sim_codegen/mod.rs tests/integration_test.rs` still reports broad pre-existing formatting churn through existing files/modules, so I did not apply broad rustfmt.