### PR TITLE
[codex] fix ARCH MCP workspace path resolution

### DIFF
--- a/mcp/arch_mcp_server.py
+++ b/mcp/arch_mcp_server.py
@@ -24,12 +24,13 @@ def _workspace_roots_from_env() -> list[pathlib.Path]:
     those repositories through ARCH_MCP_WORKSPACE_ROOTS as a colon-separated
     list of roots.
     """
-    roots = [PROJECT_ROOT]
     raw_roots = os.environ.get("ARCH_MCP_WORKSPACE_ROOTS", "")
+    roots = []
     for raw_root in raw_roots.split(os.pathsep):
         raw_root = raw_root.strip()
         if raw_root:
             roots.append(pathlib.Path(raw_root).expanduser())
+    roots.append(PROJECT_ROOT)
     return list(dict.fromkeys(root.resolve() for root in roots))
 
 
@@ -210,7 +211,17 @@ def doc_comments_spec() -> str:
 def _resolve_safe(path: str) -> pathlib.Path:
     """Resolve *path* and ensure it stays under an allowed workspace root."""
     raw_path = pathlib.Path(path).expanduser()
-    resolved = (raw_path if raw_path.is_absolute() else PROJECT_ROOT / raw_path).resolve()
+    if raw_path.is_absolute():
+        resolved = raw_path.resolve()
+    else:
+        for root in WORKSPACE_ROOTS:
+            candidate = (root / raw_path).resolve()
+            if candidate.exists():
+                resolved = candidate
+                break
+        else:
+            resolved = (WORKSPACE_ROOTS[0] / raw_path).resolve()
+
     for root in WORKSPACE_ROOTS:
         try:
             resolved.relative_to(root)


### PR DESCRIPTION
## Summary
- prefer `ARCH_MCP_WORKSPACE_ROOTS` over the bundled repo for relative workspace resolution
- resolve non-existent relative outputs like `.archgraph` into the caller workspace instead of `arch-com`
- keep `PROJECT_ROOT` as the fallback so bundled docs/resources still work

## Root Cause
The new MCP graph wrappers in `mcp/arch_mcp_server.py` documented cross-repo usage via `ARCH_MCP_WORKSPACE_ROOTS`, but relative paths were still resolved against `PROJECT_ROOT` first. That made `arch_graph_index(..., out=".archgraph")` and similar tools read from or write to the `arch-com` checkout instead of the caller's workspace.

## Validation
- Python stub repro for `_resolve_safe()` against a temp external workspace
- `python -m py_compile mcp/arch_mcp_server.py`
