### PR TITLE
feat(nic400): AXI4→AHB-Lite slave-side (mirrored) bridge

### DIFF
--- a/examples/nic400/Nic400AhbSlaveBridge.arch
+++ b/examples/nic400/Nic400AhbSlaveBridge.arch
@@ -1,0 +1,248 @@
+// AXI4 ↔ AHB-Lite slave-side (mirrored) bridge.
+//
+// This is the MIRROR of Nic400AhbBridge.arch. That module is the AHB-MASTER
+// side: an AHB-Lite CPU master driving INTO the AXI4 fabric (AHB `target` +
+// AXI `initiator`). This module flips both roles — it is the AHB-Lite master
+// interface / "mirrored slave" flavour per TRM §2.2.1/§2.2.2:
+//
+//   • AXI4 `target` on `axi`  — the fabric's AMIB / SlavePort drives this side.
+//     The bridge sees AR/AW/W as IN and drives R/B + the *_ready backpressure.
+//   • AHB-Lite `initiator` (master) on `h` — the bridge drives the AHB address
+//     and data phases at an external AHB peripheral/slave and samples
+//     HRDATA/HREADY/HRESP back.
+//
+// Sized for the same DATA_W/ADDR_W as the fabric (32/32 default) so it drops in
+// alongside the AHB-master-side bridge and the APB bridge as one of the
+// fabric's SlavePort downstreams (an AHB peripheral).
+//
+// What v1 implements (single-beat, HBURST=SINGLE):
+//   • AXI4 AR (read) → AHB address phase (HTRANS=NONSEQ, HWRITE=0, HADDR=
+//     ar_addr, HSIZE=ar_size, HPROT from ar_prot, HMASTLOCK from ar_lock) →
+//     AHB data phase (capture HRDATA when HREADY) → AXI4 R response
+//     (RDATA=HRDATA, RRESP from HRESP, RLAST=1).
+//   • AXI4 AW+W (write) → AHB address phase (HWRITE=1) + data phase
+//     (HWDATA=w_data) → AXI4 B response (BRESP from HRESP).
+//   • Map: axsize→HSIZE (direct copy), axprot→HPROT (low bits, AHB HPROT[0]=
+//     data/opcode is forced to 1=data, [3:1] from axprot), axlock→HMASTLOCK.
+//   • HRESP OKAY(0)/ERROR(1) → AXI OKAY(0)/SLVERR(2). AHB-Lite collapses the
+//     two-cycle ERROR sequence to a one-bit HRESP asserted in the data phase;
+//     this bridge samples HRESP in the same cycle it samples HREADY=1, which
+//     matches the single-data-phase model used by the rest of the NIC-400 demo.
+//
+// AHB-Lite master protocol (single transfer), as driven by this bridge:
+//   • Address phase: while the previous transfer's HREADY=1, drive
+//     HTRANS=NONSEQ + HADDR + control. The address phase "completes" (the
+//     slave latches the address) on the rising edge where HREADY=1.
+//   • Data phase: the cycle after the address phase, HRDATA/HRESP are valid
+//     when HREADY=1. The slave may insert wait states by holding HREADY=0;
+//     the bridge stays in the data-phase state until HREADY=1.
+//   During the data phase the bridge drives HTRANS=IDLE so the slave does not
+//   start a second, unintended transfer.
+//
+// Limitations (v1):
+//   • Single-beat only (HBURST=SINGLE). The AXI side accepts ar_len/aw_len but
+//     v1 verifies axlen=0; multi-beat AHB streaming is a follow-on (mirrors the
+//     master-side bridge's own single-beat-first staging).
+//   • No AXI exclusive-access semantics on the AHB side beyond forwarding
+//     ar_lock/aw_lock to HMASTLOCK.
+//
+// Concurrency: the read and write paths run as independent threads. The single
+// AHB master port is time-shared; the two threads serialise their AHB drives
+// via the h_lock priority mutex (an AXI master rarely has a read and a write to
+// the same peripheral in flight at once, but the lock keeps the multi-driver
+// legal in the lowered FSM — same pattern as the master-side bridge and the
+// APB bridge).
+module Nic400AhbSlaveBridge
+  param ADDR_WIDTH: const = 32;
+  param DATA_WIDTH: const = 32;
+  param STRB_WIDTH: const = 4;         // = DATA_WIDTH/8
+  param ID_WIDTH:   const = 3;
+
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Async, Low>;
+
+  // AXI4 target — bridge sees AR/AW/W as IN, drives R/B and the *_ready
+  // backpressure signals.
+  port axi: target    BusAxi4<ADDR_W=ADDR_WIDTH, DATA_W=DATA_WIDTH, STRB_W=STRB_WIDTH,
+                              ID_W=ID_WIDTH, READ=1, WRITE=1>;
+  // AHB-Lite initiator (master) — bridge drives address/control/HWDATA,
+  // samples HRDATA/HREADY/HRESP.
+  port h:   initiator BusAhbLite<ADDR_W=ADDR_WIDTH, DATA_W=DATA_WIDTH>;
+
+  // Mutex to serialise the multi-thread comb drives on h.*. In steady state
+  // the two threads do not contend; the lock keeps the multi-driver legal in
+  // the lowered FSM.
+  resource h_lock: mutex<priority>;
+
+  // ── Read-path captured state ────────────────────────────────────────
+  reg ar_addr_r: UInt<ADDR_WIDTH> reset rst => 0;
+  reg ar_size_r: UInt<3>          reset rst => 0;
+  reg ar_prot_r: UInt<3>          reset rst => 0;
+  reg ar_lock_r: Bool             reset rst => false;
+  reg ar_id_r:   UInt<ID_WIDTH>   reset rst => 0;
+  reg rdata_r:   UInt<DATA_WIDTH> reset rst => 0;
+  reg rerr_r:    Bool             reset rst => false;
+
+  // ── Write-path captured state ───────────────────────────────────────
+  reg aw_addr_r: UInt<ADDR_WIDTH> reset rst => 0;
+  reg aw_size_r: UInt<3>          reset rst => 0;
+  reg aw_prot_r: UInt<3>          reset rst => 0;
+  reg aw_lock_r: Bool             reset rst => false;
+  reg aw_id_r:   UInt<ID_WIDTH>   reset rst => 0;
+  reg wdata_r:   UInt<DATA_WIDTH> reset rst => 0;
+  reg werr_r:    Bool             reset rst => false;
+
+  // AXI {b,r}_resp from AHB HRESP. HRESP OKAY=0 → AXI OKAY=0; HRESP ERROR=1
+  // → AXI SLVERR=2 (0b10).
+  function ahb_resp_to_axi(hresp: Bool) -> UInt<2>
+    if hresp
+      return 2;
+    else
+      return 0;
+    end if
+  end function ahb_resp_to_axi
+
+  // AXI axprot[2:0] → AHB HPROT[3:0]. AHB HPROT bit0 (data/opcode) is forced
+  // to 1 (data access); bits [3:1] carry privilege/bufferable/cacheable hints
+  // from the AXI prot low bits. This is a pragmatic mapping for the demo — the
+  // real ARM bridge has a configurable HPROT remap table.
+  function axi_prot_to_ahb(axprot: UInt<3>) -> UInt<4>
+    return (axprot.zext<4>() << 1) | 1;
+  end function axi_prot_to_ahb
+
+  // ── Read thread ──────────────────────────────────────────────────────
+  // AXI AR → AHB read transfer → AXI R.
+  thread ReadXact on clk rising, rst low
+    default comb
+      axi.ar_ready = false;
+      axi.r_valid  = false;
+      axi.r_data   = 0;
+      axi.r_id     = 0;
+      axi.r_resp   = 0;
+      axi.r_last   = false;
+      h.hsel       = false;
+      h.haddr      = 0;
+      h.hwrite     = false;
+      h.hsize      = 0;
+      h.hburst     = 0;
+      h.hprot      = 0;
+      h.htrans     = 0;     // IDLE
+      h.hmastlock  = false;
+      h.hwdata     = 0;
+    end default
+    // AR handshake — Mealy-fuse the capture into the wake state.
+    if not (axi.ar_valid)
+      wait until axi.ar_valid;
+    end if
+    do
+      axi.ar_ready = true;
+      ar_addr_r <= axi.ar_addr;
+      ar_size_r <= axi.ar_size;
+      ar_prot_r <= axi.ar_prot;
+      ar_lock_r <= axi.ar_lock;
+      ar_id_r   <= axi.ar_id;
+    until true;
+    // AHB address phase — drive NONSEQ read. Completes when slave HREADY=1.
+    lock h_lock
+      do
+        h.hsel      = true;
+        h.htrans    = 2;     // NONSEQ
+        h.haddr     = ar_addr_r;
+        h.hwrite    = false;
+        h.hsize     = ar_size_r;
+        h.hburst    = 0;     // SINGLE
+        h.hprot     = axi_prot_to_ahb(ar_prot_r);
+        h.hmastlock = ar_lock_r;
+      until h.hready;
+    end lock h_lock
+    // AHB data phase — HTRANS=IDLE (no second transfer), capture HRDATA/HRESP
+    // on the HREADY=1 cycle.
+    lock h_lock
+      do
+        h.hsel   = true;
+        h.htrans = 0;        // IDLE
+        rdata_r <= h.hrdata;
+        rerr_r  <= h.hresp;
+      until h.hready;
+    end lock h_lock
+    // AXI R beat — single-beat, RLAST=1. Held until r_ready.
+    do
+      axi.r_valid = true;
+      axi.r_data  = rdata_r;
+      axi.r_id    = ar_id_r;
+      axi.r_resp  = ahb_resp_to_axi(rerr_r);
+      axi.r_last  = true;
+    until axi.r_ready;
+  end thread ReadXact
+
+  // ── Write thread ─────────────────────────────────────────────────────
+  // AXI AW+W → AHB write transfer → AXI B.
+  thread WriteXact on clk rising, rst low
+    default comb
+      axi.aw_ready = false;
+      axi.w_ready  = false;
+      axi.b_valid  = false;
+      axi.b_id     = 0;
+      axi.b_resp   = 0;
+      h.hsel       = false;
+      h.haddr      = 0;
+      h.hwrite     = false;
+      h.hsize      = 0;
+      h.hburst     = 0;
+      h.hprot      = 0;
+      h.htrans     = 0;     // IDLE
+      h.hmastlock  = false;
+      h.hwdata     = 0;
+    end default
+    // AW handshake — capture address/control, clear werr_r.
+    if not (axi.aw_valid)
+      wait until axi.aw_valid;
+    end if
+    do
+      axi.aw_ready = true;
+      aw_addr_r <= axi.aw_addr;
+      aw_size_r <= axi.aw_size;
+      aw_prot_r <= axi.aw_prot;
+      aw_lock_r <= axi.aw_lock;
+      aw_id_r   <= axi.aw_id;
+      werr_r    <= false;
+    until true;
+    // W handshake — capture the single write-data beat.
+    if not (axi.w_valid)
+      wait until axi.w_valid;
+    end if
+    do
+      axi.w_ready = true;
+      wdata_r <= axi.w_data;
+    until true;
+    // AHB address phase — drive NONSEQ write. Completes when slave HREADY=1.
+    lock h_lock
+      do
+        h.hsel      = true;
+        h.htrans    = 2;     // NONSEQ
+        h.haddr     = aw_addr_r;
+        h.hwrite    = true;
+        h.hsize     = aw_size_r;
+        h.hburst    = 0;     // SINGLE
+        h.hprot     = axi_prot_to_ahb(aw_prot_r);
+        h.hmastlock = aw_lock_r;
+      until h.hready;
+    end lock h_lock
+    // AHB data phase — drive HWDATA, HTRANS=IDLE, capture HRESP on HREADY=1.
+    lock h_lock
+      do
+        h.hsel   = true;
+        h.htrans = 0;        // IDLE
+        h.hwrite = true;
+        h.hwdata = wdata_r;
+        werr_r <= h.hresp;
+      until h.hready;
+    end lock h_lock
+    // AXI B response — single-beat write done.
+    do
+      axi.b_valid = true;
+      axi.b_id    = aw_id_r;
+      axi.b_resp  = ahb_resp_to_axi(werr_r);
+    until axi.b_ready;
+  end thread WriteXact
+end module Nic400AhbSlaveBridge

