### PR TITLE
feat(nic400): low-power C-channel clock-gating controller (CSYSREQ/CSYSACK/CACTIVE)

### DIFF
--- a/examples/nic400/BusCChannel.arch
+++ b/examples/nic400/BusCChannel.arch
@@ -1,0 +1,15 @@
+// AMBA Low-Power Interface "C-channel" — NIC-400's hierarchical clock-gating
+// handshake (TRM §2.2.3 / Appendix A.1.1), one set per clock domain.
+//
+// Initiator perspective = the system clock controller:
+//   csysreq  out  — request: 1 = keep clock running, 0 = quiesce/gate the domain
+//   csysack  in   — device acknowledge: follows csysreq once the device is idle
+//   cactive  in   — device activity: 1 = the domain has pending work (don't gate)
+//
+// A `target` flips these, so the gated domain's controller sees csysreq as an
+// input and drives csysack / cactive.
+bus BusCChannel
+  csysreq: out Bool;
+  csysack: in  Bool;
+  cactive: in  Bool;
+end bus BusCChannel

--- a/examples/nic400/Nic400CChannelClockGate.arch
+++ b/examples/nic400/Nic400CChannelClockGate.arch
@@ -1,0 +1,47 @@
+// NIC-400 low-power C-channel clock-gating controller (device side).
+//
+// Implements the AMBA Low-Power Interface handshake for one clock domain
+// (TRM §2.2.3). The system clock controller drives `cc.csysreq` to request the
+// domain quiesce (0) or run (1); this FSM responds on `cc.csysack` only once
+// the gated logic is idle (`busy == 0`), and reflects pending work on
+// `cc.cactive`. `clk_en` is the resulting clock-enable for the gated domain
+// (1 = clock runs, 0 = clock gated).
+//
+// Runs on the always-on controller clock `clk` (NOT the gated clock), so the
+// handshake keeps advancing while the downstream domain is parked.
+//
+//   ACTIVE  (clock on):  csysack=1, clk_en=1.  → GATED when !csysreq && !busy.
+//   GATED   (clock off): csysack=0, clk_en=0.  → ACTIVE when  csysreq ||  busy.
+//
+// `cactive` mirrors `busy` in both states: the controller watches it to decide
+// whether a gate request is safe, and `busy` also forces an immediate wake.
+
+fsm Nic400CChannelClockGate
+  port clk:    in Clock<SysDomain>;
+  port rst:    in Reset<Sync>;
+  port cc:     target BusCChannel;
+  port busy:   in  Bool;
+  port clk_en: out Bool;
+
+  state [Active, Gated]
+  default state Active;
+  default seq on clk rising;
+
+  state Active
+    comb
+      cc.csysack = true;
+      cc.cactive = busy;
+      clk_en     = true;
+    end comb
+    -> Gated when (not cc.csysreq) and (not busy);
+  end state Active
+
+  state Gated
+    comb
+      cc.csysack = false;
+      cc.cactive = busy;
+      clk_en     = false;
+    end comb
+    -> Active when cc.csysreq or busy;
+  end state Gated
+end fsm Nic400CChannelClockGate

--- a/examples/nic400/Nic400CChannelClockGate_test.harc
+++ b/examples/nic400/Nic400CChannelClockGate_test.harc
@@ -1,0 +1,73 @@
+// Nic400CChannelClockGate testbench — drives the C-channel low-power handshake
+// and checks the gate/wake behavior:
+//   1. csysreq=1, idle      → ACTIVE  (csysack=1, clk_en=1).
+//   2. csysreq=0 while idle  → GATED   (csysack=0, clk_en=0) after one edge.
+//   3. busy while gated      → WAKE    (back to ACTIVE, cactive=1).
+//   4. csysreq=0 but busy    → stays ACTIVE (a gate request can't gate active work).
+//   5. csysreq=1             → ACTIVE (run again).
+//
+// FSM outputs are combinational on the state register; `wait 1 cycles` advances
+// one clk edge so the post-edge state is observed.
+
+testbench Nic400CChannelTb
+    dut : Nic400CChannelClockGate
+end testbench Nic400CChannelTb
+
+impl Nic400CChannelTest for Nic400CChannelTb
+    clock clk = 10ns   // 100 MHz always-on controller clock
+
+    run
+        log(info, "Nic400 C-channel low-power clock-gating handshake test")
+
+        // ── Reset → ACTIVE, running ──────────────────────────────────────
+        dut.rst        = 1
+        dut.cc_csysreq = 1     // controller wants clock running
+        dut.busy       = 0
+        wait 2 cycles
+        dut.rst = 0
+        wait 1 cycles
+        assert dut.cc_csysack == 1 else fail("post-reset csysack != 1")
+        assert dut.clk_en == 1     else fail("post-reset clk_en != 1")
+        assert dut.cc_cactive == 0 else fail("idle cactive != 0")
+        log(info, "reset: ACTIVE, clock running")
+
+        // ── 1. Request quiesce while idle → GATED ────────────────────────
+        dut.cc_csysreq = 0     // controller requests gate
+        dut.busy       = 0
+        wait 1 cycles          // one edge to enter GATED
+        assert dut.cc_csysack == 0 else fail("gate: csysack != 0")
+        assert dut.clk_en == 0     else fail("gate: clk_en != 0 (clock not gated)")
+        log(info, "csysreq=0 while idle → GATED (clock off)")
+
+        // Stays gated while idle + request held low.
+        wait 3 cycles
+        assert dut.clk_en == 0 else fail("stayed gated: clk_en flipped on")
+
+        // ── 2. Activity while gated → immediate wake ─────────────────────
+        dut.busy = 1
+        wait 1 cycles
+        assert dut.clk_en == 1     else fail("busy wake: clk_en != 1")
+        assert dut.cc_csysack == 1 else fail("busy wake: csysack != 1")
+        assert dut.cc_cactive == 1 else fail("busy: cactive != 1")
+        log(info, "busy while gated → WAKE (clock on, cactive=1)")
+
+        // ── 3. csysreq still 0 but busy → cannot gate, stays ACTIVE ──────
+        wait 2 cycles
+        assert dut.clk_en == 1 else fail("busy held: gated despite activity")
+
+        // ── 4. Idle again with request low → GATED ──────────────────────
+        dut.busy = 0
+        wait 1 cycles
+        assert dut.clk_en == 0 else fail("idle again: did not re-gate")
+        log(info, "idle again with csysreq=0 → GATED")
+
+        // ── 5. Controller requests run → ACTIVE ─────────────────────────
+        dut.cc_csysreq = 1
+        wait 1 cycles
+        assert dut.cc_csysack == 1 else fail("run req: csysack != 1")
+        assert dut.clk_en == 1     else fail("run req: clk_en != 1")
+        log(info, "csysreq=1 → ACTIVE (clock running)")
+
+        log(info, "PASS Nic400CChannelClockGate: gate / wake-on-activity / wake-on-request all correct")
+    end run
+end impl Nic400CChannelTest

