### PR TITLE
fix(lower_threads): fold wait-until exit assignments into cond-exit arm (closes #306)

### DIFF
--- a/ideas/2026-06-03-auto-pipeline-asserts.md
+++ b/ideas/2026-06-03-auto-pipeline-asserts.md
@@ -1,0 +1,277 @@
+# Enhancement: `--auto-pipeline-asserts` — compiler-generated SVA hazard contracts for `pipeline` constructs
+
+**Date:** 2026-06-03
+**Status:** Proposal — needs team discussion before implementation
+**Related:** `--auto-thread-asserts` (shipped, `src/codegen/`), bounds-check SVA (shipped), div-by-zero SVA (shipped)
+
+---
+
+## Problem
+
+The `pipeline` construct auto-generates stall propagation, flush masks, and forward muxes from
+`stall when`, `flush`, and `forward` directives.  The generated logic is correct *in isolation*,
+but there is currently **no machine-checkable contract that says so**.  If a later edit to the
+pipeline body, a stall condition expression, or a downstream consumer introduces a hazard, the
+first symptom is a functional simulation failure — not a compiler or formal diagnostic.
+
+Pipeline hazard bugs are the #2 class of subtle RTL bugs after CDC, and they are particularly
+expensive to root-cause because the failure (a wrong value read N cycles after a stall or flush)
+is temporally distant from the cause (the stall/flush logic that failed to freeze/clear a stage).
+
+The ARCH compiler already auto-generates SVA contracts for three other domains:
+
+| Feature | Flag | What it asserts |
+|---|---|---|
+| Thread state transitions | `--auto-thread-asserts` | Each `wait until` / `wait N cycle` advances state correctly |
+| Vec / bit-select bounds | always-on | Index stays within declared bounds |
+| Divide-by-zero | always-on | Divisor is non-zero when expression evaluates |
+
+The `pipeline` construct is the natural next target.
+
+---
+
+## Proposed flag
+
+```
+arch build   Pipe.arch --auto-pipeline-asserts    # emit SV with embedded SVA
+arch formal  Pipe.arch --auto-pipeline-asserts    # also works (passes option to codegen)
+arch sim     Pipe.arch --auto-pipeline-asserts    # checked by Verilator via --assert
+```
+
+Off by default (same as `--auto-thread-asserts`).  All emitted SVA is wrapped in
+`// synopsys translate_off / on` so synthesis tools ignore it.  Reset polarity is inferred
+from the module's `Reset<Kind, Polarity>` port — the same helper already used by the thread
+and bounds-check SVA emitters.
+
+---
+
+## Property classes
+
+### P1 — Stall-freeze: stalled stage holds its valid and data registers
+
+When a stage is stalled (`{stage}_stall` is asserted), its registered state must not change on
+the next clock edge.  A violation means the stall backpressure logic has a bug (a hole in the
+stall chain, or a `<=` assign that bypasses the stall gate).
+
+```systemverilog
+// synopsys translate_off
+_auto_pipe_fetch_stall_freeze_0: assert property (
+    @(posedge clk) disable iff (rst)
+    (fetch_stall |-> ##1 fetch_valid_r == $past(fetch_valid_r, 1))
+) else $fatal(1, "PIPELINE VIOLATION: PipelineName._auto_pipe_fetch_stall_freeze_0");
+
+_auto_pipe_fetch_stall_freeze_1: assert property (
+    @(posedge clk) disable iff (rst)
+    (fetch_stall |-> ##1 fetch_data == $past(fetch_data, 1))
+) else $fatal(1, "PIPELINE VIOLATION: PipelineName._auto_pipe_fetch_stall_freeze_1");
+// synopsys translate_on
+```
+
+One property per emitted stage register plus one for `{stage}_valid_r`.  Counter `_N` increments
+globally across all pipeline stages so names remain unique per module.
+
+**Scope:** stages that have at least one stall condition (either local `stall when` or
+propagated backpressure).  Stall-free stages have a trivially-true stall property; skip them
+to avoid vacuous assertions.
+
+### P2 — Flush-clears-valid: flushed stage loses its valid token
+
+When a `flush` directive fires, the targeted stage's `valid_r` register must be zero on the
+following clock edge.  A violation means the flush did not write `valid_r <= 0` — either the
+write is in the wrong clock domain, gated incorrectly, or the flush expression is wrong.
+
+```systemverilog
+// synopsys translate_off
+_auto_pipe_decode_flush_clears_0: assert property (
+    @(posedge clk) disable iff (rst)
+    (flush_cond |=> !decode_valid_r)
+) else $fatal(1, "PIPELINE VIOLATION: PipelineName._auto_pipe_decode_flush_clears_0");
+// synopsys translate_on
+```
+
+One property per `flush` directive targeting a named stage.
+
+**Interaction with stall.** If a flush fires simultaneously with a stall on the same stage,
+SV pipeline convention is flush-wins (the `valid_r <= 0` override in `always_ff` is unconditional
+under flush).  The compiler already generates the flush-wins override; the property correctly
+validates it.
+
+### P3 — Forward consistency: forwarded value equals the source-stage register
+
+When a `forward X.reg from Y when cond` directive evaluates its condition as true, the
+mux output that `X` reads must equal `Y.reg` at that cycle.  A violation means the forward
+condition is wrong, or the mux wiring has a logic error.
+
+```systemverilog
+// synopsys translate_off
+_auto_pipe_fwd_data_0: assert property (
+    @(posedge clk) disable iff (rst)
+    (execute_fwd_en |-> decode_data_out == execute_result_r)
+) else $fatal(1, "PIPELINE VIOLATION: PipelineName._auto_pipe_fwd_data_0");
+// synopsys translate_on
+```
+
+`execute_fwd_en` is the forwarding condition expression, `execute_result_r` is the source
+stage's register, `decode_data_out` is the forwarding mux output consumed by the destination
+stage.  These three are all named signals in the generated SV; the codegen already knows them
+from the `ForwardDirective` AST node.
+
+One property per `forward` directive.
+
+---
+
+## Rationale: why these three and not others
+
+| Candidate | Included? | Reason |
+|---|---|---|
+| Stall-freeze | ✅ | Direct SV coverage of the backpressure chain; catches the most common hazard class |
+| Flush-clears-valid | ✅ | Directly validates the flush-wins override; catches wrong flush expressions |
+| Forward consistency | ✅ | Validates the mux; catches forwarding-condition bugs |
+| Token liveness ("valid entering stage N eventually exits") | ❌ | Requires `s_eventually` (unbounded liveness) — out of scope per COMPILER_STATUS.md |
+| No-duplication ("at most one valid token per stage") | ❌ | Trivially true for linear pipelines; vacuous unless multi-issue is supported |
+
+---
+
+## Implementation approach
+
+The change is **entirely within `src/codegen/pipeline.rs`**.  No new pass, no new AST node.
+
+### 1. Add the flag to CLI and codegen opts
+
+```rust
+// src/main.rs — alongside auto_thread_asserts in Build/Formal/Sim variants
+#[arg(long, default_value_t = false)]
+auto_pipeline_asserts: bool,
+```
+
+Pass it through `BuildOpts` / `FormalOpts` to `Codegen::new(opts)`.  `Codegen` already carries
+`opts.auto_thread_asserts`; add `opts.auto_pipeline_asserts` as a sibling field.
+
+### 2. Emit assertions at the end of `emit_pipeline`
+
+After the `endmodule` line (or before it, following the thread-assert convention), call a new
+`emit_pipeline_asserts(&p, ...)` helper if `self.opts.auto_pipeline_asserts`.
+
+```rust
+fn emit_pipeline_asserts(&mut self, p: &PipelineDecl,
+    stage_names: &[&str], stage_regs: &[Vec<(String, String, String)>],
+    clk_name: &str, rst_name: &str, is_low: bool) {
+
+    let disable_iff = if is_low {
+        format!("disable iff (!{})", rst_name)
+    } else {
+        format!("disable iff ({})", rst_name)
+    };
+
+    let mut n = 0usize;   // global counter for unique SVA names
+
+    // P1: stall-freeze
+    for (si, stage) in p.stages.iter().enumerate() {
+        if !stage_has_stall(stage, p) { continue; }
+        let prefix = stage_names[si].to_lowercase();
+        let stall = format!("{prefix}_stall");
+        // valid_r
+        self.emit_sva_assert(
+            &format!("_auto_pipe_{prefix}_stall_freeze_{n}"),
+            &format!("@(posedge {clk_name}) {disable_iff} ({stall} |-> ##1 {prefix}_valid_r == $past({prefix}_valid_r, 1))"),
+            &format!("PIPELINE VIOLATION: {}._auto_pipe_{prefix}_stall_freeze_{n}", p.name.name),
+        );
+        n += 1;
+        // data regs
+        for (reg_name, _, _) in &stage_regs[si] {
+            let sig = format!("{prefix}_{reg_name}");
+            self.emit_sva_assert(
+                &format!("_auto_pipe_{prefix}_stall_freeze_{n}"),
+                &format!("@(posedge {clk_name}) {disable_iff} ({stall} |-> ##1 {sig} == $past({sig}, 1))"),
+                &format!("PIPELINE VIOLATION: {}._auto_pipe_{prefix}_stall_freeze_{n}", p.name.name),
+            );
+            n += 1;
+        }
+    }
+
+    // P2: flush-clears-valid
+    for flush in &p.flush_directives {
+        let stage_prefix = flush.stage.name.to_lowercase();
+        let cond = self.emit_pipeline_expr_str(&flush.condition, stage_names, stage_regs, &Default::default());
+        self.emit_sva_assert(
+            &format!("_auto_pipe_{stage_prefix}_flush_clears_{n}"),
+            &format!("@(posedge {clk_name}) {disable_iff} ({cond} |=> !{stage_prefix}_valid_r)"),
+            &format!("PIPELINE VIOLATION: {}._auto_pipe_{stage_prefix}_flush_clears_{n}", p.name.name),
+        );
+        n += 1;
+    }
+
+    // P3: forward consistency
+    for fwd in &p.forward_directives {
+        let cond = self.emit_pipeline_expr_str(&fwd.condition, stage_names, stage_regs, &Default::default());
+        let dest = self.emit_pipeline_expr_str(&fwd.dest,      stage_names, stage_regs, &Default::default());
+        let src  = self.emit_pipeline_expr_str(&fwd.source,    stage_names, stage_regs, &Default::default());
+        self.emit_sva_assert(
+            &format!("_auto_pipe_fwd_{n}"),
+            &format!("@(posedge {clk_name}) {disable_iff} ({cond} |-> {dest} == {src})"),
+            &format!("PIPELINE VIOLATION: {}._auto_pipe_fwd_{n}", p.name.name),
+        );
+        n += 1;
+    }
+}
+```
+
+`emit_sva_assert` is a 4-line helper (already used by thread/bounds/div0 emitters) that emits
+the `translate_off` wrapper, the `assert property` line, the `else $fatal`, and `translate_on`.
+
+### 3. Tests
+
+| Test | Expected |
+|---|---|
+| Stall-freeze: correct design, stall asserted → data held | Verilator `--assert` passes |
+| Stall-freeze: mutated design, `<=` escapes stall gate → data changes under stall | `$fatal(1, "PIPELINE VIOLATION: ...")` |
+| Flush-clears-valid: flush fires → valid clears next cycle | Verilator `--assert` passes |
+| Flush-clears-valid: missing `valid_r <= 0` in flush body | `$fatal(1, ...)` |
+| Forward consistency: fwd_en true → dest == src | Verilator `--assert` passes |
+| Forward consistency: wrong fwd condition (misses the case) | Property vacuously true (no false fire) — documented limitation |
+| EBMC: unconstrained stall input → P1 PROVED (stall freezes by design) | PROVED up to bound 5 |
+| No stall/flush/forward pipeline | `--auto-pipeline-asserts` emits no SVA, no compilation error |
+
+---
+
+## What this does not do
+
+- Does not change emitted SV for designs that don't use `--auto-pipeline-asserts`.
+- Does not assert liveness (`s_eventually` is out of scope).
+- Does not instrument `sim_codegen/pipeline.rs` — assertion firing is caught by Verilator
+  `--assert` on the emitted SV, not by the native simulator directly (same limitation as
+  `--auto-thread-asserts` today).
+- Does not cover `wait`-stage FSMs within a pipeline (those are already covered by
+  `--auto-thread-asserts` on the underlying thread lowering).  The interaction is additive:
+  run both flags to get thread-state contracts and pipeline-hazard contracts simultaneously.
+
+---
+
+## Precedent in the compiler
+
+This follows the exact pattern of all other auto-SVA emitters:
+
+| Emitter | Source | Properties |
+|---|---|---|
+| Bounds check | `codegen/mod.rs:emit_auto_bounds_sva` | `idx < N` for Vec/bit-select |
+| Div-by-zero | `codegen/mod.rs:emit_auto_div0_sva` | `divisor != 0` |
+| Thread contracts | `lower_threads.rs` | `wait until` → next state; `wait N cycle` stay/done |
+| **Pipeline hazards** | `codegen/pipeline.rs` (proposed) | Stall-freeze, flush-clears-valid, forward consistency |
+
+The pattern is: compiler lowers a high-level construct → emits SVA that captures the *intent*
+the lowered comb+seq blob no longer expresses in prose → downstream tools (Verilator `--assert`,
+EBMC) can prove or disprove it.
+
+---
+
+## Why this matters
+
+A pipeline with five stages and two forwarding paths requires **manually** writing ~15 SVA
+properties to cover the hazard matrix.  That work is almost never done in practice, so the
+first indication of a stall or forward bug is a simulation failure that requires waveform
+archaeology to diagnose.
+
+With `--auto-pipeline-asserts`, the compiler generates those 15 properties for free from
+the same `stall when`, `flush`, and `forward` directives the designer already wrote.  Running
+`arch build Pipe.arch --auto-pipeline-asserts | verilator --binary --assert` is a one-liner
+that turns every pipeline definition into a self-checking module.  The cost is one extra flag.

--- a/src/elaborate.rs
+++ b/src/elaborate.rs
@@ -2698,6 +2698,14 @@ fn lower_module_threads(
             continue;
         }
 
+        // Issue #306: fold register assignments from a sole-entry action state
+        // that immediately follows a `wait until` state into the wait state's
+        // cond-exit arm.  This makes `wait until cond; X <= Y;` fire X on
+        // the same clock edge as the cond detection (one cycle earlier than
+        // the unfolded two-state form).  The absorbed action state is marked
+        // `is_folded` and skipped during codegen — it becomes unreachable.
+        fold_wait_until_exit_assignments(&mut raw_states, t.once);
+
         let n_states = raw_states.len();
         let state_reg = format!("_t{}_state", ti);
         let state_bits = crate::width::index_width(n_states as u64) as u64;
@@ -2903,10 +2911,17 @@ fn lower_module_threads(
         // State transition always_ff
         let mut seq_stmts: Vec<Stmt> = Vec::new();
         for (si, raw) in raw_states.iter().enumerate() {
+            // Issue #306: skip states that were absorbed into a preceding
+            // wait_until exit arm.  They are unreachable at runtime.
+            if raw.is_folded {
+                continue;
+            }
+
             // Only skip truly empty states that don't need state advancement
             let needs_transition = si + 1 < n_states || !t.once; // non-terminal states always need advancement
             if raw.seq_stmts.is_empty() && raw.transition_cond.is_none()
                 && raw.wait_cycles.is_none() && raw.multi_transitions.is_empty()
+                && raw.folded_exit_seq.is_empty()
                 && !needs_transition {
                 continue;
             }
@@ -2924,8 +2939,14 @@ fn lower_module_threads(
             body.extend(raw.seq_stmts.clone());
 
             // State transitions
-            // For thread_once: last state stays (terminal), otherwise wrap to 0
-            let next_state = if si + 1 < n_states {
+            // For thread_once: last state stays (terminal), otherwise wrap to 0.
+            // Issue #306: when folded_exit_target is set, the wait_until state
+            // transitions directly to that target (skipping the absorbed action
+            // state si+1).  For all other transition kinds the natural next-state
+            // computation below applies.
+            let next_state = if let Some(folded_tgt) = raw.folded_exit_target {
+                folded_tgt
+            } else if si + 1 < n_states {
                 si + 1
             } else if t.once {
                 si // terminal: stay in last state
@@ -2971,13 +2992,19 @@ fn lower_module_threads(
                     }));
                 }
             } else if let Some(ref cond) = raw.transition_cond {
+                // Issue #306: if folded_exit_seq is non-empty, include those
+                // seq assigns inside the cond-exit arm so they fire on the same
+                // clock edge as the wait-exit detection (one cycle earlier than
+                // the unfolded two-state form).
+                let mut then_stmts: Vec<Stmt> = raw.folded_exit_seq.clone();
+                then_stmts.push(Stmt::Assign(RegAssign {
+                    target: Expr::new(ExprKind::Ident(state_reg.clone()), sp),
+                    value: state_name_expr(next_state),
+                    span: sp,
+                }));
                 body.push(Stmt::IfElse(IfElse {
                     cond: cond.clone(),
-                    then_stmts: vec![Stmt::Assign(RegAssign {
-                        target: Expr::new(ExprKind::Ident(state_reg.clone()), sp),
-                        value: state_name_expr(next_state),
-                        span: sp,
-                    })],
+                    then_stmts,
                     else_stmts: Vec::new(), unique: false, span: sp,
                 }));
             } else if raw.wait_cycles.is_some() {
@@ -3116,6 +3143,11 @@ fn lower_module_threads(
         // Collect comb outputs for this thread (merged into one block later)
         // For shared(or) signals, transform `sig = val` → `sig = sig | val`
         for (si, raw) in raw_states.iter().enumerate() {
+            // Issue #306: folded states are unreachable; skip their comb outputs.
+            if raw.is_folded {
+                continue;
+            }
+
             let state_cond = Expr::new(ExprKind::Binary(
                 BinOp::Eq,
                 Box::new(Expr::new(ExprKind::Ident(state_reg.clone()), sp)),
@@ -4301,6 +4333,119 @@ struct ThreadFsmState {
     /// Target-side TLM only: this state exits to a generated response state
     /// carrying the indexed return expression instead of falling through.
     terminal_return: Option<usize>,
+    /// Issue #306: seq assigns folded from the immediately-following action
+    /// state into this wait_until state's cond-exit arm.  Only populated
+    /// when `transition_cond.is_some()` and the next state was a sole-entry
+    /// pure-action state.  Emitted inside `if (cond) { folded_exit_seq; state <= next; }`.
+    folded_exit_seq: Vec<Stmt>,
+    /// When `folded_exit_seq` is non-empty, the transition target skips the
+    /// absorbed action state and jumps directly to the state after it.
+    /// `None` means use the natural `si + 1` computation.
+    folded_exit_target: Option<usize>,
+    /// True when this state was absorbed into a preceding wait_until exit arm
+    /// (issue #306).  The state is unreachable; codegen skips it entirely.
+    is_folded: bool,
+    /// True when this state must NOT be folded into the preceding wait_until
+    /// state's exit arm (issue #306).  Set when a `wait 1 cycle` was elided
+    /// before this state — the natural S(wait)→S(action) transition provides
+    /// the 1-cycle budget and folding would lose that cycle.
+    no_fold_into_prev: bool,
+}
+
+/// Issue #306: fold `wait until` exit assignments.
+///
+/// Scans `states` for pairs (si, si+1) where:
+///   - state si is a pure `wait until cond` state (has `transition_cond`,
+///     no `wait_cycles`, no `multi_transitions`, no `folded_exit_seq` already)
+///   - state si+1 is a pure action state (no `transition_cond`, no
+///     `wait_cycles`, no `multi_transitions`, not already folded), AND
+///   - state si+1 has at least one seq assign to fold, AND
+///   - no other state targets si+1 via `multi_transitions` (sole-entry check)
+///
+/// When all conditions hold, `seq_stmts` from si+1 are moved into
+/// si's `folded_exit_seq` field.  The transition target for si is updated to
+/// `folded_exit_target = si+2` so the codegen skips si+1 directly.
+/// State si+1 is marked `is_folded = true`; the codegen loop skips it.
+///
+/// This does NOT fold across `wait N cycle` states (those need the counter
+/// states) or into/out of fork/join dispatch states.
+fn fold_wait_until_exit_assignments(states: &mut Vec<ThreadFsmState>, t_once: bool) {
+    let n = states.len();
+    // Build the set of state indices targeted by any multi_transition from
+    // any state.  A state in this set may be reachable from multiple
+    // predecessors, so folding it into the single wait_until predecessor
+    // would silently drop an execution path.
+    let mut multi_targets: std::collections::HashSet<usize> = std::collections::HashSet::new();
+    for state in states.iter() {
+        for (_, target) in &state.multi_transitions {
+            if *target < n {
+                multi_targets.insert(*target);
+            }
+        }
+    }
+
+    // Walk forward; after folding si+1 into si we continue at si+1 (now
+    // marked is_folded) — no index confusion since we only read/write
+    // `states[si]` and `states[si+1]` in each iteration.
+    for si in 0..n.saturating_sub(1) {
+        let successor = si + 1;
+
+        // State si: must be a pure wait_until (no wait_cycles, no multi,
+        // no prior fold already applied, and empty folded_exit_seq).
+        // Also require empty seq_stmts: if the fast_region mechanism has
+        // already merged guarded assigns into si's seq_stmts (as it does for
+        // `if not X; wait until X; end if` followed by actions), folding
+        // the next action state would stack a second if-guard on top, producing
+        // two separate `if (cond)` arms in the always_ff block.
+        {
+            let s = &states[si];
+            if s.transition_cond.is_none()
+                || s.wait_cycles.is_some()
+                || !s.multi_transitions.is_empty()
+                || !s.folded_exit_seq.is_empty()
+                || !s.seq_stmts.is_empty()
+                || s.is_folded
+            {
+                continue;
+            }
+        }
+
+        // State si+1: must be a pure action state (no wait cond/cycles/multi,
+        // not already folded), have at least one seq assign to fold, and be
+        // a sole-entry state (not targeted by any multi_transition).
+        // Also must not have the `no_fold_into_prev` flag set (which marks
+        // states created after a `wait 1 cycle` elision — the natural
+        // si→si+1 transition is the 1-cycle budget, folding would lose it).
+        {
+            let s1 = &states[successor];
+            if s1.transition_cond.is_some()
+                || s1.wait_cycles.is_some()
+                || !s1.multi_transitions.is_empty()
+                || s1.is_folded
+                || s1.seq_stmts.is_empty()
+                || s1.no_fold_into_prev
+                || multi_targets.contains(&successor)
+            {
+                continue;
+            }
+        }
+
+        // Compute the effective target after si+1: the state that si+1
+        // would naturally advance to.
+        let after_action = if successor + 1 < n {
+            successor + 1
+        } else if t_once {
+            successor // terminal
+        } else {
+            0 // wrap
+        };
+
+        // Move seq_stmts from si+1 into si's folded_exit_seq.
+        let folded = std::mem::take(&mut states[successor].seq_stmts);
+        states[si].folded_exit_seq = folded;
+        states[si].folded_exit_target = Some(after_action);
+        states[successor].is_folded = true;
+    }
 }
 
 fn thread_map_state_role(si: usize, state: &ThreadFsmState) -> &'static str {
@@ -4580,6 +4725,10 @@ fn redirect_fallthrough_to_return(
             wait_cycles: None,
             multi_transitions: Vec::new(),
             terminal_return: Some(return_idx),
+            folded_exit_seq: Vec::new(),
+            folded_exit_target: None,
+            is_folded: false,
+            no_fold_into_prev: false,
         });
         return;
     };
@@ -4887,6 +5036,10 @@ fn flush_pending_thread_state(
         wait_cycles: None,
         multi_transitions: Vec::new(),
         terminal_return: None,
+        folded_exit_seq: Vec::new(),
+        folded_exit_target: None,
+        is_folded: false,
+        no_fold_into_prev: false,
     });
     true
 }
@@ -5146,6 +5299,12 @@ fn partition_thread_body_impl(
     let mut cur_seq: Vec<Stmt> = Vec::new();
     let mut fast_region: Option<(usize, Expr)> = None;
     let mut no_trailing_merge_from: Option<usize> = None;
+    // Issue #306: set to true when a `wait 1 cycle` was elided using the
+    // natural wait_until→action transition as the 1-cycle budget.  The NEXT
+    // action state created must be marked `no_fold_into_prev` so the fold
+    // pass does not absorb it back into the wait_until state (which would
+    // lose the 1-cycle guarantee provided by the elision).
+    let mut next_state_no_fold: bool = false;
     for (stmt_idx, stmt) in body.iter().enumerate() {
         match stmt {
             ThreadStmt::CombAssign(ca) => {
@@ -5181,6 +5340,10 @@ fn partition_thread_body_impl(
                 // the same comb expression in two consecutive states
                 // produces the same per-cycle value.
                 if !cur_seq.is_empty() {
+                    // Issue #306: if next_state_no_fold is set (from a prior
+                    // `wait 1 cycle` elision), apply it to the dead-skid
+                    // prefix state and reset the flag.
+                    let nfip = std::mem::take(&mut next_state_no_fold);
                     states.push(ThreadFsmState {
                         comb_stmts: cur_comb.clone(),
                         seq_stmts: std::mem::take(&mut cur_seq),
@@ -5188,7 +5351,16 @@ fn partition_thread_body_impl(
                         wait_cycles: None,
                         multi_transitions: Vec::new(),
                         terminal_return: None,
+                        folded_exit_seq: Vec::new(),
+                        folded_exit_target: None,
+                        is_folded: false,
+                        no_fold_into_prev: nfip,
                     });
+                } else {
+                    // No dead-skid state created; reset next_state_no_fold
+                    // since the wait_until state itself doesn't need it (the
+                    // fold only targets action states, not wait states).
+                    next_state_no_fold = false;
                 }
                 states.push(ThreadFsmState {
                     comb_stmts: std::mem::take(&mut cur_comb),
@@ -5196,7 +5368,11 @@ fn partition_thread_body_impl(
                     transition_cond: Some(cond.clone()),
                     wait_cycles: None,
                     multi_transitions: Vec::new(),
-                        terminal_return: None,
+                    terminal_return: None,
+                    folded_exit_seq: Vec::new(),
+                    folded_exit_target: None,
+                    is_folded: false,
+                    no_fold_into_prev: false,
                 });
                 let _ = sp; // span retained for parity with the prior arm
             }
@@ -5231,6 +5407,10 @@ fn partition_thread_body_impl(
                     | ExprKind::Literal(LitKind::Bin(1))
                     | ExprKind::Literal(LitKind::Sized(_, 1)));
                 if !count_is_one || !had_flush {
+                    // A real wait_cycles state is pushed; any prior
+                    // `next_state_no_fold` from an earlier elision is no
+                    // longer relevant (the boundary state absorbed it).
+                    next_state_no_fold = false;
                     states.push(ThreadFsmState {
                         comb_stmts: Vec::new(),
                         seq_stmts: Vec::new(),
@@ -5238,9 +5418,18 @@ fn partition_thread_body_impl(
                         wait_cycles: Some(count.clone()),
                         multi_transitions: Vec::new(),
                         terminal_return: None,
+                        folded_exit_seq: Vec::new(),
+                        folded_exit_target: None,
+                        is_folded: false,
+                        no_fold_into_prev: false,
                     });
                 } else if let Some(idx) = merged_fast_idx {
                     no_trailing_merge_from = Some(idx);
+                    // Issue #306: mark that the next action state (created after
+                    // this elided wait) must not be folded into the preceding
+                    // wait_until state — the natural transition provides the
+                    // 1-cycle budget already consumed by the elision.
+                    next_state_no_fold = true;
                 }
             }
             ThreadStmt::IfElse(ie) => {
@@ -5254,6 +5443,10 @@ fn partition_thread_body_impl(
                             wait_cycles: None,
                             multi_transitions: Vec::new(),
                             terminal_return: None,
+                            folded_exit_seq: Vec::new(),
+                            folded_exit_target: None,
+                            is_folded: false,
+                            no_fold_into_prev: false,
                         });
                         fast_region = Some((fast_idx, cond));
                         continue;
@@ -5294,6 +5487,10 @@ fn partition_thread_body_impl(
                         wait_cycles: None,
                         multi_transitions: Vec::new(),
                         terminal_return: None,
+                        folded_exit_seq: Vec::new(),
+                        folded_exit_target: None,
+                        is_folded: false,
+                        no_fold_into_prev: false,
                     });
                     // Step 3: recursively partition `then_stmts` and append at then_base.
                     // Empty branches (§II.10.4) skip the recursive call —
@@ -5582,7 +5779,11 @@ fn partition_thread_body_impl(
                     transition_cond: Some(cond.clone()),
                     wait_cycles: None,
                     multi_transitions: Vec::new(),
-                        terminal_return: None,
+                    terminal_return: None,
+                    folded_exit_seq: Vec::new(),
+                    folded_exit_target: None,
+                    is_folded: false,
+                    no_fold_into_prev: false,
                 });
             }
             ThreadStmt::Return(e, ret_span) => {
@@ -5609,6 +5810,10 @@ fn partition_thread_body_impl(
                                 wait_cycles: None,
                                 multi_transitions: Vec::new(),
                                 terminal_return: Some(return_idx),
+                                folded_exit_seq: Vec::new(),
+                                folded_exit_target: None,
+                                is_folded: false,
+                                no_fold_into_prev: false,
                             });
                         }
                     } else {
@@ -5763,13 +5968,18 @@ fn partition_thread_body_impl(
             false
         };
         if !merged_into_exit {
+            let nfip = std::mem::take(&mut next_state_no_fold);
             states.push(ThreadFsmState {
                 comb_stmts: std::mem::take(&mut cur_comb),
                 seq_stmts: std::mem::take(&mut cur_seq),
                 transition_cond: None,
                 wait_cycles: None,
                 multi_transitions: Vec::new(),
-                        terminal_return: None,
+                terminal_return: None,
+                folded_exit_seq: Vec::new(),
+                folded_exit_target: None,
+                is_folded: false,
+                no_fold_into_prev: nfip,
             });
         }
     }
@@ -5811,7 +6021,11 @@ fn lower_fork_join(
         states.push(ThreadFsmState {
             comb_stmts: Vec::new(), seq_stmts: Vec::new(),
             transition_cond: None, wait_cycles: None, multi_transitions: Vec::new(),
-                        terminal_return: None,
+            terminal_return: None,
+            folded_exit_seq: Vec::new(),
+            folded_exit_target: None,
+            is_folded: false,
+            no_fold_into_prev: false,
         });
         branch_states.push(states);
     }
@@ -5924,6 +6138,10 @@ fn lower_fork_join(
             transition_cond: None, wait_cycles: None,
             multi_transitions: multi,
             terminal_return: None,
+            folded_exit_seq: Vec::new(),
+            folded_exit_target: None,
+            is_folded: false,
+            no_fold_into_prev: false,
         });
     }
 
@@ -6345,7 +6563,11 @@ fn lower_thread_lock(
             transition_cond: Some(make_grant()),
             wait_cycles: None,
             multi_transitions: Vec::new(),
-                        terminal_return: None,
+            terminal_return: None,
+            folded_exit_seq: Vec::new(),
+            folded_exit_target: None,
+            is_folded: false,
+            no_fold_into_prev: false,
         });
     }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -16397,12 +16397,15 @@ fn test_thread_state_localparams_emitted() {
     let sv = compile_to_sv(source);
 
     // (1) One `localparam` per state with the expected role suffix.
-    //     S0 = wait_until (transition_cond = `req`), S1 = action (seq write),
-    //     S2 = wait_cycles (wait 2 cycle), S3 = action (final seq write).
+    //     S0 = wait_until (transition_cond = `req`), S1 = action (seq write,
+    //     now folded into S0's cond-exit arm by issue #306), S2 = wait_cycles
+    //     (wait 2 cycle), S3 = action (final seq write — not folded because
+    //     the preceding state is wait_cycles, not wait_until).
+    //     Localparams are still emitted for all states including folded ones.
     assert!(sv.contains("localparam [1:0] _t0_S0_wait_until = 0"),
         "expected S0 wait_until localparam:\n{sv}");
     assert!(sv.contains("localparam [1:0] _t0_S1_action = 1"),
-        "expected S1 action localparam:\n{sv}");
+        "expected S1 action localparam (folded but still declared):\n{sv}");
     assert!(sv.contains("localparam [1:0] _t0_S2_wait_cycles = 2"),
         "expected S2 wait_cycles localparam:\n{sv}");
     assert!(sv.contains("localparam [1:0] _t0_S3_action = 3"),
@@ -16420,10 +16423,21 @@ fn test_thread_state_localparams_emitted() {
         "expected name-form state comparison for S2:\n{sv}");
 
     // (4) State-register assignments use the name, not a bare literal.
-    assert!(sv.contains("_t0_state <= _t0_S1_action"),
-        "expected name-form state assignment to S1:\n{sv}");
+    //     Issue #306: S0's cond-exit arm now folds S1's `done <= true` and
+    //     transitions directly to S2 (skipping S1).  So `_t0_S1_action` no
+    //     longer appears as a transition target; `_t0_S2_wait_cycles` still
+    //     does (from the folded S0 exit arm).
+    assert!(!sv.contains("_t0_state <= _t0_S1_action"),
+        "S1 was folded into S0's exit; S0 must jump directly to S2:\n{sv}");
     assert!(sv.contains("_t0_state <= _t0_S2_wait_cycles"),
-        "expected name-form state assignment to S2:\n{sv}");
+        "expected name-form state assignment to S2 (folded from S0 exit arm):\n{sv}");
+    // The folded seq assign must appear inside the if(req) block.
+    let trimmed: String = sv.split_whitespace().collect::<Vec<_>>().join(" ");
+    assert!(
+        trimmed.contains("if (req) begin done <= 1'b1; _t0_state <= _t0_S2_wait_cycles;")
+            || trimmed.contains("if (req) begin done <= 1'b1; _t0_state <= _t0_S2_wait_cycles"),
+        "expected `done <= true` folded into S0's if(req) arm (issue #306):\n{sv}",
+    );
 
     // (5) No bare `_t0_state == N` or `_t0_state <= N` numeric-literal forms
     //     should remain. The synchronous-reset path emits `_t0_state <= 0`