--- a/examples/nic400/Nic400AhbSlaveBridge_test.harc
+++ b/examples/nic400/Nic400AhbSlaveBridge_test.harc
@@ -1,0 +1,303 @@
+// HARC testbench: Nic400AhbSlaveBridge (AXI4 target → AHB-Lite master mirror).
+//
+// Exercises the never-built reverse direction of Nic400AhbBridge: an AXI4
+// `target` driven by the fabric on one side, an AHB-Lite `initiator` (master)
+// driving an external AHB peripheral on the other. The TB plays both ends —
+// it is the AXI master (drives AR/AW/W, samples R/B) AND the AHB peripheral
+// (samples the bridge's HSEL/HADDR/HWRITE/HWDATA, drives HRDATA/HREADY/HRESP).
+//
+// Run with:
+//   harc sim --dut examples/nic400/Nic400AhbSlaveBridge.arch \
+//             examples/nic400/BusAxi4.arch \
+//             examples/nic400/BusAhbLite.arch \
+//             examples/nic400/Nic400AhbSlaveBridge_test.harc \
+//             --top Nic400AhbSlaveBridge
+//
+// Scenarios:
+//   S1. Single read: AXI AR(addr=0x4000_1000) → bridge drives AHB NONSEQ read
+//       → peripheral returns HRDATA=0xCAFEF00D, HRESP=OKAY → AXI R beat with
+//       RDATA=0xCAFEF00D, RRESP=0 (OKAY), RLAST=1. Also checks the bridge
+//       drove HADDR=0x4000_1000, HWRITE=0, HTRANS=NONSEQ on the AHB side.
+//   S2. Single write: AXI AW+W(addr=0x4000_2000, data=0x1234_5678) → bridge
+//       drives AHB NONSEQ write, HWDATA=0x1234_5678 → peripheral OKAY → AXI B
+//       with BRESP=0 (OKAY). Checks HADDR/HWRITE/HWDATA on the AHB side.
+//   S3. Read with AHB error: peripheral asserts HRESP=ERROR in the data phase
+//       → AXI R returns RRESP=2 (SLVERR). Confirms the HRESP→AXI-resp map.
+//   S4. Write with AHB error: peripheral asserts HRESP=ERROR → AXI B returns
+//       BRESP=2 (SLVERR).
+//
+// The peripheral model here is a zero-wait-state AHB-Lite slave (HREADY always
+// 1) that returns a fixed read word and a selectable HRESP. AHB samples the
+// address in the address phase and presents data/response in the data phase;
+// because this TB holds HREADY=1, the bridge advances one state per cycle.
+
+testbench Nic400AhbSlaveBridgeTb
+    dut : Nic400AhbSlaveBridge
+end testbench Nic400AhbSlaveBridgeTb
+
+impl Nic400AhbSlaveBridgeTest for Nic400AhbSlaveBridgeTb
+    run
+        log(info, "Nic400AhbSlaveBridge AXI4-target → AHB-master mirror test")
+
+        // ── Reset ────────────────────────────────────────────────────────
+        dut.rst         = 0
+        dut.axi_ar_valid = 0
+        dut.axi_ar_addr  = 0
+        dut.axi_ar_id    = 0
+        dut.axi_ar_len   = 0
+        dut.axi_ar_size  = 0
+        dut.axi_ar_burst = 0
+        dut.axi_ar_lock  = 0
+        dut.axi_ar_prot  = 0
+        dut.axi_r_ready  = 0
+        dut.axi_aw_valid = 0
+        dut.axi_aw_addr  = 0
+        dut.axi_aw_id    = 0
+        dut.axi_aw_len   = 0
+        dut.axi_aw_size  = 0
+        dut.axi_aw_burst = 0
+        dut.axi_aw_lock  = 0
+        dut.axi_aw_prot  = 0
+        dut.axi_w_valid  = 0
+        dut.axi_w_data   = 0
+        dut.axi_w_strb   = 0
+        dut.axi_w_last   = 0
+        dut.axi_b_ready  = 0
+        // AHB peripheral: zero-wait-state, OKAY by default, no data yet.
+        dut.h_hrdata = 0
+        dut.h_hready = 1
+        dut.h_hresp  = 0
+        wait 4 cycles
+        dut.rst = 1
+        wait 3 cycles
+
+        // ── S1: single AXI read → AHB read → AXI R (OKAY) ─────────────────
+        dut.axi_ar_valid = 1
+        dut.axi_ar_addr  = 0x40001000
+        dut.axi_ar_id    = 5
+        dut.axi_ar_size  = 2
+        dut.axi_ar_burst = 1
+        dut.axi_ar_len   = 0
+        dut.axi_ar_prot  = 0
+        dut.axi_r_ready  = 1
+
+        let s1_rdata   : uint<32> = 99
+        let s1_resp    : uint<32> = 99
+        let s1_id      : uint<32> = 99
+        let s1_last    : uint<32> = 99
+        let s1_done    : uint<32> = 0
+        let s1_haddr   : uint<32> = 99
+        let s1_hwrite  : uint<32> = 99
+        let s1_htrans  : uint<32> = 99
+        let s1_addrseen: uint<32> = 0
+
+        // Hold AR-valid until the R response is observed — the bridge's
+        // ar_ready pulse can fall in a cycle the TB does not sample (the AR
+        // handshake is Mealy-fused into the wake state), so dropping AR-valid
+        // on a sampled ar_ready races the handshake. Holding is the proven
+        // pattern (cf. Nic400DefaultSlave_test.harc S3).
+        for _ in 0 .. 30
+            wait 1 cycle
+            // AHB peripheral: when the bridge drives a NONSEQ transfer,
+            // capture the address-phase signals and present read data in the
+            // following data phase. HREADY is held 1 so HRDATA we drive now is
+            // sampled by the bridge on the next edge.
+            if dut.h_hsel == 1 && dut.h_htrans == 2 && s1_addrseen == 0
+                s1_addrseen = 1
+                s1_haddr  = dut.h_haddr
+                s1_hwrite = dut.h_hwrite
+                s1_htrans = dut.h_htrans
+                dut.h_hrdata = 0xCAFEF00D
+                dut.h_hresp  = 0
+            end if
+            if s1_done == 0 && dut.axi_r_valid == 1
+                s1_rdata = dut.axi_r_data
+                s1_resp  = dut.axi_r_resp
+                s1_id    = (dut.axi_r_id & 7)
+                s1_last  = dut.axi_r_last
+                s1_done  = 1
+                dut.axi_ar_valid = 0
+            end if
+        end for
+
+        assert s1_addrseen == 1
+            else fail("S1: bridge never drove an AHB NONSEQ read address phase")
+        assert s1_haddr == 0x40001000
+            else fail("S1: AHB HADDR=0x${s1_haddr:08x} (expected 0x40001000)")
+        assert s1_hwrite == 0
+            else fail("S1: AHB HWRITE=${s1_hwrite} (expected 0=read)")
+        assert s1_htrans == 2
+            else fail("S1: AHB HTRANS=${s1_htrans} (expected 2=NONSEQ)")
+        assert s1_done == 1
+            else fail("S1: AXI read got no R response")
+        assert s1_rdata == 0xCAFEF00D
+            else fail("S1: AXI RDATA=0x${s1_rdata:08x} (expected 0xCAFEF00D)")
+        assert s1_resp == 0
+            else fail("S1: AXI RRESP=${s1_resp} (expected 0=OKAY)")
+        assert s1_id == 5
+            else fail("S1: AXI R-id=${s1_id} (expected 5, echoed AR-id)")
+        assert s1_last == 1
+            else fail("S1: AXI RLAST=${s1_last} (expected 1)")
+        log(info, "PASS S1: AXI read → AHB read → AXI R OKAY (RDATA=0xCAFEF00D)")
+
+        dut.axi_ar_valid = 0
+        dut.axi_r_ready  = 0
+        dut.h_hresp = 0
+        wait 4 cycles
+
+        // ── S2: single AXI write → AHB write → AXI B (OKAY) ───────────────
+        dut.axi_aw_valid = 1
+        dut.axi_aw_addr  = 0x40002000
+        dut.axi_aw_id    = 3
+        dut.axi_aw_size  = 2
+        dut.axi_aw_burst = 1
+        dut.axi_aw_len   = 0
+        dut.axi_aw_prot  = 0
+        dut.axi_w_valid  = 1
+        dut.axi_w_data   = 0x12345678
+        dut.axi_w_strb   = 15
+        dut.axi_w_last   = 1
+        dut.axi_b_ready  = 1
+
+        let s2_resp   : uint<32> = 99
+        let s2_id     : uint<32> = 99
+        let s2_done   : uint<32> = 0
+        let s2_haddr  : uint<32> = 99
+        let s2_hwrite : uint<32> = 99
+        let s2_hwdata : uint<32> = 99
+        let s2_addrseen: uint<32> = 0
+        let s2_dataseen: uint<32> = 0
+
+        // Hold AW+W valid until B is observed (single-beat write). The
+        // bridge's aw_ready/w_ready pulses are Mealy-fused into their wake
+        // states and can fall in cycles the TB does not sample; dropping
+        // valid on a sampled ready races the handshake and aborts the
+        // transfer mid-flight.
+        for _ in 0 .. 40
+            wait 1 cycle
+            // AHB peripheral: capture write address phase, then HWDATA in the
+            // data phase. HTRANS=NONSEQ marks the address phase; HWRITE=1.
+            if dut.h_hsel == 1 && dut.h_htrans == 2 && dut.h_hwrite == 1 && s2_addrseen == 0
+                s2_addrseen = 1
+                s2_haddr  = dut.h_haddr
+                s2_hwrite = dut.h_hwrite
+                dut.h_hresp = 0
+            end if
+            // Data phase: bridge drives HTRANS=IDLE with HWRITE held and
+            // HWDATA present. Capture the first address-phase→data-phase cycle.
+            if s2_addrseen == 1 && s2_dataseen == 0 && dut.h_hwrite == 1 && dut.h_htrans == 0
+                s2_dataseen = 1
+                s2_hwdata = dut.h_hwdata
+            end if
+            if s2_done == 0 && dut.axi_b_valid == 1
+                s2_resp = dut.axi_b_resp
+                s2_id   = (dut.axi_b_id & 7)
+                s2_done = 1
+                dut.axi_aw_valid = 0
+                dut.axi_w_valid  = 0
+            end if
+        end for
+
+        assert s2_addrseen == 1
+            else fail("S2: bridge never drove an AHB NONSEQ write address phase")
+        assert s2_haddr == 0x40002000
+            else fail("S2: AHB HADDR=0x${s2_haddr:08x} (expected 0x40002000)")
+        assert s2_hwrite == 1
+            else fail("S2: AHB HWRITE=${s2_hwrite} (expected 1=write)")
+        assert s2_dataseen == 1
+            else fail("S2: bridge never drove an AHB write data phase")
+        assert s2_hwdata == 0x12345678
+            else fail("S2: AHB HWDATA=0x${s2_hwdata:08x} (expected 0x12345678)")
+        assert s2_done == 1
+            else fail("S2: AXI write got no B response")
+        assert s2_resp == 0
+            else fail("S2: AXI BRESP=${s2_resp} (expected 0=OKAY)")
+        assert s2_id == 3
+            else fail("S2: AXI B-id=${s2_id} (expected 3, echoed AW-id)")
+        log(info, "PASS S2: AXI write → AHB write → AXI B OKAY (HWDATA=0x12345678)")
+
+        dut.axi_aw_valid = 0
+        dut.axi_w_valid  = 0
+        dut.axi_b_ready  = 0
+        dut.h_hresp = 0
+        wait 4 cycles
+
+        // ── S3: read with AHB HRESP=ERROR → AXI RRESP=SLVERR ──────────────
+        dut.axi_ar_valid = 1
+        dut.axi_ar_addr  = 0x40003000
+        dut.axi_ar_id    = 1
+        dut.axi_ar_size  = 2
+        dut.axi_ar_burst = 1
+        dut.axi_ar_len   = 0
+        dut.axi_r_ready  = 1
+
+        let s3_resp    : uint<32> = 99
+        let s3_done    : uint<32> = 0
+        let s3_addrseen: uint<32> = 0
+
+        for _ in 0 .. 30
+            wait 1 cycle
+            // Peripheral asserts HRESP=ERROR in the data phase for this xact.
+            if dut.h_hsel == 1 && dut.h_htrans == 2 && s3_addrseen == 0
+                s3_addrseen = 1
+                dut.h_hrdata = 0xBADBAD00
+                dut.h_hresp  = 1
+            end if
+            if s3_done == 0 && dut.axi_r_valid == 1
+                s3_resp = dut.axi_r_resp
+                s3_done = 1
+                dut.axi_ar_valid = 0
+            end if
+        end for
+
+        assert s3_done == 1
+            else fail("S3: AXI read (error) got no R response")
+        assert s3_resp == 2
+            else fail("S3: AXI RRESP=${s3_resp} (expected 2=SLVERR from HRESP=ERROR)")
+        log(info, "PASS S3: AHB HRESP=ERROR → AXI RRESP=SLVERR")
+
+        dut.axi_ar_valid = 0
+        dut.axi_r_ready  = 0
+        dut.h_hresp = 0
+        wait 4 cycles
+
+        // ── S4: write with AHB HRESP=ERROR → AXI BRESP=SLVERR ─────────────
+        dut.axi_aw_valid = 1
+        dut.axi_aw_addr  = 0x40004000
+        dut.axi_aw_id    = 4
+        dut.axi_aw_size  = 2
+        dut.axi_aw_burst = 1
+        dut.axi_aw_len   = 0
+        dut.axi_w_valid  = 1
+        dut.axi_w_data   = 0xDEADBEEF
+        dut.axi_w_strb   = 15
+        dut.axi_w_last   = 1
+        dut.axi_b_ready  = 1
+
+        let s4_resp    : uint<32> = 99
+        let s4_done    : uint<32> = 0
+        let s4_addrseen: uint<32> = 0
+
+        for _ in 0 .. 40
+            wait 1 cycle
+            if dut.h_hsel == 1 && dut.h_htrans == 2 && dut.h_hwrite == 1 && s4_addrseen == 0
+                s4_addrseen = 1
+                dut.h_hresp = 1
+            end if
+            if s4_done == 0 && dut.axi_b_valid == 1
+                s4_resp = dut.axi_b_resp
+                s4_done = 1
+                dut.axi_aw_valid = 0
+                dut.axi_w_valid  = 0
+            end if
+        end for
+
+        assert s4_done == 1
+            else fail("S4: AXI write (error) got no B response")
+        assert s4_resp == 2
+            else fail("S4: AXI BRESP=${s4_resp} (expected 2=SLVERR from HRESP=ERROR)")
+        log(info, "PASS S4: AHB HRESP=ERROR → AXI BRESP=SLVERR")
+
+        log(info, "PASS Nic400AhbSlaveBridge: read/write OKAY + HRESP→AXI-resp SLVERR mapping")
+    end run
+end impl Nic400AhbSlaveBridgeTest

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -25217,6 +25217,82 @@ fn test_nic400_apb_bridge_excl_len_illegal_is_rejected_by_sva() {
 }
 
 // ────────────────────────────────────────────────────────────────────
