### PR TITLE
feat(sim): native C++ simulation bring-up for the Ibex port

### DIFF
--- a/src/comb_graph.rs
+++ b/src/comb_graph.rs
@@ -1069,15 +1069,23 @@ pub fn analyze_module(
         // At the instance level this appears as a cycle (ctrl ↔ lru_upd), but
         // it converges in 2 passes because lru_tree_in is register-driven.
         //
-        // We treat such cycles as requiring settle_depth=2 (not an error).
+        // We treat such cycles as requiring extra settle passes (not an error).
         // The topo sort for the cyclic nodes is undefined; fall back to the
         // original declaration order for ALL instances in this module so that
-        // the first pass produces partially-valid values and the second pass
-        // converges.  (For truly non-convergent loops the single-driver rule
-        // should prevent them from type-checking.)
+        // the early passes produce partially-valid values and the last pass
+        // converges. If parent comb intermediates bridge any instance inputs,
+        // one pass is consumed just refreshing those bridges before the
+        // instance feedback loop can settle, so 3 passes are needed.
+        // (For truly non-convergent loops the single-driver rule should
+        // prevent them from type-checking.)
+        let settle_depth = if parent_has_comb_intermediates(m) {
+            3
+        } else {
+            2
+        };
         return Ok(ModuleAnalysis {
             sorted_inst_indices: (0..n).collect(),
-            settle_depth: 2,
+            settle_depth,
         });
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ use miette::{IntoDiagnostic, NamedSource, Report, WrapErr};
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use arch::ast::Item;
+use arch::ast::{BinOp, Expr, ExprKind, Item, LitKind, ParamDecl, ParamKind, SourceFile, UnaryOp};
 use arch::codegen::Codegen;
 use arch::diagnostics::CompileError;
 use arch::elaborate;
@@ -281,9 +281,9 @@ enum Command {
         #[arg(long)]
         auto_thread_asserts: bool,
         /// Override a module param default: --param NAME=VALUE (repeatable).
-        /// Value must be an integer literal. The override is passed to the
-        /// C++ compiler as -DNAME=VALUE; the generated header's `#ifndef`
-        /// guard then defers to the command-line definition.
+        /// Value must be an integer literal. The override is applied before
+        /// sim codegen and also passed to the C++ compiler as -DNAME=VALUE
+        /// for generated header guards.
         #[arg(long = "param", value_name = "NAME=VALUE")]
         param_overrides: Vec<String>,
         /// Floating-point special-value compatibility profile (doc/plan_fp_types.md
@@ -1829,11 +1829,20 @@ fn run_sim_opts(
     // 1. Parse + type-check
     let all_files = resolve_use_imports(arch_files)?;
     let ms = MultiSource::from_files(&all_files)?;
-    let (ast, symbols, overload_map) = run_check_multi_opts(
-        &ms,
-        thread_sim_parallel,
-        /*auto_thread_asserts=*/ false,
-    )?;
+    let (ast, symbols, overload_map) = if param_overrides.is_empty() {
+        run_check_multi_opts(
+            &ms,
+            thread_sim_parallel,
+            /*auto_thread_asserts=*/ false,
+        )?
+    } else {
+        run_check_multi_opts_with_param_overrides(
+            &ms,
+            thread_sim_parallel,
+            /*auto_thread_asserts=*/ false,
+            param_overrides,
+        )?
+    };
 
     // 2. Set up output directory
     let build_dir = outdir
@@ -3232,6 +3241,165 @@ fn parse_graph_source_ast(ms: &MultiSource) -> miette::Result<arch::ast::SourceF
     Ok(parsed_ast)
 }
 
+fn params_mut_for_item(item: &mut Item) -> Option<(&str, &mut Vec<ParamDecl>)> {
+    match item {
+        Item::Module(m) => Some((&m.name.name, &mut m.params)),
+        Item::Fsm(f) => Some((&f.common.name.name, &mut f.common.params)),
+        Item::Fifo(f) => Some((&f.common.name.name, &mut f.common.params)),
+        Item::Ram(r) => Some((&r.common.name.name, &mut r.common.params)),
+        Item::Cam(c) => Some((&c.common.name.name, &mut c.common.params)),
+        Item::Counter(c) => Some((&c.common.name.name, &mut c.common.params)),
+        Item::Arbiter(a) => Some((&a.common.name.name, &mut a.common.params)),
+        Item::Regfile(r) => Some((&r.common.name.name, &mut r.common.params)),
+        Item::Pipeline(p) => Some((&p.common.name.name, &mut p.common.params)),
+        Item::Linklist(l) => Some((&l.common.name.name, &mut l.common.params)),
+        Item::Synchronizer(s) => Some((&s.name.name, &mut s.params)),
+        Item::Clkgate(c) => Some((&c.name.name, &mut c.params)),
+        Item::Bus(b) => Some((&b.name.name, &mut b.params)),
+        Item::Template(t) => Some((&t.name.name, &mut t.params)),
+        Item::Package(p) => Some((&p.name.name, &mut p.params)),
+        _ => None,
+    }
+}
+
+fn const_expr_i64(expr: &Expr, values: &std::collections::HashMap<String, i64>) -> Option<i64> {
+    match &expr.kind {
+        ExprKind::Literal(LitKind::Dec(v))
+        | ExprKind::Literal(LitKind::Hex(v))
+        | ExprKind::Literal(LitKind::Bin(v))
+        | ExprKind::Literal(LitKind::Sized(_, v)) => Some(*v as i64),
+        ExprKind::Ident(name) => values.get(name).copied(),
+        ExprKind::Unary(op, inner) => {
+            let v = const_expr_i64(inner, values)?;
+            match op {
+                UnaryOp::Neg => Some(v.wrapping_neg()),
+                UnaryOp::Not => Some(!v),
+                _ => None,
+            }
+        }
+        ExprKind::Binary(op, lhs, rhs) => {
+            let l = const_expr_i64(lhs, values)?;
+            let r = const_expr_i64(rhs, values)?;
+            match op {
+                BinOp::Add | BinOp::AddWrap => Some(l.wrapping_add(r)),
+                BinOp::Sub | BinOp::SubWrap => Some(l.wrapping_sub(r)),
+                BinOp::Mul | BinOp::MulWrap => Some(l.wrapping_mul(r)),
+                BinOp::Div => (r != 0).then_some(l / r),
+                BinOp::Mod => (r != 0).then_some(l % r),
+                BinOp::Shl => Some(l.wrapping_shl(r as u32)),
+                BinOp::Shr => Some(((l as u64).wrapping_shr(r as u32)) as i64),
+                BinOp::BitAnd => Some(l & r),
+                BinOp::BitOr => Some(l | r),
+                BinOp::BitXor => Some(l ^ r),
+                _ => None,
+            }
+        }
+        ExprKind::Clog2(inner) => {
+            let v = const_expr_i64(inner, values)?;
+            if v <= 1 {
+                Some(0)
+            } else {
+                Some(64 - ((v as u64) - 1).leading_zeros() as i64)
+            }
+        }
+        _ => None,
+    }
+}
+
+fn literal_for_param_override(
+    param: &ParamDecl,
+    value: u64,
+    values: &std::collections::HashMap<String, i64>,
+) -> LitKind {
+    if let ParamKind::WidthConst(hi, lo) = &param.kind {
+        if let (Some(h), Some(l)) = (const_expr_i64(hi, values), const_expr_i64(lo, values)) {
+            if h >= l {
+                return LitKind::Sized((h - l + 1) as u32, value);
+            }
+        }
+    }
+    LitKind::Dec(value)
+}
+
+fn apply_overrides_to_params(
+    construct_name: &str,
+    params: &mut [ParamDecl],
+    overrides: &std::collections::HashMap<String, u64>,
+    seen: &mut std::collections::HashSet<String>,
+) -> miette::Result<()> {
+    let mut values = std::collections::HashMap::<String, i64>::new();
+    for p in params.iter() {
+        if let Some(default) = &p.default {
+            if let Some(v) = const_expr_i64(default, &values) {
+                values.insert(p.name.name.clone(), v);
+            }
+        }
+    }
+
+    for p in params.iter_mut() {
+        let Some(&value) = overrides.get(&p.name.name) else {
+            continue;
+        };
+        seen.insert(p.name.name.clone());
+        if p.is_local {
+            return Err(miette::miette!(
+                "--param {}={} targets local param `{}` in `{}`; local params are not overridable",
+                p.name.name,
+                value,
+                p.name.name,
+                construct_name,
+            ));
+        }
+        if !matches!(
+            p.kind,
+            ParamKind::Const | ParamKind::WidthConst(..) | ParamKind::Logic(_)
+        ) {
+            return Err(miette::miette!(
+                "--param {}={} targets non-integer param `{}` in `{}`; only const/logic value params are supported",
+                p.name.name,
+                value,
+                p.name.name,
+                construct_name,
+            ));
+        }
+        let lit = literal_for_param_override(p, value, &values);
+        p.default = Some(Expr::new(ExprKind::Literal(lit), p.name.span));
+        values.insert(p.name.name.clone(), value as i64);
+    }
+    Ok(())
+}
+
+fn apply_top_param_overrides(
+    ast: &mut SourceFile,
+    overrides: &std::collections::HashMap<String, u64>,
+) -> miette::Result<()> {
+    if overrides.is_empty() {
+        return Ok(());
+    }
+
+    let mut seen = std::collections::HashSet::<String>::new();
+    for item in ast.items.iter_mut() {
+        let Some((construct_name, params)) = params_mut_for_item(item) else {
+            continue;
+        };
+        apply_overrides_to_params(construct_name, params, overrides, &mut seen)?;
+    }
+
+    let mut unknown: Vec<_> = overrides
+        .keys()
+        .filter(|name| !seen.contains(*name))
+        .cloned()
+        .collect();
+    unknown.sort();
+    if !unknown.is_empty() {
+        return Err(miette::miette!(
+            "--param override(s) did not match any non-local value parameter: {}",
+            unknown.join(", ")
+        ));
+    }
+    Ok(())
+}
+
 fn run_check_multi(
     ms: &MultiSource,
 ) -> miette::Result<(
@@ -3253,7 +3421,13 @@ fn run_check_multi_opts(
     resolve::SymbolTable,
     std::collections::HashMap<usize, usize>,
 )> {
-    run_check_multi_opts_with_thread_map(ms, skip_lower_threads, auto_thread_asserts, None)
+    run_check_multi_opts_with_thread_map_and_params(
+        ms,
+        skip_lower_threads,
+        auto_thread_asserts,
+        None,
+        None,
+    )
 }
 
 fn run_check_multi_opts_with_thread_map(
@@ -3261,6 +3435,45 @@ fn run_check_multi_opts_with_thread_map(
     skip_lower_threads: bool,
     auto_thread_asserts: bool,
     thread_map: Option<std::rc::Rc<std::cell::RefCell<arch::thread_map::ThreadMap>>>,
+) -> miette::Result<(
+    arch::ast::SourceFile,
+    resolve::SymbolTable,
+    std::collections::HashMap<usize, usize>,
+)> {
+    run_check_multi_opts_with_thread_map_and_params(
+        ms,
+        skip_lower_threads,
+        auto_thread_asserts,
+        thread_map,
+        None,
+    )
+}
+
+fn run_check_multi_opts_with_param_overrides(
+    ms: &MultiSource,
+    skip_lower_threads: bool,
+    auto_thread_asserts: bool,
+    param_overrides: &std::collections::HashMap<String, u64>,
+) -> miette::Result<(
+    arch::ast::SourceFile,
+    resolve::SymbolTable,
+    std::collections::HashMap<usize, usize>,
+)> {
+    run_check_multi_opts_with_thread_map_and_params(
+        ms,
+        skip_lower_threads,
+        auto_thread_asserts,
+        None,
+        Some(param_overrides),
+    )
+}
+
+fn run_check_multi_opts_with_thread_map_and_params(
+    ms: &MultiSource,
+    skip_lower_threads: bool,
+    auto_thread_asserts: bool,
+    thread_map: Option<std::rc::Rc<std::cell::RefCell<arch::thread_map::ThreadMap>>>,
+    param_overrides: Option<&std::collections::HashMap<String, u64>>,
 ) -> miette::Result<(
     arch::ast::SourceFile,
     resolve::SymbolTable,
@@ -3338,6 +3551,10 @@ fn run_check_multi_opts_with_thread_map(
     if !prec_errors.is_empty() {
         let err = prec_errors.into_iter().next().unwrap();
         return Err(ms.report_error(err));
+    }
+
+    if let Some(overrides) = param_overrides {
+        apply_top_param_overrides(&mut parsed_ast, overrides)?;
     }
 
     // Resolve module-scope `type Name = ...;` aliases by inlining them at

--- a/src/sim_codegen/fsm.rs
+++ b/src/sim_codegen/fsm.rs
@@ -82,9 +82,16 @@ impl<'a> SimCodegen<'a> {
         };
 
         let mut h = String::new();
+        let has_structs = f.ports.iter().any(|p| ty_references_named(&p.ty))
+            || f.regs.iter().any(|r| ty_references_named(&r.ty))
+            || f.wires.iter().any(|w| ty_references_named(&w.ty));
         h.push_str(
-            "#pragma once\n#include <cstdint>\n#include <cstdio>\n#include \"verilated.h\"\n\n",
+            "#pragma once\n#include <cstdint>\n#include <cstdio>\n#include \"verilated.h\"\n",
         );
+        if has_structs {
+            h.push_str("#include \"VStructs.h\"\n");
+        }
+        h.push('\n');
         // Emit param constants as #define
         for p in &f.params {
             if matches!(p.kind, ParamKind::Const | ParamKind::WidthConst(..)) {
@@ -211,7 +218,13 @@ impl<'a> SimCodegen<'a> {
             .filter(|p| {
                 !fsm_vec_port_names.contains(&p.name.name) && !bus_port_names.contains(&p.name.name)
             })
-            .map(|p| format!("{}(0)", p.name.name))
+            .map(|p| {
+                if ty_references_named(&p.ty) {
+                    format!("{}()", p.name.name)
+                } else {
+                    format!("{}(0)", p.name.name)
+                }
+            })
             .collect();
         let vec_port_flat_inits: Vec<String> = fsm_vec_port_infos
             .iter()
@@ -239,6 +252,8 @@ impl<'a> SimCodegen<'a> {
                         ),
                     );
                     format!("{}({})", r.name.name, init_val)
+                } else if ty_references_named(&r.ty) {
+                    format!("{}()", r.name.name)
                 } else {
                     format!("{}(0)", r.name.name)
                 }

--- a/src/sim_codegen/mod.rs
+++ b/src/sim_codegen/mod.rs
@@ -17,6 +17,7 @@ use std::collections::{HashMap, HashSet};
 use crate::ast::*;
 use crate::comb_graph;
 use crate::resolve::{Symbol, SymbolTable};
+use crate::thread_map::expr_label;
 use crate::typecheck::enum_width;
 
 // Per-construct emitters split out to keep this file from growing further.
@@ -99,12 +100,12 @@ impl SourceMap {
     }
 }
 
-/// One coverage point recorded during gen_module. Currently only branch
-/// coverage (one entry per if/elsif/else arm in seq+comb) — see
-/// doc/plan_arch_coverage.md for the phased rollout.
+/// One coverage point recorded during gen_module. Covers statement arms
+/// (`if`/`elsif`/`else`, `match`) plus expression-level control such as
+/// ternary arms, then block-entry/toggle/FSM points.
 #[derive(Debug, Clone)]
 pub(crate) struct CovPoint {
-    /// "if", "elsif", or "else"
+    /// "if", "elsif", "else", "expr-then", "expr-else", ...
     pub kind: &'static str,
     /// Source byte offset of the cond expr (else: of the `else` keyword).
     /// Resolved to file:line at dump-emit time via the SourceFile span map.
@@ -131,6 +132,16 @@ impl CoverageRegistry {
         });
         idx
     }
+}
+
+fn coverage_expr_label(prefix: &str, expr: &Expr) -> String {
+    let mut label = format!("{prefix} {}", expr_label(expr).replace('\n', " "));
+    const MAX_LABEL_CHARS: usize = 60;
+    if label.chars().count() > MAX_LABEL_CHARS {
+        label = label.chars().take(MAX_LABEL_CHARS).collect();
+        label.push_str("...");
+    }
+    label
 }
 
 impl<'a> SimCodegen<'a> {
@@ -1466,6 +1477,7 @@ fn add_trace_to_simple_construct(
 ) {
     // Build signal list from ports + extras.
     // Vec and bus ports are skipped (their flat fields are passed via extra_signals by caller).
+    // Named struct/enum ports are not scalar-shiftable in the C++ native sim.
     // `params` is the enclosing construct's param list, used to resolve
     // `UInt<PARAM>` / `SInt<PARAM>` widths in port VCD declarations to
     // their real bit width rather than the legacy 32-default. See
@@ -1473,9 +1485,9 @@ fn add_trace_to_simple_construct(
     // this footgun.
     let mut signals = Vec::new();
     for p in ports {
-        if matches!(p.ty, TypeExpr::Vec(..)) {
+        if ty_references_named(&p.ty) {
             continue;
-        } // handled as flat via extra_signals
+        } // handled elsewhere or intentionally untraced when struct-typed
         if p.bus_info.is_some() {
             continue;
         } // bus ports flattened via extra_signals
@@ -1534,17 +1546,9 @@ fn eval_width(expr: &Expr) -> u32 {
 /// legacy `eval_width` for shapes the const evaluator can't fold (which
 /// preserves prior conservative-32 behavior).
 fn eval_width_in(expr: &Expr, ctx: &Ctx) -> u32 {
-    let folded = eval_const_expr_with_params(expr, ctx.params);
-    if folded != 0
-        || matches!(
-            &expr.kind,
-            ExprKind::Literal(LitKind::Dec(0)) | ExprKind::Literal(LitKind::Hex(0))
-        )
-    {
-        folded as u32
-    } else {
-        eval_width(expr)
-    }
+    try_eval_const_expr_with_params(expr, ctx.params)
+        .map(|v| v as u32)
+        .unwrap_or_else(|| eval_width(expr))
 }
 
 /// Number of 32-bit words needed for `bits` bits.
@@ -1566,6 +1570,14 @@ fn is_wide_bits(bits: u32) -> bool {
                     // surface a deprecation warning at PR review time.
 fn cpp_port_type(ty: &TypeExpr) -> String {
     cpp_port_type_with_params(ty, &[])
+}
+
+fn ty_references_named(ty: &TypeExpr) -> bool {
+    match ty {
+        TypeExpr::Named(_) => true,
+        TypeExpr::Vec(inner, _) => ty_references_named(inner),
+        _ => false,
+    }
 }
 
 /// Param-aware variant of [`cpp_port_type`]. Resolves param identifiers in
@@ -1611,17 +1623,9 @@ fn cpp_port_type_with_params(ty: &TypeExpr, params: &[ParamDecl]) -> String {
 /// legacy literal-only `eval_width` for shapes the const evaluator can't
 /// fold (preserving prior conservative-32 behavior). arch-com#330.
 fn eval_width_with_params(expr: &Expr, params: &[ParamDecl]) -> u32 {
-    let folded = eval_const_expr_with_params(expr, params);
-    if folded != 0
-        || matches!(
-            &expr.kind,
-            ExprKind::Literal(LitKind::Dec(0)) | ExprKind::Literal(LitKind::Hex(0))
-        )
-    {
-        folded as u32
-    } else {
-        eval_width(expr)
-    }
+    try_eval_const_expr_with_params(expr, params)
+        .map(|v| v as u32)
+        .unwrap_or_else(|| eval_width(expr))
 }
 
 /// Substitute param idents in a TypeExpr (for bus param resolution in sim codegen).
@@ -2412,11 +2416,16 @@ fn stmt_indexes_vob_with_var(
 /// Param-aware constant evaluator. Resolves bare identifiers against
 /// `params` (regular + local) by recursing on each param's `default`
 /// expression. Handles literals, `$clog2(x)`, unary `-`/`~`, and
-/// binary `+`, `-`, `*`, `/`, `%`, `<<`, `>>`, `&`, `|`, `^`. Returns 0
-/// for anything it can't fold (e.g. non-literal port reads), matching
-/// the conservative behavior of the legacy single-arg version.
+/// binary `+`, `-`, `*`, `/`, `%`, `<<`, `>>`, `&`, `|`, `^`. The public
+/// wrapper preserves the historical "unknown folds to 0" behavior; callers
+/// that need to distinguish a real zero from an unknown expression use the
+/// `try_` variant directly.
 fn eval_const_expr_with_params(expr: &Expr, params: &[ParamDecl]) -> u64 {
-    eval_const_expr_with_params_seen(expr, params, &mut HashSet::new())
+    try_eval_const_expr_with_params(expr, params).unwrap_or(0)
+}
+
+fn try_eval_const_expr_with_params(expr: &Expr, params: &[ParamDecl]) -> Option<u64> {
+    try_eval_const_expr_with_params_seen(expr, params, &mut HashSet::new())
 }
 
 /// Return true if the module body contains a preserved `Generate(For)`
@@ -2486,75 +2495,63 @@ fn flatten_preserved_generates_for_sim(
     out
 }
 
-fn eval_const_expr_with_params_seen(
+fn try_eval_const_expr_with_params_seen(
     expr: &Expr,
     params: &[ParamDecl],
     seen_params: &mut HashSet<String>,
-) -> u64 {
+) -> Option<u64> {
     match &expr.kind {
-        ExprKind::Literal(LitKind::Dec(v)) => *v,
-        ExprKind::Literal(LitKind::Hex(v)) => *v,
-        ExprKind::Literal(LitKind::Bin(v)) => *v,
-        ExprKind::Literal(LitKind::Sized(_, v)) => *v,
+        ExprKind::Literal(LitKind::Dec(v)) => Some(*v),
+        ExprKind::Literal(LitKind::Hex(v)) => Some(*v),
+        ExprKind::Literal(LitKind::Bin(v)) => Some(*v),
+        ExprKind::Literal(LitKind::Sized(_, v)) => Some(*v),
         ExprKind::Ident(name) => {
             if let Some(p) = params.iter().find(|p| p.name.name == *name) {
                 if let Some(d) = &p.default {
                     if !seen_params.insert(name.clone()) {
-                        return 0;
+                        return None;
                     }
-                    let value = eval_const_expr_with_params_seen(d, params, seen_params);
+                    let value = try_eval_const_expr_with_params_seen(d, params, seen_params);
                     seen_params.remove(name);
                     return value;
                 }
             }
-            0
+            None
         }
         ExprKind::Clog2(a) => {
-            let v = eval_const_expr_with_params_seen(a, params, seen_params);
-            if v <= 1 {
+            let v = try_eval_const_expr_with_params_seen(a, params, seen_params)?;
+            Some(if v <= 1 {
                 0
             } else {
                 64 - (v - 1).leading_zeros() as u64
-            }
+            })
         }
         ExprKind::Unary(op, a) => {
-            let v = eval_const_expr_with_params_seen(a, params, seen_params);
+            let v = try_eval_const_expr_with_params_seen(a, params, seen_params)?;
             match op {
-                UnaryOp::Not => !v,
-                UnaryOp::Neg => v.wrapping_neg(),
-                _ => 0,
+                UnaryOp::Not => Some(!v),
+                UnaryOp::Neg => Some(v.wrapping_neg()),
+                _ => None,
             }
         }
         ExprKind::Binary(op, l, r) => {
-            let lv = eval_const_expr_with_params_seen(l, params, seen_params);
-            let rv = eval_const_expr_with_params_seen(r, params, seen_params);
+            let lv = try_eval_const_expr_with_params_seen(l, params, seen_params)?;
+            let rv = try_eval_const_expr_with_params_seen(r, params, seen_params)?;
             match op {
-                BinOp::Add => lv.wrapping_add(rv),
-                BinOp::Sub => lv.wrapping_sub(rv),
-                BinOp::Mul => lv.wrapping_mul(rv),
-                BinOp::Div => {
-                    if rv == 0 {
-                        0
-                    } else {
-                        lv / rv
-                    }
-                }
-                BinOp::Mod => {
-                    if rv == 0 {
-                        0
-                    } else {
-                        lv % rv
-                    }
-                }
-                BinOp::Shl => lv.wrapping_shl(rv as u32),
-                BinOp::Shr => lv.wrapping_shr(rv as u32),
-                BinOp::BitAnd => lv & rv,
-                BinOp::BitOr => lv | rv,
-                BinOp::BitXor => lv ^ rv,
-                _ => 0,
+                BinOp::Add => Some(lv.wrapping_add(rv)),
+                BinOp::Sub => Some(lv.wrapping_sub(rv)),
+                BinOp::Mul => Some(lv.wrapping_mul(rv)),
+                BinOp::Div => (rv != 0).then_some(lv / rv),
+                BinOp::Mod => (rv != 0).then_some(lv % rv),
+                BinOp::Shl => Some(lv.wrapping_shl(rv as u32)),
+                BinOp::Shr => Some(lv.wrapping_shr(rv as u32)),
+                BinOp::BitAnd => Some(lv & rv),
+                BinOp::BitOr => Some(lv | rv),
+                BinOp::BitXor => Some(lv ^ rv),
+                _ => None,
             }
         }
-        _ => 0,
+        _ => None,
     }
 }
 
@@ -2816,6 +2813,9 @@ struct Ctx<'a> {
     /// like `CounterWidth-1` in `BitSlice` hi/lo and `PartSelect` width.
     /// Empty by default; populated via [`Ctx::with_params`] at module entry.
     params: &'a [ParamDecl],
+    /// Reg names whose shadow valid bit should be marked true when a seq
+    /// assignment writes the reg.
+    vinit_regs: Option<&'a HashSet<String>>,
 }
 
 impl<'a> Ctx<'a> {
@@ -2865,6 +2865,7 @@ impl<'a> Ctx<'a> {
             vec_of_bus_wire_count: None,
             coverage: None,
             params: EMPTY_PARAMS,
+            vinit_regs: None,
         }
     }
 
@@ -2892,6 +2893,11 @@ impl<'a> Ctx<'a> {
 
     fn with_params(mut self, params: &'a [ParamDecl]) -> Self {
         self.params = params;
+        self
+    }
+
+    fn with_vinit_regs(mut self, vinit_regs: &'a HashSet<String>) -> Self {
+        self.vinit_regs = Some(vinit_regs);
         self
     }
 
@@ -3351,6 +3357,7 @@ fn lower_vec_method_cpp(
             vec_of_bus_wire_count: ctx.vec_of_bus_wire_count,
             coverage: ctx.coverage,
             params: ctx.params,
+            vinit_regs: ctx.vinit_regs,
         };
         // The sub map must outlive the cpp_expr call. We keep `sub` as a
         // stack-local binding whose lifetime covers the call.
@@ -3946,6 +3953,22 @@ fn cpp_expr_inner(expr: &Expr, ctx: &Ctx, is_lhs: bool) -> String {
             let c = cpp_expr(cond, ctx);
             let t = cpp_expr(then_expr, ctx);
             let e = cpp_expr(else_expr, ctx);
+            if let Some(reg) = ctx.coverage {
+                let mut cov = reg.borrow_mut();
+                let then_idx = cov.alloc(
+                    "expr-then",
+                    cond.span.start,
+                    coverage_expr_label("then", cond),
+                );
+                let else_idx = cov.alloc(
+                    "expr-else",
+                    cond.span.start,
+                    coverage_expr_label("else", cond),
+                );
+                return format!(
+                    "(({c}) ? (_arch_cov[{then_idx}]++, ({t})) : (_arch_cov[{else_idx}]++, ({e})))"
+                );
+            }
             format!("(({c}) ? ({t}) : ({e}))")
         }
 
@@ -4407,6 +4430,26 @@ fn emit_stmts(stmts: &[Stmt], ctx: &Ctx, out: &mut String, indent: usize, k: Sim
     }
 }
 
+fn assigned_base_ident(expr: &Expr) -> Option<&str> {
+    match &expr.kind {
+        ExprKind::Ident(name) => Some(name.as_str()),
+        ExprKind::Index(base, _) | ExprKind::BitSlice(base, _, _) => assigned_base_ident(base),
+        _ => None,
+    }
+}
+
+fn emit_vinit_mark_for_target(target: &Expr, ctx: &Ctx, out: &mut String, indent: usize) {
+    let Some(vinit_regs) = ctx.vinit_regs else {
+        return;
+    };
+    let Some(name) = assigned_base_ident(target) else {
+        return;
+    };
+    if vinit_regs.contains(name) {
+        out.push_str(&format!("{}_{name}_vinit = true;\n", ind(indent)));
+    }
+}
+
 fn emit_stmt(stmt: &Stmt, ctx: &Ctx, out: &mut String, indent: usize, k: SimAssignKind) {
     let is_seq = k == SimAssignKind::Seq;
     match stmt {
@@ -4448,6 +4491,9 @@ fn emit_stmt(stmt: &Stmt, ctx: &Ctx, out: &mut String, indent: usize, k: SimAssi
                             "{}memset({lhs}, 0, sizeof({lhs}));\n",
                             ind(indent)
                         ));
+                        if is_seq {
+                            emit_vinit_mark_for_target(&a.target, ctx, out, indent);
+                        }
                         return;
                     }
                     if let Some(rhs_name) = vec_name_of_expr(&a.value) {
@@ -4460,6 +4506,9 @@ fn emit_stmt(stmt: &Stmt, ctx: &Ctx, out: &mut String, indent: usize, k: SimAssi
                                     "{}for (size_t _i = 0; _i < {count}; ++_i) {{ {lhs}[_i] = {rhs}[_i]; }}\n",
                                     ind(indent)
                                 ));
+                                if is_seq {
+                                    emit_vinit_mark_for_target(&a.target, ctx, out, indent);
+                                }
                                 return;
                             }
                         }
@@ -4482,6 +4531,9 @@ fn emit_stmt(stmt: &Stmt, ctx: &Ctx, out: &mut String, indent: usize, k: SimAssi
                             "{}{resolved_base} = ({resolved_base} & ~(uint64_t(1) << ({idx_cpp}))) | (uint64_t(({rhs}) & 1) << ({idx_cpp}));\n",
                             ind(indent)
                         ));
+                        if is_seq {
+                            emit_vinit_mark_for_target(&a.target, ctx, out, indent);
+                        }
                         return;
                     }
                 }
@@ -4489,14 +4541,18 @@ fn emit_stmt(stmt: &Stmt, ctx: &Ctx, out: &mut String, indent: usize, k: SimAssi
             // Bit-slice LHS: name[hi:lo] = val. Lower to mask-and-OR rather
             // than the read-side `((name >> lo) & mask)` (an rvalue — gcc /
             // clang reject as "expression is not assignable"). Only the
-            // bare-ident base case `name[hi:lo]` is handled here; Vec-element
-            // slice LHS or wider-than-64 bases keep the generic path and
-            // would need their own arms.
+            // narrow scalar and Vec-element base cases are handled here;
+            // wider-than-64 bases keep the generic path and would need their
+            // own arms.
             if let ExprKind::BitSlice(base, hi_e, lo_e) = &a.target.kind {
-                if let ExprKind::Ident(base_name) = &base.kind {
-                    let base_w = infer_expr_width(base, ctx);
-                    if base_w > 0 && base_w <= 64 {
-                        let resolved_base = ctx.resolve_name(base_name, is_seq);
+                let base_w = infer_expr_width(base, ctx);
+                if base_w > 0 && base_w <= 64 {
+                    let resolved_base = match &base.kind {
+                        ExprKind::Ident(base_name) => ctx.resolve_name(base_name, is_seq),
+                        ExprKind::Index(_, _) => cpp_expr_lhs(base, ctx),
+                        _ => String::new(),
+                    };
+                    if !resolved_base.is_empty() {
                         let hi = eval_width_in(hi_e, ctx);
                         let lo = eval_width_in(lo_e, ctx);
                         let width = hi - lo + 1;
@@ -4510,6 +4566,9 @@ fn emit_stmt(stmt: &Stmt, ctx: &Ctx, out: &mut String, indent: usize, k: SimAssi
                             "{}{resolved_base} = ({resolved_base} & ~(uint64_t(0x{val_mask:X}ULL) << {lo})) | ((uint64_t(({rhs}) & 0x{val_mask:X}ULL)) << {lo});\n",
                             ind(indent)
                         ));
+                        if is_seq {
+                            emit_vinit_mark_for_target(&a.target, ctx, out, indent);
+                        }
                         return;
                     }
                 }
@@ -4518,6 +4577,7 @@ fn emit_stmt(stmt: &Stmt, ctx: &Ctx, out: &mut String, indent: usize, k: SimAssi
             if is_seq {
                 let lhs = cpp_expr_lhs(&a.target, ctx);
                 out.push_str(&format!("{}{}  = {};\n", ind(indent), lhs, rhs));
+                emit_vinit_mark_for_target(&a.target, ctx, out, indent);
             } else {
                 // Comb: bare-ident-aware target name + wide-output-port conversion.
                 let target_name = if let ExprKind::Ident(name) = &a.target.kind {
@@ -6066,6 +6126,62 @@ impl<'a> SimCodegen<'a> {
     /// via `ConstructCommon` and we return it directly from the AST rather than
     /// going through the resolve::Symbol summary (which not all construct kinds
     /// expose `ports` through).
+    fn lookup_inst_arbiter(&self, module_name: &str) -> Option<&ArbiterDecl> {
+        self.source.items.iter().find_map(|item| match item {
+            Item::Arbiter(a) if a.name.name == module_name => Some(a),
+            _ => None,
+        })
+    }
+
+    fn indexed_arbiter_port(
+        &self,
+        inst: &crate::ast::InstDecl,
+        port_name: &str,
+    ) -> Option<(String, u64)> {
+        let (indexed_name, signal_name) = port_name.rsplit_once('_')?;
+        let digit_start = indexed_name
+            .char_indices()
+            .rev()
+            .find(|(_, ch)| !ch.is_ascii_digit())
+            .map(|(idx, ch)| idx + ch.len_utf8())
+            .unwrap_or(0);
+        if digit_start == indexed_name.len() {
+            return None;
+        }
+
+        let group_name = &indexed_name[..digit_start];
+        let index: u64 = indexed_name[digit_start..].parse().ok()?;
+        if group_name.is_empty() {
+            return None;
+        }
+
+        let arbiter = self.lookup_inst_arbiter(&inst.module_name.name)?;
+        let port_array = arbiter
+            .port_arrays
+            .iter()
+            .find(|pa| pa.name.name == group_name)?;
+        if !port_array
+            .signals
+            .iter()
+            .any(|sig| sig.name.name == signal_name)
+        {
+            return None;
+        }
+
+        let mut sub_params = arbiter.params.clone();
+        for pa in &inst.param_assigns {
+            if let Some(p) = sub_params.iter_mut().find(|p| p.name.name == pa.name.name) {
+                p.default = Some(pa.value.clone());
+            }
+        }
+        let count = eval_const_expr_with_params(&port_array.count_expr, &sub_params);
+        if index >= count {
+            return None;
+        }
+
+        Some((format!("{group_name}_{signal_name}"), index))
+    }
+
     fn lookup_inst_ports(&self, module_name: &str) -> Vec<PortDecl> {
         for item in &self.source.items {
             let ports = match item {
@@ -6085,6 +6201,15 @@ impl<'a> SimCodegen<'a> {
             };
             if let Some(p) = ports {
                 return p.clone();
+            }
+        }
+        if let Some((sym, _)) = self.symbols.globals.get(module_name) {
+            match sym {
+                crate::resolve::Symbol::Module(info) => return info.ports.clone(),
+                crate::resolve::Symbol::Fsm(info) => return info.ports.clone(),
+                crate::resolve::Symbol::Fifo(info) => return info.ports.clone(),
+                crate::resolve::Symbol::Pipeline(info) => return info.ports.clone(),
+                _ => {}
             }
         }
         Vec::new()
@@ -6113,6 +6238,13 @@ impl<'a> SimCodegen<'a> {
             };
             if let Some(p) = params {
                 return p.clone();
+            }
+        }
+        if let Some((sym, _)) = self.symbols.globals.get(module_name) {
+            match sym {
+                crate::resolve::Symbol::Module(info) => return info.params.clone(),
+                crate::resolve::Symbol::Pipeline(info) => return info.params.clone(),
+                _ => {}
             }
         }
         Vec::new()
@@ -6312,6 +6444,34 @@ impl<'a> SimCodegen<'a> {
                         type_bits_te_with_params(&f.ty, &m.params),
                     );
                 }
+            }
+        }
+        let mut named_signal_names: HashSet<String> = HashSet::new();
+        for p in &m.ports {
+            if ty_references_named(&p.ty) {
+                named_signal_names.insert(p.name.name.clone());
+            }
+        }
+        for item in &m.body {
+            match item {
+                ModuleBodyItem::RegDecl(r) => {
+                    if ty_references_named(&r.ty) {
+                        named_signal_names.insert(r.name.name.clone());
+                    }
+                }
+                ModuleBodyItem::WireDecl(w) => {
+                    if ty_references_named(&w.ty) {
+                        named_signal_names.insert(w.name.name.clone());
+                    }
+                }
+                ModuleBodyItem::LetBinding(l) => {
+                    if let Some(ty) = &l.ty {
+                        if ty_references_named(ty) {
+                            named_signal_names.insert(l.name.name.clone());
+                        }
+                    }
+                }
+                _ => {}
             }
         }
 
@@ -6561,8 +6721,7 @@ impl<'a> SimCodegen<'a> {
             }
         }
 
-        // Collect reset-none reg names for --check-uninit + any guarded reg (regardless
-        // of reset) so Check A can use _<name>_vinit to detect producer bugs.
+        // Collect reset-none reg names for --check-uninit warning plumbing.
         let mut uninit_regs: HashSet<String> = if self.check_uninit {
             m.body
                 .iter()
@@ -6721,6 +6880,11 @@ impl<'a> SimCodegen<'a> {
                 })
             }))
             .collect();
+        // Guard checks are emitted in normal native sim too, so guarded regs
+        // need shadow valid bits even when the broader --check-uninit warning
+        // machinery is disabled.
+        let mut vinit_regs = uninit_regs.clone();
+        vinit_regs.extend(guarded_regs.keys().cloned());
 
         // Also include inst_out in "known" names for the wide set and widths
         // (they come from sub-inst ports — we'll default them to uint32_t for now)
@@ -6939,7 +7103,7 @@ impl<'a> SimCodegen<'a> {
         // When a sub-instance has a Vec output port and the parent connects it to a scalar
         // wire (e.g. thread lowering creates `thread_complete -> thread_complete`), we need
         // to emit flat fields and element-by-element copies instead of scalar assignments.
-        let mut inst_vec_out: HashMap<String, (String, u64)> = HashMap::new(); // sig → (elem_ty, count)
+        let mut inst_vec_out: HashMap<String, (String, u64, u32, bool)> = HashMap::new(); // sig → (elem_ty, count, elem_bits, array_storage)
         for (inst_idx, inst) in insts.iter().enumerate() {
             let sub_ports = self.lookup_inst_ports(&inst.module_name.name);
             // Build the effective param map for this instance: start with
@@ -6967,9 +7131,33 @@ impl<'a> SimCodegen<'a> {
                             {
                                 let count: u64 = count_str.parse().unwrap_or(0);
                                 if count > 0 {
-                                    inst_vec_out.insert(sig_name.clone(), (elem_ty, count));
-                                    // Also add to vec_wire_counts so output reads expand correctly
-                                    vec_wire_counts.insert(sig_name.clone(), count);
+                                    let elem_bits = if let TypeExpr::Vec(elem, _) = &port.ty {
+                                        type_bits_te_with_params(elem, &sub_params)
+                                    } else {
+                                        0
+                                    };
+                                    let target_is_vec_port = m.ports.iter().any(|p| {
+                                        p.name.name == *sig_name
+                                            && matches!(p.ty, TypeExpr::Vec(..))
+                                    });
+                                    let target_is_declared_vec =
+                                        target_is_vec_port || vec_reg_names.contains(sig_name);
+                                    let target_is_declared_scalar = !target_is_declared_vec
+                                        && (port_names.contains(sig_name)
+                                            || reg_names.contains(sig_name)
+                                            || let_names.contains(sig_name));
+                                    let array_storage =
+                                        target_is_declared_vec || !target_is_declared_scalar;
+
+                                    inst_vec_out.insert(
+                                        sig_name.clone(),
+                                        (elem_ty, count, elem_bits, array_storage),
+                                    );
+                                    // Only array-backed targets should use Vec indexing. A packed
+                                    // scalar parent connected to a child Vec output is packed below.
+                                    if array_storage {
+                                        vec_wire_counts.insert(sig_name.clone(), count);
+                                    }
                                 }
                             }
                         }
@@ -6979,8 +7167,10 @@ impl<'a> SimCodegen<'a> {
         }
         // Add inst-output Vec names to vec_reg_names so Index uses [i] syntax,
         // and add their element widths to the width map for expression codegen.
-        for (name, (elem_ty, count)) in &inst_vec_out {
-            vec_reg_names.insert(name.clone());
+        for (name, (elem_ty, count, _elem_bits, array_storage)) in &inst_vec_out {
+            if *array_storage {
+                vec_reg_names.insert(name.clone());
+            }
             // Infer element width from C++ type
             let elem_bits = match elem_ty.as_str() {
                 "uint8_t" => 8,
@@ -7037,13 +7227,6 @@ impl<'a> SimCodegen<'a> {
         // whose only struct use was inside a Vec produced headers that
         // referenced the struct without declaring it — both the reg storage
         // line (`Entry _ent[N];`) and the pybind wrapper failed to compile.
-        fn ty_references_named(ty: &TypeExpr) -> bool {
-            match ty {
-                TypeExpr::Named(_) => true,
-                TypeExpr::Vec(inner, _) => ty_references_named(inner),
-                _ => false,
-            }
-        }
         let has_structs = m
             .body
             .iter()
@@ -7536,6 +7719,9 @@ impl<'a> SimCodegen<'a> {
                     if wide_names.contains(sig_name) {
                         continue;
                     }
+                    if named_signal_names.contains(sig_name) {
+                        continue;
+                    }
                     if vec_port_names.contains(sig_name) {
                         continue;
                     }
@@ -7592,10 +7778,10 @@ impl<'a> SimCodegen<'a> {
             }
         }
 
-        // Shadow valid bits for --check-uninit (reset-none regs + pipe_reg stages)
-        if !uninit_regs.is_empty() {
-            h.push_str("  // --check-uninit shadow valid bits\n");
-            for name in &uninit_regs {
+        // Shadow valid bits for --check-uninit and guarded-reg checks.
+        if !vinit_regs.is_empty() {
+            h.push_str("  // --check-uninit / guard-check shadow valid bits\n");
+            for name in &vinit_regs {
                 h.push_str(&format!("  bool _{name}_vinit = false;\n"));
             }
             // pipe_reg stages whose source is uninit also get shadow bits
@@ -7761,7 +7947,9 @@ impl<'a> SimCodegen<'a> {
                 && !bus_wire_names.contains(sig_name)
             {
                 // Vec output ports need a C array, not a scalar
-                if let Some((elem_ty, count)) = inst_vec_out.get(sig_name) {
+                if let Some((elem_ty, count, _elem_bits, _array_storage)) =
+                    inst_vec_out.get(sig_name)
+                {
                     h.push_str(&format!("  {elem_ty} {sig_name}[{count}];\n"));
                 } else {
                     // Pick the C++ type from the resolved width when known
@@ -7913,6 +8101,25 @@ impl<'a> SimCodegen<'a> {
         .with_let_values(&let_values)
         .with_params(&m.params);
 
+        let child_vec_output_shape =
+            |inst: &crate::ast::InstDecl, port_name: &str| -> Option<(u64, u32)> {
+                let mut sub_params = self.lookup_inst_params(&inst.module_name.name);
+                for pa in &inst.param_assigns {
+                    if let Some(p) = sub_params.iter_mut().find(|p| p.name.name == pa.name.name) {
+                        p.default = Some(pa.value.clone());
+                    }
+                }
+                let sub_ports = self.lookup_inst_ports(&inst.module_name.name);
+                let port = sub_ports.iter().find(|p| p.name.name == port_name)?;
+                let TypeExpr::Vec(elem, _) = &port.ty else {
+                    return None;
+                };
+                let (_elem_ty, count_str) = vec_array_info_with_params(&port.ty, &sub_params)?;
+                let count = count_str.parse().ok()?;
+                let elem_bits = type_bits_te_with_params(elem, &sub_params);
+                Some((count, elem_bits))
+            };
+
         if insts.is_empty() {
             // No sub-instances: simple path
             cpp.push_str("  eval_comb();\n");
@@ -8030,6 +8237,15 @@ impl<'a> SimCodegen<'a> {
                             }
                             if wide_names.contains(src_name.as_str()) {
                                 let resolved = ctx.resolve_name(src_name, false);
+                                if let Some((packed_port, index)) =
+                                    self.indexed_arbiter_port(inst, &conn.port_name.name)
+                                {
+                                    cpp.push_str(&format!(
+                                        "  _inst_{}.{} = (_inst_{}.{} & ~(1ULL << {})) | ((((uint64_t)({})) & 1ULL) << {});\n",
+                                        inst.name.name, packed_port, inst.name.name, packed_port, index, resolved, index
+                                    ));
+                                    continue;
+                                }
                                 cpp.push_str(&format!(
                                     "  _inst_{}.{} = {};\n",
                                     inst.name.name, conn.port_name.name, resolved
@@ -8037,7 +8253,120 @@ impl<'a> SimCodegen<'a> {
                                 continue;
                             }
                         }
+                        if let ExprKind::Ident(sig_name) = &conn.signal.kind {
+                            if let Some((_elem_ty, count, elem_bits, array_storage)) =
+                                inst_vec_out.get(sig_name)
+                            {
+                                let total_bits = elem_bits.saturating_mul(*count as u32);
+                                if !*array_storage && *elem_bits > 0 && total_bits <= 64 {
+                                    let sig = cpp_expr(&conn.signal, &ctx);
+                                    cpp.push_str(&format!("    {sig} = 0;\n"));
+                                    let mask = if *elem_bits >= 64 {
+                                        "UINT64_MAX".to_string()
+                                    } else {
+                                        format!("((1ULL << {elem_bits}) - 1ULL)")
+                                    };
+                                    for i in 0..*count {
+                                        let shift = i as u32 * *elem_bits;
+                                        cpp.push_str(&format!(
+                                            "    {sig} |= (((uint64_t)_inst_{}.{}_{i}) & {mask}) << {shift};\n",
+                                            inst.name.name, conn.port_name.name
+                                        ));
+                                    }
+                                    continue;
+                                }
+                            }
+                        }
+                        if let ExprKind::Ident(sig_name) = &conn.signal.kind {
+                            if let Some((_elem_ty, count, elem_bits, array_storage)) =
+                                inst_vec_out.get(sig_name)
+                            {
+                                let total_bits = elem_bits.saturating_mul(*count as u32);
+                                if !*array_storage && *elem_bits > 0 && total_bits <= 64 {
+                                    let sig = cpp_expr(&conn.signal, &ctx);
+                                    cpp.push_str(&format!("    {sig} = 0;\n"));
+                                    let mask = if *elem_bits >= 64 {
+                                        "UINT64_MAX".to_string()
+                                    } else {
+                                        format!("((1ULL << {elem_bits}) - 1ULL)")
+                                    };
+                                    for i in 0..*count {
+                                        let shift = i as u32 * *elem_bits;
+                                        cpp.push_str(&format!(
+                                            "    {sig} |= (((uint64_t)_inst_{}.{}_{i}) & {mask}) << {shift};\n",
+                                            inst.name.name, conn.port_name.name
+                                        ));
+                                    }
+                                    continue;
+                                }
+                            }
+                        }
+                        if let ExprKind::Ident(sig_name) = &conn.signal.kind {
+                            if let Some((count, elem_bits)) =
+                                child_vec_output_shape(inst, &conn.port_name.name)
+                            {
+                                let total_bits = elem_bits.saturating_mul(count as u32);
+                                if !vec_wire_counts.contains_key(sig_name.as_str())
+                                    && !vec_port_names.contains(sig_name.as_str())
+                                    && elem_bits > 0
+                                    && total_bits <= 64
+                                {
+                                    let sig = cpp_expr(&conn.signal, &ctx);
+                                    cpp.push_str(&format!("    {sig} = 0;\n"));
+                                    let mask = if elem_bits >= 64 {
+                                        "UINT64_MAX".to_string()
+                                    } else {
+                                        format!("((1ULL << {elem_bits}) - 1ULL)")
+                                    };
+                                    for i in 0..count {
+                                        let shift = i as u32 * elem_bits;
+                                        cpp.push_str(&format!(
+                                            "    {sig} |= (((uint64_t)_inst_{}.{}_{i}) & {mask}) << {shift};\n",
+                                            inst.name.name, conn.port_name.name
+                                        ));
+                                    }
+                                    continue;
+                                }
+                            }
+                        }
+                        if let ExprKind::Ident(sig_name) = &conn.signal.kind {
+                            if let Some((count, elem_bits)) =
+                                child_vec_output_shape(inst, &conn.port_name.name)
+                            {
+                                let total_bits = elem_bits.saturating_mul(count as u32);
+                                if !vec_wire_counts.contains_key(sig_name.as_str())
+                                    && !vec_port_names.contains(sig_name.as_str())
+                                    && elem_bits > 0
+                                    && total_bits <= 64
+                                {
+                                    let sig = cpp_expr(&conn.signal, &ctx);
+                                    cpp.push_str(&format!("    {sig} = 0;\n"));
+                                    let mask = if elem_bits >= 64 {
+                                        "UINT64_MAX".to_string()
+                                    } else {
+                                        format!("((1ULL << {elem_bits}) - 1ULL)")
+                                    };
+                                    for i in 0..count {
+                                        let shift = i as u32 * elem_bits;
+                                        cpp.push_str(&format!(
+                                            "    {sig} |= (((uint64_t)_inst_{}.{}_{i}) & {mask}) << {shift};\n",
+                                            inst.name.name, conn.port_name.name
+                                        ));
+                                    }
+                                    continue;
+                                }
+                            }
+                        }
                         let sig = cpp_expr(&conn.signal, &ctx);
+                        if let Some((packed_port, index)) =
+                            self.indexed_arbiter_port(inst, &conn.port_name.name)
+                        {
+                            cpp.push_str(&format!(
+                                "  _inst_{}.{} = (_inst_{}.{} & ~(1ULL << {})) | ((((uint64_t)({})) & 1ULL) << {});\n",
+                                inst.name.name, packed_port, inst.name.name, packed_port, index, sig, index
+                            ));
+                            continue;
+                        }
                         cpp.push_str(&format!(
                             "  _inst_{}.{} = {};\n",
                             inst.name.name, conn.port_name.name, sig
@@ -8103,6 +8432,15 @@ impl<'a> SimCodegen<'a> {
                             }
                             if wide_names.contains(src_name.as_str()) {
                                 let resolved = ctx.resolve_name(src_name, false);
+                                if let Some((packed_port, index)) =
+                                    self.indexed_arbiter_port(inst, &conn.port_name.name)
+                                {
+                                    cpp.push_str(&format!(
+                                        "    _inst_{}.{} = (_inst_{}.{} & ~(1ULL << {})) | ((((uint64_t)({})) & 1ULL) << {});\n",
+                                        inst.name.name, packed_port, inst.name.name, packed_port, index, resolved, index
+                                    ));
+                                    continue;
+                                }
                                 cpp.push_str(&format!(
                                     "    _inst_{}.{} = {};\n",
                                     inst.name.name, conn.port_name.name, resolved
@@ -8111,6 +8449,15 @@ impl<'a> SimCodegen<'a> {
                             }
                         }
                         let sig = cpp_expr(&conn.signal, &ctx);
+                        if let Some((packed_port, index)) =
+                            self.indexed_arbiter_port(inst, &conn.port_name.name)
+                        {
+                            cpp.push_str(&format!(
+                                "    _inst_{}.{} = (_inst_{}.{} & ~(1ULL << {})) | ((((uint64_t)({})) & 1ULL) << {});\n",
+                                inst.name.name, packed_port, inst.name.name, packed_port, index, sig, index
+                            ));
+                            continue;
+                        }
                         cpp.push_str(&format!(
                             "    _inst_{}.{} = {};\n",
                             inst.name.name, conn.port_name.name, sig
@@ -8186,6 +8533,33 @@ impl<'a> SimCodegen<'a> {
                         } else {
                             0
                         };
+                        if let ExprKind::Ident(sig_name) = &conn.signal.kind {
+                            if let Some((count, elem_bits)) =
+                                child_vec_output_shape(inst, &conn.port_name.name)
+                            {
+                                let total_bits = elem_bits.saturating_mul(count as u32);
+                                if !vec_wire_counts.contains_key(sig_name.as_str())
+                                    && !vec_port_names.contains(sig_name.as_str())
+                                    && elem_bits > 0
+                                    && total_bits <= 64
+                                {
+                                    cpp.push_str(&format!("    {sig} = 0;\n"));
+                                    let mask = if elem_bits >= 64 {
+                                        "UINT64_MAX".to_string()
+                                    } else {
+                                        format!("((1ULL << {elem_bits}) - 1ULL)")
+                                    };
+                                    for i in 0..count {
+                                        let shift = i as u32 * elem_bits;
+                                        cpp.push_str(&format!(
+                                            "    {sig} |= (((uint64_t)_inst_{}.{}_{i}) & {mask}) << {shift};\n",
+                                            inst.name.name, conn.port_name.name
+                                        ));
+                                    }
+                                    continue;
+                                }
+                            }
+                        }
                         if _out_w > 64 {
                             cpp.push_str(&format!(
                                 "    {} = _arch_vl_to_u128(_inst_{}.{}.data(), {});\n",
@@ -8193,6 +8567,13 @@ impl<'a> SimCodegen<'a> {
                                 inst.name.name,
                                 conn.port_name.name,
                                 wide_words(_out_w)
+                            ));
+                        } else if let Some((packed_port, index)) =
+                            self.indexed_arbiter_port(inst, &conn.port_name.name)
+                        {
+                            cpp.push_str(&format!(
+                                "    {} = ((_inst_{}.{} >> {}) & 1ULL);\n",
+                                sig, inst.name.name, packed_port, index
                             ));
                         } else {
                             cpp.push_str(&format!(
@@ -8207,7 +8588,7 @@ impl<'a> SimCodegen<'a> {
                         }
                         // --check-uninit: mark inst output as initialized
                         if let ExprKind::Ident(name) = &conn.signal.kind {
-                            if uninit_regs.contains(name.as_str()) {
+                            if vinit_regs.contains(name.as_str()) {
                                 cpp.push_str(&format!("    _{name}_vinit = true;\n"));
                             }
                         }
@@ -8275,6 +8656,15 @@ impl<'a> SimCodegen<'a> {
                                 }
                                 if wide_names.contains(src_name.as_str()) {
                                     let resolved = ctx.resolve_name(src_name, false);
+                                    if let Some((packed_port, index)) =
+                                        self.indexed_arbiter_port(inst, &conn.port_name.name)
+                                    {
+                                        cpp.push_str(&format!(
+                                            "  _inst_{}.{} = (_inst_{}.{} & ~(1ULL << {})) | ((((uint64_t)({})) & 1ULL) << {});\n",
+                                            inst.name.name, packed_port, inst.name.name, packed_port, index, resolved, index
+                                        ));
+                                        continue;
+                                    }
                                     cpp.push_str(&format!(
                                         "  _inst_{}.{} = {};\n",
                                         inst.name.name, conn.port_name.name, resolved
@@ -8282,7 +8672,124 @@ impl<'a> SimCodegen<'a> {
                                     continue;
                                 }
                             }
+                            if let ExprKind::Ident(sig_name) = &conn.signal.kind {
+                                if let Some((_elem_ty, count, elem_bits, array_storage)) =
+                                    inst_vec_out.get(sig_name)
+                                {
+                                    let total_bits = elem_bits.saturating_mul(*count as u32);
+                                    if !*array_storage && *elem_bits > 0 && total_bits <= 64 {
+                                        let sig = cpp_expr(&conn.signal, &ctx);
+                                        cpp.push_str(&format!("    {sig} = 0;\n"));
+                                        let mask = if *elem_bits >= 64 {
+                                            "UINT64_MAX".to_string()
+                                        } else {
+                                            format!("((1ULL << {elem_bits}) - 1ULL)")
+                                        };
+                                        for i in 0..*count {
+                                            let shift = i as u32 * *elem_bits;
+                                            cpp.push_str(&format!(
+                                                "    {sig} |= (((uint64_t)_inst_{}.{}_{i}) & {mask}) << {shift};\n",
+                                                inst.name.name, conn.port_name.name
+                                            ));
+                                        }
+                                        continue;
+                                    }
+                                }
+                            }
+                            if let ExprKind::Ident(sig_name) = &conn.signal.kind {
+                                if let Some((count, elem_bits)) =
+                                    child_vec_output_shape(inst, &conn.port_name.name)
+                                {
+                                    let total_bits = elem_bits.saturating_mul(count as u32);
+                                    if !vec_wire_counts.contains_key(sig_name.as_str())
+                                        && !vec_port_names.contains(sig_name.as_str())
+                                        && elem_bits > 0
+                                        && total_bits <= 64
+                                    {
+                                        let sig = cpp_expr(&conn.signal, &ctx);
+                                        cpp.push_str(&format!("    {sig} = 0;\n"));
+                                        let mask = if elem_bits >= 64 {
+                                            "UINT64_MAX".to_string()
+                                        } else {
+                                            format!("((1ULL << {elem_bits}) - 1ULL)")
+                                        };
+                                        for i in 0..count {
+                                            let shift = i as u32 * elem_bits;
+                                            cpp.push_str(&format!(
+                                                "    {sig} |= (((uint64_t)_inst_{}.{}_{i}) & {mask}) << {shift};\n",
+                                                inst.name.name, conn.port_name.name
+                                            ));
+                                        }
+                                        continue;
+                                    }
+                                }
+                            }
+                            if let ExprKind::Ident(sig_name) = &conn.signal.kind {
+                                if let Some((count, elem_bits)) =
+                                    child_vec_output_shape(inst, &conn.port_name.name)
+                                {
+                                    let total_bits = elem_bits.saturating_mul(count as u32);
+                                    if !vec_wire_counts.contains_key(sig_name.as_str())
+                                        && !vec_port_names.contains(sig_name.as_str())
+                                        && elem_bits > 0
+                                        && total_bits <= 64
+                                    {
+                                        let sig = cpp_expr(&conn.signal, &ctx);
+                                        cpp.push_str(&format!("    {sig} = 0;\n"));
+                                        let mask = if elem_bits >= 64 {
+                                            "UINT64_MAX".to_string()
+                                        } else {
+                                            format!("((1ULL << {elem_bits}) - 1ULL)")
+                                        };
+                                        for i in 0..count {
+                                            let shift = i as u32 * elem_bits;
+                                            cpp.push_str(&format!(
+                                                "    {sig} |= (((uint64_t)_inst_{}.{}_{i}) & {mask}) << {shift};\n",
+                                                inst.name.name, conn.port_name.name
+                                            ));
+                                        }
+                                        continue;
+                                    }
+                                }
+                            }
+                            if let ExprKind::Ident(sig_name) = &conn.signal.kind {
+                                if let Some((count, elem_bits)) =
+                                    child_vec_output_shape(inst, &conn.port_name.name)
+                                {
+                                    let total_bits = elem_bits.saturating_mul(count as u32);
+                                    if !vec_wire_counts.contains_key(sig_name.as_str())
+                                        && !vec_port_names.contains(sig_name.as_str())
+                                        && elem_bits > 0
+                                        && total_bits <= 64
+                                    {
+                                        let sig = cpp_expr(&conn.signal, &ctx);
+                                        cpp.push_str(&format!("    {sig} = 0;\n"));
+                                        let mask = if elem_bits >= 64 {
+                                            "UINT64_MAX".to_string()
+                                        } else {
+                                            format!("((1ULL << {elem_bits}) - 1ULL)")
+                                        };
+                                        for i in 0..count {
+                                            let shift = i as u32 * elem_bits;
+                                            cpp.push_str(&format!(
+                                                "    {sig} |= (((uint64_t)_inst_{}.{}_{i}) & {mask}) << {shift};\n",
+                                                inst.name.name, conn.port_name.name
+                                            ));
+                                        }
+                                        continue;
+                                    }
+                                }
+                            }
                             let sig = cpp_expr(&conn.signal, &ctx);
+                            if let Some((packed_port, index)) =
+                                self.indexed_arbiter_port(inst, &conn.port_name.name)
+                            {
+                                cpp.push_str(&format!(
+                                    "  _inst_{}.{} = (_inst_{}.{} & ~(1ULL << {})) | ((((uint64_t)({})) & 1ULL) << {});\n",
+                                    inst.name.name, packed_port, inst.name.name, packed_port, index, sig, index
+                                ));
+                                continue;
+                            }
                             cpp.push_str(&format!(
                                 "  _inst_{}.{} = {};\n",
                                 inst.name.name, conn.port_name.name, sig
@@ -8347,6 +8854,15 @@ impl<'a> SimCodegen<'a> {
                                 }
                                 if wide_names.contains(src_name.as_str()) {
                                     let resolved = ctx.resolve_name(src_name, false);
+                                    if let Some((packed_port, index)) =
+                                        self.indexed_arbiter_port(inst, &conn.port_name.name)
+                                    {
+                                        cpp.push_str(&format!(
+                                            "    _inst_{}.{} = (_inst_{}.{} & ~(1ULL << {})) | ((((uint64_t)({})) & 1ULL) << {});\n",
+                                            inst.name.name, packed_port, inst.name.name, packed_port, index, resolved, index
+                                        ));
+                                        continue;
+                                    }
                                     cpp.push_str(&format!(
                                         "    _inst_{}.{} = {};\n",
                                         inst.name.name, conn.port_name.name, resolved
@@ -8355,6 +8871,15 @@ impl<'a> SimCodegen<'a> {
                                 }
                             }
                             let sig = cpp_expr(&conn.signal, &ctx);
+                            if let Some((packed_port, index)) =
+                                self.indexed_arbiter_port(inst, &conn.port_name.name)
+                            {
+                                cpp.push_str(&format!(
+                                    "    _inst_{}.{} = (_inst_{}.{} & ~(1ULL << {})) | ((((uint64_t)({})) & 1ULL) << {});\n",
+                                    inst.name.name, packed_port, inst.name.name, packed_port, index, sig, index
+                                ));
+                                continue;
+                            }
                             cpp.push_str(&format!(
                                 "    _inst_{}.{} = {};\n",
                                 inst.name.name, conn.port_name.name, sig
@@ -8425,6 +8950,33 @@ impl<'a> SimCodegen<'a> {
                             } else {
                                 0
                             };
+                            if let ExprKind::Ident(sig_name) = &conn.signal.kind {
+                                if let Some((count, elem_bits)) =
+                                    child_vec_output_shape(inst, &conn.port_name.name)
+                                {
+                                    let total_bits = elem_bits.saturating_mul(count as u32);
+                                    if !vec_wire_counts.contains_key(sig_name.as_str())
+                                        && !vec_port_names.contains(sig_name.as_str())
+                                        && elem_bits > 0
+                                        && total_bits <= 64
+                                    {
+                                        cpp.push_str(&format!("    {sig} = 0;\n"));
+                                        let mask = if elem_bits >= 64 {
+                                            "UINT64_MAX".to_string()
+                                        } else {
+                                            format!("((1ULL << {elem_bits}) - 1ULL)")
+                                        };
+                                        for i in 0..count {
+                                            let shift = i as u32 * elem_bits;
+                                            cpp.push_str(&format!(
+                                                "    {sig} |= (((uint64_t)_inst_{}.{}_{i}) & {mask}) << {shift};\n",
+                                                inst.name.name, conn.port_name.name
+                                            ));
+                                        }
+                                        continue;
+                                    }
+                                }
+                            }
                             if _out_w > 64 {
                                 cpp.push_str(&format!(
                                     "    {} = _arch_vl_to_u128(_inst_{}.{}.data(), {});\n",
@@ -8432,6 +8984,13 @@ impl<'a> SimCodegen<'a> {
                                     inst.name.name,
                                     conn.port_name.name,
                                     wide_words(_out_w)
+                                ));
+                            } else if let Some((packed_port, index)) =
+                                self.indexed_arbiter_port(inst, &conn.port_name.name)
+                            {
+                                cpp.push_str(&format!(
+                                    "    {} = ((_inst_{}.{} >> {}) & 1ULL);\n",
+                                    sig, inst.name.name, packed_port, index
                                 ));
                             } else {
                                 cpp.push_str(&format!(
@@ -8448,7 +9007,7 @@ impl<'a> SimCodegen<'a> {
                             }
                             // --check-uninit: mark inst output as initialized
                             if let ExprKind::Ident(name) = &conn.signal.kind {
-                                if uninit_regs.contains(name.as_str()) {
+                                if vinit_regs.contains(name.as_str()) {
                                     cpp.push_str(&format!("    _{name}_vinit = true;\n"));
                                 }
                             }
@@ -8499,6 +9058,9 @@ impl<'a> SimCodegen<'a> {
                     if wide_names.contains(sig_name) {
                         continue;
                     }
+                    if named_signal_names.contains(sig_name) {
+                        continue;
+                    }
                     if vec_port_names.contains(sig_name) {
                         continue;
                     }
@@ -8515,8 +9077,15 @@ impl<'a> SimCodegen<'a> {
                     );
                     let inst_n = &inst.name.name;
                     let port_n = &conn.port_name.name;
+                    let port_read = if let Some((packed_port, index)) =
+                        self.indexed_arbiter_port(inst, &conn.port_name.name)
+                    {
+                        format!("((_inst_{inst_n}.{packed_port} >> {index}) & 1ULL)")
+                    } else {
+                        format!("_inst_{inst_n}.{port_n}")
+                    };
                     cpp.push_str(&format!(
-                        "  {{ uint64_t _cur = (uint64_t)_inst_{inst_n}.{port_n}; \
+                        "  {{ uint64_t _cur = (uint64_t){port_read}; \
                          _arch_cov[{cidx}] += __builtin_popcountll(_cur ^ _prev_{inst_n}_{port_n}); \
                          _prev_{inst_n}_{port_n} = _cur; }}\n"
                     ));
@@ -8644,7 +9213,8 @@ impl<'a> SimCodegen<'a> {
             .posedge()
             .with_coverage(cov_handle)
             .with_let_values(&let_values)
-            .with_params(&m.params);
+            .with_params(&m.params)
+            .with_vinit_regs(&vinit_regs);
 
             for rb in &reg_blocks {
                 let mut assigned = std::collections::BTreeSet::new();
@@ -9107,8 +9677,17 @@ impl<'a> SimCodegen<'a> {
             // Guard Check A: for each `reg ... guard <sig>`, warn if guard asserts
             // but the reg has never been written. Fires once per module per signal.
             for (reg_name, guard_sig) in &guarded_regs {
+                let guard_cpp = if reg_decls.iter().any(|r| r.name.name == *guard_sig)
+                    || m.ports
+                        .iter()
+                        .any(|p| p.name.name == *guard_sig && p.reg_info.is_some())
+                {
+                    format!("_{guard_sig}")
+                } else {
+                    guard_sig.clone()
+                };
                 cpp.push_str(&format!(
-                    "  if ({guard_sig} && !_{reg_name}_vinit) {{\n\
+                    "  if ({guard_cpp} && !_{reg_name}_vinit) {{\n\
                      \x20   static bool _w_{reg_name}_guard = false;\n\
                      \x20   if (!_w_{reg_name}_guard) {{\n\
                      \x20     _w_{reg_name}_guard = true;\n\
@@ -9116,6 +9695,7 @@ impl<'a> SimCodegen<'a> {
                      \x20             \"{guard_sig}=1 but {reg_name} was never written\\n\");\n\
                      \x20   }}\n\
                      \x20 }}\n",
+                    guard_cpp = guard_cpp,
                     guard_sig = guard_sig,
                     reg_name = reg_name,
                     name = name,
@@ -9253,6 +9833,7 @@ impl<'a> SimCodegen<'a> {
                                         vec_of_bus_wire_count: ctx_comb.vec_of_bus_wire_count,
                                         coverage: ctx_comb.coverage,
                                         params: ctx_comb.params,
+                                        vinit_regs: ctx_comb.vinit_regs,
                                     };
                                     hits.push(cpp_expr(&margs[0], &sub_ctx));
                                 }
@@ -9358,11 +9939,152 @@ impl<'a> SimCodegen<'a> {
                             }
                             if wide_names.contains(src_name.as_str()) {
                                 let resolved = ctx_comb.resolve_name(src_name, false);
+                                if let Some((packed_port, index)) =
+                                    self.indexed_arbiter_port(inst, &conn.port_name.name)
+                                {
+                                    cpp.push_str(&format!(
+                                        "  _inst_{}.{} = (_inst_{}.{} & ~(1ULL << {})) | ((((uint64_t)({})) & 1ULL) << {});\n",
+                                        inst.name.name, packed_port, inst.name.name, packed_port, index, resolved, index
+                                    ));
+                                    continue;
+                                }
                                 cpp.push_str(&format!(
                                     "  _inst_{}.{} = {};\n",
                                     inst.name.name, conn.port_name.name, resolved
                                 ));
                                 continue;
+                            }
+                        }
+                        if let ExprKind::Ident(sig_name) = &conn.signal.kind {
+                            if let Some((_elem_ty, count, elem_bits, array_storage)) =
+                                inst_vec_out.get(sig_name)
+                            {
+                                let total_bits = elem_bits.saturating_mul(*count as u32);
+                                if !*array_storage && *elem_bits > 0 && total_bits <= 64 {
+                                    let sig = cpp_expr(&conn.signal, &ctx_comb);
+                                    cpp.push_str(&format!("  {sig} = 0;\n"));
+                                    let mask = if *elem_bits >= 64 {
+                                        "UINT64_MAX".to_string()
+                                    } else {
+                                        format!("((1ULL << {elem_bits}) - 1ULL)")
+                                    };
+                                    for i in 0..*count {
+                                        let shift = i as u32 * *elem_bits;
+                                        cpp.push_str(&format!(
+                                            "  {sig} |= (((uint64_t)_inst_{}.{}_{i}) & {mask}) << {shift};\n",
+                                            inst.name.name, conn.port_name.name
+                                        ));
+                                    }
+                                    continue;
+                                }
+                            }
+                        }
+                        if let ExprKind::Ident(sig_name) = &conn.signal.kind {
+                            if let Some((_elem_ty, count, elem_bits, array_storage)) =
+                                inst_vec_out.get(sig_name)
+                            {
+                                let total_bits = elem_bits.saturating_mul(*count as u32);
+                                if !*array_storage && *elem_bits > 0 && total_bits <= 64 {
+                                    let sig = cpp_expr(&conn.signal, &ctx_comb);
+                                    cpp.push_str(&format!("  {sig} = 0;\n"));
+                                    let mask = if *elem_bits >= 64 {
+                                        "UINT64_MAX".to_string()
+                                    } else {
+                                        format!("((1ULL << {elem_bits}) - 1ULL)")
+                                    };
+                                    for i in 0..*count {
+                                        let shift = i as u32 * *elem_bits;
+                                        cpp.push_str(&format!(
+                                            "  {sig} |= (((uint64_t)_inst_{}.{}_{i}) & {mask}) << {shift};\n",
+                                            inst.name.name, conn.port_name.name
+                                        ));
+                                    }
+                                    continue;
+                                }
+                            }
+                        }
+                        if let ExprKind::Ident(sig_name) = &conn.signal.kind {
+                            if let Some((count, elem_bits)) =
+                                child_vec_output_shape(inst, &conn.port_name.name)
+                            {
+                                let total_bits = elem_bits.saturating_mul(count as u32);
+                                if !vec_wire_counts.contains_key(sig_name.as_str())
+                                    && !vec_port_names.contains(sig_name.as_str())
+                                    && elem_bits > 0
+                                    && total_bits <= 64
+                                {
+                                    let sig = cpp_expr(&conn.signal, &ctx_comb);
+                                    cpp.push_str(&format!("  {sig} = 0;\n"));
+                                    let mask = if elem_bits >= 64 {
+                                        "UINT64_MAX".to_string()
+                                    } else {
+                                        format!("((1ULL << {elem_bits}) - 1ULL)")
+                                    };
+                                    for i in 0..count {
+                                        let shift = i as u32 * elem_bits;
+                                        cpp.push_str(&format!(
+                                            "  {sig} |= (((uint64_t)_inst_{}.{}_{i}) & {mask}) << {shift};\n",
+                                            inst.name.name, conn.port_name.name
+                                        ));
+                                    }
+                                    continue;
+                                }
+                            }
+                        }
+                        if let ExprKind::Ident(sig_name) = &conn.signal.kind {
+                            if let Some((count, elem_bits)) =
+                                child_vec_output_shape(inst, &conn.port_name.name)
+                            {
+                                let total_bits = elem_bits.saturating_mul(count as u32);
+                                if !vec_wire_counts.contains_key(sig_name.as_str())
+                                    && !vec_port_names.contains(sig_name.as_str())
+                                    && elem_bits > 0
+                                    && total_bits <= 64
+                                {
+                                    let sig = cpp_expr(&conn.signal, &ctx_comb);
+                                    cpp.push_str(&format!("  {sig} = 0;\n"));
+                                    let mask = if elem_bits >= 64 {
+                                        "UINT64_MAX".to_string()
+                                    } else {
+                                        format!("((1ULL << {elem_bits}) - 1ULL)")
+                                    };
+                                    for i in 0..count {
+                                        let shift = i as u32 * elem_bits;
+                                        cpp.push_str(&format!(
+                                            "  {sig} |= (((uint64_t)_inst_{}.{}_{i}) & {mask}) << {shift};\n",
+                                            inst.name.name, conn.port_name.name
+                                        ));
+                                    }
+                                    continue;
+                                }
+                            }
+                        }
+                        if let ExprKind::Ident(sig_name) = &conn.signal.kind {
+                            if let Some((count, elem_bits)) =
+                                child_vec_output_shape(inst, &conn.port_name.name)
+                            {
+                                let total_bits = elem_bits.saturating_mul(count as u32);
+                                if !vec_wire_counts.contains_key(sig_name.as_str())
+                                    && !vec_port_names.contains(sig_name.as_str())
+                                    && elem_bits > 0
+                                    && total_bits <= 64
+                                {
+                                    let sig = cpp_expr(&conn.signal, &ctx_comb);
+                                    cpp.push_str(&format!("  {sig} = 0;\n"));
+                                    let mask = if elem_bits >= 64 {
+                                        "UINT64_MAX".to_string()
+                                    } else {
+                                        format!("((1ULL << {elem_bits}) - 1ULL)")
+                                    };
+                                    for i in 0..count {
+                                        let shift = i as u32 * elem_bits;
+                                        cpp.push_str(&format!(
+                                            "  {sig} |= (((uint64_t)_inst_{}.{}_{i}) & {mask}) << {shift};\n",
+                                            inst.name.name, conn.port_name.name
+                                        ));
+                                    }
+                                    continue;
+                                }
                             }
                         }
                         let sig = cpp_expr(&conn.signal, &ctx_comb);
@@ -9379,6 +10101,13 @@ impl<'a> SimCodegen<'a> {
                                 inst.name.name,
                                 conn.port_name.name,
                                 wide_words(_in_w)
+                            ));
+                        } else if let Some((packed_port, index)) =
+                            self.indexed_arbiter_port(inst, &conn.port_name.name)
+                        {
+                            cpp.push_str(&format!(
+                                "  _inst_{}.{} = (_inst_{}.{} & ~(1ULL << {})) | ((((uint64_t)({})) & 1ULL) << {});\n",
+                                inst.name.name, packed_port, inst.name.name, packed_port, index, sig, index
                             ));
                         } else {
                             cpp.push_str(&format!(
@@ -9449,6 +10178,33 @@ impl<'a> SimCodegen<'a> {
                         } else {
                             0
                         };
+                        if let ExprKind::Ident(sig_name) = &conn.signal.kind {
+                            if let Some((count, elem_bits)) =
+                                child_vec_output_shape(inst, &conn.port_name.name)
+                            {
+                                let total_bits = elem_bits.saturating_mul(count as u32);
+                                if !vec_wire_counts.contains_key(sig_name.as_str())
+                                    && !vec_port_names.contains(sig_name.as_str())
+                                    && elem_bits > 0
+                                    && total_bits <= 64
+                                {
+                                    cpp.push_str(&format!("  {sig} = 0;\n"));
+                                    let mask = if elem_bits >= 64 {
+                                        "UINT64_MAX".to_string()
+                                    } else {
+                                        format!("((1ULL << {elem_bits}) - 1ULL)")
+                                    };
+                                    for i in 0..count {
+                                        let shift = i as u32 * elem_bits;
+                                        cpp.push_str(&format!(
+                                            "  {sig} |= (((uint64_t)_inst_{}.{}_{i}) & {mask}) << {shift};\n",
+                                            inst.name.name, conn.port_name.name
+                                        ));
+                                    }
+                                    continue;
+                                }
+                            }
+                        }
                         if _out_w > 64 {
                             cpp.push_str(&format!(
                                 "  {} = _arch_vl_to_u128(_inst_{}.{}.data(), {});\n",
@@ -9456,6 +10212,13 @@ impl<'a> SimCodegen<'a> {
                                 inst.name.name,
                                 conn.port_name.name,
                                 wide_words(_out_w)
+                            ));
+                        } else if let Some((packed_port, index)) =
+                            self.indexed_arbiter_port(inst, &conn.port_name.name)
+                        {
+                            cpp.push_str(&format!(
+                                "  {} = ((_inst_{}.{} >> {}) & 1ULL);\n",
+                                sig, inst.name.name, packed_port, index
                             ));
                         } else {
                             cpp.push_str(&format!(
@@ -9857,6 +10620,7 @@ impl<'a> SimCodegen<'a> {
                     let file_esc = file_disp.replace('\\', "\\\\").replace('"', "\\\"");
                     let page = match p.kind {
                         "if" | "elsif" | "else" => "v_branch",
+                        "expr-then" | "expr-else" => "v_expr",
                         "seq" | "comb" => "v_line",
                         "state" | "trans" => "v_user/fsm",
                         "toggle" => "v_toggle",

--- a/src/sim_codegen/pipeline.rs
+++ b/src/sim_codegen/pipeline.rs
@@ -1264,6 +1264,7 @@ impl<'a> SimCodegen<'a> {
             vec_of_bus_wire_count: None,
             coverage: None,
             params,
+            vinit_regs: None,
         };
         match &expr.kind {
             ExprKind::FieldAccess(base, field) => {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -28533,3 +28533,458 @@ end module WideMul140
         "diagnostic should point users at filing an enhancement request; got stderr:\n{stderr}"
     );
 }
+
+#[test]
+fn test_arch_sim_param_override_reaches_parametric_slices() {
+    let arch_bin = env!("CARGO_BIN_EXE_arch");
+    let td = tempfile::tempdir().expect("tempdir");
+    let arch_path = td.path().join("ParamSliceRegress.arch");
+    let tb_path = td.path().join("ParamSliceRegress_tb.cpp");
+    let outdir = td.path().join("sim");
+
+    std::fs::write(
+        &arch_path,
+        r#"
+domain D
+  freq_mhz: 100
+end domain D
+
+module ParamSliceRegress
+  param CounterWidth: const = 32;
+
+  port clk: in Clock<D>;
+  port rst_n: in Reset<Async, Low>;
+  port inc: in Bool;
+  port low_we: in Bool;
+  port high_we: in Bool;
+  port data: in UInt<32>;
+  port val: out UInt<64>;
+
+  reg counter_q: UInt<64> reset rst_n => 0;
+
+  default seq on clk rising;
+
+  seq
+    if high_we
+      counter_q[CounterWidth-1:0] <= {data, counter_q[31:0]}[CounterWidth-1:0];
+    elsif low_we
+      counter_q[CounterWidth-1:0] <= {counter_q[63:32], data}[CounterWidth-1:0];
+    elsif inc
+      counter_q[CounterWidth-1:0] <= (counter_q[CounterWidth-1:0] + 1).trunc<CounterWidth>();
+    end if
+  end seq
+
+  let val = counter_q[CounterWidth-1:0].resize<64>();
+end module ParamSliceRegress
+"#,
+    )
+    .expect("write arch fixture");
+
+    std::fs::write(
+        &tb_path,
+        r#"
+#include "VParamSliceRegress.h"
+#include <cstdio>
+
+static VParamSliceRegress dut;
+
+static void tick() {
+  dut.clk = 0; dut.eval();
+  dut.clk = 1; dut.eval();
+  dut.clk = 0; dut.eval();
+}
+
+static bool expect_val(unsigned long long want, const char* label) {
+  dut.eval();
+  unsigned long long got = (unsigned long long)dut.val;
+  if (got != want) {
+    std::printf("FAIL %s got=%llu want=%llu\n", label, got, want);
+    return false;
+  }
+  return true;
+}
+
+int main() {
+  bool ok = true;
+  dut.rst_n = 0;
+  dut.inc = 0;
+  dut.low_we = 0;
+  dut.high_we = 0;
+  dut.data = 0;
+  tick();
+  dut.rst_n = 1;
+  tick();
+
+  dut.low_we = 1;
+  dut.data = 1;
+  tick();
+  dut.low_we = 0;
+  ok &= expect_val(1, "write low bit");
+
+  dut.inc = 1;
+  tick();
+  dut.inc = 0;
+  ok &= expect_val(0, "CounterWidth=1 increment wraps");
+
+  dut.high_we = 1;
+  dut.data = 0xffffffffu;
+  tick();
+  dut.high_we = 0;
+  ok &= expect_val(0, "CounterWidth=1 high write stays outside active width");
+
+  std::printf(ok ? "PASS param_slice_override\n" : "FAIL param_slice_override\n");
+  return ok ? 0 : 1;
+}
+"#,
+    )
+    .expect("write tb fixture");
+
+    let out = std::process::Command::new(arch_bin)
+        .arg("sim")
+        .arg(&arch_path)
+        .arg("--param")
+        .arg("CounterWidth=1")
+        .arg("--tb")
+        .arg(&tb_path)
+        .arg("--outdir")
+        .arg(&outdir)
+        .output()
+        .expect("run arch sim");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success() && stdout.contains("PASS param_slice_override"),
+        "arch sim --param must affect parametric slice/trunc codegen\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+}
+
+#[test]
+fn test_comb_graph_cycles_with_parent_intermediates_need_three_settle_passes() {
+    // Regression: a direct cyclic instance graph normally needs two settle
+    // passes, but if parent comb wires also feed an instance input, one pass
+    // is consumed refreshing those parent intermediates. ibex_ex_block has
+    // this shape: parent bridge wires feed multdiv, multdiv feeds ALU, and
+    // ALU feeds multdiv. The native simulator therefore needs settle_depth=3.
+    let source = r#"
+        module A
+          port i: in UInt<1>;
+          port o: out UInt<1>;
+          comb
+            o = i;
+          end comb
+        end module A
+
+        module B
+          port i: in UInt<1>;
+          port bridge: in UInt<1>;
+          port o: out UInt<1>;
+          comb
+            o = i ^ bridge;
+          end comb
+        end module B
+
+        module Top
+          port seed: in UInt<1>;
+          port q: out UInt<1>;
+          wire wa: UInt<1>;
+          wire wb: UInt<1>;
+          wire bridged: UInt<1>;
+
+          inst a: A
+            i <- wb;
+            o -> wa;
+          end inst a
+
+          inst b: B
+            i <- wa;
+            bridge <- bridged;
+            o -> wb;
+          end inst b
+
+          comb
+            bridged = seed;
+            q = wa;
+          end comb
+        end module Top
+    "#;
+    let tokens = lexer::tokenize(source).expect("lexer error");
+    let mut parser = Parser::new(tokens, source);
+    let parsed_ast = parser.parse_source_file().expect("parse error");
+    let ast = elaborate::elaborate(parsed_ast).expect("elaborate error");
+    let symbols = resolve::resolve(&ast).expect("resolve error");
+    let checker = TypeChecker::new(&symbols, &ast);
+    let _ = checker.check().expect("type check error");
+    let top = ast
+        .items
+        .iter()
+        .find_map(|item| match item {
+            arch::ast::Item::Module(m) if m.name.name == "Top" => Some(m),
+            _ => None,
+        })
+        .expect("Top module");
+    let analysis =
+        arch::comb_graph::analyze_module(top, &symbols, &ast).expect("comb graph analysis");
+    assert_eq!(analysis.settle_depth, 3);
+}
+
+#[test]
+fn test_sim_guard_check_uses_internal_names_for_guarded_reset_none_regs() {
+    // A guarded reset-none reg gets a native-sim vinit check. Internal regs in
+    // generated C++ are stored with leading underscores, so the guard check
+    // must render `_valid_q`, not bare `valid_q`.
+    let source = r#"
+domain D
+  freq_mhz: 100
+end domain D
+
+module M
+  port clk: in Clock<D>;
+  port rst: in Reset<Async, Low>;
+  port d:   in UInt<8>;
+  port v_in: in Bool;
+  port q:   out UInt<8>;
+
+  reg valid_q: Bool reset rst => false;
+  reg data_q: UInt<8> guard valid_q reset none;
+
+  seq on clk rising
+    valid_q <= v_in;
+    data_q <= d;
+  end seq
+
+  let q = data_q;
+end module M
+"#;
+    let cpp = compile_to_sim_h(source, false);
+    assert!(
+        cpp.contains("bool _data_q_vinit = false;"),
+        "guarded reset-none native sim check should declare a shadow valid bit:\n{cpp}"
+    );
+    assert!(
+        cpp.contains("_data_q_vinit = true;"),
+        "seq writes to guarded reset-none regs should mark the shadow valid bit:\n{cpp}"
+    );
+    assert!(
+        cpp.contains("if (_valid_q && !_data_q_vinit)"),
+        "guarded reset-none native sim check should use internal storage names:\n{cpp}"
+    );
+    assert!(
+        !cpp.contains("if (valid_q && !_data_q_vinit)"),
+        "guarded reset-none native sim check must not emit bare internal reg names:\n{cpp}"
+    );
+}
+
+#[test]
+fn test_native_sim_vec_inst_output_packs_scalar_parent_port() {
+    // Regression from arch-ibex IbexIfStage: a child Vec<UInt<1>, N> output
+    // connected to a packed parent UInt<N> output must pack lanes into bits.
+    // The broken native sim path treated the packed parent as C-array storage
+    // and emitted `packed_out[i] = ...`, which failed C++ compilation.
+    let td = tempfile::tempdir().expect("tempdir");
+    let arch_bin = env!("CARGO_BIN_EXE_arch");
+    let out = std::process::Command::new(arch_bin)
+        .arg("sim")
+        .arg("tests/native_vec_inst_output_packed_port/Probe.arch")
+        .arg("--tb")
+        .arg("tests/native_vec_inst_output_packed_port/tb.cpp")
+        .arg("--outdir")
+        .arg(td.path())
+        .output()
+        .expect("run arch sim for native Vec inst output packed port probe");
+    assert!(
+        out.status.success(),
+        "native Vec inst output packed port sim should compile + run\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&out.stdout).contains("PASS native Vec inst output packed port"),
+        "expected PASS marker in stdout:\n{}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+}
+
+#[test]
+fn test_native_sim_arbiter_indexed_handshake_packs_request_array() {
+    // Regression from arch-ibex IbexIcache/FbAgeArb: arbiter indexed
+    // handshake connections such as `request[0].valid <- req0` flatten to
+    // `request0_valid` in the AST, but the native arbiter model stores the
+    // request array as packed `request_valid/request_ready` fields.
+    let td = tempfile::tempdir().expect("tempdir");
+    let arch_bin = env!("CARGO_BIN_EXE_arch");
+    let out = std::process::Command::new(arch_bin)
+        .arg("sim")
+        .arg("tests/native_arbiter_indexed_handshake/Probe.arch")
+        .arg("--tb")
+        .arg("tests/native_arbiter_indexed_handshake/tb.cpp")
+        .arg("--outdir")
+        .arg(td.path())
+        .output()
+        .expect("run arch sim for native arbiter indexed handshake probe");
+    assert!(
+        out.status.success(),
+        "native arbiter indexed handshake sim should compile + run\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&out.stdout).contains("PASS native arbiter indexed handshake"),
+        "expected PASS marker in stdout:\n{}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+}
+
+#[test]
+fn test_native_sim_vec_element_bit_slice_assignment_updates_element() {
+    // Regression from arch-ibex IbexIcache: assigning to a bit slice of a Vec
+    // element, e.g. `fill_data_q[0][31:0] <= instr`, must lower to a
+    // mask-and-OR update of the element. Emitting the read-side slice
+    // expression on the LHS is invalid C++.
+    let td = tempfile::tempdir().expect("tempdir");
+    let arch_bin = env!("CARGO_BIN_EXE_arch");
+    let out = std::process::Command::new(arch_bin)
+        .arg("sim")
+        .arg("tests/native_vec_element_slice_assign/Probe.arch")
+        .arg("--tb")
+        .arg("tests/native_vec_element_slice_assign/tb.cpp")
+        .arg("--outdir")
+        .arg(td.path())
+        .output()
+        .expect("run arch sim for native Vec element slice assignment probe");
+    assert!(
+        out.status.success(),
+        "native Vec element slice assignment sim should compile + run\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&out.stdout).contains("PASS native Vec element slice assign"),
+        "expected PASS marker in stdout:\n{}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+}
+
+#[test]
+fn test_native_sim_package_struct_fsm_ports_compile_with_coverage() {
+    // Regression from arch-ibex IbexIdStage: package struct signals crossing a
+    // parent module into an FSM child must include VStructs.h, default-construct
+    // struct ports/regs, skip scalar-style struct traces, and avoid output-toggle
+    // coverage casts of struct instance outputs.
+    let td = tempfile::tempdir().expect("tempdir");
+    let coverage_dat = td.path().join("coverage.dat");
+    let arch_bin = env!("CARGO_BIN_EXE_arch");
+    let out = std::process::Command::new(arch_bin)
+        .arg("sim")
+        .arg("tests/native_pkg_struct_fsm/Probe.arch")
+        .arg("--tb")
+        .arg("tests/native_pkg_struct_fsm/tb.cpp")
+        .arg("--outdir")
+        .arg(td.path())
+        .arg("--coverage")
+        .arg("--coverage-dat")
+        .arg(&coverage_dat)
+        .output()
+        .expect("run arch sim for native package struct FSM coverage probe");
+    assert!(
+        out.status.success(),
+        "native package struct FSM coverage sim should compile + run\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&out.stdout).contains("PASS native package struct FSM coverage"),
+        "expected PASS marker in stdout:\n{}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+    let coverage_text = std::fs::read_to_string(&coverage_dat).expect("read coverage.dat");
+    assert!(
+        coverage_text.contains("tests/native_pkg_struct_fsm/Probe.arch")
+            && coverage_text.contains("state Idle")
+            && coverage_text.contains("trans Idle -> Seen"),
+        "coverage records should include the struct/FSM fixture state and transition hits:\n{coverage_text}"
+    );
+}
+
+#[test]
+fn test_arch_sim_coverage_dat_records_ternary_expression_arms() {
+    let td = tempfile::tempdir().expect("tempdir");
+    let arch = td.path().join("TernaryCov.arch");
+    let tb = td.path().join("tb_ternary_cov.cpp");
+    let coverage = td.path().join("coverage.dat");
+
+    std::fs::write(
+        &arch,
+        "/// Ternary expression coverage smoke test.\n\
+module TernaryCov\n\
+  port a: in UInt<1>;\n\
+  port b: in UInt<1>;\n\
+  port y: out UInt<1>;\n\
+\n\
+  let y = a ? b : 0;\n\
+end module TernaryCov\n",
+    )
+    .expect("write TernaryCov.arch");
+
+    std::fs::write(
+        &tb,
+        "#include \"VTernaryCov.h\"\n\
+#include <cstdio>\n\
+\n\
+int main() {\n\
+  VTernaryCov dut;\n\
+  dut.a = 0;\n\
+  dut.b = 0;\n\
+  dut.eval();\n\
+  if (dut.y != 0) return 1;\n\
+\n\
+  dut.a = 1;\n\
+  dut.b = 1;\n\
+  dut.eval();\n\
+  if (dut.y != 1) return 2;\n\
+\n\
+  std::puts(\"PASS ternary coverage\");\n\
+  return 0;\n\
+}\n",
+    )
+    .expect("write tb_ternary_cov.cpp");
+
+    let out = std::process::Command::new(env!("CARGO_BIN_EXE_arch"))
+        .arg("sim")
+        .arg(&arch)
+        .arg("--tb")
+        .arg(&tb)
+        .arg("--outdir")
+        .arg(td.path())
+        .arg("--coverage-dat")
+        .arg(&coverage)
+        .output()
+        .expect("run arch sim with coverage");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        out.status.success(),
+        "arch sim should pass for ternary coverage\nstdout:\n{}\nstderr:\n{}",
+        stdout,
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        stdout.contains("PASS ternary coverage"),
+        "expected PASS marker in arch-sim stdout:\n{stdout}"
+    );
+
+    let coverage_text = std::fs::read_to_string(&coverage).expect("read coverage.dat");
+    assert!(
+        coverage_text.contains("\u{1}page\u{2}v_expr")
+            && coverage_text.contains("\u{1}comment\u{2}expr-then")
+            && coverage_text.contains("\u{1}comment\u{2}expr-else"),
+        "ternary arms should be emitted as expression coverage records:\n{coverage_text}"
+    );
+    assert!(
+        coverage_text
+            .lines()
+            .any(|line| line.contains("\u{1}comment\u{2}expr-then") && !line.ends_with(" 0"))
+            && coverage_text
+                .lines()
+                .any(|line| line.contains("\u{1}comment\u{2}expr-else") && !line.ends_with(" 0")),
+        "both ternary arms should be hit by the smoke bench:\n{coverage_text}"
+    );
+}

--- a/tests/native_arbiter_indexed_handshake/Probe.arch
+++ b/tests/native_arbiter_indexed_handshake/Probe.arch
@@ -1,0 +1,59 @@
+//! ---
+//! tags: [native-sim, arbiter, handshake, indexed-port, regression]
+//! refs:
+//!   - "arch-ibex IbexIcache FbAgeArb request indexed handshake"
+//! ---
+//!
+//! Regression for native C++ simulation of indexed arbiter handshake-array connections.
+//! Parent modules connect per-requester signals with request[i].valid/ready syntax while
+//! the first-class arbiter sim model stores the array as packed request_valid/request_ready bits.
+
+/// Priority arbiter fixture with a request handshake array.
+///
+/// The first-class arbiter model exposes the request array as packed native-sim fields.
+arbiter NativeIndexedHandshakeArb
+  //! Priority is used so the C++ regression has a deterministic winner when multiple requests are asserted.
+  policy priority;
+  param NUM_REQ: const = 4;
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync, High>;
+  ports[NUM_REQ] request
+    valid: in Bool;
+    ready: out Bool;
+  end ports request
+  port grant_valid: out Bool;
+  port grant_requester: out UInt<2>;
+end arbiter NativeIndexedHandshakeArb
+
+/// Parent probe that connects each indexed request handshake signal explicitly.
+///
+/// Native simulation must pack input valid bits and unpack output ready bits when wiring the child arbiter.
+module NativeArbiterIndexedHandshakeProbe
+  port clk_i: in Clock<SysDomain>;
+  port rst_i: in Reset<Sync, High>;
+  port req0_i: in Bool;
+  port req1_i: in Bool;
+  port req2_i: in Bool;
+  port req3_i: in Bool;
+  port ready0_o: out Bool;
+  port ready1_o: out Bool;
+  port ready2_o: out Bool;
+  port ready3_o: out Bool;
+  port grant_valid_o: out Bool;
+  port grant_idx_o: out UInt<2>;
+
+  inst arb: NativeIndexedHandshakeArb
+    clk <- clk_i;
+    rst <- rst_i;
+    request[0].valid <- req0_i;
+    request[1].valid <- req1_i;
+    request[2].valid <- req2_i;
+    request[3].valid <- req3_i;
+    request[0].ready -> ready0_o;
+    request[1].ready -> ready1_o;
+    request[2].ready -> ready2_o;
+    request[3].ready -> ready3_o;
+    grant_valid -> grant_valid_o;
+    grant_requester -> grant_idx_o;
+  end inst arb
+end module NativeArbiterIndexedHandshakeProbe

--- a/tests/native_arbiter_indexed_handshake/tb.cpp
+++ b/tests/native_arbiter_indexed_handshake/tb.cpp
@@ -1,0 +1,37 @@
+#include "VNativeArbiterIndexedHandshakeProbe.h"
+
+#include <cstdint>
+#include <iostream>
+
+int main() {
+  VNativeArbiterIndexedHandshakeProbe dut;
+
+  dut.clk_i = 0;
+  dut.rst_i = 0;
+  dut.req0_i = 1;
+  dut.req1_i = 0;
+  dut.req2_i = 1;
+  dut.req3_i = 0;
+  dut.eval();
+
+  if (!dut.grant_valid_o) {
+    std::cerr << "grant_valid_o was low\n";
+    return 1;
+  }
+  if (dut.grant_idx_o != 0u) {
+    std::cerr << "grant_idx_o got " << dut.grant_idx_o << ", expected 0\n";
+    return 1;
+  }
+  if (!dut.ready0_o || dut.ready1_o || dut.ready2_o || dut.ready3_o) {
+    std::cerr << "ready bits got "
+              << static_cast<unsigned>(dut.ready0_o)
+              << static_cast<unsigned>(dut.ready1_o)
+              << static_cast<unsigned>(dut.ready2_o)
+              << static_cast<unsigned>(dut.ready3_o)
+              << ", expected 1000\n";
+    return 1;
+  }
+
+  std::cout << "PASS native arbiter indexed handshake\n";
+  return 0;
+}

--- a/tests/native_pkg_struct_fsm/Probe.arch
+++ b/tests/native_pkg_struct_fsm/Probe.arch
@@ -1,0 +1,79 @@
+//! ---
+//! tags: [native-sim, package-struct, fsm, coverage]
+//! refs:
+//!   - "arch-ibex ibex_id_stage package struct native-sim bring-up"
+//! ---
+//!
+//! Regression fixture for native C++ simulation of package struct signals crossing
+//! a parent module and FSM child while coverage is enabled.
+
+/// Shared package struct type used by the parent and FSM child.
+package NativePkgStructFsmPkg
+  struct NativeIrqs
+    irq_fast: UInt<15>;
+    irq_timer: Bool;
+  end struct NativeIrqs
+end package NativePkgStructFsmPkg
+
+/// FSM child with package struct input and output ports.
+use NativePkgStructFsmPkg;
+fsm NativePkgStructFsmChild
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync, High>;
+  port irq_in: in NativeIrqs;
+  port irq_out: out NativeIrqs;
+  port timer_seen: out Bool;
+
+  state [Idle, Seen]
+  default state Idle;
+
+  default
+    comb
+      irq_out.irq_fast = irq_in.irq_fast;
+      irq_out.irq_timer = irq_in.irq_timer;
+      timer_seen = false;
+    end comb
+  end default
+
+  state Idle
+    comb
+      timer_seen = irq_in.irq_timer;
+    end comb
+    -> Seen when irq_in.irq_timer;
+  end state Idle
+
+  state Seen
+    comb
+      timer_seen = true;
+    end comb
+    -> Idle when not irq_in.irq_timer;
+  end state Seen
+end fsm NativePkgStructFsmChild
+
+/// Parent probe connects struct wires through the FSM child and exposes scalar fields.
+use NativePkgStructFsmPkg;
+module NativePkgStructFsmProbe
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync, High>;
+  port fast_in: in UInt<15>;
+  port timer_in: in Bool;
+  port fast_seen: out UInt<15>;
+  port timer_seen: out Bool;
+
+  wire irq_req: NativeIrqs;
+  wire irq_resp: NativeIrqs;
+
+  inst child: NativePkgStructFsmChild
+    clk <- clk;
+    rst <- rst;
+    irq_in <- irq_req;
+    irq_out -> irq_resp;
+    timer_seen -> timer_seen;
+  end inst child
+
+  comb
+    irq_req.irq_fast = fast_in;
+    irq_req.irq_timer = timer_in;
+    fast_seen = irq_resp.irq_fast;
+  end comb
+end module NativePkgStructFsmProbe

--- a/tests/native_pkg_struct_fsm/tb.cpp
+++ b/tests/native_pkg_struct_fsm/tb.cpp
@@ -1,0 +1,65 @@
+#include "VNativePkgStructFsmProbe.h"
+
+#include <cstdint>
+#include <iostream>
+
+static void tick(VNativePkgStructFsmProbe& dut) {
+  dut.clk = 0;
+  dut.eval();
+  dut.clk = 1;
+  dut.eval();
+  dut.clk = 0;
+  dut.eval();
+}
+
+int main() {
+  VNativePkgStructFsmProbe dut;
+
+  dut.rst = 1;
+  dut.fast_in = 0;
+  dut.timer_in = 0;
+  tick(dut);
+
+  dut.rst = 0;
+  dut.fast_in = 0x1234u;
+  dut.timer_in = 0;
+  dut.eval();
+  if (dut.fast_seen != 0x1234u) {
+    std::cerr << "fast_seen reset path got 0x" << std::hex << dut.fast_seen
+              << ", expected 0x1234\n";
+    return 1;
+  }
+  if (dut.timer_seen != 0) {
+    std::cerr << "timer_seen should be low before timer input\n";
+    return 1;
+  }
+
+  dut.timer_in = 1;
+  dut.fast_in = 0x3456u;
+  dut.eval();
+  if (dut.fast_seen != 0x3456u) {
+    std::cerr << "fast_seen active path got 0x" << std::hex << dut.fast_seen
+              << ", expected 0x3456\n";
+    return 1;
+  }
+  if (dut.timer_seen != 1) {
+    std::cerr << "timer_seen should reflect timer input in Idle\n";
+    return 1;
+  }
+
+  tick(dut);
+  if (dut.timer_seen != 1) {
+    std::cerr << "timer_seen should remain high after entering Seen\n";
+    return 1;
+  }
+
+  dut.timer_in = 0;
+  tick(dut);
+  if (dut.timer_seen != 0) {
+    std::cerr << "timer_seen should drop after returning to Idle\n";
+    return 1;
+  }
+
+  std::cout << "PASS native package struct FSM coverage\n";
+  return 0;
+}

--- a/tests/native_vec_element_slice_assign/Probe.arch
+++ b/tests/native_vec_element_slice_assign/Probe.arch
@@ -1,0 +1,35 @@
+//! ---
+//! tags: [native-sim, vec, bit-slice, assignment, regression]
+//! refs:
+//!   - "arch-ibex IbexIcache fill_data_q beat writes"
+//! ---
+//!
+//! Regression for native C++ simulation of assignments to a bit slice of a Vec element.
+//! The generated C++ must update the selected bits in the array element instead of assigning
+//! to the read-side slice expression.
+
+/// Probe that writes two 32-bit slices of a 64-bit Vec element.
+///
+/// Native simulation must lower the slice writes to mask-and-OR updates on lanes[0].
+module NativeVecElementSliceAssignProbe
+  port clk_i: in Clock<SysDomain>;
+  port rst_i: in Reset<Sync, High>;
+  port lo_i: in UInt<32>;
+  port hi_i: in UInt<32>;
+  port word_o: out UInt<64>;
+
+  reg lanes: Vec<UInt<64>, 1>;
+
+  default seq on clk_i rising;
+
+  seq
+    if rst_i
+      lanes[0] <= 64'd0;
+    else
+      lanes[0][31:0] <= lo_i;
+      lanes[0][63:32] <= hi_i;
+    end if
+  end seq
+
+  let word_o = lanes[0];
+end module NativeVecElementSliceAssignProbe

--- a/tests/native_vec_element_slice_assign/tb.cpp
+++ b/tests/native_vec_element_slice_assign/tb.cpp
@@ -1,0 +1,34 @@
+#include "VNativeVecElementSliceAssignProbe.h"
+
+#include <cstdint>
+#include <iostream>
+
+int main() {
+  VNativeVecElementSliceAssignProbe dut;
+
+  dut.clk_i = 0;
+  dut.rst_i = 1;
+  dut.lo_i = 0;
+  dut.hi_i = 0;
+  dut.eval();
+  dut.clk_i = 1;
+  dut.eval();
+
+  dut.clk_i = 0;
+  dut.rst_i = 0;
+  dut.lo_i = 0x89ABCDEFu;
+  dut.hi_i = 0x12345678u;
+  dut.eval();
+  dut.clk_i = 1;
+  dut.eval();
+
+  const uint64_t expected = 0x1234567889ABCDEFULL;
+  if (dut.word_o != expected) {
+    std::cerr << std::hex << "word_o got 0x" << dut.word_o
+              << ", expected 0x" << expected << "\n";
+    return 1;
+  }
+
+  std::cout << "PASS native Vec element slice assign\n";
+  return 0;
+}

--- a/tests/native_vec_inst_output_packed_port/Probe.arch
+++ b/tests/native_vec_inst_output_packed_port/Probe.arch
@@ -1,0 +1,27 @@
+//! ---
+//! tags: [native-sim, vec, packed-port, inst-output, regression]
+//! refs:
+//!   - "arch-ibex IbexIfStage icache request ports"
+//! ---
+//!
+//! Regression for native C++ simulation of a sub-instance Vec output connected
+//! to a packed scalar parent output port.
+
+/// Constant single-bit Vec producer used to expose packed parent port wiring.
+module NativeVecPackedProducer
+  port values: out Vec<UInt<1>, 2>;
+
+  comb
+    values[0] = 1'd0;
+    values[1] = 1'd1;
+  end comb
+end module NativeVecPackedProducer
+
+/// Parent probe that packs a child Vec output into a scalar UInt output.
+module NativeVecInstOutputPackedPortProbe
+  port packed_out: out UInt<2>;
+
+  inst producer: NativeVecPackedProducer
+    values -> packed_out;
+  end inst producer
+end module NativeVecInstOutputPackedPortProbe

--- a/tests/native_vec_inst_output_packed_port/tb.cpp
+++ b/tests/native_vec_inst_output_packed_port/tb.cpp
@@ -1,0 +1,17 @@
+#include "VNativeVecInstOutputPackedPortProbe.h"
+
+#include <cstdint>
+#include <iostream>
+
+int main() {
+  VNativeVecInstOutputPackedPortProbe dut;
+
+  dut.eval();
+  if (dut.packed_out != 2u) {
+    std::cerr << "packed_out got " << dut.packed_out << ", expected 2\n";
+    return 1;
+  }
+
+  std::cout << "PASS native Vec inst output packed port\n";
+  return 0;
+}


### PR DESCRIPTION
## Summary

Adds native C++ simulation support for the language features the Ibex CPU port exercises, plus an `arch sim --param NAME=VALUE` top-level parameter override. **Internal only** (sim codegen + comb-settle analysis + CLI) — no user-facing syntax or type-system semantics change.

Rebased on top of the rustfmt baseline (#632, merged), so this is a minimal, purely-semantic diff: **14 files, +1936/−123.**

## What's in it

**Native-sim codegen** (`src/sim_codegen/{mod,fsm,pipeline}.rs`):
- **Vec element bit-slice assignment** — `lanes[0][31:0] <= x` lowers to a mask-and-OR update on the array lane, not the read-side slice.
- **Vec sub-instance output → packed scalar parent port.**
- **package-struct signals crossing a parent module and an FSM child** — emits `#include "VStructs.h"`, default-constructs struct-typed port/reg inits.
- **arbiter indexed handshake** — packed `valid` / unpacked `ready`.
- `vinit_regs` threaded through `Ctx` for vec-init reg handling.

**Comb-settle analysis** (`src/comb_graph.rs`):
- A comb cycle whose instance inputs are bridged by parent comb intermediates needs **3** native-sim settle passes (bridge refresh + producer + consumer/feedback), not 2.

**CLI** (`src/main.rs`):
- `arch sim --param NAME=VALUE` overrides a top-level `const`/width param before elaboration; forwards `-DNAME=VALUE` to the C++/pybind build.

## Tests

4 new native-sim fixtures with **behavioral** `tb.cpp` checks (vec slice assign, vec→packed port, package-struct FSM, arbiter indexed handshake), a 3-settle-pass comb-graph regression, plus integration coverage.

## Verification

- `cargo build --release` — clean, no warnings.
- `cargo test --release` — **677 passed, 0 failed** (integration), all other suites green.