### PR TITLE
fix(fp): bf16_fma is fused f32-accumulate, not correctly-rounded — correct docs + prove the true characterization

### DIFF
--- a/proofs/lean_fp_equiv/ArchFpEquiv.lean
+++ b/proofs/lean_fp_equiv/ArchFpEquiv.lean
@@ -8,4 +8,5 @@ import ArchFpEquiv.RoundProof
 import ArchFpEquiv.Equiv
 import ArchFpEquiv.RoundFma
 import ArchFpEquiv.Fma
+import ArchFpEquiv.Bf16FmaNote
 import ArchFpEquiv.SpecCheck

--- a/proofs/lean_fp_equiv/ArchFpEquiv/Bf16FmaNote.lean
+++ b/proofs/lean_fp_equiv/ArchFpEquiv/Bf16FmaNote.lean
@@ -1,4 +1,4 @@
-import ArchFpEquiv.Model
+import ArchFpEquiv.Fma
 
 /-!
 # `bf16_fma` is fused f32-accumulate — NOT correctly-rounded bf16 fma
@@ -25,5 +25,25 @@ def archBf16Fma (a b c : BitVec 16) : BitVec 16 :=
 -- bf16 midpoint, so the narrow ties-to-even up). They differ by 1 ULP.
 #guard archBf16Fma 0x2a20#16 0x51a6#16 0x9359#16 = 0x3c50#16
 #guard archBf16Fma 0x2a20#16 0x51a6#16 0x9359#16 ≠ 0x3c4f#16
