### PR TITLE
fix(signal-flow): retain all leading const indices in inst-conn driver key (nested Vec<Vec<Bus>>)

### DIFF
--- a/src/signal_flow.rs
+++ b/src/signal_flow.rs
@@ -70,8 +70,9 @@ fn lhs_base_name(expr: &Expr) -> Option<String> {
     }
 }
 
-/// Like [`lhs_base_name`], but preserves a trailing **constant-literal**
-/// index as part of the key (`out[0]` → `"out[0]"`, `out[i]` → `"out"`).
+/// Like [`lhs_base_name`], but preserves every **leading constant-literal**
+/// index as part of the key (`out[0]` → `"out[0]"`, `out[i]` → `"out"`,
+/// `edges[1][0]` → `"edges[1][0]"`).
 ///
 /// Used ONLY for `inst` output connections.  An inst output wired to a
 /// vector element (`last -> out[0]`) lowers to a continuous driver of that
@@ -82,10 +83,18 @@ fn lhs_base_name(expr: &Expr) -> Option<String> {
 /// `out[<const i>]`.  Collapsing them to a bare `out` reported a phantom
 /// multi-driver.
 ///
-/// A *variable* index (`out[i]`) is still stripped to the bare name — it
-/// conservatively aliases the whole vector — so two inst items driving the
-/// same constant element (`out[0]` twice) still collide, preserving
-/// genuine multi-driver detection.
+/// Nested vectors (`Vec<Vec<Bus>>`) unroll to multi-level constant indices
+/// (`edges[1][0]`, `edges[1][1]`).  ALL consecutive leading constant indices
+/// are retained so distinct nested elements stay distinct keys — retaining
+/// only one level would collapse `edges[1][0]` and `edges[1][1]` onto the
+/// same `edges[1]` key and report a phantom multi-driver (the bug this
+/// generalizes #528 to fix).
+///
+/// A *variable* index at any level (`out[i]`, `edges[r][c]`) terminates the
+/// retention: it conservatively aliases the whole (sub)vector, so the access
+/// from that level inward is dropped and the name keys at the bare base.  Two
+/// inst items driving the same constant element (`edges[1][0]` twice) still
+/// collide, preserving genuine multi-driver detection.
 ///
 /// This granularity is deliberately NOT applied to `comb`/`seq` blocks:
 /// each such block is one `always_comb`/`always_ff` over the whole array,
@@ -93,12 +102,29 @@ fn lhs_base_name(expr: &Expr) -> Option<String> {
 /// SV conflict and must keep erroring (see
 /// `test_multi_driver_vec_index_from_two_blocks_errors`).
 fn inst_conn_driver_name(expr: &Expr) -> Option<String> {
-    if let ExprKind::Index(base, idx) = &expr.kind {
-        if let Some(v) = const_index_value(idx) {
-            return lhs_base_name(base).map(|b| format!("{}[{}]", b, v));
+    // Walk down the chain of `Index` accesses (outermost first), collecting
+    // leading constant indices until a non-index base or a non-constant index
+    // stops us.  A non-constant index (or any other access kind) terminates
+    // retention: from there inward the access aliases the whole (sub)vector.
+    let mut indices: Vec<u64> = Vec::new();
+    let mut cur = expr;
+    while let ExprKind::Index(base, idx) = &cur.kind {
+        match const_index_value(idx) {
+            Some(v) => {
+                indices.push(v);
+                cur = base;
+            }
+            None => return lhs_base_name(expr),
         }
     }
-    lhs_base_name(expr)
+    lhs_base_name(cur).map(|b| {
+        let mut key = b;
+        // `indices` was collected inner-most-last; render outermost-first.
+        for v in indices.iter().rev() {
+            key.push_str(&format!("[{}]", v));
+        }
+        key
+    })
 }
 
 /// Collect every distinct signal name driven by `stmts`, storing the

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -23681,6 +23681,168 @@ end module ParentDistinctElem
     );
 }
 
+/// POSITIVE regression (extends #528 to nested vectors): a `generate_for`
+/// over a 2-D `Vec<Vec<Bus>>` wire whose body forwards inst outputs to
+/// `edges[r][c]` (two const indices) must type-check.  The producer
+/// generate_for unrolls into separate inst blocks each driving a DISTINCT
+/// nested element (`edges[0][0]`, `edges[0][1]`, `edges[1][0]`,
+/// `edges[1][1]`).  #528 retained only ONE trailing constant index, so
+/// `edges[r][c]` collapsed to the key `edges[<c>]` and every row aliased
+/// onto the same key — `edges[1][0]` and `edges[1][1]` both became
+/// `edges[1]` and looked double-driven.  Retaining ALL leading constant
+/// indices keeps the four elements distinct.
+#[test]
+fn test_multi_driver_genfor_nested2d_vecbus_distinct_elements_no_error() {
+    let source = r#"
+bus BusVr
+  param DATA_W: const = 8;
+  valid: out Bool;
+  ready: in  Bool;
+  data:  out UInt<DATA_W>;
+end bus BusVr
+
+module Fx6Prod
+  param COLS:   const = 2;
+  param DATA_W: const = 8;
+  port v: in Bool;
+  port d: in UInt<DATA_W>;
+  port o: initiator Vec<BusVr<DATA_W=DATA_W>, COLS>;
+  comb
+    o[0].valid = v; o[0].data = d;
+    o[1].valid = v; o[1].data = d;
+  end comb
+end module Fx6Prod
+
+module Fx6Cons
+  param ROWS:   const = 2;
+  param DATA_W: const = 8;
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Async, Low>;
+  port ins: target    Vec<BusVr<DATA_W=DATA_W>, ROWS>;
+  port acc: initiator BusVr<DATA_W=DATA_W>;
+  reg acc_r: UInt<DATA_W> reset rst => 0;
+  comb
+    ins[0].ready = true;
+    ins[1].ready = true;
+    acc.valid = true;
+    acc.data  = acc_r;
+  end comb
+  seq on clk rising
+    if ins[0].valid and ins[1].valid
+      acc_r <= acc_r +% (ins[0].data +% ins[1].data);
+    elsif ins[0].valid
+      acc_r <= acc_r +% ins[0].data;
+    elsif ins[1].valid
+      acc_r <= acc_r +% ins[1].data;
+    end if
+  end seq
+end module Fx6Cons
+
+module Fx6Nested2D
+  param ROWS:   const = 2;
+  param COLS:   const = 2;
+  param DATA_W: const = 8;
+  type EdgeBus = BusVr<DATA_W=DATA_W>;
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Async, Low>;
+  port v:   in unpacked Vec<Bool, ROWS>;
+  port d:   in unpacked Vec<UInt<DATA_W>, ROWS>;
+  port acc: initiator Vec<EdgeBus, COLS>;
+  wire edges: Vec<Vec<EdgeBus, COLS>, ROWS>;
+  generate_for r in 0..ROWS-1
+    inst prod_r: Fx6Prod
+      param COLS = COLS;
+      param DATA_W = DATA_W;
+      v <- v[r];
+      d <- d[r];
+      for c in 0..COLS-1
+        o[c] -> edges[r][c];
+      end for
+    end inst prod_r
+  end generate_for
+  generate_for c in 0..COLS-1
+    inst cons_c: Fx6Cons
+      param ROWS = ROWS;
+      param DATA_W = DATA_W;
+      clk <- clk;
+      rst <- rst;
+      for k in 0..ROWS-1
+        ins[k] <- edges[k][c];
+      end for
+      acc -> acc[c];
+    end inst cons_c
+  end generate_for
+end module Fx6Nested2D
+"#;
+    assert!(
+        typecheck_source(source).is_ok(),
+        "generate_for over a 2-D Vec<Vec<Bus>> forwarding distinct nested \
+         elements (edges[r][c] per iteration) must NOT be a multi-driver — \
+         each (r,c) is a separate element"
+    );
+}
+
+/// NEGATIVE regression (nested-vector sibling of
+/// `test_multi_driver_two_inst_same_vec_element_errors`): two `inst` items
+/// both forwarding to the SAME nested constant element `edges[0][0]` IS a
+/// genuine multiple-driver and must still error.  This pins that retaining
+/// all leading constant indices keeps "distinct nested element" legal while
+/// "same nested element twice" stays illegal — the fix must not weaken
+/// multi-driver detection for nested vectors.
+#[test]
+fn test_multi_driver_two_inst_same_nested2d_element_errors() {
+    let source = r#"
+bus BusVr
+  param DATA_W: const = 8;
+  valid: out Bool;
+  ready: in  Bool;
+  data:  out UInt<DATA_W>;
+end bus BusVr
+
+module Fx6Prod
+  param COLS:   const = 2;
+  param DATA_W: const = 8;
+  port v: in Bool;
+  port d: in UInt<DATA_W>;
+  port o: initiator Vec<BusVr<DATA_W=DATA_W>, COLS>;
+  comb
+    o[0].valid = v; o[0].data = d;
+    o[1].valid = v; o[1].data = d;
+  end comb
+end module Fx6Prod
+
+module Fx6Bad2D
+  param COLS:   const = 2;
+  param DATA_W: const = 8;
+  type EdgeBus = BusVr<DATA_W=DATA_W>;
+  port v:   in Bool;
+  port d:   in UInt<DATA_W>;
+  wire edges: Vec<Vec<EdgeBus, COLS>, 2>;
+  inst prod_a: Fx6Prod
+    param COLS = COLS;
+    param DATA_W = DATA_W;
+    v <- v;
+    d <- d;
+    o[0] -> edges[0][0];
+    o[1] -> edges[0][1];
+  end inst prod_a
+  inst prod_b: Fx6Prod
+    param COLS = COLS;
+    param DATA_W = DATA_W;
+    v <- v;
+    d <- d;
+    o[0] -> edges[0][0];
+    o[1] -> edges[1][1];
+  end inst prod_b
+end module Fx6Bad2D
+"#;
+    assert!(
+        has_multi_driver_error(source, "edges[0][0]"),
+        "two inst outputs driving the same nested Vec element edges[0][0] \
+         must still trigger MultipleDrivers"
+    );
+}
+
 /// Bus-typed wires connected from both initiator and target insts must NOT
 /// trigger multi-driver.  This is the canonical TLM bus wire pattern.
 #[test]


### PR DESCRIPTION
## Root cause

Follow-up to merged #528. The ARCH single-driver checker emitted a FALSE `signal edges[1] has multiple drivers` for nested (2-D) `Vec<Vec<Bus>>` per-element forwards, rejecting valid code.

#528 fixed the 1-D case: the `Inst` branch of `collect_module_drivers` in `src/signal_flow.rs` keyed driven signals via `lhs_base_name`, which strips ALL index access, so `out[0]/out[1]/out[2]` collapsed onto a bare `out` and looked multi-driven. #528 introduced `inst_conn_driver_name` to retain a **single trailing constant index**:

```rust
if let ExprKind::Index(base, idx) = &expr.kind {
    if let Some(v) = const_index_value(idx) {
        return lhs_base_name(base).map(|b| format!("{}[{}]", b, v));
    }
}
```

`lhs_base_name(base)` strips the inner index, so for a 2-D forward `o[c] -> edges[r][c]` (unrolled to `edges[1][0]`, `edges[1][1]`), both retain only the **outer** const index and collapse onto the key `edges[1]` — making row 1 look driven twice.

## Fix

`inst_conn_driver_name` now walks the **full chain** of `Index` accesses and retains **every leading constant index**, so `edges[1][0]` and `edges[1][1]` become distinct keys. A non-constant index at any level (`edges[r][c]`, `out[i]`) terminates retention — the access conservatively aliases the whole sub-vector — so genuine multi-driver detection is preserved (two inst items forwarding to the same nested element `edges[0][0]` still error). The loop generalizes to arbitrary nesting depth, not a depth-2 special-case.

Internal correctness fix only; no user-facing syntax/semantics change. Minimal, targeted diff in `src/signal_flow.rs`.

## Tests (`tests/integration_test.rs`, matching #528's 1-D style)

- **positive** `test_multi_driver_genfor_nested2d_vecbus_distinct_elements_no_error`: 2-D `Vec<Vec<Bus>>` generate_for forwarding distinct `edges[r][c]` elements type-checks.
- **negative** `test_multi_driver_two_inst_same_nested2d_element_errors`: two inst items both forwarding to `edges[0][0]` still raises MultipleDrivers.

## Verification

- Reproducer (`BusVr/Fx6Prod/Fx6Cons/Fx6Nested2D`): `arch check` → OK, `arch build` emits SV cleanly.
- Negative 2-D double-drive errors with the precise key `edges[0][0]`.
- NIC-400 fabric (real-world 2-D `edges[i][j]` wire) checks clean.
- `cargo test --release`: 601 integration tests pass, 0 regressions. (2 pre-existing `formal_test` Lean-toolchain failures are environmental — they require a built Lean proof project and fail identically on the #528 baseline.)

Extends #528 to nested indices.