### PR TITLE
test(nic400,pipeline): cover GPV + C-channel designs and #549 taint edge cases

### DIFF
--- a/examples/nic400/tb_nic400_cchannel_clockgate.cpp
+++ b/examples/nic400/tb_nic400_cchannel_clockgate.cpp
@@ -1,0 +1,86 @@
+// Behavioral testbench for Nic400CChannelClockGate (AMBA Low-Power Interface
+// "C-channel" clock-gating handshake, NIC-400 TRM §2.2.3).
+//
+// Mirrors the harc-side Nic400CChannelClockGate_test.harc scenario so the same
+// gate/wake contract is exercised through arch-com's own sim + Verilator
+// backends (the harc test runs only through the harc harness):
+//   reset            → ACTIVE  (csysack=1, clk_en=1, cactive=0 when idle)
+//   csysreq=0 idle   → GATED   (csysack=0, clk_en=0)
+//   busy while gated  → WAKE    (back to ACTIVE, cactive=1)
+//   csysreq=0 + busy  → stays ACTIVE (a gate request can't gate active work)
+//   csysreq=1        → ACTIVE (run again)
+//
+// FSM outputs are combinational on the state register, so one clk edge then a
+// read observes the post-edge state. Runs identically under arch-sim (--tb)
+// and Verilator; prints "PASS cchannel_clockgate" on success, non-zero exit on
+// any mismatch.
+
+#include "VNic400CChannelClockGate.h"
+#include <cstdio>
+#include <cstdlib>
+
+static VNic400CChannelClockGate dut;
+
+static void tick() {
+    dut.clk = 0;
+    dut.eval();
+    dut.clk = 1;
+    dut.eval();
+}
+
+static int fail(const char *msg) {
+    fprintf(stdout, "FAIL cchannel_clockgate: %s\n", msg);
+    return 1;
+}
+
+int main() {
+    // ── Reset → ACTIVE, running ──────────────────────────────────────────
+    dut.rst = 1;
+    dut.cc_csysreq = 1; // controller wants the clock running
+    dut.busy = 0;
+    tick();
+    tick();
+    dut.rst = 0;
+    tick();
+    if (dut.cc_csysack != 1) return fail("post-reset csysack != 1");
+    if (dut.clk_en != 1)     return fail("post-reset clk_en != 1");
+    if (dut.cc_cactive != 0) return fail("idle cactive != 0");
+
+    // ── 1. Request quiesce while idle → GATED ────────────────────────────
+    dut.cc_csysreq = 0;
+    dut.busy = 0;
+    tick();
+    if (dut.cc_csysack != 0) return fail("gate: csysack != 0");
+    if (dut.clk_en != 0)     return fail("gate: clk_en != 0 (clock not gated)");
+
+    // ── 2. Activity while gated → WAKE back to ACTIVE ────────────────────
+    dut.busy = 1; // csysreq still 0, but pending work forces a wake
+    tick();
+    if (dut.clk_en != 1)     return fail("wake: clk_en != 1 (clock stayed gated)");
+    if (dut.cc_csysack != 1) return fail("wake: csysack != 1");
+    if (dut.cc_cactive != 1) return fail("wake: cactive != 1 (busy not reflected)");
+
+    // ── 3. csysreq=0 but busy → cannot gate active work, stays ACTIVE ────
+    dut.cc_csysreq = 0;
+    dut.busy = 1;
+    tick();
+    if (dut.clk_en != 1)     return fail("busy-hold: clk_en != 1 (gated despite busy)");
+    if (dut.cc_cactive != 1) return fail("busy-hold: cactive != 1");
+
+    // ── 4. Drop busy with csysreq=0 → now safe to GATE ───────────────────
+    dut.busy = 0;
+    tick();
+    if (dut.clk_en != 0)     return fail("regate: clk_en != 0 (idle gate request ignored)");
+    if (dut.cc_csysack != 0) return fail("regate: csysack != 0");
+
+    // ── 5. csysreq=1 → ACTIVE again ──────────────────────────────────────
+    dut.cc_csysreq = 1;
+    dut.busy = 0;
+    tick();
+    if (dut.cc_csysack != 1) return fail("rerun: csysack != 1");
+    if (dut.clk_en != 1)     return fail("rerun: clk_en != 1");
+    if (dut.cc_cactive != 0) return fail("rerun: cactive != 0");
+
+    fprintf(stdout, "PASS cchannel_clockgate\n");
+    return 0;
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -27515,3 +27515,310 @@ fn test_nic400_axi3_to_axi4_limiter_field_mapping_sv() {
         "MAX_BURST must be the GPV-programmable onward-AxLEN cap (default 16):\n{sv}",
     );
 }
