### PR TITLE
feat(parser): accept `!` as prefix logical-not (alias of `not`)

### DIFF
--- a/doc/Arch_AI_Reference_Card.md
+++ b/doc/Arch_AI_Reference_Card.md
@@ -278,7 +278,7 @@ let {field1, field2} = struct_expr;   // binds two locals to the struct's named 
 Arithmetic:  + - * / %   (auto-widen)
 Wrapping:    +% -% *%    (no-widen; result width = max(W(a),W(b)))
 Comparison:  == != < > <= >=
-Logical:     and or not    // `&&` == `and`, `||` == `or` (symbolic aliases)
+Logical:     and or not    // `&&`==`and`, `||`==`or`, `!`==`not` (symbolic aliases; `~` is bitwise-not)
 Bitwise:     & | ^ ~ << >>
 SVA-only:    |->  (overlap implication, same-cycle)
              |=>  (next-cycle implication)

--- a/ideas/2026-06-03-bang-prefix-logical-not.md
+++ b/ideas/2026-06-03-bang-prefix-logical-not.md
@@ -1,0 +1,77 @@
+# `!` prefix logical-not: documented and tokenized, but not parsed
+
+**Status:** ✅ IMPLEMENTED (Option C) — owner-approved 2026-06-03. Parser now
+accepts `!` as prefix logical-not; reference card notes the `!`==`not` alias.
+**Found:** 2026-06-03 daily code review, while reviewing PR #493 (`&&`/`||` aliases)
+**Related:** #493 (added `&&`/`||` as symbolic aliases for `and`/`or`), #488 / #485
+(recurring `if !…` → `if not …` churn in NIC-400 designs)
+
+## The inconsistency (now resolved)
+
+ARCH advertised `!` as the symbolic spelling of logical-not in three separate
+places, but the parser rejected it — only the `not` keyword parsed.
+
+| Surface | Said `!` is logical-not? | Before | After |
+|---|---|---|---|
+| `doc/Arch_AI_Reference_Card.md` §3 | yes — *"use `(!a) \|\| b` …"* | mentioned `not` only | `!`==`not` noted |
+| `doc/ARCH_HDL_Specification.md:7783` | yes — same `(!a) \|\| b` guidance | guidance was a parse error | now valid |
+| `doc/arch.ebnf:789` `prefix_op` | yes — `"!" (* logical not *)` | grammar-only | parser conforms |
+| `src/lexer.rs:350` | tokenizes `!` as `Bang` | token unused in prefix | wired up |
+| `src/parser.rs` prefix-unary | **no — parse error** | — | `Bang ⇒ UnaryOp::Not` |
+
+Repro that used to fail and now compiles:
+
+```arch
+comb
+  y = !a;                 // was: × unexpected token: expected expression, found !
+  impl_out = (!a) || b;   // the exact form the reference card prescribes
+  nested = !(a and b);
+end comb
+```
+
+## Why this was a real, recurring papercut
+
+- **`arch advise` learning store** surfaced this exact error with a 2×
+  retrieval count: `if !outs[j].b_valid` in `tests/nic400/Nic400MasterPort.arch`,
+  fixed by hand to `if not outs[j].b_valid`.
+- **PR #488** was titled *"restore if-not/wait-until pattern"* — the same
+  `!` → `not` rewrite, churned again after a regression.
+- **21** bundled `.arch` files already used `not` where a human or model would
+  naturally reach for `!`.
+- It was the precise sibling of the gap **#493** closed for `&&`/`||`: a
+  symbolic operator the grammar documented but the front-end never wired up.
+
+## Implementation (Option C)
+
+One arm in `parse_prefix` (`src/parser.rs`), exactly parallel to the existing
+`Tilde ⇒ UnaryOp::BitNot`:
+
+```rust
+// `not` keyword and `!` symbol are exact aliases for logical-not.
+Some(TokenKind::Not) | Some(TokenKind::Bang) => { … UnaryOp::Not … }
+```
+
+**No new lowering work** — the `UnaryOp::Not` path already existed end-to-end:
+typecheck (`Ty::Bool`, `typecheck.rs:2950`), SV emit (`(!o)`), native sim
+(width-1 after #493), formal (`formal.rs`). `TokenKind::Not` is dispatched only
+in `parse_prefix`, so no expression-start helper needed updating. No `!=`
+ambiguity: `!=` is the distinct `BangEq` token (longest-match), so `a != b` is
+unaffected and `!a` / `!(expr)` are unambiguous in prefix position.
+
+Plus the matching doc note in the reference card (`!`==`not`), mirroring #495's
+`&&`==`and` / `||`==`or` note. The EBNF already listed `!` in `prefix_op` and
+the #495 alias note already covered `not`==`!` — aspirational then, accurate now.
+
+## Tests
+
+- `src/lexer.rs::test_bang_vs_bang_eq` — `! != !a` lexes as `Bang BangEq Bang Ident`.
+- `tests/integration_test.rs::test_bang_prefix_is_logical_not_alias` — `!a`,
+  `(!a) || b`, `!(a and b)` lower to SV `!`; `a != b` unaffected; and the whole
+  module lowers **byte-identically** to its `not`/`or` keyword spelling.
+- Full suite green: 558 integration tests, 25 lexer unit tests, 0 failures.
+
+## Scope / non-goals
+
+- Logical-not only (`!`). Bitwise complement stays `~` (`BitNot`), unchanged.
+- No precedence change: `!` takes the same prefix-unary tier the EBNF already
+  assigned it, identical to `not`.

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -701,6 +701,17 @@ mod tests {
     }
 
     #[test]
+    fn test_bang_vs_bang_eq() {
+        // `!` (prefix logical-not, arch#496) must not swallow a following `=`:
+        // `!=` is the distinct BangEq token (longest-match).
+        let tokens = tokenize("! != !a").unwrap();
+        assert_eq!(tokens[0].kind, TokenKind::Bang);
+        assert_eq!(tokens[1].kind, TokenKind::BangEq);
+        assert_eq!(tokens[2].kind, TokenKind::Bang);
+        assert!(matches!(tokens[3].kind, TokenKind::Ident(_)));
+    }
+
+    #[test]
     fn test_literals() {
         let tokens = tokenize("42 0xFF 0b1010 8'hAB").unwrap();
         assert_eq!(tokens[0].kind, TokenKind::DecLiteral("42".into()));

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3841,7 +3841,11 @@ impl Parser {
                     kind: ExprKind::SvaNext(n_val, Box::new(operand)),
                     span, parenthesized: false })
             }
