### PR TITLE
feat(nic400): AXI3 shim + AXI4↔AXI3 protocol conversion (long-burst split + limiter)

### DIFF
--- a/examples/nic400/BusAxi3.arch
+++ b/examples/nic400/BusAxi3.arch
@@ -1,0 +1,72 @@
+// AXI3 bus bundle for the NIC-400 interconnect.
+//
+// Modeled on examples/nic400/BusAxi4.arch but carrying AXI3-vs-AXI4 protocol
+// deltas (ARM NIC-400 TRM DDI 0475E §2.3.1, AMBA AXI3 spec IHI 0022 issue D):
+//
+//   • AxLEN is 4-bit on AXI3 (max burst 16 beats) vs 8-bit on AXI4 (max 256).
+//   • AxLOCK is 2-bit on AXI3 (NORMAL/EXCLUSIVE/LOCKED) vs 1-bit on AXI4.
+//   • AXI3 carries WID on the W channel (write-data ID); AXI4 removed it.
+//   • AXI3 has NO QoS / REGION sideband. Callers crossing AXI4→AXI3 simply drop
+//     those fields; AXI3→AXI4 holds them at 0. This bundle omits them entirely.
+//
+// Width / direction conventions match BusAxi4: `initiator` keeps the directions
+// shown here, `target` flips them. Flattens to individual SV ports
+// (ar_valid → ar_valid, etc.).
+bus BusAxi3
+  param ADDR_W: const = 32;
+  param DATA_W: const = 32;
+  param STRB_W: const = 4;                   // = DATA_W/8 caller-set
+  param ID_W:   const = 1;
+  param READ:   const = 1;
+  param WRITE:  const = 1;
+
+  generate_if READ
+    // Read address channel
+    ar_valid:  out Bool;
+    ar_ready:  in  Bool;
+    ar_addr:   out UInt<ADDR_W>;
+    ar_id:     out UInt<ID_W>;
+    ar_len:    out UInt<4>;                   // AXI3: 4-bit (1..16 beats)
+    ar_size:   out UInt<3>;
+    ar_burst:  out UInt<2>;
+    ar_lock:   out UInt<2>;                   // AXI3: 2-bit lock
+    ar_cache:  out UInt<4>;
+    ar_prot:   out UInt<3>;
+
+    // Read data channel
+    r_valid:   in  Bool;
+    r_ready:   out Bool;
+    r_data:    in  UInt<DATA_W>;
+    r_id:      in  UInt<ID_W>;
+    r_resp:    in  UInt<2>;
+    r_last:    in  Bool;
+  end generate_if
+
+  generate_if WRITE
+    // Write address channel
+    aw_valid:  out Bool;
+    aw_ready:  in  Bool;
+    aw_addr:   out UInt<ADDR_W>;
+    aw_id:     out UInt<ID_W>;
+    aw_len:    out UInt<4>;                   // AXI3: 4-bit (1..16 beats)
+    aw_size:   out UInt<3>;
+    aw_burst:  out UInt<2>;
+    aw_lock:   out UInt<2>;                   // AXI3: 2-bit lock
+    aw_cache:  out UInt<4>;
+    aw_prot:   out UInt<3>;
+
+    // Write data channel
+    w_valid:   out Bool;
+    w_ready:   in  Bool;
+    w_id:      out UInt<ID_W>;                // AXI3: WID present on W channel
+    w_data:    out UInt<DATA_W>;
+    w_strb:    out UInt<STRB_W>;
+    w_last:    out Bool;
+
+    // Write response channel
+    b_valid:   in  Bool;
+    b_ready:   out Bool;
+    b_id:      in  UInt<ID_W>;
+    b_resp:    in  UInt<2>;
+  end generate_if
+end bus BusAxi3

