### PR TITLE
feat(fp): bf16-fma special-value lattice + yosys synthesis harness

### DIFF
--- a/proofs/lean_fp_equiv/ArchFpEquiv/Bf16FmaNote.lean
+++ b/proofs/lean_fp_equiv/ArchFpEquiv/Bf16FmaNote.lean
@@ -46,4 +46,91 @@ theorem archBf16Fma_eq_narrow_roundNE (a b c : BitVec 16)
   unfold archBf16Fma
   rw [arch_fma_f32_finite_correct _ _ _ ha hb hc hnc]
 
+/-! ## Special-value composition (closes the non-finite path)
+
+The finite characterization above covers the rounded path. The remaining
+NaN / Inf / Zero-cancel cases compose the **proved** f32 special-value lattice
+(`Fma.lean`) with the **exhaustively-proved** `narrow` (`arch_f32_to_bf16`).
+Hypotheses are stated on the *widened* operands (`arch_bf16_to_f32 _`), exactly
+matching the f32 lattice — and widening preserves NaN/Inf/Zero, so a bf16
+NaN/Inf/Zero operand satisfies them. Concrete bf16 outputs are pinned where the
+result is a constant; the ±∞ cases keep the (single, free) sign bit symbolic.
+Together with `archBf16Fma_eq_narrow_roundNE` this is the full bf16-fma lattice. -/
+
+/-- A NaN (widened) operand ⇒ the canonical bf16 NaN `0x7FC0`. -/
+theorem archBf16Fma_nan (a b c : BitVec 16)
+    (h : isNaN (arch_bf16_to_f32 a) = true ∨ isNaN (arch_bf16_to_f32 b) = true
+         ∨ isNaN (arch_bf16_to_f32 c) = true) :
+    archBf16Fma a b c = 0x7FC0#16 := by
+  unfold archBf16Fma
+  rw [fma_nan _ _ _ h]
+  unfold arch_f32_to_bf16
+  bv_decide
+
+/-- Exact cancellation of finite-nonzero (widened) operands ⇒ bf16 `+0`. -/
+theorem archBf16Fma_cancel (a b c : BitVec 16)
+    (ha : finiteNonzero (arch_bf16_to_f32 a) = true)
+    (hb : finiteNonzero (arch_bf16_to_f32 b) = true)
+    (hc : finiteNonzero (arch_bf16_to_f32 c) = true)
+    (hcanc : arch_fma_mag (arch_bf16_to_f32 a) (arch_bf16_to_f32 b) (arch_bf16_to_f32 c) = 0#470) :
+    archBf16Fma a b c = 0#16 := by
+  unfold archBf16Fma
+  rw [fma_cancel _ _ _ ha hb hc hcanc]
+  unfold arch_f32_to_bf16
+  bv_decide
+
+/-- `0 · ∞ ± c` (widened) ⇒ the canonical bf16 NaN `0x7FC0`. -/
+theorem archBf16Fma_zero_times_inf (a b c : BitVec 16)
+    (h : (isZero (arch_bf16_to_f32 a) = true ∧ isInf (arch_bf16_to_f32 b) = true)
+       ∨ (isInf (arch_bf16_to_f32 a) = true ∧ isZero (arch_bf16_to_f32 b) = true)) :
+    archBf16Fma a b c = 0x7FC0#16 := by
+  unfold archBf16Fma
+  rw [fma_zero_times_inf _ _ _ h]
+  unfold arch_f32_to_bf16
+  bv_decide
+
+/-- `∞ − ∞` (an infinite addend opposing an infinite product) ⇒ bf16 NaN `0x7FC0`. -/
+theorem archBf16Fma_inf_minus_inf (a b c : BitVec 16)
+    (hna : isNaN (arch_bf16_to_f32 a) = false) (hnb : isNaN (arch_bf16_to_f32 b) = false)
+    (hpi : isInf (arch_bf16_to_f32 a) = true ∨ isInf (arch_bf16_to_f32 b) = true)
+    (hci : isInf (arch_bf16_to_f32 c) = true)
+    (hsgn : sgn (arch_bf16_to_f32 c)
+              ≠ sgn (arch_bf16_to_f32 a) ^^^ sgn (arch_bf16_to_f32 b)) :
+    archBf16Fma a b c = 0x7FC0#16 := by
+  unfold archBf16Fma
+  rw [fma_inf_minus_inf _ _ _ hna hnb hpi hci hsgn]
+  unfold arch_f32_to_bf16
+  bv_decide
+
+/-- An infinite product (not `0·∞`, addend not the opposite ∞) ⇒ product-signed
+    bf16 infinity. The sign bit is left symbolic (`bv_decide` after generalizing). -/
+theorem archBf16Fma_inf_prod (a b c : BitVec 16)
+    (hna : isNaN (arch_bf16_to_f32 a) = false) (hnb : isNaN (arch_bf16_to_f32 b) = false)
+    (hnc : isNaN (arch_bf16_to_f32 c) = false)
+    (hpi : isInf (arch_bf16_to_f32 a) = true ∨ isInf (arch_bf16_to_f32 b) = true)
+    (hzti : ¬((isZero (arch_bf16_to_f32 a) = true ∧ isInf (arch_bf16_to_f32 b) = true)
+            ∨ (isInf (arch_bf16_to_f32 a) = true ∧ isZero (arch_bf16_to_f32 b) = true)))
+    (hcc : isInf (arch_bf16_to_f32 c) = false
+            ∨ sgn (arch_bf16_to_f32 c) = sgn (arch_bf16_to_f32 a) ^^^ sgn (arch_bf16_to_f32 b)) :
+    archBf16Fma a b c
+      = (sgn (arch_bf16_to_f32 a) ^^^ sgn (arch_bf16_to_f32 b)) ++ (0xFF#8 ++ 0#7) := by
+  unfold archBf16Fma
+  rw [fma_inf_prod _ _ _ hna hnb hnc hpi hzti hcc]
+  generalize (sgn (arch_bf16_to_f32 a) ^^^ sgn (arch_bf16_to_f32 b)) = s
+  unfold arch_f32_to_bf16
+  bv_decide
+
+/-- A finite product plus an infinite (widened) addend ⇒ the addend's bf16 ∞. -/
+theorem archBf16Fma_inf_c (a b c : BitVec 16)
+    (hna : isNaN (arch_bf16_to_f32 a) = false) (hnb : isNaN (arch_bf16_to_f32 b) = false)
+    (hnc : isNaN (arch_bf16_to_f32 c) = false)
+    (hpa : isInf (arch_bf16_to_f32 a) = false) (hpb : isInf (arch_bf16_to_f32 b) = false)
+    (hci : isInf (arch_bf16_to_f32 c) = true) :
+    archBf16Fma a b c = sgn (arch_bf16_to_f32 c) ++ (0xFF#8 ++ 0#7) := by
+  unfold archBf16Fma
+  rw [fma_inf_c _ _ _ hna hnb hnc hpa hpb hci]
+  generalize sgn (arch_bf16_to_f32 c) = s
+  unfold arch_f32_to_bf16
+  bv_decide
+
 end ArchFp

--- a/tests/fp_v1/synth/README.md
+++ b/tests/fp_v1/synth/README.md
@@ -1,0 +1,80 @@
+# FP RTL — yosys synthesis (logic depth / area proxy)
+
+Combinational synthesis of the arch-emitted **f32** and **bf16** FP operators,
+to estimate **logic depth** (a timing proxy) and **gate count** (an area proxy).
+
+This is *not* sign-off timing — no PDK / Liberty cell library is assumed, so the
+numbers are **2-input-gate levels** and **generic-cell counts**, not ns / µm².
+It complements the correctness work (`tests/fp_v1/smt_proof`,
+`proofs/lean_fp_equiv`): same operators, same source-of-truth IR
+(`src/fp_ops.rs`), now looked at through a physical-cost lens.
+
+## Running
+
+```
+tests/fp_v1/synth/run_synth.sh [outdir]
+```
+
+Requires `yosys` (≥0.30) and `python3`. Builds a fresh release `arch` by default
+(set `ARCH_BIN=/path/to/arch` to reuse one). The generated `.arch`/`.sv`/`.v`,
+yosys scripts, and logs land in `outdir` (a temp dir unless given) — nothing is
+written back into the repo tree.
+
+### Flow (per operator)
+
+1. Emit a single-operator `.arch` module (e.g. `comb y = a * b;`).
+2. `arch build` → SystemVerilog — **the proven RTL**, rendered from the same
+   `fp_ops.rs` IR as the SMT and Lean models.
+3. `hoist_decls.py` → yosys-friendly Verilog. The emitted helpers are pure SSA
+   `function automatic`s with decl-with-initializer locals
+   (`logic [7:0] _t0 = a[30:23];`); yosys's built-in Verilog parser rejects those,
+   so the pass hoists declarations and splits the initializers into blocking
+   assignments (semantics-preserving; the bodies have no control flow).
+4. yosys `synth -flatten` → `abc -fast -g <2-input gates>` → `ltp` (longest
+   topological path = logic depth) + `stat` (cell count).
+
+## Results (yosys 0.33, `abc -fast`, 2-input generic gates)
+
+| operator | gate cells (area proxy) | logic depth (levels) |
+|---|---:|---:|
+| `bf16_to_f32` (widen) | 30 | 5 |
+| `f32_to_bf16` (narrow) | 90 | 9 |
+| `bf16_mul` | 2,242 | 143 |
+| `f32_mul` | 5,948 | 147 |
+| `f32_add` | 4,270 | 183 |
+| `f32_sub` | 4,269 | 183 |
+| `bf16_add` | 3,797 | 192 |
+| `bf16_sub` | 3,764 | 194 |
+| `bf16_fma` | 32,077 | 236 |
+| `f32_fma` | 38,064 | 235 |
+
+### Reading it
+
+- **Conversions are nearly free** (depth 5–9) — field manipulation + one round.
+- **Multiply is shallower than add** (147 vs 183). The bounded f32 adder's serial
+  chain (exponent compare → barrel-shift align → add → leading-zero count →
+  normalize shift → round) is the long pole; the multiplier's partial-product
+  tree reduces in ~log depth.
+- **bf16 arith ≈ f32 arith in depth**, because bf16 = widen→f32 op→narrow: it
+  *reuses* the f32 datapath. bf16 has fewer cells (narrower significand) but the
+  same critical-path structure, and add/sub edge slightly deeper than f32 from
+  the extra narrow stage.
+- **FMA is the critical operator** — depth ~235, ~32–38k gates — from the
+  exact-wide 470-bit alignment + normalization (the design trades area/depth for
+  not needing sticky-fold logic; the same width that keeps the Lean proof clean).
+
+## Caveats
+
+1. **Depth is gate levels, not ns.** No standard-cell library, so no ns / Fmax.
+   Absolute numbers are *pessimistic* — a real library with complex gates and
+   dedicated carry chains collapses them; only the cross-operator *ranking* is
+   robust.
+2. **`abc -fast`** favors runtime over optimization quality; depths are
+   upper-ish estimates, not the minimum achievable.
+3. **All combinational, unpipelined.** Depths of 150–235 gate-levels are far too
+   deep for a high clock in one cycle — the arithmetic operators (especially
+   `fma`) want pipelining (the `pipeline` construct) for a real frequency target.
+   Conversions and compares are single-cycle-cheap.
+
+To get real ns/Fmax, point yosys at a Liberty file (`abc -liberty cells.lib`,
+e.g. a free Sky130 / Nangate `.lib`) instead of the `-g` generic-gate mapping.

--- a/tests/fp_v1/synth/flow.ys.tmpl
+++ b/tests/fp_v1/synth/flow.ys.tmpl
@@ -1,0 +1,14 @@
+# yosys combinational-synthesis flow for one FP operator module.
+# `TOP` is substituted with the module name by run_synth.sh.
+#
+# Maps to a 2-input generic gate library and reports the longest topological
+# path (logic depth in gate levels) as a technology-independent timing proxy,
+# plus a cell count as an area proxy. No PDK/Liberty is assumed, so results are
+# levels/cells, not ns/um^2 — see README.md.
+read_verilog -sv TOP.v
+hierarchy -top TOP
+synth -top TOP -flatten
+abc -fast -g AND,OR,XOR,NAND,NOR,XNOR,ANDNOT,ORNOT,MUX
+opt_clean
+stat
+ltp

--- a/tests/fp_v1/synth/hoist_decls.py
+++ b/tests/fp_v1/synth/hoist_decls.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Hoist function-local declarations so yosys's Verilog frontend accepts the
+arch-emitted FP helper library.
+
+`arch build` emits each FP operator as a library of SystemVerilog
+`function automatic`s whose bodies are pure SSA:
+
+    function automatic logic [31:0] arch_f32_mul(input logic [31:0] a, ...);
+      logic [7:0] _t0 = a[30:23];      // decl-with-initializer
+      ...
+      arch_f32_mul = _t330;            // return assignment
+    endfunction
+
+Verilator/iverilog accept decl-with-initializer inside a function, but yosys
+0.x's built-in Verilog parser rejects it ("Invalid nesting of always blocks
+and/or initializations"). This pass rewrites each function body to put all bare
+declarations first, then the initializers as ordinary blocking assignments in
+their original order — semantically identical, and yosys-friendly. The helper
+bodies contain no control flow (verified: no for/if/case/begin), so a flat
+hoist is sound.
+
+Usage:  hoist_decls.py < in.sv > out.v
+"""
+import re
+import sys
+
+_decl_init = re.compile(r'^(\s*)logic(\s*(\[[^\]]*\])?\s*)([A-Za-z_]\w*)\s*=\s*(.*);\s*$')
+_decl_bare = re.compile(r'^(\s*)logic(\s*(\[[^\]]*\])?\s*)([A-Za-z_]\w*)\s*;\s*$')
+
+
+def convert(text: str) -> str:
+    lines = text.splitlines()
+    out, i, n = [], 0, len(lines)
+    while i < n:
+        line = lines[i]
+        if line.lstrip().startswith("function automatic"):
+            out.append(line)
+            i += 1
+            decls, stmts = [], []
+            while i < n and lines[i].strip() != "endfunction":
+                b = lines[i]
+                m = _decl_init.match(b)
+                if m:
+                    ind, _, wid, name, rhs = m.groups()
+                    wid = (wid + " ") if wid else ""
+                    decls.append(f"{ind}logic {wid}{name};")
+                    stmts.append(f"{ind}{name} = {rhs};")
+                elif _decl_bare.match(b):
+                    decls.append(b)
+                else:
+                    stmts.append(b)
+                i += 1
+            out.extend(decls)
+            out.extend(stmts)
+            out.append("endfunction")
+            i += 1  # skip the endfunction line
+        else:
+            out.append(line)
+            i += 1
+    return "\n".join(out) + "\n"
+
+
+if __name__ == "__main__":
+    sys.stdout.write(convert(sys.stdin.read()))

--- a/tests/fp_v1/synth/run_synth.sh
+++ b/tests/fp_v1/synth/run_synth.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Combinational yosys synthesis of the arch-emitted f32 / bf16 FP operators, to
+# estimate logic depth (timing proxy) and gate count (area proxy).
+#
+# Pipeline per operator:
+#   1. write a single-operator .arch module
+#   2. `arch build` it  -> SystemVerilog (the proven RTL; same IR as the SMT/Lean
+#      models in tests/fp_v1/smt_proof and proofs/lean_fp_equiv)
+#   3. hoist_decls.py    -> yosys-friendly Verilog (see that file for why)
+#   4. yosys synth + ltp -> logic depth + cell count
+#
+# Requires: yosys (>=0.30), python3, and a release `arch` binary. Builds the
+# binary fresh by default (the repo's no-stale-binary rule); set ARCH_BIN to
+# reuse one you trust.
+#
+# Usage:   tests/fp_v1/synth/run_synth.sh [outdir]
+# Output:  a results table on stdout; per-op logs under <outdir> (default: a
+#          temp dir). Nothing is written back into the repo tree.
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo="$(cd "$here/../../.." && pwd)"
+outdir="${1:-$(mktemp -d)}"
+mkdir -p "$outdir"
+
+if [[ -z "${ARCH_BIN:-}" ]]; then
+  echo "# building arch (release)…" >&2
+  ( cd "$repo" && cargo build --release --bin arch >&2 )
+  ARCH_BIN="$repo/target/release/arch"
+fi
+
+emit() { printf '%s\n' "$2" > "$outdir/$1.arch"; }
+
+emit F32ToBf16 'module F32ToBf16
+  port a: in FP32; port y: out BF16;
+  comb y = a.to_bf16(); end comb
+end module F32ToBf16'
+emit Bf16ToF32 'module Bf16ToF32
+  port a: in BF16; port y: out FP32;
+  comb y = a.to_fp32(); end comb
+end module Bf16ToF32'
+emit F32Mul 'module F32Mul
+  port a: in FP32; port b: in FP32; port y: out FP32;
+  comb y = a * b; end comb
+end module F32Mul'
+emit F32Add 'module F32Add
+  port a: in FP32; port b: in FP32; port y: out FP32;
+  comb y = a + b; end comb
+end module F32Add'
+emit F32Sub 'module F32Sub
+  port a: in FP32; port b: in FP32; port y: out FP32;
+  comb y = a - b; end comb
+end module F32Sub'
+emit F32Fma 'module F32Fma
+  port a: in FP32; port b: in FP32; port c: in FP32; port y: out FP32;
+  comb y = fma(a, b, c); end comb
+end module F32Fma'
+emit Bf16Mul 'module Bf16Mul
+  port a: in BF16; port b: in BF16; port y: out BF16;
+  comb y = a * b; end comb
+end module Bf16Mul'
+emit Bf16Add 'module Bf16Add
+  port a: in BF16; port b: in BF16; port y: out BF16;
+  comb y = a + b; end comb
+end module Bf16Add'
+emit Bf16Sub 'module Bf16Sub
+  port a: in BF16; port b: in BF16; port y: out BF16;
+  comb y = a - b; end comb
+end module Bf16Sub'
+emit Bf16Fma 'module Bf16Fma
+  port a: in BF16; port b: in BF16; port c: in BF16; port y: out BF16;
+  comb y = fma(a, b, c); end comb
+end module Bf16Fma'
+
+ops=(Bf16ToF32 F32ToBf16 Bf16Mul F32Mul F32Add F32Sub Bf16Add Bf16Sub Bf16Fma F32Fma)
+
+for t in "${ops[@]}"; do
+  "$ARCH_BIN" build "$outdir/$t.arch" -o "$outdir/$t.sv" >&2
+  python3 "$here/hoist_decls.py" < "$outdir/$t.sv" > "$outdir/$t.v"
+  sed "s/TOP/$t/g" "$here/flow.ys.tmpl" > "$outdir/_$t.ys"
+  ( cd "$outdir" && yosys -q "_$t.ys" > "log_$t.txt" 2>&1 )
+done
+
+printf '\n%-12s %12s %12s\n' "operator" "cells" "depth"
+printf '%-12s %12s %12s\n' "--------" "-----" "-----"
+for t in "${ops[@]}"; do
+  cells=$(grep -m1 "Number of cells:" "$outdir/log_$t.txt" | grep -oE "[0-9]+" || echo "?")
+  depth=$(grep -m1 "Longest topological path" "$outdir/log_$t.txt" | grep -oE "length=[0-9]+" | grep -oE "[0-9]+" || echo "?")
+  printf '%-12s %12s %12s\n' "$t" "$cells" "$depth"
+done
+echo
+echo "# logs + netlists in: $outdir"


### PR DESCRIPTION
## Summary

Two follow-ups to the merged #627 (which corrected the `bf16_fma` docs and proved
the finite-path characterization). No RTL/codegen changes.

1. **Close the bf16-fma special-value path in Lean.** #627 proved only the finite
   rounded path (`archBf16Fma_eq_narrow_roundNE`). This adds the remaining
   NaN/Inf/Zero-cancel cases as composition theorems.
2. **Add a yosys synthesis harness** for the f32/bf16 operators — a physical-cost
   (logic-depth / gate-count) view to complement the existing SMT/Lean
   correctness work.

## 1. bf16-fma special-value lattice (`Bf16FmaNote.lean`)

Six theorems bind the **proved** f32 special-value lattice (`Fma.lean`) to the
**exhaustively-proved** `narrow` (`arch_f32_to_bf16`). Together with the finite
characterization, this is the complete bf16-fma lattice.

| theorem | widened-operand condition | bf16 result |
|---|---|---|
| `archBf16Fma_nan` | any NaN operand | `0x7FC0` (canonical NaN) |
| `archBf16Fma_zero_times_inf` | `0·∞` | `0x7FC0` |
| `archBf16Fma_inf_minus_inf` | `∞−∞` | `0x7FC0` |
| `archBf16Fma_cancel` | finite, exact cancellation (`mag=0`) | `+0` |
| `archBf16Fma_inf_prod` | infinite product | product-signed bf16 `∞` (sign symbolic) |
| `archBf16Fma_inf_c` | finite product + infinite addend | addend-signed bf16 `∞` (sign symbolic) |

`lake build` green (14 jobs); `#print axioms` on all six shows only
`propext`/`Classical.choice`/`Quot.sound` + the LRAT-certified `bv_decide`
axioms — **no `sorryAx`**.

## 2. yosys synthesis harness (`tests/fp_v1/synth/`)

Combinational synthesis of each operator: single-op `.arch` → `arch build` SV
(the proven RTL, same `fp_ops.rs` IR as the SMT/Lean models) → `hoist_decls.py`
(makes the SSA `function automatic` helpers parseable by yosys's Verilog
frontend) → yosys `synth` + `ltp`. No PDK/Liberty assumed, so results are
**2-input-gate levels** (timing proxy) and **generic-cell counts** (area proxy),
not ns/area.

Measured (yosys 0.33, `abc -fast`):

| operator | cells | depth (levels) |
|---|---:|---:|
| `bf16_to_f32` | 30 | 5 |
| `f32_to_bf16` | 90 | 9 |
| `bf16_mul` | 2,242 | 143 |
| `f32_mul` | 5,948 | 147 |
| `f32_add` / `f32_sub` | 4,270 / 4,269 | 183 / 183 |
| `bf16_add` / `bf16_sub` | 3,797 / 3,764 | 192 / 194 |
| `bf16_fma` | 32,077 | 236 |
| `f32_fma` | 38,064 | 235 |

Headline: conversions are nearly free; bf16 arith tracks f32 (it reuses the f32
datapath via widen→op→narrow); **FMA is the critical operator** (deepest +
largest, from the exact-wide 470-bit alignment) and wants pipelining for any real
Fmax. Full reading + caveats in `tests/fp_v1/synth/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015i1am9AsxcxNnDeb6zU38p)_