### PR TITLE
feat(nic400): Global Programmers View (GPV) AXI4-target config register file

### DIFF
--- a/examples/nic400/Nic400Gpv.arch
+++ b/examples/nic400/Nic400Gpv.arch
@@ -1,0 +1,110 @@
+// NIC-400 Global Programmers View (GPV) — the interconnect's configuration
+// register file, presented as an AXI4 *target* (slave).
+//
+// Per the NIC-400 TRM (§3.2): the GPV is AXI-accessed, 32-bit (AxSIZE=2) only,
+// Secure-only, non-cacheable, aligned, single-beat. This shim implements an
+// AXI4-Lite-style target (one outstanding read, one outstanding write) backed
+// by the Nic400GpvRegs register bank, and enforces the two access constraints:
+//
+//   * AxSIZE must be 2 (32-bit). A wrong size → SLVERR (resp = 0b10).
+//   * AxPROT[1] (the Non-secure bit) must be 0. A Non-secure access → DECERR
+//     (resp = 0b11). DECERR takes priority over SLVERR.
+//
+// A rejected write does not update the register bank; a rejected read returns
+// zero data with the error response. Word address bits [REG_AW+1:2] select the
+// register; the bank is REG_AW bits wide (NREGS = 1 << REG_AW).
+
+module Nic400Gpv
+  param REG_AW: const = 4;   // 16 registers
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+
+  // GPV is a 4 KB block (12-bit address), 32-bit data.
+  port s: target BusAxi4<ADDR_W=12, DATA_W=32, STRB_W=4, ID_W=4, READ=1, WRITE=1>;
+
+  // ── Read-response state (one outstanding) ────────────────────────────────
+  reg r_pending: Bool     reset rst => false;
+  reg r_data_r:  UInt<32> reset rst => 0;
+  reg r_resp_r:  UInt<2>  reset rst => 0;
+  reg r_id_r:    UInt<4>  reset rst => 0;
+
+  // ── Write-response state (one outstanding) ───────────────────────────────
+  reg b_pending: Bool     reset rst => false;
+  reg b_resp_r:  UInt<2>  reset rst => 0;
+  reg b_id_r:    UInt<4>  reset rst => 0;
+
+  // ── Access-constraint decode ─────────────────────────────────────────────
+  // AxPROT[1] = Non-secure bit (1 = Non-secure → DECERR). AxSIZE must be 2.
+  let ar_ns:    Bool = (s.ar_prot[1:1] == 1);
+  let ar_bad_sz: Bool = (s.ar_size != 2);
+  let ar_resp:  UInt<2> = ar_ns ? 3 : (ar_bad_sz ? 2 : 0);
+  let aw_ns:    Bool = (s.aw_prot[1:1] == 1);
+  let aw_bad_sz: Bool = (s.aw_size != 2);
+  let aw_resp:  UInt<2> = aw_ns ? 3 : (aw_bad_sz ? 2 : 0);
+
+  // Word-index decode (drop the 2 byte-offset bits).
+  let ar_index: UInt<4> = s.ar_addr[REG_AW+1:2];
+  let aw_index: UInt<4> = s.aw_addr[REG_AW+1:2];
+
+  // Handshake fires.
+  let ar_fire: Bool = s.ar_valid and (not r_pending);
+  let aw_w_fire: Bool = s.aw_valid and s.w_valid and (not b_pending);
+  let wr_ok: Bool = aw_w_fire and (aw_resp == 0);
+
+  // ── Register bank ────────────────────────────────────────────────────────
+  wire rf_rdata: UInt<32>;
+  inst rf: Nic400GpvRegs
+    clk          <- clk;
+    rst          <- rst;
+    read.addr    <- ar_index;
+    read.data    -> rf_rdata;
+    write.en     <- wr_ok;
+    write.addr   <- aw_index;
+    write.data   <- s.w_data;
+  end inst rf
+
+  // ── Combinational AXI drives ─────────────────────────────────────────────
+  comb
+    // Read address channel: accept a new AR only when not holding a response.
+    s.ar_ready = not r_pending;
+    // Read data channel.
+    s.r_valid  = r_pending;
+    s.r_data   = r_data_r;
+    s.r_resp   = r_resp_r;
+    s.r_id     = r_id_r;
+    s.r_last   = true;
+
+    // Write address + data channels: accept AW and W together.
+    s.aw_ready = aw_w_fire;
+    s.w_ready  = aw_w_fire;
+    // Write response channel.
+    s.b_valid  = b_pending;
+    s.b_resp   = b_resp_r;
+    s.b_id     = b_id_r;
+  end comb
+
+  // ── Sequential handshake / capture ───────────────────────────────────────
+  seq on clk rising
+    // Read: capture index→data and response on AR accept; clear on R complete.
+    if ar_fire
+      r_pending <= true;
+      r_id_r    <= s.ar_id;
+      r_resp_r  <= ar_resp;
+      r_data_r  <= (ar_resp == 0) ? rf_rdata : 0;
+    end if
+    if s.r_valid and s.r_ready
+      r_pending <= false;
+    end if
+
+    // Write: capture response on AW+W accept (the bank write itself is comb-
+    // gated by wr_ok); clear on B complete.
+    if aw_w_fire
+      b_pending <= true;
+      b_id_r    <= s.aw_id;
+      b_resp_r  <= aw_resp;
+    end if
+    if s.b_valid and s.b_ready
+      b_pending <= false;
+    end if
+  end seq
+end module Nic400Gpv

