### PR TITLE
[codex] Clean up pipeline wait-stage sim fallback

### DIFF
--- a/src/sim_codegen/mod.rs
+++ b/src/sim_codegen/mod.rs
@@ -3786,8 +3786,9 @@ fn emit_stmt(stmt: &Stmt, ctx: &Ctx, out: &mut String, indent: usize, k: SimAssi
             if !is_seq {
                 unreachable!("Stmt::WaitUntil/DoUntil reached emit_stmt(Comb) — typecheck bug");
             }
-            // Seq path: pipeline-stage wait/do-until isn't yet sim-supported.
-            panic!("pipeline wait-stages not yet supported in sim");
+            // Pipeline wait-stage seq blocks are emitted by `gen_pipeline`;
+            // the generic module stmt walker should never lower them.
+            unreachable!("Stmt::WaitUntil/DoUntil reached generic sim stmt emitter");
         }
     }
 }


### PR DESCRIPTION
## Summary
- replace the stale generic sim panic that said pipeline wait-stages are unsupported
- clarify that pipeline wait-stage seq blocks are handled by `gen_pipeline`, and reaching the generic stmt emitter is an internal unreachable case

## Why
Pipeline wait/do-until simulation is now supported through the pipeline-specific sim emitter. The generic fallback message was stale and misleading.

## Validation
- `git diff --check`
- `cargo test test_pipeline_wait_until_do_until_runs_in_sim --test integration_test -- --nocapture`
- `cargo check`