### PR TITLE
Async-clock CDC bridge (NIC-400) + fix dual-clock FIFO sub-instance sim

### DIFF
--- a/examples/nic400/Nic400ArCdcFifo.arch
+++ b/examples/nic400/Nic400ArCdcFifo.arch
@@ -1,0 +1,29 @@
+// AR-channel clock-domain-crossing FIFO for the NIC-400 async bridge.
+//
+// Write port in the master domain (MClkDom), read port in the slave domain
+// (SClkDom). The two differing Clock<...> domains make the compiler
+// auto-synthesise gray-code pointer synchronisers — the legal way to move a
+// multi-bit word between unrelated clocks. Payload is the full AXI4 AR channel
+// packed into one 64-bit word (see Nic400CdcAxi4 for the field layout).
+
+domain MClkDom
+  freq_mhz: 200
+end domain MClkDom
+
+domain SClkDom
+  freq_mhz: 100
+end domain SClkDom
+
+fifo Nic400ArCdcFifo
+  param DEPTH: const = 8;
+  param T: type = UInt<64>;
+  port wr_clk: in Clock<MClkDom>;
+  port rd_clk: in Clock<SClkDom>;
+  port rst: in Reset<Async, Low>;
+  port push_valid: in Bool;
+  port push_ready: out Bool;
+  port push_data: in T;
+  port pop_valid: out Bool;
+  port pop_ready: in Bool;
+  port pop_data: out T;
+end fifo Nic400ArCdcFifo