+
+// The original #549 trio covers value-taint (direct + via-let) and the
+// register-read allow case. These three extend coverage to two distinct code
+// paths the trio doesn't touch: (1) the cross-stage register read (the key
+// "no false positive" guarantee — `Stage.reg` surfaces as the stage ident, so
+// it must not taint), and (2) the if-guard / mux-select taint threaded by
+// `collect_pipeline_comb_drivers` (an input used only as a mux SELECT still
+// drives the output combinationally, so it must be rejected — and a register
+// used the same way must NOT be).
+
+#[test]
+fn test_pipeline_allows_cross_stage_register_read() {
+    // `o = Fetch.captured` reads a register in ANOTHER stage. `Fetch.captured`
+    // surfaces as the stage ident `Fetch` (never an input/tainted name), so
+    // this must be accepted — the canonical pipeline data-flow pattern.
+    let source = r#"
+domain D
+  freq_mhz: 100
+end domain D
+pipeline XStagePipe
+  port clk: in Clock<D>;
+  port rst: in Reset<Sync>;
+  port a: in UInt<8>;
+  port o: out UInt<8>;
+  stage Fetch
+    reg captured: UInt<8> reset rst => 0;
+    seq on clk rising
+      captured <= a;
+    end seq
+  end stage Fetch
+  stage WB
+    reg r2: UInt<8> reset rst => 0;
+    seq on clk rising
+      r2 <= Fetch.captured;
+    end seq
+    comb
+      o = Fetch.captured;
+    end comb
+  end stage WB
+end pipeline XStagePipe
+"#;
+    assert!(
+        pipeline_checks_ok(source),
+        "a pipeline output driven from a cross-stage register read must be accepted"
+    );
+}
+
+#[test]
+fn test_pipeline_rejects_input_used_as_comb_mux_select() {
+    // `o = r0; if sel: o = r1;` — `sel` is an INPUT used only as a mux select,
+    // yet it drives `o` combinationally (the output flips sub-cycle with the
+    // input). Must be rejected: the if-guard idents are threaded into the
+    // driver's read set, so `sel` taints `o`.
+    let source = r#"
+domain D
+  freq_mhz: 100
+end domain D
+pipeline GuardSelPipe
+  port clk: in Clock<D>;
+  port rst: in Reset<Sync>;
+  port sel: in Bool;
+  port o: out UInt<8>;
+  stage S
+    reg r0: UInt<8> reset rst => 0;
+    reg r1: UInt<8> reset rst => 1;
+    seq on clk rising
+      r0 <= r0;
+      r1 <= r1;
+    end seq
+    comb
+      o = r0;
+      if sel
+        o = r1;
+      end if
+    end comb
+  end stage S
+end pipeline GuardSelPipe
+"#;
+    assert!(
+        !pipeline_checks_ok(source),
+        "an input used as a combinational mux select on an output must be rejected"
+    );
+}
+
+#[test]
+fn test_pipeline_allows_register_used_as_comb_mux_select() {
+    // Same shape as the reject case, but the mux select is a REGISTER
+    // (`sel_r`), so there is no comb path from any input to `o`. Reading a
+    // register as a guard must NOT taint — guards against an over-broad rule
+    // that would flag every conditional output.
+    let source = r#"
+domain D
+  freq_mhz: 100
+end domain D
+pipeline GuardRegPipe
+  port clk: in Clock<D>;
+  port rst: in Reset<Sync>;
+  port sel: in Bool;
+  port o: out UInt<8>;
+  stage S
+    reg sel_r: Bool reset rst => false;
+    reg r0: UInt<8> reset rst => 0;
+    reg r1: UInt<8> reset rst => 1;
+    seq on clk rising
+      sel_r <= sel;
+      r0 <= r0;
+      r1 <= r1;
+    end seq
+    comb
+      o = r0;
+      if sel_r
+        o = r1;
+      end if
+    end comb
+  end stage S
+end pipeline GuardRegPipe
+"#;
+    assert!(
+        pipeline_checks_ok(source),
+        "a register used as a combinational mux select on an output must be accepted"
+    );
+}
+
+
+// ────────────────────────────────────────────────────────────────────
+// NIC-400 GPV (PR #551) + C-channel clock-gate (PR #555) — coverage
+// ────────────────────────────────────────────────────────────────────
+//
+// Both designs landed as example .arch files with only harc-side
+// `_test.harc` coverage — nothing in arch-com's own integration suite
+// exercised them, so an arch-com codegen regression could silently break
+// either design (the harc tests run through a different repo's harness).
+// These tests close that gap: a behavioral cross-check of the C-channel
+// handshake on both the arch-sim and Verilator backends, and a
+// build + lint-clean + structure pin for the GPV AXI4-target regfile.
+
+/// C-channel low-power clock-gating handshake — behavioral check on the
+/// arch-sim backend. Mirrors examples/nic400/Nic400CChannelClockGate_test.harc
+/// (gate / wake / busy-hold / regate / rerun) so the FSM's same-cycle
+/// combinational outputs (csysack / cactive / clk_en) are verified through
+/// arch-com's own sim, not only the harc harness.
+#[test]
+fn test_nic400_cchannel_clockgate_arch_sim_behavior() {
+    let td = tempfile::tempdir().expect("tempdir");
+    let arch_bin = env!("CARGO_BIN_EXE_arch");
+    let out = std::process::Command::new(arch_bin)
+        .arg("sim")
+        .arg("examples/nic400/Nic400CChannelClockGate.arch")
+        .arg("examples/nic400/BusCChannel.arch")
+        .arg("--tb")
+        .arg("examples/nic400/tb_nic400_cchannel_clockgate.cpp")
+        .arg("--outdir")
+        .arg(td.path())
+        .output()
+        .expect("run arch sim for Nic400CChannelClockGate");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        out.status.success(),
+        "arch sim should pass for Nic400CChannelClockGate\nstdout:\n{}\nstderr:\n{}",
+        stdout,
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        stdout.contains("PASS cchannel_clockgate"),
+        "expected PASS marker in arch-sim stdout:\n{stdout}"
+    );
+}
+
+/// Verilator cross-check for the same C-channel handshake fixture — runs the
+/// identical TB through the SV backend so any divergence between the arch-sim
+/// scheduler and the generated SV trips both tests (or neither).
+#[test]
+fn test_nic400_cchannel_clockgate_verilator_behavior() {
+    if std::process::Command::new("verilator")
+        .arg("--version")
+        .output()
+        .is_err()
+    {
+        eprintln!("skipping Nic400CChannelClockGate Verilator behavior: verilator not found");
+        return;
+    }
+    let td = tempfile::tempdir().expect("tempdir");
+    let sv_out = td.path().join("cc.sv");
+    let obj_dir = td.path().join("obj_dir");
+    let arch_bin = env!("CARGO_BIN_EXE_arch");
+
+    let build = std::process::Command::new(arch_bin)
+        .arg("build")
+        .arg("examples/nic400/Nic400CChannelClockGate.arch")
+        .arg("examples/nic400/BusCChannel.arch")
+        .arg("-o")
+        .arg(&sv_out)
+        .output()
+        .expect("build Nic400CChannelClockGate SV");
+    assert!(
+        build.status.success(),
+        "arch build should pass\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&build.stdout),
+        String::from_utf8_lossy(&build.stderr)
+    );
+
+    // A 2-state FSM fills its 1-bit encoding completely, so PR #554's fix
+    // must have suppressed the (now vacuous) legal-state assertion. Pin it:
+    // if a future change re-introduces a power-of-2 legal-state assertion,
+    // this catches it before Verilator even runs.
+    let sv = std::fs::read_to_string(&sv_out).expect("read cc.sv");
+    assert!(
+        !sv.contains("legal_state"),
+        "a 2-state FSM must NOT emit a vacuous legal-state assertion (PR #554):\n{sv}"
+    );
+
+    let verilate = std::process::Command::new("verilator")
+        .arg("--cc")
+        .arg("--exe")
+        .arg("--build")
+        .arg("--sv")
+        .arg("--assert")
+        .arg("-Wno-DECLFILENAME")
+        .arg("--top-module")
+        .arg("Nic400CChannelClockGate")
+        .arg("-Mdir")
+        .arg(&obj_dir)
+        .arg(&sv_out)
+        .arg("examples/nic400/tb_nic400_cchannel_clockgate.cpp")
+        .output()
+        .expect("verilate Nic400CChannelClockGate");
+    assert!(
+        verilate.status.success(),
+        "Verilator build should pass\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&verilate.stdout),
+        String::from_utf8_lossy(&verilate.stderr)
+    );
+
+    let run = std::process::Command::new(obj_dir.join("VNic400CChannelClockGate"))
+        .output()
+        .expect("run Verilator Nic400CChannelClockGate");
+    let stdout = String::from_utf8_lossy(&run.stdout);
+    assert!(
+        run.status.success() && stdout.contains("PASS cchannel_clockgate"),
+        "expected PASS marker in Verilator stdout:\n{stdout}"
+    );
+}
+
+/// GPV AXI4-target config register file (PR #551) — build + Verilator
+/// lint-clean + module-structure pin. The GPV is a multi-file design
+/// (Nic400Gpv + Nic400GpvRegs + BusAxi4); behavioral correctness is
+/// covered by the harc-side `_test.harc`, so this guards specifically
+/// against an arch-com codegen / elaboration regression that would make
+/// the design fail to build or lint clean.
+#[test]
+fn test_nic400_gpv_builds_and_verilator_lint_clean() {
+    let td = tempfile::tempdir().expect("tempdir");
+    let sv_out = td.path().join("gpv.sv");
+    let arch_bin = env!("CARGO_BIN_EXE_arch");
+
+    let build = std::process::Command::new(arch_bin)
+        .arg("build")
+        .arg("examples/nic400/Nic400Gpv.arch")
+        .arg("examples/nic400/Nic400GpvRegs.arch")
+        .arg("examples/nic400/BusAxi4.arch")
+        .arg("-o")
+        .arg(&sv_out)
+        .output()
+        .expect("build Nic400Gpv SV");
+    assert!(
+        build.status.success(),
+        "arch build should pass for Nic400Gpv\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&build.stdout),
+        String::from_utf8_lossy(&build.stderr)
+    );
+
+    let sv = std::fs::read_to_string(&sv_out).expect("read gpv.sv");
+    assert!(
+        sv.contains("module Nic400Gpv") && sv.contains("module Nic400GpvRegs"),
+        "both GPV modules must be emitted:\n{sv}"
+    );
+    // The bus flattens to individual AXI ports — pin a representative one so a
+    // bus-flattening regression on a `target` AXI4 port trips here.
+    assert!(
+        sv.contains("s_ar_addr") && sv.contains("s_r_resp"),
+        "GPV `target BusAxi4` ports must flatten (s_ar_addr / s_r_resp):\n{sv}"
+    );
+
+    if std::process::Command::new("verilator")
+        .arg("--version")
+        .output()
+        .is_err()
+    {
+        eprintln!("skipping Nic400Gpv Verilator lint: verilator not found");
+        return;
+    }
+    let lint = std::process::Command::new("verilator")
+        .arg("--lint-only")
+        .arg("--sv")
+        .arg("-Wno-DECLFILENAME")
+        .arg("--top-module")
+        .arg("Nic400Gpv")
+        .arg(&sv_out)
+        .output()
+        .expect("verilator lint Nic400Gpv");
+    assert!(
+        lint.status.success(),
+        "Nic400Gpv must lint clean under Verilator\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&lint.stdout),
+        String::from_utf8_lossy(&lint.stderr)
+    );
+}


