### PR TITLE
Forward params to lowered thread helpers

### DIFF
--- a/src/elaborate.rs
+++ b/src/elaborate.rs
@@ -3431,7 +3431,16 @@ fn lower_module_threads(
     let inst = InstDecl {
         name: Ident::new("_threads".to_string(), sp),
         module_name: Ident::new(merged_name, sp),
-        param_assigns: Vec::new(),
+        param_assigns: m
+            .params
+            .iter()
+            .filter(|p| !p.is_local)
+            .map(|p| ParamAssign {
+                name: p.name.clone(),
+                value: Expr::new(ExprKind::Ident(p.name.name.clone()), p.span),
+                ty: None,
+            })
+            .collect(),
         connections,
         for_loops: Vec::new(),
         span: sp,

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -12984,6 +12984,64 @@ fn test_lower_threads_clones_parent_params_into_threads_submodule() {
 }
 
 #[test]
+fn test_lower_threads_forwards_parent_params_to_threads_inst() {
+    // arch-com#507: the synthetic `_<mod>_threads` submodule repeats
+    // overridable parent params so thread bodies can reference them, but
+    // the wrapper must also pass through the wrapper's current parameter
+    // values. Otherwise an inst-site override affects parent logic while
+    // the lifted thread body silently keeps the helper defaults.
+    let source = r#"
+        module ParamThread
+          param DONE_VALUE: const = 5;
+          param OUT_W: const = 4;
+          local param LOCAL_DONE: const = DONE_VALUE + 1;
+
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync, High>;
+          port go: in Bool;
+          port reg result: out UInt<OUT_W> reset rst => 0;
+
+          thread on clk rising, rst high
+            wait until go;
+            result <= DONE_VALUE;
+            wait 1 cycle;
+          end thread
+        end module ParamThread
+
+        module Top
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync, High>;
+          port go: in Bool;
+          port result: out UInt<8>;
+
+          inst u: ParamThread
+            param DONE_VALUE = 9;
+            param OUT_W = 8;
+            clk <- clk;
+            rst <- rst;
+            go <- go;
+            result -> result;
+          end inst u
+        end module Top
+    "#;
+    let sv = compile_to_sv(source);
+    assert!(
+        sv.contains("ParamThread #(.DONE_VALUE(9), .OUT_W(8)) u ("),
+        "top-level override should still be emitted:\n{sv}"
+    );
+    assert!(
+        sv.contains(
+            "_ParamThread_threads #(.DONE_VALUE(DONE_VALUE), .OUT_W(OUT_W)) _threads ("
+        ),
+        "wrapper must forward overridable params into the synthesized threads helper:\n{sv}"
+    );
+    assert!(
+        !sv.contains(".LOCAL_DONE(LOCAL_DONE)"),
+        "localparams are cloned into the helper but must not be overridden at the inst site:\n{sv}"
+    );
+}
+
+#[test]
 fn test_thread_sim_declares_module_params_used_by_thread_body() {
     // arch-com#352: the ARCH-native coroutine thread sim path skips
     // lower_threads, so parent params are not cloned into a synthetic FSM


### PR DESCRIPTION
## Summary
- forward non-local module params into synthesized `_threads` helper instantiations
- add regression coverage for parent param overrides reaching lowered thread helpers
- keep local params cloned into helpers but not overridden at the helper inst site

Fixes #507.

## Tests
- `cargo test --test integration_test test_lower_threads`
- `cargo test --test integration_test module_params`
- `git diff --check main...HEAD`

Note: `cargo fmt --check -- src/elaborate.rs tests/integration_test.rs` still reports broad pre-existing repo formatting churn outside this patch, so I did not apply global formatting changes.