--- a/examples/nic400/Nic400CdcAxi4.arch
+++ b/examples/nic400/Nic400CdcAxi4.arch
@@ -1,0 +1,112 @@
+// NIC-400 asynchronous clock-domain-crossing bridge (AXI4 read path).
+//
+// A master/slave pair operating in DIFFERENT clock domains: the master-facing
+// side runs on MClkDom, the slave-facing side on SClkDom. The two AXI4 read
+// channels cross the boundary through dual-clock async FIFOs, so the compiler
+// auto-synthesises gray-code pointer CDC — the only legal way to move a signal
+// between unrelated clocks.
+//
+//   m (MClkDom)  --AR-->  [ArCdcFifo]  --AR-->  s (SClkDom)
+//   m (MClkDom)  <--R---  [RCdcFifo]   <--R---  s (SClkDom)
+//
+// Each channel's fields are packed into one FIFO word (concat on the push
+// side, bit-select on the pop side); comb logic wires the valid/ready
+// handshakes. No thread/FSM is needed — the FIFOs hold all the crossing state.
+// ID_W=3 keeps the full AR field set at exactly 64 bits, the widest payload
+// the FIFO carries in a single 64-bit word.
+
+// The two crossing FIFOs live in their own files (one construct per file):
+//   Nic400ArCdcFifo.arch — AR channel, 64-bit payload, M->S
+//   Nic400RCdcFifo.arch  — R  channel, 38-bit payload, S->M
+// They are resolved by name at compile time (pass all three .arch files, or
+// rely on .archi auto-discovery in the same directory).
+
+domain MClkDom
+  freq_mhz: 200
+end domain MClkDom
+
+domain SClkDom
+  freq_mhz: 100
+end domain SClkDom
+
+module Nic400CdcAxi4
+  port m_clk: in Clock<MClkDom>;
+  port s_clk: in Clock<SClkDom>;
+  port rst:   in Reset<Async, Low>;
+
+  // Master-facing bus (master domain) and slave-facing bus (slave domain).
+  port m: target    BusAxi4<ADDR_W=32, DATA_W=32, STRB_W=4, ID_W=3, READ=1, WRITE=0>;
+  port s: initiator BusAxi4<ADDR_W=32, DATA_W=32, STRB_W=4, ID_W=3, READ=1, WRITE=0>;
+
+  // The whole-design comb-cycle detector treats the async-FIFO insts as
+  // combinationally transparent (push -> pop), so it reports a feedback loop
+  // m.ar -> ar_fifo -> s.ar ... -> r_fifo -> m.r. That loop is NOT real: both
+  // FIFOs register push_ready/pop_valid through the gray-code pointer
+  // synchronisers, so no combinational path crosses a FIFO. Verilator lints
+  // this design loop-free. Bless the false positive here.
+  pragma comb_loops_allowed;
+
+  // AR fields packed MSB->LSB into one 64-bit word (addr at the top, region
+  // at the bottom): addr32 id3 len8 size3 burst2 lock1 cache4 prot3 qos4 region4.
+  let ar_payload: UInt<64> = { m.ar_addr, m.ar_id, m.ar_len, m.ar_size,
+                               m.ar_burst, m.ar_lock, m.ar_cache, m.ar_prot,
+                               m.ar_qos, m.ar_region };
+  // R fields packed MSB->LSB into 38 bits: data32 id3 resp2 last1.
+  let r_payload: UInt<38> = { s.r_data, s.r_id, s.r_resp, s.r_last };
+
+  // FIFO output nets (driven by the inst outputs, read in comb).
+  wire ar_push_ready: Bool;
+  wire ar_pop_valid:  Bool;
+  wire ar_pop:        UInt<64>;
+  wire r_push_ready:  Bool;
+  wire r_pop_valid:   Bool;
+  wire r_pop:         UInt<38>;
+
+  inst ar_fifo: Nic400ArCdcFifo
+    wr_clk     <- m_clk;
+    rd_clk     <- s_clk;
+    rst        <- rst;
+    push_valid <- m.ar_valid;
+    push_ready -> ar_push_ready;
+    push_data  <- ar_payload;
+    pop_valid  -> ar_pop_valid;
+    pop_ready  <- s.ar_ready;
+    pop_data   -> ar_pop;
+  end inst ar_fifo
+
+  inst r_fifo: Nic400RCdcFifo
+    wr_clk     <- s_clk;
+    rd_clk     <- m_clk;
+    rst        <- rst;
+    push_valid <- s.r_valid;
+    push_ready -> r_push_ready;
+    push_data  <- r_payload;
+    pop_valid  -> r_pop_valid;
+    pop_ready  <- m.r_ready;
+    pop_data   -> r_pop;
+  end inst r_fifo
+
+  comb
+    // AR: master push handshake completion + slave-side drive (unpack).
+    m.ar_ready  = ar_push_ready;
+    s.ar_valid  = ar_pop_valid;
+    s.ar_addr   = ar_pop[63:32];
+    s.ar_id     = ar_pop[31:29];
+    s.ar_len    = ar_pop[28:21];
+    s.ar_size   = ar_pop[20:18];
+    s.ar_burst  = ar_pop[17:16];
+    s.ar_lock   = (ar_pop[15:15] == 1);
+    s.ar_cache  = ar_pop[14:11];
+    s.ar_prot   = ar_pop[10:8];
+    s.ar_qos    = ar_pop[7:4];
+    s.ar_region = ar_pop[3:0];
+
+    // R: slave push handshake completion + master-side drive (unpack).
+    s.r_ready   = r_push_ready;
+    m.r_valid   = r_pop_valid;
+    m.r_data    = r_pop[37:6];
+    m.r_id      = r_pop[5:3];
+    m.r_resp    = r_pop[2:1];
+    m.r_last    = (r_pop[0:0] == 1);
+  end comb
+end module Nic400CdcAxi4

