### PR TITLE
[codex] Support pipeline comb match codegen

### DIFF
--- a/src/codegen/pipeline.rs
+++ b/src/codegen/pipeline.rs
@@ -847,18 +847,33 @@ impl<'a> Codegen<'a> {
                 }
                 Stmt::IfElse(ie) => {
                     for t in Self::collect_comb_targets(&ie.then_stmts) {
-                        if !targets.contains(&t) { targets.push(t); }
+                        if !targets.contains(&t) {
+                            targets.push(t);
+                        }
                     }
                     for t in Self::collect_comb_targets(&ie.else_stmts) {
-                        if !targets.contains(&t) { targets.push(t); }
+                        if !targets.contains(&t) {
+                            targets.push(t);
+                        }
                     }
                 }
-                Stmt::Match(_) | Stmt::Log(_) => {}
+                Stmt::Match(m) => {
+                    for arm in &m.arms {
+                        for t in Self::collect_comb_targets(&arm.body) {
+                            if !targets.contains(&t) {
+                                targets.push(t);
+                            }
+                        }
+                    }
+                }
+                Stmt::Log(_) => {}
                 Stmt::For(f) => {
                     for s in &f.body {
                         if let Stmt::Assign(a) = s {
                             if let ExprKind::Ident(name) = &a.target.kind {
-                                if !targets.contains(name) { targets.push(name.clone()); }
+                                if !targets.contains(name) {
+                                    targets.push(name.clone());
+                                }
                             }
                         }
                     }
@@ -980,6 +995,19 @@ impl<'a> Codegen<'a> {
                         return Some(ty);
                     }
                 }
+                Stmt::Match(m) => {
+                    for arm in &m.arms {
+                        if let Some(ty) = Self::resolve_comb_wire_type(
+                            target,
+                            &arm.body,
+                            current_stage_idx,
+                            stage_regs,
+                            stage_names,
+                        ) {
+                            return Some(ty);
+                        }
+                    }
+                }
                 _ => {}
             }
         }
@@ -1012,17 +1040,77 @@ impl<'a> Codegen<'a> {
                 self.line(&format!("{} = {};", target, val));
             }
             Stmt::IfElse(ie) => {
-                self.emit_pipeline_comb_if_else(ie, current_prefix, current_stage_idx, stage_names, stage_regs, port_names, false);
+                self.emit_pipeline_comb_if_else(
+                    ie,
+                    current_prefix,
+                    current_stage_idx,
+                    stage_names,
+                    stage_regs,
+                    port_names,
+                    false,
+                );
             }
-            Stmt::Match(_) => {} // TODO if needed
+            Stmt::Match(m) => {
+                self.emit_pipeline_comb_match(
+                    m,
+                    current_prefix,
+                    current_stage_idx,
+                    stage_names,
+                    stage_regs,
+                    port_names,
+                );
+            }
             Stmt::Log(l) => { self.emit_log_stmt(l); }
             Stmt::For(f) => {
                 self.emit_for_loop_sv(f, |s, stmt| {
                     s.emit_pipeline_comb_stmt(stmt, current_prefix, current_stage_idx, stage_names, stage_regs, port_names);
                 });
             }
-                Stmt::Init(_) | Stmt::WaitUntil(..) | Stmt::DoUntil { .. } => unreachable!("seq-only Stmt variant inside comb-context walker"),
+            Stmt::Init(_) | Stmt::WaitUntil(..) | Stmt::DoUntil { .. } => {
+                unreachable!("seq-only Stmt variant inside comb-context walker")
+            }
         }
+    }
+
+    fn emit_pipeline_comb_match(
+        &mut self,
+        m: &MatchStmt,
+        current_prefix: &str,
+        current_stage_idx: usize,
+        stage_names: &[&str],
+        stage_regs: &[Vec<(String, String, String)>],
+        port_names: &std::collections::HashSet<String>,
+    ) {
+        let scrut = self.emit_pipeline_stage_expr_str(
+            &m.scrutinee,
+            current_prefix,
+            current_stage_idx,
+            stage_names,
+            stage_regs,
+            port_names,
+        );
+        let u = if m.unique { "unique " } else { "" };
+        self.line(&format!("{}case ({})", u, scrut));
+        self.indent += 1;
+        for arm in &m.arms {
+            let pat = self.emit_pattern(&arm.pattern);
+            self.line(&format!("{}: begin", pat));
+            self.indent += 1;
+            for s in &arm.body {
+                self.emit_pipeline_comb_stmt(
+                    s,
+                    current_prefix,
+                    current_stage_idx,
+                    stage_names,
+                    stage_regs,
+                    port_names,
+                );
+            }
+            self.indent -= 1;
+            self.line("end");
+        }
+        self.indent -= 1;
+        self.line("endcase");
     }
 
     fn emit_pipeline_reg_if_else(

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -5692,11 +5692,7 @@ impl<'a> TypeChecker<'a> {
         for stage in &p.stages {
             for item in &stage.body {
                 if let ModuleBodyItem::CombBlock(cb) = item {
-                    for stmt in &cb.stmts {
-                        if let Stmt::Assign(a) = stmt {
-                            if let ExprKind::Ident(name) = &a.target.kind { driven.insert(name.clone()); }
-                        }
-                    }
+                    Self::collect_comb_stmt_targets(&cb.stmts, &mut driven);
                 }
                 if let ModuleBodyItem::Inst(inst) = item {
                     for conn in &inst.connections {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -2962,6 +2962,44 @@ end pipeline SextPipe
 }
 
 #[test]
+fn test_pipeline_comb_match_emits_case() {
+    let source = r#"
+domain D
+  freq_mhz: 100
+end domain D
+pipeline MatchPipe
+  port clk: in Clock<D>;
+  port rst: in Reset<Sync>;
+  port sel: in UInt<2>;
+  port y: out UInt<8>;
+  stage S
+    reg sel_r: UInt<2> reset rst => 0;
+    seq on clk rising
+      sel_r <= sel;
+    end seq
+    comb
+      match sel_r
+        2'd0 => y = 8'h11;
+        2'd1 => y = 8'h22;
+        _ => y = 8'h33;
+      end match
+    end comb
+  end stage S
+end pipeline MatchPipe
+"#;
+    let sv = compile_to_sv(source);
+    assert!(
+        sv.contains("case (s_sel_r)")
+            && sv.contains("2'd0: begin")
+            && sv.contains("y = 8'd17;")
+            && sv.contains("default: begin")
+            && sv.contains("y = 8'd51;")
+            && sv.contains("endcase"),
+        "pipeline comb match should emit a stage-aware case statement:\n{sv}"
+    );
+}
+
+#[test]
 fn test_pipeline_rejects_comb_input_to_output_passthrough() {
     // `y = a` drives an output straight from an input — direct comb passthrough.
     let source = r#"


### PR DESCRIPTION
## Summary
- emit pipeline combinational `match` statements as stage-aware SystemVerilog `case` blocks
- recurse through match arms when collecting pipeline comb targets and resolving comb wire types
- use the recursive comb target collector for pipeline output-drive validation
- add a regression covering match-based output assignment in a pipeline stage

## Root Cause
Pipeline combinational statement emission explicitly skipped `Stmt::Match`, so valid ARCH pipeline comb match blocks were silently dropped during SV generation. The output-drive checker also only scanned top-level assignments, which rejected outputs driven solely inside match arms.

## Validation
- `git diff --check`
- `cargo check`
- `cargo test test_pipeline_comb_match_emits_case -- --nocapture`
- `cargo test test_pipeline -- --nocapture`