### PR TITLE
fix(typecheck): reject RAM latency > 2 instead of emitting undriven rdata

### DIFF
--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -5131,6 +5131,19 @@ impl<'a> TypeChecker<'a> {
                 r.name.span,
             ));
         }
+        // latency must be 0 (async), 1 (sync), or 2 (sync_out). Higher
+        // values are unsupported by codegen — the SV/sim emitters only
+        // handle 0/1/2 and would otherwise silently leave `rdata` outputs
+        // undriven. Reject loudly instead.
+        if r.latency > 2 {
+            self.errors.push(CompileError::general(
+                &format!(
+                    "ram `{}`: latency {} is out of range — must be 0 (async), 1 (sync), or 2 (sync_out)",
+                    r.name.name, r.latency
+                ),
+                r.name.span,
+            ));
+        }
         // true_dual requires exactly 2 port groups
         if r.kind == crate::ast::RamKind::TrueDual && r.port_groups.len() != 2 {
             self.errors.push(CompileError::general(

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -892,6 +892,43 @@ end ram TrueDualLat{latency}
     );
 }
 
+#[test]
+fn test_ram_latency_out_of_range_errors() {
+    // RAM codegen only handles latency 0/1/2; a higher value would
+    // silently emit an undriven `rdata` output. Reject it at check time.
+    let source = r#"
+ram BadLatRam
+  kind single;
+  latency 3;
+  param DEPTH: const = 16;
+  param T: type = UInt<8>;
+  port clk: in Clock<SysDomain>;
+  store
+    data: Vec<T, DEPTH>;
+  end store
+  ports a
+    en: in Bool;
+    wen: in Bool;
+    addr: in UInt<4>;
+    wdata: in T;
+    rdata: out T;
+  end ports a
+end ram BadLatRam
+"#;
+    let tokens = lexer::tokenize(source).expect("lex");
+    let mut parser = Parser::new(tokens, source);
+    let ast = parser.parse_source_file().expect("parse");
+    let symbols = resolve::resolve(&ast).expect("resolve");
+    let checker = arch::typecheck::TypeChecker::new(&symbols, &ast);
+    let result = checker.check();
+    assert!(result.is_err(), "latency 3 RAM should be rejected");
+    let errs = result.err().unwrap();
+    assert!(
+        errs.iter().any(|e| format!("{e:?}").contains("latency 3 is out of range")),
+        "error should name the out-of-range latency: {errs:?}"
+    );
+}
+
 // ── Counter ───────────────────────────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Problem

RAM `latency` had **no range validation**. The parser accepts any integer, but codegen (both SV and native sim) only handles `latency 0` (async), `1` (sync), and `2` (sync_out). So:

```
ram BadLatRam
  kind true_dual;
  latency 3;        // <-- accepted silently
  ...
  ports a ... rdata: out T; end ports a
  ports b ... rdata: out T; end ports b
end ram BadLatRam
```

passes `arch check` (`OK: no errors`) and `arch build` emits `a_rdata`/`b_rdata` as **undriven** output ports — no `assign`, no `always_ff`. Silently broken hardware (latch / X-prop downstream).

PR #585 (`true_dual` native sim) made this sharper: its new
`match r.latency { 0 => .. 1 | 2 => .. _ => {} }` leaves the read path **entirely empty** for any latency ≥ 3, where the pre-#585 code at least fell through to latency-1 behavior.

The spec defines `latency 0|1|2` as the only legal values, so any higher value is already-invalid input — this just rejects it loudly instead of producing broken output.

## Fix

Add a bound in `check_ram` (typecheck): `latency > 2` ⇒ clear, spec-aligned error:

```
ram `BadLatRam`: latency 3 is out of range — must be 0 (async), 1 (sync), or 2 (sync_out)
```

Valid latencies (0/1/2) are unaffected — verified all three still `check` clean and build.

## Scope

Internal validation / error-message improvement only. No change to any valid user-facing syntax or semantics (latency 0/1/2 behave exactly as before). Per the repo's compiler-bug policy this is an autonomous internal fix.

## Tests

- `test_ram_latency_out_of_range_errors` (new) — asserts `latency 3` is rejected with the out-of-range message.
- Re-ran `test_true_dual_ram_*`, `test_simple_dual_ram`, `test_ram_missing_port_group_errors` — all green.

Found during the daily merged-PR review of #583–#587.