### PR TITLE
[codex] Support waited if branches in thread sim

### DIFF
--- a/src/sim_codegen/thread_sim.rs
+++ b/src/sim_codegen/thread_sim.rs
@@ -77,6 +77,14 @@ enum WaitKind {
     /// all of them to reach `Done`. Branch indices are into
     /// ThreadInfo.branches.
     ForkJoin(Vec<usize>),
+    /// Source-level if/else whose branches contain waits. Launches
+    /// exactly one branch coroutine based on the condition, then rejoins
+    /// when that selected branch completes.
+    IfElseJoin {
+        cond: Expr,
+        then_branch: usize,
+        else_branch: usize,
+    },
     /// Wait until the named resource's holder is either free (-1) or
     /// already this thread (priority-arbitrated; lower thread index
     /// wins ties because pass 2 of the scheduler resumes slots in
@@ -795,6 +803,17 @@ pub fn gen_module_thread(m: &ModuleDecl, debug: bool, wave: bool, num_os_threads
                         "{pad2}co_await arch_rt::wait_until(&_slot_{ti}, [this]{{ return {pred}; }});\n"
                     ));
                 }
+                WaitKind::IfElseJoin { cond, then_branch, else_branch } => {
+                    emit_ifelse_join_wait(
+                        &mut body_cpp,
+                        &pad2,
+                        ti,
+                        &format!("_slot_{ti}"),
+                        cond,
+                        *then_branch,
+                        *else_branch,
+                    )?;
+                }
                 WaitKind::LockAcquire(res, my_id) => {
                     // Wait until lock is free or already held by this thread.
                     // Re-check after resume because another thread (lower
@@ -897,9 +916,28 @@ pub fn gen_module_thread(m: &ModuleDecl, debug: bool, wave: bool, num_os_threads
                     WaitKind::ForkJoin(_) => {
                         return Err("nested fork/join inside fork branch not yet supported".into());
                     }
+                    WaitKind::IfElseJoin { cond, then_branch, else_branch } => {
+                        emit_ifelse_join_wait(
+                            &mut header,
+                            pad2,
+                            ti,
+                            &format!("_t{ti}_br{}_slot", br.id),
+                            cond,
+                            *then_branch,
+                            *else_branch,
+                        )?;
+                    }
                     WaitKind::LockAcquire(_, _) => {
                         return Err("`lock` inside fork branch not yet supported".into());
                     }
+                }
+                for sa in &seg.post_wait_seq {
+                    let lhs = expr_to_cpp(&sa.target)?;
+                    let rhs = expr_to_cpp(&sa.value)?;
+                    header.push_str(&format!("{pad2}{lhs} = {rhs};\n"));
+                }
+                for ie in &seg.post_wait_seq_if {
+                    emit_seq_if(ie, &mut header, if seg.for_loop.is_some() { 6 } else { 4 })?;
                 }
                 if seg.for_loop.is_some() {
                     header.push_str("    }\n");
@@ -972,7 +1010,27 @@ fn partition(body: &[ThreadStmt], branches: &mut Vec<Branch>, thread_id: usize) 
             }
             ThreadStmt::IfElse(ie) => {
                 if contains_wait(&ie.then_stmts) || contains_wait(&ie.else_stmts) {
-                    return Err("`if/else` containing `wait` not yet supported by thread sim".into());
+                    let then_segs = partition(&ie.then_stmts, branches, thread_id)?;
+                    let then_branch = branches.len();
+                    branches.push(Branch {
+                        id: then_branch,
+                        segs: then_segs,
+                    });
+
+                    let else_segs = partition(&ie.else_stmts, branches, thread_id)?;
+                    let else_branch = branches.len();
+                    branches.push(Branch {
+                        id: else_branch,
+                        segs: else_segs,
+                    });
+
+                    cur.wait_kind = WaitKind::IfElseJoin {
+                        cond: ie.cond.clone(),
+                        then_branch,
+                        else_branch,
+                    };
+                    segs.push(std::mem::replace(&mut cur, new_segment()));
+                    continue;
                 }
                 let kind = classify_ifelse(ie);
                 match kind {
@@ -1035,8 +1093,8 @@ fn partition(body: &[ThreadStmt], branches: &mut Vec<Branch>, thread_id: usize) 
                 // Allocate a Branch per branch body, partition each.
                 let mut branch_ids: Vec<usize> = Vec::new();
                 for body in branch_bodies {
-                    let id = branches.len();
                     let segs = partition(body, branches, thread_id)?;
+                    let id = branches.len();
                     branches.push(Branch { id, segs });
                     branch_ids.push(id);
                 }
@@ -1126,7 +1184,10 @@ fn partition(body: &[ThreadStmt], branches: &mut Vec<Branch>, thread_id: usize) 
     } else if !cur.entry_seq.is_empty() || !cur.entry_seq_if.is_empty() {
         if let Some(prev) = segs.last_mut() {
             // Only fold into a wait segment (not Terminal/ForkJoin etc.).
-            if matches!(prev.wait_kind, WaitKind::Until(_) | WaitKind::Cycles(_)) {
+            if matches!(
+                prev.wait_kind,
+                WaitKind::Until(_) | WaitKind::Cycles(_) | WaitKind::IfElseJoin { .. }
+            ) {
                 prev.post_wait_seq.extend(std::mem::take(&mut cur.entry_seq));
                 prev.post_wait_seq_if.extend(std::mem::take(&mut cur.entry_seq_if));
             } else {
@@ -1205,6 +1266,38 @@ fn lower_thread_ifelse_to_comb(ie: &IfElseOf<ThreadStmt>) -> Result<IfElseOf<Stm
         unique: ie.unique,
         span: ie.span,
     })
+}
+
+fn emit_branch_launch(out: &mut String, pad: &str, ti: usize, bid: usize) {
+    out.push_str(&format!("{pad}_t{ti}_br{bid}_slot.thread.destroy();\n"));
+    out.push_str(&format!("{pad}_t{ti}_br{bid}_slot.thread = _t{ti}_br{bid}_make();\n"));
+    out.push_str(&format!("{pad}_t{ti}_br{bid}_slot.kind = arch_rt::WaitKind::Ready;\n"));
+    out.push_str(&format!("{pad}_t{ti}_br{bid}_slot.cycles_remaining = 0;\n"));
+    out.push_str(&format!("{pad}_t{ti}_br{bid}_slot.pred = nullptr;\n"));
+    out.push_str(&format!("{pad}_t{ti}_br{bid}_seg = 0;\n"));
+}
+
+fn emit_ifelse_join_wait(
+    out: &mut String,
+    pad: &str,
+    ti: usize,
+    slot_name: &str,
+    cond: &Expr,
+    then_branch: usize,
+    else_branch: usize,
+) -> Result<(), String> {
+    let cond_cpp = expr_to_cpp_bool(cond)?;
+    let sel_name = format!("_if_sel_{then_branch}_{else_branch}");
+    out.push_str(&format!("{pad}bool {sel_name} = ({cond_cpp});\n"));
+    out.push_str(&format!("{pad}if ({sel_name}) {{\n"));
+    emit_branch_launch(out, &format!("{pad}  "), ti, then_branch);
+    out.push_str(&format!("{pad}}} else {{\n"));
+    emit_branch_launch(out, &format!("{pad}  "), ti, else_branch);
+    out.push_str(&format!("{pad}}}\n"));
+    out.push_str(&format!(
+        "{pad}co_await arch_rt::wait_until(&{slot_name}, [this, {sel_name}]{{ return {sel_name} ? _t{ti}_br{then_branch}_slot.kind == arch_rt::WaitKind::Done : _t{ti}_br{else_branch}_slot.kind == arch_rt::WaitKind::Done; }});\n"
+    ));
+    Ok(())
 }
 
 // Emit a sequential statement (from a module-level `seq on clk rising`

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -10189,6 +10189,15 @@ fn test_thread_wait_ifelse_fuses_dispatch_and_first_branch_action() {
 }
 
 #[test]
+fn test_thread_wait_ifelse_thread_sim_both_branch_latency() {
+    run_tlm_thread_sim_both(
+        "tests/thread/if_wait_thread_sim_both.arch",
+        "tests/thread/tb_if_wait_thread_sim_both.cpp",
+        "PASS IfWaitThreadSimBoth",
+    );
+}
+
+#[test]
 fn test_thread_wait_elsif_chain_fuses_to_single_dispatch() {
     // An `elsif` parses as a nested `else { if ... }`. The wait-dispatch
     // fusion should flatten that chain so later arms do not pay an extra

--- a/tests/thread/if_wait_thread_sim_both.arch
+++ b/tests/thread/if_wait_thread_sim_both.arch
@@ -1,0 +1,24 @@
+module IfWaitThreadSimBoth
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Async, High>;
+  port req: in Bool;
+  port is_mul: in Bool;
+  port phase: out UInt<4>;
+
+  reg phase_q: UInt<4> reset rst => 0;
+  let phase = phase_q;
+
+  thread on clk rising, rst high
+    wait until req;
+    if is_mul
+      phase_q <= 1;
+      wait 1 cycle;
+      phase_q <= 2;
+    else
+      phase_q <= 3;
+      wait 1 cycle;
+      phase_q <= 4;
+    end if
+    wait 1 cycle;
+  end thread
+end module IfWaitThreadSimBoth

--- a/tests/thread/tb_if_wait_thread_sim_both.cpp
+++ b/tests/thread/tb_if_wait_thread_sim_both.cpp
@@ -1,0 +1,55 @@
+#include "VIfWaitThreadSimBoth.h"
+
+#include <cstdio>
+
+static VIfWaitThreadSimBoth dut;
+static int cycle_count = 0;
+
+static void tick() {
+    dut.clk = 0;
+    dut.eval();
+    dut.clk = 1;
+    dut.eval();
+    cycle_count++;
+}
+
+static bool expect_phase(unsigned expected, const char* label) {
+    if (dut.phase != expected) {
+        std::printf("FAIL %s cycle=%d phase=%u expected=%u\n",
+                    label, cycle_count, (unsigned)dut.phase, expected);
+        return false;
+    }
+    return true;
+}
+
+int main() {
+    dut.rst = 1;
+    dut.req = 0;
+    dut.is_mul = 0;
+    tick();
+    dut.rst = 0;
+    tick();
+
+    dut.req = 1;
+    dut.is_mul = 1;
+    tick();
+    if (!expect_phase(1, "mul dispatch")) return 1;
+    dut.req = 0;
+    tick();
+    if (!expect_phase(2, "mul wait")) return 1;
+    tick();
+    if (!expect_phase(2, "mul rejoin")) return 1;
+
+    dut.req = 1;
+    dut.is_mul = 0;
+    tick();
+    if (!expect_phase(3, "div dispatch")) return 1;
+    dut.req = 0;
+    tick();
+    if (!expect_phase(4, "div wait")) return 1;
+    tick();
+    if (!expect_phase(4, "div rejoin")) return 1;
+
+    std::puts("PASS IfWaitThreadSimBoth");
+    return 0;
+}


### PR DESCRIPTION
## What changed
- add native thread-sim support for `if/else` branches that contain waits by lowering them to a selected branch coroutine and rejoin wait
- fold trailing sequential work across the new wait kind so branch-local post-wait updates preserve the intended latency
- add an integration test and ARCH/C++ fixtures that exercise the branch-latency and rejoin behavior under `--thread-sim both`

## Why
This branch already had the implementation and tracked test hook, but the fixture files were only present locally. That made the test pass in this worktree while leaving the branch incomplete for clean checkouts and CI.

## Validation
- `cargo test test_thread_wait_ifelse_thread_sim_both_branch_latency -- --nocapture`
