### PR TITLE
feat(typecheck): reject combinational input→output passthrough in pipelines

### DIFF
--- a/doc/ARCH_HDL_Specification.md
+++ b/doc/ARCH_HDL_Specification.md
@@ -1535,6 +1535,21 @@ Each stage has a compiler-generated `valid_r` register that tracks whether the s
 
 > ◈ stall, flush, and forward are declarative. The compiler generates all enable signals, bubble insertion logic, and bypass muxes. The designer describes intent; the compiler generates mechanism.
 
+**6.2 Pipeline outputs must be registered (no combinational input→output path)**
+
+A pipeline output port may **not** combinationally depend on an input port --- neither directly (`comb out = in;`) nor transitively through a `let`/`wire`/comb intermediate or an `if`/`match` guard (`let t = in + 1; ... out = t;`). Every output must be driven from a **stage register**; reading a register, whether local (`out = result;`) or cross-stage (`out_pc = Fetch.pc;`), breaks the combinational path and is the intended pattern (see §6.1, where `out_pc`/`out_instr` come from `Fetch.pc`).
+
+This is enforced --- `arch check` rejects a combinational passthrough:
+
+```
+pipeline P output port `out` is driven combinationally from input port `in`;
+a pipeline output must come from a stage register, not a combinational path
+through an input. Move the combinational logic into a wrapping module and
+register the result in the pipeline.
+```
+
+Two reasons. First, intent: a `pipeline` *stages* a datapath --- it registers data as it advances --- so a pure combinational relay defeats the construct's purpose and belongs in a `module`. Second, soundness: the whole-design combinational-loop checker models a pipeline instance as having registered (combinationally pure) outputs, so a real comb input→output path *inside* a pipeline would let a feedback loop routed through it escape detection. Forbidding the path at the source keeps that model honest by construction. If you need combinational logic at the boundary, wrap the pipeline in a `module` that does the combinational work and feeds the pipeline, which then registers the result.
+
 **7. First-Class Construct: fsm**
 
 An fsm block declares a finite state machine with named states and exhaustive coverage enforced by the compiler. Missing transitions, undriven outputs in any state, and unreachable states are all compile-time errors.

--- a/doc/Arch_AI_Reference_Card.md
+++ b/doc/Arch_AI_Reference_Card.md
@@ -423,6 +423,16 @@ through intermediate registers — rejected at typecheck. Forward reads
 (Decode → Execute for hazard checks) and references inside `stall when` /
 `flush when` / `forward` clauses are allowed.
 
+**Output rule:** a pipeline output port must come from a stage **register**; it
+may not combinationally depend on an input port — directly (`comb out = in;`)
+or transitively via a `let`/`wire`/comb intermediate or `if`/`match` guard.
+Reading a register (local `out = result;` or cross-stage `out = Fetch.pc;`)
+is the intended pattern and breaks the comb path. A combinational passthrough
+is rejected at typecheck — put that logic in a wrapping `module` and let the
+pipeline register the result. (Rationale: a pipeline *stages* a datapath, and
+the comb-loop checker treats pipeline outputs as registered, so an internal
+comb input→output path would hide a real feedback loop.)
+
 `flush <Stage> when <cond>` clears `valid_r` only (bubble). Add the
 `clear` modifier to also reset every data register in `<Stage>` to its
 declared reset value — useful for security / speculation scenarios where

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -5717,6 +5717,163 @@ impl<'a> TypeChecker<'a> {
                 });
             }
         }
