### PR TITLE
feat(fp): --fp-compat=riscv|cuda special-value profile

### DIFF
--- a/doc/plan_fp_types.md
+++ b/doc/plan_fp_types.md
@@ -263,6 +263,13 @@ the alternative behind a flag (§6.2).
 
 ### 6.2 Compatibility profiles — `--fp-compat=riscv|cuda` (default `riscv`)
 
+**Status: landed.** `--fp-compat=riscv|cuda` is implemented on `arch build`,
+`arch sim`, and `arch formal` (validated there but inert, as FP is rejected by
+the formal backend). The SV backend (`src/codegen/fp.rs`) and the sim prelude
+(`src/sim_codegen` `verilated_h`) each apply the same thin constant
+substitution; covered by `fp_compat_build_profiles` / `fp_compat_sim_profiles`
+in `tests/fp_test.rs`.
+
 A single flag selects the special-value profile. The crucial design point is
 that the two profiles **share an identical arithmetic core** — both compute
 IEEE-754 RNE results and both canonicalize to a *single* NaN. They differ only
@@ -504,12 +511,14 @@ Landed and tested (`cargo test --test fp_test`, plus the full suite green):
    §8.2 differential Verilator campaign is wired in as a regression test. What
    remains of §7 is the *pipelined latency-N* variant (v1 is combinational, by
    design) and the §8.1 SMT equivalence proof.
