### PR TITLE
fix(sim,threads): lower variable-index Vec<Bus> element access correctly

### DIFF
--- a/src/elaborate.rs
+++ b/src/elaborate.rs
@@ -2464,6 +2464,34 @@ fn lower_module_threads(
                 .map(|bi| (p.name.name.clone(), bi.bus_name.name.clone()))
         })
         .collect();
+    // Vec-of-bus port name → element count N. A *variable* index into one
+    // of these (`o[sel].ready`) can't be resolved to a single static lane
+    // at lowering time, so reads of such expressions are lowered to a
+    // runtime mux over the N flattened per-lane signals (`o_0_ready` …
+    // `o_{N-1}_ready`). Constant indices keep the existing single-lane path.
+    let vob_counts: HashMap<String, u32> = {
+        let param_vals: HashMap<String, i64> = m
+            .params
+            .iter()
+            .filter_map(|p| {
+                p.default
+                    .as_ref()
+                    .and_then(|d| try_eval_i64(d, &HashMap::new()).map(|v| (p.name.name.clone(), v)))
+            })
+            .collect();
+        let mut out = HashMap::new();
+        for p in &m.ports {
+            if let Some(bi) = p.bus_info.as_ref() {
+                if let Some(count_expr) = bi.count.as_ref() {
+                    let n = try_eval_i64(count_expr, &param_vals).unwrap_or(0) as u32;
+                    if n > 0 {
+                        out.insert(p.name.name.clone(), n);
+                    }
+                }
+            }
+        }
+        out
+    };
     let _reg_map = build_module_reg_map(&m);
     let mut errors: Vec<CompileError> = Vec::new();
 
