### PR TITLE
docs+test: document && / || logical-operator aliases, cover || in native sim

### DIFF
--- a/doc/Arch_AI_Reference_Card.md
+++ b/doc/Arch_AI_Reference_Card.md
@@ -278,7 +278,7 @@ let {field1, field2} = struct_expr;   // binds two locals to the struct's named 
 Arithmetic:  + - * / %   (auto-widen)
 Wrapping:    +% -% *%    (no-widen; result width = max(W(a),W(b)))
 Comparison:  == != < > <= >=
-Logical:     and or not
+Logical:     and or not    // `&&` == `and`, `||` == `or` (symbolic aliases)
 Bitwise:     & | ^ ~ << >>
 SVA-only:    |->  (overlap implication, same-cycle)
              |=>  (next-cycle implication)

--- a/doc/arch.ebnf
+++ b/doc/arch.ebnf
@@ -762,6 +762,11 @@ reset_polarity   = "High" | "Low" ;
      19-20:  *  /  %
      21   :  prefix unary (!, ~, -, &, |, ^)
      postfix: . [] as inside  (highest)
+
+   Logical operators have keyword and symbolic spellings that are exact
+   aliases (same token, same precedence): `and` == `&&`, `or` == `||`,
+   `not` == `!`. Either spelling is accepted; the keyword form is canonical
+   in the spec and examples.
 *)
 
 expr = ternary_expr ;
@@ -770,7 +775,7 @@ ternary_expr = binary_expr [ "?" expr ":" expr ] ;
 
 binary_expr = prefix_expr { binary_op prefix_expr } ;
 
