### PR TITLE
feat(fp): bounded f32 adder — machine-prove f32 add/sub over all 2^64 inputs

### DIFF
--- a/doc/plan_fp_types.md
+++ b/doc/plan_fp_types.md
@@ -353,19 +353,26 @@ input space:
 - FP32 comparisons ×6 (2^64); `f32→bf16` narrow RNE (2^32); `bf16→f32` widen
   exact (2^16); `f32→{sint,uint}` toward-zero in-range (vs the partial
   `fp.to_sbv`/`fp.to_ubv`).
+- **f32 `add`/`sub`** vs `fp.add`/`fp.sub` over all 2^64 inputs (~80 s each in
+  z3). The decisive factor is *datapath width*, not the input space: the bounded
+  adder (§5 / `fp_ops.rs`) keeps the aligned magnitude ~56-bit (no multiplier),
+  so the bit-blasted miter stays small — the earlier 280-bit exact-wide adder
+  timed out purely from CNF size. (The proof now *is* the adder's correctness
+  certificate, superseding the differential check for these two ops.)
 - **BF16 arithmetic** — the §8.1 *primary* target — `bf16_{mul,add,sub}` vs
   `fp.{mul,add,sub}` on `(_ FloatingPoint 8 8)` (2^32), plus the six bf16
   comparisons. The small input space makes the miters tractable even though they
   route through the f32 datapath; `bf16_mul` cross-checked with cvc5 `--fp-exp`.
 
-Not yet machine-discharged: the **f32 RNE arithmetic** (`+ - *`, `fma`) —
-generated identically from the same IR (`dump_fp -- proof mul`), but its 2^64 /
-fused miter times out (§8.2 backstop). And **`bf16_fma`** — which *is* correct
-(innocuous double rounding: f32 keeps a 16-bit precision lead over bf16 at every
-magnitude, ≥ the `2p+2` margin since `p ≤ 8`; confirmed by an exhaustive
-deep-subnormal check) — but its `fp.fma` miter triggers a z3 4.8.12 soundness gap
-(spurious `sat`); a solver with sound `fp.fma` at `(8,8)` closes it. See
-`tests/fp_v1/smt_proof/README.md`.
+Not yet machine-discharged — **only the multiplier-bearing ops**: f32 `mul` /
+`fma` (a 24×24-multiplier equivalence is SAT-hard at 2^64 regardless of
+bit-blaster; z3 times out → §8.2 backstop). And **`bf16_fma`** — which *is*
+correct (innocuous double rounding: f32 keeps a 16-bit precision lead over bf16
+at every magnitude, ≥ the `2p+2` margin since `p ≤ 8`; confirmed by an exhaustive
+deep-subnormal check) — but its `fp.fma` miter trips a z3 4.8.12 soundness gap
+(spurious `sat`); a solver with sound `fp.fma` at `(8,8)` closes it. The
+remaining multiplier proofs are the natural fit for a structured theorem prover
+(Lean/Coq) rather than a bit-blaster. See `tests/fp_v1/smt_proof/README.md`.
 
 ARCH already has a formal backend (`src/formal.rs`, SMT-LIB2, EBMC) and a
 proof-certificate culture (`construct_proof_cert.rs`, `thread_proof_cert.rs`).

