### PR TITLE
fix(linklist): reject `op length` at typecheck instead of panicking codegen

### DIFF
--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -6013,10 +6013,15 @@ impl<'a> TypeChecker<'a> {
                 ));
             }
 
-            // Known op names
+            // Known op names. NOTE: `length` is intentionally NOT an op — it is a
+            // status port (`port length: out ...`) maintained by `track length:`.
+            // It was previously listed here, which let `op length` type-check and
+            // then hit the `unreachable!` in codegen (src/codegen/linklist.rs), since
+            // there is no codegen arm for it. Keep this list in lockstep with the
+            // dispatch arms in emit_ll_op_controller.
             let known_ops = [
                 "alloc", "free", "insert_head", "insert_tail", "insert_after",
-                "delete_head", "delete", "read_data", "write_data", "next", "prev", "length",
+                "delete_head", "delete", "read_data", "write_data", "next", "prev",
             ];
             if !known_ops.contains(&op.name.name.as_str()) {
                 self.errors.push(CompileError::general(

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -4600,6 +4600,48 @@ end linklist BadList
 }
 
 #[test]
+fn test_linklist_op_length_is_type_error_not_codegen_panic() {
+    // `length` is a status port (`port length: out ...` maintained by
+    // `track length:`), never an op. It was mistakenly listed in the
+    // typechecker's known-ops allow-list, so `op length` type-checked and then
+    // panicked at codegen via the `unreachable!` in emit_ll_op_controller
+    // (which has no `length` dispatch arm). It must be rejected at typecheck.
+    let source = r#"
+linklist LenList
+  param DEPTH: const = 16;
+  param DATA: type = UInt<32>;
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  kind singly;
+  op length
+    latency: 1;
+    port req_valid:  in Bool;
+    port req_ready:  out Bool;
+    port resp_valid: out Bool;
+    port resp_data:  out UInt<8>;
+  end op length
+end linklist LenList
+"#;
+    let tokens = lexer::tokenize(source).expect("lexer error");
+    let mut parser = Parser::new(tokens, source);
+    let parsed = parser.parse_source_file().expect("parse error");
+    let ast = elaborate::elaborate(parsed).expect("elaborate error");
+    let symbols = resolve::resolve(&ast).expect("resolve error");
+    let checker = TypeChecker::new(&symbols, &ast);
+    let result = checker.check();
+    assert!(result.is_err(), "expected type error for `op length`");
+    let errs = result.unwrap_err();
+    assert!(
+        errs.iter().any(|e| {
+            let s = e.to_string();
+            s.contains("linklist `LenList`: unknown op `length`; known ops:")
+        }),
+        "expected unknown-op diagnostic for `length`, got: {:?}",
+        errs
+    );
+}
+
+#[test]
 fn test_linklist_inst_in_module() {
     // PacketQueue wraps TaskQueue linklist as a push/pop FIFO interface.
     // Verifies that: linklist can be instantiated inside a module,


### PR DESCRIPTION
## Summary

`op length` type-checked but then **panicked the compiler at codegen** with an internal-error backtrace.

```
$ arch build LenList.arch   # linklist with `op length ...`
thread 'main' panicked at src/codegen/linklist.rs:657:17:
internal error: entered unreachable code: unsupported linklist op `length` should have been rejected by typecheck
```

## Root cause

`length` is a **status port** (`port length: out ...`, maintained by the `track length:` directive) — it is not an op. But the typechecker's linklist `known_ops` allow-list (`src/typecheck.rs`) listed `"length"` alongside the real ops, so `op length` passed `arch check`. Codegen's `emit_ll_op_controller` (`src/codegen/linklist.rs`) has no `length` dispatch arm, so the op fell through to the `other => unreachable!(...)` that #580../#576 introduced — which assumes typecheck has already rejected anything codegen can't lower.

The `known_ops` list had 12 entries; the codegen dispatch has 11 arms. The single extra entry (`length`) was the gap.

## Fix

Remove `"length"` from `known_ops`, restoring the typecheck↔codegen lockstep invariant that #576's `unreachable!` relies on. `op length` now produces the intended clean diagnostic:

```
Error:   × linklist `LenList`: unknown op `length`; known ops: alloc, free,
  │ insert_head, insert_tail, insert_after, delete_head, delete, read_data,
  │ write_data, next, prev
```

This is an **internal error-handling fix** — no user-facing syntax or semantics change. `op length` was never documented or supported (the spec uses `length` only as a status port and via `track length:`).

## Tests

- New regression `test_linklist_op_length_is_type_error_not_codegen_panic` pinning the diagnostic.
- `cargo test --release --test integration_test`: **645 passed, 0 failed**.
- Manual: `arch build` on the repro now emits the diagnostic and exits cleanly (no panic).

Found during the daily merged-PR review (follow-up to #576).