### PR TITLE
fix(codegen): skip vacuous FSM legal-state assertion for power-of-2 state counts

### DIFF
--- a/src/codegen/fsm.rs
+++ b/src/codegen/fsm.rs
@@ -359,13 +359,24 @@ self.line("unique case (state_r)");
             self.line("");
             self.line("// synopsys translate_off");
 
-            // Assert: no illegal state (reset-guarded)
-            self.line(&format!(
-                "_auto_legal_state: assert property (@(posedge {clk}) {rst_inactive} |-> state_r < {n_states})"
-            ));
-            self.line(&format!(
-                "  else $fatal(1, \"FSM ILLEGAL STATE: {n}.state_r = %0d\", state_r);"
-            ));
+            // Assert: no illegal state (reset-guarded).
+            //
+            // `state_r` is ceil(log2(n_states)) bits wide. When `n_states` is an
+            // exact power of two, EVERY encoding is a legal state, so
+            // `state_r < n_states` is vacuously true — and the literal needs one
+            // more bit than `state_r`, which Verilator flags as WIDTHEXPAND
+            // (e.g. a 2-state FSM: 1-bit `state_r` vs the 2-bit `2`). Skip the
+            // assertion in that case; it only adds value when there are unused
+            // encodings (non-power-of-two state counts), where the widths match.
+            let is_pow2 = n_states >= 1 && (n_states & (n_states - 1)) == 0;
+            if !is_pow2 {
+                self.line(&format!(
+                    "_auto_legal_state: assert property (@(posedge {clk}) {rst_inactive} |-> state_r < {n_states})"
+                ));
+                self.line(&format!(
+                    "  else $fatal(1, \"FSM ILLEGAL STATE: {n}.state_r = %0d\", state_r);"
+                ));
+            }
 
             // Cover: each state is reachable
             for sn in &f.state_names {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -282,6 +282,80 @@ fn test_fsm_traffic_light() {
 }
 
 #[test]
+fn test_fsm_legal_state_assert_skipped_for_power_of_two_state_count() {
+    // The auto `_auto_legal_state: ... state_r < N` assertion is vacuous when N
+    // is a power of two (every encoding is a legal state) AND it width-mismatches
+    // (the N literal needs one more bit than `state_r`) → Verilator WIDTHEXPAND.
+    // It must be SKIPPED for power-of-two state counts and KEPT (and width-clean)
+    // for non-power-of-two counts where unused encodings exist.
+    let two_state = r#"
+fsm Toggle
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port flip: in Bool;
+  port q: out Bool;
+  state [A, B]
+  default state A;
+  default seq on clk rising;
+  state A
+    comb
+      q = false;
+    end comb
+    -> B when flip;
+  end state A
+  state B
+    comb
+      q = true;
+    end comb
+    -> A when flip;
+  end state B
+end fsm Toggle
+"#;
+    let sv2 = compile_to_sv(two_state);
+    assert!(
+        !sv2.contains("_auto_legal_state"),
+        "a 2-state (power-of-two) FSM must NOT emit the vacuous, width-mismatched \
+         legal-state assertion:\n{sv2}"
+    );
+
+    let three_state = r#"
+fsm Tri
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port go: in Bool;
+  port q: out UInt<2>;
+  state [A, B, C]
+  default state A;
+  default seq on clk rising;
+  state A
+    comb
+      q = 0;
+    end comb
+    -> B when go;
+  end state A
+  state B
+    comb
+      q = 1;
+    end comb
+    -> C when go;
+  end state B
+  state C
+    comb
+      q = 2;
+    end comb
+    -> A when go;
+  end state C
+end fsm Tri
+"#;
+    let sv3 = compile_to_sv(three_state);
+    assert!(
+        sv3.contains("_auto_legal_state") && sv3.contains("state_r < 3"),
+        "a 3-state (non-power-of-two) FSM must KEEP the legal-state assertion \
+         (`state_r < 3`):\n{sv3}"
+    );
+}
+
+#[test]
 fn test_fsm_missing_default_state_errors() {
     let source = r#"
 fsm Broken


### PR DESCRIPTION
## Summary

The auto-generated FSM `_auto_legal_state: assert property (... state_r < N)` is **vacuous** when N (the state count) is a power of two — every encoding of the `ceil(log2(N))`-bit `state_r` is a legal state — **and** it width-mismatches: the N literal needs one more bit than `state_r` (a 2-state FSM: 1-bit `state_r` vs the 2-bit `2`), which Verilator flags as `WIDTHEXPAND`.

So every 2/4/8/16-state FSM emitted a pointless assertion that also tripped a width warning. dma_engine's 3-state FSM happened to dodge it; it surfaced while building the NIC-400 low-power C-channel controller (a 2-state FSM).

## Fix

Skip the assertion when N is a power of two. It only adds value for **non**-power-of-two state counts, where unused encodings exist (e.g. 3 states → values 3 illegal) AND the widths already match (2-bit `state_r` vs the 2-bit `3`).

## Verification

- 2-state FSM (C-channel): assertion now skipped → Verilator `-Wall` **clean** (was `WIDTHEXPAND`).
- 3-state FSM (dma_engine): assertion retained (`state_r < 3`).
- New test `test_fsm_legal_state_assert_skipped_for_power_of_two_state_count`.
- Full suite green (lib 47 + integration 616, +1; no snapshot changes — no existing fixture is a power-of-two-state FSM).

Internal codegen fix — no user-facing syntax/semantics change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)