### PR TITLE
fix(codegen): stop stack overflow on param-forwarded Vec<Bus> inst forward

### DIFF
--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -2228,7 +2228,24 @@ impl<'a> Codegen<'a> {
         let mut child_params_overridden = child_params.clone();
         for pa in &inst.param_assigns {
             if let Some(p) = child_params_overridden.iter_mut().find(|p| p.name.name == pa.name.name) {
-                p.default = Some(pa.value.clone());
+                // The override RHS is written in the *parent* param scope, so
+                // resolve it there before substituting into the child param
+                // list. Without this, `param NUM = NUM` (parent NUM forwarded
+                // into the child's same-named NUM) yields a self-referential
+                // child default `NUM => NUM`, and a later eval_const_u32 against
+                // the child params recurses forever (stack overflow). Folding to
+                // a literal in the parent scope severs that cycle; if the parent
+                // value isn't reducible at codegen we keep the original expr
+                // (eval_const_u32's visited-guard then safely bails to None).
+                let resolved = self
+                    .eval_const_u32(&pa.value, &self.current_module_params.clone())
+                    .map(|n| Expr {
+                        kind: ExprKind::Literal(LitKind::Dec(n as u64)),
+                        span: pa.value.span,
+                        parenthesized: false,
+                    })
+                    .unwrap_or_else(|| pa.value.clone());
+                p.default = Some(resolved);
             }
         }
         let target_bus_ports: Vec<(String, String, Vec<ParamAssign>)> = target_ports_ref
@@ -4358,6 +4375,19 @@ impl<'a> Codegen<'a> {
     /// Returns None if the expression can't be reduced — caller then treats
     /// the receiver as size-unknown and skips Vec method lowering.
     fn eval_const_u32(&self, e: &Expr, params: &[ParamDecl]) -> Option<u32> {
+        self.eval_const_u32_depth(e, params, 0)
+    }
+
+    /// Depth-guarded core of `eval_const_u32`. A self-referential param default
+    /// (e.g. a child param `NUM => NUM` produced by an inst override that shares
+    /// a name with a parent param) would otherwise recurse until the stack
+    /// overflows. Bail to None past a generous depth — no legitimate
+    /// compile-time size expression nests anywhere near this far.
+    fn eval_const_u32_depth(&self, e: &Expr, params: &[ParamDecl], depth: u32) -> Option<u32> {
+        const MAX_DEPTH: u32 = 64;
+        if depth > MAX_DEPTH {
+            return None;
+        }
         match &e.kind {
             ExprKind::Literal(LitKind::Dec(v)) => Some(*v as u32),
             ExprKind::Literal(LitKind::Hex(v))
@@ -4370,11 +4400,11 @@ impl<'a> Codegen<'a> {
                     _ => return None,
                 }
                 let d = p.default.as_ref()?;
-                self.eval_const_u32(d, params)
+                self.eval_const_u32_depth(d, params, depth + 1)
             }
             ExprKind::Binary(op, l, r) => {
-                let lv = self.eval_const_u32(l, params)?;
-                let rv = self.eval_const_u32(r, params)?;
+                let lv = self.eval_const_u32_depth(l, params, depth + 1)?;
+                let rv = self.eval_const_u32_depth(r, params, depth + 1)?;
                 Some(match op {
                     BinOp::Add => lv + rv,
                     BinOp::Sub => lv.saturating_sub(rv),

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -1421,8 +1421,38 @@ impl<'a> TypeChecker<'a> {
                 }
             }
 
+            // Base names of the child's Vec-of-bus ports (`port mm: ...
+            // Vec<Bus, N>`). The parser flattens a per-element connection
+            // `mm[k] <- ...` into port_name `mm_<k>`, so to credit the right
+            // parent driver below we must recognise `mm_<k>` as element k of
+            // the child's `mm` port. We only need to know which child ports are
+            // Vec-of-bus (count present) — not the concrete N — so this avoids
+            // resolving a possibly param-dependent count here.
+            let child_vob_bases: Vec<String> = self.source.items.iter()
+                .find_map(|item| match item {
+                    Item::Module(m2) if m2.name.name == inst.module_name.name => Some(m2.ports.as_slice()),
+                    Item::Fsm(f2)    if f2.name.name == inst.module_name.name => Some(f2.ports.as_slice()),
+                    Item::Pipeline(p2) if p2.name.name == inst.module_name.name => Some(p2.ports.as_slice()),
+                    _ => None,
+                })
+                .map(|ports| ports.iter()
+                    .filter(|p| p.bus_info.as_ref().map_or(false, |bi| bi.count.is_some()))
+                    .map(|p| p.name.name.clone())
+                    .collect())
+                .unwrap_or_default();
+
             // Mark connected output ports as driven
             for conn in &inst.connections {
+                // Resolve the child bus port this connection targets. Whole-bus
+                // (`mm <- ...`) keeps the port name verbatim; per-element
+                // (`mm[k] <- ...`, flattened to `mm_<k>`) strips the trailing
+                // `_<idx>` back to the Vec-of-bus base `mm`.
+                let conn_port_base: String = child_vob_bases.iter()
+                    .find_map(|base| {
+                        let rest = conn.port_name.name.strip_prefix(&format!("{base}_"))?;
+                        rest.parse::<u32>().ok().map(|_| base.clone())
+                    })
+                    .unwrap_or_else(|| conn.port_name.name.clone());
                 if conn.direction == ConnectDir::Output {
                     if let ExprKind::Ident(name) = &conn.signal.kind {
                         driven.insert(name.clone());
@@ -1454,7 +1484,7 @@ impl<'a> TypeChecker<'a> {
                 // Whole-bus connection: axi_rd -> m_axi_mm2s expands to N signals.
                 // The inst's bus port drives/receives signals based on its perspective.
                 // We need to mark parent signals as "driven" when the inst OUTPUTS them.
-                if let Some((_, bus_name)) = target_bus_ports.iter().find(|(pn, _)| *pn == conn.port_name.name) {
+                if let Some((_, bus_name)) = target_bus_ports.iter().find(|(pn, _)| *pn == conn_port_base) {
                     if let Some((crate::resolve::Symbol::Bus(info), _)) = self.symbols.globals.get(bus_name) {
                         // Find the inst's bus port perspective, params, and Vec count.
                         let inst_bus_info = self.source.items.iter()
@@ -1464,7 +1494,7 @@ impl<'a> TypeChecker<'a> {
                                 _ => None,
                             })
                             .and_then(|ports| ports.iter()
-                                .find(|p| p.name.name == conn.port_name.name)
+                                .find(|p| p.name.name == conn_port_base)
                                 .and_then(|p| p.bus_info.as_ref()));
                         let inst_perspective = inst_bus_info.map(|bi| bi.perspective);
                         // Inst port's Vec count (Some(N) means `port: ... Vec<Bus, N>`).

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -5566,6 +5566,47 @@ fn test_nested_for_in_thread_uses_distinct_loop_counters() {
 }
 
 #[test]
+fn test_vec_bus_param_forward_no_stack_overflow() {
+    // Regression: a `target Vec<Bus, N>` forwarded across an inst boundary
+    // where the count N is itself an inst-forwarded param (`param NUM = NUM`).
+    //
+    //  * Whole-vector (`mm <- m`): `arch check` passed but `arch build`
+    //    stack-overflowed (abort 134). `emit_inst` copied the inst override
+    //    RHS verbatim into the child param list, so `param NUM = NUM` became a
+    //    self-referential child default `NUM => NUM`, and `eval_const_u32`
+    //    (resolving the Vec<Bus> count) recursed forever. Fixed by folding the
+    //    override in the parent scope before substitution, plus a depth guard.
+    //
+    //  * Per-element (`mm[k] <- m[k]`): never crashed but failed single-driver
+    //    checking ("output port m_0_ready is not driven") — the parser-
+    //    flattened LHS `mm_<k>` didn't match the child's Vec-of-bus port `mm`
+    //    in the inst driver-tracking, so the reverse (ready) direction went
+    //    uncredited. Fixed by stripping the `_<idx>` suffix to the base.
+    //
+    // Both shapes must now build to Verilator-clean SV (lint verified in CI
+    // via the standing repro; here we assert the structural SV shape).
+    let source = include_str!(
+        "regression/issues/vec_bus_param_forward/VecBusParamForward.arch"
+    );
+    let sv = compile_to_sv(source);
+    // All three modules emit.
+    for m in ["module CrashSink", "module CrashWhole", "module CrashPerElem"] {
+        assert!(sv.contains(m), "expected `{m}` in SV:\n{sv}");
+    }
+    // Whole-vector forward packs each bus signal whole.
+    assert!(
+        sv.contains(".mm_ready(m_ready)") && sv.contains(".mm_valid(m_valid)"),
+        "expected whole-Vec packed forwarding in CrashWhole:\n{sv}"
+    );
+    // Per-element forward packs element-wise via a concat over the Vec count.
+    assert!(
+        sv.contains(".mm_ready({m_ready[1], m_ready[0]})")
+            && sv.contains(".mm_valid({m_valid[1], m_valid[0]})"),
+        "expected per-element packed forwarding in CrashPerElem:\n{sv}"
+    );
+}
+
+#[test]
 fn test_vec_bus_whole_vec_forward_to_child_inst() {
     // Regression for issue #424: forwarding a `target Vec<Bus, N>`
     // parent port to a child instance via a whole-Vec connection
@@ -21658,9 +21699,18 @@ fn test_inst_for_loop_matches_hand_enumerated_form() {
         sv_loop.contains("sp_0") && sv_loop.contains("sp_1"),
         "expected sp_0 and sp_1 instances in SV:\n{sv_loop}"
     );
+    // The `param NMC = NM` forwarding makes the child's `ins: Vec<B, NMC>`
+    // count resolve to 2 in the parent scope, so each `ins[k] <- edges[k][j]`
+    // packs into the per-bus-signal concat form `.ins_v({edges_v[1][j],
+    // edges_v[0][j]})` / `.ins_d(...)`. (Before the inst param-forwarding fix
+    // the count was unresolved and codegen fell back to the invalid pins
+    // `.ins_0(edges[0][0])` — non-existent on the child and referencing the
+    // bus-typed name `edges` that SV had already split into `edges_v`/`edges_d`;
+    // Verilator rejected it with "Pin not found: 'ins_1'".)
     assert!(
-        sv_loop.contains("edges[0][0]") && sv_loop.contains("edges[1][1]"),
-        "expected per-index edges refs in SV:\n{sv_loop}"
+        sv_loop.contains(".ins_v({edges_v[1][0], edges_v[0][0]})")
+            && sv_loop.contains(".ins_d({edges_d[1][1], edges_d[0][1]})"),
+        "expected packed per-bus-signal Vec-of-bus forwarding refs in SV:\n{sv_loop}"
     );
 }
 

--- a/tests/regression/issues/vec_bus_param_forward/VecBusParamForward.arch
+++ b/tests/regression/issues/vec_bus_param_forward/VecBusParamForward.arch
@@ -1,0 +1,70 @@
+// Regression: forwarding a `target Vec<Bus, N>` across an inst boundary
+// where the Vec count N is itself an inst-forwarded param
+// (`param NUM = NUM`, parent NUM → child's same-named NUM).
+//
+// Two bugs lived here, both in the Vec-of-bus inst-boundary forwarding:
+//
+//  1. STACK OVERFLOW in `arch build` (check passed, build aborted 134).
+//     `emit_inst` built the child param list by copying the inst override
+//     RHS verbatim, so `param NUM = NUM` produced a self-referential child
+//     default `NUM => NUM`. `eval_const_u32` (resolving the Vec<Bus> count)
+//     then recursed NUM→NUM→NUM… until the stack blew. Fix: resolve the
+//     override RHS in the *parent* param scope and substitute the folded
+//     literal; a depth guard in eval_const_u32 backstops any future cycle.
+//
+//  2. PER-ELEMENT passthrough `mm[k] <- m[k]` failed single-driver
+//     checking ("output port m_0_ready is not driven"). The parser
+//     flattens the LHS `mm[k]` to port_name `mm_<k>`, but the inst
+//     driver-tracking in `check_inst_decl` only matched the bare child bus
+//     port name `mm`, so the reverse (ready) direction was never credited.
+//     Fix: strip the `_<idx>` suffix back to the Vec-of-bus base when
+//     looking up the child bus port for driver bookkeeping.
+//
+// Both whole-vector (`mm <- m`) and per-element (`mm[k] <- m[k]`) shapes
+// are exercised here; both must `arch build` to Verilator-clean SV.
+bus BusVr
+  param DATA_W: const = 8;
+  valid: out Bool;
+  ready: in  Bool;
+  data:  out UInt<DATA_W>;
+end bus BusVr
+
+module CrashSink
+  param NUM: const = 2;
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Async, Low>;
+  port mm: target Vec<BusVr<DATA_W=8>, NUM>;
+  comb
+    mm[0].ready = true;
+    mm[1].ready = true;
+  end comb
+end module CrashSink
+
+// Whole-vector forward: `mm <- m`.
+module CrashWhole
+  param NUM: const = 2;
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Async, Low>;
+  port m: target Vec<BusVr<DATA_W=8>, NUM>;
+  inst sink: CrashSink
+    param NUM = NUM;
+    clk <- clk;
+    rst <- rst;
+    mm <- m;
+  end inst sink
+end module CrashWhole
+
+// Per-element forward: `mm[k] <- m[k]`.
+module CrashPerElem
+  param NUM: const = 2;
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Async, Low>;
+  port m: target Vec<BusVr<DATA_W=8>, NUM>;
+  inst sink: CrashSink
+    param NUM = NUM;
+    clk <- clk;
+    rst <- rst;
+    mm[0] <- m[0];
+    mm[1] <- m[1];
+  end inst sink
+end module CrashPerElem


### PR DESCRIPTION
## Summary

`arch build` stack-overflowed (infinite recursion, abort 134) when a `target Vec<Bus, N>` port was forwarded across an inst boundary and the count `N` was itself an inst-forwarded param (`param NUM = NUM`). `arch check` passed; only `arch build` crashed.

This PR fixes two distinct bugs in the same Vec-of-bus inst-boundary forwarding path. Both are internal codegen/elaboration fixes — **no user-facing syntax/semantics change**.

### Bug 1 — stack overflow on whole-vector forward (`mm <- m`)

`emit_inst` built the child param list by copying the inst override RHS verbatim, so `param NUM = NUM` (parent `NUM` forwarded into the child's same-named `NUM`) produced a **self-referential** child default `NUM => NUM`. `eval_const_u32`, resolving the `Vec<Bus>` count, then recursed `NUM → NUM → NUM …` until the stack blew.

**Fix:** fold the override RHS in the *parent* param scope before substituting into the child param list, severing the cycle. A depth guard in `eval_const_u32` backstops any future self-reference.

### Bug 2 — per-element passthrough single-driver failure (`mm[k] <- m[k]`)

Did not crash, but failed single-driver checking with `output port m_0_ready is not driven` — the reverse (ready) direction was never wired across the boundary. The parser flattens the LHS `mm[k]` to port_name `mm_<k>`, but the inst driver-tracking in `check_inst_decl` only matched the bare child bus port name `mm`.

**Fix:** strip the `_<idx>` suffix back to the Vec-of-bus base when looking up the child bus port for driver bookkeeping. Codegen already emitted the correct packed concat for this shape.

Both shapes now build to **Verilator-clean SV**.

### Latent bug surfaced & fixed

`test_inst_for_loop_matches_hand_enumerated_form` was a string-only test locking in *invalid* SV: with the count previously unresolvable, codegen fell back to `.ins_0(edges[0][0])` — pins that don't exist on the child, referencing the bus-typed name `edges` that SV had already split into `edges_v`/`edges_d`. Verilator rejects it (`Pin not found: 'ins_1'`). With the count now resolvable, codegen emits the correct packed form; the test assertion is updated to the valid shape.

## Tests

- New `tests/regression/issues/vec_bus_param_forward/VecBusParamForward.arch` + `test_vec_bus_param_forward_no_stack_overflow` covering both whole-vector and per-element shapes.
- Updated `test_inst_for_loop_matches_hand_enumerated_form` to assert the corrected, Verilator-valid packed form.
- Full suite green (587 integration + formal + unit). New repros verilate clean.