--- a/examples/nic400/Nic400GpvRegs.arch
+++ b/examples/nic400/Nic400GpvRegs.arch
@@ -1,0 +1,23 @@
+// Backing register array for the NIC-400 Global Programmers View (GPV).
+//
+// A flat bank of NREGS 32-bit configuration registers, one read port and one
+// write port, with write-before-read forwarding so a same-cycle write is
+// visible to a read at the same index. The GPV shim (Nic400Gpv) maps AXI4
+// word accesses onto this regfile.
+
+regfile Nic400GpvRegs
+  param NREGS: const = 16;
+  param T: type = UInt<32>;
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  ports[1] read
+    addr: in UInt<4>;
+    data: out UInt<32>;
+  end ports read
+  ports[1] write
+    en:   in Bool;
+    addr: in UInt<4>;
+    data: in UInt<32>;
+  end ports write
+  forward write_before_read: true;
+end regfile Nic400GpvRegs

--- a/examples/nic400/Nic400Gpv_test.harc
+++ b/examples/nic400/Nic400Gpv_test.harc
@@ -1,0 +1,175 @@
+// Nic400Gpv testbench — drives the GPV AXI4 target and checks:
+//   1. A Secure 32-bit write then read round-trips the data (BRESP/RRESP=OKAY).
+//   2. A Non-secure access is refused with DECERR (0b11) and does NOT write.
+//   3. A wrong-size (not 32-bit) access is refused with SLVERR (0b10).
+//
+// AXI-Lite single-beat handshakes (axlen=0). Secure = AxPROT[1]==0.
+//
+// Run:
+//   harc sim --dut examples/nic400/BusAxi4.arch \
+//            --dut examples/nic400/Nic400GpvRegs.arch \
+//            --dut examples/nic400/Nic400Gpv.arch \
+//            examples/nic400/Nic400Gpv_test.harc --top Nic400Gpv
+
+testbench Nic400GpvTb
+    dut : Nic400Gpv
+end testbench Nic400GpvTb
+
+impl Nic400GpvTest for Nic400GpvTb
+    clock clk = 10ns   // 100 MHz
+
+    run
+        log(info, "Nic400 GPV AXI4-target config-register test")
+
+        // ── Reset / idle all AXI inputs ──────────────────────────────────
+        dut.rst         = 1
+        dut.s_ar_valid  = 0
+        dut.s_ar_addr   = 0
+        dut.s_ar_id     = 0
+        dut.s_ar_size   = 2
+        dut.s_ar_prot   = 0
+        dut.s_r_ready   = 0
+        dut.s_aw_valid  = 0
+        dut.s_aw_addr   = 0
+        dut.s_aw_id     = 0
+        dut.s_aw_size   = 2
+        dut.s_aw_prot   = 0
+        dut.s_w_valid   = 0
+        dut.s_w_data    = 0
+        dut.s_w_strb    = 0xF
+        dut.s_b_ready   = 0
+        wait 3 cycles
+        dut.rst = 0
+        wait 2 cycles
+
+        // ── 1. Secure 32-bit write: reg[2] = 0xDEADBEEF ──────────────────
+        dut.s_aw_addr  = 0x008   // word index 2 (byte addr 8)
+        dut.s_aw_id    = 5
+        dut.s_aw_size  = 2
+        dut.s_aw_prot  = 0       // Secure
+        dut.s_w_data   = 0xDEADBEEF
+        dut.s_aw_valid = 1
+        dut.s_w_valid  = 1
+        dut.s_b_ready  = 1
+        // Single loop: deassert AW/W on accept, capture B on b_valid (holding
+        // b_ready high, so capture in the SAME loop to avoid missing the pulse).
+        let bresp : uint<32> = 9
+        for _ in 0 .. 12
+            wait 1 cycles
+            if dut.s_aw_ready == 1
+                dut.s_aw_valid = 0
+                dut.s_w_valid  = 0
+            end if
+            if dut.s_b_valid == 1 && bresp == 9
+                bresp = dut.s_b_resp
+            end if
+        end for
+        assert bresp == 0 else fail("secure write BRESP != OKAY: got ${bresp}")
+        dut.s_b_ready = 0
+        log(info, "secure write accepted, BRESP=OKAY")
+
+        // ── 2. Secure 32-bit read of reg[2] → expect 0xDEADBEEF, OKAY ────
+        dut.s_ar_addr  = 0x008
+        dut.s_ar_id    = 6
+        dut.s_ar_size  = 2
+        dut.s_ar_prot  = 0
+        dut.s_ar_valid = 1
+        dut.s_r_ready  = 1
+        let rdata : uint<32> = 0
+        let rresp : uint<32> = 9
+        let rid   : uint<32> = 0
+        let rseen : uint<32> = 0
+        for _ in 0 .. 12
+            wait 1 cycles
+            if dut.s_ar_ready == 1
+                dut.s_ar_valid = 0
+            end if
+            if dut.s_r_valid == 1 && rseen == 0
+                rseen = 1
+                rdata = dut.s_r_data
+                rresp = dut.s_r_resp
+                rid   = dut.s_r_id
+            end if
+        end for
+        assert rseen == 1 else fail("read R never returned")
+        assert rresp == 0 else fail("secure read RRESP != OKAY: got ${rresp}")
+        assert rdata == 0xDEADBEEF else fail("read data mismatch: got 0x${rdata:x}")
+        assert rid == 6 else fail("read RID mismatch: got ${rid}")
+        dut.s_r_ready = 0
+        log(info, "secure read returned 0x${rdata:x} RRESP=OKAY RID=${rid}")
+
+        // ── 3. Non-secure write to reg[3] → DECERR, and reg[3] stays 0 ───
+        dut.s_aw_addr  = 0x00C   // word index 3
+        dut.s_aw_id    = 7
+        dut.s_aw_size  = 2
+        dut.s_aw_prot  = 2       // Non-secure (bit1=1)
+        dut.s_w_data   = 0x12345678
+        dut.s_aw_valid = 1
+        dut.s_w_valid  = 1
+        dut.s_b_ready  = 1
+        let bns : uint<32> = 9
+        for _ in 0 .. 12
+            wait 1 cycles
+            if dut.s_aw_ready == 1
+                dut.s_aw_valid = 0
+                dut.s_w_valid  = 0
+            end if
+            if dut.s_b_valid == 1 && bns == 9
+                bns = dut.s_b_resp
+            end if
+        end for
+        assert bns == 3 else fail("non-secure write BRESP != DECERR: got ${bns}")
+        dut.s_b_ready = 0
+        log(info, "non-secure write refused with DECERR")
+
+        // Confirm reg[3] was NOT written: secure read must return 0.
+        dut.s_ar_addr  = 0x00C
+        dut.s_ar_id    = 8
+        dut.s_ar_size  = 2
+        dut.s_ar_prot  = 0
+        dut.s_ar_valid = 1
+        dut.s_r_ready  = 1
+        let rd3 : uint<32> = 7
+        let rseen3 : uint<32> = 0
+        for _ in 0 .. 12
+            wait 1 cycles
+            if dut.s_ar_ready == 1
+                dut.s_ar_valid = 0
+            end if
+            if dut.s_r_valid == 1 && rseen3 == 0
+                rseen3 = 1
+                rd3 = dut.s_r_data
+            end if
+        end for
+        assert rseen3 == 1 else fail("reg[3] readback never returned")
+        assert rd3 == 0 else fail("non-secure write leaked into reg[3]: got 0x${rd3:x}")
+        dut.s_r_ready = 0
+        log(info, "reg[3] confirmed unwritten (0)")
+
+        // ── 4. Wrong-size read (size=1, not 32-bit) → SLVERR ─────────────
+        dut.s_ar_addr  = 0x008
+        dut.s_ar_id    = 9
+        dut.s_ar_size  = 1       // 16-bit, illegal for GPV
+        dut.s_ar_prot  = 0
+        dut.s_ar_valid = 1
+        dut.s_r_ready  = 1
+        let rsz : uint<32> = 9
+        let rseensz : uint<32> = 0
+        for _ in 0 .. 12
+            wait 1 cycles
+            if dut.s_ar_ready == 1
+                dut.s_ar_valid = 0
+            end if
+            if dut.s_r_valid == 1 && rseensz == 0
+                rseensz = 1
+                rsz = dut.s_r_resp
+            end if
+        end for
+        assert rseensz == 1 else fail("wrong-size read never returned")
+        assert rsz == 2 else fail("wrong-size read RRESP != SLVERR: got ${rsz}")
+        dut.s_r_ready = 0
+        log(info, "wrong-size read refused with SLVERR")
+
+        log(info, "PASS Nic400Gpv: OKAY round-trip, DECERR (non-secure), SLVERR (bad size)")
+    end run
+end impl Nic400GpvTest

