### PR TITLE
Add LZ4 block decompressor example

### DIFF
--- a/examples/lz4_block_decoder.arch
+++ b/examples/lz4_block_decoder.arch
@@ -1,0 +1,246 @@
+//! ---
+//! tags: [compression, lz4, lossless, streaming, decompressor, cast-inc]
+//! refs:
+//!   - "LZ4 Block Format (https://github.com/lz4/lz4/blob/dev/doc/lz4_Block_format.md)"
+//!   - "CAST LZ4SNP-D | LZ4/Snappy Data Decompressor IP Core (cast-inc.com)"
+//! ---
+//!
+//! LZ4 Block Decompressor — hardware IP analog to CAST LZ4SNP-D
+//!
+//! Decodes a single LZ4 block (no frame header) from a byte-streaming input
+//! to a byte-streaming output. Matches the I/O surface of the CAST LZ4SNP-D
+//! IP: AXI-stream-style byte-wide ports, single-clock synchronous design,
+//! parameterizable history-buffer depth.
+//!
+//! Interface:
+//!   in_valid/in_data/in_last/in_ready  — compressed byte input stream
+//!   out_valid/out_data/out_last/out_ready — decompressed byte output stream
+//!   busy   — high while decoding (combinational)
+//!   done   — pulses high for one cycle when the last output byte is accepted
+//!   error  — latches high on malformed input; hold until reset
+//!
+//! Algorithm (LZ4 Block Format v1.9):
+//!   Each "sequence":
+//!     1. Token byte: upper nibble = literal_length, lower nibble = match_len_raw
+//!     2. Extended literal length bytes (while byte == 255, if raw == 15)
+//!     3. Literal bytes: literal_length bytes forwarded verbatim to output
+//!     4. Match offset: 2 bytes little-endian (absent in the LAST sequence)
+//!     5. Extended match length bytes (while byte == 255, if raw == 15)
+//!     6. Match copy: (match_len_raw + 4) bytes from history at offset back
+//!   The last sequence ends after step 3 (no offset or match). in_last is
+//!   set on the final literal byte of the block. Minimum match = 4 bytes.
+//!
+//! Throughput: 1 byte/cycle. Register-array history (suitable for
+//! HIST_DEPTH ≤ 512 in sim; replace with BRAM inst for synthesis).
+//!
+//! Error conditions latched in ERROR state (until reset):
+//!   - offset == 0 (invalid per LZ4 spec)
+//!   - offset high byte != 0 (offset > 255 > HIST_DEPTH for default params)
+
+domain SysDomain
+  freq_mhz: 200
+end domain SysDomain
+
+module Lz4BlockDecoder
+  // History buffer depth in bytes (must be a power of 2).
+  // HIST_PTR must equal log2(HIST_DEPTH).
+  param HIST_DEPTH: const = 256;
+  param HIST_PTR:   const = 8;
+
+  port clk:       in  Clock<SysDomain>;
+  port rst:       in  Reset<Sync>;
+
+  // Compressed input byte stream
+  port in_valid:  in  Bool;
+  port in_data:   in  UInt<8>;
+  port in_last:   in  Bool;       // high on last byte of the compressed block
+  port in_ready:  out Bool;
+
+  // Decompressed output byte stream
+  port out_valid: out Bool;
+  port out_data:  out UInt<8>;
+  port out_last:  out Bool;       // high on last decompressed byte
+  port out_ready: in  Bool;
+
+  // Status
+  port busy:      out Bool;       // high while decoding
+  port done:      out Bool;       // pulses one cycle when last byte is accepted
+  port error:     out Bool;       // latches on malformed block
+
+  // ── FSM state encoding ──────────────────────────────────────────────────
+  // 0=READ_TOKEN (reset state)  1=LIT_EXT   2=LIT_COPY
+  // 3=OFF_LO  4=OFF_HI  5=MAT_EXT  6=MAT_COPY  7=ERROR
+  reg state:      UInt<3>  reset rst => 0;
+
+  // ── Decoder data registers ───────────────────────────────────────────────
+  reg lit_cnt:    UInt<16> reset rst => 0;   // literals remaining to copy
+  reg mat_cnt:    UInt<16> reset rst => 0;   // match bytes remaining to copy
+  reg tok_ml:     UInt<4>  reset rst => 0;   // raw match nibble from token
+  reg offset_lo:  UInt<8>  reset rst => 0;   // low byte of 16-bit LZ4 offset
+  reg eob_r:      Bool     reset rst => 0;   // end-of-block accumulated flag
+
+  // ── Circular history buffer ──────────────────────────────────────────────
+  // Register array: suitable for HIST_DEPTH ≤ 512. For larger depths convert
+  // hist_buf to a simple_dual RAM instantiation with 1-cycle read latency
+  // and add a MAT_RD_WAIT state between MAT_REQ and MAT_COPY.
+  reg hist_buf:   Vec<UInt<8>, HIST_DEPTH> reset rst => 0;
+  reg wr_ptr:     UInt<HIST_PTR> reset rst => 0;
+  reg mat_rd_ptr: UInt<HIST_PTR> reset rst => 0;
+
+  // ── Combinational signals ────────────────────────────────────────────────
+
+  // History read — zero-latency register array
+  let rd_data: UInt<8> = hist_buf[mat_rd_ptr];
+
+  // True on the cycle the last literal of the block is accepted
+  let last_lit: Bool = (lit_cnt == 16'd1) && (eob_r || in_last);
+
+  // Token nibbles from current input (meaningful in READ_TOKEN)
+  let tok_ll_w: UInt<4> = in_data[7:4];
+  let tok_ml_w: UInt<4> = in_data[3:0];
+
+  // Match count base = tok_ml + 4 (LZ4 min match is 4)
+  let base_mat_cnt: UInt<16> = (tok_ml.zext<16>() + 16'd4).trunc<16>();
+
+  // mat_rd_ptr init = wr_ptr − offset (wrapping)
+  let mat_rd_init: UInt<HIST_PTR> = wr_ptr -% offset_lo;
+
+  // State one-hot flags for output mux
+  let s_rd: Bool = (state == 3'd0);   // READ_TOKEN
+  let s_le: Bool = (state == 3'd1);   // LIT_EXT
+  let s_lc: Bool = (state == 3'd2);   // LIT_COPY
+  let s_ol: Bool = (state == 3'd3);   // OFF_LO
+  let s_oh: Bool = (state == 3'd4);   // OFF_HI
+  let s_me: Bool = (state == 3'd5);   // MAT_EXT
+  let s_mc: Bool = (state == 3'd6);   // MAT_COPY
+  let s_er: Bool = (state == 3'd7);   // ERROR
+
+  // ── Output port assignments (all combinational) ──────────────────────────
+  comb
+    // in_ready: accept whenever we need a byte. In LIT_COPY gate on out_ready
+    // so input and output flow together (the literal byte passes straight through).
+    in_ready  = s_rd || s_le || s_ol || s_oh || s_me || (s_lc && out_ready);
+
+    // out_valid: emit in LIT_COPY (when we have input) or MAT_COPY.
+    out_valid = (s_lc && in_valid) || s_mc;
+
+    // out_data: pass through literal; or serve from history during match copy.
+    out_data  = s_lc ? in_data : rd_data;
+
+    // out_last: high on the final output byte of the block.
+    out_last  = s_lc && last_lit;
+
+    // busy: active in all non-error, non-idle states (READ_TOKEN counts as busy).
+    busy      = !s_er;
+
+    // done: pulse on the cycle the last byte is handed off downstream.
+    done      = s_lc && last_lit && in_valid && out_ready;
+
+    // error: latch
+    error     = s_er;
+  end comb
+
+  // ── Sequential state machine ─────────────────────────────────────────────
+  seq on clk rising
+    match state
+
+      3'd0 =>  // READ_TOKEN: wait for token byte and decode literal/match lengths
+        if in_valid
+          tok_ml <= tok_ml_w;
+          eob_r  <= in_last;
+          if tok_ll_w == 4'd15
+            lit_cnt <= 16'd15;
+            state   <= 1;   // LIT_EXT
+          elsif tok_ll_w == 4'd0
+            lit_cnt <= 0;
+            if in_last
+              state <= 0;   // empty last sequence: back to READ_TOKEN (done pulsed via comb)
+            else
+              state <= 3;   // OFF_LO: no literals in this sequence
+            end if
+          else
+            lit_cnt <= tok_ll_w.zext<16>();
+            state   <= 2;   // LIT_COPY
+          end if
+        end if
+
+      3'd1 =>  // LIT_EXT: accumulate extra literal length bytes
+        if in_valid
+          lit_cnt <= (lit_cnt + in_data.zext<16>()).trunc<16>();
+          eob_r   <= eob_r || in_last;
+          if in_data != 8'd255
+            state <= 2;   // LIT_COPY
+          end if
+        end if
+
+      3'd2 =>  // LIT_COPY: forward input → output + history
+        if in_valid && out_ready
+          hist_buf[wr_ptr] <= in_data;
+          wr_ptr            <= wr_ptr +% 8'd1;
+          eob_r             <= eob_r || in_last;
+          if last_lit
+            lit_cnt <= 0;
+            state   <= 0;   // end of block: done pulsed combinationally
+          elsif lit_cnt == 16'd1
+            lit_cnt <= 0;
+            state   <= 3;   // last literal of mid-block sequence: read offset
+          else
+            lit_cnt <= (lit_cnt - 16'd1).trunc<16>();
+          end if
+        end if
+
+      3'd3 =>  // OFF_LO: read low byte of 16-bit little-endian match offset
+        if in_valid
+          offset_lo <= in_data;
+          state     <= 4;
+        end if
+
+      3'd4 =>  // OFF_HI: read high byte, validate, initialise mat_rd_ptr
+        if in_valid
+          if in_data != 8'd0
+            // offset > 255: exceeds history depth for default HIST_DEPTH=256
+            state <= 7;   // ERROR
+          elsif offset_lo == 8'd0
+            // offset == 0 is invalid in the LZ4 format
+            state <= 7;   // ERROR
+          else
+            mat_rd_ptr <= mat_rd_init;
+            mat_cnt    <= base_mat_cnt;
+            if tok_ml == 4'd15
+              state <= 5;   // MAT_EXT
+            else
+              state <= 6;   // MAT_COPY
+            end if
+          end if
+        end if
+
+      3'd5 =>  // MAT_EXT: accumulate extra match length bytes
+        if in_valid
+          mat_cnt <= (mat_cnt + in_data.zext<16>()).trunc<16>();
+          if in_data != 8'd255
+            state <= 6;   // MAT_COPY
+          end if
+        end if
+
+      3'd6 =>  // MAT_COPY: stream history bytes to output + record in history
+        if out_ready
+          hist_buf[wr_ptr] <= rd_data;
+          wr_ptr            <= wr_ptr +% 8'd1;
+          mat_rd_ptr        <= mat_rd_ptr +% 8'd1;
+          if mat_cnt == 16'd1
+            mat_cnt <= 0;
+            state   <= 0;   // READ_TOKEN: fetch next sequence
+          else
+            mat_cnt <= (mat_cnt - 16'd1).trunc<16>();
+          end if
+        end if
+
+      3'd7 =>  // ERROR: latch until reset
+        if false
+          state <= 7;   // satisfy exhaustiveness checker; dead code
+        end if
+
+    end match
+  end seq
+
+end module Lz4BlockDecoder

--- a/examples/lz4_block_decoder.sv
+++ b/examples/lz4_block_decoder.sv
@@ -1,0 +1,298 @@
+//! ---
+//! tags: [compression, lz4, lossless, streaming, decompressor, cast-inc]
+//! refs:
+//!   - "LZ4 Block Format (https://github.com/lz4/lz4/blob/dev/doc/lz4_Block_format.md)"
+//!   - "CAST LZ4SNP-D | LZ4/Snappy Data Decompressor IP Core (cast-inc.com)"
+//! ---
+//!
+//! LZ4 Block Decompressor — hardware IP analog to CAST LZ4SNP-D
+//!
+//! Decodes a single LZ4 block (no frame header) from a byte-streaming input
+//! to a byte-streaming output. Matches the I/O surface of the CAST LZ4SNP-D
+//! IP: AXI-stream-style byte-wide ports, single-clock synchronous design,
+//! parameterizable history-buffer depth.
+//!
+//! Interface:
+//!   in_valid/in_data/in_last/in_ready  — compressed byte input stream
+//!   out_valid/out_data/out_last/out_ready — decompressed byte output stream
+//!   busy   — high while decoding (combinational)
+//!   done   — pulses high for one cycle when the last output byte is accepted
+//!   error  — latches high on malformed input; hold until reset
+//!
+//! Algorithm (LZ4 Block Format v1.9):
+//!   Each "sequence":
+//!     1. Token byte: upper nibble = literal_length, lower nibble = match_len_raw
+//!     2. Extended literal length bytes (while byte == 255, if raw == 15)
+//!     3. Literal bytes: literal_length bytes forwarded verbatim to output
+//!     4. Match offset: 2 bytes little-endian (absent in the LAST sequence)
+//!     5. Extended match length bytes (while byte == 255, if raw == 15)
+//!     6. Match copy: (match_len_raw + 4) bytes from history at offset back
+//!   The last sequence ends after step 3 (no offset or match). in_last is
+//!   set on the final literal byte of the block. Minimum match = 4 bytes.
+//!
+//! Throughput: 1 byte/cycle. Register-array history (suitable for
+//! HIST_DEPTH ≤ 512 in sim; replace with BRAM inst for synthesis).
+//!
+//! Error conditions latched in ERROR state (until reset):
+//!   - offset == 0 (invalid per LZ4 spec)
+//!   - offset high byte != 0 (offset > 255 > HIST_DEPTH for default params)
+// domain SysDomain
+//   freq_mhz: 200
+
+module Lz4BlockDecoder #(
+  parameter int HIST_DEPTH = 256,
+  parameter int HIST_PTR = 8
+) (
+  input logic clk,
+  input logic rst,
+  input logic in_valid,
+  input logic [7:0] in_data,
+  input logic in_last,
+  output logic in_ready,
+  output logic out_valid,
+  output logic [7:0] out_data,
+  output logic out_last,
+  input logic out_ready,
+  output logic busy,
+  output logic done,
+  output logic error
+);
+
+  logic [7:0] rd_data;
+  logic last_lit;
+  logic [3:0] tok_ll_w;
+  logic [3:0] tok_ml_w;
+  logic [15:0] base_mat_cnt;
+  logic [HIST_PTR-1:0] mat_rd_init;
+  logic s_rd;
+  logic s_le;
+  logic s_lc;
+  logic s_ol;
+  logic s_oh;
+  logic s_me;
+  logic s_mc;
+  logic s_er;
+  // History buffer depth in bytes (must be a power of 2).
+  // HIST_PTR must equal log2(HIST_DEPTH).
+  // Compressed input byte stream
+  // high on last byte of the compressed block
+  // Decompressed output byte stream
+  // high on last decompressed byte
+  // Status
+  // high while decoding
+  // pulses one cycle when last byte is accepted
+  // latches on malformed block
+  // ── FSM state encoding ──────────────────────────────────────────────────
+  // 0=READ_TOKEN (reset state)  1=LIT_EXT   2=LIT_COPY
+  // 3=OFF_LO  4=OFF_HI  5=MAT_EXT  6=MAT_COPY  7=ERROR
+  logic [2:0] state;
+  // ── Decoder data registers ───────────────────────────────────────────────
+  logic [15:0] lit_cnt;
+  // literals remaining to copy
+  logic [15:0] mat_cnt;
+  // match bytes remaining to copy
+  logic [3:0] tok_ml;
+  // raw match nibble from token
+  logic [7:0] offset_lo;
+  // low byte of 16-bit LZ4 offset
+  logic eob_r;
+  // end-of-block accumulated flag
+  // ── Circular history buffer ──────────────────────────────────────────────
+  // Register array: suitable for HIST_DEPTH ≤ 512. For larger depths convert
+  // hist_buf to a simple_dual RAM instantiation with 1-cycle read latency
+  // and add a MAT_RD_WAIT state between MAT_REQ and MAT_COPY.
+  logic [HIST_DEPTH-1:0] [7:0] hist_buf;
+  logic [HIST_PTR-1:0] wr_ptr;
+  logic [HIST_PTR-1:0] mat_rd_ptr;
+  // ── Combinational signals ────────────────────────────────────────────────
+  // History read — zero-latency register array
+  assign rd_data = hist_buf[mat_rd_ptr];
+  // True on the cycle the last literal of the block is accepted
+  assign last_lit = lit_cnt == 16'd1 && (eob_r || in_last);
+  // Token nibbles from current input (meaningful in READ_TOKEN)
+  assign tok_ll_w = in_data[7:4];
+  assign tok_ml_w = in_data[3:0];
+  // Match count base = tok_ml + 4 (LZ4 min match is 4)
+  assign base_mat_cnt = 16'(16'($unsigned(tok_ml)) + 16'd4);
+  // mat_rd_ptr init = wr_ptr − offset (wrapping)
+  assign mat_rd_init = (HIST_PTR > 8 ? HIST_PTR : 8)'(wr_ptr - offset_lo);
+  // State one-hot flags for output mux
+  assign s_rd = state == 3'd0;
+  // READ_TOKEN
+  assign s_le = state == 3'd1;
+  // LIT_EXT
+  assign s_lc = state == 3'd2;
+  // LIT_COPY
+  assign s_ol = state == 3'd3;
+  // OFF_LO
+  assign s_oh = state == 3'd4;
+  // OFF_HI
+  assign s_me = state == 3'd5;
+  // MAT_EXT
+  assign s_mc = state == 3'd6;
+  // MAT_COPY
+  assign s_er = state == 3'd7;
+  // ERROR
+  // ── Output port assignments (all combinational) ──────────────────────────
+  assign in_ready = s_rd || s_le || s_ol || s_oh || s_me || s_lc && out_ready;
+  assign out_valid = s_lc && in_valid || s_mc;
+  assign out_data = s_lc ? in_data : rd_data;
+  assign out_last = s_lc && last_lit;
+  assign busy = !s_er;
+  assign done = s_lc && last_lit && in_valid && out_ready;
+  assign error = s_er;
+  // in_ready: accept whenever we need a byte. In LIT_COPY gate on out_ready
+  // so input and output flow together (the literal byte passes straight through).
+  // out_valid: emit in LIT_COPY (when we have input) or MAT_COPY.
+  // out_data: pass through literal; or serve from history during match copy.
+  // out_last: high on the final output byte of the block.
+  // busy: active in all non-error, non-idle states (READ_TOKEN counts as busy).
+  // done: pulse on the cycle the last byte is handed off downstream.
+  // error: latch
+  // ── Sequential state machine ─────────────────────────────────────────────
+  always_ff @(posedge clk) begin
+    if (rst) begin
+      eob_r <= 0;
+      for (int __ri0 = 0; __ri0 < HIST_DEPTH; __ri0++) begin
+        hist_buf[__ri0] <= 0;
+      end
+      lit_cnt <= 0;
+      mat_cnt <= 0;
+      mat_rd_ptr <= 0;
+      offset_lo <= 0;
+      state <= 0;
+      tok_ml <= 0;
+      wr_ptr <= 0;
+    end else begin
+      case (state)
+        3'd0: begin
+          // READ_TOKEN: wait for token byte and decode literal/match lengths
+          if (in_valid) begin
+            tok_ml <= tok_ml_w;
+            eob_r <= in_last;
+            if (tok_ll_w == 4'd15) begin
+              lit_cnt <= 16'd15;
+              state <= 1;
+            end else if (tok_ll_w == 4'd0) begin
+              // LIT_EXT
+              lit_cnt <= 0;
+              if (in_last) begin
+                state <= 0;
+              end else begin
+                // empty last sequence: back to READ_TOKEN (done pulsed via comb)
+                state <= 3;
+              end
+            end else begin
+              // OFF_LO: no literals in this sequence
+              lit_cnt <= 16'($unsigned(tok_ll_w));
+              state <= 2;
+            end
+          end
+        end
+        3'd1: begin
+          // LIT_COPY
+          // LIT_EXT: accumulate extra literal length bytes
+          if (in_valid) begin
+            lit_cnt <= 16'(lit_cnt + 16'($unsigned(in_data)));
+            eob_r <= eob_r || in_last;
+            if (in_data != 8'd255) begin
+              state <= 2;
+            end
+          end
+        end
+        3'd2: begin
+          // LIT_COPY
+          // LIT_COPY: forward input → output + history
+          if (in_valid && out_ready) begin
+            hist_buf[wr_ptr] <= in_data;
+            wr_ptr <= (HIST_PTR > 8 ? HIST_PTR : 8)'(wr_ptr + 8'd1);
+            eob_r <= eob_r || in_last;
+            if (last_lit) begin
+              lit_cnt <= 0;
+              state <= 0;
+            end else if (lit_cnt == 16'd1) begin
+              // end of block: done pulsed combinationally
+              lit_cnt <= 0;
+              state <= 3;
+            end else begin
+              // last literal of mid-block sequence: read offset
+              lit_cnt <= 16'(lit_cnt - 16'd1);
+            end
+          end
+        end
+        3'd3: begin
+          // OFF_LO: read low byte of 16-bit little-endian match offset
+          if (in_valid) begin
+            offset_lo <= in_data;
+            state <= 4;
+          end
+        end
+        3'd4: begin
+          // OFF_HI: read high byte, validate, initialise mat_rd_ptr
+          if (in_valid) begin
+            if (in_data != 8'd0) begin
+              // offset > 255: exceeds history depth for default HIST_DEPTH=256
+              state <= 7;
+            end else if (offset_lo == 8'd0) begin
+              // ERROR
+              // offset == 0 is invalid in the LZ4 format
+              state <= 7;
+            end else begin
+              // ERROR
+              mat_rd_ptr <= mat_rd_init;
+              mat_cnt <= base_mat_cnt;
+              if (tok_ml == 4'd15) begin
+                state <= 5;
+              end else begin
+                // MAT_EXT
+                state <= 6;
+              end
+            end
+          end
+        end
+        3'd5: begin
+          // MAT_COPY
+          // MAT_EXT: accumulate extra match length bytes
+          if (in_valid) begin
+            mat_cnt <= 16'(mat_cnt + 16'($unsigned(in_data)));
+            if (in_data != 8'd255) begin
+              state <= 6;
+            end
+          end
+        end
+        3'd6: begin
+          // MAT_COPY
+          // MAT_COPY: stream history bytes to output + record in history
+          if (out_ready) begin
+            hist_buf[wr_ptr] <= rd_data;
+            wr_ptr <= (HIST_PTR > 8 ? HIST_PTR : 8)'(wr_ptr + 8'd1);
+            mat_rd_ptr <= (HIST_PTR > 8 ? HIST_PTR : 8)'(mat_rd_ptr + 8'd1);
+            if (mat_cnt == 16'd1) begin
+              mat_cnt <= 0;
+              state <= 0;
+            end else begin
+              // READ_TOKEN: fetch next sequence
+              mat_cnt <= 16'(mat_cnt - 16'd1);
+            end
+          end
+        end
+        3'd7: begin
+          // ERROR: latch until reset
+          if (1'b0) begin
+            state <= 7;
+          end
+        end
+      endcase
+      // satisfy exhaustiveness checker; dead code
+    end
+  end
+  // synopsys translate_off
+  // Auto-generated safety assertions (bounds / divide-by-zero)
+  _auto_bound_vec_0: assert property (@(posedge clk) disable iff (rst) ((in_valid && out_ready) |-> (int'(wr_ptr) < (HIST_DEPTH))))
+    else $fatal(1, "BOUNDS VIOLATION: Lz4BlockDecoder._auto_bound_vec_0");
+  _auto_bound_vec_1: assert property (@(posedge clk) disable iff (rst) ((out_ready) |-> (int'(wr_ptr) < (HIST_DEPTH))))
+    else $fatal(1, "BOUNDS VIOLATION: Lz4BlockDecoder._auto_bound_vec_1");
+  // synopsys translate_on
+
+endmodule
+

--- a/examples/lz4_block_decoder_tb.cpp
+++ b/examples/lz4_block_decoder_tb.cpp
@@ -1,0 +1,254 @@
+// Testbench for Lz4BlockDecoder — LZ4 block decompressor
+//
+// Three functional tests plus an error-path test, all with out_ready=1
+// (no back-pressure). Compressed bytes are fed one per cycle; the
+// decoder outputs one byte per cycle (literals) or per match-copy step.
+//
+// Sampling discipline: combinational outputs (out_valid, out_data, done)
+// are read at the negedge eval before posedge register update.
+
+#include "VLz4BlockDecoder.h"
+#include "verilated.h"
+#include <cstdio>
+#include <cstdint>
+#include <vector>
+
+static int g_errors = 0;
+static VLz4BlockDecoder* dut;
+
+#define CHECK(cond, fmt, ...) \
+    do { if (!(cond)) { printf("  FAIL: " fmt "\n", ##__VA_ARGS__); g_errors++; } } while(0)
+
+// ── Simulation helpers ────────────────────────────────────────────────────
+
+static void reset() {
+    dut->rst       = 1;
+    dut->in_valid  = 0;
+    dut->in_data   = 0;
+    dut->in_last   = 0;
+    dut->out_ready = 0;
+    for (int i = 0; i < 3; i++) {
+        dut->clk = 0; dut->eval();
+        dut->clk = 1; dut->eval();
+    }
+    dut->rst = 0;
+    dut->clk = 0; dut->eval();
+    dut->clk = 1; dut->eval();
+}
+
+// Decode one LZ4 block.
+// `input`: compressed bytes with in_last=1 on the last one.
+// Returns decompressed bytes collected from out_valid/out_data.
+// Stops when `done` is sampled high or `error` is latched, or `max_cycles`.
+static std::vector<uint8_t> decode_block(const std::vector<uint8_t>& input,
+                                          int max_cycles = 4096) {
+    std::vector<uint8_t> output;
+    size_t in_idx = 0;
+
+    dut->out_ready = 1;     // accept output every cycle
+    dut->in_valid  = 0;
+    dut->in_last   = 0;
+    dut->in_data   = 0;
+
+    for (int c = 0; c < max_cycles; c++) {
+        // Present the next unshipped input byte when we have one
+        if (in_idx < input.size()) {
+            dut->in_valid = 1;
+            dut->in_data  = input[in_idx];
+            dut->in_last  = (in_idx == input.size() - 1) ? 1 : 0;
+        } else {
+            dut->in_valid = 0;
+            dut->in_last  = 0;
+        }
+
+        // Negedge eval: combinational outputs valid here (registers hold
+        // previous-cycle values; in/out signals are driven above)
+        dut->clk = 0; dut->eval();
+
+        // Sample handshake signals at this point (stable comb values)
+        bool out_fire = (dut->out_valid != 0) && (dut->out_ready != 0);
+        bool in_fire  = (dut->in_valid  != 0) && (dut->in_ready  != 0);
+        bool is_done  = (dut->done      != 0);
+        bool is_err   = (dut->error     != 0);
+
+        if (out_fire)          output.push_back((uint8_t)dut->out_data);
+        if (in_fire)           in_idx++;
+
+        // Posedge: advance registers
+        dut->clk = 1; dut->eval();
+
+        if (is_done || is_err) break;
+    }
+
+    dut->in_valid  = 0;
+    dut->in_last   = 0;
+    dut->out_ready = 0;
+    return output;
+}
+
+// ── Test helpers ──────────────────────────────────────────────────────────
+
+static void check_output(const char* test, const std::vector<uint8_t>& got,
+                          const std::vector<uint8_t>& expected) {
+    CHECK(got.size() == expected.size(),
+          "%s: output length %zu, expected %zu", test, got.size(), expected.size());
+    size_t n = got.size() < expected.size() ? got.size() : expected.size();
+    for (size_t i = 0; i < n; i++) {
+        CHECK(got[i] == expected[i],
+              "%s byte[%zu]: got 0x%02x, expected 0x%02x",
+              test, i, got[i], expected[i]);
+    }
+}
+
+// ── Test 1: Pure literals — "Hello" (5 bytes, no match) ──────────────────
+//
+// Compressed:  token=0x50 (lit=5, ml_raw=0)
+//              literals: 'H','e','l','l','o'   (in_last on 'o')
+// Expected out: H e l l o
+static void test1_pure_literals() {
+    printf("Test 1: pure literals — \"Hello\"\n");
+    reset();
+
+    // 0x50 = {lit=5, ml=0}
+    std::vector<uint8_t> input = { 0x50, 'H', 'e', 'l', 'l', 'o' };
+    std::vector<uint8_t> expected = { 'H', 'e', 'l', 'l', 'o' };
+    // in_last is on the last byte ('o')
+
+    // Annotate last byte manually via decode_block (it treats last element as in_last=1)
+    auto output = decode_block(input);
+    check_output("Test1", output, expected);
+
+    CHECK(!dut->error, "Test1: unexpected error");
+    printf("  output: ");
+    for (uint8_t b : output) printf("'%c'(0x%02x) ", (b >= 0x20 && b < 0x7f) ? (char)b : '.', b);
+    printf("\n  %s\n", g_errors == 0 ? "PASS" : "FAIL");
+}
+
+// ── Test 2: Literals + match copy + final literal — "abcdabcdX" (9 bytes) ─
+//
+// Sequence 1: token=0x40 (lit=4, ml_raw=0 → match_len=4)
+//             literals: a b c d
+//             offset: {0x04, 0x00} (LE) = 4 → copy a b c d from history
+// Sequence 2: token=0x10 (lit=1, ml_raw=0, last sequence — no match)
+//             literal: 'X' (in_last=1)
+// Expected: a b c d a b c d X
+static void test2_match_copy() {
+    printf("Test 2: match copy — \"abcdabcdX\"\n");
+    reset();
+
+    std::vector<uint8_t> input = {
+        0x40,                           // token: lit=4, ml=0
+        'a', 'b', 'c', 'd',            // 4 literals
+        0x04, 0x00,                     // offset = 4 (LE)
+        0x10,                           // token: lit=1, ml=0 (last sequence)
+        'X'                             // 1 literal, in_last=1 (last byte)
+    };
+    std::vector<uint8_t> expected = { 'a','b','c','d','a','b','c','d','X' };
+
+    auto output = decode_block(input);
+    check_output("Test2", output, expected);
+
+    CHECK(!dut->error, "Test2: unexpected error");
+    printf("  output: ");
+    for (uint8_t b : output) printf("'%c'(0x%02x) ", (b >= 0x20 && b < 0x7f) ? (char)b : '.', b);
+    printf("\n  %s\n", (g_errors == 0) ? "PASS" : "FAIL");
+}
+
+// ── Test 3: Run-length expansion — "aaaaaz" (1 lit + 4-byte run + 1 lit) ──
+//
+// LZ4 matches with offset=1 (copy from 1 byte back) implement run-length
+// encoding: the match read-pointer "chases" the write pointer, re-reading
+// the same byte as it is written. This is a valid and common LZ4 pattern.
+//
+// Sequence 1: token=0x10 (lit=1, ml_raw=0 → match_len=4)
+//             literal: 'a'          → history[0]='a', wr_ptr=1
+//             offset: {0x01, 0x00}  → mat_rd_ptr = 1-1 = 0
+//             match 4:  hist[0]='a', hist[1]='a', hist[2]='a', hist[3]='a'
+// Sequence 2: token=0x10 (lit=1, last)
+//             literal: 'z' (in_last=1)
+// Expected: a a a a a z
+static void test3_runlength_match() {
+    printf("Test 3: run-length match — \"aaaaaz\"\n");
+    reset();
+
+    std::vector<uint8_t> input = {
+        0x10,                           // token: lit=1, ml=0
+        'a',                            // 1 literal
+        0x01, 0x00,                     // offset = 1 (LE)
+        0x10,                           // token: lit=1, ml=0 (last sequence)
+        'z'                             // 1 literal, in_last=1
+    };
+    std::vector<uint8_t> expected = { 'a','a','a','a','a','z' };
+
+    auto output = decode_block(input);
+    check_output("Test3", output, expected);
+
+    CHECK(!dut->error, "Test3: unexpected error");
+    printf("  output: ");
+    for (uint8_t b : output) printf("'%c'(0x%02x) ", (b >= 0x20 && b < 0x7f) ? (char)b : '.', b);
+    printf("\n  %s\n", (g_errors == 0) ? "PASS" : "FAIL");
+}
+
+// ── Test 4: Error path — offset == 0 (invalid) ────────────────────────────
+//
+// LZ4 prohibits offset=0. Our decoder must latch error and hold it.
+static void test4_error_offset_zero() {
+    printf("Test 4: error path — offset == 0\n");
+    reset();
+
+    // Sequence: lit=1, then offset={0x00,0x00} (invalid)
+    std::vector<uint8_t> input = {
+        0x10,                           // token: lit=1, ml=0
+        'x',                            // 1 literal
+        0x00, 0x00,                     // offset = 0 (INVALID → should latch error)
+        // in_last is on 0x00 (last byte) — but error should latch first
+        // so this byte may not even be consumed
+    };
+    // Patch: last byte of sequence is the second 0x00 (in_last=1)
+    // decode_block will detect error and stop
+
+    auto output = decode_block(input);
+
+    // After offset-zero error, error flag must be latched
+    // (re-eval to ensure error is visible)
+    dut->clk = 0; dut->eval();
+    CHECK(dut->error, "Test4: expected error=1 for offset==0");
+    dut->clk = 1; dut->eval();
+
+    // error must persist across cycles without reset
+    for (int i = 0; i < 3; i++) {
+        dut->clk = 0; dut->eval();
+        CHECK(dut->error, "Test4: error should persist (cycle %d after error)", i);
+        dut->clk = 1; dut->eval();
+    }
+
+    // Reset should clear error
+    reset();
+    dut->clk = 0; dut->eval();
+    CHECK(!dut->error, "Test4: error should clear after reset");
+    dut->clk = 1; dut->eval();
+
+    printf("  %s\n", (g_errors == 0) ? "PASS" : "FAIL");
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────
+
+int main(int argc, char** argv) {
+    Verilated::commandArgs(argc, argv);
+    dut = new VLz4BlockDecoder;
+    dut->clk = 0;
+
+    printf("=== Lz4BlockDecoder testbench (CAST LZ4SNP-D analog) ===\n");
+
+    test1_pure_literals();
+    test2_match_copy();
+    test3_runlength_match();
+    test4_error_offset_zero();
+
+    printf("\n=== %s (%d error%s) ===\n",
+           g_errors == 0 ? "ALL TESTS PASSED" : "TESTS FAILED",
+           g_errors, g_errors == 1 ? "" : "s");
+
+    delete dut;
+    return g_errors ? 1 : 0;
+}


### PR DESCRIPTION
Adds `examples/lz4_block_decoder.arch` — an AXI-stream byte-wide LZ4 block decompressor implemented in ARCH.

## What's included

- **`lz4_block_decoder.arch`** — 8-state FSM (`READ_TOKEN`, `LIT_EXT`, `LIT_COPY`, `OFF_LO`, `OFF_HI`, `MAT_EXT`, `MAT_COPY`, `ERROR`), 256-byte circular history buffer, AXI-stream byte-wide I/O
- **`lz4_block_decoder.sv`** — deterministic SystemVerilog emitted by `arch build`
- **`lz4_block_decoder_tb.cpp`** — C++ testbench (`arch sim`) covering: pure literals, match copy, run-length expansion, and the offset-zero error path

Analog to the CAST LZ4SNP-D IP; intended as a reference example for ARCH HDL.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SYXCvMo7podQMQ9tYY3cHB)_