### PR TITLE
Trim thread helper SV spacing

### DIFF
--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -392,7 +392,8 @@ impl<'a> Codegen<'a> {
                 _ => vec![],
             })
             .collect();
-        for item in items {
+        let mut trimmed_threads_helper_boundary = false;
+        for (idx, item) in items.iter().enumerate() {
             self.emit_comments_before(item.span().start);
             // Function / Template / Bus / Use have no top-level SV emit
             // (Function is emitted inside each module body, Template is
@@ -400,10 +401,17 @@ impl<'a> Codegen<'a> {
             // an import emitted inside modules) — their `Construct::emit_sv`
             // impl is the trait default no-op.
             item.as_construct().emit_sv(self);
+            if Self::is_threads_helper_for_next_public_module(item, items.get(idx + 1)) {
+                self.trim_trailing_blank_line();
+                trimmed_threads_helper_boundary = true;
+            }
         }
         // Flush any trailing comments after the last item.
         let end = usize::MAX;
         self.emit_comments_before(end);
+        if trimmed_threads_helper_boundary {
+            self.trim_trailing_blank_line();
+        }
 
         // Prepend typedefs for any synthesized find_first result structs.
         // One packed struct per unique index width used in the source.
@@ -423,6 +431,22 @@ impl<'a> Codegen<'a> {
             self.out = prefix;
         }
         std::mem::take(&mut self.out)
+    }
+
+    fn is_threads_helper_for_next_public_module(item: &Item, next: Option<&Item>) -> bool {
+        let Item::Module(m) = item else {
+            return false;
+        };
+        let Some(Item::Module(next_m)) = next else {
+            return false;
+        };
+        m.name.name == format!("_{}_threads", next_m.name.name)
+    }
+
+    fn trim_trailing_blank_line(&mut self) {
+        while self.out.ends_with("\n\n") {
+            self.out.pop();
+        }
     }
 
     fn line(&mut self, s: &str) {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -11132,6 +11132,38 @@ fn test_wait_1_cycle_in_else_branch_kept() {
         "thread with wait-1-cycle in else branch should compile:\n{sv}");
 }
 
+#[test]
+fn test_lowered_threads_codegen_has_no_extra_blank_separator_or_eof_blank() {
+    // Regression: `arch build` briefly emitted `endmodule\n\nmodule M`
+    // between the synthetic `_M_threads` helper and the public wrapper,
+    // plus `endmodule\n\n` at EOF. That produced blank-line-only churn in
+    // downstream generated SV such as fpt26 AttentionTileShell.sv.
+    let source = r#"
+        module M
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync, High>;
+          port go: in Bool;
+          port done: out Bool;
+          thread on clk rising, rst high
+            wait until go;
+            done = 1;
+            wait 1 cycle;
+          end thread
+        end module M
+    "#;
+    let sv = compile_to_sv(source);
+    assert!(sv.contains("module _M_threads"), "expected lowered helper:\n{sv}");
+    assert!(sv.contains("endmodule\nmodule M"), "expected tight helper/public boundary:\n{sv}");
+    assert!(
+        !sv.contains("endmodule\n\nmodule M"),
+        "helper/public boundary must not contain a blank separator:\n{sv}"
+    );
+    assert!(
+        sv.ends_with("endmodule\n") && !sv.ends_with("endmodule\n\n"),
+        "generated SV must end with one newline after final endmodule:\n{sv:?}"
+    );
+}
+
 // ── Auto-emitted SVA from thread lowering ─────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary
- Collapse the extra blank line between synthesized `_<Module>_threads` helpers and their public wrapper modules.
- Trim the extra EOF blank only when a thread-helper boundary was normalized.
- Add regression coverage for the helper/public boundary and EOF newline shape.

## Verification
- `cargo test test_lowered_threads_codegen_has_no_extra_blank_separator_or_eof_blank`
- `cargo test test_lower_threads_forwards_parent_params_to_threads_inst`
- `git diff --check`
- In `/Users/shuqingzhao/github/fpt26-accel`: `make arch-build ARCH_HOME=../arch-com-latest` passed and did not introduce generated-SV blank-line churn.
- `codex review --base origin/main` found no issues.