--- a/examples/nic400/Nic400CdcAxi4_test.harc
+++ b/examples/nic400/Nic400CdcAxi4_test.harc
@@ -1,0 +1,153 @@
+// Nic400CdcAxi4 dual-clock CDC bridge testbench.
+//
+// DUT: examples/nic400/Nic400CdcAxi4.arch — an AXI4 read-path bridge whose
+// master side runs on MClkDom (200 MHz) and slave side on SClkDom (100 MHz),
+// with the AR and R channels crossing through dual-clock async FIFOs.
+//
+// The TB plays BOTH endpoints: the master (driving AR / accepting R on m_clk)
+// and the slave (accepting AR / driving R on s_clk). It verifies an AR issued
+// in the master domain arrives intact in the slave domain, and an R issued in
+// the slave domain arrives intact back in the master domain — i.e. both
+// channels cross the async clock boundary with their payloads preserved.
+//
+// Run with:
+//   harc sim --dut examples/nic400/BusAxi4.arch \
+//            --dut examples/nic400/Nic400ArCdcFifo.arch \
+//            --dut examples/nic400/Nic400RCdcFifo.arch \
+//            --dut examples/nic400/Nic400CdcAxi4.arch \
+//             examples/nic400/Nic400CdcAxi4_test.harc \
+//             --top Nic400CdcAxi4
+
+domain MClkDom
+  freq_mhz: 200
+end domain MClkDom
+
+domain SClkDom
+  freq_mhz: 100
+end domain SClkDom
+
+testbench Nic400CdcAxi4Tb
+    dut : Nic400CdcAxi4
+end testbench Nic400CdcAxi4Tb
+
+impl Nic400CdcAxi4Test for Nic400CdcAxi4Tb
+    clock m_clk = MClkDom     // 200 MHz primary (5 ns)
+    clock s_clk = SClkDom     // 100 MHz        (10 ns)
+
+    run
+        log(info, "Nic400 async-clock CDC bridge test (AR: M->S, R: S->M)")
+
+        // ── Reset (active-low) ───────────────────────────────────────────
+        dut.rst        = 0
+        dut.m_ar_valid = 0
+        dut.m_ar_addr  = 0
+        dut.m_ar_id    = 0
+        dut.m_ar_len   = 0
+        dut.m_ar_size  = 0
+        dut.m_ar_burst = 0
+        dut.m_ar_lock  = 0
+        dut.m_ar_cache = 0
+        dut.m_ar_prot  = 0
+        dut.m_ar_qos   = 0
+        dut.m_ar_region = 0
+        dut.m_r_ready  = 0
+        dut.s_ar_ready = 0
+        dut.s_r_valid  = 0
+        dut.s_r_data   = 0
+        dut.s_r_id     = 0
+        dut.s_r_resp   = 0
+        dut.s_r_last   = 0
+        wait 80ns
+        dut.rst = 1
+        wait 40ns
+
+        // ── Master issues one AR (master domain) ─────────────────────────
+        // Hold the slave accept side LOW so the crossed AR is *held* in the
+        // FIFO (pop_valid stays high) rather than draining on the next s_clk
+        // edge. This makes the observation independent of clock phase: a
+        // polling loop sampling at m_clk granularity is guaranteed to catch
+        // the steady valid. We pulse s_ar_ready to drain only after capture.
+        dut.s_ar_ready  = 0
+        dut.m_ar_addr   = 0x0000CAFE
+        dut.m_ar_id     = 3
+        dut.m_ar_len    = 0
+        dut.m_ar_size   = 2
+        dut.m_ar_burst  = 1
+        dut.m_ar_region = 5
+        dut.m_ar_valid  = 1
+        wait 5ns                 // one m_clk edge → one push into the AR FIFO
+        dut.m_ar_valid  = 0
+
+        // ── Verify AR crossed to the slave domain (poll, CDC latency) ────
+        let ar_seen : uint<32> = 0
+        let ar_addr : uint<32> = 0
+        let ar_id   : uint<32> = 0
+        let ar_rgn  : uint<32> = 0
+        for _ in 0 .. 60
+            wait 5ns
+            if dut.s_ar_valid == 1 && ar_seen == 0
+                ar_seen = 1
+                ar_addr = dut.s_ar_addr
+                ar_id   = dut.s_ar_id
+                ar_rgn  = dut.s_ar_region
+            end if
+        end for
+        assert ar_seen == 1
+            else fail("AR never crossed M->S through the async FIFO")
+        assert ar_addr == 0x0000CAFE
+            else fail("AR addr corrupted across CDC: got 0x${ar_addr:x}")
+        assert ar_id == 3
+            else fail("AR id corrupted across CDC: got ${ar_id}")
+        assert ar_rgn == 5
+            else fail("AR region (sideband) corrupted across CDC: got ${ar_rgn}")
+        log(info, "AR crossed M->S intact (addr=0x${ar_addr:x} id=${ar_id} region=${ar_rgn})")
+
+        // Accept the AR on the slave side (one s_clk cycle of ready).
+        dut.s_ar_ready = 1
+        wait 10ns
+        dut.s_ar_ready = 0
+
+        // ── Slave issues the R response (slave domain) ───────────────────
+        // Symmetric: hold the master accept side LOW so the crossed R is
+        // held in the FIFO until we have captured it.
+        dut.m_r_ready = 0
+        dut.s_r_data  = 0x0000D00D
+        dut.s_r_id    = 3
+        dut.s_r_resp  = 0
+        dut.s_r_last  = 1
+        dut.s_r_valid = 1
+        wait 10ns                // one s_clk edge → one push into the R FIFO
+        dut.s_r_valid = 0
+
+        // ── Verify R crossed back to the master domain ───────────────────
+        let r_seen : uint<32> = 0
+        let r_data : uint<32> = 0
+        let r_id   : uint<32> = 0
+        let r_last : uint<32> = 0
+        for _ in 0 .. 60
+            wait 5ns
+            if dut.m_r_valid == 1 && r_seen == 0
+                r_seen = 1
+                r_data = dut.m_r_data
+                r_id   = dut.m_r_id
+                r_last = dut.m_r_last
+            end if
+        end for
+        assert r_seen == 1
+            else fail("R never crossed S->M through the async FIFO")
+        assert r_data == 0x0000D00D
+            else fail("R data corrupted across CDC: got 0x${r_data:x}")
+        assert r_id == 3
+            else fail("R id corrupted across CDC: got ${r_id}")
+        assert r_last == 1
+            else fail("R last corrupted across CDC: got ${r_last}")
+        log(info, "R crossed S->M intact (data=0x${r_data:x} id=${r_id} last=${r_last})")
+
+        // Accept the R on the master side.
+        dut.m_r_ready = 1
+        wait 5ns
+        dut.m_r_ready = 0
+
+        log(info, "PASS Nic400CdcAxi4: AR M->S and R S->M both crossed the async clock boundary intact")
+    end run
+end impl Nic400CdcAxi4Test

