### PR TITLE
test(fp): SMT equivalence proofs for non-rounding FP RTL (P3 partial)

### DIFF
--- a/doc/plan_fp_types.md
+++ b/doc/plan_fp_types.md
@@ -331,6 +331,20 @@ methods; we want **both**, with formal as the primary guarantee where tractable.
 
 ### 8.1 Formal equivalence via SMT FloatingPoint theory (primary)
 
+**Status (partial, landed):** proofs for the **non-rounding** operators are
+wired in under `tests/fp_v1/smt_proof/` and run by
+`cargo test --test fp_test fp_smt_equivalence_proofs` (z3, auto-skips if absent).
+Each emitted RTL operator is transcribed bit-for-bit into SMT-LIB and proven
+`unsat`-equivalent to the `FloatingPoint` theory over its **entire** input space:
+FP32 comparisons ×6 (2^64), `f32→bf16` narrow RNE (2^32), `bf16→f32` widen exact
+(2^16), and `f32→{sint,uint}` toward-zero in-range (vs the partial `fp.to_sbv` /
+`fp.to_ubv`). The **RNE arithmetic** (`+ - *`, `fma`, `int→float`) is *not* yet
+formally proved — the emitted rounder's packed-struct returns and early
+`return`/`break` are beyond the available SV→SMT frontend (Yosys 0.33), and a
+from-scratch SMT rounder would be an unfaithful second implementation; it stays
+on the §8.2 differential backstop pending an EBMC-class frontend. See
+`tests/fp_v1/smt_proof/README.md`.
+
 ARCH already has a formal backend (`src/formal.rs`, SMT-LIB2, EBMC) and a
 proof-certificate culture (`construct_proof_cert.rs`, `thread_proof_cert.rs`).
 We exploit that the **SMT-LIB `FloatingPoint` theory is exactly IEEE-754 RNE** —
@@ -435,7 +449,10 @@ vectors against our configured instance once, in CI.
 2. **P2 — RTL** ✅ *(landed)*: emit synthesizable `arch_f32_*`/`arch_bf16_*` SV;
    differential co-sim campaign (§8.2) green against the host-IEEE-754 reference
    under Verilator. Remaining P2 stretch: pipelined latency-N variant.
-3. **P3 — formal sign-off**: SMT equivalence (§8.1) — full proof for all BF16
+3. **P3 — formal sign-off** *(partial)*: SMT equivalence (§8.1) is wired for the
+   non-rounding operators (compares, bf16 widen/narrow, float→int in-range),
+   proven exhaustively under z3; the RNE arithmetic awaits an SV→SMT frontend
+   that accepts the emitted rounder. Original target — SMT equivalence: full proof for all BF16
    ops, FP32 where tractable, documented gaps backstopped by P2. Proof certs.
 4. **P4 — docs & examples**: spec sections, AI reference card entry, a small
    GEMM/attention example exercising `fma`.
@@ -487,10 +504,12 @@ Landed and tested (`cargo test --test fp_test`, plus the full suite green):
    §8.2 differential Verilator campaign is wired in as a regression test. What
    remains of §7 is the *pipelined latency-N* variant (v1 is combinational, by
    design) and the §8.1 SMT equivalence proof.
