### PR TITLE
feat(nic400): sparse per-master address decode (CONNECT_MASK) + fix sim param-override drop

### DIFF
--- a/examples/nic400/Nic400SparseAddrDecode.arch
+++ b/examples/nic400/Nic400SparseAddrDecode.arch
@@ -1,0 +1,64 @@
+// Sparse per-master address decoder (NIC-400 "sparse connectivity" feature).
+//
+// Each master interface (ASIB) in a NIC-400 is wired to its OWN subset of
+// slaves, configured per-master at build time. An access from a master to a
+// slave region it is NOT connected to returns DECERR (AXI resp 0b11). This
+// gives every master a distinct *view* of the global address map — the
+// faithful NIC-400 feature (NOT arbitrary per-master remapping, which base
+// NIC-400 does not have).
+//
+// This is the pure-combinational decode core, parameterised by a per-instance
+// connectivity bitmap CONNECT_MASK (bit j set = this master reaches slave j).
+// Instantiate two copies with DIFFERENT masks to give two masters different
+// reachable region sets over the SAME global address map.
+//
+// Address map (same shape as Nic400MasterPort, spec §3): NUM_SLAVES contiguous
+// 2^REGION_BITS regions. The decoder takes the top NS_W = $clog2(NUM_SLAVES)
+// bits below REGION_BITS to pick the slave index.
+//
+//   slot      = addr >> REGION_BITS
+//   slave_idx = slot[NS_W-1:0]
+//   oor       = (bits above the NS_W selector are non-zero)        // beyond the map
+//            or (slave_idx >= NUM_SLAVES)                          // hole in NS_W space
+//   not_conn  = CONNECT_MASK bit for slave_idx is 0                // sparse hole
+//   decerr    = valid and (oor or not_conn)
+//
+// Pure comb, no clock — a decode has no latency. `decerr=1` tells the caller to
+// synthesise a DECERR response instead of forwarding the transaction.
+module Nic400SparseAddrDecode
+  param NUM_SLAVES:  const = 4;
+  param REGION_BITS: const = 28;          // 256 MiB per region (with ADDR_W=32)
+  param ADDR_W:      const = 32;
+  // Per-instance connectivity bitmap: bit j = this master reaches slave j.
+  // Default = all slaves reachable (dense). Override per master for sparse view.
+  param CONNECT_MASK: const = (1 << NUM_SLAVES) - 1;
+
+  param NS_W: const = $clog2(NUM_SLAVES);
+
+  port addr:      in  UInt<ADDR_W>;
+  port valid:     in  Bool;
+
+  port slave_idx: out UInt<NS_W>;
+  port decerr:    out Bool;
+
+  // `slot` is the full region index of this address (ADDR_W wide). The low
+  // NS_W bits give the slave selector; a populated slave has slot < NUM_SLAVES.
+  let slot: UInt<ADDR_W> = addr >> REGION_BITS;
+  let sel:  UInt<NS_W>   = slot.trunc<NS_W>();
+
+  // Out-of-range: addr lands beyond the populated map. Comparing the full-width
+  // `slot` against NUM_SLAVES covers BOTH addresses above the NS_W window AND
+  // in-window holes when NUM_SLAVES is not a power of two (e.g. NUM_SLAVES=3,
+  // slot==3). `slot` is ADDR_W wide so this is a width-clean comparison.
+  let oor: Bool = (slot >= NUM_SLAVES);
+
+  // Not connected: this master's CONNECT_MASK does not have slave `sel` set.
+  // (CONNECT_MASK >> sel) & 1 == 0  ⇒  sparse hole for this master.
+  let mask_bit: UInt<1> = ((CONNECT_MASK >> sel) & 1).trunc<1>();
+  let not_conn: Bool = (mask_bit == 0);
+
+  comb
+    slave_idx = sel;
+    decerr    = valid and (oor or not_conn);
+  end comb
+end module Nic400SparseAddrDecode

