### PR TITLE
[codex] Implement true dual RAM native sim

### DIFF
--- a/src/codegen/ram.rs
+++ b/src/codegen/ram.rs
@@ -396,39 +396,75 @@ impl<'a> Codegen<'a> {
 
         let rdata_a_r = format!("{pfx_a}_{rdata_a}_r");
         let rdata_b_r = format!("{pfx_b}_{rdata_b}_r");
-        self.line(&format!("logic [DATA_WIDTH-1:0] {rdata_a_r};"));
-        self.line(&format!("logic [DATA_WIDTH-1:0] {rdata_b_r};"));
-        self.line("");
-        self.line(&format!("always_ff @(posedge {clk}) begin"));
-        self.indent += 1;
-        self.line(&format!("if ({pfx_a}_en) begin"));
-        self.indent += 1;
-        self.line(&format!("if ({pfx_a}_wen)"));
-        self.indent += 1;
-        self.line(&format!("mem[{pfx_a}_addr] <= {pfx_a}_wdata;"));
-        self.indent -= 1;
-        self.line("else");
-        self.indent += 1;
-        self.line(&format!("{rdata_a_r} <= mem[{pfx_a}_addr];"));
-        self.indent -= 1;
-        self.indent -= 1;
-        self.line("end");
-        self.line(&format!("if ({pfx_b}_en) begin"));
-        self.indent += 1;
-        self.line(&format!("if ({pfx_b}_wen)"));
-        self.indent += 1;
-        self.line(&format!("mem[{pfx_b}_addr] <= {pfx_b}_wdata;"));
-        self.indent -= 1;
-        self.line("else");
-        self.indent += 1;
-        self.line(&format!("{rdata_b_r} <= mem[{pfx_b}_addr];"));
-        self.indent -= 1;
-        self.indent -= 1;
-        self.line("end");
-        self.indent -= 1;
-        self.line("end");
-        self.line(&format!("assign {pfx_a}_{rdata_a} = {rdata_a_r};"));
-        self.line(&format!("assign {pfx_b}_{rdata_b} = {rdata_b_r};"));
+        match r.latency {
+            0 => {
+                self.line(&format!("always_ff @(posedge {clk}) begin"));
+                self.indent += 1;
+                self.line(&format!("if ({pfx_a}_en && {pfx_a}_wen)"));
+                self.indent += 1;
+                self.line(&format!("mem[{pfx_a}_addr] <= {pfx_a}_wdata;"));
+                self.indent -= 1;
+                self.line(&format!("if ({pfx_b}_en && {pfx_b}_wen)"));
+                self.indent += 1;
+                self.line(&format!("mem[{pfx_b}_addr] <= {pfx_b}_wdata;"));
+                self.indent -= 1;
+                self.indent -= 1;
+                self.line("end");
+                self.line(&format!("assign {pfx_a}_{rdata_a} = mem[{pfx_a}_addr];"));
+                self.line(&format!("assign {pfx_b}_{rdata_b} = mem[{pfx_b}_addr];"));
+            }
+            1 | 2 => {
+                self.line(&format!("logic [DATA_WIDTH-1:0] {rdata_a_r};"));
+                self.line(&format!("logic [DATA_WIDTH-1:0] {rdata_b_r};"));
+                self.line("");
+                self.line(&format!("always_ff @(posedge {clk}) begin"));
+                self.indent += 1;
+                self.line(&format!("if ({pfx_a}_en) begin"));
+                self.indent += 1;
+                self.line(&format!("if ({pfx_a}_wen)"));
+                self.indent += 1;
+                self.line(&format!("mem[{pfx_a}_addr] <= {pfx_a}_wdata;"));
+                self.indent -= 1;
+                self.line("else");
+                self.indent += 1;
+                self.line(&format!("{rdata_a_r} <= mem[{pfx_a}_addr];"));
+                self.indent -= 1;
+                self.indent -= 1;
+                self.line("end");
+                self.line(&format!("if ({pfx_b}_en) begin"));
+                self.indent += 1;
+                self.line(&format!("if ({pfx_b}_wen)"));
+                self.indent += 1;
+                self.line(&format!("mem[{pfx_b}_addr] <= {pfx_b}_wdata;"));
+                self.indent -= 1;
+                self.line("else");
+                self.indent += 1;
+                self.line(&format!("{rdata_b_r} <= mem[{pfx_b}_addr];"));
+                self.indent -= 1;
+                self.indent -= 1;
+                self.line("end");
+                self.indent -= 1;
+                self.line("end");
+                if r.latency == 2 {
+                    let rdata_a_r2 = format!("{pfx_a}_{rdata_a}_r2");
+                    let rdata_b_r2 = format!("{pfx_b}_{rdata_b}_r2");
+                    self.line(&format!("logic [DATA_WIDTH-1:0] {rdata_a_r2};"));
+                    self.line(&format!("logic [DATA_WIDTH-1:0] {rdata_b_r2};"));
+                    self.line(&format!("always_ff @(posedge {clk}) begin"));
+                    self.indent += 1;
+                    self.line(&format!("{rdata_a_r2} <= {rdata_a_r};"));
+                    self.line(&format!("{rdata_b_r2} <= {rdata_b_r};"));
+                    self.indent -= 1;
+                    self.line("end");
+                    self.line(&format!("assign {pfx_a}_{rdata_a} = {rdata_a_r2};"));
+                    self.line(&format!("assign {pfx_b}_{rdata_b} = {rdata_b_r2};"));
+                } else {
+                    self.line(&format!("assign {pfx_a}_{rdata_a} = {rdata_a_r};"));
+                    self.line(&format!("assign {pfx_b}_{rdata_b} = {rdata_b_r};"));
+                }
+            }
+            _ => {}
+        }
     }
 
     fn emit_ram_rom(&mut self, r: &RamDecl, clk: &str) {

--- a/src/sim_codegen/ram.rs
+++ b/src/sim_codegen/ram.rs
@@ -159,6 +159,19 @@ impl<'a> SimCodegen<'a> {
                 h.push_str(&format!("    memset(&{}, 0, sizeof({}));\n", fs.full_name, fs.full_name));
             }
         }
