### PR TITLE
Bump arch version to 0.70.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,7 +75,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arch"
-version = "0.70.0"
+version = "0.70.1"
 dependencies = [
  "clap",
  "insta",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arch"
-version = "0.70.0"
+version = "0.70.1"
 edition = "2021"
 description = "Compiler for the ARCH hardware description language"
 license = "LGPL-3.0-or-later"


### PR DESCRIPTION
## Summary
- bump arch package version from 0.70.0 to 0.70.1
- keep Cargo.lock in sync

## Why
- v0.70.0 already exists and predates the cargo-dist binary release workflow
- cargo-dist correctly rejects v0.70.1 unless the package version is also 0.70.1

## Validation
- dist host --steps=create --tag=v0.70.1 --output-format=json
- cargo check
- git diff --check