--- a/examples/nic400/Nic400Axi3ToAxi4.arch
+++ b/examples/nic400/Nic400Axi3ToAxi4.arch
@@ -1,0 +1,167 @@
+// NIC-400 AXI3 → AXI4 protocol converter with programmable burst limiter
+// (READ path).
+//
+// ARM NIC-400 TRM (DDI 0475E) §2.3.1: the AXI3→AXI4 direction is the easy one
+// for burst length — AXI3 AxLEN is already 4-bit (≤16 beats), well within
+// AXI4's 8-bit range, so a sub-burst SPLIT is never needed. What the NIC-400
+// exposes on this path is a GPV-programmable burst LIMITER: a knob that caps
+// the onward AXI4 AxLEN so a downstream slave that can't absorb long bursts
+// sees them chopped. Since AXI3 already maxes at 16 beats, MAX_BURST is the
+// programmable cap and the converter splits only when ar_len+1 > MAX_BURST.
+//
+//   m  : AXI3 master-facing port (target — accept the master's AR, drive R).
+//   s  : AXI4 slave-facing  port (initiator — issue AR, accept R).
+//
+// AXI3-vs-AXI4 field deltas handled here:
+//   • AxLEN: AXI3 4-bit → AXI4 8-bit (zero-extend; further capped by MAX_BURST).
+//   • AxLOCK: AXI3 2-bit → AXI4 1-bit. AXI4 dropped the LOCKED (2'b10) encoding;
+//     we map EXCLUSIVE (2'b01) → 1 and everything else → 0 (NORMAL).
+//   • QoS / REGION: absent on AXI3 → held at 0 on the AXI4 side.
+//
+// Limiter arithmetic (INCR only, same shape as the AXI4→AXI3 splitter but with
+// a programmable chunk instead of a fixed 16):
+//   total_beats = m.ar_len + 1                     (1..16)
+//   chunk       = MAX_BURST                        (programmable, 1..16)
+//   num_sub     = ceil(total_beats / chunk)
+//   for sub i:  sub_beats = min(chunk, total - i*chunk); INCR-stepped address.
+// With MAX_BURST >= 16 the loop runs once and the burst forwards unchanged.
+//
+// Scope (v1): READ path (AR→R limiter + merge). Write-path is tied off (the
+// AXI4 W channel has no WID, so AXI3 WID is simply dropped; AW/W/B limiting is
+// a follow-on mirroring the read path).
+module Nic400Axi3ToAxi4
+  param ADDR_W:    const = 32;
+  param DATA_W:    const = 32;
+  param STRB_W:    const = 4;       // = DATA_W/8
+  param ID_W:      const = 4;
+  // Programmable onward-AxLEN cap (beats per AXI4 sub-burst). GPV knob.
+  // 16 = forward AXI3 bursts unchanged; smaller chops them.
+  param MAX_BURST: const = 16;
+
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Async, Low>;
+
+  // AXI3 master-facing (target): READ only.
+  port m: target    BusAxi3<ADDR_W=ADDR_W, DATA_W=DATA_W, STRB_W=STRB_W,
+                            ID_W=ID_W, READ=1, WRITE=0>;
+  // AXI4 slave-facing (initiator): READ only.
+  port s: initiator BusAxi4<ADDR_W=ADDR_W, DATA_W=DATA_W, STRB_W=STRB_W,
+                            ID_W=ID_W, READ=1, WRITE=0>;
+
+  // Latched AXI3 AR fields.
+  reg base_addr_r: UInt<ADDR_W> reset rst => 0;
+  reg size_r:      UInt<3>      reset rst => 0;
+  reg id_r:        UInt<ID_W>   reset rst => 0;
+  reg cache_r:     UInt<4>      reset rst => 0;
+  reg prot_r:      UInt<3>      reset rst => 0;
+  reg lock_r:      Bool         reset rst => false;   // mapped AXI4 1-bit lock
+  reg total_r:     UInt<5>      reset rst => 0;        // total_beats (1..16)
+  reg num_sub_r:   UInt<5>      reset rst => 0;        // ceil(total/MAX_BURST)
+  reg err_r:       UInt<2>      reset rst => 0;        // sticky merged resp
+
+  // ── Sub-burst arithmetic helpers ───────────────────────────────────────
+  // beats covered by sub-bursts 0..i-1  (i*MAX_BURST).
+  function beats_done(i: UInt<5>) -> UInt<9>
+    return i.zext<9>() * MAX_BURST;
+  end function beats_done
+
+  // this sub-burst's beat count: min(MAX_BURST, total - i*MAX_BURST).
+  function sub_beats(i: UInt<5>, total: UInt<5>) -> UInt<9>
+    let done:      UInt<9> = beats_done(i);
+    let remaining: UInt<9> = total.zext<9>() - done;
+    if remaining > MAX_BURST
+      return (9'd0 + MAX_BURST).trunc<9>();
+    else
+      return remaining;
+    end if
+  end function sub_beats
+
+  // start address of sub-burst i: base + (i*MAX_BURST) << size.
+  function sub_addr(i: UInt<5>, base: UInt<ADDR_W>, size: UInt<3>) -> UInt<ADDR_W>
+    let done:    UInt<ADDR_W> = beats_done(i).zext<ADDR_W>();
+    let stepped: UInt<ADDR_W> = done << size;
+    return (base + stepped).trunc<ADDR_W>();
+  end function sub_addr
+
+  // AXI3 2-bit AxLOCK → AXI4 1-bit: EXCLUSIVE (01) → 1, else 0.
+  function lock3_to_lock4(l: UInt<2>) -> Bool
+    return l == 1;
+  end function lock3_to_lock4
+
+  // ── Limiter read thread ────────────────────────────────────────────────
+  thread Limit on clk rising, rst low
+    default comb
+      // AXI4 AR (initiator drives) — idle.
+      s.ar_valid  = false;
+      s.ar_addr   = 0;
+      s.ar_id     = 0;
+      s.ar_len    = 0;
+      s.ar_size   = 0;
+      s.ar_burst  = 0;
+      s.ar_lock   = false;
+      s.ar_cache  = 0;
+      s.ar_prot   = 0;
+      s.ar_qos    = 0;          // AXI3 has no QoS → 0
+      s.ar_region = 0;          // AXI3 has no REGION → 0
+      s.r_ready   = false;
+      // AXI3 master-facing drives — idle.
+      m.ar_ready  = false;
+      m.r_valid   = false;
+      m.r_data    = 0;
+      m.r_id      = 0;
+      m.r_resp    = 0;
+      m.r_last    = false;
+    end default
+
+    // ── AR accept ──────────────────────────────────────────────────────
+    if not (m.ar_valid)
+      wait until m.ar_valid;
+    end if
+    do
+      m.ar_ready  = true;
+      base_addr_r <= m.ar_addr;
+      size_r      <= m.ar_size;
+      id_r        <= m.ar_id;
+      cache_r     <= m.ar_cache;
+      prot_r      <= m.ar_prot;
+      lock_r      <= lock3_to_lock4(m.ar_lock);
+      total_r     <= (m.ar_len.zext<5>() + 1).trunc<5>();
+      // ceil(total / MAX_BURST) = (total + MAX_BURST - 1) / MAX_BURST.
+      // total = ar_len+1 ⇒ (ar_len + MAX_BURST) / MAX_BURST.
+      num_sub_r   <= ((m.ar_len.zext<9>() + MAX_BURST) / MAX_BURST).trunc<5>();
+      err_r       <= 0;
+    until m.ar_ready;
+
+    // ── Sub-burst loop ─────────────────────────────────────────────────
+    for i in 0..num_sub_r - 1
+      do
+        s.ar_valid  = true;
+        s.ar_addr   = sub_addr(i, base_addr_r, size_r);
+        s.ar_id     = id_r;
+        s.ar_len    = (sub_beats(i, total_r) - 1).trunc<8>();
+        s.ar_size   = size_r;
+        s.ar_burst  = 1;                  // INCR
+        s.ar_lock   = lock_r;
+        s.ar_cache  = cache_r;
+        s.ar_prot   = prot_r;
+        s.ar_qos    = 0;
+        s.ar_region = 0;
+      until s.ar_ready;
+
+      do
+        s.r_ready = m.r_ready;
+        m.r_valid = s.r_valid;
+        m.r_data  = s.r_data;
+        m.r_id    = s.r_id;
+        m.r_resp  = err_r | s.r_resp;
+        m.r_last  = (i == (num_sub_r - 1)) and s.r_last;
+        if s.r_valid and m.r_ready
+          err_r <= err_r | s.r_resp;
+        end if
+      until s.r_valid and s.r_last and m.r_ready;
+    end for
+  end thread Limit
+
+  // INCR-only limiter (FIXED/WRAP sub-burst stepping is out of scope).
+  assert ar_incr_only: (m.ar_valid and m.ar_ready) |-> (m.ar_burst == 1);
+end module Nic400Axi3ToAxi4

--- a/examples/nic400/Nic400Axi4ToAxi3.arch
+++ b/examples/nic400/Nic400Axi4ToAxi3.arch
@@ -1,0 +1,189 @@
+// NIC-400 AXI4 → AXI3 protocol converter: long-burst splitter (READ path).
+//
+// ARM NIC-400 TRM (DDI 0475E) §1.2/§2.3.1: NIC-400 performs AXI4↔AXI3 protocol
+// conversion. The defining hazard of the AXI4→AXI3 direction is burst length:
+// AXI4 AxLEN is 8-bit (up to 256 beats) but AXI3 AxLEN is only 4-bit (max 16
+// beats). An AXI4 INCR burst longer than 16 beats CANNOT be forwarded as one
+// AXI3 burst — it must be SPLIT into ceil((len+1)/16) AXI3 sub-bursts.
+//
+// This module is the read-path splitter:
+//   m  : AXI4 master-facing port (target — we accept the master's AR, drive R).
+//   s  : AXI3 slave-facing  port (initiator — we issue AR, accept R).
+//
+// Split arithmetic (INCR only):
+//   total_beats = m.ar_len + 1                          (1..256)
+//   num_sub     = ceil(total_beats / 16) = (total+15)>>4 (1..16)
+//   for sub i in 0..num_sub-1:
+//     beats_done = i * 16
+//     sub_beats  = min(16, total_beats - beats_done)    (1..16)
+//     s.ar_len   = sub_beats - 1                         (AXI3 4-bit)
+//     s.ar_addr  = base + (beats_done << size)           (INCR step)
+//     s.ar_burst = INCR (01)
+//
+// Response merge (AXI4 R coalescing):
+//   • Each AXI3 sub-burst returns sub_beats R beats with its OWN r_last on its
+//     final beat. We forward every beat to the AXI4 master but SUPPRESS r_last
+//     except on the true final beat (last beat of the last sub-burst).
+//   • r_resp is sticky-OR'd across all sub-bursts into err_r so a SLVERR/DECERR
+//     on any sub-burst surfaces; the merged AXI4 r_resp on every beat carries
+//     the running max-severity (OR of {OKAY=0,..,DECERR=3} bit patterns, which
+//     orders OKAY<EXOKAY<SLVERR<DECERR monotonically under bitwise-OR for the
+//     2-bit AXI resp encoding).
+//
+// The whole transaction is sequenced by ONE thread: issue sub-burst i's AR,
+// drain its R beats, then move to sub-burst i+1. Non-pipelined (one AXI3
+// sub-burst outstanding at a time) — this keeps "which sub-burst is final"
+// and the RLAST/error merge in a single state machine with no cross-thread
+// coordination. NIC-400's base splitter does not interleave sub-bursts, so
+// this matches the TRM behaviour.
+//
+// Scope (v1): READ path fully (AR→R split + merge). Write-path splitting (AW→W
+// with WID generation per sub-burst + B coalescing) is a strictly larger design
+// (the W data stream must be re-segmented in lockstep with the AW sub-bursts)
+// and is tracked as a follow-on; the AXI3 W/B ports are tied off here.
+module Nic400Axi4ToAxi3
+  param ADDR_W: const = 32;
+  param DATA_W: const = 32;
+  param STRB_W: const = 4;       // = DATA_W/8
+  param ID_W:   const = 4;
+
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Async, Low>;
+
+  // AXI4 master-facing (target): READ only on this converter instance.
+  port m: target    BusAxi4<ADDR_W=ADDR_W, DATA_W=DATA_W, STRB_W=STRB_W,
+                            ID_W=ID_W, READ=1, WRITE=0>;
+  // AXI3 slave-facing (initiator): READ only.
+  port s: initiator BusAxi3<ADDR_W=ADDR_W, DATA_W=DATA_W, STRB_W=STRB_W,
+                            ID_W=ID_W, READ=1, WRITE=0>;
+
+  // Latched AXI4 AR fields (the master holds them only during the AR
+  // handshake; the split sequence runs for many cycles afterwards).
+  reg base_addr_r: UInt<ADDR_W> reset rst => 0;
+  reg size_r:      UInt<3>      reset rst => 0;
+  reg id_r:        UInt<ID_W>   reset rst => 0;
+  reg cache_r:     UInt<4>      reset rst => 0;
+  reg prot_r:      UInt<3>      reset rst => 0;
+  // total_beats-1 (the AXI4 ar_len) and total_beats live in 9 bits.
+  reg total_r:     UInt<9>      reset rst => 0;   // total_beats (1..256)
+  reg num_sub_r:   UInt<5>      reset rst => 0;   // ceil(total/16)  (1..16)
+  // Sticky OR of every sub-burst's r_resp — the merged AXI4 error.
+  reg err_r:       UInt<2>      reset rst => 0;
+
+  // ── Sub-burst arithmetic helpers ───────────────────────────────────────
+  // beats covered by sub-bursts 0..i-1  (i*16).
+  function beats_done(i: UInt<5>) -> UInt<9>
+    return i.zext<9>() << 4;
+  end function beats_done
+
+  // this sub-burst's beat count: min(16, total - i*16).  (1..16)
+  function sub_beats(i: UInt<5>, total: UInt<9>) -> UInt<9>
+    let done:      UInt<9> = beats_done(i);
+    let remaining: UInt<9> = total - done;
+    if remaining > 16
+      return 9'd16;
+    else
+      return remaining;
+    end if
+  end function sub_beats
+
+  // start address of sub-burst i: base + (i*16) << size.
+  function sub_addr(i: UInt<5>, base: UInt<ADDR_W>, size: UInt<3>) -> UInt<ADDR_W>
+    let done:    UInt<ADDR_W> = beats_done(i).zext<ADDR_W>();
+    let stepped: UInt<ADDR_W> = done << size;
+    return (base + stepped).trunc<ADDR_W>();
+  end function sub_addr
+
+  // ── Split read thread ──────────────────────────────────────────────────
+  thread Split on clk rising, rst low
+    default comb
+      // AXI3 AR (initiator drives) — idle.
+      s.ar_valid = false;
+      s.ar_addr  = 0;
+      s.ar_id    = 0;
+      s.ar_len   = 0;
+      s.ar_size  = 0;
+      s.ar_burst = 0;
+      s.ar_lock  = 0;
+      s.ar_cache = 0;
+      s.ar_prot  = 0;
+      s.r_ready  = false;
+      // AXI4 master-facing drives — idle.
+      m.ar_ready = false;
+      m.r_valid  = false;
+      m.r_data   = 0;
+      m.r_id     = 0;
+      m.r_resp   = 0;
+      m.r_last   = false;
+    end default
+
+    // ── AR accept ──────────────────────────────────────────────────────
+    // Accept the AXI4 AR, latch its fields, compute the sub-burst count.
+    if not (m.ar_valid)
+      wait until m.ar_valid;
+    end if
+    do
+      m.ar_ready  = true;
+      base_addr_r <= m.ar_addr;
+      size_r      <= m.ar_size;
+      id_r        <= m.ar_id;
+      cache_r     <= m.ar_cache;
+      prot_r      <= m.ar_prot[2:0];
+      total_r     <= (m.ar_len.zext<9>() + 1).trunc<9>();
+      // ceil(total/16) = (total_beats + 15) >> 4. total_beats = ar_len+1,
+      // so (ar_len + 16) >> 4. ar_len ∈ 0..255 ⇒ result ∈ 1..16.
+      num_sub_r   <= (((m.ar_len.zext<9>() + 16).trunc<9>()) >> 4).trunc<5>();
+      err_r       <= 0;
+    until m.ar_ready;
+
+    // ── Sub-burst loop ─────────────────────────────────────────────────
+    // For each sub-burst i: issue the AXI3 AR (short, ≤16 beats, stepped
+    // address) then drain that sub-burst's R beats into the AXI4 master.
+    for i in 0..num_sub_r - 1
+      // AXI3 AR for this sub-burst. sub_addr()/sub_beats() compute the
+      // INCR-stepped start address and the min(16, remaining) length.
+      do
+        s.ar_valid = true;
+        s.ar_addr  = sub_addr(i, base_addr_r, size_r);
+        s.ar_id    = id_r;
+        s.ar_len   = (sub_beats(i, total_r) - 1).trunc<4>();   // AXI3 4-bit
+        s.ar_size  = size_r;
+        s.ar_burst = 1;                                          // INCR
+        s.ar_lock  = 0;
+        s.ar_cache = cache_r;
+        s.ar_prot  = prot_r;
+      until s.ar_ready;
+
+      // Drain this sub-burst's R beats. Forward each beat to the AXI4
+      // master; suppress AXI3 r_last unless this is the final sub-burst
+      // (i == num_sub_r-1). Sticky-OR the response into err_r and present
+      // the running merged error on every beat.
+      do
+        s.r_ready = m.r_ready;
+        m.r_valid = s.r_valid;
+        m.r_data  = s.r_data;
+        m.r_id    = s.r_id;
+        m.r_resp  = err_r | s.r_resp;
+        m.r_last  = (i == (num_sub_r - 1)) and s.r_last;
+        if s.r_valid and m.r_ready
+          err_r <= err_r | s.r_resp;
+        end if
+      until s.r_valid and s.r_last and m.r_ready;
+    end for
+  end thread Split
+
+  // The AXI3 write channel is absent on this READ-only converter instance
+  // (WRITE=0 on both bus ports — see file header for write-path scope).
+
+  // INCR-only: this splitter computes per-sub-burst INCR addresses. A FIXED
+  // (00) or WRAP (10) AXI4 burst would need different sub-burst address
+  // arithmetic and is rejected here.
+  assert ar_incr_only: (m.ar_valid and m.ar_ready) |-> (m.ar_burst == 1);
+
+  // AXI4 §A3.4.1 4 KB boundary: an INCR burst must not cross a 4 KB region.
+  // The splitter inherits this from the master — each 16-beat sub-burst is a
+  // contiguous slice of the same INCR, so honouring it on the whole burst
+  // keeps every sub-burst inside the same 4 KB window.
+  assert ar_no_4k_cross: (m.ar_valid and m.ar_ready and m.ar_burst == 1)
+    |-> (m.ar_addr[11:0].zext<21>() + ((m.ar_len.zext<9>() + 1) << m.ar_size).zext<21>() <= 21'd4096);
+end module Nic400Axi4ToAxi3

--- a/examples/nic400/Nic400Axi4ToAxi3_test.harc
+++ b/examples/nic400/Nic400Axi4ToAxi3_test.harc
@@ -1,0 +1,212 @@
+// HARC testbench: Nic400Axi4ToAxi3 long-burst splitter (READ path).
+//
+// DUT: examples/nic400/Nic400Axi4ToAxi3.arch — an AXI4→AXI3 converter that
+// splits a long AXI4 INCR read burst into ≤16-beat AXI3 sub-bursts and
+// coalesces the AXI3 R streams back into one AXI4 R stream.
+//
+// The TB plays BOTH endpoints:
+//   • AXI4 master  : drives m_ar_*, accepts m_r_* (the long-burst requester).
+//   • AXI3 slave   : accepts s_ar_* (capturing each sub-burst's addr+len) and
+//                    drives s_r_* (returning the right number of R beats per
+//                    sub-burst, with the AXI3 r_last on each sub-burst's final
+//                    beat).
+//
+// Scenario: AXI4 read burst of 20 beats (ar_len=19), size=2 (4 B/beat),
+// base=0x0000_1000. Expect the splitter to emit exactly TWO AXI3 sub-bursts:
+//   sub 0: addr=0x1000, ar_len=15  (16 beats)
+//   sub 1: addr=0x1040, ar_len=3   ( 4 beats)   [0x1000 + 16*4 = 0x1040]
+// and a single coalesced AXI4 R stream of 20 beats, with r_last asserted ONLY
+// on beat 20. R data is i for beat i so we can confirm ordering + coalescing.
+//
+// Run with:
+//   harc sim --check-backends \
+//     --arch-bin <worktree>/target/release/arch \
+//     --dut examples/nic400/BusAxi4.arch \
+//     --dut examples/nic400/BusAxi3.arch \
+//     --dut examples/nic400/Nic400Axi4ToAxi3.arch \
+//     examples/nic400/Nic400Axi4ToAxi3_test.harc \
+//     --top Nic400Axi4ToAxi3
+
+testbench Nic400Axi4ToAxi3Tb
+    dut : Nic400Axi4ToAxi3
+end testbench Nic400Axi4ToAxi3Tb
+
+impl Nic400Axi4ToAxi3Test for Nic400Axi4ToAxi3Tb
+    run
+        log(info, "Nic400Axi4ToAxi3 long-burst splitter test (20-beat AXI4 read → 16+4 AXI3 sub-bursts)")
+
+        // ── Reset (active-low) ───────────────────────────────────────────
+        dut.rst        = 0
+        dut.m_ar_valid = 0
+        dut.m_ar_addr  = 0
+        dut.m_ar_id    = 0
+        dut.m_ar_len   = 0
+        dut.m_ar_size  = 0
+        dut.m_ar_burst = 0
+        dut.m_ar_lock  = 0
+        dut.m_ar_cache = 0
+        dut.m_ar_prot  = 0
+        dut.m_ar_qos   = 0
+        dut.m_ar_region = 0
+        dut.m_r_ready  = 0
+        dut.s_ar_ready = 0
+        dut.s_r_valid  = 0
+        dut.s_r_data   = 0
+        dut.s_r_id     = 0
+        dut.s_r_resp   = 0
+        dut.s_r_last   = 0
+        wait 4 cycles
+        dut.rst = 1
+        wait 2 cycles
+
+        // ── AXI4 master issues a 20-beat INCR read ────────────────────────
+        dut.m_ar_addr  = 0x00001000
+        dut.m_ar_id    = 7
+        dut.m_ar_len   = 19          // 20 beats
+        dut.m_ar_size  = 2           // 4 bytes/beat
+        dut.m_ar_burst = 1           // INCR
+        dut.m_ar_valid = 1
+        dut.m_r_ready  = 1           // master always ready to accept R
+        dut.s_ar_ready = 1           // slave always ready to accept AR
+
+        // Observed sub-burst AR fields (capture the first two we see).
+        let sub_seen   : uint<32> = 0
+        let sub0_addr  : uint<32> = 0
+        let sub0_len   : uint<32> = 0
+        let sub1_addr  : uint<32> = 0
+        let sub1_len   : uint<32> = 0
+
+        // R-stream bookkeeping (AXI4 master side).
+        let r_beats      : uint<32> = 0       // total coalesced AXI4 R beats
+        let last_count   : uint<32> = 0       // # of m_r_last=1 beats seen
+        let last_beat_ix : uint<32> = 99      // beat index where r_last fired
+        let data_ok      : uint<32> = 1       // data == beat index on every beat
+
+        // The TB plays the AXI3 slave and observes the coalesced AXI4 stream.
+        //
+        // The slave is driven off GLOBAL beat indices, which sidesteps the
+        // sub-burst-boundary off-by-one entirely:
+        //   • glob_i : index of the next AXI3 R beat to present (== its data).
+        //   • sb_end : global index of the FINAL beat of every sub-burst seen
+        //              so far. `s_r_last` is asserted exactly when glob_i hits
+        //              a recorded sub-burst boundary. The two boundaries for
+        //              this scenario are captured from the AR `len` fields, so
+        //              the slave keeps streaming continuously across the
+        //              sub-burst handoff (the DUT pipelines the next sub-burst
+        //              AR before the previous sub-burst's final R beat lands on
+        //              the master, so a per-sub-burst `sb_active` gate would
+        //              drop the handoff cycle under post-edge sampling).
+        //
+        // Boundaries: sub-burst i ends at global beat (cumulative_len). We
+        // record the running end of each captured sub-burst in `bnd0`/`bnd1`.
+        let glob_i : uint<32> = 0
+        let bnd0   : uint<32> = 99    // global index of sub0's last beat
+        let bnd1   : uint<32> = 99    // global index of sub1's last beat
+        let ar_run : uint<32> = 0     // running cumulative beat count for ARs
+
+        // Loop: SAMPLE DUT outputs (settled across the prior edge), observe +
+        // advance, then DRIVE slave inputs for the next edge. m_ar_valid is
+        // dropped only once the first AXI3 AR appears, so the AR-accept
+        // S0→S1 transition condition is not cleared before its latching edge.
+        for _ in 0 .. 100
+            // ── SAMPLE: capture each sub-burst AR (held until s_ar_ready). ─
+            // AR capture is independent of the R-stream state because the DUT
+            // pipelines the next AR ahead of the previous R completion.
+            if dut.s_ar_valid == 1 && sub_seen < 2 && (sub_seen == 0 || dut.s_ar_addr != sub0_addr)
+                if sub_seen == 0
+                    sub0_addr = dut.s_ar_addr
+                    sub0_len  = dut.s_ar_len
+                    bnd0      = ar_run + dut.s_ar_len    // sub0 last beat index
+                    ar_run    = ar_run + dut.s_ar_len + 1
+                    sub_seen  = 1
+                else
+                    sub1_addr = dut.s_ar_addr
+                    sub1_len  = dut.s_ar_len
+                    bnd1      = ar_run + dut.s_ar_len    // sub1 last beat index
+                    ar_run    = ar_run + dut.s_ar_len + 1
+                    sub_seen  = 2
+                end if
+            end if
+
+            // ── SAMPLE: observe the coalesced AXI4 R beat for this edge. ───
+            if dut.m_r_valid == 1 && dut.m_r_ready == 1
+                if dut.m_r_data != r_beats
+                    data_ok = 0
+                end if
+                if dut.m_r_last == 1
+                    last_count   = last_count + 1
+                    last_beat_ix = r_beats
+                end if
+                r_beats = r_beats + 1
+                glob_i  = glob_i + 1
+            end if
+
+            // ── DRIVE: drop master AR once the first sub-burst AR appears. ─
+            if dut.s_ar_valid == 1
+                dut.m_ar_valid = 0
+            end if
+
+            // ── DRIVE: present the AXI3 R beat. Stream continuously while
+            //    the master has not yet received all 20 coalesced beats;
+            //    assert s_r_last at each recorded sub-burst boundary. ───────
+            if sub_seen >= 1 && r_beats < 20
+                dut.s_r_valid = 1
+                dut.s_r_data  = glob_i
+                dut.s_r_id    = 7
+                dut.s_r_resp  = 0
+                if glob_i == bnd0 || glob_i == bnd1
+                    dut.s_r_last = 1
+                else
+                    dut.s_r_last = 0
+                end if
+            else
+                dut.s_r_valid = 0
+                dut.s_r_last  = 0
+            end if
+
+            wait 1 cycle
+        end for
+
+        // ── Assertions ────────────────────────────────────────────────────
+        assert sub_seen == 2
+            else fail("expected exactly 2 AXI3 sub-burst ARs, saw ${sub_seen}")
+
+        // sub 0: addr 0x1000, ar_len 15 (16 beats).
+        assert sub0_addr == 0x00001000
+            else fail("sub0 addr=0x${sub0_addr:x} (expected 0x1000)")
+        assert sub0_len == 15
+            else fail("sub0 ar_len=${sub0_len} (expected 15 = 16 beats)")
+
+        // sub 1: addr 0x1040 (= 0x1000 + 16*4), ar_len 3 (4 beats).
+        assert sub1_addr == 0x00001040
+            else fail("sub1 addr=0x${sub1_addr:x} (expected 0x1040 = base + 16*4)")
+        assert sub1_len == 3
+            else fail("sub1 ar_len=${sub1_len} (expected 3 = 4 beats)")
+
+        // Coalesced AXI4 R stream: at least the first sub-burst's worth of
+        // beats are observed in order on the master side (data == index).
+        assert r_beats >= 16
+            else fail("too few coalesced AXI4 R beats observed: ${r_beats}")
+        assert data_ok == 1
+            else fail("coalesced R data out of order (beat i != data i)")
+
+        // ── Phasing note (why the R-stream RLAST/total-beat checks live in
+        //    the C++ TB, not here) ───────────────────────────────────────────
+        // The splitter's merged m_r_last/m_r_valid are Mealy functions of the
+        // AXI3 s_r_last input AND the lowered thread-FSM's sub-burst counter.
+        // HARC's `wait 1 cycle` samples the DUT AFTER the clock edge, by which
+        // point that counter has already advanced past the R-dispatch state, so
+        // the merged R stream cannot be observed at the same (pre-edge)
+        // combinational phase a real AXI consumer would. The cycle-exact R-side
+        // properties — "exactly 20 coalesced beats, RLAST once on beat 19,
+        // sticky-OR error merge" — are therefore checked by the companion
+        // pre/post-edge C++ testbench tb_nic400_axi4_to_axi3_split.cpp, which is
+        // verified IDENTICAL under BOTH `arch sim` and Verilator
+        // (sub_seen=2, addrs 0x1000/0x1040, lens 15/3, rb=20, RLAST on beat 19).
+        // This .harc TB pins the phase-robust headline: the burst-split AR
+        // arithmetic (sub-burst count, per-sub-burst start address, short final
+        // length) that is the point of the AXI4→AXI3 converter.
+
+        log(info, "PASS Nic400Axi4ToAxi3: 20-beat AXI4 read split into AXI3 16+4 sub-bursts (addrs 0x1000/0x1040, lens 15/3); R-stream coalescing + RLAST verified cycle-exact by the C++ TB under arch-sim and Verilator")
+    end run
+end impl Nic400Axi4ToAxi3Test

--- a/examples/nic400/tb_nic400_axi3_to_axi4_limit.cpp
+++ b/examples/nic400/tb_nic400_axi3_to_axi4_limit.cpp
@@ -1,0 +1,108 @@
+// AXI3→AXI4 limiter TB (READ path).
+//
+// DUT: Nic400Axi3ToAxi4 — forwards an AXI3 read burst onto an AXI4 slave,
+// chopping the onward AxLEN to the programmable cap MAX_BURST (default 16). At
+// MAX_BURST=16 an AXI3 burst (max 16 beats) forwards as ONE AXI4 sub-burst.
+//
+// The TB plays the AXI3 master (drives m_ar_*, accepts m_r_*) and the AXI4
+// slave (accepts s_ar_*, drives s_r_*). Scenario: AXI3 16-beat INCR read
+// (ar_len=15), size=2, base=0x2000, ar_lock=1 (EXCLUSIVE). Expect:
+//   • exactly ONE AXI4 AR, addr=0x2000, ar_len=15 (forwarded unchanged),
+//     ar_lock=1 (AXI3 EXCLUSIVE→AXI4 1), ar_qos=0, ar_region=0 (AXI3 has none).
+//   • 16 coalesced AXI4→AXI3 R beats in order, RLAST once on the 16th beat.
+//
+// pre_edge sampling per the NIC-400 TB convention.
+
+#include "VNic400Axi3ToAxi4.h"
+#include <cstdint>
+#include <cstdio>
+
+static VNic400Axi3ToAxi4 dut;
+static uint64_t cycle = 0;
+static void pre_edge()  { dut.clk = 0; dut.eval(); }
+static void post_edge() { dut.clk = 1; dut.eval(); cycle++; }
+static int fail(const char* m) { std::printf("FAIL %s (cycle=%llu)\n", m, (unsigned long long)cycle); return 1; }
+
+int main() {
+    dut.rst = 0;
+    dut.m_ar_valid = 0; dut.m_ar_addr = 0; dut.m_ar_id = 0; dut.m_ar_len = 0;
+    dut.m_ar_size = 0;  dut.m_ar_burst = 0; dut.m_ar_lock = 0;
+    dut.m_ar_cache = 0; dut.m_ar_prot = 0;
+    dut.m_r_ready = 0;
+    dut.s_ar_ready = 0;
+    dut.s_r_valid = 0; dut.s_r_data = 0; dut.s_r_id = 0; dut.s_r_resp = 0; dut.s_r_last = 0;
+    for (int i = 0; i < 4; ++i) { pre_edge(); post_edge(); }
+    dut.rst = 1;
+    for (int i = 0; i < 2; ++i) { pre_edge(); post_edge(); }
+
+    // AXI3 master issues a 16-beat INCR read, EXCLUSIVE lock.
+    dut.m_ar_addr  = 0x00002000u;
+    dut.m_ar_id    = 5;
+    dut.m_ar_len   = 15;        // AXI3 4-bit: 16 beats
+    dut.m_ar_size  = 2;
+    dut.m_ar_burst = 1;         // INCR
+    dut.m_ar_lock  = 1;         // AXI3 EXCLUSIVE (2'b01)
+    dut.m_ar_valid = 1;
+    dut.m_r_ready  = 1;
+    dut.s_ar_ready = 1;
+
+    int      ar_seen   = 0;
+    uint32_t s_addr    = 0;
+    uint32_t s_len     = 0;
+    uint32_t s_lock    = 0;
+    uint32_t s_qos     = 0;
+    uint32_t s_region  = 0;
+
+    int      sb_active = 0;
+    uint32_t sb_len    = 0, sb_i = 0, glob = 0;
+
+    uint32_t r_beats = 0;
+    int      last_count = 0, last_beat_ix = -1, data_ok = 1;
+
+    for (int i = 0; i < 200 && (ar_seen < 1 || r_beats < 16); ++i) {
+        if (sb_active) {
+            dut.s_r_valid = 1; dut.s_r_data = glob; dut.s_r_id = 5;
+            dut.s_r_resp = 0; dut.s_r_last = (sb_i == sb_len) ? 1 : 0;
+        } else { dut.s_r_valid = 0; dut.s_r_last = 0; }
+
+        pre_edge();
+
+        if (dut.s_ar_valid) dut.m_ar_valid = 0;
+
+        if (dut.s_ar_valid && dut.s_ar_ready && !ar_seen) {
+            s_addr = dut.s_ar_addr; s_len = dut.s_ar_len; s_lock = dut.s_ar_lock;
+            s_qos = dut.s_ar_qos;   s_region = dut.s_ar_region;
+            ar_seen = 1; sb_active = 1; sb_len = dut.s_ar_len; sb_i = 0;
+        } else if (dut.s_ar_valid && dut.s_ar_ready && ar_seen && !sb_active) {
+            // a second AXI4 AR would mean the limiter split a ≤16-beat burst
+            return fail("limiter issued a second AXI4 sub-burst for a 16-beat AXI3 read");
+        }
+
+        bool m_fire = dut.m_r_valid && dut.m_r_ready;
+        bool s_fire = dut.s_r_valid && dut.s_r_ready;
+        if (m_fire && r_beats < 16) {
+            if (dut.m_r_data != r_beats) data_ok = 0;
+            if (dut.m_r_last) { last_count++; last_beat_ix = (int)r_beats; }
+            r_beats++;
+        }
+
+        post_edge();
+
+        if (s_fire && sb_active) { glob++; if (sb_i == sb_len) sb_active = 0; else sb_i++; }
+    }
+
+    if (!ar_seen) return fail("no AXI4 AR issued");
+    if (s_addr != 0x00002000u) { std::printf("  s_addr=0x%x\n", s_addr); return fail("AXI4 AR addr (expected 0x2000)"); }
+    if (s_len  != 15) { std::printf("  s_len=%u\n", s_len); return fail("AXI4 AR len (expected 15 — forwarded unchanged at MAX_BURST=16)"); }
+    if (s_lock != 1)  { std::printf("  s_lock=%u\n", s_lock); return fail("AXI4 AR lock (expected 1 — AXI3 EXCLUSIVE→AXI4)"); }
+    if (s_qos != 0)   { std::printf("  s_qos=%u\n", s_qos); return fail("AXI4 AR qos (expected 0 — AXI3 has none)"); }
+    if (s_region != 0){ std::printf("  s_region=%u\n", s_region); return fail("AXI4 AR region (expected 0 — AXI3 has none)"); }
+    if (r_beats != 16){ std::printf("  r_beats=%u\n", r_beats); return fail("coalesced R beats (expected 16)"); }
+    if (!data_ok) return fail("R data out of order");
+    if (last_count != 1) { std::printf("  last_count=%d\n", last_count); return fail("RLAST must fire exactly once"); }
+    if (last_beat_ix != 15) { std::printf("  last_beat_ix=%d\n", last_beat_ix); return fail("RLAST must fire on beat 15 (16th beat)"); }
+
+    std::printf("PASS Nic400Axi3ToAxi4: AXI3 16-beat EXCLUSIVE read forwarded as ONE AXI4 AR "
+                "(addr 0x2000, len 15, lock 1, qos/region 0), 16 R beats in order with single RLAST\n");
+    return 0;
+}

--- a/examples/nic400/tb_nic400_axi4_to_axi3_split.cpp
+++ b/examples/nic400/tb_nic400_axi4_to_axi3_split.cpp
@@ -1,0 +1,141 @@
+// AXI4→AXI3 long-burst splitter TB (READ path).
+//
+// DUT: Nic400Axi4ToAxi3 — splits a long AXI4 INCR read burst into ≤16-beat
+// AXI3 sub-bursts and coalesces the AXI3 R streams back to one AXI4 R stream.
+//
+// The TB plays BOTH endpoints:
+//   • AXI4 master : drives m_ar_*, accepts m_r_*.
+//   • AXI3 slave  : accepts s_ar_* (capturing each sub-burst addr+len) and
+//                   drives s_r_* (returns the right beat count per sub-burst
+//                   with the AXI3 r_last on each sub-burst's final beat).
+//
+// Scenario: AXI4 read burst of 20 beats (ar_len=19), size=2, base=0x1000.
+// Expect TWO AXI3 sub-bursts:
+//   sub 0: addr=0x1000, ar_len=15  (16 beats)
+//   sub 1: addr=0x1040, ar_len=3   ( 4 beats)   [0x1000 + 16*4]
+// and one coalesced AXI4 R stream of 20 in-order beats, r_last ONLY on beat 20.
+//
+// Phasing matches the other NIC-400 TBs: sample combinational Mealy drives on
+// pre_edge() (clk low), advance the slave's R data AFTER post_edge(), holding
+// it stable across the clock edge.
+
+#include "VNic400Axi4ToAxi3.h"
+#include <cstdint>
+#include <cstdio>
+
+static VNic400Axi4ToAxi3 dut;
+static uint64_t cycle = 0;
+
+static void pre_edge()  { dut.clk = 0; dut.eval(); }
+static void post_edge() { dut.clk = 1; dut.eval(); cycle++; }
+
+static int fail(const char* m) {
+    std::printf("FAIL %s (cycle=%llu)\n", m, (unsigned long long)cycle);
+    return 1;
+}
+
+int main() {
+    // ── Reset (active-low) ────────────────────────────────────────────────
+    dut.rst = 0;
+    dut.m_ar_valid = 0; dut.m_ar_addr = 0; dut.m_ar_id = 0; dut.m_ar_len = 0;
+    dut.m_ar_size = 0;  dut.m_ar_burst = 0; dut.m_ar_lock = 0;
+    dut.m_ar_cache = 0; dut.m_ar_prot = 0;
+    dut.m_r_ready = 0;
+    dut.s_ar_ready = 0;
+    dut.s_r_valid = 0; dut.s_r_data = 0; dut.s_r_id = 0; dut.s_r_resp = 0;
+    dut.s_r_last = 0;
+    for (int i = 0; i < 4; ++i) { pre_edge(); post_edge(); }
+    dut.rst = 1;
+    for (int i = 0; i < 2; ++i) { pre_edge(); post_edge(); }
+
+    // ── AXI4 master issues a 20-beat INCR read ────────────────────────────
+    dut.m_ar_addr  = 0x00001000u;
+    dut.m_ar_id    = 7;
+    dut.m_ar_len   = 19;        // 20 beats
+    dut.m_ar_size  = 2;         // 4 bytes/beat
+    dut.m_ar_burst = 1;         // INCR
+    dut.m_ar_valid = 1;
+    dut.m_r_ready  = 1;         // master always ready to accept R
+    dut.s_ar_ready = 1;         // slave always ready to accept AR
+
+    // Sub-burst AR capture.
+    int      sub_seen  = 0;
+    uint32_t sub0_addr = 0, sub1_addr = 0;
+    uint32_t sub0_len  = 0, sub1_len  = 0;
+
+    // AXI3-slave R driver state.
+    int      sb_active = 0;     // streaming a sub-burst's R beats
+    uint32_t sb_len    = 0;     // active sub-burst ar_len (beats-1)
+    uint32_t sb_i      = 0;     // beats emitted in active sub-burst
+    uint32_t glob_i    = 0;     // global beat index == R data
+
+    // AXI4-master R observer.
+    uint32_t r_beats      = 0;  // coalesced beats accepted
+    int      last_count   = 0;  // # of m_r_last=1 beats
+    int      last_beat_ix = -1; // beat index where r_last fired
+    int      data_ok      = 1;  // data == beat index everywhere
+
+    for (int i = 0; i < 400 && (sub_seen < 2 || r_beats < 20); ++i) {
+        // Drive the AXI3 R beat for the active sub-burst BEFORE the edge so
+        // the DUT's combinational m_r_* settle on this pre_edge.
+        if (sb_active) {
+            dut.s_r_valid = 1;
+            dut.s_r_data  = glob_i;
+            dut.s_r_id    = 7;
+            dut.s_r_resp  = 0;
+            dut.s_r_last  = (sb_i == sb_len) ? 1 : 0;
+        } else {
+            dut.s_r_valid = 0;
+            dut.s_r_last  = 0;
+        }
+
+        pre_edge();   // settle combinational outputs with current inputs
+
+        // Drop AXI4 ar_valid only once the splitter has moved past the AR
+        // accept state (it began issuing the first AXI3 sub-burst AR). Dropping
+        // it the same pre_edge the accept handshake completes would clear the
+        // S0→S1 transition condition before the post_edge that latches it.
+        if (dut.s_ar_valid) dut.m_ar_valid = 0;
+
+        // Capture a sub-burst AR the cycle the DUT presents it.
+        if (dut.s_ar_valid && dut.s_ar_ready && !sb_active) {
+            if (sub_seen == 0) { sub0_addr = dut.s_ar_addr; sub0_len = dut.s_ar_len; sub_seen = 1; }
+            else if (sub_seen == 1) { sub1_addr = dut.s_ar_addr; sub1_len = dut.s_ar_len; sub_seen = 2; }
+            sb_active = 1; sb_len = dut.s_ar_len; sb_i = 0;
+        }
+
+        // Observe the coalesced AXI4 R beat (Mealy, sampled pre-edge).
+        bool m_fire = dut.m_r_valid && dut.m_r_ready;
+        bool s_fire = dut.s_r_valid && dut.s_r_ready;
+        if (m_fire && r_beats < 20) {
+            if (dut.m_r_data != r_beats) data_ok = 0;
+            if (dut.m_r_last) { last_count++; last_beat_ix = (int)r_beats; }
+            r_beats++;
+        }
+
+        post_edge();  // clock the registers; hold slave data stable across it
+
+        // Advance the AXI3 slave AFTER the edge for the beat just consumed.
+        if (s_fire && sb_active) {
+            glob_i++;
+            if (sb_i == sb_len) sb_active = 0;   // sub-burst done; await next AR
+            else sb_i++;
+        }
+    }
+
+    // ── Assertions ────────────────────────────────────────────────────────
+    if (sub_seen != 2) { std::printf("  sub_seen=%d\n", sub_seen); return fail("expected exactly 2 AXI3 sub-burst ARs"); }
+    if (sub0_addr != 0x00001000u) { std::printf("  sub0_addr=0x%x\n", sub0_addr); return fail("sub0 addr (expected 0x1000)"); }
+    if (sub0_len  != 15) { std::printf("  sub0_len=%u\n", sub0_len); return fail("sub0 ar_len (expected 15 = 16 beats)"); }
+    if (sub1_addr != 0x00001040u) { std::printf("  sub1_addr=0x%x\n", sub1_addr); return fail("sub1 addr (expected 0x1040 = base + 16*4)"); }
+    if (sub1_len  != 3) { std::printf("  sub1_len=%u\n", sub1_len); return fail("sub1 ar_len (expected 3 = 4 beats)"); }
+    if (r_beats   != 20) { std::printf("  r_beats=%u\n", r_beats); return fail("coalesced AXI4 R beats (expected 20)"); }
+    if (!data_ok) return fail("coalesced R data out of order (beat i != data i)");
+    if (last_count != 1) { std::printf("  last_count=%d\n", last_count); return fail("m_r_last must assert exactly once"); }
+    if (last_beat_ix != 19) { std::printf("  last_beat_ix=%d\n", last_beat_ix); return fail("m_r_last must fire on beat 19 (20th beat)"); }
+
+    std::printf("PASS Nic400Axi4ToAxi3: 20-beat AXI4 read split into AXI3 16+4 sub-bursts "
+                "(addrs 0x1000/0x1040, lens 15/3), coalesced to one 20-beat AXI4 R stream "
+                "with single final RLAST on beat 20\n");
+    return 0;
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -25829,3 +25829,105 @@ end module TopBad
         errs
     );
 }
+
+// ────────────────────────────────────────────────────────────────────
+// NIC-400 AXI3 endpoint shim + AXI4↔AXI3 protocol conversion
+// (nic400_interconnect_spec.md §16.1, TRM DDI 0475E §1.2/§2.3.1)
+// ────────────────────────────────────────────────────────────────────
+//
+// Three new examples: examples/nic400/BusAxi3.arch (AXI3 bus bundle),
+// Nic400Axi4ToAxi3.arch (AXI4→AXI3 long-burst splitter), and
+// Nic400Axi3ToAxi4.arch (AXI3→AXI4 programmable burst limiter).
+//
+// End-to-end behaviour is verified by the pre/post-edge C++ TBs
+// tb_nic400_axi4_to_axi3_split.cpp and tb_nic400_axi3_to_axi4_limit.cpp
+// (PASS under BOTH `arch sim` and Verilator — see PR description) and by
+// the HARC TB Nic400Axi4ToAxi3_test.harc (`--check-backends` reports no
+// divergence). These cargo tests pin the load-bearing SV codegen of the
+// burst-split arithmetic so a future thread-lowering / width regression
+// trips a dedicated test.
+
+#[test]
+fn test_nic400_axi4_to_axi3_burst_split_arithmetic_sv() {
+    // The AXI4→AXI3 splitter lowers to a `_threads` sub-module that must:
+    //   1. compute num_sub = ceil((ar_len+1)/16) as (ar_len + 16) >> 4;
+    //   2. step each sub-burst start address by (i*16) << size;
+    //   3. truncate the per-sub-burst AXI3 ar_len to 4 bits (max 16 beats);
+    //   4. suppress the merged RLAST except on the final sub-burst
+    //      (loop_cnt == num_sub-1).
+    let bus4 = include_str!("../examples/nic400/BusAxi4.arch");
+    let bus3 = include_str!("../examples/nic400/BusAxi3.arch");
+    let dut = include_str!("../examples/nic400/Nic400Axi4ToAxi3.arch");
+    let sv = compile_to_sv(&format!("{bus4}\n{bus3}\n{dut}"));
+    let flat: String = sv.split_whitespace().collect::<Vec<_>>().join(" ");
+
+    // 1. ceil-div sub-burst count: (ar_len + 16) >> 4.
+    assert!(
+        flat.contains("num_sub_r <= 5'(9'(9'($unsigned(m_ar_len)) + 16) >> 4)"),
+        "num_sub must be ceil((ar_len+1)/16) = (ar_len+16)>>4:\n{sv}",
+    );
+    // 2. INCR-stepped sub-burst start address: base + (beats_done << size).
+    assert!(
+        flat.contains("logic [ADDR_W-1:0] stepped = done << size;")
+            && flat.contains("return ADDR_W'(base + stepped);"),
+        "sub-burst start address must step by (i*16)<<size:\n{sv}",
+    );
+    // 3. AXI3 ar_len is 4-bit and is sub_beats-1.
+    assert!(
+        flat.contains("output logic [3:0] s_ar_len"),
+        "AXI3 s_ar_len must be 4-bit (max 16-beat burst):\n{sv}",
+    );
+    assert!(
+        flat.contains("s_ar_len = 4'(sub_beats_5_9(_t0_loop_cnt_0, total_r) - 1)"),
+        "AXI3 ar_len must be (sub_beats - 1) truncated to 4 bits:\n{sv}",
+    );
+    // min(16, remaining) clamp inside sub_beats().
+    assert!(
+        flat.contains("if (remaining > 16) begin return 9'd16;"),
+        "sub_beats must clamp to min(16, remaining):\n{sv}",
+    );
+    // 4. merged RLAST only on the final sub-burst.
+    assert!(
+        flat.contains("m_r_last = _t0_loop_cnt_0 == num_sub_r - 1 && s_r_last"),
+        "merged RLAST must fire only on the final sub-burst:\n{sv}",
+    );
+}
+
+#[test]
+fn test_nic400_axi3_to_axi4_limiter_field_mapping_sv() {
+    // The AXI3→AXI4 limiter forwards (limits) AXI3 reads onto AXI4. It must:
+    //   1. zero AXI4 QoS / REGION (AXI3 has neither);
+    //   2. map AXI3 2-bit AxLOCK (EXCLUSIVE=01) to AXI4 1-bit lock (==1);
+    //   3. take MAX_BURST as the programmable onward-AxLEN cap.
+    let bus3 = include_str!("../examples/nic400/BusAxi3.arch");
+    let bus4 = include_str!("../examples/nic400/BusAxi4.arch");
+    let dut = include_str!("../examples/nic400/Nic400Axi3ToAxi4.arch");
+    let sv = compile_to_sv(&format!("{bus3}\n{bus4}\n{dut}"));
+    let flat: String = sv.split_whitespace().collect::<Vec<_>>().join(" ");
+
+    // 1. AXI3 AxLEN is 4-bit on the master-facing port (target flips dir →
+    //    input on this converter), AXI4 AxLEN is 8-bit on the slave port.
+    assert!(
+        flat.contains("input logic [3:0] m_ar_len"),
+        "AXI3 master-facing ar_len must be 4-bit:\n{sv}",
+    );
+    assert!(
+        flat.contains("output logic [7:0] s_ar_len"),
+        "AXI4 slave-facing ar_len must be 8-bit:\n{sv}",
+    );
+    // 2. AXI4 QoS / REGION held at 0.
+    assert!(
+        flat.contains("s_ar_qos = 0") && flat.contains("s_ar_region = 0"),
+        "AXI4 QoS/REGION must be tied to 0 (AXI3 has neither):\n{sv}",
+    );
+    // 3. AXI3 2-bit lock → AXI4 1-bit lock via (l == 1).
+    assert!(
+        flat.contains("return l == 1;"),
+        "AXI3 2-bit AxLOCK must map EXCLUSIVE(01)→1, else 0:\n{sv}",
+    );
+    // 4. MAX_BURST is the programmable cap parameter, default 16.
+    assert!(
+        flat.contains("parameter int MAX_BURST = 16"),
+        "MAX_BURST must be the GPV-programmable onward-AxLEN cap (default 16):\n{sv}",
+    );
+}


### PR DESCRIPTION
## What

Closes the NIC-400 §16.1 tracker row for the AXI3 endpoint shim and AXI4↔AXI3 protocol conversion (ARM NIC-400 TRM DDI 0475E §1.2/§2.3.1). READ path, one construct per `.arch` file.

### New examples
- **`examples/nic400/BusAxi3.arch`** — AXI3 bus bundle. AXI3-vs-AXI4 deltas: 4-bit `AxLEN` (≤16 beats), 2-bit `AxLOCK`, `WID` on the W channel, no QoS/REGION. Modeled on `BusAxi4.arch`.
- **`examples/nic400/Nic400Axi4ToAxi3.arch`** — the headline piece: AXI4→AXI3 **long-burst splitter**. An incoming AXI4 INCR `AR` with `ar_len` up to 255 is split into `ceil((ar_len+1)/16)` AXI3 sub-bursts, each ≤16 beats:
  - per-sub-burst start address `base + (i*16) << size` (INCR step),
  - short final-sub-burst length `min(16, remaining) - 1` truncated to the AXI3 4-bit `ar_len`,
  - sub-bursts sequenced by one `thread` (non-pipelined, matching NIC-400 base behaviour),
  - R responses **merged** into one AXI4 stream: merged `RLAST` only on the true final beat (`loop_cnt == num_sub-1`), `r_resp` sticky-OR'd across sub-bursts,
  - 4 KB-boundary + INCR-only concurrent SVA.
- **`examples/nic400/Nic400Axi3ToAxi4.arch`** — reverse converter with a GPV-programmable burst **limiter** (`param MAX_BURST` caps the onward `AxLEN`). Maps AXI3 2-bit `AxLOCK` (EXCLUSIVE=01) → AXI4 1-bit lock, ties AXI4 `QoS`/`REGION` to 0 (AXI3 has neither). At `MAX_BURST=16` an AXI3 burst forwards unchanged.

Write-path splitting is out of scope in v1 (documented in the file headers); the AXI3 W/B channels are absent (`WRITE=0`) on these READ-only converter instances.

## Verification

**Burst-split numbers confirmed:** AXI4 20-beat INCR read (`ar_len=19`, `size=2`, base `0x1000`) → exactly **two** AXI3 sub-bursts: sub0 `addr=0x1000, ar_len=15` (16 beats), sub1 `addr=0x1040, ar_len=3` (4 beats, `0x1000 + 16*4`); coalesced into one **20-beat** in-order AXI4 R stream with a single `RLAST` on **beat 20**.

- `tb_nic400_axi4_to_axi3_split.cpp` (pre/post-edge C++ TB) — **PASS under `arch sim` AND Verilator** (independently cross-checked: `sub_seen=2`, addrs `0x1000`/`0x1040`, lens `15`/`3`, `rb=20`, RLAST on beat 19).
- `tb_nic400_axi3_to_axi4_limit.cpp` — AXI3 16-beat EXCLUSIVE read forwarded as **one** AXI4 AR (`addr=0x2000, len=15, lock=1, qos/region=0`), 16 in-order R beats, RLAST once. **PASS under `arch sim` AND Verilator.**
- `Nic400Axi4ToAxi3_test.harc` (HARC TB) — `harc sim --check-backends` reports **traces match across backends (no divergence)**. It asserts the phase-robust burst-split AR arithmetic; the cycle-exact Mealy R-stream/RLAST property is pinned by the C++ TB. The `.harc` documents why: HARC's `wait 1 cycle` samples the DUT *after* the clock edge, so the merged R channel's Mealy `m_r_last` (a function of `s_r_last` AND the lowered-thread sub-burst counter) cannot be observed at the same pre-edge combinational phase a real AXI consumer would — a TB-side sampling property, not a DUT bug (both backends agree).
- `arch check` clean on all four module/bus files.
- `verilator -Wall` — only the established thread-lowering warning families (DECLFILENAME, PROCASSINIT, SYNCASYNCNET, UNUSEDPARAM/SIGNAL, WIDTHEXPAND/TRUNC), identical to the existing `Nic400WidthAdapter` baseline; no genuine lint errors.
- `tests/integration_test.rs` — two new tests pin the burst-split / limiter SV codegen; `cargo test test_nic400` → 14/14 pass.

## Compiler bug

**None found.** Both DUTs verified consistent across `arch sim` and Verilator.

Do not merge — for parent-session review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)