### PR TITLE
fix(build): don't re-pull a .archi for a construct already defined in-source

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2336,37 +2336,34 @@ fn resolve_use_imports(files: &[PathBuf]) -> miette::Result<Vec<PathBuf>> {
             }
         }
 
-        // Track all module names defined across all input files
+        // Track every construct name defined across all input files, so the
+        // `.archi` auto-discovery below does NOT pull in a (possibly stale)
+        // interface stub for a construct that is ALREADY defined in-source —
+        // doing so adds a duplicate item and the construct emits twice (the
+        // stub copy missing its port-array ports → broken SV/sim).
         for item in &parsed.items {
             match item {
-                Item::Module(m) => {
-                    all_defined_modules.insert(m.name.name.clone());
-                }
-                Item::Fsm(f) => {
-                    all_defined_modules.insert(f.name.name.clone());
-                }
-                Item::Counter(c) => {
-                    all_defined_modules.insert(c.name.name.clone());
-                }
-                Item::Pipeline(p) => {
-                    all_defined_modules.insert(p.name.name.clone());
-                }
-                Item::Synchronizer(s) => {
-                    all_defined_modules.insert(s.name.name.clone());
-                }
-                Item::Fifo(f) => {
-                    all_defined_modules.insert(f.name.name.clone());
-                }
-                Item::Ram(r) => {
-                    all_defined_modules.insert(r.name.name.clone());
-                }
-                Item::Arbiter(a) => {
-                    all_defined_modules.insert(a.name.name.clone());
-                }
                 Item::Bus(b) => {
                     all_defined_buses.insert(b.name.name.clone());
                 }
-                _ => {}
+                // Types / values / packages / imports — never `inst` targets.
+                Item::Domain(_)
+                | Item::Struct(_)
+                | Item::Enum(_)
+                | Item::Function(_)
+                | Item::Package(_)
+                | Item::Use(_)
+                | Item::ExternPackage(_) => {}
+                // Everything else is an instantiable construct (module, fsm,
+                // fifo, ram, arbiter, regfile, cam, counter, synchronizer,
+                // pipeline, clkgate, linklist, template). Use the generic
+                // construct-name accessor rather than a per-variant arm so a
+                // future construct can't be silently omitted — the missing
+                // `regfile` arm here is exactly what duplicated GPV's regfile.
+                instantiable => {
+                    all_defined_modules
+                        .insert(instantiable.as_construct().name().name.clone());
+                }
             }
         }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -855,6 +855,85 @@ end arbiter RRArb3
 /// Builds RRArb3 (NUM_REQ=3, the canonical non-power-of-2 case) to SV,
 /// runs it under Verilator with all three requesters always asserted,
 /// and checks that the grant_requester sequence is strict
