### PR TITLE
[codex] Reject TLM connect bus-shape mismatches

### DIFF
--- a/src/elaborate.rs
+++ b/src/elaborate.rs
@@ -732,13 +732,13 @@ fn rewrite_inst(
 // ── TLM/bus connect sugar ───────────────────────────────────────────────────
 
 fn lower_tlm_connects(ast: SourceFile) -> Result<SourceFile, Vec<CompileError>> {
-    let module_ports: HashMap<String, Vec<PortDecl>> = ast
+    let module_defs: HashMap<String, (Vec<ParamDecl>, Vec<PortDecl>)> = ast
         .items
         .iter()
         .filter_map(|item| match item {
-            Item::Module(m) => Some((m.name.name.clone(), m.ports.clone())),
-            Item::Fsm(f) => Some((f.name.name.clone(), f.ports.clone())),
-            Item::Pipeline(p) => Some((p.name.name.clone(), p.ports.clone())),
+            Item::Module(m) => Some((m.name.name.clone(), (m.params.clone(), m.ports.clone()))),
+            Item::Fsm(f) => Some((f.name.name.clone(), (f.params.clone(), f.ports.clone()))),
+            Item::Pipeline(p) => Some((p.name.name.clone(), (p.params.clone(), p.ports.clone()))),
             _ => None,
         })
         .collect();
@@ -755,7 +755,7 @@ fn lower_tlm_connects(ast: SourceFile) -> Result<SourceFile, Vec<CompileError>> 
     let mut items = Vec::new();
     for item in ast.items {
         match item {
-            Item::Module(m) => match lower_tlm_connects_in_module(m, &module_ports, &bus_defs) {
+            Item::Module(m) => match lower_tlm_connects_in_module(m, &module_defs, &bus_defs) {
                 Ok(m) => items.push(Item::Module(m)),
                 Err(mut errs) => errors.append(&mut errs),
             },
@@ -776,7 +776,7 @@ fn lower_tlm_connects(ast: SourceFile) -> Result<SourceFile, Vec<CompileError>> 
 
 fn lower_tlm_connects_in_module(
     mut m: ModuleDecl,
-    module_ports: &HashMap<String, Vec<PortDecl>>,
+    module_defs: &HashMap<String, (Vec<ParamDecl>, Vec<PortDecl>)>,
     bus_defs: &HashMap<String, BusDecl>,
 ) -> Result<ModuleDecl, Vec<CompileError>> {
     let connects: Vec<TlmConnectDecl> = m
@@ -836,7 +836,9 @@ fn lower_tlm_connects_in_module(
             &conn.from_inst,
             &conn.from_port,
             &inst_modules,
-            module_ports,
+            module_defs,
+            &inst_params,
+            bus_defs,
         ) {
             Ok(endpoint) => endpoint,
             Err(err) => {
@@ -844,7 +846,7 @@ fn lower_tlm_connects_in_module(
                 continue;
             }
         };
-        let (from_bus, from_persp, from_span) = from;
+        let (from_bus, from_persp, from_span, from_shape) = from;
 
         let mut target_infos = Vec::new();
         for target in &conn.targets {
@@ -852,10 +854,12 @@ fn lower_tlm_connects_in_module(
                 &target.to_inst,
                 &target.to_port,
                 &inst_modules,
-                module_ports,
+                module_defs,
+                &inst_params,
+                bus_defs,
             ) {
-                Ok((to_bus, to_persp, to_span)) => {
-                    target_infos.push((target, to_bus, to_persp, to_span));
+                Ok((to_bus, to_persp, to_span, to_shape)) => {
+                    target_infos.push((target, to_bus, to_persp, to_span, to_shape));
                 }
                 Err(err) => {
                     errors.push(err);
@@ -889,7 +893,7 @@ fn lower_tlm_connects_in_module(
             continue;
         }
         let mut bus_mismatch = false;
-        for (target, to_bus, _, _) in &target_infos {
+        for (target, to_bus, _, _, _) in &target_infos {
             if from_bus != *to_bus {
                 errors.push(CompileError::general(
                     &format!(
@@ -907,8 +911,29 @@ fn lower_tlm_connects_in_module(
         if bus_mismatch {
             continue;
         }
+        let mut bus_shape_mismatch = false;
+        for (target, _, _, _, to_shape) in &target_infos {
+            if from_shape != *to_shape {
+                errors.push(CompileError::general(
+                    &format!(
+                        "TLM connect bus-shape mismatch: `{}.{}` exposes {}, but `{}.{}` exposes {}",
+                        conn.from_inst.name,
+                        conn.from_port.name,
+                        format_tlm_connect_shape(&from_shape),
+                        target.to_inst.name,
+                        target.to_port.name,
+                        format_tlm_connect_shape(to_shape)
+                    ),
+                    conn.span,
+                ));
+                bus_shape_mismatch = true;
+            }
+        }
+        if bus_shape_mismatch {
+            continue;
+        }
         let mut direction_mismatch = false;
-        for (target, _, to_persp, to_span) in &target_infos {
+        for (target, _, to_persp, to_span, _) in &target_infos {
             if from_persp != BusPerspective::Initiator || *to_persp != BusPerspective::Target {
                 errors.push(CompileError::general(
                     &format!(
@@ -1705,15 +1730,17 @@ fn tlm_connect_endpoint_bus(
     inst: &Ident,
     port: &Ident,
     inst_modules: &HashMap<String, String>,
-    module_ports: &HashMap<String, Vec<PortDecl>>,
-) -> Result<(String, BusPerspective, Span), CompileError> {
+    module_defs: &HashMap<String, (Vec<ParamDecl>, Vec<PortDecl>)>,
+    inst_params: &HashMap<String, Vec<ParamAssign>>,
+    bus_defs: &HashMap<String, BusDecl>,
+) -> Result<(String, BusPerspective, Span, TlmConnectShape), CompileError> {
     let Some(module_name) = inst_modules.get(&inst.name) else {
         return Err(CompileError::general(
             &format!("unknown TLM connect instance `{}`", inst.name),
             inst.span,
         ));
     };
-    let Some(ports) = module_ports.get(module_name) else {
+    let Some((module_params, ports)) = module_defs.get(module_name) else {
         return Err(CompileError::general(
             &format!(
                 "TLM connect instance `{}` has construct type `{}` whose ports are not supported by connect",
@@ -1740,7 +1767,84 @@ fn tlm_connect_endpoint_bus(
             p.span,
         ));
     };
-    Ok((bi.bus_name.name.clone(), bi.perspective, p.span))
+    let Some(bus_decl) = bus_defs.get(&bi.bus_name.name) else {
+        return Err(CompileError::general(
+            &format!(
+                "TLM connect endpoint `{}.{}` references unknown bus `{}`",
+                inst.name, port.name, bi.bus_name.name
+            ),
+            p.span,
+        ));
+    };
+    let shape = tlm_connect_shape_for_port(
+        bus_decl,
+        bi,
+        module_params,
+        inst_params
+            .get(&inst.name)
+            .map(Vec::as_slice)
+            .unwrap_or(&[]),
+    );
+    Ok((bi.bus_name.name.clone(), bi.perspective, p.span, shape))
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct TlmConnectShape {
+    count: Option<u64>,
+    signals: Vec<(String, String)>,
+}
+
+fn tlm_connect_shape_for_port(
+    bus_decl: &BusDecl,
+    bi: &BusPortInfo,
+    module_params: &[ParamDecl],
+    inst_param_assigns: &[ParamAssign],
+) -> TlmConnectShape {
+    let mut module_param_map: HashMap<String, &Expr> = module_params
+        .iter()
+        .filter_map(|p| p.default.as_ref().map(|d| (p.name.name.clone(), d)))
+        .collect();
+    for pa in inst_param_assigns {
+        module_param_map.insert(pa.name.name.clone(), &pa.value);
+    }
+
+    let mut bus_param_map = module_param_map.clone();
+    for p in &bus_decl.params {
+        if let Some(default) = p.default.as_ref() {
+            bus_param_map.insert(p.name.name.clone(), default);
+        }
+    }
+    for pa in &bi.params {
+        bus_param_map.insert(pa.name.name.clone(), &pa.value);
+    }
+
+    let count = bi
+        .count
+        .as_ref()
+        .and_then(|e| eval_const_expr_from_param_map_for_lower(e, &module_param_map));
+    let mut signals: Vec<(String, String)> = bus_effective_signals(bus_decl, &bus_param_map)
+        .into_iter()
+        .map(|(name, _dir, ty)| {
+            let subst = subst_type_expr_for_lower(&ty, &bus_param_map);
+            (name, format!("{subst:?}"))
+        })
+        .collect();
+    signals.sort();
+    TlmConnectShape { count, signals }
+}
+
+fn format_tlm_connect_shape(shape: &TlmConnectShape) -> String {
+    let count = shape
+        .count
+        .map(|n| format!("count={n}, "))
+        .unwrap_or_default();
+    let sigs = shape
+        .signals
+        .iter()
+        .map(|(name, ty)| format!("{name}:{ty}"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!("{count}signals [{sigs}]")
 }
 
 // ── Generate expansion ────────────────────────────────────────────────────────
@@ -5288,6 +5392,57 @@ fn gen_if_cond_truthy(e: &Expr, params: &HashMap<String, &Expr>) -> bool {
             .get(name)
             .map_or(false, |v| gen_if_cond_truthy(v, params)),
         _ => false,
+    }
+}
+
+fn eval_const_expr_from_param_map_for_lower(
+    expr: &Expr,
+    params: &HashMap<String, &Expr>,
+) -> Option<u64> {
+    match &expr.kind {
+        ExprKind::Literal(LitKind::Dec(n))
+        | ExprKind::Literal(LitKind::Hex(n))
+        | ExprKind::Literal(LitKind::Bin(n))
+        | ExprKind::Literal(LitKind::Sized(_, n)) => Some(*n),
+        ExprKind::Bool(b) => Some(if *b { 1 } else { 0 }),
+        ExprKind::Ident(name) => params
+            .get(name)
+            .and_then(|v| eval_const_expr_from_param_map_for_lower(v, params)),
+        ExprKind::Unary(op, expr) => {
+            let v = eval_const_expr_from_param_map_for_lower(expr, params)?;
+            match op {
+                UnaryOp::Neg => Some((0u64).wrapping_sub(v)),
+                UnaryOp::Not => Some(if v == 0 { 1 } else { 0 }),
+                UnaryOp::BitNot => Some(!v),
+                _ => None,
+            }
+        }
+        ExprKind::Binary(op, lhs, rhs) => {
+            let a = eval_const_expr_from_param_map_for_lower(lhs, params)?;
+            let b = eval_const_expr_from_param_map_for_lower(rhs, params)?;
+            match op {
+                BinOp::Add => Some(a.wrapping_add(b)),
+                BinOp::Sub => Some(a.wrapping_sub(b)),
+                BinOp::Mul => Some(a.wrapping_mul(b)),
+                BinOp::Div => (b != 0).then_some(a / b),
+                BinOp::Mod => (b != 0).then_some(a % b),
+                BinOp::Shl => Some(a.wrapping_shl(b as u32)),
+                BinOp::Shr => Some(a.wrapping_shr(b as u32)),
+                BinOp::BitAnd => Some(a & b),
+                BinOp::BitOr => Some(a | b),
+                BinOp::BitXor => Some(a ^ b),
+                BinOp::Eq => Some((a == b) as u64),
+                BinOp::Neq => Some((a != b) as u64),
+                BinOp::Lt => Some((a < b) as u64),
+                BinOp::Lte => Some((a <= b) as u64),
+                BinOp::Gt => Some((a > b) as u64),
+                BinOp::Gte => Some((a >= b) as u64),
+                BinOp::And => Some((a != 0 && b != 0) as u64),
+                BinOp::Or => Some((a != 0 || b != 0) as u64),
+                _ => None,
+            }
+        }
+        _ => None,
     }
 }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -978,15 +978,26 @@ end regfile Rf1
     let rf_path = dir.join("Rf1.arch");
     fs::write(&rf_path, regfile).unwrap();
     let b1 = std::process::Command::new(arch_bin)
-        .arg("build").arg(&rf_path).arg("-o").arg(dir.join("Rf1.sv"))
-        .output().expect("build regfile");
-    assert!(b1.status.success(), "regfile build failed: {}",
-            String::from_utf8_lossy(&b1.stderr));
-    assert!(dir.join("Rf1.archi").exists(), "Rf1.archi should have been written");
+        .arg("build")
+        .arg(&rf_path)
+        .arg("-o")
+        .arg(dir.join("Rf1.sv"))
+        .output()
+        .expect("build regfile");
+    assert!(
+        b1.status.success(),
+        "regfile build failed: {}",
+        String::from_utf8_lossy(&b1.stderr)
+    );
+    assert!(
+        dir.join("Rf1.archi").exists(),
+        "Rf1.archi should have been written"
+    );
 
     // 2) Build a combined file that DEFINES Rf1 in-source AND insts it, in the
     //    same dir as the stale Rf1.archi. The construct must emit exactly once.
-    let combined = format!("{regfile}
+    let combined = format!(
+        "{regfile}
 module Top
   port clk: in Clock<SysDomain>;
   port rst: in Reset<Sync>;
@@ -1006,15 +1017,23 @@ module Top
     d = dw;
   end comb
 end module Top
-");
+"
+    );
     let top_path = dir.join("Top.arch");
     fs::write(&top_path, combined).unwrap();
     let sv_out = dir.join("Top.sv");
     let b2 = std::process::Command::new(arch_bin)
-        .arg("build").arg(&top_path).arg("-o").arg(&sv_out)
-        .output().expect("build combined");
-    assert!(b2.status.success(), "combined build failed: {}",
-            String::from_utf8_lossy(&b2.stderr));
+        .arg("build")
+        .arg(&top_path)
+        .arg("-o")
+        .arg(&sv_out)
+        .output()
+        .expect("build combined");
+    assert!(
+        b2.status.success(),
+        "combined build failed: {}",
+        String::from_utf8_lossy(&b2.stderr)
+    );
     let sv = fs::read_to_string(&sv_out).unwrap();
     let n = sv.matches("\nmodule Rf1").count() + sv.starts_with("module Rf1") as usize;
     assert_eq!(
@@ -1221,8 +1240,14 @@ fn test_var_index_vec_bus_comb_lowering_matches_backends() {
         include_str!("backend_equiv/Fx3bVarIndexVecBusBug.arch")
     );
     let sv = compile_to_sv(source);
-    assert!(sv.contains("o_valid[sel]"), "SV must select lane `sel`:\n{sv}");
-    assert!(sv.contains("o_data[sel]"), "SV must select lane `sel`:\n{sv}");
+    assert!(
+        sv.contains("o_valid[sel]"),
+        "SV must select lane `sel`:\n{sv}"
+    );
+    assert!(
+        sv.contains("o_data[sel]"),
+        "SV must select lane `sel`:\n{sv}"
+    );
     assert!(
         !sv.contains("o[sel]"),
         "SV must not leave the un-flattened Vec<Bus> index `o[sel]`:\n{sv}"
@@ -1249,7 +1274,10 @@ fn test_var_index_vec_bus_thread_lowering_matches_backends() {
     let sv = compile_to_sv(source);
     // Per-lane flattened sub-module input ports + the runtime lane mux.
     for lane in ["o_0_ready", "o_1_ready", "o_2_ready", "o_3_ready"] {
-        assert!(sv.contains(lane), "SV thread sub-module needs port `{lane}`:\n{sv}");
+        assert!(
+            sv.contains(lane),
+            "SV thread sub-module needs port `{lane}`:\n{sv}"
+        );
     }
     assert!(
         !sv.contains("o[sel]"),
@@ -1341,8 +1369,15 @@ fn test_var_index_vec_bus_backend_equivalence_e2e() {
         let tb_abs = std::fs::canonicalize(tb).expect("tb path");
         let verilate = std::process::Command::new("verilator")
             .args([
-                "--cc", "--exe", "--build", "-Wno-WIDTH", "-Wno-UNOPTFLAT",
-                "-Wno-DECLFILENAME", "--top-module", top, "-Mdir",
+                "--cc",
+                "--exe",
+                "--build",
+                "-Wno-WIDTH",
+                "-Wno-UNOPTFLAT",
+                "-Wno-DECLFILENAME",
+                "--top-module",
+                top,
+                "-Mdir",
             ])
             .arg(&obj_dir)
             .arg(&sv_out)
@@ -1407,7 +1442,10 @@ fn test_var_index_vec_bus_wire_lowering_matches_backends() {
         end module M
     ";
     let sv = compile_to_sv(source);
-    assert!(sv.contains("w_v[sel]") && sv.contains("w_d[sel]"), "SV must slice the packed wire:\n{sv}");
+    assert!(
+        sv.contains("w_v[sel]") && sv.contains("w_d[sel]"),
+        "SV must slice the packed wire:\n{sv}"
+    );
 
     let sim = compile_to_sim_h(source, false);
     assert!(
@@ -1428,7 +1466,10 @@ fn test_var_index_vec_bus_thread_write_lowering_matches_backends() {
     let source = include_str!("backend_equiv/Fx3bVarIndexVecBusThreadWrite.arch");
     let sv = compile_to_sv(source);
     for lane in ["o_0_valid", "o_1_valid", "o_2_valid", "o_3_valid"] {
-        assert!(sv.contains(lane), "SV thread sub-module must drive lane `{lane}`:\n{sv}");
+        assert!(
+            sv.contains(lane),
+            "SV thread sub-module must drive lane `{lane}`:\n{sv}"
+        );
     }
     assert!(
         sv.contains("if (sel == 0)") && sv.contains("o_0_valid <= 1'b1"),
@@ -1499,8 +1540,15 @@ fn test_var_index_vec_bus_thread_write_backend_equivalence_e2e() {
     let tb_abs = std::fs::canonicalize("tests/backend_equiv/VselWr_vl_tb.cpp").expect("tb path");
     let verilate = std::process::Command::new("verilator")
         .args([
-            "--cc", "--exe", "--build", "-Wno-WIDTH", "-Wno-UNOPTFLAT",
-            "-Wno-DECLFILENAME", "--top-module", "VselWr", "-Mdir",
+            "--cc",
+            "--exe",
+            "--build",
+            "-Wno-WIDTH",
+            "-Wno-UNOPTFLAT",
+            "-Wno-DECLFILENAME",
+            "--top-module",
+            "VselWr",
+            "-Mdir",
         ])
         .arg(&obj_dir)
         .arg(&sv_out)
@@ -6328,12 +6376,14 @@ fn test_vec_bus_param_forward_no_stack_overflow() {
     //
     // Both shapes must now build to Verilator-clean SV (lint verified in CI
     // via the standing repro; here we assert the structural SV shape).
-    let source = include_str!(
-        "regression/issues/vec_bus_param_forward/VecBusParamForward.arch"
-    );
+    let source = include_str!("regression/issues/vec_bus_param_forward/VecBusParamForward.arch");
     let sv = compile_to_sv(source);
     // All three modules emit.
-    for m in ["module CrashSink", "module CrashWhole", "module CrashPerElem"] {
+    for m in [
+        "module CrashSink",
+        "module CrashWhole",
+        "module CrashPerElem",
+    ] {
         assert!(sv.contains(m), "expected `{m}` in SV:\n{sv}");
     }
     // Whole-vector forward packs each bus signal whole.
@@ -10270,6 +10320,44 @@ end module Top
 }
 
 #[test]
+fn test_tlm_connect_bus_shape_mismatch_diagnostic() {
+    let msg = tlm_connect_elaborate_error(
+        r#"
+bus BusRw
+  param READ: const = 1;
+  param WRITE: const = 1;
+  generate_if READ
+    ar_valid: out Bool;
+  end generate_if
+  generate_if WRITE
+    aw_valid: out Bool;
+  end generate_if
+end bus BusRw
+use BusRw;
+module Initiator
+  port m: initiator BusRw<WRITE=0>;
+end module Initiator
+module Target
+  port s: target BusRw<READ=0>;
+end module Target
+module Top
+  inst i: Initiator
+  end inst i
+  inst t: Target
+  end inst t
+  connect i.m -> t.s;
+end module Top
+"#,
+    );
+    assert!(
+        msg.contains("TLM connect bus-shape mismatch")
+            && msg.contains("ar_valid")
+            && msg.contains("aw_valid"),
+        "expected bus-shape mismatch diagnostic, got: {msg}"
+    );
+}
+
+#[test]
 fn test_tlm_connect_duplicate_explicit_connection_diagnostic() {
     let msg = tlm_connect_elaborate_error(
         r#"
@@ -10328,7 +10416,8 @@ end module Top
     );
     assert!(
         msg.contains("requires target inst `t0` to override `param SLAVE_START_ADDR = ...;`")
-            && msg.contains("requires target inst `t1` to override `param SLAVE_START_ADDR = ...;`"),
+            && msg
+                .contains("requires target inst `t1` to override `param SLAVE_START_ADDR = ...;`"),
         "expected missing-address-map-param diagnostic, got: {msg}"
     );
 }
@@ -10360,7 +10449,8 @@ end module Top
     );
     assert!(
         msg.contains("requires target inst `t_0` to override `param SLAVE_START_ADDR = ...;`")
-            && msg.contains("requires target inst `t_1` to override `param SLAVE_START_ADDR = ...;`"),
+            && msg
+                .contains("requires target inst `t_1` to override `param SLAVE_START_ADDR = ...;`"),
         "expected missing-address-map-param-after-generate diagnostic, got: {msg}"
     );
 }
@@ -17674,9 +17764,7 @@ end module Dut
 
     // Round-trip: parse the emitted `.archi` module stub back and confirm the
     // BusPortInfo.params survived (so harc / re-emit see the same override).
-    let rt_src = format!(
-        "domain SysDomain\n  freq_mhz: 100\nend domain SysDomain\n\n{body}"
-    );
+    let rt_src = format!("domain SysDomain\n  freq_mhz: 100\nend domain SysDomain\n\n{body}");
     let rt_tokens = lexer::tokenize(&rt_src).expect("re-lex emitted .archi");
     let mut rt_parser = Parser::new(rt_tokens, &rt_src);
     let rt_parsed = rt_parser
@@ -17690,11 +17778,7 @@ end module Dut
     let arch::ast::Item::Module(m) = rt_dut else {
         unreachable!()
     };
-    let s_port = m
-        .ports
-        .iter()
-        .find(|p| p.name.name == "s")
-        .expect("port s");
+    let s_port = m.ports.iter().find(|p| p.name.name == "s").expect("port s");
     let bi = s_port.bus_info.as_ref().expect("s is a bus port");
     assert!(
         bi.params.iter().any(|pa| pa.name.name == "WRITE"),
@@ -21506,11 +21590,18 @@ fn test_fifo_inst_does_not_close_comb_cycle() {
     "#;
     let wd = whole_design_from(source);
     assert_eq!(
-        wd.total_sccs, 0,
+        wd.total_sccs,
+        0,
         "FIFO inst must not manufacture a comb cycle; SCCs found: {:?}",
-        wd.sccs.iter().map(|s| &s.owning_modules).collect::<Vec<_>>()
+        wd.sccs
+            .iter()
+            .map(|s| &s.owning_modules)
+            .collect::<Vec<_>>()
     );
-    assert_eq!(wd.suppressed, 0, "no pragma present, nothing should be suppressed");
+    assert_eq!(
+        wd.suppressed, 0,
+        "no pragma present, nothing should be suppressed"
+    );
 }
 
 #[test]
@@ -21674,10 +21765,14 @@ fn test_arbiter_inst_comb_grant_loop_still_detected() {
     "#;
     let wd = whole_design_from(source);
     assert_eq!(
-        wd.total_sccs, 1,
+        wd.total_sccs,
+        1,
         "a real comb loop through an arbiter's combinational grant must be \
          detected (no under-approximation); SCCs found: {:?}",
-        wd.sccs.iter().map(|s| &s.owning_modules).collect::<Vec<_>>()
+        wd.sccs
+            .iter()
+            .map(|s| &s.owning_modules)
+            .collect::<Vec<_>>()
     );
 }
 
@@ -21714,10 +21809,14 @@ fn test_bus_ready_eq_valid_is_not_a_false_comb_cycle() {
     "#;
     let wd = whole_design_from(source);
     assert_eq!(
-        wd.total_sccs, 0,
+        wd.total_sccs,
+        0,
         "a target's `ready = f(valid)` handshake must not be a comb cycle \
          (bus members are distinct nodes); SCCs found: {:?}",
-        wd.sccs.iter().map(|s| &s.owning_modules).collect::<Vec<_>>()
+        wd.sccs
+            .iter()
+            .map(|s| &s.owning_modules)
+            .collect::<Vec<_>>()
     );
 }
 
@@ -21748,10 +21847,14 @@ fn test_real_comb_cycle_through_bus_member_still_detected() {
     "#;
     let wd = whole_design_from(source);
     assert_eq!(
-        wd.total_sccs, 1,
+        wd.total_sccs,
+        1,
         "a real comb loop through a single bus member must still be detected; \
          SCCs found: {:?}",
-        wd.sccs.iter().map(|s| &s.owning_modules).collect::<Vec<_>>()
+        wd.sccs
+            .iter()
+            .map(|s| &s.owning_modules)
+            .collect::<Vec<_>>()
     );
 }
 


### PR DESCRIPTION
## What changed

This teaches TLM `connect` lowering to compare the effective endpoint shape, not just the bus name and perspective.

The new check folds:
- module param defaults plus inst overrides
- bus param defaults plus port-level bus overrides
- `Vec<Bus, N>` count
- the effective flattened bus signal set after `generate_if`

If two endpoints expose different shapes, elaboration now fails with a targeted `TLM connect bus-shape mismatch` diagnostic instead of silently lowering a broken connection.

It also adds a regression test for a mismatched `BusRw<WRITE=0>` initiator connected to a `BusRw<READ=0>` target.

## Why

PR #570 added decoded one-to-many TLM connect support, but the one-to-one connect path still treated matching bus names as sufficient. That let us accept endpoints whose port-level overrides removed different channels.

In the failing repro, the compiler emitted two unrelated private wires:
- one for `ar_valid`
- one for `aw_valid`

That means the `connect` compiles but does not actually connect the initiator to the target.

## Impact

This turns a silent miscompile into an actionable compile-time error and keeps `connect` consistent with the already-parameterized bus flattening behavior elsewhere in the compiler.

## Validation

- `cargo test -q tlm_connect_ -- --nocapture`
- manual CLI repro now reports `TLM connect bus-shape mismatch`

## Review

Code-review pass against `git diff origin/main...HEAD` found no remaining findings after this fix.
