### PR TITLE
feat(resolve): auto-discover .archi for bus port types

### DIFF
--- a/doc/ARCH_HDL_Specification.md
+++ b/doc/ARCH_HDL_Specification.md
@@ -8718,6 +8718,8 @@ When the compiler encounters `inst sub: SubModule` and `SubModule` is not define
 2. `SubModule.archi` in the input file's directory
 3. `SubModule.arch` or `SubModule.archi` in directories listed in `ARCH_LIB_PATH` (colon-separated)
 
+The same discovery applies to **bus port types**. A port declaration `port m: initiator BusName` or `port m: target BusName` whose `BusName` is not defined in the input files triggers the identical search for `BusName.arch` / `BusName.archi` (input directory, then `ARCH_LIB_PATH`, then the stdlib). This means `arch check ModuleWithBusPort.arch` resolves the bus on its own — there is no need to also pass the bus source. An explicit `use BusName;` takes precedence: when the bus is named in a `use`, that declaration drives resolution and the fallback bus scan is skipped, so a stale build-emitted `BusName.archi` in the source directory cannot shadow it. Emitted bus `.archi` files are round-trippable — bus members are written as bare `name: dir Type;`, matching the `bus` body grammar.
+
 This enables separate compilation workflows:
 
 ```bash

--- a/doc/Arch_AI_Reference_Card.md
+++ b/doc/Arch_AI_Reference_Card.md
@@ -1356,6 +1356,8 @@ arch build *.arch                 # builds all, respects deps via .archi discove
 
 When `inst sub: SubModule` references an undefined module, the compiler searches for `SubModule.archi` or `SubModule.arch` in the input directory and `ARCH_LIB_PATH`.
 
+The same auto-discovery applies to **bus port types**: a `port m: initiator BusName` / `port m: target BusName` declaration whose `BusName` is not defined in the current input set pulls in `BusName.arch` / `BusName.archi` from the input directory, `ARCH_LIB_PATH`, then the stdlib. So `arch check ModuleWithBusPort.arch` resolves its bus standalone, no need to also pass the bus file. An explicit `use BusName;` takes precedence — when present, the fallback bus scan is skipped (the `use` already names the dependency). The emitted `BusName.archi` is round-trippable: bus members are written as bare `name: dir Type;`, matching the `bus` body grammar.
+
 ---
 
 ## 5. Logging

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -81,7 +81,21 @@ pub(crate) fn emit_bus_interface(b: &BusDecl) -> String {
     let name = &b.name.name;
     let mut s = format!("bus {name}\n");
     emit_params(&mut s, &b.params);
-    emit_ports(&mut s, &b.signals);
+    // Bus members are bare `name: dir Type;` — that is how `parse_bus_signal`
+    // reads them. The generic `emit_ports` would prefix each with `port `,
+    // producing a `.archi` the parser rejects ("'port' is a reserved
+    // keyword"), so the emitted bus interface could never be read back.
+    for sig in &b.signals {
+        let dir = match sig.direction {
+            Direction::In => "in",
+            Direction::Out => "out",
+        };
+        s.push_str(&format!(
+            "  {}: {dir} {};\n",
+            sig.name.name,
+            type_str(&sig.ty)
+        ));
+    }
     s.push_str(&format!("end bus {name}\n"));
     s
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1345,6 +1345,38 @@ fn resolve_stdlib_dir() -> Option<PathBuf> {
     None
 }
 
+/// Port list for any port-bearing construct. Returns an empty slice for
+/// items that carry no ports (struct, enum, function, bus, package, …).
+/// Used by the dep-discovery scan to find `initiator`/`target` bus-port
+/// type references the `inst` scan cannot see.
+fn item_ports(item: &Item) -> &[arch::ast::PortDecl] {
+    match item {
+        // Own `ports` field.
+        Item::Module(m) => &m.ports,
+        Item::Synchronizer(s) => &s.ports,
+        Item::Clkgate(c) => &c.ports,
+        Item::Template(t) => &t.ports,
+        // `ports` via `Deref<Target = ConstructCommon>`.
+        Item::Fsm(f) => &f.ports,
+        Item::Fifo(f) => &f.ports,
+        Item::Ram(r) => &r.ports,
+        Item::Cam(c) => &c.ports,
+        Item::Counter(c) => &c.ports,
+        Item::Arbiter(a) => &a.ports,
+        Item::Regfile(r) => &r.ports,
+        Item::Pipeline(p) => &p.ports,
+        Item::Linklist(l) => &l.ports,
+        Item::Domain(_)
+        | Item::Struct(_)
+        | Item::Enum(_)
+        | Item::Function(_)
+        | Item::Bus(_)
+        | Item::Package(_)
+        | Item::Use(_)
+        | Item::ExternPackage(_) => &[],
+    }
+}
+
 fn resolve_use_imports(files: &[PathBuf]) -> miette::Result<Vec<PathBuf>> {
     use std::collections::HashSet;
 
@@ -1355,6 +1387,7 @@ fn resolve_use_imports(files: &[PathBuf]) -> miette::Result<Vec<PathBuf>> {
     let mut all_files: Vec<PathBuf> = Vec::new();
     let mut seen: HashSet<PathBuf> = HashSet::new();
     let mut all_defined_modules: HashSet<String> = HashSet::new();
+    let mut all_defined_buses: HashSet<String> = HashSet::new();
     let mut queue: Vec<PathBuf> = files.to_vec();
 
     // Process files, discovering new dependencies via `use`
@@ -1376,8 +1409,10 @@ fn resolve_use_imports(files: &[PathBuf]) -> miette::Result<Vec<PathBuf>> {
 
         // Find `use` items and queue their files
         let mut deps = Vec::new();
+        let mut use_names: HashSet<String> = HashSet::new();
         for item in &parsed.items {
             if let arch::ast::Item::Use(u) = item {
+                use_names.insert(u.name.name.clone());
                 // Resolution order:
                 //   1. Same-directory relative path
                 //   2. ARCH_LIB_PATH entries (colon-separated)
@@ -1416,6 +1451,7 @@ fn resolve_use_imports(files: &[PathBuf]) -> miette::Result<Vec<PathBuf>> {
                 Item::Fifo(f) => { all_defined_modules.insert(f.name.name.clone()); }
                 Item::Ram(r) => { all_defined_modules.insert(r.name.name.clone()); }
                 Item::Arbiter(a) => { all_defined_modules.insert(a.name.name.clone()); }
+                Item::Bus(b) => { all_defined_buses.insert(b.name.name.clone()); }
                 _ => {}
             }
         }
@@ -1458,6 +1494,55 @@ fn resolve_use_imports(files: &[PathBuf]) -> miette::Result<Vec<PathBuf>> {
                     let p = stdlib.join(format!("{inst_name}.archi"));
                     if p.exists() { deps.push(p); }
                 }
+            }
+        }
+
+        // Find bus port-type references (`port p: initiator|target BusName<…>`)
+        // and look for their `.arch` / `.archi` definitions with the same
+        // search chain as `inst` references. Bus types referenced across files
+        // appear in port declarations, not `inst` nodes, so the scan above
+        // never queues them — without this a single-file `arch check` of a
+        // module with a bus port fails with "unknown bus type" even when the
+        // bus's `.arch`/`.archi` sits right next to it.
+        let mut bus_refs: Vec<String> = Vec::new();
+        for item in &parsed.items {
+            for port in item_ports(item) {
+                if let Some(bus) = &port.bus_info {
+                    bus_refs.push(bus.bus_name.name.clone());
+                }
+            }
+        }
+        for bus_name in bus_refs {
+            if all_defined_buses.contains(bus_name.as_str()) { continue; }
+            // An explicit `use <Bus>;` is authoritative — it already queued
+            // the canonical definition above. Skip the fallback scan for it
+            // so we don't also pull in a stale build-artifact `<Bus>.archi`
+            // sitting in the source directory (which would double-define the
+            // bus).
+            if use_names.contains(bus_name.as_str()) { continue; }
+            // Same-directory `.arch` first, then `.archi`.
+            let arch_path = base_dir.join(format!("{bus_name}.arch"));
+            let archi_path = base_dir.join(format!("{bus_name}.archi"));
+            if arch_path.exists() {
+                deps.push(arch_path);
+            } else if archi_path.exists() {
+                deps.push(archi_path);
+            }
+            // Then ARCH_LIB_PATH entries.
+            if let Ok(lib_path) = std::env::var("ARCH_LIB_PATH") {
+                for dir in lib_path.split(':') {
+                    let p = std::path::Path::new(dir).join(format!("{bus_name}.arch"));
+                    if p.exists() { deps.push(p); break; }
+                    let p = std::path::Path::new(dir).join(format!("{bus_name}.archi"));
+                    if p.exists() { deps.push(p); break; }
+                }
+            }
+            // Finally the shipped standard library.
+            if let Some(stdlib) = resolve_stdlib_dir() {
+                let p = stdlib.join(format!("{bus_name}.arch"));
+                if p.exists() { deps.push(p); continue; }
+                let p = stdlib.join(format!("{bus_name}.archi"));
+                if p.exists() { deps.push(p); }
             }
         }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -19971,3 +19971,128 @@ end module UserAssertNoReset
          user-assert SVA; got:\n{sv}"
     );
 }
+
+/// `arch check Foo.arch` for a module that references a `bus` type via a
+/// port (`port m: initiator|target BusName`) must auto-discover the bus
+/// definition (`BusName.arch` / `.archi`) from the same directory, the
+/// same way `inst SubModule` auto-discovers `SubModule.archi`. Before this
+/// was wired up, the dep scan only inspected `inst` nodes, so a single-file
+/// check of a bus-consuming module failed with "unknown bus type".
+#[test]
+fn bus_port_type_auto_discovers_sibling_definition() {
+    let td = tempfile::tempdir().expect("tempdir");
+    let arch_bin = env!("CARGO_BIN_EXE_arch");
+
+    std::fs::write(
+        td.path().join("MyBus.arch"),
+        "bus MyBus\n  cmd: out UInt<8>;\n  resp: in UInt<8>;\nend bus MyBus\n",
+    )
+    .unwrap();
+    // NOTE: no `use MyBus;` — resolution must come purely from the
+    // bus-port dependency scan.
+    let consumer = td.path().join("Consumer.arch");
+    std::fs::write(
+        &consumer,
+        "module Consumer\n  port clk: in Clock<SysDomain>;\n  \
+         port m: initiator MyBus;\n  comb\n    m.cmd = 8'h0;\n  end comb\n\
+         end module Consumer\n",
+    )
+    .unwrap();
+
+    let out = std::process::Command::new(arch_bin)
+        .arg("check")
+        .arg(&consumer)
+        .output()
+        .expect("run arch check");
+    assert!(
+        out.status.success(),
+        "single-file check of a bus-consuming module should auto-discover \
+         the sibling bus definition; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    // Control: with the bus definition absent, the check must still fail
+    // with the unresolved-bus diagnostic (auto-discovery is additive, not a
+    // silent pass).
+    let td2 = tempfile::tempdir().expect("tempdir");
+    let lonely = td2.path().join("Consumer.arch");
+    std::fs::copy(&consumer, &lonely).unwrap();
+    let out2 = std::process::Command::new(arch_bin)
+        .arg("check")
+        .arg(&lonely)
+        .output()
+        .expect("run arch check");
+    assert!(
+        !out2.status.success(),
+        "check should fail when the referenced bus cannot be found"
+    );
+    assert!(
+        String::from_utf8_lossy(&out2.stderr).contains("unknown bus type"),
+        "expected 'unknown bus type' diagnostic; stderr:\n{}",
+        String::from_utf8_lossy(&out2.stderr)
+    );
+}
+
+/// The `.archi` bus interface emitted by `arch build` must parse back in —
+/// `emit_bus_interface` previously wrote `port name: ...` members, but a
+/// `bus` body is parsed with bare `name: dir Type;` members, so the
+/// emitted interface tripped "'port' is a reserved keyword" on read-back.
+/// This guards the round-trip now that bus interfaces are auto-discovered.
+#[test]
+fn bus_interface_archi_round_trips() {
+    let td = tempfile::tempdir().expect("tempdir");
+    let arch_bin = env!("CARGO_BIN_EXE_arch");
+
+    std::fs::write(
+        td.path().join("MyBus.arch"),
+        "bus MyBus\n  cmd: out UInt<8>;\n  resp: in UInt<8>;\nend bus MyBus\n",
+    )
+    .unwrap();
+    let consumer = td.path().join("Consumer.arch");
+    std::fs::write(
+        &consumer,
+        "module Consumer\n  port clk: in Clock<SysDomain>;\n  \
+         port m: initiator MyBus;\n  comb\n    m.cmd = 8'h0;\n  end comb\n\
+         end module Consumer\n",
+    )
+    .unwrap();
+
+    // Build the consumer — this emits `MyBus.archi` alongside the SV.
+    let sv_out = td.path().join("Consumer.sv");
+    let bld = std::process::Command::new(arch_bin)
+        .arg("build")
+        .arg(&consumer)
+        .arg("-o")
+        .arg(&sv_out)
+        .output()
+        .expect("run arch build");
+    assert!(
+        bld.status.success(),
+        "arch build failed; stderr:\n{}",
+        String::from_utf8_lossy(&bld.stderr)
+    );
+
+    let bus_archi = td.path().join("MyBus.archi");
+    assert!(
+        bus_archi.exists(),
+        "arch build should emit MyBus.archi next to the generated SV"
+    );
+    let archi_text = std::fs::read_to_string(&bus_archi).unwrap();
+    assert!(
+        archi_text.contains("cmd: out UInt<8>") && !archi_text.contains("port cmd"),
+        "bus interface members must be bare `name: dir Type;`, not \
+         `port`-prefixed; got:\n{archi_text}"
+    );
+
+    // The emitted interface must parse standalone (the round-trip).
+    let chk = std::process::Command::new(arch_bin)
+        .arg("check")
+        .arg(&bus_archi)
+        .output()
+        .expect("run arch check");
+    assert!(
+        chk.status.success(),
+        "emitted bus .archi must parse back in; stderr:\n{}",
+        String::from_utf8_lossy(&chk.stderr)
+    );
+}


### PR DESCRIPTION
## Summary

Implements the bus auto-discovery proposal from the 2026-06-02 review note
(#489 §3). Single-file `arch check ModuleWithBusPort.arch` previously failed
with `unknown bus type` when the module referenced a bus via
`port m: initiator|target BusName` and the bus lived in a sibling file —
even though module `inst` dependencies already auto-discover `.archi`/`.arch`.
The dep-discovery scan in `resolve_use_imports` only inspected `inst` nodes;
bus references appear in **port declarations**, so they were never resolved.

### Change

1. **Bus-port discovery** (`src/main.rs`). A new `item_ports` helper returns
   the port list of any port-bearing construct; the scan collects bus names
   from `initiator`/`target` ports and resolves each undefined one through
   the *same* search chain as `inst` (input dir `.arch` then `.archi`, then
   `ARCH_LIB_PATH`, then stdlib).

2. **`use` precedence.** An explicit `use BusName;` is authoritative — when
   present, the fallback bus scan is skipped, so a stale build-emitted
   `BusName.archi` sitting in the source directory cannot double-define the
   bus. (This is also what keeps the existing
   `test_stdlib_bus_apb_pslverr_decoupled_from_pprot` green, since it drives
   the bus via `use BusApb;`.)

3. **Round-trip fix** (`src/interface.rs`). Enabling `.archi` discovery for
   buses surfaced a latent bug: `emit_bus_interface` wrote members via the
   generic `emit_ports`, prefixing each with `port `, but a `bus` body is
   parsed with **bare** `name: dir Type;` members (`parse_bus_signal`). So
   every build-emitted bus `.archi` tripped *"'port' is a reserved keyword"*
   on read-back and could never be consumed. Members are now emitted bare,
   matching the grammar — bus interfaces finally round-trip.

### Scope (per `CLAUDE.md`)

Internal compiler change — extends an existing documented mechanism (`.archi`
auto-discovery) to bus ports and fixes interface emission. No surface syntax,
type rules, or lowering semantics change. Spec updated as part of the fix
(§30.2 + reference-card separate-compilation section).

## Test plan

- [x] `arch check tests/nic400/Nic400MasterPort.arch` (no `use`, sibling
  `BusAxi4.arch`) — **OK** (was `unknown bus type BusAxi4`).
- [x] New `bus_port_type_auto_discovers_sibling_definition` — positive case
  + unknown-bus control (still errors when the bus is absent).
- [x] New `bus_interface_archi_round_trips` — `arch build` a bus-consuming
  module, then `arch check` the emitted `BusName.archi` standalone.
- [x] Full suite green: **560** integration tests (was 558 + 2 new),
  including the previously-affected stdlib APB test. No new warnings.
- [x] Docs: `ARCH_HDL_Specification.md` §30.2 and `Arch_AI_Reference_Card.md`.