-3. **`--fp-compat=cuda` (§6.2) and the formal equivalence proof (§8.1) are not yet
-   wired** — the default RISC-V special-value policy is implemented in both sim
-   and the synthesizable SV; `arch formal` rejects FP types with a clear message.
-   (The §8.2 differential campaign **is** now wired — see delta #2.)
+3. **`--fp-compat=cuda` (§6.2) is not yet wired**; the default RISC-V
+   special-value policy is implemented in both sim and the synthesizable SV.
+   `arch formal` still rejects FP types in a design with a clear message. The
+   **§8.1 SMT equivalence proof is partially wired** (compares + conversions
+   proven exhaustively under z3; RNE arithmetic deferred — see §8.1 status), and
+   the **§8.2 differential campaign is wired** (delta #2).
 4. **Float literals default to `FP32`**; `BF16` immediates use `.to_bf16()`
    (§3.3, resolved open question — keeps no-implicit-conversion uniform).
 

--- a/tests/fp_test.rs
+++ b/tests/fp_test.rs
@@ -275,3 +275,65 @@ fn fp_rtl_differential_equiv_verilator() {
         String::from_utf8_lossy(&run.stderr)
     );
 }
+
+/// SMT equivalence proofs (doc/plan_fp_types.md §8.1): the emitted FP RTL
+/// (`src/codegen/fp.rs`), transcribed bit-for-bit into SMT-LIB, is proven
+/// equivalent to the IEEE-754 `FloatingPoint` theory by z3. Each `.smt2` in
+/// `tests/fp_v1/smt_proof/` must discharge `unsat` (no counterexample over the
+/// entire input space). Covers FP32 comparisons, BF16 widen/narrow, and
+/// float->int (in-range); the RNE arithmetic stays on the §8.2 differential
+/// backstop (see the directory README). Emits a small proof certificate.
+///
+/// Skips cleanly when `z3` is not installed.
+#[test]
+fn fp_smt_equivalence_proofs() {
+    fn z3_available() -> bool {
+        std::process::Command::new("z3")
+            .arg("--version")
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+    }
+    if !z3_available() {
+        eprintln!("skipping fp_smt_equivalence_proofs: z3 not in PATH");
+        return;
+    }
+    let z3ver = {
+        let o = std::process::Command::new("z3").arg("--version").output().unwrap();
+        String::from_utf8_lossy(&o.stdout).trim().to_string()
+    };
+
+    let manifest = env!("CARGO_MANIFEST_DIR");
+    let dir = format!("{manifest}/tests/fp_v1/smt_proof");
+    let proofs = [
+        "fp32_compare.smt2",
+        "bf16_narrow.smt2",
+        "bf16_widen.smt2",
+        "f32_to_sint.smt2",
+        "f32_to_uint.smt2",
+    ];
+
+    let mut cert = String::new();
+    cert.push_str("ARCH FP RTL — SMT equivalence proof certificate (plan §8.1)\n");
+    cert.push_str(&format!("solver: {z3ver}\n"));
+    cert.push_str("property: emitted RTL (src/codegen/fp.rs) ≡ SMT FloatingPoint theory (IEEE-754 RNE)\n\n");
+
+    for p in proofs {
+        let path = format!("{dir}/{p}");
+        let out = std::process::Command::new("z3")
+            .arg("-T:600") // per-query 600s wall-clock cap
+            .arg(&path)
+            .output()
+            .unwrap_or_else(|e| panic!("failed to run z3 on {p}: {e}"));
+        let res = String::from_utf8_lossy(&out.stdout);
+        let first = res.lines().next().unwrap_or("").trim();
+        cert.push_str(&format!("{p}: {first}\n"));
+        assert_eq!(
+            first, "unsat",
+            "SMT proof {p} did not discharge as unsat (got {first:?})\nstdout:\n{res}\nstderr:\n{}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+    cert.push_str("\nresult: ALL PROVED (unsat)\n");
+    eprintln!("\n{cert}");
+}

--- a/tests/fp_v1/smt_proof/README.md
+++ b/tests/fp_v1/smt_proof/README.md
@@ -1,0 +1,45 @@
+# FP RTL — SMT equivalence proofs (plan §8.1)
+
+Machine-checked proofs that the emitted synthesizable FP SystemVerilog
+(`src/codegen/fp.rs`) is equivalent to the SMT-LIB `FloatingPoint` theory, which
+**is** IEEE-754 round-to-nearest-even. Transitively:
+
+```
+emitted SV  ≡  SMT fp.* (RNE)  ≡  IEEE-754
+   (proved here)   (by the theory)
+```
+
+Each `.smt2` asserts the *negation* of the equivalence and asks z3 for a
+counterexample; `unsat` means none exists — the property holds for **all**
+inputs (exhaustive, not sampled). The `rtl_*` definitions in each file are a
+literal transcription of the SystemVerilog bit-logic in `src/codegen/fp.rs`, so
+these prove the emitted RTL directly (not a separate model).
+
+Run via `cargo test --test fp_test fp_smt_equivalence_proofs` (auto-skips when
+`z3` is not on `PATH`), or by hand: `z3 fp32_compare.smt2`.
+
+| File | Operator(s) | Spec | Input space |
+|---|---|---|---|
+| `fp32_compare.smt2` | `arch_f32_{eq,ne,lt,le,gt,ge}` | `fp.eq/lt/leq/gt/geq` | 2^64 (all pairs) |
+| `bf16_narrow.smt2` | `arch_f32_to_bf16` | RNE round f32→`(_ FloatingPoint 8 8)` | 2^32 |
+| `bf16_widen.smt2` | `arch_bf16_to_f32` | exact widen bf16→f32 | 2^16 |
+| `f32_to_sint.smt2` | `arch_f32_to_sint` (N=32) | `fp.to_sbv` RTZ, in-range | 2^32 |
+| `f32_to_uint.smt2` | `arch_f32_to_uint` (N=32) | `fp.to_ubv` RTZ, in-range | 2^32 |
+
+All currently discharge **`unsat`** under z3 4.8.12.
+
+## Scope and deferrals (no silent caps)
+
+- **float→int** is proved only for the **in-range** cases: SMT-LIB `fp.to_sbv` /
+  `fp.to_ubv` are *partial* functions (undefined for NaN / out-of-range), so the
+  saturation and NaN→type-max corners (plan §6) are signed off by the §8.2
+  differential Verilator campaign instead, exactly as §8.1 anticipates.
+- **RNE arithmetic** (`+ - *`, `fma`, and `int→float`) is **not** proved here.
+  The emitted rounder uses packed-struct function returns and early `return` /
+  `break`, which the available SV→SMT frontend (Yosys 0.33) cannot lift, and a
+  from-scratch SMT rounder would be a second, unfaithful implementation. These
+  operators remain backstopped by the §8.2 differential campaign
+  (`fp_rtl_differential_equiv_verilator`), which checks them bit-exact against a
+  host-IEEE-754 reference over corner + randomized + cancellation-prone vectors.
+  A full formal sign-off of the arithmetic datapath (via EBMC or a frontend that
+  accepts the emitted SV) is the remaining P3 item.

--- a/tests/fp_v1/smt_proof/bf16_narrow.smt2
+++ b/tests/fp_v1/smt_proof/bf16_narrow.smt2
@@ -1,0 +1,27 @@
+; SMT equivalence proof (doc/plan_fp_types.md §8.1).
+;
+; Property: the emitted f32->bf16 narrow RTL (src/codegen/fp.rs:
+;   arch_f32_to_bf16) is bit-exactly equivalent to IEEE-754 round-to-nearest-
+;   even rounding of the f32 value into binary-bf16 (FloatingPoint 8 8), with a
+;   canonical quiet NaN (0x7FC0), for ALL 2^32 inputs. `rtl_narrow` is a literal
+;   transcription of the SystemVerilog bit-logic (guard/round/sticky bias trick).
+;
+; Result: `unsat` (z3) ⇒ proven for all inputs.
+(set-logic QF_FPBV)
+(define-sort BV () (_ BitVec 32))
+(define-fun isnan32 ((x BV)) Bool (and (= ((_ extract 30 23) x) #b11111111) (not (= ((_ extract 22 0) x) (_ bv0 23)))))
+; ---- emitted-RTL arch_f32_to_bf16, transcribed bit-for-bit ----
+(define-fun rtl_narrow ((x BV)) (_ BitVec 16)
+  (ite (isnan32 x) #x7FC0
+    (let ((lsb ((_ extract 16 16) x)) (rbit ((_ extract 15 15) x))
+          (sticky (ite (= ((_ extract 14 0) x) (_ bv0 15)) #b0 #b1)))
+      (let ((roundup (bvand rbit (bvor sticky lsb))))
+        ((_ extract 31 16) (bvadd x (ite (= roundup #b1) #x00010000 #x00000000)))))))
+(declare-fun x () BV)
+(define-fun fx   () (_ FloatingPoint 8 24) ((_ to_fp 8 24) x))
+(define-fun spec () (_ FloatingPoint 8  8) ((_ to_fp 8 8) RNE fx))   ; round f32 value -> bf16, RNE
+(define-fun rbf  () (_ BitVec 16) (rtl_narrow x))
+(define-fun frbf () (_ FloatingPoint 8 8) ((_ to_fp 8 8) rbf))
+; bit-exact: NaN -> canonical 0x7FC0, else same bf16 value (incl signed zero)
+(assert (not (ite (fp.isNaN spec) (= rbf #x7FC0) (= frbf spec))))
+(check-sat)

--- a/tests/fp_v1/smt_proof/bf16_widen.smt2
+++ b/tests/fp_v1/smt_proof/bf16_widen.smt2
@@ -1,0 +1,18 @@
+; SMT equivalence proof (doc/plan_fp_types.md §8.1).
+;
+; Property: the emitted bf16->f32 widen RTL (src/codegen/fp.rs:
+;   arch_bf16_to_f32 = canon({h, 16'b0})) is bit-exactly equal to the EXACT
+;   widening of the bf16 value into f32 (bf16 ⊂ f32), with canonical NaN, for
+;   ALL 2^16 inputs. `rtl_widen` is a literal transcription of the SV.
+;
+; Result: `unsat` (z3) ⇒ proven for all inputs.
+(set-logic QF_FPBV)
+(define-fun isnan32 ((x (_ BitVec 32))) Bool (and (= ((_ extract 30 23) x) #b11111111) (not (= ((_ extract 22 0) x) (_ bv0 23)))))
+; ---- emitted-RTL arch_bf16_to_f32, transcribed bit-for-bit ----
+(define-fun rtl_widen ((h (_ BitVec 16))) (_ BitVec 32)
+  (let ((z (concat h (_ bv0 16)))) (ite (isnan32 z) #x7FC00000 z)))
+(declare-fun h () (_ BitVec 16))
+(define-fun spec () (_ FloatingPoint 8 24) ((_ to_fp 8 24) RNE ((_ to_fp 8 8) h)))  ; widen bf16 value -> f32 (exact)
+(define-fun rf   () (_ BitVec 32) (rtl_widen h))
+(assert (not (ite (fp.isNaN spec) (= rf #x7FC00000) (= ((_ to_fp 8 24) rf) spec))))
+(check-sat)

--- a/tests/fp_v1/smt_proof/f32_to_sint.smt2
+++ b/tests/fp_v1/smt_proof/f32_to_sint.smt2
@@ -1,0 +1,47 @@
+; SMT equivalence proof (doc/plan_fp_types.md §8.1).
+;
+; Property: the emitted float->sint RTL (src/codegen/fp.rs: arch_f32_to_sint,
+;   here at N=32) computes the toward-zero conversion bit-exactly. For inputs in
+;   the representable range it equals the IEEE-754 `fp.to_sbv` (RTZ) partial
+;   function. The decode + variable-shift + saturate logic is transcribed
+;   literally from the SV.
+;
+; Scope (per §8.1): SMT-LIB `fp.to_sbv` is a PARTIAL function — undefined for
+;   NaN / out-of-range inputs — so this proves only the in-range cases. The
+;   saturation and NaN->type-max corners (§6) are signed off by the §8.2
+;   differential campaign instead, as the plan documents.
+;
+; Result: `unsat` (z3) ⇒ proven for all in-range inputs.
+(set-logic QF_FPBV)
+(define-sort BV32 () (_ BitVec 32))
+(define-fun isnan32 ((x BV32)) Bool (and (= ((_ extract 30 23) x) #b11111111) (not (= ((_ extract 22 0) x) (_ bv0 23)))))
+(define-fun isinf32 ((x BV32)) Bool (and (= ((_ extract 30 23) x) #b11111111) (= ((_ extract 22 0) x) (_ bv0 23))))
+(define-fun iszero32 ((x BV32)) Bool (= ((_ extract 30 0) x) (_ bv0 31)))
+; ---- emitted-RTL decode + toward-zero magnitude, transcribed bit-for-bit ----
+(define-fun mant24 ((x BV32)) (_ BitVec 24)
+  (ite (= ((_ extract 30 23) x) #b00000000) (concat #b0 ((_ extract 22 0) x)) (concat #b1 ((_ extract 22 0) x))))
+(define-fun eunb128 ((x BV32)) (_ BitVec 128)
+  (ite (= ((_ extract 30 23) x) #b00000000) (bvneg (_ bv149 128)) (bvsub ((_ zero_extend 120) ((_ extract 30 23) x)) (_ bv150 128))))
+(define-fun magf ((x BV32)) (_ BitVec 128)
+  (let ((m ((_ zero_extend 104) (mant24 x))) (e (eunb128 x)))
+    (ite (bvsge e (_ bv64 128)) (bvnot (_ bv0 128))
+    (ite (bvsge e (_ bv0 128))  (bvshl m e)
+         (let ((sh (bvneg e))) (ite (bvuge sh (_ bv128 128)) (_ bv0 128) (bvlshr m sh)))))))
+(define-fun limpos_s () (_ BitVec 128) (bvsub (bvshl (_ bv1 128) (_ bv31 128)) (_ bv1 128)))
+(define-fun limneg_s () (_ BitVec 128) (bvshl (_ bv1 128) (_ bv31 128)))
+(define-fun rtl_to_sint32 ((x BV32)) (_ BitVec 64)
+  (ite (isnan32 x) ((_ zero_extend 32) #x7FFFFFFF)
+  (ite (iszero32 x) (_ bv0 64)
+  (ite (isinf32 x) (ite (= ((_ extract 31 31) x) #b1) ((_ extract 63 0) (bvadd (bvnot limneg_s) (_ bv1 128))) ((_ extract 63 0) limpos_s))
+  (let ((mag (magf x)))
+    (ite (= ((_ extract 31 31) x) #b0)
+         (ite (bvugt mag limpos_s) ((_ extract 63 0) limpos_s) ((_ extract 63 0) mag))
+         (ite (bvugt mag limneg_s) ((_ extract 63 0) (bvadd (bvnot limneg_s) (_ bv1 128))) ((_ extract 63 0) (bvadd (bvnot mag) (_ bv1 128))))))))))
+(declare-fun x () BV32)
+(define-fun fx   () (_ FloatingPoint 8 24) ((_ to_fp 8 24) x))
+(define-fun spec () (_ BitVec 64) ((_ fp.to_sbv 64) RTZ fx))
+(define-fun inrange () Bool (and (not (fp.isNaN fx)) (not (fp.isInfinite fx))
+   (fp.lt (fp.abs fx) ((_ to_fp 8 24) RNE 2147483648.0))))
+(assert inrange)
+(assert (not (= ((_ sign_extend 32) ((_ extract 31 0) (rtl_to_sint32 x))) spec)))
+(check-sat)

--- a/tests/fp_v1/smt_proof/f32_to_uint.smt2
+++ b/tests/fp_v1/smt_proof/f32_to_uint.smt2
@@ -1,0 +1,41 @@
+; SMT equivalence proof (doc/plan_fp_types.md §8.1).
+;
+; Property: the emitted float->uint RTL (src/codegen/fp.rs: arch_f32_to_uint,
+;   here at N=32) computes the toward-zero conversion bit-exactly, equal to the
+;   IEEE-754 `fp.to_ubv` (RTZ) partial function for in-range inputs. Decode +
+;   variable-shift + negative->0 + saturate logic transcribed literally.
+;
+; Scope (per §8.1): `fp.to_ubv` is partial (undefined for NaN / out-of-range /
+;   negative), so this proves the in-range non-negative cases; saturation and
+;   NaN->uint-max corners are signed off by the §8.2 differential campaign.
+;
+; Result: `unsat` (z3) ⇒ proven for all in-range inputs.
+(set-logic QF_FPBV)
+(define-sort BV32 () (_ BitVec 32))
+(define-fun isnan32 ((x BV32)) Bool (and (= ((_ extract 30 23) x) #b11111111) (not (= ((_ extract 22 0) x) (_ bv0 23)))))
+(define-fun isinf32 ((x BV32)) Bool (and (= ((_ extract 30 23) x) #b11111111) (= ((_ extract 22 0) x) (_ bv0 23))))
+(define-fun iszero32 ((x BV32)) Bool (= ((_ extract 30 0) x) (_ bv0 31)))
+(define-fun mant24 ((x BV32)) (_ BitVec 24)
+  (ite (= ((_ extract 30 23) x) #b00000000) (concat #b0 ((_ extract 22 0) x)) (concat #b1 ((_ extract 22 0) x))))
+(define-fun eunb128 ((x BV32)) (_ BitVec 128)
+  (ite (= ((_ extract 30 23) x) #b00000000) (bvneg (_ bv149 128)) (bvsub ((_ zero_extend 120) ((_ extract 30 23) x)) (_ bv150 128))))
+(define-fun magf ((x BV32)) (_ BitVec 128)
+  (let ((m ((_ zero_extend 104) (mant24 x))) (e (eunb128 x)))
+    (ite (bvsge e (_ bv64 128)) (bvnot (_ bv0 128))
+    (ite (bvsge e (_ bv0 128))  (bvshl m e)
+         (let ((sh (bvneg e))) (ite (bvuge sh (_ bv128 128)) (_ bv0 128) (bvlshr m sh)))))))
+(define-fun limu () (_ BitVec 128) (bvsub (bvshl (_ bv1 128) (_ bv32 128)) (_ bv1 128)))
+(define-fun rtl_to_uint32 ((x BV32)) (_ BitVec 64)
+  (ite (isnan32 x) ((_ zero_extend 32) #xFFFFFFFF)
+  (ite (iszero32 x) (_ bv0 64)
+  (ite (= ((_ extract 31 31) x) #b1) (_ bv0 64)
+  (ite (isinf32 x) ((_ extract 63 0) limu)
+  (let ((mag (magf x))) (ite (bvugt mag limu) ((_ extract 63 0) limu) ((_ extract 63 0) mag))))))))
+(declare-fun x () BV32)
+(define-fun fx   () (_ FloatingPoint 8 24) ((_ to_fp 8 24) x))
+(define-fun spec () (_ BitVec 64) ((_ fp.to_ubv 64) RTZ fx))
+(define-fun inrange () Bool (and (not (fp.isNaN fx)) (not (fp.isInfinite fx))
+   (fp.geq fx ((_ to_fp 8 24) RNE 0.0)) (fp.lt fx ((_ to_fp 8 24) RNE 4294967296.0))))
+(assert inrange)
+(assert (not (= ((_ zero_extend 32) ((_ extract 31 0) (rtl_to_uint32 x))) spec)))
+(check-sat)

--- a/tests/fp_v1/smt_proof/fp32_compare.smt2
+++ b/tests/fp_v1/smt_proof/fp32_compare.smt2
@@ -1,0 +1,41 @@
+; SMT equivalence proof (doc/plan_fp_types.md §8.1).
+;
+; Property: the emitted FP32 comparison RTL (src/codegen/fp.rs:
+;   arch_f32_eq / ne / lt / le / gt / ge) is bit-exactly equivalent to the
+;   SMT-LIB `FloatingPoint` theory (IEEE-754) comparisons, for ALL 2^64 input
+;   pairs. The `rtl_*` definitions below are a literal transcription of the
+;   SystemVerilog bit-logic, so this proves the emitted RTL directly.
+;
+; Result: `unsat` (z3) ⇒ no counterexample ⇒ proven for all inputs.
+; Chain: emitted SV ≡ fp.* (proved here) ≡ IEEE-754 (by the theory).
+(set-logic QF_FPBV)
+(define-sort BV () (_ BitVec 32))
+(define-sort F () (_ FloatingPoint 8 24))
+(define-fun isnan ((x BV)) Bool (and (= ((_ extract 30 23) x) #b11111111) (not (= ((_ extract 22 0) x) (_ bv0 23)))))
+(define-fun iszero ((x BV)) Bool (= ((_ extract 30 0) x) (_ bv0 31)))
+; ---- emitted-RTL logic, transcribed bit-for-bit from src/codegen/fp.rs ----
+(define-fun rtl_eq ((a BV)(b BV)) Bool
+  (ite (or (isnan a)(isnan b)) false (or (= a b) (and (iszero a)(iszero b)))))
+(define-fun rtl_lt ((a BV)(b BV)) Bool
+  (ite (or (isnan a)(isnan b)) false
+  (ite (and (iszero a)(iszero b)) false
+  (ite (distinct ((_ extract 31 31) a) ((_ extract 31 31) b)) (= ((_ extract 31 31) a) #b1)
+  (ite (= ((_ extract 31 31) a) #b0) (bvult ((_ extract 30 0) a) ((_ extract 30 0) b))
+       (bvugt ((_ extract 30 0) a) ((_ extract 30 0) b)))))))
+(define-fun rtl_le ((a BV)(b BV)) Bool (or (rtl_lt a b) (rtl_eq a b)))
+(define-fun rtl_gt ((a BV)(b BV)) Bool (rtl_lt b a))
+(define-fun rtl_ge ((a BV)(b BV)) Bool (or (rtl_lt b a) (rtl_eq a b)))
+(define-fun rtl_ne ((a BV)(b BV)) Bool (not (rtl_eq a b)))
+(declare-fun a () BV)
+(declare-fun b () BV)
+(define-fun fa () F ((_ to_fp 8 24) a))
+(define-fun fb () F ((_ to_fp 8 24) b))
+; miter: RTL compare must equal the IEEE compare for every (a,b)
+(assert (not (and
+  (= (rtl_eq a b) (fp.eq  fa fb))
+  (= (rtl_ne a b) (not (fp.eq fa fb)))
+  (= (rtl_lt a b) (fp.lt  fa fb))
+  (= (rtl_le a b) (fp.leq fa fb))
+  (= (rtl_gt a b) (fp.gt  fa fb))
+  (= (rtl_ge a b) (fp.geq fa fb)))))
+(check-sat)


### PR DESCRIPTION
## SMT equivalence proofs for the FP RTL (plan §8.1, partial)

Machine-checked proofs (z3, SMT-LIB `FloatingPoint` theory = IEEE-754 RNE) that the emitted synthesizable FP RTL (`src/codegen/fp.rs`, merged in #612) is equivalent to IEEE-754. Each proof transcribes the emitted SystemVerilog bit-logic **literally** into SMT and asserts the negation of equivalence; z3 returns `unsat`, so the property holds over the **entire** input space (exhaustive, not sampled).

```
emitted SV  ≡  SMT fp.* (RNE)  ≡  IEEE-754
   (proved)        (by theory)
```

### Proven (`tests/fp_v1/smt_proof/`)
| File | Operator(s) | Spec | Input space |
|---|---|---|---|
| `fp32_compare.smt2` | `arch_f32_{eq,ne,lt,le,gt,ge}` | `fp.eq/lt/leq/gt/geq` | 2⁶⁴ (all pairs) |
| `bf16_narrow.smt2` | `arch_f32_to_bf16` | RNE round f32→`(FloatingPoint 8 8)` | 2³² |
| `bf16_widen.smt2` | `arch_bf16_to_f32` | exact widen | 2¹⁶ |
| `f32_to_sint.smt2` | `arch_f32_to_sint` (N=32) | `fp.to_sbv` RTZ, in-range | 2³² |
| `f32_to_uint.smt2` | `arch_f32_to_uint` (N=32) | `fp.to_ubv` RTZ, in-range | 2³² |

Wired as `fp_smt_equivalence_proofs` (`cargo test --test fp_test`): runs z3 on each `.smt2`, asserts `unsat`, emits a proof certificate. **Auto-skips when z3 is absent.**

### Scope (no silent caps)
- **float→int** is proved for the **in-range** cases only — SMT-LIB `fp.to_sbv`/`fp.to_ubv` are *partial* (undefined for NaN/out-of-range), so saturation and NaN→type-max corners stay on §8.2 (exactly as §8.1 anticipates).
- **RNE arithmetic** (`+ - *`, `fma`, `int→float`) is **not** proved here: the emitted rounder's packed-struct returns and early `return`/`break` are beyond the available SV→SMT frontend (Yosys 0.33), and a from-scratch SMT rounder would be an unfaithful second implementation. Those operators remain backstopped by the §8.2 differential Verilator campaign (`fp_rtl_differential_equiv_verilator`, merged in #612). A full arithmetic sign-off via an EBMC-class frontend is the remaining P3 item. See `tests/fp_v1/smt_proof/README.md`.

### Tests
`cargo test --test fp_test` — 11/0 (incl. the new SMT proof test; all five proofs discharge `unsat` under z3 4.8.12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015i1am9AsxcxNnDeb6zU38p)_