### PR TITLE
feat(sim): honor $ARCH_SIM_BUILD_DIR for default sim build dir

### DIFF
--- a/doc/Arch_AI_Reference_Card.md
+++ b/doc/Arch_AI_Reference_Card.md
@@ -1412,7 +1412,7 @@ arch build F.arch                              // emit SystemVerilog
 arch build F.arch -o out.sv                   // combined output
 arch build a.arch b.arch                       // multi-file: one .sv per input
 arch sim F.arch --tb F_tb.cpp                 // compile + run C++ testbench
-arch sim F.arch --tb F_tb.cpp --outdir build/
+arch sim F.arch --tb F_tb.cpp --outdir build/        // build dir: --outdir > $ARCH_SIM_BUILD_DIR > arch_sim_build/
 arch sim F.arch --tb F_tb.cpp --check-uninit  // warn on uninitialized reset-none regs
 arch sim F.arch --tb F_tb.cpp --inputs-start-uninit  // warn on reads of TB-undriven inputs (TB calls dut.set_<port>() to mark init)
 arch sim F.arch --tb F_tb.cpp --check-uninit-ram  // warn on reads of RAM cells never written (per-cell valid bitmap; init: cells pre-marked; ROMs exempt)

--- a/doc/ONBOARDING_CHEATSHEET.md
+++ b/doc/ONBOARDING_CHEATSHEET.md
@@ -23,6 +23,7 @@ CLI commands:
 - `arch check <files...>`
 - `arch build <files...> [-o out.sv]`
 - `arch sim <arch_files...> --tb <tb.cpp...> [--outdir DIR] [--check-uninit] [--cdc-random] [--wave out.vcd]`
+  - Build artifacts go to `--outdir` if given, else `$ARCH_SIM_BUILD_DIR` if set, else `arch_sim_build/` in the cwd. Export `ARCH_SIM_BUILD_DIR=/tmp/arch_sim` to keep them out of the repo.
 
 ## 2) Core subsystem map
 

--- a/doc/arch_sim_cocotb.md
+++ b/doc/arch_sim_cocotb.md
@@ -15,7 +15,7 @@ arch sim --pybind --test test_mymodule.py MyModule.arch
 Under the hood this:
 
 1. Runs the ARCH → C++ codegen (`SimCodegen::generate_pybind`), producing `VMyModule_pybind.cpp` next to the normal `VMyModule.cpp`.
-2. Compiles the pybind11 wrapper with `python3 -m pybind11 --includes` plus the configured C++ compiler (`g++` by default; override with `ARCH_CXX`, e.g. `ARCH_CXX=clang++` — required on Linux, where GCC miscompiles the C++20 coroutine testbench scheduler), emitting `VMyModule_pybind.<ext>` into the build directory (default `arch_sim_build/`).
+2. Compiles the pybind11 wrapper with `python3 -m pybind11 --includes` plus the configured C++ compiler (`g++` by default; override with `ARCH_CXX`, e.g. `ARCH_CXX=clang++` — required on Linux, where GCC miscompiles the C++20 coroutine testbench scheduler), emitting `VMyModule_pybind.<ext>` into the build directory (`--outdir` if given, else `$ARCH_SIM_BUILD_DIR`, else `arch_sim_build/`).
 3. Spawns `python3 test_mymodule.py` with `PYTHONPATH` set to find three packages:
    - `python/cocotb_shim/cocotb/` — so `import cocotb` works unchanged
    - `python/arch_cocotb/` — the real implementation

--- a/src/main.rs
+++ b/src/main.rs
@@ -190,7 +190,8 @@ enum Command {
         /// C++ testbench file(s) to compile alongside the generated models
         #[arg(long = "tb", num_args = 1..)]
         tb_files: Vec<PathBuf>,
-        /// Output directory for generated C++ files (default: arch_sim_build/)
+        /// Output directory for generated C++ files
+        /// (default: $ARCH_SIM_BUILD_DIR, else arch_sim_build/)
         #[arg(short, long)]
         outdir: Option<PathBuf>,
         /// Enable uninitialized register read detection (reset-none regs + pipe_reg propagation)
@@ -1432,6 +1433,18 @@ fn main() -> miette::Result<()> {
     }
 }
 
+/// Default sim build/output directory used when neither `--outdir` nor an
+/// explicit path is supplied. Honors the `ARCH_SIM_BUILD_DIR` env var so
+/// callers can route build artifacts to a scratch location instead of
+/// dropping `arch_sim_build/` in the current directory; falls back to
+/// `arch_sim_build` (relative to cwd) when the var is unset or empty.
+fn default_sim_build_dir() -> PathBuf {
+    std::env::var_os("ARCH_SIM_BUILD_DIR")
+        .filter(|s| !s.is_empty())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("arch_sim_build"))
+}
+
 /// `--thread-sim both` driver: build + run fsm and parallel sims
 /// independently with --debug, then diff their port-change traces.
 /// Mismatch ⇒ abort with the first divergence highlighted.
@@ -1442,7 +1455,7 @@ fn run_thread_sim_cross_check(
 ) -> miette::Result<()> {
     let base = outdir
         .map(|p| p.to_path_buf())
-        .unwrap_or_else(|| PathBuf::from("arch_sim_build"));
+        .unwrap_or_else(default_sim_build_dir);
     let fsm_dir = base.with_file_name(format!(
         "{}_fsm",
         base.file_name()
@@ -1635,7 +1648,7 @@ fn run_sim_opts(
     // 2. Set up output directory
     let build_dir = outdir
         .map(|p| p.to_path_buf())
-        .unwrap_or_else(|| PathBuf::from("arch_sim_build"));
+        .unwrap_or_else(default_sim_build_dir);
     fs::create_dir_all(&build_dir).into_diagnostic()?;
 
     // 3. Generate C++ models


### PR DESCRIPTION
## What

`arch sim` hardcoded its default output directory to `arch_sim_build/` in the cwd whenever `--outdir` wasn't passed, so every bare sim run — including agent/MCP-driven ones, which run with `cwd = repo root` — dropped a build dir in the working tree. (This is what produced the ~34 `*_build` dirs recently cleaned up.)

This adds a `default_sim_build_dir()` helper that reads the `ARCH_SIM_BUILD_DIR` env var, wired into both default sites (`run_sim_opts` and the `--thread-sim both` cross-check driver).

## Precedence

```
outdir =
  --outdir flag        (if given)
  else $ARCH_SIM_BUILD_DIR (if set and non-empty)
  else "arch_sim_build"    (cwd — today's behavior)
```

Fully backward-compatible: with the env var unset or empty, behavior is identical to before. Export `ARCH_SIM_BUILD_DIR=/tmp/arch_sim` (or any scratch path) to keep build artifacts out of the repo.

## Scope

Tooling/CLI change only — **no language syntax or semantics touched**. Name is `ARCH_SIM_BUILD_DIR` (not `ARCH_BUILD_DIR`) because it controls only the sim build/scratch dir; `arch build` writes SV next to source and is unaffected.

## Testing

- Manual precedence matrix verified end-to-end (flag > env > default; empty env falls back; no cwd leak when env set).
- `cargo test --release`: **647 pass** (46 lib + 601 integration). The only failures are 2 pre-existing `formal_test` Lean-proof cases that require a built `.lake/` olean (absent in a fresh worktree) — unrelated to this diff, which touches only `src/main.rs` sim-outdir.

Docs updated: `ONBOARDING_CHEATSHEET.md`, `Arch_AI_Reference_Card.md`, `arch_sim_cocotb.md`.