### PR TITLE
Fix false-positive multi-driver on genfor Vec-of-bus sibling element

### DIFF
--- a/src/signal_flow.rs
+++ b/src/signal_flow.rs
@@ -30,6 +30,25 @@ pub struct DriveEntry {
     pub span: Span,
 }
 
+/// Extracts the integer value of a compile-time-constant literal index.
+///
+/// Returns `Some(v)` only for bare numeric literals (`out[2]`).  Any
+/// non-literal index — a variable (`out[i]`), an arithmetic expression,
+/// or a param reference — returns `None`.  This is deliberately narrow:
+/// a literal index targets ONE element that downstream codegen emits as a
+/// distinct flat signal, whereas a variable index conservatively aliases
+/// the whole vector (a single `always_comb` writing `out[idx]` is one
+/// driver regardless of which element it hits at runtime).
+fn const_index_value(idx: &Expr) -> Option<u64> {
+    match &idx.kind {
+        ExprKind::Literal(LitKind::Dec(v))
+        | ExprKind::Literal(LitKind::Hex(v))
+        | ExprKind::Literal(LitKind::Bin(v)) => Some(*v),
+        ExprKind::Literal(LitKind::Sized(_, v)) => Some(*v),
+        _ => None,
+    }
+}
+
 /// Extracts the signal name from an LHS expression.
 ///
 /// Bit-slices, part-selects, index accesses, and latency annotations are
@@ -49,6 +68,37 @@ fn lhs_base_name(expr: &Expr) -> Option<String> {
         }
         _ => None,
     }
+}
+
+/// Like [`lhs_base_name`], but preserves a trailing **constant-literal**
+/// index as part of the key (`out[0]` → `"out[0]"`, `out[i]` → `"out"`).
+///
+/// Used ONLY for `inst` output connections.  An inst output wired to a
+/// vector element (`last -> out[0]`) lowers to a continuous driver of that
+/// single element (`.last(out[0])` in the SV port map), so two inst items
+/// driving distinct constant elements (`out[0]` and `out[1]`) are NOT a
+/// conflict.  This is the shape a `generate_for` over a Vec-of-bus port
+/// unrolls into at elaboration time: N separate inst blocks each driving
+/// `out[<const i>]`.  Collapsing them to a bare `out` reported a phantom
+/// multi-driver.
+///
+/// A *variable* index (`out[i]`) is still stripped to the bare name — it
+/// conservatively aliases the whole vector — so two inst items driving the
+/// same constant element (`out[0]` twice) still collide, preserving
+/// genuine multi-driver detection.
+///
+/// This granularity is deliberately NOT applied to `comb`/`seq` blocks:
+/// each such block is one `always_comb`/`always_ff` over the whole array,
+/// so two blocks writing different constant indices of one Vec ARE a real
+/// SV conflict and must keep erroring (see
+/// `test_multi_driver_vec_index_from_two_blocks_errors`).
+fn inst_conn_driver_name(expr: &Expr) -> Option<String> {
+    if let ExprKind::Index(base, idx) = &expr.kind {
+        if let Some(v) = const_index_value(idx) {
+            return lhs_base_name(base).map(|b| format!("{}[{}]", b, v));
+        }
+    }
+    lhs_base_name(expr)
 }
 
 /// Collect every distinct signal name driven by `stmts`, storing the
