### PR TITLE
docs(fp): propagate #627 bf16-fma correction to source + plan; flag int→bf16 double-rounding

### DIFF
--- a/doc/plan_fp_types.md
+++ b/doc/plan_fp_types.md
@@ -170,6 +170,23 @@ saturate per the RISC-V spec (§6).
 
 ### 5.3 BF16 operations — provably single-rounded via f64
 
+> **⚠ Correction (PR #627) — this section is superseded and its `fma` claim is
+> unsound.** Two things diverge from what shipped:
+> 1. **Intermediate precision.** The implementation does **not** use an f64
+>    intermediate (`p₁ = 53`); it uses an **f32** intermediate (`p₁ = 24`,
+>    `widen → arch_*_f32 → narrow`, see §appendix and `src/fp_ops.rs`).
+> 2. **`fma` is not innocuous.** The `p₁ ≥ 2·p₂ + 2` sufficiency argument below
+>    is a **known fallacy** for round-to-nearest (it fails already at
+>    `p₁ = 4, p₂ = 1`: `RNE₁(RNE₄(1.4375)) = 2` but `RNE₁(1.4375) = 1`). It does
+>    hold operationally for bf16 `mul`/`add`/`sub` — those are *exhaustively*
+>    SMT-proved correctly-rounded vs `fp.{mul,add,sub}` on `(8,8)` — but **not**
+>    for `fma`. The shipped `arch_fma_bf16` is fused f32-accumulate (one f32 fma,
+>    then a second rounding to bf16) and differs from a correctly-rounded
+>    `a*b+c` on ~0.37% of finite inputs, always by 1 ULP. See §8 below,
+>    `tests/fp_v1/smt_proof/README.md`, and `proofs/lean_fp_equiv`.
+>
+> The rest of this section is retained as historical design rationale.
+
 SoftFloat has no native bfloat16. Naively doing a BF16 op by promoting to
 `float32`, operating, and narrowing **double-rounds** and can be wrong. We avoid
 this with a clean, provable construction:
@@ -364,15 +381,28 @@ input space:
   comparisons. The small input space makes the miters tractable even though they
   route through the f32 datapath; `bf16_mul` cross-checked with cvc5 `--fp-exp`.
 
-Not yet machine-discharged — **only the multiplier-bearing ops**: f32 `mul` /
-`fma` (a 24×24-multiplier equivalence is SAT-hard at 2^64 regardless of
-bit-blaster; z3 times out → §8.2 backstop). And **`bf16_fma`** — which *is*
-correct (innocuous double rounding: f32 keeps a 16-bit precision lead over bf16
-at every magnitude, ≥ the `2p+2` margin since `p ≤ 8`; confirmed by an exhaustive
-deep-subnormal check) — but its `fp.fma` miter trips a z3 4.8.12 soundness gap
-(spurious `sat`); a solver with sound `fp.fma` at `(8,8)` closes it. The
-remaining multiplier proofs are the natural fit for a structured theorem prover
-(Lean/Coq) rather than a bit-blaster. See `tests/fp_v1/smt_proof/README.md`.
+The multiplier-bearing ops — f32 `mul` / `fma` — are SAT-hard for any
+bit-blaster (a 24×24-multiplier equivalence at 2^64; z3 times out), so they are
+**not** discharged by SMT. They are instead **machine-proved in Lean 4**
+(`proofs/lean_fp_equiv`, PRs #625/#626): both are proved correctly-rounded
+against a value-level RNE spec, zero `sorry`, by lifting the multiplier to a
+structural `Nat` multiply instead of bit-blasting. The remaining multiplier
+proofs were always the natural fit for a structured theorem prover (Lean/Coq)
+rather than a bit-blaster.
+
+**`bf16_fma` is NOT correctly-rounded** — a claim earlier in this plan asserted
+it was (via "innocuous double rounding," f32's 16-bit precision lead ≥ the
+`2p+2` margin). That reasoning is a **known fallacy** for round-to-nearest:
+`bf16_fma` is fused f32-accumulate (one correctly-rounded f32 fma, then a second
+rounding f32→bf16), and that second rounding is not innocuous. It differs from a
+correctly-rounded `a*b+c` on ~0.37% of finite inputs, always by 1 ULP. Its
+`fp.fma` miter on `(8,8)` therefore returns a **genuine `sat`** (a real
+counterexample), **not** a z3 4.8.12 soundness gap — the earlier "spurious sat /
+needs a sound `fp.fma` solver" framing was wrong. The behavior is intentional
+(the NVIDIA Tensor Core / TPU convention, strictly more accurate than non-fused
+bf16 fma) and is machine-characterized as `archBf16Fma_eq_narrow_roundNE` in
+`proofs/lean_fp_equiv` (PR #627). See `tests/fp_v1/smt_proof/README.md` and
+`proofs/lean_fp_equiv/README.md`.
 
 ARCH already has a formal backend (`src/formal.rs`, SMT-LIB2, EBMC) and a
 proof-certificate culture (`construct_proof_cert.rs`, `thread_proof_cert.rs`).
@@ -525,10 +555,12 @@ Landed and tested (`cargo test --test fp_test`, plus the full suite green):
 1. **Sim uses the host FPU, not a linked Berkeley SoftFloat** (§5). Native
    `float`/`double` arithmetic is IEEE-754 RNE and therefore bit-identical to
    SoftFloat for `+ - * fma` and the conversions; this avoids vendoring/building
-   the C library for v1. BF16 goes through an f32 intermediate (innocuous double
-   rounding, 24 ≥ 2·8+2 — a tighter but equally valid form of §5.3's f64 route).
-   Swapping in the RISC-V-spec SoftFloat build behind the same helper names is a
-   drop-in hardening step.
+   the C library for v1. BF16 goes through an f32 intermediate; `mul`/`add`/`sub`
+   are correctly-rounded bf16 (exhaustively SMT-proved), but `fma` is fused
+   f32-accumulate — the f32→bf16 narrow is a second, *non*-innocuous rounding, so
+   bf16 `fma` is **not** correctly-rounded (see the §5.3 correction note and
+   PR #627). Swapping in the RISC-V-spec SoftFloat build behind the same helper
+   names is a drop-in hardening step.
 2. ~~**SV helpers are behavioral, not synthesizable**~~ **Resolved (P2).** The SV
    helpers are now synthesizable RTL (`src/codegen/fp.rs`), CVFPU-referenced in
    datapath structure but written as deterministic, commented ARCH-owned SV. The

--- a/doc/proposal_fp_rounding_semantics.md
+++ b/doc/proposal_fp_rounding_semantics.md
@@ -1,0 +1,96 @@
+# Proposal: a normative FP rounding-semantics contract for ARCH
+
+Status: research note / discussion. No implementation in this note.
+
+## Motivation
+
+ARCH's floating-point support (FP32 / BF16, #609) is built on a clean idea:
+BF16 arithmetic is `widen → f32 op → narrow`, and a single shared rounder backs
+every op. The trouble is that the *numeric contract* of each op and conversion —
+**"is the result correctly-rounded, or merely convention-rounded via an f32
+intermediate?"** — was never written down as a normative rule. It lived only in
+code comments, and those comments asserted a uniform "correctly-rounded /
+innocuous double rounding" story that is **not actually uniform**.
+
+Two latent defects of the *same class* have now surfaced, both because the
+`p₁ ≥ 2·p₂ + 2` "innocuous double rounding" argument was applied where it does
+not hold:
+
+1. **`bf16_fma` is not correctly-rounded** (PR #627). It is fused
+   f32-accumulate; the final f32→bf16 narrow is a second, non-innocuous rounding.
+   Differs from correctly-rounded `a·b+c` on ~0.37 % of finite inputs.
+2. **`int.to_bf16()` is not correctly-rounded** (issue #629). Same `int→f32→bf16`
+   double rounding; differs for `|i| ≥ 2²⁴` (witness `16842753 → 0x4b80`,
+   correct `0x4b81`; 8064 cases in `[1, 2³⁰)`).
+
+Both were found by ad-hoc audit, not by any structural guard. The
+`p₁ ≥ 2·p₂ + 2` rule is a **known fallacy** for round-to-nearest applied to an
+arbitrary real (it fails already at `p₁ = 4, p₂ = 1`:
+`RNE₁(RNE₄(1.4375)) = 2` but `RNE₁(1.4375) = 1`), yet it was used as blanket
+justification across `fp_ops.rs`, `sim_codegen`, and `doc/plan_fp_types.md`.
+
+The risk is open-ended: every *future* narrow format (fp16, fp8 E4M3/E5M2 — the
+natural next step for LLM inference, cf. #622) re-introduces the same hazard for
+every op and conversion routed through a wider intermediate. Without a written
+contract, each one is a fresh place to silently assume "correctly-rounded."
+
+## Proposal
+
+Add one normative subsection to the spec (and the AI reference card) — **"FP
+rounding semantics"** — that, for every FP op and conversion, classifies the
+result as exactly one of:
+
+- **CR** — *correctly-rounded* to the destination format (RNE), bit-exact to the
+  IEEE-754 / SoftFloat single-rounding result.
+- **VR(f32)** — *convention-rounded via an f32 intermediate*: defined as
+  `narrow_dst(arch_*_f32(widen(...)))`, i.e. one f32 rounding then a destination
+  narrow. May differ from CR by ≤ 1 ULP on inputs where the double rounding is
+  not innocuous.
+
+A first cut of the table from today's implementation:
+
+| Op / conversion | Class | Notes |
+|---|---|---|
+| f32 `add` `sub` `mul` `fma` | **CR** | mul/fma Lean-proved (#625/#626); add/sub exhaustively SMT-proved |
+| f32 compares, f32↔int | **CR** | exhaustive SMT |
+| bf16 `add` `sub` `mul` | **CR** | exhaustively SMT-proved vs `fp.{add,sub,mul}` on (8,8) |
+| bf16 `fma` | **VR(f32)** | fused f32-accumulate (#627); NVIDIA/TPU convention |
+| `int → bf16` | **VR(f32)** | #629; not CR for `\|i\| ≥ 2²⁴` |
+| `f32 → bf16` narrow | **CR** | RNE, bit-identical to PyTorch `c10::BFloat16` |
+
+The classification is **load-bearing for verification**: a CR op is a legitimate
+target for an `fp.*` SMT miter or a Lean `roundNE` proof; a VR(f32) op is **not**
+(its miter has a genuine `sat`, as #627 demonstrated — the failing bf16_fma miter
+was mistaken for a z3 soundness gap for exactly this reason). Writing the class
+down stops the next person from chasing a "sound `fp.fma` solver" to close a
+miter that should never close.
+
+## Optional enforcement (later, not required by this note)
+
+1. **A characterization test per VR(f32) op** pinning it to
+   `narrow(arch_*_f32(...))` and asserting it is *not* CR via a stored witness —
+   exactly the shape #627 added for `bf16_fma` (`archBf16Fma_eq_narrow_roundNE`).
+   #629 should get the int→bf16 analogue.
+2. **A `--strict-fp` build mode** that lowers VR(f32) ops to their CR form where
+   one exists (direct int→bf16 rounding; a true bf16 fma), for users who need
+   IEEE correctly-rounded results over hardware-convention accuracy. Default
+   stays the hardware-realistic VR(f32) path.
+3. **A lint** (`arch check`) that flags any *new* `narrow(wide_op(widen(...)))`
+   lowering not present in the classification table, so the next narrow format
+   can't add an unclassified VR op silently.
+
+## Why not just "make everything correctly-rounded"
+
+Because VR(f32) is frequently the *intended, hardware-faithful* behavior, not a
+bug: NVIDIA Tensor Cores and TPUs do f32-accumulate bf16 fma, and no mainstream
+ISA has a direct int→bf16 instruction. Forcing CR everywhere would make ARCH's
+sim/RTL *diverge from the hardware it models*. The goal is not to eliminate
+VR(f32) but to **name it**, so "correctly-rounded" is a claim the spec makes
+deliberately and verification can rely on, never an unexamined default.
+
+## Related
+
+- #609 FP types (v1); #622 context-typed float literals (fp8/fp16 horizon)
+- #627 bf16_fma f32-accumulate characterization; #629 int→bf16 double-rounding
+- PR #628 corrected the stale "correctly-rounded / innocuous" comments this note
+  generalizes from

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -5070,7 +5070,17 @@ impl<'a> Codegen<'a> {
                             Some("f32") => format!("arch_f32_to_bf16({b})"),
                             Some("bf16") => b,
                             _ => {
-                                // int -> f32 (RNE) -> bf16 (RNE) — innocuous double rounding.
+                                // int -> f32 (RNE) -> bf16 (RNE). NOTE: this is a
+                                // *double* rounding and is NOT correctly-rounded
+                                // int->bf16 for |i| >= 2^24 — the f32 step can land
+                                // exactly on a bf16 midpoint and tie-to-even the
+                                // wrong way (witness i=16842753 -> 0x4b80, correctly
+                                // rounded 0x4b81). Routing via f32 is hardware-
+                                // realistic (no direct int->bf16 in RISC-V) and the
+                                // sim runtime matches, but the result is not the
+                                // correctly-rounded bf16. Same double-rounding class
+                                // as bf16 fma (PR #627); tracked in the int->bf16
+                                // issue. Sim mirror: src/sim_codegen _arch_{i,u}_to_bf16.
                                 if self.expr_is_signed(base) {
                                     format!("arch_f32_to_bf16(arch_i64_to_f32(64'($signed({b}))))")
                                 } else {

--- a/src/fp_ops.rs
+++ b/src/fp_ops.rs
@@ -454,16 +454,25 @@ fn f32_to_uint(p: FpCompat) -> FpFn {
 
 // ── bf16 arithmetic = widen -> f32 op -> narrow (calls into the f32 fns) ─────
 //
-// Correctness of the f32 intermediate (innocuous double rounding): f32's
-// subnormal range extends exactly 16 binades below bf16's (f32 to 2^-149, bf16
-// to 2^-133), so at every bf16-representable magnitude the f32 precision is
-// `p_bf16 + 16` bits. The double rounding is exact when `p_f32 >= 2*p_bf16 + 2`,
-// i.e. `p_bf16 + 16 >= 2*p_bf16 + 2`, i.e. `p_bf16 <= 14` — always true since
-// `p_bf16 <= 8`. So mul/add/sub/fma via f32 are correctly-rounded bf16.
-// `arch_bf16_{mul,add,sub}` are machine-proved `unsat` vs `fp.{mul,add,sub}` on
-// `(_ FloatingPoint 8 8)` (z3); `arch_fma_bf16` is correct by the same argument
-// (and an exhaustive deep-subnormal check) but its `fp.fma`-based miter is not
-// dischargeable by z3 4.8.12 (incomplete `fp.fma` -> spurious `sat`).
+// `arch_bf16_{mul,add,sub}` are correctly-rounded bf16: each is machine-proved
+// `unsat` vs `fp.{mul,add,sub}` on `(_ FloatingPoint 8 8)` (z3), exhaustively
+// over all 2^32 inputs. (For `mul` the f32 intermediate is *exact* — two 8-bit
+// significands multiply to <=16 bits, which fit f32's 24-bit field with no
+// rounding — so the narrow is the only rounding. For add/sub the f32 step does
+// round, but the exhaustive miter still closes.)
+//
+// `arch_fma_bf16` is NOT correctly-rounded bf16 — it is fused f32-accumulate:
+// widen -> one correctly-rounded f32 fma (the exact `a*b+c`) -> round f32->bf16.
+// That final narrow is a SECOND rounding and double rounding here is NOT
+// innocuous (the "`p_f32 >= 2*p_bf16 + 2` margin" reasoning is a known fallacy
+// for round-to-nearest). `arch_fma_bf16` differs from the correctly-rounded
+// `a*b+c` on ~0.37% of finite inputs, always by 1 ULP (witness a=0x2a20,
+// b=0x51a6, c=0x9359 -> arch 0x3c50 vs correctly-rounded 0x3c4f). Its `fp.fma`
+// miter on (8,8) therefore returns a GENUINE `sat` (a real counterexample), not
+// a z3 4.8.12 soundness gap as previously assumed. This f32-accumulate behavior
+// is intentional (the NVIDIA Tensor Core / TPU convention, strictly more
+// accurate than a non-fused bf16 fma) and machine-characterized as
+// `archBf16Fma_eq_narrow_roundNE` in proofs/lean_fp_equiv (PR #627).
 
 fn bf16_bin(name: &str, f32fn: &str) -> FpFn {
     let a = var("a", 16);

--- a/src/sim_codegen/mod.rs
+++ b/src/sim_codegen/mod.rs
@@ -919,9 +919,13 @@ static inline uint64_t _arch_repeat(uint64_t val, uint32_t n, uint32_t val_width
 // Floats are carried as raw bit patterns (FP32→uint32_t, BF16→uint16_t).
 // Arithmetic uses the host FPU, which is IEEE-754 round-to-nearest-even and
 // therefore bit-identical to Berkeley SoftFloat for + - * and fma. BF16 ops go
-// through an f32 intermediate then round once to bf16 — innocuous double
-// rounding (24 >= 2*8+2), so the result equals direct correctly-rounded bf16
-// (doc/plan_fp_types.md §5.3). NaN results are canonicalized to the RISC-V
+// through an f32 intermediate then round once to bf16. For mul/add/sub the bf16
+// result is correctly rounded (exhaustively SMT-proved vs fp.{mul,add,sub} on
+// (8,8)). BF16 fma is fused f32-accumulate (one f32 fma via fmaf, then narrow),
+// NOT correctly-rounded bf16 — the narrow is a second, non-innocuous rounding;
+// it matches the RTL and the NVIDIA/TPU convention but differs from a
+// correctly-rounded bf16 fma by 1 ULP on ~0.37% of inputs (see fp_ops.rs and
+// proofs/lean_fp_equiv, PR #627). NaN results are canonicalized to the RISC-V
 // default pattern (0x7FC00000 / 0x7FC0); float→int is toward-zero, saturating,
 // NaN→type-max (RISC-V profile, §6).
 static inline float    _arch_f32b(uint32_t b){ float f; memcpy(&f,&b,4); return f; }


### PR DESCRIPTION
## Why

PR #627 found that the documented "bf16_fma is correctly-rounded" claim is **false** — `arch_fma_bf16` is fused **f32-accumulate** (one correctly-rounded f32 fma, then a second non-innocuous rounding f32→bf16), differing from a correctly-rounded `a·b+c` on ~0.37% of finite inputs. It corrected the two FP **READMEs** but left the **identical now-false claim** in several source comments and the design plan. That stale prose now directly contradicts a merged machine-checked theorem (`archBf16Fma_eq_narrow_roundNE`) sitting in the same repo — classic doc-drift tech debt.

## What this changes (comments + design-doc prose only — zero RTL/SMT/sim output change)

| File | Was | Now |
|---|---|---|
| `src/fp_ops.rs` | "mul/add/sub/**fma** via f32 are correctly-rounded bf16"; fma miter "spurious sat (incomplete z3 fp.fma)" | fma is **not** correctly-rounded (f32-accumulate); its `fp.fma` sat is a **genuine** counterexample. mul/add/sub claim kept (exhaustively SMT-proved). |
| `src/sim_codegen/mod.rs` | "innocuous double rounding … result equals direct correctly-rounded bf16" (sweeps fma in) | mul/add/sub correctly-rounded; **fma f32-accumulate**, not. |
| `doc/plan_fp_types.md` §5.3 + appendix | "provably single-rounded via f64", `p₁ ≥ 2p₂+2` ⇒ fma correct | correction admonition: that sufficiency argument is a **known RNE fallacy** (fails at `p₁=4,p₂=1`: `RNE₁(RNE₄(1.4375))=2` ≠ `RNE₁(1.4375)=1`); shipped uses an **f32** intermediate, not f64; f32 mul/fma now **Lean-proved** (#625/#626). |

## New finding (separate bug, same class) — flagged, not fixed

While auditing, I found **`int.to_bf16()` has the same double-rounding defect**: `int → f32 → bf16` is **not** correctly-rounded for `|i| ≥ 2²⁴`.

- Witness: `i = 16842753` (`= 2²⁴+2¹⁶+1`) → `0x4b80`, correctly-rounded is `0x4b81`. `(float)i` ties-to-even down onto the exact bf16 midpoint, then the narrow ties the wrong way.
- **8064** mismatching integers in `[1, 2³⁰)`, all ≥ 2²⁴, each off by 1 bf16 ULP.
- Both backends agree (SV `arch_f32_to_bf16(arch_*_to_f32(...))` and sim `_arch_{i,u}_to_bf16`), so it's not a sim/SV divergence — it's a shared semantic question.

Routing via f32 is hardware-realistic (RISC-V has no direct int→bf16), so this **may** be intended-as-is — but the result is not correctly-rounded and that should be a deliberate, documented decision, not an accident left under an "innocuous" comment. **Behavior is unchanged here** (the conversion result is user-facing semantics); only the comment is corrected to be honest. Filed as a separate issue for a spec decision.

## Verification

`cargo build --release` clean. No `.sv` / `.smt2` / sim-C output bytes change — confirmed the edits are restricted to `//` comments and `.md` prose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)