--- a/examples/nic400/README.md
+++ b/examples/nic400/README.md
@@ -116,6 +116,11 @@ Verified with `Nic400CdcAxi4_test.harc` (a dual-clock HARC testbench that drives
 - **`Nic400Gpv.arch`** — the **Global Programmers View**: the interconnect's configuration register file, presented as an AXI4 *target* (slave). Per the NIC-400 TRM (§3.2), the GPV is AXI-accessed, **32-bit only** (`AxSIZE=2`), **Secure-only**, non-cacheable, aligned, single-beat. This shim is an AXI4-Lite-style target (one outstanding read, one outstanding write) backed by `Nic400GpvRegs`, enforcing the two constraints: a wrong size → **SLVERR** (`0b10`), a Non-secure access (`AxPROT[1]=1`) → **DECERR** (`0b11`, priority over SLVERR), and a rejected write leaves the bank unchanged. The lowest-cost path to programmable QoS/decode/remap state (spec §16.1 roadmap item #4). Verified by `Nic400Gpv_test.harc` on the ARCH sim **and** Verilator with matching cross-backend traces (`harc sim --check-backends`).
 - **`Nic400GpvRegs.arch`** — the backing `regfile` bank: `NREGS` 32-bit config registers, one read + one write port, write-before-read forwarding.
 
+### Low-power (clock gating)
+
+- **`Nic400CChannelClockGate.arch`** — the AMBA Low-Power Interface **C-channel** clock-gating controller for one clock domain (TRM §2.2.3). The system clock controller drives `cc.csysreq` to request the domain quiesce (0) or run (1); this 2-state `fsm` drops `cc.csysack` (and the `clk_en` output) only once the gated logic is idle (`busy == 0`), reflects pending work on `cc.cactive`, and wakes immediately on activity (`busy`) or a run request. Runs on the always-on controller clock so the handshake advances while the downstream domain is parked. Exercises an `fsm` driving a `target` bus + a fresh handshake bundle; verified by `Nic400CChannelClockGate_test.harc` (gate / wake-on-activity / wake-on-request) on the ARCH sim **and** Verilator with matching cross-backend traces (`harc sim --check-backends`).
+- **`BusCChannel.arch`** — the C-channel handshake bundle (`csysreq` / `csysack` / `cactive`), initiator = system clock controller.
+
 ### Helpers
 
 - **`Nic400ArbiterPolicy.arch`** — module-local `qos_grant_select(req_mask, last_grant, qos_vec)` for QoS-weighted grant selection.


### PR DESCRIPTION
## Summary

Adds the AMBA Low-Power Interface **C-channel** clock-gating controller — a NIC-400 ❌ gap from the spec's §16.1 tracker (TRM §2.2.3, one set per clock domain).

- **`BusCChannel.arch`** — the handshake bundle (`csysreq` / `csysack` / `cactive`), initiator = the system clock controller.
- **`Nic400CChannelClockGate.arch`** — a 2-state `fsm` (ACTIVE↔GATED) on the always-on controller clock. It drops `csysack` + the `clk_en` output **only when the gated logic is idle** (`busy==0`) after a quiesce request (`csysreq==0`); reflects pending work on `cactive`; and wakes immediately on activity or a run request.
- **`Nic400CChannelClockGate_test.harc`** — checks gate / wake-on-activity / wake-on-request.

## Compiler coverage ("one stone, two birds")

This exercises previously-untested NIC-400 surface: an `fsm` driving a `target` bus with comb outputs, plus a fresh handshake bundle. Building it surfaced an FSM-codegen bug — the auto legal-state assertion was vacuous and width-mismatched for power-of-2 state counts — now fixed on main in #554, so this design is **Verilator `-Wall` clean**.

## Verification

- `harc sim --check-backends`: PASS on the ARCH native sim **and** Verilator, with **matching cross-backend traces (no divergence)**.
- `arch check` clean (no false comb-loop on the bus handshake — #550 bus-member granularity); Verilator `-Wall` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)