@@ -2584,16 +2612,16 @@ fn lower_module_threads(
         all_read.extend(ar);
         // Also seed flat bus-signal read names (`b.r` → `b_r`) so the
         // sub-module declares them as inputs.
-        collect_thread_bus_reads(&t.body, &bus_port_map, &mut all_read);
+        collect_thread_bus_reads(&t.body, &bus_port_map, &vob_counts, &mut all_read);
         // Also collect signals referenced in the `default when` clause
         if let Some((dw_cond, dw_stmts)) = &t.default_when {
             let (dw_cd, dw_sd, dw_ar) = collect_thread_signals_with_buses(dw_stmts, &bus_port_map);
             all_comb_driven.extend(dw_cd);
             all_seq_driven.extend(dw_sd);
             all_read.extend(dw_ar);
-            collect_thread_bus_reads(dw_stmts, &bus_port_map, &mut all_read);
+            collect_thread_bus_reads(dw_stmts, &bus_port_map, &vob_counts, &mut all_read);
             collect_expr_reads(dw_cond, &mut all_read);
-            collect_expr_bus_reads(dw_cond, &bus_port_map, &mut all_read);
+            collect_expr_bus_reads(dw_cond, &bus_port_map, &vob_counts, &mut all_read);
         }
     }
     for (_, t) in &threads {
@@ -3910,7 +3938,7 @@ fn lower_module_threads(
     // doesn't carry the bus ports themselves (only the flattened signal
     // outputs `b_v`, ...), so the original thread-body references to
     // `b.v` need to land on the flat names.
-    rewrite_bus_targets_in_body(&mut merged_body, &bus_port_map);
+    rewrite_bus_targets_in_body(&mut merged_body, &bus_port_map, &vob_counts);
 
     let merged_module = ModuleDecl {
         name: Ident::new(merged_name.clone(), sp),
@@ -4486,44 +4514,76 @@ fn expr_target_flat_name(e: &Expr, bus_port_map: &HashMap<String, String>) -> Op
 fn rewrite_bus_targets_in_body(
     body: &mut Vec<ModuleBodyItem>,
     bus_port_map: &HashMap<String, String>,
+    vob_counts: &HashMap<String, u32>,
 ) {
-    fn rw_expr(e: &mut Expr, bus_port_map: &HashMap<String, String>) {
-        // Bottom-up: rewrite children first.
+    // Build a runtime mux `(idx==0 ? arr_0_field : … : arr_{n-1}_field)`
+    // selecting the right flattened lane for a *variable* index into a
+    // Vec<Bus> read. Mirrors the SV/sim packed-array form `arr_field[idx]`
+    // but over the sub-module's per-lane scalar input ports.
+    fn build_lane_mux(arr: &str, field: &str, idx: &Expr, n: u32) -> ExprKind {
+        let sp = idx.span;
+        let mut acc = ExprKind::Ident(format!("{arr}_{}_{field}", n - 1));
+        for i in (0..n - 1).rev() {
+            let cond = Expr::new(
+                ExprKind::Binary(
+                    BinOp::Eq,
+                    Box::new(idx.clone()),
+                    Box::new(Expr::new(ExprKind::Literal(LitKind::Dec(i as u64)), sp)),
+                ),
+                sp,
+            );
+            let then_e = Expr::new(ExprKind::Ident(format!("{arr}_{i}_{field}")), sp);
+            acc = ExprKind::Ternary(Box::new(cond), Box::new(then_e), Box::new(Expr::new(acc, sp)));
+        }
+        acc
+    }
+    // `is_lhs` gates the variable-index mux: a mux is not an lvalue, so it
+    // must only be substituted in read (RHS / condition) positions, never
+    // as an assignment target. (Variable-index bus *writes* in threads are
+    // a separate, currently-unsupported case — they are left unrewritten.)
+    fn rw_expr(
+        e: &mut Expr,
+        bus_port_map: &HashMap<String, String>,
+        vob_counts: &HashMap<String, u32>,
+        is_lhs: bool,
+    ) {
+        // Bottom-up: rewrite children first. Children are never themselves
+        // assignment targets, so they recurse with is_lhs = false.
         match &mut e.kind {
             ExprKind::Binary(_, l, r) => {
-                rw_expr(l, bus_port_map);
-                rw_expr(r, bus_port_map);
+                rw_expr(l, bus_port_map, vob_counts, false);
+                rw_expr(r, bus_port_map, vob_counts, false);
             }
             ExprKind::Unary(_, x)
             | ExprKind::Cast(x, _)
             | ExprKind::LatencyAt(x, _)
-            | ExprKind::SvaNext(_, x) => rw_expr(x, bus_port_map),
+            | ExprKind::SvaNext(_, x) => rw_expr(x, bus_port_map, vob_counts, false),
             ExprKind::Index(b, i) | ExprKind::BitSlice(b, i, _) => {
-                rw_expr(b, bus_port_map);
-                rw_expr(i, bus_port_map);
+                rw_expr(b, bus_port_map, vob_counts, false);
+                rw_expr(i, bus_port_map, vob_counts, false);
             }
             ExprKind::PartSelect(b, lo, hi, _) => {
-                rw_expr(b, bus_port_map);
-                rw_expr(lo, bus_port_map);
-                rw_expr(hi, bus_port_map);
+                rw_expr(b, bus_port_map, vob_counts, false);
+                rw_expr(lo, bus_port_map, vob_counts, false);
+                rw_expr(hi, bus_port_map, vob_counts, false);
             }
             ExprKind::Ternary(c, t, e2) => {
-                rw_expr(c, bus_port_map);
-                rw_expr(t, bus_port_map);
-                rw_expr(e2, bus_port_map);
+                rw_expr(c, bus_port_map, vob_counts, false);
+                rw_expr(t, bus_port_map, vob_counts, false);
+                rw_expr(e2, bus_port_map, vob_counts, false);
             }
             ExprKind::Concat(parts) | ExprKind::FunctionCall(_, parts) => {
                 for p in parts {
-                    rw_expr(p, bus_port_map);
+                    rw_expr(p, bus_port_map, vob_counts, false);
                 }
             }
             ExprKind::MethodCall(b, _, args) => {
-                rw_expr(b, bus_port_map);
+                rw_expr(b, bus_port_map, vob_counts, false);
                 for a in args {
-                    rw_expr(a, bus_port_map);
+                    rw_expr(a, bus_port_map, vob_counts, false);
                 }
             }
-            ExprKind::FieldAccess(b, _) => rw_expr(b, bus_port_map),
+            ExprKind::FieldAccess(b, _) => rw_expr(b, bus_port_map, vob_counts, false),
             _ => {}
         }
         // Now check if THIS node is a bus-port FieldAccess to rewrite.
@@ -4536,14 +4596,18 @@ fn rewrite_bus_targets_in_body(
                         None
                     }
                 } else if let ExprKind::Index(arr, idx) = &base.kind {
-                    if let (ExprKind::Ident(arr_name), ExprKind::Literal(LitKind::Dec(i))) =
-                        (&arr.kind, &idx.kind)
-                    {
-                        if bus_port_map.contains_key(arr_name) {
-                            Some(ExprKind::Ident(format!(
-                                "{}_{}_{}",
-                                arr_name, i, field.name
-                            )))
+                    if let ExprKind::Ident(arr_name) = &arr.kind {
+                        if let ExprKind::Literal(LitKind::Dec(i)) = &idx.kind {
+                            if bus_port_map.contains_key(arr_name) {
+                                Some(ExprKind::Ident(format!("{}_{}_{}", arr_name, i, field.name)))
+                            } else {
+                                None
+                            }
+                        } else if !is_lhs {
+                            // Variable index in a read position → lane mux.
+                            vob_counts
+                                .get(arr_name)
+                                .map(|&n| build_lane_mux(arr_name, &field.name, idx, n))
                         } else {
                             None
                         }
@@ -4560,49 +4624,53 @@ fn rewrite_bus_targets_in_body(
             e.kind = new_kind;
         }
     }
-    fn rw_stmt(s: &mut Stmt, bus_port_map: &HashMap<String, String>) {
+    fn rw_stmt(
+        s: &mut Stmt,
+        bus_port_map: &HashMap<String, String>,
+        vob_counts: &HashMap<String, u32>,
+    ) {
         match s {
             Stmt::Assign(a) => {
-                rw_expr(&mut a.target, bus_port_map);
-                rw_expr(&mut a.value, bus_port_map);
+                rw_expr(&mut a.target, bus_port_map, vob_counts, true);
+                rw_expr(&mut a.value, bus_port_map, vob_counts, false);
             }
             Stmt::IfElse(ie) => {
-                rw_expr(&mut ie.cond, bus_port_map);
+                rw_expr(&mut ie.cond, bus_port_map, vob_counts, false);
                 for s in &mut ie.then_stmts {
-                    rw_stmt(s, bus_port_map);
+                    rw_stmt(s, bus_port_map, vob_counts);
                 }
                 for s in &mut ie.else_stmts {
-                    rw_stmt(s, bus_port_map);
+                    rw_stmt(s, bus_port_map, vob_counts);
                 }
             }
             Stmt::Match(m) => {
-                rw_expr(&mut m.scrutinee, bus_port_map);
+                rw_expr(&mut m.scrutinee, bus_port_map, vob_counts, false);
                 for arm in &mut m.arms {
                     for s in &mut arm.body {
-                        rw_stmt(s, bus_port_map);
+                        rw_stmt(s, bus_port_map, vob_counts);
                     }
                 }
             }
             Stmt::For(f) => {
                 for s in &mut f.body {
-                    rw_stmt(s, bus_port_map);
+                    rw_stmt(s, bus_port_map, vob_counts);
                 }
             }
             Stmt::Init(ib) => {
                 for s in &mut ib.body {
-                    rw_stmt(s, bus_port_map);
+                    rw_stmt(s, bus_port_map, vob_counts);
                 }
             }
             Stmt::DoUntil { body, cond, .. } => {
-                rw_expr(cond, bus_port_map);
+                rw_expr(cond, bus_port_map, vob_counts, false);
                 for s in body {
-                    rw_stmt(s, bus_port_map);
+                    rw_stmt(s, bus_port_map, vob_counts);
                 }
             }
-            Stmt::WaitUntil(e, _) => rw_expr(e, bus_port_map),
+            Stmt::WaitUntil(e, _) => rw_expr(e, bus_port_map, vob_counts, false),
             Stmt::Log(l) => {
                 for a in &mut l.args {
-                    rw_expr(a, bus_port_map);
+                    rw_expr(a, bus_port_map, vob_counts, false);
                 }
             }
         }
@@ -4611,23 +4679,23 @@ fn rewrite_bus_targets_in_body(
         match item {
             ModuleBodyItem::CombBlock(cb) => {
                 for s in &mut cb.stmts {
-                    rw_stmt(s, bus_port_map);
+                    rw_stmt(s, bus_port_map, vob_counts);
                 }
             }
             ModuleBodyItem::RegBlock(rb) => {
                 for s in &mut rb.stmts {
-                    rw_stmt(s, bus_port_map);
+                    rw_stmt(s, bus_port_map, vob_counts);
                 }
             }
             ModuleBodyItem::LatchBlock(lb) => {
                 for s in &mut lb.stmts {
-                    rw_stmt(s, bus_port_map);
+                    rw_stmt(s, bus_port_map, vob_counts);
                 }
             }
-            ModuleBodyItem::LetBinding(lb) => rw_expr(&mut lb.value, bus_port_map),
+            ModuleBodyItem::LetBinding(lb) => rw_expr(&mut lb.value, bus_port_map, vob_counts, false),
             ModuleBodyItem::RegDecl(r) => {
                 if let Some(init) = r.init.as_mut() {
-                    rw_expr(init, bus_port_map);
+                    rw_expr(init, bus_port_map, vob_counts, false);
                 }
             }
             _ => {}
@@ -4962,6 +5030,7 @@ fn expr_root_name(e: &Expr) -> Option<String> {
 fn collect_expr_bus_reads(
     e: &Expr,
     bus_port_map: &HashMap<String, String>,
+    vob_counts: &HashMap<String, u32>,
     out: &mut HashSet<String>,
 ) {
     if let ExprKind::FieldAccess(base, field) = &e.kind {
@@ -4971,11 +5040,18 @@ fn collect_expr_bus_reads(
             }
         }
         if let ExprKind::Index(arr, idx) = &base.kind {
-            if let (ExprKind::Ident(arr_name), ExprKind::Literal(LitKind::Dec(i))) =
-                (&arr.kind, &idx.kind)
-            {
-                if bus_port_map.contains_key(arr_name) {
-                    out.insert(format!("{}_{}_{}", arr_name, i, field.name));
+            if let ExprKind::Ident(arr_name) = &arr.kind {
+                if let ExprKind::Literal(LitKind::Dec(i)) = &idx.kind {
+                    if bus_port_map.contains_key(arr_name) {
+                        out.insert(format!("{}_{}_{}", arr_name, i, field.name));
+                    }
+                } else if let Some(&n) = vob_counts.get(arr_name) {
+                    // Variable index into a Vec<Bus> port: the read is
+                    // lowered to a runtime mux over all N lanes, so every
+                    // per-lane signal becomes a sub-module input port.
+                    for i in 0..n {
+                        out.insert(format!("{}_{}_{}", arr_name, i, field.name));
+                    }
                 }
             }
         }
@@ -4983,39 +5059,39 @@ fn collect_expr_bus_reads(
     // Recurse into children.
     match &e.kind {
         ExprKind::Binary(_, l, r) => {
-            collect_expr_bus_reads(l, bus_port_map, out);
-            collect_expr_bus_reads(r, bus_port_map, out);
+            collect_expr_bus_reads(l, bus_port_map, vob_counts, out);
+            collect_expr_bus_reads(r, bus_port_map, vob_counts, out);
         }
         ExprKind::Unary(_, x)
         | ExprKind::Cast(x, _)
         | ExprKind::LatencyAt(x, _)
-        | ExprKind::SvaNext(_, x) => collect_expr_bus_reads(x, bus_port_map, out),
+        | ExprKind::SvaNext(_, x) => collect_expr_bus_reads(x, bus_port_map, vob_counts, out),
         ExprKind::Index(b, i) | ExprKind::BitSlice(b, i, _) => {
-            collect_expr_bus_reads(b, bus_port_map, out);
-            collect_expr_bus_reads(i, bus_port_map, out);
+            collect_expr_bus_reads(b, bus_port_map, vob_counts, out);
+            collect_expr_bus_reads(i, bus_port_map, vob_counts, out);
         }
         ExprKind::PartSelect(b, lo, hi, _) => {
-            collect_expr_bus_reads(b, bus_port_map, out);
-            collect_expr_bus_reads(lo, bus_port_map, out);
-            collect_expr_bus_reads(hi, bus_port_map, out);
+            collect_expr_bus_reads(b, bus_port_map, vob_counts, out);
+            collect_expr_bus_reads(lo, bus_port_map, vob_counts, out);
+            collect_expr_bus_reads(hi, bus_port_map, vob_counts, out);
         }
         ExprKind::Ternary(c, t, e2) => {
-            collect_expr_bus_reads(c, bus_port_map, out);
-            collect_expr_bus_reads(t, bus_port_map, out);
-            collect_expr_bus_reads(e2, bus_port_map, out);
+            collect_expr_bus_reads(c, bus_port_map, vob_counts, out);
+            collect_expr_bus_reads(t, bus_port_map, vob_counts, out);
+            collect_expr_bus_reads(e2, bus_port_map, vob_counts, out);
         }
         ExprKind::Concat(parts) | ExprKind::FunctionCall(_, parts) => {
             for p in parts {
-                collect_expr_bus_reads(p, bus_port_map, out);
+                collect_expr_bus_reads(p, bus_port_map, vob_counts, out);
             }
         }
         ExprKind::MethodCall(b, _, args) => {
-            collect_expr_bus_reads(b, bus_port_map, out);
+            collect_expr_bus_reads(b, bus_port_map, vob_counts, out);
             for a in args {
-                collect_expr_bus_reads(a, bus_port_map, out);
+                collect_expr_bus_reads(a, bus_port_map, vob_counts, out);
             }
         }
-        ExprKind::FieldAccess(b, _) => collect_expr_bus_reads(b, bus_port_map, out),
+        ExprKind::FieldAccess(b, _) => collect_expr_bus_reads(b, bus_port_map, vob_counts, out),
         _ => {}
     }
 }
@@ -5026,33 +5102,34 @@ fn collect_expr_bus_reads(
 fn collect_thread_bus_reads(
     body: &[ThreadStmt],
     bus_port_map: &HashMap<String, String>,
+    vob_counts: &HashMap<String, u32>,
     out: &mut HashSet<String>,
 ) {
     for s in body {
         match s {
             ThreadStmt::CombAssign(a) | ThreadStmt::SeqAssign(a) | ThreadStmt::ForkTlmAssign(a) => {
-                collect_expr_bus_reads(&a.value, bus_port_map, out);
-                collect_expr_bus_reads(&a.target, bus_port_map, out);
+                collect_expr_bus_reads(&a.value, bus_port_map, vob_counts, out);
+                collect_expr_bus_reads(&a.target, bus_port_map, vob_counts, out);
             }
-            ThreadStmt::WaitUntil(c, _) => collect_expr_bus_reads(c, bus_port_map, out),
+            ThreadStmt::WaitUntil(c, _) => collect_expr_bus_reads(c, bus_port_map, vob_counts, out),
             ThreadStmt::IfElse(ie) => {
-                collect_expr_bus_reads(&ie.cond, bus_port_map, out);
-                collect_thread_bus_reads(&ie.then_stmts, bus_port_map, out);
-                collect_thread_bus_reads(&ie.else_stmts, bus_port_map, out);
+                collect_expr_bus_reads(&ie.cond, bus_port_map, vob_counts, out);
+                collect_thread_bus_reads(&ie.then_stmts, bus_port_map, vob_counts, out);
+                collect_thread_bus_reads(&ie.else_stmts, bus_port_map, vob_counts, out);
             }
             ThreadStmt::For { body, .. } | ThreadStmt::Lock { body, .. } => {
-                collect_thread_bus_reads(body, bus_port_map, out)
+                collect_thread_bus_reads(body, bus_port_map, vob_counts, out)
             }
             ThreadStmt::DoUntil { body, cond, .. } => {
-                collect_expr_bus_reads(cond, bus_port_map, out);
-                collect_thread_bus_reads(body, bus_port_map, out);
+                collect_expr_bus_reads(cond, bus_port_map, vob_counts, out);
+                collect_thread_bus_reads(body, bus_port_map, vob_counts, out);
             }
             ThreadStmt::ForkJoin(branches, _) => {
                 for b in branches {
-                    collect_thread_bus_reads(b, bus_port_map, out);
+                    collect_thread_bus_reads(b, bus_port_map, vob_counts, out);
                 }
             }
-            ThreadStmt::Return(e, _) => collect_expr_bus_reads(e, bus_port_map, out),
+            ThreadStmt::Return(e, _) => collect_expr_bus_reads(e, bus_port_map, vob_counts, out),
             _ => {}
         }
     }

--- a/src/sim_codegen/mod.rs
+++ b/src/sim_codegen/mod.rs
@@ -2870,6 +2870,37 @@ fn cpp_expr_inner(expr: &Expr, ctx: &Ctx, is_lhs: bool) -> String {
                             return format!("{}_{}_{}", arr_name, i, field.name);
                         }
                     }
+                    // Variable (non-constant) index into a Vec<Bus>.
+                    //
+                    // The constant path above resolves to a per-element flat
+                    // field (`o_0_valid`). Those fields are reference aliases
+                    // into a real C array (`o_valid[N]` for ports,
+                    // `_let_o[N]` struct array for wires), so a runtime index
+                    // selects the right lane directly — the same packed-array
+                    // form the SV emitter uses (`o_valid[sel]`). Without this
+                    // the FieldAccess fell through to the scalar bit-select
+                    // path below, mis-lowering `o[sel].valid` to
+                    // `((o >> sel) & 1).valid` against an undefined `o`.
+                    // Bounds-checked like every other runtime index.
+                    if idx_val.is_none() {
+                        let fld = &field.name;
+                        if let Some(n) = ctx.vec_of_bus_port_count
+                            .and_then(|m| m.get(arr_name).copied())
+                        {
+                            let i = cpp_expr(idx, ctx);
+                            return format!(
+                                "(_ARCH_BCHK(({i}), {n}, \"{arr_name}[i].{fld}\"), {arr_name}_{fld}[{i}])"
+                            );
+                        }
+                        if let Some(n) = ctx.vec_of_bus_wire_count
+                            .and_then(|m| m.get(arr_name).copied())
+                        {
+                            let i = cpp_expr(idx, ctx);
+                            return format!(
+                                "(_ARCH_BCHK(({i}), {n}, \"{arr_name}[i].{fld}\"), _let_{arr_name}[{i}].{fld})"
+                            );
+                        }
+                    }
                 }
             }
             // Use is_lhs when evaluating base so struct reg fields get _n_ prefix on LHS

--- a/tests/backend_equiv/Fx3bVarIndexVecBusBug.arch
+++ b/tests/backend_equiv/Fx3bVarIndexVecBusBug.arch
@@ -1,0 +1,30 @@
+// Regression: variable-index access to a Vec<Bus> element.
+//
+// `arch build` lowers `o[sel].valid` to the packed-array form
+// `o_valid[sel]`; the C++ sim backend (`arch sim`) must do the same. Before
+// the fix the sim emitter mis-treated the Vec<Bus> element as a scalar
+// bit-select (`((o) >> sel) & 1`) against an undefined `o`, producing
+// uncompilable C++. Both backends must select lane `sel`.
+//
+// See also Fx3bVarIndexVecBusThread.arch for the `thread`-lowering mirror.
+bus BusVr
+  param DATA_W: const = 8;
+  valid: out Bool;
+  ready: in  Bool;
+  data:  out UInt<DATA_W>;
+end bus BusVr
+
+module Vsel
+  param LANES: const = 4;
+  port sel: in UInt<2>;
+  port dv: in UInt<8>;
+  port o: initiator Vec<BusVr<DATA_W=8>, LANES>;
+  comb
+    o[0].valid = false; o[0].data = 0;
+    o[1].valid = false; o[1].data = 0;
+    o[2].valid = false; o[2].data = 0;
+    o[3].valid = false; o[3].data = 0;
+    o[sel].valid = true;     // variable index
+    o[sel].data  = dv;
+  end comb
+end module Vsel

--- a/tests/backend_equiv/Fx3bVarIndexVecBusThread.arch
+++ b/tests/backend_equiv/Fx3bVarIndexVecBusThread.arch
@@ -1,0 +1,39 @@
+// Regression: variable-index Vec<Bus> read inside a `thread` `wait until`.
+//
+// `thread` lowering extracts the body into a `_<mod>_threads` sub-module.
+// A constant index (`o[2].ready`) lowers to a flattened scalar sub-port
+// `o_2_ready`. A *variable* index (`o[sel].ready`) cannot pick a static
+// lane, so it lowers to a runtime mux over all N flattened lane ports
+// (`o_0_ready` … `o_{N-1}_ready`). Before the fix the bus reference was
+// dropped, leaving an undefined `o` in both the emitted SV and the C++ sim.
+//
+// See also Fx3bVarIndexVecBusBug.arch for the comb-block mirror.
+bus BusVrT
+  param DATA_W: const = 8;
+  valid: out Bool;
+  ready: in  Bool;
+  data:  out UInt<DATA_W>;
+end bus BusVrT
+
+module VselThread
+  param LANES: const = 4;
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Async, Low>;
+  port sel: in UInt<2>;
+  port dv:  in UInt<8>;
+  port o: initiator Vec<BusVrT<DATA_W=8>, LANES>;
+  port done: out Bool;
+  comb
+    o[0].valid = false; o[0].data = 0;
+    o[1].valid = false; o[1].data = 0;
+    o[2].valid = false; o[2].data = 0;
+    o[3].valid = false; o[3].data = 0;
+    o[sel].valid = true;
+    o[sel].data  = dv;
+  end comb
+  thread on clk rising, rst low
+    wait until o[sel].ready;   // variable-index Vec<Bus> read
+    done = 1;
+    wait 1 cycle;
+  end thread
+end module VselThread

--- a/tests/backend_equiv/VselThread_arch_tb.cpp
+++ b/tests/backend_equiv/VselThread_arch_tb.cpp
@@ -1,0 +1,23 @@
+#include "VVselThread.h"
+#include <cstdio>
+// `wait until o[sel].ready` must observe ready on the selected lane only.
+// For each sel, drive ready on lane==sel starting cycle 2; `done` must
+// pulse exactly at cycle 2 regardless of sel.
+int main() {
+  bool ok = true;
+  for (int sel = 0; sel < 4; sel++) {
+    VVselThread d;
+    d.rst = 0; d.clk = 0; d.sel = sel; d.dv = 0x33; d.eval();
+    d.rst = 1;
+    int fired = -1;
+    for (int i = 0; i < 5; i++) {
+      for (int l = 0; l < 4; l++) d.o_ready[l] = 0;
+      if (i >= 2) d.o_ready[sel] = 1;
+      d.clk = 0; d.eval(); d.clk = 1; d.eval();
+      if (d.done && fired < 0) fired = i;
+    }
+    if (fired != 2) { printf("MISMATCH sel=%d done_fired_at=%d (exp 2)\n", sel, fired); ok = false; }
+  }
+  printf(ok ? "PASS vsel_thread_varidx\n" : "FAIL vsel_thread_varidx\n");
+  return ok ? 0 : 1;
+}

--- a/tests/backend_equiv/VselThread_vl_tb.cpp
+++ b/tests/backend_equiv/VselThread_vl_tb.cpp
@@ -1,0 +1,21 @@
+#include "VVselThread.h"
+#include <verilated.h>
+#include <cstdio>
+int main() {
+  bool ok = true;
+  for (int sel = 0; sel < 4; sel++) {
+    VVselThread* d = new VVselThread;
+    d->rst = 0; d->clk = 0; d->sel = sel; d->dv = 0x33; d->eval();
+    d->rst = 1;
+    int fired = -1;
+    for (int i = 0; i < 5; i++) {
+      d->o_ready = (i >= 2) ? (1u << sel) : 0;
+      d->clk = 0; d->eval(); d->clk = 1; d->eval();
+      if (d->done && fired < 0) fired = i;
+    }
+    if (fired != 2) { printf("MISMATCH sel=%d done_fired_at=%d (exp 2)\n", sel, fired); ok = false; }
+    delete d;
+  }
+  printf(ok ? "PASS vsel_thread_varidx\n" : "FAIL vsel_thread_varidx\n");
+  return ok ? 0 : 1;
+}

--- a/tests/backend_equiv/Vsel_arch_tb.cpp
+++ b/tests/backend_equiv/Vsel_arch_tb.cpp
@@ -1,0 +1,24 @@
+#include "VVsel.h"
+#include <cstdio>
+// Variable-index Vec<Bus> comb write: for each sel, lane[sel] must carry
+// (valid=1, data=dv) and every other lane must stay (0,0).
+int main() {
+  bool ok = true;
+  for (int sel = 0; sel < 4; sel++) {
+    VVsel d;
+    d.sel = sel;
+    d.dv = 0xAB;
+    d.eval();
+    for (int l = 0; l < 4; l++) {
+      int exp_v = (l == sel) ? 1 : 0;
+      int exp_d = (l == sel) ? 0xAB : 0;
+      if (d.o_valid[l] != exp_v || d.o_data[l] != exp_d) {
+        printf("MISMATCH sel=%d lane=%d valid=%d(exp %d) data=%x(exp %x)\n",
+               sel, l, d.o_valid[l], exp_v, d.o_data[l], exp_d);
+        ok = false;
+      }
+    }
+  }
+  printf(ok ? "PASS vsel_varidx\n" : "FAIL vsel_varidx\n");
+  return ok ? 0 : 1;
+}

--- a/tests/backend_equiv/Vsel_vl_tb.cpp
+++ b/tests/backend_equiv/Vsel_vl_tb.cpp
@@ -1,0 +1,26 @@
+#include "VVsel.h"
+#include <verilated.h>
+#include <cstdio>
+int main() {
+  bool ok = true;
+  for (int sel = 0; sel < 4; sel++) {
+    VVsel* d = new VVsel;
+    d->sel = sel;
+    d->dv = 0xAB;
+    d->eval();
+    for (int l = 0; l < 4; l++) {
+      int got_v = (d->o_valid >> l) & 1;
+      int got_d = (d->o_data >> (l * 8)) & 0xff;
+      int exp_v = (l == sel) ? 1 : 0;
+      int exp_d = (l == sel) ? 0xAB : 0;
+      if (got_v != exp_v || got_d != exp_d) {
+        printf("MISMATCH sel=%d lane=%d valid=%d(exp %d) data=%x(exp %x)\n",
+               sel, l, got_v, exp_v, got_d, exp_d);
+        ok = false;
+      }
+    }
+    delete d;
+  }
+  printf(ok ? "PASS vsel_varidx\n" : "FAIL vsel_varidx\n");
+  return ok ? 0 : 1;
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -890,6 +890,212 @@ fn test_arbiter_round_robin_arch_sim_nonpow2_behavior() {
     );
 }
 
+// ── Variable-index Vec<Bus> element access — backend equivalence ──────────────
+//
+// Regression for the silent backend-capability divergence where `arch build`
+// lowered `o[sel].valid` / `wait until o[sel].ready` correctly but `arch sim`
+// (and, for the thread case, both backends) mis-lowered the variable index.
+// See tests/backend_equiv/Fx3bVarIndexVecBusBug.arch (comb) and
+// Fx3bVarIndexVecBusThread.arch (thread `wait until`).
+
+/// Codegen-level guard (no Verilator needed): the comb-block variable index
+/// must flatten to the packed-array form in BOTH backends, never the scalar
+/// bit-select against an undefined bus name.
+#[test]
+fn test_var_index_vec_bus_comb_lowering_matches_backends() {
+    let source = include_str!("backend_equiv/Fx3bVarIndexVecBusBug.arch");
+    let sv = compile_to_sv(source);
+    assert!(sv.contains("o_valid[sel]"), "SV must select lane `sel`:\n{sv}");
+    assert!(sv.contains("o_data[sel]"), "SV must select lane `sel`:\n{sv}");
+    assert!(
+        !sv.contains("o[sel]"),
+        "SV must not leave the un-flattened Vec<Bus> index `o[sel]`:\n{sv}"
+    );
+
+    let sim = compile_to_sim_h(source, false);
+    assert!(
+        sim.contains("o_valid[sel]") && sim.contains("o_data[sel]"),
+        "sim C++ must select lane `sel` from the packed array, mirroring SV:\n{sim}"
+    );
+    assert!(
+        !sim.contains("(o) >> (sel)"),
+        "sim C++ must not mis-lower the Vec<Bus> element to a scalar bit-select \
+         against an undefined `o`:\n{sim}"
+    );
+}
+
+/// Codegen-level guard for the `thread` `wait until` mirror: the variable
+/// index lowers to a runtime mux over per-lane flattened sub-module ports in
+/// both backends.
+#[test]
+fn test_var_index_vec_bus_thread_lowering_matches_backends() {
+    let source = include_str!("backend_equiv/Fx3bVarIndexVecBusThread.arch");
+    let sv = compile_to_sv(source);
+    // Per-lane flattened sub-module input ports + the runtime lane mux.
+    for lane in ["o_0_ready", "o_1_ready", "o_2_ready", "o_3_ready"] {
+        assert!(sv.contains(lane), "SV thread sub-module needs port `{lane}`:\n{sv}");
+    }
+    assert!(
+        !sv.contains("o[sel]"),
+        "SV must not leave the un-flattened Vec<Bus> index `o[sel]` in the \
+         thread sub-module:\n{sv}"
+    );
+
+    let sim = compile_to_sim_h(source, false);
+    assert!(
+        sim.contains("o_0_ready") && sim.contains("o_3_ready"),
+        "sim C++ thread sub-module must read the flattened per-lane signals:\n{sim}"
+    );
+    assert!(
+        !sim.contains("(o) >> (sel)"),
+        "sim C++ must not mis-lower the thread-condition Vec<Bus> read:\n{sim}"
+    );
+}
+
+/// End-to-end value parity: run the comb and thread fixtures through `arch
+/// sim` (always) and `arch build` + Verilator (when available), asserting the
+/// same PASS markers from both backends. A regression makes the mis-lowered
+/// backend fail to compile, so the PASS assertion is the real guard.
+#[test]
+fn test_var_index_vec_bus_backend_equivalence_e2e() {
+    let arch_bin = env!("CARGO_BIN_EXE_arch");
+
+    // Helper: run `arch sim <arch> --tb <tb>` and assert a PASS marker.
+    let run_arch_sim = |arch: &str, tb: &str, marker: &str| {
+        let td = tempfile::tempdir().expect("tempdir");
+        let out = std::process::Command::new(arch_bin)
+            .arg("sim")
+            .arg(arch)
+            .arg("--tb")
+            .arg(tb)
+            .arg("--outdir")
+            .arg(td.path())
+            .output()
+            .expect("run arch sim");
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(
+            out.status.success() && stdout.contains(marker),
+            "arch sim should pass for {arch}\nwant marker: {marker}\nstdout:\n{stdout}\nstderr:\n{stderr}"
+        );
+    };
+
+    run_arch_sim(
+        "tests/backend_equiv/Fx3bVarIndexVecBusBug.arch",
+        "tests/backend_equiv/Vsel_arch_tb.cpp",
+        "PASS vsel_varidx",
+    );
+    run_arch_sim(
+        "tests/backend_equiv/Fx3bVarIndexVecBusThread.arch",
+        "tests/backend_equiv/VselThread_arch_tb.cpp",
+        "PASS vsel_thread_varidx",
+    );
+
+    if std::process::Command::new("verilator")
+        .arg("--version")
+        .output()
+        .is_err()
+    {
+        eprintln!("skipping Verilator parity leg: verilator not found");
+        return;
+    }
+
+    // Helper: build SV, verilate with the matching TB, run, assert PASS marker.
+    let run_verilator = |arch: &str, tb: &str, top: &str, marker: &str| {
+        let td = tempfile::tempdir().expect("tempdir");
+        let sv_out = td.path().join(format!("{top}.sv"));
+        let obj_dir = td.path().join("obj_dir");
+        let build = std::process::Command::new(arch_bin)
+            .arg("build")
+            .arg(arch)
+            .arg("-o")
+            .arg(&sv_out)
+            .output()
+            .expect("arch build");
+        assert!(
+            build.status.success(),
+            "arch build should pass for {arch}\nstderr:\n{}",
+            String::from_utf8_lossy(&build.stderr)
+        );
+        let tb_abs = std::fs::canonicalize(tb).expect("tb path");
+        let verilate = std::process::Command::new("verilator")
+            .args([
+                "--cc", "--exe", "--build", "-Wno-WIDTH", "-Wno-UNOPTFLAT",
+                "-Wno-DECLFILENAME", "--top-module", top, "-Mdir",
+            ])
+            .arg(&obj_dir)
+            .arg(&sv_out)
+            .arg(&tb_abs)
+            .output()
+            .expect("verilate");
+        assert!(
+            verilate.status.success(),
+            "Verilator build should pass for {arch}\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&verilate.stdout),
+            String::from_utf8_lossy(&verilate.stderr)
+        );
+        let run = std::process::Command::new(obj_dir.join(format!("V{top}")))
+            .output()
+            .expect("run verilator sim");
+        let stdout = String::from_utf8_lossy(&run.stdout);
+        assert!(
+            run.status.success() && stdout.contains(marker),
+            "Verilator sim should pass for {arch}\nwant marker: {marker}\nstdout:\n{stdout}"
+        );
+    };
+
+    run_verilator(
+        "tests/backend_equiv/Fx3bVarIndexVecBusBug.arch",
+        "tests/backend_equiv/Vsel_vl_tb.cpp",
+        "Vsel",
+        "PASS vsel_varidx",
+    );
+    run_verilator(
+        "tests/backend_equiv/Fx3bVarIndexVecBusThread.arch",
+        "tests/backend_equiv/VselThread_vl_tb.cpp",
+        "VselThread",
+        "PASS vsel_thread_varidx",
+    );
+}
+
+/// Vec<Bus> *wire* mirror: a variable index into a `wire w: Vec<B,N>;`
+/// must resolve to the per-element struct-array storage in the sim backend
+/// (`_let_w[sel].v`), matching the SV packed-slice form (`w_v[sel]`).
+#[test]
+fn test_var_index_vec_bus_wire_lowering_matches_backends() {
+    let source = "
+        bus B
+          v: out Bool;
+          d: out UInt<8>;
+        end bus B
+
+        module M
+          port sel: in UInt<1>;
+          port o_v: out Bool;
+          port o_d: out UInt<8>;
+          wire w: Vec<B, 2>;
+          comb
+            w[0].v = true;  w[0].d = 8'h11;
+            w[1].v = false; w[1].d = 8'h22;
+            o_v = w[sel].v;
+            o_d = w[sel].d;
+          end comb
+        end module M
+    ";
+    let sv = compile_to_sv(source);
+    assert!(sv.contains("w_v[sel]") && sv.contains("w_d[sel]"), "SV must slice the packed wire:\n{sv}");
+
+    let sim = compile_to_sim_h(source, false);
+    assert!(
+        sim.contains("_let_w[sel].v") && sim.contains("_let_w[sel].d"),
+        "sim C++ must index the struct-array wire storage:\n{sim}"
+    );
+    assert!(
+        !sim.contains("(w) >> (sel)"),
+        "sim C++ must not mis-lower the Vec<Bus> wire element to a scalar bit-select:\n{sim}"
+    );
+}
+
 #[test]
 fn test_arbiter_latency2() {
     let source = include_str!("../examples/arbiter_latency2.arch");


### PR DESCRIPTION
## Summary

The C++ sim backend (`arch sim`) miscompiled a **variable** index into a `Vec<Bus>` element, while the SystemVerilog backend (`arch build`) lowered the *same* source correctly — a silent backend-capability divergence.

Two symptoms:

1. **comb block** — `o[sel].valid = …` (variable `sel`) lowered in the sim emitter to a scalar bit-select against an undefined `o`:
   ```cpp
   (_ARCH_BCHK((sel), 32, "o[i]"), (((o) >> (sel)) & 1)).valid = 1;   // uncompilable C++
   ```
   `arch build` already produced correct SV (`assign o_valid[sel] = 1'b1;`).

2. **thread `wait until`** — a variable-index Vec<Bus> read in a thread condition (`wait until o[sel].ready;`) was dropped during thread lowering, leaving an undefined `o` in **both** the emitted SV (`if (o[sel].ready)`) and the sim. Constant indices (`o[2].ready`) lowered fine in both backends.

Internal codegen only — no language-surface syntax/semantics change — so fixed autonomously per `CLAUDE.md`.

## Fix

- **`src/sim_codegen/mod.rs`** — in the `FieldAccess(Index(..))` emitter, when the index is non-constant and the base is a `Vec<Bus>`, select the lane directly from the underlying packed storage instead of falling through to the scalar bit-select path:
  - **ports**: `o_valid[sel]` — the `o_<i>_<sig>` flat fields are reference aliases into a real `o_<sig>[N]` array, so a runtime subscript works (mirrors the SV `o_valid[sel]` form).
  - **wires**: `_let_o[sel].<sig>` — Vec<Bus> wires are stored as a `B _let_o[N]` struct array.
  - Both bounds-checked via `_ARCH_BCHK`.

- **`src/elaborate.rs`** — thread lowering now handles a variable index into a `Vec<Bus>` read. The signal collector expands it to all N flattened per-lane signals (so they become sub-module input ports), and the rewrite replaces the read with a runtime mux over those lanes (`sel==0 ? o_0_ready : … : o_3_ready`). Constant indices keep the existing single-lane path. The mux is gated to read positions only (it is not an lvalue).

## Tests

New `tests/backend_equiv/` fixtures + `tests/integration_test.rs`:

- **End-to-end value parity**: `Fx3bVarIndexVecBusBug.arch` (comb) and `Fx3bVarIndexVecBusThread.arch` (thread `wait until`), each run through `arch sim` **and** `arch build` + Verilator with matching testbenches asserting identical `PASS` markers across all `sel` lanes.
- **Codegen-level guards** for the comb, thread, and Vec<Bus> *wire* mirror: assert the packed/mux lowering in both backends and reject the old scalar-bit-select form. These run without Verilator.

Full suite green (590 integration tests, no regressions).

## Known limitation (pre-existing, out of scope)

A *variable*-index Vec<Bus> *write* inside a thread is still unsupported (it was silently dropped before this change too).

🤖 Generated with [Claude Code](https://claude.com/claude-code)