### PR TITLE
test(backend_equiv): permanent feature-interaction torture-fixture corpus

### DIFF
--- a/tests/backend_equiv/BusVr.arch
+++ b/tests/backend_equiv/BusVr.arch
@@ -1,0 +1,10 @@
+// Tiny valid/ready/data bus for backend-equivalence torture fixtures.
+// Parameterized payload width so fixtures can stress param-driven widths.
+// initiator drives valid+data, receives ready (target flips).
+bus BusVr
+  param DATA_W: const = 8;
+
+  valid: out Bool;
+  ready: in  Bool;
+  data:  out UInt<DATA_W>;
+end bus BusVr

--- a/tests/backend_equiv/CrashSink.arch
+++ b/tests/backend_equiv/CrashSink.arch
@@ -1,0 +1,13 @@
+// Companion child for Fx5bWholeVecForwardCrash (A+D+E). Receives a whole
+// Vec<Bus> via a single `mm <- m` forward across the inst boundary.
+module CrashSink
+  param NUM: const = 2;
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Async, Low>;
+  port mm: target Vec<BusVr<DATA_W=8>, NUM>;
+  comb
+    for i in 0..NUM-1
+      mm[i].ready = true;
+    end for
+  end comb
+end module CrashSink

--- a/tests/backend_equiv/Fx10MutexContendPrio.arch
+++ b/tests/backend_equiv/Fx10MutexContendPrio.arch
@@ -1,0 +1,39 @@
+// Fixture 10 — axes B+C+D + mutex-policy PARITY (priority twin of Fx4).
+// B: N threads contending on ONE shared mutex.  C: generate_for over N.
+// D: param-driven thread count NUM and width DATA_W.
+//
+// Each lane thread, while its req[i] holds, repeatedly acquires the shared
+// `bus_ch` mutex and drives the single shared output bus `o` with its own tag
+// (i) for one accepted beat, then releases. The TB holds all reqs high and
+// pulls o.ready every cycle; under round_robin the granted tag should rotate
+// fairly across lanes (no starvation).
+module Fx10MutexContendPrio
+  param NUM:    const = 3;
+  param DATA_W: const = 8;
+
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Async, Low>;
+
+  port req: in unpacked Vec<Bool, NUM>;
+  port o:   initiator BusVr<DATA_W=DATA_W>;   // single shared sink
+
+  resource bus_ch: mutex<priority>;
+
+  generate_for i in 0..NUM-1
+    thread Lane_i on clk rising, rst low
+      default comb
+        o.valid = false;
+        o.data  = 0;
+      end default
+      if not req[i]
+        wait until req[i];
+      end if
+      lock bus_ch
+        do
+          o.valid = true;
+          o.data  = i;          // tag = lane index
+        until o.ready;
+      end lock bus_ch
+    end thread Lane_i
+  end generate_for
+end module Fx10MutexContendPrio

--- a/tests/backend_equiv/Fx10MutexContendPrio_test.harc
+++ b/tests/backend_equiv/Fx10MutexContendPrio_test.harc
@@ -1,0 +1,58 @@
+// Backend-equivalence test for Fixture 10 (B+C+D, mutex<priority>).
+// Mirror of Fx4 but asserting PRIORITY semantics: with all lanes contending
+// continuously and lane 0 highest priority, lane 0 must win the lion's share
+// of grants and lanes 1/2 must be largely starved. This is the divergence
+// trap: if priority silently behaves like round_robin, g0≈g1≈g2 and the
+// assertion below (g0 strictly dominates) fails.
+testbench Fx10Tb
+    dut : Fx10MutexContendPrio
+end testbench Fx10Tb
+
+impl Fx10Test for Fx10Tb
+    run
+        log(info, "Fx10 B+C+D mutex priority parity")
+
+        dut.rst = 0
+        dut.req[0] = 0
+        dut.req[1] = 0
+        dut.req[2] = 0
+        dut.o_ready = 0
+        wait 4 cycles
+        dut.rst = 1
+        wait 2 cycles
+
+        dut.req[0] = 1
+        dut.req[1] = 1
+        dut.req[2] = 1
+        dut.o_ready = 1
+
+        let g0 : uint<32> = 0
+        let g1 : uint<32> = 0
+        let g2 : uint<32> = 0
+        let total : uint<32> = 0
+        for _ in 0 .. 60
+            wait 1 cycle
+            if dut.o_valid == 1 && dut.o_ready == 1 && total < 30
+                let tag = dut.o_data
+                if tag == 0
+                    g0 = g0 + 1
+                elsif tag == 1
+                    g1 = g1 + 1
+                elsif tag == 2
+                    g2 = g2 + 1
+                end if
+                total = total + 1
+            end if
+        end for
+
+        assert total == 30
+            else fail("total grants=${total} expected 30")
+        // Priority: lane 0 dominates. Strictly: g0 > g1 and g0 > g2.
+        // (Round-robin would give g0==g1==g2; this catches a silent RR fallback.)
+        assert g0 > g1
+            else fail("priority violated: g0=${g0} !> g1=${g1} (RR fallback?)")
+        assert g0 > g2
+            else fail("priority violated: g0=${g0} !> g2=${g2} (RR fallback?)")
+        log(info, "PASS Fx10 PRIO: total=${total} g0=${g0} g1=${g1} g2=${g2}")
+    end run
+end impl Fx10Test

--- a/tests/backend_equiv/Fx1VecTapFabric.arch
+++ b/tests/backend_equiv/Fx1VecTapFabric.arch
@@ -1,0 +1,28 @@
+// Fixture 1 — axes A+C+E.
+// A: Vec<Bus,LANES> ports (m, o).  C: generate_for replication.  E: inst
+// hierarchy + per-element cross-boundary forwarding (m[i] -> taps[i].b,
+// taps[i].o -> o[i]). Pure structural wiring, no threads. Each external
+// master bus element is forwarded into one VrTap child; each tap re-exports
+// its latched word on the outbound Vec<Bus> port o.
+module Fx1VecTapFabric
+  param LANES:  const = 3;
+  param DATA_W: const = 8;
+
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Async, Low>;
+
+  port m:  target      Vec<BusVr<DATA_W=DATA_W>, LANES>;
+  port en: in unpacked Vec<Bool, LANES>;
+  port o:  initiator   Vec<BusVr<DATA_W=DATA_W>, LANES>;
+
+  generate_for i in 0..LANES-1
+    inst tap_i: VrTap
+      param DATA_W = DATA_W;
+      clk <- clk;
+      rst <- rst;
+      b   <- m[i];
+      en  <- en[i];
+      o   -> o[i];
+    end inst tap_i
+  end generate_for
+end module Fx1VecTapFabric

--- a/tests/backend_equiv/Fx1VecTapFabric_test.harc
+++ b/tests/backend_equiv/Fx1VecTapFabric_test.harc
@@ -1,0 +1,66 @@
+// Backend-equivalence test for Fixture 1 (A+C+E).
+// Drives each Vec<Bus> input element with a distinct data word, accepts it on
+// a different cycle per lane, and checks each VrTap re-exported its own word on
+// the outbound Vec<Bus> port (o_data[i]).
+testbench Fx1Tb
+    dut : Fx1VecTapFabric
+end testbench Fx1Tb
+
+impl Fx1Test for Fx1Tb
+    run
+        log(info, "Fx1 A+C+E vec-tap fabric")
+
+        dut.rst = 0
+        dut.m_valid[0] = 0
+        dut.m_valid[1] = 0
+        dut.m_valid[2] = 0
+        dut.m_data[0]  = 0
+        dut.m_data[1]  = 0
+        dut.m_data[2]  = 0
+        dut.en[0] = 0
+        dut.en[1] = 0
+        dut.en[2] = 0
+        dut.o_ready[0] = 0
+        dut.o_ready[1] = 0
+        dut.o_ready[2] = 0
+        wait 4 cycles
+        dut.rst = 1
+        wait 2 cycles
+
+        // Lane 0 accepts a word.
+        dut.m_valid[0] = 1
+        dut.m_data[0]  = 0xA1
+        dut.en[0] = 1
+        wait 2 cycles
+        dut.en[0] = 0
+        dut.m_valid[0] = 0
+
+        // Lane 1 accepts a different word.
+        dut.m_valid[1] = 1
+        dut.m_data[1]  = 0xB2
+        dut.en[1] = 1
+        wait 2 cycles
+        dut.en[1] = 0
+        dut.m_valid[1] = 0
+
+        // Lane 2 accepts a third word.
+        dut.m_valid[2] = 1
+        dut.m_data[2]  = 0xC3
+        dut.en[2] = 1
+        wait 2 cycles
+        dut.en[2] = 0
+        dut.m_valid[2] = 0
+        wait 2 cycles
+
+        assert dut.o_data[0] == 0xA1
+            else fail("lane0 latched ${dut.o_data[0]} expected 0xA1")
+        assert dut.o_data[1] == 0xB2
+            else fail("lane1 latched ${dut.o_data[1]} expected 0xB2")
+        assert dut.o_data[2] == 0xC3
+            else fail("lane2 latched ${dut.o_data[2]} expected 0xC3")
+        // valid is always asserted on every lane
+        assert dut.o_valid[0] == 1
+            else fail("lane0 o_valid not high")
+        log(info, "PASS Fx1: per-lane Vec<Bus> forwarding to inst children")
+    end run
+end impl Fx1Test