--- a/examples/nic400/Nic400SparseDemo.arch
+++ b/examples/nic400/Nic400SparseDemo.arch
@@ -1,0 +1,63 @@
+// Sparse-connectivity demonstrator: two masters, one global address map, two
+// DIFFERENT views of it via per-instance CONNECT_MASK.
+//
+// Global map (NUM_SLAVES=4, REGION_BITS=28, 256 MiB each):
+//   slave 0 : 0x0000_0000 .. 0x0FFF_FFFF
+//   slave 1 : 0x1000_0000 .. 0x1FFF_FFFF
+//   slave 2 : 0x2000_0000 .. 0x2FFF_FFFF
+//   slave 3 : 0x3000_0000 .. 0x3FFF_FFFF
+//   >= 0x4000_0000 : out-of-range
+//
+// Per-master connectivity:
+//   M0  CONNECT_MASK = 0b0011 = 0x3  → reaches slaves {0, 1}
+//   M1  CONNECT_MASK = 0b0110 = 0x6  → reaches slaves {1, 2}
+//
+// Both decoders see the SAME addr/valid, but produce different reachability:
+//   - addr in slave-0 region : M0 decerr=0, M1 decerr=1  (M1 not connected to S0)
+//   - addr in slave-1 region : M0 decerr=0, M1 decerr=0  (both connected to S1)
+//   - addr in slave-2 region : M0 decerr=1, M1 decerr=0  (M0 not connected to S2)
+//   - addr in slave-3 region : M0 decerr=1, M1 decerr=1  (neither connected, in-map hole)
+//   - addr >= 0x4000_0000    : M0 decerr=1, M1 decerr=1  (out-of-range for both)
+// slave_idx is the same on both ports (same global decode); only decerr differs.
+//
+// Pure combinational — instantiates two Nic400SparseAddrDecode copies.
+module Nic400SparseDemo
+  param NUM_SLAVES:  const = 4;
+  param REGION_BITS: const = 28;
+  param ADDR_W:      const = 32;
+  param NS_W:        const = $clog2(NUM_SLAVES);
+
+  port addr:  in  UInt<ADDR_W>;
+  port valid: in  Bool;
+
+  // M0 view
+  port m0_slave_idx: out UInt<NS_W>;
+  port m0_decerr:    out Bool;
+  // M1 view
+  port m1_slave_idx: out UInt<NS_W>;
+  port m1_decerr:    out Bool;
+
+  // M0 reaches slaves {0,1}.
+  inst dec_m0: Nic400SparseAddrDecode
+    param NUM_SLAVES   = NUM_SLAVES;
+    param REGION_BITS  = REGION_BITS;
+    param ADDR_W       = ADDR_W;
+    param CONNECT_MASK = 0x3;
+    addr      <- addr;
+    valid     <- valid;
+    slave_idx -> m0_slave_idx;
+    decerr    -> m0_decerr;
+  end inst dec_m0
+
+  // M1 reaches slaves {1,2}.
+  inst dec_m1: Nic400SparseAddrDecode
+    param NUM_SLAVES   = NUM_SLAVES;
+    param REGION_BITS  = REGION_BITS;
+    param ADDR_W       = ADDR_W;
+    param CONNECT_MASK = 0x6;
+    addr      <- addr;
+    valid     <- valid;
+    slave_idx -> m1_slave_idx;
+    decerr    -> m1_decerr;
+  end inst dec_m1
+end module Nic400SparseDemo