### PR DESCRIPTION
## What

Pure **test coverage** for code that landed in the last 24h (no source changes).

### Gap closed
- **NIC-400 GPV (#551)** and **C-channel clock-gate (#555)** shipped as example `.arch` files with only harc-side `_test.harc` coverage — nothing in arch-com's own integration suite exercised them. An arch-com codegen/elaboration regression could silently break either design (the harc tests run through a different repo's harness).
- The **#549 pipeline comb-passthrough rule** shipped a differential trio (value-taint direct + via-let, register-read allow) but left two code paths untested: the cross-stage register read (no-false-positive guarantee) and the if-guard / mux-select taint threading.

### Added (all green on a fresh release build)
- `test_nic400_cchannel_clockgate_arch_sim_behavior` / `..._verilator_behavior` — a new behavioral TB (`tb_nic400_cchannel_clockgate.cpp`) drives the full gate / wake / busy-hold / regate / rerun handshake on **both** the arch-sim and Verilator backends, mirroring the harc scenario. The Verilator path also pins **PR #554**'s fix: a 2-state FSM must NOT emit a vacuous legal-state assertion.
- `test_nic400_gpv_builds_and_verilator_lint_clean` — multi-file build of the GPV (`Nic400Gpv` + `Nic400GpvRegs` + `BusAxi4`), module-structure + bus-flatten pins, and a Verilator lint-clean gate (the design is clean even under strict lint).
- `test_pipeline_allows_cross_stage_register_read` — the key #549 no-false-positive guarantee (`o = Fetch.captured` must be accepted).
- `test_pipeline_rejects_input_used_as_comb_mux_select` / `test_pipeline_allows_register_used_as_comb_mux_select` — the if-guard threading path: an input used only as a mux SELECT taints the output (reject), a register used the same way does not (accept).

## Test
`cargo test --release --test integration_test`: **622 passed** (was 616), 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)