### PR TITLE
Expose FSM state_r in native sim

### DIFF
--- a/src/sim_codegen/fsm.rs
+++ b/src/sim_codegen/fsm.rs
@@ -134,7 +134,8 @@ impl<'a> SimCodegen<'a> {
             let ty = cpp_port_type_with_params(flat_ty, &f.common.params);
             h.push_str(&format!("  {ty} {flat_name};\n"));
         }
-        // Datapath registers as public members (accessible from testbench)
+        // FSM state and datapath registers as public members (accessible from testbench)
+        h.push_str(&format!("  {state_ty} state_r;\n"));
         for reg in &f.regs {
             if let Some((elem_ty, count)) = vec_array_info_with_params(&reg.ty, &f.common.params) {
                 h.push_str(&format!("  {} {}[{}];\n", elem_ty, reg.name.name, count));
@@ -181,7 +182,11 @@ impl<'a> SimCodegen<'a> {
                     format!("{}(0)", r.name.name)
                 }
             }).collect();
-        let state_inits = vec!["_clk_prev(0)".to_string(), format!("_state_r({default_idx})")];
+        let state_inits = vec![
+            "_clk_prev(0)".to_string(),
+            format!("state_r({default_idx})"),
+            format!("_state_r({default_idx})"),
+        ];
         let all_inits: Vec<String> = port_inits.into_iter()
             .chain(vec_port_flat_inits)
             .chain(bus_flat_inits)
@@ -367,7 +372,7 @@ impl<'a> SimCodegen<'a> {
             }
             cpp.push_str("        break;\n");
         }
-        cpp.push_str("    }\n  }\n  _state_r = _n_state;\n");
+        cpp.push_str("    }\n  }\n  _state_r = _n_state;\n  state_r = _state_r;\n");
         // Commit datapath regs
         for reg in &f.regs {
             let n = &reg.name.name;

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -4963,13 +4963,20 @@ impl<'a> TypeChecker<'a> {
         }
 
         // `state` is reserved — the codegen maps it to the internal
-        // `state_r` register via ident_subst. A user port/signal named
-        // `state` would have its assignments rewritten to the enum-typed
-        // register, producing SV ENUMVALUE errors.
+        // `state_r` register via ident_subst. `state_r` is also reserved:
+        // SV/native codegen expose that compiler-owned state register name
+        // directly to support white-box probes. User declarations using either
+        // name would collide with generated state storage.
         for p in &f.ports {
             if p.name.name == "state" {
                 self.errors.push(CompileError::general(
                     "'state' is reserved in fsm (the codegen maps it to the internal state_r register). Rename the port (e.g. 'state_o').",
+                    p.name.span,
+                ));
+            }
+            if p.name.name == "state_r" {
+                self.errors.push(CompileError::general(
+                    "'state_r' is reserved in fsm for compiler-generated state storage. Rename the port (e.g. 'state_o').",
                     p.name.span,
                 ));
             }
@@ -4981,6 +4988,12 @@ impl<'a> TypeChecker<'a> {
                     r.name.span,
                 ));
             }
+            if r.name.name == "state_r" {
+                self.errors.push(CompileError::general(
+                    "'state_r' is reserved in fsm for compiler-generated state storage. Rename the signal.",
+                    r.name.span,
+                ));
+            }
         }
         for w in &f.wires {
             if w.name.name == "state" {
@@ -4989,11 +5002,23 @@ impl<'a> TypeChecker<'a> {
                     w.name.span,
                 ));
             }
+            if w.name.name == "state_r" {
+                self.errors.push(CompileError::general(
+                    "'state_r' is reserved in fsm for compiler-generated state storage. Rename the signal.",
+                    w.name.span,
+                ));
+            }
         }
         for l in &f.lets {
             if l.name.name == "state" {
                 self.errors.push(CompileError::general(
                     "'state' is reserved in fsm. Rename the binding.",
+                    l.name.span,
+                ));
+            }
+            if l.name.name == "state_r" {
+                self.errors.push(CompileError::general(
+                    "'state_r' is reserved in fsm for compiler-generated state storage. Rename the binding.",
                     l.name.span,
                 ));
             }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -435,6 +435,40 @@ end fsm BadFsm
     assert!(result.is_err(), "fsm with port named 'state' should error");
 }
 
+#[test]
+fn test_fsm_port_named_state_r_errors() {
+    // `state_r` is compiler-owned FSM state storage in both SV and native sim.
+    // User declarations with that name would collide with generated state.
+    let source = r#"
+fsm BadFsm
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port state_r: out UInt<2>;
+  state [A, B]
+  default state A;
+  state A
+    comb
+      state_r = 2'd0;
+    end comb
+    -> B when true;
+  end state A
+  state B
+    comb
+      state_r = 2'd1;
+    end comb
+    -> A when true;
+  end state B
+end fsm BadFsm
+"#;
+    let tokens = lexer::tokenize(source).expect("lex");
+    let mut parser = Parser::new(tokens, source);
+    let ast = parser.parse_source_file().expect("parse");
+    let symbols = resolve::resolve(&ast).expect("resolve");
+    let checker = TypeChecker::new(&symbols, &ast);
+    let result = checker.check();
+    assert!(result.is_err(), "fsm with port named 'state_r' should error");
+}
+
 // ── FIFO ──────────────────────────────────────────────────────────────────────
 
 #[test]