-            Some(TokenKind::Not) => {
+            // `not` keyword and `!` symbol are exact aliases for logical-not
+            // (same token semantics, same precedence) — mirrors `&&`==`and` /
+            // `||`==`or`. Bitwise complement stays `~` (BitNot). `!=` is a
+            // distinct token (BangEq), so `a != b` is unaffected.
+            Some(TokenKind::Not) | Some(TokenKind::Bang) => {
                 let tok = self.advance();
                 let operand = self.parse_expr_bp(prefix_bp())?;
                 let span = tok.span.merge(operand.span);

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -154,6 +154,69 @@ end module Placeholder
     insta::assert_snapshot!(sv);
 }
 
+// ── Operators ─────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_bang_prefix_is_logical_not_alias() {
+    // arch#496: `!` is a symbolic alias for the `not` keyword (logical-not),
+    // exactly parallel to `&&`==`and` / `||`==`or` (#493). It must lower to
+    // SV `!`, and `!=` must remain a distinct, unaffected operator.
+    let bang_src = r#"
+domain SysDomain
+  freq_mhz: 100
+end domain SysDomain
+
+module BangAlias
+  port a: in Bool;
+  port b: in Bool;
+  port y: out Bool;
+  port impl_out: out Bool;
+  port nested: out Bool;
+  port ne: out Bool;
+  comb
+    y = !a;
+    impl_out = (!a) || b;
+    nested = !(a and b);
+    ne = a != b;
+  end comb
+end module BangAlias
+"#;
+    let bang = compile_to_sv(bang_src);
+    assert!(bang.contains("assign y = !a;"), "got:\n{bang}");
+    assert!(bang.contains("assign impl_out = !a || b;"), "got:\n{bang}");
+    assert!(bang.contains("assign nested = !(a && b);"), "got:\n{bang}");
+    // `!=` is a distinct token (BangEq) — prefix `!` must not disturb it.
+    assert!(bang.contains("assign ne = a != b;"), "got:\n{bang}");
+
+    // The keyword spelling of the same module must lower byte-identically:
+    // `!`/`||`/`and` and `not`/`or`/`and` are exact aliases.
+    let kw_src = r#"
+domain SysDomain
+  freq_mhz: 100
+end domain SysDomain
+
+module BangAlias
+  port a: in Bool;
+  port b: in Bool;
+  port y: out Bool;
+  port impl_out: out Bool;
+  port nested: out Bool;
+  port ne: out Bool;
+  comb
+    y = not a;
+    impl_out = (not a) or b;
+    nested = not (a and b);
+    ne = a != b;
+  end comb
+end module BangAlias
+"#;
+    let kw = compile_to_sv(kw_src);
+    assert_eq!(
+        bang, kw,
+        "`!`/`||` must lower identically to `not`/`or`:\n--- bang ---\n{bang}\n--- kw ---\n{kw}"
+    );
+}
+
 // ── Let bindings ──────────────────────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary

Implements the proposal from the 2026-06-03 daily review (originally noted in PR #496, which auto-merged as a duplicate of #495 before the note/impl landed — this PR carries the real change). Owner-approved.

`!` was advertised as logical-not in **three** places yet rejected by the parser — only the `not` keyword parsed:

| Surface | Said `!` is logical-not? |
|---|---|
| `doc/Arch_AI_Reference_Card.md` §3 | yes — *"use `(!a) \|\| b` …"* |
| `doc/ARCH_HDL_Specification.md:7783` | yes — same `(!a) \|\| b` guidance |
| `doc/arch.ebnf:789` (`prefix_op`) | yes — `"!" (* logical not *)` |
| `src/lexer.rs:350` | tokenized `!` as `Bang` (unused in prefix) |
| parser prefix-unary | **no — parse error** |

So the docs (which exist so an LLM emits correct ARCH) prescribed a form that failed to compile. Recurring papercut: `arch advise` learning store has a 2× retrieval on `if !outs[j].b_valid` (`Nic400MasterPort.arch`), PR #488 re-churned the same `!`→`not` rewrite, and 21 bundled `.arch` files use `not` where `!` reads naturally. Direct sibling of #493 (`&&`/`||` aliases).

## Change

One arm in `parse_prefix`, parallel to the existing `~`→`BitNot`:

```rust
// `not` keyword and `!` symbol are exact aliases for logical-not.
Some(TokenKind::Not) | Some(TokenKind::Bang) => { … UnaryOp::Not … }
```

**No new lowering** — the `UnaryOp::Not` path already exists end-to-end (typecheck `Ty::Bool`, SV `!`, native sim, formal). `TokenKind::Not` is dispatched only here, so no expr-start helper needs updating. **No `!=` ambiguity** — `!=` is the distinct `BangEq` token (longest-match), so `a != b` is unaffected.

Plus the `!`==`not` reference-card note (mirrors #495's `&&`==`and`). The EBNF `prefix_op` already listed `!`, and #495's alias note already covered `not`==`!` — aspirational then, accurate now. Includes the proposal note `ideas/2026-06-03-bang-prefix-logical-not.md` (status → implemented).

## Test plan

- [x] `src/lexer.rs::test_bang_vs_bang_eq` — `! != !a` lexes as `Bang BangEq Bang Ident`
- [x] `tests/integration_test.rs::test_bang_prefix_is_logical_not_alias` — `!a` / `(!a) || b` / `!(a and b)` lower to SV `!`; `a != b` intact; whole module lowers **byte-identically** to its `not`/`or` spelling
- [x] Full suite green: **558 integration tests + 25 lexer unit tests**, 0 failures