### PR TITLE
[codex] Add native sim folded wait target regression

### DIFF
--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -18804,6 +18804,38 @@ fn test_native_sim_thread_driven_top_pipe_reg_output_is_public() {
 }
 
 #[test]
+fn test_native_sim_wait_until_fold_target_reaches_post_action_state() {
+    // Regression for the folded wait-until exit target: after
+    // `wait until go; phase <= 1; wait 2 cycle; phase <= 2;`, default native
+    // sim must update phase on the go-detection edge and then continue into
+    // the counted-wait state. If the folded wait targets the absorbed action
+    // state instead, the native sim state machine gets stuck and never reaches
+    // phase=2.
+    let td = tempfile::tempdir().expect("tempdir");
+    let arch_bin = env!("CARGO_BIN_EXE_arch");
+    let out = std::process::Command::new(arch_bin)
+        .arg("sim")
+        .arg("tests/native_wait_until_fold_target/Probe.arch")
+        .arg("--tb")
+        .arg("tests/native_wait_until_fold_target/tb.cpp")
+        .arg("--outdir")
+        .arg(td.path())
+        .output()
+        .expect("run arch sim for native wait-until folded target probe");
+    assert!(
+        out.status.success(),
+        "native wait-until folded target sim should compile + run\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&out.stdout).contains("PASS native wait-until folded target"),
+        "expected PASS marker in stdout:\n{}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+}
+
+#[test]
 fn test_nic400_master_port_marks_non_power_of_two_decode_holes_oor() {
     // PR #487 added a default-slave DECERR path for out-of-range accesses,
     // but the original OOR predicate only checked high address bits above

--- a/tests/native_wait_until_fold_target/Probe.arch
+++ b/tests/native_wait_until_fold_target/Probe.arch
@@ -1,0 +1,28 @@
+//! ---
+//! tags: [native-sim, thread-lowering, wait-until-fold, regression]
+//! refs:
+//!   - "arch-com#306"
+//! ---
+//!
+//! Regression for native simulation of folded wait-until exit assignments.
+//! The folded wait state must jump to the post-action target, not the absorbed
+//! action state.
+
+/// Thread whose wait-until exit action is folded before a counted wait.
+module NativeWaitUntilFoldTargetProbe
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync, High>;
+  port go: in Bool;
+  port phase: out UInt<2>;
+
+  reg phase_r: UInt<2> reset rst => 0;
+  let phase = phase_r;
+
+  thread on clk rising, rst high
+    wait until go;
+    phase_r <= 2'd1;
+    wait 2 cycle;
+    phase_r <= 2'd2;
+    wait until go;
+  end thread
+end module NativeWaitUntilFoldTargetProbe

--- a/tests/native_wait_until_fold_target/tb.cpp
+++ b/tests/native_wait_until_fold_target/tb.cpp
@@ -1,0 +1,62 @@
+#include "VNativeWaitUntilFoldTargetProbe.h"
+
+#include <cstdio>
+
+static void tick(VNativeWaitUntilFoldTargetProbe& dut) {
+    dut.clk = 0;
+    dut.eval();
+    dut.clk = 1;
+    dut.eval();
+    dut.clk = 0;
+    dut.eval();
+}
+
+int main() {
+    VNativeWaitUntilFoldTargetProbe dut;
+
+    dut.rst = 1;
+    dut.go = 0;
+    tick(dut);
+
+    dut.rst = 0;
+    tick(dut);
+
+    if (dut.phase != 0) {
+        std::printf("FAIL: reset/release phase=%u, expected 0\n", (unsigned)dut.phase);
+        return 1;
+    }
+
+    // The wait-until exit assignment is folded into the go-detection arm, so
+    // phase must update on this tick. The folded transition target must skip
+    // the absorbed action state and enter the following wait-2-cycle state.
+    dut.go = 1;
+    tick(dut);
+    dut.go = 0;
+
+    if (dut.phase != 1) {
+        std::printf("FAIL: phase after go=%u, expected folded assignment value 1\n",
+                    (unsigned)dut.phase);
+        return 1;
+    }
+
+    // If the folded wait state incorrectly targets the absorbed action state,
+    // native sim gets stuck because that state has no emitted body. Reaching
+    // phase=2 proves the target advanced into the counted-wait path instead.
+    bool reached_phase_2 = false;
+    for (int i = 0; i < 8; ++i) {
+        tick(dut);
+        if (dut.phase == 2) {
+            reached_phase_2 = true;
+            break;
+        }
+    }
+
+    if (!reached_phase_2) {
+        std::printf("FAIL: phase never reached 2 after folded wait target; final phase=%u\n",
+                    (unsigned)dut.phase);
+        return 1;
+    }
+
+    std::printf("PASS native wait-until folded target\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary

Adds a focused native-sim regression for folded `wait until` exit assignments.

The fixture checks that default `arch sim` updates the folded assignment on the `go` detection edge and then continues into the post-action `wait 2 cycle` state. If the folded wait target incorrectly points at the absorbed action state, the testbench never reaches `phase == 2` and fails.

## Validation

- `cargo test test_native_sim_wait_until_fold_target_reaches_post_action_state`
- `scripts/pre_pr_review.sh mark`
- `scripts/pre_pr_review.sh check`

## Review

Findings: none.

Open questions: none.
