### PR TITLE
[codex] Add pre-PR review gate

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+branch="$(git branch --show-current)"
+
+case "$branch" in
+  codex/*)
+    scripts/pre_pr_review.sh check
+    ;;
+  *)
+    ;;
+esac

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,19 @@ change, and AI co-author trailers break the CLA Assistant (which requires every
 listed author to individually sign the CLA — `noreply@anthropic.com` can't).
 Just write a normal commit message with no AI attribution trailer.
 
+## PR review gate
+
+Before creating a pull request, run a code-review pass against the branch diff:
+findings first, ordered by severity, with file/line references; then open
+questions, then a brief summary and validation gaps. Address or explicitly
+accept any findings before opening the PR.
+
+After the review pass is complete, run `scripts/pre_pr_review.sh mark` to record
+the reviewed HEAD. Run `scripts/pre_pr_review.sh check` before creating the PR.
+Use `git config core.hooksPath .githooks` in local clones to install the
+versioned `.githooks/pre-push` hook. The hook blocks pushes from `codex/*`
+branches when the review marker is missing or stale.
+
 ## Project Overview
 
 `arch-com` is a compiler for **ARCH**, a purpose-built hardware description language (HDL) for micro-architecture work. The compiler ingests `.arch` source files and emits deterministic, readable SystemVerilog. The language is explicitly designed to be generated correctly by LLMs from natural-language hardware descriptions.

--- a/README.md
+++ b/README.md
@@ -252,6 +252,26 @@ See `doc/ARCH_HDL_Specification.md` for the full language reference and `doc/COM
 
 - Start here for a fast contributor orientation: `doc/ONBOARDING_CHEATSHEET.md`
 
+### PR review gate
+
+Install the versioned local git hooks with:
+
+```sh
+git config core.hooksPath .githooks
+chmod +x .githooks/pre-push scripts/pre_pr_review.sh
+```
+
+Before opening a PR, run a code-review pass against the branch diff, address or
+accept the findings, then record the reviewed HEAD:
+
+```sh
+scripts/pre_pr_review.sh mark
+scripts/pre_pr_review.sh check
+```
+
+The installed `pre-push` hook checks `codex/*` branches and blocks the push when
+the review marker is missing or stale, so review happens before PR creation.
+
 ## Tests
 
 ```sh

--- a/scripts/pre_pr_review.sh
+++ b/scripts/pre_pr_review.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  scripts/pre_pr_review.sh mark [base-ref]
+  scripts/pre_pr_review.sh check [base-ref]
+
+Records or checks that the current branch HEAD has received a code-review pass
+before it is pushed/opened as a PR. Review markers are local and stored under
+.git/pre-pr-reviews/.
+USAGE
+}
+
+mode="${1:-}"
+base_ref="${2:-origin/main}"
+
+if [[ "$mode" != "mark" && "$mode" != "check" ]]; then
+  usage >&2
+  exit 2
+fi
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+branch="$(git branch --show-current)"
+if [[ -z "$branch" ]]; then
+  echo "pre-pr-review: detached HEAD is not supported" >&2
+  exit 2
+fi
+
+head_sha="$(git rev-parse HEAD)"
+safe_branch="$(printf '%s' "$branch" | tr '/: ' '___')"
+marker_dir="$(git rev-parse --git-path pre-pr-reviews)"
+marker="${marker_dir}/${safe_branch}.review"
+
+mkdir -p "$marker_dir"
+
+changed_files="$(git diff --name-only "${base_ref}...HEAD" 2>/dev/null || true)"
+if [[ -z "$changed_files" ]]; then
+  changed_files="$(git diff --name-only HEAD~1...HEAD 2>/dev/null || true)"
+fi
+
+if [[ "$mode" == "mark" ]]; then
+  {
+    printf 'branch=%s\n' "$branch"
+    printf 'head=%s\n' "$head_sha"
+    printf 'base=%s\n' "$base_ref"
+    printf 'reviewed_at_utc=%s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+    printf 'changed_files<<EOF\n%s\nEOF\n' "$changed_files"
+  } >"$marker"
+  echo "pre-pr-review: recorded code review marker for ${branch} at ${head_sha}"
+  exit 0
+fi
+
+if [[ ! -f "$marker" ]]; then
+  cat >&2 <<EOF
+pre-pr-review: missing code-review marker for ${branch}.
+
+Before creating/pushing a PR, run a code-review pass against:
+  git diff ${base_ref}...HEAD
+
+Review stance:
+  findings first, ordered by severity, with file/line references;
+  then open questions, then a brief summary and validation gaps.
+
+After the review is complete and findings are addressed or accepted, run:
+  scripts/pre_pr_review.sh mark
+EOF
+  exit 1
+fi
+
+reviewed_head="$(awk -F= '$1 == "head" { print $2; exit }' "$marker")"
+if [[ "$reviewed_head" != "$head_sha" ]]; then
+  cat >&2 <<EOF
+pre-pr-review: marker is stale for ${branch}.
+  reviewed: ${reviewed_head:-<none>}
+  current : ${head_sha}
+
+Run a fresh code-review pass, then:
+  scripts/pre_pr_review.sh mark
+EOF
+  exit 1
+fi
+
+echo "pre-pr-review: review marker is current for ${branch}"


### PR DESCRIPTION
## Summary

- add a versioned `.githooks/pre-push` hook for `codex/*` branches
- add `scripts/pre_pr_review.sh` to mark/check a reviewed branch HEAD before PR creation
- document the pre-PR review gate in `AGENTS.md` and `README.md`

## Validation

- `bash -n scripts/pre_pr_review.sh .githooks/pre-push`
- `scripts/pre_pr_review.sh check` fails before a marker exists
- `scripts/pre_pr_review.sh mark && scripts/pre_pr_review.sh check`
- `.githooks/pre-push`
- `git diff --check`
