### PR TITLE
fix(nic400): return DECERR for out-of-range addresses

### DIFF
--- a/doc/nic400_interconnect_spec.md
+++ b/doc/nic400_interconnect_spec.md
@@ -1113,7 +1113,7 @@ A verification pass against the ARM TRM (DDI 0475E, *CoreLink NIC-400 Network In
 | Parameterizable M×N matrix | ✅ | `Nic400Fabric.arch`; demo is 3×4. [TRM] §1.2 caps NIC-400 at 1-128 slave IFs × 1-64 master IFs and up to 5 cascaded switches between any master/slave pair. |
 | ID remap (master idx prefix) | ✅ | `MASTER_ID_W → SLAVE_ID_W = MASTER_ID_W + ceil(log2(M))`. [TRM] §2.3.12 names the components "Interconnect ID (IID) + Virtual ID (VID) + Slave-Interface ID (SIID)"; global ID width is 1-24 bits with an optional "ID reduction" pass at AMIB. Our shim does a single SIID prefix; we do not implement ID reduction. |
 | Address decode | 🟡 | Compile-time, top-NS_W bits of REGION_BITS=28 page. [TRM] §2.3.11 names the runtime knob "Remap" (8 remap-state bits, GPV-programmable, can alias/move/add/remove regions); we don't implement it. |
-| Decode-error (DECERR) response on unmatched address | ❌ | [TRM] §2.2.1: "Any transaction that does not decode to a legal master interface destination... receives a DECERR response." NIC-400 builds this into the slave interface block (ASIB) automatically — there is no separately-instantiated "default slave" module; rephrase the row as a behavior the ASIB must emit. Demo's `Nic400MasterPort` silently drops un-matched addrs. |
+| Decode-error (DECERR) response on unmatched address | ✅ | `Nic400DefaultSlave.arch` (per-master Rd/Wr thread pair returning RRESP/BRESP=2'b11). `Nic400MasterPort` decodes OOR via `m_ar_oor`/`m_aw_oor` (`addr[ADDR_WIDTH-1:REGION_BITS+NS_W] != 0`) and routes OOR AR/AW to the `default_s` port; the default slave echoes the request ID in the error response. Verified by `Nic400DefaultSlave_test.harc` (OOR read + OOR write → DECERR, valid decode intact). [TRM] §2.2.1: real NIC-400 builds this into the ASIB rather than a separate module; we model it as a standalone default-slave block for clarity. |
 | Per-master / per-slave clock domains | ❌ | All ports share `clk: in Clock<SysDomain>`. [TRM] §2.2.1 / §2.3.5: each ASIB/AMIB can select SYNC 1:1, SYNC 1:n, SYNC n:1, SYNC n:m, or ASYNC frequency-domain crossing with a per-FIFO depth of 2-32, and the `sync_mode` is GPV-programmable. CDC via `fifo kind: async` is doable but not wired. |
 | Cyclic Dependency Avoidance Schemes (CDAS) — Single-Slave / Single-Slave-per-ID | ❌ | [TRM] §2.3.7: per-ASIB knob that stalls transactions to a different destination than outstanding ones of the same type (or same ID), to break AW/W-channel ordering deadlocks. Not modelled. |
 | Single Active Slave (SAS) | ❌ | [TRM] §2.3.8: at a divergent switch slave IF, an AW address beat is stalled if any outstanding write data beats are still in flight to a different master IF. Used as a fallback CDAS resolution. Not modelled. |
@@ -1165,8 +1165,10 @@ A verification pass against the ARM TRM (DDI 0475E, *CoreLink NIC-400 Network In
 |---|---|---|
 | Single-master, single-slave smoke | ✅ | `tb_nic400_system.cpp` |
 | Multi-master contention (M=2..3 active at once) | ✅ | `tb_nic400_fabric_multi_master.cpp`: S1 3-master disjoint reads at 3.00 t/c; S2 3-way hot-slave round_robin at 1.00 t/c (m0=10,m1=10,m2=10, no starvation); S3 3-master disjoint writes (18/18 BRESPs correctly routed). |
-| Multi-slave hot-spot QoS test | ❌ | Implied by §16 row above — `tb_hot_slave_qos.cpp` from spec Appendix A was never landed |
-| OOO completion (interleaved B per master) | ❌ | `tb_ooo_completion.cpp` from spec Appendix A — not landed |
+| Hot-slave handoff throughput | ✅ | `Nic400FabricHotSlave_test.harc`: S1 M↔M swap timing (zero dead cycle), S2 persistent round_robin contention, S3 contender dropout, S4 asymmetric load — all at ≥0.9 t/c. (Per-master QoS *priority* arbitration remains 🟡 — `ar_lock` is `mutex<round_robin>`, not the QoS hook.) |
+| OOO completion (interleaved B per master) | ✅ | `Nic400OooCompletion_test.harc` (§15.5): M0 issues two writes to slaves 0/1; slave1's B injected first → M0 receives B(id=1) before B(id=0). Enabled by the MasterPort B-phase fix (wait outside `b_ch` until the slave has `b_valid`). |
+| Default-slave DECERR | ✅ | `Nic400DefaultSlave_test.harc`: OOR read → RRESP=DECERR (id echoed, RLAST=1), OOR write → BRESP=DECERR (id echoed), valid decode unaffected. |
+| Decode-error response | ✅ | See "Decode-error (DECERR) response on unmatched address" row above. |
 | Reg-slice fabric throughput | ✅ | `tb_nic400_fabric_regslice.cpp`, `tb_nic400_fabric_throughput.cpp` |
 | Width-adapter independent TB | ✅ | `tb_nic400_width_adapter.cpp` |
 | PMU exact-count TB | ✅ | `tb_nic400_pmu.cpp` (counter glue is in the dedicated PMU TB, not the integrated demo — see `tb_nic400_system.cpp` comments) |
@@ -1174,7 +1176,7 @@ A verification pass against the ARM TRM (DDI 0475E, *CoreLink NIC-400 Network In
 #### Quick-pick "close next" candidates
 Roughly ordered by likely effort × value, picked from the rows above:
 
-1. **Default-slave responder** — small extra module returning DECERR for un-decoded addrs, wire into the fabric's "no match" output of `Nic400MasterPort`. Closes a basic conformance item. [TRM §2.2.1]
+1. ~~**Default-slave responder**~~ — ✅ **DONE**: `Nic400DefaultSlave.arch` returns DECERR for OOR addresses; `Nic400MasterPort` routes un-decoded AR/AW to it via the `default_s` port. [TRM §2.2.1]
 2. **Per-slave reg slice wrapper** — symmetric to `Nic400FabricRs1` but on the s side. Mostly copy-paste; useful as a real-SoC pattern. [TRM §2.2.1/§2.2.2]
 3. **Wire width adapter into a system variant** — `Nic400SystemWide` with a 64-bit AXI master and the 32-bit APB target, so the adapter is exercised in-system.
 4. **GPV regfile sketch** — AXI4 target (TRM §3.2: GPV is AXI-accessed, AxSIZE=32-bit only, Secure-only, non-cacheable, no interleaved WDATA) plus a `regfile` block with a few mapped registers (`read_qos`/`write_qos` from Table 3-1, decode-table / remap-state override). Lowest-cost path to "programmable" status on the QoS, decode, and remap rows.

--- a/src/sim_codegen/mod.rs
+++ b/src/sim_codegen/mod.rs
@@ -6224,8 +6224,9 @@ impl<'a> SimCodegen<'a> {
                         }
                         if let crate::ast::ExprKind::Ident(src_name) = &conn.signal.kind {
                             if let Some(&n) = vec_wire_counts.get(src_name.as_str()) {
+                                let _vec_pfx = vec_storage_prefix(src_name.as_str(), &reg_names, &let_names, &inst_out);
                                 for i in 0..n {
-                                    cpp.push_str(&format!("  _inst_{}.{}_{i} = _let_{src_name}[{i}];\n",
+                                    cpp.push_str(&format!("  _inst_{}.{}_{i} = {_vec_pfx}{src_name}[{i}];\n",
                                         inst.name.name, conn.port_name.name));
                                 }
                                 continue;
@@ -6274,8 +6275,9 @@ impl<'a> SimCodegen<'a> {
                         if let crate::ast::ExprKind::Ident(src_name) = &conn.signal.kind {
                             // Vec wire/reg → inst Vec port: expand element-by-element
                             if let Some(&n) = vec_wire_counts.get(src_name.as_str()) {
+                                let _vec_pfx = vec_storage_prefix(src_name.as_str(), &reg_names, &let_names, &inst_out);
                                 for i in 0..n {
-                                    cpp.push_str(&format!("    _inst_{}.{}_{i} = _let_{src_name}[{i}];\n",
+                                    cpp.push_str(&format!("    _inst_{}.{}_{i} = {_vec_pfx}{src_name}[{i}];\n",
                                         inst.name.name, conn.port_name.name));
                                 }
                                 continue;
@@ -6405,8 +6407,9 @@ impl<'a> SimCodegen<'a> {
                         }
                         if let crate::ast::ExprKind::Ident(src_name) = &conn.signal.kind {
                             if let Some(&n) = vec_wire_counts.get(src_name.as_str()) {
+                                let _vec_pfx = vec_storage_prefix(src_name.as_str(), &reg_names, &let_names, &inst_out);
                                 for i in 0..n {
-                                    cpp.push_str(&format!("  _inst_{}.{}_{i} = _let_{src_name}[{i}];\n",
+                                    cpp.push_str(&format!("  _inst_{}.{}_{i} = {_vec_pfx}{src_name}[{i}];\n",
                                         inst.name.name, conn.port_name.name));
                                 }
                                 continue;
@@ -6454,8 +6457,9 @@ impl<'a> SimCodegen<'a> {
                         if let crate::ast::ExprKind::Ident(src_name) = &conn.signal.kind {
                             // Vec wire/reg → inst Vec port: expand element-by-element
                             if let Some(&n) = vec_wire_counts.get(src_name.as_str()) {
+                                let _vec_pfx = vec_storage_prefix(src_name.as_str(), &reg_names, &let_names, &inst_out);
                                 for i in 0..n {
-                                    cpp.push_str(&format!("    _inst_{}.{}_{i} = _let_{src_name}[{i}];\n",
+                                    cpp.push_str(&format!("    _inst_{}.{}_{i} = {_vec_pfx}{src_name}[{i}];\n",
                                         inst.name.name, conn.port_name.name));
                                 }
                                 continue;
@@ -7253,8 +7257,9 @@ impl<'a> SimCodegen<'a> {
                         if let crate::ast::ExprKind::Ident(src_name) = &conn.signal.kind {
                             // Vec wire/reg → inst Vec port: expand element-by-element
                             if let Some(&n) = vec_wire_counts.get(src_name.as_str()) {
+                                let _vec_pfx = vec_storage_prefix(src_name.as_str(), &reg_names, &let_names, &inst_out);
                                 for i in 0..n {
-                                    cpp.push_str(&format!("  _inst_{}.{}_{i} = _let_{src_name}[{i}];\n",
+                                    cpp.push_str(&format!("  _inst_{}.{}_{i} = {_vec_pfx}{src_name}[{i}];\n",
                                         inst.name.name, conn.port_name.name));
                                 }
                                 continue;

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -18509,6 +18509,61 @@ fn test_sim_nested_vec_reg_round_trips_all_cells() {
 }
 
 #[test]
+fn test_sim_vec_reg_forwarded_to_thread_inst_uses_reg_storage() {
+    // Regression: a module that contains BOTH threads AND a module-scope
+    // `Vec<T, N>` reg lowers the threads into an `_inst__threads`
+    // sub-instance; the parent forwards each Vec-reg element into the
+    // thread's flattened scalar inputs. The forwarding path used to
+    // hardcode the `_let_` (wire) prefix — emitting `_inst__threads.foo_0
+    // = _let_foo[0];` — but a Vec *reg* stores under `_foo[0]`, so the
+    // generated C++ referenced an undeclared `_let_foo` and failed to
+    // compile. Fix: resolve the prefix via `vec_storage_prefix` (reg → `_`,
+    // wire/let → `_let_`, inst-output → ``).
+    let src = r#"
+module VecRegThread
+  param N: const = 2;
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Async, Low>;
+  port go:  in Bool;
+  port done: out Bool;
+
+  reg tag: Vec<UInt<8>, N> reset rst => 0;
+
+  seq on clk rising
+    for i in 0..N-1
+      if go
+        tag[i] <= 7;
+      end if
+    end for
+  end seq
+
+  thread Worker on clk rising, rst low
+    default comb
+      done = false;
+    end default
+    if not go
+      wait until go;
+    end if
+    do
+      done = (tag[0] == 7);
+    until tag[0] == 7;
+  end thread Worker
+end module VecRegThread
+"#;
+    let h = compile_to_sim_h(src, false);
+    // The forwarding must use reg storage `_tag[`, never the wire form.
+    assert!(
+        !h.contains("_let_tag["),
+        "Vec reg forwarded to thread inst must not use `_let_` (wire) prefix:\n{h}"
+    );
+    assert!(
+        h.contains("_inst__threads.tag_0 = _tag[0]")
+            || h.contains("_inst__threads.tag_0  = _tag[0]"),
+        "expected Vec reg forwarded as `_tag[0]` into thread inst:\n{h}"
+    );
+}
+
+#[test]
 fn test_native_sim_vec_inst_output_wire_feeds_indexed_let() {
     // Regression for arch-com#437: a sub-instance Vec output connected to a
     // declared Vec wire must update the wire's `_let_` storage, because parent

--- a/tests/nic400/Nic400DefaultSlave.arch
+++ b/tests/nic400/Nic400DefaultSlave.arch
@@ -1,0 +1,103 @@
+// Default-slave error responder for Nic400Fabric.
+//
+// Returns AXI4 DECERR (RRESP / BRESP = 2'b11) for every transaction it
+// receives.  Instantiated by Nic400Fabric; each MasterPort routes OOR
+// (out-of-range address) transactions here through its `default_s` port.
+//
+// One independent Rd / Wr thread pair per master; no arbitration needed
+// since each master gets its own dedicated port (m[i]).
+//
+// Read path: accepts one AR at a time, returns a single RRESP=DECERR beat
+// with RLAST=1 (ar_len ignored for multi-beat bursts).
+//
+// Write path: accepts AW, drains W to WLAST, returns BRESP=DECERR.
+
+module Nic400DefaultSlave
+  param NUM_MASTERS: const = 3;
+  param ADDR_WIDTH:  const = 32;
+  param DATA_WIDTH:  const = 32;
+  param STRB_WIDTH:  const = 4;
+  param SLAVE_ID_W:  const = 5;
+  param MASTER_ID_W: const = 3;
+
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Async, Low>;
+
+  port m: target Vec<BusAxi4<ADDR_W=ADDR_WIDTH, DATA_W=DATA_WIDTH,
+                              STRB_W=STRB_WIDTH, ID_W=SLAVE_ID_W,
+                              READ=1, WRITE=1>, NUM_MASTERS>;
+
+  // Latched IDs — Vec regs declared at module scope, indexed inside
+  // generate_for per the ARCH rule.  Captured on the AR / AW handshake
+  // cycle so the response echoes the correct ID after ar_valid / aw_valid
+  // may be de-asserted.
+  reg rd_id: Vec<UInt<SLAVE_ID_W>, NUM_MASTERS> reset rst => 0;
+  reg wr_id: Vec<UInt<SLAVE_ID_W>, NUM_MASTERS> reset rst => 0;
+
+  generate_for i in 0..NUM_MASTERS-1
+
+    // ID-latch seq: one per master (loop variable i substituted by elaboration).
+    seq on clk rising
+      if m[i].ar_valid and m[i].ar_ready
+        rd_id[i] <= m[i].ar_id;
+      end if
+      if m[i].aw_valid and m[i].aw_ready
+        wr_id[i] <= m[i].aw_id;
+      end if
+    end seq
+
+    // ── Rd_i: accept AR → return RRESP=DECERR ──────────────────────────
+    thread Rd_i on clk rising, rst low
+      default comb
+        m[i].ar_ready = false;
+        m[i].r_valid  = false;
+        m[i].r_data   = 0;
+        m[i].r_id     = 0;
+        m[i].r_resp   = 0;
+        m[i].r_last   = false;
+      end default
+
+      // Hold ar_ready=1 until the master presents AR.
+      // seq fires on the same posedge as the do..until exit, latching ar_id
+      // into rd_id[i]; the register is available from the next state onward.
+      do
+        m[i].ar_ready = true;
+      until m[i].ar_valid;
+
+      // Single RRESP=DECERR (0b11) beat with RLAST.
+      do
+        m[i].r_valid = true;
+        m[i].r_id    = rd_id[i];
+        m[i].r_resp  = 3;
+        m[i].r_data  = 0;
+        m[i].r_last  = true;
+      until m[i].r_ready;
+    end thread Rd_i
+
+    // ── Wr_i: accept AW → drain W → return BRESP=DECERR ────────────────
+    thread Wr_i on clk rising, rst low
+      default comb
+        m[i].aw_ready = false;
+        m[i].w_ready  = false;
+        m[i].b_valid  = false;
+        m[i].b_id     = 0;
+        m[i].b_resp   = 0;
+      end default
+
+      do
+        m[i].aw_ready = true;
+      until m[i].aw_valid;
+
+      do
+        m[i].w_ready = true;
+      until m[i].w_valid and m[i].w_last;
+
+      do
+        m[i].b_valid = true;
+        m[i].b_id    = wr_id[i];
+        m[i].b_resp  = 3;
+      until m[i].b_ready;
+    end thread Wr_i
+
+  end generate_for
+end module Nic400DefaultSlave

--- a/tests/nic400/Nic400DefaultSlave.arch
+++ b/tests/nic400/Nic400DefaultSlave.arch
@@ -32,6 +32,7 @@ module Nic400DefaultSlave
   // cycle so the response echoes the correct ID after ar_valid / aw_valid
   // may be de-asserted.
   reg rd_id: Vec<UInt<SLAVE_ID_W>, NUM_MASTERS> reset rst => 0;
+  reg rd_len: Vec<UInt<8>, NUM_MASTERS> reset rst => 0;
   reg wr_id: Vec<UInt<SLAVE_ID_W>, NUM_MASTERS> reset rst => 0;
 
   generate_for i in 0..NUM_MASTERS-1
@@ -40,6 +41,7 @@ module Nic400DefaultSlave
     seq on clk rising
       if m[i].ar_valid and m[i].ar_ready
         rd_id[i] <= m[i].ar_id;
+        rd_len[i] <= m[i].ar_len;
       end if
       if m[i].aw_valid and m[i].aw_ready
         wr_id[i] <= m[i].aw_id;
@@ -64,14 +66,17 @@ module Nic400DefaultSlave
         m[i].ar_ready = true;
       until m[i].ar_valid;
 
-      // Single RRESP=DECERR (0b11) beat with RLAST.
-      do
-        m[i].r_valid = true;
-        m[i].r_id    = rd_id[i];
-        m[i].r_resp  = 3;
-        m[i].r_data  = 0;
-        m[i].r_last  = true;
-      until m[i].r_ready;
+      // Return one DECERR beat per requested transfer so burst reads keep
+      // AXI beat count and RLAST semantics intact.
+      for b in 0..rd_len[i]
+        do
+          m[i].r_valid = true;
+          m[i].r_id    = rd_id[i];
+          m[i].r_resp  = 3;
+          m[i].r_data  = 0;
+          m[i].r_last  = (b == rd_len[i]);
+        until m[i].r_ready;
+      end for
     end thread Rd_i
 
     // ── Wr_i: accept AW → drain W → return BRESP=DECERR ────────────────

--- a/tests/nic400/Nic400DefaultSlave_test.harc
+++ b/tests/nic400/Nic400DefaultSlave_test.harc
@@ -1,0 +1,273 @@
+// HARC testbench: Nic400Fabric default-slave DECERR responder.
+//
+// Closes the gap-tracker row "Decode-error (DECERR) response on unmatched
+// address" (doc/nic400_interconnect_spec.md §16.1, TRM §2.2.1).
+//
+// Run with:
+//   harc sim --dut tests/nic400/BusAxi4.arch \
+//             tests/nic400/Nic400DefaultSlave.arch \
+//             tests/nic400/Nic400Fabric.arch \
+//             tests/nic400/Nic400MasterPort.arch \
+//             tests/nic400/Nic400SlavePort.arch \
+//             tests/nic400/Nic400DefaultSlave_test.harc \
+//             --top Nic400Fabric
+//
+// Address map (NS_W=2, REGION_BITS=28):
+//   0x0000_0000–0x3FFF_FFFF → slaves 0..3  (valid)
+//   addr[31:30] != 0        → OUT OF RANGE → default slave → DECERR
+//
+// Scenarios:
+//   S1. OOR read:  M0 issues AR with addr=0x8000_0000 (bit31 set → OOR).
+//       Expect RRESP=DECERR (0b11), RLAST=1, R-id echoes the AR-id.
+//   S2. OOR write: M1 issues AW+W with addr=0xC000_0000 (OOR).
+//       Expect BRESP=DECERR (0b11), B-id echoes the AW-id.
+//   S3. Valid read still works (regression): M2 → slave2 (0x2000_0000),
+//       confirms the OOR path didn't break normal decode.
+
+testbench Nic400DefaultSlaveTb
+    dut : Nic400Fabric
+end testbench Nic400DefaultSlaveTb
+
+impl Nic400DefaultSlaveTest for Nic400DefaultSlaveTb
+    run
+        log(info, "Nic400Fabric default-slave DECERR test")
+
+        // ── Reset ────────────────────────────────────────────────────────
+        dut.rst           = 0
+        dut.m_ar_valid[0] = 0
+        dut.m_ar_valid[1] = 0
+        dut.m_ar_valid[2] = 0
+        dut.m_ar_addr[0]  = 0
+        dut.m_ar_addr[1]  = 0
+        dut.m_ar_addr[2]  = 0
+        dut.m_ar_id[0]    = 0
+        dut.m_ar_id[1]    = 0
+        dut.m_ar_id[2]    = 0
+        dut.m_ar_len[0]   = 0
+        dut.m_ar_len[1]   = 0
+        dut.m_ar_len[2]   = 0
+        dut.m_ar_size[0]  = 0
+        dut.m_ar_size[1]  = 0
+        dut.m_ar_size[2]  = 0
+        dut.m_ar_burst[0] = 0
+        dut.m_ar_burst[1] = 0
+        dut.m_ar_burst[2] = 0
+        dut.m_r_ready[0]  = 0
+        dut.m_r_ready[1]  = 0
+        dut.m_r_ready[2]  = 0
+        dut.m_aw_valid[0] = 0
+        dut.m_aw_valid[1] = 0
+        dut.m_aw_valid[2] = 0
+        dut.m_aw_addr[0]  = 0
+        dut.m_aw_addr[1]  = 0
+        dut.m_aw_addr[2]  = 0
+        dut.m_aw_id[0]    = 0
+        dut.m_aw_id[1]    = 0
+        dut.m_aw_id[2]    = 0
+        dut.m_aw_len[0]   = 0
+        dut.m_aw_len[1]   = 0
+        dut.m_aw_len[2]   = 0
+        dut.m_aw_size[0]  = 0
+        dut.m_aw_size[1]  = 0
+        dut.m_aw_size[2]  = 0
+        dut.m_aw_burst[0] = 0
+        dut.m_aw_burst[1] = 0
+        dut.m_aw_burst[2] = 0
+        dut.m_w_valid[0]  = 0
+        dut.m_w_valid[1]  = 0
+        dut.m_w_valid[2]  = 0
+        dut.m_w_data[0]   = 0
+        dut.m_w_data[1]   = 0
+        dut.m_w_data[2]   = 0
+        dut.m_w_strb[0]   = 0
+        dut.m_w_strb[1]   = 0
+        dut.m_w_strb[2]   = 0
+        dut.m_w_last[0]   = 0
+        dut.m_w_last[1]   = 0
+        dut.m_w_last[2]   = 0
+        dut.m_b_ready[0]  = 0
+        dut.m_b_ready[1]  = 0
+        dut.m_b_ready[2]  = 0
+        dut.s_ar_ready[0] = 0
+        dut.s_ar_ready[1] = 0
+        dut.s_ar_ready[2] = 0
+        dut.s_ar_ready[3] = 0
+        dut.s_r_valid[0]  = 0
+        dut.s_r_valid[1]  = 0
+        dut.s_r_valid[2]  = 0
+        dut.s_r_valid[3]  = 0
+        dut.s_r_data[0]   = 0
+        dut.s_r_data[1]   = 0
+        dut.s_r_data[2]   = 0
+        dut.s_r_data[3]   = 0
+        dut.s_r_id[0]     = 0
+        dut.s_r_id[1]     = 0
+        dut.s_r_id[2]     = 0
+        dut.s_r_id[3]     = 0
+        dut.s_r_resp[0]   = 0
+        dut.s_r_resp[1]   = 0
+        dut.s_r_resp[2]   = 0
+        dut.s_r_resp[3]   = 0
+        dut.s_r_last[0]   = 0
+        dut.s_r_last[1]   = 0
+        dut.s_r_last[2]   = 0
+        dut.s_r_last[3]   = 0
+        dut.s_aw_ready[0] = 0
+        dut.s_aw_ready[1] = 0
+        dut.s_aw_ready[2] = 0
+        dut.s_aw_ready[3] = 0
+        dut.s_w_ready[0]  = 0
+        dut.s_w_ready[1]  = 0
+        dut.s_w_ready[2]  = 0
+        dut.s_w_ready[3]  = 0
+        dut.s_b_valid[0]  = 0
+        dut.s_b_valid[1]  = 0
+        dut.s_b_valid[2]  = 0
+        dut.s_b_valid[3]  = 0
+        dut.s_b_id[0]     = 0
+        dut.s_b_id[1]     = 0
+        dut.s_b_id[2]     = 0
+        dut.s_b_id[3]     = 0
+        dut.s_b_resp[0]   = 0
+        dut.s_b_resp[1]   = 0
+        dut.s_b_resp[2]   = 0
+        dut.s_b_resp[3]   = 0
+        wait 4 cycles
+        dut.rst = 1
+        wait 3 cycles
+
+        // ── S1: OOR read → DECERR ─────────────────────────────────────────
+        // M0 issues AR to 0x8000_0000 (bit31 set → out of range).
+        dut.m_ar_valid[0] = 1
+        dut.m_ar_addr[0]  = 0x80000000
+        dut.m_ar_id[0]    = 5
+        dut.m_ar_size[0]  = 2
+        dut.m_ar_burst[0] = 1
+        dut.m_ar_len[0]   = 0
+        dut.m_r_ready[0]  = 1
+
+        let s1_resp : uint<32> = 99
+        let s1_id   : uint<32> = 99
+        let s1_last : uint<32> = 99
+        let s1_done : uint<32> = 0
+
+        for _ in 0 .. 30
+            wait 1 cycle
+            // Drop ar_valid once the AR has been accepted by the default slave.
+            if dut.m_ar_ready[0] == 1
+                dut.m_ar_valid[0] = 0
+            end if
+            if s1_done == 0 && dut.m_r_valid[0] == 1
+                s1_resp = dut.m_r_resp[0]
+                s1_id   = (dut.m_r_id[0] & 7)
+                s1_last = dut.m_r_last[0]
+                s1_done = 1
+            end if
+        end for
+
+        assert s1_done == 1
+            else fail("S1: OOR read got no R response")
+        assert s1_resp == 3
+            else fail("S1: OOR read RRESP=${s1_resp} (expected 3=DECERR)")
+        assert s1_id == 5
+            else fail("S1: OOR read R-id=${s1_id} (expected 5, echoed AR-id)")
+        assert s1_last == 1
+            else fail("S1: OOR read RLAST=${s1_last} (expected 1)")
+        log(info, "PASS S1: OOR read → DECERR (RRESP=3, R-id=5, RLAST=1)")
+
+        dut.m_ar_valid[0] = 0
+        dut.m_r_ready[0]  = 0
+        wait 3 cycles
+
+        // ── S2: OOR write → DECERR ────────────────────────────────────────
+        // M1 issues AW+W to 0xC000_0000 (bits[31:30]=0b11 → out of range).
+        dut.m_aw_valid[1] = 1
+        dut.m_aw_addr[1]  = 0xC0000000
+        dut.m_aw_id[1]    = 2
+        dut.m_aw_size[1]  = 2
+        dut.m_aw_burst[1] = 1
+        dut.m_aw_len[1]   = 0
+        dut.m_w_valid[1]  = 1
+        dut.m_w_data[1]   = 0x12345678
+        dut.m_w_strb[1]   = 15
+        dut.m_w_last[1]   = 1
+        dut.m_b_ready[1]  = 1
+
+        let s2_resp : uint<32> = 99
+        let s2_id   : uint<32> = 99
+        let s2_done : uint<32> = 0
+
+        // Hold AW+W valid steady until B is observed (single-beat write).
+        // Dropping valid the same cycle ready pulses can race the
+        // MasterPort AwWb_default W-phase `until` check; holding is the
+        // proven pattern (cf. Nic400FabricMultiMaster_test.harc S3).
+        for _ in 0 .. 40
+            wait 1 cycle
+            if s2_done == 0 && dut.m_b_valid[1] == 1
+                s2_resp = dut.m_b_resp[1]
+                s2_id   = (dut.m_b_id[1] & 7)
+                s2_done = 1
+                dut.m_aw_valid[1] = 0
+                dut.m_w_valid[1]  = 0
+            end if
+        end for
+
+        assert s2_done == 1
+            else fail("S2: OOR write got no B response")
+        assert s2_resp == 3
+            else fail("S2: OOR write BRESP=${s2_resp} (expected 3=DECERR)")
+        assert s2_id == 2
+            else fail("S2: OOR write B-id=${s2_id} (expected 2, echoed AW-id)")
+        log(info, "PASS S2: OOR write → DECERR (BRESP=3, B-id=2)")
+
+        dut.m_aw_valid[1] = 0
+        dut.m_w_valid[1]  = 0
+        dut.m_b_ready[1]  = 0
+        wait 3 cycles
+
+        // ── S3: Valid read regression ─────────────────────────────────────
+        // M2 reads slave2 (0x2000_0000). The TB plays slave2: accept AR,
+        // return one OKAY R beat. Confirms OOR path didn't break decode.
+        dut.m_ar_valid[2] = 1
+        dut.m_ar_addr[2]  = 0x20001000   // addr[29:28]=0b10 → slave 2
+        dut.m_ar_id[2]    = 1
+        dut.m_ar_size[2]  = 2
+        dut.m_ar_burst[2] = 1
+        dut.m_ar_len[2]   = 0
+        dut.m_r_ready[2]  = 1
+        dut.s_ar_ready[2] = 1
+
+        let s3_resp   : uint<32> = 99
+        let s3_done   : uint<32> = 0
+        let s3_arseen : uint<32> = 0
+
+        for _ in 0 .. 30
+            wait 1 cycle
+            // Slave2 side: when fabric forwards AR, capture it and respond.
+            if dut.s_ar_valid[2] == 1 && s3_arseen == 0
+                s3_arseen = 1
+                dut.s_r_valid[2] = 1
+                dut.s_r_data[2]  = 0xCAFEBABE
+                dut.s_r_id[2]    = dut.s_ar_id[2]   // echo prefixed id back
+                dut.s_r_resp[2]  = 0                // OKAY
+                dut.s_r_last[2]  = 1
+            end if
+            if dut.m_ar_ready[2] == 1
+                dut.m_ar_valid[2] = 0
+            end if
+            if s3_done == 0 && dut.m_r_valid[2] == 1
+                s3_resp = dut.m_r_resp[2]
+                s3_done = 1
+                dut.s_r_valid[2] = 0
+            end if
+        end for
+
+        assert s3_done == 1
+            else fail("S3: valid read got no R response")
+        assert s3_resp == 0
+            else fail("S3: valid read RRESP=${s3_resp} (expected 0=OKAY)")
+        log(info, "PASS S3: valid read → OKAY (decode path intact)")
+
+        log(info, "PASS Nic400Fabric default-slave: OOR read+write DECERR, valid decode intact")
+    end run
+end impl Nic400DefaultSlaveTest

--- a/tests/nic400/Nic400DefaultSlave_test.harc
+++ b/tests/nic400/Nic400DefaultSlave_test.harc
@@ -19,9 +19,11 @@
 // Scenarios:
 //   S1. OOR read:  M0 issues AR with addr=0x8000_0000 (bit31 set → OOR).
 //       Expect RRESP=DECERR (0b11), RLAST=1, R-id echoes the AR-id.
-//   S2. OOR write: M1 issues AW+W with addr=0xC000_0000 (OOR).
+//   S2. OOR burst read: M0 issues ARLEN=3 to an OOR address.
+//       Expect 4 DECERR beats, echoed id on every beat, RLAST only on beat 3.
+//   S3. OOR write: M1 issues AW+W with addr=0xC000_0000 (OOR).
 //       Expect BRESP=DECERR (0b11), B-id echoes the AW-id.
-//   S3. Valid read still works (regression): M2 → slave2 (0x2000_0000),
+//   S4. Valid read still works (regression): M2 → slave2 (0x2000_0000),
 //       confirms the OOR path didn't break normal decode.
 
 testbench Nic400DefaultSlaveTb
@@ -179,7 +181,57 @@ impl Nic400DefaultSlaveTest for Nic400DefaultSlaveTb
         dut.m_r_ready[0]  = 0
         wait 3 cycles
 
-        // ── S2: OOR write → DECERR ────────────────────────────────────────
+        // ── S2: OOR burst read → 4x DECERR beats ─────────────────────────
+        dut.m_ar_valid[0] = 1
+        dut.m_ar_addr[0]  = 0xC0001000
+        dut.m_ar_id[0]    = 6
+        dut.m_ar_size[0]  = 2
+        dut.m_ar_burst[0] = 1
+        dut.m_ar_len[0]   = 3
+        dut.m_r_ready[0]  = 1
+
+        let s2_beats     : uint<32> = 0
+        let s2_last_seen : uint<32> = 99
+        let s2_id_ok     : uint<32> = 1
+        let s2_resp_ok   : uint<32> = 1
+
+        for _ in 0 .. 50
+            wait 1 cycle
+            if dut.m_ar_ready[0] == 1
+                dut.m_ar_valid[0] = 0
+            end if
+            if dut.m_r_valid[0] == 1
+                if (dut.m_r_id[0] & 7) != 6
+                    s2_id_ok = 0
+                end if
+                if dut.m_r_resp[0] != 3
+                    s2_resp_ok = 0
+                end if
+                if s2_beats == 3
+                    s2_last_seen = dut.m_r_last[0]
+                elsif dut.m_r_last[0] != 0
+                    s2_last_seen = 77
+                end if
+                s2_beats = s2_beats + 1
+            end if
+        end for
+
+        assert s2_beats == 4
+            else fail("S2: OOR burst read saw ${s2_beats} beats (expected 4)")
+        assert s2_id_ok == 1
+            else fail("S2: OOR burst read did not echo AR-id on every beat")
+        assert s2_resp_ok == 1
+            else fail("S2: OOR burst read did not return DECERR on every beat")
+        assert s2_last_seen == 1
+            else fail("S2: OOR burst read RLAST handling wrong (${s2_last_seen})")
+        log(info, "PASS S2: OOR burst read → 4x DECERR beats with final RLAST")
+
+        dut.m_ar_valid[0] = 0
+        dut.m_r_ready[0]  = 0
+        dut.m_ar_len[0]   = 0
+        wait 3 cycles
+
+        // ── S3: OOR write → DECERR ────────────────────────────────────────
         // M1 issues AW+W to 0xC000_0000 (bits[31:30]=0b11 → out of range).
         dut.m_aw_valid[1] = 1
         dut.m_aw_addr[1]  = 0xC0000000
@@ -213,19 +265,19 @@ impl Nic400DefaultSlaveTest for Nic400DefaultSlaveTb
         end for
 
         assert s2_done == 1
-            else fail("S2: OOR write got no B response")
+            else fail("S3: OOR write got no B response")
         assert s2_resp == 3
-            else fail("S2: OOR write BRESP=${s2_resp} (expected 3=DECERR)")
+            else fail("S3: OOR write BRESP=${s2_resp} (expected 3=DECERR)")
         assert s2_id == 2
-            else fail("S2: OOR write B-id=${s2_id} (expected 2, echoed AW-id)")
-        log(info, "PASS S2: OOR write → DECERR (BRESP=3, B-id=2)")
+            else fail("S3: OOR write B-id=${s2_id} (expected 2, echoed AW-id)")
+        log(info, "PASS S3: OOR write → DECERR (BRESP=3, B-id=2)")
 
         dut.m_aw_valid[1] = 0
         dut.m_w_valid[1]  = 0
         dut.m_b_ready[1]  = 0
         wait 3 cycles
 
-        // ── S3: Valid read regression ─────────────────────────────────────
+        // ── S4: Valid read regression ─────────────────────────────────────
         // M2 reads slave2 (0x2000_0000). The TB plays slave2: accept AR,
         // return one OKAY R beat. Confirms OOR path didn't break decode.
         dut.m_ar_valid[2] = 1
@@ -263,11 +315,11 @@ impl Nic400DefaultSlaveTest for Nic400DefaultSlaveTb
         end for
 
         assert s3_done == 1
-            else fail("S3: valid read got no R response")
+            else fail("S4: valid read got no R response")
         assert s3_resp == 0
-            else fail("S3: valid read RRESP=${s3_resp} (expected 0=OKAY)")
-        log(info, "PASS S3: valid read → OKAY (decode path intact)")
+            else fail("S4: valid read RRESP=${s3_resp} (expected 0=OKAY)")
+        log(info, "PASS S4: valid read → OKAY (decode path intact)")
 
-        log(info, "PASS Nic400Fabric default-slave: OOR read+write DECERR, valid decode intact")
+        log(info, "PASS Nic400Fabric default-slave: OOR read/burst/write DECERR, valid decode intact")
     end run
 end impl Nic400DefaultSlaveTest

--- a/tests/nic400/Nic400Fabric.arch
+++ b/tests/nic400/Nic400Fabric.arch
@@ -43,6 +43,9 @@ module Nic400Fabric
   // carrying the prefixed (slave-perspective) ID.
   wire edges: Vec<Vec<SlaveBus, NUM_SLAVES>, NUM_MASTERS>;
 
+  // Per-master OOR wires: master_i.default_s ↔ default_sl.m[i].
+  wire default_edges: Vec<SlaveBus, NUM_MASTERS>;
+
   // ── M MasterPort instances ────────────────────────────────────────────
   //
   // Param-pass note: passing `param NUM_SLAVES = NUM_SLAVES` would alias the
@@ -56,12 +59,24 @@ module Nic400Fabric
   generate_for i in 0..NUM_MASTERS-1
     inst mp_i: Nic400MasterPort
       param I = i;
-      clk <- clk;
-      rst <- rst;
-      m   <- m[i];
-      outs -> edges[i];
+      clk       <- clk;
+      rst       <- rst;
+      m         <- m[i];
+      outs      -> edges[i];
+      default_s -> default_edges[i];
     end inst mp_i
   end generate_for
+
+  // ── Default slave — returns DECERR for OOR addresses ─────────────────
+  // Receives OOR transactions from every MasterPort's default_s port and
+  // immediately responds with RRESP/BRESP=2'b11 (DECERR).
+  inst default_sl: Nic400DefaultSlave
+    clk <- clk;
+    rst <- rst;
+    for k in 0..NUM_MASTERS-1
+      m[k] <- default_edges[k];
+    end for
+  end inst default_sl
 
   // ── N SlavePort instances ─────────────────────────────────────────────
   // Each slave_j gathers element [j] from every master's row of edges via

--- a/tests/nic400/Nic400MasterPort.arch
+++ b/tests/nic400/Nic400MasterPort.arch
@@ -5,53 +5,48 @@
 // the high MIDX_W bits of the returned slave-side id select which slave's
 // return path drives the master. Symmetric structure for AW/W/B.
 //
-// Per-channel resource locks (ar_ch, r_ch, aw_ch, w_ch, b_ch) serialise
-// the multi-driver write to the shared m.* signals: with N per-slave
-// threads each driving the same master-side handshake outputs, the lock
-// keeps the multi-driver legal even though only one thread is in the
-// body at a time in steady state.
+// OOR (out-of-range) addresses — any address with bits[ADDR_WIDTH-1:REGION_BITS+NS_W] ≠ 0
+// — are routed to `default_s` (Nic400DefaultSlave) which returns DECERR.
+// Valid slave range: 0x0000_0000 – 0x3FFF_FFFF (4 slaves × 256 MB each,
+// with REGION_BITS=28 and NS_W=2).  Addresses ≥ 0x4000_0000 → OOR.
 //
-// W routing simplification (v1): each per-slave thread handles AW → W → B
-// for a transaction as one sequential chunk. The master sees back-pressure
-// (m.aw_ready=0) if a second AW for the same slave arrives before the
-// first completes. Cross-slave concurrency works (different threads),
-// but the same-slave pipeline depth is 1. The locks enforce W-beat
-// ordering when multiple slaves' threads contend.
+// wait 0+ cycle is retired; Mealy-equivalent replacement used throughout:
+//   if not <cond>
+//     wait until <cond>;
+//   end if
 module Nic400MasterPort
-  param I:             const = 0;        // this master's index, 0..NUM_MASTERS-1
+  param I:             const = 0;
   param NUM_SLAVES:    const = 4;
   param ADDR_WIDTH:    const = 32;
   param DATA_WIDTH:    const = 32;
   param STRB_WIDTH:    const = 4;
   param MASTER_ID_W:   const = 3;
-  param SLAVE_ID_W:    const = 5;        // MASTER_ID_W + ceil(log2(NUM_MASTERS))
-  param NS_W:          const = 2;        // ceil(log2(NUM_SLAVES))
+  param SLAVE_ID_W:    const = 5;
+  param NS_W:          const = 2;
   param REGION_BITS:   const = 28;
 
   port clk: in Clock<SysDomain>;
   port rst: in Reset<Async, Low>;
 
-  // System-facing master port (target perspective).
   port m:  target BusAxi4<ADDR_W=ADDR_WIDTH, DATA_W=DATA_WIDTH, STRB_W=STRB_WIDTH,
                           ID_W=MASTER_ID_W, READ=1, WRITE=1>;
-
-  // Fabric-facing outbound buses, one per slave.
   port outs: initiator Vec<BusAxi4<ADDR_W=ADDR_WIDTH, DATA_W=DATA_WIDTH, STRB_W=STRB_WIDTH,
-                                  ID_W=SLAVE_ID_W,  READ=1, WRITE=1>, NUM_SLAVES>;
+                                  ID_W=SLAVE_ID_W, READ=1, WRITE=1>, NUM_SLAVES>;
+  port default_s: initiator BusAxi4<ADDR_W=ADDR_WIDTH, DATA_W=DATA_WIDTH, STRB_W=STRB_WIDTH,
+                                    ID_W=SLAVE_ID_W, READ=1, WRITE=1>;
 
-  // Address decode for AR/AW: top NS_W bits of the REGION_BITS-aligned page.
-  // For 4 slaves: ar_addr[29:28] picks 0..3. For 2 slaves: ar_addr[28] picks 0..1.
   let m_ar_slv: UInt<NS_W> = m.ar_addr[REGION_BITS+NS_W-1:REGION_BITS];
   let m_aw_slv: UInt<NS_W> = m.aw_addr[REGION_BITS+NS_W-1:REGION_BITS];
+  let m_ar_oor: Bool = m.ar_addr[ADDR_WIDTH-1:REGION_BITS+NS_W] != 0;
+  let m_aw_oor: Bool = m.aw_addr[ADDR_WIDTH-1:REGION_BITS+NS_W] != 0;
 
-  // Per-channel arbiters — N per-slave threads contend on shared m.* drives.
   resource ar_ch: mutex<priority>;
   resource r_ch:  mutex<priority>;
   resource aw_ch: mutex<priority>;
   resource w_ch:  mutex<priority>;
   resource b_ch:  mutex<priority>;
 
-  // ── AR forwarding threads — one per slave ──────────────────────────────
+  // ── AR forwarding threads — one per real slave ─────────────────────────
   generate_for j in 0..NUM_SLAVES-1
     thread Ar_j on clk rising, rst low
       default comb
@@ -68,8 +63,8 @@ module Nic400MasterPort
         outs[j].ar_region = 0;
         m.ar_ready      = false;
       end default
-      if not (m.ar_valid and m_ar_slv == j)
-        wait until m.ar_valid and m_ar_slv == j;
+      if not (m.ar_valid and (not m_ar_oor) and m_ar_slv == j)
+        wait until m.ar_valid and (not m_ar_oor) and m_ar_slv == j;
       end if
       lock ar_ch
         do
@@ -90,7 +85,63 @@ module Nic400MasterPort
     end thread Ar_j
   end generate_for
 
-  // ── R return threads — one per slave, serialise via r_ch lock ──────────
+  // ── AR + R thread — OOR → default slave ───────────────────────────────
+  thread Ar_default on clk rising, rst low
+    default comb
+      default_s.ar_valid  = false;
+      default_s.ar_addr   = 0;
+      default_s.ar_id     = 0;
+      default_s.ar_len    = 0;
+      default_s.ar_size   = 0;
+      default_s.ar_burst  = 0;
+      default_s.ar_lock   = false;
+      default_s.ar_cache  = 0;
+      default_s.ar_prot   = 0;
+      default_s.ar_qos    = 0;
+      default_s.ar_region = 0;
+      default_s.r_ready   = false;
+      m.ar_ready          = false;
+      m.r_valid           = false;
+      m.r_data            = 0;
+      m.r_id              = 0;
+      m.r_resp            = 0;
+      m.r_last            = false;
+    end default
+    if not (m.ar_valid and m_ar_oor)
+      wait until m.ar_valid and m_ar_oor;
+    end if
+    lock ar_ch
+      do
+        default_s.ar_valid  = true;
+        default_s.ar_addr   = m.ar_addr;
+        default_s.ar_id     = (I.zext<SLAVE_ID_W>() << MASTER_ID_W) | m.ar_id.zext<SLAVE_ID_W>();
+        default_s.ar_len    = m.ar_len;
+        default_s.ar_size   = m.ar_size;
+        default_s.ar_burst  = m.ar_burst;
+        default_s.ar_lock   = m.ar_lock;
+        default_s.ar_cache  = m.ar_cache;
+        default_s.ar_prot   = m.ar_prot;
+        default_s.ar_qos    = m.ar_qos;
+        default_s.ar_region = m.ar_region;
+        m.ar_ready          = default_s.ar_ready;
+      until default_s.ar_ready;
+    end lock ar_ch
+    if not default_s.r_valid
+      wait until default_s.r_valid;
+    end if
+    lock r_ch
+      do
+        m.r_valid         = true;
+        m.r_data          = default_s.r_data;
+        m.r_id            = default_s.r_id[MASTER_ID_W-1:0];
+        m.r_resp          = default_s.r_resp;
+        m.r_last          = default_s.r_last;
+        default_s.r_ready = m.r_ready;
+      until m.r_ready and m.r_last;
+    end lock r_ch
+  end thread Ar_default
+
+  // ── R return threads — one per real slave ─────────────────────────────
   generate_for j in 0..NUM_SLAVES-1
     thread R_j on clk rising, rst low
       default comb
@@ -117,10 +168,7 @@ module Nic400MasterPort
     end thread R_j
   end generate_for
 
-  // ── AW → W → B threads — one per slave ────────────────────────────────
-  // Each thread handles a complete write transaction targeted at slave j.
-  // The aw_ch / w_ch / b_ch locks serialise multi-driver writes to the
-  // shared m.* signals across the N per-slave threads of this master.
+  // ── AW → W → B threads — one per real slave ───────────────────────────
   generate_for j in 0..NUM_SLAVES-1
     thread AwWb_j on clk rising, rst low
       default comb
@@ -146,9 +194,8 @@ module Nic400MasterPort
         m.b_id     = 0;
         m.b_resp   = 0;
       end default
-      // AW phase: wait for master's AW and address-decode match.
-      if not (m.aw_valid and m_aw_slv == j)
-        wait until m.aw_valid and m_aw_slv == j;
+      if not (m.aw_valid and (not m_aw_oor) and m_aw_slv == j)
+        wait until m.aw_valid and (not m_aw_oor) and m_aw_slv == j;
       end if
       lock aw_ch
         do
@@ -166,7 +213,6 @@ module Nic400MasterPort
           m.aw_ready      = outs[j].aw_ready;
         until outs[j].aw_ready;
       end lock aw_ch
-      // W phase: forward each beat until w_last handshake fires.
       lock w_ch
         do
           outs[j].w_valid = m.w_valid;
@@ -176,10 +222,6 @@ module Nic400MasterPort
           m.w_ready     = outs[j].w_ready;
         until m.w_valid and m.w_last and outs[j].w_ready;
       end lock w_ch
-      // B phase: wait outside b_ch until the slave actually has B valid,
-      // then acquire the lock to forward to master.  Waiting outside the
-      // lock lets a faster slave's AwWb thread win b_ch ahead of a slower
-      // one, enabling out-of-order B delivery within the same master.
       if not outs[j].b_valid
         wait until outs[j].b_valid;
       end if
@@ -193,4 +235,71 @@ module Nic400MasterPort
       end lock b_ch
     end thread AwWb_j
   end generate_for
+
+  // ── AW → W → B thread — OOR → default slave ───────────────────────────
+  thread AwWb_default on clk rising, rst low
+    default comb
+      default_s.aw_valid  = false;
+      default_s.aw_addr   = 0;
+      default_s.aw_id     = 0;
+      default_s.aw_len    = 0;
+      default_s.aw_size   = 0;
+      default_s.aw_burst  = 0;
+      default_s.aw_lock   = false;
+      default_s.aw_cache  = 0;
+      default_s.aw_prot   = 0;
+      default_s.aw_qos    = 0;
+      default_s.aw_region = 0;
+      default_s.w_valid   = false;
+      default_s.w_data    = 0;
+      default_s.w_strb    = 0;
+      default_s.w_last    = false;
+      default_s.b_ready   = false;
+      m.aw_ready = false;
+      m.w_ready  = false;
+      m.b_valid  = false;
+      m.b_id     = 0;
+      m.b_resp   = 0;
+    end default
+    if not (m.aw_valid and m_aw_oor)
+      wait until m.aw_valid and m_aw_oor;
+    end if
+    lock aw_ch
+      do
+        default_s.aw_valid  = true;
+        default_s.aw_addr   = m.aw_addr;
+        default_s.aw_id     = (I.zext<SLAVE_ID_W>() << MASTER_ID_W) | m.aw_id.zext<SLAVE_ID_W>();
+        default_s.aw_len    = m.aw_len;
+        default_s.aw_size   = m.aw_size;
+        default_s.aw_burst  = m.aw_burst;
+        default_s.aw_lock   = m.aw_lock;
+        default_s.aw_cache  = m.aw_cache;
+        default_s.aw_prot   = m.aw_prot;
+        default_s.aw_qos    = m.aw_qos;
+        default_s.aw_region = m.aw_region;
+        m.aw_ready          = default_s.aw_ready;
+      until default_s.aw_ready;
+    end lock aw_ch
+    lock w_ch
+      do
+        default_s.w_valid = m.w_valid;
+        default_s.w_data  = m.w_data;
+        default_s.w_strb  = m.w_strb;
+        default_s.w_last  = m.w_last;
+        m.w_ready         = default_s.w_ready;
+      until m.w_valid and m.w_last and default_s.w_ready;
+    end lock w_ch
+    if not default_s.b_valid
+      wait until default_s.b_valid;
+    end if
+    lock b_ch
+      do
+        m.b_valid          = true;
+        m.b_id             = default_s.b_id[MASTER_ID_W-1:0];
+        m.b_resp           = default_s.b_resp;
+        default_s.b_ready  = m.b_ready;
+      until m.b_ready;
+    end lock b_ch
+  end thread AwWb_default
+
 end module Nic400MasterPort


### PR DESCRIPTION
## Summary

- add a NIC-400 default-slave responder for out-of-range AR/AW decode misses
- route OOR traffic from `Nic400MasterPort` to the default slave and return DECERR
- preserve AXI read burst length by returning one DECERR R beat per requested transfer
- include the required sim-codegen fix for forwarding module-scope Vec regs into thread sub-instances

## Verification

- `cargo run -- check tests/nic400/PkgNic400.arch tests/nic400/BusAxi4.arch tests/nic400/Nic400DefaultSlave.arch tests/nic400/Nic400Fabric.arch tests/nic400/Nic400MasterPort.arch tests/nic400/Nic400SlavePort.arch`
- `cargo test test_sim_vec_reg_forwarded_to_thread_inst_uses_reg_storage -- --exact`
- `harc sim` focused OOR read repro against `Nic400Fabric` using `/tmp/nic400_oor_repro_main.harc`
