### PR TITLE
[codex] Update Lean proof docs and compiler version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,7 +75,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arch"
-version = "0.70.1"
+version = "0.70.2"
 dependencies = [
  "clap",
  "insta",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arch"
-version = "0.70.1"
+version = "0.70.2"
 edition = "2021"
 description = "Compiler for the ARCH hardware description language"
 license = "LGPL-3.0-or-later"

--- a/doc/ARCH_HDL_Specification.md
+++ b/doc/ARCH_HDL_Specification.md
@@ -5919,7 +5919,7 @@ The first column lists sources of undefined values. The second column indicates 
 
 **20.2 Arch Intermediate Representation (FIR)**
 
-All three Arch output targets --- native simulation binary, SystemVerilog for synthesis, and SMT-LIB for formal verification --- are lowered from a common intermediate representation called FIR (Arch Intermediate Representation). FIR is a typed, clock-domain-aware dataflow graph.
+Arch's primary executable/RTL/formal output targets --- native simulation binary, SystemVerilog for synthesis, and SMT-LIB for bounded property checking --- are lowered from a common intermediate representation called FIR (Arch Intermediate Representation). FIR is a typed, clock-domain-aware dataflow graph. Compiler-lowering proof artifacts, such as the Lean thread-lowering certificate, are emitted from compiler metadata captured during lowering rather than from FIR.
 
 +--------------------------------------------------------------------------------------+
 | *fir_conceptual.fir*                                                                 |
@@ -5989,7 +5989,11 @@ From FIR, the three backends diverge:
   **Synthesis**           arch build         FIR nodes → SystemVerilog always_ff / always_comb / assign            Synthesisable SV for FPGA/ASIC tools
 
   **Formal**              arch formal        FIR nodes → SMT-LIB2 bit-vector transition relation                  Self-contained SMT-LIB2 + invocation of Z3 / Boolector / Bitwuzla
+
+  **Thread proof**        arch build/formal  Thread-lowering map → JSON or Lean proof certificate                 Per-design thread-to-FSM lowering replay artifact
   ------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+The Lean thread proof target is a compiler-lowering proof path, not a bounded design-property proof. `arch build --emit-thread-proof` writes a JSON certificate for the recorded thread-to-FSM lowering map. `arch build --emit-thread-proof-lean` and `arch formal --emit-thread-proof-lean` write a Lean replay file; `--check-thread-proof-lean` immediately runs `lake env lean` against that file. `arch formal --thread-proof-only` may be used with Lean proof emission/checking to skip the SMT-LIB2 backend when the desired result is only certificate replay. The Lean project defaults to `proofs/lean_thread_lowering`, or can be supplied with `--thread-proof-lean-project=DIR` / `ARCH_THREAD_PROOF_LEAN_PROJECT`.
 
 **20.3 The Simulation Execution Model**
 
@@ -7987,7 +7991,7 @@ A practical AI workflow: generate a correct skeleton with todo! for all logic, t
 
   **Micro-Arch Lowering**   Pipeline hazard generation, FIFO implementation, arbiter logic, FSM encoding
 
-  **Verification Emit**     assert/cover/assume converted to SystemVerilog Assertions (SVA)
+  **Verification Emit**     assert/cover/assume converted to SystemVerilog Assertions (SVA); optional thread-lowering certificates emitted as JSON/Lean replay files
 
   **SV Emit**               One deterministic, lint-clean SystemVerilog file per Arch top-level module
   ---------------------------------------------------------------------------------------------------------
@@ -8047,6 +8051,8 @@ The compiler emits warnings (non-fatal, printed before "OK: no errors") for the 
   **SystemVerilog (FPGA Intel)**    arch build \--target fpga \--vendor intel    Inserts Intel BRAM/DSP primitives
 
   **Formal verification**           arch formal \[\--bound N\] \[\--solver z3\|boolector\|bitwuzla\]   Direct SMT-LIB2 BMC; the SV-SVA path (arch build + EBMC/Verilator \--assert) still ships as an alternative
+
+  **Thread-lowering proof**         arch build/formal \--emit-thread-proof-lean \[\--check-thread-proof-lean\]   Per-design Lean certificate replay for compiler thread-to-FSM lowering; use \--thread-proof-only on arch formal to skip SMT
 
   **Simulation**                    arch sim \--tb MyTb                          Compiles with Verilator or ModelSim/Questa
 

--- a/doc/Arch_AI_Reference_Card.md
+++ b/doc/Arch_AI_Reference_Card.md
@@ -1429,7 +1429,15 @@ arch formal F.arch                             // direct SMT-LIB2 bounded model 
 arch formal F.arch --bound 64 --solver bitwuzla
 arch formal F.arch --emit-smt model.smt2       // dump the SMT-LIB2 for inspection
 arch formal multi.arch --top MyTop             // pick a top module when the file has >1
+arch build F.arch --emit-thread-proof          // JSON thread-lowering proof certificate
+arch build F.arch --emit-thread-proof-lean     // Lean replay file for thread-to-FSM lowering certificate
+arch build F.arch --check-thread-proof-lean \
+  --thread-proof-lean-project proofs/lean_thread_lowering
+arch formal F.arch --check-thread-proof-lean \
+  --thread-proof-lean-project proofs/lean_thread_lowering \
+  --thread-proof-only                          // replay Lean certificate and skip SMT
 // v1 scope: flat module, scalar types (UInt/SInt/Bool/Bit), single clock, no sub-`inst`
+// Lean thread proof scope: per-design compiler-lowering certificate replay, not bounded design-property proof
 // Exit codes: 0 all PROVED/HIT · 1 any REFUTED/NOT-REACHED · 2 any INCONCLUSIVE · 3 compile error
 ```
 


### PR DESCRIPTION
## Summary

Follow-up to #514.

- Bumps the compiler package version from `0.70.1` to `0.70.2`
- Updates the full ARCH HDL specification with the Lean thread-lowering proof target
- Updates the compact AI reference card with the new proof certificate commands

## Review

Findings: none from the required pre-PR review pass against this branch diff.

Open questions: none.

## Validation

- `cargo test thread_proof`
- `git diff --check`
- `scripts/pre_pr_review.sh mark`
- `scripts/pre_pr_review.sh check`