--- a/tests/backend_equiv/Fx1bMultiDriverBug.arch
+++ b/tests/backend_equiv/Fx1bMultiDriverBug.arch
@@ -1,0 +1,36 @@
+// Fixture 1b — BUG REPRO (axes A+C+E). Does NOT type-check; kept as a
+// standing regression marker for a false-positive multi-driver diagnostic.
+//
+// Symptom: `arch check` reports
+//     × signal `out` has multiple drivers   (at `last -> out[i]`)
+// even though each generate_for iteration drives a DISTINCT element out[i].
+//
+// Trigger (3-way interaction, minimized):
+//   - a `target Vec<Bus>` port forwarded per-element in a generate_for body
+//     (`b <- m[i]`), AND
+//   - a sibling non-bus per-element forward target in the SAME loop body
+//     (an `unpacked Vec` output element `out[i]`, or even a plain `wire`
+//     element).
+// Remove EITHER the Vec<Bus> port OR replace the unpacked-Vec output with a
+// Vec<Bus> output (see Fx1VecTapFabric.arch) and the error disappears.
+//
+// Root-cause hypothesis: the single-driver checker, when it sees the per-bus
+// signals fanned out from a forwarded `Vec<Bus>` element, over-attributes
+// those driver counts onto the sibling unpacked-Vec/wire element indexed by
+// the same loop var, so out[i] looks driven more than once.
+//
+// Companion leaf is intentionally inline-described; this file is a marker,
+// not a buildable design.
+module Fx1bMultiDriverBug
+  param LANES: const = 3;
+  port m:   target      Vec<BusVr<DATA_W=8>, LANES>;
+  port en:  in unpacked Vec<Bool, LANES>;
+  port out: out unpacked Vec<UInt<8>, LANES>;
+  generate_for i in 0..LANES-1
+    inst tap_i: VrTapScalar         // a leaf with `b: target BusVr`, `last: out UInt<8>`
+      b    <- m[i];
+      en   <- en[i];
+      last -> out[i];               // <-- FALSE "multiple drivers" here
+    end inst tap_i
+  end generate_for
+end module Fx1bMultiDriverBug

--- a/tests/backend_equiv/Fx2GenThreadLock.arch
+++ b/tests/backend_equiv/Fx2GenThreadLock.arch
@@ -1,0 +1,52 @@
+// Fixture 2 — axes A+B+C.
+// A: Vec<Bus,LANES> initiator port (o).  B: thread + lock (shared mutex).
+// C: generate_for spawning LANES threads.
+// Each lane i has a thread that, when its request input req[i] is high, takes
+// a shared lock and pushes the word d[i] onto o[i] until accepted (ready).
+// The shared lock serializes the side-effect of bumping a shared "tickets"
+// counter so only one lane completes per grant window — exercising B's mutex
+// over A's per-element Vec<Bus> drive, replicated by C.
+module Fx2GenThreadLock
+  param LANES:  const = 3;
+  param DATA_W: const = 8;
+
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Async, Low>;
+
+  port req: in unpacked Vec<Bool, LANES>;
+  port d:   in unpacked Vec<UInt<DATA_W>, LANES>;
+  port o:   initiator   Vec<BusVr<DATA_W=DATA_W>, LANES>;
+  port grants: out UInt<DATA_W>;          // total accepted beats, shared
+
+  reg grants_r: UInt<DATA_W> reset rst => 0;
+  resource push_ch: mutex<round_robin>;
+
+  comb
+    grants = grants_r;
+  end comb
+
+  generate_for i in 0..LANES-1
+    thread Push_i on clk rising, rst low
+      default comb
+        o[i].valid = false;
+        o[i].data  = 0;
+      end default
+      if not req[i]
+        wait until req[i];
+      end if
+      lock push_ch
+        do
+          o[i].valid = true;
+          o[i].data  = d[i];
+        until o[i].ready;
+      end lock push_ch
+    end thread Push_i
+  end generate_for
+
+  // Shared accounting: one increment per any-lane accepted beat.
+  seq on clk rising
+    if (o[0].valid and o[0].ready) or (o[1].valid and o[1].ready) or (o[2].valid and o[2].ready)
+      grants_r <= grants_r +% 1;
+    end if
+  end seq
+end module Fx2GenThreadLock

--- a/tests/backend_equiv/Fx2GenThreadLock_test.harc
+++ b/tests/backend_equiv/Fx2GenThreadLock_test.harc
@@ -1,0 +1,64 @@
+// Backend-equivalence test for Fixture 2 (A+B+C).
+// All LANES request simultaneously; accept all three with ready high. The
+// round-robin lock should let each lane push its word; the shared grants
+// counter must reach 3 (one per accepted beat).
+testbench Fx2Tb
+    dut : Fx2GenThreadLock
+end testbench Fx2Tb
+
+impl Fx2Test for Fx2Tb
+    run
+        log(info, "Fx2 A+B+C gen-thread-lock")
+
+        dut.rst = 0
+        dut.req[0] = 0
+        dut.req[1] = 0
+        dut.req[2] = 0
+        dut.d[0] = 0
+        dut.d[1] = 0
+        dut.d[2] = 0
+        dut.o_ready[0] = 0
+        dut.o_ready[1] = 0
+        dut.o_ready[2] = 0
+        wait 4 cycles
+        dut.rst = 1
+        wait 2 cycles
+
+        // All lanes request, all ready. Distinct payloads.
+        dut.d[0] = 0x11
+        dut.d[1] = 0x22
+        dut.d[2] = 0x33
+        dut.req[0] = 1
+        dut.req[1] = 1
+        dut.req[2] = 1
+        dut.o_ready[0] = 1
+        dut.o_ready[1] = 1
+        dut.o_ready[2] = 1
+
+        let seen0 : uint<32> = 0
+        let seen1 : uint<32> = 0
+        let seen2 : uint<32> = 0
+        for _ in 0 .. 30
+            if dut.o_valid[0] == 1 && dut.o_ready[0] == 1 && dut.o_data[0] == 0x11
+                seen0 = 1
+            end if
+            if dut.o_valid[1] == 1 && dut.o_ready[1] == 1 && dut.o_data[1] == 0x22
+                seen1 = 1
+            end if
+            if dut.o_valid[2] == 1 && dut.o_ready[2] == 1 && dut.o_data[2] == 0x33
+                seen2 = 1
+            end if
+            wait 1 cycle
+        end for
+
+        assert seen0 == 1
+            else fail("lane0 never pushed 0x11")
+        assert seen1 == 1
+            else fail("lane1 never pushed 0x22")
+        assert seen2 == 1
+            else fail("lane2 never pushed 0x33")
+        assert dut.grants >= 3
+            else fail("grants=${dut.grants} expected >=3")
+        log(info, "PASS Fx2: all lanes pushed under round_robin lock, grants=${dut.grants}")
+    end run
+end impl Fx2Test

