### PR TITLE
fix(elaborate): mangle bit-63 param values into valid variant identifiers

### DIFF
--- a/src/elaborate.rs
+++ b/src/elaborate.rs
@@ -454,11 +454,20 @@ fn find_varying_params(param_sets: &[HashMap<String, i64>]) -> Vec<String> {
 }
 
 fn make_variant_name(base: &str, params: &HashMap<String, i64>, varying: &[String]) -> String {
-    // Regular param suffixes (skip __ro__* synthetic reset-override keys)
+    // Regular param suffixes (skip __ro__* synthetic reset-override keys).
+    // A param value whose bit 63 is set is a negative `i64`, and formatting it
+    // directly would splice a bare `-` into the variant name — illegal in both
+    // SystemVerilog and C++ identifiers, so `arch build`/`arch sim` would emit
+    // an uncompilable `Mod__P_-9223372036854775807`. Render the leading minus as
+    // `n` (e.g. `P_-5` → `P_n5`); positive values are pure digits, so this stays
+    // collision-free while keeping the magnitude readable.
     let regular: Vec<String> = varying
         .iter()
         .filter(|k| !k.starts_with("__ro__"))
-        .map(|k| format!("{}_{}", k, params.get(k).copied().unwrap_or(0)))
+        .map(|k| {
+            let v = params.get(k).copied().unwrap_or(0);
+            format!("{}_{}", k, format!("{v}").replace('-', "n"))
+        })
         .collect();
 
     // Reset-override suffixes: group by port name for a clean suffix like rst_Async_Low

--- a/tests/axi_dma_tlm/TlmConnectDecodeThree.arch
+++ b/tests/axi_dma_tlm/TlmConnectDecodeThree.arch
@@ -1,0 +1,105 @@
+//! ---
+//! tags: [tlm_method, connect, address_decode, one_to_many, three_way]
+//! refs:
+//!   - "compiler decoded TLM connect regression (3-way priority decode)"
+//! ---
+//!
+//! Three-target decoded connect regression. The landed two-target fixture
+//! (`TlmConnectDecode.arch`) exercises a single-bit route register and a
+//! two-way selector. This fixture adds a middle target so the generated
+//! response-route register is multi-bit (`route_w == 2`) and the middle
+//! selector takes the priority-decode `raw && !any_previous` path. Each
+//! target returns a distinct tag so a mis-route shows up as a wrong value.
+
+/// Blocking memory transaction bus used by the 3-way decoded connect test.
+bus DecodeMem3
+  tlm_method read(addr: UInt<32>) -> UInt<64>: blocking;
+end bus DecodeMem3
+
+use DecodeMem3;
+
+/// One address-mapped memory target; the returned tag is param-selected so a
+/// single module definition can stand in for all three slaves.
+module DecodeMem3Target
+  param SLAVE_START_ADDR: const = 32'h0000_0000;
+  param SLAVE_END_ADDR: const = 32'h0000_0000;
+  param TAG: const = 64'h0;
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port s: target DecodeMem3;
+
+  thread s.read(addr) on clk rising, rst high
+    return TAG;
+  end thread s.read
+end module DecodeMem3Target
+
+/// Initiator that issues one transaction into each of the three address ranges.
+module DecodeMem3Initiator
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port m: initiator DecodeMem3;
+  port lo_o: out UInt<64>;
+  port mid_o: out UInt<64>;
+  port hi_o: out UInt<64>;
+
+  reg lo_r: UInt<64> reset rst => 0;
+  reg mid_r: UInt<64> reset rst => 0;
+  reg hi_r: UInt<64> reset rst => 0;
+
+  comb
+    lo_o = lo_r;
+    mid_o = mid_r;
+    hi_o = hi_r;
+  end comb
+
+  thread driver on clk rising, rst high
+    lo_r <= m.read(32'h0000_0010);
+    mid_r <= m.read(32'h4000_0010);
+    hi_r <= m.read(32'h9000_0010);
+  end thread driver
+end module DecodeMem3Initiator
+
+/// Top-level: one initiator decoded across three address-mapped targets.
+module TlmConnectDecodeThreeTop
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port lo_o: out UInt<64>;
+  port mid_o: out UInt<64>;
+  port hi_o: out UInt<64>;
+
+  inst i: DecodeMem3Initiator
+    clk <- clk;
+    rst <- rst;
+    lo_o -> lo_o;
+    mid_o -> mid_o;
+    hi_o -> hi_o;
+  end inst i
+
+  inst lo_t: DecodeMem3Target
+    param SLAVE_START_ADDR = 32'h0000_0000;
+    param SLAVE_END_ADDR = 32'h3fff_ffff;
+    param TAG = 64'hAAAA_0000_0000_0000;
+    clk <- clk;
+    rst <- rst;
+  end inst lo_t
+
+  inst mid_t: DecodeMem3Target
+    param SLAVE_START_ADDR = 32'h4000_0000;
+    param SLAVE_END_ADDR = 32'h7fff_ffff;
+    param TAG = 64'hBBBB_0000_0000_0000;
+    clk <- clk;
+    rst <- rst;
+  end inst mid_t
+
+  inst hi_t: DecodeMem3Target
+    param SLAVE_START_ADDR = 32'h8000_0000;
+    param SLAVE_END_ADDR = 32'hffff_ffff;
+    param TAG = 64'hCCCC_0000_0000_0000;
+    clk <- clk;
+    rst <- rst;
+  end inst hi_t
+
+  connect i.m -> lo_t.s;
+  connect i.m -> mid_t.s;
+  connect i.m -> hi_t.s;
+end module TlmConnectDecodeThreeTop

--- a/tests/axi_dma_tlm/tb_tlm_connect_decode_three.cpp
+++ b/tests/axi_dma_tlm/tb_tlm_connect_decode_three.cpp
@@ -1,0 +1,49 @@
+#include "VTlmConnectDecodeThreeTop.h"
+
+#include <cstdint>
+#include <cstdio>
+
+static VTlmConnectDecodeThreeTop dut;
+
+static void tick() {
+    dut.clk = 0;
+    dut.eval();
+    dut.clk = 1;
+    dut.eval();
+}
+
+static void reset() {
+    dut.rst = 1;
+    for (int i = 0; i < 4; ++i) {
+        tick();
+    }
+    dut.rst = 0;
+    tick();
+}
+
+int main() {
+    reset();
+
+    constexpr uint64_t lo_expected = 0xAAAA000000000000ull;
+    constexpr uint64_t mid_expected = 0xBBBB000000000000ull;
+    constexpr uint64_t hi_expected = 0xCCCC000000000000ull;
+
+    for (int cycle = 0; cycle < 200; ++cycle) {
+        tick();
+        if (dut.lo_o == lo_expected
+            && dut.mid_o == mid_expected
+            && dut.hi_o == hi_expected) {
+            std::printf("PASS decoded connect 3way: lo=0x%016llx mid=0x%016llx hi=0x%016llx\n",
+                        static_cast<unsigned long long>(dut.lo_o),
+                        static_cast<unsigned long long>(dut.mid_o),
+                        static_cast<unsigned long long>(dut.hi_o));
+            return 0;
+        }
+    }
+
+    std::printf("FAIL decoded connect 3way: lo=0x%016llx mid=0x%016llx hi=0x%016llx\n",
+                static_cast<unsigned long long>(dut.lo_o),
+                static_cast<unsigned long long>(dut.mid_o),
+                static_cast<unsigned long long>(dut.hi_o));
+    return 1;
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -11366,6 +11366,38 @@ fn test_tlm_connect_decode_subtype_arch_sim_behavior() {
 }
 
 #[test]
+fn test_tlm_connect_decode_three_way_arch_sim_behavior() {
+    // The two-target decode fixture exercises only a single-bit route register
+    // and a two-way selector. A third target makes the synthesized
+    // response-route register multi-bit (route_w == 2) and forces the middle
+    // target through the priority-decode `raw && !any_previous` selector path.
+    // Each target returns a distinct tag, so a mis-route surfaces as a wrong
+    // value at the corresponding output port.
+    let td = tempfile::tempdir().expect("tempdir");
+    let arch_bin = env!("CARGO_BIN_EXE_arch");
+    let out = std::process::Command::new(arch_bin)
+        .arg("sim")
+        .arg("tests/axi_dma_tlm/TlmConnectDecodeThree.arch")
+        .arg("--tb")
+        .arg("tests/axi_dma_tlm/tb_tlm_connect_decode_three.cpp")
+        .arg("--outdir")
+        .arg(td.path())
+        .output()
+        .expect("run arch sim for 3-way decoded connect");
+    assert!(
+        out.status.success(),
+        "3-way decoded connect sim should pass\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&out.stdout).contains("PASS decoded connect 3way"),
+        "expected PASS marker in stdout:\n{}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+}
+
+#[test]
 fn test_tlm_one_initiator_many_targets_router_arch_sim_behavior() {
     let td = tempfile::tempdir().expect("tempdir");
     let arch_bin = env!("CARGO_BIN_EXE_arch");
@@ -26635,6 +26667,61 @@ fn test_derived_param_override_reevaluates_and_creates_nested_variants() {
         sv.contains("module Leaf__PW_9"),
         "missing Leaf__PW_9 variant (derived param DB=W+4 must re-evaluate to 9 \
          under the W=5 override):\n{sv}"
+    );
+}
+
+#[test]
+fn test_variant_name_with_bit63_param_is_valid_identifier() {
+    // A `const` param value with bit 63 set is a negative `i64`. The variant
+    // name mangler used to format it directly, splicing a bare `-` into the
+    // emitted module/class name (`Leaf__TAG_-9223372036854775807`) — illegal in
+    // both SystemVerilog and C++ identifiers, so the design would emit
+    // uncompilable SV and the sim model would not build. The minus is now
+    // rendered as `n` (`TAG_n9223...`); positive values stay pure digits, so the
+    // mapping is collision-free. Two distinct high-bit variants exercise it.
+    let source = r#"
+module Leaf
+  param TAG: const = 64'h0;
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port o: out UInt<64>;
+  reg r: UInt<64> reset rst => 0;
+  comb o = r; end comb
+  seq on clk rising
+    r <= TAG;
+  end seq
+end module Leaf
+
+module Top
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port o0: out UInt<64>;
+  port o1: out UInt<64>;
+  inst l0: Leaf
+    param TAG = 64'h0000_0000_0000_0001;
+    clk <- clk; rst <- rst; o -> o0;
+  end inst l0
+  inst l1: Leaf
+    param TAG = 64'h8000_0000_0000_0001;
+    clk <- clk; rst <- rst; o -> o1;
+  end inst l1
+end module Top
+"#;
+    let sv = compile_to_sv(source);
+    // The high-bit variant must appear with an `n`-rendered suffix, never a
+    // bare `-` that would break the SV/C++ identifier.
+    assert!(
+        sv.contains("module Leaf__TAG_n9223372036854775807"),
+        "bit-63 param variant must mangle the leading minus to `n`:\n{sv}"
+    );
+    assert!(
+        !sv.contains("Leaf__TAG_-"),
+        "variant name must not contain a bare `-` (invalid identifier):\n{sv}"
+    );
+    // The low-bit variant is unchanged (pure digits).
+    assert!(
+        sv.contains("module Leaf__TAG_1"),
+        "positive param variant naming must be unchanged:\n{sv}"
     );
 }
 


### PR DESCRIPTION
## Summary

Fixes a general, latent sim/build codegen bug surfaced while reviewing the just-landed decoded TLM connect feature (#570): **a `const` param value with bit 63 set mangles into an invalid variant identifier.**

A param value like `64'h8000_0000_0000_0001` is stored as a negative `i64`. `make_variant_name` (`src/elaborate.rs`) formatted it directly, so a module instantiated with two distinct variants produced an elaborated name containing a bare `-`:

```
module Leaf__TAG_-9223372036854775807   // illegal in SV *and* C++
```

Consequences:
- `arch build` emits SystemVerilog with an illegal module identifier.
- `arch sim` generates a C++ model that fails to compile: `error: expected unqualified-id`.

The bug only appears when a module has **multiple** param variants (a single variant gets no suffix), which is why the existing suite never hit it. It is fully general — not specific to TLM or any construct. High-bit param values are realistic: a memory-map base address such as `0x8000_0000_0000_0000` triggers it.

## Repro (before this PR)

```arch
module Leaf
  param TAG: const = 64'h0;
  ...
end module Leaf
module Top
  inst l0: Leaf  param TAG = 64'h0000_0000_0000_0001; ... end inst l0
  inst l1: Leaf  param TAG = 64'h8000_0000_0000_0001; ... end inst l1
end module Top
```
`arch sim Top.arch --tb tb.cpp` → `VLeaf__TAG_-9223372036854775807.h:... error: expected unqualified-id`.

## Fix

Render the leading minus as `n` (`TAG_-5` → `TAG_n5`). Positive values are pure digits, so the mapping is collision-free, and magnitude stays readable. There is a single mangling site; the elaborated name is the canonical identifier every backend consumes, and nothing reverse-parses the suffix.

## Tests

- **`test_variant_name_with_bit63_param_is_valid_identifier`** — fast compile-level guard: asserts the `n`-rendered suffix and the absence of any bare `-`.
- **`test_tlm_connect_decode_three_way_arch_sim_behavior`** — a 3-way decoded TLM-connect end-to-end sim. #570 only shipped a 2-way fixture; this exercises the multi-bit response-route register (`route_w == 2`) and the middle target's priority-decode `raw && !any_previous` selector path. Because its per-slave tags are high-bit memory-map values, it also guards this fix end-to-end.

Full integration suite: **637 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