--- a/examples/nic400/Nic400RCdcFifo.arch
+++ b/examples/nic400/Nic400RCdcFifo.arch
@@ -1,0 +1,28 @@
+// R-channel clock-domain-crossing FIFO for the NIC-400 async bridge.
+//
+// The reverse direction of Nic400ArCdcFifo: write port in the slave domain
+// (SClkDom), read port in the master domain (MClkDom). The differing
+// Clock<...> domains trigger gray-code pointer CDC. Payload is the AXI4 R
+// channel packed into 38 bits (see Nic400CdcAxi4 for the field layout).
+
+domain MClkDom
+  freq_mhz: 200
+end domain MClkDom
+
+domain SClkDom
+  freq_mhz: 100
+end domain SClkDom
+
+fifo Nic400RCdcFifo
+  param DEPTH: const = 8;
+  param T: type = UInt<38>;
+  port wr_clk: in Clock<SClkDom>;
+  port rd_clk: in Clock<MClkDom>;
+  port rst: in Reset<Async, Low>;
+  port push_valid: in Bool;
+  port push_ready: out Bool;
+  port push_data: in T;
+  port pop_valid: out Bool;
+  port pop_ready: in Bool;
+  port pop_data: out T;
+end fifo Nic400RCdcFifo

--- a/examples/nic400/README.md
+++ b/examples/nic400/README.md
@@ -99,6 +99,14 @@ Nic400Read2x2 — older 2×2 read-only crossbar (predates Nic400Fabric).
 - **`Nic400ApbBridge.arch`** — AXI4 target → APB initiator. Two threads sharing APB drives via `apb_lock`. Splits AXI bursts into sequential APB Setup → Access phases. Per-beat `paddr = base + (b << size)`.
 - **`Nic400WidthAdapter.arch`** — AXI4 downsize adapter (`M_DATA_W` > `S_DATA_W`). 5 per-channel threads. Master beats split into RATIO little-endian slave sub-beats; reads pack RATIO slave beats into one master beat with OR-reduced `r_resp`.
 