+/// A construct already defined in the input files must not also be pulled in
+/// from a stale `.archi` by auto-discovery — doing so emitted the construct
+/// twice (the stub copy missing its port-array ports → broken SV). The
+/// `.archi`-discovery defined-name set tracked module/fsm/fifo/ram/arbiter/...
+/// but omitted `regfile` (and cam/clkgate/linklist), so an in-source `regfile`
+/// + a present `Rf1.archi` (e.g. from a prior build) duplicate-emitted it.
+#[test]
+fn test_inscope_construct_not_duplicated_by_stale_archi() {
+    use std::fs;
+    let td = tempfile::tempdir().expect("tempdir");
+    let dir = td.path();
+    let arch_bin = env!("CARGO_BIN_EXE_arch");
+    let regfile = "\
+regfile Rf1
+  param NREGS: const = 4;
+  param T: type = UInt<32>;
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  ports[1] read
+    addr: in UInt<2>;
+    data: out UInt<32>;
+  end ports read
+  ports[1] write
+    en:   in Bool;
+    addr: in UInt<2>;
+    data: in UInt<32>;
+  end ports write
+end regfile Rf1
+";
+    // 1) Build the regfile alone so its `Rf1.archi` lands in `dir`.
+    let rf_path = dir.join("Rf1.arch");
+    fs::write(&rf_path, regfile).unwrap();
+    let b1 = std::process::Command::new(arch_bin)
+        .arg("build").arg(&rf_path).arg("-o").arg(dir.join("Rf1.sv"))
+        .output().expect("build regfile");
+    assert!(b1.status.success(), "regfile build failed: {}",
+            String::from_utf8_lossy(&b1.stderr));
+    assert!(dir.join("Rf1.archi").exists(), "Rf1.archi should have been written");
+
+    // 2) Build a combined file that DEFINES Rf1 in-source AND insts it, in the
+    //    same dir as the stale Rf1.archi. The construct must emit exactly once.
+    let combined = format!("{regfile}
+module Top
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port a: in UInt<2>;
+  port d: out UInt<32>;
+  wire dw: UInt<32>;
+  inst rf: Rf1
+    clk <- clk;
+    rst <- rst;
+    read.addr <- a;
+    read.data -> dw;
+    write.en  <- false;
+    write.addr <- 0;
+    write.data <- 0;
+  end inst rf
+  comb
+    d = dw;
+  end comb
+end module Top
+");
+    let top_path = dir.join("Top.arch");
+    fs::write(&top_path, combined).unwrap();
+    let sv_out = dir.join("Top.sv");
+    let b2 = std::process::Command::new(arch_bin)
+        .arg("build").arg(&top_path).arg("-o").arg(&sv_out)
+        .output().expect("build combined");
+    assert!(b2.status.success(), "combined build failed: {}",
+            String::from_utf8_lossy(&b2.stderr));
+    let sv = fs::read_to_string(&sv_out).unwrap();
+    let n = sv.matches("\nmodule Rf1").count() + sv.starts_with("module Rf1") as usize;
+    assert_eq!(
+        n, 1,
+        "regfile defined in-source must emit exactly once even with a stale \
+         Rf1.archi present (got {n}):\n{sv}"
+    );
+}
+
 /// round-robin (each idx wins exactly 1/3 of cycles).
 ///
 /// Pre-fix grant pattern was `0,1,2,0,0,1,2,0,...` (idx 0 at 50%).


### PR DESCRIPTION
## Summary

Fixes Bug C from the GPV session: a construct **defined in the input files** was *also* pulled in from a stale `.archi` by auto-discovery, so it emitted twice — the interface-stub copy missing its port-array ports, whose body then references undeclared signals → broken SV (Verilator `Can't find definition of variable`) and sim (`no member named`).

Root cause: the `.archi`-discovery skip-check consults `all_defined_modules`, but that set was built from a hand-listed match over construct kinds (module/fsm/counter/pipeline/synchronizer/fifo/ram/arbiter) that **omitted `regfile`** (and cam/clkgate/linklist). So an in-source `regfile` wasn't recognized as already-defined, and a present `<Name>.archi` (e.g. from a prior build — and the GPV's own builds write one) got pulled in as a duplicate.

It took some chasing — the duplicate looked tied to `read[0]` / single-file, but those were red herrings (stale `.archi` files left in `/tmp` by earlier builds). The real trigger is **in-source construct + a present `.archi` of the same name**.

## Fix

Build `all_defined_modules` generically via `Item::as_construct().name()` for every instantiable construct, excluding only the non-instantiable items (bus → its own set; domain/struct/enum/function/package/use/extern-package). A future construct can no longer be silently omitted — exactly the trap that dropped `regfile`.

## Verification

- Manually: with a stale `Rf1.archi` present, a combined regfile+module file now emits `module Rf1` **once** and is Verilator-clean (was twice + errors).
- New `test_inscope_construct_not_duplicated_by_stale_archi`: builds the regfile to produce its `.archi`, then builds a combined file (regfile in-source + an inst) in the same dir, and asserts exactly one emission.
- Full suite green (lib 47 + integration 615, +1).

Internal build-CLI fix — no user-facing syntax/semantics change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)