--- a/examples/nic400/Nic400SparseDemo_test.harc
+++ b/examples/nic400/Nic400SparseDemo_test.harc
@@ -1,0 +1,118 @@
+// HARC unit test for the NIC-400 sparse-connectivity address decoder.
+//
+// Nic400SparseDemo instantiates TWO Nic400SparseAddrDecode copies over one
+// global address map (4 slaves, 256 MiB each, REGION_BITS=28):
+//   M0  CONNECT_MASK = 0x3 → reaches slaves {0, 1}
+//   M1  CONNECT_MASK = 0x6 → reaches slaves {1, 2}
+//
+// Same addr/valid drives both; they must produce DIFFERENT reachability.
+// slave_idx is the same on both (same global decode); only decerr differs.
+//
+// Run:
+//   harc sim --dut examples/nic400/Nic400SparseAddrDecode.arch \
+//            --dut examples/nic400/Nic400SparseDemo.arch \
+//            examples/nic400/Nic400SparseDemo_test.harc --top Nic400SparseDemo
+//
+// Region base addresses: slave j = j << 28.
+//   S0 = 0x0000_0000   S1 = 0x1000_0000   S2 = 0x2000_0000   S3 = 0x3000_0000
+//   OOR = 0x4000_0000+
+testbench Nic400SparseDemoTb
+    dut : Nic400SparseDemo
+end testbench Nic400SparseDemoTb
+
+impl Nic400SparseDemoTest for Nic400SparseDemoTb
+    run
+        log(info, "Nic400 sparse-connectivity decode test: M0={0,1}, M1={1,2}")
+
+        dut.valid = 1
+
+        // ── Slave 0 region (0x0000_0000) ────────────────────────────────
+        // M0 connected → decerr=0; M1 NOT connected → decerr=1. idx=0 both.
+        dut.addr = 0x00000000
+        wait 1 cycle
+        assert dut.m0_slave_idx == 0
+            else fail("S0: m0_slave_idx=0x${dut.m0_slave_idx:x}, expected 0")
+        assert dut.m1_slave_idx == 0
+            else fail("S0: m1_slave_idx=0x${dut.m1_slave_idx:x}, expected 0")
+        assert dut.m0_decerr == 0
+            else fail("S0: M0 should reach S0 (decerr=0), got ${dut.m0_decerr}")
+        assert dut.m1_decerr == 1
+            else fail("S0: M1 must NOT reach S0 (decerr=1), got ${dut.m1_decerr}")
+
+        // mid-region address (0x0ABC_DEF0) must decode identically to base.
+        dut.addr = 0x0ABCDEF0
+        wait 1 cycle
+        assert dut.m0_slave_idx == 0
+            else fail("S0-mid: m0_slave_idx=0x${dut.m0_slave_idx:x}, expected 0")
+        assert dut.m0_decerr == 0
+            else fail("S0-mid: M0 decerr=0 expected, got ${dut.m0_decerr}")
+        assert dut.m1_decerr == 1
+            else fail("S0-mid: M1 decerr=1 expected, got ${dut.m1_decerr}")
+
+        // ── Slave 1 region (0x1000_0000) ────────────────────────────────
+        // Both connected → decerr=0 both. idx=1 both.
+        dut.addr = 0x10000000
+        wait 1 cycle
+        assert dut.m0_slave_idx == 1
+            else fail("S1: m0_slave_idx=0x${dut.m0_slave_idx:x}, expected 1")
+        assert dut.m1_slave_idx == 1
+            else fail("S1: m1_slave_idx=0x${dut.m1_slave_idx:x}, expected 1")
+        assert dut.m0_decerr == 0
+            else fail("S1: M0 should reach S1 (decerr=0), got ${dut.m0_decerr}")
+        assert dut.m1_decerr == 0
+            else fail("S1: M1 should reach S1 (decerr=0), got ${dut.m1_decerr}")
+
+        // ── Slave 2 region (0x2000_0000) ────────────────────────────────
+        // M0 NOT connected → decerr=1; M1 connected → decerr=0. idx=2 both.
+        dut.addr = 0x20000000
+        wait 1 cycle
+        assert dut.m0_slave_idx == 2
+            else fail("S2: m0_slave_idx=0x${dut.m0_slave_idx:x}, expected 2")
+        assert dut.m1_slave_idx == 2
+            else fail("S2: m1_slave_idx=0x${dut.m1_slave_idx:x}, expected 2")
+        assert dut.m0_decerr == 1
+            else fail("S2: M0 must NOT reach S2 (decerr=1), got ${dut.m0_decerr}")
+        assert dut.m1_decerr == 0
+            else fail("S2: M1 should reach S2 (decerr=0), got ${dut.m1_decerr}")
+
+        // ── Slave 3 region (0x3000_0000) ────────────────────────────────
+        // In-map but neither master is connected (S3 in neither mask) → decerr=1 both.
+        dut.addr = 0x30000000
+        wait 1 cycle
+        assert dut.m0_slave_idx == 3
+            else fail("S3: m0_slave_idx=0x${dut.m0_slave_idx:x}, expected 3")
+        assert dut.m0_decerr == 1
+            else fail("S3: M0 not connected to S3 (decerr=1), got ${dut.m0_decerr}")
+        assert dut.m1_decerr == 1
+            else fail("S3: M1 not connected to S3 (decerr=1), got ${dut.m1_decerr}")
+
+        // ── Out-of-range (0x4000_0000) ──────────────────────────────────
+        // Beyond the populated map → decerr=1 for both masters.
+        dut.addr = 0x40000000
+        wait 1 cycle
+        assert dut.m0_decerr == 1
+            else fail("OOR: M0 decerr=1 expected, got ${dut.m0_decerr}")
+        assert dut.m1_decerr == 1
+            else fail("OOR: M1 decerr=1 expected, got ${dut.m1_decerr}")
+
+        // top of address space (0xFFFF_FFFF) → OOR for both.
+        dut.addr = 0xFFFFFFFF
+        wait 1 cycle
+        assert dut.m0_decerr == 1
+            else fail("OOR-top: M0 decerr=1 expected, got ${dut.m0_decerr}")
+        assert dut.m1_decerr == 1
+            else fail("OOR-top: M1 decerr=1 expected, got ${dut.m1_decerr}")
+
+        // ── valid=0 squelches decerr (no transaction) ───────────────────
+        // Same OOR addr, but valid=0 → decerr must be 0 (no access in flight).
+        dut.valid = 0
+        dut.addr = 0x40000000
+        wait 1 cycle
+        assert dut.m0_decerr == 0
+            else fail("valid=0: M0 decerr must squelch to 0, got ${dut.m0_decerr}")
+        assert dut.m1_decerr == 0
+            else fail("valid=0: M1 decerr must squelch to 0, got ${dut.m1_decerr}")
+
+        log(info, "PASS: Nic400SparseDemo — per-master distinct reachability (S0/S1/S2/S3/OOR/valid-gate) all OK")
+    end run
+end impl Nic400SparseDemoTest