--- a/tests/backend_equiv/Fx3ThreadVecParamW.arch
+++ b/tests/backend_equiv/Fx3ThreadVecParamW.arch
@@ -1,0 +1,98 @@
+// Fixture 3 — axes A+B+D.
+// A: Vec<Bus,LANES> initiator port.  B: a thread + lock.  D: payload width is
+// a param DATA_W (default 12 — deliberately non-power-of-8 to stress odd-width
+// handling through the bus + thread lowering).
+//
+// NOTE: a variable-index write to a Vec<Bus> element directly inside the
+// thread lock body (`o[sel].valid = ...`) trips a FALSE latch-inference error
+// in thread lowering (see Fx3bVarIndexVecBusBug.arch). Workaround used
+// here: the thread drives a scalar (drive_valid/drive_sel/drive_data) and a
+// plain comb block demuxes that onto the Vec<Bus> by the runtime sel — the
+// variable index in comb is accepted. The interaction (thread+lock producing a
+// runtime-selected Vec<Bus> drive at param width) is still exercised end-to-end.
+module Fx3ThreadVecParamW
+  param LANES:  const = 4;
+  param DATA_W: const = 12;
+  param SEL_W:  const = 2;            // ceil(log2(LANES))
+
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Async, Low>;
+
+  port start: in Bool;
+  port sel:   in UInt<SEL_W>;
+  port d:     in UInt<DATA_W>;
+  port o:     initiator Vec<BusVr<DATA_W=DATA_W>, LANES>;
+  port busy:  out Bool;
+
+  // The thread's `until o[sel].ready` is a genuine handshake read-back of the
+  // bus ready (an external input), so the conservative dead-skid feedback
+  // warning is expected and acknowledged.
+  pragma allow_dead_skid_feedback;
+
+  resource drv_ch: mutex<priority>;
+  reg busy_r: Bool reset rst => false;
+
+  wire drive_valid: Bool;
+  wire drive_sel:   UInt<SEL_W>;
+  wire drive_data:  UInt<DATA_W>;
+  wire sel_ready:   Bool;
+
+  comb
+    busy = busy_r;
+  end comb
+
+  // Surface the selected lane's ready as a scalar the thread can read.
+  // Constant-index reads only, to stay clear of the variable-index Vec<Bus>
+  // arch-sim codegen bug.
+  comb
+    if sel == 0
+      sel_ready = o[0].ready;
+    elsif sel == 1
+      sel_ready = o[1].ready;
+    elsif sel == 2
+      sel_ready = o[2].ready;
+    else
+      sel_ready = o[3].ready;
+    end if
+  end comb
+
+  thread Drive on clk rising, rst low
+    default comb
+      drive_valid = false;
+      drive_sel   = 0;
+      drive_data  = 0;
+    end default
+    if not start
+      wait until start;
+    end if
+    lock drv_ch
+      do
+        drive_valid = true;
+        drive_sel   = sel;
+        drive_data  = d;
+      until sel_ready;
+    end lock drv_ch
+  end thread Drive
+
+  // Demux the thread's scalar drive onto the Vec<Bus> by runtime sel.
+  // NOTE: written as explicit per-lane comparisons rather than the natural
+  // `o[drive_sel].valid = drive_valid;` because a variable-index WRITE to a
+  // Vec<Bus> element miscompiles in the arch C++ sim backend (it emits a
+  // scalar bit-select `((o) >> sel) & 1` against an undefined `o`) even though
+  // it lowers correctly in the SV backend — a backend capability divergence.
+  // See Fx3bVarIndexVecBusBug.arch.
+  comb
+    o[0].valid = drive_valid and (drive_sel == 0);
+    o[0].data  = drive_data;
+    o[1].valid = drive_valid and (drive_sel == 1);
+    o[1].data  = drive_data;
+    o[2].valid = drive_valid and (drive_sel == 2);
+    o[2].data  = drive_data;
+    o[3].valid = drive_valid and (drive_sel == 3);
+    o[3].data  = drive_data;
+  end comb
+
+  seq on clk rising
+    busy_r <= start;
+  end seq
+end module Fx3ThreadVecParamW

--- a/tests/backend_equiv/Fx3ThreadVecParamW_test.harc
+++ b/tests/backend_equiv/Fx3ThreadVecParamW_test.harc
@@ -1,0 +1,69 @@
+// Backend-equivalence test for Fixture 3 (A+B+D).
+// Drive lane sel=2 with a 12-bit payload 0xABC, ready high on that lane.
+// Expect o[2] to carry 0xABC and other lanes to stay quiet, then a second
+// transaction to lane 1 with payload 0x5A5.
+testbench Fx3Tb
+    dut : Fx3ThreadVecParamW
+end testbench Fx3Tb
+
+impl Fx3Test for Fx3Tb
+    run
+        log(info, "Fx3 A+B+D thread-vec param-width")
+
+        dut.rst = 0
+        dut.start = 0
+        dut.sel = 0
+        dut.d = 0
+        dut.o_ready[0] = 0
+        dut.o_ready[1] = 0
+        dut.o_ready[2] = 0
+        dut.o_ready[3] = 0
+        wait 4 cycles
+        dut.rst = 1
+        wait 2 cycles
+
+        // Txn 1 -> lane 2, payload 0xABC.
+        dut.sel = 2
+        dut.d = 0xABC
+        dut.o_ready[2] = 1
+        dut.start = 1
+
+        let hit2 : uint<32> = 0
+        for _ in 0 .. 12
+            if hit2 == 0 && dut.o_valid[2] == 1 && dut.o_ready[2] == 1
+                hit2 = 1
+                assert dut.o_data[2] == 0xABC
+                    else fail("lane2 data=${dut.o_data[2]} expected 0xABC")
+                assert dut.o_valid[0] == 0
+                    else fail("lane0 leaked valid")
+                assert dut.o_valid[1] == 0
+                    else fail("lane1 leaked valid")
+            end if
+            wait 1 cycle
+        end for
+        assert hit2 == 1
+            else fail("lane2 txn never accepted")
+        dut.start = 0
+        dut.o_ready[2] = 0
+        wait 3 cycles
+
+        // Txn 2 -> lane 1, payload 0x5A5.
+        dut.sel = 1
+        dut.d = 0x5A5
+        dut.o_ready[1] = 1
+        dut.start = 1
+        let hit1 : uint<32> = 0
+        for _ in 0 .. 12
+            if hit1 == 0 && dut.o_valid[1] == 1 && dut.o_ready[1] == 1
+                hit1 = 1
+                assert dut.o_data[1] == 0x5A5
+                    else fail("lane1 data=${dut.o_data[1]} expected 0x5A5")
+            end if
+            wait 1 cycle
+        end for
+        assert hit1 == 1
+            else fail("lane1 txn never accepted")
+
+        log(info, "PASS Fx3: runtime-selected Vec<Bus> drive at 12-bit width")
+    end run
+end impl Fx3Test

--- a/tests/backend_equiv/Fx3bVarIndexVecBusBug.arch
+++ b/tests/backend_equiv/Fx3bVarIndexVecBusBug.arch
@@ -1,30 +1,38 @@
-// Regression: variable-index access to a Vec<Bus> element.
+// Fixture 3b — BUG REPRO (axes A+B+D). Builds SV but MISCOMPILES under the
+// arch C++ sim backend; the `until` form ALSO produces invalid SV.
 //
-// `arch build` lowers `o[sel].valid` to the packed-array form
-// `o_valid[sel]`; the C++ sim backend (`arch sim`) must do the same. Before
-// the fix the sim emitter mis-treated the Vec<Bus> element as a scalar
-// bit-select (`((o) >> sel) & 1`) against an undefined `o`, producing
-// uncompilable C++. Both backends must select lane `sel`.
+// Two related defects in variable-index Vec<Bus> element access:
 //
-// See also Fx3bVarIndexVecBusThread.arch for the `thread`-lowering mirror.
-bus BusVr
-  param DATA_W: const = 8;
-  valid: out Bool;
-  ready: in  Bool;
-  data:  out UInt<DATA_W>;
-end bus BusVr
-
-module Vsel
+// (1) arch-sim C++ codegen — a variable-index WRITE to a Vec<Bus> element in
+//     a plain comb block:
+//         o[sel].valid = dv;        // sel : UInt<2>, o : Vec<BusVr,4>
+//     lowers to invalid C++:
+//         (... (((o) >> (sel)) & 1)).data = dv;
+//     i.e. it is treated as a bit-select on a (nonexistent) scalar `o`
+//     instead of selecting Vec<Bus> element `sel`. The SV backend lowers the
+//     SAME source correctly to `assign o_data[sel] = dv;` — a backend
+//     capability divergence (SV ok, arch-sim broken).
+//
+// (2) thread lowering — a variable-index Vec<Bus> read in an `until`
+//     condition:
+//         until o[sel].ready;
+//     lowers to invalid SV `if (start && o[sel].ready)` where `o` is undefined
+//     (the bus was flattened to o_ready[0..3]); arch-sim emits the same
+//     undefined-`o` reference. Constant-index `o[2].ready` lowers fine.
+//
+// Minimal reproducer for (1) below. Workaround in Fx3ThreadVecParamW.arch:
+// expand the variable index into explicit per-lane constant-index branches.
+module Fx3bVarIndexVecBusBug
   param LANES: const = 4;
   port sel: in UInt<2>;
-  port dv: in UInt<8>;
-  port o: initiator Vec<BusVr<DATA_W=8>, LANES>;
+  port dv:  in UInt<8>;
+  port o:   initiator Vec<BusVr<DATA_W=8>, LANES>;
   comb
     o[0].valid = false; o[0].data = 0;
     o[1].valid = false; o[1].data = 0;
     o[2].valid = false; o[2].data = 0;
     o[3].valid = false; o[3].data = 0;
-    o[sel].valid = true;     // variable index
+    o[sel].valid = true;     // SV: assign o_valid[sel] = 1; arch-sim: ((o)>>sel)&1  <-- BUG
     o[sel].data  = dv;
   end comb
-end module Vsel
+end module Fx3bVarIndexVecBusBug

