### PR TITLE
fix(comb_graph): keep arbiter/cam/regfile opaque in comb-loop detector (soundness regression from #545)

### DIFF
--- a/src/comb_graph.rs
+++ b/src/comb_graph.rs
@@ -619,6 +619,35 @@ fn comb_info_for_ram(ram: &RamDecl) -> CombInfo {
     }
 }
 
+/// Whether a non-Module/non-Fsm construct's `comb_info_for_symbol` SOUNDLY
+/// models its combinational input→output paths, so the whole-design comb-loop
+/// detector may take the non-opaque path for it (using its `CombInfo`) instead
+/// of the opaque every-input→every-output over-approximation.
+///
+/// Returns `true` ONLY for constructs whose `comb_info_for_symbol` is either
+/// genuinely PURE (all outputs registered) or latency-aware/conservative:
+///   * `fifo` / `counter` / `synchronizer` / `pipeline` — registered outputs.
+///   * `ram` — `comb_info_for_ram` is latency-aware (PURE for latency>0, a
+///     conservative comb-dep set for latency-0).
+///
+/// Returns `false` for every other construct (arbiter, cam, regfile, clkgate,
+/// linklist, …) because each has — or may have — a real combinational
+/// input→output path that `comb_info_for_symbol` currently reports as an
+/// empty (PURE) `CombInfo`. Modeling those as PURE is UNSOUND: it drops real
+/// comb cycles routed through them (a false negative). They must fall back to
+/// the opaque over-approximation. See the call site in `expand_inst` for the
+/// per-construct combinational-path rationale.
+fn construct_comb_info_is_sound(sym: &Symbol) -> bool {
+    matches!(
+        sym,
+        Symbol::Fifo(_)
+            | Symbol::Counter(_)
+            | Symbol::Synchronizer(_)
+            | Symbol::Pipeline(_)
+            | Symbol::Ram(_)
+    )
+}
+
 /// Look up the `CombInfo` for an instance whose construct is named `sym_name`.
 pub fn comb_info_for_symbol(sym_name: &str, symbols: &SymbolTable, source: &SourceFile) -> CombInfo {
     let sym = match symbols.globals.get(sym_name) {
@@ -1180,19 +1209,53 @@ impl GraphBuilder {
         }
 
         // Is the inst a KNOWN first-class construct that is neither a
-        // Module nor an Fsm (fifo, ram, arbiter, counter, synchronizer,
-        // clkgate, regfile, …)? Such a construct has no `ModuleDecl`/
-        // `FsmDecl` (so `child_mod`/`child_fsm` are both `None`), yet it
-        // IS resolvable in the symbol table and `comb_info_for_symbol`
-        // already returns a construct-aware `CombInfo` for it:
-        //   * fifo/arbiter/counter/synchronizer/clkgate/regfile and
-        //     latency>0 ram → `CombInfo::default()` (PURE — outputs are
-        //     all functions of internal registered state, no comb path
-        //     from any input to any output).
-        //   * latency-0 (async) ram → a real per-port comb-dep set.
+        // Module nor an Fsm, AND one whose `comb_info_for_symbol` SOUNDLY
+        // models its input→output combinational paths? Such a construct
+        // has no `ModuleDecl`/`FsmDecl` (so `child_mod`/`child_fsm` are
+        // both `None`), yet it is resolvable in the symbol table.
+        //
+        // CRUCIAL soundness caveat: a whole-design comb-loop detector must
+        // OVER-approximate — it may report a spurious cycle, but it must
+        // NEVER miss a real one. Routing an inst through the non-opaque
+        // path uses its `comb_info_for_symbol` `CombInfo`; if that
+        // `CombInfo` is empty (PURE) for a construct that actually HAS a
+        // combinational input→output path, the detector silently drops
+        // real cycles routed through it (a false NEGATIVE — unsound).
+        //
+        // Only these constructs may take the non-opaque path, because for
+        // them `comb_info_for_symbol` is provably sound:
+        //   * fifo / counter / synchronizer / pipeline → `CombInfo`
+        //     empty (PURE): outputs are all functions of internal
+        //     registered state, no comb path from any input to any output.
+        //   * ram → `comb_info_for_ram`, which is latency-aware: empty
+        //     (PURE) for latency>0, a conservative per-port comb-dep set
+        //     for latency-0 (async) ram (so async-RAM cycles are caught).
+        //
+        // DELIBERATELY EXCLUDED (must stay opaque): arbiter, cam, regfile,
+        // clkgate, linklist. Each has — or may have — a genuine
+        // combinational input→output path that `comb_info_for_symbol`
+        // currently reports as empty (PURE):
+        //   * arbiter — grant_valid/grant_requester/ready are driven in
+        //     `always_comb` from the request `valid` inputs (priority +
+        //     round-robin policies). A registered grant only exists for
+        //     latency>0 arbiters; the common latency-0 form is comb.
+        //   * cam — the match/hit outputs are a comb function of the
+        //     search key.
+        //   * regfile — a latency-0 (async-read) regfile drives read data
+        //     combinationally from the read address.
+        //   * clkgate — the gated clock is `clk & enable`, comb on enable.
+        //   * linklist — opaque internals; default to the safe model.
+        // Modeling any of these as PURE manufactured a false NEGATIVE:
+        // e.g. `req -> arbiter.valid -> arbiter.ready (comb) -> req` is a
+        // real comb loop (Verilator: UNOPTFLAT) that went undetected.
+        // Falling back to the opaque every-connected-in→every-connected-out
+        // model (built directly from the connection map) is the sound
+        // over-approximation and matches the pre-#545 behavior for them.
         let symbol_is_known_construct = child_mod.is_none()
             && child_fsm.is_none()
-            && symbols.globals.contains_key(&inst.module_name.name);
+            && symbols.globals.get(&inst.module_name.name)
+                .map(|(sym, _)| construct_comb_info_is_sound(sym))
+                .unwrap_or(false);
 
         // Treat the child as opaque (every-out-depends-on-every-in,
         // modulo any port-level `comb_dep_on(...)` annotations) when
@@ -1203,10 +1266,12 @@ impl GraphBuilder {
         // walker that produces precise per-output deps. Issue #246
         // Phase 3 = bodied module, Phase 4 = bodied fsm.
         //
-        // A known first-class construct (fifo/ram/arbiter/…) must NOT be
+        // A first-class construct whose `comb_info_for_symbol` is SOUND
+        // (`symbol_is_known_construct == true`: fifo/counter/synchronizer/
+        // pipeline/ram — see `construct_comb_info_is_sound`) must NOT be
         // modeled as combinationally transparent: its `child_is_interface`
         // is `None` only because it isn't a Module/Fsm decl, NOT because it
-        // is an unknown extern. Modeling a registered construct as
+        // is an unknown extern. Modeling such a registered construct as
         // every-input→every-output manufactures spurious comb edges — e.g.
         // routing signals through async `fifo` insts (an AXI CDC bridge:
         // `m.ar -> ar_fifo -> s.ar … s.r -> r_fifo -> m.r`) closes a false
@@ -1216,9 +1281,16 @@ impl GraphBuilder {
         // construct-aware `info` (`CombInfo` from `comb_info_for_symbol`):
         // empty for a fifo (→ no edges), but a real dep set for a
         // latency-0 ram (→ genuine async-RAM cycles are still caught).
+        //
+        // Constructs with a real comb input→output path but an empty
+        // `CombInfo` (arbiter/cam/regfile/clkgate/linklist) have
+        // `symbol_is_known_construct == false` and fall through to the
+        // opaque branch — the sound over-approximation that catches a comb
+        // loop routed through e.g. an arbiter's combinational grant.
         let treat_as_opaque = match child_is_interface {
-            // extern/unknown ⇒ opaque; known first-class construct ⇒ use
-            // its construct-aware CombInfo (`info`) instead.
+            // extern/unknown OR a construct whose CombInfo is not provably
+            // sound ⇒ opaque; a sound known construct ⇒ use its
+            // construct-aware CombInfo (`info`) instead.
             None => !symbol_is_known_construct,
             Some(is_iface) => is_iface,
         };

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -20946,6 +20946,73 @@ fn test_latency0_ram_in_real_cycle_still_flagged() {
     );
 }
 
+#[test]
+fn test_arbiter_inst_comb_grant_loop_still_detected() {
+    // Soundness guard for the comb-loop detector (regression for the over-
+    // correction in #545). An `arbiter`'s grant outputs — `grant_valid`,
+    // `grant_requester`, and the per-requester `ready` — are driven in
+    // `always_comb` from the request `valid` inputs (priority + round-robin
+    // policies). So there IS a real combinational path request → grant.
+    //
+    // #545 broadened "model fifo/ram as non-opaque" to ALL non-module/non-fsm
+    // constructs, which made `arbiter` use its empty (PURE) `CombInfo` and
+    // silently DROPPED real comb loops routed through an arbiter's grant — a
+    // false negative (Verilator flags the same design `UNOPTFLAT: Circular
+    // combinational logic`). This wires the priority arbiter's `ready` (grant)
+    // straight back into its `valid` request, forming a genuine 1-cycle comb
+    // loop that the whole-design detector must report as exactly one SCC.
+    let source = r#"
+        domain D
+          freq_mhz: 100
+        end domain D
+
+        arbiter PrioArb
+          policy priority;
+          param NUM_REQ: const = 2;
+          port clk: in Clock<D>;
+          port rst: in Reset<Sync>;
+          ports[NUM_REQ] request
+            valid: in Bool;
+            ready: out Bool;
+          end ports request
+          port grant_valid:     out Bool;
+          port grant_requester: out UInt<1>;
+        end arbiter PrioArb
+
+        module Top
+          port clk: in Clock<D>;
+          port rst: in Reset<Sync>;
+          port seed: in UInt<2>;
+          port gv: out Bool;
+          port gr: out UInt<1>;
+
+          wire req: UInt<2>;
+          wire rdy: UInt<2>;
+
+          inst a: PrioArb
+            clk             <- clk;
+            rst             <- rst;
+            request.valid   <- req;
+            request.ready   -> rdy;
+            grant_valid     -> gv;
+            grant_requester -> gr;
+          end inst a
+
+          comb
+            // req -> arb.valid -> arb.ready (comb grant) -> rdy -> req
+            req = rdy | seed;
+          end comb
+        end module Top
+    "#;
+    let wd = whole_design_from(source);
+    assert_eq!(
+        wd.total_sccs, 1,
+        "a real comb loop through an arbiter's combinational grant must be \
+         detected (no under-approximation); SCCs found: {:?}",
+        wd.sccs.iter().map(|s| &s.owning_modules).collect::<Vec<_>>()
+    );
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Issue #246 Phase 2: per-output `comb_dep_on(...)` annotation.
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

PR #545 fixed a genuine FIFO **false positive** in the whole-design
combinational-loop detector by routing every non-`module`/non-`fsm`
construct through its construct-aware `CombInfo` instead of the opaque
every-input→every-output over-approximation.

That fix was correct for `fifo`, but it **over-broadened**: it also routed
`arbiter`, `cam`, and (latency-0) `regfile` through the same path — and
`comb_info_for_symbol` returns an **empty (PURE) `CombInfo`** for those
constructs (the `_ => CombInfo::default()` arm). That is wrong: each of
them has a genuine **combinational input→output path**:

| Construct | Combinational path |
|---|---|
| `arbiter` | `grant_valid` / `grant_requester` / `ready` are driven in `always_comb` from the request `valid` inputs (priority + round-robin). Registered grant only exists for latency>0. |
| `cam` | match/hit outputs are a comb function of the search key. |
| `regfile` | a latency-0 (async-read) regfile drives read data combinationally from the read address. |
| `clkgate` | the gated clock is `clk & enable`, comb on enable. |

Modeling these as PURE made the detector **silently drop real comb cycles
routed through them — a false negative**. A comb-loop detector must
*over-approximate*: it may report a spurious cycle, but it must **never
miss a real one**. So #545 traded a FIFO false-positive for an
arbiter/cam/regfile **false-negative** — a soundness regression.

Ironically, #545's own title — "stop modeling fifo/ram/**arbiter** insts
as combinationally transparent" — names arbiter, but arbiter grant *is*
combinational, so treating it as transparent (opaque) was correct for it.

## Reproduction

```arch
arbiter PrioArb
  policy priority;
  param NUM_REQ: const = 2;
  ...
  ports[NUM_REQ] request
    valid: in Bool;
    ready: out Bool;
  end ports request
  ...
end arbiter PrioArb

module Top
  ...
  inst a: PrioArb
    request.valid <- req;
    request.ready -> rdy;
    ...
  end inst a
  comb
    req = rdy | seed;   // req -> arb.valid -> arb.ready (comb grant) -> rdy -> req
  end comb
end module Top
```

This is a genuine 1-cycle combinational loop.

- **Parent #544 (pre-#545):** `warning: whole-design combinational feedback cycle ... cycle: rdy -> req -> rdy` ✔ detected
- **#545 (HEAD):** `OK: no errors` ✗ missed
- **Verilator on the generated SV:** `%Warning-UNOPTFLAT: Signal unoptimizable: Circular combinational logic: 'Top.req'` ✔ confirms the loop is real

## Fix

Gate the non-opaque path on a new `construct_comb_info_is_sound` allowlist.
Only constructs whose `comb_info_for_symbol` is provably sound take the
non-opaque path:

- `fifo` / `counter` / `synchronizer` / `pipeline` — registered outputs → empty `CombInfo` (PURE) is correct.
- `ram` — `comb_info_for_ram` is latency-aware (PURE for latency>0, conservative comb-dep set for latency-0).

`arbiter` / `cam` / `regfile` / `clkgate` / `linklist` fall back to the
**sound opaque over-approximation**, built directly from the connection
map (so no port-name-matching fragility for `ports[N]` array constructs).
This exactly matches the pre-#545 behavior for those constructs.

The #545 FIFO fix and its three regression tests are **fully preserved**;
the NIC-400 CDC bridge still type-checks clean with no `pragma`.

This is an **internal detector-only change**: no user-facing syntax or
semantics change.

## Regression test (`tests/integration_test.rs`)

- `test_arbiter_inst_comb_grant_loop_still_detected` — a real comb loop
  through a priority arbiter's combinational grant is reported as exactly
  one SCC (proves no under-approximation).

## Verification

- `arch check` on the arbiter-loop fixture: cycle now reported (was
  silently dropped); Verilator confirms `UNOPTFLAT` on the same SV.
- NIC-400 CDC bridge (`Nic400CdcAxi4` + AR/R FIFOs) and `dma_engine.arch`:
  still clean, no false positive.
- Full `examples/` sweep: **no new comb-cycle warnings** introduced
  (the pre-existing `Nic400Read2x2` thread-lowering self-loops are
  unchanged by this PR).
- `cargo test`: **608 integration + 46 lib tests green**. The 2
  `formal_test` Lean construct-proof failures are pre-existing
  environment-only (the `ArchConstructProof.olean` proof lib isn't built
  in a fresh worktree) and unrelated — they fail identically on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)