+        for fs in &out_sigs {
+            if is_wide {
+                h.push_str(&format!("    memset(&_r_{}, 0, sizeof(_r_{}));\n", fs.full_name, fs.full_name));
+                if r.latency == 2 {
+                    h.push_str(&format!("    memset(&_r2_{}, 0, sizeof(_r2_{}));\n", fs.full_name, fs.full_name));
+                }
+            } else {
+                h.push_str(&format!("    _r_{} = 0;\n", fs.full_name));
+                if r.latency == 2 {
+                    h.push_str(&format!("    _r2_{} = 0;\n", fs.full_name));
+                }
+            }
+        }
         h.push_str("  }\n");
         h.push_str(&format!("  explicit {class}(VerilatedContext*) : {class}() {{}}\n"));
         h.push_str("  void eval();\n  void eval_posedge();\n  void eval_comb();\n  void final() { trace_close(); }\n");
@@ -183,6 +196,9 @@ impl<'a> SimCodegen<'a> {
         // Read check uses a static guard so each RAM warns at most once per run.
         let write_mark = |addr: &str| -> String {
             if uninit_ram_check { format!("    _mem_valid[{addr}] = true;\n") } else { String::new() }
+        };
+        let write_mark_indented = |addr: &str, indent: &str| -> String {
+            if uninit_ram_check { format!("{indent}_mem_valid[{addr}] = true;\n") } else { String::new() }
         };
         let read_check = |addr: &str, indent: &str| -> String {
             if !uninit_ram_check { return String::new(); }
@@ -287,7 +303,65 @@ impl<'a> SimCodegen<'a> {
                 }
             }
             RamKind::TrueDual => {
-                cpp.push_str("  // TrueDual: not yet implemented\n");
+                for pg in &r.port_groups {
+                    let pfx = &pg.name.name;
+                    let has_wen = pg.signals.iter().any(|s| s.name.name == "wen");
+                    let wdata_name = pg.signals.iter()
+                        .find(|s| s.direction == Direction::In && (s.name.name == "wdata" || s.name.name == "data"))
+                        .map(|s| format!("{pfx}_{}", s.name.name))
+                        .unwrap_or_else(|| format!("{pfx}_wdata"));
+                    let out_name = pg.signals.iter()
+                        .find(|s| s.direction == Direction::Out)
+                        .map(|s| format!("{pfx}_{}", s.name.name));
+                    let addr = format!("{pfx}_addr");
+
+                    cpp.push_str(&format!("  if ({pfx}_en) {{\n"));
+                    if has_wen {
+                        cpp.push_str(&format!("    if ({pfx}_wen) {{\n"));
+                        if is_wide {
+                            cpp.push_str(&format!("      memcpy(&_mem[{pfx}_addr], &{wdata_name}, sizeof({elem_ty}));\n"));
+                        } else {
+                            cpp.push_str(&format!("      _mem[{pfx}_addr] = {wdata_name};\n"));
+                        }
+                        cpp.push_str(&write_mark_indented(&addr, "      "));
+                        cpp.push_str("    }");
+                        if matches!(r.latency, 1 | 2) {
+                            if let Some(out_name) = &out_name {
+                                cpp.push_str(" else {\n");
+                                cpp.push_str(&read_check(&addr, "      "));
+                                if is_wide {
+                                    cpp.push_str(&format!("      memcpy(&_r_{out_name}, &_mem[{pfx}_addr], sizeof({elem_ty}));\n"));
+                                } else {
+                                    cpp.push_str(&format!("      _r_{out_name} = _mem[{pfx}_addr];\n"));
+                                }
+                                cpp.push_str("    }\n");
+                            } else {
+                                cpp.push('\n');
+                            }
+                        } else {
+                            cpp.push('\n');
+                        }
+                    } else if matches!(r.latency, 1 | 2) {
+                        if let Some(out_name) = &out_name {
+                            cpp.push_str(&read_check(&addr, "    "));
+                            if is_wide {
+                                cpp.push_str(&format!("    memcpy(&_r_{out_name}, &_mem[{pfx}_addr], sizeof({elem_ty}));\n"));
+                            } else {
+                                cpp.push_str(&format!("    _r_{out_name} = _mem[{pfx}_addr];\n"));
+                            }
+                        }
+                    }
+                    cpp.push_str("  }\n");
+                }
+                if r.latency == 2 {
+                    for fs in &out_sigs {
+                        if is_wide {
+                            cpp.push_str(&format!("  memcpy(&_r2_{}, &_r_{}, sizeof({elem_ty}));\n", fs.full_name, fs.full_name));
+                        } else {
+                            cpp.push_str(&format!("  _r2_{} = _r_{};\n", fs.full_name, fs.full_name));
+                        }
+                    }
+                }
             }
             RamKind::Rom => {
                 // ROM: read-only, no writes in posedge
@@ -315,7 +389,10 @@ impl<'a> SimCodegen<'a> {
             match r.latency {
                 0 => {
                     let rpfx = r.port_groups.iter()
-                        .find(|pg| pg.signals.iter().any(|s| s.direction == Direction::Out))
+                        .find(|pg| pg.signals.iter().any(|s| {
+                            s.direction == Direction::Out
+                                && format!("{}_{}", pg.name.name, s.name.name) == fs.full_name
+                        }))
                         .map(|pg| pg.name.name.as_str())
                         .unwrap_or("access");
                     let rd_addr = format!("{rpfx}_addr");

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -708,6 +708,190 @@ fn test_simple_dual_ram() {
     insta::assert_snapshot!(sv);
 }
 
+#[test]
+fn test_true_dual_ram_runs_in_native_sim() {
+    let td = tempfile::tempdir().expect("tempdir");
+    let arch_path = td.path().join("TrueDualMem.arch");
+    let tb_path = td.path().join("tb_true_dual.cpp");
+    std::fs::write(
+        &arch_path,
+        r#"
+//! ---
+//! tags: [ram, true_dual, native_sim]
+//! ---
+//!
+//! Regression fixture for true-dual RAM native C++ simulation.
+
+/// 16x8 true-dual RAM with independent read/write ports.
+ram TrueDualMem
+  kind true_dual;
+  latency 1;
+  init: zero;
+  param DEPTH: const = 16;
+  param T: type = UInt<8>;
+  port clk: in Clock<SysDomain>;
+  store
+    data: Vec<T, DEPTH>;
+  end store
+  ports a
+    en: in Bool;
+    wen: in Bool;
+    addr: in UInt<4>;
+    wdata: in T;
+    rdata: out T;
+  end ports a
+  ports b
+    en: in Bool;
+    wen: in Bool;
+    addr: in UInt<4>;
+    wdata: in T;
+    rdata: out T;
+  end ports b
+end ram TrueDualMem
+"#,
+    )
+    .expect("write arch");
+    std::fs::write(
+        &tb_path,
+        r#"
+#include "VTrueDualMem.h"
+#include <cstdio>
+
+static void tick(VTrueDualMem& dut) {
+  dut.clk = 0;
+  dut.eval();
+  dut.clk = 1;
+  dut.eval();
+  dut.clk = 0;
+  dut.eval();
+}
+
+int main() {
+  VTrueDualMem dut;
+
+  dut.a_en = 1;
+  dut.a_wen = 1;
+  dut.a_addr = 3;
+  dut.a_wdata = 0x2a;
+  dut.b_en = 1;
+  dut.b_wen = 1;
+  dut.b_addr = 5;
+  dut.b_wdata = 0x55;
+  tick(dut);
+
+  dut.a_wen = 0;
+  dut.a_addr = 3;
+  dut.b_wen = 0;
+  dut.b_addr = 5;
+  tick(dut);
+  if (dut.a_rdata != 0x2a || dut.b_rdata != 0x55) {
+    std::printf("FAIL first read a=%u b=%u\n",
+                (unsigned)dut.a_rdata, (unsigned)dut.b_rdata);
+    return 1;
+  }
+
+  dut.a_en = 1;
+  dut.a_wen = 1;
+  dut.a_addr = 7;
+  dut.a_wdata = 0xc3;
+  dut.b_en = 1;
+  dut.b_wen = 0;
+  dut.b_addr = 3;
+  tick(dut);
+  if (dut.b_rdata != 0x2a) {
+    std::printf("FAIL read while other port writes b=%u\n",
+                (unsigned)dut.b_rdata);
+    return 1;
+  }
+
+  dut.a_wen = 0;
+  dut.a_addr = 7;
+  dut.b_en = 0;
+  tick(dut);
+  if (dut.a_rdata != 0xc3) {
+    std::printf("FAIL read back port-a write a=%u\n",
+                (unsigned)dut.a_rdata);
+    return 1;
+  }
+
+  std::printf("PASS true_dual_ram_native_sim\n");
+  return 0;
+}
+"#,
+    )
+    .expect("write tb");
+
+    let out = std::process::Command::new(env!("CARGO_BIN_EXE_arch"))
+        .arg("sim")
+        .arg(&arch_path)
+        .arg("--tb")
+        .arg(&tb_path)
+        .arg("--outdir")
+        .arg(td.path().join("build"))
+        .output()
+        .expect("run arch sim");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success() && stdout.contains("PASS true_dual_ram_native_sim"),
+        "true-dual RAM native sim should compile and run\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+}
+
+#[test]
+fn test_true_dual_ram_sv_honors_latency() {
+    let source = |latency: u32| {
+        format!(
+            r#"
+ram TrueDualLat{latency}
+  kind true_dual;
+  latency {latency};
+  param DEPTH: const = 16;
+  param T: type = UInt<8>;
+  port clk: in Clock<SysDomain>;
+  store
+    data: Vec<T, DEPTH>;
+  end store
+  ports a
+    en: in Bool;
+    wen: in Bool;
+    addr: in UInt<4>;
+    wdata: in T;
+    rdata: out T;
+  end ports a
+  ports b
+    en: in Bool;
+    wen: in Bool;
+    addr: in UInt<4>;
+    wdata: in T;
+    rdata: out T;
+  end ports b
+end ram TrueDualLat{latency}
+"#
+        )
+    };
+
+    let sv0 = compile_to_sv(&source(0));
+    assert!(
+        sv0.contains("assign a_rdata = mem[a_addr];")
+            && sv0.contains("assign b_rdata = mem[b_addr];"),
+        "latency-0 true-dual RAM should emit async read assigns:\n{sv0}"
+    );
+    assert!(
+        !sv0.contains("a_rdata_r"),
+        "latency-0 true-dual RAM should not emit read pipeline regs:\n{sv0}"
+    );
+
+    let sv2 = compile_to_sv(&source(2));
+    assert!(
+        sv2.contains("logic [DATA_WIDTH-1:0] a_rdata_r2;")
+            && sv2.contains("logic [DATA_WIDTH-1:0] b_rdata_r2;")
+            && sv2.contains("assign a_rdata = a_rdata_r2;")
+            && sv2.contains("assign b_rdata = b_rdata_r2;"),
+        "latency-2 true-dual RAM should emit output pipeline regs:\n{sv2}"
+    );
+}
+
 // ── Counter ───────────────────────────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary

Implements native C++ simulation support for `ram kind true_dual` and aligns true-dual SV codegen with the declared RAM latency.

- Replaces the true-dual native sim placeholder with per-port read/write lowering.
- Initializes private RAM read pipeline latches deterministically in generated C++ models.
- Updates true-dual SV codegen to honor latency 0, 1, and 2.
- Adds an end-to-end `arch sim` regression for true-dual RAM and a codegen regression for true-dual latency 0/2.

## Root Cause

`ram kind true_dual` was documented as supported, but native sim emitted only a `// TrueDual: not yet implemented` placeholder in `eval_posedge()`, so true-dual RAM models compiled without actually updating memory or read outputs.

## Validation

- `cargo test test_true_dual_ram_runs_in_native_sim --test integration_test`
- `cargo test test_true_dual_ram_sv_honors_latency --test integration_test`
- `cargo test ram --test integration_test`
- `git diff --check`
- Pre-PR review pass: no findings