--- a/tests/backend_equiv/Fx4MutexContendRR.arch
+++ b/tests/backend_equiv/Fx4MutexContendRR.arch
@@ -1,0 +1,39 @@
+// Fixture 4 — axes B+C+D (round_robin variant; see Fx10 for priority twin).
+// B: N threads contending on ONE shared mutex.  C: generate_for over N.
+// D: param-driven thread count NUM and width DATA_W.
+//
+// Each lane thread, while its req[i] holds, repeatedly acquires the shared
+// `bus_ch` mutex and drives the single shared output bus `o` with its own tag
+// (i) for one accepted beat, then releases. The TB holds all reqs high and
+// pulls o.ready every cycle; under round_robin the granted tag should rotate
+// fairly across lanes (no starvation).
+module Fx4MutexContendRR
+  param NUM:    const = 3;
+  param DATA_W: const = 8;
+
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Async, Low>;
+
+  port req: in unpacked Vec<Bool, NUM>;
+  port o:   initiator BusVr<DATA_W=DATA_W>;   // single shared sink
+
+  resource bus_ch: mutex<round_robin>;
+
+  generate_for i in 0..NUM-1
+    thread Lane_i on clk rising, rst low
+      default comb
+        o.valid = false;
+        o.data  = 0;
+      end default
+      if not req[i]
+        wait until req[i];
+      end if
+      lock bus_ch
+        do
+          o.valid = true;
+          o.data  = i;          // tag = lane index
+        until o.ready;
+      end lock bus_ch
+    end thread Lane_i
+  end generate_for
+end module Fx4MutexContendRR

--- a/tests/backend_equiv/Fx4MutexContendRR_test.harc
+++ b/tests/backend_equiv/Fx4MutexContendRR_test.harc
@@ -1,0 +1,63 @@
+// Backend-equivalence test for Fixture 4 (B+C+D) round_robin.
+// All NUM lanes request; o.ready held high. Count grants per tag (lane index
+// appears on o.data). Round-robin must serve every lane (no starvation) and
+// keep ~1 beat/cycle.
+testbench Fx4Tb
+    dut : Fx4MutexContendRR
+end testbench Fx4Tb
+
+impl Fx4Test for Fx4Tb
+    run
+        log(info, "Fx4 B+C+D mutex round_robin")
+
+        dut.rst = 0
+        dut.req[0] = 0
+        dut.req[1] = 0
+        dut.req[2] = 0
+        dut.o_ready = 0
+        wait 4 cycles
+        dut.rst = 1
+        wait 2 cycles
+
+        dut.req[0] = 1
+        dut.req[1] = 1
+        dut.req[2] = 1
+        dut.o_ready = 1
+
+        let g0 : uint<32> = 0
+        let g1 : uint<32> = 0
+        let g2 : uint<32> = 0
+        let total : uint<32> = 0
+        let cyc : uint<32> = 0
+        let lastc : uint<32> = 1
+        for _ in 0 .. 60
+            wait 1 cycle
+            cyc = cyc + 1
+            if dut.o_valid == 1 && dut.o_ready == 1 && total < 30
+                let tag = dut.o_data
+                if tag == 0
+                    g0 = g0 + 1
+                elsif tag == 1
+                    g1 = g1 + 1
+                elsif tag == 2
+                    g2 = g2 + 1
+                end if
+                total = total + 1
+                lastc = cyc
+            end if
+        end for
+
+        assert total == 30
+            else fail("total grants=${total} expected 30")
+        assert g0 > 0
+            else fail("lane0 starved")
+        assert g1 > 0
+            else fail("lane1 starved")
+        assert g2 > 0
+            else fail("lane2 starved")
+        // throughput >= 0.9 beat/cyc
+        assert (total * 10) >= (lastc * 9)
+            else fail("throughput low: ${total} in ${lastc}")
+        log(info, "PASS Fx4 RR: total=${total} g0=${g0} g1=${g1} g2=${g2}")
+    end run
+end impl Fx4Test

--- a/tests/backend_equiv/Fx5Sink.arch
+++ b/tests/backend_equiv/Fx5Sink.arch
@@ -1,0 +1,28 @@
+// Child for Fixture 5 (A+D+E). One scalar BusVr target per child instance;
+// accumulates accepted data into acc. Ready always high (free sink).
+// Scalar (non-Vec) bus passthrough across the inst boundary is the form that
+// actually works — see Fx5bWholeVecForwardCrash.arch for the Vec<Bus>
+// whole-vector forward that crashes arch build.
+module Fx5Sink
+  param DATA_W: const = 8;
+
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Async, Low>;
+
+  port mm:  target    BusVr<DATA_W=DATA_W>;
+  port acc: initiator BusVr<DATA_W=DATA_W>;   // acc.data = running accumulator
+
+  reg acc_r: UInt<DATA_W> reset rst => 0;
+
+  comb
+    mm.ready  = true;
+    acc.valid = true;
+    acc.data  = acc_r;
+  end comb
+
+  seq on clk rising
+    if mm.valid
+      acc_r <= acc_r +% mm.data;
+    end if
+  end seq
+end module Fx5Sink

--- a/tests/backend_equiv/Fx5WholeVecForward.arch
+++ b/tests/backend_equiv/Fx5WholeVecForward.arch
@@ -1,0 +1,31 @@
+// Fixture 5 — axes A+D+E.
+// A: Vec<Bus,NUM> port (m).  D: param-driven NUM and DATA_W.  E: inst boundary
+// — each Vec<Bus> ELEMENT m[i] is forwarded across the boundary to one of NUM
+// child Fx5Sink instances (generate_for), as a scalar bus passthrough.
+//
+// NOTE: the natural "whole-vector forward to a single Vec<Bus> child"
+// (`mm <- m;` with a Vec<Bus> child port) CRASHES arch build with a stack
+// overflow (see Fx5bWholeVecForwardCrash.arch), and per-element Vec<Bus>
+// target->target passthrough fails to wire the reverse (ready) direction.
+// Slicing the Vec<Bus> into N scalar-bus children is the form that works.
+module Fx5WholeVecForward
+  param NUM:    const = 3;
+  param DATA_W: const = 8;
+
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Async, Low>;
+
+  port m:   target    Vec<BusVr<DATA_W=DATA_W>, NUM>;
+  port acc: initiator Vec<BusVr<DATA_W=DATA_W>, NUM>;   // acc[i].data = lane sum
+
+  generate_for i in 0..NUM-1
+    inst sink_i: Fx5Sink
+      param DATA_W = DATA_W;
+      clk <- clk;
+      rst <- rst;
+      mm  <- m[i];        // scalar-bus element passthrough across boundary
+      acc -> acc[i];      // Vec<Bus> output element (avoids the unpacked-Vec
+                          // multi-driver false-positive of Fx1b)
+    end inst sink_i
+  end generate_for
+end module Fx5WholeVecForward

--- a/tests/backend_equiv/Fx5WholeVecForward_test.harc
+++ b/tests/backend_equiv/Fx5WholeVecForward_test.harc
@@ -1,0 +1,49 @@
+// Backend-equivalence test for Fixture 5 (A+D+E).
+// Whole-vector Vec<Bus> forwarded across an inst boundary. Push a few beats
+// into each lane and check each lane's accumulator equals its running sum.
+testbench Fx5Tb
+    dut : Fx5WholeVecForward
+end testbench Fx5Tb
+
+impl Fx5Test for Fx5Tb
+    run
+        log(info, "Fx5 A+D+E whole-vec forward")
+
+        dut.rst = 0
+        dut.m_valid[0] = 0
+        dut.m_valid[1] = 0
+        dut.m_valid[2] = 0
+        dut.m_data[0] = 0
+        dut.m_data[1] = 0
+        dut.m_data[2] = 0
+        dut.acc_ready[0] = 0
+        dut.acc_ready[1] = 0
+        dut.acc_ready[2] = 0
+        wait 4 cycles
+        dut.rst = 1
+        wait 2 cycles
+
+        // One cycle: lane0 += 5, lane1 += 7, lane2 += 9
+        dut.m_valid[0] = 1
+        dut.m_data[0] = 5
+        dut.m_valid[1] = 1
+        dut.m_data[1] = 7
+        dut.m_valid[2] = 1
+        dut.m_data[2] = 9
+        wait 1 cycle
+        // Second cycle: lane0 += 5, lane1 += 7, lane2 += 9
+        wait 1 cycle
+        dut.m_valid[0] = 0
+        dut.m_valid[1] = 0
+        dut.m_valid[2] = 0
+        wait 2 cycles
+
+        assert dut.acc_data[0] == 10
+            else fail("acc0=${dut.acc_data[0]} expected 10")
+        assert dut.acc_data[1] == 14
+            else fail("acc1=${dut.acc_data[1]} expected 14")
+        assert dut.acc_data[2] == 18
+            else fail("acc2=${dut.acc_data[2]} expected 18")
+        log(info, "PASS Fx5: whole-vec forward, per-lane accumulators correct")
+    end run
+end impl Fx5Test

