### PR TITLE
[codex] Document nested lock restriction

### DIFF
--- a/doc/thread_spec_section.md
+++ b/doc/thread_spec_section.md
@@ -290,8 +290,8 @@ end
 ### 20.8.5  Rules
 
 - **Exclusive drive**: signals driven inside a `lock` block must not be driven outside any `lock` on the same resource.  The compiler enforces this — these signals have no defined driver when no thread holds the lock (the mux defaults to zero or the last granted value, configurable).
-- **Multiple resources**: a thread may lock different resources in sequence or hold multiple locks simultaneously (nested `lock` blocks on different resources).
-- **Deadlock warning**: if two threads lock resources A and B in opposite order, the compiler emits a warning.  The compiler performs static lock-order analysis across all threads in the module.
+- **Multiple resources**: a thread may lock different resources in sequence, but nested `lock` blocks are a compile error.  The compiler currently does not support holding multiple resource locks simultaneously.
+- **Nested locks**: any `lock` block inside another `lock` block is rejected at elaboration time.  This keeps the implemented mutual-exclusion invariant simple and avoids deadlock-prone lock-order interactions.
 - **No lock in `comb`/`seq`**: `lock` is only valid inside `thread` blocks.
 
 ## 20.9  Interaction with Other Blocks


### PR DESCRIPTION
## Summary

- Update `doc/thread_spec_section.md` to state that nested `lock` blocks are a compile error.
- Clarify that multiple resources may be locked sequentially, but simultaneous nested resource locks are not currently supported.

## Why

This aligns the thread spec section with implemented compiler behavior. `lower_threads` rejects lock bodies containing another lock with `nested lock blocks are not supported ... use sequential lock blocks instead`, and the ARCH specification/reference card already document nested locks as compile errors.

## Validation

- `cargo test test_do_until_rejects_nested_lock -- --nocapture`
- temporary CLI fixture: `cargo run -- build NestedLock.arch` rejected nested `lock a`/`lock b` with the expected diagnostic
- `git diff --check`
- `scripts/pre_pr_review.sh check`
