### PR TITLE
[codex] Add Lean thread lowering proof backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,10 +83,11 @@ Always-on runtime checks: out-of-range `Vec<T,N>` indexing, bit-selects `val[i]`
 
 ## Formal verification
 
-Two paths, both driven by the same `assert` / `cover` clauses in the source:
+Three paths:
 
 1. **SV-SVA path** — `arch build` emits SystemVerilog with concurrent assertions consumable by EBMC, Verilator `--assert`, and SymbiYosys. Nothing extra to configure.
 2. **Direct SMT-LIB2 path** — `arch formal` lowers a module straight to SMT-LIB2 and shells out to a bit-vector solver. No Yosys in the loop; ARCH semantics (wrapping arithmetic, width casts) are encoded precisely.
+3. **Lean thread-lowering proof path** — `arch formal --emit-thread-proof-lean` emits a Lean replay file proving the compiler-recorded thread-to-FSM lowering certificate. `--check-thread-proof-lean` immediately replays it with `lake env lean`. This is a compiler-lowering proof artifact, not a bounded design-property proof.
 
 ```sh
 arch formal MyModule.arch                            # defaults: z3, bound=20, 60s timeout
@@ -94,6 +95,12 @@ arch formal MyModule.arch --bound 64                 # deeper unroll
 arch formal MyModule.arch --solver boolector         # or bitwuzla
 arch formal MyModule.arch --emit-smt model.smt2      # dump the SMT-LIB2 for inspection
 arch formal multi.arch --top MyTop                   # pick a top when the file has >1 module
+arch formal MyModule.arch --emit-thread-proof-lean    # emit <input>.thread-proof.lean
+arch formal MyModule.arch --check-thread-proof-lean \
+  --thread-proof-lean-project proofs/lean_thread_lowering
+arch formal MyModule.arch --check-thread-proof-lean \
+  --thread-proof-lean-project proofs/lean_thread_lowering \
+  --thread-proof-only                              # replay Lean and skip SMT
 ```
 
 Output is one line per property — `PROVED up to bound N`, `REFUTED at cycle C` (with a per-cycle signal counterexample), `HIT at cycle C` for covers, `NOT REACHED within bound N`, or `INCONCLUSIVE` on solver timeout. Exit codes: `0` all-good, `1` any failure, `2` inconclusive, `3` compile error. Scope in v1 is flat modules with scalar signals (`UInt<N>` / `SInt<N>` / `Bool` / `Bit`), single clock, no sub-`inst`; anything out of scope errors out with a pointer at the offending construct.

--- a/proofs/lean_thread_lowering/.gitignore
+++ b/proofs/lean_thread_lowering/.gitignore
@@ -1,0 +1,4 @@
+.lake/
+
+__pycache__/
+scripts/__pycache__/

--- a/proofs/lean_thread_lowering/ArchThreadLoweringProof.lean
+++ b/proofs/lean_thread_lowering/ArchThreadLoweringProof.lean
@@ -1,0 +1,3 @@
+import ArchThreadLoweringProof.Simple
+import ArchThreadLoweringProof.CountedWait
+import ArchThreadLoweringProof.FoldedExit

--- a/proofs/lean_thread_lowering/ArchThreadLoweringProof/CountedWait.lean
+++ b/proofs/lean_thread_lowering/ArchThreadLoweringProof/CountedWait.lean
@@ -1,0 +1,412 @@
+/-!
+Counted-wait extension for the ARCH thread-to-FSM lowering certificate model.
+
+This module adds the first timing-sensitive ingredient from the real lowering:
+`wait N cycle` states with a counter in the runtime configuration. Both the
+source semantics and lowered FSM semantics load the counter when entering a
+counted-wait state, decrement it while waiting, and advance when it reaches
+zero.
+
+It also models `multi_transitions`: a deterministic dispatch list of guarded
+branches with a fall-through target. That covers the control-table shape used
+by ARCH lowering for if-with-wait dispatch states, for-loop exits, and
+fork/join product states.
+-/
+
+namespace Arch.ThreadLoweringProof.CountedWait
+
+abbrev Action := Nat
+abbrev Guard := Nat
+abbrev Env := Guard -> Bool
+abbrev NatEnv := Nat -> Nat
+
+inductive NatExpr where
+  | var (name : Nat)
+  | const (value : Nat)
+deriving Repr, BEq
+
+def NatExpr.eval (env : NatEnv) : NatExpr -> Nat
+  | NatExpr.var name => env name
+  | NatExpr.const value => value
+
+inductive GuardExpr where
+  | atom (guard : Guard)
+  | trueLit
+  | falseLit
+  | neg (expr : GuardExpr)
+  | and (lhs rhs : GuardExpr)
+  | or (lhs rhs : GuardExpr)
+  | lt (lhs rhs : NatExpr)
+  | ge (lhs rhs : NatExpr)
+  | eq (lhs rhs : NatExpr)
+  | ne (lhs rhs : NatExpr)
+deriving Repr, BEq
+
+def GuardExpr.eval (env : Env) (expr : GuardExpr) (natEnv : NatEnv := fun _ => 0) : Bool :=
+  match expr with
+  | GuardExpr.atom guard => env guard
+  | GuardExpr.trueLit => true
+  | GuardExpr.falseLit => false
+  | GuardExpr.neg expr => !(GuardExpr.eval env expr natEnv)
+  | GuardExpr.and lhs rhs => GuardExpr.eval env lhs natEnv && GuardExpr.eval env rhs natEnv
+  | GuardExpr.or lhs rhs => GuardExpr.eval env lhs natEnv || GuardExpr.eval env rhs natEnv
+  | GuardExpr.lt lhs rhs => decide (NatExpr.eval natEnv lhs < NatExpr.eval natEnv rhs)
+  | GuardExpr.ge lhs rhs => decide (NatExpr.eval natEnv rhs <= NatExpr.eval natEnv lhs)
+  | GuardExpr.eq lhs rhs => decide (NatExpr.eval natEnv lhs = NatExpr.eval natEnv rhs)
+  | GuardExpr.ne lhs rhs => decide (NatExpr.eval natEnv lhs ≠ NatExpr.eval natEnv rhs)
+
+structure Branch where
+  guard : GuardExpr
+  target : Nat
+deriving Repr, BEq
+
+inductive Control where
+  | advance
+  | jump (target : Nat)
+  | waitUntil (guard : GuardExpr)
+  | waitCycles (count : Nat)
+  | guarded (guard : GuardExpr) (target : Nat)
+  | dispatch (branches : List Branch)
+deriving Repr, BEq
+
+def dispatchBranches : Control -> List Branch
+  | Control.dispatch branches => branches
+  | _ => []
+
+structure ThreadState where
+  actions : List Action
+  control : Control
+deriving Repr, BEq
+
+structure SourceThread where
+  numStates : Nat
+  once : Bool
+  state : Nat -> ThreadState
+
+structure FsmState where
+  actions : List Action
+  control : Control
+  target : Nat
+deriving Repr, BEq
+
+structure LoweredFsm where
+  state : Nat -> FsmState
+
+structure Config where
+  pc : Nat
+  cnt : Nat
+deriving Repr, BEq
+
+def sourceNext (src : SourceThread) (pc : Nat) : Nat :=
+  if pc + 1 < src.numStates then pc + 1 else if src.once then pc else 0
+
+def sourceObs (src : SourceThread) (cfg : Config) : List Action :=
+  (src.state cfg.pc).actions
+
+def fsmObs (fsm : LoweredFsm) (cfg : Config) : List Action :=
+  (fsm.state cfg.pc).actions
+
+def sourceLoadCounterAt (src : SourceThread) (pc : Nat) (oldCnt : Nat) : Nat :=
+  match (src.state pc).control with
+  | Control.waitCycles count => count.pred
+  | _ => oldCnt
+
+def fsmLoadCounterAt (fsm : LoweredFsm) (pc : Nat) (oldCnt : Nat) : Nat :=
+  match (fsm.state pc).control with
+  | Control.waitCycles count => count.pred
+  | _ => oldCnt
+
+def sourceAdvanceTo (src : SourceThread) (cfg : Config) (target : Nat) : Config :=
+  { pc := target, cnt := sourceLoadCounterAt src target cfg.cnt }
+
+def fsmAdvanceTo (fsm : LoweredFsm) (cfg : Config) (target : Nat) : Config :=
+  { pc := target, cnt := fsmLoadCounterAt fsm target cfg.cnt }
+
+def firstEnabledTarget (env : Env) (natEnv : NatEnv) (branches : List Branch) (fallback : Nat) : Nat :=
+  match branches with
+  | [] => fallback
+  | branch :: rest =>
+      if GuardExpr.eval env branch.guard natEnv then
+        branch.target
+      else
+        firstEnabledTarget env natEnv rest fallback
+
+theorem firstEnabledTarget_fallback_eq
+    (env : Env)
+    (natEnv : NatEnv)
+    (branches : List Branch)
+    {a b : Nat}
+    (h : a = b) :
+    firstEnabledTarget env natEnv branches a = firstEnabledTarget env natEnv branches b := by
+  induction branches with
+  | nil => simp [firstEnabledTarget, h]
+  | cons branch rest ih =>
+      by_cases hguard : GuardExpr.eval env branch.guard natEnv
+      · simp [firstEnabledTarget, hguard]
+      · simp [firstEnabledTarget, hguard, ih]
+
+def sourceStep (src : SourceThread) (env : Env) (natEnv : NatEnv) (cfg : Config) : Config :=
+  match (src.state cfg.pc).control with
+  | Control.advance =>
+      sourceAdvanceTo src cfg (sourceNext src cfg.pc)
+  | Control.jump target =>
+      sourceAdvanceTo src cfg target
+  | Control.waitUntil guard =>
+      if GuardExpr.eval env guard natEnv then
+        sourceAdvanceTo src cfg (sourceNext src cfg.pc)
+      else
+        cfg
+  | Control.waitCycles _ =>
+      if cfg.cnt = 0 then
+        sourceAdvanceTo src cfg (sourceNext src cfg.pc)
+      else
+        { cfg with cnt := cfg.cnt.pred }
+  | Control.guarded guard target =>
+      if GuardExpr.eval env guard natEnv then
+        sourceAdvanceTo src cfg target
+      else
+        cfg
+  | Control.dispatch branches =>
+      sourceAdvanceTo src cfg (firstEnabledTarget env natEnv branches (sourceNext src cfg.pc))
+
+def fsmStep (fsm : LoweredFsm) (env : Env) (natEnv : NatEnv) (cfg : Config) : Config :=
+  let state := fsm.state cfg.pc
+  match state.control with
+  | Control.advance =>
+      fsmAdvanceTo fsm cfg state.target
+  | Control.jump target =>
+      fsmAdvanceTo fsm cfg target
+  | Control.waitUntil guard =>
+      if GuardExpr.eval env guard natEnv then
+        fsmAdvanceTo fsm cfg state.target
+      else
+        cfg
+  | Control.waitCycles _ =>
+      if cfg.cnt = 0 then
+        fsmAdvanceTo fsm cfg state.target
+      else
+        { cfg with cnt := cfg.cnt.pred }
+  | Control.guarded guard target =>
+      if GuardExpr.eval env guard natEnv then
+        fsmAdvanceTo fsm cfg target
+      else
+        cfg
+  | Control.dispatch branches =>
+      fsmAdvanceTo fsm cfg (firstEnabledTarget env natEnv branches state.target)
+
+structure LoweringCertifies (src : SourceThread) (fsm : LoweredFsm) : Prop where
+  actions_ok : forall pc, (fsm.state pc).actions = (src.state pc).actions
+  control_ok : forall pc, (fsm.state pc).control = (src.state pc).control
+  dispatch_branches_ok :
+    forall pc, dispatchBranches (fsm.state pc).control = dispatchBranches (src.state pc).control
+  target_ok : forall pc, (fsm.state pc).target = sourceNext src pc
+
+theorem load_counter_equiv
+    {src : SourceThread}
+    {fsm : LoweredFsm}
+    (cert : LoweringCertifies src fsm)
+    (pc oldCnt : Nat) :
+    sourceLoadCounterAt src pc oldCnt = fsmLoadCounterAt fsm pc oldCnt := by
+  simp [sourceLoadCounterAt, fsmLoadCounterAt, cert.control_ok pc]
+
+theorem advance_equiv
+    {src : SourceThread}
+    {fsm : LoweredFsm}
+    (cert : LoweringCertifies src fsm)
+    (cfg : Config)
+    (target : Nat) :
+    sourceAdvanceTo src cfg target = fsmAdvanceTo fsm cfg target := by
+  simp [sourceAdvanceTo, fsmAdvanceTo, load_counter_equiv cert target cfg.cnt]
+
+theorem one_step_equiv
+    {src : SourceThread}
+    {fsm : LoweredFsm}
+    (cert : LoweringCertifies src fsm)
+    (env : Env)
+    (natEnv : NatEnv)
+    (cfg : Config) :
+    sourceObs src cfg = fsmObs fsm cfg
+      /\ sourceStep src env natEnv cfg = fsmStep fsm env natEnv cfg := by
+  constructor
+  · simp [sourceObs, fsmObs, cert.actions_ok cfg.pc]
+  · cases h : (src.state cfg.pc).control with
+    | advance =>
+        simp [
+          sourceStep,
+          fsmStep,
+          h,
+          cert.control_ok cfg.pc,
+          cert.target_ok cfg.pc,
+          advance_equiv cert cfg (sourceNext src cfg.pc),
+        ]
+    | jump target =>
+        simp [
+          sourceStep,
+          fsmStep,
+          h,
+          cert.control_ok cfg.pc,
+          advance_equiv cert cfg target,
+        ]
+    | waitUntil guard =>
+        by_cases henv : GuardExpr.eval env guard natEnv
+        · simp [
+            sourceStep,
+            fsmStep,
+            h,
+            henv,
+            cert.control_ok cfg.pc,
+            cert.target_ok cfg.pc,
+            advance_equiv cert cfg (sourceNext src cfg.pc),
+          ]
+        · simp [sourceStep, fsmStep, h, henv, cert.control_ok cfg.pc]
+    | waitCycles count =>
+        by_cases hcnt : cfg.cnt = 0
+        · simp [
+            sourceStep,
+            fsmStep,
+            h,
+            hcnt,
+            cert.control_ok cfg.pc,
+            cert.target_ok cfg.pc,
+            advance_equiv cert cfg (sourceNext src cfg.pc),
+          ]
+        · simp [sourceStep, fsmStep, h, hcnt, cert.control_ok cfg.pc]
+    | guarded guard target =>
+        by_cases henv : GuardExpr.eval env guard natEnv
+        · simp [
+            sourceStep,
+            fsmStep,
+            h,
+            henv,
+            cert.control_ok cfg.pc,
+            advance_equiv cert cfg target,
+          ]
+        · simp [sourceStep, fsmStep, h, henv, cert.control_ok cfg.pc]
+    | dispatch branches =>
+        have htarget :
+            firstEnabledTarget env natEnv branches (sourceNext src cfg.pc)
+              = firstEnabledTarget env natEnv branches (fsm.state cfg.pc).target :=
+          firstEnabledTarget_fallback_eq env natEnv branches (cert.target_ok cfg.pc).symm
+        simp [
+          sourceStep,
+          fsmStep,
+          h,
+          cert.control_ok cfg.pc,
+          htarget,
+          advance_equiv cert cfg (firstEnabledTarget env natEnv branches (fsm.state cfg.pc).target),
+        ]
+
+def sourceCfgAt
+    (src : SourceThread)
+    (inputs : Nat -> Env)
+    (natInputs : Nat -> NatEnv)
+    (cfg0 : Config) : Nat -> Config
+  | 0 => cfg0
+  | Nat.succ t => sourceStep src (inputs t) (natInputs t) (sourceCfgAt src inputs natInputs cfg0 t)
+
+def fsmCfgAt
+    (fsm : LoweredFsm)
+    (inputs : Nat -> Env)
+    (natInputs : Nat -> NatEnv)
+    (cfg0 : Config) : Nat -> Config
+  | 0 => cfg0
+  | Nat.succ t => fsmStep fsm (inputs t) (natInputs t) (fsmCfgAt fsm inputs natInputs cfg0 t)
+
+theorem cfg_trace_equiv
+    {src : SourceThread}
+    {fsm : LoweredFsm}
+    (cert : LoweringCertifies src fsm)
+    (inputs : Nat -> Env)
+    (natInputs : Nat -> NatEnv)
+    (cfg0 : Config) :
+    forall t, sourceCfgAt src inputs natInputs cfg0 t = fsmCfgAt fsm inputs natInputs cfg0 t := by
+  intro t
+  induction t with
+  | zero => rfl
+  | succ t ih =>
+      simp [sourceCfgAt, fsmCfgAt]
+      rw [ih]
+      exact (one_step_equiv cert (inputs t) (natInputs t) (fsmCfgAt fsm inputs natInputs cfg0 t)).right
+
+def sourceTraceObs
+    (src : SourceThread)
+    (inputs : Nat -> Env)
+    (natInputs : Nat -> NatEnv)
+    (cfg0 : Config)
+    (t : Nat) : List Action :=
+  sourceObs src (sourceCfgAt src inputs natInputs cfg0 t)
+
+def fsmTraceObs
+    (fsm : LoweredFsm)
+    (inputs : Nat -> Env)
+    (natInputs : Nat -> NatEnv)
+    (cfg0 : Config)
+    (t : Nat) : List Action :=
+  fsmObs fsm (fsmCfgAt fsm inputs natInputs cfg0 t)
+
+theorem trace_equiv
+    {src : SourceThread}
+    {fsm : LoweredFsm}
+    (cert : LoweringCertifies src fsm)
+    (inputs : Nat -> Env)
+    (natInputs : Nat -> NatEnv)
+    (cfg0 : Config) :
+    forall t, sourceTraceObs src inputs natInputs cfg0 t = fsmTraceObs fsm inputs natInputs cfg0 t := by
+  intro t
+  have hcfg := cfg_trace_equiv cert inputs natInputs cfg0 t
+  simp [sourceTraceObs, fsmTraceObs, hcfg]
+  exact (one_step_equiv cert (fun _ => false) (fun _ => 0) (fsmCfgAt fsm inputs natInputs cfg0 t)).left
+
+def reqGuard : Guard := 0
+def reqGuardExpr : GuardExpr := GuardExpr.atom reqGuard
+
+def exampleSource : SourceThread :=
+  { numStates := 4
+    once := false
+    state := fun pc =>
+      if pc = 0 then
+        { actions := [10], control := Control.waitUntil reqGuardExpr }
+      else if pc = 1 then
+        { actions := [20], control := Control.waitCycles 3 }
+      else if pc = 2 then
+        { actions := [30], control := Control.dispatch [
+            { guard := GuardExpr.atom 1, target := 0 },
+            { guard := GuardExpr.atom 2, target := 3 },
+          ] }
+      else
+        { actions := [40], control := Control.advance } }
+
+def exampleFsm : LoweredFsm :=
+  { state := fun pc =>
+      if pc = 0 then
+        { actions := [10], control := Control.waitUntil reqGuardExpr, target := 1 }
+      else if pc = 1 then
+        { actions := [20], control := Control.waitCycles 3, target := 2 }
+      else if pc = 2 then
+        { actions := [30], control := Control.dispatch [
+            { guard := GuardExpr.atom 1, target := 0 },
+            { guard := GuardExpr.atom 2, target := 3 },
+          ], target := sourceNext exampleSource pc }
+      else
+        { actions := [40], control := Control.advance, target := sourceNext exampleSource pc } }
+
+example : LoweringCertifies exampleSource exampleFsm := by
+  refine
+    { actions_ok := ?_
+      control_ok := ?_
+      dispatch_branches_ok := ?_
+      target_ok := ?_ }
+  · intro pc
+    by_cases h0 : pc = 0 <;> by_cases h1 : pc = 1 <;> by_cases h2 : pc = 2 <;>
+      simp [exampleSource, exampleFsm, h0, h1, h2]
+  · intro pc
+    by_cases h0 : pc = 0 <;> by_cases h1 : pc = 1 <;> by_cases h2 : pc = 2 <;>
+      simp [exampleSource, exampleFsm, h0, h1, h2]
+  · intro pc
+    by_cases h0 : pc = 0 <;> by_cases h1 : pc = 1 <;> by_cases h2 : pc = 2 <;>
+      simp [exampleSource, exampleFsm, dispatchBranches, h0, h1, h2]
+  · intro pc
+    by_cases h0 : pc = 0 <;> by_cases h1 : pc = 1 <;> by_cases h2 : pc = 2 <;>
+      simp [exampleSource, exampleFsm, sourceNext, h0, h1, h2]
+
+end Arch.ThreadLoweringProof.CountedWait

--- a/proofs/lean_thread_lowering/ArchThreadLoweringProof/FoldedExit.lean
+++ b/proofs/lean_thread_lowering/ArchThreadLoweringProof/FoldedExit.lean
@@ -1,0 +1,316 @@
+/-!
+Folded wait-exit assignment proof for ARCH thread-to-FSM lowering.
+
+The Rust lowering has an optimization (`fold_wait_until_exit_assignments`) that
+moves a pure action state's sequential assignments into the preceding
+`wait until` state's exit arm, then skips the absorbed action state. This file
+models that timing shape with an abstract register store and proves that a
+certified folded FSM step matches the source thread step for every environment
+and configuration.
+-/
+
+namespace Arch.ThreadLoweringProof.FoldedExit
+
+abbrev Guard := Nat
+abbrev Var := Nat
+abbrev Value := Nat
+abbrev Env := Guard -> Bool
+abbrev NatEnv := Nat -> Nat
+abbrev Store := Var -> Value
+abbrev Update := Store -> Store
+
+inductive NatExpr where
+  | var (name : Nat)
+  | const (value : Nat)
+deriving Repr, BEq
+
+def NatExpr.eval (env : NatEnv) : NatExpr -> Nat
+  | NatExpr.var name => env name
+  | NatExpr.const value => value
+
+inductive GuardExpr where
+  | atom (guard : Guard)
+  | trueLit
+  | falseLit
+  | neg (expr : GuardExpr)
+  | and (lhs rhs : GuardExpr)
+  | or (lhs rhs : GuardExpr)
+  | lt (lhs rhs : NatExpr)
+  | ge (lhs rhs : NatExpr)
+  | eq (lhs rhs : NatExpr)
+  | ne (lhs rhs : NatExpr)
+deriving Repr, BEq
+
+def GuardExpr.eval (env : Env) (expr : GuardExpr) (natEnv : NatEnv := fun _ => 0) : Bool :=
+  match expr with
+  | GuardExpr.atom guard => env guard
+  | GuardExpr.trueLit => true
+  | GuardExpr.falseLit => false
+  | GuardExpr.neg expr => !(GuardExpr.eval env expr natEnv)
+  | GuardExpr.and lhs rhs => GuardExpr.eval env lhs natEnv && GuardExpr.eval env rhs natEnv
+  | GuardExpr.or lhs rhs => GuardExpr.eval env lhs natEnv || GuardExpr.eval env rhs natEnv
+  | GuardExpr.lt lhs rhs => decide (NatExpr.eval natEnv lhs < NatExpr.eval natEnv rhs)
+  | GuardExpr.ge lhs rhs => decide (NatExpr.eval natEnv rhs <= NatExpr.eval natEnv lhs)
+  | GuardExpr.eq lhs rhs => decide (NatExpr.eval natEnv lhs = NatExpr.eval natEnv rhs)
+  | GuardExpr.ne lhs rhs => decide (NatExpr.eval natEnv lhs ≠ NatExpr.eval natEnv rhs)
+
+def applyUpdates (updates : List Update) (store : Store) : Store :=
+  updates.foldl (fun acc update => update acc) store
+
+inductive Control where
+  | advance
+  | waitUntil (guard : GuardExpr)
+deriving Repr, BEq
+
+structure SourceState where
+  updates : List Update
+  exitUpdates : List Update
+  control : Control
+
+structure SourceThread where
+  numStates : Nat
+  state : Nat -> SourceState
+
+structure FsmState where
+  updates : List Update
+  foldedExitUpdates : List Update
+  control : Control
+  target : Nat
+  foldedTarget : Option Nat
+
+structure LoweredFsm where
+  state : Nat -> FsmState
+
+structure Config where
+  pc : Nat
+  store : Store
+
+def sourceNext (src : SourceThread) (pc : Nat) : Nat :=
+  if pc + 1 < src.numStates then pc + 1 else 0
+
+def sourceAdvanceTo
+    (src : SourceThread)
+    (cfg : Config)
+    (target : Nat)
+    (exitUpdates : List Update) : Config :=
+  let base := applyUpdates (src.state cfg.pc).updates cfg.store
+  { pc := target, store := applyUpdates exitUpdates base }
+
+def fsmAdvanceTo
+    (fsm : LoweredFsm)
+    (cfg : Config)
+    (target : Nat)
+    (exitUpdates : List Update) : Config :=
+  let base := applyUpdates (fsm.state cfg.pc).updates cfg.store
+  { pc := target, store := applyUpdates exitUpdates base }
+
+def sourceStep (src : SourceThread) (env : Env) (natEnv : NatEnv) (cfg : Config) : Config :=
+  match (src.state cfg.pc).control with
+  | Control.advance =>
+      sourceAdvanceTo src cfg (sourceNext src cfg.pc) []
+  | Control.waitUntil guard =>
+      if GuardExpr.eval env guard natEnv then
+        sourceAdvanceTo src cfg (sourceNext src cfg.pc) (src.state cfg.pc).exitUpdates
+      else
+        cfg
+
+def fsmStep (fsm : LoweredFsm) (env : Env) (natEnv : NatEnv) (cfg : Config) : Config :=
+  let state := fsm.state cfg.pc
+  match state.control with
+  | Control.advance =>
+      fsmAdvanceTo fsm cfg state.target []
+  | Control.waitUntil guard =>
+      if GuardExpr.eval env guard natEnv then
+        let target := state.foldedTarget.getD state.target
+        fsmAdvanceTo fsm cfg target state.foldedExitUpdates
+      else
+        cfg
+
+structure LoweringCertifies (src : SourceThread) (fsm : LoweredFsm) : Prop where
+  updates_ok : forall pc, (fsm.state pc).updates = (src.state pc).updates
+  control_ok : forall pc, (fsm.state pc).control = (src.state pc).control
+  target_ok : forall pc, (fsm.state pc).target = sourceNext src pc
+  folded_updates_ok :
+    forall pc, (fsm.state pc).foldedExitUpdates = (src.state pc).exitUpdates
+  folded_target_ok :
+    forall pc,
+      (src.state pc).exitUpdates = [] ->
+        (fsm.state pc).foldedTarget = none
+      \/ (fsm.state pc).foldedTarget = some (sourceNext src pc)
+  folded_target_some_ok :
+    forall pc target,
+      (fsm.state pc).foldedTarget = some target ->
+        target = sourceNext src pc
+
+theorem advance_equiv
+    {src : SourceThread}
+    {fsm : LoweredFsm}
+    (cert : LoweringCertifies src fsm)
+    (cfg : Config)
+    (target : Nat)
+    (exitUpdates : List Update)
+    (htarget : target = sourceNext src cfg.pc) :
+    sourceAdvanceTo src cfg (sourceNext src cfg.pc) exitUpdates
+      = fsmAdvanceTo fsm cfg target exitUpdates := by
+  simp [sourceAdvanceTo, fsmAdvanceTo, cert.updates_ok cfg.pc, htarget]
+
+theorem folded_target_value
+    {src : SourceThread}
+    {fsm : LoweredFsm}
+    (cert : LoweringCertifies src fsm)
+    (pc : Nat) :
+    (fsm.state pc).foldedTarget.getD (fsm.state pc).target = sourceNext src pc := by
+  cases hfold : (fsm.state pc).foldedTarget with
+  | none =>
+      simp [cert.target_ok pc]
+  | some target =>
+      have htarget := cert.folded_target_some_ok pc target hfold
+      simp [htarget]
+
+theorem one_step_equiv
+    {src : SourceThread}
+    {fsm : LoweredFsm}
+    (cert : LoweringCertifies src fsm)
+    (env : Env)
+    (natEnv : NatEnv)
+    (cfg : Config) :
+    sourceStep src env natEnv cfg = fsmStep fsm env natEnv cfg := by
+  cases h : (src.state cfg.pc).control with
+  | advance =>
+      simp [
+        sourceStep,
+        fsmStep,
+        h,
+        cert.control_ok cfg.pc,
+        cert.target_ok cfg.pc,
+        advance_equiv cert cfg (sourceNext src cfg.pc) [] rfl,
+      ]
+  | waitUntil guard =>
+      by_cases henv : GuardExpr.eval env guard natEnv
+      · have htarget :
+            (fsm.state cfg.pc).foldedTarget.getD (fsm.state cfg.pc).target
+              = sourceNext src cfg.pc :=
+          folded_target_value cert cfg.pc
+        simp [
+          sourceStep,
+          fsmStep,
+          h,
+          henv,
+          cert.control_ok cfg.pc,
+          cert.folded_updates_ok cfg.pc,
+          htarget,
+          advance_equiv cert cfg
+            ((fsm.state cfg.pc).foldedTarget.getD (fsm.state cfg.pc).target)
+            (src.state cfg.pc).exitUpdates
+            htarget,
+        ]
+      · simp [sourceStep, fsmStep, h, henv, cert.control_ok cfg.pc]
+
+def sourceCfgAt
+    (src : SourceThread)
+    (inputs : Nat -> Env)
+    (natInputs : Nat -> NatEnv)
+    (cfg0 : Config) : Nat -> Config
+  | 0 => cfg0
+  | Nat.succ t => sourceStep src (inputs t) (natInputs t) (sourceCfgAt src inputs natInputs cfg0 t)
+
+def fsmCfgAt
+    (fsm : LoweredFsm)
+    (inputs : Nat -> Env)
+    (natInputs : Nat -> NatEnv)
+    (cfg0 : Config) : Nat -> Config
+  | 0 => cfg0
+  | Nat.succ t => fsmStep fsm (inputs t) (natInputs t) (fsmCfgAt fsm inputs natInputs cfg0 t)
+
+theorem cfg_trace_equiv
+    {src : SourceThread}
+    {fsm : LoweredFsm}
+    (cert : LoweringCertifies src fsm)
+    (inputs : Nat -> Env)
+    (natInputs : Nat -> NatEnv)
+    (cfg0 : Config) :
+    forall t, sourceCfgAt src inputs natInputs cfg0 t = fsmCfgAt fsm inputs natInputs cfg0 t := by
+  intro t
+  induction t with
+  | zero => rfl
+  | succ t ih =>
+      simp [sourceCfgAt, fsmCfgAt]
+      rw [ih]
+      exact one_step_equiv cert (inputs t) (natInputs t) (fsmCfgAt fsm inputs natInputs cfg0 t)
+
+def setVar (var : Var) (value : Value) : Update :=
+  fun store name => if name = var then value else store name
+
+theorem setVar_same (var : Var) (value : Value) (store : Store) :
+    setVar var value store var = value := by
+  simp [setVar]
+
+theorem setVar_other
+    {var other : Var}
+    (value : Value)
+    (store : Store)
+    (h : other ≠ var) :
+    setVar var value store other = store other := by
+  simp [setVar, h]
+
+theorem applyUpdates_single_setVar_same
+    (var : Var)
+    (value : Value)
+    (store : Store) :
+    applyUpdates [setVar var value] store var = value := by
+  simp [applyUpdates, setVar]
+
+def reqGuard : Guard := 0
+def reqGuardExpr : GuardExpr := GuardExpr.atom reqGuard
+def outVar : Var := 0
+
+def exampleSource : SourceThread :=
+  { numStates := 2
+    state := fun pc =>
+      if pc = 0 then
+        { updates := []
+          exitUpdates := [setVar outVar 42]
+          control := Control.waitUntil reqGuardExpr }
+      else
+        { updates := []
+          exitUpdates := []
+          control := Control.advance } }
+
+def exampleFsm : LoweredFsm :=
+  { state := fun pc =>
+      if pc = 0 then
+        { updates := []
+          foldedExitUpdates := [setVar outVar 42]
+          control := Control.waitUntil reqGuardExpr
+          target := 1
+          foldedTarget := some 1 }
+      else
+        { updates := []
+          foldedExitUpdates := []
+          control := Control.advance
+          target := sourceNext exampleSource pc
+          foldedTarget := none } }
+
+example : LoweringCertifies exampleSource exampleFsm := by
+  refine
+    { updates_ok := ?_
+      control_ok := ?_
+      target_ok := ?_
+      folded_updates_ok := ?_
+      folded_target_ok := ?_
+      folded_target_some_ok := ?_ }
+  · intro pc
+    by_cases h : pc = 0 <;> simp [exampleSource, exampleFsm, h]
+  · intro pc
+    by_cases h : pc = 0 <;> simp [exampleSource, exampleFsm, h]
+  · intro pc
+    by_cases h : pc = 0 <;> simp [exampleSource, exampleFsm, sourceNext, h]
+  · intro pc
+    by_cases h : pc = 0 <;> simp [exampleSource, exampleFsm, h]
+  · intro pc hupdates
+    by_cases h : pc = 0 <;> simp [exampleSource, exampleFsm, sourceNext, h] at *
+  · intro pc target hfold
+    by_cases h : pc = 0 <;> simp [exampleSource, exampleFsm, sourceNext, h] at *
+    exact hfold.symm
+
+end Arch.ThreadLoweringProof.FoldedExit

--- a/proofs/lean_thread_lowering/ArchThreadLoweringProof/Simple.lean
+++ b/proofs/lean_thread_lowering/ArchThreadLoweringProof/Simple.lean
@@ -1,0 +1,160 @@
+/-!
+Prototype certificate model for ARCH thread-to-FSM lowering.
+
+This file intentionally models a very small fragment first: straight-line
+thread states with per-cycle observable actions and optional `wait until`
+guards. The lowered FSM is accepted by a certificate predicate that ties each
+runtime state back to the source state it claims to implement.
+
+The theorem at the bottom is the shape we want for the real backend:
+if the generated FSM table satisfies the certificate, then source thread
+execution and lowered FSM execution have the same observable trace for every
+input stream and every cycle.
+-/
+
+namespace Arch.ThreadLoweringProof
+
+abbrev Action := Nat
+abbrev Guard := Nat
+abbrev Env := Guard -> Bool
+
+structure ThreadState where
+  actions : List Action
+  wait : Option Guard
+deriving Repr, BEq
+
+structure SourceThread where
+  numStates : Nat
+  state : Nat -> ThreadState
+
+structure FsmState where
+  actions : List Action
+  wait : Option Guard
+  target : Nat
+deriving Repr, BEq
+
+structure LoweredFsm where
+  state : Nat -> FsmState
+
+def sourceNext (src : SourceThread) (pc : Nat) : Nat :=
+  if pc + 1 < src.numStates then pc + 1 else 0
+
+def sourceObs (src : SourceThread) (pc : Nat) : List Action :=
+  (src.state pc).actions
+
+def fsmObs (fsm : LoweredFsm) (pc : Nat) : List Action :=
+  (fsm.state pc).actions
+
+def sourceStep (src : SourceThread) (env : Env) (pc : Nat) : Nat :=
+  match (src.state pc).wait with
+  | none => sourceNext src pc
+  | some guard => if env guard then sourceNext src pc else pc
+
+def fsmStep (fsm : LoweredFsm) (env : Env) (pc : Nat) : Nat :=
+  let state := fsm.state pc
+  match state.wait with
+  | none => state.target
+  | some guard => if env guard then state.target else pc
+
+structure LoweringCertifies (src : SourceThread) (fsm : LoweredFsm) : Prop where
+  actions_ok : forall pc, (fsm.state pc).actions = (src.state pc).actions
+  wait_ok : forall pc, (fsm.state pc).wait = (src.state pc).wait
+  target_ok : forall pc, (fsm.state pc).target = sourceNext src pc
+
+theorem one_step_equiv
+    {src : SourceThread}
+    {fsm : LoweredFsm}
+    (cert : LoweringCertifies src fsm)
+    (env : Env)
+    (pc : Nat) :
+    sourceObs src pc = fsmObs fsm pc
+      /\ sourceStep src env pc = fsmStep fsm env pc := by
+  constructor
+  · simp [sourceObs, fsmObs, cert.actions_ok pc]
+  · simp [sourceStep, fsmStep, cert.wait_ok pc, cert.target_ok pc]
+
+def sourcePcAt
+    (src : SourceThread)
+    (inputs : Nat -> Env)
+    (pc0 : Nat) : Nat -> Nat
+  | 0 => pc0
+  | Nat.succ t => sourceStep src (inputs t) (sourcePcAt src inputs pc0 t)
+
+def fsmPcAt
+    (fsm : LoweredFsm)
+    (inputs : Nat -> Env)
+    (pc0 : Nat) : Nat -> Nat
+  | 0 => pc0
+  | Nat.succ t => fsmStep fsm (inputs t) (fsmPcAt fsm inputs pc0 t)
+
+theorem pc_trace_equiv
+    {src : SourceThread}
+    {fsm : LoweredFsm}
+    (cert : LoweringCertifies src fsm)
+    (inputs : Nat -> Env)
+    (pc0 : Nat) :
+    forall t, sourcePcAt src inputs pc0 t = fsmPcAt fsm inputs pc0 t := by
+  intro t
+  induction t with
+  | zero => rfl
+  | succ t ih =>
+      simp [sourcePcAt, fsmPcAt]
+      rw [ih]
+      exact (one_step_equiv cert (inputs t) (fsmPcAt fsm inputs pc0 t)).right
+
+def sourceTraceObs
+    (src : SourceThread)
+    (inputs : Nat -> Env)
+    (pc0 : Nat)
+    (t : Nat) : List Action :=
+  sourceObs src (sourcePcAt src inputs pc0 t)
+
+def fsmTraceObs
+    (fsm : LoweredFsm)
+    (inputs : Nat -> Env)
+    (pc0 : Nat)
+    (t : Nat) : List Action :=
+  fsmObs fsm (fsmPcAt fsm inputs pc0 t)
+
+theorem trace_equiv
+    {src : SourceThread}
+    {fsm : LoweredFsm}
+    (cert : LoweringCertifies src fsm)
+    (inputs : Nat -> Env)
+    (pc0 : Nat) :
+    forall t, sourceTraceObs src inputs pc0 t = fsmTraceObs fsm inputs pc0 t := by
+  intro t
+  have hpc := pc_trace_equiv cert inputs pc0 t
+  simp [sourceTraceObs, fsmTraceObs, hpc]
+  exact (one_step_equiv cert (fun _ => false) (fsmPcAt fsm inputs pc0 t)).left
+
+def reqGuard : Guard := 0
+
+def exampleSource : SourceThread :=
+  { numStates := 2
+    state := fun pc =>
+      if pc = 0 then
+        { actions := [10], wait := some reqGuard }
+      else
+        { actions := [20], wait := none } }
+
+def exampleFsm : LoweredFsm :=
+  { state := fun pc =>
+      if pc = 0 then
+        { actions := [10], wait := some reqGuard, target := 1 }
+      else
+        { actions := [20], wait := none, target := sourceNext exampleSource pc } }
+
+example : LoweringCertifies exampleSource exampleFsm := by
+  refine
+    { actions_ok := ?_
+      wait_ok := ?_
+      target_ok := ?_ }
+  · intro pc
+    by_cases h : pc = 0 <;> simp [exampleSource, exampleFsm, h]
+  · intro pc
+    by_cases h : pc = 0 <;> simp [exampleSource, exampleFsm, h]
+  · intro pc
+    by_cases h : pc = 0 <;> simp [exampleSource, exampleFsm, sourceNext, h]
+
+end Arch.ThreadLoweringProof

--- a/proofs/lean_thread_lowering/README.md
+++ b/proofs/lean_thread_lowering/README.md
@@ -1,0 +1,177 @@
+# Lean Thread Lowering Prototype
+
+This is a proof-of-concept Lean project for machine-checking ARCH thread-to-FSM
+lowering certificates.
+
+The first file, `ArchThreadLoweringProof/Simple.lean`, proves a small but useful
+theorem:
+
+> if a lowered FSM table is certified to implement each source thread state,
+> then the source thread semantics and lowered FSM semantics produce the same
+> observable trace for every input stream and every cycle.
+
+`ArchThreadLoweringProof/CountedWait.lean` extends the same theorem shape to
+include explicit runtime configuration state (`pc` plus the wait counter) and
+`wait N cycle` semantics. It also models `multi_transitions` as a deterministic
+guarded dispatch list with a certified fall-through target.
+
+`ArchThreadLoweringProof/FoldedExit.lean` adds an abstract register store and
+proves the timing shape used by `fold_wait_until_exit_assignments`: sequential
+updates folded into a `wait until` state's exit arm commit on the same edge as
+the source thread's post-wait exit update.
+
+The prototype currently covers:
+
+- straight-line states,
+- observable per-state actions,
+- optional `wait until` guards,
+- counted `wait N cycle` states with counter load/decrement/exit behavior,
+- single guarded non-dispatch jumps that hold when the guard is false,
+- unconditional non-natural jumps, used for fork/join rejoin edges,
+- multi-transition dispatch states,
+- folded wait-exit sequential updates,
+- repeating fall-through to state zero.
+
+That is enough to establish the architecture: Rust lowering should eventually
+emit a compact certificate for the actual generated `ThreadFsmState` table, and
+Lean should prove that accepting the certificate implies trace equivalence.
+
+## How To Check
+
+Install Lean via `elan`, then run:
+
+```sh
+cd proofs/lean_thread_lowering
+lake build
+```
+
+To emit and replay a compiler-emitted Lean certificate directly:
+
+```sh
+arch build Foo.arch --emit-thread-proof-lean=Foo.thread-proof.lean
+cd proofs/lean_thread_lowering
+lake env lean /path/to/Foo.thread-proof.lean
+```
+
+For the compiler to run the replay immediately after emission:
+
+```sh
+arch build Foo.arch \
+  --check-thread-proof-lean \
+  --thread-proof-lean-project=proofs/lean_thread_lowering
+```
+
+The same Lean thread-lowering proof path is also available from the formal
+entry point:
+
+```sh
+arch formal Foo.arch --emit-thread-proof-lean=Foo.thread-proof.lean
+arch formal Foo.arch \
+  --check-thread-proof-lean \
+  --thread-proof-lean-project=proofs/lean_thread_lowering
+arch formal Foo.arch \
+  --check-thread-proof-lean \
+  --thread-proof-lean-project=proofs/lean_thread_lowering \
+  --thread-proof-only
+```
+
+`--check-thread-proof-lean` implies Lean proof emission. If
+`--thread-proof-lean-project` is omitted, the compiler uses
+`ARCH_THREAD_PROOF_LEAN_PROJECT` when set, otherwise
+`proofs/lean_thread_lowering` relative to the current working directory.
+`--thread-proof-only` is available on `arch formal` when the desired formal
+backend is only the Lean lowering replay; it skips the SMT-LIB2 design-property
+backend after the Lean artifact is emitted and checked.
+
+The JSON sidecar and Python bridge remain useful for debugging certificate
+schema changes:
+
+```sh
+arch build Foo.arch --emit-thread-proof=Foo.thread-proof.json
+python3 proofs/lean_thread_lowering/scripts/cert_to_lean.py \
+  Foo.thread-proof.json \
+  -o proofs/lean_thread_lowering/ArchThreadLoweringProof/GeneratedFoo.lean
+cd proofs/lean_thread_lowering
+lake env lean ArchThreadLoweringProof/GeneratedFoo.lean
+```
+
+The bridge regression suite can also execute Lean when `lake` is on `PATH`:
+it checks that a matching generated certificate replays successfully and that
+an intentionally mismatched source/FSM dispatch certificate is rejected.
+
+The generated file proves the compiler-recorded lowered FSM table against the
+`CountedWait` source model, including repeating versus `thread once`
+terminal-hold behavior. FSM targets are emitted from the certificate and Lean
+proves they match `sourceNext`; dispatch branch target lists are also an
+explicit Lean certificate obligation. Guard/action/update/variable/value names
+are interned through per-generated-file symbol tables, so equal source strings
+map to equal abstract Lean `Nat`s and distinct source strings cannot collide.
+For transition guards, schema v5 certificates and direct Rust-emitted Lean
+artifacts use the structured `condition_guard` term as the control-proof
+identity, while older JSON certificates fall back to parsed labels in the
+Python bridge for compatibility. v5 requires `condition_guard` on every
+non-counted transition, so a current source/FSM certificate with the same
+display label but different machine-readable guard structure no longer replays.
+For structured or parseable dispatch guards, the Python converter also emits small
+`GuardExpr.eval` proofs for branch pairs with an obvious contradiction. Boolean
+contradictions cover `x` versus `!x`, such as `aw_ready && w_ready` versus
+`w_ready && !aw_ready`. Simple Nat comparison contradictions cover loop-style
+conditions such as `_t0_loop_cnt_1 < 3.resize(2)` versus
+`_t0_loop_cnt_1 >= 3.resize(2)`, proved with Lean's `omega` after expression
+simplification. Newer compiler sidecars carry a structured
+`condition_guard` term (`atom`, `true`, `false`, `not`, `and`, `or`, `lt`,
+`ge`, `eq`, `ne`) derived from the Rust AST. This is still a small untyped
+guard subset, not full typed ARCH expression semantics.
+The Python bridge rejects non-dispatch target mismatches before Lean
+generation. Schema v3+ certificates carry an explicit
+`source_next_index`/`source_next_name` for each state; the bridge
+requires that source-next target to resolve to the natural next emitted compact
+state before using it as the source model's fall-through target. Schema v4+
+also carries `source_transitions` separately from lowered `transitions`; the
+generated Lean source model is built from the former and the lowered FSM model
+from the latter. In the Rust emitter, `source_transitions` are snapshotted
+before folded wait-exit assignment optimization and then compacted across
+folded states, while lowered `transitions` are read from the post-fold FSM
+table. The bridge requires `source_transition_origin: "pre_fold_snapshot"` for
+v4+ states so this provenance is checked, not merely documented. State tables
+must be contiguous raw FSM tables starting at state 0, with raw state 0 emitted
+as the first compact state.
+Transition targets must resolve to emitted states after folded-state
+compaction; unknown or non-emitted targets are hard certificate errors.
+Emitted states are role-checked: non-dispatch states must have exactly one
+transition, dispatch states must have at least two, and transition objects must
+carry condition, target index, and target name fields. A non-dispatch transition
+whose guard is not `always` may target a non-natural compact state; the bridge
+models this as a `Control.guarded` state, whose false branch holds the current
+state and whose true branch jumps to the recorded target. A non-dispatch
+transition whose condition is literal true (`always`, `true`, `1'b1`, or `1`)
+and whose target is non-natural is modeled as `Control.jump target`, preserving
+fork/join rejoin edges without turning the true literal into an unconstrained
+abstract guard.
+Counted-wait durations come from the structured `wait_cycles_count` field, not
+human-readable labels. The converter also emits per-edge `FoldedExit`
+store-effect proofs for folded wait-exit update lists present in the
+certificate. Direct assignments are replayed as structured `setVar target
+value` store updates. Folded wait-exit updates are accepted only when every
+update has a structured assignment representation; unsupported nested
+statements are rejected rather than proved through opaque identities.
+When a runtime state's direct `seq_assignments` are present, they must cover the
+entire `seq_updates` list; partial structured coverage is rejected so generated
+action observations cannot silently drop unsupported nested statements. The
+direct Rust Lean emitter also turns those structured assignments into concrete
+`setVar` update lists and emits per-state `applyUpdates` examples proving the
+final store value for every variable written by the action state. For repeated
+writes to the same variable in one state, the generated obligation follows the
+lowered update order and proves the final write.
+Generated certificate proofs use a linear nested case split over state numbers,
+so larger real thread tables such as fork/join products replay without the
+exponential blow-up of a chained `<;>` tactic.
+
+## Next Extensions
+
+Good next proof increments:
+
+- extend `GuardExpr` comparison support from label-level Nat variables and
+  constants to typed ARCH bit-vector expression semantics,
+- replace abstract symbol IDs with full ARCH guard and assignment expression
+  semantics.

--- a/proofs/lean_thread_lowering/lake-manifest.json
+++ b/proofs/lean_thread_lowering/lake-manifest.json
@@ -1,0 +1,6 @@
+{"version": "1.2.0",
+ "packagesDir": ".lake/packages",
+ "packages": [],
+ "name": "arch_thread_lowering_proof",
+ "lakeDir": ".lake",
+ "fixedToolchain": false}

--- a/proofs/lean_thread_lowering/lakefile.toml
+++ b/proofs/lean_thread_lowering/lakefile.toml
@@ -1,0 +1,6 @@
+name = "arch_thread_lowering_proof"
+version = "0.1.0"
+defaultTargets = ["ArchThreadLoweringProof"]
+
+[[lean_lib]]
+name = "ArchThreadLoweringProof"

--- a/proofs/lean_thread_lowering/lean-toolchain
+++ b/proofs/lean_thread_lowering/lean-toolchain
@@ -1,0 +1,1 @@
+leanprover/lean4:v4.30.0

--- a/proofs/lean_thread_lowering/scripts/cert_to_lean.py
+++ b/proofs/lean_thread_lowering/scripts/cert_to_lean.py
@@ -1,0 +1,1417 @@
+#!/usr/bin/env python3
+"""Convert an ARCH thread-proof JSON sidecar into Lean proof replay files.
+
+This is a prototype bridge between `arch build --emit-thread-proof` and the
+Lean thread-lowering proof models. It checks the abstract control table through
+the `CountedWait` model and, for certificates that include folded wait-exit
+updates, emits `FoldedExit` store-effect replay proofs as well.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+
+GuardExprNode = tuple[str, Any]
+NatExprNode = tuple[str, Any]
+
+
+class SymbolTable:
+    """Injective string-to-Nat assignment for one generated Lean file."""
+
+    def __init__(self) -> None:
+        self._ids: dict[str, int] = {}
+
+    def id(self, value: str) -> int:
+        if value not in self._ids:
+            self._ids[value] = len(self._ids)
+        return self._ids[value]
+
+
+def lean_ident(name: str) -> str:
+    cleaned = re.sub(r"[^A-Za-z0-9_]", "_", name)
+    if not cleaned or cleaned[0].isdigit():
+        cleaned = f"cert_{cleaned}"
+    return cleaned
+
+
+def strip_outer_parens(value: str) -> str:
+    s = value.strip()
+    while s.startswith("(") and s.endswith(")"):
+        depth = 0
+        wraps = True
+        for idx, ch in enumerate(s):
+            if ch == "(":
+                depth += 1
+            elif ch == ")":
+                depth -= 1
+                if depth == 0 and idx != len(s) - 1:
+                    wraps = False
+                    break
+            if depth < 0:
+                wraps = False
+                break
+        if not wraps or depth != 0:
+            break
+        s = s[1:-1].strip()
+    return s
+
+
+def split_top_level(value: str, op: str) -> list[str] | None:
+    parts: list[str] = []
+    depth = 0
+    start = 0
+    idx = 0
+    while idx < len(value):
+        ch = value[idx]
+        if ch == "(":
+            depth += 1
+            idx += 1
+            continue
+        if ch == ")":
+            depth -= 1
+            idx += 1
+            continue
+        if depth == 0 and value.startswith(op, idx):
+            parts.append(value[start:idx].strip())
+            idx += len(op)
+            start = idx
+            continue
+        idx += 1
+    if not parts:
+        return None
+    parts.append(value[start:].strip())
+    return parts
+
+
+def split_top_level_comparison(value: str) -> tuple[str, str, str] | None:
+    depth = 0
+    idx = 0
+    ops = (">=", "<=", "==", "!=", "<", ">")
+    while idx < len(value):
+        ch = value[idx]
+        if ch == "(":
+            depth += 1
+            idx += 1
+            continue
+        if ch == ")":
+            depth -= 1
+            idx += 1
+            continue
+        if depth == 0:
+            for op in ops:
+                if value.startswith(op, idx):
+                    return value[:idx].strip(), op, value[idx + len(op):].strip()
+        idx += 1
+    return None
+
+
+def parse_nat_expr(value: str, nat_ids: SymbolTable) -> NatExprNode:
+    s = strip_outer_parens(value)
+    sized_dec = re.fullmatch(r"[0-9]+'d([0-9]+)(?:\.(?:resize|trunc)\([0-9]+\))?", s)
+    if sized_dec:
+        return ("const", int(sized_dec.group(1)))
+    plain = re.fullmatch(r"([0-9]+)(?:\.(?:resize|trunc)\([0-9]+\))?", s)
+    if plain:
+        return ("const", int(plain.group(1)))
+    return ("var", nat_ids.id(s))
+
+
+def nat_expr_from_json(value: Any, nat_ids: SymbolTable) -> NatExprNode:
+    if not isinstance(value, dict):
+        raise SystemExit(f"condition_guard Nat expression must be an object, got {value!r}")
+    kind = value.get("kind")
+    if kind == "const":
+        if "value" not in value:
+            raise SystemExit(f"const Nat expression missing value: {value!r}")
+        const_value = value["value"]
+        if not isinstance(const_value, int) or isinstance(const_value, bool):
+            raise SystemExit(f"const Nat expression value must be an integer: {value!r}")
+        if const_value < 0:
+            raise SystemExit(f"const Nat expression value must be non-negative: {value!r}")
+        return ("const", const_value)
+    if kind == "var":
+        if "name" not in value:
+            raise SystemExit(f"var Nat expression missing name: {value!r}")
+        if not isinstance(value["name"], str):
+            raise SystemExit(f"var Nat expression name must be a string: {value!r}")
+        return ("var", nat_ids.id(value["name"]))
+    raise SystemExit(f"unsupported condition_guard Nat expression kind: {kind!r}")
+
+
+def render_nat_expr_in_namespace(expr: NatExprNode, namespace: str = "") -> str:
+    nat_expr = f"{namespace}.NatExpr" if namespace else "NatExpr"
+    tag = expr[0]
+    if tag == "const":
+        return f"({nat_expr}.const {expr[1]})"
+    if tag == "var":
+        return f"({nat_expr}.var {expr[1]})"
+    raise ValueError(f"unknown Nat expression tag: {tag}")
+
+
+def render_nat_expr(expr: NatExprNode) -> str:
+    return render_nat_expr_in_namespace(expr)
+
+
+def parse_guard_expr(
+    condition: str,
+    guard_ids: SymbolTable,
+    nat_ids: SymbolTable,
+) -> GuardExprNode:
+    s = strip_outer_parens(condition)
+    if s in {"always", "true", "1'b1", "1"}:
+        return ("true",)
+    if s in {"false", "1'b0", "0"}:
+        return ("false",)
+    or_parts = split_top_level(s, "||")
+    if or_parts is not None:
+        expr = parse_guard_expr(or_parts[0], guard_ids, nat_ids)
+        for part in or_parts[1:]:
+            expr = ("or", expr, parse_guard_expr(part, guard_ids, nat_ids))
+        return expr
+    and_parts = split_top_level(s, "&&")
+    if and_parts is not None:
+        expr = parse_guard_expr(and_parts[0], guard_ids, nat_ids)
+        for part in and_parts[1:]:
+            expr = ("and", expr, parse_guard_expr(part, guard_ids, nat_ids))
+        return expr
+    if s.startswith("!"):
+        return ("not", parse_guard_expr(s[1:], guard_ids, nat_ids))
+    comparison = split_top_level_comparison(s)
+    if comparison is not None:
+        lhs, op, rhs = comparison
+        lhs_expr = parse_nat_expr(lhs, nat_ids)
+        rhs_expr = parse_nat_expr(rhs, nat_ids)
+        if op == "<":
+            return ("lt", lhs_expr, rhs_expr)
+        if op == ">=":
+            return ("ge", lhs_expr, rhs_expr)
+        if op == ">":
+            return ("lt", rhs_expr, lhs_expr)
+        if op == "<=":
+            return ("ge", rhs_expr, lhs_expr)
+        if op == "==":
+            return ("eq", lhs_expr, rhs_expr)
+        if op == "!=":
+            return ("ne", lhs_expr, rhs_expr)
+    return ("atom", guard_ids.id(s))
+
+
+def guard_expr_from_json(
+    value: Any,
+    guard_ids: SymbolTable,
+    nat_ids: SymbolTable,
+) -> GuardExprNode:
+    if not isinstance(value, dict):
+        raise SystemExit(f"condition_guard must be an object, got {value!r}")
+    kind = value.get("kind")
+    if kind == "atom":
+        if "name" not in value:
+            raise SystemExit(f"atom condition_guard missing name: {value!r}")
+        if not isinstance(value["name"], str):
+            raise SystemExit(f"atom condition_guard name must be a string: {value!r}")
+        return ("atom", guard_ids.id(value["name"]))
+    if kind == "true":
+        return ("true",)
+    if kind == "false":
+        return ("false",)
+    if kind == "not":
+        if "expr" not in value:
+            raise SystemExit(f"not condition_guard missing expr: {value!r}")
+        return ("not", guard_expr_from_json(value["expr"], guard_ids, nat_ids))
+    if kind in {"and", "or"}:
+        if "lhs" not in value or "rhs" not in value:
+            raise SystemExit(f"{kind} condition_guard missing lhs/rhs: {value!r}")
+        return (
+            kind,
+            guard_expr_from_json(value["lhs"], guard_ids, nat_ids),
+            guard_expr_from_json(value["rhs"], guard_ids, nat_ids),
+        )
+    if kind in {"lt", "ge", "eq", "ne"}:
+        if "lhs" not in value or "rhs" not in value:
+            raise SystemExit(f"{kind} condition_guard missing lhs/rhs: {value!r}")
+        return (
+            kind,
+            nat_expr_from_json(value["lhs"], nat_ids),
+            nat_expr_from_json(value["rhs"], nat_ids),
+        )
+    raise SystemExit(f"unsupported condition_guard kind: {kind!r}")
+
+
+def transition_guard_expr(
+    transition: dict[str, Any],
+    guard_atom_ids: SymbolTable,
+    nat_ids: SymbolTable,
+) -> GuardExprNode:
+    structured = transition.get("condition_guard")
+    if isinstance(structured, dict):
+        return guard_expr_from_json(structured, guard_atom_ids, nat_ids)
+    return parse_guard_expr(str(transition["condition"]), guard_atom_ids, nat_ids)
+
+
+def transition_guard_key(
+    transition: dict[str, Any],
+    guard_atom_ids: SymbolTable,
+    nat_ids: SymbolTable,
+) -> str:
+    return render_guard_expr(transition_guard_expr(transition, guard_atom_ids, nat_ids))
+
+
+def transition_is_unconditional(
+    transition: dict[str, Any],
+    guard_atom_ids: SymbolTable,
+    nat_ids: SymbolTable,
+) -> bool:
+    return transition_guard_expr(transition, guard_atom_ids, nat_ids)[0] == "true"
+
+
+def render_guard_expr_in_namespace(expr: GuardExprNode, namespace: str = "") -> str:
+    guard_expr = f"{namespace}.GuardExpr" if namespace else "GuardExpr"
+    tag = expr[0]
+    if tag == "true":
+        return f"{guard_expr}.trueLit"
+    if tag == "false":
+        return f"{guard_expr}.falseLit"
+    if tag == "atom":
+        return f"({guard_expr}.atom {expr[1]})"
+    if tag == "not":
+        return f"({guard_expr}.neg {render_guard_expr_in_namespace(expr[1], namespace)})"
+    if tag == "and":
+        return (
+            f"({guard_expr}.and {render_guard_expr_in_namespace(expr[1], namespace)} "
+            f"{render_guard_expr_in_namespace(expr[2], namespace)})"
+        )
+    if tag == "or":
+        return (
+            f"({guard_expr}.or {render_guard_expr_in_namespace(expr[1], namespace)} "
+            f"{render_guard_expr_in_namespace(expr[2], namespace)})"
+        )
+    if tag == "lt":
+        return (
+            f"({guard_expr}.lt {render_nat_expr_in_namespace(expr[1], namespace)} "
+            f"{render_nat_expr_in_namespace(expr[2], namespace)})"
+        )
+    if tag == "ge":
+        return (
+            f"({guard_expr}.ge {render_nat_expr_in_namespace(expr[1], namespace)} "
+            f"{render_nat_expr_in_namespace(expr[2], namespace)})"
+        )
+    if tag == "eq":
+        return (
+            f"({guard_expr}.eq {render_nat_expr_in_namespace(expr[1], namespace)} "
+            f"{render_nat_expr_in_namespace(expr[2], namespace)})"
+        )
+    if tag == "ne":
+        return (
+            f"({guard_expr}.ne {render_nat_expr_in_namespace(expr[1], namespace)} "
+            f"{render_nat_expr_in_namespace(expr[2], namespace)})"
+        )
+    raise ValueError(f"unknown guard expression tag: {tag}")
+
+
+def render_guard_expr(expr: GuardExprNode) -> str:
+    return render_guard_expr_in_namespace(expr)
+
+
+def guard_expr_atoms(expr: GuardExprNode) -> set[int]:
+    tag = expr[0]
+    if tag == "atom":
+        return {int(expr[1])}
+    if tag in {"true", "false", "lt", "ge", "eq", "ne"}:
+        return set()
+    if tag == "not":
+        return guard_expr_atoms(expr[1])
+    if tag in {"and", "or"}:
+        return guard_expr_atoms(expr[1]) | guard_expr_atoms(expr[2])
+    return set()
+
+
+def guard_requirements(expr: GuardExprNode) -> dict[int, bool] | None:
+    tag = expr[0]
+    if tag == "true":
+        return {}
+    if tag == "false":
+        return {}
+    if tag == "atom":
+        return {int(expr[1]): True}
+    if tag == "not":
+        inner = expr[1]
+        if inner[0] != "atom":
+            return None
+        return {int(inner[1]): False}
+    if tag in {"lt", "ge", "eq", "ne"}:
+        return {}
+    if tag == "and":
+        lhs = guard_requirements(expr[1])
+        rhs = guard_requirements(expr[2])
+        if lhs is None or rhs is None:
+            return None
+        merged = dict(lhs)
+        for atom, value in rhs.items():
+            if atom in merged and merged[atom] != value:
+                return None
+            merged[atom] = value
+        return merged
+    return None
+
+
+def guard_comparisons(expr: GuardExprNode) -> set[tuple[str, NatExprNode, NatExprNode]] | None:
+    tag = expr[0]
+    if tag in {"true", "false", "atom"}:
+        return set()
+    if tag in {"lt", "ge", "eq", "ne"}:
+        return {(tag, expr[1], expr[2])}
+    if tag == "and":
+        lhs = guard_comparisons(expr[1])
+        rhs = guard_comparisons(expr[2])
+        if lhs is None or rhs is None:
+            return None
+        return lhs | rhs
+    return None
+
+
+def guards_syntactically_exclusive(lhs: GuardExprNode, rhs: GuardExprNode) -> bool:
+    lhs_req = guard_requirements(lhs)
+    rhs_req = guard_requirements(rhs)
+    if lhs_req is None or rhs_req is None:
+        bool_exclusive = False
+    else:
+        bool_exclusive = any(
+            atom in rhs_req and rhs_req[atom] != value for atom, value in lhs_req.items()
+        )
+    lhs_cmp = guard_comparisons(lhs)
+    rhs_cmp = guard_comparisons(rhs)
+    cmp_exclusive = False
+    if lhs_cmp is not None and rhs_cmp is not None:
+        cmp_exclusive = any(
+            (("ge" if op == "lt" else "lt"), lhs_expr, rhs_expr) in rhs_cmp
+            for op, lhs_expr, rhs_expr in lhs_cmp
+            if op in {"lt", "ge"}
+        ) or any(
+            (("ne" if op == "eq" else "eq"), lhs_expr, rhs_expr) in rhs_cmp
+            for op, lhs_expr, rhs_expr in lhs_cmp
+            if op in {"eq", "ne"}
+        )
+    return bool_exclusive or cmp_exclusive
+
+
+def guard_has_comparison(expr: GuardExprNode) -> bool:
+    tag = expr[0]
+    if tag in {"lt", "ge", "eq", "ne"}:
+        return True
+    if tag == "not":
+        return guard_has_comparison(expr[1])
+    if tag in {"and", "or"}:
+        return guard_has_comparison(expr[1]) or guard_has_comparison(expr[2])
+    return False
+
+
+def control_for_state(
+    state: dict[str, Any],
+    index_map: dict[int, int],
+    guard_atom_ids: SymbolTable,
+    nat_ids: SymbolTable,
+    source_next: int | None,
+    num_states: int,
+    once: bool,
+    raw_states: list[dict[str, Any]],
+    transitions_field: str = "transitions",
+) -> str:
+    role = state.get("role", "")
+    transitions = state.get(transitions_field, [])
+    if role == "wait_until":
+        guard = (
+            transition_guard_key(transitions[0], guard_atom_ids, nat_ids)
+            if transitions
+            else "GuardExpr.trueLit"
+        )
+        return f"Control.waitUntil {guard}"
+    if role == "wait_cycles":
+        raw_count = state.get("wait_cycles_count")
+        if raw_count is None:
+            raise SystemExit(f"{state.get('state_name', '<unnamed>')}: missing wait_cycles_count")
+        if not re.fullmatch(r"[0-9]+", str(raw_count)):
+            raise SystemExit(
+                f"{state.get('state_name', '<unnamed>')}: non-literal wait_cycles_count {raw_count!r}"
+            )
+        count = int(raw_count)
+        return f"Control.waitCycles {count}"
+    if role == "dispatch":
+        branches = []
+        for tr in transitions:
+            guard = transition_guard_key(tr, guard_atom_ids, nat_ids)
+            target = resolve_target(state, tr, index_map, num_states, once, raw_states)
+            branches.append(f"{{ guard := {guard}, target := {target} }}")
+        return "Control.dispatch [" + ", ".join(branches) + "]"
+    if len(transitions) == 1 and source_next is not None:
+        target = resolve_target(
+            state, transitions[0], index_map, num_states, once, raw_states
+        )
+        if transition_is_unconditional(transitions[0], guard_atom_ids, nat_ids):
+            if target != source_next:
+                return f"Control.jump {target}"
+        else:
+            guard = transition_guard_key(transitions[0], guard_atom_ids, nat_ids)
+            return f"Control.guarded {guard} {target}"
+    return "Control.advance"
+
+
+def is_guarded_non_dispatch_transition(
+    state: dict[str, Any],
+    transition: dict[str, Any],
+    index_map: dict[int, int],
+    source_next: int,
+    guard_atom_ids: SymbolTable,
+    nat_ids: SymbolTable,
+) -> bool:
+    if state.get("role") == "dispatch":
+        return False
+    return not transition_is_unconditional(transition, guard_atom_ids, nat_ids)
+
+
+def is_jump_non_dispatch_transition(
+    state: dict[str, Any],
+    transition: dict[str, Any],
+    index_map: dict[int, int],
+    source_next: int,
+    guard_atom_ids: SymbolTable,
+    nat_ids: SymbolTable,
+    num_states: int,
+    once: bool,
+    raw_states: list[dict[str, Any]],
+) -> bool:
+    if state.get("role") == "dispatch":
+        return False
+    target = resolve_target(state, transition, index_map, num_states, once, raw_states)
+    return target != source_next and transition_is_unconditional(
+        transition, guard_atom_ids, nat_ids
+    )
+
+
+def resolve_target(
+    state: dict[str, Any],
+    transition: dict[str, Any],
+    index_map: dict[int, int],
+    num_states: int,
+    once: bool,
+    raw_states: list[dict[str, Any]],
+) -> int:
+    raw_target = int(transition["target_index"])
+    if raw_target not in index_map:
+        if is_once_terminal_raw_target(raw_target, raw_states, once):
+            compact_idx = index_map.get(int(state["index"]))
+            if compact_idx is not None:
+                return compact_next(compact_idx, num_states, once)
+        state_name = state.get("state_name", "<unnamed>")
+        target_name = transition.get("target_name", f"S{raw_target}")
+        raise SystemExit(
+            f"{state_name}: transition targets non-emitted or unknown state "
+            f"{raw_target} ({target_name})"
+        )
+    return index_map[raw_target]
+
+
+def target_for_state(
+    state: dict[str, Any],
+    num_states: int,
+    index_map: dict[int, int],
+    once: bool,
+    raw_states: list[dict[str, Any]],
+) -> int:
+    transitions = state.get("transitions", [])
+    if transitions:
+        return resolve_target(state, transitions[0], index_map, num_states, once, raw_states)
+    compact_idx = index_map.get(int(state["index"]), 0)
+    return compact_next(compact_idx, num_states, once)
+
+
+def source_next_for_state(
+    state: dict[str, Any],
+    num_states: int,
+    index_map: dict[int, int],
+    once: bool,
+    require_explicit: bool,
+    raw_states: list[dict[str, Any]],
+) -> int:
+    compact_idx = index_map.get(int(state["index"]), 0)
+    inferred = compact_next(compact_idx, num_states, once)
+    if "source_next_index" not in state:
+        if require_explicit:
+            raise SystemExit(
+                f"{state.get('state_name', '<unnamed>')}: missing source_next_index"
+            )
+        return inferred
+    if require_explicit and "source_next_name" not in state:
+        raise SystemExit(
+            f"{state.get('state_name', '<unnamed>')}: missing source_next_name"
+        )
+
+    raw_target = int(state["source_next_index"])
+    if raw_target not in index_map:
+        if is_once_terminal_raw_target(raw_target, raw_states, once):
+            return inferred
+        target_name = state.get("source_next_name", f"S{raw_target}")
+        raise SystemExit(
+            f"{state.get('state_name', '<unnamed>')}: source_next targets "
+            f"non-emitted or unknown state {raw_target} ({target_name})"
+        )
+    explicit = index_map[raw_target]
+    if explicit != inferred:
+        raise SystemExit(
+            f"{state.get('state_name', '<unnamed>')}: source_next compact state "
+            f"{explicit}, expected natural compact next {inferred}"
+        )
+    return explicit
+
+
+def compact_next(idx: int, num_states: int, once: bool) -> int:
+    if idx + 1 < num_states:
+        return idx + 1
+    return idx if once else 0
+
+
+def is_once_terminal_raw_target(
+    raw_target: int,
+    raw_states: list[dict[str, Any]],
+    once: bool,
+) -> bool:
+    if not once or raw_target < 0 or raw_target >= len(raw_states):
+        return False
+    state = raw_states[raw_target]
+    if state.get("emitted", True):
+        return False
+    if int(state.get("source_next_index", -1)) != raw_target:
+        return False
+    return all(
+        int(transition.get("target_index", -1)) == raw_target
+        for transition in state.get("source_transitions", [])
+    )
+
+
+def lean_nat_list(values: list[int]) -> str:
+    if not values:
+        return "[]"
+    return "[" + ", ".join(str(value) for value in values) + "]"
+
+
+def action_list_for_state(state: dict[str, Any], action_ids: SymbolTable) -> str:
+    assignments = state.get("seq_assignments", [])
+    if assignments:
+        return lean_nat_list(
+            [
+                action_ids.id(f"{assignment.get('target', '')} := {assignment.get('value', '')}")
+                for assignment in assignments
+            ]
+        )
+    return lean_nat_list([action_ids.id(str(label)) for label in state.get("seq_updates", [])])
+
+
+def validate_assignment_coverage(base: str, state: dict[str, Any]) -> None:
+    state_name = state.get("state_name", f"S{state.get('index', '?')}")
+    seq_updates = state.get("seq_updates", [])
+    seq_assignments = state.get("seq_assignments", [])
+    if seq_assignments and len(seq_assignments) != len(seq_updates):
+        raise SystemExit(
+            f"{base}: {state_name}: seq_assignments partially cover seq_updates "
+            f"({len(seq_assignments)} of {len(seq_updates)})"
+        )
+
+    folded_updates = state.get("folded_exit_updates", [])
+    folded_assignments = state.get("folded_exit_assignments", [])
+    if folded_updates and len(folded_assignments) != len(folded_updates):
+        raise SystemExit(
+            f"{base}: {state_name}: folded_exit_updates require structured "
+            f"folded_exit_assignments for every update "
+            f"({len(folded_assignments)} of {len(folded_updates)})"
+        )
+
+
+def validate_thread_table(
+    base: str,
+    thread: dict[str, Any],
+    require_structured_guards: bool,
+) -> list[dict[str, Any]]:
+    raw_states = thread.get("states", [])
+    if not isinstance(raw_states, list) or not raw_states:
+        raise SystemExit(f"{base}: certificate has no states")
+
+    for expected_idx, state in enumerate(raw_states):
+        try:
+            raw_idx = int(state["index"])
+        except (KeyError, TypeError, ValueError) as err:
+            raise SystemExit(f"{base}: state at table slot {expected_idx} has invalid index") from err
+        if raw_idx != expected_idx:
+            raise SystemExit(
+                f"{base}: state table must be contiguous; slot {expected_idx} has index {raw_idx}"
+            )
+        validate_assignment_coverage(base, state)
+
+    emitted = [state for state in raw_states if state.get("emitted", True)]
+    if not emitted:
+        raise SystemExit(f"{base}: certificate has no emitted states")
+    if int(emitted[0]["index"]) != 0:
+        raise SystemExit(
+            f"{base}: first emitted state must be raw state 0, got {emitted[0]['index']}"
+        )
+    for state in emitted:
+        validate_emitted_state_shape(base, state, require_structured_guards)
+    return emitted
+
+
+def validate_emitted_state_shape(
+    base: str,
+    state: dict[str, Any],
+    require_structured_guards: bool,
+) -> None:
+    role = state.get("role")
+    state_name = state.get("state_name", f"S{state.get('index', '?')}")
+    transitions = state.get("transitions", [])
+    if not isinstance(transitions, list):
+        raise SystemExit(f"{base}: {state_name}: transitions must be a list")
+
+    expected_roles = {"entry", "action", "wait_until", "wait_cycles", "dispatch"}
+    if role not in expected_roles:
+        raise SystemExit(f"{base}: {state_name}: unknown state role {role!r}")
+
+    if role == "dispatch":
+        if len(transitions) < 2:
+            raise SystemExit(
+                f"{base}: {state_name}: dispatch state requires at least two transitions"
+            )
+    elif len(transitions) != 1:
+        raise SystemExit(
+            f"{base}: {state_name}: {role} state requires exactly one transition"
+        )
+
+    if role != "wait_cycles" and state.get("wait_cycles_count") is not None:
+        raise SystemExit(
+            f"{base}: {state_name}: wait_cycles_count only allowed on wait_cycles states"
+        )
+
+    for ti, transition in enumerate(transitions):
+        for field in ("condition", "target_index", "target_name"):
+            if field not in transition:
+                raise SystemExit(
+                    f"{base}: {state_name}: transition {ti} missing {field}"
+                )
+        validate_transition_guard_shape(
+            base,
+            state_name,
+            role,
+            "transition",
+            ti,
+            transition,
+            require_structured_guards,
+        )
+
+
+def validate_transition_guard_shape(
+    base: str,
+    state_name: str,
+    role: str,
+    transition_kind: str,
+    transition_index: int,
+    transition: dict[str, Any],
+    require_structured_guards: bool,
+) -> None:
+    if not require_structured_guards or role == "wait_cycles":
+        return
+    if "condition_guard" not in transition:
+        raise SystemExit(
+            f"{base}: {state_name}: {transition_kind} {transition_index} "
+            "missing condition_guard"
+        )
+    if not isinstance(transition["condition_guard"], dict):
+        raise SystemExit(
+            f"{base}: {state_name}: {transition_kind} {transition_index} "
+            "condition_guard must be an object"
+        )
+    try:
+        guard_expr_from_json(
+            transition["condition_guard"],
+            SymbolTable(),
+            SymbolTable(),
+        )
+    except SystemExit as err:
+        raise SystemExit(
+            f"{base}: {state_name}: {transition_kind} {transition_index} "
+            f"invalid condition_guard: {err}"
+        ) from err
+
+
+def validate_source_transitions(
+    base: str,
+    state: dict[str, Any],
+    require_source_transitions: bool,
+    require_structured_guards: bool,
+) -> None:
+    role = state.get("role")
+    state_name = state.get("state_name", f"S{state.get('index', '?')}")
+    if "source_transitions" not in state:
+        if require_source_transitions:
+            raise SystemExit(f"{base}: {state_name}: missing source_transitions")
+        return
+    origin = state.get("source_transition_origin")
+    if require_source_transitions and origin != "pre_fold_snapshot":
+        raise SystemExit(
+            f"{base}: {state_name}: unsupported source_transition_origin {origin!r}"
+        )
+
+    source_transitions = state.get("source_transitions")
+    if not isinstance(source_transitions, list):
+        raise SystemExit(f"{base}: {state_name}: source_transitions must be a list")
+
+    transitions = state.get("transitions", [])
+    if role == "dispatch" and len(source_transitions) != len(transitions):
+        raise SystemExit(
+            f"{base}: {state_name}: source_transitions length "
+            f"{len(source_transitions)} must match transitions length {len(transitions)}"
+        )
+    if role != "dispatch" and len(source_transitions) != 1:
+        raise SystemExit(
+            f"{base}: {state_name}: non-dispatch source_transitions requires exactly one transition"
+        )
+
+    for ti, transition in enumerate(source_transitions):
+        for field in ("condition", "target_index", "target_name"):
+            if field not in transition:
+                raise SystemExit(
+                    f"{base}: {state_name}: source transition {ti} missing {field}"
+                )
+        validate_transition_guard_shape(
+            base,
+            state_name,
+            role,
+            "source transition",
+            ti,
+            transition,
+            require_structured_guards,
+        )
+
+
+def render_thread(
+    module_name: str,
+    thread: dict[str, Any],
+    require_source_next: bool,
+    require_source_transitions: bool,
+    require_structured_guards: bool,
+    guard_atom_ids: SymbolTable,
+    nat_ids: SymbolTable,
+    action_ids: SymbolTable,
+) -> str:
+    base = lean_ident(f"{module_name}_{thread['name']}_{thread['index']}")
+    raw_states = thread.get("states", [])
+    states = validate_thread_table(base, thread, require_structured_guards)
+    once = bool(thread.get("once", False))
+    index_map = {int(s["index"]): new_idx for new_idx, s in enumerate(states)}
+    num_states = len(states)
+    by_index = {idx: state for idx, state in enumerate(states)}
+    has_dispatch = any(state.get("role") == "dispatch" for state in states)
+
+    arms = []
+    for idx in range(num_states):
+        state = by_index.get(idx)
+        if state is None:
+            actions = "[]"
+            source_control = "Control.advance"
+            fsm_control = "Control.advance"
+            target = compact_next(idx, num_states, once)
+        else:
+            validate_source_transitions(
+                base, state, require_source_transitions, require_structured_guards
+            )
+            source_next = source_next_for_state(
+                state, num_states, index_map, once, require_source_next, raw_states
+            )
+            source_control = control_for_state(
+                state,
+                index_map,
+                guard_atom_ids,
+                nat_ids,
+                source_next,
+                num_states,
+                once,
+                raw_states,
+                "source_transitions" if "source_transitions" in state else "transitions",
+            )
+            fsm_control = control_for_state(
+                state,
+                index_map,
+                guard_atom_ids,
+                nat_ids,
+                source_next,
+                num_states,
+                once,
+                raw_states,
+                "transitions",
+            )
+            if state.get("role") != "dispatch" and "source_transitions" in state:
+                source_transition = state["source_transitions"][0]
+                source_target = resolve_target(
+                    state,
+                    source_transition,
+                    index_map,
+                    num_states,
+                    once,
+                    raw_states,
+                )
+                if source_target != source_next and not is_guarded_non_dispatch_transition(
+                    state,
+                    source_transition,
+                    index_map,
+                    source_next,
+                    guard_atom_ids,
+                    nat_ids,
+                ) and not is_jump_non_dispatch_transition(
+                    state,
+                    source_transition,
+                    index_map,
+                    source_next,
+                    guard_atom_ids,
+                    nat_ids,
+                    num_states,
+                    once,
+                    raw_states,
+                ):
+                    raise SystemExit(
+                        f"{base}: state {state['state_name']} source transition targets "
+                        f"compact state {source_target}, expected source_next {source_next}"
+                    )
+            target = target_for_state(state, num_states, index_map, once, raw_states)
+            lowered_transition = state.get("transitions", [{}])[0]
+            has_guarded_lowered = (
+                state.get("role") != "dispatch"
+                and state.get("transitions")
+                and is_guarded_non_dispatch_transition(
+                    state,
+                    lowered_transition,
+                    index_map,
+                    source_next,
+                    guard_atom_ids,
+                    nat_ids,
+                )
+            )
+            has_jump_lowered = (
+                state.get("role") != "dispatch"
+                and state.get("transitions")
+                and is_jump_non_dispatch_transition(
+                    state,
+                    lowered_transition,
+                    index_map,
+                    source_next,
+                    guard_atom_ids,
+                    nat_ids,
+                    num_states,
+                    once,
+                    raw_states,
+                )
+            )
+            if (
+                state.get("role") != "dispatch"
+                and target != source_next
+                and not has_guarded_lowered
+                and not has_jump_lowered
+            ):
+                raise SystemExit(
+                    f"{base}: state {state['state_name']} targets compact state {target}, "
+                    f"expected source_next {source_next}"
+                )
+            if state.get("role") == "dispatch" or has_guarded_lowered or has_jump_lowered:
+                target = source_next
+            actions = action_list_for_state(state, action_ids)
+        arms.append((idx, actions, source_control, fsm_control, target))
+
+    source_lines = [
+        f"def {base}Source : SourceThread :=",
+        f"  {{ numStates := {num_states}",
+        f"    once := {'true' if once else 'false'}",
+        "    state := fun pc =>",
+    ]
+    for idx, actions, source_control, fsm_control, target in arms:
+        prefix = "      if" if idx == 0 else "      else if"
+        source_lines.append(f"{prefix} pc = {idx} then")
+        source_lines.append(f"        {{ actions := {actions}, control := {source_control} }}")
+    source_lines.append("      else")
+    source_lines.append("        { actions := [], control := Control.advance } }")
+    fsm_lines = [
+        f"def {base}Fsm : LoweredFsm :=",
+        "  { state := fun pc =>",
+    ]
+    for idx, actions, source_control, fsm_control, target in arms:
+        prefix = "      if" if idx == 0 else "      else if"
+        fsm_lines.append(f"{prefix} pc = {idx} then")
+        fsm_lines.append(
+            f"        {{ actions := {actions}, control := {fsm_control}, target := {target} }}"
+        )
+    fsm_lines.append("      else")
+    fsm_lines.append(
+        f"        {{ actions := [], control := Control.advance, target := sourceNext {base}Source pc }} }}"
+    )
+
+    cert_tactic = cert_field_tactic(base, num_states)
+    dispatch_cert_tactic = cert_field_tactic(
+        base, num_states, include_dispatch_branches=has_dispatch
+    )
+
+    proof = [
+        f"example : LoweringCertifies {base}Source {base}Fsm := by",
+        "  refine",
+        "    { actions_ok := ?_",
+        "      control_ok := ?_",
+        "      dispatch_branches_ok := ?_",
+        "      target_ok := ?_ }",
+        "  · intro pc",
+        indent_block(cert_tactic, 4),
+        "  · intro pc",
+        indent_block(cert_tactic, 4),
+        "  · intro pc",
+        indent_block(dispatch_cert_tactic, 4),
+        "  · intro pc",
+        indent_block(cert_tactic, 4),
+        "",
+        f"example (inputs : Nat -> Env) (natInputs : Nat -> NatEnv) (cfg0 : Config) :",
+        f"    forall t, sourceTraceObs {base}Source inputs natInputs cfg0 t = fsmTraceObs {base}Fsm inputs natInputs cfg0 t :=",
+        f"  trace_equiv (by",
+        "    refine",
+        "      { actions_ok := ?_",
+        "        control_ok := ?_",
+        "        dispatch_branches_ok := ?_",
+        "        target_ok := ?_ }",
+        "    · intro pc",
+        indent_block(cert_tactic, 6),
+        "    · intro pc",
+        indent_block(cert_tactic, 6),
+        "    · intro pc",
+        indent_block(dispatch_cert_tactic, 6),
+        "    · intro pc",
+        indent_block(cert_tactic, 6),
+        "  ) inputs natInputs cfg0",
+    ]
+    exclusivity = render_dispatch_exclusivity_proofs(base, states, guard_atom_ids, nat_ids)
+    return "\n".join(source_lines + [""] + fsm_lines + [""] + proof + exclusivity)
+
+
+def render_dispatch_exclusivity_proofs(
+    base: str,
+    states: list[dict[str, Any]],
+    guard_ids: SymbolTable,
+    nat_ids: SymbolTable,
+) -> list[str]:
+    chunks: list[str] = []
+    for state in states:
+        if state.get("role") != "dispatch":
+            continue
+        transitions = state.get("source_transitions", state.get("transitions", []))
+        parsed = [
+            transition_guard_expr(transition, guard_ids, nat_ids)
+            for transition in transitions
+        ]
+        state_name = lean_ident(str(state.get("state_name", f"S{state.get('index', '?')}")))
+        for i, lhs in enumerate(parsed):
+            for j in range(i + 1, len(parsed)):
+                rhs = parsed[j]
+                if not guards_syntactically_exclusive(lhs, rhs):
+                    continue
+                atoms = sorted(guard_expr_atoms(lhs) | guard_expr_atoms(rhs))
+                split = " <;> ".join(f"by_cases h{atom} : env {atom}" for atom in atoms)
+                has_comparison = guard_has_comparison(lhs) or guard_has_comparison(rhs)
+                if split:
+                    simp_args = "GuardExpr.eval, NatExpr.eval, " + ", ".join(
+                        f"h{atom}" for atom in atoms
+                    )
+                    tactic = f"{split} <;> simp [{simp_args}]"
+                else:
+                    tactic = "simp [GuardExpr.eval, NatExpr.eval]"
+                if has_comparison:
+                    tactic += " <;> omega"
+                    example_binder = "(env : Env) (natEnv : NatEnv)"
+                else:
+                    example_binder = "(env : Env)"
+                lhs_eval = f"GuardExpr.eval env {render_guard_expr(lhs)}"
+                rhs_eval = f"GuardExpr.eval env {render_guard_expr(rhs)}"
+                if has_comparison:
+                    lhs_eval += " natEnv"
+                    rhs_eval += " natEnv"
+                chunks.extend(
+                    [
+                        "",
+                        f"-- Parseable dispatch guards {i} and {j} in {state_name} are mutually exclusive.",
+                        f"example {example_binder} :",
+                        f"    {lhs_eval} = true ->",
+                        f"    {rhs_eval} = true ->",
+                        f"    False := by",
+                        f"  {tactic}",
+                    ]
+                )
+    return chunks
+
+
+def indent_block(text: str, spaces: int) -> str:
+    prefix = " " * spaces
+    return "\n".join(prefix + line if line else line for line in text.splitlines())
+
+
+def cert_field_tactic(
+    base: str,
+    num_states: int,
+    include_dispatch_branches: bool = False,
+) -> str:
+    extra = ", dispatchBranches" if include_dispatch_branches else ""
+    if num_states == 0:
+        return f"simp [{base}Source, {base}Fsm, sourceNext{extra}]"
+
+    def simp_line(hyps: list[str]) -> str:
+        hyp_args = "".join(f", {hyp}" for hyp in hyps)
+        return f"simp [{base}Source, {base}Fsm, sourceNext{extra}{hyp_args}]"
+
+    def go(idx: int, hyps: list[str], depth: int) -> list[str]:
+        if idx >= num_states:
+            return ["  " * depth + simp_line(hyps)]
+        hyp = f"h{idx}"
+        lines = ["  " * depth + f"by_cases {hyp} : pc = {idx}"]
+        lines.append("  " * depth + "· " + simp_line(hyps + [hyp]))
+        lines.append("  " * depth + "·")
+        lines.extend(go(idx + 1, hyps + [hyp], depth + 1))
+        return lines
+
+    return "\n".join(go(0, [], 0))
+
+
+def lean_update_list(
+    labels: list[str],
+    assignments: list[dict[str, Any]],
+    update_ids: SymbolTable,
+    var_ids: SymbolTable,
+    value_ids: SymbolTable,
+) -> str:
+    if assignments:
+        updates = []
+        fe = "Arch.ThreadLoweringProof.FoldedExit"
+        for assignment in assignments:
+            target = var_ids.id(str(assignment.get("target", "")))
+            value = value_ids.id(str(assignment.get("value", "")))
+            updates.append(f"{fe}.setVar {target} {value}")
+        return "[" + ", ".join(updates) + "]"
+    if not labels:
+        return "[]"
+    return "[" + ", ".join(f"updateById {update_ids.id(str(label))}" for label in labels) + "]"
+
+
+def render_folded_exit_proof(
+    module_name: str,
+    thread: dict[str, Any],
+    source_state: dict[str, Any],
+    folded_ordinal: int,
+    guard_atom_ids: SymbolTable,
+    nat_ids: SymbolTable,
+    update_ids: SymbolTable,
+    var_ids: SymbolTable,
+    value_ids: SymbolTable,
+) -> str:
+    base = lean_ident(
+        f"{module_name}_{thread['name']}_{thread['index']}_{source_state['state_name']}_folded_{folded_ordinal}"
+    )
+    transitions = source_state.get("transitions", [])
+    fe = "Arch.ThreadLoweringProof.FoldedExit"
+    guard = (
+        render_guard_expr_in_namespace(
+            transition_guard_expr(transitions[0], guard_atom_ids, nat_ids), fe
+        )
+        if transitions
+        else f"{fe}.GuardExpr.trueLit"
+    )
+    updates = lean_update_list(
+        source_state.get("folded_exit_updates", []),
+        source_state.get("folded_exit_assignments", []),
+        update_ids,
+        var_ids,
+        value_ids,
+    )
+    assignments = source_state.get("folded_exit_assignments", [])
+    lines = [
+            f"def {base}Source : {fe}.SourceThread :=",
+            "  { numStates := 2",
+            "    state := fun pc =>",
+            "      if pc = 0 then",
+            f"        {{ updates := []",
+            f"          exitUpdates := {updates}",
+            f"          control := {fe}.Control.waitUntil {guard} }}",
+            "      else",
+            "        { updates := []",
+            "          exitUpdates := []",
+            f"          control := {fe}.Control.advance }} }}",
+            "",
+            f"def {base}Fsm : {fe}.LoweredFsm :=",
+            "  { state := fun pc =>",
+            "      if pc = 0 then",
+            "        { updates := []",
+            f"          foldedExitUpdates := {updates}",
+            f"          control := {fe}.Control.waitUntil {guard}",
+            "          target := 1",
+            "          foldedTarget := some 1 }",
+            "      else",
+            "        { updates := []",
+            "          foldedExitUpdates := []",
+            f"          control := {fe}.Control.advance",
+            f"          target := {fe}.sourceNext {base}Source pc",
+            "          foldedTarget := none } }",
+            "",
+            f"example : {fe}.LoweringCertifies {base}Source {base}Fsm := by",
+            "  refine",
+            "    { updates_ok := ?_",
+            "      control_ok := ?_",
+            "      target_ok := ?_",
+            "      folded_updates_ok := ?_",
+            "      folded_target_ok := ?_",
+            "      folded_target_some_ok := ?_ }",
+            "  · intro pc",
+            f"    by_cases h : pc = 0 <;> simp [{base}Source, {base}Fsm, h]",
+            "  · intro pc",
+            f"    by_cases h : pc = 0 <;> simp [{base}Source, {base}Fsm, h]",
+            "  · intro pc",
+            f"    by_cases h : pc = 0 <;> simp [{base}Source, {base}Fsm, {fe}.sourceNext, h]",
+            "  · intro pc",
+            f"    by_cases h : pc = 0 <;> simp [{base}Source, {base}Fsm, h]",
+            "  · intro pc hupdates",
+            f"    by_cases h : pc = 0 <;> simp [{base}Source, {base}Fsm, {fe}.sourceNext, h] at *",
+            "  · intro pc target hfold",
+            f"    by_cases h : pc = 0 <;> simp [{base}Source, {base}Fsm, {fe}.sourceNext, h] at *",
+            "    exact hfold.symm",
+            "",
+            f"example (env : {fe}.Env) (natEnv : {fe}.NatEnv) (cfg : {fe}.Config) :",
+            f"    {fe}.sourceStep {base}Source env natEnv cfg = {fe}.fsmStep {base}Fsm env natEnv cfg :=",
+            f"  {fe}.one_step_equiv (by",
+            "    refine",
+            "      { updates_ok := ?_",
+            "        control_ok := ?_",
+            "        target_ok := ?_",
+            "        folded_updates_ok := ?_",
+            "        folded_target_ok := ?_",
+            "        folded_target_some_ok := ?_ }",
+            f"    · intro pc; by_cases h : pc = 0 <;> simp [{base}Source, {base}Fsm, h]",
+            f"    · intro pc; by_cases h : pc = 0 <;> simp [{base}Source, {base}Fsm, h]",
+            f"    · intro pc; by_cases h : pc = 0 <;> simp [{base}Source, {base}Fsm, {fe}.sourceNext, h]",
+            f"    · intro pc; by_cases h : pc = 0 <;> simp [{base}Source, {base}Fsm, h]",
+            f"    · intro pc hupdates; by_cases h : pc = 0 <;> simp [{base}Source, {base}Fsm, {fe}.sourceNext, h] at *",
+            f"    · intro pc target hfold; by_cases h : pc = 0 <;> simp [{base}Source, {base}Fsm, {fe}.sourceNext, h] at *; exact hfold.symm",
+            "  ) env natEnv cfg",
+    ]
+    seen_targets = set()
+    final_writes = []
+    for assignment in reversed(assignments):
+        target_name = str(assignment.get("target", ""))
+        if target_name in seen_targets:
+            continue
+        seen_targets.add(target_name)
+        final_writes.append(assignment)
+    final_writes.reverse()
+
+    for assignment in final_writes:
+        target = var_ids.id(str(assignment.get("target", "")))
+        value = value_ids.id(str(assignment.get("value", "")))
+        lines.extend(
+            [
+                "",
+                f"example (env : {fe}.Env) (natEnv : {fe}.NatEnv) (store : {fe}.Store)",
+                f"    (hguard : {fe}.GuardExpr.eval env {guard} natEnv = true) :",
+                f"    let cfg : {fe}.Config := {{ pc := 0, store := store }}",
+                f"    (({fe}.sourceStep {base}Source env natEnv cfg).store {target} = {value}) /\\",
+                f"      (({fe}.fsmStep {base}Fsm env natEnv cfg).store {target} = {value}) := by",
+                f"  simp [{fe}.sourceStep, {fe}.fsmStep, {base}Source, {base}Fsm,",
+                f"    {fe}.sourceAdvanceTo, {fe}.fsmAdvanceTo, {fe}.applyUpdates, {fe}.setVar, hguard]",
+            ]
+        )
+    return "\n".join(lines)
+
+
+def render_seq_assignment_store_proof(
+    module_name: str,
+    thread: dict[str, Any],
+    state: dict[str, Any],
+    ordinal: int,
+    var_ids: SymbolTable,
+    value_ids: SymbolTable,
+) -> str:
+    base = lean_ident(
+        f"{module_name}_{thread['name']}_{thread['index']}_{state['state_name']}_seq_{ordinal}"
+    )
+    fe = "Arch.ThreadLoweringProof.FoldedExit"
+    assignments = state.get("seq_assignments", [])
+    updates = []
+    for assignment in assignments:
+        target = var_ids.id(str(assignment.get("target", "")))
+        value = value_ids.id(str(assignment.get("value", "")))
+        updates.append(f"{fe}.setVar {target} {value}")
+
+    lines = [
+        f"def {base}Updates : List {fe}.Update :=",
+        "  [" + ", ".join(updates) + "]",
+    ]
+
+    seen_targets = set()
+    final_writes = []
+    for assignment in reversed(assignments):
+        target_name = str(assignment.get("target", ""))
+        if target_name in seen_targets:
+            continue
+        seen_targets.add(target_name)
+        final_writes.append(assignment)
+    final_writes.reverse()
+
+    for assignment in final_writes:
+        target = var_ids.id(str(assignment.get("target", "")))
+        value = value_ids.id(str(assignment.get("value", "")))
+        lines.extend(
+            [
+                "",
+                f"example (store : {fe}.Store) :",
+                f"    {fe}.applyUpdates {base}Updates store {target} = {value} := by",
+                f"  simp [{base}Updates, {fe}.applyUpdates, {fe}.setVar]",
+            ]
+        )
+    return "\n".join(lines)
+
+
+def render_seq_assignment_store_proofs(
+    cert: dict[str, Any],
+    var_ids: SymbolTable,
+    value_ids: SymbolTable,
+) -> list[str]:
+    chunks: list[str] = []
+    ordinal = 0
+    for module in cert.get("modules", []):
+        for thread in module.get("threads", []):
+            for state in thread.get("states", []):
+                if not state.get("emitted", True) or not state.get("seq_assignments"):
+                    continue
+                chunks.append(
+                    render_seq_assignment_store_proof(
+                        module["module_name"],
+                        thread,
+                        state,
+                        ordinal,
+                        var_ids,
+                        value_ids,
+                    )
+                )
+                ordinal += 1
+    return chunks
+
+
+def render_folded_exit_proofs(
+    cert: dict[str, Any],
+    guard_atom_ids: SymbolTable,
+    nat_ids: SymbolTable,
+    update_ids: SymbolTable,
+    var_ids: SymbolTable,
+    value_ids: SymbolTable,
+) -> list[str]:
+    chunks: list[str] = []
+    ordinal = 0
+    for module in cert.get("modules", []):
+        for thread in module.get("threads", []):
+            for state in thread.get("states", []):
+                if state.get("folded_exit_updates"):
+                    chunks.append(
+                        render_folded_exit_proof(
+                            module["module_name"],
+                            thread,
+                            state,
+                            ordinal,
+                            guard_atom_ids,
+                            nat_ids,
+                            update_ids,
+                            var_ids,
+                            value_ids,
+                        )
+                    )
+                    ordinal += 1
+    return chunks
+
+
+def render(cert: dict[str, Any]) -> str:
+    schema = cert.get("schema")
+    require_source_next = schema == "arch.thread_lowering_proof.v3"
+    require_source_transitions = schema in {
+        "arch.thread_lowering_proof.v4",
+        "arch.thread_lowering_proof.v5",
+    }
+    require_structured_guards = schema == "arch.thread_lowering_proof.v5"
+    require_source_next = require_source_next or require_source_transitions
+    guard_atom_ids = SymbolTable()
+    nat_ids = SymbolTable()
+    action_ids = SymbolTable()
+    update_ids = SymbolTable()
+    var_ids = SymbolTable()
+    value_ids = SymbolTable()
+    chunks = [
+        "import ArchThreadLoweringProof.CountedWait",
+        "import ArchThreadLoweringProof.FoldedExit",
+        "",
+        "set_option linter.unusedSimpArgs false",
+        "",
+        "namespace Arch.ThreadLoweringProof.Generated",
+        "open Arch.ThreadLoweringProof.CountedWait",
+        "",
+        "def updateById (id : Nat) : Arch.ThreadLoweringProof.FoldedExit.Update :=",
+        "  fun store var => if var = id then id else store var",
+        "",
+    ]
+    for module in cert.get("modules", []):
+        for thread in module.get("threads", []):
+            chunks.append(
+                render_thread(
+                    module["module_name"],
+                    thread,
+                    require_source_next,
+                    require_source_transitions,
+                    require_structured_guards,
+                    guard_atom_ids,
+                    nat_ids,
+                    action_ids,
+                )
+            )
+            chunks.append("")
+    chunks.extend(render_seq_assignment_store_proofs(cert, var_ids, value_ids))
+    if chunks and chunks[-1] != "":
+        chunks.append("")
+    chunks.extend(
+        render_folded_exit_proofs(
+            cert,
+            guard_atom_ids,
+            nat_ids,
+            update_ids,
+            var_ids,
+            value_ids,
+        )
+    )
+    chunks.append("end Arch.ThreadLoweringProof.Generated")
+    chunks.append("")
+    return "\n".join(chunks)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("certificate", type=Path)
+    parser.add_argument("-o", "--output", type=Path, required=True)
+    args = parser.parse_args()
+
+    cert = json.loads(args.certificate.read_text())
+    if cert.get("schema") not in {
+        "arch.thread_lowering_proof.v0",
+        "arch.thread_lowering_proof.v1",
+        "arch.thread_lowering_proof.v2",
+        "arch.thread_lowering_proof.v3",
+        "arch.thread_lowering_proof.v4",
+        "arch.thread_lowering_proof.v5",
+    }:
+        raise SystemExit(f"unsupported schema: {cert.get('schema')!r}")
+    args.output.write_text(render(cert))
+
+
+if __name__ == "__main__":
+    main()

--- a/proofs/lean_thread_lowering/scripts/test_cert_to_lean.py
+++ b/proofs/lean_thread_lowering/scripts/test_cert_to_lean.py
@@ -1,0 +1,955 @@
+#!/usr/bin/env python3
+"""Focused regression tests for the certificate-to-Lean bridge."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+
+SCRIPT = Path(__file__).with_name("cert_to_lean.py")
+PROJECT_DIR = SCRIPT.parent.parent
+SPEC = importlib.util.spec_from_file_location("cert_to_lean", SCRIPT)
+assert SPEC is not None
+cert_to_lean = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(cert_to_lean)
+
+
+def guard_true() -> dict:
+    return {"kind": "true"}
+
+
+def guard_atom(name: str) -> dict:
+    return {"kind": "atom", "name": name}
+
+
+def guard_not(inner: dict) -> dict:
+    return {"kind": "not", "expr": inner}
+
+
+def nat_var(name: str) -> dict:
+    return {"kind": "var", "name": name}
+
+
+def nat_const(value: int) -> dict:
+    return {"kind": "const", "value": value}
+
+
+def transition(
+    condition: str,
+    target_index: int,
+    target_name: str,
+    condition_guard: dict | None = None,
+) -> dict:
+    if condition_guard is None:
+        if condition in {"always", "true", "1'b1", "1"}:
+            condition_guard = guard_true()
+        elif condition.startswith("!") and condition[1:].replace("_", "").isalnum():
+            condition_guard = guard_not(guard_atom(condition[1:]))
+        else:
+            condition_guard = guard_atom(condition)
+    return {
+        "condition": condition,
+        "condition_guard": condition_guard,
+        "target_index": target_index,
+        "target_name": target_name,
+    }
+
+
+def strip_condition_guards(cert: dict) -> None:
+    for module in cert.get("modules", []):
+        for thread in module.get("threads", []):
+            for state in thread.get("states", []):
+                for field in ("source_transitions", "transitions"):
+                    for tr in state.get(field, []):
+                        tr.pop("condition_guard", None)
+
+
+def base_cert(target_index: int = 1) -> dict:
+    return {
+        "schema": "arch.thread_lowering_proof.v5",
+        "modules": [
+            {
+                "module_name": "M",
+                "generated_module_name": "_M_threads",
+                "threads": [
+                    {
+                        "name": "T",
+                        "index": 0,
+                        "once": False,
+                        "states": [
+                            {
+                                "index": 0,
+                                "state_name": "_t0_S0_entry",
+                                "role": "entry",
+                                "emitted": True,
+                                "source_next_index": 1,
+                                "source_next_name": "_t0_S1_action",
+                                "labels": ["seq: 1 stmt"],
+                                "wait_cycles_count": None,
+                                "seq_updates": ["x <= true"],
+                                "seq_assignments": [
+                                    {"target": "x", "value": "true"},
+                                ],
+                                "folded_exit_updates": [],
+                                "folded_exit_assignments": [],
+                                "source_transitions": [
+                                    transition("always", target_index, "_t0_S1_action"),
+                                ],
+                                "source_transition_origin": "pre_fold_snapshot",
+                                "transitions": [
+                                    transition("always", target_index, "_t0_S1_action"),
+                                ],
+                            },
+                            {
+                                "index": 1,
+                                "state_name": "_t0_S1_action",
+                                "role": "action",
+                                "emitted": True,
+                                "source_next_index": 0,
+                                "source_next_name": "_t0_S0_entry",
+                                "labels": [],
+                                "wait_cycles_count": None,
+                                "seq_updates": [],
+                                "seq_assignments": [],
+                                "folded_exit_updates": [],
+                                "folded_exit_assignments": [],
+                                "source_transitions": [
+                                    transition("always", 0, "_t0_S0_entry"),
+                                ],
+                                "source_transition_origin": "pre_fold_snapshot",
+                                "transitions": [
+                                    transition("always", 0, "_t0_S0_entry"),
+                                ],
+                            },
+                        ],
+                    },
+                ],
+            },
+        ],
+    }
+
+
+def cert_targeting_non_emitted_state() -> dict:
+    cert = base_cert(target_index=2)
+    cert["modules"][0]["threads"][0]["states"].append(
+        {
+            "index": 2,
+            "state_name": "_t0_S2_folded_action",
+            "role": "action",
+            "emitted": False,
+            "source_next_index": 0,
+            "source_next_name": "_t0_S0_entry",
+            "labels": [],
+            "wait_cycles_count": None,
+            "seq_updates": [],
+            "seq_assignments": [],
+            "folded_exit_updates": [],
+            "folded_exit_assignments": [],
+            "source_transitions": [],
+            "source_transition_origin": "pre_fold_snapshot",
+            "transitions": [],
+        }
+    )
+    return cert
+
+
+def dispatch_cert() -> dict:
+    cert = base_cert(target_index=1)
+    states = cert["modules"][0]["threads"][0]["states"]
+    states[1]["source_next_index"] = 2
+    states[1]["source_next_name"] = "_t0_S2_action"
+    states[1]["source_transitions"] = [
+        transition("always", 2, "_t0_S2_action"),
+    ]
+    states[1]["source_transition_origin"] = "pre_fold_snapshot"
+    states[1]["transitions"] = [
+        transition("always", 2, "_t0_S2_action"),
+    ]
+    states.append(
+        {
+            "index": 2,
+            "state_name": "_t0_S2_action",
+            "role": "action",
+            "emitted": True,
+            "source_next_index": 0,
+            "source_next_name": "_t0_S0_entry",
+            "labels": [],
+            "wait_cycles_count": None,
+            "seq_updates": [],
+            "seq_assignments": [],
+            "folded_exit_updates": [],
+            "folded_exit_assignments": [],
+            "source_transitions": [
+                transition("always", 0, "_t0_S0_entry"),
+            ],
+            "source_transition_origin": "pre_fold_snapshot",
+            "transitions": [
+                transition("always", 0, "_t0_S0_entry"),
+            ],
+        }
+    )
+    state0 = states[0]
+    state0["role"] = "dispatch"
+    state0["source_transitions"] = [
+        transition("sel", 2, "_t0_S2_action"),
+        transition("!sel", 1, "_t0_S1_action"),
+    ]
+    state0["source_transition_origin"] = "pre_fold_snapshot"
+    state0["transitions"] = [
+        transition("sel", 1, "_t0_S1_action"),
+        transition("!sel", 2, "_t0_S2_action"),
+    ]
+    return cert
+
+
+def single_guard_cert() -> dict:
+    cert = base_cert(target_index=1)
+    states = cert["modules"][0]["threads"][0]["states"]
+    states[1]["source_next_index"] = 2
+    states[1]["source_next_name"] = "_t0_S2_action"
+    states[1]["source_transitions"] = [
+        transition("always", 2, "_t0_S2_action"),
+    ]
+    states[1]["transitions"] = [
+        transition("always", 2, "_t0_S2_action"),
+    ]
+    states.append(
+        {
+            "index": 2,
+            "state_name": "_t0_S2_action",
+            "role": "action",
+            "emitted": True,
+            "source_next_index": 0,
+            "source_next_name": "_t0_S0_entry",
+            "labels": [],
+            "wait_cycles_count": None,
+            "seq_updates": [],
+            "seq_assignments": [],
+            "folded_exit_updates": [],
+            "folded_exit_assignments": [],
+            "source_transitions": [
+                transition("always", 0, "_t0_S0_entry"),
+            ],
+            "source_transition_origin": "pre_fold_snapshot",
+            "transitions": [
+                transition("always", 0, "_t0_S0_entry"),
+            ],
+        }
+    )
+    guarded = states[1]
+    guarded["source_transitions"] = [
+        transition("ack", 0, "_t0_S0_entry"),
+    ]
+    guarded["transitions"] = [
+        transition("ack", 0, "_t0_S0_entry"),
+    ]
+    return cert
+
+
+def unconditional_jump_cert() -> dict:
+    cert = single_guard_cert()
+    guarded = cert["modules"][0]["threads"][0]["states"][1]
+    guarded["source_transitions"] = [
+        transition("true", 0, "_t0_S0_entry"),
+    ]
+    guarded["transitions"] = [
+        transition("true", 0, "_t0_S0_entry"),
+    ]
+    return cert
+
+
+def comparison_dispatch_cert() -> dict:
+    cert = dispatch_cert()
+    state0 = cert["modules"][0]["threads"][0]["states"][0]
+    state0["source_transitions"] = [
+        {
+            "condition": "branch_lt",
+            "condition_guard": {
+                "kind": "and",
+                "lhs": {"kind": "atom", "name": "grant"},
+                "rhs": {
+                    "kind": "lt",
+                    "lhs": {"kind": "var", "name": "cnt"},
+                    "rhs": {"kind": "const", "value": 3},
+                },
+            },
+            "target_index": 2,
+            "target_name": "_t0_S2_action",
+        },
+        {
+            "condition": "branch_ge",
+            "condition_guard": {
+                "kind": "and",
+                "lhs": {"kind": "atom", "name": "grant"},
+                "rhs": {
+                    "kind": "ge",
+                    "lhs": {"kind": "var", "name": "cnt"},
+                    "rhs": {"kind": "const", "value": 3},
+                },
+            },
+            "target_index": 1,
+            "target_name": "_t0_S1_action",
+        },
+    ]
+    state0["transitions"] = [dict(tr) for tr in state0["source_transitions"]]
+    return cert
+
+
+def equality_dispatch_cert() -> dict:
+    cert = dispatch_cert()
+    state0 = cert["modules"][0]["threads"][0]["states"][0]
+    state0["source_transitions"] = [
+        transition(
+            "idx == 3",
+            2,
+            "_t0_S2_action",
+            {"kind": "eq", "lhs": nat_var("idx"), "rhs": nat_const(3)},
+        ),
+        transition(
+            "idx != 3",
+            1,
+            "_t0_S1_action",
+            {"kind": "ne", "lhs": nat_var("idx"), "rhs": nat_const(3)},
+        ),
+    ]
+    state0["transitions"] = [dict(tr) for tr in state0["source_transitions"]]
+    return cert
+
+
+class CertToLeanTests(unittest.TestCase):
+    def run_lean(self, lean_source: str) -> subprocess.CompletedProcess[str]:
+        if shutil.which("lake") is None:
+            self.skipTest("lake not found on PATH")
+        with tempfile.NamedTemporaryFile("w", suffix=".lean", delete=False) as tmp:
+            tmp.write(lean_source)
+            tmp_path = Path(tmp.name)
+        try:
+            return subprocess.run(
+                ["lake", "env", "lean", str(tmp_path)],
+                cwd=PROJECT_DIR,
+                env=os.environ.copy(),
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+        finally:
+            tmp_path.unlink(missing_ok=True)
+
+    def test_fsm_table_uses_certificate_target_not_source_next_alias(self) -> None:
+        lean = cert_to_lean.render(base_cert())
+        self.assertIn("def M_T_0Fsm : LoweredFsm :=", lean)
+        self.assertIn("dispatch_branches_ok", lean)
+        self.assertIn("{ actions := [", lean)
+        self.assertIn("target := 1", lean)
+        self.assertIn("target := 0", lean)
+        self.assertIn("target := sourceNext M_T_0Source pc", lean)
+
+    def test_non_dispatch_source_fsm_target_mismatch_fails_lean(self) -> None:
+        cert = base_cert()
+        state = cert["modules"][0]["threads"][0]["states"][0]
+        state["source_transitions"][0]["target_index"] = 0
+        state["source_transitions"][0]["target_name"] = "_t0_S0_entry"
+        result = self.run_lean(cert_to_lean.render(cert))
+        self.assertNotEqual(
+            result.returncode,
+            0,
+            "mismatched non-dispatch source/FSM jump should not replay in Lean",
+        )
+
+    def test_unknown_target_is_rejected(self) -> None:
+        with self.assertRaises(SystemExit) as caught:
+            cert_to_lean.render(base_cert(target_index=99))
+        self.assertIn("targets non-emitted or unknown state 99", str(caught.exception))
+
+    def test_non_emitted_target_is_rejected(self) -> None:
+        with self.assertRaises(SystemExit) as caught:
+            cert_to_lean.render(cert_targeting_non_emitted_state())
+        self.assertIn("targets non-emitted or unknown state 2", str(caught.exception))
+
+    def test_non_contiguous_state_table_is_rejected(self) -> None:
+        cert = base_cert()
+        cert["modules"][0]["threads"][0]["states"][1]["index"] = 7
+        with self.assertRaises(SystemExit) as caught:
+            cert_to_lean.render(cert)
+        self.assertIn("state table must be contiguous", str(caught.exception))
+
+    def test_empty_emitted_state_table_is_rejected(self) -> None:
+        cert = base_cert()
+        for state in cert["modules"][0]["threads"][0]["states"]:
+            state["emitted"] = False
+        with self.assertRaises(SystemExit) as caught:
+            cert_to_lean.render(cert)
+        self.assertIn("certificate has no emitted states", str(caught.exception))
+
+    def test_first_emitted_state_must_be_raw_zero(self) -> None:
+        cert = base_cert()
+        cert["modules"][0]["threads"][0]["states"][0]["emitted"] = False
+        with self.assertRaises(SystemExit) as caught:
+            cert_to_lean.render(cert)
+        self.assertIn("first emitted state must be raw state 0", str(caught.exception))
+
+    def test_v3_requires_source_next_index(self) -> None:
+        cert = base_cert()
+        del cert["modules"][0]["threads"][0]["states"][0]["source_next_index"]
+        with self.assertRaises(SystemExit) as caught:
+            cert_to_lean.render(cert)
+        self.assertIn("missing source_next_index", str(caught.exception))
+
+    def test_v3_requires_source_next_name(self) -> None:
+        cert = base_cert()
+        del cert["modules"][0]["threads"][0]["states"][0]["source_next_name"]
+        with self.assertRaises(SystemExit) as caught:
+            cert_to_lean.render(cert)
+        self.assertIn("missing source_next_name", str(caught.exception))
+
+    def test_source_next_unknown_target_is_rejected(self) -> None:
+        cert = base_cert()
+        state = cert["modules"][0]["threads"][0]["states"][0]
+        state["source_next_index"] = 99
+        state["source_next_name"] = "_t0_S99_missing"
+        with self.assertRaises(SystemExit) as caught:
+            cert_to_lean.render(cert)
+        self.assertIn("source_next targets non-emitted or unknown state 99", str(caught.exception))
+
+    def test_source_next_must_match_compact_natural_next(self) -> None:
+        cert = base_cert()
+        state = cert["modules"][0]["threads"][0]["states"][0]
+        state["source_next_index"] = 0
+        state["source_next_name"] = "_t0_S0_entry"
+        with self.assertRaises(SystemExit) as caught:
+            cert_to_lean.render(cert)
+        self.assertIn("expected natural compact next 1", str(caught.exception))
+
+    def test_v5_requires_source_transitions(self) -> None:
+        cert = base_cert()
+        del cert["modules"][0]["threads"][0]["states"][0]["source_transitions"]
+        with self.assertRaises(SystemExit) as caught:
+            cert_to_lean.render(cert)
+        self.assertIn("missing source_transitions", str(caught.exception))
+
+    def test_v5_requires_supported_source_transition_origin(self) -> None:
+        cert = base_cert()
+        del cert["modules"][0]["threads"][0]["states"][0]["source_transition_origin"]
+        with self.assertRaises(SystemExit) as caught:
+            cert_to_lean.render(cert)
+        self.assertIn("unsupported source_transition_origin", str(caught.exception))
+
+    def test_v5_rejects_unknown_source_transition_origin(self) -> None:
+        cert = base_cert()
+        cert["modules"][0]["threads"][0]["states"][0]["source_transition_origin"] = "post_fold_clone"
+        with self.assertRaises(SystemExit) as caught:
+            cert_to_lean.render(cert)
+        self.assertIn("unsupported source_transition_origin", str(caught.exception))
+
+    def test_source_transition_requires_required_fields(self) -> None:
+        cert = base_cert()
+        del cert["modules"][0]["threads"][0]["states"][0]["source_transitions"][0]["target_name"]
+        with self.assertRaises(SystemExit) as caught:
+            cert_to_lean.render(cert)
+        self.assertIn("source transition 0 missing target_name", str(caught.exception))
+
+    def test_v5_requires_lowered_transition_condition_guard(self) -> None:
+        cert = base_cert()
+        del cert["modules"][0]["threads"][0]["states"][0]["transitions"][0][
+            "condition_guard"
+        ]
+        with self.assertRaises(SystemExit) as caught:
+            cert_to_lean.render(cert)
+        self.assertIn("transition 0 missing condition_guard", str(caught.exception))
+
+    def test_v5_requires_source_transition_condition_guard(self) -> None:
+        cert = base_cert()
+        del cert["modules"][0]["threads"][0]["states"][0]["source_transitions"][0][
+            "condition_guard"
+        ]
+        with self.assertRaises(SystemExit) as caught:
+            cert_to_lean.render(cert)
+        self.assertIn("source transition 0 missing condition_guard", str(caught.exception))
+
+    def test_v5_rejects_malformed_boolean_condition_guard(self) -> None:
+        cert = base_cert()
+        cert["modules"][0]["threads"][0]["states"][0]["transitions"][0][
+            "condition_guard"
+        ] = {
+            "kind": "and",
+            "lhs": guard_atom("req"),
+        }
+        with self.assertRaises(SystemExit) as caught:
+            cert_to_lean.render(cert)
+        message = str(caught.exception)
+        self.assertIn("transition 0 invalid condition_guard", message)
+        self.assertIn("and condition_guard missing lhs/rhs", message)
+
+    def test_v5_rejects_malformed_nat_condition_guard(self) -> None:
+        cert = base_cert()
+        cert["modules"][0]["threads"][0]["states"][0]["source_transitions"][0][
+            "condition_guard"
+        ] = {
+            "kind": "lt",
+            "lhs": {"kind": "var"},
+            "rhs": {"kind": "const", "value": 3},
+        }
+        with self.assertRaises(SystemExit) as caught:
+            cert_to_lean.render(cert)
+        message = str(caught.exception)
+        self.assertIn("source transition 0 invalid condition_guard", message)
+        self.assertIn("var Nat expression missing name", message)
+
+    def test_v5_rejects_non_string_condition_guard_atom_name(self) -> None:
+        cert = base_cert()
+        cert["modules"][0]["threads"][0]["states"][0]["transitions"][0][
+            "condition_guard"
+        ] = {
+            "kind": "atom",
+            "name": ["req"],
+        }
+        with self.assertRaises(SystemExit) as caught:
+            cert_to_lean.render(cert)
+        message = str(caught.exception)
+        self.assertIn("transition 0 invalid condition_guard", message)
+        self.assertIn("atom condition_guard name must be a string", message)
+
+    def test_v5_rejects_non_integer_condition_guard_nat_const(self) -> None:
+        cert = base_cert()
+        cert["modules"][0]["threads"][0]["states"][0]["source_transitions"][0][
+            "condition_guard"
+        ] = {
+            "kind": "lt",
+            "lhs": {"kind": "var", "name": "idx"},
+            "rhs": {"kind": "const", "value": "3"},
+        }
+        with self.assertRaises(SystemExit) as caught:
+            cert_to_lean.render(cert)
+        message = str(caught.exception)
+        self.assertIn("source transition 0 invalid condition_guard", message)
+        self.assertIn("const Nat expression value must be an integer", message)
+
+    def test_v5_rejects_negative_condition_guard_nat_const(self) -> None:
+        cert = base_cert()
+        cert["modules"][0]["threads"][0]["states"][0]["source_transitions"][0][
+            "condition_guard"
+        ] = {
+            "kind": "lt",
+            "lhs": {"kind": "var", "name": "idx"},
+            "rhs": {"kind": "const", "value": -1},
+        }
+        with self.assertRaises(SystemExit) as caught:
+            cert_to_lean.render(cert)
+        message = str(caught.exception)
+        self.assertIn("source transition 0 invalid condition_guard", message)
+        self.assertIn("const Nat expression value must be non-negative", message)
+
+    def test_v5_accepts_structured_equality_condition_guard(self) -> None:
+        cert = base_cert()
+        guard = {"kind": "eq", "lhs": nat_var("idx"), "rhs": nat_const(3)}
+        state = cert["modules"][0]["threads"][0]["states"][0]
+        state["source_transitions"][0]["condition_guard"] = guard
+        state["transitions"][0]["condition_guard"] = guard
+
+        lean = cert_to_lean.render(cert)
+        self.assertIn("GuardExpr.eq", lean)
+        self.assertIn("NatExpr.const 3", lean)
+
+    def test_v4_allows_label_only_guards_for_compatibility(self) -> None:
+        cert = base_cert()
+        cert["schema"] = "arch.thread_lowering_proof.v4"
+        strip_condition_guards(cert)
+        lean = cert_to_lean.render(cert)
+        self.assertIn("LoweringCertifies", lean)
+
+    def test_unconditional_non_dispatch_jump_replays_in_lean(self) -> None:
+        lean = cert_to_lean.render(unconditional_jump_cert())
+        self.assertIn("Control.jump 0", lean)
+        result = self.run_lean(lean)
+        self.assertEqual(
+            result.returncode,
+            0,
+            f"expected unconditional jump replay to pass\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}",
+        )
+
+    def test_single_guarded_natural_transition_is_not_unconditional_advance(self) -> None:
+        cert = single_guard_cert()
+        guarded = cert["modules"][0]["threads"][0]["states"][1]
+        guarded["source_transitions"][0]["target_index"] = 2
+        guarded["source_transitions"][0]["target_name"] = "_t0_S2_action"
+        guarded["transitions"][0]["target_index"] = 2
+        guarded["transitions"][0]["target_name"] = "_t0_S2_action"
+        lean = cert_to_lean.render(cert)
+        self.assertIn("Control.guarded (GuardExpr.atom 0) 2", lean)
+        result = self.run_lean(lean)
+        self.assertEqual(
+            result.returncode,
+            0,
+            f"expected natural guarded transition replay to pass\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}",
+        )
+
+    def test_mismatched_unconditional_jump_fails_lean(self) -> None:
+        cert = base_cert()
+        state = cert["modules"][0]["threads"][0]["states"][0]
+        state["source_transitions"][0]["target_index"] = 0
+        state["source_transitions"][0]["target_name"] = "_t0_S0_entry"
+        state["transitions"][0]["target_index"] = 1
+        state["transitions"][0]["target_name"] = "_t0_S1_action"
+        result = self.run_lean(cert_to_lean.render(cert))
+        self.assertNotEqual(
+            result.returncode,
+            0,
+            "mismatched unconditional source/FSM targets should not replay in Lean",
+        )
+
+    def test_source_transition_unknown_target_is_rejected(self) -> None:
+        cert = base_cert()
+        state = cert["modules"][0]["threads"][0]["states"][0]
+        state["source_transitions"][0]["target_index"] = 99
+        state["source_transitions"][0]["target_name"] = "_t0_S99_missing"
+        with self.assertRaises(SystemExit) as caught:
+            cert_to_lean.render(cert)
+        self.assertIn("targets non-emitted or unknown state 99", str(caught.exception))
+
+    def test_source_dispatch_control_uses_source_transitions(self) -> None:
+        lean = cert_to_lean.render(dispatch_cert())
+        self.assertIn(
+            "control := Control.dispatch [{ guard := (GuardExpr.atom 0), target := 2 }, { guard := (GuardExpr.neg (GuardExpr.atom 0)), target := 1 }]",
+            lean,
+        )
+        self.assertIn(
+            "control := Control.dispatch [{ guard := (GuardExpr.atom 0), target := 1 }, { guard := (GuardExpr.neg (GuardExpr.atom 0)), target := 2 }]",
+            lean,
+        )
+
+    def test_parseable_dispatch_guards_emit_exclusivity_proof(self) -> None:
+        lean = cert_to_lean.render(dispatch_cert())
+        self.assertIn("GuardExpr.eval", lean)
+        self.assertIn("mutually exclusive", lean)
+        self.assertIn("by_cases", lean)
+
+    def test_comparison_dispatch_guards_emit_exclusivity_proof(self) -> None:
+        lean = cert_to_lean.render(comparison_dispatch_cert())
+        self.assertIn("GuardExpr.lt", lean)
+        self.assertIn("GuardExpr.ge", lean)
+        self.assertIn("omega", lean)
+        result = self.run_lean(lean)
+        self.assertEqual(
+            result.returncode,
+            0,
+            f"expected comparison exclusivity replay to pass\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}",
+        )
+
+    def test_equality_dispatch_guards_emit_exclusivity_proof(self) -> None:
+        lean = cert_to_lean.render(equality_dispatch_cert())
+        self.assertIn("GuardExpr.eq", lean)
+        self.assertIn("GuardExpr.ne", lean)
+        self.assertIn("mutually exclusive", lean)
+        self.assertIn("omega", lean)
+        result = self.run_lean(lean)
+        self.assertEqual(
+            result.returncode,
+            0,
+            f"expected equality exclusivity replay to pass\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}",
+        )
+
+    def test_structured_guards_not_display_labels_drive_lean_control_terms(self) -> None:
+        cert = dispatch_cert()
+        state0 = cert["modules"][0]["threads"][0]["states"][0]
+        state0["source_transitions"][1]["condition"] = "sel_alias"
+        state0["transitions"] = [dict(tr) for tr in state0["source_transitions"]]
+        lean = cert_to_lean.render(cert)
+        self.assertIn("{ guard := (GuardExpr.atom 0), target := 2 }", lean)
+        self.assertIn("{ guard := (GuardExpr.neg (GuardExpr.atom 0)), target := 1 }", lean)
+        self.assertNotIn("{ guard := (GuardExpr.atom 0), target := 1 }", lean)
+
+    def test_same_guard_label_with_different_structured_guard_fails_lean(self) -> None:
+        cert = single_guard_cert()
+        guarded = cert["modules"][0]["threads"][0]["states"][1]
+        guarded["source_transitions"][0]["condition_guard"] = {
+            "kind": "atom",
+            "name": "ack",
+        }
+        guarded["transitions"][0]["condition_guard"] = {
+            "kind": "atom",
+            "name": "ack_shadow",
+        }
+        lean = cert_to_lean.render(cert)
+        self.assertIn("Control.guarded (GuardExpr.atom 0) 0", lean)
+        self.assertIn("Control.guarded (GuardExpr.atom 1) 0", lean)
+        result = self.run_lean(lean)
+        self.assertNotEqual(
+            result.returncode,
+            0,
+            "same label with different structured guards should not replay in Lean",
+        )
+
+    def test_single_guarded_non_dispatch_transition_replays_in_lean(self) -> None:
+        lean = cert_to_lean.render(single_guard_cert())
+        self.assertIn("Control.guarded (GuardExpr.atom 0) 0", lean)
+        result = self.run_lean(lean)
+        self.assertEqual(
+            result.returncode,
+            0,
+            f"expected single guarded jump replay to pass\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}",
+        )
+
+    def test_mismatched_single_guarded_transition_fails_lean(self) -> None:
+        cert = single_guard_cert()
+        guarded = cert["modules"][0]["threads"][0]["states"][1]
+        guarded["transitions"][0]["target_index"] = 0
+        guarded["transitions"][0]["target_name"] = "_t0_S0_entry"
+        guarded["source_transitions"][0]["target_index"] = 2
+        guarded["source_transitions"][0]["target_name"] = "_t0_S2_action"
+        result = self.run_lean(cert_to_lean.render(cert))
+        self.assertNotEqual(
+            result.returncode,
+            0,
+            "mismatched single guarded source/FSM targets should not replay in Lean",
+        )
+
+    def test_matching_certificate_replays_in_lean(self) -> None:
+        result = self.run_lean(cert_to_lean.render(base_cert()))
+        self.assertEqual(
+            result.returncode,
+            0,
+            f"expected Lean replay to pass\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}",
+        )
+
+    def test_mismatched_dispatch_certificate_fails_lean(self) -> None:
+        result = self.run_lean(cert_to_lean.render(dispatch_cert()))
+        self.assertNotEqual(
+            result.returncode,
+            0,
+            "mismatched source/FSM dispatch table should not replay in Lean",
+        )
+        self.assertIn(
+            "error",
+            (result.stdout + result.stderr).lower(),
+            f"expected Lean failure to report an error\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}",
+        )
+
+    def test_unknown_role_is_rejected(self) -> None:
+        cert = base_cert()
+        cert["modules"][0]["threads"][0]["states"][0]["role"] = "mystery"
+        with self.assertRaises(SystemExit) as caught:
+            cert_to_lean.render(cert)
+        self.assertIn("unknown state role", str(caught.exception))
+
+    def test_non_dispatch_state_requires_one_transition(self) -> None:
+        cert = base_cert()
+        cert["modules"][0]["threads"][0]["states"][0]["transitions"] = []
+        with self.assertRaises(SystemExit) as caught:
+            cert_to_lean.render(cert)
+        self.assertIn("entry state requires exactly one transition", str(caught.exception))
+
+    def test_dispatch_requires_at_least_two_transitions(self) -> None:
+        cert = base_cert()
+        cert["modules"][0]["threads"][0]["states"][0]["role"] = "dispatch"
+        with self.assertRaises(SystemExit) as caught:
+            cert_to_lean.render(cert)
+        self.assertIn("dispatch state requires at least two transitions", str(caught.exception))
+
+    def test_transition_requires_required_fields(self) -> None:
+        cert = base_cert()
+        del cert["modules"][0]["threads"][0]["states"][0]["transitions"][0]["target_name"]
+        with self.assertRaises(SystemExit) as caught:
+            cert_to_lean.render(cert)
+        self.assertIn("transition 0 missing target_name", str(caught.exception))
+
+    def test_wait_count_only_allowed_on_wait_cycles(self) -> None:
+        cert = base_cert()
+        cert["modules"][0]["threads"][0]["states"][0]["wait_cycles_count"] = "2"
+        with self.assertRaises(SystemExit) as caught:
+            cert_to_lean.render(cert)
+        self.assertIn("wait_cycles_count only allowed", str(caught.exception))
+
+    def test_wait_cycles_requires_structured_count(self) -> None:
+        cert = base_cert()
+        state = cert["modules"][0]["threads"][0]["states"][0]
+        state["role"] = "wait_cycles"
+        state["labels"] = ["wait 2 cycle"]
+        state["wait_cycles_count"] = None
+        with self.assertRaises(SystemExit) as caught:
+            cert_to_lean.render(cert)
+        self.assertIn("missing wait_cycles_count", str(caught.exception))
+
+    def test_wait_cycles_uses_structured_count(self) -> None:
+        cert = base_cert()
+        state = cert["modules"][0]["threads"][0]["states"][0]
+        state["role"] = "wait_cycles"
+        state["labels"] = ["wait 999 cycle"]
+        state["wait_cycles_count"] = "2"
+        lean = cert_to_lean.render(cert)
+        self.assertIn("Control.waitCycles 2", lean)
+        self.assertNotIn("Control.waitCycles 999", lean)
+
+    def test_partial_seq_assignment_coverage_is_rejected(self) -> None:
+        cert = base_cert()
+        state = cert["modules"][0]["threads"][0]["states"][0]
+        state["seq_updates"].append("if y then z <= true")
+        with self.assertRaises(SystemExit) as caught:
+            cert_to_lean.render(cert)
+        self.assertIn("seq_assignments partially cover seq_updates", str(caught.exception))
+
+    def test_seq_assignment_store_effects_are_emitted(self) -> None:
+        cert = base_cert()
+        state = cert["modules"][0]["threads"][0]["states"][0]
+        state["seq_updates"] = ["x <= true", "y <= false"]
+        state["seq_assignments"] = [
+            {"target": "x", "value": "true"},
+            {"target": "y", "value": "false"},
+        ]
+        lean = cert_to_lean.render(cert)
+        self.assertIn(
+            "def M_T_0__t0_S0_entry_seq_0Updates : List "
+            "Arch.ThreadLoweringProof.FoldedExit.Update :=",
+            lean,
+        )
+        self.assertIn(
+            "[Arch.ThreadLoweringProof.FoldedExit.setVar 0 0, "
+            "Arch.ThreadLoweringProof.FoldedExit.setVar 1 1]",
+            lean,
+        )
+        self.assertIn(
+            "Arch.ThreadLoweringProof.FoldedExit.applyUpdates "
+            "M_T_0__t0_S0_entry_seq_0Updates store 0 = 0",
+            lean,
+        )
+        self.assertIn(
+            "Arch.ThreadLoweringProof.FoldedExit.applyUpdates "
+            "M_T_0__t0_S0_entry_seq_0Updates store 1 = 1",
+            lean,
+        )
+
+    def test_repeated_seq_assignment_proves_final_write(self) -> None:
+        cert = base_cert()
+        state = cert["modules"][0]["threads"][0]["states"][0]
+        state["seq_updates"] = ["x <= true", "x <= false"]
+        state["seq_assignments"] = [
+            {"target": "x", "value": "true"},
+            {"target": "x", "value": "false"},
+        ]
+        lean = cert_to_lean.render(cert)
+        self.assertIn(
+            "[Arch.ThreadLoweringProof.FoldedExit.setVar 0 0, "
+            "Arch.ThreadLoweringProof.FoldedExit.setVar 0 1]",
+            lean,
+        )
+        self.assertIn(
+            "Arch.ThreadLoweringProof.FoldedExit.applyUpdates "
+            "M_T_0__t0_S0_entry_seq_0Updates store 0 = 1",
+            lean,
+        )
+        self.assertNotIn(
+            "Arch.ThreadLoweringProof.FoldedExit.applyUpdates "
+            "M_T_0__t0_S0_entry_seq_0Updates store 0 = 0",
+            lean,
+        )
+
+    def test_once_terminal_non_emitted_target_maps_to_hold(self) -> None:
+        cert = base_cert(target_index=1)
+        thread = cert["modules"][0]["threads"][0]
+        thread["once"] = True
+        terminal = thread["states"][1]
+        terminal["emitted"] = False
+        terminal["source_next_index"] = 1
+        terminal["source_next_name"] = "_t0_S1_action"
+        terminal["source_transitions"] = [
+            transition("always", 1, "_t0_S1_action"),
+        ]
+        terminal["transitions"] = [
+            transition("always", 1, "_t0_S1_action"),
+        ]
+
+        lean = cert_to_lean.render(cert)
+        self.assertIn("once := true", lean)
+        self.assertIn(
+            "{ actions := [0], control := Control.advance, target := 0 }",
+            lean,
+        )
+        self.assertIn(
+            "forall t, sourceTraceObs M_T_0Source inputs natInputs cfg0 t = "
+            "fsmTraceObs M_T_0Fsm inputs natInputs cfg0 t",
+            lean,
+        )
+
+    def test_folded_exit_multi_assignment_store_effects_are_emitted(self) -> None:
+        cert = base_cert()
+        state = cert["modules"][0]["threads"][0]["states"][0]
+        state["seq_updates"] = []
+        state["seq_assignments"] = []
+        state["folded_exit_updates"] = ["x <= true", "y <= false"]
+        state["folded_exit_assignments"] = [
+            {"target": "x", "value": "true"},
+            {"target": "y", "value": "false"},
+        ]
+        lean = cert_to_lean.render(cert)
+        self.assertIn(
+            "[Arch.ThreadLoweringProof.FoldedExit.setVar 0 0, "
+            "Arch.ThreadLoweringProof.FoldedExit.setVar 1 1]",
+            lean,
+        )
+        self.assertIn(
+            "((Arch.ThreadLoweringProof.FoldedExit.sourceStep "
+            "M_T_0__t0_S0_entry_folded_0Source env natEnv cfg).store 0 = 0)",
+            lean,
+        )
+        self.assertIn(
+            "((Arch.ThreadLoweringProof.FoldedExit.fsmStep "
+            "M_T_0__t0_S0_entry_folded_0Fsm env natEnv cfg).store 1 = 1)",
+            lean,
+        )
+
+    def test_repeated_folded_exit_assignment_proves_final_write(self) -> None:
+        cert = base_cert()
+        state = cert["modules"][0]["threads"][0]["states"][0]
+        state["seq_updates"] = []
+        state["seq_assignments"] = []
+        state["folded_exit_updates"] = ["x <= true", "x <= false"]
+        state["folded_exit_assignments"] = [
+            {"target": "x", "value": "true"},
+            {"target": "x", "value": "false"},
+        ]
+        lean = cert_to_lean.render(cert)
+        self.assertIn(
+            "[Arch.ThreadLoweringProof.FoldedExit.setVar 0 0, "
+            "Arch.ThreadLoweringProof.FoldedExit.setVar 0 1]",
+            lean,
+        )
+        self.assertIn(
+            "((Arch.ThreadLoweringProof.FoldedExit.sourceStep "
+            "M_T_0__t0_S0_entry_folded_0Source env natEnv cfg).store 0 = 1)",
+            lean,
+        )
+        self.assertNotIn(
+            "((Arch.ThreadLoweringProof.FoldedExit.sourceStep "
+            "M_T_0__t0_S0_entry_folded_0Source env natEnv cfg).store 0 = 0)",
+            lean,
+        )
+
+    def test_unsupported_folded_exit_update_is_rejected(self) -> None:
+        cert = base_cert()
+        state = cert["modules"][0]["threads"][0]["states"][0]
+        state["folded_exit_updates"] = ["if req then done_r <= true"]
+        state["folded_exit_assignments"] = []
+        with self.assertRaises(SystemExit) as caught:
+            cert_to_lean.render(cert)
+        self.assertIn("folded_exit_updates require structured", str(caught.exception))
+
+    def test_partial_folded_exit_assignment_coverage_is_rejected(self) -> None:
+        cert = base_cert()
+        state = cert["modules"][0]["threads"][0]["states"][0]
+        state["folded_exit_updates"] = ["done_r <= true", "ack_r <= false"]
+        state["folded_exit_assignments"] = [
+            {"target": "done_r", "value": "true"},
+        ]
+        with self.assertRaises(SystemExit) as caught:
+            cert_to_lean.render(cert)
+        self.assertIn("folded_exit_updates require structured", str(caught.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/elaborate.rs
+++ b/src/elaborate.rs
@@ -34,26 +34,35 @@ pub fn elaborate(ast: SourceFile) -> Result<SourceFile, Vec<CompileError>> {
     let ast = crate::type_alias::resolve_type_aliases(ast)?;
 
     // Build enum variant → value map for resolving enum-typed params
-    let enum_values: HashMap<String, Vec<(String, u64)>> = ast.items.iter()
+    let enum_values: HashMap<String, Vec<(String, u64)>> = ast
+        .items
+        .iter()
         .filter_map(|item| {
             let e = match item {
                 Item::Enum(e) => Some(e),
-                Item::Package(p) => p.enums.first(),  // simplification: first enum in pkg
+                Item::Package(p) => p.enums.first(), // simplification: first enum in pkg
                 _ => None,
             }?;
-            let entries: Vec<(String, u64)> = e.variants.iter().enumerate().map(|(i, v)| {
-                let val = e.values.get(i)
-                    .and_then(|opt| opt.as_ref())
-                    .and_then(|expr| match &expr.kind {
-                        ExprKind::Literal(LitKind::Dec(n)) => Some(*n),
-                        ExprKind::Literal(LitKind::Hex(n)) => Some(*n),
-                        ExprKind::Literal(LitKind::Bin(n)) => Some(*n),
-                        ExprKind::Literal(LitKind::Sized(_, n)) => Some(*n),
-                        _ => None,
-                    })
-                    .unwrap_or(i as u64);
-                (v.name.clone(), val)
-            }).collect();
+            let entries: Vec<(String, u64)> = e
+                .variants
+                .iter()
+                .enumerate()
+                .map(|(i, v)| {
+                    let val = e
+                        .values
+                        .get(i)
+                        .and_then(|opt| opt.as_ref())
+                        .and_then(|expr| match &expr.kind {
+                            ExprKind::Literal(LitKind::Dec(n)) => Some(*n),
+                            ExprKind::Literal(LitKind::Hex(n)) => Some(*n),
+                            ExprKind::Literal(LitKind::Bin(n)) => Some(*n),
+                            ExprKind::Literal(LitKind::Sized(_, n)) => Some(*n),
+                            _ => None,
+                        })
+                        .unwrap_or(i as u64);
+                    (v.name.clone(), val)
+                })
+                .collect();
             Some((e.name.name.clone(), entries))
         })
         .collect();
@@ -64,7 +73,10 @@ pub fn elaborate(ast: SourceFile) -> Result<SourceFile, Vec<CompileError>> {
         .iter()
         .filter_map(|item| {
             if let Item::Module(m) = item {
-                Some((m.name.name.clone(), compute_defaults_with_enums(&m.params, &enum_values)))
+                Some((
+                    m.name.name.clone(),
+                    compute_defaults_with_enums(&m.params, &enum_values),
+                ))
             } else {
                 None
             }
@@ -75,7 +87,10 @@ pub fn elaborate(ast: SourceFile) -> Result<SourceFile, Vec<CompileError>> {
     let mut inst_raw: HashMap<String, Vec<HashMap<String, i64>>> = HashMap::new();
     for item in &ast.items {
         if let Item::Module(m) = item {
-            let param_vals = module_defaults.get(&m.name.name).cloned().unwrap_or_default();
+            let param_vals = module_defaults
+                .get(&m.name.name)
+                .cloned()
+                .unwrap_or_default();
             collect_raw_overrides_from_body(&m.body, &mut inst_raw, &param_vals);
         }
     }
@@ -86,7 +101,9 @@ pub fn elaborate(ast: SourceFile) -> Result<SourceFile, Vec<CompileError>> {
     // Child-module port info: needed by expand_generate_for to detect
     // Vec-of-bus child ports that disqualify the SV-genvar preservation.
     // Built once for the whole file (mirrors the lower_tlm_connects map).
-    let child_module_ports: HashMap<String, Vec<PortDecl>> = ast.items.iter()
+    let child_module_ports: HashMap<String, Vec<PortDecl>> = ast
+        .items
+        .iter()
         .filter_map(|item| match item {
             Item::Module(m) => Some((m.name.name.clone(), m.ports.clone())),
             Item::Fsm(f) => Some((f.name.name.clone(), f.ports.clone())),
@@ -102,10 +119,16 @@ pub fn elaborate(ast: SourceFile) -> Result<SourceFile, Vec<CompileError>> {
     for item in ast.items {
         match item {
             Item::Module(m) => {
-                let variants = module_variants.get(&m.name.name).cloned().unwrap_or_else(|| {
-                    let d = module_defaults.get(&m.name.name).cloned().unwrap_or_default();
-                    vec![(d, m.name.name.clone())]
-                });
+                let variants = module_variants
+                    .get(&m.name.name)
+                    .cloned()
+                    .unwrap_or_else(|| {
+                        let d = module_defaults
+                            .get(&m.name.name)
+                            .cloned()
+                            .unwrap_or_default();
+                        vec![(d, m.name.name.clone())]
+                    });
                 for (param_vals, variant_name) in variants {
                     match elaborate_module_variant(
                         m.clone(),
@@ -130,7 +153,11 @@ pub fn elaborate(ast: SourceFile) -> Result<SourceFile, Vec<CompileError>> {
     if !errors.is_empty() {
         Err(errors)
     } else {
-        lower_tlm_connects(SourceFile { items: new_items, inner_doc: None, frontmatter: None })
+        lower_tlm_connects(SourceFile {
+            items: new_items,
+            inner_doc: None,
+            frontmatter: None,
+        })
     }
 }
 
@@ -153,7 +180,7 @@ fn collect_raw_overrides_from_body(
                 // so eval with those.
                 GenerateDecl::For(gf) => {
                     let start = try_eval_i64(&gf.start, enclosing_params);
-                    let end   = try_eval_i64(&gf.end,   enclosing_params);
+                    let end = try_eval_i64(&gf.end, enclosing_params);
                     let var_name = &gf.var.name;
                     for it in &gf.items {
                         if let GenItem::Inst(inst) = it {
@@ -186,7 +213,7 @@ fn collect_raw_overrides_from_body(
                         }
                     }
                 }
-            }
+            },
             ModuleBodyItem::TlmConnect(_) => {}
             _ => {}
         }
@@ -218,12 +245,20 @@ fn record_inst(
         if let ExprKind::Cast(_, ty) = &conn.signal.kind {
             if let TypeExpr::Reset(kind, level) = ty.as_ref() {
                 let pname = &conn.port_name.name;
-                overrides.insert(format!("__ro__{pname}__kind"),  if kind == &ResetKind::Async { 1 } else { 0 });
-                overrides.insert(format!("__ro__{pname}__level"), if level == &ResetLevel::Low { 1 } else { 0 });
+                overrides.insert(
+                    format!("__ro__{pname}__kind"),
+                    if kind == &ResetKind::Async { 1 } else { 0 },
+                );
+                overrides.insert(
+                    format!("__ro__{pname}__level"),
+                    if level == &ResetLevel::Low { 1 } else { 0 },
+                );
             }
         }
     }
-    out.entry(inst.module_name.name.clone()).or_default().push(overrides);
+    out.entry(inst.module_name.name.clone())
+        .or_default()
+        .push(overrides);
 }
 
 // ── Step 3: compute variants ──────────────────────────────────────────────────
@@ -238,7 +273,10 @@ fn compute_all_variants(
 
     for item in items {
         if let Item::Module(m) = item {
-            let defaults = module_defaults.get(&m.name.name).cloned().unwrap_or_default();
+            let defaults = module_defaults
+                .get(&m.name.name)
+                .cloned()
+                .unwrap_or_default();
 
             // Compute effective params for each inst site (deduped)
             let mut effective_sets: Vec<HashMap<String, i64>> = Vec::new();
@@ -260,7 +298,10 @@ fn compute_all_variants(
 
             let variants = if effective_sets.len() == 1 {
                 // Only one combination → keep original name
-                vec![(effective_sets.into_iter().next().unwrap(), m.name.name.clone())]
+                vec![(
+                    effective_sets.into_iter().next().unwrap(),
+                    m.name.name.clone(),
+                )]
             } else {
                 // Multiple combinations → mangle names
                 let varying = find_varying_params(&effective_sets);
@@ -314,8 +355,8 @@ fn make_variant_name(base: &str, params: &HashMap<String, i64>, varying: &[Strin
             let kind_val = params.get(k.as_str()).copied().unwrap_or(0);
             let level_key = format!("__ro__{port}__level");
             let level_val = params.get(&level_key).copied().unwrap_or(0);
-            let kind_str  = if kind_val  == 1 { "Async" } else { "Sync"  };
-            let level_str = if level_val == 1 { "Low"   } else { "High"  };
+            let kind_str = if kind_val == 1 { "Async" } else { "Sync" };
+            let level_str = if level_val == 1 { "Low" } else { "High" };
             format!("{port}_{kind_str}_{level_str}")
         })
         .collect();
@@ -353,13 +394,15 @@ fn elaborate_module_variant(
 
     for item in m.body {
         match item {
-            ModuleBodyItem::Generate(gen) => match expand_generate(gen, &param_vals, &parent_shape, child_module_ports) {
-                Ok((ports, items)) => {
-                    extra_ports.extend(ports);
-                    pre_rewrite.extend(items);
+            ModuleBodyItem::Generate(gen) => {
+                match expand_generate(gen, &param_vals, &parent_shape, child_module_ports) {
+                    Ok((ports, items)) => {
+                        extra_ports.extend(ports);
+                        pre_rewrite.extend(items);
+                    }
+                    Err(mut errs) => errors.append(&mut errs),
                 }
-                Err(mut errs) => errors.append(&mut errs),
-            },
+            }
             other => pre_rewrite.push(other),
         }
     }
@@ -377,12 +420,10 @@ fn elaborate_module_variant(
     let mut flattened: Vec<ModuleBodyItem> = Vec::with_capacity(pre_rewrite.len());
     for item in pre_rewrite {
         match item {
-            ModuleBodyItem::Inst(inst) => {
-                match flatten_inst_for_loops(inst, &param_vals) {
-                    Ok(inst) => flattened.push(ModuleBodyItem::Inst(inst)),
-                    Err(mut errs) => errors.append(&mut errs),
-                }
-            }
+            ModuleBodyItem::Inst(inst) => match flatten_inst_for_loops(inst, &param_vals) {
+                Ok(inst) => flattened.push(ModuleBodyItem::Inst(inst)),
+                Err(mut errs) => errors.append(&mut errs),
+            },
             other => flattened.push(other),
         }
     }
@@ -394,9 +435,12 @@ fn elaborate_module_variant(
     let new_body = flattened
         .into_iter()
         .map(|item| match item {
-            ModuleBodyItem::Inst(inst) => {
-                ModuleBodyItem::Inst(rewrite_inst(inst, module_variants, module_defaults, &param_vals))
-            }
+            ModuleBodyItem::Inst(inst) => ModuleBodyItem::Inst(rewrite_inst(
+                inst,
+                module_variants,
+                module_defaults,
+                &param_vals,
+            )),
             other => other,
         })
         .collect();
@@ -411,12 +455,20 @@ fn elaborate_module_variant(
     // Synthetic keys: "__ro__<port>__kind" (0=Sync,1=Async), "__ro__<port>__level" (0=High,1=Low)
     for port in &mut all_ports {
         if let TypeExpr::Reset(_, _) = &port.ty {
-            let kind_key  = format!("__ro__{}__kind",  port.name.name);
+            let kind_key = format!("__ro__{}__kind", port.name.name);
             let level_key = format!("__ro__{}__level", port.name.name);
             if let Some(&k) = param_vals.get(&kind_key) {
                 let l = param_vals.get(&level_key).copied().unwrap_or(0);
-                let new_kind  = if k == 1 { ResetKind::Async } else { ResetKind::Sync  };
-                let new_level = if l == 1 { ResetLevel::Low   } else { ResetLevel::High };
+                let new_kind = if k == 1 {
+                    ResetKind::Async
+                } else {
+                    ResetKind::Sync
+                };
+                let new_level = if l == 1 {
+                    ResetLevel::Low
+                } else {
+                    ResetLevel::High
+                };
                 port.ty = TypeExpr::Reset(new_kind, new_level);
             }
         }
@@ -430,44 +482,65 @@ fn elaborate_module_variant(
     //   instead of a hardcoded literal. This allows derived params to update correctly
     //   when a parent param is overridden at instantiation.
     // - Literal-only params: replace with the evaluated literal.
-    let param_names: std::collections::HashSet<&str> = param_vals.keys().map(|s| s.as_str()).collect();
-    let new_params: Vec<ParamDecl> = m.params.into_iter().map(|mut p| {
-        if let Some(&val) = param_vals.get(&p.name.name) {
-            if matches!(p.kind, ParamKind::EnumConst(_)) {
-                // Preserve the EnumVariant expression for clean SV output
-            } else if p.default.as_ref().map_or(false, |d| expr_references_params(d, &param_names)) {
-                // Preserve original expression for derived params
-            } else {
-                // Width-typed params (`param NAME[hi:lo]: const = ...`) emit
-                // SV `parameter [hi:lo] NAME = <default>`. If we replaced
-                // the default with a bare `LitKind::Dec(val)`, the SV
-                // initializer would be unsized (32-bit by default) and
-                // Verilator's WIDTHTRUNC fires on the parameter init when
-                // the typed width is narrower. Emit a sized literal that
-                // matches the declared width so the init is width-clean.
-                let lit = if let ParamKind::WidthConst(hi, lo) = &p.kind {
-                    let hi_val = try_eval_i64(hi, &param_vals);
-                    let lo_val = try_eval_i64(lo, &param_vals);
-                    match (hi_val, lo_val) {
-                        (Some(h), Some(l)) if h >= l => {
-                            let width = (h - l + 1) as u32;
-                            LitKind::Sized(width, val as u64)
-                        }
-                        _ => LitKind::Dec(val as u64),
-                    }
+    let param_names: std::collections::HashSet<&str> =
+        param_vals.keys().map(|s| s.as_str()).collect();
+    let new_params: Vec<ParamDecl> = m
+        .params
+        .into_iter()
+        .map(|mut p| {
+            if let Some(&val) = param_vals.get(&p.name.name) {
+                if matches!(p.kind, ParamKind::EnumConst(_)) {
+                    // Preserve the EnumVariant expression for clean SV output
+                } else if p
+                    .default
+                    .as_ref()
+                    .map_or(false, |d| expr_references_params(d, &param_names))
+                {
+                    // Preserve original expression for derived params
                 } else {
-                    LitKind::Dec(val as u64)
-                };
-                p.default = Some(Expr::new(
-                    ExprKind::Literal(lit),
-                    p.name.span,
-                ));
+                    // Width-typed params (`param NAME[hi:lo]: const = ...`) emit
+                    // SV `parameter [hi:lo] NAME = <default>`. If we replaced
+                    // the default with a bare `LitKind::Dec(val)`, the SV
+                    // initializer would be unsized (32-bit by default) and
+                    // Verilator's WIDTHTRUNC fires on the parameter init when
+                    // the typed width is narrower. Emit a sized literal that
+                    // matches the declared width so the init is width-clean.
+                    let lit = if let ParamKind::WidthConst(hi, lo) = &p.kind {
+                        let hi_val = try_eval_i64(hi, &param_vals);
+                        let lo_val = try_eval_i64(lo, &param_vals);
+                        match (hi_val, lo_val) {
+                            (Some(h), Some(l)) if h >= l => {
+                                let width = (h - l + 1) as u32;
+                                LitKind::Sized(width, val as u64)
+                            }
+                            _ => LitKind::Dec(val as u64),
+                        }
+                    } else {
+                        LitKind::Dec(val as u64)
+                    };
+                    p.default = Some(Expr::new(ExprKind::Literal(lit), p.name.span));
+                }
             }
-        }
-        p
-    }).collect();
+            p
+        })
+        .collect();
 
-    Ok(ModuleDecl { name: new_name, params: new_params, ports: all_ports, body: new_body, implements: m.implements, hooks: m.hooks, cdc_safe: m.cdc_safe, rdc_safe: m.rdc_safe, comb_loops_allowed: m.comb_loops_allowed, allow_dead_skid_feedback: m.allow_dead_skid_feedback, span: m.span, doc: m.doc, inner_doc: m.inner_doc, is_interface: m.is_interface })
+    Ok(ModuleDecl {
+        name: new_name,
+        params: new_params,
+        ports: all_ports,
+        body: new_body,
+        implements: m.implements,
+        hooks: m.hooks,
+        cdc_safe: m.cdc_safe,
+        rdc_safe: m.rdc_safe,
+        comb_loops_allowed: m.comb_loops_allowed,
+        allow_dead_skid_feedback: m.allow_dead_skid_feedback,
+        span: m.span,
+        doc: m.doc,
+        inner_doc: m.inner_doc,
+        is_interface: m.is_interface,
+    })
 }
 
 /// Rewrite an inst's `module_name` to the correct variant name.
@@ -501,8 +574,14 @@ fn rewrite_inst(
         if let ExprKind::Cast(_, ty) = &conn.signal.kind {
             if let TypeExpr::Reset(kind, level) = ty.as_ref() {
                 let pname = &conn.port_name.name;
-                effective.insert(format!("__ro__{pname}__kind"),  if kind == &ResetKind::Async { 1 } else { 0 });
-                effective.insert(format!("__ro__{pname}__level"), if level == &ResetLevel::Low { 1 } else { 0 });
+                effective.insert(
+                    format!("__ro__{pname}__kind"),
+                    if kind == &ResetKind::Async { 1 } else { 0 },
+                );
+                effective.insert(
+                    format!("__ro__{pname}__level"),
+                    if level == &ResetLevel::Low { 1 } else { 0 },
+                );
             }
         }
     }
@@ -522,7 +601,9 @@ fn rewrite_inst(
 // ── TLM/bus connect sugar ───────────────────────────────────────────────────
 
 fn lower_tlm_connects(ast: SourceFile) -> Result<SourceFile, Vec<CompileError>> {
-    let module_ports: HashMap<String, Vec<PortDecl>> = ast.items.iter()
+    let module_ports: HashMap<String, Vec<PortDecl>> = ast
+        .items
+        .iter()
         .filter_map(|item| match item {
             Item::Module(m) => Some((m.name.name.clone(), m.ports.clone())),
             Item::Fsm(f) => Some((f.name.name.clone(), f.ports.clone())),
@@ -544,7 +625,11 @@ fn lower_tlm_connects(ast: SourceFile) -> Result<SourceFile, Vec<CompileError>> 
     }
 
     if errors.is_empty() {
-        Ok(SourceFile { items, inner_doc: ast.inner_doc, frontmatter: ast.frontmatter })
+        Ok(SourceFile {
+            items,
+            inner_doc: ast.inner_doc,
+            frontmatter: ast.frontmatter,
+        })
     } else {
         Err(errors)
     }
@@ -554,7 +639,9 @@ fn lower_tlm_connects_in_module(
     mut m: ModuleDecl,
     module_ports: &HashMap<String, Vec<PortDecl>>,
 ) -> Result<ModuleDecl, Vec<CompileError>> {
-    let connects: Vec<TlmConnectDecl> = m.body.iter()
+    let connects: Vec<TlmConnectDecl> = m
+        .body
+        .iter()
         .filter_map(|item| match item {
             ModuleBodyItem::TlmConnect(c) => Some(c.clone()),
             _ => None,
@@ -578,10 +665,18 @@ fn lower_tlm_connects_in_module(
                     }
                 }
             }
-            ModuleBodyItem::RegDecl(r) => { used_names.insert(r.name.name.clone()); }
-            ModuleBodyItem::WireDecl(w) => { used_names.insert(w.name.name.clone()); }
-            ModuleBodyItem::LetBinding(l) => { used_names.insert(l.name.name.clone()); }
-            ModuleBodyItem::PipeRegDecl(p) => { used_names.insert(p.name.name.clone()); }
+            ModuleBodyItem::RegDecl(r) => {
+                used_names.insert(r.name.name.clone());
+            }
+            ModuleBodyItem::WireDecl(w) => {
+                used_names.insert(w.name.name.clone());
+            }
+            ModuleBodyItem::LetBinding(l) => {
+                used_names.insert(l.name.name.clone());
+            }
+            ModuleBodyItem::PipeRegDecl(p) => {
+                used_names.insert(p.name.name.clone());
+            }
             _ => {}
         }
     }
@@ -621,7 +716,10 @@ fn lower_tlm_connects_in_module(
         let (to_bus, to_persp, to_span) = to;
 
         let error_count_before_endpoint_checks = errors.len();
-        for endpoint in [(&conn.from_inst, &conn.from_port), (&conn.to_inst, &conn.to_port)] {
+        for endpoint in [
+            (&conn.from_inst, &conn.from_port),
+            (&conn.to_inst, &conn.to_port),
+        ] {
             let key = (endpoint.0.name.clone(), endpoint.1.name.clone());
             if let Some(first_span) = connected_endpoints.get(&key) {
                 errors.push(CompileError::general(
@@ -665,11 +763,23 @@ fn lower_tlm_connects_in_module(
             continue;
         }
         let error_count_before_duplicate_checks = errors.len();
-        for (inst_name, port_name) in [(&conn.from_inst, &conn.from_port), (&conn.to_inst, &conn.to_port)] {
-            if let Some(existing) = m.body.iter().find_map(|item| match item {
-                ModuleBodyItem::Inst(inst) if inst.name.name == inst_name.name => Some(inst),
-                _ => None,
-            }).and_then(|inst| inst.connections.iter().find(|c| c.port_name.name == port_name.name)) {
+        for (inst_name, port_name) in [
+            (&conn.from_inst, &conn.from_port),
+            (&conn.to_inst, &conn.to_port),
+        ] {
+            if let Some(existing) = m
+                .body
+                .iter()
+                .find_map(|item| match item {
+                    ModuleBodyItem::Inst(inst) if inst.name.name == inst_name.name => Some(inst),
+                    _ => None,
+                })
+                .and_then(|inst| {
+                    inst.connections
+                        .iter()
+                        .find(|c| c.port_name.name == port_name.name)
+                })
+            {
                 errors.push(CompileError::general(
                     &format!(
                         "`connect {}.{}` duplicates an explicit connection on inst `{}` port `{}`",
@@ -696,28 +806,36 @@ fn lower_tlm_connects_in_module(
         used_names.insert(wire_name.clone());
 
         let wire_ident = Ident::new(wire_name.clone(), conn.span);
-        synthesized_wires.push(ModuleBodyItem::WireDecl(WireDecl { bus_params: Vec::new(),
+        synthesized_wires.push(ModuleBodyItem::WireDecl(WireDecl {
+            bus_params: Vec::new(),
             name: wire_ident.clone(),
             ty: TypeExpr::Named(Ident::new(from_bus.clone(), conn.span)),
-            unpacked: false, unpacked_ascending: false,
+            unpacked: false,
+            unpacked_ascending: false,
             span: conn.span,
         }));
 
         let signal = Expr::new(ExprKind::Ident(wire_name), conn.span);
-        synthesized_conns.entry(conn.from_inst.name.clone()).or_default().push(Connection {
-            port_name: conn.from_port.clone(),
-            direction: ConnectDir::Output,
-            signal: signal.clone(),
-            reset_override: None,
-            span: conn.span,
-        });
-        synthesized_conns.entry(conn.to_inst.name.clone()).or_default().push(Connection {
-            port_name: conn.to_port.clone(),
-            direction: ConnectDir::Output,
-            signal,
-            reset_override: None,
-            span: conn.span,
-        });
+        synthesized_conns
+            .entry(conn.from_inst.name.clone())
+            .or_default()
+            .push(Connection {
+                port_name: conn.from_port.clone(),
+                direction: ConnectDir::Output,
+                signal: signal.clone(),
+                reset_override: None,
+                span: conn.span,
+            });
+        synthesized_conns
+            .entry(conn.to_inst.name.clone())
+            .or_default()
+            .push(Connection {
+                port_name: conn.to_port.clone(),
+                direction: ConnectDir::Output,
+                signal,
+                reset_override: None,
+                span: conn.span,
+            });
     }
 
     if !errors.is_empty() {
@@ -857,7 +975,9 @@ fn expand_generate(
     child_module_ports: &HashMap<String, Vec<PortDecl>>,
 ) -> Result<(Vec<PortDecl>, Vec<ModuleBodyItem>), Vec<CompileError>> {
     match gen {
-        GenerateDecl::For(gf) => expand_generate_for(gf, param_vals, parent_shape, child_module_ports),
+        GenerateDecl::For(gf) => {
+            expand_generate_for(gf, param_vals, parent_shape, child_module_ports)
+        }
         GenerateDecl::If(gi) => expand_generate_if(gi, param_vals),
     }
 }
@@ -867,13 +987,12 @@ fn expr_references_param(expr: &Expr, param_names: &[String]) -> bool {
     match &expr.kind {
         ExprKind::Ident(name) => param_names.contains(name),
         ExprKind::Binary(_, l, r) => {
-            expr_references_param(l, param_names)
-                || expr_references_param(r, param_names)
+            expr_references_param(l, param_names) || expr_references_param(r, param_names)
         }
         ExprKind::Unary(_, e) => expr_references_param(e, param_names),
-        ExprKind::Clog2(e)
-        | ExprKind::Signed(e)
-        | ExprKind::Unsigned(e) => expr_references_param(e, param_names),
+        ExprKind::Clog2(e) | ExprKind::Signed(e) | ExprKind::Unsigned(e) => {
+            expr_references_param(e, param_names)
+        }
         _ => false,
     }
 }
@@ -888,8 +1007,14 @@ fn expand_generate_for(
     let param_names: Vec<String> = param_vals.keys().cloned().collect();
 
     let has_port_items = gf.items.iter().any(|item| matches!(item, GenItem::Port(_)));
-    let has_thread_items = gf.items.iter().any(|item| matches!(item, GenItem::Thread(_)));
-    let has_connect_items = gf.items.iter().any(|item| matches!(item, GenItem::TlmConnect(_)));
+    let has_thread_items = gf
+        .items
+        .iter()
+        .any(|item| matches!(item, GenItem::Thread(_)));
+    let has_connect_items = gf
+        .items
+        .iter()
+        .any(|item| matches!(item, GenItem::TlmConnect(_)));
     let has_inst_items = gf.items.iter().any(|item| matches!(item, GenItem::Inst(_)));
     let has_wire_items = gf.items.iter().any(|item| matches!(item, GenItem::Wire(_)));
     let range_depends_on_param = expr_references_param(&gf.start, &param_names)
@@ -975,7 +1100,7 @@ fn expand_generate_for(
     let mut errors: Vec<CompileError> = Vec::new();
     for item in &gf.items {
         match item {
-            GenItem::Seq(rb)  => check_gen_for_reg_stmts(&rb.stmts, var, &mut errors),
+            GenItem::Seq(rb) => check_gen_for_reg_stmts(&rb.stmts, var, &mut errors),
             GenItem::Comb(cb) => check_gen_for_comb_stmts(&cb.stmts, var, &mut errors),
             _ => {}
         }
@@ -994,9 +1119,13 @@ fn expand_generate_for(
                 }
                 GenItem::Thread(t) => body.push(ModuleBodyItem::Thread(subst_thread(t, var, i))),
                 GenItem::Assert(a) => body.push(ModuleBodyItem::Assert(subst_assert(a, var, i))),
-                GenItem::Seq(rb)  => body.push(ModuleBodyItem::RegBlock(subst_reg_block(rb, var, i))),
-                GenItem::Comb(cb) => body.push(ModuleBodyItem::CombBlock(subst_comb_block(cb, var, i))),
-                GenItem::Wire(w)  => body.push(ModuleBodyItem::WireDecl(subst_wire_decl(w, var, i))),
+                GenItem::Seq(rb) => {
+                    body.push(ModuleBodyItem::RegBlock(subst_reg_block(rb, var, i)))
+                }
+                GenItem::Comb(cb) => {
+                    body.push(ModuleBodyItem::CombBlock(subst_comb_block(cb, var, i)))
+                }
+                GenItem::Wire(w) => body.push(ModuleBodyItem::WireDecl(subst_wire_decl(w, var, i))),
             }
         }
     }
@@ -1041,7 +1170,10 @@ fn inst_is_shape_stable_for_genvar(
 
     for conn in &inst.connections {
         // Child-side: Vec-of-bus port? Unsafe.
-        if let Some(p) = child_ports.iter().find(|p| p.name.name == conn.port_name.name) {
+        if let Some(p) = child_ports
+            .iter()
+            .find(|p| p.name.name == conn.port_name.name)
+        {
             if let Some(bi) = &p.bus_info {
                 if bi.count.is_some() {
                     return false;
@@ -1102,23 +1234,25 @@ fn signal_indexes_vec_of_bus(expr: &Expr, parent_shape: &ParentShapeInfo) -> boo
 fn expr_mentions_ident(expr: &Expr, name: &str) -> bool {
     match &expr.kind {
         ExprKind::Ident(n) => n == name,
-        ExprKind::Binary(_, l, r) =>
-            expr_mentions_ident(l, name) || expr_mentions_ident(r, name),
+        ExprKind::Binary(_, l, r) => expr_mentions_ident(l, name) || expr_mentions_ident(r, name),
         ExprKind::Unary(_, x) => expr_mentions_ident(x, name),
         ExprKind::FieldAccess(b, _) => expr_mentions_ident(b, name),
-        ExprKind::Index(b, i) =>
-            expr_mentions_ident(b, name) || expr_mentions_ident(i, name),
-        ExprKind::BitSlice(b, h, l) =>
-            expr_mentions_ident(b, name) || expr_mentions_ident(h, name)
-            || expr_mentions_ident(l, name),
+        ExprKind::Index(b, i) => expr_mentions_ident(b, name) || expr_mentions_ident(i, name),
+        ExprKind::BitSlice(b, h, l) => {
+            expr_mentions_ident(b, name)
+                || expr_mentions_ident(h, name)
+                || expr_mentions_ident(l, name)
+        }
         ExprKind::Cast(e, _) => expr_mentions_ident(e, name),
-        ExprKind::Ternary(c, t, f) =>
-            expr_mentions_ident(c, name) || expr_mentions_ident(t, name)
-            || expr_mentions_ident(f, name),
+        ExprKind::Ternary(c, t, f) => {
+            expr_mentions_ident(c, name)
+                || expr_mentions_ident(t, name)
+                || expr_mentions_ident(f, name)
+        }
         ExprKind::Concat(xs) => xs.iter().any(|x| expr_mentions_ident(x, name)),
-        ExprKind::MethodCall(r, _, args) =>
-            expr_mentions_ident(r, name)
-            || args.iter().any(|a| expr_mentions_ident(a, name)),
+        ExprKind::MethodCall(r, _, args) => {
+            expr_mentions_ident(r, name) || args.iter().any(|a| expr_mentions_ident(a, name))
+        }
         _ => false,
     }
 }
@@ -1170,10 +1304,12 @@ fn check_gen_for_reg_stmts(stmts: &[Stmt], var: &str, errors: &mut Vec<CompileEr
                 check_gen_for_reg_stmts(&ie.then_stmts, var, errors);
                 check_gen_for_reg_stmts(&ie.else_stmts, var, errors);
             }
-            Stmt::Match(m) => for arm in &m.arms {
-                check_gen_for_reg_stmts(&arm.body, var, errors);
-            },
-            Stmt::For(f)  => check_gen_for_reg_stmts(&f.body, var, errors),
+            Stmt::Match(m) => {
+                for arm in &m.arms {
+                    check_gen_for_reg_stmts(&arm.body, var, errors);
+                }
+            }
+            Stmt::For(f) => check_gen_for_reg_stmts(&f.body, var, errors),
             Stmt::Init(ib) => check_gen_for_reg_stmts(&ib.body, var, errors),
             Stmt::Log(_) | Stmt::WaitUntil(..) | Stmt::DoUntil { .. } => {}
         }
@@ -1189,10 +1325,14 @@ fn check_gen_for_comb_stmts(stmts: &[Stmt], var: &str, errors: &mut Vec<CompileE
                 check_gen_for_comb_stmts(&ie.else_stmts, var, errors);
             }
             Stmt::Match(m) => {
-                for arm in &m.arms { check_gen_for_comb_stmts(&arm.body, var, errors); }
+                for arm in &m.arms {
+                    check_gen_for_comb_stmts(&arm.body, var, errors);
+                }
             }
             Stmt::For(f) => check_gen_for_comb_stmts(&f.body, var, errors),
-                Stmt::Init(_) | Stmt::WaitUntil(..) | Stmt::DoUntil { .. } => unreachable!("seq-only Stmt variant inside comb-context walker"),
+            Stmt::Init(_) | Stmt::WaitUntil(..) | Stmt::DoUntil { .. } => {
+                unreachable!("seq-only Stmt variant inside comb-context walker")
+            }
             Stmt::Log(_) => {}
         }
     }
@@ -1204,7 +1344,11 @@ fn subst_reg_block(rb: &RegBlock, var: &str, val: i64) -> RegBlock {
     RegBlock {
         clock: rb.clock.clone(),
         clock_edge: rb.clock_edge,
-        stmts: rb.stmts.iter().map(|s| subst_reg_stmt(s, var, val)).collect(),
+        stmts: rb
+            .stmts
+            .iter()
+            .map(|s| subst_reg_stmt(s, var, val))
+            .collect(),
         span: rb.span,
     }
 }
@@ -1217,22 +1361,38 @@ fn subst_reg_stmt(s: &Stmt, var: &str, val: i64) -> Stmt {
     match s {
         Stmt::Assign(a) => Stmt::Assign(Assign {
             target: subst_expr_names(a.target.clone(), var, val),
-            value:  subst_expr_names(a.value.clone(),  var, val),
-            span:   a.span,
+            value: subst_expr_names(a.value.clone(), var, val),
+            span: a.span,
         }),
         Stmt::IfElse(ie) => Stmt::IfElse(IfElseOf {
-            cond:       subst_expr_names(ie.cond.clone(), var, val),
-            then_stmts: ie.then_stmts.iter().map(|x| subst_reg_stmt(x, var, val)).collect(),
-            else_stmts: ie.else_stmts.iter().map(|x| subst_reg_stmt(x, var, val)).collect(),
-            unique:     ie.unique,
-            span:       ie.span,
+            cond: subst_expr_names(ie.cond.clone(), var, val),
+            then_stmts: ie
+                .then_stmts
+                .iter()
+                .map(|x| subst_reg_stmt(x, var, val))
+                .collect(),
+            else_stmts: ie
+                .else_stmts
+                .iter()
+                .map(|x| subst_reg_stmt(x, var, val))
+                .collect(),
+            unique: ie.unique,
+            span: ie.span,
         }),
         Stmt::Match(m) => Stmt::Match(MatchStmt {
             scrutinee: subst_expr_names(m.scrutinee.clone(), var, val),
-            arms: m.arms.iter().map(|arm| MatchArm {
-                pattern: arm.pattern.clone(),
-                body: arm.body.iter().map(|s| subst_reg_stmt(s, var, val)).collect(),
-            }).collect(),
+            arms: m
+                .arms
+                .iter()
+                .map(|arm| MatchArm {
+                    pattern: arm.pattern.clone(),
+                    body: arm
+                        .body
+                        .iter()
+                        .map(|s| subst_reg_stmt(s, var, val))
+                        .collect(),
+                })
+                .collect(),
             unique: m.unique,
             span: m.span,
         }),
@@ -1246,7 +1406,11 @@ fn subst_reg_stmt(s: &Stmt, var: &str, val: i64) -> Stmt {
 
 fn subst_comb_block(cb: &CombBlock, var: &str, val: i64) -> CombBlock {
     CombBlock {
-        stmts: cb.stmts.iter().map(|s| subst_comb_stmt(s, var, val)).collect(),
+        stmts: cb
+            .stmts
+            .iter()
+            .map(|s| subst_comb_stmt(s, var, val))
+            .collect(),
         span: cb.span,
     }
 }
@@ -1255,15 +1419,23 @@ fn subst_comb_stmt(s: &Stmt, var: &str, val: i64) -> Stmt {
     match s {
         Stmt::Assign(a) => Stmt::Assign(Assign {
             target: subst_expr_names(a.target.clone(), var, val),
-            value:  subst_expr_names(a.value.clone(),  var, val),
-            span:   a.span,
+            value: subst_expr_names(a.value.clone(), var, val),
+            span: a.span,
         }),
         Stmt::IfElse(ie) => Stmt::IfElse(IfElseOf {
-            cond:       subst_expr_names(ie.cond.clone(), var, val),
-            then_stmts: ie.then_stmts.iter().map(|x| subst_comb_stmt(x, var, val)).collect(),
-            else_stmts: ie.else_stmts.iter().map(|x| subst_comb_stmt(x, var, val)).collect(),
-            unique:     ie.unique,
-            span:       ie.span,
+            cond: subst_expr_names(ie.cond.clone(), var, val),
+            then_stmts: ie
+                .then_stmts
+                .iter()
+                .map(|x| subst_comb_stmt(x, var, val))
+                .collect(),
+            else_stmts: ie
+                .else_stmts
+                .iter()
+                .map(|x| subst_comb_stmt(x, var, val))
+                .collect(),
+            unique: ie.unique,
+            span: ie.span,
         }),
         other => other.clone(),
     }
@@ -1295,9 +1467,9 @@ fn expand_generate_if(
             // No loop var in generate_if, so seq/comb/wire pass through
             // verbatim. Reading B's write-target rule only applies to
             // generate_for.
-            GenItem::Seq(rb)  => body.push(ModuleBodyItem::RegBlock(rb)),
+            GenItem::Seq(rb) => body.push(ModuleBodyItem::RegBlock(rb)),
             GenItem::Comb(cb) => body.push(ModuleBodyItem::CombBlock(cb)),
-            GenItem::Wire(w)  => body.push(ModuleBodyItem::WireDecl(w)),
+            GenItem::Wire(w) => body.push(ModuleBodyItem::WireDecl(w)),
         }
     }
     Ok((ports, body))
@@ -1463,11 +1635,14 @@ fn subst_inst_for_loop(fl: &InstForLoop, var: &str, val: i64) -> InstForLoop {
     InstForLoop {
         var: fl.var.clone(),
         start: subst_expr_names(fl.start.clone(), var, val),
-        end:   subst_expr_names(fl.end.clone(),   var, val),
+        end: subst_expr_names(fl.end.clone(), var, val),
         body: if shadowed {
             fl.body.clone()
         } else {
-            fl.body.iter().map(|it| subst_inst_body_item(it, var, val)).collect()
+            fl.body
+                .iter()
+                .map(|it| subst_inst_body_item(it, var, val))
+                .collect()
         },
         span: fl.span,
     }
@@ -1494,19 +1669,35 @@ fn subst_thread(t: &ThreadBlock, var: &str, val: i64) -> ThreadBlock {
         reset: t.reset.clone(),
         reset_level: t.reset_level,
         once: t.once,
-        default_when: t.default_when.as_ref().map(|(cond, stmts)| (
-            subst_expr_names(cond.clone(), var, val),
-            stmts.iter().map(|s| subst_thread_stmt(s, var, val)).collect(),
-        )),
-        default_comb: t.default_comb.iter().map(|s| subst_comb_stmt(s, var, val)).collect(),
+        default_when: t.default_when.as_ref().map(|(cond, stmts)| {
+            (
+                subst_expr_names(cond.clone(), var, val),
+                stmts
+                    .iter()
+                    .map(|s| subst_thread_stmt(s, var, val))
+                    .collect(),
+            )
+        }),
+        default_comb: t
+            .default_comb
+            .iter()
+            .map(|s| subst_comb_stmt(s, var, val))
+            .collect(),
         tlm_target: t.tlm_target.as_ref().map(|tb| TlmTargetBinding {
             port: tb.port.clone(),
             method: tb.method.clone(),
-            tag_lane: tb.tag_lane.as_ref().map(|e| subst_expr_names(e.clone(), var, val)),
+            tag_lane: tb
+                .tag_lane
+                .as_ref()
+                .map(|e| subst_expr_names(e.clone(), var, val)),
             args: tb.args.clone(),
         }),
         implement: t.implement.clone(),
-        body: t.body.iter().map(|s| subst_thread_stmt(s, var, val)).collect(),
+        body: t
+            .body
+            .iter()
+            .map(|s| subst_thread_stmt(s, var, val))
+            .collect(),
         span: t.span,
     }
 }
@@ -1537,34 +1728,66 @@ fn subst_thread_stmt(stmt: &ThreadStmt, var: &str, val: i64) -> ThreadStmt {
         }
         ThreadStmt::IfElse(ie) => ThreadStmt::IfElse(ThreadIfElse {
             cond: subst_expr_names(ie.cond.clone(), var, val),
-            then_stmts: ie.then_stmts.iter().map(|s| subst_thread_stmt(s, var, val)).collect(),
-            else_stmts: ie.else_stmts.iter().map(|s| subst_thread_stmt(s, var, val)).collect(),
+            then_stmts: ie
+                .then_stmts
+                .iter()
+                .map(|s| subst_thread_stmt(s, var, val))
+                .collect(),
+            else_stmts: ie
+                .else_stmts
+                .iter()
+                .map(|s| subst_thread_stmt(s, var, val))
+                .collect(),
             unique: ie.unique,
             span: ie.span,
         }),
         ThreadStmt::ForkJoin(branches, sp) => ThreadStmt::ForkJoin(
-            branches.iter().map(|br| br.iter().map(|s| subst_thread_stmt(s, var, val)).collect()).collect(),
+            branches
+                .iter()
+                .map(|br| br.iter().map(|s| subst_thread_stmt(s, var, val)).collect())
+                .collect(),
             *sp,
         ),
-        ThreadStmt::For { var: fvar, start: fstart, end: fend, body, span } => ThreadStmt::For {
+        ThreadStmt::For {
+            var: fvar,
+            start: fstart,
+            end: fend,
+            body,
+            span,
+        } => ThreadStmt::For {
             var: subst_ident(fvar, var, val),
             start: subst_expr_names(fstart.clone(), var, val),
             end: subst_expr_names(fend.clone(), var, val),
-            body: body.iter().map(|s| subst_thread_stmt(s, var, val)).collect(),
+            body: body
+                .iter()
+                .map(|s| subst_thread_stmt(s, var, val))
+                .collect(),
             span: *span,
         },
-        ThreadStmt::Lock { resource, body, span } => ThreadStmt::Lock {
+        ThreadStmt::Lock {
+            resource,
+            body,
+            span,
+        } => ThreadStmt::Lock {
             resource: resource.clone(),
-            body: body.iter().map(|s| subst_thread_stmt(s, var, val)).collect(),
+            body: body
+                .iter()
+                .map(|s| subst_thread_stmt(s, var, val))
+                .collect(),
             span: *span,
         },
         ThreadStmt::DoUntil { body, cond, span } => ThreadStmt::DoUntil {
-            body: body.iter().map(|s| subst_thread_stmt(s, var, val)).collect(),
+            body: body
+                .iter()
+                .map(|s| subst_thread_stmt(s, var, val))
+                .collect(),
             cond: subst_expr_names(cond.clone(), var, val),
             span: *span,
         },
         ThreadStmt::Log(l) => ThreadStmt::Log(l.clone()),
-        ThreadStmt::Return(e, span) => ThreadStmt::Return(subst_expr_names(e.clone(), var, val), *span),
+        ThreadStmt::Return(e, span) => {
+            ThreadStmt::Return(subst_expr_names(e.clone(), var, val), *span)
+        }
     }
 }
 
@@ -1608,7 +1831,11 @@ fn fold_literal_bit_slices_thread_stmt(stmt: ThreadStmt) -> ThreadStmt {
         ThreadStmt::ForkJoin(branches, sp) => ThreadStmt::ForkJoin(
             branches
                 .into_iter()
-                .map(|br| br.into_iter().map(fold_literal_bit_slices_thread_stmt).collect())
+                .map(|br| {
+                    br.into_iter()
+                        .map(fold_literal_bit_slices_thread_stmt)
+                        .collect()
+                })
                 .collect(),
             sp,
         ),
@@ -1622,7 +1849,10 @@ fn fold_literal_bit_slices_thread_stmt(stmt: ThreadStmt) -> ThreadStmt {
             var,
             start: fold_literal_bit_slices_expr(start),
             end: fold_literal_bit_slices_expr(end),
-            body: body.into_iter().map(fold_literal_bit_slices_thread_stmt).collect(),
+            body: body
+                .into_iter()
+                .map(fold_literal_bit_slices_thread_stmt)
+                .collect(),
             span,
         },
         ThreadStmt::Lock {
@@ -1631,11 +1861,17 @@ fn fold_literal_bit_slices_thread_stmt(stmt: ThreadStmt) -> ThreadStmt {
             span,
         } => ThreadStmt::Lock {
             resource,
-            body: body.into_iter().map(fold_literal_bit_slices_thread_stmt).collect(),
+            body: body
+                .into_iter()
+                .map(fold_literal_bit_slices_thread_stmt)
+                .collect(),
             span,
         },
         ThreadStmt::DoUntil { body, cond, span } => ThreadStmt::DoUntil {
-            body: body.into_iter().map(fold_literal_bit_slices_thread_stmt).collect(),
+            body: body
+                .into_iter()
+                .map(fold_literal_bit_slices_thread_stmt)
+                .collect(),
             cond: fold_literal_bit_slices_expr(cond),
             span,
         },
@@ -1665,9 +1901,11 @@ fn fold_literal_bit_slices_expr(expr: Expr) -> Expr {
             let base = fold_literal_bit_slices_expr(*base);
             let hi = fold_literal_bit_slices_expr(*hi);
             let lo = fold_literal_bit_slices_expr(*lo);
-            if let (Some(v), Some(hi_v), Some(lo_v)) =
-                (literal_expr_u64(&base), literal_expr_u64(&hi), literal_expr_u64(&lo))
-            {
+            if let (Some(v), Some(hi_v), Some(lo_v)) = (
+                literal_expr_u64(&base),
+                literal_expr_u64(&hi),
+                literal_expr_u64(&lo),
+            ) {
                 if hi_v >= lo_v && hi_v < 64 {
                     let width = (hi_v - lo_v + 1) as u32;
                     let mask = if width >= 64 {
@@ -1688,9 +1926,7 @@ fn fold_literal_bit_slices_expr(expr: Expr) -> Expr {
             Box::new(fold_literal_bit_slices_expr(*l)),
             Box::new(fold_literal_bit_slices_expr(*r)),
         ),
-        ExprKind::Unary(op, e) => {
-            ExprKind::Unary(op, Box::new(fold_literal_bit_slices_expr(*e)))
-        }
+        ExprKind::Unary(op, e) => ExprKind::Unary(op, Box::new(fold_literal_bit_slices_expr(*e))),
         ExprKind::FieldAccess(e, f) => {
             ExprKind::FieldAccess(Box::new(fold_literal_bit_slices_expr(*e)), f)
         }
@@ -1700,9 +1936,12 @@ fn fold_literal_bit_slices_expr(expr: Expr) -> Expr {
             args.into_iter().map(fold_literal_bit_slices_expr).collect(),
         ),
         ExprKind::Cast(e, ty) => ExprKind::Cast(Box::new(fold_literal_bit_slices_expr(*e)), ty),
-        ExprKind::Concat(exprs) => {
-            ExprKind::Concat(exprs.into_iter().map(fold_literal_bit_slices_expr).collect())
-        }
+        ExprKind::Concat(exprs) => ExprKind::Concat(
+            exprs
+                .into_iter()
+                .map(fold_literal_bit_slices_expr)
+                .collect(),
+        ),
         ExprKind::Ternary(c, t, f) => ExprKind::Ternary(
             Box::new(fold_literal_bit_slices_expr(*c)),
             Box::new(fold_literal_bit_slices_expr(*t)),
@@ -1748,7 +1987,9 @@ fn subst_expr_names(expr: Expr, var: &str, val: i64) -> Expr {
         ExprKind::MethodCall(e, m, args) => ExprKind::MethodCall(
             Box::new(subst_expr_names(*e, var, val)),
             m,
-            args.into_iter().map(|a| subst_expr_names(a, var, val)).collect(),
+            args.into_iter()
+                .map(|a| subst_expr_names(a, var, val))
+                .collect(),
         ),
         ExprKind::Index(base, idx) => ExprKind::Index(
             Box::new(subst_expr_names(*base, var, val)),
@@ -1759,13 +2000,13 @@ fn subst_expr_names(expr: Expr, var: &str, val: i64) -> Expr {
             Box::new(subst_expr_names(*hi, var, val)),
             Box::new(subst_expr_names(*lo, var, val)),
         ),
-        ExprKind::Cast(e, ty) => ExprKind::Cast(
-            Box::new(subst_expr_names(*e, var, val)),
-            ty,
+        ExprKind::Cast(e, ty) => ExprKind::Cast(Box::new(subst_expr_names(*e, var, val)), ty),
+        ExprKind::Concat(exprs) => ExprKind::Concat(
+            exprs
+                .into_iter()
+                .map(|e| subst_expr_names(e, var, val))
+                .collect(),
         ),
-        ExprKind::Concat(exprs) => {
-            ExprKind::Concat(exprs.into_iter().map(|e| subst_expr_names(e, var, val)).collect())
-        }
         ExprKind::Ternary(c, t, f) => ExprKind::Ternary(
             Box::new(subst_expr_names(*c, var, val)),
             Box::new(subst_expr_names(*t, var, val)),
@@ -1773,11 +2014,18 @@ fn subst_expr_names(expr: Expr, var: &str, val: i64) -> Expr {
         ),
         other => other,
     };
-    Expr { kind: new_kind, span: expr.span, parenthesized: expr.parenthesized }
+    Expr {
+        kind: new_kind,
+        span: expr.span,
+        parenthesized: expr.parenthesized,
+    }
 }
 
 fn subst_ident(ident: &Ident, var: &str, val: i64) -> Ident {
-    Ident { name: subst_name(&ident.name, var, val), span: ident.span }
+    Ident {
+        name: subst_name(&ident.name, var, val),
+        span: ident.span,
+    }
 }
 
 /// Substitute the loop var into a wire declaration: rename `w_i` →
@@ -1791,7 +2039,9 @@ fn subst_wire_decl(w: &WireDecl, var: &str, val: i64) -> WireDecl {
         ty: subst_type_expr(&w.ty, var, val),
         unpacked: w.unpacked,
         unpacked_ascending: w.unpacked_ascending,
-        bus_params: w.bus_params.iter()
+        bus_params: w
+            .bus_params
+            .iter()
             .map(|pa| ParamAssign {
                 name: pa.name.clone(),
                 value: subst_expr(pa.value.clone(), var, val),
@@ -1865,7 +2115,11 @@ fn subst_expr(expr: Expr, var: &str, val: i64) -> Expr {
         }
         other => other,
     };
-    Expr { kind: new_kind, span: expr.span, parenthesized: false }
+    Expr {
+        kind: new_kind,
+        span: expr.span,
+        parenthesized: false,
+    }
 }
 
 /// Returns true if the expression references any identifier in `param_names`.
@@ -1911,7 +2165,8 @@ fn compute_defaults_with_enums(
                 if let Some(default) = &p.default {
                     // Resolve EnumVariant expr to its integer value
                     let val = if let ExprKind::EnumVariant(_, variant) = &default.kind {
-                        enum_values.get(enum_name)
+                        enum_values
+                            .get(enum_name)
                             .and_then(|entries| entries.iter().find(|(n, _)| *n == variant.name))
                             .map(|(_, v)| *v as i64)
                     } else {
@@ -1947,42 +2202,84 @@ pub fn try_eval_i64(expr: &Expr, param_vals: &HashMap<String, i64>) -> Option<i6
         }
         ExprKind::Binary(BinOp::Div, l, r) => {
             let rv = try_eval_i64(r, param_vals)?;
-            if rv == 0 { None } else { Some(try_eval_i64(l, param_vals)? / rv) }
+            if rv == 0 {
+                None
+            } else {
+                Some(try_eval_i64(l, param_vals)? / rv)
+            }
         }
         ExprKind::Binary(BinOp::Mod, l, r) => {
             let rv = try_eval_i64(r, param_vals)?;
-            if rv == 0 { None } else { Some(try_eval_i64(l, param_vals)? % rv) }
+            if rv == 0 {
+                None
+            } else {
+                Some(try_eval_i64(l, param_vals)? % rv)
+            }
         }
         ExprKind::Unary(UnaryOp::Neg, e) => Some(-try_eval_i64(e, param_vals)?),
-        ExprKind::Unary(UnaryOp::Not, e) => {
-            Some(if try_eval_i64(e, param_vals)? != 0 { 0 } else { 1 })
-        }
+        ExprKind::Unary(UnaryOp::Not, e) => Some(if try_eval_i64(e, param_vals)? != 0 {
+            0
+        } else {
+            1
+        }),
         // Comparison operators → 0 or 1
-        ExprKind::Binary(BinOp::Eq, l, r) => {
-            Some(if try_eval_i64(l, param_vals)? == try_eval_i64(r, param_vals)? { 1 } else { 0 })
-        }
-        ExprKind::Binary(BinOp::Neq, l, r) => {
-            Some(if try_eval_i64(l, param_vals)? != try_eval_i64(r, param_vals)? { 1 } else { 0 })
-        }
-        ExprKind::Binary(BinOp::Lt, l, r) => {
-            Some(if try_eval_i64(l, param_vals)? < try_eval_i64(r, param_vals)? { 1 } else { 0 })
-        }
-        ExprKind::Binary(BinOp::Gt, l, r) => {
-            Some(if try_eval_i64(l, param_vals)? > try_eval_i64(r, param_vals)? { 1 } else { 0 })
-        }
-        ExprKind::Binary(BinOp::Lte, l, r) => {
-            Some(if try_eval_i64(l, param_vals)? <= try_eval_i64(r, param_vals)? { 1 } else { 0 })
-        }
-        ExprKind::Binary(BinOp::Gte, l, r) => {
-            Some(if try_eval_i64(l, param_vals)? >= try_eval_i64(r, param_vals)? { 1 } else { 0 })
-        }
+        ExprKind::Binary(BinOp::Eq, l, r) => Some(
+            if try_eval_i64(l, param_vals)? == try_eval_i64(r, param_vals)? {
+                1
+            } else {
+                0
+            },
+        ),
+        ExprKind::Binary(BinOp::Neq, l, r) => Some(
+            if try_eval_i64(l, param_vals)? != try_eval_i64(r, param_vals)? {
+                1
+            } else {
+                0
+            },
+        ),
+        ExprKind::Binary(BinOp::Lt, l, r) => Some(
+            if try_eval_i64(l, param_vals)? < try_eval_i64(r, param_vals)? {
+                1
+            } else {
+                0
+            },
+        ),
+        ExprKind::Binary(BinOp::Gt, l, r) => Some(
+            if try_eval_i64(l, param_vals)? > try_eval_i64(r, param_vals)? {
+                1
+            } else {
+                0
+            },
+        ),
+        ExprKind::Binary(BinOp::Lte, l, r) => Some(
+            if try_eval_i64(l, param_vals)? <= try_eval_i64(r, param_vals)? {
+                1
+            } else {
+                0
+            },
+        ),
+        ExprKind::Binary(BinOp::Gte, l, r) => Some(
+            if try_eval_i64(l, param_vals)? >= try_eval_i64(r, param_vals)? {
+                1
+            } else {
+                0
+            },
+        ),
         // Logical operators
-        ExprKind::Binary(BinOp::And, l, r) => {
-            Some(if try_eval_i64(l, param_vals)? != 0 && try_eval_i64(r, param_vals)? != 0 { 1 } else { 0 })
-        }
-        ExprKind::Binary(BinOp::Or, l, r) => {
-            Some(if try_eval_i64(l, param_vals)? != 0 || try_eval_i64(r, param_vals)? != 0 { 1 } else { 0 })
-        }
+        ExprKind::Binary(BinOp::And, l, r) => Some(
+            if try_eval_i64(l, param_vals)? != 0 && try_eval_i64(r, param_vals)? != 0 {
+                1
+            } else {
+                0
+            },
+        ),
+        ExprKind::Binary(BinOp::Or, l, r) => Some(
+            if try_eval_i64(l, param_vals)? != 0 || try_eval_i64(r, param_vals)? != 0 {
+                1
+            } else {
+                0
+            },
+        ),
         // Bitwise operators
         ExprKind::Binary(BinOp::BitAnd, l, r) => {
             Some(try_eval_i64(l, param_vals)? & try_eval_i64(r, param_vals)?)
@@ -2012,7 +2309,11 @@ pub fn try_eval_i64(expr: &Expr, param_vals: &HashMap<String, i64>) -> Option<i6
         ExprKind::Bool(b) => Some(if *b { 1 } else { 0 }),
         ExprKind::Clog2(arg) => {
             let v = try_eval_i64(arg, param_vals)? as u64;
-            if v <= 1 { Some(1) } else { Some(64 - (v - 1).leading_zeros() as i64) }
+            if v <= 1 {
+                Some(1)
+            } else {
+                Some(64 - (v - 1).leading_zeros() as i64)
+            }
         }
         _ => None,
     }
@@ -2090,14 +2391,25 @@ pub fn lower_threads_with_opts(
     // names (e.g. `b.v = true;` → drives `b_v`). Without this, threads
     // that write to bus signals leave the corresponding flat output
     // undriven post-lowering.
-    let bus_defs: HashMap<String, BusDecl> = ast.items.iter()
-        .filter_map(|it| if let Item::Bus(b) = it { Some((b.name.name.clone(), b.clone())) } else { None })
+    let bus_defs: HashMap<String, BusDecl> = ast
+        .items
+        .iter()
+        .filter_map(|it| {
+            if let Item::Bus(b) = it {
+                Some((b.name.name.clone(), b.clone()))
+            } else {
+                None
+            }
+        })
         .collect();
 
     for item in ast.items {
         match item {
             Item::Module(m) => {
-                let has_threads = m.body.iter().any(|i| matches!(i, ModuleBodyItem::Thread(_)));
+                let has_threads = m
+                    .body
+                    .iter()
+                    .any(|i| matches!(i, ModuleBodyItem::Thread(_)));
                 if !has_threads {
                     new_items.push(Item::Module(m));
                     continue;
@@ -2121,7 +2433,11 @@ pub fn lower_threads_with_opts(
     // Insert generated FSMs before the modules that use them
     let mut result = extra_fsms;
     result.extend(new_items);
-    Ok(SourceFile { items: result, inner_doc: None, frontmatter: None })
+    Ok(SourceFile {
+        items: result,
+        inner_doc: None,
+        frontmatter: None,
+    })
 }
 
 /// Lower all threads in a single module to a SINGLE merged module.
@@ -2139,8 +2455,14 @@ fn lower_module_threads(
     // Mapping bus port name → bus name. Used to resolve `b.v = ...` thread
     // targets to the flat signal name `b_v` so the lowering registers
     // them as outputs of the synthesized `_<mod>_threads` sub-module.
-    let bus_port_map: HashMap<String, String> = m.ports.iter()
-        .filter_map(|p| p.bus_info.as_ref().map(|bi| (p.name.name.clone(), bi.bus_name.name.clone())))
+    let bus_port_map: HashMap<String, String> = m
+        .ports
+        .iter()
+        .filter_map(|p| {
+            p.bus_info
+                .as_ref()
+                .map(|bi| (p.name.name.clone(), bi.bus_name.name.clone()))
+        })
         .collect();
     let _reg_map = build_module_reg_map(&m);
     let mut errors: Vec<CompileError> = Vec::new();
@@ -2212,14 +2534,18 @@ fn lower_module_threads(
                         t.span,
                     )]);
                 }
-                let name = t.name.as_ref()
-                    .map(|n| n.name.clone())
-                    .unwrap_or_else(|| {
-                        let n = if thread_idx == 0 { "thread".to_string() }
-                                else { format!("thread{}", thread_idx) };
-                        thread_idx += 1; n
-                    });
-                if t.name.is_some() { thread_idx += 1; }
+                let name = t.name.as_ref().map(|n| n.name.clone()).unwrap_or_else(|| {
+                    let n = if thread_idx == 0 {
+                        "thread".to_string()
+                    } else {
+                        format!("thread{}", thread_idx)
+                    };
+                    thread_idx += 1;
+                    n
+                });
+                if t.name.is_some() {
+                    thread_idx += 1;
+                }
                 threads.push((name, t));
             }
             ModuleBodyItem::Resource(r) => {
@@ -2233,7 +2559,13 @@ fn lower_module_threads(
     }
 
     if threads.is_empty() {
-        return Ok((ModuleDecl { body: new_body, ..m }, Vec::new()));
+        return Ok((
+            ModuleDecl {
+                body: new_body,
+                ..m
+            },
+            Vec::new(),
+        ));
     }
 
     // ── Build merged thread module ─────────────────────────────────────
@@ -2265,7 +2597,8 @@ fn lower_module_threads(
         }
     }
     for (_, t) in &threads {
-        let (dc_targets, dc_reads) = collect_comb_stmt_signals_with_buses(&t.default_comb, &bus_port_map);
+        let (dc_targets, dc_reads) =
+            collect_comb_stmt_signals_with_buses(&t.default_comb, &bus_port_map);
         for target in &dc_targets {
             if all_seq_driven.contains(target) {
                 return Err(vec![CompileError::general(
@@ -2285,19 +2618,44 @@ fn lower_module_threads(
     // Clock and reset ports (from first thread)
     let (clk_name, rst_name, _rst_level) = {
         let t = &threads[0].1;
-        let rk = type_map.get(&t.reset.name).and_then(|si| {
-            if let TypeExpr::Reset(k, _) = &si.ty { Some(*k) } else { None }
-        }).unwrap_or(ResetKind::Async);
+        let rk = type_map
+            .get(&t.reset.name)
+            .and_then(|si| {
+                if let TypeExpr::Reset(k, _) = &si.ty {
+                    Some(*k)
+                } else {
+                    None
+                }
+            })
+            .unwrap_or(ResetKind::Async);
         merged_ports.push(PortDecl {
-            name: t.clock.clone(), direction: Direction::In,
-            ty: type_map.get(&t.clock.name).map(|si| si.ty.clone())
+            name: t.clock.clone(),
+            direction: Direction::In,
+            ty: type_map
+                .get(&t.clock.name)
+                .map(|si| si.ty.clone())
                 .unwrap_or(TypeExpr::Clock(Ident::new("SysDomain".to_string(), sp))),
-            default: None, reg_info: None, bus_info: None, shared: None, unpacked: false, unpacked_ascending: false, comb_deps: None, span: sp,
+            default: None,
+            reg_info: None,
+            bus_info: None,
+            shared: None,
+            unpacked: false,
+            unpacked_ascending: false,
+            comb_deps: None,
+            span: sp,
         });
         merged_ports.push(PortDecl {
-            name: t.reset.clone(), direction: Direction::In,
+            name: t.reset.clone(),
+            direction: Direction::In,
             ty: TypeExpr::Reset(rk, t.reset_level),
-            default: None, reg_info: None, bus_info: None, shared: None, unpacked: false, unpacked_ascending: false, comb_deps: None, span: sp,
+            default: None,
+            reg_info: None,
+            bus_info: None,
+            shared: None,
+            unpacked: false,
+            unpacked_ascending: false,
+            comb_deps: None,
+            span: sp,
         });
         (t.clock.name.clone(), t.reset.name.clone(), t.reset_level)
     };
@@ -2317,22 +2675,30 @@ fn lower_module_threads(
     // (`b_v`, `b_r`, ...) — never the bus name itself. The bus-aware
     // collectors emit both root and flat entries; the rewrite pass
     // converts in-body references to flat names so the root would dangle.
-    let read_only: HashSet<String> = all_read.iter()
-        .filter(|n| !all_comb_driven.contains(*n) && !all_seq_driven.contains(*n)
+    let read_only: HashSet<String> = all_read
+        .iter()
+        .filter(|n| {
+            !all_comb_driven.contains(*n) && !all_seq_driven.contains(*n)
                 && **n != clk_name && **n != rst_name
                 && !n.starts_with("_t") // per-thread counters (_t0_cnt, _t0_loop_cnt_0, etc.)
                 && **n != "_cnt" && !n.starts_with("_loop_cnt")
                 && !lock_internal.contains(*n)
-                && !bus_port_map.contains_key(*n))
-        .cloned().collect();
+                && !bus_port_map.contains_key(*n)
+        })
+        .cloned()
+        .collect();
     let mut sorted_reads: Vec<&String> = read_only.iter().collect();
     sorted_reads.sort();
     for name in sorted_reads {
         if let Some(info) = type_map.get(name.as_str()) {
             merged_ports.push(PortDecl {
-                name: Ident::new(name.clone(), sp), direction: Direction::In,
+                name: Ident::new(name.clone(), sp),
+                direction: Direction::In,
                 ty: info.ty.clone(),
-                default: None, reg_info: None, bus_info: None, shared: None,
+                default: None,
+                reg_info: None,
+                bus_info: None,
+                shared: None,
                 unpacked: info.unpacked,
                 unpacked_ascending: info.unpacked_ascending,
                 comb_deps: None,
@@ -2342,17 +2708,21 @@ fn lower_module_threads(
     }
 
     // Output ports (comb-driven, excluding internal lock signals)
-    let mut sorted_comb: Vec<&String> = all_comb_driven.iter()
+    let mut sorted_comb: Vec<&String> = all_comb_driven
+        .iter()
         .filter(|n| !lock_internal.contains(*n))
         .collect();
     sorted_comb.sort();
     for name in sorted_comb {
         if let Some(info) = type_map.get(name.as_str()) {
             merged_ports.push(PortDecl {
-                name: Ident::new(name.clone(), sp), direction: Direction::Out,
+                name: Ident::new(name.clone(), sp),
+                direction: Direction::Out,
                 ty: info.ty.clone(),
                 default: Some(make_zero_expr(sp)),
-                reg_info: None, bus_info: None, shared: info.shared,
+                reg_info: None,
+                bus_info: None,
+                shared: info.shared,
                 unpacked: info.unpacked,
                 unpacked_ascending: info.unpacked_ascending,
                 comb_deps: None,
@@ -2367,16 +2737,25 @@ fn lower_module_threads(
     for name in sorted_seq {
         if let Some(info) = type_map.get(name.as_str()) {
             merged_ports.push(PortDecl {
-                name: Ident::new(name.clone(), sp), direction: Direction::Out,
-                ty: info.ty.clone(), default: None,
+                name: Ident::new(name.clone(), sp),
+                direction: Direction::Out,
+                ty: info.ty.clone(),
+                default: None,
                 reg_info: Some(PortRegInfo {
-                    init: info.reg_init.clone(), reset: info.reg_reset.clone(), guard: None,
+                    init: info.reg_init.clone(),
+                    reset: info.reg_reset.clone(),
+                    guard: None,
                     latency: 1,
                     // Synthesized by thread lowering, not user-written;
                     // don't deprecate internal artifacts.
                     legacy_port_reg: false,
                 }),
-                bus_info: None, shared: None, unpacked: false, unpacked_ascending: false, comb_deps: None, span: sp,
+                bus_info: None,
+                shared: None,
+                unpacked: false,
+                unpacked_ascending: false,
+                comb_deps: None,
+                span: sp,
             });
         }
     }
@@ -2404,27 +2783,42 @@ fn lower_module_threads(
         let n_threads = threads.len();
         // Per-thread scalar req/grant wires (internal to the merged module).
         for ti in 0..n_threads {
-            merged_body.push(ModuleBodyItem::WireDecl(WireDecl { bus_params: Vec::new(),
+            merged_body.push(ModuleBodyItem::WireDecl(WireDecl {
+                bus_params: Vec::new(),
                 name: Ident::new(format!("_{}_req_{}", res_name, ti), sp),
-                ty: TypeExpr::Bool, unpacked: false, unpacked_ascending: false, span: sp,
+                ty: TypeExpr::Bool,
+                unpacked: false,
+                unpacked_ascending: false,
+                span: sp,
             }));
-            merged_body.push(ModuleBodyItem::WireDecl(WireDecl { bus_params: Vec::new(),
+            merged_body.push(ModuleBodyItem::WireDecl(WireDecl {
+                bus_params: Vec::new(),
                 name: Ident::new(format!("_{}_grant_{}", res_name, ti), sp),
-                ty: TypeExpr::Bool, unpacked: false, unpacked_ascending: false, span: sp,
+                ty: TypeExpr::Bool,
+                unpacked: false,
+                unpacked_ascending: false,
+                span: sp,
             }));
         }
         // Build packed req/grant vectors used by the arbiter inst.
         let req_packed = format!("_{}_req_packed", res_name);
         let grant_packed = format!("_{}_grant_packed", res_name);
-        let n_threads_expr = Expr::new(
-            ExprKind::Literal(LitKind::Dec(n_threads as u64)), sp);
-        merged_body.push(ModuleBodyItem::WireDecl(WireDecl { bus_params: Vec::new(),
+        let n_threads_expr = Expr::new(ExprKind::Literal(LitKind::Dec(n_threads as u64)), sp);
+        merged_body.push(ModuleBodyItem::WireDecl(WireDecl {
+            bus_params: Vec::new(),
             name: Ident::new(req_packed.clone(), sp),
-            ty: TypeExpr::UInt(Box::new(n_threads_expr.clone())), unpacked: false, unpacked_ascending: false, span: sp,
+            ty: TypeExpr::UInt(Box::new(n_threads_expr.clone())),
+            unpacked: false,
+            unpacked_ascending: false,
+            span: sp,
         }));
-        merged_body.push(ModuleBodyItem::WireDecl(WireDecl { bus_params: Vec::new(),
+        merged_body.push(ModuleBodyItem::WireDecl(WireDecl {
+            bus_params: Vec::new(),
             name: Ident::new(grant_packed.clone(), sp),
-            ty: TypeExpr::UInt(Box::new(n_threads_expr.clone())), unpacked: false, unpacked_ascending: false, span: sp,
+            ty: TypeExpr::UInt(Box::new(n_threads_expr.clone())),
+            unpacked: false,
+            unpacked_ascending: false,
+            span: sp,
         }));
         // Throwaway sinks for arbiter scalar outputs (the lock idiom only
         // consumes the per-thread grant ready bits, not the scalar grant
@@ -2432,14 +2826,24 @@ fn lower_module_threads(
         let gv_sink = format!("_{}_grant_valid", res_name);
         let gr_sink = format!("_{}_grant_requester", res_name);
         let gr_width = crate::width::index_width(n_threads as u64);
-        merged_body.push(ModuleBodyItem::WireDecl(WireDecl { bus_params: Vec::new(),
+        merged_body.push(ModuleBodyItem::WireDecl(WireDecl {
+            bus_params: Vec::new(),
             name: Ident::new(gv_sink.clone(), sp),
-            ty: TypeExpr::Bool, unpacked: false, unpacked_ascending: false, span: sp,
+            ty: TypeExpr::Bool,
+            unpacked: false,
+            unpacked_ascending: false,
+            span: sp,
         }));
-        merged_body.push(ModuleBodyItem::WireDecl(WireDecl { bus_params: Vec::new(),
+        merged_body.push(ModuleBodyItem::WireDecl(WireDecl {
+            bus_params: Vec::new(),
             name: Ident::new(gr_sink.clone(), sp),
             ty: TypeExpr::UInt(Box::new(Expr::new(
-                ExprKind::Literal(LitKind::Dec(gr_width as u64)), sp))), unpacked: false, unpacked_ascending: false, span: sp,
+                ExprKind::Literal(LitKind::Dec(gr_width as u64)),
+                sp,
+            ))),
+            unpacked: false,
+            unpacked_ascending: false,
+            span: sp,
         }));
 
         // Pack/unpack between scalar wires and packed vectors.
@@ -2447,24 +2851,33 @@ fn lower_module_threads(
         for ti in 0..n_threads {
             // _packed[ti] = _req_ti
             pack_stmts.push(Stmt::Assign(CombAssign {
-                target: Expr::new(ExprKind::Index(
-                    Box::new(Expr::new(ExprKind::Ident(req_packed.clone()), sp)),
-                    Box::new(Expr::new(ExprKind::Literal(LitKind::Dec(ti as u64)), sp)),
-                ), sp),
+                target: Expr::new(
+                    ExprKind::Index(
+                        Box::new(Expr::new(ExprKind::Ident(req_packed.clone()), sp)),
+                        Box::new(Expr::new(ExprKind::Literal(LitKind::Dec(ti as u64)), sp)),
+                    ),
+                    sp,
+                ),
                 value: Expr::new(ExprKind::Ident(format!("_{}_req_{}", res_name, ti)), sp),
                 span: sp,
             }));
             // _grant_ti = _grant_packed[ti]
             pack_stmts.push(Stmt::Assign(CombAssign {
                 target: Expr::new(ExprKind::Ident(format!("_{}_grant_{}", res_name, ti)), sp),
-                value: Expr::new(ExprKind::Index(
-                    Box::new(Expr::new(ExprKind::Ident(grant_packed.clone()), sp)),
-                    Box::new(Expr::new(ExprKind::Literal(LitKind::Dec(ti as u64)), sp)),
-                ), sp),
+                value: Expr::new(
+                    ExprKind::Index(
+                        Box::new(Expr::new(ExprKind::Ident(grant_packed.clone()), sp)),
+                        Box::new(Expr::new(ExprKind::Literal(LitKind::Dec(ti as u64)), sp)),
+                    ),
+                    sp,
+                ),
                 span: sp,
             }));
         }
-        merged_body.push(ModuleBodyItem::CombBlock(CombBlock { stmts: pack_stmts, span: sp }));
+        merged_body.push(ModuleBodyItem::CombBlock(CombBlock {
+            stmts: pack_stmts,
+            span: sp,
+        }));
 
         // Synthesize the per-resource arbiter Item.
         let (policy, hook) = match resource_decls.get(res_name) {
@@ -2495,37 +2908,43 @@ fn lower_module_threads(
                     port_name: Ident::new("clk".to_string(), sp),
                     direction: ConnectDir::Input,
                     signal: Expr::new(ExprKind::Ident(clk_name.clone()), sp),
-                    reset_override: None, span: sp,
+                    reset_override: None,
+                    span: sp,
                 },
                 Connection {
                     port_name: Ident::new("rst".to_string(), sp),
                     direction: ConnectDir::Input,
                     signal: Expr::new(ExprKind::Ident(rst_name.clone()), sp),
-                    reset_override: None, span: sp,
+                    reset_override: None,
+                    span: sp,
                 },
                 Connection {
                     port_name: Ident::new("request_valid".to_string(), sp),
                     direction: ConnectDir::Input,
                     signal: Expr::new(ExprKind::Ident(req_packed.clone()), sp),
-                    reset_override: None, span: sp,
+                    reset_override: None,
+                    span: sp,
                 },
                 Connection {
                     port_name: Ident::new("request_ready".to_string(), sp),
                     direction: ConnectDir::Output,
                     signal: Expr::new(ExprKind::Ident(grant_packed.clone()), sp),
-                    reset_override: None, span: sp,
+                    reset_override: None,
+                    span: sp,
                 },
                 Connection {
                     port_name: Ident::new("grant_valid".to_string(), sp),
                     direction: ConnectDir::Output,
                     signal: Expr::new(ExprKind::Ident(gv_sink), sp),
-                    reset_override: None, span: sp,
+                    reset_override: None,
+                    span: sp,
                 },
                 Connection {
                     port_name: Ident::new("grant_requester".to_string(), sp),
                     direction: ConnectDir::Output,
                     signal: Expr::new(ExprKind::Ident(gr_sink), sp),
-                    reset_override: None, span: sp,
+                    reset_override: None,
+                    span: sp,
                 },
             ],
             for_loops: Vec::new(),
@@ -2534,19 +2953,24 @@ fn lower_module_threads(
     }
 
     // ── Collect shared(or) signal names for OR-accumulation ────────────
-    let shared_or_signals: HashSet<String> = type_map.iter()
+    let shared_or_signals: HashSet<String> = type_map
+        .iter()
         .filter(|(_, info)| matches!(info.shared, Some(SharedReduction::Or)))
         .map(|(name, _)| name.clone())
         .collect();
 
     // shared(or) signals that are seq-driven need per-thread shadow wires + OR reduction
-    let shared_or_seq: HashSet<String> = shared_or_signals.iter()
+    let shared_or_seq: HashSet<String> = shared_or_signals
+        .iter()
         .filter(|n| all_seq_driven.contains(*n))
-        .cloned().collect();
+        .cloned()
+        .collect();
     // shared(or) signals that are comb-driven use inline OR-accumulation (existing behavior)
-    let _shared_or_comb: HashSet<String> = shared_or_signals.iter()
+    let _shared_or_comb: HashSet<String> = shared_or_signals
+        .iter()
         .filter(|n| all_comb_driven.contains(*n))
-        .cloned().collect();
+        .cloned()
+        .collect();
 
     // For seq shared(or) signals, create per-thread input wires and OR reduction
     let n_threads = threads.len();
@@ -2555,21 +2979,29 @@ fn lower_module_threads(
             // Per-thread input wires: _sig_in_0, _sig_in_1, ...
             for ti in 0..n_threads {
                 let wire_name = format!("_{}_in_{}", sig_name, ti);
-                merged_body.push(ModuleBodyItem::WireDecl(WireDecl { bus_params: Vec::new(),
+                merged_body.push(ModuleBodyItem::WireDecl(WireDecl {
+                    bus_params: Vec::new(),
                     name: Ident::new(wire_name, sp),
                     ty: info.ty.clone(),
-                    unpacked: false, unpacked_ascending: false,
+                    unpacked: false,
+                    unpacked_ascending: false,
                     span: sp,
                 }));
             }
             // OR reduction in comb block: sig_next = _sig_in_0 | _sig_in_1 | ...
             let mut or_expr = Expr::new(ExprKind::Ident(format!("_{}_in_0", sig_name)), sp);
             for ti in 1..n_threads {
-                or_expr = Expr::new(ExprKind::Binary(
-                    BinOp::BitOr,
-                    Box::new(or_expr),
-                    Box::new(Expr::new(ExprKind::Ident(format!("_{}_in_{}", sig_name, ti)), sp)),
-                ), sp);
+                or_expr = Expr::new(
+                    ExprKind::Binary(
+                        BinOp::BitOr,
+                        Box::new(or_expr),
+                        Box::new(Expr::new(
+                            ExprKind::Ident(format!("_{}_in_{}", sig_name, ti)),
+                            sp,
+                        )),
+                    ),
+                    sp,
+                );
             }
             // Wire for OR reduction result
             let next_name = format!("_{}_next", sig_name);
@@ -2631,19 +3063,21 @@ fn lower_module_threads(
             continue;
         }
         let mut loop_id_gen: u32 = 0;
-        let mut raw_states = match partition_thread_body_with_loop_ids(&t.body, sp, cnt_width, &mut loop_id_gen) {
-            Ok(s) => s,
-            Err(e) => { errors.push(e); continue; }
-        };
+        let mut raw_states =
+            match partition_thread_body_with_loop_ids(&t.body, sp, cnt_width, &mut loop_id_gen) {
+                Ok(s) => s,
+                Err(e) => {
+                    errors.push(e);
+                    continue;
+                }
+            };
         let num_loop_counters = loop_id_gen as usize;
 
         // Rename per-thread: lock signals, counter regs
         // Counters: _cnt → _t{ti}_cnt, _loop_cnt_{id} → _t{ti}_loop_cnt_{id}
         // Each `for` instance in the thread gets a distinct counter
         // (issue #414) — rename all of them with the same per-thread prefix.
-        let mut cnt_renames = vec![
-            ("_cnt".to_string(), format!("_t{}_cnt", ti)),
-        ];
+        let mut cnt_renames = vec![("_cnt".to_string(), format!("_t{}_cnt", ti))];
         for id in 0..num_loop_counters {
             cnt_renames.push((
                 format!("_loop_cnt_{}", id),
@@ -2687,16 +3121,30 @@ fn lower_module_threads(
             for state in &mut raw_states {
                 let mut moved_comb = Vec::new();
                 let new_seq = rewrite_shared_or_seq_stmts(
-                    &state.seq_stmts, &shared_or_seq, ti, sp, &mut moved_comb);
+                    &state.seq_stmts,
+                    &shared_or_seq,
+                    ti,
+                    sp,
+                    &mut moved_comb,
+                );
                 state.seq_stmts = new_seq;
                 state.comb_stmts.extend(moved_comb);
             }
         }
 
         if raw_states.is_empty() {
-            errors.push(CompileError::general("thread must have at least one wait", sp));
+            errors.push(CompileError::general(
+                "thread must have at least one wait",
+                sp,
+            ));
             continue;
         }
+
+        // Snapshot source-level transition intent before folded wait-exit
+        // optimization mutates the runtime FSM table. The proof sidecar later
+        // compacts these targets across folded states, giving the Lean source
+        // model a channel that is not copied from the post-fold lowered table.
+        let source_transition_intents = thread_source_transition_intents(&raw_states, ti, t.once);
 
         // Issue #306: fold register assignments from a sole-entry action state
         // that immediately follows a `wait until` state into the wait state's
@@ -2754,19 +3202,18 @@ fn lower_module_threads(
         // and the SVA auto-assert state_lit closure. Bare literals would still
         // be correct SV (the localparam evaluates to the same N) but the
         // name-form is the whole point of #247.
-        let state_name_expr = |id: usize| -> Expr {
-            Expr::new(ExprKind::Ident(state_names[id].clone()), sp)
-        };
+        let state_name_expr =
+            |id: usize| -> Expr { Expr::new(ExprKind::Ident(state_names[id].clone()), sp) };
 
         // State register
         merged_body.push(ModuleBodyItem::RegDecl(RegDecl {
             name: Ident::new(state_reg.clone(), sp),
-            ty: TypeExpr::UInt(Box::new(Expr::new(ExprKind::Literal(LitKind::Dec(state_bits.max(1))), sp))),
+            ty: TypeExpr::UInt(Box::new(Expr::new(
+                ExprKind::Literal(LitKind::Dec(state_bits.max(1))),
+                sp,
+            ))),
             init: Some(make_zero_expr(sp)),
-            reset: RegReset::Inherit(
-                Ident::new(rst_name.clone(), sp),
-                make_zero_expr(sp),
-            ),
+            reset: RegReset::Inherit(Ident::new(rst_name.clone(), sp), make_zero_expr(sp)),
             guard: None,
             multicycle: None,
             span: sp,
@@ -2775,24 +3222,32 @@ fn lower_module_threads(
         if opts.thread_map.is_some() {
             let mut states = Vec::new();
             for (si, raw) in raw_states.iter().enumerate() {
-                let next_state = if si + 1 < n_states {
+                let natural_next_state = if si + 1 < n_states {
                     si + 1
                 } else if t.once {
                     si
                 } else {
                     0
                 };
+                let next_state = raw.folded_exit_target.unwrap_or(natural_next_state);
+                let source_next_state =
+                    compact_thread_source_target(&raw_states, natural_next_state, t.once);
                 let transitions = if !raw.multi_transitions.is_empty() {
                     raw.multi_transitions
                         .iter()
                         .map(|(cond, target)| {
                             let tgt = if *target >= n_states {
-                                if t.once { n_states - 1 } else { 0 }
+                                if t.once {
+                                    n_states - 1
+                                } else {
+                                    0
+                                }
                             } else {
                                 *target
                             };
                             crate::thread_map::ThreadMapTransition {
                                 condition: crate::thread_map::expr_label(cond),
+                                condition_guard: Some(crate::thread_map::guard_expr(cond)),
                                 target_index: tgt,
                                 target_name: state_names[tgt].clone(),
                             }
@@ -2801,18 +3256,21 @@ fn lower_module_threads(
                 } else if let Some(cond) = &raw.transition_cond {
                     vec![crate::thread_map::ThreadMapTransition {
                         condition: crate::thread_map::expr_label(cond),
+                        condition_guard: Some(crate::thread_map::guard_expr(cond)),
                         target_index: next_state,
                         target_name: state_names[next_state].clone(),
                     }]
                 } else if raw.wait_cycles.is_some() {
                     vec![crate::thread_map::ThreadMapTransition {
                         condition: format!("_t{}_cnt == 0", ti),
+                        condition_guard: None,
                         target_index: next_state,
                         target_name: state_names[next_state].clone(),
                     }]
                 } else {
                     vec![crate::thread_map::ThreadMapTransition {
                         condition: "always".to_string(),
+                        condition_guard: Some(crate::thread_map::ThreadMapGuardExpr::True),
                         target_index: next_state,
                         target_name: state_names[next_state].clone(),
                     }]
@@ -2821,14 +3279,43 @@ fn lower_module_threads(
                     index: si,
                     state_name: state_names[si].clone(),
                     role: thread_map_state_role(si, raw).to_string(),
+                    emitted: !raw.is_folded,
                     span: thread_fsm_state_span(raw, t.span),
                     labels: thread_map_state_labels(raw),
+                    source_next_index: source_next_state,
+                    source_next_name: state_names[source_next_state].clone(),
+                    wait_cycles_count: raw.wait_cycles.as_ref().map(crate::thread_map::expr_label),
+                    seq_updates: raw
+                        .seq_stmts
+                        .iter()
+                        .map(crate::thread_map::stmt_label)
+                        .collect(),
+                    seq_assignments: crate::thread_map::stmt_assignments(&raw.seq_stmts),
+                    folded_exit_updates: raw
+                        .folded_exit_seq
+                        .iter()
+                        .map(crate::thread_map::stmt_label)
+                        .collect(),
+                    folded_exit_assignments: crate::thread_map::stmt_assignments(
+                        &raw.folded_exit_seq,
+                    ),
+                    source_transitions: thread_source_map_transitions(
+                        source_transition_intents
+                            .get(si)
+                            .map(Vec::as_slice)
+                            .unwrap_or(&[]),
+                        &raw_states,
+                        &state_names,
+                        t.once,
+                    ),
+                    source_transition_origin: "pre_fold_snapshot".to_string(),
                     transitions,
                 });
             }
             thread_map_threads.push(crate::thread_map::ThreadMapThread {
                 name: _tname.clone(),
                 index: ti,
+                once: t.once,
                 span: t.span,
                 states,
                 hazards: Vec::new(),
@@ -2857,23 +3344,37 @@ fn lower_module_threads(
                 if !raw_states[si].multi_transitions.is_empty() {
                     for (cond, target) in &raw_states[si].multi_transitions {
                         let resolved = if *target >= raw_states.len() {
-                            if t.once { raw_states.len() - 1 } else { 0 }
-                        } else { *target };
+                            if t.once {
+                                raw_states.len() - 1
+                            } else {
+                                0
+                            }
+                        } else {
+                            *target
+                        };
                         if resolved == wait_idx {
                             counter_loads.push((si, count_expr.clone(), Some(cond.clone())));
                         }
                     }
                 } else if raw_states[si].transition_cond.is_some() {
                     if natural_next == wait_idx {
-                        counter_loads.push((si, count_expr.clone(), raw_states[si].transition_cond.clone()));
+                        counter_loads.push((
+                            si,
+                            count_expr.clone(),
+                            raw_states[si].transition_cond.clone(),
+                        ));
                     }
                 } else if raw_states[si].wait_cycles.is_some() {
                     if natural_next == wait_idx {
                         let cnt_id = Expr::new(ExprKind::Ident(cnt_name.clone()), sp);
-                        let cnt_zero = Expr::new(ExprKind::Binary(
-                            BinOp::Eq, Box::new(cnt_id),
-                            Box::new(make_zero_expr(sp)),
-                        ), sp);
+                        let cnt_zero = Expr::new(
+                            ExprKind::Binary(
+                                BinOp::Eq,
+                                Box::new(cnt_id),
+                                Box::new(make_zero_expr(sp)),
+                            ),
+                            sp,
+                        );
                         counter_loads.push((si, count_expr.clone(), Some(cnt_zero)));
                     }
                 } else if natural_next == wait_idx {
@@ -2884,24 +3385,36 @@ fn lower_module_threads(
         for (si, count_expr, cond) in counter_loads {
             // cnt <= (count - 32'd1).trunc<32>()
             let count_span = count_expr.span;
-            let sub = Expr::new(ExprKind::Binary(
-                BinOp::Sub,
-                Box::new(count_expr.clone()),
-                Box::new(Expr::new(ExprKind::Literal(LitKind::Sized(32, 1)), count_span)),
-            ), count_span);
+            let sub = Expr::new(
+                ExprKind::Binary(
+                    BinOp::Sub,
+                    Box::new(count_expr.clone()),
+                    Box::new(Expr::new(
+                        ExprKind::Literal(LitKind::Sized(32, 1)),
+                        count_span,
+                    )),
+                ),
+                count_span,
+            );
             let load = Stmt::Assign(RegAssign {
                 target: Expr::new(ExprKind::Ident(cnt_name.clone()), count_span),
-                value: Expr::new(ExprKind::MethodCall(
-                    Box::new(sub),
-                    Ident::new("trunc".to_string(), count_span),
-                    vec![Expr::new(ExprKind::Literal(LitKind::Dec(32)), count_span)],
-                ), count_span),
+                value: Expr::new(
+                    ExprKind::MethodCall(
+                        Box::new(sub),
+                        Ident::new("trunc".to_string(), count_span),
+                        vec![Expr::new(ExprKind::Literal(LitKind::Dec(32)), count_span)],
+                    ),
+                    count_span,
+                ),
                 span: count_span,
             });
             if let Some(guard) = cond {
                 raw_states[si].seq_stmts.push(Stmt::IfElse(IfElse {
-                    cond: guard, then_stmts: vec![load],
-                    else_stmts: Vec::new(), unique: false, span: count_span,
+                    cond: guard,
+                    then_stmts: vec![load],
+                    else_stmts: Vec::new(),
+                    unique: false,
+                    span: count_span,
                 }));
             } else {
                 raw_states[si].seq_stmts.push(load);
@@ -2919,19 +3432,25 @@ fn lower_module_threads(
 
             // Only skip truly empty states that don't need state advancement
             let needs_transition = si + 1 < n_states || !t.once; // non-terminal states always need advancement
-            if raw.seq_stmts.is_empty() && raw.transition_cond.is_none()
-                && raw.wait_cycles.is_none() && raw.multi_transitions.is_empty()
+            if raw.seq_stmts.is_empty()
+                && raw.transition_cond.is_none()
+                && raw.wait_cycles.is_none()
+                && raw.multi_transitions.is_empty()
                 && raw.folded_exit_seq.is_empty()
-                && !needs_transition {
+                && !needs_transition
+            {
                 continue;
             }
 
             // Build transition + seq logic for this state
-            let state_cond = Expr::new(ExprKind::Binary(
-                BinOp::Eq,
-                Box::new(Expr::new(ExprKind::Ident(state_reg.clone()), sp)),
-                Box::new(state_name_expr(si)),
-            ), sp);
+            let state_cond = Expr::new(
+                ExprKind::Binary(
+                    BinOp::Eq,
+                    Box::new(Expr::new(ExprKind::Ident(state_reg.clone()), sp)),
+                    Box::new(state_name_expr(si)),
+                ),
+                sp,
+            );
 
             let mut body: Vec<Stmt> = Vec::new();
 
@@ -2961,17 +3480,24 @@ fn lower_module_threads(
             if raw.wait_cycles.is_some() {
                 let cnt_name = format!("_t{}_cnt", ti);
                 let cnt_id = Expr::new(ExprKind::Ident(cnt_name.clone()), sp);
-                let sub = Expr::new(ExprKind::Binary(
-                    BinOp::Sub, Box::new(cnt_id),
-                    Box::new(Expr::new(ExprKind::Literal(LitKind::Sized(32, 1)), sp)),
-                ), sp);
+                let sub = Expr::new(
+                    ExprKind::Binary(
+                        BinOp::Sub,
+                        Box::new(cnt_id),
+                        Box::new(Expr::new(ExprKind::Literal(LitKind::Sized(32, 1)), sp)),
+                    ),
+                    sp,
+                );
                 body.push(Stmt::Assign(RegAssign {
                     target: Expr::new(ExprKind::Ident(cnt_name.clone()), sp),
-                    value: Expr::new(ExprKind::MethodCall(
-                        Box::new(sub),
-                        Ident::new("trunc".to_string(), sp),
-                        vec![Expr::new(ExprKind::Literal(LitKind::Dec(32)), sp)],
-                    ), sp),
+                    value: Expr::new(
+                        ExprKind::MethodCall(
+                            Box::new(sub),
+                            Ident::new("trunc".to_string(), sp),
+                            vec![Expr::new(ExprKind::Literal(LitKind::Dec(32)), sp)],
+                        ),
+                        sp,
+                    ),
                     span: sp,
                 }));
             }
@@ -2979,8 +3505,14 @@ fn lower_module_threads(
             if !raw.multi_transitions.is_empty() {
                 for (cond, target) in &raw.multi_transitions {
                     let tgt = if *target >= n_states {
-                        if t.once { n_states - 1 } else { 0 }
-                    } else { *target };
+                        if t.once {
+                            n_states - 1
+                        } else {
+                            0
+                        }
+                    } else {
+                        *target
+                    };
                     body.push(Stmt::IfElse(IfElse {
                         cond: cond.clone(),
                         then_stmts: vec![Stmt::Assign(RegAssign {
@@ -2988,7 +3520,9 @@ fn lower_module_threads(
                             value: state_name_expr(tgt),
                             span: sp,
                         })],
-                        else_stmts: Vec::new(), unique: false, span: sp,
+                        else_stmts: Vec::new(),
+                        unique: false,
+                        span: sp,
                     }));
                 }
             } else if let Some(ref cond) = raw.transition_cond {
@@ -3005,16 +3539,18 @@ fn lower_module_threads(
                 body.push(Stmt::IfElse(IfElse {
                     cond: cond.clone(),
                     then_stmts,
-                    else_stmts: Vec::new(), unique: false, span: sp,
+                    else_stmts: Vec::new(),
+                    unique: false,
+                    span: sp,
                 }));
             } else if raw.wait_cycles.is_some() {
                 // Default wait_cycles transition: cnt==0 ⇒ next_state.
                 let cnt_name = format!("_t{}_cnt", ti);
                 let cnt_id = Expr::new(ExprKind::Ident(cnt_name.clone()), sp);
-                let cnt_zero = Expr::new(ExprKind::Binary(
-                    BinOp::Eq, Box::new(cnt_id),
-                    Box::new(make_zero_expr(sp)),
-                ), sp);
+                let cnt_zero = Expr::new(
+                    ExprKind::Binary(BinOp::Eq, Box::new(cnt_id), Box::new(make_zero_expr(sp))),
+                    sp,
+                );
                 body.push(Stmt::IfElse(IfElse {
                     cond: cnt_zero,
                     then_stmts: vec![Stmt::Assign(RegAssign {
@@ -3022,7 +3558,9 @@ fn lower_module_threads(
                         value: state_name_expr(next_state),
                         span: sp,
                     })],
-                    else_stmts: Vec::new(), unique: false, span: sp,
+                    else_stmts: Vec::new(),
+                    unique: false,
+                    span: sp,
                 }));
             } else {
                 // Unconditional transition
@@ -3038,10 +3576,7 @@ fn lower_module_threads(
             // so they don't fire during reset. Skipped for terminal once
             // states (vacuous) and for threads with `default_when` (the
             // soft-reset escape can preempt any state).
-            if opts.auto_asserts
-                && t.default_when.is_none()
-                && !(t.once && si + 1 >= n_states)
-            {
+            if opts.auto_asserts && t.default_when.is_none() && !(t.once && si + 1 >= n_states) {
                 let mk_bin = |op: BinOp, a: Expr, b: Expr| -> Expr {
                     Expr::new(ExprKind::Binary(op, Box::new(a), Box::new(b)), sp)
                 };
@@ -3050,7 +3585,9 @@ fn lower_module_threads(
                 let state_eq = |id: usize| mk_bin(BinOp::Eq, state_id(), state_lit(id));
                 let rst_g = rst_inactive.clone().unwrap();
                 let in_state = mk_bin(BinOp::And, rst_g.clone(), state_eq(si));
-                let push_assert = |name: String, antecedent: Expr, consequent: Expr,
+                let push_assert = |name: String,
+                                   antecedent: Expr,
+                                   consequent: Expr,
                                    acc: &mut Vec<AssertDecl>| {
                     let prop = mk_bin(BinOp::ImpliesNext, antecedent, consequent);
                     acc.push(AssertDecl {
@@ -3065,12 +3602,20 @@ fn lower_module_threads(
                     // Each branch: when its cond fires, state goes to its target.
                     for (bi, (cond, target)) in raw.multi_transitions.iter().enumerate() {
                         let tgt = if *target >= n_states {
-                            if t.once { n_states - 1 } else { 0 }
-                        } else { *target };
+                            if t.once {
+                                n_states - 1
+                            } else {
+                                0
+                            }
+                        } else {
+                            *target
+                        };
                         let antecedent = mk_bin(BinOp::And, in_state.clone(), cond.clone());
                         push_assert(
                             format!("_auto_thread_t{}_branch_s{}_b{}", ti, si, bi),
-                            antecedent, state_eq(tgt), &mut auto_asserts,
+                            antecedent,
+                            state_eq(tgt),
+                            &mut auto_asserts,
                         );
                     }
                 } else if let Some(ref cond) = raw.transition_cond {
@@ -3078,7 +3623,9 @@ fn lower_module_threads(
                     let antecedent = mk_bin(BinOp::And, in_state.clone(), cond.clone());
                     push_assert(
                         format!("_auto_thread_t{}_wait_until_s{}", ti, si),
-                        antecedent, state_eq(next_state), &mut auto_asserts,
+                        antecedent,
+                        state_eq(next_state),
+                        &mut auto_asserts,
                     );
                 } else if raw.wait_cycles.is_some() {
                     // wait N cycle — counter-driven stay-then-advance.
@@ -3091,11 +3638,15 @@ fn lower_module_threads(
                     let done_ant = mk_bin(BinOp::And, in_state.clone(), cnt_eq_zero);
                     push_assert(
                         format!("_auto_thread_t{}_wait_stay_s{}", ti, si),
-                        stay_ant, state_eq(si), &mut auto_asserts,
+                        stay_ant,
+                        state_eq(si),
+                        &mut auto_asserts,
                     );
                     push_assert(
                         format!("_auto_thread_t{}_wait_done_s{}", ti, si),
-                        done_ant, state_eq(next_state), &mut auto_asserts,
+                        done_ant,
+                        state_eq(next_state),
+                        &mut auto_asserts,
                     );
                 }
                 // Unconditional transitions (no cond, no wait, no multi)
@@ -3106,7 +3657,9 @@ fn lower_module_threads(
             seq_stmts.push(Stmt::IfElse(IfElse {
                 cond: state_cond,
                 then_stmts: body,
-                else_stmts: Vec::new(), unique: false, span: sp,
+                else_stmts: Vec::new(),
+                unique: false,
+                span: sp,
             }));
         }
 
@@ -3114,7 +3667,8 @@ fn lower_module_threads(
         // if (cond) { <assigns>; state <= 0; } else { <normal FSM states> }
         if let Some((dw_cond, dw_thread_stmts)) = &t.default_when {
             // Convert ThreadStmt::SeqAssign items to Stmt::Assign
-            let mut dw_then: Vec<Stmt> = dw_thread_stmts.iter()
+            let mut dw_then: Vec<Stmt> = dw_thread_stmts
+                .iter()
                 .filter_map(|ts| {
                     if let ThreadStmt::SeqAssign(ra) = ts {
                         Some(Stmt::Assign(ra.clone()))
@@ -3148,20 +3702,25 @@ fn lower_module_threads(
                 continue;
             }
 
-            let state_cond = Expr::new(ExprKind::Binary(
-                BinOp::Eq,
-                Box::new(Expr::new(ExprKind::Ident(state_reg.clone()), sp)),
-                Box::new(state_name_expr(si)),
-            ), sp);
+            let state_cond = Expr::new(
+                ExprKind::Binary(
+                    BinOp::Eq,
+                    Box::new(Expr::new(ExprKind::Ident(state_reg.clone()), sp)),
+                    Box::new(state_name_expr(si)),
+                ),
+                sp,
+            );
 
             // This state's own comb outputs
             if !raw.comb_stmts.is_empty() {
-                let transformed_stmts = transform_shared_or_assigns(&raw.comb_stmts, &shared_or_signals, sp);
+                let transformed_stmts =
+                    transform_shared_or_assigns(&raw.comb_stmts, &shared_or_signals, sp);
                 all_thread_comb.push(Stmt::IfElse(IfElse {
                     cond: state_cond.clone(),
                     then_stmts: transformed_stmts,
                     else_stmts: Vec::new(),
-                    unique: false, span: sp,
+                    unique: false,
+                    span: sp,
                 }));
             }
 
@@ -3196,12 +3755,14 @@ fn lower_module_threads(
     }
 
     if let Some(map) = &opts.thread_map {
-        map.borrow_mut().modules.push(crate::thread_map::ThreadMapModule {
-            module_name: m.name.name.clone(),
-            generated_module_name: merged_name.clone(),
-            span: m.span,
-            threads: thread_map_threads,
-        });
+        map.borrow_mut()
+            .modules
+            .push(crate::thread_map::ThreadMapModule {
+                module_name: m.name.name.clone(),
+                generated_module_name: merged_name.clone(),
+                span: m.span,
+                threads: thread_map_threads,
+            });
     }
 
     // ── Per-thread counter registers ─────────────────────────────────────
@@ -3212,7 +3773,10 @@ fn lower_module_threads(
                 name: Ident::new(format!("_t{}_cnt", ti), sp),
                 ty: TypeExpr::UInt(Box::new(Expr::new(ExprKind::Literal(LitKind::Dec(32)), sp))),
                 init: Some(make_zero_expr(sp)),
-                reset: RegReset::None, guard: None, multicycle: None, span: sp,
+                reset: RegReset::None,
+                guard: None,
+                multicycle: None,
+                span: sp,
             }));
         }
         // Per-`for`-instance loop counter regs. Each `for` (including nested
@@ -3226,9 +3790,15 @@ fn lower_module_threads(
             for id in 0..num_for_instances {
                 merged_body.push(ModuleBodyItem::RegDecl(RegDecl {
                     name: Ident::new(format!("_t{}_loop_cnt_{}", ti, id), sp),
-                    ty: TypeExpr::UInt(Box::new(Expr::new(ExprKind::Literal(LitKind::Dec(for_cnt_width as u64)), sp))),
+                    ty: TypeExpr::UInt(Box::new(Expr::new(
+                        ExprKind::Literal(LitKind::Dec(for_cnt_width as u64)),
+                        sp,
+                    ))),
                     init: Some(make_zero_expr(sp)),
-                    reset: RegReset::None, guard: None, multicycle: None, span: sp,
+                    reset: RegReset::None,
+                    guard: None,
+                    multicycle: None,
+                    span: sp,
                 }));
             }
         }
@@ -3252,10 +3822,13 @@ fn lower_module_threads(
                 if let Some(n) = try_eval_i64(size_expr, &HashMap::new()) {
                     for i in 0..(n as u64) {
                         merged_comb.push(Stmt::Assign(CombAssign {
-                            target: Expr::new(ExprKind::Index(
-                                Box::new(Expr::new(ExprKind::Ident(p.name.name.clone()), sp)),
-                                Box::new(Expr::new(ExprKind::Literal(LitKind::Dec(i)), sp)),
-                            ), sp),
+                            target: Expr::new(
+                                ExprKind::Index(
+                                    Box::new(Expr::new(ExprKind::Ident(p.name.name.clone()), sp)),
+                                    Box::new(Expr::new(ExprKind::Literal(LitKind::Dec(i)), sp)),
+                                ),
+                                sp,
+                            ),
                             value: make_zero_expr(sp),
                             span: sp,
                         }));
@@ -3301,9 +3874,13 @@ fn lower_module_threads(
     // Per-thread state-guarded comb assigns
     merged_comb.extend(all_thread_comb);
     if !merged_comb.is_empty() {
-        merged_body.insert(0, ModuleBodyItem::CombBlock(CombBlock {
-            stmts: merged_comb, span: sp,
-        }));
+        merged_body.insert(
+            0,
+            ModuleBodyItem::CombBlock(CombBlock {
+                stmts: merged_comb,
+                span: sp,
+            }),
+        );
     }
 
     // Prepend parent-module function clones so thread-body calls inside
@@ -3367,22 +3944,37 @@ fn lower_module_threads(
     let parent_vob: _HashMap<String, (u32, Vec<String>)> = {
         let mut out = _HashMap::new();
         for p in &m.ports {
-            let Some(bi) = p.bus_info.as_ref() else { continue; };
-            let Some(count_expr) = bi.count.as_ref() else { continue; };
+            let Some(bi) = p.bus_info.as_ref() else {
+                continue;
+            };
+            let Some(count_expr) = bi.count.as_ref() else {
+                continue;
+            };
             // Build a tiny param-vals map from the module's param defaults so
             // expressions like `NUM_SLAVES` resolve at elaboration-time.
-            let param_vals_local: HashMap<String, i64> = m.params.iter()
-                .filter_map(|p| p.default.as_ref()
-                    .and_then(|d| try_eval_i64(d, &HashMap::new()).map(|v| (p.name.name.clone(), v))))
+            let param_vals_local: HashMap<String, i64> = m
+                .params
+                .iter()
+                .filter_map(|p| {
+                    p.default.as_ref().and_then(|d| {
+                        try_eval_i64(d, &HashMap::new()).map(|v| (p.name.name.clone(), v))
+                    })
+                })
                 .collect();
             let n = try_eval_i64(count_expr, &param_vals_local).unwrap_or(0) as u32;
-            if n == 0 { continue; }
-            let Some(bus_decl) = bus_defs.get(&bi.bus_name.name) else { continue; };
+            if n == 0 {
+                continue;
+            }
+            let Some(bus_decl) = bus_defs.get(&bi.bus_name.name) else {
+                continue;
+            };
             // BusDecl.signals lists unconditional signals; conditional ones
             // (under READ/WRITE flags) live in BusDecl.generates. Collect
             // names from BOTH so the `<base>_<i>_<sig>` pattern matches
             // every flattened sub-port name.
-            let mut sigs: Vec<String> = bus_decl.signals.iter()
+            let mut sigs: Vec<String> = bus_decl
+                .signals
+                .iter()
                 .map(|s| s.name.name.clone())
                 .collect();
             for g in &bus_decl.generates {
@@ -3404,14 +3996,24 @@ fn lower_module_threads(
         let mut signal = Expr::new(ExprKind::Ident(p.name.name.clone()), sp);
         for (base, (n, sigs)) in &parent_vob {
             let prefix = format!("{base}_");
-            let Some(rest) = p.name.name.strip_prefix(&prefix) else { continue; };
+            let Some(rest) = p.name.name.strip_prefix(&prefix) else {
+                continue;
+            };
             // rest looks like "<i>_<sig>" — split on first '_'.
-            let Some(und) = rest.find('_') else { continue; };
+            let Some(und) = rest.find('_') else {
+                continue;
+            };
             let idx_str = &rest[..und];
             let sig = &rest[und + 1..];
-            let Ok(idx) = idx_str.parse::<u32>() else { continue; };
-            if idx >= *n { continue; }
-            if !sigs.iter().any(|s| s == sig) { continue; }
+            let Ok(idx) = idx_str.parse::<u32>() else {
+                continue;
+            };
+            if idx >= *n {
+                continue;
+            }
+            if !sigs.iter().any(|s| s == sig) {
+                continue;
+            }
             // Match. Emit Index(Ident("<base>_<sig>"), idx).
             signal = Expr::new(
                 ExprKind::Index(
@@ -3423,9 +4025,11 @@ fn lower_module_threads(
             break;
         }
         connections.push(Connection {
-            port_name: p.name.clone(), direction: dir,
+            port_name: p.name.clone(),
+            direction: dir,
             signal,
-            reset_override: None, span: sp,
+            reset_override: None,
+            span: sp,
         });
     }
     let inst = InstDecl {
@@ -3450,13 +4054,18 @@ fn lower_module_threads(
     // Thread-driven regs live inside the synthesized threads module. Keep a
     // typed parent-side wire for each moved reg so ordinary parent logic can
     // still read the instance output with the original signedness/width.
-    let thread_driven: HashSet<String> = all_seq_driven.iter().chain(all_comb_driven.iter()).cloned().collect();
+    let thread_driven: HashSet<String> = all_seq_driven
+        .iter()
+        .chain(all_comb_driven.iter())
+        .cloned()
+        .collect();
     for item in &mut new_body {
         let ModuleBodyItem::RegDecl(r) = item else {
             continue;
         };
         if thread_driven.contains(&r.name.name) {
-            *item = ModuleBodyItem::WireDecl(WireDecl { bus_params: Vec::new(),
+            *item = ModuleBodyItem::WireDecl(WireDecl {
+                bus_params: Vec::new(),
                 name: r.name.clone(),
                 ty: r.ty.clone(),
                 unpacked: false,
@@ -3466,7 +4075,10 @@ fn lower_module_threads(
         }
     }
 
-    let new_module = ModuleDecl { body: new_body, ..m };
+    let new_module = ModuleDecl {
+        body: new_body,
+        ..m
+    };
     let mut extras = synthesized_arbiters;
     extras.push(Item::Module(merged_module));
     Ok((new_module, extras))
@@ -3500,8 +4112,7 @@ fn synthesize_lock_arbiter(
     // for thread-driven resets).
     let rst_ty = TypeExpr::Reset(ResetKind::Async, rst_level);
     let clk_ty = TypeExpr::Clock(Ident::new("SysDomain".to_string(), sp));
-    let n_threads_expr = Expr::new(
-        ExprKind::Literal(LitKind::Dec(n_threads as u64)), sp);
+    let n_threads_expr = Expr::new(ExprKind::Literal(LitKind::Dec(n_threads as u64)), sp);
     let gr_width = crate::width::index_width(n_threads as u64);
 
     // The arbiter is an internal synthesized module; its port names are
@@ -3511,25 +4122,58 @@ fn synthesize_lock_arbiter(
     let scalar_ports = vec![
         PortDecl {
             name: Ident::new("clk".to_string(), sp),
-            direction: Direction::In, ty: clk_ty, default: None,
-            reg_info: None, bus_info: None, shared: None, unpacked: false, unpacked_ascending: false, comb_deps: None, span: sp,
+            direction: Direction::In,
+            ty: clk_ty,
+            default: None,
+            reg_info: None,
+            bus_info: None,
+            shared: None,
+            unpacked: false,
+            unpacked_ascending: false,
+            comb_deps: None,
+            span: sp,
         },
         PortDecl {
             name: Ident::new("rst".to_string(), sp),
-            direction: Direction::In, ty: rst_ty, default: None,
-            reg_info: None, bus_info: None, shared: None, unpacked: false, unpacked_ascending: false, comb_deps: None, span: sp,
+            direction: Direction::In,
+            ty: rst_ty,
+            default: None,
+            reg_info: None,
+            bus_info: None,
+            shared: None,
+            unpacked: false,
+            unpacked_ascending: false,
+            comb_deps: None,
+            span: sp,
         },
         PortDecl {
             name: Ident::new("grant_valid".to_string(), sp),
-            direction: Direction::Out, ty: TypeExpr::Bool, default: None,
-            reg_info: None, bus_info: None, shared: None, unpacked: false, unpacked_ascending: false, comb_deps: None, span: sp,
+            direction: Direction::Out,
+            ty: TypeExpr::Bool,
+            default: None,
+            reg_info: None,
+            bus_info: None,
+            shared: None,
+            unpacked: false,
+            unpacked_ascending: false,
+            comb_deps: None,
+            span: sp,
         },
         PortDecl {
             name: Ident::new("grant_requester".to_string(), sp),
             direction: Direction::Out,
             ty: TypeExpr::UInt(Box::new(Expr::new(
-                ExprKind::Literal(LitKind::Dec(gr_width as u64)), sp))),
-            default: None, reg_info: None, bus_info: None, shared: None, unpacked: false, unpacked_ascending: false, comb_deps: None, span: sp,
+                ExprKind::Literal(LitKind::Dec(gr_width as u64)),
+                sp,
+            ))),
+            default: None,
+            reg_info: None,
+            bus_info: None,
+            shared: None,
+            unpacked: false,
+            unpacked_ascending: false,
+            comb_deps: None,
+            span: sp,
         },
     ];
 
@@ -3539,13 +4183,29 @@ fn synthesize_lock_arbiter(
         signals: vec![
             PortDecl {
                 name: Ident::new("valid".to_string(), sp),
-                direction: Direction::In, ty: TypeExpr::Bool, default: None,
-                reg_info: None, bus_info: None, shared: None, unpacked: false, unpacked_ascending: false, comb_deps: None, span: sp,
+                direction: Direction::In,
+                ty: TypeExpr::Bool,
+                default: None,
+                reg_info: None,
+                bus_info: None,
+                shared: None,
+                unpacked: false,
+                unpacked_ascending: false,
+                comb_deps: None,
+                span: sp,
             },
             PortDecl {
                 name: Ident::new("ready".to_string(), sp),
-                direction: Direction::Out, ty: TypeExpr::Bool, default: None,
-                reg_info: None, bus_info: None, shared: None, unpacked: false, unpacked_ascending: false, comb_deps: None, span: sp,
+                direction: Direction::Out,
+                ty: TypeExpr::Bool,
+                default: None,
+                reg_info: None,
+                bus_info: None,
+                shared: None,
+                unpacked: false,
+                unpacked_ascending: false,
+                comb_deps: None,
+                span: sp,
             },
         ],
         span: sp,
@@ -3614,15 +4274,23 @@ fn build_module_type_map_with_buses(
 ) -> HashMap<String, SignalInfo> {
     let mut map = build_module_type_map(m);
     for p in &m.ports {
-        let Some(bi) = p.bus_info.as_ref() else { continue; };
-        let Some(bd) = bus_defs.get(&bi.bus_name.name) else { continue; };
+        let Some(bi) = p.bus_info.as_ref() else {
+            continue;
+        };
+        let Some(bd) = bus_defs.get(&bi.bus_name.name) else {
+            continue;
+        };
         // Effective signals (with `generate_if READ`/`WRITE` resolved). Use the
         // bus port's own param overrides + bus defaults so width-bearing types
         // like `UInt<DATA_W>` substitute correctly.
-        let mut param_map: HashMap<String, &Expr> = bd.params.iter()
+        let mut param_map: HashMap<String, &Expr> = bd
+            .params
+            .iter()
             .filter_map(|pd| pd.default.as_ref().map(|d| (pd.name.name.clone(), d)))
             .collect();
-        for pa in &bi.params { param_map.insert(pa.name.name.clone(), &pa.value); }
+        for pa in &bi.params {
+            param_map.insert(pa.name.name.clone(), &pa.value);
+        }
         let eff = bus_effective_signals(bd, &param_map);
         // For Vec-of-bus ports, register entries for each indexed copy.
         let prefixes: Vec<String> = match bi.count.as_ref() {
@@ -3635,14 +4303,15 @@ fn build_module_type_map_with_buses(
         for prefix in &prefixes {
             for (sname, _sdir, sty) in &eff {
                 let subst_ty = subst_type_expr_for_lower(sty, &param_map);
-                map.entry(format!("{prefix}_{sname}")).or_insert(SignalInfo {
-                    ty: subst_ty,
-                    reg_reset: RegReset::None,
-                    reg_init: None,
-                    shared: None,
-                    unpacked: false,
-                    unpacked_ascending: false,
-                });
+                map.entry(format!("{prefix}_{sname}"))
+                    .or_insert(SignalInfo {
+                        ty: subst_ty,
+                        reg_reset: RegReset::None,
+                        reg_init: None,
+                        shared: None,
+                        unpacked: false,
+                        unpacked_ascending: false,
+                    });
             }
         }
     }
@@ -3658,19 +4327,27 @@ fn bus_effective_signals(
     bd: &BusDecl,
     param_map: &HashMap<String, &Expr>,
 ) -> Vec<(String, Direction, TypeExpr)> {
-    let mut out: Vec<(String, Direction, TypeExpr)> = bd.signals.iter()
+    let mut out: Vec<(String, Direction, TypeExpr)> = bd
+        .signals
+        .iter()
         .map(|s| (s.name.name.clone(), s.direction, s.ty.clone()))
         .collect();
     for gi in &bd.generates {
         let cond_v = eval_const_expr_for_lower(&gi.cond, &[]);
         // Resolve any param references in the cond by substituting from
         // param_map; fall back to the bare const eval otherwise.
-        let cond = if cond_v != 0 { true } else {
+        let cond = if cond_v != 0 {
+            true
+        } else {
             param_map.get(&format!("{:?}", gi.cond.kind)).is_some()
         };
         // Simpler: re-evaluate cond by walking param_map for Ident matches.
         let cond = cond || gen_if_cond_truthy(&gi.cond, param_map);
-        let branch = if cond { &gi.then_signals } else { &gi.else_signals };
+        let branch = if cond {
+            &gi.then_signals
+        } else {
+            &gi.else_signals
+        };
         for s in branch {
             out.push((s.name.name.clone(), s.direction, s.ty.clone()));
         }
@@ -3685,7 +4362,9 @@ fn gen_if_cond_truthy(e: &Expr, params: &HashMap<String, &Expr>) -> bool {
         | ExprKind::Literal(LitKind::Bin(n))
         | ExprKind::Literal(LitKind::Sized(_, n)) => *n != 0,
         ExprKind::Bool(b) => *b,
-        ExprKind::Ident(name) => params.get(name).map_or(false, |v| gen_if_cond_truthy(v, params)),
+        ExprKind::Ident(name) => params
+            .get(name)
+            .map_or(false, |v| gen_if_cond_truthy(v, params)),
         _ => false,
     }
 }
@@ -3700,7 +4379,8 @@ fn eval_const_expr_for_lower(expr: &Expr, params: &[ParamDecl]) -> u64 {
         | ExprKind::Literal(LitKind::Hex(n))
         | ExprKind::Literal(LitKind::Bin(n))
         | ExprKind::Literal(LitKind::Sized(_, n)) => *n,
-        ExprKind::Ident(name) => params.iter()
+        ExprKind::Ident(name) => params
+            .iter()
             .find(|p| p.name.name == *name)
             .and_then(|p| p.default.as_ref())
             .map(|d| eval_const_expr_for_lower(d, params))
@@ -3729,7 +4409,9 @@ fn subst_type_expr_for_lower(ty: &TypeExpr, params: &HashMap<String, &Expr>) -> 
     fn subst(e: &Expr, params: &HashMap<String, &Expr>) -> Expr {
         let kind = match &e.kind {
             ExprKind::Ident(name) => {
-                if let Some(v) = params.get(name) { return (*v).clone(); }
+                if let Some(v) = params.get(name) {
+                    return (*v).clone();
+                }
                 ExprKind::Ident(name.clone())
             }
             // Recurse into arithmetic shapes so widths like `UInt<DATA_W / 8>`
@@ -3738,11 +4420,9 @@ fn subst_type_expr_for_lower(ty: &TypeExpr, params: &HashMap<String, &Expr>) -> 
             // and the synthesized `_<mod>_threads` sub-module emits SV ports
             // referencing the bus's local param name (DATA_W) instead of the
             // enclosing module's (DATA_WIDTH).
-            ExprKind::Binary(op, l, r) => ExprKind::Binary(
-                *op,
-                Box::new(subst(l, params)),
-                Box::new(subst(r, params)),
-            ),
+            ExprKind::Binary(op, l, r) => {
+                ExprKind::Binary(*op, Box::new(subst(l, params)), Box::new(subst(r, params)))
+            }
             ExprKind::Unary(op, x) => ExprKind::Unary(*op, Box::new(subst(x, params))),
             ExprKind::Ternary(c, t, f) => ExprKind::Ternary(
                 Box::new(subst(c, params)),
@@ -3752,7 +4432,11 @@ fn subst_type_expr_for_lower(ty: &TypeExpr, params: &HashMap<String, &Expr>) -> 
             ExprKind::Clog2(x) => ExprKind::Clog2(Box::new(subst(x, params))),
             _ => return e.clone(),
         };
-        Expr { kind, span: e.span, parenthesized: e.parenthesized }
+        Expr {
+            kind,
+            span: e.span,
+            parenthesized: e.parenthesized,
+        }
     }
     match ty {
         TypeExpr::UInt(w) => TypeExpr::UInt(Box::new(subst(w, params))),
@@ -3780,7 +4464,9 @@ fn expr_target_flat_name(e: &Expr, bus_port_map: &HashMap<String, String>) -> Op
                 }
             }
             if let ExprKind::Index(arr, idx) = &base.kind {
-                if let (ExprKind::Ident(arr_name), ExprKind::Literal(LitKind::Dec(i))) = (&arr.kind, &idx.kind) {
+                if let (ExprKind::Ident(arr_name), ExprKind::Literal(LitKind::Dec(i))) =
+                    (&arr.kind, &idx.kind)
+                {
                     if bus_port_map.contains_key(arr_name) {
                         return Some(format!("{}_{}_{}", arr_name, i, field.name));
                     }
@@ -3797,29 +4483,45 @@ fn expr_target_flat_name(e: &Expr, bus_port_map: &HashMap<String, String>) -> Op
 /// (`b_v`) on both LHS and RHS. The sub-module exposes the flat signals
 /// as ports — `b` itself was never carried over — so any reference to
 /// the bus name must be rewritten before SV codegen.
-fn rewrite_bus_targets_in_body(body: &mut Vec<ModuleBodyItem>, bus_port_map: &HashMap<String, String>) {
+fn rewrite_bus_targets_in_body(
+    body: &mut Vec<ModuleBodyItem>,
+    bus_port_map: &HashMap<String, String>,
+) {
     fn rw_expr(e: &mut Expr, bus_port_map: &HashMap<String, String>) {
         // Bottom-up: rewrite children first.
         match &mut e.kind {
-            ExprKind::Binary(_, l, r) => { rw_expr(l, bus_port_map); rw_expr(r, bus_port_map); }
-            ExprKind::Unary(_, x) | ExprKind::Cast(x, _) | ExprKind::LatencyAt(x, _) | ExprKind::SvaNext(_, x) =>
-                rw_expr(x, bus_port_map),
+            ExprKind::Binary(_, l, r) => {
+                rw_expr(l, bus_port_map);
+                rw_expr(r, bus_port_map);
+            }
+            ExprKind::Unary(_, x)
+            | ExprKind::Cast(x, _)
+            | ExprKind::LatencyAt(x, _)
+            | ExprKind::SvaNext(_, x) => rw_expr(x, bus_port_map),
             ExprKind::Index(b, i) | ExprKind::BitSlice(b, i, _) => {
                 rw_expr(b, bus_port_map);
                 rw_expr(i, bus_port_map);
             }
             ExprKind::PartSelect(b, lo, hi, _) => {
-                rw_expr(b, bus_port_map); rw_expr(lo, bus_port_map); rw_expr(hi, bus_port_map);
+                rw_expr(b, bus_port_map);
+                rw_expr(lo, bus_port_map);
+                rw_expr(hi, bus_port_map);
             }
             ExprKind::Ternary(c, t, e2) => {
-                rw_expr(c, bus_port_map); rw_expr(t, bus_port_map); rw_expr(e2, bus_port_map);
+                rw_expr(c, bus_port_map);
+                rw_expr(t, bus_port_map);
+                rw_expr(e2, bus_port_map);
             }
             ExprKind::Concat(parts) | ExprKind::FunctionCall(_, parts) => {
-                for p in parts { rw_expr(p, bus_port_map); }
+                for p in parts {
+                    rw_expr(p, bus_port_map);
+                }
             }
             ExprKind::MethodCall(b, _, args) => {
                 rw_expr(b, bus_port_map);
-                for a in args { rw_expr(a, bus_port_map); }
+                for a in args {
+                    rw_expr(a, bus_port_map);
+                }
             }
             ExprKind::FieldAccess(b, _) => rw_expr(b, bus_port_map),
             _ => {}
@@ -3830,16 +4532,27 @@ fn rewrite_bus_targets_in_body(body: &mut Vec<ModuleBodyItem>, bus_port_map: &Ha
                 if let ExprKind::Ident(base_name) = &base.kind {
                     if bus_port_map.contains_key(base_name) {
                         Some(ExprKind::Ident(format!("{}_{}", base_name, field.name)))
-                    } else { None }
+                    } else {
+                        None
+                    }
                 } else if let ExprKind::Index(arr, idx) = &base.kind {
-                    if let (ExprKind::Ident(arr_name), ExprKind::Literal(LitKind::Dec(i)))
-                        = (&arr.kind, &idx.kind)
+                    if let (ExprKind::Ident(arr_name), ExprKind::Literal(LitKind::Dec(i))) =
+                        (&arr.kind, &idx.kind)
                     {
                         if bus_port_map.contains_key(arr_name) {
-                            Some(ExprKind::Ident(format!("{}_{}_{}", arr_name, i, field.name)))
-                        } else { None }
-                    } else { None }
-                } else { None }
+                            Some(ExprKind::Ident(format!(
+                                "{}_{}_{}",
+                                arr_name, i, field.name
+                            )))
+                        } else {
+                            None
+                        }
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                }
             }
             _ => None,
         };
@@ -3849,34 +4562,73 @@ fn rewrite_bus_targets_in_body(body: &mut Vec<ModuleBodyItem>, bus_port_map: &Ha
     }
     fn rw_stmt(s: &mut Stmt, bus_port_map: &HashMap<String, String>) {
         match s {
-            Stmt::Assign(a) => { rw_expr(&mut a.target, bus_port_map); rw_expr(&mut a.value, bus_port_map); }
+            Stmt::Assign(a) => {
+                rw_expr(&mut a.target, bus_port_map);
+                rw_expr(&mut a.value, bus_port_map);
+            }
             Stmt::IfElse(ie) => {
                 rw_expr(&mut ie.cond, bus_port_map);
-                for s in &mut ie.then_stmts { rw_stmt(s, bus_port_map); }
-                for s in &mut ie.else_stmts { rw_stmt(s, bus_port_map); }
+                for s in &mut ie.then_stmts {
+                    rw_stmt(s, bus_port_map);
+                }
+                for s in &mut ie.else_stmts {
+                    rw_stmt(s, bus_port_map);
+                }
             }
             Stmt::Match(m) => {
                 rw_expr(&mut m.scrutinee, bus_port_map);
-                for arm in &mut m.arms { for s in &mut arm.body { rw_stmt(s, bus_port_map); } }
+                for arm in &mut m.arms {
+                    for s in &mut arm.body {
+                        rw_stmt(s, bus_port_map);
+                    }
+                }
             }
-            Stmt::For(f) => { for s in &mut f.body { rw_stmt(s, bus_port_map); } }
-            Stmt::Init(ib) => { for s in &mut ib.body { rw_stmt(s, bus_port_map); } }
+            Stmt::For(f) => {
+                for s in &mut f.body {
+                    rw_stmt(s, bus_port_map);
+                }
+            }
+            Stmt::Init(ib) => {
+                for s in &mut ib.body {
+                    rw_stmt(s, bus_port_map);
+                }
+            }
             Stmt::DoUntil { body, cond, .. } => {
                 rw_expr(cond, bus_port_map);
-                for s in body { rw_stmt(s, bus_port_map); }
+                for s in body {
+                    rw_stmt(s, bus_port_map);
+                }
             }
             Stmt::WaitUntil(e, _) => rw_expr(e, bus_port_map),
-            Stmt::Log(l) => { for a in &mut l.args { rw_expr(a, bus_port_map); } }
+            Stmt::Log(l) => {
+                for a in &mut l.args {
+                    rw_expr(a, bus_port_map);
+                }
+            }
         }
     }
     for item in body.iter_mut() {
         match item {
-            ModuleBodyItem::CombBlock(cb) => { for s in &mut cb.stmts { rw_stmt(s, bus_port_map); } }
-            ModuleBodyItem::RegBlock(rb) => { for s in &mut rb.stmts { rw_stmt(s, bus_port_map); } }
-            ModuleBodyItem::LatchBlock(lb) => { for s in &mut lb.stmts { rw_stmt(s, bus_port_map); } }
+            ModuleBodyItem::CombBlock(cb) => {
+                for s in &mut cb.stmts {
+                    rw_stmt(s, bus_port_map);
+                }
+            }
+            ModuleBodyItem::RegBlock(rb) => {
+                for s in &mut rb.stmts {
+                    rw_stmt(s, bus_port_map);
+                }
+            }
+            ModuleBodyItem::LatchBlock(lb) => {
+                for s in &mut lb.stmts {
+                    rw_stmt(s, bus_port_map);
+                }
+            }
             ModuleBodyItem::LetBinding(lb) => rw_expr(&mut lb.value, bus_port_map),
             ModuleBodyItem::RegDecl(r) => {
-                if let Some(init) = r.init.as_mut() { rw_expr(init, bus_port_map); }
+                if let Some(init) = r.init.as_mut() {
+                    rw_expr(init, bus_port_map);
+                }
             }
             _ => {}
         }
@@ -3886,44 +4638,63 @@ fn rewrite_bus_targets_in_body(body: &mut Vec<ModuleBodyItem>, bus_port_map: &Ha
 fn build_module_type_map(m: &ModuleDecl) -> HashMap<String, SignalInfo> {
     let mut map = HashMap::new();
     for p in &m.ports {
-        map.insert(p.name.name.clone(), SignalInfo {
-            ty: p.ty.clone(),
-            reg_reset: p.reg_info.as_ref().map(|ri| ri.reset.clone()).unwrap_or(RegReset::None),
-            reg_init: p.reg_info.as_ref().and_then(|ri| ri.init.clone()),
-            shared: p.shared,
-            unpacked: p.unpacked,
-        unpacked_ascending: p.unpacked_ascending,
-        });
+        map.insert(
+            p.name.name.clone(),
+            SignalInfo {
+                ty: p.ty.clone(),
+                reg_reset: p
+                    .reg_info
+                    .as_ref()
+                    .map(|ri| ri.reset.clone())
+                    .unwrap_or(RegReset::None),
+                reg_init: p.reg_info.as_ref().and_then(|ri| ri.init.clone()),
+                shared: p.shared,
+                unpacked: p.unpacked,
+                unpacked_ascending: p.unpacked_ascending,
+            },
+        );
     }
     for item in &m.body {
         match item {
             ModuleBodyItem::RegDecl(r) => {
-                map.insert(r.name.name.clone(), SignalInfo {
-                    ty: r.ty.clone(),
-                    reg_reset: r.reset.clone(),
-                    reg_init: r.init.clone(),
-                    shared: None,
-                    unpacked: false, unpacked_ascending: false,
-                });
+                map.insert(
+                    r.name.name.clone(),
+                    SignalInfo {
+                        ty: r.ty.clone(),
+                        reg_reset: r.reset.clone(),
+                        reg_init: r.init.clone(),
+                        shared: None,
+                        unpacked: false,
+                        unpacked_ascending: false,
+                    },
+                );
             }
             ModuleBodyItem::WireDecl(w) => {
-                map.insert(w.name.name.clone(), SignalInfo {
-                    ty: w.ty.clone(),
-                    reg_reset: RegReset::None,
-                    reg_init: None,
-                    shared: None,
-                    unpacked: false, unpacked_ascending: false,
-                });
-            }
-            ModuleBodyItem::LetBinding(l) => {
-                if let Some(ty) = &l.ty {
-                    map.insert(l.name.name.clone(), SignalInfo {
-                        ty: ty.clone(),
+                map.insert(
+                    w.name.name.clone(),
+                    SignalInfo {
+                        ty: w.ty.clone(),
                         reg_reset: RegReset::None,
                         reg_init: None,
                         shared: None,
-                        unpacked: false, unpacked_ascending: false,
-                    });
+                        unpacked: false,
+                        unpacked_ascending: false,
+                    },
+                );
+            }
+            ModuleBodyItem::LetBinding(l) => {
+                if let Some(ty) = &l.ty {
+                    map.insert(
+                        l.name.name.clone(),
+                        SignalInfo {
+                            ty: ty.clone(),
+                            reg_reset: RegReset::None,
+                            reg_init: None,
+                            shared: None,
+                            unpacked: false,
+                            unpacked_ascending: false,
+                        },
+                    );
                 }
             }
             _ => {}
@@ -3953,7 +4724,11 @@ fn collect_comb_stmt_signals_with_buses(
     // ("b_v"). The underlying expr_root_name walker can't distinguish them
     // since it doesn't know which signals are bus ports.
     comb_driven.retain(|n| !bus_port_map.contains_key(n));
-    fn walk(stmts: &[Stmt], comb_driven: &mut HashSet<String>, bus_port_map: &HashMap<String, String>) {
+    fn walk(
+        stmts: &[Stmt],
+        comb_driven: &mut HashSet<String>,
+        bus_port_map: &HashMap<String, String>,
+    ) {
         for s in stmts {
             match s {
                 Stmt::Assign(a) => {
@@ -3967,7 +4742,11 @@ fn collect_comb_stmt_signals_with_buses(
                     walk(&ie.then_stmts, comb_driven, bus_port_map);
                     walk(&ie.else_stmts, comb_driven, bus_port_map);
                 }
-                Stmt::Match(m) => { for arm in &m.arms { walk(&arm.body, comb_driven, bus_port_map); } }
+                Stmt::Match(m) => {
+                    for arm in &m.arms {
+                        walk(&arm.body, comb_driven, bus_port_map);
+                    }
+                }
                 Stmt::For(f) => walk(&f.body, comb_driven, bus_port_map),
                 Stmt::Init(ib) => walk(&ib.body, comb_driven, bus_port_map),
                 Stmt::DoUntil { body, .. } => walk(body, comb_driven, bus_port_map),
@@ -3986,10 +4765,12 @@ fn collect_thread_signals_with_buses(
     let (mut comb_driven, mut seq_driven, all_read) = collect_thread_signals(body);
     comb_driven.retain(|n| !bus_port_map.contains_key(n));
     seq_driven.retain(|n| !bus_port_map.contains_key(n));
-    fn walk(stmts: &[ThreadStmt],
-            comb_driven: &mut HashSet<String>,
-            seq_driven: &mut HashSet<String>,
-            bus_port_map: &HashMap<String, String>) {
+    fn walk(
+        stmts: &[ThreadStmt],
+        comb_driven: &mut HashSet<String>,
+        seq_driven: &mut HashSet<String>,
+        bus_port_map: &HashMap<String, String>,
+    ) {
         for s in stmts {
             match s {
                 ThreadStmt::CombAssign(a) => {
@@ -4012,9 +4793,13 @@ fn collect_thread_signals_with_buses(
                 }
                 ThreadStmt::For { body, .. }
                 | ThreadStmt::Lock { body, .. }
-                | ThreadStmt::DoUntil { body, .. } => walk(body, comb_driven, seq_driven, bus_port_map),
+                | ThreadStmt::DoUntil { body, .. } => {
+                    walk(body, comb_driven, seq_driven, bus_port_map)
+                }
                 ThreadStmt::ForkJoin(branches, _) => {
-                    for b in branches { walk(b, comb_driven, seq_driven, bus_port_map); }
+                    for b in branches {
+                        walk(b, comb_driven, seq_driven, bus_port_map);
+                    }
                 }
                 _ => {}
             }
@@ -4084,7 +4869,9 @@ fn collect_comb_stmt_signals(stmts: &[Stmt]) -> (HashSet<String>, HashSet<String
     (comb_driven, all_read)
 }
 
-fn collect_thread_signals(body: &[ThreadStmt]) -> (HashSet<String>, HashSet<String>, HashSet<String>) {
+fn collect_thread_signals(
+    body: &[ThreadStmt],
+) -> (HashSet<String>, HashSet<String>, HashSet<String>) {
     let mut comb_driven = HashSet::new();
     let mut seq_driven = HashSet::new();
     let mut all_read = HashSet::new();
@@ -4127,7 +4914,13 @@ fn collect_thread_signals(body: &[ThreadStmt]) -> (HashSet<String>, HashSet<Stri
                         walk_stmts(br, comb_driven, seq_driven, all_read);
                     }
                 }
-                ThreadStmt::For { var: _, start, end, body, .. } => {
+                ThreadStmt::For {
+                    var: _,
+                    start,
+                    end,
+                    body,
+                    ..
+                } => {
                     collect_expr_reads(start, all_read);
                     collect_expr_reads(end, all_read);
                     walk_stmts(body, comb_driven, seq_driven, all_read);
@@ -4166,7 +4959,11 @@ fn expr_root_name(e: &Expr) -> Option<String> {
 /// FieldAccess it contains. `b.r` (a bus signal read) → adds `b_r` to
 /// `out`. Used after the underlying `collect_expr_reads` to seed the
 /// flattened input names into the sub-module's port list.
-fn collect_expr_bus_reads(e: &Expr, bus_port_map: &HashMap<String, String>, out: &mut HashSet<String>) {
+fn collect_expr_bus_reads(
+    e: &Expr,
+    bus_port_map: &HashMap<String, String>,
+    out: &mut HashSet<String>,
+) {
     if let ExprKind::FieldAccess(base, field) = &e.kind {
         if let ExprKind::Ident(base_name) = &base.kind {
             if bus_port_map.contains_key(base_name) {
@@ -4174,8 +4971,8 @@ fn collect_expr_bus_reads(e: &Expr, bus_port_map: &HashMap<String, String>, out:
             }
         }
         if let ExprKind::Index(arr, idx) = &base.kind {
-            if let (ExprKind::Ident(arr_name), ExprKind::Literal(LitKind::Dec(i)))
-                = (&arr.kind, &idx.kind)
+            if let (ExprKind::Ident(arr_name), ExprKind::Literal(LitKind::Dec(i))) =
+                (&arr.kind, &idx.kind)
             {
                 if bus_port_map.contains_key(arr_name) {
                     out.insert(format!("{}_{}_{}", arr_name, i, field.name));
@@ -4185,24 +4982,38 @@ fn collect_expr_bus_reads(e: &Expr, bus_port_map: &HashMap<String, String>, out:
     }
     // Recurse into children.
     match &e.kind {
-        ExprKind::Binary(_, l, r) => { collect_expr_bus_reads(l, bus_port_map, out); collect_expr_bus_reads(r, bus_port_map, out); }
-        ExprKind::Unary(_, x) | ExprKind::Cast(x, _) | ExprKind::LatencyAt(x, _) | ExprKind::SvaNext(_, x) =>
-            collect_expr_bus_reads(x, bus_port_map, out),
+        ExprKind::Binary(_, l, r) => {
+            collect_expr_bus_reads(l, bus_port_map, out);
+            collect_expr_bus_reads(r, bus_port_map, out);
+        }
+        ExprKind::Unary(_, x)
+        | ExprKind::Cast(x, _)
+        | ExprKind::LatencyAt(x, _)
+        | ExprKind::SvaNext(_, x) => collect_expr_bus_reads(x, bus_port_map, out),
         ExprKind::Index(b, i) | ExprKind::BitSlice(b, i, _) => {
-            collect_expr_bus_reads(b, bus_port_map, out); collect_expr_bus_reads(i, bus_port_map, out);
+            collect_expr_bus_reads(b, bus_port_map, out);
+            collect_expr_bus_reads(i, bus_port_map, out);
         }
         ExprKind::PartSelect(b, lo, hi, _) => {
-            collect_expr_bus_reads(b, bus_port_map, out); collect_expr_bus_reads(lo, bus_port_map, out); collect_expr_bus_reads(hi, bus_port_map, out);
+            collect_expr_bus_reads(b, bus_port_map, out);
+            collect_expr_bus_reads(lo, bus_port_map, out);
+            collect_expr_bus_reads(hi, bus_port_map, out);
         }
         ExprKind::Ternary(c, t, e2) => {
-            collect_expr_bus_reads(c, bus_port_map, out); collect_expr_bus_reads(t, bus_port_map, out); collect_expr_bus_reads(e2, bus_port_map, out);
+            collect_expr_bus_reads(c, bus_port_map, out);
+            collect_expr_bus_reads(t, bus_port_map, out);
+            collect_expr_bus_reads(e2, bus_port_map, out);
         }
         ExprKind::Concat(parts) | ExprKind::FunctionCall(_, parts) => {
-            for p in parts { collect_expr_bus_reads(p, bus_port_map, out); }
+            for p in parts {
+                collect_expr_bus_reads(p, bus_port_map, out);
+            }
         }
         ExprKind::MethodCall(b, _, args) => {
             collect_expr_bus_reads(b, bus_port_map, out);
-            for a in args { collect_expr_bus_reads(a, bus_port_map, out); }
+            for a in args {
+                collect_expr_bus_reads(a, bus_port_map, out);
+            }
         }
         ExprKind::FieldAccess(b, _) => collect_expr_bus_reads(b, bus_port_map, out),
         _ => {}
@@ -4212,7 +5023,11 @@ fn collect_expr_bus_reads(e: &Expr, bus_port_map: &HashMap<String, String>, out:
 /// Walk a thread body (recursively) and add flat bus-signal read names
 /// to `out`. Companion to `collect_expr_bus_reads` for the statement
 /// shape.
-fn collect_thread_bus_reads(body: &[ThreadStmt], bus_port_map: &HashMap<String, String>, out: &mut HashSet<String>) {
+fn collect_thread_bus_reads(
+    body: &[ThreadStmt],
+    bus_port_map: &HashMap<String, String>,
+    out: &mut HashSet<String>,
+) {
     for s in body {
         match s {
             ThreadStmt::CombAssign(a) | ThreadStmt::SeqAssign(a) | ThreadStmt::ForkTlmAssign(a) => {
@@ -4225,12 +5040,18 @@ fn collect_thread_bus_reads(body: &[ThreadStmt], bus_port_map: &HashMap<String, 
                 collect_thread_bus_reads(&ie.then_stmts, bus_port_map, out);
                 collect_thread_bus_reads(&ie.else_stmts, bus_port_map, out);
             }
-            ThreadStmt::For { body, .. } | ThreadStmt::Lock { body, .. } => collect_thread_bus_reads(body, bus_port_map, out),
+            ThreadStmt::For { body, .. } | ThreadStmt::Lock { body, .. } => {
+                collect_thread_bus_reads(body, bus_port_map, out)
+            }
             ThreadStmt::DoUntil { body, cond, .. } => {
                 collect_expr_bus_reads(cond, bus_port_map, out);
                 collect_thread_bus_reads(body, bus_port_map, out);
             }
-            ThreadStmt::ForkJoin(branches, _) => { for b in branches { collect_thread_bus_reads(b, bus_port_map, out); } }
+            ThreadStmt::ForkJoin(branches, _) => {
+                for b in branches {
+                    collect_thread_bus_reads(b, bus_port_map, out);
+                }
+            }
             ThreadStmt::Return(e, _) => collect_expr_bus_reads(e, bus_port_map, out),
             _ => {}
         }
@@ -4239,7 +5060,9 @@ fn collect_thread_bus_reads(body: &[ThreadStmt], bus_port_map: &HashMap<String, 
 
 fn collect_expr_reads(e: &Expr, out: &mut HashSet<String>) {
     match &e.kind {
-        ExprKind::Ident(name) => { out.insert(name.clone()); }
+        ExprKind::Ident(name) => {
+            out.insert(name.clone());
+        }
         ExprKind::Binary(_, l, r) => {
             collect_expr_reads(l, out);
             collect_expr_reads(r, out);
@@ -4262,11 +5085,15 @@ fn collect_expr_reads(e: &Expr, out: &mut HashSet<String>) {
         ExprKind::FieldAccess(base, _) => collect_expr_reads(base, out),
         ExprKind::MethodCall(recv, _, args) => {
             collect_expr_reads(recv, out);
-            for a in args { collect_expr_reads(a, out); }
+            for a in args {
+                collect_expr_reads(a, out);
+            }
         }
         ExprKind::Cast(e, _) => collect_expr_reads(e, out),
         ExprKind::Concat(parts) => {
-            for p in parts { collect_expr_reads(p, out); }
+            for p in parts {
+                collect_expr_reads(p, out);
+            }
         }
         ExprKind::Repeat(count, val) => {
             collect_expr_reads(count, out);
@@ -4276,7 +5103,9 @@ fn collect_expr_reads(e: &Expr, out: &mut HashSet<String>) {
         ExprKind::Signed(e) => collect_expr_reads(e, out),
         ExprKind::Unsigned(e) => collect_expr_reads(e, out),
         ExprKind::FunctionCall(_, args) => {
-            for a in args { collect_expr_reads(a, out); }
+            for a in args {
+                collect_expr_reads(a, out);
+            }
         }
         ExprKind::Ternary(c, t, f) => {
             collect_expr_reads(c, out);
@@ -4299,13 +5128,17 @@ fn collect_expr_reads(e: &Expr, out: &mut HashSet<String>) {
             collect_expr_reads(scrut, out);
             for arm in arms {
                 for s in &arm.body {
-                    if let Stmt::Assign(a) = s { collect_expr_reads(&a.value, out); }
+                    if let Stmt::Assign(a) = s {
+                        collect_expr_reads(&a.value, out);
+                    }
                 }
             }
         }
         ExprKind::ExprMatch(scrut, arms) => {
             collect_expr_reads(scrut, out);
-            for arm in arms { collect_expr_reads(&arm.value, out); }
+            for arm in arms {
+                collect_expr_reads(&arm.value, out);
+            }
         }
         _ => {} // Literal, Bool, Todo, EnumVariant, StructLiteral
     }
@@ -4457,6 +5290,115 @@ fn fold_wait_until_exit_assignments(states: &mut Vec<ThreadFsmState>, t_once: bo
     }
 }
 
+fn thread_natural_next_state(si: usize, n_states: usize, t_once: bool) -> usize {
+    if si + 1 < n_states {
+        si + 1
+    } else if t_once {
+        si
+    } else {
+        0
+    }
+}
+
+fn thread_resolve_target(target: usize, n_states: usize, t_once: bool) -> usize {
+    if target >= n_states {
+        if t_once {
+            n_states.saturating_sub(1)
+        } else {
+            0
+        }
+    } else {
+        target
+    }
+}
+
+fn compact_thread_source_target(states: &[ThreadFsmState], target: usize, t_once: bool) -> usize {
+    let n_states = states.len();
+    let mut current = thread_resolve_target(target, n_states, t_once);
+    for _ in 0..n_states {
+        if !states[current].is_folded {
+            return current;
+        }
+        let next = thread_natural_next_state(current, n_states, t_once);
+        if next == current {
+            return current;
+        }
+        current = next;
+    }
+    current
+}
+
+#[derive(Debug, Clone)]
+struct ThreadSourceTransitionIntent {
+    condition: String,
+    condition_guard: Option<crate::thread_map::ThreadMapGuardExpr>,
+    target: usize,
+}
+
+fn thread_source_transition_intents(
+    states: &[ThreadFsmState],
+    ti: usize,
+    t_once: bool,
+) -> Vec<Vec<ThreadSourceTransitionIntent>> {
+    let n_states = states.len();
+    states
+        .iter()
+        .enumerate()
+        .map(|(si, state)| {
+            let natural_next = thread_natural_next_state(si, n_states, t_once);
+            if !state.multi_transitions.is_empty() {
+                state
+                    .multi_transitions
+                    .iter()
+                    .map(|(cond, target)| ThreadSourceTransitionIntent {
+                        condition: crate::thread_map::expr_label(cond),
+                        condition_guard: Some(crate::thread_map::guard_expr(cond)),
+                        target: thread_resolve_target(*target, n_states, t_once),
+                    })
+                    .collect()
+            } else if let Some(cond) = &state.transition_cond {
+                vec![ThreadSourceTransitionIntent {
+                    condition: crate::thread_map::expr_label(cond),
+                    condition_guard: Some(crate::thread_map::guard_expr(cond)),
+                    target: natural_next,
+                }]
+            } else if state.wait_cycles.is_some() {
+                vec![ThreadSourceTransitionIntent {
+                    condition: format!("_t{}_cnt == 0", ti),
+                    condition_guard: None,
+                    target: natural_next,
+                }]
+            } else {
+                vec![ThreadSourceTransitionIntent {
+                    condition: "always".to_string(),
+                    condition_guard: Some(crate::thread_map::ThreadMapGuardExpr::True),
+                    target: natural_next,
+                }]
+            }
+        })
+        .collect()
+}
+
+fn thread_source_map_transitions(
+    intents: &[ThreadSourceTransitionIntent],
+    states: &[ThreadFsmState],
+    state_names: &[String],
+    t_once: bool,
+) -> Vec<crate::thread_map::ThreadMapTransition> {
+    intents
+        .iter()
+        .map(|intent| {
+            let compact_target = compact_thread_source_target(states, intent.target, t_once);
+            crate::thread_map::ThreadMapTransition {
+                condition: intent.condition.clone(),
+                condition_guard: intent.condition_guard.clone(),
+                target_index: compact_target,
+                target_name: state_names[compact_target].clone(),
+            }
+        })
+        .collect()
+}
+
 fn thread_map_state_role(si: usize, state: &ThreadFsmState) -> &'static str {
     if state.multi_transitions.len() > 1 {
         "dispatch"
@@ -4511,16 +5453,30 @@ fn thread_fsm_state_span(state: &ThreadFsmState, fallback: Span) -> Span {
 fn thread_map_state_labels(state: &ThreadFsmState) -> Vec<String> {
     let mut labels = Vec::new();
     if !state.comb_stmts.is_empty() {
-        labels.push(format!("comb: {} stmt{}", state.comb_stmts.len(), plural_s(state.comb_stmts.len())));
+        labels.push(format!(
+            "comb: {} stmt{}",
+            state.comb_stmts.len(),
+            plural_s(state.comb_stmts.len())
+        ));
     }
     if !state.seq_stmts.is_empty() {
-        labels.push(format!("seq: {} stmt{}", state.seq_stmts.len(), plural_s(state.seq_stmts.len())));
+        labels.push(format!(
+            "seq: {} stmt{}",
+            state.seq_stmts.len(),
+            plural_s(state.seq_stmts.len())
+        ));
     }
     if let Some(cond) = &state.transition_cond {
-        labels.push(format!("wait until {}", crate::thread_map::expr_label(cond)));
+        labels.push(format!(
+            "wait until {}",
+            crate::thread_map::expr_label(cond)
+        ));
     }
     if let Some(count) = &state.wait_cycles {
-        labels.push(format!("wait {} cycle", crate::thread_map::expr_label(count)));
+        labels.push(format!(
+            "wait {} cycle",
+            crate::thread_map::expr_label(count)
+        ));
     }
     if !state.multi_transitions.is_empty() {
         labels.push(format!("branches: {}", state.multi_transitions.len()));
@@ -4529,7 +5485,11 @@ fn thread_map_state_labels(state: &ThreadFsmState) -> Vec<String> {
 }
 
 fn plural_s(n: usize) -> &'static str {
-    if n == 1 { "" } else { "s" }
+    if n == 1 {
+        ""
+    } else {
+        "s"
+    }
 }
 
 const THREAD_TARGET_NEXT: usize = usize::MAX;
@@ -4575,11 +5535,10 @@ fn type_expr_uint_width_literal(ty: &TypeExpr) -> Option<u32> {
 ///   - Default → 16 (covers burst lengths up to 65535)
 fn infer_expr_uint_width(expr: &Expr, type_map: &HashMap<String, SignalInfo>) -> u32 {
     match &expr.kind {
-        ExprKind::Ident(name) => {
-            type_map.get(name)
-                .and_then(|si| type_expr_uint_width_literal(&si.ty))
-                .unwrap_or(16)
-        }
+        ExprKind::Ident(name) => type_map
+            .get(name)
+            .and_then(|si| type_expr_uint_width_literal(&si.ty))
+            .unwrap_or(16),
         ExprKind::Binary(BinOp::Sub | BinOp::Add | BinOp::BitAnd | BinOp::BitOr, a, _) => {
             infer_expr_uint_width(a, type_map)
         }
@@ -4596,7 +5555,11 @@ fn infer_expr_uint_width(expr: &Expr, type_map: &HashMap<String, SignalInfo>) ->
             infer_expr_uint_width(inner, type_map)
         }
         ExprKind::Literal(LitKind::Dec(v)) => {
-            if *v == 0 { 1 } else { (u64::BITS - v.leading_zeros()) as u32 }
+            if *v == 0 {
+                1
+            } else {
+                (u64::BITS - v.leading_zeros()) as u32
+            }
         }
         _ => 16,
     }
@@ -4606,7 +5569,11 @@ fn infer_expr_uint_width(expr: &Expr, type_map: &HashMap<String, SignalInfo>) ->
 /// Returns 16 if no for loops are found or width cannot be determined.
 fn infer_for_cnt_width(stmts: &[ThreadStmt], type_map: &HashMap<String, SignalInfo>) -> u32 {
     let w = infer_for_cnt_width_inner(stmts, type_map);
-    if w == 0 { 16 } else { w }
+    if w == 0 {
+        16
+    } else {
+        w
+    }
 }
 
 /// Inner helper: returns 0 when no for loops found (avoids poisoning max() with the default).
@@ -4644,9 +5611,13 @@ fn infer_for_cnt_width_inner(stmts: &[ThreadStmt], type_map: &HashMap<String, Si
 fn thread_has_wait_cycles(stmts: &[ThreadStmt]) -> bool {
     stmts.iter().any(|s| match s {
         ThreadStmt::WaitCycles(..) => true,
-        ThreadStmt::IfElse(ie) => thread_has_wait_cycles(&ie.then_stmts) || thread_has_wait_cycles(&ie.else_stmts),
+        ThreadStmt::IfElse(ie) => {
+            thread_has_wait_cycles(&ie.then_stmts) || thread_has_wait_cycles(&ie.else_stmts)
+        }
         ThreadStmt::ForkJoin(branches, _) => branches.iter().any(|br| thread_has_wait_cycles(br)),
-        ThreadStmt::Lock { body, .. } | ThreadStmt::DoUntil { body, .. } => thread_has_wait_cycles(body),
+        ThreadStmt::Lock { body, .. } | ThreadStmt::DoUntil { body, .. } => {
+            thread_has_wait_cycles(body)
+        }
         ThreadStmt::For { body, .. } => thread_has_wait_cycles(body),
         _ => false,
     })
@@ -4669,7 +5640,9 @@ fn count_for_instances(stmts: &[ThreadStmt]) -> usize {
                 n += count_for_instances(&ie.else_stmts);
             }
             ThreadStmt::ForkJoin(branches, _) => {
-                for br in branches { n += count_for_instances(br); }
+                for br in branches {
+                    n += count_for_instances(br);
+                }
             }
             ThreadStmt::Lock { body, .. } | ThreadStmt::DoUntil { body, .. } => {
                 n += count_for_instances(body);
@@ -4698,19 +5671,15 @@ fn count_for_instances(stmts: &[ThreadStmt]) -> usize {
 /// - `M ≠ ∅`: append `(true, target)` only if no existing entry already
 ///   targets `target`. (For-loop exits already target the resolved sentinel,
 ///   which equals `target` when the for-group is the last sub-state.)
-fn redirect_fallthrough_to(
-    states: &mut [ThreadFsmState],
-    idx: usize,
-    target: usize,
-    span: Span,
-) {
+fn redirect_fallthrough_to(states: &mut [ThreadFsmState], idx: usize, target: usize, span: Span) {
     let s = &mut states[idx];
     if s.terminal_return.is_some() {
         return;
     }
     if !s.multi_transitions.is_empty() {
         if !s.multi_transitions.iter().any(|(_, t)| *t == target) {
-            s.multi_transitions.push((Expr::new(ExprKind::Bool(true), span), target));
+            s.multi_transitions
+                .push((Expr::new(ExprKind::Bool(true), span), target));
         }
         return;
     }
@@ -4720,21 +5689,17 @@ fn redirect_fallthrough_to(
     }
     if s.wait_cycles.is_some() {
         let cnt_id = Expr::new(ExprKind::Ident("_cnt".to_string()), span);
-        let cnt_zero = Expr::new(ExprKind::Binary(
-            BinOp::Eq, Box::new(cnt_id),
-            Box::new(make_zero_expr(span)),
-        ), span);
+        let cnt_zero = Expr::new(
+            ExprKind::Binary(BinOp::Eq, Box::new(cnt_id), Box::new(make_zero_expr(span))),
+            span,
+        );
         s.multi_transitions = vec![(cnt_zero, target)];
         return;
     }
     s.multi_transitions = vec![(Expr::new(ExprKind::Bool(true), span), target)];
 }
 
-fn redirect_fallthrough_to_return(
-    states: &mut Vec<ThreadFsmState>,
-    return_idx: usize,
-    span: Span,
-) {
+fn redirect_fallthrough_to_return(states: &mut Vec<ThreadFsmState>, return_idx: usize, span: Span) {
     let target = thread_return_target(return_idx);
     let Some(idx) = states.len().checked_sub(1) else {
         states.push(ThreadFsmState {
@@ -4762,7 +5727,8 @@ fn redirect_fallthrough_to_return(
             }
         }
         if !rewrote {
-            s.multi_transitions.push((Expr::new(ExprKind::Bool(true), span), target));
+            s.multi_transitions
+                .push((Expr::new(ExprKind::Bool(true), span), target));
         }
         return;
     }
@@ -4783,7 +5749,9 @@ fn contains_wait(stmts: &[ThreadStmt]) -> bool {
 fn contains_return(stmts: &[ThreadStmt]) -> bool {
     stmts.iter().any(|s| match s {
         ThreadStmt::Return(..) => true,
-        ThreadStmt::IfElse(ie) => contains_return(&ie.then_stmts) || contains_return(&ie.else_stmts),
+        ThreadStmt::IfElse(ie) => {
+            contains_return(&ie.then_stmts) || contains_return(&ie.else_stmts)
+        }
         ThreadStmt::ForkJoin(branches, _) => branches.iter().any(|br| contains_return(br)),
         ThreadStmt::For { body, .. } => contains_return(body),
         ThreadStmt::Lock { body, .. } | ThreadStmt::DoUntil { body, .. } => contains_return(body),
@@ -4836,11 +5804,11 @@ fn try_hoist_initial_thread_state(states: &mut Vec<ThreadFsmState>) -> Option<Ho
     // Only remove the first state if no later local transition targets it.
     // This keeps loop/fork products that intentionally branch to state 0
     // on the conservative path.
-    if states.iter().skip(1).any(|s| {
-        s.multi_transitions
-            .iter()
-            .any(|(_, target)| *target == 0)
-    }) {
+    if states
+        .iter()
+        .skip(1)
+        .any(|s| s.multi_transitions.iter().any(|(_, target)| *target == 0))
+    {
         return None;
     }
 
@@ -4937,7 +5905,10 @@ fn expr_same_shape(a: &Expr, b: &Expr) -> bool {
         (ExprKind::FieldAccess(a_base, a_field), ExprKind::FieldAccess(b_base, b_field)) => {
             a_field.name == b_field.name && expr_same_shape(a_base, b_base)
         }
-        (ExprKind::MethodCall(a_base, a_name, a_args), ExprKind::MethodCall(b_base, b_name, b_args)) => {
+        (
+            ExprKind::MethodCall(a_base, a_name, a_args),
+            ExprKind::MethodCall(b_base, b_name, b_args),
+        ) => {
             a_name.name == b_name.name
                 && expr_same_shape(a_base, b_base)
                 && expr_slice_same_shape(a_args, b_args)
@@ -4990,9 +5961,7 @@ fn expr_same_shape(a: &Expr, b: &Expr) -> bool {
                     .all(|(a_member, b_member)| inside_member_same_shape(a_member, b_member))
         }
         (ExprKind::Ternary(a_c, a_t, a_f), ExprKind::Ternary(b_c, b_t, b_f)) => {
-            expr_same_shape(a_c, b_c)
-                && expr_same_shape(a_t, b_t)
-                && expr_same_shape(a_f, b_f)
+            expr_same_shape(a_c, b_c) && expr_same_shape(a_t, b_t) && expr_same_shape(a_f, b_f)
         }
         _ => false,
     }
@@ -5063,9 +6032,7 @@ fn flush_pending_thread_state(
     true
 }
 
-fn collect_single_state_thread_body(
-    body: &[ThreadStmt],
-) -> (Vec<Stmt>, Vec<Stmt>) {
+fn collect_single_state_thread_body(body: &[ThreadStmt]) -> (Vec<Stmt>, Vec<Stmt>) {
     let mut comb_stmts = Vec::new();
     let mut seq_stmts = Vec::new();
     for stmt in body {
@@ -5102,11 +6069,7 @@ fn mealy_gate_first_lock_state(lock_states: &mut [ThreadFsmState], cond: &Expr, 
         }));
         if let Some(existing_cond) = first.transition_cond.take() {
             first.transition_cond = Some(Expr::new(
-                ExprKind::Binary(
-                    BinOp::And,
-                    Box::new(cond.clone()),
-                    Box::new(existing_cond),
-                ),
+                ExprKind::Binary(BinOp::And, Box::new(cond.clone()), Box::new(existing_cond)),
                 span,
             ));
         }
@@ -5260,9 +6223,7 @@ fn disallow_nested_control_in_do_until(
 ) -> Result<(), CompileError> {
     for s in body {
         let bad = match s {
-            ThreadStmt::CombAssign(_)
-            | ThreadStmt::SeqAssign(_)
-            | ThreadStmt::Log(_) => None,
+            ThreadStmt::CombAssign(_) | ThreadStmt::SeqAssign(_) | ThreadStmt::Log(_) => None,
             ThreadStmt::IfElse(ie) => {
                 disallow_nested_control_in_do_until(&ie.then_stmts, do_span)?;
                 disallow_nested_control_in_do_until(&ie.else_stmts, do_span)?;
@@ -5420,11 +6381,13 @@ fn partition_thread_body_impl(
                 // (e.g. an if/else branch whose only body is `wait 1
                 // cycle;`), keep the wait state — eliding would leave the
                 // branch with zero states and break dispatch-and-rejoin.
-                let count_is_one = matches!(&count.kind,
+                let count_is_one = matches!(
+                    &count.kind,
                     ExprKind::Literal(LitKind::Dec(1))
-                    | ExprKind::Literal(LitKind::Hex(1))
-                    | ExprKind::Literal(LitKind::Bin(1))
-                    | ExprKind::Literal(LitKind::Sized(_, 1)));
+                        | ExprKind::Literal(LitKind::Hex(1))
+                        | ExprKind::Literal(LitKind::Bin(1))
+                        | ExprKind::Literal(LitKind::Sized(_, 1))
+                );
                 if !count_is_one || !had_flush {
                     // A real wait_cycles state is pushed; any prior
                     // `next_state_no_fold` from an earlier elision is no
@@ -5519,9 +6482,20 @@ fn partition_thread_body_impl(
                     let then_base = states.len();
                     if !ie.then_stmts.is_empty() {
                         let mut then_states = if let Some(rets) = target_returns.as_deref_mut() {
-                            partition_thread_body_impl(&ie.then_stmts, ie.span, cnt_width, Some(rets), loop_id_gen)?
+                            partition_thread_body_impl(
+                                &ie.then_stmts,
+                                ie.span,
+                                cnt_width,
+                                Some(rets),
+                                loop_id_gen,
+                            )?
                         } else {
-                            partition_thread_body_with_loop_ids(&ie.then_stmts, ie.span, cnt_width, loop_id_gen)?
+                            partition_thread_body_with_loop_ids(
+                                &ie.then_stmts,
+                                ie.span,
+                                cnt_width,
+                                loop_id_gen,
+                            )?
                         };
                         let then_len = then_states.len();
                         for fs in &mut then_states {
@@ -5544,9 +6518,20 @@ fn partition_thread_body_impl(
                     let else_base = states.len();
                     if !ie.else_stmts.is_empty() {
                         let mut else_states = if let Some(rets) = target_returns.as_deref_mut() {
-                            partition_thread_body_impl(&ie.else_stmts, ie.span, cnt_width, Some(rets), loop_id_gen)?
+                            partition_thread_body_impl(
+                                &ie.else_stmts,
+                                ie.span,
+                                cnt_width,
+                                Some(rets),
+                                loop_id_gen,
+                            )?
                         } else {
-                            partition_thread_body_with_loop_ids(&ie.else_stmts, ie.span, cnt_width, loop_id_gen)?
+                            partition_thread_body_with_loop_ids(
+                                &ie.else_stmts,
+                                ie.span,
+                                cnt_width,
+                                loop_id_gen,
+                            )?
                         };
                         let else_len = else_states.len();
                         for fs in &mut else_states {
@@ -5601,21 +6586,31 @@ fn partition_thread_body_impl(
                     // Step 2 (deferred): fill dispatch state's M.
                     // Empty-branch handling (§II.10.4): if a branch is empty, its
                     // base equals the next position, and the dispatch jumps there.
-                    let then_target = if then_base == else_base { rejoin_idx } else { then_base };
-                    let else_target = if else_base == rejoin_idx { rejoin_idx } else { else_base };
+                    let then_target = if then_base == else_base {
+                        rejoin_idx
+                    } else {
+                        then_base
+                    };
+                    let else_target = if else_base == rejoin_idx {
+                        rejoin_idx
+                    } else {
+                        else_base
+                    };
                     let neg_cond = Expr::new(
                         ExprKind::Unary(UnaryOp::Not, Box::new(ie.cond.clone())),
                         ie.span,
                     );
-                    states[dispatch_idx].multi_transitions = vec![
-                        (ie.cond.clone(), then_target),
-                        (neg_cond, else_target),
-                    ];
+                    states[dispatch_idx].multi_transitions =
+                        vec![(ie.cond.clone(), then_target), (neg_cond, else_target)];
                 } else {
                     // Same-state conditional: convert to IfElse / IfElse for comb and seq
                     let (comb_if, seq_if) = thread_if_to_fsm_stmts(ie);
-                    if let Some(c) = comb_if { cur_comb.push(c); }
-                    if let Some(s) = seq_if { cur_seq.push(s); }
+                    if let Some(c) = comb_if {
+                        cur_comb.push(c);
+                    }
+                    if let Some(s) = seq_if {
+                        cur_seq.push(s);
+                    }
                 }
             }
             ThreadStmt::ForkJoin(branches, sp) => {
@@ -5640,7 +6635,13 @@ fn partition_thread_body_impl(
                 }
                 states.extend(fork_states);
             }
-            ThreadStmt::For { var, start, end, body, span } => {
+            ThreadStmt::For {
+                var,
+                start,
+                end,
+                body,
+                span,
+            } => {
                 // Allocate this for-loop's unique counter id and name. Nested
                 // for-loops inside `body` get their own ids via the recursive
                 // partition inside `lower_thread_for`. Issue #414: without
@@ -5690,7 +6691,8 @@ fn partition_thread_body_impl(
                         *span,
                     );
                 }
-                let mut for_states = lower_thread_for(var, start, end, body, *span, cnt_width, loop_id_gen)?;
+                let mut for_states =
+                    lower_thread_for(var, start, end, body, *span, cnt_width, loop_id_gen)?;
                 // Adjust multi_transitions targets (relative → absolute)
                 let for_base = states.len();
                 let for_len = for_states.len();
@@ -5706,7 +6708,11 @@ fn partition_thread_body_impl(
                 }
                 states.extend(for_states);
             }
-            ThreadStmt::Lock { resource, body, span } => {
+            ThreadStmt::Lock {
+                resource,
+                body,
+                span,
+            } => {
                 // Nested lock blocks would violate mutual exclusion:
                 // once a thread is past the first body state (grant-gated), subsequent
                 // states do not re-check grant, so a higher-priority thread can enter
@@ -5733,13 +6739,8 @@ fn partition_thread_body_impl(
                     if fast_idx + 1 == states.len() {
                         states.pop();
                     }
-                    let mut lock_states = lower_thread_lock(
-                        &resource.name,
-                        body,
-                        *span,
-                        cnt_width,
-                        loop_id_gen,
-                    )?;
+                    let mut lock_states =
+                        lower_thread_lock(&resource.name, body, *span, cnt_width, loop_id_gen)?;
                     mealy_gate_first_lock_state(&mut lock_states, &wait_cond, *span);
                     states.extend(lock_states);
                     continue;
@@ -5751,10 +6752,15 @@ fn partition_thread_body_impl(
                     &mut cur_seq,
                     *span,
                 );
-                let lock_states = lower_thread_lock(&resource.name, body, *span, cnt_width, loop_id_gen)?;
+                let lock_states =
+                    lower_thread_lock(&resource.name, body, *span, cnt_width, loop_id_gen)?;
                 states.extend(lock_states);
             }
-            ThreadStmt::DoUntil { body, cond, span: do_sp } => {
+            ThreadStmt::DoUntil {
+                body,
+                cond,
+                span: do_sp,
+            } => {
                 // `do { … } until cond;` is a SINGLE-STATE hold: the body's
                 // comb/seq drives fire every cycle while waiting for `cond`.
                 // It is NOT a loop construct. Nested control flow inside the
@@ -5774,11 +6780,8 @@ fn partition_thread_body_impl(
                         if let Some(stmt) = guarded_stmt(wait_cond.clone(), do_seq, *do_sp) {
                             states[fast_idx].seq_stmts.push(stmt);
                         }
-                        states[fast_idx].transition_cond = Some(expr_and(
-                            wait_cond,
-                            cond.clone(),
-                            *do_sp,
-                        ));
+                        states[fast_idx].transition_cond =
+                            Some(expr_and(wait_cond, cond.clone(), *do_sp));
                         continue;
                     }
                 }
@@ -6025,21 +7028,29 @@ fn lower_fork_join(
     loop_id_gen: &mut u32,
 ) -> Result<Vec<ThreadFsmState>, CompileError> {
     if branches.len() < 2 {
-        return Err(CompileError::general("fork/join requires at least 2 branches", span));
+        return Err(CompileError::general(
+            "fork/join requires at least 2 branches",
+            span,
+        ));
     }
 
     // Partition each branch, append a "done" hold state to each
     let mut branch_states: Vec<Vec<ThreadFsmState>> = Vec::new();
     for (i, br) in branches.iter().enumerate() {
-        let mut states = partition_thread_body_with_loop_ids(br, span, cnt_width, loop_id_gen).map_err(|e| {
-            CompileError::general(&format!("in fork branch {}: {}", i, e), span)
-        })?;
+        let mut states = partition_thread_body_with_loop_ids(br, span, cnt_width, loop_id_gen)
+            .map_err(|e| CompileError::general(&format!("in fork branch {}: {}", i, e), span))?;
         if states.is_empty() {
-            return Err(CompileError::general(&format!("fork branch {} has no wait", i), span));
+            return Err(CompileError::general(
+                &format!("fork branch {} has no wait", i),
+                span,
+            ));
         }
         states.push(ThreadFsmState {
-            comb_stmts: Vec::new(), seq_stmts: Vec::new(),
-            transition_cond: None, wait_cycles: None, multi_transitions: Vec::new(),
+            comb_stmts: Vec::new(),
+            seq_stmts: Vec::new(),
+            transition_cond: None,
+            wait_cycles: None,
+            multi_transitions: Vec::new(),
             terminal_return: None,
             folded_exit_seq: Vec::new(),
             folded_exit_target: None,
@@ -6053,13 +7064,18 @@ fn lower_fork_join(
     let total: usize = branch_lens.iter().product();
     if total > 64 {
         return Err(CompileError::general(
-            &format!("fork/join product expansion too large ({} states)", total), span));
+            &format!("fork/join product expansion too large ({} states)", total),
+            span,
+        ));
     }
 
     // Encode branch indices → flat product index
     let encode = |indices: &[usize]| -> usize {
         let (mut idx, mut m) = (0, 1);
-        for (bi, &si) in indices.iter().enumerate() { idx += si * m; m *= branch_lens[bi]; }
+        for (bi, &si) in indices.iter().enumerate() {
+            idx += si * m;
+            m *= branch_lens[bi];
+        }
         idx
     };
 
@@ -6069,7 +7085,10 @@ fn lower_fork_join(
         // Decode
         let mut indices = Vec::new();
         let mut rem = prod_idx;
-        for &len in &branch_lens { indices.push(rem % len); rem /= len; }
+        for &len in &branch_lens {
+            indices.push(rem % len);
+            rem /= len;
+        }
 
         let all_done = indices.iter().zip(&branch_lens).all(|(&i, &l)| i == l - 1);
 
@@ -6082,8 +7101,11 @@ fn lower_fork_join(
             if !br.seq_stmts.is_empty() {
                 if let Some(ref c) = br.transition_cond {
                     seq.push(Stmt::IfElse(IfElse {
-                        cond: c.clone(), then_stmts: br.seq_stmts.clone(),
-                        else_stmts: Vec::new(), unique: false, span,
+                        cond: c.clone(),
+                        then_stmts: br.seq_stmts.clone(),
+                        else_stmts: Vec::new(),
+                        unique: false,
+                        span,
                     }));
                 } else {
                     seq.extend(br.seq_stmts.clone());
@@ -6105,19 +7127,25 @@ fn lower_fork_join(
             //
             // Sanity assert: comb + seq merged here must be empty
             // (otherwise we'd be losing user-driven assignments).
-            debug_assert!(comb.is_empty() && seq.is_empty(),
-                "fork all_done state non-empty — branch done-hold states have unexpected content");
+            debug_assert!(
+                comb.is_empty() && seq.is_empty(),
+                "fork all_done state non-empty — branch done-hold states have unexpected content"
+            );
             continue;
         }
 
         // Build multi-transitions: enumerate subsets of active branches that can fire
-        let active: Vec<(usize, Option<&Expr>)> = indices.iter().enumerate()
+        let active: Vec<(usize, Option<&Expr>)> = indices
+            .iter()
+            .enumerate()
             .filter(|&(bi, &si)| si < branch_lens[bi] - 1)
             .map(|(bi, _)| (bi, branch_states[bi][indices[bi]].transition_cond.as_ref()))
             .collect();
 
         // Unconditional branches (cond_opt=None) always fire — they must be set in every mask
-        let unconditional_mask: u32 = active.iter().enumerate()
+        let unconditional_mask: u32 = active
+            .iter()
+            .enumerate()
             .filter(|(_, (_, c))| c.is_none())
             .fold(0u32, |m, (bit, _)| m | (1 << bit));
 
@@ -6126,7 +7154,9 @@ fn lower_fork_join(
 
         for mask in (1..(1u32 << n)).rev() {
             // Skip masks that don't include all unconditional branches
-            if mask & unconditional_mask != unconditional_mask { continue; }
+            if mask & unconditional_mask != unconditional_mask {
+                continue;
+            }
 
             let mut next = indices.clone();
             let mut pos: Vec<Expr> = Vec::new();
@@ -6134,7 +7164,9 @@ fn lower_fork_join(
             for (bit, &(bi, cond_opt)) in active.iter().enumerate() {
                 if (mask >> bit) & 1 == 1 {
                     next[bi] += 1;
-                    if let Some(c) = cond_opt { pos.push(c.clone()); }
+                    if let Some(c) = cond_opt {
+                        pos.push(c.clone());
+                    }
                 } else if let Some(c) = cond_opt {
                     neg.push(c.clone());
                 }
@@ -6142,19 +7174,30 @@ fn lower_fork_join(
             let mut cond = if pos.is_empty() {
                 Expr::new(ExprKind::Bool(true), span)
             } else {
-                pos.into_iter().reduce(|a, b|
-                    Expr::new(ExprKind::Binary(BinOp::And, Box::new(a), Box::new(b)), span)).unwrap()
+                pos.into_iter()
+                    .reduce(|a, b| {
+                        Expr::new(ExprKind::Binary(BinOp::And, Box::new(a), Box::new(b)), span)
+                    })
+                    .unwrap()
             };
             for n in neg {
-                cond = Expr::new(ExprKind::Binary(BinOp::And, Box::new(cond),
-                    Box::new(Expr::new(ExprKind::Unary(UnaryOp::Not, Box::new(n)), span))), span);
+                cond = Expr::new(
+                    ExprKind::Binary(
+                        BinOp::And,
+                        Box::new(cond),
+                        Box::new(Expr::new(ExprKind::Unary(UnaryOp::Not, Box::new(n)), span)),
+                    ),
+                    span,
+                );
             }
             multi.push((cond, encode(&next)));
         }
 
         result.push(ThreadFsmState {
-            comb_stmts: comb, seq_stmts: seq,
-            transition_cond: None, wait_cycles: None,
+            comb_stmts: comb,
+            seq_stmts: seq,
+            transition_cond: None,
+            wait_cycles: None,
             multi_transitions: multi,
             terminal_return: None,
             folded_exit_seq: Vec::new(),
@@ -6196,13 +7239,15 @@ fn lower_thread_for(
     // Replace loop variable with this counter in the body. Nested `for`
     // loops inside `body` will allocate their own ids during the
     // recursive partition below, so they each get distinct counter names.
-    let rewritten_body: Vec<ThreadStmt> = body.iter()
+    let rewritten_body: Vec<ThreadStmt> = body
+        .iter()
         .map(|s| rewrite_loop_var(s, &var.name, &cnt_name))
         .collect();
 
     // Partition the rewritten body into states. Share `loop_id_gen` so
     // any nested `for` allocates a fresh id.
-    let body_states = partition_thread_body_with_loop_ids(&rewritten_body, span, cnt_width, loop_id_gen)?;
+    let body_states =
+        partition_thread_body_with_loop_ids(&rewritten_body, span, cnt_width, loop_id_gen)?;
     if body_states.is_empty() {
         return Err(CompileError::general(
             "for loop body must contain at least one wait statement",
@@ -6228,11 +7273,22 @@ fn lower_thread_for(
         target: cnt_ident.clone(),
         value: Expr::new(
             ExprKind::MethodCall(
-                Box::new(Expr::new(ExprKind::Binary(BinOp::Add,
-                    Box::new(cnt_ident.clone()),
-                    Box::new(Expr::new(ExprKind::Literal(LitKind::Sized(cnt_width, 1)), span))), span)),
+                Box::new(Expr::new(
+                    ExprKind::Binary(
+                        BinOp::Add,
+                        Box::new(cnt_ident.clone()),
+                        Box::new(Expr::new(
+                            ExprKind::Literal(LitKind::Sized(cnt_width, 1)),
+                            span,
+                        )),
+                    ),
+                    span,
+                )),
                 Ident::new("trunc".to_string(), span),
-                vec![Expr::new(ExprKind::Literal(LitKind::Dec(cnt_width as u64)), span)],
+                vec![Expr::new(
+                    ExprKind::Literal(LitKind::Dec(cnt_width as u64)),
+                    span,
+                )],
             ),
             span,
         ),
@@ -6251,11 +7307,17 @@ fn lower_thread_for(
     //     where `.trunc<>()` would be flagged as a no-op by typecheck.
     // `resize` accepts both directions without complaint and lowers to the
     // same SV cast when widths match.
-    let end_w = Expr::new(ExprKind::MethodCall(
-        Box::new(end.clone()),
-        Ident::new("resize".to_string(), span),
-        vec![Expr::new(ExprKind::Literal(LitKind::Dec(cnt_width as u64)), span)],
-    ), span);
+    let end_w = Expr::new(
+        ExprKind::MethodCall(
+            Box::new(end.clone()),
+            Ident::new("resize".to_string(), span),
+            vec![Expr::new(
+                ExprKind::Literal(LitKind::Dec(cnt_width as u64)),
+                span,
+            )],
+        ),
+        span,
+    );
 
     let result_len = result.len();
     if let Some(last) = result.last_mut() {
@@ -6301,11 +7363,25 @@ fn lower_thread_for(
                     last.seq_stmts.push(cnt_inc.clone());
                     last.multi_transitions = new_trans;
                     last.multi_transitions.push((
-                        Expr::new(ExprKind::Binary(BinOp::Lt, Box::new(cnt_ident.clone()), Box::new(end_w.clone())), span),
+                        Expr::new(
+                            ExprKind::Binary(
+                                BinOp::Lt,
+                                Box::new(cnt_ident.clone()),
+                                Box::new(end_w.clone()),
+                            ),
+                            span,
+                        ),
                         loop_back_target,
                     ));
                     last.multi_transitions.push((
-                        Expr::new(ExprKind::Binary(BinOp::Gte, Box::new(cnt_ident.clone()), Box::new(end_w.clone())), span),
+                        Expr::new(
+                            ExprKind::Binary(
+                                BinOp::Gte,
+                                Box::new(cnt_ident.clone()),
+                                Box::new(end_w.clone()),
+                            ),
+                            span,
+                        ),
                         usize::MAX,
                     ));
                     return Ok(result);
@@ -6314,7 +7390,10 @@ fn lower_thread_for(
                 _ => {
                     let mut acc = inner_exit_conds.remove(0);
                     for c in inner_exit_conds {
-                        acc = Expr::new(ExprKind::Binary(BinOp::Or, Box::new(acc), Box::new(c)), span);
+                        acc = Expr::new(
+                            ExprKind::Binary(BinOp::Or, Box::new(acc), Box::new(c)),
+                            span,
+                        );
                     }
                     acc
                 }
@@ -6331,21 +7410,37 @@ fn lower_thread_for(
                 span,
             }));
             // Outer loop-back: inner_exit && cnt < end → 0
-            let outer_loop_cond = Expr::new(ExprKind::Binary(
-                BinOp::And,
-                Box::new(inner_exit_for_loop),
-                Box::new(Expr::new(ExprKind::Binary(
-                    BinOp::Lt, Box::new(cnt_ident.clone()), Box::new(end_w.clone()),
-                ), span)),
-            ), span);
+            let outer_loop_cond = Expr::new(
+                ExprKind::Binary(
+                    BinOp::And,
+                    Box::new(inner_exit_for_loop),
+                    Box::new(Expr::new(
+                        ExprKind::Binary(
+                            BinOp::Lt,
+                            Box::new(cnt_ident.clone()),
+                            Box::new(end_w.clone()),
+                        ),
+                        span,
+                    )),
+                ),
+                span,
+            );
             // Outer exit: inner_exit && cnt >= end → NEXT (sentinel)
-            let outer_exit_cond = Expr::new(ExprKind::Binary(
-                BinOp::And,
-                Box::new(inner_exit_for_exit),
-                Box::new(Expr::new(ExprKind::Binary(
-                    BinOp::Gte, Box::new(cnt_ident.clone()), Box::new(end_w.clone()),
-                ), span)),
-            ), span);
+            let outer_exit_cond = Expr::new(
+                ExprKind::Binary(
+                    BinOp::And,
+                    Box::new(inner_exit_for_exit),
+                    Box::new(Expr::new(
+                        ExprKind::Binary(
+                            BinOp::Gte,
+                            Box::new(cnt_ident.clone()),
+                            Box::new(end_w.clone()),
+                        ),
+                        span,
+                    )),
+                ),
+                span,
+            );
             new_trans.push((outer_loop_cond, loop_back_target));
             new_trans.push((outer_exit_cond, usize::MAX));
             last.multi_transitions = new_trans;
@@ -6354,20 +7449,36 @@ fn lower_thread_for(
             // Replace with multi_transitions: loop-back and exit, both
             // guarded by the original body condition AND counter check.
             let body_cond_clone = body_cond.clone();
-            let loop_cond = Expr::new(ExprKind::Binary(
-                BinOp::And,
-                Box::new(body_cond.clone()),
-                Box::new(Expr::new(ExprKind::Binary(
-                    BinOp::Lt, Box::new(cnt_ident.clone()), Box::new(end_w.clone()),
-                ), span)),
-            ), span);
-            let exit_cond = Expr::new(ExprKind::Binary(
-                BinOp::And,
-                Box::new(body_cond),
-                Box::new(Expr::new(ExprKind::Binary(
-                    BinOp::Gte, Box::new(cnt_ident.clone()), Box::new(end_w.clone()),
-                ), span)),
-            ), span);
+            let loop_cond = Expr::new(
+                ExprKind::Binary(
+                    BinOp::And,
+                    Box::new(body_cond.clone()),
+                    Box::new(Expr::new(
+                        ExprKind::Binary(
+                            BinOp::Lt,
+                            Box::new(cnt_ident.clone()),
+                            Box::new(end_w.clone()),
+                        ),
+                        span,
+                    )),
+                ),
+                span,
+            );
+            let exit_cond = Expr::new(
+                ExprKind::Binary(
+                    BinOp::And,
+                    Box::new(body_cond),
+                    Box::new(Expr::new(
+                        ExprKind::Binary(
+                            BinOp::Gte,
+                            Box::new(cnt_ident.clone()),
+                            Box::new(end_w.clone()),
+                        ),
+                        span,
+                    )),
+                ),
+                span,
+            );
 
             // Counter increment guarded by the body condition —
             // only increment when a beat is actually accepted
@@ -6387,18 +7498,23 @@ fn lower_thread_for(
             // Last body state has no condition (unconditional advance) —
             // just add counter check as multi_transitions.
             let loop_cond = Expr::new(
-                ExprKind::Binary(BinOp::Lt, Box::new(cnt_ident.clone()), Box::new(end_w.clone())),
+                ExprKind::Binary(
+                    BinOp::Lt,
+                    Box::new(cnt_ident.clone()),
+                    Box::new(end_w.clone()),
+                ),
                 span,
             );
             let exit_cond = Expr::new(
-                ExprKind::Binary(BinOp::Gte, Box::new(cnt_ident.clone()), Box::new(end_w.clone())),
+                ExprKind::Binary(
+                    BinOp::Gte,
+                    Box::new(cnt_ident.clone()),
+                    Box::new(end_w.clone()),
+                ),
                 span,
             );
             last.seq_stmts.push(cnt_inc.clone());
-            last.multi_transitions = vec![
-                (loop_cond, loop_back_target),
-                (exit_cond, usize::MAX),
-            ];
+            last.multi_transitions = vec![(loop_cond, loop_back_target), (exit_cond, usize::MAX)];
         }
     }
 
@@ -6439,7 +7555,10 @@ fn lower_thread_for(
             } else {
                 let mut acc = off_end_conds.remove(0);
                 for c in off_end_conds {
-                    acc = Expr::new(ExprKind::Binary(BinOp::Or, Box::new(acc), Box::new(c)), span);
+                    acc = Expr::new(
+                        ExprKind::Binary(BinOp::Or, Box::new(acc), Box::new(c)),
+                        span,
+                    );
                 }
                 acc
             };
@@ -6456,23 +7575,39 @@ fn lower_thread_for(
             }));
             // Replace off-the-end transitions with loop-back + exit cascade.
             new_trans.push((
-                Expr::new(ExprKind::Binary(
-                    BinOp::And,
-                    Box::new(off_end_for_loop),
-                    Box::new(Expr::new(ExprKind::Binary(
-                        BinOp::Lt, Box::new(cnt_ident.clone()), Box::new(end_w.clone()),
-                    ), span)),
-                ), span),
+                Expr::new(
+                    ExprKind::Binary(
+                        BinOp::And,
+                        Box::new(off_end_for_loop),
+                        Box::new(Expr::new(
+                            ExprKind::Binary(
+                                BinOp::Lt,
+                                Box::new(cnt_ident.clone()),
+                                Box::new(end_w.clone()),
+                            ),
+                            span,
+                        )),
+                    ),
+                    span,
+                ),
                 loop_back_target,
             ));
             new_trans.push((
-                Expr::new(ExprKind::Binary(
-                    BinOp::And,
-                    Box::new(off_end_for_exit),
-                    Box::new(Expr::new(ExprKind::Binary(
-                        BinOp::Gte, Box::new(cnt_ident.clone()), Box::new(end_w.clone()),
-                    ), span)),
-                ), span),
+                Expr::new(
+                    ExprKind::Binary(
+                        BinOp::And,
+                        Box::new(off_end_for_exit),
+                        Box::new(Expr::new(
+                            ExprKind::Binary(
+                                BinOp::Gte,
+                                Box::new(cnt_ident.clone()),
+                                Box::new(end_w.clone()),
+                            ),
+                            span,
+                        )),
+                    ),
+                    span,
+                ),
                 usize::MAX,
             ));
             result[si].multi_transitions = new_trans;
@@ -6515,7 +7650,9 @@ fn lower_thread_lock(
     // Without grant gating, all contending threads would drive outputs simultaneously.
     if let Some(first) = body_states.first_mut() {
         // Wrap ALL comb outputs (except req) in `if (grant) { ... }`
-        let non_req_comb: Vec<Stmt> = first.comb_stmts.iter()
+        let non_req_comb: Vec<Stmt> = first
+            .comb_stmts
+            .iter()
             .filter(|s| {
                 if let Stmt::Assign(a) = s {
                     if let ExprKind::Ident(ref n) = a.target.kind {
@@ -6548,11 +7685,14 @@ fn lower_thread_lock(
 
         // AND grant into transition condition
         if let Some(ref existing_cond) = first.transition_cond {
-            first.transition_cond = Some(Expr::new(ExprKind::Binary(
-                BinOp::And,
-                Box::new(make_grant()),
-                Box::new(existing_cond.clone()),
-            ), span));
+            first.transition_cond = Some(Expr::new(
+                ExprKind::Binary(
+                    BinOp::And,
+                    Box::new(make_grant()),
+                    Box::new(existing_cond.clone()),
+                ),
+                span,
+            ));
         } else if first.wait_cycles.is_none() && first.multi_transitions.is_empty() {
             first.transition_cond = Some(make_grant());
         }
@@ -6607,7 +7747,9 @@ fn collect_locked_resources(stmts: &[ThreadStmt]) -> HashSet<String> {
                 resources.extend(collect_locked_resources(&ie.else_stmts));
             }
             ThreadStmt::ForkJoin(branches, _) => {
-                for br in branches { resources.extend(collect_locked_resources(br)); }
+                for br in branches {
+                    resources.extend(collect_locked_resources(br));
+                }
             }
             ThreadStmt::For { body, .. } | ThreadStmt::DoUntil { body, .. } => {
                 resources.extend(collect_locked_resources(body));
@@ -6645,34 +7787,70 @@ fn rewrite_loop_var(stmt: &ThreadStmt, var: &str, replacement: &str) -> ThreadSt
         }
         ThreadStmt::IfElse(ie) => ThreadStmt::IfElse(ThreadIfElse {
             cond: rewrite_var_expr(ie.cond.clone(), var, replacement),
-            then_stmts: ie.then_stmts.iter().map(|s| rewrite_loop_var(s, var, replacement)).collect(),
-            else_stmts: ie.else_stmts.iter().map(|s| rewrite_loop_var(s, var, replacement)).collect(),
+            then_stmts: ie
+                .then_stmts
+                .iter()
+                .map(|s| rewrite_loop_var(s, var, replacement))
+                .collect(),
+            else_stmts: ie
+                .else_stmts
+                .iter()
+                .map(|s| rewrite_loop_var(s, var, replacement))
+                .collect(),
             unique: ie.unique,
             span: ie.span,
         }),
         ThreadStmt::ForkJoin(branches, sp) => ThreadStmt::ForkJoin(
-            branches.iter().map(|br| br.iter().map(|s| rewrite_loop_var(s, var, replacement)).collect()).collect(),
+            branches
+                .iter()
+                .map(|br| {
+                    br.iter()
+                        .map(|s| rewrite_loop_var(s, var, replacement))
+                        .collect()
+                })
+                .collect(),
             *sp,
         ),
-        ThreadStmt::For { var: fv, start, end, body, span } => ThreadStmt::For {
+        ThreadStmt::For {
+            var: fv,
+            start,
+            end,
+            body,
+            span,
+        } => ThreadStmt::For {
             var: fv.clone(),
             start: rewrite_var_expr(start.clone(), var, replacement),
             end: rewrite_var_expr(end.clone(), var, replacement),
-            body: body.iter().map(|s| rewrite_loop_var(s, var, replacement)).collect(),
+            body: body
+                .iter()
+                .map(|s| rewrite_loop_var(s, var, replacement))
+                .collect(),
             span: *span,
         },
-        ThreadStmt::Lock { resource, body, span } => ThreadStmt::Lock {
+        ThreadStmt::Lock {
+            resource,
+            body,
+            span,
+        } => ThreadStmt::Lock {
             resource: resource.clone(),
-            body: body.iter().map(|s| rewrite_loop_var(s, var, replacement)).collect(),
+            body: body
+                .iter()
+                .map(|s| rewrite_loop_var(s, var, replacement))
+                .collect(),
             span: *span,
         },
         ThreadStmt::DoUntil { body, cond, span } => ThreadStmt::DoUntil {
-            body: body.iter().map(|s| rewrite_loop_var(s, var, replacement)).collect(),
+            body: body
+                .iter()
+                .map(|s| rewrite_loop_var(s, var, replacement))
+                .collect(),
             cond: rewrite_var_expr(cond.clone(), var, replacement),
             span: *span,
         },
         ThreadStmt::Log(l) => ThreadStmt::Log(l.clone()),
-        ThreadStmt::Return(e, span) => ThreadStmt::Return(rewrite_var_expr(e.clone(), var, replacement), *span),
+        ThreadStmt::Return(e, span) => {
+            ThreadStmt::Return(rewrite_var_expr(e.clone(), var, replacement), *span)
+        }
     }
 }
 
@@ -6690,7 +7868,10 @@ fn rewrite_var_expr(expr: Expr, var: &str, replacement: &str) -> Expr {
             Box::new(rewrite_var_expr(*l.clone(), var, replacement)),
             Box::new(rewrite_var_expr(*r.clone(), var, replacement)),
         ),
-        ExprKind::Unary(op, e) => ExprKind::Unary(*op, Box::new(rewrite_var_expr(*e.clone(), var, replacement))),
+        ExprKind::Unary(op, e) => ExprKind::Unary(
+            *op,
+            Box::new(rewrite_var_expr(*e.clone(), var, replacement)),
+        ),
         ExprKind::Index(base, idx) => ExprKind::Index(
             Box::new(rewrite_var_expr(*base.clone(), var, replacement)),
             Box::new(rewrite_var_expr(*idx.clone(), var, replacement)),
@@ -6716,7 +7897,10 @@ fn rewrite_var_expr(expr: Expr, var: &str, replacement: &str) -> Expr {
             Box::new(rewrite_var_expr(*f.clone(), var, replacement)),
         ),
         ExprKind::Concat(parts) => ExprKind::Concat(
-            parts.iter().map(|p| rewrite_var_expr(p.clone(), var, replacement)).collect(),
+            parts
+                .iter()
+                .map(|p| rewrite_var_expr(p.clone(), var, replacement))
+                .collect(),
         ),
         ExprKind::Repeat(count, inner) => ExprKind::Repeat(
             Box::new(rewrite_var_expr(*count.clone(), var, replacement)),
@@ -6725,23 +7909,31 @@ fn rewrite_var_expr(expr: Expr, var: &str, replacement: &str) -> Expr {
         ExprKind::MethodCall(recv, name, args) => ExprKind::MethodCall(
             Box::new(rewrite_var_expr(*recv.clone(), var, replacement)),
             name.clone(),
-            args.iter().map(|a| rewrite_var_expr(a.clone(), var, replacement)).collect(),
+            args.iter()
+                .map(|a| rewrite_var_expr(a.clone(), var, replacement))
+                .collect(),
         ),
         ExprKind::FunctionCall(name, args) => ExprKind::FunctionCall(
             name.clone(),
-            args.iter().map(|a| rewrite_var_expr(a.clone(), var, replacement)).collect(),
+            args.iter()
+                .map(|a| rewrite_var_expr(a.clone(), var, replacement))
+                .collect(),
         ),
-        ExprKind::Signed(inner) => ExprKind::Signed(
-            Box::new(rewrite_var_expr(*inner.clone(), var, replacement)),
-        ),
-        ExprKind::Unsigned(inner) => ExprKind::Unsigned(
-            Box::new(rewrite_var_expr(*inner.clone(), var, replacement)),
-        ),
+        ExprKind::Signed(inner) => {
+            ExprKind::Signed(Box::new(rewrite_var_expr(*inner.clone(), var, replacement)))
+        }
+        ExprKind::Unsigned(inner) => {
+            ExprKind::Unsigned(Box::new(rewrite_var_expr(*inner.clone(), var, replacement)))
+        }
         // Leaf nodes / non-substitutable forms: Ident-not-matching, Literal,
         // Bool, EnumVariant, Todo, etc. Fall through unchanged.
         _ => return expr,
     };
-    Expr { kind: new_kind, span: expr.span, parenthesized: expr.parenthesized }
+    Expr {
+        kind: new_kind,
+        span: expr.span,
+        parenthesized: expr.parenthesized,
+    }
 }
 
 /// Convert a ThreadIfElse (no waits) into FSM comb and seq statements.
@@ -6760,8 +7952,12 @@ fn thread_if_to_fsm_stmts(ie: &ThreadIfElse) -> (Option<Stmt>, Option<Stmt>) {
                 ThreadStmt::Log(l) => seq.push(Stmt::Log(l.clone())),
                 ThreadStmt::IfElse(nested) => {
                     let (c, s) = thread_if_to_fsm_stmts(nested);
-                    if let Some(c) = c { comb.push(c); }
-                    if let Some(s) = s { seq.push(s); }
+                    if let Some(c) = c {
+                        comb.push(c);
+                    }
+                    if let Some(s) = s {
+                        seq.push(s);
+                    }
                 }
                 _ => {} // wait already excluded by contains_wait check
             }
@@ -6779,7 +7975,9 @@ fn thread_if_to_fsm_stmts(ie: &ThreadIfElse) -> (Option<Stmt>, Option<Stmt>) {
             unique: false,
             span: ie.span,
         }))
-    } else { None };
+    } else {
+        None
+    };
 
     let seq_if = if !then_seq.is_empty() || !else_seq.is_empty() {
         Some(Stmt::IfElse(IfElse {
@@ -6789,11 +7987,12 @@ fn thread_if_to_fsm_stmts(ie: &ThreadIfElse) -> (Option<Stmt>, Option<Stmt>) {
             unique: false,
             span: ie.span,
         }))
-    } else { None };
+    } else {
+        None
+    };
 
     (comb_if, seq_if)
 }
-
 
 /// Rewrite seq stmts: if a seq assign targets a shared(or) signal, convert it
 /// to a comb assign targeting the per-thread shadow wire `_sig_in_ti`.
@@ -6826,9 +8025,19 @@ fn rewrite_shared_or_seq_stmts(
                 let mut then_comb = Vec::new();
                 let mut else_comb = Vec::new();
                 let then_seq = rewrite_shared_or_seq_stmts(
-                    &ie.then_stmts, shared_or_seq, thread_idx, sp, &mut then_comb);
+                    &ie.then_stmts,
+                    shared_or_seq,
+                    thread_idx,
+                    sp,
+                    &mut then_comb,
+                );
                 let else_seq = rewrite_shared_or_seq_stmts(
-                    &ie.else_stmts, shared_or_seq, thread_idx, sp, &mut else_comb);
+                    &ie.else_stmts,
+                    shared_or_seq,
+                    thread_idx,
+                    sp,
+                    &mut else_comb,
+                );
                 // Push rewritten comb assigns under the same if guard
                 if !then_comb.is_empty() || !else_comb.is_empty() {
                     out_comb.push(Stmt::IfElse(IfElse {
@@ -6857,46 +8066,46 @@ fn rewrite_shared_or_seq_stmts(
 
 /// Transform comb assigns for shared(or) signals: `sig = val` → `sig = sig | val`.
 /// This ensures multiple threads OR-accumulate rather than last-writer-wins.
-fn transform_shared_or_assigns(
-    stmts: &[Stmt],
-    shared_or: &HashSet<String>,
-    sp: Span,
-) -> Vec<Stmt> {
-    stmts.iter().map(|stmt| {
-        match stmt {
-            Stmt::Assign(a) => {
-                let target_name = match &a.target.kind {
-                    ExprKind::Ident(n) => Some(n.clone()),
-                    _ => None,
-                };
-                if let Some(ref name) = target_name {
-                    if shared_or.contains(name) {
-                        // sig = sig | val
-                        return Stmt::Assign(CombAssign {
-                            target: a.target.clone(),
-                            value: Expr::new(ExprKind::Binary(
-                                BinOp::BitOr,
-                                Box::new(Expr::new(ExprKind::Ident(name.clone()), sp)),
-                                Box::new(a.value.clone()),
-                            ), sp),
-                            span: a.span,
-                        });
+fn transform_shared_or_assigns(stmts: &[Stmt], shared_or: &HashSet<String>, sp: Span) -> Vec<Stmt> {
+    stmts
+        .iter()
+        .map(|stmt| {
+            match stmt {
+                Stmt::Assign(a) => {
+                    let target_name = match &a.target.kind {
+                        ExprKind::Ident(n) => Some(n.clone()),
+                        _ => None,
+                    };
+                    if let Some(ref name) = target_name {
+                        if shared_or.contains(name) {
+                            // sig = sig | val
+                            return Stmt::Assign(CombAssign {
+                                target: a.target.clone(),
+                                value: Expr::new(
+                                    ExprKind::Binary(
+                                        BinOp::BitOr,
+                                        Box::new(Expr::new(ExprKind::Ident(name.clone()), sp)),
+                                        Box::new(a.value.clone()),
+                                    ),
+                                    sp,
+                                ),
+                                span: a.span,
+                            });
+                        }
                     }
+                    stmt.clone()
                 }
-                stmt.clone()
-            }
-            Stmt::IfElse(ie) => {
-                Stmt::IfElse(IfElse {
+                Stmt::IfElse(ie) => Stmt::IfElse(IfElse {
                     cond: ie.cond.clone(),
                     then_stmts: transform_shared_or_assigns(&ie.then_stmts, shared_or, sp),
                     else_stmts: transform_shared_or_assigns(&ie.else_stmts, shared_or, sp),
                     unique: ie.unique,
                     span: ie.span,
-                })
+                }),
+                _ => stmt.clone(),
             }
-            _ => stmt.clone(),
-        }
-    }).collect()
+        })
+        .collect()
 }
 
 /// Rename an identifier in an expression tree.
@@ -6906,24 +8115,55 @@ fn rename_ident_in_expr(expr: &mut Expr, old: &str, new: &str) {
     // tree, and missing a container leaves a bare `_loop_cnt` ident in the
     // lowered SV that references no real variable.
     match &mut expr.kind {
-        ExprKind::Ident(ref mut name) if name == old => { *name = new.to_string(); }
-        ExprKind::Binary(_, l, r) => { rename_ident_in_expr(l, old, new); rename_ident_in_expr(r, old, new); }
+        ExprKind::Ident(ref mut name) if name == old => {
+            *name = new.to_string();
+        }
+        ExprKind::Binary(_, l, r) => {
+            rename_ident_in_expr(l, old, new);
+            rename_ident_in_expr(r, old, new);
+        }
         ExprKind::Unary(_, e) => rename_ident_in_expr(e, old, new),
-        ExprKind::Index(b, i) => { rename_ident_in_expr(b, old, new); rename_ident_in_expr(i, old, new); }
-        ExprKind::BitSlice(b, h, l) => { rename_ident_in_expr(b, old, new); rename_ident_in_expr(h, old, new); rename_ident_in_expr(l, old, new); }
-        ExprKind::PartSelect(b, s, w, _) => { rename_ident_in_expr(b, old, new); rename_ident_in_expr(s, old, new); rename_ident_in_expr(w, old, new); }
+        ExprKind::Index(b, i) => {
+            rename_ident_in_expr(b, old, new);
+            rename_ident_in_expr(i, old, new);
+        }
+        ExprKind::BitSlice(b, h, l) => {
+            rename_ident_in_expr(b, old, new);
+            rename_ident_in_expr(h, old, new);
+            rename_ident_in_expr(l, old, new);
+        }
+        ExprKind::PartSelect(b, s, w, _) => {
+            rename_ident_in_expr(b, old, new);
+            rename_ident_in_expr(s, old, new);
+            rename_ident_in_expr(w, old, new);
+        }
         ExprKind::FieldAccess(b, _) => rename_ident_in_expr(b, old, new),
         ExprKind::MethodCall(recv, _, args) => {
             rename_ident_in_expr(recv, old, new);
-            for a in args { rename_ident_in_expr(a, old, new); }
+            for a in args {
+                rename_ident_in_expr(a, old, new);
+            }
         }
         ExprKind::FunctionCall(_, args) => {
-            for a in args { rename_ident_in_expr(a, old, new); }
+            for a in args {
+                rename_ident_in_expr(a, old, new);
+            }
         }
-        ExprKind::Ternary(c, t, f) => { rename_ident_in_expr(c, old, new); rename_ident_in_expr(t, old, new); rename_ident_in_expr(f, old, new); }
+        ExprKind::Ternary(c, t, f) => {
+            rename_ident_in_expr(c, old, new);
+            rename_ident_in_expr(t, old, new);
+            rename_ident_in_expr(f, old, new);
+        }
         ExprKind::Cast(e, _) => rename_ident_in_expr(e, old, new),
-        ExprKind::Concat(parts) => { for p in parts { rename_ident_in_expr(p, old, new); } }
-        ExprKind::Repeat(c, e) => { rename_ident_in_expr(c, old, new); rename_ident_in_expr(e, old, new); }
+        ExprKind::Concat(parts) => {
+            for p in parts {
+                rename_ident_in_expr(p, old, new);
+            }
+        }
+        ExprKind::Repeat(c, e) => {
+            rename_ident_in_expr(c, old, new);
+            rename_ident_in_expr(e, old, new);
+        }
         ExprKind::Signed(e) | ExprKind::Unsigned(e) | ExprKind::Clog2(e) | ExprKind::Onehot(e) => {
             rename_ident_in_expr(e, old, new);
         }
@@ -6934,7 +8174,10 @@ fn rename_ident_in_expr(expr: &mut Expr, old: &str, new: &str) {
 fn rename_ident_in_stmts(stmts: &mut [Stmt], old: &str, new: &str) {
     for s in stmts {
         match s {
-            Stmt::Assign(ra) => { rename_ident_in_expr(&mut ra.target, old, new); rename_ident_in_expr(&mut ra.value, old, new); }
+            Stmt::Assign(ra) => {
+                rename_ident_in_expr(&mut ra.target, old, new);
+                rename_ident_in_expr(&mut ra.value, old, new);
+            }
             Stmt::IfElse(ie) => {
                 rename_ident_in_expr(&mut ie.cond, old, new);
                 rename_ident_in_stmts(&mut ie.then_stmts, old, new);
@@ -6948,7 +8191,10 @@ fn rename_ident_in_stmts(stmts: &mut [Stmt], old: &str, new: &str) {
 fn rename_ident_in_comb_stmts(stmts: &mut [Stmt], old: &str, new: &str) {
     for s in stmts {
         match s {
-            Stmt::Assign(ca) => { rename_ident_in_expr(&mut ca.target, old, new); rename_ident_in_expr(&mut ca.value, old, new); }
+            Stmt::Assign(ca) => {
+                rename_ident_in_expr(&mut ca.target, old, new);
+                rename_ident_in_expr(&mut ca.value, old, new);
+            }
             Stmt::IfElse(ie) => {
                 rename_ident_in_expr(&mut ie.cond, old, new);
                 rename_ident_in_comb_stmts(&mut ie.then_stmts, old, new);
@@ -6993,8 +8239,14 @@ pub fn lower_pipe_reg_ports(ast: SourceFile) -> Result<SourceFile, Vec<CompileEr
             other => new_items.push(other),
         }
     }
-    if !errors.is_empty() { return Err(errors); }
-    Ok(SourceFile { items: new_items, inner_doc: None, frontmatter: None })
+    if !errors.is_empty() {
+        return Err(errors);
+    }
+    Ok(SourceFile {
+        items: new_items,
+        inner_doc: None,
+        frontmatter: None,
+    })
 }
 
 struct PipePortInfoLocal {
@@ -7046,13 +8298,22 @@ fn lower_pipe_reg_module(mut m: ModuleDecl) -> Result<ModuleDecl, Vec<CompileErr
             validate_pipe_assignments(&rb.stmts, &all_pipe_ports, &pipe_depths, &mut errors);
         }
         if let ModuleBodyItem::CombBlock(cb) = bi {
-            validate_comb_pipe_refs(&cb.stmts, &all_pipe_ports, &m.ports, &pipe_depths, &mut errors);
+            validate_comb_pipe_refs(
+                &cb.stmts,
+                &all_pipe_ports,
+                &m.ports,
+                &pipe_depths,
+                &mut errors,
+            );
         }
     }
-    if !errors.is_empty() { return Err(errors); }
+    if !errors.is_empty() {
+        return Err(errors);
+    }
 
     // Filter to ports that actually need the cascade expansion (latency > 1).
-    let pipes: Vec<PipePortInfoLocal> = all_pipe_ports.into_iter()
+    let pipes: Vec<PipePortInfoLocal> = all_pipe_ports
+        .into_iter()
         .filter(|pp| pp.latency > 1)
         .collect();
     if pipes.is_empty() {
@@ -7142,7 +8403,9 @@ fn validate_pipe_assign_stmt(
                 ExprKind::Ident(name) => (name.clone(), None),
                 _ => return,
             };
-            let Some(pp) = ports.iter().find(|p| p.name == target_name) else { return; };
+            let Some(pp) = ports.iter().find(|p| p.name == target_name) else {
+                return;
+            };
             match latency_opt {
                 Some(n) if n != pp.latency => {
                     errors.push(CompileError::general(
@@ -7212,7 +8475,10 @@ fn validate_rhs_latency_with_depths(
             }
             validate_rhs_latency_with_depths(inner, pipe_depths, errors);
         }
-        ExprKind::Binary(_, l, r) => { validate_rhs_latency_with_depths(l, pipe_depths, errors); validate_rhs_latency_with_depths(r, pipe_depths, errors); }
+        ExprKind::Binary(_, l, r) => {
+            validate_rhs_latency_with_depths(l, pipe_depths, errors);
+            validate_rhs_latency_with_depths(r, pipe_depths, errors);
+        }
         ExprKind::Unary(_, x) => validate_rhs_latency_with_depths(x, pipe_depths, errors),
         ExprKind::Ternary(c, t, e2) => {
             validate_rhs_latency_with_depths(c, pipe_depths, errors);
@@ -7220,7 +8486,10 @@ fn validate_rhs_latency_with_depths(
             validate_rhs_latency_with_depths(e2, pipe_depths, errors);
         }
         ExprKind::FieldAccess(b, _) => validate_rhs_latency_with_depths(b, pipe_depths, errors),
-        ExprKind::Index(b, i) => { validate_rhs_latency_with_depths(b, pipe_depths, errors); validate_rhs_latency_with_depths(i, pipe_depths, errors); }
+        ExprKind::Index(b, i) => {
+            validate_rhs_latency_with_depths(b, pipe_depths, errors);
+            validate_rhs_latency_with_depths(i, pipe_depths, errors);
+        }
         ExprKind::BitSlice(b, h, l) => {
             validate_rhs_latency_with_depths(b, pipe_depths, errors);
             validate_rhs_latency_with_depths(h, pipe_depths, errors);
@@ -7228,10 +8497,14 @@ fn validate_rhs_latency_with_depths(
         }
         ExprKind::MethodCall(b, _, args) => {
             validate_rhs_latency_with_depths(b, pipe_depths, errors);
-            for a in args { validate_rhs_latency_with_depths(a, pipe_depths, errors); }
+            for a in args {
+                validate_rhs_latency_with_depths(a, pipe_depths, errors);
+            }
         }
         ExprKind::FunctionCall(_, args) => {
-            for a in args { validate_rhs_latency_with_depths(a, pipe_depths, errors); }
+            for a in args {
+                validate_rhs_latency_with_depths(a, pipe_depths, errors);
+            }
         }
         _ => {}
     }
@@ -7265,7 +8538,9 @@ fn validate_comb_pipe_refs(
                 validate_comb_pipe_refs(&ie.then_stmts, pipe_ports, all_ports, pipe_depths, errors);
                 validate_comb_pipe_refs(&ie.else_stmts, pipe_ports, all_ports, pipe_depths, errors);
             }
-                Stmt::Init(_) | Stmt::WaitUntil(..) | Stmt::DoUntil { .. } => unreachable!("seq-only Stmt variant inside comb-context walker"),
+            Stmt::Init(_) | Stmt::WaitUntil(..) | Stmt::DoUntil { .. } => {
+                unreachable!("seq-only Stmt variant inside comb-context walker")
+            }
             Stmt::Match(_) | Stmt::For(_) | Stmt::Log(_) => {}
         }
     }
@@ -7354,7 +8629,6 @@ fn rewrite_seq_stmts_pp(stmts: Vec<Stmt>, pipes: &[PipePortInfoLocal]) -> Vec<St
     out
 }
 
-
 // ── credit_channel method-dispatch (PR #3b-v-β) ─────────────────────────────
 //
 // Rewrites `port.ch.valid` / `port.ch.data` / `port.ch.can_send` expressions,
@@ -7387,19 +8661,31 @@ pub fn lower_credit_channel_dispatch(ast: SourceFile) -> Result<SourceFile, Vec<
             _ => {}
         }
     }
-    if bus_ccs.is_empty() { return Ok(ast); }
+    if bus_ccs.is_empty() {
+        return Ok(ast);
+    }
     let mut items: Vec<Item> = Vec::with_capacity(ast.items.len());
     let mut errors: Vec<CompileError> = Vec::new();
     for item in ast.items {
         match item {
             Item::Module(mut m) => {
-                let port_buses: HashMap<String, (String, BusPerspective)> = m.ports.iter()
-                    .filter_map(|p| p.bus_info.as_ref().map(|bi|
-                        (p.name.name.clone(), (bi.bus_name.name.clone(), bi.perspective))
-                    ))
+                let port_buses: HashMap<String, (String, BusPerspective)> = m
+                    .ports
+                    .iter()
+                    .filter_map(|p| {
+                        p.bus_info.as_ref().map(|bi| {
+                            (
+                                p.name.name.clone(),
+                                (bi.bus_name.name.clone(), bi.perspective),
+                            )
+                        })
+                    })
                     .collect();
                 if port_buses.values().any(|(b, _)| bus_ccs.contains_key(b)) {
-                    let ctx = CcDispatchCtx { bus_ccs: &bus_ccs, port_buses: &port_buses };
+                    let ctx = CcDispatchCtx {
+                        bus_ccs: &bus_ccs,
+                        port_buses: &port_buses,
+                    };
                     for bi in &mut m.body {
                         rewrite_body_item_cc(bi, &ctx, &mut errors);
                     }
@@ -7409,8 +8695,14 @@ pub fn lower_credit_channel_dispatch(ast: SourceFile) -> Result<SourceFile, Vec<
             other => items.push(other),
         }
     }
-    if !errors.is_empty() { return Err(errors); }
-    Ok(SourceFile { items, inner_doc: None, frontmatter: None })
+    if !errors.is_empty() {
+        return Err(errors);
+    }
+    Ok(SourceFile {
+        items,
+        inner_doc: None,
+        frontmatter: None,
+    })
 }
 
 struct CcDispatchCtx<'a> {
@@ -7418,15 +8710,25 @@ struct CcDispatchCtx<'a> {
     port_buses: &'a std::collections::HashMap<String, (String, BusPerspective)>,
 }
 
-fn rewrite_body_item_cc(bi: &mut ModuleBodyItem, ctx: &CcDispatchCtx, errors: &mut Vec<CompileError>) {
+fn rewrite_body_item_cc(
+    bi: &mut ModuleBodyItem,
+    ctx: &CcDispatchCtx,
+    errors: &mut Vec<CompileError>,
+) {
     match bi {
         ModuleBodyItem::CombBlock(cb) => {
-            for s in &mut cb.stmts { rewrite_stmt_cc(s, ctx, errors); }
+            for s in &mut cb.stmts {
+                rewrite_stmt_cc(s, ctx, errors);
+            }
         }
         ModuleBodyItem::RegBlock(rb) => {
-            for s in &mut rb.stmts { rewrite_stmt_cc(s, ctx, errors); }
+            for s in &mut rb.stmts {
+                rewrite_stmt_cc(s, ctx, errors);
+            }
         }
-        ModuleBodyItem::LetBinding(l) => { rewrite_expr_cc(&mut l.value, ctx, errors); }
+        ModuleBodyItem::LetBinding(l) => {
+            rewrite_expr_cc(&mut l.value, ctx, errors);
+        }
         _ => {}
     }
 }
@@ -7453,62 +8755,105 @@ fn rewrite_stmt_cc(s: &mut Stmt, ctx: &CcDispatchCtx, errors: &mut Vec<CompileEr
         }
         Stmt::IfElse(ie) => {
             rewrite_expr_cc(&mut ie.cond, ctx, errors);
-            for s in &mut ie.then_stmts { rewrite_stmt_cc(s, ctx, errors); }
-            for s in &mut ie.else_stmts { rewrite_stmt_cc(s, ctx, errors); }
+            for s in &mut ie.then_stmts {
+                rewrite_stmt_cc(s, ctx, errors);
+            }
+            for s in &mut ie.else_stmts {
+                rewrite_stmt_cc(s, ctx, errors);
+            }
         }
         Stmt::For(fl) => {
-            for s in &mut fl.body { rewrite_stmt_cc(s, ctx, errors); }
+            for s in &mut fl.body {
+                rewrite_stmt_cc(s, ctx, errors);
+            }
         }
         Stmt::Match(m) => {
             rewrite_expr_cc(&mut m.scrutinee, ctx, errors);
             for arm in &mut m.arms {
-                for s in &mut arm.body { rewrite_stmt_cc(s, ctx, errors); }
+                for s in &mut arm.body {
+                    rewrite_stmt_cc(s, ctx, errors);
+                }
             }
         }
         Stmt::Init(ib) => {
-            for s in &mut ib.body { rewrite_stmt_cc(s, ctx, errors); }
+            for s in &mut ib.body {
+                rewrite_stmt_cc(s, ctx, errors);
+            }
         }
         Stmt::WaitUntil(expr, _) => {
             rewrite_expr_cc(expr, ctx, errors);
         }
         Stmt::DoUntil { body, cond, .. } => {
-            for s in body { rewrite_stmt_cc(s, ctx, errors); }
+            for s in body {
+                rewrite_stmt_cc(s, ctx, errors);
+            }
             rewrite_expr_cc(cond, ctx, errors);
         }
         Stmt::Log(l) => {
-            for arg in &mut l.args { rewrite_expr_cc(arg, ctx, errors); }
+            for arg in &mut l.args {
+                rewrite_expr_cc(arg, ctx, errors);
+            }
         }
     }
 }
 
 fn rewrite_expr_cc(e: &mut Expr, ctx: &CcDispatchCtx, errors: &mut Vec<CompileError>) {
     match &mut e.kind {
-        ExprKind::Binary(_, l, r) => { rewrite_expr_cc(l, ctx, errors); rewrite_expr_cc(r, ctx, errors); }
-        ExprKind::Unary(_, x) | ExprKind::Cast(x, _) | ExprKind::Clog2(x)
-        | ExprKind::Onehot(x) | ExprKind::Signed(x) | ExprKind::Unsigned(x)
+        ExprKind::Binary(_, l, r) => {
+            rewrite_expr_cc(l, ctx, errors);
+            rewrite_expr_cc(r, ctx, errors);
+        }
+        ExprKind::Unary(_, x)
+        | ExprKind::Cast(x, _)
+        | ExprKind::Clog2(x)
+        | ExprKind::Onehot(x)
+        | ExprKind::Signed(x)
+        | ExprKind::Unsigned(x)
         | ExprKind::LatencyAt(x, _)
-        | ExprKind::SvaNext(_, x) => { rewrite_expr_cc(x, ctx, errors); }
-        ExprKind::Index(b, i) => { rewrite_expr_cc(b, ctx, errors); rewrite_expr_cc(i, ctx, errors); }
+        | ExprKind::SvaNext(_, x) => {
+            rewrite_expr_cc(x, ctx, errors);
+        }
+        ExprKind::Index(b, i) => {
+            rewrite_expr_cc(b, ctx, errors);
+            rewrite_expr_cc(i, ctx, errors);
+        }
         ExprKind::BitSlice(b, hi, lo) => {
-            rewrite_expr_cc(b, ctx, errors); rewrite_expr_cc(hi, ctx, errors); rewrite_expr_cc(lo, ctx, errors);
+            rewrite_expr_cc(b, ctx, errors);
+            rewrite_expr_cc(hi, ctx, errors);
+            rewrite_expr_cc(lo, ctx, errors);
         }
         ExprKind::PartSelect(b, s, w, _) => {
-            rewrite_expr_cc(b, ctx, errors); rewrite_expr_cc(s, ctx, errors); rewrite_expr_cc(w, ctx, errors);
+            rewrite_expr_cc(b, ctx, errors);
+            rewrite_expr_cc(s, ctx, errors);
+            rewrite_expr_cc(w, ctx, errors);
         }
         ExprKind::Ternary(c, t, el) => {
-            rewrite_expr_cc(c, ctx, errors); rewrite_expr_cc(t, ctx, errors); rewrite_expr_cc(el, ctx, errors);
+            rewrite_expr_cc(c, ctx, errors);
+            rewrite_expr_cc(t, ctx, errors);
+            rewrite_expr_cc(el, ctx, errors);
         }
         ExprKind::Concat(xs) | ExprKind::FunctionCall(_, xs) => {
-            for x in xs { rewrite_expr_cc(x, ctx, errors); }
+            for x in xs {
+                rewrite_expr_cc(x, ctx, errors);
+            }
         }
-        ExprKind::Repeat(n, x) => { rewrite_expr_cc(n, ctx, errors); rewrite_expr_cc(x, ctx, errors); }
+        ExprKind::Repeat(n, x) => {
+            rewrite_expr_cc(n, ctx, errors);
+            rewrite_expr_cc(x, ctx, errors);
+        }
         ExprKind::MethodCall(recv, _, args) => {
             rewrite_expr_cc(recv, ctx, errors);
-            for a in args { rewrite_expr_cc(a, ctx, errors); }
+            for a in args {
+                rewrite_expr_cc(a, ctx, errors);
+            }
         }
-        ExprKind::FieldAccess(base, _) => { rewrite_expr_cc(base, ctx, errors); }
+        ExprKind::FieldAccess(base, _) => {
+            rewrite_expr_cc(base, ctx, errors);
+        }
         ExprKind::StructLiteral(_, fields) => {
-            for fi in fields { rewrite_expr_cc(&mut fi.value, ctx, errors); }
+            for fi in fields {
+                rewrite_expr_cc(&mut fi.value, ctx, errors);
+            }
         }
         _ => {}
     }
@@ -7522,7 +8867,9 @@ fn rewrite_expr_cc(e: &mut Expr, ctx: &CcDispatchCtx, errors: &mut Vec<CompileEr
                     for cc in ccs {
                         let ch = &cc.name.name;
                         let m = &member.name;
-                        let suggest = if m == &format!("{ch}_send_valid") || m == &format!("{ch}_send_data") {
+                        let suggest = if m == &format!("{ch}_send_valid")
+                            || m == &format!("{ch}_send_data")
+                        {
                             Some(format!("{port}.{ch}.send(...) or {port}.{ch}.no_send()"))
                         } else if m == &format!("{ch}_credit_return") {
                             Some(format!("{port}.{ch}.pop() or {port}.{ch}.no_pop()"))
@@ -7552,28 +8899,29 @@ fn rewrite_expr_cc(e: &mut Expr, ctx: &CcDispatchCtx, errors: &mut Vec<CompileEr
                             let is_sender = matches!(
                                 (cc.role_dir, perspective),
                                 (Direction::Out, BusPerspective::Initiator)
-                              | (Direction::In,  BusPerspective::Target)
+                                    | (Direction::In, BusPerspective::Target)
                             );
                             let synth = match member.name.as_str() {
                                 "can_send" if is_sender => Some((TypeExpr::Bool, "can_send")),
-                                "valid"    if !is_sender => Some((TypeExpr::Bool, "valid")),
-                                "data"     if !is_sender => {
-                                    cc.params.iter()
-                                        .find(|p| p.name.name == "T")
-                                        .and_then(|p| match &p.kind {
-                                            ParamKind::Type(te) => Some(te.clone()),
-                                            _ => None,
-                                        })
-                                        .map(|ty| (ty, "data"))
-                                }
+                                "valid" if !is_sender => Some((TypeExpr::Bool, "valid")),
+                                "data" if !is_sender => cc
+                                    .params
+                                    .iter()
+                                    .find(|p| p.name.name == "T")
+                                    .and_then(|p| match &p.kind {
+                                        ParamKind::Type(te) => Some(te.clone()),
+                                        _ => None,
+                                    })
+                                    .map(|ty| (ty, "data")),
                                 _ => None,
                             };
                             if let Some((ty, suffix)) = synth {
                                 let name = format!("__{port}_{}_{suffix}", ch.name);
                                 e.kind = ExprKind::SynthIdent(name, ty);
-                            } else if matches!(member.name.as_str(),
-                                "send_valid" | "send_data" | "credit_return")
-                            {
+                            } else if matches!(
+                                member.name.as_str(),
+                                "send_valid" | "send_data" | "credit_return"
+                            ) {
                                 // Dotted access to raw wire (escape hatch for
                                 // direct conditional drives that no_send/no_pop
                                 // can't express). Rewrite to the flat bus signal
@@ -7633,7 +8981,9 @@ pub fn lower_tlm_target_threads(ast: SourceFile) -> Result<SourceFile, Vec<Compi
             _ => {}
         }
     }
-    if bus_methods.is_empty() { return Ok(ast); }
+    if bus_methods.is_empty() {
+        return Ok(ast);
+    }
 
     let mut out_items: Vec<Item> = Vec::with_capacity(ast.items.len());
     let mut errors: Vec<CompileError> = Vec::new();
@@ -7648,20 +8998,31 @@ pub fn lower_tlm_target_threads(ast: SourceFile) -> Result<SourceFile, Vec<Compi
                 // generating private lane endpoints plus one shared mux.
                 // Non-indexed multi-targets still produce multiple drivers.
                 {
-                    let mut counts: HashMap<(String, String), (usize, usize, Span)> = HashMap::new();
+                    let mut counts: HashMap<(String, String), (usize, usize, Span)> =
+                        HashMap::new();
                     for item in &m.body {
                         if let ModuleBodyItem::Thread(t) = item {
                             let key = if let Some(tb) = &t.tlm_target {
-                                Some((tb.port.name.clone(), tb.method.name.clone(), tb.tag_lane.is_some()))
+                                Some((
+                                    tb.port.name.clone(),
+                                    tb.method.name.clone(),
+                                    tb.tag_lane.is_some(),
+                                ))
                             } else if let Some(ib) = &t.implement {
                                 if ib.kind == TlmImplementKind::Target {
                                     Some((ib.port.name.clone(), ib.method.name.clone(), false))
-                                } else { None }
-                            } else { None };
+                                } else {
+                                    None
+                                }
+                            } else {
+                                None
+                            };
                             if let Some((port, method, indexed)) = key {
                                 let e = counts.entry((port, method)).or_insert((0, 0, t.span));
                                 e.0 += 1;
-                                if indexed { e.1 += 1; }
+                                if indexed {
+                                    e.1 += 1;
+                                }
                             }
                         }
                     }
@@ -7679,27 +9040,35 @@ pub fn lower_tlm_target_threads(ast: SourceFile) -> Result<SourceFile, Vec<Compi
 
                 // Collect TLM target threads + their method metadata.
                 let mut new_body: Vec<ModuleBodyItem> = Vec::new();
-                let resource_decls: HashMap<String, ResourceDecl> = m.body.iter()
+                let resource_decls: HashMap<String, ResourceDecl> = m
+                    .body
+                    .iter()
                     .filter_map(|item| match item {
                         ModuleBodyItem::Resource(r) => Some((r.name.name.clone(), r.clone())),
                         _ => None,
                     })
                     .collect();
-                let mut indexed_target_groups: HashMap<(String, String), Vec<(ThreadBlock, TlmTargetBinding, TlmMethodMeta)>> = HashMap::new();
+                let mut indexed_target_groups: HashMap<
+                    (String, String),
+                    Vec<(ThreadBlock, TlmTargetBinding, TlmMethodMeta)>,
+                > = HashMap::new();
                 for item in std::mem::take(&mut m.body) {
                     if let ModuleBodyItem::Thread(t) = &item {
                         // v1 dotted-name form populates `tlm_target`; v2
                         // `implement target port.method(args)` populates
                         // `implement`. Normalize to a single TlmTargetBinding.
-                        let effective_target: Option<TlmTargetBinding> = t.tlm_target.clone()
-                            .or_else(|| t.implement.as_ref()
-                                .filter(|b| b.kind == TlmImplementKind::Target)
-                                .map(|b| TlmTargetBinding {
-                                    port: b.port.clone(),
-                                    method: b.method.clone(),
-                                    tag_lane: None,
-                                    args: b.args.clone(),
-                                }));
+                        let effective_target: Option<TlmTargetBinding> =
+                            t.tlm_target.clone().or_else(|| {
+                                t.implement
+                                    .as_ref()
+                                    .filter(|b| b.kind == TlmImplementKind::Target)
+                                    .map(|b| TlmTargetBinding {
+                                        port: b.port.clone(),
+                                        method: b.method.clone(),
+                                        tag_lane: None,
+                                        args: b.args.clone(),
+                                    })
+                            });
                         if let Some(binding) = effective_target {
                             let bus_name = match port_buses.get(&binding.port.name) {
                                 Some(b) => b.clone(),
@@ -7715,9 +9084,9 @@ pub fn lower_tlm_target_threads(ast: SourceFile) -> Result<SourceFile, Vec<Compi
                                     continue;
                                 }
                             };
-                            let method = match port_methods.get(&binding.port.name)
-                                .and_then(|v| v.iter().find(|mm| mm.name.name == binding.method.name))
-                            {
+                            let method = match port_methods.get(&binding.port.name).and_then(|v| {
+                                v.iter().find(|mm| mm.name.name == binding.method.name)
+                            }) {
                                 Some(m) => m.clone(),
                                 None => {
                                     errors.push(CompileError::general(
@@ -7744,7 +9113,11 @@ pub fn lower_tlm_target_threads(ast: SourceFile) -> Result<SourceFile, Vec<Compi
                                 new_body.push(item);
                                 continue;
                             }
-                            let t_moved = if let ModuleBodyItem::Thread(t) = item { t } else { unreachable!() };
+                            let t_moved = if let ModuleBodyItem::Thread(t) = item {
+                                t
+                            } else {
+                                unreachable!()
+                            };
                             if binding.tag_lane.is_some() {
                                 indexed_target_groups
                                     .entry((binding.port.name.clone(), binding.method.name.clone()))
@@ -7765,11 +9138,7 @@ pub fn lower_tlm_target_threads(ast: SourceFile) -> Result<SourceFile, Vec<Compi
                 }
                 let mut extra_items: Vec<Item> = Vec::new();
                 for ((_port, _method), group) in indexed_target_groups {
-                    match lower_indexed_tlm_target_group(
-                        &m.name.name,
-                        group,
-                        &resource_decls,
-                    ) {
+                    match lower_indexed_tlm_target_group(&m.name.name, group, &resource_decls) {
                         Ok((items, mut extras)) => {
                             new_body.extend(items);
                             extra_items.append(&mut extras);
@@ -7780,7 +9149,10 @@ pub fn lower_tlm_target_threads(ast: SourceFile) -> Result<SourceFile, Vec<Compi
                 // Inline lowering emits its own RegDecl / RegBlock /
                 // CombBlock items directly into new_body; no additional
                 // accumulation needed.
-                if !new_body.iter().any(|item| matches!(item, ModuleBodyItem::Thread(_))) {
+                if !new_body
+                    .iter()
+                    .any(|item| matches!(item, ModuleBodyItem::Thread(_)))
+                {
                     new_body.retain(|item| !matches!(item, ModuleBodyItem::Resource(_)));
                 }
                 m.body = new_body;
@@ -7790,8 +9162,14 @@ pub fn lower_tlm_target_threads(ast: SourceFile) -> Result<SourceFile, Vec<Compi
             other => out_items.push(other),
         }
     }
-    if !errors.is_empty() { return Err(errors); }
-    Ok(SourceFile { items: out_items, inner_doc: None, frontmatter: None })
+    if !errors.is_empty() {
+        return Err(errors);
+    }
+    Ok(SourceFile {
+        items: out_items,
+        inner_doc: None,
+        frontmatter: None,
+    })
 }
 
 fn specialize_tlm_methods_for_module_ports(
@@ -7802,10 +9180,14 @@ fn specialize_tlm_methods_for_module_ports(
     let mut port_buses: HashMap<String, String> = HashMap::new();
     let mut port_methods: HashMap<String, Vec<TlmMethodMeta>> = HashMap::new();
     for p in &m.ports {
-        let Some(bi) = &p.bus_info else { continue; };
+        let Some(bi) = &p.bus_info else {
+            continue;
+        };
         let bus_name = bi.bus_name.name.clone();
         port_buses.insert(p.name.name.clone(), bus_name.clone());
-        let Some(methods) = bus_methods.get(&bus_name) else { continue; };
+        let Some(methods) = bus_methods.get(&bus_name) else {
+            continue;
+        };
         let mut param_map: HashMap<String, &Expr> = HashMap::new();
         if let Some(params) = bus_params.get(&bus_name) {
             for pd in params {
@@ -7896,17 +9278,24 @@ fn subst_expr_params(expr: &Expr, param_map: &HashMap<String, &Expr>) -> Expr {
         ExprKind::MethodCall(base, method, args) => ExprKind::MethodCall(
             Box::new(subst_expr_params(base, param_map)),
             method.clone(),
-            args.iter().map(|arg| subst_expr_params(arg, param_map)).collect(),
+            args.iter()
+                .map(|arg| subst_expr_params(arg, param_map))
+                .collect(),
         ),
         ExprKind::Concat(parts) => ExprKind::Concat(
-            parts.iter().map(|part| subst_expr_params(part, param_map)).collect(),
+            parts
+                .iter()
+                .map(|part| subst_expr_params(part, param_map))
+                .collect(),
         ),
         _ => return expr.clone(),
     };
-    Expr { kind, span: expr.span, parenthesized: expr.parenthesized }
+    Expr {
+        kind,
+        span: expr.span,
+        parenthesized: expr.parenthesized,
+    }
 }
-
-
 
 // ── TLM initiator call-site lowering ────────────────────────────────────────
 //
@@ -7939,7 +9328,9 @@ pub fn lower_tlm_initiator_calls(ast: SourceFile) -> Result<SourceFile, Vec<Comp
             _ => {}
         }
     }
-    if bus_methods.is_empty() { return Ok(ast); }
+    if bus_methods.is_empty() {
+        return Ok(ast);
+    }
 
     let mut errors: Vec<CompileError> = Vec::new();
     let mut out_items: Vec<Item> = Vec::with_capacity(ast.items.len());
@@ -7952,30 +9343,41 @@ pub fn lower_tlm_initiator_calls(ast: SourceFile) -> Result<SourceFile, Vec<Comp
                     .keys()
                     .map(|port| (port.clone(), port.clone()))
                     .collect();
-                let resource_decls: HashMap<String, ResourceDecl> = m.body.iter()
+                let resource_decls: HashMap<String, ResourceDecl> = m
+                    .body
+                    .iter()
                     .filter_map(|item| match item {
                         ModuleBodyItem::Resource(r) => Some((r.name.name.clone(), r.clone())),
                         _ => None,
                     })
                     .collect();
 
-                let mut direct_groups: HashMap<(String, String), Vec<DirectTlmThread>> = HashMap::new();
+                let mut direct_groups: HashMap<(String, String), Vec<DirectTlmThread>> =
+                    HashMap::new();
                 for item in &m.body {
                     if let ModuleBodyItem::Thread(t) = item {
-                        if t.tlm_target.is_some() || t.implement.is_some() { continue; }
+                        if t.tlm_target.is_some() || t.implement.is_some() {
+                            continue;
+                        }
                         for dt in direct_tlm_threads(t, &port_buses, &port_methods) {
-                            direct_groups.entry((dt.call.port.clone(), dt.call.method.clone()))
+                            direct_groups
+                                .entry((dt.call.port.clone(), dt.call.method.clone()))
                                 .or_default()
                                 .push(dt);
                         }
                     }
                 }
-                let cohort_groups: std::collections::HashSet<(String, String)> = direct_groups.iter()
+                let cohort_groups: std::collections::HashSet<(String, String)> = direct_groups
+                    .iter()
                     .filter_map(|(k, v)| if v.len() > 1 { Some(k.clone()) } else { None })
                     .collect();
-                let cohort_thread_spans: std::collections::HashSet<(usize, usize)> = direct_groups.values()
+                let cohort_thread_spans: std::collections::HashSet<(usize, usize)> = direct_groups
+                    .values()
                     .filter(|v| v.len() > 1)
-                    .flat_map(|v| v.iter().map(|dt| (dt.thread.span.start, dt.thread.span.end)))
+                    .flat_map(|v| {
+                        v.iter()
+                            .map(|dt| (dt.thread.span.start, dt.thread.span.end))
+                    })
                     .collect();
 
                 // Detect unlocked multi-thread sharing of a (port, method)
@@ -7992,21 +9394,31 @@ pub fn lower_tlm_initiator_calls(ast: SourceFile) -> Result<SourceFile, Vec<Comp
                     let mut bare_uses: HashMap<(String, String), Vec<Span>> = HashMap::new();
                     for item in &m.body {
                         if let ModuleBodyItem::Thread(t) = item {
-                            if t.tlm_target.is_some() { continue; }
+                            if t.tlm_target.is_some() {
+                                continue;
+                            }
                             // Threads carrying `implement` are the opt-in
                             // mechanism for multi-thread TLM — skip the
                             // lock-idiom diagnostic on them; the TLM
                             // lowering pass groups/cohorts them below.
-                            if t.implement.is_some() { continue; }
-                            collect_bare_tlm_calls(&t.body, t.span, &port_buses, &port_methods, &mut bare_uses);
+                            if t.implement.is_some() {
+                                continue;
+                            }
+                            collect_bare_tlm_calls(
+                                &t.body,
+                                t.span,
+                                &port_buses,
+                                &port_methods,
+                                &mut bare_uses,
+                            );
                         }
                     }
                     for ((port, method), spans) in &bare_uses {
                         if cohort_groups.contains(&(port.clone(), method.clone())) {
                             continue;
                         }
-                        let mut sorted_offsets: Vec<(usize, usize)> = spans.iter()
-                            .map(|s| (s.start, s.end)).collect();
+                        let mut sorted_offsets: Vec<(usize, usize)> =
+                            spans.iter().map(|s| (s.start, s.end)).collect();
                         sorted_offsets.sort();
                         sorted_offsets.dedup();
                         if sorted_offsets.len() > 1 {
@@ -8046,13 +9458,17 @@ pub fn lower_tlm_initiator_calls(ast: SourceFile) -> Result<SourceFile, Vec<Comp
                 }
 
                 let mut new_body: Vec<ModuleBodyItem> = Vec::new();
-                let mut emitted_cohorts: std::collections::HashSet<(String, String)> = std::collections::HashSet::new();
+                let mut emitted_cohorts: std::collections::HashSet<(String, String)> =
+                    std::collections::HashSet::new();
                 let mut emitted_inline_tlm_group = false;
                 for item in std::mem::take(&mut m.body) {
                     if let ModuleBodyItem::Thread(t) = &item {
                         let t_key = (t.span.start, t.span.end);
                         if cohort_thread_spans.contains(&t_key) {
-                            if let Some(dt) = direct_tlm_threads(t, &port_buses, &port_methods).into_iter().next() {
+                            if let Some(dt) = direct_tlm_threads(t, &port_buses, &port_methods)
+                                .into_iter()
+                                .next()
+                            {
                                 let key = (dt.call.port.clone(), dt.call.method.clone());
                                 if emitted_cohorts.insert(key.clone()) {
                                     if let Some(group) = direct_groups.get(&key) {
@@ -8085,7 +9501,11 @@ pub fn lower_tlm_initiator_calls(ast: SourceFile) -> Result<SourceFile, Vec<Comp
                             continue;
                         }
                         if thread_has_fork_tlm_assign(&t.body) {
-                            match inline_lower_tlm_fork_join_all(t.clone(), &port_buses, &port_methods) {
+                            match inline_lower_tlm_fork_join_all(
+                                t.clone(),
+                                &port_buses,
+                                &port_methods,
+                            ) {
                                 Ok(items) => new_body.extend(items),
                                 Err(e) => {
                                     errors.push(e);
@@ -8112,7 +9532,11 @@ pub fn lower_tlm_initiator_calls(ast: SourceFile) -> Result<SourceFile, Vec<Comp
                             }
                         }
                         if thread_body_has_tlm_call(&t.body, &port_buses, &port_methods) {
-                            let t_moved = if let ModuleBodyItem::Thread(t) = item { t } else { unreachable!() };
+                            let t_moved = if let ModuleBodyItem::Thread(t) = item {
+                                t
+                            } else {
+                                unreachable!()
+                            };
                             match inline_lower_tlm_initiator(t_moved, &port_buses, &port_methods) {
                                 Ok(items) => new_body.extend(items),
                                 Err(e) => errors.push(e),
@@ -8127,7 +9551,10 @@ pub fn lower_tlm_initiator_calls(ast: SourceFile) -> Result<SourceFile, Vec<Comp
                 // declarations that only existed for those locks must not
                 // leak to codegen. Regular thread lowering consumes
                 // resources only when Thread items remain.
-                if !new_body.iter().any(|item| matches!(item, ModuleBodyItem::Thread(_))) {
+                if !new_body
+                    .iter()
+                    .any(|item| matches!(item, ModuleBodyItem::Thread(_)))
+                {
                     new_body.retain(|item| !matches!(item, ModuleBodyItem::Resource(_)));
                 }
                 m.body = new_body;
@@ -8136,8 +9563,14 @@ pub fn lower_tlm_initiator_calls(ast: SourceFile) -> Result<SourceFile, Vec<Comp
             other => out_items.push(other),
         }
     }
-    if !errors.is_empty() { return Err(errors); }
-    Ok(SourceFile { items: out_items, inner_doc: None, frontmatter: None })
+    if !errors.is_empty() {
+        return Err(errors);
+    }
+    Ok(SourceFile {
+        items: out_items,
+        inner_doc: None,
+        frontmatter: None,
+    })
 }
 
 #[derive(Clone)]
@@ -8184,7 +9617,11 @@ fn direct_tlm_threads(
                 };
                 out.push(dt);
             }
-            if out.len() > 1 { out } else { Vec::new() }
+            if out.len() > 1 {
+                out
+            } else {
+                Vec::new()
+            }
         }
         _ => Vec::new(),
     }
@@ -8215,7 +9652,10 @@ fn lower_tlm_initiator_cohort(
     module_span: Span,
 ) -> Result<Vec<ModuleBodyItem>, CompileError> {
     if group.len() < 2 {
-        return Err(CompileError::general("internal error: TLM cohort lowering requires at least two threads", module_span));
+        return Err(CompileError::general(
+            "internal error: TLM cohort lowering requires at least two threads",
+            module_span,
+        ));
     }
     let first = &group[0];
     let port = first.call.port.clone();
@@ -8223,10 +9663,12 @@ fn lower_tlm_initiator_cohort(
     let method_meta = first.call.method_meta.clone();
     let span = first.thread.span;
     let tag_width = if let Some(e) = &method_meta.out_of_order_tags {
-        Some(literal_expr_u64(e).ok_or_else(|| CompileError::general(
-            "`out_of_order tags` must be a literal width in the first implementation",
-            span,
-        ))? as u32)
+        Some(literal_expr_u64(e).ok_or_else(|| {
+            CompileError::general(
+                "`out_of_order tags` must be a literal width in the first implementation",
+                span,
+            )
+        })? as u32)
     } else {
         None
     };
@@ -8250,7 +9692,9 @@ fn lower_tlm_initiator_cohort(
             return Err(CompileError::general(
                 &format!(
                     "TLM call `{port}.{method}` takes {} args but `tlm_method {}` declares {}",
-                    dt.call.args.len(), method, method_meta.args.len()
+                    dt.call.args.len(),
+                    method,
+                    method_meta.args.len()
                 ),
                 dt.thread.span,
             ));
@@ -8259,7 +9703,11 @@ fn lower_tlm_initiator_cohort(
 
     let n = group.len();
     if let Some(tag_w) = tag_width {
-        let tag_slots = if tag_w >= 64 { u128::MAX } else { 1u128 << tag_w };
+        let tag_slots = if tag_w >= 64 {
+            u128::MAX
+        } else {
+            1u128 << tag_w
+        };
         if tag_slots < n as u128 {
             return Err(CompileError::general(
                 &format!(
@@ -8279,22 +9727,30 @@ fn lower_tlm_initiator_cohort(
     let sized = |w: u32, v: u64| Expr::new(ExprKind::Literal(LitKind::Sized(w, v)), span);
     let zero = || Expr::new(ExprKind::Literal(LitKind::Dec(0)), span);
     let bool_lit = |b: bool| Expr::new(ExprKind::Bool(b), span);
-    let bin = |op: BinOp, l: Expr, r: Expr| Expr::new(ExprKind::Binary(op, Box::new(l), Box::new(r)), span);
+    let bin = |op: BinOp, l: Expr, r: Expr| {
+        Expr::new(ExprKind::Binary(op, Box::new(l), Box::new(r)), span)
+    };
     let not = |e: Expr| Expr::new(ExprKind::Unary(UnaryOp::Not, Box::new(e)), span);
-    let tern = |c: Expr, t: Expr, e: Expr| Expr::new(ExprKind::Ternary(Box::new(c), Box::new(t), Box::new(e)), span);
-    let index = |base: Expr, idx: Expr| Expr::new(ExprKind::Index(Box::new(base), Box::new(idx)), span);
-    let trunc = |e: Expr, w: u32| Expr::new(
-        ExprKind::MethodCall(
-            Box::new(e),
-            ident("trunc".to_string()),
-            vec![dec(w as u64)],
-        ),
-        span,
-    );
-    let port_member = |member: String| Expr::new(
-        ExprKind::FieldAccess(Box::new(id(port.clone())), ident(member)),
-        span,
-    );
+    let tern = |c: Expr, t: Expr, e: Expr| {
+        Expr::new(
+            ExprKind::Ternary(Box::new(c), Box::new(t), Box::new(e)),
+            span,
+        )
+    };
+    let index =
+        |base: Expr, idx: Expr| Expr::new(ExprKind::Index(Box::new(base), Box::new(idx)), span);
+    let trunc = |e: Expr, w: u32| {
+        Expr::new(
+            ExprKind::MethodCall(Box::new(e), ident("trunc".to_string()), vec![dec(w as u64)]),
+            span,
+        )
+    };
+    let port_member = |member: String| {
+        Expr::new(
+            ExprKind::FieldAccess(Box::new(id(port.clone())), ident(member)),
+            span,
+        )
+    };
     let state_name = |i: usize| format!("{prefix}_t{i}_state");
     let fifo_name = format!("{prefix}_fifo");
     let head_name = format!("{prefix}_head");
@@ -8350,7 +9806,11 @@ fn lower_tlm_initiator_cohort(
 
     let occ_nonzero = bin(BinOp::Gt, id(occ_name.clone()), sized(occ_w, 0));
     let occ_not_full = bin(BinOp::Lt, id(occ_name.clone()), sized(occ_w, n as u64));
-    let rsp_pop = bin(BinOp::And, port_member(format!("{method}_rsp_valid")), occ_nonzero.clone());
+    let rsp_pop = bin(
+        BinOp::And,
+        port_member(format!("{method}_rsp_valid")),
+        occ_nonzero.clone(),
+    );
     let fifo_head = index(id(fifo_name.clone()), id(head_name.clone()));
 
     let mut grants: Vec<Expr> = Vec::new();
@@ -8372,7 +9832,11 @@ fn lower_tlm_initiator_cohort(
         acc
     };
     let req_valid = or_expr(&grants);
-    let req_fire = bin(BinOp::And, req_valid.clone(), port_member(format!("{method}_req_ready")));
+    let req_fire = bin(
+        BinOp::And,
+        req_valid.clone(),
+        port_member(format!("{method}_req_ready")),
+    );
     let ptr_inc = |ptr: &str, width: u32| -> Expr {
         tern(
             bin(BinOp::Eq, id(ptr.to_string()), sized(width, (n - 1) as u64)),
@@ -8417,7 +9881,11 @@ fn lower_tlm_initiator_cohort(
 
     let mut seq_body: Vec<Stmt> = Vec::new();
     for (i, dt) in group.iter().enumerate() {
-        let push_i = bin(BinOp::And, grants[i].clone(), port_member(format!("{method}_req_ready")));
+        let push_i = bin(
+            BinOp::And,
+            grants[i].clone(),
+            port_member(format!("{method}_req_ready")),
+        );
         seq_body.push(Stmt::IfElse(IfElse {
             cond: push_i.clone(),
             then_stmts: vec![
@@ -8445,7 +9913,11 @@ fn lower_tlm_initiator_cohort(
                     rsp_pop.clone(),
                     bin(BinOp::Eq, id(state_name(i)), sized(1, 1)),
                 ),
-                bin(BinOp::Eq, port_member(format!("{method}_rsp_tag")), sized(tag_w, i as u64)),
+                bin(
+                    BinOp::Eq,
+                    port_member(format!("{method}_rsp_tag")),
+                    sized(tag_w, i as u64),
+                ),
             )
         } else {
             bin(
@@ -8501,7 +9973,10 @@ fn lower_tlm_initiator_cohort(
         cond: bin(BinOp::And, req_fire.clone(), not(rsp_pop.clone())),
         then_stmts: vec![Stmt::Assign(RegAssign {
             target: id(occ_name.clone()),
-            value: trunc(bin(BinOp::Add, id(occ_name.clone()), sized(occ_w, 1)), occ_w),
+            value: trunc(
+                bin(BinOp::Add, id(occ_name.clone()), sized(occ_w, 1)),
+                occ_w,
+            ),
             span,
         })],
         else_stmts: Vec::new(),
@@ -8512,7 +9987,10 @@ fn lower_tlm_initiator_cohort(
         cond: bin(BinOp::And, rsp_pop.clone(), not(req_fire)),
         then_stmts: vec![Stmt::Assign(RegAssign {
             target: id(occ_name.clone()),
-            value: trunc(bin(BinOp::Sub, id(occ_name.clone()), sized(occ_w, 1)), occ_w),
+            value: trunc(
+                bin(BinOp::Sub, id(occ_name.clone()), sized(occ_w, 1)),
+                occ_w,
+            ),
             span,
         })],
         else_stmts: Vec::new(),
@@ -8526,7 +10004,10 @@ fn lower_tlm_initiator_cohort(
         stmts: seq_body,
         span,
     }));
-    items.push(ModuleBodyItem::CombBlock(CombBlock { stmts: comb_stmts, span }));
+    items.push(ModuleBodyItem::CombBlock(CombBlock {
+        stmts: comb_stmts,
+        span,
+    }));
     Ok(items)
 }
 
@@ -8566,10 +10047,12 @@ fn collect_bare_tlm_calls(
                 collect_bare_tlm_calls(&ie.then_stmts, owner_span, port_buses, bus_methods, out);
                 collect_bare_tlm_calls(&ie.else_stmts, owner_span, port_buses, bus_methods, out);
             }
-            ThreadStmt::ForkJoin(branches, _) => for branch in branches {
-                let branch_span = branch.first().map(thread_stmt_span).unwrap_or(owner_span);
-                collect_bare_tlm_calls(branch, branch_span, port_buses, bus_methods, out);
-            },
+            ThreadStmt::ForkJoin(branches, _) => {
+                for branch in branches {
+                    let branch_span = branch.first().map(thread_stmt_span).unwrap_or(owner_span);
+                    collect_bare_tlm_calls(branch, branch_span, port_buses, bus_methods, out);
+                }
+            }
             ThreadStmt::For { body, .. } => {
                 collect_bare_tlm_calls(body, owner_span, port_buses, bus_methods, out);
             }
@@ -8583,7 +10066,9 @@ fn collect_bare_tlm_calls(
 
 fn thread_stmt_span(stmt: &ThreadStmt) -> Span {
     match stmt {
-        ThreadStmt::SeqAssign(a) | ThreadStmt::CombAssign(a) | ThreadStmt::ForkTlmAssign(a) => a.span,
+        ThreadStmt::SeqAssign(a) | ThreadStmt::CombAssign(a) | ThreadStmt::ForkTlmAssign(a) => {
+            a.span
+        }
         ThreadStmt::WaitUntil(_, sp)
         | ThreadStmt::WaitCycles(_, sp)
         | ThreadStmt::ForkJoin(_, sp)
@@ -8603,27 +10088,32 @@ fn thread_body_has_tlm_call(
     bus_methods: &std::collections::HashMap<String, Vec<TlmMethodMeta>>,
 ) -> bool {
     stmts.iter().any(|s| match s {
-        ThreadStmt::SeqAssign(ra) =>
+        ThreadStmt::SeqAssign(ra) => {
             contains_tlm_call(&ra.value, port_buses, bus_methods)
-            || contains_tlm_call(&ra.target, port_buses, bus_methods),
-        ThreadStmt::ForkTlmAssign(ra) =>
+                || contains_tlm_call(&ra.target, port_buses, bus_methods)
+        }
+        ThreadStmt::ForkTlmAssign(ra) => {
             contains_tlm_call(&ra.value, port_buses, bus_methods)
-            || contains_tlm_call(&ra.target, port_buses, bus_methods),
-        ThreadStmt::CombAssign(ca) =>
+                || contains_tlm_call(&ra.target, port_buses, bus_methods)
+        }
+        ThreadStmt::CombAssign(ca) => {
             contains_tlm_call(&ca.value, port_buses, bus_methods)
-            || contains_tlm_call(&ca.target, port_buses, bus_methods),
-        ThreadStmt::WaitUntil(e, _) =>
-            contains_tlm_call(e, port_buses, bus_methods),
-        ThreadStmt::IfElse(ie) =>
+                || contains_tlm_call(&ca.target, port_buses, bus_methods)
+        }
+        ThreadStmt::WaitUntil(e, _) => contains_tlm_call(e, port_buses, bus_methods),
+        ThreadStmt::IfElse(ie) => {
             contains_tlm_call(&ie.cond, port_buses, bus_methods)
-            || thread_body_has_tlm_call(&ie.then_stmts, port_buses, bus_methods)
-            || thread_body_has_tlm_call(&ie.else_stmts, port_buses, bus_methods),
-        ThreadStmt::ForkJoin(branches, _) =>
-            branches.iter().any(|branch| thread_body_has_tlm_call(branch, port_buses, bus_methods)),
+                || thread_body_has_tlm_call(&ie.then_stmts, port_buses, bus_methods)
+                || thread_body_has_tlm_call(&ie.else_stmts, port_buses, bus_methods)
+        }
+        ThreadStmt::ForkJoin(branches, _) => branches
+            .iter()
+            .any(|branch| thread_body_has_tlm_call(branch, port_buses, bus_methods)),
         ThreadStmt::For { body, .. }
         | ThreadStmt::Lock { body, .. }
-        | ThreadStmt::DoUntil { body, .. } =>
-            thread_body_has_tlm_call(body, port_buses, bus_methods),
+        | ThreadStmt::DoUntil { body, .. } => {
+            thread_body_has_tlm_call(body, port_buses, bus_methods)
+        }
         _ => false,
     })
 }
@@ -8631,8 +10121,9 @@ fn thread_body_has_tlm_call(
 fn thread_has_fork_tlm_assign(stmts: &[ThreadStmt]) -> bool {
     stmts.iter().any(|s| match s {
         ThreadStmt::ForkTlmAssign(_) => true,
-        ThreadStmt::IfElse(ie) => thread_has_fork_tlm_assign(&ie.then_stmts)
-            || thread_has_fork_tlm_assign(&ie.else_stmts),
+        ThreadStmt::IfElse(ie) => {
+            thread_has_fork_tlm_assign(&ie.then_stmts) || thread_has_fork_tlm_assign(&ie.else_stmts)
+        }
         ThreadStmt::ForkJoin(branches, _) => branches.iter().any(|b| thread_has_fork_tlm_assign(b)),
         ThreadStmt::For { body, .. }
         | ThreadStmt::Lock { body, .. }
@@ -8789,24 +10280,33 @@ fn build_tlm_init_thread_plan(
                     }
                     if let Some(call) = match_tlm_call(&ra.value, port_buses, bus_methods) {
                         if !pending_seq.is_empty() {
-                            push_state(states, TlmInitGroupStateKind::Compute {
-                                seq_on_exit: std::mem::take(pending_seq),
-                            });
+                            push_state(
+                                states,
+                                TlmInitGroupStateKind::Compute {
+                                    seq_on_exit: std::mem::take(pending_seq),
+                                },
+                            );
                         }
                         let has_ret = call.method_meta.ret.is_some();
-                        push_state(states, TlmInitGroupStateKind::TlmIssue {
-                            port: call.port.clone(),
-                            method: call.method.clone(),
-                            args: call.args.clone(),
-                            method_meta: call.method_meta.clone(),
-                            lock_resource: current_lock.map(|s| s.to_string()),
-                        });
-                        push_state(states, TlmInitGroupStateKind::TlmWait {
-                            port: call.port,
-                            method: call.method,
-                            method_meta: call.method_meta.clone(),
-                            dest: if has_ret { Some(ra.target) } else { None },
-                        });
+                        push_state(
+                            states,
+                            TlmInitGroupStateKind::TlmIssue {
+                                port: call.port.clone(),
+                                method: call.method.clone(),
+                                args: call.args.clone(),
+                                method_meta: call.method_meta.clone(),
+                                lock_resource: current_lock.map(|s| s.to_string()),
+                            },
+                        );
+                        push_state(
+                            states,
+                            TlmInitGroupStateKind::TlmWait {
+                                port: call.port,
+                                method: call.method,
+                                method_meta: call.method_meta.clone(),
+                                dest: if has_ret { Some(ra.target) } else { None },
+                            },
+                        );
                     } else {
                         pending_seq.push(Stmt::Assign(ra));
                     }
@@ -8825,8 +10325,10 @@ fn build_tlm_init_thread_plan(
                     )?;
                 }
                 ThreadStmt::IfElse(ie) => {
-                    let then_has_tlm = thread_body_has_tlm_call(&ie.then_stmts, port_buses, bus_methods);
-                    let else_has_tlm = thread_body_has_tlm_call(&ie.else_stmts, port_buses, bus_methods);
+                    let then_has_tlm =
+                        thread_body_has_tlm_call(&ie.then_stmts, port_buses, bus_methods);
+                    let else_has_tlm =
+                        thread_body_has_tlm_call(&ie.else_stmts, port_buses, bus_methods);
                     if !then_has_tlm && !else_has_tlm {
                         pending_seq.push(Stmt::IfElse(IfElseOf {
                             cond: ie.cond,
@@ -8849,13 +10351,21 @@ fn build_tlm_init_thread_plan(
                     }
 
                     if !pending_seq.is_empty() {
-                        push_state(states, TlmInitGroupStateKind::Compute {
-                            seq_on_exit: std::mem::take(pending_seq),
-                        });
+                        push_state(
+                            states,
+                            TlmInitGroupStateKind::Compute {
+                                seq_on_exit: std::mem::take(pending_seq),
+                            },
+                        );
                     }
 
                     let branch_idx = states.len();
-                    push_state(states, TlmInitGroupStateKind::Compute { seq_on_exit: Vec::new() });
+                    push_state(
+                        states,
+                        TlmInitGroupStateKind::Compute {
+                            seq_on_exit: Vec::new(),
+                        },
+                    );
 
                     let then_start = states.len();
                     let mut then_pending = Vec::new();
@@ -8871,9 +10381,12 @@ fn build_tlm_init_thread_plan(
                         current_lock,
                     )?;
                     if !then_pending.is_empty() {
-                        push_state(states, TlmInitGroupStateKind::Compute {
-                            seq_on_exit: std::mem::take(&mut then_pending),
-                        });
+                        push_state(
+                            states,
+                            TlmInitGroupStateKind::Compute {
+                                seq_on_exit: std::mem::take(&mut then_pending),
+                            },
+                        );
                     }
                     let then_end = states.len();
 
@@ -8891,20 +10404,36 @@ fn build_tlm_init_thread_plan(
                         current_lock,
                     )?;
                     if !else_pending.is_empty() {
-                        push_state(states, TlmInitGroupStateKind::Compute {
-                            seq_on_exit: std::mem::take(&mut else_pending),
-                        });
+                        push_state(
+                            states,
+                            TlmInitGroupStateKind::Compute {
+                                seq_on_exit: std::mem::take(&mut else_pending),
+                            },
+                        );
                     }
                     let else_end = states.len();
 
                     let join_idx = states.len();
-                    push_state(states, TlmInitGroupStateKind::Compute { seq_on_exit: Vec::new() });
+                    push_state(
+                        states,
+                        TlmInitGroupStateKind::Compute {
+                            seq_on_exit: Vec::new(),
+                        },
+                    );
 
                     if let Some(branch_state) = states.get_mut(branch_idx) {
                         branch_state.next = TlmInitGroupNext::Branch {
                             cond: ie.cond,
-                            then_start: if then_end > then_start { then_start } else { join_idx },
-                            else_start: if else_end > else_start { else_start } else { join_idx },
+                            then_start: if then_end > then_start {
+                                then_start
+                            } else {
+                                join_idx
+                            },
+                            else_start: if else_end > else_start {
+                                else_start
+                            } else {
+                                join_idx
+                            },
                             span: ie.span,
                         };
                     }
@@ -8925,61 +10454,30 @@ fn build_tlm_init_thread_plan(
                         }
                     }
                 }
-                ThreadStmt::For { var, start, end, body, span: for_span } => {
-                    match (literal_expr_u64(&start), literal_expr_u64(&end)) {
-                        (Some(start_v), Some(end_v)) => {
-                            if end_v < start_v {
-                                return Err(CompileError::general(
-                                    "TLM initiator `for` loop end must be >= start",
-                                    for_span,
-                                ));
-                            }
-                            for i in start_v..=end_v {
-                                let expanded: Vec<ThreadStmt> = body
-                                    .iter()
-                                    .map(|s| subst_thread_stmt(s, &var.name, i as i64))
-                                    .map(fold_literal_bit_slices_thread_stmt)
-                                    .collect();
-                                lower_stmts(
-                                    expanded,
-                                    states,
-                                    pending_seq,
-                                    loop_counters,
-                                    tag,
-                                    port_buses,
-                                    bus_methods,
-                                    span,
-                                    current_lock,
-                                )?;
-                            }
+                ThreadStmt::For {
+                    var,
+                    start,
+                    end,
+                    body,
+                    span: for_span,
+                } => match (literal_expr_u64(&start), literal_expr_u64(&end)) {
+                    (Some(start_v), Some(end_v)) => {
+                        if end_v < start_v {
+                            return Err(CompileError::general(
+                                "TLM initiator `for` loop end must be >= start",
+                                for_span,
+                            ));
                         }
-                        _ => {
-                            if !pending_seq.is_empty() {
-                                push_state(states, TlmInitGroupStateKind::Compute {
-                                    seq_on_exit: std::mem::take(pending_seq),
-                                });
-                            }
-
-                            let counter = format!("_tlm_init_{}_loop_cnt_{}", tag, loop_counters.len());
-                            loop_counters.push(counter.clone());
-                            push_state(states, TlmInitGroupStateKind::Compute {
-                                seq_on_exit: vec![Stmt::Assign(RegAssign {
-                                    target: Expr::new(ExprKind::Ident(counter.clone()), for_span),
-                                    value: start.clone(),
-                                    span: for_span,
-                                })],
-                            });
-
-                            let body_start = states.len();
-                            let rewritten: Vec<ThreadStmt> = body
+                        for i in start_v..=end_v {
+                            let expanded: Vec<ThreadStmt> = body
                                 .iter()
-                                .map(|s| rewrite_loop_var(s, &var.name, &counter))
+                                .map(|s| subst_thread_stmt(s, &var.name, i as i64))
+                                .map(fold_literal_bit_slices_thread_stmt)
                                 .collect();
-                            let mut body_pending = Vec::new();
                             lower_stmts(
-                                rewritten,
+                                expanded,
                                 states,
-                                &mut body_pending,
+                                pending_seq,
                                 loop_counters,
                                 tag,
                                 port_buses,
@@ -8987,28 +10485,72 @@ fn build_tlm_init_thread_plan(
                                 span,
                                 current_lock,
                             )?;
-                            if !body_pending.is_empty() {
-                                push_state(states, TlmInitGroupStateKind::Compute {
+                        }
+                    }
+                    _ => {
+                        if !pending_seq.is_empty() {
+                            push_state(
+                                states,
+                                TlmInitGroupStateKind::Compute {
+                                    seq_on_exit: std::mem::take(pending_seq),
+                                },
+                            );
+                        }
+
+                        let counter = format!("_tlm_init_{}_loop_cnt_{}", tag, loop_counters.len());
+                        loop_counters.push(counter.clone());
+                        push_state(
+                            states,
+                            TlmInitGroupStateKind::Compute {
+                                seq_on_exit: vec![Stmt::Assign(RegAssign {
+                                    target: Expr::new(ExprKind::Ident(counter.clone()), for_span),
+                                    value: start.clone(),
+                                    span: for_span,
+                                })],
+                            },
+                        );
+
+                        let body_start = states.len();
+                        let rewritten: Vec<ThreadStmt> = body
+                            .iter()
+                            .map(|s| rewrite_loop_var(s, &var.name, &counter))
+                            .collect();
+                        let mut body_pending = Vec::new();
+                        lower_stmts(
+                            rewritten,
+                            states,
+                            &mut body_pending,
+                            loop_counters,
+                            tag,
+                            port_buses,
+                            bus_methods,
+                            span,
+                            current_lock,
+                        )?;
+                        if !body_pending.is_empty() {
+                            push_state(
+                                states,
+                                TlmInitGroupStateKind::Compute {
                                     seq_on_exit: std::mem::take(&mut body_pending),
-                                });
-                            }
-                            if states.len() == body_start {
-                                return Err(CompileError::general(
+                                },
+                            );
+                        }
+                        if states.len() == body_start {
+                            return Err(CompileError::general(
                                     "TLM initiator runtime `for` loop body must lower to at least one state",
                                     for_span,
                                 ));
-                            }
-                            if let Some(last) = states.last_mut() {
-                                last.next = TlmInitGroupNext::LoopBack {
-                                    counter,
-                                    end: end.clone(),
-                                    body_start,
-                                    span: for_span,
-                                };
-                            }
+                        }
+                        if let Some(last) = states.last_mut() {
+                            last.next = TlmInitGroupNext::LoopBack {
+                                counter,
+                                end: end.clone(),
+                                body_start,
+                                span: for_span,
+                            };
                         }
                     }
-                }
+                },
                 other => {
                     return Err(CompileError::general(
                         &format!(
@@ -9024,7 +10566,11 @@ fn build_tlm_init_thread_plan(
     }
 
     let span = t.span;
-    let tag = t.name.as_ref().map(|n| n.name.clone()).unwrap_or_else(|| "tlm_init".to_string());
+    let tag = t
+        .name
+        .as_ref()
+        .map(|n| n.name.clone())
+        .unwrap_or_else(|| "tlm_init".to_string());
     let mut states = Vec::new();
     let mut pending_seq = Vec::new();
     let mut loop_counters = Vec::new();
@@ -9047,7 +10593,12 @@ fn build_tlm_init_thread_plan(
             next: TlmInitGroupNext::Fallthrough,
         });
     }
-    Ok(TlmInitThreadPlan { thread: t, tag, states, loop_counters })
+    Ok(TlmInitThreadPlan {
+        thread: t,
+        tag,
+        states,
+        loop_counters,
+    })
 }
 
 fn inline_lower_tlm_initiator_group(
@@ -9087,12 +10638,21 @@ fn inline_lower_tlm_initiator_group(
     let id = |name: String| Expr::new(ExprKind::Ident(name), span);
     let dec = |v: u64| Expr::new(ExprKind::Literal(LitKind::Dec(v)), span);
     let sized = |w: u32, v: u64| Expr::new(ExprKind::Literal(LitKind::Sized(w, v)), span);
-    let bin = |op: BinOp, l: Expr, r: Expr| Expr::new(ExprKind::Binary(op, Box::new(l), Box::new(r)), span);
-    let tern = |c: Expr, t: Expr, e: Expr| Expr::new(ExprKind::Ternary(Box::new(c), Box::new(t), Box::new(e)), span);
-    let port_member = |port: &str, member: String| Expr::new(
-        ExprKind::FieldAccess(Box::new(id(port.to_string())), mk_ident(member)),
-        span,
-    );
+    let bin = |op: BinOp, l: Expr, r: Expr| {
+        Expr::new(ExprKind::Binary(op, Box::new(l), Box::new(r)), span)
+    };
+    let tern = |c: Expr, t: Expr, e: Expr| {
+        Expr::new(
+            ExprKind::Ternary(Box::new(c), Box::new(t), Box::new(e)),
+            span,
+        )
+    };
+    let port_member = |port: &str, member: String| {
+        Expr::new(
+            ExprKind::FieldAccess(Box::new(id(port.to_string())), mk_ident(member)),
+            span,
+        )
+    };
 
     struct GroupAgg {
         port: String,
@@ -9134,80 +10694,92 @@ fn inline_lower_tlm_initiator_group(
         let state_expr = id(state_reg_name.clone());
         let state_lit = |v: u64| sized(state_width, v);
         let state_eq = |v: u64| bin(BinOp::Eq, state_expr.clone(), state_lit(v));
-        let loop_transition_stmts = |
-            next: &TlmInitGroupNext,
-            normal_next_idx: u64,
-            state_expr: Expr,
-        | -> Vec<Stmt> {
-            match next {
-                TlmInitGroupNext::Fallthrough => vec![Stmt::Assign(RegAssign {
-                    target: state_expr,
-                    value: state_lit(normal_next_idx),
-                    span,
-                })],
-                TlmInitGroupNext::Goto { target, span: goto_span } => vec![Stmt::Assign(RegAssign {
-                    target: state_expr,
-                    value: state_lit(*target as u64),
-                    span: *goto_span,
-                })],
-                TlmInitGroupNext::Branch { cond, then_start, else_start, span: branch_span } => {
-                    vec![Stmt::IfElse(IfElseOf {
-                        cond: cond.clone(),
-                        then_stmts: vec![Stmt::Assign(RegAssign {
-                            target: state_expr.clone(),
-                            value: state_lit(*then_start as u64),
-                            span: *branch_span,
-                        })],
-                        else_stmts: vec![Stmt::Assign(RegAssign {
-                            target: state_expr,
-                            value: state_lit(*else_start as u64),
-                            span: *branch_span,
-                        })],
-                        unique: false,
-                        span: *branch_span,
-                    })]
-                }
-                TlmInitGroupNext::LoopBack { counter, end, body_start, span: loop_span } => {
-                    let counter_expr = id(counter.clone());
-                    let inc_expr = bin(BinOp::AddWrap, counter_expr.clone(), sized(32, 1));
-                    let end_w = Expr::new(
-                        ExprKind::MethodCall(
-                            Box::new(end.clone()),
-                            mk_ident("resize".to_string()),
-                            vec![dec(32)],
-                        ),
-                        *loop_span,
-                    );
-                    let loop_cond = bin(BinOp::Lt, counter_expr.clone(), end_w);
-                    let inc_stmt = || Stmt::Assign(RegAssign {
-                        target: counter_expr.clone(),
-                        value: inc_expr.clone(),
-                        span: *loop_span,
-                    });
-                    vec![Stmt::IfElse(IfElseOf {
-                        cond: loop_cond,
-                        then_stmts: vec![
-                            inc_stmt(),
-                            Stmt::Assign(RegAssign {
+        let loop_transition_stmts =
+            |next: &TlmInitGroupNext, normal_next_idx: u64, state_expr: Expr| -> Vec<Stmt> {
+                match next {
+                    TlmInitGroupNext::Fallthrough => vec![Stmt::Assign(RegAssign {
+                        target: state_expr,
+                        value: state_lit(normal_next_idx),
+                        span,
+                    })],
+                    TlmInitGroupNext::Goto {
+                        target,
+                        span: goto_span,
+                    } => vec![Stmt::Assign(RegAssign {
+                        target: state_expr,
+                        value: state_lit(*target as u64),
+                        span: *goto_span,
+                    })],
+                    TlmInitGroupNext::Branch {
+                        cond,
+                        then_start,
+                        else_start,
+                        span: branch_span,
+                    } => {
+                        vec![Stmt::IfElse(IfElseOf {
+                            cond: cond.clone(),
+                            then_stmts: vec![Stmt::Assign(RegAssign {
                                 target: state_expr.clone(),
-                                value: state_lit(*body_start as u64),
-                                span: *loop_span,
-                            }),
-                        ],
-                        else_stmts: vec![
-                            inc_stmt(),
-                            Stmt::Assign(RegAssign {
+                                value: state_lit(*then_start as u64),
+                                span: *branch_span,
+                            })],
+                            else_stmts: vec![Stmt::Assign(RegAssign {
                                 target: state_expr,
-                                value: state_lit(normal_next_idx),
+                                value: state_lit(*else_start as u64),
+                                span: *branch_span,
+                            })],
+                            unique: false,
+                            span: *branch_span,
+                        })]
+                    }
+                    TlmInitGroupNext::LoopBack {
+                        counter,
+                        end,
+                        body_start,
+                        span: loop_span,
+                    } => {
+                        let counter_expr = id(counter.clone());
+                        let inc_expr = bin(BinOp::AddWrap, counter_expr.clone(), sized(32, 1));
+                        let end_w = Expr::new(
+                            ExprKind::MethodCall(
+                                Box::new(end.clone()),
+                                mk_ident("resize".to_string()),
+                                vec![dec(32)],
+                            ),
+                            *loop_span,
+                        );
+                        let loop_cond = bin(BinOp::Lt, counter_expr.clone(), end_w);
+                        let inc_stmt = || {
+                            Stmt::Assign(RegAssign {
+                                target: counter_expr.clone(),
+                                value: inc_expr.clone(),
                                 span: *loop_span,
-                            }),
-                        ],
-                        unique: false,
-                        span: *loop_span,
-                    })]
+                            })
+                        };
+                        vec![Stmt::IfElse(IfElseOf {
+                            cond: loop_cond,
+                            then_stmts: vec![
+                                inc_stmt(),
+                                Stmt::Assign(RegAssign {
+                                    target: state_expr.clone(),
+                                    value: state_lit(*body_start as u64),
+                                    span: *loop_span,
+                                }),
+                            ],
+                            else_stmts: vec![
+                                inc_stmt(),
+                                Stmt::Assign(RegAssign {
+                                    target: state_expr,
+                                    value: state_lit(normal_next_idx),
+                                    span: *loop_span,
+                                }),
+                            ],
+                            unique: false,
+                            span: *loop_span,
+                        })]
+                    }
                 }
-            }
-        };
+            };
 
         for (i, state) in plan.states.iter().enumerate() {
             let cur_idx = i as u64;
@@ -9327,12 +10899,11 @@ fn inline_lower_tlm_initiator_group(
         }
         acc
     };
-    let emit_bool_or_tree = |
-        prefix: &str,
-        exprs: &[Expr],
-        items: &mut Vec<ModuleBodyItem>,
-        comb_stmts: &mut Vec<Stmt>,
-    | -> Expr {
+    let emit_bool_or_tree = |prefix: &str,
+                             exprs: &[Expr],
+                             items: &mut Vec<ModuleBodyItem>,
+                             comb_stmts: &mut Vec<Stmt>|
+     -> Expr {
         const CHUNK: usize = 8;
         if exprs.is_empty() {
             return Expr::new(ExprKind::Bool(false), span);
@@ -9343,7 +10914,8 @@ fn inline_lower_tlm_initiator_group(
             let mut next = Vec::new();
             for (chunk_i, chunk) in cur.chunks(CHUNK).enumerate() {
                 let wire_name = format!("{prefix}_or_l{level}_{chunk_i}");
-                items.push(ModuleBodyItem::WireDecl(WireDecl { bus_params: Vec::new(),
+                items.push(ModuleBodyItem::WireDecl(WireDecl {
+                    bus_params: Vec::new(),
                     name: mk_ident(wire_name.clone()),
                     ty: TypeExpr::Bool,
                     unpacked: false,
@@ -9362,12 +10934,11 @@ fn inline_lower_tlm_initiator_group(
         }
         or_expr(&cur)
     };
-    let emit_bool_and_tree = |
-        prefix: &str,
-        exprs: &[Expr],
-        items: &mut Vec<ModuleBodyItem>,
-        comb_stmts: &mut Vec<Stmt>,
-    | -> Expr {
+    let emit_bool_and_tree = |prefix: &str,
+                              exprs: &[Expr],
+                              items: &mut Vec<ModuleBodyItem>,
+                              comb_stmts: &mut Vec<Stmt>|
+     -> Expr {
         const CHUNK: usize = 8;
         if exprs.is_empty() {
             return Expr::new(ExprKind::Bool(true), span);
@@ -9378,7 +10949,8 @@ fn inline_lower_tlm_initiator_group(
             let mut next = Vec::new();
             for (chunk_i, chunk) in cur.chunks(CHUNK).enumerate() {
                 let wire_name = format!("{prefix}_and_l{level}_{chunk_i}");
-                items.push(ModuleBodyItem::WireDecl(WireDecl { bus_params: Vec::new(),
+                items.push(ModuleBodyItem::WireDecl(WireDecl {
+                    bus_params: Vec::new(),
                     name: mk_ident(wire_name.clone()),
                     ty: TypeExpr::Bool,
                     unpacked: false,
@@ -9411,14 +10983,13 @@ fn inline_lower_tlm_initiator_group(
         }
         value
     };
-    let emit_mux_tree = |
-        prefix: &str,
-        ty: &TypeExpr,
-        pairs: &[(Expr, Expr)],
-        default: Expr,
-        items: &mut Vec<ModuleBodyItem>,
-        comb_stmts: &mut Vec<Stmt>,
-    | -> Expr {
+    let emit_mux_tree = |prefix: &str,
+                         ty: &TypeExpr,
+                         pairs: &[(Expr, Expr)],
+                         default: Expr,
+                         items: &mut Vec<ModuleBodyItem>,
+                         comb_stmts: &mut Vec<Stmt>|
+     -> Expr {
         const CHUNK: usize = 8;
         if pairs.is_empty() {
             return default;
@@ -9430,14 +11001,16 @@ fn inline_lower_tlm_initiator_group(
             for (chunk_i, chunk) in cur.chunks(CHUNK).enumerate() {
                 let valid_name = format!("{prefix}_mux_valid_l{level}_{chunk_i}");
                 let data_name = format!("{prefix}_mux_data_l{level}_{chunk_i}");
-                items.push(ModuleBodyItem::WireDecl(WireDecl { bus_params: Vec::new(),
+                items.push(ModuleBodyItem::WireDecl(WireDecl {
+                    bus_params: Vec::new(),
                     name: mk_ident(valid_name.clone()),
                     ty: TypeExpr::Bool,
                     unpacked: false,
                     unpacked_ascending: false,
                     span,
                 }));
-                items.push(ModuleBodyItem::WireDecl(WireDecl { bus_params: Vec::new(),
+                items.push(ModuleBodyItem::WireDecl(WireDecl {
+                    bus_params: Vec::new(),
                     name: mk_ident(data_name.clone()),
                     ty: ty.clone(),
                     unpacked: false,
@@ -9477,7 +11050,8 @@ fn inline_lower_tlm_initiator_group(
         let mut want_refs: Vec<Expr> = Vec::new();
         for (i, cond) in issue_conds.iter().enumerate() {
             let want_name = format!("_tlm_init_{}_{}_want_{}", agg.port, agg.method, i);
-            items.push(ModuleBodyItem::WireDecl(WireDecl { bus_params: Vec::new(),
+            items.push(ModuleBodyItem::WireDecl(WireDecl {
+                bus_params: Vec::new(),
                 name: mk_ident(want_name.clone()),
                 ty: TypeExpr::Bool,
                 unpacked: false,
@@ -9531,10 +11105,7 @@ fn inline_lower_tlm_initiator_group(
                         j = (j + 1) % n;
                     }
                     let term = emit_bool_and_tree(
-                        &format!(
-                            "_tlm_init_{}_{}_rr_s{}_g{}",
-                            agg.port, agg.method, start, i
-                        ),
+                        &format!("_tlm_init_{}_{}_rr_s{}_g{}", agg.port, agg.method, start, i),
                         &term_inputs,
                         &mut items,
                         &mut comb_stmts,
@@ -9561,12 +11132,16 @@ fn inline_lower_tlm_initiator_group(
                 let grant = bin(
                     BinOp::And,
                     want.clone(),
-                    Expr::new(ExprKind::Unary(UnaryOp::Not, Box::new(prev_taken.clone())), span),
+                    Expr::new(
+                        ExprKind::Unary(UnaryOp::Not, Box::new(prev_taken.clone())),
+                        span,
+                    ),
                 );
                 grants.push(grant);
                 if i + 1 < want_refs.len() {
                     let taken_name = format!("_tlm_init_{}_{}_taken_{}", agg.port, agg.method, i);
-                    items.push(ModuleBodyItem::WireDecl(WireDecl { bus_params: Vec::new(),
+                    items.push(ModuleBodyItem::WireDecl(WireDecl {
+                        bus_params: Vec::new(),
                         name: mk_ident(taken_name.clone()),
                         ty: TypeExpr::Bool,
                         unpacked: false,
@@ -9586,7 +11161,8 @@ fn inline_lower_tlm_initiator_group(
         let mut grants: Vec<Expr> = Vec::new();
         for (i, grant_expr) in grant_exprs.iter().enumerate() {
             let grant_name = format!("_tlm_init_{}_{}_grant_{}", agg.port, agg.method, i);
-            items.push(ModuleBodyItem::WireDecl(WireDecl { bus_params: Vec::new(),
+            items.push(ModuleBodyItem::WireDecl(WireDecl {
+                bus_params: Vec::new(),
                 name: mk_ident(grant_name.clone()),
                 ty: TypeExpr::Bool,
                 unpacked: false,
@@ -9837,7 +11413,10 @@ fn collect_fork_join_all_plan(
             }
             ThreadStmt::JoinAll(sp) => {
                 if saw_join {
-                    return Err(CompileError::general("duplicate `join all;` in forked TLM group", *sp));
+                    return Err(CompileError::general(
+                        "duplicate `join all;` in forked TLM group",
+                        *sp,
+                    ));
                 }
                 saw_join = true;
             }
@@ -9857,7 +11436,10 @@ fn collect_fork_join_all_plan(
         }
     }
     if issues.is_empty() {
-        return Err(CompileError::general("`join all;` has no preceding forked TLM calls", t.span));
+        return Err(CompileError::general(
+            "`join all;` has no preceding forked TLM calls",
+            t.span,
+        ));
     }
     if !saw_join {
         return Err(CompileError::general(
@@ -9892,7 +11474,9 @@ fn inline_lower_tlm_fork_join_all(
             return Err(CompileError::general(
                 &format!(
                     "TLM call `{port}.{method}` takes {} args but `tlm_method {}` declares {}",
-                    issue.call.args.len(), method, method_meta.args.len()
+                    issue.call.args.len(),
+                    method,
+                    method_meta.args.len()
                 ),
                 issue.span,
             ));
@@ -9900,15 +11484,21 @@ fn inline_lower_tlm_fork_join_all(
     }
     let n = issues.len();
     let tag_width = if let Some(e) = &method_meta.out_of_order_tags {
-        Some(literal_expr_u64(e).ok_or_else(|| CompileError::general(
-            "`out_of_order tags` must be a literal width in the first implementation",
-            e.span,
-        ))? as u32)
+        Some(literal_expr_u64(e).ok_or_else(|| {
+            CompileError::general(
+                "`out_of_order tags` must be a literal width in the first implementation",
+                e.span,
+            )
+        })? as u32)
     } else {
         None
     };
     if let Some(tag_w) = tag_width {
-        let tag_slots = if tag_w >= 64 { u128::MAX } else { 1u128 << tag_w };
+        let tag_slots = if tag_w >= 64 {
+            u128::MAX
+        } else {
+            1u128 << tag_w
+        };
         if tag_slots < n as u128 {
             return Err(CompileError::general(
                 &format!("`{port}.{method}` has {n} forked calls but only {tag_slots} out-of-order tags; increase `tags` width"),
@@ -9921,7 +11511,11 @@ fn inline_lower_tlm_fork_join_all(
     let idx_w = clog2_width(n as u64);
     let occ_w = clog2_width((n + 1) as u64);
     let age_w = clog2_width((max_delay + 2).max(2));
-    let tag = t.name.as_ref().map(|n| n.name.clone()).unwrap_or_else(|| "anon".to_string());
+    let tag = t
+        .name
+        .as_ref()
+        .map(|n| n.name.clone())
+        .unwrap_or_else(|| "anon".to_string());
     let prefix = format!("_tlm_fork_{}_{}_{}", tag, port, method);
 
     let ident = |name: String| Ident { name, span };
@@ -9930,18 +11524,30 @@ fn inline_lower_tlm_fork_join_all(
     let sized = |w: u32, v: u64| Expr::new(ExprKind::Literal(LitKind::Sized(w, v)), span);
     let zero = || Expr::new(ExprKind::Literal(LitKind::Dec(0)), span);
     let bool_lit = |b: bool| Expr::new(ExprKind::Bool(b), span);
-    let bin = |op: BinOp, l: Expr, r: Expr| Expr::new(ExprKind::Binary(op, Box::new(l), Box::new(r)), span);
+    let bin = |op: BinOp, l: Expr, r: Expr| {
+        Expr::new(ExprKind::Binary(op, Box::new(l), Box::new(r)), span)
+    };
     let not = |e: Expr| Expr::new(ExprKind::Unary(UnaryOp::Not, Box::new(e)), span);
-    let tern = |c: Expr, t: Expr, e: Expr| Expr::new(ExprKind::Ternary(Box::new(c), Box::new(t), Box::new(e)), span);
-    let index = |base: Expr, idx: Expr| Expr::new(ExprKind::Index(Box::new(base), Box::new(idx)), span);
-    let trunc = |e: Expr, w: u32| Expr::new(
-        ExprKind::MethodCall(Box::new(e), ident("trunc".to_string()), vec![dec(w as u64)]),
-        span,
-    );
-    let port_member = |member: String| Expr::new(
-        ExprKind::FieldAccess(Box::new(id(port.clone())), ident(member)),
-        span,
-    );
+    let tern = |c: Expr, t: Expr, e: Expr| {
+        Expr::new(
+            ExprKind::Ternary(Box::new(c), Box::new(t), Box::new(e)),
+            span,
+        )
+    };
+    let index =
+        |base: Expr, idx: Expr| Expr::new(ExprKind::Index(Box::new(base), Box::new(idx)), span);
+    let trunc = |e: Expr, w: u32| {
+        Expr::new(
+            ExprKind::MethodCall(Box::new(e), ident("trunc".to_string()), vec![dec(w as u64)]),
+            span,
+        )
+    };
+    let port_member = |member: String| {
+        Expr::new(
+            ExprKind::FieldAccess(Box::new(id(port.clone())), ident(member)),
+            span,
+        )
+    };
     let state_name = |i: usize| format!("{prefix}_t{i}_state");
     let fifo_name = format!("{prefix}_fifo");
     let head_name = format!("{prefix}_head");
@@ -9998,12 +11604,20 @@ fn inline_lower_tlm_fork_join_all(
 
     let occ_nonzero = bin(BinOp::Gt, id(occ_name.clone()), sized(occ_w, 0));
     let occ_not_full = bin(BinOp::Lt, id(occ_name.clone()), sized(occ_w, n as u64));
-    let rsp_pop = bin(BinOp::And, port_member(format!("{method}_rsp_valid")), occ_nonzero.clone());
+    let rsp_pop = bin(
+        BinOp::And,
+        port_member(format!("{method}_rsp_valid")),
+        occ_nonzero.clone(),
+    );
     let fifo_head = index(id(fifo_name.clone()), id(head_name.clone()));
     let all_done = {
         let mut acc = bin(BinOp::Eq, id(state_name(0)), sized(2, 2));
         for i in 1..n {
-            acc = bin(BinOp::And, acc, bin(BinOp::Eq, id(state_name(i)), sized(2, 2)));
+            acc = bin(
+                BinOp::And,
+                acc,
+                bin(BinOp::Eq, id(state_name(i)), sized(2, 2)),
+            );
         }
         acc
     };
@@ -10016,7 +11630,11 @@ fn inline_lower_tlm_fork_join_all(
         } else {
             bin(BinOp::Gte, id(age_name.clone()), sized(age_w, issue.delay))
         };
-        let want_i = bin(BinOp::And, bin(BinOp::And, pending, aged), occ_not_full.clone());
+        let want_i = bin(
+            BinOp::And,
+            bin(BinOp::And, pending, aged),
+            occ_not_full.clone(),
+        );
         let mut grant_i = want_i.clone();
         for prev in &wants {
             grant_i = bin(BinOp::And, grant_i, not(prev.clone()));
@@ -10032,7 +11650,11 @@ fn inline_lower_tlm_fork_join_all(
         acc
     };
     let req_valid = or_expr(&grants);
-    let req_fire = bin(BinOp::And, req_valid.clone(), port_member(format!("{method}_req_ready")));
+    let req_fire = bin(
+        BinOp::And,
+        req_valid.clone(),
+        port_member(format!("{method}_req_ready")),
+    );
     let ptr_inc = |ptr: &str, width: u32| -> Expr {
         tern(
             bin(BinOp::Eq, id(ptr.to_string()), sized(width, (n - 1) as u64)),
@@ -10075,15 +11697,20 @@ fn inline_lower_tlm_fork_join_all(
         span,
     }));
 
-    let mut reset_group_stmts: Vec<Stmt> = (0..n).map(|i| Stmt::Assign(RegAssign {
-        target: id(state_name(i)),
-        value: sized(2, 0),
-        span,
-    })).chain(std::iter::once(Stmt::Assign(RegAssign {
-        target: id(age_name.clone()),
-        value: sized(age_w, 0),
-        span,
-    }))).collect();
+    let mut reset_group_stmts: Vec<Stmt> = (0..n)
+        .map(|i| {
+            Stmt::Assign(RegAssign {
+                target: id(state_name(i)),
+                value: sized(2, 0),
+                span,
+            })
+        })
+        .chain(std::iter::once(Stmt::Assign(RegAssign {
+            target: id(age_name.clone()),
+            value: sized(age_w, 0),
+            span,
+        })))
+        .collect();
     if !tail_stmts.is_empty() {
         reset_group_stmts.push(Stmt::Assign(RegAssign {
             target: id(tail_done_name.clone()),
@@ -10096,14 +11723,19 @@ fn inline_lower_tlm_fork_join_all(
             cond: bin(BinOp::Lt, id(age_name.clone()), sized(age_w, max_delay)),
             then_stmts: vec![Stmt::Assign(RegAssign {
                 target: id(age_name.clone()),
-                value: trunc(bin(BinOp::Add, id(age_name.clone()), sized(age_w, 1)), age_w),
+                value: trunc(
+                    bin(BinOp::Add, id(age_name.clone()), sized(age_w, 1)),
+                    age_w,
+                ),
                 span,
             })],
             else_stmts: Vec::new(),
             unique: false,
             span,
         })]
-    } else { Vec::new() };
+    } else {
+        Vec::new()
+    };
 
     let mut seq_body: Vec<Stmt> = Vec::new();
     if tail_stmts.is_empty() {
@@ -10115,7 +11747,11 @@ fn inline_lower_tlm_fork_join_all(
             span,
         }));
     } else {
-        let tail_pending = bin(BinOp::And, all_done.clone(), not(id(tail_done_name.clone())));
+        let tail_pending = bin(
+            BinOp::And,
+            all_done.clone(),
+            not(id(tail_done_name.clone())),
+        );
         let mut run_tail_stmts = tail_stmts.clone();
         run_tail_stmts.push(Stmt::Assign(RegAssign {
             target: id(tail_done_name.clone()),
@@ -10137,7 +11773,11 @@ fn inline_lower_tlm_fork_join_all(
         }));
     }
     for i in 0..n {
-        let push_i = bin(BinOp::And, grants[i].clone(), port_member(format!("{method}_req_ready")));
+        let push_i = bin(
+            BinOp::And,
+            grants[i].clone(),
+            port_member(format!("{method}_req_ready")),
+        );
         seq_body.push(Stmt::IfElse(IfElse {
             cond: push_i,
             then_stmts: vec![
@@ -10159,13 +11799,25 @@ fn inline_lower_tlm_fork_join_all(
         let rsp_i = if let Some(tag_w) = tag_width {
             bin(
                 BinOp::And,
-                bin(BinOp::And, rsp_pop.clone(), bin(BinOp::Eq, id(state_name(i)), sized(2, 1))),
-                bin(BinOp::Eq, port_member(format!("{method}_rsp_tag")), sized(tag_w, i as u64)),
+                bin(
+                    BinOp::And,
+                    rsp_pop.clone(),
+                    bin(BinOp::Eq, id(state_name(i)), sized(2, 1)),
+                ),
+                bin(
+                    BinOp::Eq,
+                    port_member(format!("{method}_rsp_tag")),
+                    sized(tag_w, i as u64),
+                ),
             )
         } else {
             bin(
                 BinOp::And,
-                bin(BinOp::And, rsp_pop.clone(), bin(BinOp::Eq, id(state_name(i)), sized(2, 1))),
+                bin(
+                    BinOp::And,
+                    rsp_pop.clone(),
+                    bin(BinOp::Eq, id(state_name(i)), sized(2, 1)),
+                ),
                 bin(BinOp::Eq, fifo_head.clone(), sized(idx_w, i as u64)),
             )
         };
@@ -10216,7 +11868,10 @@ fn inline_lower_tlm_fork_join_all(
         cond: bin(BinOp::And, req_fire.clone(), not(rsp_pop.clone())),
         then_stmts: vec![Stmt::Assign(RegAssign {
             target: id(occ_name.clone()),
-            value: trunc(bin(BinOp::Add, id(occ_name.clone()), sized(occ_w, 1)), occ_w),
+            value: trunc(
+                bin(BinOp::Add, id(occ_name.clone()), sized(occ_w, 1)),
+                occ_w,
+            ),
             span,
         })],
         else_stmts: Vec::new(),
@@ -10227,7 +11882,10 @@ fn inline_lower_tlm_fork_join_all(
         cond: bin(BinOp::And, rsp_pop.clone(), not(req_fire)),
         then_stmts: vec![Stmt::Assign(RegAssign {
             target: id(occ_name.clone()),
-            value: trunc(bin(BinOp::Sub, id(occ_name.clone()), sized(occ_w, 1)), occ_w),
+            value: trunc(
+                bin(BinOp::Sub, id(occ_name.clone()), sized(occ_w, 1)),
+                occ_w,
+            ),
             span,
         })],
         else_stmts: Vec::new(),
@@ -10241,7 +11899,10 @@ fn inline_lower_tlm_fork_join_all(
         stmts: seq_body,
         span,
     }));
-    items.push(ModuleBodyItem::CombBlock(CombBlock { stmts: comb_stmts, span }));
+    items.push(ModuleBodyItem::CombBlock(CombBlock {
+        stmts: comb_stmts,
+        span,
+    }));
     Ok(items)
 }
 
@@ -10259,7 +11920,11 @@ fn inline_lower_tlm_initiator(
 
     // Thread name for state-reg naming; anonymous threads get a counter
     // elsewhere, but at this point it should have a name from the parser.
-    let tag = t.name.as_ref().map(|n| n.name.clone()).unwrap_or_else(|| "tlm_init".to_string());
+    let tag = t
+        .name
+        .as_ref()
+        .map(|n| n.name.clone())
+        .unwrap_or_else(|| "tlm_init".to_string());
 
     // Each state is either ComputeOnly (fire seq then advance) or
     // IssueThenWait (drive req / wait for req_ready; drive rsp_ready /
@@ -10294,76 +11959,76 @@ fn inline_lower_tlm_initiator(
     ) -> Result<(), CompileError> {
         for stmt in stmts {
             match stmt {
-            ThreadStmt::SeqAssign(ra) => {
-                // Reject nested TLM calls in either side (composed RHS
-                // like `d <= m.read(a) + 1;` or LHS ref).
-                if match_tlm_call(&ra.value, port_buses, bus_methods).is_none()
-                    && contains_tlm_call(&ra.value, port_buses, bus_methods)
-                {
-                    return Err(CompileError::general(
+                ThreadStmt::SeqAssign(ra) => {
+                    // Reject nested TLM calls in either side (composed RHS
+                    // like `d <= m.read(a) + 1;` or LHS ref).
+                    if match_tlm_call(&ra.value, port_buses, bus_methods).is_none()
+                        && contains_tlm_call(&ra.value, port_buses, bus_methods)
+                    {
+                        return Err(CompileError::general(
                         "TLM method call must be the direct right-hand side of `<=` in a thread body — nested or composed uses are not supported in v1",
                         ra.span,
                     ));
-                }
-                if contains_tlm_call(&ra.target, port_buses, bus_methods) {
-                    return Err(CompileError::general(
-                        "TLM method calls cannot appear on the LHS of an assignment",
-                        ra.span,
-                    ));
-                }
-                if let Some(call) = match_tlm_call(&ra.value, port_buses, bus_methods) {
-                    // Flush any pending non-TLM seq assigns as a Compute state.
-                    if !pending_seq.is_empty() {
-                        states.push(StateKind::Compute {
-                            seq_on_exit: std::mem::take(pending_seq),
-                        });
                     }
-                    let has_ret = call.method_meta.ret.is_some();
-                    states.push(StateKind::TlmIssue {
-                        port: call.port.clone(),
-                        method: call.method.clone(),
-                        args: call.args.clone(),
-                        method_meta: call.method_meta.clone(),
-                    });
-                    states.push(StateKind::TlmWait {
-                        port: call.port,
-                        method: call.method,
-                        method_meta: call.method_meta.clone(),
-                        dest: if has_ret { Some(ra.target) } else { None },
-                    });
-                } else {
-                    pending_seq.push(Stmt::Assign(ra));
+                    if contains_tlm_call(&ra.target, port_buses, bus_methods) {
+                        return Err(CompileError::general(
+                            "TLM method calls cannot appear on the LHS of an assignment",
+                            ra.span,
+                        ));
+                    }
+                    if let Some(call) = match_tlm_call(&ra.value, port_buses, bus_methods) {
+                        // Flush any pending non-TLM seq assigns as a Compute state.
+                        if !pending_seq.is_empty() {
+                            states.push(StateKind::Compute {
+                                seq_on_exit: std::mem::take(pending_seq),
+                            });
+                        }
+                        let has_ret = call.method_meta.ret.is_some();
+                        states.push(StateKind::TlmIssue {
+                            port: call.port.clone(),
+                            method: call.method.clone(),
+                            args: call.args.clone(),
+                            method_meta: call.method_meta.clone(),
+                        });
+                        states.push(StateKind::TlmWait {
+                            port: call.port,
+                            method: call.method,
+                            method_meta: call.method_meta.clone(),
+                            dest: if has_ret { Some(ra.target) } else { None },
+                        });
+                    } else {
+                        pending_seq.push(Stmt::Assign(ra));
+                    }
                 }
-            }
-            ThreadStmt::Lock { body, .. } => {
-                // TLM initiator lowering is responsible for consuming any
-                // TLM call before the generic thread pass sees it. Recurse
-                // through `lock` so the lock idiom recommended by the
-                // multi-driver diagnostic is accepted for TLM methods. The
-                // actual TLM method drives are still emitted once per lowered
-                // thread by the method aggregator below, so the call site
-                // stays on the TLM path instead of falling into ordinary
-                // thread lowering.
-                lower_initiator_stmts(
-                    body,
-                    states,
-                    pending_seq,
-                    port_buses,
-                    bus_methods,
-                    span,
-                )?;
-            }
-            other => {
-                return Err(CompileError::general(
+                ThreadStmt::Lock { body, .. } => {
+                    // TLM initiator lowering is responsible for consuming any
+                    // TLM call before the generic thread pass sees it. Recurse
+                    // through `lock` so the lock idiom recommended by the
+                    // multi-driver diagnostic is accepted for TLM methods. The
+                    // actual TLM method drives are still emitted once per lowered
+                    // thread by the method aggregator below, so the call site
+                    // stays on the TLM path instead of falling into ordinary
+                    // thread lowering.
+                    lower_initiator_stmts(
+                        body,
+                        states,
+                        pending_seq,
+                        port_buses,
+                        bus_methods,
+                        span,
+                    )?;
+                }
+                other => {
+                    return Err(CompileError::general(
                     &format!(
                         "v1 TLM initiator thread body only supports SeqAssign statements and `lock` blocks around them (found {:?}). Refactor more complex control flow into a `thread` without TLM calls.",
                         std::mem::discriminant(&other),
                     ),
                     span,
                 ));
+                }
             }
         }
-    }
         Ok(())
     }
 
@@ -10377,7 +12042,9 @@ fn inline_lower_tlm_initiator(
     )?;
     // Trailing pending seq becomes a Compute state too.
     if !pending_seq.is_empty() {
-        states.push(StateKind::Compute { seq_on_exit: std::mem::take(&mut pending_seq) });
+        states.push(StateKind::Compute {
+            seq_on_exit: std::mem::take(&mut pending_seq),
+        });
     }
     // Empty body is fine — nothing to lower.
     if states.is_empty() {
@@ -10389,29 +12056,41 @@ fn inline_lower_tlm_initiator(
     let state_reg_name = format!("_tlm_init_{}_state", tag);
     let state_expr = Expr::new(ExprKind::Ident(state_reg_name.clone()), span);
     let mk_state_lit = |v: u64| Expr::new(ExprKind::Literal(LitKind::Sized(state_width, v)), span);
-    let state_eq = |v: u64| Expr::new(
-        ExprKind::Binary(BinOp::Eq, Box::new(state_expr.clone()), Box::new(mk_state_lit(v))),
-        span,
-    );
+    let state_eq = |v: u64| {
+        Expr::new(
+            ExprKind::Binary(
+                BinOp::Eq,
+                Box::new(state_expr.clone()),
+                Box::new(mk_state_lit(v)),
+            ),
+            span,
+        )
+    };
     let state_reg_decl = RegDecl {
         name: mk_ident(state_reg_name.clone()),
         ty: TypeExpr::UInt(Box::new(Expr::new(
-            ExprKind::Literal(LitKind::Dec(state_width as u64)), span,
+            ExprKind::Literal(LitKind::Dec(state_width as u64)),
+            span,
         ))),
         init: None,
-        reset: RegReset::Inherit(t.reset.clone(), Expr::new(ExprKind::Literal(LitKind::Dec(0)), span)),
+        reset: RegReset::Inherit(
+            t.reset.clone(),
+            Expr::new(ExprKind::Literal(LitKind::Dec(0)), span),
+        ),
         guard: None,
         multicycle: None,
         span,
     };
 
-    let mk_port_member = |port: &str, member: String| Expr::new(
-        ExprKind::FieldAccess(
-            Box::new(Expr::new(ExprKind::Ident(port.to_string()), span)),
-            mk_ident(member),
-        ),
-        span,
-    );
+    let mk_port_member = |port: &str, member: String| {
+        Expr::new(
+            ExprKind::FieldAccess(
+                Box::new(Expr::new(ExprKind::Ident(port.to_string()), span)),
+                mk_ident(member),
+            ),
+            span,
+        )
+    };
 
     let mut seq_body: Vec<Stmt> = Vec::new();
     // Per-method aggregators for unconditional drives — keyed by
@@ -10426,8 +12105,8 @@ fn inline_lower_tlm_initiator(
         ret_ty: Option<TypeExpr>,
         arg_decls: Vec<(Ident, TypeExpr)>,
         tag_width: Option<Expr>,
-        issues: Vec<(u64, Vec<Expr>)>,  // (state_idx, args at that call site)
-        waits: Vec<u64>,                 // state_idx
+        issues: Vec<(u64, Vec<Expr>)>, // (state_idx, args at that call site)
+        waits: Vec<u64>,               // state_idx
     }
     let mut aggs: std::collections::BTreeMap<String, MethodAgg> = std::collections::BTreeMap::new();
 
@@ -10450,20 +12129,29 @@ fn inline_lower_tlm_initiator(
                     span,
                 }));
             }
-            StateKind::TlmIssue { port, method, args, method_meta } => {
+            StateKind::TlmIssue {
+                port,
+                method,
+                args,
+                method_meta,
+            } => {
                 let key = format!("{port}.{method}");
-                aggs.entry(key).or_insert_with(|| MethodAgg {
-                    port: port.clone(),
-                    method: method.clone(),
-                    ret_ty: method_meta.ret.clone(),
-                    arg_decls: method_meta.args.clone(),
-                    tag_width: method_meta.out_of_order_tags.clone(),
-                    issues: Vec::new(),
-                    waits: Vec::new(),
-                }).issues.push((cur_idx, args.clone()));
+                aggs.entry(key)
+                    .or_insert_with(|| MethodAgg {
+                        port: port.clone(),
+                        method: method.clone(),
+                        ret_ty: method_meta.ret.clone(),
+                        arg_decls: method_meta.args.clone(),
+                        tag_width: method_meta.out_of_order_tags.clone(),
+                        issues: Vec::new(),
+                        waits: Vec::new(),
+                    })
+                    .issues
+                    .push((cur_idx, args.clone()));
                 // Seq: advance on req_ready.
                 let advance_cond = Expr::new(
-                    ExprKind::Binary(BinOp::And,
+                    ExprKind::Binary(
+                        BinOp::And,
                         Box::new(state_eq(cur_idx)),
                         Box::new(mk_port_member(port, format!("{method}_req_ready"))),
                     ),
@@ -10481,17 +12169,25 @@ fn inline_lower_tlm_initiator(
                     span,
                 }));
             }
-            StateKind::TlmWait { port, method, method_meta, dest } => {
+            StateKind::TlmWait {
+                port,
+                method,
+                method_meta,
+                dest,
+            } => {
                 let key = format!("{port}.{method}");
-                aggs.entry(key).or_insert_with(|| MethodAgg {
-                    port: port.clone(),
-                    method: method.clone(),
-                    ret_ty: method_meta.ret.clone(),
-                    arg_decls: method_meta.args.clone(),
-                    tag_width: method_meta.out_of_order_tags.clone(),
-                    issues: Vec::new(),
-                    waits: Vec::new(),
-                }).waits.push(cur_idx);
+                aggs.entry(key)
+                    .or_insert_with(|| MethodAgg {
+                        port: port.clone(),
+                        method: method.clone(),
+                        ret_ty: method_meta.ret.clone(),
+                        arg_decls: method_meta.args.clone(),
+                        tag_width: method_meta.out_of_order_tags.clone(),
+                        issues: Vec::new(),
+                        waits: Vec::new(),
+                    })
+                    .waits
+                    .push(cur_idx);
                 let mut then_stmts: Vec<Stmt> = Vec::new();
                 if let Some(dest_expr) = dest {
                     then_stmts.push(Stmt::Assign(RegAssign {
@@ -10520,7 +12216,10 @@ fn inline_lower_tlm_initiator(
                                 ExprKind::Binary(
                                     BinOp::Eq,
                                     Box::new(mk_port_member(port, format!("{method}_rsp_tag"))),
-                                    Box::new(Expr::new(ExprKind::Literal(LitKind::Sized(tag_w, 0)), span)),
+                                    Box::new(Expr::new(
+                                        ExprKind::Literal(LitKind::Sized(tag_w, 0)),
+                                        span,
+                                    )),
                                 ),
                                 span,
                             )),
@@ -10529,7 +12228,8 @@ fn inline_lower_tlm_initiator(
                     );
                 }
                 let advance_cond = Expr::new(
-                    ExprKind::Binary(BinOp::And,
+                    ExprKind::Binary(
+                        BinOp::And,
                         Box::new(state_eq(cur_idx)),
                         Box::new(advance_rhs),
                     ),
@@ -10661,26 +12361,48 @@ fn contains_tlm_call(
     port_buses: &std::collections::HashMap<String, String>,
     bus_methods: &std::collections::HashMap<String, Vec<TlmMethodMeta>>,
 ) -> bool {
-    if match_tlm_call(e, port_buses, bus_methods).is_some() { return true; }
+    if match_tlm_call(e, port_buses, bus_methods).is_some() {
+        return true;
+    }
     match &e.kind {
-        ExprKind::Binary(_, l, r) => contains_tlm_call(l, port_buses, bus_methods) || contains_tlm_call(r, port_buses, bus_methods),
-        ExprKind::Unary(_, x) | ExprKind::Cast(x, _) | ExprKind::Clog2(x)
-        | ExprKind::Onehot(x) | ExprKind::Signed(x) | ExprKind::Unsigned(x)
+        ExprKind::Binary(_, l, r) => {
+            contains_tlm_call(l, port_buses, bus_methods)
+                || contains_tlm_call(r, port_buses, bus_methods)
+        }
+        ExprKind::Unary(_, x)
+        | ExprKind::Cast(x, _)
+        | ExprKind::Clog2(x)
+        | ExprKind::Onehot(x)
+        | ExprKind::Signed(x)
+        | ExprKind::Unsigned(x)
         | ExprKind::LatencyAt(x, _)
         | ExprKind::SvaNext(_, x) => contains_tlm_call(x, port_buses, bus_methods),
-        ExprKind::Index(b, i) => contains_tlm_call(b, port_buses, bus_methods) || contains_tlm_call(i, port_buses, bus_methods),
+        ExprKind::Index(b, i) => {
+            contains_tlm_call(b, port_buses, bus_methods)
+                || contains_tlm_call(i, port_buses, bus_methods)
+        }
         ExprKind::FieldAccess(b, _) => contains_tlm_call(b, port_buses, bus_methods),
         ExprKind::MethodCall(recv, _, args) => {
             contains_tlm_call(recv, port_buses, bus_methods)
-                || args.iter().any(|a| contains_tlm_call(a, port_buses, bus_methods))
+                || args
+                    .iter()
+                    .any(|a| contains_tlm_call(a, port_buses, bus_methods))
         }
-        ExprKind::Ternary(c, t, el) => contains_tlm_call(c, port_buses, bus_methods) || contains_tlm_call(t, port_buses, bus_methods) || contains_tlm_call(el, port_buses, bus_methods),
-        ExprKind::Concat(xs) | ExprKind::FunctionCall(_, xs) => xs.iter().any(|x| contains_tlm_call(x, port_buses, bus_methods)),
-        ExprKind::Repeat(n, x) => contains_tlm_call(n, port_buses, bus_methods) || contains_tlm_call(x, port_buses, bus_methods),
+        ExprKind::Ternary(c, t, el) => {
+            contains_tlm_call(c, port_buses, bus_methods)
+                || contains_tlm_call(t, port_buses, bus_methods)
+                || contains_tlm_call(el, port_buses, bus_methods)
+        }
+        ExprKind::Concat(xs) | ExprKind::FunctionCall(_, xs) => xs
+            .iter()
+            .any(|x| contains_tlm_call(x, port_buses, bus_methods)),
+        ExprKind::Repeat(n, x) => {
+            contains_tlm_call(n, port_buses, bus_methods)
+                || contains_tlm_call(x, port_buses, bus_methods)
+        }
         _ => false,
     }
 }
-
 
 // ── TLM target in-place lowering ────────────────────────────────────────────
 //
@@ -10720,15 +12442,25 @@ fn lower_indexed_tlm_target_group(
         )
     })?;
     let tag_w = literal_expr_u64(&tag_w_expr).ok_or_else(|| {
-        CompileError::general("`out_of_order tags` must be a literal width for indexed target lowering", tag_w_expr.span)
+        CompileError::general(
+            "`out_of_order tags` must be a literal width for indexed target lowering",
+            tag_w_expr.span,
+        )
     })? as u32;
-    let tag_slots = if tag_w >= 64 { u128::MAX } else { 1u128 << tag_w };
+    let tag_slots = if tag_w >= 64 {
+        u128::MAX
+    } else {
+        1u128 << tag_w
+    };
 
     let mut seen = std::collections::HashSet::new();
     let mut lanes: Vec<(u64, ThreadBlock, TlmTargetBinding, TlmMethodMeta)> = Vec::new();
     for (t, binding, method_meta) in group.drain(..) {
         let lane_expr = binding.tag_lane.as_ref().ok_or_else(|| {
-            CompileError::general("internal error: indexed TLM target group contains an unindexed target", t.span)
+            CompileError::general(
+                "internal error: indexed TLM target group contains an unindexed target",
+                t.span,
+            )
         })?;
         let lane = literal_expr_u64(lane_expr).ok_or_else(|| {
             CompileError::general(
@@ -10754,24 +12486,28 @@ fn lower_indexed_tlm_target_group(
 
     let mk_ident = |name: String| Ident { name, span };
     let ident_expr = |name: String| Expr::new(ExprKind::Ident(name), span);
-    let port_member = |member: String| Expr::new(
-        ExprKind::FieldAccess(
-            Box::new(Expr::new(ExprKind::Ident(port.clone()), span)),
-            mk_ident(member),
-        ),
-        span,
-    );
+    let port_member = |member: String| {
+        Expr::new(
+            ExprKind::FieldAccess(
+                Box::new(Expr::new(ExprKind::Ident(port.clone()), span)),
+                mk_ident(member),
+            ),
+            span,
+        )
+    };
     let lit0 = Expr::new(ExprKind::Literal(LitKind::Dec(0)), span);
     let lit1 = Expr::new(ExprKind::Literal(LitKind::Sized(1, 1)), span);
     let tag_lit = |lane: u64| Expr::new(ExprKind::Literal(LitKind::Sized(tag_w, lane)), span);
-    let tag_eq = |lane: u64| Expr::new(
-        ExprKind::Binary(
-            BinOp::Eq,
-            Box::new(port_member(format!("{method_name}_req_tag"))),
-            Box::new(tag_lit(lane)),
-        ),
-        span,
-    );
+    let tag_eq = |lane: u64| {
+        Expr::new(
+            ExprKind::Binary(
+                BinOp::Eq,
+                Box::new(port_member(format!("{method_name}_req_tag"))),
+                Box::new(tag_lit(lane)),
+            ),
+            span,
+        )
+    };
 
     let mut out = Vec::new();
     let mut extra_items = Vec::new();
@@ -10803,17 +12539,50 @@ fn lower_indexed_tlm_target_group(
         let rsp_tag = format!("{prefix}_rsp_tag");
         let rsp_data = format!("{prefix}_rsp_data");
 
-        out.push(ModuleBodyItem::WireDecl(WireDecl { bus_params: Vec::new(), name: mk_ident(req_ready.clone()), ty: TypeExpr::Bool, unpacked: false, unpacked_ascending: false, span }));
-        out.push(ModuleBodyItem::WireDecl(WireDecl { bus_params: Vec::new(), name: mk_ident(rsp_valid.clone()), ty: TypeExpr::Bool, unpacked: false, unpacked_ascending: false, span }));
-        out.push(ModuleBodyItem::WireDecl(WireDecl { bus_params: Vec::new(), name: mk_ident(rsp_ready.clone()), ty: TypeExpr::Bool, unpacked: false, unpacked_ascending: false, span }));
-        out.push(ModuleBodyItem::WireDecl(WireDecl { bus_params: Vec::new(),
+        out.push(ModuleBodyItem::WireDecl(WireDecl {
+            bus_params: Vec::new(),
+            name: mk_ident(req_ready.clone()),
+            ty: TypeExpr::Bool,
+            unpacked: false,
+            unpacked_ascending: false,
+            span,
+        }));
+        out.push(ModuleBodyItem::WireDecl(WireDecl {
+            bus_params: Vec::new(),
+            name: mk_ident(rsp_valid.clone()),
+            ty: TypeExpr::Bool,
+            unpacked: false,
+            unpacked_ascending: false,
+            span,
+        }));
+        out.push(ModuleBodyItem::WireDecl(WireDecl {
+            bus_params: Vec::new(),
+            name: mk_ident(rsp_ready.clone()),
+            ty: TypeExpr::Bool,
+            unpacked: false,
+            unpacked_ascending: false,
+            span,
+        }));
+        out.push(ModuleBodyItem::WireDecl(WireDecl {
+            bus_params: Vec::new(),
             name: mk_ident(rsp_tag.clone()),
-            ty: TypeExpr::UInt(Box::new(Expr::new(ExprKind::Literal(LitKind::Dec(tag_w as u64)), span))),
-            unpacked: false, unpacked_ascending: false,
+            ty: TypeExpr::UInt(Box::new(Expr::new(
+                ExprKind::Literal(LitKind::Dec(tag_w as u64)),
+                span,
+            ))),
+            unpacked: false,
+            unpacked_ascending: false,
             span,
         }));
         if let Some(ret_ty) = &method.ret {
-            out.push(ModuleBodyItem::WireDecl(WireDecl { bus_params: Vec::new(), name: mk_ident(rsp_data.clone()), ty: ret_ty.clone(), unpacked: false, unpacked_ascending: false, span }));
+            out.push(ModuleBodyItem::WireDecl(WireDecl {
+                bus_params: Vec::new(),
+                name: mk_ident(rsp_data.clone()),
+                ty: ret_ty.clone(),
+                unpacked: false,
+                unpacked_ascending: false,
+                span,
+            }));
         }
 
         let req_valid = Expr::new(
@@ -10833,7 +12602,12 @@ fn lower_indexed_tlm_target_group(
             rsp_data_target: method.ret.as_ref().map(|_| ident_expr(rsp_data.clone())),
             rsp_tag_target: Some(ident_expr(rsp_tag.clone())),
         };
-        out.extend(inline_lower_tlm_target_with_io(t, &binding, &method_meta, io)?);
+        out.extend(inline_lower_tlm_target_with_io(
+            t,
+            &binding,
+            &method_meta,
+            io,
+        )?);
         lane_infos.push((lane, req_ready, rsp_valid, rsp_ready, rsp_data, rsp_tag));
     }
     if response_resource.is_some() && response_resource_lanes != lane_infos.len() {
@@ -10859,30 +12633,37 @@ fn lower_indexed_tlm_target_group(
     let lane_count_expr = Expr::new(ExprKind::Literal(LitKind::Dec(lane_count as u64)), span);
     let grant_width = crate::width::index_width(lane_count as u64);
 
-    out.push(ModuleBodyItem::WireDecl(WireDecl { bus_params: Vec::new(),
+    out.push(ModuleBodyItem::WireDecl(WireDecl {
+        bus_params: Vec::new(),
         name: mk_ident(req_packed.clone()),
         ty: TypeExpr::UInt(Box::new(lane_count_expr.clone())),
         unpacked: false,
         unpacked_ascending: false,
         span,
     }));
-    out.push(ModuleBodyItem::WireDecl(WireDecl { bus_params: Vec::new(),
+    out.push(ModuleBodyItem::WireDecl(WireDecl {
+        bus_params: Vec::new(),
         name: mk_ident(grant_packed.clone()),
         ty: TypeExpr::UInt(Box::new(lane_count_expr.clone())),
         unpacked: false,
         unpacked_ascending: false,
         span,
     }));
-    out.push(ModuleBodyItem::WireDecl(WireDecl { bus_params: Vec::new(),
+    out.push(ModuleBodyItem::WireDecl(WireDecl {
+        bus_params: Vec::new(),
         name: mk_ident(grant_valid.clone()),
         ty: TypeExpr::Bool,
         unpacked: false,
         unpacked_ascending: false,
         span,
     }));
-    out.push(ModuleBodyItem::WireDecl(WireDecl { bus_params: Vec::new(),
+    out.push(ModuleBodyItem::WireDecl(WireDecl {
+        bus_params: Vec::new(),
         name: mk_ident(grant_requester.clone()),
-        ty: TypeExpr::UInt(Box::new(Expr::new(ExprKind::Literal(LitKind::Dec(grant_width as u64)), span))),
+        ty: TypeExpr::UInt(Box::new(Expr::new(
+            ExprKind::Literal(LitKind::Dec(grant_width as u64)),
+            span,
+        ))),
         unpacked: false,
         unpacked_ascending: false,
         span,
@@ -10891,16 +12672,25 @@ fn lower_indexed_tlm_target_group(
         name: mk_ident(hold_valid.clone()),
         ty: TypeExpr::Bool,
         init: None,
-        reset: RegReset::Inherit(group_reset_ident.clone(), Expr::new(ExprKind::Literal(LitKind::Dec(0)), span)),
+        reset: RegReset::Inherit(
+            group_reset_ident.clone(),
+            Expr::new(ExprKind::Literal(LitKind::Dec(0)), span),
+        ),
         guard: None,
         multicycle: None,
         span,
     }));
     out.push(ModuleBodyItem::RegDecl(RegDecl {
         name: mk_ident(hold_idx.clone()),
-        ty: TypeExpr::UInt(Box::new(Expr::new(ExprKind::Literal(LitKind::Dec(grant_width as u64)), span))),
+        ty: TypeExpr::UInt(Box::new(Expr::new(
+            ExprKind::Literal(LitKind::Dec(grant_width as u64)),
+            span,
+        ))),
         init: None,
-        reset: RegReset::Inherit(group_reset_ident.clone(), Expr::new(ExprKind::Literal(LitKind::Dec(0)), span)),
+        reset: RegReset::Inherit(
+            group_reset_ident.clone(),
+            Expr::new(ExprKind::Literal(LitKind::Dec(0)), span),
+        ),
         guard: None,
         multicycle: None,
         span,
@@ -10977,12 +12767,17 @@ fn lower_indexed_tlm_target_group(
     }));
 
     let mut comb_stmts = Vec::new();
-    for (idx, (_lane, _req_ready, rsp_valid, _rsp_ready, _rsp_data, _rsp_tag)) in lane_infos.iter().enumerate() {
+    for (idx, (_lane, _req_ready, rsp_valid, _rsp_ready, _rsp_data, _rsp_tag)) in
+        lane_infos.iter().enumerate()
+    {
         comb_stmts.push(Stmt::Assign(CombAssign {
-            target: Expr::new(ExprKind::Index(
-                Box::new(Expr::new(ExprKind::Ident(req_packed.clone()), span)),
-                Box::new(Expr::new(ExprKind::Literal(LitKind::Dec(idx as u64)), span)),
-            ), span),
+            target: Expr::new(
+                ExprKind::Index(
+                    Box::new(Expr::new(ExprKind::Ident(req_packed.clone()), span)),
+                    Box::new(Expr::new(ExprKind::Literal(LitKind::Dec(idx as u64)), span)),
+                ),
+                span,
+            ),
             value: Expr::new(
                 ExprKind::Binary(
                     BinOp::And,
@@ -11046,11 +12841,16 @@ fn lower_indexed_tlm_target_group(
             span,
         }));
     }
-    for (idx, (_lane, _req_ready, rsp_valid, rsp_ready, rsp_data, rsp_tag)) in lane_infos.iter().enumerate() {
-        let lane_grant = Expr::new(ExprKind::Index(
-            Box::new(Expr::new(ExprKind::Ident(grant_packed.clone()), span)),
-            Box::new(Expr::new(ExprKind::Literal(LitKind::Dec(idx as u64)), span)),
-        ), span);
+    for (idx, (_lane, _req_ready, rsp_valid, rsp_ready, rsp_data, rsp_tag)) in
+        lane_infos.iter().enumerate()
+    {
+        let lane_grant = Expr::new(
+            ExprKind::Index(
+                Box::new(Expr::new(ExprKind::Ident(grant_packed.clone()), span)),
+                Box::new(Expr::new(ExprKind::Literal(LitKind::Dec(idx as u64)), span)),
+            ),
+            span,
+        );
         let held_lane = Expr::new(
             ExprKind::Binary(
                 BinOp::And,
@@ -11059,7 +12859,10 @@ fn lower_indexed_tlm_target_group(
                     ExprKind::Binary(
                         BinOp::Eq,
                         Box::new(Expr::new(ExprKind::Ident(hold_idx.clone()), span)),
-                        Box::new(Expr::new(ExprKind::Literal(LitKind::Sized(grant_width, idx as u64)), span)),
+                        Box::new(Expr::new(
+                            ExprKind::Literal(LitKind::Sized(grant_width, idx as u64)),
+                            span,
+                        )),
                     ),
                     span,
                 )),
@@ -11109,7 +12912,10 @@ fn lower_indexed_tlm_target_group(
             span,
         }));
     }
-    out.push(ModuleBodyItem::CombBlock(CombBlock { stmts: comb_stmts, span }));
+    out.push(ModuleBodyItem::CombBlock(CombBlock {
+        stmts: comb_stmts,
+        span,
+    }));
     let rsp_ready_member = port_member(format!("{method_name}_rsp_ready"));
     out.push(ModuleBodyItem::RegBlock(RegBlock {
         clock: Ident::new(group_clk.clone(), span),
@@ -11188,7 +12994,11 @@ fn strip_tlm_response_lock(t: &mut ThreadBlock) -> Result<Option<String>, Compil
         let mut out = Vec::new();
         for stmt in stmts {
             match stmt {
-                ThreadStmt::Lock { resource, body, span } if contains_return(&body) => {
+                ThreadStmt::Lock {
+                    resource,
+                    body,
+                    span,
+                } if contains_return(&body) => {
                     if let Some(existing) = found.as_ref() {
                         if existing != &resource.name {
                             return Err(CompileError::general(
@@ -11209,7 +13019,13 @@ fn strip_tlm_response_lock(t: &mut ThreadBlock) -> Result<Option<String>, Compil
                     ie.else_stmts = rewrite_stmts(ie.else_stmts, found)?;
                     out.push(ThreadStmt::IfElse(ie));
                 }
-                ThreadStmt::For { var, start, end, body, span } => {
+                ThreadStmt::For {
+                    var,
+                    start,
+                    end,
+                    body,
+                    span,
+                } => {
                     out.push(ThreadStmt::For {
                         var,
                         start,
@@ -11263,21 +13079,29 @@ fn inline_lower_tlm_target(
     let method_name = &binding.method.name;
     let span = t.span;
     let mk_ident = |name: String| Ident { name, span };
-    let mk_port_member = |member: String| Expr::new(
-        ExprKind::FieldAccess(
-            Box::new(Expr::new(ExprKind::Ident(port.clone()), span)),
-            mk_ident(member),
-        ),
-        span,
-    );
+    let mk_port_member = |member: String| {
+        Expr::new(
+            ExprKind::FieldAccess(
+                Box::new(Expr::new(ExprKind::Ident(port.clone()), span)),
+                mk_ident(member),
+            ),
+            span,
+        )
+    };
     let io = TlmTargetIo {
         suffix: String::new(),
         req_valid: mk_port_member(format!("{method_name}_req_valid")),
         rsp_ready: mk_port_member(format!("{method_name}_rsp_ready")),
         req_ready_target: mk_port_member(format!("{method_name}_req_ready")),
         rsp_valid_target: mk_port_member(format!("{method_name}_rsp_valid")),
-        rsp_data_target: method.ret.as_ref().map(|_| mk_port_member(format!("{method_name}_rsp_data"))),
-        rsp_tag_target: method.out_of_order_tags.as_ref().map(|_| mk_port_member(format!("{method_name}_rsp_tag"))),
+        rsp_data_target: method
+            .ret
+            .as_ref()
+            .map(|_| mk_port_member(format!("{method_name}_rsp_data"))),
+        rsp_tag_target: method
+            .out_of_order_tags
+            .as_ref()
+            .map(|_| mk_port_member(format!("{method_name}_rsp_tag"))),
     };
     inline_lower_tlm_target_with_io(t, binding, method, io)
 }
@@ -11292,13 +13116,15 @@ fn inline_lower_tlm_target_with_io(
     let method_name = &binding.method.name;
     let span = t.span;
     let mk_ident = |name: String| Ident { name, span };
-    let mk_port_member = |member: String| Expr::new(
-        ExprKind::FieldAccess(
-            Box::new(Expr::new(ExprKind::Ident(port.clone()), span)),
-            mk_ident(member),
-        ),
-        span,
-    );
+    let mk_port_member = |member: String| {
+        Expr::new(
+            ExprKind::FieldAccess(
+                Box::new(Expr::new(ExprKind::Ident(port.clone()), span)),
+                mk_ident(member),
+            ),
+            span,
+        )
+    };
     // Arg renames: user-bound arg name → latched reg name.
     let mut arg_renames: Vec<(String, String)> = Vec::new();
     let mut latch_regs: Vec<RegDecl> = Vec::new();
@@ -11308,7 +13134,10 @@ fn inline_lower_tlm_target_with_io(
             name: mk_ident(latch_name.clone()),
             ty: TypeExpr::UInt(Box::new(tag_w.clone())),
             init: None,
-            reset: RegReset::Inherit(t.reset.clone(), Expr::new(ExprKind::Literal(LitKind::Dec(0)), span)),
+            reset: RegReset::Inherit(
+                t.reset.clone(),
+                Expr::new(ExprKind::Literal(LitKind::Dec(0)), span),
+            ),
             guard: None,
             multicycle: None,
             span,
@@ -11316,12 +13145,18 @@ fn inline_lower_tlm_target_with_io(
         latch_name
     });
     for (user_arg, method_arg) in binding.args.iter().zip(method.args.iter()) {
-        let latch_name = format!("_tlm_{port}_{method_name}{}_{}_latched", io.suffix, method_arg.0.name);
+        let latch_name = format!(
+            "_tlm_{port}_{method_name}{}_{}_latched",
+            io.suffix, method_arg.0.name
+        );
         latch_regs.push(RegDecl {
             name: mk_ident(latch_name.clone()),
             ty: method_arg.1.clone(),
             init: None,
-            reset: RegReset::Inherit(t.reset.clone(), Expr::new(ExprKind::Literal(LitKind::Dec(0)), span)),
+            reset: RegReset::Inherit(
+                t.reset.clone(),
+                Expr::new(ExprKind::Literal(LitKind::Dec(0)), span),
+            ),
             guard: None,
             multicycle: None,
             span,
@@ -11396,7 +13231,12 @@ fn inline_lower_tlm_target_with_io(
     // `_loop_cnt_{id}` placeholder; rename each to a unique
     // `<base>_{id}` so nested loops don't share a counter (issue #414).
     let loop_renames: Vec<(String, String)> = (0..num_loop_counters)
-        .map(|id| (format!("_loop_cnt_{}", id), format!("{}_{}", loop_cnt_name_base, id)))
+        .map(|id| {
+            (
+                format!("_loop_cnt_{}", id),
+                format!("{}_{}", loop_cnt_name_base, id),
+            )
+        })
         .collect();
     for (old, new) in &loop_renames {
         for state in &mut body_states {
@@ -11432,19 +13272,29 @@ fn inline_lower_tlm_target_with_io(
     let state_reg_name = format!("_tlm_{port}_{method_name}{}_state", io.suffix);
     let state_ident = Expr::new(ExprKind::Ident(state_reg_name.clone()), span);
     let mk_state_lit = |v: u64| Expr::new(ExprKind::Literal(LitKind::Sized(state_width, v)), span);
-    let state_eq = |v: u64| Expr::new(
-        ExprKind::Binary(BinOp::Eq, Box::new(state_ident.clone()), Box::new(mk_state_lit(v))),
-        span,
-    );
+    let state_eq = |v: u64| {
+        Expr::new(
+            ExprKind::Binary(
+                BinOp::Eq,
+                Box::new(state_ident.clone()),
+                Box::new(mk_state_lit(v)),
+            ),
+            span,
+        )
+    };
 
     // ── State register declaration ───────────────────────────────────────
     let state_reg = RegDecl {
         name: mk_ident(state_reg_name.clone()),
         ty: TypeExpr::UInt(Box::new(Expr::new(
-            ExprKind::Literal(LitKind::Dec(state_width as u64)), span,
+            ExprKind::Literal(LitKind::Dec(state_width as u64)),
+            span,
         ))),
         init: None,
-        reset: RegReset::Inherit(t.reset.clone(), Expr::new(ExprKind::Literal(LitKind::Dec(0)), span)),
+        reset: RegReset::Inherit(
+            t.reset.clone(),
+            Expr::new(ExprKind::Literal(LitKind::Dec(0)), span),
+        ),
         guard: None,
         multicycle: None,
         span,
@@ -11454,7 +13304,10 @@ fn inline_lower_tlm_target_with_io(
     let wait_cnt_ident = Expr::new(ExprKind::Ident(wait_cnt_name.clone()), span);
     let wait_count_init = |count: &Expr| -> Expr {
         if let Some(v) = literal_expr_u64(count) {
-            Expr::new(ExprKind::Literal(LitKind::Sized(32, v.saturating_sub(1))), span)
+            Expr::new(
+                ExprKind::Literal(LitKind::Sized(32, v.saturating_sub(1))),
+                span,
+            )
         } else {
             count.clone()
         }
@@ -11489,7 +13342,10 @@ fn inline_lower_tlm_target_with_io(
     // State 0: ENTRY — if req_valid, latch args and advance to 1.
     let mut entry_then: Vec<Stmt> = Vec::new();
     for (user_arg, method_arg) in binding.args.iter().zip(method.args.iter()) {
-        let latch_name = format!("_tlm_{port}_{method_name}{}_{}_latched", io.suffix, method_arg.0.name);
+        let latch_name = format!(
+            "_tlm_{port}_{method_name}{}_{}_latched",
+            io.suffix, method_arg.0.name
+        );
         entry_then.push(Stmt::Assign(RegAssign {
             target: Expr::new(ExprKind::Ident(latch_name), span),
             value: mk_port_member(format!("{method_name}_{}", method_arg.0.name)),
@@ -11504,10 +13360,7 @@ fn inline_lower_tlm_target_with_io(
             span,
         }));
     }
-    let transition_to_body_or_respond = |
-        target: usize,
-        state_ident: Expr,
-    | -> Vec<Stmt> {
+    let transition_to_body_or_respond = |target: usize, state_ident: Expr| -> Vec<Stmt> {
         let mut stmts = Vec::new();
         if thread_target_return_idx(target).is_none() {
             if let Some(wait) = body_states.get(target).and_then(|s| s.wait_cycles.as_ref()) {
@@ -11550,11 +13403,16 @@ fn inline_lower_tlm_target_with_io(
     }
     entry_then.push(Stmt::Assign(RegAssign {
         target: state_ident.clone(),
-        value: if body_states.is_empty() { mk_state_lit(fallback_response_idx) } else { mk_state_lit(1) },
+        value: if body_states.is_empty() {
+            mk_state_lit(fallback_response_idx)
+        } else {
+            mk_state_lit(1)
+        },
         span,
     }));
     let entry_branch_cond = Expr::new(
-        ExprKind::Binary(BinOp::And,
+        ExprKind::Binary(
+            BinOp::And,
             Box::new(state_eq(entry_idx)),
             Box::new(io.req_valid.clone()),
         ),
@@ -11600,7 +13458,10 @@ fn inline_lower_tlm_target_with_io(
             for (cond, target) in &us.multi_transitions {
                 let target_idx = *target;
                 let mut then_stmts = us.seq_stmts.clone();
-                then_stmts.extend(transition_to_body_or_respond(target_idx, state_ident.clone()));
+                then_stmts.extend(transition_to_body_or_respond(
+                    target_idx,
+                    state_ident.clone(),
+                ));
                 let mut branch_cond = Expr::new(
                     ExprKind::Binary(
                         BinOp::And,
@@ -11630,11 +13491,17 @@ fn inline_lower_tlm_target_with_io(
         } else {
             let mut then_stmts = us.seq_stmts.clone();
             if let Some(return_idx) = us.terminal_return {
-                then_stmts.extend(transition_to_state_response(return_idx, state_ident.clone()));
+                then_stmts.extend(transition_to_state_response(
+                    return_idx,
+                    state_ident.clone(),
+                ));
             } else {
                 then_stmts.extend(transition_to_body_or_respond(i + 1, state_ident.clone()));
             }
-            let transition_cond = us.transition_cond.clone().unwrap_or_else(|| Expr::new(ExprKind::Bool(true), span));
+            let transition_cond = us
+                .transition_cond
+                .clone()
+                .unwrap_or_else(|| Expr::new(ExprKind::Bool(true), span));
             let mut branch_cond = Expr::new(
                 ExprKind::Binary(
                     BinOp::And,
@@ -11666,7 +13533,8 @@ fn inline_lower_tlm_target_with_io(
     for slot in 0..response_count {
         let response_idx = (response_base + slot) as u64;
         let respond_branch_cond = Expr::new(
-            ExprKind::Binary(BinOp::And,
+            ExprKind::Binary(
+                BinOp::And,
                 Box::new(state_eq(response_idx)),
                 Box::new(io.rsp_ready.clone()),
             ),
@@ -11776,9 +13644,15 @@ fn inline_lower_tlm_target_with_io(
     if has_wait_cycles {
         items.push(ModuleBodyItem::RegDecl(RegDecl {
             name: mk_ident(wait_cnt_name),
-            ty: TypeExpr::UInt(Box::new(Expr::new(ExprKind::Literal(LitKind::Dec(32)), span))),
+            ty: TypeExpr::UInt(Box::new(Expr::new(
+                ExprKind::Literal(LitKind::Dec(32)),
+                span,
+            ))),
             init: None,
-            reset: RegReset::Inherit(t.reset.clone(), Expr::new(ExprKind::Literal(LitKind::Dec(0)), span)),
+            reset: RegReset::Inherit(
+                t.reset.clone(),
+                Expr::new(ExprKind::Literal(LitKind::Dec(0)), span),
+            ),
             guard: None,
             multicycle: None,
             span,
@@ -11790,7 +13664,10 @@ fn inline_lower_tlm_target_with_io(
     for id in 0..num_loop_counters {
         items.push(ModuleBodyItem::RegDecl(RegDecl {
             name: mk_ident(format!("{}_{}", loop_cnt_name_base, id)),
-            ty: TypeExpr::UInt(Box::new(Expr::new(ExprKind::Literal(LitKind::Dec(cnt_width as u64)), span))),
+            ty: TypeExpr::UInt(Box::new(Expr::new(
+                ExprKind::Literal(LitKind::Dec(cnt_width as u64)),
+                span,
+            ))),
             init: Some(Expr::new(ExprKind::Literal(LitKind::Dec(0)), span)),
             reset: RegReset::None,
             guard: None,
@@ -11798,7 +13675,9 @@ fn inline_lower_tlm_target_with_io(
             span,
         }));
     }
-    for r in latch_regs { items.push(ModuleBodyItem::RegDecl(r)); }
+    for r in latch_regs {
+        items.push(ModuleBodyItem::RegDecl(r));
+    }
     items.push(ModuleBodyItem::RegBlock(reg_block));
     items.push(ModuleBodyItem::CombBlock(comb_block));
     Ok(items)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ pub mod signal_flow;
 pub mod sim_codegen;
 pub mod sim_credit_channel;
 pub mod thread_map;
+pub mod thread_proof_cert;
 pub mod type_alias;
 pub mod typecheck;
 pub mod width;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use clap::{Parser, Subcommand};
 use miette::{IntoDiagnostic, NamedSource, Report};
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use arch::ast::Item;
 use arch::codegen::Codegen;
@@ -100,6 +100,26 @@ enum Command {
         /// the explicit path. The optional value requires `=`.
         #[arg(long, num_args = 0..=1, require_equals = true)]
         emit_thread_map: Option<Option<PathBuf>>,
+        /// Emit a machine-readable thread lowering proof certificate JSON.
+        /// Bare flag writes `<sv-output-stem>.thread-proof.json`;
+        /// `--emit-thread-proof=PATH` writes the explicit path. The optional
+        /// value requires `=`.
+        #[arg(long, num_args = 0..=1, require_equals = true)]
+        emit_thread_proof: Option<Option<PathBuf>>,
+        /// Emit a Lean replay file for the thread lowering proof certificate.
+        /// Bare flag writes `<sv-output-stem>.thread-proof.lean`;
+        /// `--emit-thread-proof-lean=PATH` writes the explicit path. The
+        /// optional value requires `=`.
+        #[arg(long, num_args = 0..=1, require_equals = true)]
+        emit_thread_proof_lean: Option<Option<PathBuf>>,
+        /// Emit the Lean thread proof file and immediately replay it with
+        /// `lake env lean`. Use `--thread-proof-lean-project=DIR` or
+        /// `ARCH_THREAD_PROOF_LEAN_PROJECT` to locate the Lean project.
+        #[arg(long)]
+        check_thread_proof_lean: bool,
+        /// Lean project directory used by `--check-thread-proof-lean`.
+        #[arg(long)]
+        thread_proof_lean_project: Option<PathBuf>,
         /// Auto-emit SVA properties from `thread` lowering (wait_until / wait
         /// N cycle progress, fork-join branch transitions). Wrapped in
         /// `synopsys translate_off/on` so they don't reach synthesis. Off by
@@ -226,6 +246,25 @@ enum Command {
         /// Dump the generated SMT-LIB2 to this file (for inspection / debugging)
         #[arg(long)]
         emit_smt: Option<PathBuf>,
+        /// Emit a Lean replay file for the thread lowering proof certificate.
+        /// Bare flag writes `<first-input-stem>.thread-proof.lean`;
+        /// `--emit-thread-proof-lean=PATH` writes the explicit path. The
+        /// optional value requires `=`.
+        #[arg(long, num_args = 0..=1, require_equals = true)]
+        emit_thread_proof_lean: Option<Option<PathBuf>>,
+        /// Emit the Lean thread proof file and immediately replay it with
+        /// `lake env lean`. Use `--thread-proof-lean-project=DIR` or
+        /// `ARCH_THREAD_PROOF_LEAN_PROJECT` to locate the Lean project.
+        #[arg(long)]
+        check_thread_proof_lean: bool,
+        /// Lean project directory used by `--check-thread-proof-lean`.
+        #[arg(long)]
+        thread_proof_lean_project: Option<PathBuf>,
+        /// After emitting/replaying the Lean thread-lowering proof, skip the
+        /// SMT-LIB2 backend. Use this when the goal is compiler lowering
+        /// proof replay rather than bounded design-property checking.
+        #[arg(long)]
+        thread_proof_only: bool,
         /// Per-property solver timeout in seconds
         #[arg(long, default_value_t = 60)]
         timeout: u32,
@@ -282,29 +321,91 @@ impl MultiSource {
         let offset = err.span_offset();
         let (filename, file_source, local_offset) = self.locate(offset);
         let relocated_err = err.relocate(local_offset);
-        Report::new(relocated_err)
-            .with_source_code(NamedSource::new(filename.to_string(), file_source.to_string()))
+        Report::new(relocated_err).with_source_code(NamedSource::new(
+            filename.to_string(),
+            file_source.to_string(),
+        ))
     }
-
 }
 
 fn thread_map_sources_from_multi(ms: &MultiSource) -> Vec<arch::thread_map::ThreadMapSource> {
-    ms.segments.iter()
-        .map(|(start, end, filename, source)| arch::thread_map::ThreadMapSource {
-            start: *start,
-            end: *end,
-            filename: filename.clone(),
-            source: source.clone(),
-        })
+    ms.segments
+        .iter()
+        .map(
+            |(start, end, filename, source)| arch::thread_map::ThreadMapSource {
+                start: *start,
+                end: *end,
+                filename: filename.clone(),
+                source: source.clone(),
+            },
+        )
         .collect()
+}
+
+fn check_thread_proof_lean_file(
+    proof_path: &Path,
+    explicit_project: Option<&Path>,
+) -> miette::Result<()> {
+    let project_dir = thread_proof_lean_project_dir(explicit_project)?;
+    let proof_path = proof_path
+        .canonicalize()
+        .unwrap_or_else(|_| proof_path.to_path_buf());
+    let output = std::process::Command::new("lake")
+        .arg("env")
+        .arg("lean")
+        .arg(&proof_path)
+        .current_dir(&project_dir)
+        .output()
+        .into_diagnostic()
+        .map_err(|err| {
+            miette::miette!(
+                "failed to run Lean proof replay via `lake`; set PATH so `lake` is available: {err}"
+            )
+        })?;
+    if !output.status.success() {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(miette::miette!(
+            "Lean thread proof replay failed for {} in {}\nstdout:\n{}\nstderr:\n{}",
+            proof_path.display(),
+            project_dir.display(),
+            stdout,
+            stderr
+        ));
+    }
+    eprintln!("Lean proof replay OK {}", proof_path.display());
+    Ok(())
+}
+
+fn thread_proof_lean_project_dir(explicit_project: Option<&Path>) -> miette::Result<PathBuf> {
+    let candidate = if let Some(path) = explicit_project {
+        path.to_path_buf()
+    } else if let Ok(path) = std::env::var("ARCH_THREAD_PROOF_LEAN_PROJECT") {
+        PathBuf::from(path)
+    } else {
+        PathBuf::from("proofs/lean_thread_lowering")
+    };
+    if !candidate.join("lakefile.toml").exists() {
+        return Err(miette::miette!(
+            "Lean thread proof project not found at {}; pass --thread-proof-lean-project=DIR or set ARCH_THREAD_PROOF_LEAN_PROJECT",
+            candidate.display()
+        ));
+    }
+    Ok(candidate)
 }
 
 fn filter_thread_map_by_ranges(
     map: &arch::thread_map::ThreadMap,
     ranges: &[(usize, usize)],
 ) -> arch::thread_map::ThreadMap {
-    let modules = map.modules.iter()
-        .filter(|module| ranges.iter().any(|(start, end)| module.span.start >= *start && module.span.start < *end))
+    let modules = map
+        .modules
+        .iter()
+        .filter(|module| {
+            ranges
+                .iter()
+                .any(|(start, end)| module.span.start >= *start && module.span.start < *end)
+        })
         .cloned()
         .collect();
     arch::thread_map::ThreadMap { modules }
@@ -367,28 +468,35 @@ fn main() -> miette::Result<()> {
     let cli = Cli::parse();
 
     match cli.command {
-        Command::Check { files } => {
-            learn_wrap(&files, || {
-                let all_files = resolve_use_imports(&files)?;
-                let ms = MultiSource::from_files(&all_files)?;
-                run_check_multi(&ms)?;
-                eprintln!("OK: no errors");
-                Ok(())
-            })
-        }
+        Command::Check { files } => learn_wrap(&files, || {
+            let all_files = resolve_use_imports(&files)?;
+            let ms = MultiSource::from_files(&all_files)?;
+            run_check_multi(&ms)?;
+            eprintln!("OK: no errors");
+            Ok(())
+        }),
         Command::LearnIndex => {
             let n = arch::learn::build_index().into_diagnostic()?;
             eprintln!("Indexed {} events.", n);
             Ok(())
         }
-        Command::Advise { query, top, from_stderr, feature } => {
+        Command::Advise {
+            query,
+            top,
+            from_stderr,
+            feature,
+        } => {
             let mut q = query.join(" ");
             if from_stderr {
                 use std::io::Read;
                 let mut buf = String::new();
-                std::io::stdin().read_to_string(&mut buf).into_diagnostic()?;
+                std::io::stdin()
+                    .read_to_string(&mut buf)
+                    .into_diagnostic()?;
                 if !buf.trim().is_empty() {
-                    if !q.is_empty() { q.push(' '); }
+                    if !q.is_empty() {
+                        q.push(' ');
+                    }
                     q.push_str(buf.trim());
                 }
             }
@@ -401,12 +509,14 @@ fn main() -> miette::Result<()> {
             let pool_size = if feature { top.max(1) * 8 } else { top };
             let matches = arch::learn::advise(&q, pool_size).into_diagnostic()?;
             let matches: Vec<_> = if feature {
-                matches.into_iter()
+                matches
+                    .into_iter()
                     .filter(|m| m.event.kind == "feature")
                     .take(top)
                     .collect()
             } else {
-                matches.into_iter()
+                matches
+                    .into_iter()
                     .filter(|m| m.event.kind != "feature")
                     .take(top)
                     .collect()
@@ -416,8 +526,12 @@ fn main() -> miette::Result<()> {
                 return Ok(());
             }
             for (i, m) in matches.iter().enumerate() {
-                println!("── match #{} (score {:.3}, retrieved {}×) ──────────────────────",
-                         i + 1, m.score, m.retrieved_count);
+                println!(
+                    "── match #{} (score {:.3}, retrieved {}×) ──────────────────────",
+                    i + 1,
+                    m.score,
+                    m.retrieved_count
+                );
                 if m.event.kind == "feature" {
                     // Feature event: file::construct + truncated doc snippet.
                     println!("  kind:      {}", m.event.error_code);
@@ -425,9 +539,11 @@ fn main() -> miette::Result<()> {
                     println!("  file:      {}", m.event.file_path);
                     let snippet: String = m.event.error_message.chars().take(240).collect();
                     let truncated = m.event.error_message.chars().count() > 240;
-                    println!("  doc:       {}{}",
-                             snippet.replace('\n', " "),
-                             if truncated { " …" } else { "" });
+                    println!(
+                        "  doc:       {}{}",
+                        snippet.replace('\n', " "),
+                        if truncated { " …" } else { "" }
+                    );
                 } else {
                     println!("  code:    {}", m.event.error_code);
                     println!("  message: {}", m.event.error_message);
@@ -442,15 +558,18 @@ fn main() -> miette::Result<()> {
             arch::learn::print_stats().into_diagnostic()?;
             Ok(())
         }
-        Command::LearnBootstrap { path } => {
-            run_learn_bootstrap(&path)
-        }
+        Command::LearnBootstrap { path } => run_learn_bootstrap(&path),
         Command::LearnClear => {
             arch::learn::clear_store().into_diagnostic()?;
             eprintln!("Cleared ~/.arch/learn/");
             Ok(())
         }
-        Command::LearnPrune { code, contains, older_than_days, dry_run } => {
+        Command::LearnPrune {
+            code,
+            contains,
+            older_than_days,
+            dry_run,
+        } => {
             if code.is_none() && contains.is_none() && older_than_days.is_none() {
                 eprintln!("error: specify at least one of --code / --contains / --older-than-days");
                 std::process::exit(2);
@@ -460,46 +579,115 @@ fn main() -> miette::Result<()> {
                 contains.as_deref(),
                 older_than_days,
                 dry_run,
-            ).into_diagnostic()?;
+            )
+            .into_diagnostic()?;
             if dry_run {
                 eprintln!("Would remove {} events; {} would remain.", removed, kept);
             } else {
-                eprintln!("Removed {} events; {} remain. Run `arch learn-index` to refresh the index.", removed, kept);
+                eprintln!(
+                    "Removed {} events; {} remain. Run `arch learn-index` to refresh the index.",
+                    removed, kept
+                );
             }
             Ok(())
         }
-        Command::Sim { arch_files, tb_files, outdir, check_uninit, inputs_start_uninit, check_uninit_ram, cdc_random, wave, debug, debug_depth, debug_fsm, coverage, coverage_dat, thread_sim, threads, pybind, test, pybind_module_name, auto_thread_asserts, param_overrides } => {
+        Command::Sim {
+            arch_files,
+            tb_files,
+            outdir,
+            check_uninit,
+            inputs_start_uninit,
+            check_uninit_ram,
+            cdc_random,
+            wave,
+            debug,
+            debug_depth,
+            debug_fsm,
+            coverage,
+            coverage_dat,
+            thread_sim,
+            threads,
+            pybind,
+            test,
+            pybind_module_name,
+            auto_thread_asserts,
+            param_overrides,
+        } => {
             let _ = auto_thread_asserts;
 
             // Parse --param NAME=VALUE overrides
-            let mut param_overrides_map: std::collections::HashMap<String, u64> = std::collections::HashMap::new();
+            let mut param_overrides_map: std::collections::HashMap<String, u64> =
+                std::collections::HashMap::new();
             for ov in &param_overrides {
-                let (name, val_str) = ov.split_once('=').ok_or_else(|| {
-                    miette::miette!("--param: expected NAME=VALUE, got '{ov}'")
-                })?;
+                let (name, val_str) = ov
+                    .split_once('=')
+                    .ok_or_else(|| miette::miette!("--param: expected NAME=VALUE, got '{ov}'"))?;
                 let val: u64 = val_str.parse().map_err(|_| {
                     miette::miette!("--param: value must be an integer, got '{val_str}' in '{ov}'")
                 })?;
                 param_overrides_map.insert(name.to_string(), val);
             }
 
-            let dbg_ports = debug || debug_fsm;  // any debug option implies port logging
-            // --inputs-start-uninit and --check-uninit-ram both imply --check-uninit
+            let dbg_ports = debug || debug_fsm; // any debug option implies port logging
+                                                // --inputs-start-uninit and --check-uninit-ram both imply --check-uninit
             let check_uninit = check_uninit || inputs_start_uninit || check_uninit_ram;
             // --coverage-dat resolves to a path: explicit --coverage-dat=foo
             // → Some(Some("foo")) → "foo"; bare --coverage-dat
             // → Some(None) → default "coverage.dat"; absent → None.
-            let cov_dat_path: Option<String> = coverage_dat.map(|opt| opt.unwrap_or_else(|| "coverage.dat".to_string()));
+            let cov_dat_path: Option<String> =
+                coverage_dat.map(|opt| opt.unwrap_or_else(|| "coverage.dat".to_string()));
             let coverage = coverage || cov_dat_path.is_some();
             if threads > 1 && thread_sim != "parallel" {
-                return Err(miette::miette!("--threads N (N>1) requires --thread-sim parallel"));
+                return Err(miette::miette!(
+                    "--threads N (N>1) requires --thread-sim parallel"
+                ));
             }
             match thread_sim.as_str() {
                 "fsm" => learn_wrap(&arch_files, || {
-                    run_sim(&arch_files, &tb_files, outdir.as_deref(), check_uninit, inputs_start_uninit, check_uninit_ram, cdc_random, wave.as_deref(), dbg_ports, debug_depth, debug_fsm, coverage, cov_dat_path.clone(), false, threads, pybind, test.as_deref(), pybind_module_name.as_deref(), &param_overrides_map)
+                    run_sim(
+                        &arch_files,
+                        &tb_files,
+                        outdir.as_deref(),
+                        check_uninit,
+                        inputs_start_uninit,
+                        check_uninit_ram,
+                        cdc_random,
+                        wave.as_deref(),
+                        dbg_ports,
+                        debug_depth,
+                        debug_fsm,
+                        coverage,
+                        cov_dat_path.clone(),
+                        false,
+                        threads,
+                        pybind,
+                        test.as_deref(),
+                        pybind_module_name.as_deref(),
+                        &param_overrides_map,
+                    )
                 }),
                 "parallel" => learn_wrap(&arch_files, || {
-                    run_sim(&arch_files, &tb_files, outdir.as_deref(), check_uninit, inputs_start_uninit, check_uninit_ram, cdc_random, wave.as_deref(), dbg_ports, debug_depth, debug_fsm, coverage, cov_dat_path.clone(), true, threads, pybind, test.as_deref(), pybind_module_name.as_deref(), &param_overrides_map)
+                    run_sim(
+                        &arch_files,
+                        &tb_files,
+                        outdir.as_deref(),
+                        check_uninit,
+                        inputs_start_uninit,
+                        check_uninit_ram,
+                        cdc_random,
+                        wave.as_deref(),
+                        dbg_ports,
+                        debug_depth,
+                        debug_fsm,
+                        coverage,
+                        cov_dat_path.clone(),
+                        true,
+                        threads,
+                        pybind,
+                        test.as_deref(),
+                        pybind_module_name.as_deref(),
+                        &param_overrides_map,
+                    )
                 }),
                 "both" => {
                     // Cross-check: build + run both fsm and parallel sims
@@ -507,135 +695,132 @@ fn main() -> miette::Result<()> {
                     // traces. Mismatch ⇒ abort with first divergence.
                     run_thread_sim_cross_check(&arch_files, &tb_files, outdir.as_deref())
                 }
-                other => return Err(miette::miette!("--thread-sim: expected `fsm`, `parallel`, or `both`, got `{}`", other)),
+                other => {
+                    return Err(miette::miette!(
+                        "--thread-sim: expected `fsm`, `parallel`, or `both`, got `{}`",
+                        other
+                    ))
+                }
             }
         }
-        Command::Build { files, o, emit_thread_map, auto_thread_asserts, no_inline_deps } => {
+        Command::Build {
+            files,
+            o,
+            emit_thread_map,
+            emit_thread_proof,
+            emit_thread_proof_lean,
+            check_thread_proof_lean,
+            thread_proof_lean_project,
+            auto_thread_asserts,
+            no_inline_deps,
+        } => {
             let files_for_learn = files.clone();
             learn_wrap(&files_for_learn, move || {
-            if matches!(emit_thread_map, Some(Some(_))) && files.len() > 1 && o.is_none() {
-                return Err(miette::miette!(
+                if matches!(emit_thread_map, Some(Some(_))) && files.len() > 1 && o.is_none() {
+                    return Err(miette::miette!(
                     "--emit-thread-map=PATH requires a single combined build output; pass -o or use bare --emit-thread-map for per-file maps"
                 ));
-            }
-            let all_files = resolve_use_imports(&files)?;
-            let ms = MultiSource::from_files(&all_files)?;
-            let thread_map_store = emit_thread_map
-                .as_ref()
-                .map(|_| std::rc::Rc::new(std::cell::RefCell::new(arch::thread_map::ThreadMap::default())));
-            let (ast, symbols, overload_map) = run_check_multi_opts_with_thread_map(
-                &ms,
-                false,
-                auto_thread_asserts,
-                thread_map_store.clone(),
-            )?;
-            let thread_map_sources = thread_map_sources_from_multi(&ms);
+                }
+                if matches!(emit_thread_proof, Some(Some(_))) && files.len() > 1 && o.is_none() {
+                    return Err(miette::miette!(
+                    "--emit-thread-proof=PATH requires a single combined build output; pass -o or use bare --emit-thread-proof for per-file certificates"
+                ));
+                }
+                if matches!(emit_thread_proof_lean, Some(Some(_))) && files.len() > 1 && o.is_none()
+                {
+                    return Err(miette::miette!(
+                    "--emit-thread-proof-lean=PATH requires a single combined build output; pass -o or use bare --emit-thread-proof-lean for per-file Lean certificates"
+                ));
+                }
+                let need_thread_proof_lean =
+                    emit_thread_proof_lean.is_some() || check_thread_proof_lean;
+                let all_files = resolve_use_imports(&files)?;
+                let ms = MultiSource::from_files(&all_files)?;
+                let collect_thread_metadata = emit_thread_map.is_some()
+                    || emit_thread_proof.is_some()
+                    || need_thread_proof_lean;
+                let thread_map_store = collect_thread_metadata.then(|| {
+                    std::rc::Rc::new(std::cell::RefCell::new(
+                        arch::thread_map::ThreadMap::default(),
+                    ))
+                });
+                let (ast, symbols, overload_map) = run_check_multi_opts_with_thread_map(
+                    &ms,
+                    false,
+                    auto_thread_asserts,
+                    thread_map_store.clone(),
+                )?;
+                let thread_map_sources = thread_map_sources_from_multi(&ms);
 
-            let comments = lexer::extract_comments(&ms.combined);
+                let comments = lexer::extract_comments(&ms.combined);
 
-            // --no-inline-deps: only emit constructs from the original
-            // input files, not from auto-discovered dependency files.
-            let original_names: std::collections::HashSet<String> = if no_inline_deps {
-                files.iter()
-                    .map(|f| f.to_string_lossy().to_string())
-                    .collect()
-            } else {
-                std::collections::HashSet::new()
-            };
-
-            if files.len() == 1 || o.is_some() {
-                // Single file or explicit -o: emit one combined SV file
-                let (sv, sdc) = if no_inline_deps {
-                    // Only items from the original input files
-                    let file_items: Vec<_> = ast.items.iter()
-                        .filter(|item| {
-                            let s = item.span().start;
-                            ms.segments.iter().any(|(seg_start, seg_end, fname, _)| {
-                                s >= *seg_start && s < *seg_end
-                                    && original_names.contains(fname)
-                            })
-                        })
-                        .cloned()
-                        .collect();
-                    let mut codegen = Codegen::new(&symbols, &ast, overload_map).with_comments(comments);
-                    let sv = codegen.generate_items(&file_items);
-                    let out_path_hint = o.clone().unwrap_or_else(|| files[0].with_extension("sv"));
-                    let sdc = codegen.emit_sdc(&out_path_hint.to_string_lossy());
-                    (sv, sdc)
+                // --no-inline-deps: only emit constructs from the original
+                // input files, not from auto-discovered dependency files.
+                let original_names: std::collections::HashSet<String> = if no_inline_deps {
+                    files
+                        .iter()
+                        .map(|f| f.to_string_lossy().to_string())
+                        .collect()
                 } else {
-                    let mut codegen = Codegen::new(&symbols, &ast, overload_map).with_comments(comments);
-                    let sv = codegen.generate();
-                    let out_path_hint = o.clone().unwrap_or_else(|| files[0].with_extension("sv"));
-                    let sdc = codegen.emit_sdc(&out_path_hint.to_string_lossy());
-                    (sv, sdc)
+                    std::collections::HashSet::new()
                 };
-                let out_path = o.unwrap_or_else(|| files[0].with_extension("sv"));
-                fs::write(&out_path, &sv).into_diagnostic()?;
-                eprintln!("Wrote {}", out_path.display());
-                if let (Some(req), Some(map_store)) = (&emit_thread_map, &thread_map_store) {
-                    let html_path = req
-                        .clone()
-                        .unwrap_or_else(|| out_path.with_extension("thread.html"));
-                    let map = if no_inline_deps {
-                        let keep: Vec<(usize, usize)> = ms.segments.iter()
-                            .filter_map(|(start, end, filename, _)| {
-                                if original_names.contains(filename) { Some((*start, *end)) } else { None }
+
+                if files.len() == 1 || o.is_some() {
+                    // Single file or explicit -o: emit one combined SV file
+                    let (sv, sdc) = if no_inline_deps {
+                        // Only items from the original input files
+                        let file_items: Vec<_> = ast
+                            .items
+                            .iter()
+                            .filter(|item| {
+                                let s = item.span().start;
+                                ms.segments.iter().any(|(seg_start, seg_end, fname, _)| {
+                                    s >= *seg_start
+                                        && s < *seg_end
+                                        && original_names.contains(fname)
+                                })
                             })
+                            .cloned()
                             .collect();
-                        filter_thread_map_by_ranges(&map_store.borrow(), &keep)
+                        let mut codegen =
+                            Codegen::new(&symbols, &ast, overload_map).with_comments(comments);
+                        let sv = codegen.generate_items(&file_items);
+                        let out_path_hint =
+                            o.clone().unwrap_or_else(|| files[0].with_extension("sv"));
+                        let sdc = codegen.emit_sdc(&out_path_hint.to_string_lossy());
+                        (sv, sdc)
                     } else {
-                        map_store.borrow().clone()
+                        let mut codegen =
+                            Codegen::new(&symbols, &ast, overload_map).with_comments(comments);
+                        let sv = codegen.generate();
+                        let out_path_hint =
+                            o.clone().unwrap_or_else(|| files[0].with_extension("sv"));
+                        let sdc = codegen.emit_sdc(&out_path_hint.to_string_lossy());
+                        (sv, sdc)
                     };
-                    let html = arch::thread_map::render_html(
-                        &map,
-                        &thread_map_sources,
-                        &format!("Thread map for {}", out_path.display()),
-                    );
-                    fs::write(&html_path, html).into_diagnostic()?;
-                    eprintln!("Wrote {}", html_path.display());
-                }
-                // Companion .sdc file: only written if any module contained
-                // a `multicycle <N>` reg. No-op for legacy `.arch` sources.
-                if let Some(sdc_text) = sdc {
-                    let sdc_path = out_path.with_extension("sdc");
-                    fs::write(&sdc_path, &sdc_text).into_diagnostic()?;
-                    eprintln!("Wrote {}", sdc_path.display());
-                }
-            } else {
-                // Multi-file: emit one .sv per .arch input file
-                for (seg_start, seg_end, filename, _) in &ms.segments {
-                    // --no-inline-deps: skip dependency files not in the original input set
-                    if no_inline_deps && !original_names.contains(filename.as_str()) {
-                        continue;
-                    }
-                    // Collect items whose span falls within this file's segment
-                    let file_items: Vec<_> = ast.items.iter()
-                        .filter(|item| {
-                            let s = item.span().start;
-                            s >= *seg_start && s < *seg_end
-                        })
-                        .cloned()
-                        .collect();
-
-                    if file_items.is_empty() {
-                        continue; // skip domain-only files etc. that produce no SV
-                    }
-
-                    // Filter comments belonging to this file's segment
-                    let file_comments: Vec<_> = comments.iter()
-                        .filter(|(span, _)| span.start >= *seg_start && span.start < *seg_end)
-                        .cloned()
-                        .collect();
-
-                    let mut codegen = Codegen::new(&symbols, &ast, overload_map.clone()).with_comments(file_comments);
-                    let sv = codegen.generate_items(&file_items);
-
-                    let out_path = std::path::Path::new(filename).with_extension("sv");
+                    let out_path = o.unwrap_or_else(|| files[0].with_extension("sv"));
                     fs::write(&out_path, &sv).into_diagnostic()?;
                     eprintln!("Wrote {}", out_path.display());
-                    if let (Some(None), Some(map_store)) = (&emit_thread_map, &thread_map_store) {
-                        let map = filter_thread_map_by_ranges(&map_store.borrow(), &[(*seg_start, *seg_end)]);
-                        let html_path = out_path.with_extension("thread.html");
+                    if let (Some(req), Some(map_store)) = (&emit_thread_map, &thread_map_store) {
+                        let html_path = req
+                            .clone()
+                            .unwrap_or_else(|| out_path.with_extension("thread.html"));
+                        let map = if no_inline_deps {
+                            let keep: Vec<(usize, usize)> = ms
+                                .segments
+                                .iter()
+                                .filter_map(|(start, end, filename, _)| {
+                                    if original_names.contains(filename) {
+                                        Some((*start, *end))
+                                    } else {
+                                        None
+                                    }
+                                })
+                                .collect();
+                            filter_thread_map_by_ranges(&map_store.borrow(), &keep)
+                        } else {
+                            map_store.borrow().clone()
+                        };
                         let html = arch::thread_map::render_html(
                             &map,
                             &thread_map_sources,
@@ -644,43 +829,257 @@ fn main() -> miette::Result<()> {
                         fs::write(&html_path, html).into_diagnostic()?;
                         eprintln!("Wrote {}", html_path.display());
                     }
-                    // Companion .sdc per-file: only if this file's items
-                    // declared `multicycle <N>` regs.
-                    if let Some(sdc_text) = codegen.emit_sdc(&out_path.to_string_lossy()) {
+                    if let (Some(req), Some(map_store)) = (&emit_thread_proof, &thread_map_store) {
+                        let proof_path = req
+                            .clone()
+                            .unwrap_or_else(|| out_path.with_extension("thread-proof.json"));
+                        let map = if no_inline_deps {
+                            let keep: Vec<(usize, usize)> = ms
+                                .segments
+                                .iter()
+                                .filter_map(|(start, end, filename, _)| {
+                                    if original_names.contains(filename) {
+                                        Some((*start, *end))
+                                    } else {
+                                        None
+                                    }
+                                })
+                                .collect();
+                            filter_thread_map_by_ranges(&map_store.borrow(), &keep)
+                        } else {
+                            map_store.borrow().clone()
+                        };
+                        let json = arch::thread_proof_cert::render_json(&map);
+                        fs::write(&proof_path, json).into_diagnostic()?;
+                        eprintln!("Wrote {}", proof_path.display());
+                    }
+                    if need_thread_proof_lean {
+                        let map_store = thread_map_store
+                            .as_ref()
+                            .expect("thread map store must exist for Lean proof emission");
+                        let proof_path = emit_thread_proof_lean
+                            .as_ref()
+                            .and_then(|req| req.clone())
+                            .unwrap_or_else(|| out_path.with_extension("thread-proof.lean"));
+                        let map = if no_inline_deps {
+                            let keep: Vec<(usize, usize)> = ms
+                                .segments
+                                .iter()
+                                .filter_map(|(start, end, filename, _)| {
+                                    if original_names.contains(filename) {
+                                        Some((*start, *end))
+                                    } else {
+                                        None
+                                    }
+                                })
+                                .collect();
+                            filter_thread_map_by_ranges(&map_store.borrow(), &keep)
+                        } else {
+                            map_store.borrow().clone()
+                        };
+                        let lean =
+                            arch::thread_proof_cert::render_lean_checked(&map).map_err(|err| {
+                                miette::miette!("thread proof Lean emission failed: {err}")
+                            })?;
+                        fs::write(&proof_path, lean).into_diagnostic()?;
+                        eprintln!("Wrote {}", proof_path.display());
+                        if check_thread_proof_lean {
+                            check_thread_proof_lean_file(
+                                &proof_path,
+                                thread_proof_lean_project.as_deref(),
+                            )?;
+                        }
+                    }
+                    // Companion .sdc file: only written if any module contained
+                    // a `multicycle <N>` reg. No-op for legacy `.arch` sources.
+                    if let Some(sdc_text) = sdc {
                         let sdc_path = out_path.with_extension("sdc");
                         fs::write(&sdc_path, &sdc_text).into_diagnostic()?;
                         eprintln!("Wrote {}", sdc_path.display());
                     }
-                }
-            }
+                } else {
+                    // Multi-file: emit one .sv per .arch input file
+                    for (seg_start, seg_end, filename, _) in &ms.segments {
+                        // --no-inline-deps: skip dependency files not in the original input set
+                        if no_inline_deps && !original_names.contains(filename.as_str()) {
+                            continue;
+                        }
+                        // Collect items whose span falls within this file's segment
+                        let file_items: Vec<_> = ast
+                            .items
+                            .iter()
+                            .filter(|item| {
+                                let s = item.span().start;
+                                s >= *seg_start && s < *seg_end
+                            })
+                            .cloned()
+                            .collect();
 
-            // Emit .archi interface files alongside .sv (for separate compilation)
-            for item in &ast.items {
-                // Don't re-emit .archi for an interface stub we just
-                // loaded — we'd be overwriting the source file we
-                // read. Covers module + every ConstructCommon-bearing
-                // variant via `Item::is_interface`.
-                if item.is_interface() { continue; }
-                if let Some(content) = arch::interface::emit_interface(item) {
-                    let name = &item.as_construct().name().name;
-                    // Write .archi next to the .sv output
-                    let archi_dir = files[0].parent()
-                        .unwrap_or(std::path::Path::new(".")).to_path_buf();
-                    let archi_path = archi_dir.join(format!("{name}.archi"));
-                    fs::write(&archi_path, &content).into_diagnostic()?;
-                    eprintln!("Wrote {}", archi_path.display());
-                }
-            }
+                        if file_items.is_empty() {
+                            continue; // skip domain-only files etc. that produce no SV
+                        }
 
-            Ok(())
+                        // Filter comments belonging to this file's segment
+                        let file_comments: Vec<_> = comments
+                            .iter()
+                            .filter(|(span, _)| span.start >= *seg_start && span.start < *seg_end)
+                            .cloned()
+                            .collect();
+
+                        let mut codegen = Codegen::new(&symbols, &ast, overload_map.clone())
+                            .with_comments(file_comments);
+                        let sv = codegen.generate_items(&file_items);
+
+                        let out_path = std::path::Path::new(filename).with_extension("sv");
+                        fs::write(&out_path, &sv).into_diagnostic()?;
+                        eprintln!("Wrote {}", out_path.display());
+                        if let (Some(None), Some(map_store)) = (&emit_thread_map, &thread_map_store)
+                        {
+                            let map = filter_thread_map_by_ranges(
+                                &map_store.borrow(),
+                                &[(*seg_start, *seg_end)],
+                            );
+                            let html_path = out_path.with_extension("thread.html");
+                            let html = arch::thread_map::render_html(
+                                &map,
+                                &thread_map_sources,
+                                &format!("Thread map for {}", out_path.display()),
+                            );
+                            fs::write(&html_path, html).into_diagnostic()?;
+                            eprintln!("Wrote {}", html_path.display());
+                        }
+                        if let (Some(None), Some(map_store)) =
+                            (&emit_thread_proof, &thread_map_store)
+                        {
+                            let map = filter_thread_map_by_ranges(
+                                &map_store.borrow(),
+                                &[(*seg_start, *seg_end)],
+                            );
+                            let proof_path = out_path.with_extension("thread-proof.json");
+                            let json = arch::thread_proof_cert::render_json(&map);
+                            fs::write(&proof_path, json).into_diagnostic()?;
+                            eprintln!("Wrote {}", proof_path.display());
+                        }
+                        if need_thread_proof_lean {
+                            let map_store = thread_map_store
+                                .as_ref()
+                                .expect("thread map store must exist for Lean proof emission");
+                            let map = filter_thread_map_by_ranges(
+                                &map_store.borrow(),
+                                &[(*seg_start, *seg_end)],
+                            );
+                            let proof_path = out_path.with_extension("thread-proof.lean");
+                            let lean = arch::thread_proof_cert::render_lean_checked(&map).map_err(
+                                |err| miette::miette!("thread proof Lean emission failed: {err}"),
+                            )?;
+                            fs::write(&proof_path, lean).into_diagnostic()?;
+                            eprintln!("Wrote {}", proof_path.display());
+                            if check_thread_proof_lean {
+                                check_thread_proof_lean_file(
+                                    &proof_path,
+                                    thread_proof_lean_project.as_deref(),
+                                )?;
+                            }
+                        }
+                        // Companion .sdc per-file: only if this file's items
+                        // declared `multicycle <N>` regs.
+                        if let Some(sdc_text) = codegen.emit_sdc(&out_path.to_string_lossy()) {
+                            let sdc_path = out_path.with_extension("sdc");
+                            fs::write(&sdc_path, &sdc_text).into_diagnostic()?;
+                            eprintln!("Wrote {}", sdc_path.display());
+                        }
+                    }
+                }
+
+                // Emit .archi interface files alongside .sv (for separate compilation)
+                for item in &ast.items {
+                    // Don't re-emit .archi for an interface stub we just
+                    // loaded — we'd be overwriting the source file we
+                    // read. Covers module + every ConstructCommon-bearing
+                    // variant via `Item::is_interface`.
+                    if item.is_interface() {
+                        continue;
+                    }
+                    if let Some(content) = arch::interface::emit_interface(item) {
+                        let name = &item.as_construct().name().name;
+                        // Write .archi next to the .sv output
+                        let archi_dir = files[0]
+                            .parent()
+                            .unwrap_or(std::path::Path::new("."))
+                            .to_path_buf();
+                        let archi_path = archi_dir.join(format!("{name}.archi"));
+                        fs::write(&archi_path, &content).into_diagnostic()?;
+                        eprintln!("Wrote {}", archi_path.display());
+                    }
+                }
+
+                Ok(())
             })
         }
-        Command::Formal { files, top, bound, solver, emit_smt, timeout, auto_thread_asserts } => {
+        Command::Formal {
+            files,
+            top,
+            bound,
+            solver,
+            emit_smt,
+            emit_thread_proof_lean,
+            check_thread_proof_lean,
+            thread_proof_lean_project,
+            thread_proof_only,
+            timeout,
+            auto_thread_asserts,
+        } => {
             let files_for_learn = files.clone();
             learn_wrap(&files_for_learn, move || {
                 let all_files = resolve_use_imports(&files)?;
                 let ms = MultiSource::from_files(&all_files)?;
-                let (ast, symbols, _overload_map) = run_check_multi_opts(&ms, false, auto_thread_asserts)?;
+                let need_thread_proof_lean =
+                    emit_thread_proof_lean.is_some() || check_thread_proof_lean;
+                if thread_proof_only && !need_thread_proof_lean {
+                    return Err(miette::miette!(
+                        "--thread-proof-only requires --emit-thread-proof-lean or --check-thread-proof-lean"
+                    ));
+                }
+                if thread_proof_only && emit_smt.is_some() {
+                    return Err(miette::miette!(
+                        "--thread-proof-only skips SMT-LIB2 generation; remove --emit-smt"
+                    ));
+                }
+                let thread_map_store = need_thread_proof_lean.then(|| {
+                    std::rc::Rc::new(std::cell::RefCell::new(
+                        arch::thread_map::ThreadMap::default(),
+                    ))
+                });
+                let (ast, symbols, _overload_map) = run_check_multi_opts_with_thread_map(
+                    &ms,
+                    false,
+                    auto_thread_asserts,
+                    thread_map_store.clone(),
+                )?;
+                if need_thread_proof_lean {
+                    let map_store = thread_map_store
+                        .as_ref()
+                        .expect("thread map store must exist for Lean proof emission");
+                    let proof_path = emit_thread_proof_lean
+                        .as_ref()
+                        .and_then(|req| req.clone())
+                        .unwrap_or_else(|| files[0].with_extension("thread-proof.lean"));
+                    let lean = arch::thread_proof_cert::render_lean_checked(&map_store.borrow())
+                        .map_err(|err| {
+                            miette::miette!("thread proof Lean emission failed: {err}")
+                        })?;
+                    fs::write(&proof_path, lean).into_diagnostic()?;
+                    eprintln!("Wrote {}", proof_path.display());
+                    if check_thread_proof_lean {
+                        check_thread_proof_lean_file(
+                            &proof_path,
+                            thread_proof_lean_project.as_deref(),
+                        )?;
+                    }
+                }
+                if thread_proof_only {
+                    return Ok(());
+                }
 
                 let args = formal::FormalArgs {
                     top: top.clone(),
@@ -689,9 +1088,8 @@ fn main() -> miette::Result<()> {
                     emit_smt: emit_smt.clone(),
                     timeout,
                 };
-                let report = formal::run(&ast, &symbols, &args).map_err(|err| {
-                    ms.report_error(err)
-                })?;
+                let report =
+                    formal::run(&ast, &symbols, &args).map_err(|err| ms.report_error(err))?;
                 std::process::exit(report.exit_code());
             })
         }
@@ -706,14 +1104,26 @@ fn run_thread_sim_cross_check(
     tb_files: &[PathBuf],
     outdir: Option<&std::path::Path>,
 ) -> miette::Result<()> {
-    let base = outdir.map(|p| p.to_path_buf()).unwrap_or_else(|| PathBuf::from("arch_sim_build"));
-    let fsm_dir = base.with_file_name(format!("{}_fsm", base.file_name().and_then(|s| s.to_str()).unwrap_or("arch_sim_build")));
-    let par_dir = base.with_file_name(format!("{}_par", base.file_name().and_then(|s| s.to_str()).unwrap_or("arch_sim_build")));
+    let base = outdir
+        .map(|p| p.to_path_buf())
+        .unwrap_or_else(|| PathBuf::from("arch_sim_build"));
+    let fsm_dir = base.with_file_name(format!(
+        "{}_fsm",
+        base.file_name()
+            .and_then(|s| s.to_str())
+            .unwrap_or("arch_sim_build")
+    ));
+    let par_dir = base.with_file_name(format!(
+        "{}_par",
+        base.file_name()
+            .and_then(|s| s.to_str())
+            .unwrap_or("arch_sim_build")
+    ));
 
     eprintln!("=== arch sim --thread-sim both: building fsm path ===");
-    let fsm_trace = build_and_capture(arch_files, tb_files, &fsm_dir, /*parallel=*/false)?;
+    let fsm_trace = build_and_capture(arch_files, tb_files, &fsm_dir, /*parallel=*/ false)?;
     eprintln!("=== arch sim --thread-sim both: building parallel path ===");
-    let par_trace = build_and_capture(arch_files, tb_files, &par_dir, /*parallel=*/true)?;
+    let par_trace = build_and_capture(arch_files, tb_files, &par_dir, /*parallel=*/ true)?;
 
     // Filter to just the [cycle][Mod.port](in/out) debug lines, ignore
     // TB stdout. The fsm path uses --debug --depth N to optionally
@@ -731,7 +1141,10 @@ fn run_thread_sim_cross_check(
     let par_lines = extract_trace(&par_trace);
 
     if fsm_lines == par_lines {
-        eprintln!("=== Cross-check PASS: {} port-change events match ===", fsm_lines.len());
+        eprintln!(
+            "=== Cross-check PASS: {} port-change events match ===",
+            fsm_lines.len()
+        );
         return Ok(());
     }
 
@@ -748,8 +1161,11 @@ fn run_thread_sim_cross_check(
             return Err(miette::miette!("--thread-sim both: cross-check failed"));
         }
     }
-    Err(miette::miette!("--thread-sim both: trace lengths differ ({} fsm vs {} parallel)",
-        fsm_lines.len(), par_lines.len()))
+    Err(miette::miette!(
+        "--thread-sim both: trace lengths differ ({} fsm vs {} parallel)",
+        fsm_lines.len(),
+        par_lines.len()
+    ))
 }
 
 /// Helper for run_thread_sim_cross_check: build a sim binary in `dir`
@@ -770,14 +1186,24 @@ fn build_and_capture(
 
     // Generate models + verilated stubs into dir.
     run_sim_opts(
-        arch_files, tb_files, Some(dir),
-        /*check_uninit*/ false, /*inputs_start_uninit*/ false, /*check_uninit_ram*/ false,
-        /*cdc_random*/ false, /*wave*/ None,
-        /*debug*/ true, /*debug_depth*/ 1, /*debug_fsm*/ false,
-        /*coverage*/ false, /*coverage_dat*/ None,
+        arch_files,
+        tb_files,
+        Some(dir),
+        /*check_uninit*/ false,
+        /*inputs_start_uninit*/ false,
+        /*check_uninit_ram*/ false,
+        /*cdc_random*/ false,
+        /*wave*/ None,
+        /*debug*/ true,
+        /*debug_depth*/ 1,
+        /*debug_fsm*/ false,
+        /*coverage*/ false,
+        /*coverage_dat*/ None,
         parallel,
         /*threads*/ 1,
-        /*pybind*/ false, /*test_file*/ None, /*pybind_module_name_override*/ None,
+        /*pybind*/ false,
+        /*test_file*/ None,
+        /*pybind_module_name_override*/ None,
         /*no_exit*/ true,
         &std::collections::HashMap::new(),
     )?;
@@ -814,9 +1240,28 @@ fn run_sim(
     pybind_module_name_override: Option<&str>,
     param_overrides: &std::collections::HashMap<String, u64>,
 ) -> miette::Result<()> {
-    run_sim_opts(arch_files, tb_files, outdir, check_uninit, inputs_start_uninit, check_uninit_ram,
-        cdc_random, wave, debug, debug_depth, debug_fsm, coverage, coverage_dat, thread_sim_parallel,
-        threads, pybind, test_file, pybind_module_name_override, /*no_exit=*/false, param_overrides)
+    run_sim_opts(
+        arch_files,
+        tb_files,
+        outdir,
+        check_uninit,
+        inputs_start_uninit,
+        check_uninit_ram,
+        cdc_random,
+        wave,
+        debug,
+        debug_depth,
+        debug_fsm,
+        coverage,
+        coverage_dat,
+        thread_sim_parallel,
+        threads,
+        pybind,
+        test_file,
+        pybind_module_name_override,
+        /*no_exit=*/ false,
+        param_overrides,
+    )
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -845,7 +1290,11 @@ fn run_sim_opts(
     // 1. Parse + type-check
     let all_files = resolve_use_imports(arch_files)?;
     let ms = MultiSource::from_files(&all_files)?;
-    let (ast, symbols, overload_map) = run_check_multi_opts(&ms, thread_sim_parallel, /*auto_thread_asserts=*/ false)?;
+    let (ast, symbols, overload_map) = run_check_multi_opts(
+        &ms,
+        thread_sim_parallel,
+        /*auto_thread_asserts=*/ false,
+    )?;
 
     // 2. Set up output directory
     let build_dir = outdir
@@ -867,12 +1316,19 @@ fn run_sim_opts(
         for item in &ast.items {
             match item {
                 arch::ast::Item::Module(m) => {
-                    let has_thread = m.body.iter().any(|i| matches!(i, arch::ast::ModuleBodyItem::Thread(_)));
+                    let has_thread = m
+                        .body
+                        .iter()
+                        .any(|i| matches!(i, arch::ast::ModuleBodyItem::Thread(_)));
                     if has_thread {
                         let model = arch::sim_codegen::thread_sim::gen_module_thread_with_warnings(
-                            m, debug, wave.is_some(), threads, &mut thread_sim_warnings,
+                            m,
+                            debug,
+                            wave.is_some(),
+                            threads,
+                            &mut thread_sim_warnings,
                         )
-                            .map_err(|e| miette::miette!("thread sim: {}", e))?;
+                        .map_err(|e| miette::miette!("thread sim: {}", e))?;
                         out.push(model);
                     } else {
                         regular_items.push(item.clone());
@@ -888,38 +1344,51 @@ fn run_sim_opts(
             let (filename, _, local_offset) = ms.locate(w.span.start);
             eprintln!("warning: {} ({}:{})", w.message, filename, local_offset);
         }
-        if regular_items.iter().any(|item| matches!(
-            item,
-            arch::ast::Item::Module(_)
-                | arch::ast::Item::Fsm(_)
-                | arch::ast::Item::Fifo(_)
-                | arch::ast::Item::Ram(_)
-                | arch::ast::Item::Cam(_)
-                | arch::ast::Item::Counter(_)
-                | arch::ast::Item::Arbiter(_)
-                | arch::ast::Item::Regfile(_)
-                | arch::ast::Item::Pipeline(_)
-                | arch::ast::Item::Synchronizer(_)
-                | arch::ast::Item::Clkgate(_)
-                | arch::ast::Item::Function(_)
-                | arch::ast::Item::Package(_)
-                | arch::ast::Item::Struct(_)
-                | arch::ast::Item::Enum(_)
-        )) {
+        if regular_items.iter().any(|item| {
+            matches!(
+                item,
+                arch::ast::Item::Module(_)
+                    | arch::ast::Item::Fsm(_)
+                    | arch::ast::Item::Fifo(_)
+                    | arch::ast::Item::Ram(_)
+                    | arch::ast::Item::Cam(_)
+                    | arch::ast::Item::Counter(_)
+                    | arch::ast::Item::Arbiter(_)
+                    | arch::ast::Item::Regfile(_)
+                    | arch::ast::Item::Pipeline(_)
+                    | arch::ast::Item::Synchronizer(_)
+                    | arch::ast::Item::Clkgate(_)
+                    | arch::ast::Item::Function(_)
+                    | arch::ast::Item::Package(_)
+                    | arch::ast::Item::Struct(_)
+                    | arch::ast::Item::Enum(_)
+            )
+        }) {
             let regular_ast = arch::ast::SourceFile {
                 items: regular_items,
                 inner_doc: ast.inner_doc.clone(),
                 frontmatter: ast.frontmatter.clone(),
             };
-            let mut sim = SimCodegen::new(&symbols, &regular_ast, overload_map.clone()).check_uninit(check_uninit).inputs_start_uninit(inputs_start_uninit).check_uninit_ram(check_uninit_ram).cdc_random(cdc_random).debug(debug, debug_depth).with_debug_fsm(debug_fsm).coverage(coverage).coverage_dat(coverage_dat.clone());
+            let mut sim = SimCodegen::new(&symbols, &regular_ast, overload_map.clone())
+                .check_uninit(check_uninit)
+                .inputs_start_uninit(inputs_start_uninit)
+                .check_uninit_ram(check_uninit_ram)
+                .cdc_random(cdc_random)
+                .debug(debug, debug_depth)
+                .with_debug_fsm(debug_fsm)
+                .coverage(coverage)
+                .coverage_dat(coverage_dat.clone());
             if coverage {
-                let segs: Vec<(usize, String, String)> = ms.segments.iter()
+                let segs: Vec<(usize, String, String)> = ms
+                    .segments
+                    .iter()
                     .map(|(start, _end, name, src)| (*start, name.clone(), src.clone()))
                     .collect();
                 sim = sim.with_source_map(arch::sim_codegen::SourceMap::new(segs));
             }
             for model in sim.generate() {
-                if model.class_name == "VStructs" && out.iter().any(|m| m.class_name == "VStructs") {
+                if model.class_name == "VStructs" && out.iter().any(|m| m.class_name == "VStructs")
+                {
                     continue;
                 }
                 if !out.iter().any(|m| m.class_name == model.class_name) {
@@ -929,11 +1398,21 @@ fn run_sim_opts(
         }
         out
     } else {
-        let mut sim = SimCodegen::new(&symbols, &ast, overload_map.clone()).check_uninit(check_uninit).inputs_start_uninit(inputs_start_uninit).check_uninit_ram(check_uninit_ram).cdc_random(cdc_random).debug(debug, debug_depth).with_debug_fsm(debug_fsm).coverage(coverage).coverage_dat(coverage_dat.clone());
+        let mut sim = SimCodegen::new(&symbols, &ast, overload_map.clone())
+            .check_uninit(check_uninit)
+            .inputs_start_uninit(inputs_start_uninit)
+            .check_uninit_ram(check_uninit_ram)
+            .cdc_random(cdc_random)
+            .debug(debug, debug_depth)
+            .with_debug_fsm(debug_fsm)
+            .coverage(coverage)
+            .coverage_dat(coverage_dat.clone());
         if coverage {
             // Build a SourceMap so the coverage dumper can render
             // file:line instead of opaque branch[N] ordinals.
-            let segs: Vec<(usize, String, String)> = ms.segments.iter()
+            let segs: Vec<(usize, String, String)> = ms
+                .segments
+                .iter()
                 .map(|(start, _end, name, src)| (*start, name.clone(), src.clone()))
                 .collect();
             sim = sim.with_source_map(arch::sim_codegen::SourceMap::new(segs));
@@ -948,34 +1427,50 @@ fn run_sim_opts(
     let mut generated_cpps: Vec<PathBuf> = Vec::new();
 
     for model in &models {
-        let h_path   = build_dir.join(format!("{}.h",   model.class_name));
+        let h_path = build_dir.join(format!("{}.h", model.class_name));
         let cpp_path = build_dir.join(format!("{}.cpp", model.class_name));
-        fs::write(&h_path,   &model.header).into_diagnostic()?;
+        fs::write(&h_path, &model.header).into_diagnostic()?;
         fs::write(&cpp_path, &model.impl_).into_diagnostic()?;
         eprintln!("Generated {}", cpp_path.display());
         generated_cpps.push(cpp_path);
     }
 
     // 4. Write verilated.h / verilated.cpp stubs
-    let verilated_h   = build_dir.join("verilated.h");
+    let verilated_h = build_dir.join("verilated.h");
     let verilated_cpp = build_dir.join("verilated.cpp");
-    fs::write(&verilated_h,   SimCodegen::verilated_h()).into_diagnostic()?;
+    fs::write(&verilated_h, SimCodegen::verilated_h()).into_diagnostic()?;
     fs::write(&verilated_cpp, SimCodegen::verilated_cpp()).into_diagnostic()?;
     generated_cpps.push(verilated_cpp);
 
     // 4b. Thread sim runtime header (only used under --thread-sim parallel,
     // but emit unconditionally — cheap and keeps the build dir self-contained).
     let arch_thread_rt_h = build_dir.join("arch_thread_rt.h");
-    fs::write(&arch_thread_rt_h, arch::sim_codegen::thread_sim::arch_thread_rt_h()).into_diagnostic()?;
+    fs::write(
+        &arch_thread_rt_h,
+        arch::sim_codegen::thread_sim::arch_thread_rt_h(),
+    )
+    .into_diagnostic()?;
 
     // ── Pybind11 mode ────────────────────────────────────────────────────
     if pybind {
         if thread_sim_parallel {
-            return Err(miette::miette!("--pybind not yet supported with --thread-sim parallel"));
+            return Err(miette::miette!(
+                "--pybind not yet supported with --thread-sim parallel"
+            ));
         }
-        let mut sim = SimCodegen::new(&symbols, &ast, overload_map.clone()).check_uninit(check_uninit).inputs_start_uninit(inputs_start_uninit).check_uninit_ram(check_uninit_ram).cdc_random(cdc_random).debug(debug, debug_depth).with_debug_fsm(debug_fsm).coverage(coverage).coverage_dat(coverage_dat.clone());
+        let mut sim = SimCodegen::new(&symbols, &ast, overload_map.clone())
+            .check_uninit(check_uninit)
+            .inputs_start_uninit(inputs_start_uninit)
+            .check_uninit_ram(check_uninit_ram)
+            .cdc_random(cdc_random)
+            .debug(debug, debug_depth)
+            .with_debug_fsm(debug_fsm)
+            .coverage(coverage)
+            .coverage_dat(coverage_dat.clone());
         if coverage {
-            let segs: Vec<(usize, String, String)> = ms.segments.iter()
+            let segs: Vec<(usize, String, String)> = ms
+                .segments
+                .iter()
                 .map(|(start, _end, name, src)| (*start, name.clone(), src.clone()))
                 .collect();
             sim = sim.with_source_map(arch::sim_codegen::SourceMap::new(segs));
@@ -998,7 +1493,8 @@ fn run_sim_opts(
         // Prefer the LAST wrapper whose class name doesn't start with
         // `V_`; fall back to wrapper[0] for designs without thread-
         // submodule lowering (the existing default shape).
-        let user_top_idx = pybind_wrappers.iter()
+        let user_top_idx = pybind_wrappers
+            .iter()
             .rposition(|w| !w.class_name.starts_with("V_"))
             .unwrap_or(0);
 
@@ -1015,15 +1511,17 @@ fn run_sim_opts(
         let mut pybind_cpps: Vec<PathBuf> = Vec::new();
         let mut pybind_module_name = String::new();
         for (i, wrapper) in pybind_wrappers.iter().enumerate() {
-            let (class_name, impl_src) = if i == user_top_idx && pybind_module_name_override.is_some() {
-                let new_name = &effective_first_name;
-                let retargeted = wrapper.impl_
-                    .replace(&format!("PYBIND11_MODULE({}, m)", default_first_name),
-                             &format!("PYBIND11_MODULE({}, m)", new_name));
-                (new_name.clone(), retargeted)
-            } else {
-                (wrapper.class_name.clone(), wrapper.impl_.clone())
-            };
+            let (class_name, impl_src) =
+                if i == user_top_idx && pybind_module_name_override.is_some() {
+                    let new_name = &effective_first_name;
+                    let retargeted = wrapper.impl_.replace(
+                        &format!("PYBIND11_MODULE({}, m)", default_first_name),
+                        &format!("PYBIND11_MODULE({}, m)", new_name),
+                    );
+                    (new_name.clone(), retargeted)
+                } else {
+                    (wrapper.class_name.clone(), wrapper.impl_.clone())
+                };
             let cpp_path = build_dir.join(format!("{}.cpp", class_name));
             fs::write(&cpp_path, &impl_src).into_diagnostic()?;
             eprintln!("Generated pybind11 wrapper: {}", cpp_path.display());
@@ -1070,21 +1568,28 @@ fn run_sim_opts(
         // Precompile shared C++ into .o.
         let mut shared_objs: Vec<PathBuf> = Vec::new();
         for cpp in &generated_cpps {
-            let obj = build_dir.join(
-                cpp.file_stem().unwrap().to_string_lossy().into_owned() + ".o",
-            );
+            let obj =
+                build_dir.join(cpp.file_stem().unwrap().to_string_lossy().into_owned() + ".o");
             let mut cmd = std::process::Command::new("g++");
             cmd.arg(cxx_std_flag())
-               .arg("-O2")
-               .arg("-fPIC")
-               .arg("-c")
-               .arg("-I").arg(&build_dir);
-            for flag in py_includes.split_whitespace() { cmd.arg(flag); }
-            for (name, val) in param_overrides { cmd.arg(format!("-D{name}={val}")); }
+                .arg("-O2")
+                .arg("-fPIC")
+                .arg("-c")
+                .arg("-I")
+                .arg(&build_dir);
+            for flag in py_includes.split_whitespace() {
+                cmd.arg(flag);
+            }
+            for (name, val) in param_overrides {
+                cmd.arg(format!("-D{name}={val}"));
+            }
             cmd.arg(cpp).arg("-o").arg(&obj);
             let status = cmd.status().into_diagnostic()?;
             if !status.success() {
-                eprintln!("Pybind11 compilation failed (shared .o for {})", cpp.display());
+                eprintln!(
+                    "Pybind11 compilation failed (shared .o for {})",
+                    cpp.display()
+                );
                 std::process::exit(1);
             }
             shared_objs.push(obj);
@@ -1105,14 +1610,21 @@ fn run_sim_opts(
             let so_path = build_dir.join(format!("{class_name}{ext_suffix}"));
             let mut cmd = std::process::Command::new("g++");
             cmd.arg(cxx_std_flag())
-               .arg("-O2")
-               .arg("-shared")
-               .arg("-fPIC")
-               .arg("-I").arg(&build_dir);
-            for flag in py_includes.split_whitespace() { cmd.arg(flag); }
-            for (name, val) in param_overrides { cmd.arg(format!("-D{name}={val}")); }
+                .arg("-O2")
+                .arg("-shared")
+                .arg("-fPIC")
+                .arg("-I")
+                .arg(&build_dir);
+            for flag in py_includes.split_whitespace() {
+                cmd.arg(flag);
+            }
+            for (name, val) in param_overrides {
+                cmd.arg(format!("-D{name}={val}"));
+            }
             cmd.arg(cpp_path);
-            for obj in &shared_objs { cmd.arg(obj); }
+            for obj in &shared_objs {
+                cmd.arg(obj);
+            }
             cmd.arg("-o").arg(&so_path);
             #[cfg(target_os = "macos")]
             cmd.arg("-undefined").arg("dynamic_lookup");
@@ -1141,11 +1653,14 @@ fn run_sim_opts(
             // `<arch-com>/target/{debug,release}/arch`, so go up twice and
             // look for a sibling `python/` directory. Fall back to
             // `$ARCH_PYTHON_DIR` or the current cwd for development layouts.
-            let python_dir = std::env::current_exe().ok()
-                .and_then(|exe| exe.parent()
-                    .and_then(|p| p.parent())
-                    .and_then(|p| p.parent())
-                    .map(|p| p.join("python")))
+            let python_dir = std::env::current_exe()
+                .ok()
+                .and_then(|exe| {
+                    exe.parent()
+                        .and_then(|p| p.parent())
+                        .and_then(|p| p.parent())
+                        .map(|p| p.join("python"))
+                })
                 .filter(|p| p.is_dir())
                 .or_else(|| std::env::var("ARCH_PYTHON_DIR").ok().map(PathBuf::from))
                 .or_else(|| std::env::current_dir().ok().map(|cwd| cwd.join("python")))
@@ -1158,20 +1673,31 @@ fn run_sim_opts(
 
             let pythonpath = format!("{shim_str}:{cocotb_dir}:{build_str}");
 
-            let test_path_abs = test_path.canonicalize().unwrap_or_else(|_| test_path.to_path_buf());
-            let test_dir = test_path_abs.parent().map(|p| p.to_path_buf()).unwrap_or_default();
-            let test_module_name = test_path_abs.file_stem()
-                .unwrap_or_default().to_string_lossy().into_owned();
+            let test_path_abs = test_path
+                .canonicalize()
+                .unwrap_or_else(|_| test_path.to_path_buf());
+            let test_dir = test_path_abs
+                .parent()
+                .map(|p| p.to_path_buf())
+                .unwrap_or_default();
+            let test_module_name = test_path_abs
+                .file_stem()
+                .unwrap_or_default()
+                .to_string_lossy()
+                .into_owned();
 
             // Derive the model class name. The class is the pybind module
             // name minus the `_pybind` suffix (matches emit_pybind_module).
-            let model_class = pybind_module_name.strip_suffix("_pybind")
-                .unwrap_or(&pybind_module_name).to_string();
+            let model_class = pybind_module_name
+                .strip_suffix("_pybind")
+                .unwrap_or(&pybind_module_name)
+                .to_string();
 
             // Generated runner: runs user __main__, then dispatches any
             // registered @cocotb.test() functions.
             let runner_py = build_dir.join("_arch_cocotb_runner.py");
-            let runner_src = format!(r#"import sys
+            let runner_src = format!(
+                r#"import sys
 import runpy
 import importlib
 from pathlib import Path
@@ -1211,8 +1737,8 @@ from arch_cocotb.runner import run_tests
 ok = run_tests(model_class, TEST_MODULE)
 sys.exit(0 if ok else 1)
 "#,
-                test_path   = test_path_abs.display(),
-                test_dir    = test_dir.display(),
+                test_path = test_path_abs.display(),
+                test_dir = test_dir.display(),
                 test_module = test_module_name,
                 pybind_module = pybind_module_name,
                 model_class = model_class,
@@ -1233,10 +1759,17 @@ sys.exit(0 if ok else 1)
 
     // ── Normal sim mode (C++ testbench) ──────────────────────────────────
     if tb_files.is_empty() {
-        eprintln!("No testbench files supplied — generated models are in {}/", build_dir.display());
-        eprintln!("Compile with: g++ {} {}/verilated.cpp {}/V*.cpp <your_tb.cpp> -I{} -o sim_out",
+        eprintln!(
+            "No testbench files supplied — generated models are in {}/",
+            build_dir.display()
+        );
+        eprintln!(
+            "Compile with: g++ {} {}/verilated.cpp {}/V*.cpp <your_tb.cpp> -I{} -o sim_out",
             cxx_std_flag(),
-            build_dir.display(), build_dir.display(), build_dir.display());
+            build_dir.display(),
+            build_dir.display(),
+            build_dir.display()
+        );
         return Ok(());
     }
 
@@ -1304,9 +1837,7 @@ sys.exit(0 if ok else 1)
         let _ = run_cmd.status();
         return Ok(());
     }
-    let run_status = run_cmd
-        .status()
-        .into_diagnostic()?;
+    let run_status = run_cmd.status().into_diagnostic()?;
 
     std::process::exit(run_status.code().unwrap_or(1));
 }
@@ -1323,10 +1854,14 @@ sys.exit(0 if ok else 1)
 ///   5. `<exe>/../share/arch/stdlib/` — matches Unix `<prefix>/bin/arch` installs
 /// Returns None if none of these resolve to an existing directory.
 fn resolve_stdlib_dir() -> Option<PathBuf> {
-    if std::env::var("ARCH_NO_STDLIB").is_ok() { return None; }
+    if std::env::var("ARCH_NO_STDLIB").is_ok() {
+        return None;
+    }
     if let Ok(p) = std::env::var("ARCH_STDLIB_PATH") {
         let p = PathBuf::from(p);
-        if p.is_dir() { return Some(p); }
+        if p.is_dir() {
+            return Some(p);
+        }
     }
     let exe = std::env::current_exe().ok()?;
     for up in 1..=4 {
@@ -1335,13 +1870,17 @@ fn resolve_stdlib_dir() -> Option<PathBuf> {
             candidate = candidate.parent()?.to_path_buf();
         }
         let stdlib = candidate.join("stdlib");
-        if stdlib.is_dir() { return Some(stdlib); }
+        if stdlib.is_dir() {
+            return Some(stdlib);
+        }
     }
     // Unix prefix install: /usr/local/bin/arch → /usr/local/share/arch/stdlib
     let exe_parent = exe.parent()?;
     let prefix = exe_parent.parent()?;
     let share = prefix.join("share").join("arch").join("stdlib");
-    if share.is_dir() { return Some(share); }
+    if share.is_dir() {
+        return Some(share);
+    }
     None
 }
 
@@ -1380,7 +1919,8 @@ fn item_ports(item: &Item) -> &[arch::ast::PortDecl] {
 fn resolve_use_imports(files: &[PathBuf]) -> miette::Result<Vec<PathBuf>> {
     use std::collections::HashSet;
 
-    let base_dir = files.first()
+    let base_dir = files
+        .first()
         .and_then(|f| f.parent())
         .unwrap_or(std::path::Path::new("."));
 
@@ -1399,12 +1939,12 @@ fn resolve_use_imports(files: &[PathBuf]) -> miette::Result<Vec<PathBuf>> {
         seen.insert(canon);
 
         let source = fs::read_to_string(&file).into_diagnostic()?;
-        let tokens = lexer::tokenize(&source).map_err(|_| {
-            miette::miette!("Lexer error in {}", file.display())
-        })?;
+        let tokens = lexer::tokenize(&source)
+            .map_err(|_| miette::miette!("Lexer error in {}", file.display()))?;
         let mut p = parser::Parser::new(tokens, &source);
         let parsed = p.parse_source_file().map_err(|err| {
-            Report::new(err).with_source_code(NamedSource::new(file.display().to_string(), source.clone()))
+            Report::new(err)
+                .with_source_code(NamedSource::new(file.display().to_string(), source.clone()))
         })?;
 
         // Find `use` items and queue their files
@@ -1427,10 +1967,16 @@ fn resolve_use_imports(files: &[PathBuf]) -> miette::Result<Vec<PathBuf>> {
                 if let Ok(lib_path) = std::env::var("ARCH_LIB_PATH") {
                     for dir in lib_path.split(':') {
                         let p = std::path::Path::new(dir).join(&file_name);
-                        if p.exists() { deps.push(p); found = true; break; }
+                        if p.exists() {
+                            deps.push(p);
+                            found = true;
+                            break;
+                        }
                     }
                 }
-                if found { continue; }
+                if found {
+                    continue;
+                }
                 if let Some(stdlib) = resolve_stdlib_dir() {
                     let p = stdlib.join(&file_name);
                     if p.exists() {
@@ -1443,15 +1989,33 @@ fn resolve_use_imports(files: &[PathBuf]) -> miette::Result<Vec<PathBuf>> {
         // Track all module names defined across all input files
         for item in &parsed.items {
             match item {
-                Item::Module(m) => { all_defined_modules.insert(m.name.name.clone()); }
-                Item::Fsm(f) => { all_defined_modules.insert(f.name.name.clone()); }
-                Item::Counter(c) => { all_defined_modules.insert(c.name.name.clone()); }
-                Item::Pipeline(p) => { all_defined_modules.insert(p.name.name.clone()); }
-                Item::Synchronizer(s) => { all_defined_modules.insert(s.name.name.clone()); }
-                Item::Fifo(f) => { all_defined_modules.insert(f.name.name.clone()); }
-                Item::Ram(r) => { all_defined_modules.insert(r.name.name.clone()); }
-                Item::Arbiter(a) => { all_defined_modules.insert(a.name.name.clone()); }
-                Item::Bus(b) => { all_defined_buses.insert(b.name.name.clone()); }
+                Item::Module(m) => {
+                    all_defined_modules.insert(m.name.name.clone());
+                }
+                Item::Fsm(f) => {
+                    all_defined_modules.insert(f.name.name.clone());
+                }
+                Item::Counter(c) => {
+                    all_defined_modules.insert(c.name.name.clone());
+                }
+                Item::Pipeline(p) => {
+                    all_defined_modules.insert(p.name.name.clone());
+                }
+                Item::Synchronizer(s) => {
+                    all_defined_modules.insert(s.name.name.clone());
+                }
+                Item::Fifo(f) => {
+                    all_defined_modules.insert(f.name.name.clone());
+                }
+                Item::Ram(r) => {
+                    all_defined_modules.insert(r.name.name.clone());
+                }
+                Item::Arbiter(a) => {
+                    all_defined_modules.insert(a.name.name.clone());
+                }
+                Item::Bus(b) => {
+                    all_defined_buses.insert(b.name.name.clone());
+                }
                 _ => {}
             }
         }
@@ -1459,17 +2023,35 @@ fn resolve_use_imports(files: &[PathBuf]) -> miette::Result<Vec<PathBuf>> {
         // Find inst references and look for .archi interface files
         for item in &parsed.items {
             let insts = match item {
-                Item::Module(m) => m.body.iter()
-                    .filter_map(|b| if let arch::ast::ModuleBodyItem::Inst(i) = b { Some(&i.module_name.name) } else { None })
+                Item::Module(m) => m
+                    .body
+                    .iter()
+                    .filter_map(|b| {
+                        if let arch::ast::ModuleBodyItem::Inst(i) = b {
+                            Some(&i.module_name.name)
+                        } else {
+                            None
+                        }
+                    })
                     .collect::<Vec<_>>(),
-                Item::Pipeline(p) => p.stages.iter()
+                Item::Pipeline(p) => p
+                    .stages
+                    .iter()
                     .flat_map(|s| s.body.iter())
-                    .filter_map(|b| if let arch::ast::ModuleBodyItem::Inst(i) = b { Some(&i.module_name.name) } else { None })
+                    .filter_map(|b| {
+                        if let arch::ast::ModuleBodyItem::Inst(i) = b {
+                            Some(&i.module_name.name)
+                        } else {
+                            None
+                        }
+                    })
                     .collect::<Vec<_>>(),
                 _ => vec![],
             };
             for inst_name in insts {
-                if all_defined_modules.contains(inst_name.as_str()) { continue; }
+                if all_defined_modules.contains(inst_name.as_str()) {
+                    continue;
+                }
                 // Look for .arch first, then .archi
                 let arch_path = base_dir.join(format!("{inst_name}.arch"));
                 let archi_path = base_dir.join(format!("{inst_name}.archi"));
@@ -1482,17 +2064,28 @@ fn resolve_use_imports(files: &[PathBuf]) -> miette::Result<Vec<PathBuf>> {
                 if let Ok(lib_path) = std::env::var("ARCH_LIB_PATH") {
                     for dir in lib_path.split(':') {
                         let p = std::path::Path::new(dir).join(format!("{inst_name}.archi"));
-                        if p.exists() { deps.push(p); break; }
+                        if p.exists() {
+                            deps.push(p);
+                            break;
+                        }
                         let p = std::path::Path::new(dir).join(format!("{inst_name}.arch"));
-                        if p.exists() { deps.push(p); break; }
+                        if p.exists() {
+                            deps.push(p);
+                            break;
+                        }
                     }
                 }
                 // Fall back to the shipped standard library.
                 if let Some(stdlib) = resolve_stdlib_dir() {
                     let p = stdlib.join(format!("{inst_name}.arch"));
-                    if p.exists() { deps.push(p); continue; }
+                    if p.exists() {
+                        deps.push(p);
+                        continue;
+                    }
                     let p = stdlib.join(format!("{inst_name}.archi"));
-                    if p.exists() { deps.push(p); }
+                    if p.exists() {
+                        deps.push(p);
+                    }
                 }
             }
         }
@@ -1513,13 +2106,17 @@ fn resolve_use_imports(files: &[PathBuf]) -> miette::Result<Vec<PathBuf>> {
             }
         }
         for bus_name in bus_refs {
-            if all_defined_buses.contains(bus_name.as_str()) { continue; }
+            if all_defined_buses.contains(bus_name.as_str()) {
+                continue;
+            }
             // An explicit `use <Bus>;` is authoritative — it already queued
             // the canonical definition above. Skip the fallback scan for it
             // so we don't also pull in a stale build-artifact `<Bus>.archi`
             // sitting in the source directory (which would double-define the
             // bus).
-            if use_names.contains(bus_name.as_str()) { continue; }
+            if use_names.contains(bus_name.as_str()) {
+                continue;
+            }
             // Same-directory `.arch` first, then `.archi`.
             let arch_path = base_dir.join(format!("{bus_name}.arch"));
             let archi_path = base_dir.join(format!("{bus_name}.archi"));
@@ -1532,17 +2129,28 @@ fn resolve_use_imports(files: &[PathBuf]) -> miette::Result<Vec<PathBuf>> {
             if let Ok(lib_path) = std::env::var("ARCH_LIB_PATH") {
                 for dir in lib_path.split(':') {
                     let p = std::path::Path::new(dir).join(format!("{bus_name}.arch"));
-                    if p.exists() { deps.push(p); break; }
+                    if p.exists() {
+                        deps.push(p);
+                        break;
+                    }
                     let p = std::path::Path::new(dir).join(format!("{bus_name}.archi"));
-                    if p.exists() { deps.push(p); break; }
+                    if p.exists() {
+                        deps.push(p);
+                        break;
+                    }
                 }
             }
             // Finally the shipped standard library.
             if let Some(stdlib) = resolve_stdlib_dir() {
                 let p = stdlib.join(format!("{bus_name}.arch"));
-                if p.exists() { deps.push(p); continue; }
+                if p.exists() {
+                    deps.push(p);
+                    continue;
+                }
                 let p = stdlib.join(format!("{bus_name}.archi"));
-                if p.exists() { deps.push(p); }
+                if p.exists() {
+                    deps.push(p);
+                }
             }
         }
 
@@ -1559,7 +2167,8 @@ fn resolve_use_imports(files: &[PathBuf]) -> miette::Result<Vec<PathBuf>> {
     // end, all_files has: first input files first, then deps. We need deps first.
     // Let's just deduplicate and reorder: deps before users.
     // Simple approach: move any file that is NOT in the original `files` list to front.
-    let orig_set: HashSet<PathBuf> = files.iter()
+    let orig_set: HashSet<PathBuf> = files
+        .iter()
         .map(|f| f.canonicalize().unwrap_or_else(|_| f.clone()))
         .collect();
     let mut dep_files: Vec<PathBuf> = Vec::new();
@@ -1567,7 +2176,9 @@ fn resolve_use_imports(files: &[PathBuf]) -> miette::Result<Vec<PathBuf>> {
     let mut seen2: HashSet<PathBuf> = HashSet::new();
     for f in &all_files {
         let canon = f.canonicalize().unwrap_or_else(|_| f.clone());
-        if seen2.contains(&canon) { continue; }
+        if seen2.contains(&canon) {
+            continue;
+        }
         seen2.insert(canon.clone());
         if orig_set.contains(&canon) {
             main_files.push(f.clone());
@@ -1585,14 +2196,15 @@ fn resolve_use_imports(files: &[PathBuf]) -> miette::Result<Vec<PathBuf>> {
 fn collect_arch_files(root: &std::path::Path) -> Vec<PathBuf> {
     let mut out = Vec::new();
     fn walk(p: &std::path::Path, out: &mut Vec<PathBuf>) {
-        let Ok(rd) = fs::read_dir(p) else { return; };
+        let Ok(rd) = fs::read_dir(p) else {
+            return;
+        };
         for entry in rd.flatten() {
             let path = entry.path();
             if let Ok(ft) = entry.file_type() {
                 if ft.is_dir() {
                     walk(&path, out);
-                } else if ft.is_file()
-                    && path.extension().and_then(|s| s.to_str()) == Some("arch")
+                } else if ft.is_file() && path.extension().and_then(|s| s.to_str()) == Some("arch")
                 {
                     out.push(path);
                 }
@@ -1638,21 +2250,30 @@ fn run_learn_bootstrap(path: &std::path::Path) -> miette::Result<()> {
     for file in &files {
         let src = match fs::read_to_string(file) {
             Ok(s) => s,
-            Err(_) => { skipped_files += 1; continue; }
+            Err(_) => {
+                skipped_files += 1;
+                continue;
+            }
         };
         let tokens = match arch::lexer::tokenize(&src) {
             Ok(t) => t,
-            Err(_) => { skipped_files += 1; continue; }
+            Err(_) => {
+                skipped_files += 1;
+                continue;
+            }
         };
         let mut p = parser::Parser::new(tokens, &src);
         let ast = match p.parse_source_file() {
             Ok(a) => a,
-            Err(_) => { skipped_files += 1; continue; }
+            Err(_) => {
+                skipped_files += 1;
+                continue;
+            }
         };
         let path_str = file.display().to_string();
         let path_str_for_closure = path_str.clone();
-        let n = arch::learn::harvest_features(&ast, |_item| path_str_for_closure.clone())
-            .unwrap_or(0);
+        let n =
+            arch::learn::harvest_features(&ast, |_item| path_str_for_closure.clone()).unwrap_or(0);
         total_events += n;
         parsed_files += 1;
     }
@@ -1673,15 +2294,25 @@ fn run_learn_bootstrap(path: &std::path::Path) -> miette::Result<()> {
 
 fn run_check_multi(
     ms: &MultiSource,
-) -> miette::Result<(arch::ast::SourceFile, resolve::SymbolTable, std::collections::HashMap<usize, usize>)> {
-    run_check_multi_opts(ms, /*skip_lower_threads=*/ false, /*auto_thread_asserts=*/ false)
+) -> miette::Result<(
+    arch::ast::SourceFile,
+    resolve::SymbolTable,
+    std::collections::HashMap<usize, usize>,
+)> {
+    run_check_multi_opts(
+        ms, /*skip_lower_threads=*/ false, /*auto_thread_asserts=*/ false,
+    )
 }
 
 fn run_check_multi_opts(
     ms: &MultiSource,
     skip_lower_threads: bool,
     auto_thread_asserts: bool,
-) -> miette::Result<(arch::ast::SourceFile, resolve::SymbolTable, std::collections::HashMap<usize, usize>)> {
+) -> miette::Result<(
+    arch::ast::SourceFile,
+    resolve::SymbolTable,
+    std::collections::HashMap<usize, usize>,
+)> {
     run_check_multi_opts_with_thread_map(ms, skip_lower_threads, auto_thread_asserts, None)
 }
 
@@ -1690,7 +2321,11 @@ fn run_check_multi_opts_with_thread_map(
     skip_lower_threads: bool,
     auto_thread_asserts: bool,
     thread_map: Option<std::rc::Rc<std::cell::RefCell<arch::thread_map::ThreadMap>>>,
-) -> miette::Result<(arch::ast::SourceFile, resolve::SymbolTable, std::collections::HashMap<usize, usize>)> {
+) -> miette::Result<(
+    arch::ast::SourceFile,
+    resolve::SymbolTable,
+    std::collections::HashMap<usize, usize>,
+)> {
     let source = &ms.combined;
 
     // Lex
@@ -1698,16 +2333,20 @@ fn run_check_multi_opts_with_thread_map(
         let offset = spans[0].start;
         let (filename, file_source, local_offset) = ms.locate(offset);
         let err = CompileError::LexerError {
-            span: miette::SourceSpan::new(local_offset.into(), (spans[0].end - spans[0].start).into()),
+            span: miette::SourceSpan::new(
+                local_offset.into(),
+                (spans[0].end - spans[0].start).into(),
+            ),
         };
-        Report::new(err).with_source_code(NamedSource::new(filename.to_string(), file_source.to_string()))
+        Report::new(err).with_source_code(NamedSource::new(
+            filename.to_string(),
+            file_source.to_string(),
+        ))
     })?;
 
     // Parse
     let mut p = parser::Parser::new(tokens, source);
-    let mut parsed_ast = p.parse_source_file().map_err(|err| {
-        ms.report_error(err)
-    })?;
+    let mut parsed_ast = p.parse_source_file().map_err(|err| ms.report_error(err))?;
 
     // Tag items loaded from `.archi` interface stubs (port-only, no body).
     // Body-only downstream passes — typecheck's output-driven check /
@@ -1848,7 +2487,11 @@ fn run_check_multi_opts_with_thread_map(
         if !collected_hazards.is_empty() {
             let mut map = map_rc.borrow_mut();
             for (mod_name, hz) in &collected_hazards {
-                for tmm in map.modules.iter_mut().filter(|m| m.module_name == *mod_name) {
+                for tmm in map
+                    .modules
+                    .iter_mut()
+                    .filter(|m| m.module_name == *mod_name)
+                {
                     for tmt in tmm.threads.iter_mut().filter(|t| t.name == hz.thread_name) {
                         tmt.hazards.push(arch::thread_map::CombFeedbackHazard {
                             read_signal: hz.read_signal.clone(),

--- a/src/thread_map.rs
+++ b/src/thread_map.rs
@@ -1,4 +1,4 @@
-use crate::ast::{BinOp, Expr, ExprKind, InsideMember, LitKind, Stmt, UnaryOp};
+use crate::ast::{BinOp, Expr, ExprKind, ForRange, InsideMember, LitKind, Stmt, UnaryOp};
 use crate::lexer::Span;
 
 #[derive(Debug, Clone, Default)]
@@ -18,6 +18,9 @@ pub struct ThreadMapModule {
 pub struct ThreadMapThread {
     pub name: String,
     pub index: usize,
+    /// True for `thread once`, where the terminal state holds instead of
+    /// wrapping to state 0.
+    pub once: bool,
     pub span: Span,
     pub states: Vec<ThreadMapState>,
     /// Dead-skid comb-feedback hazards for this thread (issue #245).  Populated
@@ -42,16 +45,92 @@ pub struct ThreadMapState {
     pub index: usize,
     pub state_name: String,
     pub role: String,
+    /// False when this source partition was absorbed by an optimization such
+    /// as folded wait-exit assignment lowering and is not emitted as a runtime
+    /// state arm in the generated FSM.
+    pub emitted: bool,
     pub span: Span,
     pub labels: Vec<String>,
+    /// Source-level fall-through target after local proof-preserving
+    /// compaction such as folded wait-exit assignments.
+    ///
+    /// The lowered FSM transition target is still represented separately in
+    /// `transitions`; proof tooling checks the two agree where source
+    /// semantics require natural fall-through.
+    pub source_next_index: usize,
+    pub source_next_name: String,
+    /// Rendered `wait N cycle` count expression for counted-wait states.
+    ///
+    /// `None` for all other state roles. The proof converter only accepts
+    /// literal natural counts today, but this field keeps the certificate
+    /// source-of-truth separate from human-readable labels.
+    pub wait_cycles_count: Option<String>,
+    /// Sequential updates that fire while this runtime state is active.
+    pub seq_updates: Vec<String>,
+    /// Direct sequential assignments that fire while this runtime state is
+    /// active. Nested/guarded statements remain represented by `seq_updates`
+    /// until the proof certificate grows a full statement language.
+    pub seq_assignments: Vec<ThreadMapAssignment>,
+    /// Sequential updates folded into this state's guarded exit arm.
+    ///
+    /// This is populated by the wait-until exit folding optimization. The
+    /// absorbed successor state is still present in the map with
+    /// `emitted == false`, while these updates document the store effect that
+    /// moved onto the wait state's exit edge.
+    pub folded_exit_updates: Vec<String>,
+    /// Direct sequential assignments folded into this state's guarded exit
+    /// arm. This mirrors `folded_exit_updates` with structure when the folded
+    /// statement is a plain `target <= value` assignment.
+    pub folded_exit_assignments: Vec<ThreadMapAssignment>,
+    /// Source-level transition intent for this state, after local compaction.
+    ///
+    /// This is intentionally separate from `transitions`, which records the
+    /// lowered FSM table. Today the lowering path populates both from the same
+    /// raw table for most states, but proof tooling treats them as separate
+    /// channels so later source-intent extraction can catch lowered-table drift.
+    pub source_transitions: Vec<ThreadMapTransition>,
+    /// Machine-readable provenance for `source_transitions`.
+    ///
+    /// v5 uses `pre_fold_snapshot`: transition intent was snapshotted before
+    /// folded wait-exit assignment optimization and compacted across folded
+    /// states before emission.
+    pub source_transition_origin: String,
+    /// Lowered FSM transition table emitted by `lower_threads`.
     pub transitions: Vec<ThreadMapTransition>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ThreadMapAssignment {
+    pub target: String,
+    pub value: String,
 }
 
 #[derive(Debug, Clone)]
 pub struct ThreadMapTransition {
     pub condition: String,
+    pub condition_guard: Option<ThreadMapGuardExpr>,
     pub target_index: usize,
     pub target_name: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ThreadMapGuardExpr {
+    Atom(String),
+    True,
+    False,
+    Not(Box<ThreadMapGuardExpr>),
+    And(Box<ThreadMapGuardExpr>, Box<ThreadMapGuardExpr>),
+    Or(Box<ThreadMapGuardExpr>, Box<ThreadMapGuardExpr>),
+    Lt(ThreadMapNatExpr, ThreadMapNatExpr),
+    Ge(ThreadMapNatExpr, ThreadMapNatExpr),
+    Eq(ThreadMapNatExpr, ThreadMapNatExpr),
+    Ne(ThreadMapNatExpr, ThreadMapNatExpr),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ThreadMapNatExpr {
+    Var(String),
+    Const(u64),
 }
 
 #[derive(Debug, Clone)]
@@ -158,6 +237,132 @@ pub fn expr_label(expr: &Expr) -> String {
     }
 }
 
+pub fn guard_expr(expr: &Expr) -> ThreadMapGuardExpr {
+    match &expr.kind {
+        ExprKind::Bool(true) => ThreadMapGuardExpr::True,
+        ExprKind::Bool(false) => ThreadMapGuardExpr::False,
+        ExprKind::Unary(UnaryOp::Not, inner) => {
+            ThreadMapGuardExpr::Not(Box::new(guard_expr(inner)))
+        }
+        ExprKind::Binary(BinOp::And, lhs, rhs) => {
+            ThreadMapGuardExpr::And(Box::new(guard_expr(lhs)), Box::new(guard_expr(rhs)))
+        }
+        ExprKind::Binary(BinOp::Or, lhs, rhs) => {
+            ThreadMapGuardExpr::Or(Box::new(guard_expr(lhs)), Box::new(guard_expr(rhs)))
+        }
+        ExprKind::Binary(BinOp::Lt, lhs, rhs) => {
+            ThreadMapGuardExpr::Lt(nat_expr(lhs), nat_expr(rhs))
+        }
+        ExprKind::Binary(BinOp::Gte, lhs, rhs) => {
+            ThreadMapGuardExpr::Ge(nat_expr(lhs), nat_expr(rhs))
+        }
+        ExprKind::Binary(BinOp::Gt, lhs, rhs) => {
+            ThreadMapGuardExpr::Lt(nat_expr(rhs), nat_expr(lhs))
+        }
+        ExprKind::Binary(BinOp::Lte, lhs, rhs) => {
+            ThreadMapGuardExpr::Ge(nat_expr(rhs), nat_expr(lhs))
+        }
+        ExprKind::Binary(BinOp::Eq, lhs, rhs) => {
+            ThreadMapGuardExpr::Eq(nat_expr(lhs), nat_expr(rhs))
+        }
+        ExprKind::Binary(BinOp::Neq, lhs, rhs) => {
+            ThreadMapGuardExpr::Ne(nat_expr(lhs), nat_expr(rhs))
+        }
+        _ => ThreadMapGuardExpr::Atom(expr_label(expr)),
+    }
+}
+
+pub fn nat_expr(expr: &Expr) -> ThreadMapNatExpr {
+    match &expr.kind {
+        ExprKind::Literal(LitKind::Dec(v))
+        | ExprKind::Literal(LitKind::Hex(v))
+        | ExprKind::Literal(LitKind::Bin(v))
+        | ExprKind::Literal(LitKind::Sized(_, v)) => ThreadMapNatExpr::Const(*v),
+        ExprKind::Cast(inner, _) | ExprKind::Signed(inner) | ExprKind::Unsigned(inner) => {
+            nat_expr(inner)
+        }
+        ExprKind::MethodCall(inner, method, args)
+            if matches!(method.name.as_str(), "trunc" | "zext" | "sext" | "resize")
+                && args.len() == 1 =>
+        {
+            nat_expr(inner)
+        }
+        _ => ThreadMapNatExpr::Var(expr_label(expr)),
+    }
+}
+
+pub fn stmt_label(stmt: &Stmt) -> String {
+    match stmt {
+        Stmt::Assign(assign) => format!(
+            "{} <= {}",
+            expr_label(&assign.target),
+            expr_label(&assign.value)
+        ),
+        Stmt::IfElse(ie) => {
+            let then_labels = ie
+                .then_stmts
+                .iter()
+                .map(stmt_label)
+                .collect::<Vec<_>>()
+                .join("; ");
+            let else_labels = ie
+                .else_stmts
+                .iter()
+                .map(stmt_label)
+                .collect::<Vec<_>>()
+                .join("; ");
+            if ie.else_stmts.is_empty() {
+                format!("if {} then [{}]", expr_label(&ie.cond), then_labels)
+            } else {
+                format!(
+                    "if {} then [{}] else [{}]",
+                    expr_label(&ie.cond),
+                    then_labels,
+                    else_labels
+                )
+            }
+        }
+        Stmt::Match(m) => format!("match {}", expr_label(&m.scrutinee)),
+        Stmt::Log(log) => format!("log {}", log.tag),
+        Stmt::For(f) => {
+            let body = f.body.iter().map(stmt_label).collect::<Vec<_>>().join("; ");
+            format!(
+                "for {} in {} [{}]",
+                f.var.name,
+                for_range_label(&f.range),
+                body
+            )
+        }
+        Stmt::Init(init) => {
+            let body = init
+                .body
+                .iter()
+                .map(stmt_label)
+                .collect::<Vec<_>>()
+                .join("; ");
+            format!("init on {} [{}]", init.reset_signal.name, body)
+        }
+        Stmt::WaitUntil(cond, _) => format!("wait until {}", expr_label(cond)),
+        Stmt::DoUntil { body, cond, .. } => {
+            let body = body.iter().map(stmt_label).collect::<Vec<_>>().join("; ");
+            format!("do [{}] until {}", body, expr_label(cond))
+        }
+    }
+}
+
+pub fn stmt_assignments(stmts: &[Stmt]) -> Vec<ThreadMapAssignment> {
+    stmts
+        .iter()
+        .filter_map(|stmt| match stmt {
+            Stmt::Assign(assign) => Some(ThreadMapAssignment {
+                target: expr_label(&assign.target),
+                value: expr_label(&assign.value),
+            }),
+            _ => None,
+        })
+        .collect()
+}
+
 pub fn render_html(map: &ThreadMap, sources: &[ThreadMapSource], title: &str) -> String {
     let mut out = String::new();
     out.push_str("<!doctype html>\n<html lang=\"en\">\n<head>\n<meta charset=\"utf-8\">\n");
@@ -241,7 +446,11 @@ table.hazards td { border-top: 1px solid #ffe0bf; }
             html_escape(&module.generated_module_name)
         ));
         for thread in &module.threads {
-            let warn = if thread.hazards.is_empty() { "" } else { "⚠ " };
+            let warn = if thread.hazards.is_empty() {
+                ""
+            } else {
+                "⚠ "
+            };
             out.push_str(&format!(
                 "<h4>{}thread {} <span class=\"role\">index {}</span></h4>",
                 warn,
@@ -364,7 +573,11 @@ fn line_has_hazard(map: &ThreadMap, line_start: usize, line_end: usize) -> bool 
     })
 }
 
-fn render_thread_flow_chart(out: &mut String, sources: &[ThreadMapSource], thread: &ThreadMapThread) {
+fn render_thread_flow_chart(
+    out: &mut String,
+    sources: &[ThreadMapSource],
+    thread: &ThreadMapThread,
+) {
     let positions = graph_positions(thread);
     let width = GRAPH_W;
     let height = positions
@@ -396,7 +609,13 @@ fn render_thread_flow_chart(out: &mut String, sources: &[ThreadMapSource], threa
     for state in &thread.states {
         let pos = positions[state.index];
         let lines = find_line_range(sources, state.span)
-            .map(|(_, a, b)| if a == b { a.to_string() } else { format!("{a}-{b}") })
+            .map(|(_, a, b)| {
+                if a == b {
+                    a.to_string()
+                } else {
+                    format!("{a}-{b}")
+                }
+            })
             .unwrap_or_else(|| "-".to_string());
         out.push_str(&format!(
             "<g class=\"flow-state\" data-state=\"S{}\"><rect class=\"graph-node c{}\" x=\"{}\" y=\"{}\" width=\"{}\" height=\"{}\"/>",
@@ -437,7 +656,10 @@ struct GraphPos {
 
 fn graph_positions(thread: &ThreadMapThread) -> Vec<GraphPos> {
     let mut positions = (0..thread.states.len())
-        .map(|i| GraphPos { x: 380, y: 24 + i as i32 * 122 })
+        .map(|i| GraphPos {
+            x: 380,
+            y: 24 + i as i32 * 122,
+        })
         .collect::<Vec<_>>();
 
     for state in &thread.states {
@@ -450,10 +672,16 @@ fn graph_positions(thread: &ThreadMapThread) -> Vec<GraphPos> {
         if forward_targets.len() == 2 {
             let branch_y = positions[state.index].y + 132;
             if let Some(pos) = positions.get_mut(forward_targets[0]) {
-                *pos = GraphPos { x: 250, y: branch_y };
+                *pos = GraphPos {
+                    x: 250,
+                    y: branch_y,
+                };
             }
             if let Some(pos) = positions.get_mut(forward_targets[1]) {
-                *pos = GraphPos { x: 560, y: branch_y };
+                *pos = GraphPos {
+                    x: 560,
+                    y: branch_y,
+                };
             }
             break;
         }
@@ -480,15 +708,28 @@ fn render_graph_edge(
         } else {
             GRAPH_W - 24 - lane_offset
         };
-        let sx = if use_left_lane { from.x } else { from.x + GRAPH_NODE_W };
+        let sx = if use_left_lane {
+            from.x
+        } else {
+            from.x + GRAPH_NODE_W
+        };
         let sy = from.y + GRAPH_NODE_H / 2;
-        let ex = if use_left_lane { to.x } else { to.x + GRAPH_NODE_W };
+        let ex = if use_left_lane {
+            to.x
+        } else {
+            to.x + GRAPH_NODE_W
+        };
         let ey = to.y + GRAPH_NODE_H / 2;
         out.push_str(&format!(
             "<path class=\"graph-edge\" marker-end=\"url(#{})\" d=\"M{sx},{sy} C{lane},{sy} {lane},{ey} {ex},{ey}\"/>",
             html_escape(marker_id)
         ));
-        render_graph_label(out, if use_left_lane { lane + 8 } else { lane - 42 }, (sy + ey) / 2, &label);
+        render_graph_label(
+            out,
+            if use_left_lane { lane + 8 } else { lane - 42 },
+            (sy + ey) / 2,
+            &label,
+        );
     } else {
         let sx = from.x + GRAPH_NODE_W / 2;
         let sy = from.y + GRAPH_NODE_H;
@@ -527,7 +768,11 @@ fn graph_node_title(state: &ThreadMapState) -> String {
     if let Some(label) = state.labels.iter().find(|l| l.starts_with("wait until ")) {
         return format!("S{}: {}", state.index, label);
     }
-    if let Some(label) = state.labels.iter().find(|l| l.starts_with("wait ") && l.ends_with(" cycle")) {
+    if let Some(label) = state
+        .labels
+        .iter()
+        .find(|l| l.starts_with("wait ") && l.ends_with(" cycle"))
+    {
         return format!("S{}: {}", state.index, label);
     }
     if state.role == "dispatch" && state.transitions.len() == 2 {
@@ -543,7 +788,12 @@ fn graph_node_title(state: &ThreadMapState) -> String {
 }
 
 fn transition_summary(state: &ThreadMapState, tr: &ThreadMapTransition) -> String {
-    transition_summary_with(state.role.as_str(), state.transitions.len(), state.index, tr)
+    transition_summary_with(
+        state.role.as_str(),
+        state.transitions.len(),
+        state.index,
+        tr,
+    )
 }
 
 fn transition_summary_with(
@@ -647,7 +897,11 @@ fn line_range_in_source(src: &ThreadMapSource, span: Span) -> Option<(usize, usi
 fn anchor_line_for_span(src: &ThreadMapSource, span: Span) -> Option<usize> {
     let (start_line, end_line) = line_range_in_source(src, span)?;
     for line_no in start_line..=end_line {
-        let text = src.source.lines().nth(line_no.saturating_sub(1)).unwrap_or("");
+        let text = src
+            .source
+            .lines()
+            .nth(line_no.saturating_sub(1))
+            .unwrap_or("");
         let trimmed = text.trim_start();
         if !trimmed.is_empty() && !trimmed.starts_with("//") {
             return Some(line_no);
@@ -745,5 +999,74 @@ fn inside_member_label(member: &InsideMember) -> String {
     match member {
         InsideMember::Single(e) => expr_label(e),
         InsideMember::Range(lo, hi) => format!("{}..{}", expr_label(lo), expr_label(hi)),
+    }
+}
+
+fn for_range_label(range: &ForRange) -> String {
+    match range {
+        ForRange::Range(start, end) => format!("{}..{}", expr_label(start), expr_label(end)),
+        ForRange::ValueList(values) => values.iter().map(expr_label).collect::<Vec<_>>().join(", "),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ast::{Expr, Ident};
+
+    fn dec(value: u64) -> Expr {
+        Expr::new(ExprKind::Literal(LitKind::Dec(value)), Span::new(0, 1))
+    }
+
+    fn ident(name: &str) -> Expr {
+        Expr::new(ExprKind::Ident(name.to_string()), Span::new(0, 1))
+    }
+
+    fn binary(op: BinOp, lhs: Expr, rhs: Expr) -> Expr {
+        Expr::new(
+            ExprKind::Binary(op, Box::new(lhs), Box::new(rhs)),
+            Span::new(0, 1),
+        )
+    }
+
+    fn method(base: Expr, name: &str, args: Vec<Expr>) -> Expr {
+        Expr::new(
+            ExprKind::MethodCall(
+                Box::new(base),
+                Ident::new(name.to_string(), Span::new(0, 1)),
+                args,
+            ),
+            Span::new(0, 1),
+        )
+    }
+
+    #[test]
+    fn nat_expr_preserves_literal_through_width_method_call() {
+        assert_eq!(
+            nat_expr(&method(dec(3), "resize", vec![dec(2)])),
+            ThreadMapNatExpr::Const(3)
+        );
+        assert_eq!(
+            nat_expr(&method(dec(7), "trunc", vec![dec(3)])),
+            ThreadMapNatExpr::Const(7)
+        );
+    }
+
+    #[test]
+    fn guard_expr_preserves_equality_as_structured_nat_comparison() {
+        assert_eq!(
+            guard_expr(&binary(BinOp::Eq, ident("idx"), dec(3))),
+            ThreadMapGuardExpr::Eq(
+                ThreadMapNatExpr::Var("idx".to_string()),
+                ThreadMapNatExpr::Const(3)
+            )
+        );
+        assert_eq!(
+            guard_expr(&binary(BinOp::Neq, ident("idx"), dec(3))),
+            ThreadMapGuardExpr::Ne(
+                ThreadMapNatExpr::Var("idx".to_string()),
+                ThreadMapNatExpr::Const(3)
+            )
+        );
     }
 }

--- a/src/thread_proof_cert.rs
+++ b/src/thread_proof_cert.rs
@@ -1,0 +1,1833 @@
+//! Machine-readable thread-lowering proof certificate sidecars.
+//!
+//! This is intentionally a small JSON emitter over `thread_map::ThreadMap`.
+//! The map is populated from the real lowered `ThreadFsmState` table after
+//! lowering optimizations such as folded wait-exit assignments, so it is a
+//! useful first Rust-side artifact for Lean/certificate tooling to consume.
+
+use crate::thread_map::{
+    ThreadMap, ThreadMapAssignment, ThreadMapGuardExpr, ThreadMapNatExpr, ThreadMapState,
+    ThreadMapThread, ThreadMapTransition,
+};
+use std::collections::{HashMap, HashSet};
+
+pub fn render_json(map: &ThreadMap) -> String {
+    let mut out = String::new();
+    out.push_str("{\n");
+    out.push_str("  \"schema\": \"arch.thread_lowering_proof.v5\",\n");
+    out.push_str("  \"modules\": [\n");
+    for (mi, module) in map.modules.iter().enumerate() {
+        if mi > 0 {
+            out.push_str(",\n");
+        }
+        out.push_str("    {\n");
+        push_json_field(&mut out, 6, "module_name", &module.module_name, true);
+        push_json_field(
+            &mut out,
+            6,
+            "generated_module_name",
+            &module.generated_module_name,
+            true,
+        );
+        out.push_str("      \"threads\": [\n");
+        for (ti, thread) in module.threads.iter().enumerate() {
+            if ti > 0 {
+                out.push_str(",\n");
+            }
+            out.push_str("        {\n");
+            push_json_field(&mut out, 10, "name", &thread.name, true);
+            out.push_str(&format!("          \"index\": {},\n", thread.index));
+            out.push_str(&format!("          \"once\": {},\n", thread.once));
+            out.push_str("          \"states\": [\n");
+            for (si, state) in thread.states.iter().enumerate() {
+                if si > 0 {
+                    out.push_str(",\n");
+                }
+                push_state(&mut out, state);
+            }
+            out.push_str("\n          ]\n");
+            out.push_str("        }");
+        }
+        out.push_str("\n      ]\n");
+        out.push_str("    }");
+    }
+    out.push_str("\n  ]\n");
+    out.push_str("}\n");
+    out
+}
+
+pub fn render_lean_checked(map: &ThreadMap) -> Result<String, String> {
+    validate_lean_render_map(map)?;
+    Ok(render_lean(map))
+}
+
+pub fn render_lean(map: &ThreadMap) -> String {
+    render_lean_unchecked(map)
+}
+
+fn render_lean_unchecked(map: &ThreadMap) -> String {
+    let mut ctx = LeanRenderCtx::default();
+    let mut chunks = vec![
+        "import ArchThreadLoweringProof.CountedWait".to_string(),
+        "import ArchThreadLoweringProof.FoldedExit".to_string(),
+        String::new(),
+        "set_option linter.unusedSimpArgs false".to_string(),
+        String::new(),
+        "namespace Arch.ThreadLoweringProof.Generated".to_string(),
+        "open Arch.ThreadLoweringProof.CountedWait".to_string(),
+        String::new(),
+        "def updateById (id : Nat) : Arch.ThreadLoweringProof.FoldedExit.Update :=".to_string(),
+        "  fun store var => if var = id then id else store var".to_string(),
+        String::new(),
+    ];
+
+    for module in &map.modules {
+        for thread in &module.threads {
+            chunks.push(render_lean_thread(
+                &module.module_name,
+                thread,
+                &mut ctx.guard_ids,
+                &mut ctx.nat_ids,
+                &mut ctx.action_ids,
+            ));
+            chunks.push(String::new());
+        }
+    }
+
+    let mut seq_ordinal = 0usize;
+    for module in &map.modules {
+        for thread in &module.threads {
+            for state in &thread.states {
+                if !state.emitted || state.seq_assignments.is_empty() {
+                    continue;
+                }
+                chunks.push(render_seq_assignment_store_lean_proof(
+                    &module.module_name,
+                    thread,
+                    state,
+                    seq_ordinal,
+                    &mut ctx,
+                ));
+                chunks.push(String::new());
+                seq_ordinal += 1;
+            }
+        }
+    }
+
+    let mut folded_ordinal = 0usize;
+    for module in &map.modules {
+        for thread in &module.threads {
+            for state in &thread.states {
+                if state.folded_exit_updates.is_empty() {
+                    continue;
+                }
+                chunks.push(render_folded_exit_lean_proof(
+                    &module.module_name,
+                    thread,
+                    state,
+                    folded_ordinal,
+                    &mut ctx,
+                ));
+                chunks.push(String::new());
+                folded_ordinal += 1;
+            }
+        }
+    }
+
+    chunks.push("end Arch.ThreadLoweringProof.Generated".to_string());
+    chunks.push(String::new());
+    chunks.join("\n")
+}
+
+#[derive(Default)]
+struct LeanRenderCtx {
+    guard_ids: SymbolTable,
+    nat_ids: SymbolTable,
+    action_ids: SymbolTable,
+    update_ids: SymbolTable,
+    var_ids: SymbolTable,
+    value_ids: SymbolTable,
+}
+
+fn validate_lean_render_map(map: &ThreadMap) -> Result<(), String> {
+    for module in &map.modules {
+        for thread in &module.threads {
+            validate_lean_render_thread(&module.module_name, thread)?;
+        }
+    }
+    Ok(())
+}
+
+fn validate_lean_render_thread(module_name: &str, thread: &ThreadMapThread) -> Result<(), String> {
+    let base = lean_ident(&format!("{}_{}_{}", module_name, thread.name, thread.index));
+    validate_raw_state_table(&base, thread)?;
+    let states: Vec<&ThreadMapState> = thread.states.iter().filter(|s| s.emitted).collect();
+    if states.is_empty() {
+        return Err(format!("{base}: certificate has no emitted states"));
+    }
+
+    let mut seen_indices = HashSet::new();
+    let mut index_map = HashMap::new();
+    for (compact, state) in states.iter().enumerate() {
+        if !seen_indices.insert(state.index) {
+            return Err(format!(
+                "{base}: duplicate emitted state index {} ({})",
+                state.index, state.state_name
+            ));
+        }
+        index_map.insert(state.index, compact);
+    }
+
+    for state in &states {
+        validate_source_next(
+            &base,
+            state,
+            states.len(),
+            &index_map,
+            thread.once,
+            &thread.states,
+        )?;
+        validate_counted_wait(&base, state)?;
+        let source_transitions = if state.source_transitions.is_empty() {
+            &state.transitions
+        } else {
+            &state.source_transitions
+        };
+        validate_transitions(
+            &base,
+            state,
+            "source transition",
+            source_transitions,
+            &index_map,
+            states.len(),
+            thread.once,
+            &thread.states,
+        )?;
+        validate_transitions(
+            &base,
+            state,
+            "transition",
+            &state.transitions,
+            &index_map,
+            states.len(),
+            thread.once,
+            &thread.states,
+        )?;
+        validate_role_shape(&base, state, source_transitions)?;
+        validate_assignment_coverage(&base, state)?;
+        validate_folded_exit_transition(&base, state)?;
+    }
+
+    Ok(())
+}
+
+fn validate_raw_state_table(base: &str, thread: &ThreadMapThread) -> Result<(), String> {
+    for (raw_idx, state) in thread.states.iter().enumerate() {
+        if state.index != raw_idx {
+            return Err(format!(
+                "{base}: raw state table is not contiguous at position {raw_idx}; found state index {} ({})",
+                state.index, state.state_name
+            ));
+        }
+        if state.source_transition_origin != "pre_fold_snapshot" {
+            return Err(format!(
+                "{base}: {} has unsupported source_transition_origin {:?}",
+                state.state_name, state.source_transition_origin
+            ));
+        }
+    }
+    if let Some(first) = thread.states.first() {
+        if first.index != 0 || !first.emitted {
+            return Err(format!(
+                "{base}: raw state 0 must be the first emitted compact state"
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn validate_source_next(
+    base: &str,
+    state: &ThreadMapState,
+    num_states: usize,
+    index_map: &HashMap<usize, usize>,
+    once: bool,
+    raw_states: &[ThreadMapState],
+) -> Result<(), String> {
+    let compact_idx = *index_map.get(&state.index).ok_or_else(|| {
+        format!(
+            "{base}: emitted state {} ({}) is missing from compact index map",
+            state.index, state.state_name
+        )
+    })?;
+    let inferred = compact_next(compact_idx, num_states, once);
+    let explicit = if let Some(compact) = index_map.get(&state.source_next_index) {
+        *compact
+    } else if is_once_terminal_raw_target(state.source_next_index, raw_states, once) {
+        inferred
+    } else {
+        return Err(format!(
+            "{base}: {} source_next targets non-emitted or unknown state {} ({})",
+            state.state_name, state.source_next_index, state.source_next_name
+        ));
+    };
+    if explicit != inferred {
+        return Err(format!(
+            "{base}: {} source_next compact state {}, expected natural compact next {}",
+            state.state_name, explicit, inferred
+        ));
+    }
+    Ok(())
+}
+
+fn validate_counted_wait(base: &str, state: &ThreadMapState) -> Result<(), String> {
+    if state.role != "wait_cycles" {
+        return Ok(());
+    }
+    let Some(count) = &state.wait_cycles_count else {
+        return Err(format!(
+            "{base}: {} wait_cycles state missing structured wait_cycles_count",
+            state.state_name
+        ));
+    };
+    if !count.chars().all(|ch| ch.is_ascii_digit()) {
+        return Err(format!(
+            "{base}: {} non-literal wait_cycles_count {:?}",
+            state.state_name, count
+        ));
+    }
+    Ok(())
+}
+
+fn validate_transitions(
+    base: &str,
+    state: &ThreadMapState,
+    label: &str,
+    transitions: &[ThreadMapTransition],
+    index_map: &HashMap<usize, usize>,
+    num_states: usize,
+    once: bool,
+    raw_states: &[ThreadMapState],
+) -> Result<(), String> {
+    for (idx, transition) in transitions.iter().enumerate() {
+        if resolve_target_checked(state, transition, index_map, num_states, once, raw_states)
+            .is_none()
+        {
+            return Err(format!(
+                "{base}: {} {} targets non-emitted or unknown state {} ({})",
+                state.state_name, label, transition.target_index, transition.target_name
+            ));
+        }
+        if state.role != "wait_cycles" && transition.condition_guard.is_none() {
+            return Err(format!(
+                "{base}: {} {} {idx} missing structured condition_guard",
+                state.state_name, label
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn validate_role_shape(
+    base: &str,
+    state: &ThreadMapState,
+    source_transitions: &[ThreadMapTransition],
+) -> Result<(), String> {
+    let lowered_count = state.transitions.len();
+    let source_count = source_transitions.len();
+    if state.role == "dispatch" {
+        if lowered_count < 2 || source_count < 2 {
+            return Err(format!(
+                "{base}: {} dispatch state must have at least two source and lowered transitions",
+                state.state_name
+            ));
+        }
+    } else if lowered_count != 1 || source_count != 1 {
+        return Err(format!(
+            "{base}: {} non-dispatch state must have exactly one source and lowered transition",
+            state.state_name
+        ));
+    }
+    Ok(())
+}
+
+fn validate_assignment_coverage(base: &str, state: &ThreadMapState) -> Result<(), String> {
+    if !state.seq_assignments.is_empty() && state.seq_assignments.len() != state.seq_updates.len() {
+        return Err(format!(
+            "{base}: {} seq_assignments only cover {}/{} seq_updates",
+            state.state_name,
+            state.seq_assignments.len(),
+            state.seq_updates.len()
+        ));
+    }
+    if !state.folded_exit_updates.is_empty()
+        && state.folded_exit_assignments.len() != state.folded_exit_updates.len()
+    {
+        return Err(format!(
+            "{base}: {} folded_exit_assignments only cover {}/{} folded_exit_updates",
+            state.state_name,
+            state.folded_exit_assignments.len(),
+            state.folded_exit_updates.len()
+        ));
+    }
+    Ok(())
+}
+
+fn validate_folded_exit_transition(base: &str, state: &ThreadMapState) -> Result<(), String> {
+    if state.folded_exit_updates.is_empty() {
+        return Ok(());
+    }
+    if let Some(transition) = state.transitions.first() {
+        if transition.condition_guard.is_none() {
+            return Err(format!(
+                "{base}: {} folded-exit transition missing structured condition_guard",
+                state.state_name
+            ));
+        }
+    }
+    Ok(())
+}
+
+#[derive(Default)]
+struct SymbolTable {
+    ids: HashMap<String, usize>,
+}
+
+impl SymbolTable {
+    fn id(&mut self, value: &str) -> usize {
+        if let Some(id) = self.ids.get(value) {
+            return *id;
+        }
+        let id = self.ids.len();
+        self.ids.insert(value.to_string(), id);
+        id
+    }
+}
+
+#[derive(Clone)]
+struct LeanArm {
+    idx: usize,
+    actions: String,
+    source_control: String,
+    fsm_control: String,
+    target: usize,
+}
+
+fn render_lean_thread(
+    module_name: &str,
+    thread: &ThreadMapThread,
+    guard_ids: &mut SymbolTable,
+    nat_ids: &mut SymbolTable,
+    action_ids: &mut SymbolTable,
+) -> String {
+    let base = lean_ident(&format!("{}_{}_{}", module_name, thread.name, thread.index));
+    let states: Vec<&ThreadMapState> = thread.states.iter().filter(|s| s.emitted).collect();
+    assert!(
+        !states.is_empty(),
+        "{base}: certificate has no emitted states"
+    );
+    let index_map: HashMap<usize, usize> = states
+        .iter()
+        .enumerate()
+        .map(|(compact, state)| (state.index, compact))
+        .collect();
+    let num_states = states.len();
+    let has_dispatch = states.iter().any(|state| state.role == "dispatch");
+
+    let arms: Vec<LeanArm> = states
+        .iter()
+        .enumerate()
+        .map(|(idx, state)| {
+            let source_next =
+                source_next_for_state(state, num_states, &index_map, thread.once, &thread.states);
+            let source_transitions = if state.source_transitions.is_empty() {
+                &state.transitions
+            } else {
+                &state.source_transitions
+            };
+            let source_control = lean_control_for_state(
+                state,
+                source_transitions,
+                &index_map,
+                guard_ids,
+                nat_ids,
+                source_next,
+                num_states,
+                thread.once,
+                &thread.states,
+            );
+            let fsm_control = lean_control_for_state(
+                state,
+                &state.transitions,
+                &index_map,
+                guard_ids,
+                nat_ids,
+                source_next,
+                num_states,
+                thread.once,
+                &thread.states,
+            );
+            let lowered = state.transitions.first();
+            let has_guarded_lowered = lowered
+                .map(|tr| {
+                    state.role != "dispatch"
+                        && is_guarded_non_dispatch_transition(
+                            state,
+                            tr,
+                            &index_map,
+                            source_next,
+                            guard_ids,
+                            nat_ids,
+                        )
+                })
+                .unwrap_or(false);
+            let has_jump_lowered = lowered
+                .map(|tr| {
+                    state.role != "dispatch"
+                        && is_jump_non_dispatch_transition(
+                            state,
+                            tr,
+                            &index_map,
+                            source_next,
+                            guard_ids,
+                            nat_ids,
+                            num_states,
+                            thread.once,
+                            &thread.states,
+                        )
+                })
+                .unwrap_or(false);
+            let mut target =
+                target_for_state(state, num_states, &index_map, thread.once, &thread.states);
+            if state.role == "dispatch" || has_guarded_lowered || has_jump_lowered {
+                target = source_next;
+            }
+            LeanArm {
+                idx,
+                actions: lean_action_list_for_state(state, action_ids),
+                source_control,
+                fsm_control,
+                target,
+            }
+        })
+        .collect();
+
+    let mut source_lines = vec![
+        format!("def {base}Source : SourceThread :="),
+        format!("  {{ numStates := {num_states}"),
+        format!("    once := {}", if thread.once { "true" } else { "false" }),
+        "    state := fun pc =>".to_string(),
+    ];
+    for arm in &arms {
+        let prefix = if arm.idx == 0 {
+            "      if"
+        } else {
+            "      else if"
+        };
+        source_lines.push(format!("{prefix} pc = {} then", arm.idx));
+        source_lines.push(format!(
+            "        {{ actions := {}, control := {} }}",
+            arm.actions, arm.source_control
+        ));
+    }
+    source_lines.push("      else".to_string());
+    source_lines.push("        { actions := [], control := Control.advance } }".to_string());
+
+    let mut fsm_lines = vec![
+        format!("def {base}Fsm : LoweredFsm :="),
+        "  { state := fun pc =>".to_string(),
+    ];
+    for arm in &arms {
+        let prefix = if arm.idx == 0 {
+            "      if"
+        } else {
+            "      else if"
+        };
+        fsm_lines.push(format!("{prefix} pc = {} then", arm.idx));
+        fsm_lines.push(format!(
+            "        {{ actions := {}, control := {}, target := {} }}",
+            arm.actions, arm.fsm_control, arm.target
+        ));
+    }
+    fsm_lines.push("      else".to_string());
+    fsm_lines.push(format!(
+        "        {{ actions := [], control := Control.advance, target := sourceNext {base}Source pc }} }}"
+    ));
+
+    let cert_tactic = cert_field_tactic(&base, num_states, false);
+    let dispatch_cert_tactic = cert_field_tactic(&base, num_states, has_dispatch);
+    let proof = vec![
+        format!("example : LoweringCertifies {base}Source {base}Fsm := by"),
+        "  refine".to_string(),
+        "    { actions_ok := ?_".to_string(),
+        "      control_ok := ?_".to_string(),
+        "      dispatch_branches_ok := ?_".to_string(),
+        "      target_ok := ?_ }".to_string(),
+        "  · intro pc".to_string(),
+        indent_block(&cert_tactic, 4),
+        "  · intro pc".to_string(),
+        indent_block(&cert_tactic, 4),
+        "  · intro pc".to_string(),
+        indent_block(&dispatch_cert_tactic, 4),
+        "  · intro pc".to_string(),
+        indent_block(&cert_tactic, 4),
+        String::new(),
+        format!("example (inputs : Nat -> Env) (natInputs : Nat -> NatEnv) (cfg0 : Config) :"),
+        format!(
+            "    forall t, sourceTraceObs {base}Source inputs natInputs cfg0 t = fsmTraceObs {base}Fsm inputs natInputs cfg0 t :="
+        ),
+        "  trace_equiv (by".to_string(),
+        "    refine".to_string(),
+        "      { actions_ok := ?_".to_string(),
+        "        control_ok := ?_".to_string(),
+        "        dispatch_branches_ok := ?_".to_string(),
+        "        target_ok := ?_ }".to_string(),
+        "    · intro pc".to_string(),
+        indent_block(&cert_tactic, 6),
+        "    · intro pc".to_string(),
+        indent_block(&cert_tactic, 6),
+        "    · intro pc".to_string(),
+        indent_block(&dispatch_cert_tactic, 6),
+        "    · intro pc".to_string(),
+        indent_block(&cert_tactic, 6),
+        "  ) inputs natInputs cfg0".to_string(),
+    ];
+
+    [
+        source_lines,
+        vec![String::new()],
+        fsm_lines,
+        vec![String::new()],
+        proof,
+    ]
+    .concat()
+    .join("\n")
+}
+
+fn push_state(out: &mut String, state: &ThreadMapState) {
+    out.push_str("            {\n");
+    out.push_str(&format!("              \"index\": {},\n", state.index));
+    push_json_field(out, 14, "state_name", &state.state_name, true);
+    push_json_field(out, 14, "role", &state.role, true);
+    out.push_str(&format!("              \"emitted\": {},\n", state.emitted));
+    out.push_str(&format!(
+        "              \"source_next_index\": {},\n",
+        state.source_next_index
+    ));
+    push_json_field(out, 14, "source_next_name", &state.source_next_name, true);
+    out.push_str("              \"labels\": [");
+    for (i, label) in state.labels.iter().enumerate() {
+        if i > 0 {
+            out.push_str(", ");
+        }
+        push_json_string(out, label);
+    }
+    out.push_str("],\n");
+    out.push_str("              \"wait_cycles_count\": ");
+    if let Some(count) = &state.wait_cycles_count {
+        push_json_string(out, count);
+    } else {
+        out.push_str("null");
+    }
+    out.push_str(",\n");
+    out.push_str("              \"seq_updates\": [");
+    push_json_string_array(out, &state.seq_updates);
+    out.push_str("],\n");
+    out.push_str("              \"seq_assignments\": [");
+    push_assignments(out, &state.seq_assignments);
+    out.push_str("],\n");
+    out.push_str("              \"folded_exit_updates\": [");
+    push_json_string_array(out, &state.folded_exit_updates);
+    out.push_str("],\n");
+    out.push_str("              \"folded_exit_assignments\": [");
+    push_assignments(out, &state.folded_exit_assignments);
+    out.push_str("],\n");
+    out.push_str("              \"source_transitions\": [");
+    push_transitions(out, &state.source_transitions);
+    out.push_str("],\n");
+    push_json_field(
+        out,
+        14,
+        "source_transition_origin",
+        &state.source_transition_origin,
+        true,
+    );
+    out.push_str("              \"transitions\": [");
+    push_transitions(out, &state.transitions);
+    out.push_str("]\n");
+    out.push_str("            }");
+}
+
+fn render_folded_exit_lean_proof(
+    module_name: &str,
+    thread: &ThreadMapThread,
+    state: &ThreadMapState,
+    ordinal: usize,
+    ctx: &mut LeanRenderCtx,
+) -> String {
+    let base = lean_ident(&format!(
+        "{}_{}_{}_{}_folded_{}",
+        module_name, thread.name, thread.index, state.state_name, ordinal
+    ));
+    let fe = "Arch.ThreadLoweringProof.FoldedExit";
+    let guard = state
+        .transitions
+        .first()
+        .map(|tr| {
+            render_guard_expr_for_namespace(
+                &transition_guard_expr(tr, &mut ctx.guard_ids, &mut ctx.nat_ids),
+                fe,
+            )
+        })
+        .unwrap_or_else(|| format!("{fe}.GuardExpr.trueLit"));
+    let updates = lean_update_list(
+        &state.folded_exit_updates,
+        &state.folded_exit_assignments,
+        &mut ctx.update_ids,
+        &mut ctx.var_ids,
+        &mut ctx.value_ids,
+    );
+
+    let mut lines = vec![
+        format!("def {base}Source : {fe}.SourceThread :="),
+        "  { numStates := 2".to_string(),
+        "    state := fun pc =>".to_string(),
+        "      if pc = 0 then".to_string(),
+        "        { updates := []".to_string(),
+        format!("          exitUpdates := {updates}"),
+        format!("          control := {fe}.Control.waitUntil {guard} }}"),
+        "      else".to_string(),
+        "        { updates := []".to_string(),
+        "          exitUpdates := []".to_string(),
+        format!("          control := {fe}.Control.advance }} }}"),
+        String::new(),
+        format!("def {base}Fsm : {fe}.LoweredFsm :="),
+        "  { state := fun pc =>".to_string(),
+        "      if pc = 0 then".to_string(),
+        "        { updates := []".to_string(),
+        format!("          foldedExitUpdates := {updates}"),
+        format!("          control := {fe}.Control.waitUntil {guard}"),
+        "          target := 1".to_string(),
+        "          foldedTarget := some 1 }".to_string(),
+        "      else".to_string(),
+        "        { updates := []".to_string(),
+        "          foldedExitUpdates := []".to_string(),
+        format!("          control := {fe}.Control.advance"),
+        format!("          target := {fe}.sourceNext {base}Source pc"),
+        "          foldedTarget := none } }".to_string(),
+        String::new(),
+        format!("example : {fe}.LoweringCertifies {base}Source {base}Fsm := by"),
+        "  refine".to_string(),
+        "    { updates_ok := ?_".to_string(),
+        "      control_ok := ?_".to_string(),
+        "      target_ok := ?_".to_string(),
+        "      folded_updates_ok := ?_".to_string(),
+        "      folded_target_ok := ?_".to_string(),
+        "      folded_target_some_ok := ?_ }".to_string(),
+        "  · intro pc".to_string(),
+        format!("    by_cases h : pc = 0 <;> simp [{base}Source, {base}Fsm, h]"),
+        "  · intro pc".to_string(),
+        format!("    by_cases h : pc = 0 <;> simp [{base}Source, {base}Fsm, h]"),
+        "  · intro pc".to_string(),
+        format!("    by_cases h : pc = 0 <;> simp [{base}Source, {base}Fsm, {fe}.sourceNext, h]"),
+        "  · intro pc".to_string(),
+        format!("    by_cases h : pc = 0 <;> simp [{base}Source, {base}Fsm, h]"),
+        "  · intro pc hupdates".to_string(),
+        format!(
+            "    by_cases h : pc = 0 <;> simp [{base}Source, {base}Fsm, {fe}.sourceNext, h] at *"
+        ),
+        "  · intro pc target hfold".to_string(),
+        format!(
+            "    by_cases h : pc = 0 <;> simp [{base}Source, {base}Fsm, {fe}.sourceNext, h] at *"
+        ),
+        "    exact hfold.symm".to_string(),
+        String::new(),
+        format!("example (env : {fe}.Env) (natEnv : {fe}.NatEnv) (cfg : {fe}.Config) :"),
+        format!(
+            "    {fe}.sourceStep {base}Source env natEnv cfg = {fe}.fsmStep {base}Fsm env natEnv cfg :="
+        ),
+        format!("  {fe}.one_step_equiv (by"),
+        "    refine".to_string(),
+        "      { updates_ok := ?_".to_string(),
+        "        control_ok := ?_".to_string(),
+        "        target_ok := ?_".to_string(),
+        "        folded_updates_ok := ?_".to_string(),
+        "        folded_target_ok := ?_".to_string(),
+        "        folded_target_some_ok := ?_ }".to_string(),
+        format!("    · intro pc; by_cases h : pc = 0 <;> simp [{base}Source, {base}Fsm, h]"),
+        format!("    · intro pc; by_cases h : pc = 0 <;> simp [{base}Source, {base}Fsm, h]"),
+        format!("    · intro pc; by_cases h : pc = 0 <;> simp [{base}Source, {base}Fsm, {fe}.sourceNext, h]"),
+        format!("    · intro pc; by_cases h : pc = 0 <;> simp [{base}Source, {base}Fsm, h]"),
+        format!("    · intro pc hupdates; by_cases h : pc = 0 <;> simp [{base}Source, {base}Fsm, {fe}.sourceNext, h] at *"),
+        format!("    · intro pc target hfold; by_cases h : pc = 0 <;> simp [{base}Source, {base}Fsm, {fe}.sourceNext, h] at *; exact hfold.symm"),
+        "  ) env natEnv cfg".to_string(),
+    ];
+
+    let mut seen_targets = HashSet::new();
+    let mut final_writes = Vec::new();
+    for assignment in state.folded_exit_assignments.iter().rev() {
+        if seen_targets.insert(assignment.target.clone()) {
+            final_writes.push(assignment);
+        }
+    }
+    final_writes.reverse();
+
+    for assignment in final_writes {
+        let target = ctx.var_ids.id(&assignment.target);
+        let value = ctx.value_ids.id(&assignment.value);
+        lines.extend([
+            String::new(),
+            format!("example (env : {fe}.Env) (natEnv : {fe}.NatEnv) (store : {fe}.Store)"),
+            format!("    (hguard : {fe}.GuardExpr.eval env {guard} natEnv = true) :"),
+            format!("    let cfg : {fe}.Config := {{ pc := 0, store := store }}"),
+            format!(
+                "    (({fe}.sourceStep {base}Source env natEnv cfg).store {target} = {value}) /\\"
+            ),
+            format!(
+                "      (({fe}.fsmStep {base}Fsm env natEnv cfg).store {target} = {value}) := by"
+            ),
+            format!("  simp [{fe}.sourceStep, {fe}.fsmStep, {base}Source, {base}Fsm,"),
+            format!("    {fe}.sourceAdvanceTo, {fe}.fsmAdvanceTo, {fe}.applyUpdates, {fe}.setVar, hguard]"),
+        ]);
+    }
+
+    lines.join("\n")
+}
+
+fn render_seq_assignment_store_lean_proof(
+    module_name: &str,
+    thread: &ThreadMapThread,
+    state: &ThreadMapState,
+    ordinal: usize,
+    ctx: &mut LeanRenderCtx,
+) -> String {
+    let base = lean_ident(&format!(
+        "{}_{}_{}_{}_seq_{}",
+        module_name, thread.name, thread.index, state.state_name, ordinal
+    ));
+    let fe = "Arch.ThreadLoweringProof.FoldedExit";
+    let updates = state
+        .seq_assignments
+        .iter()
+        .map(|assignment| {
+            let target = ctx.var_ids.id(&assignment.target);
+            let value = ctx.value_ids.id(&assignment.value);
+            format!("{fe}.setVar {target} {value}")
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    let mut lines = vec![
+        format!("def {base}Updates : List {fe}.Update :="),
+        format!("  [{updates}]"),
+    ];
+
+    let mut seen_targets = HashSet::new();
+    let mut final_writes = Vec::new();
+    for assignment in state.seq_assignments.iter().rev() {
+        if seen_targets.insert(assignment.target.clone()) {
+            final_writes.push(assignment);
+        }
+    }
+    final_writes.reverse();
+
+    for assignment in final_writes {
+        let target = ctx.var_ids.id(&assignment.target);
+        let value = ctx.value_ids.id(&assignment.value);
+        lines.extend([
+            String::new(),
+            format!("example (store : {fe}.Store) :"),
+            format!("    {fe}.applyUpdates {base}Updates store {target} = {value} := by"),
+            format!("  simp [{base}Updates, {fe}.applyUpdates, {fe}.setVar]"),
+        ]);
+    }
+
+    lines.join("\n")
+}
+
+fn lean_ident(name: &str) -> String {
+    let mut out = String::new();
+    for ch in name.chars() {
+        if ch.is_ascii_alphanumeric() || ch == '_' {
+            out.push(ch);
+        } else {
+            out.push('_');
+        }
+    }
+    if out.is_empty() || out.as_bytes()[0].is_ascii_digit() {
+        out = format!("cert_{out}");
+    }
+    out
+}
+
+fn render_nat_expr(expr: &ThreadMapNatExpr, namespace: Option<&str>) -> String {
+    let prefix = namespace
+        .map(|ns| format!("{ns}.NatExpr"))
+        .unwrap_or_else(|| "NatExpr".to_string());
+    match expr {
+        ThreadMapNatExpr::Var(name) => format!("({prefix}.var {})", lean_symbol_id(name)),
+        ThreadMapNatExpr::Const(value) => format!("({prefix}.const {value})"),
+    }
+}
+
+fn render_guard_expr(expr: &ThreadMapGuardExpr) -> String {
+    render_guard_expr_for_namespace(expr, "")
+}
+
+fn render_guard_expr_for_namespace(expr: &ThreadMapGuardExpr, namespace: &str) -> String {
+    let guard_prefix = if namespace.is_empty() {
+        "GuardExpr".to_string()
+    } else {
+        format!("{namespace}.GuardExpr")
+    };
+    let nat_namespace = (!namespace.is_empty()).then_some(namespace);
+    match expr {
+        ThreadMapGuardExpr::Atom(name) => format!("({guard_prefix}.atom {})", lean_symbol_id(name)),
+        ThreadMapGuardExpr::True => format!("{guard_prefix}.trueLit"),
+        ThreadMapGuardExpr::False => format!("{guard_prefix}.falseLit"),
+        ThreadMapGuardExpr::Not(inner) => {
+            format!(
+                "({guard_prefix}.neg {})",
+                render_guard_expr_for_namespace(inner, namespace)
+            )
+        }
+        ThreadMapGuardExpr::And(lhs, rhs) => format!(
+            "({guard_prefix}.and {} {})",
+            render_guard_expr_for_namespace(lhs, namespace),
+            render_guard_expr_for_namespace(rhs, namespace)
+        ),
+        ThreadMapGuardExpr::Or(lhs, rhs) => format!(
+            "({guard_prefix}.or {} {})",
+            render_guard_expr_for_namespace(lhs, namespace),
+            render_guard_expr_for_namespace(rhs, namespace)
+        ),
+        ThreadMapGuardExpr::Lt(lhs, rhs) => format!(
+            "({guard_prefix}.lt {} {})",
+            render_nat_expr(lhs, nat_namespace),
+            render_nat_expr(rhs, nat_namespace)
+        ),
+        ThreadMapGuardExpr::Ge(lhs, rhs) => format!(
+            "({guard_prefix}.ge {} {})",
+            render_nat_expr(lhs, nat_namespace),
+            render_nat_expr(rhs, nat_namespace)
+        ),
+        ThreadMapGuardExpr::Eq(lhs, rhs) => format!(
+            "({guard_prefix}.eq {} {})",
+            render_nat_expr(lhs, nat_namespace),
+            render_nat_expr(rhs, nat_namespace)
+        ),
+        ThreadMapGuardExpr::Ne(lhs, rhs) => format!(
+            "({guard_prefix}.ne {} {})",
+            render_nat_expr(lhs, nat_namespace),
+            render_nat_expr(rhs, nat_namespace)
+        ),
+    }
+}
+
+fn transition_guard_expr(
+    transition: &ThreadMapTransition,
+    guard_ids: &mut SymbolTable,
+    nat_ids: &mut SymbolTable,
+) -> ThreadMapGuardExpr {
+    if let Some(guard) = &transition.condition_guard {
+        return intern_guard_expr(guard, guard_ids, nat_ids);
+    }
+    panic!(
+        "transition {:?} -> {} missing structured condition_guard",
+        transition.condition, transition.target_name
+    )
+}
+
+fn intern_guard_expr(
+    expr: &ThreadMapGuardExpr,
+    guard_ids: &mut SymbolTable,
+    nat_ids: &mut SymbolTable,
+) -> ThreadMapGuardExpr {
+    match expr {
+        ThreadMapGuardExpr::Atom(name) => ThreadMapGuardExpr::Atom(guard_ids.id(name).to_string()),
+        ThreadMapGuardExpr::True => ThreadMapGuardExpr::True,
+        ThreadMapGuardExpr::False => ThreadMapGuardExpr::False,
+        ThreadMapGuardExpr::Not(inner) => {
+            ThreadMapGuardExpr::Not(Box::new(intern_guard_expr(inner, guard_ids, nat_ids)))
+        }
+        ThreadMapGuardExpr::And(lhs, rhs) => ThreadMapGuardExpr::And(
+            Box::new(intern_guard_expr(lhs, guard_ids, nat_ids)),
+            Box::new(intern_guard_expr(rhs, guard_ids, nat_ids)),
+        ),
+        ThreadMapGuardExpr::Or(lhs, rhs) => ThreadMapGuardExpr::Or(
+            Box::new(intern_guard_expr(lhs, guard_ids, nat_ids)),
+            Box::new(intern_guard_expr(rhs, guard_ids, nat_ids)),
+        ),
+        ThreadMapGuardExpr::Lt(lhs, rhs) => {
+            ThreadMapGuardExpr::Lt(intern_nat_expr(lhs, nat_ids), intern_nat_expr(rhs, nat_ids))
+        }
+        ThreadMapGuardExpr::Ge(lhs, rhs) => {
+            ThreadMapGuardExpr::Ge(intern_nat_expr(lhs, nat_ids), intern_nat_expr(rhs, nat_ids))
+        }
+        ThreadMapGuardExpr::Eq(lhs, rhs) => {
+            ThreadMapGuardExpr::Eq(intern_nat_expr(lhs, nat_ids), intern_nat_expr(rhs, nat_ids))
+        }
+        ThreadMapGuardExpr::Ne(lhs, rhs) => {
+            ThreadMapGuardExpr::Ne(intern_nat_expr(lhs, nat_ids), intern_nat_expr(rhs, nat_ids))
+        }
+    }
+}
+
+fn intern_nat_expr(expr: &ThreadMapNatExpr, nat_ids: &mut SymbolTable) -> ThreadMapNatExpr {
+    match expr {
+        ThreadMapNatExpr::Var(name) => ThreadMapNatExpr::Var(nat_ids.id(name).to_string()),
+        ThreadMapNatExpr::Const(value) => ThreadMapNatExpr::Const(*value),
+    }
+}
+
+fn lean_symbol_id(value: &str) -> String {
+    value.parse::<usize>().unwrap_or(0).to_string()
+}
+
+fn transition_is_unconditional(
+    transition: &ThreadMapTransition,
+    guard_ids: &mut SymbolTable,
+    nat_ids: &mut SymbolTable,
+) -> bool {
+    matches!(
+        transition_guard_expr(transition, guard_ids, nat_ids),
+        ThreadMapGuardExpr::True
+    )
+}
+
+fn lean_control_for_state(
+    state: &ThreadMapState,
+    transitions: &[ThreadMapTransition],
+    index_map: &HashMap<usize, usize>,
+    guard_ids: &mut SymbolTable,
+    nat_ids: &mut SymbolTable,
+    source_next: usize,
+    num_states: usize,
+    once: bool,
+    raw_states: &[ThreadMapState],
+) -> String {
+    match state.role.as_str() {
+        "wait_until" => {
+            let guard = transitions
+                .first()
+                .map(|tr| render_guard_expr(&transition_guard_expr(tr, guard_ids, nat_ids)))
+                .unwrap_or_else(|| "GuardExpr.trueLit".to_string());
+            format!("Control.waitUntil {guard}")
+        }
+        "wait_cycles" => {
+            let count = state.wait_cycles_count.as_deref().unwrap_or_else(|| {
+                panic!(
+                    "{}: wait_cycles state missing structured wait_cycles_count",
+                    state.state_name
+                )
+            });
+            assert!(
+                count.chars().all(|ch| ch.is_ascii_digit()),
+                "{}: non-literal wait_cycles_count {:?}",
+                state.state_name,
+                count
+            );
+            format!("Control.waitCycles {count}")
+        }
+        "dispatch" => {
+            let branches = transitions
+                .iter()
+                .map(|tr| {
+                    let guard = render_guard_expr(&transition_guard_expr(tr, guard_ids, nat_ids));
+                    let target = resolve_target(state, tr, index_map, num_states, once, raw_states);
+                    format!("{{ guard := {guard}, target := {target} }}")
+                })
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!("Control.dispatch [{branches}]")
+        }
+        _ => {
+            if transitions.len() == 1 {
+                let tr = &transitions[0];
+                let target = resolve_target(state, tr, index_map, num_states, once, raw_states);
+                if transition_is_unconditional(tr, guard_ids, nat_ids) {
+                    if target != source_next {
+                        return format!("Control.jump {target}");
+                    }
+                } else {
+                    let guard = render_guard_expr(&transition_guard_expr(tr, guard_ids, nat_ids));
+                    return format!("Control.guarded {guard} {target}");
+                }
+            }
+            "Control.advance".to_string()
+        }
+    }
+}
+
+fn resolve_target(
+    state: &ThreadMapState,
+    transition: &ThreadMapTransition,
+    index_map: &HashMap<usize, usize>,
+    num_states: usize,
+    once: bool,
+    raw_states: &[ThreadMapState],
+) -> usize {
+    resolve_target_checked(state, transition, index_map, num_states, once, raw_states)
+        .unwrap_or_else(|| {
+            panic!(
+                "{}: transition targets non-emitted or unknown state {} ({})",
+                state.state_name, transition.target_index, transition.target_name
+            )
+        })
+}
+
+fn resolve_target_checked(
+    state: &ThreadMapState,
+    transition: &ThreadMapTransition,
+    index_map: &HashMap<usize, usize>,
+    num_states: usize,
+    once: bool,
+    raw_states: &[ThreadMapState],
+) -> Option<usize> {
+    if let Some(compact) = index_map.get(&transition.target_index) {
+        Some(*compact)
+    } else if is_once_terminal_raw_target(transition.target_index, raw_states, once) {
+        let compact_idx = *index_map.get(&state.index)?;
+        Some(compact_next(compact_idx, num_states, once))
+    } else {
+        None
+    }
+}
+
+fn source_next_for_state(
+    state: &ThreadMapState,
+    num_states: usize,
+    index_map: &HashMap<usize, usize>,
+    once: bool,
+    raw_states: &[ThreadMapState],
+) -> usize {
+    let compact_idx = *index_map.get(&state.index).unwrap_or(&0);
+    let inferred = compact_next(compact_idx, num_states, once);
+    let explicit = if let Some(compact) = index_map.get(&state.source_next_index) {
+        *compact
+    } else if is_once_terminal_raw_target(state.source_next_index, raw_states, once) {
+        inferred
+    } else {
+        panic!(
+            "{}: source_next targets non-emitted or unknown state {} ({})",
+            state.state_name, state.source_next_index, state.source_next_name
+        );
+    };
+    assert_eq!(
+        explicit, inferred,
+        "{}: source_next compact state {}, expected natural compact next {}",
+        state.state_name, explicit, inferred
+    );
+    explicit
+}
+
+fn target_for_state(
+    state: &ThreadMapState,
+    num_states: usize,
+    index_map: &HashMap<usize, usize>,
+    once: bool,
+    raw_states: &[ThreadMapState],
+) -> usize {
+    state
+        .transitions
+        .first()
+        .map(|tr| resolve_target(state, tr, index_map, num_states, once, raw_states))
+        .unwrap_or_else(|| {
+            let compact_idx = *index_map.get(&state.index).unwrap_or(&0);
+            compact_next(compact_idx, num_states, once)
+        })
+}
+
+fn is_once_terminal_raw_target(
+    raw_target: usize,
+    raw_states: &[ThreadMapState],
+    once: bool,
+) -> bool {
+    once && raw_states
+        .get(raw_target)
+        .map(|state| {
+            !state.emitted
+                && state.source_next_index == raw_target
+                && state
+                    .source_transitions
+                    .iter()
+                    .all(|transition| transition.target_index == raw_target)
+        })
+        .unwrap_or(false)
+}
+
+fn compact_next(idx: usize, num_states: usize, once: bool) -> usize {
+    if idx + 1 < num_states {
+        idx + 1
+    } else if once {
+        idx
+    } else {
+        0
+    }
+}
+
+fn is_guarded_non_dispatch_transition(
+    state: &ThreadMapState,
+    transition: &ThreadMapTransition,
+    _index_map: &HashMap<usize, usize>,
+    _source_next: usize,
+    guard_ids: &mut SymbolTable,
+    nat_ids: &mut SymbolTable,
+) -> bool {
+    state.role != "dispatch"
+        && state.role != "wait_cycles"
+        && !transition_is_unconditional(transition, guard_ids, nat_ids)
+}
+
+fn is_jump_non_dispatch_transition(
+    state: &ThreadMapState,
+    transition: &ThreadMapTransition,
+    index_map: &HashMap<usize, usize>,
+    source_next: usize,
+    guard_ids: &mut SymbolTable,
+    nat_ids: &mut SymbolTable,
+    num_states: usize,
+    once: bool,
+    raw_states: &[ThreadMapState],
+) -> bool {
+    state.role != "dispatch"
+        && state.role != "wait_cycles"
+        && resolve_target(state, transition, index_map, num_states, once, raw_states) != source_next
+        && transition_is_unconditional(transition, guard_ids, nat_ids)
+}
+
+fn lean_action_list_for_state(state: &ThreadMapState, action_ids: &mut SymbolTable) -> String {
+    let ids = if !state.seq_assignments.is_empty() {
+        state
+            .seq_assignments
+            .iter()
+            .map(|assignment| {
+                action_ids.id(&format!("{} := {}", assignment.target, assignment.value))
+            })
+            .collect::<Vec<_>>()
+    } else {
+        state
+            .seq_updates
+            .iter()
+            .map(|label| action_ids.id(label))
+            .collect::<Vec<_>>()
+    };
+    lean_nat_list(&ids)
+}
+
+fn lean_update_list(
+    labels: &[String],
+    assignments: &[ThreadMapAssignment],
+    update_ids: &mut SymbolTable,
+    var_ids: &mut SymbolTable,
+    value_ids: &mut SymbolTable,
+) -> String {
+    if !assignments.is_empty() {
+        let fe = "Arch.ThreadLoweringProof.FoldedExit";
+        let updates = assignments
+            .iter()
+            .map(|assignment| {
+                let target = var_ids.id(&assignment.target);
+                let value = value_ids.id(&assignment.value);
+                format!("{fe}.setVar {target} {value}")
+            })
+            .collect::<Vec<_>>()
+            .join(", ");
+        return format!("[{updates}]");
+    }
+    let updates = labels
+        .iter()
+        .map(|label| format!("updateById {}", update_ids.id(label)))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!("[{updates}]")
+}
+
+fn lean_nat_list(values: &[usize]) -> String {
+    if values.is_empty() {
+        "[]".to_string()
+    } else {
+        format!(
+            "[{}]",
+            values
+                .iter()
+                .map(|value| value.to_string())
+                .collect::<Vec<_>>()
+                .join(", ")
+        )
+    }
+}
+
+fn cert_field_tactic(base: &str, num_states: usize, include_dispatch_branches: bool) -> String {
+    let extra = if include_dispatch_branches {
+        ", dispatchBranches"
+    } else {
+        ""
+    };
+    if num_states == 0 {
+        return format!("simp [{base}Source, {base}Fsm, sourceNext{extra}]");
+    }
+
+    fn simp_line(base: &str, extra: &str, hyps: &[String]) -> String {
+        let hyp_args = hyps
+            .iter()
+            .map(|hyp| format!(", {hyp}"))
+            .collect::<String>();
+        format!("simp [{base}Source, {base}Fsm, sourceNext{extra}{hyp_args}]")
+    }
+
+    fn go(
+        base: &str,
+        extra: &str,
+        idx: usize,
+        num_states: usize,
+        hyps: Vec<String>,
+        depth: usize,
+        lines: &mut Vec<String>,
+    ) {
+        let indent = "  ".repeat(depth);
+        if idx >= num_states {
+            lines.push(format!("{indent}{}", simp_line(base, extra, &hyps)));
+            return;
+        }
+        let hyp = format!("h{idx}");
+        lines.push(format!("{indent}by_cases {hyp} : pc = {idx}"));
+        let mut with_hyp = hyps.clone();
+        with_hyp.push(hyp.clone());
+        lines.push(format!("{indent}· {}", simp_line(base, extra, &with_hyp)));
+        lines.push(format!("{indent}·"));
+        let mut without = hyps;
+        without.push(hyp);
+        go(base, extra, idx + 1, num_states, without, depth + 1, lines);
+    }
+
+    let mut lines = Vec::new();
+    go(base, extra, 0, num_states, Vec::new(), 0, &mut lines);
+    lines.join("\n")
+}
+
+fn indent_block(text: &str, spaces: usize) -> String {
+    let prefix = " ".repeat(spaces);
+    text.lines()
+        .map(|line| {
+            if line.is_empty() {
+                String::new()
+            } else {
+                format!("{prefix}{line}")
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn push_transitions(out: &mut String, transitions: &[ThreadMapTransition]) {
+    for (i, tr) in transitions.iter().enumerate() {
+        if i > 0 {
+            out.push_str(", ");
+        }
+        out.push_str("{\"condition\": ");
+        push_json_string(out, &tr.condition);
+        if let Some(guard) = &tr.condition_guard {
+            out.push_str(", \"condition_guard\": ");
+            push_guard_expr(out, guard);
+        }
+        out.push_str(&format!(
+            ", \"target_index\": {}, \"target_name\": ",
+            tr.target_index
+        ));
+        push_json_string(out, &tr.target_name);
+        out.push('}');
+    }
+}
+
+fn push_guard_expr(out: &mut String, guard: &ThreadMapGuardExpr) {
+    out.push('{');
+    match guard {
+        ThreadMapGuardExpr::Atom(name) => {
+            out.push_str("\"kind\":\"atom\",\"name\":");
+            push_json_string(out, name);
+        }
+        ThreadMapGuardExpr::True => {
+            out.push_str("\"kind\":\"true\"");
+        }
+        ThreadMapGuardExpr::False => {
+            out.push_str("\"kind\":\"false\"");
+        }
+        ThreadMapGuardExpr::Not(expr) => {
+            out.push_str("\"kind\":\"not\",\"expr\":");
+            push_guard_expr(out, expr);
+        }
+        ThreadMapGuardExpr::And(lhs, rhs) => {
+            out.push_str("\"kind\":\"and\",\"lhs\":");
+            push_guard_expr(out, lhs);
+            out.push_str(",\"rhs\":");
+            push_guard_expr(out, rhs);
+        }
+        ThreadMapGuardExpr::Or(lhs, rhs) => {
+            out.push_str("\"kind\":\"or\",\"lhs\":");
+            push_guard_expr(out, lhs);
+            out.push_str(",\"rhs\":");
+            push_guard_expr(out, rhs);
+        }
+        ThreadMapGuardExpr::Lt(lhs, rhs) => {
+            out.push_str("\"kind\":\"lt\",\"lhs\":");
+            push_nat_expr(out, lhs);
+            out.push_str(",\"rhs\":");
+            push_nat_expr(out, rhs);
+        }
+        ThreadMapGuardExpr::Ge(lhs, rhs) => {
+            out.push_str("\"kind\":\"ge\",\"lhs\":");
+            push_nat_expr(out, lhs);
+            out.push_str(",\"rhs\":");
+            push_nat_expr(out, rhs);
+        }
+        ThreadMapGuardExpr::Eq(lhs, rhs) => {
+            out.push_str("\"kind\":\"eq\",\"lhs\":");
+            push_nat_expr(out, lhs);
+            out.push_str(",\"rhs\":");
+            push_nat_expr(out, rhs);
+        }
+        ThreadMapGuardExpr::Ne(lhs, rhs) => {
+            out.push_str("\"kind\":\"ne\",\"lhs\":");
+            push_nat_expr(out, lhs);
+            out.push_str(",\"rhs\":");
+            push_nat_expr(out, rhs);
+        }
+    }
+    out.push('}');
+}
+
+fn push_nat_expr(out: &mut String, expr: &ThreadMapNatExpr) {
+    out.push('{');
+    match expr {
+        ThreadMapNatExpr::Var(name) => {
+            out.push_str("\"kind\":\"var\",\"name\":");
+            push_json_string(out, name);
+        }
+        ThreadMapNatExpr::Const(value) => {
+            out.push_str(&format!("\"kind\":\"const\",\"value\":{value}"));
+        }
+    }
+    out.push('}');
+}
+
+fn push_assignments(out: &mut String, assignments: &[ThreadMapAssignment]) {
+    for (i, assignment) in assignments.iter().enumerate() {
+        if i > 0 {
+            out.push_str(", ");
+        }
+        out.push_str("{\"target\": ");
+        push_json_string(out, &assignment.target);
+        out.push_str(", \"value\": ");
+        push_json_string(out, &assignment.value);
+        out.push('}');
+    }
+}
+
+fn push_json_string_array(out: &mut String, values: &[String]) {
+    for (i, value) in values.iter().enumerate() {
+        if i > 0 {
+            out.push_str(", ");
+        }
+        push_json_string(out, value);
+    }
+}
+
+fn push_json_field(out: &mut String, indent: usize, name: &str, value: &str, comma: bool) {
+    out.push_str(&" ".repeat(indent));
+    push_json_string(out, name);
+    out.push_str(": ");
+    push_json_string(out, value);
+    if comma {
+        out.push(',');
+    }
+    out.push('\n');
+}
+
+fn push_json_string(out: &mut String, value: &str) {
+    out.push('"');
+    for ch in value.chars() {
+        match ch {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if c.is_control() => out.push_str(&format!("\\u{:04x}", c as u32)),
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lexer::Span;
+    use crate::thread_map::{
+        ThreadMapGuardExpr, ThreadMapModule, ThreadMapState, ThreadMapThread, ThreadMapTransition,
+    };
+
+    fn map_with_states(states: Vec<ThreadMapState>) -> ThreadMap {
+        ThreadMap {
+            modules: vec![ThreadMapModule {
+                module_name: "M".to_string(),
+                generated_module_name: "_M_threads".to_string(),
+                span: Span::new(0, 1),
+                threads: vec![ThreadMapThread {
+                    name: "Worker".to_string(),
+                    index: 0,
+                    once: false,
+                    span: Span::new(0, 1),
+                    hazards: Vec::new(),
+                    states,
+                }],
+            }],
+        }
+    }
+
+    fn emitted_action_state(index: usize, source_next_index: usize) -> ThreadMapState {
+        ThreadMapState {
+            index,
+            state_name: format!("_t0_S{index}_action"),
+            role: "action".to_string(),
+            emitted: true,
+            span: Span::new(0, 1),
+            labels: Vec::new(),
+            source_next_index,
+            source_next_name: format!("_t0_S{source_next_index}_action"),
+            wait_cycles_count: None,
+            seq_updates: Vec::new(),
+            seq_assignments: Vec::new(),
+            folded_exit_updates: Vec::new(),
+            folded_exit_assignments: Vec::new(),
+            source_transitions: Vec::new(),
+            source_transition_origin: "pre_fold_snapshot".to_string(),
+            transitions: vec![ThreadMapTransition {
+                condition: "true".to_string(),
+                condition_guard: Some(ThreadMapGuardExpr::True),
+                target_index: source_next_index,
+                target_name: format!("_t0_S{source_next_index}_action"),
+            }],
+        }
+    }
+
+    #[test]
+    fn render_includes_folded_state_marker_and_resolved_transition() {
+        let map = ThreadMap {
+            modules: vec![ThreadMapModule {
+                module_name: "M".to_string(),
+                generated_module_name: "_M_threads".to_string(),
+                span: Span::new(0, 1),
+                threads: vec![ThreadMapThread {
+                    name: "Worker".to_string(),
+                    index: 0,
+                    once: false,
+                    span: Span::new(0, 1),
+                    hazards: Vec::new(),
+                    states: vec![
+                        ThreadMapState {
+                            index: 1,
+                            state_name: "_t0_S1_wait_until".to_string(),
+                            role: "wait_until".to_string(),
+                            emitted: true,
+                            span: Span::new(0, 1),
+                            labels: vec!["wait until req".to_string()],
+                            source_next_index: 3,
+                            source_next_name: "_t0_S3_wait_cycles".to_string(),
+                            wait_cycles_count: None,
+                            seq_updates: Vec::new(),
+                            seq_assignments: Vec::new(),
+                            folded_exit_updates: vec!["done_r <= true".to_string()],
+                            folded_exit_assignments: vec![ThreadMapAssignment {
+                                target: "done_r".to_string(),
+                                value: "true".to_string(),
+                            }],
+                            source_transitions: vec![ThreadMapTransition {
+                                condition: "req".to_string(),
+                                condition_guard: Some(ThreadMapGuardExpr::Atom("req".to_string())),
+                                target_index: 3,
+                                target_name: "_t0_S3_wait_cycles".to_string(),
+                            }],
+                            source_transition_origin: "pre_fold_snapshot".to_string(),
+                            transitions: vec![ThreadMapTransition {
+                                condition: "req".to_string(),
+                                condition_guard: Some(ThreadMapGuardExpr::Atom("req".to_string())),
+                                target_index: 3,
+                                target_name: "_t0_S3_wait_cycles".to_string(),
+                            }],
+                        },
+                        ThreadMapState {
+                            index: 2,
+                            state_name: "_t0_S2_action".to_string(),
+                            role: "action".to_string(),
+                            emitted: false,
+                            span: Span::new(0, 1),
+                            labels: Vec::new(),
+                            source_next_index: 0,
+                            source_next_name: "_t0_S0_wait_until".to_string(),
+                            wait_cycles_count: None,
+                            seq_updates: Vec::new(),
+                            seq_assignments: Vec::new(),
+                            folded_exit_updates: Vec::new(),
+                            folded_exit_assignments: Vec::new(),
+                            source_transitions: Vec::new(),
+                            source_transition_origin: "pre_fold_snapshot".to_string(),
+                            transitions: Vec::new(),
+                        },
+                    ],
+                }],
+            }],
+        };
+
+        let json = render_json(&map);
+        assert!(json.contains("\"schema\": \"arch.thread_lowering_proof.v5\""));
+        assert!(json.contains("\"source_next_index\": 3"));
+        assert!(json.contains("\"source_next_name\": \"_t0_S3_wait_cycles\""));
+        assert!(json.contains("\"once\": false"));
+        assert!(json.contains("\"folded_exit_updates\": [\"done_r <= true\"]"));
+        assert!(json.contains(
+            "\"folded_exit_assignments\": [{\"target\": \"done_r\", \"value\": \"true\"}]"
+        ));
+        assert!(json.contains("\"source_transitions\": [{\"condition\": \"req\""));
+        assert!(json.contains("\"condition_guard\": {\"kind\":\"atom\",\"name\":\"req\"}"));
+        assert!(json.contains("\"source_transition_origin\": \"pre_fold_snapshot\""));
+        assert!(json.contains("\"condition\": \"req\""));
+        assert!(json.contains("\"target_index\": 3"));
+        assert!(json.contains("\"target_name\": \"_t0_S3_wait_cycles\""));
+        assert!(json.contains("\"state_name\": \"_t0_S2_action\""));
+        assert!(json.contains("\"emitted\": false"));
+    }
+
+    #[test]
+    fn render_lean_checked_rejects_missing_wait_cycles_count() {
+        let map = ThreadMap {
+            modules: vec![ThreadMapModule {
+                module_name: "M".to_string(),
+                generated_module_name: "_M_threads".to_string(),
+                span: Span::new(0, 1),
+                threads: vec![ThreadMapThread {
+                    name: "Worker".to_string(),
+                    index: 0,
+                    once: false,
+                    span: Span::new(0, 1),
+                    hazards: Vec::new(),
+                    states: vec![ThreadMapState {
+                        index: 0,
+                        state_name: "_t0_S0_wait_cycles".to_string(),
+                        role: "wait_cycles".to_string(),
+                        emitted: true,
+                        span: Span::new(0, 1),
+                        labels: vec!["wait 2 cycle".to_string()],
+                        source_next_index: 0,
+                        source_next_name: "_t0_S0_wait_cycles".to_string(),
+                        wait_cycles_count: None,
+                        seq_updates: Vec::new(),
+                        seq_assignments: Vec::new(),
+                        folded_exit_updates: Vec::new(),
+                        folded_exit_assignments: Vec::new(),
+                        source_transitions: vec![ThreadMapTransition {
+                            condition: "true".to_string(),
+                            condition_guard: Some(ThreadMapGuardExpr::True),
+                            target_index: 0,
+                            target_name: "_t0_S0_wait_cycles".to_string(),
+                        }],
+                        source_transition_origin: "pre_fold_snapshot".to_string(),
+                        transitions: vec![ThreadMapTransition {
+                            condition: "true".to_string(),
+                            condition_guard: Some(ThreadMapGuardExpr::True),
+                            target_index: 0,
+                            target_name: "_t0_S0_wait_cycles".to_string(),
+                        }],
+                    }],
+                }],
+            }],
+        };
+
+        let err = render_lean_checked(&map).expect_err("missing wait count should fail");
+        assert!(
+            err.contains("missing structured wait_cycles_count"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn render_lean_checked_rejects_missing_non_counted_condition_guard() {
+        let map = ThreadMap {
+            modules: vec![ThreadMapModule {
+                module_name: "M".to_string(),
+                generated_module_name: "_M_threads".to_string(),
+                span: Span::new(0, 1),
+                threads: vec![ThreadMapThread {
+                    name: "Worker".to_string(),
+                    index: 0,
+                    once: false,
+                    span: Span::new(0, 1),
+                    hazards: Vec::new(),
+                    states: vec![ThreadMapState {
+                        index: 0,
+                        state_name: "_t0_S0_wait_until".to_string(),
+                        role: "wait_until".to_string(),
+                        emitted: true,
+                        span: Span::new(0, 1),
+                        labels: vec!["wait until req".to_string()],
+                        source_next_index: 0,
+                        source_next_name: "_t0_S0_wait_until".to_string(),
+                        wait_cycles_count: None,
+                        seq_updates: Vec::new(),
+                        seq_assignments: Vec::new(),
+                        folded_exit_updates: Vec::new(),
+                        folded_exit_assignments: Vec::new(),
+                        source_transitions: vec![ThreadMapTransition {
+                            condition: "req".to_string(),
+                            condition_guard: None,
+                            target_index: 0,
+                            target_name: "_t0_S0_wait_until".to_string(),
+                        }],
+                        source_transition_origin: "pre_fold_snapshot".to_string(),
+                        transitions: vec![ThreadMapTransition {
+                            condition: "req".to_string(),
+                            condition_guard: None,
+                            target_index: 0,
+                            target_name: "_t0_S0_wait_until".to_string(),
+                        }],
+                    }],
+                }],
+            }],
+        };
+
+        let err = render_lean_checked(&map).expect_err("missing guard should fail");
+        assert!(
+            err.contains("missing structured condition_guard"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn render_lean_checked_allows_wait_cycles_transition_without_guard() {
+        let map = ThreadMap {
+            modules: vec![ThreadMapModule {
+                module_name: "M".to_string(),
+                generated_module_name: "_M_threads".to_string(),
+                span: Span::new(0, 1),
+                threads: vec![ThreadMapThread {
+                    name: "Worker".to_string(),
+                    index: 0,
+                    once: false,
+                    span: Span::new(0, 1),
+                    hazards: Vec::new(),
+                    states: vec![ThreadMapState {
+                        index: 0,
+                        state_name: "_t0_S0_wait_cycles".to_string(),
+                        role: "wait_cycles".to_string(),
+                        emitted: true,
+                        span: Span::new(0, 1),
+                        labels: vec!["wait 2 cycle".to_string()],
+                        source_next_index: 0,
+                        source_next_name: "_t0_S0_wait_cycles".to_string(),
+                        wait_cycles_count: Some("2".to_string()),
+                        seq_updates: Vec::new(),
+                        seq_assignments: Vec::new(),
+                        folded_exit_updates: Vec::new(),
+                        folded_exit_assignments: Vec::new(),
+                        source_transitions: vec![ThreadMapTransition {
+                            condition: "true".to_string(),
+                            condition_guard: None,
+                            target_index: 0,
+                            target_name: "_t0_S0_wait_cycles".to_string(),
+                        }],
+                        source_transition_origin: "pre_fold_snapshot".to_string(),
+                        transitions: vec![ThreadMapTransition {
+                            condition: "true".to_string(),
+                            condition_guard: None,
+                            target_index: 0,
+                            target_name: "_t0_S0_wait_cycles".to_string(),
+                        }],
+                    }],
+                }],
+            }],
+        };
+
+        let lean = render_lean_checked(&map).expect("wait_cycles guard should be optional");
+        assert!(
+            lean.contains("Control.waitCycles 2"),
+            "expected counted-wait control in Lean:\n{lean}"
+        );
+    }
+
+    #[test]
+    fn render_lean_checked_rejects_unknown_transition_target() {
+        let mut state = emitted_action_state(0, 0);
+        state.transitions[0].target_index = 99;
+        state.transitions[0].target_name = "_t0_S99_missing".to_string();
+        let map = map_with_states(vec![state]);
+
+        let err = render_lean_checked(&map).expect_err("unknown target should fail");
+        assert!(
+            err.contains("targets non-emitted or unknown state 99"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn render_lean_checked_rejects_source_next_drift() {
+        let map = map_with_states(vec![emitted_action_state(0, 0), emitted_action_state(1, 0)]);
+
+        let err = render_lean_checked(&map).expect_err("source-next drift should fail");
+        assert!(
+            err.contains("source_next compact state 0, expected natural compact next 1"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn render_lean_checked_rejects_non_contiguous_raw_state_table() {
+        let state = emitted_action_state(1, 1);
+        let map = map_with_states(vec![state]);
+
+        let err = render_lean_checked(&map).expect_err("non-contiguous raw table should fail");
+        assert!(
+            err.contains("raw state table is not contiguous at position 0"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn render_lean_checked_rejects_unknown_source_transition_origin() {
+        let mut state = emitted_action_state(0, 0);
+        state.source_transition_origin = "post_fold_guess".to_string();
+        let map = map_with_states(vec![state]);
+
+        let err = render_lean_checked(&map).expect_err("bad provenance should fail");
+        assert!(
+            err.contains("unsupported source_transition_origin"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn render_lean_checked_rejects_single_branch_dispatch() {
+        let mut state = emitted_action_state(0, 0);
+        state.role = "dispatch".to_string();
+        let map = map_with_states(vec![state]);
+
+        let err = render_lean_checked(&map).expect_err("single-branch dispatch should fail");
+        assert!(
+            err.contains("dispatch state must have at least two source and lowered transitions"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn render_lean_checked_rejects_partial_folded_assignment_coverage() {
+        let mut state = emitted_action_state(0, 0);
+        state.folded_exit_updates = vec!["done_r <= true".to_string()];
+        let map = map_with_states(vec![state]);
+
+        let err = render_lean_checked(&map).expect_err("partial folded assignments should fail");
+        assert!(
+            err.contains("folded_exit_assignments only cover 0/1 folded_exit_updates"),
+            "unexpected error: {err}"
+        );
+    }
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -27,13 +27,13 @@ fn strip_auto_handshake_sva(sv: &str) -> String {
         let trimmed = line.trim_start();
         if trimmed == "// synopsys translate_off" {
             // Skip the entire block (translate_off..translate_on).
-            while i < lines.len()
-                && lines[i].trim_start() != "// synopsys translate_on"
-            {
+            while i < lines.len() && lines[i].trim_start() != "// synopsys translate_on" {
                 i += 1;
             }
             // Consume the translate_on line too.
-            if i < lines.len() { i += 1; }
+            if i < lines.len() {
+                i += 1;
+            }
             // Retroactively swallow exactly one leading blank-ish line
             // (whitespace only — `Codegen::line("")` at indent>0 emits a
             // fully-indented empty line). The corresponding leading
@@ -81,7 +81,9 @@ fn collect_thread_map(source: &str) -> arch::thread_map::ThreadMap {
     let ast = elaborate::elaborate(parsed_ast).expect("elaborate error");
     let ast = elaborate::lower_tlm_target_threads(ast).expect("tlm_target lowering error");
     let ast = elaborate::lower_tlm_initiator_calls(ast).expect("tlm_initiator lowering error");
-    let map = std::rc::Rc::new(std::cell::RefCell::new(arch::thread_map::ThreadMap::default()));
+    let map = std::rc::Rc::new(std::cell::RefCell::new(
+        arch::thread_map::ThreadMap::default(),
+    ));
     let opts = elaborate::ThreadLowerOpts {
         thread_map: Some(map.clone()),
         ..Default::default()
@@ -224,14 +226,32 @@ fn test_let_bindings() {
     let source = include_str!("../examples/let_bindings.arch");
     let sv = compile_to_sv(source);
     // Typed let: emits declared type then a separate assign
-    assert!(sv.contains("logic [7:0] mask;"), "expected typed let decl, got:\n{sv}");
-    assert!(sv.contains("assign mask = a & b;"), "expected typed let assign, got:\n{sv}");
+    assert!(
+        sv.contains("logic [7:0] mask;"),
+        "expected typed let decl, got:\n{sv}"
+    );
+    assert!(
+        sv.contains("assign mask = a & b;"),
+        "expected typed let assign, got:\n{sv}"
+    );
     // Untyped let: emits logic declaration + assign (same pattern as typed let)
-    assert!(sv.contains("logic same;"), "expected untyped let decl, got:\n{sv}");
-    assert!(sv.contains("assign same = a == b;"), "expected untyped let assign, got:\n{sv}");
+    assert!(
+        sv.contains("logic same;"),
+        "expected untyped let decl, got:\n{sv}"
+    );
+    assert!(
+        sv.contains("assign same = a == b;"),
+        "expected untyped let assign, got:\n{sv}"
+    );
     // Outputs driven from the let-bound wires
-    assert!(sv.contains("assign masked = mask;"), "expected masked assign, got:\n{sv}");
-    assert!(sv.contains("assign equal = same;"), "expected equal assign, got:\n{sv}");
+    assert!(
+        sv.contains("assign masked = mask;"),
+        "expected masked assign, got:\n{sv}"
+    );
+    assert!(
+        sv.contains("assign equal = same;"),
+        "expected equal assign, got:\n{sv}"
+    );
     insta::assert_snapshot!(sv);
 }
 
@@ -249,7 +269,7 @@ fn test_fsm_traffic_light() {
     // State register FF
     assert!(sv.contains("always_ff @(posedge clk)"));
     assert!(sv.contains("state_r <= RED")); // reset value
-    // Next-state logic
+                                            // Next-state logic
     assert!(sv.contains("state_next = state_r")); // hold default
     assert!(sv.contains("state_next = GREEN"));
     assert!(sv.contains("state_next = YELLOW"));
@@ -595,7 +615,10 @@ end arbiter BadArb
     let symbols = resolve::resolve(&ast).expect("resolve error");
     let checker = TypeChecker::new(&symbols, &ast);
     let result = checker.check();
-    assert!(result.is_err(), "expected error for custom policy without hook");
+    assert!(
+        result.is_err(),
+        "expected error for custom policy without hook"
+    );
 }
 
 #[test]
@@ -630,7 +653,10 @@ end arbiter BadArb
     let symbols = resolve::resolve(&ast).expect("resolve error");
     let checker = TypeChecker::new(&symbols, &ast);
     let result = checker.check();
-    assert!(result.is_err(), "expected error for hook param shadowing port");
+    assert!(
+        result.is_err(),
+        "expected error for hook param shadowing port"
+    );
 }
 
 /// Round-robin arbiter sim must grant index 0 on the first
@@ -761,7 +787,11 @@ end arbiter RRArb3
 /// After fix: `0,1,2,0,1,2,...`, idx-fair.
 #[test]
 fn test_arbiter_round_robin_sv_nonpow2_verilator_behavior() {
-    if std::process::Command::new("verilator").arg("--version").output().is_err() {
+    if std::process::Command::new("verilator")
+        .arg("--version")
+        .output()
+        .is_err()
+    {
         eprintln!("skipping Verilator RR NUM_REQ=3 fairness smoke: verilator not found");
         return;
     }
@@ -778,10 +808,12 @@ fn test_arbiter_round_robin_sv_nonpow2_verilator_behavior() {
         .arg(&sv_out)
         .output()
         .expect("build RRArb3 SV");
-    assert!(build.status.success(),
+    assert!(
+        build.status.success(),
         "arch build should pass\nstdout:\n{}\nstderr:\n{}",
         String::from_utf8_lossy(&build.stdout),
-        String::from_utf8_lossy(&build.stderr));
+        String::from_utf8_lossy(&build.stderr)
+    );
 
     let verilate = std::process::Command::new("verilator")
         .arg("--cc")
@@ -800,22 +832,28 @@ fn test_arbiter_round_robin_sv_nonpow2_verilator_behavior() {
         .arg("tests/arbiter_rr_nonpow2/tb_rr_arb3.cpp")
         .output()
         .expect("verilate RRArb3");
-    assert!(verilate.status.success(),
+    assert!(
+        verilate.status.success(),
         "Verilator build should pass\nstdout:\n{}\nstderr:\n{}",
         String::from_utf8_lossy(&verilate.stdout),
-        String::from_utf8_lossy(&verilate.stderr));
+        String::from_utf8_lossy(&verilate.stderr)
+    );
 
     let exe = obj_dir.join("VRRArb3");
     let run = std::process::Command::new(&exe)
         .output()
         .expect("run Verilator RRArb3");
-    assert!(run.status.success(),
+    assert!(
+        run.status.success(),
         "Verilator sim should pass\nstdout:\n{}\nstderr:\n{}",
         String::from_utf8_lossy(&run.stdout),
-        String::from_utf8_lossy(&run.stderr));
-    assert!(String::from_utf8_lossy(&run.stdout).contains("PASS rr_arb3"),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&run.stdout).contains("PASS rr_arb3"),
         "expected PASS marker in Verilator stdout:\n{}",
-        String::from_utf8_lossy(&run.stdout));
+        String::from_utf8_lossy(&run.stdout)
+    );
 }
 
 /// arch-sim cross-check for the same RR fairness fixture, closing the §3
@@ -838,14 +876,18 @@ fn test_arbiter_round_robin_arch_sim_nonpow2_behavior() {
         .arg(td.path())
         .output()
         .expect("run arch sim for RRArb3");
-    assert!(out.status.success(),
+    assert!(
+        out.status.success(),
         "arch sim should pass for RRArb3\nstdout:\n{}\nstderr:\n{}",
         String::from_utf8_lossy(&out.stdout),
-        String::from_utf8_lossy(&out.stderr));
+        String::from_utf8_lossy(&out.stderr)
+    );
     let stdout = String::from_utf8_lossy(&out.stdout);
-    assert!(stdout.contains("PASS rr_arb3"),
+    assert!(
+        stdout.contains("PASS rr_arb3"),
         "expected `PASS rr_arb3` (strict round-robin, idx-fair) in arch \
-         sim stdout — the same fairness contract Verilator verifies; got:\n{stdout}");
+         sim stdout — the same fairness contract Verilator verifies; got:\n{stdout}"
+    );
 }
 
 #[test]
@@ -942,14 +984,20 @@ arbiter HsArbB
 end arbiter HsArbB
 "#;
     let sv = compile_to_sv(source);
-    assert!(sv.contains("input logic [NUM_REQ-1:0] request_valid"),
-        "expected request_valid array port:\n{sv}");
-    assert!(sv.contains("output logic [NUM_REQ-1:0] request_ready"),
-        "expected request_ready array port:\n{sv}");
+    assert!(
+        sv.contains("input logic [NUM_REQ-1:0] request_valid"),
+        "expected request_valid array port:\n{sv}"
+    );
+    assert!(
+        sv.contains("output logic [NUM_REQ-1:0] request_ready"),
+        "expected request_ready array port:\n{sv}"
+    );
     // Payload flows in the same direction as `receive` (in to the arbiter).
     // Width comes from the field type; SV declares one wire per index slot.
-    assert!(sv.contains("request_qos"),
-        "expected request_qos payload port:\n{sv}");
+    assert!(
+        sv.contains("request_qos"),
+        "expected request_qos payload port:\n{sv}"
+    );
 }
 
 // ── Tier-2 auto-SVA for arbiter handshake_channel ────────────────────────────
@@ -979,24 +1027,40 @@ end arbiter HsArbSvaArr
 "#;
     let sv = compile_to_sv(source);
     // Wrapper + structural shape.
-    assert!(sv.contains("// synopsys translate_off"),
-        "expected translate_off wrapper:\n{sv}");
-    assert!(sv.contains("// synopsys translate_on"),
-        "expected translate_on wrapper:\n{sv}");
-    assert!(sv.contains("// Auto-generated handshake protocol assertions"),
-        "expected Tier-2 header comment:\n{sv}");
-    assert!(sv.contains("generate for (genvar i = 0; i < NUM_REQ; i++) begin: g_auto_hs_request"),
-        "expected genvar-indexed generate block over NUM_REQ:\n{sv}");
-    assert!(sv.contains("end endgenerate"),
-        "expected generate block close:\n{sv}");
+    assert!(
+        sv.contains("// synopsys translate_off"),
+        "expected translate_off wrapper:\n{sv}"
+    );
+    assert!(
+        sv.contains("// synopsys translate_on"),
+        "expected translate_on wrapper:\n{sv}"
+    );
+    assert!(
+        sv.contains("// Auto-generated handshake protocol assertions"),
+        "expected Tier-2 header comment:\n{sv}"
+    );
+    assert!(
+        sv.contains("generate for (genvar i = 0; i < NUM_REQ; i++) begin: g_auto_hs_request"),
+        "expected genvar-indexed generate block over NUM_REQ:\n{sv}"
+    );
+    assert!(
+        sv.contains("end endgenerate"),
+        "expected generate block close:\n{sv}"
+    );
     // Property uses lane-indexed signals + disable iff (rst) + the same
     // `(v && !r) |=> v` predicate as the bus-side emitter.
-    assert!(sv.contains("_auto_hs_request__lane_valid_stable"),
-        "expected per-lane valid_stable label:\n{sv}");
-    assert!(sv.contains("disable iff (rst)"),
-        "expected reset-disable clause:\n{sv}");
-    assert!(sv.contains("(request_valid[i] && !request_ready[i]) |=> request_valid[i]"),
-        "expected lane-indexed valid-stable predicate:\n{sv}");
+    assert!(
+        sv.contains("_auto_hs_request__lane_valid_stable"),
+        "expected per-lane valid_stable label:\n{sv}"
+    );
+    assert!(
+        sv.contains("disable iff (rst)"),
+        "expected reset-disable clause:\n{sv}"
+    );
+    assert!(
+        sv.contains("(request_valid[i] && !request_ready[i]) |=> request_valid[i]"),
+        "expected lane-indexed valid-stable predicate:\n{sv}"
+    );
 }
 
 /// A non-array `handshake_channel` (no `[N]` shape, e.g. an arbiter's
@@ -1026,14 +1090,20 @@ arbiter HsArbSvaBare
 end arbiter HsArbSvaBare
 "#;
     let sv = compile_to_sv(source);
-    assert!(sv.contains("_auto_hs_grant_valid_stable"),
-        "expected bare grant valid_stable label:\n{sv}");
+    assert!(
+        sv.contains("_auto_hs_grant_valid_stable"),
+        "expected bare grant valid_stable label:\n{sv}"
+    );
     // Crucially, no generate-for wrapper for the non-array channel.
-    assert!(!sv.contains("g_auto_hs_grant"),
-        "non-array handshake_channel must not be wrapped in generate-for:\n{sv}");
+    assert!(
+        !sv.contains("g_auto_hs_grant"),
+        "non-array handshake_channel must not be wrapped in generate-for:\n{sv}"
+    );
     // And the predicate uses unindexed signal names.
-    assert!(sv.contains("(grant_valid && !grant_ready) |=> grant_valid"),
-        "expected unindexed grant valid-stable predicate:\n{sv}");
+    assert!(
+        sv.contains("(grant_valid && !grant_ready) |=> grant_valid"),
+        "expected unindexed grant valid-stable predicate:\n{sv}"
+    );
 }
 
 /// A `valid_only` `handshake_channel` has no ready signal to gate
@@ -1064,12 +1134,16 @@ end arbiter HsArbSvaVOnly
     let sv = compile_to_sv(source);
     // No SVA label for `grant` should appear — mirrors the bus side's
     // v1 silent-skip for variants without a back-signal.
-    assert!(!sv.contains("_auto_hs_grant"),
-        "valid_only handshake_channel must not emit Tier-2 SVA:\n{sv}");
+    assert!(
+        !sv.contains("_auto_hs_grant"),
+        "valid_only handshake_channel must not emit Tier-2 SVA:\n{sv}"
+    );
     // The Tier-2 wrapper itself must be elided too when no channel
     // produced any property (matches bus-side emit_handshake_asserts).
-    assert!(!sv.contains("Auto-generated handshake protocol assertions"),
-        "Tier-2 wrapper must not be emitted when no property applies:\n{sv}");
+    assert!(
+        !sv.contains("Auto-generated handshake protocol assertions"),
+        "Tier-2 wrapper must not be emitted when no property applies:\n{sv}"
+    );
 }
 
 /// A `valid_ready` `handshake_channel` declared *without* any payload
@@ -1100,12 +1174,16 @@ end arbiter HsArbSvaNoPL
 "#;
     let sv = compile_to_sv(source);
     // Exactly one property — valid_stable — for the channel, lane-indexed.
-    assert!(sv.contains("_auto_hs_request__lane_valid_stable"),
-        "expected valid_stable property:\n{sv}");
+    assert!(
+        sv.contains("_auto_hs_request__lane_valid_stable"),
+        "expected valid_stable property:\n{sv}"
+    );
     // No `$stable` payload-stability check (Tier-2 v1 scope explicitly
     // doesn't include payload-stability, matching bus-side behaviour).
-    assert!(!sv.contains("$stable"),
-        "Tier-2 v1 must not emit payload-stability $stable checks:\n{sv}");
+    assert!(
+        !sv.contains("$stable"),
+        "Tier-2 v1 must not emit payload-stability $stable checks:\n{sv}"
+    );
 }
 
 /// Regression: the bus-side handshake_channel Tier-2 SVA path is
@@ -1141,8 +1219,10 @@ fn test_existing_bus_handshake_sva_unaffected() {
     assert!(sv.contains("synopsys translate_off"));
     assert!(sv.contains("synopsys translate_on"));
     // Bus path is non-array, so no generate-for wrapper.
-    assert!(!sv.contains("g_auto_hs_aw"),
-        "bus-path Tier-2 SVA must remain non-generate-wrapped:\n{sv}");
+    assert!(
+        !sv.contains("g_auto_hs_aw"),
+        "bus-path Tier-2 SVA must remain non-generate-wrapped:\n{sv}"
+    );
 }
 
 // ── (Existing) handshake_channel port-shape tests ────────────────────────────
@@ -1194,11 +1274,15 @@ end arbiter HsArbC
     // can't see (no HandshakeMeta). Strip it before structural compare.
     assert_eq!(strip_auto_handshake_sva(&sv_h), strip_auto_handshake_sva(&sv_n),
         "valid_only handshake_channel + receive valid_ready array must match hand-rolled shape (modulo Tier-2 SVA)");
-    assert!(sv_n.contains("output logic grant_valid"),
-        "expected grant_valid top-level port:\n{sv_n}");
-    assert!(sv_n.contains("output logic [2-1:0] grant_requester")
-        || sv_n.contains("output logic [1:0] grant_requester"),
-        "expected grant_requester top-level port:\n{sv_n}");
+    assert!(
+        sv_n.contains("output logic grant_valid"),
+        "expected grant_valid top-level port:\n{sv_n}"
+    );
+    assert!(
+        sv_n.contains("output logic [2-1:0] grant_requester")
+            || sv_n.contains("output logic [1:0] grant_requester"),
+        "expected grant_requester top-level port:\n{sv_n}"
+    );
 }
 
 // ── Template ─────────────────────────────────────────────────────────────────
@@ -1262,9 +1346,15 @@ fn test_active_low_reset() {
     let source = include_str!("../examples/reset_low.arch");
     let sv = compile_to_sv(source);
     // reset condition must be inverted
-    assert!(sv.contains("if ((!rst_n))"), "expected inverted reset condition, got:\n{sv}");
+    assert!(
+        sv.contains("if ((!rst_n))"),
+        "expected inverted reset condition, got:\n{sv}"
+    );
     // must NOT contain bare active-high check
-    assert!(!sv.contains("if (rst_n)"), "unexpected active-high reset check:\n{sv}");
+    assert!(
+        !sv.contains("if (rst_n)"),
+        "unexpected active-high reset check:\n{sv}"
+    );
     insta::assert_snapshot!(sv);
 }
 
@@ -1323,11 +1413,16 @@ end module BadCounter
     let symbols = resolve::resolve(&ast).expect("resolve");
     let checker = arch::typecheck::TypeChecker::new(&symbols, &ast);
     let result = checker.check();
-    assert!(result.is_err(), "expected type error for implicit truncation");
+    assert!(
+        result.is_err(),
+        "expected type error for implicit truncation"
+    );
     let errors = result.unwrap_err();
     assert!(
-        errors.iter().any(|e| format!("{e:?}").contains("width mismatch")
-            || format!("{e:?}").contains("trunc")),
+        errors
+            .iter()
+            .any(|e| format!("{e:?}").contains("width mismatch")
+                || format!("{e:?}").contains("trunc")),
         "expected width-mismatch error mentioning trunc, got: {errors:?}"
     );
 }
@@ -1340,23 +1435,37 @@ fn test_generate_for() {
     let sv = compile_to_sv(source);
     // Ports are declared as Vec<Bool, N> at module scope — the SV boundary is
     // a single packed vector per direction, not N separately-named scalars.
-    assert!(sv.contains("input logic [N-1:0] req"), "expected Vec req port, got:\n{sv}");
-    assert!(sv.contains("output logic [N-1:0] gnt"), "expected Vec gnt port, got:\n{sv}");
+    assert!(
+        sv.contains("input logic [N-1:0] req"),
+        "expected Vec req port, got:\n{sv}"
+    );
+    assert!(
+        sv.contains("output logic [N-1:0] gnt"),
+        "expected Vec gnt port, got:\n{sv}"
+    );
     // generate_for over `inst` items with shape-stable connections (scalar
     // child ports + `Index(Ident, loop_var)` against a Vec parent port,
     // no Vec-of-bus shapes) preserves the SV genvar `for begin gen_i end`
     // form. One compact block, scales to any N.
-    assert!(sv.contains("genvar i;"),
-            "expected `genvar i;` for shape-stable inst-bearing generate_for, got:\n{sv}");
-    assert!(sv.contains("begin : gen_i"),
-            "expected `begin : gen_i` block, got:\n{sv}");
+    assert!(
+        sv.contains("genvar i;"),
+        "expected `genvar i;` for shape-stable inst-bearing generate_for, got:\n{sv}"
+    );
+    assert!(
+        sv.contains("begin : gen_i"),
+        "expected `begin : gen_i` block, got:\n{sv}"
+    );
     // Inside the gen_i block the inst is named `pt_i` (the loop-var-
     // bearing source name) — substitution to `pt_0`/`pt_1` happens at
     // SV-elaboration time, not at arch-com elaboration.
-    assert!(sv.contains("PassThrough pt_i"),
-            "expected `PassThrough pt_i` instance in the gen_i block, got:\n{sv}");
-    assert!(!sv.contains("PassThrough pt_0"),
-            "shape-stable case should NOT emit flat `pt_0`, got:\n{sv}");
+    assert!(
+        sv.contains("PassThrough pt_i"),
+        "expected `PassThrough pt_i` instance in the gen_i block, got:\n{sv}"
+    );
+    assert!(
+        !sv.contains("PassThrough pt_0"),
+        "shape-stable case should NOT emit flat `pt_0`, got:\n{sv}"
+    );
     insta::assert_snapshot!(sv);
 }
 
@@ -1377,13 +1486,17 @@ fn test_generate_for_inst_genvar_sim_behavior() {
         .arg(td.path())
         .output()
         .expect("run arch sim for generate_for genvar probe");
-    assert!(out.status.success(),
+    assert!(
+        out.status.success(),
         "generate_for genvar sim should pass\nstdout:\n{}\nstderr:\n{}",
         String::from_utf8_lossy(&out.stdout),
-        String::from_utf8_lossy(&out.stderr));
-    assert!(String::from_utf8_lossy(&out.stdout).contains("PASS generate_for genvar sim"),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&out.stdout).contains("PASS generate_for genvar sim"),
         "expected PASS marker in stdout:\n{}",
-        String::from_utf8_lossy(&out.stdout));
+        String::from_utf8_lossy(&out.stdout)
+    );
 }
 
 #[test]
@@ -1422,16 +1535,25 @@ end module Big
     let sv = compile_to_sv(source);
     // Exactly ONE genvar block, not 8 flat insts.
     assert!(sv.contains("genvar i;"), "expected `genvar i;`, got:\n{sv}");
-    assert!(sv.contains("for (i = 0; i <= N - 1; i = i + 1) begin : gen_i"),
-            "expected SV genvar `for` loop, got:\n{sv}");
+    assert!(
+        sv.contains("for (i = 0; i <= N - 1; i = i + 1) begin : gen_i"),
+        "expected SV genvar `for` loop, got:\n{sv}"
+    );
     // No literal-i instance names — substitution is deferred to SV elaboration.
-    assert!(!sv.contains("PassThrough pt_0"),
-            "did not expect literal `pt_0` flat inst, got:\n{sv}");
-    assert!(!sv.contains("PassThrough pt_7"),
-            "did not expect literal `pt_7` flat inst, got:\n{sv}");
+    assert!(
+        !sv.contains("PassThrough pt_0"),
+        "did not expect literal `pt_0` flat inst, got:\n{sv}"
+    );
+    assert!(
+        !sv.contains("PassThrough pt_7"),
+        "did not expect literal `pt_7` flat inst, got:\n{sv}"
+    );
     // Single instantiation in the source body.
     let pt_count = sv.matches("PassThrough pt_i").count();
-    assert_eq!(pt_count, 1, "expected exactly one `PassThrough pt_i`, got {pt_count}:\n{sv}");
+    assert_eq!(
+        pt_count, 1,
+        "expected exactly one `PassThrough pt_i`, got {pt_count}:\n{sv}"
+    );
 }
 
 #[test]
@@ -1439,7 +1561,10 @@ fn test_generate_if_true() {
     let source = include_str!("../examples/generate_if.arch");
     let sv = compile_to_sv(source);
     // generate_if true → debug_out port is included
-    assert!(sv.contains("debug_out"), "expected debug_out port, got:\n{sv}");
+    assert!(
+        sv.contains("debug_out"),
+        "expected debug_out port, got:\n{sv}"
+    );
     insta::assert_snapshot!(sv);
 }
 
@@ -1465,7 +1590,10 @@ module ParamDebug
 end module ParamDebug
 "#;
     let sv = compile_to_sv(source);
-    assert!(sv.contains("debug_out"), "expected debug_out when ENABLE_DEBUG=1, got:\n{sv}");
+    assert!(
+        sv.contains("debug_out"),
+        "expected debug_out when ENABLE_DEBUG=1, got:\n{sv}"
+    );
 }
 
 #[test]
@@ -1489,7 +1617,10 @@ module NoDebug2
 end module NoDebug2
 "#;
     let sv = compile_to_sv(source);
-    assert!(!sv.contains("debug_out"), "debug_out should be excluded when ENABLE_DEBUG=0, got:\n{sv}");
+    assert!(
+        !sv.contains("debug_out"),
+        "debug_out should be excluded when ENABLE_DEBUG=0, got:\n{sv}"
+    );
 }
 
 #[test]
@@ -1514,7 +1645,10 @@ module CmpDebug
 end module CmpDebug
 "#;
     let sv = compile_to_sv(source);
-    assert!(sv.contains("verbose_out"), "expected verbose_out when LOG_LEVEL=2 > 1, got:\n{sv}");
+    assert!(
+        sv.contains("verbose_out"),
+        "expected verbose_out when LOG_LEVEL=2 > 1, got:\n{sv}"
+    );
 }
 
 #[test]
@@ -1552,8 +1686,14 @@ end module Outer
     let sv = compile_to_sv(source);
     // The elaborated Inner module (single variant, ENABLE_DEBUG=1) must have debug_out.
     // Single inst → no name mangling, module keeps its original name.
-    assert!(sv.contains("debug_out"), "Inner should have debug_out when ENABLE_DEBUG=1:\n{sv}");
-    assert!(sv.contains("module Inner"), "module should keep original name for single variant:\n{sv}");
+    assert!(
+        sv.contains("debug_out"),
+        "Inner should have debug_out when ENABLE_DEBUG=1:\n{sv}"
+    );
+    assert!(
+        sv.contains("module Inner"),
+        "module should keep original name for single variant:\n{sv}"
+    );
 }
 
 #[test]
@@ -1587,8 +1727,14 @@ end module Outer2
 "#;
     let sv = compile_to_sv(source);
     // Single inst → no mangling, module keeps its name but is elaborated with ENABLE_DEBUG=0.
-    assert!(!sv.contains("debug_out"), "Inner2 should NOT have debug_out when ENABLE_DEBUG=0:\n{sv}");
-    assert!(sv.contains("module Inner2"), "module should keep original name for single variant:\n{sv}");
+    assert!(
+        !sv.contains("debug_out"),
+        "Inner2 should NOT have debug_out when ENABLE_DEBUG=0:\n{sv}"
+    );
+    assert!(
+        sv.contains("module Inner2"),
+        "module should keep original name for single variant:\n{sv}"
+    );
 }
 
 #[test]
@@ -1629,11 +1775,23 @@ end module Top
 "#;
     let sv = compile_to_sv(source);
     // Both variant module declarations must be emitted
-    assert!(sv.contains("module Sub__ENABLE_0"), "expected Sub__ENABLE_0 module:\n{sv}");
-    assert!(sv.contains("module Sub__ENABLE_1"), "expected Sub__ENABLE_1 module:\n{sv}");
+    assert!(
+        sv.contains("module Sub__ENABLE_0"),
+        "expected Sub__ENABLE_0 module:\n{sv}"
+    );
+    assert!(
+        sv.contains("module Sub__ENABLE_1"),
+        "expected Sub__ENABLE_1 module:\n{sv}"
+    );
     // Top's inst blocks must reference the renamed variants
-    assert!(sv.contains("Sub__ENABLE_1"), "Top should reference Sub__ENABLE_1:\n{sv}");
-    assert!(sv.contains("Sub__ENABLE_0"), "Top should reference Sub__ENABLE_0:\n{sv}");
+    assert!(
+        sv.contains("Sub__ENABLE_1"),
+        "Top should reference Sub__ENABLE_1:\n{sv}"
+    );
+    assert!(
+        sv.contains("Sub__ENABLE_0"),
+        "Top should reference Sub__ENABLE_0:\n{sv}"
+    );
     // sub_on and sub_off instance names must still appear
     assert!(sv.contains("sub_on"), "expected sub_on instance:\n{sv}");
     assert!(sv.contains("sub_off"), "expected sub_off instance:\n{sv}");
@@ -1685,23 +1843,43 @@ end module Outer
 "#;
     let sv = compile_to_sv(source);
     // Two distinct SV modules emitted
-    assert!(sv.contains("module Inner__ENABLE_DEBUG_0"), "missing Inner__ENABLE_DEBUG_0:\n{sv}");
-    assert!(sv.contains("module Inner__ENABLE_DEBUG_1"), "missing Inner__ENABLE_DEBUG_1:\n{sv}");
+    assert!(
+        sv.contains("module Inner__ENABLE_DEBUG_0"),
+        "missing Inner__ENABLE_DEBUG_0:\n{sv}"
+    );
+    assert!(
+        sv.contains("module Inner__ENABLE_DEBUG_1"),
+        "missing Inner__ENABLE_DEBUG_1:\n{sv}"
+    );
     // ENABLE_DEBUG=1 variant has debug_in port; ENABLE_DEBUG=0 does not.
     // Verify by checking what each module declaration contains.
-    let debug_1_block = sv.split("module Inner__ENABLE_DEBUG_1").nth(1)
+    let debug_1_block = sv
+        .split("module Inner__ENABLE_DEBUG_1")
+        .nth(1)
         .and_then(|s| s.split("endmodule").next())
         .unwrap_or("");
-    let debug_0_block = sv.split("module Inner__ENABLE_DEBUG_0").nth(1)
+    let debug_0_block = sv
+        .split("module Inner__ENABLE_DEBUG_0")
+        .nth(1)
         .and_then(|s| s.split("endmodule").next())
         .unwrap_or("");
-    assert!(debug_1_block.contains("debug_in"), "ENABLE_DEBUG=1 variant missing debug_in:\n{sv}");
-    assert!(!debug_0_block.contains("debug_in"), "ENABLE_DEBUG=0 variant should not have debug_in:\n{sv}");
+    assert!(
+        debug_1_block.contains("debug_in"),
+        "ENABLE_DEBUG=1 variant missing debug_in:\n{sv}"
+    );
+    assert!(
+        !debug_0_block.contains("debug_in"),
+        "ENABLE_DEBUG=0 variant should not have debug_in:\n{sv}"
+    );
     // Inst sites reference the correct variants (params appear between name and instance)
-    assert!(sv.contains("Inner__ENABLE_DEBUG_1") && sv.contains("inner_on"),
-        "inner_on should use _1 variant:\n{sv}");
-    assert!(sv.contains("Inner__ENABLE_DEBUG_0") && sv.contains("inner_off"),
-        "inner_off should use _0 variant:\n{sv}");
+    assert!(
+        sv.contains("Inner__ENABLE_DEBUG_1") && sv.contains("inner_on"),
+        "inner_on should use _1 variant:\n{sv}"
+    );
+    assert!(
+        sv.contains("Inner__ENABLE_DEBUG_0") && sv.contains("inner_off"),
+        "inner_off should use _0 variant:\n{sv}"
+    );
 }
 
 #[test]
@@ -1721,7 +1899,10 @@ module NoDebug
 end module NoDebug
 "#;
     let sv = compile_to_sv(source);
-    assert!(!sv.contains("debug_out"), "debug_out should be excluded when condition is false, got:\n{sv}");
+    assert!(
+        !sv.contains("debug_out"),
+        "debug_out should be excluded when condition is false, got:\n{sv}"
+    );
 }
 
 // ── Mixed reset / no-reset in always block ───────────────────────────────────
@@ -1756,17 +1937,32 @@ end module MixedReset
 "#;
     let sv = compile_to_sv(source);
     // count_r has reset: should appear inside if(rst)/else guard in first always_ff
-    assert!(sv.contains("if (rst) begin"), "expected reset guard, got:\n{sv}");
-    assert!(sv.contains("count_r <= 0;"), "expected count_r reset init, got:\n{sv}");
+    assert!(
+        sv.contains("if (rst) begin"),
+        "expected reset guard, got:\n{sv}"
+    );
+    assert!(
+        sv.contains("count_r <= 0;"),
+        "expected count_r reset init, got:\n{sv}"
+    );
     // pipe_r has reset none: must be in a SEPARATE always_ff block (no reset in sensitivity list).
     // Mixing resetable and non-resetable regs in one always_ff with async reset causes
     // synthesis tools to infer unintended clock gating on the reset path.
     let always_blocks: Vec<&str> = sv.split("always_ff").collect();
-    assert!(always_blocks.len() >= 3, "expected at least 2 always_ff blocks (reset + no-reset), got:\n{sv}");
+    assert!(
+        always_blocks.len() >= 3,
+        "expected at least 2 always_ff blocks (reset + no-reset), got:\n{sv}"
+    );
     // The second always_ff should contain pipe_r and NOT have reset in sensitivity
     let second_block = always_blocks[2];
-    assert!(second_block.contains("pipe_r <= data_in"), "pipe_r should be in separate always_ff, got:\n{sv}");
-    assert!(!second_block.contains("rst"), "no-reset always_ff should not reference rst, got:\n{sv}");
+    assert!(
+        second_block.contains("pipe_r <= data_in"),
+        "pipe_r should be in separate always_ff, got:\n{sv}"
+    );
+    assert!(
+        !second_block.contains("rst"),
+        "no-reset always_ff should not reference rst, got:\n{sv}"
+    );
     insta::assert_snapshot!(sv);
 }
 
@@ -1798,14 +1994,17 @@ end module RoConst
 "#;
     let sv = compile_to_sv(source);
     // The reset value must be driven somewhere in an always_ff.
-    assert!(sv.contains("always_ff @(posedge clk)"),
-        "expected an always_ff for the reset-only reg, got:\n{sv}");
-    assert!(sv.contains("if (rst)"),
-        "expected reset guard, got:\n{sv}");
+    assert!(
+        sv.contains("always_ff @(posedge clk)"),
+        "expected an always_ff for the reset-only reg, got:\n{sv}"
+    );
+    assert!(sv.contains("if (rst)"), "expected reset guard, got:\n{sv}");
     // arch-com emits the literal as decimal; accept either form since
     // what matters is that the RHS is the reset value (4).
-    assert!(sv.contains("roconst_r <= 32'd4;") || sv.contains("roconst_r <= 32'h4;"),
-        "expected roconst_r reset-init assignment, got:\n{sv}");
+    assert!(
+        sv.contains("roconst_r <= 32'd4;") || sv.contains("roconst_r <= 32'h4;"),
+        "expected roconst_r reset-init assignment, got:\n{sv}"
+    );
     insta::assert_snapshot!(sv);
 }
 
@@ -1841,15 +2040,21 @@ end module MixedOrphan
 "#;
     let sv = compile_to_sv(source);
     // Original seq-block always_ff resets ticker_r.
-    assert!(sv.contains("ticker_r <= 0;"),
-        "expected ticker_r reset in seq-block always_ff, got:\n{sv}");
+    assert!(
+        sv.contains("ticker_r <= 0;"),
+        "expected ticker_r reset in seq-block always_ff, got:\n{sv}"
+    );
     // Orphan reset always_ff fires for constant_r.
-    assert!(sv.contains("constant_r <= 32'd42;"),
-        "expected constant_r orphan reset assignment, got:\n{sv}");
+    assert!(
+        sv.contains("constant_r <= 32'd42;"),
+        "expected constant_r orphan reset assignment, got:\n{sv}"
+    );
     // Two distinct always_ff blocks — one for each.
     let always_count = sv.matches("always_ff @").count();
-    assert!(always_count >= 2,
-        "expected >=2 always_ff blocks (seq + orphan), got {always_count}:\n{sv}");
+    assert!(
+        always_count >= 2,
+        "expected >=2 always_ff blocks (seq + orphan), got {always_count}:\n{sv}"
+    );
     insta::assert_snapshot!(sv);
 }
 
@@ -1887,7 +2092,10 @@ end module BadMixed
     let symbols = resolve::resolve(&ast).expect("resolve");
     let checker = arch::typecheck::TypeChecker::new(&symbols, &ast);
     let result = checker.check();
-    assert!(result.is_err(), "expected error for mixed reset signals in same always block");
+    assert!(
+        result.is_err(),
+        "expected error for mixed reset signals in same always block"
+    );
 }
 
 #[test]
@@ -1923,7 +2131,10 @@ end module BadSyncAsync
     let symbols = resolve::resolve(&ast).expect("resolve");
     let checker = arch::typecheck::TypeChecker::new(&symbols, &ast);
     let result = checker.check();
-    assert!(result.is_err(), "expected error for mixing sync and async reset in same always block");
+    assert!(
+        result.is_err(),
+        "expected error for mixing sync and async reset in same always block"
+    );
 }
 
 // ── Pipeline ──────────────────────────────────────────────────────────────────
@@ -1934,11 +2145,23 @@ fn test_simple_pipeline() {
     let sv = compile_to_sv(source);
     assert!(sv.contains("module SimplePipe"), "missing module header");
     assert!(sv.contains("fetch_valid_r"), "missing fetch valid register");
-    assert!(sv.contains("writeback_valid_r"), "missing writeback valid register");
-    assert!(sv.contains("fetch_captured"), "missing fetch stage register");
-    assert!(sv.contains("writeback_result"), "missing writeback stage register");
+    assert!(
+        sv.contains("writeback_valid_r"),
+        "missing writeback valid register"
+    );
+    assert!(
+        sv.contains("fetch_captured"),
+        "missing fetch stage register"
+    );
+    assert!(
+        sv.contains("writeback_result"),
+        "missing writeback stage register"
+    );
     assert!(sv.contains("always_ff"), "missing always_ff block");
-    assert!(sv.contains("assign data_out = writeback_result"), "missing comb output");
+    assert!(
+        sv.contains("assign data_out = writeback_result"),
+        "missing comb output"
+    );
     insta::assert_snapshot!(sv);
 }
 
@@ -1970,7 +2193,10 @@ end pipeline BadPipe
     let symbols = resolve::resolve(&elaborated).expect("resolve");
     let checker = arch::typecheck::TypeChecker::new(&symbols, &elaborated);
     let result = checker.check();
-    assert!(result.is_err(), "expected error for comb-only pipeline stage");
+    assert!(
+        result.is_err(),
+        "expected error for comb-only pipeline stage"
+    );
 }
 
 #[test]
@@ -2014,7 +2240,10 @@ end pipeline BadFlush
     let symbols = resolve::resolve(&elaborated).expect("resolve");
     let checker = arch::typecheck::TypeChecker::new(&symbols, &elaborated);
     let result = checker.check();
-    assert!(result.is_err(), "expected error for undeclared flush target stage");
+    assert!(
+        result.is_err(),
+        "expected error for undeclared flush target stage"
+    );
 }
 
 #[test]
@@ -2026,30 +2255,66 @@ fn test_cpu_pipeline() {
     // Per-stage stall chain
     assert!(sv.contains("fetch_stall"), "missing fetch_stall signal");
     assert!(sv.contains("decode_stall"), "missing decode_stall signal");
-    assert!(sv.contains("(!imem_valid)"), "missing Fetch stall condition");
+    assert!(
+        sv.contains("(!imem_valid)"),
+        "missing Fetch stall condition"
+    );
     // Backpressure propagation
-    assert!(sv.contains("fetch_stall = (!imem_valid) || decode_stall"), "missing backpressure chain");
+    assert!(
+        sv.contains("fetch_stall = (!imem_valid) || decode_stall"),
+        "missing backpressure chain"
+    );
     // Stage register updates with stall guard
-    assert!(sv.contains("if (!fetch_stall)"), "missing fetch stall guard");
-    assert!(sv.contains("if (!decode_stall)"), "missing decode stall guard");
+    assert!(
+        sv.contains("if (!fetch_stall)"),
+        "missing fetch stall guard"
+    );
+    assert!(
+        sv.contains("if (!decode_stall)"),
+        "missing decode stall guard"
+    );
     // Bubble insertion
-    assert!(sv.contains("fetch_stall ? 1'b0 : fetch_valid_r"), "missing bubble insertion");
+    assert!(
+        sv.contains("fetch_stall ? 1'b0 : fetch_valid_r"),
+        "missing bubble insertion"
+    );
     // Flush
     assert!(sv.contains("if (branch_taken)"), "missing flush condition");
     assert!(sv.contains("fetch_valid_r <= 1'b0"), "missing fetch flush");
-    assert!(sv.contains("decode_valid_r <= 1'b0"), "missing decode flush");
+    assert!(
+        sv.contains("decode_valid_r <= 1'b0"),
+        "missing decode flush"
+    );
     // Cross-stage references rewritten
-    assert!(sv.contains("fetch_instr"), "missing rewritten cross-stage ref");
-    assert!(sv.contains("decode_rs1_val"), "missing rewritten decode ref");
-    assert!(sv.contains("execute_alu_result"), "missing rewritten execute ref");
+    assert!(
+        sv.contains("fetch_instr"),
+        "missing rewritten cross-stage ref"
+    );
+    assert!(
+        sv.contains("decode_rs1_val"),
+        "missing rewritten decode ref"
+    );
+    assert!(
+        sv.contains("execute_alu_result"),
+        "missing rewritten execute ref"
+    );
     // Outputs
-    assert!(sv.contains("assign wb_data = writeback_result"), "missing wb output");
+    assert!(
+        sv.contains("assign wb_data = writeback_result"),
+        "missing wb output"
+    );
     // pc is now passed forward through registered stages instead of
     // being read directly from Fetch (which would be a 3-hop bypass).
-    assert!(sv.contains("assign pc_out = writeback_pc"), "missing pc output");
+    assert!(
+        sv.contains("assign pc_out = writeback_pc"),
+        "missing pc output"
+    );
     // Explicit forwarding mux
     assert!(sv.contains("decode_rs1_fwd"), "missing forwarding mux wire");
-    assert!(sv.contains("always_comb"), "missing always_comb for forwarding mux");
+    assert!(
+        sv.contains("always_comb"),
+        "missing always_comb for forwarding mux"
+    );
     insta::assert_snapshot!(sv);
 }
 
@@ -2089,11 +2354,20 @@ end module BitExtract
 "#;
     let sv = compile_to_sv(source);
     // trunc<7>() → 7'(instr)
-    assert!(sv.contains("7'(instr)"), "expected trunc<7> → 7'(instr), got:\n{sv}");
+    assert!(
+        sv.contains("7'(instr)"),
+        "expected trunc<7> → 7'(instr), got:\n{sv}"
+    );
     // trunc<11,7>() → instr[11:7]
-    assert!(sv.contains("instr[11:7]"), "expected trunc<11,7> → instr[11:7], got:\n{sv}");
+    assert!(
+        sv.contains("instr[11:7]"),
+        "expected trunc<11,7> → instr[11:7], got:\n{sv}"
+    );
     // trunc<14,12>() → instr[14:12]
-    assert!(sv.contains("instr[14:12]"), "expected trunc<14,12> → instr[14:12], got:\n{sv}");
+    assert!(
+        sv.contains("instr[14:12]"),
+        "expected trunc<14,12> → instr[14:12], got:\n{sv}"
+    );
     insta::assert_snapshot!(sv);
 }
 
@@ -2129,8 +2403,10 @@ end module BadAccum
     let result = arch::typecheck::TypeChecker::new(&symbols, &ast).check();
     let errs = result.expect_err("expected typecheck to reject bare-ident <= in seq for-loop");
     let msg = errs.iter().map(|e| format!("{e:?}")).collect::<String>();
-    assert!(msg.contains("non-blocking assignment") && msg.contains("for"),
-            "expected for-loop NBA error, got: {msg}");
+    assert!(
+        msg.contains("non-blocking assignment") && msg.contains("for"),
+        "expected for-loop NBA error, got: {msg}"
+    );
 }
 
 #[test]
@@ -2161,7 +2437,8 @@ end module ShiftFill
     let mut parser = arch::parser::Parser::new(tokens, ok);
     let ast = parser.parse_source_file().expect("parse");
     let symbols = arch::resolve::resolve(&ast).expect("resolve");
-    arch::typecheck::TypeChecker::new(&symbols, &ast).check()
+    arch::typecheck::TypeChecker::new(&symbols, &ast)
+        .check()
         .expect("indexed-target NBA in for-loop should typecheck");
 }
 
@@ -2286,8 +2563,10 @@ end pipeline SkipBypass
     let result = checker.check();
     let errs = result.expect_err("expected typecheck to flag the 2-hop bypass");
     let msg = errs.iter().map(|e| format!("{e:?}")).collect::<String>();
-    assert!(msg.contains("bypassing the intermediate"),
-            "expected bypass message, got: {msg}");
+    assert!(
+        msg.contains("bypassing the intermediate"),
+        "expected bypass message, got: {msg}"
+    );
 }
 
 #[test]
@@ -2334,7 +2613,9 @@ end pipeline ForwardRead
     let ast = parser.parse_source_file().expect("parse");
     let symbols = arch::resolve::resolve(&ast).expect("resolve");
     let checker = arch::typecheck::TypeChecker::new(&symbols, &ast);
-    checker.check().expect("forward-reference pattern should typecheck");
+    checker
+        .check()
+        .expect("forward-reference pattern should typecheck");
 }
 
 #[test]
@@ -2389,9 +2670,15 @@ end module Top
     assert!(sv.contains("module SimplePipe"), "missing pipeline module");
     // Should contain the top module with instantiation
     assert!(sv.contains("module Top"), "missing top module");
-    assert!(sv.contains("SimplePipe pipe0"), "missing pipeline instantiation");
+    assert!(
+        sv.contains("SimplePipe pipe0"),
+        "missing pipeline instantiation"
+    );
     assert!(sv.contains(".data_in(din)"), "missing data_in connection");
-    assert!(sv.contains(".data_out(dout)"), "missing data_out connection");
+    assert!(
+        sv.contains(".data_out(dout)"),
+        "missing data_out connection"
+    );
     insta::assert_snapshot!(sv);
 }
 
@@ -2449,10 +2736,16 @@ end pipeline AluPipe
     // ALU module should be emitted
     assert!(sv.contains("module Alu"), "missing Alu module");
     // Pipeline should contain the inst
-    assert!(sv.contains("Alu alu0"), "missing Alu instantiation inside pipeline stage");
+    assert!(
+        sv.contains("Alu alu0"),
+        "missing Alu instantiation inside pipeline stage"
+    );
     assert!(sv.contains(".a("), "missing port a connection");
     assert!(sv.contains(".b("), "missing port b connection");
-    assert!(sv.contains(".result(result_out)"), "missing result connection");
+    assert!(
+        sv.contains(".result(result_out)"),
+        "missing result connection"
+    );
     insta::assert_snapshot!(sv);
 }
 
@@ -2588,7 +2881,10 @@ end pipeline P2
 "#;
     let sv = compile_to_sv(source);
     assert!(sv.contains("module Helper"), "Helper module should emit");
-    assert!(sv.contains("Helper h ("), "Helper inst should emit inside pipeline stage");
+    assert!(
+        sv.contains("Helper h ("),
+        "Helper inst should emit inside pipeline stage"
+    );
     assert!(
         sv.contains("logic [15:0] only_h_out"),
         "inst output wire should be 16-bit per Helper.q_out"
@@ -2807,11 +3103,20 @@ end module FifoCtrl
 "#;
     let sv = compile_to_sv(source);
     // $clog2(DEPTH) should appear in port widths
-    assert!(sv.contains("$clog2(DEPTH)"), "expected $clog2(DEPTH) in SV output, got:\n{sv}");
+    assert!(
+        sv.contains("$clog2(DEPTH)"),
+        "expected $clog2(DEPTH) in SV output, got:\n{sv}"
+    );
     // $clog2(DEPTH) + 1 in count port
-    assert!(sv.contains("$clog2(DEPTH) + 1"), "expected $clog2(DEPTH) + 1 in SV output, got:\n{sv}");
+    assert!(
+        sv.contains("$clog2(DEPTH) + 1"),
+        "expected $clog2(DEPTH) + 1 in SV output, got:\n{sv}"
+    );
     // trunc<$clog2(DEPTH)>() should emit as size cast
-    assert!(sv.contains("$clog2(DEPTH)'("), "expected $clog2(DEPTH)'(...) size cast, got:\n{sv}");
+    assert!(
+        sv.contains("$clog2(DEPTH)'("),
+        "expected $clog2(DEPTH)'(...) size cast, got:\n{sv}"
+    );
     insta::assert_snapshot!(sv);
 }
 
@@ -2856,24 +3161,39 @@ end linklist TaskQueue
     let sv = compile_to_sv(source);
     // Module header
     assert!(sv.contains("module TaskQueue #("), "missing module header");
-    assert!(sv.contains("parameter int  DEPTH = 8"), "missing DEPTH param");
+    assert!(
+        sv.contains("parameter int  DEPTH = 8"),
+        "missing DEPTH param"
+    );
     assert!(sv.contains("parameter type DATA"), "missing DATA param");
     // Infrastructure signals
     assert!(sv.contains("_fl_mem"), "missing free list memory");
     assert!(sv.contains("_next_mem"), "missing next pointer RAM");
     assert!(sv.contains("_head_r"), "missing head register");
-    assert!(sv.contains("_tail_r"), "missing tail register (track_tail: true)");
+    assert!(
+        sv.contains("_tail_r"),
+        "missing tail register (track_tail: true)"
+    );
     // Status outputs
     assert!(sv.contains("assign empty"), "missing empty assign");
     assert!(sv.contains("assign full"), "missing full assign");
     assert!(sv.contains("assign length"), "missing length assign");
     // Op ports
     assert!(sv.contains("alloc_req_valid"), "missing alloc port");
-    assert!(sv.contains("delete_head_resp_data"), "missing delete_head resp_data port");
+    assert!(
+        sv.contains("delete_head_resp_data"),
+        "missing delete_head resp_data port"
+    );
     // alloc FSM
-    assert!(sv.contains("_fl_rdp <= _fl_rdp + 1'b1"), "missing free-list dequeue");
+    assert!(
+        sv.contains("_fl_rdp <= _fl_rdp + 1'b1"),
+        "missing free-list dequeue"
+    );
     // delete_head 2-cycle FSM
-    assert!(sv.contains("_ctrl_delete_head_busy"), "missing delete_head busy reg");
+    assert!(
+        sv.contains("_ctrl_delete_head_busy"),
+        "missing delete_head busy reg"
+    );
     assert!(sv.contains("_head_r <= _next_mem"), "missing head advance");
     insta::assert_snapshot!(sv);
 }
@@ -2919,7 +3239,10 @@ end linklist SchedList
     assert!(sv.contains("_prev_mem"), "doubly list missing _prev_mem");
     assert!(sv.contains("_next_mem"), "missing _next_mem");
     // prev op controller
-    assert!(sv.contains("_ctrl_prev_resp_handle <= _prev_mem"), "missing prev pointer follow");
+    assert!(
+        sv.contains("_ctrl_prev_resp_handle <= _prev_mem"),
+        "missing prev pointer follow"
+    );
     insta::assert_snapshot!(sv);
 }
 
@@ -2957,26 +3280,43 @@ linklist MhQ
 end linklist MhQ
 "#;
     let sim = compile_to_sim_h(source, false);
-    assert!(sim.contains("uint8_t _head_r[2]"), "missing _head_r[2]:\n{sim}");
+    assert!(
+        sim.contains("uint8_t _head_r[2]"),
+        "missing _head_r[2]:\n{sim}"
+    );
     assert!(sim.contains("uint8_t _tail_r[2]"), "missing _tail_r[2]");
     assert!(sim.contains("uint8_t _length_r[2]"), "missing _length_r[2]");
-    assert!(sim.contains("_ctrl_insert_tail_head_idx"),
-            "missing insert_tail head_idx latch");
-    assert!(sim.contains("_ctrl_delete_head_head_idx"),
-            "missing delete_head head_idx latch");
+    assert!(
+        sim.contains("_ctrl_insert_tail_head_idx"),
+        "missing insert_tail head_idx latch"
+    );
+    assert!(
+        sim.contains("_ctrl_delete_head_head_idx"),
+        "missing delete_head head_idx latch"
+    );
     // Delete ready gated by per-head length
-    assert!(sim.contains("_length_r[delete_head_req_head_idx] != 0"),
-            "missing per-head delete ready gate");
+    assert!(
+        sim.contains("_length_r[delete_head_req_head_idx] != 0"),
+        "missing per-head delete ready gate"
+    );
     // Busy-cycle head/tail access uses the latched idx
-    assert!(sim.contains("_head_r[_ctrl_delete_head_head_idx]"),
-            "missing busy-cycle head ref");
-    assert!(sim.contains("_tail_r[_ctrl_insert_tail_head_idx]"),
-            "missing busy-cycle tail ref");
+    assert!(
+        sim.contains("_head_r[_ctrl_delete_head_head_idx]"),
+        "missing busy-cycle head ref"
+    );
+    assert!(
+        sim.contains("_tail_r[_ctrl_insert_tail_head_idx]"),
+        "missing busy-cycle tail ref"
+    );
     // Per-head length updates
-    assert!(sim.contains("_length_r[_ctrl_insert_tail_head_idx]++"),
-            "missing length inc in insert");
-    assert!(sim.contains("_length_r[_ctrl_delete_head_head_idx]--"),
-            "missing length dec in delete");
+    assert!(
+        sim.contains("_length_r[_ctrl_insert_tail_head_idx]++"),
+        "missing length inc in insert"
+    );
+    assert!(
+        sim.contains("_length_r[_ctrl_delete_head_head_idx]--"),
+        "missing length dec in delete"
+    );
 }
 
 #[test]
@@ -3013,24 +3353,46 @@ end linklist MhQ
 "#;
     let sv = compile_to_sv(source);
     // Module header carries NUM_HEADS param
-    assert!(sv.contains("parameter int  NUM_HEADS = 4"), "missing NUM_HEADS param:\n{sv}");
+    assert!(
+        sv.contains("parameter int  NUM_HEADS = 4"),
+        "missing NUM_HEADS param:\n{sv}"
+    );
     // Head/tail/length become arrays indexed by NUM_HEADS
     assert!(sv.contains("_head_r [NUM_HEADS]"), "missing head array");
     assert!(sv.contains("_tail_r [NUM_HEADS]"), "missing tail array");
-    assert!(sv.contains("_length_r [NUM_HEADS]"), "missing internal length array");
+    assert!(
+        sv.contains("_length_r [NUM_HEADS]"),
+        "missing internal length array"
+    );
     // Per-op latched head_idx register
-    assert!(sv.contains("_ctrl_insert_tail_head_idx"), "missing insert_tail head_idx latch");
-    assert!(sv.contains("_ctrl_delete_head_head_idx"), "missing delete_head head_idx latch");
+    assert!(
+        sv.contains("_ctrl_insert_tail_head_idx"),
+        "missing insert_tail head_idx latch"
+    );
+    assert!(
+        sv.contains("_ctrl_delete_head_head_idx"),
+        "missing delete_head head_idx latch"
+    );
     // Accept cycle reads head/tail by request idx directly; busy cycle
     // by the latched idx.
-    assert!(sv.contains("_head_r[delete_head_req_head_idx]"), "missing accept-cycle head ref");
-    assert!(sv.contains("_tail_r[_ctrl_insert_tail_head_idx]"), "missing busy-cycle tail ref");
+    assert!(
+        sv.contains("_head_r[delete_head_req_head_idx]"),
+        "missing accept-cycle head ref"
+    );
+    assert!(
+        sv.contains("_tail_r[_ctrl_insert_tail_head_idx]"),
+        "missing busy-cycle tail ref"
+    );
     // req_ready for delete gated by per-head length
-    assert!(sv.contains("_length_r[delete_head_req_head_idx] != '0"),
-            "missing per-head delete ready gate");
+    assert!(
+        sv.contains("_length_r[delete_head_req_head_idx] != '0"),
+        "missing per-head delete ready gate"
+    );
     // Reset loops through NUM_HEADS
-    assert!(sv.contains("for (_ll_i = 0; _ll_i < NUM_HEADS; _ll_i++)"),
-            "missing NUM_HEADS reset loop");
+    assert!(
+        sv.contains("for (_ll_i = 0; _ll_i < NUM_HEADS; _ll_i++)"),
+        "missing NUM_HEADS reset loop"
+    );
 }
 
 #[test]
@@ -3079,29 +3441,49 @@ end linklist MhFull
 "#;
     let sv = compile_to_sv(source);
     // No $fatal stub anywhere — all three ops are now wired.
-    assert!(!sv.contains("not yet implemented for multi-head"),
-            "stub message should be gone:\n{sv}");
+    assert!(
+        !sv.contains("not yet implemented for multi-head"),
+        "stub message should be gone:\n{sv}"
+    );
     // insert_head: head_idx latch + busy-cycle uses latched idx + length++
-    assert!(sv.contains("_ctrl_insert_head_head_idx  <= insert_head_req_head_idx"),
-            "missing insert_head idx latch:\n{sv}");
-    assert!(sv.contains("_head_r[_ctrl_insert_head_head_idx] <= _ctrl_insert_head_resp_handle"),
-            "missing insert_head busy-cycle head update");
-    assert!(sv.contains("_length_r[_ctrl_insert_head_head_idx] <= _length_r[_ctrl_insert_head_head_idx] + 1'b1"),
-            "missing insert_head length increment");
-    assert!(sv.contains("_ctrl_insert_head_was_empty <= (_length_r[insert_head_req_head_idx] == '0)"),
-            "missing per-head was_empty check on insert_head");
+    assert!(
+        sv.contains("_ctrl_insert_head_head_idx  <= insert_head_req_head_idx"),
+        "missing insert_head idx latch:\n{sv}"
+    );
+    assert!(
+        sv.contains("_head_r[_ctrl_insert_head_head_idx] <= _ctrl_insert_head_resp_handle"),
+        "missing insert_head busy-cycle head update"
+    );
+    assert!(
+        sv.contains(
+            "_length_r[_ctrl_insert_head_head_idx] <= _length_r[_ctrl_insert_head_head_idx] + 1'b1"
+        ),
+        "missing insert_head length increment"
+    );
+    assert!(
+        sv.contains("_ctrl_insert_head_was_empty <= (_length_r[insert_head_req_head_idx] == '0)"),
+        "missing per-head was_empty check on insert_head"
+    );
     // insert_after: head_idx latch + length++ (pointer patches stay shared)
-    assert!(sv.contains("_ctrl_insert_after_head_idx <= insert_after_req_head_idx"),
-            "missing insert_after idx latch");
+    assert!(
+        sv.contains("_ctrl_insert_after_head_idx <= insert_after_req_head_idx"),
+        "missing insert_after idx latch"
+    );
     assert!(sv.contains("_length_r[_ctrl_insert_after_head_idx] <= _length_r[_ctrl_insert_after_head_idx] + 1'b1"),
             "missing insert_after length increment");
     // delete: head_idx latch + length-- + per-head ready gate
-    assert!(sv.contains("_ctrl_delete_head_idx <= delete_req_head_idx"),
-            "missing delete idx latch");
-    assert!(sv.contains("_length_r[_ctrl_delete_head_idx] <= _length_r[_ctrl_delete_head_idx] - 1'b1"),
-            "missing delete length decrement");
-    assert!(sv.contains("_length_r[delete_req_head_idx] != '0"),
-            "missing per-head delete ready gate");
+    assert!(
+        sv.contains("_ctrl_delete_head_idx <= delete_req_head_idx"),
+        "missing delete idx latch"
+    );
+    assert!(
+        sv.contains("_length_r[_ctrl_delete_head_idx] <= _length_r[_ctrl_delete_head_idx] - 1'b1"),
+        "missing delete length decrement"
+    );
+    assert!(
+        sv.contains("_length_r[delete_req_head_idx] != '0"),
+        "missing per-head delete ready gate"
+    );
 }
 
 #[test]
@@ -3146,27 +3528,45 @@ linklist MhFull
 end linklist MhFull
 "#;
     let sim = compile_to_sim_h(source, false);
-    assert!(!sim.contains("is not yet implemented for multi-head"),
-            "stub message should be gone:\n{sim}");
+    assert!(
+        !sim.contains("is not yet implemented for multi-head"),
+        "stub message should be gone:\n{sim}"
+    );
     // insert_head: head_idx latch + length++ + per-head head update
-    assert!(sim.contains("_ctrl_insert_head_head_idx = insert_head_req_head_idx"),
-            "missing insert_head idx latch:\n{sim}");
-    assert!(sim.contains("_head_r[_ctrl_insert_head_head_idx] = _ctrl_insert_head_resp_handle"),
-            "missing insert_head busy head update");
-    assert!(sim.contains("_length_r[_ctrl_insert_head_head_idx]++"),
-            "missing insert_head length increment");
+    assert!(
+        sim.contains("_ctrl_insert_head_head_idx = insert_head_req_head_idx"),
+        "missing insert_head idx latch:\n{sim}"
+    );
+    assert!(
+        sim.contains("_head_r[_ctrl_insert_head_head_idx] = _ctrl_insert_head_resp_handle"),
+        "missing insert_head busy head update"
+    );
+    assert!(
+        sim.contains("_length_r[_ctrl_insert_head_head_idx]++"),
+        "missing insert_head length increment"
+    );
     // insert_after: idx latch + length++
-    assert!(sim.contains("_ctrl_insert_after_head_idx = insert_after_req_head_idx"),
-            "missing insert_after idx latch");
-    assert!(sim.contains("_length_r[_ctrl_insert_after_head_idx]++"),
-            "missing insert_after length increment");
+    assert!(
+        sim.contains("_ctrl_insert_after_head_idx = insert_after_req_head_idx"),
+        "missing insert_after idx latch"
+    );
+    assert!(
+        sim.contains("_length_r[_ctrl_insert_after_head_idx]++"),
+        "missing insert_after length increment"
+    );
     // delete: idx latch + length-- + per-head ready gate
-    assert!(sim.contains("_ctrl_delete_head_idx = delete_req_head_idx"),
-            "missing delete idx latch");
-    assert!(sim.contains("_length_r[_ctrl_delete_head_idx]--"),
-            "missing delete length decrement");
-    assert!(sim.contains("_length_r[delete_req_head_idx] != 0"),
-            "missing per-head delete ready gate");
+    assert!(
+        sim.contains("_ctrl_delete_head_idx = delete_req_head_idx"),
+        "missing delete idx latch"
+    );
+    assert!(
+        sim.contains("_length_r[_ctrl_delete_head_idx]--"),
+        "missing delete length decrement"
+    );
+    assert!(
+        sim.contains("_length_r[delete_req_head_idx] != 0"),
+        "missing per-head delete ready gate"
+    );
 }
 
 #[test]
@@ -3197,10 +3597,21 @@ end linklist BadMh
     let ast = elaborate::elaborate(parsed).expect("elaborate");
     let symbols = resolve::resolve(&ast).expect("resolve");
     let result = TypeChecker::new(&symbols, &ast).check();
-    assert!(result.is_err(), "expected typecheck to reject per-head op without req_head_idx");
-    let msg = result.unwrap_err().iter().map(|e| format!("{e:?}")).collect::<String>();
-    assert!(msg.contains("req_head_idx") && msg.contains("multi-head") == false && msg.contains("NUM_HEADS"),
-            "expected NUM_HEADS-specific error, got: {msg}");
+    assert!(
+        result.is_err(),
+        "expected typecheck to reject per-head op without req_head_idx"
+    );
+    let msg = result
+        .unwrap_err()
+        .iter()
+        .map(|e| format!("{e:?}"))
+        .collect::<String>();
+    assert!(
+        msg.contains("req_head_idx")
+            && msg.contains("multi-head") == false
+            && msg.contains("NUM_HEADS"),
+        "expected NUM_HEADS-specific error, got: {msg}"
+    );
 }
 
 #[test]
@@ -3231,10 +3642,19 @@ end linklist BadSh
     let ast = elaborate::elaborate(parsed).expect("elaborate");
     let symbols = resolve::resolve(&ast).expect("resolve");
     let result = TypeChecker::new(&symbols, &ast).check();
-    assert!(result.is_err(), "expected typecheck to reject req_head_idx on single-head list");
-    let msg = result.unwrap_err().iter().map(|e| format!("{e:?}")).collect::<String>();
-    assert!(msg.contains("req_head_idx") && msg.contains("single-head"),
-            "expected single-head-specific error, got: {msg}");
+    assert!(
+        result.is_err(),
+        "expected typecheck to reject req_head_idx on single-head list"
+    );
+    let msg = result
+        .unwrap_err()
+        .iter()
+        .map(|e| format!("{e:?}"))
+        .collect::<String>();
+    assert!(
+        msg.contains("req_head_idx") && msg.contains("single-head"),
+        "expected single-head-specific error, got: {msg}"
+    );
 }
 
 #[test]
@@ -3266,10 +3686,19 @@ end linklist BadList
     let symbols = resolve::resolve(&ast).expect("resolve error");
     let checker = TypeChecker::new(&symbols, &ast);
     let result = checker.check();
-    assert!(result.is_err(), "expected type error for prev on singly list");
+    assert!(
+        result.is_err(),
+        "expected type error for prev on singly list"
+    );
     let errs = result.unwrap_err();
-    assert!(errs.iter().any(|e| { let s = e.to_string(); s.contains("prev") && s.contains("doubly") }),
-            "expected error about prev requiring doubly, got: {:?}", errs);
+    assert!(
+        errs.iter().any(|e| {
+            let s = e.to_string();
+            s.contains("prev") && s.contains("doubly")
+        }),
+        "expected error about prev requiring doubly, got: {:?}",
+        errs
+    );
 }
 
 #[test]
@@ -3277,8 +3706,8 @@ fn test_linklist_inst_in_module() {
     // PacketQueue wraps TaskQueue linklist as a push/pop FIFO interface.
     // Verifies that: linklist can be instantiated inside a module,
     // inst output ports are auto-declared as wires, and codegen succeeds.
-    let source = std::fs::read_to_string("examples/pkt_queue.arch")
-        .expect("pkt_queue.arch not found");
+    let source =
+        std::fs::read_to_string("examples/pkt_queue.arch").expect("pkt_queue.arch not found");
     let tokens = lexer::tokenize(&source).expect("lexer error");
     let mut parser = Parser::new(tokens, &source);
     let parsed = parser.parse_source_file().expect("parse error");
@@ -3351,14 +3780,35 @@ end module RfUser
 "#;
     let sv = compile_to_sv(source);
     // Parser transforms read[0].addr → read0_addr, read[1].data → read1_data
-    assert!(sv.contains(".read0_addr"), "expected .read0_addr port connection, got:\n{sv}");
-    assert!(sv.contains(".read0_data"), "expected .read0_data port connection, got:\n{sv}");
-    assert!(sv.contains(".read1_addr"), "expected .read1_addr port connection, got:\n{sv}");
-    assert!(sv.contains(".read1_data"), "expected .read1_data port connection, got:\n{sv}");
+    assert!(
+        sv.contains(".read0_addr"),
+        "expected .read0_addr port connection, got:\n{sv}"
+    );
+    assert!(
+        sv.contains(".read0_data"),
+        "expected .read0_data port connection, got:\n{sv}"
+    );
+    assert!(
+        sv.contains(".read1_addr"),
+        "expected .read1_addr port connection, got:\n{sv}"
+    );
+    assert!(
+        sv.contains(".read1_data"),
+        "expected .read1_data port connection, got:\n{sv}"
+    );
     // Also check dot-only syntax: write.en → write_en
-    assert!(sv.contains(".write_en"),   "expected .write_en port connection, got:\n{sv}");
-    assert!(sv.contains(".write_addr"), "expected .write_addr port connection, got:\n{sv}");
-    assert!(sv.contains(".write_data"), "expected .write_data port connection, got:\n{sv}");
+    assert!(
+        sv.contains(".write_en"),
+        "expected .write_en port connection, got:\n{sv}"
+    );
+    assert!(
+        sv.contains(".write_addr"),
+        "expected .write_addr port connection, got:\n{sv}"
+    );
+    assert!(
+        sv.contains(".write_data"),
+        "expected .write_data port connection, got:\n{sv}"
+    );
     insta::assert_snapshot!(sv);
 }
 
@@ -3377,7 +3827,9 @@ struct Foo
 end struct Foo
 "#;
     let sv = compile_to_sv(source);
-    let td = sv.find("typedef struct packed").expect("expected typedef struct packed in SV");
+    let td = sv
+        .find("typedef struct packed")
+        .expect("expected typedef struct packed in SV");
     let end = sv[td..].find("} Foo;").expect("expected `} Foo;` closing") + td;
     let body = &sv[td..end];
     let pos_a = body.find("a;").expect("expected field `a`");
@@ -3455,7 +3907,10 @@ end module LteExpr
 "#;
     let sv = compile_to_sv(source);
     // Statement-level `<=` still produces a non-blocking assignment.
-    assert!(sv.contains("cnt <="), "expected seq `cnt <= ...` in SV, got:\n{sv}");
+    assert!(
+        sv.contains("cnt <="),
+        "expected seq `cnt <= ...` in SV, got:\n{sv}"
+    );
     // Expression-level `<=` appears in the assertion body.
     assert!(
         sv.contains("bounded") && sv.contains("<= 200"),
@@ -3491,13 +3946,31 @@ fn test_handshake_valid_ready_expansion() {
     ";
     let sv = compile_to_sv(source);
     // Send-side valid is OUTPUT, ready is INPUT.
-    assert!(sv.contains("output logic bus_p_aw_valid"), "aw_valid should be output on initiator");
-    assert!(sv.contains("input logic bus_p_aw_ready"), "aw_ready should be input on initiator");
-    assert!(sv.contains("output logic [31:0] bus_p_aw_addr"), "aw payload out");
+    assert!(
+        sv.contains("output logic bus_p_aw_valid"),
+        "aw_valid should be output on initiator"
+    );
+    assert!(
+        sv.contains("input logic bus_p_aw_ready"),
+        "aw_ready should be input on initiator"
+    );
+    assert!(
+        sv.contains("output logic [31:0] bus_p_aw_addr"),
+        "aw payload out"
+    );
     // Receive-side b: valid becomes INPUT for the initiator.
-    assert!(sv.contains("input logic bus_p_b_valid"), "b_valid should be input on initiator");
-    assert!(sv.contains("output logic bus_p_b_ready"), "b_ready should be output on initiator");
-    assert!(sv.contains("input logic [1:0] bus_p_b_resp"), "b payload in");
+    assert!(
+        sv.contains("input logic bus_p_b_valid"),
+        "b_valid should be input on initiator"
+    );
+    assert!(
+        sv.contains("output logic bus_p_b_ready"),
+        "b_ready should be output on initiator"
+    );
+    assert!(
+        sv.contains("input logic [1:0] bus_p_b_resp"),
+        "b payload in"
+    );
 }
 
 #[test]
@@ -3521,9 +3994,18 @@ fn test_handshake_target_flip() {
     ";
     let sv = compile_to_sv(source);
     // Target flips: producer-side 'out' becomes 'in' at the consumer.
-    assert!(sv.contains("input logic bus_c_aw_valid"), "target flip: aw_valid becomes input");
-    assert!(sv.contains("output logic bus_c_aw_ready"), "target flip: aw_ready becomes output");
-    assert!(sv.contains("input logic [31:0] bus_c_aw_addr"), "target flip: payload becomes input");
+    assert!(
+        sv.contains("input logic bus_c_aw_valid"),
+        "target flip: aw_valid becomes input"
+    );
+    assert!(
+        sv.contains("output logic bus_c_aw_ready"),
+        "target flip: aw_ready becomes output"
+    );
+    assert!(
+        sv.contains("input logic [31:0] bus_c_aw_addr"),
+        "target flip: payload becomes input"
+    );
 }
 
 #[test]
@@ -3672,8 +4154,10 @@ fn test_use_bus_does_not_emit_sv_import() {
         end module M
     ";
     let sv = compile_to_sv(source);
-    assert!(!sv.contains("import BusS"),
-            "spurious SV import emitted for a bus-typed use:\n{sv}");
+    assert!(
+        !sv.contains("import BusS"),
+        "spurious SV import emitted for a bus-typed use:\n{sv}"
+    );
 }
 
 #[test]
@@ -3699,8 +4183,10 @@ fn test_use_package_still_emits_sv_import() {
         end module M
     ";
     let sv = compile_to_sv(source);
-    assert!(sv.contains("import PkgA::*;"),
-            "expected SV import for a package-typed use:\n{sv}");
+    assert!(
+        sv.contains("import PkgA::*;"),
+        "expected SV import for a package-typed use:\n{sv}"
+    );
 }
 
 /// `extern package` declares opaque types from an SV-side package.
@@ -3728,19 +4214,31 @@ end module IbexCore
     // rather than wildcard `import Pkg::*;` so unrelated enum
     // items / parameters from the upstream SV package don't pollute
     // the compilation unit and conflict with locally-named signals.
-    assert!(sv.contains("import ibex_pkg::rv32m_e;"),
-            "expected SV `import ibex_pkg::rv32m_e;` for extern package:\n{sv}");
-    assert!(sv.contains("import ibex_pkg::rv32b_e;"),
-            "expected SV `import ibex_pkg::rv32b_e;` for extern package:\n{sv}");
-    assert!(!sv.contains("import ibex_pkg::*;"),
-            "extern packages must NOT emit wildcard `import ibex_pkg::*;`:\n{sv}");
-    assert!(sv.contains("parameter rv32m_e RV32M = RV32MFast"),
-            "expected bare `rv32m_e` type and `RV32MFast` variant:\n{sv}");
-    assert!(sv.contains("parameter rv32b_e RV32B = RV32BNone"),
-            "expected bare `rv32b_e` type and `RV32BNone` variant:\n{sv}");
+    assert!(
+        sv.contains("import ibex_pkg::rv32m_e;"),
+        "expected SV `import ibex_pkg::rv32m_e;` for extern package:\n{sv}"
+    );
+    assert!(
+        sv.contains("import ibex_pkg::rv32b_e;"),
+        "expected SV `import ibex_pkg::rv32b_e;` for extern package:\n{sv}"
+    );
+    assert!(
+        !sv.contains("import ibex_pkg::*;"),
+        "extern packages must NOT emit wildcard `import ibex_pkg::*;`:\n{sv}"
+    );
+    assert!(
+        sv.contains("parameter rv32m_e RV32M = RV32MFast"),
+        "expected bare `rv32m_e` type and `RV32MFast` variant:\n{sv}"
+    );
+    assert!(
+        sv.contains("parameter rv32b_e RV32B = RV32BNone"),
+        "expected bare `rv32b_e` type and `RV32BNone` variant:\n{sv}"
+    );
     // No extern package body should be emitted (SV package lives upstream).
-    assert!(!sv.contains("extern package") && !sv.contains("endpackage"),
-            "extern package must not emit SV package body:\n{sv}");
+    assert!(
+        !sv.contains("extern package") && !sv.contains("endpackage"),
+        "extern package must not emit SV package body:\n{sv}"
+    );
 }
 
 fn compile_to_sim_h(source: &str, inputs_start_uninit: bool) -> String {
@@ -3762,7 +4260,8 @@ fn compile_to_sim_h(source: &str, inputs_start_uninit: bool) -> String {
         .inputs_start_uninit(inputs_start_uninit);
     let models = sim.generate();
     // Concatenate all model headers + impl files — tests can grep across them.
-    models.iter()
+    models
+        .iter()
         .map(|m| format!("{}\n// ---\n{}", m.header, m.impl_))
         .collect::<Vec<_>>()
         .join("\n// ---\n")
@@ -3781,13 +4280,18 @@ fn compile_to_thread_sim_h(source: &str) -> String {
     let checker = arch::typecheck::TypeChecker::new(&symbols, &ast);
     checker.check().expect("type check error");
 
-    ast.items.iter()
+    ast.items
+        .iter()
         .filter_map(|item| match item {
             arch::ast::Item::Module(m)
-                if m.body.iter().any(|i| matches!(i, arch::ast::ModuleBodyItem::Thread(_))) =>
+                if m.body
+                    .iter()
+                    .any(|i| matches!(i, arch::ast::ModuleBodyItem::Thread(_))) =>
             {
-                Some(arch::sim_codegen::thread_sim::gen_module_thread(m, false, false, 1)
-                    .expect("thread sim codegen"))
+                Some(
+                    arch::sim_codegen::thread_sim::gen_module_thread(m, false, false, 1)
+                        .expect("thread sim codegen"),
+                )
             }
             _ => None,
         })
@@ -3815,9 +4319,16 @@ fn compile_to_thread_sim_collect_warnings(source: &str) -> Vec<arch::diagnostics
     let mut warnings: Vec<arch::diagnostics::CompileWarning> = Vec::new();
     for item in &ast.items {
         if let arch::ast::Item::Module(m) = item {
-            if m.body.iter().any(|i| matches!(i, arch::ast::ModuleBodyItem::Thread(_))) {
+            if m.body
+                .iter()
+                .any(|i| matches!(i, arch::ast::ModuleBodyItem::Thread(_)))
+            {
                 arch::sim_codegen::thread_sim::gen_module_thread_with_warnings(
-                    m, false, false, 1, &mut warnings,
+                    m,
+                    false,
+                    false,
+                    1,
+                    &mut warnings,
                 )
                 .expect("thread sim codegen");
             }
@@ -3851,14 +4362,22 @@ fn test_inputs_start_uninit_bus_flattened() {
         end module Reader
     ";
     let h = compile_to_sim_h(source, true);
-    assert!(h.contains("bool _b_data_vinit = false;"),
-            "expected shadow bit for flattened bus input 'b_data':\n{h}");
-    assert!(h.contains("bool _b_valid_vinit = false;"),
-            "expected shadow bit for flattened bus input 'b_valid':\n{h}");
-    assert!(h.contains("void set_b_data("),
-            "expected setter for flattened bus input 'b_data':\n{h}");
-    assert!(h.contains("void set_b_valid("),
-            "expected setter for flattened bus input 'b_valid':\n{h}");
+    assert!(
+        h.contains("bool _b_data_vinit = false;"),
+        "expected shadow bit for flattened bus input 'b_data':\n{h}"
+    );
+    assert!(
+        h.contains("bool _b_valid_vinit = false;"),
+        "expected shadow bit for flattened bus input 'b_valid':\n{h}"
+    );
+    assert!(
+        h.contains("void set_b_data("),
+        "expected setter for flattened bus input 'b_data':\n{h}"
+    );
+    assert!(
+        h.contains("void set_b_valid("),
+        "expected setter for flattened bus input 'b_valid':\n{h}"
+    );
 }
 
 #[test]
@@ -3883,10 +4402,14 @@ fn test_inputs_start_uninit_bus_skips_output_direction() {
         end module Driver
     ";
     let h = compile_to_sim_h(source, true);
-    assert!(!h.contains("_b_data_vinit"),
-            "did not expect vinit for output-side bus signal 'b_data':\n{h}");
-    assert!(!h.contains("set_b_data("),
-            "did not expect setter for output-side bus signal 'b_data':\n{h}");
+    assert!(
+        !h.contains("_b_data_vinit"),
+        "did not expect vinit for output-side bus signal 'b_data':\n{h}"
+    );
+    assert!(
+        !h.contains("set_b_data("),
+        "did not expect setter for output-side bus signal 'b_data':\n{h}"
+    );
 }
 
 #[test]
@@ -3907,8 +4430,10 @@ fn test_inputs_start_uninit_without_flag_emits_nothing() {
         end module Reader
     ";
     let h = compile_to_sim_h(source, false);
-    assert!(!h.contains("_b_data_vinit"),
-            "no --inputs-start-uninit → no bus vinit tracking:\n{h}");
+    assert!(
+        !h.contains("_b_data_vinit"),
+        "no --inputs-start-uninit → no bus vinit tracking:\n{h}"
+    );
 }
 
 #[test]
@@ -3952,19 +4477,29 @@ fn test_handshake_tier15_payload_warning_gated_on_valid() {
         .check_uninit(true)
         .inputs_start_uninit(true);
     let models = sim.generate();
-    let cpp = models.iter().find(|m| m.class_name == "VConsumer").unwrap().impl_.clone();
+    let cpp = models
+        .iter()
+        .find(|m| m.class_name == "VConsumer")
+        .unwrap()
+        .impl_
+        .clone();
 
     // Payload-signal read warning must be AND'd with the handshake's valid.
-    assert!(cpp.contains("!_b_ch_data_vinit && b_ch_valid"),
-            "expected payload warning gated on valid signal:\n{cpp}");
+    assert!(
+        cpp.contains("!_b_ch_data_vinit && b_ch_valid"),
+        "expected payload warning gated on valid signal:\n{cpp}"
+    );
 
     // Valid-signal itself is tracked but NOT a payload, so its warning is
     // unconditional (no extra gate).
-    let valid_check_line = cpp.lines()
+    let valid_check_line = cpp
+        .lines()
         .find(|l| l.contains("!_b_ch_valid_vinit"))
         .expect("expected warning for b_ch_valid signal");
-    assert!(!valid_check_line.contains("&& b_ch_valid"),
-            "valid signal's own warning should not self-gate:\n{valid_check_line}");
+    assert!(
+        !valid_check_line.contains("&& b_ch_valid"),
+        "valid signal's own warning should not self-gate:\n{valid_check_line}"
+    );
 }
 
 #[test]
@@ -4003,9 +4538,16 @@ fn test_handshake_tier15_req_ack_4phase_uses_req_as_guard() {
         .check_uninit(true)
         .inputs_start_uninit(true);
     let models = sim.generate();
-    let cpp = models.iter().find(|m| m.class_name == "VC").unwrap().impl_.clone();
-    assert!(cpp.contains("!_b_ch_payload_vinit && b_ch_req"),
-            "req_ack_4phase payload should gate on b_ch_req:\n{cpp}");
+    let cpp = models
+        .iter()
+        .find(|m| m.class_name == "VC")
+        .unwrap()
+        .impl_
+        .clone();
+    assert!(
+        cpp.contains("!_b_ch_payload_vinit && b_ch_req"),
+        "req_ack_4phase payload should gate on b_ch_req:\n{cpp}"
+    );
 }
 
 fn warnings_from(source: &str) -> Vec<String> {
@@ -4040,8 +4582,12 @@ fn test_handshake_tier15_unguarded_payload_warns() {
         end module Consumer
     ";
     let ws = warnings_from(source);
-    assert!(ws.iter().any(|m| m.contains("b.ch_data") && m.contains("if b.ch_valid")),
-            "expected unguarded-payload warning; got: {:?}", ws);
+    assert!(
+        ws.iter()
+            .any(|m| m.contains("b.ch_data") && m.contains("if b.ch_valid")),
+        "expected unguarded-payload warning; got: {:?}",
+        ws
+    );
 }
 
 #[test]
@@ -4069,8 +4615,12 @@ fn test_handshake_tier15_guarded_payload_silent() {
         end module Consumer
     ";
     let ws = warnings_from(source);
-    assert!(!ws.iter().any(|m| m.contains("handshake payload") && m.contains("ch_data")),
-            "did not expect handshake warning; got: {:?}", ws);
+    assert!(
+        !ws.iter()
+            .any(|m| m.contains("handshake payload") && m.contains("ch_data")),
+        "did not expect handshake warning; got: {:?}",
+        ws
+    );
 }
 
 #[test]
@@ -4097,11 +4647,9 @@ fn test_check_port_reg_timing_fires_on_legacy_port_reg() {
     ";
     let ws = warnings_from(source);
     assert!(
-        ws.iter().any(|m|
-            m.contains("out_reg")
+        ws.iter().any(|m| m.contains("out_reg")
             && m.contains("deprecated `port reg`")
-            && m.contains("state-dependent")
-        ),
+            && m.contains("state-dependent")),
         "expected check_port_reg_timing warning for legacy `port reg` \
          output; got: {:?}",
         ws,
@@ -4133,10 +4681,8 @@ fn test_check_port_reg_timing_skips_modern_pipe_reg() {
     ";
     let ws = warnings_from(source);
     assert!(
-        !ws.iter().any(|m|
-            m.contains("out_reg")
-            && (m.contains("state-dependent") || m.contains("deprecated `port reg`"))
-        ),
+        !ws.iter().any(|m| m.contains("out_reg")
+            && (m.contains("state-dependent") || m.contains("deprecated `port reg`"))),
         "did not expect check_port_reg_timing warning for modern \
          `pipe_reg<T, N>` output (user opted into the N-cycle latency \
          explicitly); got: {:?}",
@@ -4178,23 +4724,19 @@ fn test_check_port_reg_timing_skips_synthesized_thread_lowered_regs() {
     let mut parser = arch::parser::Parser::new(tokens, source);
     let parsed_ast = parser.parse_source_file().expect("parse error");
     let ast = arch::elaborate::elaborate(parsed_ast).expect("elaborate error");
-    let ast = arch::elaborate::lower_tlm_target_threads(ast)
-        .expect("tlm target lowering");
-    let ast = arch::elaborate::lower_tlm_initiator_calls(ast)
-        .expect("tlm initiator lowering");
+    let ast = arch::elaborate::lower_tlm_target_threads(ast).expect("tlm target lowering");
+    let ast = arch::elaborate::lower_tlm_initiator_calls(ast).expect("tlm initiator lowering");
     let ast = arch::elaborate::lower_threads(ast).expect("thread lowering");
-    let ast = arch::elaborate::lower_pipe_reg_ports(ast)
-        .expect("pipe_reg lowering");
-    let ast = arch::elaborate::lower_credit_channel_dispatch(ast)
-        .expect("credit_channel lowering");
+    let ast = arch::elaborate::lower_pipe_reg_ports(ast).expect("pipe_reg lowering");
+    let ast = arch::elaborate::lower_credit_channel_dispatch(ast).expect("credit_channel lowering");
     let symbols = arch::resolve::resolve(&ast).expect("resolve");
     let checker = arch::typecheck::TypeChecker::new(&symbols, &ast);
     let (warnings, _) = checker.check().expect("typecheck");
     let msgs: Vec<String> = warnings.into_iter().map(|w| w.message).collect();
     assert!(
-        !msgs.iter().any(|m|
-            m.contains("state-dependent") || m.contains("deprecated `port reg`")
-        ),
+        !msgs
+            .iter()
+            .any(|m| m.contains("state-dependent") || m.contains("deprecated `port reg`")),
         "expected NO check_port_reg_timing warning on synthesized \
          thread-lowered port regs; got: {:?}",
         msgs,
@@ -4227,8 +4769,12 @@ fn test_handshake_tier15_guard_via_compound_and_silent() {
         end module Consumer
     ";
     let ws = warnings_from(source);
-    assert!(!ws.iter().any(|m| m.contains("handshake payload") && m.contains("ch_data")),
-            "AND-conjunct guard should silence the lint; got: {:?}", ws);
+    assert!(
+        !ws.iter()
+            .any(|m| m.contains("handshake payload") && m.contains("ch_data")),
+        "AND-conjunct guard should silence the lint; got: {:?}",
+        ws
+    );
 }
 
 #[test]
@@ -4256,8 +4802,11 @@ fn test_handshake_tier15_else_branch_warns() {
         end module Consumer
     ";
     let ws = warnings_from(source);
-    assert!(ws.iter().any(|m| m.contains("b.ch_data")),
-            "read in else-branch of `if valid` is NOT guarded; should warn. got: {:?}", ws);
+    assert!(
+        ws.iter().any(|m| m.contains("b.ch_data")),
+        "read in else-branch of `if valid` is NOT guarded; should warn. got: {:?}",
+        ws
+    );
 }
 
 #[test]
@@ -4285,8 +4834,11 @@ fn test_handshake_tier15_req_ack_uses_req_as_guard() {
         end module C
     ";
     let ws = warnings_from(source);
-    assert!(!ws.iter().any(|m| m.contains("handshake payload")),
-            "if b.ch_req should guard req_ack payload; got: {:?}", ws);
+    assert!(
+        !ws.iter().any(|m| m.contains("handshake payload")),
+        "if b.ch_req should guard req_ack payload; got: {:?}",
+        ws
+    );
 }
 
 #[test]
@@ -4307,10 +4859,14 @@ fn test_vec_methods_any_all_expand_to_reduction() {
     ";
     let sv = compile_to_sv(source);
     // Fully unrolled, item → vec[i]:
-    assert!(sv.contains("vec[0] == needle || vec[1] == needle"),
-            "expected any to expand to OR of 4 compares: {sv}");
-    assert!(sv.contains("vec[0] != 0 && vec[1] != 0"),
-            "expected all to expand to AND of 4 compares: {sv}");
+    assert!(
+        sv.contains("vec[0] == needle || vec[1] == needle"),
+        "expected any to expand to OR of 4 compares: {sv}"
+    );
+    assert!(
+        sv.contains("vec[0] != 0 && vec[1] != 0"),
+        "expected all to expand to AND of 4 compares: {sv}"
+    );
 }
 
 #[test]
@@ -4329,8 +4885,10 @@ fn test_vec_methods_index_binder() {
     ";
     let sv = compile_to_sv(source);
     // index should expand to 2-bit literals 2'd0..2'd3 (clog2(4)=2).
-    assert!(sv.contains("2'd0") && sv.contains("2'd3"),
-            "expected index binder to emit sized literals: {sv}");
+    assert!(
+        sv.contains("2'd0") && sv.contains("2'd3"),
+        "expected index binder to emit sized literals: {sv}"
+    );
 }
 
 #[test]
@@ -4349,11 +4907,15 @@ fn test_vec_methods_count_and_contains() {
     ";
     let sv = compile_to_sv(source);
     // count emits 3-bit population-count expression (clog2(N+1)=3 for N=4).
-    assert!(sv.contains("3'(vec[0] == x ? 1 : 0)"),
-            "expected count to emit width-3 bool-to-bit casts: {sv}");
+    assert!(
+        sv.contains("3'(vec[0] == x ? 1 : 0)"),
+        "expected count to emit width-3 bool-to-bit casts: {sv}"
+    );
     // contains lowers identically to any(item == x).
-    assert!(sv.contains("(vec[0] == x) || (vec[1] == x)"),
-            "expected contains to OR per-element equality: {sv}");
+    assert!(
+        sv.contains("(vec[0] == x) || (vec[1] == x)"),
+        "expected contains to OR per-element equality: {sv}"
+    );
 }
 
 #[test]
@@ -4372,12 +4934,18 @@ fn test_vec_methods_reduce_or_and_xor() {
         end module M
     ";
     let sv = compile_to_sv(source);
-    assert!(sv.contains("flags[0] | flags[1] | flags[2] | flags[3]"),
-            "reduce_or expected: {sv}");
-    assert!(sv.contains("flags[0] & flags[1] & flags[2] & flags[3]"),
-            "reduce_and expected: {sv}");
-    assert!(sv.contains("flags[0] ^ flags[1] ^ flags[2] ^ flags[3]"),
-            "reduce_xor expected: {sv}");
+    assert!(
+        sv.contains("flags[0] | flags[1] | flags[2] | flags[3]"),
+        "reduce_or expected: {sv}"
+    );
+    assert!(
+        sv.contains("flags[0] & flags[1] & flags[2] & flags[3]"),
+        "reduce_and expected: {sv}"
+    );
+    assert!(
+        sv.contains("flags[0] ^ flags[1] ^ flags[2] ^ flags[3]"),
+        "reduce_xor expected: {sv}"
+    );
 }
 
 #[test]
@@ -4400,13 +4968,19 @@ fn test_let_destructure_basic() {
         end module M
     ";
     let sv = compile_to_sv(source);
-    assert!(sv.contains("assign x = p_in.x;"),
-            "expected field assign for x:\n{sv}");
-    assert!(sv.contains("assign y = p_in.y;"),
-            "expected field assign for y:\n{sv}");
+    assert!(
+        sv.contains("assign x = p_in.x;"),
+        "expected field assign for x:\n{sv}"
+    );
+    assert!(
+        sv.contains("assign y = p_in.y;"),
+        "expected field assign for y:\n{sv}"
+    );
     // Per-field width comes from the struct definition.
-    assert!(sv.contains("logic [7:0] x;") && sv.contains("logic [7:0] y;"),
-            "expected 8-bit wire declarations:\n{sv}");
+    assert!(
+        sv.contains("logic [7:0] x;") && sv.contains("logic [7:0] y;"),
+        "expected 8-bit wire declarations:\n{sv}"
+    );
 }
 
 #[test]
@@ -4429,10 +5003,14 @@ fn test_let_destructure_partial() {
         end module M
     ";
     let sv = compile_to_sv(source);
-    assert!(sv.contains("assign a = t.a;"),
-            "expected partial destructure:\n{sv}");
-    assert!(!sv.contains("assign b = t.b;") && !sv.contains("assign c = t.c;"),
-            "did not expect unbound fields:\n{sv}");
+    assert!(
+        sv.contains("assign a = t.a;"),
+        "expected partial destructure:\n{sv}"
+    );
+    assert!(
+        !sv.contains("assign b = t.b;") && !sv.contains("assign c = t.c;"),
+        "did not expect unbound fields:\n{sv}"
+    );
 }
 
 #[test]
@@ -4454,11 +5032,15 @@ fn test_let_destructure_non_struct_errors() {
     let symbols = arch::resolve::resolve(&ast).expect("resolve");
     let checker = arch::typecheck::TypeChecker::new(&symbols, &ast);
     let result = checker.check();
-    assert!(result.is_err(),
-            "expected type-check error for destructure on non-struct");
+    assert!(
+        result.is_err(),
+        "expected type-check error for destructure on non-struct"
+    );
     let msg = format!("{:?}", result.unwrap_err());
-    assert!(msg.contains("requires a struct-typed RHS"),
-            "expected specific error message, got: {msg}");
+    assert!(
+        msg.contains("requires a struct-typed RHS"),
+        "expected specific error message, got: {msg}"
+    );
 }
 
 #[test]
@@ -4485,11 +5067,15 @@ fn test_let_destructure_unknown_field_errors() {
     let symbols = arch::resolve::resolve(&ast).expect("resolve");
     let checker = arch::typecheck::TypeChecker::new(&symbols, &ast);
     let result = checker.check();
-    assert!(result.is_err(),
-            "expected type-check error for unknown field");
+    assert!(
+        result.is_err(),
+        "expected type-check error for unknown field"
+    );
     let msg = format!("{:?}", result.unwrap_err());
-    assert!(msg.contains("has no field named `z`"),
-            "expected unknown-field message, got: {msg}");
+    assert!(
+        msg.contains("has no field named `z`"),
+        "expected unknown-field message, got: {msg}"
+    );
 }
 
 #[test]
@@ -4527,19 +5113,29 @@ fn test_bus_wire_typechecks_and_codegens() {
     ";
     let h = compile_to_sim_h(source, false);
     // VStructs.h should emit a plain C++ struct for the bus.
-    assert!(h.contains("struct FooBus {"),
-            "expected `struct FooBus {{` in generated structs header:\n{h}");
-    assert!(h.contains("uint8_t cmd;") && h.contains("uint8_t resp;"),
-            "expected bus fields as struct members:\n{h}");
+    assert!(
+        h.contains("struct FooBus {"),
+        "expected `struct FooBus {{` in generated structs header:\n{h}"
+    );
+    assert!(
+        h.contains("uint8_t cmd;") && h.contains("uint8_t resp;"),
+        "expected bus fields as struct members:\n{h}"
+    );
 
     // VParent.h should declare the wire as a struct-typed member and must
     // NOT emit a shadow `uint32_t w;` scalar.
-    let parent = h.split("// ---\n").find(|p| p.contains("class VParent"))
+    let parent = h
+        .split("// ---\n")
+        .find(|p| p.contains("class VParent"))
         .expect("no VParent header section");
-    assert!(parent.contains("FooBus _let_w;"),
-            "expected `FooBus _let_w;` in VParent header:\n{parent}");
-    assert!(!parent.contains("uint32_t w;"),
-            "unexpected shadow `uint32_t w;` in VParent header:\n{parent}");
+    assert!(
+        parent.contains("FooBus _let_w;"),
+        "expected `FooBus _let_w;` in VParent header:\n{parent}"
+    );
+    assert!(
+        !parent.contains("uint32_t w;"),
+        "unexpected shadow `uint32_t w;` in VParent header:\n{parent}"
+    );
 }
 
 #[test]
@@ -4575,19 +5171,31 @@ fn test_vec_of_bus_port_flattens_to_n_indexed_copies() {
     // One port per signal, with `[N-1:0]` *packed* outer dim. Packed shape
     // works with both Verilator and Yosys's built-in read_verilog and lets
     // inst connection sites use SV concat literals for column gather.
-    assert!(sv.contains("output logic [2:0] chans_v"),
-            "missing `output logic [2:0] chans_v` (packed 3-element) in SV:\n{sv}");
-    assert!(sv.contains("input logic [2:0] chans_r"),
-            "missing `input logic [2:0] chans_r` in SV:\n{sv}");
-    assert!(sv.contains("output logic [2:0] [7:0] chans_d"),
-            "missing `output logic [2:0] [7:0] chans_d` in SV:\n{sv}");
+    assert!(
+        sv.contains("output logic [2:0] chans_v"),
+        "missing `output logic [2:0] chans_v` (packed 3-element) in SV:\n{sv}"
+    );
+    assert!(
+        sv.contains("input logic [2:0] chans_r"),
+        "missing `input logic [2:0] chans_r` in SV:\n{sv}"
+    );
+    assert!(
+        sv.contains("output logic [2:0] [7:0] chans_d"),
+        "missing `output logic [2:0] [7:0] chans_d` in SV:\n{sv}"
+    );
     // Bracket-dot access lowers to packed indexed SV refs.
-    assert!(sv.contains("chans_v[0] = 1'b1") || sv.contains("assign chans_v[0] = 1'b1"),
-            "expected `chans_v[0] = 1'b1` assignment in SV:\n{sv}");
-    assert!(sv.contains("chans_v[1] = 1'b0") || sv.contains("assign chans_v[1] = 1'b0"),
-            "expected `chans_v[1] = 1'b0` assignment in SV:\n{sv}");
-    assert!(sv.contains("chans_d[2] = 8'd51") || sv.contains("assign chans_d[2] = 8'd51"),
-            "expected `chans_d[2] = 8'd51` assignment in SV:\n{sv}");
+    assert!(
+        sv.contains("chans_v[0] = 1'b1") || sv.contains("assign chans_v[0] = 1'b1"),
+        "expected `chans_v[0] = 1'b1` assignment in SV:\n{sv}"
+    );
+    assert!(
+        sv.contains("chans_v[1] = 1'b0") || sv.contains("assign chans_v[1] = 1'b0"),
+        "expected `chans_v[1] = 1'b0` assignment in SV:\n{sv}"
+    );
+    assert!(
+        sv.contains("chans_d[2] = 8'd51") || sv.contains("assign chans_d[2] = 8'd51"),
+        "expected `chans_d[2] = 8'd51` assignment in SV:\n{sv}"
+    );
 }
 
 #[test]
@@ -4605,9 +5213,13 @@ fn test_vec_of_bus_port_rejects_zero_count() {
     "#;
     let tokens = arch::lexer::tokenize(src_zero).expect("lex");
     let mut parser = arch::parser::Parser::new(tokens, src_zero);
-    let err = parser.parse_source_file().expect_err("Vec<B, 0> should fail to parse");
-    assert!(format!("{err:?}").contains("N must be >= 1"),
-            "expected `N must be >= 1` diagnostic, got: {err:?}");
+    let err = parser
+        .parse_source_file()
+        .expect_err("Vec<B, 0> should fail to parse");
+    assert!(
+        format!("{err:?}").contains("N must be >= 1"),
+        "expected `N must be >= 1` diagnostic, got: {err:?}"
+    );
 }
 
 #[test]
@@ -4637,16 +5249,24 @@ fn test_vec_of_bus_port_param_driven_n() {
     let sv = compile_to_sv(source);
     // Packed Vec-of-bus port: single decl with `[N-1:0]` packed outer dim
     // (param folded to 3).
-    assert!(sv.contains("output logic [2:0] chans_v"),
-            "missing `output logic [2:0] chans_v` (packed) in SV:\n{sv}");
-    assert!(sv.contains("output logic [2:0] [7:0] chans_d"),
-            "missing `output logic [2:0] [7:0] chans_d` in SV:\n{sv}");
+    assert!(
+        sv.contains("output logic [2:0] chans_v"),
+        "missing `output logic [2:0] chans_v` (packed) in SV:\n{sv}"
+    );
+    assert!(
+        sv.contains("output logic [2:0] [7:0] chans_d"),
+        "missing `output logic [2:0] [7:0] chans_d` in SV:\n{sv}"
+    );
     // for-loop should be statically unrolled even though the upper bound
     // is `NUM_CHANS-1` (param expression).
-    assert!(!sv.contains("for (int i ="),
-            "expected param-driven for-loop bounds to fold + unroll:\n{sv}");
-    assert!(sv.contains("chans_d[2] = 8'(idx + 2)") || sv.contains("chans_d[2] = 8'((idx + 2))"),
-            "missing unrolled last-element assignment:\n{sv}");
+    assert!(
+        !sv.contains("for (int i ="),
+        "expected param-driven for-loop bounds to fold + unroll:\n{sv}"
+    );
+    assert!(
+        sv.contains("chans_d[2] = 8'(idx + 2)") || sv.contains("chans_d[2] = 8'((idx + 2))"),
+        "missing unrolled last-element assignment:\n{sv}"
+    );
 }
 
 #[test]
@@ -4675,8 +5295,10 @@ fn test_vec_of_bus_port_typecheck_drives_all_indexed_outputs() {
     let msg = errs.iter().map(|e| format!("{e:?}")).collect::<String>();
     // Diagnostic Display = "output port `chans_1_v` is not driven";
     // Debug = `UndriveOutput { name: "chans_1_v", ... }`. Accept either.
-    assert!(msg.contains("chans_1_v") && (msg.contains("not driven") || msg.contains("UndriveOutput")),
-            "expected `chans_1_v not driven` diagnostic, got: {msg}");
+    assert!(
+        msg.contains("chans_1_v") && (msg.contains("not driven") || msg.contains("UndriveOutput")),
+        "expected `chans_1_v not driven` diagnostic, got: {msg}"
+    );
 }
 
 #[test]
@@ -4723,15 +5345,21 @@ fn test_fast_gate_do_until_mealy_fusion() {
     let sv = compile_to_sv(source);
     // Exactly one wait_until state (S0) — no separate entry state.
     let state_decls = sv.matches("_t0_S").count();
-    assert!(state_decls <= 4,
-            "expected at most 2 `_t0_Sx` references (state localparam + one use); \
-             single-state Mealy fusion should not generate extra states. Got {state_decls}:\n{sv}");
+    assert!(
+        state_decls <= 4,
+        "expected at most 2 `_t0_Sx` references (state localparam + one use); \
+             single-state Mealy fusion should not generate extra states. Got {state_decls}:\n{sv}"
+    );
     // The do-body comb is wrapped in `if (m_val)`.
-    assert!(sv.contains("if (m_val)"),
-            "expected `if (m_val)` gating the Mealy body's comb drives:\n{sv}");
+    assert!(
+        sv.contains("if (m_val)"),
+        "expected `if (m_val)` gating the Mealy body's comb drives:\n{sv}"
+    );
     // Transition guard ANDs the wait + do-until conditions.
-    assert!(sv.contains("if (m_val && b_r)") || sv.contains("m_val && b_r"),
-            "expected `m_val && b_r` as the fused transition guard:\n{sv}");
+    assert!(
+        sv.contains("if (m_val && b_r)") || sv.contains("m_val && b_r"),
+        "expected `m_val && b_r` as the fused transition guard:\n{sv}"
+    );
 }
 
 #[test]
@@ -4914,10 +5542,14 @@ fn test_nested_for_in_thread_uses_distinct_loop_counters() {
     ";
     let sv = compile_to_sv(source);
     // Two distinct loop-counter regs must be declared.
-    assert!(sv.contains("_t0_loop_cnt_0"),
-        "expected outer loop counter `_t0_loop_cnt_0`:\n{sv}");
-    assert!(sv.contains("_t0_loop_cnt_1"),
-        "expected inner loop counter `_t0_loop_cnt_1`:\n{sv}");
+    assert!(
+        sv.contains("_t0_loop_cnt_0"),
+        "expected outer loop counter `_t0_loop_cnt_0`:\n{sv}"
+    );
+    assert!(
+        sv.contains("_t0_loop_cnt_1"),
+        "expected inner loop counter `_t0_loop_cnt_1`:\n{sv}"
+    );
     // No leftover shared `_t0_loop_cnt` (without an `_{id}` suffix) — a
     // grep for `_t0_loop_cnt;` or `_t0_loop_cnt ` (followed by anything
     // other than `_`) would catch the old shared-counter shape.
@@ -4927,8 +5559,10 @@ fn test_nested_for_in_thread_uses_distinct_loop_counters() {
         || sv.contains("_t0_loop_cnt =")
         || sv.contains("_t0_loop_cnt >=")
         || sv.contains("_t0_loop_cnt <");
-    assert!(!bad_shared,
-        "found references to shared `_t0_loop_cnt` (issue #414 regression):\n{sv}");
+    assert!(
+        !bad_shared,
+        "found references to shared `_t0_loop_cnt` (issue #414 regression):\n{sv}"
+    );
 }
 
 #[test]
@@ -4952,24 +5586,50 @@ fn test_vec_bus_whole_vec_forward_to_child_inst() {
     let source = include_str!("regression/issues/vec_bus_forward/VecBusForward.arch");
     let sv = compile_to_sv(source);
     // Both modules must be emitted.
-    assert!(sv.contains("module Inner"), "expected Inner module in SV:\n{sv}");
-    assert!(sv.contains("module Wrapper"), "expected Wrapper module in SV:\n{sv}");
+    assert!(
+        sv.contains("module Inner"),
+        "expected Inner module in SV:\n{sv}"
+    );
+    assert!(
+        sv.contains("module Wrapper"),
+        "expected Wrapper module in SV:\n{sv}"
+    );
     // The Vec-of-bus port should emit as packed signals on Wrapper.
-    assert!(sv.contains("m_top_v_valid"), "expected m_top_v_valid port:\n{sv}");
-    assert!(sv.contains("m_top_v_ready"), "expected m_top_v_ready port:\n{sv}");
-    assert!(sv.contains("m_top_v_data"), "expected m_top_v_data port:\n{sv}");
+    assert!(
+        sv.contains("m_top_v_valid"),
+        "expected m_top_v_valid port:\n{sv}"
+    );
+    assert!(
+        sv.contains("m_top_v_ready"),
+        "expected m_top_v_ready port:\n{sv}"
+    );
+    assert!(
+        sv.contains("m_top_v_data"),
+        "expected m_top_v_data port:\n{sv}"
+    );
     // Inner inst should forward each bus signal whole.
-    assert!(sv.contains("Inner inner"), "expected inst `Inner inner` in SV:\n{sv}");
-    assert!(sv.contains(".m_v_ready(m_top_v_ready)"),
-        "expected whole-Vec packed forwarding `.m_v_ready(m_top_v_ready)`:\n{sv}");
-    assert!(sv.contains(".m_v_valid(m_top_v_valid)"),
-        "expected whole-Vec packed forwarding `.m_v_valid(m_top_v_valid)`:\n{sv}");
+    assert!(
+        sv.contains("Inner inner"),
+        "expected inst `Inner inner` in SV:\n{sv}"
+    );
+    assert!(
+        sv.contains(".m_v_ready(m_top_v_ready)"),
+        "expected whole-Vec packed forwarding `.m_v_ready(m_top_v_ready)`:\n{sv}"
+    );
+    assert!(
+        sv.contains(".m_v_valid(m_top_v_valid)"),
+        "expected whole-Vec packed forwarding `.m_v_valid(m_top_v_valid)`:\n{sv}"
+    );
     // The pre-fix bug emitted shadowing wires like `logic m_top_v_ready;` —
     // assert none of those slipped in.
-    assert!(!sv.contains("logic m_top_v_ready;"),
-        "redundant `logic m_top_v_ready;` declaration shadows the SV port (issue #424):\n{sv}");
-    assert!(!sv.contains("logic m_top_v_valid;"),
-        "redundant `logic m_top_v_valid;` declaration shadows the SV port (issue #424):\n{sv}");
+    assert!(
+        !sv.contains("logic m_top_v_ready;"),
+        "redundant `logic m_top_v_ready;` declaration shadows the SV port (issue #424):\n{sv}"
+    );
+    assert!(
+        !sv.contains("logic m_top_v_valid;"),
+        "redundant `logic m_top_v_valid;` declaration shadows the SV port (issue #424):\n{sv}"
+    );
 }
 
 #[test]
@@ -4985,9 +5645,7 @@ fn test_type_alias_bus_params_propagate_into_generate_if() {
     // `GenItem::Wire` the same way the top-level `WireDecl` substitution
     // path already did. After the fix, both the module-scope wire and the
     // generate_if wire must emit with the alias's `ID_W = 5`.
-    let source = include_str!(
-        "regression/issues/alias_in_generate_if/AliasInGenif.arch"
-    );
+    let source = include_str!("regression/issues/alias_in_generate_if/AliasInGenif.arch");
     let sv = compile_to_sv(source);
     // Both wires must be 5 bits wide. Before the fix, `bad_bus_ar_id` was
     // 1 bit (BusAxi4's default ID_W).
@@ -5002,8 +5660,7 @@ fn test_type_alias_bus_params_propagate_into_generate_if() {
     );
     // Defensive: the buggy shape must not reappear.
     assert!(
-        !sv.contains("logic [0:0] bad_bus_ar_id")
-            && !sv.contains("logic bad_bus_ar_id"),
+        !sv.contains("logic [0:0] bad_bus_ar_id") && !sv.contains("logic bad_bus_ar_id"),
         "found buggy 1-bit / scalar `bad_bus_ar_id` (issue #423 regression):\n{sv}",
     );
 }
@@ -5114,9 +5771,7 @@ fn test_concat_bus_field_width_uses_module_param_binding() {
     // After the fix, the bus-flat width fold uses
     // `type_bits_te_with_params(&m.params)`, so `up_ar_id`'s width
     // resolves correctly to 3 and the concat shift is `<< 3`.
-    let source = include_str!(
-        "regression/issues/concat_bus_field_width/ConcatBusFieldWidth.arch"
-    );
+    let source = include_str!("regression/issues/concat_bus_field_width/ConcatBusFieldWidth.arch");
     let cpp = compile_to_sim_h(source, false);
     // The pack expression must shift `up_ar_addr` by 3 (the width of
     // `up_ar_id`), not 32.
@@ -5145,12 +5800,15 @@ fn test_pybind_bus_flat_width_uses_module_param_binding() {
     // report the real width, not the legacy `eval_width` 32-bit
     // fallback that bare `type_bits_te` produced for an unresolved
     // module-param Ident.
-    let source = include_str!(
-        "regression/issues/pybind_bus_flat_param_width/PybindBusFlatParamWidth.arch"
-    );
+    let source =
+        include_str!("regression/issues/pybind_bus_flat_param_width/PybindBusFlatParamWidth.arch");
     let pybinds = compile_to_pybind_cpps(source);
-    let cpp = pybinds.iter().find(|(n, _)| n.contains("PybindBusFlatParamWidth"))
-        .expect("PybindBusFlatParamWidth pybind wrapper").1.clone();
+    let cpp = pybinds
+        .iter()
+        .find(|(n, _)| n.contains("PybindBusFlatParamWidth"))
+        .expect("PybindBusFlatParamWidth pybind wrapper")
+        .1
+        .clone();
     // _port_info tuple for `up_data` must carry the param-substituted
     // width (128), not the conservative 32-bit fallback.
     assert!(
@@ -5175,19 +5833,21 @@ fn test_fsm_bus_flat_trace_width_uses_construct_param_binding() {
     // width is bound through an FSM-param-substituted bus-alias param,
     // the VCD `$var wire <width> ... <name> $end` header line must
     // announce the real lane width.
-    let source = include_str!(
-        "regression/issues/fsm_bus_flat_param_width/FsmBusFlatParamWidth.arch"
-    );
+    let source =
+        include_str!("regression/issues/fsm_bus_flat_param_width/FsmBusFlatParamWidth.arch");
     let sim = compile_to_sim_h(source, false);
     // VCD declaration for `up_data` must carry the param-substituted
     // width (96), not the conservative 32-bit fallback.
-    let up_data_lines: Vec<&str> = sim.lines()
+    let up_data_lines: Vec<&str> = sim
+        .lines()
         .filter(|l| l.contains("up_data $end") && l.contains("$var wire"))
         .collect();
     assert_eq!(
-        up_data_lines.len(), 1,
+        up_data_lines.len(),
+        1,
         "expected exactly one VCD `$var wire ... up_data $end` declaration \
-         line; found {} in:\n{sim}", up_data_lines.len()
+         line; found {} in:\n{sim}",
+        up_data_lines.len()
     );
     let line = up_data_lines[0];
     assert!(
@@ -5225,9 +5885,8 @@ fn test_fsm_param_vec_scalar_widths_resolve_through_sibling_helpers() {
     // `uint32_t`, the Vec count would fold to 0 (`buf[0]`,
     // `_vec_word[0]`), and the per-element VCD trace declarations would
     // announce width 32 instead of 48.
-    let source = include_str!(
-        "regression/issues/fsm_param_vec_scalar_widths/FsmParamVecScalarWidths.arch"
-    );
+    let source =
+        include_str!("regression/issues/fsm_param_vec_scalar_widths/FsmParamVecScalarWidths.arch");
     let sim = compile_to_sim_h(source, false);
 
     // 1. Scalar UInt<ACC> port: bucket must be uint64_t.
@@ -5281,7 +5940,8 @@ fn test_fsm_param_vec_scalar_widths_resolve_through_sibling_helpers() {
     //    didn't take a params slice). When `add_trace_to_simple_construct`
     //    was migrated to accept `params: &[ParamDecl]`, the FSM callsite
     //    started passing `&f.common.params` so `UInt<ACC>` resolves to 48.
-    let out_word_trace_line = sim.lines()
+    let out_word_trace_line = sim
+        .lines()
         .find(|l| l.contains("(out_word >> _i) & 1"))
         .unwrap_or("(out_word trace dump line not found)");
     assert!(
@@ -5372,9 +6032,7 @@ fn test_wait_0plus_is_retired_with_migration_hint() {
         .expect_err("retired wait 0+ syntax should be a parse error");
     let msg = format!("{err:?}");
     assert!(
-        msg.contains("retired")
-            && msg.contains("if not")
-            && msg.contains("wait until"),
+        msg.contains("retired") && msg.contains("if not") && msg.contains("wait until"),
         "expected wait-0+ retirement diagnostic with migration hint, got: {msg}"
     );
 }
@@ -5409,8 +6067,10 @@ fn test_wait_0plus_requires_no_space_between_0_and_plus() {
     "#;
     let tokens = arch::lexer::tokenize(source).expect("lex");
     let mut parser = arch::parser::Parser::new(tokens, source);
-    assert!(parser.parse_source_file().is_err(),
-            "wait `0 + cycle` (with space) should not parse as Mealy wait");
+    assert!(
+        parser.parse_source_file().is_err(),
+        "wait `0 + cycle` (with space) should not parse as Mealy wait"
+    );
 }
 
 #[test]
@@ -5459,10 +6119,14 @@ fn test_comb_graph_treats_bus_wires_as_intermediates() {
     // the SV still emits valid bus-wire flattening and a clean inst
     // chain — combined with the v2 NIC-400 smoke test (arch sim path)
     // already covered above.
-    assert!(sv.contains("logic w_v") && sv.contains("logic [7:0] w_d"),
-            "expected flattened bus wire signals:\n{sv}");
-    assert!(sv.contains(".inp_v(w_v)") || sv.contains(".inp_v (w_v)"),
-            "expected `.inp_v(w_v)` inst connection:\n{sv}");
+    assert!(
+        sv.contains("logic w_v") && sv.contains("logic [7:0] w_d"),
+        "expected flattened bus wire signals:\n{sv}"
+    );
+    assert!(
+        sv.contains(".inp_v(w_v)") || sv.contains(".inp_v (w_v)"),
+        "expected `.inp_v(w_v)` inst connection:\n{sv}"
+    );
 }
 
 #[test]
@@ -5501,16 +6165,22 @@ fn test_thread_writing_bus_signals_lowers_correctly() {
     ";
     let sv = compile_to_sv(source);
     // Sub-module exposes flat bus signals as ports.
-    assert!(sv.contains("output logic b_v")
+    assert!(
+        sv.contains("output logic b_v")
             && sv.contains("output logic [7:0] b_d")
             && sv.contains("input logic b_r"),
-            "expected sub-module flat bus signals in SV:\n{sv}");
+        "expected sub-module flat bus signals in SV:\n{sv}"
+    );
     // Sub-inst connects them through to parent's flat ports — and the
     // parent's signature must NOT have duplicate `logic b_v;` decls.
-    assert!(sv.matches("logic b_v").count() <= 2,
-            "expected at most one `logic b_v` decl per module:\n{sv}");
-    assert!(sv.contains(".b_v(b_v)") || sv.contains(".b_v (b_v)"),
-            "expected `.b_v(b_v)` inst-output connection:\n{sv}");
+    assert!(
+        sv.matches("logic b_v").count() <= 2,
+        "expected at most one `logic b_v` decl per module:\n{sv}"
+    );
+    assert!(
+        sv.contains(".b_v(b_v)") || sv.contains(".b_v (b_v)"),
+        "expected `.b_v(b_v)` inst-output connection:\n{sv}"
+    );
 }
 
 #[test]
@@ -5540,15 +6210,21 @@ fn test_vec_of_bus_for_loop_static_unroll() {
     let sv = compile_to_sv(source);
     // The loop should be statically unrolled: no behavioral `for (int i ...`,
     // and per-element array-indexed assignments (D2 shape).
-    assert!(!sv.contains("for (int i ="),
-            "expected for-loop to be statically unrolled (no behavioral SV for-loop):\n{sv}");
+    assert!(
+        !sv.contains("for (int i ="),
+        "expected for-loop to be statically unrolled (no behavioral SV for-loop):\n{sv}"
+    );
     for i in 0..4 {
-        assert!(sv.contains(&format!("chans_v[{i}] = 1'b1")),
-                "missing unrolled `chans_v[{i}] = 1'b1`:\n{sv}");
+        assert!(
+            sv.contains(&format!("chans_v[{i}] = 1'b1")),
+            "missing unrolled `chans_v[{i}] = 1'b1`:\n{sv}"
+        );
         // RHS must reference the literal i (not the loop variable).
-        assert!(sv.contains(&format!("chans_d[{i}] = 8'(idx + {i})"))
+        assert!(
+            sv.contains(&format!("chans_d[{i}] = 8'(idx + {i})"))
                 || sv.contains(&format!("chans_d[{i}] = 8'((idx + {i}))")),
-                "missing unrolled `chans_d[{i}] = 8'(idx + {i})`:\n{sv}");
+            "missing unrolled `chans_d[{i}] = 8'(idx + {i})`:\n{sv}"
+        );
     }
 }
 
@@ -5587,13 +6263,20 @@ fn test_vec_of_bus_inst_whole_vec_connection() {
     let sv = compile_to_sv(source);
     // Whole-vec `chans -> w` now emits ONE packed connection per bus signal —
     // both sides have the same packed shape. No per-element split needed.
-    assert!(sv.contains(".chans_v(w_v)") || sv.contains(".chans_v (w_v)"),
-            "missing `.chans_v(w_v)` packed whole-vec connection:\n{sv}");
-    assert!(sv.contains(".chans_d(w_d)") || sv.contains(".chans_d (w_d)"),
-            "missing `.chans_d(w_d)` packed whole-vec connection:\n{sv}");
+    assert!(
+        sv.contains(".chans_v(w_v)") || sv.contains(".chans_v (w_v)"),
+        "missing `.chans_v(w_v)` packed whole-vec connection:\n{sv}"
+    );
+    assert!(
+        sv.contains(".chans_d(w_d)") || sv.contains(".chans_d (w_d)"),
+        "missing `.chans_d(w_d)` packed whole-vec connection:\n{sv}"
+    );
     // The parent's bus wire `w` is also packed, so reads like `w[0].d`
     // lower to `w_d[0]`.
-    assert!(sv.contains("w_d[0]"), "expected `w_d[0]` indexed wire read:\n{sv}");
+    assert!(
+        sv.contains("w_d[0]"),
+        "expected `w_d[0]` indexed wire read:\n{sv}"
+    );
 }
 
 #[test]
@@ -5621,19 +6304,29 @@ fn test_vec_of_bus_wire_flattens_to_n_indexed_signals() {
     ";
     let sv = compile_to_sv(source);
     // Packed wire: one decl per bus signal with `[N-1:0]` outer dim.
-    assert!(sv.contains("logic [1:0] w_v;"),
-            "missing `logic [1:0] w_v;` packed wire in SV:\n{sv}");
-    assert!(sv.contains("logic [1:0] [7:0] w_d;"),
-            "missing `logic [1:0] [7:0] w_d;` packed wire in SV:\n{sv}");
+    assert!(
+        sv.contains("logic [1:0] w_v;"),
+        "missing `logic [1:0] w_v;` packed wire in SV:\n{sv}"
+    );
+    assert!(
+        sv.contains("logic [1:0] [7:0] w_d;"),
+        "missing `logic [1:0] [7:0] w_d;` packed wire in SV:\n{sv}"
+    );
     // Indexed writes/reads use SV packed slicing.
     for (i, expected_d) in [(0u32, "8'd17"), (1u32, "8'd34")] {
-        assert!(sv.contains(&format!("w_d[{i}] = {expected_d}")),
-                "missing `w_d[{i}] = {expected_d}` assignment in SV:\n{sv}");
+        assert!(
+            sv.contains(&format!("w_d[{i}] = {expected_d}")),
+            "missing `w_d[{i}] = {expected_d}` assignment in SV:\n{sv}"
+        );
     }
-    assert!(sv.contains("o_v0 = w_v[0]"),
-            "expected `o_v0 = w_v[0]` in SV:\n{sv}");
-    assert!(sv.contains("o_d1 = w_d[1]"),
-            "expected `o_d1 = w_d[1]` in SV:\n{sv}");
+    assert!(
+        sv.contains("o_v0 = w_v[0]"),
+        "expected `o_v0 = w_v[0]` in SV:\n{sv}"
+    );
+    assert!(
+        sv.contains("o_d1 = w_d[1]"),
+        "expected `o_d1 = w_d[1]` in SV:\n{sv}"
+    );
 }
 
 #[test]
@@ -5676,22 +6369,34 @@ fn test_vec_of_bus_wire_carries_inst_output_through_indexed_connection() {
     ";
     let sv = compile_to_sv(source);
     // Packed Vec-of-bus wire: one decl per bus signal with [N-1:0] outer dim.
-    assert!(sv.contains("logic [1:0] w_v;"),
-            "missing `logic [1:0] w_v;` packed wire in Parent SV:\n{sv}");
-    assert!(sv.contains("logic [1:0] [7:0] w_d;"),
-            "missing `logic [1:0] [7:0] w_d;` packed wire in Parent SV:\n{sv}");
+    assert!(
+        sv.contains("logic [1:0] w_v;"),
+        "missing `logic [1:0] w_v;` packed wire in Parent SV:\n{sv}"
+    );
+    assert!(
+        sv.contains("logic [1:0] [7:0] w_d;"),
+        "missing `logic [1:0] [7:0] w_d;` packed wire in Parent SV:\n{sv}"
+    );
     // Producer inst's Vec-of-bus port connects via packed concat from the
     // per-element parent expressions.
     // `chans[0] -> w[0]; chans[1] -> w[1];` gathers into `.chans_<sig>({w[1].sig, w[0].sig})`.
-    assert!(sv.contains(".chans_v({w_v[1], w_v[0]})") || sv.contains(".chans_v ({w_v[1], w_v[0]})"),
-            "expected `.chans_v({{w_v[1], w_v[0]}})` packed concat connection in SV:\n{sv}");
-    assert!(sv.contains(".chans_d({w_d[1], w_d[0]})") || sv.contains(".chans_d ({w_d[1], w_d[0]})"),
-            "expected `.chans_d({{w_d[1], w_d[0]}})` packed concat connection in SV:\n{sv}");
+    assert!(
+        sv.contains(".chans_v({w_v[1], w_v[0]})") || sv.contains(".chans_v ({w_v[1], w_v[0]})"),
+        "expected `.chans_v({{w_v[1], w_v[0]}})` packed concat connection in SV:\n{sv}"
+    );
+    assert!(
+        sv.contains(".chans_d({w_d[1], w_d[0]})") || sv.contains(".chans_d ({w_d[1], w_d[0]})"),
+        "expected `.chans_d({{w_d[1], w_d[0]}})` packed concat connection in SV:\n{sv}"
+    );
     // Downstream reads use packed indexed access.
-    assert!(sv.contains("o_v0 = w_v[0]"),
-            "expected `o_v0 = w_v[0]` in SV:\n{sv}");
-    assert!(sv.contains("o_d1 = w_d[1]"),
-            "expected `o_d1 = w_d[1]` in SV:\n{sv}");
+    assert!(
+        sv.contains("o_v0 = w_v[0]"),
+        "expected `o_v0 = w_v[0]` in SV:\n{sv}"
+    );
+    assert!(
+        sv.contains("o_d1 = w_d[1]"),
+        "expected `o_d1 = w_d[1]` in SV:\n{sv}"
+    );
 }
 
 #[test]
@@ -5734,16 +6439,24 @@ fn test_vec_of_bus_inst_connection_uses_bracket_index_syntax() {
     ";
     let sv = compile_to_sv(source);
     // Child exposes one packed port per Vec-of-bus signal.
-    assert!(sv.contains("output logic [1:0] chans_v"),
-            "child should expose `output logic [1:0] chans_v` (packed):\n{sv}");
-    assert!(sv.contains("output logic [1:0] [7:0] chans_d"),
-            "child should expose `output logic [1:0] [7:0] chans_d`:\n{sv}");
+    assert!(
+        sv.contains("output logic [1:0] chans_v"),
+        "child should expose `output logic [1:0] chans_v` (packed):\n{sv}"
+    );
+    assert!(
+        sv.contains("output logic [1:0] [7:0] chans_d"),
+        "child should expose `output logic [1:0] [7:0] chans_d`:\n{sv}"
+    );
     // Per-element scalar wire connections gather into a packed concat
     // at the inst boundary — big-endian, so chans[1] is the MSB.
-    assert!(sv.contains(".chans_v({w1_v, w0_v})") || sv.contains(".chans_v ({w1_v, w0_v})"),
-            "expected `.chans_v({{w1_v, w0_v}})` packed concat connection in SV:\n{sv}");
-    assert!(sv.contains(".chans_d({w1_d, w0_d})") || sv.contains(".chans_d ({w1_d, w0_d})"),
-            "expected `.chans_d({{w1_d, w0_d}})` packed concat connection in SV:\n{sv}");
+    assert!(
+        sv.contains(".chans_v({w1_v, w0_v})") || sv.contains(".chans_v ({w1_v, w0_v})"),
+        "expected `.chans_v({{w1_v, w0_v}})` packed concat connection in SV:\n{sv}"
+    );
+    assert!(
+        sv.contains(".chans_d({w1_d, w0_d})") || sv.contains(".chans_d ({w1_d, w0_d})"),
+        "expected `.chans_d({{w1_d, w0_d}})` packed concat connection in SV:\n{sv}"
+    );
 }
 
 #[test]
@@ -5789,19 +6502,29 @@ fn test_bus_wire_sv_flattens_to_individual_signals() {
     let sv = cg.generate();
 
     // Bus wire must decompose into flat signals.
-    assert!(sv.contains("logic [7:0] w_cmd;") && sv.contains("logic [7:0] w_resp;"),
-            "expected flat `w_cmd` / `w_resp` wires:\n{sv}");
+    assert!(
+        sv.contains("logic [7:0] w_cmd;") && sv.contains("logic [7:0] w_resp;"),
+        "expected flat `w_cmd` / `w_resp` wires:\n{sv}"
+    );
     // No `FooBus w;` placeholder left behind.
-    assert!(!sv.contains("FooBus w"),
-            "unexpected `FooBus w` decl (should be flattened):\n{sv}");
+    assert!(
+        !sv.contains("FooBus w"),
+        "unexpected `FooBus w` decl (should be flattened):\n{sv}"
+    );
     // Field access on bus wire rewrites to flat name.
-    assert!(sv.contains("assign w_cmd = x_in") || sv.contains("w_cmd = x_in"),
-            "expected `w_cmd = x_in` assignment:\n{sv}");
-    assert!(sv.contains("x_out = w_resp"),
-            "expected `x_out = w_resp` assignment:\n{sv}");
+    assert!(
+        sv.contains("assign w_cmd = x_in") || sv.contains("w_cmd = x_in"),
+        "expected `w_cmd = x_in` assignment:\n{sv}"
+    );
+    assert!(
+        sv.contains("x_out = w_resp"),
+        "expected `x_out = w_resp` assignment:\n{sv}"
+    );
     // Inst binding connects to the flat wires.
-    assert!(sv.contains(".p_cmd(w_cmd)") && sv.contains(".p_resp(w_resp)"),
-            "expected inst binding to flat wires:\n{sv}");
+    assert!(
+        sv.contains(".p_cmd(w_cmd)") && sv.contains(".p_resp(w_resp)"),
+        "expected inst binding to flat wires:\n{sv}"
+    );
 }
 
 #[test]
@@ -5825,11 +6548,27 @@ fn test_bus_declaration_inside_package_parses() {
     let tokens = arch::lexer::tokenize(source).expect("lexer");
     let mut parser = arch::parser::Parser::new(tokens, source);
     let sf = parser.parse_source_file().expect("parse");
-    let pkg = sf.items.iter().find_map(|i|
-        if let arch::ast::Item::Package(p) = i { Some(p) } else { None }
-    ).expect("parsed package");
-    assert_eq!(pkg.structs.len(), 1, "struct should still parse alongside bus");
-    assert_eq!(pkg.buses.len(), 1, "bus should be collected into package.buses");
+    let pkg = sf
+        .items
+        .iter()
+        .find_map(|i| {
+            if let arch::ast::Item::Package(p) = i {
+                Some(p)
+            } else {
+                None
+            }
+        })
+        .expect("parsed package");
+    assert_eq!(
+        pkg.structs.len(),
+        1,
+        "struct should still parse alongside bus"
+    );
+    assert_eq!(
+        pkg.buses.len(),
+        1,
+        "bus should be collected into package.buses"
+    );
     assert_eq!(pkg.buses[0].name.name, "MyBus");
 }
 
@@ -5873,10 +6612,14 @@ fn test_package_nested_bus_used_as_wire_and_port() {
     ";
     // Sim codegen: struct MyBus lands in VStructs header.
     let sim_h = compile_to_sim_h(source, false);
-    assert!(sim_h.contains("struct MyBus {"),
-            "expected `struct MyBus` in sim structs header:\n{sim_h}");
-    assert!(sim_h.contains("uint8_t cmd_valid;") && sim_h.contains("uint8_t cmd_data;"),
-            "expected bus fields as struct members:\n{sim_h}");
+    assert!(
+        sim_h.contains("struct MyBus {"),
+        "expected `struct MyBus` in sim structs header:\n{sim_h}"
+    );
+    assert!(
+        sim_h.contains("uint8_t cmd_valid;") && sim_h.contains("uint8_t cmd_data;"),
+        "expected bus fields as struct members:\n{sim_h}"
+    );
 
     // SV codegen: package emits no bus type; wires flatten to per-signal.
     use arch::codegen::Codegen;
@@ -5889,12 +6632,18 @@ fn test_package_nested_bus_used_as_wire_and_port() {
     let (_w, overload_map) = checker.check().expect("type check");
     let mut cg = Codegen::new(&symbols, &ast, overload_map);
     let sv = cg.generate();
-    assert!(sv.contains("logic b_cmd_valid;"),
-            "bus wire should flatten to b_cmd_valid:\n{sv}");
-    assert!(sv.contains("logic [7:0] b_cmd_data;"),
-            "bus wire should flatten to b_cmd_data:\n{sv}");
-    assert!(sv.contains(".p_cmd_data(b_cmd_data)"),
-            "inst binding should use flat wire names:\n{sv}");
+    assert!(
+        sv.contains("logic b_cmd_valid;"),
+        "bus wire should flatten to b_cmd_valid:\n{sv}"
+    );
+    assert!(
+        sv.contains("logic [7:0] b_cmd_data;"),
+        "bus wire should flatten to b_cmd_data:\n{sv}"
+    );
+    assert!(
+        sv.contains(".p_cmd_data(b_cmd_data)"),
+        "inst binding should use flat wire names:\n{sv}"
+    );
 }
 
 #[test]
@@ -5927,9 +6676,12 @@ fn test_bus_port_connected_via_per_field_bindings_no_warning() {
         end module Parent
     ";
     let ws = warnings_from(source);
-    assert!(!ws.iter().any(|m| m.contains("output port `p`")
-                               && m.contains("not connected")),
-            "per-field bus binding should not trigger 'not connected': {:?}", ws);
+    assert!(
+        !ws.iter()
+            .any(|m| m.contains("output port `p`") && m.contains("not connected")),
+        "per-field bus binding should not trigger 'not connected': {:?}",
+        ws
+    );
 }
 
 #[test]
@@ -5956,9 +6708,12 @@ fn test_bus_port_unconnected_still_warns() {
         end module Parent
     ";
     let ws = warnings_from(source);
-    assert!(ws.iter().any(|m| m.contains("output port `p`")
-                              && m.contains("not connected")),
-            "completely-unbound bus port should still warn: {:?}", ws);
+    assert!(
+        ws.iter()
+            .any(|m| m.contains("output port `p`") && m.contains("not connected")),
+        "completely-unbound bus port should still warn: {:?}",
+        ws
+    );
 }
 
 #[test]
@@ -5984,9 +6739,13 @@ fn test_handshake_payload_guard_via_short_circuit_and() {
         end module Consumer
     ";
     let ws = warnings_from(source);
-    assert!(!ws.iter().any(|m| m.contains("cmd_op") && m.contains("unguarded")
-                               || (m.contains("cmd_op") && m.contains("outside"))),
-            "short-circuit `and` should guard cmd_op read; got: {:?}", ws);
+    assert!(
+        !ws.iter()
+            .any(|m| m.contains("cmd_op") && m.contains("unguarded")
+                || (m.contains("cmd_op") && m.contains("outside"))),
+        "short-circuit `and` should guard cmd_op read; got: {:?}",
+        ws
+    );
 }
 
 #[test]
@@ -6012,8 +6771,12 @@ fn test_handshake_payload_guard_via_ternary_condition() {
         end module Consumer
     ";
     let ws = warnings_from(source);
-    assert!(!ws.iter().any(|m| m.contains("cmd_op") && m.contains("outside")),
-            "ternary condition should guard cmd_op read; got: {:?}", ws);
+    assert!(
+        !ws.iter()
+            .any(|m| m.contains("cmd_op") && m.contains("outside")),
+        "ternary condition should guard cmd_op read; got: {:?}",
+        ws
+    );
 }
 
 #[test]
@@ -6037,8 +6800,12 @@ fn test_handshake_payload_truly_unguarded_still_warns() {
         end module Consumer
     ";
     let ws = warnings_from(source);
-    assert!(ws.iter().any(|m| m.contains("cmd_op") && m.contains("outside")),
-            "genuinely unguarded cmd_op read should still warn: {:?}", ws);
+    assert!(
+        ws.iter()
+            .any(|m| m.contains("cmd_op") && m.contains("outside")),
+        "genuinely unguarded cmd_op read should still warn: {:?}",
+        ws
+    );
 }
 
 fn compile_to_pybind_cpps(source: &str) -> Vec<(String, String)> {
@@ -6051,7 +6818,10 @@ fn compile_to_pybind_cpps(source: &str) -> Vec<(String, String)> {
     let checker = arch::typecheck::TypeChecker::new(&symbols, &ast);
     let (_warnings, overload_map) = checker.check().expect("type check");
     let sim = SimCodegen::new(&symbols, &ast, overload_map);
-    sim.generate_pybind().into_iter().map(|m| (m.class_name, m.impl_)).collect()
+    sim.generate_pybind()
+        .into_iter()
+        .map(|m| (m.class_name, m.impl_))
+        .collect()
 }
 
 #[test]
@@ -6114,34 +6884,62 @@ fn test_pybind_struct_bindings_are_scoped_to_module() {
     ";
 
     let pybinds = compile_to_pybind_cpps(source);
-    let prim = pybinds.iter().find(|(n, _)| n.contains("PrimitivesOnly"))
-        .expect("PrimitivesOnly pybind wrapper").1.clone();
-    let one = pybinds.iter().find(|(n, _)| n.contains("UsesOneStruct"))
-        .expect("UsesOneStruct pybind wrapper").1.clone();
-    let uses = pybinds.iter().find(|(n, _)| n.contains("UsesStructs"))
-        .expect("UsesStructs pybind wrapper").1.clone();
+    let prim = pybinds
+        .iter()
+        .find(|(n, _)| n.contains("PrimitivesOnly"))
+        .expect("PrimitivesOnly pybind wrapper")
+        .1
+        .clone();
+    let one = pybinds
+        .iter()
+        .find(|(n, _)| n.contains("UsesOneStruct"))
+        .expect("UsesOneStruct pybind wrapper")
+        .1
+        .clone();
+    let uses = pybinds
+        .iter()
+        .find(|(n, _)| n.contains("UsesStructs"))
+        .expect("UsesStructs pybind wrapper")
+        .1
+        .clone();
 
     // PrimitivesOnly: no struct bindings at all.
-    assert!(!prim.contains("py::class_<Reg1>"),
-            "PrimitivesOnly must not bind Reg1:\n{prim}");
-    assert!(!prim.contains("py::class_<Reg2>"),
-            "PrimitivesOnly must not bind Reg2:\n{prim}");
-    assert!(!prim.contains("py::class_<PipeBus>"),
-            "PrimitivesOnly must not bind PipeBus:\n{prim}");
+    assert!(
+        !prim.contains("py::class_<Reg1>"),
+        "PrimitivesOnly must not bind Reg1:\n{prim}"
+    );
+    assert!(
+        !prim.contains("py::class_<Reg2>"),
+        "PrimitivesOnly must not bind Reg2:\n{prim}"
+    );
+    assert!(
+        !prim.contains("py::class_<PipeBus>"),
+        "PrimitivesOnly must not bind PipeBus:\n{prim}"
+    );
 
     // UsesOneStruct: binds PipeBus, nothing else.
-    assert!(one.contains("py::class_<PipeBus>"),
-            "UsesOneStruct must bind PipeBus:\n{one}");
-    assert!(!one.contains("py::class_<Reg1>"),
-            "UsesOneStruct must not bind Reg1:\n{one}");
-    assert!(!one.contains("py::class_<Reg2>"),
-            "UsesOneStruct must not bind Reg2:\n{one}");
+    assert!(
+        one.contains("py::class_<PipeBus>"),
+        "UsesOneStruct must bind PipeBus:\n{one}"
+    );
+    assert!(
+        !one.contains("py::class_<Reg1>"),
+        "UsesOneStruct must not bind Reg1:\n{one}"
+    );
+    assert!(
+        !one.contains("py::class_<Reg2>"),
+        "UsesOneStruct must not bind Reg2:\n{one}"
+    );
 
     // UsesStructs: binds Reg1 and Reg2 (internal reg types).
-    assert!(uses.contains("py::class_<Reg1>"),
-            "UsesStructs must bind Reg1:\n{uses}");
-    assert!(uses.contains("py::class_<Reg2>"),
-            "UsesStructs must bind Reg2:\n{uses}");
+    assert!(
+        uses.contains("py::class_<Reg1>"),
+        "UsesStructs must bind Reg1:\n{uses}"
+    );
+    assert!(
+        uses.contains("py::class_<Reg2>"),
+        "UsesStructs must bind Reg2:\n{uses}"
+    );
 }
 
 #[test]
@@ -6167,11 +6965,17 @@ fn test_pybind_struct_bindings_transitive_closure() {
         end module M
     ";
     let pybinds = compile_to_pybind_cpps(source);
-    let m = pybinds.iter().find(|(n, _)| n.contains("VM_pybind"))
-        .expect("M pybind wrapper").1.clone();
+    let m = pybinds
+        .iter()
+        .find(|(n, _)| n.contains("VM_pybind"))
+        .expect("M pybind wrapper")
+        .1
+        .clone();
     assert!(m.contains("py::class_<Outer>"), "must bind Outer:\n{m}");
-    assert!(m.contains("py::class_<Inner>"),
-            "must bind Inner (transitive via Outer.inner):\n{m}");
+    assert!(
+        m.contains("py::class_<Inner>"),
+        "must bind Inner (transitive via Outer.inner):\n{m}"
+    );
 }
 
 #[test]
@@ -6202,10 +7006,14 @@ fn test_trace_skips_struct_typed_let_and_wire() {
         end module M
     ";
     let h = compile_to_sim_h(source, false);
-    assert!(!h.contains("(_let_scratch >> _i)"),
-            "scratch (struct wire) leaked into trace:\n{h}");
-    assert!(!h.contains("(_let_view >> _i)"),
-            "view (struct let) leaked into trace:\n{h}");
+    assert!(
+        !h.contains("(_let_scratch >> _i)"),
+        "scratch (struct wire) leaked into trace:\n{h}"
+    );
+    assert!(
+        !h.contains("(_let_view >> _i)"),
+        "view (struct let) leaked into trace:\n{h}"
+    );
 }
 
 #[test]
@@ -6225,17 +7033,27 @@ fn test_find_first_destructure_basic() {
     ";
     let sv = compile_to_sv(source);
     // Typedef emitted for the synthesized result struct.
-    assert!(sv.contains("typedef struct packed { logic found; logic [1:0] index; } __ArchFindResult_2;"),
-            "expected ArchFindResult typedef: {sv}");
+    assert!(
+        sv.contains(
+            "typedef struct packed { logic found; logic [1:0] index; } __ArchFindResult_2;"
+        ),
+        "expected ArchFindResult typedef: {sv}"
+    );
     // Raw OR reduction for `found`, no spurious struct literal:
-    assert!(sv.contains("assign found = vec[0] == needle || vec[1] == needle"),
-            "expected OR reduction: {sv}");
+    assert!(
+        sv.contains("assign found = vec[0] == needle || vec[1] == needle"),
+        "expected OR reduction: {sv}"
+    );
     // Priority encoder for `index`, nested ternary:
-    assert!(sv.contains("assign index = (vec[0] == needle) ? 2'd0 : (vec[1] == needle) ? 2'd1"),
-            "expected priority encoder: {sv}");
+    assert!(
+        sv.contains("assign index = (vec[0] == needle) ? 2'd0 : (vec[1] == needle) ? 2'd1"),
+        "expected priority encoder: {sv}"
+    );
     // Correct width on `index`:
-    assert!(sv.contains("logic [1:0] index;"),
-            "expected 2-bit index wire: {sv}");
+    assert!(
+        sv.contains("logic [1:0] index;"),
+        "expected 2-bit index wire: {sv}"
+    );
 }
 
 #[test]
@@ -6253,13 +7071,18 @@ fn test_find_first_partial_destructure() {
         end module M
     ";
     let sv = compile_to_sv(source);
-    assert!(sv.contains("logic found;") && sv.contains("assign found ="),
-            "expected `found` wire + assign: {sv}");
+    assert!(
+        sv.contains("logic found;") && sv.contains("assign found ="),
+        "expected `found` wire + assign: {sv}"
+    );
     // No `index` wire should be emitted since the user didn't bind it.
     // (It can still appear as a module port in the future; for now, assert
     // no `logic index` declaration at module scope.)
-    assert!(!sv.lines().any(|l| l.trim_start().starts_with("logic ") && l.contains(" index;")),
-            "did not expect unbound `index`: {sv}");
+    assert!(
+        !sv.lines()
+            .any(|l| l.trim_start().starts_with("logic ") && l.contains(" index;")),
+        "did not expect unbound `index`: {sv}"
+    );
 }
 
 #[test]
@@ -6283,11 +7106,15 @@ fn test_find_first_unknown_binding_errors() {
     let symbols = arch::resolve::resolve(&ast).expect("resolve");
     let checker = arch::typecheck::TypeChecker::new(&symbols, &ast);
     let result = checker.check();
-    assert!(result.is_err(),
-            "expected type-check error for bad destructure binding");
+    assert!(
+        result.is_err(),
+        "expected type-check error for bad destructure binding"
+    );
     let msg = format!("{:?}", result.unwrap_err());
-    assert!(msg.contains("find_first result has no field named `wrong_name`"),
-            "expected specific error message, got: {msg}");
+    assert!(
+        msg.contains("find_first result has no field named `wrong_name`"),
+        "expected specific error message, got: {msg}"
+    );
 }
 
 #[test]
@@ -6317,8 +7144,11 @@ fn test_pipe_reg_port_n1_equivalent_to_port_reg() {
           end seq
         end module M
     ";
-    assert_eq!(compile_to_sv(src_new), compile_to_sv(src_old),
-        "pipe_reg<T, 1> + @1 should be byte-identical to port reg");
+    assert_eq!(
+        compile_to_sv(src_new),
+        compile_to_sv(src_old),
+        "pipe_reg<T, 1> + @1 should be byte-identical to port reg"
+    );
 }
 
 #[test]
@@ -6337,14 +7167,24 @@ fn test_pipe_reg_port_n3_emits_cascade() {
     ";
     let sv = compile_to_sv(source);
     // Two intermediate stage regs should be declared + cascade assigns.
-    assert!(sv.contains("q_stg1") && sv.contains("q_stg2"),
-        "expected 2 intermediate stages for depth=3:\n{sv}");
+    assert!(
+        sv.contains("q_stg1") && sv.contains("q_stg2"),
+        "expected 2 intermediate stages for depth=3:\n{sv}"
+    );
     assert!(sv.contains("q_stg1 <= a;"), "stage 0 write missing:\n{sv}");
-    assert!(sv.contains("q_stg2 <= q_stg1;"), "stage 1 shift missing:\n{sv}");
-    assert!(sv.contains("q <= q_stg2;"), "final output write missing:\n{sv}");
+    assert!(
+        sv.contains("q_stg2 <= q_stg1;"),
+        "stage 1 shift missing:\n{sv}"
+    );
+    assert!(
+        sv.contains("q <= q_stg2;"),
+        "final output write missing:\n{sv}"
+    );
     // Uniform reset across all stages:
-    assert!(sv.contains("q_stg1 <= 0") && sv.contains("q_stg2 <= 0") && sv.contains("q <= 0"),
-        "expected uniform reset across all stages:\n{sv}");
+    assert!(
+        sv.contains("q_stg1 <= 0") && sv.contains("q_stg2 <= 0") && sv.contains("q <= 0"),
+        "expected uniform reset across all stages:\n{sv}"
+    );
 }
 
 #[test]
@@ -6369,8 +7209,10 @@ fn test_pipe_reg_port_depth_mismatch_errors() {
     let result = arch::elaborate::lower_pipe_reg_ports(ast);
     assert!(result.is_err(), "expected depth-mismatch error");
     let msg = format!("{:?}", result.unwrap_err());
-    assert!(msg.contains("exceeds declared latency 3"),
-        "expected specific error message, got: {msg}");
+    assert!(
+        msg.contains("exceeds declared latency 3"),
+        "expected specific error message, got: {msg}"
+    );
 }
 
 #[test]
@@ -6395,8 +7237,10 @@ fn test_pipe_reg_port_bare_assign_ambiguous_errors() {
     let result = arch::elaborate::lower_pipe_reg_ports(ast);
     assert!(result.is_err(), "expected ambiguous-assignment error");
     let msg = format!("{:?}", result.unwrap_err());
-    assert!(msg.contains("is ambiguous"),
-        "expected specific error message, got: {msg}");
+    assert!(
+        msg.contains("is ambiguous"),
+        "expected specific error message, got: {msg}"
+    );
 }
 
 #[test]
@@ -6419,7 +7263,9 @@ fn test_stdlib_bus_axi_stream_discovery() {
     // by running the real compiler binary against a stub test case.
     let td = tempfile::tempdir().expect("tempdir");
     let src = td.path().join("Prod.arch");
-    std::fs::write(&src, "\
+    std::fs::write(
+        &src,
+        "\
         use BusAxiStream;\n\
         module Prod\n\
           port clk: in Clock<SysDomain>;\n\
@@ -6432,16 +7278,20 @@ fn test_stdlib_bus_axi_stream_discovery() {
             m_axis.t_keep  = 4'h0;\n\
           end comb\n\
         end module Prod\n\
-    ").unwrap();
+    ",
+    )
+    .unwrap();
     let arch_bin = env!("CARGO_BIN_EXE_arch");
     let out = std::process::Command::new(arch_bin)
         .arg("check")
         .arg(&src)
         .output()
         .expect("run arch check");
-    assert!(out.status.success(),
+    assert!(
+        out.status.success(),
         "arch check should succeed with stdlib discovery; stderr:\n{}",
-        String::from_utf8_lossy(&out.stderr));
+        String::from_utf8_lossy(&out.stderr)
+    );
 }
 
 #[test]
@@ -6464,8 +7314,10 @@ fn test_stdlib_disabled_via_env() {
         .env("ARCH_NO_STDLIB", "1")
         .output()
         .expect("run arch check");
-    assert!(!out.status.success(),
-        "expected failure when ARCH_NO_STDLIB=1 disables stdlib resolution");
+    assert!(
+        !out.status.success(),
+        "expected failure when ARCH_NO_STDLIB=1 disables stdlib resolution"
+    );
 }
 
 #[test]
@@ -6509,18 +7361,31 @@ fn test_handshake_generate_if_payload_toggle() {
     ";
     let sv = compile_to_sv(source);
     // Full config emits all four optional ports.
-    assert!(sv.contains("output logic [15:0] p_t_data"), "Full: data 16-bit expected:\n{sv}");
-    assert!(sv.contains("output logic p_t_last"), "Full: t_last present:\n{sv}");
-    assert!(sv.contains("output logic [3:0] p_t_id"), "Full: t_id [3:0]:\n{sv}");
+    assert!(
+        sv.contains("output logic [15:0] p_t_data"),
+        "Full: data 16-bit expected:\n{sv}"
+    );
+    assert!(
+        sv.contains("output logic p_t_last"),
+        "Full: t_last present:\n{sv}"
+    );
+    assert!(
+        sv.contains("output logic [3:0] p_t_id"),
+        "Full: t_id [3:0]:\n{sv}"
+    );
     // Bare config omits t_last (USE_LAST=0) AND t_id (ID_W=0).
     // Both Full and Bare emit into the same SV string; check Bare's
     // module block specifically for the absence of those fields.
     let bare = sv.split("module Bare").nth(1).expect("Bare module present");
     let bare_until_end = bare.split("endmodule").next().unwrap_or("");
-    assert!(!bare_until_end.contains("t_last"),
-        "Bare config should omit t_last: {bare_until_end}");
-    assert!(!bare_until_end.contains("t_id"),
-        "Bare config should omit t_id: {bare_until_end}");
+    assert!(
+        !bare_until_end.contains("t_last"),
+        "Bare config should omit t_last: {bare_until_end}"
+    );
+    assert!(
+        !bare_until_end.contains("t_id"),
+        "Bare config should omit t_id: {bare_until_end}"
+    );
 }
 
 #[test]
@@ -6545,15 +7410,19 @@ fn test_handshake_generate_if_nested_in_bus_genif_errors() {
     let result = parser.parse_source_file();
     assert!(result.is_err(), "expected parser error");
     let msg = format!("{:?}", result.unwrap_err());
-    assert!(msg.contains("not supported when the handshake itself is nested"),
-        "expected specific nesting-error message, got: {msg}");
+    assert!(
+        msg.contains("not supported when the handshake itself is nested"),
+        "expected specific nesting-error message, got: {msg}"
+    );
 }
 
 #[test]
 fn test_stdlib_bus_apb_discovery_apb3_minimal() {
     let td = tempfile::tempdir().expect("tempdir");
     let src = td.path().join("Csr.arch");
-    std::fs::write(&src, "\
+    std::fs::write(
+        &src,
+        "\
         use BusApb;\n\
         module Csr\n\
           port clk: in Clock<SysDomain>;\n\
@@ -6561,13 +7430,20 @@ fn test_stdlib_bus_apb_discovery_apb3_minimal() {
           port s_apb: target BusApb<ADDR_W=12, DATA_W=32>;\n\
           comb s_apb.pready = 1'b1; s_apb.prdata = 32'h0; end comb\n\
         end module Csr\n\
-    ").unwrap();
+    ",
+    )
+    .unwrap();
     let arch_bin = env!("CARGO_BIN_EXE_arch");
     let out = std::process::Command::new(arch_bin)
-        .arg("check").arg(&src).output().expect("run arch check");
-    assert!(out.status.success(),
+        .arg("check")
+        .arg(&src)
+        .output()
+        .expect("run arch check");
+    assert!(
+        out.status.success(),
         "APB3 minimal should compile; stderr:\n{}",
-        String::from_utf8_lossy(&out.stderr));
+        String::from_utf8_lossy(&out.stderr)
+    );
 }
 
 #[test]
@@ -6589,7 +7465,9 @@ fn test_stdlib_bus_apb_pslverr_decoupled_from_pprot() {
         // drive it whenever USE_PSLVERR=1.
         let pslverr_drive = if *use_pslverr == 1 {
             "s_apb.pslverr = 1'b0;\n            "
-        } else { "" };
+        } else {
+            ""
+        };
         std::fs::write(&src, format!("\
             use BusApb;\n\
             module {name}\n\
@@ -6606,25 +7484,42 @@ fn test_stdlib_bus_apb_pslverr_decoupled_from_pprot() {
 
         // arch check should succeed for every combination.
         let chk = std::process::Command::new(arch_bin)
-            .arg("check").arg(&src).output().expect("run arch check");
-        assert!(chk.status.success(),
+            .arg("check")
+            .arg(&src)
+            .output()
+            .expect("run arch check");
+        assert!(
+            chk.status.success(),
             "arch check failed for USE_PSLVERR={use_pslverr} USE_PPROT={use_pprot}; stderr:\n{}",
-            String::from_utf8_lossy(&chk.stderr));
+            String::from_utf8_lossy(&chk.stderr)
+        );
 
         // Build SV and inspect the generated port list.
         let sv_out = td.path().join(format!("{name}.sv"));
         let bld = std::process::Command::new(arch_bin)
-            .arg("build").arg(&src).arg("-o").arg(&sv_out)
-            .output().expect("run arch build");
-        assert!(bld.status.success(),
+            .arg("build")
+            .arg(&src)
+            .arg("-o")
+            .arg(&sv_out)
+            .output()
+            .expect("run arch build");
+        assert!(
+            bld.status.success(),
             "arch build failed for USE_PSLVERR={use_pslverr} USE_PPROT={use_pprot}; stderr:\n{}",
-            String::from_utf8_lossy(&bld.stderr));
+            String::from_utf8_lossy(&bld.stderr)
+        );
         let sv = std::fs::read_to_string(&sv_out).expect("read sv");
 
         // Baseline APB v2 signals always present.
-        for s in ["s_apb_psel", "s_apb_penable", "s_apb_pwrite",
-                  "s_apb_paddr", "s_apb_pwdata", "s_apb_pready",
-                  "s_apb_prdata"] {
+        for s in [
+            "s_apb_psel",
+            "s_apb_penable",
+            "s_apb_pwrite",
+            "s_apb_paddr",
+            "s_apb_pwdata",
+            "s_apb_pready",
+            "s_apb_prdata",
+        ] {
             assert!(sv.contains(s),
                 "missing baseline signal {s} for USE_PSLVERR={use_pslverr} USE_PPROT={use_pprot}\nSV:\n{sv}");
         }
@@ -6661,12 +7556,16 @@ fn test_port_reg_deprecation_warning_fires() {
     let ast = arch::elaborate::lower_threads(ast).expect("lower threads");
     let ast = arch::elaborate::lower_pipe_reg_ports(ast).expect("lower pipe_reg");
     let symbols = arch::resolve::resolve(&ast).expect("resolve");
-    let (warnings, _) = arch::typecheck::TypeChecker::new(&symbols, &ast).check().expect("typecheck");
-    assert!(warnings.iter().any(|w| w.message.contains("`port reg q")
+    let (warnings, _) = arch::typecheck::TypeChecker::new(&symbols, &ast)
+        .check()
+        .expect("typecheck");
+    assert!(
+        warnings.iter().any(|w| w.message.contains("`port reg q")
             && w.message.contains("deprecated")
             && w.message.contains("pipe_reg<T, 1>")),
         "expected deprecation warning, got: {:?}",
-        warnings.iter().map(|w| &w.message).collect::<Vec<_>>());
+        warnings.iter().map(|w| &w.message).collect::<Vec<_>>()
+    );
 }
 
 #[test]
@@ -6689,10 +7588,14 @@ fn test_pipe_reg_port_no_deprecation_warning() {
     let ast = arch::elaborate::lower_threads(ast).expect("lower threads");
     let ast = arch::elaborate::lower_pipe_reg_ports(ast).expect("lower pipe_reg");
     let symbols = arch::resolve::resolve(&ast).expect("resolve");
-    let (warnings, _) = arch::typecheck::TypeChecker::new(&symbols, &ast).check().expect("typecheck");
-    assert!(!warnings.iter().any(|w| w.message.contains("deprecated")),
+    let (warnings, _) = arch::typecheck::TypeChecker::new(&symbols, &ast)
+        .check()
+        .expect("typecheck");
+    assert!(
+        !warnings.iter().any(|w| w.message.contains("deprecated")),
         "did not expect deprecation warning for pipe_reg<T,1>, got: {:?}",
-        warnings.iter().map(|w| &w.message).collect::<Vec<_>>());
+        warnings.iter().map(|w| &w.message).collect::<Vec<_>>()
+    );
 }
 
 #[test]
@@ -6715,12 +7618,18 @@ fn test_handshake_channel_parses_new_keyword() {
         end module M
     ";
     let sv = compile_to_sv(source);
-    assert!(sv.contains("output logic p_cmd_valid"),
-        "handshake_channel should expand to the same ports as legacy `handshake`:\n{sv}");
-    assert!(sv.contains("input logic p_cmd_ready"),
-        "handshake_channel should emit the ready signal:\n{sv}");
-    assert!(sv.contains("output logic [31:0] p_cmd_addr"),
-        "handshake_channel should emit the payload:\n{sv}");
+    assert!(
+        sv.contains("output logic p_cmd_valid"),
+        "handshake_channel should expand to the same ports as legacy `handshake`:\n{sv}"
+    );
+    assert!(
+        sv.contains("input logic p_cmd_ready"),
+        "handshake_channel should emit the ready signal:\n{sv}"
+    );
+    assert!(
+        sv.contains("output logic [31:0] p_cmd_addr"),
+        "handshake_channel should emit the payload:\n{sv}"
+    );
 }
 
 #[test]
@@ -6749,13 +7658,16 @@ fn test_handshake_legacy_keyword_emits_deprecation_warning() {
     let ast = arch::elaborate::lower_threads(ast).expect("lower threads");
     let ast = arch::elaborate::lower_pipe_reg_ports(ast).expect("lower pipe_reg");
     let symbols = arch::resolve::resolve(&ast).expect("resolve");
-    let (warnings, _) = arch::typecheck::TypeChecker::new(&symbols, &ast).check().expect("typecheck");
-    assert!(warnings.iter().any(|w|
-        w.message.contains("`handshake cmd")
-        && w.message.contains("deprecated")
-        && w.message.contains("handshake_channel")),
+    let (warnings, _) = arch::typecheck::TypeChecker::new(&symbols, &ast)
+        .check()
+        .expect("typecheck");
+    assert!(
+        warnings.iter().any(|w| w.message.contains("`handshake cmd")
+            && w.message.contains("deprecated")
+            && w.message.contains("handshake_channel")),
         "expected deprecation warning, got: {:?}",
-        warnings.iter().map(|w| &w.message).collect::<Vec<_>>());
+        warnings.iter().map(|w| &w.message).collect::<Vec<_>>()
+    );
 }
 
 #[test]
@@ -6784,11 +7696,16 @@ fn test_handshake_channel_no_deprecation_warning() {
     let ast = arch::elaborate::lower_threads(ast).expect("lower threads");
     let ast = arch::elaborate::lower_pipe_reg_ports(ast).expect("lower pipe_reg");
     let symbols = arch::resolve::resolve(&ast).expect("resolve");
-    let (warnings, _) = arch::typecheck::TypeChecker::new(&symbols, &ast).check().expect("typecheck");
-    assert!(!warnings.iter().any(|w| w.message.contains("handshake_channel")
-                                    && w.message.contains("deprecated")),
+    let (warnings, _) = arch::typecheck::TypeChecker::new(&symbols, &ast)
+        .check()
+        .expect("typecheck");
+    assert!(
+        !warnings
+            .iter()
+            .any(|w| w.message.contains("handshake_channel") && w.message.contains("deprecated")),
         "did not expect deprecation warning for handshake_channel form, got: {:?}",
-        warnings.iter().map(|w| &w.message).collect::<Vec<_>>());
+        warnings.iter().map(|w| &w.message).collect::<Vec<_>>()
+    );
 }
 
 #[test]
@@ -6807,10 +7724,14 @@ fn test_credit_channel_parses_as_bus_sub_construct() {
     let tokens = arch::lexer::tokenize(source).expect("lexer");
     let mut parser = arch::parser::Parser::new(tokens, source);
     let ast = parser.parse_source_file().expect("parse");
-    let bus = ast.items.iter().find_map(|it| match it {
-        arch::ast::Item::Bus(b) if b.name.name == "DmaCh" => Some(b),
-        _ => None,
-    }).expect("DmaCh bus should be in AST");
+    let bus = ast
+        .items
+        .iter()
+        .find_map(|it| match it {
+            arch::ast::Item::Bus(b) if b.name.name == "DmaCh" => Some(b),
+            _ => None,
+        })
+        .expect("DmaCh bus should be in AST");
     assert_eq!(bus.credit_channels.len(), 1);
     let cc = &bus.credit_channels[0];
     assert_eq!(cc.name.name, "data");
@@ -6845,12 +7766,18 @@ fn test_credit_channel_wires_flatten_at_bus_port() {
         end module Prod
     ";
     let sv = compile_to_sv(source);
-    assert!(sv.contains("output logic p_data_send_valid"),
-        "credit_channel should emit send_valid as an initiator output:\n{sv}");
-    assert!(sv.contains("output logic [15:0] p_data_send_data"),
-        "credit_channel should emit send_data with the payload type:\n{sv}");
-    assert!(sv.contains("input logic p_data_credit_return"),
-        "credit_channel should emit credit_return as an initiator input:\n{sv}");
+    assert!(
+        sv.contains("output logic p_data_send_valid"),
+        "credit_channel should emit send_valid as an initiator output:\n{sv}"
+    );
+    assert!(
+        sv.contains("output logic [15:0] p_data_send_data"),
+        "credit_channel should emit send_data with the payload type:\n{sv}"
+    );
+    assert!(
+        sv.contains("input logic p_data_credit_return"),
+        "credit_channel should emit credit_return as an initiator input:\n{sv}"
+    );
 }
 
 #[test]
@@ -6873,12 +7800,18 @@ fn test_credit_channel_wires_flip_on_target_perspective() {
         end module Cons
     ";
     let sv = compile_to_sv(source);
-    assert!(sv.contains("input logic p_data_send_valid"),
-        "on target perspective, send_valid should be an input:\n{sv}");
-    assert!(sv.contains("input logic [15:0] p_data_send_data"),
-        "on target perspective, send_data should be an input:\n{sv}");
-    assert!(sv.contains("output logic p_data_credit_return"),
-        "on target perspective, credit_return should be an output:\n{sv}");
+    assert!(
+        sv.contains("input logic p_data_send_valid"),
+        "on target perspective, send_valid should be an input:\n{sv}"
+    );
+    assert!(
+        sv.contains("input logic [15:0] p_data_send_data"),
+        "on target perspective, send_data should be an input:\n{sv}"
+    );
+    assert!(
+        sv.contains("output logic p_data_credit_return"),
+        "on target perspective, credit_return should be an output:\n{sv}"
+    );
 }
 
 #[test]
@@ -6908,18 +7841,30 @@ fn test_credit_channel_emits_sender_counter_state() {
         end module Prod
     ";
     let sv = compile_to_sv(source);
-    assert!(sv.contains("__p_data_credit"),
-        "credit register should be declared:\n{sv}");
-    assert!(sv.contains("__p_data_can_send"),
-        "can_send wire should be declared:\n{sv}");
-    assert!(sv.contains("__p_data_can_send = __p_data_credit != 0"),
-        "can_send wire should read the credit reg:\n{sv}");
-    assert!(sv.contains("p_data_send_valid && !p_data_credit_return"),
-        "counter-update should decrement on pure send:\n{sv}");
-    assert!(sv.contains("p_data_credit_return && !p_data_send_valid"),
-        "counter-update should increment on pure credit_return:\n{sv}");
-    assert!(sv.contains("always_ff"),
-        "counter should update in an always_ff block:\n{sv}");
+    assert!(
+        sv.contains("__p_data_credit"),
+        "credit register should be declared:\n{sv}"
+    );
+    assert!(
+        sv.contains("__p_data_can_send"),
+        "can_send wire should be declared:\n{sv}"
+    );
+    assert!(
+        sv.contains("__p_data_can_send = __p_data_credit != 0"),
+        "can_send wire should read the credit reg:\n{sv}"
+    );
+    assert!(
+        sv.contains("p_data_send_valid && !p_data_credit_return"),
+        "counter-update should decrement on pure send:\n{sv}"
+    );
+    assert!(
+        sv.contains("p_data_credit_return && !p_data_send_valid"),
+        "counter-update should increment on pure credit_return:\n{sv}"
+    );
+    assert!(
+        sv.contains("always_ff"),
+        "counter should update in an always_ff block:\n{sv}"
+    );
 }
 
 #[test]
@@ -6946,22 +7891,38 @@ fn test_credit_channel_emits_target_fifo() {
         end module Cons
     ";
     let sv = compile_to_sv(source);
-    assert!(sv.contains("__p_data_buf"),
-        "target FIFO buffer array should be declared:\n{sv}");
-    assert!(sv.contains("__p_data_head"),
-        "FIFO head pointer should be declared:\n{sv}");
-    assert!(sv.contains("__p_data_tail"),
-        "FIFO tail pointer should be declared:\n{sv}");
-    assert!(sv.contains("__p_data_occ"),
-        "FIFO occupancy should be declared:\n{sv}");
-    assert!(sv.contains("__p_data_valid = __p_data_occ != 0"),
-        "valid wire should report non-empty:\n{sv}");
-    assert!(sv.contains("__p_data_data = __p_data_buf[__p_data_head]"),
-        "data wire should read the head slot:\n{sv}");
-    assert!(sv.contains("if (p_data_send_valid)"),
-        "push path should be gated on send_valid:\n{sv}");
-    assert!(sv.contains("p_data_credit_return && __p_data_valid"),
-        "pop should fire on user-driven credit_return when FIFO non-empty:\n{sv}");
+    assert!(
+        sv.contains("__p_data_buf"),
+        "target FIFO buffer array should be declared:\n{sv}"
+    );
+    assert!(
+        sv.contains("__p_data_head"),
+        "FIFO head pointer should be declared:\n{sv}"
+    );
+    assert!(
+        sv.contains("__p_data_tail"),
+        "FIFO tail pointer should be declared:\n{sv}"
+    );
+    assert!(
+        sv.contains("__p_data_occ"),
+        "FIFO occupancy should be declared:\n{sv}"
+    );
+    assert!(
+        sv.contains("__p_data_valid = __p_data_occ != 0"),
+        "valid wire should report non-empty:\n{sv}"
+    );
+    assert!(
+        sv.contains("__p_data_data = __p_data_buf[__p_data_head]"),
+        "data wire should read the head slot:\n{sv}"
+    );
+    assert!(
+        sv.contains("if (p_data_send_valid)"),
+        "push path should be gated on send_valid:\n{sv}"
+    );
+    assert!(
+        sv.contains("p_data_credit_return && __p_data_valid"),
+        "pop should fire on user-driven credit_return when FIFO non-empty:\n{sv}"
+    );
 }
 
 #[test]
@@ -6990,8 +7951,10 @@ fn test_credit_channel_no_target_fifo_on_send_role() {
         end module Prod
     ";
     let sv = compile_to_sv(source);
-    assert!(!sv.contains("__p_data_buf"),
-        "sender-role module must not emit target FIFO buffer:\n{sv}");
+    assert!(
+        !sv.contains("__p_data_buf"),
+        "sender-role module must not emit target FIFO buffer:\n{sv}"
+    );
 }
 
 #[test]
@@ -7020,8 +7983,10 @@ fn test_credit_channel_no_counter_on_receive_role() {
         end module Cons
     ";
     let sv = compile_to_sv(source);
-    assert!(!sv.contains("__p_data_credit"),
-        "target-role module should not emit sender counter:\n{sv}");
+    assert!(
+        !sv.contains("__p_data_credit"),
+        "target-role module should not emit sender counter:\n{sv}"
+    );
 }
 
 #[test]
@@ -7051,10 +8016,14 @@ fn test_credit_channel_can_send_method_dispatch() {
         end module Prod
     ";
     let sv = compile_to_sv(source);
-    assert!(sv.contains("__p_data_can_send"),
-        "dispatch should rewrite p.data.can_send → __p_data_can_send:\n{sv}");
-    assert!(sv.contains("p_data_send_valid = __p_data_can_send"),
-        "valid assignment should reference the rewritten name:\n{sv}");
+    assert!(
+        sv.contains("__p_data_can_send"),
+        "dispatch should rewrite p.data.can_send → __p_data_can_send:\n{sv}"
+    );
+    assert!(
+        sv.contains("p_data_send_valid = __p_data_can_send"),
+        "valid assignment should reference the rewritten name:\n{sv}"
+    );
 }
 
 #[test]
@@ -7082,10 +8051,14 @@ fn test_credit_channel_valid_and_data_method_dispatch_on_receiver() {
         end module Cons
     ";
     let sv = compile_to_sv(source);
-    assert!(sv.contains("latest = __p_data_data"),
-        "receiver read of p.data.data should rewrite to __p_data_data:\n{sv}");
-    assert!(sv.contains("__p_data_valid"),
-        "p.data.valid should rewrite to __p_data_valid:\n{sv}");
+    assert!(
+        sv.contains("latest = __p_data_data"),
+        "receiver read of p.data.data should rewrite to __p_data_data:\n{sv}"
+    );
+    assert!(
+        sv.contains("__p_data_valid"),
+        "p.data.valid should rewrite to __p_data_valid:\n{sv}"
+    );
 }
 
 #[test]
@@ -7116,14 +8089,20 @@ fn test_credit_channel_can_send_registered_emits_flop() {
     ";
     let sv = compile_to_sv(source);
     // Registered form declares can_send as `logic` (register), not `wire`.
-    assert!(sv.contains("logic __p_data_can_send;"),
-        "CAN_SEND_REGISTERED=1 should declare can_send as a register:\n{sv}");
+    assert!(
+        sv.contains("logic __p_data_can_send;"),
+        "CAN_SEND_REGISTERED=1 should declare can_send as a register:\n{sv}"
+    );
     // And assigns it inside the always_ff block.
-    assert!(sv.contains("__p_data_can_send <="),
-        "registered can_send should be updated via non-blocking assign:\n{sv}");
+    assert!(
+        sv.contains("__p_data_can_send <="),
+        "registered can_send should be updated via non-blocking assign:\n{sv}"
+    );
     // No `wire` form for can_send.
-    assert!(!sv.contains("wire  __p_data_can_send"),
-        "CAN_SEND_REGISTERED=1 must not emit the combinational wire form:\n{sv}");
+    assert!(
+        !sv.contains("wire  __p_data_can_send"),
+        "CAN_SEND_REGISTERED=1 must not emit the combinational wire form:\n{sv}"
+    );
 }
 
 #[test]
@@ -7151,8 +8130,10 @@ fn test_credit_channel_can_send_default_is_combinational() {
         end module Prod
     ";
     let sv = compile_to_sv(source);
-    assert!(sv.contains("wire  __p_data_can_send = __p_data_credit != 0"),
-        "default (unregistered) can_send should stay combinational:\n{sv}");
+    assert!(
+        sv.contains("wire  __p_data_can_send = __p_data_credit != 0"),
+        "default (unregistered) can_send should stay combinational:\n{sv}"
+    );
 }
 
 #[test]
@@ -7178,14 +8159,22 @@ fn test_credit_channel_tier2_sender_assertions() {
         end module Prod
     ";
     let sv = compile_to_sv(source);
-    assert!(sv.contains("_auto_cc_p_data_credit_bounds"),
-        "credit_bounds assertion label should be present on sender:\n{sv}");
-    assert!(sv.contains("__p_data_credit <= (4)"),
-        "credit_bounds property should compare credit reg to DEPTH:\n{sv}");
-    assert!(sv.contains("_auto_cc_p_data_send_requires_credit"),
-        "send_requires_credit assertion should be present:\n{sv}");
-    assert!(sv.contains("p_data_send_valid |-> __p_data_credit > 0"),
-        "send_requires_credit property should encode valid-implies-credit:\n{sv}");
+    assert!(
+        sv.contains("_auto_cc_p_data_credit_bounds"),
+        "credit_bounds assertion label should be present on sender:\n{sv}"
+    );
+    assert!(
+        sv.contains("__p_data_credit <= (4)"),
+        "credit_bounds property should compare credit reg to DEPTH:\n{sv}"
+    );
+    assert!(
+        sv.contains("_auto_cc_p_data_send_requires_credit"),
+        "send_requires_credit assertion should be present:\n{sv}"
+    );
+    assert!(
+        sv.contains("p_data_send_valid |-> __p_data_credit > 0"),
+        "send_requires_credit property should encode valid-implies-credit:\n{sv}"
+    );
 }
 
 #[test]
@@ -7210,10 +8199,14 @@ fn test_credit_channel_tier2_receiver_assertion() {
         end module Cons
     ";
     let sv = compile_to_sv(source);
-    assert!(sv.contains("_auto_cc_p_data_credit_return_requires_buffered"),
-        "receiver-side assertion should be present:\n{sv}");
-    assert!(sv.contains("p_data_credit_return |-> __p_data_valid"),
-        "credit_return should imply buffer-non-empty:\n{sv}");
+    assert!(
+        sv.contains("_auto_cc_p_data_credit_return_requires_buffered"),
+        "receiver-side assertion should be present:\n{sv}"
+    );
+    assert!(
+        sv.contains("p_data_credit_return |-> __p_data_valid"),
+        "credit_return should imply buffer-non-empty:\n{sv}"
+    );
 }
 
 #[test]
@@ -7245,11 +8238,14 @@ fn test_credit_channel_send_sugar() {
         end module Prod
     ";
     let sv = compile_to_sv(source);
-    assert!(sv.contains("p_data_send_valid = 1'd1")
-          || sv.contains("p_data_send_valid = 1'b1"),
-        ".send() should set send_valid to 1:\n{sv}");
-    assert!(sv.contains("p_data_send_data = payload"),
-        ".send(payload) should set send_data to payload:\n{sv}");
+    assert!(
+        sv.contains("p_data_send_valid = 1'd1") || sv.contains("p_data_send_valid = 1'b1"),
+        ".send() should set send_valid to 1:\n{sv}"
+    );
+    assert!(
+        sv.contains("p_data_send_data = payload"),
+        ".send(payload) should set send_data to payload:\n{sv}"
+    );
 }
 
 #[test]
@@ -7278,9 +8274,10 @@ fn test_credit_channel_pop_sugar() {
         end module Cons
     ";
     let sv = compile_to_sv(source);
-    assert!(sv.contains("p_data_credit_return = 1'd1")
-          || sv.contains("p_data_credit_return = 1'b1"),
-        ".pop() should assert credit_return:\n{sv}");
+    assert!(
+        sv.contains("p_data_credit_return = 1'd1") || sv.contains("p_data_credit_return = 1'b1"),
+        ".pop() should assert credit_return:\n{sv}"
+    );
 }
 
 #[test]
@@ -7359,29 +8356,62 @@ fn test_credit_channel_end_to_end_noc_producer_consumer() {
     let sv = compile_to_sv(source);
 
     // Sender-side checks
-    assert!(sv.contains("__out_flits_credit"), "sender credit reg:\n{sv}");
-    assert!(sv.contains("__out_flits_can_send"), "sender can_send:\n{sv}");
-    assert!(sv.contains("_auto_cc_out_flits_credit_bounds"), "sender SVA:\n{sv}");
-    assert!(sv.contains("_auto_cc_out_flits_send_requires_credit"), "sender SVA:\n{sv}");
+    assert!(
+        sv.contains("__out_flits_credit"),
+        "sender credit reg:\n{sv}"
+    );
+    assert!(
+        sv.contains("__out_flits_can_send"),
+        "sender can_send:\n{sv}"
+    );
+    assert!(
+        sv.contains("_auto_cc_out_flits_credit_bounds"),
+        "sender SVA:\n{sv}"
+    );
+    assert!(
+        sv.contains("_auto_cc_out_flits_send_requires_credit"),
+        "sender SVA:\n{sv}"
+    );
 
     // .send(x) sugar must materialize both signals
-    assert!(sv.contains("out_flits_send_valid = 1'd1"), "send sugar valid:\n{sv}");
-    assert!(sv.contains("out_flits_send_data = seq_no"), "send sugar data:\n{sv}");
+    assert!(
+        sv.contains("out_flits_send_valid = 1'd1"),
+        "send sugar valid:\n{sv}"
+    );
+    assert!(
+        sv.contains("out_flits_send_data = seq_no"),
+        "send sugar data:\n{sv}"
+    );
 
     // Receiver-side checks
-    assert!(sv.contains("__incoming_flits_buf"), "receiver buffer:\n{sv}");
-    assert!(sv.contains("__incoming_flits_valid"), "receiver valid wire:\n{sv}");
-    assert!(sv.contains("__incoming_flits_data"), "receiver data wire:\n{sv}");
-    assert!(sv.contains("_auto_cc_incoming_flits_credit_return_requires_buffered"),
-        "receiver SVA:\n{sv}");
+    assert!(
+        sv.contains("__incoming_flits_buf"),
+        "receiver buffer:\n{sv}"
+    );
+    assert!(
+        sv.contains("__incoming_flits_valid"),
+        "receiver valid wire:\n{sv}"
+    );
+    assert!(
+        sv.contains("__incoming_flits_data"),
+        "receiver data wire:\n{sv}"
+    );
+    assert!(
+        sv.contains("_auto_cc_incoming_flits_credit_return_requires_buffered"),
+        "receiver SVA:\n{sv}"
+    );
 
     // .pop() sugar
-    assert!(sv.contains("incoming_flits_credit_return = 1'd1"),
-        "pop sugar credit_return:\n{sv}");
+    assert!(
+        sv.contains("incoming_flits_credit_return = 1'd1"),
+        "pop sugar credit_return:\n{sv}"
+    );
 
     // Read-side dispatch in seq and comb contexts
-    assert!(sv.contains("last_seq <= __incoming_flits_data"),
-        "read-side dispatch in seq:\n{sv}");
+    assert!(
+        sv.contains("last_seq <= __incoming_flits_data"),
+        "read-side dispatch in seq:\n{sv}"
+    );
 }
 
 #[test]
@@ -7411,18 +8441,30 @@ fn test_credit_channel_sim_emits_sender_state() {
         end module Prod
     ";
     let out = compile_to_sim_h(source, false);
-    assert!(out.contains("uint32_t __p_data_credit;"),
-        "sender credit field should be declared:\n{out}");
-    assert!(out.contains("uint8_t  __p_data_can_send;"),
-        "sender can_send field should be declared:\n{out}");
-    assert!(out.contains("__p_data_credit = 4;"),
-        "constructor should initialize credit to DEPTH:\n{out}");
-    assert!(out.contains("__p_data_can_send = (__p_data_credit != 0)"),
-        "eval_comb should assign can_send combinationally:\n{out}");
-    assert!(out.contains("__p_data_credit--"),
-        "eval_posedge should decrement on pure send:\n{out}");
-    assert!(out.contains("__p_data_credit++"),
-        "eval_posedge should increment on pure credit_return:\n{out}");
+    assert!(
+        out.contains("uint32_t __p_data_credit;"),
+        "sender credit field should be declared:\n{out}"
+    );
+    assert!(
+        out.contains("uint8_t  __p_data_can_send;"),
+        "sender can_send field should be declared:\n{out}"
+    );
+    assert!(
+        out.contains("__p_data_credit = 4;"),
+        "constructor should initialize credit to DEPTH:\n{out}"
+    );
+    assert!(
+        out.contains("__p_data_can_send = (__p_data_credit != 0)"),
+        "eval_comb should assign can_send combinationally:\n{out}"
+    );
+    assert!(
+        out.contains("__p_data_credit--"),
+        "eval_posedge should decrement on pure send:\n{out}"
+    );
+    assert!(
+        out.contains("__p_data_credit++"),
+        "eval_posedge should increment on pure credit_return:\n{out}"
+    );
 }
 
 #[test]
@@ -7447,17 +8489,28 @@ fn test_credit_channel_sim_emits_receiver_state() {
         end module Cons
     ";
     let out = compile_to_sim_h(source, false);
-    assert!(out.contains("uint8_t __p_data_buf[4];"),
-        "receiver buffer array should be declared with correct width + depth:\n{out}");
-    assert!(out.contains("__p_data_head;") && out.contains("__p_data_tail;")
-         && out.contains("__p_data_occ;"),
-        "head/tail/occ pointers should be declared:\n{out}");
-    assert!(out.contains("__p_data_valid = (__p_data_occ != 0)"),
-        "valid should be computed in eval_comb:\n{out}");
-    assert!(out.contains("__p_data_data  = __p_data_buf[__p_data_head]"),
-        "data should read front of buffer in eval_comb:\n{out}");
-    assert!(out.contains("p_data_credit_return && __p_data_valid"),
-        "pop should fire on user-driven credit_return when valid:\n{out}");
+    assert!(
+        out.contains("uint8_t __p_data_buf[4];"),
+        "receiver buffer array should be declared with correct width + depth:\n{out}"
+    );
+    assert!(
+        out.contains("__p_data_head;")
+            && out.contains("__p_data_tail;")
+            && out.contains("__p_data_occ;"),
+        "head/tail/occ pointers should be declared:\n{out}"
+    );
+    assert!(
+        out.contains("__p_data_valid = (__p_data_occ != 0)"),
+        "valid should be computed in eval_comb:\n{out}"
+    );
+    assert!(
+        out.contains("__p_data_data  = __p_data_buf[__p_data_head]"),
+        "data should read front of buffer in eval_comb:\n{out}"
+    );
+    assert!(
+        out.contains("p_data_credit_return && __p_data_valid"),
+        "pop should fire on user-driven credit_return when valid:\n{out}"
+    );
 }
 
 #[test]
@@ -7474,10 +8527,14 @@ fn test_tlm_method_parses_as_bus_sub_construct() {
     let tokens = arch::lexer::tokenize(source).expect("lexer");
     let mut parser = arch::parser::Parser::new(tokens, source);
     let ast = parser.parse_source_file().expect("parse");
-    let bus = ast.items.iter().find_map(|it| match it {
-        arch::ast::Item::Bus(b) if b.name.name == "Mem" => Some(b),
-        _ => None,
-    }).expect("Mem bus in AST");
+    let bus = ast
+        .items
+        .iter()
+        .find_map(|it| match it {
+            arch::ast::Item::Bus(b) if b.name.name == "Mem" => Some(b),
+            _ => None,
+        })
+        .expect("Mem bus in AST");
     assert_eq!(bus.tlm_methods.len(), 3);
 
     let r = &bus.tlm_methods[0];
@@ -7528,20 +8585,28 @@ fn test_tlm_method_out_of_order_tags_parse_and_flatten() {
     let tokens = arch::lexer::tokenize(source).expect("lexer");
     let mut parser = arch::parser::Parser::new(tokens, source);
     let ast = parser.parse_source_file().expect("parse");
-    let bus = ast.items.iter().find_map(|it| match it {
-        arch::ast::Item::Bus(b) if b.name.name == "Mem" => Some(b),
-        _ => None,
-    }).expect("Mem bus in AST");
+    let bus = ast
+        .items
+        .iter()
+        .find_map(|it| match it {
+            arch::ast::Item::Bus(b) if b.name.name == "Mem" => Some(b),
+            _ => None,
+        })
+        .expect("Mem bus in AST");
     assert_eq!(bus.tlm_methods[0].mode.name, "out_of_order");
     assert!(bus.tlm_methods[0].out_of_order_tags.is_some());
 
     let sv = compile_to_sv(source);
-    assert!(sv.contains("output logic [2:0] m_read_req_tag")
-         && sv.contains("input logic [2:0] m_read_rsp_tag"),
-        "initiator should expose out-of-order tag wires:\n{sv}");
-    assert!(sv.contains("input logic [2:0] s_read_req_tag")
-         && sv.contains("output logic [2:0] s_read_rsp_tag"),
-        "target perspective should flip tag wire directions:\n{sv}");
+    assert!(
+        sv.contains("output logic [2:0] m_read_req_tag")
+            && sv.contains("input logic [2:0] m_read_rsp_tag"),
+        "initiator should expose out-of-order tag wires:\n{sv}"
+    );
+    assert!(
+        sv.contains("input logic [2:0] s_read_req_tag")
+            && sv.contains("output logic [2:0] s_read_rsp_tag"),
+        "target perspective should flip tag wire directions:\n{sv}"
+    );
 }
 
 #[test]
@@ -7568,18 +8633,30 @@ fn test_tlm_method_wires_flatten_at_bus_port() {
         end module Initiator
     ";
     let sv = compile_to_sv(source);
-    assert!(sv.contains("output logic m_read_req_valid"),
-        "req_valid should be an initiator output:\n{sv}");
-    assert!(sv.contains("output logic [31:0] m_read_addr"),
-        "arg should appear as initiator output with its declared type:\n{sv}");
-    assert!(sv.contains("input logic m_read_req_ready"),
-        "req_ready should flow back to initiator:\n{sv}");
-    assert!(sv.contains("input logic m_read_rsp_valid"),
-        "rsp_valid should be an initiator input:\n{sv}");
-    assert!(sv.contains("input logic [63:0] m_read_rsp_data"),
-        "rsp_data should appear with declared ret type:\n{sv}");
-    assert!(sv.contains("output logic m_read_rsp_ready"),
-        "rsp_ready flows back from initiator to target:\n{sv}");
+    assert!(
+        sv.contains("output logic m_read_req_valid"),
+        "req_valid should be an initiator output:\n{sv}"
+    );
+    assert!(
+        sv.contains("output logic [31:0] m_read_addr"),
+        "arg should appear as initiator output with its declared type:\n{sv}"
+    );
+    assert!(
+        sv.contains("input logic m_read_req_ready"),
+        "req_ready should flow back to initiator:\n{sv}"
+    );
+    assert!(
+        sv.contains("input logic m_read_rsp_valid"),
+        "rsp_valid should be an initiator input:\n{sv}"
+    );
+    assert!(
+        sv.contains("input logic [63:0] m_read_rsp_data"),
+        "rsp_data should appear with declared ret type:\n{sv}"
+    );
+    assert!(
+        sv.contains("output logic m_read_rsp_ready"),
+        "rsp_ready flows back from initiator to target:\n{sv}"
+    );
 }
 
 #[test]
@@ -7616,14 +8693,22 @@ fn test_tlm_method_param_widths_substitute_in_implicit_bus_wires() {
         end module Parent
     ";
     let sv = compile_to_sv(source);
-    assert!(sv.contains("logic [2:0] link_read_req_tag;"),
-        "implicit req tag wire should use overridden KV_HEAD_W:\n{sv}");
-    assert!(sv.contains("logic [4:0] link_read_tile;"),
-        "implicit arg wire should use overridden TILE_W:\n{sv}");
-    assert!(sv.contains("logic [16:0] link_read_rsp_data;"),
-        "implicit response wire should use overridden TOKEN_W:\n{sv}");
-    assert!(!sv.contains("KV_HEAD_W") && !sv.contains("TILE_W") && !sv.contains("TOKEN_W"),
-        "generated SV should not leak bus param identifiers into Parent plumbing:\n{sv}");
+    assert!(
+        sv.contains("logic [2:0] link_read_req_tag;"),
+        "implicit req tag wire should use overridden KV_HEAD_W:\n{sv}"
+    );
+    assert!(
+        sv.contains("logic [4:0] link_read_tile;"),
+        "implicit arg wire should use overridden TILE_W:\n{sv}"
+    );
+    assert!(
+        sv.contains("logic [16:0] link_read_rsp_data;"),
+        "implicit response wire should use overridden TOKEN_W:\n{sv}"
+    );
+    assert!(
+        !sv.contains("KV_HEAD_W") && !sv.contains("TILE_W") && !sv.contains("TOKEN_W"),
+        "generated SV should not leak bus param identifiers into Parent plumbing:\n{sv}"
+    );
 }
 
 #[test]
@@ -7689,14 +8774,22 @@ fn test_tlm_method_param_widths_substitute_in_lowered_target_and_initiator() {
         end module Top
     ";
     let sv = compile_to_sv(source);
-    assert!(sv.contains("logic [4:0] _tlm_m_read_tile_latched;"),
-        "target latch reg should use substituted TILE_W:\n{sv}");
-    assert!(sv.contains("output logic [16:0] m_read_rsp_data"),
-        "target response data should use substituted TOKEN_W:\n{sv}");
-    assert!(sv.contains("assign m_read_tile = _tlm_init_m_read_grant_0 ? 5'd3 : 0;"),
-        "initiator request drive should use substituted TILE_W:\n{sv}");
-    assert!(!sv.contains("TILE_W") && !sv.contains("TOKEN_W"),
-        "lowered generated SV should not leak bus param identifiers:\n{sv}");
+    assert!(
+        sv.contains("logic [4:0] _tlm_m_read_tile_latched;"),
+        "target latch reg should use substituted TILE_W:\n{sv}"
+    );
+    assert!(
+        sv.contains("output logic [16:0] m_read_rsp_data"),
+        "target response data should use substituted TOKEN_W:\n{sv}"
+    );
+    assert!(
+        sv.contains("assign m_read_tile = _tlm_init_m_read_grant_0 ? 5'd3 : 0;"),
+        "initiator request drive should use substituted TILE_W:\n{sv}"
+    );
+    assert!(
+        !sv.contains("TILE_W") && !sv.contains("TOKEN_W"),
+        "lowered generated SV should not leak bus param identifiers:\n{sv}"
+    );
 }
 
 #[test]
@@ -7719,10 +8812,14 @@ fn test_tlm_method_void_omits_rsp_data() {
         end module I
     ";
     let sv = compile_to_sv(source);
-    assert!(!sv.contains("poke_rsp_data"),
-        "void methods must not emit rsp_data:\n{sv}");
-    assert!(sv.contains("poke_rsp_valid"),
-        "void methods still need rsp_valid/ready for back-pressure:\n{sv}");
+    assert!(
+        !sv.contains("poke_rsp_data"),
+        "void methods must not emit rsp_data:\n{sv}"
+    );
+    assert!(
+        sv.contains("poke_rsp_valid"),
+        "void methods still need rsp_valid/ready for back-pressure:\n{sv}"
+    );
 }
 
 #[test]
@@ -7750,15 +8847,26 @@ fn test_tlm_target_thread_parses_with_dotted_name() {
     let tokens = arch::lexer::tokenize(source).expect("lexer");
     let mut parser = arch::parser::Parser::new(tokens, source);
     let ast = parser.parse_source_file().expect("parse");
-    let m = ast.items.iter().find_map(|it| match it {
-        arch::ast::Item::Module(m) if m.name.name == "MemTarget" => Some(m),
-        _ => None,
-    }).expect("MemTarget in AST");
-    let t = m.body.iter().find_map(|i| match i {
-        arch::ast::ModuleBodyItem::Thread(t) => Some(t),
-        _ => None,
-    }).expect("thread in MemTarget body");
-    let binding = t.tlm_target.as_ref().expect("tlm_target should be populated");
+    let m = ast
+        .items
+        .iter()
+        .find_map(|it| match it {
+            arch::ast::Item::Module(m) if m.name.name == "MemTarget" => Some(m),
+            _ => None,
+        })
+        .expect("MemTarget in AST");
+    let t = m
+        .body
+        .iter()
+        .find_map(|i| match i {
+            arch::ast::ModuleBodyItem::Thread(t) => Some(t),
+            _ => None,
+        })
+        .expect("thread in MemTarget body");
+    let binding = t
+        .tlm_target
+        .as_ref()
+        .expect("tlm_target should be populated");
     assert_eq!(binding.port.name, "s");
     assert_eq!(binding.method.name, "read");
     assert_eq!(binding.args.len(), 1);
@@ -7787,14 +8895,19 @@ fn test_tlm_initiator_call_site_end_to_end_sv() {
         end module Initiator
     ";
     let sv = compile_to_sv(source);
-    assert!(sv.contains("_tlm_init_driver_state"),
-        "state reg should be emitted:\n{sv}");
-    assert!(sv.contains("m_read_req_valid"),
-        "SV should drive req_valid:\n{sv}");
-    assert!(sv.contains("m_read_addr"),
-        "SV should drive the arg:\n{sv}");
-    assert!(sv.contains("m_read_rsp_ready"),
-        "SV should drive rsp_ready:\n{sv}");
+    assert!(
+        sv.contains("_tlm_init_driver_state"),
+        "state reg should be emitted:\n{sv}"
+    );
+    assert!(
+        sv.contains("m_read_req_valid"),
+        "SV should drive req_valid:\n{sv}"
+    );
+    assert!(sv.contains("m_read_addr"), "SV should drive the arg:\n{sv}");
+    assert!(
+        sv.contains("m_read_rsp_ready"),
+        "SV should drive rsp_ready:\n{sv}"
+    );
 }
 
 #[test]
@@ -7822,10 +8935,14 @@ fn test_tlm_target_sim_mirror_works_via_inlined_state_machine() {
         end module MemTarget
     ";
     let out = compile_to_sim_h(source, false);
-    assert!(out.contains("_tlm_s_read_state"),
-        "state reg should appear in sim C++:\n{out}");
-    assert!(out.contains("_tlm_s_read_addr_latched"),
-        "arg latch reg should appear in sim C++:\n{out}");
+    assert!(
+        out.contains("_tlm_s_read_state"),
+        "state reg should appear in sim C++:\n{out}"
+    );
+    assert!(
+        out.contains("_tlm_s_read_addr_latched"),
+        "arg latch reg should appear in sim C++:\n{out}"
+    );
 }
 
 #[test]
@@ -7848,8 +8965,10 @@ fn test_tlm_initiator_sim_mirror_works() {
         end module Initiator
     ";
     let out = compile_to_sim_h(source, false);
-    assert!(out.contains("_tlm_init_driver_state"),
-        "initiator state reg should appear in sim C++:\n{out}");
+    assert!(
+        out.contains("_tlm_init_driver_state"),
+        "initiator state reg should appear in sim C++:\n{out}"
+    );
 }
 
 #[test]
@@ -7877,12 +8996,18 @@ fn test_tlm_vec_return_sim_mirror_uses_array_copy() {
             && out.contains("uint32_t& m_read4_rsp_data_0;"),
         "bus Vec payload should expose a C++ array with flat compatibility aliases:\n{out}"
     );
-    assert!(out.contains("uint32_t _m_read4_rsp_data[4];"),
-        "flattened bus Vec payload should have an internal array:\n{out}");
-    assert!(out.contains("_m_read4_rsp_data[0] = m_read4_rsp_data_0;"),
-        "input bridge should copy flat fields into the internal array:\n{out}");
-    assert!(out.contains("for (size_t _i = 0; _i < 4; ++_i) { _n_data[_i] = _m_read4_rsp_data[_i]; }"),
-        "whole-Vec TLM response assignment should lower to element copy:\n{out}");
+    assert!(
+        out.contains("uint32_t _m_read4_rsp_data[4];"),
+        "flattened bus Vec payload should have an internal array:\n{out}"
+    );
+    assert!(
+        out.contains("_m_read4_rsp_data[0] = m_read4_rsp_data_0;"),
+        "input bridge should copy flat fields into the internal array:\n{out}"
+    );
+    assert!(
+        out.contains("for (size_t _i = 0; _i < 4; ++_i) { _n_data[_i] = _m_read4_rsp_data[_i]; }"),
+        "whole-Vec TLM response assignment should lower to element copy:\n{out}"
+    );
 }
 
 #[test]
@@ -7915,14 +9040,22 @@ fn test_struct_vec_field_sim_mirror_uses_array_field() {
         end module StructVecFieldsSmoke
     ";
     let out = compile_to_sim_h(source, false);
-    assert!(out.contains("uint32_t data[4];"),
-        "struct Vec field should emit as a C++ array:\n{out}");
-    assert!(out.contains("out0  = _r.data[0];"),
-        "struct Vec field read should use array indexing, not bit extraction:\n{out}");
-    assert!(out.contains("_n_r.data[0]  = in0;"),
-        "struct Vec field write should use array indexing:\n{out}");
-    assert!(!out.contains("((_n_r.data) >> (0)) & 1"),
-        "struct Vec field must not be treated as scalar bit indexing:\n{out}");
+    assert!(
+        out.contains("uint32_t data[4];"),
+        "struct Vec field should emit as a C++ array:\n{out}"
+    );
+    assert!(
+        out.contains("out0  = _r.data[0];"),
+        "struct Vec field read should use array indexing, not bit extraction:\n{out}"
+    );
+    assert!(
+        out.contains("_n_r.data[0]  = in0;"),
+        "struct Vec field write should use array indexing:\n{out}"
+    );
+    assert!(
+        !out.contains("((_n_r.data) >> (0)) & 1"),
+        "struct Vec field must not be treated as scalar bit indexing:\n{out}"
+    );
 }
 
 #[test]
@@ -7959,12 +9092,18 @@ fn test_tlm_struct_vec_response_sim_mirror_compiles_shape() {
         end module StructVecTlmCaller
     ";
     let out = compile_to_sim_h(source, false);
-    assert!(out.contains("BoundedVecResp32x4 m_read_burst_rsp_data;"),
-        "TLM struct response should expose the struct payload in sim:\n{out}");
-    assert!(out.contains("_n_r  = m_read_burst_rsp_data;"),
-        "TLM struct response should copy into the destination register:\n{out}");
-    assert!(!out.contains("m_read_burst_rsp_data >>"),
-        "struct response should not be emitted as a scalar trace expression:\n{out}");
+    assert!(
+        out.contains("BoundedVecResp32x4 m_read_burst_rsp_data;"),
+        "TLM struct response should expose the struct payload in sim:\n{out}"
+    );
+    assert!(
+        out.contains("_n_r  = m_read_burst_rsp_data;"),
+        "TLM struct response should copy into the destination register:\n{out}"
+    );
+    assert!(
+        !out.contains("m_read_burst_rsp_data >>"),
+        "struct response should not be emitted as a scalar trace expression:\n{out}"
+    );
 }
 
 #[test]
@@ -7976,35 +9115,48 @@ fn test_tlm_canonical_end_to_end_initiator_plus_target() {
     let sv = compile_to_sv(source);
 
     // Target-side state machines.
-    assert!(sv.contains("_tlm_s_read_state"),
-        "target: read state reg should appear:\n{sv}");
-    assert!(sv.contains("_tlm_s_write_state"),
-        "target: write state reg should appear:\n{sv}");
-    assert!(sv.contains("_tlm_s_read_addr_latched"),
-        "target: read arg latch reg should appear:\n{sv}");
-    assert!(sv.contains("_tlm_s_write_addr_latched")
-         && sv.contains("_tlm_s_write_data_latched"),
-        "target: write arg latch regs should appear:\n{sv}");
+    assert!(
+        sv.contains("_tlm_s_read_state"),
+        "target: read state reg should appear:\n{sv}"
+    );
+    assert!(
+        sv.contains("_tlm_s_write_state"),
+        "target: write state reg should appear:\n{sv}"
+    );
+    assert!(
+        sv.contains("_tlm_s_read_addr_latched"),
+        "target: read arg latch reg should appear:\n{sv}"
+    );
+    assert!(
+        sv.contains("_tlm_s_write_addr_latched") && sv.contains("_tlm_s_write_data_latched"),
+        "target: write arg latch regs should appear:\n{sv}"
+    );
 
     // Initiator state machine + wire drives.
-    assert!(sv.contains("_tlm_init_driver_state"),
-        "initiator: driver state reg should appear:\n{sv}");
-    assert!(sv.contains("m_read_req_valid")
-         && sv.contains("m_write_req_valid"),
-        "initiator: both methods should drive req_valid:\n{sv}");
-    assert!(sv.contains("m_read_addr")
-         && sv.contains("m_write_addr")
-         && sv.contains("m_write_data"),
-        "initiator: arg signals should appear:\n{sv}");
-    assert!(sv.contains("module TlmOneToOneTop")
-         && sv.contains("link_read_req_valid"),
-        "top-level one-to-one bus wire connection should appear:\n{sv}");
+    assert!(
+        sv.contains("_tlm_init_driver_state"),
+        "initiator: driver state reg should appear:\n{sv}"
+    );
+    assert!(
+        sv.contains("m_read_req_valid") && sv.contains("m_write_req_valid"),
+        "initiator: both methods should drive req_valid:\n{sv}"
+    );
+    assert!(
+        sv.contains("m_read_addr") && sv.contains("m_write_addr") && sv.contains("m_write_data"),
+        "initiator: arg signals should appear:\n{sv}"
+    );
+    assert!(
+        sv.contains("module TlmOneToOneTop") && sv.contains("link_read_req_valid"),
+        "top-level one-to-one bus wire connection should appear:\n{sv}"
+    );
 
     // Compile to sim C++ too — same path should flow through the existing
     // reg/seq/comb sim mirror without issues.
     let sim = compile_to_sim_h(source, false);
-    assert!(sim.contains("_tlm_s_read_state") && sim.contains("_tlm_init_driver_state"),
-        "sim C++ should mirror the state regs for both sides");
+    assert!(
+        sim.contains("_tlm_s_read_state") && sim.contains("_tlm_init_driver_state"),
+        "sim C++ should mirror the state regs for both sides"
+    );
 }
 
 #[test]
@@ -8012,18 +9164,26 @@ fn test_tlm_connect_one_to_one_sugar_lowers_to_bus_wire() {
     let source = include_str!("axi_dma_tlm/TlmConnectOneToOne.arch");
     let sv = compile_to_sv(source);
 
-    assert!(sv.contains("module TlmConnectOneToOneTop"),
-        "connect-sugar top should build:\n{sv}");
-    assert!(sv.contains("_tlm_conn_i_m_t_s_read_req_valid")
-         && sv.contains("_tlm_conn_i_m_t_s_write_req_valid"),
-        "connect sugar should synthesize a private flattened TLM bus wire:\n{sv}");
-    assert!(sv.contains(".m_read_req_valid(_tlm_conn_i_m_t_s_read_req_valid)")
-         && sv.contains(".s_read_req_valid(_tlm_conn_i_m_t_s_read_req_valid)"),
-        "connect sugar should wire initiator and target endpoints together:\n{sv}");
+    assert!(
+        sv.contains("module TlmConnectOneToOneTop"),
+        "connect-sugar top should build:\n{sv}"
+    );
+    assert!(
+        sv.contains("_tlm_conn_i_m_t_s_read_req_valid")
+            && sv.contains("_tlm_conn_i_m_t_s_write_req_valid"),
+        "connect sugar should synthesize a private flattened TLM bus wire:\n{sv}"
+    );
+    assert!(
+        sv.contains(".m_read_req_valid(_tlm_conn_i_m_t_s_read_req_valid)")
+            && sv.contains(".s_read_req_valid(_tlm_conn_i_m_t_s_read_req_valid)"),
+        "connect sugar should wire initiator and target endpoints together:\n{sv}"
+    );
 
     let sim = compile_to_sim_h(source, false);
-    assert!(sim.contains("class VTlmConnectOneToOneTop"),
-        "sim C++ should include the connect-sugar top");
+    assert!(
+        sim.contains("class VTlmConnectOneToOneTop"),
+        "sim C++ should include the connect-sugar top"
+    );
 }
 
 #[test]
@@ -8031,20 +9191,28 @@ fn test_tlm_connect_inside_generate_for_lowers_to_per_iteration_wires() {
     let source = include_str!("axi_dma_tlm/TlmConnectGenerate.arch");
     let sv = compile_to_sv(source);
 
-    assert!(sv.contains("module TlmConnectGenerateTop"),
-        "generate-for connect-sugar top should build:\n{sv}");
-    assert!(sv.contains("_tlm_conn_src_0_m_dst_0_s_read_req_valid")
-         && sv.contains("_tlm_conn_src_1_m_dst_1_s_read_req_valid"),
-        "generate-for connect sugar should synthesize one private TLM bus per iteration:\n{sv}");
-    assert!(sv.contains(".m_read_req_valid(_tlm_conn_src_0_m_dst_0_s_read_req_valid)")
-         && sv.contains(".s_read_req_valid(_tlm_conn_src_0_m_dst_0_s_read_req_valid)")
-         && sv.contains(".m_read_req_valid(_tlm_conn_src_1_m_dst_1_s_read_req_valid)")
-         && sv.contains(".s_read_req_valid(_tlm_conn_src_1_m_dst_1_s_read_req_valid)"),
-        "unrolled initiator and target endpoints should be wired pairwise:\n{sv}");
+    assert!(
+        sv.contains("module TlmConnectGenerateTop"),
+        "generate-for connect-sugar top should build:\n{sv}"
+    );
+    assert!(
+        sv.contains("_tlm_conn_src_0_m_dst_0_s_read_req_valid")
+            && sv.contains("_tlm_conn_src_1_m_dst_1_s_read_req_valid"),
+        "generate-for connect sugar should synthesize one private TLM bus per iteration:\n{sv}"
+    );
+    assert!(
+        sv.contains(".m_read_req_valid(_tlm_conn_src_0_m_dst_0_s_read_req_valid)")
+            && sv.contains(".s_read_req_valid(_tlm_conn_src_0_m_dst_0_s_read_req_valid)")
+            && sv.contains(".m_read_req_valid(_tlm_conn_src_1_m_dst_1_s_read_req_valid)")
+            && sv.contains(".s_read_req_valid(_tlm_conn_src_1_m_dst_1_s_read_req_valid)"),
+        "unrolled initiator and target endpoints should be wired pairwise:\n{sv}"
+    );
 
     let sim = compile_to_sim_h(source, false);
-    assert!(sim.contains("class VTlmConnectGenerateTop"),
-        "sim C++ should include the generate-for connect-sugar top");
+    assert!(
+        sim.contains("class VTlmConnectGenerateTop"),
+        "sim C++ should include the generate-for connect-sugar top"
+    );
 }
 
 fn tlm_connect_elaborate_error(source: &str) -> String {
@@ -8057,7 +9225,8 @@ fn tlm_connect_elaborate_error(source: &str) -> String {
 
 #[test]
 fn test_tlm_connect_unknown_instance_diagnostic() {
-    let msg = tlm_connect_elaborate_error(r#"
+    let msg = tlm_connect_elaborate_error(
+        r#"
 bus Mem
   tlm_method read(addr: UInt<32>) -> UInt<64>: blocking;
 end bus Mem
@@ -8073,14 +9242,18 @@ module Top
   end inst t
   connect missing.m -> t.s;
 end module Top
-"#);
-    assert!(msg.contains("unknown TLM connect instance `missing`"),
-        "expected unknown-instance diagnostic, got: {msg}");
+"#,
+    );
+    assert!(
+        msg.contains("unknown TLM connect instance `missing`"),
+        "expected unknown-instance diagnostic, got: {msg}"
+    );
 }
 
 #[test]
 fn test_tlm_connect_unknown_port_diagnostic() {
-    let msg = tlm_connect_elaborate_error(r#"
+    let msg = tlm_connect_elaborate_error(
+        r#"
 bus Mem
   tlm_method read(addr: UInt<32>) -> UInt<64>: blocking;
 end bus Mem
@@ -8098,14 +9271,18 @@ module Top
   end inst t
   connect i.nope -> t.s;
 end module Top
-"#);
-    assert!(msg.contains("module `Initiator` has no port `nope`"),
-        "expected unknown-port diagnostic, got: {msg}");
+"#,
+    );
+    assert!(
+        msg.contains("module `Initiator` has no port `nope`"),
+        "expected unknown-port diagnostic, got: {msg}"
+    );
 }
 
 #[test]
 fn test_tlm_connect_non_bus_port_diagnostic() {
-    let msg = tlm_connect_elaborate_error(r#"
+    let msg = tlm_connect_elaborate_error(
+        r#"
 bus Mem
   tlm_method read(addr: UInt<32>) -> UInt<64>: blocking;
 end bus Mem
@@ -8124,14 +9301,18 @@ module Top
   end inst t
   connect i.scalar -> t.s;
 end module Top
-"#);
-    assert!(msg.contains("non-bus port `scalar`"),
-        "expected non-bus-port diagnostic, got: {msg}");
+"#,
+    );
+    assert!(
+        msg.contains("non-bus port `scalar`"),
+        "expected non-bus-port diagnostic, got: {msg}"
+    );
 }
 
 #[test]
 fn test_tlm_connect_direction_mismatch_diagnostic() {
-    let msg = tlm_connect_elaborate_error(r#"
+    let msg = tlm_connect_elaborate_error(
+        r#"
 bus Mem
   tlm_method read(addr: UInt<32>) -> UInt<64>: blocking;
 end bus Mem
@@ -8149,16 +9330,23 @@ module Top
   end inst t
   connect t.s -> i.m;
 end module Top
-"#);
-    assert!(msg.contains("requires `connect initiator_inst.initiator_port -> target_inst.target_port;`")
-         && msg.contains("t.s") && msg.contains("Target")
-         && msg.contains("i.m") && msg.contains("Initiator"),
-        "expected direction-mismatch diagnostic, got: {msg}");
+"#,
+    );
+    assert!(
+        msg.contains(
+            "requires `connect initiator_inst.initiator_port -> target_inst.target_port;`"
+        ) && msg.contains("t.s")
+            && msg.contains("Target")
+            && msg.contains("i.m")
+            && msg.contains("Initiator"),
+        "expected direction-mismatch diagnostic, got: {msg}"
+    );
 }
 
 #[test]
 fn test_tlm_connect_bus_mismatch_diagnostic() {
-    let msg = tlm_connect_elaborate_error(r#"
+    let msg = tlm_connect_elaborate_error(
+        r#"
 bus MemA
   tlm_method read(addr: UInt<32>) -> UInt<64>: blocking;
 end bus MemA
@@ -8180,15 +9368,18 @@ module Top
   end inst t
   connect i.m -> t.s;
 end module Top
-"#);
-    assert!(msg.contains("TLM connect bus mismatch")
-         && msg.contains("MemA") && msg.contains("MemB"),
-        "expected bus-mismatch diagnostic, got: {msg}");
+"#,
+    );
+    assert!(
+        msg.contains("TLM connect bus mismatch") && msg.contains("MemA") && msg.contains("MemB"),
+        "expected bus-mismatch diagnostic, got: {msg}"
+    );
 }
 
 #[test]
 fn test_tlm_connect_duplicate_explicit_connection_diagnostic() {
-    let msg = tlm_connect_elaborate_error(r#"
+    let msg = tlm_connect_elaborate_error(
+        r#"
 bus Mem
   tlm_method read(addr: UInt<32>) -> UInt<64>: blocking;
 end bus Mem
@@ -8208,15 +9399,18 @@ module Top
   end inst t
   connect i.m -> t.s;
 end module Top
-"#);
-    assert!(msg.contains("duplicates an explicit connection")
-         && msg.contains("i.m"),
-        "expected duplicate-explicit-connection diagnostic, got: {msg}");
+"#,
+    );
+    assert!(
+        msg.contains("duplicates an explicit connection") && msg.contains("i.m"),
+        "expected duplicate-explicit-connection diagnostic, got: {msg}"
+    );
 }
 
 #[test]
 fn test_tlm_connect_endpoint_reuse_diagnostic() {
-    let msg = tlm_connect_elaborate_error(r#"
+    let msg = tlm_connect_elaborate_error(
+        r#"
 bus Mem
   tlm_method read(addr: UInt<32>) -> UInt<64>: blocking;
 end bus Mem
@@ -8237,14 +9431,18 @@ module Top
   connect i.m -> t0.s;
   connect i.m -> t1.s;
 end module Top
-"#);
-    assert!(msg.contains("TLM connect endpoint `i.m` is connected more than once"),
-        "expected endpoint-reuse diagnostic, got: {msg}");
+"#,
+    );
+    assert!(
+        msg.contains("TLM connect endpoint `i.m` is connected more than once"),
+        "expected endpoint-reuse diagnostic, got: {msg}"
+    );
 }
 
 #[test]
 fn test_tlm_connect_endpoint_reuse_after_generate_for_diagnostic() {
-    let msg = tlm_connect_elaborate_error(r#"
+    let msg = tlm_connect_elaborate_error(
+        r#"
 bus Mem
   tlm_method read(addr: UInt<32>) -> UInt<64>: blocking;
 end bus Mem
@@ -8264,108 +9462,152 @@ module Top
     connect i.m -> t_n.s;
   end generate_for
 end module Top
-"#);
-    assert!(msg.contains("TLM connect endpoint `i.m` is connected more than once"),
-        "expected endpoint-reuse-after-generate diagnostic, got: {msg}");
+"#,
+    );
+    assert!(
+        msg.contains("TLM connect endpoint `i.m` is connected more than once"),
+        "expected endpoint-reuse-after-generate diagnostic, got: {msg}"
+    );
 }
 
 #[test]
 fn test_tlm_one_initiator_many_targets_router_example_compiles() {
     let source = include_str!("axi_dma_tlm/TlmOneToMany.arch");
     let sv = compile_to_sv(source);
-    assert!(sv.contains("module TlmAddrRouter2"),
-        "one-to-many TLM router should build:\n{sv}");
-    assert!(sv.contains("lo_read_req_valid = up_read_req_valid && read_to_hi == 1'b0")
-         && sv.contains("hi_read_req_valid = up_read_req_valid && read_to_hi"),
-        "router should decode request valid to exactly one downstream target:\n{sv}");
-    assert!(sv.contains("up_read_rsp_data = read_sel_hi ? hi_read_rsp_data : lo_read_rsp_data")
-         && sv.contains("up_write_rsp_data = write_sel_hi ? hi_write_rsp_data : lo_write_rsp_data"),
-        "router should mux responses through the latched request target:\n{sv}");
-    assert!(sv.contains("module TlmOneToManyTop")
-         && sv.contains("cpu_link_read_req_valid")
-         && sv.contains("lo_link_read_req_valid")
-         && sv.contains("hi_link_read_req_valid"),
-        "top should connect one initiator through router to two target links:\n{sv}");
+    assert!(
+        sv.contains("module TlmAddrRouter2"),
+        "one-to-many TLM router should build:\n{sv}"
+    );
+    assert!(
+        sv.contains("lo_read_req_valid = up_read_req_valid && read_to_hi == 1'b0")
+            && sv.contains("hi_read_req_valid = up_read_req_valid && read_to_hi"),
+        "router should decode request valid to exactly one downstream target:\n{sv}"
+    );
+    assert!(
+        sv.contains("up_read_rsp_data = read_sel_hi ? hi_read_rsp_data : lo_read_rsp_data")
+            && sv.contains(
+                "up_write_rsp_data = write_sel_hi ? hi_write_rsp_data : lo_write_rsp_data"
+            ),
+        "router should mux responses through the latched request target:\n{sv}"
+    );
+    assert!(
+        sv.contains("module TlmOneToManyTop")
+            && sv.contains("cpu_link_read_req_valid")
+            && sv.contains("lo_link_read_req_valid")
+            && sv.contains("hi_link_read_req_valid"),
+        "top should connect one initiator through router to two target links:\n{sv}"
+    );
 
     let sim = compile_to_sim_h(source, false);
-    assert!(sim.contains("class VTlmAddrRouter2")
-         && sim.contains("class VTlmOneToManyTop"),
-        "sim C++ should include router and top mirrors");
+    assert!(
+        sim.contains("class VTlmAddrRouter2") && sim.contains("class VTlmOneToManyTop"),
+        "sim C++ should include router and top mirrors"
+    );
 }
 
 #[test]
 fn test_tlm_one_initiator_many_targets_ooo_router_example_compiles() {
     let source = include_str!("axi_dma_tlm/TlmOneToManyOoo.arch");
     let sv = compile_to_sv(source);
-    assert!(sv.contains("module TlmOooAddrRouter2"),
-        "OOO one-to-many TLM router should build:\n{sv}");
-    assert!(sv.contains("logic [3:0] read_route_hi;")
-         && sv.contains("read_route_hi[up_read_req_tag] <= read_to_hi"),
-        "OOO router should record downstream route per upstream tag:\n{sv}");
-    assert!(sv.contains("lo_read_req_tag = up_read_req_tag")
-         && sv.contains("hi_read_req_tag = up_read_req_tag"),
-        "OOO router should forward upstream tags unchanged downstream:\n{sv}");
-    assert!(sv.contains("up_read_rsp_tag = choose_hi_rsp ? hi_read_rsp_tag : lo_read_rsp_tag")
-         && sv.contains("hi_read_rsp_ready = up_read_rsp_ready && choose_hi_rsp"),
-        "OOO router should mux responses by saved route and downstream response tag:\n{sv}");
-    assert!(sv.contains("module TlmOneToManyOooTop")
-         && sv.contains("cpu_link_read_req_tag")
-         && sv.contains("lo_link_read_req_tag")
-         && sv.contains("hi_link_read_req_tag"),
-        "OOO top should connect tag signals through one-to-many links:\n{sv}");
+    assert!(
+        sv.contains("module TlmOooAddrRouter2"),
+        "OOO one-to-many TLM router should build:\n{sv}"
+    );
+    assert!(
+        sv.contains("logic [3:0] read_route_hi;")
+            && sv.contains("read_route_hi[up_read_req_tag] <= read_to_hi"),
+        "OOO router should record downstream route per upstream tag:\n{sv}"
+    );
+    assert!(
+        sv.contains("lo_read_req_tag = up_read_req_tag")
+            && sv.contains("hi_read_req_tag = up_read_req_tag"),
+        "OOO router should forward upstream tags unchanged downstream:\n{sv}"
+    );
+    assert!(
+        sv.contains("up_read_rsp_tag = choose_hi_rsp ? hi_read_rsp_tag : lo_read_rsp_tag")
+            && sv.contains("hi_read_rsp_ready = up_read_rsp_ready && choose_hi_rsp"),
+        "OOO router should mux responses by saved route and downstream response tag:\n{sv}"
+    );
+    assert!(
+        sv.contains("module TlmOneToManyOooTop")
+            && sv.contains("cpu_link_read_req_tag")
+            && sv.contains("lo_link_read_req_tag")
+            && sv.contains("hi_link_read_req_tag"),
+        "OOO top should connect tag signals through one-to-many links:\n{sv}"
+    );
 
     let sim = compile_to_sim_h(source, false);
-    assert!(sim.contains("class VTlmOooAddrRouter2")
-         && sim.contains("class VTlmOneToManyOooTop"),
-        "sim C++ should include OOO router and top mirrors");
+    assert!(
+        sim.contains("class VTlmOooAddrRouter2") && sim.contains("class VTlmOneToManyOooTop"),
+        "sim C++ should include OOO router and top mirrors"
+    );
 }
 
 #[test]
 fn test_tlm_one_initiator_many_targets_response_router_example_compiles() {
     let source = include_str!("axi_dma_tlm/TlmOneToManyResp.arch");
     let sv = compile_to_sv(source);
-    assert!(sv.contains("module TlmAddrRouter4Resp"),
-        "response-typed one-to-many TLM router should build:\n{sv}");
-    assert!(sv.contains("typedef struct packed")
-         && sv.contains("MemResp64"),
-        "struct response payload should be emitted:\n{sv}");
-    assert!(sv.contains("read_err_valid")
-         && sv.contains("up_read_rsp_data = read_err_valid ?"),
-        "router should synthesize its own decode-error response:\n{sv}");
-    assert!(sv.contains("s_read_rsp_data = {64'd1152921504606846976, 2'd0}")
-         && sv.contains("up_read_rsp_data = read_err_valid ? {64'd0, 2'd1}"),
-        "SV codegen should emit packed struct literals as iverilog-friendly concatenations:\n{sv}");
-    assert!(sv.contains("_auto_tlm_m_read_req_stable")
-         && sv.contains("$stable(m_read_addr)")
-         && sv.contains("_auto_tlm_m_read_rsp_stable")
-         && sv.contains("$stable(m_read_rsp_data)"),
-        "TLM protocol assertions should track request args and struct response payloads:\n{sv}");
-    assert!(sv.contains("t0_read_req_valid = up_read_req_valid && read_to_0")
-         && sv.contains("t3_read_req_valid = up_read_req_valid && read_to_3"),
-        "router should decode requests across four downstream targets:\n{sv}");
+    assert!(
+        sv.contains("module TlmAddrRouter4Resp"),
+        "response-typed one-to-many TLM router should build:\n{sv}"
+    );
+    assert!(
+        sv.contains("typedef struct packed") && sv.contains("MemResp64"),
+        "struct response payload should be emitted:\n{sv}"
+    );
+    assert!(
+        sv.contains("read_err_valid") && sv.contains("up_read_rsp_data = read_err_valid ?"),
+        "router should synthesize its own decode-error response:\n{sv}"
+    );
+    assert!(
+        sv.contains("s_read_rsp_data = {64'd1152921504606846976, 2'd0}")
+            && sv.contains("up_read_rsp_data = read_err_valid ? {64'd0, 2'd1}"),
+        "SV codegen should emit packed struct literals as iverilog-friendly concatenations:\n{sv}"
+    );
+    assert!(
+        sv.contains("_auto_tlm_m_read_req_stable")
+            && sv.contains("$stable(m_read_addr)")
+            && sv.contains("_auto_tlm_m_read_rsp_stable")
+            && sv.contains("$stable(m_read_rsp_data)"),
+        "TLM protocol assertions should track request args and struct response payloads:\n{sv}"
+    );
+    assert!(
+        sv.contains("t0_read_req_valid = up_read_req_valid && read_to_0")
+            && sv.contains("t3_read_req_valid = up_read_req_valid && read_to_3"),
+        "router should decode requests across four downstream targets:\n{sv}"
+    );
 
     let sim = compile_to_sim_h(source, false);
-    assert!(sim.contains("class VTlmAddrRouter4Resp")
-         && sim.contains("MemResp64 up_read_rsp_data"),
-        "sim C++ should include struct response router mirror:\n{sim}");
-    assert!(sim.contains("if (_let_read_mapped == 0)"),
-        "sim C++ if conditions should not double-wrap comparison expressions:\n{sim}");
-    assert!(!sim.contains("if ((_let_read_mapped == 0))"),
-        "sim C++ should avoid Clang -Wparentheses-equality noise:\n{sim}");
+    assert!(
+        sim.contains("class VTlmAddrRouter4Resp") && sim.contains("MemResp64 up_read_rsp_data"),
+        "sim C++ should include struct response router mirror:\n{sim}"
+    );
+    assert!(
+        sim.contains("if (_let_read_mapped == 0)"),
+        "sim C++ if conditions should not double-wrap comparison expressions:\n{sim}"
+    );
+    assert!(
+        !sim.contains("if ((_let_read_mapped == 0))"),
+        "sim C++ should avoid Clang -Wparentheses-equality noise:\n{sim}"
+    );
 }
 
 #[test]
 fn test_tlm_ooo_protocol_asserts_track_tags() {
     let source = include_str!("axi_dma_tlm/TlmOneToManyOoo.arch");
     let sv = compile_to_sv(source);
-    assert!(sv.contains("_auto_tlm_m_read_req_stable")
-         && sv.contains("$stable(m_read_req_tag)")
-         && sv.contains("$stable(m_read_addr)"),
-        "OOO request assertion should track req_tag under backpressure:\n{sv}");
-    assert!(sv.contains("_auto_tlm_m_read_rsp_stable")
-         && sv.contains("$stable(m_read_rsp_tag)")
-         && sv.contains("$stable(m_read_rsp_data)"),
-        "OOO response assertion should track rsp_tag under backpressure:\n{sv}");
+    assert!(
+        sv.contains("_auto_tlm_m_read_req_stable")
+            && sv.contains("$stable(m_read_req_tag)")
+            && sv.contains("$stable(m_read_addr)"),
+        "OOO request assertion should track req_tag under backpressure:\n{sv}"
+    );
+    assert!(
+        sv.contains("_auto_tlm_m_read_rsp_stable")
+            && sv.contains("$stable(m_read_rsp_tag)")
+            && sv.contains("$stable(m_read_rsp_data)"),
+        "OOO response assertion should track rsp_tag under backpressure:\n{sv}"
+    );
 }
 
 #[test]
@@ -8381,13 +9623,17 @@ fn test_tlm_one_initiator_many_targets_router_arch_sim_behavior() {
         .arg(td.path())
         .output()
         .expect("run arch sim for one-to-many router");
-    assert!(out.status.success(),
+    assert!(
+        out.status.success(),
         "one-to-many router sim should pass\nstdout:\n{}\nstderr:\n{}",
         String::from_utf8_lossy(&out.stdout),
-        String::from_utf8_lossy(&out.stderr));
-    assert!(String::from_utf8_lossy(&out.stdout).contains("PASS one-to-many blocking"),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&out.stdout).contains("PASS one-to-many blocking"),
         "expected PASS marker in stdout:\n{}",
-        String::from_utf8_lossy(&out.stdout));
+        String::from_utf8_lossy(&out.stdout)
+    );
 }
 
 #[test]
@@ -8403,13 +9649,17 @@ fn test_tlm_one_initiator_many_targets_ooo_router_arch_sim_behavior() {
         .arg(td.path())
         .output()
         .expect("run arch sim for OOO one-to-many router");
-    assert!(out.status.success(),
+    assert!(
+        out.status.success(),
         "OOO one-to-many router sim should pass\nstdout:\n{}\nstderr:\n{}",
         String::from_utf8_lossy(&out.stdout),
-        String::from_utf8_lossy(&out.stderr));
-    assert!(String::from_utf8_lossy(&out.stdout).contains("PASS one-to-many OOO"),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&out.stdout).contains("PASS one-to-many OOO"),
         "expected PASS marker in stdout:\n{}",
-        String::from_utf8_lossy(&out.stdout));
+        String::from_utf8_lossy(&out.stdout)
+    );
 }
 
 #[test]
@@ -8425,13 +9675,17 @@ fn test_tlm_one_initiator_many_targets_response_router_arch_sim_behavior() {
         .arg(td.path())
         .output()
         .expect("run arch sim for response-typed one-to-many router");
-    assert!(out.status.success(),
+    assert!(
+        out.status.success(),
         "response-typed one-to-many router sim should pass\nstdout:\n{}\nstderr:\n{}",
         String::from_utf8_lossy(&out.stdout),
-        String::from_utf8_lossy(&out.stderr));
-    assert!(String::from_utf8_lossy(&out.stdout).contains("PASS one-to-many response router"),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&out.stdout).contains("PASS one-to-many response router"),
         "expected PASS marker in stdout:\n{}",
-        String::from_utf8_lossy(&out.stdout));
+        String::from_utf8_lossy(&out.stdout)
+    );
 }
 
 #[test]
@@ -8452,7 +9706,10 @@ fn test_reentrant_thread_keyword_rejected_by_parser() {
     let tokens = arch::lexer::tokenize(source).expect("lexer");
     let mut parser = arch::parser::Parser::new(tokens, source);
     let result = parser.parse_source_file();
-    assert!(result.is_err(), "reentrant thread syntax should no longer parse");
+    assert!(
+        result.is_err(),
+        "reentrant thread syntax should no longer parse"
+    );
 }
 
 #[test]
@@ -8479,14 +9736,22 @@ fn test_implement_initiator_parses() {
     let tokens = arch::lexer::tokenize(source).expect("lexer");
     let mut parser = arch::parser::Parser::new(tokens, source);
     let ast = parser.parse_source_file().expect("parse");
-    let m = ast.items.iter().find_map(|it| match it {
-        arch::ast::Item::Module(m) if m.name.name == "M" => Some(m),
-        _ => None,
-    }).expect("module M");
-    let t = m.body.iter().find_map(|i| match i {
-        arch::ast::ModuleBodyItem::Thread(t) => Some(t),
-        _ => None,
-    }).expect("thread");
+    let m = ast
+        .items
+        .iter()
+        .find_map(|it| match it {
+            arch::ast::Item::Module(m) if m.name.name == "M" => Some(m),
+            _ => None,
+        })
+        .expect("module M");
+    let t = m
+        .body
+        .iter()
+        .find_map(|i| match i {
+            arch::ast::ModuleBodyItem::Thread(t) => Some(t),
+            _ => None,
+        })
+        .expect("thread");
     let b = t.implement.as_ref().expect("implement should be populated");
     assert_eq!(b.kind, arch::ast::TlmImplementKind::Initiator);
     assert_eq!(b.port.name, "m");
@@ -8517,14 +9782,22 @@ fn test_implement_target_parses() {
     let tokens = arch::lexer::tokenize(source).expect("lexer");
     let mut parser = arch::parser::Parser::new(tokens, source);
     let ast = parser.parse_source_file().expect("parse");
-    let m = ast.items.iter().find_map(|it| match it {
-        arch::ast::Item::Module(m) if m.name.name == "T" => Some(m),
-        _ => None,
-    }).expect("module T");
-    let t = m.body.iter().find_map(|i| match i {
-        arch::ast::ModuleBodyItem::Thread(t) => Some(t),
-        _ => None,
-    }).expect("thread");
+    let m = ast
+        .items
+        .iter()
+        .find_map(|it| match it {
+            arch::ast::Item::Module(m) if m.name.name == "T" => Some(m),
+            _ => None,
+        })
+        .expect("module T");
+    let t = m
+        .body
+        .iter()
+        .find_map(|i| match i {
+            arch::ast::ModuleBodyItem::Thread(t) => Some(t),
+            _ => None,
+        })
+        .expect("thread");
     let b = t.implement.as_ref().expect("implement should be populated");
     assert_eq!(b.kind, arch::ast::TlmImplementKind::Target);
     assert_eq!(b.args.len(), 1);
@@ -8555,12 +9828,18 @@ fn test_implement_target_single_compiles_end_to_end() {
         end module MemTarget
     ";
     let sv = compile_to_sv(source);
-    assert!(sv.contains("_tlm_s_read_state"),
-        "state reg should appear in SV:\n{sv}");
-    assert!(sv.contains("_tlm_s_read_addr_latched"),
-        "arg latch reg should appear in SV:\n{sv}");
-    assert!(sv.contains("s_read_req_ready"),
-        "req_ready driver should appear:\n{sv}");
+    assert!(
+        sv.contains("_tlm_s_read_state"),
+        "state reg should appear in SV:\n{sv}"
+    );
+    assert!(
+        sv.contains("_tlm_s_read_addr_latched"),
+        "arg latch reg should appear in SV:\n{sv}"
+    );
+    assert!(
+        sv.contains("s_read_req_ready"),
+        "req_ready driver should appear:\n{sv}"
+    );
 }
 
 #[test]
@@ -8594,10 +9873,15 @@ fn test_implement_target_multi_implementer_rejected() {
     let ast = parser.parse_source_file().expect("parse");
     let ast = arch::elaborate::elaborate(ast).expect("elaborate");
     let r = arch::elaborate::lower_tlm_target_threads(ast);
-    assert!(r.is_err(), "non-indexed multi-implementer target should error");
+    assert!(
+        r.is_err(),
+        "non-indexed multi-implementer target should error"
+    );
     let msg = format!("{:?}", r.unwrap_err());
-    assert!(msg.contains("multi-implementer target") && msg.contains("s.read"),
-        "expected targeted error, got: {msg}");
+    assert!(
+        msg.contains("multi-implementer target") && msg.contains("s.read"),
+        "expected targeted error, got: {msg}"
+    );
 }
 
 #[test]
@@ -8622,18 +9906,23 @@ fn test_tlm_indexed_target_generate_for_lowers_tag_lanes() {
         end module MemTarget
     ";
     let sv = compile_to_sv(source);
-    assert!(sv.contains("_tlm_s_read_tag0_state")
-         && sv.contains("_tlm_s_read_tag3_state"),
-        "indexed target lanes should lower to independent lane FSMs:\n{sv}");
-    assert!(sv.contains("_tlm_s_read_tag0_req_ready")
-         && sv.contains("_tlm_s_read_tag3_rsp_valid"),
-        "indexed target lanes should use private endpoint wires:\n{sv}");
-    assert!(sv.contains("s_read_req_tag == 2'd0")
-         && sv.contains("s_read_req_tag == 2'd3"),
-        "shared target endpoint should route requests by tag lane:\n{sv}");
-    assert!(sv.contains("s_read_rsp_tag = _tlm_s_read_tag0_rsp_tag")
-         && sv.contains("s_read_rsp_data = _tlm_s_read_tag0_rsp_data"),
-        "shared response endpoint should mux lane responses:\n{sv}");
+    assert!(
+        sv.contains("_tlm_s_read_tag0_state") && sv.contains("_tlm_s_read_tag3_state"),
+        "indexed target lanes should lower to independent lane FSMs:\n{sv}"
+    );
+    assert!(
+        sv.contains("_tlm_s_read_tag0_req_ready") && sv.contains("_tlm_s_read_tag3_rsp_valid"),
+        "indexed target lanes should use private endpoint wires:\n{sv}"
+    );
+    assert!(
+        sv.contains("s_read_req_tag == 2'd0") && sv.contains("s_read_req_tag == 2'd3"),
+        "shared target endpoint should route requests by tag lane:\n{sv}"
+    );
+    assert!(
+        sv.contains("s_read_rsp_tag = _tlm_s_read_tag0_rsp_tag")
+            && sv.contains("s_read_rsp_data = _tlm_s_read_tag0_rsp_data"),
+        "shared response endpoint should mux lane responses:\n{sv}"
+    );
 }
 
 #[test]
@@ -8662,38 +9951,57 @@ fn test_tlm_indexed_target_response_lock_uses_resource_policy() {
         end module MemTarget
     ";
     let sv = compile_to_sv(source);
-    assert!(sv.contains("module _arb_MemTarget_read_rsp"),
-        "response lock should synthesize a policy arbiter module:\n{sv}");
+    assert!(
+        sv.contains("module _arb_MemTarget_read_rsp"),
+        "response lock should synthesize a policy arbiter module:\n{sv}"
+    );
     // Round-robin pointer-advance shape inside the synthesized
     // `_arb_MemTarget_read_rsp` arbiter module — uses the bare
     // `grant_requester` port. The bare `rr_ptr_r + 1` form was incorrect
     // for non-power-of-2 NUM_REQ.
-    assert!(sv.contains("rr_ptr_r <= (grant_requester ==")
-         && sv.contains("? '0 : grant_requester + 1'b1;"),
-        "response arbiter should use the resource's round-robin policy:\n{sv}");
+    assert!(
+        sv.contains("rr_ptr_r <= (grant_requester ==")
+            && sv.contains("? '0 : grant_requester + 1'b1;"),
+        "response arbiter should use the resource's round-robin policy:\n{sv}"
+    );
     assert!(sv.contains("_tlm_s_read_rsp_arb_req_packed[0] = !_tlm_s_read_rsp_arb_hold_valid_r && _tlm_s_read_tag0_rsp_valid")
          && sv.contains("_tlm_s_read_rsp_arb_req_packed[3] = !_tlm_s_read_rsp_arb_hold_valid_r && _tlm_s_read_tag3_rsp_valid"),
         "lane response valids should feed the response arbiter:\n{sv}");
-    assert!(sv.contains("_tlm_s_read_rsp_arb_hold_idx_r == 2'd0 || _tlm_s_read_rsp_arb_grant_packed[0]")
-         && sv.contains("_tlm_s_read_rsp_arb_hold_idx_r == 2'd3 || _tlm_s_read_rsp_arb_grant_packed[3]"),
-        "shared response mux should be gated by the granted lane:\n{sv}");
-    assert!(sv.contains("_tlm_s_read_rsp_arb_hold_valid_r <= 1'd1")
-         && sv.contains("_tlm_s_read_rsp_arb_hold_idx_r <= _tlm_s_read_rsp_arb_grant_requester"),
-        "backpressured response selection should be held stable:\n{sv}");
-    assert!(sv.contains("_tlm_s_read_tag0_rsp_ready = s_read_rsp_ready"),
-        "only the selected lane should receive shared response ready:\n{sv}");
+    assert!(
+        sv.contains(
+            "_tlm_s_read_rsp_arb_hold_idx_r == 2'd0 || _tlm_s_read_rsp_arb_grant_packed[0]"
+        ) && sv.contains(
+            "_tlm_s_read_rsp_arb_hold_idx_r == 2'd3 || _tlm_s_read_rsp_arb_grant_packed[3]"
+        ),
+        "shared response mux should be gated by the granted lane:\n{sv}"
+    );
+    assert!(
+        sv.contains("_tlm_s_read_rsp_arb_hold_valid_r <= 1'd1")
+            && sv.contains("_tlm_s_read_rsp_arb_hold_idx_r <= _tlm_s_read_rsp_arb_grant_requester"),
+        "backpressured response selection should be held stable:\n{sv}"
+    );
+    assert!(
+        sv.contains("_tlm_s_read_tag0_rsp_ready = s_read_rsp_ready"),
+        "only the selected lane should receive shared response ready:\n{sv}"
+    );
 }
 
 #[test]
 fn test_axi_dma_tlm_indexed_burst_target_example_compiles() {
     let source = include_str!("axi_dma_tlm/TlmIndexedBurstTarget.arch");
     let sv = compile_to_sv(source);
-    assert!(sv.contains("module TlmIndexedBurstTarget"),
-        "indexed burst target example should build:\n{sv}");
-    assert!(sv.contains("BoundedVecResp32x4 _tlm_s_read_burst_tag0_rsp_data"),
-        "bounded Vec response should stay struct-typed through target lane lowering:\n{sv}");
-    assert!(sv.contains("s_read_burst_req_tag == 2'd3"),
-        "generated target lanes should route by request tag:\n{sv}");
+    assert!(
+        sv.contains("module TlmIndexedBurstTarget"),
+        "indexed burst target example should build:\n{sv}"
+    );
+    assert!(
+        sv.contains("BoundedVecResp32x4 _tlm_s_read_burst_tag0_rsp_data"),
+        "bounded Vec response should stay struct-typed through target lane lowering:\n{sv}"
+    );
+    assert!(
+        sv.contains("s_read_burst_req_tag == 2'd3"),
+        "generated target lanes should route by request tag:\n{sv}"
+    );
 }
 
 #[test]
@@ -8709,18 +10017,26 @@ fn test_axi_dma_tlm_indexed_burst_target_arch_sim_behavior() {
         .arg(td.path())
         .output()
         .expect("run arch sim for indexed burst target response arbiter");
-    assert!(out.status.success(),
+    assert!(
+        out.status.success(),
         "indexed burst target arch sim should pass\nstdout:\n{}\nstderr:\n{}",
         String::from_utf8_lossy(&out.stdout),
-        String::from_utf8_lossy(&out.stderr));
-    assert!(String::from_utf8_lossy(&out.stdout).contains("PASS indexed response arb"),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&out.stdout).contains("PASS indexed response arb"),
         "expected PASS marker in stdout:\n{}",
-        String::from_utf8_lossy(&out.stdout));
+        String::from_utf8_lossy(&out.stdout)
+    );
 }
 
 #[test]
 fn test_axi_dma_tlm_indexed_burst_target_verilator_behavior() {
-    if std::process::Command::new("verilator").arg("--version").output().is_err() {
+    if std::process::Command::new("verilator")
+        .arg("--version")
+        .output()
+        .is_err()
+    {
         eprintln!("skipping Verilator indexed burst target smoke: verilator not found");
         return;
     }
@@ -8737,10 +10053,12 @@ fn test_axi_dma_tlm_indexed_burst_target_verilator_behavior() {
         .arg(&sv_out)
         .output()
         .expect("build indexed burst target SV");
-    assert!(build.status.success(),
+    assert!(
+        build.status.success(),
         "arch build should pass\nstdout:\n{}\nstderr:\n{}",
         String::from_utf8_lossy(&build.stdout),
-        String::from_utf8_lossy(&build.stderr));
+        String::from_utf8_lossy(&build.stderr)
+    );
 
     let verilate = std::process::Command::new("verilator")
         .arg("--cc")
@@ -8759,34 +10077,46 @@ fn test_axi_dma_tlm_indexed_burst_target_verilator_behavior() {
         .arg("tests/axi_dma_tlm/tb_tlm_indexed_burst_target.cpp")
         .output()
         .expect("verilate indexed burst target");
-    assert!(verilate.status.success(),
+    assert!(
+        verilate.status.success(),
         "Verilator build should pass\nstdout:\n{}\nstderr:\n{}",
         String::from_utf8_lossy(&verilate.stdout),
-        String::from_utf8_lossy(&verilate.stderr));
+        String::from_utf8_lossy(&verilate.stderr)
+    );
 
     let exe = obj_dir.join("VTlmIndexedBurstTarget");
     let run = std::process::Command::new(&exe)
         .output()
         .expect("run Verilator indexed burst target");
-    assert!(run.status.success(),
+    assert!(
+        run.status.success(),
         "Verilator sim should pass\nstdout:\n{}\nstderr:\n{}",
         String::from_utf8_lossy(&run.stdout),
-        String::from_utf8_lossy(&run.stderr));
-    assert!(String::from_utf8_lossy(&run.stdout).contains("PASS indexed response arb"),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&run.stdout).contains("PASS indexed response arb"),
         "expected PASS marker in Verilator stdout:\n{}",
-        String::from_utf8_lossy(&run.stdout));
+        String::from_utf8_lossy(&run.stdout)
+    );
 }
 
 #[test]
 fn test_axi_read_beat_interleave_example_compiles() {
     let source = include_str!("axi_dma_thread/ThreadAxiReadBeatInterleave.arch");
     let sv = compile_to_sv(source);
-    assert!(sv.contains("module ThreadAxiReadBeatInterleave"),
-        "beat-interleaving thread example should build:\n{sv}");
-    assert!(sv.contains("_arb_ThreadAxiReadBeatInterleave_r_ch"),
-        "response channel mutex should lower to a generated arbiter:\n{sv}");
-    assert!(sv.contains("r_id = 1"),
-        "generate_for lanes should become concrete response IDs:\n{sv}");
+    assert!(
+        sv.contains("module ThreadAxiReadBeatInterleave"),
+        "beat-interleaving thread example should build:\n{sv}"
+    );
+    assert!(
+        sv.contains("_arb_ThreadAxiReadBeatInterleave_r_ch"),
+        "response channel mutex should lower to a generated arbiter:\n{sv}"
+    );
+    assert!(
+        sv.contains("r_id = 1"),
+        "generate_for lanes should become concrete response IDs:\n{sv}"
+    );
 }
 
 #[test]
@@ -8802,18 +10132,26 @@ fn test_axi_read_beat_interleave_arch_sim_behavior() {
         .arg(td.path())
         .output()
         .expect("run arch sim for beat-interleaving response target");
-    assert!(out.status.success(),
+    assert!(
+        out.status.success(),
         "beat-interleaving arch sim should pass\nstdout:\n{}\nstderr:\n{}",
         String::from_utf8_lossy(&out.stdout),
-        String::from_utf8_lossy(&out.stderr));
-    assert!(String::from_utf8_lossy(&out.stdout).contains("PASS beat interleave alternating"),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&out.stdout).contains("PASS beat interleave alternating"),
         "expected PASS marker in stdout:\n{}",
-        String::from_utf8_lossy(&out.stdout));
+        String::from_utf8_lossy(&out.stdout)
+    );
 }
 
 #[test]
 fn test_axi_read_beat_interleave_verilator_behavior() {
-    if std::process::Command::new("verilator").arg("--version").output().is_err() {
+    if std::process::Command::new("verilator")
+        .arg("--version")
+        .output()
+        .is_err()
+    {
         eprintln!("skipping Verilator beat-interleaving smoke: verilator not found");
         return;
     }
@@ -8830,10 +10168,12 @@ fn test_axi_read_beat_interleave_verilator_behavior() {
         .arg(&sv_out)
         .output()
         .expect("build beat-interleaving SV");
-    assert!(build.status.success(),
+    assert!(
+        build.status.success(),
         "arch build should pass\nstdout:\n{}\nstderr:\n{}",
         String::from_utf8_lossy(&build.stdout),
-        String::from_utf8_lossy(&build.stderr));
+        String::from_utf8_lossy(&build.stderr)
+    );
 
     let verilate = std::process::Command::new("verilator")
         .arg("--cc")
@@ -8852,22 +10192,28 @@ fn test_axi_read_beat_interleave_verilator_behavior() {
         .arg("tests/axi_dma_thread/tb_axi_read_beat_interleave.cpp")
         .output()
         .expect("verilate beat-interleaving response target");
-    assert!(verilate.status.success(),
+    assert!(
+        verilate.status.success(),
         "Verilator build should pass\nstdout:\n{}\nstderr:\n{}",
         String::from_utf8_lossy(&verilate.stdout),
-        String::from_utf8_lossy(&verilate.stderr));
+        String::from_utf8_lossy(&verilate.stderr)
+    );
 
     let exe = obj_dir.join("VThreadAxiReadBeatInterleave");
     let run = std::process::Command::new(&exe)
         .output()
         .expect("run Verilator beat-interleaving response target");
-    assert!(run.status.success(),
+    assert!(
+        run.status.success(),
         "Verilator sim should pass\nstdout:\n{}\nstderr:\n{}",
         String::from_utf8_lossy(&run.stdout),
-        String::from_utf8_lossy(&run.stderr));
-    assert!(String::from_utf8_lossy(&run.stdout).contains("PASS beat interleave alternating"),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&run.stdout).contains("PASS beat interleave alternating"),
         "expected PASS marker in Verilator stdout:\n{}",
-        String::from_utf8_lossy(&run.stdout));
+        String::from_utf8_lossy(&run.stdout)
+    );
 }
 
 #[test]
@@ -8892,10 +10238,14 @@ fn test_implement_initiator_single_compiles_end_to_end() {
         end module M
     ";
     let sv = compile_to_sv(source);
-    assert!(sv.contains("_tlm_init_driver_state"),
-        "single-implementer initiator should use v1 inline lowering:\n{sv}");
-    assert!(sv.contains("m_read_req_valid") && sv.contains("m_read_rsp_ready"),
-        "bus signals should be driven:\n{sv}");
+    assert!(
+        sv.contains("_tlm_init_driver_state"),
+        "single-implementer initiator should use v1 inline lowering:\n{sv}"
+    );
+    assert!(
+        sv.contains("m_read_req_valid") && sv.contains("m_read_rsp_ready"),
+        "bus signals should be driven:\n{sv}"
+    );
 }
 
 #[test]
@@ -8925,12 +10275,14 @@ fn test_implement_initiator_multi_implementer_compiles_end_to_end() {
         end module M
     ";
     let sv = compile_to_sv(source);
-    assert!(sv.contains("_tlm_init_w0_state")
-         && sv.contains("_tlm_init_w1_state"),
-        "multi-implementer initiator should lower both workers:\n{sv}");
-    assert!(sv.contains("m_read_req_valid")
-         && sv.contains("m_read_rsp_ready"),
-        "shared method driver should still drive req/rsp handshake:\n{sv}");
+    assert!(
+        sv.contains("_tlm_init_w0_state") && sv.contains("_tlm_init_w1_state"),
+        "multi-implementer initiator should lower both workers:\n{sv}"
+    );
+    assert!(
+        sv.contains("m_read_req_valid") && sv.contains("m_read_rsp_ready"),
+        "shared method driver should still drive req/rsp handshake:\n{sv}"
+    );
 }
 
 #[test]
@@ -8955,7 +10307,10 @@ fn test_implement_initiator_with_args_in_parens_errors() {
     let tokens = arch::lexer::tokenize(source).expect("lexer");
     let mut parser = arch::parser::Parser::new(tokens, source);
     let r = parser.parse_source_file();
-    assert!(r.is_err(), "initiator implement with args should be a parse error");
+    assert!(
+        r.is_err(),
+        "initiator implement with args should be a parse error"
+    );
 }
 
 #[test]
@@ -8985,14 +10340,18 @@ fn test_tlm_multi_thread_direct_calls_lower_to_in_order_pool() {
         end module Shared
     ";
     let sv = compile_to_sv(source);
-    assert!(sv.contains("_tlm_pool_m_read_fifo"),
-        "cohort lowering should emit issue-order FIFO:\n{sv}");
-    assert!(sv.contains("_tlm_pool_m_read_t0_state")
-         && sv.contains("_tlm_pool_m_read_t1_state"),
-        "cohort lowering should emit per-thread state regs:\n{sv}");
-    assert!(sv.contains("m_read_req_valid")
-         && sv.contains("m_read_rsp_ready"),
-        "cohort lowering should drive shared TLM handshakes:\n{sv}");
+    assert!(
+        sv.contains("_tlm_pool_m_read_fifo"),
+        "cohort lowering should emit issue-order FIFO:\n{sv}"
+    );
+    assert!(
+        sv.contains("_tlm_pool_m_read_t0_state") && sv.contains("_tlm_pool_m_read_t1_state"),
+        "cohort lowering should emit per-thread state regs:\n{sv}"
+    );
+    assert!(
+        sv.contains("m_read_req_valid") && sv.contains("m_read_rsp_ready"),
+        "cohort lowering should drive shared TLM handshakes:\n{sv}"
+    );
 }
 
 #[test]
@@ -9018,12 +10377,16 @@ fn test_tlm_generate_for_workers_share_method() {
         end module Shared
     ";
     let sv = compile_to_sv(source);
-    assert!(sv.contains("_tlm_pool_m_read_fifo"),
-        "generated worker cohort should use pooled TLM lowering:\n{sv}");
-    assert!(sv.contains("data[0] <= m_read_rsp_data")
-         && sv.contains("data[1] <= m_read_rsp_data")
-         && sv.contains("data[2] <= m_read_rsp_data"),
-        "each generated worker should capture its routed response:\n{sv}");
+    assert!(
+        sv.contains("_tlm_pool_m_read_fifo"),
+        "generated worker cohort should use pooled TLM lowering:\n{sv}"
+    );
+    assert!(
+        sv.contains("data[0] <= m_read_rsp_data")
+            && sv.contains("data[1] <= m_read_rsp_data")
+            && sv.contains("data[2] <= m_read_rsp_data"),
+        "each generated worker should capture its routed response:\n{sv}"
+    );
 }
 
 #[test]
@@ -9051,11 +10414,14 @@ fn test_tlm_fork_join_workers_share_method() {
         end module Shared
     ";
     let sv = compile_to_sv(source);
-    assert!(sv.contains("_tlm_pool_m_read_fifo"),
-        "fork/join TLM workers should use pooled TLM lowering:\n{sv}");
-    assert!(sv.contains("data[0] <= m_read_rsp_data")
-         && sv.contains("data[1] <= m_read_rsp_data"),
-        "fork/join worker responses should route by issue order:\n{sv}");
+    assert!(
+        sv.contains("_tlm_pool_m_read_fifo"),
+        "fork/join TLM workers should use pooled TLM lowering:\n{sv}"
+    );
+    assert!(
+        sv.contains("data[0] <= m_read_rsp_data") && sv.contains("data[1] <= m_read_rsp_data"),
+        "fork/join worker responses should route by issue order:\n{sv}"
+    );
 }
 
 #[test]
@@ -9082,13 +10448,18 @@ fn test_tlm_rhs_fork_join_all_workers_share_method() {
         end module Shared
     ";
     let sv = compile_to_sv(source);
-    assert!(sv.contains("_tlm_fork_workers_m_read_age"),
-        "forked RHS TLM lowering should emit an issue-age counter:\n{sv}");
-    assert!(sv.contains("_tlm_fork_workers_m_read_fifo"),
-        "blocking forked RHS TLM should route responses by issue-order FIFO:\n{sv}");
-    assert!(sv.contains("data[0] <= m_read_rsp_data")
-         && sv.contains("data[1] <= m_read_rsp_data"),
-        "forked RHS worker responses should capture routed data:\n{sv}");
+    assert!(
+        sv.contains("_tlm_fork_workers_m_read_age"),
+        "forked RHS TLM lowering should emit an issue-age counter:\n{sv}"
+    );
+    assert!(
+        sv.contains("_tlm_fork_workers_m_read_fifo"),
+        "blocking forked RHS TLM should route responses by issue-order FIFO:\n{sv}"
+    );
+    assert!(
+        sv.contains("data[0] <= m_read_rsp_data") && sv.contains("data[1] <= m_read_rsp_data"),
+        "forked RHS worker responses should capture routed data:\n{sv}"
+    );
 }
 
 #[test]
@@ -9118,7 +10489,10 @@ fn test_tlm_rhs_fork_requires_join_all() {
     let r = arch::elaborate::lower_tlm_initiator_calls(ast);
     assert!(r.is_err(), "forked RHS TLM calls should require join all");
     let msg = format!("{:?}", r.unwrap_err());
-    assert!(msg.contains("join all"), "expected join-all diagnostic, got: {msg}");
+    assert!(
+        msg.contains("join all"),
+        "expected join-all diagnostic, got: {msg}"
+    );
 }
 
 #[test]
@@ -9180,11 +10554,14 @@ fn test_tlm_cohort_multi_arg_method() {
         end module Shared
     ";
     let sv = compile_to_sv(source);
-    assert!(sv.contains("_tlm_pool_m_read_fifo"),
-        "multi-arg method should use pooled TLM lowering:\n{sv}");
-    assert!(sv.contains("m_read_addr")
-         && sv.contains("m_read_len"),
-        "cohort lowering should mux every method arg:\n{sv}");
+    assert!(
+        sv.contains("_tlm_pool_m_read_fifo"),
+        "multi-arg method should use pooled TLM lowering:\n{sv}"
+    );
+    assert!(
+        sv.contains("m_read_addr") && sv.contains("m_read_len"),
+        "cohort lowering should mux every method arg:\n{sv}"
+    );
 }
 
 #[test]
@@ -9219,8 +10596,10 @@ fn test_tlm_unsupported_fork_join_call_errors() {
     let r = arch::elaborate::lower_tlm_initiator_calls(ast);
     assert!(r.is_err(), "unsupported fork/join TLM shape should error");
     let msg = format!("{:?}", r.unwrap_err());
-    assert!(msg.contains("multi-thread sharing") || msg.contains("TLM initiator thread body"),
-        "expected targeted TLM fork/join error, got: {msg}");
+    assert!(
+        msg.contains("multi-thread sharing") || msg.contains("TLM initiator thread body"),
+        "expected targeted TLM fork/join error, got: {msg}"
+    );
 }
 
 #[test]
@@ -9248,14 +10627,18 @@ fn test_tlm_out_of_order_fork_join_routes_by_tag() {
         end module Shared
     ";
     let sv = compile_to_sv(source);
-    assert!(sv.contains("m_read_req_tag"),
-        "out-of-order cohort should drive request tags:\n{sv}");
-    assert!(sv.contains("m_read_rsp_tag == 2'd0")
-         && sv.contains("m_read_rsp_tag == 2'd1"),
-        "out-of-order cohort should route responses by rsp_tag:\n{sv}");
-    assert!(sv.contains("data[0] <= m_read_rsp_data")
-         && sv.contains("data[1] <= m_read_rsp_data"),
-        "tag-routed responses should capture into each worker destination:\n{sv}");
+    assert!(
+        sv.contains("m_read_req_tag"),
+        "out-of-order cohort should drive request tags:\n{sv}"
+    );
+    assert!(
+        sv.contains("m_read_rsp_tag == 2'd0") && sv.contains("m_read_rsp_tag == 2'd1"),
+        "out-of-order cohort should route responses by rsp_tag:\n{sv}"
+    );
+    assert!(
+        sv.contains("data[0] <= m_read_rsp_data") && sv.contains("data[1] <= m_read_rsp_data"),
+        "tag-routed responses should capture into each worker destination:\n{sv}"
+    );
 }
 
 #[test]
@@ -9282,12 +10665,14 @@ fn test_tlm_rhs_fork_out_of_order_routes_by_tag() {
         end module Shared
     ";
     let sv = compile_to_sv(source);
-    assert!(sv.contains("m_read_req_tag")
-         && sv.contains("m_read_rsp_tag"),
-        "OOO forked RHS TLM should drive and consume tag wires:\n{sv}");
-    assert!(sv.contains("m_read_rsp_tag == 2'd0")
-         && sv.contains("m_read_rsp_tag == 2'd1"),
-        "OOO forked RHS responses should route by worker tag:\n{sv}");
+    assert!(
+        sv.contains("m_read_req_tag") && sv.contains("m_read_rsp_tag"),
+        "OOO forked RHS TLM should drive and consume tag wires:\n{sv}"
+    );
+    assert!(
+        sv.contains("m_read_rsp_tag == 2'd0") && sv.contains("m_read_rsp_tag == 2'd1"),
+        "OOO forked RHS responses should route by worker tag:\n{sv}"
+    );
 }
 
 #[test]
@@ -9340,7 +10725,11 @@ fn test_tlm_rhs_fork_tail_arch_sim_behavior() {
 
 #[test]
 fn test_tlm_rhs_fork_tail_verilator_behavior() {
-    if std::process::Command::new("verilator").arg("--version").output().is_err() {
+    if std::process::Command::new("verilator")
+        .arg("--version")
+        .output()
+        .is_err()
+    {
         eprintln!("skipping Verilator RHS-fork tail smoke: verilator not found");
         return;
     }
@@ -9415,9 +10804,11 @@ fn test_axi_dma_tlm_burst_vec_example_compiles() {
     assert!(sv.contains("mem_read_burst_req_tag"));
     assert!(sv.contains("mem_read_burst_rsp_tag"));
     assert!(sv.contains("_tlm_fork_issue_bursts_mem_read_burst"));
-    assert!(sv.contains("mem_read_burst_rsp_tag == 2'd0")
-        && sv.contains("mem_read_burst_rsp_tag == 2'd1"),
-        "burst Vec OOO responses should route by worker tag:\n{sv}");
+    assert!(
+        sv.contains("mem_read_burst_rsp_tag == 2'd0")
+            && sv.contains("mem_read_burst_rsp_tag == 2'd1"),
+        "burst Vec OOO responses should route by worker tag:\n{sv}"
+    );
 
     let sim = compile_to_sim_h(source, false);
     assert!(
@@ -9425,11 +10816,18 @@ fn test_axi_dma_tlm_burst_vec_example_compiles() {
             && sim.contains("uint32_t& mem_read_burst_rsp_data_0;"),
         "sim API should preserve Vec response lanes as an array with flat aliases:\n{sim}"
     );
-    assert!(sim.contains("uint32_t _mem_read_burst_rsp_data[4];"),
-        "sim model should mirror the flattened Vec response as an internal array:\n{sim}");
-    assert!(sim.contains("for (size_t _i = 0; _i < 4; ++_i) { _n_burst0_r[_i] = _mem_read_burst_rsp_data[_i]; }")
-        && sim.contains("for (size_t _i = 0; _i < 4; ++_i) { _n_burst1_r[_i] = _mem_read_burst_rsp_data[_i]; }"),
-        "burst Vec responses should copy into both destination arrays:\n{sim}");
+    assert!(
+        sim.contains("uint32_t _mem_read_burst_rsp_data[4];"),
+        "sim model should mirror the flattened Vec response as an internal array:\n{sim}"
+    );
+    assert!(
+        sim.contains(
+            "for (size_t _i = 0; _i < 4; ++_i) { _n_burst0_r[_i] = _mem_read_burst_rsp_data[_i]; }"
+        ) && sim.contains(
+            "for (size_t _i = 0; _i < 4; ++_i) { _n_burst1_r[_i] = _mem_read_burst_rsp_data[_i]; }"
+        ),
+        "burst Vec responses should copy into both destination arrays:\n{sim}"
+    );
 }
 
 #[test]
@@ -9582,10 +10980,14 @@ fn test_tlm_out_of_order_target_echoes_tag() {
         end module MemTarget
     ";
     let sv = compile_to_sv(source);
-    assert!(sv.contains("_tlm_s_read_tag_latched"),
-        "target should latch accepted request tag:\n{sv}");
-    assert!(sv.contains("s_read_rsp_tag = _tlm_s_read_tag_latched"),
-        "target should echo the latched tag on response:\n{sv}");
+    assert!(
+        sv.contains("_tlm_s_read_tag_latched"),
+        "target should latch accepted request tag:\n{sv}"
+    );
+    assert!(
+        sv.contains("s_read_rsp_tag = _tlm_s_read_tag_latched"),
+        "target should echo the latched tag on response:\n{sv}"
+    );
 }
 
 #[test]
@@ -9617,8 +11019,10 @@ fn test_tlm_call_rejected_outside_seq_assign_rhs() {
     let r = arch::elaborate::lower_tlm_initiator_calls(ast);
     assert!(r.is_err(), "nested TLM call in RHS should be rejected");
     let msg = format!("{:?}", r.unwrap_err());
-    assert!(msg.contains("direct right-hand side") || msg.contains("direct"),
-        "expected direct-RHS error, got: {msg}");
+    assert!(
+        msg.contains("direct right-hand side") || msg.contains("direct"),
+        "expected direct-RHS error, got: {msg}"
+    );
 }
 
 #[test]
@@ -9737,18 +11141,26 @@ fn test_tlm_conditional_initiator_arch_sim_behavior() {
         .arg(td.path())
         .output()
         .expect("run arch sim for conditional TLM initiator");
-    assert!(out.status.success(),
+    assert!(
+        out.status.success(),
         "conditional TLM initiator arch sim should pass\nstdout:\n{}\nstderr:\n{}",
         String::from_utf8_lossy(&out.stdout),
-        String::from_utf8_lossy(&out.stderr));
-    assert!(String::from_utf8_lossy(&out.stdout).contains("PASS TlmConditionalInitiator"),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&out.stdout).contains("PASS TlmConditionalInitiator"),
         "expected PASS marker in stdout:\n{}",
-        String::from_utf8_lossy(&out.stdout));
+        String::from_utf8_lossy(&out.stdout)
+    );
 }
 
 #[test]
 fn test_tlm_conditional_initiator_verilator_behavior() {
-    if std::process::Command::new("verilator").arg("--version").output().is_err() {
+    if std::process::Command::new("verilator")
+        .arg("--version")
+        .output()
+        .is_err()
+    {
         eprintln!("skipping Verilator conditional TLM smoke: verilator not found");
         return;
     }
@@ -9765,10 +11177,12 @@ fn test_tlm_conditional_initiator_verilator_behavior() {
         .arg(&sv_out)
         .output()
         .expect("build conditional TLM initiator SV");
-    assert!(build.status.success(),
+    assert!(
+        build.status.success(),
         "arch build should pass\nstdout:\n{}\nstderr:\n{}",
         String::from_utf8_lossy(&build.stdout),
-        String::from_utf8_lossy(&build.stderr));
+        String::from_utf8_lossy(&build.stderr)
+    );
 
     let verilate = std::process::Command::new("verilator")
         .arg("--cc")
@@ -9787,22 +11201,28 @@ fn test_tlm_conditional_initiator_verilator_behavior() {
         .arg("tests/axi_dma_tlm/tb_tlm_conditional_initiator.cpp")
         .output()
         .expect("verilate conditional TLM initiator");
-    assert!(verilate.status.success(),
+    assert!(
+        verilate.status.success(),
         "Verilator build should pass\nstdout:\n{}\nstderr:\n{}",
         String::from_utf8_lossy(&verilate.stdout),
-        String::from_utf8_lossy(&verilate.stderr));
+        String::from_utf8_lossy(&verilate.stderr)
+    );
 
     let exe = obj_dir.join("VTlmConditionalInitiator");
     let run = std::process::Command::new(&exe)
         .output()
         .expect("run Verilator conditional TLM initiator");
-    assert!(run.status.success(),
+    assert!(
+        run.status.success(),
         "Verilator sim should pass\nstdout:\n{}\nstderr:\n{}",
         String::from_utf8_lossy(&run.stdout),
-        String::from_utf8_lossy(&run.stderr));
-    assert!(String::from_utf8_lossy(&run.stdout).contains("PASS TlmConditionalInitiator"),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&run.stdout).contains("PASS TlmConditionalInitiator"),
         "expected PASS marker in Verilator stdout:\n{}",
-        String::from_utf8_lossy(&run.stdout));
+        String::from_utf8_lossy(&run.stdout)
+    );
 }
 
 #[test]
@@ -9814,8 +11234,7 @@ fn test_fpt26_runtime_loop_tlm_initiator_compiles() {
         "runtime TLM for loop should allocate a loop counter:\n{sv}"
     );
     assert!(
-        sv.contains("assign hbm_read_k_req_valid")
-            && sv.contains("assign qk_qk_tile_req_valid"),
+        sv.contains("assign hbm_read_k_req_valid") && sv.contains("assign qk_qk_tile_req_valid"),
         "runtime loop should still drive both serialized TLM request channels:\n{sv}"
     );
 }
@@ -9861,18 +11280,26 @@ fn test_fpt26_runtime_loop_tlm_arch_sim_behavior() {
         .arg(td.path())
         .output()
         .expect("run arch sim for FPT26 runtime-loop TLM");
-    assert!(out.status.success(),
+    assert!(
+        out.status.success(),
         "FPT26 runtime-loop TLM arch sim should pass\nstdout:\n{}\nstderr:\n{}",
         String::from_utf8_lossy(&out.stdout),
-        String::from_utf8_lossy(&out.stderr));
-    assert!(String::from_utf8_lossy(&out.stdout).contains("PASS Fpt26RuntimeLoopTlm"),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&out.stdout).contains("PASS Fpt26RuntimeLoopTlm"),
         "expected PASS marker in stdout:\n{}",
-        String::from_utf8_lossy(&out.stdout));
+        String::from_utf8_lossy(&out.stdout)
+    );
 }
 
 #[test]
 fn test_fpt26_runtime_loop_tlm_verilator_behavior() {
-    if std::process::Command::new("verilator").arg("--version").output().is_err() {
+    if std::process::Command::new("verilator")
+        .arg("--version")
+        .output()
+        .is_err()
+    {
         eprintln!("skipping Verilator runtime-loop TLM smoke: verilator not found");
         return;
     }
@@ -9889,10 +11316,12 @@ fn test_fpt26_runtime_loop_tlm_verilator_behavior() {
         .arg(&sv_out)
         .output()
         .expect("build FPT26 runtime-loop TLM SV");
-    assert!(build.status.success(),
+    assert!(
+        build.status.success(),
         "arch build should pass\nstdout:\n{}\nstderr:\n{}",
         String::from_utf8_lossy(&build.stdout),
-        String::from_utf8_lossy(&build.stderr));
+        String::from_utf8_lossy(&build.stderr)
+    );
 
     let verilate = std::process::Command::new("verilator")
         .arg("--cc")
@@ -9912,22 +11341,28 @@ fn test_fpt26_runtime_loop_tlm_verilator_behavior() {
         .arg("tests/fpt26_tlm/tb_fpt26_runtime_loop_tlm.cpp")
         .output()
         .expect("verilate FPT26 runtime-loop TLM");
-    assert!(verilate.status.success(),
+    assert!(
+        verilate.status.success(),
         "Verilator build should pass\nstdout:\n{}\nstderr:\n{}",
         String::from_utf8_lossy(&verilate.stdout),
-        String::from_utf8_lossy(&verilate.stderr));
+        String::from_utf8_lossy(&verilate.stderr)
+    );
 
     let exe = obj_dir.join("VFpt26RuntimeLoopTlm");
     let run = std::process::Command::new(&exe)
         .output()
         .expect("run Verilator FPT26 runtime-loop TLM");
-    assert!(run.status.success(),
+    assert!(
+        run.status.success(),
         "Verilator sim should pass\nstdout:\n{}\nstderr:\n{}",
         String::from_utf8_lossy(&run.stdout),
-        String::from_utf8_lossy(&run.stderr));
-    assert!(String::from_utf8_lossy(&run.stdout).contains("PASS Fpt26RuntimeLoopTlm"),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&run.stdout).contains("PASS Fpt26RuntimeLoopTlm"),
         "expected PASS marker in Verilator stdout:\n{}",
-        String::from_utf8_lossy(&run.stdout));
+        String::from_utf8_lossy(&run.stdout)
+    );
 }
 
 #[test]
@@ -10085,14 +11520,22 @@ fn test_tlm_target_thread_lowers_inline_to_state_machine() {
         end module MemTarget
     ";
     let sv = compile_to_sv(source);
-    assert!(sv.contains("_tlm_s_read_state"),
-        "state register should appear in SV:\n{sv}");
-    assert!(sv.contains("_tlm_s_read_addr_latched"),
-        "arg latch reg should appear in SV:\n{sv}");
-    assert!(sv.contains("s_read_req_ready"),
-        "req_ready driver should appear in SV:\n{sv}");
-    assert!(sv.contains("s_read_rsp_valid"),
-        "rsp_valid driver should appear in SV:\n{sv}");
+    assert!(
+        sv.contains("_tlm_s_read_state"),
+        "state register should appear in SV:\n{sv}"
+    );
+    assert!(
+        sv.contains("_tlm_s_read_addr_latched"),
+        "arg latch reg should appear in SV:\n{sv}"
+    );
+    assert!(
+        sv.contains("s_read_req_ready"),
+        "req_ready driver should appear in SV:\n{sv}"
+    );
+    assert!(
+        sv.contains("s_read_rsp_valid"),
+        "rsp_valid driver should appear in SV:\n{sv}"
+    );
 }
 
 #[test]
@@ -10115,10 +11558,14 @@ fn test_tlm_target_thread_accepts_wait_cycles_before_return() {
         end module MemTarget
     ";
     let sv = compile_to_sv(source);
-    assert!(sv.contains("_tlm_s_read_wait_cnt"),
-        "wait-cycle target should allocate a counter:\n{sv}");
-    assert!(sv.contains("32'd6"),
-        "wait 7 cycle should initialize the counter to 6:\n{sv}");
+    assert!(
+        sv.contains("_tlm_s_read_wait_cnt"),
+        "wait-cycle target should allocate a counter:\n{sv}"
+    );
+    assert!(
+        sv.contains("32'd6"),
+        "wait 7 cycle should initialize the counter to 6:\n{sv}"
+    );
 }
 
 #[test]
@@ -10204,7 +11651,11 @@ fn test_tlm_target_thread_rich_body_thread_sim_both() {
 
 #[test]
 fn test_tlm_target_thread_rich_body_verilator_behavior() {
-    if std::process::Command::new("verilator").arg("--version").output().is_err() {
+    if std::process::Command::new("verilator")
+        .arg("--version")
+        .output()
+        .is_err()
+    {
         eprintln!("skipping Verilator rich TLM target smoke: verilator not found");
         return;
     }
@@ -10350,7 +11801,11 @@ fn test_tlm_target_thread_early_return_thread_sim_both() {
 
 #[test]
 fn test_tlm_target_thread_early_return_verilator_behavior() {
-    if std::process::Command::new("verilator").arg("--version").output().is_err() {
+    if std::process::Command::new("verilator")
+        .arg("--version")
+        .output()
+        .is_err()
+    {
         eprintln!("skipping Verilator early-return TLM target smoke: verilator not found");
         return;
     }
@@ -10474,15 +11929,26 @@ fn test_tlm_target_thread_parses_return_stmt() {
     let tokens = arch::lexer::tokenize(source).expect("lexer");
     let mut parser = arch::parser::Parser::new(tokens, source);
     let ast = parser.parse_source_file().expect("parse");
-    let m = ast.items.iter().find_map(|it| match it {
-        arch::ast::Item::Module(m) if m.name.name == "MemTarget" => Some(m),
-        _ => None,
-    }).expect("MemTarget in AST");
-    let t = m.body.iter().find_map(|i| match i {
-        arch::ast::ModuleBodyItem::Thread(t) => Some(t),
-        _ => None,
-    }).expect("thread in body");
-    let has_return = t.body.iter().any(|s| matches!(s, arch::ast::ThreadStmt::Return(_, _)));
+    let m = ast
+        .items
+        .iter()
+        .find_map(|it| match it {
+            arch::ast::Item::Module(m) if m.name.name == "MemTarget" => Some(m),
+            _ => None,
+        })
+        .expect("MemTarget in AST");
+    let t = m
+        .body
+        .iter()
+        .find_map(|i| match i {
+            arch::ast::ModuleBodyItem::Thread(t) => Some(t),
+            _ => None,
+        })
+        .expect("thread in body");
+    let has_return = t
+        .body
+        .iter()
+        .any(|s| matches!(s, arch::ast::ThreadStmt::Return(_, _)));
     assert!(has_return, "body should contain a Return stmt");
 }
 
@@ -10513,8 +11979,10 @@ fn test_return_in_regular_thread_errors_in_lower_threads() {
     let result = arch::elaborate::lower_threads(ast);
     assert!(result.is_err(), "regular thread with return should error");
     let msg = format!("{:?}", result.unwrap_err());
-    assert!(msg.contains("return") && msg.contains("TLM method target thread"),
-        "expected targeted error, got: {msg}");
+    assert!(
+        msg.contains("return") && msg.contains("TLM method target thread"),
+        "expected targeted error, got: {msg}"
+    );
 }
 
 #[test]
@@ -10539,8 +12007,10 @@ fn test_tlm_target_thread_accepts_matched_closing_method_name() {
     ";
     let tokens = arch::lexer::tokenize(source).expect("lexer");
     let mut parser = arch::parser::Parser::new(tokens, source);
-    assert!(parser.parse_source_file().is_err(),
-        "mismatched closing method name should be a parse error");
+    assert!(
+        parser.parse_source_file().is_err(),
+        "mismatched closing method name should be a parse error"
+    );
 }
 
 #[test]
@@ -10562,16 +12032,26 @@ fn test_tlm_method_target_perspective_flips() {
         end module Target
     ";
     let sv = compile_to_sv(source);
-    assert!(sv.contains("input logic s_read_req_valid"),
-        "target perspective: req_valid should be an input:\n{sv}");
-    assert!(sv.contains("output logic s_read_req_ready"),
-        "target perspective: req_ready flows back as output:\n{sv}");
-    assert!(sv.contains("output logic s_read_rsp_valid"),
-        "target perspective: rsp_valid is output:\n{sv}");
-    assert!(sv.contains("output logic [63:0] s_read_rsp_data"),
-        "target perspective: rsp_data is output:\n{sv}");
-    assert!(sv.contains("input logic s_read_rsp_ready"),
-        "target perspective: rsp_ready flows back as input:\n{sv}");
+    assert!(
+        sv.contains("input logic s_read_req_valid"),
+        "target perspective: req_valid should be an input:\n{sv}"
+    );
+    assert!(
+        sv.contains("output logic s_read_req_ready"),
+        "target perspective: req_ready flows back as output:\n{sv}"
+    );
+    assert!(
+        sv.contains("output logic s_read_rsp_valid"),
+        "target perspective: rsp_valid is output:\n{sv}"
+    );
+    assert!(
+        sv.contains("output logic [63:0] s_read_rsp_data"),
+        "target perspective: rsp_data is output:\n{sv}"
+    );
+    assert!(
+        sv.contains("input logic s_read_rsp_ready"),
+        "target perspective: rsp_ready flows back as input:\n{sv}"
+    );
 }
 
 #[test]
@@ -10585,8 +12065,10 @@ fn test_tlm_method_unsupported_modes_rejected() {
         let tokens = arch::lexer::tokenize(&source).expect("lexer");
         let mut parser = arch::parser::Parser::new(tokens, &source);
         let result = parser.parse_source_file();
-        assert!(result.is_err(),
-            "mode `{mode}` should be rejected in v1: source={source}");
+        assert!(
+            result.is_err(),
+            "mode `{mode}` should be rejected in v1: source={source}"
+        );
     }
 }
 
@@ -10602,8 +12084,10 @@ fn test_credit_channel_mismatched_closing_keyword_errors() {
     ";
     let tokens = arch::lexer::tokenize(source).expect("lexer");
     let mut parser = arch::parser::Parser::new(tokens, source);
-    assert!(parser.parse_source_file().is_err(),
-        "mismatched credit_channel close should be a parse error");
+    assert!(
+        parser.parse_source_file().is_err(),
+        "mismatched credit_channel close should be a parse error"
+    );
 }
 
 #[test]
@@ -10620,7 +12104,10 @@ fn test_handshake_mismatched_closing_keyword_errors() {
     let tokens = arch::lexer::tokenize(source).expect("lexer");
     let mut parser = arch::parser::Parser::new(tokens, source);
     let result = parser.parse_source_file();
-    assert!(result.is_err(), "expected parse error for mismatched opening/closing keyword");
+    assert!(
+        result.is_err(),
+        "expected parse error for mismatched opening/closing keyword"
+    );
 }
 
 #[test]
@@ -10635,8 +12122,10 @@ fn test_temporal_sva_past_emits_dollar_past() {
         end module M
     "#;
     let sv = compile_to_sv(source);
-    assert!(sv.contains("$past(b, 2)"),
-        "past(b, 2) should emit SV $past(b, 2):\n{sv}");
+    assert!(
+        sv.contains("$past(b, 2)"),
+        "past(b, 2) should emit SV $past(b, 2):\n{sv}"
+    );
 }
 
 #[test]
@@ -10651,8 +12140,10 @@ fn test_temporal_sva_implies_next_emits_pipe_arrow() {
         end module M
     "#;
     let sv = compile_to_sv(source);
-    assert!(sv.contains("a |=> b"),
-        "a |=> b should emit SV a |=> b:\n{sv}");
+    assert!(
+        sv.contains("a |=> b"),
+        "a |=> b should emit SV a |=> b:\n{sv}"
+    );
 }
 
 #[test]
@@ -10677,8 +12168,10 @@ fn test_past_outside_assert_rejected() {
     let result = checker.check();
     assert!(result.is_err(), "past() outside assert should be rejected");
     let errs = result.err().unwrap();
-    assert!(errs.iter().any(|e| format!("{e:?}").contains("past")),
-        "error should mention past: {errs:?}");
+    assert!(
+        errs.iter().any(|e| format!("{e:?}").contains("past")),
+        "error should mention past: {errs:?}"
+    );
 }
 
 #[test]
@@ -10720,7 +12213,10 @@ fn test_past_arity_errors() {
     let ast = elaborate::elaborate(parsed_ast).expect("elaborate");
     let symbols = resolve::resolve(&ast).expect("resolve");
     let checker = TypeChecker::new(&symbols, &ast);
-    assert!(checker.check().is_err(), "past with wrong arity should error");
+    assert!(
+        checker.check().is_err(),
+        "past with wrong arity should error"
+    );
 }
 
 #[test]
@@ -10782,7 +12278,10 @@ fn test_phase2_hashhash_emits_sva_delay() {
         end module M
     "#;
     let sv = compile_to_sv(source);
-    assert!(sv.contains("##2 b") || sv.contains("##2b"), "expected ##2 in SV:\n{sv}");
+    assert!(
+        sv.contains("##2 b") || sv.contains("##2b"),
+        "expected ##2 in SV:\n{sv}"
+    );
 }
 
 #[test]
@@ -10802,7 +12301,10 @@ fn test_phase2_rose_outside_assert_rejected() {
     let ast = elaborate::elaborate(parsed_ast).expect("elaborate");
     let symbols = resolve::resolve(&ast).expect("resolve");
     let checker = TypeChecker::new(&symbols, &ast);
-    assert!(checker.check().is_err(), "rose() outside assert should be rejected");
+    assert!(
+        checker.check().is_err(),
+        "rose() outside assert should be rejected"
+    );
 }
 
 #[test]
@@ -10822,7 +12324,10 @@ fn test_phase2_hashhash_outside_assert_rejected() {
     let ast = elaborate::elaborate(parsed_ast).expect("elaborate");
     let symbols = resolve::resolve(&ast).expect("resolve");
     let checker = TypeChecker::new(&symbols, &ast);
-    assert!(checker.check().is_err(), "##N outside assert should be rejected");
+    assert!(
+        checker.check().is_err(),
+        "##N outside assert should be rejected"
+    );
 }
 
 #[test]
@@ -10870,13 +12375,19 @@ fn test_inst_site_type_param_override_translates_to_data_width() {
     "#;
     let sv = compile_to_sv(source);
     // Type param `T = UInt<W>` should translate to `.DATA_WIDTH(W)` in the SV inst.
-    assert!(sv.contains(".DATA_WIDTH(W)"),
-        "type override `T = UInt<W>` should emit `.DATA_WIDTH(W)`:\n{sv}");
-    assert!(sv.contains(".DEPTH(4)"),
-        "value override `DEPTH = 4` should emit `.DEPTH(4)`:\n{sv}");
+    assert!(
+        sv.contains(".DATA_WIDTH(W)"),
+        "type override `T = UInt<W>` should emit `.DATA_WIDTH(W)`:\n{sv}"
+    );
+    assert!(
+        sv.contains(".DEPTH(4)"),
+        "value override `DEPTH = 4` should emit `.DEPTH(4)`:\n{sv}"
+    );
     // Sanity: no `.T(...)` raw type in the inst — the fifo doesn't expose `T` at SV level.
-    assert!(!sv.contains(".T(logic"),
-        "should not emit raw `.T(logic ...)` for fifo whose T was synthesized to DATA_WIDTH:\n{sv}");
+    assert!(
+        !sv.contains(".T(logic"),
+        "should not emit raw `.T(logic ...)` for fifo whose T was synthesized to DATA_WIDTH:\n{sv}"
+    );
 }
 
 #[test]
@@ -10904,9 +12415,18 @@ fn test_pipe_reg_tap_reads_q_at_k() {
         end module M
     "#;
     let sv = compile_to_sv(source);
-    assert!(sv.contains("assign o0 = a;"), "q@0 should be source `a`:\n{sv}");
-    assert!(sv.contains("assign o1 = q_stg1;"), "q@1 should be q_stg1:\n{sv}");
-    assert!(sv.contains("assign o2 = q_stg2;"), "q@2 should be q_stg2:\n{sv}");
+    assert!(
+        sv.contains("assign o0 = a;"),
+        "q@0 should be source `a`:\n{sv}"
+    );
+    assert!(
+        sv.contains("assign o1 = q_stg1;"),
+        "q@1 should be q_stg1:\n{sv}"
+    );
+    assert!(
+        sv.contains("assign o2 = q_stg2;"),
+        "q@2 should be q_stg2:\n{sv}"
+    );
     assert!(sv.contains("assign o3 = q;"), "q@3 should be bare q:\n{sv}");
 }
 
@@ -10930,8 +12450,11 @@ fn test_pipe_reg_tap_out_of_range_errors() {
     let result = elaborate::lower_pipe_reg_ports(parsed_ast);
     assert!(result.is_err(), "q@4 should be rejected for stages=3");
     let errs = result.err().unwrap();
-    assert!(errs.iter().any(|e| format!("{e:?}").contains("exceeds pipe_reg depth")),
-        "error should mention depth: {errs:?}");
+    assert!(
+        errs.iter()
+            .any(|e| format!("{e:?}").contains("exceeds pipe_reg depth")),
+        "error should mention depth: {errs:?}"
+    );
 }
 
 #[test]
@@ -10961,10 +12484,14 @@ fn test_fsm_sint_uses_arithmetic_shift() {
         end fsm F
     "#;
     let sv = compile_to_sv(source);
-    assert!(sv.contains("a >>> 1"),
-        "fsm-scope SInt port `a` shifted right should emit `>>>` (arithmetic):\n{sv}");
-    assert!(!sv.contains("a >> 1"),
-        "should not emit `>>` (logical) for SInt:\n{sv}");
+    assert!(
+        sv.contains("a >>> 1"),
+        "fsm-scope SInt port `a` shifted right should emit `>>>` (arithmetic):\n{sv}"
+    );
+    assert!(
+        !sv.contains("a >> 1"),
+        "should not emit `>>` (logical) for SInt:\n{sv}"
+    );
 }
 
 #[test]
@@ -10980,14 +12507,20 @@ fn test_vec_of_const_param_emits_packed_and_indexes() {
         end module M
     "#;
     let sv = compile_to_sv(source);
-    assert!(sv.contains("parameter logic [(4)*(8)-1:0] coeffs"),
-        "expected packed parameter:\n{sv}");
+    assert!(
+        sv.contains("parameter logic [(4)*(8)-1:0] coeffs"),
+        "expected packed parameter:\n{sv}"
+    );
     // Default packed in reverse so coeffs[0] = parts[0] = 1 (LSB).
-    assert!(sv.contains("(8)'(4), (8)'(3), (8)'(2), (8)'(1)"),
-        "expected reversed default chunks (MSB-first packing):\n{sv}");
+    assert!(
+        sv.contains("(8)'(4), (8)'(3), (8)'(2), (8)'(1)"),
+        "expected reversed default chunks (MSB-first packing):\n{sv}"
+    );
     // Indexing rewritten to part-select.
-    assert!(sv.contains("coeffs[(0) * (8) +: (8)]"),
-        "expected coeffs[0] → coeffs[(0) * (8) +: (8)]:\n{sv}");
+    assert!(
+        sv.contains("coeffs[(0) * (8) +: (8)]"),
+        "expected coeffs[0] → coeffs[(0) * (8) +: (8)]:\n{sv}"
+    );
 }
 
 #[test]
@@ -11009,11 +12542,15 @@ fn test_uint_as_vec_cast_for_find_first() {
     "#;
     let sv = compile_to_sv(source);
     // No bit-unpack `for` loop or intermediate Vec wire.
-    assert!(!sv.contains("for ("),
-        "should not synthesize a for-loop bit unpack:\n{sv}");
+    assert!(
+        !sv.contains("for ("),
+        "should not synthesize a for-loop bit unpack:\n{sv}"
+    );
     // Should index `d[i]` directly in the priority encoder.
-    assert!(sv.contains("d[0]") && sv.contains("d[7]"),
-        "expected direct bit indexing of `d`:\n{sv}");
+    assert!(
+        sv.contains("d[0]") && sv.contains("d[7]"),
+        "expected direct bit indexing of `d`:\n{sv}"
+    );
 }
 
 #[test]
@@ -11036,14 +12573,20 @@ fn test_counter_runtime_max_port() {
     "#;
     let sv = compile_to_sv(source);
     // Wrap compare uses the runtime `max` port, not a const.
-    assert!(sv.contains("count_r == max"),
-        "expected wrap compare against `max` port:\n{sv}");
+    assert!(
+        sv.contains("count_r == max"),
+        "expected wrap compare against `max` port:\n{sv}"
+    );
     // at_max output mirrors the same compare.
-    assert!(sv.contains("assign at_max = (count_r == max)"),
-        "expected at_max against `max` port:\n{sv}");
+    assert!(
+        sv.contains("assign at_max = (count_r == max)"),
+        "expected at_max against `max` port:\n{sv}"
+    );
     // No const MAX appears (no MAX param declared).
-    assert!(!sv.contains("'(MAX)"),
-        "should not emit const MAX comparator when port is present:\n{sv}");
+    assert!(
+        !sv.contains("'(MAX)"),
+        "should not emit const MAX comparator when port is present:\n{sv}"
+    );
 }
 
 // ── Wait-1-cycle elision optimisation ─────────────────────────────────────────
@@ -11081,19 +12624,25 @@ fn test_wait_1_cycle_between_seq_writes_takes_one_cycle() {
     // The dedicated wait_cycles state's body decrements a counter and
     // checks `_t0_cnt == 0`; its absence means `wait 1 cycle` produced
     // no extra state between the phase writes.
-    assert!(!sv.contains("_t0_cnt <= 32'(_t0_cnt - 32'd1);"),
-        "should not emit counter-decrement state for `wait 1 cycle`:\n{sv}");
+    assert!(
+        !sv.contains("_t0_cnt <= 32'(_t0_cnt - 32'd1);"),
+        "should not emit counter-decrement state for `wait 1 cycle`:\n{sv}"
+    );
     // Three phase writes appear, each transitioning to the next state.
     // State numbering after elision: 0=initial wait, 1=phase=1,
     // 2=phase=2, 3=phase=3, then loop back to 0. Issue #247 changed
     // state assignments to reference per-state `localparam` names
     // (`_t0_S<N>_<role>`) instead of bare numeric literals.
-    assert!(sv.contains("phase <= 2'd1;") && sv.contains("phase <= 2'd2;")
+    assert!(
+        sv.contains("phase <= 2'd1;")
+            && sv.contains("phase <= 2'd2;")
             && sv.contains("phase <= 2'd3;"),
-        "expected three phase writes:\n{sv}");
-    assert!(sv.contains("_t0_state <= _t0_S2_action;")
-            && sv.contains("_t0_state <= _t0_S3_action;"),
-        "expected state transitions 1->2 and 2->3 via state-name localparams:\n{sv}");
+        "expected three phase writes:\n{sv}"
+    );
+    assert!(
+        sv.contains("_t0_state <= _t0_S2_action;") && sv.contains("_t0_state <= _t0_S3_action;"),
+        "expected state transitions 1->2 and 2->3 via state-name localparams:\n{sv}"
+    );
 }
 
 #[test]
@@ -11128,8 +12677,10 @@ fn test_wait_1_cycle_in_else_branch_kept() {
         end module M
     "#;
     let sv = compile_to_sv(source);
-    assert!(sv.contains("module _M_threads"),
-        "thread with wait-1-cycle in else branch should compile:\n{sv}");
+    assert!(
+        sv.contains("module _M_threads"),
+        "thread with wait-1-cycle in else branch should compile:\n{sv}"
+    );
 }
 
 #[test]
@@ -11152,8 +12703,14 @@ fn test_lowered_threads_codegen_has_no_extra_blank_separator_or_eof_blank() {
         end module M
     "#;
     let sv = compile_to_sv(source);
-    assert!(sv.contains("module _M_threads"), "expected lowered helper:\n{sv}");
-    assert!(sv.contains("endmodule\nmodule M"), "expected tight helper/public boundary:\n{sv}");
+    assert!(
+        sv.contains("module _M_threads"),
+        "expected lowered helper:\n{sv}"
+    );
+    assert!(
+        sv.contains("endmodule\nmodule M"),
+        "expected tight helper/public boundary:\n{sv}"
+    );
     assert!(
         !sv.contains("endmodule\n\nmodule M"),
         "helper/public boundary must not contain a blank separator:\n{sv}"
@@ -11170,8 +12727,10 @@ fn test_lowered_threads_codegen_has_no_extra_blank_separator_or_eof_blank() {
 fn test_auto_thread_asserts_off_by_default() {
     let source = include_str!("../tests/thread/wait_cycles.arch");
     let sv = compile_to_sv(source);
-    assert!(!sv.contains("_auto_thread_"),
-        "default lowering must not emit auto-thread asserts:\n{sv}");
+    assert!(
+        !sv.contains("_auto_thread_"),
+        "default lowering must not emit auto-thread asserts:\n{sv}"
+    );
 }
 
 #[test]
@@ -11181,32 +12740,49 @@ fn test_auto_thread_asserts_wait_cycles_and_until() {
     // emit, wrapped in `synopsys translate_off/on`, with reset-guarded
     // antecedents.
     let source = include_str!("../tests/thread/wait_cycles.arch");
-    let opts = elaborate::ThreadLowerOpts { auto_asserts: true, ..Default::default() };
+    let opts = elaborate::ThreadLowerOpts {
+        auto_asserts: true,
+        ..Default::default()
+    };
     let sv = compile_to_sv_with_opts(source, &opts);
 
     // Wait-until: state 0 transitions on `start`. Issue #247 changed
     // state comparisons in auto-asserts to reference per-state
     // `localparam` names (`_t0_S<N>_<role>`) instead of bare literals.
-    assert!(sv.contains("_auto_thread_t0_wait_until_s0:"),
-        "expected wait_until property at state 0:\n{sv}");
-    assert!(sv.contains("|=> _t0_state == _t0_S1_wait_cycles"),
-        "expected next-cycle implication to state 1 (wait_cycles) via state-name localparam:\n{sv}");
+    assert!(
+        sv.contains("_auto_thread_t0_wait_until_s0:"),
+        "expected wait_until property at state 0:\n{sv}"
+    );
+    assert!(
+        sv.contains("|=> _t0_state == _t0_S1_wait_cycles"),
+        "expected next-cycle implication to state 1 (wait_cycles) via state-name localparam:\n{sv}"
+    );
 
     // Wait-cycles: stay + done assertions.
-    assert!(sv.contains("_auto_thread_t0_wait_stay_s1:"),
-        "expected wait-cycles stay assertion:\n{sv}");
-    assert!(sv.contains("_auto_thread_t0_wait_done_s1:"),
-        "expected wait-cycles done assertion:\n{sv}");
+    assert!(
+        sv.contains("_auto_thread_t0_wait_stay_s1:"),
+        "expected wait-cycles stay assertion:\n{sv}"
+    );
+    assert!(
+        sv.contains("_auto_thread_t0_wait_done_s1:"),
+        "expected wait-cycles done assertion:\n{sv}"
+    );
 
     // Reset guard: rst_n is active-low, so `not_in_reset == rst_n`.
-    assert!(sv.contains("rst_n &&"),
-        "expected reset guard `rst_n && ...` in antecedent:\n{sv}");
+    assert!(
+        sv.contains("rst_n &&"),
+        "expected reset guard `rst_n && ...` in antecedent:\n{sv}"
+    );
 
     // SVA wrapped in translate_off/on (so synth ignores it).
-    assert!(sv.contains("// synopsys translate_off"),
-        "expected translate_off wrapping:\n{sv}");
-    assert!(sv.contains("// synopsys translate_on"),
-        "expected translate_on wrapping:\n{sv}");
+    assert!(
+        sv.contains("// synopsys translate_off"),
+        "expected translate_off wrapping:\n{sv}"
+    );
+    assert!(
+        sv.contains("// synopsys translate_on"),
+        "expected translate_on wrapping:\n{sv}"
+    );
 }
 
 #[test]
@@ -11214,10 +12790,15 @@ fn test_auto_thread_asserts_fork_join_branches() {
     // fork/join produces multi_transitions. Each branch transition gets
     // an `_auto_thread_t{i}_branch_s{s}_b{b}` assertion.
     let source = include_str!("../tests/thread/fork_join.arch");
-    let opts = elaborate::ThreadLowerOpts { auto_asserts: true, ..Default::default() };
+    let opts = elaborate::ThreadLowerOpts {
+        auto_asserts: true,
+        ..Default::default()
+    };
     let sv = compile_to_sv_with_opts(source, &opts);
-    assert!(sv.contains("_auto_thread_t0_branch_s"),
-        "expected at least one fork/join branch assertion:\n{sv}");
+    assert!(
+        sv.contains("_auto_thread_t0_branch_s"),
+        "expected at least one fork/join branch assertion:\n{sv}"
+    );
 }
 
 #[test]
@@ -11237,18 +12818,26 @@ fn test_auto_thread_asserts_active_high_reset() {
           end thread
         end module M
     "#;
-    let opts = elaborate::ThreadLowerOpts { auto_asserts: true, ..Default::default() };
+    let opts = elaborate::ThreadLowerOpts {
+        auto_asserts: true,
+        ..Default::default()
+    };
     let sv = compile_to_sv_with_opts(source, &opts);
-    assert!(sv.contains("!rst &&"),
-        "expected `!rst` guard for active-high reset:\n{sv}");
-    assert!(!sv.contains("(rst) &&"),
-        "should not use bare `rst` as guard for active-high:\n{sv}");
+    assert!(
+        sv.contains("!rst &&"),
+        "expected `!rst` guard for active-high reset:\n{sv}"
+    );
+    assert!(
+        !sv.contains("(rst) &&"),
+        "should not use bare `rst` as guard for active-high:\n{sv}"
+    );
 }
 
 // ── Thread map HTML sidecar ──────────────────────────────────────────────────
 
 fn thread_map_smoke_source(module_name: &str) -> String {
-    format!(r#"
+    format!(
+        r#"
         module {module_name}
           port clk:  in Clock<SysDomain>;
           port rst:  in Reset<Async, Low>;
@@ -11261,11 +12850,13 @@ fn thread_map_smoke_source(module_name: &str) -> String {
             wait 2 cycle;
           end thread T
         end module {module_name}
-    "#)
+    "#
+    )
 }
 
 fn thread_map_control_flow_source(module_name: &str) -> String {
-    format!(r#"
+    format!(
+        r#"
         module {module_name}
           port clk:  in Clock<SysDomain>;
           port rst:  in Reset<Async, Low>;
@@ -11284,7 +12875,106 @@ fn thread_map_control_flow_source(module_name: &str) -> String {
             wait 1 cycle;
           end thread T
         end module {module_name}
-    "#)
+    "#
+    )
+}
+
+fn thread_proof_fold_source(module_name: &str) -> String {
+    format!(
+        r#"
+        module {module_name}
+          port clk:  in Clock<SysDomain>;
+          port rst:  in Reset<Async, Low>;
+          port go:   in Bool;
+          port done: out Bool;
+          reg done_r: Bool reset rst => false;
+          thread T on clk rising, rst low
+            done_r <= false;
+            wait until go;
+            done_r <= true;
+            wait 2 cycle;
+            done_r <= false;
+          end thread T
+          comb
+            done = done_r;
+          end comb
+        end module {module_name}
+    "#
+    )
+}
+
+fn thread_proof_multi_seq_source(module_name: &str) -> String {
+    format!(
+        r#"
+        module {module_name}
+          port clk:  in Clock<SysDomain>;
+          port rst:  in Reset<Async, Low>;
+          port go:   in Bool;
+          port a: out Bool;
+          port b: out Bool;
+          reg a_r: Bool reset rst => false;
+          reg b_r: Bool reset rst => false;
+          thread T on clk rising, rst low
+            a_r <= true;
+            b_r <= false;
+            wait until go;
+            a_r <= false;
+            b_r <= true;
+            wait 1 cycle;
+          end thread T
+          comb
+            a = a_r;
+            b = b_r;
+          end comb
+        end module {module_name}
+    "#
+    )
+}
+
+fn thread_proof_once_source(module_name: &str) -> String {
+    format!(
+        r#"
+        module {module_name}
+          port clk:  in Clock<SysDomain>;
+          port rst:  in Reset<Async, Low>;
+          port go:   in Bool;
+          port done: out Bool;
+          reg done_r: Bool reset rst => false;
+          thread once T on clk rising, rst low
+            wait until go;
+            wait 2 cycle;
+            done_r <= true;
+          end thread T
+          comb
+            done = done_r;
+          end comb
+        end module {module_name}
+    "#
+    )
+}
+
+fn thread_proof_once_folded_terminal_source(module_name: &str) -> String {
+    format!(
+        r#"
+        module {module_name}
+          port clk:       in Clock<SysDomain>;
+          port rst:       in Reset<Async, Low>;
+          port go:        in Bool;
+          port start:     out Bool;
+          port done:      out Bool;
+          reg done_r: Bool reset rst => false;
+          thread once T on clk rising, rst low
+            start = true;
+            wait until go;
+            start = false;
+            done_r <= true;
+          end thread T
+          comb
+            done = done_r;
+          end comb
+        end module {module_name}
+    "#
+    )
 }
 
 #[test]
@@ -11304,16 +12994,34 @@ fn test_build_emit_thread_map_bare_path() {
         .arg("--emit-thread-map")
         .output()
         .expect("run arch build --emit-thread-map");
-    assert!(out.status.success(),
+    assert!(
+        out.status.success(),
         "build should pass\nstdout:\n{}\nstderr:\n{}",
         String::from_utf8_lossy(&out.stdout),
-        String::from_utf8_lossy(&out.stderr));
-    assert!(html_out.exists(), "expected bare flag to write {}", html_out.display());
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        html_out.exists(),
+        "expected bare flag to write {}",
+        html_out.display()
+    );
     let html = std::fs::read_to_string(&html_out).expect("read thread map");
-    assert!(html.contains("_t0_S0_wait_until"), "expected generated state name in HTML:\n{html}");
-    assert!(html.contains("thread-flow-chart"), "expected flow chart in HTML:\n{html}");
-    assert!(html.contains("wait until go"), "expected source line in HTML:\n{html}");
-    assert!(html.contains("done = 1"), "expected source assignment in HTML:\n{html}");
+    assert!(
+        html.contains("_t0_S0_wait_until"),
+        "expected generated state name in HTML:\n{html}"
+    );
+    assert!(
+        html.contains("thread-flow-chart"),
+        "expected flow chart in HTML:\n{html}"
+    );
+    assert!(
+        html.contains("wait until go"),
+        "expected source line in HTML:\n{html}"
+    );
+    assert!(
+        html.contains("done = 1"),
+        "expected source assignment in HTML:\n{html}"
+    );
 }
 
 #[test]
@@ -11333,11 +13041,742 @@ fn test_build_emit_thread_map_explicit_path() {
         .arg(format!("--emit-thread-map={}", html_out.display()))
         .output()
         .expect("run arch build --emit-thread-map=path");
-    assert!(out.status.success(),
+    assert!(
+        out.status.success(),
         "build should pass\nstdout:\n{}\nstderr:\n{}",
         String::from_utf8_lossy(&out.stdout),
-        String::from_utf8_lossy(&out.stderr));
-    assert!(html_out.exists(), "expected explicit map path to be written");
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        html_out.exists(),
+        "expected explicit map path to be written"
+    );
+}
+
+#[test]
+fn test_build_emit_thread_proof_records_folded_target() {
+    let td = tempfile::tempdir().expect("tempdir");
+    let src = td.path().join("ProofFlow.arch");
+    let sv_out = td.path().join("ProofFlow.sv");
+    let proof_out = td.path().join("ProofFlow.thread-proof.json");
+    std::fs::write(&src, thread_proof_fold_source("ProofFlow")).expect("write source");
+
+    let out = std::process::Command::new(env!("CARGO_BIN_EXE_arch"))
+        .env("ARCH_NO_LEARN", "1")
+        .arg("build")
+        .arg(&src)
+        .arg("-o")
+        .arg(&sv_out)
+        .arg("--emit-thread-proof")
+        .output()
+        .expect("run arch build --emit-thread-proof");
+    assert!(
+        out.status.success(),
+        "build should pass\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let json = std::fs::read_to_string(&proof_out).expect("read proof certificate");
+    assert!(
+        json.contains("\"schema\": \"arch.thread_lowering_proof.v5\""),
+        "expected schema in proof certificate:\n{json}"
+    );
+    assert!(
+        json.contains("\"state_name\": \"_t0_S1_wait_until\""),
+        "expected wait_until state in proof certificate:\n{json}"
+    );
+    assert!(
+        json.contains("\"target_index\": 3"),
+        "folded wait state should target the emitted wait_cycles state:\n{json}"
+    );
+    assert!(
+        json.contains("\"source_next_index\": 3"),
+        "folded wait source-next should skip the absorbed action state:\n{json}"
+    );
+    assert!(
+        json.contains("\"source_next_name\": \"_t0_S3_wait_cycles\""),
+        "folded wait source-next name should identify the emitted wait state:\n{json}"
+    );
+    assert!(
+        json.contains("\"state_name\": \"_t0_S2_action\""),
+        "expected absorbed action state to remain documented:\n{json}"
+    );
+    assert!(
+        json.contains("\"emitted\": false"),
+        "expected absorbed action state to be marked non-emitted:\n{json}"
+    );
+    assert!(
+        json.contains("\"wait_cycles_count\": \"2\""),
+        "expected structured wait-cycle count in proof certificate:\n{json}"
+    );
+    assert!(
+        json.contains("\"seq_updates\": [\"done_r <= false\"]"),
+        "expected entry state's ordinary update in proof certificate:\n{json}"
+    );
+    assert!(
+        json.contains("\"folded_exit_updates\": [\"done_r <= true\"]"),
+        "expected folded wait-exit update in proof certificate:\n{json}"
+    );
+    assert!(
+        json.contains("\"seq_assignments\": [{\"target\": \"done_r\", \"value\": \"false\"}]"),
+        "expected structured ordinary assignment in proof certificate:\n{json}"
+    );
+    assert!(
+        json.contains(
+            "\"folded_exit_assignments\": [{\"target\": \"done_r\", \"value\": \"true\"}]"
+        ),
+        "expected structured folded assignment in proof certificate:\n{json}"
+    );
+    assert!(
+        json.contains("\"source_transitions\": [{\"condition\": \"go\""),
+        "expected compacted pre-fold source transition in proof certificate:\n{json}"
+    );
+    assert!(
+        json.contains("\"condition_guard\": {\"kind\":\"atom\",\"name\":\"go\"}"),
+        "expected structured source transition guard in proof certificate:\n{json}"
+    );
+    assert!(
+        json.contains("\"target_index\": 3")
+            && json.contains("\"target_name\": \"_t0_S3_wait_cycles\""),
+        "expected compacted pre-fold source transition target in proof certificate:\n{json}"
+    );
+    assert!(
+        json.contains("\"source_transition_origin\": \"pre_fold_snapshot\""),
+        "expected source transition provenance in proof certificate:\n{json}"
+    );
+
+    let sv = std::fs::read_to_string(&sv_out).expect("read sv");
+    assert!(
+        sv.contains("_t0_state <= _t0_S3_wait_cycles"),
+        "SV should skip folded S2 and jump to S3:\n{sv}"
+    );
+}
+
+#[test]
+fn test_build_emit_thread_proof_lean_proves_multi_assignment_store_effects() {
+    let td = tempfile::tempdir().expect("tempdir");
+    let src = td.path().join("ProofMulti.arch");
+    let sv_out = td.path().join("ProofMulti.sv");
+    let lean_out = td.path().join("ProofMulti.thread-proof.lean");
+    std::fs::write(&src, thread_proof_multi_seq_source("ProofMulti")).expect("write source");
+
+    let out = std::process::Command::new(env!("CARGO_BIN_EXE_arch"))
+        .env("ARCH_NO_LEARN", "1")
+        .arg("build")
+        .arg(&src)
+        .arg("-o")
+        .arg(&sv_out)
+        .arg("--emit-thread-proof-lean")
+        .output()
+        .expect("run arch build --emit-thread-proof-lean");
+    assert!(
+        out.status.success(),
+        "build should pass\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let lean = std::fs::read_to_string(&lean_out).expect("read Lean proof certificate");
+    assert!(
+        lean.contains("[Arch.ThreadLoweringProof.FoldedExit.setVar 0 0, Arch.ThreadLoweringProof.FoldedExit.setVar 1 1]"),
+        "Lean artifact should model both assignments in one action update list:\n{lean}"
+    );
+    assert!(
+        lean.contains("Arch.ThreadLoweringProof.FoldedExit.applyUpdates ProofMulti_T_0__t0_S0_entry_seq_0Updates store 0 = 0"),
+        "Lean artifact should prove the first assignment's final store effect:\n{lean}"
+    );
+    assert!(
+        lean.contains("Arch.ThreadLoweringProof.FoldedExit.applyUpdates ProofMulti_T_0__t0_S0_entry_seq_0Updates store 1 = 1"),
+        "Lean artifact should prove the second assignment's final store effect:\n{lean}"
+    );
+    assert!(
+        lean.contains("((Arch.ThreadLoweringProof.FoldedExit.sourceStep ProofMulti_T_0__t0_S1_wait_until_folded_0Source env natEnv cfg).store 0 = 1)")
+            && lean.contains("((Arch.ThreadLoweringProof.FoldedExit.sourceStep ProofMulti_T_0__t0_S1_wait_until_folded_0Source env natEnv cfg).store 1 = 0)"),
+        "Lean artifact should prove folded multi-assignment source store effects:\n{lean}"
+    );
+    assert!(
+        lean.contains("((Arch.ThreadLoweringProof.FoldedExit.fsmStep ProofMulti_T_0__t0_S1_wait_until_folded_0Fsm env natEnv cfg).store 0 = 1)")
+            && lean.contains("((Arch.ThreadLoweringProof.FoldedExit.fsmStep ProofMulti_T_0__t0_S1_wait_until_folded_0Fsm env natEnv cfg).store 1 = 0)"),
+        "Lean artifact should prove folded multi-assignment FSM store effects:\n{lean}"
+    );
+}
+
+#[test]
+fn test_build_emit_thread_proof_lean_records_replay_artifact() {
+    let td = tempfile::tempdir().expect("tempdir");
+    let src = td.path().join("ProofFlow.arch");
+    let sv_out = td.path().join("ProofFlow.sv");
+    let lean_out = td.path().join("ProofFlow.thread-proof.lean");
+    std::fs::write(&src, thread_proof_fold_source("ProofFlow")).expect("write source");
+
+    let out = std::process::Command::new(env!("CARGO_BIN_EXE_arch"))
+        .env("ARCH_NO_LEARN", "1")
+        .arg("build")
+        .arg(&src)
+        .arg("-o")
+        .arg(&sv_out)
+        .arg("--emit-thread-proof-lean")
+        .output()
+        .expect("run arch build --emit-thread-proof-lean");
+    assert!(
+        out.status.success(),
+        "build should pass\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        lean_out.exists(),
+        "expected bare flag to write {}",
+        lean_out.display()
+    );
+
+    let lean = std::fs::read_to_string(&lean_out).expect("read Lean proof certificate");
+    assert!(
+        lean.contains("import ArchThreadLoweringProof.CountedWait"),
+        "Lean artifact should import the CountedWait model:\n{lean}"
+    );
+    assert!(
+        lean.contains(
+            "forall t, sourceTraceObs ProofFlow_T_0Source inputs natInputs cfg0 t = fsmTraceObs ProofFlow_T_0Fsm inputs natInputs cfg0 t"
+        ),
+        "Lean artifact should include an unbounded trace-equivalence theorem:\n{lean}"
+    );
+    assert!(
+        lean.contains("Control.waitUntil (GuardExpr.atom 0)"),
+        "Lean artifact should carry structured CountedWait guard expressions:\n{lean}"
+    );
+    assert!(
+        lean.contains("Arch.ThreadLoweringProof.FoldedExit.Control.waitUntil (Arch.ThreadLoweringProof.FoldedExit.GuardExpr.atom 0)"),
+        "Lean artifact should carry structured FoldedExit guard expressions:\n{lean}"
+    );
+    assert!(
+        lean.contains("ProofFlow_T_0__t0_S0_entry_seq_0Updates"),
+        "Lean artifact should define ordinary seq-assignment update proofs:\n{lean}"
+    );
+    assert!(
+        lean.contains("Arch.ThreadLoweringProof.FoldedExit.applyUpdates ProofFlow_T_0__t0_S0_entry_seq_0Updates store 0 = 0"),
+        "Lean artifact should prove the ordinary assignment's store effect:\n{lean}"
+    );
+    assert!(
+        !lean.contains("Control.waitUntil 0"),
+        "Lean artifact should not use opaque numeric guard IDs in controls:\n{lean}"
+    );
+}
+
+#[test]
+fn test_build_check_thread_proof_lean_missing_project_fails_cleanly() {
+    let td = tempfile::tempdir().expect("tempdir");
+    let src = td.path().join("ProofFlow.arch");
+    let sv_out = td.path().join("ProofFlow.sv");
+    let missing_project = td.path().join("missing_lean_project");
+    std::fs::write(&src, thread_proof_fold_source("ProofFlow")).expect("write source");
+
+    let out = std::process::Command::new(env!("CARGO_BIN_EXE_arch"))
+        .env("ARCH_NO_LEARN", "1")
+        .arg("build")
+        .arg(&src)
+        .arg("-o")
+        .arg(&sv_out)
+        .arg("--check-thread-proof-lean")
+        .arg(format!(
+            "--thread-proof-lean-project={}",
+            missing_project.display()
+        ))
+        .output()
+        .expect("run arch build --check-thread-proof-lean");
+    assert!(
+        !out.status.success(),
+        "build should fail when Lean project is missing\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("Lean thread proof project not found"),
+        "expected clean missing-project diagnostic, got:\n{stderr}"
+    );
+    assert!(
+        td.path().join("ProofFlow.thread-proof.lean").exists(),
+        "check mode should still emit the replay artifact before checking"
+    );
+}
+
+#[test]
+fn test_formal_emit_thread_proof_lean_writes_artifact_before_smt_run() {
+    let td = tempfile::tempdir().expect("tempdir");
+    let src = td.path().join("ProofEq.arch");
+    let proof_out = td.path().join("ProofEq.thread-proof.lean");
+    std::fs::write(
+        &src,
+        r#"
+module ProofEq
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port idx: in UInt<3>;
+  port done: out pipe_reg<Bool, 1> reset rst => false;
+
+  thread T on clk rising, rst high
+    wait until idx == 2;
+    wait until idx != 1;
+    done <= true;
+  end thread T
+end module ProofEq
+"#,
+    )
+    .expect("write source");
+
+    let out = std::process::Command::new(env!("CARGO_BIN_EXE_arch"))
+        .env("ARCH_NO_LEARN", "1")
+        .arg("formal")
+        .arg(&src)
+        .arg("--bound")
+        .arg("2")
+        .arg("--timeout")
+        .arg("5")
+        .arg(format!(
+            "--emit-thread-proof-lean={}",
+            proof_out.to_string_lossy()
+        ))
+        .output()
+        .expect("run arch formal --emit-thread-proof-lean");
+
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains(&format!("Wrote {}", proof_out.display())),
+        "formal command should write the Lean proof before SMT handoff\nstatus: {}\nstdout:\n{}\nstderr:\n{}",
+        out.status,
+        String::from_utf8_lossy(&out.stdout),
+        stderr
+    );
+    let lean = std::fs::read_to_string(&proof_out).expect("read Lean proof");
+    assert!(
+        lean.contains("GuardExpr.eq") && lean.contains("GuardExpr.ne"),
+        "formal-emitted Lean proof should preserve structured equality guards:\n{lean}"
+    );
+}
+
+#[test]
+fn test_formal_thread_proof_only_skips_smt_backend() {
+    let td = tempfile::tempdir().expect("tempdir");
+    let src = td.path().join("ProofEq.arch");
+    let proof_out = td.path().join("ProofEq.thread-proof.lean");
+    std::fs::write(
+        &src,
+        r#"
+module ProofEq
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port idx: in UInt<3>;
+  port done: out pipe_reg<Bool, 1> reset rst => false;
+
+  thread T on clk rising, rst high
+    wait until idx == 2;
+    wait until idx != 1;
+    done <= true;
+  end thread T
+end module ProofEq
+"#,
+    )
+    .expect("write source");
+
+    let out = std::process::Command::new(env!("CARGO_BIN_EXE_arch"))
+        .env("ARCH_NO_LEARN", "1")
+        .arg("formal")
+        .arg(&src)
+        .arg(format!(
+            "--emit-thread-proof-lean={}",
+            proof_out.to_string_lossy()
+        ))
+        .arg("--thread-proof-only")
+        .output()
+        .expect("run arch formal --thread-proof-only");
+
+    assert!(
+        out.status.success(),
+        "thread-proof-only should skip the SMT backend\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !stderr.contains("unknown identifier"),
+        "thread-proof-only should not reach the current SMT thread limitation:\n{stderr}"
+    );
+    let lean = std::fs::read_to_string(&proof_out).expect("read Lean proof");
+    assert!(
+        lean.contains("GuardExpr.eq") && lean.contains("GuardExpr.ne"),
+        "proof-only formal mode should emit the Lean certificate:\n{lean}"
+    );
+}
+
+#[test]
+fn test_formal_thread_proof_only_requires_lean_output() {
+    let td = tempfile::tempdir().expect("tempdir");
+    let src = td.path().join("Plain.arch");
+    std::fs::write(
+        &src,
+        r#"
+module Plain
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port a: in UInt<4>;
+  port b: out pipe_reg<UInt<4>, 1> reset rst => 0;
+
+  seq on clk rising
+    b <= a;
+  end seq
+end module Plain
+"#,
+    )
+    .expect("write source");
+
+    let out = std::process::Command::new(env!("CARGO_BIN_EXE_arch"))
+        .env("ARCH_NO_LEARN", "1")
+        .arg("formal")
+        .arg(&src)
+        .arg("--thread-proof-only")
+        .output()
+        .expect("run arch formal --thread-proof-only");
+
+    assert!(
+        !out.status.success(),
+        "thread-proof-only without Lean output/check should fail\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("--thread-proof-only requires --emit-thread-proof-lean"),
+        "expected thread-proof-only guardrail diagnostic, got:\n{stderr}"
+    );
+}
+
+#[test]
+fn test_formal_check_thread_proof_lean_missing_project_fails_cleanly() {
+    let td = tempfile::tempdir().expect("tempdir");
+    let src = td.path().join("ProofFlow.arch");
+    let proof_out = td.path().join("ProofFlow.thread-proof.lean");
+    let missing_project = td.path().join("missing_lean_project");
+    std::fs::write(&src, thread_proof_fold_source("ProofFlow")).expect("write source");
+
+    let out = std::process::Command::new(env!("CARGO_BIN_EXE_arch"))
+        .env("ARCH_NO_LEARN", "1")
+        .arg("formal")
+        .arg(&src)
+        .arg("--bound")
+        .arg("2")
+        .arg("--timeout")
+        .arg("5")
+        .arg(format!(
+            "--emit-thread-proof-lean={}",
+            proof_out.to_string_lossy()
+        ))
+        .arg("--check-thread-proof-lean")
+        .arg(format!(
+            "--thread-proof-lean-project={}",
+            missing_project.to_string_lossy()
+        ))
+        .output()
+        .expect("run arch formal --check-thread-proof-lean");
+
+    assert!(
+        !out.status.success(),
+        "missing Lean project should fail before SMT run\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("Lean thread proof project not found"),
+        "expected clean missing-project diagnostic, got:\n{stderr}"
+    );
+    assert!(
+        proof_out.exists(),
+        "Lean proof should still be written before replay failure"
+    );
+}
+
+#[test]
+fn test_build_emit_thread_proof_records_once_terminal_hold() {
+    let td = tempfile::tempdir().expect("tempdir");
+    let src = td.path().join("ProofOnce.arch");
+    let sv_out = td.path().join("ProofOnce.sv");
+    let proof_out = td.path().join("ProofOnce.thread-proof.json");
+    std::fs::write(&src, thread_proof_once_source("ProofOnce")).expect("write source");
+
+    let out = std::process::Command::new(env!("CARGO_BIN_EXE_arch"))
+        .env("ARCH_NO_LEARN", "1")
+        .arg("build")
+        .arg(&src)
+        .arg("-o")
+        .arg(&sv_out)
+        .arg("--emit-thread-proof")
+        .output()
+        .expect("run arch build --emit-thread-proof");
+    assert!(
+        out.status.success(),
+        "build should pass\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let json = std::fs::read_to_string(&proof_out).expect("read proof certificate");
+    assert!(
+        json.contains("\"once\": true"),
+        "expected one-shot thread flag in proof certificate:\n{json}"
+    );
+    assert!(
+        json.contains("\"state_name\": \"_t0_S2_action\""),
+        "expected terminal action state in proof certificate:\n{json}"
+    );
+    assert!(
+        json.contains("\"target_index\": 2"),
+        "thread once terminal state should hold instead of wrapping:\n{json}"
+    );
+    assert!(
+        json.contains("\"source_next_index\": 2"),
+        "thread once terminal source-next should hold instead of wrapping:\n{json}"
+    );
+
+    let sv = std::fs::read_to_string(&sv_out).expect("read sv");
+    assert!(
+        sv.contains("_t0_state <= _t0_S2_action"),
+        "SV terminal state should hold in S2:\n{sv}"
+    );
+}
+
+#[test]
+fn test_build_emit_thread_proof_lean_accepts_once_folded_terminal_action() {
+    let td = tempfile::tempdir().expect("tempdir");
+    let src = td.path().join("ProofOnceFold.arch");
+    let sv_out = td.path().join("ProofOnceFold.sv");
+    let lean_out = td.path().join("ProofOnceFold.thread-proof.lean");
+    std::fs::write(
+        &src,
+        thread_proof_once_folded_terminal_source("ProofOnceFold"),
+    )
+    .expect("write source");
+
+    let out = std::process::Command::new(env!("CARGO_BIN_EXE_arch"))
+        .env("ARCH_NO_LEARN", "1")
+        .arg("build")
+        .arg(&src)
+        .arg("-o")
+        .arg(&sv_out)
+        .arg("--emit-thread-proof-lean")
+        .output()
+        .expect("run arch build --emit-thread-proof-lean");
+    assert!(
+        out.status.success(),
+        "build should pass\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let lean = std::fs::read_to_string(&lean_out).expect("read Lean proof certificate");
+    assert!(
+        lean.contains("once := true"),
+        "Lean artifact should model one-shot thread hold semantics:\n{lean}"
+    );
+    assert!(
+        lean.contains(
+            "forall t, sourceTraceObs ProofOnceFold_T_0Source inputs natInputs cfg0 t = fsmTraceObs ProofOnceFold_T_0Fsm inputs natInputs cfg0 t"
+        ),
+        "Lean artifact should include the once trace-equivalence theorem:\n{lean}"
+    );
+    assert!(
+        lean.contains(
+            "Arch.ThreadLoweringProof.FoldedExit.sourceStep ProofOnceFold_T_0__t0_S0_wait_until_folded_0Source"
+        ),
+        "Lean artifact should include the folded terminal action proof:\n{lean}"
+    );
+}
+
+#[test]
+fn test_build_emit_thread_proof_records_branch_guarded_transitions() {
+    let td = tempfile::tempdir().expect("tempdir");
+    let src = td.path().join("ProofBranch.arch");
+    let sv_out = td.path().join("ProofBranch.sv");
+    let proof_out = td.path().join("ProofBranch.thread-proof.json");
+    std::fs::write(&src, thread_map_control_flow_source("ProofBranch")).expect("write source");
+
+    let out = std::process::Command::new(env!("CARGO_BIN_EXE_arch"))
+        .env("ARCH_NO_LEARN", "1")
+        .arg("build")
+        .arg(&src)
+        .arg("-o")
+        .arg(&sv_out)
+        .arg("--emit-thread-proof")
+        .output()
+        .expect("run arch build --emit-thread-proof");
+    assert!(
+        out.status.success(),
+        "build should pass\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let json = std::fs::read_to_string(&proof_out).expect("read proof certificate");
+    assert!(
+        json.contains("\"state_name\": \"_t0_S0_dispatch\""),
+        "expected fused go/sel dispatch state in proof certificate:\n{json}"
+    );
+    assert!(
+        json.contains("\"source_transitions\": [{\"condition\": \"go && sel\""),
+        "dispatch source transitions should preserve both branch targets:\n{json}"
+    );
+    assert!(
+        json.contains("\"condition\": \"go && !sel\""),
+        "dispatch source transitions should preserve both branch guards:\n{json}"
+    );
+    assert!(json.contains("\"condition_guard\": {\"kind\":\"and\",\"lhs\":{\"kind\":\"atom\",\"name\":\"go\"},\"rhs\":{\"kind\":\"atom\",\"name\":\"sel\"}}"),
+        "dispatch source transition should carry structured positive guard:\n{json}");
+    assert!(json.contains("\"condition_guard\": {\"kind\":\"and\",\"lhs\":{\"kind\":\"atom\",\"name\":\"go\"},\"rhs\":{\"kind\":\"not\",\"expr\":{\"kind\":\"atom\",\"name\":\"sel\"}}}"),
+        "dispatch source transition should carry structured negated guard:\n{json}");
+    assert!(
+        json.contains("\"target_index\": 1") && json.contains("\"target_name\": \"_t0_S1_action\""),
+        "dispatch source transitions should preserve first branch target:\n{json}"
+    );
+    assert!(
+        json.contains("\"target_index\": 2")
+            && json.contains("\"target_name\": \"_t0_S2_wait_cycles\""),
+        "dispatch source transitions should preserve second branch target:\n{json}"
+    );
+    assert!(json.contains("\"condition\": \"ack\", \"condition_guard\": {\"kind\":\"atom\",\"name\":\"ack\"}, \"target_index\": 3, \"target_name\": \"_t0_S3_action\""),
+        "single guarded branch wait should preserve its non-natural target:\n{json}");
+    assert!(
+        json.contains("\"source_next_index\": 2"),
+        "single guarded branch state's natural fallback should remain source-next:\n{json}"
+    );
+}
+
+#[test]
+fn test_build_emit_thread_proof_records_fork_join_rejoin_jumps() {
+    let td = tempfile::tempdir().expect("tempdir");
+    let src = td.path().join("AxiWrite.arch");
+    let sv_out = td.path().join("AxiWrite.sv");
+    let proof_out = td.path().join("AxiWrite.thread-proof.json");
+    std::fs::write(&src, include_str!("../tests/thread/fork_join.arch")).expect("write source");
+
+    let out = std::process::Command::new(env!("CARGO_BIN_EXE_arch"))
+        .env("ARCH_NO_LEARN", "1")
+        .arg("build")
+        .arg(&src)
+        .arg("-o")
+        .arg(&sv_out)
+        .arg("--emit-thread-proof")
+        .output()
+        .expect("run arch build --emit-thread-proof");
+    assert!(
+        out.status.success(),
+        "build should pass\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let json = std::fs::read_to_string(&proof_out).expect("read proof certificate");
+    assert!(
+        json.contains("\"state_name\": \"_t0_S0_dispatch\""),
+        "fork/join should begin with a product-state dispatch:\n{json}"
+    );
+    assert!(json.contains("\"condition\": \"aw_ready && w_ready\", \"condition_guard\": {\"kind\":\"and\",\"lhs\":{\"kind\":\"atom\",\"name\":\"aw_ready\"},\"rhs\":{\"kind\":\"atom\",\"name\":\"w_ready\"}}, \"target_index\": 4"),
+        "fork/join dispatch should record the both-branches-done transition:\n{json}");
+    assert!(json.contains("\"condition\": \"true\", \"condition_guard\": {\"kind\":\"true\"}, \"target_index\": 8"),
+        "completed fork branch states should record unconditional non-natural rejoin jumps:\n{json}");
+    assert!(json.contains("\"source_next_index\": 5"),
+        "unconditional rejoin jump state should still preserve natural source-next fallback:\n{json}");
+}
+
+#[test]
+fn test_build_emit_thread_proof_records_loop_bound_constants_as_structured_nat() {
+    let td = tempfile::tempdir().expect("tempdir");
+    let src = td.path().join("NestedForRepro.arch");
+    let sv_out = td.path().join("NestedForRepro.sv");
+    let proof_out = td.path().join("NestedForRepro.thread-proof.json");
+    std::fs::write(
+        &src,
+        include_str!("regression/issues/nested_for_threads/NestedForRepro.arch"),
+    )
+    .expect("write source");
+
+    let out = std::process::Command::new(env!("CARGO_BIN_EXE_arch"))
+        .env("ARCH_NO_LEARN", "1")
+        .arg("build")
+        .arg(&src)
+        .arg("-o")
+        .arg(&sv_out)
+        .arg("--emit-thread-proof")
+        .output()
+        .expect("run arch build --emit-thread-proof");
+    assert!(
+        out.status.success(),
+        "build should pass\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let json = std::fs::read_to_string(&proof_out).expect("read proof certificate");
+    assert!(
+        json.contains("\"kind\":\"lt\",\"lhs\":{\"kind\":\"var\",\"name\":\"_t0_loop_cnt_1\"},\"rhs\":{\"kind\":\"const\",\"value\":3}"),
+        "inner loop bound should remain a structured Nat constant:\n{json}"
+    );
+    assert!(
+        json.contains("\"kind\":\"ge\",\"lhs\":{\"kind\":\"var\",\"name\":\"_t0_loop_cnt_0\"},\"rhs\":{\"kind\":\"const\",\"value\":2}"),
+        "outer loop bound should remain a structured Nat constant:\n{json}"
+    );
+}
+
+#[test]
+fn test_build_emit_thread_proof_records_equality_as_structured_nat() {
+    let td = tempfile::tempdir().expect("tempdir");
+    let src = td.path().join("ProofEq.arch");
+    let sv_out = td.path().join("ProofEq.sv");
+    let proof_out = td.path().join("ProofEq.thread-proof.json");
+    std::fs::write(
+        &src,
+        r#"
+module ProofEq
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port idx: in UInt<3>;
+  port done: out pipe_reg<Bool, 1> reset rst => false;
+
+  thread T on clk rising, rst high
+    wait until idx == 2;
+    wait until idx != 1;
+    done <= true;
+  end thread T
+end module ProofEq
+"#,
+    )
+    .expect("write source");
+
+    let out = std::process::Command::new(env!("CARGO_BIN_EXE_arch"))
+        .env("ARCH_NO_LEARN", "1")
+        .arg("build")
+        .arg(&src)
+        .arg("-o")
+        .arg(&sv_out)
+        .arg("--emit-thread-proof")
+        .output()
+        .expect("run arch build --emit-thread-proof");
+    assert!(
+        out.status.success(),
+        "build should pass\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let json = std::fs::read_to_string(&proof_out).expect("read proof certificate");
+    assert!(
+        json.contains("\"kind\":\"eq\",\"lhs\":{\"kind\":\"var\",\"name\":\"idx\"},\"rhs\":{\"kind\":\"const\",\"value\":2}"),
+        "equality guard should remain structured in the proof certificate:\n{json}"
+    );
+    assert!(
+        json.contains("\"kind\":\"ne\",\"lhs\":{\"kind\":\"var\",\"name\":\"idx\"},\"rhs\":{\"kind\":\"const\",\"value\":1}"),
+        "inequality guard should remain structured in the proof certificate:\n{json}"
+    );
 }
 
 #[test]
@@ -11356,12 +13795,20 @@ fn test_build_emit_thread_map_multifile_paths_and_explicit_error() {
         .arg("--emit-thread-map")
         .output()
         .expect("run multi-file build");
-    assert!(ok.status.success(),
+    assert!(
+        ok.status.success(),
         "multi-file bare map should pass\nstdout:\n{}\nstderr:\n{}",
         String::from_utf8_lossy(&ok.stdout),
-        String::from_utf8_lossy(&ok.stderr));
-    assert!(td.path().join("A.thread.html").exists(), "expected A.thread.html");
-    assert!(td.path().join("B.thread.html").exists(), "expected B.thread.html");
+        String::from_utf8_lossy(&ok.stderr)
+    );
+    assert!(
+        td.path().join("A.thread.html").exists(),
+        "expected A.thread.html"
+    );
+    assert!(
+        td.path().join("B.thread.html").exists(),
+        "expected B.thread.html"
+    );
 
     let explicit = td.path().join("all.html");
     let err = std::process::Command::new(env!("CARGO_BIN_EXE_arch"))
@@ -11374,24 +13821,39 @@ fn test_build_emit_thread_map_multifile_paths_and_explicit_error() {
         .expect("run multi-file explicit map build");
     assert!(!err.status.success(), "explicit map without -o should fail");
     let stderr = String::from_utf8_lossy(&err.stderr);
-    assert!(stderr.contains("--emit-thread-map=PATH requires"),
-        "expected explicit multi-file diagnostic, got:\n{stderr}");
+    assert!(
+        stderr.contains("--emit-thread-map=PATH requires"),
+        "expected explicit multi-file diagnostic, got:\n{stderr}"
+    );
 }
 
 #[test]
 fn test_thread_map_metadata_records_dispatch_and_wait_roles() {
     let simple = collect_thread_map(&thread_map_smoke_source("Simple"));
     let simple_thread = &simple.modules[0].threads[0];
-    assert!(simple_thread.states.iter().any(|s| s.role == "wait_until" && s.labels.iter().any(|l| l.contains("go"))),
-        "expected simple wait_until state labelled with go: {simple_thread:#?}");
+    assert!(
+        simple_thread
+            .states
+            .iter()
+            .any(|s| s.role == "wait_until" && s.labels.iter().any(|l| l.contains("go"))),
+        "expected simple wait_until state labelled with go: {simple_thread:#?}"
+    );
 
     let source = thread_map_control_flow_source("M");
     let map = collect_thread_map(&source);
     let thread = &map.modules[0].threads[0];
-    assert!(thread.states.iter().any(|s| s.role == "wait_cycles"),
-        "expected wait_cycles state: {thread:#?}");
-    assert!(thread.states.iter().any(|s| s.role == "dispatch" && s.transitions.iter().any(|t| t.condition.contains("sel"))),
-        "expected dispatch state with sel transition: {thread:#?}");
+    assert!(
+        thread.states.iter().any(|s| s.role == "wait_cycles"),
+        "expected wait_cycles state: {thread:#?}"
+    );
+    assert!(
+        thread
+            .states
+            .iter()
+            .any(|s| s.role == "dispatch"
+                && s.transitions.iter().any(|t| t.condition.contains("sel"))),
+        "expected dispatch state with sel transition: {thread:#?}"
+    );
 }
 
 #[test]
@@ -11405,29 +13867,49 @@ fn test_thread_map_html_renders_control_flow_chart() {
         source,
     }];
     let html = arch::thread_map::render_html(&map, &sources, "Branchy.thread.html");
-    assert!(html.contains("<h2>Thread Flow</h2>"),
-        "expected right pane to be a flow-chart pane:\n{html}");
-    assert!(html.contains("thread-flow-chart"),
-        "expected generated graph-style flow chart:\n{html}");
-    assert!(html.contains("graph-edge"),
-        "expected graph transition edges:\n{html}");
-    assert!(html.contains("marker-end"),
-        "expected arrowheads on graph edges:\n{html}");
-    assert!(html.contains("then") && html.contains("else"),
-        "expected source-like branch labels in graph:\n{html}");
-    assert!(html.contains("data-state=\"S"),
-        "expected state nodes in flow chart:\n{html}");
-    assert!(html.contains("dispatch"),
-        "expected branch dispatch state in chart/table:\n{html}");
-    assert!(html.contains("sel"),
-        "expected branch condition label in chart/table:\n{html}");
-    assert!(html.contains("wait until ack"),
-        "expected then-branch wait label in chart/table:\n{html}");
+    assert!(
+        html.contains("<h2>Thread Flow</h2>"),
+        "expected right pane to be a flow-chart pane:\n{html}"
+    );
+    assert!(
+        html.contains("thread-flow-chart"),
+        "expected generated graph-style flow chart:\n{html}"
+    );
+    assert!(
+        html.contains("graph-edge"),
+        "expected graph transition edges:\n{html}"
+    );
+    assert!(
+        html.contains("marker-end"),
+        "expected arrowheads on graph edges:\n{html}"
+    );
+    assert!(
+        html.contains("then") && html.contains("else"),
+        "expected source-like branch labels in graph:\n{html}"
+    );
+    assert!(
+        html.contains("data-state=\"S"),
+        "expected state nodes in flow chart:\n{html}"
+    );
+    assert!(
+        html.contains("dispatch"),
+        "expected branch dispatch state in chart/table:\n{html}"
+    );
+    assert!(
+        html.contains("sel"),
+        "expected branch condition label in chart/table:\n{html}"
+    );
+    assert!(
+        html.contains("wait until ack"),
+        "expected then-branch wait label in chart/table:\n{html}"
+    );
 }
 
 #[test]
 fn test_thread_map_source_bands_anchor_broad_control_spans() {
-    let source = include_str!("regression/issues/nested_if_lock_outer_for_continuation/IfLockOuterForRepro.arch");
+    let source = include_str!(
+        "regression/issues/nested_if_lock_outer_for_continuation/IfLockOuterForRepro.arch"
+    );
     let map = collect_thread_map(source);
     let sources = vec![arch::thread_map::ThreadMapSource {
         start: 0,
@@ -11438,20 +13920,34 @@ fn test_thread_map_source_bands_anchor_broad_control_spans() {
     let html = arch::thread_map::render_html(&map, &sources, "IfLockOuterForRepro.thread.html");
     let row_for_line = |line: usize| {
         let needle = format!("<span class=\"ln\">{line}</span>");
-        let pos = html.find(&needle).unwrap_or_else(|| panic!("missing source line {line}"));
+        let pos = html
+            .find(&needle)
+            .unwrap_or_else(|| panic!("missing source line {line}"));
         let row_start = html[..pos].rfind("<div class=\"src-line\">").unwrap();
         let row_end = html[pos..].find("</div>").map(|off| pos + off).unwrap();
         &html[row_start..row_end]
     };
 
-    assert!(row_for_line(30).contains(">S0<"),
-        "wait-until state should mark the wait line:\n{}", row_for_line(30));
-    assert!(row_for_line(32).contains(">S3<") || row_for_line(32).contains(">S4<"),
-        "broad loop/dispatch states should anchor to the loop header:\n{}", row_for_line(32));
-    assert!(!row_for_line(33).contains("class=\"band "),
-        "comment lines inside a broad span should not be painted:\n{}", row_for_line(33));
-    assert!(!row_for_line(39).contains("class=\"band "),
-        "nested comment lines inside a broad span should not be painted:\n{}", row_for_line(39));
+    assert!(
+        row_for_line(30).contains(">S0<"),
+        "wait-until state should mark the wait line:\n{}",
+        row_for_line(30)
+    );
+    assert!(
+        row_for_line(32).contains(">S3<") || row_for_line(32).contains(">S4<"),
+        "broad loop/dispatch states should anchor to the loop header:\n{}",
+        row_for_line(32)
+    );
+    assert!(
+        !row_for_line(33).contains("class=\"band "),
+        "comment lines inside a broad span should not be painted:\n{}",
+        row_for_line(33)
+    );
+    assert!(
+        !row_for_line(39).contains("class=\"band "),
+        "nested comment lines inside a broad span should not be painted:\n{}",
+        row_for_line(39)
+    );
 }
 
 #[test]
@@ -11465,25 +13961,41 @@ fn test_thread_map_spans_ignore_generated_counter_loads() {
         (start_line, end_line)
     };
 
-    let wait_until = thread.states.iter()
+    let wait_until = thread
+        .states
+        .iter()
         .find(|s| s.role == "wait_until")
         .expect("wait_until state");
-    assert_eq!(line_range(wait_until.span), (8, 8),
-        "S0 should render only on the wait-until source line: {wait_until:#?}");
+    assert_eq!(
+        line_range(wait_until.span),
+        (8, 8),
+        "S0 should render only on the wait-until source line: {wait_until:#?}"
+    );
     let wait_until_src = &source[wait_until.span.start..wait_until.span.end];
-    assert!(!wait_until_src.contains("wait 5 cycle"),
-        "S0 span should stop before the following wait-cycle source: {wait_until_src:?}");
-    assert!(!wait_until_src.contains("end module"),
-        "S0 span should not stretch to the whole module: {wait_until_src:?}");
+    assert!(
+        !wait_until_src.contains("wait 5 cycle"),
+        "S0 span should stop before the following wait-cycle source: {wait_until_src:?}"
+    );
+    assert!(
+        !wait_until_src.contains("end module"),
+        "S0 span should not stretch to the whole module: {wait_until_src:?}"
+    );
 
-    let wait_cycles = thread.states.iter()
+    let wait_cycles = thread
+        .states
+        .iter()
         .find(|s| s.role == "wait_cycles")
         .expect("wait_cycles state");
-    assert_eq!(line_range(wait_cycles.span), (9, 9),
-        "S1 should render only on the wait-cycle source line: {wait_cycles:#?}");
+    assert_eq!(
+        line_range(wait_cycles.span),
+        (9, 9),
+        "S1 should render only on the wait-cycle source line: {wait_cycles:#?}"
+    );
     let wait_cycles_src = &source[wait_cycles.span.start..wait_cycles.span.end];
-    assert!(!wait_cycles_src.contains("pulse = 1"),
-        "wait_cycles span should stop before the action source: {wait_cycles_src:?}");
+    assert!(
+        !wait_cycles_src.contains("pulse = 1"),
+        "wait_cycles span should stop before the action source: {wait_cycles_src:?}"
+    );
 }
 
 // ── If/else with internal waits — dispatch-and-rejoin ─────────────────────────
@@ -11512,8 +14024,10 @@ fn test_if_wait_then_only() {
     "#;
     let sv = compile_to_sv(source);
     // Compiles without rejection.
-    assert!(sv.contains("module _M_threads"),
-        "merged thread module should be emitted:\n{sv}");
+    assert!(
+        sv.contains("module _M_threads"),
+        "merged thread module should be emitted:\n{sv}"
+    );
 }
 
 #[test]
@@ -11537,8 +14051,10 @@ fn test_if_wait_else_only() {
         end module M
     "#;
     let sv = compile_to_sv(source);
-    assert!(sv.contains("module _M_threads"),
-        "merged thread module should be emitted:\n{sv}");
+    assert!(
+        sv.contains("module _M_threads"),
+        "merged thread module should be emitted:\n{sv}"
+    );
 }
 
 #[test]
@@ -11579,12 +14095,16 @@ fn test_if_wait_both_branches() {
         end module M
     "#;
     let sv = compile_to_sv(source);
-    assert!(sv.contains("module _M_threads"),
-        "merged thread module should be emitted:\n{sv}");
+    assert!(
+        sv.contains("module _M_threads"),
+        "merged thread module should be emitted:\n{sv}"
+    );
     // The dispatch state's transition table negates the if condition for
     // the else branch. Verify both arms land at distinct branch bases.
-    assert!(sv.contains("is_wr") && sv.contains("!"),
-        "expected dispatch to use `is_wr` and `!is_wr` arms:\n{sv}");
+    assert!(
+        sv.contains("is_wr") && sv.contains("!"),
+        "expected dispatch to use `is_wr` and `!is_wr` arms:\n{sv}"
+    );
 }
 
 #[test]
@@ -11631,20 +14151,20 @@ fn test_thread_without_wait_or_do_until_errors_with_seq_hint() {
         let mut parser = arch::parser::Parser::new(tokens, source);
         let parsed_ast = parser.parse_source_file().expect("parse error");
         let ast = arch::elaborate::elaborate(parsed_ast).expect("elaborate error");
-        let ast = arch::elaborate::lower_tlm_target_threads(ast)
-            .expect("tlm target lowering");
-        let ast = arch::elaborate::lower_tlm_initiator_calls(ast)
-            .expect("tlm initiator lowering");
+        let ast = arch::elaborate::lower_tlm_target_threads(ast).expect("tlm target lowering");
+        let ast = arch::elaborate::lower_tlm_initiator_calls(ast).expect("tlm initiator lowering");
         let result = arch::elaborate::lower_threads(ast);
-        let errs = result.expect_err(
-            "thread with no wait / do until should fail lower_threads"
-        );
+        let errs = result.expect_err("thread with no wait / do until should fail lower_threads");
         assert!(!errs.is_empty(), "expected at least one error");
         let msg = errs[0].to_string();
-        assert!(msg.contains("must contain at least one `wait` or `do until`"),
-            "error should mention wait + do until: {msg}");
-        assert!(msg.contains("seq on clk"),
-            "error should suggest `seq on clk` alternative: {msg}");
+        assert!(
+            msg.contains("must contain at least one `wait` or `do until`"),
+            "error should mention wait + do until: {msg}"
+        );
+        assert!(
+            msg.contains("seq on clk"),
+            "error should suggest `seq on clk` alternative: {msg}"
+        );
     }
 }
 
@@ -11668,8 +14188,10 @@ fn test_thread_with_do_until_only_is_accepted() {
         end module M
     "#;
     let sv = compile_to_sv(source);
-    assert!(sv.contains("always_ff"),
-        "do/until thread should still compile to SV:\n{sv}");
+    assert!(
+        sv.contains("always_ff"),
+        "do/until thread should still compile to SV:\n{sv}"
+    );
 }
 
 #[test]
@@ -11709,8 +14231,10 @@ fn test_do_until_rejects_nested_lock() {
     let ast = parser.parse_source_file().expect("parse");
     let err = arch::elaborate::lower_threads(ast).expect_err("expected lowering error");
     let msg = err.iter().map(|e| format!("{e:?}")).collect::<String>();
-    assert!(msg.contains("`lock`") && msg.contains("`do ... until`"),
-            "expected do-until-rejects-lock diagnostic, got: {msg}");
+    assert!(
+        msg.contains("`lock`") && msg.contains("`do ... until`"),
+        "expected do-until-rejects-lock diagnostic, got: {msg}"
+    );
 }
 
 #[test]
@@ -11738,8 +14262,10 @@ fn test_do_until_rejects_nested_wait() {
     let ast = parser.parse_source_file().expect("parse");
     let err = arch::elaborate::lower_threads(ast).expect_err("expected lowering error");
     let msg = err.iter().map(|e| format!("{e:?}")).collect::<String>();
-    assert!(msg.contains("`wait until`") && msg.contains("`do ... until`"),
-            "expected do-until-rejects-nested-wait diagnostic, got: {msg}");
+    assert!(
+        msg.contains("`wait until`") && msg.contains("`do ... until`"),
+        "expected do-until-rejects-nested-wait diagnostic, got: {msg}"
+    );
 }
 
 #[test]
@@ -11767,8 +14293,10 @@ fn test_do_until_rejects_nested_for() {
     let ast = parser.parse_source_file().expect("parse");
     let err = arch::elaborate::lower_threads(ast).expect_err("expected lowering error");
     let msg = err.iter().map(|e| format!("{e:?}")).collect::<String>();
-    assert!(msg.contains("`for`") && msg.contains("`do ... until`"),
-            "expected do-until-rejects-nested-for diagnostic, got: {msg}");
+    assert!(
+        msg.contains("`for`") && msg.contains("`do ... until`"),
+        "expected do-until-rejects-nested-for diagnostic, got: {msg}"
+    );
 }
 
 #[test]
@@ -11799,8 +14327,10 @@ fn test_do_until_allows_nested_ifelse_with_simple_assigns() {
         end module M
     "#;
     let sv = compile_to_sv(source);
-    assert!(sv.contains("always_ff"),
-            "do/until with simple if/else body should compile:\n{sv}");
+    assert!(
+        sv.contains("always_ff"),
+        "do/until with simple if/else body should compile:\n{sv}"
+    );
 }
 
 #[test]
@@ -11836,12 +14366,18 @@ fn test_thread_wait_ifelse_fuses_dispatch_and_first_branch_action() {
     "#;
     let sv = compile_to_sv(source);
 
-    assert!(sv.contains("if (req && is_mul) begin\n          phase <= 4'd1;"),
-        "then-branch first action should be hoisted onto the wait-exit edge:\n{sv}");
-    assert!(sv.contains("if (req && !is_mul) begin\n          phase <= 4'd3;"),
-        "else-branch first action should be hoisted onto the wait-exit edge:\n{sv}");
-    assert!(!sv.contains("_t0_state == 3"),
-        "fused lowering should not emit old wait->dispatch->prefix state chain:\n{sv}");
+    assert!(
+        sv.contains("if (req && is_mul) begin\n          phase <= 4'd1;"),
+        "then-branch first action should be hoisted onto the wait-exit edge:\n{sv}"
+    );
+    assert!(
+        sv.contains("if (req && !is_mul) begin\n          phase <= 4'd3;"),
+        "else-branch first action should be hoisted onto the wait-exit edge:\n{sv}"
+    );
+    assert!(
+        !sv.contains("_t0_state == 3"),
+        "fused lowering should not emit old wait->dispatch->prefix state chain:\n{sv}"
+    );
 }
 
 #[test]
@@ -11874,20 +14410,34 @@ fn test_thread_wait_elsif_chain_fuses_to_single_dispatch() {
     "#;
     let sv = compile_to_sv(source);
 
-    assert!(sv.contains("phase <= 4'd1;"),
-        "first arm should keep its first action:\n{sv}");
-    assert!(sv.contains("phase <= 4'd2;"),
-        "elsif arm should keep its first action:\n{sv}");
-    assert!(sv.contains("phase <= 4'd3;"),
-        "else arm should keep its first action:\n{sv}");
-    assert!(sv.contains("req && sel == 2'd0"),
-        "first arm guard should include the wait condition:\n{sv}");
-    assert!(sv.contains("req && !(sel == 2'd0) && sel == 2'd1"),
-        "elsif guard should be flattened onto the original wait state:\n{sv}");
-    assert!(sv.contains("req && !(sel == 2'd0) && !(sel == 2'd1)"),
-        "else guard should be flattened onto the original wait state:\n{sv}");
-    assert!(!sv.contains("_t0_state == 3"),
-        "flattened three-arm dispatch should not leave a nested dispatch state:\n{sv}");
+    assert!(
+        sv.contains("phase <= 4'd1;"),
+        "first arm should keep its first action:\n{sv}"
+    );
+    assert!(
+        sv.contains("phase <= 4'd2;"),
+        "elsif arm should keep its first action:\n{sv}"
+    );
+    assert!(
+        sv.contains("phase <= 4'd3;"),
+        "else arm should keep its first action:\n{sv}"
+    );
+    assert!(
+        sv.contains("req && sel == 2'd0"),
+        "first arm guard should include the wait condition:\n{sv}"
+    );
+    assert!(
+        sv.contains("req && !(sel == 2'd0) && sel == 2'd1"),
+        "elsif guard should be flattened onto the original wait state:\n{sv}"
+    );
+    assert!(
+        sv.contains("req && !(sel == 2'd0) && !(sel == 2'd1)"),
+        "else guard should be flattened onto the original wait state:\n{sv}"
+    );
+    assert!(
+        !sv.contains("_t0_state == 3"),
+        "flattened three-arm dispatch should not leave a nested dispatch state:\n{sv}"
+    );
 }
 
 #[test]
@@ -11924,14 +14474,20 @@ fn test_thread_default_comb_applies_before_state_comb_and_collects_reads() {
         end module M
     "#;
     let sv = compile_to_sv(source);
-    assert!(sv.contains("input logic [7:0] payload"),
-        "`default comb` RHS-only signal must be wired into the lowered thread module:\n{sv}");
-    let default_pos = sv.find("data = payload;")
+    assert!(
+        sv.contains("input logic [7:0] payload"),
+        "`default comb` RHS-only signal must be wired into the lowered thread module:\n{sv}"
+    );
+    let default_pos = sv
+        .find("data = payload;")
         .expect("expected unconditional default data assignment");
-    let state_pos = sv.find("if (_t0_state")
+    let state_pos = sv
+        .find("if (_t0_state")
         .expect("expected state-guarded comb assignments");
-    assert!(default_pos < state_pos,
-        "`default comb` assignments must precede state-specific comb assignments:\n{sv}");
+    assert!(
+        default_pos < state_pos,
+        "`default comb` assignments must precede state-specific comb assignments:\n{sv}"
+    );
     assert!(sv.contains("data = 8'd255;"),
         "state-specific comb assignment should still override the default later in the block:\n{sv}");
 }
@@ -11959,8 +14515,10 @@ fn test_thread_default_comb_rejects_seq_driven_target() {
     let ast = elaborate::elaborate(parsed_ast).expect("elaborate error");
     let err = elaborate::lower_threads(ast).expect_err("default comb must not drive seq target");
     let msg = format!("{err:?}");
-    assert!(msg.contains("default comb") && msg.contains("done") && msg.contains("<="),
-        "expected targeted diagnostic for default-comb/seq-driver conflict, got: {msg}");
+    assert!(
+        msg.contains("default comb") && msg.contains("done") && msg.contains("<="),
+        "expected targeted diagnostic for default-comb/seq-driver conflict, got: {msg}"
+    );
 }
 
 #[test]
@@ -11987,10 +14545,15 @@ fn test_if_wait_with_auto_asserts() {
           end thread
         end module M
     "#;
-    let opts = elaborate::ThreadLowerOpts { auto_asserts: true, ..Default::default() };
+    let opts = elaborate::ThreadLowerOpts {
+        auto_asserts: true,
+        ..Default::default()
+    };
     let sv = compile_to_sv_with_opts(source, &opts);
-    assert!(sv.contains("_auto_thread_t0_branch_"),
-        "expected dispatch-state branch assertions:\n{sv}");
+    assert!(
+        sv.contains("_auto_thread_t0_branch_"),
+        "expected dispatch-state branch assertions:\n{sv}"
+    );
 }
 
 // ── resource arbiter policies ─────────────────────────────────────────────────
@@ -12035,14 +14598,20 @@ fn test_resource_lock_priority_default() {
     "#;
     let sv = compile_to_sv(source);
     // Synthesized arbiter is named _arb_<Mod>_<res>.
-    assert!(sv.contains("module _arb_M_shared_lk"),
-        "expected synthesized arbiter module:\n{sv}");
+    assert!(
+        sv.contains("module _arb_M_shared_lk"),
+        "expected synthesized arbiter module:\n{sv}"
+    );
     // Default = priority arbiter (linear pri_i loop).
-    assert!(sv.contains("for (int pri_i = 0; pri_i < 3"),
-        "default policy should be priority:\n{sv}");
+    assert!(
+        sv.contains("for (int pri_i = 0; pri_i < 3"),
+        "default policy should be priority:\n{sv}"
+    );
     // Inst inside the merged module.
-    assert!(sv.contains("_arb_M_shared_lk _arb_inst_shared_lk"),
-        "expected arbiter instance inside merged module:\n{sv}");
+    assert!(
+        sv.contains("_arb_M_shared_lk _arb_inst_shared_lk"),
+        "expected arbiter instance inside merged module:\n{sv}"
+    );
 }
 
 #[test]
@@ -12075,14 +14644,18 @@ fn test_resource_lock_round_robin() {
         end module M
     "#;
     let sv = compile_to_sv(source);
-    assert!(sv.contains("logic [0:0] rr_ptr_r;"),
-        "round_robin should emit rr_ptr_r register:\n{sv}");
+    assert!(
+        sv.contains("logic [0:0] rr_ptr_r;"),
+        "round_robin should emit rr_ptr_r register:\n{sv}"
+    );
     // Pointer advances from the actual grantee (not the scan start) and wraps
     // explicitly at NUM_REQ; the bare `rr_ptr_r + 1` form was incorrect for
     // non-power-of-2 NUM_REQ. See `emit_arbiter_round_robin`.
-    assert!(sv.contains("rr_ptr_r <= (grant_requester ==")
-        && sv.contains("? '0 : grant_requester + 1'b1;"),
-        "round_robin should advance from grant_requester with explicit wrap:\n{sv}");
+    assert!(
+        sv.contains("rr_ptr_r <= (grant_requester ==")
+            && sv.contains("? '0 : grant_requester + 1'b1;"),
+        "round_robin should advance from grant_requester with explicit wrap:\n{sv}"
+    );
 }
 
 #[test]
@@ -12123,13 +14696,19 @@ fn test_resource_lock_custom_policy_with_hook() {
     "#;
     let sv = compile_to_sv(source);
     // Custom policy emits the user's function inside the synthesized arbiter.
-    assert!(sv.contains("function automatic"),
-        "custom-policy arbiter should embed the user function:\n{sv}");
-    assert!(sv.contains("PickHigh"),
-        "expected user function name in arbiter:\n{sv}");
+    assert!(
+        sv.contains("function automatic"),
+        "custom-policy arbiter should embed the user function:\n{sv}"
+    );
+    assert!(
+        sv.contains("PickHigh"),
+        "expected user function name in arbiter:\n{sv}"
+    );
     // last_grant_r register comes from the custom-arbiter codegen.
-    assert!(sv.contains("last_grant_r"),
-        "custom-policy arbiter should track last_grant_r:\n{sv}");
+    assert!(
+        sv.contains("last_grant_r"),
+        "custom-policy arbiter should track last_grant_r:\n{sv}"
+    );
 }
 
 #[test]
@@ -12162,8 +14741,10 @@ fn test_if_wait_nested() {
         end module M
     "#;
     let sv = compile_to_sv(source);
-    assert!(sv.contains("module _M_threads"),
-        "nested if/else with waits should compile:\n{sv}");
+    assert!(
+        sv.contains("module _M_threads"),
+        "nested if/else with waits should compile:\n{sv}"
+    );
 }
 
 #[test]
@@ -12205,8 +14786,10 @@ fn test_if_wait_for_in_then_branch() {
         end module M
     "#;
     let sv = compile_to_sv(source);
-    assert!(sv.contains("module _M_threads"),
-        "for-loop in then-branch should compile:\n{sv}");
+    assert!(
+        sv.contains("module _M_threads"),
+        "for-loop in then-branch should compile:\n{sv}"
+    );
     // Bug witness: the buggy lowering emitted `if (1'b1) _t0_state <= <rejoin>`
     // inside the for-loop's last state, causing the body to execute exactly once.
     // The fix removes this unconditional override, so the only state-write
@@ -12214,8 +14797,10 @@ fn test_if_wait_for_in_then_branch() {
     // arms — both guarded by `_t0_loop_cnt_0` comparisons against `burst_len - 1`.
     // (The counter is named `_t0_loop_cnt_0` since issue #414: each `for`
     // instance in a thread allocates its own `_loop_cnt_{id}` register.)
-    assert!(!sv.contains("if (1'b1) begin\n          _t0_state"),
-        "buggy unconditional override should not be emitted:\n{sv}");
+    assert!(
+        !sv.contains("if (1'b1) begin\n          _t0_state"),
+        "buggy unconditional override should not be emitted:\n{sv}"
+    );
     // The for-loop's exit arm should land at the rejoin state (post-if
     // wait_cycles), not at the start of the else branch.
     // The else branch is `wait 1 cycle` (one state); the rejoin is the
@@ -12223,8 +14808,10 @@ fn test_if_wait_for_in_then_branch() {
     // (burst_len - 1)` should write the rejoin state, not else_base.
     let exit_arm = sv.contains("if (_t0_loop_cnt_0 >= 16'(burst_len - 1)) begin")
         || sv.contains("if (_t0_loop_cnt_0 >= 16'(burst_len-1)) begin");
-    assert!(exit_arm,
-        "for-loop exit arm should compare loop_cnt_0 against burst_len-1:\n{sv}");
+    assert!(
+        exit_arm,
+        "for-loop exit arm should compare loop_cnt_0 against burst_len-1:\n{sv}"
+    );
 }
 
 // ── Doc comments and frontmatter (V1) ─────────────────────────────────────────
@@ -12253,10 +14840,14 @@ fn test_doc_outer_attaches_to_module() {
         _ => panic!("expected module"),
     };
     let doc = m.doc.as_ref().expect("module should have outer doc");
-    assert!(doc.contains("Saturating up-counter."),
-        "outer doc text missing first line: {doc:?}");
-    assert!(doc.contains("Wraps to MAX"),
-        "outer doc text missing third line: {doc:?}");
+    assert!(
+        doc.contains("Saturating up-counter."),
+        "outer doc text missing first line: {doc:?}"
+    );
+    assert!(
+        doc.contains("Wraps to MAX"),
+        "outer doc text missing third line: {doc:?}"
+    );
 }
 
 #[test]
@@ -12276,8 +14867,15 @@ fn test_doc_inner_attaches_to_module() {
         _ => panic!("expected module"),
     };
     let inner = m.inner_doc.as_ref().expect("module should have inner doc");
-    assert!(inner.contains("CSR access"), "inner doc text missing: {inner:?}");
-    assert!(m.doc.is_none(), "outer doc should be None, got: {:?}", m.doc);
+    assert!(
+        inner.contains("CSR access"),
+        "inner doc text missing: {inner:?}"
+    );
+    assert!(
+        m.doc.is_none(),
+        "outer doc should be None, got: {:?}",
+        m.doc
+    );
 }
 
 #[test]
@@ -12298,18 +14896,32 @@ end module Top
 ";
     let ast = parse_to_ast(source);
     let inner = ast.inner_doc.as_ref().expect("file should carry inner_doc");
-    assert!(inner.contains("Multi-channel DMA engine"),
-        "file inner_doc should preserve the prose summary:\n{inner}");
-    assert!(inner.contains("---"),
-        "file inner_doc should retain the frontmatter delimiters verbatim:\n{inner}");
-    let fm = ast.frontmatter.as_ref().expect("file should carry frontmatter");
-    assert!(fm.contains("spec_md: doc/specs/dma_engine.md"),
-        "frontmatter should preserve spec_md field:\n{fm}");
-    assert!(fm.contains("tags: [dma, axi]"),
-        "frontmatter should preserve tags:\n{fm}");
+    assert!(
+        inner.contains("Multi-channel DMA engine"),
+        "file inner_doc should preserve the prose summary:\n{inner}"
+    );
+    assert!(
+        inner.contains("---"),
+        "file inner_doc should retain the frontmatter delimiters verbatim:\n{inner}"
+    );
+    let fm = ast
+        .frontmatter
+        .as_ref()
+        .expect("file should carry frontmatter");
+    assert!(
+        fm.contains("spec_md: doc/specs/dma_engine.md"),
+        "frontmatter should preserve spec_md field:\n{fm}"
+    );
+    assert!(
+        fm.contains("tags: [dma, axi]"),
+        "frontmatter should preserve tags:\n{fm}"
+    );
     let open_close: Vec<_> = fm.lines().filter(|l| l.trim() == "---").collect();
-    assert_eq!(open_close.len(), 2,
-        "frontmatter should contain exactly 2 `---` delimiter lines:\n{fm}");
+    assert_eq!(
+        open_close.len(),
+        2,
+        "frontmatter should contain exactly 2 `---` delimiter lines:\n{fm}"
+    );
 }
 
 #[test]
@@ -12331,7 +14943,11 @@ fn test_doc_outer_on_counter() {
         arch::ast::Item::Counter(c) => c,
         _ => panic!("expected counter"),
     };
-    let doc = c.common.doc.as_ref().expect("counter should have outer doc");
+    let doc = c
+        .common
+        .doc
+        .as_ref()
+        .expect("counter should have outer doc");
     assert!(doc.contains("watchdog"), "outer doc text missing: {doc:?}");
 }
 
@@ -12350,8 +14966,11 @@ fn test_four_slashes_dropped_as_regular_comment() {
         arch::ast::Item::Module(m) => m,
         _ => panic!("expected module"),
     };
-    assert!(m.doc.is_none(),
-        "4-slash banner should not attach as a doc comment, got: {:?}", m.doc);
+    assert!(
+        m.doc.is_none(),
+        "4-slash banner should not attach as a doc comment, got: {:?}",
+        m.doc
+    );
 }
 
 // ── PR-doc-1.5: outer-doc + inner-doc on every top-level item kind ────────────
@@ -12381,20 +15000,35 @@ fn test_doc_outer_on_struct_enum_function() {
         arch::ast::Item::Struct(s) => s,
         _ => panic!("expected struct"),
     };
-    assert!(s.doc.as_ref().map_or(false, |d| d.contains("Cache line state")),
-        "struct should have outer doc, got {:?}", s.doc);
+    assert!(
+        s.doc
+            .as_ref()
+            .map_or(false, |d| d.contains("Cache line state")),
+        "struct should have outer doc, got {:?}",
+        s.doc
+    );
     let e = match &ast.items[1] {
         arch::ast::Item::Enum(e) => e,
         _ => panic!("expected enum"),
     };
-    assert!(e.doc.as_ref().map_or(false, |d| d.contains("Branch direction")),
-        "enum should have outer doc, got {:?}", e.doc);
+    assert!(
+        e.doc
+            .as_ref()
+            .map_or(false, |d| d.contains("Branch direction")),
+        "enum should have outer doc, got {:?}",
+        e.doc
+    );
     let f = match &ast.items[2] {
         arch::ast::Item::Function(f) => f,
         _ => panic!("expected function"),
     };
-    assert!(f.doc.as_ref().map_or(false, |d| d.contains("Saturating add")),
-        "function should have outer doc, got {:?}", f.doc);
+    assert!(
+        f.doc
+            .as_ref()
+            .map_or(false, |d| d.contains("Saturating add")),
+        "function should have outer doc, got {:?}",
+        f.doc
+    );
 }
 
 #[test]
@@ -12422,14 +15056,20 @@ fn test_doc_outer_on_bus_synchronizer_clkgate() {
         arch::ast::Item::Bus(b) => b,
         _ => panic!("expected bus"),
     };
-    assert!(b.doc.as_ref().map_or(false, |d| d.contains("AXI4")),
-        "bus should have outer doc, got {:?}", b.doc);
+    assert!(
+        b.doc.as_ref().map_or(false, |d| d.contains("AXI4")),
+        "bus should have outer doc, got {:?}",
+        b.doc
+    );
     let s = match &ast.items[1] {
         arch::ast::Item::Synchronizer(s) => s,
         _ => panic!("expected synchronizer"),
     };
-    assert!(s.doc.as_ref().map_or(false, |d| d.contains("2-FF")),
-        "synchronizer should have outer doc, got {:?}", s.doc);
+    assert!(
+        s.doc.as_ref().map_or(false, |d| d.contains("2-FF")),
+        "synchronizer should have outer doc, got {:?}",
+        s.doc
+    );
 }
 
 #[test]
@@ -12465,14 +15105,26 @@ fn test_inner_doc_on_counter_and_arbiter() {
         arch::ast::Item::Counter(c) => c,
         _ => panic!("expected counter"),
     };
-    assert!(c.common.inner_doc.as_ref().map_or(false, |d| d.contains("watchdog timer")),
-        "counter inner_doc missing, got {:?}", c.common.inner_doc);
+    assert!(
+        c.common
+            .inner_doc
+            .as_ref()
+            .map_or(false, |d| d.contains("watchdog timer")),
+        "counter inner_doc missing, got {:?}",
+        c.common.inner_doc
+    );
     let a = match &ast.items[1] {
         arch::ast::Item::Arbiter(a) => a,
         _ => panic!("expected arbiter"),
     };
-    assert!(a.common.inner_doc.as_ref().map_or(false, |d| d.contains("Round-robin")),
-        "arbiter inner_doc missing, got {:?}", a.common.inner_doc);
+    assert!(
+        a.common
+            .inner_doc
+            .as_ref()
+            .map_or(false, |d| d.contains("Round-robin")),
+        "arbiter inner_doc missing, got {:?}",
+        a.common.inner_doc
+    );
 }
 
 #[test]
@@ -12487,8 +15139,11 @@ fn test_doc_outer_on_use_decl() {
         arch::ast::Item::Use(u) => u,
         _ => panic!("expected use"),
     };
-    assert!(u.doc.as_ref().map_or(false, |d| d.contains("cache-line")),
-        "use decl should have outer doc, got {:?}", u.doc);
+    assert!(
+        u.doc.as_ref().map_or(false, |d| d.contains("cache-line")),
+        "use decl should have outer doc, got {:?}",
+        u.doc
+    );
 }
 
 // ── Member-level doc tokens are silently ignored (not yet attached) ──────────
@@ -12519,7 +15174,11 @@ fn test_doc_above_port_silently_ignored() {
     assert_eq!(m.ports.len(), 3, "expected 3 ports, got {}", m.ports.len());
     // Module-level outer doc is still None (the `///` was member-level
     // and got silently dropped, NOT promoted to module).
-    assert!(m.doc.is_none(), "module doc should be None, got {:?}", m.doc);
+    assert!(
+        m.doc.is_none(),
+        "module doc should be None, got {:?}",
+        m.doc
+    );
 }
 
 #[test]
@@ -12550,10 +15209,19 @@ fn test_doc_above_reg_wire_inst_silently_ignored() {
         arch::ast::Item::Module(m) => m,
         _ => panic!("expected module"),
     };
-    let has_reg = m.body.iter().any(|i| matches!(i, arch::ast::ModuleBodyItem::RegDecl(_)));
-    let has_wire = m.body.iter().any(|i| matches!(i, arch::ast::ModuleBodyItem::WireDecl(_)));
+    let has_reg = m
+        .body
+        .iter()
+        .any(|i| matches!(i, arch::ast::ModuleBodyItem::RegDecl(_)));
+    let has_wire = m
+        .body
+        .iter()
+        .any(|i| matches!(i, arch::ast::ModuleBodyItem::WireDecl(_)));
     assert!(has_reg, "reg should be present despite leading doc comment");
-    assert!(has_wire, "wire should be present despite leading doc comment");
+    assert!(
+        has_wire,
+        "wire should be present despite leading doc comment"
+    );
 }
 
 #[test]
@@ -12579,8 +15247,11 @@ fn test_inner_doc_inside_body_silently_ignored() {
     };
     // A `//!` not immediately after `module M` is a stray — should NOT
     // attach to inner_doc (which only catches the post-name position).
-    assert!(m.inner_doc.is_none(),
-        "stray //! mid-body should not attach to inner_doc, got: {:?}", m.inner_doc);
+    assert!(
+        m.inner_doc.is_none(),
+        "stray //! mid-body should not attach to inner_doc, got: {:?}",
+        m.inner_doc
+    );
 }
 
 // ── regfile `kind: latch` (PR #200) ───────────────────────────────────────────
@@ -12609,7 +15280,8 @@ const LATCH_RF_DECL: &str = "
 
 #[test]
 fn test_regfile_latch_emits_always_latch_per_row() {
-    let source = format!("{LATCH_RF_DECL}
+    let source = format!(
+        "{LATCH_RF_DECL}
         module Top
           port clk: in Clock<SysDomain>;
           port rst: in Reset<Sync>;
@@ -12638,21 +15310,40 @@ fn test_regfile_latch_emits_always_latch_per_row() {
             read_data  -> q;
           end inst rf
         end module Top
-    ");
+    "
+    );
     let sv = compile_to_sv(&source);
     let n = sv.matches("always_latch").count();
-    assert_eq!(n, 4, "expected 4 always_latch blocks (NREGS=4), got {n}:\n{sv}");
-    assert!(sv.contains("write_addr == 2'd0"), "row 0 enable missing:\n{sv}");
-    assert!(sv.contains("write_addr == 2'd3"), "row 3 enable missing:\n{sv}");
-    let module_body: String = sv.split("module LatchRf").nth(1).unwrap_or(&sv)
-        .split("endmodule").next().unwrap_or(&sv).to_string();
-    assert!(!module_body.contains("always_ff"),
-        "latch RF body should not contain always_ff:\n{module_body}");
+    assert_eq!(
+        n, 4,
+        "expected 4 always_latch blocks (NREGS=4), got {n}:\n{sv}"
+    );
+    assert!(
+        sv.contains("write_addr == 2'd0"),
+        "row 0 enable missing:\n{sv}"
+    );
+    assert!(
+        sv.contains("write_addr == 2'd3"),
+        "row 3 enable missing:\n{sv}"
+    );
+    let module_body: String = sv
+        .split("module LatchRf")
+        .nth(1)
+        .unwrap_or(&sv)
+        .split("endmodule")
+        .next()
+        .unwrap_or(&sv)
+        .to_string();
+    assert!(
+        !module_body.contains("always_ff"),
+        "latch RF body should not contain always_ff:\n{module_body}"
+    );
 }
 
 #[test]
 fn test_regfile_latch_rejects_let_source() {
-    let source = format!("{LATCH_RF_DECL}
+    let source = format!(
+        "{LATCH_RF_DECL}
         module Top
           port clk: in Clock<SysDomain>;
           port rst: in Reset<Sync>;
@@ -12674,7 +15365,8 @@ fn test_regfile_latch_rejects_let_source() {
             read_data  -> q;
           end inst rf
         end module Top
-    ");
+    "
+    );
     let tokens = lexer::tokenize(&source).expect("lex");
     let mut parser = Parser::new(tokens, &source);
     let ast = parser.parse_source_file().expect("parse");
@@ -12684,8 +15376,10 @@ fn test_regfile_latch_rejects_let_source() {
     let result = TypeChecker::new(&symbols, &ast).check();
     assert!(result.is_err(), "latch RF with `let` source should error");
     let err_msg = format!("{:?}", result.err().unwrap());
-    assert!(err_msg.contains("kind: latch regfile") && err_msg.contains("flop"),
-        "diagnostic should explain the flop-source requirement; got: {err_msg}");
+    assert!(
+        err_msg.contains("kind: latch regfile") && err_msg.contains("flop"),
+        "diagnostic should explain the flop-source requirement; got: {err_msg}"
+    );
 }
 
 const LATCH_RF_INTERNAL_DECL: &str = "
@@ -12713,7 +15407,8 @@ const LATCH_RF_INTERNAL_DECL: &str = "
 
 #[test]
 fn test_regfile_latch_internal_emits_sample_flops_and_gated_latches() {
-    let source = format!("{LATCH_RF_INTERNAL_DECL}
+    let source = format!(
+        "{LATCH_RF_INTERNAL_DECL}
         module Top
           port clk: in Clock<SysDomain>;
           port we_in:    in Bool;
@@ -12731,22 +15426,44 @@ fn test_regfile_latch_internal_emits_sample_flops_and_gated_latches() {
             read_data  -> q;
           end inst rf
         end module Top
-    ");
+    "
+    );
     let sv = compile_to_sv(&source);
-    let body: String = sv.split("module LatchRfInt").nth(1).unwrap_or(&sv)
-        .split("endmodule").next().unwrap_or(&sv).to_string();
-    assert!(body.contains("we_q"),     "expected we_q sample flop:\n{body}");
-    assert!(body.contains("waddr_q"),  "expected waddr_q sample flop:\n{body}");
-    assert!(body.contains("wdata_q"),  "expected wdata_q sample flop:\n{body}");
-    assert!(body.contains("always_ff @(posedge clk)"),
-        "expected sample flop always_ff:\n{body}");
+    let body: String = sv
+        .split("module LatchRfInt")
+        .nth(1)
+        .unwrap_or(&sv)
+        .split("endmodule")
+        .next()
+        .unwrap_or(&sv)
+        .to_string();
+    assert!(body.contains("we_q"), "expected we_q sample flop:\n{body}");
+    assert!(
+        body.contains("waddr_q"),
+        "expected waddr_q sample flop:\n{body}"
+    );
+    assert!(
+        body.contains("wdata_q"),
+        "expected wdata_q sample flop:\n{body}"
+    );
+    assert!(
+        body.contains("always_ff @(posedge clk)"),
+        "expected sample flop always_ff:\n{body}"
+    );
     let n_latch = body.matches("always_latch").count();
-    assert_eq!(n_latch, 4, "expected 4 always_latch blocks (NREGS=4):\n{body}");
+    assert_eq!(
+        n_latch, 4,
+        "expected 4 always_latch blocks (NREGS=4):\n{body}"
+    );
     // ICG-equivalent gating: latch transparent only when clk is low.
-    assert!(body.contains("!clk"),
-        "expected `!clk` gating in latch enable for ICG-equivalent path:\n{body}");
-    assert!(body.contains("we_q && waddr_q == 2'd0"),
-        "row 0 enable should use sampled (q) signals:\n{body}");
+    assert!(
+        body.contains("!clk"),
+        "expected `!clk` gating in latch enable for ICG-equivalent path:\n{body}"
+    );
+    assert!(
+        body.contains("we_q && waddr_q == 2'd0"),
+        "row 0 enable should use sampled (q) signals:\n{body}"
+    );
 }
 
 #[test]
@@ -12754,7 +15471,8 @@ fn test_regfile_latch_internal_skips_flop_source_check() {
     // With flops: internal the regfile owns its own sample flops, so the
     // caller is allowed to drive write pins from a `let` (combinational
     // expression). This is the static-check skip property.
-    let source = format!("{LATCH_RF_INTERNAL_DECL}
+    let source = format!(
+        "{LATCH_RF_INTERNAL_DECL}
         module Top
           port clk: in Clock<SysDomain>;
           port a: in UInt<8>;
@@ -12775,7 +15493,8 @@ fn test_regfile_latch_internal_skips_flop_source_check() {
             read_data  -> q;
           end inst rf
         end module Top
-    ");
+    "
+    );
     let tokens = lexer::tokenize(&source).expect("lex");
     let mut parser = Parser::new(tokens, &source);
     let ast = parser.parse_source_file().expect("parse");
@@ -12783,8 +15502,11 @@ fn test_regfile_latch_internal_skips_flop_source_check() {
     let ast = elaborate::lower_threads(ast).expect("lower threads");
     let symbols = resolve::resolve(&ast).expect("resolve");
     let result = TypeChecker::new(&symbols, &ast).check();
-    assert!(result.is_ok(),
-        "flops: internal should skip flop-source check; got error: {:?}", result.err());
+    assert!(
+        result.is_ok(),
+        "flops: internal should skip flop-source check; got error: {:?}",
+        result.err()
+    );
 }
 
 #[test]
@@ -12794,23 +15516,45 @@ fn test_regfile_latch_internal_sim_codegen_emits_sample_flops_and_gated_capture(
     // during clk-low (the half-cycle latch transparency window).
     let source = format!("{LATCH_RF_INTERNAL_DECL}");
     let cpp = compile_to_sim_h(&source, false);
-    assert!(cpp.contains("_we_q"),    "expected _we_q sample flop in sim:\n{cpp}");
-    assert!(cpp.contains("_waddr_q"), "expected _waddr_q sample flop in sim:\n{cpp}");
-    assert!(cpp.contains("_wdata_q"), "expected _wdata_q sample flop in sim:\n{cpp}");
+    assert!(
+        cpp.contains("_we_q"),
+        "expected _we_q sample flop in sim:\n{cpp}"
+    );
+    assert!(
+        cpp.contains("_waddr_q"),
+        "expected _waddr_q sample flop in sim:\n{cpp}"
+    );
+    assert!(
+        cpp.contains("_wdata_q"),
+        "expected _wdata_q sample flop in sim:\n{cpp}"
+    );
     // Posedge: sample.
-    assert!(cpp.contains("_we_q = write_en;"),
-        "sim should sample _we_q from write_en on posedge:\n{cpp}");
+    assert!(
+        cpp.contains("_we_q = write_en;"),
+        "sim should sample _we_q from write_en on posedge:\n{cpp}"
+    );
     // Comb: latch transparency gated by `!clk && _we_q`.
-    assert!(cpp.contains("if (!clk && _we_q)"),
-        "sim should gate latch capture with `!clk && _we_q`:\n{cpp}");
-    assert!(cpp.contains("_rf[_waddr_q] = _wdata_q;"),
-        "sim should capture _wdata_q into _rf[_waddr_q]:\n{cpp}");
+    assert!(
+        cpp.contains("if (!clk && _we_q)"),
+        "sim should gate latch capture with `!clk && _we_q`:\n{cpp}"
+    );
+    assert!(
+        cpp.contains("_rf[_waddr_q] = _wdata_q;"),
+        "sim should capture _wdata_q into _rf[_waddr_q]:\n{cpp}"
+    );
     // Posedge must NOT contain a direct flop-style write — that would
     // collapse the latch into a flop and lose the 1-cycle latency.
-    let posedge = cpp.split("eval_posedge() {").nth(1).unwrap_or("")
-        .split("}").next().unwrap_or("");
-    assert!(!posedge.contains("_rf[write_addr]"),
-        "eval_posedge must NOT do a flop-style _rf write under flops:internal:\n{posedge}");
+    let posedge = cpp
+        .split("eval_posedge() {")
+        .nth(1)
+        .unwrap_or("")
+        .split("}")
+        .next()
+        .unwrap_or("");
+    assert!(
+        !posedge.contains("_rf[write_addr]"),
+        "eval_posedge must NOT do a flop-style _rf write under flops:internal:\n{posedge}"
+    );
 }
 
 #[test]
@@ -12840,16 +15584,27 @@ fn test_regfile_latch_external_sim_codegen_uses_comb_latch() {
         end regfile LatchExtRf
     ";
     let cpp = compile_to_sim_h(source, false);
-    assert!(!cpp.contains("_we_q"),
-        "external flops should NOT emit _we_q sample flop:\n{cpp}");
+    assert!(
+        !cpp.contains("_we_q"),
+        "external flops should NOT emit _we_q sample flop:\n{cpp}"
+    );
     // Comb-time latch update gated by write_en.
-    assert!(cpp.contains("if (write_en)") && cpp.contains("_rf[write_addr] = write_data;"),
-        "external flops sim should be a comb-gated _rf write:\n{cpp}");
+    assert!(
+        cpp.contains("if (write_en)") && cpp.contains("_rf[write_addr] = write_data;"),
+        "external flops sim should be a comb-gated _rf write:\n{cpp}"
+    );
     // Posedge eval must not directly sample _rf (that's flop semantics).
-    let posedge = cpp.split("eval_posedge() {").nth(1).unwrap_or("")
-        .split("}").next().unwrap_or("");
-    assert!(!posedge.contains("_rf[write_addr] = write_data"),
-        "eval_posedge must not be the only writer under kind:latch:\n{posedge}");
+    let posedge = cpp
+        .split("eval_posedge() {")
+        .nth(1)
+        .unwrap_or("")
+        .split("}")
+        .next()
+        .unwrap_or("");
+    assert!(
+        !posedge.contains("_rf[write_addr] = write_data"),
+        "eval_posedge must not be the only writer under kind:latch:\n{posedge}"
+    );
 }
 
 #[test]
@@ -12874,10 +15629,14 @@ fn test_regfile_flop_default_unchanged() {
         end regfile FlopRf
     ";
     let sv = compile_to_sv(source);
-    assert!(sv.contains("always_ff @(posedge clk)"),
-        "default kind:flop should emit always_ff:\n{sv}");
-    assert!(!sv.contains("always_latch"),
-        "default kind:flop should not emit always_latch:\n{sv}");
+    assert!(
+        sv.contains("always_ff @(posedge clk)"),
+        "default kind:flop should emit always_ff:\n{sv}"
+    );
+    assert!(
+        !sv.contains("always_latch"),
+        "default kind:flop should not emit always_latch:\n{sv}"
+    );
 }
 
 #[test]
@@ -12924,8 +15683,10 @@ fn test_sim_codegen_comb_match_arm_recurses_into_nested_for() {
     let case_0_body = case_0_section.split("break;").next().unwrap_or("");
     assert!(case_0_body.contains("for (int i ="),
         "comb match arm with nested for should emit the for loop (post-fix); pre-fix the comb walker dropped it:\n{cpp}");
-    assert!(case_0_body.contains("0xAA") || case_0_body.contains("170"),
-        "for-body assign of 0xAA should reach the C++ sim:\n{cpp}");
+    assert!(
+        case_0_body.contains("0xAA") || case_0_body.contains("170"),
+        "for-body assign of 0xAA should reach the C++ sim:\n{cpp}"
+    );
 }
 
 #[test]
@@ -12966,12 +15727,16 @@ fn test_sim_codegen_match_arm_let_bound_ident_emits_case_with_literal() {
     // emit, but it must NOT be `default:` for the three arms, and
     // must contain the three values 0/1/2.
     let default_count = cpp.matches("default:").count();
-    assert!(default_count <= 1,
-        "fix means only the wildcard arm emits `default:`; got {default_count}\n{cpp}");
+    assert!(
+        default_count <= 1,
+        "fix means only the wildcard arm emits `default:`; got {default_count}\n{cpp}"
+    );
     // All three case values should appear as case labels.
     for (n, lit) in [(0, "case 0"), (1, "case 1"), (2, "case 2")] {
-        assert!(cpp.contains(lit) || cpp.contains(&format!("case {n}u")) ,
-            "let-bound ident arm should emit `case {n}` for value {n}:\n{cpp}");
+        assert!(
+            cpp.contains(lit) || cpp.contains(&format!("case {n}u")),
+            "let-bound ident arm should emit `case {n}` for value {n}:\n{cpp}"
+        );
     }
     // The arm bodies should be paired with their case values, not
     // collapsed onto a single default. Search for the body marker.
@@ -13015,8 +15780,10 @@ fn test_sim_codegen_match_arm_local_param_const_emits_case_with_literal() {
     assert!(default_count <= 1,
         "literal-default `local param` arms must fold to `case <lit>:`, not `default:`; got {default_count}\n{cpp}");
     for (n, lit) in [(0, "case 0"), (1, "case 1"), (2, "case 2")] {
-        assert!(cpp.contains(lit) || cpp.contains(&format!("case {n}u")),
-            "param-bound ident arm should emit `case {n}`:\n{cpp}");
+        assert!(
+            cpp.contains(lit) || cpp.contains(&format!("case {n}u")),
+            "param-bound ident arm should emit `case {n}`:\n{cpp}"
+        );
     }
     assert!(cpp.contains("0xAA") || cpp.contains("170"));
     assert!(cpp.contains("0xBB") || cpp.contains("187"));
@@ -13056,8 +15823,10 @@ fn test_sim_codegen_concat_with_local_param_uses_declared_width() {
         "param OPCODE[6:0] must be treated as 7 bits wide in concat offsets; cpp lacks `<< 7`:\n{cpp}");
     // And the 7+5=12-bit boundary should produce `<< 12` for the 20-bit
     // imm field, not `<< 13`.
-    assert!(cpp.contains("<< 12"),
-        "7-bit OPCODE + 5-bit rd must place 20-bit imm at offset 12, not 13:\n{cpp}");
+    assert!(
+        cpp.contains("<< 12"),
+        "7-bit OPCODE + 5-bit rd must place 20-bit imm at offset 12, not 13:\n{cpp}"
+    );
 }
 
 #[test]
@@ -13098,8 +15867,10 @@ fn test_lower_threads_clones_parent_params_into_threads_submodule() {
     // own `localparam [1:0] OP_GO = 2'd2`.
     let sv = compile_to_sv(source);
     // Parent module still declares OP_GO.
-    assert!(sv.contains("localparam [1:0] OP_GO = 2'd2"),
-        "parent module must keep its localparam OP_GO:\n{sv}");
+    assert!(
+        sv.contains("localparam [1:0] OP_GO = 2'd2"),
+        "parent module must keep its localparam OP_GO:\n{sv}"
+    );
     // Synthetic threads submodule should ALSO declare OP_GO, not refer
     // to an undeclared identifier. The emit places submodule decls
     // ahead of the parent module, but both must contain it.
@@ -13108,8 +15879,10 @@ fn test_lower_threads_clones_parent_params_into_threads_submodule() {
         "both parent and `_M_threads` submodule should declare OP_GO; only {occurrences} occurrence(s):\n{sv}");
     // And the thread body's predicate must reference OP_GO (proves the
     // identifier survived lowering).
-    assert!(sv.contains("OP_GO") && sv.matches("OP_GO").count() >= 3,
-        "thread body should compare op_i against OP_GO:\n{sv}");
+    assert!(
+        sv.contains("OP_GO") && sv.matches("OP_GO").count() >= 3,
+        "thread body should compare op_i against OP_GO:\n{sv}"
+    );
 }
 
 #[test]
@@ -13159,9 +15932,7 @@ fn test_lower_threads_forwards_parent_params_to_threads_inst() {
         "top-level override should still be emitted:\n{sv}"
     );
     assert!(
-        sv.contains(
-            "_ParamThread_threads #(.DONE_VALUE(DONE_VALUE), .OUT_W(OUT_W)) _threads ("
-        ),
+        sv.contains("_ParamThread_threads #(.DONE_VALUE(DONE_VALUE), .OUT_W(OUT_W)) _threads ("),
         "wrapper must forward overridable params into the synthesized threads helper:\n{sv}"
     );
     assert!(
@@ -13192,16 +15963,26 @@ fn test_thread_sim_declares_module_params_used_by_thread_body() {
         end module M
     "#;
     let h = compile_to_thread_sim_h(source);
-    assert!(h.contains("static constexpr uint64_t SCHEDULED_CORE_CYCLES = 7ULL;"),
-        "thread sim header should declare module param constants:\n{h}");
-    assert!(h.contains("static constexpr uint64_t DONE_W = 8ULL;"),
-        "derived module params should be folded for C++ visibility:\n{h}");
-    assert!(h.contains("co_await arch_rt::wait_cycles(&_slot_0, SCHEDULED_CORE_CYCLES);"),
-        "wait-cycle expression should keep using the declared constexpr param:\n{h}");
-    assert!(h.contains("done = DONE_W;"),
-        "thread body should use the declared constexpr param:\n{h}");
-    assert!(h.contains("uint8_t done = 0;"),
-        "param-derived port widths should resolve in thread sim C++ types:\n{h}");
+    assert!(
+        h.contains("static constexpr uint64_t SCHEDULED_CORE_CYCLES = 7ULL;"),
+        "thread sim header should declare module param constants:\n{h}"
+    );
+    assert!(
+        h.contains("static constexpr uint64_t DONE_W = 8ULL;"),
+        "derived module params should be folded for C++ visibility:\n{h}"
+    );
+    assert!(
+        h.contains("co_await arch_rt::wait_cycles(&_slot_0, SCHEDULED_CORE_CYCLES);"),
+        "wait-cycle expression should keep using the declared constexpr param:\n{h}"
+    );
+    assert!(
+        h.contains("done = DONE_W;"),
+        "thread body should use the declared constexpr param:\n{h}"
+    );
+    assert!(
+        h.contains("uint8_t done = 0;"),
+        "param-derived port widths should resolve in thread sim C++ types:\n{h}"
+    );
 }
 
 #[test]
@@ -13227,16 +16008,26 @@ fn test_sim_codegen_declares_typed_module_params_used_by_lowered_thread_body() {
         end module M
     "#;
     let cpp = compile_to_sim_h(source, false);
-    assert!(cpp.contains("#define SCHEDULED_CORE_CYCLES 7ULL"),
-        "sim header should define typed module params for lowered thread bodies:\n{cpp}");
-    assert!(cpp.contains("#define DONE_W 8ULL"),
-        "derived typed module params should be folded for C++ visibility:\n{cpp}");
-    assert!(cpp.contains("#define CALLS 3ULL"),
-        "narrow typed module params should also be emitted:\n{cpp}");
-    assert!(cpp.contains("uint8_t done;"),
-        "param-derived port widths should resolve in normal sim C++ types:\n{cpp}");
-    assert!(cpp.contains("_n_calls_r  = CALLS;"),
-        "lowered thread body should keep using the declared C++ param constant:\n{cpp}");
+    assert!(
+        cpp.contains("#define SCHEDULED_CORE_CYCLES 7ULL"),
+        "sim header should define typed module params for lowered thread bodies:\n{cpp}"
+    );
+    assert!(
+        cpp.contains("#define DONE_W 8ULL"),
+        "derived typed module params should be folded for C++ visibility:\n{cpp}"
+    );
+    assert!(
+        cpp.contains("#define CALLS 3ULL"),
+        "narrow typed module params should also be emitted:\n{cpp}"
+    );
+    assert!(
+        cpp.contains("uint8_t done;"),
+        "param-derived port widths should resolve in normal sim C++ types:\n{cpp}"
+    );
+    assert!(
+        cpp.contains("_n_calls_r  = CALLS;"),
+        "lowered thread body should keep using the declared C++ param constant:\n{cpp}"
+    );
 }
 
 #[test]
@@ -13280,17 +16071,23 @@ fn test_sim_codegen_bit_slice_lhs_compiles_and_uses_param_width() {
     let cpp = compile_to_sim_h(source, false);
     // Slice-LHS must lower to a mask-and-OR write — not the pre-fix rvalue
     // form `((_n_counter_q >> 0) & MASK) = ...`.
-    assert!(!cpp.contains(") =") || cpp.contains("== "),
-        "slice-LHS regression: rvalue form must not appear:\n{cpp}");
+    assert!(
+        !cpp.contains(") =") || cpp.contains("== "),
+        "slice-LHS regression: rvalue form must not appear:\n{cpp}"
+    );
     // The clear-mask must be 32 bits (0xFFFFFFFFULL), not 33 (0x1FFFFFFFFULL).
-    assert!(cpp.contains("0xFFFFFFFFULL"),
-        "slice-LHS should use a 32-bit mask for [CounterWidth-1:0] when CounterWidth=32:\n{cpp}");
+    assert!(
+        cpp.contains("0xFFFFFFFFULL"),
+        "slice-LHS should use a 32-bit mask for [CounterWidth-1:0] when CounterWidth=32:\n{cpp}"
+    );
     assert!(!cpp.contains("0x1FFFFFFFFULL"),
         "slice-LHS must not use a 33-bit mask for [CounterWidth-1:0] (param folding regression):\n{cpp}");
     // Sanity: the mask-and-OR shape includes `& ~(uint64_t(0x...` for the clear
     // and `| ((uint64_t(...` for the set.
-    assert!(cpp.contains("_n_counter_q = (_n_counter_q & ~"),
-        "expected mask-and-OR LHS shape:\n{cpp}");
+    assert!(
+        cpp.contains("_n_counter_q = (_n_counter_q & ~"),
+        "expected mask-and-OR LHS shape:\n{cpp}"
+    );
 }
 
 #[test]
@@ -13334,19 +16131,30 @@ fn test_sim_codegen_async_reset_fires_outside_rising_edge() {
     // Anchor on the eval_posedge function definition and slice through
     // the function body (closes at the next `\n}\n` after the open).
     let start_marker = "void VM::eval_posedge() {";
-    let pe_start = cpp.find(start_marker)
+    let pe_start = cpp
+        .find(start_marker)
         .unwrap_or_else(|| panic!("expected eval_posedge body in:\n{cpp}"));
     let pe_body = &cpp[pe_start + start_marker.len()..];
     let pe_body = pe_body.split("\n}\n").next().unwrap_or("");
     let async_pos = pe_body.find("if ((!rst_ni))");
     let rising_pos = pe_body.find("if (_rising_clk)");
-    assert!(async_pos.is_some(), "async reset arm should be emitted in eval_posedge:\n{pe_body}");
-    assert!(rising_pos.is_some(), "rising-edge guard should be emitted in eval_posedge:\n{pe_body}");
-    assert!(async_pos.unwrap() < rising_pos.unwrap(),
-        "async reset arm must precede the rising-edge gate:\n{pe_body}");
+    assert!(
+        async_pos.is_some(),
+        "async reset arm should be emitted in eval_posedge:\n{pe_body}"
+    );
+    assert!(
+        rising_pos.is_some(),
+        "rising-edge guard should be emitted in eval_posedge:\n{pe_body}"
+    );
+    assert!(
+        async_pos.unwrap() < rising_pos.unwrap(),
+        "async reset arm must precede the rising-edge gate:\n{pe_body}"
+    );
     // The async arm writes to both `_q_r` (live) and `_n_q_r` (shadow).
-    assert!(pe_body.contains("_q_r = 0;") && pe_body.contains("_n_q_r = 0;"),
-        "async reset must write both live and shadow regs:\n{pe_body}");
+    assert!(
+        pe_body.contains("_q_r = 0;") && pe_body.contains("_n_q_r = 0;"),
+        "async reset must write both live and shadow regs:\n{pe_body}"
+    );
 }
 
 #[test]
@@ -13388,8 +16196,10 @@ fn test_sim_codegen_collect_assigns_walks_indexed_lhs() {
         end module M
     ";
     let cpp = compile_to_sim_h(source, false);
-    assert!(cpp.contains("_q_r = 0;"),
-        "indexed-LHS reg should still get its async reset arm:\n{cpp}");
+    assert!(
+        cpp.contains("_q_r = 0;"),
+        "indexed-LHS reg should still get its async reset arm:\n{cpp}"
+    );
 }
 
 #[test]
@@ -13442,8 +16252,10 @@ fn test_cc_dispatch_rewrites_seq_match_scrutinee() {
     let sv = compile_to_sv(source);
     // Scrutinee must be rewritten — pre-fix this would compile-error in the
     // resolver because `p.data.data` was untouched.
-    assert!(sv.contains("case (__p_data_data)"),
-        "seq-block match scrutinee should rewrite to __p_data_data:\n{sv}");
+    assert!(
+        sv.contains("case (__p_data_data)"),
+        "seq-block match scrutinee should rewrite to __p_data_data:\n{sv}"
+    );
 }
 
 #[test]
@@ -13508,11 +16320,15 @@ fn test_comb_for_loop_body_type_checked_as_comb() {
     let ast = elaborate::lower_threads(ast).expect("lower threads");
     let symbols = resolve::resolve(&ast).expect("resolve");
     let result = TypeChecker::new(&symbols, &ast).check();
-    assert!(result.is_err(),
-        "assigning to a `reg` in a comb-block for-loop body must be a typecheck error");
+    assert!(
+        result.is_err(),
+        "assigning to a `reg` in a comb-block for-loop body must be a typecheck error"
+    );
     let err_msg = format!("{:?}", result.err().unwrap());
-    assert!(err_msg.contains("`arr_r` is a reg") && err_msg.contains("seq"),
-        "diagnostic should explain reg-vs-seq rule; got: {err_msg}");
+    assert!(
+        err_msg.contains("`arr_r` is a reg") && err_msg.contains("seq"),
+        "diagnostic should explain reg-vs-seq rule; got: {err_msg}"
+    );
 }
 
 // ── unpacked-array port emission ─────────────────────────────────────────
@@ -13537,13 +16353,19 @@ end module unpacked_demo
 "#;
     let sv = compile_to_sv(source);
     // packed Vec port stays packed (default).
-    assert!(sv.contains("input logic [1:0] [31:0] packed_in"),
-            "packed Vec port should keep packed multi-dim shape, got: {sv}");
+    assert!(
+        sv.contains("input logic [1:0] [31:0] packed_in"),
+        "packed Vec port should keep packed multi-dim shape, got: {sv}"
+    );
     // unpacked Vec port flips to SV unpacked-array shape.
-    assert!(sv.contains("input logic [31:0] unpacked_in [1:0]"),
-            "unpacked Vec port should emit SV unpacked array, got: {sv}");
-    assert!(sv.contains("output logic [31:0] unpacked_out [1:0]"),
-            "unpacked Vec output port should emit SV unpacked array, got: {sv}");
+    assert!(
+        sv.contains("input logic [31:0] unpacked_in [1:0]"),
+        "unpacked Vec port should emit SV unpacked array, got: {sv}"
+    );
+    assert!(
+        sv.contains("output logic [31:0] unpacked_out [1:0]"),
+        "unpacked Vec output port should emit SV unpacked array, got: {sv}"
+    );
     // Internal body indexing is identical regardless of port shape.
     assert!(sv.contains("assign unpacked_out[0] = unpacked_in[0]"));
 }
@@ -13568,13 +16390,19 @@ end module unpacked_asc_demo
 "#;
     let sv = compile_to_sv(source);
     // `ascending` flips both directions.
-    assert!(sv.contains("input logic [5:0] asc_in [0:3]"),
-            "ascending unpacked input should emit [0:N-1], got: {sv}");
-    assert!(sv.contains("output logic [5:0] asc_out [0:3]"),
-            "ascending unpacked output should emit [0:N-1], got: {sv}");
+    assert!(
+        sv.contains("input logic [5:0] asc_in [0:3]"),
+        "ascending unpacked input should emit [0:N-1], got: {sv}"
+    );
+    assert!(
+        sv.contains("output logic [5:0] asc_out [0:3]"),
+        "ascending unpacked output should emit [0:N-1], got: {sv}"
+    );
     // Plain `unpacked` (no `ascending`) keeps default descending.
-    assert!(sv.contains("input logic [5:0] desc_in [3:0]"),
-            "plain unpacked stays descending, got: {sv}");
+    assert!(
+        sv.contains("input logic [5:0] desc_in [3:0]"),
+        "plain unpacked stays descending, got: {sv}"
+    );
     // ARCH-side indexing is unchanged — `asc_in[0]` is still the first
     // element regardless of SV dim direction.
     assert!(sv.contains("assign asc_out[0] = asc_in[0]"));
@@ -13603,8 +16431,10 @@ module asc_wire_demo
 end module asc_wire_demo
 "#;
     let sv = compile_to_sv(source);
-    assert!(sv.contains("logic [5:0] w [0:3]"),
-            "ascending unpacked wire should emit [0:N-1], got: {sv}");
+    assert!(
+        sv.contains("logic [5:0] w [0:3]"),
+        "ascending unpacked wire should emit [0:N-1], got: {sv}"
+    );
 }
 
 #[test]
@@ -13623,12 +16453,16 @@ end module AscIface
     let tokens = lexer::tokenize(source).expect("lexer error");
     let mut parser = Parser::new(tokens, source);
     let parsed = parser.parse_source_file().expect("parse error");
-    let item = parsed.items.iter()
+    let item = parsed
+        .items
+        .iter()
         .find(|i| matches!(i, arch::ast::Item::Module(_)))
         .expect("expected a module item");
     let body = arch::interface::emit_interface(item).expect("emit_interface");
-    assert!(body.contains("port asc_in: in unpacked ascending Vec"),
-            ".archi should preserve `unpacked ascending`: {body}");
+    assert!(
+        body.contains("port asc_in: in unpacked ascending Vec"),
+        ".archi should preserve `unpacked ascending`: {body}"
+    );
 }
 
 #[test]
@@ -13651,7 +16485,9 @@ end module PipeIface
     let tokens = lexer::tokenize(source).expect("lexer error");
     let mut parser = Parser::new(tokens, source);
     let parsed = parser.parse_source_file().expect("parse error");
-    let item = parsed.items.iter()
+    let item = parsed
+        .items
+        .iter()
         .find(|i| matches!(i, arch::ast::Item::Module(_)))
         .expect("expected a module item");
     let body = arch::interface::emit_interface(item).expect("emit_interface");
@@ -13679,10 +16515,15 @@ end module unpacked_neg
     let tokens = lexer::tokenize(source).expect("lex");
     let mut parser = Parser::new(tokens, source);
     let result = parser.parse_source_file();
-    assert!(result.is_err(), "unpacked on non-Vec should be a parse error");
+    assert!(
+        result.is_err(),
+        "unpacked on non-Vec should be a parse error"
+    );
     let msg = format!("{:?}", result.err().unwrap());
-    assert!(msg.contains("`unpacked` is only valid on `Vec<T,N>` ports"),
-            "diagnostic should explain Vec-only restriction, got: {msg}");
+    assert!(
+        msg.contains("`unpacked` is only valid on `Vec<T,N>` ports"),
+        "diagnostic should explain Vec-only restriction, got: {msg}"
+    );
 }
 
 #[test]
@@ -13695,10 +16536,15 @@ end module unpacked_neg2
     let tokens = lexer::tokenize(source).expect("lex");
     let mut parser = Parser::new(tokens, source);
     let result = parser.parse_source_file();
-    assert!(result.is_err(), "unpacked + port reg should be a parse error");
+    assert!(
+        result.is_err(),
+        "unpacked + port reg should be a parse error"
+    );
     let msg = format!("{:?}", result.err().unwrap());
-    assert!(msg.contains("`unpacked` is not allowed on `port reg`"),
-            "diagnostic should explain port-reg restriction, got: {msg}");
+    assert!(
+        msg.contains("`unpacked` is not allowed on `port reg`"),
+        "diagnostic should explain port-reg restriction, got: {msg}"
+    );
 }
 
 #[test]
@@ -13752,8 +16598,10 @@ end module BadRdc
     assert!(
         errs.iter().any(|e| {
             let s = e.to_string();
-            s.contains("RDC violation") && s.contains("rst")
-                && s.contains("DomA") && s.contains("DomB")
+            s.contains("RDC violation")
+                && s.contains("rst")
+                && s.contains("DomA")
+                && s.contains("DomB")
         }),
         "expected RDC error naming both domains, got: {:?}",
         errs
@@ -13805,7 +16653,11 @@ end module GoodRdc
     let symbols = resolve::resolve(&ast).expect("resolve");
     let checker = TypeChecker::new(&symbols, &ast);
     let result = checker.check();
-    assert!(result.is_ok(), "expected no RDC error, got: {:?}", result.err());
+    assert!(
+        result.is_ok(),
+        "expected no RDC error, got: {:?}",
+        result.err()
+    );
 }
 
 #[test]
@@ -13844,8 +16696,11 @@ end module M
     let symbols = resolve::resolve(&ast).expect("resolve");
     let checker = TypeChecker::new(&symbols, &ast);
     let result = checker.check();
-    assert!(result.is_ok(),
-        "expected guard-waivered RDC to pass, got: {:?}", result.err());
+    assert!(
+        result.is_ok(),
+        "expected guard-waivered RDC to pass, got: {:?}",
+        result.err()
+    );
 }
 
 #[test]
@@ -13885,15 +16740,18 @@ end module M
     let symbols = resolve::resolve(&ast).expect("resolve");
     let checker = TypeChecker::new(&symbols, &ast);
     let result = checker.check();
-    assert!(result.is_err(), "expected RDC error (sync guard doesn't qualify)");
+    assert!(
+        result.is_err(),
+        "expected RDC error (sync guard doesn't qualify)"
+    );
     let errs = result.unwrap_err();
     assert!(
         errs.iter().any(|e| {
             let s = e.to_string();
-            s.contains("RDC violation") && s.contains("data_q")
-                && s.contains("not async-reset")
+            s.contains("RDC violation") && s.contains("data_q") && s.contains("not async-reset")
         }),
-        "expected hint about non-async guard, got: {:?}", errs
+        "expected hint about non-async guard, got: {:?}",
+        errs
     );
 }
 
@@ -13929,15 +16787,20 @@ end module M
     let symbols = resolve::resolve(&ast).expect("resolve");
     let checker = TypeChecker::new(&symbols, &ast);
     let result = checker.check();
-    assert!(result.is_err(), "expected RDC error (port guard doesn't qualify)");
+    assert!(
+        result.is_err(),
+        "expected RDC error (port guard doesn't qualify)"
+    );
     let errs = result.unwrap_err();
     assert!(
         errs.iter().any(|e| {
             let s = e.to_string();
-            s.contains("RDC violation") && s.contains("data_q")
+            s.contains("RDC violation")
+                && s.contains("data_q")
                 && s.contains("not a register in this module")
         }),
-        "expected hint about port-input guard, got: {:?}", errs
+        "expected hint about port-input guard, got: {:?}",
+        errs
     );
 }
 
@@ -13984,14 +16847,18 @@ end module M
     let symbols = resolve::resolve(&ast).expect("resolve");
     let checker = TypeChecker::new(&symbols, &ast);
     let result = checker.check();
-    assert!(result.is_err(), "expected RDC error (cross-domain guard doesn't waive)");
+    assert!(
+        result.is_err(),
+        "expected RDC error (cross-domain guard doesn't waive)"
+    );
     let errs = result.unwrap_err();
     assert!(
         errs.iter().any(|e| {
             let s = e.to_string();
             s.contains("RDC violation") && s.contains("data_q")
         }),
-        "expected RDC error on data_q, got: {:?}", errs
+        "expected RDC error on data_q, got: {:?}",
+        errs
     );
 }
 
@@ -14030,7 +16897,6 @@ end module SingleDomain
     assert!(checker.check().is_ok());
 }
 
-
 // ─── RDC phase 2a: data-path reset domain crossing tests ────────────────────
 // Rule (option 1, sync flops are transparent):
 //   reach[f] = { f.reset } if f.reset_kind == Async, else union of reach[srcs]
@@ -14052,7 +16918,11 @@ fn rdc_check(source: &str) -> Result<(), Vec<arch::diagnostics::CompileError>> {
 
 fn assert_rdc_ok(label: &str, source: &str) {
     let r = rdc_check(source);
-    assert!(r.is_ok(), "[{label}] expected no RDC error, got: {:?}", r.err());
+    assert!(
+        r.is_ok(),
+        "[{label}] expected no RDC error, got: {:?}",
+        r.err()
+    );
 }
 
 fn assert_rdc_fails(label: &str, source: &str, must_contain: &[&str]) {
@@ -14065,9 +16935,11 @@ fn assert_rdc_fails(label: &str, source: &str, must_contain: &[&str]) {
         // shares its diagnostic shape across both hazard classes.
         (s.contains("RDC") || s.contains("CDC")) && must_contain.iter().all(|m| s.contains(m))
     });
-    assert!(any_match,
+    assert!(
+        any_match,
         "[{label}] expected RDC/CDC error containing all of {:?}, got: {:?}",
-        must_contain, errs);
+        must_contain, errs
+    );
 }
 
 // ── Group A: direct edges (1-hop) ───────────────────────────────────────────
@@ -14075,7 +16947,9 @@ fn assert_rdc_fails(label: &str, source: &str, must_contain: &[&str]) {
 #[test]
 fn rdc_a1_same_async_direct_ok() {
     // ra (rst_a, async) → rb (rst_a, async); same domain → no violation.
-    assert_rdc_ok("A1", r#"
+    assert_rdc_ok(
+        "A1",
+        r#"
 domain D
   freq_mhz: 100
 end domain D
@@ -14092,20 +16966,26 @@ module M
   end seq
   let q = rb;
 end module M
-"#);
+"#,
+    );
 }
 
 #[test]
 fn rdc_reset_type_cast_at_inst_is_direct_reset_ok() {
     // `rst <- rst_async_n as Reset<Async, Low>` is a reset type override at
     // the inst boundary. It should not be classified as reset-combining logic.
-    assert_rdc_ok("reset-cast-inst", include_str!("../examples/param_reset.arch"));
+    assert_rdc_ok(
+        "reset-cast-inst",
+        include_str!("../examples/param_reset.arch"),
+    );
 }
 
 #[test]
 fn rdc_a2_diff_async_direct_fails() {
     // ra (rst_a, async) → rb (rst_b, async); different async domains → FAIL.
-    assert_rdc_fails("A2", r#"
+    assert_rdc_fails(
+        "A2",
+        r#"
 domain D
   freq_mhz: 100
 end domain D
@@ -14125,7 +17005,9 @@ module M
   end seq
   let q = rb;
 end module M
-"#, &["rst_a", "rst_b"]);
+"#,
+        &["rst_a", "rst_b"],
+    );
 }
 
 #[test]
@@ -14134,7 +17016,9 @@ fn rdc_a3_async_to_sync_fails() {
     // transparent for propagation but cannot gate its data input on the
     // upstream's async reset event; mid-deassert transients on `ra`
     // metastabilise `rb` and propagate downstream. Flag.
-    assert_rdc_fails("A3", r#"
+    assert_rdc_fails(
+        "A3",
+        r#"
 domain D
   freq_mhz: 100
 end domain D
@@ -14154,7 +17038,9 @@ module M
   end seq
   let q = rb;
 end module M
-"#, &["rst_a", "rb"]);
+"#,
+        &["rst_a", "rb"],
+    );
 }
 
 #[test]
@@ -14162,7 +17048,9 @@ fn rdc_a4_async_to_none_fails() {
     // ra (rst_a, async) → rb (reset none). Strict rule: a reset-less
     // flop cannot gate its data input on the source's async reset
     // event; mid-deassert transients on `ra` metastabilise `rb`. Flag.
-    assert_rdc_fails("A4", r#"
+    assert_rdc_fails(
+        "A4",
+        r#"
 domain D
   freq_mhz: 100
 end domain D
@@ -14181,14 +17069,18 @@ module M
   end seq
   let q = rb;
 end module M
-"#, &["rst_a", "rb"]);
+"#,
+        &["rst_a", "rb"],
+    );
 }
 
 #[test]
 fn rdc_a5_sync_source_ok() {
     // ra (rst_a, sync) sourced from a port has reach[ra]=∅. Then rb
     // (rst_b, async) reads ra → reach[rb's src]=∅ → no violation.
-    assert_rdc_ok("A5", r#"
+    assert_rdc_ok(
+        "A5",
+        r#"
 domain D
   freq_mhz: 100
 end domain D
@@ -14208,7 +17100,8 @@ module M
   end seq
   let q = rb;
 end module M
-"#);
+"#,
+    );
 }
 
 // ── Group B: 2-hop chains (the canonical reset-less / sync-bridge bug) ─────
@@ -14217,7 +17110,9 @@ end module M
 fn rdc_b1_async_none_async_diff_fails() {
     // ra (rst_a) → rx (none) → rb (rst_b). reach[rx]={rst_a};
     // reach[rb's src]={rst_a} ≠ rb.reset=rst_b → FAIL at rb.
-    assert_rdc_fails("B1", r#"
+    assert_rdc_fails(
+        "B1",
+        r#"
 domain D
   freq_mhz: 100
 end domain D
@@ -14241,7 +17136,9 @@ module M
   end seq
   let q = rb;
 end module M
-"#, &["rst_a", "rst_b"]);
+"#,
+        &["rst_a", "rst_b"],
+    );
 }
 
 #[test]
@@ -14251,7 +17148,9 @@ fn rdc_b2_async_none_async_same_fails() {
     // being gated on the upstream reset; even though both async flops
     // share rst_a, the middle hop is the metastability propagator.
     // Fix is to also reset `rx` by rst_a (or add a synchroniser).
-    assert_rdc_fails("B2", r#"
+    assert_rdc_fails(
+        "B2",
+        r#"
 domain D
   freq_mhz: 100
 end domain D
@@ -14272,13 +17171,17 @@ module M
   end seq
   let q = rb;
 end module M
-"#, &["rst_a", "rx"]);
+"#,
+        &["rst_a", "rx"],
+    );
 }
 
 #[test]
 fn rdc_b3_async_sync_async_diff_fails() {
     // Sync rx is transparent like none → still flagged.
-    assert_rdc_fails("B3", r#"
+    assert_rdc_fails(
+        "B3",
+        r#"
 domain D
   freq_mhz: 100
 end domain D
@@ -14303,7 +17206,9 @@ module M
   end seq
   let q = rb;
 end module M
-"#, &["rst_a", "rst_b"]);
+"#,
+        &["rst_a", "rst_b"],
+    );
 }
 
 // ── Group C: convergence at non-async flop ─────────────────────────────────
@@ -14312,7 +17217,9 @@ end module M
 fn rdc_c1_two_async_converge_at_none_fails() {
     // ra (rst_a) and rb (rst_b) both feed rx (none).
     // reach[rx]={rst_a, rst_b} → FAIL at rx.
-    assert_rdc_fails("C1", r#"
+    assert_rdc_fails(
+        "C1",
+        r#"
 domain D
   freq_mhz: 100
 end domain D
@@ -14337,7 +17244,9 @@ module M
   end seq
   let q = rx;
 end module M
-"#, &["rst_a", "rst_b"]);
+"#,
+        &["rst_a", "rst_b"],
+    );
 }
 
 #[test]
@@ -14346,7 +17255,9 @@ fn rdc_c2_two_same_domain_converge_fails() {
     // Strict rule: rx is reset-less, captures async-domain data without
     // gating on the upstream reset event → flag, even though only one
     // async domain reaches it. The fix is to also reset `rx` by rst_a.
-    assert_rdc_fails("C2", r#"
+    assert_rdc_fails(
+        "C2",
+        r#"
 domain D
   freq_mhz: 100
 end domain D
@@ -14368,7 +17279,9 @@ module M
   end seq
   let q = rx;
 end module M
-"#, &["rst_a", "rx"]);
+"#,
+        &["rst_a", "rx"],
+    );
 }
 
 #[test]
@@ -14376,7 +17289,9 @@ fn rdc_c3_async_plus_port_at_none_fails() {
     // ra (rst_a) + port input → rx (reset none). Port contributes no
     // async, but rx still captures async-domain data from `ra` without
     // a reset gate — flag.
-    assert_rdc_fails("C3", r#"
+    assert_rdc_fails(
+        "C3",
+        r#"
 domain D
   freq_mhz: 100
 end domain D
@@ -14396,7 +17311,9 @@ module M
   end seq
   let q = rx;
 end module M
-"#, &["rst_a", "rx"]);
+"#,
+        &["rst_a", "rx"],
+    );
 }
 
 // ── Group D: multi-clock-domain interactions ───────────────────────────────
@@ -14407,7 +17324,9 @@ fn rdc_d1_same_async_two_clocks_no_data_path_phase1_flags() {
     // two clock domains, regardless of whether a data path exists. Phase
     // 2's data-path rule alone would let this pass; we keep phase 1 as a
     // structural backstop so the test pins the union of both checks.
-    assert_rdc_fails("D1", r#"
+    assert_rdc_fails(
+        "D1",
+        r#"
 domain DA
   freq_mhz: 100
 end domain DA
@@ -14433,7 +17352,9 @@ module M
   let qa = ra;
   let qb = rb;
 end module M
-"#, &["rst", "DA", "DB"]);
+"#,
+        &["rst", "DA", "DB"],
+    );
 }
 
 #[test]
@@ -14441,7 +17362,9 @@ fn rdc_d2_diff_async_diff_clocks_with_path_fails() {
     // Two clocks, two async resets, data path between them → FAIL.
     // Module marks itself `cdc_safe` to opt out of the CDC check (which
     // would otherwise also fire on this design); RDC must still flag.
-    assert_rdc_fails("D2", r#"
+    assert_rdc_fails(
+        "D2",
+        r#"
 domain DA
   freq_mhz: 100
 end domain DA
@@ -14466,14 +17389,18 @@ module M
   end seq
   let q = rb;
 end module M
-"#, &["rst_a", "rst_b"]);
+"#,
+        &["rst_a", "rst_b"],
+    );
 }
 
 // ── Group E: feedback loops (require fixpoint) ─────────────────────────────
 
 #[test]
 fn rdc_e1_self_loop_same_domain_ok() {
-    assert_rdc_ok("E1", r#"
+    assert_rdc_ok(
+        "E1",
+        r#"
 domain D
   freq_mhz: 100
 end domain D
@@ -14487,14 +17414,17 @@ module M
   end seq
   let q = ra;
 end module M
-"#);
+"#,
+    );
 }
 
 #[test]
 fn rdc_e2_mutual_feedback_diff_domains_fails() {
     // ra ↔ rb across different async domains. Fixpoint converges with
     // reach[rb's src]={rst_a} and reach[ra's src]={rst_b}; both flagged.
-    assert_rdc_fails("E2", r#"
+    assert_rdc_fails(
+        "E2",
+        r#"
 domain D
   freq_mhz: 100
 end domain D
@@ -14513,7 +17443,9 @@ module M
   end seq
   let q = ra;
 end module M
-"#, &["rst_a", "rst_b"]);
+"#,
+        &["rst_a", "rst_b"],
+    );
 }
 
 // ── Group F: trivial / sanity ──────────────────────────────────────────────
@@ -14521,7 +17453,9 @@ end module M
 #[test]
 fn rdc_f1_single_async_domain_ok() {
     // Several flops all reset by rst_a → no violation.
-    assert_rdc_ok("F1", r#"
+    assert_rdc_ok(
+        "F1",
+        r#"
 domain D
   freq_mhz: 100
 end domain D
@@ -14540,13 +17474,16 @@ module M
   end seq
   let q = r3;
 end module M
-"#);
+"#,
+    );
 }
 
 #[test]
 fn rdc_f2_no_async_flops_ok() {
     // All sync — phase-2 rule originates no domain → no violation.
-    assert_rdc_ok("F2", r#"
+    assert_rdc_ok(
+        "F2",
+        r#"
 domain D
   freq_mhz: 100
 end domain D
@@ -14563,7 +17500,8 @@ module M
   end seq
   let q = r2;
 end module M
-"#);
+"#,
+    );
 }
 
 // ── Group G: Phase 2b — clock-gating cell enable from async reset ─────────
@@ -14598,15 +17536,16 @@ fn rdc_g3_clkgate_enable_from_sync_flop_ok() {
 
 #[test]
 fn rdc_h1_reconvergent_two_syncs_same_domain_fails() {
-    let src = std::fs::read_to_string("tests/rdc/rdc_h1_reconvergent_two_syncs_same_domain_fail.arch")
-        .expect("read H1");
+    let src =
+        std::fs::read_to_string("tests/rdc/rdc_h1_reconvergent_two_syncs_same_domain_fail.arch")
+            .expect("read H1");
     assert_rdc_fails("H1", &src, &["raw_rst", "sync_a", "sync_b", "Dst"]);
 }
 
 #[test]
 fn rdc_h2_single_reset_sync_ok() {
-    let src = std::fs::read_to_string("tests/rdc/rdc_h2_single_reset_sync_ok.arch")
-        .expect("read H2");
+    let src =
+        std::fs::read_to_string("tests/rdc/rdc_h2_single_reset_sync_ok.arch").expect("read H2");
     assert_rdc_ok("H2", &src);
 }
 
@@ -14619,8 +17558,9 @@ fn rdc_h3_reset_syncs_to_diff_domains_ok() {
 
 #[test]
 fn rdc_h4_reconvergent_three_syncs_same_domain_fails() {
-    let src = std::fs::read_to_string("tests/rdc/rdc_h4_reconvergent_three_syncs_same_domain_fail.arch")
-        .expect("read H4");
+    let src =
+        std::fs::read_to_string("tests/rdc/rdc_h4_reconvergent_three_syncs_same_domain_fail.arch")
+            .expect("read H4");
     assert_rdc_fails("H4", &src, &["raw_rst", "sync_1", "Dst"]);
 }
 
@@ -14629,15 +17569,17 @@ fn rdc_h4_reconvergent_three_syncs_same_domain_fails() {
 
 #[test]
 fn rdc_j1_cdc_reconvergent_two_ff_syncs_same_domain_fails() {
-    let src = std::fs::read_to_string("tests/rdc/rdc_j1_cdc_reconvergent_two_ff_syncs_same_domain_fail.arch")
-        .expect("read J1");
+    let src = std::fs::read_to_string(
+        "tests/rdc/rdc_j1_cdc_reconvergent_two_ff_syncs_same_domain_fail.arch",
+    )
+    .expect("read J1");
     assert_rdc_fails("J1", &src, &["CDC", "flag", "sync_a", "sync_b", "Dst"]);
 }
 
 #[test]
 fn rdc_j2_cdc_single_ff_sync_ok() {
-    let src = std::fs::read_to_string("tests/rdc/rdc_j2_cdc_single_ff_sync_ok.arch")
-        .expect("read J2");
+    let src =
+        std::fs::read_to_string("tests/rdc/rdc_j2_cdc_single_ff_sync_ok.arch").expect("read J2");
     assert_rdc_ok("J2", &src);
 }
 
@@ -14650,8 +17592,10 @@ fn rdc_j3_cdc_syncs_to_diff_domains_ok() {
 
 #[test]
 fn rdc_j4_mixed_reset_and_data_sync_same_source_fails() {
-    let src = std::fs::read_to_string("tests/rdc/rdc_j4_mixed_reset_and_data_sync_same_source_same_domain_fail.arch")
-        .expect("read J4");
+    let src = std::fs::read_to_string(
+        "tests/rdc/rdc_j4_mixed_reset_and_data_sync_same_source_same_domain_fail.arch",
+    )
+    .expect("read J4");
     assert_rdc_fails("J4", &src, &["RDC/CDC", "shared", "Dst"]);
 }
 
@@ -14679,13 +17623,19 @@ fn package_width_qualified_param_emits_bracket_form() {
     ";
     let sv = compile_to_sv(source);
     // Untyped const stays `localparam int`.
-    assert!(sv.contains("localparam int NARROW = 42;"),
-            "untyped const must keep `int`:\n{sv}");
+    assert!(
+        sv.contains("localparam int NARROW = 42;"),
+        "untyped const must keep `int`:\n{sv}"
+    );
     // Width-qualified params must keep the [hi:lo] qualifier.
-    assert!(sv.contains("localparam [31:0] WIDE32 = 42;"),
-            "32-bit width qualifier dropped:\n{sv}");
-    assert!(sv.contains("localparam [63:0] WIDE64 = 24314014034;"),
-            "64-bit width qualifier dropped (would truncate):\n{sv}");
+    assert!(
+        sv.contains("localparam [31:0] WIDE32 = 42;"),
+        "32-bit width qualifier dropped:\n{sv}"
+    );
+    assert!(
+        sv.contains("localparam [63:0] WIDE64 = 24314014034;"),
+        "64-bit width qualifier dropped (would truncate):\n{sv}"
+    );
 }
 
 #[test]
@@ -14712,14 +17662,18 @@ fn package_enum_typed_param_emits_typedef_before_localparam() {
         end module M
     ";
     let sv = compile_to_sv(source);
-    let typedef_pos = sv.find("typedef enum")
-        .expect("typedef enum missing");
-    let param_pos = sv.find("DEFAULT_OP")
+    let typedef_pos = sv.find("typedef enum").expect("typedef enum missing");
+    let param_pos = sv
+        .find("DEFAULT_OP")
         .expect("DEFAULT_OP localparam missing");
-    assert!(typedef_pos < param_pos,
-        "enum typedef must precede localparam that references it:\n{sv}");
-    assert!(sv.contains("localparam Op DEFAULT_OP = "),
-        "EnumConst must emit typed `localparam Op …`:\n{sv}");
+    assert!(
+        typedef_pos < param_pos,
+        "enum typedef must precede localparam that references it:\n{sv}"
+    );
+    assert!(
+        sv.contains("localparam Op DEFAULT_OP = "),
+        "EnumConst must emit typed `localparam Op …`:\n{sv}"
+    );
 }
 
 // ── Group K: Phase 2d — combiner-derived reset glitches at inst boundaries
@@ -14728,29 +17682,29 @@ fn package_enum_typed_param_emits_typedef_before_localparam() {
 
 #[test]
 fn rdc_k1_combiner_or_at_inst_fails() {
-    let src = std::fs::read_to_string("tests/rdc/rdc_k1_combiner_or_at_inst_fail.arch")
-        .expect("read K1");
+    let src =
+        std::fs::read_to_string("tests/rdc/rdc_k1_combiner_or_at_inst_fail.arch").expect("read K1");
     assert_rdc_fails("K1", &src, &["sub", "rst", "combinational"]);
 }
 
 #[test]
 fn rdc_k2_negation_at_inst_fails() {
-    let src = std::fs::read_to_string("tests/rdc/rdc_k2_negation_at_inst_fail.arch")
-        .expect("read K2");
+    let src =
+        std::fs::read_to_string("tests/rdc/rdc_k2_negation_at_inst_fail.arch").expect("read K2");
     assert_rdc_fails("K2", &src, &["sub", "rst", "combinational"]);
 }
 
 #[test]
 fn rdc_k3_direct_reset_at_inst_ok() {
-    let src = std::fs::read_to_string("tests/rdc/rdc_k3_direct_reset_at_inst_ok.arch")
-        .expect("read K3");
+    let src =
+        std::fs::read_to_string("tests/rdc/rdc_k3_direct_reset_at_inst_ok.arch").expect("read K3");
     assert_rdc_ok("K3", &src);
 }
 
 #[test]
 fn rdc_k4_sync_output_to_reset_ok() {
-    let src = std::fs::read_to_string("tests/rdc/rdc_k4_sync_output_to_reset_ok.arch")
-        .expect("read K4");
+    let src =
+        std::fs::read_to_string("tests/rdc/rdc_k4_sync_output_to_reset_ok.arch").expect("read K4");
     assert_rdc_ok("K4", &src);
 }
 
@@ -14792,8 +17746,8 @@ fn rdc_m4_cdc_let_alias_same_source_fails() {
 
 #[test]
 fn rdc_m5_cdc_distinct_sources_ok() {
-    let src = std::fs::read_to_string("tests/rdc/rdc_m5_cdc_distinct_sources_ok.arch")
-        .expect("read M5");
+    let src =
+        std::fs::read_to_string("tests/rdc/rdc_m5_cdc_distinct_sources_ok.arch").expect("read M5");
     assert_rdc_ok("M5", &src);
 }
 
@@ -14811,22 +17765,25 @@ fn rdc_m6_cdc_bit_slice_distinct_vecs_ok() {
 
 #[test]
 fn rdc_l1_pragma_rdc_safe_suppresses_phase2a() {
-    let src = std::fs::read_to_string("tests/rdc/rdc_l1_pragma_rdc_safe_suppresses_phase2a_ok.arch")
-        .expect("read L1");
+    let src =
+        std::fs::read_to_string("tests/rdc/rdc_l1_pragma_rdc_safe_suppresses_phase2a_ok.arch")
+            .expect("read L1");
     assert_rdc_ok("L1", &src);
 }
 
 #[test]
 fn rdc_l2_pragma_rdc_safe_suppresses_phase2c() {
-    let src = std::fs::read_to_string("tests/rdc/rdc_l2_pragma_rdc_safe_suppresses_phase2c_ok.arch")
-        .expect("read L2");
+    let src =
+        std::fs::read_to_string("tests/rdc/rdc_l2_pragma_rdc_safe_suppresses_phase2c_ok.arch")
+            .expect("read L2");
     assert_rdc_ok("L2", &src);
 }
 
 #[test]
 fn rdc_l3_pragma_rdc_safe_suppresses_phase2d() {
-    let src = std::fs::read_to_string("tests/rdc/rdc_l3_pragma_rdc_safe_suppresses_phase2d_ok.arch")
-        .expect("read L3");
+    let src =
+        std::fs::read_to_string("tests/rdc/rdc_l3_pragma_rdc_safe_suppresses_phase2d_ok.arch")
+            .expect("read L3");
     assert_rdc_ok("L3", &src);
 }
 
@@ -14863,8 +17820,10 @@ end module M
     let result = parser.parse_source_file();
     assert!(result.is_err(), "unknown pragma should be a parse error");
     let msg = format!("{:?}", result.err().unwrap());
-    assert!(msg.contains("unknown pragma") && msg.contains("totally_unsafe"),
-        "expected unknown-pragma diagnostic, got: {msg}");
+    assert!(
+        msg.contains("unknown pragma") && msg.contains("totally_unsafe"),
+        "expected unknown-pragma diagnostic, got: {msg}"
+    );
 }
 
 #[test]
@@ -14910,7 +17869,9 @@ end module Parent
     let mut parsed_ast = parser.parse_source_file().expect("parse");
     for item in parsed_ast.items.iter_mut() {
         if let arch::ast::Item::Module(m) = item {
-            if m.name.name == "ChildStub" { m.is_interface = true; }
+            if m.name.name == "ChildStub" {
+                m.is_interface = true;
+            }
         }
     }
     let ast = elaborate::elaborate(parsed_ast).expect("elaborate");
@@ -14922,13 +17883,19 @@ end module Parent
     let ast = elaborate::lower_credit_channel_dispatch(ast).expect("credit_channel dispatch");
     let symbols = resolve::resolve(&ast).expect("resolve");
     let checker = TypeChecker::new(&symbols, &ast);
-    let (_warnings, overload_map) = checker.check()
+    let (_warnings, overload_map) = checker
+        .check()
         .expect("typecheck must not report 'output port out_o is not driven' on interface stub");
     let mut codegen = Codegen::new(&symbols, &ast, overload_map);
     let sv = codegen.generate();
-    assert!(sv.contains("module Parent"), "parent module should be emitted");
-    assert!(!sv.contains("module ChildStub"),
-        "interface stub must not be emitted to SV (real impl lives in a separately-built file)");
+    assert!(
+        sv.contains("module Parent"),
+        "parent module should be emitted"
+    );
+    assert!(
+        !sv.contains("module ChildStub"),
+        "interface stub must not be emitted to SV (real impl lives in a separately-built file)"
+    );
 }
 
 #[test]
@@ -14972,14 +17939,17 @@ end module Parent
 "#;
     let tokens = lexer::tokenize(source).expect("lex");
     let mut parser = Parser::new(tokens, source);
-    let mut parsed_ast = parser.parse_source_file()
+    let mut parsed_ast = parser
+        .parse_source_file()
         .expect("parser must accept body-less fsm (interface stub)");
     // Mimic main.rs's post-parse tagger: items loaded from `.archi` get
     // is_interface = true. Here we tag the FSM by name to simulate
     // "loaded from <name>.archi".
     for item in parsed_ast.items.iter_mut() {
         if let arch::ast::Item::Fsm(f) = item {
-            if f.name.name == "ChildFsm" { f.common.is_interface = true; }
+            if f.name.name == "ChildFsm" {
+                f.common.is_interface = true;
+            }
         }
     }
     let ast = elaborate::elaborate(parsed_ast).expect("elaborate");
@@ -14992,13 +17962,19 @@ end module Parent
     let symbols = resolve::resolve(&ast)
         .expect("resolve must accept fsm interface stub (no default_state validation)");
     let checker = TypeChecker::new(&symbols, &ast);
-    let (_warnings, overload_map) = checker.check()
+    let (_warnings, overload_map) = checker
+        .check()
         .expect("typecheck must skip body checks on fsm interface stub");
     let mut codegen = Codegen::new(&symbols, &ast, overload_map);
     let sv = codegen.generate();
-    assert!(sv.contains("module Parent"), "parent module should be emitted");
-    assert!(!sv.contains("module ChildFsm"),
-        "fsm interface stub must not be emitted to SV (real impl lives in a separately-built file)");
+    assert!(
+        sv.contains("module Parent"),
+        "parent module should be emitted"
+    );
+    assert!(
+        !sv.contains("module ChildFsm"),
+        "fsm interface stub must not be emitted to SV (real impl lives in a separately-built file)"
+    );
 }
 
 #[test]
@@ -15026,14 +18002,18 @@ end fsm BrokenFsm
 "#;
     let tokens = lexer::tokenize(source).expect("lex");
     let mut parser = Parser::new(tokens, source);
-    let parsed_ast = parser.parse_source_file()
+    let parsed_ast = parser
+        .parse_source_file()
         .expect("parser accepts body-less fsm now; default-state check moved to resolve");
     let ast = elaborate::elaborate(parsed_ast).expect("elaborate");
-    let resolve_err = resolve::resolve(&ast).err()
+    let resolve_err = resolve::resolve(&ast)
+        .err()
         .expect("real fsm without default_state must still error");
     let msg = format!("{resolve_err:?}");
-    assert!(msg.contains("default state"),
-        "expected `default state` diagnostic, got: {msg}");
+    assert!(
+        msg.contains("default state"),
+        "expected `default state` diagnostic, got: {msg}"
+    );
 }
 
 #[test]
@@ -15084,8 +18064,10 @@ end fsm Painter
 "#;
     let sv = compile_to_sv(source);
     // Package is emitted up front (no change here — that's package codegen).
-    assert!(sv.contains("package SharedPkg;"),
-        "package SharedPkg should be emitted to SV");
+    assert!(
+        sv.contains("package SharedPkg;"),
+        "package SharedPkg should be emitted to SV"
+    );
     assert!(sv.contains("import SharedPkg::*;"),
         "fsm consumer of `use SharedPkg;` must emit `import SharedPkg::*;` so the module body can reference `Color` without a fully-qualified name");
     // Sanity: the import comes BEFORE the module declaration so the type
@@ -15197,13 +18179,20 @@ end module M
         panic!("no `begin` precedes the assign; SV malformed:\n{}", sv);
     });
     // Extract the line containing that `begin`.
-    let line_start = preceding[..last_begin_at].rfind('\n').map(|p| p + 1).unwrap_or(0);
+    let line_start = preceding[..last_begin_at]
+        .rfind('\n')
+        .map(|p| p + 1)
+        .unwrap_or(0);
     let begin_line = &preceding[line_start..last_begin_at + "begin".len()];
-    assert!(!begin_line.contains("if (cond_b)"),
+    assert!(
+        !begin_line.contains("if (cond_b)"),
         "inter-yield seq assign `x <= 8'd42` must NOT be wrapped in \
          `if (cond_b) begin ... end` — that's the pre-fix merge-into-wait-state \
          behavior, which conflicts with spec §7a.2 (only TRAILING assigns merge). \
-         Enclosing begin-line was: {:?}\nFull SV:\n{}", begin_line, sv);
+         Enclosing begin-line was: {:?}\nFull SV:\n{}",
+        begin_line,
+        sv
+    );
 }
 
 #[test]
@@ -15260,9 +18249,11 @@ end module M
         panic!("missing S0 wait branch in SV:\n{sv}");
     });
     let after_s0 = &sv[s0_start + s0_marker.len()..];
-    let s1_rel = after_s0.find("if (_t0_state == _t0_S1_action) begin").unwrap_or_else(|| {
-        panic!("missing S1 action branch after S0 in SV:\n{sv}");
-    });
+    let s1_rel = after_s0
+        .find("if (_t0_state == _t0_S1_action) begin")
+        .unwrap_or_else(|| {
+            panic!("missing S1 action branch after S0 in SV:\n{sv}");
+        });
     let s0_branch = &sv[s0_start..s0_start + s0_marker.len() + s1_rel];
 
     assert!(
@@ -15419,7 +18410,9 @@ end module M
     let trimmed: String = sv.split_whitespace().collect::<Vec<_>>().join(" ");
 
     assert!(
-        trimmed.contains("if (_t0_state == _t0_S0_wait_until) begin if (start) begin done = done | 1'b1"),
+        trimmed.contains(
+            "if (_t0_state == _t0_S0_wait_until) begin if (start) begin done = done | 1'b1"
+        ),
         "comb assign after fast gate should be gated by start in the S0 comb block:\n{sv}"
     );
 }
@@ -15499,7 +18492,9 @@ end module M
     let trimmed: String = sv.split_whitespace().collect::<Vec<_>>().join(" ");
 
     assert!(
-        trimmed.contains("_t0_state == _t0_S0_wait_until) begin if (start) begin _t0_state <= _t0_S1_wait_until"),
+        trimmed.contains(
+            "_t0_state == _t0_S0_wait_until) begin if (start) begin _t0_state <= _t0_S1_wait_until"
+        ),
         "S0 should wait for start before entering the following fast-gate fused state:\n{sv}"
     );
     assert!(
@@ -15578,7 +18573,9 @@ end module M
         "lock after fast gate should preserve the start wait before entering lock arbitration:\n{sv}"
     );
     assert!(
-        trimmed.contains("_t0_state == _t0_S0_wait_until) begin if (start) begin _t0_state <= _t0_S1_wait_until"),
+        trimmed.contains(
+            "_t0_state == _t0_S0_wait_until) begin if (start) begin _t0_state <= _t0_S1_wait_until"
+        ),
         "S0 should transition into the lock state only when start is true:\n{sv}"
     );
 }
@@ -15622,12 +18619,15 @@ end module M
         "fork/join after fast gate should preserve the start wait and enter fork product states after it:\n{sv}"
     );
     assert!(
-        trimmed.contains("_t0_state == _t0_S0_wait_until) begin if (start) begin _t0_state <= _t0_S1_action"),
+        trimmed.contains(
+            "_t0_state == _t0_S0_wait_until) begin if (start) begin _t0_state <= _t0_S1_action"
+        ),
         "S0 should transition into fork/join lowering only when start is true:\n{sv}"
     );
     assert!(
         !trimmed.contains("_t0_state == _t0_S0_wait_until) begin if (start) begin a_r <= 1'b1")
-            && !trimmed.contains("_t0_state == _t0_S0_wait_until) begin if (start) begin b_r <= 1'b1"),
+            && !trimmed
+                .contains("_t0_state == _t0_S0_wait_until) begin if (start) begin b_r <= 1'b1"),
         "fork branch bodies should remain in fork product states, not collapse into S0:\n{sv}"
     );
 }
@@ -15664,13 +18664,22 @@ fn test_unpacked_wire_modifier_emits_unpacked_sv() {
     ";
     let sv = compile_to_sv(source);
     // Wire emits unpacked-array shape, not packed multi-dim.
-    assert!(sv.contains("logic [31:0] bridge [1:0]") || sv.contains("logic [31:0] bridge [0:1]"),
-        "expected unpacked wire shape `logic [31:0] bridge [N-1:0]`, got:\n{}", sv);
-    assert!(!sv.contains("logic [1:0][31:0] bridge"),
-        "must NOT emit packed multi-dim for `unpacked` wire, got:\n{}", sv);
+    assert!(
+        sv.contains("logic [31:0] bridge [1:0]") || sv.contains("logic [31:0] bridge [0:1]"),
+        "expected unpacked wire shape `logic [31:0] bridge [N-1:0]`, got:\n{}",
+        sv
+    );
+    assert!(
+        !sv.contains("logic [1:0][31:0] bridge"),
+        "must NOT emit packed multi-dim for `unpacked` wire, got:\n{}",
+        sv
+    );
     // Parent's port still uses unpacked (sanity).
-    assert!(sv.contains("input logic [31:0] pq [1:0]") || sv.contains("input logic [31:0] pq [0:1]"),
-        "expected unpacked port shape on parent, got:\n{}", sv);
+    assert!(
+        sv.contains("input logic [31:0] pq [1:0]") || sv.contains("input logic [31:0] pq [0:1]"),
+        "expected unpacked port shape on parent, got:\n{}",
+        sv
+    );
 }
 
 #[test]
@@ -15703,14 +18712,19 @@ end cam TestCam
     let tokens = lexer::tokenize(source).expect("lexer error");
     let mut parser = Parser::new(tokens, source);
     let parsed = parser.parse_source_file().expect("parse error");
-    let item = parsed.items.iter()
+    let item = parsed
+        .items
+        .iter()
         .find(|i| matches!(i, arch::ast::Item::Cam(_)))
         .expect("expected a cam item");
-    let body = arch::interface::emit_interface(item)
-        .expect("cam should now emit an .archi interface");
+    let body =
+        arch::interface::emit_interface(item).expect("cam should now emit an .archi interface");
     assert!(body.starts_with("cam TestCam\n"), "body: {body}");
     assert!(body.contains("param DEPTH: const = 8;"), "body: {body}");
-    assert!(body.contains("port search_first: out UInt<3>;"), "body: {body}");
+    assert!(
+        body.contains("port search_first: out UInt<3>;"),
+        "body: {body}"
+    );
     assert!(body.ends_with("end cam TestCam\n"), "body: {body}");
 }
 
@@ -15742,19 +18756,29 @@ end arbiter TestArb
     let tokens = lexer::tokenize(source).expect("lexer error");
     let mut parser = Parser::new(tokens, source);
     let parsed = parser.parse_source_file().expect("parse error");
-    let item = parsed.items.iter()
+    let item = parsed
+        .items
+        .iter()
         .find(|i| matches!(i, arch::ast::Item::Arbiter(_)))
         .expect("expected an arbiter item");
-    let body = arch::interface::emit_interface(item)
-        .expect("arbiter should emit an .archi interface");
-    assert!(body.contains("ports[NUM_REQ] request"),
-            ".archi must include the ports[N] group: {body}");
-    assert!(body.contains("    valid: in Bool;"),
-            ".archi must include per-requester valid signal: {body}");
-    assert!(body.contains("    ready: out Bool;"),
-            ".archi must include per-requester ready signal: {body}");
-    assert!(body.contains("  end ports request"),
-            ".archi ports group must be properly closed: {body}");
+    let body =
+        arch::interface::emit_interface(item).expect("arbiter should emit an .archi interface");
+    assert!(
+        body.contains("ports[NUM_REQ] request"),
+        ".archi must include the ports[N] group: {body}"
+    );
+    assert!(
+        body.contains("    valid: in Bool;"),
+        ".archi must include per-requester valid signal: {body}"
+    );
+    assert!(
+        body.contains("    ready: out Bool;"),
+        ".archi must include per-requester ready signal: {body}"
+    );
+    assert!(
+        body.contains("  end ports request"),
+        ".archi ports group must be properly closed: {body}"
+    );
 }
 
 #[test]
@@ -15818,22 +18842,34 @@ end module Parent
 ";
     let sv = compile_to_sv(source);
     // Synthesized wire is declared.
-    assert!(sv.contains("logic [3:0] __arb_request_valid;"),
-            "expected synthesized vector wire: {sv}");
+    assert!(
+        sv.contains("logic [3:0] __arb_request_valid;"),
+        "expected synthesized vector wire: {sv}"
+    );
     // Each bit of the wire is driven from the user's per-index
     // expression.
-    assert!(sv.contains("assign __arb_request_valid[0] = req0;"),
-            "expected per-index drive [0]: {sv}");
-    assert!(sv.contains("assign __arb_request_valid[3] = req3;"),
-            "expected per-index drive [3]: {sv}");
+    assert!(
+        sv.contains("assign __arb_request_valid[0] = req0;"),
+        "expected per-index drive [0]: {sv}"
+    );
+    assert!(
+        sv.contains("assign __arb_request_valid[3] = req3;"),
+        "expected per-index drive [3]: {sv}"
+    );
     // The whole vector is connected to the inst's `request_valid` port.
-    assert!(sv.contains(".request_valid(__arb_request_valid)"),
-            "expected whole-vector connection: {sv}");
+    assert!(
+        sv.contains(".request_valid(__arb_request_valid)"),
+        "expected whole-vector connection: {sv}"
+    );
     // The non-existent flattened port names must NOT appear.
-    assert!(!sv.contains(".request0_valid("),
-            "must not emit per-index port name: {sv}");
-    assert!(!sv.contains(".request3_valid("),
-            "must not emit per-index port name: {sv}");
+    assert!(
+        !sv.contains(".request0_valid("),
+        "must not emit per-index port name: {sv}"
+    );
+    assert!(
+        !sv.contains(".request3_valid("),
+        "must not emit per-index port name: {sv}"
+    );
 }
 
 #[test]
@@ -15872,17 +18908,23 @@ end ram TagRam
 ";
     let sv = compile_to_sv(source);
     // SV header includes the user param.
-    assert!(sv.contains("parameter int TagW = 22"),
-            "user param TagW must appear in SV header: {sv}");
+    assert!(
+        sv.contains("parameter int TagW = 22"),
+        "user param TagW must appear in SV header: {sv}"
+    );
     // DATA_WIDTH is derived from the store element type. Default may
     // be the symbolic param `TagW` (forward-resolves via the user
     // param decl above) or the literal `22`; either is correct SV.
-    assert!(sv.contains("parameter int DATA_WIDTH = TagW")
-         || sv.contains("parameter int DATA_WIDTH = 22"),
-            "DATA_WIDTH should follow the store element width: {sv}");
+    assert!(
+        sv.contains("parameter int DATA_WIDTH = TagW")
+            || sv.contains("parameter int DATA_WIDTH = 22"),
+        "DATA_WIDTH should follow the store element width: {sv}"
+    );
     // Port refs to TagW now resolve.
-    assert!(sv.contains("[TagW-1:0]"),
-            "port type must keep referencing TagW: {sv}");
+    assert!(
+        sv.contains("[TagW-1:0]"),
+        "port type must keep referencing TagW: {sv}"
+    );
 }
 
 #[test]
@@ -15913,10 +18955,14 @@ module DocLocal
 end module DocLocal
 ";
     let sv = compile_to_sv(source);
-    assert!(sv.contains("parameter int Foo = 32"),
-            "regular param should still emit: {sv}");
-    assert!(sv.contains("localparam int Bar = 64"),
-            "local param after doc comment should still emit: {sv}");
+    assert!(
+        sv.contains("parameter int Foo = 32"),
+        "regular param should still emit: {sv}"
+    );
+    assert!(
+        sv.contains("localparam int Bar = 64"),
+        "local param after doc comment should still emit: {sv}"
+    );
 }
 
 #[test]
@@ -15946,21 +18992,31 @@ end module UpkPort
     let tokens = lexer::tokenize(source).expect("lexer error");
     let mut parser = Parser::new(tokens, source);
     let parsed = parser.parse_source_file().expect("parse error");
-    let item = parsed.items.iter()
+    let item = parsed
+        .items
+        .iter()
         .find(|i| matches!(i, arch::ast::Item::Module(_)))
         .expect("expected a module item");
     let body = arch::interface::emit_interface(item).expect("emit_interface");
-    assert!(body.contains("port a: in unpacked Vec<UInt<W>, N>;"),
-            "unpacked input port should round-trip into .archi: {body}");
+    assert!(
+        body.contains("port a: in unpacked Vec<UInt<W>, N>;"),
+        "unpacked input port should round-trip into .archi: {body}"
+    );
     // Issue #246 Phase 2: output ports may pick up a `comb_dep_on(...)`
     // suffix listing the precise input ports that feed each output.
-    assert!(body.contains("port b: out unpacked Vec<UInt<W>, N>"),
-            "unpacked output port should round-trip into .archi: {body}");
+    assert!(
+        body.contains("port b: out unpacked Vec<UInt<W>, N>"),
+        "unpacked output port should round-trip into .archi: {body}"
+    );
     // Packed Vec port (no `unpacked` modifier) still emits without it.
-    assert!(body.contains("port c: in Vec<UInt<W>, N>;"),
-            "packed Vec port must NOT gain the `unpacked` keyword: {body}");
-    assert!(!body.contains("port c: in unpacked Vec"),
-            "packed Vec port must NOT gain the `unpacked` keyword: {body}");
+    assert!(
+        body.contains("port c: in Vec<UInt<W>, N>;"),
+        "packed Vec port must NOT gain the `unpacked` keyword: {body}"
+    );
+    assert!(
+        !body.contains("port c: in unpacked Vec"),
+        "packed Vec port must NOT gain the `unpacked` keyword: {body}"
+    );
 }
 
 #[test]
@@ -15973,10 +19029,15 @@ fn test_unpacked_wire_rejected_on_non_vec() {
     ";
     let tokens = lexer::tokenize(source).expect("lexer");
     let mut parser = Parser::new(tokens, source);
-    let err = parser.parse_source_file().expect_err("must reject `unpacked UInt<32>`");
+    let err = parser
+        .parse_source_file()
+        .expect_err("must reject `unpacked UInt<32>`");
     let msg = format!("{:?}", err);
-    assert!(msg.contains("unpacked") && msg.contains("Vec"),
-        "error should mention the `unpacked` + Vec constraint, got: {}", msg);
+    assert!(
+        msg.contains("unpacked") && msg.contains("Vec"),
+        "error should mention the `unpacked` + Vec constraint, got: {}",
+        msg
+    );
 }
 
 #[test]
@@ -16022,8 +19083,10 @@ fn test_emit_bound_asserts_elides_for_loop_iterator_index() {
     // Sanity: bound-assertion block should be absent entirely (no
     // other Vec writes here), confirming the for-loop iterator was
     // the only candidate and it was correctly elided.
-    assert!(!sv.contains("_auto_bound_vec_"),
-        "no bound assertion expected when the only Vec index is a for-loop iterator:\n{sv}");
+    assert!(
+        !sv.contains("_auto_bound_vec_"),
+        "no bound assertion expected when the only Vec index is a for-loop iterator:\n{sv}"
+    );
 }
 
 #[test]
@@ -16066,15 +19129,21 @@ fn test_codegen_vec_uint1_collapses_inner_zero_dim() {
     ";
     let sv = compile_to_sv(source);
     // `Vec<UInt<1>, 4>` should emit as single-dim packed `logic [3:0]`.
-    assert!(sv.contains("output logic [3:0] en_v"),
-        "Vec<UInt<1>, 4> should emit as `logic [3:0]` (no inner [0:0]):\n{sv}");
-    assert!(!sv.contains("[3:0] [0:0]"),
-        "no `[N-1:0] [0:0]` multi-dim form expected for Vec<UInt<1>, _>:\n{sv}");
+    assert!(
+        sv.contains("output logic [3:0] en_v"),
+        "Vec<UInt<1>, 4> should emit as `logic [3:0]` (no inner [0:0]):\n{sv}"
+    );
+    assert!(
+        !sv.contains("[3:0] [0:0]"),
+        "no `[N-1:0] [0:0]` multi-dim form expected for Vec<UInt<1>, _>:\n{sv}"
+    );
     // Vec<Bool, 4> behaves the same (Bool is 1-bit) — sanity check the
     // emission stays single-packed (was always `logic [3:0]` pre-fix
     // because Bool's emit_type_str returns just `logic`).
-    assert!(sv.contains("output logic [3:0] mask"),
-        "Vec<Bool, 4> should still emit as `logic [3:0]`:\n{sv}");
+    assert!(
+        sv.contains("output logic [3:0] mask"),
+        "Vec<Bool, 4> should still emit as `logic [3:0]`:\n{sv}"
+    );
 }
 
 /// Loading both an `.archi` interface stub *and* the real `.arch`
@@ -16194,28 +19263,44 @@ fn test_uint_48_param_width_emits_uint64_storage() {
     let out = compile_to_sim_h(source, false);
 
     // Storage types: ports + internal regs all 48 bits → uint64_t.
-    assert!(out.contains("uint64_t score_out"),
-            "score_out port should be uint64_t for UInt<48>; got:\n{out}");
-    assert!(out.contains("uint64_t inc_in"),
-            "inc_in port should be uint64_t for UInt<48>; got:\n{out}");
-    assert!(out.contains("uint64_t _accumulator"),
-            "accumulator reg should be uint64_t for UInt<48>; got:\n{out}");
-    assert!(out.contains("uint64_t _score_reg"),
-            "score_reg reg should be uint64_t for UInt<48>; got:\n{out}");
+    assert!(
+        out.contains("uint64_t score_out"),
+        "score_out port should be uint64_t for UInt<48>; got:\n{out}"
+    );
+    assert!(
+        out.contains("uint64_t inc_in"),
+        "inc_in port should be uint64_t for UInt<48>; got:\n{out}"
+    );
+    assert!(
+        out.contains("uint64_t _accumulator"),
+        "accumulator reg should be uint64_t for UInt<48>; got:\n{out}"
+    );
+    assert!(
+        out.contains("uint64_t _score_reg"),
+        "score_reg reg should be uint64_t for UInt<48>; got:\n{out}"
+    );
 
     // _n_ shadow should match.
-    assert!(out.contains("uint64_t _n_accumulator"),
-            "_n_accumulator shadow should be uint64_t; got:\n{out}");
+    assert!(
+        out.contains("uint64_t _n_accumulator"),
+        "_n_accumulator shadow should be uint64_t; got:\n{out}"
+    );
 
     // Truncating arithmetic should mask to 48 bits (12 F's), not 32.
-    assert!(out.contains("0xFFFFFFFFFFFFULL"),
-            "expected 48-bit mask 0xFFFFFFFFFFFFULL; got:\n{out}");
-    assert!(!out.contains(" 0xFFFFFFFFULL"),
-            "must not emit 32-bit mask 0xFFFFFFFFULL for 48-bit accumulator; got:\n{out}");
+    assert!(
+        out.contains("0xFFFFFFFFFFFFULL"),
+        "expected 48-bit mask 0xFFFFFFFFFFFFULL; got:\n{out}"
+    );
+    assert!(
+        !out.contains(" 0xFFFFFFFFULL"),
+        "must not emit 32-bit mask 0xFFFFFFFFULL for 48-bit accumulator; got:\n{out}"
+    );
 
     // The seq-assign cast must be (uint64_t), not (uint32_t).
-    assert!(out.contains("(uint64_t)((((_accumulator + inc_in))"),
-            "trunc cast should be (uint64_t)(...); got:\n{out}");
+    assert!(
+        out.contains("(uint64_t)((((_accumulator + inc_in))"),
+        "trunc cast should be (uint64_t)(...); got:\n{out}"
+    );
 }
 
 #[test]
@@ -16243,18 +19328,28 @@ fn test_uint_width_boundary_buckets_with_param() {
         end module W
     "#;
     let out = compile_to_sim_h(source, false);
-    assert!(out.contains("uint32_t a32"),
-            "UInt<32> port should be uint32_t; got:\n{out}");
-    assert!(out.contains("uint64_t a33"),
-            "UInt<33> port should be uint64_t; got:\n{out}");
-    assert!(out.contains("uint64_t a64"),
-            "UInt<64> port should be uint64_t; got:\n{out}");
+    assert!(
+        out.contains("uint32_t a32"),
+        "UInt<32> port should be uint32_t; got:\n{out}"
+    );
+    assert!(
+        out.contains("uint64_t a33"),
+        "UInt<33> port should be uint64_t; got:\n{out}"
+    );
+    assert!(
+        out.contains("uint64_t a64"),
+        "UInt<64> port should be uint64_t; got:\n{out}"
+    );
     // 65 bits → wide (VlWide). Don't pin the exact word count here — just
     // assert it isn't the legacy uint32_t bucket.
-    assert!(out.contains("VlWide") && out.contains("a65"),
-            "UInt<65> port should be VlWide<...>; got:\n{out}");
-    assert!(!out.contains("uint32_t a65"),
-            "UInt<65> must not be uint32_t; got:\n{out}");
+    assert!(
+        out.contains("VlWide") && out.contains("a65"),
+        "UInt<65> port should be VlWide<...>; got:\n{out}"
+    );
+    assert!(
+        !out.contains("uint32_t a65"),
+        "UInt<65> must not be uint32_t; got:\n{out}"
+    );
 }
 
 #[test]
@@ -16277,14 +19372,22 @@ fn test_uint_48_literal_width_emits_uint64_storage() {
         end module Acc
     "#;
     let out = compile_to_sim_h(source, false);
-    assert!(out.contains("uint64_t a"),
-            "UInt<48> port should be uint64_t; got:\n{out}");
-    assert!(out.contains("uint64_t inc"),
-            "UInt<48> port should be uint64_t; got:\n{out}");
-    assert!(out.contains("uint64_t _r"),
-            "UInt<48> reg should be uint64_t; got:\n{out}");
-    assert!(out.contains("0xFFFFFFFFFFFFULL"),
-            "expected 48-bit mask; got:\n{out}");
+    assert!(
+        out.contains("uint64_t a"),
+        "UInt<48> port should be uint64_t; got:\n{out}"
+    );
+    assert!(
+        out.contains("uint64_t inc"),
+        "UInt<48> port should be uint64_t; got:\n{out}"
+    );
+    assert!(
+        out.contains("uint64_t _r"),
+        "UInt<48> reg should be uint64_t; got:\n{out}"
+    );
+    assert!(
+        out.contains("0xFFFFFFFFFFFFULL"),
+        "expected 48-bit mask; got:\n{out}"
+    );
 }
 
 #[test]
@@ -16313,25 +19416,45 @@ fn test_sint_40_param_width_emits_int64_storage_and_signed_trunc() {
     "#;
     let out = compile_to_sim_h(source, false);
 
-    assert!(out.contains("int64_t score_out"),
-            "SInt<40> output port should use int64_t storage; got:\n{out}");
-    assert!(out.contains("int64_t inc_in"),
-            "SInt<40> input port should use int64_t storage; got:\n{out}");
-    assert!(out.contains("int64_t _accumulator"),
-            "SInt<40> internal reg should use int64_t storage; got:\n{out}");
-    assert!(out.contains("int64_t _score_reg"),
-            "SInt<40> internal reg should use int64_t storage; got:\n{out}");
-    assert!(out.contains("int64_t _n_accumulator"),
-            "SInt<40> _n_ shadow should use int64_t storage; got:\n{out}");
-    assert!(!out.contains("uint32_t _accumulator"),
-            "SInt<40> accumulator must not fall into uint32_t storage; got:\n{out}");
-    assert!(!out.contains("uint64_t _accumulator"),
-            "SInt<40> accumulator must not use unsigned 64-bit storage; got:\n{out}");
+    assert!(
+        out.contains("int64_t score_out"),
+        "SInt<40> output port should use int64_t storage; got:\n{out}"
+    );
+    assert!(
+        out.contains("int64_t inc_in"),
+        "SInt<40> input port should use int64_t storage; got:\n{out}"
+    );
+    assert!(
+        out.contains("int64_t _accumulator"),
+        "SInt<40> internal reg should use int64_t storage; got:\n{out}"
+    );
+    assert!(
+        out.contains("int64_t _score_reg"),
+        "SInt<40> internal reg should use int64_t storage; got:\n{out}"
+    );
+    assert!(
+        out.contains("int64_t _n_accumulator"),
+        "SInt<40> _n_ shadow should use int64_t storage; got:\n{out}"
+    );
+    assert!(
+        !out.contains("uint32_t _accumulator"),
+        "SInt<40> accumulator must not fall into uint32_t storage; got:\n{out}"
+    );
+    assert!(
+        !out.contains("uint64_t _accumulator"),
+        "SInt<40> accumulator must not use unsigned 64-bit storage; got:\n{out}"
+    );
 
-    assert!(out.contains("0xFFFFFFFFFFULL"),
-            "SInt<40> trunc should still mask to exactly 40 bits; got:\n{out}");
-    assert!(out.contains("((int64_t)(((uint64_t)((_accumulator + inc_in)) & 0xFFFFFFFFFFULL) << 24) >> 24)"),
-            "SInt<40> trunc should sign-extend from bit 39 into int64_t; got:\n{out}");
+    assert!(
+        out.contains("0xFFFFFFFFFFULL"),
+        "SInt<40> trunc should still mask to exactly 40 bits; got:\n{out}"
+    );
+    assert!(
+        out.contains(
+            "((int64_t)(((uint64_t)((_accumulator + inc_in)) & 0xFFFFFFFFFFULL) << 24) >> 24)"
+        ),
+        "SInt<40> trunc should sign-extend from bit 39 into int64_t; got:\n{out}"
+    );
 }
 
 #[test]
@@ -16372,8 +19495,10 @@ fn test_thread_driven_sint_reg_keeps_parent_wire_type() {
     "#;
 
     let sv = compile_to_sv(source);
-    assert!(sv.contains("logic signed [W-1:0] acc;"),
-            "parent-side wire for thread-driven SInt reg should keep signedness/width:\n{sv}");
+    assert!(
+        sv.contains("logic signed [W-1:0] acc;"),
+        "parent-side wire for thread-driven SInt reg should keep signedness/width:\n{sv}"
+    );
     assert!(sv.contains("assign next_acc = W'(acc + product_ext);"),
             "parent expression should see typed signed acc/product_ext and emit the trunc assignment:\n{sv}");
 }
@@ -16419,14 +19544,22 @@ fn test_sint_40_inst_output_wire_keeps_signed_storage() {
     "#;
     let out = compile_to_sim_h(source, false);
 
-    assert!(out.contains("int64_t _let_score_wire"),
-            "SInt<40> child output wire should use int64_t storage in wrapper/native sim; got:\n{out}");
-    assert!(!out.contains("uint32_t _let_score_wire"),
-            "SInt<40> child output wire must not use uint32_t storage; got:\n{out}");
-    assert!(!out.contains("uint64_t _let_score_wire"),
-            "SInt<40> child output wire must not use unsigned storage; got:\n{out}");
-    assert!(out.contains("score  = _let_score_wire"),
-            "wrapper should forward the signed child output to its public port; got:\n{out}");
+    assert!(
+        out.contains("int64_t _let_score_wire"),
+        "SInt<40> child output wire should use int64_t storage in wrapper/native sim; got:\n{out}"
+    );
+    assert!(
+        !out.contains("uint32_t _let_score_wire"),
+        "SInt<40> child output wire must not use uint32_t storage; got:\n{out}"
+    );
+    assert!(
+        !out.contains("uint64_t _let_score_wire"),
+        "SInt<40> child output wire must not use unsigned storage; got:\n{out}"
+    );
+    assert!(
+        out.contains("score  = _let_score_wire"),
+        "wrapper should forward the signed child output to its public port; got:\n{out}"
+    );
 }
 
 #[test]
@@ -16545,19 +19678,30 @@ fn test_sint_40_lowered_thread_regs_keep_signed_storage() {
     "#;
     let out = compile_to_sim_h(source, false);
 
-    assert!(out.contains("int64_t accumulator"),
-            "lowered thread submodule ports for SInt<40> regs should use int64_t; got:\n{out}");
+    assert!(
+        out.contains("int64_t accumulator"),
+        "lowered thread submodule ports for SInt<40> regs should use int64_t; got:\n{out}"
+    );
     assert!(out.contains("int64_t _accumulator"),
             "parent/native sim SInt<40> reg storage should use int64_t after thread lowering; got:\n{out}");
-    assert!(out.contains("int64_t _n_accumulator"),
-            "lowered thread/native sim _n_ temporaries should use int64_t for SInt<40>; got:\n{out}");
-    assert!(!out.contains("uint32_t _accumulator"),
-            "lowered thread/native sim must not use uint32_t for SInt<40> accumulator; got:\n{out}");
+    assert!(
+        out.contains("int64_t _n_accumulator"),
+        "lowered thread/native sim _n_ temporaries should use int64_t for SInt<40>; got:\n{out}"
+    );
+    assert!(
+        !out.contains("uint32_t _accumulator"),
+        "lowered thread/native sim must not use uint32_t for SInt<40> accumulator; got:\n{out}"
+    );
     assert!(!out.contains("uint64_t _accumulator"),
             "lowered thread/native sim must not use unsigned storage for SInt<40> accumulator; got:\n{out}");
-    assert!(out.contains("((int64_t)(((uint64_t)((_accumulator + inc_in)) & 0xFFFFFFFFFFULL) << 24) >> 24)")
-            || out.contains("((int64_t)(((uint64_t)((accumulator + inc_in)) & 0xFFFFFFFFFFULL) << 24) >> 24)"),
-            "lowered thread/native sim trunc should sign-extend SInt<40>; got:\n{out}");
+    assert!(
+        out.contains(
+            "((int64_t)(((uint64_t)((_accumulator + inc_in)) & 0xFFFFFFFFFFULL) << 24) >> 24)"
+        ) || out.contains(
+            "((int64_t)(((uint64_t)((accumulator + inc_in)) & 0xFFFFFFFFFFULL) << 24) >> 24)"
+        ),
+        "lowered thread/native sim trunc should sign-extend SInt<40>; got:\n{out}"
+    );
 }
 
 // ── Thread state-name localparams (issue #247) ──────────────────────────────
@@ -16589,35 +19733,53 @@ fn test_thread_state_localparams_emitted() {
     //     (wait 2 cycle), S3 = action (final seq write — not folded because
     //     the preceding state is wait_cycles, not wait_until).
     //     Localparams are still emitted for all states including folded ones.
-    assert!(sv.contains("localparam [1:0] _t0_S0_wait_until = 0"),
-        "expected S0 wait_until localparam:\n{sv}");
-    assert!(sv.contains("localparam [1:0] _t0_S1_action = 1"),
-        "expected S1 action localparam (folded but still declared):\n{sv}");
-    assert!(sv.contains("localparam [1:0] _t0_S2_wait_cycles = 2"),
-        "expected S2 wait_cycles localparam:\n{sv}");
-    assert!(sv.contains("localparam [1:0] _t0_S3_action = 3"),
-        "expected S3 action localparam:\n{sv}");
+    assert!(
+        sv.contains("localparam [1:0] _t0_S0_wait_until = 0"),
+        "expected S0 wait_until localparam:\n{sv}"
+    );
+    assert!(
+        sv.contains("localparam [1:0] _t0_S1_action = 1"),
+        "expected S1 action localparam (folded but still declared):\n{sv}"
+    );
+    assert!(
+        sv.contains("localparam [1:0] _t0_S2_wait_cycles = 2"),
+        "expected S2 wait_cycles localparam:\n{sv}"
+    );
+    assert!(
+        sv.contains("localparam [1:0] _t0_S3_action = 3"),
+        "expected S3 action localparam:\n{sv}"
+    );
 
     // (2) Localparams declared in the merged threads module's parameter list,
     //     not inside the procedural block.
-    assert!(sv.contains("module _M_threads #("),
-        "merged threads module should have a parameter list:\n{sv}");
+    assert!(
+        sv.contains("module _M_threads #("),
+        "merged threads module should have a parameter list:\n{sv}"
+    );
 
     // (3) State comparisons use the name, not a bare literal.
-    assert!(sv.contains("_t0_state == _t0_S0_wait_until"),
-        "expected name-form state comparison for S0:\n{sv}");
-    assert!(sv.contains("_t0_state == _t0_S2_wait_cycles"),
-        "expected name-form state comparison for S2:\n{sv}");
+    assert!(
+        sv.contains("_t0_state == _t0_S0_wait_until"),
+        "expected name-form state comparison for S0:\n{sv}"
+    );
+    assert!(
+        sv.contains("_t0_state == _t0_S2_wait_cycles"),
+        "expected name-form state comparison for S2:\n{sv}"
+    );
 
     // (4) State-register assignments use the name, not a bare literal.
     //     Issue #306: S0's cond-exit arm now folds S1's `done <= true` and
     //     transitions directly to S2 (skipping S1).  So `_t0_S1_action` no
     //     longer appears as a transition target; `_t0_S2_wait_cycles` still
     //     does (from the folded S0 exit arm).
-    assert!(!sv.contains("_t0_state <= _t0_S1_action"),
-        "S1 was folded into S0's exit; S0 must jump directly to S2:\n{sv}");
-    assert!(sv.contains("_t0_state <= _t0_S2_wait_cycles"),
-        "expected name-form state assignment to S2 (folded from S0 exit arm):\n{sv}");
+    assert!(
+        !sv.contains("_t0_state <= _t0_S1_action"),
+        "S1 was folded into S0's exit; S0 must jump directly to S2:\n{sv}"
+    );
+    assert!(
+        sv.contains("_t0_state <= _t0_S2_wait_cycles"),
+        "expected name-form state assignment to S2 (folded from S0 exit arm):\n{sv}"
+    );
     // The folded seq assign must appear inside the if(req) block.
     let trimmed: String = sv.split_whitespace().collect::<Vec<_>>().join(" ");
     assert!(
@@ -16634,10 +19796,18 @@ fn test_thread_state_localparams_emitted() {
         let bad_assign = format!("_t0_state <= {};", n);
         // Reset assigns to literal 0 (acceptable). All other uses must be name-form.
         if n != 0 {
-            assert!(!sv.contains(&bad_cmp),
-                "state comparison should use name-form, found bare `{}`:\n{}", bad_cmp, sv);
-            assert!(!sv.contains(&bad_assign),
-                "state assignment should use name-form, found bare `{}`:\n{}", bad_assign, sv);
+            assert!(
+                !sv.contains(&bad_cmp),
+                "state comparison should use name-form, found bare `{}`:\n{}",
+                bad_cmp,
+                sv
+            );
+            assert!(
+                !sv.contains(&bad_assign),
+                "state assignment should use name-form, found bare `{}`:\n{}",
+                bad_assign,
+                sv
+            );
         }
     }
 }
@@ -16665,14 +19835,19 @@ fn test_thread_state_names_distinguish_wait_until_vs_wait_cycles() {
     // The wait-until state and the wait-cycles state must carry distinct
     // role suffixes so a waveform reader can tell at a glance what kind
     // of wait the FSM is sitting in.
-    assert!(sv.contains("_t0_S0_wait_until"),
-        "expected wait_until role suffix on S0:\n{sv}");
-    assert!(sv.contains("_wait_cycles"),
-        "expected wait_cycles role suffix on the wait-cycles state:\n{sv}");
+    assert!(
+        sv.contains("_t0_S0_wait_until"),
+        "expected wait_until role suffix on S0:\n{sv}"
+    );
+    assert!(
+        sv.contains("_wait_cycles"),
+        "expected wait_cycles role suffix on the wait-cycles state:\n{sv}"
+    );
     // Sanity: the two roles are NOT collapsed to the same name.
-    assert!(sv.matches("_t0_S0_wait_until").count() >= 1
-            && sv.matches("_wait_cycles =").count() >= 1,
-        "wait_until and wait_cycles must produce distinct localparam decls:\n{sv}");
+    assert!(
+        sv.matches("_t0_S0_wait_until").count() >= 1 && sv.matches("_wait_cycles =").count() >= 1,
+        "wait_until and wait_cycles must produce distinct localparam decls:\n{sv}"
+    );
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -16682,8 +19857,7 @@ fn test_thread_state_names_distinguish_wait_until_vs_wait_cycles() {
 fn comb_loop_warnings(source: &str) -> Vec<String> {
     warnings_from(source)
         .into_iter()
-        .filter(|m| m.contains("combinational feedback cycle")
-                 || m.starts_with("arch check:"))
+        .filter(|m| m.contains("combinational feedback cycle") || m.starts_with("arch check:"))
         .collect()
 }
 
@@ -16706,8 +19880,12 @@ fn test_comb_loop_within_module_detected() {
         end module M
     "#;
     let ws = comb_loop_warnings(source);
-    assert!(ws.iter().any(|m| m.contains("combinational feedback cycle")),
-        "expected a comb-loop warning, got: {:?}", ws);
+    assert!(
+        ws.iter()
+            .any(|m| m.contains("combinational feedback cycle")),
+        "expected a comb-loop warning, got: {:?}",
+        ws
+    );
 }
 
 #[test]
@@ -16746,8 +19924,12 @@ fn test_comb_loop_across_two_instances_detected() {
         end module Top
     "#;
     let ws = comb_loop_warnings(source);
-    assert!(ws.iter().any(|m| m.contains("combinational feedback cycle")),
-        "expected a comb-loop warning, got: {:?}", ws);
+    assert!(
+        ws.iter()
+            .any(|m| m.contains("combinational feedback cycle")),
+        "expected a comb-loop warning, got: {:?}",
+        ws
+    );
 }
 
 #[test]
@@ -16788,13 +19970,24 @@ fn test_comb_loop_suppressed_by_pragma() {
     // No cycle warnings should remain; the summary line MAY still fire
     // mentioning suppression — but no "combinational feedback cycle (…)"
     // node-listing warning should be present.
-    let cycle_msgs: Vec<_> = ws.iter().filter(|m| m.contains("combinational feedback cycle (")).collect();
-    assert!(cycle_msgs.is_empty(),
-        "expected pragma to suppress cycle warning, got: {:?}", ws);
+    let cycle_msgs: Vec<_> = ws
+        .iter()
+        .filter(|m| m.contains("combinational feedback cycle ("))
+        .collect();
+    assert!(
+        cycle_msgs.is_empty(),
+        "expected pragma to suppress cycle warning, got: {:?}",
+        ws
+    );
     // Sanity: the summary should report 1 SCC found / 1 suppressed.
     let summary: Vec<_> = ws.iter().filter(|m| m.starts_with("arch check:")).collect();
-    assert!(summary.iter().any(|m| m.contains("1 comb SCC(s) found") && m.contains("1 suppressed")),
-        "expected suppression-summary line, got: {:?}", ws);
+    assert!(
+        summary
+            .iter()
+            .any(|m| m.contains("1 comb SCC(s) found") && m.contains("1 suppressed")),
+        "expected suppression-summary line, got: {:?}",
+        ws
+    );
 }
 
 #[test]
@@ -16825,9 +20018,15 @@ fn test_comb_loop_through_register_not_flagged() {
         end module M
     "#;
     let ws = comb_loop_warnings(source);
-    let cycle_msgs: Vec<_> = ws.iter().filter(|m| m.contains("combinational feedback cycle (")).collect();
-    assert!(cycle_msgs.is_empty(),
-        "register should break the cycle, but got: {:?}", ws);
+    let cycle_msgs: Vec<_> = ws
+        .iter()
+        .filter(|m| m.contains("combinational feedback cycle ("))
+        .collect();
+    assert!(
+        cycle_msgs.is_empty(),
+        "register should break the cycle, but got: {:?}",
+        ws
+    );
 }
 
 #[test]
@@ -16893,8 +20092,12 @@ fn test_interface_module_treated_as_opaque() {
     let checker = arch::typecheck::TypeChecker::new(&symbols, &ast);
     let (warnings, _) = checker.check().expect("type check error");
     let ws: Vec<String> = warnings.into_iter().map(|w| w.message).collect();
-    assert!(ws.iter().any(|m| m.contains("combinational feedback cycle")),
-        "expected opaque-interface module to participate in a detected cycle; warnings: {:?}", ws);
+    assert!(
+        ws.iter()
+            .any(|m| m.contains("combinational feedback cycle")),
+        "expected opaque-interface module to participate in a detected cycle; warnings: {:?}",
+        ws
+    );
 }
 
 #[test]
@@ -16969,12 +20172,15 @@ fn test_opaque_interface_pipe_reg_output_does_not_close_cycle() {
     let checker = arch::typecheck::TypeChecker::new(&symbols, &ast);
     let (warnings, _) = checker.check().expect("type check error");
     let ws: Vec<String> = warnings.into_iter().map(|w| w.message).collect();
-    let cycle_msgs: Vec<_> = ws.iter()
+    let cycle_msgs: Vec<_> = ws
+        .iter()
         .filter(|m| m.contains("combinational feedback cycle ("))
         .collect();
-    assert!(cycle_msgs.is_empty(),
+    assert!(
+        cycle_msgs.is_empty(),
         "pipe_reg / port reg outputs on an opaque stub must not close a comb cycle; got: {:?}",
-        cycle_msgs);
+        cycle_msgs
+    );
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -16999,30 +20205,46 @@ fn test_archi_comb_dep_annotation_parses() {
     let tokens = lexer::tokenize(source).expect("lexer");
     let mut parser = Parser::new(tokens, source);
     let parsed = parser.parse_source_file().expect("parse");
-    let m = parsed.items.iter().find_map(|i| match i {
-        arch::ast::Item::Module(m) => Some(m),
-        _ => None,
-    }).expect("module");
+    let m = parsed
+        .items
+        .iter()
+        .find_map(|i| match i {
+            arch::ast::Item::Module(m) => Some(m),
+            _ => None,
+        })
+        .expect("module");
 
     let by_name: std::collections::HashMap<&str, &arch::ast::PortDecl> =
         m.ports.iter().map(|p| (p.name.name.as_str(), p)).collect();
 
-    let x_deps: Vec<&str> = by_name["x"].comb_deps.as_ref()
+    let x_deps: Vec<&str> = by_name["x"]
+        .comb_deps
+        .as_ref()
         .expect("x must carry comb_deps")
-        .iter().map(|i| i.name.as_str()).collect();
+        .iter()
+        .map(|i| i.name.as_str())
+        .collect();
     assert_eq!(x_deps, vec!["a"], "x deps");
 
-    let y_deps: Vec<&str> = by_name["y"].comb_deps.as_ref()
+    let y_deps: Vec<&str> = by_name["y"]
+        .comb_deps
+        .as_ref()
         .expect("y must carry comb_deps")
-        .iter().map(|i| i.name.as_str()).collect();
+        .iter()
+        .map(|i| i.name.as_str())
+        .collect();
     assert_eq!(y_deps, vec!["a", "b"], "y deps");
 
-    let z_deps: &Vec<arch::ast::Ident> = by_name["z"].comb_deps.as_ref()
+    let z_deps: &Vec<arch::ast::Ident> = by_name["z"]
+        .comb_deps
+        .as_ref()
         .expect("z must carry comb_deps (empty list = pure)");
     assert!(z_deps.is_empty(), "z must be pure (empty deps)");
 
-    assert!(by_name["w"].comb_deps.is_none(),
-        "w must carry no annotation (opaque fallback)");
+    assert!(
+        by_name["w"].comb_deps.is_none(),
+        "w must carry no annotation (opaque fallback)"
+    );
 }
 
 #[test]
@@ -17047,16 +20269,24 @@ fn test_archi_comb_dep_annotation_round_trip() {
     let tokens = lexer::tokenize(source).expect("lexer");
     let mut parser = Parser::new(tokens, source);
     let parsed = parser.parse_source_file().expect("parse");
-    let item = parsed.items.iter()
+    let item = parsed
+        .items
+        .iter()
         .find(|i| matches!(i, arch::ast::Item::Module(_)))
         .expect("module");
     let body = arch::interface::emit_interface(item).expect("emit_interface");
-    assert!(body.contains("port x: out UInt<8> comb_dep_on(a);"),
-        "x must depend only on a: {body}");
-    assert!(body.contains("port y: out UInt<8> comb_dep_on(a, b);"),
-        "y must depend on a and b: {body}");
-    assert!(body.contains("port z: out UInt<8> comb_dep_on();"),
-        "z is pure (constant): {body}");
+    assert!(
+        body.contains("port x: out UInt<8> comb_dep_on(a);"),
+        "x must depend only on a: {body}"
+    );
+    assert!(
+        body.contains("port y: out UInt<8> comb_dep_on(a, b);"),
+        "y must depend on a and b: {body}"
+    );
+    assert!(
+        body.contains("port z: out UInt<8> comb_dep_on();"),
+        "z is pure (constant): {body}"
+    );
 }
 
 #[test]
@@ -17108,25 +20338,33 @@ fn test_archi_comb_dep_precise_eliminates_false_positive() {
     // Mark `Stub` as an interface to mimic the .archi path.
     for item in parsed_ast.items.iter_mut() {
         if let arch::ast::Item::Module(m) = item {
-            if m.name.name == "Stub" { m.is_interface = true; }
+            if m.name.name == "Stub" {
+                m.is_interface = true;
+            }
         }
     }
     let ast = arch::elaborate::elaborate(parsed_ast).expect("elaborate");
     let mut ast = ast;
     for item in ast.items.iter_mut() {
         if let arch::ast::Item::Module(m) = item {
-            if m.name.name.starts_with("Stub") { m.is_interface = true; }
+            if m.name.name.starts_with("Stub") {
+                m.is_interface = true;
+            }
         }
     }
     let symbols = arch::resolve::resolve(&ast).expect("resolve");
     let checker = arch::typecheck::TypeChecker::new(&symbols, &ast);
     let (warnings, _) = checker.check().expect("type check");
     let ws: Vec<String> = warnings.into_iter().map(|w| w.message).collect();
-    let cycle_msgs: Vec<_> = ws.iter()
+    let cycle_msgs: Vec<_> = ws
+        .iter()
         .filter(|m| m.contains("combinational feedback cycle ("))
         .collect();
-    assert!(cycle_msgs.is_empty(),
-        "comb_dep_on(in_a) should restrict edges so no cycle fires; got: {:?}", cycle_msgs);
+    assert!(
+        cycle_msgs.is_empty(),
+        "comb_dep_on(in_a) should restrict edges so no cycle fires; got: {:?}",
+        cycle_msgs
+    );
 }
 
 #[test]
@@ -17165,25 +20403,33 @@ fn test_archi_comb_dep_empty_marks_output_pure() {
     let mut parsed_ast = parser.parse_source_file().expect("parse");
     for item in parsed_ast.items.iter_mut() {
         if let arch::ast::Item::Module(m) = item {
-            if m.name.name == "Stub" { m.is_interface = true; }
+            if m.name.name == "Stub" {
+                m.is_interface = true;
+            }
         }
     }
     let ast = arch::elaborate::elaborate(parsed_ast).expect("elaborate");
     let mut ast = ast;
     for item in ast.items.iter_mut() {
         if let arch::ast::Item::Module(m) = item {
-            if m.name.name.starts_with("Stub") { m.is_interface = true; }
+            if m.name.name.starts_with("Stub") {
+                m.is_interface = true;
+            }
         }
     }
     let symbols = arch::resolve::resolve(&ast).expect("resolve");
     let checker = arch::typecheck::TypeChecker::new(&symbols, &ast);
     let (warnings, _) = checker.check().expect("type check");
     let ws: Vec<String> = warnings.into_iter().map(|w| w.message).collect();
-    let cycle_msgs: Vec<_> = ws.iter()
+    let cycle_msgs: Vec<_> = ws
+        .iter()
         .filter(|m| m.contains("combinational feedback cycle ("))
         .collect();
-    assert!(cycle_msgs.is_empty(),
-        "comb_dep_on() (pure) must produce no incoming comb edges; got: {:?}", cycle_msgs);
+    assert!(
+        cycle_msgs.is_empty(),
+        "comb_dep_on() (pure) must produce no incoming comb edges; got: {:?}",
+        cycle_msgs
+    );
 }
 
 #[test]
@@ -17223,22 +20469,30 @@ fn test_archi_comb_dep_absent_falls_back_to_opaque() {
     let mut parsed_ast = parser.parse_source_file().expect("parse");
     for item in parsed_ast.items.iter_mut() {
         if let arch::ast::Item::Module(m) = item {
-            if m.name.name == "Stub" { m.is_interface = true; }
+            if m.name.name == "Stub" {
+                m.is_interface = true;
+            }
         }
     }
     let ast = arch::elaborate::elaborate(parsed_ast).expect("elaborate");
     let mut ast = ast;
     for item in ast.items.iter_mut() {
         if let arch::ast::Item::Module(m) = item {
-            if m.name.name.starts_with("Stub") { m.is_interface = true; }
+            if m.name.name.starts_with("Stub") {
+                m.is_interface = true;
+            }
         }
     }
     let symbols = arch::resolve::resolve(&ast).expect("resolve");
     let checker = arch::typecheck::TypeChecker::new(&symbols, &ast);
     let (warnings, _) = checker.check().expect("type check");
     let ws: Vec<String> = warnings.into_iter().map(|w| w.message).collect();
-    assert!(ws.iter().any(|m| m.contains("combinational feedback cycle")),
-        "absent annotation must keep opaque fallback that fires cycle: {:?}", ws);
+    assert!(
+        ws.iter()
+            .any(|m| m.contains("combinational feedback cycle")),
+        "absent annotation must keep opaque fallback that fires cycle: {:?}",
+        ws
+    );
 }
 
 #[test]
@@ -17258,11 +20512,15 @@ fn test_archi_comb_dep_on_registered_output_rejected_at_parse() {
     ";
     let tokens = lexer::tokenize(source).expect("lexer");
     let mut parser = Parser::new(tokens, source);
-    let err = parser.parse_source_file()
+    let err = parser
+        .parse_source_file()
         .expect_err("must reject comb_dep_on on registered output");
     let msg = format!("{:?}", err);
-    assert!(msg.contains("comb_dep_on") && msg.contains("registered"),
-        "error should mention comb_dep_on + registered; got: {}", msg);
+    assert!(
+        msg.contains("comb_dep_on") && msg.contains("registered"),
+        "error should mention comb_dep_on + registered; got: {}",
+        msg
+    );
 }
 
 #[test]
@@ -17275,11 +20533,15 @@ fn test_archi_comb_dep_on_input_port_rejected_at_parse() {
     ";
     let tokens = lexer::tokenize(source).expect("lexer");
     let mut parser = Parser::new(tokens, source);
-    let err = parser.parse_source_file()
+    let err = parser
+        .parse_source_file()
         .expect_err("must reject comb_dep_on on input port");
     let msg = format!("{:?}", err);
-    assert!(msg.contains("comb_dep_on"),
-        "error should mention comb_dep_on; got: {}", msg);
+    assert!(
+        msg.contains("comb_dep_on"),
+        "error should mention comb_dep_on; got: {}",
+        msg
+    );
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -17339,12 +20601,16 @@ fn test_comb_loop_bodied_per_output_precision_eliminates_false_positive() {
         end module Top
     "#;
     let ws = comb_loop_warnings(source);
-    let cycle_msgs: Vec<_> = ws.iter()
+    let cycle_msgs: Vec<_> = ws
+        .iter()
         .filter(|m| m.contains("combinational feedback cycle ("))
         .collect();
-    assert!(cycle_msgs.is_empty(),
+    assert!(
+        cycle_msgs.is_empty(),
         "per-output precision must eliminate the aggregate-only phantom \
-         cycle; got: {:?}", cycle_msgs);
+         cycle; got: {:?}",
+        cycle_msgs
+    );
 }
 
 #[test]
@@ -17393,12 +20659,16 @@ fn test_comb_loop_bodied_real_cycle_still_detected() {
         end module Top
     "#;
     let ws = comb_loop_warnings(source);
-    let cycle_msgs: Vec<_> = ws.iter()
+    let cycle_msgs: Vec<_> = ws
+        .iter()
         .filter(|m| m.contains("combinational feedback cycle ("))
         .collect();
-    assert!(!cycle_msgs.is_empty(),
+    assert!(
+        !cycle_msgs.is_empty(),
         "real cycle (u1.out_a ← w2; u2.out_b ← w1) must still fire; \
-         warnings: {:?}", ws);
+         warnings: {:?}",
+        ws
+    );
 }
 
 #[test]
@@ -17454,12 +20724,16 @@ fn test_comb_loop_bodied_output_missing_from_per_output_map_falls_back() {
         end module Top
     "#;
     let ws = comb_loop_warnings(source);
-    let cycle_msgs: Vec<_> = ws.iter()
+    let cycle_msgs: Vec<_> = ws
+        .iter()
         .filter(|m| m.contains("combinational feedback cycle ("))
         .collect();
-    assert!(cycle_msgs.is_empty(),
+    assert!(
+        cycle_msgs.is_empty(),
         "pure output (per-output map empty) must not close a comb cycle; \
-         got: {:?}", cycle_msgs);
+         got: {:?}",
+        cycle_msgs
+    );
 }
 
 #[test]
@@ -17515,12 +20789,15 @@ fn test_comb_loop_bodied_per_output_cache_handles_repeated_insts() {
         end module Top
     "#;
     let ws = comb_loop_warnings(source);
-    let cycle_msgs: Vec<_> = ws.iter()
+    let cycle_msgs: Vec<_> = ws
+        .iter()
         .filter(|m| m.contains("combinational feedback cycle ("))
         .collect();
-    assert!(cycle_msgs.is_empty(),
+    assert!(
+        cycle_msgs.is_empty(),
         "per-output precision must hold across 3 cross-wired insts; got: {:?}",
-        cycle_msgs);
+        cycle_msgs
+    );
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -17594,12 +20871,16 @@ fn test_comb_loop_fsm_per_output_precision_eliminates_false_positive() {
         end module Top
     "#;
     let ws = comb_loop_warnings(source);
-    let cycle_msgs: Vec<_> = ws.iter()
+    let cycle_msgs: Vec<_> = ws
+        .iter()
         .filter(|m| m.contains("combinational feedback cycle ("))
         .collect();
-    assert!(cycle_msgs.is_empty(),
+    assert!(
+        cycle_msgs.is_empty(),
         "fsm per-output precision must eliminate the aggregate-only \
-         phantom cycle; got: {:?}", cycle_msgs);
+         phantom cycle; got: {:?}",
+        cycle_msgs
+    );
 }
 
 #[test]
@@ -17660,12 +20941,16 @@ fn test_comb_loop_fsm_real_cycle_still_detected() {
         end module Top
     "#;
     let ws = comb_loop_warnings(source);
-    let cycle_msgs: Vec<_> = ws.iter()
+    let cycle_msgs: Vec<_> = ws
+        .iter()
         .filter(|m| m.contains("combinational feedback cycle ("))
         .collect();
-    assert!(!cycle_msgs.is_empty(),
+    assert!(
+        !cycle_msgs.is_empty(),
         "real cycle (u1.out_a ← w2; u2.out_b ← w1) through fsm \
-         must still fire; warnings: {:?}", ws);
+         must still fire; warnings: {:?}",
+        ws
+    );
 }
 
 #[test]
@@ -17696,16 +20981,24 @@ fn test_archi_fsm_emit_includes_comb_dep_on() {
     let tokens = lexer::tokenize(source).expect("lexer");
     let mut parser = Parser::new(tokens, source);
     let parsed = parser.parse_source_file().expect("parse");
-    let item = parsed.items.iter()
+    let item = parsed
+        .items
+        .iter()
         .find(|i| matches!(i, arch::ast::Item::Fsm(_)))
         .expect("fsm");
     let body = arch::interface::emit_interface(item).expect("emit_interface");
-    assert!(body.contains("port x: out UInt<8> comb_dep_on(a);"),
-        "x must depend only on a: {body}");
-    assert!(body.contains("port y: out UInt<8> comb_dep_on(a, b);"),
-        "y must depend on a and b: {body}");
-    assert!(body.contains("port z: out UInt<8> comb_dep_on();"),
-        "z is pure (constant): {body}");
+    assert!(
+        body.contains("port x: out UInt<8> comb_dep_on(a);"),
+        "x must depend only on a: {body}"
+    );
+    assert!(
+        body.contains("port y: out UInt<8> comb_dep_on(a, b);"),
+        "y must depend on a and b: {body}"
+    );
+    assert!(
+        body.contains("port z: out UInt<8> comb_dep_on();"),
+        "z is pure (constant): {body}"
+    );
 }
 
 #[test]
@@ -17760,12 +21053,16 @@ fn test_comb_loop_fsm_default_comb_deps_included() {
     // The cross-wire w1 → in_z → out_a → w1 is a legitimate cycle.
     // Per-output FSM walker must include in_z in out_a's dep set.
     let ws = comb_loop_warnings(source);
-    let cycle_msgs: Vec<_> = ws.iter()
+    let cycle_msgs: Vec<_> = ws
+        .iter()
         .filter(|m| m.contains("combinational feedback cycle ("))
         .collect();
-    assert!(!cycle_msgs.is_empty(),
+    assert!(
+        !cycle_msgs.is_empty(),
         "default_comb reads in_z driving out_a; w1 → in_z → out_a → w1 \
-         must fire as a comb cycle; warnings: {:?}", ws);
+         must fire as a comb cycle; warnings: {:?}",
+        ws
+    );
 }
 
 #[test]
@@ -17813,12 +21110,16 @@ fn test_comb_loop_fsm_output_default_expr_deps_included() {
         end module Top
     "#;
     let ws = comb_loop_warnings(source);
-    let cycle_msgs: Vec<_> = ws.iter()
+    let cycle_msgs: Vec<_> = ws
+        .iter()
         .filter(|m| m.contains("combinational feedback cycle ("))
         .collect();
-    assert!(!cycle_msgs.is_empty(),
+    assert!(
+        !cycle_msgs.is_empty(),
         "out_a's default expression reads in_y; w1 → in_y → out_a → w1 \
-         must fire as a comb cycle; warnings: {:?}", ws);
+         must fire as a comb cycle; warnings: {:?}",
+        ws
+    );
 
     // And the dual: with cross-wire through in_a (NOT a dep), no cycle.
     let source2 = r#"
@@ -17856,12 +21157,16 @@ fn test_comb_loop_fsm_output_default_expr_deps_included() {
         end module Top
     "#;
     let ws2 = comb_loop_warnings(source2);
-    let cycle_msgs2: Vec<_> = ws2.iter()
+    let cycle_msgs2: Vec<_> = ws2
+        .iter()
         .filter(|m| m.contains("combinational feedback cycle ("))
         .collect();
-    assert!(cycle_msgs2.is_empty(),
+    assert!(
+        cycle_msgs2.is_empty(),
         "out_a's default reads only in_x; w1 → in_y is NOT a dep, \
-         so no cycle should fire; got: {:?}", cycle_msgs2);
+         so no cycle should fire; got: {:?}",
+        cycle_msgs2
+    );
 }
 
 // ─── multicycle reg annotation (Phase A) ─────────────────────────────────────
@@ -17946,10 +21251,12 @@ end module M
 "#;
     let (sv_ctrl, sdc_ctrl) = compile_to_sv_with_sdc(control);
     let (sv_mc, sdc_mc) = compile_to_sv_with_sdc(mc);
-    assert_eq!(sv_ctrl, sv_mc,
-        "multicycle annotation must not alter SV emission");
+    assert_eq!(
+        sv_ctrl, sv_mc,
+        "multicycle annotation must not alter SV emission"
+    );
     assert!(sdc_ctrl.is_none(), "control case: no .sdc expected");
-    assert!(sdc_mc.is_some(),  "multicycle case: .sdc expected");
+    assert!(sdc_mc.is_some(), "multicycle case: .sdc expected");
 }
 
 #[test]
@@ -17976,29 +21283,47 @@ end module M
 "#;
     let (_sv, sdc) = compile_to_sv_with_sdc(source);
     let sdc = sdc.expect(".sdc expected when multicycle reg is present");
-    assert!(sdc.contains("set_multicycle_path 3 -setup -to [get_cells -hierarchical {*result_reg*}]"),
-        "expected setup constraint with N=3; got:\n{}", sdc);
-    assert!(sdc.contains("set_multicycle_path 2 -hold -to [get_cells -hierarchical {*result_reg*}]"),
-        "expected hold constraint with N-1=2; got:\n{}", sdc);
-    assert!(sdc.contains("Module M: multicycle reg result"),
-        "expected per-reg header comment; got:\n{}", sdc);
+    assert!(
+        sdc.contains("set_multicycle_path 3 -setup -to [get_cells -hierarchical {*result_reg*}]"),
+        "expected setup constraint with N=3; got:\n{}",
+        sdc
+    );
+    assert!(
+        sdc.contains("set_multicycle_path 2 -hold -to [get_cells -hierarchical {*result_reg*}]"),
+        "expected hold constraint with N-1=2; got:\n{}",
+        sdc
+    );
+    assert!(
+        sdc.contains("Module M: multicycle reg result"),
+        "expected per-reg header comment; got:\n{}",
+        sdc
+    );
     // The leading `*` in the glob is load-bearing: it lets the constraint
     // attach under both flat synth (no instance prefix) and hierarchical
     // synth (any number of `top/.../<Module>/` levels). A regression that
     // re-introduces the `<Module>/` prefix would silently fail to attach
     // under flat / standalone synth (OpenSTA warns `instance not found`).
-    assert!(sdc.contains("[get_cells -hierarchical {*result_reg*}]"),
-        "expected wildcard-prefix glob `*result_reg*` with -hierarchical; got:\n{}", sdc);
-    assert!(!sdc.contains("{M/result_reg"),
-        "expected NO hierarchical `M/result_reg` prefix in glob; got:\n{}", sdc);
+    assert!(
+        sdc.contains("[get_cells -hierarchical {*result_reg*}]"),
+        "expected wildcard-prefix glob `*result_reg*` with -hierarchical; got:\n{}",
+        sdc
+    );
+    assert!(
+        !sdc.contains("{M/result_reg"),
+        "expected NO hierarchical `M/result_reg` prefix in glob; got:\n{}",
+        sdc
+    );
     // `-hierarchical` is mandatory: under hierarchical synth (parent +
     // child module), OpenSTA's `get_cells` is non-recursive by default, so
     // the `*` glob does not descend into instance subhierarchies. Without
     // the flag the multicycle constraint silently attaches to zero cells
     // and the path is treated as single-cycle (verified with the
     // MultdivMulticycleHier two-pass example).
-    assert!(sdc.contains("get_cells -hierarchical"),
-        "expected `-hierarchical` flag on get_cells; got:\n{}", sdc);
+    assert!(
+        sdc.contains("get_cells -hierarchical"),
+        "expected `-hierarchical` flag on get_cells; got:\n{}",
+        sdc
+    );
 }
 
 #[test]
@@ -18024,7 +21349,8 @@ end module M
     // N >= 1 requirement so the diagnostic is actionable.
     let msg = format!("{:?}", err);
     assert!(
-        msg.contains("multicycle") && (msg.contains(">= 1") || msg.contains("N=0") || msg.contains("meaningless")),
+        msg.contains("multicycle")
+            && (msg.contains(">= 1") || msg.contains("N=0") || msg.contains("meaningless")),
         "expected an N >= 1 diagnostic mentioning `multicycle`; got: {}",
         msg
     );
@@ -18051,10 +21377,16 @@ end module M
 "#;
     let (_sv, sdc) = compile_to_sv_with_sdc(source);
     let sdc = sdc.expect("unused multicycle reg still emits SDC");
-    assert!(sdc.contains("set_multicycle_path 4 -setup -to [get_cells -hierarchical {*_unused_reg*}]"),
-        "got:\n{}", sdc);
-    assert!(sdc.contains("set_multicycle_path 3 -hold -to [get_cells -hierarchical {*_unused_reg*}]"),
-        "got:\n{}", sdc);
+    assert!(
+        sdc.contains("set_multicycle_path 4 -setup -to [get_cells -hierarchical {*_unused_reg*}]"),
+        "got:\n{}",
+        sdc
+    );
+    assert!(
+        sdc.contains("set_multicycle_path 3 -hold -to [get_cells -hierarchical {*_unused_reg*}]"),
+        "got:\n{}",
+        sdc
+    );
 }
 
 #[test]
@@ -18078,9 +21410,11 @@ end module M
 "#;
     let (sv, sdc) = compile_to_sv_with_sdc(source);
     assert!(sv.contains("module M"));
-    assert!(sdc.is_none(),
+    assert!(
+        sdc.is_none(),
         "no multicycle annotation → `emit_sdc` must return None so the driver \
-         skips writing a `.sdc` companion file");
+         skips writing a `.sdc` companion file"
+    );
 }
 
 #[test]
@@ -18122,10 +21456,16 @@ end fsm F
 "#;
     let (_sv, sdc) = compile_to_sv_with_sdc(source);
     let sdc = sdc.expect(".sdc expected for multicycle reg inside fsm");
-    assert!(sdc.contains("set_multicycle_path 5 -setup -to [get_cells -hierarchical {*slow_r_reg*}]"),
-        "got:\n{}", sdc);
-    assert!(sdc.contains("set_multicycle_path 4 -hold -to [get_cells -hierarchical {*slow_r_reg*}]"),
-        "got:\n{}", sdc);
+    assert!(
+        sdc.contains("set_multicycle_path 5 -setup -to [get_cells -hierarchical {*slow_r_reg*}]"),
+        "got:\n{}",
+        sdc
+    );
+    assert!(
+        sdc.contains("set_multicycle_path 4 -hold -to [get_cells -hierarchical {*slow_r_reg*}]"),
+        "got:\n{}",
+        sdc
+    );
 }
 
 /// Regression: a module-internal `function` whose body references a
@@ -18149,13 +21489,17 @@ fn test_sim_function_uses_package_param() {
         .arg(td.path())
         .output()
         .expect("run arch sim for pkg_param_in_function repro");
-    assert!(out.status.success(),
+    assert!(
+        out.status.success(),
         "pkg_param_in_function sim should compile + run\nstdout:\n{}\nstderr:\n{}",
         String::from_utf8_lossy(&out.stdout),
-        String::from_utf8_lossy(&out.stderr));
-    assert!(String::from_utf8_lossy(&out.stdout).contains("PASS pkg_param_in_function"),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&out.stdout).contains("PASS pkg_param_in_function"),
         "expected PASS marker in stdout:\n{}",
-        String::from_utf8_lossy(&out.stdout));
+        String::from_utf8_lossy(&out.stdout)
+    );
 }
 
 #[test]
@@ -18206,8 +21550,10 @@ fn test_inst_for_loop_unrolls_connections() {
     // (big-endian, so chans[1] is the MSB).
     assert!(sv.contains(".chans_v({w_1_v, w_0_v})") || sv.contains(".chans_v ({w_1_v, w_0_v})"),
             "expected `.chans_v({{w_1_v, w_0_v}})` packed concat from unrolled inst-for-loop in SV:\n{sv}");
-    assert!(sv.contains(".chans_d({w_1_d, w_0_d})") || sv.contains(".chans_d ({w_1_d, w_0_d})"),
-            "expected `.chans_d({{w_1_d, w_0_d}})` packed concat in SV:\n{sv}");
+    assert!(
+        sv.contains(".chans_d({w_1_d, w_0_d})") || sv.contains(".chans_d ({w_1_d, w_0_d})"),
+        "expected `.chans_d({{w_1_d, w_0_d}})` packed concat in SV:\n{sv}"
+    );
 }
 
 #[test]
@@ -18237,7 +21583,8 @@ fn test_inst_for_loop_matches_hand_enumerated_form() {
         end module Slave
     ";
 
-    let fabric_handw = format!("{bus_and_slave}
+    let fabric_handw = format!(
+        "{bus_and_slave}
         module Fabric
           param NM: const = 2;
           param NS: const = 2;
@@ -18262,9 +21609,11 @@ fn test_inst_for_loop_matches_hand_enumerated_form() {
             end inst sp_j
           end generate_for
         end module Fabric
-    ");
+    "
+    );
 
-    let fabric_loop = format!("{bus_and_slave}
+    let fabric_loop = format!(
+        "{bus_and_slave}
         module Fabric
           param NM: const = 2;
           param NS: const = 2;
@@ -18290,22 +21639,29 @@ fn test_inst_for_loop_matches_hand_enumerated_form() {
             end inst sp_j
           end generate_for
         end module Fabric
-    ");
+    "
+    );
 
     let sv_handw = compile_to_sv(&fabric_handw);
-    let sv_loop  = compile_to_sv(&fabric_loop);
-    assert_eq!(sv_handw, sv_loop,
+    let sv_loop = compile_to_sv(&fabric_loop);
+    assert_eq!(
+        sv_handw, sv_loop,
         "inst-body for-loop must produce byte-identical SV to the \
          hand-enumerated form. Diff:\n\
          === hand-enumerated ===\n{sv_handw}\n\
-         === loop-unrolled ===\n{sv_loop}");
+         === loop-unrolled ===\n{sv_loop}"
+    );
 
     // Sanity: the SV actually contains the expected per-index connections
     // (so this isn't just `equal-but-empty`).
-    assert!(sv_loop.contains("sp_0") && sv_loop.contains("sp_1"),
-            "expected sp_0 and sp_1 instances in SV:\n{sv_loop}");
-    assert!(sv_loop.contains("edges[0][0]") && sv_loop.contains("edges[1][1]"),
-            "expected per-index edges refs in SV:\n{sv_loop}");
+    assert!(
+        sv_loop.contains("sp_0") && sv_loop.contains("sp_1"),
+        "expected sp_0 and sp_1 instances in SV:\n{sv_loop}"
+    );
+    assert!(
+        sv_loop.contains("edges[0][0]") && sv_loop.contains("edges[1][1]"),
+        "expected per-index edges refs in SV:\n{sv_loop}"
+    );
 }
 
 #[test]
@@ -18322,10 +21678,14 @@ fn test_type_alias_uint_scalar() {
         end module M
     "#;
     let sv = compile_to_sv(source);
-    assert!(sv.contains("input logic [31:0] a"),
-            "alias should expand to UInt<32> at the port: {sv}");
-    assert!(sv.contains("output logic [31:0] out"),
-            "alias should expand to UInt<32> at the output port: {sv}");
+    assert!(
+        sv.contains("input logic [31:0] a"),
+        "alias should expand to UInt<32> at the port: {sv}"
+    );
+    assert!(
+        sv.contains("output logic [31:0] out"),
+        "alias should expand to UInt<32> at the output port: {sv}"
+    );
 }
 
 #[test]
@@ -18348,8 +21708,10 @@ fn test_type_alias_struct() {
     "#;
     let sv = compile_to_sv(source);
     // Aliased struct port should look identical to an inline Pair port.
-    assert!(sv.contains("in_p") && sv.contains("struct"),
-            "struct alias should expand at port site: {sv}");
+    assert!(
+        sv.contains("in_p") && sv.contains("struct"),
+        "struct alias should expand at port site: {sv}"
+    );
 }
 
 #[test]
@@ -18374,9 +21736,11 @@ fn test_type_alias_bus_parameterized_port() {
     let sv = compile_to_sv(source);
     // ADDR_W should expand to 16 via the alias, so the port carries
     // [15:0] not [31:0].
-    assert!(sv.contains("output logic [15:0] m_addr")
+    assert!(
+        sv.contains("output logic [15:0] m_addr")
             || sv.contains("output logic [ADDR_W-1:0] m_addr"),
-            "bus alias with ADDR_W=16 override should produce 16-bit addr port: {sv}");
+        "bus alias with ADDR_W=16 override should produce 16-bit addr port: {sv}"
+    );
 }
 
 #[test]
@@ -18394,10 +21758,14 @@ fn test_type_alias_chain() {
         end module M
     "#;
     let sv = compile_to_sv(source);
-    assert!(sv.contains("input logic [7:0] a"),
-            "chained alias should resolve through to UInt<8>: {sv}");
-    assert!(sv.contains("output logic [7:0] out"),
-            "chained alias should resolve through to UInt<8>: {sv}");
+    assert!(
+        sv.contains("input logic [7:0] a"),
+        "chained alias should resolve through to UInt<8>: {sv}"
+    );
+    assert!(
+        sv.contains("output logic [7:0] out"),
+        "chained alias should resolve through to UInt<8>: {sv}"
+    );
 }
 
 #[test]
@@ -18426,11 +21794,13 @@ fn test_type_alias_undeclared_errors() {
                     let checker = TypeChecker::new(&symbols, &ast3);
                     checker.check().is_err()
                 }
-            }
-        }
+            },
+        },
     };
-    assert!(pipeline_errors_out,
-            "unknown type name 'Frobnitz' should error somewhere in the compile pipeline");
+    assert!(
+        pipeline_errors_out,
+        "unknown type name 'Frobnitz' should error somewhere in the compile pipeline"
+    );
 }
 
 #[test]
@@ -18450,9 +21820,12 @@ fn test_type_alias_circular_errors() {
     assert!(r.is_err(), "circular alias should error: {r:?}");
     let errs = r.unwrap_err();
     let msg: String = errs.iter().map(|e| format!("{e:?}")).collect();
-    assert!(msg.to_lowercase().contains("circular") || msg.to_lowercase().contains("cycle")
+    assert!(
+        msg.to_lowercase().contains("circular")
+            || msg.to_lowercase().contains("cycle")
             || msg.to_lowercase().contains("recursive"),
-            "expected circular/cycle/recursive in diagnostic, got: {msg}");
+        "expected circular/cycle/recursive in diagnostic, got: {msg}"
+    );
 }
 
 #[test]
@@ -18476,8 +21849,10 @@ fn test_generate_for_wire_decls() {
     let sv = compile_to_sv(source);
     // Three flat wires named w_0, w_1, w_2 — one per iteration value.
     for i in 0..3 {
-        assert!(sv.contains(&format!("logic [7:0] w_{i};")),
-                "missing `logic [7:0] w_{i};` in SV:\n{sv}");
+        assert!(
+            sv.contains(&format!("logic [7:0] w_{i};")),
+            "missing `logic [7:0] w_{i};` in SV:\n{sv}"
+        );
     }
 }
 
@@ -18513,14 +21888,22 @@ fn test_generate_for_wire_inst_loopback() {
         end module Top
     ";
     let sv = compile_to_sv(source);
-    assert!(sv.contains("logic [7:0] stage_0;"),
-            "missing `logic [7:0] stage_0;` (wire from generate_for iter 0):\n{sv}");
-    assert!(sv.contains("logic [7:0] stage_1;"),
-            "missing `logic [7:0] stage_1;` (wire from generate_for iter 1):\n{sv}");
-    assert!(sv.contains("assign out0 = stage_0;"),
-            "expected `out0 = stage_0` read of per-iter wire:\n{sv}");
-    assert!(sv.contains("assign out1 = stage_1;"),
-            "expected `out1 = stage_1` read of per-iter wire:\n{sv}");
+    assert!(
+        sv.contains("logic [7:0] stage_0;"),
+        "missing `logic [7:0] stage_0;` (wire from generate_for iter 0):\n{sv}"
+    );
+    assert!(
+        sv.contains("logic [7:0] stage_1;"),
+        "missing `logic [7:0] stage_1;` (wire from generate_for iter 1):\n{sv}"
+    );
+    assert!(
+        sv.contains("assign out0 = stage_0;"),
+        "expected `out0 = stage_0` read of per-iter wire:\n{sv}"
+    );
+    assert!(
+        sv.contains("assign out1 = stage_1;"),
+        "expected `out1 = stage_1` read of per-iter wire:\n{sv}"
+    );
 }
 
 #[test]
@@ -18547,10 +21930,14 @@ fn test_generate_for_wire_param_size() {
     ";
     let sv = compile_to_sv(source);
     // Wire width should fold to 16 bits via the W param's default.
-    assert!(sv.contains("logic [W-1:0] bus_0;") || sv.contains("logic [15:0] bus_0;"),
-            "missing `logic [W-1:0] bus_0;` (param-driven width wire):\n{sv}");
-    assert!(sv.contains("logic [W-1:0] bus_1;") || sv.contains("logic [15:0] bus_1;"),
-            "missing `logic [W-1:0] bus_1;` (param-driven width wire):\n{sv}");
+    assert!(
+        sv.contains("logic [W-1:0] bus_0;") || sv.contains("logic [15:0] bus_0;"),
+        "missing `logic [W-1:0] bus_0;` (param-driven width wire):\n{sv}"
+    );
+    assert!(
+        sv.contains("logic [W-1:0] bus_1;") || sv.contains("logic [15:0] bus_1;"),
+        "missing `logic [W-1:0] bus_1;` (param-driven width wire):\n{sv}"
+    );
 }
 
 #[test]
@@ -18601,19 +21988,27 @@ fn test_generate_if_variant_discovery_with_param_expr() {
     let sv = compile_to_sv(source);
     // Two specialized variants must be emitted, one per distinct
     // `param I = <expr>` value resolved against enclosing module params.
-    assert!(sv.contains("module Inner__I_10"),
-            "missing `Inner__I_10` specialized variant — variant discovery \
-             didn't resolve `param I = TEN` against enclosing module's params:\n{sv}");
-    assert!(sv.contains("module Inner__I_20"),
-            "missing `Inner__I_20` specialized variant — variant discovery \
-             didn't resolve `param I = TWENTY` against enclosing module's params:\n{sv}");
+    assert!(
+        sv.contains("module Inner__I_10"),
+        "missing `Inner__I_10` specialized variant — variant discovery \
+             didn't resolve `param I = TEN` against enclosing module's params:\n{sv}"
+    );
+    assert!(
+        sv.contains("module Inner__I_20"),
+        "missing `Inner__I_20` specialized variant — variant discovery \
+             didn't resolve `param I = TWENTY` against enclosing module's params:\n{sv}"
+    );
     // Inst sites should reference the specialized variant by name.
-    assert!(sv.contains("Inner__I_10 inner_a")
+    assert!(
+        sv.contains("Inner__I_10 inner_a")
             || sv.contains("Inner__I_10 #") && sv.contains("inner_a"),
-            "expected sp_0 to reference Inner__I_10 variant:\n{sv}");
-    assert!(sv.contains("Inner__I_20 inner_b")
+        "expected sp_0 to reference Inner__I_10 variant:\n{sv}"
+    );
+    assert!(
+        sv.contains("Inner__I_20 inner_b")
             || sv.contains("Inner__I_20 #") && sv.contains("inner_b"),
-            "expected sp_1 to reference Inner__I_20 variant:\n{sv}");
+        "expected sp_1 to reference Inner__I_20 variant:\n{sv}"
+    );
 }
 
 #[test]
@@ -18658,8 +22053,10 @@ fn test_generate_if_variant_discovery_with_default_branch_values() {
     // Both branches' values get discovered. The cond=1 branch's inst
     // actually survives; the cond=0 branch's variant is emitted but
     // never instantiated — synthesis tools dead-code it.
-    assert!(sv.contains("module Inner__I_7"),
-            "missing `Inner__I_7` variant (active branch's param):\n{sv}");
+    assert!(
+        sv.contains("module Inner__I_7"),
+        "missing `Inner__I_7` variant (active branch's param):\n{sv}"
+    );
 }
 
 #[test]
@@ -18686,13 +22083,17 @@ fn test_sim_nested_vec_reg_round_trips_all_cells() {
         .arg(td.path())
         .output()
         .expect("run arch sim for nested_vec_sim probe");
-    assert!(out.status.success(),
+    assert!(
+        out.status.success(),
         "nested-Vec sim should compile + run\nstdout:\n{}\nstderr:\n{}",
         String::from_utf8_lossy(&out.stdout),
-        String::from_utf8_lossy(&out.stderr));
-    assert!(String::from_utf8_lossy(&out.stdout).contains("PASS nested-Vec storage"),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&out.stdout).contains("PASS nested-Vec storage"),
         "expected PASS marker in stdout:\n{}",
-        String::from_utf8_lossy(&out.stdout));
+        String::from_utf8_lossy(&out.stdout)
+    );
 }
 
 #[test]
@@ -18901,6 +22302,38 @@ fn test_native_sim_thread_driven_top_pipe_reg_output_is_public() {
 }
 
 #[test]
+fn test_native_sim_wait_until_fold_target_reaches_post_action_state() {
+    // Regression for the folded wait-until exit target: after
+    // `wait until go; phase <= 1; wait 2 cycle; phase <= 2;`, default native
+    // sim must update phase on the go-detection edge and then continue into
+    // the counted-wait state. If the folded wait targets the absorbed action
+    // state instead, the native sim state machine gets stuck and never reaches
+    // phase=2.
+    let td = tempfile::tempdir().expect("tempdir");
+    let arch_bin = env!("CARGO_BIN_EXE_arch");
+    let out = std::process::Command::new(arch_bin)
+        .arg("sim")
+        .arg("tests/native_wait_until_fold_target/Probe.arch")
+        .arg("--tb")
+        .arg("tests/native_wait_until_fold_target/tb.cpp")
+        .arg("--outdir")
+        .arg(td.path())
+        .output()
+        .expect("run arch sim for native wait-until folded target probe");
+    assert!(
+        out.status.success(),
+        "native wait-until folded target sim should compile + run\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&out.stdout).contains("PASS native wait-until folded target"),
+        "expected PASS marker in stdout:\n{}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+}
+
+#[test]
 fn test_nic400_master_port_marks_non_power_of_two_decode_holes_oor() {
     // PR #487 added a default-slave DECERR path for out-of-range accesses,
     // but the original OOR predicate only checked high address bits above
@@ -18908,8 +22341,10 @@ fn test_nic400_master_port_marks_non_power_of_two_decode_holes_oor() {
     // power of two: with NUM_SLAVES=3 and NS_W=2, slave index 3 has no
     // backing thread and must still route to the default slave.
     let bus = include_str!("nic400/BusAxi4.arch");
-    let master = include_str!("nic400/Nic400MasterPort.arch")
-        .replace("param NUM_SLAVES:    const = 4;", "param NUM_SLAVES:    const = 3;");
+    let master = include_str!("nic400/Nic400MasterPort.arch").replace(
+        "param NUM_SLAVES:    const = 4;",
+        "param NUM_SLAVES:    const = 3;",
+    );
     let sv = compile_to_sv(&format!("{bus}\n{master}"));
     let trimmed: String = sv.split_whitespace().collect::<Vec<_>>().join(" ");
     assert!(
@@ -18995,9 +22430,8 @@ fn test_elaborate_440_bus_port_type_param_binary() {
     // when `lower_threads` synthesizes the `_<mod>_threads` sub-module.
     // Pre-#440, the inner `DATA_W` ident leaked into the sub-module's
     // port list (which only knows the outer module's `DATA_WIDTH`).
-    let source = include_str!(
-        "regression/issues/elaborate_440/bus_port_type_param_binary/Probe.arch"
-    );
+    let source =
+        include_str!("regression/issues/elaborate_440/bus_port_type_param_binary/Probe.arch");
     let sv = compile_to_sv(source);
 
     // The lowered `_Probe_threads` sub-module is the one that exercises
@@ -19008,7 +22442,10 @@ fn test_elaborate_440_bus_port_type_param_binary() {
         "expected lowered sub-module `_Probe_threads` in SV (the thread \
          lowering is what exercises `subst_type_expr_for_lower`):\n{sv}",
     );
-    let threads_end = sv[threads_start..].find("endmodule").map(|e| threads_start + e).unwrap_or(sv.len());
+    let threads_end = sv[threads_start..]
+        .find("endmodule")
+        .map(|e| threads_start + e)
+        .unwrap_or(sv.len());
     let threads_body = &sv[threads_start..threads_end];
 
     assert!(
@@ -19036,9 +22473,8 @@ fn test_elaborate_440_for_loop_iter_in_function_call() {
     // referenced inside a function-call argument substitutes to the
     // per-loop counter ident. Pre-#440, the raw `b` leaked into the
     // lowered SV as an undeclared variable.
-    let source = include_str!(
-        "regression/issues/elaborate_440/for_loop_iter_in_function_call/Probe.arch"
-    );
+    let source =
+        include_str!("regression/issues/elaborate_440/for_loop_iter_in_function_call/Probe.arch");
     let sv = compile_to_sv(source);
 
     // Single thread → ti=0 → counter ident = `_t0_loop_cnt_0`.
@@ -19070,9 +22506,8 @@ fn test_elaborate_440_rename_ident_in_function_call() {
     // substitutes the user-written iter var into `_loop_cnt_{id}`, 3
     // renames `_loop_cnt_{id}` to its per-thread form. A multi-thread
     // fixture exercises the rename for both ti=0 and ti=1.
-    let source = include_str!(
-        "regression/issues/elaborate_440/rename_ident_in_function_call/Probe.arch"
-    );
+    let source =
+        include_str!("regression/issues/elaborate_440/rename_ident_in_function_call/Probe.arch");
     let sv = compile_to_sv(source);
 
     // Both threads' function-call args must carry the per-thread
@@ -19093,8 +22528,7 @@ fn test_elaborate_440_rename_ident_in_function_call() {
     // Pre-#440 buggy fingerprints: raw `a`/`b` (site 2 missing the
     // FunctionCall arm) or bare `_loop_cnt_0` (site 3 missing it).
     assert!(
-        !sv.contains("step_8(8'($unsigned(a)))")
-            && !sv.contains("step_8(8'($unsigned(b)))"),
+        !sv.contains("step_8(8'($unsigned(a)))") && !sv.contains("step_8(8'($unsigned(b)))"),
         "found buggy raw iter var (`a` or `b`) in `step_8(...)` \
          argument — `rewrite_var_expr` failed to recurse into \
          FunctionCall args (site 2 paired with site 3). SV:\n{sv}"
@@ -19148,7 +22582,9 @@ fn test_thread_sim_honors_round_robin_mutex_policy_without_warning() {
     "#;
     let warnings = compile_to_thread_sim_collect_warnings(source);
     assert!(
-        warnings.iter().all(|w| !w.message.contains("--thread-sim ignores mutex policy")),
+        warnings
+            .iter()
+            .all(|w| !w.message.contains("--thread-sim ignores mutex policy")),
         "thread-sim should implement mutex policy instead of warning; got: {:?}",
         warnings.iter().map(|w| &w.message).collect::<Vec<_>>(),
     );
@@ -19201,7 +22637,9 @@ fn test_thread_sim_emits_lru_and_weighted_mutex_policy_state() {
 
     let warnings = compile_to_thread_sim_collect_warnings(source);
     assert!(
-        warnings.iter().all(|w| !w.message.contains("--thread-sim ignores mutex policy")),
+        warnings
+            .iter()
+            .all(|w| !w.message.contains("--thread-sim ignores mutex policy")),
         "lru/weighted mutex policies should not be downgraded to warnings: {:?}",
         warnings.iter().map(|w| &w.message).collect::<Vec<_>>(),
     );
@@ -19262,7 +22700,8 @@ fn test_thread_sim_no_warning_on_priority_mutex_policy() {
         end module SharedBus
     "#;
     let warnings = compile_to_thread_sim_collect_warnings(source);
-    let policy_warnings: Vec<&str> = warnings.iter()
+    let policy_warnings: Vec<&str> = warnings
+        .iter()
         .filter(|w| w.message.contains("--thread-sim ignores mutex policy"))
         .map(|w| w.message.as_str())
         .collect();
@@ -19312,7 +22751,9 @@ fn test_thread_sim_honors_custom_mutex_policy_with_hook() {
     "#;
     let warnings = compile_to_thread_sim_collect_warnings(source);
     assert!(
-        warnings.iter().all(|w| !w.message.contains("--thread-sim ignores mutex policy")),
+        warnings
+            .iter()
+            .all(|w| !w.message.contains("--thread-sim ignores mutex policy")),
         "custom mutex policy should dispatch its hook instead of warning; got: {:?}",
         warnings.iter().map(|w| &w.message).collect::<Vec<_>>(),
     );
@@ -19843,7 +23284,8 @@ end module IntraTop
 "#;
     let hz = dead_skid_hazards(source, "IntraTop");
     assert!(
-        hz.iter().any(|h| h.read_signal == "fb" && h.driven_signal == "x"),
+        hz.iter()
+            .any(|h| h.read_signal == "fb" && h.driven_signal == "x"),
         "expected intra-module dead-skid hazard `x -> fb`, got {hz:?}"
     );
 }
@@ -19889,7 +23331,8 @@ end module Top
 "#;
     let hz = dead_skid_hazards(source, "Top");
     assert!(
-        hz.iter().any(|h| h.read_signal == "z_w" && h.driven_signal == "a_drv"),
+        hz.iter()
+            .any(|h| h.read_signal == "z_w" && h.driven_signal == "a_drv"),
         "expected default-comb read hazard `a_drv -> z_w`, got {hz:?}"
     );
 }
@@ -19965,6 +23408,7 @@ fn test_thread_map_html_renders_hazard_overlay() {
             threads: vec![ThreadMapThread {
                 name: "Worker".into(),
                 index: 0,
+                once: false,
                 span: Span::new(0, 18),
                 states: vec![],
                 hazards: vec![CombFeedbackHazard {
@@ -20004,6 +23448,7 @@ fn test_thread_map_html_no_hazard_no_overlay() {
             threads: vec![ThreadMapThread {
                 name: "W".into(),
                 index: 0,
+                once: false,
                 span: Span::new(0, 10),
                 states: vec![],
                 hazards: vec![],
@@ -20062,7 +23507,10 @@ fn test_comb_reachable_from_transitive() {
     let seeds: HashSet<String> = ["a".to_string()].into_iter().collect();
     let reached = arch::signal_flow::comb_reachable_from(&seeds, &fwd);
     assert!(reached.contains("b") && reached.contains("c"));
-    assert!(!reached.contains("a"), "seed must not appear unless via a cycle");
+    assert!(
+        !reached.contains("a"),
+        "seed must not appear unless via a cycle"
+    );
 }
 
 /// AW-side mirror of `test_nic400_apb_bridge_wrap_illegal_len_is_rejected_by_sva`.


### PR DESCRIPTION
## Summary

Adds a proof-certificate backend for ARCH thread lowering, with JSON and Lean replay artifacts emitted from the compiler's recorded thread map.

This PR includes:

- `arch build --emit-thread-proof` for JSON certificates
- `arch build/formal --emit-thread-proof-lean` and `--check-thread-proof-lean`
- `arch formal --thread-proof-only` for replaying Lean without running the SMT backend
- a Lean project under `proofs/lean_thread_lowering` modeling counted waits, dispatches, folded wait-exit updates, and store-effect checks
- structured guard/assignment metadata in thread maps so per-design certificates can be replayed instead of treated as opaque labels
- regression coverage for counted waits, fork/join, generated threads, `thread once`, folded terminal actions, structured equality guards, and multi-assignment store effects

## Review

Findings: none from the required pre-PR review pass against this branch diff.

Open questions: none.

## Validation

- `cargo test`
- `ELAN_HOME=/private/tmp/arch-lean-elan PATH=/private/tmp/arch-lean-elan/bin:$PATH lake build` from `proofs/lean_thread_lowering`
- `ELAN_HOME=/private/tmp/arch-lean-elan PATH=/private/tmp/arch-lean-elan/bin:$PATH python3 scripts/test_cert_to_lean.py`
- `scripts/pre_pr_review.sh mark`
- `scripts/pre_pr_review.sh check`
- Lean replay on representative repo examples including:
  - `tests/thread/basic_thread.arch`
  - `tests/thread/wait_cycles.arch`
  - `tests/thread/thread_once.arch`
  - `tests/thread/fork_join.arch`
  - `tests/thread/generate_thread.arch`
  - `tests/thread/resource_lock.arch`
  - `tests/axi_dma_thread/ThreadMm2s.arch`
  - `tests/axi_dma_thread/ThreadS2mm.arch`
  - `tests/nic400/Nic400WidthAdapter.arch`
  - `tests/nic400/Nic400AhbBridge.arch`

## Notes

The PR targets `codex/thread-map-html` so the diff excludes unrelated base-branch work already present before this proof backend.