--- a/tests/backend_equiv/Fx5bWholeVecForwardCrash.arch
+++ b/tests/backend_equiv/Fx5bWholeVecForwardCrash.arch
@@ -1,0 +1,38 @@
+// Fixture 5b — BUG REPRO (axes A+D+E). `arch check` PASSES but `arch build`
+// STACK-OVERFLOWS (abort, exit 134) on whole-vector Vec<Bus> forwarding across
+// an inst boundary.
+//
+//   arch check  examples ... Fx5bWholeVecForwardCrash.arch  → "OK: no errors"
+//   arch build  examples ... Fx5bWholeVecForwardCrash.arch  →
+//       thread 'main' has overflowed its stack
+//       fatal runtime error: stack overflow, aborting
+//
+// Trigger (minimized to 2 lanes): a child with a `target Vec<Bus>` port wired
+// in ONE whole-vector connection `mm <- m`. The same crash reproduces with:
+//   - an internal `wire edges: Vec<Bus>` driven in comb and forwarded to a
+//     child Vec<Bus> port, and
+//   - a producer-inst -> wire -> consumer-inst chain over a 1-D Vec<Bus>.
+// Per-element Vec<Bus> target->target passthrough (`mm[k] <- m[k]`) does NOT
+// crash but instead fails single-driver checking ("output port m_0_ready is
+// not driven") — the reverse (ready) direction is not wired across the
+// boundary. Scalar (non-Vec) bus passthrough across an inst works fine.
+//
+// Companion child (inline for clarity):
+//   module CrashSink
+//     param NUM: const = 2;
+//     port clk: in Clock<SysDomain>; port rst: in Reset<Async, Low>;
+//     port mm: target Vec<BusVr<DATA_W=8>, NUM>;
+//     comb mm[0].ready = true; mm[1].ready = true; end comb
+//   end module CrashSink
+module Fx5bWholeVecForwardCrash
+  param NUM: const = 2;
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Async, Low>;
+  port m: target Vec<BusVr<DATA_W=8>, NUM>;
+  inst sink: CrashSink
+    param NUM = NUM;
+    clk <- clk;
+    rst <- rst;
+    mm <- m;                 // <-- whole-vector Vec<Bus> forward: stack overflow
+  end inst sink
+end module Fx5bWholeVecForwardCrash

--- a/tests/backend_equiv/Fx6Cons.arch
+++ b/tests/backend_equiv/Fx6Cons.arch
@@ -1,0 +1,32 @@
+// Consumer for Fixture 6. Gathers ROWS inbound buses (one per row) and sums
+// the accepted payloads into a running accumulator, re-exported on acc.
+// Constant-index body, ROWS fixed at 2.
+module Fx6Cons
+  param ROWS:   const = 2;
+  param DATA_W: const = 8;
+
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Async, Low>;
+
+  port ins: target    Vec<BusVr<DATA_W=DATA_W>, ROWS>;
+  port acc: initiator BusVr<DATA_W=DATA_W>;
+
+  reg acc_r: UInt<DATA_W> reset rst => 0;
+
+  comb
+    ins[0].ready = true;
+    ins[1].ready = true;
+    acc.valid = true;
+    acc.data  = acc_r;
+  end comb
+
+  seq on clk rising
+    if ins[0].valid and ins[1].valid
+      acc_r <= acc_r +% (ins[0].data +% ins[1].data);
+    elsif ins[0].valid
+      acc_r <= acc_r +% ins[0].data;
+    elsif ins[1].valid
+      acc_r <= acc_r +% ins[1].data;
+    end if
+  end seq
+end module Fx6Cons

--- a/tests/backend_equiv/Fx6Nested2D.arch
+++ b/tests/backend_equiv/Fx6Nested2D.arch
@@ -1,0 +1,61 @@
+// Fixture 6 — axes A+C+E (nested 2-D). BUG-BLOCKED: this combination cannot
+// currently be expressed in a form that builds. It is kept as a standing
+// repro of two interacting defects on a 2-D Vec<Vec<Bus,COLS>,ROWS> wire.
+//
+// (parse) The nested Vec<Vec<BusVr<DATA_W=DATA_W>,COLS>,ROWS> form fails to
+//   parse ("expected ,, found <") unless the inner bus is hidden behind a
+//   `type` alias (as Nic400Fabric does). With the alias it parses — but then:
+//
+// (build/elab) Forwarding the 2-D edge wire to child insts hits the same
+//   Vec<Bus>-across-boundary bug family as Fx5b:
+//     - whole-row forward  `o -> edges[r]`        → arch build STACK OVERFLOW
+//     - per-element forward `o[c] -> edges[r][c]`  → FALSE "signal `edges` has
+//       multiple drivers" (each edges[r][c] is a distinct element driven once;
+//       same false-positive class as Fx1bMultiDriverBug, now 2-D).
+//
+// Nic400Fabric DOES build a 2-D edge wire — but it drives each row from a
+// dedicated per-row inst's whole-Vec<Bus> initiator (`mp_i.outs -> edges[i]`)
+// where the producer drives `outs` from THREADS, and gathers on the consumer
+// side with `ins[k] <- edges[k][j]`. Reducing that to a tiny standalone
+// fixture (comb-driven producer, or explicit per-element row forward) trips
+// the bugs above. The minimal failing shape is preserved below.
+module Fx6Nested2D
+  param ROWS:   const = 2;
+  param COLS:   const = 2;
+  param DATA_W: const = 8;
+
+  type EdgeBus = BusVr<DATA_W=DATA_W>;            // alias needed for nested Vec to parse
+
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Async, Low>;
+  port v:   in unpacked Vec<Bool, ROWS>;
+  port d:   in unpacked Vec<UInt<DATA_W>, ROWS>;
+  port acc: initiator Vec<EdgeBus, COLS>;
+
+  wire edges: Vec<Vec<EdgeBus, COLS>, ROWS>;     // 2-D Vec<Bus> wire
+
+  generate_for r in 0..ROWS-1
+    inst prod_r: Fx6Prod
+      param COLS = COLS;
+      param DATA_W = DATA_W;
+      v <- v[r];
+      d <- d[r];
+      for c in 0..COLS-1
+        o[c] -> edges[r][c];     // FALSE "edges has multiple drivers" here
+      end for
+    end inst prod_r
+  end generate_for
+
+  generate_for c in 0..COLS-1
+    inst cons_c: Fx6Cons
+      param ROWS = ROWS;
+      param DATA_W = DATA_W;
+      clk <- clk;
+      rst <- rst;
+      for k in 0..ROWS-1
+        ins[k] <- edges[k][c];   // double-indexed gather (consumer side)
+      end for
+      acc -> acc[c];
+    end inst cons_c
+  end generate_for
+end module Fx6Nested2D

--- a/tests/backend_equiv/Fx6Prod.arch
+++ b/tests/backend_equiv/Fx6Prod.arch
@@ -1,0 +1,15 @@
+// Producer for Fixture 6. Broadcasts a single (v,d) onto a whole row of
+// COLS outbound buses (constant-index body, COLS fixed at 2).
+module Fx6Prod
+  param COLS:   const = 2;
+  param DATA_W: const = 8;
+
+  port v: in Bool;
+  port d: in UInt<DATA_W>;
+  port o: initiator Vec<BusVr<DATA_W=DATA_W>, COLS>;
+
+  comb
+    o[0].valid = v; o[0].data = d;
+    o[1].valid = v; o[1].data = d;
+  end comb
+end module Fx6Prod

--- a/tests/backend_equiv/Fx7Latch.arch
+++ b/tests/backend_equiv/Fx7Latch.arch
@@ -1,0 +1,26 @@
+// Child for Fixture 7 (B+D+E). Latches an accepted (valid&ready) word at
+// param width DATA_W. Always ready.
+module Fx7Latch
+  param DATA_W: const = 10;
+
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Async, Low>;
+
+  port b_valid: in  Bool;
+  port b_data:  in  UInt<DATA_W>;
+  port b_ready: out Bool;
+  port got:     out UInt<DATA_W>;
+
+  reg got_r: UInt<DATA_W> reset rst => 0;
+
+  comb
+    b_ready = true;
+    got = got_r;
+  end comb
+
+  seq on clk rising
+    if b_valid
+      got_r <= b_data;
+    end if
+  end seq
+end module Fx7Latch

--- a/tests/backend_equiv/Fx7ThreadFwdInst.arch
+++ b/tests/backend_equiv/Fx7ThreadFwdInst.arch
@@ -1,0 +1,52 @@
+// Fixture 7 — axes B+D+E.
+// B: a thread (with lock) drives a scalar BusVr.  D: param-driven width DATA_W
+// (default 10 — odd width).  E: the thread's output bus is forwarded across an
+// inst boundary to a child sink that latches it.
+//
+// A producer thread, on `start`, takes a lock and drives an internal bus
+// `gen` with payload `d` until accepted; `gen` is forwarded whole (scalar bus)
+// to a child Fx7Latch which captures the word. Tests a thread output crossing
+// a module boundary at a param width.
+module Fx7ThreadFwdInst
+  param DATA_W: const = 10;
+
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Async, Low>;
+
+  port start: in Bool;
+  port d:     in UInt<DATA_W>;
+  port got:   out UInt<DATA_W>;
+
+  resource gen_ch: mutex<priority>;
+
+  // Internal scalar bus the thread drives and the child consumes.
+  wire gen_valid: Bool;
+  wire gen_data:  UInt<DATA_W>;
+  wire gen_ready: Bool;
+
+  thread Gen on clk rising, rst low
+    default comb
+      gen_valid = false;
+      gen_data  = 0;
+    end default
+    if not start
+      wait until start;
+    end if
+    lock gen_ch
+      do
+        gen_valid = true;
+        gen_data  = d;
+      until gen_ready;
+    end lock gen_ch
+  end thread Gen
+
+  inst lat: Fx7Latch
+    param DATA_W = DATA_W;
+    clk <- clk;
+    rst <- rst;
+    b_valid <- gen_valid;
+    b_data  <- gen_data;
+    b_ready -> gen_ready;
+    got     -> got;
+  end inst lat
+end module Fx7ThreadFwdInst