+### Clock-domain crossing (async master/slave)
+
+- **`Nic400CdcAxi4.arch`** — AXI4 read-path bridge whose master side runs on `MClkDom` (200 MHz) and slave side on `SClkDom` (100 MHz). The AR (M→S) and R (S→M) channels each cross the boundary through a dual-clock async FIFO; the compiler auto-synthesises gray-code pointer CDC because each FIFO's `wr_clk`/`rd_clk` reference different domains. Each channel's fields are packed into one FIFO word (concat on push, bit-select on pop) — `comb` wires the valid/ready handshakes, no thread/FSM needed. `pragma comb_loops_allowed` blesses the false whole-design comb-cycle report (both FIFOs register through the pointer synchronisers; Verilator lints loop-free).
+- **`Nic400ArCdcFifo.arch`** — AR-channel crossing FIFO. Write port `MClkDom`, read port `SClkDom`; 64-bit packed AR payload (`addr32 id3 len8 size3 burst2 lock1 cache4 prot3 qos4 region4`).
+- **`Nic400RCdcFifo.arch`** — R-channel crossing FIFO (reverse direction). Write port `SClkDom`, read port `MClkDom`; 38-bit packed R payload (`data32 id3 resp2 last1`).
+
+Verified with `Nic400CdcAxi4_test.harc` (a dual-clock HARC testbench that drives both endpoints): AR crosses M→S and R crosses S→M with payloads intact, on both the ARCH native sim and the Verilator backend, with matching cross-backend traces (`harc sim --check-backends`).
+
 ### Observability
 
 - **`Nic400Pmu.arch`** — performance monitor counters. Per-master AR/AW/R/W/B counters, `COUNTER_W`-wide (default 32). Inputs are pre-qualified one-cycle event pulses (typically `m[i].x_valid && m[i].x_ready`). `r`/`w` count beats; `ar`/`aw`/`b` count transactions.