--- a/src/fp_ops.rs
+++ b/src/fp_ops.rs
@@ -230,7 +230,7 @@ fn f32_to_bf16(p: FpCompat) -> FpFn {
 // guard/round/sticky). add: 23 + max-exponent-spread(253) + carry. fma: 48-bit
 // product + max product/addend spread. Correctness is by construction; the §8.2
 // differential harness is the oracle.
-const ADD_W: u32 = 280;
+const ADD_G: u32 = 30; // bounded-adder guard bits (field = 24 + ADD_G)
 const FMA_W: u32 = 470;
 
 fn f32_add_core(name: &str, flip_b_sign: bool, p: FpCompat) -> FpFn {
@@ -255,21 +255,34 @@ fn f32_add_core(name: &str, flip_b_sign: bool, p: FpCompat) -> FpFn {
     let sign_hi = pick(&da.sign, &db.sign);
     let sign_lo = pick(&db.sign, &da.sign);
 
+    // Bounded alignment: keep G guard bits below the larger significand's LSB
+    // and fold everything past that into one sticky bit. Catastrophic
+    // cancellation needs the exponents within ~1, where no bits are dropped
+    // (exact); otherwise the larger operand dominates and the sticky carries the
+    // rest. The sticky is appended as the LOW bit of each aligned operand, so the
+    // magnitude compare and the subtraction handle the borrow automatically (and
+    // resolve the HI==LO tie). Far narrower than exact-wide -> compact SV and a
+    // solver-tractable miter.
     let diff = sub(&eunb_hi, &eunb_lo); // >= 0
-    let hi_f = shl(&zext(&mant_hi, ADD_W), &diff);
-    let lo_f = zext(&mant_lo, ADD_W);
+    let fw = 24 + ADD_G; // aligned-field width
+    let hi_field = shl(&zext(&mant_hi, fw), &cst(ADD_G as u128, 16));
+    let lo_ext = shl(&zext(&mant_lo, fw), &cst(ADD_G as u128, 16));
+    let lo_field = lshr(&lo_ext, &diff);
+    let mask = sub(&shl(&cst(1, fw), &diff), &cst(1, fw)); // (1<<diff)-1
+    let sticky = ne(&band(&lo_ext, &mask), &cst(0, fw));
 
+    let hi_e = concat(&hi_field, &cst(0, 1)); // fw+1
+    let lo_e = concat(&lo_field, &sticky); // fw+1
     let same_sign = eq(&sign_hi, &sign_lo);
-    let hi_gt = ugt(&hi_f, &lo_f);
-    let mag = ite(
-        &same_sign,
-        &add(&hi_f, &lo_f),
-        &ite(&hi_gt, &sub(&hi_f, &lo_f), &sub(&lo_f, &hi_f)),
-    );
-    let res_sign = ite(&same_sign, &sign_hi, &ite(&hi_gt, &sign_hi, &sign_lo));
-    let rounded = normround(&res_sign, &mag, &eunb_lo);
-    // exact cancellation (opposite signs, equal magnitude) -> +0 (RNE)
-    let cancel = and(&bnot(&same_sign), &eq(&hi_f, &lo_f));
+    let ge = uge(&hi_e, &lo_e);
+    let raw = ite(&ge, &sub(&hi_e, &lo_e), &sub(&lo_e, &hi_e)); // fw+1
+    let mw = fw + 2; // add-carry headroom
+    let mag = ite(&same_sign, &add(&zext(&hi_e, mw), &zext(&lo_e, mw)), &zext(&raw, mw));
+    let res_sign = ite(&same_sign, &sign_hi, &ite(&ge, &sign_hi, &sign_lo));
+    let e0 = sub(&eunb_hi, &cst((ADD_G + 1) as u128, 16)); // LSB exponent of mag
+    let rounded = normround(&res_sign, &mag, &e0);
+    // exact cancellation (opposite signs, equal magnitude incl. sticky) -> +0
+    let cancel = and(&bnot(&same_sign), &eq(&raw, &cst(0, fw + 1)));
     let finite = ite(&cancel, &cst(0, 32), &rounded);
 
     // specials

--- a/src/fp_smt_proof.rs
+++ b/src/fp_smt_proof.rs
@@ -19,9 +19,15 @@ use crate::FpCompat;
 pub const TRACTABLE: &[&str] =
     &["eq", "ne", "lt", "le", "gt", "ge", "narrow", "widen", "to_sint", "to_uint"];
 
-/// f32 RNE arithmetic — generated identically from the IR, but the 2^64 (or
-/// fused) miter is not solver-tractable; these stay on the §8.2 backstop.
-pub const ARITHMETIC: &[&str] = &["mul", "add", "sub", "fma"];
+/// f32 add/sub — machine-proved `unsat` vs `fp.add`/`fp.sub` over all 2^64
+/// inputs (~80 s each in z3). Tractable because the bounded adder keeps the
+/// datapath ~56-bit (no multiplier) — the SAT instance stays small.
+pub const F32_ADD: &[&str] = &["add", "sub"];
+
+/// f32 mul/fma — generated identically from the IR, but their 24x24-multiplier
+/// equivalence is SAT-hard at 2^64; z3 times out. These stay on the §8.2
+/// differential backstop.
+pub const ARITHMETIC: &[&str] = &["mul", "fma"];
 
 /// BF16 comparisons — route through the cheap f32 compare path; prove instantly.
 pub const BF16_CMP: &[&str] =

--- a/tests/fp_test.rs
+++ b/tests/fp_test.rs
@@ -341,34 +341,42 @@ fn fp_smt_equivalence_proofs() {
     eprintln!("\n{cert}");
 }
 
-/// BF16 RNE arithmetic equivalence (doc/plan_fp_types.md §8.1) — the §8.1
-/// primary target. The bf16 ops route through the f32 datapath, but the small
-/// input space (2^32) makes the miter solver-tractable: z3 discharges
-/// `arch_bf16_{mul,add,sub}` as `unsat` (proven equal to `fp.mul/add/sub` on
-/// `(_ FloatingPoint 8 8)` over every input). Slower than the comparisons
-/// (~minutes total); kept in its own test and z3-gated.
+/// RNE arithmetic equivalence (doc/plan_fp_types.md §8.1), the slower miters.
 ///
-/// `bf16_fma` is excluded: its spec needs `fp.fma`, whose z3 4.8.12 support is
-/// incomplete (returns a spurious `sat` whose witness in fact satisfies the
-/// equivalence). It stays on the §8.2 differential backstop; see fp_ops.rs.
+/// - **f32 `add`/`sub`** are proved `unsat` vs `fp.add`/`fp.sub` over all 2^64
+///   inputs (~80 s each). Tractable because the bounded adder keeps the datapath
+///   ~56-bit (no multiplier) so the SAT instance stays small — the 280-bit
+///   exact-wide version used to time out.
+/// - **bf16 `mul`/`add`/`sub`** are proved `unsat` vs `fp.{mul,add,sub}` on
+///   `(_ FloatingPoint 8 8)` (2^32) — the §8.1 primary target.
+///
+/// Not here: f32 `mul`/`fma` (24x24-multiplier equivalence is SAT-hard at 2^64,
+/// z3 times out) and `bf16_fma` (correct, but its `fp.fma` miter trips a z3
+/// 4.8.12 incompleteness — spurious `sat`). Both on the §8.2 backstop; see
+/// fp_ops.rs. Slower (~minutes total); z3-gated.
 #[test]
-fn fp_smt_bf16_arith_proofs() {
+fn fp_smt_arith_proofs() {
     fn z3_available() -> bool {
         std::process::Command::new("z3").arg("--version").output().map(|o| o.status.success()).unwrap_or(false)
     }
     if !z3_available() {
-        eprintln!("skipping fp_smt_bf16_arith_proofs: z3 not in PATH");
+        eprintln!("skipping fp_smt_arith_proofs: z3 not in PATH");
         return;
     }
+    let ops: Vec<&str> = arch::fp_smt_proof::F32_ADD
+        .iter()
+        .chain(arch::fp_smt_proof::BF16_ARITH.iter())
+        .copied()
+        .collect();
     let td = tempfile::tempdir().expect("tempdir");
-    for op in arch::fp_smt_proof::BF16_ARITH {
+    for op in ops {
         let smt = arch::fp_smt_proof::equiv_proof(op, arch::FpCompat::Riscv);
         let path = td.path().join(format!("{op}.smt2"));
         std::fs::write(&path, smt).unwrap();
         let out = std::process::Command::new("z3").arg("-T:600").arg(&path).output().unwrap();
         let first = String::from_utf8_lossy(&out.stdout).lines().next().unwrap_or("").trim().to_string();
-        eprintln!("bf16 arith proof {op}: {first}");
-        assert_eq!(first, "unsat", "bf16 arith proof {op} did not discharge as unsat (got {first:?})");
+        eprintln!("arith proof {op}: {first}");
+        assert_eq!(first, "unsat", "arith proof {op} did not discharge as unsat (got {first:?})");
     }
 }
 

--- a/tests/fp_v1/smt_proof/README.md
+++ b/tests/fp_v1/smt_proof/README.md
@@ -51,6 +51,7 @@ Proven `unsat` exhaustively (z3 4.8.12):
 | `narrow` (`arch_f32_to_bf16`) | RNE round to `(FloatingPoint 8 8)` | 2^32 |
 | `widen` (`arch_bf16_to_f32`) | exact widen | 2^16 |
 | `to_sint` / `to_uint` (N=32) | `fp.to_sbv`/`fp.to_ubv` RTZ, in-range | 2^32 |
+| **`add` / `sub`** | `fp.add` / `fp.sub` | **2^64** (~80 s each) |
 | `bf16_eq … bf16_ge` | `fp.eq/lt/…` on `(FloatingPoint 8 8)` | 2^32 |
 | `bf16_mul` / `bf16_add` / `bf16_sub` | `fp.mul/add/sub` on `(FloatingPoint 8 8)` | 2^32 |
 
@@ -61,11 +62,14 @@ mul cross-checked with cvc5 `--fp-exp`). They are the plan's §8.1 primary targe
 - **float→int** is proved in-range only — SMT-LIB `fp.to_sbv`/`fp.to_ubv` are
   *partial* (undefined for NaN / out-of-range), so the saturation / NaN→type-max
   corners are signed off by the §8.2 differential campaign, as §8.1 anticipates.
-- **f32 RNE arithmetic** (`mul add sub fma`) is generated from the same IR (run
-  `dump_fp -- proof mul`), but its 2^64 / fused miter is not solver-tractable
-  (z3 times out). It stays on the §8.2 differential Verilator campaign
+- **f32 `add`/`sub` ARE proved** (2^64) — the bounded adder keeps the datapath
+  ~56-bit, so the bit-blasted miter is small enough for z3 (~80 s). Only the
+  **multiplier-bearing** f32 ops remain: `mul` / `fma` (a 24×24-multiplier
+  equivalence is SAT-hard at 2^64 for any bit-blaster — z3, cvc5, or Lean's
+  `bv_decide` alike). They stay on the §8.2 differential Verilator campaign
   (`fp_rtl_differential_equiv_verilator`), bit-exact against a host-IEEE-754
-  reference over corner + randomized + cancellation-prone vectors.
+  reference over corner + randomized + cancellation-prone vectors. A structured
+  theorem prover (Lean/Coq) is the natural route for the multiplier ops.
 - **`bf16_fma`** is *correct* — via f32 the double rounding is innocuous (f32
   keeps a 16-bit precision lead over bf16 at every magnitude, ≥ the `2p+2`
   margin since `p ≤ 8`; confirmed by an exhaustive deep-subnormal check) — but


### PR DESCRIPTION
## Machine-prove f32 `add` / `sub` over all 2⁶⁴ inputs (bounded adder)

The f32 add/sub equivalence miters used to time out in z3, so they sat on the §8.2 backstop. This PR proves them outright.

**Diagnosis** (prompted by a discussion of theorem-prover / `bv_decide` approaches): it was never 2⁶⁴ fundamental hardness — add/sub contain no multiplier, and SAT handles adder equivalence well. The blocker was the **280-bit exact-wide alignment datapath** bloating the bit-blasted CNF. A quick experiment confirmed it: at a narrow datapath z3 engages the add miter in seconds.

**Fix — bounded adder** (`src/fp_ops.rs`): align the smaller operand `ADD_G=30` guard bits below the larger significand's LSB and fold everything past that into one sticky bit, **appended as the low bit of each aligned operand** so the magnitude compare and the subtraction handle the borrow (and the `HI==LO` tie) automatically. Catastrophic cancellation needs the exponents within ~1, where nothing is dropped (exact); otherwise the larger operand dominates and the sticky carries the rest. Datapath drops from 280-bit to ~56-bit.

**Result:** z3 now discharges `arch_f32_add` / `arch_f32_sub` as **`unsat`** vs `fp.add` / `fp.sub` over the **entire 2⁶⁴ input space (~80 s each)**.

### Verification
- Bit-exact against host IEEE-754 over the §8.2 Verilator differential campaign (2M+ corner + randomized + cancellation-prone vectors) **and** exhaustively by the new SMT proof — the proof now *is* the adder's correctness certificate.
- Wired into `fp_smt_arith_proofs` (with the bf16 arithmetic). `fp_test` **14/0**.

### What remains
Only the **multiplier-bearing** ops: f32 `mul`/`fma` (a 24×24-multiplier equivalence is SAT-hard at 2⁶⁴ for *any* bit-blaster — z3, cvc5, or Lean's `bv_decide` alike) and `bf16_fma` (correct, but z3's `fp.fma` is incomplete). Both on the §8.2 backstop; a structured theorem prover (Lean/Coq) is the natural route for the multiplier ops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015i1am9AsxcxNnDeb6zU38p)_