--- a/tests/backend_equiv/Fx7ThreadFwdInst_test.harc
+++ b/tests/backend_equiv/Fx7ThreadFwdInst_test.harc
@@ -1,0 +1,31 @@
+// Backend-equivalence test for Fixture 7 (B+D+E).
+// Thread produces a 10-bit word that crosses an inst boundary into a latch.
+// Drive start with d=0x2AB (10-bit), expect got == 0x2AB.
+testbench Fx7Tb
+    dut : Fx7ThreadFwdInst
+end testbench Fx7Tb
+
+impl Fx7Test for Fx7Tb
+    run
+        log(info, "Fx7 B+D+E thread-fwd-inst")
+
+        dut.rst = 0
+        dut.start = 0
+        dut.d = 0
+        wait 4 cycles
+        dut.rst = 1
+        wait 2 cycles
+
+        dut.start = 1
+        dut.d = 0x2AB
+        // Hold start; the thread takes the lock and drives; the always-ready
+        // child latches on the accepted beat. Allow a few cycles.
+        wait 4 cycles
+        dut.start = 0
+        wait 2 cycles
+
+        assert dut.got == 0x2AB
+            else fail("got=${dut.got} expected 0x2AB")
+        log(info, "PASS Fx7: 10-bit thread output crossed inst boundary, got=0x${dut.got}")
+    end run
+end impl Fx7Test

--- a/tests/backend_equiv/Fx8Dbl.arch
+++ b/tests/backend_equiv/Fx8Dbl.arch
@@ -1,0 +1,9 @@
+// double child for Fixture 8 (C+D+E).
+module Fx8Dbl
+  param DATA_W: const = 8;
+  port x: in  UInt<DATA_W>;
+  port r: out UInt<DATA_W>;
+  comb
+    r = x +% x;
+  end comb
+end module Fx8Dbl

--- a/tests/backend_equiv/Fx8GenIfSelect.arch
+++ b/tests/backend_equiv/Fx8GenIfSelect.arch
@@ -1,0 +1,36 @@
+// Fixture 8 — axes C+D+E.
+// C: generate_if (param-gated).  D: param MODE selects behavior; param DATA_W.
+// E: each generate_if arm instantiates a DIFFERENT child module, forwarding the
+// same external signals to it.
+//
+// MODE==0 → instantiate Fx8Inc (output = in + 1).
+// MODE!=0 → instantiate Fx8Dbl (output = in * 2, wrapping at DATA_W).
+// Whichever arm is active drives `y` via a forwarded child inst. Default MODE
+// is 1 here; the companion Fx8GenIfSelectMode0.arch fixes MODE=0 for the other
+// arm so both paths are exercised by the same source.
+module Fx8GenIfSelect
+  param MODE:   const = 1;
+  param DATA_W: const = 8;
+
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Async, Low>;
+
+  port a: in  UInt<DATA_W>;
+  port y: out UInt<DATA_W>;
+
+  generate_if MODE == 0
+    inst u_inc: Fx8Inc
+      param DATA_W = DATA_W;
+      x <- a;
+      r -> y;
+    end inst u_inc
+  end generate_if
+
+  generate_if MODE != 0
+    inst u_dbl: Fx8Dbl
+      param DATA_W = DATA_W;
+      x <- a;
+      r -> y;
+    end inst u_dbl
+  end generate_if
+end module Fx8GenIfSelect

--- a/tests/backend_equiv/Fx8GenIfSelectMode0.arch
+++ b/tests/backend_equiv/Fx8GenIfSelectMode0.arch
@@ -1,0 +1,36 @@
+// Fixture 8 — axes C+D+E.
+// C: generate_if (param-gated).  D: param MODE selects behavior; param DATA_W.
+// E: each generate_if arm instantiates a DIFFERENT child module, forwarding the
+// same external signals to it.
+//
+// MODE==0 → instantiate Fx8Inc (output = in + 1).
+// MODE!=0 → instantiate Fx8Dbl (output = in * 2, wrapping at DATA_W).
+// Whichever arm is active drives `y` via a forwarded child inst. MODE fixed to 0 here so the inc arm is selected (twin of Fx8GenIfSelect).
+// is 1 here; the companion Fx8GenIfSelectMode0.arch fixes MODE=0 for the other
+// arm so both paths are exercised by the same source.
+module Fx8GenIfSelectMode0
+  param MODE:   const = 0;            // exercises the OTHER (inc) arm
+  param DATA_W: const = 8;
+
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Async, Low>;
+
+  port a: in  UInt<DATA_W>;
+  port y: out UInt<DATA_W>;
+
+  generate_if MODE == 0
+    inst u_inc: Fx8Inc
+      param DATA_W = DATA_W;
+      x <- a;
+      r -> y;
+    end inst u_inc
+  end generate_if
+
+  generate_if MODE != 0
+    inst u_dbl: Fx8Dbl
+      param DATA_W = DATA_W;
+      x <- a;
+      r -> y;
+    end inst u_dbl
+  end generate_if
+end module Fx8GenIfSelectMode0

--- a/tests/backend_equiv/Fx8GenIfSelectMode0_test.harc
+++ b/tests/backend_equiv/Fx8GenIfSelectMode0_test.harc
@@ -1,0 +1,24 @@
+// Backend-equivalence test for Fixture 8 (C+D+E), MODE=0 (inc arm).
+// y should be a+1 (wrapping). a=0x40 -> 0x41; a=0xFF -> 0x00 (wrap).
+testbench Fx8M0Tb
+    dut : Fx8GenIfSelectMode0
+end testbench Fx8M0Tb
+
+impl Fx8M0Test for Fx8M0Tb
+    run
+        log(info, "Fx8 C+D+E gen-if MODE=0 (inc)")
+        dut.rst = 0
+        dut.a = 0
+        wait 3 cycles
+        dut.rst = 1
+        dut.a = 0x40
+        wait 1 cycle
+        assert dut.y == 0x41
+            else fail("MODE0 a=0x40 y=${dut.y} expected 0x41")
+        dut.a = 0xFF
+        wait 1 cycle
+        assert dut.y == 0x00
+            else fail("MODE0 a=0xFF y=${dut.y} expected 0x00 (wrap)")
+        log(info, "PASS Fx8 MODE0: inc arm selected")
+    end run
+end impl Fx8M0Test

--- a/tests/backend_equiv/Fx8GenIfSelect_test.harc
+++ b/tests/backend_equiv/Fx8GenIfSelect_test.harc
@@ -1,0 +1,24 @@
+// Backend-equivalence test for Fixture 8 (C+D+E), MODE=1 (double arm).
+// y should be 2*a (wrapping). a=0x40 -> 0x80; a=0xC0 -> 0x80 (wrap).
+testbench Fx8Tb
+    dut : Fx8GenIfSelect
+end testbench Fx8Tb
+
+impl Fx8Test for Fx8Tb
+    run
+        log(info, "Fx8 C+D+E gen-if MODE=1 (double)")
+        dut.rst = 0
+        dut.a = 0
+        wait 3 cycles
+        dut.rst = 1
+        dut.a = 0x40
+        wait 1 cycle
+        assert dut.y == 0x80
+            else fail("MODE1 a=0x40 y=${dut.y} expected 0x80")
+        dut.a = 0xC0
+        wait 1 cycle
+        assert dut.y == 0x80
+            else fail("MODE1 a=0xC0 y=${dut.y} expected 0x80 (wrap)")
+        log(info, "PASS Fx8 MODE1: double arm selected")
+    end run
+end impl Fx8Test

--- a/tests/backend_equiv/Fx8Inc.arch
+++ b/tests/backend_equiv/Fx8Inc.arch
@@ -1,0 +1,9 @@
+// inc child for Fixture 8 (C+D+E).
+module Fx8Inc
+  param DATA_W: const = 8;
+  port x: in  UInt<DATA_W>;
+  port r: out UInt<DATA_W>;
+  comb
+    r = x +% 1;
+  end comb
+end module Fx8Inc