--- a/src/elaborate.rs
+++ b/src/elaborate.rs
@@ -566,14 +566,29 @@ fn elaborate_module_variant(
         .into_iter()
         .map(|mut p| {
             if let Some(&val) = param_vals.get(&p.name.name) {
-                if matches!(p.kind, ParamKind::EnumConst(_)) {
-                    // Preserve the EnumVariant expression for clean SV output
-                } else if p
+                // A derived default (one that references other params) is only
+                // safe to *preserve* when this variant's resolved value still
+                // equals re-evaluating that expression under the variant's
+                // params. If the inst site explicitly overrode the param, the
+                // resolved `val` diverges from the expression — preserving the
+                // expression would silently drop the override (the SV backend
+                // re-applies it as an inst param, but the sim backend bakes the
+                // module default into a `#define`, so the override is lost).
+                // In that case fall through to the literal-replacement path so
+                // both backends see the overridden value.
+                let derived_default_tracks = p
                     .default
                     .as_ref()
                     .map_or(false, |d| expr_references_params(d, &param_names))
-                {
-                    // Preserve original expression for derived params
+                    && p.default
+                        .as_ref()
+                        .and_then(|d| try_eval_i64(d, &param_vals))
+                        .map_or(false, |dv| dv == val);
+                if matches!(p.kind, ParamKind::EnumConst(_)) {
+                    // Preserve the EnumVariant expression for clean SV output
+                } else if derived_default_tracks {
+                    // Preserve original expression for derived params that were
+                    // NOT overridden (value still tracks the parent param).
                 } else {
                     // Width-typed params (`param NAME[hi:lo]: const = ...`) emit
                     // SV `parameter [hi:lo] NAME = <default>`. If we replaced

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -16933,6 +16933,68 @@ fn test_sim_codegen_declares_typed_module_params_used_by_lowered_thread_body() {
 }
 
 #[test]
+fn test_sim_codegen_inst_override_of_derived_default_param_wins_in_define() {
+    // Regression (NIC-400 sparse-connectivity decoder): a sub-module param
+    // whose *default* references another param (`CONNECT_MASK = (1 << N) - 1`)
+    // but which is EXPLICITLY OVERRIDDEN at the inst site must bake the
+    // overridden value — not the default expression's value — into the sim
+    // backend's `#define`.
+    //
+    // Pre-fix: monomorphize_module preserved the derived-default expression
+    // for any param referencing other params, even when the inst site
+    // overrode it. The SV backend masked this (it re-applies the override as
+    // an inst param), but the C++ sim backend emits `#define CONNECT_MASK
+    // <default>`, so the override was silently dropped — two instances with
+    // different masks both evaluated against the default value. The two
+    // backends then diverged under harc --check-backends.
+    let source = r#"
+        module Sub
+          param N: const = 4;
+          param MASK: const = (1 << N) - 1;
+          port sel:  in  UInt<2>;
+          port hit:  out Bool;
+          let bit_v: UInt<1> = ((MASK >> sel) & 1).trunc<1>();
+          comb
+            hit = (bit_v == 1);
+          end comb
+        end module Sub
+
+        module Top
+          port sel:   in  UInt<2>;
+          port hit_a: out Bool;
+          port hit_b: out Bool;
+          inst a: Sub
+            param N    = 4;
+            param MASK = 3;
+            sel <- sel;
+            hit -> hit_a;
+          end inst a
+          inst b: Sub
+            param N    = 4;
+            param MASK = 6;
+            sel <- sel;
+            hit -> hit_b;
+          end inst b
+        end module Top
+    "#;
+    let cpp = compile_to_sim_h(source, false);
+    // The two specialized variants must carry their OVERRIDDEN mask values,
+    // not the derived default `(1 << 4) - 1 == 15`.
+    assert!(
+        cpp.contains("#define MASK 3ULL"),
+        "overridden derived-default param must bake the override (3), not the default (15):\n{cpp}"
+    );
+    assert!(
+        cpp.contains("#define MASK 6ULL"),
+        "second instance's overridden mask (6) must also be baked, not the default (15):\n{cpp}"
+    );
+    assert!(
+        !cpp.contains("#define MASK 15ULL"),
+        "the derived default (15) must NOT leak into either specialized sim header:\n{cpp}"
+    );
+}
+
+#[test]
 fn test_sim_codegen_bit_slice_lhs_compiles_and_uses_param_width() {
     // Regression: pre-fix, `name[hi:lo] = val` in a seq block lowered to
     // the read-side bit-slice form `((name >> lo) & MASK) = val`, an


### PR DESCRIPTION
## What

Implements the NIC-400 **sparse connectivity** feature: a per-master combinational address decoder parameterised by a per-instance `CONNECT_MASK` bitmap. Each master interface (ASIB) reaches its OWN subset of slaves; an access to a slave region it is NOT connected to returns **DECERR**. Each master thus gets a distinct *view* of the single global address map — the faithful NIC-400 feature (NOT arbitrary per-master remapping, which base NIC-400 lacks; no remap registers).

### New example files
- `examples/nic400/Nic400SparseAddrDecode.arch` — pure-comb decode core. Inputs `addr`/`valid`; params `NUM_SLAVES`/`REGION_BITS`/`ADDR_W`/`CONNECT_MASK`; outputs `slave_idx` + `decerr`. Decode: `slot = addr >> REGION_BITS`, `slave_idx = slot[NS_W-1:0]`, `oor = slot >= NUM_SLAVES`, `not_conn = ((CONNECT_MASK >> slave_idx) & 1) == 0`, `decerr = valid and (oor or not_conn)`.
- `examples/nic400/Nic400SparseDemo.arch` — wrapper instantiating two decoders over the SAME global map with DIFFERENT masks: **M0 = {0,1} (0x3)**, **M1 = {1,2} (0x6)**.
- `examples/nic400/Nic400SparseDemo_test.harc` — drives S0/S1/S2/S3/OOR + a `valid=0` squelch case; asserts `(slave_idx, decerr)` per mask on both masters (e.g. S0 → M0 decerr=0 / M1 decerr=1; S2 → M0 decerr=1 / M1 decerr=0).

## Compiler bug found + fixed (internal, no user-facing change)

Building this surfaced a real **param-specialization bug** in elaboration that affects the C++ sim backend. When a sub-module param's *default* references another param (e.g. `CONNECT_MASK = (1 << N) - 1`) but the inst site **explicitly overrides** it, `monomorphize_module` preserved the derived-default *expression* and dropped the override.

- The **SV backend** masked the bug — it re-applies the override as an inst param (`.CONNECT_MASK('h3)`).
- The **C++ sim backend** bakes the module default into a `#define`, so both specialised instances emitted `#define CONNECT_MASK 15ULL` (the default) instead of `3`/`6`. The two backends then **diverged** under `harc --check-backends`.

**Fix** (`src/elaborate.rs`, `elaborate_module_variant`): only preserve a derived-default expression when the variant's resolved value still equals re-evaluating that expression under the variant's params (i.e. the param was NOT overridden). When the override diverges from the default, fall through to literal replacement so both backends agree.

Regression test: `test_sim_codegen_inst_override_of_derived_default_param_wins_in_define` (asserts the two specialised sim headers carry `#define MASK 3ULL` / `6ULL` and never the default `15ULL`).

## Verification
- `arch check`: clean (no warnings).
- `arch build` + `verilator --lint-only -Wall -Wno-DECLFILENAME --top-module Nic400SparseDemo`: **lint-clean**.
- `harc sim --check-backends` (ARCH sim ↔ Verilator): **ALL TESTS PASSED** on both backends; **"traces match across backends (no divergence)"**.
- `cargo test --lib --test integration_test`: 47 + 617 green (the new regression test included).

🤖 Generated with [Claude Code](https://claude.com/claude-code)