### PR TITLE
feat: FP32/BF16 floating-point types (v1)

### DIFF
--- a/doc/plan_fp_types.md
+++ b/doc/plan_fp_types.md
@@ -480,8 +480,34 @@ Landed and tested (`cargo test --test fp_test`, plus the full suite green):
    special-value policy is implemented in the sim helpers; `arch formal` rejects
    FP types with a clear message.
 4. **Float literals default to `FP32`**; `BF16` immediates use `.to_bf16()`
-   (§3.3, resolved open question — keeps no-implicit-conversion uniform). Floats
-   inside `function` bodies are not yet float-dispatched (module scope only).
+   (§3.3, resolved open question — keeps no-implicit-conversion uniform).
+
+### v1 scope restrictions (enforced — rejected, never miscompiled)
+
+Floats are supported only as **scalar** module signals (ports, `reg`, `wire`,
+`let`) and the operations on them. The float-op dispatch in the backends keys
+off a per-signal name→format map, so positions it can't resolve are **rejected
+at type-check** rather than silently emitting integer arithmetic on the bit
+pattern:
+
+- **`Vec<FP32/BF16, N>`** — rejected (element access can't be float-dispatched).
+- **Float `struct` fields** — rejected (field access can't be float-dispatched).
+- **Floats in module-local `function` signatures/bodies** — rejected (function
+  scope isn't threaded into the dispatch map).
+
+Each has a clear error and is a natural follow-up once dispatch is driven off the
+type-checker's resolved-type map instead of a backend-rebuilt name set. Also: a
+float `reg`'s reset value must be a **float literal** (`reset rst => 0.0`); an
+integer literal is rejected (it would store a bit pattern, not the value).
+
+### Conversion semantics (sim, validated)
+
+`float→int` (`.to_uint<N>()` / `.to_sint<N>()`) is toward-zero, **saturating to
+the N-bit target range**, NaN→type-max — verified for N<64 and at the bound. The
+SV emission of float→int is **behavioral and ≤32-bit** (`$rtoi`); full per-N
+saturation and >32-bit conversions ride with the synthesizable datapath
+follow-up. (No local SV simulator was available, so the emitted SV is
+structurally checked but not run in-tree.)
 
 These deltas keep v1 faithful to the *semantics* (IEEE-754 RNE, the special-value
 policy, no implicit conversions) while deferring the heavyweight infrastructure

--- a/doc/plan_fp_types.md
+++ b/doc/plan_fp_types.md
@@ -1,7 +1,8 @@
 # Plan: Floating-Point Types for LLM Inference (`FP32`, `BF16`)
 
-Status: **draft / design** — no code yet.
-Scope owner: TBD. Tracking issue: TBD (sibling of #605).
+Status: **v1 implemented** (front-end + simulation + SV emission, tested). See
+§12 for the implementation status and the deltas from this design.
+Tracking issue: #609 (sibling of #605).
 
 ## 1. Goal and scope
 
@@ -439,3 +440,49 @@ vectors against our configured instance once, in CI.
 Future (out of scope): FP16/FP8/MX block formats (reuse the generic
 `Float{exp,mant}` + a `Block<Elem,K,Scale>` wrapper), pipelined latency-N FP
 units, exception flags, additional rounding modes, FTZ.
+
+## 12. Implementation status (v1)
+
+Landed and tested (`cargo test --test fp_test`, plus the full suite green):
+
+- **Front-end**: `FP32`/`BF16` type keywords, float literals (`1.5`, `3.0e-2`),
+  and the operator/conversion surface parse and type-check. No-implicit-float-
+  conversion is enforced at assignment and in operators (mixing `FP32`/`BF16`,
+  or float↔int without a cast, is a compile error). Built-ins `fma(a,b,c)` and
+  `is_nan(x)` are typed. `Ty::FP32`/`Ty::BF16` carry 32/16-bit widths.
+- **Operators**: built-in combinational `+ - *` and ordered compares (`==` `!=`
+  `<` `>` `<=` `>=` → `Bool`); `fma` (fused); conversions `.to_fp32()`,
+  `.to_bf16()`, `.to_uint<N>()`, `.to_sint<N>()` (float↔float, int↔float).
+- **Simulation** (`arch sim`): floats carried as bit patterns
+  (`uint32_t`/`uint16_t`); ops dispatch to `_arch_*` helpers in the generated
+  prelude. NaN canonicalized to `0x7FC00000`/`0x7FC0`; sNaN quieted;
+  float→int toward-zero, saturating, NaN→type-max. Verified bit-exact against
+  host IEEE-754 across arithmetic, fma, is_nan, NaN/sNaN, and all conversions.
+- **SystemVerilog** (`arch build`): `FP32`→`logic [31:0]`, `BF16`→`logic [15:0]`;
+  ops dispatch to emitted `arch_f32_*`/`arch_bf16_*` `function automatic`
+  helpers, prepended once per file when FP is used.
+
+### Deltas from the design above (deliberate v1 simplifications)
+
+1. **Sim uses the host FPU, not a linked Berkeley SoftFloat** (§5). Native
+   `float`/`double` arithmetic is IEEE-754 RNE and therefore bit-identical to
+   SoftFloat for `+ - * fma` and the conversions; this avoids vendoring/building
+   the C library for v1. BF16 goes through an f32 intermediate (innocuous double
+   rounding, 24 ≥ 2·8+2 — a tighter but equally valid form of §5.3's f64 route).
+   Swapping in the RISC-V-spec SoftFloat build behind the same helper names is a
+   drop-in hardening step.
+2. **SV helpers are behavioral, not the synthesizable CVFPU datapath** (§7).
+   They use `shortreal`/`$bitstoshortreal`/`$shortrealtobits` — correct for
+   simulation, not synthesis. The hand-written CVFPU-referenced RTL is the P2/P3
+   follow-up. (No local SV simulator was available to run them in-tree.)
+3. **`--fp-compat=cuda` (§6.2), the formal equivalence proof (§8), and the
+   differential Verilator campaign are not yet wired** — the default RISC-V
+   special-value policy is implemented in the sim helpers; `arch formal` rejects
+   FP types with a clear message.
+4. **Float literals default to `FP32`**; `BF16` immediates use `.to_bf16()`
+   (§3.3, resolved open question — keeps no-implicit-conversion uniform). Floats
+   inside `function` bodies are not yet float-dispatched (module scope only).
+
+These deltas keep v1 faithful to the *semantics* (IEEE-754 RNE, the special-value
+policy, no implicit conversions) while deferring the heavyweight infrastructure
+(SoftFloat vendor build, synthesizable FP datapath, SMT proofs) to follow-ups.

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1046,6 +1046,10 @@ pub enum TypeExpr {
     Reset(ResetKind, ResetLevel),
     Vec(Box<TypeExpr>, Box<Expr>),
     Named(Ident),
+    /// IEEE-754 binary32 floating point (1 sign + 8 exp + 23 mant = 32 bits).
+    FP32,
+    /// bfloat16 (1 sign + 8 exp + 7 mant = 16 bits).
+    BF16,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1155,6 +1159,12 @@ pub enum LitKind {
     Hex(u64),
     Bin(u64),
     Sized(u32, u64), // width, value
+    /// Floating-point literal, e.g. `1.5`, `3.0e-2`. The decimal value is
+    /// parsed to an f64 (exact enough for source literals); the concrete
+    /// FP32/BF16 bit pattern is produced by rounding to the context type at
+    /// lowering. Stored as raw bits so the AST stays `Clone`/`Debug` without
+    /// pulling float `PartialEq` semantics into derived comparisons.
+    Float(u64), // f64::to_bits of the parsed literal value
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -127,8 +127,12 @@ enum GroupKind {
 /// widen to f32, compute, and round once to bf16 (innocuous double rounding).
 const FP_SV_HELPERS: &str = r#"// ── arch floating-point helpers (behavioral; see doc/plan_fp_types.md §7) ──
 function automatic logic [15:0] arch_f32bits_to_bf16(input logic [31:0] x);
+  logic [31:0] rounded;
   if ((x[30:23] == 8'hFF) && (x[22:0] != 23'b0)) arch_f32bits_to_bf16 = 16'h7FC0;
-  else arch_f32bits_to_bf16 = (x + 32'h00007FFF + {31'b0, x[16]})[31:16];
+  else begin
+    rounded = x + 32'h00007FFF + {31'b0, x[16]};
+    arch_f32bits_to_bf16 = rounded[31:16];
+  end
 endfunction
 function automatic logic [31:0] arch_f32_canon(input logic [31:0] x);
   arch_f32_canon = ((x[30:23] == 8'hFF) && (x[22:0] != 23'b0)) ? 32'h7FC00000 : x;

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -118,6 +118,90 @@ enum GroupKind {
     },
 }
 
+/// Behavioral SystemVerilog floating-point helper functions, emitted at
+/// compilation-unit ($unit) scope when a design uses FP32/BF16 ops. These are
+/// **simulation-oriented** (they use `$bitstoshortreal`/`$shortrealtobits` and
+/// `shortreal` arithmetic, which model IEEE-754 binary32). A synthesizable,
+/// CVFPU-referenced datapath replacing these is the documented P2/P3 follow-up
+/// (doc/plan_fp_types.md §7). Floats are carried as raw bit vectors; BF16 ops
+/// widen to f32, compute, and round once to bf16 (innocuous double rounding).
+const FP_SV_HELPERS: &str = r#"// ── arch floating-point helpers (behavioral; see doc/plan_fp_types.md §7) ──
+function automatic logic [15:0] arch_f32bits_to_bf16(input logic [31:0] x);
+  if ((x[30:23] == 8'hFF) && (x[22:0] != 23'b0)) arch_f32bits_to_bf16 = 16'h7FC0;
+  else arch_f32bits_to_bf16 = (x + 32'h00007FFF + {31'b0, x[16]})[31:16];
+endfunction
+function automatic logic [31:0] arch_f32_canon(input logic [31:0] x);
+  arch_f32_canon = ((x[30:23] == 8'hFF) && (x[22:0] != 23'b0)) ? 32'h7FC00000 : x;
+endfunction
+function automatic logic [31:0] arch_f32_add(input logic [31:0] a, input logic [31:0] b);
+  arch_f32_add = arch_f32_canon($shortrealtobits($bitstoshortreal(a) + $bitstoshortreal(b)));
+endfunction
+function automatic logic [31:0] arch_f32_sub(input logic [31:0] a, input logic [31:0] b);
+  arch_f32_sub = arch_f32_canon($shortrealtobits($bitstoshortreal(a) - $bitstoshortreal(b)));
+endfunction
+function automatic logic [31:0] arch_f32_mul(input logic [31:0] a, input logic [31:0] b);
+  arch_f32_mul = arch_f32_canon($shortrealtobits($bitstoshortreal(a) * $bitstoshortreal(b)));
+endfunction
+function automatic logic [31:0] arch_fma_f32(input logic [31:0] a, input logic [31:0] b, input logic [31:0] c);
+  arch_fma_f32 = arch_f32_canon($shortrealtobits($bitstoshortreal(a) * $bitstoshortreal(b) + $bitstoshortreal(c)));
+endfunction
+function automatic logic arch_f32_eq(input logic [31:0] a, input logic [31:0] b);
+  arch_f32_eq = ($bitstoshortreal(a) == $bitstoshortreal(b));
+endfunction
+function automatic logic arch_f32_ne(input logic [31:0] a, input logic [31:0] b);
+  arch_f32_ne = ($bitstoshortreal(a) != $bitstoshortreal(b));
+endfunction
+function automatic logic arch_f32_lt(input logic [31:0] a, input logic [31:0] b);
+  arch_f32_lt = ($bitstoshortreal(a) < $bitstoshortreal(b));
+endfunction
+function automatic logic arch_f32_gt(input logic [31:0] a, input logic [31:0] b);
+  arch_f32_gt = ($bitstoshortreal(a) > $bitstoshortreal(b));
+endfunction
+function automatic logic arch_f32_le(input logic [31:0] a, input logic [31:0] b);
+  arch_f32_le = ($bitstoshortreal(a) <= $bitstoshortreal(b));
+endfunction
+function automatic logic arch_f32_ge(input logic [31:0] a, input logic [31:0] b);
+  arch_f32_ge = ($bitstoshortreal(a) >= $bitstoshortreal(b));
+endfunction
+function automatic logic [31:0] arch_bf16_to_f32(input logic [15:0] h);
+  arch_bf16_to_f32 = arch_f32_canon({h, 16'b0});
+endfunction
+function automatic logic [15:0] arch_f32_to_bf16(input logic [31:0] x);
+  arch_f32_to_bf16 = arch_f32bits_to_bf16(x);
+endfunction
+function automatic logic [15:0] arch_bf16_add(input logic [15:0] a, input logic [15:0] b);
+  arch_bf16_add = arch_f32bits_to_bf16($shortrealtobits($bitstoshortreal({a,16'b0}) + $bitstoshortreal({b,16'b0})));
+endfunction
+function automatic logic [15:0] arch_bf16_sub(input logic [15:0] a, input logic [15:0] b);
+  arch_bf16_sub = arch_f32bits_to_bf16($shortrealtobits($bitstoshortreal({a,16'b0}) - $bitstoshortreal({b,16'b0})));
+endfunction
+function automatic logic [15:0] arch_bf16_mul(input logic [15:0] a, input logic [15:0] b);
+  arch_bf16_mul = arch_f32bits_to_bf16($shortrealtobits($bitstoshortreal({a,16'b0}) * $bitstoshortreal({b,16'b0})));
+endfunction
+function automatic logic [15:0] arch_fma_bf16(input logic [15:0] a, input logic [15:0] b, input logic [15:0] c);
+  arch_fma_bf16 = arch_f32bits_to_bf16($shortrealtobits($bitstoshortreal({a,16'b0}) * $bitstoshortreal({b,16'b0}) + $bitstoshortreal({c,16'b0})));
+endfunction
+function automatic logic arch_bf16_eq(input logic [15:0] a, input logic [15:0] b);
+  arch_bf16_eq = ($bitstoshortreal({a,16'b0}) == $bitstoshortreal({b,16'b0}));
+endfunction
+function automatic logic arch_bf16_ne(input logic [15:0] a, input logic [15:0] b);
+  arch_bf16_ne = ($bitstoshortreal({a,16'b0}) != $bitstoshortreal({b,16'b0}));
+endfunction
+function automatic logic arch_bf16_lt(input logic [15:0] a, input logic [15:0] b);
+  arch_bf16_lt = ($bitstoshortreal({a,16'b0}) < $bitstoshortreal({b,16'b0}));
+endfunction
+function automatic logic arch_bf16_gt(input logic [15:0] a, input logic [15:0] b);
+  arch_bf16_gt = ($bitstoshortreal({a,16'b0}) > $bitstoshortreal({b,16'b0}));
+endfunction
+function automatic logic arch_bf16_le(input logic [15:0] a, input logic [15:0] b);
+  arch_bf16_le = ($bitstoshortreal({a,16'b0}) <= $bitstoshortreal({b,16'b0}));
+endfunction
+function automatic logic arch_bf16_ge(input logic [15:0] a, input logic [15:0] b);
+  arch_bf16_ge = ($bitstoshortreal({a,16'b0}) >= $bitstoshortreal({b,16'b0}));
+endfunction
+
+"#;
+
 pub struct Codegen<'a> {
     pub symbols: &'a SymbolTable,
     pub source: &'a SourceFile,
@@ -158,6 +242,9 @@ pub struct Codegen<'a> {
     bus_wires: std::collections::HashMap<String, String>,
     /// Reset port names in the current module → (kind, level), for `.asserted` emission.
     reset_ports: std::collections::HashMap<String, (ResetKind, ResetLevel)>,
+    /// Set when any FP32/BF16 operation was emitted, so the `arch_f32_*` /
+    /// `arch_bf16_*` SystemVerilog helper package is prepended to the output.
+    fp_helpers_used: std::cell::Cell<bool>,
     /// Name of the construct currently being emitted (for symbol lookups).
     current_construct: String,
     /// Context-sensitive identifier substitutions.
@@ -240,6 +327,7 @@ impl<'a> Codegen<'a> {
             current_module_params: Vec::new(),
             bus_wires: std::collections::HashMap::new(),
             reset_ports: std::collections::HashMap::new(),
+            fp_helpers_used: std::cell::Cell::new(false),
             current_construct: String::new(),
             ident_subst: std::collections::HashMap::new(),
             loop_var_subst: std::collections::HashMap::new(),
@@ -427,6 +515,13 @@ impl<'a> Codegen<'a> {
                 ));
             }
             prefix.push('\n');
+            prefix.push_str(&self.out);
+            self.out = prefix;
+        }
+
+        // Prepend the floating-point helper functions if any FP op was emitted.
+        if self.fp_helpers_used.get() {
+            let mut prefix = String::from(FP_SV_HELPERS);
             prefix.push_str(&self.out);
             self.out = prefix;
         }
@@ -1751,6 +1846,90 @@ impl<'a> Codegen<'a> {
         }
     }
 
+    /// Floating-point format of an expression in the current scope, if any.
+    /// Drives dispatch of `+ - *` / comparisons / conversions to the emitted
+    /// `arch_f32_*` / `arch_bf16_*` SystemVerilog helper functions.
+    fn expr_float_fmt(&self, expr: &Expr) -> Option<&'static str> {
+        match &expr.kind {
+            ExprKind::Cast(_, ty) => match &**ty {
+                TypeExpr::FP32 => Some("f32"),
+                TypeExpr::BF16 => Some("bf16"),
+                _ => None,
+            },
+            ExprKind::Ident(name) => self.ident_float_fmt(name),
+            ExprKind::Literal(LitKind::Float(_)) => Some("f32"),
+            ExprKind::MethodCall(_, method, _) => match method.name.as_str() {
+                "to_fp32" => Some("f32"),
+                "to_bf16" => Some("bf16"),
+                _ => None,
+            },
+            ExprKind::FunctionCall(name, args) if name == "fma" =>
+                args.first().and_then(|a| self.expr_float_fmt(a)),
+            ExprKind::Binary(op, lhs, rhs) => match op {
+                BinOp::Add | BinOp::Sub | BinOp::Mul =>
+                    self.expr_float_fmt(lhs).or_else(|| self.expr_float_fmt(rhs)),
+                _ => None,
+            },
+            ExprKind::Ternary(_, t, e) => self.expr_float_fmt(t).or_else(|| self.expr_float_fmt(e)),
+            _ => None,
+        }
+    }
+
+    /// Float format of an identifier declared in the current construct's scope.
+    fn ident_float_fmt(&self, name: &str) -> Option<&'static str> {
+        if let Some(scope) = self.symbols.module_scopes.get(&self.current_construct) {
+            if let Some((sym, _)) = scope.get(name) {
+                let ty = match sym {
+                    Symbol::Port(p) => Some(&p.ty),
+                    Symbol::Reg(r) => Some(&r.ty),
+                    _ => None,
+                };
+                if let Some(ty) = ty {
+                    return match ty {
+                        TypeExpr::FP32 => Some("f32"),
+                        TypeExpr::BF16 => Some("bf16"),
+                        _ => None,
+                    };
+                }
+                if matches!(sym, Symbol::Let(_)) {
+                    return self.let_binding_float_fmt(name);
+                }
+            }
+        }
+        None
+    }
+
+    /// Float format of a `let` binding by AST lookup (modules + fsms).
+    fn let_binding_float_fmt(&self, name: &str) -> Option<&'static str> {
+        let fmt_of = |t: &TypeExpr| match t {
+            TypeExpr::FP32 => Some("f32"),
+            TypeExpr::BF16 => Some("bf16"),
+            _ => None,
+        };
+        for item in &self.source.items {
+            match item {
+                Item::Module(m) if m.name.name == self.current_construct => {
+                    for bi in &m.body {
+                        if let ModuleBodyItem::LetBinding(l) = bi {
+                            if l.name.name == name {
+                                return l.ty.as_ref().and_then(|t| fmt_of(t));
+                            }
+                        }
+                    }
+                }
+                Item::Fsm(f) if f.name.name == self.current_construct => {
+                    for l in &f.lets {
+                        if l.name.name == name {
+                            return l.ty.as_ref().and_then(|t| fmt_of(t));
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+        None
+    }
+
     /// Check if an identifier is declared as SInt in the current construct's scope.
     fn ident_is_sint(&self, name: &str) -> bool {
         if let Some(scope) = self.symbols.module_scopes.get(&self.current_construct) {
@@ -1814,6 +1993,7 @@ impl<'a> Codegen<'a> {
                     let val = match lit {
                         LitKind::Dec(v) | LitKind::Hex(v) | LitKind::Bin(v) => *v as i64,
                         LitKind::Sized(_, v) => *v as i64,
+                        LitKind::Float(_) => return None, // not an integer constant
                     };
                     Some(val)
                 }
@@ -1845,6 +2025,7 @@ impl<'a> Codegen<'a> {
                 ExprKind::Literal(lit) => match lit {
                     LitKind::Dec(v) | LitKind::Hex(v) | LitKind::Bin(v) => format!("{v}"),
                     LitKind::Sized(w, v) => format!("{w}'{v}"),
+                    LitKind::Float(bits) => format!("f{bits}"),
                 },
                 ExprKind::Binary(op, lhs, rhs) => {
                     format!("({} {:?} {})", expr_key(lhs), op, expr_key(rhs))
@@ -1862,6 +2043,7 @@ impl<'a> Codegen<'a> {
                     let val = match lit {
                         LitKind::Dec(v) | LitKind::Hex(v) | LitKind::Bin(v) => *v as i64,
                         LitKind::Sized(_, v) => *v as i64,
+                        LitKind::Float(_) => { terms.push((sign, None, expr_key(expr))); return; }
                     };
                     terms.push((sign, Some(val), String::new()));
                 }
@@ -1963,6 +2145,8 @@ impl<'a> Codegen<'a> {
             TypeExpr::Bool | TypeExpr::Bit | TypeExpr::Clock(_) | TypeExpr::Reset(_, _) => {
                 Some("1".to_string())
             }
+            TypeExpr::FP32 => Some("32".to_string()),
+            TypeExpr::BF16 => Some("16".to_string()),
             TypeExpr::Vec(inner, size) => {
                 let iw = self.type_expr_data_width(inner)?;
                 let n = self.emit_expr_str(size);
@@ -4187,6 +4371,8 @@ impl<'a> Codegen<'a> {
         match ty {
             TypeExpr::UInt(w) | TypeExpr::SInt(w) => eval(w),
             TypeExpr::Bool | TypeExpr::Bit | TypeExpr::Clock(_) | TypeExpr::Reset(_, _) => Some(1),
+            TypeExpr::FP32 => Some(32),
+            TypeExpr::BF16 => Some(16),
             TypeExpr::Vec(inner, size) => {
                 let iw = self.type_expr_width(inner)?;
                 let n = eval(size)?;
@@ -4640,6 +4826,8 @@ impl<'a> Codegen<'a> {
                 LitKind::Hex(v) => format!("'h{v:X}"),
                 LitKind::Bin(v) => format!("'b{v:b}"),
                 LitKind::Sized(w, v) => format!("{w}'d{v}"),
+                // Float literal (FP32 by default) → 32-bit binary32 bit pattern.
+                LitKind::Float(bits) => format!("32'h{:08X}", (f64::from_bits(*bits) as f32).to_bits()),
             },
             ExprKind::Bool(true) => "1'b1".to_string(),
             ExprKind::Bool(false) => "1'b0".to_string(),
@@ -4659,6 +4847,23 @@ impl<'a> Codegen<'a> {
                 name.clone()
             }
             ExprKind::Binary(op, lhs, rhs) => {
+                // Floating-point operands dispatch to the emitted `arch_f32_*` /
+                // `arch_bf16_*` SystemVerilog helper functions.
+                if let Some(fmt) = self.expr_float_fmt(lhs).or_else(|| self.expr_float_fmt(rhs)) {
+                    let fop = match op {
+                        BinOp::Add => Some("add"), BinOp::Sub => Some("sub"), BinOp::Mul => Some("mul"),
+                        BinOp::Eq => Some("eq"), BinOp::Neq => Some("ne"),
+                        BinOp::Lt => Some("lt"), BinOp::Gt => Some("gt"),
+                        BinOp::Lte => Some("le"), BinOp::Gte => Some("ge"),
+                        _ => None,
+                    };
+                    if let Some(fop) = fop {
+                        self.fp_helpers_used.set(true);
+                        let l = self.emit_expr_prec(lhs, 0);
+                        let r = self.emit_expr_prec(rhs, 0);
+                        return format!("arch_{fmt}_{fop}({l}, {r})");
+                    }
+                }
                 // `implies` lowers to (!lhs || rhs)
                 if *op == BinOp::Implies {
                     let l = self.emit_expr_prec(lhs, 14); // unary prec for !
@@ -4915,6 +5120,40 @@ impl<'a> Codegen<'a> {
                     | "find_first" => {
                         self.emit_vec_method(&b, base, method, args)
                     }
+                    // Float conversions → emitted helper functions.
+                    "to_fp32" => {
+                        self.fp_helpers_used.set(true);
+                        match self.expr_float_fmt(base) {
+                            Some("bf16") => format!("arch_bf16_to_f32({b})"),
+                            Some("f32") => b,
+                            _ => {
+                                let src = if self.expr_is_signed(base) { format!("$signed({b})") } else { format!("$unsigned({b})") };
+                                format!("$shortrealtobits(shortreal'({src}))")
+                            }
+                        }
+                    }
+                    "to_bf16" => {
+                        self.fp_helpers_used.set(true);
+                        match self.expr_float_fmt(base) {
+                            Some("f32") => format!("arch_f32_to_bf16({b})"),
+                            Some("bf16") => b,
+                            _ => {
+                                let src = if self.expr_is_signed(base) { format!("$signed({b})") } else { format!("$unsigned({b})") };
+                                format!("arch_f32_to_bf16($shortrealtobits(shortreal'({src})))")
+                            }
+                        }
+                    }
+                    "to_uint" | "to_sint" => {
+                        self.fp_helpers_used.set(true);
+                        let width = args.first().map(|w| self.emit_expr_str(w)).unwrap_or_else(|| "32".to_string());
+                        let wp = Self::paren_width(&width);
+                        let f32bits = match self.expr_float_fmt(base) {
+                            Some("bf16") => format!("arch_bf16_to_f32({b})"),
+                            _ => b.clone(),
+                        };
+                        // Toward-zero via $rtoi on the decoded shortreal.
+                        format!("{wp}'($rtoi($bitstoshortreal({f32bits})))")
+                    }
                     _ => format!("{b}.{}()", method.name),
                 }
             }
@@ -5153,6 +5392,23 @@ impl<'a> Codegen<'a> {
                 if name == "past" || name == "rose" || name == "fell" {
                     return format!("${name}({})", arg_strs.join(", "));
                 }
+                // Float intrinsics → emitted helper functions.
+                if name == "fma" && args.len() == 3 {
+                    self.fp_helpers_used.set(true);
+                    let fmt = self.expr_float_fmt(&args[0])
+                        .or_else(|| self.expr_float_fmt(&args[1]))
+                        .or_else(|| self.expr_float_fmt(&args[2]))
+                        .unwrap_or("f32");
+                    return format!("arch_fma_{fmt}({})", arg_strs.join(", "));
+                }
+                if name == "is_nan" && args.len() == 1 {
+                    // exponent all-ones and mantissa nonzero.
+                    let a = &arg_strs[0];
+                    return match self.expr_float_fmt(&args[0]) {
+                        Some("bf16") => format!("(({a}[14:7] == 8'hFF) && ({a}[6:0] != 7'b0))"),
+                        _ => format!("(({a}[30:23] == 8'hFF) && ({a}[22:0] != 23'b0))"),
+                    };
+                }
                 // Resolve mangled name if this is an overloaded function.
                 let sv_name = if let Some((Symbol::Function(overloads), _)) = self.symbols.globals.get(name) {
                     if overloads.len() > 1 {
@@ -5212,6 +5468,10 @@ impl<'a> Codegen<'a> {
             }
             TypeExpr::Bool => "logic".to_string(),
             TypeExpr::Bit => "logic".to_string(),
+            // Floats are carried as packed bit vectors (the FP unit modules
+            // operate on the raw [W-1:0] bit pattern).
+            TypeExpr::FP32 => "logic [31:0]".to_string(),
+            TypeExpr::BF16 => "logic [15:0]".to_string(),
             TypeExpr::Clock(_) => "logic".to_string(),
             TypeExpr::Reset(_, _) => "logic".to_string(),
             TypeExpr::Vec(_, _) => {

--- a/src/construct_proof_cert.rs
+++ b/src/construct_proof_cert.rs
@@ -289,6 +289,8 @@ fn type_width_u64(ty: &TypeExpr) -> Result<u64, String> {
     match ty {
         TypeExpr::UInt(width) | TypeExpr::SInt(width) => const_expr_u64(width),
         TypeExpr::Bool | TypeExpr::Bit => Ok(1),
+        TypeExpr::FP32 => Ok(32),
+        TypeExpr::BF16 => Ok(16),
         TypeExpr::Vec(elem, len) => {
             let elem_width = type_width_u64(elem)?;
             let len = const_expr_u64(len)?;

--- a/src/formal.rs
+++ b/src/formal.rs
@@ -1591,6 +1591,10 @@ impl<'a> FormalCtx<'a> {
         match ty {
             TypeExpr::UInt(_) | TypeExpr::SInt(_) | TypeExpr::Bool | TypeExpr::Bit
                 | TypeExpr::Clock(_) | TypeExpr::Reset(_, _) => Ok(()),
+            TypeExpr::FP32 | TypeExpr::BF16 => Err(CompileError::general(
+                "floating-point types (FP32/BF16) are not supported by `arch formal` v1",
+                span,
+            )),
             TypeExpr::Vec(_, _) => Err(CompileError::general(
                 "Vec types are not supported by `arch formal` v1 — use scalars",
                 span,
@@ -1626,7 +1630,7 @@ impl<'a> FormalCtx<'a> {
             }
             TypeExpr::Bool | TypeExpr::Bit | TypeExpr::Clock(_) | TypeExpr::Reset(_, _) =>
                 Ok((1, false)),
-            TypeExpr::Vec(_, _) | TypeExpr::Named(_) => Err(CompileError::general(
+            TypeExpr::FP32 | TypeExpr::BF16 | TypeExpr::Vec(_, _) | TypeExpr::Named(_) => Err(CompileError::general(
                 "type not supported by arch formal v1",
                 span,
             )),
@@ -2602,6 +2606,13 @@ fn lit_to_term(l: &LitKind) -> SmtTerm {
             SmtTerm { s: bv_lit(*v, w), width: w, signed: false }
         }
         LitKind::Sized(w, v) => SmtTerm { s: bv_lit(*v, *w), width: *w, signed: false },
+        // Float literals are unreachable here in practice — FP types are rejected
+        // by `check_scalar_type` before emission. Fall back to the FP32 bit
+        // pattern as a 32-bit vector so this stays total.
+        LitKind::Float(bits) => {
+            let f = (f64::from_bits(*bits)) as f32;
+            SmtTerm { s: bv_lit(f.to_bits() as u64, 32), width: 32, signed: false }
+        }
     }
 }
 

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -2016,7 +2016,7 @@ impl Builder {
                 self.walk_expr(owner, &rel, scope, e, ExprUse::Read);
             }
             TypeExpr::Clock(domain) => self.add_uses_type(owner, &domain.name, domain.span),
-            TypeExpr::Reset(_, _) | TypeExpr::Bool | TypeExpr::Bit => {}
+            TypeExpr::Reset(_, _) | TypeExpr::Bool | TypeExpr::Bit | TypeExpr::FP32 | TypeExpr::BF16 => {}
             TypeExpr::Vec(inner, n) => {
                 self.walk_type(owner, scope, inner, span);
                 let rel = self.rel_for_span(n.span);

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -488,6 +488,8 @@ fn type_str(ty: &TypeExpr) -> String {
         TypeExpr::SInt(w) => format!("SInt<{}>", expr_str(w)),
         TypeExpr::Bool => "Bool".to_string(),
         TypeExpr::Bit => "Bit".to_string(),
+        TypeExpr::FP32 => "FP32".to_string(),
+        TypeExpr::BF16 => "BF16".to_string(),
         TypeExpr::Clock(domain) => format!("Clock<{}>", domain.name),
         TypeExpr::Reset(kind, level) => {
             let k = match kind {
@@ -513,6 +515,10 @@ fn expr_str(expr: &Expr) -> String {
             LitKind::Hex(v) => format!("0x{:X}", v),
             LitKind::Bin(v) => format!("0b{:b}", v),
             LitKind::Sized(width, val) => format!("{width}'d{val}"),
+            LitKind::Float(bits) => {
+                let v = f64::from_bits(*bits);
+                if v.fract() == 0.0 { format!("{v:.1}") } else { v.to_string() }
+            }
         },
         ExprKind::Bool(b) => if *b { "true".to_string() } else { "false".to_string() },
         ExprKind::Ident(name) => name.clone(),

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -271,6 +271,10 @@ pub enum TokenKind {
     Async,
     #[token("Vec")]
     KwVec,
+    #[token("FP32")]
+    FP32,
+    #[token("BF16")]
+    BF16,
 
     // Operators and punctuation
     #[token("+:")]
@@ -367,6 +371,12 @@ pub enum TokenKind {
 
     #[regex(r"[0-9]+'[bhd][0-9a-fA-F_]+", |lex| lex.slice().to_string())]
     SizedLiteral(String),
+
+    // Float literal: must contain a decimal point (and may have an exponent),
+    // e.g. 1.5, 3.0, 1.0e-3, 2.5E10. Higher priority than DecLiteral so the
+    // integer part isn't matched on its own.
+    #[regex(r"[0-9][0-9_]*\.[0-9_]+([eE][+-]?[0-9]+)?", priority = 3, callback = |lex| lex.slice().to_string())]
+    FloatLiteral(String),
 
     #[regex(r"[0-9][0-9_]*", priority = 2, callback = |lex| lex.slice().to_string())]
     DecLiteral(String),
@@ -498,6 +508,8 @@ impl fmt::Display for TokenKind {
             TokenKind::Sync => write!(f, "Sync"),
             TokenKind::Async => write!(f, "Async"),
             TokenKind::KwVec => write!(f, "Vec"),
+            TokenKind::FP32 => write!(f, "FP32"),
+            TokenKind::BF16 => write!(f, "BF16"),
             TokenKind::Plus => write!(f, "+"),
             TokenKind::Minus => write!(f, "-"),
             TokenKind::Star => write!(f, "*"),
@@ -542,6 +554,7 @@ impl fmt::Display for TokenKind {
             TokenKind::HexLiteral(s) => write!(f, "{s}"),
             TokenKind::BinLiteral(s) => write!(f, "{s}"),
             TokenKind::SizedLiteral(s) => write!(f, "{s}"),
+            TokenKind::FloatLiteral(s) => write!(f, "{s}"),
             TokenKind::DecLiteral(s) => write!(f, "{s}"),
             TokenKind::Clog2 => write!(f, "$clog2"),
             TokenKind::Onehot => write!(f, "onehot"),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3554,6 +3554,14 @@ impl Parser {
                 self.advance();
                 Ok(TypeExpr::Bool)
             }
+            Some(TokenKind::FP32) => {
+                self.advance();
+                Ok(TypeExpr::FP32)
+            }
+            Some(TokenKind::BF16) => {
+                self.advance();
+                Ok(TypeExpr::BF16)
+            }
             Some(TokenKind::Bit) => {
                 self.advance();
                 Ok(TypeExpr::Bit)
@@ -4103,6 +4111,12 @@ impl Parser {
                     CompileError::general("invalid decimal literal", tok.span)
                 })?;
                 ExprKind::Literal(LitKind::Dec(v))
+            }
+            TokenKind::FloatLiteral(s) => {
+                let v = s.replace('_', "").parse::<f64>().map_err(|_| {
+                    CompileError::general("invalid float literal", tok.span)
+                })?;
+                ExprKind::Literal(LitKind::Float(v.to_bits()))
             }
             TokenKind::HexLiteral(s) => {
                 let v = u64::from_str_radix(&s[2..].replace('_', ""), 16).map_err(|_| {
@@ -6106,6 +6120,8 @@ fn is_method_name(name: &str) -> bool {
     matches!(
         name,
         "trunc" | "zext" | "sext" | "resize" | "reverse"
+        // float→int conversions carry a width type-arg: `.to_uint<N>()`
+        | "to_uint" | "to_sint"
         // credit_channel write-side sugar (PR #3b-vi). These are only
         // meaningful as bare statements; the parser's `parse_comb_stmt`
         // and `parse_reg_stmt` desugar `port.ch.send(x);` / `.pop();` to

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -4021,7 +4021,8 @@ impl Parser {
                     span: tok.span, parenthesized: false })
             }
             Some(TokenKind::DecLiteral(_)) | Some(TokenKind::HexLiteral(_))
-            | Some(TokenKind::BinLiteral(_)) | Some(TokenKind::SizedLiteral(_)) => {
+            | Some(TokenKind::BinLiteral(_)) | Some(TokenKind::SizedLiteral(_))
+            | Some(TokenKind::FloatLiteral(_)) => {
                 self.parse_literal()
             }
             Some(TokenKind::Ident(_)) | Some(TokenKind::Counter) => {

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -256,6 +256,7 @@ fn eval_bus_cond(expr: &Expr, param_map: &HashMap<String, &Expr>) -> bool {
             match lit {
                 LitKind::Dec(n) | LitKind::Hex(n) | LitKind::Bin(n) => *n != 0,
                 LitKind::Sized(_, n) => *n != 0,
+                LitKind::Float(bits) => f64::from_bits(*bits) != 0.0,
             }
         }
         ExprKind::Bool(b) => *b,
@@ -298,6 +299,8 @@ fn eval_bus_int(expr: &Expr, param_map: &HashMap<String, &Expr>) -> Option<i64> 
     match &expr.kind {
         ExprKind::Literal(lit) => match lit {
             LitKind::Dec(n) | LitKind::Hex(n) | LitKind::Bin(n) | LitKind::Sized(_, n) => Some(*n as i64),
+            // Float literals are not valid in integer bus-condition contexts.
+            LitKind::Float(_) => None,
         },
         ExprKind::Ident(name) => {
             let val_expr = param_map.get(name.as_str())?;

--- a/src/sim_codegen/mod.rs
+++ b/src/sim_codegen/mod.rs
@@ -985,6 +985,25 @@ static inline uint64_t _arch_f32_to_u(uint32_t b){
 }
 static inline int64_t  _arch_bf16_to_i(uint16_t h){ return _arch_f32_to_i(_arch_bf16_to_f32(h)); }
 static inline uint64_t _arch_bf16_to_u(uint16_t h){ return _arch_f32_to_u(_arch_bf16_to_f32(h)); }
+// Width-aware float→int: toward-zero, saturating to the N-bit target range,
+// NaN→type-max (RISC-V profile). Builds on the 64-bit-safe conversions above
+// (which already map NaN→max and saturate to the 64-bit range) then clamps to
+// the requested width — so the int64 cast never sees an out-of-range float.
+static inline int64_t _arch_f32_to_sint(uint32_t b, int bits){
+    int64_t v = _arch_f32_to_i(b);
+    if (bits >= 64) return v;
+    int64_t maxv = ((int64_t)1 << (bits - 1)) - 1;
+    int64_t minv = -((int64_t)1 << (bits - 1));
+    if (v > maxv) return maxv;
+    if (v < minv) return minv;
+    return v;
+}
+static inline uint64_t _arch_f32_to_uint(uint32_t b, int bits){
+    uint64_t v = _arch_f32_to_u(b);
+    if (bits >= 64) return v;
+    uint64_t maxv = ((uint64_t)1 << bits) - 1;
+    return (v > maxv) ? maxv : v;
+}
 "#.to_string()
     }
 
@@ -3620,11 +3639,16 @@ fn cpp_method_call(base: &Expr, method: &Ident, args: &[Expr], ctx: &Ctx) -> Str
         "to_uint" | "to_sint" => {
             let bits = args.first().map(|w| eval_width_in(w, ctx)).unwrap_or(32);
             let signed = method.name == "to_sint";
-            let conv = match infer_expr_float(base, ctx) {
-                Some(FpFmt::Bf16) if signed => format!("_arch_bf16_to_i({b})"),
-                Some(FpFmt::Bf16)           => format!("_arch_bf16_to_u({b})"),
-                _ if signed                 => format!("_arch_f32_to_i({b})"),
-                _                           => format!("_arch_f32_to_u({b})"),
+            // Decode bf16 to f32 bits first; then a width-aware, saturating,
+            // toward-zero, NaN→type-max conversion to the N-bit integer.
+            let f32bits = match infer_expr_float(base, ctx) {
+                Some(FpFmt::Bf16) => format!("_arch_bf16_to_f32({b})"),
+                _ => b,
+            };
+            let conv = if signed {
+                format!("_arch_f32_to_sint({f32bits}, {bits})")
+            } else {
+                format!("_arch_f32_to_uint({f32bits}, {bits})")
             };
             let cast = if signed { cpp_sint(bits) } else { cpp_uint(bits) };
             format!("(({cast})({conv}))")

--- a/src/sim_codegen/mod.rs
+++ b/src/sim_codegen/mod.rs
@@ -686,6 +686,8 @@ PYBIND11_MODULE({pybind_module}, m) {{
         match ty {
             TypeExpr::UInt(w) | TypeExpr::SInt(w) => eval_width(w),
             TypeExpr::Bool | TypeExpr::Bit | TypeExpr::Clock(_) | TypeExpr::Reset(..) => 1,
+            TypeExpr::FP32 => 32,
+            TypeExpr::BF16 => 16,
             TypeExpr::Named(_) => 32,
             TypeExpr::Vec(_, _) => 32,
         }
@@ -732,6 +734,7 @@ r#"        .def_property("{field}",
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <cmath>
 
 // --coverage-dat: forward declaration for the helper defined in
 // verilated.cpp. Each class's atexit dumper calls this to get a
@@ -911,6 +914,77 @@ static inline uint64_t _arch_repeat(uint64_t val, uint32_t n, uint32_t val_width
 #define _ARCH_DCHK(divisor, loc) \
     ((unsigned long long)(divisor) != 0 \
         ? (void)0 : _arch_div0_abort((loc)))
+
+// ── Floating-point (FP32 / BF16) runtime ─────────────────────────────────────
+// Floats are carried as raw bit patterns (FP32→uint32_t, BF16→uint16_t).
+// Arithmetic uses the host FPU, which is IEEE-754 round-to-nearest-even and
+// therefore bit-identical to Berkeley SoftFloat for + - * and fma. BF16 ops go
+// through an f32 intermediate then round once to bf16 — innocuous double
+// rounding (24 >= 2*8+2), so the result equals direct correctly-rounded bf16
+// (doc/plan_fp_types.md §5.3). NaN results are canonicalized to the RISC-V
+// default pattern (0x7FC00000 / 0x7FC0); float→int is toward-zero, saturating,
+// NaN→type-max (RISC-V profile, §6).
+static inline float    _arch_f32b(uint32_t b){ float f; memcpy(&f,&b,4); return f; }
+static inline uint32_t _arch_b32f(float f){ uint32_t b; memcpy(&b,&f,4); return b; }
+static inline uint32_t _arch_f32_canon(uint32_t b){
+    if (((b>>23)&0xFFu)==0xFFu && (b&0x7FFFFFu)!=0u) return 0x7FC00000u;
+    return b;
+}
+static inline uint32_t _arch_f32_add(uint32_t a,uint32_t b){ return _arch_f32_canon(_arch_b32f(_arch_f32b(a)+_arch_f32b(b))); }
+static inline uint32_t _arch_f32_sub(uint32_t a,uint32_t b){ return _arch_f32_canon(_arch_b32f(_arch_f32b(a)-_arch_f32b(b))); }
+static inline uint32_t _arch_f32_mul(uint32_t a,uint32_t b){ return _arch_f32_canon(_arch_b32f(_arch_f32b(a)*_arch_f32b(b))); }
+static inline uint32_t _arch_fma_f32(uint32_t a,uint32_t b,uint32_t c){ return _arch_f32_canon(_arch_b32f(fmaf(_arch_f32b(a),_arch_f32b(b),_arch_f32b(c)))); }
+static inline uint8_t _arch_f32_eq(uint32_t a,uint32_t b){ return _arch_f32b(a)==_arch_f32b(b); }
+static inline uint8_t _arch_f32_ne(uint32_t a,uint32_t b){ return _arch_f32b(a)!=_arch_f32b(b); }
+static inline uint8_t _arch_f32_lt(uint32_t a,uint32_t b){ return _arch_f32b(a)< _arch_f32b(b); }
+static inline uint8_t _arch_f32_gt(uint32_t a,uint32_t b){ return _arch_f32b(a)> _arch_f32b(b); }
+static inline uint8_t _arch_f32_le(uint32_t a,uint32_t b){ return _arch_f32b(a)<=_arch_f32b(b); }
+static inline uint8_t _arch_f32_ge(uint32_t a,uint32_t b){ return _arch_f32b(a)>=_arch_f32b(b); }
+static inline uint8_t _arch_f32_isnan(uint32_t a){ return std::isnan(_arch_f32b(a))?1:0; }
+
+// BF16 <-> f32: bf16 is the top 16 bits of binary32.
+static inline float    _arch_bf16f(uint16_t h){ return _arch_f32b(((uint32_t)h)<<16); }
+static inline uint16_t _arch_f2bf16(float f){
+    uint32_t x=_arch_b32f(f);
+    if (((x>>23)&0xFFu)==0xFFu && (x&0x7FFFFFu)!=0u) return 0x7FC0u; // canonical NaN
+    uint32_t lsb=(x>>16)&1u; x += 0x7FFFu+lsb; // round-to-nearest-even
+    return (uint16_t)(x>>16);
+}
+static inline uint32_t _arch_bf16_to_f32(uint16_t h){ return _arch_f32_canon(((uint32_t)h)<<16); }
+static inline uint16_t _arch_f32_to_bf16(uint32_t b){ return _arch_f2bf16(_arch_f32b(b)); }
+static inline uint16_t _arch_bf16_add(uint16_t a,uint16_t b){ return _arch_f2bf16(_arch_bf16f(a)+_arch_bf16f(b)); }
+static inline uint16_t _arch_bf16_sub(uint16_t a,uint16_t b){ return _arch_f2bf16(_arch_bf16f(a)-_arch_bf16f(b)); }
+static inline uint16_t _arch_bf16_mul(uint16_t a,uint16_t b){ return _arch_f2bf16(_arch_bf16f(a)*_arch_bf16f(b)); }
+static inline uint16_t _arch_fma_bf16(uint16_t a,uint16_t b,uint16_t c){ return _arch_f2bf16(fmaf(_arch_bf16f(a),_arch_bf16f(b),_arch_bf16f(c))); }
+static inline uint8_t _arch_bf16_eq(uint16_t a,uint16_t b){ return _arch_bf16f(a)==_arch_bf16f(b); }
+static inline uint8_t _arch_bf16_ne(uint16_t a,uint16_t b){ return _arch_bf16f(a)!=_arch_bf16f(b); }
+static inline uint8_t _arch_bf16_lt(uint16_t a,uint16_t b){ return _arch_bf16f(a)< _arch_bf16f(b); }
+static inline uint8_t _arch_bf16_gt(uint16_t a,uint16_t b){ return _arch_bf16f(a)> _arch_bf16f(b); }
+static inline uint8_t _arch_bf16_le(uint16_t a,uint16_t b){ return _arch_bf16f(a)<=_arch_bf16f(b); }
+static inline uint8_t _arch_bf16_ge(uint16_t a,uint16_t b){ return _arch_bf16f(a)>=_arch_bf16f(b); }
+static inline uint8_t _arch_bf16_isnan(uint16_t a){ return std::isnan(_arch_bf16f(a))?1:0; }
+
+// int <-> float conversions.
+static inline uint32_t _arch_i_to_f32(int64_t v){ return _arch_b32f((float)v); }
+static inline uint32_t _arch_u_to_f32(uint64_t v){ return _arch_b32f((float)v); }
+static inline uint16_t _arch_i_to_bf16(int64_t v){ return _arch_f2bf16((float)v); }
+static inline uint16_t _arch_u_to_bf16(uint64_t v){ return _arch_f2bf16((float)v); }
+static inline int64_t  _arch_f32_to_i(uint32_t b){
+    float f=_arch_f32b(b);
+    if (std::isnan(f)) return INT64_MAX;
+    if (f >= 9223372036854775808.0f) return INT64_MAX;
+    if (f <  -9223372036854775808.0f) return INT64_MIN;
+    return (int64_t)f; // truncates toward zero
+}
+static inline uint64_t _arch_f32_to_u(uint32_t b){
+    float f=_arch_f32b(b);
+    if (std::isnan(f)) return UINT64_MAX;
+    if (f <= 0.0f) return 0;
+    if (f >= 18446744073709551616.0f) return UINT64_MAX;
+    return (uint64_t)f;
+}
+static inline int64_t  _arch_bf16_to_i(uint16_t h){ return _arch_f32_to_i(_arch_bf16_to_f32(h)); }
+static inline uint64_t _arch_bf16_to_u(uint16_t h){ return _arch_f32_to_u(_arch_bf16_to_f32(h)); }
 "#.to_string()
     }
 
@@ -1333,6 +1407,11 @@ fn cpp_port_type_with_params(ty: &TypeExpr, params: &[ParamDecl]) -> String {
             else { cpp_sint(b).to_string() }
         }
         TypeExpr::Bool | TypeExpr::Bit | TypeExpr::Clock(_) | TypeExpr::Reset(..) => "uint8_t".to_string(),
+        // Floats are carried as their raw bit pattern in an unsigned integer
+        // (FP32 → uint32_t, BF16 → uint16_t); arithmetic goes through the
+        // `_arch_fp.h` helpers, never C++ float operators on the storage.
+        TypeExpr::FP32 => "uint32_t".to_string(),
+        TypeExpr::BF16 => "uint16_t".to_string(),
         TypeExpr::Named(n) => n.name.clone(),
         TypeExpr::Vec(_, _) => "uint32_t".to_string(),
     }
@@ -1846,6 +1925,8 @@ fn cpp_internal_type_with_params(ty: &TypeExpr, params: &[ParamDecl]) -> String 
             else { cpp_sint(b).to_string() }
         }
         TypeExpr::Bool | TypeExpr::Bit | TypeExpr::Clock(_) | TypeExpr::Reset(..) => "uint8_t".to_string(),
+        TypeExpr::FP32 => "uint32_t".to_string(),
+        TypeExpr::BF16 => "uint16_t".to_string(),
         TypeExpr::Named(n) => n.name.clone(),
         TypeExpr::Vec(_, _) => "uint32_t".to_string(),
     }
@@ -2163,6 +2244,8 @@ fn type_width_of(ty: &TypeExpr) -> u32 {
     match ty {
         TypeExpr::UInt(w) | TypeExpr::SInt(w) => eval_width(w),
         TypeExpr::Bool | TypeExpr::Bit | TypeExpr::Clock(_) | TypeExpr::Reset(..) => 1,
+        TypeExpr::FP32 => 32,
+        TypeExpr::BF16 => 16,
         TypeExpr::Vec(..) | TypeExpr::Named(_) => 0,
     }
 }
@@ -2258,6 +2341,10 @@ struct Ctx<'a> {
     widths:      &'a HashMap<String, u32>,
     /// Signal names whose HDL scalar type is signed.
     signed_names: &'a HashSet<String>,
+    /// Signal name → floating-point format (FP32/BF16). Used to dispatch
+    /// `+ - *` and comparisons to the `_arch_fp.h` helpers instead of integer
+    /// operators on the bit-pattern carrier.
+    float_names: &'a HashMap<String, FpFmt>,
     posedge_lhs: bool,
     /// FSM mode: regs are public members, no `_` prefix on reads
     fsm_mode:    bool,
@@ -2319,11 +2406,13 @@ impl<'a> Ctx<'a> {
     ) -> Self {
         static EMPTY_RESET_LEVELS: std::sync::OnceLock<HashMap<String, ResetLevel>> = std::sync::OnceLock::new();
         static EMPTY_SIGNED_NAMES: std::sync::OnceLock<HashSet<String>> = std::sync::OnceLock::new();
+        static EMPTY_FLOAT_NAMES: std::sync::OnceLock<HashMap<String, FpFmt>> = std::sync::OnceLock::new();
         let reset_levels = EMPTY_RESET_LEVELS.get_or_init(HashMap::new);
         let signed_names = EMPTY_SIGNED_NAMES.get_or_init(HashSet::new);
+        let float_names = EMPTY_FLOAT_NAMES.get_or_init(HashMap::new);
         static EMPTY_PARAMS: &[ParamDecl] = &[];
         Ctx { reg_names, port_names, let_names, let_values: None, inst_names, wide_names,
-              widths, signed_names, posedge_lhs: false, fsm_mode: false, enum_map, bus_ports,
+              widths, signed_names, float_names, posedge_lhs: false, fsm_mode: false, enum_map, bus_ports,
               reset_levels, vec_names: None, vec_2d_names: None, vec_sizes: None,
               fsm_vec_port_regs: None,
               ident_subst: None, loop_var_subst: None,
@@ -2345,6 +2434,11 @@ impl<'a> Ctx<'a> {
 
     fn with_signed_names(mut self, signed_names: &'a HashSet<String>) -> Self {
         self.signed_names = signed_names;
+        self
+    }
+
+    fn with_float_names(mut self, float_names: &'a HashMap<String, FpFmt>) -> Self {
+        self.float_names = float_names;
         self
     }
 
@@ -2676,6 +2770,49 @@ fn infer_expr_signed(expr: &Expr, ctx: &Ctx) -> bool {
     }
 }
 
+/// Floating-point format of a sim signal/expression. Mirrors `Ty::FP32`/`BF16`
+/// but local to the sim backend so it can live in `Ctx`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FpFmt { Fp32, Bf16 }
+
+impl FpFmt {
+    /// Suffix used in the `_arch_fp.h` helper names: `_arch_f32_add` / `_arch_bf16_add`.
+    fn helper_tag(self) -> &'static str {
+        match self { FpFmt::Fp32 => "f32", FpFmt::Bf16 => "bf16" }
+    }
+}
+
+/// Infer the floating-point format of an expression, or `None` if it is not a
+/// float. Drives dispatch of `+ - *` / comparisons to the `_arch_fp.h` helpers.
+fn infer_expr_float(expr: &Expr, ctx: &Ctx) -> Option<FpFmt> {
+    match &expr.kind {
+        ExprKind::Ident(name) => ctx.float_names.get(name.as_str()).copied(),
+        // Float literals default to FP32.
+        ExprKind::Literal(LitKind::Float(_)) => Some(FpFmt::Fp32),
+        ExprKind::Cast(_, ty) => match ty.as_ref() {
+            TypeExpr::FP32 => Some(FpFmt::Fp32),
+            TypeExpr::BF16 => Some(FpFmt::Bf16),
+            _ => None,
+        },
+        ExprKind::MethodCall(_, method, _) => match method.name.as_str() {
+            "to_fp32" => Some(FpFmt::Fp32),
+            "to_bf16" => Some(FpFmt::Bf16),
+            _ => None, // to_uint/to_sint produce integers
+        },
+        // Arithmetic preserves the float format; comparisons are not float.
+        ExprKind::Binary(op, lhs, rhs) => match op {
+            BinOp::Add | BinOp::Sub | BinOp::Mul =>
+                infer_expr_float(lhs, ctx).or_else(|| infer_expr_float(rhs, ctx)),
+            _ => None,
+        },
+        ExprKind::Ternary(_, then_expr, else_expr) =>
+            infer_expr_float(then_expr, ctx).or_else(|| infer_expr_float(else_expr, ctx)),
+        ExprKind::FunctionCall(name, args) if name == "fma" =>
+            args.first().and_then(|a| infer_expr_float(a, ctx)),
+        _ => None,
+    }
+}
+
 // ── Expression emitter ────────────────────────────────────────────────────────
 
 /// Lower a Vec method call (any/all/count/contains/reduce_*) to an
@@ -2706,6 +2843,7 @@ fn lower_vec_method_cpp(
             reg_names: ctx.reg_names, port_names: ctx.port_names,
             let_names: ctx.let_names, let_values: ctx.let_values, inst_names: ctx.inst_names,
             wide_names: ctx.wide_names, widths: ctx.widths, signed_names: ctx.signed_names,
+            float_names: ctx.float_names,
             posedge_lhs: ctx.posedge_lhs, fsm_mode: ctx.fsm_mode,
             enum_map: ctx.enum_map, bus_ports: ctx.bus_ports,
             reset_levels: ctx.reset_levels, vec_names: ctx.vec_names,
@@ -2833,6 +2971,9 @@ fn cpp_expr_inner(expr: &Expr, ctx: &Ctx, is_lhs: bool) -> String {
             LitKind::Hex(v) => format!("0x{v:X}"),
             LitKind::Bin(v) => format!("{v}"),
             LitKind::Sized(_, v) => format!("{v}"),
+            // Float literals are FP32 by default — emit the binary32 bit pattern
+            // as an unsigned hex constant (matches the uint32_t carrier).
+            LitKind::Float(bits) => format!("0x{:X}u", (f64::from_bits(*bits) as f32).to_bits()),
         },
         ExprKind::Bool(true)  => "1".to_string(),
         ExprKind::Bool(false) => "0".to_string(),
@@ -2866,6 +3007,21 @@ fn cpp_expr_inner(expr: &Expr, ctx: &Ctx, is_lhs: bool) -> String {
                 // by the time it reaches expr lowering, lhs has been rewritten
                 // into past-state. Treat as Implies for fallback paths.
                 return format!("(!{l} || {r})");
+            }
+            // Floating-point operands: dispatch to the `_arch_fp.h` helpers
+            // (IEEE-754 RNE) instead of integer operators on the bit pattern.
+            if let Some(fmt) = infer_expr_float(lhs, ctx).or_else(|| infer_expr_float(rhs, ctx)) {
+                let tag = fmt.helper_tag();
+                let fop = match op {
+                    BinOp::Add => Some("add"), BinOp::Sub => Some("sub"), BinOp::Mul => Some("mul"),
+                    BinOp::Eq => Some("eq"), BinOp::Neq => Some("ne"),
+                    BinOp::Lt => Some("lt"), BinOp::Gt => Some("gt"),
+                    BinOp::Lte => Some("le"), BinOp::Gte => Some("ge"),
+                    _ => None,
+                };
+                if let Some(fop) = fop {
+                    return format!("_arch_{tag}_{fop}({l}, {r})");
+                }
             }
             if matches!(op, BinOp::Mul | BinOp::MulWrap) {
                 let cast_ty = if infer_expr_signed(lhs, ctx) || infer_expr_signed(rhs, ctx) {
@@ -3194,6 +3350,21 @@ fn cpp_expr_inner(expr: &Expr, ctx: &Ctx, is_lhs: bool) -> String {
             format!("(({c}) ? ({t}) : ({e}))")
         }
 
+        ExprKind::FunctionCall(name, args) if name == "fma" && args.len() == 3 => {
+            let fmt = infer_expr_float(&args[0], ctx)
+                .or_else(|| infer_expr_float(&args[1], ctx))
+                .or_else(|| infer_expr_float(&args[2], ctx))
+                .unwrap_or(FpFmt::Fp32);
+            let a = cpp_expr(&args[0], ctx);
+            let b = cpp_expr(&args[1], ctx);
+            let c = cpp_expr(&args[2], ctx);
+            format!("_arch_fma_{}({a}, {b}, {c})", fmt.helper_tag())
+        }
+        ExprKind::FunctionCall(name, args) if name == "is_nan" && args.len() == 1 => {
+            let fmt = infer_expr_float(&args[0], ctx).unwrap_or(FpFmt::Fp32);
+            let a = cpp_expr(&args[0], ctx);
+            format!("_arch_{}_isnan({a})", fmt.helper_tag())
+        }
         ExprKind::FunctionCall(name, args) => {
             let arg_strs: Vec<String> = args.iter().map(|a| cpp_expr(a, ctx)).collect();
             format!("{name}({})", arg_strs.join(", "))
@@ -3422,6 +3593,41 @@ fn cpp_method_call(base: &Expr, method: &Ident, args: &[Expr], ctx: &Ctx) -> Str
         "any" | "all" | "count" | "contains"
         | "reduce_or" | "reduce_and" | "reduce_xor" => {
             lower_vec_method_cpp(&b, base, method, args, ctx)
+        }
+        // Float conversions → `_arch_fp.h` helpers.
+        "to_fp32" => match infer_expr_float(base, ctx) {
+            Some(FpFmt::Bf16) => format!("_arch_bf16_to_f32({b})"),
+            Some(FpFmt::Fp32) => b, // no-op (typecheck rejects, but stay total)
+            None => {
+                if infer_expr_signed(base, ctx) {
+                    format!("_arch_i_to_f32((int64_t)({b}))")
+                } else {
+                    format!("_arch_u_to_f32((uint64_t)({b}))")
+                }
+            }
+        },
+        "to_bf16" => match infer_expr_float(base, ctx) {
+            Some(FpFmt::Fp32) => format!("_arch_f32_to_bf16({b})"),
+            Some(FpFmt::Bf16) => b,
+            None => {
+                if infer_expr_signed(base, ctx) {
+                    format!("_arch_i_to_bf16((int64_t)({b}))")
+                } else {
+                    format!("_arch_u_to_bf16((uint64_t)({b}))")
+                }
+            }
+        },
+        "to_uint" | "to_sint" => {
+            let bits = args.first().map(|w| eval_width_in(w, ctx)).unwrap_or(32);
+            let signed = method.name == "to_sint";
+            let conv = match infer_expr_float(base, ctx) {
+                Some(FpFmt::Bf16) if signed => format!("_arch_bf16_to_i({b})"),
+                Some(FpFmt::Bf16)           => format!("_arch_bf16_to_u({b})"),
+                _ if signed                 => format!("_arch_f32_to_i({b})"),
+                _                           => format!("_arch_f32_to_u({b})"),
+            };
+            let cast = if signed { cpp_sint(bits) } else { cpp_uint(bits) };
+            format!("(({cast})({conv}))")
         }
         _ => format!("{b}.{}()", method.name),
     }
@@ -4460,6 +4666,44 @@ fn build_signed_names(ports: &[PortDecl], body: &[ModuleBodyItem]) -> HashSet<St
     s
 }
 
+/// Floating-point format of a scalar TypeExpr, if any.
+fn type_float_fmt(ty: &TypeExpr) -> Option<FpFmt> {
+    match ty {
+        TypeExpr::FP32 => Some(FpFmt::Fp32),
+        TypeExpr::BF16 => Some(FpFmt::Bf16),
+        _ => None,
+    }
+}
+
+/// Collect scalar signal names whose HDL type is a float (FP32/BF16), mapping
+/// each to its format. Parallels [`build_signed_names`]; drives float-op
+/// dispatch in the expression emitter.
+fn build_float_names(ports: &[PortDecl], body: &[ModuleBodyItem]) -> HashMap<String, FpFmt> {
+    let mut m = HashMap::new();
+    for p in ports {
+        if let Some(f) = type_float_fmt(&p.ty) {
+            m.insert(p.name.name.clone(), f);
+        }
+    }
+    for item in body {
+        match item {
+            ModuleBodyItem::RegDecl(r) => {
+                if let Some(f) = type_float_fmt(&r.ty) { m.insert(r.name.name.clone(), f); }
+            }
+            ModuleBodyItem::WireDecl(w) => {
+                if let Some(f) = type_float_fmt(&w.ty) { m.insert(w.name.name.clone(), f); }
+            }
+            ModuleBodyItem::LetBinding(l) => {
+                if let Some(f) = l.ty.as_ref().and_then(type_float_fmt) {
+                    m.insert(l.name.name.clone(), f);
+                }
+            }
+            _ => {}
+        }
+    }
+    m
+}
+
 /// Collect names whose bit width exceeds 64 (require wide handling).
 fn collect_wide_names(ports: &[PortDecl], body: &[ModuleBodyItem], params: &[ParamDecl]) -> HashSet<String> {
     let mut s = HashSet::new();
@@ -5029,6 +5273,7 @@ impl<'a> SimCodegen<'a> {
         let mut wide_names  = collect_wide_names(&m.ports, &m.body, &m.params);
         let mut widths      = build_widths(&m.ports, &m.body, &m.params);
         let mut signed_names = build_signed_names(&m.ports, &m.body);
+        let float_names = build_float_names(&m.ports, &m.body);
 
         // Add bus flattened signals to wide_names and widths.
         // Use the param-aware width evaluator (issue #427): when a bus's
@@ -6317,7 +6562,7 @@ impl<'a> SimCodegen<'a> {
         // Returns (input_code, comb_call, output_read_code) per inst
         let ctx = Ctx::new(&reg_names, &port_names, &let_names, &inst_names,
                            &wide_names, &widths, &enum_map, &bus_port_names)
-                      .with_signed_names(&signed_names)
+                      .with_signed_names(&signed_names).with_float_names(&float_names)
                       .with_reset_levels(&reset_levels)
                       .with_vec_names(&vec_reg_names).with_vec_2d_names(&vec_2d_names).with_vec_sizes(&vec_sizes)
                       .with_let_values(&let_values)
@@ -6859,7 +7104,7 @@ impl<'a> SimCodegen<'a> {
 
             let ctx = Ctx::new(&reg_names, &port_names, &let_names, &inst_names,
                                &wide_names, &widths, &enum_map, &bus_port_names)
-                          .with_signed_names(&signed_names)
+                          .with_signed_names(&signed_names).with_float_names(&float_names)
                           .with_vec_names(&vec_reg_names).with_vec_2d_names(&vec_2d_names).with_vec_sizes(&vec_sizes).posedge()
                           .with_coverage(cov_handle)
                           .with_let_values(&let_values)
@@ -6904,7 +7149,7 @@ impl<'a> SimCodegen<'a> {
                                         let tmp_ctx = Ctx::new(&reg_names, &port_names,
                                             &let_names, &inst_names, &wide_names, &widths,
                                             &enum_map, &bus_port_names)
-                                            .with_signed_names(&signed_names);
+                                            .with_signed_names(&signed_names).with_float_names(&float_names);
                                         cpp_expr(expr, &tmp_ctx)
                                     }
                                 }
@@ -7075,7 +7320,7 @@ impl<'a> SimCodegen<'a> {
                     }
                     let ctx_pe = Ctx::new(&reg_names, &port_names, &let_names, &inst_names,
                                            &wide_names, &widths, &enum_map, &bus_port_names)
-                                       .with_signed_names(&signed_names)
+                                       .with_signed_names(&signed_names).with_float_names(&float_names)
                                        .with_vec_names(&vec_reg_names).with_vec_2d_names(&vec_2d_names).with_vec_sizes(&vec_sizes)
                                        .with_let_values(&let_values)
                                        .with_params(&m.params);
@@ -7300,7 +7545,7 @@ impl<'a> SimCodegen<'a> {
         cpp.push_str(&format!("void {class}::eval_comb() {{\n"));
         let ctx_comb = Ctx::new(&reg_names, &port_names, &let_names, &inst_names,
                                 &wide_names, &widths, &enum_map, &bus_port_names)
-                           .with_signed_names(&signed_names)
+                           .with_signed_names(&signed_names).with_float_names(&float_names)
                            .with_vec_names(&vec_reg_names).with_vec_2d_names(&vec_2d_names).with_vec_sizes(&vec_sizes)
                            .with_coverage(cov_handle)
                            .with_let_values(&let_values)
@@ -7354,6 +7599,7 @@ impl<'a> SimCodegen<'a> {
                                         reg_names: ctx_comb.reg_names, port_names: ctx_comb.port_names,
                                         let_names: ctx_comb.let_names, let_values: ctx_comb.let_values, inst_names: ctx_comb.inst_names,
                                         wide_names: ctx_comb.wide_names, widths: ctx_comb.widths, signed_names: ctx_comb.signed_names,
+                                        float_names: ctx_comb.float_names,
                                         posedge_lhs: ctx_comb.posedge_lhs, fsm_mode: ctx_comb.fsm_mode,
                                         enum_map: ctx_comb.enum_map, bus_ports: ctx_comb.bus_ports,
                                         reset_levels: ctx_comb.reset_levels, vec_names: ctx_comb.vec_names,

--- a/src/sim_codegen/pipeline.rs
+++ b/src/sim_codegen/pipeline.rs
@@ -673,7 +673,8 @@ impl<'a> SimCodegen<'a> {
     ) -> String {
         let empty = HashSet::new();
         let empty_rl: HashMap<String, ResetLevel> = HashMap::new();
-        let ctx = Ctx { reg_names: rn, port_names: pn, let_names: ln, let_values: None, inst_names: &empty, wide_names: &empty, widths: w, signed_names: &empty, posedge_lhs: false, fsm_mode: false, enum_map: em, bus_ports: &empty, reset_levels: &empty_rl, vec_names: None, vec_2d_names: None, vec_sizes: None, fsm_vec_port_regs: None, ident_subst: None, loop_var_subst: None, vec_of_bus_port_count: None, vec_of_bus_wire_count: None, coverage: None, params };
+        let empty_fn: HashMap<String, FpFmt> = HashMap::new();
+        let ctx = Ctx { reg_names: rn, port_names: pn, let_names: ln, let_values: None, inst_names: &empty, wide_names: &empty, widths: w, signed_names: &empty, float_names: &empty_fn, posedge_lhs: false, fsm_mode: false, enum_map: em, bus_ports: &empty, reset_levels: &empty_rl, vec_names: None, vec_2d_names: None, vec_sizes: None, fsm_vec_port_regs: None, ident_subst: None, loop_var_subst: None, vec_of_bus_port_count: None, vec_of_bus_wire_count: None, coverage: None, params };
         match &expr.kind {
             ExprKind::FieldAccess(base, field) => {
                 if let ExprKind::Ident(bn) = &base.kind {
@@ -774,7 +775,7 @@ impl<'a> SimCodegen<'a> {
                 let i = self.pipeline_sim_expr(idx, prefix, si, sn, sp, srn, pn, rn, ln, w, em, params);
                 format!("(({b} >> {i}) & 1)")
             }
-            ExprKind::Literal(lit) => match lit { LitKind::Dec(v) => format!("{v}"), LitKind::Hex(v) | LitKind::Bin(v) => format!("0x{v:X}"), LitKind::Sized(_, v) => format!("{v}") },
+            ExprKind::Literal(lit) => match lit { LitKind::Dec(v) => format!("{v}"), LitKind::Hex(v) | LitKind::Bin(v) => format!("0x{v:X}"), LitKind::Sized(_, v) => format!("{v}"), LitKind::Float(bits) => format!("0x{:X}u", (f64::from_bits(*bits) as f32).to_bits()) },
             ExprKind::Bool(b) => if *b { "1".to_string() } else { "0".to_string() },
             ExprKind::Ternary(c, t, e) => {
                 let cv = self.pipeline_sim_expr(c, prefix, si, sn, sp, srn, pn, rn, ln, w, em, params);

--- a/src/thread_map.rs
+++ b/src/thread_map.rs
@@ -964,6 +964,7 @@ fn lit_label(lit: &LitKind) -> String {
         LitKind::Hex(v) => format!("0x{v:x}"),
         LitKind::Bin(v) => format!("0b{v:b}"),
         LitKind::Sized(w, v) => format!("{w}'d{v}"),
+        LitKind::Float(bits) => f64::from_bits(*bits).to_string(),
     }
 }
 

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -11,6 +11,10 @@ pub enum Ty {
     UInt(u32),
     SInt(u32),
     Bool,
+    /// IEEE-754 binary32 (1+8+23 = 32 bits). Stored/carried as 32 bits.
+    FP32,
+    /// bfloat16 (1+8+7 = 16 bits). Stored/carried as 16 bits.
+    BF16,
     Clock(String), // domain name
     Reset(ResetKind, ResetLevel), // always concrete (Param resolved during elaboration)
     Vec(Box<Ty>, u32),
@@ -19,6 +23,13 @@ pub enum Ty {
     Bus(String),       // bus type name
     Todo,
     Error,
+}
+
+impl Ty {
+    /// True for the floating-point types (FP32, BF16).
+    pub fn is_float(&self) -> bool {
+        matches!(self, Ty::FP32 | Ty::BF16)
+    }
 }
 
 #[derive(Clone)]
@@ -43,6 +54,8 @@ impl Ty {
         match self {
             Ty::UInt(w) | Ty::SInt(w) => Some(*w),
             Ty::Bool => Some(1),
+            Ty::FP32 => Some(32),
+            Ty::BF16 => Some(16),
             Ty::Enum(_, w) => Some(*w),
             Ty::Vec(inner, count) => inner.width().map(|w| w * count),
             Ty::Struct(_) | Ty::Bus(_) => None,
@@ -56,6 +69,8 @@ impl Ty {
             Ty::UInt(w) => format!("UInt<{w}>"),
             Ty::SInt(w) => format!("SInt<{w}>"),
             Ty::Bool => "Bool".to_string(),
+            Ty::FP32 => "FP32".to_string(),
+            Ty::BF16 => "BF16".to_string(),
             Ty::Clock(d) => format!("Clock<{d}>"),
             Ty::Reset(k, l) => format!("Reset<{}, {}>",
                 match k { ResetKind::Sync => "Sync", ResetKind::Async => "Async" },
@@ -2278,6 +2293,8 @@ impl<'a> TypeChecker<'a> {
         match ty {
             Ty::UInt(w) | Ty::SInt(w) => Some(*w),
             Ty::Bool | Ty::Clock(_) | Ty::Reset(_, _) => Some(1),
+            Ty::FP32 => Some(32),
+            Ty::BF16 => Some(16),
             Ty::Enum(_, w) => Some(*w),
             Ty::Vec(inner, count) => self.type_total_width(inner).map(|w| w * count),
             Ty::Struct(name) => {
@@ -2302,6 +2319,8 @@ impl<'a> TypeChecker<'a> {
         match ty {
             TypeExpr::UInt(w) | TypeExpr::SInt(w) => eval_type_width_expr(w),
             TypeExpr::Bool | TypeExpr::Bit | TypeExpr::Clock(_) | TypeExpr::Reset(_, _) => Some(1),
+            TypeExpr::FP32 => Some(32),
+            TypeExpr::BF16 => Some(16),
             TypeExpr::Vec(inner, size) => {
                 let iw = self.type_expr_width(inner)?;
                 let n = eval_type_width_expr(size)?;
@@ -2387,6 +2406,23 @@ impl<'a> TypeChecker<'a> {
     }
 
     pub(crate) fn check_width_compatible(&mut self, lhs_ty: &Ty, rhs_ty: &Ty, name: &str, span: Span) {
+        // Floating-point: no implicit conversion. The target and RHS must be the
+        // exact same float type; a float can't be assigned to/from a non-float
+        // either. (Errors and todo! propagate silently.)
+        if (lhs_ty.is_float() || rhs_ty.is_float())
+            && !matches!(lhs_ty, Ty::Error | Ty::Todo)
+            && !matches!(rhs_ty, Ty::Error | Ty::Todo)
+            && lhs_ty != rhs_ty
+        {
+            self.errors.push(CompileError::general(
+                &format!(
+                    "type mismatch: `{name}` is {} but RHS is {} (no implicit float conversion; use .to_fp32()/.to_bf16()/.to_uint<N>()/.to_sint<N>())",
+                    lhs_ty.display(), rhs_ty.display()
+                ),
+                span,
+            ));
+            return;
+        }
         match (lhs_ty, rhs_ty) {
             (Ty::UInt(lw), Ty::UInt(rw)) if rw > lw => {
                 let hint = if *rw == lw + 1 { " (arithmetic widening)" } else { "" };
@@ -2893,6 +2929,8 @@ impl<'a> TypeChecker<'a> {
             }
             TypeExpr::Bool => Ty::Bool,
             TypeExpr::Bit => Ty::UInt(1),
+            TypeExpr::FP32 => Ty::FP32,
+            TypeExpr::BF16 => Ty::BF16,
             TypeExpr::Clock(domain) => Ty::Clock(domain.name.clone()),
             TypeExpr::Reset(kind, level) => Ty::Reset(*kind, *level),
             TypeExpr::Vec(inner, size_expr) => {
@@ -2999,6 +3037,9 @@ impl<'a> TypeChecker<'a> {
                     Ty::UInt(bits)
                 }
                 LitKind::Sized(w, _) => Ty::UInt(*w),
+                // Float literals default to FP32; BF16 values are written via an
+                // explicit `.to_bf16()` conversion (no implicit float narrowing).
+                LitKind::Float(_) => Ty::FP32,
             },
             ExprKind::Bool(_) => Ty::Bool,
             ExprKind::Ident(name) => {
@@ -3240,6 +3281,49 @@ impl<'a> TypeChecker<'a> {
                 Ty::Bool
             }
             ExprKind::FunctionCall(name, call_args) => {
+                // Built-in float intrinsics. `fma(a, b, c)` is a single-rounded
+                // fused multiply-add (a*b + c); all three operands must be the
+                // same float type, result is that type. `is_nan(x)` → Bool.
+                if name == "fma" {
+                    if call_args.len() != 3 {
+                        self.errors.push(CompileError::general(
+                            &format!("`fma(a, b, c)` takes 3 arguments, got {}", call_args.len()),
+                            expr.span,
+                        ));
+                        return Ty::Error;
+                    }
+                    let ta = self.resolve_expr_type(&call_args[0], module_name, local_types);
+                    let tb = self.resolve_expr_type(&call_args[1], module_name, local_types);
+                    let tc = self.resolve_expr_type(&call_args[2], module_name, local_types);
+                    if ta == Ty::Error || tb == Ty::Error || tc == Ty::Error { return Ty::Error; }
+                    if !ta.is_float() || tb != ta || tc != ta {
+                        self.errors.push(CompileError::general(
+                            &format!("`fma` requires three operands of the same float type, got {}, {}, {}",
+                                ta.display(), tb.display(), tc.display()),
+                            expr.span,
+                        ));
+                        return Ty::Error;
+                    }
+                    return ta;
+                }
+                if name == "is_nan" {
+                    if call_args.len() != 1 {
+                        self.errors.push(CompileError::general(
+                            &format!("`is_nan(x)` takes 1 argument, got {}", call_args.len()),
+                            expr.span,
+                        ));
+                        return Ty::Error;
+                    }
+                    let tx = self.resolve_expr_type(&call_args[0], module_name, local_types);
+                    if tx != Ty::Error && !tx.is_float() {
+                        self.errors.push(CompileError::general(
+                            &format!("`is_nan(x)` requires a float operand, got {}", tx.display()),
+                            call_args[0].span,
+                        ));
+                        return Ty::Error;
+                    }
+                    return Ty::Bool;
+                }
                 // Built-in SVA edge sugar: `rose(a)` ≡ `a and not past(a, 1)`,
                 // `fell(a)` ≡ `not a and past(a, 1)`. Both Bool-returning,
                 // arity 1, SVA-context only.
@@ -3537,6 +3621,57 @@ impl<'a> TypeChecker<'a> {
                     Ty::Error
                 }
             }
+            // Float conversions. `.to_fp32()` / `.to_bf16()` take no args and
+            // widen/narrow/convert into the named float type. `.to_uint<N>()` /
+            // `.to_sint<N>()` convert a float to an integer (toward-zero,
+            // saturating per the RISC-V profile — see doc/plan_fp_types.md §6).
+            "to_fp32" | "to_bf16" => {
+                let target = if method.name == "to_fp32" { Ty::FP32 } else { Ty::BF16 };
+                match &base_ty {
+                    Ty::FP32 | Ty::BF16 | Ty::UInt(_) | Ty::SInt(_) | Ty::Bool => {
+                        if base_ty == target {
+                            self.errors.push(CompileError::general(
+                                &format!(".{}() on a {} value is a no-op — remove the cast", method.name, target.display()),
+                                method.span,
+                            ));
+                            return Ty::Error;
+                        }
+                        target
+                    }
+                    Ty::Todo => Ty::Todo,
+                    Ty::Error => Ty::Error,
+                    _ => {
+                        self.errors.push(CompileError::general(
+                            &format!(".{}() requires a float or integer operand, got {}", method.name, base_ty.display()),
+                            method.span,
+                        ));
+                        Ty::Error
+                    }
+                }
+            }
+            "to_uint" | "to_sint" => {
+                if !base_ty.is_float() && !matches!(base_ty, Ty::Todo | Ty::Error) {
+                    self.errors.push(CompileError::general(
+                        &format!(".{}<N>() requires a floating-point operand, got {}", method.name, base_ty.display()),
+                        method.span,
+                    ));
+                    return Ty::Error;
+                }
+                if let Some(width_expr) = args.first() {
+                    if let Some(w) = self.eval_const_expr(width_expr, local_types) {
+                        let target_w = w as u32;
+                        if method.name == "to_uint" { Ty::UInt(target_w) } else { Ty::SInt(target_w) }
+                    } else {
+                        Ty::Error
+                    }
+                } else {
+                    self.errors.push(CompileError::general(
+                        &format!(".{}<N>() requires a width type argument, e.g. .{}<32>()", method.name, method.name),
+                        method.span,
+                    ));
+                    Ty::Error
+                }
+            }
             "reverse" => {
                 if let Some(chunk_expr) = args.first() {
                     if let Some(chunk) = self.eval_const_expr(chunk_expr, local_types) {
@@ -3758,6 +3893,56 @@ impl<'a> TypeChecker<'a> {
         }
         if *lt == Ty::Error || *rt == Ty::Error {
             return Ty::Error;
+        }
+
+        // Floating-point operands: comparisons → Bool; `+ - *` → the same float
+        // type (no widening). The two operands must be the identical float type;
+        // there is no implicit float conversion (use `.to_fp32()`/`.to_bf16()`).
+        if lt.is_float() || rt.is_float() {
+            let sym = match op {
+                BinOp::Add => "+", BinOp::Sub => "-", BinOp::Mul => "*",
+                BinOp::Eq => "==", BinOp::Neq => "!=", BinOp::Lt => "<",
+                BinOp::Gt => ">", BinOp::Lte => "<=", BinOp::Gte => ">=",
+                _ => "<op>",
+            };
+            match op {
+                BinOp::Eq | BinOp::Neq | BinOp::Lt | BinOp::Gt | BinOp::Lte | BinOp::Gte => {
+                    if lt != rt {
+                        self.errors.push(CompileError::general(
+                            &format!(
+                                "floating-point comparison `{sym}` requires matching types, got {} and {}",
+                                lt.display(), rt.display()
+                            ),
+                            _span,
+                        ));
+                        return Ty::Error;
+                    }
+                    return Ty::Bool;
+                }
+                BinOp::Add | BinOp::Sub | BinOp::Mul => {
+                    if lt != rt {
+                        self.errors.push(CompileError::general(
+                            &format!(
+                                "type mismatch in floating-point `{sym}`: {} vs {} (no implicit float conversion; use .to_fp32()/.to_bf16())",
+                                lt.display(), rt.display()
+                            ),
+                            _span,
+                        ));
+                        return Ty::Error;
+                    }
+                    return lt.clone();
+                }
+                _ => {
+                    self.errors.push(CompileError::general(
+                        &format!(
+                            "operator `{sym}` is not supported on floating-point type {} (v1 supports + - * and comparisons; use fma() for fused multiply-add)",
+                            if lt.is_float() { lt.display() } else { rt.display() }
+                        ),
+                        _span,
+                    ));
+                    return Ty::Error;
+                }
+            }
         }
 
         match op {
@@ -6665,6 +6850,9 @@ fn types_compatible(expected: &Ty, actual: &Ty) -> bool {
         // Bool ≡ UInt<1>: freely assignable in both directions.
         (Ty::Bool, Ty::UInt(1)) | (Ty::UInt(1), Ty::Bool) => true,
         (Ty::Bool, Ty::Bool) => true,
+        // Floating-point: same type only — no implicit FP32↔BF16 conversion.
+        (Ty::FP32, Ty::FP32) => true,
+        (Ty::BF16, Ty::BF16) => true,
         _ => false,
     }
 }

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -453,6 +453,19 @@ impl<'a> TypeChecker<'a> {
         self.check_pascal_case(&s.name);
         for field in &s.fields {
             self.check_snake_case(&field.name);
+            // v1: floats are only supported as scalar module signals. A float
+            // inside a struct would reach codegen via FieldAccess, which the
+            // float-op dispatch does not yet resolve — reject rather than
+            // silently emit integer arithmetic on the bit pattern.
+            if type_expr_contains_float(&field.ty) {
+                self.errors.push(CompileError::general(
+                    &format!(
+                        "floating-point types (FP32/BF16) are not supported in struct fields in v1 (field `{}` of `{}`)",
+                        field.name.name, s.name.name
+                    ),
+                    field.name.span,
+                ));
+            }
         }
     }
 
@@ -486,6 +499,59 @@ impl<'a> TypeChecker<'a> {
                     if let Some(n) = self.eval_const_expr(count_expr, &empty_types) {
                         if n > 0 {
                             self.vec_of_bus_ports.insert(p.name.name.clone(), n as u32);
+                        }
+                    }
+                }
+            }
+        }
+
+        // v1 float restriction: scalar FP32/BF16 signals are supported, but a
+        // float nested inside a Vec is not — `Vec<FP32,N>` element access
+        // (Index) is not yet resolved by the float-op dispatch, so it would
+        // silently emit integer arithmetic. Reject Vec-of-float on every
+        // declared signal type. (Scalar floats pass `is_float` but not the
+        // `Vec(...)` guard below.)
+        let mut float_decls: Vec<(&TypeExpr, Span, String)> = Vec::new();
+        for p in &m.ports {
+            float_decls.push((&p.ty, p.name.span, p.name.name.clone()));
+        }
+        for item in &m.body {
+            match item {
+                ModuleBodyItem::RegDecl(r)    => float_decls.push((&r.ty, r.name.span, r.name.name.clone())),
+                ModuleBodyItem::WireDecl(w)   => float_decls.push((&w.ty, w.name.span, w.name.name.clone())),
+                ModuleBodyItem::LetBinding(l) => {
+                    if let Some(t) = l.ty.as_ref() { float_decls.push((t, l.name.span, l.name.name.clone())); }
+                }
+                _ => {}
+            }
+        }
+        for (ty, span, name) in float_decls {
+            if matches!(ty, TypeExpr::Vec(..)) && type_expr_contains_float(ty) {
+                self.errors.push(CompileError::general(
+                    &format!("floating-point types (FP32/BF16) inside `Vec` are not supported in v1 (signal `{name}`)"),
+                    span,
+                ));
+            }
+        }
+
+        // A float `reg`'s reset value must be a float literal, not an integer
+        // literal (`reset rst => 1` would store the bit pattern 0x1, a tiny
+        // subnormal — almost never the intent). Catch the common foot-gun.
+        for item in &m.body {
+            if let ModuleBodyItem::RegDecl(r) = item {
+                if matches!(r.ty, TypeExpr::FP32 | TypeExpr::BF16) {
+                    let val = match &r.reset {
+                        RegReset::Explicit(_, _, _, v) => Some(v),
+                        RegReset::Inherit(_, v) => Some(v),
+                        RegReset::None => None,
+                    };
+                    if let Some(v) = val {
+                        if matches!(&v.kind, ExprKind::Literal(LitKind::Dec(_) | LitKind::Hex(_) | LitKind::Bin(_) | LitKind::Sized(_, _))) {
+                            let tn = if matches!(r.ty, TypeExpr::FP32) { "FP32" } else { "BF16" };
+                            self.errors.push(CompileError::general(
+                                &format!("float `reg {}: {tn}` reset value must be a float literal (e.g. `=> 0.0`), not an integer literal", r.name.name),
+                                v.span,
+                            ));
                         }
                     }
                 }
@@ -6345,6 +6411,24 @@ impl<'a> TypeChecker<'a> {
         for arg in &f.args {
             self.check_snake_case(&arg.name);
         }
+        // v1: floats are not supported in module-local functions — function
+        // params/locals are not added to the backend float-op dispatch scope,
+        // so a float `x + y` inside a function would silently emit integer
+        // arithmetic. Reject float signatures rather than miscompile.
+        for arg in &f.args {
+            if type_expr_contains_float(&arg.ty) {
+                self.errors.push(CompileError::general(
+                    &format!("floating-point types (FP32/BF16) are not supported in function parameters in v1 (parameter `{}` of `{}`)", arg.name.name, f.name.name),
+                    arg.name.span,
+                ));
+            }
+        }
+        if type_expr_contains_float(&f.ret_ty) {
+            self.errors.push(CompileError::general(
+                &format!("floating-point types (FP32/BF16) are not supported as a function return type in v1 (function `{}`)", f.name.name),
+                f.name.span,
+            ));
+        }
 
         // Build local type environment with args
         let mut local_types: HashMap<String, Ty> = HashMap::new();
@@ -6843,6 +6927,17 @@ fn eval_type_width_expr(e: &Expr) -> Option<u32> {
 
 /// Returns true if `actual` is assignable to `expected` without an explicit cast.
 /// In hardware, narrower unsigned values zero-extend to wider wires.
+/// True if a TypeExpr is, or contains (via Vec nesting), a float type.
+/// Used to reject FP32/BF16 in positions the v1 float-op dispatch can't
+/// resolve (Vec elements, struct fields, function signatures).
+fn type_expr_contains_float(ty: &TypeExpr) -> bool {
+    match ty {
+        TypeExpr::FP32 | TypeExpr::BF16 => true,
+        TypeExpr::Vec(inner, _) => type_expr_contains_float(inner),
+        _ => false,
+    }
+}
+
 fn types_compatible(expected: &Ty, actual: &Ty) -> bool {
     match (expected, actual) {
         (Ty::UInt(em), Ty::UInt(am)) => am <= em,

--- a/tests/fp_test.rs
+++ b/tests/fp_test.rs
@@ -124,3 +124,80 @@ end module Bad2
     let out = arch().arg("check").arg(&path).output().expect("run arch check");
     assert!(!out.status.success(), "FP32 -> BF16 assignment without cast must error");
 }
+
+/// Registered FP32 accumulator simulates correctly, including a float-literal
+/// reg reset value driving the seq float path.
+#[test]
+fn fp_reg_accumulator_sim() {
+    let td = tempfile::tempdir().expect("tempdir");
+    let out = arch()
+        .arg("sim")
+        .arg("tests/fp_v1/FpAcc.arch")
+        .arg("--tb")
+        .arg("tests/fp_v1/tb_acc.cpp")
+        .arg("--outdir")
+        .arg(td.path())
+        .output()
+        .expect("run arch sim");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        out.status.success() && stdout.contains("2 pass / 0 fail"),
+        "FP32 accumulator sim should pass; got:\n{stdout}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stderr),
+    );
+}
+
+/// float→int conversions are toward-zero, per-N saturating, NaN→type-max.
+#[test]
+fn fp_to_int_saturation_sim() {
+    let td = tempfile::tempdir().expect("tempdir");
+    let out = arch()
+        .arg("sim")
+        .arg("tests/fp_v1/FpSat.arch")
+        .arg("--tb")
+        .arg("tests/fp_v1/tb_sat.cpp")
+        .arg("--outdir")
+        .arg(td.path())
+        .output()
+        .expect("run arch sim");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        out.status.success() && stdout.contains("7 pass / 0 fail"),
+        "float->int saturation sim should pass; got:\n{stdout}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stderr),
+    );
+}
+
+/// v1 rejects floats in positions the float-op dispatch can't resolve:
+/// inside `Vec`, in `struct` fields, and in module-local `function`
+/// signatures — rather than silently emitting integer arithmetic.
+#[test]
+fn fp_unsupported_positions_rejected() {
+    let cases = [
+        ("vec", "module M\n  port a: in Vec<FP32, 4>;\n  port o: out FP32;\n  comb o = a[0]; end comb\nend module M\n"),
+        ("struct", "struct P\n  x: FP32;\nend struct P\nmodule M\n  port p: in P;\n  port o: out FP32;\n  comb o = p.x; end comb\nend module M\n"),
+        ("function", "module M\n  function f(x: FP32) -> FP32\n    return x;\n  end function f\n  port a: in FP32;\n  port o: out FP32;\n  comb o = f(a); end comb\nend module M\n"),
+    ];
+    for (label, src) in cases {
+        let td = tempfile::tempdir().expect("tempdir");
+        let path = td.path().join("M.arch");
+        std::fs::write(&path, src).unwrap();
+        let out = arch().arg("check").arg(&path).output().expect("run arch check");
+        assert!(
+            !out.status.success(),
+            "float in {label} position must be rejected in v1\nsrc:\n{src}"
+        );
+    }
+}
+
+/// A float `reg` reset value must be a float literal, not an integer literal
+/// (which would store a bit pattern, not the numeric value).
+#[test]
+fn fp_reg_integer_reset_rejected() {
+    let src = "module M\n  port clk: in Clock<S>;\n  port rst: in Reset<Sync>;\n  reg r: FP32 reset rst => 1;\n  seq on clk rising\n    r <= r;\n  end seq\nend module M\n";
+    let td = tempfile::tempdir().expect("tempdir");
+    let path = td.path().join("M.arch");
+    std::fs::write(&path, src).unwrap();
+    let out = arch().arg("check").arg(&path).output().expect("run arch check");
+    assert!(!out.status.success(), "integer reset for a float reg must be rejected");
+}

--- a/tests/fp_test.rs
+++ b/tests/fp_test.rs
@@ -1,0 +1,126 @@
+//! FP32 / BF16 floating-point v1 integration tests.
+//!
+//! Covers the front-end (parse + type check), the SoftFloat-semantics
+//! simulation backend (host IEEE-754 RNE), and the SystemVerilog emission
+//! shape. See doc/plan_fp_types.md.
+
+use std::process::Command;
+
+fn arch() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_arch"))
+}
+
+/// `arch check` accepts the full FP surface.
+#[test]
+fn fp_check_passes() {
+    let out = arch()
+        .arg("check")
+        .arg("tests/fp_v1/FpArith.arch")
+        .output()
+        .expect("run arch check");
+    assert!(
+        out.status.success(),
+        "arch check should pass for FpArith.arch\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+}
+
+/// End-to-end simulation: FP32/BF16 arithmetic, fma, is_nan, NaN
+/// canonicalization, and the conversion surface all match host IEEE-754.
+#[test]
+fn fp_sim_matches_host_ieee754() {
+    let td = tempfile::tempdir().expect("tempdir");
+    let out = arch()
+        .arg("sim")
+        .arg("tests/fp_v1/FpArith.arch")
+        .arg("--tb")
+        .arg("tests/fp_v1/tb_fp.cpp")
+        .arg("--outdir")
+        .arg(td.path())
+        .output()
+        .expect("run arch sim");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        out.status.success(),
+        "arch sim should pass for FpArith\nstdout:\n{stdout}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stderr),
+    );
+    assert!(
+        stdout.contains("13 pass / 0 fail"),
+        "expected all 13 FP checks to pass; got:\n{stdout}"
+    );
+}
+
+/// `arch build` dispatches FP ops to the emitted helper functions and
+/// prepends the helper package.
+#[test]
+fn fp_build_emits_helpers_and_dispatch() {
+    let td = tempfile::tempdir().expect("tempdir");
+    let arch_path = td.path().join("FpArith.arch");
+    std::fs::copy("tests/fp_v1/FpArith.arch", &arch_path).expect("copy arch into tempdir");
+    let out = arch()
+        .arg("build")
+        .arg(&arch_path)
+        .output()
+        .expect("run arch build");
+    assert!(
+        out.status.success(),
+        "arch build should succeed\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stderr),
+    );
+    let sv = std::fs::read_to_string(td.path().join("FpArith.sv")).expect("read FpArith.sv");
+    assert!(sv.contains("function automatic logic [31:0] arch_f32_add"), "f32 add helper missing:\n{sv}");
+    assert!(sv.contains("function automatic logic [15:0] arch_bf16_add"), "bf16 add helper missing");
+    assert!(sv.contains("assign sum = arch_f32_add(a, b);"), "f32 add not dispatched:\n{sv}");
+    assert!(sv.contains("assign prod = arch_f32_mul(a, b);"), "f32 mul not dispatched");
+    assert!(sv.contains("assign hsum = arch_bf16_add(ha, hb);"), "bf16 add not dispatched");
+    assert!(sv.contains("arch_fma_f32(a, b, c)"), "fma not dispatched");
+    assert!(sv.contains("arch_bf16_to_f32(ha)"), "bf16->f32 conversion not dispatched");
+    // FP32 and BF16 ports are packed bit vectors.
+    assert!(sv.contains("input logic [31:0] a"), "FP32 port width wrong");
+    assert!(sv.contains("input logic [15:0] ha"), "BF16 port width wrong");
+}
+
+/// The no-implicit-conversion rule: mixing FP32 and BF16 in an operator,
+/// and assigning across float types without an explicit cast, are errors.
+#[test]
+fn fp_no_implicit_conversion_errors() {
+    let src = r#"module Bad
+  port a: in FP32;
+  port h: in BF16;
+  port o: out FP32;
+  comb o = a + h; end comb
+end module Bad
+"#;
+    let td = tempfile::tempdir().expect("tempdir");
+    let path = td.path().join("Bad.arch");
+    std::fs::write(&path, src).unwrap();
+    let out = arch().arg("check").arg(&path).output().expect("run arch check");
+    assert!(!out.status.success(), "mixing FP32 and BF16 must be a type error");
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        combined.contains("float") || combined.contains("FP32") || combined.contains("BF16"),
+        "error should mention the float type mismatch; got:\n{combined}"
+    );
+}
+
+/// Assigning an FP32 value into a BF16 target without `.to_bf16()` is rejected.
+#[test]
+fn fp_assign_across_types_errors() {
+    let src = r#"module Bad2
+  port a: in FP32;
+  port o: out BF16;
+  comb o = a; end comb
+end module Bad2
+"#;
+    let td = tempfile::tempdir().expect("tempdir");
+    let path = td.path().join("Bad2.arch");
+    std::fs::write(&path, src).unwrap();
+    let out = arch().arg("check").arg(&path).output().expect("run arch check");
+    assert!(!out.status.success(), "FP32 -> BF16 assignment without cast must error");
+}

--- a/tests/fp_v1/FpAcc.arch
+++ b/tests/fp_v1/FpAcc.arch
@@ -1,0 +1,16 @@
+// Registered FP32 accumulator — exercises the seq float path and a
+// float-literal reg reset value.
+module FpAcc
+  port clk: in Clock<Sys>;
+  port rst: in Reset<Sync>;
+  port en: in Bool;
+  port x: in FP32;
+  port acc: out FP32;
+  reg acc_r: FP32 reset rst => 0.0;
+  seq on clk rising
+    if en
+      acc_r <= acc_r + x;
+    end if
+  end seq
+  comb acc = acc_r; end comb
+end module FpAcc

--- a/tests/fp_v1/FpArith.arch
+++ b/tests/fp_v1/FpArith.arch
@@ -1,0 +1,38 @@
+// FP32 / BF16 v1 exercise: arithmetic, comparisons, fma, is_nan, and the
+// conversion surface (float↔float, int↔float). Plain comb outputs so the
+// testbench sees same-cycle results.
+module FpArith
+  port a: in FP32;
+  port b: in FP32;
+  port c: in FP32;
+  port sum:   out FP32;
+  port diff:  out FP32;
+  port prod:  out FP32;
+  port fused: out FP32;
+  port a_gt_b:  out Bool;
+  port a_is_nan: out Bool;
+
+  port ha: in BF16;
+  port hb: in BF16;
+  port hsum:    out BF16;
+  port a_to_h:  out BF16;
+  port ha_to_f: out FP32;
+
+  port i: in SInt<32>;
+  port i_to_f: out FP32;
+  port f_to_i: out SInt<32>;
+
+  comb sum   = a + b; end comb
+  comb diff  = a - b; end comb
+  comb prod  = a * b; end comb
+  comb fused = fma(a, b, c); end comb
+  comb a_gt_b   = a > b; end comb
+  comb a_is_nan = is_nan(a); end comb
+
+  comb hsum    = ha + hb; end comb
+  comb a_to_h  = a.to_bf16(); end comb
+  comb ha_to_f = ha.to_fp32(); end comb
+
+  comb i_to_f = i.to_fp32(); end comb
+  comb f_to_i = a.to_sint<32>(); end comb
+end module FpArith

--- a/tests/fp_v1/FpSat.arch
+++ b/tests/fp_v1/FpSat.arch
@@ -1,0 +1,10 @@
+// float->int conversions: toward-zero, per-N saturating, NaN->type-max.
+module FpSat
+  port f: in FP32;
+  port s8:  out SInt<8>;
+  port u8:  out UInt<8>;
+  port s32: out SInt<32>;
+  comb s8  = f.to_sint<8>(); end comb
+  comb u8  = f.to_uint<8>(); end comb
+  comb s32 = f.to_sint<32>(); end comb
+end module FpSat

--- a/tests/fp_v1/tb_acc.cpp
+++ b/tests/fp_v1/tb_acc.cpp
@@ -1,0 +1,18 @@
+#include "VFpAcc.h"
+#include <cstdio>
+#include <cstring>
+static VFpAcc dut; static int pass=0,fail=0;
+static uint32_t b32(float f){uint32_t u;memcpy(&u,&f,4);return u;}
+static float f32(uint32_t u){float f;memcpy(&f,&u,4);return f;}
+#define CHECK(c,m,...) do{if(c){printf("  PASS: " m "\n",##__VA_ARGS__);++pass;}else{printf("  FAIL: " m "\n",##__VA_ARGS__);++fail;}}while(0)
+static void tick(){ dut.clk=0; dut.eval(); dut.clk=1; dut.eval(); }
+int main(){
+  dut.rst=1; dut.en=0; dut.x=b32(0.0f); tick();
+  CHECK(f32(dut.acc)==0.0f, "reset acc=0.0 (got %g)", f32(dut.acc));
+  dut.rst=0; dut.en=1;
+  dut.x=b32(1.5f); tick();
+  dut.x=b32(2.25f); tick();
+  dut.x=b32(0.25f); tick();
+  CHECK(f32(dut.acc)==4.0f, "1.5+2.25+0.25=4.0 (got %g)", f32(dut.acc));
+  printf("=== %d pass / %d fail ===\n",pass,fail); return fail==0?0:1;
+}

--- a/tests/fp_v1/tb_fp.cpp
+++ b/tests/fp_v1/tb_fp.cpp
@@ -1,0 +1,40 @@
+// Testbench for FpArith — verifies FP32/BF16 arithmetic, fma, is_nan, and
+// conversions against host IEEE-754 reference values.
+#include "VFpArith.h"
+#include <cstdio>
+#include <cstring>
+#include <cmath>
+static VFpArith dut;
+static int pass=0, fail=0;
+static uint32_t b32(float f){ uint32_t u; memcpy(&u,&f,4); return u; }
+static float f32(uint32_t u){ float f; memcpy(&f,&u,4); return f; }
+static uint16_t bf16(float f){ uint32_t u=b32(f); uint32_t lsb=(u>>16)&1; u+=0x7FFF+lsb; return (uint16_t)(u>>16); }
+static float bf2f(uint16_t h){ return f32(((uint32_t)h)<<16); }
+#define CHECK(c,m,...) do{ if(c){printf("  PASS: " m "\n",##__VA_ARGS__);++pass;} else {printf("  FAIL: " m "\n",##__VA_ARGS__);++fail;} }while(0)
+int main(){
+    dut.a=b32(1.5f); dut.b=b32(2.25f); dut.c=b32(0.5f);
+    dut.ha=bf16(1.5f); dut.hb=bf16(0.5f);
+    dut.i=-7;
+    dut.eval();
+    CHECK(f32(dut.sum)==3.75f,  "FP32 1.5+2.25=3.75 (got %g)", f32(dut.sum));
+    CHECK(f32(dut.diff)==-0.75f, "FP32 1.5-2.25=-0.75 (got %g)", f32(dut.diff));
+    CHECK(f32(dut.prod)==3.375f, "FP32 1.5*2.25=3.375 (got %g)", f32(dut.prod));
+    CHECK(f32(dut.fused)==fmaf(1.5f,2.25f,0.5f), "FP32 fma=%g (got %g)", fmaf(1.5f,2.25f,0.5f), f32(dut.fused));
+    CHECK(dut.a_gt_b==0, "1.5 > 2.25 is false (got %u)", (unsigned)dut.a_gt_b);
+    CHECK(dut.a_is_nan==0, "1.5 is not NaN (got %u)", (unsigned)dut.a_is_nan);
+    CHECK(bf2f(dut.hsum)==2.0f, "BF16 1.5+0.5=2.0 (got %g)", bf2f(dut.hsum));
+    CHECK(dut.a_to_h==bf16(1.5f), "1.5.to_bf16() (got 0x%04X)", (unsigned)dut.a_to_h);
+    CHECK(f32(dut.ha_to_f)==1.5f, "bf16(1.5).to_fp32()=1.5 (got %g)", f32(dut.ha_to_f));
+    CHECK(f32(dut.i_to_f)==-7.0f, "int(-7).to_fp32()=-7 (got %g)", f32(dut.i_to_f));
+    CHECK((int32_t)dut.f_to_i==1, "1.5.to_sint<32>()=1 trunc (got %d)", (int32_t)dut.f_to_i);
+
+    // NaN canonicalization + is_nan
+    dut.a=0x7FC00000u; dut.eval();
+    CHECK(dut.a_is_nan==1, "0x7FC00000 is NaN (got %u)", (unsigned)dut.a_is_nan);
+    // sNaN input gets quieted to canonical qNaN through an op
+    dut.a=0x7F800001u; dut.b=b32(1.0f); dut.eval();
+    CHECK(dut.sum==0x7FC00000u, "sNaN+1.0 -> canonical qNaN 0x7FC00000 (got 0x%08X)", dut.sum);
+
+    printf("=== %d pass / %d fail ===\n", pass, fail);
+    return fail==0?0:1;
+}

--- a/tests/fp_v1/tb_sat.cpp
+++ b/tests/fp_v1/tb_sat.cpp
@@ -1,0 +1,20 @@
+#include "VFpSat.h"
+#include <cstdio>
+#include <cstring>
+static VFpSat dut; static int pass=0,fail=0;
+static uint32_t b32(float f){uint32_t u;memcpy(&u,&f,4);return u;}
+#define CHECK(c,m,...) do{if(c){printf("  PASS: " m "\n",##__VA_ARGS__);++pass;}else{printf("  FAIL: " m "\n",##__VA_ARGS__);++fail;}}while(0)
+int main(){
+  dut.f=b32(1000.0f); dut.eval();
+  CHECK((int8_t)dut.s8==127,  "1000->s8 saturates 127 (got %d)",(int)(int8_t)dut.s8);
+  CHECK((uint8_t)dut.u8==255, "1000->u8 saturates 255 (got %u)",(unsigned)(uint8_t)dut.u8);
+  dut.f=b32(-5.0f); dut.eval();
+  CHECK((int8_t)dut.s8==-5,  "-5->s8 = -5 (got %d)",(int)(int8_t)dut.s8);
+  CHECK((uint8_t)dut.u8==0,  "-5->u8 saturates 0 (got %u)",(unsigned)(uint8_t)dut.u8);
+  dut.f=0x7FC00000u; dut.eval();
+  CHECK((int8_t)dut.s8==127, "NaN->s8 = max (got %d)",(int)(int8_t)dut.s8);
+  CHECK((int32_t)dut.s32==2147483647, "NaN->s32 = INT32_MAX (got %d)",(int32_t)dut.s32);
+  dut.f=b32(2.7f); dut.eval();
+  CHECK((int8_t)dut.s8==2, "2.7->s8 = 2 trunc (got %d)",(int)(int8_t)dut.s8);
+  printf("=== %d pass / %d fail ===\n",pass,fail); return fail==0?0:1;
+}


### PR DESCRIPTION
## Summary

Implements first-class **`FP32` and `BF16` floating-point types** for LLM inference datapaths in ARCH, per [`doc/plan_fp_types.md`](https://github.com/arch-hdl-lang/arch-com/blob/claude/named-vector-dimensions-py9jaz/doc/plan_fp_types.md). Tracking issue: #609.

An independent pre-PR review (verdict: NEEDS-CHANGES) found real correctness issues, all of which are fixed in this branch — see the second commit.

## What's implemented

- **Front-end**: `FP32`/`BF16` keywords, float literals (`1.5`, `3.0e-2`), built-in combinational `+ - *`, ordered comparisons → `Bool`, `fma(a,b,c)`, `is_nan(x)`, and conversions `.to_fp32()` / `.to_bf16()` / `.to_uint<N>()` / `.to_sint<N>()`. No-implicit-conversion is enforced (mixing `FP32`/`BF16`, or float↔int without a cast, is a compile error).
- **Simulation** (`arch sim`): floats carried as bit patterns; ops dispatch to `_arch_*` helpers using the host FPU (IEEE-754 RNE — bit-identical to SoftFloat for `+ - * fma`). BF16 via f32 intermediate (innocuous double rounding). Canonical NaN `0x7FC00000`/`0x7FC0`, sNaN quieted, float→int toward-zero, **per-N saturating, NaN→type-max**. Verified bit-exact against host IEEE-754.
- **SystemVerilog** (`arch build`): `FP32`→`logic[31:0]`, `BF16`→`logic[15:0]`; ops dispatch to emitted `arch_f32_*`/`arch_bf16_*` behavioral `function automatic` helpers.

## Review fixes (commit 2)

- **Reject** floats in positions the op-dispatch can't resolve — inside `Vec`, in `struct` fields, in module-local `function` signatures — instead of silently emitting integer arithmetic on the bit pattern. Each rejected at type-check with a clear v1-scope message.
- **float→int saturation** now per-N (was 64-bit-only then truncated): toward-zero, saturating to the target width, NaN→type-max.
- **Float reg reset**: float literals now parse in the reset-value position; an integer-literal reset for a float reg is rejected.
- **SV bf16 round helper**: replaced an illegal part-select on a parenthesized expression with a local temp, so emitted BF16 SystemVerilog is LRM-valid.

## v1 scope (documented in plan §12)

Floats are supported as scalar signals + ops. Vec/struct/function floats, `--fp-compat=cuda`, the SMT formal proof, the synthesizable CVFPU datapath, and a vendored SoftFloat build are deferred follow-ups — none are silently miscompiled.

## Testing

`tests/fp_test.rs` (9 tests: check/sim/build, accumulator, saturation, + negative type-error cases) and `tests/fp_v1/` fixtures. **Full suite green: 748 tests, 0 warnings.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015i1am9AsxcxNnDeb6zU38p)_