### PR TITLE
fix(elaborate): normalize count-1 ports[1] array [0]-index inst connections

### DIFF
--- a/src/elaborate.rs
+++ b/src/elaborate.rs
@@ -153,11 +153,88 @@ pub fn elaborate(ast: SourceFile) -> Result<SourceFile, Vec<CompileError>> {
     if !errors.is_empty() {
         Err(errors)
     } else {
-        lower_tlm_connects(SourceFile {
+        let mut sf = SourceFile {
             items: new_items,
             inner_doc: None,
             frontmatter: None,
-        })
+        };
+        normalize_count1_portarray_conns(&mut sf);
+        lower_tlm_connects(sf)
+    }
+}
+
+/// Normalize inst-connection names to a single-element (`ports[1]`) port-array
+/// member.
+///
+/// A first-class construct with a `ports[N]` group (regfile read/write, arbiter
+/// request, template) flattens its member ports as `{group}{i}_{sig}` for N>1
+/// but DROPS the index when N==1 — the count-1 declaration emits `read_addr`,
+/// not `read0_addr` (see `src/codegen/regfile.rs`). The parser, however,
+/// flattens an explicit `read[0].addr` connection to `read0_addr` regardless of
+/// the target's count. Against a count-1 target that produced a pin/member-name
+/// mismatch (`read0_addr` vs `read_addr`) — Verilator `PINNOTFOUND`, and a sim
+/// `no member named 'read0_addr'`. Both the idiomatic `read.addr` (no index) and
+/// the explicit `read[0].addr` should resolve to the same `read_addr`.
+///
+/// Here we rewrite any connection named `{group}0_{sig}` to `{group}_{sig}` when
+/// the inst's target construct has a LITERAL count-1 group `group` — once, in
+/// the AST, so every downstream backend (SV, sim, .archi) sees the consistent
+/// un-indexed name. Param-driven counts that resolve to 1 are out of scope (a
+/// literal `ports[1]` is the case that occurs in practice).
+fn normalize_count1_portarray_conns(sf: &mut SourceFile) {
+    use std::collections::HashMap;
+    fn count1_groups(groups: &[&PortArrayDecl]) -> Vec<(String, Vec<String>)> {
+        groups
+            .iter()
+            .filter(|pa| matches!(&pa.count_expr.kind, ExprKind::Literal(LitKind::Dec(1))))
+            .map(|pa| {
+                (
+                    pa.name.name.clone(),
+                    pa.signals.iter().map(|s| s.name.name.clone()).collect(),
+                )
+            })
+            .collect()
+    }
+
+    // construct name → [(group_name, [signal names])] for literal count-1 groups
+    let mut count1: HashMap<String, Vec<(String, Vec<String>)>> = HashMap::new();
+    for item in &sf.items {
+        let (cname, groups): (&str, Vec<&PortArrayDecl>) = match item {
+            Item::Regfile(r) => (
+                &r.common.name.name,
+                r.read_ports.iter().chain(r.write_ports.iter()).collect(),
+            ),
+            Item::Arbiter(a) => (&a.common.name.name, a.port_arrays.iter().collect()),
+            Item::Template(t) => (&t.name.name, t.port_arrays.iter().collect()),
+            _ => continue,
+        };
+        let g1 = count1_groups(&groups);
+        if !g1.is_empty() {
+            count1.insert(cname.to_string(), g1);
+        }
+    }
+    if count1.is_empty() {
+        return;
+    }
+
+    for item in &mut sf.items {
+        if let Item::Module(m) = item {
+            for bi in &mut m.body {
+                if let ModuleBodyItem::Inst(inst) = bi {
+                    if let Some(groups) = count1.get(&inst.module_name.name) {
+                        for conn in &mut inst.connections {
+                            for (g, sigs) in groups {
+                                for s in sigs {
+                                    if conn.port_name.name == format!("{g}0_{s}") {
+                                        conn.port_name.name = format!("{g}_{s}");
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -15965,6 +15965,69 @@ const LATCH_RF_DECL: &str = "
 ";
 
 #[test]
+fn test_count1_port_array_inst_connection_uses_unindexed_name() {
+    // A `ports[1]` (count-1) regfile group flattens its member ports WITHOUT an
+    // index in the module declaration (`read_addr`, not `read0_addr`). An inst
+    // connection written with an explicit `read[0].addr` is parser-flattened to
+    // `read0_addr`, which mismatched the declaration → Verilator PINNOTFOUND and
+    // a sim `no member named 'read0_addr'`. Both `read.addr` and `read[0].addr`
+    // must resolve to the un-indexed `read_addr`.
+    let source = r#"
+regfile Rf1
+  param NREGS: const = 4;
+  param T: type = UInt<32>;
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  ports[1] read
+    addr: in UInt<2>;
+    data: out UInt<32>;
+  end ports read
+  ports[1] write
+    en:   in Bool;
+    addr: in UInt<2>;
+    data: in UInt<32>;
+  end ports write
+end regfile Rf1
+
+module Top
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port a: in UInt<2>;
+  port d: out UInt<32>;
+  wire dw: UInt<32>;
+  inst rf: Rf1
+    clk <- clk;
+    rst <- rst;
+    read[0].addr <- a;
+    read[0].data -> dw;
+    write.en     <- false;
+    write.addr   <- 0;
+    write.data   <- 0;
+  end inst rf
+  comb
+    d = dw;
+  end comb
+end module Top
+"#;
+    let sv = compile_to_sv(source);
+    // The inst connection must use the un-indexed pin name matching the count-1
+    // declaration.
+    assert!(
+        sv.contains(".read_addr(") && sv.contains(".read_data("),
+        "count-1 `read[0]` connection must emit `.read_addr(`/`.read_data(`:\n{sv}"
+    );
+    assert!(
+        !sv.contains(".read0_addr(") && !sv.contains(".read0_data("),
+        "count-1 `read[0]` connection must NOT emit the indexed `.read0_addr(`:\n{sv}"
+    );
+    // The declaration side (always un-indexed for count-1) must agree.
+    assert!(
+        sv.contains("read_addr") && !sv.contains("read0_addr"),
+        "count-1 regfile declaration + connection names must both be un-indexed:\n{sv}"
+    );
+}
+
+#[test]
 fn test_regfile_latch_emits_always_latch_per_row() {
     let source = format!(
         "{LATCH_RF_DECL}


### PR DESCRIPTION
## Summary

Fixes a codegen name mismatch (Bug B from the GPV session). A first-class construct with a `ports[N]` group — regfile read/write, arbiter request, template — flattens its member ports as `{group}{i}_{sig}` for N>1 but **drops the index when N==1**: a count-1 declaration emits `read_addr`, not `read0_addr` (`src/codegen/regfile.rs`). The parser, however, flattens an explicit `read[0].addr` connection to `read0_addr` regardless of the target's count.

Against a count-1 target that produced a name mismatch:
- Verilator: `%Error-PINNOTFOUND` on `.read0_addr(...)` vs the declared `read_addr`
- sim: `no member named 'read0_addr'`

The idiomatic no-index `read.addr` worked; only the explicit `read[0].addr` was broken.

## Fix

In `elaborate`, after generate expansion, rewrite any inst connection named `{group}0_{sig}` → `{group}_{sig}` when the inst's target construct has a **literal count-1** group `group`. Done once in the AST, so every backend (SV, sim, `.archi`) sees the consistent un-indexed name. Both `read.addr` and `read[0].addr` now resolve to `read_addr`. Param-driven counts that resolve to 1 are out of scope (a literal `ports[1]` is the case that occurs in practice).

## Verification

- New test `test_count1_port_array_inst_connection_uses_unindexed_name` asserts the count-1 `read[0]` connection emits `.read_addr(` (not `.read0_addr(`) and matches the declaration.
- Manually confirmed Verilator-clean on a multi-file regfile+module with `read[0]`.
- Full suite green (lib 47 + integration 614, +1).

Internal elaboration/codegen fix — `read[0]` was already accepted, it just generated wrong names; no user-facing syntax/semantics change.

> Note: building the repro surfaced a *separate* pre-existing bug — a single-file `regfile`+`module` emits the regfile module twice (the first copy missing its port-array ports). Tracked separately; not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)