--- a/examples/nic400/README.md
+++ b/examples/nic400/README.md
@@ -111,6 +111,11 @@ Verified with `Nic400CdcAxi4_test.harc` (a dual-clock HARC testbench that drives
 
 - **`Nic400Pmu.arch`** — performance monitor counters. Per-master AR/AW/R/W/B counters, `COUNTER_W`-wide (default 32). Inputs are pre-qualified one-cycle event pulses (typically `m[i].x_valid && m[i].x_ready`). `r`/`w` count beats; `ar`/`aw`/`b` count transactions.
 
+### Configuration (GPV)
+
+- **`Nic400Gpv.arch`** — the **Global Programmers View**: the interconnect's configuration register file, presented as an AXI4 *target* (slave). Per the NIC-400 TRM (§3.2), the GPV is AXI-accessed, **32-bit only** (`AxSIZE=2`), **Secure-only**, non-cacheable, aligned, single-beat. This shim is an AXI4-Lite-style target (one outstanding read, one outstanding write) backed by `Nic400GpvRegs`, enforcing the two constraints: a wrong size → **SLVERR** (`0b10`), a Non-secure access (`AxPROT[1]=1`) → **DECERR** (`0b11`, priority over SLVERR), and a rejected write leaves the bank unchanged. The lowest-cost path to programmable QoS/decode/remap state (spec §16.1 roadmap item #4). Verified by `Nic400Gpv_test.harc` on the ARCH sim **and** Verilator with matching cross-backend traces (`harc sim --check-backends`).
+- **`Nic400GpvRegs.arch`** — the backing `regfile` bank: `NREGS` 32-bit config registers, one read + one write port, write-before-read forwarding.
+
 ### Helpers
 
 - **`Nic400ArbiterPolicy.arch`** — module-local `qos_grant_select(req_mask, last_grant, qos_vec)` for QoS-weighted grant selection.


### PR DESCRIPTION
## Summary

Adds the NIC-400 **Global Programmers View** — the interconnect's configuration register file, the spec's own #1 roadmap gap (§16.1 item 4, *"lowest-cost path to programmable status on QoS/decode/remap"*). Per the TRM (§3.2) the GPV is AXI-accessed, **32-bit only** (`AxSIZE=2`), **Secure-only**, non-cacheable, aligned, single-beat.

- **`Nic400Gpv.arch`** — an AXI4-Lite-style *target* (one outstanding read, one outstanding write) backed by a `regfile`. Enforces the two access constraints:
  - wrong size → **SLVERR** (`0b10`)
  - Non-secure (`AxPROT[1]=1`) → **DECERR** (`0b11`, priority over SLVERR), and the write is dropped
- **`Nic400GpvRegs.arch`** — the backing `regfile` bank (`NREGS` 32-bit regs, 1R/1W, write-before-read forwarding).
- **`Nic400Gpv_test.harc`** — checks the OKAY round-trip, DECERR (non-secure, and confirms the register stays unwritten), and SLVERR (bad size).

## Verification

- **`harc sim --check-backends`**: PASS on the ARCH native sim **and** Verilator, with **matching cross-backend traces (no divergence)**.
- Verilator lint-clean; `arch check` clean.

## Compiler dividend ("one stone, two birds")

This is the first NIC-400 use of the `regfile` construct + an AXI bus-target shim, and building it surfaced **two real compiler bugs**:
- the bus-port comb-loop **false positive** (`ready = f(valid)` fabricated a self-cycle) — fixed in #550;
- the count-1 `ports[1]` array `[0]`-index → pin-name mismatch (`read0_addr` vs `read_addr`) — follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)