+// NIC-400 §16.1 — AHB-Lite slave-side (mirrored) bridge
+// ────────────────────────────────────────────────────────────────────
+//
+// Nic400AhbSlaveBridge.arch is the MIRROR of Nic400AhbBridge.arch: it
+// flips both bus roles so the AXI4 side is a `target` (driven by the
+// fabric) and the AHB-Lite side is an `initiator` (driving an external
+// AHB peripheral). This exercises bus target/initiator direction-flip
+// and thread lowering in the reverse direction from the shipped
+// master-side bridge. End-to-end behaviour (AXI read/write through to
+// the AHB peripheral, plus HRESP→AXI-resp SLVERR mapping) is verified by
+// examples/nic400/Nic400AhbSlaveBridge_test.harc under
+// `harc sim --check-backends` (ARCH native sim ≡ Verilator).
+//
+// This regression pins the direction-flip in the lowered SV: a rename or
+// a target/initiator regression in the bus flatten / thread-lowering path
+// would change these port directions and trip the test.
+#[test]
+fn test_nic400_ahb_slave_bridge_flips_bus_roles_in_lowered_sv() {
+    let source = concat!(
+        include_str!("../examples/nic400/Nic400AhbSlaveBridge.arch"),
+        "\n",
+        include_str!("../examples/nic400/BusAxi4.arch"),
+        "\n",
+        include_str!("../examples/nic400/BusAhbLite.arch"),
+    );
+    let sv = compile_to_sv(source);
+
+    // AXI4 is the `target`: the bridge SEES AR/AW/W as inputs and DRIVES
+    // the R/B channels + the *_ready backpressure as outputs. (On the
+    // master-side bridge these directions are reversed.)
+    assert!(
+        sv.contains("input logic axi_ar_valid,"),
+        "AXI4 target: ar_valid must be an INPUT to the bridge:\n{sv}"
+    );
+    assert!(
+        sv.contains("output logic axi_ar_ready,"),
+        "AXI4 target: ar_ready must be an OUTPUT of the bridge:\n{sv}"
+    );
+    assert!(
+        sv.contains("output logic axi_r_valid,") && sv.contains("input logic axi_r_ready,"),
+        "AXI4 target: r_valid is an OUTPUT, r_ready an INPUT:\n{sv}"
+    );
+
+    // AHB-Lite is the `initiator` (master): the bridge DRIVES the address/
+    // control/HWDATA as outputs and SAMPLES HRDATA/HREADY/HRESP as inputs.
+    assert!(
+        sv.contains("output logic h_hsel,") && sv.contains("output logic h_hwrite,"),
+        "AHB initiator: HSEL/HWRITE must be OUTPUTs of the bridge:\n{sv}"
+    );
+    assert!(
+        sv.contains("output logic [1:0] h_htrans,"),
+        "AHB initiator: HTRANS must be an OUTPUT of the bridge:\n{sv}"
+    );
+    assert!(
+        sv.contains("input logic h_hready") && sv.contains("input logic h_hresp"),
+        "AHB initiator: HREADY/HRESP must be INPUTs to the bridge:\n{sv}"
+    );
+    assert!(
+        sv.contains("input logic [DATA_WIDTH-1:0] h_hrdata,")
+            && sv.contains("output logic [DATA_WIDTH-1:0] h_hwdata,"),
+        "AHB initiator: HRDATA in, HWDATA out:\n{sv}"
+    );
+
+    // Two independent threads (read + write) lower to two state machines
+    // in the `_threads` sub-module.
+    assert!(
+        sv.contains("module _Nic400AhbSlaveBridge_threads"),
+        "expected lowered `_Nic400AhbSlaveBridge_threads` sub-module:\n{sv}"
+    );
+    assert!(
+        sv.contains("_t0_state") && sv.contains("_t1_state"),
+        "expected two lowered thread state registers (read + write):\n{sv}"
+    );
+}
+
+// ────────────────────────────────────────────────────────────────────
 // NIC-400 read+write async-clock CDC bridge (GPV ring)
 // ────────────────────────────────────────────────────────────────────
 //


