### PR TITLE
[codex] Reject unsupported thread-sim comb shapes

### DIFF
--- a/src/sim_codegen/thread_sim.rs
+++ b/src/sim_codegen/thread_sim.rs
@@ -351,7 +351,7 @@ pub fn gen_module_thread_with_warnings(
             for (si, seg) in info.main_segs.iter().enumerate() {
                 header.push_str(&format!("      case {si}: {{\n"));
                 for cs in &seg.hold_comb {
-                    emit_comb_stmt(cs, &mut header, 8);
+                    emit_comb_stmt(cs, &mut header, 8)?;
                 }
                 header.push_str("        break;\n");
                 header.push_str("      }\n");
@@ -371,7 +371,7 @@ pub fn gen_module_thread_with_warnings(
             for (si, seg) in br.segs.iter().enumerate() {
                 header.push_str(&format!("        case {si}: {{\n"));
                 for cs in &seg.hold_comb {
-                    emit_comb_stmt(cs, &mut header, 10);
+                    emit_comb_stmt(cs, &mut header, 10)?;
                 }
                 header.push_str("          break;\n");
                 header.push_str("        }\n");
@@ -393,7 +393,7 @@ pub fn gen_module_thread_with_warnings(
     for item in &m.body {
         if let ModuleBodyItem::CombBlock(cb) = item {
             for cs in &cb.stmts {
-                emit_comb_stmt(cs, &mut header, 4);
+                emit_comb_stmt(cs, &mut header, 4)?;
             }
         }
     }
@@ -1292,26 +1292,32 @@ fn emit_seq_stmt(s: &crate::ast::Stmt, out: &mut String, indent: usize) -> Resul
     Ok(())
 }
 
-fn emit_comb_stmt(cs: &Stmt, out: &mut String, indent: usize) {
+fn emit_comb_stmt(cs: &Stmt, out: &mut String, indent: usize) -> Result<(), String> {
     let pad = " ".repeat(indent);
     match cs {
         Stmt::Assign(a) => {
-            let lhs = expr_to_cpp(&a.target).unwrap_or_else(|e| format!("/* err: {e} */"));
-            let rhs = expr_to_cpp(&a.value).unwrap_or_else(|e| format!("/* err: {e} */"));
+            let lhs = expr_to_cpp(&a.target)?;
+            let rhs = expr_to_cpp(&a.value)?;
             out.push_str(&format!("{pad}{lhs} = {rhs};\n"));
         }
         Stmt::IfElse(ie) => {
-            let cond = expr_to_cpp_bool(&ie.cond).unwrap_or_else(|e| format!("/* err: {e} */"));
+            let cond = expr_to_cpp_bool(&ie.cond)?;
             out.push_str(&format!("{pad}if ({cond}) {{\n"));
-            for s in &ie.then_stmts { emit_comb_stmt(s, out, indent + 2); }
+            for s in &ie.then_stmts { emit_comb_stmt(s, out, indent + 2)?; }
             if !ie.else_stmts.is_empty() {
                 out.push_str(&format!("{pad}}} else {{\n"));
-                for s in &ie.else_stmts { emit_comb_stmt(s, out, indent + 2); }
+                for s in &ie.else_stmts { emit_comb_stmt(s, out, indent + 2)?; }
             }
             out.push_str(&format!("{pad}}}\n"));
         }
-        _ => out.push_str(&format!("{pad}/* unsupported Stmt */\n")),
+        other => {
+            return Err(format!(
+                "comb stmt kind not yet supported by thread sim: {:?}",
+                std::mem::discriminant(other)
+            ));
+        }
     }
+    Ok(())
 }
 
 fn emit_seq_if(ie: &IfElseOf<ThreadStmt>, out: &mut String, indent: usize) -> Result<(), String> {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -5166,6 +5166,10 @@ fn compile_to_sim_h(source: &str, inputs_start_uninit: bool) -> String {
 }
 
 fn compile_to_thread_sim_h(source: &str) -> String {
+    compile_to_thread_sim_result(source).expect("thread sim codegen")
+}
+
+fn compile_to_thread_sim_result(source: &str) -> Result<String, String> {
     let tokens = arch::lexer::tokenize(source).expect("lexer error");
     let mut parser = arch::parser::Parser::new(tokens, source);
     let parsed_ast = parser.parse_source_file().expect("parse error");
@@ -5178,7 +5182,8 @@ fn compile_to_thread_sim_h(source: &str) -> String {
     let checker = arch::typecheck::TypeChecker::new(&symbols, &ast);
     checker.check().expect("type check error");
 
-    ast.items
+    let models = ast
+        .items
         .iter()
         .filter_map(|item| match item {
             arch::ast::Item::Module(m)
@@ -5186,16 +5191,19 @@ fn compile_to_thread_sim_h(source: &str) -> String {
                     .iter()
                     .any(|i| matches!(i, arch::ast::ModuleBodyItem::Thread(_))) =>
             {
-                Some(
-                    arch::sim_codegen::thread_sim::gen_module_thread(m, false, false, 1)
-                        .expect("thread sim codegen"),
-                )
+                Some(arch::sim_codegen::thread_sim::gen_module_thread(
+                    m, false, false, 1,
+                ))
             }
             _ => None,
         })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    Ok(models
+        .iter()
         .map(|m| format!("{}\n// ---\n{}", m.header, m.impl_))
         .collect::<Vec<_>>()
-        .join("\n// ---\n")
+        .join("\n// ---\n"))
 }
 
 /// Mirror of `compile_to_thread_sim_h` that also collects the warnings
@@ -17324,6 +17332,31 @@ fn test_thread_sim_rejects_wide_arithmetic_until_codegen_supports_it() {
         err.contains("currently supports wide (>64-bit) values only as direct copies")
             && err.contains("assignment value"),
         "expected a direct-copy-only diagnostic for unsupported wide arithmetic:\n{err}"
+    );
+}
+
+#[test]
+fn test_thread_sim_rejects_unsupported_comb_expr_before_cpp_codegen() {
+    let source = r#"
+        module M
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync, High>;
+          port hi: in UInt<8>;
+          port lo: in UInt<8>;
+          port out: out UInt<16>;
+
+          thread on clk rising, rst high
+            out = {hi, lo};
+            wait 1 cycle;
+          end thread
+        end module M
+    "#;
+
+    let err = compile_to_thread_sim_result(source)
+        .expect_err("unsupported thread-sim expression should be a codegen error");
+    assert!(
+        err.contains("expr shape not supported"),
+        "expected unsupported expression diagnostic, got: {err}"
     );
 }
 


### PR DESCRIPTION
## Summary

- Reject unsupported thread-sim comb statement/expression shapes during codegen instead of emitting comment fragments into generated C++.
- Add a regression test for an unsupported concat expression in a thread comb assignment.
- Keep existing thread-sim helper coverage able to assert generator errors directly.

## Why

The 1024-bit thread-sim storage support is already on `main`. This PR closes the remaining diagnostic gap: unsupported shapes should fail as compiler/codegen diagnostics before C++ compilation, not leak as `/* err */` or `/* unsupported Stmt */` comments in generated output.

## Validation

- `cargo check`
- `cargo test test_thread_sim -- --nocapture`
- `git diff --check`
- `scripts/pre_pr_review.sh check`
