### PR TITLE
[codex] add ARCH graph MCP wrappers

### DIFF
--- a/mcp/arch_mcp_server.py
+++ b/mcp/arch_mcp_server.py
@@ -460,6 +460,29 @@ def arch_graph_query(query: str, index: str = ".archgraph", limit: int = 20) -> 
 
 
 @mcp.tool()
+def arch_graph_index(
+    paths: list[str],
+    out: str = ".archgraph",
+    root: str | None = None,
+    clean: bool = False,
+    timeout: int = 60,
+) -> str:
+    """Build the compiler-native JSONL graph index for ARCH source paths.
+
+    Paths may be .arch files or directories under the configured workspace
+    roots. Pass clean=True to replace an existing graph directory.
+    """
+    resolved_paths = [str(_resolve_safe(path)) for path in paths]
+    out_path = str(_resolve_safe(out))
+    cmd = [ARCH_BIN, "graph", "index", *resolved_paths, "--out", out_path]
+    if root:
+        cmd += ["--root", str(_resolve_safe(root))]
+    if clean:
+        cmd.append("--clean")
+    return _run(cmd, timeout=timeout)
+
+
+@mcp.tool()
 def arch_graph_context(task: str, index: str = ".archgraph", limit: int = 30) -> str:
     """Return a bounded graph context slice for a task description."""
     index_path = str(_resolve_safe(index))
@@ -491,6 +514,28 @@ def arch_graph_impact(symbol: str, depth: int = 2, index: str = ".archgraph", li
         ],
         timeout=20,
     )
+
+
+@mcp.tool()
+def arch_graph_callers(target: str, index: str = ".archgraph", limit: int = 20, json: bool = False) -> str:
+    """Show indexed callers for a function or method name."""
+    index_path = str(_resolve_safe(index))
+    capped = max(1, min(limit, 100))
+    cmd = [ARCH_BIN, "graph", "callers", target, "--index", index_path, "--limit", str(capped)]
+    if json:
+        cmd.append("--json")
+    return _run(cmd, timeout=20)
+
+
+@mcp.tool()
+def arch_graph_html(index: str = ".archgraph", out: str = "arch-graph.html", title: str | None = None) -> str:
+    """Render an ARCH graph index as a standalone clickable HTML file."""
+    index_path = str(_resolve_safe(index))
+    out_path = str(_resolve_safe(out))
+    cmd = [ARCH_BIN, "graph", "html", "--index", index_path, "--out", out_path]
+    if title:
+        cmd += ["--title", title]
+    return _run(cmd, timeout=30)
 
 
 @mcp.tool()


### PR DESCRIPTION
## Summary

Adds the missing ARCH MCP wrappers for the compiler-native graph feature:

- `arch_graph_index` for building graph indexes from `.arch` files or directories
- `arch_graph_callers` for caller lookups
- `arch_graph_html` for rendering clickable graph HTML

The existing query/context/impact wrappers were already present; this completes the MCP surface for the graph command family.

## Validation

- `/Users/shuqingzhao/github/arch-com/mcp/.venv/bin/python3 -m py_compile mcp/arch_mcp_server.py`
- Direct MCP-wrapper smoke test for `arch_graph_index`, `arch_graph_query`, and `arch_graph_html`
- Code-review pass required by `scripts/pre_pr_review.sh`
