### PR TITLE
proposal: `!` prefix logical-not — documented + tokenized, but not parsed

### DIFF
--- a/doc/Arch_AI_Reference_Card.md
+++ b/doc/Arch_AI_Reference_Card.md
@@ -278,7 +278,7 @@ let {field1, field2} = struct_expr;   // binds two locals to the struct's named 
 Arithmetic:  + - * / %   (auto-widen)
 Wrapping:    +% -% *%    (no-widen; result width = max(W(a),W(b)))
 Comparison:  == != < > <= >=
-Logical:     and or not
+Logical:     and or not    // `&&` == `and`, `||` == `or` (symbolic aliases)
 Bitwise:     & | ^ ~ << >>
 SVA-only:    |->  (overlap implication, same-cycle)
              |=>  (next-cycle implication)

--- a/doc/arch.ebnf
+++ b/doc/arch.ebnf
@@ -762,6 +762,11 @@ reset_polarity   = "High" | "Low" ;
      19-20:  *  /  %
      21   :  prefix unary (!, ~, -, &, |, ^)
      postfix: . [] as inside  (highest)
+
+   Logical operators have keyword and symbolic spellings that are exact
+   aliases (same token, same precedence): `and` == `&&`, `or` == `||`,
+   `not` == `!`. Either spelling is accepted; the keyword form is canonical
+   in the spec and examples.
 *)
 
 expr = ternary_expr ;
@@ -770,7 +775,7 @@ ternary_expr = binary_expr [ "?" expr ":" expr ] ;
 
 binary_expr = prefix_expr { binary_op prefix_expr } ;
 