--- a/tests/backend_equiv/Fx9MiniFabric.arch
+++ b/tests/backend_equiv/Fx9MiniFabric.arch
@@ -1,0 +1,59 @@
+// Fixture 9 — axes A+B+C+D (the full small-scale stack).
+// A: per-lane Vec<Bus> input port (m) AND Vec<Bus> output port (o).
+// B: one thread per lane, all contending on a SHARED mutex to drive a single
+//    merged output, plus a lock-free per-lane passthrough.
+// C: generate_for over LANES.
+// D: param-driven LANES and DATA_W (default 16-bit).
+//
+// Each lane i forwards its input bus m[i] straight to its output bus o[i]
+// (registered acceptance), and ALSO, when m[i] presents a beat, a per-lane
+// thread contends on the shared `merge_ch` mutex to push that lane's tag onto
+// the single shared `merged` bus. Round-robin arbitration over LANES threads,
+// with the Vec<Bus> ports sized by param DATA_W.
+module Fx9MiniFabric
+  param LANES:  const = 3;
+  param DATA_W: const = 16;
+
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Async, Low>;
+
+  port m: target    Vec<BusVr<DATA_W=DATA_W>, LANES>;   // per-lane input
+  port o: initiator Vec<BusVr<DATA_W=DATA_W>, LANES>;   // per-lane passthrough out
+  port merged: initiator BusVr<DATA_W=DATA_W>;          // shared merged stream
+
+  resource merge_ch: mutex<round_robin>;
+
+  // Per-lane passthrough: o[i] mirrors m[i] (always ready in, always valid out
+  // when input valid). Constant-index body, LANES fixed at 3.
+  comb
+    m[0].ready = o[0].ready;
+    o[0].valid = m[0].valid;
+    o[0].data  = m[0].data;
+    m[1].ready = o[1].ready;
+    o[1].valid = m[1].valid;
+    o[1].data  = m[1].data;
+    m[2].ready = o[2].ready;
+    o[2].valid = m[2].valid;
+    o[2].data  = m[2].data;
+  end comb
+
+  // Per-lane merge threads contend on the shared mutex to stamp lane tag onto
+  // the merged stream when that lane's input is valid.
+  generate_for i in 0..LANES-1
+    thread Merge_i on clk rising, rst low
+      default comb
+        merged.valid = false;
+        merged.data  = 0;
+      end default
+      if not m[i].valid
+        wait until m[i].valid;
+      end if
+      lock merge_ch
+        do
+          merged.valid = true;
+          merged.data  = i;          // tag = lane index
+        until merged.ready;
+      end lock merge_ch
+    end thread Merge_i
+  end generate_for
+end module Fx9MiniFabric

--- a/tests/backend_equiv/Fx9MiniFabric_test.harc
+++ b/tests/backend_equiv/Fx9MiniFabric_test.harc
@@ -1,0 +1,77 @@
+// Backend-equivalence test for Fixture 9 (A+B+C+D mini-fabric).
+// All lanes present input beats; check (1) per-lane passthrough m[i]->o[i]
+// carries distinct payloads, and (2) the shared merged stream is served fairly
+// across lanes under round_robin (every lane tag appears).
+testbench Fx9Tb
+    dut : Fx9MiniFabric
+end testbench Fx9Tb
+
+impl Fx9Test for Fx9Tb
+    run
+        log(info, "Fx9 A+B+C+D mini-fabric")
+
+        dut.rst = 0
+        dut.m_valid[0] = 0
+        dut.m_valid[1] = 0
+        dut.m_valid[2] = 0
+        dut.m_data[0] = 0
+        dut.m_data[1] = 0
+        dut.m_data[2] = 0
+        dut.o_ready[0] = 0
+        dut.o_ready[1] = 0
+        dut.o_ready[2] = 0
+        dut.merged_ready = 0
+        wait 4 cycles
+        dut.rst = 1
+        wait 2 cycles
+
+        // Present distinct payloads on all lanes; accept passthrough + merged.
+        dut.m_data[0] = 0x1111
+        dut.m_data[1] = 0x2222
+        dut.m_data[2] = 0x3333
+        dut.m_valid[0] = 1
+        dut.m_valid[1] = 1
+        dut.m_valid[2] = 1
+        dut.o_ready[0] = 1
+        dut.o_ready[1] = 1
+        dut.o_ready[2] = 1
+        dut.merged_ready = 1
+
+        // (1) passthrough is combinational — check immediately after a tick.
+        wait 1 cycle
+        assert dut.o_valid[0] == 1 && dut.o_data[0] == 0x1111
+            else fail("passthrough lane0 o_data=${dut.o_data[0]}")
+        assert dut.o_valid[1] == 1 && dut.o_data[1] == 0x2222
+            else fail("passthrough lane1 o_data=${dut.o_data[1]}")
+        assert dut.o_valid[2] == 1 && dut.o_data[2] == 0x3333
+            else fail("passthrough lane2 o_data=${dut.o_data[2]}")
+
+        // (2) merged stream fairness — collect tags over a window.
+        let t0 : uint<32> = 0
+        let t1 : uint<32> = 0
+        let t2 : uint<32> = 0
+        let tot : uint<32> = 0
+        for _ in 0 .. 40
+            if dut.merged_valid == 1 && dut.merged_ready == 1 && tot < 30
+                let tag = dut.merged_data
+                if tag == 0
+                    t0 = t0 + 1
+                elsif tag == 1
+                    t1 = t1 + 1
+                elsif tag == 2
+                    t2 = t2 + 1
+                end if
+                tot = tot + 1
+            end if
+            wait 1 cycle
+        end for
+
+        assert t0 > 0
+            else fail("merged: lane0 tag never seen")
+        assert t1 > 0
+            else fail("merged: lane1 tag never seen")
+        assert t2 > 0
+            else fail("merged: lane2 tag never seen")
+        log(info, "PASS Fx9: passthrough + round_robin merge (t0=${t0} t1=${t1} t2=${t2})")
+    end run
+end impl Fx9Test

--- a/tests/backend_equiv/README.md
+++ b/tests/backend_equiv/README.md
@@ -1,0 +1,57 @@
+# Backend-equivalence torture fixtures
+
+Tiny ARCH designs that deliberately **stack** the compiler's load-bearing
+composition axes (3–4 at a time) to surface bugs that only appear at feature
+*interactions* — the class that hit the NIC-400 interconnect ~25 times, always
+at 3–4-way intersections, never at single features.
+
+## Load-bearing axes
+- **A** — `Vec<Bus,N>` ports (and nested `Vec<Vec<Bus,N>,M>`) — wiring fabric
+- **B** — `thread` + `lock`/`mutex` (round_robin vs priority) — protocol logic
+- **C** — `generate_for` / `generate_if` — replication
+- **D** — param-driven widths & counts — parameterization
+- **E** — `inst` hierarchy + cross-boundary signal forwarding — composition
+
+## Running
+```sh
+./run.sh                        # uses ../../target/release/arch
+ARCH=/path/to/arch ./run.sh
+```
+`run.sh` checks/builds/sims every fixture; exits non-zero on any regression.
+This is the **arch-com side** (check/build/sim soundness). The full per-cycle
+**sim↔SV trace equivalence** runs these same designs under
+`harc sim --check-backends` in harc-com CI.
+
+## Parity-pass fixtures (clean interactions)
+| Fixture | Axes | What it stacks |
+|---|---|---|
+| `Fx1VecTapFabric` | A+C+E | generate_for over `Vec<Bus>`, each elem → child inst |
+| `Fx2GenThreadLock` | A+B+C | generate_for of N threads driving `Vec<Bus>` via a lock |
+| `Fx3ThreadVecParamW` | A+B+D | thread+lock driving a runtime-selected `Vec<Bus>` at param width |
+| `Fx4MutexContendRR` | B+C+D | N threads contending on `mutex<round_robin>`, param N |
+| `Fx5WholeVecForward` | A+D+E | `Vec<Bus>` sliced across an inst boundary, param N |
+| `Fx7ThreadFwdInst` | B+D+E | thread output at param width forwarded into a child inst |
+| `Fx8GenIfSelect{,Mode0}` | C+D+E | `generate_if` param-gated, different child inst per arm |
+| `Fx9MiniFabric` | A+B+C+D | the full stack: per-lane `Vec<Bus>` + threads + lock + param |
+| `Fx10MutexContendPrio` | B+C+D | `mutex<priority>` twin of Fx4 — policy-parity guard |
+
+## Regression fixtures — each caught a real bug, now fixed
+These were authored as bug *reproducers*; the bugs are fixed and the fixtures
+must stay **green** (a regression re-breaks them). All defects were
+`Vec<Bus>`-interaction bugs that no prior test caught.
+
+| Fixture | Axes | Bug it locks down | Fix |
+|---|---|---|---|
+| `Fx5bWholeVecForwardCrash` | A+D+E | `arch build` **stack overflow** on whole-vector `Vec<Bus>` inst forward | `77bd55e` |
+| `Fx3bVarIndexVecBusBug` (+`…Thread`, `…ThreadWrite`) | A+B+D | variable-index `Vec<Bus>` element access miscompiled in arch-sim (SV was correct → backend divergence) | `5fab9d6`, `f2c7e38` |
+| `Fx1bMultiDriverBug` | A+C+E | false "multiple drivers" when a `Vec<Bus>` per-element forward sits beside a non-bus per-element forward in one `generate_for` | #528 |
+| `Fx6Nested2D` | A+C+E (2-D) | same false multi-driver, one dimension deeper (`edges[r][c]`) | #533 |
+
+## Mutex policy parity
+`Fx4` (round_robin) and `Fx10` (priority) are value-cross-checked on both
+backends: round_robin 10/10/10, priority 30/0/0 — identical across arch-sim and
+Verilator, guarding against the silent-policy-divergence class.
+
+## Companion leaves
+`BusVr` (the shared tiny valid/ready/data bus), `VrTap`, `VrTapScalar`,
+`Fx5Sink`, `Fx7Latch`, `Fx8Inc`, `Fx8Dbl`, `Fx6Prod`, `Fx6Cons`, `CrashSink`.