-binary_op = "||" | "&&"
+binary_op = "||" | "&&" | "or" | "and"   (* `||`/`&&` are aliases for `or`/`and` *)
            | "==" | "!="
            | "<" | ">" | "<=" | ">="
            | "|" | "^" | "&"

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -18504,6 +18504,10 @@ fn test_native_sim_bool_not_pipe_reg_outputs_and_ampamp() {
     // `not result_valid_out@0` as 8 bits. That emitted a reduction-AND
     // over `!result_valid_out`, so `not false` collapsed back to false
     // for byte-backed Bool values.
+    //
+    // Also covers the `||` sibling alias (review 2026-06-03): #493 added both
+    // `&&` and `||` tokens but only exercised `&&`. `||` must lower to C++
+    // logical `||`, not bitwise/reduction glue, on the same Bool pipe_reg path.
     let td = tempfile::tempdir().expect("tempdir");
     let arch_bin = env!("CARGO_BIN_EXE_arch");
     let out = std::process::Command::new(arch_bin)
@@ -18533,6 +18537,11 @@ fn test_native_sim_bool_not_pipe_reg_outputs_and_ampamp() {
         generated_cpp.contains("idle_ampamp")
             && generated_cpp.contains("((!_busy_out) && (!_result_valid_out))"),
         "symbolic `&&` should lower to C++ logical &&, not bitwise/reduction glue:\n{generated_cpp}"
+    );
+    assert!(
+        generated_cpp.contains("busy_pipebar")
+            && generated_cpp.contains("(_busy_out || _result_valid_out)"),
+        "symbolic `||` should lower to C++ logical ||, not bitwise/reduction glue:\n{generated_cpp}"
     );
     assert!(
         !generated_cpp.contains("0xffULL") && !generated_cpp.contains("0xFFULL"),

--- a/tests/native_bool_not/Probe.arch
+++ b/tests/native_bool_not/Probe.arch
@@ -20,6 +20,8 @@ module NativeBoolNotProbe
   port not_result_valid: out Bool;
   port idle_ampamp: out Bool;
   port idle_keyword: out Bool;
+  port busy_pipebar: out Bool;
+  port busy_or_keyword: out Bool;
 
   seq on clk rising
     busy_out <= busy_in;
@@ -30,5 +32,10 @@ module NativeBoolNotProbe
     not_result_valid = not result_valid_out@0;
     idle_ampamp = not busy_out@0 && not result_valid_out@0;
     idle_keyword = (busy_out@0 == false) and (result_valid_out@0 == false);
+    // `||` is the symbolic alias for the `or` keyword (arch-com#492 / #493).
+    // Cover the OR sibling so the alias lowers to C++ logical `||`, not a
+    // bitwise/reduction glue over byte-backed Bool pipe_reg values.
+    busy_pipebar = busy_out@0 || result_valid_out@0;
+    busy_or_keyword = busy_out@0 or result_valid_out@0;
   end comb
 end module NativeBoolNotProbe

--- a/tests/native_bool_not/tb.cpp
+++ b/tests/native_bool_not/tb.cpp
@@ -34,6 +34,8 @@ int main() {
     CHECK(dut.not_result_valid == 1, "not false is true on a Bool pipe_reg @0 read");
     CHECK(dut.idle_ampamp == 1, "symbolic && preserves not false && not false");
     CHECK(dut.idle_keyword == 1, "keyword and matches symbolic &&");
+    CHECK(dut.busy_pipebar == 0, "symbolic || preserves false || false");
+    CHECK(dut.busy_or_keyword == 0, "keyword or matches symbolic ||");
 
     dut.busy_in = 0;
     dut.result_valid_in = 1;
@@ -42,6 +44,8 @@ int main() {
     CHECK(dut.not_result_valid == 0, "not true is false on a Bool pipe_reg @0 read");
     CHECK(dut.idle_ampamp == 0, "symbolic && observes not true as false");
     CHECK(dut.idle_keyword == 0, "keyword and matches symbolic && when false");
+    CHECK(dut.busy_pipebar == 1, "symbolic || observes false || true as true");
+    CHECK(dut.busy_or_keyword == 1, "keyword or matches symbolic || when true");
 
     std::printf("PASS native Bool not pipe_reg: %d pass / %d fail\n", pass, fail);
     return fail == 0 ? 0 : 1;


### PR DESCRIPTION
## Summary

Follow-up to **#493** (which added `&&`/`||` as symbolic aliases for the `and`/`or` keyword operators, fixing native-sim mis-tokenization in #492). Two gaps remained from that change — found during the 2026-06-03 daily code review:

1. **Doc consistency.** The user-facing operator references didn't mention the symbolic forms, even though the lexer and the EBNF grammar both accept them:
   - `doc/Arch_AI_Reference_Card.md` §3 listed only `Logical: and or not`.
   - `doc/arch.ebnf`'s `binary_op` production listed only the symbolic `"||" | "&&"` and *omitted* the keyword spellings `and`/`or` — the reverse drift.

   Both are now reconciled: the card notes ``&&`==`and` / `||`==`or``, and the EBNF lists both spellings with a note that `and`/`or`/`not` and `&&`/`||`/`!` are exact token aliases (same token, same precedence; keyword form canonical in spec/examples).

2. **Test coverage.** #493's regression (`test_native_sim_bool_not_pipe_reg_outputs_and_ampamp`) exercised only `&&`. This extends the `tests/native_bool_not` fixture with the `||` sibling on the same Bool `pipe_reg` path, asserting it lowers to C++ logical `||` — not bitwise/reduction glue over byte-backed Bool values (the exact failure mode #492 hit for `&&`).

## Why this matters

ARCH is designed to be generated correctly by LLMs from the reference card. Before this, the card only advertised `and`/`or`, so a generated design using `&&`/`||` (now valid) would look undocumented; and the EBNF disagreed with the card on which spelling exists. The `||` lowering path was also unverified.

## Scope

**No compiler/source change** — pure docs + test. Verified `||` lowers correctly end-to-end (`a || b` → SV `a || b`, native sim `(_busy_out || _result_valid_out)`).

## Test plan

- [x] `cargo test test_native_sim_bool_not_pipe_reg_outputs_and_ampamp` — green (now covers both `&&` and `||`)
- [x] Full suite green: **557 integration tests**, 0 failures
- [x] Manual: `arch check` / `arch build` of an `a || b` design lowers to SV `a || b`