-binary_op = "||" | "&&"
+binary_op = "||" | "&&" | "or" | "and"   (* `||`/`&&` are aliases for `or`/`and` *)
            | "==" | "!="
            | "<" | ">" | "<=" | ">="
            | "|" | "^" | "&"

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -18504,6 +18504,10 @@ fn test_native_sim_bool_not_pipe_reg_outputs_and_ampamp() {
     // `not result_valid_out@0` as 8 bits. That emitted a reduction-AND
     // over `!result_valid_out`, so `not false` collapsed back to false
     // for byte-backed Bool values.
+    //
+    // Also covers the `||` sibling alias (review 2026-06-03): #493 added both
+    // `&&` and `||` tokens but only exercised `&&`. `||` must lower to C++
+    // logical `||`, not bitwise/reduction glue, on the same Bool pipe_reg path.
     let td = tempfile::tempdir().expect("tempdir");
     let arch_bin = env!("CARGO_BIN_EXE_arch");
     let out = std::process::Command::new(arch_bin)
@@ -18533,6 +18537,11 @@ fn test_native_sim_bool_not_pipe_reg_outputs_and_ampamp() {
         generated_cpp.contains("idle_ampamp")
             && generated_cpp.contains("((!_busy_out) && (!_result_valid_out))"),
         "symbolic `&&` should lower to C++ logical &&, not bitwise/reduction glue:\n{generated_cpp}"
+    );
+    assert!(
+        generated_cpp.contains("busy_pipebar")
+            && generated_cpp.contains("(_busy_out || _result_valid_out)"),
+        "symbolic `||` should lower to C++ logical ||, not bitwise/reduction glue:\n{generated_cpp}"
     );
     assert!(
         !generated_cpp.contains("0xffULL") && !generated_cpp.contains("0xFFULL"),

--- a/tests/native_bool_not/Probe.arch
+++ b/tests/native_bool_not/Probe.arch
@@ -20,6 +20,8 @@ module NativeBoolNotProbe
   port not_result_valid: out Bool;
   port idle_ampamp: out Bool;
   port idle_keyword: out Bool;
+  port busy_pipebar: out Bool;
+  port busy_or_keyword: out Bool;
 
   seq on clk rising
     busy_out <= busy_in;
@@ -30,5 +32,10 @@ module NativeBoolNotProbe
     not_result_valid = not result_valid_out@0;
     idle_ampamp = not busy_out@0 && not result_valid_out@0;
     idle_keyword = (busy_out@0 == false) and (result_valid_out@0 == false);
+    // `||` is the symbolic alias for the `or` keyword (arch-com#492 / #493).
+    // Cover the OR sibling so the alias lowers to C++ logical `||`, not a
+    // bitwise/reduction glue over byte-backed Bool pipe_reg values.
+    busy_pipebar = busy_out@0 || result_valid_out@0;
+    busy_or_keyword = busy_out@0 or result_valid_out@0;
   end comb
 end module NativeBoolNotProbe

--- a/tests/native_bool_not/tb.cpp
+++ b/tests/native_bool_not/tb.cpp
@@ -34,6 +34,8 @@ int main() {
     CHECK(dut.not_result_valid == 1, "not false is true on a Bool pipe_reg @0 read");
     CHECK(dut.idle_ampamp == 1, "symbolic && preserves not false && not false");
     CHECK(dut.idle_keyword == 1, "keyword and matches symbolic &&");
+    CHECK(dut.busy_pipebar == 0, "symbolic || preserves false || false");
+    CHECK(dut.busy_or_keyword == 0, "keyword or matches symbolic ||");
 
     dut.busy_in = 0;
     dut.result_valid_in = 1;
@@ -42,6 +44,8 @@ int main() {
     CHECK(dut.not_result_valid == 0, "not true is false on a Bool pipe_reg @0 read");
     CHECK(dut.idle_ampamp == 0, "symbolic && observes not true as false");
     CHECK(dut.idle_keyword == 0, "keyword and matches symbolic && when false");
+    CHECK(dut.busy_pipebar == 1, "symbolic || observes false || true as true");
+    CHECK(dut.busy_or_keyword == 1, "keyword or matches symbolic || when true");
 
     std::printf("PASS native Bool not pipe_reg: %d pass / %d fail\n", pass, fail);
     return fail == 0 ? 0 : 1;


### PR DESCRIPTION
## Research note (not a code change)

A daily code-review finding (2026-06-03) surfaced while reviewing **#493** (the `&&`/`||` alias fix). Adds `ideas/2026-06-03-bang-prefix-logical-not.md`.

### The inconsistency

ARCH advertises `!` as the symbolic logical-not in **three** places, but the parser rejects it — only `not` parses:

| Surface | Says `!` is logical-not? |
|---|---|
| `doc/Arch_AI_Reference_Card.md:286` | yes — *"use `(!a) \|\| b` for plain Boolean implication"* |
| `doc/ARCH_HDL_Specification.md:7783` | yes — same `(!a) \|\| b` guidance |
| `doc/arch.ebnf:763` | yes — `21 : prefix unary (!, ~, -, …)` |
| `src/lexer.rs:350` | tokenizes `!` as `Bang` |
| parser prefix-unary | **no — parse error** |

So the docs (which exist so an LLM emits correct ARCH) prescribe a form that fails to compile.

### Evidence it's a recurring papercut

- `arch advise` learning store surfaces this exact error with a **2× retrieval** count (`if !outs[j].b_valid` in `Nic400MasterPort.arch`, hand-fixed to `if not …`).
- **PR #488** (this review window) was *"restore if-not/wait-until pattern"* — the same `!`→`not` rewrite, re-churned after a regression.
- 21 bundled `.arch` files use `not` where `!` would read naturally.
- Direct sibling of the gap **#493** just closed for `&&`/`||`.

### Recommendation (needs owner sign-off)

**Option C** = implement `!` → logical-not in the parser (one arm, parallel to the existing `~`→`BitNot`; the `UnaryOp::Not` lowering already exists end-to-end through typecheck/SV/native-sim/formal) **+** a `!`==`not` doc note mirroring #495's `&&`==`and` note. No `!=` ambiguity (distinct `BangEq` token).

Filed as a **proposal, not an autonomous fix**, because it alters accepted surface syntax — per the repo rule, a language-surface change waits for confirmation even when the spec already describes it. The note lays out all three options (implement / retract-the-docs / both) so the owner can decide.

See the note for full detail.