--- a/tests/backend_equiv/VrTap.arch
+++ b/tests/backend_equiv/VrTap.arch
@@ -1,0 +1,29 @@
+// Leaf: latches the last accepted data word from a BusVr target port and
+// re-exposes it on an outbound BusVr initiator (o.data = latched value,
+// o.valid always true). Driving the result back out as a bus — rather than
+// a scalar `out` port — sidesteps the A+C+E multi-driver false-positive
+// documented in Fx1bMultiDriverBug.arch.
+module VrTap
+  param DATA_W: const = 8;
+
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Async, Low>;
+
+  port b:  target BusVr<DATA_W=DATA_W>;     // incoming beats
+  port en: in Bool;                          // ready source
+  port o:  initiator BusVr<DATA_W=DATA_W>;   // o.data = last accepted word
+
+  reg last_r: UInt<DATA_W> reset rst => 0;
+
+  comb
+    b.ready = en;
+    o.valid = true;
+    o.data  = last_r;
+  end comb
+
+  seq on clk rising
+    if b.valid and en
+      last_r <= b.data;
+    end if
+  end seq
+end module VrTap

--- a/tests/backend_equiv/VrTapScalar.arch
+++ b/tests/backend_equiv/VrTapScalar.arch
@@ -1,0 +1,12 @@
+// Companion leaf for Fx1bMultiDriverBug (A+C+E). One scalar BusVr target +
+// a scalar output, so the parent can forward `b <- m[i]` (Vec<Bus> elem)
+// beside `last -> out[i]` (non-bus elem) in one generate_for body.
+module VrTapScalar
+  port b:    target BusVr<DATA_W=8>;
+  port en:   in Bool;
+  port last: out UInt<8>;
+  comb
+    b.ready = en;
+    last    = b.data;
+  end comb
+end module VrTapScalar

--- a/tests/backend_equiv/run.sh
+++ b/tests/backend_equiv/run.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Backend-equivalence torture-fixture runner.
+#
+# Each fixture deliberately STACKS 3–4 of the compiler's load-bearing
+# composition axes (Vec<Bus>, thread+lock/mutex, generate, param widths,
+# inst forwarding). Every one is checked (and the structural / sim cases
+# built / simulated) so a regression at any feature *intersection* fails CI.
+#
+# Usage:  ARCH=path/to/arch  ./run.sh        (defaults to ../../target/release/arch)
+#
+# NOTE: this runs the arch-com side (check/build/sim soundness). The full
+# sim<->SV trace-equivalence pass runs these same designs under
+# `harc sim --check-backends` in harc-com CI.
+set -u
+ARCH="${ARCH:-$(cd "$(dirname "$0")/../.." && pwd)/target/release/arch}"
+cd "$(dirname "$0")"
+pass=0; fail=0
+ck() { # ck <kind> <deps...> <top>
+  local kind="$1"; shift
+  local top="${@: -1}"
+  local out rc
+  case "$kind" in
+    check) out=$("$ARCH" check "$@" 2>&1); rc=$?;;
+    build) out=$("$ARCH" build "$@" -o /tmp/_be_$$.sv 2>&1); rc=$?; rm -f /tmp/_be_$$.sv;;
+    sim)   echo 'int main(){return 0;}' >/tmp/_be_$$.cpp
+           out=$("$ARCH" sim "$@" --tb /tmp/_be_$$.cpp --outdir /tmp/_be_$$ 2>&1); rc=$?
+           rm -rf /tmp/_be_$$ /tmp/_be_$$.cpp;;
+  esac
+  if [ $rc -eq 0 ] && { [ "$kind" != check ] || echo "$out" | grep -q "OK: no errors"; }; then
+    printf '  PASS %-6s %s\n' "$kind" "$top"; pass=$((pass+1))
+  else
+    printf '  FAIL %-6s %s\n%s\n' "$kind" "$top" "$out"; fail=$((fail+1))
+  fi
+}
+
+# Parity-pass fixtures (clean interactions)
+ck check BusVr.arch VrTap.arch        Fx1VecTapFabric.arch
+ck check BusVr.arch                   Fx2GenThreadLock.arch
+ck check BusVr.arch                   Fx3ThreadVecParamW.arch
+ck check BusVr.arch                   Fx4MutexContendRR.arch
+ck check BusVr.arch Fx5Sink.arch      Fx5WholeVecForward.arch
+ck check BusVr.arch Fx7Latch.arch     Fx7ThreadFwdInst.arch
+ck check BusVr.arch Fx8Inc.arch Fx8Dbl.arch Fx8GenIfSelect.arch
+ck check BusVr.arch Fx8Inc.arch Fx8Dbl.arch Fx8GenIfSelectMode0.arch
+ck check BusVr.arch                   Fx9MiniFabric.arch
+ck check BusVr.arch                   Fx10MutexContendPrio.arch
+
+# Regression fixtures — each caught a real Vec<Bus>-interaction bug
+# (all now fixed; they must stay green):
+ck check BusVr.arch VrTapScalar.arch  Fx1bMultiDriverBug.arch      # Bug 3 (#528): 1-D false multi-driver
+ck check BusVr.arch Fx6Prod.arch Fx6Cons.arch Fx6Nested2D.arch     # Bug 4 (#533): 2-D nested false multi-driver
+ck build BusVr.arch CrashSink.arch    Fx5bWholeVecForwardCrash.arch # Bug 1 (77bd55e): arch-build stack overflow
+ck sim   BusVr.arch                   Fx3bVarIndexVecBusBug.arch     # Bug 2 (5fab9d6/f2c7e38): var-index Vec<Bus> sim
+ck sim   BusVr.arch                   Fx3bVarIndexVecBusThread.arch
+ck sim   BusVr.arch                   Fx3bVarIndexVecBusThreadWrite.arch
+
+echo "=== backend_equiv: $pass passed, $fail failed ==="
+[ $fail -eq 0 ]


### PR DESCRIPTION
## Summary

Lands the torture fixtures that drove this cycle's compiler-bug campaign as a **standing regression net** under `tests/backend_equiv/`. Each fixture deliberately stacks 3–4 of the compiler's load-bearing composition axes — `Vec<Bus>`, `thread`+`lock`/`mutex`, `generate`, param widths, `inst` forwarding — the intersections where the NIC-400 interconnect hit ~25 bugs that no single-feature test caught.

## Two groups

**Parity-pass** (Fx1,2,3,4,5,7,8,9,10) — clean interactions that must keep compiling.

**Regression** (Fx1b, Fx3b, Fx5b, Fx6 + variants) — each was authored as a bug reproducer; all four bugs are now fixed and these lock the fixes in:
| Fixture | Bug | Fix |
|---|---|---|
| `Fx5bWholeVecForwardCrash` | `arch build` stack overflow on whole-vector `Vec<Bus>` inst forward | `77bd55e` |
| `Fx3bVarIndexVecBusBug` (+variants) | variable-index `Vec<Bus>` sim miscompile (SV correct → backend divergence) | `5fab9d6`/`f2c7e38` |
| `Fx1bMultiDriverBug` | 1-D false multi-driver | #528 |
| `Fx6Nested2D` | 2-D nested false multi-driver | #533 |

## Runner

`run.sh` checks/builds/sims every fixture — **16/16 green on current main**. This is the arch-com soundness side. The full per-cycle **sim↔SV trace equivalence** runs these same designs under `harc sim --check-backends` in harc-com CI (unblocked by harc-com #338 + #339).

The two previously-incomplete reproducers got their companion leaves (`CrashSink`, `VrTapScalar`) so every fixture is self-contained.

## Test plan
- [x] `./run.sh` → 16 passed, 0 failed (fresh binary, current main)
- [x] Each former-bug fixture verified to exercise the now-fixed path (check/build/sim as appropriate)