### PR TITLE
ci: keep arch-programming skill snapshots in sync with sources

### DIFF
--- a/.github/workflows/skill-snapshots.yml
+++ b/.github/workflows/skill-snapshots.yml
@@ -1,0 +1,49 @@
+name: skill-snapshots
+
+# The arch-programming skill bundles point-in-time copies of core ARCH docs
+# under skills/arch-programming/references/. This check fails if a source doc
+# changes without refreshing its bundled snapshot (or vice versa).
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'README.md'
+      - 'LICENSE'
+      - 'doc/Arch_AI_Reference_Card.md'
+      - 'doc/ARCH_HDL_Specification.md'
+      - 'doc/COMPILER_STATUS.md'
+      - 'doc/arch_sim_cocotb.md'
+      - 'doc/plan_arch_doc_comments.md'
+      - 'mcp/README.md'
+      - 'mcp/instructions.md'
+      - 'skills/arch-programming/references/**'
+      - 'scripts/sync_skill_snapshots.sh'
+      - '.github/workflows/skill-snapshots.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'README.md'
+      - 'LICENSE'
+      - 'doc/Arch_AI_Reference_Card.md'
+      - 'doc/ARCH_HDL_Specification.md'
+      - 'doc/COMPILER_STATUS.md'
+      - 'doc/arch_sim_cocotb.md'
+      - 'doc/plan_arch_doc_comments.md'
+      - 'mcp/README.md'
+      - 'mcp/instructions.md'
+      - 'skills/arch-programming/references/**'
+      - 'scripts/sync_skill_snapshots.sh'
+      - '.github/workflows/skill-snapshots.yml'
+
+concurrency:
+  group: skill-snapshots-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check-snapshots:
+    name: skill snapshots in sync
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Verify bundled skill snapshots match their sources
+        run: scripts/sync_skill_snapshots.sh check

--- a/scripts/sync_skill_snapshots.sh
+++ b/scripts/sync_skill_snapshots.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  scripts/sync_skill_snapshots.sh check    # verify snapshots match their sources (CI)
+  scripts/sync_skill_snapshots.sh refresh  # copy sources over snapshots (local)
+
+The arch-programming skill bundles point-in-time copies of core ARCH docs under
+skills/arch-programming/references/ so the skill works when installed outside an
+arch-com checkout. This script is the single source of truth for the
+source -> snapshot mapping. `check` fails (exit 1) if any snapshot has drifted;
+`refresh` re-copies every source over its snapshot.
+USAGE
+}
+
+mode="${1:-}"
+if [[ "$mode" != "check" && "$mode" != "refresh" ]]; then
+  usage >&2
+  exit 2
+fi
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+ref_dir="skills/arch-programming/references"
+
+# source path                         snapshot filename under $ref_dir
+mappings=(
+  "README.md|README.md"
+  "doc/Arch_AI_Reference_Card.md|Arch_AI_Reference_Card.md"
+  "doc/ARCH_HDL_Specification.md|ARCH_HDL_Specification.md"
+  "doc/COMPILER_STATUS.md|COMPILER_STATUS.md"
+  "doc/arch_sim_cocotb.md|arch_sim_cocotb.md"
+  "doc/plan_arch_doc_comments.md|plan_arch_doc_comments.md"
+  "mcp/README.md|mcp_README.md"
+  "mcp/instructions.md|mcp_instructions.md"
+  "LICENSE|LICENSE"
+)
+
+drift=0
+for entry in "${mappings[@]}"; do
+  src="${entry%%|*}"
+  dst="$ref_dir/${entry##*|}"
+
+  if [[ ! -f "$src" ]]; then
+    echo "ERROR: missing source $src" >&2
+    drift=1
+    continue
+  fi
+  if [[ ! -f "$dst" ]]; then
+    echo "ERROR: missing snapshot $dst" >&2
+    drift=1
+    continue
+  fi
+
+  if [[ "$mode" == "refresh" ]]; then
+    cp "$src" "$dst"
+    continue
+  fi
+
+  if ! cmp -s "$src" "$dst"; then
+    echo "DRIFT: $dst is out of sync with $src" >&2
+    drift=1
+  fi
+done
+
+if [[ "$mode" == "refresh" ]]; then
+  echo "Refreshed ${#mappings[@]} skill reference snapshot(s)."
+  exit 0
+fi
+
+if [[ "$drift" -ne 0 ]]; then
+  cat >&2 <<'MSG'
+
+One or more arch-programming skill snapshots are stale.
+Run `scripts/sync_skill_snapshots.sh refresh` and commit the result.
+MSG
+  exit 1
+fi
+
+echo "All ${#mappings[@]} skill reference snapshots are in sync."