--- a/src/sim_codegen/fifo.rs
+++ b/src/sim_codegen/fifo.rs
@@ -17,19 +17,31 @@ impl<'a> SimCodegen<'a> {
             .and_then(|e| if let ExprKind::Literal(LitKind::Dec(v)) = &e.kind { Some(*v) } else { None })
             .unwrap_or(8);
 
-        let elem_ty: String = f.params.iter()
-            .find(|p| p.name.name == "TYPE")
-            .and_then(|p| if let ParamKind::Type(te) = &p.kind { Some(te) } else { None })
-            .map(|te| cpp_internal_type_with_params(te, &f.params))
-            .unwrap_or_else(|| "uint32_t".to_string());
-
-        let (rst_name, _is_async, is_low) = extract_reset_info(&f.ports);
-        let rst_cond = if is_low { format!("(!{rst_name})") } else { rst_name.clone() };
-
         // Build type-param substitution: param name → concrete TypeExpr (from default)
         let type_param_map: std::collections::HashMap<String, TypeExpr> = f.params.iter()
             .filter_map(|p| if let ParamKind::Type(te) = &p.kind { Some((p.name.name.clone(), te.clone())) } else { None })
             .collect();
+
+        // Internal storage (`_mem`) element type = the resolved payload type,
+        // taken from the `push_data` port. The payload type param is named by
+        // the user (commonly `T`), not literally "TYPE", so the previous
+        // `.find(name == "TYPE")` never matched and `_mem` always fell back to
+        // `uint32_t` — silently truncating payloads wider than 32 bits and
+        // type-mismatching struct payloads.
+        let elem_ty: String = f.ports.iter()
+            .find(|p| p.name.name == "push_data")
+            .or_else(|| f.ports.iter().find(|p| p.name.name == "pop_data"))
+            .map(|p| {
+                let resolved: TypeExpr = match &p.ty {
+                    TypeExpr::Named(n) => type_param_map.get(&n.name).cloned().unwrap_or_else(|| p.ty.clone()),
+                    other => other.clone(),
+                };
+                cpp_internal_type_with_params(&resolved, &f.params)
+            })
+            .unwrap_or_else(|| "uint32_t".to_string());
+
+        let (rst_name, _is_async, is_low) = extract_reset_info(&f.ports);
+        let rst_cond = if is_low { format!("(!{rst_name})") } else { rst_name.clone() };
         // Resolve a port's TypeExpr, substituting Named types that match type params
         let resolve_port_ty = |ty: &TypeExpr| -> String {
             if let TypeExpr::Named(n) = ty {
@@ -159,8 +171,23 @@ impl<'a> SimCodegen<'a> {
             cpp.push_str("    _rd_ptr++;\n");
             cpp.push_str(&format!("    if (_rd_ptr >= 2u * {depth}) _rd_ptr = 0;\n  }}\n"));
             cpp.push_str("}\n\n");
-            // Keep the standard eval_posedge symbol for ABI parity (unused).
-            cpp.push_str(&format!("void {class}::eval_posedge() {{}}\n\n"));
+            // eval_posedge() — self-gating dual-clock entry point. A parent
+            // module drives a sub-instance by calling _inst_X.eval_posedge()
+            // (the sim_codegen convention); it never calls eval()/eval_posedge_dual
+            // directly. So eval_posedge() must do its OWN per-side edge detection
+            // (against the clocks the parent mirrored in just before) and dispatch
+            // to eval_posedge_dual. Without this, a dual-clock async FIFO used as a
+            // sub-instance would never advance its pointers — push works, pop never
+            // fires. The top-DUT path is unaffected: eval() calls eval_posedge_dual
+            // directly and owns _clk_prev_wr/_clk_prev_rd, while the sub-instance
+            // path only ever calls eval_comb()/eval_posedge(); the two never mix.
+            cpp.push_str(&format!("void {class}::eval_posedge() {{\n"));
+            cpp.push_str("  bool _wr_rising = (wr_clk && !_clk_prev_wr);\n");
+            cpp.push_str("  bool _rd_rising = (rd_clk && !_clk_prev_rd);\n");
+            cpp.push_str("  _clk_prev_wr = wr_clk;\n");
+            cpp.push_str("  _clk_prev_rd = rd_clk;\n");
+            cpp.push_str("  if (_wr_rising || _rd_rising) eval_posedge_dual(_wr_rising, _rd_rising);\n");
+            cpp.push_str("}\n\n");
         } else {
             // eval_posedge() — single-clock path. Self-gates on rising
             // edge so the parent's unconditional call is safe.

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -379,6 +379,80 @@ fn test_async_fifo() {
     insta::assert_snapshot!(sv);
 }
 
+/// Regression: a dual-clock (async) FIFO used as a SUB-INSTANCE must still
+/// advance its read/write pointers in arch sim. The sim-codegen convention is
+/// that a parent module drives each sub-instance by calling
+/// `_inst_X.eval_posedge()` — it never calls the sub-instance's `eval()` or
+/// `eval_posedge_dual()` directly. The async FIFO previously emitted an EMPTY
+/// `eval_posedge() {}` (with all the sequential logic only reachable from
+/// `eval()`), so a sub-instanced async FIFO never pushed/popped: push side
+/// looked ready, but pop never fired and no data ever crossed the boundary.
+/// `eval_posedge()` must self-gate on its own per-side clock edges and
+/// dispatch to `eval_posedge_dual`.
+///
+/// Also guards the `_mem` element-type width: the payload type param is named
+/// by the user (here `T`), not literally "TYPE", so a wide payload must lower
+/// to the matching C++ integer type (`uint64_t` for `UInt<64>`), not a
+/// silently-truncating `uint32_t`.
+#[test]
+fn test_async_fifo_subinstance_eval_posedge_and_mem_width() {
+    let source = r#"
+domain MDom
+  freq_mhz: 200
+end domain MDom
+
+domain SDom
+  freq_mhz: 100
+end domain SDom
+
+fifo WideAsyncFifo
+  param DEPTH: const = 8;
+  param T: type = UInt<64>;
+  port wr_clk: in Clock<MDom>;
+  port rd_clk: in Clock<SDom>;
+  port rst: in Reset<Async, Low>;
+  port push_valid: in Bool;
+  port push_ready: out Bool;
+  port push_data: in T;
+  port pop_valid: out Bool;
+  port pop_ready: in Bool;
+  port pop_data: out T;
+end fifo WideAsyncFifo
+"#;
+    let sim = compile_to_sim_h(source, false);
+
+    // eval_posedge() must dispatch to the dual-clock handler, NOT be an empty
+    // stub. (Match flexibly on whitespace by checking the dispatch call is
+    // present and an empty body is absent.)
+    assert!(
+        sim.contains("eval_posedge_dual(_wr_rising, _rd_rising)"),
+        "async FIFO eval_posedge_dual dispatch missing from sim codegen:\n{sim}"
+    );
+    assert!(
+        !sim.contains("::eval_posedge() {}"),
+        "async FIFO eval_posedge() must not be an empty stub (sub-instances \
+         would never advance their pointers):\n{sim}"
+    );
+    // The self-gating edge detection must live inside eval_posedge() so a
+    // parent's unconditional `_inst_X.eval_posedge()` call works.
+    assert!(
+        sim.contains("void VWideAsyncFifo::eval_posedge()"),
+        "expected a non-trivial eval_posedge() for the async FIFO:\n{sim}"
+    );
+
+    // _mem must be the full-width payload type, not a truncating uint32_t.
+    assert!(
+        sim.contains("uint64_t _mem["),
+        "async FIFO _mem must use uint64_t for a UInt<64> payload (the type \
+         param is named `T`, not \"TYPE\"); got truncating storage:\n{sim}"
+    );
+    assert!(
+        !sim.contains("uint32_t _mem["),
+        "async FIFO _mem must NOT fall back to uint32_t for a UInt<64> \
+         payload:\n{sim}"
+    );
+}
+
 #[test]
 fn test_fifo_missing_port_errors() {
     let source = r#"


### PR DESCRIPTION
## Summary

Implements **multi async-clock support for a master/slave pair**: a NIC-400 AXI4 read-path bridge whose master side runs on `MClkDom` (200 MHz) and slave side on `SClkDom` (100 MHz). The AR (M→S) and R (S→M) channels each cross the async clock boundary through a dual-clock async FIFO, so the compiler auto-synthesises gray-code pointer CDC.

Building it surfaced **two genuine sim-codegen bugs**, fixed here. Both are internal codegen-only changes — no user-facing syntax, type rules, or lowering-at-the-surface changes.

## Compiler fixes (`src/sim_codegen/fifo.rs`)

1. **Dual-clock async FIFO as a sub-instance never advanced its pointers.**
   The sim convention is that a parent module drives each sub-instance via `_inst_X.eval_posedge()` — it never calls the child's `eval()` / `eval_posedge_dual()`. The async FIFO emitted an **empty** `eval_posedge() {}` (all sequential logic reachable only from `eval()`), so a sub-instanced async FIFO looked push-ready but never pushed/popped and **no data ever crossed the boundary**. `eval_posedge()` now self-gates on its own per-side clock edges and dispatches to `eval_posedge_dual`, mirroring the existing sync-FIFO design. The top-DUT path is unchanged.

2. **`_mem` element type silently fell back to `uint32_t`.** The storage-type lookup keyed on a param literally named `"TYPE"`, but the payload type param is user-named (commonly `T`), so it never matched — truncating any payload wider than 32 bits and type-mismatching struct payloads. Storage type is now derived from the resolved `push_data` port (`UInt<64>` → `uint64_t`).

## New example (one construct per file)

- `examples/nic400/Nic400CdcAxi4.arch` — the bridge module (packs each channel into one FIFO word; `comb` wires valid/ready; `pragma comb_loops_allowed` blesses the false whole-design comb-cycle report — Verilator lints loop-free).
- `examples/nic400/Nic400ArCdcFifo.arch` — AR crossing FIFO (64-bit payload, M→S).
- `examples/nic400/Nic400RCdcFifo.arch` — R crossing FIFO (38-bit payload, S→M).
- `examples/nic400/Nic400CdcAxi4_test.harc` — dual-clock HARC TB driving both endpoints.
- README file-index entry.

## Verification

- **HARC co-sim (`harc sim --dut`)**: AR crosses M→S and R crosses S→M with payloads intact.
- **Verilator backend + cross-backend parity (`harc sim --check-backends`)**: both backends PASS and **traces match (no divergence)** — the sim↔SV parity invariant holds.
- **Verilator lint-clean.**
- **New cargo regression test** `test_async_fifo_subinstance_eval_posedge_and_mem_width` guards both codegen fixes.
- **Full `cargo test` green** (the 2 pre-existing `formal_test` Lean construct-proof failures are environment-only — the Lean proof lib isn't built in this worktree — and are unrelated to this change; verified they fail identically on a clean tree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)