### PR DESCRIPTION
## Summary

Builds the **slave-side mirror** of `Nic400AhbBridge.arch` (the AHB-master-side bridge), closing the NIC-400 §16.1 tracker row for the AHB-Lite slave bridge / mirrored-slave direction (TRM §2.2.1/§2.2.2).

`examples/nic400/Nic400AhbSlaveBridge.arch` flips both bus roles vs. the shipped bridge:
- **AXI4 `target`** on `axi` — driven by the fabric's AMIB / SlavePort.
- **AHB-Lite `initiator` (master)** on `h` — drives an external AHB peripheral, samples HRDATA/HREADY/HRESP.

### v1 scope (single-beat, HBURST=SINGLE)
Two threads mirroring the master-side bridge's read+write structure with roles reversed:
- AXI AR → AHB NONSEQ read → capture HRDATA → AXI R (RLAST=1).
- AXI AW+W → AHB NONSEQ write → drive HWDATA → AXI B.
- Maps `axsize→HSIZE`, `axprot→HPROT` (data bit forced, hints in [3:1]), `axlock→HMASTLOCK`; HRESP OKAY/ERROR → AXI OKAY(0)/SLVERR(2).

## Verification
- `arch check` clean.
- `examples/nic400/Nic400AhbSlaveBridge_test.harc`: AXI single read + single write through to the AHB peripheral side; checks RDATA/RRESP/BRESP and the HRESP=ERROR → AXI SLVERR mapping (both read and write paths). **Passes under `harc sim --check-backends` — ARCH native sim and Verilator traces match with no divergence** across all 4 scenarios.
- `verilator -Wall` on the generated SV: only the benign `UNUSEDSIGNAL`/`PROCASSINIT`/`UNUSEDPARAM` families that the existing thread-based nic400 bridges (e.g. `Nic400ApbBridge`) also emit — unused AXI sideband on a single-beat bridge plus thread-lowering codegen artifacts.
- Regression test `test_nic400_ahb_slave_bridge_flips_bus_roles_in_lowered_sv` in `tests/integration_test.rs` pins the target/initiator direction-flip in the lowered SV (AXI ar_valid in / ar_ready out; AHB hsel/hwrite/htrans out, hready/hresp/hrdata in, hwdata out) plus the two-thread state-machine lowering. `cargo test` green.

## Sister-repo dependency (harc-com)
Running `harc sim --check-backends` against this DUT surfaced **two parser gaps in harc**, fixed in a separate harc-com PR (`claude/bus-generate-if-and-in-keyword`):
- harc's bus parser didn't handle `generate_if` groups (BusAxi4's READ/WRITE gating).
- harc's bus parser rejected the `in` keyword token in signal declarations.

Both are internal harc parser-completeness fixes (accepting already-valid ARCH syntax, no surface change). Without them `--check-backends` cannot parse BusAxi4. **This arch-com PR does not depend on the harc PR for `arch check`/`arch build`/`cargo test`** — only the `--check-backends` cross-check does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)