@@ -178,11 +228,18 @@ pub fn collect_module_drivers(m: &ModuleDecl, source: &SourceFile) -> HashMap<St
                 let mut t = HashMap::new();
                 for conn in &inst.connections {
                     if conn.direction == ConnectDir::Output {
-                        if let Some(name) = lhs_base_name(&conn.signal) {
+                        if let Some(name) = inst_conn_driver_name(&conn.signal) {
                             // Skip connections to explicitly-declared bus/struct
                             // wires — these are driven by multiple inst items by
-                            // design.
-                            if named_wire_names.contains(name.as_str()) {
+                            // design.  Match on the BASE name: `name` may carry a
+                            // constant-index suffix (`link[0]`), but the skip-set
+                            // is keyed by the bare declaration name (`link`).
+                            let base = lhs_base_name(&conn.signal);
+                            if base
+                                .as_deref()
+                                .map(|b| named_wire_names.contains(b))
+                                .unwrap_or(false)
+                            {
                                 continue;
                             }
                             // Skip connections where the child port is a bus

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -23162,6 +23162,166 @@ end module VecIndexSingleBlock
     );
 }
 
+/// POSITIVE regression: a `generate_for` over a Vec-of-bus port whose body
+/// also forwards a sibling non-bus output element (`last -> out[i]`) must
+/// type-check.  The Vec-of-bus connection (`b <- m[i]`) forces the
+/// generate_for to unroll at elaboration time into N separate `inst`
+/// blocks, each driving a DISTINCT element `out[<const i>]`.  Before the
+/// fix, `lhs_base_name` collapsed every `out[0..N-1]` to a bare `out`, so
+/// the inst-output driver tracker counted N drivers on `out` and reported a
+/// phantom "multiple drivers" — rejecting valid code.  Each iteration
+/// drives a different element, so this is legal.
+#[test]
+fn test_multi_driver_genfor_vecbus_sibling_element_no_error() {
+    let source = r#"
+bus BusVr
+  param DATA_W: const = 8;
+  valid: out Bool;
+  ready: in  Bool;
+  data:  out UInt<DATA_W>;
+end bus BusVr
+
+module VrTapScalar
+  port b:    target BusVr<DATA_W=8>;
+  port en:   in Bool;
+  port last: out UInt<8>;
+  comb
+    b.ready = en;
+    last    = b.data;
+  end comb
+end module VrTapScalar
+
+module Fx1bMultiDriver
+  param LANES: const = 3;
+  port m:   target      Vec<BusVr<DATA_W=8>, LANES>;
+  port en:  in unpacked Vec<Bool, LANES>;
+  port out: out unpacked Vec<UInt<8>, LANES>;
+  generate_for i in 0..LANES-1
+    inst tap_i: VrTapScalar
+      b    <- m[i];
+      en   <- en[i];
+      last -> out[i];
+    end inst tap_i
+  end generate_for
+end module Fx1bMultiDriver
+"#;
+    assert!(
+        typecheck_source(source).is_ok(),
+        "generate_for over Vec-of-bus forwarding distinct sibling elements \
+         (out[i] per iteration) must NOT be a multi-driver — each iteration \
+         drives a different element"
+    );
+}
+
+/// NEGATIVE regression: even with the same Vec-of-bus generate_for shape,
+/// if every iteration forwards to the SAME constant element (`last ->
+/// out[0]`, not `out[i]`), that IS a genuine multiple-driver of `out[0]`
+/// and must still error.  This pins that the fix distinguishes "distinct
+/// element per iteration" (legal) from "same element driven N times"
+/// (illegal) — it must not blanket-suppress the inst-output multi-driver
+/// check for Vec elements.
+#[test]
+fn test_multi_driver_genfor_same_const_element_errors() {
+    let source = r#"
+bus BusVr
+  param DATA_W: const = 8;
+  valid: out Bool;
+  ready: in  Bool;
+  data:  out UInt<DATA_W>;
+end bus BusVr
+
+module VrTapScalar
+  port b:    target BusVr<DATA_W=8>;
+  port en:   in Bool;
+  port last: out UInt<8>;
+  comb
+    b.ready = en;
+    last    = b.data;
+  end comb
+end module VrTapScalar
+
+module GenConstDrive
+  param LANES: const = 3;
+  port m:   target      Vec<BusVr<DATA_W=8>, LANES>;
+  port en:  in unpacked Vec<Bool, LANES>;
+  port out: out unpacked Vec<UInt<8>, LANES>;
+  generate_for i in 0..LANES-1
+    inst tap_i: VrTapScalar
+      b    <- m[i];
+      en   <- en[i];
+      last -> out[0];
+    end inst tap_i
+  end generate_for
+end module GenConstDrive
+"#;
+    assert!(
+        has_multi_driver_error(source, "out[0]"),
+        "all generate_for iterations driving the same constant element \
+         out[0] must still trigger MultipleDrivers"
+    );
+}
+
+/// NEGATIVE regression (no generate_for): two plain `inst` items both wired
+/// to the same constant element `out[0]` must error.  Pins that the
+/// per-constant-index inst-output granularity still catches a same-element
+/// double drive.
+#[test]
+fn test_multi_driver_two_inst_same_vec_element_errors() {
+    let source = r#"
+module Src
+  port v: out UInt<8>;
+  comb
+    v = 8'd1;
+  end comb
+end module Src
+
+module ParentDoubleElem
+  port out: out unpacked Vec<UInt<8>, 2>;
+  inst a: Src
+    v -> out[0];
+  end inst a
+  inst b: Src
+    v -> out[0];
+  end inst b
+end module ParentDoubleElem
+"#;
+    assert!(
+        has_multi_driver_error(source, "out[0]"),
+        "two inst outputs driving the same Vec element out[0] must trigger \
+         MultipleDrivers"
+    );
+}
+
+/// POSITIVE sister case: two plain `inst` items wired to DISTINCT constant
+/// elements (`out[0]` and `out[1]`) must NOT error — each drives a separate
+/// element via its own continuous driver, which is legal in SV.
+#[test]
+fn test_multi_driver_two_inst_distinct_vec_elements_no_error() {
+    let source = r#"
+module Src
+  port v: out UInt<8>;
+  comb
+    v = 8'd1;
+  end comb
+end module Src
+
+module ParentDistinctElem
+  port out: out unpacked Vec<UInt<8>, 2>;
+  inst a: Src
+    v -> out[0];
+  end inst a
+  inst b: Src
+    v -> out[1];
+  end inst b
+end module ParentDistinctElem
+"#;
+    assert!(
+        typecheck_source(source).is_ok(),
+        "two inst outputs driving distinct Vec elements out[0]/out[1] must \
+         NOT be a multi-driver"
+    );
+}
+
 /// Bus-typed wires connected from both initiator and target insts must NOT
 /// trigger multi-driver.  This is the canonical TLM bus wire pattern.
 #[test]


### PR DESCRIPTION
## Summary

Fixes a false-positive in the single-driver / driver-tracking checker. When a `generate_for` body forwards BOTH a `Vec<Bus>` per-element connection (`b <- m[i]`) and a sibling non-bus output element (`last -> out[i]`), `arch check` wrongly reported `signal \`out\` has multiple drivers`, rejecting valid code.

This is an **internal correctness fix** — no user-facing syntax or semantics change. It only stops rejecting already-valid code, so per CLAUDE.md it's a sanctioned autonomous fix filed as a PR.

### Reproducer (now `OK: no errors`, previously errored)

```arch
module Fx1bMultiDriverBug
  param LANES: const = 3;
  port m:   target      Vec<BusVr<DATA_W=8>, LANES>;
  port en:  in unpacked Vec<Bool, LANES>;
  port out: out unpacked Vec<UInt<8>, LANES>;
  generate_for i in 0..LANES-1
    inst tap_i: VrTapScalar
      b    <- m[i];
      en   <- en[i];
      last -> out[i];
    end inst tap_i
  end generate_for
end module Fx1bMultiDriverBug
```

## Root cause

The `Vec<Bus>` connection `b <- m[i]` indexes a Vec-of-bus parent port, which forces the `generate_for` to **unroll at elaboration time** (SV genvar form can't express per-iteration flat bus-name expansion — `src/elaborate.rs`). Unrolling produces N separate `inst` blocks, each driving a distinct element: `out[0]`, `out[1]`, `out[2]`.

In `src/signal_flow.rs::collect_module_drivers`, each `inst` is a distinct driver block. The Inst branch keyed each driven signal via `lhs_base_name`, which **strips every index access** — so `out[0]`, `out[1]`, `out[2]` all collapsed to the bare key `out`. The map then held 3 driver entries for `out`, and `check_multi_driver` flagged it.

`lhs_base_name` strips indices *on purpose*: two `comb`/`seq` blocks writing different Vec indices ARE a real SV conflict (one `always_comb`/`always_ff` per block over the whole array). That coarse-graining is correct for comb/seq but wrong for `inst` output connections, where a wire-to-element connection (`.last(out[0])`) is a continuous driver of one element only.

## The fix (minimal, scoped to inst connections)

`src/signal_flow.rs`:
- Add `const_index_value` — extracts the value of a **constant-literal** index (`out[2]`); returns `None` for variable/expression indices (`out[i]`).
- Add `inst_conn_driver_name` — like `lhs_base_name` but preserves a trailing constant-literal index in the key (`out[0]` and `out[1]` distinct; `out[i]` still stripped to `out`). Used **only** in the `Inst` branch.
- The named-wire skip-set check now matches on the base name (via `lhs_base_name`) so a `link[0]` connection to a named bus/struct wire `link` is still skipped.

`comb`/`seq`/latch collection is untouched, so genuine multi-driver detection for those blocks is unchanged.

### Why it's safe (distinct-element vs same-element)
- `out[i]` distinct per iteration → distinct keys → legal (the bug).
- `out[0]` driven by N iterations / two insts → same key `out[0]` → still errors.
- `out[i]` with a *variable* index → still stripped to `out` → two such blocks still conflict.

## Tests (`tests/integration_test.rs`)

- `test_multi_driver_genfor_vecbus_sibling_element_no_error` — positive: the exact reproducer type-checks.
- `test_multi_driver_genfor_same_const_element_errors` — negative: all iterations driving `out[0]` still errors.
- `test_multi_driver_two_inst_same_vec_element_errors` — negative: two plain insts on `out[0]` still errors.
- `test_multi_driver_two_inst_distinct_vec_elements_no_error` — positive: two insts on `out[0]`/`out[1]` is legal.

Existing `test_multi_driver_vec_index_from_two_blocks_errors` (two comb blocks writing distinct Vec indices) still passes — comb-block granularity is intentionally unchanged.

## Test evidence

- Reproducer `arch check` → `OK: no errors`; `arch build` → emits `Fx1bMultiDriverBug.sv` cleanly.
- Negative double-drive cases still error with `signal \`out[0]\` has multiple drivers`.
- Full `cargo test --release`: **649 tests, 0 failures**.