--- a/skills/arch-programming/references/README.md
+++ b/skills/arch-programming/references/README.md
@@ -123,6 +123,26 @@ arch learn-clear                    # wipe the store
 
 Design goals: **local-first** (no telemetry, no network); **capped** (100 MB default via `ARCH_LEARN_MAX_MB`, warns at 90% full); **opt-out** (`ARCH_NO_LEARN=1` disables capture entirely). The long-term roadmap — idiom capture, contributor sharing, promoting stable patterns to compiler lints — lives in [`doc/plan_arch_learning_system.md`](doc/plan_arch_learning_system.md).
 
+## AI assistant support
+
+This repo includes two optional Codex-facing helpers:
+
+- [`mcp/`](mcp/) — an ARCH MCP server that exposes compiler-backed tools for
+  construct syntax, file writing/checking, SystemVerilog build/lint, simulation,
+  formal checks, and local `arch advise` learning-store retrieval.
+- [`skills/arch-programming`](skills/arch-programming/) — an installable Codex
+  skill with bundled ARCH reference snapshots and a workflow that prefers the
+  MCP server when available.
+
+Install the skill into the default Codex skill directory with:
+
+```sh
+mkdir -p "${CODEX_HOME:-$HOME/.codex}/skills"
+cp -R skills/arch-programming "${CODEX_HOME:-$HOME/.codex}/skills/"
+```
+
+Register the MCP server separately by following [`mcp/README.md`](mcp/README.md).
+
 ## Language snapshot
 
 ### Combinational logic

--- a/skills/arch-programming/references/SNAPSHOT.md
+++ b/skills/arch-programming/references/SNAPSHOT.md
@@ -29,16 +29,13 @@ runnable examples and full regression context, use a live `arch-com` checkout.
 
 ## Refresh
 
-When ARCH docs change, refresh this snapshot from the repository root:
+When ARCH docs change, refresh these snapshots from the repository root:
 
 ```sh
-cp README.md skills/arch-programming/references/README.md
-cp doc/Arch_AI_Reference_Card.md skills/arch-programming/references/Arch_AI_Reference_Card.md
-cp doc/ARCH_HDL_Specification.md skills/arch-programming/references/ARCH_HDL_Specification.md
-cp doc/COMPILER_STATUS.md skills/arch-programming/references/COMPILER_STATUS.md
-cp doc/arch_sim_cocotb.md skills/arch-programming/references/arch_sim_cocotb.md
-cp doc/plan_arch_doc_comments.md skills/arch-programming/references/plan_arch_doc_comments.md
-cp mcp/README.md skills/arch-programming/references/mcp_README.md
-cp mcp/instructions.md skills/arch-programming/references/mcp_instructions.md
-cp LICENSE skills/arch-programming/references/LICENSE
+scripts/sync_skill_snapshots.sh refresh
 ```
+
+The script owns the source -> snapshot mapping. The `skill-snapshots` CI
+workflow runs `scripts/sync_skill_snapshots.sh check` on every PR that touches
+a source doc or a bundled snapshot, and fails if the two have drifted — so a
+doc change must be accompanied by a refresh in the same PR.


### PR DESCRIPTION
The arch-programming skill bundles point-in-time copies of core ARCH docs
under skills/arch-programming/references/. Nothing kept them in sync with
their doc/ + mcp/ + root sources, and the root README snapshot had already
drifted (missing the 'AI assistant support' section).

- Add scripts/sync_skill_snapshots.sh as the single source of truth for the
  source -> snapshot mapping, with check (CI) and refresh (local) modes.
- Add the skill-snapshots GitHub Actions workflow that runs the check on PRs
  touching any source doc or bundled snapshot.
- Refresh the stale README snapshot.
- Point SNAPSHOT.md's refresh instructions at the script instead of a
  duplicated cp list.