@@ -20094,5 +20108,160 @@ fn bus_interface_archi_round_trips() {
         chk.status.success(),
         "emitted bus .archi must parse back in; stderr:\n{}",
         String::from_utf8_lossy(&chk.stderr)
+    );
+}
+
+// ── Issue #306: wait-until exit assignment fold ───────────────────────────────
+
+/// Basic fold: `wait until go; phase <= 2'd1;` — the register assignment
+/// must appear inside the `if (go)` arm of state S0, not in a separate S1.
+#[test]
+fn test_wait_until_fold_basic() {
+    let source = r#"
+module M
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync, High>;
+  port go: in Bool;
+  port phase: out UInt<2>;
+  reg phase_r: UInt<2> reset rst => 0;
+  let phase = phase_r;
+  thread on clk rising, rst high
+    wait until go;
+    phase_r <= 2'd1;
+    wait until go;
+  end thread
+end module M
+"#;
+    let sv = compile_to_sv(source);
+    // The assignment must be inside the if (go) block at state 0.
+    let trimmed: String = sv.split_whitespace().collect::<Vec<_>>().join(" ");
+    assert!(
+        trimmed.contains("if (go) begin phase_r <= 2'd1;")
+            || trimmed.contains("if (go) begin phase_r <= 2'(2'd1)"),
+        "phase_r <= 2'd1 must be folded into the if(go) arm of the \
+         wait_until state (issue #306):\n{sv}",
+    );
+    // The S1 action state should be is_folded — it must NOT appear as a
+    // standalone `_t0_state == _t0_S1_action` check in the always_ff block.
+    assert!(
+        !sv.contains("_t0_state == _t0_S1_action"),
+        "S1 must be folded (unreachable); no standalone S1 check \
+         should appear in always_ff (issue #306):\n{sv}",
+    );
+}
+
+/// Multi-assign fold: `wait until go; X <= A; Y <= B;` — both assignments
+/// must appear in the same if(go) arm of state S0.
+#[test]
+fn test_wait_until_fold_multi_assign() {
+    let source = r#"
+module M
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync, High>;
+  port go: in Bool;
+  port x_out: out UInt<8>;
+  port y_out: out UInt<8>;
+  reg x_r: UInt<8> reset rst => 0;
+  reg y_r: UInt<8> reset rst => 0;
+  let x_out = x_r;
+  let y_out = y_r;
+  thread on clk rising, rst high
+    wait until go;
+    x_r <= 8'd10;
+    y_r <= 8'd20;
+    wait until go;
+  end thread
+end module M
+"#;
+    let sv = compile_to_sv(source);
+    let trimmed: String = sv.split_whitespace().collect::<Vec<_>>().join(" ");
+    // Both assigns must be inside the same if(go) arm.
+    assert!(
+        trimmed.contains("if (go) begin x_r <= 8'd10; y_r <= 8'd20;")
+            || trimmed.contains("if (go) begin y_r <= 8'd20; x_r <= 8'd10;"),
+        "both x_r and y_r assigns must fold into the same if(go) arm \
+         (issue #306 multi-assign):\n{sv}",
+    );
+}
+
+/// Fold correctness: `wait until go; X <= A; wait until done; Y <= B;` —
+/// X folds into state 0's go-exit arm; Y folds into state 1's done-exit arm.
+/// Verify state ordering is correct and no extra intermediate state exists.
+#[test]
+fn test_wait_until_fold_no_fold_past_second_wait() {
+    let source = r#"
+module M
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync, High>;
+  port go: in Bool;
+  port done: in Bool;
+  port x_out: out UInt<8>;
+  port y_out: out UInt<8>;
+  reg x_r: UInt<8> reset rst => 0;
+  reg y_r: UInt<8> reset rst => 0;
+  let x_out = x_r;
+  let y_out = y_r;
+  thread on clk rising, rst high
+    wait until go;
+    x_r <= 8'd1;
+    wait until done;
+    y_r <= 8'd2;
+  end thread
+end module M
+"#;
+    let sv = compile_to_sv(source);
+    let trimmed: String = sv.split_whitespace().collect::<Vec<_>>().join(" ");
+    // x_r folds into state 0's go-exit arm.
+    assert!(
+        trimmed.contains("if (go) begin x_r <= 8'd1;"),
+        "x_r must fold into state 0's if(go) arm (issue #306):\n{sv}",
+    );
+    // y_r folds into state 1's done-exit arm (the second wait_until).
+    assert!(
+        trimmed.contains("if (done) begin y_r <= 8'd2;"),
+        "y_r must fold into the wait_until(done) state's if(done) arm \
+         (issue #306 second-wait fold):\n{sv}",
+    );
+    // Both wait_until localparams must be declared (no states collapsed
+    // beyond the fold).
+    assert!(
+        sv.contains("_wait_until"),
+        "expected wait_until role localparam(s) in emitted SV:\n{sv}",
+    );
+}
+
+/// Wait-N-cycle unaffected: `wait 3 cycle; X <= A;` — the counter states
+/// must NOT be folded.  The fold applies only to `wait until`, not `wait N cycle`.
+#[test]
+fn test_wait_until_fold_wait_n_cycle_not_folded() {
+    let source = r#"
+module M
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync, High>;
+  port go: in Bool;
+  port x_out: out UInt<8>;
+  reg x_r: UInt<8> reset rst => 0;
+  let x_out = x_r;
+  thread on clk rising, rst high
+    wait until go;
+    wait 3 cycle;
+    x_r <= 8'd42;
+  end thread
+end module M
+"#;
+    let sv = compile_to_sv(source);
+    // A wait_cycles localparam must be present (counter state kept).
+    assert!(
+        sv.contains("_wait_cycles"),
+        "wait_cycles localparam must be emitted (counter states must not \
+         be folded — issue #306):\n{sv}",
+    );
+    // x_r must NOT appear inside an if(go) arm — it fires after the counter
+    // expires, not on the go-detection edge.
+    let trimmed: String = sv.split_whitespace().collect::<Vec<_>>().join(" ");
+    assert!(
+        !trimmed.contains("if (go) begin x_r <= 8'd42"),
+        "x_r must NOT be folded into state 0's if(go) arm when separated \
+         by a wait N cycle (issue #306 wait-N-cycle unaffected):\n{sv}",
     );
 }

