### PR TITLE
fix(threads): lower variable-index Vec<Bus> writes via a per-lane demux

### DIFF
--- a/src/elaborate.rs
+++ b/src/elaborate.rs
@@ -2606,7 +2606,7 @@ fn lower_module_threads(
     let mut all_seq_driven: HashSet<String> = HashSet::new();
     let mut all_read: HashSet<String> = HashSet::new();
     for (_, t) in &threads {
-        let (cd, sd, ar) = collect_thread_signals_with_buses(&t.body, &bus_port_map);
+        let (cd, sd, ar) = collect_thread_signals_with_buses(&t.body, &bus_port_map, &vob_counts);
         all_comb_driven.extend(cd);
         all_seq_driven.extend(sd);
         all_read.extend(ar);
@@ -2615,7 +2615,8 @@ fn lower_module_threads(
         collect_thread_bus_reads(&t.body, &bus_port_map, &vob_counts, &mut all_read);
         // Also collect signals referenced in the `default when` clause
         if let Some((dw_cond, dw_stmts)) = &t.default_when {
-            let (dw_cd, dw_sd, dw_ar) = collect_thread_signals_with_buses(dw_stmts, &bus_port_map);
+            let (dw_cd, dw_sd, dw_ar) =
+                collect_thread_signals_with_buses(dw_stmts, &bus_port_map, &vob_counts);
             all_comb_driven.extend(dw_cd);
             all_seq_driven.extend(dw_sd);
             all_read.extend(dw_ar);
@@ -4506,6 +4507,37 @@ fn expr_target_flat_name(e: &Expr, bus_port_map: &HashMap<String, String>) -> Op
     }
 }
 
+/// For a *variable*-index Vec<Bus> write target (`arr[idx].field` with a
+/// non-literal `idx`), return every flattened per-lane signal name
+/// (`arr_0_field` … `arr_{N-1}_field`). These all become driven outputs of
+/// the synthesized thread sub-module because the write is lowered to a
+/// per-lane demux (see `rewrite_bus_targets_in_body`). Returns `None` for
+/// constant indices and non-bus / non-Vec<Bus> targets.
+fn vob_write_lane_names(
+    e: &Expr,
+    bus_port_map: &HashMap<String, String>,
+    vob_counts: &HashMap<String, u32>,
+) -> Option<Vec<String>> {
+    let ExprKind::FieldAccess(base, field) = &e.kind else {
+        return None;
+    };
+    let ExprKind::Index(arr, idx) = &base.kind else {
+        return None;
+    };
+    let ExprKind::Ident(arr_name) = &arr.kind else {
+        return None;
+    };
+    if matches!(idx.kind, ExprKind::Literal(LitKind::Dec(_))) {
+        return None;
+    }
+    if !bus_port_map.contains_key(arr_name) {
+        return None;
+    }
+    vob_counts
+        .get(arr_name)
+        .map(|&n| (0..n).map(|i| format!("{}_{}_{}", arr_name, i, field.name)).collect())
+}
+
 /// Walk every `Stmt` in the synthesized thread sub-module body and
 /// replace bus-port FieldAccess expressions (`b.v`) with the flat ident
 /// (`b_v`) on both LHS and RHS. The sub-module exposes the flat signals
@@ -4624,6 +4656,107 @@ fn rewrite_bus_targets_in_body(
             e.kind = new_kind;
         }
     }
+    // Detect an assignment target of the form `arr[idx].field` where `arr`
+    // is a Vec<Bus> port and `idx` is *not* a compile-time literal. Returns
+    // `(arr, field, idx, N)`. Such a write can't pick a static lane, so it
+    // is expanded into a per-lane demux (see `rw_stmts`). Constant indices
+    // are handled by the in-place `rw_expr` rewrite (single lane).
+    fn var_index_bus_write_target<'a>(
+        e: &'a Expr,
+        bus_port_map: &HashMap<String, String>,
+        vob_counts: &'a HashMap<String, u32>,
+    ) -> Option<(&'a str, &'a str, &'a Expr, u32)> {
+        let ExprKind::FieldAccess(base, field) = &e.kind else {
+            return None;
+        };
+        let ExprKind::Index(arr, idx) = &base.kind else {
+            return None;
+        };
+        let ExprKind::Ident(arr_name) = &arr.kind else {
+            return None;
+        };
+        if matches!(idx.kind, ExprKind::Literal(LitKind::Dec(_))) {
+            return None;
+        }
+        if !bus_port_map.contains_key(arr_name) {
+            return None;
+        }
+        vob_counts
+            .get(arr_name)
+            .map(|&n| (arr_name.as_str(), field.name.as_str(), idx.as_ref(), n))
+    }
+    // Rewrite a statement *list*, allowing one statement to expand into many.
+    // A variable-index Vec<Bus> write `arr[idx].field <op> v` is expanded to
+    // a per-lane demux — one guarded assign per lane:
+    //   if (idx == 0) arr_0_field <op> v;
+    //   …
+    //   if (idx == N-1) arr_{N-1}_field <op> v;
+    // For seq (`<=`) targets the unselected lanes simply hold; for comb the
+    // surrounding default assignment covers them. This is the write-side
+    // mirror of the read-side lane mux in `rw_expr`.
+    fn rw_stmts(
+        stmts: &mut Vec<Stmt>,
+        bus_port_map: &HashMap<String, String>,
+        vob_counts: &HashMap<String, u32>,
+    ) {
+        let mut i = 0;
+        while i < stmts.len() {
+            let expansion: Option<Vec<Stmt>> = if let Stmt::Assign(a) = &stmts[i] {
+                var_index_bus_write_target(&a.target, bus_port_map, vob_counts).map(
+                    |(arr, field, idx, n)| {
+                        let span = a.span;
+                        // The RHS (and the index) are read positions — apply
+                        // the normal rewrite (incl. read-side lane mux) once,
+                        // then reuse for every lane.
+                        let mut value = a.value.clone();
+                        rw_expr(&mut value, bus_port_map, vob_counts, false);
+                        let mut idx_e = idx.clone();
+                        rw_expr(&mut idx_e, bus_port_map, vob_counts, false);
+                        (0..n)
+                            .map(|lane| {
+                                let cond = Expr::new(
+                                    ExprKind::Binary(
+                                        BinOp::Eq,
+                                        Box::new(idx_e.clone()),
+                                        Box::new(Expr::new(
+                                            ExprKind::Literal(LitKind::Dec(lane as u64)),
+                                            span,
+                                        )),
+                                    ),
+                                    span,
+                                );
+                                let assign = Stmt::Assign(Assign {
+                                    target: Expr::new(
+                                        ExprKind::Ident(format!("{arr}_{lane}_{field}")),
+                                        span,
+                                    ),
+                                    value: value.clone(),
+                                    span,
+                                });
+                                Stmt::IfElse(IfElseOf {
+                                    cond,
+                                    then_stmts: vec![assign],
+                                    else_stmts: vec![],
+                                    unique: false,
+                                    span,
+                                })
+                            })
+                            .collect()
+                    },
+                )
+            } else {
+                None
+            };
+            if let Some(expanded) = expansion {
+                let cnt = expanded.len();
+                stmts.splice(i..=i, expanded);
+                i += cnt;
+                continue;
+            }
+            rw_stmt(&mut stmts[i], bus_port_map, vob_counts);
+            i += 1;
+        }
+    }
     fn rw_stmt(
         s: &mut Stmt,
         bus_port_map: &HashMap<String, String>,
@@ -4636,36 +4769,24 @@ fn rewrite_bus_targets_in_body(
             }
             Stmt::IfElse(ie) => {
                 rw_expr(&mut ie.cond, bus_port_map, vob_counts, false);
-                for s in &mut ie.then_stmts {
-                    rw_stmt(s, bus_port_map, vob_counts);
-                }
-                for s in &mut ie.else_stmts {
-                    rw_stmt(s, bus_port_map, vob_counts);
-                }
+                rw_stmts(&mut ie.then_stmts, bus_port_map, vob_counts);
+                rw_stmts(&mut ie.else_stmts, bus_port_map, vob_counts);
             }
             Stmt::Match(m) => {
                 rw_expr(&mut m.scrutinee, bus_port_map, vob_counts, false);
                 for arm in &mut m.arms {
-                    for s in &mut arm.body {
-                        rw_stmt(s, bus_port_map, vob_counts);
-                    }
+                    rw_stmts(&mut arm.body, bus_port_map, vob_counts);
                 }
             }
             Stmt::For(f) => {
-                for s in &mut f.body {
-                    rw_stmt(s, bus_port_map, vob_counts);
-                }
+                rw_stmts(&mut f.body, bus_port_map, vob_counts);
             }
             Stmt::Init(ib) => {
-                for s in &mut ib.body {
-                    rw_stmt(s, bus_port_map, vob_counts);
-                }
+                rw_stmts(&mut ib.body, bus_port_map, vob_counts);
             }
             Stmt::DoUntil { body, cond, .. } => {
                 rw_expr(cond, bus_port_map, vob_counts, false);
-                for s in body {
-                    rw_stmt(s, bus_port_map, vob_counts);
-                }
+                rw_stmts(body, bus_port_map, vob_counts);
             }
             Stmt::WaitUntil(e, _) => rw_expr(e, bus_port_map, vob_counts, false),
             Stmt::Log(l) => {
@@ -4678,19 +4799,13 @@ fn rewrite_bus_targets_in_body(
     for item in body.iter_mut() {
         match item {
             ModuleBodyItem::CombBlock(cb) => {
-                for s in &mut cb.stmts {
-                    rw_stmt(s, bus_port_map, vob_counts);
-                }
+                rw_stmts(&mut cb.stmts, bus_port_map, vob_counts);
             }
             ModuleBodyItem::RegBlock(rb) => {
-                for s in &mut rb.stmts {
-                    rw_stmt(s, bus_port_map, vob_counts);
-                }
+                rw_stmts(&mut rb.stmts, bus_port_map, vob_counts);
             }
             ModuleBodyItem::LatchBlock(lb) => {
-                for s in &mut lb.stmts {
-                    rw_stmt(s, bus_port_map, vob_counts);
-                }
+                rw_stmts(&mut lb.stmts, bus_port_map, vob_counts);
             }
             ModuleBodyItem::LetBinding(lb) => rw_expr(&mut lb.value, bus_port_map, vob_counts, false),
             ModuleBodyItem::RegDecl(r) => {
@@ -4829,51 +4944,62 @@ fn collect_comb_stmt_signals_with_buses(
 fn collect_thread_signals_with_buses(
     body: &[ThreadStmt],
     bus_port_map: &HashMap<String, String>,
+    vob_counts: &HashMap<String, u32>,
 ) -> (HashSet<String>, HashSet<String>, HashSet<String>) {
     let (mut comb_driven, mut seq_driven, all_read) = collect_thread_signals(body);
     comb_driven.retain(|n| !bus_port_map.contains_key(n));
     seq_driven.retain(|n| !bus_port_map.contains_key(n));
+    fn record(
+        target: &Expr,
+        driven: &mut HashSet<String>,
+        bus_port_map: &HashMap<String, String>,
+        vob_counts: &HashMap<String, u32>,
+    ) {
+        // A variable-index Vec<Bus> write lowers to a per-lane demux, so
+        // every lane becomes a driven output. Constant / scalar targets keep
+        // the single-name path.
+        if let Some(lanes) = vob_write_lane_names(target, bus_port_map, vob_counts) {
+            driven.extend(lanes);
+        } else if let Some(name) = expr_target_flat_name(target, bus_port_map) {
+            if !bus_port_map.contains_key(&name) {
+                driven.insert(name);
+            }
+        }
+    }
     fn walk(
         stmts: &[ThreadStmt],
         comb_driven: &mut HashSet<String>,
         seq_driven: &mut HashSet<String>,
         bus_port_map: &HashMap<String, String>,
+        vob_counts: &HashMap<String, u32>,
     ) {
         for s in stmts {
             match s {
                 ThreadStmt::CombAssign(a) => {
-                    if let Some(name) = expr_target_flat_name(&a.target, bus_port_map) {
-                        if !bus_port_map.contains_key(&name) {
-                            comb_driven.insert(name);
-                        }
-                    }
+                    record(&a.target, comb_driven, bus_port_map, vob_counts);
                 }
                 ThreadStmt::SeqAssign(a) | ThreadStmt::ForkTlmAssign(a) => {
-                    if let Some(name) = expr_target_flat_name(&a.target, bus_port_map) {
-                        if !bus_port_map.contains_key(&name) {
-                            seq_driven.insert(name);
-                        }
-                    }
+                    record(&a.target, seq_driven, bus_port_map, vob_counts);
                 }
                 ThreadStmt::IfElse(ie) => {
-                    walk(&ie.then_stmts, comb_driven, seq_driven, bus_port_map);
-                    walk(&ie.else_stmts, comb_driven, seq_driven, bus_port_map);
+                    walk(&ie.then_stmts, comb_driven, seq_driven, bus_port_map, vob_counts);
+                    walk(&ie.else_stmts, comb_driven, seq_driven, bus_port_map, vob_counts);
                 }
                 ThreadStmt::For { body, .. }
                 | ThreadStmt::Lock { body, .. }
                 | ThreadStmt::DoUntil { body, .. } => {
-                    walk(body, comb_driven, seq_driven, bus_port_map)
+                    walk(body, comb_driven, seq_driven, bus_port_map, vob_counts)
                 }
                 ThreadStmt::ForkJoin(branches, _) => {
                     for b in branches {
-                        walk(b, comb_driven, seq_driven, bus_port_map);
+                        walk(b, comb_driven, seq_driven, bus_port_map, vob_counts);
                     }
                 }
                 _ => {}
             }
         }
     }
-    walk(body, &mut comb_driven, &mut seq_driven, bus_port_map);
+    walk(body, &mut comb_driven, &mut seq_driven, bus_port_map, vob_counts);
     (comb_driven, seq_driven, all_read)
 }
 
@@ -5224,11 +5350,21 @@ fn collect_expr_reads(e: &Expr, out: &mut HashSet<String>) {
 /// Collect reads from index expressions in a target (e.g. `buf[i]` — `i` is a read).
 fn collect_expr_index_reads(e: &Expr, out: &mut HashSet<String>) {
     match &e.kind {
-        ExprKind::Index(_, idx) => collect_expr_reads(idx, out),
-        ExprKind::BitSlice(_, hi, lo) => {
+        // Recurse into the base too: a 2D target `mem[i][j]` reads both `i`
+        // and `j`, and a bus-element target `o[sel].field` carries the index
+        // `sel` *under* the FieldAccess — without descending we'd miss it and
+        // the synthesized thread sub-module would reference an undeclared
+        // index signal.
+        ExprKind::Index(base, idx) => {
+            collect_expr_reads(idx, out);
+            collect_expr_index_reads(base, out);
+        }
+        ExprKind::BitSlice(base, hi, lo) => {
             collect_expr_reads(hi, out);
             collect_expr_reads(lo, out);
+            collect_expr_index_reads(base, out);
         }
+        ExprKind::FieldAccess(base, _) => collect_expr_index_reads(base, out),
         _ => {}
     }
 }

--- a/tests/backend_equiv/Fx3bVarIndexVecBusThreadWrite.arch
+++ b/tests/backend_equiv/Fx3bVarIndexVecBusThreadWrite.arch
@@ -1,0 +1,36 @@
+// Regression: variable-index Vec<Bus> *write* inside a `thread`.
+//
+// `o[sel].valid <= true;` (variable `sel`) can't pick a static lane, so
+// thread lowering expands it into a per-lane demux — one guarded assign per
+// lane (`if (sel==i) o_i_valid <= true;`). All lanes become driven
+// sub-module outputs. Before this fix the write was dropped, leaving an
+// undefined `o` in BOTH the emitted SV and the C++ sim. This is the
+// write-side mirror of Fx3bVarIndexVecBusThread.arch (read in `wait until`).
+//
+// The thread drives constant per-lane defaults first, then overrides the
+// selected lane — the demux assigns land after the defaults so last-write-
+// wins yields a clean one-hot on `sel`.
+bus BusVrW
+  param DATA_W: const = 8;
+  valid: out Bool;
+  ready: in  Bool;
+  data:  out UInt<DATA_W>;
+end bus BusVrW
+
+module VselWr
+  param LANES: const = 4;
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Async, Low>;
+  port sel: in UInt<2>;
+  port dv:  in UInt<8>;
+  port o: initiator Vec<BusVrW<DATA_W=8>, LANES>;
+  thread on clk rising, rst low
+    o[0].valid <= false; o[0].data <= 0;
+    o[1].valid <= false; o[1].data <= 0;
+    o[2].valid <= false; o[2].data <= 0;
+    o[3].valid <= false; o[3].data <= 0;
+    o[sel].valid <= true;     // variable-index write (demux)
+    o[sel].data  <= dv;
+    wait 1 cycle;
+  end thread
+end module VselWr

--- a/tests/backend_equiv/VselWr_arch_tb.cpp
+++ b/tests/backend_equiv/VselWr_arch_tb.cpp
@@ -1,0 +1,20 @@
+#include "VVselWr.h"
+#include <cstdio>
+// Registered one-hot drive: after a few cycles, lane `sel` carries
+// (valid=1, data=dv), every other lane stays (0,0).
+int main() {
+  bool ok = true;
+  for (int sel = 0; sel < 4; sel++) {
+    VVselWr d; d.rst = 0; d.clk = 0; d.sel = sel; d.dv = 0x5A; d.eval(); d.rst = 1;
+    for (int i = 0; i < 3; i++) { d.clk = 0; d.eval(); d.clk = 1; d.eval(); }
+    for (int l = 0; l < 4; l++) {
+      int ev = (l == sel) ? 1 : 0, ed = (l == sel) ? 0x5A : 0;
+      if (d.o_valid[l] != ev || d.o_data[l] != ed) {
+        printf("MISMATCH sel=%d l=%d v=%d(exp %d) d=%x(exp %x)\n", sel, l, d.o_valid[l], ev, d.o_data[l], ed);
+        ok = false;
+      }
+    }
+  }
+  printf(ok ? "PASS vselwr_varidx\n" : "FAIL vselwr_varidx\n");
+  return ok ? 0 : 1;
+}

--- a/tests/backend_equiv/VselWr_vl_tb.cpp
+++ b/tests/backend_equiv/VselWr_vl_tb.cpp
@@ -1,0 +1,21 @@
+#include "VVselWr.h"
+#include <verilated.h>
+#include <cstdio>
+int main() {
+  bool ok = true;
+  for (int sel = 0; sel < 4; sel++) {
+    VVselWr* d = new VVselWr; d->rst = 0; d->clk = 0; d->sel = sel; d->dv = 0x5A; d->eval(); d->rst = 1;
+    for (int i = 0; i < 3; i++) { d->clk = 0; d->eval(); d->clk = 1; d->eval(); }
+    for (int l = 0; l < 4; l++) {
+      int gv = (d->o_valid >> l) & 1, gd = (d->o_data >> (l * 8)) & 0xff;
+      int ev = (l == sel) ? 1 : 0, ed = (l == sel) ? 0x5A : 0;
+      if (gv != ev || gd != ed) {
+        printf("MISMATCH sel=%d l=%d v=%d(exp %d) d=%x(exp %x)\n", sel, l, gv, ev, gd, ed);
+        ok = false;
+      }
+    }
+    delete d;
+  }
+  printf(ok ? "PASS vselwr_varidx\n" : "FAIL vselwr_varidx\n");
+  return ok ? 0 : 1;
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1096,6 +1096,109 @@ fn test_var_index_vec_bus_wire_lowering_matches_backends() {
     );
 }
 
+/// Variable-index Vec<Bus> *write* inside a thread: codegen-level guard.
+/// The write must expand to a per-lane demux (`if (sel == i) o_i_field …`)
+/// driving all flattened lanes in BOTH backends — never a dangling `o[sel]`.
+#[test]
+fn test_var_index_vec_bus_thread_write_lowering_matches_backends() {
+    let source = include_str!("backend_equiv/Fx3bVarIndexVecBusThreadWrite.arch");
+    let sv = compile_to_sv(source);
+    for lane in ["o_0_valid", "o_1_valid", "o_2_valid", "o_3_valid"] {
+        assert!(sv.contains(lane), "SV thread sub-module must drive lane `{lane}`:\n{sv}");
+    }
+    assert!(
+        sv.contains("if (sel == 0)") && sv.contains("o_0_valid <= 1'b1"),
+        "SV must expand the variable-index write to a per-lane demux:\n{sv}"
+    );
+    assert!(
+        !sv.contains("o[sel]"),
+        "SV must not leave the un-flattened Vec<Bus> write `o[sel]`:\n{sv}"
+    );
+
+    let sim = compile_to_sim_h(source, false);
+    assert!(
+        sim.contains("if (sel == 0)") && sim.contains("o_0_valid"),
+        "sim C++ must expand the variable-index write to a per-lane demux:\n{sim}"
+    );
+}
+
+/// Variable-index Vec<Bus> *write* end-to-end value parity: `arch sim` and
+/// (when available) `arch build` + Verilator must agree that lane `sel`
+/// carries the written (valid, data) and all other lanes stay cleared.
+#[test]
+fn test_var_index_vec_bus_thread_write_backend_equivalence_e2e() {
+    let arch_bin = env!("CARGO_BIN_EXE_arch");
+    let arch = "tests/backend_equiv/Fx3bVarIndexVecBusThreadWrite.arch";
+
+    // arch sim leg (always).
+    let td = tempfile::tempdir().expect("tempdir");
+    let out = std::process::Command::new(arch_bin)
+        .arg("sim")
+        .arg(arch)
+        .arg("--tb")
+        .arg("tests/backend_equiv/VselWr_arch_tb.cpp")
+        .arg("--outdir")
+        .arg(td.path())
+        .output()
+        .expect("run arch sim");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        out.status.success() && stdout.contains("PASS vselwr_varidx"),
+        "arch sim should pass for the variable-index write\nstdout:\n{stdout}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    // Verilator leg (when available).
+    if std::process::Command::new("verilator")
+        .arg("--version")
+        .output()
+        .is_err()
+    {
+        eprintln!("skipping Verilator parity leg: verilator not found");
+        return;
+    }
+    let td2 = tempfile::tempdir().expect("tempdir");
+    let sv_out = td2.path().join("VselWr.sv");
+    let obj_dir = td2.path().join("obj_dir");
+    let build = std::process::Command::new(arch_bin)
+        .arg("build")
+        .arg(arch)
+        .arg("-o")
+        .arg(&sv_out)
+        .output()
+        .expect("arch build");
+    assert!(
+        build.status.success(),
+        "arch build should pass\nstderr:\n{}",
+        String::from_utf8_lossy(&build.stderr)
+    );
+    let tb_abs = std::fs::canonicalize("tests/backend_equiv/VselWr_vl_tb.cpp").expect("tb path");
+    let verilate = std::process::Command::new("verilator")
+        .args([
+            "--cc", "--exe", "--build", "-Wno-WIDTH", "-Wno-UNOPTFLAT",
+            "-Wno-DECLFILENAME", "--top-module", "VselWr", "-Mdir",
+        ])
+        .arg(&obj_dir)
+        .arg(&sv_out)
+        .arg(&tb_abs)
+        .output()
+        .expect("verilate");
+    assert!(
+        verilate.status.success(),
+        "Verilator build should pass\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&verilate.stdout),
+        String::from_utf8_lossy(&verilate.stderr)
+    );
+    let run = std::process::Command::new(obj_dir.join("VVselWr"))
+        .output()
+        .expect("run verilator sim");
+    let vl_stdout = String::from_utf8_lossy(&run.stdout);
+    assert!(
+        run.status.success() && vl_stdout.contains("PASS vselwr_varidx"),
+        "Verilator sim should pass for the variable-index write\nstdout:\n{vl_stdout}"
+    );
+}
+
 #[test]
 fn test_arbiter_latency2() {
     let source = include_str!("../examples/arbiter_latency2.arch");


### PR DESCRIPTION
## Summary

Follow-up to #530 (now merged). A **variable**-index `Vec<Bus>` *write* inside a `thread` — `o[sel].valid <= true;` — was silently dropped during thread lowering, leaving an undefined `o` in **both** the emitted SV and the C++ sim. Constant indices already lowered to a single flattened lane. This was the "known limitation" called out in #530.

## Fix

A variable index can't pick a static lane, so the write is expanded into a **per-lane demux** — one guarded assign per lane (the write-side mirror of #530's read-side lane mux):

```sv
if (sel == 0) o_0_valid <= 1'b1;
…
if (sel == 3) o_3_valid <= 1'b1;
```

For seq (`<=`) targets the unselected lanes hold; in the defaults-then-override idiom the demux assigns land after the per-lane defaults, so last-write-wins yields a clean one-hot on `sel`.

All in `src/elaborate.rs` thread lowering (internal codegen — no language-surface change):

- **`rewrite_bus_targets_in_body`** now rewrites statement *lists* (`rw_stmts`) so one variable-index bus-write `Assign` can expand into N guarded assigns. The RHS and index are rewritten once (incl. the read-side lane mux) and reused per lane.
- **`collect_thread_signals_with_buses`** registers all N flattened lanes as driven outputs for a variable-index bus write, so a thread that drives the bus *only* via a variable index still declares every lane output.
- **`collect_expr_index_reads`** descends through `FieldAccess` and nested `Index` so the index signal (`sel` in `o[sel].field`) is collected as a read and becomes a sub-module input port. Also fixes a latent gap for 2D indexed targets (`mem[i][j]` previously missed `i`).

## Tests

`tests/backend_equiv/Fx3bVarIndexVecBusThreadWrite.arch` + `tests/integration_test.rs`:

- **End-to-end value parity**: the write fixture run through `arch sim` **and** `arch build` + Verilator with matching testbenches asserting identical `PASS` markers — one-hot `(valid, data)` on lane `sel`, all others cleared, for every `sel`.
- **Codegen-level guard** for the demux shape that rejects the old dangling-`o[sel]` form (runs without Verilator).

Verified end-to-end across three idioms: defaults+override, variable-only (no explicit defaults — unselected lanes hold), and a combined variable-read-in-variable-write statement (`o[sel].valid <= o[sel].ready;`). Full suite green (592 integration tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)