+
+/-- **The *true* bf16-fma characterization (f32-accumulate).** For bf16 operands
+    whose widened f32 values are finite nonzero and non-cancelling, `archBf16Fma`
+    is the f32→bf16 narrowing of the **correctly-rounded** f32 fma — i.e. `bf16_fma
+    = narrow(RNE_f32(a·b+c))`. This is the honest statement (derived directly from
+    the proved `arch_fma_f32_finite_correct`); the stricter `= RNE_bf16(a·b+c)` is
+    *false* (the `#guard` witness above). -/
+theorem archBf16Fma_eq_narrow_roundNE (a b c : BitVec 16)
+    (ha : finiteNonzero (arch_bf16_to_f32 a) = true)
+    (hb : finiteNonzero (arch_bf16_to_f32 b) = true)
+    (hc : finiteNonzero (arch_bf16_to_f32 c) = true)
+    (hnc : arch_fma_mag (arch_bf16_to_f32 a) (arch_bf16_to_f32 b) (arch_bf16_to_f32 c) ≠ 0#470) :
+    archBf16Fma a b c
+      = arch_f32_to_bf16
+          (roundNE_f32
+            (arch_fma_sign (arch_bf16_to_f32 a) (arch_bf16_to_f32 b) (arch_bf16_to_f32 c) == 1#1)
+            (arch_fma_mag (arch_bf16_to_f32 a) (arch_bf16_to_f32 b) (arch_bf16_to_f32 c)).toNat
+            (arch_fma_elo (arch_bf16_to_f32 a) (arch_bf16_to_f32 b) (arch_bf16_to_f32 c)).toInt) := by
+  unfold archBf16Fma
+  rw [arch_fma_f32_finite_correct _ _ _ ha hb hc hnc]
 
 end ArchFp

--- a/proofs/lean_fp_equiv/ArchFpEquiv/Bf16FmaNote.lean
+++ b/proofs/lean_fp_equiv/ArchFpEquiv/Bf16FmaNote.lean
@@ -1,0 +1,29 @@
+import ArchFpEquiv.Model
+
+/-!
+# `bf16_fma` is fused f32-accumulate — NOT correctly-rounded bf16 fma
+
+`fp_ops.rs::bf16_fma` composes widen→f32 fma→narrow. The f32 fma is correctly
+rounded (proved in `Fma.lean`); the final f32→bf16 narrow is a *second* rounding,
+and double-rounding here is not innocuous. So the result is the f32-accumulate
+value, which differs from the correctly-rounded `a·b+c` on ~0.37% of finite inputs
+(always 1 ULP). The witness below is pinned as a regression so this stays visible.
+
+This matches the mainstream f32-accumulate convention; the narrow is bit-identical
+to PyTorch `round_to_nearest_even`, and arch bf16 mul/add/sub match PyTorch
+`c10::BFloat16` bit-for-bit. See `proofs/lean_fp_equiv/README.md` for the analysis.
+-/
+
+namespace ArchFp
+
+/-- bf16 fma exactly as `fp_ops.rs::bf16_fma` composes it. -/
+def archBf16Fma (a b c : BitVec 16) : BitVec 16 :=
+  arch_f32_to_bf16 (arch_fma_f32 (arch_bf16_to_f32 a) (arch_bf16_to_f32 b) (arch_bf16_to_f32 c))
+
+-- Witness `a=0x2a20, b=0x51a6, c=0x9359`: arch gives the f32-accumulate result
+-- 0x3c50; the correctly-rounded bf16 fma is 0x3c4f (the f32 result is exactly a
+-- bf16 midpoint, so the narrow ties-to-even up). They differ by 1 ULP.
+#guard archBf16Fma 0x2a20#16 0x51a6#16 0x9359#16 = 0x3c50#16
+#guard archBf16Fma 0x2a20#16 0x51a6#16 0x9359#16 ≠ 0x3c4f#16
+
+end ArchFp

--- a/proofs/lean_fp_equiv/README.md
+++ b/proofs/lean_fp_equiv/README.md
@@ -73,9 +73,23 @@ so `arch_fma_f32_finite_correct` follows from a structural `bv_decide` reduction
 `arch_fma_f32` branch is covered: finite non-cancel / cancel / `c=0` (rounded
 product) / product`=0` (the proved adder) / NaN / `0·∞` / `∞−∞` / `∞`-product /
 `∞`-addend. `f32 mul`, `add`, `sub`, and `fma` are now all proved (mul/fma here,
-add/sub by the exhaustive SMT backend). **`bf16_fma` remains** — it routes through
-the f32 datapath, so it needs a `roundNE_bf16` spec plus the
-double-rounding-innocuous lemma (f32's 24 bits ≥ `2·8+2`) on top of the f32 result.
+add/sub by the exhaustive SMT backend).
+
+**`bf16_fma` is *not* correctly-rounded — and that is by design, not a gap.** It
+implements **fused f32-accumulate**: widen→one correctly-rounded f32 fma (proved
+here)→round f32→bf16. The narrow is a second rounding, and double rounding here is
+*not* innocuous (the "≥ `2p+2` margin" reasoning is a known fallacy for round-to-
+nearest — `RNE_p(RNE_q(x)) ≠ RNE_q(x)` in general; fails at `p=4,q=1`). Empirically
+the bf16 result differs from the correctly-rounded `a·b+c` on ~0.37 % of finite
+inputs, always by 1 ULP (witness `a=0x2a20,b=0x51a6,c=0x9359` → arch `0x3c50`,
+correct `0x3c4f`; the f32 result lands on a bf16 midpoint). This is the same
+f32-accumulate convention NVIDIA Tensor Cores / TPUs use; the f32→bf16 narrow is
+**bit-identical to PyTorch's `round_to_nearest_even`**, and arch's bf16
+`mul`/`add`/`sub` match PyTorch `c10::BFloat16` bit-for-bit (arch's *fused* fma is
+strictly more accurate than PyTorch's non-fused scalar `a*b+c`). So the meaningful
+Lean theorem for bf16 fma is the **f32-accumulate characterization**
+`arch_bf16_fma = narrow(roundNE_f32 …)` (true, derivable from the f32 result) —
+*not* `= roundNE_bf16(a·b+c)`, which is **false**.
 
 **Proven (`bv_decide`, no IEEE spec needed — pure `BitVec` facts about the real
 emitted operators):**

--- a/tests/fp_v1/smt_proof/README.md
+++ b/tests/fp_v1/smt_proof/README.md
@@ -80,11 +80,28 @@ mul cross-checked with cvc5 `--fp-exp`). They are the plan's §8.1 primary targe
   lifting rather than bit-blasting — so finite `f32_mul` is correctly rounded
   (`arch_f32_mul_finite_correct`), and the same op-independent lemma carries to
   `fma`.
-- **`bf16_fma`** is *correct* — via f32 the double rounding is innocuous (f32
-  keeps a 16-bit precision lead over bf16 at every magnitude, ≥ the `2p+2`
-  margin since `p ≤ 8`; confirmed by an exhaustive deep-subnormal check) — but
-  its proof needs `fp.fma`, whose z3 4.8.12 support is incomplete (it returns a
-  *spurious* `sat` whose own witness satisfies the equivalence). cvc5 `--fp-exp`
-  handles `(8,8)` but times out. So `bf16_fma` is verified by the theorem +
-  §8.2, not yet machine-discharged; a solver with sound `fp.fma` at `(8,8)`
-  would close it.
+- **`bf16_fma`** computes **fused f32-accumulate**, *not* correctly-rounded bf16
+  fma: it widens to f32, does one correctly-rounded f32 fma (the exact `a·b+c`
+  rounded once to f32 — machine-proved in `proofs/lean_fp_equiv`), then rounds
+  f32→bf16. That final narrow is a second rounding, and **double rounding here is
+  not innocuous**: `RNE_p(RNE_q(x)) = RNE_q(x)` is *not* guaranteed by `p ≥ 2q+2`
+  for round-to-nearest (a known fallacy — fails already at `p=4, q=1`). The bf16
+  result differs from the correctly-rounded `a·b+c` in **~0.37 % of finite
+  inputs, always by 1 ULP**. Reproducible witness: `a=0x2a20, b=0x51a6,
+  c=0x9359` → arch `0x3c50`, correctly-rounded bf16 `0x3c4f` (the f32 result
+  lands exactly on a bf16 midpoint, so the narrow ties-to-even up). The earlier
+  "deep-subnormal check" missed it (these are normal-range), and the §8.2
+  differential harness cannot catch it — its DPI reference (`dpi_ref.cpp:50`,
+  `narrow_bf16(__builtin_fmaf(...))`) is *itself* f32-accumulate, so RTL and
+  reference double-round identically by construction.
+
+  This is a sound, mainstream design, not a bug. The f32→bf16 narrow is
+  **bit-identical to PyTorch's `round_to_nearest_even`**, and arch's bf16
+  `mul`/`add`/`sub` match PyTorch's `c10::BFloat16` operators bit-for-bit; arch's
+  *fused* fma is in fact **more accurate** than PyTorch's scalar `a*b+c` (which
+  has no fma and rounds the product to bf16 first — differs from arch on ~1.2 %
+  of inputs). It also mirrors the NVIDIA Tensor Core / TPU f32-accumulate
+  convention. What is *not* true is "correctly-rounded bf16 fma" — no mainstream
+  hardware implements that. So `bf16_fma` is correct **for f32-accumulate
+  semantics** (the f32 fma is machine-proved; the narrow matches PyTorch), and is
+  verified end-to-end by §8.2 against the matching f32-accumulate reference.


### PR DESCRIPTION
## Summary

While scoping a Lean proof that `bf16_fma` is correctly-rounded, I found the target
statement is **false**: `arch_bf16_fma` is **fused f32-accumulate**, not
correctly-rounded bf16 fma. The implementation is fine (it's the mainstream
convention); the **documentation claim** was wrong. This PR corrects the docs, pins
a regression, and proves the *honest* characterization theorem. No RTL/codegen
changes.

## The finding

`fp_ops.rs::bf16_fma` composes widen→f32 fma→narrow. The f32 fma is correctly
rounded (machine-proved in `proofs/lean_fp_equiv`, already on `main`), but the
final f32→bf16 narrow is a **second rounding**, and double-rounding here is **not
innocuous**:

- The READMEs justified correctness via "f32 keeps ≥ `2p+2` precision lead, double
  rounding is innocuous." That reasoning is a **known fallacy** for round-to-
  nearest: `RNE_p(RNE_q(x)) = RNE_q(x)` is *not* implied by `p ≥ 2q+2` (fails
  already at `p=4, q=1`).
- Empirically, `arch_bf16_fma` differs from the correctly-rounded `a·b+c` on
  **~0.37 % of finite inputs, always by 1 ULP**.
- Reproducible witness: `a=0x2a20, b=0x51a6, c=0x9359` → arch `0x3c50`,
  correctly-rounded bf16 `0x3c4f`. The f32 result lands exactly on a bf16 midpoint
  (`…8000`), so the narrow ties-to-even *up*. Confirmed on the **rendered Lean
  `Model`** (same IR as the SystemVerilog), not just an external model.

### Why it went unnoticed
- The "exhaustive deep-subnormal check" only covered subnormals; these are
  normal-range.
- The §8.2 differential harness **cannot** catch it: its DPI reference
  (`tests/fp_v1/rtl_diff/dpi_ref.cpp:50`) is *itself* f32-accumulate
  (`narrow_bf16(__builtin_fmaf(widen(a), widen(b), widen(c)))`), so the RTL and the
  reference double-round identically by construction.

## This is a sound design, not a bug

Verified against **PyTorch source** (`torch/headeronly/util/BFloat16.h`):

| op | PyTorch `c10::BFloat16` | arch | match |
|---|---|---|---|
| f32→bf16 narrow | `round_to_nearest_even` (`(U32 + ((lsb)+0x7FFF))>>16`) | `f32_to_bf16` | **bit-identical** (0 / 2,000,000) |
| bf16 mul / add / sub | `float(a) op float(b)` → narrow | `narrow(f32(a) op f32(b))` | **bit-identical** (0 / 800k each) |
| bf16 fma | *no fused fma* — rounds `a·b` to bf16 first | **fused** (one f32 rounding, then narrow) | differs ~1.2 % — arch is **more accurate** |

So arch's narrow matches PyTorch's exactly, its bf16 mul/add/sub match
`c10::BFloat16` bit-for-bit, and its *fused* fma is strictly more accurate than
PyTorch's non-fused scalar path. It mirrors the NVIDIA Tensor Core / TPU
f32-accumulate convention. "Correctly-rounded bf16 fma" is a software-only spec
that essentially no production hardware implements.

## Changes

- **`proofs/lean_fp_equiv/README.md`** and **`tests/fp_v1/smt_proof/README.md`** —
  replace the "innocuous double-rounding / correctly-rounded" claim with the
  accurate f32-accumulate characterization, the repro, and the PyTorch comparison.
- **`proofs/lean_fp_equiv/ArchFpEquiv/Bf16FmaNote.lean`** (new):
  - `archBf16Fma` — bf16 fma exactly as `fp_ops.rs` composes it;
  - a `#guard` regression pinning the witness (`= 0x3c50`, `≠ 0x3c4f`);
  - **`archBf16Fma_eq_narrow_roundNE`** — the *true* machine-checked theorem:
    `bf16_fma = arch_f32_to_bf16(roundNE_f32(a·b+c))` (f32-accumulate), derived
    directly from the proved f32 fma. The stricter `= roundNE_bf16(a·b+c)` is
    **false** (the `#guard` witness), so this is the honest statement.

Full `lake build` green; zero `sorry`, no `sorryAx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)