--- a/tests/native_pipe_reg_thread_output/tb.cpp
+++ b/tests/native_pipe_reg_thread_output/tb.cpp
@@ -20,9 +20,12 @@ int main() {
     dut.rst = 0;
     tick();
 
+    // Issue #306 (wait-until exit fold): payload_out and valid_out now fire
+    // on the SAME clock edge as `start` detection (one cycle earlier than
+    // the pre-fold two-state form).  After a single tick with start=1 the
+    // outputs are already updated.
     dut.payload_in = 0x5a;
     dut.start = 1;
-    tick();
     tick();
 
     if (!dut.valid_out || dut.payload_out != 0x5a) {
@@ -31,6 +34,9 @@ int main() {
         return 1;
     }
 
+    // The `wait 1 cycle` after the two assignments means the state machine
+    // spends one cycle in the post-assignment action state before clearing
+    // valid_out.  De-assert start and advance one more cycle.
     dut.start = 0;
     tick();
     if (dut.valid_out) {


### PR DESCRIPTION
## Summary

- **Bug**: `wait until cond; X <= Y;` lowered to two FSM states — the assignment fired at T+2 (one cycle too late). A skilled engineer writing hand-rolled SV would put both the condition check and the register assignment in the same `if (cond)` arm.
- **Fix**: Added a `fold_wait_until_exit_assignments` post-processing pass on `raw_states`. For any `wait until` state (S_wait) immediately followed by a sole-entry pure-action state (S_assign), S_assign's seq statements are moved into S_wait's `folded_exit_seq` field and emitted inside the `if (cond)` arm. S_assign becomes unreachable (`is_folded = true`) and is skipped during codegen.
- **Result**: The register assignment and state transition now fire on the same clock edge as cond detection, saving one cycle.

### Before / After Waveform

```sv
// Before (two states, X visible at T+2)
if (_t0_state == _t0_S0_wait_until) begin
  if (cond) _t0_state <= _t0_S1_action;
end
if (_t0_state == _t0_S1_action) begin
  X <= Y;                        // fires at T+1, visible T+2
  _t0_state <= _t0_S2_...;
end

// After (folded, X visible at T+1)
if (_t0_state == _t0_S0_wait_until) begin
  if (cond) begin
    X <= Y;                      // fires with cond detection at T, visible T+1
    _t0_state <= _t0_S2_...;    // skips S1 entirely
  end
end
```

### Safety conditions for the fold

The fold is guarded by:
1. State si must be a pure `wait until` (has `transition_cond`, no `wait_cycles`, no `multi_transitions`, no existing `folded_exit_seq` or `seq_stmts`).
2. State si+1 must be a pure action state (no `transition_cond`, no `wait_cycles`, no `multi_transitions`, not already folded), with at least one seq stmt to fold.
3. Sole-entry check: si+1 must not be targeted by any `multi_transition` (fork/join or dispatch rejoin states are excluded).
4. `no_fold_into_prev` flag: states created directly after a `wait 1 cycle` elision carry this flag, preventing the fold from losing the 1-cycle budget already consumed by the elision.

`wait N cycle` states are not eligible as si (they have `wait_cycles.is_some()`), satisfying the spec requirement that counter states remain intact.

## Test plan

- [x] All 547 pre-existing tests still pass.
- [x] `test_wait_until_fold_basic`: `wait until go; phase <= 2'd1;` — assignment appears inside `if (go)` arm, not in a separate S1 state.
- [x] `test_wait_until_fold_multi_assign`: `wait until go; X <= A; Y <= B;` — both assignments fold into the same `if (go)` arm.
- [x] `test_wait_until_fold_no_fold_past_second_wait`: `wait until go; X <= A; wait until done; Y <= B;` — X folds into S0's go-arm, Y folds into S1's done-arm; state ordering correct.
- [x] `test_wait_until_fold_wait_n_cycle_not_folded`: `wait 3 cycle; X <= A;` — counter states remain intact, X not in the go-arm.
- [x] Updated `test_thread_state_localparams_emitted` to reflect the folded 3-state shape (S1_action now unreachable, S0 jumps directly to S2_wait_cycles).
- [x] Updated `test_native_sim_thread_driven_top_pipe_reg_output_is_public` testbench: fold makes `payload_out` and `valid_out` visible 1 cycle earlier, so the check is after 1 tick instead of 2.

https://claude.ai/code/session_01NcGJqy1DDcTG66F7Fzof53

---
_Generated by [Claude Code](https://claude.ai/code/session_01NcGJqy1DDcTG66F7Fzof53)_