@@ -24876,6 +24910,35 @@ fn test_native_sim_bool_not_pipe_reg_outputs_and_ampamp() {
     assert!(
         !generated_cpp.contains("0xffULL") && !generated_cpp.contains("0xFFULL"),
         "Bool `not` should not be reduced as an 8-bit all-ones value:\n{generated_cpp}"
+    );
+}
+
+#[test]
+fn test_native_sim_fsm_state_r_is_public_and_synced() {
+    // HARC and SV-style white-box probes read `dut.state_r` for FSMs. Native
+    // sim already traced this name, but only generated a private `_state_r`,
+    // so generated C++ testbenches failed to compile when probing state.
+    let td = tempfile::tempdir().expect("tempdir");
+    let arch_bin = env!("CARGO_BIN_EXE_arch");
+    let out = std::process::Command::new(arch_bin)
+        .arg("sim")
+        .arg("tests/native_fsm_state_r/Probe.arch")
+        .arg("--tb")
+        .arg("tests/native_fsm_state_r/tb.cpp")
+        .arg("--outdir")
+        .arg(td.path())
+        .output()
+        .expect("run arch sim for native FSM state_r probe");
+    assert!(
+        out.status.success(),
+        "native FSM state_r probe should compile + run\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&out.stdout).contains("PASS native FSM state_r probe"),
+        "expected PASS marker in stdout:\n{}",
+        String::from_utf8_lossy(&out.stdout)
     );
 }
 

--- a/tests/native_fsm_state_r/Probe.arch
+++ b/tests/native_fsm_state_r/Probe.arch
@@ -1,0 +1,44 @@
+//! ---
+//! tags: [native-sim, fsm, state-probe]
+//! ---
+//!
+//! Regression fixture for native C++ FSM state exposure. The testbench reads
+//! the generated public `state_r` field the same way SV-style white-box probes do.
+
+/// Small FSM used to verify native sim exposes its current state to testbenches.
+fsm FsmStateProbe
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync, High>;
+  port advance: in Bool;
+  port state_code: out UInt<2>;
+
+  state [Idle, Busy, Done]
+  default state Idle;
+
+  default
+    comb
+      state_code = 0;
+    end comb
+  end default
+
+  state Idle
+    comb
+      state_code = 0;
+    end comb
+    -> Busy when advance;
+  end state Idle
+
+  state Busy
+    comb
+      state_code = 1;
+    end comb
+    -> Done when advance;
+  end state Busy
+
+  state Done
+    comb
+      state_code = 2;
+    end comb
+    -> Idle when advance;
+  end state Done
+end fsm FsmStateProbe

--- a/tests/native_fsm_state_r/tb.cpp
+++ b/tests/native_fsm_state_r/tb.cpp
@@ -1,0 +1,48 @@
+#include "VFsmStateProbe.h"
+#include <cstdio>
+
+static int pass = 0;
+static int fail = 0;
+
+#define CHECK(cond, msg, ...) do { \
+    if (cond) { std::printf("  PASS: " msg "\n", ##__VA_ARGS__); ++pass; } \
+    else { std::printf("  FAIL: " msg "\n", ##__VA_ARGS__); ++fail; } \
+} while (0)
+
+static void tick(VFsmStateProbe& dut) {
+    dut.clk = 0;
+    dut.eval();
+    dut.clk = 1;
+    dut.eval();
+    dut.clk = 0;
+    dut.eval();
+}
+
+int main() {
+    VFsmStateProbe dut;
+
+    dut.rst = 1;
+    dut.advance = 0;
+    tick(dut);
+    CHECK(dut.state_r == VFsmStateProbe::STATE_IDLE, "reset exposes Idle on state_r");
+    CHECK(dut.state_code == 0, "Idle drives state_code 0");
+
+    dut.rst = 0;
+    tick(dut);
+    CHECK(dut.state_r == VFsmStateProbe::STATE_IDLE, "state_r holds Idle without advance");
+
+    dut.advance = 1;
+    tick(dut);
+    CHECK(dut.state_r == VFsmStateProbe::STATE_BUSY, "state_r advances to Busy");
+    CHECK(dut.state_code == 1, "Busy drives state_code 1");
+
+    tick(dut);
+    CHECK(dut.state_r == VFsmStateProbe::STATE_DONE, "state_r advances to Done");
+    CHECK(dut.state_code == 2, "Done drives state_code 2");
+
+    tick(dut);
+    CHECK(dut.state_r == VFsmStateProbe::STATE_IDLE, "state_r wraps back to Idle");
+
+    std::printf("PASS native FSM state_r probe: %d pass / %d fail\n", pass, fail);
+    return fail == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary
- expose a public `state_r` mirror in generated native-sim FSM classes
- keep the internal `_state_r` state machine implementation and trace mapping intact
- reserve user-declared FSM `state_r` names so generated state storage cannot collide
- add native-sim and typecheck regressions

## Validation
- `cargo test -q test_native_sim_fsm_state_r_is_public_and_synced -- --nocapture`
- `cargo test -q test_fsm_port_named_state_r_errors -- --nocapture`
- `cargo build --release -q`
- `git diff --check origin/main...HEAD`

## Local Review
- Reviewed `git diff origin/main...HEAD`; finding found and fixed: user-declared FSM `state_r` could collide with generated public state storage. Added typecheck guard and regression before marking review complete.