+
+        // A `pipeline` exists to stage a datapath: every output must come from
+        // a stage register, never from a combinational path through an input
+        // port. A comb passthrough (`comb out = in`, or `out = f(in)`, possibly
+        // via a `let`/`wire`) defeats the construct's purpose AND breaks a
+        // soundness assumption downstream — the whole-design comb-loop detector
+        // models a pipeline inst as having registered (PURE) outputs, so a real
+        // comb input→output path inside one would let a feedback loop routed
+        // through the pipeline go undetected (Verilator flags it `UNOPTFLAT`).
+        // Reject it here; the combinational logic belongs in a wrapping
+        // `module` whose result the pipeline then registers.
+        self.check_pipeline_no_comb_input_to_output(p);
+    }
+
+    /// Reject any `pipeline` output port that combinationally depends on an
+    /// input port (directly, or transitively through `let`/`wire`/comb
+    /// intermediates, including `if`/`match` guards). Reading a register —
+    /// local (`result`) or cross-stage (`Fetch.captured`) — is safe: that
+    /// breaks the comb path. See the call site for the rationale.
+    fn check_pipeline_no_comb_input_to_output(&mut self, p: &PipelineDecl) {
+        use std::collections::HashSet;
+        let input_ports: HashSet<String> = p.ports.iter()
+            .filter(|pt| pt.direction == Direction::In)
+            .map(|pt| pt.name.name.clone())
+            .collect();
+        let output_ports: HashSet<String> = p.ports.iter()
+            .filter(|pt| pt.direction == Direction::Out)
+            .map(|pt| pt.name.name.clone())
+            .collect();
+        if input_ports.is_empty() || output_ports.is_empty() {
+            return;
+        }
+
+        // Registers across all stages — reading one breaks the comb path, so a
+        // register name is never tainted (`Stage.reg` surfaces as the stage
+        // ident via `collect_expr_idents`, so cross-stage reg reads are safe
+        // too).
+        let mut reg_names: HashSet<String> = HashSet::new();
+        for stage in &p.stages {
+            for item in &stage.body {
+                match item {
+                    ModuleBodyItem::RegDecl(r) => { reg_names.insert(r.name.name.clone()); }
+                    ModuleBodyItem::PipeRegDecl(pr) => { reg_names.insert(pr.name.name.clone()); }
+                    _ => {}
+                }
+            }
+        }
+
+        // Every combinational driver: (target-base-name, idents-read, span).
+        // `idents-read` folds in the value plus any enclosing if/match guards.
+        let mut drivers: Vec<(String, HashSet<String>, crate::lexer::Span)> = Vec::new();
+        for stage in &p.stages {
+            for item in &stage.body {
+                match item {
+                    ModuleBodyItem::LetBinding(lb) => {
+                        let mut reads = HashSet::new();
+                        crate::comb_graph::collect_expr_idents(&lb.value, &mut reads);
+                        drivers.push((lb.name.name.clone(), reads, lb.name.span));
+                    }
+                    ModuleBodyItem::CombBlock(cb) => {
+                        Self::collect_pipeline_comb_drivers(&cb.stmts, &HashSet::new(), &mut drivers);
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        // Taint fixpoint: a signal is input-tainted if it reads an input port
+        // or another tainted signal (and isn't a register).
+        let mut tainted: HashSet<String> = input_ports.clone();
+        let mut changed = true;
+        while changed {
+            changed = false;
+            for (tgt, reads, _) in &drivers {
+                if reg_names.contains(tgt) || tainted.contains(tgt) {
+                    continue;
+                }
+                if reads.iter().any(|id| tainted.contains(id)) {
+                    tainted.insert(tgt.clone());
+                    changed = true;
+                }
+            }
+        }
+
+        // Flag output ports driven combinationally from a tainted expression.
+        for (tgt, reads, span) in &drivers {
+            if !output_ports.contains(tgt) {
+                continue;
+            }
+            let direct_input = reads.iter().find(|id| input_ports.contains(*id)).cloned();
+            let via = reads.iter()
+                .find(|id| tainted.contains(*id) && !input_ports.contains(*id))
+                .cloned();
+            let src_desc = match (&direct_input, &via) {
+                (Some(inp), _) => format!("input port `{inp}`"),
+                (None, Some(v)) => format!("`{v}` (combinationally derived from a pipeline input)"),
+                (None, None) => continue,
+            };
+            self.errors.push(CompileError::general(
+                &format!(
+                    "pipeline `{}` output port `{}` is driven combinationally from {}; a `pipeline` output must come from a stage register, not a combinational path through an input. Move the combinational logic into a wrapping `module` and register the result in the pipeline.",
+                    p.name.name, tgt, src_desc
+                ),
+                *span,
+            ));
+        }
+    }
+
+    /// Recursively collect `(target-base, idents-read, span)` for every
+    /// combinational assignment under `stmts`, threading enclosing `if`/`match`
+    /// guard idents into each driver's read set.
+    fn collect_pipeline_comb_drivers(
+        stmts: &[Stmt],
+        guards: &std::collections::HashSet<String>,
+        out: &mut Vec<(String, std::collections::HashSet<String>, crate::lexer::Span)>,
+    ) {
+        use crate::comb_graph::collect_expr_idents;
+        for s in stmts {
+            match s {
+                Stmt::Assign(a) => {
+                    if let Some(tgt) = Self::pipe_assign_base_name(&a.target) {
+                        let mut reads = guards.clone();
+                        collect_expr_idents(&a.value, &mut reads);
+                        out.push((tgt, reads, a.span));
+                    }
+                }
+                Stmt::IfElse(ie) => {
+                    let mut g = guards.clone();
+                    collect_expr_idents(&ie.cond, &mut g);
+                    Self::collect_pipeline_comb_drivers(&ie.then_stmts, &g, out);
+                    Self::collect_pipeline_comb_drivers(&ie.else_stmts, &g, out);
+                }
+                Stmt::Match(m) => {
+                    let mut g = guards.clone();
+                    collect_expr_idents(&m.scrutinee, &mut g);
+                    for arm in &m.arms {
+                        Self::collect_pipeline_comb_drivers(&arm.body, &g, out);
+                    }
+                }
+                Stmt::For(fl) => {
+                    Self::collect_pipeline_comb_drivers(&fl.body, guards, out);
+                }
+                _ => {}
+            }
+        }
+    }
+
+    /// The base port/signal name an assignment target writes — peels
+    /// `Index`/`BitSlice`/`PartSelect` wrappers off a partial assignment.
+    fn pipe_assign_base_name(e: &Expr) -> Option<String> {
+        match &e.kind {
+            ExprKind::Ident(n) => Some(n.clone()),
+            ExprKind::Index(b, _)
+            | ExprKind::BitSlice(b, _, _)
+            | ExprKind::PartSelect(b, _, _, _) => Self::pipe_assign_base_name(b),
+            _ => None,
+        }
     }
 
     // ── Linklist ──────────────────────────────────────────────────────────────

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -2663,6 +2663,116 @@ end pipeline BadPipe
     );
 }
 
+/// `arch check` accepts `source` (returns Ok) iff there are no type errors.
+fn pipeline_checks_ok(source: &str) -> bool {
+    let tokens = lexer::tokenize(source).expect("lex");
+    let mut parser = Parser::new(tokens, source);
+    let ast = parser.parse_source_file().expect("parse");
+    let elaborated = elaborate::elaborate(ast).expect("elaborate");
+    let symbols = resolve::resolve(&elaborated).expect("resolve");
+    let checker = arch::typecheck::TypeChecker::new(&symbols, &elaborated);
+    checker.check().is_ok()
+}
+
+// A `pipeline` output must come from a stage register, never a combinational
+// path through an input port. These three tests are differential: the ALLOW
+// case (output from a register) and the two REJECT cases (direct + via-let
+// comb passthrough) differ only in how the output is driven, so the delta
+// isolates exactly the new rule. Rationale: a comb input→output path inside a
+// pipeline is hidden from the whole-design comb-loop detector (which models a
+// pipeline inst as registered/PURE), so a feedback loop through it would go
+// undetected — Verilator flags the same SV `UNOPTFLAT`.
+
+#[test]
+fn test_pipeline_allows_comb_output_from_register() {
+    // `y = held` reads a stage REGISTER — no comb path from input `a` to
+    // output `y`. Must be accepted.
+    let source = r#"
+domain D
+  freq_mhz: 100
+end domain D
+pipeline RegPipe
+  port clk: in Clock<D>;
+  port rst: in Reset<Sync>;
+  port a: in UInt<8>;
+  port y: out UInt<8>;
+  stage S
+    reg held: UInt<8> reset rst => 0;
+    seq on clk rising
+      held <= a;
+    end seq
+    comb
+      y = held;
+    end comb
+  end stage S
+end pipeline RegPipe
+"#;
+    assert!(
+        pipeline_checks_ok(source),
+        "a pipeline output driven from a stage register must be accepted"
+    );
+}
+
+#[test]
+fn test_pipeline_rejects_comb_input_to_output_passthrough() {
+    // `y = a` drives an output straight from an input — direct comb passthrough.
+    let source = r#"
+domain D
+  freq_mhz: 100
+end domain D
+pipeline CombPipe
+  port clk: in Clock<D>;
+  port rst: in Reset<Sync>;
+  port a: in UInt<8>;
+  port y: out UInt<8>;
+  stage S
+    reg dummy: UInt<8> reset rst => 0;
+    seq on clk rising
+      dummy <= a;
+    end seq
+    comb
+      y = a;
+    end comb
+  end stage S
+end pipeline CombPipe
+"#;
+    assert!(
+        !pipeline_checks_ok(source),
+        "a pipeline output driven combinationally from an input must be rejected"
+    );
+}
+
+#[test]
+fn test_pipeline_rejects_comb_input_to_output_via_let() {
+    // Transitive: `let t = a + 1; ... y = t` — `t` carries the input
+    // combinationally into output `y`. Must be rejected (taint through let).
+    let source = r#"
+domain D
+  freq_mhz: 100
+end domain D
+pipeline LetPipe
+  port clk: in Clock<D>;
+  port rst: in Reset<Sync>;
+  port a: in UInt<8>;
+  port y: out UInt<8>;
+  stage S
+    let t: UInt<8> = a +% 1;
+    reg dummy: UInt<8> reset rst => 0;
+    seq on clk rising
+      dummy <= a;
+    end seq
+    comb
+      y = t;
+    end comb
+  end stage S
+end pipeline LetPipe
+"#;
+    assert!(
+        !pipeline_checks_ok(source),
+        "a pipeline output driven from a let that reads an input must be rejected"
+    );
+}
+
 #[test]
 fn test_pipeline_bad_flush_target_error() {
     let source = r#"


### PR DESCRIPTION
## Summary

Closes a real `arch check` **false-negative** in the comb-loop detector (surfaced while reviewing #548): a `pipeline` whose output is driven combinationally from an input hides a feedback loop from the whole-design checker — which models a pipeline instance as having registered/PURE outputs (the #546 allowlist). Verilator flags the same SV `UNOPTFLAT`, but `arch check` was silent.

Rather than teach the detector about pipeline comb passthroughs, this fixes it **at the source**: a `pipeline` exists to *stage* a datapath, so a combinational input→output passthrough is a misuse — it belongs in a wrapping `module`. Forbidding it makes "pipeline outputs are registered w.r.t. inputs" a real **invariant**, so the allowlist is sound by construction.

## Rule

A pipeline output port may not combinationally depend on an input port — directly (`comb out = in;`), or transitively through a `let`/`wire`/comb intermediate or an `if`/`match` guard. Reading a **register** — local (`out = result;`) or cross-stage (`out = Fetch.pc;`) — is unaffected (it breaks the comb path and is the intended pattern).

```
pipeline P output port `out` is driven combinationally from input port `in`;
a pipeline output must come from a stage register, not a combinational path
through an input. Move the combinational logic into a wrapping module and
register the result in the pipeline.
```

Implemented as a taint analysis over each pipeline's stage `comb`/`let` bodies (fixpoint through lets/wires; folds in `if`/`match` guard idents). Cross-stage register reads (`Fetch.pc`) collapse to the stage ident in `collect_expr_idents`, so they're correctly non-tainting — no false rejections.

## Verification

- **Repro confirmed both ways:** before, `comb y = a` in a pipeline closed in a loop → `arch check` `OK` but Verilator `%Error: circular logic`. After → `arch check` rejects it.
- **No legitimate pipeline breaks:** simple_pipeline, cpu_pipeline, pipeline_wait_stage, and the cvdp pipelined adder all still pass (their outputs come from registers).
- **Tests:** differential trio (`test_pipeline_allows_comb_output_from_register`, `..._rejects_comb_input_to_output_passthrough`, `..._rejects_comb_input_to_output_via_let`).
- Full `cargo test` green (lib 47 + integration 611).

## Spec

Updated `doc/ARCH_HDL_Specification.md` (new §6.2) and `doc/Arch_AI_Reference_Card.md` ("Output rule"). The binary `doc/*.docx` should be regenerated from the updated `.md`.

This is a **user-facing semantic change** (new compile error) — requested in-thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)