### PR TITLE
[codex] fix(nic400): route decode holes to default DECERR

### DIFF
--- a/tests/nic400/Nic400MasterPort.arch
+++ b/tests/nic400/Nic400MasterPort.arch
@@ -37,8 +37,12 @@ module Nic400MasterPort
 
   let m_ar_slv: UInt<NS_W> = m.ar_addr[REGION_BITS+NS_W-1:REGION_BITS];
   let m_aw_slv: UInt<NS_W> = m.aw_addr[REGION_BITS+NS_W-1:REGION_BITS];
-  let m_ar_oor: Bool = m.ar_addr[ADDR_WIDTH-1:REGION_BITS+NS_W] != 0;
-  let m_aw_oor: Bool = m.aw_addr[ADDR_WIDTH-1:REGION_BITS+NS_W] != 0;
+  // Decode holes inside the NS_W selector space (e.g. NUM_SLAVES=3, NS_W=2,
+  // addr selecting slot 3) must also route to the default slave; otherwise
+  // no per-slave thread matches and the request stalls forever instead of
+  // returning DECERR.
+  let m_ar_oor: Bool = (m.ar_addr[ADDR_WIDTH-1:REGION_BITS+NS_W] != 0) or (m_ar_slv >= NUM_SLAVES);
+  let m_aw_oor: Bool = (m.aw_addr[ADDR_WIDTH-1:REGION_BITS+NS_W] != 0) or (m_aw_slv >= NUM_SLAVES);
 
   resource ar_ch: mutex<priority>;
   resource r_ch:  mutex<priority>;


### PR DESCRIPTION
## Summary
- treat selector values `>= NUM_SLAVES` as out-of-range in `Nic400MasterPort`
- route decode holes inside the `NS_W` selector space to the default slave
- prevent unmatched addresses from stalling forever when `NUM_SLAVES < 2^NS_W`

## Why
`#487`/`#491` added a default DECERR path, but the OOR predicate only checked high address bits above the slave-select field. That still leaves decode holes when the selector width allows values that no slave thread handles.

Example: `NUM_SLAVES=3, NS_W=2`, selector value `3` has zero upper bits, so no `Ar_j` / `AwWb_j` thread matches and the request stalls instead of returning DECERR.

## Verification
- source-level review of the decode predicates and per-slave wait conditions
- limited local verification only
- isolated worktree compile validation was blocked by existing cross-file NIC-400 bus/module setup in this repo, so this should still get a project-native NIC-400 build/sim pass before merge

Ref: https://github.com/arch-hdl-lang/arch-com/pull/487