-3. **`--fp-compat=cuda` (§6.2) is not yet wired**; the default RISC-V
-   special-value policy is implemented in both sim and the synthesizable SV.
-   `arch formal` still rejects FP types in a design with a clear message. The
-   **§8.1 SMT equivalence proof is partially wired** (compares + conversions
-   proven exhaustively under z3; RNE arithmetic deferred — see §8.1 status), and
-   the **§8.2 differential campaign is wired** (delta #2).
+3. **`--fp-compat=riscv|cuda` (§6.2) is wired** on `arch build`/`sim`/`formal`
+   (default `riscv`), honored identically by the SV and sim backends as a thin
+   output-constant shim (canonical NaN pattern + NaN→int result); the arithmetic
+   core is untouched. `arch formal` still rejects FP types in a design, so the
+   flag is validated-but-inert there. The **§8.1 SMT equivalence proof is
+   partially wired** (compares + conversions proven exhaustively under z3; RNE
+   arithmetic deferred — see §8.1 status), and the **§8.2 differential campaign
+   is wired** (delta #2).
 4. **Float literals default to `FP32`**; `BF16` immediates use `.to_bf16()`
    (§3.3, resolved open question — keeps no-implicit-conversion uniform).
 

--- a/src/codegen/fp.rs
+++ b/src/codegen/fp.rs
@@ -27,7 +27,29 @@
 //! Emitted once at `$unit` scope ahead of the modules that use FP, gated by
 //! `Codegen::fp_helpers_used`.
 
-pub(super) const FP_SV_HELPERS: &str = r#"// ── arch floating-point helpers (synthesizable RTL; see doc/plan_fp_types.md §7) ──
+use crate::FpCompat;
+
+/// SystemVerilog FP helper block for the given special-value profile
+/// (doc/plan_fp_types.md §6.2). The `riscv` (default) text is the canonical
+/// source below; `cuda` is a thin output-constant substitution — the canonical
+/// NaN pattern and the NaN→int saturation constant — leaving the arithmetic
+/// datapath, RNE rounding, subnormal handling, and in-range conversions
+/// bit-identical, exactly as §6.2 specifies.
+pub(super) fn fp_sv_helpers(profile: FpCompat) -> String {
+    match profile {
+        FpCompat::Riscv => FP_SV_HELPERS_RISCV.to_string(),
+        FpCompat::Cuda => FP_SV_HELPERS_RISCV
+            // canonical quiet NaN: 0x7FC00000 / 0x7FC0  ->  0x7FFFFFFF / 0x7FFF
+            .replace("32'h7FC00000", "32'h7FFFFFFF")
+            .replace("16'h7FC0", "16'h7FFF")
+            // float->int of NaN: type max  ->  0 (the `(u.is_nan)` prefix targets
+            // the NaN case only, never the structural saturate-to-max branches).
+            .replace("(u.is_nan)  return lim_pos[63:0];", "(u.is_nan)  return 64'd0;")
+            .replace("(u.is_nan)  return lim[63:0];", "(u.is_nan)  return 64'd0;"),
+    }
+}
+
+const FP_SV_HELPERS_RISCV: &str = r#"// ── arch floating-point helpers (synthesizable RTL; see doc/plan_fp_types.md §7) ──
 typedef struct packed {
   logic        sign;
   logic [23:0] mant;        // 24-bit significand (implicit bit included for normals)
@@ -265,7 +287,7 @@ function automatic logic [63:0] arch_f32_to_sint(input logic [31:0] x, input int
   u = arch_f32_decode(x);
   lim_pos = (128'd1 << (n - 1)) - 128'd1;   //  2^(n-1)-1
   lim_neg = (128'd1 << (n - 1));            // |min| = 2^(n-1)
-  if (u.is_nan)  return lim_pos[63:0];                       // NaN -> int max
+  if (u.is_nan)  return lim_pos[63:0];                       // NaN -> type max (riscv) / 0 (cuda)
   if (u.is_zero) return 64'd0;
   if (u.is_inf)  return u.sign ? (~lim_neg[63:0] + 64'd1) : lim_pos[63:0];
   if (u.eunb >= 64)      mag = {128{1'b1}};                  // |value| >= 2^64 -> saturate
@@ -285,7 +307,7 @@ function automatic logic [63:0] arch_f32_to_uint(input logic [31:0] x, input int
   integer sh;
   u = arch_f32_decode(x);
   lim = (128'd1 << n) - 128'd1;                              // 2^n - 1
-  if (u.is_nan)  return lim[63:0];                           // NaN -> uint max
+  if (u.is_nan)  return lim[63:0];                           // NaN -> type max (riscv) / 0 (cuda)
   if (u.is_zero) return 64'd0;
   if (u.sign)    return 64'd0;                               // negative (incl -inf) -> 0
   if (u.is_inf)  return lim[63:0];

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -163,6 +163,9 @@ pub struct Codegen<'a> {
     /// Set when any FP32/BF16 operation was emitted, so the `arch_f32_*` /
     /// `arch_bf16_*` SystemVerilog helper package is prepended to the output.
     fp_helpers_used: std::cell::Cell<bool>,
+    /// Floating-point special-value profile (doc/plan_fp_types.md §6.2).
+    /// Selects the emitted NaN-canonicalization / NaN→int constants.
+    fp_compat: crate::FpCompat,
     /// Name of the construct currently being emitted (for symbol lookups).
     current_construct: String,
     /// Context-sensitive identifier substitutions.
@@ -246,6 +249,7 @@ impl<'a> Codegen<'a> {
             bus_wires: std::collections::HashMap::new(),
             reset_ports: std::collections::HashMap::new(),
             fp_helpers_used: std::cell::Cell::new(false),
+            fp_compat: crate::FpCompat::default(),
             current_construct: String::new(),
             ident_subst: std::collections::HashMap::new(),
             loop_var_subst: std::collections::HashMap::new(),
@@ -376,6 +380,12 @@ impl<'a> Codegen<'a> {
         self
     }
 
+    /// Select the floating-point special-value profile (§6.2). Default `Riscv`.
+    pub fn with_fp_compat(mut self, profile: crate::FpCompat) -> Self {
+        self.fp_compat = profile;
+        self
+    }
+
     pub fn generate(&mut self) -> String {
         // `source.items` is borrowed for the whole call but `generate_items`
         // only needs an `&[Item]` slice — clone the Vec into a local so we
@@ -439,7 +449,7 @@ impl<'a> Codegen<'a> {
 
         // Prepend the floating-point helper functions if any FP op was emitted.
         if self.fp_helpers_used.get() {
-            let mut prefix = String::from(fp::FP_SV_HELPERS);
+            let mut prefix = fp::fp_sv_helpers(self.fp_compat);
             prefix.push_str(&self.out);
             self.out = prefix;
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,3 +20,40 @@ pub mod thread_proof_cert;
 pub mod type_alias;
 pub mod typecheck;
 pub mod width;
+
+/// Floating-point special-value compatibility profile (doc/plan_fp_types.md §6.2).
+///
+/// Both profiles share an identical IEEE-754 RNE arithmetic core, full subnormal
+/// support, and toward-zero in-range float→int conversion. They differ only in
+/// the two GPU-divergent corners:
+///
+/// | profile | canonical NaN (f32 / bf16) | NaN → int |
+/// |---|---|---|
+/// | `Riscv` (default) | `0x7FC00000` / `0x7FC0` | type max |
+/// | `Cuda` | `0x7FFFFFFF` / `0x7FFF` | `0` |
+///
+/// Selected at compile time by `--fp-compat=riscv|cuda` on `arch build`/`sim`/
+/// `formal`; honored identically by the sim and SV backends so they never
+/// disagree. It is a thin output shim, NOT a second arithmetic path.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub enum FpCompat {
+    #[default]
+    Riscv,
+    Cuda,
+}
+
+impl FpCompat {
+    /// Parse the `--fp-compat` value.
+    pub fn parse(s: &str) -> Result<Self, String> {
+        match s {
+            "riscv" => Ok(Self::Riscv),
+            "cuda" => Ok(Self::Cuda),
+            other => Err(format!(
+                "--fp-compat: expected `riscv` or `cuda`, got `{other}`"
+            )),
+        }
+    }
+    pub fn is_cuda(self) -> bool {
+        matches!(self, Self::Cuda)
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -181,6 +181,12 @@ enum Command {
         /// .sv files and linked together downstream.
         #[arg(long)]
         no_inline_deps: bool,
+        /// Floating-point special-value compatibility profile (doc/plan_fp_types.md
+        /// §6.2): `riscv` (default) or `cuda`. Shares one IEEE-754 RNE arithmetic
+        /// core; selects only the canonical NaN pattern (0x7FC00000/0x7FC0 vs
+        /// 0x7FFFFFFF/0x7FFF) and the NaN→int result (type max vs 0).
+        #[arg(long = "fp-compat", default_value = "riscv")]
+        fp_compat: String,
     },
     /// Compile ARCH + C++ testbench and run simulation
     ///
@@ -280,6 +286,11 @@ enum Command {
         /// guard then defers to the command-line definition.
         #[arg(long = "param", value_name = "NAME=VALUE")]
         param_overrides: Vec<String>,
+        /// Floating-point special-value compatibility profile (doc/plan_fp_types.md
+        /// §6.2): `riscv` (default) or `cuda`. Honored identically by the SV and
+        /// sim backends so they never disagree.
+        #[arg(long = "fp-compat", default_value = "riscv")]
+        fp_compat: String,
     },
     /// Formal verification: emit SMT-LIB2 and invoke a bit-vector SMT solver.
     ///
@@ -328,6 +339,10 @@ enum Command {
         /// by construction). See `arch build` help for the property set.
         #[arg(long)]
         auto_thread_asserts: bool,
+        /// Floating-point special-value compatibility profile (doc/plan_fp_types.md
+        /// §6.2): `riscv` (default) or `cuda`. Accepted for parity with `build`/`sim`.
+        #[arg(long = "fp-compat", default_value = "riscv")]
+        fp_compat: String,
     },
 }
 
@@ -945,8 +960,10 @@ fn main() -> miette::Result<()> {
             pybind_module_name,
             auto_thread_asserts,
             param_overrides,
+            fp_compat,
         } => {
             let _ = auto_thread_asserts;
+            let fp_compat = arch::FpCompat::parse(&fp_compat).map_err(|e| miette::miette!(e))?;
 
             // Parse --param NAME=VALUE overrides
             let mut param_overrides_map: std::collections::HashMap<String, u64> =
@@ -997,6 +1014,7 @@ fn main() -> miette::Result<()> {
                         test.as_deref(),
                         pybind_module_name.as_deref(),
                         &param_overrides_map,
+                        fp_compat,
                     )
                 }),
                 "parallel" => learn_wrap(&arch_files, || {
@@ -1020,13 +1038,14 @@ fn main() -> miette::Result<()> {
                         test.as_deref(),
                         pybind_module_name.as_deref(),
                         &param_overrides_map,
+                        fp_compat,
                     )
                 }),
                 "both" => {
                     // Cross-check: build + run both fsm and parallel sims
                     // independently with --debug, then diff the port-change
                     // traces. Mismatch ⇒ abort with first divergence.
-                    run_thread_sim_cross_check(&arch_files, &tb_files, outdir.as_deref())
+                    run_thread_sim_cross_check(&arch_files, &tb_files, outdir.as_deref(), fp_compat)
                 }
                 other => {
                     return Err(miette::miette!(
@@ -1052,7 +1071,9 @@ fn main() -> miette::Result<()> {
             construct_proof_smt_solver,
             auto_thread_asserts,
             no_inline_deps,
+            fp_compat,
         } => {
+            let fp_compat = arch::FpCompat::parse(&fp_compat).map_err(|e| miette::miette!(e))?;
             let files_for_learn = files.clone();
             learn_wrap(&files_for_learn, move || {
                 if matches!(emit_thread_map, Some(Some(_))) && files.len() > 1 && o.is_none() {
@@ -1142,7 +1163,7 @@ fn main() -> miette::Result<()> {
                             .cloned()
                             .collect();
                         let mut codegen =
-                            Codegen::new(&symbols, &ast, overload_map).with_comments(comments);
+                            Codegen::new(&symbols, &ast, overload_map).with_comments(comments).with_fp_compat(fp_compat);
                         let sv = codegen.generate_items(&file_items);
                         let out_path_hint =
                             o.clone().unwrap_or_else(|| files[0].with_extension("sv"));
@@ -1150,7 +1171,7 @@ fn main() -> miette::Result<()> {
                         (sv, sdc)
                     } else {
                         let mut codegen =
-                            Codegen::new(&symbols, &ast, overload_map).with_comments(comments);
+                            Codegen::new(&symbols, &ast, overload_map).with_comments(comments).with_fp_compat(fp_compat);
                         let sv = codegen.generate();
                         let out_path_hint =
                             o.clone().unwrap_or_else(|| files[0].with_extension("sv"));
@@ -1374,7 +1395,8 @@ fn main() -> miette::Result<()> {
                             .collect();
 
                         let mut codegen = Codegen::new(&symbols, &ast, overload_map.clone())
-                            .with_comments(file_comments);
+                            .with_comments(file_comments)
+                            .with_fp_compat(fp_compat);
                         let sv = codegen.generate_items(&file_items);
 
                         let out_path = std::path::Path::new(filename).with_extension("sv");
@@ -1515,7 +1537,11 @@ fn main() -> miette::Result<()> {
             thread_proof_only,
             timeout,
             auto_thread_asserts,
+            fp_compat,
         } => {
+            // Validated for parity with build/sim; FP types are rejected by the
+            // formal backend in v1, so the profile has no effect here yet.
+            let _ = arch::FpCompat::parse(&fp_compat).map_err(|e| miette::miette!(e))?;
             let files_for_learn = files.clone();
             learn_wrap(&files_for_learn, move || {
                 let all_files = resolve_use_imports(&files)?;
@@ -1602,6 +1628,7 @@ fn run_thread_sim_cross_check(
     arch_files: &[PathBuf],
     tb_files: &[PathBuf],
     outdir: Option<&std::path::Path>,
+    fp_compat: arch::FpCompat,
 ) -> miette::Result<()> {
     let base = outdir
         .map(|p| p.to_path_buf())
@@ -1620,9 +1647,9 @@ fn run_thread_sim_cross_check(
     ));
 
     eprintln!("=== arch sim --thread-sim both: building fsm path ===");
-    let fsm_trace = build_and_capture(arch_files, tb_files, &fsm_dir, /*parallel=*/ false)?;
+    let fsm_trace = build_and_capture(arch_files, tb_files, &fsm_dir, /*parallel=*/ false, fp_compat)?;
     eprintln!("=== arch sim --thread-sim both: building parallel path ===");
-    let par_trace = build_and_capture(arch_files, tb_files, &par_dir, /*parallel=*/ true)?;
+    let par_trace = build_and_capture(arch_files, tb_files, &par_dir, /*parallel=*/ true, fp_compat)?;
 
     // Filter to just the [cycle][Mod.port](in/out) debug lines, ignore
     // TB stdout. The fsm path uses --debug --depth N to optionally
@@ -1674,6 +1701,7 @@ fn build_and_capture(
     tb_files: &[PathBuf],
     dir: &std::path::Path,
     parallel: bool,
+    fp_compat: arch::FpCompat,
 ) -> miette::Result<String> {
     // Capture stdout via a temp file: redirect the child's stdout to it,
     // then read it back. Easier than threading capture through run_sim.
@@ -1705,6 +1733,7 @@ fn build_and_capture(
         /*pybind_module_name_override*/ None,
         /*no_exit*/ true,
         &std::collections::HashMap::new(),
+        fp_compat,
     )?;
 
     // The sim_out binary was already executed by run_sim; capture its
@@ -1738,6 +1767,7 @@ fn run_sim(
     test_file: Option<&std::path::Path>,
     pybind_module_name_override: Option<&str>,
     param_overrides: &std::collections::HashMap<String, u64>,
+    fp_compat: arch::FpCompat,
 ) -> miette::Result<()> {
     run_sim_opts(
         arch_files,
@@ -1760,6 +1790,7 @@ fn run_sim(
         pybind_module_name_override,
         /*no_exit=*/ false,
         param_overrides,
+        fp_compat,
     )
 }
 
@@ -1785,6 +1816,7 @@ fn run_sim_opts(
     pybind_module_name_override: Option<&str>,
     no_exit: bool,
     param_overrides: &std::collections::HashMap<String, u64>,
+    fp_compat: arch::FpCompat,
 ) -> miette::Result<()> {
     // 1. Parse + type-check
     let all_files = resolve_use_imports(arch_files)?;
@@ -1937,7 +1969,7 @@ fn run_sim_opts(
     // 4. Write verilated.h / verilated.cpp stubs
     let verilated_h = build_dir.join("verilated.h");
     let verilated_cpp = build_dir.join("verilated.cpp");
-    fs::write(&verilated_h, SimCodegen::verilated_h()).into_diagnostic()?;
+    fs::write(&verilated_h, SimCodegen::verilated_h(fp_compat)).into_diagnostic()?;
     fs::write(&verilated_cpp, SimCodegen::verilated_cpp()).into_diagnostic()?;
     generated_cpps.push(verilated_cpp);
 

--- a/src/sim_codegen/mod.rs
+++ b/src/sim_codegen/mod.rs
@@ -728,8 +728,8 @@ r#"        .def_property("{field}",
     }
 
     /// Return the contents of the `verilated.h` stub.
-    pub fn verilated_h() -> String {
-        r#"#pragma once
+    pub fn verilated_h(fp_compat: crate::FpCompat) -> String {
+        let prelude = r#"#pragma once
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
@@ -1004,7 +1004,18 @@ static inline uint64_t _arch_f32_to_uint(uint32_t b, int bits){
     uint64_t maxv = ((uint64_t)1 << bits) - 1;
     return (v > maxv) ? maxv : v;
 }
-"#.to_string()
+"#.to_string();
+        // Profile shim (doc/plan_fp_types.md §6.2): the `cuda` profile differs
+        // from the default `riscv` only in the canonical NaN pattern and the
+        // NaN→int result; the arithmetic core is untouched.
+        match fp_compat {
+            crate::FpCompat::Riscv => prelude,
+            crate::FpCompat::Cuda => prelude
+                .replace("return 0x7FC00000u;", "return 0x7FFFFFFFu;")
+                .replace("return 0x7FC0u;", "return 0x7FFFu;")
+                .replace("if (std::isnan(f)) return INT64_MAX;", "if (std::isnan(f)) return 0;")
+                .replace("if (std::isnan(f)) return UINT64_MAX;", "if (std::isnan(f)) return 0;"),
+        }
     }
 
     pub fn verilated_cpp() -> String {

--- a/tests/fp_test.rs
+++ b/tests/fp_test.rs
@@ -337,3 +337,63 @@ fn fp_smt_equivalence_proofs() {
     cert.push_str("\nresult: ALL PROVED (unsat)\n");
     eprintln!("\n{cert}");
 }
+
+/// `--fp-compat=cuda` (doc/plan_fp_types.md §6.2) selects the CUDA special-value
+/// profile in the emitted SystemVerilog: canonical NaN 0x7FFFFFFF / 0x7FFF and
+/// NaN->int = 0. The default `riscv` profile keeps 0x7FC00000 / 0x7FC0 and
+/// NaN->type-max. The arithmetic datapath is identical across profiles.
+#[test]
+fn fp_compat_build_profiles() {
+    let manifest = env!("CARGO_MANIFEST_DIR");
+    let arch_src = format!("{manifest}/tests/fp_v1/FpArith.arch");
+
+    // default = riscv
+    let td = tempfile::tempdir().unwrap();
+    let sv = td.path().join("d.sv");
+    let out = arch().arg("build").arg(&arch_src).arg("-o").arg(&sv).output().unwrap();
+    assert!(out.status.success(), "default build failed: {}", String::from_utf8_lossy(&out.stderr));
+    let d = std::fs::read_to_string(&sv).unwrap();
+    assert!(d.contains("32'h7FC00000") && d.contains("16'h7FC0"), "riscv NaN constants missing");
+    assert!(!d.contains("32'h7FFFFFFF"), "default must not use the cuda NaN pattern");
+
+    // cuda
+    let sv2 = td.path().join("c.sv");
+    let out2 = arch().arg("build").arg(&arch_src).arg("--fp-compat=cuda").arg("-o").arg(&sv2).output().unwrap();
+    assert!(out2.status.success(), "cuda build failed: {}", String::from_utf8_lossy(&out2.stderr));
+    let c = std::fs::read_to_string(&sv2).unwrap();
+    assert!(c.contains("32'h7FFFFFFF") && c.contains("16'h7FFF"), "cuda NaN constants missing");
+    assert!(!c.contains("32'h7FC00000"), "cuda must not use the riscv NaN pattern");
+    assert!(c.contains("(u.is_nan)  return 64'd0;"), "cuda NaN->int should be 0");
+
+    // invalid profile rejected
+    let bad = arch().arg("build").arg(&arch_src).arg("--fp-compat=nvidia").arg("-o").arg(td.path().join("x.sv")).output().unwrap();
+    assert!(!bad.status.success(), "invalid --fp-compat must be rejected");
+    assert!(String::from_utf8_lossy(&bad.stderr).contains("expected `riscv` or `cuda`"));
+}
+
+/// The sim backend honors `--fp-compat` identically to the SV backend: a NaN
+/// result and a NaN->int conversion follow the selected profile.
+#[test]
+fn fp_compat_sim_profiles() {
+    let manifest = env!("CARGO_MANIFEST_DIR");
+    let arch_src = format!("{manifest}/tests/fp_v1/NanProf.arch");
+    let tb = format!("{manifest}/tests/fp_v1/tb_nanprof.cpp");
+
+    let run = |extra: &[&str], dir: &str| -> String {
+        let td = tempfile::tempdir().unwrap();
+        let mut c = arch();
+        c.arg("sim").arg(&arch_src).arg("--tb").arg(&tb).arg("--outdir").arg(td.path().join(dir));
+        for a in extra { c.arg(a); }
+        let o = c.output().unwrap();
+        assert!(o.status.success(), "sim failed: {}", String::from_utf8_lossy(&o.stderr));
+        String::from_utf8_lossy(&o.stdout).to_string()
+    };
+
+    let riscv = run(&[], "r");
+    assert!(riscv.contains("nan_out=0x7FC00000 nan_to_int=2147483647"),
+        "riscv profile wrong:\n{riscv}");
+
+    let cuda = run(&["--fp-compat=cuda"], "c");
+    assert!(cuda.contains("nan_out=0x7FFFFFFF nan_to_int=0"),
+        "cuda profile wrong:\n{cuda}");
+}

--- a/tests/fp_v1/NanProf.arch
+++ b/tests/fp_v1/NanProf.arch
@@ -1,0 +1,12 @@
+// Exercises the --fp-compat profile: NaN canonicalization and NaN->int.
+// a - b with a = b = +inf produces a NaN; the profile selects its bit
+// pattern (0x7FC00000 riscv / 0x7FFFFFFF cuda) and the NaN->int result
+// (INT_MAX riscv / 0 cuda).
+module NanProf
+  port a: in FP32;
+  port b: in FP32;
+  port nan_out: out FP32;
+  port nan_to_int: out SInt<32>;
+  comb nan_out = a - b; end comb
+  comb nan_to_int = (a - b).to_sint<32>(); end comb
+end module NanProf

--- a/tests/fp_v1/tb_nanprof.cpp
+++ b/tests/fp_v1/tb_nanprof.cpp
@@ -1,0 +1,15 @@
+// Profile probe for --fp-compat. Feeds a=b=+inf so (a-b) is NaN, then prints
+// the canonical NaN bit pattern and the NaN->int result. The expected values
+// depend on the compile-time --fp-compat profile (checked by fp_test.rs).
+#include "VNanProf.h"
+#include <cstdio>
+#include <cstdint>
+static VNanProf dut;
+int main(){
+    dut.a = 0x7F800000u; // +inf
+    dut.b = 0x7F800000u; // +inf
+    dut.eval();
+    printf("nan_out=0x%08X nan_to_int=%d\n",
+           (unsigned)dut.nan_out, (int)dut.nan_to_int);
+    return 0;
+}


### PR DESCRIPTION
## `--fp-compat=riscv|cuda` special-value profile (plan §6.2)

Implements the FP compatibility-profile flag. The two profiles share an **identical** IEEE-754 RNE arithmetic core, full subnormals, and toward-zero in-range float→int; they differ only in the two GPU-divergent output corners:

| profile | canonical NaN (f32 / bf16) | NaN → int |
|---|---|---|
| `riscv` (default) | `0x7FC00000` / `0x7FC0` | type max |
| `cuda` | `0x7FFFFFFF` / `0x7FFF` | `0` |

This is the feature originally requested as "the cuda flag", now implemented per its spec.

### What changed
- **`FpCompat` enum** (`src/lib.rs`), parsed from `--fp-compat` on `arch build`/`sim`/`formal` (default `riscv`; invalid values rejected with a clear message). `formal` validates but ignores it (FP is rejected there in v1).
- **SV backend**: `fp::fp_sv_helpers(profile)` substitutes the NaN constants and the NaN→int return in the emitted helpers, threaded via `Codegen::with_fp_compat`.
- **Sim backend**: `SimCodegen::verilated_h(profile)` applies the same substitution to the C++ prelude (`_arch_f32_canon` / `_arch_f2bf16` / `_arch_f32_to_i/u`), threaded through `run_sim`/`run_sim_opts`.

Both are pure output-constant shims — **no second arithmetic path** — so sim and SV never disagree, exactly as §6.2 specifies. (The §8.1 arithmetic-equivalence proof is profile-independent; the compare proofs already cover both.)

### Tests
- `fp_compat_build_profiles` — asserts the SV NaN constants + NaN→int for both profiles, plus the invalid-value error.
- `fp_compat_sim_profiles` — runs a new `NanProf` design under both profiles and checks the NaN bit pattern and NaN→int result.
- Full `fp_test` suite **13/0**; integration suite **669/0** (no sim-plumbing regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015i1am9AsxcxNnDeb6zU38p)_