### PR TITLE
style: apply rustfmt 1.8.0 to the codebase

### DIFF
--- a/examples/dump_fp.rs
+++ b/examples/dump_fp.rs
@@ -10,7 +10,10 @@ fn main() {
     let p = arch::FpCompat::Riscv;
     let mode = std::env::args().nth(1).unwrap_or_default();
     match mode.as_str() {
-        "smt" => print!("{}", arch::fp_ir::render_smt(&arch::fp_ops::fp_functions(p))),
+        "smt" => print!(
+            "{}",
+            arch::fp_ir::render_smt(&arch::fp_ops::fp_functions(p))
+        ),
         "lean" => {
             let mut funcs = arch::fp_ops::fp_functions(p);
             // Lean-only helpers (decode fields + shared rounder at the mul width)

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -79,8 +79,8 @@ pub struct BusDecl {
     pub doc: Option<String>,
     pub inner_doc: Option<String>,
     pub params: Vec<ParamDecl>,
-    pub signals: Vec<PortDecl>,  // direction = from initiator's perspective
-    pub generates: Vec<BusGenerateIf>,  // conditional signal groups
+    pub signals: Vec<PortDecl>, // direction = from initiator's perspective
+    pub generates: Vec<BusGenerateIf>, // conditional signal groups
     /// Handshake sub-constructs declared in this bus. The synthesized
     /// PortDecls already live in `signals` (or inside `generates`); this
     /// list preserves the grouping so codegen can emit per-variant SVA
@@ -435,15 +435,15 @@ pub struct TypeAliasDecl {
 impl ModuleBodyItem {
     pub fn span(&self) -> Span {
         match self {
-            ModuleBodyItem::RegDecl(r)    => r.span,
-            ModuleBodyItem::RegBlock(r)   => r.span,
+            ModuleBodyItem::RegDecl(r) => r.span,
+            ModuleBodyItem::RegBlock(r) => r.span,
             ModuleBodyItem::LatchBlock(l) => l.span,
-            ModuleBodyItem::CombBlock(c)  => c.span,
+            ModuleBodyItem::CombBlock(c) => c.span,
             ModuleBodyItem::LetBinding(l) => l.span,
-            ModuleBodyItem::Inst(i)       => i.span,
-            ModuleBodyItem::Generate(g)   => match g {
+            ModuleBodyItem::Inst(i) => i.span,
+            ModuleBodyItem::Generate(g) => match g {
                 GenerateDecl::For(f) => f.span,
-                GenerateDecl::If(i)  => i.span,
+                GenerateDecl::If(i) => i.span,
             },
             ModuleBodyItem::PipeRegDecl(p) => p.span,
             ModuleBodyItem::WireDecl(w) => w.span,
@@ -498,12 +498,15 @@ pub struct PipeRegDecl {
 // ── Assert / Cover ────────────────────────────────────────────────────────────
 
 #[derive(Debug, Clone, PartialEq)]
-pub enum AssertKind { Assert, Cover }
+pub enum AssertKind {
+    Assert,
+    Cover,
+}
 
 #[derive(Debug, Clone)]
 pub struct AssertDecl {
     pub kind: AssertKind,
-    pub name: Option<Ident>,   // optional label (e.g. `assert no_overflow: expr;`)
+    pub name: Option<Ident>, // optional label (e.g. `assert no_overflow: expr;`)
     pub expr: Expr,
     pub span: Span,
 }
@@ -719,11 +722,25 @@ pub enum ThreadStmt {
     /// `fork ... and ... join` — parallel branches
     ForkJoin(Vec<Vec<ThreadStmt>>, Span),
     /// `for var in start..end ... end for` — counted loop with waits
-    For { var: Ident, start: Expr, end: Expr, body: Vec<ThreadStmt>, span: Span },
+    For {
+        var: Ident,
+        start: Expr,
+        end: Expr,
+        body: Vec<ThreadStmt>,
+        span: Span,
+    },
     /// `lock resource_name ... end lock resource_name` — exclusive bus access
-    Lock { resource: Ident, body: Vec<ThreadStmt>, span: Span },
+    Lock {
+        resource: Ident,
+        body: Vec<ThreadStmt>,
+        span: Span,
+    },
     /// `do ... until cond;` — hold comb outputs while waiting for condition
-    DoUntil { body: Vec<ThreadStmt>, cond: Expr, span: Span },
+    DoUntil {
+        body: Vec<ThreadStmt>,
+        cond: Expr,
+        span: Span,
+    },
     /// `log(Level, "TAG", "fmt", args...);` — debug output
     Log(LogStmt),
     /// `return expr;` — valid only inside a TLM target thread body
@@ -924,26 +941,28 @@ pub enum ConnectDir {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LogLevel {
     Always = 0,
-    Low    = 1,
+    Low = 1,
     Medium = 2,
-    High   = 3,
-    Full   = 4,
-    Debug  = 5,
+    High = 3,
+    Full = 4,
+    Debug = 5,
 }
 
 impl LogLevel {
     pub fn name(self) -> &'static str {
         match self {
             LogLevel::Always => "ALWAYS",
-            LogLevel::Low    => "LOW",
+            LogLevel::Low => "LOW",
             LogLevel::Medium => "MEDIUM",
-            LogLevel::High   => "HIGH",
-            LogLevel::Full   => "FULL",
-            LogLevel::Debug  => "DEBUG",
+            LogLevel::High => "HIGH",
+            LogLevel::Full => "FULL",
+            LogLevel::Debug => "DEBUG",
         }
     }
 
-    pub fn value(self) -> u8 { self as u8 }
+    pub fn value(self) -> u8 {
+        self as u8
+    }
 }
 
 // Statements inside reg blocks
@@ -963,7 +982,11 @@ pub enum Stmt {
     WaitUntil(Expr, Span),
     /// `do ... until cond;` — hold comb/seq outputs while waiting for condition.
     /// Only valid inside a pipeline stage `seq` block.
-    DoUntil { body: Vec<Stmt>, cond: Expr, span: Span },
+    DoUntil {
+        body: Vec<Stmt>,
+        cond: Expr,
+        span: Span,
+    },
 }
 
 #[derive(Debug, Clone)]
@@ -976,8 +999,8 @@ pub struct InitBlock {
 
 #[derive(Debug, Clone)]
 pub enum ForRange {
-    Range(Expr, Expr),      // start..end
-    ValueList(Vec<Expr>),   // {a, b, c}
+    Range(Expr, Expr),    // start..end
+    ValueList(Vec<Expr>), // {a, b, c}
 }
 
 #[derive(Debug, Clone)]
@@ -1070,10 +1093,18 @@ pub struct Expr {
 
 impl Expr {
     pub fn new(kind: ExprKind, span: Span) -> Self {
-        Expr { kind, span, parenthesized: false }
+        Expr {
+            kind,
+            span,
+            parenthesized: false,
+        }
     }
     pub fn parens(kind: ExprKind, span: Span) -> Self {
-        Expr { kind, span, parenthesized: true }
+        Expr {
+            kind,
+            span,
+            parenthesized: true,
+        }
     }
 }
 
@@ -1092,11 +1123,11 @@ pub enum ExprKind {
     Binary(BinOp, Box<Expr>, Box<Expr>),
     Unary(UnaryOp, Box<Expr>),
     FieldAccess(Box<Expr>, Ident),
-    MethodCall(Box<Expr>, Ident, Vec<Expr>),  // receiver, method, type_args encoded as exprs
+    MethodCall(Box<Expr>, Ident, Vec<Expr>), // receiver, method, type_args encoded as exprs
     Cast(Box<Expr>, Box<TypeExpr>),
     Index(Box<Expr>, Box<Expr>),
-    BitSlice(Box<Expr>, Box<Expr>, Box<Expr>),  // base[hi:lo]
-    PartSelect(Box<Expr>, Box<Expr>, Box<Expr>, bool),  // base[start +: width] (true=+:, false=-:)
+    BitSlice(Box<Expr>, Box<Expr>, Box<Expr>), // base[hi:lo]
+    PartSelect(Box<Expr>, Box<Expr>, Box<Expr>, bool), // base[start +: width] (true=+:, false=-:)
     StructLiteral(Ident, Vec<FieldInit>),
     EnumVariant(Ident, Ident), // EnumName::Variant
     Todo,
@@ -1300,16 +1331,16 @@ impl Item {
     /// `regfile`, `pipeline`, `linklist`).
     pub fn is_interface(&self) -> bool {
         match self {
-            Item::Module(m)        => m.is_interface,
-            Item::Fsm(f)           => f.common.is_interface,
-            Item::Fifo(f)          => f.common.is_interface,
-            Item::Ram(r)           => r.common.is_interface,
-            Item::Cam(c)           => c.common.is_interface,
-            Item::Counter(c)       => c.common.is_interface,
-            Item::Arbiter(a)       => a.common.is_interface,
-            Item::Regfile(r)       => r.common.is_interface,
-            Item::Pipeline(p)      => p.common.is_interface,
-            Item::Linklist(l)      => l.common.is_interface,
+            Item::Module(m) => m.is_interface,
+            Item::Fsm(f) => f.common.is_interface,
+            Item::Fifo(f) => f.common.is_interface,
+            Item::Ram(r) => r.common.is_interface,
+            Item::Cam(c) => c.common.is_interface,
+            Item::Counter(c) => c.common.is_interface,
+            Item::Arbiter(a) => a.common.is_interface,
+            Item::Regfile(r) => r.common.is_interface,
+            Item::Pipeline(p) => p.common.is_interface,
+            Item::Linklist(l) => l.common.is_interface,
             // The remaining variants (Domain, Struct, Enum, Function,
             // Template, Synchronizer, Clkgate, Bus, Package, Use)
             // either don't get instantiated across `.archi` boundaries
@@ -1325,16 +1356,46 @@ impl Item {
     /// flag (and the assignment took effect); `false` otherwise.
     pub fn set_is_interface(&mut self, val: bool) -> bool {
         match self {
-            Item::Module(m)        => { m.is_interface = val; true }
-            Item::Fsm(f)           => { f.common.is_interface = val; true }
-            Item::Fifo(f)          => { f.common.is_interface = val; true }
-            Item::Ram(r)           => { r.common.is_interface = val; true }
-            Item::Cam(c)           => { c.common.is_interface = val; true }
-            Item::Counter(c)       => { c.common.is_interface = val; true }
-            Item::Arbiter(a)       => { a.common.is_interface = val; true }
-            Item::Regfile(r)       => { r.common.is_interface = val; true }
-            Item::Pipeline(p)      => { p.common.is_interface = val; true }
-            Item::Linklist(l)      => { l.common.is_interface = val; true }
+            Item::Module(m) => {
+                m.is_interface = val;
+                true
+            }
+            Item::Fsm(f) => {
+                f.common.is_interface = val;
+                true
+            }
+            Item::Fifo(f) => {
+                f.common.is_interface = val;
+                true
+            }
+            Item::Ram(r) => {
+                r.common.is_interface = val;
+                true
+            }
+            Item::Cam(c) => {
+                c.common.is_interface = val;
+                true
+            }
+            Item::Counter(c) => {
+                c.common.is_interface = val;
+                true
+            }
+            Item::Arbiter(a) => {
+                a.common.is_interface = val;
+                true
+            }
+            Item::Regfile(r) => {
+                r.common.is_interface = val;
+                true
+            }
+            Item::Pipeline(p) => {
+                p.common.is_interface = val;
+                true
+            }
+            Item::Linklist(l) => {
+                l.common.is_interface = val;
+                true
+            }
             _ => false,
         }
     }
@@ -1381,7 +1442,9 @@ pub trait Construct {
     /// arbiter, regfile, synchronizer, clkgate, linklist, bus, struct,
     /// enum, package); `None` for the rest. Default returns `None`,
     /// matching the original `_ => None` arm in `interface::emit_interface`.
-    fn emit_interface(&self) -> Option<String> { None }
+    fn emit_interface(&self) -> Option<String> {
+        None
+    }
 
     /// Run typecheck on this construct. Default is a no-op (matches the
     /// `Item::Use(_) => {}` arm in the original dispatch). Each
@@ -1403,7 +1466,12 @@ pub trait Construct {
     /// (Module is handled specially by the caller because it needs the
     /// debug-module set; Domain / Struct / Enum / Function / Template
     /// / Bus / Package / Use don't generate sim code).
-    fn emit_sim(&self, _simgen: &crate::sim_codegen::SimCodegen) -> Option<crate::sim_codegen::SimModel> { None }
+    fn emit_sim(
+        &self,
+        _simgen: &crate::sim_codegen::SimCodegen,
+    ) -> Option<crate::sim_codegen::SimModel> {
+        None
+    }
 }
 
 // ── Construct trait impls ────────────────────────────────────────────────────
@@ -1455,39 +1523,164 @@ macro_rules! impl_construct_direct {
     };
 }
 
-impl_construct_direct!(ModuleDecl,           "module",       iface = crate::interface::emit_module_interface,       check = check_module,       emit_sv = emit_module);
-impl_construct_via_common!(FsmDecl,          "fsm",          iface = crate::interface::emit_fsm_interface,          check = check_fsm,          emit_sv = emit_fsm,          emit_sim = gen_fsm);
-impl_construct_via_common!(FifoDecl,         "fifo",         iface = crate::interface::emit_fifo_interface,         check = check_fifo,         emit_sv = emit_fifo,         emit_sim = gen_fifo);
-impl_construct_via_common!(RamDecl,          "ram",          iface = crate::interface::emit_ram_interface,          check = check_ram,          emit_sv = emit_ram,          emit_sim = gen_ram);
-impl_construct_via_common!(CamDecl,          "cam",          iface = crate::interface::emit_cam_interface,          check = check_cam,          emit_sv = emit_cam,          emit_sim = gen_cam);
-impl_construct_via_common!(CounterDecl,      "counter",      iface = crate::interface::emit_counter_interface,      check = check_counter,      emit_sv = emit_counter,      emit_sim = gen_counter);
-impl_construct_via_common!(ArbiterDecl,      "arbiter",      iface = crate::interface::emit_arbiter_interface,      check = check_arbiter,      emit_sv = emit_arbiter,      emit_sim = gen_arbiter);
-impl_construct_via_common!(RegfileDecl,      "regfile",      iface = crate::interface::emit_regfile_interface,      check = check_regfile,      emit_sv = emit_regfile,      emit_sim = gen_regfile);
-impl_construct_via_common!(PipelineDecl,     "pipeline",     iface = crate::interface::emit_pipeline_interface,     check = check_pipeline,     emit_sv = emit_pipeline,     emit_sim = gen_pipeline);
-impl_construct_via_common!(LinklistDecl,     "linklist",     iface = crate::interface::emit_linklist_interface,     check = check_linklist,     emit_sv = emit_linklist,     emit_sim = gen_linklist);
+impl_construct_direct!(
+    ModuleDecl,
+    "module",
+    iface = crate::interface::emit_module_interface,
+    check = check_module,
+    emit_sv = emit_module
+);
+impl_construct_via_common!(
+    FsmDecl,
+    "fsm",
+    iface = crate::interface::emit_fsm_interface,
+    check = check_fsm,
+    emit_sv = emit_fsm,
+    emit_sim = gen_fsm
+);
+impl_construct_via_common!(
+    FifoDecl,
+    "fifo",
+    iface = crate::interface::emit_fifo_interface,
+    check = check_fifo,
+    emit_sv = emit_fifo,
+    emit_sim = gen_fifo
+);
+impl_construct_via_common!(
+    RamDecl,
+    "ram",
+    iface = crate::interface::emit_ram_interface,
+    check = check_ram,
+    emit_sv = emit_ram,
+    emit_sim = gen_ram
+);
+impl_construct_via_common!(
+    CamDecl,
+    "cam",
+    iface = crate::interface::emit_cam_interface,
+    check = check_cam,
+    emit_sv = emit_cam,
+    emit_sim = gen_cam
+);
+impl_construct_via_common!(
+    CounterDecl,
+    "counter",
+    iface = crate::interface::emit_counter_interface,
+    check = check_counter,
+    emit_sv = emit_counter,
+    emit_sim = gen_counter
+);
+impl_construct_via_common!(
+    ArbiterDecl,
+    "arbiter",
+    iface = crate::interface::emit_arbiter_interface,
+    check = check_arbiter,
+    emit_sv = emit_arbiter,
+    emit_sim = gen_arbiter
+);
+impl_construct_via_common!(
+    RegfileDecl,
+    "regfile",
+    iface = crate::interface::emit_regfile_interface,
+    check = check_regfile,
+    emit_sv = emit_regfile,
+    emit_sim = gen_regfile
+);
+impl_construct_via_common!(
+    PipelineDecl,
+    "pipeline",
+    iface = crate::interface::emit_pipeline_interface,
+    check = check_pipeline,
+    emit_sv = emit_pipeline,
+    emit_sim = gen_pipeline
+);
+impl_construct_via_common!(
+    LinklistDecl,
+    "linklist",
+    iface = crate::interface::emit_linklist_interface,
+    check = check_linklist,
+    emit_sv = emit_linklist,
+    emit_sim = gen_linklist
+);
 
-impl_construct_direct!(DomainDecl,           "domain",                                                              check = check_domain,       emit_sv = emit_domain);
-impl_construct_direct!(StructDecl,           "struct",       iface = crate::interface::emit_struct,                 check = check_struct,       emit_sv = emit_struct);
-impl_construct_direct!(EnumDecl,             "enum",         iface = crate::interface::emit_enum,                   check = check_enum,         emit_sv = emit_enum);
-impl_construct_direct!(FunctionDecl,         "function",                                                            check = check_function);
-impl_construct_direct!(SynchronizerDecl,     "synchronizer", iface = crate::interface::emit_synchronizer_interface, check = check_synchronizer, emit_sv = emit_synchronizer, emit_sim = gen_synchronizer);
-impl_construct_direct!(ClkGateDecl,          "clkgate",      iface = crate::interface::emit_clkgate_interface,      check = check_clkgate,      emit_sv = emit_clkgate,      emit_sim = gen_clkgate);
-impl_construct_direct!(BusDecl,              "bus",          iface = crate::interface::emit_bus_interface,          check = check_bus);
-impl_construct_direct!(PackageDecl,          "package",      iface = crate::interface::emit_package_interface,      check = check_package,      emit_sv = emit_package);
-impl_construct_direct!(TemplateDecl,         "template",                                                            check = check_template);
+impl_construct_direct!(
+    DomainDecl,
+    "domain",
+    check = check_domain,
+    emit_sv = emit_domain
+);
+impl_construct_direct!(
+    StructDecl,
+    "struct",
+    iface = crate::interface::emit_struct,
+    check = check_struct,
+    emit_sv = emit_struct
+);
+impl_construct_direct!(
+    EnumDecl,
+    "enum",
+    iface = crate::interface::emit_enum,
+    check = check_enum,
+    emit_sv = emit_enum
+);
+impl_construct_direct!(FunctionDecl, "function", check = check_function);
+impl_construct_direct!(
+    SynchronizerDecl,
+    "synchronizer",
+    iface = crate::interface::emit_synchronizer_interface,
+    check = check_synchronizer,
+    emit_sv = emit_synchronizer,
+    emit_sim = gen_synchronizer
+);
+impl_construct_direct!(
+    ClkGateDecl,
+    "clkgate",
+    iface = crate::interface::emit_clkgate_interface,
+    check = check_clkgate,
+    emit_sv = emit_clkgate,
+    emit_sim = gen_clkgate
+);
+impl_construct_direct!(
+    BusDecl,
+    "bus",
+    iface = crate::interface::emit_bus_interface,
+    check = check_bus
+);
+impl_construct_direct!(
+    PackageDecl,
+    "package",
+    iface = crate::interface::emit_package_interface,
+    check = check_package,
+    emit_sv = emit_package
+);
+impl_construct_direct!(TemplateDecl, "template", check = check_template);
 
 // `extern package` — opaque type declarations for SV-side packages.
 // No SV body emission (the SV package lives upstream); typecheck is a
 // no-op (there are no ARCH-side values to validate).
-impl_construct_direct!(ExternPackageDecl,    "extern package",                                                      check = check_extern_package);
+impl_construct_direct!(
+    ExternPackageDecl,
+    "extern package",
+    check = check_extern_package
+);
 
 // `Use` has only `doc` — no inner doc (single-line decl).
 impl Construct for UseDecl {
-    fn kind_label(&self) -> &'static str { "use" }
-    fn name(&self)      -> &Ident         { &self.name }
-    fn span(&self)      -> Span           { self.span }
-    fn doc(&self)       -> Option<&str>   { self.doc.as_deref() }
-    fn inner_doc(&self) -> Option<&str>   { None }
+    fn kind_label(&self) -> &'static str {
+        "use"
+    }
+    fn name(&self) -> &Ident {
+        &self.name
+    }
+    fn span(&self) -> Span {
+        self.span
+    }
+    fn doc(&self) -> Option<&str> {
+        self.doc.as_deref()
+    }
+    fn inner_doc(&self) -> Option<&str> {
+        None
+    }
 }
 
 // ── Function ──────────────────────────────────────────────────────────────────
@@ -1563,15 +1756,15 @@ pub struct FunctionAssign {
 /// (`param_int`, `resolve_count_expr`).
 #[derive(Debug, Clone)]
 pub struct ConstructCommon {
-    pub name:    Ident,
-    pub params:  Vec<ParamDecl>,
-    pub ports:   Vec<PortDecl>,
+    pub name: Ident,
+    pub params: Vec<ParamDecl>,
+    pub ports: Vec<PortDecl>,
     pub asserts: Vec<AssertDecl>,
-    pub span:    Span,
+    pub span: Span,
     /// Outer doc comment from immediately-preceding `///` lines. None when
     /// the construct has no doc-comment block above it. See
     /// `doc/plan_arch_doc_comments.md` for the V1 surface.
-    pub doc:     Option<String>,
+    pub doc: Option<String>,
     /// Inner doc comment from `//!` lines that appear between the opening
     /// keyword + name and any other body item. Distinct from `doc` so
     /// downstream tooling can tell "from the outside" prose apart from
@@ -1600,10 +1793,17 @@ impl ConstructCommon {
     /// duplicated in `codegen::emit_regfile`, `sim_codegen::gen_regfile`,
     /// and `sim_codegen/linklist.rs`.
     pub fn param_int(&self, name: &str, default: u64) -> u64 {
-        self.params.iter()
+        self.params
+            .iter()
             .find(|p| p.name.name == name)
             .and_then(|p| p.default.as_ref())
-            .and_then(|e| if let ExprKind::Literal(LitKind::Dec(v)) = &e.kind { Some(*v) } else { None })
+            .and_then(|e| {
+                if let ExprKind::Literal(LitKind::Dec(v)) = &e.kind {
+                    Some(*v)
+                } else {
+                    None
+                }
+            })
             .unwrap_or(default)
     }
 
@@ -1650,10 +1850,14 @@ pub struct FsmDecl {
 }
 impl std::ops::Deref for FsmDecl {
     type Target = ConstructCommon;
-    fn deref(&self) -> &ConstructCommon { &self.common }
+    fn deref(&self) -> &ConstructCommon {
+        &self.common
+    }
 }
 impl std::ops::DerefMut for FsmDecl {
-    fn deref_mut(&mut self) -> &mut ConstructCommon { &mut self.common }
+    fn deref_mut(&mut self) -> &mut ConstructCommon {
+        &mut self.common
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -1689,10 +1893,14 @@ pub struct FifoDecl {
 }
 impl std::ops::Deref for FifoDecl {
     type Target = ConstructCommon;
-    fn deref(&self) -> &ConstructCommon { &self.common }
+    fn deref(&self) -> &ConstructCommon {
+        &self.common
+    }
 }
 impl std::ops::DerefMut for FifoDecl {
-    fn deref_mut(&mut self) -> &mut ConstructCommon { &mut self.common }
+    fn deref_mut(&mut self) -> &mut ConstructCommon {
+        &mut self.common
+    }
 }
 
 // ── Synchronizer (CDC) ──────────────────────────────────────────────────────
@@ -1756,10 +1964,14 @@ pub struct RamDecl {
 }
 impl std::ops::Deref for RamDecl {
     type Target = ConstructCommon;
-    fn deref(&self) -> &ConstructCommon { &self.common }
+    fn deref(&self) -> &ConstructCommon {
+        &self.common
+    }
 }
 impl std::ops::DerefMut for RamDecl {
-    fn deref_mut(&mut self) -> &mut ConstructCommon { &mut self.common }
+    fn deref_mut(&mut self) -> &mut ConstructCommon {
+        &mut self.common
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1825,10 +2037,14 @@ pub struct CamDecl {
 }
 impl std::ops::Deref for CamDecl {
     type Target = ConstructCommon;
-    fn deref(&self) -> &ConstructCommon { &self.common }
+    fn deref(&self) -> &ConstructCommon {
+        &self.common
+    }
 }
 impl std::ops::DerefMut for CamDecl {
-    fn deref_mut(&mut self) -> &mut ConstructCommon { &mut self.common }
+    fn deref_mut(&mut self) -> &mut ConstructCommon {
+        &mut self.common
+    }
 }
 
 // ── Counter ───────────────────────────────────────────────────────────────────
@@ -1842,10 +2058,14 @@ pub struct CounterDecl {
 }
 impl std::ops::Deref for CounterDecl {
     type Target = ConstructCommon;
-    fn deref(&self) -> &ConstructCommon { &self.common }
+    fn deref(&self) -> &ConstructCommon {
+        &self.common
+    }
 }
 impl std::ops::DerefMut for CounterDecl {
-    fn deref_mut(&mut self) -> &mut ConstructCommon { &mut self.common }
+    fn deref_mut(&mut self) -> &mut ConstructCommon {
+        &mut self.common
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1886,10 +2106,14 @@ pub struct ArbiterDecl {
 }
 impl std::ops::Deref for ArbiterDecl {
     type Target = ConstructCommon;
-    fn deref(&self) -> &ConstructCommon { &self.common }
+    fn deref(&self) -> &ConstructCommon {
+        &self.common
+    }
 }
 impl std::ops::DerefMut for ArbiterDecl {
-    fn deref_mut(&mut self) -> &mut ConstructCommon { &mut self.common }
+    fn deref_mut(&mut self) -> &mut ConstructCommon {
+        &mut self.common
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -1897,18 +2121,18 @@ pub enum ArbiterPolicy {
     RoundRobin,
     Priority,
     Lru,
-    Weighted(Expr),  // weight expression (param reference)
-    Custom(Ident),   // user function name as policy
+    Weighted(Expr), // weight expression (param reference)
+    Custom(Ident),  // user function name as policy
 }
 
 /// `hook grant_select(req_mask: UInt<N>, ...) -> UInt<N> = FnName(arg1, arg2, ...);`
 #[derive(Debug, Clone)]
 pub struct ArbiterHookDecl {
-    pub hook_name: Ident,          // e.g. "grant_select"
-    pub params: Vec<FunctionArg>,  // formal parameters with types
-    pub ret_ty: TypeExpr,          // return type
-    pub fn_name: Ident,            // bound function name
-    pub fn_args: Vec<Ident>,       // bound arguments
+    pub hook_name: Ident,         // e.g. "grant_select"
+    pub params: Vec<FunctionArg>, // formal parameters with types
+    pub ret_ty: TypeExpr,         // return type
+    pub fn_name: Ident,           // bound function name
+    pub fn_args: Vec<Ident>,      // bound arguments
     pub span: Span,
 }
 
@@ -1962,10 +2186,14 @@ pub enum RegfileFlops {
 }
 impl std::ops::Deref for RegfileDecl {
     type Target = ConstructCommon;
-    fn deref(&self) -> &ConstructCommon { &self.common }
+    fn deref(&self) -> &ConstructCommon {
+        &self.common
+    }
 }
 impl std::ops::DerefMut for RegfileDecl {
-    fn deref_mut(&mut self) -> &mut ConstructCommon { &mut self.common }
+    fn deref_mut(&mut self) -> &mut ConstructCommon {
+        &mut self.common
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -1987,10 +2215,14 @@ pub struct PipelineDecl {
 }
 impl std::ops::Deref for PipelineDecl {
     type Target = ConstructCommon;
-    fn deref(&self) -> &ConstructCommon { &self.common }
+    fn deref(&self) -> &ConstructCommon {
+        &self.common
+    }
 }
 impl std::ops::DerefMut for PipelineDecl {
-    fn deref_mut(&mut self) -> &mut ConstructCommon { &mut self.common }
+    fn deref_mut(&mut self) -> &mut ConstructCommon {
+        &mut self.common
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -2048,10 +2280,14 @@ pub struct LinklistDecl {
 }
 impl std::ops::Deref for LinklistDecl {
     type Target = ConstructCommon;
-    fn deref(&self) -> &ConstructCommon { &self.common }
+    fn deref(&self) -> &ConstructCommon {
+        &self.common
+    }
 }
 impl std::ops::DerefMut for LinklistDecl {
-    fn deref_mut(&mut self) -> &mut ConstructCommon { &mut self.common }
+    fn deref_mut(&mut self) -> &mut ConstructCommon {
+        &mut self.common
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -2062,10 +2298,14 @@ pub struct OpDecl {
 }
 impl std::ops::Deref for OpDecl {
     type Target = ConstructCommon;
-    fn deref(&self) -> &ConstructCommon { &self.common }
+    fn deref(&self) -> &ConstructCommon {
+        &self.common
+    }
 }
 impl std::ops::DerefMut for OpDecl {
-    fn deref_mut(&mut self) -> &mut ConstructCommon { &mut self.common }
+    fn deref_mut(&mut self) -> &mut ConstructCommon {
+        &mut self.common
+    }
 }
 
 // ── Template ─────────────────────────────────────────────────────────────────

--- a/src/codegen/arbiter.rs
+++ b/src/codegen/arbiter.rs
@@ -13,7 +13,9 @@ impl<'a> Codegen<'a> {
         let n = &a.name.name.clone();
 
         // Find NUM_REQ param
-        let num_req_default = a.params.iter()
+        let num_req_default = a
+            .params
+            .iter()
             .find(|p| p.name.name == "NUM_REQ")
             .and_then(|p| p.default.as_ref())
             .map(|e| self.emit_expr_str(e))
@@ -23,7 +25,9 @@ impl<'a> Codegen<'a> {
         let num_req_int: u64 = num_req_default.parse().unwrap_or(4);
         let req_width = crate::width::index_width(num_req_int as u64);
 
-        let clk = a.ports.iter()
+        let clk = a
+            .ports
+            .iter()
             .find(|p| matches!(&p.ty, TypeExpr::Clock(_)))
             .map(|p| p.name.name.clone())
             .unwrap_or_else(|| "clk".to_string());
@@ -37,10 +41,15 @@ impl<'a> Codegen<'a> {
         } else {
             for (i, p) in a.params.iter().enumerate() {
                 let comma = if i < a.params.len() - 1 { "," } else { "" };
-                let default_str = p.default.as_ref()
+                let default_str = p
+                    .default
+                    .as_ref()
                     .map(|e| format!(" = {}", self.emit_expr_str(e)))
                     .unwrap_or_default();
-                self.line(&format!("parameter int {}{default_str}{comma}", p.name.name));
+                self.line(&format!(
+                    "parameter int {}{default_str}{comma}",
+                    p.name.name
+                ));
             }
         }
         self.indent -= 1;
@@ -50,7 +59,10 @@ impl<'a> Codegen<'a> {
         // Scalar ports (clk, rst)
         let mut all_ports: Vec<String> = Vec::new();
         for p in &a.ports {
-            let dir = match p.direction { Direction::In => "input", Direction::Out => "output" };
+            let dir = match p.direction {
+                Direction::In => "input",
+                Direction::Out => "output",
+            };
             let ty_str = self.emit_port_type_str(&p.ty);
             all_ports.push(format!("{dir} {ty_str} {}", p.name.name));
         }
@@ -58,7 +70,10 @@ impl<'a> Codegen<'a> {
         for pa in &a.port_arrays {
             let count_str = self.emit_expr_str(&pa.count_expr);
             for s in &pa.signals {
-                let dir = match s.direction { Direction::In => "input", Direction::Out => "output" };
+                let dir = match s.direction {
+                    Direction::In => "input",
+                    Direction::Out => "output",
+                };
                 let port_name = format!("{}_{}", pa.name.name, s.name.name);
                 let port_str = self.emit_port_array_signal_str(dir, &s.ty, &port_name, &count_str);
                 all_ports.push(port_str);
@@ -90,11 +105,15 @@ impl<'a> Codegen<'a> {
         // Input signal in it → req_valid_sig; output signal → req_ready_sig
         let (req_valid_sig, req_ready_sig) = if let Some(pa) = a.port_arrays.first() {
             let pfx = &pa.name.name;
-            let valid = pa.signals.iter()
+            let valid = pa
+                .signals
+                .iter()
                 .find(|s| s.direction == Direction::In)
                 .map(|s| format!("{pfx}_{}", s.name.name))
                 .unwrap_or_else(|| format!("{pfx}_valid"));
-            let ready = pa.signals.iter()
+            let ready = pa
+                .signals
+                .iter()
                 .find(|s| s.direction == Direction::Out)
                 .map(|s| format!("{pfx}_{}", s.name.name))
                 .unwrap_or_else(|| format!("{pfx}_ready"));
@@ -110,39 +129,104 @@ impl<'a> Codegen<'a> {
         // which are then pipelined to the actual output ports.
         let (gv_sig, gr_sig, rr_sig) = if latency > 1 {
             let num_req_str = self.emit_expr_str(
-                &a.params.iter().find(|p| p.name.name == "NUM_REQ")
+                &a.params
+                    .iter()
+                    .find(|p| p.name.name == "NUM_REQ")
                     .and_then(|p| p.default.clone())
                     .unwrap_or(crate::ast::Expr {
                         kind: crate::ast::ExprKind::Literal(crate::ast::LitKind::Dec(num_req_int)),
                         span: a.span,
                         parenthesized: false,
-                    })
+                    }),
             );
             self.line(&format!("logic grant_valid_comb;"));
-            self.line(&format!("logic [{}:0] grant_requester_comb;", req_width - 1));
-            self.line(&format!("logic [{}] {req_ready_sig}_comb;", Self::fold_width_str(&num_req_str)));
+            self.line(&format!(
+                "logic [{}:0] grant_requester_comb;",
+                req_width - 1
+            ));
+            self.line(&format!(
+                "logic [{}] {req_ready_sig}_comb;",
+                Self::fold_width_str(&num_req_str)
+            ));
             self.line("");
-            ("grant_valid_comb".to_string(), "grant_requester_comb".to_string(), format!("{req_ready_sig}_comb"))
+            (
+                "grant_valid_comb".to_string(),
+                "grant_requester_comb".to_string(),
+                format!("{req_ready_sig}_comb"),
+            )
         } else {
-            ("grant_valid".to_string(), "grant_requester".to_string(), req_ready_sig.clone())
+            (
+                "grant_valid".to_string(),
+                "grant_requester".to_string(),
+                req_ready_sig.clone(),
+            )
         };
 
         // ── Arbiter logic ─────────────────────────────────────────────────────
         match policy {
             ArbiterPolicy::RoundRobin => {
-                self.emit_arbiter_round_robin(&clk, &rst, is_async, is_low, req_width, num_req_int, &req_valid_sig, &rr_sig, &gv_sig, &gr_sig);
+                self.emit_arbiter_round_robin(
+                    &clk,
+                    &rst,
+                    is_async,
+                    is_low,
+                    req_width,
+                    num_req_int,
+                    &req_valid_sig,
+                    &rr_sig,
+                    &gv_sig,
+                    &gr_sig,
+                );
             }
             ArbiterPolicy::Priority => {
-                self.emit_arbiter_priority(req_width, num_req_int, &req_valid_sig, &rr_sig, &gv_sig, &gr_sig);
+                self.emit_arbiter_priority(
+                    req_width,
+                    num_req_int,
+                    &req_valid_sig,
+                    &rr_sig,
+                    &gv_sig,
+                    &gr_sig,
+                );
             }
             ArbiterPolicy::Lru => {
-                self.emit_arbiter_round_robin(&clk, &rst, is_async, is_low, req_width, num_req_int, &req_valid_sig, &rr_sig, &gv_sig, &gr_sig);
+                self.emit_arbiter_round_robin(
+                    &clk,
+                    &rst,
+                    is_async,
+                    is_low,
+                    req_width,
+                    num_req_int,
+                    &req_valid_sig,
+                    &rr_sig,
+                    &gv_sig,
+                    &gr_sig,
+                );
             }
             ArbiterPolicy::Weighted(_) => {
-                self.emit_arbiter_priority(req_width, num_req_int, &req_valid_sig, &rr_sig, &gv_sig, &gr_sig);
+                self.emit_arbiter_priority(
+                    req_width,
+                    num_req_int,
+                    &req_valid_sig,
+                    &rr_sig,
+                    &gv_sig,
+                    &gr_sig,
+                );
             }
             ArbiterPolicy::Custom(ref fn_ident) => {
-                self.emit_arbiter_custom(a, fn_ident, &clk, &rst, is_async, is_low, req_width, num_req_int, &req_valid_sig, &rr_sig, &gv_sig, &gr_sig);
+                self.emit_arbiter_custom(
+                    a,
+                    fn_ident,
+                    &clk,
+                    &rst,
+                    is_async,
+                    is_low,
+                    req_width,
+                    num_req_int,
+                    &req_valid_sig,
+                    &rr_sig,
+                    &gv_sig,
+                    &gr_sig,
+                );
             }
         }
 
@@ -155,9 +239,21 @@ impl<'a> Codegen<'a> {
             self.line("");
 
             for s in 0..stages {
-                let src_gv = if s == 0 { gv_sig.clone() } else { format!("grant_valid_p{s}") };
-                let src_gr = if s == 0 { gr_sig.clone() } else { format!("grant_requester_p{s}") };
-                let src_rr = if s == 0 { rr_sig.clone() } else { format!("{req_ready_sig}_p{s}") };
+                let src_gv = if s == 0 {
+                    gv_sig.clone()
+                } else {
+                    format!("grant_valid_p{s}")
+                };
+                let src_gr = if s == 0 {
+                    gr_sig.clone()
+                } else {
+                    format!("grant_requester_p{s}")
+                };
+                let src_rr = if s == 0 {
+                    rr_sig.clone()
+                } else {
+                    format!("{req_ready_sig}_p{s}")
+                };
                 let dst_suffix = if s == stages - 1 {
                     // Last stage drives the output ports directly
                     String::new()
@@ -165,15 +261,30 @@ impl<'a> Codegen<'a> {
                     format!("_p{}", s + 1)
                 };
 
-                let dst_gv = if dst_suffix.is_empty() { "grant_valid".to_string() } else { format!("grant_valid{dst_suffix}") };
-                let dst_gr = if dst_suffix.is_empty() { "grant_requester".to_string() } else { format!("grant_requester{dst_suffix}") };
-                let dst_rr = if dst_suffix.is_empty() { req_ready_sig.clone() } else { format!("{req_ready_sig}{dst_suffix}") };
+                let dst_gv = if dst_suffix.is_empty() {
+                    "grant_valid".to_string()
+                } else {
+                    format!("grant_valid{dst_suffix}")
+                };
+                let dst_gr = if dst_suffix.is_empty() {
+                    "grant_requester".to_string()
+                } else {
+                    format!("grant_requester{dst_suffix}")
+                };
+                let dst_rr = if dst_suffix.is_empty() {
+                    req_ready_sig.clone()
+                } else {
+                    format!("{req_ready_sig}{dst_suffix}")
+                };
 
                 // Declare intermediate regs (not needed for last stage which drives output ports)
                 if !dst_suffix.is_empty() {
                     self.line(&format!("logic {dst_gv};"));
                     self.line(&format!("logic [{}:0] {dst_gr};", req_width - 1));
-                    self.line(&format!("logic [{}] {dst_rr};", Self::fold_width_str(&num_req_str)));
+                    self.line(&format!(
+                        "logic [{}] {dst_rr};",
+                        Self::fold_width_str(&num_req_str)
+                    ));
                 }
 
                 self.line(&format!("always_ff @({ff_sens}) begin"));
@@ -197,8 +308,12 @@ impl<'a> Codegen<'a> {
         }
 
         if !a.asserts.is_empty() {
-            let clk = a.ports.iter().find(|p| matches!(&p.ty, TypeExpr::Clock(_)))
-                .map(|p| p.name.name.clone()).unwrap_or_else(|| "clk".to_string());
+            let clk = a
+                .ports
+                .iter()
+                .find(|p| matches!(&p.ty, TypeExpr::Clock(_)))
+                .map(|p| p.name.name.clone())
+                .unwrap_or_else(|| "clk".to_string());
             self.line("");
             let asserts = a.asserts.clone();
             let aname = a.name.name.clone();
@@ -250,7 +365,6 @@ impl<'a> Codegen<'a> {
         }
     }
 
-
     fn emit_arbiter_round_robin(
         &mut self,
         clk: &str,
@@ -294,7 +408,9 @@ impl<'a> Codegen<'a> {
         self.line(&format!("{req_ready} = '0;"));
         self.line(&format!("{grant_requester_sig} = '0;"));
         self.line("arb_found = 1'b0;");
-        self.line(&format!("for (arb_i = 0; arb_i < {num_req}; arb_i++) begin"));
+        self.line(&format!(
+            "for (arb_i = 0; arb_i < {num_req}; arb_i++) begin"
+        ));
         self.indent += 1;
         // All index arithmetic in integer domain; only cast at use sites
         self.line(&format!(
@@ -317,15 +433,27 @@ impl<'a> Codegen<'a> {
         self.line("end");
     }
 
-    fn emit_arbiter_priority(&mut self, req_width: u32, num_req: u64, req_valid: &str, req_ready: &str, grant_valid_sig: &str, grant_requester_sig: &str) {
+    fn emit_arbiter_priority(
+        &mut self,
+        req_width: u32,
+        num_req: u64,
+        req_valid: &str,
+        req_ready: &str,
+        grant_valid_sig: &str,
+        grant_requester_sig: &str,
+    ) {
         self.line("always_comb begin");
         self.indent += 1;
         self.line(&format!("{grant_valid_sig} = 1'b0;"));
         self.line(&format!("{req_ready} = '0;"));
         self.line(&format!("{grant_requester_sig} = '0;"));
-        self.line(&format!("for (int pri_i = 0; pri_i < {num_req}; pri_i++) begin"));
+        self.line(&format!(
+            "for (int pri_i = 0; pri_i < {num_req}; pri_i++) begin"
+        ));
         self.indent += 1;
-        self.line(&format!("if (!{grant_valid_sig} && {req_valid}[pri_i]) begin"));
+        self.line(&format!(
+            "if (!{grant_valid_sig} && {req_valid}[pri_i]) begin"
+        ));
         self.indent += 1;
         self.line(&format!("{grant_valid_sig} = 1'b1;"));
         self.line(&format!("{grant_requester_sig} = {req_width}'(pri_i);"));
@@ -370,29 +498,35 @@ impl<'a> Codegen<'a> {
         self.line(&format!("always_ff @({ff_sens}) begin"));
         self.indent += 1;
         self.line(&format!("if ({rst_cond}) last_grant_r <= '0;"));
-        self.line(&format!("else if ({grant_valid_sig}) last_grant_r <= grant_onehot;"));
+        self.line(&format!(
+            "else if ({grant_valid_sig}) last_grant_r <= grant_onehot;"
+        ));
         self.indent -= 1;
         self.line("end");
         self.line("");
 
         // Build function call arguments from hook bindings
         let hook = a.hook.as_ref().unwrap();
-        let args: Vec<String> = hook.fn_args.iter().map(|arg| {
-            let name = &arg.name;
-            // Map hook formal param names to actual SV signals
-            let hook_param = hook.params.iter().find(|p| p.name.name == *name);
-            if hook_param.is_some() {
-                // This is a hook formal param — map known names to SV signals
-                match name.as_str() {
-                    "req_mask" => req_valid.to_string(),
-                    "last_grant" => "last_grant_r".to_string(),
-                    _ => name.clone(),
+        let args: Vec<String> = hook
+            .fn_args
+            .iter()
+            .map(|arg| {
+                let name = &arg.name;
+                // Map hook formal param names to actual SV signals
+                let hook_param = hook.params.iter().find(|p| p.name.name == *name);
+                if hook_param.is_some() {
+                    // This is a hook formal param — map known names to SV signals
+                    match name.as_str() {
+                        "req_mask" => req_valid.to_string(),
+                        "last_grant" => "last_grant_r".to_string(),
+                        _ => name.clone(),
+                    }
+                } else {
+                    // Must be a port or param name on the arbiter — use as-is
+                    name.clone()
                 }
-            } else {
-                // Must be a port or param name on the arbiter — use as-is
-                name.clone()
-            }
-        }).collect();
+            })
+            .collect();
         let args_str = args.join(", ");
 
         // grant_onehot decl was hoisted above (next to last_grant_r)
@@ -407,7 +541,9 @@ impl<'a> Codegen<'a> {
         self.line(&format!("{grant_requester_sig} = '0;"));
         self.line(&format!("for (int ci = 0; ci < {num_req}; ci++) begin"));
         self.indent += 1;
-        self.line(&format!("if (grant_onehot[ci]) {grant_requester_sig} = {req_width}'(ci);"));
+        self.line(&format!(
+            "if (grant_onehot[ci]) {grant_requester_sig} = {req_width}'(ci);"
+        ));
         self.indent -= 1;
         self.line("end");
         self.indent -= 1;

--- a/src/codegen/cam.rs
+++ b/src/codegen/cam.rs
@@ -11,25 +11,33 @@ impl<'a> Codegen<'a> {
         let n = c.name.name.clone();
 
         // Required params (validated by typecheck): DEPTH, KEY_W
-        let depth_default = c.params.iter()
+        let depth_default = c
+            .params
+            .iter()
             .find(|p| p.name.name == "DEPTH")
             .and_then(|p| p.default.as_ref())
             .map(|e| self.emit_expr_str(e))
             .unwrap_or_else(|| "0".to_string());
-        let key_w_default = c.params.iter()
+        let key_w_default = c
+            .params
+            .iter()
             .find(|p| p.name.name == "KEY_W")
             .and_then(|p| p.default.as_ref())
             .map(|e| self.emit_expr_str(e))
             .unwrap_or_else(|| "0".to_string());
         // v3: optional VAL_W param activates the value-payload bundle.
         let has_value = c.params.iter().any(|p| p.name.name == "VAL_W");
-        let val_w_default = c.params.iter()
+        let val_w_default = c
+            .params
+            .iter()
             .find(|p| p.name.name == "VAL_W")
             .and_then(|p| p.default.as_ref())
             .map(|e| self.emit_expr_str(e))
             .unwrap_or_else(|| "0".to_string());
 
-        let clk = c.ports.iter()
+        let clk = c
+            .ports
+            .iter()
             .find(|p| matches!(&p.ty, TypeExpr::Clock(_)))
             .map(|p| p.name.name.clone())
             .unwrap_or_else(|| "clk".to_string());
@@ -52,7 +60,10 @@ impl<'a> Codegen<'a> {
 
         let mut all_ports: Vec<String> = Vec::new();
         for p in &c.ports {
-            let dir = match p.direction { Direction::In => "input", Direction::Out => "output" };
+            let dir = match p.direction {
+                Direction::In => "input",
+                Direction::Out => "output",
+            };
             let ty_str = self.emit_port_type_str(&p.ty);
             all_ports.push(format!("{dir} {ty_str} {}", p.name.name));
         }
@@ -180,5 +191,4 @@ impl<'a> Codegen<'a> {
         self.line("endmodule");
         self.line("");
     }
-
 }

--- a/src/codegen/clkgate.rs
+++ b/src/codegen/clkgate.rs
@@ -8,23 +8,45 @@ impl<'a> Codegen<'a> {
         let n = &c.name.name;
 
         // Find port names
-        let clk_in = c.ports.iter().find(|p| matches!(&p.ty, TypeExpr::Clock(_)) && p.direction == Direction::In)
-            .map(|p| p.name.name.as_str()).unwrap_or("clk_in");
-        let clk_out = c.ports.iter().find(|p| matches!(&p.ty, TypeExpr::Clock(_)) && p.direction == Direction::Out)
-            .map(|p| p.name.name.as_str()).unwrap_or("clk_out");
-        let enable = c.ports.iter().find(|p| p.name.name == "enable")
-            .map(|p| p.name.name.as_str()).unwrap_or("enable");
-        let test_en = c.ports.iter().find(|p| p.name.name == "test_en")
+        let clk_in = c
+            .ports
+            .iter()
+            .find(|p| matches!(&p.ty, TypeExpr::Clock(_)) && p.direction == Direction::In)
+            .map(|p| p.name.name.as_str())
+            .unwrap_or("clk_in");
+        let clk_out = c
+            .ports
+            .iter()
+            .find(|p| matches!(&p.ty, TypeExpr::Clock(_)) && p.direction == Direction::Out)
+            .map(|p| p.name.name.as_str())
+            .unwrap_or("clk_out");
+        let enable = c
+            .ports
+            .iter()
+            .find(|p| p.name.name == "enable")
+            .map(|p| p.name.name.as_str())
+            .unwrap_or("enable");
+        let test_en = c
+            .ports
+            .iter()
+            .find(|p| p.name.name == "test_en")
             .map(|p| p.name.name.as_str());
 
         // Module header
         self.line(&format!("module {n} ("));
         self.indent += 1;
-        let port_strs: Vec<String> = c.ports.iter().map(|p| {
-            let dir = match p.direction { Direction::In => "input", Direction::Out => "output" };
-            let ty = self.emit_port_type_str(&p.ty);
-            format!("{dir} {ty} {}", p.name.name)
-        }).collect();
+        let port_strs: Vec<String> = c
+            .ports
+            .iter()
+            .map(|p| {
+                let dir = match p.direction {
+                    Direction::In => "input",
+                    Direction::Out => "output",
+                };
+                let ty = self.emit_port_type_str(&p.ty);
+                format!("{dir} {ty} {}", p.name.name)
+            })
+            .collect();
         for (i, ps) in port_strs.iter().enumerate() {
             let comma = if i < port_strs.len() - 1 { "," } else { "" };
             self.line(&format!("{ps}{comma}"));
@@ -43,7 +65,9 @@ impl<'a> Codegen<'a> {
         match c.kind {
             crate::ast::ClkGateKind::Latch => {
                 self.line("logic en_latched;");
-                self.line(&format!("always_latch if (!{clk_in}) en_latched = {en_expr};"));
+                self.line(&format!(
+                    "always_latch if (!{clk_in}) en_latched = {en_expr};"
+                ));
                 self.line(&format!("assign {clk_out} = {clk_in} & en_latched;"));
             }
             crate::ast::ClkGateKind::And => {

--- a/src/codegen/counter.rs
+++ b/src/codegen/counter.rs
@@ -8,7 +8,7 @@ use super::*;
 
 impl<'a> Codegen<'a> {
     pub(crate) fn emit_counter(&mut self, c: &crate::ast::CounterDecl) {
-        use crate::ast::{CounterMode, CounterDirection};
+        use crate::ast::{CounterDirection, CounterMode};
 
         let n = &c.name.name.clone();
 
@@ -17,22 +17,26 @@ impl<'a> Codegen<'a> {
         // comparator. Callers tie it off to a constant for fixed-max counters
         // (synthesis folds it). When absent, the counter wraps at the natural
         // width bound (all-ones).
-        let max_port = c.ports.iter()
+        let max_port = c
+            .ports
+            .iter()
             .find(|p| p.name.name == "max" && matches!(p.direction, Direction::In))
             .map(|_| "max".to_string());
 
         // Determine counter width
         // Use MAX param if present, else look for WIDTH
-        let width_param = c.params.iter()
+        let width_param = c
+            .params
+            .iter()
             .find(|p| p.name.name == "WIDTH")
             .and_then(|p| p.default.as_ref())
             .map(|e| self.emit_expr_str(e));
 
         // Find ports to determine direction
-        let has_inc  = c.ports.iter().any(|p| p.name.name == "inc");
-        let has_dec  = c.ports.iter().any(|p| p.name.name == "dec");
+        let has_inc = c.ports.iter().any(|p| p.name.name == "inc");
+        let has_dec = c.ports.iter().any(|p| p.name.name == "dec");
         let has_load = c.ports.iter().any(|p| p.name.name == "load");
-        let has_clear= c.ports.iter().any(|p| p.name.name == "clear");
+        let has_clear = c.ports.iter().any(|p| p.name.name == "clear");
         let value_port = c.ports.iter().find(|p| p.name.name == "value");
 
         // Compute width from value port type or fallback
@@ -45,7 +49,9 @@ impl<'a> Codegen<'a> {
             width_param.clone().unwrap_or_else(|| "8".to_string())
         };
 
-        let clk = c.ports.iter()
+        let clk = c
+            .ports
+            .iter()
             .find(|p| matches!(&p.ty, TypeExpr::Clock(_)))
             .map(|p| p.name.name.clone())
             .unwrap_or_else(|| "clk".to_string());
@@ -59,10 +65,15 @@ impl<'a> Codegen<'a> {
             self.indent += 1;
             for (i, p) in c.params.iter().enumerate() {
                 let comma = if i < c.params.len() - 1 { "," } else { "" };
-                let default_str = p.default.as_ref()
+                let default_str = p
+                    .default
+                    .as_ref()
                     .map(|e| format!(" = {}", self.emit_expr_str(e)))
                     .unwrap_or_default();
-                self.line(&format!("parameter int {}{default_str}{comma}", p.name.name));
+                self.line(&format!(
+                    "parameter int {}{default_str}{comma}",
+                    p.name.name
+                ));
             }
             self.indent -= 1;
             self.line(") (");
@@ -71,7 +82,10 @@ impl<'a> Codegen<'a> {
 
         let mut all_ports: Vec<String> = Vec::new();
         for p in &c.ports {
-            let dir = match p.direction { Direction::In => "input", Direction::Out => "output" };
+            let dir = match p.direction {
+                Direction::In => "input",
+                Direction::Out => "output",
+            };
             let ty_str = self.emit_port_type_str(&p.ty);
             all_ports.push(format!("{dir} {ty_str} {}", p.name.name));
         }
@@ -85,12 +99,17 @@ impl<'a> Codegen<'a> {
         self.line("");
         self.indent += 1;
 
-        let init_val = c.init.as_ref()
+        let init_val = c
+            .init
+            .as_ref()
             .map(|e| self.emit_expr_str(e))
             .unwrap_or_else(|| "'0".to_string());
 
         // ── Internal register ─────────────────────────────────────────────────
-        self.line(&format!("logic [{}] count_r;", Self::fold_width_str(&count_width)));
+        self.line(&format!(
+            "logic [{}] count_r;",
+            Self::fold_width_str(&count_width)
+        ));
 
         // ── Determine FF sensitivity list ─────────────────────────────────────
         let ff_sens = Self::ff_sensitivity(&clk, &rst, is_async, is_low);
@@ -115,9 +134,13 @@ impl<'a> Codegen<'a> {
                 let max_cond = if let Some(mp) = &max_port {
                     format!("count_r == {mp}")
                 } else {
-                    format!("&count_r")  // all bits set
+                    format!("&count_r") // all bits set
                 };
-                let inc_cond = if has_inc { "else if (inc) begin" } else { "else begin" };
+                let inc_cond = if has_inc {
+                    "else if (inc) begin"
+                } else {
+                    "else begin"
+                };
                 self.line(inc_cond);
                 self.indent += 1;
                 self.line(&format!("if ({max_cond}) count_r <= {init_val};"));
@@ -132,7 +155,11 @@ impl<'a> Codegen<'a> {
                 } else {
                     format!("'1")
                 };
-                let dec_cond = if has_dec { "else if (dec) begin" } else { "else begin" };
+                let dec_cond = if has_dec {
+                    "else if (dec) begin"
+                } else {
+                    "else begin"
+                };
                 self.line(dec_cond);
                 self.indent += 1;
                 self.line(&format!("if ({min_cond}) count_r <= {max_val};"));
@@ -150,7 +177,11 @@ impl<'a> Codegen<'a> {
                 } else {
                     format!("!(&count_r)")
                 };
-                let inc_cond = if has_inc { "else if (inc) begin" } else { "else begin" };
+                let inc_cond = if has_inc {
+                    "else if (inc) begin"
+                } else {
+                    "else begin"
+                };
                 self.line(inc_cond);
                 self.indent += 1;
                 self.line(&format!("if ({max_cond}) count_r <= count_r + 1;"));
@@ -158,7 +189,11 @@ impl<'a> Codegen<'a> {
                 self.line("end");
             }
             (CounterDirection::Down, CounterMode::Saturate) => {
-                let dec_cond = if has_dec { "else if (dec) begin" } else { "else begin" };
+                let dec_cond = if has_dec {
+                    "else if (dec) begin"
+                } else {
+                    "else begin"
+                };
                 self.line(dec_cond);
                 self.indent += 1;
                 self.line("if (count_r > '0) count_r <= count_r - 1;");
@@ -174,18 +209,30 @@ impl<'a> Codegen<'a> {
                 self.line("end");
             }
             (CounterDirection::Up, CounterMode::OneHot) => {
-                let inc_cond = if has_inc { "else if (inc) begin" } else { "else begin" };
+                let inc_cond = if has_inc {
+                    "else if (inc) begin"
+                } else {
+                    "else begin"
+                };
                 self.line(inc_cond);
                 self.indent += 1;
-                self.line(&format!("count_r <= {{count_r[{count_width}-2:0], count_r[{count_width}-1]}};"));
+                self.line(&format!(
+                    "count_r <= {{count_r[{count_width}-2:0], count_r[{count_width}-1]}};"
+                ));
                 self.indent -= 1;
                 self.line("end");
             }
             (CounterDirection::Up, CounterMode::Johnson) => {
-                let inc_cond = if has_inc { "else if (inc) begin" } else { "else begin" };
+                let inc_cond = if has_inc {
+                    "else if (inc) begin"
+                } else {
+                    "else begin"
+                };
                 self.line(inc_cond);
                 self.indent += 1;
-                self.line(&format!("count_r <= {{~count_r[0], count_r[{count_width}-1:1]}};"));
+                self.line(&format!(
+                    "count_r <= {{~count_r[0], count_r[{count_width}-1:1]}};"
+                ));
                 self.indent -= 1;
                 self.line("end");
             }
@@ -233,8 +280,12 @@ impl<'a> Codegen<'a> {
         }
 
         if !c.asserts.is_empty() {
-            let clk = c.ports.iter().find(|p| matches!(&p.ty, TypeExpr::Clock(_)))
-                .map(|p| p.name.name.clone()).unwrap_or_else(|| "clk".to_string());
+            let clk = c
+                .ports
+                .iter()
+                .find(|p| matches!(&p.ty, TypeExpr::Clock(_)))
+                .map(|p| p.name.name.clone())
+                .unwrap_or_else(|| "clk".to_string());
             self.line("");
             let asserts = c.asserts.clone();
             let cname = c.name.name.clone();
@@ -249,5 +300,4 @@ impl<'a> Codegen<'a> {
     }
 
     // ── Arbiter ───────────────────────────────────────────────────────────────
-
 }

--- a/src/codegen/fifo.rs
+++ b/src/codegen/fifo.rs
@@ -12,17 +12,23 @@ impl<'a> Codegen<'a> {
         let is_async = detect_async_fifo(&f.ports);
 
         // Resolve DEPTH and TYPE from params
-        let depth_expr = f.params.iter()
+        let depth_expr = f
+            .params
+            .iter()
             .find(|p| p.name.name == "DEPTH")
             .and_then(|p| p.default.as_ref())
             .map(|e| self.emit_expr_str(e))
             .unwrap_or_else(|| "16".to_string());
 
         // Find the type parameter (any name) and compute its bit-width for DATA_WIDTH
-        let type_param_name = f.params.iter()
+        let type_param_name = f
+            .params
+            .iter()
             .find(|p| matches!(p.kind, crate::ast::ParamKind::Type(_)))
             .map(|p| p.name.name.clone());
-        let data_width_str = f.params.iter()
+        let data_width_str = f
+            .params
+            .iter()
             .find(|p| matches!(p.kind, crate::ast::ParamKind::Type(_)))
             .and_then(|p| match &p.kind {
                 crate::ast::ParamKind::Type(ty) => self.type_expr_data_width(ty),
@@ -31,7 +37,9 @@ impl<'a> Codegen<'a> {
             .unwrap_or_else(|| "8".to_string());
 
         // Check for OVERFLOW param (0 = block when full, 1 = overwrite oldest)
-        let overflow_expr = f.params.iter()
+        let overflow_expr = f
+            .params
+            .iter()
             .find(|p| p.name.name == "OVERFLOW")
             .and_then(|p| p.default.as_ref())
             .map(|e| self.emit_expr_str(e))
@@ -57,7 +65,10 @@ impl<'a> Codegen<'a> {
 
         // Emit declared ports
         for (i, p) in f.ports.iter().enumerate() {
-            let dir = match p.direction { Direction::In => "input", Direction::Out => "output" };
+            let dir = match p.direction {
+                Direction::In => "input",
+                Direction::Out => "output",
+            };
             // Type param references → use DATA_WIDTH
             let ty_str = self.emit_fifo_port_type(&p.ty, &type_param_name);
             let comma = if i < f.ports.len() - 1 { "," } else { "" };
@@ -78,11 +89,16 @@ impl<'a> Codegen<'a> {
 
         // Auto-generated safety assertions for FIFO invariants
         {
-            let clk_names: Vec<String> = f.ports.iter()
+            let clk_names: Vec<String> = f
+                .ports
+                .iter()
                 .filter(|p| matches!(&p.ty, TypeExpr::Clock(_)))
                 .map(|p| p.name.name.clone())
                 .collect();
-            let clk = clk_names.first().cloned().unwrap_or_else(|| "clk".to_string());
+            let clk = clk_names
+                .first()
+                .cloned()
+                .unwrap_or_else(|| "clk".to_string());
             let n = &f.name.name;
 
             self.line("");
@@ -143,8 +159,12 @@ impl<'a> Codegen<'a> {
         }
 
         if !f.asserts.is_empty() {
-            let clk = f.ports.iter().find(|p| matches!(&p.ty, TypeExpr::Clock(_)))
-                .map(|p| p.name.name.clone()).unwrap_or_else(|| "clk".to_string());
+            let clk = f
+                .ports
+                .iter()
+                .find(|p| matches!(&p.ty, TypeExpr::Clock(_)))
+                .map(|p| p.name.name.clone())
+                .unwrap_or_else(|| "clk".to_string());
             self.line("");
             let asserts = f.asserts.clone();
             let fname = f.name.name.clone();
@@ -198,7 +218,9 @@ impl<'a> Codegen<'a> {
 
         // Determine reset port info
         let (rst, is_async, is_low) = Self::extract_reset_info(&f.ports);
-        let clk = f.ports.iter()
+        let clk = f
+            .ports
+            .iter()
             .find(|p| matches!(&p.ty, TypeExpr::Clock(_)))
             .map(|p| p.name.name.as_str())
             .unwrap_or("clk");
@@ -262,7 +284,9 @@ impl<'a> Codegen<'a> {
         self.line("");
 
         let (rst, is_async, is_low) = Self::extract_reset_info(&f.ports);
-        let clk = f.ports.iter()
+        let clk = f
+            .ports
+            .iter()
             .find(|p| matches!(&p.ty, TypeExpr::Clock(_)))
             .map(|p| p.name.name.as_str())
             .unwrap_or("clk");
@@ -298,13 +322,26 @@ impl<'a> Codegen<'a> {
         self.line("end");
     }
 
-    fn emit_fifo_async_body(&mut self, f: &FifoDecl, port_names: &[&str], has_overflow_param: bool) {
+    fn emit_fifo_async_body(
+        &mut self,
+        f: &FifoDecl,
+        port_names: &[&str],
+        has_overflow_param: bool,
+    ) {
         // Find wr_clk, rd_clk, rst port names
-        let clock_ports: Vec<&PortDecl> = f.ports.iter()
+        let clock_ports: Vec<&PortDecl> = f
+            .ports
+            .iter()
             .filter(|p| matches!(&p.ty, TypeExpr::Clock(_)))
             .collect();
-        let wr_clk = clock_ports.get(0).map(|p| p.name.name.as_str()).unwrap_or("wr_clk");
-        let rd_clk = clock_ports.get(1).map(|p| p.name.name.as_str()).unwrap_or("rd_clk");
+        let wr_clk = clock_ports
+            .get(0)
+            .map(|p| p.name.name.as_str())
+            .unwrap_or("wr_clk");
+        let rd_clk = clock_ports
+            .get(1)
+            .map(|p| p.name.name.as_str())
+            .unwrap_or("rd_clk");
         let (rst, _is_async_rst, is_low) = Self::extract_reset_info(&f.ports);
         // Async FIFOs always use async reset (reset in sensitivity list for all FF blocks)
         let rst_cond = Self::rst_condition(&rst, is_low);
@@ -338,17 +375,29 @@ impl<'a> Codegen<'a> {
         self.line("assign rd_ptr_gray = bin2gray(rd_ptr_bin);");
         self.line("");
         self.line(&format!("// Sync wr_ptr into rd domain ({rd_clk})"));
-        self.line(&format!("always_ff @(posedge {rd_clk} or {rst_edge} {rst}) begin"));
+        self.line(&format!(
+            "always_ff @(posedge {rd_clk} or {rst_edge} {rst}) begin"
+        ));
         self.indent += 1;
-        self.line(&format!("if ({rst_cond}) begin wr_ptr_gray_s1 <= '0; wr_ptr_gray_sync <= '0; end"));
-        self.line("else begin wr_ptr_gray_s1 <= wr_ptr_gray; wr_ptr_gray_sync <= wr_ptr_gray_s1; end");
+        self.line(&format!(
+            "if ({rst_cond}) begin wr_ptr_gray_s1 <= '0; wr_ptr_gray_sync <= '0; end"
+        ));
+        self.line(
+            "else begin wr_ptr_gray_s1 <= wr_ptr_gray; wr_ptr_gray_sync <= wr_ptr_gray_s1; end",
+        );
         self.indent -= 1;
         self.line("end");
         self.line(&format!("// Sync rd_ptr into wr domain ({wr_clk})"));
-        self.line(&format!("always_ff @(posedge {wr_clk} or {rst_edge} {rst}) begin"));
+        self.line(&format!(
+            "always_ff @(posedge {wr_clk} or {rst_edge} {rst}) begin"
+        ));
         self.indent += 1;
-        self.line(&format!("if ({rst_cond}) begin rd_ptr_gray_s1 <= '0; rd_ptr_gray_sync <= '0; end"));
-        self.line("else begin rd_ptr_gray_s1 <= rd_ptr_gray; rd_ptr_gray_sync <= rd_ptr_gray_s1; end");
+        self.line(&format!(
+            "if ({rst_cond}) begin rd_ptr_gray_s1 <= '0; rd_ptr_gray_sync <= '0; end"
+        ));
+        self.line(
+            "else begin rd_ptr_gray_s1 <= rd_ptr_gray; rd_ptr_gray_sync <= rd_ptr_gray_s1; end",
+        );
         self.indent -= 1;
         self.line("end");
         self.line("");
@@ -363,7 +412,9 @@ impl<'a> Codegen<'a> {
         } else {
             self.line("assign push_ready = !full_r;");
         }
-        self.line(&format!("always_ff @(posedge {wr_clk} or {rst_edge} {rst}) begin"));
+        self.line(&format!(
+            "always_ff @(posedge {wr_clk} or {rst_edge} {rst}) begin"
+        ));
         self.indent += 1;
         self.line(&format!("if ({rst_cond}) wr_ptr_bin <= '0;"));
         self.line("else if (push_valid && push_ready) begin");
@@ -388,12 +439,13 @@ impl<'a> Codegen<'a> {
         if port_names.contains(&"empty") {
             self.line("assign empty = empty_r;");
         }
-        self.line(&format!("always_ff @(posedge {rd_clk} or {rst_edge} {rst}) begin"));
+        self.line(&format!(
+            "always_ff @(posedge {rd_clk} or {rst_edge} {rst}) begin"
+        ));
         self.indent += 1;
         self.line(&format!("if ({rst_cond}) rd_ptr_bin <= '0;"));
         self.line("else if (pop_valid && pop_ready) rd_ptr_bin <= rd_ptr_bin + 1;");
         self.indent -= 1;
         self.line("end");
     }
-
 }

--- a/src/codegen/fp.rs
+++ b/src/codegen/fp.rs
@@ -20,6 +20,8 @@ pub(super) fn fp_sv_helpers(profile: FpCompat) -> String {
          // shared bit-vector IR (the same source emits the SMT-LIB equivalence\n\
          // model; see doc/plan_fp_types.md §8). Do not edit by hand. ──\n",
     );
-    s.push_str(&crate::fp_ir::render_sv(&crate::fp_ops::fp_functions(profile)));
+    s.push_str(&crate::fp_ir::render_sv(&crate::fp_ops::fp_functions(
+        profile,
+    )));
     s
 }

--- a/src/codegen/fsm.rs
+++ b/src/codegen/fsm.rs
@@ -28,12 +28,15 @@ impl<'a> Codegen<'a> {
         // that `use IbexPkg;` for shared `ExcCause` / `Irqs` types.)
         for item in &self.source.items {
             if let Item::Use(u) = item {
-                let is_package = self.source.items.iter().any(|i| {
-                    matches!(i, Item::Package(p) if p.name.name == u.name.name)
-                });
-                let is_extern = self.source.items.iter().any(|i| {
-                    matches!(i, Item::ExternPackage(ep) if ep.name.name == u.name.name)
-                });
+                let is_package = self
+                    .source
+                    .items
+                    .iter()
+                    .any(|i| matches!(i, Item::Package(p) if p.name.name == u.name.name));
+                let is_extern =
+                    self.source.items.iter().any(
+                        |i| matches!(i, Item::ExternPackage(ep) if ep.name.name == u.name.name),
+                    );
                 if is_package || is_extern {
                     self.out.push_str(&format!("import {}::*;\n", u.name.name));
                 }
@@ -43,7 +46,8 @@ impl<'a> Codegen<'a> {
         // encoded state register. SV emission lowers to `state_r` (the enum
         // register), which implicitly casts to the user-declared output port
         // width. Cleared at the end of emit_fsm.
-        self.ident_subst.insert("state".to_string(), "state_r".to_string());
+        self.ident_subst
+            .insert("state".to_string(), "state_r".to_string());
         let n = f.name.name.clone();
         let n_states = f.state_names.len();
         let state_bits = enum_width(n_states);
@@ -68,8 +72,12 @@ impl<'a> Codegen<'a> {
             if let Some(ref bi) = p.bus_info {
                 let bus_name = &bi.bus_name.name;
                 self.bus_ports.insert(p.name.name.clone(), bus_name.clone());
-                if let Some((crate::resolve::Symbol::Bus(info), _)) = self.symbols.globals.get(bus_name) {
-                    let mut param_map: std::collections::HashMap<String, &Expr> = info.params.iter()
+                if let Some((crate::resolve::Symbol::Bus(info), _)) =
+                    self.symbols.globals.get(bus_name)
+                {
+                    let mut param_map: std::collections::HashMap<String, &Expr> = info
+                        .params
+                        .iter()
                         .filter_map(|pd| pd.default.as_ref().map(|d| (pd.name.name.clone(), d)))
                         .collect();
                     for pa in &bi.params {
@@ -87,11 +95,15 @@ impl<'a> Codegen<'a> {
                         };
                         let subst_ty = Self::subst_type_expr(sty, &param_map);
                         let ty_str = self.emit_port_type_str(&subst_ty);
-                        port_lines.push(format!("{} {} {}_{}", dir_str, ty_str, p.name.name, sname));
+                        port_lines
+                            .push(format!("{} {} {}_{}", dir_str, ty_str, p.name.name, sname));
                     }
                 }
             } else {
-                let dir = match p.direction { Direction::In => "input", Direction::Out => "output" };
+                let dir = match p.direction {
+                    Direction::In => "input",
+                    Direction::Out => "output",
+                };
                 if let TypeExpr::Vec(_, _) = &p.ty {
                     let (base_ty, suffix) = self.emit_type_and_array_suffix(&p.ty);
                     port_lines.push(format!("{dir} {base_ty} {}{suffix}", p.name.name));
@@ -112,11 +124,17 @@ impl<'a> Codegen<'a> {
         self.indent += 1;
 
         // ── State type ───────────────────────────────────────────────────────
-        self.line(&format!("typedef enum logic [{}:0] {{", state_bits.saturating_sub(1)));
+        self.line(&format!(
+            "typedef enum logic [{}:0] {{",
+            state_bits.saturating_sub(1)
+        ));
         self.indent += 1;
         for (i, sn) in f.state_names.iter().enumerate() {
             let comma = if i < f.state_names.len() - 1 { "," } else { "" };
-            self.line(&format!("{} = {state_bits}'d{i}{comma}", sn.name.to_uppercase()));
+            self.line(&format!(
+                "{} = {state_bits}'d{i}{comma}",
+                sn.name.to_uppercase()
+            ));
         }
         self.indent -= 1;
         self.line(&format!("}} {n}_state_t;"));
@@ -180,15 +198,19 @@ impl<'a> Codegen<'a> {
         // `default_state` is `Some(_)` here because codegen only runs for
         // non-interface fsms (interface stubs are filtered out earlier);
         // resolve.rs already errored on the `None` case for real fsms.
-        let default_state_name = f.default_state.as_ref()
+        let default_state_name = f
+            .default_state
+            .as_ref()
             .expect("codegen: fsm without default_state — should have been rejected by resolve")
             .name
             .clone();
-        self.line(&format!("state_r <= {};", default_state_name.to_uppercase()));
+        self.line(&format!(
+            "state_r <= {};",
+            default_state_name.to_uppercase()
+        ));
         // Reset datapath registers
         for reg in &f.regs {
-            let reset_expr = Self::reset_value_expr(&reg.reset)
-                .or(reg.init.as_ref());
+            let reset_expr = Self::reset_value_expr(&reg.reset).or(reg.init.as_ref());
             if let Some(val_expr) = reset_expr {
                 let init_str = self.emit_expr_str(val_expr);
                 if let TypeExpr::Vec(_, size_expr) = &reg.ty {
@@ -207,8 +229,7 @@ impl<'a> Codegen<'a> {
         // Reset port-reg outputs (ports with reg_info)
         for p in &f.ports {
             if let Some(ri) = &p.reg_info {
-                let reset_expr = Self::reset_value_expr(&ri.reset)
-                    .or(ri.init.as_ref());
+                let reset_expr = Self::reset_value_expr(&ri.reset).or(ri.init.as_ref());
                 if let Some(val_expr) = reset_expr {
                     let init_str = self.emit_expr_str(val_expr);
                     self.line(&format!("{} <= {init_str};", p.name.name));
@@ -226,10 +247,10 @@ impl<'a> Codegen<'a> {
         // Per-state sequential logic
         if has_seq || !f.default_seq.is_empty() {
             // `unique case`: state_r is one-hot by construction (single FSM
-// state register), so all arms are mutually exclusive. Tells
-// yosys-slang to synthesize a parallel mux instead of a priority
-// encoder.
-self.line("unique case (state_r)");
+            // state register), so all arms are mutually exclusive. Tells
+            // yosys-slang to synthesize a parallel mux instead of a priority
+            // encoder.
+            self.line("unique case (state_r)");
             self.indent += 1;
             for sb in &f.states {
                 if sb.seq_stmts.is_empty() {
@@ -258,36 +279,44 @@ self.line("unique case (state_r)");
         self.indent += 1;
         self.line("state_next = state_r; // hold by default");
         // `unique case`: state_r is one-hot by construction (single FSM
-// state register), so all arms are mutually exclusive. Tells
-// yosys-slang to synthesize a parallel mux instead of a priority
-// encoder.
-self.line("unique case (state_r)");
+        // state register), so all arms are mutually exclusive. Tells
+        // yosys-slang to synthesize a parallel mux instead of a priority
+        // encoder.
+        self.line("unique case (state_r)");
         self.indent += 1;
         for sb in &f.states {
             self.line(&format!("{}: begin", sb.name.name.to_uppercase()));
             self.indent += 1;
-            let cond_strs: Vec<String> = sb.transitions.iter()
+            let cond_strs: Vec<String> = sb
+                .transitions
+                .iter()
                 .map(|tr| self.emit_expr_str(&tr.condition))
                 .collect();
             // Single unconditional transition — emit plain assignment.
             if cond_strs.len() == 1 && (cond_strs[0] == "1'b1" || cond_strs[0] == "1") {
-                self.line(&format!("state_next = {};",
-                    sb.transitions[0].target.name.to_uppercase()));
+                self.line(&format!(
+                    "state_next = {};",
+                    sb.transitions[0].target.name.to_uppercase()
+                ));
             } else {
                 for (i, tr) in sb.transitions.iter().enumerate() {
                     let is_true = cond_strs[i] == "1'b1" || cond_strs[i] == "1";
                     if i == 0 && is_true {
                         // First and unconditional — plain assignment
-                        self.line(&format!("state_next = {};",
-                            tr.target.name.to_uppercase()));
+                        self.line(&format!("state_next = {};", tr.target.name.to_uppercase()));
                     } else if i > 0 && is_true {
                         // Last catch-all — emit as else
-                        self.line(&format!("else state_next = {};",
-                            tr.target.name.to_uppercase()));
+                        self.line(&format!(
+                            "else state_next = {};",
+                            tr.target.name.to_uppercase()
+                        ));
                     } else {
                         let kw = if i == 0 { "if" } else { "else if" };
-                        self.line(&format!("{kw} ({}) state_next = {};",
-                            cond_strs[i], tr.target.name.to_uppercase()));
+                        self.line(&format!(
+                            "{kw} ({}) state_next = {};",
+                            cond_strs[i],
+                            tr.target.name.to_uppercase()
+                        ));
                     }
                 }
             }
@@ -303,10 +332,13 @@ self.line("unique case (state_r)");
 
         // ── Output logic ─────────────────────────────────────────────────────
         // Emit default zeros for all outputs
-        let out_ports: Vec<&PortDecl> = f.ports.iter()
+        let out_ports: Vec<&PortDecl> = f
+            .ports
+            .iter()
             .filter(|p| p.direction == Direction::Out)
             .collect();
-        let has_comb = !out_ports.is_empty() || !f.default_comb.is_empty()
+        let has_comb = !out_ports.is_empty()
+            || !f.default_comb.is_empty()
             || f.states.iter().any(|s| !s.comb_stmts.is_empty());
         if has_comb {
             self.line("always_comb begin");
@@ -315,8 +347,12 @@ self.line("unique case (state_r)");
             // before the case so any state that doesn't assign the port
             // still produces the declared default instead of latching.
             for p in &f.ports {
-                if p.direction != Direction::Out { continue; }
-                if p.reg_info.is_some() { continue; }
+                if p.direction != Direction::Out {
+                    continue;
+                }
+                if p.reg_info.is_some() {
+                    continue;
+                }
                 if let Some(def) = &p.default {
                     let val = self.emit_expr_str(def);
                     self.line(&format!("{} = {};", p.name.name, val));
@@ -327,10 +363,10 @@ self.line("unique case (state_r)");
                 self.emit_comb_stmt(stmt);
             }
             // `unique case`: state_r is one-hot by construction (single FSM
-// state register), so all arms are mutually exclusive. Tells
-// yosys-slang to synthesize a parallel mux instead of a priority
-// encoder.
-self.line("unique case (state_r)");
+            // state register), so all arms are mutually exclusive. Tells
+            // yosys-slang to synthesize a parallel mux instead of a priority
+            // encoder.
+            self.line("unique case (state_r)");
             self.indent += 1;
             for sb in &f.states {
                 self.line(&format!("{}: begin", sb.name.name.to_uppercase()));
@@ -351,9 +387,15 @@ self.line("unique case (state_r)");
         // Auto-generated FSM safety assertions and coverage
         {
             let clk_port = f.ports.iter().find(|p| matches!(&p.ty, TypeExpr::Clock(_)));
-            let clk = clk_port.map(|p| p.name.name.clone()).unwrap_or_else(|| "clk".to_string());
+            let clk = clk_port
+                .map(|p| p.name.name.clone())
+                .unwrap_or_else(|| "clk".to_string());
             let (rst_name, _, is_low) = Self::extract_reset_info(&f.ports);
-            let rst_inactive = if is_low { rst_name.clone() } else { format!("!{rst_name}") };
+            let rst_inactive = if is_low {
+                rst_name.clone()
+            } else {
+                format!("!{rst_name}")
+            };
             let n = &f.name.name;
             let n_states = f.state_names.len();
             self.line("");
@@ -390,14 +432,19 @@ self.line("unique case (state_r)");
             // Cover: each declared transition can fire
             // Use a counter to disambiguate duplicate src→tgt transitions
             {
-                let mut tr_counts: std::collections::HashMap<(String, String), usize> = std::collections::HashMap::new();
+                let mut tr_counts: std::collections::HashMap<(String, String), usize> =
+                    std::collections::HashMap::new();
                 for sb in &f.states {
                     let src = sb.name.name.to_uppercase();
                     for tr in &sb.transitions {
                         let tgt = tr.target.name.to_uppercase();
                         let key = (src.clone(), tgt.clone());
                         let count = tr_counts.entry(key).or_insert(0);
-                        let suffix = if *count > 0 { format!("_{count}") } else { String::new() };
+                        let suffix = if *count > 0 {
+                            format!("_{count}")
+                        } else {
+                            String::new()
+                        };
                         *count += 1;
                         self.line(&format!(
                             "_auto_tr_{src}_to_{tgt}{suffix}: cover property (@(posedge {clk}) state_r == {src} && state_next == {tgt});",
@@ -412,7 +459,9 @@ self.line("unique case (state_r)");
         // ── Assert / cover SVA ───────────────────────────────────────────────
         if !f.asserts.is_empty() {
             let clk_port = f.ports.iter().find(|p| matches!(&p.ty, TypeExpr::Clock(_)));
-            let clk = clk_port.map(|p| p.name.name.clone()).unwrap_or_else(|| "clk".to_string());
+            let clk = clk_port
+                .map(|p| p.name.name.clone())
+                .unwrap_or_else(|| "clk".to_string());
             self.line("");
             let asserts = f.asserts.clone();
             let fname = f.name.name.clone();
@@ -428,5 +477,4 @@ self.line("unique case (state_r)");
     }
 
     // ── Pipeline ──────────────────────────────────────────────────────────────
-
 }

--- a/src/codegen/linklist.rs
+++ b/src/codegen/linklist.rs
@@ -11,7 +11,10 @@ impl<'a> Codegen<'a> {
         use crate::ast::LinklistKind;
         let n = &l.name.name;
         let is_doubly = matches!(l.kind, LinklistKind::Doubly | LinklistKind::CircularDoubly);
-        let is_circular = matches!(l.kind, LinklistKind::CircularSingly | LinklistKind::CircularDoubly);
+        let is_circular = matches!(
+            l.kind,
+            LinklistKind::CircularSingly | LinklistKind::CircularDoubly
+        );
 
         // Multi-head linklist support. NUM_HEADS defaults to 1; when set
         // to N > 1, the head / tail / length registers become arrays
@@ -19,20 +22,26 @@ impl<'a> Codegen<'a> {
         // The node pool and free list stay shared across all heads.
         let num_heads = crate::typecheck::linklist_num_heads(l);
         let multi_head = num_heads > 1;
-        let num_heads_expr = l.params.iter()
+        let num_heads_expr = l
+            .params
+            .iter()
             .find(|p| p.name.name == "NUM_HEADS")
             .and_then(|p| p.default.as_ref())
             .map(|e| self.emit_expr_str(e))
             .unwrap_or_else(|| "1".to_string());
 
         // Resolve DEPTH default expression and DATA SV type
-        let depth_expr = l.params.iter()
+        let depth_expr = l
+            .params
+            .iter()
             .find(|p| p.name.name == "DEPTH")
             .and_then(|p| p.default.as_ref())
             .map(|e| self.emit_expr_str(e))
             .unwrap_or_else(|| "16".to_string());
 
-        let data_default_sv = l.params.iter()
+        let data_default_sv = l
+            .params
+            .iter()
             .find(|p| p.name.name == "DATA")
             .and_then(|p| match &p.kind {
                 crate::ast::ParamKind::Type(ty) => Some(self.emit_port_type_str(ty)),
@@ -43,17 +52,23 @@ impl<'a> Codegen<'a> {
         // Operations that touch a specific head (need `req_head_idx` when
         // multi-head). Shared-pool ops (alloc, free) and slot-addressed
         // ops (read_data, write_data, next, prev) don't.
-        let head_addressed_op = |name: &str| matches!(
-            name,
-            "insert_head" | "insert_tail" | "insert_after" | "delete_head" | "delete"
-        );
+        let head_addressed_op = |name: &str| {
+            matches!(
+                name,
+                "insert_head" | "insert_tail" | "insert_after" | "delete_head" | "delete"
+            )
+        };
 
         // Find clk/rst port names
-        let clk_name = l.ports.iter()
+        let clk_name = l
+            .ports
+            .iter()
             .find(|p| matches!(&p.ty, crate::ast::TypeExpr::Clock(_)))
             .map(|p| p.name.name.as_str())
             .unwrap_or("clk");
-        let rst_name = l.ports.iter()
+        let rst_name = l
+            .ports
+            .iter()
             .find(|p| matches!(&p.ty, crate::ast::TypeExpr::Reset(_, _)))
             .map(|p| p.name.name.as_str())
             .unwrap_or("rst");
@@ -76,21 +91,34 @@ impl<'a> Codegen<'a> {
 
         // Op ports — one group per declared op
         let all_ops = &l.ops;
-        let status_ports: Vec<&crate::ast::PortDecl> = l.ports.iter()
-            .filter(|p| !matches!(&p.ty, crate::ast::TypeExpr::Clock(_) | crate::ast::TypeExpr::Reset(_, _)))
+        let status_ports: Vec<&crate::ast::PortDecl> = l
+            .ports
+            .iter()
+            .filter(|p| {
+                !matches!(
+                    &p.ty,
+                    crate::ast::TypeExpr::Clock(_) | crate::ast::TypeExpr::Reset(_, _)
+                )
+            })
             .collect();
 
         // Collect all port lines then emit with trailing comma logic
         let mut port_lines: Vec<String> = Vec::new();
         for op in all_ops {
             for p in &op.ports {
-                let dir = match p.direction { Direction::In => "input ", Direction::Out => "output" };
+                let dir = match p.direction {
+                    Direction::In => "input ",
+                    Direction::Out => "output",
+                };
                 let ty_str = self.emit_ll_port_type(&p.ty);
                 port_lines.push(format!("{dir} {ty_str} {}_{}", op.name.name, p.name.name));
             }
         }
         for p in &status_ports {
-            let dir = match p.direction { Direction::In => "input ", Direction::Out => "output" };
+            let dir = match p.direction {
+                Direction::In => "input ",
+                Direction::Out => "output",
+            };
             let ty_str = self.emit_ll_port_type(&p.ty);
             port_lines.push(format!("{dir} {ty_str} {}", p.name.name));
         }
@@ -162,7 +190,11 @@ impl<'a> Codegen<'a> {
                 self.line(&format!("logic _ctrl_{on}_resp_v;"));
             }
             // latch any output data ports
-            for p in op.ports.iter().filter(|p| p.direction == Direction::Out && p.name.name != "req_ready" && p.name.name != "resp_valid") {
+            for p in op.ports.iter().filter(|p| {
+                p.direction == Direction::Out
+                    && p.name.name != "req_ready"
+                    && p.name.name != "resp_valid"
+            }) {
                 let ty = self.emit_ll_port_type(&p.ty);
                 self.line(&format!("{ty} _ctrl_{on}_{};", p.name.name));
             }
@@ -239,8 +271,15 @@ impl<'a> Codegen<'a> {
                 self.line(&format!("assign {on}_resp_valid = _ctrl_{on}_resp_v;"));
             }
             // wire other output data ports
-            for p in op.ports.iter().filter(|p| p.direction == Direction::Out && p.name.name != "req_ready" && p.name.name != "resp_valid") {
-                self.line(&format!("assign {}_{} = _ctrl_{on}_{};", on, p.name.name, p.name.name));
+            for p in op.ports.iter().filter(|p| {
+                p.direction == Direction::Out
+                    && p.name.name != "req_ready"
+                    && p.name.name != "resp_valid"
+            }) {
+                self.line(&format!(
+                    "assign {}_{} = _ctrl_{on}_{};",
+                    on, p.name.name, p.name.name
+                ));
             }
         }
         self.line("");
@@ -262,17 +301,23 @@ impl<'a> Codegen<'a> {
             self.line("for (_ll_i = 0; _ll_i < NUM_HEADS; _ll_i++) begin");
             self.indent += 1;
             self.line("_head_r[_ll_i] <= '0;");
-            if l.track_tail { self.line("_tail_r[_ll_i] <= '0;"); }
+            if l.track_tail {
+                self.line("_tail_r[_ll_i] <= '0;");
+            }
             self.line("_length_r[_ll_i] <= '0;");
             self.indent -= 1;
             self.line("end");
         } else {
             self.line("_head_r <= '0;");
-            if l.track_tail { self.line("_tail_r <= '0;"); }
+            if l.track_tail {
+                self.line("_tail_r <= '0;");
+            }
         }
         for op in all_ops {
             let on = &op.name.name;
-            if op.latency > 1 { self.line(&format!("_ctrl_{on}_busy <= 1'b0;")); }
+            if op.latency > 1 {
+                self.line(&format!("_ctrl_{on}_busy <= 1'b0;"));
+            }
             if op.ports.iter().any(|p| p.name.name == "resp_valid") {
                 self.line(&format!("_ctrl_{on}_resp_v <= 1'b0;"));
             }
@@ -301,8 +346,12 @@ impl<'a> Codegen<'a> {
         self.line("");
 
         if !l.asserts.is_empty() {
-            let clk = l.ports.iter().find(|p| matches!(&p.ty, TypeExpr::Clock(_)))
-                .map(|p| p.name.name.clone()).unwrap_or_else(|| "clk".to_string());
+            let clk = l
+                .ports
+                .iter()
+                .find(|p| matches!(&p.ty, TypeExpr::Clock(_)))
+                .map(|p| p.name.name.clone())
+                .unwrap_or_else(|| "clk".to_string());
             self.line("");
             let asserts = l.asserts.clone();
             let lname = l.name.name.clone();
@@ -334,10 +383,10 @@ impl<'a> Codegen<'a> {
         num_heads: u32,
     ) {
         let on = &op.name.name;
-        let has_req_valid   = op.ports.iter().any(|p| p.name.name == "req_valid");
-        let has_resp_valid  = op.ports.iter().any(|p| p.name.name == "resp_valid");
-        let has_req_handle  = op.ports.iter().any(|p| p.name.name == "req_handle");
-        let has_req_data    = op.ports.iter().any(|p| p.name.name == "req_data");
+        let has_req_valid = op.ports.iter().any(|p| p.name.name == "req_valid");
+        let has_resp_valid = op.ports.iter().any(|p| p.name.name == "resp_valid");
+        let has_req_handle = op.ports.iter().any(|p| p.name.name == "req_handle");
+        let has_req_data = op.ports.iter().any(|p| p.name.name == "req_data");
         let multi_head = num_heads > 1;
         let is_head_addr = matches!(
             on.as_str(),
@@ -354,18 +403,26 @@ impl<'a> Codegen<'a> {
         // compiler.
         let head_r_accept = if multi_head && is_head_addr {
             format!("_head_r[{on}_req_head_idx]")
-        } else { "_head_r".to_string() };
+        } else {
+            "_head_r".to_string()
+        };
         let head_r_busy = if multi_head && is_head_addr {
             format!("_head_r[_ctrl_{on}_head_idx]")
-        } else { "_head_r".to_string() };
+        } else {
+            "_head_r".to_string()
+        };
         // _tail_r is only read at the busy cycle (post-accept). The
         // accept-cycle variant would be `_tail_r[<op>_req_head_idx]`
         // if an op ever needed it.
         let tail_r_busy = if multi_head && is_head_addr {
             format!("_tail_r[_ctrl_{on}_head_idx]")
-        } else { "_tail_r".to_string() };
+        } else {
+            "_tail_r".to_string()
+        };
 
-        self.line(&format!("// ── {on} ─────────────────────────────────────────"));
+        self.line(&format!(
+            "// ── {on} ─────────────────────────────────────────"
+        ));
 
         // Multi-head `insert_head` falls back to a $fatal only on the
         // latency-1 fast path — that path doesn't carry a busy register,
@@ -384,25 +441,37 @@ impl<'a> Codegen<'a> {
         match on.as_str() {
             "alloc" => {
                 // Latency-1: dequeue one slot from free list
-                let guard = if has_req_valid { format!("{on}_req_valid && !(_fl_cnt == '0)") } else { "1'b1".into() };
+                let guard = if has_req_valid {
+                    format!("{on}_req_valid && !(_fl_cnt == '0)")
+                } else {
+                    "1'b1".into()
+                };
                 self.line(&format!("if ({guard}) begin"));
                 self.indent += 1;
                 self.line("_fl_rdp <= _fl_rdp + 1'b1;");
                 self.line("_fl_cnt <= _fl_cnt - 1'b1;");
                 if has_resp_valid {
                     self.line(&format!("_ctrl_{on}_resp_v <= 1'b1;"));
-                    self.line(&format!("_ctrl_{on}_resp_handle <= _fl_mem[_fl_rdp[HANDLE_W-1:0]];"));
+                    self.line(&format!(
+                        "_ctrl_{on}_resp_handle <= _fl_mem[_fl_rdp[HANDLE_W-1:0]];"
+                    ));
                 }
                 self.indent -= 1;
                 self.line("end");
             }
             "free" => {
                 // Latency-1: enqueue slot back onto free list
-                let guard = if has_req_valid { format!("{on}_req_valid") } else { "1'b1".into() };
+                let guard = if has_req_valid {
+                    format!("{on}_req_valid")
+                } else {
+                    "1'b1".into()
+                };
                 self.line(&format!("if ({guard}) begin"));
                 self.indent += 1;
                 if has_req_handle {
-                    self.line(&format!("_fl_mem[_fl_wrp[HANDLE_W-1:0]] <= {on}_req_handle;"));
+                    self.line(&format!(
+                        "_fl_mem[_fl_wrp[HANDLE_W-1:0]] <= {on}_req_handle;"
+                    ));
                 }
                 self.line("_fl_wrp <= _fl_wrp + 1'b1;");
                 self.line("_fl_cnt <= _fl_cnt + 1'b1;");
@@ -426,28 +495,40 @@ impl<'a> Codegen<'a> {
                     // uses the per-head length counter so chains from other
                     // heads don't mask this head's emptiness.
                     if multi_head {
-                        self.line(&format!("_ctrl_{on}_was_empty <= (_length_r[{on}_req_head_idx] == '0);"));
+                        self.line(&format!(
+                            "_ctrl_{on}_was_empty <= (_length_r[{on}_req_head_idx] == '0);"
+                        ));
                         self.line(&format!("_ctrl_{on}_head_idx  <= {on}_req_head_idx;"));
                     } else {
-                        self.line(&format!("_ctrl_{on}_was_empty <= (_fl_cnt == CNT_W'(DEPTH));"));
+                        self.line(&format!(
+                            "_ctrl_{on}_was_empty <= (_fl_cnt == CNT_W'(DEPTH));"
+                        ));
                     }
                     self.line(&format!("_ctrl_{on}_busy <= 1'b1;"));
                     self.indent -= 1;
                     self.line(&format!("end else if (_ctrl_{on}_busy) begin"));
                     self.indent += 1;
-                    self.line(&format!("_next_mem[_ctrl_{on}_resp_handle] <= {head_r_busy};"));
+                    self.line(&format!(
+                        "_next_mem[_ctrl_{on}_resp_handle] <= {head_r_busy};"
+                    ));
                     if is_doubly {
                         // old head.prev = new node; new node.prev = sentinel (0)
-                        self.line(&format!("_prev_mem[{head_r_busy}] <= _ctrl_{on}_resp_handle;"));
+                        self.line(&format!(
+                            "_prev_mem[{head_r_busy}] <= _ctrl_{on}_resp_handle;"
+                        ));
                     }
                     self.line(&format!("{head_r_busy} <= _ctrl_{on}_resp_handle;"));
                     if track_tail {
-                        self.line(&format!("if (_ctrl_{on}_was_empty) {tail_r_busy} <= _ctrl_{on}_resp_handle;"));
+                        self.line(&format!(
+                            "if (_ctrl_{on}_was_empty) {tail_r_busy} <= _ctrl_{on}_resp_handle;"
+                        ));
                     }
                     if multi_head {
                         self.line(&format!("_length_r[_ctrl_{on}_head_idx] <= _length_r[_ctrl_{on}_head_idx] + 1'b1;"));
                     }
-                    if has_resp_valid { self.line(&format!("_ctrl_{on}_resp_v <= 1'b1;")); }
+                    if has_resp_valid {
+                        self.line(&format!("_ctrl_{on}_resp_v <= 1'b1;"));
+                    }
                     self.line(&format!("_ctrl_{on}_busy <= 1'b0;"));
                     self.indent -= 1;
                     self.line("end");
@@ -456,12 +537,16 @@ impl<'a> Codegen<'a> {
                     let slot = "_fl_mem[_fl_rdp[HANDLE_W-1:0]]";
                     self.line(&format!("if ({on}_req_valid && !(_fl_cnt == '0)) begin"));
                     self.indent += 1;
-                    if has_req_data { self.line(&format!("_data_mem[{slot}] <= {on}_req_data;")); }
+                    if has_req_data {
+                        self.line(&format!("_data_mem[{slot}] <= {on}_req_data;"));
+                    }
                     self.line(&format!("_next_mem[{slot}] <= _head_r;"));
                     self.line(&format!("_head_r <= {slot};"));
                     self.line("_fl_rdp <= _fl_rdp + 1'b1;");
                     self.line("_fl_cnt <= _fl_cnt - 1'b1;");
-                    if has_resp_valid { self.line(&format!("_ctrl_{on}_resp_v <= 1'b1;")); }
+                    if has_resp_valid {
+                        self.line(&format!("_ctrl_{on}_resp_v <= 1'b1;"));
+                    }
                     self.indent -= 1;
                     self.line("end");
                 }
@@ -473,17 +558,23 @@ impl<'a> Codegen<'a> {
                 self.indent += 1;
                 let slot = "_fl_mem[_fl_rdp[HANDLE_W-1:0]]";
                 self.line(&format!("_ctrl_{on}_resp_handle <= {slot};"));
-                if has_req_data { self.line(&format!("_data_mem[{slot}] <= {on}_req_data;")); }
+                if has_req_data {
+                    self.line(&format!("_data_mem[{slot}] <= {on}_req_data;"));
+                }
                 self.line("_fl_rdp <= _fl_rdp + 1'b1;");
                 self.line("_fl_cnt <= _fl_cnt - 1'b1;");
                 // Empty check: single-head uses pool occupancy; multi-head
                 // uses the per-head length counter so chains from other
                 // heads don't mask this head's emptiness.
                 if multi_head {
-                    self.line(&format!("_ctrl_{on}_was_empty <= (_length_r[{on}_req_head_idx] == '0);"));
+                    self.line(&format!(
+                        "_ctrl_{on}_was_empty <= (_length_r[{on}_req_head_idx] == '0);"
+                    ));
                     self.line(&format!("_ctrl_{on}_head_idx  <= {on}_req_head_idx;"));
                 } else {
-                    self.line(&format!("_ctrl_{on}_was_empty <= (_fl_cnt == CNT_W'(DEPTH));"));
+                    self.line(&format!(
+                        "_ctrl_{on}_was_empty <= (_fl_cnt == CNT_W'(DEPTH));"
+                    ));
                 }
                 self.line(&format!("_ctrl_{on}_busy <= 1'b1;"));
                 self.indent -= 1;
@@ -493,18 +584,28 @@ impl<'a> Codegen<'a> {
                     self.line(&format!("if (!_ctrl_{on}_was_empty) _next_mem[{tail_r_busy}] <= _ctrl_{on}_resp_handle;"));
                     if is_doubly {
                         // new node.prev = old tail
-                        self.line(&format!("_prev_mem[_ctrl_{on}_resp_handle] <= {tail_r_busy};"));
+                        self.line(&format!(
+                            "_prev_mem[_ctrl_{on}_resp_handle] <= {tail_r_busy};"
+                        ));
                     }
                     self.line(&format!("{tail_r_busy} <= _ctrl_{on}_resp_handle;"));
-                    self.line(&format!("if (_ctrl_{on}_was_empty) {head_r_busy} <= _ctrl_{on}_resp_handle;"));
+                    self.line(&format!(
+                        "if (_ctrl_{on}_was_empty) {head_r_busy} <= _ctrl_{on}_resp_handle;"
+                    ));
                 } else {
                     self.line(&format!("if (!_ctrl_{on}_was_empty) _next_mem[{head_r_busy}] <= _ctrl_{on}_resp_handle;"));
-                    self.line(&format!("if (_ctrl_{on}_was_empty) {head_r_busy} <= _ctrl_{on}_resp_handle;"));
+                    self.line(&format!(
+                        "if (_ctrl_{on}_was_empty) {head_r_busy} <= _ctrl_{on}_resp_handle;"
+                    ));
                 }
                 if multi_head {
-                    self.line(&format!("_length_r[_ctrl_{on}_head_idx] <= _length_r[_ctrl_{on}_head_idx] + 1'b1;"));
+                    self.line(&format!(
+                        "_length_r[_ctrl_{on}_head_idx] <= _length_r[_ctrl_{on}_head_idx] + 1'b1;"
+                    ));
                 }
-                if has_resp_valid { self.line(&format!("_ctrl_{on}_resp_v <= 1'b1;")); }
+                if has_resp_valid {
+                    self.line(&format!("_ctrl_{on}_resp_v <= 1'b1;"));
+                }
                 self.line(&format!("_ctrl_{on}_busy <= 1'b0;"));
                 self.indent -= 1;
                 self.line("end");
@@ -519,10 +620,14 @@ impl<'a> Codegen<'a> {
                 let guard = format!("!_ctrl_{on}_busy && {on}_req_valid && {pool_gate}");
                 self.line(&format!("if ({guard}) begin"));
                 self.indent += 1;
-                self.line(&format!("_ctrl_delete_head_resp_data <= _data_mem[{head_r_accept}];"));
+                self.line(&format!(
+                    "_ctrl_delete_head_resp_data <= _data_mem[{head_r_accept}];"
+                ));
                 self.line(&format!("_ctrl_delete_head_slot      <= {head_r_accept};"));
                 if multi_head {
-                    self.line(&format!("_ctrl_{on}_head_idx          <= {on}_req_head_idx;"));
+                    self.line(&format!(
+                        "_ctrl_{on}_head_idx          <= {on}_req_head_idx;"
+                    ));
                 }
                 self.line(&format!("_ctrl_{on}_busy <= 1'b1;"));
                 self.indent -= 1;
@@ -533,60 +638,96 @@ impl<'a> Codegen<'a> {
                 self.line("_fl_wrp <= _fl_wrp + 1'b1;");
                 self.line("_fl_cnt <= _fl_cnt + 1'b1;");
                 // Advance head
-                self.line(&format!("{head_r_busy} <= _next_mem[_ctrl_delete_head_slot];"));
+                self.line(&format!(
+                    "{head_r_busy} <= _next_mem[_ctrl_delete_head_slot];"
+                ));
                 if multi_head {
-                    self.line(&format!("_length_r[_ctrl_{on}_head_idx] <= _length_r[_ctrl_{on}_head_idx] - 1'b1;"));
+                    self.line(&format!(
+                        "_length_r[_ctrl_{on}_head_idx] <= _length_r[_ctrl_{on}_head_idx] - 1'b1;"
+                    ));
                 }
-                if has_resp_valid { self.line(&format!("_ctrl_{on}_resp_v <= 1'b1;")); }
+                if has_resp_valid {
+                    self.line(&format!("_ctrl_{on}_resp_v <= 1'b1;"));
+                }
                 self.line(&format!("_ctrl_{on}_busy <= 1'b0;"));
                 self.indent -= 1;
                 self.line("end");
             }
             "read_data" => {
                 // Latency-1: RAM read (registered output)
-                let guard = if has_req_valid { format!("{on}_req_valid") } else { "1'b1".into() };
+                let guard = if has_req_valid {
+                    format!("{on}_req_valid")
+                } else {
+                    "1'b1".into()
+                };
                 self.line(&format!("if ({guard}) begin"));
                 self.indent += 1;
                 if has_req_handle {
-                    self.line(&format!("_ctrl_{on}_resp_data <= _data_mem[{on}_req_handle];"));
+                    self.line(&format!(
+                        "_ctrl_{on}_resp_data <= _data_mem[{on}_req_handle];"
+                    ));
                 }
-                if has_resp_valid { self.line(&format!("_ctrl_{on}_resp_v <= 1'b1;")); }
+                if has_resp_valid {
+                    self.line(&format!("_ctrl_{on}_resp_v <= 1'b1;"));
+                }
                 self.indent -= 1;
                 self.line("end");
             }
             "write_data" => {
                 // Latency-1: RAM write
-                let guard = if has_req_valid { format!("{on}_req_valid") } else { "1'b1".into() };
+                let guard = if has_req_valid {
+                    format!("{on}_req_valid")
+                } else {
+                    "1'b1".into()
+                };
                 self.line(&format!("if ({guard}) begin"));
                 self.indent += 1;
                 if has_req_handle && has_req_data {
                     self.line(&format!("_data_mem[{on}_req_handle] <= {on}_req_data;"));
                 }
-                if has_resp_valid { self.line(&format!("_ctrl_{on}_resp_v <= 1'b1;")); }
+                if has_resp_valid {
+                    self.line(&format!("_ctrl_{on}_resp_v <= 1'b1;"));
+                }
                 self.indent -= 1;
                 self.line("end");
             }
             "next" => {
                 // Latency-1: follow next pointer
-                let guard = if has_req_valid { format!("{on}_req_valid") } else { "1'b1".into() };
+                let guard = if has_req_valid {
+                    format!("{on}_req_valid")
+                } else {
+                    "1'b1".into()
+                };
                 self.line(&format!("if ({guard}) begin"));
                 self.indent += 1;
                 if has_req_handle {
-                    self.line(&format!("_ctrl_{on}_resp_handle <= _next_mem[{on}_req_handle];"));
+                    self.line(&format!(
+                        "_ctrl_{on}_resp_handle <= _next_mem[{on}_req_handle];"
+                    ));
                 }
-                if has_resp_valid { self.line(&format!("_ctrl_{on}_resp_v <= 1'b1;")); }
+                if has_resp_valid {
+                    self.line(&format!("_ctrl_{on}_resp_v <= 1'b1;"));
+                }
                 self.indent -= 1;
                 self.line("end");
             }
             "prev" => {
                 // Latency-1: follow prev pointer (doubly only)
-                let guard = if has_req_valid { format!("{on}_req_valid") } else { "1'b1".into() };
+                let guard = if has_req_valid {
+                    format!("{on}_req_valid")
+                } else {
+                    "1'b1".into()
+                };
                 self.line(&format!("if ({guard}) begin"));
                 self.indent += 1;
                 if has_req_handle {
-                    self.line(&format!("_ctrl_{on}_resp_handle <= _prev_mem[{on}_req_handle];"));
+                    self.line(&format!(
+                        "_ctrl_{on}_resp_handle <= _prev_mem[{on}_req_handle];"
+                    ));
                 }
-                if has_resp_valid { self.line(&format!("_ctrl_{on}_resp_v <= 1'b1;")); }
+                if has_resp_valid {
+                    self.line(&format!("_ctrl_{on}_resp_v <= 1'b1;"));
+                }
                 self.indent -= 1;
                 self.line("end");
             }
@@ -597,7 +738,9 @@ impl<'a> Codegen<'a> {
                 self.indent += 1;
                 let slot = "_fl_mem[_fl_rdp[HANDLE_W-1:0]]";
                 self.line(&format!("_ctrl_{on}_resp_handle <= {slot};"));
-                if has_req_data { self.line(&format!("_data_mem[{slot}] <= {on}_req_data;")); }
+                if has_req_data {
+                    self.line(&format!("_data_mem[{slot}] <= {on}_req_data;"));
+                }
                 // Latch after_handle so cycle 2 doesn't read live port
                 self.line(&format!("_ctrl_{on}_after_handle <= {on}_req_handle;"));
                 // new.next = after.next (the successor)
@@ -612,17 +755,27 @@ impl<'a> Codegen<'a> {
                 self.line(&format!("end else if (_ctrl_{on}_busy) begin"));
                 self.indent += 1;
                 // after.next = new
-                self.line(&format!("_next_mem[_ctrl_{on}_after_handle] <= _ctrl_{on}_resp_handle;"));
+                self.line(&format!(
+                    "_next_mem[_ctrl_{on}_after_handle] <= _ctrl_{on}_resp_handle;"
+                ));
                 if is_doubly {
                     // new.prev = after
-                    self.line(&format!("_prev_mem[_ctrl_{on}_resp_handle] <= _ctrl_{on}_after_handle;"));
+                    self.line(&format!(
+                        "_prev_mem[_ctrl_{on}_resp_handle] <= _ctrl_{on}_after_handle;"
+                    ));
                     // successor.prev = new  (new.next is already committed from cycle 1)
-                    self.line(&format!("_prev_mem[_next_mem[_ctrl_{on}_resp_handle]] <= _ctrl_{on}_resp_handle;"));
+                    self.line(&format!(
+                        "_prev_mem[_next_mem[_ctrl_{on}_resp_handle]] <= _ctrl_{on}_resp_handle;"
+                    ));
                 }
                 if multi_head {
-                    self.line(&format!("_length_r[_ctrl_{on}_head_idx] <= _length_r[_ctrl_{on}_head_idx] + 1'b1;"));
+                    self.line(&format!(
+                        "_length_r[_ctrl_{on}_head_idx] <= _length_r[_ctrl_{on}_head_idx] + 1'b1;"
+                    ));
                 }
-                if has_resp_valid { self.line(&format!("_ctrl_{on}_resp_v <= 1'b1;")); }
+                if has_resp_valid {
+                    self.line(&format!("_ctrl_{on}_resp_v <= 1'b1;"));
+                }
                 self.line(&format!("_ctrl_{on}_busy <= 1'b0;"));
                 self.indent -= 1;
                 self.line("end");
@@ -642,13 +795,19 @@ impl<'a> Codegen<'a> {
                 self.indent -= 1;
                 self.line(&format!("end else if (_ctrl_{on}_busy) begin"));
                 self.indent += 1;
-                self.line(&format!("_fl_mem[_fl_wrp[HANDLE_W-1:0]] <= _ctrl_{on}_slot;"));
+                self.line(&format!(
+                    "_fl_mem[_fl_wrp[HANDLE_W-1:0]] <= _ctrl_{on}_slot;"
+                ));
                 self.line("_fl_wrp <= _fl_wrp + 1'b1;");
                 self.line("_fl_cnt <= _fl_cnt + 1'b1;");
                 if multi_head {
-                    self.line(&format!("_length_r[_ctrl_{on}_head_idx] <= _length_r[_ctrl_{on}_head_idx] - 1'b1;"));
+                    self.line(&format!(
+                        "_length_r[_ctrl_{on}_head_idx] <= _length_r[_ctrl_{on}_head_idx] - 1'b1;"
+                    ));
                 }
-                if has_resp_valid { self.line(&format!("_ctrl_{on}_resp_v <= 1'b1;")); }
+                if has_resp_valid {
+                    self.line(&format!("_ctrl_{on}_resp_v <= 1'b1;"));
+                }
                 self.line(&format!("_ctrl_{on}_busy <= 1'b0;"));
                 self.indent -= 1;
                 self.line("end");

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -52,7 +52,6 @@ fn stmt_span_start(stmt: &Stmt) -> usize {
     }
 }
 
-
 /// One `shared function` harness: one MAC (or whatever the function
 /// computes), driven by per-state operand muxes. `sv_name` is the
 /// emitted SV function name (post overload-mangling); `src_name` is
@@ -74,7 +73,13 @@ struct SharedHarness {
 
 impl SharedHarness {
     fn new(src_name: String, sv_name: String, state_reg: String, fn_decl: FunctionDecl) -> Self {
-        Self { src_name, sv_name, state_reg, fn_decl, entries: Vec::new() }
+        Self {
+            src_name,
+            sv_name,
+            state_reg,
+            fn_decl,
+            entries: Vec::new(),
+        }
     }
 }
 
@@ -118,7 +123,6 @@ enum GroupKind {
         bus_params: Vec<ParamAssign>,
     },
 }
-
 
 pub struct Codegen<'a> {
     pub symbols: &'a SymbolTable,
@@ -319,7 +323,8 @@ impl<'a> Codegen<'a> {
             ));
             s.push_str(&format!(
                 "set_multicycle_path {} -hold -to [get_cells -hierarchical {{*{}_reg*}}]\n",
-                mc.latency.saturating_sub(1), mc.reg_name
+                mc.latency.saturating_sub(1),
+                mc.reg_name
             ));
             s.push('\n');
         }
@@ -401,7 +406,8 @@ impl<'a> Codegen<'a> {
         self.comment_idx = 0;
         self.collect_multicycle_regs(items);
         // Pre-collect all functions so they can be emitted inside each module.
-        self.pending_functions = items.iter()
+        self.pending_functions = items
+            .iter()
             .flat_map(|i| match i {
                 Item::Function(f) => vec![f.clone()],
                 Item::Package(p) => p.functions.clone(),
@@ -497,19 +503,21 @@ impl<'a> Codegen<'a> {
         let Some(te) = &pa.ty else {
             return format!(".{}({})", pa.name.name, self.emit_expr_str(&pa.value));
         };
-        let width = self.type_expr_data_width(te).unwrap_or_else(|| "0".to_string());
+        let width = self
+            .type_expr_data_width(te)
+            .unwrap_or_else(|| "0".to_string());
         // Map T → DATA_WIDTH for constructs that erase type params into a
         // synthesized packed payload width.
         let is_fifo_type_param = self.source.items.iter().any(|it| match it {
-            Item::Fifo(f) if f.name.name == child => f.params.iter().any(|p|
-                p.name.name == pa.name.name
-                && matches!(p.kind, crate::ast::ParamKind::Type(_))),
+            Item::Fifo(f) if f.name.name == child => f.params.iter().any(|p| {
+                p.name.name == pa.name.name && matches!(p.kind, crate::ast::ParamKind::Type(_))
+            }),
             _ => false,
         });
         let is_ram_type_param = self.source.items.iter().any(|it| match it {
-            Item::Ram(r) if r.name.name == child => r.params.iter().any(|p|
-                p.name.name == pa.name.name
-                && matches!(p.kind, crate::ast::ParamKind::Type(_))),
+            Item::Ram(r) if r.name.name == child => r.params.iter().any(|p| {
+                p.name.name == pa.name.name && matches!(p.kind, crate::ast::ParamKind::Type(_))
+            }),
             _ => false,
         });
         if is_fifo_type_param || is_ram_type_param {
@@ -525,7 +533,11 @@ impl<'a> Codegen<'a> {
         } else {
             String::new()
         };
-        let kw = if p.is_local { "localparam" } else { "parameter" };
+        let kw = if p.is_local {
+            "localparam"
+        } else {
+            "parameter"
+        };
         // Optional post-name unpacked dim: `param NAME: T [N]` →
         // SV `parameter T NAME [N]`. Goes after the param name and
         // before the `=` default. Used to forward upstream-SV
@@ -539,10 +551,16 @@ impl<'a> Codegen<'a> {
             ParamKind::WidthConst(hi, lo) => {
                 let hi_s = self.emit_expr_str(hi);
                 let lo_s = self.emit_expr_str(lo);
-                self.line(&format!("{kw} [{}:{}] {}{}{}{}", hi_s, lo_s, p.name.name, unpacked_str, default_str, comma));
+                self.line(&format!(
+                    "{kw} [{}:{}] {}{}{}{}",
+                    hi_s, lo_s, p.name.name, unpacked_str, default_str, comma
+                ));
             }
             ParamKind::EnumConst(enum_name) => {
-                self.line(&format!("{kw} {} {}{}{}{}", enum_name, p.name.name, unpacked_str, default_str, comma));
+                self.line(&format!(
+                    "{kw} {} {}{}{}{}",
+                    enum_name, p.name.name, unpacked_str, default_str, comma
+                ));
             }
             ParamKind::Logic(ty) => {
                 // Emit as `parameter <packed-bits> NAME [unpacked]? = ...`.
@@ -552,11 +570,20 @@ impl<'a> Codegen<'a> {
                 // doesn't take `logic` as the type qualifier in the
                 // same way `input/output` does).
                 let ty_str = self.emit_port_type_str(ty);
-                let ty_qual = ty_str.strip_prefix("logic").map(|r| r.trim_start()).unwrap_or(&ty_str);
+                let ty_qual = ty_str
+                    .strip_prefix("logic")
+                    .map(|r| r.trim_start())
+                    .unwrap_or(&ty_str);
                 if ty_qual.is_empty() {
-                    self.line(&format!("{kw} {}{}{}{}", p.name.name, unpacked_str, default_str, comma));
+                    self.line(&format!(
+                        "{kw} {}{}{}{}",
+                        p.name.name, unpacked_str, default_str, comma
+                    ));
                 } else {
-                    self.line(&format!("{kw} {} {}{}{}{}", ty_qual, p.name.name, unpacked_str, default_str, comma));
+                    self.line(&format!(
+                        "{kw} {} {}{}{}{}",
+                        ty_qual, p.name.name, unpacked_str, default_str, comma
+                    ));
                 }
             }
             ParamKind::ConstVec(ty) => {
@@ -588,21 +615,27 @@ impl<'a> Codegen<'a> {
                         // Reverse so parts[0] is the LSB chunk → NAME[0] reads parts[0].
                         let mut rev: Vec<&Expr> = parts.iter().collect();
                         rev.reverse();
-                        let chunks: Vec<String> = rev.iter()
+                        let chunks: Vec<String> = rev
+                            .iter()
                             .map(|e| format!("({})'({})", elem_w_s, self.emit_expr_str(e)))
                             .collect();
                         format!(" = {{{}}}", chunks.join(", "))
                     } else {
                         format!(" = {}", self.emit_expr_str(d))
                     }
-                } else { String::new() };
+                } else {
+                    String::new()
+                };
                 self.line(&format!(
                     "{kw} logic {signed_kw}[({size_s})*({elem_w_s})-1:0] {}{default_packed}{comma}",
                     p.name.name
                 ));
             }
             _ => {
-                self.line(&format!("{kw} int {}{}{}{}", p.name.name, unpacked_str, default_str, comma));
+                self.line(&format!(
+                    "{kw} int {}{}{}{}",
+                    p.name.name, unpacked_str, default_str, comma
+                ));
             }
         }
     }
@@ -610,7 +643,11 @@ impl<'a> Codegen<'a> {
     pub(crate) fn emit_domain(&mut self, d: &DomainDecl) {
         self.line(&format!("// domain {}", d.name.name));
         for field in &d.fields {
-            self.line(&format!("//   {}: {}", field.name.name, self.emit_expr_str(&field.value)));
+            self.line(&format!(
+                "//   {}: {}",
+                field.name.name,
+                self.emit_expr_str(&field.value)
+            ));
         }
         self.line("");
     }
@@ -622,7 +659,7 @@ impl<'a> Codegen<'a> {
             TypeExpr::UInt(e) => Self::expr_simple_str(e),
             TypeExpr::SInt(e) => format!("s{}", Self::expr_simple_str(e)),
             TypeExpr::Bool => "b".to_string(),
-            TypeExpr::Bit  => "1".to_string(),
+            TypeExpr::Bit => "1".to_string(),
             TypeExpr::Named(n) => n.name.clone(),
             _ => "x".to_string(),
         }
@@ -641,7 +678,9 @@ impl<'a> Codegen<'a> {
     fn sv_function_name(&self, f: &FunctionDecl) -> String {
         if let Some((Symbol::Function(overloads), _)) = self.symbols.globals.get(&f.name.name) {
             if overloads.len() > 1 {
-                let suffix: String = f.args.iter()
+                let suffix: String = f
+                    .args
+                    .iter()
                     .map(|a| Self::type_mangle_tag(&a.ty))
                     .collect::<Vec<_>>()
                     .join("_");
@@ -654,7 +693,9 @@ impl<'a> Codegen<'a> {
     fn emit_function(&mut self, f: &FunctionDecl) {
         let sv_name = self.sv_function_name(f);
         let ret_str = self.emit_type_str(&f.ret_ty);
-        let args_str: Vec<String> = f.args.iter()
+        let args_str: Vec<String> = f
+            .args
+            .iter()
             .map(|a| format!("input {} {}", self.emit_type_str(&a.ty), a.name.name))
             .collect();
         self.line(&format!(
@@ -885,7 +926,9 @@ impl<'a> Codegen<'a> {
                     self.symbols.globals.get(name),
                     Some((Symbol::Function(ovs), _)) if ovs.iter().any(|o| o.shared)
                 );
-                if !is_shared { return; }
+                if !is_shared {
+                    return;
+                }
                 let Some((reg, lit)) = state_pred else {
                     // Outside a state predicate: fall back to inline.
                     return;
@@ -894,7 +937,9 @@ impl<'a> Codegen<'a> {
                 // harness emission). If the decl isn't visible in this
                 // module, we can't synthesize the harness — fall back
                 // to inline.
-                let Some(fd) = fn_decls.get(name).cloned() else { return; };
+                let Some(fd) = fn_decls.get(name).cloned() else {
+                    return;
+                };
                 // Resolve mangled SV name (mirrors emit_expr_str's
                 // FunctionCall arm).
                 let sv_name = self.fn_call_sv_name(name, expr);
@@ -926,7 +971,8 @@ impl<'a> Codegen<'a> {
                     }
                     // Identical args — merge by recording this call
                     // site for rewrite without adding another mux entry.
-                    self.shared_call_sites.insert(expr.span.start, format!("__shared_{sv_name}_out"));
+                    self.shared_call_sites
+                        .insert(expr.span.start, format!("__shared_{sv_name}_out"));
                     return;
                 }
                 // New entry: record args + rewrite this call site.
@@ -935,19 +981,28 @@ impl<'a> Codegen<'a> {
                     arg_strs,
                     args: args.clone(),
                 });
-                self.shared_call_sites.insert(expr.span.start, format!("__shared_{sv_name}_out"));
+                self.shared_call_sites
+                    .insert(expr.span.start, format!("__shared_{sv_name}_out"));
             }
             ExprKind::Binary(_, a, b) => {
                 self.walk_expr_for_shared(a, state_pred, harnesses, errors, fn_decls);
                 self.walk_expr_for_shared(b, state_pred, harnesses, errors, fn_decls);
             }
-            ExprKind::Unary(_, a) => self.walk_expr_for_shared(a, state_pred, harnesses, errors, fn_decls),
-            ExprKind::FieldAccess(e, _) => self.walk_expr_for_shared(e, state_pred, harnesses, errors, fn_decls),
+            ExprKind::Unary(_, a) => {
+                self.walk_expr_for_shared(a, state_pred, harnesses, errors, fn_decls)
+            }
+            ExprKind::FieldAccess(e, _) => {
+                self.walk_expr_for_shared(e, state_pred, harnesses, errors, fn_decls)
+            }
             ExprKind::MethodCall(recv, _, margs) => {
                 self.walk_expr_for_shared(recv, state_pred, harnesses, errors, fn_decls);
-                for a in margs { self.walk_expr_for_shared(a, state_pred, harnesses, errors, fn_decls); }
+                for a in margs {
+                    self.walk_expr_for_shared(a, state_pred, harnesses, errors, fn_decls);
+                }
             }
-            ExprKind::Cast(e, _) => self.walk_expr_for_shared(e, state_pred, harnesses, errors, fn_decls),
+            ExprKind::Cast(e, _) => {
+                self.walk_expr_for_shared(e, state_pred, harnesses, errors, fn_decls)
+            }
             ExprKind::Index(b, i) => {
                 self.walk_expr_for_shared(b, state_pred, harnesses, errors, fn_decls);
                 self.walk_expr_for_shared(i, state_pred, harnesses, errors, fn_decls);
@@ -963,13 +1018,18 @@ impl<'a> Codegen<'a> {
                 self.walk_expr_for_shared(w, state_pred, harnesses, errors, fn_decls);
             }
             ExprKind::Concat(es) => {
-                for e in es { self.walk_expr_for_shared(e, state_pred, harnesses, errors, fn_decls); }
+                for e in es {
+                    self.walk_expr_for_shared(e, state_pred, harnesses, errors, fn_decls);
+                }
             }
             ExprKind::Repeat(n, e) => {
                 self.walk_expr_for_shared(n, state_pred, harnesses, errors, fn_decls);
                 self.walk_expr_for_shared(e, state_pred, harnesses, errors, fn_decls);
             }
-            ExprKind::Clog2(e) | ExprKind::Onehot(e) | ExprKind::Signed(e) | ExprKind::Unsigned(e) => {
+            ExprKind::Clog2(e)
+            | ExprKind::Onehot(e)
+            | ExprKind::Signed(e)
+            | ExprKind::Unsigned(e) => {
                 self.walk_expr_for_shared(e, state_pred, harnesses, errors, fn_decls);
             }
             ExprKind::Ternary(c, t, f) => {
@@ -981,7 +1041,9 @@ impl<'a> Codegen<'a> {
                 self.walk_expr_for_shared(s, state_pred, harnesses, errors, fn_decls);
                 for m in members {
                     match m {
-                        InsideMember::Single(e) => self.walk_expr_for_shared(e, state_pred, harnesses, errors, fn_decls),
+                        InsideMember::Single(e) => {
+                            self.walk_expr_for_shared(e, state_pred, harnesses, errors, fn_decls)
+                        }
                         InsideMember::Range(a, b) => {
                             self.walk_expr_for_shared(a, state_pred, harnesses, errors, fn_decls);
                             self.walk_expr_for_shared(b, state_pred, harnesses, errors, fn_decls);
@@ -995,10 +1057,16 @@ impl<'a> Codegen<'a> {
                     self.walk_expr_for_shared(&arm.value, state_pred, harnesses, errors, fn_decls);
                 }
             }
-            ExprKind::SvaNext(_, e) => self.walk_expr_for_shared(e, state_pred, harnesses, errors, fn_decls),
-            ExprKind::LatencyAt(e, _) => self.walk_expr_for_shared(e, state_pred, harnesses, errors, fn_decls),
+            ExprKind::SvaNext(_, e) => {
+                self.walk_expr_for_shared(e, state_pred, harnesses, errors, fn_decls)
+            }
+            ExprKind::LatencyAt(e, _) => {
+                self.walk_expr_for_shared(e, state_pred, harnesses, errors, fn_decls)
+            }
             ExprKind::StructLiteral(_, fields) => {
-                for fi in fields { self.walk_expr_for_shared(&fi.value, state_pred, harnesses, errors, fn_decls); }
+                for fi in fields {
+                    self.walk_expr_for_shared(&fi.value, state_pred, harnesses, errors, fn_decls);
+                }
             }
             // Leaf nodes: literals, idents, enum variants, todo, bool.
             _ => {}
@@ -1028,9 +1096,15 @@ impl<'a> Codegen<'a> {
     fn fn_call_sv_name(&self, name: &str, expr: &Expr) -> String {
         if let Some((Symbol::Function(overloads), _)) = self.symbols.globals.get(name) {
             if overloads.len() > 1 {
-                let idx = self.overload_map.get(&expr.span.start).copied().unwrap_or(0);
+                let idx = self
+                    .overload_map
+                    .get(&expr.span.start)
+                    .copied()
+                    .unwrap_or(0);
                 let ov = &overloads[idx];
-                let suffix: String = ov.arg_types.iter()
+                let suffix: String = ov
+                    .arg_types
+                    .iter()
                     .map(|t| Self::type_mangle_tag(t))
                     .collect::<Vec<_>>()
                     .join("_");
@@ -1076,7 +1150,10 @@ impl<'a> Codegen<'a> {
             self.line("always_comb begin");
             self.indent += 1;
             for arg in &fd.args {
-                self.line(&format!("__shared_{}_in_{} = '0;", h.sv_name, arg.name.name));
+                self.line(&format!(
+                    "__shared_{}_in_{} = '0;",
+                    h.sv_name, arg.name.name
+                ));
             }
             self.line(&format!("unique case ({})", h.state_reg));
             self.indent += 1;
@@ -1101,12 +1178,16 @@ impl<'a> Codegen<'a> {
             // 3. Single function call. The args are fed by the wires
             //    above, so yosys synthesizes ONE evaluation of the
             //    function body.
-            let arg_wires: Vec<String> = fd.args.iter()
+            let arg_wires: Vec<String> = fd
+                .args
+                .iter()
                 .map(|a| format!("__shared_{}_in_{}", h.sv_name, a.name.name))
                 .collect();
             self.line(&format!(
                 "assign __shared_{}_out = {}({});",
-                h.sv_name, h.sv_name, arg_wires.join(", ")
+                h.sv_name,
+                h.sv_name,
+                arg_wires.join(", ")
             ));
             self.line("");
         }
@@ -1178,12 +1259,16 @@ impl<'a> Codegen<'a> {
             ForRange::Range(lo, hi) => {
                 let lo_s = self.emit_expr_str(lo);
                 let hi_s = self.emit_expr_str(hi);
-                self.line(&format!("for (int {var} = {lo_s}; {var} <= {hi_s}; {var}++) begin"));
+                self.line(&format!(
+                    "for (int {var} = {lo_s}; {var} <= {hi_s}; {var}++) begin"
+                ));
             }
             ForRange::ValueList(_vals) => {
                 if let ForRange::ValueList(vals) = &fl.range {
                     for val in vals {
-                        if let Some(v) = self.eval_const_u32(val, &self.current_module_params.clone()) {
+                        if let Some(v) =
+                            self.eval_const_u32(val, &self.current_module_params.clone())
+                        {
                             let old = self.loop_var_subst.insert(var.clone(), v);
                             self.emit_function_body_items(&fl.body);
                             if let Some(prev) = old {
@@ -1193,7 +1278,9 @@ impl<'a> Codegen<'a> {
                             }
                         } else {
                             let v = self.emit_expr_str(val);
-                            self.line(&format!("for (int {var} = {v}; {var} == {v}; {var}++) begin"));
+                            self.line(&format!(
+                                "for (int {var} = {v}; {var} == {v}; {var}++) begin"
+                            ));
                             self.indent += 1;
                             self.emit_function_body_items(&fl.body);
                             self.indent -= 1;
@@ -1232,18 +1319,30 @@ impl<'a> Codegen<'a> {
                     ParamKind::WidthConst(hi, lo) => {
                         let hi_s = self.emit_expr_str(hi);
                         let lo_s = self.emit_expr_str(lo);
-                        self.line(&format!("localparam [{}:{}] {} = {};", hi_s, lo_s, p.name.name, val));
+                        self.line(&format!(
+                            "localparam [{}:{}] {} = {};",
+                            hi_s, lo_s, p.name.name, val
+                        ));
                     }
                     ParamKind::EnumConst(enum_name) => {
-                        self.line(&format!("localparam {} {} = {};", enum_name, p.name.name, val));
+                        self.line(&format!(
+                            "localparam {} {} = {};",
+                            enum_name, p.name.name, val
+                        ));
                     }
                     ParamKind::Logic(ty) => {
                         let ty_str = self.emit_port_type_str(ty);
-                        let ty_qual = ty_str.strip_prefix("logic").map(|r| r.trim_start()).unwrap_or(&ty_str);
+                        let ty_qual = ty_str
+                            .strip_prefix("logic")
+                            .map(|r| r.trim_start())
+                            .unwrap_or(&ty_str);
                         if ty_qual.is_empty() {
                             self.line(&format!("localparam {} = {};", p.name.name, val));
                         } else {
-                            self.line(&format!("localparam {} {} = {};", ty_qual, p.name.name, val));
+                            self.line(&format!(
+                                "localparam {} {} = {};",
+                                ty_qual, p.name.name, val
+                            ));
                         }
                     }
                     ParamKind::Const | ParamKind::Type(_) | ParamKind::ConstVec(_) => {
@@ -1281,20 +1380,34 @@ impl<'a> Codegen<'a> {
 
     pub(crate) fn emit_enum(&mut self, e: &EnumDecl) {
         // Compute effective values: explicit where provided, auto-sequential otherwise
-        let effective_values: Vec<u64> = e.values.iter().enumerate().map(|(i, v)| {
-            v.as_ref().and_then(|expr| match &expr.kind {
-                ExprKind::Literal(LitKind::Dec(n)) => Some(*n),
-                ExprKind::Literal(LitKind::Hex(n)) => Some(*n),
-                ExprKind::Literal(LitKind::Bin(n)) => Some(*n),
-                ExprKind::Literal(LitKind::Sized(_, n)) => Some(*n),
-                _ => None,
-            }).unwrap_or(i as u64)
-        }).collect();
+        let effective_values: Vec<u64> = e
+            .values
+            .iter()
+            .enumerate()
+            .map(|(i, v)| {
+                v.as_ref()
+                    .and_then(|expr| match &expr.kind {
+                        ExprKind::Literal(LitKind::Dec(n)) => Some(*n),
+                        ExprKind::Literal(LitKind::Hex(n)) => Some(*n),
+                        ExprKind::Literal(LitKind::Bin(n)) => Some(*n),
+                        ExprKind::Literal(LitKind::Sized(_, n)) => Some(*n),
+                        _ => None,
+                    })
+                    .unwrap_or(i as u64)
+            })
+            .collect();
         // Width: from max value (covers explicit encodings like one-hot)
         let max_val = effective_values.iter().copied().max().unwrap_or(0);
-        let width = if max_val == 0 { 1 } else { 64 - max_val.leading_zeros() };
+        let width = if max_val == 0 {
+            1
+        } else {
+            64 - max_val.leading_zeros()
+        };
         let width = std::cmp::max(width, enum_width(e.variants.len()));
-        let variants: Vec<String> = e.variants.iter().zip(effective_values.iter())
+        let variants: Vec<String> = e
+            .variants
+            .iter()
+            .zip(effective_values.iter())
             .map(|(v, val)| format!("{} = {}'d{}", v.name.to_uppercase(), width, val))
             .collect();
         self.line(&format!(
@@ -1314,7 +1427,11 @@ impl<'a> Codegen<'a> {
         self.line("");
     }
 
-    fn emit_for_loop_sv(&mut self, f: &ForLoop<Stmt>, mut emit_body_stmt: impl FnMut(&mut Self, &Stmt)) {
+    fn emit_for_loop_sv(
+        &mut self,
+        f: &ForLoop<Stmt>,
+        mut emit_body_stmt: impl FnMut(&mut Self, &Stmt),
+    ) {
         let var = &f.var.name;
         // Static unrolling for Vec-of-bus indexed access: the SV signature
         // exposes only the flattened `<port>_<i>_<sig>` names, with no
@@ -1330,13 +1447,20 @@ impl<'a> Codegen<'a> {
             let start_lit = self.eval_const_u32(rs, &self.current_module_params.clone());
             let end_lit = self.eval_const_u32(re, &self.current_module_params.clone());
             if let (Some(start_lit), Some(end_lit)) = (start_lit, end_lit) {
-                let body_touches_vob = f.body.iter().any(|s| Self::stmt_indexes_vob_with_var(
-                    s, var, &self.vec_of_bus_port_count, &self.vec_of_bus_wire_count,
-                ));
+                let body_touches_vob = f.body.iter().any(|s| {
+                    Self::stmt_indexes_vob_with_var(
+                        s,
+                        var,
+                        &self.vec_of_bus_port_count,
+                        &self.vec_of_bus_wire_count,
+                    )
+                });
                 if body_touches_vob {
                     for i in start_lit..=end_lit {
                         self.loop_var_subst.insert(var.clone(), i);
-                        for s in &f.body { emit_body_stmt(self, s); }
+                        for s in &f.body {
+                            emit_body_stmt(self, s);
+                        }
                     }
                     self.loop_var_subst.remove(var);
                     return;
@@ -1347,9 +1471,13 @@ impl<'a> Codegen<'a> {
             ForRange::Range(rs, re) => {
                 let start = self.emit_expr_str(rs);
                 let end = self.emit_expr_str(re);
-                self.line(&format!("for (int {var} = {start}; {var} <= {end}; {var}++) begin"));
+                self.line(&format!(
+                    "for (int {var} = {start}; {var} <= {end}; {var}++) begin"
+                ));
                 self.indent += 1;
-                for s in &f.body { emit_body_stmt(self, s); }
+                for s in &f.body {
+                    emit_body_stmt(self, s);
+                }
                 self.indent -= 1;
                 self.line("end");
             }
@@ -1358,9 +1486,13 @@ impl<'a> Codegen<'a> {
                     let val = self.emit_expr_str(v);
                     // Emit as a for-loop with a single iteration for Icarus compatibility
                     // (Icarus doesn't support variable declarations inside always_* blocks)
-                    self.line(&format!("for (int {var} = {val}; {var} == {val}; {var}++) begin"));
+                    self.line(&format!(
+                        "for (int {var} = {val}; {var} == {val}; {var}++) begin"
+                    ));
                     self.indent += 1;
-                    for s in &f.body { emit_body_stmt(self, s); }
+                    for s in &f.body {
+                        emit_body_stmt(self, s);
+                    }
                     self.indent -= 1;
                     self.line("end");
                 }
@@ -1386,46 +1518,85 @@ impl<'a> Codegen<'a> {
             wires: &std::collections::HashMap<String, u32>,
         ) -> bool {
             if let ExprKind::Index(arr, idx) = &e.kind {
-                if let (ExprKind::Ident(arr_name), ExprKind::Ident(idx_name)) = (&arr.kind, &idx.kind) {
-                    if idx_name == var && (ports.contains_key(arr_name) || wires.contains_key(arr_name)) {
+                if let (ExprKind::Ident(arr_name), ExprKind::Ident(idx_name)) =
+                    (&arr.kind, &idx.kind)
+                {
+                    if idx_name == var
+                        && (ports.contains_key(arr_name) || wires.contains_key(arr_name))
+                    {
                         return true;
                     }
                 }
             }
             match &e.kind {
-                ExprKind::Binary(_, l, r) => walk_expr(l, var, ports, wires) || walk_expr(r, var, ports, wires),
-                ExprKind::Unary(_, x) | ExprKind::Cast(x, _) | ExprKind::LatencyAt(x, _) | ExprKind::SvaNext(_, x) =>
-                    walk_expr(x, var, ports, wires),
+                ExprKind::Binary(_, l, r) => {
+                    walk_expr(l, var, ports, wires) || walk_expr(r, var, ports, wires)
+                }
+                ExprKind::Unary(_, x)
+                | ExprKind::Cast(x, _)
+                | ExprKind::LatencyAt(x, _)
+                | ExprKind::SvaNext(_, x) => walk_expr(x, var, ports, wires),
                 ExprKind::FieldAccess(b, _) => walk_expr(b, var, ports, wires),
-                ExprKind::Index(b, i) | ExprKind::BitSlice(b, i, _) =>
-                    walk_expr(b, var, ports, wires) || walk_expr(i, var, ports, wires),
-                ExprKind::PartSelect(b, lo, hi, _) =>
-                    walk_expr(b, var, ports, wires) || walk_expr(lo, var, ports, wires) || walk_expr(hi, var, ports, wires),
-                ExprKind::Ternary(c, t, e2) =>
-                    walk_expr(c, var, ports, wires) || walk_expr(t, var, ports, wires) || walk_expr(e2, var, ports, wires),
-                ExprKind::Concat(parts) | ExprKind::FunctionCall(_, parts) =>
-                    parts.iter().any(|p| walk_expr(p, var, ports, wires)),
-                ExprKind::MethodCall(b, _, args) =>
-                    walk_expr(b, var, ports, wires) || args.iter().any(|a| walk_expr(a, var, ports, wires)),
+                ExprKind::Index(b, i) | ExprKind::BitSlice(b, i, _) => {
+                    walk_expr(b, var, ports, wires) || walk_expr(i, var, ports, wires)
+                }
+                ExprKind::PartSelect(b, lo, hi, _) => {
+                    walk_expr(b, var, ports, wires)
+                        || walk_expr(lo, var, ports, wires)
+                        || walk_expr(hi, var, ports, wires)
+                }
+                ExprKind::Ternary(c, t, e2) => {
+                    walk_expr(c, var, ports, wires)
+                        || walk_expr(t, var, ports, wires)
+                        || walk_expr(e2, var, ports, wires)
+                }
+                ExprKind::Concat(parts) | ExprKind::FunctionCall(_, parts) => {
+                    parts.iter().any(|p| walk_expr(p, var, ports, wires))
+                }
+                ExprKind::MethodCall(b, _, args) => {
+                    walk_expr(b, var, ports, wires)
+                        || args.iter().any(|a| walk_expr(a, var, ports, wires))
+                }
                 _ => false,
             }
         }
         match stmt {
-            Stmt::Assign(a) => walk_expr(&a.target, var, ports, wires) || walk_expr(&a.value, var, ports, wires),
+            Stmt::Assign(a) => {
+                walk_expr(&a.target, var, ports, wires) || walk_expr(&a.value, var, ports, wires)
+            }
             Stmt::IfElse(ie) => {
                 walk_expr(&ie.cond, var, ports, wires)
-                    || ie.then_stmts.iter().any(|s| Self::stmt_indexes_vob_with_var(s, var, ports, wires))
-                    || ie.else_stmts.iter().any(|s| Self::stmt_indexes_vob_with_var(s, var, ports, wires))
+                    || ie
+                        .then_stmts
+                        .iter()
+                        .any(|s| Self::stmt_indexes_vob_with_var(s, var, ports, wires))
+                    || ie
+                        .else_stmts
+                        .iter()
+                        .any(|s| Self::stmt_indexes_vob_with_var(s, var, ports, wires))
             }
             Stmt::Match(m) => {
                 walk_expr(&m.scrutinee, var, ports, wires)
-                    || m.arms.iter().any(|arm| arm.body.iter().any(|s| Self::stmt_indexes_vob_with_var(s, var, ports, wires)))
+                    || m.arms.iter().any(|arm| {
+                        arm.body
+                            .iter()
+                            .any(|s| Self::stmt_indexes_vob_with_var(s, var, ports, wires))
+                    })
             }
-            Stmt::For(f) => f.body.iter().any(|s| Self::stmt_indexes_vob_with_var(s, var, ports, wires)),
-            Stmt::Init(ib) => ib.body.iter().any(|s| Self::stmt_indexes_vob_with_var(s, var, ports, wires)),
-            Stmt::DoUntil { body, cond, .. } =>
+            Stmt::For(f) => f
+                .body
+                .iter()
+                .any(|s| Self::stmt_indexes_vob_with_var(s, var, ports, wires)),
+            Stmt::Init(ib) => ib
+                .body
+                .iter()
+                .any(|s| Self::stmt_indexes_vob_with_var(s, var, ports, wires)),
+            Stmt::DoUntil { body, cond, .. } => {
                 walk_expr(cond, var, ports, wires)
-                    || body.iter().any(|s| Self::stmt_indexes_vob_with_var(s, var, ports, wires)),
+                    || body
+                        .iter()
+                        .any(|s| Self::stmt_indexes_vob_with_var(s, var, ports, wires))
+            }
             Stmt::WaitUntil(e, _) => walk_expr(e, var, ports, wires),
             Stmt::Log(l) => l.args.iter().any(|a| walk_expr(a, var, ports, wires)),
         }
@@ -1434,34 +1605,54 @@ impl<'a> Codegen<'a> {
     /// Emit a `log(...)` statement as an `if`-guarded `$display` or `$fwrite`.
     /// Wrapped in translate_off/on so synthesis tools ignore it.
     fn emit_log_stmt(&mut self, l: &LogStmt) {
-        let args_str: String = l.args.iter()
+        let args_str: String = l
+            .args
+            .iter()
             .map(|a| format!(", {}", self.emit_expr_str(a)))
             .collect();
         let stmt = if let Some(ref path) = l.file {
             let fd_name = Self::log_fd_name(path);
             format!(
                 "$fwrite({}, \"[%0t][{}][{}] {}\\n\", $time{});",
-                fd_name, l.level.name(), l.tag, l.fmt, args_str
+                fd_name,
+                l.level.name(),
+                l.tag,
+                l.fmt,
+                args_str
             )
         } else {
             format!(
                 "$display(\"[%0t][{}][{}] {}\", $time{});",
-                l.level.name(), l.tag, l.fmt, args_str
+                l.level.name(),
+                l.tag,
+                l.fmt,
+                args_str
             )
         };
         self.line("// synopsys translate_off");
         if l.level == LogLevel::Always {
             self.line(&stmt);
         } else {
-            self.line(&format!("if (_arch_verbosity >= {}) {}", l.level.value(), stmt));
+            self.line(&format!(
+                "if (_arch_verbosity >= {}) {}",
+                l.level.value(),
+                stmt
+            ));
         }
         self.line("// synopsys translate_on");
     }
 
     /// Generate a deterministic SV file descriptor name from a log file path.
     fn log_fd_name(path: &str) -> String {
-        let clean: String = path.chars()
-            .map(|c| if c.is_alphanumeric() || c == '_' { c } else { '_' })
+        let clean: String = path
+            .chars()
+            .map(|c| {
+                if c.is_alphanumeric() || c == '_' {
+                    c
+                } else {
+                    '_'
+                }
+            })
             .collect();
         format!("_log_fd_{clean}")
     }
@@ -1495,7 +1686,11 @@ impl<'a> Codegen<'a> {
                                 Pattern::Literal(e) => self.emit_expr_str(e),
                                 Pattern::Ident(id) => id.name.clone(),
                                 Pattern::EnumVariant(en, vr) => {
-                                    format!("{}__{}", en.name.to_uppercase(), vr.name.to_uppercase())
+                                    format!(
+                                        "{}__{}",
+                                        en.name.to_uppercase(),
+                                        vr.name.to_uppercase()
+                                    )
                                 }
                             };
                             let val = self.emit_expr_str(&arm.value);
@@ -1548,7 +1743,11 @@ impl<'a> Codegen<'a> {
 
     fn emit_if_else(&mut self, ie: &IfElse, ctx: AssignCtx, is_chain: bool) {
         let cond = self.emit_expr_str(&ie.cond);
-        let u = if ie.unique && !is_chain { "unique " } else { "" };
+        let u = if ie.unique && !is_chain {
+            "unique "
+        } else {
+            ""
+        };
         if is_chain {
             self.line(&format!("end else if ({}) begin", cond));
         } else {
@@ -1580,7 +1779,6 @@ impl<'a> Codegen<'a> {
         self.emit_stmt(stmt, AssignCtx::Blocking);
     }
 
-
     fn reset_value_expr(reset: &RegReset) -> Option<&Expr> {
         match reset {
             RegReset::None => None,
@@ -1591,13 +1789,11 @@ impl<'a> Codegen<'a> {
     fn resolve_reg_reset(&self, reset: &RegReset, m: &ModuleDecl) -> Option<(String, bool, bool)> {
         match reset {
             RegReset::None => Option::None,
-            RegReset::Explicit(signal, kind, level, _) => {
-                Some((
-                    signal.name.clone(),
-                    *kind == ResetKind::Async,
-                    *level == ResetLevel::Low,
-                ))
-            }
+            RegReset::Explicit(signal, kind, level, _) => Some((
+                signal.name.clone(),
+                *kind == ResetKind::Async,
+                *level == ResetLevel::Low,
+            )),
             RegReset::Inherit(signal, _) => {
                 // Look up the port declaration to get sync/async and polarity
                 let port = m.ports.iter().find(|p| p.name.name == signal.name);
@@ -1682,10 +1878,14 @@ impl<'a> Codegen<'a> {
                 }
             }
             Stmt::IfElse(ie) => {
-                let then_filt: Vec<Stmt> = ie.then_stmts.iter()
+                let then_filt: Vec<Stmt> = ie
+                    .then_stmts
+                    .iter()
                     .filter_map(|s| Self::filter_stmt_by_assigned_set(s, target_set, keep_in_set))
                     .collect();
-                let else_filt: Vec<Stmt> = ie.else_stmts.iter()
+                let else_filt: Vec<Stmt> = ie
+                    .else_stmts
+                    .iter()
                     .filter_map(|s| Self::filter_stmt_by_assigned_set(s, target_set, keep_in_set))
                     .collect();
                 if then_filt.is_empty() && else_filt.is_empty() {
@@ -1701,15 +1901,27 @@ impl<'a> Codegen<'a> {
                 let mut clone = m.clone();
                 let mut any = false;
                 for arm in &mut clone.arms {
-                    arm.body = arm.body.iter()
-                        .filter_map(|s| Self::filter_stmt_by_assigned_set(s, target_set, keep_in_set))
+                    arm.body = arm
+                        .body
+                        .iter()
+                        .filter_map(|s| {
+                            Self::filter_stmt_by_assigned_set(s, target_set, keep_in_set)
+                        })
                         .collect();
-                    if !arm.body.is_empty() { any = true; }
+                    if !arm.body.is_empty() {
+                        any = true;
+                    }
                 }
-                if any { Some(Stmt::Match(clone)) } else { None }
+                if any {
+                    Some(Stmt::Match(clone))
+                } else {
+                    None
+                }
             }
             Stmt::For(f) => {
-                let body_filt: Vec<Stmt> = f.body.iter()
+                let body_filt: Vec<Stmt> = f
+                    .body
+                    .iter()
                     .filter_map(|s| Self::filter_stmt_by_assigned_set(s, target_set, keep_in_set))
                     .collect();
                 if body_filt.is_empty() {
@@ -1721,7 +1933,9 @@ impl<'a> Codegen<'a> {
                 }
             }
             Stmt::Init(ib) => {
-                let body_filt: Vec<Stmt> = ib.body.iter()
+                let body_filt: Vec<Stmt> = ib
+                    .body
+                    .iter()
                     .filter_map(|s| Self::filter_stmt_by_assigned_set(s, target_set, keep_in_set))
                     .collect();
                 if body_filt.is_empty() {
@@ -1733,13 +1947,18 @@ impl<'a> Codegen<'a> {
                 }
             }
             Stmt::DoUntil { body, cond, span } => {
-                let body_filt: Vec<Stmt> = body.iter()
+                let body_filt: Vec<Stmt> = body
+                    .iter()
                     .filter_map(|s| Self::filter_stmt_by_assigned_set(s, target_set, keep_in_set))
                     .collect();
                 if body_filt.is_empty() {
                     None
                 } else {
-                    Some(Stmt::DoUntil { body: body_filt, cond: cond.clone(), span: *span })
+                    Some(Stmt::DoUntil {
+                        body: body_filt,
+                        cond: cond.clone(),
+                        span: *span,
+                    })
                 }
             }
             // Log + WaitUntil don't have assignments themselves; if they
@@ -1791,11 +2010,13 @@ impl<'a> Codegen<'a> {
                 "to_bf16" => Some("bf16"),
                 _ => None,
             },
-            ExprKind::FunctionCall(name, args) if name == "fma" =>
-                args.first().and_then(|a| self.expr_float_fmt(a)),
+            ExprKind::FunctionCall(name, args) if name == "fma" => {
+                args.first().and_then(|a| self.expr_float_fmt(a))
+            }
             ExprKind::Binary(op, lhs, rhs) => match op {
-                BinOp::Add | BinOp::Sub | BinOp::Mul =>
-                    self.expr_float_fmt(lhs).or_else(|| self.expr_float_fmt(rhs)),
+                BinOp::Add | BinOp::Sub | BinOp::Mul => self
+                    .expr_float_fmt(lhs)
+                    .or_else(|| self.expr_float_fmt(rhs)),
                 _ => None,
             },
             ExprKind::Ternary(_, t, e) => self.expr_float_fmt(t).or_else(|| self.expr_float_fmt(e)),
@@ -1882,7 +2103,10 @@ impl<'a> Codegen<'a> {
                     for bi in &m.body {
                         if let ModuleBodyItem::LetBinding(l) = bi {
                             if l.name.name == name {
-                                return l.ty.as_ref().map_or(false, |t| matches!(t, TypeExpr::SInt(_)));
+                                return l
+                                    .ty
+                                    .as_ref()
+                                    .map_or(false, |t| matches!(t, TypeExpr::SInt(_)));
                             }
                         }
                     }
@@ -1890,7 +2114,10 @@ impl<'a> Codegen<'a> {
                 Item::Fsm(f) if f.name.name == self.current_construct => {
                     for l in &f.lets {
                         if l.name.name == name {
-                            return l.ty.as_ref().map_or(false, |t| matches!(t, TypeExpr::SInt(_)));
+                            return l
+                                .ty
+                                .as_ref()
+                                .map_or(false, |t| matches!(t, TypeExpr::SInt(_)));
                         }
                     }
                 }
@@ -1971,7 +2198,10 @@ impl<'a> Codegen<'a> {
                     let val = match lit {
                         LitKind::Dec(v) | LitKind::Hex(v) | LitKind::Bin(v) => *v as i64,
                         LitKind::Sized(_, v) => *v as i64,
-                        LitKind::Float(_) => { terms.push((sign, None, expr_key(expr))); return; }
+                        LitKind::Float(_) => {
+                            terms.push((sign, None, expr_key(expr)));
+                            return;
+                        }
                     };
                     terms.push((sign, Some(val), String::new()));
                 }
@@ -2018,7 +2248,8 @@ impl<'a> Codegen<'a> {
         }
 
         // Collect remaining (non-cancelled) variable terms
-        let remaining_vars: Vec<(&String, &i64)> = var_map.iter().filter(|(_, &v)| v != 0).collect();
+        let remaining_vars: Vec<(&String, &i64)> =
+            var_map.iter().filter(|(_, &v)| v != 0).collect();
 
         if remaining_vars.is_empty() && const_sum > 0 {
             // Pure constant width
@@ -2048,8 +2279,12 @@ impl<'a> Codegen<'a> {
         match &expr.kind {
             ExprKind::Ident(n) => n.clone(),
             ExprKind::FieldAccess(base, _) => Self::expr_root_name(base),
-            ExprKind::Index(base, _) | ExprKind::BitSlice(base, _, _) | ExprKind::PartSelect(base, _, _, _) => Self::expr_root_name(base),
-            ExprKind::LatencyAt(inner, _) | ExprKind::SvaNext(_, inner) => Self::expr_root_name(inner),
+            ExprKind::Index(base, _)
+            | ExprKind::BitSlice(base, _, _)
+            | ExprKind::PartSelect(base, _, _, _) => Self::expr_root_name(base),
+            ExprKind::LatencyAt(inner, _) | ExprKind::SvaNext(_, inner) => {
+                Self::expr_root_name(inner)
+            }
             _ => String::new(),
         }
     }
@@ -2067,9 +2302,7 @@ impl<'a> Codegen<'a> {
     /// nothing about it is fifo-specific.
     fn type_expr_data_width(&self, ty: &TypeExpr) -> Option<String> {
         match ty {
-            TypeExpr::UInt(w) | TypeExpr::SInt(w) => {
-                Some(self.emit_expr_str(w))
-            }
+            TypeExpr::UInt(w) | TypeExpr::SInt(w) => Some(self.emit_expr_str(w)),
             TypeExpr::Bool | TypeExpr::Bit | TypeExpr::Clock(_) | TypeExpr::Reset(_, _) => {
                 Some("1".to_string())
             }
@@ -2081,7 +2314,9 @@ impl<'a> Codegen<'a> {
                 Some(format!("({iw}) * ({n})"))
             }
             TypeExpr::Named(ident) => {
-                if let Some((crate::resolve::Symbol::Struct(info), _)) = self.symbols.globals.get(&ident.name) {
+                if let Some((crate::resolve::Symbol::Struct(info), _)) =
+                    self.symbols.globals.get(&ident.name)
+                {
                     let mut parts = Vec::new();
                     for (_, field_ty) in &info.fields {
                         parts.push(self.type_expr_data_width(field_ty)?);
@@ -2091,7 +2326,9 @@ impl<'a> Codegen<'a> {
                     } else {
                         Some(parts.join(" + "))
                     }
-                } else if let Some((crate::resolve::Symbol::Enum(info), _)) = self.symbols.globals.get(&ident.name) {
+                } else if let Some((crate::resolve::Symbol::Enum(info), _)) =
+                    self.symbols.globals.get(&ident.name)
+                {
                     let n = info.variants.len();
                     let bits = crate::width::index_width(n as u64);
                     Some(bits.to_string())
@@ -2125,7 +2362,6 @@ impl<'a> Codegen<'a> {
         self.emit_stmt(stmt, AssignCtx::NonBlocking);
     }
 
-
     /// Auto-declare `logic` wires for inst output connections that reference
     /// names not already declared as ports, regs, or lets in the current module.
     /// The wire type is resolved from the source module's port definition.
@@ -2147,9 +2383,7 @@ impl<'a> Codegen<'a> {
             self.symbols.globals.get(&inst.module_name.name)
         {
             info.ports.clone()
-        } else if let Some((Symbol::Ram(_), _)) =
-            self.symbols.globals.get(&inst.module_name.name)
-        {
+        } else if let Some((Symbol::Ram(_), _)) = self.symbols.globals.get(&inst.module_name.name) {
             // RAM uses port groups — handle separately below
             Vec::new()
         } else if let Some((Symbol::Regfile(_), _)) =
@@ -2163,43 +2397,47 @@ impl<'a> Codegen<'a> {
 
         // For RAM instances, build a flattened port map from port groups
         // Resolve type params (e.g. WIDTH → UInt<32>) from the RAM's param list.
-        let ram_flat_ports: Vec<(String, TypeExpr)> = if let Some((Symbol::Ram(_), _)) =
-            self.symbols.globals.get(&inst.module_name.name)
-        {
-            let mut flat = Vec::new();
-            for item in &self.source.items {
-                if let Item::Ram(r) = item {
-                    if r.name.name == inst.module_name.name {
-                        // Build type param map: param name → resolved TypeExpr
-                        let type_params: std::collections::HashMap<String, TypeExpr> = r.params.iter()
-                            .filter_map(|p| match &p.kind {
-                                crate::ast::ParamKind::Type(ty) => Some((p.name.name.clone(), ty.clone())),
-                                _ => None,
-                            })
-                            .collect();
-                        for pg in &r.port_groups {
-                            for s in &pg.signals {
-                                // Resolve Named type params to their actual types
-                                let resolved_ty = match &s.ty {
-                                    TypeExpr::Named(ident) => {
-                                        type_params.get(&ident.name).cloned().unwrap_or_else(|| s.ty.clone())
+        let ram_flat_ports: Vec<(String, TypeExpr)> =
+            if let Some((Symbol::Ram(_), _)) = self.symbols.globals.get(&inst.module_name.name) {
+                let mut flat = Vec::new();
+                for item in &self.source.items {
+                    if let Item::Ram(r) = item {
+                        if r.name.name == inst.module_name.name {
+                            // Build type param map: param name → resolved TypeExpr
+                            let type_params: std::collections::HashMap<String, TypeExpr> = r
+                                .params
+                                .iter()
+                                .filter_map(|p| match &p.kind {
+                                    crate::ast::ParamKind::Type(ty) => {
+                                        Some((p.name.name.clone(), ty.clone()))
                                     }
-                                    other => other.clone(),
-                                };
-                                flat.push((
-                                    format!("{}_{}", pg.name.name, s.name.name),
-                                    resolved_ty,
-                                ));
+                                    _ => None,
+                                })
+                                .collect();
+                            for pg in &r.port_groups {
+                                for s in &pg.signals {
+                                    // Resolve Named type params to their actual types
+                                    let resolved_ty = match &s.ty {
+                                        TypeExpr::Named(ident) => type_params
+                                            .get(&ident.name)
+                                            .cloned()
+                                            .unwrap_or_else(|| s.ty.clone()),
+                                        other => other.clone(),
+                                    };
+                                    flat.push((
+                                        format!("{}_{}", pg.name.name, s.name.name),
+                                        resolved_ty,
+                                    ));
+                                }
                             }
+                            break;
                         }
-                        break;
                     }
                 }
-            }
-            flat
-        } else {
-            Vec::new()
-        };
+                flat
+            } else {
+                Vec::new()
+            };
 
         // For Regfile instances, build a flattened port map from port arrays
         let regfile_flat_ports: Vec<(String, TypeExpr)> = if let Some((Symbol::Regfile(_), _)) =
@@ -2218,7 +2456,10 @@ impl<'a> Codegen<'a> {
                             let count = self.resolve_regfile_count(&rp.count_expr, r);
                             for i in 0..count {
                                 for s in &rp.signals {
-                                    flat.push((format!("{}{i}_{}", rp.name.name, s.name.name), s.ty.clone()));
+                                    flat.push((
+                                        format!("{}{i}_{}", rp.name.name, s.name.name),
+                                        s.ty.clone(),
+                                    ));
                                 }
                             }
                         }
@@ -2227,7 +2468,10 @@ impl<'a> Codegen<'a> {
                             let count = self.resolve_regfile_count(&wp.count_expr, r);
                             for i in 0..count {
                                 for s in &wp.signals {
-                                    flat.push((format!("{}{i}_{}", wp.name.name, s.name.name), s.ty.clone()));
+                                    flat.push((
+                                        format!("{}{i}_{}", wp.name.name, s.name.name),
+                                        s.ty.clone(),
+                                    ));
                                 }
                             }
                         }
@@ -2248,16 +2492,31 @@ impl<'a> Codegen<'a> {
         // signals like `_flits_send_data` and the design appears dead.
         let mut bus_emitted: std::collections::HashSet<String> = std::collections::HashSet::new();
         for conn in &inst.connections {
-            let Some(port) = module_ports.iter().find(|p| p.name.name == conn.port_name.name) else { continue; };
-            let Some(bi) = &port.bus_info else { continue; };
-            let ExprKind::Ident(parent_name) = &conn.signal.kind else { continue; };
-            let Some((Symbol::Bus(bus_info), _)) =
-                self.symbols.globals.get(&bi.bus_name.name) else { continue; };
+            let Some(port) = module_ports
+                .iter()
+                .find(|p| p.name.name == conn.port_name.name)
+            else {
+                continue;
+            };
+            let Some(bi) = &port.bus_info else {
+                continue;
+            };
+            let ExprKind::Ident(parent_name) = &conn.signal.kind else {
+                continue;
+            };
+            let Some((Symbol::Bus(bus_info), _)) = self.symbols.globals.get(&bi.bus_name.name)
+            else {
+                continue;
+            };
             let mut pm = bus_info.default_param_map();
-            for pa in &bi.params { pm.insert(pa.name.name.clone(), &pa.value); }
+            for pa in &bi.params {
+                pm.insert(pa.name.name.clone(), &pa.value);
+            }
             for (sname, _sdir, ty) in bus_info.effective_signals(&pm) {
                 let flat = format!("{parent_name}_{sname}");
-                if declared.contains(&flat) || !bus_emitted.insert(flat.clone()) { continue; }
+                if declared.contains(&flat) || !bus_emitted.insert(flat.clone()) {
+                    continue;
+                }
                 let subst_ty = Self::subst_type_expr(&ty, &pm);
                 let (ty_str, arr_suffix) = self.emit_type_and_array_suffix(&subst_ty);
                 self.line(&format!("{} {}{};", ty_str, flat, arr_suffix));
@@ -2273,14 +2532,25 @@ impl<'a> Codegen<'a> {
                     continue;
                 }
                 // Bus ports are handled above as a separate pass; skip.
-                if let Some(port) = module_ports.iter().find(|p| p.name.name == conn.port_name.name) {
-                    if port.bus_info.is_some() { continue; }
+                if let Some(port) = module_ports
+                    .iter()
+                    .find(|p| p.name.name == conn.port_name.name)
+                {
+                    if port.bus_info.is_some() {
+                        continue;
+                    }
                     let (ty_str, arr_suffix) = self.emit_type_and_array_suffix(&port.ty);
                     self.line(&format!("{} {}{};", ty_str, target, arr_suffix));
-                } else if let Some((_, ty)) = ram_flat_ports.iter().find(|(n, _)| *n == conn.port_name.name) {
+                } else if let Some((_, ty)) = ram_flat_ports
+                    .iter()
+                    .find(|(n, _)| *n == conn.port_name.name)
+                {
                     let (ty_str, arr_suffix) = self.emit_type_and_array_suffix(ty);
                     self.line(&format!("{} {}{};", ty_str, target, arr_suffix));
-                } else if let Some((_, ty)) = regfile_flat_ports.iter().find(|(n, _)| *n == conn.port_name.name) {
+                } else if let Some((_, ty)) = regfile_flat_ports
+                    .iter()
+                    .find(|(n, _)| *n == conn.port_name.name)
+                {
                     let (ty_str, arr_suffix) = self.emit_type_and_array_suffix(ty);
                     self.line(&format!("{} {}{};", ty_str, target, arr_suffix));
                 } else {
@@ -2294,16 +2564,22 @@ impl<'a> Codegen<'a> {
         use crate::ast::{ExprKind, LitKind, ParamKind};
         match &expr.kind {
             ExprKind::Literal(LitKind::Dec(v)) => *v,
-            ExprKind::Ident(name) => {
-                r.params.iter()
-                    .find(|p| p.name.name == *name)
-                    .and_then(|p| match &p.kind {
-                        ParamKind::Const | ParamKind::WidthConst(..) => p.default.as_ref(),
-                        _ => None,
-                    })
-                    .and_then(|e| if let ExprKind::Literal(LitKind::Dec(v)) = &e.kind { Some(*v) } else { None })
-                    .unwrap_or(1)
-            }
+            ExprKind::Ident(name) => r
+                .params
+                .iter()
+                .find(|p| p.name.name == *name)
+                .and_then(|p| match &p.kind {
+                    ParamKind::Const | ParamKind::WidthConst(..) => p.default.as_ref(),
+                    _ => None,
+                })
+                .and_then(|e| {
+                    if let ExprKind::Literal(LitKind::Dec(v)) = &e.kind {
+                        Some(*v)
+                    } else {
+                        None
+                    }
+                })
+                .unwrap_or(1),
             _ => 1,
         }
     }
@@ -2331,8 +2607,8 @@ impl<'a> Codegen<'a> {
         // Expand bus port connections: one bus connect → N signal connects
         let mut connections: Vec<String> = Vec::new();
         // Find the target construct's ports to detect bus ports (modules and FSMs)
-        let target_ports_ref: Option<&[PortDecl]> = self.source.items.iter()
-            .find_map(|item| match item {
+        let target_ports_ref: Option<&[PortDecl]> =
+            self.source.items.iter().find_map(|item| match item {
                 Item::Module(m) if m.name.name == inst.module_name.name => Some(m.ports.as_slice()),
                 Item::Fsm(f) if f.name.name == inst.module_name.name => Some(f.ports.as_slice()),
                 _ => None,
@@ -2343,14 +2619,28 @@ impl<'a> Codegen<'a> {
         // element of the child. Vec count is resolved against the child
         // module's params (with the inst-site `param NAME = ...` overrides
         // applied on top).
-        let child_params: Vec<ParamDecl> = self.source.items.iter()
-            .find_map(|item| if let Item::Module(m) = item {
-                if m.name.name == inst.module_name.name { Some(m.params.clone()) } else { None }
-            } else { None })
+        let child_params: Vec<ParamDecl> = self
+            .source
+            .items
+            .iter()
+            .find_map(|item| {
+                if let Item::Module(m) = item {
+                    if m.name.name == inst.module_name.name {
+                        Some(m.params.clone())
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                }
+            })
             .unwrap_or_default();
         let mut child_params_overridden = child_params.clone();
         for pa in &inst.param_assigns {
-            if let Some(p) = child_params_overridden.iter_mut().find(|p| p.name.name == pa.name.name) {
+            if let Some(p) = child_params_overridden
+                .iter_mut()
+                .find(|p| p.name.name == pa.name.name)
+            {
                 // The override RHS is written in the *parent* param scope, so
                 // resolve it there before substituting into the child param
                 // list. Without this, `param NUM = NUM` (parent NUM forwarded
@@ -2378,12 +2668,22 @@ impl<'a> Codegen<'a> {
                     if let Some(bi) = p.bus_info.as_ref() {
                         match bi.count.as_ref() {
                             None => {
-                                v.push((p.name.name.clone(), bi.bus_name.name.clone(), bi.params.clone()));
+                                v.push((
+                                    p.name.name.clone(),
+                                    bi.bus_name.name.clone(),
+                                    bi.params.clone(),
+                                ));
                             }
                             Some(count_expr) => {
-                                if let Some(n) = self.eval_const_u32(count_expr, &child_params_overridden) {
+                                if let Some(n) =
+                                    self.eval_const_u32(count_expr, &child_params_overridden)
+                                {
                                     for i in 0..n {
-                                        v.push((format!("{}_{}", p.name.name, i), bi.bus_name.name.clone(), bi.params.clone()));
+                                        v.push((
+                                            format!("{}_{}", p.name.name, i),
+                                            bi.bus_name.name.clone(),
+                                            bi.params.clone(),
+                                        ));
                                     }
                                 }
                             }
@@ -2398,21 +2698,29 @@ impl<'a> Codegen<'a> {
         // and parent signal are `Vec<Bus, N>`) expand to N per-element
         // per-signal named-port connections without requiring the user
         // to enumerate `chans[0] -> w[0]; chans[1] -> w[1]; ...`.
-        let target_vec_of_bus_ports: Vec<(String, u32, String, Vec<ParamAssign>)> = target_ports_ref
-            .map(|ports| {
-                let mut v = Vec::new();
-                for p in ports {
-                    if let Some(bi) = p.bus_info.as_ref() {
-                        if let Some(count_expr) = bi.count.as_ref() {
-                            if let Some(n) = self.eval_const_u32(count_expr, &child_params_overridden) {
-                                v.push((p.name.name.clone(), n, bi.bus_name.name.clone(), bi.params.clone()));
+        let target_vec_of_bus_ports: Vec<(String, u32, String, Vec<ParamAssign>)> =
+            target_ports_ref
+                .map(|ports| {
+                    let mut v = Vec::new();
+                    for p in ports {
+                        if let Some(bi) = p.bus_info.as_ref() {
+                            if let Some(count_expr) = bi.count.as_ref() {
+                                if let Some(n) =
+                                    self.eval_const_u32(count_expr, &child_params_overridden)
+                                {
+                                    v.push((
+                                        p.name.name.clone(),
+                                        n,
+                                        bi.bus_name.name.clone(),
+                                        bi.params.clone(),
+                                    ));
+                                }
                             }
                         }
                     }
-                }
-                v
-            })
-            .unwrap_or_default();
+                    v
+                })
+                .unwrap_or_default();
 
         // Per-port enum-cast lookup. For each input port whose type is
         // an extern-package enum (declared via `extern package Pkg ...
@@ -2430,16 +2738,25 @@ impl<'a> Codegen<'a> {
             if let Some(ports) = target_ports_ref {
                 for p in ports {
                     if let TypeExpr::Named(id) = &p.ty {
-                        if let Some((Symbol::ExternEnum(_), _)) = self.symbols.globals.get(&id.name) {
+                        if let Some((Symbol::ExternEnum(_), _)) = self.symbols.globals.get(&id.name)
+                        {
                             // Find the owning extern-package by scanning
                             // Item::ExternPackage entries — the resolve
                             // table records only the type name, not its
                             // owning package.
-                            let pkg_name = self.source.items.iter().find_map(|it| match it {
-                                Item::ExternPackage(ep) if ep.types.iter().any(|t| t.name == id.name) =>
-                                    Some(ep.name.name.clone()),
-                                _ => None,
-                            }).unwrap_or_else(|| id.name.clone());
+                            let pkg_name = self
+                                .source
+                                .items
+                                .iter()
+                                .find_map(|it| match it {
+                                    Item::ExternPackage(ep)
+                                        if ep.types.iter().any(|t| t.name == id.name) =>
+                                    {
+                                        Some(ep.name.name.clone())
+                                    }
+                                    _ => None,
+                                })
+                                .unwrap_or_else(|| id.name.clone());
                             m.insert(p.name.name.clone(), (pkg_name, id.name.clone()));
                         }
                     }
@@ -2470,19 +2787,28 @@ impl<'a> Codegen<'a> {
         // `read1_addr`, ...) so the existing flattened-port-name behavior
         // is correct there. Regfile is intentionally excluded from the
         // synthesis here.
-        let target_port_arrays: Vec<(String, u64, Vec<(String, Direction, TypeExpr)>)> =
-            self.source.items.iter().find_map(|item| match item {
+        let target_port_arrays: Vec<(String, u64, Vec<(String, Direction, TypeExpr)>)> = self
+            .source
+            .items
+            .iter()
+            .find_map(|item| match item {
                 Item::Arbiter(a) if a.name.name == inst.module_name.name => Some(
-                    a.port_arrays.iter().map(|pa| {
-                        let n = self.eval_count_with_inst_params(&pa.count_expr, inst);
-                        let signals = pa.signals.iter()
-                            .map(|s| (s.name.name.clone(), s.direction, s.ty.clone()))
-                            .collect();
-                        (pa.name.name.clone(), n, signals)
-                    }).collect()
+                    a.port_arrays
+                        .iter()
+                        .map(|pa| {
+                            let n = self.eval_count_with_inst_params(&pa.count_expr, inst);
+                            let signals = pa
+                                .signals
+                                .iter()
+                                .map(|s| (s.name.name.clone(), s.direction, s.ty.clone()))
+                                .collect();
+                            (pa.name.name.clone(), n, signals)
+                        })
+                        .collect(),
                 ),
                 _ => None,
-            }).unwrap_or_default();
+            })
+            .unwrap_or_default();
 
         // Unified per-element "indexed-port-group" gather state. Both the
         // arbiter `port_arrays` flattening (`.req0_valid` → packed wire +
@@ -2495,8 +2821,11 @@ impl<'a> Codegen<'a> {
             std::collections::HashMap::new();
         // (base_port_name, N) → bus_name, bus_params for VOB packed emit.
         let vob_port_meta: std::collections::HashMap<String, (u32, String, Vec<ParamAssign>)> =
-            target_vec_of_bus_ports.iter()
-                .map(|(name, n, bus_name, bus_params)| (name.clone(), (*n, bus_name.clone(), bus_params.clone())))
+            target_vec_of_bus_ports
+                .iter()
+                .map(|(name, n, bus_name, bus_params)| {
+                    (name.clone(), (*n, bus_name.clone(), bus_params.clone()))
+                })
                 .collect();
 
         for c in &inst.connections {
@@ -2510,8 +2839,7 @@ impl<'a> Codegen<'a> {
                 let idx_str = &rest[..und];
                 let sig = &rest[und + 1..];
                 let idx: u32 = idx_str.parse().ok()?;
-                let (sname, dir, ty) = sigs.iter()
-                    .find(|(sn, _, _)| sn == sig)?;
+                let (sname, dir, ty) = sigs.iter().find(|(sn, _, _)| sn == sig)?;
                 Some((group.clone(), idx, sname.clone(), *dir, ty.clone()))
             });
             if let Some((group, idx, sig, dir, ty)) = matched {
@@ -2520,7 +2848,8 @@ impl<'a> Codegen<'a> {
                 // separate temp wire per (group, sig) pair, so use the
                 // concatenated key as the map slot.
                 let key = format!("{group}.{sig}");
-                let n = target_port_arrays.iter()
+                let n = target_port_arrays
+                    .iter()
                     .find(|(g, _, _)| *g == group)
                     .map(|(_, n, _)| *n)
                     .unwrap_or(0);
@@ -2529,12 +2858,16 @@ impl<'a> Codegen<'a> {
                     .or_insert_with(|| IndexedGroup {
                         base_port: group.clone(),
                         kind: GroupKind::ArbiterPortArray {
-                            sig: sig.clone(), dir, ty: ty.clone(), n,
+                            sig: sig.clone(),
+                            dir,
+                            ty: ty.clone(),
+                            n,
                         },
                         arb_entries: Vec::new(),
                         vob_entries: std::collections::HashMap::new(),
                     })
-                    .arb_entries.push((idx, sig_str));
+                    .arb_entries
+                    .push((idx, sig_str));
                 continue;
             }
             // Whole-vec bus connection on a Vec-of-bus child port.
@@ -2543,7 +2876,8 @@ impl<'a> Codegen<'a> {
             //   `chans -> w`       (1D Vec-of-bus wire `w` → packed `w_<sig>`)
             //   `chans -> edges[i]` (row of 2D wire → packed slice `edges_<sig>[i]`)
             //   `chans -> p`       (parent Vec-of-bus port `p` → packed `p_<sig>`)
-            if let Some((_, _n, bus_name, bus_params)) = target_vec_of_bus_ports.iter()
+            if let Some((_, _n, bus_name, bus_params)) = target_vec_of_bus_ports
+                .iter()
                 .find(|(pn, _, _, _)| *pn == c.port_name.name)
             {
                 let parent_expr_str = self.emit_expr_str(&c.signal);
@@ -2557,10 +2891,11 @@ impl<'a> Codegen<'a> {
                         ExprKind::Ident(name) => format!("{}_{}", name, sname),
                         ExprKind::Index(arr, idx) => {
                             let idx_str = match &idx.kind {
-                                ExprKind::Ident(loopvar) =>
-                                    self_.loop_var_subst.get(loopvar)
-                                        .map(|v| v.to_string())
-                                        .unwrap_or_else(|| loopvar.clone()),
+                                ExprKind::Ident(loopvar) => self_
+                                    .loop_var_subst
+                                    .get(loopvar)
+                                    .map(|v| v.to_string())
+                                    .unwrap_or_else(|| loopvar.clone()),
                                 _ => self_.emit_expr_str(idx),
                             };
                             if let ExprKind::Ident(arr_name) = &arr.kind {
@@ -2574,15 +2909,21 @@ impl<'a> Codegen<'a> {
                     }
                 };
                 if let Some((Symbol::Bus(info), _)) = self.symbols.globals.get(bus_name) {
-                    let mut param_map: std::collections::HashMap<String, &Expr> = info.params.iter()
+                    let mut param_map: std::collections::HashMap<String, &Expr> = info
+                        .params
+                        .iter()
                         .filter_map(|pd| pd.default.as_ref().map(|d| (pd.name.name.clone(), d)))
                         .collect();
-                    for pa in bus_params { param_map.insert(pa.name.name.clone(), &pa.value); }
+                    for pa in bus_params {
+                        param_map.insert(pa.name.name.clone(), &pa.value);
+                    }
                     let eff = info.effective_signals(&param_map);
                     for (sname, _, _) in &eff {
                         connections.push(format!(
                             ".{}_{}({})",
-                            c.port_name.name, sname, per_sig_emit(sname, self),
+                            c.port_name.name,
+                            sname,
+                            per_sig_emit(sname, self),
                         ));
                     }
                     continue;
@@ -2598,7 +2939,11 @@ impl<'a> Codegen<'a> {
                     let prefix = format!("{base}_");
                     let rest = pname.strip_prefix(&prefix)?;
                     let idx: u32 = rest.parse().ok()?;
-                    if idx < *n { Some((base.clone(), idx)) } else { None }
+                    if idx < *n {
+                        Some((base.clone(), idx))
+                    } else {
+                        None
+                    }
                 });
                 if let Some((base, idx)) = matched_vob {
                     let Some((n, bus_name, bus_params)) = vob_port_meta.get(&base) else {
@@ -2616,11 +2961,15 @@ impl<'a> Codegen<'a> {
                             arb_entries: Vec::new(),
                             vob_entries: std::collections::HashMap::new(),
                         })
-                        .vob_entries.insert(idx, c.signal.clone());
+                        .vob_entries
+                        .insert(idx, c.signal.clone());
                     continue;
                 }
             }
-            if let Some((_, bus_name, bus_params)) = target_bus_ports.iter().find(|(pn, _, _)| *pn == c.port_name.name) {
+            if let Some((_, bus_name, bus_params)) = target_bus_ports
+                .iter()
+                .find(|(pn, _, _)| *pn == c.port_name.name)
+            {
                 // Bus connection — expand to individual signals. The parent-side
                 // signal can be one of:
                 //   * `Ident("w")`               — scalar bus port or bus wire        → `w_<sig>`
@@ -2629,8 +2978,12 @@ impl<'a> Codegen<'a> {
                 //                                  where <e> is a literal, a loop var
                 //                                  (left as-is for SV genvar), or
                 //                                  a static-unrolled loop var.
-                if let Some((crate::resolve::Symbol::Bus(info), _)) = self.symbols.globals.get(bus_name) {
-                    let mut param_map: std::collections::HashMap<String, &Expr> = info.params.iter()
+                if let Some((crate::resolve::Symbol::Bus(info), _)) =
+                    self.symbols.globals.get(bus_name)
+                {
+                    let mut param_map: std::collections::HashMap<String, &Expr> = info
+                        .params
+                        .iter()
                         .filter_map(|pd| pd.default.as_ref().map(|d| (pd.name.name.clone(), d)))
                         .collect();
                     for pa in bus_params {
@@ -2663,8 +3016,12 @@ impl<'a> Codegen<'a> {
                                         _ => self.emit_expr_str(idx),
                                     };
                                     Some((arr_name.clone(), idx_str))
-                                } else { None }
-                            } else { None }
+                                } else {
+                                    None
+                                }
+                            } else {
+                                None
+                            }
                         }
                         _ => None,
                     };
@@ -2684,18 +3041,27 @@ impl<'a> Codegen<'a> {
                                 let resolve = |e: &Expr| -> Option<u64> {
                                     match &e.kind {
                                         ExprKind::Literal(LitKind::Dec(i)) => Some(*i),
-                                        ExprKind::Ident(loopvar) =>
-                                            self.loop_var_subst.get(loopvar).map(|v| *v as u64),
+                                        ExprKind::Ident(loopvar) => {
+                                            self.loop_var_subst.get(loopvar).map(|v| *v as u64)
+                                        }
                                         _ => None,
                                     }
                                 };
                                 if let ExprKind::Index(inner_arr, inner_idx) = &arr.kind {
                                     if let ExprKind::Ident(arr_name) = &inner_arr.kind {
-                                        if let (Some(m_v), Some(n_v)) = (resolve(inner_idx), resolve(idx)) {
+                                        if let (Some(m_v), Some(n_v)) =
+                                            (resolve(inner_idx), resolve(idx))
+                                        {
                                             format!("{}_{}_{}", arr_name, m_v, n_v)
-                                        } else { self.emit_expr_str(&c.signal) }
-                                    } else { self.emit_expr_str(&c.signal) }
-                                } else if let (ExprKind::Ident(arr_name), Some(i)) = (&arr.kind, resolve(idx)) {
+                                        } else {
+                                            self.emit_expr_str(&c.signal)
+                                        }
+                                    } else {
+                                        self.emit_expr_str(&c.signal)
+                                    }
+                                } else if let (ExprKind::Ident(arr_name), Some(i)) =
+                                    (&arr.kind, resolve(idx))
+                                {
                                     format!("{}_{}", arr_name, i)
                                 } else {
                                     self.emit_expr_str(&c.signal)
@@ -2704,13 +3070,17 @@ impl<'a> Codegen<'a> {
                             _ => self.emit_expr_str(&c.signal),
                         };
                         for (sname, _, _) in &eff_signals {
-                            connections.push(format!(".{}_{}({}_{})", c.port_name.name, sname, sig_prefix, sname));
+                            connections.push(format!(
+                                ".{}_{}({}_{})",
+                                c.port_name.name, sname, sig_prefix, sname
+                            ));
                         }
                     }
                 }
             } else {
                 let sig_str = self.emit_expr_str(&c.signal);
-                let conn_str = if let Some((pkg, ty_name)) = port_enum_casts.get(&c.port_name.name) {
+                let conn_str = if let Some((pkg, ty_name)) = port_enum_casts.get(&c.port_name.name)
+                {
                     // Wrap in explicit cast to the destination port's
                     // extern-enum type so yosys-slang accepts the
                     // boundary. No-op for verilator / iverilog.
@@ -2763,12 +3133,25 @@ impl<'a> Codegen<'a> {
     /// time; here we attach `.<sig>` and re-emit via `emit_expr_str`
     /// (which handles 2D-wire packed-slice lowering).
     fn emit_indexed_group(&self, g: &IndexedGroup, connections: &mut Vec<String>) {
-        let GroupKind::VecOfBusPacked { n, bus_name, bus_params } = &g.kind else { return };
-        let Some((Symbol::Bus(info), _)) = self.symbols.globals.get(bus_name) else { return };
-        let mut param_map: std::collections::HashMap<String, &Expr> = info.params.iter()
+        let GroupKind::VecOfBusPacked {
+            n,
+            bus_name,
+            bus_params,
+        } = &g.kind
+        else {
+            return;
+        };
+        let Some((Symbol::Bus(info), _)) = self.symbols.globals.get(bus_name) else {
+            return;
+        };
+        let mut param_map: std::collections::HashMap<String, &Expr> = info
+            .params
+            .iter()
             .filter_map(|pd| pd.default.as_ref().map(|d| (pd.name.name.clone(), d)))
             .collect();
-        for pa in bus_params { param_map.insert(pa.name.name.clone(), &pa.value); }
+        for pa in bus_params {
+            param_map.insert(pa.name.name.clone(), &pa.value);
+        }
         let eff = info.effective_signals(&param_map);
         for (sname, _, _) in &eff {
             // Build {expr_{N-1}_<sig>, expr_{N-2}_<sig>, …, expr_0_<sig>}.
@@ -2791,7 +3174,8 @@ impl<'a> Codegen<'a> {
             }
             connections.push(format!(
                 ".{}_{}({{{}}})",
-                g.base_port, sname,
+                g.base_port,
+                sname,
                 parts.join(", "),
             ));
         }
@@ -2807,11 +3191,17 @@ impl<'a> Codegen<'a> {
         inst: &InstDecl,
         connections: &mut Vec<String>,
     ) {
-        let GroupKind::ArbiterPortArray { sig, dir, ty, n } = &g.kind else { return };
+        let GroupKind::ArbiterPortArray { sig, dir, ty, n } = &g.kind else {
+            return;
+        };
         let group = &g.base_port;
         // If `n` is 0 (no port-array metadata found), fall back to the
         // entry count — preserves prior behavior.
-        let n = if *n == 0 { g.arb_entries.len() as u64 } else { *n };
+        let n = if *n == 0 {
+            g.arb_entries.len() as u64
+        } else {
+            *n
+        };
         let wire_name = format!("__{}_{}_{}", inst.name.name, group, sig);
         // Synthesize the vector wire as `logic [<elem>][N-1:0]`.
         // Per-bit (`elem` == Bool) flattens to `logic [N-1:0]`.
@@ -2847,11 +3237,16 @@ impl<'a> Codegen<'a> {
         // Build a param map for the inst.
         let mut params: std::collections::HashMap<String, i64> = std::collections::HashMap::new();
         // Source defaults first.
-        let target_params: Option<&[ParamDecl]> = self.source.items.iter().find_map(|item| match item {
-            Item::Arbiter(a) if a.name.name == inst.module_name.name => Some(a.params.as_slice()),
-            Item::Regfile(r) if r.name.name == inst.module_name.name => Some(r.params.as_slice()),
-            _ => None,
-        });
+        let target_params: Option<&[ParamDecl]> =
+            self.source.items.iter().find_map(|item| match item {
+                Item::Arbiter(a) if a.name.name == inst.module_name.name => {
+                    Some(a.params.as_slice())
+                }
+                Item::Regfile(r) if r.name.name == inst.module_name.name => {
+                    Some(r.params.as_slice())
+                }
+                _ => None,
+            });
         if let Some(ps) = target_params {
             for p in ps {
                 if let Some(d) = &p.default {
@@ -2867,7 +3262,9 @@ impl<'a> Codegen<'a> {
                 params.insert(pa.name.name.clone(), v);
             }
         }
-        crate::elaborate::try_eval_i64(expr, &params).unwrap_or(0).max(0) as u64
+        crate::elaborate::try_eval_i64(expr, &params)
+            .unwrap_or(0)
+            .max(0) as u64
     }
 
     fn emit_generate(&mut self, gen: &GenerateDecl) {
@@ -2884,13 +3281,21 @@ impl<'a> Codegen<'a> {
                 for item in &gf.items {
                     match item {
                         GenItem::Inst(inst) => self.emit_inst(inst),
-                        GenItem::Port(_) => unreachable!("port GenItems should have been lifted by elaboration"),
-                        GenItem::TlmConnect(_) => unreachable!("TLM connect GenItems should have been lowered by elaboration"),
-                        GenItem::Thread(_) => unreachable!("thread GenItems should have been lowered by elaboration"),
+                        GenItem::Port(_) => {
+                            unreachable!("port GenItems should have been lifted by elaboration")
+                        }
+                        GenItem::TlmConnect(_) => unreachable!(
+                            "TLM connect GenItems should have been lowered by elaboration"
+                        ),
+                        GenItem::Thread(_) => {
+                            unreachable!("thread GenItems should have been lowered by elaboration")
+                        }
                         GenItem::Seq(_) | GenItem::Comb(_) => unreachable!(
-                            "seq/comb GenItems should have been unrolled by elaboration"),
-                        GenItem::Wire(_) => unreachable!(
-                            "wire GenItems should have been unrolled by elaboration"),
+                            "seq/comb GenItems should have been unrolled by elaboration"
+                        ),
+                        GenItem::Wire(_) => {
+                            unreachable!("wire GenItems should have been unrolled by elaboration")
+                        }
                         GenItem::Assert(_) => {
                             // SVA inside generate for: not yet supported in SV codegen (SVA needs static clock ref)
                         }
@@ -2906,13 +3311,21 @@ impl<'a> Codegen<'a> {
                 for item in &gi.then_items {
                     match item {
                         GenItem::Inst(inst) => self.emit_inst(inst),
-                        GenItem::Port(_) => unreachable!("port GenItems should have been lifted by elaboration"),
-                        GenItem::TlmConnect(_) => unreachable!("TLM connect GenItems should have been lowered by elaboration"),
-                        GenItem::Thread(_) => unreachable!("thread GenItems should have been lowered by elaboration"),
-                        GenItem::Seq(_) | GenItem::Comb(_) => unreachable!(
-                            "seq/comb GenItems should have been lifted by elaboration"),
-                        GenItem::Wire(_) => unreachable!(
-                            "wire GenItems should have been unrolled by elaboration"),
+                        GenItem::Port(_) => {
+                            unreachable!("port GenItems should have been lifted by elaboration")
+                        }
+                        GenItem::TlmConnect(_) => unreachable!(
+                            "TLM connect GenItems should have been lowered by elaboration"
+                        ),
+                        GenItem::Thread(_) => {
+                            unreachable!("thread GenItems should have been lowered by elaboration")
+                        }
+                        GenItem::Seq(_) | GenItem::Comb(_) => {
+                            unreachable!("seq/comb GenItems should have been lifted by elaboration")
+                        }
+                        GenItem::Wire(_) => {
+                            unreachable!("wire GenItems should have been unrolled by elaboration")
+                        }
                         GenItem::Assert(_) => {}
                     }
                 }
@@ -2923,13 +3336,21 @@ impl<'a> Codegen<'a> {
                     for item in &gi.else_items {
                         match item {
                             GenItem::Inst(inst) => self.emit_inst(inst),
-                            GenItem::Port(_) => unreachable!("port GenItems should have been lifted by elaboration"),
-                            GenItem::TlmConnect(_) => unreachable!("TLM connect GenItems should have been lowered by elaboration"),
-                            GenItem::Thread(_) => unreachable!("thread GenItems should have been lowered by elaboration"),
+                            GenItem::Port(_) => {
+                                unreachable!("port GenItems should have been lifted by elaboration")
+                            }
+                            GenItem::TlmConnect(_) => unreachable!(
+                                "TLM connect GenItems should have been lowered by elaboration"
+                            ),
+                            GenItem::Thread(_) => unreachable!(
+                                "thread GenItems should have been lowered by elaboration"
+                            ),
                             GenItem::Seq(_) | GenItem::Comb(_) => unreachable!(
-                                "seq/comb GenItems should have been lifted by elaboration"),
+                                "seq/comb GenItems should have been lifted by elaboration"
+                            ),
                             GenItem::Wire(_) => unreachable!(
-                                "wire GenItems should have been unrolled by elaboration"),
+                                "wire GenItems should have been unrolled by elaboration"
+                            ),
                             GenItem::Assert(_) => {}
                         }
                     }
@@ -2947,7 +3368,8 @@ impl<'a> Codegen<'a> {
     /// Mirrors the inline pattern used by `_auto_bound_*` / `_auto_div0_*`
     /// emitters in this file.
     pub(crate) fn rst_active_from_ports(ports: &[PortDecl]) -> Option<String> {
-        ports.iter()
+        ports
+            .iter()
             .find(|p| matches!(&p.ty, TypeExpr::Reset(_, _)))
             .map(|p| match &p.ty {
                 TypeExpr::Reset(_, ResetLevel::Low) => format!("!{}", p.name.name),
@@ -2963,10 +3385,13 @@ impl<'a> Codegen<'a> {
         rst_active: Option<&str>,
     ) {
         let expr_str = self.emit_expr_str(&a.expr);
-        let label = a.name.as_ref().map(|n| n.name.as_str().to_string())
+        let label = a
+            .name
+            .as_ref()
+            .map(|n| n.name.as_str().to_string())
             .unwrap_or_else(|| match a.kind {
                 AssertKind::Assert => "_assert_anon".to_string(),
-                AssertKind::Cover  => "_cover_anon".to_string(),
+                AssertKind::Cover => "_cover_anon".to_string(),
             });
         let disable = rst_active
             .map(|r| format!(" disable iff ({r})"))
@@ -3000,7 +3425,9 @@ impl<'a> Codegen<'a> {
         clk: &str,
         rst_active: Option<&str>,
     ) {
-        if asserts.is_empty() { return; }
+        if asserts.is_empty() {
+            return;
+        }
         self.line("// synopsys translate_off");
         for a in asserts {
             self.emit_assert_sva(a, name, clk, rst_active);
@@ -3035,14 +3462,22 @@ impl<'a> Codegen<'a> {
                 }
             }
         }
-        if guarded.is_empty() { return; }
+        if guarded.is_empty() {
+            return;
+        }
 
-        let clk = m.ports.iter()
+        let clk = m
+            .ports
+            .iter()
             .find(|p| matches!(&p.ty, TypeExpr::Clock(_)))
             .map(|p| p.name.name.clone())
             .unwrap_or_else(|| "clk".to_string());
         let (rst_name, _, is_low) = Self::extract_reset_info(&m.ports);
-        let rst_active = if is_low { format!("!{rst_name}") } else { rst_name.clone() };
+        let rst_active = if is_low {
+            format!("!{rst_name}")
+        } else {
+            rst_name.clone()
+        };
 
         self.line("");
         self.line("// synopsys translate_off");
@@ -3055,7 +3490,11 @@ impl<'a> Codegen<'a> {
                 "1'b0".to_string()
             } else {
                 // OR-reduce
-                write_conds.iter().map(|s| format!("({s})")).collect::<Vec<_>>().join(" || ")
+                write_conds
+                    .iter()
+                    .map(|s| format!("({s})"))
+                    .collect::<Vec<_>>()
+                    .join(" || ")
             };
 
             // Shadow "written at least once" flag; goes high only when reg is actually assigned
@@ -3063,7 +3502,9 @@ impl<'a> Codegen<'a> {
             self.line(&format!("always_ff @(posedge {clk}) begin"));
             self.indent += 1;
             self.line(&format!("if ({rst_active}) _{reg_name}_written <= 1'b0;"));
-            self.line(&format!("else if ({write_cond_expr}) _{reg_name}_written <= 1'b1;"));
+            self.line(&format!(
+                "else if ({write_cond_expr}) _{reg_name}_written <= 1'b1;"
+            ));
             self.indent -= 1;
             self.line("end");
             // SVA contract (disable iff rst to exclude reset states from evaluation)
@@ -3097,40 +3538,57 @@ impl<'a> Codegen<'a> {
         // Collect const-param names — identifiers bound to compile-time constants.
         // `is_const_reducible_with` treats these as foldable so divisors named by
         // them do not produce spurious assertions.
-        let const_params: std::collections::HashSet<String> = m.params.iter()
-            .filter(|p| matches!(&p.kind, ParamKind::Const | ParamKind::WidthConst(..) | ParamKind::EnumConst(_)))
+        let const_params: std::collections::HashSet<String> = m
+            .params
+            .iter()
+            .filter(|p| {
+                matches!(
+                    &p.kind,
+                    ParamKind::Const | ParamKind::WidthConst(..) | ParamKind::EnumConst(_)
+                )
+            })
             .map(|p| p.name.name.clone())
             .collect();
 
         // Build Vec<T,N> size and scalar-width lookups for accesses in this module.
-        let mut vec_sizes: std::collections::HashMap<String, String> = std::collections::HashMap::new();
-        let mut scalar_widths: std::collections::HashMap<String, String> = std::collections::HashMap::new();
-        let record = |name: &str, ty: &TypeExpr,
-                      vec_sizes: &mut std::collections::HashMap<String, String>,
-                      scalar_widths: &mut std::collections::HashMap<String, String>| {
-            match ty {
-                TypeExpr::Vec(_, count) => {
-                    let s = Self::expr_to_sv_const(count);
-                    vec_sizes.insert(name.to_string(), s);
+        let mut vec_sizes: std::collections::HashMap<String, String> =
+            std::collections::HashMap::new();
+        let mut scalar_widths: std::collections::HashMap<String, String> =
+            std::collections::HashMap::new();
+        let record =
+            |name: &str,
+             ty: &TypeExpr,
+             vec_sizes: &mut std::collections::HashMap<String, String>,
+             scalar_widths: &mut std::collections::HashMap<String, String>| {
+                match ty {
+                    TypeExpr::Vec(_, count) => {
+                        let s = Self::expr_to_sv_const(count);
+                        vec_sizes.insert(name.to_string(), s);
+                    }
+                    TypeExpr::UInt(w) | TypeExpr::SInt(w) => {
+                        let s = Self::expr_to_sv_const(w);
+                        scalar_widths.insert(name.to_string(), s);
+                    }
+                    TypeExpr::Bool | TypeExpr::Bit => {
+                        scalar_widths.insert(name.to_string(), "1".to_string());
+                    }
+                    _ => {}
                 }
-                TypeExpr::UInt(w) | TypeExpr::SInt(w) => {
-                    let s = Self::expr_to_sv_const(w);
-                    scalar_widths.insert(name.to_string(), s);
-                }
-                TypeExpr::Bool | TypeExpr::Bit => {
-                    scalar_widths.insert(name.to_string(), "1".to_string());
-                }
-                _ => {}
-            }
-        };
+            };
         for p in &m.ports {
-            if p.bus_info.is_some() { continue; }
+            if p.bus_info.is_some() {
+                continue;
+            }
             record(&p.name.name, &p.ty, &mut vec_sizes, &mut scalar_widths);
         }
         for item in &m.body {
             match item {
-                ModuleBodyItem::RegDecl(r) => record(&r.name.name, &r.ty, &mut vec_sizes, &mut scalar_widths),
-                ModuleBodyItem::WireDecl(w) => record(&w.name.name, &w.ty, &mut vec_sizes, &mut scalar_widths),
+                ModuleBodyItem::RegDecl(r) => {
+                    record(&r.name.name, &r.ty, &mut vec_sizes, &mut scalar_widths)
+                }
+                ModuleBodyItem::WireDecl(w) => {
+                    record(&w.name.name, &w.ty, &mut vec_sizes, &mut scalar_widths)
+                }
                 ModuleBodyItem::LetBinding(l) => {
                     if let Some(ty) = &l.ty {
                         record(&l.name.name, ty, &mut vec_sizes, &mut scalar_widths);
@@ -3146,27 +3604,53 @@ impl<'a> Codegen<'a> {
         for item in &m.body {
             match item {
                 ModuleBodyItem::RegBlock(rb) => {
-                    let empty_iters: std::collections::HashSet<String> = std::collections::HashSet::new();
+                    let empty_iters: std::collections::HashSet<String> =
+                        std::collections::HashSet::new();
                     for s in &rb.stmts {
-                        self.collect_bound_stmt(s, &vec_sizes, &scalar_widths, &const_params, &empty_iters, None, &mut sites, &mut seen);
+                        self.collect_bound_stmt(
+                            s,
+                            &vec_sizes,
+                            &scalar_widths,
+                            &const_params,
+                            &empty_iters,
+                            None,
+                            &mut sites,
+                            &mut seen,
+                        );
                     }
                 }
                 ModuleBodyItem::LatchBlock(lb) => {
-                    let empty_iters: std::collections::HashSet<String> = std::collections::HashSet::new();
+                    let empty_iters: std::collections::HashSet<String> =
+                        std::collections::HashSet::new();
                     for s in &lb.stmts {
-                        self.collect_bound_stmt(s, &vec_sizes, &scalar_widths, &const_params, &empty_iters, None, &mut sites, &mut seen);
+                        self.collect_bound_stmt(
+                            s,
+                            &vec_sizes,
+                            &scalar_widths,
+                            &const_params,
+                            &empty_iters,
+                            None,
+                            &mut sites,
+                            &mut seen,
+                        );
                     }
                 }
                 _ => {}
             }
         }
-        if sites.is_empty() { return; }
+        if sites.is_empty() {
+            return;
+        }
 
         // Pick the module's clock and reset (best-effort; use first of each).
-        let clk = m.ports.iter()
+        let clk = m
+            .ports
+            .iter()
             .find(|p| matches!(&p.ty, TypeExpr::Clock(_)))
             .map(|p| p.name.name.clone());
-        let rst_active = m.ports.iter()
+        let rst_active = m
+            .ports
+            .iter()
             .find(|p| matches!(&p.ty, TypeExpr::Reset(_, _)))
             .map(|p| match &p.ty {
                 TypeExpr::Reset(_, ResetLevel::Low) => format!("!{}", p.name.name),
@@ -3174,7 +3658,9 @@ impl<'a> Codegen<'a> {
             });
 
         // A module with no clock has no meaningful concurrent assertion — skip.
-        let Some(clk) = clk else { return; };
+        let Some(clk) = clk else {
+            return;
+        };
 
         self.line("// synopsys translate_off");
         self.line("// Auto-generated safety assertions (bounds / divide-by-zero)");
@@ -3183,7 +3669,8 @@ impl<'a> Codegen<'a> {
             let label_prefix = if is_div0 { "_auto_div0" } else { "_auto_bound" };
             let label = format!("{label_prefix}_{}_{}", tag, i);
             let violation_kind = if is_div0 { "DIV-BY-ZERO" } else { "BOUNDS" };
-            let disable = rst_active.as_ref()
+            let disable = rst_active
+                .as_ref()
                 .map(|r| format!(" disable iff ({r})"))
                 .unwrap_or_default();
             self.line(&format!(
@@ -3220,31 +3707,48 @@ impl<'a> Codegen<'a> {
         // bus declares one or more handshake channels.
         let mut emissions: Vec<(String, crate::ast::HandshakeMeta)> = Vec::new();
         for p in &m.ports {
-            let Some(ref bi) = p.bus_info else { continue; };
+            let Some(ref bi) = p.bus_info else {
+                continue;
+            };
             let Some((crate::resolve::Symbol::Bus(info), _)) =
-                self.symbols.globals.get(&bi.bus_name.name) else { continue; };
+                self.symbols.globals.get(&bi.bus_name.name)
+            else {
+                continue;
+            };
             for hs in &info.handshakes {
                 emissions.push((p.name.name.clone(), hs.clone()));
             }
         }
-        if emissions.is_empty() { return; }
+        if emissions.is_empty() {
+            return;
+        }
 
         // Reuse the same clock/reset picking convention as emit_bound_asserts.
-        let clk = m.ports.iter()
+        let clk = m
+            .ports
+            .iter()
             .find(|p| matches!(&p.ty, TypeExpr::Clock(_)))
             .map(|p| p.name.name.clone());
-        let Some(clk) = clk else { return; };
-        let rst_active = m.ports.iter()
+        let Some(clk) = clk else {
+            return;
+        };
+        let rst_active = m
+            .ports
+            .iter()
             .find(|p| matches!(&p.ty, TypeExpr::Reset(_, _)))
             .map(|p| match &p.ty {
                 TypeExpr::Reset(_, ResetLevel::Low) => format!("!{}", p.name.name),
                 _ => p.name.name.clone(),
             });
-        let any_emits = emissions.iter().any(|(_, hs)| matches!(
-            hs.variant.name.as_str(),
-            "valid_ready" | "valid_stall" | "req_ack_4phase" | "req_ack_2phase"
-        ));
-        if !any_emits { return; }
+        let any_emits = emissions.iter().any(|(_, hs)| {
+            matches!(
+                hs.variant.name.as_str(),
+                "valid_ready" | "valid_stall" | "req_ack_4phase" | "req_ack_2phase"
+            )
+        });
+        if !any_emits {
+            return;
+        }
 
         self.line("// synopsys translate_off");
         self.line("// Auto-generated handshake protocol assertions (Tier 2)");
@@ -3328,9 +3832,8 @@ impl<'a> Codegen<'a> {
         let _ = (open_gen, close_gen); // generate-for header already emitted
 
         let sig = |s: &str| format!("{}_{}{}", sig_prefix, s, idx);
-        let mk_label = |rule: &str| {
-            format!("_auto_hs_{}{}_{}", label_stem, lane_label_suffix, rule)
-        };
+        let mk_label =
+            |rule: &str| format!("_auto_hs_{}{}_{}", label_stem, lane_label_suffix, rule);
         let emit_property = |cg: &mut Codegen, rule: &str, predicate: String, message: &str| {
             let label = mk_label(rule);
             cg.line(&format!(
@@ -3342,31 +3845,50 @@ impl<'a> Codegen<'a> {
         };
         match variant {
             "valid_ready" => {
-                let v = sig("valid"); let r = sig("ready");
-                emit_property(self, "valid_stable",
+                let v = sig("valid");
+                let r = sig("ready");
+                emit_property(
+                    self,
+                    "valid_stable",
                     format!("({v} && !{r}) |=> {v}"),
-                    "valid must stay asserted until ready");
+                    "valid must stay asserted until ready",
+                );
             }
             "valid_stall" => {
-                let v = sig("valid"); let s = sig("stall");
-                emit_property(self, "valid_stable_while_stall",
+                let v = sig("valid");
+                let s = sig("stall");
+                emit_property(
+                    self,
+                    "valid_stable_while_stall",
                     format!("({v} && {s}) |=> {v}"),
-                    "valid must not change while stalled");
+                    "valid must not change while stalled",
+                );
             }
             "req_ack_4phase" => {
-                let rq = sig("req"); let ak = sig("ack");
-                emit_property(self, "req_holds_until_ack",
+                let rq = sig("req");
+                let ak = sig("ack");
+                emit_property(
+                    self,
+                    "req_holds_until_ack",
                     format!("({rq} && !{ak}) |=> {rq}"),
-                    "req must stay asserted until ack");
+                    "req must stay asserted until ack",
+                );
             }
             "req_ack_2phase" => {
-                let rq = sig("req"); let ak = sig("ack");
-                emit_property(self, "req_toggles_only_when_idle",
+                let rq = sig("req");
+                let ak = sig("ack");
+                emit_property(
+                    self,
+                    "req_toggles_only_when_idle",
                     format!("({rq} != $past({rq})) |-> ($past({rq}) == $past({ak}))"),
-                    "req may toggle only when no transfer is pending");
-                emit_property(self, "ack_toggles_only_when_pending",
+                    "req may toggle only when no transfer is pending",
+                );
+                emit_property(
+                    self,
+                    "ack_toggles_only_when_pending",
                     format!("({ak} != $past({ak})) |-> ($past({rq}) != $past({ak}))"),
-                    "ack may toggle only after a req toggle");
+                    "ack may toggle only after a req toggle",
+                );
             }
             _ => unreachable!("unsupported handshake variant pre-filtered"),
         }
@@ -3390,14 +3912,22 @@ impl<'a> Codegen<'a> {
     /// `<port>_<chname>_<sig>`. Labels follow `_auto_hs_<chname>_<rule>`
     /// (with `__lane` appended inside generate blocks).
     pub(crate) fn emit_arbiter_handshake_asserts(&mut self, a: &crate::ast::ArbiterDecl) {
-        if a.handshakes.is_empty() { return; }
+        if a.handshakes.is_empty() {
+            return;
+        }
 
         // Pick clock/reset the same way emit_arbiter does.
-        let clk = a.ports.iter()
+        let clk = a
+            .ports
+            .iter()
             .find(|p| matches!(&p.ty, TypeExpr::Clock(_)))
             .map(|p| p.name.name.clone());
-        let Some(clk) = clk else { return; };
-        let rst_active = a.ports.iter()
+        let Some(clk) = clk else {
+            return;
+        };
+        let rst_active = a
+            .ports
+            .iter()
             .find(|p| matches!(&p.ty, TypeExpr::Reset(_, _)))
             .map(|p| match &p.ty {
                 TypeExpr::Reset(_, ResetLevel::Low) => format!("!{}", p.name.name),
@@ -3408,11 +3938,15 @@ impl<'a> Codegen<'a> {
         // text for, so we don't emit a translate-off block whose body is
         // empty (matches the bus side, which skips the wrapper when no
         // emission would land).
-        let any_emits = a.handshakes.iter().any(|hs| matches!(
-            hs.variant.name.as_str(),
-            "valid_ready" | "valid_stall" | "req_ack_4phase" | "req_ack_2phase"
-        ));
-        if !any_emits { return; }
+        let any_emits = a.handshakes.iter().any(|hs| {
+            matches!(
+                hs.variant.name.as_str(),
+                "valid_ready" | "valid_stall" | "req_ack_4phase" | "req_ack_2phase"
+            )
+        });
+        if !any_emits {
+            return;
+        }
 
         self.line("");
         self.line("// synopsys translate_off");
@@ -3461,16 +3995,21 @@ impl<'a> Codegen<'a> {
     fn emit_credit_channel_state(&mut self, m: &ModuleDecl) {
         let mut emissions: Vec<(String, crate::ast::CreditChannelMeta)> = Vec::new();
         for p in &m.ports {
-            let Some(ref bi) = p.bus_info else { continue; };
+            let Some(ref bi) = p.bus_info else {
+                continue;
+            };
             let Some((crate::resolve::Symbol::Bus(info), _)) =
-                self.symbols.globals.get(&bi.bus_name.name) else { continue; };
+                self.symbols.globals.get(&bi.bus_name.name)
+            else {
+                continue;
+            };
             for cc in &info.credit_channels {
                 // Initiator perspective drives send; on the target perspective
                 // the same bus flip inverts the data direction, but the sender
                 // state belongs on whichever side actually issues sends.
                 let is_sender = match (cc.role_dir, bi.perspective) {
                     (Direction::Out, crate::ast::BusPerspective::Initiator) => true,
-                    (Direction::In,  crate::ast::BusPerspective::Target)    => true,
+                    (Direction::In, crate::ast::BusPerspective::Target) => true,
                     _ => false,
                 };
                 if is_sender {
@@ -3478,13 +4017,21 @@ impl<'a> Codegen<'a> {
                 }
             }
         }
-        if emissions.is_empty() { return; }
+        if emissions.is_empty() {
+            return;
+        }
 
-        let clk = m.ports.iter()
+        let clk = m
+            .ports
+            .iter()
             .find(|p| matches!(&p.ty, TypeExpr::Clock(_)))
             .map(|p| p.name.name.clone());
-        let Some(clk) = clk else { return; };
-        let rst_port = m.ports.iter()
+        let Some(clk) = clk else {
+            return;
+        };
+        let rst_port = m
+            .ports
+            .iter()
             .find(|p| matches!(&p.ty, TypeExpr::Reset(_, _)));
         let (rst_edge, rst_active) = match rst_port {
             Some(p) => {
@@ -3493,8 +4040,12 @@ impl<'a> Codegen<'a> {
                     _ => p.name.name.clone(),
                 };
                 let edge = match &p.ty {
-                    TypeExpr::Reset(ResetKind::Async, ResetLevel::Low) => format!(" or negedge {}", p.name.name),
-                    TypeExpr::Reset(ResetKind::Async, ResetLevel::High) => format!(" or posedge {}", p.name.name),
+                    TypeExpr::Reset(ResetKind::Async, ResetLevel::Low) => {
+                        format!(" or negedge {}", p.name.name)
+                    }
+                    TypeExpr::Reset(ResetKind::Async, ResetLevel::High) => {
+                        format!(" or posedge {}", p.name.name)
+                    }
                     _ => String::new(),
                 };
                 (edge, Some(active))
@@ -3506,13 +4057,17 @@ impl<'a> Codegen<'a> {
         self.line("// Auto-generated credit_channel state (PR #3b-ii, sender side)");
         for (port_name, cc) in &emissions {
             let ch = &cc.name.name;
-            let depth_expr = cc.params.iter()
+            let depth_expr = cc
+                .params
+                .iter()
                 .find(|p| p.name.name == "DEPTH")
                 .and_then(|p| p.default.as_ref());
-            let Some(depth_expr) = depth_expr else { continue; };
+            let Some(depth_expr) = depth_expr else {
+                continue;
+            };
             let depth_str = self.emit_expr_str(depth_expr);
             let credit_reg = format!("__{port_name}_{ch}_credit");
-            let cs_name    = format!("__{port_name}_{ch}_can_send");
+            let cs_name = format!("__{port_name}_{ch}_can_send");
             let send_valid = format!("{port_name}_{ch}_send_valid");
             let credit_ret = format!("{port_name}_{ch}_credit_return");
             // Look up CAN_SEND_REGISTERED (option b — next-state flop, agreed
@@ -3521,7 +4076,9 @@ impl<'a> Codegen<'a> {
             // ends at the flop input. Full throughput is preserved because the
             // flopped signal reflects counter_next (current counter ± same-
             // cycle send/return), so send_valid |-> counter > 0 still holds.
-            let registered = cc.params.iter()
+            let registered = cc
+                .params
+                .iter()
                 .find(|p| p.name.name == "CAN_SEND_REGISTERED")
                 .and_then(|p| p.default.as_ref())
                 .map(|e| self.emit_expr_str(e))
@@ -3561,13 +4118,21 @@ impl<'a> Codegen<'a> {
                     self.line(&format!("if ({r}) begin"));
                     self.indent += 1;
                     self.line(&format!("{credit_reg} <= {depth_str};"));
-                    if registered { self.line(&format!("{cs_name} <= ({depth_str}) != 0;")); }
+                    if registered {
+                        self.line(&format!("{cs_name} <= ({depth_str}) != 0;"));
+                    }
                     self.indent -= 1;
                     self.line("end else begin");
                     self.indent += 1;
-                    self.line(&format!("if ({send_valid} && !{credit_ret}) {credit_reg} <= {credit_reg} - 1;"));
-                    self.line(&format!("else if ({credit_ret} && !{send_valid}) {credit_reg} <= {credit_reg} + 1;"));
-                    if registered { self.line(&format!("{cs_name} <= {cs_next};")); }
+                    self.line(&format!(
+                        "if ({send_valid} && !{credit_ret}) {credit_reg} <= {credit_reg} - 1;"
+                    ));
+                    self.line(&format!(
+                        "else if ({credit_ret} && !{send_valid}) {credit_reg} <= {credit_reg} + 1;"
+                    ));
+                    if registered {
+                        self.line(&format!("{cs_name} <= {cs_next};"));
+                    }
                     self.indent -= 1;
                     self.line("end");
                     self.indent -= 1;
@@ -3576,9 +4141,15 @@ impl<'a> Codegen<'a> {
                 None => {
                     self.line(&format!("always_ff @(posedge {clk}) begin"));
                     self.indent += 1;
-                    self.line(&format!("if ({send_valid} && !{credit_ret}) {credit_reg} <= {credit_reg} - 1;"));
-                    self.line(&format!("else if ({credit_ret} && !{send_valid}) {credit_reg} <= {credit_reg} + 1;"));
-                    if registered { self.line(&format!("{cs_name} <= {cs_next};")); }
+                    self.line(&format!(
+                        "if ({send_valid} && !{credit_ret}) {credit_reg} <= {credit_reg} - 1;"
+                    ));
+                    self.line(&format!(
+                        "else if ({credit_ret} && !{send_valid}) {credit_reg} <= {credit_reg} + 1;"
+                    ));
+                    if registered {
+                        self.line(&format!("{cs_name} <= {cs_next};"));
+                    }
                     self.indent -= 1;
                     self.line("end");
                 }
@@ -3612,16 +4183,21 @@ impl<'a> Codegen<'a> {
     fn emit_credit_channel_receiver_state(&mut self, m: &ModuleDecl) {
         let mut emissions: Vec<(String, crate::ast::CreditChannelMeta)> = Vec::new();
         for p in &m.ports {
-            let Some(ref bi) = p.bus_info else { continue; };
+            let Some(ref bi) = p.bus_info else {
+                continue;
+            };
             let Some((crate::resolve::Symbol::Bus(info), _)) =
-                self.symbols.globals.get(&bi.bus_name.name) else { continue; };
+                self.symbols.globals.get(&bi.bus_name.name)
+            else {
+                continue;
+            };
             for cc in &info.credit_channels {
                 // Receiver side mirrors the sender-state selector:
                 //   send role + target perspective → this module is the receiver
                 //   receive role + initiator perspective → this module is the receiver
                 let is_receiver = match (cc.role_dir, bi.perspective) {
-                    (Direction::Out, crate::ast::BusPerspective::Target)    => true,
-                    (Direction::In,  crate::ast::BusPerspective::Initiator) => true,
+                    (Direction::Out, crate::ast::BusPerspective::Target) => true,
+                    (Direction::In, crate::ast::BusPerspective::Initiator) => true,
                     _ => false,
                 };
                 if is_receiver {
@@ -3629,13 +4205,21 @@ impl<'a> Codegen<'a> {
                 }
             }
         }
-        if emissions.is_empty() { return; }
+        if emissions.is_empty() {
+            return;
+        }
 
-        let clk = m.ports.iter()
+        let clk = m
+            .ports
+            .iter()
             .find(|p| matches!(&p.ty, TypeExpr::Clock(_)))
             .map(|p| p.name.name.clone());
-        let Some(clk) = clk else { return; };
-        let rst_port = m.ports.iter()
+        let Some(clk) = clk else {
+            return;
+        };
+        let rst_port = m
+            .ports
+            .iter()
             .find(|p| matches!(&p.ty, TypeExpr::Reset(_, _)));
         let (rst_edge, rst_active) = match rst_port {
             Some(p) => {
@@ -3644,8 +4228,12 @@ impl<'a> Codegen<'a> {
                     _ => p.name.name.clone(),
                 };
                 let edge = match &p.ty {
-                    TypeExpr::Reset(ResetKind::Async, ResetLevel::Low) => format!(" or negedge {}", p.name.name),
-                    TypeExpr::Reset(ResetKind::Async, ResetLevel::High) => format!(" or posedge {}", p.name.name),
+                    TypeExpr::Reset(ResetKind::Async, ResetLevel::Low) => {
+                        format!(" or negedge {}", p.name.name)
+                    }
+                    TypeExpr::Reset(ResetKind::Async, ResetLevel::High) => {
+                        format!(" or posedge {}", p.name.name)
+                    }
                     _ => String::new(),
                 };
                 (edge, Some(active))
@@ -3657,36 +4245,54 @@ impl<'a> Codegen<'a> {
         self.line("// Auto-generated credit_channel target-side FIFO (PR #3b-iii)");
         for (port_name, cc) in &emissions {
             let ch = &cc.name.name;
-            let depth_expr = cc.params.iter()
+            let depth_expr = cc
+                .params
+                .iter()
                 .find(|p| p.name.name == "DEPTH")
                 .and_then(|p| p.default.as_ref());
-            let Some(depth_expr) = depth_expr else { continue; };
+            let Some(depth_expr) = depth_expr else {
+                continue;
+            };
             let depth_str = self.emit_expr_str(depth_expr);
             // Payload type width — resolve via the ParamKind::Type default.
-            let payload_ty_opt = cc.params.iter()
-                .find(|p| p.name.name == "T")
-                .and_then(|p| match &p.kind {
-                    crate::ast::ParamKind::Type(te) => Some(te.clone()),
-                    _ => None,
-                });
-            let Some(payload_ty) = payload_ty_opt else { continue; };
-            let Some(width_str) = self.type_expr_data_width(&payload_ty) else { continue; };
+            let payload_ty_opt =
+                cc.params
+                    .iter()
+                    .find(|p| p.name.name == "T")
+                    .and_then(|p| match &p.kind {
+                        crate::ast::ParamKind::Type(te) => Some(te.clone()),
+                        _ => None,
+                    });
+            let Some(payload_ty) = payload_ty_opt else {
+                continue;
+            };
+            let Some(width_str) = self.type_expr_data_width(&payload_ty) else {
+                continue;
+            };
             let buf = format!("__{port_name}_{ch}_buf");
             let head = format!("__{port_name}_{ch}_head");
             let tail = format!("__{port_name}_{ch}_tail");
-            let occ  = format!("__{port_name}_{ch}_occ");
+            let occ = format!("__{port_name}_{ch}_occ");
             let valid_w = format!("__{port_name}_{ch}_valid");
-            let data_w  = format!("__{port_name}_{ch}_data");
+            let data_w = format!("__{port_name}_{ch}_data");
             let push = format!("{port_name}_{ch}_send_valid");
-            let pushd= format!("{port_name}_{ch}_send_data");
+            let pushd = format!("{port_name}_{ch}_send_data");
             let pop_drv = format!("{port_name}_{ch}_credit_return");
 
-            self.line(&format!("logic [({width_str}) - 1:0] {buf} [({depth_str})];"));
-            self.line(&format!("logic [$clog2({depth_str}) == 0 ? 0 : $clog2({depth_str}) - 1:0] {head};"));
-            self.line(&format!("logic [$clog2({depth_str}) == 0 ? 0 : $clog2({depth_str}) - 1:0] {tail};"));
+            self.line(&format!(
+                "logic [({width_str}) - 1:0] {buf} [({depth_str})];"
+            ));
+            self.line(&format!(
+                "logic [$clog2({depth_str}) == 0 ? 0 : $clog2({depth_str}) - 1:0] {head};"
+            ));
+            self.line(&format!(
+                "logic [$clog2({depth_str}) == 0 ? 0 : $clog2({depth_str}) - 1:0] {tail};"
+            ));
             self.line(&format!("logic [$clog2(({depth_str}) + 1) - 1:0] {occ};"));
             self.line(&format!("wire  {valid_w} = {occ} != 0;"));
-            self.line(&format!("wire [({width_str}) - 1:0] {data_w} = {buf}[{head}];"));
+            self.line(&format!(
+                "wire [({width_str}) - 1:0] {data_w} = {buf}[{head}];"
+            ));
 
             // Update block: push on send_valid, pop on user-driven credit_return.
             let pop_fire = format!("({pop_drv} && {valid_w})");
@@ -3708,9 +4314,13 @@ impl<'a> Codegen<'a> {
                     self.line(&format!("{tail} <= ({tail} + 1) % ({depth_str});"));
                     self.indent -= 1;
                     self.line("end");
-                    self.line(&format!("if ({pop_fire}) {head} <= ({head} + 1) % ({depth_str});"));
+                    self.line(&format!(
+                        "if ({pop_fire}) {head} <= ({head} + 1) % ({depth_str});"
+                    ));
                     self.line(&format!("if ({push} && !{pop_fire}) {occ} <= {occ} + 1;"));
-                    self.line(&format!("else if (!{push} &&  {pop_fire}) {occ} <= {occ} - 1;"));
+                    self.line(&format!(
+                        "else if (!{push} &&  {pop_fire}) {occ} <= {occ} - 1;"
+                    ));
                     self.indent -= 1;
                     self.line("end");
                     self.indent -= 1;
@@ -3725,9 +4335,13 @@ impl<'a> Codegen<'a> {
                     self.line(&format!("{tail} <= ({tail} + 1) % ({depth_str});"));
                     self.indent -= 1;
                     self.line("end");
-                    self.line(&format!("if ({pop_fire}) {head} <= ({head} + 1) % ({depth_str});"));
+                    self.line(&format!(
+                        "if ({pop_fire}) {head} <= ({head} + 1) % ({depth_str});"
+                    ));
                     self.line(&format!("if ({push} && !{pop_fire}) {occ} <= {occ} + 1;"));
-                    self.line(&format!("else if (!{push} &&  {pop_fire}) {occ} <= {occ} - 1;"));
+                    self.line(&format!(
+                        "else if (!{push} &&  {pop_fire}) {occ} <= {occ} - 1;"
+                    ));
                     self.indent -= 1;
                     self.line("end");
                 }
@@ -3755,10 +4369,7 @@ impl<'a> Codegen<'a> {
         }
     }
 
-    fn is_const_reducible_with(
-        e: &Expr,
-        const_params: &std::collections::HashSet<String>,
-    ) -> bool {
+    fn is_const_reducible_with(e: &Expr, const_params: &std::collections::HashSet<String>) -> bool {
         match &e.kind {
             ExprKind::Literal(_) => true,
             ExprKind::Ident(n) => const_params.contains(n),
@@ -3793,35 +4404,52 @@ impl<'a> Codegen<'a> {
     /// Deferred: occupancy = DEPTH - credit (cross-module property; lands
     /// with a hierarchical-formal story).
     fn emit_credit_channel_asserts(&mut self, m: &ModuleDecl) {
-        let mut sender_emissions:   Vec<(String, crate::ast::CreditChannelMeta)> = Vec::new();
+        let mut sender_emissions: Vec<(String, crate::ast::CreditChannelMeta)> = Vec::new();
         let mut receiver_emissions: Vec<(String, crate::ast::CreditChannelMeta)> = Vec::new();
         for p in &m.ports {
-            let Some(ref bi) = p.bus_info else { continue; };
+            let Some(ref bi) = p.bus_info else {
+                continue;
+            };
             let Some((crate::resolve::Symbol::Bus(info), _)) =
-                self.symbols.globals.get(&bi.bus_name.name) else { continue; };
+                self.symbols.globals.get(&bi.bus_name.name)
+            else {
+                continue;
+            };
             for cc in &info.credit_channels {
                 let is_sender = matches!(
                     (cc.role_dir, bi.perspective),
                     (Direction::Out, crate::ast::BusPerspective::Initiator)
-                  | (Direction::In,  crate::ast::BusPerspective::Target)
+                        | (Direction::In, crate::ast::BusPerspective::Target)
                 );
-                if is_sender { sender_emissions.push((p.name.name.clone(), cc.clone())); }
-                else         { receiver_emissions.push((p.name.name.clone(), cc.clone())); }
+                if is_sender {
+                    sender_emissions.push((p.name.name.clone(), cc.clone()));
+                } else {
+                    receiver_emissions.push((p.name.name.clone(), cc.clone()));
+                }
             }
         }
-        if sender_emissions.is_empty() && receiver_emissions.is_empty() { return; }
+        if sender_emissions.is_empty() && receiver_emissions.is_empty() {
+            return;
+        }
 
-        let clk = m.ports.iter()
+        let clk = m
+            .ports
+            .iter()
             .find(|p| matches!(&p.ty, TypeExpr::Clock(_)))
             .map(|p| p.name.name.clone());
-        let Some(clk) = clk else { return; };
-        let rst_active = m.ports.iter()
+        let Some(clk) = clk else {
+            return;
+        };
+        let rst_active = m
+            .ports
+            .iter()
             .find(|p| matches!(&p.ty, TypeExpr::Reset(_, _)))
             .map(|p| match &p.ty {
                 TypeExpr::Reset(_, ResetLevel::Low) => format!("!{}", p.name.name),
                 _ => p.name.name.clone(),
             });
-        let disable = rst_active.as_ref()
+        let disable = rst_active
+            .as_ref()
             .map(|r| format!(" disable iff ({r})"))
             .unwrap_or_default();
         let mod_name = m.name.name.clone();
@@ -3832,10 +4460,15 @@ impl<'a> Codegen<'a> {
 
         for (port_name, cc) in &sender_emissions {
             let ch = &cc.name.name;
-            let Some(depth_expr) = cc.params.iter()
+            let Some(depth_expr) = cc
+                .params
+                .iter()
                 .find(|p| p.name.name == "DEPTH")
-                .and_then(|p| p.default.as_ref()) else { continue; };
-            let depth_str  = self.emit_expr_str(depth_expr);
+                .and_then(|p| p.default.as_ref())
+            else {
+                continue;
+            };
+            let depth_str = self.emit_expr_str(depth_expr);
             let credit_reg = format!("__{port_name}_{ch}_credit");
             let send_valid = format!("{port_name}_{ch}_send_valid");
 
@@ -3859,7 +4492,7 @@ impl<'a> Codegen<'a> {
         for (port_name, cc) in &receiver_emissions {
             let ch = &cc.name.name;
             let credit_ret = format!("{port_name}_{ch}_credit_return");
-            let buf_valid  = format!("__{port_name}_{ch}_valid");
+            let buf_valid = format!("__{port_name}_{ch}_valid");
             let label = format!("_auto_cc_{port_name}_{ch}_credit_return_requires_buffered");
             self.line(&format!(
                 "{label}: assert property (@(posedge {clk}){disable} {credit_ret} |-> {buf_valid})"
@@ -3883,26 +4516,40 @@ impl<'a> Codegen<'a> {
     fn emit_tlm_method_asserts(&mut self, m: &ModuleDecl) {
         let mut emissions: Vec<(String, crate::ast::TlmMethodMeta)> = Vec::new();
         for p in &m.ports {
-            let Some(ref bi) = p.bus_info else { continue; };
+            let Some(ref bi) = p.bus_info else {
+                continue;
+            };
             let Some((crate::resolve::Symbol::Bus(info), _)) =
-                self.symbols.globals.get(&bi.bus_name.name) else { continue; };
+                self.symbols.globals.get(&bi.bus_name.name)
+            else {
+                continue;
+            };
             for tm in &info.tlm_methods {
                 emissions.push((p.name.name.clone(), tm.clone()));
             }
         }
-        if emissions.is_empty() { return; }
+        if emissions.is_empty() {
+            return;
+        }
 
-        let clk = m.ports.iter()
+        let clk = m
+            .ports
+            .iter()
             .find(|p| matches!(&p.ty, TypeExpr::Clock(_)))
             .map(|p| p.name.name.clone());
-        let Some(clk) = clk else { return; };
-        let rst_active = m.ports.iter()
+        let Some(clk) = clk else {
+            return;
+        };
+        let rst_active = m
+            .ports
+            .iter()
             .find(|p| matches!(&p.ty, TypeExpr::Reset(_, _)))
             .map(|p| match &p.ty {
                 TypeExpr::Reset(_, ResetLevel::Low) => format!("!{}", p.name.name),
                 _ => p.name.name.clone(),
             });
-        let disable = rst_active.as_ref()
+        let disable = rst_active
+            .as_ref()
             .map(|r| format!(" disable iff ({r})"))
             .unwrap_or_default();
         let mod_name = m.name.name.clone();
@@ -3983,27 +4630,114 @@ impl<'a> Codegen<'a> {
     ) {
         match s {
             Stmt::Assign(a) => {
-                self.collect_bound_expr(&a.target, vec_sizes, scalar_widths, const_params, loop_iters, guard, sites, seen);
-                self.collect_bound_expr(&a.value, vec_sizes, scalar_widths, const_params, loop_iters, guard, sites, seen);
+                self.collect_bound_expr(
+                    &a.target,
+                    vec_sizes,
+                    scalar_widths,
+                    const_params,
+                    loop_iters,
+                    guard,
+                    sites,
+                    seen,
+                );
+                self.collect_bound_expr(
+                    &a.value,
+                    vec_sizes,
+                    scalar_widths,
+                    const_params,
+                    loop_iters,
+                    guard,
+                    sites,
+                    seen,
+                );
             }
             Stmt::IfElse(ie) => {
-                self.collect_bound_expr(&ie.cond, vec_sizes, scalar_widths, const_params, loop_iters, guard, sites, seen);
+                self.collect_bound_expr(
+                    &ie.cond,
+                    vec_sizes,
+                    scalar_widths,
+                    const_params,
+                    loop_iters,
+                    guard,
+                    sites,
+                    seen,
+                );
                 let cond = self.emit_expr_str(&ie.cond);
                 let then_guard = Self::and_bound_guard(guard, &cond);
                 let else_guard = Self::and_bound_guard(guard, &format!("!({cond})"));
-                for s in &ie.then_stmts { self.collect_bound_stmt(s, vec_sizes, scalar_widths, const_params, loop_iters, Some(&then_guard), sites, seen); }
-                for s in &ie.else_stmts { self.collect_bound_stmt(s, vec_sizes, scalar_widths, const_params, loop_iters, Some(&else_guard), sites, seen); }
+                for s in &ie.then_stmts {
+                    self.collect_bound_stmt(
+                        s,
+                        vec_sizes,
+                        scalar_widths,
+                        const_params,
+                        loop_iters,
+                        Some(&then_guard),
+                        sites,
+                        seen,
+                    );
+                }
+                for s in &ie.else_stmts {
+                    self.collect_bound_stmt(
+                        s,
+                        vec_sizes,
+                        scalar_widths,
+                        const_params,
+                        loop_iters,
+                        Some(&else_guard),
+                        sites,
+                        seen,
+                    );
+                }
             }
             Stmt::Match(m) => {
-                self.collect_bound_expr(&m.scrutinee, vec_sizes, scalar_widths, const_params, loop_iters, guard, sites, seen);
+                self.collect_bound_expr(
+                    &m.scrutinee,
+                    vec_sizes,
+                    scalar_widths,
+                    const_params,
+                    loop_iters,
+                    guard,
+                    sites,
+                    seen,
+                );
                 for arm in &m.arms {
-                    for s in &arm.body { self.collect_bound_stmt(s, vec_sizes, scalar_widths, const_params, loop_iters, guard, sites, seen); }
+                    for s in &arm.body {
+                        self.collect_bound_stmt(
+                            s,
+                            vec_sizes,
+                            scalar_widths,
+                            const_params,
+                            loop_iters,
+                            guard,
+                            sites,
+                            seen,
+                        );
+                    }
                 }
             }
             Stmt::For(f) => {
                 if let ForRange::Range(lo, hi) = &f.range {
-                    self.collect_bound_expr(lo, vec_sizes, scalar_widths, const_params, loop_iters, guard, sites, seen);
-                    self.collect_bound_expr(hi, vec_sizes, scalar_widths, const_params, loop_iters, guard, sites, seen);
+                    self.collect_bound_expr(
+                        lo,
+                        vec_sizes,
+                        scalar_widths,
+                        const_params,
+                        loop_iters,
+                        guard,
+                        sites,
+                        seen,
+                    );
+                    self.collect_bound_expr(
+                        hi,
+                        vec_sizes,
+                        scalar_widths,
+                        const_params,
+                        loop_iters,
+                        guard,
+                        sites,
+                        seen,
+                    );
                 }
                 // Add the loop iterator name to the in-scope set so any
                 // `Vec[iter]` index inside the body elides the bound assertion:
@@ -4013,15 +4747,66 @@ impl<'a> Codegen<'a> {
                 // (`Can't find definition of variable: 'fb'`).
                 let mut nested = loop_iters.clone();
                 nested.insert(f.var.name.clone());
-                for s in &f.body { self.collect_bound_stmt(s, vec_sizes, scalar_widths, const_params, &nested, guard, sites, seen); }
+                for s in &f.body {
+                    self.collect_bound_stmt(
+                        s,
+                        vec_sizes,
+                        scalar_widths,
+                        const_params,
+                        &nested,
+                        guard,
+                        sites,
+                        seen,
+                    );
+                }
             }
             Stmt::Init(ib) => {
-                for s in &ib.body { self.collect_bound_stmt(s, vec_sizes, scalar_widths, const_params, loop_iters, guard, sites, seen); }
+                for s in &ib.body {
+                    self.collect_bound_stmt(
+                        s,
+                        vec_sizes,
+                        scalar_widths,
+                        const_params,
+                        loop_iters,
+                        guard,
+                        sites,
+                        seen,
+                    );
+                }
             }
-            Stmt::WaitUntil(e, _) => self.collect_bound_expr(e, vec_sizes, scalar_widths, const_params, loop_iters, guard, sites, seen),
+            Stmt::WaitUntil(e, _) => self.collect_bound_expr(
+                e,
+                vec_sizes,
+                scalar_widths,
+                const_params,
+                loop_iters,
+                guard,
+                sites,
+                seen,
+            ),
             Stmt::DoUntil { body, cond, .. } => {
-                for s in body { self.collect_bound_stmt(s, vec_sizes, scalar_widths, const_params, loop_iters, guard, sites, seen); }
-                self.collect_bound_expr(cond, vec_sizes, scalar_widths, const_params, loop_iters, guard, sites, seen);
+                for s in body {
+                    self.collect_bound_stmt(
+                        s,
+                        vec_sizes,
+                        scalar_widths,
+                        const_params,
+                        loop_iters,
+                        guard,
+                        sites,
+                        seen,
+                    );
+                }
+                self.collect_bound_expr(
+                    cond,
+                    vec_sizes,
+                    scalar_widths,
+                    const_params,
+                    loop_iters,
+                    guard,
+                    sites,
+                    seen,
+                );
             }
             Stmt::Log(_) => {}
         }
@@ -4064,13 +4849,23 @@ impl<'a> Codegen<'a> {
         // that doesn't exist outside the for-loop body and (b) duplicate a
         // check the loop range already enforces.
         let idx_is_loop_iter = |ex: &Expr| -> bool {
-            if let ExprKind::Ident(n) = &ex.kind { loop_iters.contains(n) } else { false }
+            if let ExprKind::Ident(n) = &ex.kind {
+                loop_iters.contains(n)
+            } else {
+                false
+            }
         };
         let base_ident = |ex: &Expr| -> Option<String> {
-            if let ExprKind::Ident(n) = &ex.kind { Some(n.clone()) } else { None }
+            if let ExprKind::Ident(n) = &ex.kind {
+                Some(n.clone())
+            } else {
+                None
+            }
         };
-        let push = |predicate: String, tag: &str, sites: &mut Vec<(String, String)>,
-                        seen: &mut std::collections::HashSet<String>| {
+        let push = |predicate: String,
+                    tag: &str,
+                    sites: &mut Vec<(String, String)>,
+                    seen: &mut std::collections::HashSet<String>| {
             let predicate = Self::guard_bound_predicate(predicate, guard);
             if seen.insert(predicate.clone()) {
                 sites.push((predicate, tag.to_string()));
@@ -4088,8 +4883,26 @@ impl<'a> Codegen<'a> {
                         }
                     }
                 }
-                self.collect_bound_expr(base, vec_sizes, scalar_widths, const_params, loop_iters, guard, sites, seen);
-                self.collect_bound_expr(idx, vec_sizes, scalar_widths, const_params, loop_iters, guard, sites, seen);
+                self.collect_bound_expr(
+                    base,
+                    vec_sizes,
+                    scalar_widths,
+                    const_params,
+                    loop_iters,
+                    guard,
+                    sites,
+                    seen,
+                );
+                self.collect_bound_expr(
+                    idx,
+                    vec_sizes,
+                    scalar_widths,
+                    const_params,
+                    loop_iters,
+                    guard,
+                    sites,
+                    seen,
+                );
             }
             ExprKind::PartSelect(base, start, width, up) => {
                 if !idx_is_const(start) && !idx_is_loop_iter(start) {
@@ -4111,8 +4924,26 @@ impl<'a> Codegen<'a> {
                         }
                     }
                 }
-                self.collect_bound_expr(base, vec_sizes, scalar_widths, const_params, loop_iters, guard, sites, seen);
-                self.collect_bound_expr(start, vec_sizes, scalar_widths, const_params, loop_iters, guard, sites, seen);
+                self.collect_bound_expr(
+                    base,
+                    vec_sizes,
+                    scalar_widths,
+                    const_params,
+                    loop_iters,
+                    guard,
+                    sites,
+                    seen,
+                );
+                self.collect_bound_expr(
+                    start,
+                    vec_sizes,
+                    scalar_widths,
+                    const_params,
+                    loop_iters,
+                    guard,
+                    sites,
+                    seen,
+                );
             }
             ExprKind::Binary(op, a, b) => {
                 // Divide-by-zero assertion: divisor must be non-zero at every
@@ -4129,27 +4960,141 @@ impl<'a> Codegen<'a> {
                         sites.push((pred, tag.to_string()));
                     }
                 }
-                self.collect_bound_expr(a, vec_sizes, scalar_widths, const_params, loop_iters, guard, sites, seen);
-                self.collect_bound_expr(b, vec_sizes, scalar_widths, const_params, loop_iters, guard, sites, seen);
+                self.collect_bound_expr(
+                    a,
+                    vec_sizes,
+                    scalar_widths,
+                    const_params,
+                    loop_iters,
+                    guard,
+                    sites,
+                    seen,
+                );
+                self.collect_bound_expr(
+                    b,
+                    vec_sizes,
+                    scalar_widths,
+                    const_params,
+                    loop_iters,
+                    guard,
+                    sites,
+                    seen,
+                );
             }
-            ExprKind::Unary(_, a) => self.collect_bound_expr(a, vec_sizes, scalar_widths, const_params, loop_iters, guard, sites, seen),
+            ExprKind::Unary(_, a) => self.collect_bound_expr(
+                a,
+                vec_sizes,
+                scalar_widths,
+                const_params,
+                loop_iters,
+                guard,
+                sites,
+                seen,
+            ),
             ExprKind::Ternary(c, t, f) => {
-                self.collect_bound_expr(c, vec_sizes, scalar_widths, const_params, loop_iters, guard, sites, seen);
-                self.collect_bound_expr(t, vec_sizes, scalar_widths, const_params, loop_iters, guard, sites, seen);
-                self.collect_bound_expr(f, vec_sizes, scalar_widths, const_params, loop_iters, guard, sites, seen);
+                self.collect_bound_expr(
+                    c,
+                    vec_sizes,
+                    scalar_widths,
+                    const_params,
+                    loop_iters,
+                    guard,
+                    sites,
+                    seen,
+                );
+                self.collect_bound_expr(
+                    t,
+                    vec_sizes,
+                    scalar_widths,
+                    const_params,
+                    loop_iters,
+                    guard,
+                    sites,
+                    seen,
+                );
+                self.collect_bound_expr(
+                    f,
+                    vec_sizes,
+                    scalar_widths,
+                    const_params,
+                    loop_iters,
+                    guard,
+                    sites,
+                    seen,
+                );
             }
             ExprKind::MethodCall(base, _, args) => {
-                self.collect_bound_expr(base, vec_sizes, scalar_widths, const_params, loop_iters, guard, sites, seen);
-                for a in args { self.collect_bound_expr(a, vec_sizes, scalar_widths, const_params, loop_iters, guard, sites, seen); }
+                self.collect_bound_expr(
+                    base,
+                    vec_sizes,
+                    scalar_widths,
+                    const_params,
+                    loop_iters,
+                    guard,
+                    sites,
+                    seen,
+                );
+                for a in args {
+                    self.collect_bound_expr(
+                        a,
+                        vec_sizes,
+                        scalar_widths,
+                        const_params,
+                        loop_iters,
+                        guard,
+                        sites,
+                        seen,
+                    );
+                }
             }
             ExprKind::FunctionCall(_, args) => {
-                for a in args { self.collect_bound_expr(a, vec_sizes, scalar_widths, const_params, loop_iters, guard, sites, seen); }
+                for a in args {
+                    self.collect_bound_expr(
+                        a,
+                        vec_sizes,
+                        scalar_widths,
+                        const_params,
+                        loop_iters,
+                        guard,
+                        sites,
+                        seen,
+                    );
+                }
             }
             ExprKind::Concat(parts) => {
-                for p in parts { self.collect_bound_expr(p, vec_sizes, scalar_widths, const_params, loop_iters, guard, sites, seen); }
+                for p in parts {
+                    self.collect_bound_expr(
+                        p,
+                        vec_sizes,
+                        scalar_widths,
+                        const_params,
+                        loop_iters,
+                        guard,
+                        sites,
+                        seen,
+                    );
+                }
             }
-            ExprKind::FieldAccess(base, _) => self.collect_bound_expr(base, vec_sizes, scalar_widths, const_params, loop_iters, guard, sites, seen),
-            ExprKind::BitSlice(base, _, _) => self.collect_bound_expr(base, vec_sizes, scalar_widths, const_params, loop_iters, guard, sites, seen),
+            ExprKind::FieldAccess(base, _) => self.collect_bound_expr(
+                base,
+                vec_sizes,
+                scalar_widths,
+                const_params,
+                loop_iters,
+                guard,
+                sites,
+                seen,
+            ),
+            ExprKind::BitSlice(base, _, _) => self.collect_bound_expr(
+                base,
+                vec_sizes,
+                scalar_widths,
+                const_params,
+                loop_iters,
+                guard,
+                sites,
+                seen,
+            ),
             _ => {}
         }
     }
@@ -4189,8 +5134,10 @@ impl<'a> Codegen<'a> {
                 // Check if target root is reg_name
                 let targets_reg = match &a.target.kind {
                     ExprKind::Ident(n) => n == reg_name,
-                    ExprKind::Index(base, _) | ExprKind::FieldAccess(base, _)
-                    | ExprKind::BitSlice(base, _, _) | ExprKind::PartSelect(base, _, _, _) => {
+                    ExprKind::Index(base, _)
+                    | ExprKind::FieldAccess(base, _)
+                    | ExprKind::BitSlice(base, _, _)
+                    | ExprKind::PartSelect(base, _, _, _) => {
                         matches!(&base.kind, ExprKind::Ident(n) if n == reg_name)
                     }
                     _ => false,
@@ -4293,7 +5240,9 @@ impl<'a> Codegen<'a> {
     /// codegen for now — promote to a shared util if a third caller appears.
     fn type_expr_width(&self, ty: &TypeExpr) -> Option<u32> {
         let eval = |e: &Expr| match &e.kind {
-            ExprKind::Literal(LitKind::Dec(n)) | ExprKind::Literal(LitKind::Hex(n)) => Some(*n as u32),
+            ExprKind::Literal(LitKind::Dec(n)) | ExprKind::Literal(LitKind::Hex(n)) => {
+                Some(*n as u32)
+            }
             _ => None,
         };
         match ty {
@@ -4358,7 +5307,7 @@ impl<'a> Codegen<'a> {
             let (sym, _) = scope.get(n.as_str())?;
             let te_opt: Option<&TypeExpr> = match sym {
                 Symbol::Port(p) => Some(&p.ty),
-                Symbol::Reg(r)  => Some(&r.ty),
+                Symbol::Reg(r) => Some(&r.ty),
                 _ => None,
             };
             if let Some(TypeExpr::Named(struct_name)) = te_opt {
@@ -4424,13 +5373,7 @@ impl<'a> Codegen<'a> {
     /// alternative (threading a mutable binding map through every
     /// `emit_expr_str` caller) would touch ~30 sites; this is localized.
     #[allow(clippy::ptr_arg)]
-    fn emit_vec_method(
-        &self,
-        recv_b: &str,
-        recv: &Expr,
-        method: &Ident,
-        args: &[Expr],
-    ) -> String {
+    fn emit_vec_method(&self, recv_b: &str, recv: &Expr, method: &Ident, args: &[Expr]) -> String {
         // Resolve N. The receiver is an Ident in v1; more complex
         // expressions are not lowered (falls through to placeholder).
         let n = match &recv.kind {
@@ -4454,8 +5397,12 @@ impl<'a> Codegen<'a> {
             let this = self as *const Codegen as *mut Codegen;
             // SAFETY: single-threaded emission; no aliasing.
             unsafe {
-                (*this).ident_subst.insert("item".to_string(), format!("{recv_b}[{i}]"));
-                (*this).ident_subst.insert("index".to_string(), format!("{idx_w}'d{i}"));
+                (*this)
+                    .ident_subst
+                    .insert("item".to_string(), format!("{recv_b}[{i}]"));
+                (*this)
+                    .ident_subst
+                    .insert("index".to_string(), format!("{idx_w}'d{i}"));
             }
             let result = if let Some(pred) = args.first() {
                 self.emit_expr_str(pred)
@@ -4473,15 +5420,21 @@ impl<'a> Codegen<'a> {
 
         match method.name.as_str() {
             "any" => {
-                if n_usize == 0 { return "1'b0".to_string(); }
+                if n_usize == 0 {
+                    return "1'b0".to_string();
+                }
                 (0..n).map(emit_at).collect::<Vec<_>>().join(" || ")
             }
             "all" => {
-                if n_usize == 0 { return "1'b1".to_string(); }
+                if n_usize == 0 {
+                    return "1'b1".to_string();
+                }
                 (0..n).map(emit_at).collect::<Vec<_>>().join(" && ")
             }
             "count" => {
-                if n_usize == 0 { return "0".to_string(); }
+                if n_usize == 0 {
+                    return "0".to_string();
+                }
                 let w = crate::width::index_width((n + 1) as u64);
                 // Sum of bool conversions. SV auto-widens `+` per 1800-2012 §11.6.
                 let terms: Vec<String> = (0..n)
@@ -4497,28 +5450,40 @@ impl<'a> Codegen<'a> {
                     return "1'b0".to_string();
                 };
                 let x = self.emit_expr_str(x_expr);
-                if n_usize == 0 { return "1'b0".to_string(); }
-                (0..n).map(|i| format!("({recv_b}[{i}] == {x})"))
-                      .collect::<Vec<_>>()
-                      .join(" || ")
+                if n_usize == 0 {
+                    return "1'b0".to_string();
+                }
+                (0..n)
+                    .map(|i| format!("({recv_b}[{i}] == {x})"))
+                    .collect::<Vec<_>>()
+                    .join(" || ")
             }
             "reduce_or" => {
-                if n_usize == 0 { return "0".to_string(); }
-                (0..n).map(|i| format!("{recv_b}[{i}]"))
-                      .collect::<Vec<_>>()
-                      .join(" | ")
+                if n_usize == 0 {
+                    return "0".to_string();
+                }
+                (0..n)
+                    .map(|i| format!("{recv_b}[{i}]"))
+                    .collect::<Vec<_>>()
+                    .join(" | ")
             }
             "reduce_and" => {
-                if n_usize == 0 { return "0".to_string(); }
-                (0..n).map(|i| format!("{recv_b}[{i}]"))
-                      .collect::<Vec<_>>()
-                      .join(" & ")
+                if n_usize == 0 {
+                    return "0".to_string();
+                }
+                (0..n)
+                    .map(|i| format!("{recv_b}[{i}]"))
+                    .collect::<Vec<_>>()
+                    .join(" & ")
             }
             "reduce_xor" => {
-                if n_usize == 0 { return "0".to_string(); }
-                (0..n).map(|i| format!("{recv_b}[{i}]"))
-                      .collect::<Vec<_>>()
-                      .join(" ^ ")
+                if n_usize == 0 {
+                    return "0".to_string();
+                }
+                (0..n)
+                    .map(|i| format!("{recv_b}[{i}]"))
+                    .collect::<Vec<_>>()
+                    .join(" ^ ")
             }
             "find_first" => {
                 // Record the index width so a matching typedef is emitted
@@ -4605,7 +5570,9 @@ impl<'a> Codegen<'a> {
                         };
                         if let Some(te) = te_opt {
                             match te {
-                                TypeExpr::UInt(w) | TypeExpr::SInt(w) => return self.emit_expr_str(w),
+                                TypeExpr::UInt(w) | TypeExpr::SInt(w) => {
+                                    return self.emit_expr_str(w)
+                                }
                                 TypeExpr::Bool | TypeExpr::Bit => return "1".to_string(),
                                 _ => {}
                             }
@@ -4620,8 +5587,13 @@ impl<'a> Codegen<'a> {
                                                 if lb.name.name == *name {
                                                     if let Some(ty) = &lb.ty {
                                                         match ty {
-                                                            TypeExpr::UInt(w) | TypeExpr::SInt(w) => return self.emit_expr_str(w),
-                                                            TypeExpr::Bool | TypeExpr::Bit => return "1".to_string(),
+                                                            TypeExpr::UInt(w)
+                                                            | TypeExpr::SInt(w) => {
+                                                                return self.emit_expr_str(w)
+                                                            }
+                                                            TypeExpr::Bool | TypeExpr::Bit => {
+                                                                return "1".to_string()
+                                                            }
                                                             _ => {}
                                                         }
                                                     }
@@ -4638,7 +5610,11 @@ impl<'a> Codegen<'a> {
             }
             // Unsized literals: compute minimum bit width from value (never 0 bits)
             ExprKind::Literal(LitKind::Dec(v) | LitKind::Hex(v) | LitKind::Bin(v)) => {
-                let bits = if *v == 0 { 1 } else { (64 - v.leading_zeros()) as u32 };
+                let bits = if *v == 0 {
+                    1
+                } else {
+                    (64 - v.leading_zeros()) as u32
+                };
                 bits.to_string()
             }
             ExprKind::Literal(LitKind::Sized(w, _)) => w.to_string(),
@@ -4669,7 +5645,9 @@ impl<'a> Codegen<'a> {
                                 };
                                 if let Some(TypeExpr::Vec(inner, _)) = te_opt {
                                     match inner.as_ref() {
-                                        TypeExpr::UInt(w) | TypeExpr::SInt(w) => return self.emit_expr_str(w),
+                                        TypeExpr::UInt(w) | TypeExpr::SInt(w) => {
+                                            return self.emit_expr_str(w)
+                                        }
                                         TypeExpr::Bool | TypeExpr::Bit => return "1".to_string(),
                                         _ => {}
                                     }
@@ -4685,7 +5663,11 @@ impl<'a> Codegen<'a> {
             ExprKind::Binary(BinOp::AddWrap | BinOp::SubWrap | BinOp::MulWrap, lhs, rhs) => {
                 let lw = self.infer_sv_width_str(lhs);
                 let rw = self.infer_sv_width_str(rhs);
-                if lw == rw { lw } else { format!("({lw} > {rw} ? {lw} : {rw})") }
+                if lw == rw {
+                    lw
+                } else {
+                    format!("({lw} > {rw} ? {lw} : {rw})")
+                }
             }
             _ => format!("$bits({})", self.emit_expr_str(expr)),
         }
@@ -4755,7 +5737,9 @@ impl<'a> Codegen<'a> {
                 LitKind::Bin(v) => format!("'b{v:b}"),
                 LitKind::Sized(w, v) => format!("{w}'d{v}"),
                 // Float literal (FP32 by default) → 32-bit binary32 bit pattern.
-                LitKind::Float(bits) => format!("32'h{:08X}", (f64::from_bits(*bits) as f32).to_bits()),
+                LitKind::Float(bits) => {
+                    format!("32'h{:08X}", (f64::from_bits(*bits) as f32).to_bits())
+                }
             },
             ExprKind::Bool(true) => "1'b1".to_string(),
             ExprKind::Bool(false) => "1'b0".to_string(),
@@ -4777,12 +5761,20 @@ impl<'a> Codegen<'a> {
             ExprKind::Binary(op, lhs, rhs) => {
                 // Floating-point operands dispatch to the emitted `arch_f32_*` /
                 // `arch_bf16_*` SystemVerilog helper functions.
-                if let Some(fmt) = self.expr_float_fmt(lhs).or_else(|| self.expr_float_fmt(rhs)) {
+                if let Some(fmt) = self
+                    .expr_float_fmt(lhs)
+                    .or_else(|| self.expr_float_fmt(rhs))
+                {
                     let fop = match op {
-                        BinOp::Add => Some("add"), BinOp::Sub => Some("sub"), BinOp::Mul => Some("mul"),
-                        BinOp::Eq => Some("eq"), BinOp::Neq => Some("ne"),
-                        BinOp::Lt => Some("lt"), BinOp::Gt => Some("gt"),
-                        BinOp::Lte => Some("le"), BinOp::Gte => Some("ge"),
+                        BinOp::Add => Some("add"),
+                        BinOp::Sub => Some("sub"),
+                        BinOp::Mul => Some("mul"),
+                        BinOp::Eq => Some("eq"),
+                        BinOp::Neq => Some("ne"),
+                        BinOp::Lt => Some("lt"),
+                        BinOp::Gt => Some("gt"),
+                        BinOp::Lte => Some("le"),
+                        BinOp::Gte => Some("ge"),
                         _ => None,
                     };
                     if let Some(fop) = fop {
@@ -4795,7 +5787,7 @@ impl<'a> Codegen<'a> {
                 // `implies` lowers to (!lhs || rhs)
                 if *op == BinOp::Implies {
                     let l = self.emit_expr_prec(lhs, 14); // unary prec for !
-                    let r = self.emit_expr_prec(rhs, 4);  // || prec
+                    let r = self.emit_expr_prec(rhs, 4); // || prec
                     return format!("{l} |-> {r}");
                 }
                 if *op == BinOp::ImpliesNext {
@@ -4856,7 +5848,11 @@ impl<'a> Codegen<'a> {
                 if matches!(op, BinOp::AddWrap | BinOp::SubWrap | BinOp::MulWrap) {
                     let lw = self.infer_sv_width_str(lhs);
                     let rw = self.infer_sv_width_str(rhs);
-                    let w = if lw == rw { lw } else { format!("({lw} > {rw} ? {lw} : {rw})") };
+                    let w = if lw == rw {
+                        lw
+                    } else {
+                        format!("({lw} > {rw} ? {lw} : {rw})")
+                    };
                     let wp = Self::paren_width(&w);
                     format!("{wp}'({l} {op_str} {r})")
                 } else {
@@ -4938,7 +5934,10 @@ impl<'a> Codegen<'a> {
                             if self.bus_wires.contains_key(&cell0) {
                                 let m_str = resolve_str(inner_idx);
                                 let n_str = resolve_str(idx);
-                                return format!("{}_{}[{}][{}]", arr_name, field.name, m_str, n_str);
+                                return format!(
+                                    "{}_{}[{}][{}]",
+                                    arr_name, field.name, m_str, n_str
+                                );
                             }
                         }
                     }
@@ -5043,11 +6042,8 @@ impl<'a> Codegen<'a> {
                             b
                         }
                     }
-                    "any" | "all" | "count" | "contains"
-                    | "reduce_or" | "reduce_and" | "reduce_xor"
-                    | "find_first" => {
-                        self.emit_vec_method(&b, base, method, args)
-                    }
+                    "any" | "all" | "count" | "contains" | "reduce_or" | "reduce_and"
+                    | "reduce_xor" | "find_first" => self.emit_vec_method(&b, base, method, args),
                     // Float conversions → emitted helper functions.
                     "to_fp32" => {
                         self.fp_helpers_used.set(true);
@@ -5074,14 +6070,19 @@ impl<'a> Codegen<'a> {
                                 if self.expr_is_signed(base) {
                                     format!("arch_f32_to_bf16(arch_i64_to_f32(64'($signed({b}))))")
                                 } else {
-                                    format!("arch_f32_to_bf16(arch_u64_to_f32(64'($unsigned({b}))))")
+                                    format!(
+                                        "arch_f32_to_bf16(arch_u64_to_f32(64'($unsigned({b}))))"
+                                    )
                                 }
                             }
                         }
                     }
                     "to_uint" | "to_sint" => {
                         self.fp_helpers_used.set(true);
-                        let width = args.first().map(|w| self.emit_expr_str(w)).unwrap_or_else(|| "32".to_string());
+                        let width = args
+                            .first()
+                            .map(|w| self.emit_expr_str(w))
+                            .unwrap_or_else(|| "32".to_string());
                         let wp = Self::paren_width(&width);
                         let f32bits = match self.expr_float_fmt(base) {
                             Some("bf16") => format!("arch_bf16_to_f32({b})"),
@@ -5089,7 +6090,11 @@ impl<'a> Codegen<'a> {
                         };
                         // Toward-zero, saturating to the N-bit target, NaN -> type max
                         // (synthesizable helper; returns a 64-bit value truncated to N).
-                        let conv = if method.name == "to_sint" { "arch_f32_to_sint" } else { "arch_f32_to_uint" };
+                        let conv = if method.name == "to_sint" {
+                            "arch_f32_to_sint"
+                        } else {
+                            "arch_f32_to_uint"
+                        };
                         format!("{wp}'({conv}({f32bits}, {width}))")
                     }
                     _ => format!("{b}.{}()", method.name),
@@ -5141,9 +6146,11 @@ impl<'a> Codegen<'a> {
                 format!("{b}[{i}]")
             }
             ExprKind::BitSlice(base, hi, lo) => {
-                if let (Some(v), Some(hi_v), Some(lo_v)) =
-                    (literal_expr_u64(base), literal_expr_u64(hi), literal_expr_u64(lo))
-                {
+                if let (Some(v), Some(hi_v), Some(lo_v)) = (
+                    literal_expr_u64(base),
+                    literal_expr_u64(hi),
+                    literal_expr_u64(lo),
+                ) {
                     if hi_v >= lo_v && hi_v < 64 {
                         let width = (hi_v - lo_v + 1) as u32;
                         let mask = if width >= 64 {
@@ -5166,12 +6173,21 @@ impl<'a> Codegen<'a> {
                 // because bit-select doesn't compose with the parenthesized
                 // expression — but `func()[hi:lo]` is valid (function-call
                 // result is an "lvalue-like" form per the SV grammar).
-                let b = if matches!(base.kind, ExprKind::Ident(_) | ExprKind::SynthIdent(_, _)
-                    | ExprKind::Literal(_)
-                    | ExprKind::Index(_, _) | ExprKind::FieldAccess(_, _)
-                    | ExprKind::Concat(_)
-                    | ExprKind::FunctionCall(_, _) | ExprKind::MethodCall(_, _, _)) { b }
-                    else { format!("({})", b) };
+                let b = if matches!(
+                    base.kind,
+                    ExprKind::Ident(_)
+                        | ExprKind::SynthIdent(_, _)
+                        | ExprKind::Literal(_)
+                        | ExprKind::Index(_, _)
+                        | ExprKind::FieldAccess(_, _)
+                        | ExprKind::Concat(_)
+                        | ExprKind::FunctionCall(_, _)
+                        | ExprKind::MethodCall(_, _, _)
+                ) {
+                    b
+                } else {
+                    format!("({})", b)
+                };
                 // Try to emit indexed part-select: base[lo +: width]
                 if let Some(width) = Self::try_indexed_part_select(hi, lo) {
                     let l = self.emit_expr_str(lo);
@@ -5225,10 +6241,16 @@ impl<'a> Codegen<'a> {
             ExprKind::EnumVariant(enum_name, variant) => {
                 // Extern types from `extern package` — emit bare variant name
                 // (preserving case), relying on `import Pkg::*;` for resolution.
-                if matches!(self.symbols.globals.get(&enum_name.name), Some((Symbol::ExternEnum(_), _))) {
+                if matches!(
+                    self.symbols.globals.get(&enum_name.name),
+                    Some((Symbol::ExternEnum(_), _))
+                ) {
                     variant.name.clone()
                 // Known ARCH-side enum → emit just the variant name in uppercase.
-                } else if matches!(self.symbols.globals.get(&enum_name.name), Some((Symbol::Enum(_), _))) {
+                } else if matches!(
+                    self.symbols.globals.get(&enum_name.name),
+                    Some((Symbol::Enum(_), _))
+                ) {
                     variant.name.to_uppercase()
                 // Cross-package qualified refs (e.g. `ibex_pkg::RV32MFast`) —
                 // preserve the package prefix and original case.
@@ -5236,9 +6258,7 @@ impl<'a> Codegen<'a> {
                     format!("{}::{}", enum_name.name, variant.name)
                 }
             }
-            ExprKind::Todo => {
-                "'0 /* TODO: todo! placeholder */".to_string()
-            }
+            ExprKind::Todo => "'0 /* TODO: todo! placeholder */".to_string(),
             ExprKind::Concat(parts) => {
                 let strs: Vec<String> = parts.iter().map(|p| self.emit_expr_str(p)).collect();
                 format!("{{{}}}", strs.join(", "))
@@ -5289,7 +6309,11 @@ impl<'a> Codegen<'a> {
                         }
                         Pattern::Ident(id) => format!("({s} == {id})", id = id.name),
                         Pattern::EnumVariant(en, vr) => {
-                            format!("({s} == {en}__{vr})", en = en.name.to_uppercase(), vr = vr.name.to_uppercase())
+                            format!(
+                                "({s} == {en}__{vr})",
+                                en = en.name.to_uppercase(),
+                                vr = vr.name.to_uppercase()
+                            )
                         }
                     };
                     result = format!("({cond} ? {val} : {result})");
@@ -5305,14 +6329,17 @@ impl<'a> Codegen<'a> {
             }
             ExprKind::Inside(scrutinee, members) => {
                 let s = self.emit_expr_str(scrutinee);
-                let member_strs: Vec<String> = members.iter().map(|m| match m {
-                    InsideMember::Single(e) => self.emit_expr_str(e),
-                    InsideMember::Range(lo, hi) => {
-                        let l = self.emit_expr_str(lo);
-                        let h = self.emit_expr_str(hi);
-                        format!("[{l}:{h}]")
-                    }
-                }).collect();
+                let member_strs: Vec<String> = members
+                    .iter()
+                    .map(|m| match m {
+                        InsideMember::Single(e) => self.emit_expr_str(e),
+                        InsideMember::Range(lo, hi) => {
+                            let l = self.emit_expr_str(lo);
+                            let h = self.emit_expr_str(hi);
+                            format!("[{l}:{h}]")
+                        }
+                    })
+                    .collect();
                 format!("{s} inside {{{}}}", member_strs.join(", "))
             }
             ExprKind::FunctionCall(name, args) => {
@@ -5333,7 +6360,8 @@ impl<'a> Codegen<'a> {
                 // Float intrinsics → emitted helper functions.
                 if name == "fma" && args.len() == 3 {
                     self.fp_helpers_used.set(true);
-                    let fmt = self.expr_float_fmt(&args[0])
+                    let fmt = self
+                        .expr_float_fmt(&args[0])
                         .or_else(|| self.expr_float_fmt(&args[1]))
                         .or_else(|| self.expr_float_fmt(&args[2]))
                         .unwrap_or("f32");
@@ -5348,11 +6376,19 @@ impl<'a> Codegen<'a> {
                     };
                 }
                 // Resolve mangled name if this is an overloaded function.
-                let sv_name = if let Some((Symbol::Function(overloads), _)) = self.symbols.globals.get(name) {
+                let sv_name = if let Some((Symbol::Function(overloads), _)) =
+                    self.symbols.globals.get(name)
+                {
                     if overloads.len() > 1 {
-                        let idx = self.overload_map.get(&expr.span.start).copied().unwrap_or(0);
+                        let idx = self
+                            .overload_map
+                            .get(&expr.span.start)
+                            .copied()
+                            .unwrap_or(0);
                         let ov = &overloads[idx];
-                        let suffix: String = ov.arg_types.iter()
+                        let suffix: String = ov
+                            .arg_types
+                            .iter()
                             .map(|t| Self::type_mangle_tag(t))
                             .collect::<Vec<_>>()
                             .join("_");
@@ -5427,7 +6463,10 @@ impl<'a> Codegen<'a> {
     }
 
     /// Substitute bus parameter names in a TypeExpr with actual value expressions.
-    fn subst_type_expr(ty: &TypeExpr, params: &std::collections::HashMap<String, &Expr>) -> TypeExpr {
+    fn subst_type_expr(
+        ty: &TypeExpr,
+        params: &std::collections::HashMap<String, &Expr>,
+    ) -> TypeExpr {
         match ty {
             TypeExpr::UInt(w) => TypeExpr::UInt(Box::new(Self::subst_expr(w, params))),
             TypeExpr::SInt(w) => TypeExpr::SInt(Box::new(Self::subst_expr(w, params))),
@@ -5456,10 +6495,7 @@ impl<'a> Codegen<'a> {
                 Box::new(Self::subst_expr(l, params)),
                 Box::new(Self::subst_expr(r, params)),
             ),
-            ExprKind::Unary(op, e) => ExprKind::Unary(
-                *op,
-                Box::new(Self::subst_expr(e, params)),
-            ),
+            ExprKind::Unary(op, e) => ExprKind::Unary(*op, Box::new(Self::subst_expr(e, params))),
             ExprKind::Ternary(c, t, e) => ExprKind::Ternary(
                 Box::new(Self::subst_expr(c, params)),
                 Box::new(Self::subst_expr(t, params)),
@@ -5550,7 +6586,11 @@ impl<'a> Codegen<'a> {
     /// array as `logic [W-1:0] x [N]` shorthand (= `[0:N-1]`); without
     /// this, IEEE 1800-2017 §10.10 element-by-position port mapping
     /// silently reverses the indices. See arch-com#307.
-    fn emit_type_and_unpacked_suffix_dir(&self, ty: &TypeExpr, ascending: bool) -> (String, String) {
+    fn emit_type_and_unpacked_suffix_dir(
+        &self,
+        ty: &TypeExpr,
+        ascending: bool,
+    ) -> (String, String) {
         let mut dims = Vec::new();
         let mut cur = ty;
         while let TypeExpr::Vec(inner, size) = cur {
@@ -5588,7 +6628,6 @@ impl<'a> Codegen<'a> {
 
     // ── Synchronizer ─────────────────────────────────────────────────────────
     // ── RAM ───────────────────────────────────────────────────────────────────
-
 }
 
 fn literal_expr_u64(expr: &Expr) -> Option<u64> {

--- a/src/codegen/module.rs
+++ b/src/codegen/module.rs
@@ -43,12 +43,16 @@ impl<'a> Codegen<'a> {
         // types like `parameter rv32m_e RV32M` resolve.
         for item in &self.source.items {
             if let Item::Use(u) = item {
-                let arch_pkg = self.source.items.iter().any(|i| {
-                    matches!(i, Item::Package(p) if p.name.name == u.name.name)
-                });
+                let arch_pkg = self
+                    .source
+                    .items
+                    .iter()
+                    .any(|i| matches!(i, Item::Package(p) if p.name.name == u.name.name));
                 let extern_pkg = self.source.items.iter().find_map(|i| {
                     if let Item::ExternPackage(ep) = i {
-                        if ep.name.name == u.name.name { return Some(ep); }
+                        if ep.name.name == u.name.name {
+                            return Some(ep);
+                        }
                     }
                     None
                 });
@@ -56,7 +60,8 @@ impl<'a> Codegen<'a> {
                     self.out.push_str(&format!("import {}::*;\n", u.name.name));
                 } else if let Some(ep) = extern_pkg {
                     for ty in &ep.types {
-                        self.out.push_str(&format!("import {}::{};\n", u.name.name, ty.name));
+                        self.out
+                            .push_str(&format!("import {}::{};\n", u.name.name, ty.name));
                     }
                 }
             }
@@ -94,8 +99,10 @@ impl<'a> Codegen<'a> {
             if let ModuleBodyItem::WireDecl(w) = item {
                 if let TypeExpr::Vec(elem, size_expr) = &w.ty {
                     if let TypeExpr::Named(id) = elem.as_ref() {
-                        if matches!(self.symbols.globals.get(&id.name),
-                                    Some((crate::resolve::Symbol::Bus(_), _))) {
+                        if matches!(
+                            self.symbols.globals.get(&id.name),
+                            Some((crate::resolve::Symbol::Bus(_), _))
+                        ) {
                             if let Some(n) = self.eval_const_u32(size_expr, &m.params) {
                                 self.vec_of_bus_wire_count.insert(w.name.name.clone(), n);
                             }
@@ -110,19 +117,22 @@ impl<'a> Codegen<'a> {
         self.vec_params.clear();
         for bi in &m.body {
             if let ModuleBodyItem::PipeRegDecl(p) = bi {
-                self.pipe_regs.insert(p.name.name.clone(), (p.source.name.clone(), p.stages));
+                self.pipe_regs
+                    .insert(p.name.name.clone(), (p.source.name.clone(), p.stages));
             }
         }
         for p in m.params.iter() {
             if let ParamKind::ConstVec(ty) = &p.kind {
                 if let TypeExpr::Vec(elem, _) = ty {
-                    self.vec_params.insert(p.name.name.clone(), (**elem).clone());
+                    self.vec_params
+                        .insert(p.name.name.clone(), (**elem).clone());
                 }
             }
         }
         for p in m.ports.iter() {
             if let TypeExpr::Reset(kind, level) = &p.ty {
-                self.reset_ports.insert(p.name.name.clone(), (*kind, *level));
+                self.reset_ports
+                    .insert(p.name.name.clone(), (*kind, *level));
             }
             if let TypeExpr::Vec(_, size_expr) = &p.ty {
                 if let Some(n) = self.eval_const_u32(size_expr, &m.params) {
@@ -174,8 +184,13 @@ impl<'a> Codegen<'a> {
                 // Yosys to lower the unpacked dim into a packed slice.
                 let is_vec_of_bus = bi.count.is_some();
                 let vec_n: u32 = if is_vec_of_bus {
-                    self.vec_of_bus_port_count.get(&p.name.name).copied().unwrap_or(0)
-                } else { 0 };
+                    self.vec_of_bus_port_count
+                        .get(&p.name.name)
+                        .copied()
+                        .unwrap_or(0)
+                } else {
+                    0
+                };
                 // Register the bus_name under the parent port name so downstream
                 // refs (`port.sig`, `port[i].sig`) can resolve back to the bus def.
                 if is_vec_of_bus {
@@ -183,7 +198,8 @@ impl<'a> Codegen<'a> {
                     // bookkeeping (driver tracking, comb/seq ref substitution) keeps working.
                     // SV emission is the only surface that uses the D2 shape.
                     for i in 0..vec_n {
-                        self.bus_ports.insert(format!("{}_{}", p.name.name, i), bus_name.clone());
+                        self.bus_ports
+                            .insert(format!("{}_{}", p.name.name, i), bus_name.clone());
                     }
                     // Also register the base port name so resolvers that look up by the
                     // declared port name (without index) find the bus.
@@ -191,9 +207,13 @@ impl<'a> Codegen<'a> {
                 } else {
                     self.bus_ports.insert(p.name.name.clone(), bus_name.clone());
                 }
-                if let Some((crate::resolve::Symbol::Bus(info), _)) = self.symbols.globals.get(bus_name) {
+                if let Some((crate::resolve::Symbol::Bus(info), _)) =
+                    self.symbols.globals.get(bus_name)
+                {
                     // Build param substitution map: start with bus defaults, override with port params
-                    let mut param_map: std::collections::HashMap<String, &Expr> = info.params.iter()
+                    let mut param_map: std::collections::HashMap<String, &Expr> = info
+                        .params
+                        .iter()
                         .filter_map(|pd| pd.default.as_ref().map(|d| (pd.name.name.clone(), d)))
                         .collect();
                     for pa in &bi.params {
@@ -242,10 +262,8 @@ impl<'a> Codegen<'a> {
                             ));
                         } else {
                             // Scalar bus: `<dir> <ty> <port>_<sig>`
-                            port_lines.push(format!(
-                                "{} {} {}_{}",
-                                dir_str, ty_str, p.name.name, sname
-                            ));
+                            port_lines
+                                .push(format!("{} {} {}_{}", dir_str, ty_str, p.name.name, sname));
                         }
                     }
                 }
@@ -260,20 +278,31 @@ impl<'a> Codegen<'a> {
                 // (`logic [W-1:0] name [N-1:0]`) for interop with external SV
                 // modules whose port shape is fixed unpacked.
                 if let TypeExpr::Vec(_, _) = &p.ty {
-                    let init_str = p.reg_info.as_ref()
+                    let init_str = p
+                        .reg_info
+                        .as_ref()
                         .and_then(|ri| ri.init.as_ref())
                         .map(|e| format!(" = {}", self.emit_expr_str(e)))
                         .unwrap_or_default();
                     if p.unpacked {
-                        let (base_ty, suffix) = self.emit_type_and_unpacked_suffix_dir(&p.ty, p.unpacked_ascending);
-                        port_lines.push(format!("{} {} {}{}{}", dir, base_ty, p.name.name, suffix, init_str));
+                        let (base_ty, suffix) =
+                            self.emit_type_and_unpacked_suffix_dir(&p.ty, p.unpacked_ascending);
+                        port_lines.push(format!(
+                            "{} {} {}{}{}",
+                            dir, base_ty, p.name.name, suffix, init_str
+                        ));
                     } else {
                         let (base_ty, suffix) = self.emit_type_and_array_suffix(&p.ty);
-                        port_lines.push(format!("{} {} {}{}{}", dir, base_ty, p.name.name, suffix, init_str));
+                        port_lines.push(format!(
+                            "{} {} {}{}{}",
+                            dir, base_ty, p.name.name, suffix, init_str
+                        ));
                     }
                 } else {
                     let ty_str = self.emit_port_type_str(&p.ty);
-                    let init_str = p.reg_info.as_ref()
+                    let init_str = p
+                        .reg_info
+                        .as_ref()
                         .and_then(|ri| ri.init.as_ref())
                         .map(|e| format!(" = {}", self.emit_expr_str(e)))
                         .unwrap_or_default();
@@ -303,7 +332,9 @@ impl<'a> Codegen<'a> {
         // Override at simulation: +arch_verbosity=N on the simulator command line.
         if Self::module_has_log(&m.body) {
             self.line("// synopsys translate_off");
-            self.line("integer _arch_verbosity = 1; // 0=Always 1=Low 2=Medium 3=High 4=Full 5=Debug");
+            self.line(
+                "integer _arch_verbosity = 1; // 0=Always 1=Low 2=Medium 3=High 4=Full 5=Debug",
+            );
             self.line("initial void'($value$plusargs(\"arch_verbosity=%0d\", _arch_verbosity));");
             self.line("// synopsys translate_on");
             self.line("");
@@ -311,7 +342,8 @@ impl<'a> Codegen<'a> {
 
         // Collect names already declared as ports, regs, or lets so we can
         // auto-declare inst output wires that aren't otherwise declared.
-        let mut declared_names: std::collections::HashSet<String> = std::collections::HashSet::new();
+        let mut declared_names: std::collections::HashSet<String> =
+            std::collections::HashSet::new();
         for p in &m.ports {
             declared_names.insert(p.name.name.clone());
             // Bus ports flatten to `<port>_<sig>` (or `<port>_<i>_<sig>` for
@@ -324,15 +356,15 @@ impl<'a> Codegen<'a> {
             if let Some(bi) = p.bus_info.as_ref() {
                 if let Some((Symbol::Bus(info), _)) = self.symbols.globals.get(&bi.bus_name.name) {
                     let mut pm = info.default_param_map();
-                    for pa in &bi.params { pm.insert(pa.name.name.clone(), &pa.value); }
+                    for pa in &bi.params {
+                        pm.insert(pa.name.name.clone(), &pa.value);
+                    }
                     let prefixes: Vec<String> = match bi.count.as_ref() {
                         None => vec![p.name.name.clone()],
-                        Some(count_expr) => {
-                            match self.eval_const_u32(count_expr, &m.params) {
-                                Some(n) => (0..n).map(|i| format!("{}_{}", p.name.name, i)).collect(),
-                                None => vec![p.name.name.clone()],
-                            }
-                        }
+                        Some(count_expr) => match self.eval_const_u32(count_expr, &m.params) {
+                            Some(n) => (0..n).map(|i| format!("{}_{}", p.name.name, i)).collect(),
+                            None => vec![p.name.name.clone()],
+                        },
                     };
                     for prefix in &prefixes {
                         for (sname, _, _) in info.effective_signals(&pm) {
@@ -355,8 +387,12 @@ impl<'a> Codegen<'a> {
         }
         for item in &m.body {
             match item {
-                ModuleBodyItem::RegDecl(r) => { declared_names.insert(r.name.name.clone()); }
-                ModuleBodyItem::LetBinding(l) => { declared_names.insert(l.name.name.clone()); }
+                ModuleBodyItem::RegDecl(r) => {
+                    declared_names.insert(r.name.name.clone());
+                }
+                ModuleBodyItem::LetBinding(l) => {
+                    declared_names.insert(l.name.name.clone());
+                }
                 ModuleBodyItem::PipeRegDecl(p) => {
                     declared_names.insert(p.name.name.clone());
                     for i in 0..p.stages.saturating_sub(1) {
@@ -368,9 +404,7 @@ impl<'a> Codegen<'a> {
                     // For bus-typed wires, also pre-populate flattened signal
                     // names so that inst auto-wire-decl doesn't duplicate them.
                     if let TypeExpr::Named(id) = &w.ty {
-                        if let Some((Symbol::Bus(info), _)) =
-                            self.symbols.globals.get(&id.name)
-                        {
+                        if let Some((Symbol::Bus(info), _)) = self.symbols.globals.get(&id.name) {
                             let param_map = info.default_param_map();
                             for (sname, _sdir, _sty) in info.effective_signals(&param_map) {
                                 declared_names.insert(format!("{}_{}", w.name.name, sname));
@@ -428,7 +462,7 @@ impl<'a> Codegen<'a> {
         // references `__shared_FN_out`.
         let (body_items, decls_count): (Vec<ModuleBodyItem>, usize) = {
             let mut decls: Vec<ModuleBodyItem> = Vec::new();
-            let mut rest:  Vec<ModuleBodyItem> = Vec::new();
+            let mut rest: Vec<ModuleBodyItem> = Vec::new();
             for it in m.body.iter() {
                 match it {
                     ModuleBodyItem::Function(_) => {} // already emitted in stage 1
@@ -461,10 +495,16 @@ impl<'a> Codegen<'a> {
             std::collections::HashSet::new();
         for item in &body_items {
             if let ModuleBodyItem::LetBinding(l) = item {
-                if l.ty.is_none() { continue; }
-                if !l.destructure_fields.is_empty() { continue; }
+                if l.ty.is_none() {
+                    continue;
+                }
+                if !l.destructure_fields.is_empty() {
+                    continue;
+                }
                 if let ExprKind::ExprMatch(_, arms) = &l.value.kind {
-                    if arms.len() >= 3 { continue; }
+                    if arms.len() >= 3 {
+                        continue;
+                    }
                 }
                 if let Some(ty) = &l.ty {
                     let (ty_str, arr_suffix) = self.emit_type_and_array_suffix(ty);
@@ -532,7 +572,9 @@ impl<'a> Codegen<'a> {
                                             ExprKind::Literal(LitKind::Dec(n))
                                             | ExprKind::Literal(LitKind::Hex(n))
                                             | ExprKind::Literal(LitKind::Bin(n))
-                                            | ExprKind::Literal(LitKind::Sized(_, n)) => Some(*n as u32),
+                                            | ExprKind::Literal(LitKind::Sized(_, n)) => {
+                                                Some(*n as u32)
+                                            }
                                             ExprKind::Ident(name) => {
                                                 self.symbols.globals.get(name)
                                                     .and_then(|(s, _)| match s {
@@ -575,8 +617,14 @@ impl<'a> Codegen<'a> {
                                     let emit_at_i = |cg: &Codegen, i: u32| -> String {
                                         let this = cg as *const Codegen as *mut Codegen;
                                         unsafe {
-                                            (*this).ident_subst.insert("item".to_string(), format!("{recv_str}[{i}]"));
-                                            (*this).ident_subst.insert("index".to_string(), format!("{idx_w}'d{i}"));
+                                            (*this).ident_subst.insert(
+                                                "item".to_string(),
+                                                format!("{recv_str}[{i}]"),
+                                            );
+                                            (*this).ident_subst.insert(
+                                                "index".to_string(),
+                                                format!("{idx_w}'d{i}"),
+                                            );
                                         }
                                         let s = cg.emit_expr_str(&margs[0]);
                                         unsafe {
@@ -585,7 +633,8 @@ impl<'a> Codegen<'a> {
                                         }
                                         s
                                     };
-                                    let hits: Vec<String> = (0..n).map(|i| emit_at_i(self, i)).collect();
+                                    let hits: Vec<String> =
+                                        (0..n).map(|i| emit_at_i(self, i)).collect();
                                     let found_expr = hits.join(" || ");
                                     let mut idx_expr = format!("{idx_w}'d0");
                                     for i in (0..n).rev() {
@@ -599,7 +648,10 @@ impl<'a> Codegen<'a> {
                                                 self.line(&format!("assign found = {found_expr};"));
                                             }
                                             "index" => {
-                                                self.line(&format!("logic [{}:0] index;", idx_w.saturating_sub(1)));
+                                                self.line(&format!(
+                                                    "logic [{}:0] index;",
+                                                    idx_w.saturating_sub(1)
+                                                ));
                                                 self.line(&format!("assign index = {idx_expr};"));
                                             }
                                             _ => {}
@@ -612,16 +664,24 @@ impl<'a> Codegen<'a> {
                         let rhs_ty = self.infer_expr_struct_name(&l.value);
                         let val_str = self.emit_expr_str(&l.value);
                         for bind in &l.destructure_fields {
-                            if let Some(field_ty) = rhs_ty.as_ref()
+                            if let Some(field_ty) = rhs_ty
+                                .as_ref()
                                 .and_then(|sname| self.struct_field_type(sname, &bind.name))
                             {
-                                let (ty_str, arr_suffix) = self.emit_type_and_array_suffix(&field_ty);
+                                let (ty_str, arr_suffix) =
+                                    self.emit_type_and_array_suffix(&field_ty);
                                 self.line(&format!("{} {}{};", ty_str, bind.name, arr_suffix));
-                                self.line(&format!("assign {} = {}.{};", bind.name, val_str, bind.name));
+                                self.line(&format!(
+                                    "assign {} = {}.{};",
+                                    bind.name, val_str, bind.name
+                                ));
                             } else {
                                 // Fallback: struct type unknown at codegen — emit as logic.
                                 self.line(&format!("logic {};", bind.name));
-                                self.line(&format!("assign {} = {}.{};", bind.name, val_str, bind.name));
+                                self.line(&format!(
+                                    "assign {} = {}.{};",
+                                    bind.name, val_str, bind.name
+                                ));
                             }
                         }
                         continue;
@@ -685,13 +745,27 @@ impl<'a> Codegen<'a> {
                     {
                         let module_ports = info.ports.clone();
                         for conn in &inst.connections {
-                            let Some(port) = module_ports.iter().find(|p| p.name.name == conn.port_name.name) else { continue; };
-                            let Some(bi) = &port.bus_info else { continue; };
-                            let ExprKind::Ident(parent_name) = &conn.signal.kind else { continue; };
+                            let Some(port) = module_ports
+                                .iter()
+                                .find(|p| p.name.name == conn.port_name.name)
+                            else {
+                                continue;
+                            };
+                            let Some(bi) = &port.bus_info else {
+                                continue;
+                            };
+                            let ExprKind::Ident(parent_name) = &conn.signal.kind else {
+                                continue;
+                            };
                             let Some((Symbol::Bus(bus_info), _)) =
-                                self.symbols.globals.get(&bi.bus_name.name) else { continue; };
+                                self.symbols.globals.get(&bi.bus_name.name)
+                            else {
+                                continue;
+                            };
                             let mut pm = bus_info.default_param_map();
-                            for pa in &bi.params { pm.insert(pa.name.name.clone(), &pa.value); }
+                            for pa in &bi.params {
+                                pm.insert(pa.name.name.clone(), &pa.value);
+                            }
                             for (sname, _sdir, _ty) in bus_info.effective_signals(&pm) {
                                 just_added.push(format!("{parent_name}_{sname}"));
                             }
@@ -700,7 +774,9 @@ impl<'a> Codegen<'a> {
                             just_added.push(parent_name.clone());
                         }
                     }
-                    for n in just_added { declared_names.insert(n); }
+                    for n in just_added {
+                        declared_names.insert(n);
+                    }
                     self.emit_inst(inst);
                 }
                 ModuleBodyItem::PipeRegDecl(p) => {
@@ -718,18 +794,28 @@ impl<'a> Codegen<'a> {
                     // indexed names `w_0`, ..., `w_{N-1}`, accessed via
                     // `w[i].sig`. Each copy contributes its full signal set.
                     let bus_wire_info = match &w.ty {
-                        TypeExpr::Named(id) => self.symbols.globals.get(&id.name)
-                            .and_then(|(s, _)| if let crate::resolve::Symbol::Bus(info) = s {
-                                Some((info, id.name.clone(), None))
-                            } else { None }),
+                        TypeExpr::Named(id) => {
+                            self.symbols.globals.get(&id.name).and_then(|(s, _)| {
+                                if let crate::resolve::Symbol::Bus(info) = s {
+                                    Some((info, id.name.clone(), None))
+                                } else {
+                                    None
+                                }
+                            })
+                        }
                         TypeExpr::Vec(elem, size_expr) => match elem.as_ref() {
                             TypeExpr::Named(id) => {
                                 if let Some(n) = self.eval_const_u32(size_expr, &m_clone.params) {
-                                    self.symbols.globals.get(&id.name)
-                                        .and_then(|(s, _)| if let crate::resolve::Symbol::Bus(info) = s {
+                                    self.symbols.globals.get(&id.name).and_then(|(s, _)| {
+                                        if let crate::resolve::Symbol::Bus(info) = s {
                                             Some((info, id.name.clone(), Some((n, None))))
-                                        } else { None })
-                                } else { None }
+                                        } else {
+                                            None
+                                        }
+                                    })
+                                } else {
+                                    None
+                                }
                             }
                             // 2D bus wire: `wire edges: Vec<Vec<B, N>, M>;` →
                             // emit M*N*per_signal flat wires named
@@ -740,12 +826,23 @@ impl<'a> Codegen<'a> {
                                         self.eval_const_u32(size_expr, &m_clone.params),
                                         self.eval_const_u32(inner_size, &m_clone.params),
                                     ) {
-                                        self.symbols.globals.get(&id.name)
-                                            .and_then(|(s, _)| if let crate::resolve::Symbol::Bus(info) = s {
-                                                Some((info, id.name.clone(), Some((m_n, Some(n_n)))))
-                                            } else { None })
-                                    } else { None }
-                                } else { None }
+                                        self.symbols.globals.get(&id.name).and_then(|(s, _)| {
+                                            if let crate::resolve::Symbol::Bus(info) = s {
+                                                Some((
+                                                    info,
+                                                    id.name.clone(),
+                                                    Some((m_n, Some(n_n))),
+                                                ))
+                                            } else {
+                                                None
+                                            }
+                                        })
+                                    } else {
+                                        None
+                                    }
+                                } else {
+                                    None
+                                }
                             }
                             _ => None,
                         },
@@ -758,7 +855,9 @@ impl<'a> Codegen<'a> {
                         // per-cell even though the emitted SV is packed-array.
                         let cell_names: Vec<String> = match count {
                             None => vec![w.name.name.clone()],
-                            Some((m_n, None)) => (0..m_n).map(|i| format!("{}_{}", w.name.name, i)).collect(),
+                            Some((m_n, None)) => {
+                                (0..m_n).map(|i| format!("{}_{}", w.name.name, i)).collect()
+                            }
                             Some((m_n, Some(n_n))) => {
                                 let mut v = Vec::with_capacity((m_n * n_n) as usize);
                                 for i in 0..m_n {
@@ -774,11 +873,11 @@ impl<'a> Codegen<'a> {
                         }
                         // Start with the bus's declared defaults then layer
                         // any per-wire overrides from `wire w: Vec<B<PARAM=val>, N>;`.
-                        let mut param_map: std::collections::HashMap<String, &Expr> =
-                            info.params.iter()
-                                .filter_map(|pd| pd.default.as_ref()
-                                    .map(|d| (pd.name.name.clone(), d)))
-                                .collect();
+                        let mut param_map: std::collections::HashMap<String, &Expr> = info
+                            .params
+                            .iter()
+                            .filter_map(|pd| pd.default.as_ref().map(|d| (pd.name.name.clone(), d)))
+                            .collect();
                         for pa in &w.bus_params {
                             param_map.insert(pa.name.name.clone(), &pa.value);
                         }
@@ -797,8 +896,7 @@ impl<'a> Codegen<'a> {
                         };
                         for (sname, _sdir, sty) in info.effective_signals(&param_map) {
                             let subst_ty = Self::subst_type_expr(&sty, &param_map);
-                            let (ty_str, arr_suffix) =
-                                self.emit_type_and_array_suffix(&subst_ty);
+                            let (ty_str, arr_suffix) = self.emit_type_and_array_suffix(&subst_ty);
                             // Insert the outer packed dim between `logic` and
                             // any inner packed dim (same pattern as port emit).
                             let with_outer = if outer_dim.is_empty() {
@@ -831,7 +929,8 @@ impl<'a> Codegen<'a> {
                         // Lets this wire mate with an `unpacked Vec<T,N>` port across
                         // an `inst` connection without Verilator rejecting the
                         // packed/unpacked shape mismatch.
-                        let (base_ty, suffix) = self.emit_type_and_unpacked_suffix_dir(&w.ty, w.unpacked_ascending);
+                        let (base_ty, suffix) =
+                            self.emit_type_and_unpacked_suffix_dir(&w.ty, w.unpacked_ascending);
                         self.line(&format!("{} {}{};", base_ty, w.name.name, suffix));
                     } else {
                         let (ty_str, arr_suffix) = self.emit_type_and_array_suffix(&w.ty);
@@ -842,7 +941,9 @@ impl<'a> Codegen<'a> {
                 ModuleBodyItem::Generate(ref gen) => {
                     self.emit_generate(gen);
                 }
-                ModuleBodyItem::Thread(_) | ModuleBodyItem::Resource(_) | ModuleBodyItem::TlmConnect(_) => {
+                ModuleBodyItem::Thread(_)
+                | ModuleBodyItem::Resource(_)
+                | ModuleBodyItem::TlmConnect(_) => {
                     // Threads and resources are lowered before codegen
                     unreachable!("thread/resource should have been lowered before codegen");
                 }
@@ -862,17 +963,31 @@ impl<'a> Codegen<'a> {
 
         // Emit module-level assert/cover declarations (grouped with translate_off/on)
         {
-            let module_asserts: Vec<&AssertDecl> = body_items.iter()
-                .filter_map(|i| if let ModuleBodyItem::Assert(a) = i { Some(a) } else { None })
+            let module_asserts: Vec<&AssertDecl> = body_items
+                .iter()
+                .filter_map(|i| {
+                    if let ModuleBodyItem::Assert(a) = i {
+                        Some(a)
+                    } else {
+                        None
+                    }
+                })
                 .collect();
             if !module_asserts.is_empty() {
-                let clk_name = m_clone.ports.iter()
+                let clk_name = m_clone
+                    .ports
+                    .iter()
                     .find(|p| matches!(&p.ty, TypeExpr::Clock(_)))
                     .map(|p| p.name.name.clone())
                     .unwrap_or_else(|| "clk".to_string());
                 let owned: Vec<AssertDecl> = module_asserts.into_iter().cloned().collect();
                 let rst_active = Codegen::rst_active_from_ports(&m_clone.ports);
-                self.emit_asserts_for_construct(&owned, &m_clone.name.name, &clk_name, rst_active.as_deref());
+                self.emit_asserts_for_construct(
+                    &owned,
+                    &m_clone.name.name,
+                    &clk_name,
+                    rst_active.as_deref(),
+                );
             }
         }
 
@@ -951,12 +1066,18 @@ impl<'a> Codegen<'a> {
     fn collect_log_files(body: &[ModuleBodyItem]) -> Vec<String> {
         let mut files = Vec::new();
         let mut seen = std::collections::HashSet::new();
-        fn collect_from_comb(stmts: &[Stmt], files: &mut Vec<String>, seen: &mut std::collections::HashSet<String>) {
+        fn collect_from_comb(
+            stmts: &[Stmt],
+            files: &mut Vec<String>,
+            seen: &mut std::collections::HashSet<String>,
+        ) {
             for stmt in stmts {
                 match stmt {
                     Stmt::Log(l) => {
                         if let Some(ref path) = l.file {
-                            if seen.insert(path.clone()) { files.push(path.clone()); }
+                            if seen.insert(path.clone()) {
+                                files.push(path.clone());
+                            }
                         }
                     }
                     Stmt::IfElse(ie) => {
@@ -964,7 +1085,9 @@ impl<'a> Codegen<'a> {
                         collect_from_comb(&ie.else_stmts, files, seen);
                     }
                     Stmt::Match(m) => {
-                        for arm in &m.arms { collect_from_comb(&arm.body, files, seen); }
+                        for arm in &m.arms {
+                            collect_from_comb(&arm.body, files, seen);
+                        }
                     }
                     Stmt::For(f) => {
                         collect_from_comb(&f.body, files, seen);
@@ -973,12 +1096,18 @@ impl<'a> Codegen<'a> {
                 }
             }
         }
-        fn collect_from_seq(stmts: &[Stmt], files: &mut Vec<String>, seen: &mut std::collections::HashSet<String>) {
+        fn collect_from_seq(
+            stmts: &[Stmt],
+            files: &mut Vec<String>,
+            seen: &mut std::collections::HashSet<String>,
+        ) {
             for stmt in stmts {
                 match stmt {
                     Stmt::Log(l) => {
                         if let Some(ref path) = l.file {
-                            if seen.insert(path.clone()) { files.push(path.clone()); }
+                            if seen.insert(path.clone()) {
+                                files.push(path.clone());
+                            }
                         }
                     }
                     Stmt::IfElse(ie) => {
@@ -986,7 +1115,9 @@ impl<'a> Codegen<'a> {
                         collect_from_seq(&ie.else_stmts, files, seen);
                     }
                     Stmt::Match(m) => {
-                        for arm in &m.arms { collect_from_seq(&arm.body, files, seen); }
+                        for arm in &m.arms {
+                            collect_from_seq(&arm.body, files, seen);
+                        }
                     }
                     _ => {}
                 }
@@ -994,7 +1125,9 @@ impl<'a> Codegen<'a> {
         }
         for item in body {
             match item {
-                ModuleBodyItem::CombBlock(cb) => collect_from_comb(&cb.stmts, &mut files, &mut seen),
+                ModuleBodyItem::CombBlock(cb) => {
+                    collect_from_comb(&cb.stmts, &mut files, &mut seen)
+                }
                 ModuleBodyItem::RegBlock(rb) => collect_from_seq(&rb.stmts, &mut files, &mut seen),
                 _ => {}
             }
@@ -1053,12 +1186,16 @@ impl<'a> Codegen<'a> {
         }
 
         // Find clock and reset from module ports
-        let clk_name = m.ports.iter()
+        let clk_name = m
+            .ports
+            .iter()
             .find(|port| matches!(&port.ty, TypeExpr::Clock(_)))
             .map(|port| port.name.name.clone())
             .unwrap_or_else(|| "clk".to_string());
 
-        let rst_name = m.ports.iter()
+        let rst_name = m
+            .ports
+            .iter()
             .find(|port| matches!(&port.ty, TypeExpr::Reset(..)))
             .map(|port| port.name.name.clone());
 
@@ -1130,8 +1267,10 @@ impl<'a> Codegen<'a> {
     fn stmt_has_log(s: &Stmt) -> bool {
         match s {
             Stmt::Log(_) => true,
-            Stmt::IfElse(ie) => ie.then_stmts.iter().any(Self::stmt_has_log)
-                || ie.else_stmts.iter().any(Self::stmt_has_log),
+            Stmt::IfElse(ie) => {
+                ie.then_stmts.iter().any(Self::stmt_has_log)
+                    || ie.else_stmts.iter().any(Self::stmt_has_log)
+            }
             Stmt::Match(m) => m.arms.iter().any(|a| a.body.iter().any(Self::stmt_has_log)),
             Stmt::Assign(_) => false,
             Stmt::For(f) => f.body.iter().any(Self::stmt_has_log),
@@ -1153,8 +1292,16 @@ impl<'a> Codegen<'a> {
         Self::collect_assigned_roots(&rb.stmts, &mut assigned);
 
         // Look up reset info for each assigned register from its RegDecl
-        let reg_decls: Vec<&RegDecl> = m.body.iter()
-            .filter_map(|i| if let ModuleBodyItem::RegDecl(r) = i { Some(r) } else { None })
+        let reg_decls: Vec<&RegDecl> = m
+            .body
+            .iter()
+            .filter_map(|i| {
+                if let ModuleBodyItem::RegDecl(r) = i {
+                    Some(r)
+                } else {
+                    None
+                }
+            })
             .collect();
 
         // Resolve reset info: (rst_name, is_async, is_low) for registers that have reset
@@ -1166,14 +1313,20 @@ impl<'a> Codegen<'a> {
         let mut reset_info: Option<ResolvedReset> = Option::None;
         let mut resets: Vec<(String, String)> = Vec::new(); // (reg_name, init_str)
         for name in &assigned {
-            if name.is_empty() { continue; }
+            if name.is_empty() {
+                continue;
+            }
             // Look up reset info from RegDecl or port reg
-            let reset_ref: Option<&RegReset> = reg_decls.iter()
+            let reset_ref: Option<&RegReset> = reg_decls
+                .iter()
                 .find(|r| r.name.name == *name)
                 .map(|r| &r.reset)
-                .or_else(|| m.ports.iter()
-                    .find(|p| p.name.name == *name && p.reg_info.is_some())
-                    .and_then(|p| p.reg_info.as_ref().map(|ri| &ri.reset)));
+                .or_else(|| {
+                    m.ports
+                        .iter()
+                        .find(|p| p.name.name == *name && p.reg_info.is_some())
+                        .and_then(|p| p.reg_info.as_ref().map(|ri| &ri.reset))
+                });
             if let Some(reg_reset) = reset_ref {
                 let resolved = self.resolve_reg_reset(reg_reset, m);
                 if let Some((rst_sig, is_async, is_low)) = resolved {
@@ -1219,12 +1372,16 @@ impl<'a> Codegen<'a> {
                 let touches_reset = stmt_roots.iter().any(|n| reset_reg_names.contains(n));
                 let touches_nonreset = stmt_roots.iter().any(|n| !reset_reg_names.contains(n));
                 if touches_reset {
-                    if let Some(filtered) = Self::filter_stmt_by_assigned_set(stmt, &reset_reg_names, true) {
+                    if let Some(filtered) =
+                        Self::filter_stmt_by_assigned_set(stmt, &reset_reg_names, true)
+                    {
                         guarded_stmts.push(filtered);
                     }
                 }
                 if touches_nonreset {
-                    if let Some(filtered) = Self::filter_stmt_by_assigned_set(stmt, &reset_reg_names, false) {
+                    if let Some(filtered) =
+                        Self::filter_stmt_by_assigned_set(stmt, &reset_reg_names, false)
+                    {
                         unguarded_stmts.push(filtered);
                     }
                 }
@@ -1251,21 +1408,27 @@ impl<'a> Codegen<'a> {
             self.indent += 1;
             for (name, init) in &resets {
                 // Look up Vec depth from reg decls OR port-reg declarations
-                let reg_ty = reg_decls.iter()
+                let reg_ty = reg_decls
+                    .iter()
                     .find(|r| r.name.name == *name)
                     .map(|r| &r.ty)
-                    .or_else(|| m.ports.iter()
-                        .find(|p| p.name.name == *name && p.reg_info.is_some())
-                        .map(|p| &p.ty));
-                let vec_depth = reg_ty.map(|ty| {
-                    let mut depth = 0u32;
-                    let mut t = ty;
-                    while let TypeExpr::Vec(inner, _) = t {
-                        depth += 1;
-                        t = inner;
-                    }
-                    depth
-                }).unwrap_or(0);
+                    .or_else(|| {
+                        m.ports
+                            .iter()
+                            .find(|p| p.name.name == *name && p.reg_info.is_some())
+                            .map(|p| &p.ty)
+                    });
+                let vec_depth = reg_ty
+                    .map(|ty| {
+                        let mut depth = 0u32;
+                        let mut t = ty;
+                        while let TypeExpr::Vec(inner, _) = t {
+                            depth += 1;
+                            t = inner;
+                        }
+                        depth
+                    })
+                    .unwrap_or(0);
                 if vec_depth > 0 {
                     // Emit for-loop reset for unpacked arrays (icarus-compatible)
                     if let Some(ty) = reg_ty {
@@ -1277,10 +1440,13 @@ impl<'a> Codegen<'a> {
                             t = inner;
                         }
                         // Generate nested for-loops
-                        let idx_vars: Vec<String> = (0..dims.len()).map(|d| format!("__ri{d}")).collect();
+                        let idx_vars: Vec<String> =
+                            (0..dims.len()).map(|d| format!("__ri{d}")).collect();
                         for (d, dim_size) in dims.iter().enumerate() {
-                            self.line(&format!("for (int {} = 0; {} < {}; {}++) begin",
-                                idx_vars[d], idx_vars[d], dim_size, idx_vars[d]));
+                            self.line(&format!(
+                                "for (int {} = 0; {} < {}; {}++) begin",
+                                idx_vars[d], idx_vars[d], dim_size, idx_vars[d]
+                            ));
                             self.indent += 1;
                         }
                         let idx_str: String = idx_vars.iter().map(|v| format!("[{v}]")).collect();
@@ -1300,11 +1466,19 @@ impl<'a> Codegen<'a> {
             for stmt in &guarded_stmts {
                 if let Stmt::Init(ib) = stmt {
                     let port = m.ports.iter().find(|p| p.name.name == ib.reset_signal.name);
-                    let is_low = port.map_or(false, |p| matches!(&p.ty, TypeExpr::Reset(_, ResetLevel::Low)));
-                    let cond = if is_low { format!("(!{})", ib.reset_signal.name) } else { ib.reset_signal.name.clone() };
+                    let is_low = port.map_or(false, |p| {
+                        matches!(&p.ty, TypeExpr::Reset(_, ResetLevel::Low))
+                    });
+                    let cond = if is_low {
+                        format!("(!{})", ib.reset_signal.name)
+                    } else {
+                        ib.reset_signal.name.clone()
+                    };
                     self.line(&format!("if ({cond}) begin"));
                     self.indent += 1;
-                    for s in &ib.body { self.emit_reg_stmt(s); }
+                    for s in &ib.body {
+                        self.emit_reg_stmt(s);
+                    }
                     self.indent -= 1;
                     self.line("end");
                 } else {
@@ -1327,11 +1501,19 @@ impl<'a> Codegen<'a> {
                 for stmt in &unguarded_stmts {
                     if let Stmt::Init(ib) = stmt {
                         let port = m.ports.iter().find(|p| p.name.name == ib.reset_signal.name);
-                        let is_low = port.map_or(false, |p| matches!(&p.ty, TypeExpr::Reset(_, ResetLevel::Low)));
-                        let cond = if is_low { format!("(!{})", ib.reset_signal.name) } else { ib.reset_signal.name.clone() };
+                        let is_low = port.map_or(false, |p| {
+                            matches!(&p.ty, TypeExpr::Reset(_, ResetLevel::Low))
+                        });
+                        let cond = if is_low {
+                            format!("(!{})", ib.reset_signal.name)
+                        } else {
+                            ib.reset_signal.name.clone()
+                        };
                         self.line(&format!("if ({cond}) begin"));
                         self.indent += 1;
-                        for s in &ib.body { self.emit_reg_stmt(s); }
+                        for s in &ib.body {
+                            self.emit_reg_stmt(s);
+                        }
                         self.indent -= 1;
                         self.line("end");
                     } else {
@@ -1346,14 +1528,24 @@ impl<'a> Codegen<'a> {
             // No registers with declared reset.
             // Check for explicit `init on rst.asserted` blocks — these drive async sensitivity.
             let init_block = rb.stmts.iter().find_map(|s| {
-                if let Stmt::Init(ib) = s { Some(ib) } else { None }
+                if let Stmt::Init(ib) = s {
+                    Some(ib)
+                } else {
+                    None
+                }
             });
             let async_asserted = if let Some(ib) = init_block {
                 // Determine async/sync and polarity from the referenced reset port
-                m.ports.iter().find(|p| p.name.name == ib.reset_signal.name)
-                    .and_then(|p| if let TypeExpr::Reset(ResetKind::Async, level) = &p.ty {
-                        Some((ib.reset_signal.name.clone(), *level == ResetLevel::Low))
-                    } else { None })
+                m.ports
+                    .iter()
+                    .find(|p| p.name.name == ib.reset_signal.name)
+                    .and_then(|p| {
+                        if let TypeExpr::Reset(ResetKind::Async, level) = &p.ty {
+                            Some((ib.reset_signal.name.clone(), *level == ResetLevel::Low))
+                        } else {
+                            None
+                        }
+                    })
             } else {
                 // Still check for `rst.asserted` expressions in the body — if any reference an
                 // async reset port, we must add the async edge to the sensitivity list.
@@ -1361,7 +1553,10 @@ impl<'a> Codegen<'a> {
             };
             let sens = if let Some((ref rst_sig, is_low)) = async_asserted {
                 let rst_edge = if is_low { "negedge" } else { "posedge" };
-                format!("always_ff @({clk_edge} {} or {rst_edge} {rst_sig}) begin", rb.clock.name)
+                format!(
+                    "always_ff @({clk_edge} {} or {rst_edge} {rst_sig}) begin",
+                    rb.clock.name
+                )
             } else {
                 format!("always_ff @({clk_edge} {}) begin", rb.clock.name)
             };
@@ -1371,7 +1566,9 @@ impl<'a> Codegen<'a> {
                 if let Stmt::Init(ib) = stmt {
                     // Emit as an explicit `if (rst_cond) begin ... end` block
                     let port = m.ports.iter().find(|p| p.name.name == ib.reset_signal.name);
-                    let is_low = port.map_or(false, |p| matches!(&p.ty, TypeExpr::Reset(_, ResetLevel::Low)));
+                    let is_low = port.map_or(false, |p| {
+                        matches!(&p.ty, TypeExpr::Reset(_, ResetLevel::Low))
+                    });
                     let cond = if is_low {
                         format!("(!{})", ib.reset_signal.name)
                     } else {
@@ -1412,10 +1609,18 @@ impl<'a> Codegen<'a> {
             // Recurse into sub-expressions
             match &expr.kind {
                 ExprKind::Binary(_, l, r) => scan_expr(l, ports).or_else(|| scan_expr(r, ports)),
-                ExprKind::Unary(_, inner) | ExprKind::FieldAccess(inner, _) => scan_expr(inner, ports),
-                ExprKind::Ternary(c, t, e) => scan_expr(c, ports).or_else(|| scan_expr(t, ports)).or_else(|| scan_expr(e, ports)),
-                ExprKind::MethodCall(base, _, args) => scan_expr(base, ports).or_else(|| args.iter().find_map(|a| scan_expr(a, ports))),
-                ExprKind::Index(base, idx) => scan_expr(base, ports).or_else(|| scan_expr(idx, ports)),
+                ExprKind::Unary(_, inner) | ExprKind::FieldAccess(inner, _) => {
+                    scan_expr(inner, ports)
+                }
+                ExprKind::Ternary(c, t, e) => scan_expr(c, ports)
+                    .or_else(|| scan_expr(t, ports))
+                    .or_else(|| scan_expr(e, ports)),
+                ExprKind::MethodCall(base, _, args) => {
+                    scan_expr(base, ports).or_else(|| args.iter().find_map(|a| scan_expr(a, ports)))
+                }
+                ExprKind::Index(base, idx) => {
+                    scan_expr(base, ports).or_else(|| scan_expr(idx, ports))
+                }
                 ExprKind::Cast(inner, _) => scan_expr(inner, ports),
                 _ => None,
             }
@@ -1427,7 +1632,10 @@ impl<'a> Codegen<'a> {
                     .or_else(|| ie.then_stmts.iter().find_map(|s| scan_stmt(s, ports)))
                     .or_else(|| ie.else_stmts.iter().find_map(|s| scan_stmt(s, ports))),
                 Stmt::For(f) => f.body.iter().find_map(|s| scan_stmt(s, ports)),
-                Stmt::Match(m) => m.arms.iter().find_map(|arm| arm.body.iter().find_map(|s| scan_stmt(s, ports))),
+                Stmt::Match(m) => m
+                    .arms
+                    .iter()
+                    .find_map(|arm| arm.body.iter().find_map(|s| scan_stmt(s, ports))),
                 _ => None,
             }
         }
@@ -1487,7 +1695,9 @@ impl<'a> Codegen<'a> {
 
         let mut orphans: Vec<Orphan> = Vec::new();
         for item in &m.body {
-            let ModuleBodyItem::RegDecl(r) = item else { continue };
+            let ModuleBodyItem::RegDecl(r) = item else {
+                continue;
+            };
             if matches!(r.reset, RegReset::None) {
                 continue;
             }
@@ -1519,9 +1729,15 @@ impl<'a> Codegen<'a> {
         // the orphans land in the same clock domain as the other
         // flops. Fall back to the first Clock-typed input port.
         let rb_clock: Option<&Ident> = m.body.iter().find_map(|i| {
-            if let ModuleBodyItem::RegBlock(rb) = i { Some(&rb.clock) } else { None }
+            if let ModuleBodyItem::RegBlock(rb) = i {
+                Some(&rb.clock)
+            } else {
+                None
+            }
         });
-        let port_clock = m.ports.iter()
+        let port_clock = m
+            .ports
+            .iter()
             .find(|p| matches!(&p.ty, TypeExpr::Clock(_)))
             .map(|p| &p.name);
         let Some(clock_ident) = rb_clock.or(port_clock) else {
@@ -1537,7 +1753,8 @@ impl<'a> Codegen<'a> {
         let mut groups: std::collections::BTreeMap<(String, bool, bool), Vec<&Orphan>> =
             std::collections::BTreeMap::new();
         for o in &orphans {
-            groups.entry((o.reset_signal.clone(), o.is_async, o.is_low))
+            groups
+                .entry((o.reset_signal.clone(), o.is_async, o.is_low))
                 .or_default()
                 .push(o);
         }
@@ -1602,5 +1819,4 @@ impl<'a> Codegen<'a> {
             self.line("end");
         }
     }
-
 }

--- a/src/codegen/pipeline.rs
+++ b/src/codegen/pipeline.rs
@@ -37,8 +37,12 @@ impl<'a> Codegen<'a> {
             .iter()
             .map(|c| {
                 let sig = self.emit_pipeline_stage_expr_str(
-                    &c.signal, current_prefix, current_stage_idx,
-                    stage_names, stage_regs, port_names,
+                    &c.signal,
+                    current_prefix,
+                    current_stage_idx,
+                    stage_names,
+                    stage_regs,
+                    port_names,
                 );
                 format!(".{}({})", c.port_name.name, sig)
             })
@@ -94,9 +98,8 @@ impl<'a> Codegen<'a> {
         self.indent += 1;
 
         // Collect port names for name resolution
-        let port_names: std::collections::HashSet<String> = p.ports.iter()
-            .map(|pt| pt.name.name.clone())
-            .collect();
+        let port_names: std::collections::HashSet<String> =
+            p.ports.iter().map(|pt| pt.name.name.clone()).collect();
 
         // Collect stage names (in order) and signal names per stage
         let stage_names: Vec<&str> = p.stages.iter().map(|s| s.name.name.as_str()).collect();
@@ -158,8 +161,13 @@ impl<'a> Codegen<'a> {
                             continue;
                         }
                         let ty = Self::resolve_comb_wire_type(
-                            &target, &cb.stmts, si, &stage_regs, &stage_names,
-                        ).unwrap_or_else(|| "logic".to_string());
+                            &target,
+                            &cb.stmts,
+                            si,
+                            &stage_regs,
+                            &stage_names,
+                        )
+                        .unwrap_or_else(|| "logic".to_string());
                         if !wires.iter().any(|(n, _)| n == &target) {
                             wires.push((target, ty));
                         }
@@ -181,28 +189,37 @@ impl<'a> Codegen<'a> {
             // resolvable or has unresolved param references.
             for item in &stage.body {
                 if let ModuleBodyItem::Inst(inst) = item {
-                    let inst_ports: Vec<crate::ast::PortDecl> = match self.symbols.globals.get(&inst.module_name.name) {
-                        Some((crate::resolve::Symbol::Module(info), _))   => info.ports.clone(),
-                        Some((crate::resolve::Symbol::Pipeline(info), _)) => info.ports.clone(),
-                        Some((crate::resolve::Symbol::Fsm(info), _))      => info.ports.clone(),
-                        _ => Vec::new(),
-                    };
+                    let inst_ports: Vec<crate::ast::PortDecl> =
+                        match self.symbols.globals.get(&inst.module_name.name) {
+                            Some((crate::resolve::Symbol::Module(info), _)) => info.ports.clone(),
+                            Some((crate::resolve::Symbol::Pipeline(info), _)) => info.ports.clone(),
+                            Some((crate::resolve::Symbol::Fsm(info), _)) => info.ports.clone(),
+                            _ => Vec::new(),
+                        };
                     // Build param substitution map: source-module param name →
                     // RHS expression in parent scope. Inst-supplied first;
                     // anything missing falls back to the source's default.
                     let inst_params: std::collections::HashMap<String, Expr> = {
-                        let mut m: std::collections::HashMap<String, Expr> = inst.param_assigns.iter()
+                        let mut m: std::collections::HashMap<String, Expr> = inst
+                            .param_assigns
+                            .iter()
                             .map(|pa| (pa.name.name.clone(), pa.value.clone()))
                             .collect();
                         for src_item in &self.source.items {
                             let pname = match src_item {
-                                Item::Module(d)   if d.name.name == inst.module_name.name => &d.params,
-                                Item::Pipeline(d) if d.name.name == inst.module_name.name => &d.params,
-                                Item::Fsm(d)      if d.name.name == inst.module_name.name => &d.params,
+                                Item::Module(d) if d.name.name == inst.module_name.name => {
+                                    &d.params
+                                }
+                                Item::Pipeline(d) if d.name.name == inst.module_name.name => {
+                                    &d.params
+                                }
+                                Item::Fsm(d) if d.name.name == inst.module_name.name => &d.params,
                                 _ => continue,
                             };
                             for p in pname {
-                                if m.contains_key(&p.name.name) { continue; }
+                                if m.contains_key(&p.name.name) {
+                                    continue;
+                                }
                                 if let Some(def) = &p.default {
                                     m.insert(p.name.name.clone(), def.clone());
                                 }
@@ -222,16 +239,21 @@ impl<'a> Codegen<'a> {
                             if stage_regs[si].iter().any(|(rn, _, _)| rn == target) {
                                 continue;
                             }
-                            let port_ty = inst_ports.iter()
+                            let port_ty = inst_ports
+                                .iter()
                                 .find(|p| p.name.name == conn.port_name.name)
                                 .map(|p| {
-                                    let substituted = Self::substitute_params_in_type(&p.ty, &inst_params);
+                                    let substituted =
+                                        Self::substitute_params_in_type(&p.ty, &inst_params);
                                     self.emit_logic_type_str(&substituted)
                                 });
                             let ty = port_ty.unwrap_or_else(|| {
                                 Self::resolve_inst_wire_type_from_consumers(
-                                    target, &stage.body, &stage_regs[si],
-                                ).unwrap_or_else(|| "logic".to_string())
+                                    target,
+                                    &stage.body,
+                                    &stage_regs[si],
+                                )
+                                .unwrap_or_else(|| "logic".to_string())
                             });
                             stage_regs[si].push((target.clone(), ty, String::new()));
                         }
@@ -247,7 +269,10 @@ impl<'a> Codegen<'a> {
             for (sig_name, ty_str, init_str) in &stage_regs[si] {
                 if !init_str.is_empty() {
                     // Real register with initial value
-                    self.line(&format!("{} {}_{} = {};", ty_str, prefix, sig_name, init_str));
+                    self.line(&format!(
+                        "{} {}_{} = {};",
+                        ty_str, prefix, sig_name, init_str
+                    ));
                 } else {
                     // Comb wire (forwarding mux, etc.)
                     self.line(&format!("{} {}_{};", ty_str, prefix, sig_name));
@@ -257,14 +282,17 @@ impl<'a> Codegen<'a> {
         self.line("");
 
         // ── Detect wait-stages (variable-latency with wait until / do..until) ─
-        let wait_stage_flags: Vec<bool> = p.stages.iter().map(|s| Self::stage_has_wait(s)).collect();
+        let wait_stage_flags: Vec<bool> =
+            p.stages.iter().map(|s| Self::stage_has_wait(s)).collect();
         let has_any_wait_stage = wait_stage_flags.iter().any(|f| *f);
 
         // Declare FSM state registers for wait-stages
         if has_any_wait_stage {
             self.line("// ── Wait-stage FSM registers ──");
             for (si, stage) in p.stages.iter().enumerate() {
-                if !wait_stage_flags[si] { continue; }
+                if !wait_stage_flags[si] {
+                    continue;
+                }
                 let prefix = stage.name.name.to_lowercase();
                 let n_states = Self::count_wait_fsm_states(stage);
                 let bits = crate::width::index_width(n_states as u64) as usize;
@@ -285,11 +313,23 @@ impl<'a> Codegen<'a> {
 
             // Global stall (top-level `stall when`)
             if has_global_stall {
-                let stall_parts: Vec<String> = p.stall_conds.iter()
-                    .map(|s| self.emit_pipeline_expr_str(&s.condition, &stage_names, &stage_regs, &port_names))
+                let stall_parts: Vec<String> = p
+                    .stall_conds
+                    .iter()
+                    .map(|s| {
+                        self.emit_pipeline_expr_str(
+                            &s.condition,
+                            &stage_names,
+                            &stage_regs,
+                            &port_names,
+                        )
+                    })
                     .collect();
                 self.line("logic pipeline_stall;");
-                self.line(&format!("assign pipeline_stall = {};", stall_parts.join(" | ")));
+                self.line(&format!(
+                    "assign pipeline_stall = {};",
+                    stall_parts.join(" | ")
+                ));
             }
 
             // Per-stage stall wires: stall_N = local_stall_N || stall_{N+1}
@@ -308,7 +348,12 @@ impl<'a> Codegen<'a> {
 
                 // Local stall condition from `stage X stall when <expr>`
                 if let Some(ref cond) = p.stages[si].stall_cond {
-                    parts.push(self.emit_pipeline_expr_str(cond, &stage_names, &stage_regs, &port_names));
+                    parts.push(self.emit_pipeline_expr_str(
+                        cond,
+                        &stage_names,
+                        &stage_regs,
+                        &port_names,
+                    ));
                 }
 
                 // Wait-stage FSM busy signal
@@ -340,27 +385,39 @@ impl<'a> Codegen<'a> {
         // ── Wait-stage FSM busy assignments ─────────────────────────────────
         if has_any_wait_stage {
             for (si, stage) in p.stages.iter().enumerate() {
-                if !wait_stage_flags[si] { continue; }
+                if !wait_stage_flags[si] {
+                    continue;
+                }
                 let prefix = stage.name.name.to_lowercase();
                 // FSM is busy when not in idle state (state 0)
-                self.line(&format!("assign {prefix}_fsm_busy = ({prefix}_fsm_state != '0);"));
+                self.line(&format!(
+                    "assign {prefix}_fsm_busy = ({prefix}_fsm_state != '0);"
+                ));
             }
             self.line("");
         }
 
         // ── Forward mux wires ────────────────────────────────────────────────
         for fwd in &p.forward_directives {
-            let dest_str = self.emit_pipeline_expr_str(&fwd.dest, &stage_names, &stage_regs, &port_names);
-            let src_str = self.emit_pipeline_expr_str(&fwd.source, &stage_names, &stage_regs, &port_names);
-            let cond_str = self.emit_pipeline_expr_str(&fwd.condition, &stage_names, &stage_regs, &port_names);
-            self.line(&format!("// Forward: {} from {} when {}", dest_str, src_str, cond_str));
+            let dest_str =
+                self.emit_pipeline_expr_str(&fwd.dest, &stage_names, &stage_regs, &port_names);
+            let src_str =
+                self.emit_pipeline_expr_str(&fwd.source, &stage_names, &stage_regs, &port_names);
+            let cond_str =
+                self.emit_pipeline_expr_str(&fwd.condition, &stage_names, &stage_regs, &port_names);
+            self.line(&format!(
+                "// Forward: {} from {} when {}",
+                dest_str, src_str, cond_str
+            ));
         }
         if !p.forward_directives.is_empty() {
             self.line("");
         }
 
         // ── Identify clock and reset ─────────────────────────────────────────
-        let clk_name = p.ports.iter()
+        let clk_name = p
+            .ports
+            .iter()
             .find(|pt| matches!(&pt.ty, TypeExpr::Clock(_)))
             .map(|pt| pt.name.name.as_str())
             .unwrap_or("clk");
@@ -399,7 +456,12 @@ impl<'a> Codegen<'a> {
             if wait_stage_flags[si] {
                 // ── Wait-stage: generate FSM transition logic ────────────
                 self.emit_pipeline_wait_stage_ff(
-                    stage, &prefix, si, &stage_names, &stage_regs, &port_names,
+                    stage,
+                    &prefix,
+                    si,
+                    &stage_names,
+                    &stage_regs,
+                    &port_names,
                 );
             } else if has_any_stall {
                 // When this stage is not stalled, it accepts new data
@@ -413,14 +475,23 @@ impl<'a> Codegen<'a> {
                     self.line(&format!("{prefix}_valid_r <= 1'b1;"));
                 } else {
                     let prev_prefix = p.stages[si - 1].name.name.to_lowercase();
-                    self.line(&format!("{prefix}_valid_r <= {prev_prefix}_stall ? 1'b0 : {prev_prefix}_valid_r;"));
+                    self.line(&format!(
+                        "{prefix}_valid_r <= {prev_prefix}_stall ? 1'b0 : {prev_prefix}_valid_r;"
+                    ));
                 }
 
                 // Register assignments from seq blocks
                 for item in &stage.body {
                     if let ModuleBodyItem::RegBlock(rb) = item {
                         for stmt in &rb.stmts {
-                            self.emit_pipeline_reg_stmt(stmt, &prefix, si, &stage_names, &stage_regs, &port_names);
+                            self.emit_pipeline_reg_stmt(
+                                stmt,
+                                &prefix,
+                                si,
+                                &stage_names,
+                                &stage_regs,
+                                &port_names,
+                            );
                         }
                     }
                 }
@@ -439,7 +510,14 @@ impl<'a> Codegen<'a> {
                 for item in &stage.body {
                     if let ModuleBodyItem::RegBlock(rb) = item {
                         for stmt in &rb.stmts {
-                            self.emit_pipeline_reg_stmt(stmt, &prefix, si, &stage_names, &stage_regs, &port_names);
+                            self.emit_pipeline_reg_stmt(
+                                stmt,
+                                &prefix,
+                                si,
+                                &stage_names,
+                                &stage_regs,
+                                &port_names,
+                            );
                         }
                     }
                 }
@@ -449,12 +527,19 @@ impl<'a> Codegen<'a> {
         // Flush overrides
         for flush in &p.flush_directives {
             let target_prefix = flush.target_stage.name.to_lowercase();
-            let cond_str = self.emit_pipeline_expr_str(&flush.condition, &stage_names, &stage_regs, &port_names);
+            let cond_str = self.emit_pipeline_expr_str(
+                &flush.condition,
+                &stage_names,
+                &stage_regs,
+                &port_names,
+            );
             self.line(&format!("if ({}) begin", cond_str));
             self.indent += 1;
             self.line(&format!("{}_valid_r <= 1'b0;", target_prefix));
             // Reset FSM state on flush for wait-stages
-            let flush_si = stage_names.iter().position(|n| n.to_lowercase() == target_prefix);
+            let flush_si = stage_names
+                .iter()
+                .position(|n| n.to_lowercase() == target_prefix);
             if let Some(si) = flush_si {
                 if wait_stage_flags[si] {
                     self.line(&format!("{target_prefix}_fsm_state <= '0;"));
@@ -464,7 +549,9 @@ impl<'a> Codegen<'a> {
                 // (init_str empty) are skipped — they're not registers.
                 if flush.clear {
                     for (sig_name, _ty, init_str) in &stage_regs[si] {
-                        if init_str.is_empty() { continue; }
+                        if init_str.is_empty() {
+                            continue;
+                        }
                         self.line(&format!("{target_prefix}_{sig_name} <= {init_str};"));
                     }
                 }
@@ -490,7 +577,14 @@ impl<'a> Codegen<'a> {
                     if all_simple {
                         for stmt in &cb.stmts {
                             if let Stmt::Assign(a) = stmt {
-                                let val = self.emit_pipeline_stage_expr_str(&a.value, &prefix, si, &stage_names, &stage_regs, &port_names);
+                                let val = self.emit_pipeline_stage_expr_str(
+                                    &a.value,
+                                    &prefix,
+                                    si,
+                                    &stage_names,
+                                    &stage_regs,
+                                    &port_names,
+                                );
                                 let target = if let ExprKind::Ident(name) = &a.target.kind {
                                     if port_names.contains(name) {
                                         name.clone()
@@ -508,26 +602,51 @@ impl<'a> Codegen<'a> {
                         self.line("always_comb begin");
                         self.indent += 1;
                         for stmt in &cb.stmts {
-                            self.emit_pipeline_comb_stmt(stmt, &prefix, si, &stage_names, &stage_regs, &port_names);
+                            self.emit_pipeline_comb_stmt(
+                                stmt,
+                                &prefix,
+                                si,
+                                &stage_names,
+                                &stage_regs,
+                                &port_names,
+                            );
                         }
                         self.indent -= 1;
                         self.line("end");
                     }
                 }
                 if let ModuleBodyItem::LetBinding(l) = item {
-                    let val = self.emit_pipeline_stage_expr_str(&l.value, &prefix, si, &stage_names, &stage_regs, &port_names);
+                    let val = self.emit_pipeline_stage_expr_str(
+                        &l.value,
+                        &prefix,
+                        si,
+                        &stage_names,
+                        &stage_regs,
+                        &port_names,
+                    );
                     self.line(&format!("assign {}_{} = {};", prefix, l.name.name, val));
                 }
                 if let ModuleBodyItem::Inst(inst) = item {
-                    self.emit_pipeline_inst(inst, &prefix, si, &stage_names, &stage_regs, &port_names);
+                    self.emit_pipeline_inst(
+                        inst,
+                        &prefix,
+                        si,
+                        &stage_names,
+                        &stage_regs,
+                        &port_names,
+                    );
                 }
             }
         }
 
         // ── Assert / cover SVA ───────────────────────────────────────────────
         if !p.asserts.is_empty() {
-            let clk = p.ports.iter().find(|pt| matches!(&pt.ty, TypeExpr::Clock(_)))
-                .map(|pt| pt.name.name.clone()).unwrap_or_else(|| "clk".to_string());
+            let clk = p
+                .ports
+                .iter()
+                .find(|pt| matches!(&pt.ty, TypeExpr::Clock(_)))
+                .map(|pt| pt.name.name.clone())
+                .unwrap_or_else(|| "clk".to_string());
             self.line("");
             let asserts = p.asserts.clone();
             let pname = p.name.name.clone();
@@ -564,7 +683,9 @@ impl<'a> Codegen<'a> {
     fn stmts_contain_wait(stmts: &[Stmt]) -> bool {
         stmts.iter().any(|s| match s {
             Stmt::WaitUntil(_, _) | Stmt::DoUntil { .. } => true,
-            Stmt::IfElse(ie) => Self::stmts_contain_wait(&ie.then_stmts) || Self::stmts_contain_wait(&ie.else_stmts),
+            Stmt::IfElse(ie) => {
+                Self::stmts_contain_wait(&ie.then_stmts) || Self::stmts_contain_wait(&ie.else_stmts)
+            }
             Stmt::For(f) => Self::stmts_contain_wait(&f.body),
             _ => false,
         })
@@ -579,7 +700,9 @@ impl<'a> Codegen<'a> {
             if let ModuleBodyItem::RegBlock(rb) = item {
                 for s in &rb.stmts {
                     match s {
-                        Stmt::WaitUntil(_, _) | Stmt::DoUntil { .. } => { wait_count += 1; }
+                        Stmt::WaitUntil(_, _) | Stmt::DoUntil { .. } => {
+                            wait_count += 1;
+                        }
                         _ => {}
                     }
                 }
@@ -615,9 +738,9 @@ impl<'a> Codegen<'a> {
         // Each wait creates a wait-state. Pre-wait assigns execute on entry.
         // Trailing assigns execute when the last wait completes.
         struct WaitGroup<'a> {
-            pre_assigns: Vec<&'a Stmt>,   // assigns before the wait
-            cond: &'a Expr,               // wait condition
-            hold_assigns: Vec<&'a Stmt>,  // do..until body (empty for wait until)
+            pre_assigns: Vec<&'a Stmt>,  // assigns before the wait
+            cond: &'a Expr,              // wait condition
+            hold_assigns: Vec<&'a Stmt>, // do..until body (empty for wait until)
         }
 
         let mut groups: Vec<WaitGroup> = Vec::new();
@@ -669,7 +792,14 @@ impl<'a> Codegen<'a> {
         self.line(&format!("{bits}'d0: begin"));
         self.indent += 1;
         if let Some(g) = groups.first() {
-            let cond = self.emit_pipeline_stage_expr_str(g.cond, prefix, si, stage_names, stage_regs, port_names);
+            let cond = self.emit_pipeline_stage_expr_str(
+                g.cond,
+                prefix,
+                si,
+                stage_names,
+                stage_regs,
+                port_names,
+            );
 
             // Run pre-assigns (fire once on entry to the wait)
             // For state 0 these only fire when upstream has valid data
@@ -714,7 +844,14 @@ impl<'a> Codegen<'a> {
             self.line(&format!("{bits}'d{state_num}: begin"));
             self.indent += 1;
 
-            let cond = self.emit_pipeline_stage_expr_str(g.cond, prefix, si, stage_names, stage_regs, port_names);
+            let cond = self.emit_pipeline_stage_expr_str(
+                g.cond,
+                prefix,
+                si,
+                stage_names,
+                stage_regs,
+                port_names,
+            );
 
             // Emit hold assigns (for do..until, every cycle)
             for a in &g.hold_assigns {
@@ -772,41 +909,82 @@ impl<'a> Codegen<'a> {
         match stmt {
             Stmt::Assign(a) => {
                 let target = self.emit_pipeline_lhs_str(&a.target, current_prefix, port_names);
-                let val = self.emit_pipeline_stage_expr_str(&a.value, current_prefix, current_stage_idx, stage_names, stage_regs, port_names);
+                let val = self.emit_pipeline_stage_expr_str(
+                    &a.value,
+                    current_prefix,
+                    current_stage_idx,
+                    stage_names,
+                    stage_regs,
+                    port_names,
+                );
                 self.line(&format!("{} <= {};", target, val));
             }
             Stmt::IfElse(ie) => {
-                self.emit_pipeline_reg_if_else(ie, current_prefix, current_stage_idx, stage_names, stage_regs, port_names, false);
+                self.emit_pipeline_reg_if_else(
+                    ie,
+                    current_prefix,
+                    current_stage_idx,
+                    stage_names,
+                    stage_regs,
+                    port_names,
+                    false,
+                );
             }
             Stmt::Match(_) => {
                 // MVP: basic pipeline doesn't need match in seq blocks
             }
-            Stmt::Log(l) => { self.emit_log_stmt(l); }
+            Stmt::Log(l) => {
+                self.emit_log_stmt(l);
+            }
             Stmt::For(f) => {
                 let var = &f.var.name;
                 match &f.range {
                     ForRange::Range(rs, re) => {
                         let start = self.emit_expr_str(rs);
                         let end = self.emit_expr_str(re);
-                        self.line(&format!("for (int {var} = {start}; {var} <= {end}; {var}++) begin"));
+                        self.line(&format!(
+                            "for (int {var} = {start}; {var} <= {end}; {var}++) begin"
+                        ));
                         self.indent += 1;
-                        for s in &f.body { self.emit_pipeline_reg_stmt(s, current_prefix, current_stage_idx, stage_names, stage_regs, port_names); }
+                        for s in &f.body {
+                            self.emit_pipeline_reg_stmt(
+                                s,
+                                current_prefix,
+                                current_stage_idx,
+                                stage_names,
+                                stage_regs,
+                                port_names,
+                            );
+                        }
                         self.indent -= 1;
                         self.line("end");
                     }
                     ForRange::ValueList(vals) => {
                         for v in vals {
                             let val = self.emit_expr_str(v);
-                            self.line(&format!("for (int {var} = {val}; {var} == {val}; {var}++) begin"));
+                            self.line(&format!(
+                                "for (int {var} = {val}; {var} == {val}; {var}++) begin"
+                            ));
                             self.indent += 1;
-                            for s in &f.body { self.emit_pipeline_reg_stmt(s, current_prefix, current_stage_idx, stage_names, stage_regs, port_names); }
+                            for s in &f.body {
+                                self.emit_pipeline_reg_stmt(
+                                    s,
+                                    current_prefix,
+                                    current_stage_idx,
+                                    stage_names,
+                                    stage_regs,
+                                    port_names,
+                                );
+                            }
                             self.indent -= 1;
                             self.line("end");
                         }
                     }
                 }
             }
-            Stmt::Init(_) => unreachable!("Stmt::Init should not appear in pipeline reg stmt context"),
+            Stmt::Init(_) => {
+                unreachable!("Stmt::Init should not appear in pipeline reg stmt context")
+            }
             Stmt::WaitUntil(_, _) | Stmt::DoUntil { .. } => {
                 // Pipeline wait-stages handled separately by pipeline codegen
                 unreachable!("WaitUntil/DoUntil handled by pipeline stage codegen, not emit_pipeline_reg_stmt")
@@ -893,10 +1071,17 @@ impl<'a> Codegen<'a> {
     /// port type onto a parent-scope wire so that param refs scoped to
     /// the inst's source module are rewritten to the parent-scope
     /// expressions supplied at inst time (or the source's defaults).
-    fn substitute_params_in_type(ty: &TypeExpr, params: &std::collections::HashMap<String, Expr>) -> TypeExpr {
+    fn substitute_params_in_type(
+        ty: &TypeExpr,
+        params: &std::collections::HashMap<String, Expr>,
+    ) -> TypeExpr {
         match ty {
-            TypeExpr::UInt(w) => TypeExpr::UInt(Box::new(Self::substitute_params_in_expr(w, params))),
-            TypeExpr::SInt(w) => TypeExpr::SInt(Box::new(Self::substitute_params_in_expr(w, params))),
+            TypeExpr::UInt(w) => {
+                TypeExpr::UInt(Box::new(Self::substitute_params_in_expr(w, params)))
+            }
+            TypeExpr::SInt(w) => {
+                TypeExpr::SInt(Box::new(Self::substitute_params_in_expr(w, params)))
+            }
             TypeExpr::Vec(inner, n) => TypeExpr::Vec(
                 Box::new(Self::substitute_params_in_type(inner, params)),
                 Box::new(Self::substitute_params_in_expr(n, params)),
@@ -905,7 +1090,10 @@ impl<'a> Codegen<'a> {
         }
     }
 
-    fn substitute_params_in_expr(e: &Expr, params: &std::collections::HashMap<String, Expr>) -> Expr {
+    fn substitute_params_in_expr(
+        e: &Expr,
+        params: &std::collections::HashMap<String, Expr>,
+    ) -> Expr {
         let kind = match &e.kind {
             ExprKind::Ident(name) => {
                 if let Some(replacement) = params.get(name) {
@@ -924,7 +1112,11 @@ impl<'a> Codegen<'a> {
             ),
             other => other.clone(),
         };
-        Expr { kind, span: e.span, parenthesized: e.parenthesized }
+        Expr {
+            kind,
+            span: e.span,
+            parenthesized: e.parenthesized,
+        }
     }
 
     fn resolve_inst_wire_type_from_consumers(
@@ -968,7 +1160,8 @@ impl<'a> Codegen<'a> {
                 Stmt::Assign(a) if matches!(&a.target.kind, ExprKind::Ident(n) if n == target) => {
                     // Check if RHS is a bare identifier (local register)
                     if let ExprKind::Ident(name) = &a.value.kind {
-                        if let Some(r) = stage_regs[current_stage_idx].iter()
+                        if let Some(r) = stage_regs[current_stage_idx]
+                            .iter()
                             .find(|(rn, _, _)| rn == name)
                         {
                             return Some(r.1.clone());
@@ -978,8 +1171,8 @@ impl<'a> Codegen<'a> {
                     if let ExprKind::FieldAccess(base, field) = &a.value.kind {
                         if let ExprKind::Ident(base_name) = &base.kind {
                             if let Some(si) = stage_names.iter().position(|&sn| sn == base_name) {
-                                if let Some(r) = stage_regs[si].iter()
-                                    .find(|(rn, _, _)| rn == &field.name)
+                                if let Some(r) =
+                                    stage_regs[si].iter().find(|(rn, _, _)| rn == &field.name)
                                 {
                                     return Some(r.1.clone());
                                 }
@@ -988,10 +1181,22 @@ impl<'a> Codegen<'a> {
                     }
                 }
                 Stmt::IfElse(ie) => {
-                    if let Some(ty) = Self::resolve_comb_wire_type(target, &ie.then_stmts, current_stage_idx, stage_regs, stage_names) {
+                    if let Some(ty) = Self::resolve_comb_wire_type(
+                        target,
+                        &ie.then_stmts,
+                        current_stage_idx,
+                        stage_regs,
+                        stage_names,
+                    ) {
                         return Some(ty);
                     }
-                    if let Some(ty) = Self::resolve_comb_wire_type(target, &ie.else_stmts, current_stage_idx, stage_regs, stage_names) {
+                    if let Some(ty) = Self::resolve_comb_wire_type(
+                        target,
+                        &ie.else_stmts,
+                        current_stage_idx,
+                        stage_regs,
+                        stage_names,
+                    ) {
                         return Some(ty);
                     }
                 }
@@ -1027,7 +1232,14 @@ impl<'a> Codegen<'a> {
     ) {
         match stmt {
             Stmt::Assign(a) => {
-                let val = self.emit_pipeline_stage_expr_str(&a.value, current_prefix, current_stage_idx, stage_names, stage_regs, port_names);
+                let val = self.emit_pipeline_stage_expr_str(
+                    &a.value,
+                    current_prefix,
+                    current_stage_idx,
+                    stage_names,
+                    stage_regs,
+                    port_names,
+                );
                 let target = if let ExprKind::Ident(name) = &a.target.kind {
                     if port_names.contains(name) {
                         name.clone()
@@ -1060,10 +1272,19 @@ impl<'a> Codegen<'a> {
                     port_names,
                 );
             }
-            Stmt::Log(l) => { self.emit_log_stmt(l); }
+            Stmt::Log(l) => {
+                self.emit_log_stmt(l);
+            }
             Stmt::For(f) => {
                 self.emit_for_loop_sv(f, |s, stmt| {
-                    s.emit_pipeline_comb_stmt(stmt, current_prefix, current_stage_idx, stage_names, stage_regs, port_names);
+                    s.emit_pipeline_comb_stmt(
+                        stmt,
+                        current_prefix,
+                        current_stage_idx,
+                        stage_names,
+                        stage_regs,
+                        port_names,
+                    );
                 });
             }
             Stmt::Init(_) | Stmt::WaitUntil(..) | Stmt::DoUntil { .. } => {
@@ -1123,7 +1344,14 @@ impl<'a> Codegen<'a> {
         port_names: &std::collections::HashSet<String>,
         is_chain: bool,
     ) {
-        let cond = self.emit_pipeline_stage_expr_str(&ie.cond, current_prefix, current_stage_idx, stage_names, stage_regs, port_names);
+        let cond = self.emit_pipeline_stage_expr_str(
+            &ie.cond,
+            current_prefix,
+            current_stage_idx,
+            stage_names,
+            stage_regs,
+            port_names,
+        );
         if is_chain {
             self.line(&format!("end else if ({}) begin", cond));
         } else {
@@ -1131,12 +1359,27 @@ impl<'a> Codegen<'a> {
         }
         self.indent += 1;
         for s in &ie.then_stmts {
-            self.emit_pipeline_reg_stmt(s, current_prefix, current_stage_idx, stage_names, stage_regs, port_names);
+            self.emit_pipeline_reg_stmt(
+                s,
+                current_prefix,
+                current_stage_idx,
+                stage_names,
+                stage_regs,
+                port_names,
+            );
         }
         self.indent -= 1;
         if ie.else_stmts.len() == 1 {
             if let Stmt::IfElse(nested) = &ie.else_stmts[0] {
-                self.emit_pipeline_reg_if_else(nested, current_prefix, current_stage_idx, stage_names, stage_regs, port_names, true);
+                self.emit_pipeline_reg_if_else(
+                    nested,
+                    current_prefix,
+                    current_stage_idx,
+                    stage_names,
+                    stage_regs,
+                    port_names,
+                    true,
+                );
                 return;
             }
         }
@@ -1144,7 +1387,14 @@ impl<'a> Codegen<'a> {
             self.line("end else begin");
             self.indent += 1;
             for s in &ie.else_stmts {
-                self.emit_pipeline_reg_stmt(s, current_prefix, current_stage_idx, stage_names, stage_regs, port_names);
+                self.emit_pipeline_reg_stmt(
+                    s,
+                    current_prefix,
+                    current_stage_idx,
+                    stage_names,
+                    stage_regs,
+                    port_names,
+                );
             }
             self.indent -= 1;
         }
@@ -1161,7 +1411,14 @@ impl<'a> Codegen<'a> {
         port_names: &std::collections::HashSet<String>,
         is_chain: bool,
     ) {
-        let cond = self.emit_pipeline_stage_expr_str(&ie.cond, current_prefix, current_stage_idx, stage_names, stage_regs, port_names);
+        let cond = self.emit_pipeline_stage_expr_str(
+            &ie.cond,
+            current_prefix,
+            current_stage_idx,
+            stage_names,
+            stage_regs,
+            port_names,
+        );
         if is_chain {
             self.line(&format!("end else if ({}) begin", cond));
         } else {
@@ -1169,12 +1426,27 @@ impl<'a> Codegen<'a> {
         }
         self.indent += 1;
         for s in &ie.then_stmts {
-            self.emit_pipeline_comb_stmt(s, current_prefix, current_stage_idx, stage_names, stage_regs, port_names);
+            self.emit_pipeline_comb_stmt(
+                s,
+                current_prefix,
+                current_stage_idx,
+                stage_names,
+                stage_regs,
+                port_names,
+            );
         }
         self.indent -= 1;
         if ie.else_stmts.len() == 1 {
             if let Stmt::IfElse(nested) = &ie.else_stmts[0] {
-                self.emit_pipeline_comb_if_else(nested, current_prefix, current_stage_idx, stage_names, stage_regs, port_names, true);
+                self.emit_pipeline_comb_if_else(
+                    nested,
+                    current_prefix,
+                    current_stage_idx,
+                    stage_names,
+                    stage_regs,
+                    port_names,
+                    true,
+                );
                 return;
             }
         }
@@ -1182,7 +1454,14 @@ impl<'a> Codegen<'a> {
             self.line("end else begin");
             self.indent += 1;
             for s in &ie.else_stmts {
-                self.emit_pipeline_comb_stmt(s, current_prefix, current_stage_idx, stage_names, stage_regs, port_names);
+                self.emit_pipeline_comb_stmt(
+                    s,
+                    current_prefix,
+                    current_stage_idx,
+                    stage_names,
+                    stage_regs,
+                    port_names,
+                );
             }
             self.indent -= 1;
         }
@@ -1208,7 +1487,14 @@ impl<'a> Codegen<'a> {
                         return format!("{}_{}", prefix, field.name);
                     }
                 }
-                let b = self.emit_pipeline_stage_expr_str(base, current_prefix, current_stage_idx, stage_names, stage_regs, port_names);
+                let b = self.emit_pipeline_stage_expr_str(
+                    base,
+                    current_prefix,
+                    current_stage_idx,
+                    stage_names,
+                    stage_regs,
+                    port_names,
+                );
                 format!("{}.{}", b, field.name)
             }
             ExprKind::Ident(name) => {
@@ -1228,8 +1514,22 @@ impl<'a> Codegen<'a> {
                 name.clone()
             }
             ExprKind::Binary(op, lhs, rhs) => {
-                let l = self.emit_pipeline_stage_expr_str(lhs, current_prefix, current_stage_idx, stage_names, stage_regs, port_names);
-                let r = self.emit_pipeline_stage_expr_str(rhs, current_prefix, current_stage_idx, stage_names, stage_regs, port_names);
+                let l = self.emit_pipeline_stage_expr_str(
+                    lhs,
+                    current_prefix,
+                    current_stage_idx,
+                    stage_names,
+                    stage_regs,
+                    port_names,
+                );
+                let r = self.emit_pipeline_stage_expr_str(
+                    rhs,
+                    current_prefix,
+                    current_stage_idx,
+                    stage_names,
+                    stage_regs,
+                    port_names,
+                );
                 if *op == BinOp::Implies {
                     return format!("({l} |-> {r})");
                 }
@@ -1237,19 +1537,34 @@ impl<'a> Codegen<'a> {
                     return format!("({l} |=> {r})");
                 }
                 let op_str = match op {
-                    BinOp::Add | BinOp::AddWrap => "+", BinOp::Sub | BinOp::SubWrap => "-",
+                    BinOp::Add | BinOp::AddWrap => "+",
+                    BinOp::Sub | BinOp::SubWrap => "-",
                     BinOp::Mul | BinOp::MulWrap => "*",
-                    BinOp::Div => "/", BinOp::Mod => "%", BinOp::Eq => "==",
-                    BinOp::Neq => "!=", BinOp::Lt => "<", BinOp::Gt => ">",
-                    BinOp::Lte => "<=", BinOp::Gte => ">=", BinOp::And => "&&",
-                    BinOp::Or => "||", BinOp::BitAnd => "&", BinOp::BitOr => "|",
-                    BinOp::BitXor => "^", BinOp::Shl => "<<", BinOp::Shr => ">>",
+                    BinOp::Div => "/",
+                    BinOp::Mod => "%",
+                    BinOp::Eq => "==",
+                    BinOp::Neq => "!=",
+                    BinOp::Lt => "<",
+                    BinOp::Gt => ">",
+                    BinOp::Lte => "<=",
+                    BinOp::Gte => ">=",
+                    BinOp::And => "&&",
+                    BinOp::Or => "||",
+                    BinOp::BitAnd => "&",
+                    BinOp::BitOr => "|",
+                    BinOp::BitXor => "^",
+                    BinOp::Shl => "<<",
+                    BinOp::Shr => ">>",
                     BinOp::Implies | BinOp::ImpliesNext => unreachable!(),
                 };
                 if matches!(op, BinOp::AddWrap | BinOp::SubWrap | BinOp::MulWrap) {
                     let lw = self.infer_sv_width_str(lhs);
                     let rw = self.infer_sv_width_str(rhs);
-                    let w = if lw == rw { lw } else { format!("({lw} > {rw} ? {lw} : {rw})") };
+                    let w = if lw == rw {
+                        lw
+                    } else {
+                        format!("({lw} > {rw} ? {lw} : {rw})")
+                    };
                     let wp = Self::paren_width(&w);
                     format!("{wp}'({l} {op_str} {r})")
                 } else {
@@ -1257,7 +1572,14 @@ impl<'a> Codegen<'a> {
                 }
             }
             ExprKind::Unary(op, operand) => {
-                let o = self.emit_pipeline_stage_expr_str(operand, current_prefix, current_stage_idx, stage_names, stage_regs, port_names);
+                let o = self.emit_pipeline_stage_expr_str(
+                    operand,
+                    current_prefix,
+                    current_stage_idx,
+                    stage_names,
+                    stage_regs,
+                    port_names,
+                );
                 match op {
                     UnaryOp::Not => format!("(!{o})"),
                     UnaryOp::BitNot => format!("(~{o})"),
@@ -1268,7 +1590,14 @@ impl<'a> Codegen<'a> {
                 }
             }
             ExprKind::MethodCall(base, method, args) => {
-                let b = self.emit_pipeline_stage_expr_str(base, current_prefix, current_stage_idx, stage_names, stage_regs, port_names);
+                let b = self.emit_pipeline_stage_expr_str(
+                    base,
+                    current_prefix,
+                    current_stage_idx,
+                    stage_names,
+                    stage_regs,
+                    port_names,
+                );
                 match method.name.as_str() {
                     "trunc" | "zext" => {
                         if let Some(width) = args.first() {
@@ -1308,21 +1637,39 @@ impl<'a> Codegen<'a> {
                             b
                         }
                     }
-                    "any" | "all" | "count" | "contains"
-                    | "reduce_or" | "reduce_and" | "reduce_xor"
-                    | "find_first" => {
-                        self.emit_vec_method(&b, base, method, args)
-                    }
+                    "any" | "all" | "count" | "contains" | "reduce_or" | "reduce_and"
+                    | "reduce_xor" | "find_first" => self.emit_vec_method(&b, base, method, args),
                     _ => format!("{b}.{}()", method.name),
                 }
             }
             ExprKind::Index(base, idx) => {
-                let b = self.emit_pipeline_stage_expr_str(base, current_prefix, current_stage_idx, stage_names, stage_regs, port_names);
-                let i = self.emit_pipeline_stage_expr_str(idx, current_prefix, current_stage_idx, stage_names, stage_regs, port_names);
+                let b = self.emit_pipeline_stage_expr_str(
+                    base,
+                    current_prefix,
+                    current_stage_idx,
+                    stage_names,
+                    stage_regs,
+                    port_names,
+                );
+                let i = self.emit_pipeline_stage_expr_str(
+                    idx,
+                    current_prefix,
+                    current_stage_idx,
+                    stage_names,
+                    stage_regs,
+                    port_names,
+                );
                 format!("{b}[{i}]")
             }
             ExprKind::BitSlice(base, hi, lo) => {
-                let b = self.emit_pipeline_stage_expr_str(base, current_prefix, current_stage_idx, stage_names, stage_regs, port_names);
+                let b = self.emit_pipeline_stage_expr_str(
+                    base,
+                    current_prefix,
+                    current_stage_idx,
+                    stage_names,
+                    stage_regs,
+                    port_names,
+                );
                 if let Some(width) = Self::try_indexed_part_select(hi, lo) {
                     let l = self.emit_expr_str(lo);
                     format!("{b}[{l} +: {width}]")
@@ -1333,20 +1680,44 @@ impl<'a> Codegen<'a> {
                 }
             }
             ExprKind::PartSelect(base, start, width, up) => {
-                let b = self.emit_pipeline_stage_expr_str(base, current_prefix, current_stage_idx, stage_names, stage_regs, port_names);
+                let b = self.emit_pipeline_stage_expr_str(
+                    base,
+                    current_prefix,
+                    current_stage_idx,
+                    stage_names,
+                    stage_regs,
+                    port_names,
+                );
                 let s = self.emit_expr_str(start);
                 let w = self.emit_expr_str(width);
                 let op = if *up { "+:" } else { "-:" };
                 format!("{b}[{s} {op} {w}]")
             }
             ExprKind::Concat(parts) => {
-                let parts_str: Vec<String> = parts.iter()
-                    .map(|p| self.emit_pipeline_stage_expr_str(p, current_prefix, current_stage_idx, stage_names, stage_regs, port_names))
+                let parts_str: Vec<String> = parts
+                    .iter()
+                    .map(|p| {
+                        self.emit_pipeline_stage_expr_str(
+                            p,
+                            current_prefix,
+                            current_stage_idx,
+                            stage_names,
+                            stage_regs,
+                            port_names,
+                        )
+                    })
                     .collect();
                 format!("{{{}}}", parts_str.join(", "))
             }
             ExprKind::Cast(inner, ty) => {
-                let e = self.emit_pipeline_stage_expr_str(inner, current_prefix, current_stage_idx, stage_names, stage_regs, port_names);
+                let e = self.emit_pipeline_stage_expr_str(
+                    inner,
+                    current_prefix,
+                    current_stage_idx,
+                    stage_names,
+                    stage_regs,
+                    port_names,
+                );
                 match &**ty {
                     TypeExpr::SInt(_) => format!("$signed({e})"),
                     TypeExpr::UInt(w) => {
@@ -1360,22 +1731,70 @@ impl<'a> Codegen<'a> {
                 }
             }
             ExprKind::Signed(inner) => {
-                let e = self.emit_pipeline_stage_expr_str(inner, current_prefix, current_stage_idx, stage_names, stage_regs, port_names);
+                let e = self.emit_pipeline_stage_expr_str(
+                    inner,
+                    current_prefix,
+                    current_stage_idx,
+                    stage_names,
+                    stage_regs,
+                    port_names,
+                );
                 format!("$signed({e})")
             }
             ExprKind::Unsigned(inner) => {
-                let e = self.emit_pipeline_stage_expr_str(inner, current_prefix, current_stage_idx, stage_names, stage_regs, port_names);
+                let e = self.emit_pipeline_stage_expr_str(
+                    inner,
+                    current_prefix,
+                    current_stage_idx,
+                    stage_names,
+                    stage_regs,
+                    port_names,
+                );
                 format!("$unsigned({e})")
             }
             ExprKind::Ternary(cond, then_expr, else_expr) => {
-                let c = self.emit_pipeline_stage_expr_str(cond, current_prefix, current_stage_idx, stage_names, stage_regs, port_names);
-                let t = self.emit_pipeline_stage_expr_str(then_expr, current_prefix, current_stage_idx, stage_names, stage_regs, port_names);
-                let e = self.emit_pipeline_stage_expr_str(else_expr, current_prefix, current_stage_idx, stage_names, stage_regs, port_names);
+                let c = self.emit_pipeline_stage_expr_str(
+                    cond,
+                    current_prefix,
+                    current_stage_idx,
+                    stage_names,
+                    stage_regs,
+                    port_names,
+                );
+                let t = self.emit_pipeline_stage_expr_str(
+                    then_expr,
+                    current_prefix,
+                    current_stage_idx,
+                    stage_names,
+                    stage_regs,
+                    port_names,
+                );
+                let e = self.emit_pipeline_stage_expr_str(
+                    else_expr,
+                    current_prefix,
+                    current_stage_idx,
+                    stage_names,
+                    stage_regs,
+                    port_names,
+                );
                 format!("({c}) ? ({t}) : ({e})")
             }
-            ExprKind::Bool(b) => if *b { "1'b1".to_string() } else { "1'b0".to_string() },
+            ExprKind::Bool(b) => {
+                if *b {
+                    "1'b1".to_string()
+                } else {
+                    "1'b0".to_string()
+                }
+            }
             ExprKind::Clog2(arg) => {
-                let a = self.emit_pipeline_stage_expr_str(arg, current_prefix, current_stage_idx, stage_names, stage_regs, port_names);
+                let a = self.emit_pipeline_stage_expr_str(
+                    arg,
+                    current_prefix,
+                    current_stage_idx,
+                    stage_names,
+                    stage_regs,
+                    port_names,
+                );
                 format!("$clog2({a})")
             }
             _ => self.emit_expr_str(expr),
@@ -1425,19 +1844,34 @@ impl<'a> Codegen<'a> {
                     return format!("({l} |=> {r})");
                 }
                 let op_str = match op {
-                    BinOp::Add | BinOp::AddWrap => "+", BinOp::Sub | BinOp::SubWrap => "-",
+                    BinOp::Add | BinOp::AddWrap => "+",
+                    BinOp::Sub | BinOp::SubWrap => "-",
                     BinOp::Mul | BinOp::MulWrap => "*",
-                    BinOp::Div => "/", BinOp::Mod => "%", BinOp::Eq => "==",
-                    BinOp::Neq => "!=", BinOp::Lt => "<", BinOp::Gt => ">",
-                    BinOp::Lte => "<=", BinOp::Gte => ">=", BinOp::And => "&&",
-                    BinOp::Or => "||", BinOp::BitAnd => "&", BinOp::BitOr => "|",
-                    BinOp::BitXor => "^", BinOp::Shl => "<<", BinOp::Shr => ">>",
+                    BinOp::Div => "/",
+                    BinOp::Mod => "%",
+                    BinOp::Eq => "==",
+                    BinOp::Neq => "!=",
+                    BinOp::Lt => "<",
+                    BinOp::Gt => ">",
+                    BinOp::Lte => "<=",
+                    BinOp::Gte => ">=",
+                    BinOp::And => "&&",
+                    BinOp::Or => "||",
+                    BinOp::BitAnd => "&",
+                    BinOp::BitOr => "|",
+                    BinOp::BitXor => "^",
+                    BinOp::Shl => "<<",
+                    BinOp::Shr => ">>",
                     BinOp::Implies | BinOp::ImpliesNext => unreachable!(),
                 };
                 if matches!(op, BinOp::AddWrap | BinOp::SubWrap | BinOp::MulWrap) {
                     let lw = self.infer_sv_width_str(lhs);
                     let rw = self.infer_sv_width_str(rhs);
-                    let w = if lw == rw { lw } else { format!("({lw} > {rw} ? {lw} : {rw})") };
+                    let w = if lw == rw {
+                        lw
+                    } else {
+                        format!("({lw} > {rw} ? {lw} : {rw})")
+                    };
                     let wp = Self::paren_width(&w);
                     format!("{wp}'({l} {op_str} {r})")
                 } else {
@@ -1496,11 +1930,8 @@ impl<'a> Codegen<'a> {
                             b
                         }
                     }
-                    "any" | "all" | "count" | "contains"
-                    | "reduce_or" | "reduce_and" | "reduce_xor"
-                    | "find_first" => {
-                        self.emit_vec_method(&b, base, method, args)
-                    }
+                    "any" | "all" | "count" | "contains" | "reduce_or" | "reduce_and"
+                    | "reduce_xor" | "find_first" => self.emit_vec_method(&b, base, method, args),
                     _ => format!("{b}.{}()", method.name),
                 }
             }
@@ -1533,5 +1964,4 @@ impl<'a> Codegen<'a> {
     }
 
     // ── FIFO ──────────────────────────────────────────────────────────────────
-
 }

--- a/src/codegen/ram.rs
+++ b/src/codegen/ram.rs
@@ -8,10 +8,12 @@ use super::*;
 
 impl<'a> Codegen<'a> {
     pub(crate) fn emit_ram(&mut self, r: &RamDecl) {
-        use crate::ast::{RamKind, RamInit};
+        use crate::ast::{RamInit, RamKind};
         use std::collections::HashMap;
 
-        let type_params: HashMap<String, TypeExpr> = r.params.iter()
+        let type_params: HashMap<String, TypeExpr> = r
+            .params
+            .iter()
             .filter_map(|p| match &p.kind {
                 crate::ast::ParamKind::Type(ty) => Some((p.name.name.clone(), ty.clone())),
                 _ => None,
@@ -39,7 +41,9 @@ impl<'a> Codegen<'a> {
             TypeExpr::Vec(elem, _) => Some(resolve_type_param((**elem).clone())),
             _ => None,
         });
-        let data_width_ty = r.params.iter()
+        let data_width_ty = r
+            .params
+            .iter()
             .find(|p| p.name.name == "WIDTH")
             .and_then(|p| match &p.kind {
                 crate::ast::ParamKind::Type(ty) => {
@@ -51,7 +55,9 @@ impl<'a> Codegen<'a> {
             .unwrap_or_else(|| "logic [7:0]".to_string());
         // Compute the bit-width number directly from the TypeExpr to avoid
         // fragile string parsing of the emitted type (e.g. "logic [7:0]").
-        let data_width_num = r.params.iter()
+        let data_width_num = r
+            .params
+            .iter()
             .find(|p| p.name.name == "WIDTH")
             .and_then(|p| match &p.kind {
                 crate::ast::ParamKind::Type(ty) => {
@@ -59,11 +65,17 @@ impl<'a> Codegen<'a> {
                 }
                 _ => None,
             })
-            .or_else(|| store_elem_ty.as_ref().and_then(|ty| self.type_expr_data_width(ty)))
+            .or_else(|| {
+                store_elem_ty
+                    .as_ref()
+                    .and_then(|ty| self.type_expr_data_width(ty))
+            })
             .unwrap_or_else(|| "8".to_string());
 
         // Resolve DEPTH from param default
-        let depth_expr = r.params.iter()
+        let depth_expr = r
+            .params
+            .iter()
             .find(|p| p.name.name == "DEPTH")
             .and_then(|p| p.default.as_ref())
             .map(|e| self.emit_expr_str(e))
@@ -89,7 +101,9 @@ impl<'a> Codegen<'a> {
             }
             match &p.kind {
                 crate::ast::ParamKind::Const => {
-                    let default_str = p.default.as_ref()
+                    let default_str = p
+                        .default
+                        .as_ref()
                         .map(|d| format!(" = {}", self.emit_expr_str(d)))
                         .unwrap_or_default();
                     header_params.push(format!("parameter int {}{default_str}", p.name.name));
@@ -97,10 +111,15 @@ impl<'a> Codegen<'a> {
                 crate::ast::ParamKind::WidthConst(hi, lo) => {
                     let hi_s = self.emit_expr_str(hi);
                     let lo_s = self.emit_expr_str(lo);
-                    let default_str = p.default.as_ref()
+                    let default_str = p
+                        .default
+                        .as_ref()
                         .map(|d| format!(" = {}", self.emit_expr_str(d)))
                         .unwrap_or_default();
-                    header_params.push(format!("parameter [{hi_s}:{lo_s}] {}{default_str}", p.name.name));
+                    header_params.push(format!(
+                        "parameter [{hi_s}:{lo_s}] {}{default_str}",
+                        p.name.name
+                    ));
                 }
                 // Logic / EnumConst / ConstVec / Type are uncommon for ram
                 // params; punt for now (would emit nothing → port refs
@@ -123,14 +142,20 @@ impl<'a> Codegen<'a> {
         // Top-level ports (clk, rst)
         let mut all_ports: Vec<String> = Vec::new();
         for p in &r.ports {
-            let dir = match p.direction { Direction::In => "input", Direction::Out => "output" };
+            let dir = match p.direction {
+                Direction::In => "input",
+                Direction::Out => "output",
+            };
             let ty_str = self.emit_port_type_str(&p.ty);
             all_ports.push(format!("{dir} {ty_str} {}", p.name.name));
         }
         // Port group signals flattened: {group}_{signal}
         for pg in &r.port_groups {
             for s in &pg.signals {
-                let dir = match s.direction { Direction::In => "input", Direction::Out => "output" };
+                let dir = match s.direction {
+                    Direction::In => "input",
+                    Direction::Out => "output",
+                };
                 let ty_str = self.emit_ram_signal_type(&s.ty, &type_params);
                 all_ports.push(format!("{dir} {ty_str} {}_{}", pg.name.name, s.name.name));
             }
@@ -149,7 +174,9 @@ impl<'a> Codegen<'a> {
         self.line("logic [DATA_WIDTH-1:0] mem [0:DEPTH-1];");
 
         // Find the clock signal name
-        let clk_name = r.ports.iter()
+        let clk_name = r
+            .ports
+            .iter()
             .find(|p| matches!(&p.ty, TypeExpr::Clock(_)))
             .map(|p| p.name.name.clone())
             .unwrap_or_else(|| "clk".to_string());
@@ -201,8 +228,12 @@ impl<'a> Codegen<'a> {
         }
 
         if !r.asserts.is_empty() {
-            let clk = r.ports.iter().find(|p| matches!(&p.ty, TypeExpr::Clock(_)))
-                .map(|p| p.name.name.clone()).unwrap_or_else(|| "clk".to_string());
+            let clk = r
+                .ports
+                .iter()
+                .find(|p| matches!(&p.ty, TypeExpr::Clock(_)))
+                .map(|p| p.name.name.clone())
+                .unwrap_or_else(|| "clk".to_string());
             self.line("");
             let asserts = r.asserts.clone();
             let rname = r.name.name.clone();
@@ -218,11 +249,13 @@ impl<'a> Codegen<'a> {
 
     // ── Counter ───────────────────────────────────────────────────────────────
 
-    fn emit_ram_signal_type(&self, ty: &TypeExpr, type_params: &std::collections::HashMap<String, TypeExpr>) -> String {
+    fn emit_ram_signal_type(
+        &self,
+        ty: &TypeExpr,
+        type_params: &std::collections::HashMap<String, TypeExpr>,
+    ) -> String {
         match ty {
-            TypeExpr::Named(ident) if ident.name == "WIDTH" => {
-                "logic [DATA_WIDTH-1:0]".to_string()
-            }
+            TypeExpr::Named(ident) if ident.name == "WIDTH" => "logic [DATA_WIDTH-1:0]".to_string(),
             TypeExpr::Named(ident) if type_params.contains_key(&ident.name) => {
                 "logic [DATA_WIDTH-1:0]".to_string()
             }
@@ -238,7 +271,11 @@ impl<'a> Codegen<'a> {
 
         // Detect signal names
         let has_wen = pg.signals.iter().any(|s| s.name.name == "wen");
-        let out_sig = pg.signals.iter().find(|s| s.direction == Direction::Out).cloned();
+        let out_sig = pg
+            .signals
+            .iter()
+            .find(|s| s.direction == Direction::Out)
+            .cloned();
 
         match r.latency {
             0 => {
@@ -307,7 +344,9 @@ impl<'a> Codegen<'a> {
                     if r.latency == 2 {
                         let rdata_r2 = format!("{pfx}_{}_r2", os.name.name);
                         self.line(&format!("logic [DATA_WIDTH-1:0] {rdata_r2};"));
-                        self.line(&format!("always_ff @(posedge {clk}) {rdata_r2} <= {rdata_r};"));
+                        self.line(&format!(
+                            "always_ff @(posedge {clk}) {rdata_r2} <= {rdata_r};"
+                        ));
                         self.line(&format!("assign {pfx}_{} = {rdata_r2};", os.name.name));
                     }
                 }
@@ -318,16 +357,23 @@ impl<'a> Codegen<'a> {
 
     fn emit_ram_simple_dual(&mut self, r: &RamDecl, clk: &str, _data_width_ty: &str) {
         // Identify read port (has output signal) and write port (all inputs)
-        let read_pg = r.port_groups.iter()
+        let read_pg = r
+            .port_groups
+            .iter()
             .find(|pg| pg.signals.iter().any(|s| s.direction == Direction::Out));
-        let write_pg = r.port_groups.iter()
+        let write_pg = r
+            .port_groups
+            .iter()
             .find(|pg| pg.signals.iter().all(|s| s.direction == Direction::In));
 
         let (rpfx, wpfx) = match (read_pg, write_pg) {
             (Some(rp), Some(wp)) => (rp.name.name.clone(), wp.name.name.clone()),
             _ => return, // malformed
         };
-        let out_sig = read_pg.unwrap().signals.iter()
+        let out_sig = read_pg
+            .unwrap()
+            .signals
+            .iter()
             .find(|s| s.direction == Direction::Out)
             .map(|s| s.name.name.clone())
             .unwrap_or_else(|| "data".to_string());
@@ -339,9 +385,14 @@ impl<'a> Codegen<'a> {
         let has_rd_en = read_pg.unwrap().signals.iter().any(|s| s.name.name == "en");
 
         // Find write data signal (input data in write port)
-        let wdata_sig = write_pg.unwrap().signals.iter()
-            .find(|s| s.direction == Direction::In
-                && !["en", "addr", "mask", "wen"].contains(&s.name.name.as_str()))
+        let wdata_sig = write_pg
+            .unwrap()
+            .signals
+            .iter()
+            .find(|s| {
+                s.direction == Direction::In
+                    && !["en", "addr", "mask", "wen"].contains(&s.name.name.as_str())
+            })
             .map(|s| s.name.name.clone())
             .unwrap_or_else(|| "data".to_string());
 
@@ -374,13 +425,17 @@ impl<'a> Codegen<'a> {
                     self.indent += 1;
                 }
                 self.line(&format!("{rdata_r} <= mem[{rpfx}_addr];"));
-                if has_rd_en { self.indent -= 1; }
+                if has_rd_en {
+                    self.indent -= 1;
+                }
                 self.indent -= 1;
                 self.line("end");
                 if r.latency == 2 {
                     let rdata_r2 = format!("{rpfx}_{out_sig}_r2");
                     self.line(&format!("logic [DATA_WIDTH-1:0] {rdata_r2};"));
-                    self.line(&format!("always_ff @(posedge {clk}) {rdata_r2} <= {rdata_r};"));
+                    self.line(&format!(
+                        "always_ff @(posedge {clk}) {rdata_r2} <= {rdata_r};"
+                    ));
                     self.line(&format!("assign {rpfx}_{out_sig} = {rdata_r2};"));
                 } else {
                     self.line(&format!("assign {rpfx}_{out_sig} = {rdata_r};"));
@@ -397,10 +452,18 @@ impl<'a> Codegen<'a> {
         let pfx_a = pa.name.name.clone();
         let pfx_b = pb.name.name.clone();
 
-        let rdata_a = pa.signals.iter().find(|s| s.direction == Direction::Out)
-            .map(|s| s.name.name.clone()).unwrap_or_else(|| "rdata".to_string());
-        let rdata_b = pb.signals.iter().find(|s| s.direction == Direction::Out)
-            .map(|s| s.name.name.clone()).unwrap_or_else(|| "rdata".to_string());
+        let rdata_a = pa
+            .signals
+            .iter()
+            .find(|s| s.direction == Direction::Out)
+            .map(|s| s.name.name.clone())
+            .unwrap_or_else(|| "rdata".to_string());
+        let rdata_b = pb
+            .signals
+            .iter()
+            .find(|s| s.direction == Direction::Out)
+            .map(|s| s.name.name.clone())
+            .unwrap_or_else(|| "rdata".to_string());
 
         let rdata_a_r = format!("{pfx_a}_{rdata_a}_r");
         let rdata_b_r = format!("{pfx_b}_{rdata_b}_r");
@@ -501,7 +564,9 @@ impl<'a> Codegen<'a> {
                         self.indent += 1;
                     }
                     self.line(&format!("{rdata_r} <= mem[{pfx}_addr];"));
-                    if has_en { self.indent -= 1; }
+                    if has_en {
+                        self.indent -= 1;
+                    }
                     self.indent -= 1;
                     self.line("end");
                     self.line(&format!("assign {pfx}_{} = {rdata_r};", os.name.name));
@@ -528,5 +593,4 @@ impl<'a> Codegen<'a> {
     }
 
     // ── Linklist ─────────────────────────────────────────────────────────────
-
 }

--- a/src/codegen/regfile.rs
+++ b/src/codegen/regfile.rs
@@ -18,14 +18,25 @@ impl<'a> Codegen<'a> {
 
         // Data width: prefer the UInt<N> type of the data signal in the write port,
         // then fall back to XLEN/WIDTH/DATA_WIDTH params.
-        let data_width_num: String = r.write_ports.as_ref()
+        let data_width_num: String = r
+            .write_ports
+            .as_ref()
             .and_then(|wp| wp.signals.iter().find(|s| s.name.name == "data"))
-            .and_then(|s| if let TypeExpr::UInt(w) = &s.ty { Some(self.emit_expr_str(w)) } else { None })
+            .and_then(|s| {
+                if let TypeExpr::UInt(w) = &s.ty {
+                    Some(self.emit_expr_str(w))
+                } else {
+                    None
+                }
+            })
             .or_else(|| {
-                r.params.iter()
+                r.params
+                    .iter()
                     .find(|p| matches!(p.name.name.as_str(), "XLEN" | "WIDTH" | "DATA_WIDTH"))
                     .and_then(|p| match &p.kind {
-                        ParamKind::Const | ParamKind::WidthConst(..) => p.default.as_ref().map(|e| self.emit_expr_str(e)),
+                        ParamKind::Const | ParamKind::WidthConst(..) => {
+                            p.default.as_ref().map(|e| self.emit_expr_str(e))
+                        }
                         _ => None,
                     })
             })
@@ -35,14 +46,20 @@ impl<'a> Codegen<'a> {
         let addr_width = crate::width::index_width(nregs);
 
         // Read/write port counts — resolve param references
-        let nread = r.read_ports.as_ref()
+        let nread = r
+            .read_ports
+            .as_ref()
             .map(|rp| r.resolve_count_expr(&rp.count_expr))
             .unwrap_or(1);
-        let nwrite = r.write_ports.as_ref()
+        let nwrite = r
+            .write_ports
+            .as_ref()
             .map(|wp| r.resolve_count_expr(&wp.count_expr))
             .unwrap_or(1);
 
-        let clk = r.ports.iter()
+        let clk = r
+            .ports
+            .iter()
             .find(|p| matches!(&p.ty, TypeExpr::Clock(_)))
             .map(|p| p.name.name.clone())
             .unwrap_or_else(|| "clk".to_string());
@@ -55,7 +72,11 @@ impl<'a> Codegen<'a> {
         let param_count = r.params.len();
         for (i, p) in r.params.iter().enumerate() {
             let comma = if i < param_count - 1 { "," } else { "" };
-            let val = p.default.as_ref().map(|e| self.emit_expr_str(e)).unwrap_or_else(|| "0".to_string());
+            let val = p
+                .default
+                .as_ref()
+                .map(|e| self.emit_expr_str(e))
+                .unwrap_or_else(|| "0".to_string());
             self.line(&format!("parameter int {} = {}{}", p.name.name, val, comma));
         }
         self.indent -= 1;
@@ -67,7 +88,10 @@ impl<'a> Codegen<'a> {
         // can be connected individually via a `connect` statement.
         let mut all_ports: Vec<String> = Vec::new();
         for p in &r.ports {
-            let dir = match p.direction { Direction::In => "input", Direction::Out => "output" };
+            let dir = match p.direction {
+                Direction::In => "input",
+                Direction::Out => "output",
+            };
             let ty_str = self.emit_port_type_str(&p.ty);
             all_ports.push(format!("{dir} {ty_str} {}", p.name.name));
         }
@@ -76,13 +100,22 @@ impl<'a> Codegen<'a> {
             let pfx = &rp.name.name;
             for i in 0..nread {
                 for s in &rp.signals {
-                    let dir = match s.direction { Direction::In => "input", Direction::Out => "output" };
+                    let dir = match s.direction {
+                        Direction::In => "input",
+                        Direction::Out => "output",
+                    };
                     let flat_name = if nread == 1 {
                         format!("{pfx}_{}", s.name.name)
                     } else {
                         format!("{pfx}{i}_{}", s.name.name)
                     };
-                    let port_str = self.emit_regfile_port_scalar(dir, &s.ty, &flat_name, addr_width, &data_width_num);
+                    let port_str = self.emit_regfile_port_scalar(
+                        dir,
+                        &s.ty,
+                        &flat_name,
+                        addr_width,
+                        &data_width_num,
+                    );
                     all_ports.push(port_str);
                 }
             }
@@ -92,13 +125,22 @@ impl<'a> Codegen<'a> {
             let pfx = &wp.name.name;
             for i in 0..nwrite {
                 for s in &wp.signals {
-                    let dir = match s.direction { Direction::In => "input", Direction::Out => "output" };
+                    let dir = match s.direction {
+                        Direction::In => "input",
+                        Direction::Out => "output",
+                    };
                     let flat_name = if nwrite == 1 {
                         format!("{pfx}_{}", s.name.name)
                     } else {
                         format!("{pfx}{i}_{}", s.name.name)
                     };
-                    let port_str = self.emit_regfile_port_scalar(dir, &s.ty, &flat_name, addr_width, &data_width_num);
+                    let port_str = self.emit_regfile_port_scalar(
+                        dir,
+                        &s.ty,
+                        &flat_name,
+                        addr_width,
+                        &data_width_num,
+                    );
                     all_ports.push(port_str);
                 }
             }
@@ -114,22 +156,39 @@ impl<'a> Codegen<'a> {
         self.indent += 1;
 
         // ── Register array ────────────────────────────────────────────────────
-        self.line(&format!("logic [{}] rf_data [0:NREGS-1];", Self::fold_width_str(&data_width_num)));
+        self.line(&format!(
+            "logic [{}] rf_data [0:NREGS-1];",
+            Self::fold_width_str(&data_width_num)
+        ));
         self.line("");
 
         // ── Determine read/write port signal names (flat) ─────────────────────
-        let write_pfx = r.write_ports.as_ref().map(|wp| wp.name.name.clone()).unwrap_or_else(|| "write".to_string());
-        let read_pfx  = r.read_ports.as_ref().map(|rp| rp.name.name.clone()).unwrap_or_else(|| "read".to_string());
+        let write_pfx = r
+            .write_ports
+            .as_ref()
+            .map(|wp| wp.name.name.clone())
+            .unwrap_or_else(|| "write".to_string());
+        let read_pfx = r
+            .read_ports
+            .as_ref()
+            .map(|rp| rp.name.name.clone())
+            .unwrap_or_else(|| "read".to_string());
 
         // Flat name helper: "{pfx}{i}_{sig}" when count>1, else "{pfx}_{sig}"
         let flat = |pfx: &str, i: u64, count: u64, sig: &str| -> String {
-            if count == 1 { format!("{pfx}_{sig}") } else { format!("{pfx}{i}_{sig}") }
+            if count == 1 {
+                format!("{pfx}_{sig}")
+            } else {
+                format!("{pfx}{i}_{sig}")
+            }
         };
 
         // ── Write storage ─────────────────────────────────────────────────────
         // Collect init-guarded addresses: init[k]=v means addr k is immutable
         // (implemented as a write guard), not as a reset.
-        let guarded_addrs: Vec<String> = r.inits.iter()
+        let guarded_addrs: Vec<String> = r
+            .inits
+            .iter()
             .map(|init| self.emit_expr_str(&init.index))
             .collect();
 
@@ -137,7 +196,7 @@ impl<'a> Codegen<'a> {
         // write decoding. Saves area / power on ASIC; FPGA tools will flag
         // this at mapping (intentional — ARCH is target-agnostic).
         if r.kind == crate::ast::RegfileKind::Latch {
-            let wen_in   = flat(&write_pfx, 0, nwrite, "en");
+            let wen_in = flat(&write_pfx, 0, nwrite, "en");
             let waddr_in = flat(&write_pfx, 0, nwrite, "addr");
             let wdata_in = flat(&write_pfx, 0, nwrite, "data");
 
@@ -168,20 +227,23 @@ impl<'a> Codegen<'a> {
                 self.indent -= 1;
                 self.line("end");
                 self.line("");
-                ("we_q".to_string(), "waddr_q".to_string(), "wdata_q".to_string())
+                (
+                    "we_q".to_string(),
+                    "waddr_q".to_string(),
+                    "wdata_q".to_string(),
+                )
             } else {
                 (wen_in, waddr_in, wdata_in)
             };
 
             for k in 0..nregs {
                 let k_lit = format!("{addr_width}'d{k}");
-                let init_for_k = r.inits.iter()
-                    .find_map(|init| match &init.index.kind {
-                        crate::ast::ExprKind::Literal(crate::ast::LitKind::Dec(v)) if *v == k => {
-                            Some(self.emit_expr_str(&init.value))
-                        }
-                        _ => None,
-                    });
+                let init_for_k = r.inits.iter().find_map(|init| match &init.index.kind {
+                    crate::ast::ExprKind::Literal(crate::ast::LitKind::Dec(v)) if *v == k => {
+                        Some(self.emit_expr_str(&init.value))
+                    }
+                    _ => None,
+                });
                 if let Some(val) = init_for_k {
                     // Address with `init[k]=v` is immutable — drive a constant.
                     self.line(&format!("assign rf_data[{k}] = {val};"));
@@ -192,7 +254,9 @@ impl<'a> Codegen<'a> {
                         // ICG-equivalent gating: latch transparent only during
                         // clk-low of the cycle after the sample, when we_q /
                         // waddr_q / wdata_q are stable.
-                        self.line(&format!("if (!{clk} && {wen_eff} && {waddr_eff} == {k_lit})"));
+                        self.line(&format!(
+                            "if (!{clk} && {wen_eff} && {waddr_eff} == {k_lit})"
+                        ));
                     } else {
                         self.line(&format!("if ({wen_eff} && {waddr_eff} == {k_lit})"));
                     }
@@ -205,65 +269,65 @@ impl<'a> Codegen<'a> {
             }
             self.line("");
         } else {
+            // Only include reset sensitivity when a reset port is actually present
+            // and there are reset-driven init entries. For register files that use
+            // write guards for x0 (not reset), emit plain posedge-only always_ff.
+            let has_reset_port = !rst.is_empty();
+            let use_reset = has_reset_port && r.inits.iter().any(|_| false); // reserved for future explicit reset-on-init
 
-        // Only include reset sensitivity when a reset port is actually present
-        // and there are reset-driven init entries. For register files that use
-        // write guards for x0 (not reset), emit plain posedge-only always_ff.
-        let has_reset_port = !rst.is_empty();
-        let use_reset = has_reset_port && r.inits.iter().any(|_| false); // reserved for future explicit reset-on-init
-
-        let ff_sens = if use_reset {
-            Self::ff_sensitivity(&clk, &rst, is_async, is_low)
-        } else {
-            format!("posedge {clk}")
-        };
-
-        self.line(&format!("always_ff @({ff_sens}) begin"));
-        self.indent += 1;
-
-        if use_reset {
-            let rst_cond = Self::rst_condition(&rst, is_low);
-            self.line(&format!("if ({rst_cond}) begin"));
-            self.indent += 1;
-            for init in &r.inits {
-                let idx = self.emit_expr_str(&init.index);
-                let val = self.emit_expr_str(&init.value);
-                self.line(&format!("rf_data[{idx}] <= {val};"));
-            }
-            self.indent -= 1;
-            self.line("end else begin");
-            self.indent += 1;
-        }
-
-        // Unroll write ports; add address guards for init[k] entries
-        for wi in 0..nwrite {
-            let wen   = flat(&write_pfx, wi, nwrite, "en");
-            let waddr = flat(&write_pfx, wi, nwrite, "addr");
-            let wdata = flat(&write_pfx, wi, nwrite, "data");
-            // Build guard: skip writes to any init-protected address
-            let addr_guards: Vec<String> = guarded_addrs.iter()
-                .map(|a| format!("{waddr} != {a}"))
-                .collect();
-            let guard = if addr_guards.is_empty() {
-                wen.clone()
+            let ff_sens = if use_reset {
+                Self::ff_sensitivity(&clk, &rst, is_async, is_low)
             } else {
-                format!("{wen} && {}", addr_guards.join(" && "))
+                format!("posedge {clk}")
             };
-            self.line(&format!("if ({guard})"));
-            self.indent += 1;
-            self.line(&format!("rf_data[{waddr}] <= {wdata};"));
-            self.indent -= 1;
-        }
 
-        if use_reset {
+            self.line(&format!("always_ff @({ff_sens}) begin"));
+            self.indent += 1;
+
+            if use_reset {
+                let rst_cond = Self::rst_condition(&rst, is_low);
+                self.line(&format!("if ({rst_cond}) begin"));
+                self.indent += 1;
+                for init in &r.inits {
+                    let idx = self.emit_expr_str(&init.index);
+                    let val = self.emit_expr_str(&init.value);
+                    self.line(&format!("rf_data[{idx}] <= {val};"));
+                }
+                self.indent -= 1;
+                self.line("end else begin");
+                self.indent += 1;
+            }
+
+            // Unroll write ports; add address guards for init[k] entries
+            for wi in 0..nwrite {
+                let wen = flat(&write_pfx, wi, nwrite, "en");
+                let waddr = flat(&write_pfx, wi, nwrite, "addr");
+                let wdata = flat(&write_pfx, wi, nwrite, "data");
+                // Build guard: skip writes to any init-protected address
+                let addr_guards: Vec<String> = guarded_addrs
+                    .iter()
+                    .map(|a| format!("{waddr} != {a}"))
+                    .collect();
+                let guard = if addr_guards.is_empty() {
+                    wen.clone()
+                } else {
+                    format!("{wen} && {}", addr_guards.join(" && "))
+                };
+                self.line(&format!("if ({guard})"));
+                self.indent += 1;
+                self.line(&format!("rf_data[{waddr}] <= {wdata};"));
+                self.indent -= 1;
+            }
+
+            if use_reset {
+                self.indent -= 1;
+                self.line("end");
+            }
+
             self.indent -= 1;
             self.line("end");
-        }
-
-        self.indent -= 1;
-        self.line("end");
-        self.line("");
-        }  // end flop branch (else of `kind == Latch`)
+            self.line("");
+        } // end flop branch (else of `kind == Latch`)
 
         // ── Read always_comb — unrolled per read port ─────────────────────────
         self.line("always_comb begin");
@@ -273,7 +337,7 @@ impl<'a> Codegen<'a> {
             let rdata = flat(&read_pfx, ri, nread, "data");
             if r.forward_write_before_read {
                 // Forward from the first write port (write port 0)
-                let wen   = flat(&write_pfx, 0, nwrite, "en");
+                let wen = flat(&write_pfx, 0, nwrite, "en");
                 let waddr = flat(&write_pfx, 0, nwrite, "addr");
                 let wdata = flat(&write_pfx, 0, nwrite, "data");
                 self.line(&format!("if ({wen} && {waddr} == {raddr})"));
@@ -292,8 +356,12 @@ impl<'a> Codegen<'a> {
         self.line("end");
 
         if !r.asserts.is_empty() {
-            let clk = r.ports.iter().find(|p| matches!(&p.ty, TypeExpr::Clock(_)))
-                .map(|p| p.name.name.clone()).unwrap_or_else(|| "clk".to_string());
+            let clk = r
+                .ports
+                .iter()
+                .find(|p| matches!(&p.ty, TypeExpr::Clock(_)))
+                .map(|p| p.name.name.clone())
+                .unwrap_or_else(|| "clk".to_string());
             self.line("");
             let asserts = r.asserts.clone();
             let rname = r.name.name.clone();
@@ -321,7 +389,9 @@ impl<'a> Codegen<'a> {
             TypeExpr::Named(id) if id.name == "WIDTH" || id.name == "DATA_WIDTH" => {
                 format!("logic [{}]", Self::fold_width_str(data_width))
             }
-            TypeExpr::Named(id) if id.name == "ADDR_WIDTH" || id.name.to_lowercase().contains("addr") => {
+            TypeExpr::Named(id)
+                if id.name == "ADDR_WIDTH" || id.name.to_lowercase().contains("addr") =>
+            {
                 format!("logic [{}:0]", addr_width - 1)
             }
             TypeExpr::UInt(w) => {

--- a/src/codegen/synchronizer.rs
+++ b/src/codegen/synchronizer.rs
@@ -8,14 +8,24 @@ impl<'a> Codegen<'a> {
         let n = &s.name.name;
 
         // Resolve STAGES (default 2)
-        let stages = s.params.iter()
+        let stages = s
+            .params
+            .iter()
             .find(|p| p.name.name == "STAGES")
             .and_then(|p| p.default.as_ref())
-            .and_then(|e| if let ExprKind::Literal(LitKind::Dec(v)) = &e.kind { Some(*v as usize) } else { None })
+            .and_then(|e| {
+                if let ExprKind::Literal(LitKind::Dec(v)) = &e.kind {
+                    Some(*v as usize)
+                } else {
+                    None
+                }
+            })
             .unwrap_or(2);
 
         // Find clock ports (first = source clock, second = destination clock)
-        let clk_ports: Vec<&PortDecl> = s.ports.iter()
+        let clk_ports: Vec<&PortDecl> = s
+            .ports
+            .iter()
             .filter(|p| matches!(&p.ty, TypeExpr::Clock(_)))
             .collect();
         let src_clk = &clk_ports[0].name.name;
@@ -26,17 +36,32 @@ impl<'a> Codegen<'a> {
         let data_ty = self.emit_port_type_str(&data_in_port.ty);
 
         // Check for reset port
-        let rst_port = s.ports.iter().find(|p| matches!(&p.ty, TypeExpr::Reset(..)));
+        let rst_port = s
+            .ports
+            .iter()
+            .find(|p| matches!(&p.ty, TypeExpr::Reset(..)));
 
         // Module header — emit all declared params as SV parameters
         self.line(&format!("module {n} #("));
         self.indent += 1;
-        let param_strs: Vec<String> = s.params.iter().map(|p| {
-            let val = p.default.as_ref()
-                .and_then(|e| if let ExprKind::Literal(LitKind::Dec(v)) = &e.kind { Some(v.to_string()) } else { None })
-                .unwrap_or_else(|| "0".to_string());
-            format!("parameter int {} = {}", p.name.name, val)
-        }).collect();
+        let param_strs: Vec<String> = s
+            .params
+            .iter()
+            .map(|p| {
+                let val = p
+                    .default
+                    .as_ref()
+                    .and_then(|e| {
+                        if let ExprKind::Literal(LitKind::Dec(v)) = &e.kind {
+                            Some(v.to_string())
+                        } else {
+                            None
+                        }
+                    })
+                    .unwrap_or_else(|| "0".to_string());
+                format!("parameter int {} = {}", p.name.name, val)
+            })
+            .collect();
         // Always include STAGES if not already declared
         let has_stages = s.params.iter().any(|p| p.name.name == "STAGES");
         let mut all_param_strs = param_strs;
@@ -44,18 +69,29 @@ impl<'a> Codegen<'a> {
             all_param_strs.push(format!("parameter int STAGES = {stages}"));
         }
         for (i, ps) in all_param_strs.iter().enumerate() {
-            let comma = if i < all_param_strs.len() - 1 { "," } else { "" };
+            let comma = if i < all_param_strs.len() - 1 {
+                ","
+            } else {
+                ""
+            };
             self.line(&format!("{ps}{comma}"));
         }
         self.indent -= 1;
         self.line(") (");
         self.indent += 1;
         // Emit ports
-        let port_strs: Vec<String> = s.ports.iter().map(|p| {
-            let dir = match p.direction { Direction::In => "input", Direction::Out => "output" };
-            let ty = self.emit_port_type_str(&p.ty);
-            format!("{dir} {ty} {}", p.name.name)
-        }).collect();
+        let port_strs: Vec<String> = s
+            .ports
+            .iter()
+            .map(|p| {
+                let dir = match p.direction {
+                    Direction::In => "input",
+                    Direction::Out => "output",
+                };
+                let ty = self.emit_port_type_str(&p.ty);
+                format!("{dir} {ty} {}", p.name.name)
+            })
+            .collect();
         for (i, ps) in port_strs.iter().enumerate() {
             let comma = if i < port_strs.len() - 1 { "," } else { "" };
             self.line(&format!("{ps}{comma}"));
@@ -68,7 +104,9 @@ impl<'a> Codegen<'a> {
         match s.kind {
             SyncKind::Ff => self.emit_sync_ff(dst_clk, &data_ty, rst_port, stages),
             SyncKind::Gray => self.emit_sync_gray(src_clk, dst_clk, &data_ty, rst_port, stages),
-            SyncKind::Handshake => self.emit_sync_handshake(src_clk, dst_clk, &data_ty, rst_port, stages),
+            SyncKind::Handshake => {
+                self.emit_sync_handshake(src_clk, dst_clk, &data_ty, rst_port, stages)
+            }
             SyncKind::Reset => self.emit_sync_reset(dst_clk, rst_port, stages),
             SyncKind::Pulse => self.emit_sync_pulse(src_clk, dst_clk, rst_port, stages),
         }
@@ -81,18 +119,29 @@ impl<'a> Codegen<'a> {
 
     // ── Synchronizer kind helpers ────────────────────────────────────────────
 
-    fn emit_sync_reset_begin(&mut self, dst_clk: &str, rst_port: Option<&PortDecl>) -> Option<String> {
+    fn emit_sync_reset_begin(
+        &mut self,
+        dst_clk: &str,
+        rst_port: Option<&PortDecl>,
+    ) -> Option<String> {
         if let Some(rp) = rst_port {
             let is_low = matches!(&rp.ty, TypeExpr::Reset(_, level) if *level == ResetLevel::Low);
-            let is_async = matches!(&rp.ty, TypeExpr::Reset(sync_type, _) if *sync_type == ResetKind::Async);
+            let is_async =
+                matches!(&rp.ty, TypeExpr::Reset(sync_type, _) if *sync_type == ResetKind::Async);
             let sensitivity = if is_async {
                 let edge = if is_low { "negedge" } else { "posedge" };
                 format!(" or {edge} {}", rp.name.name)
             } else {
                 String::new()
             };
-            self.line(&format!("always_ff @(posedge {dst_clk}{sensitivity}) begin"));
-            let cond = if is_low { format!("!{}", rp.name.name) } else { rp.name.name.clone() };
+            self.line(&format!(
+                "always_ff @(posedge {dst_clk}{sensitivity}) begin"
+            ));
+            let cond = if is_low {
+                format!("!{}", rp.name.name)
+            } else {
+                rp.name.name.clone()
+            };
             Some(cond)
         } else {
             self.line(&format!("always_ff @(posedge {dst_clk}) begin"));
@@ -100,8 +149,16 @@ impl<'a> Codegen<'a> {
         }
     }
 
-    fn emit_sync_ff(&mut self, dst_clk: &str, data_ty: &str, rst_port: Option<&PortDecl>, stages: usize) {
-        self.line(&format!("// {stages}-stage FF synchronizer chain (destination clock: {dst_clk})"));
+    fn emit_sync_ff(
+        &mut self,
+        dst_clk: &str,
+        data_ty: &str,
+        rst_port: Option<&PortDecl>,
+        stages: usize,
+    ) {
+        self.line(&format!(
+            "// {stages}-stage FF synchronizer chain (destination clock: {dst_clk})"
+        ));
         self.line(&format!("{data_ty} sync_chain [0:STAGES-1];"));
         self.line("");
 
@@ -127,8 +184,17 @@ impl<'a> Codegen<'a> {
         self.line("assign data_out = sync_chain[STAGES-1];");
     }
 
-    fn emit_sync_gray(&mut self, src_clk: &str, dst_clk: &str, data_ty: &str, rst_port: Option<&PortDecl>, stages: usize) {
-        self.line(&format!("// Gray-code synchronizer ({stages} stages, {src_clk} → {dst_clk})"));
+    fn emit_sync_gray(
+        &mut self,
+        src_clk: &str,
+        dst_clk: &str,
+        data_ty: &str,
+        rst_port: Option<&PortDecl>,
+        stages: usize,
+    ) {
+        self.line(&format!(
+            "// Gray-code synchronizer ({stages} stages, {src_clk} → {dst_clk})"
+        ));
         self.line(&format!("{data_ty} bin_to_gray;"));
         self.line(&format!("{data_ty} gray_chain [0:STAGES-1];"));
         self.line(&format!("{data_ty} gray_to_bin;"));
@@ -175,21 +241,43 @@ impl<'a> Codegen<'a> {
         self.line("assign data_out = gray_to_bin;");
     }
 
-    fn emit_sync_handshake(&mut self, src_clk: &str, dst_clk: &str, data_ty: &str, rst_port: Option<&PortDecl>, stages: usize) {
-        self.line(&format!("// Handshake synchronizer ({stages} stages, {src_clk} → {dst_clk})"));
+    fn emit_sync_handshake(
+        &mut self,
+        src_clk: &str,
+        dst_clk: &str,
+        data_ty: &str,
+        rst_port: Option<&PortDecl>,
+        stages: usize,
+    ) {
+        self.line(&format!(
+            "// Handshake synchronizer ({stages} stages, {src_clk} → {dst_clk})"
+        ));
         self.line(&format!("{data_ty} data_reg;"));
         self.line("logic req_src, ack_src;");
-        self.line(&format!("logic req_sync [0:STAGES-1];  // req synchronized to {dst_clk}"));
-        self.line(&format!("logic ack_sync [0:STAGES-1];  // ack synchronized to {src_clk}"));
+        self.line(&format!(
+            "logic req_sync [0:STAGES-1];  // req synchronized to {dst_clk}"
+        ));
+        self.line(&format!(
+            "logic ack_sync [0:STAGES-1];  // ack synchronized to {src_clk}"
+        ));
         self.line("logic ack_dst;");
         self.line("");
 
         let rst_name = rst_port.map(|rp| rp.name.name.as_str()).unwrap_or("1'b0");
-        let is_low = rst_port.map_or(false, |rp| matches!(&rp.ty, TypeExpr::Reset(_, level) if *level == ResetLevel::Low));
-        let rst_active = if is_low { format!("!{rst_name}") } else { rst_name.to_string() };
+        let is_low = rst_port.map_or(
+            false,
+            |rp| matches!(&rp.ty, TypeExpr::Reset(_, level) if *level == ResetLevel::Low),
+        );
+        let rst_active = if is_low {
+            format!("!{rst_name}")
+        } else {
+            rst_name.to_string()
+        };
 
         // Source domain: latch data and toggle req
-        self.line(&format!("// Source domain ({src_clk}): latch data, manage req/ack"));
+        self.line(&format!(
+            "// Source domain ({src_clk}): latch data, manage req/ack"
+        ));
         self.line(&format!("always_ff @(posedge {src_clk}) begin"));
         self.indent += 1;
         self.line(&format!("if ({rst_active}) begin"));
@@ -252,11 +340,15 @@ impl<'a> Codegen<'a> {
     fn emit_sync_reset(&mut self, dst_clk: &str, _rst_port: Option<&PortDecl>, _stages: usize) {
         // Reset synchronizer: data_in is the async reset input (active high).
         // Assert immediately (async), deassert through N-stage FF chain (sync to dst_clk).
-        self.line(&format!("// Reset synchronizer: async assert, sync deassert on {dst_clk}"));
+        self.line(&format!(
+            "// Reset synchronizer: async assert, sync deassert on {dst_clk}"
+        ));
         self.line("logic sync_chain [0:STAGES-1];");
         self.line("");
 
-        self.line(&format!("always_ff @(posedge {dst_clk} or posedge data_in) begin"));
+        self.line(&format!(
+            "always_ff @(posedge {dst_clk} or posedge data_in) begin"
+        ));
         self.indent += 1;
         self.line("if (data_in) begin");
         self.indent += 1;
@@ -274,10 +366,25 @@ impl<'a> Codegen<'a> {
         self.line("assign data_out = sync_chain[STAGES-1];");
     }
 
-    fn emit_sync_pulse(&mut self, src_clk: &str, dst_clk: &str, rst_port: Option<&PortDecl>, _stages: usize) {
+    fn emit_sync_pulse(
+        &mut self,
+        src_clk: &str,
+        dst_clk: &str,
+        rst_port: Option<&PortDecl>,
+        _stages: usize,
+    ) {
         let rst_name = rst_port.map(|rp| rp.name.name.as_str());
-        let is_low = rst_port.map_or(false, |rp| matches!(&rp.ty, TypeExpr::Reset(_, level) if *level == ResetLevel::Low));
-        let rst_cond = rst_name.map(|n| if is_low { format!("!{n}") } else { n.to_string() });
+        let is_low = rst_port.map_or(
+            false,
+            |rp| matches!(&rp.ty, TypeExpr::Reset(_, level) if *level == ResetLevel::Low),
+        );
+        let rst_cond = rst_name.map(|n| {
+            if is_low {
+                format!("!{n}")
+            } else {
+                n.to_string()
+            }
+        });
 
         self.line(&format!("// Pulse synchronizer: {src_clk} → {dst_clk}"));
         self.line("// Source: pulse → toggle; Destination: sync toggle → edge detect → pulse");

--- a/src/comb_graph.rs
+++ b/src/comb_graph.rs
@@ -4,12 +4,11 @@
 /// performs topological sorting, detects combinational feedback cycles
 /// (which are compile errors), and computes the minimum settle depth needed
 /// for the eval() settle loop.
-
 use std::collections::{HashMap, HashSet, VecDeque};
 
 use crate::ast::{
-    ConnectDir, Stmt, ExprKind, FsmDecl, InsideMember, InstDecl, Item,
-    ModuleBodyItem, ModuleDecl, PortDecl, RamDecl, SourceFile, TypeExpr,
+    ConnectDir, ExprKind, FsmDecl, InsideMember, InstDecl, Item, ModuleBodyItem, ModuleDecl,
+    PortDecl, RamDecl, SourceFile, Stmt, TypeExpr,
 };
 use crate::diagnostics::CompileError;
 use crate::resolve::{Symbol, SymbolTable};
@@ -73,7 +72,9 @@ fn collect_idents_impl(
     use ExprKind::*;
     let rec = |e: &crate::ast::Expr, out: &mut HashSet<String>| collect_idents_impl(e, bus, out);
     match &expr.kind {
-        Ident(name) => { out.insert(name.clone()); }
+        Ident(name) => {
+            out.insert(name.clone());
+        }
         Binary(_, a, b) => {
             rec(a, out);
             rec(b, out);
@@ -91,7 +92,9 @@ fn collect_idents_impl(
         }
         MethodCall(recv, _, args) => {
             rec(recv, out);
-            for a in args { rec(a, out); }
+            for a in args {
+                rec(a, out);
+            }
         }
         Cast(e, _) => rec(e, out),
         Index(base, idx) => {
@@ -109,13 +112,19 @@ fn collect_idents_impl(
             rec(width, out);
         }
         StructLiteral(_, fields) => {
-            for f in fields { rec(&f.value, out); }
+            for f in fields {
+                rec(&f.value, out);
+            }
         }
         Concat(exprs) => {
-            for e in exprs { rec(e, out); }
+            for e in exprs {
+                rec(e, out);
+            }
         }
         FunctionCall(_, args) => {
-            for a in args { rec(a, out); }
+            for a in args {
+                rec(a, out);
+            }
         }
         Repeat(e, n) => {
             rec(e, out);
@@ -130,8 +139,8 @@ fn collect_idents_impl(
             rec(e, out);
             for m in members {
                 match m {
-                    InsideMember::Single(x)    => rec(x, out),
-                    InsideMember::Range(a, b)  => {
+                    InsideMember::Single(x) => rec(x, out),
+                    InsideMember::Range(a, b) => {
                         rec(a, out);
                         rec(b, out);
                     }
@@ -141,7 +150,9 @@ fn collect_idents_impl(
         // Expression-level match: scrutinee + arm values
         ExprMatch(scrut, arms) => {
             rec(scrut, out);
-            for arm in arms { rec(&arm.value, out); }
+            for arm in arms {
+                rec(&arm.value, out);
+            }
         }
         // Statement-level match used as expression (rare): just the scrutinee
         Match(scrut, _) => rec(scrut, out),
@@ -162,14 +173,17 @@ fn lhs_base_name(expr: &crate::ast::Expr) -> Option<String> {
 /// `collect_expr_idents_bus` on the read side so the two never conflate into a
 /// single `s` node. See `collect_expr_idents_bus` for why per-member
 /// granularity is sound.
-fn lhs_base_name_bus(expr: &crate::ast::Expr, bus_ports: Option<&HashSet<String>>) -> Option<String> {
+fn lhs_base_name_bus(
+    expr: &crate::ast::Expr,
+    bus_ports: Option<&HashSet<String>>,
+) -> Option<String> {
     use ExprKind::*;
     match &expr.kind {
-        Ident(name)               => Some(name.clone()),
-        BitSlice(base, _, _)      => lhs_base_name_bus(base, bus_ports),
+        Ident(name) => Some(name.clone()),
+        BitSlice(base, _, _) => lhs_base_name_bus(base, bus_ports),
         PartSelect(base, _, _, _) => lhs_base_name_bus(base, bus_ports),
-        Index(base, _)            => lhs_base_name_bus(base, bus_ports),
-        FieldAccess(base, field)  => {
+        Index(base, _) => lhs_base_name_bus(base, bus_ports),
+        FieldAccess(base, field) => {
             if let (Some(bp), Ident(b)) = (bus_ports, &base.kind) {
                 if bp.contains(b) {
                     return Some(format!("{b}.{}", field.name));
@@ -177,7 +191,7 @@ fn lhs_base_name_bus(expr: &crate::ast::Expr, bus_ports: Option<&HashSet<String>
             }
             lhs_base_name_bus(base, bus_ports)
         }
-        _                         => None,
+        _ => None,
     }
 }
 
@@ -202,7 +216,9 @@ fn scan_comb_stmt(
             let mut rhs = HashSet::new();
             collect_expr_idents(&a.value, &mut rhs);
             for id in &rhs {
-                if input_names.contains(id) { read.insert(id.clone()); }
+                if input_names.contains(id) {
+                    read.insert(id.clone());
+                }
             }
         }
         Stmt::IfElse(ife) => {
@@ -210,17 +226,25 @@ fn scan_comb_stmt(
             let mut cond = HashSet::new();
             collect_expr_idents(&ife.cond, &mut cond);
             for id in &cond {
-                if input_names.contains(id) { read.insert(id.clone()); }
+                if input_names.contains(id) {
+                    read.insert(id.clone());
+                }
             }
-            for s in &ife.then_stmts { scan_comb_stmt(s, input_names, output_names, driven, read); }
-            for s in &ife.else_stmts { scan_comb_stmt(s, input_names, output_names, driven, read); }
+            for s in &ife.then_stmts {
+                scan_comb_stmt(s, input_names, output_names, driven, read);
+            }
+            for s in &ife.else_stmts {
+                scan_comb_stmt(s, input_names, output_names, driven, read);
+            }
         }
         Stmt::Match(m) => {
             // Scrutinee
             let mut scrut = HashSet::new();
             collect_expr_idents(&m.scrutinee, &mut scrut);
             for id in &scrut {
-                if input_names.contains(id) { read.insert(id.clone()); }
+                if input_names.contains(id) {
+                    read.insert(id.clone());
+                }
             }
             for arm in &m.arms {
                 for s in &arm.body {
@@ -233,7 +257,9 @@ fn scan_comb_stmt(
                 scan_comb_stmt(s, input_names, output_names, driven, read);
             }
         }
-            Stmt::Init(_) | Stmt::WaitUntil(..) | Stmt::DoUntil { .. } => unreachable!("seq-only Stmt variant inside comb-context walker"),
+        Stmt::Init(_) | Stmt::WaitUntil(..) | Stmt::DoUntil { .. } => {
+            unreachable!("seq-only Stmt variant inside comb-context walker")
+        }
         Stmt::Log(_) => {}
     }
 }
@@ -273,11 +299,13 @@ fn is_named_bus_type(ty: &TypeExpr, bus_names: &HashSet<String>) -> bool {
 
 fn port_sets(ports: &[PortDecl]) -> (HashSet<String>, HashSet<String>) {
     use crate::ast::Direction;
-    let inputs = ports.iter()
+    let inputs = ports
+        .iter()
         .filter(|p| p.direction == Direction::In && !is_clk_or_rst(&p.ty))
         .map(|p| p.name.name.clone())
         .collect();
-    let outputs = ports.iter()
+    let outputs = ports
+        .iter()
         .filter(|p| p.direction == Direction::Out)
         .map(|p| p.name.name.clone())
         .collect();
@@ -289,7 +317,7 @@ fn comb_info_for_fsm(fsm: &FsmDecl) -> CombInfo {
     use crate::ast::Direction;
     let (inputs, outputs) = port_sets(&fsm.ports);
     let mut driven = HashSet::new();
-    let mut read   = HashSet::new();
+    let mut read = HashSet::new();
 
     // FSM-scope let bindings: collect any input refs they use
     // (let bindings are comb intermediates; their idents propagate to outputs
@@ -298,7 +326,9 @@ fn comb_info_for_fsm(fsm: &FsmDecl) -> CombInfo {
         let mut ids = HashSet::new();
         collect_expr_idents(&lb.value, &mut ids);
         for id in &ids {
-            if inputs.contains(id) { read.insert(id.clone()); }
+            if inputs.contains(id) {
+                read.insert(id.clone());
+            }
         }
     }
 
@@ -308,8 +338,12 @@ fn comb_info_for_fsm(fsm: &FsmDecl) -> CombInfo {
     // and identifier reads in the default expression are real comb
     // deps. Issue #246 Phase 4.
     for p in &fsm.ports {
-        if p.direction != Direction::Out { continue; }
-        if p.reg_info.is_some() { continue; }
+        if p.direction != Direction::Out {
+            continue;
+        }
+        if p.reg_info.is_some() {
+            continue;
+        }
         if let Some(def_expr) = &p.default {
             if outputs.contains(&p.name.name) {
                 driven.insert(p.name.name.clone());
@@ -317,7 +351,9 @@ fn comb_info_for_fsm(fsm: &FsmDecl) -> CombInfo {
             let mut ids = HashSet::new();
             collect_expr_idents(def_expr, &mut ids);
             for id in &ids {
-                if inputs.contains(id) { read.insert(id.clone()); }
+                if inputs.contains(id) {
+                    read.insert(id.clone());
+                }
             }
         }
     }
@@ -333,19 +369,24 @@ fn comb_info_for_fsm(fsm: &FsmDecl) -> CombInfo {
             let mut ids = HashSet::new();
             collect_expr_idents(&tr.condition, &mut ids);
             for id in &ids {
-                if inputs.contains(id) { read.insert(id.clone()); }
+                if inputs.contains(id) {
+                    read.insert(id.clone());
+                }
             }
         }
     }
 
-    CombInfo { comb_outputs: driven, comb_dep_inputs: read }
+    CombInfo {
+        comb_outputs: driven,
+        comb_dep_inputs: read,
+    }
 }
 
 /// Compute CombInfo for a module declaration.
 fn comb_info_for_module(m: &ModuleDecl) -> CombInfo {
     let (inputs, outputs) = port_sets(&m.ports);
     let mut driven = HashSet::new();
-    let mut read   = HashSet::new();
+    let mut read = HashSet::new();
 
     for item in &m.body {
         match item {
@@ -357,7 +398,9 @@ fn comb_info_for_module(m: &ModuleDecl) -> CombInfo {
                 let mut ids = HashSet::new();
                 collect_expr_idents(&lb.value, &mut ids);
                 for id in &ids {
-                    if inputs.contains(id) { read.insert(id.clone()); }
+                    if inputs.contains(id) {
+                        read.insert(id.clone());
+                    }
                 }
                 // If the let name is an output port (unusual but possible), mark driven
                 if outputs.contains(&lb.name.name) {
@@ -368,7 +411,10 @@ fn comb_info_for_module(m: &ModuleDecl) -> CombInfo {
         }
     }
 
-    CombInfo { comb_outputs: driven, comb_dep_inputs: read }
+    CombInfo {
+        comb_outputs: driven,
+        comb_dep_inputs: read,
+    }
 }
 
 /// Per-output combinational dependencies for a module.
@@ -398,9 +444,13 @@ pub fn per_output_comb_deps(m: &ModuleDecl) -> HashMap<String, HashSet<String>> 
     let mut input_names: HashSet<String> = HashSet::new();
     let mut output_names: HashSet<String> = HashSet::new();
     for p in &m.ports {
-        if is_clk_or_rst(&p.ty) { continue; }
+        if is_clk_or_rst(&p.ty) {
+            continue;
+        }
         match p.direction {
-            Direction::In  => { input_names.insert(p.name.name.clone()); }
+            Direction::In => {
+                input_names.insert(p.name.name.clone());
+            }
             Direction::Out => {
                 // Skip registered outputs — they're flopped, not comb.
                 if p.reg_info.is_none() {
@@ -422,9 +472,7 @@ pub fn per_output_comb_deps(m: &ModuleDecl) -> HashMap<String, HashSet<String>> 
             ModuleBodyItem::LetBinding(lb) => {
                 let mut ids = HashSet::new();
                 collect_expr_idents(&lb.value, &mut ids);
-                direct.entry(lb.name.name.clone())
-                    .or_default()
-                    .extend(ids);
+                direct.entry(lb.name.name.clone()).or_default().extend(ids);
             }
             _ => {}
         }
@@ -450,7 +498,9 @@ pub fn per_output_comb_deps(m: &ModuleDecl) -> HashMap<String, HashSet<String>> 
         let mut visited: HashSet<String> = HashSet::new();
         let mut stack: Vec<String> = vec![out_name.clone()];
         while let Some(cur) = stack.pop() {
-            if !visited.insert(cur.clone()) { continue; }
+            if !visited.insert(cur.clone()) {
+                continue;
+            }
             if let Some(rhs_ids) = direct.get(&cur) {
                 for id in rhs_ids {
                     if input_names.contains(id) {
@@ -497,9 +547,13 @@ pub fn per_output_comb_deps_fsm(fsm: &FsmDecl) -> HashMap<String, HashSet<String
     let mut input_names: HashSet<String> = HashSet::new();
     let mut output_names: HashSet<String> = HashSet::new();
     for p in &fsm.ports {
-        if is_clk_or_rst(&p.ty) { continue; }
+        if is_clk_or_rst(&p.ty) {
+            continue;
+        }
         match p.direction {
-            Direction::In  => { input_names.insert(p.name.name.clone()); }
+            Direction::In => {
+                input_names.insert(p.name.name.clone());
+            }
             Direction::Out => {
                 if p.reg_info.is_none() {
                     output_names.insert(p.name.name.clone());
@@ -517,23 +571,23 @@ pub fn per_output_comb_deps_fsm(fsm: &FsmDecl) -> HashMap<String, HashSet<String
     for lb in &fsm.lets {
         let mut ids = HashSet::new();
         collect_expr_idents(&lb.value, &mut ids);
-        direct.entry(lb.name.name.clone())
-            .or_default()
-            .extend(ids);
+        direct.entry(lb.name.name.clone()).or_default().extend(ids);
     }
 
     // 2b. Output port defaults — emitted by `codegen::fsm` as the
     //     comb-block default before the state case, so their identifier
     //     reads ARE real comb deps for the output.
     for p in &fsm.ports {
-        if p.direction != Direction::Out { continue; }
-        if p.reg_info.is_some() { continue; }
+        if p.direction != Direction::Out {
+            continue;
+        }
+        if p.reg_info.is_some() {
+            continue;
+        }
         if let Some(def_expr) = &p.default {
             let mut ids = HashSet::new();
             collect_expr_idents(def_expr, &mut ids);
-            direct.entry(p.name.name.clone())
-                .or_default()
-                .extend(ids);
+            direct.entry(p.name.name.clone()).or_default().extend(ids);
         }
     }
 
@@ -559,7 +613,9 @@ pub fn per_output_comb_deps_fsm(fsm: &FsmDecl) -> HashMap<String, HashSet<String
         let mut visited: HashSet<String> = HashSet::new();
         let mut stack: Vec<String> = vec![out_name.clone()];
         while let Some(cur) = stack.pop() {
-            if !visited.insert(cur.clone()) { continue; }
+            if !visited.insert(cur.clone()) {
+                continue;
+            }
             if let Some(rhs_ids) = direct.get(&cur) {
                 for id in rhs_ids {
                     if input_names.contains(id) {
@@ -638,7 +694,9 @@ pub fn collect_comb_deps(
                 // LHS index/slice expressions also read identifiers.
                 collect_lhs_index_reads(&a.target, &mut rhs);
                 for conds in cond_stack.iter() {
-                    for id in conds { rhs.insert(id.clone()); }
+                    for id in conds {
+                        rhs.insert(id.clone());
+                    }
                 }
                 direct.entry(lhs).or_default().extend(rhs);
             }
@@ -679,7 +737,10 @@ fn comb_info_for_ram(ram: &RamDecl) -> CombInfo {
         // In practice async RAMs rarely appear in cycles, and the cycle
         // detection will catch it if they do.
         let (inputs, outputs) = port_sets(&ram.ports);
-        CombInfo { comb_outputs: outputs, comb_dep_inputs: inputs }
+        CombInfo {
+            comb_outputs: outputs,
+            comb_dep_inputs: inputs,
+        }
     } else {
         CombInfo::default()
     }
@@ -749,7 +810,11 @@ fn construct_comb_info_is_sound(sym: &Symbol) -> bool {
 }
 
 /// Look up the `CombInfo` for an instance whose construct is named `sym_name`.
-pub fn comb_info_for_symbol(sym_name: &str, symbols: &SymbolTable, source: &SourceFile) -> CombInfo {
+pub fn comb_info_for_symbol(
+    sym_name: &str,
+    symbols: &SymbolTable,
+    source: &SourceFile,
+) -> CombInfo {
     let sym = match symbols.globals.get(sym_name) {
         Some((s, _)) => s,
         None => return CombInfo::default(),
@@ -803,10 +868,9 @@ pub fn comb_info_for_symbol(sym_name: &str, symbols: &SymbolTable, source: &Sour
         // Every output is a pure function of internal flopped state, so there
         // is no combinational input→output edge. These are the constructs for
         // which `construct_comb_info_is_sound` returns `true`.
-        Symbol::Fifo(_)
-        | Symbol::Counter(_)
-        | Symbol::Synchronizer(_)
-        | Symbol::Pipeline(_) => CombInfo::default(),
+        Symbol::Fifo(_) | Symbol::Counter(_) | Symbol::Synchronizer(_) | Symbol::Pipeline(_) => {
+            CombInfo::default()
+        }
 
         // ── Real (or possible) comb in→out path we do NOT precisely model ──
         // The empty `CombInfo` returned here is OPTIMISTIC, not sound. Any
@@ -853,9 +917,10 @@ pub fn comb_info_for_symbol(sym_name: &str, symbols: &SymbolTable, source: &Sour
 /// intermediate signals (those may feed instance inputs and require 2 settle
 /// passes if the parent eval_comb() runs AFTER the instance loop).
 fn parent_has_comb_intermediates(m: &ModuleDecl) -> bool {
-    m.body.iter().any(|item| matches!(
-        item,
-        ModuleBodyItem::CombBlock(_) | ModuleBodyItem::LetBinding(_)
+    m.body.iter().any(|item| {
+        matches!(
+            item,
+            ModuleBodyItem::CombBlock(_) | ModuleBodyItem::LetBinding(_)
         // Bus wires (scalar `wire w: B;` or `wire w: Vec<B, N>;`) act as
         // comb intermediates carrying instance outputs to instance
         // inputs across the parent body. The instance-edge graph above
@@ -865,15 +930,23 @@ fn parent_has_comb_intermediates(m: &ModuleDecl) -> bool {
         // through such wires. Bumping settle_depth = 2 covers the case
         // conservatively until the dep tracker handles indexed signals.
         | ModuleBodyItem::WireDecl(_)
-    ))
+        )
+    })
 }
 
 /// Collect all direct `inst` declarations from a module body (not generate
 /// blocks — those are already expanded by the elaborate pass before sim
 /// codegen runs).
 pub fn collect_insts(m: &ModuleDecl) -> Vec<&InstDecl> {
-    m.body.iter()
-        .filter_map(|i| if let ModuleBodyItem::Inst(inst) = i { Some(inst) } else { None })
+    m.body
+        .iter()
+        .filter_map(|i| {
+            if let ModuleBodyItem::Inst(inst) = i {
+                Some(inst)
+            } else {
+                None
+            }
+        })
         .collect()
 }
 
@@ -901,7 +974,8 @@ pub fn analyze_module(
     }
 
     // ── Step 1: collect CombInfo for each instance ────────────────────────
-    let infos: Vec<CombInfo> = insts.iter()
+    let infos: Vec<CombInfo> = insts
+        .iter()
         .map(|inst| comb_info_for_symbol(&inst.module_name.name, symbols, source))
         .collect();
 
@@ -927,11 +1001,15 @@ pub fn analyze_module(
 
     for (i, inst) in insts.iter().enumerate() {
         for conn in &inst.connections {
-            if conn.direction != ConnectDir::Input { continue; }
+            if conn.direction != ConnectDir::Input {
+                continue;
+            }
 
             let port_name = &conn.port_name.name;
             // Only create an edge if instance i has a comb dep on this input port.
-            if !infos[i].comb_dep_inputs.contains(port_name) { continue; }
+            if !infos[i].comb_dep_inputs.contains(port_name) {
+                continue;
+            }
 
             // Identify the signal driving this input.
             let wire_name = match &conn.signal.kind {
@@ -945,10 +1023,14 @@ pub fn analyze_module(
                 None => continue, // driven by parent reg/port, not an instance
             };
 
-            if j == i { continue; } // self-loop — not meaningful
+            if j == i {
+                continue;
+            } // self-loop — not meaningful
 
             // Only add edge if j's port is a comb output (not registered).
-            if !infos[j].comb_outputs.contains(out_port) { continue; }
+            if !infos[j].comb_outputs.contains(out_port) {
+                continue;
+            }
 
             // Avoid duplicate edges
             if !adj[j].contains(&i) {
@@ -1005,9 +1087,16 @@ pub fn analyze_module(
     // that produce intermediate signals used as instance inputs, those
     // intermediates are only updated at the end of the loop (parent eval_comb).
     // In that case we need 2 passes so the second pass sees fresh values.
-    let settle_depth = if parent_has_comb_intermediates(m) { 2 } else { 1 };
+    let settle_depth = if parent_has_comb_intermediates(m) {
+        2
+    } else {
+        1
+    };
 
-    Ok(ModuleAnalysis { sorted_inst_indices: sorted, settle_depth })
+    Ok(ModuleAnalysis {
+        sorted_inst_indices: sorted,
+        settle_depth,
+    })
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -1091,10 +1180,7 @@ pub struct WholeDesignAnalysis {
 /// 3. Run Tarjan's SCC.
 /// 4. Tag each non-trivial SCC with the set of owning-parent paths;
 ///    classify as suppressed if any owning module has the pragma.
-pub fn analyze_whole_design(
-    source: &SourceFile,
-    symbols: &SymbolTable,
-) -> WholeDesignAnalysis {
+pub fn analyze_whole_design(source: &SourceFile, symbols: &SymbolTable) -> WholeDesignAnalysis {
     // ── Step 1: collect inst counts to find top-level modules ─────────────
     let mut inst_count: HashMap<String, usize> = HashMap::new();
     let mut module_by_name: HashMap<&str, &ModuleDecl> = HashMap::new();
@@ -1134,8 +1220,7 @@ pub fn analyze_whole_design(
     let mut total = 0usize;
     for scc in sccs_raw {
         // Filter: size > 1 OR (size == 1 with self-loop)
-        let is_cycle = scc.len() > 1
-            || (scc.len() == 1 && builder.adj[scc[0]].contains(&scc[0]));
+        let is_cycle = scc.len() > 1 || (scc.len() == 1 && builder.adj[scc[0]].contains(&scc[0]));
         if !is_cycle {
             continue;
         }
@@ -1153,16 +1238,21 @@ pub fn analyze_whole_design(
             nodes.push(key);
         }
         // Suppression: any owning module has `pragma comb_loops_allowed;`.
-        let blessed = owning_modules
-            .iter()
-            .any(|mn| module_by_name.get(mn.as_str())
+        let blessed = owning_modules.iter().any(|mn| {
+            module_by_name
+                .get(mn.as_str())
                 .map(|m| m.comb_loops_allowed)
-                .unwrap_or(false));
+                .unwrap_or(false)
+        });
         if blessed {
             suppressed += 1;
             continue;
         }
-        out_sccs.push(CombScc { nodes, owning_paths, owning_modules });
+        out_sccs.push(CombScc {
+            nodes,
+            owning_paths,
+            owning_modules,
+        });
     }
 
     WholeDesignAnalysis {
@@ -1251,7 +1341,10 @@ impl GraphBuilder {
 
         // Helper to make a node at the current path.
         let mk = |gb: &mut GraphBuilder, name: &str| -> usize {
-            gb.intern(NodeKey { path: path.clone(), signal: name.to_string() })
+            gb.intern(NodeKey {
+                path: path.clone(),
+                signal: name.to_string(),
+            })
         };
 
         // Ensure all port/wire/let/reg/inst-output names exist as nodes.
@@ -1260,7 +1353,9 @@ impl GraphBuilder {
         // node — harmless for SCC).
         for p in &m.ports {
             // Skip clock/reset — they participate only in seq logic.
-            if is_clk_or_rst(&p.ty) { continue; }
+            if is_clk_or_rst(&p.ty) {
+                continue;
+            }
             mk(self, &p.name.name);
         }
 
@@ -1277,7 +1372,9 @@ impl GraphBuilder {
         // individual fields in generated comb logic; treating the whole wire as
         // one node fabricates a cycle between request and response fields.
         let bus_type_names = bus_type_names(source);
-        let mut bus_values: HashSet<String> = m.ports.iter()
+        let mut bus_values: HashSet<String> = m
+            .ports
+            .iter()
             .filter(|p| p.bus_info.is_some() || is_named_bus_type(&p.ty, &bus_type_names))
             .map(|p| p.name.name.clone())
             .collect();
@@ -1290,7 +1387,9 @@ impl GraphBuilder {
         }
         for item in &m.body {
             match item {
-                ModuleBodyItem::WireDecl(w) => { mk(self, &w.name.name); }
+                ModuleBodyItem::WireDecl(w) => {
+                    mk(self, &w.name.name);
+                }
                 ModuleBodyItem::RegDecl(_) => {
                     // Regs are seq-driven; skip — they break comb cycles.
                 }
@@ -1371,7 +1470,7 @@ impl GraphBuilder {
 
         // Map each connection's port-name → parent signal name (if a bare ident).
         // Direction is "from the parent's perspective" via ConnectDir.
-        let mut input_conn: HashMap<String, String> = HashMap::new();  // port → parent signal (signal feeds INTO inst)
+        let mut input_conn: HashMap<String, String> = HashMap::new(); // port → parent signal (signal feeds INTO inst)
         let mut output_conn: HashMap<String, String> = HashMap::new(); // port → parent signal (inst drives this signal)
         for conn in &inst.connections {
             let parent_sig = match &conn.signal.kind {
@@ -1379,8 +1478,12 @@ impl GraphBuilder {
                 _ => continue, // complex connection expression — skip
             };
             match conn.direction {
-                ConnectDir::Input  => { input_conn.insert(conn.port_name.name.clone(), parent_sig); }
-                ConnectDir::Output => { output_conn.insert(conn.port_name.name.clone(), parent_sig); }
+                ConnectDir::Input => {
+                    input_conn.insert(conn.port_name.name.clone(), parent_sig);
+                }
+                ConnectDir::Output => {
+                    output_conn.insert(conn.port_name.name.clone(), parent_sig);
+                }
             }
         }
 
@@ -1429,7 +1532,9 @@ impl GraphBuilder {
         // over-approximation and matches the pre-#545 behavior for them.
         let symbol_is_known_construct = child_mod.is_none()
             && child_fsm.is_none()
-            && symbols.globals.get(&inst.module_name.name)
+            && symbols
+                .globals
+                .get(&inst.module_name.name)
                 .map(|(sym, _)| construct_comb_info_is_sound(sym))
                 .unwrap_or(false);
 
@@ -1508,10 +1613,13 @@ impl GraphBuilder {
         // (defensive: comb_info_for_module already excludes them, but make
         // the rule explicit so future regressions don't leak in).
         let registered_outs: HashSet<&str> = child_ports
-            .map(|ports| ports.iter()
-                .filter(|p| p.reg_info.is_some())
-                .map(|p| p.name.name.as_str())
-                .collect())
+            .map(|ports| {
+                ports
+                    .iter()
+                    .filter(|p| p.reg_info.is_some())
+                    .map(|p| p.name.name.as_str())
+                    .collect()
+            })
             .unwrap_or_default();
 
         // Per-output comb-dep map. Two precision sources, both produce the
@@ -1541,56 +1649,61 @@ impl GraphBuilder {
         //   every non-registered output port so this fallback rarely
         //   triggers, but we keep it explicit so a future walker change
         //   degrades gracefully rather than silently dropping edges.
-        let per_output_deps: HashMap<String, Option<HashSet<String>>> =
-            if treat_as_opaque {
-                // Opaque branch (extern stub or `is_interface` declaration):
-                // precision comes from port-level `comb_dep_on(...)`
-                // annotations. Works uniformly for module + fsm shapes.
-                child_ports
-                    .map(|ports| ports.iter()
-                        .filter(|p| p.direction == crate::ast::Direction::Out
-                                    && p.reg_info.is_none())
+        let per_output_deps: HashMap<String, Option<HashSet<String>>> = if treat_as_opaque {
+            // Opaque branch (extern stub or `is_interface` declaration):
+            // precision comes from port-level `comb_dep_on(...)`
+            // annotations. Works uniformly for module + fsm shapes.
+            child_ports
+                .map(|ports| {
+                    ports
+                        .iter()
+                        .filter(|p| {
+                            p.direction == crate::ast::Direction::Out && p.reg_info.is_none()
+                        })
                         .map(|p| {
-                            let set = p.comb_deps.as_ref().map(|v|
-                                v.iter().map(|i| i.name.clone())
-                                    .collect::<HashSet<String>>());
+                            let set = p.comb_deps.as_ref().map(|v| {
+                                v.iter()
+                                    .map(|i| i.name.clone())
+                                    .collect::<HashSet<String>>()
+                            });
                             (p.name.name.clone(), set)
                         })
-                        .collect())
-                    .unwrap_or_default()
-            } else if let Some(cm) = child_mod {
-                // Bodied module — Phase 3.
-                let map = self.per_output_for(cm);
-                let mut out: HashMap<String, Option<HashSet<String>>> =
-                    HashMap::with_capacity(map.len());
-                for (k, v) in map {
-                    out.insert(k.clone(), Some(v.clone()));
-                }
-                // Option C: any aggregate-driven output missing from the
-                // per-output map falls back to opaque (every input). Will
-                // virtually never trigger given `per_output_comb_deps`'s
-                // current "always emit an entry per non-registered output"
-                // contract, but cheap to encode defensively.
-                for o in &info.comb_outputs {
-                    out.entry(o.clone()).or_insert(None);
-                }
-                out
-            } else if let Some(cf) = child_fsm {
-                // Bodied FSM — Phase 4. Same Option C fallback policy
-                // as the bodied-module branch.
-                let map = self.per_output_for_fsm(cf);
-                let mut out: HashMap<String, Option<HashSet<String>>> =
-                    HashMap::with_capacity(map.len());
-                for (k, v) in map {
-                    out.insert(k.clone(), Some(v.clone()));
-                }
-                for o in &info.comb_outputs {
-                    out.entry(o.clone()).or_insert(None);
-                }
-                out
-            } else {
-                HashMap::new()
-            };
+                        .collect()
+                })
+                .unwrap_or_default()
+        } else if let Some(cm) = child_mod {
+            // Bodied module — Phase 3.
+            let map = self.per_output_for(cm);
+            let mut out: HashMap<String, Option<HashSet<String>>> =
+                HashMap::with_capacity(map.len());
+            for (k, v) in map {
+                out.insert(k.clone(), Some(v.clone()));
+            }
+            // Option C: any aggregate-driven output missing from the
+            // per-output map falls back to opaque (every input). Will
+            // virtually never trigger given `per_output_comb_deps`'s
+            // current "always emit an entry per non-registered output"
+            // contract, but cheap to encode defensively.
+            for o in &info.comb_outputs {
+                out.entry(o.clone()).or_insert(None);
+            }
+            out
+        } else if let Some(cf) = child_fsm {
+            // Bodied FSM — Phase 4. Same Option C fallback policy
+            // as the bodied-module branch.
+            let map = self.per_output_for_fsm(cf);
+            let mut out: HashMap<String, Option<HashSet<String>>> =
+                HashMap::with_capacity(map.len());
+            for (k, v) in map {
+                out.insert(k.clone(), Some(v.clone()));
+            }
+            for o in &info.comb_outputs {
+                out.entry(o.clone()).or_insert(None);
+            }
+            out
+        } else {
+            HashMap::new()
+        };
 
         let comb_outs: Vec<&String> = if treat_as_opaque {
             // Opaque: every declared output port that's connected AND not
@@ -1599,11 +1712,13 @@ impl GraphBuilder {
             // edge becomes a phantom comb-dep that closes false cycles
             // through any module that exposes registered outputs (e.g.
             // arch-ibex's IbexCore decoded fields, IbexIdStage outputs).
-            output_conn.keys()
+            output_conn
+                .keys()
                 .filter(|k| !registered_outs.contains(k.as_str()))
                 .collect()
         } else {
-            info.comb_outputs.iter()
+            info.comb_outputs
+                .iter()
                 .filter(|k| !registered_outs.contains(k.as_str()))
                 .collect()
         };
@@ -1619,13 +1734,19 @@ impl GraphBuilder {
                 None => continue,
             };
             // Parent-side node receiving the inst's output.
-            let to = self.intern(NodeKey { path: parent_path.clone(), signal: out_sig });
+            let to = self.intern(NodeKey {
+                path: parent_path.clone(),
+                signal: out_sig,
+            });
 
             // Also: if we DID recurse, link the deeper inst-internal output port
             // node to the parent-side wire so cycles that close via the
             // hierarchy show the full path. We add edge child.q → parent.out_sig.
             if recursed_into_body {
-                let child_q = self.intern(NodeKey { path: child_path.clone(), signal: (*out_port).clone() });
+                let child_q = self.intern(NodeKey {
+                    path: child_path.clone(),
+                    signal: (*out_port).clone(),
+                });
                 self.add_edge(child_q, to);
             }
 
@@ -1642,13 +1763,18 @@ impl GraphBuilder {
 
             for in_port in &comb_ins {
                 if let Some(allow) = precise_deps {
-                    if !allow.contains(in_port.as_str()) { continue; }
+                    if !allow.contains(in_port.as_str()) {
+                        continue;
+                    }
                 }
                 let in_sig = match input_conn.get(in_port.as_str()) {
                     Some(s) => s.clone(),
                     None => continue,
                 };
-                let from = self.intern(NodeKey { path: parent_path.clone(), signal: in_sig });
+                let from = self.intern(NodeKey {
+                    path: parent_path.clone(),
+                    signal: in_sig,
+                });
 
                 // Direct over-approximation edge in_sig → out_sig at parent level.
                 // (Captures the loop even when we don't recurse into the child.)
@@ -1657,7 +1783,10 @@ impl GraphBuilder {
                 // And, if we recursed, also link parent.in_sig → child.in_port
                 // so the cycle path display shows the descent.
                 if recursed_into_body {
-                    let child_p = self.intern(NodeKey { path: child_path.clone(), signal: (*in_port).clone() });
+                    let child_p = self.intern(NodeKey {
+                        path: child_path.clone(),
+                        signal: (*in_port).clone(),
+                    });
                     self.add_edge(from, child_p);
                 }
             }
@@ -1666,12 +1795,7 @@ impl GraphBuilder {
 
     /// Walk a comb-block's statements and add edges from RHS identifiers to
     /// LHS base names. Conditions count as reads of every then/else target.
-    fn scan_assignments(
-        &mut self,
-        stmts: &[Stmt],
-        path: &InstPath,
-        bus_ports: &HashSet<String>,
-    ) {
+    fn scan_assignments(&mut self, stmts: &[Stmt], path: &InstPath, bus_ports: &HashSet<String>) {
         let mut cond_stack: Vec<HashSet<String>> = Vec::new();
         self.scan_assignments_inner(stmts, path, bus_ports, &mut cond_stack);
     }
@@ -1788,9 +1912,14 @@ fn tarjan_scc(adj: &[Vec<usize>], n: usize) -> Vec<Vec<usize>> {
     let mut call_stack: Vec<Frame> = Vec::new();
 
     for v_start in 0..n {
-        if index_of[v_start] != -1 { continue; }
+        if index_of[v_start] != -1 {
+            continue;
+        }
         // Push initial frame
-        call_stack.push(Frame { v: v_start, iter_pos: 0 });
+        call_stack.push(Frame {
+            v: v_start,
+            iter_pos: 0,
+        });
         index_of[v_start] = index;
         lowlink[v_start] = index;
         index += 1;
@@ -1824,7 +1953,9 @@ fn tarjan_scc(adj: &[Vec<usize>], n: usize) -> Vec<Vec<usize>> {
                         let w = stack.pop().expect("tarjan stack underflow");
                         on_stack[w] = false;
                         comp.push(w);
-                        if w == v { break; }
+                        if w == v {
+                            break;
+                        }
                     }
                     sccs.push(comp);
                 }
@@ -1841,7 +1972,6 @@ fn tarjan_scc(adj: &[Vec<usize>], n: usize) -> Vec<Vec<usize>> {
 
     sccs
 }
-
 
 #[cfg(test)]
 mod soundness_classification_tests {
@@ -1870,27 +2000,34 @@ mod soundness_classification_tests {
             is_async: true,
         })));
         assert!(construct_comb_info_is_sound(&Symbol::Synchronizer(
-            SynchronizerInfo { name: "S".into(), stages: 2 }
+            SynchronizerInfo {
+                name: "S".into(),
+                stages: 2
+            }
         )));
-        assert!(construct_comb_info_is_sound(&Symbol::Pipeline(PipelineInfo {
-            name: "P".into(),
-            params: vec![],
-            ports: vec![],
-            stage_names: vec![],
-        })));
+        assert!(construct_comb_info_is_sound(&Symbol::Pipeline(
+            PipelineInfo {
+                name: "P".into(),
+                params: vec![],
+                ports: vec![],
+                stage_names: vec![],
+            }
+        )));
 
         // UNSOUND — a real comb input→output path reported as empty CombInfo;
         // must be over-approximated opaque. Do NOT move these to the sound set.
-        assert!(!construct_comb_info_is_sound(&Symbol::Arbiter(ArbiterInfo {
-            name: "A".into(),
-            num_req: 2,
-        })));
+        assert!(!construct_comb_info_is_sound(&Symbol::Arbiter(
+            ArbiterInfo {
+                name: "A".into(),
+                num_req: 2,
+            }
+        )));
         assert!(!construct_comb_info_is_sound(&Symbol::Cam(CamInfo {
             name: "C".into()
         })));
-        assert!(!construct_comb_info_is_sound(&Symbol::Regfile(RegfileInfo {
-            name: "R".into()
-        })));
+        assert!(!construct_comb_info_is_sound(&Symbol::Regfile(
+            RegfileInfo { name: "R".into() }
+        )));
 
         // Not instantiable as a construct → opaque (never reaches the gate).
         assert!(!construct_comb_info_is_sound(&Symbol::Param("x".into())));

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -186,30 +186,74 @@ impl CompileError {
             SourceSpan::new(new_offset.into(), span.len().into())
         }
         match self {
-            CompileError::UnexpectedToken { expected, found, span } =>
-                CompileError::UnexpectedToken { expected, found, span: respan(span, new_offset) },
-            CompileError::MismatchedClosingName { expected, found, span } =>
-                CompileError::MismatchedClosingName { expected, found, span: respan(span, new_offset) },
-            CompileError::UndefinedName { name, span } =>
-                CompileError::UndefinedName { name, span: respan(span, new_offset) },
-            CompileError::UndefinedModule { name, hint, span } =>
-                CompileError::UndefinedModule { name, hint, span: respan(span, new_offset) },
-            CompileError::DuplicateDefinition { name, span } =>
-                CompileError::DuplicateDefinition { name, span: respan(span, new_offset) },
-            CompileError::TypeMismatch { expected, found, span } =>
-                CompileError::TypeMismatch { expected, found, span: respan(span, new_offset) },
-            CompileError::WidthMismatch { target_width, value_width, span } =>
-                CompileError::WidthMismatch { target_width, value_width, span: respan(span, new_offset) },
-            CompileError::MultipleDrivers { name, span } =>
-                CompileError::MultipleDrivers { name, span: respan(span, new_offset) },
-            CompileError::UndriveOutput { name, span } =>
-                CompileError::UndriveOutput { name, span: respan(span, new_offset) },
-            CompileError::NamingViolation { message, span } =>
-                CompileError::NamingViolation { message, span: respan(span, new_offset) },
-            CompileError::LexerError { span } =>
-                CompileError::LexerError { span: respan(span, new_offset) },
-            CompileError::General { message, span } =>
-                CompileError::General { message, span: respan(span, new_offset) },
+            CompileError::UnexpectedToken {
+                expected,
+                found,
+                span,
+            } => CompileError::UnexpectedToken {
+                expected,
+                found,
+                span: respan(span, new_offset),
+            },
+            CompileError::MismatchedClosingName {
+                expected,
+                found,
+                span,
+            } => CompileError::MismatchedClosingName {
+                expected,
+                found,
+                span: respan(span, new_offset),
+            },
+            CompileError::UndefinedName { name, span } => CompileError::UndefinedName {
+                name,
+                span: respan(span, new_offset),
+            },
+            CompileError::UndefinedModule { name, hint, span } => CompileError::UndefinedModule {
+                name,
+                hint,
+                span: respan(span, new_offset),
+            },
+            CompileError::DuplicateDefinition { name, span } => CompileError::DuplicateDefinition {
+                name,
+                span: respan(span, new_offset),
+            },
+            CompileError::TypeMismatch {
+                expected,
+                found,
+                span,
+            } => CompileError::TypeMismatch {
+                expected,
+                found,
+                span: respan(span, new_offset),
+            },
+            CompileError::WidthMismatch {
+                target_width,
+                value_width,
+                span,
+            } => CompileError::WidthMismatch {
+                target_width,
+                value_width,
+                span: respan(span, new_offset),
+            },
+            CompileError::MultipleDrivers { name, span } => CompileError::MultipleDrivers {
+                name,
+                span: respan(span, new_offset),
+            },
+            CompileError::UndriveOutput { name, span } => CompileError::UndriveOutput {
+                name,
+                span: respan(span, new_offset),
+            },
+            CompileError::NamingViolation { message, span } => CompileError::NamingViolation {
+                message,
+                span: respan(span, new_offset),
+            },
+            CompileError::LexerError { span } => CompileError::LexerError {
+                span: respan(span, new_offset),
+            },
+            CompileError::General { message, span } => CompileError::General {
+                message,
+                span: respan(span, new_offset),
+            },
             CompileError::UnexpectedEof => CompileError::UnexpectedEof,
         }
     }

--- a/src/formal.rs
+++ b/src/formal.rs
@@ -64,7 +64,13 @@ impl FormalReport {
                 PropertyStatus::Inconclusive(_) => any_incon = true,
             }
         }
-        if any_bad { 1 } else if any_incon { 2 } else { 0 }
+        if any_bad {
+            1
+        } else if any_incon {
+            2
+        } else {
+            0
+        }
     }
 }
 
@@ -81,7 +87,11 @@ pub fn run(
     //    doc/plan_hierarchical_formal.md for the design.
     let flat_module: ModuleDecl;
     let mut carried_credit_sites: Vec<CarriedCreditSite> = Vec::new();
-    let encode_module: &ModuleDecl = if module.body.iter().any(|b| matches!(b, ModuleBodyItem::Inst(_))) {
+    let encode_module: &ModuleDecl = if module
+        .body
+        .iter()
+        .any(|b| matches!(b, ModuleBodyItem::Inst(_)))
+    {
         let out = flatten_for_formal(ast, module, symbols)?;
         flat_module = out.module;
         carried_credit_sites = out.carried_sites;
@@ -100,10 +110,12 @@ pub fn run(
 
     // 4. Optionally dump
     if let Some(path) = &args.emit_smt {
-        std::fs::write(path, &base).map_err(|e| CompileError::general(
-            &format!("failed to write --emit-smt output: {e}"),
-            module.span,
-        ))?;
+        std::fs::write(path, &base).map_err(|e| {
+            CompileError::general(
+                &format!("failed to write --emit-smt output: {e}"),
+                module.span,
+            )
+        })?;
     }
 
     // 5. For each assert/cover, run one (push)/(check-sat)/(pop) scope
@@ -206,8 +218,12 @@ fn flatten_for_formal(
                 // names need a single string prefix.
                 let mut bus_remap: HashMap<String, String> = HashMap::new();
                 for sp in &sub.ports {
-                    let Some(bi) = &sp.bus_info else { continue; };
-                    let Some(parent_expr) = port_map.get(&sp.name.name) else { continue; };
+                    let Some(bi) = &sp.bus_info else {
+                        continue;
+                    };
+                    let Some(parent_expr) = port_map.get(&sp.name.name) else {
+                        continue;
+                    };
                     let parent_name = match &parent_expr.kind {
                         ExprKind::Ident(n) => n.clone(),
                         _ => {
@@ -264,7 +280,8 @@ fn flatten_for_formal(
                 // whose name isn't also a port.
                 let port_names: std::collections::HashSet<String> =
                     sub.ports.iter().map(|p| p.name.name.clone()).collect();
-                let mut locals: std::collections::HashSet<String> = std::collections::HashSet::new();
+                let mut locals: std::collections::HashSet<String> =
+                    std::collections::HashSet::new();
                 for bi in &sub.body {
                     match bi {
                         ModuleBodyItem::LetBinding(lb) => {
@@ -291,9 +308,8 @@ fn flatten_for_formal(
                             // IS the driver for that port — its rewritten
                             // target is whatever the parent side connects
                             // to that port.
-                            let rewritten_value = subst_expr_for_formal(
-                                &lb.value, &port_map, &locals, &prefix,
-                            );
+                            let rewritten_value =
+                                subst_expr_for_formal(&lb.value, &port_map, &locals, &prefix);
                             if port_names.contains(&lb.name.name) {
                                 // Port-driving let. Emit
                                 //   `let <parent_side_name> = <value>;`
@@ -325,7 +341,10 @@ fn flatten_for_formal(
                             } else {
                                 // Internal let — prefix its name.
                                 new_body.push(ModuleBodyItem::LetBinding(LetBinding {
-                                    name: Ident::new(format!("{prefix}{}", lb.name.name), lb.name.span),
+                                    name: Ident::new(
+                                        format!("{prefix}{}", lb.name.name),
+                                        lb.name.span,
+                                    ),
                                     ty: lb.ty.clone(),
                                     value: rewritten_value,
                                     span: lb.span,
@@ -334,10 +353,10 @@ fn flatten_for_formal(
                             }
                         }
                         ModuleBodyItem::CombBlock(cb) => {
-                            let new_stmts: Vec<Stmt> = cb.stmts.iter()
-                                .map(|s| subst_comb_stmt_for_formal(
-                                    s, &port_map, &locals, &prefix,
-                                ))
+                            let new_stmts: Vec<Stmt> = cb
+                                .stmts
+                                .iter()
+                                .map(|s| subst_comb_stmt_for_formal(s, &port_map, &locals, &prefix))
                                 .collect::<Result<_, _>>()?;
                             new_body.push(ModuleBodyItem::CombBlock(CombBlock {
                                 stmts: new_stmts,
@@ -348,11 +367,12 @@ fn flatten_for_formal(
                             // Prefix the reg name (regs don't share names
                             // with ports — that'd be a driver conflict in
                             // the sub-module itself).
-                            let new_init = rd.init.as_ref()
+                            let new_init = rd
+                                .init
+                                .as_ref()
                                 .map(|e| subst_expr_for_formal(e, &port_map, &locals, &prefix));
-                            let new_reset = subst_reg_reset_for_formal(
-                                &rd.reset, &port_map, &locals, &prefix,
-                            );
+                            let new_reset =
+                                subst_reg_reset_for_formal(&rd.reset, &port_map, &locals, &prefix);
                             new_body.push(ModuleBodyItem::RegDecl(RegDecl {
                                 name: Ident::new(format!("{prefix}{}", rd.name.name), rd.name.span),
                                 ty: rd.ty.clone(),
@@ -368,12 +388,14 @@ fn flatten_for_formal(
                             // `clk` port binds to parent's clock via the
                             // inst connection).
                             let clock = resolve_port_ident_for_formal(
-                                &rb.clock, &port_map, &inst.name.name,
+                                &rb.clock,
+                                &port_map,
+                                &inst.name.name,
                             )?;
-                            let new_stmts: Vec<Stmt> = rb.stmts.iter()
-                                .map(|s| subst_stmt_for_formal(
-                                    s, &port_map, &locals, &prefix,
-                                ))
+                            let new_stmts: Vec<Stmt> = rb
+                                .stmts
+                                .iter()
+                                .map(|s| subst_stmt_for_formal(s, &port_map, &locals, &prefix))
                                 .collect::<Result<_, _>>()?;
                             new_body.push(ModuleBodyItem::RegBlock(RegBlock {
                                 clock,
@@ -404,7 +426,10 @@ fn flatten_for_formal(
     }
 
     flat.body = new_body;
-    Ok(FlattenOutput { module: flat, carried_sites })
+    Ok(FlattenOutput {
+        module: flat,
+        carried_sites,
+    })
 }
 
 /// Walk a ModuleBodyItem and rewrite SynthIdent prefixes per `remap`
@@ -419,10 +444,14 @@ fn rewrite_synth_idents_in_body_item(
     match item {
         ModuleBodyItem::LetBinding(lb) => rewrite_synth_idents_in_expr(&mut lb.value, remap),
         ModuleBodyItem::CombBlock(cb) => {
-            for s in &mut cb.stmts { rewrite_synth_idents_in_comb_stmt(s, remap); }
+            for s in &mut cb.stmts {
+                rewrite_synth_idents_in_comb_stmt(s, remap);
+            }
         }
         ModuleBodyItem::RegDecl(rd) => {
-            if let Some(init) = &mut rd.init { rewrite_synth_idents_in_expr(init, remap); }
+            if let Some(init) = &mut rd.init {
+                rewrite_synth_idents_in_expr(init, remap);
+            }
             match &mut rd.reset {
                 RegReset::Inherit(_, val) | RegReset::Explicit(_, _, _, val) => {
                     rewrite_synth_idents_in_expr(val, remap);
@@ -431,7 +460,9 @@ fn rewrite_synth_idents_in_body_item(
             }
         }
         ModuleBodyItem::RegBlock(rb) => {
-            for s in &mut rb.stmts { rewrite_synth_idents_in_stmt(s, remap); }
+            for s in &mut rb.stmts {
+                rewrite_synth_idents_in_stmt(s, remap);
+            }
         }
         _ => {}
     }
@@ -448,17 +479,18 @@ fn rewrite_synth_idents_in_comb_stmt(
         }
         Stmt::IfElse(ie) => {
             rewrite_synth_idents_in_expr(&mut ie.cond, remap);
-            for st in &mut ie.then_stmts { rewrite_synth_idents_in_comb_stmt(st, remap); }
-            for st in &mut ie.else_stmts { rewrite_synth_idents_in_comb_stmt(st, remap); }
+            for st in &mut ie.then_stmts {
+                rewrite_synth_idents_in_comb_stmt(st, remap);
+            }
+            for st in &mut ie.else_stmts {
+                rewrite_synth_idents_in_comb_stmt(st, remap);
+            }
         }
         _ => {}
     }
 }
 
-fn rewrite_synth_idents_in_stmt(
-    s: &mut Stmt,
-    remap: &std::collections::HashMap<String, String>,
-) {
+fn rewrite_synth_idents_in_stmt(s: &mut Stmt, remap: &std::collections::HashMap<String, String>) {
     match s {
         Stmt::Assign(a) => {
             rewrite_synth_idents_in_expr(&mut a.target, remap);
@@ -466,8 +498,12 @@ fn rewrite_synth_idents_in_stmt(
         }
         Stmt::IfElse(ie) => {
             rewrite_synth_idents_in_expr(&mut ie.cond, remap);
-            for st in &mut ie.then_stmts { rewrite_synth_idents_in_stmt(st, remap); }
-            for st in &mut ie.else_stmts { rewrite_synth_idents_in_stmt(st, remap); }
+            for st in &mut ie.then_stmts {
+                rewrite_synth_idents_in_stmt(st, remap);
+            }
+            for st in &mut ie.else_stmts {
+                rewrite_synth_idents_in_stmt(st, remap);
+            }
         }
         _ => {}
     }
@@ -532,7 +568,9 @@ fn rewrite_synth_idents_in_expr(
             rewrite_synth_idents_in_expr(f, remap);
         }
         Concat(xs) => {
-            for x in xs { rewrite_synth_idents_in_expr(x, remap); }
+            for x in xs {
+                rewrite_synth_idents_in_expr(x, remap);
+            }
         }
         Repeat(n, x) => {
             rewrite_synth_idents_in_expr(n, remap);
@@ -541,10 +579,14 @@ fn rewrite_synth_idents_in_expr(
         FieldAccess(b, _) => rewrite_synth_idents_in_expr(b, remap),
         MethodCall(recv, _, args) => {
             rewrite_synth_idents_in_expr(recv, remap);
-            for a in args { rewrite_synth_idents_in_expr(a, remap); }
+            for a in args {
+                rewrite_synth_idents_in_expr(a, remap);
+            }
         }
         FunctionCall(_, xs) => {
-            for x in xs { rewrite_synth_idents_in_expr(x, remap); }
+            for x in xs {
+                rewrite_synth_idents_in_expr(x, remap);
+            }
         }
         _ => {}
     }
@@ -560,14 +602,22 @@ fn subst_comb_stmt_for_formal(
         Stmt::Assign(a) => {
             let target = subst_expr_for_formal(&a.target, port_map, locals, prefix);
             let value = subst_expr_for_formal(&a.value, port_map, locals, prefix);
-            Ok(Stmt::Assign(Assign { target, value, span: a.span }))
+            Ok(Stmt::Assign(Assign {
+                target,
+                value,
+                span: a.span,
+            }))
         }
         Stmt::IfElse(ie) => {
             let cond = subst_expr_for_formal(&ie.cond, port_map, locals, prefix);
-            let then_stmts: Vec<Stmt> = ie.then_stmts.iter()
+            let then_stmts: Vec<Stmt> = ie
+                .then_stmts
+                .iter()
                 .map(|s| subst_comb_stmt_for_formal(s, port_map, locals, prefix))
                 .collect::<Result<_, _>>()?;
-            let else_stmts: Vec<Stmt> = ie.else_stmts.iter()
+            let else_stmts: Vec<Stmt> = ie
+                .else_stmts
+                .iter()
                 .map(|s| subst_comb_stmt_for_formal(s, port_map, locals, prefix))
                 .collect::<Result<_, _>>()?;
             Ok(Stmt::IfElse(IfElseOf {
@@ -610,11 +660,17 @@ fn validate_sub_for_formal(sub: &ModuleDecl) -> Result<(), CompileError> {
         // signals) still need their own modelling and aren't supported
         // in this slice — `flatten_for_formal` checks the bus's content
         // when it processes the inst.
-        if p.bus_info.is_some() { continue; }
+        if p.bus_info.is_some() {
+            continue;
+        }
         // Scalar ports only.
         match &p.ty {
-            TypeExpr::UInt(_) | TypeExpr::SInt(_) | TypeExpr::Bool
-                | TypeExpr::Bit | TypeExpr::Clock(_) | TypeExpr::Reset(_, _) => {}
+            TypeExpr::UInt(_)
+            | TypeExpr::SInt(_)
+            | TypeExpr::Bool
+            | TypeExpr::Bit
+            | TypeExpr::Clock(_)
+            | TypeExpr::Reset(_, _) => {}
             _ => {
                 return Err(CompileError::general(
                     &format!(
@@ -736,14 +792,22 @@ fn subst_stmt_for_formal(
         Stmt::Assign(a) => {
             let target = subst_expr_for_formal(&a.target, port_map, locals, prefix);
             let value = subst_expr_for_formal(&a.value, port_map, locals, prefix);
-            Ok(Stmt::Assign(Assign { target, value, span: a.span }))
+            Ok(Stmt::Assign(Assign {
+                target,
+                value,
+                span: a.span,
+            }))
         }
         Stmt::IfElse(ie) => {
             let cond = subst_expr_for_formal(&ie.cond, port_map, locals, prefix);
-            let then_stmts: Vec<Stmt> = ie.then_stmts.iter()
+            let then_stmts: Vec<Stmt> = ie
+                .then_stmts
+                .iter()
                 .map(|s| subst_stmt_for_formal(s, port_map, locals, prefix))
                 .collect::<Result<_, _>>()?;
-            let else_stmts: Vec<Stmt> = ie.else_stmts.iter()
+            let else_stmts: Vec<Stmt> = ie
+                .else_stmts
+                .iter()
                 .map(|s| subst_stmt_for_formal(s, port_map, locals, prefix))
                 .collect::<Result<_, _>>()?;
             Ok(Stmt::IfElse(IfElseOf {
@@ -788,7 +852,9 @@ fn subst_expr_for_formal(
     use ExprKind::*;
     let new_kind = match &expr.kind {
         Ident(name) => {
-            if let Some(p) = port_map.get(name) { return p.clone(); }
+            if let Some(p) = port_map.get(name) {
+                return p.clone();
+            }
             if locals.contains(name) {
                 Ident(format!("{prefix}{name}"))
             } else {
@@ -800,8 +866,14 @@ fn subst_expr_for_formal(
             Box::new(subst_expr_for_formal(l, port_map, locals, prefix)),
             Box::new(subst_expr_for_formal(r, port_map, locals, prefix)),
         ),
-        Unary(op, e) => Unary(*op, Box::new(subst_expr_for_formal(e, port_map, locals, prefix))),
-        Cast(e, ty) => Cast(Box::new(subst_expr_for_formal(e, port_map, locals, prefix)), ty.clone()),
+        Unary(op, e) => Unary(
+            *op,
+            Box::new(subst_expr_for_formal(e, port_map, locals, prefix)),
+        ),
+        Cast(e, ty) => Cast(
+            Box::new(subst_expr_for_formal(e, port_map, locals, prefix)),
+            ty.clone(),
+        ),
         Index(b, i) => Index(
             Box::new(subst_expr_for_formal(b, port_map, locals, prefix)),
             Box::new(subst_expr_for_formal(i, port_map, locals, prefix)),
@@ -829,9 +901,15 @@ fn subst_expr_for_formal(
         MethodCall(recv, m, args) => MethodCall(
             Box::new(subst_expr_for_formal(recv, port_map, locals, prefix)),
             m.clone(),
-            args.iter().map(|a| subst_expr_for_formal(a, port_map, locals, prefix)).collect(),
+            args.iter()
+                .map(|a| subst_expr_for_formal(a, port_map, locals, prefix))
+                .collect(),
         ),
-        Concat(xs) => Concat(xs.iter().map(|x| subst_expr_for_formal(x, port_map, locals, prefix)).collect()),
+        Concat(xs) => Concat(
+            xs.iter()
+                .map(|x| subst_expr_for_formal(x, port_map, locals, prefix))
+                .collect(),
+        ),
         Repeat(n, x) => Repeat(
             Box::new(subst_expr_for_formal(n, port_map, locals, prefix)),
             Box::new(subst_expr_for_formal(x, port_map, locals, prefix)),
@@ -842,11 +920,17 @@ fn subst_expr_for_formal(
         ),
         FunctionCall(n, xs) => FunctionCall(
             n.clone(),
-            xs.iter().map(|x| subst_expr_for_formal(x, port_map, locals, prefix)).collect(),
+            xs.iter()
+                .map(|x| subst_expr_for_formal(x, port_map, locals, prefix))
+                .collect(),
         ),
         _ => return expr.clone(),
     };
-    Expr { kind: new_kind, span: expr.span, parenthesized: expr.parenthesized }
+    Expr {
+        kind: new_kind,
+        span: expr.span,
+        parenthesized: expr.parenthesized,
+    }
 }
 
 // ── Top-module selection ─────────────────────────────────────────────────────
@@ -856,17 +940,23 @@ fn select_top<'a>(
     requested: Option<&str>,
 ) -> Result<&'a ModuleDecl, CompileError> {
     // Visible modules = non-underscore-prefixed (hides `_<Name>_threads` helpers).
-    let visible: Vec<&ModuleDecl> = ast.items.iter().filter_map(|it| match it {
-        Item::Module(m) if !m.name.name.starts_with('_') => Some(m),
-        _ => None,
-    }).collect();
+    let visible: Vec<&ModuleDecl> = ast
+        .items
+        .iter()
+        .filter_map(|it| match it {
+            Item::Module(m) if !m.name.name.starts_with('_') => Some(m),
+            _ => None,
+        })
+        .collect();
 
     if let Some(name) = requested {
         for m in ast.items.iter().filter_map(|it| match it {
             Item::Module(m) => Some(m),
             _ => None,
         }) {
-            if m.name.name == name { return Ok(m); }
+            if m.name.name == name {
+                return Ok(m);
+            }
         }
         return Err(CompileError::general(
             &format!("module `{name}` not found in input"),
@@ -883,7 +973,10 @@ fn select_top<'a>(
         _ => {
             let names: Vec<&str> = visible.iter().map(|m| m.name.name.as_str()).collect();
             Err(CompileError::general(
-                &format!("multiple modules in input ({}); specify --top <Name>", names.join(", ")),
+                &format!(
+                    "multiple modules in input ({}); specify --top <Name>",
+                    names.join(", ")
+                ),
                 Span { start: 0, end: 0 },
             ))
         }
@@ -973,8 +1066,8 @@ struct FormalCtx<'a> {
 
 #[derive(Debug, Clone)]
 struct CombAssignFlat {
-    target: String,          // flat name (e.g. "y" or "out[2]"); v1 supports ident targets only
-    guard: Vec<Expr>,        // stack of conditions (ANDed)
+    target: String,   // flat name (e.g. "y" or "out[2]"); v1 supports ident targets only
+    guard: Vec<Expr>, // stack of conditions (ANDed)
     value: Expr,
 }
 
@@ -1015,7 +1108,11 @@ impl<'a> FormalCtx<'a> {
             reg_writes: HashMap::new(),
             comb_assigns: Vec::new(),
             let_bindings: HashMap::new(),
-            reset: ResetInfo { name: "rst".to_string(), is_async: false, is_low: false },
+            reset: ResetInfo {
+                name: "rst".to_string(),
+                is_async: false,
+                is_low: false,
+            },
             params: HashMap::new(),
             enum_variants: HashMap::new(),
             properties: Vec::new(),
@@ -1041,7 +1138,10 @@ impl<'a> FormalCtx<'a> {
         // state should use as the prefix.
         let carried = std::mem::take(&mut self.carried_credit_sites);
         for cs in carried {
-            let depth = cs.meta.params.iter()
+            let depth = cs
+                .meta
+                .params
+                .iter()
                 .find(|pp| pp.name.name == "DEPTH")
                 .and_then(|pp| pp.default.as_ref())
                 .and_then(|e| fold_const_expr(e, &self.params));
@@ -1053,9 +1153,14 @@ impl<'a> FormalCtx<'a> {
             });
         }
         for p in &self.module.ports {
-            let Some(bi) = &p.bus_info else { continue; };
+            let Some(bi) = &p.bus_info else {
+                continue;
+            };
             let Some((crate::resolve::Symbol::Bus(info), _)) =
-                self.symbols.globals.get(&bi.bus_name.name) else { continue; };
+                self.symbols.globals.get(&bi.bus_name.name)
+            else {
+                continue;
+            };
             for cc in &info.credit_channels {
                 // Role flipping: on the target perspective the bus
                 // reverses directions, so an `Out` channel role on the
@@ -1065,7 +1170,9 @@ impl<'a> FormalCtx<'a> {
                     (Direction::Out, crate::ast::BusPerspective::Initiator)
                         | (Direction::In, crate::ast::BusPerspective::Target)
                 );
-                let depth = cc.params.iter()
+                let depth = cc
+                    .params
+                    .iter()
                     .find(|pp| pp.name.name == "DEPTH")
                     .and_then(|pp| pp.default.as_ref())
                     .and_then(|e| fold_const_expr(e, &self.params));
@@ -1100,13 +1207,19 @@ impl<'a> FormalCtx<'a> {
         // handshake signals (send_valid, credit_return) become internal
         // wires shared between the two sides instead of separate
         // input/output ports on the flat module.
-        let mut both_sides: std::collections::HashSet<(String, String)> = std::collections::HashSet::new();
-        let mut have_sender: std::collections::HashSet<(String, String)> = std::collections::HashSet::new();
-        let mut have_receiver: std::collections::HashSet<(String, String)> = std::collections::HashSet::new();
+        let mut both_sides: std::collections::HashSet<(String, String)> =
+            std::collections::HashSet::new();
+        let mut have_sender: std::collections::HashSet<(String, String)> =
+            std::collections::HashSet::new();
+        let mut have_receiver: std::collections::HashSet<(String, String)> =
+            std::collections::HashSet::new();
         for s in &sites {
             let key = (s.port_name.clone(), s.meta.name.name.clone());
-            if s.is_sender { have_sender.insert(key); }
-            else { have_receiver.insert(key); }
+            if s.is_sender {
+                have_sender.insert(key);
+            } else {
+                have_receiver.insert(key);
+            }
         }
         for k in have_sender.intersection(&have_receiver) {
             both_sides.insert(k.clone());
@@ -1162,11 +1275,14 @@ impl<'a> FormalCtx<'a> {
             if self.sigs.contains_key(&sig.name) {
                 continue;
             }
-            self.sigs.insert(sig.name.clone(), SignalInfo {
-                width: sig.width,
-                signed: sig.signed,
-                kind: kind.clone(),
-            });
+            self.sigs.insert(
+                sig.name.clone(),
+                SignalInfo {
+                    width: sig.width,
+                    signed: sig.signed,
+                    kind: kind.clone(),
+                },
+            );
             match kind {
                 SignalKind::Input => self.inputs.push(sig.name),
                 SignalKind::Output => self.outputs.push(sig.name),
@@ -1185,7 +1301,10 @@ impl<'a> FormalCtx<'a> {
             });
         }
         for eq in model.next_equations {
-            self.reg_writes.entry(eq.target).or_default().push((eq.cond, eq.value));
+            self.reg_writes
+                .entry(eq.target)
+                .or_default()
+                .push((eq.cond, eq.value));
         }
         for derived in model.derived_nonzero {
             self.derived_nonzero.insert(derived.name, derived.source);
@@ -1210,7 +1329,11 @@ impl<'a> FormalCtx<'a> {
 
         // Reset info
         let (rn, is_async, is_low) = crate::ast::extract_reset_info(&self.module.ports);
-        self.reset = ResetInfo { name: rn, is_async, is_low };
+        self.reset = ResetInfo {
+            name: rn,
+            is_async,
+            is_low,
+        };
 
         // PR-hf4 item 1: collect credit_channel sites for later state
         // registration and SynthIdent resolution.
@@ -1260,7 +1383,14 @@ impl<'a> FormalCtx<'a> {
                 Direction::In => SignalKind::Input,
                 Direction::Out => SignalKind::Output,
             };
-            self.sigs.insert(port.name.name.clone(), SignalInfo { width: w, signed, kind: kind.clone() });
+            self.sigs.insert(
+                port.name.name.clone(),
+                SignalInfo {
+                    width: w,
+                    signed,
+                    kind: kind.clone(),
+                },
+            );
             match kind {
                 SignalKind::Input => self.inputs.push(port.name.name.clone()),
                 SignalKind::Output => self.outputs.push(port.name.name.clone()),
@@ -1270,7 +1400,9 @@ impl<'a> FormalCtx<'a> {
             if let Some(reg_info) = &port.reg_info {
                 self.regs.push(port.name.name.clone());
                 self.sigs.get_mut(&port.name.name).unwrap().kind = SignalKind::Reg;
-                if let RegReset::Inherit(_, val) | RegReset::Explicit(_, _, _, val) = &reg_info.reset {
+                if let RegReset::Inherit(_, val) | RegReset::Explicit(_, _, _, val) =
+                    &reg_info.reset
+                {
                     self.reg_reset.insert(port.name.name.clone(), val.clone());
                 } else if let Some(init) = &reg_info.init {
                     self.reg_reset.insert(port.name.name.clone(), init.clone());
@@ -1285,7 +1417,14 @@ impl<'a> FormalCtx<'a> {
                 ModuleBodyItem::RegDecl(r) => {
                     self.check_scalar_type(&r.ty, r.span)?;
                     let (w, signed) = self.type_width_signed(&r.ty, r.span)?;
-                    self.sigs.insert(r.name.name.clone(), SignalInfo { width: w, signed, kind: SignalKind::Reg });
+                    self.sigs.insert(
+                        r.name.name.clone(),
+                        SignalInfo {
+                            width: w,
+                            signed,
+                            kind: SignalKind::Reg,
+                        },
+                    );
                     self.regs.push(r.name.name.clone());
                     match &r.reset {
                         RegReset::Inherit(_, val) | RegReset::Explicit(_, _, _, val) => {
@@ -1301,14 +1440,25 @@ impl<'a> FormalCtx<'a> {
                 ModuleBodyItem::WireDecl(w) => {
                     self.check_scalar_type(&w.ty, w.span)?;
                     let (width, signed) = self.type_width_signed(&w.ty, w.span)?;
-                    self.sigs.insert(w.name.name.clone(), SignalInfo { width, signed, kind: SignalKind::Wire });
+                    self.sigs.insert(
+                        w.name.name.clone(),
+                        SignalInfo {
+                            width,
+                            signed,
+                            kind: SignalKind::Wire,
+                        },
+                    );
                     self.wires.push(w.name.name.clone());
                 }
                 ModuleBodyItem::LetBinding(lb) => {
-                    self.let_bindings.insert(lb.name.name.clone(), lb.value.clone());
+                    self.let_bindings
+                        .insert(lb.name.name.clone(), lb.value.clone());
                 }
                 ModuleBodyItem::Assert(a) => {
-                    let name = a.name.as_ref().map(|i| i.name.clone())
+                    let name = a
+                        .name
+                        .as_ref()
+                        .map(|i| i.name.clone())
                         .unwrap_or_else(|| format!("prop_{}", a.span.start));
                     self.properties.push(PropertyDecl {
                         name,
@@ -1360,7 +1510,9 @@ impl<'a> FormalCtx<'a> {
                         self.module.span,
                     ));
                 }
-                ModuleBodyItem::Function(_) | ModuleBodyItem::Resource(_) | ModuleBodyItem::TlmConnect(_) => {
+                ModuleBodyItem::Function(_)
+                | ModuleBodyItem::Resource(_)
+                | ModuleBodyItem::TlmConnect(_) => {
                     // Ignore; v1 doesn't encode module-local functions
                 }
                 ModuleBodyItem::Inst(_) | ModuleBodyItem::Thread(_) => {
@@ -1446,11 +1598,17 @@ impl<'a> FormalCtx<'a> {
                 }
             }
             Stmt::IfElse(ie) => {
-                for c in &ie.then_stmts { self.collect_init_writes(c)?; }
-                for c in &ie.else_stmts { self.collect_init_writes(c)?; }
+                for c in &ie.then_stmts {
+                    self.collect_init_writes(c)?;
+                }
+                for c in &ie.else_stmts {
+                    self.collect_init_writes(c)?;
+                }
             }
             Stmt::Init(ib) => {
-                for c in &ib.body { self.collect_init_writes(c)?; }
+                for c in &ib.body {
+                    self.collect_init_writes(c)?;
+                }
             }
             _ => {}
         }
@@ -1462,10 +1620,12 @@ impl<'a> FormalCtx<'a> {
             Stmt::Assign(a) => {
                 let name = match target_root_ident(&a.target) {
                     Some(n) => n,
-                    None => return Err(CompileError::general(
-                        "arch formal v1 only supports comb assignments to bare identifiers",
-                        a.span,
-                    )),
+                    None => {
+                        return Err(CompileError::general(
+                            "arch formal v1 only supports comb assignments to bare identifiers",
+                            a.span,
+                        ))
+                    }
                 };
                 self.comb_assigns.push(CombAssignFlat {
                     target: name,
@@ -1476,10 +1636,14 @@ impl<'a> FormalCtx<'a> {
             Stmt::IfElse(ie) => {
                 let mut then_path = path.to_vec();
                 then_path.push(ie.cond.clone());
-                for c in &ie.then_stmts { self.walk_comb_stmt(c, &then_path)?; }
+                for c in &ie.then_stmts {
+                    self.walk_comb_stmt(c, &then_path)?;
+                }
                 let mut else_path = path.to_vec();
                 else_path.push(not_expr(ie.cond.clone()));
-                for c in &ie.else_stmts { self.walk_comb_stmt(c, &else_path)?; }
+                for c in &ie.else_stmts {
+                    self.walk_comb_stmt(c, &else_path)?;
+                }
             }
             Stmt::Match(m) => {
                 return Err(CompileError::general(
@@ -1493,7 +1657,9 @@ impl<'a> FormalCtx<'a> {
                     fl.span,
                 ));
             }
-                Stmt::Init(_) | Stmt::WaitUntil(..) | Stmt::DoUntil { .. } => unreachable!("seq-only Stmt variant inside comb-context walker"),
+            Stmt::Init(_) | Stmt::WaitUntil(..) | Stmt::DoUntil { .. } => {
+                unreachable!("seq-only Stmt variant inside comb-context walker")
+            }
             Stmt::Log(_) => { /* ignore */ }
         }
         Ok(())
@@ -1506,7 +1672,9 @@ impl<'a> FormalCtx<'a> {
         for ca in &self.comb_assigns {
             targets.insert(ca.target.clone());
             let set = deps.entry(ca.target.clone()).or_default();
-            for g in &ca.guard { collect_idents(g, set); }
+            for g in &ca.guard {
+                collect_idents(g, set);
+            }
             collect_idents(&ca.value, set);
         }
         // Add let bindings as targets too (so they participate in ordering if referenced).
@@ -1535,7 +1703,9 @@ impl<'a> FormalCtx<'a> {
         visited: &mut HashSet<String>,
         visiting: &mut HashSet<String>,
     ) -> Result<(), CompileError> {
-        if visited.contains(name) { return Ok(()); }
+        if visited.contains(name) {
+            return Ok(());
+        }
         if visiting.contains(name) {
             return Err(CompileError::general(
                 &format!("combinational feedback loop through `{name}` — arch formal cannot handle cyclic comb"),
@@ -1609,31 +1779,35 @@ impl<'a> FormalCtx<'a> {
     fn type_width_signed(&self, ty: &TypeExpr, span: Span) -> Result<(u32, bool), CompileError> {
         match ty {
             TypeExpr::UInt(w) => {
-                let width = fold_const_expr(w, &self.params).ok_or_else(|| CompileError::general(
-                    "could not fold UInt<W> width to a compile-time constant",
-                    span,
-                ))? as u32;
+                let width = fold_const_expr(w, &self.params).ok_or_else(|| {
+                    CompileError::general(
+                        "could not fold UInt<W> width to a compile-time constant",
+                        span,
+                    )
+                })? as u32;
                 if width == 0 {
                     return Err(CompileError::general("width of 0 is not supported", span));
                 }
                 Ok((width, false))
             }
             TypeExpr::SInt(w) => {
-                let width = fold_const_expr(w, &self.params).ok_or_else(|| CompileError::general(
-                    "could not fold SInt<W> width to a compile-time constant",
-                    span,
-                ))? as u32;
+                let width = fold_const_expr(w, &self.params).ok_or_else(|| {
+                    CompileError::general(
+                        "could not fold SInt<W> width to a compile-time constant",
+                        span,
+                    )
+                })? as u32;
                 if width == 0 {
                     return Err(CompileError::general("width of 0 is not supported", span));
                 }
                 Ok((width, true))
             }
-            TypeExpr::Bool | TypeExpr::Bit | TypeExpr::Clock(_) | TypeExpr::Reset(_, _) =>
-                Ok((1, false)),
-            TypeExpr::FP32 | TypeExpr::BF16 | TypeExpr::Vec(_, _) | TypeExpr::Named(_) => Err(CompileError::general(
-                "type not supported by arch formal v1",
-                span,
-            )),
+            TypeExpr::Bool | TypeExpr::Bit | TypeExpr::Clock(_) | TypeExpr::Reset(_, _) => {
+                Ok((1, false))
+            }
+            TypeExpr::FP32 | TypeExpr::BF16 | TypeExpr::Vec(_, _) | TypeExpr::Named(_) => Err(
+                CompileError::general("type not supported by arch formal v1", span),
+            ),
         }
     }
 
@@ -1654,7 +1828,9 @@ impl<'a> FormalCtx<'a> {
                 out.push_str(&format!("(declare-fun {name}_{t} () (_ BitVec {w}))\n"));
             }
             for name in &self.outputs {
-                if self.sigs[name].kind == SignalKind::Reg { continue; }
+                if self.sigs[name].kind == SignalKind::Reg {
+                    continue;
+                }
                 let w = self.sigs[name].width;
                 out.push_str(&format!("(declare-fun {name}_{t} () (_ BitVec {w}))\n"));
             }
@@ -1695,9 +1871,14 @@ impl<'a> FormalCtx<'a> {
                     }
                     continue;
                 }
-                let assigns: Vec<&CombAssignFlat> = self.comb_assigns.iter()
-                    .filter(|c| &c.target == tgt).collect();
-                if assigns.is_empty() { continue; }
+                let assigns: Vec<&CombAssignFlat> = self
+                    .comb_assigns
+                    .iter()
+                    .filter(|c| &c.target == tgt)
+                    .collect();
+                if assigns.is_empty() {
+                    continue;
+                }
                 let info = &self.sigs[tgt];
                 // Build nested ite from the guard chain. Last unguarded write wins as default.
                 let rhs = self.build_comb_ite(&assigns, t, info.width, info.signed)?;
@@ -1708,7 +1889,10 @@ impl<'a> FormalCtx<'a> {
 
         // Register transition: r_{t+1} = ite(reset, reset_val, next_value)
         for t in 0..bound {
-            out.push_str(&format!("; ── register transition cycle {t}→{} ──\n", t + 1));
+            out.push_str(&format!(
+                "; ── register transition cycle {t}→{} ──\n",
+                t + 1
+            ));
             for reg in &self.regs {
                 let info = &self.sigs[reg];
                 let next = self.reg_next(reg, t, info.width, info.signed)?;
@@ -1735,7 +1919,13 @@ impl<'a> FormalCtx<'a> {
     }
 
     /// Build nested ite for a reg's next value at cycle t.
-    fn reg_next(&self, reg: &str, t: u32, width: u32, signed: bool) -> Result<String, CompileError> {
+    fn reg_next(
+        &self,
+        reg: &str,
+        t: u32,
+        width: u32,
+        signed: bool,
+    ) -> Result<String, CompileError> {
         let writes = match self.reg_writes.get(reg) {
             Some(w) if !w.is_empty() => w,
             _ => return Ok(format!("{reg}_{t}")), // hold
@@ -2066,7 +2256,11 @@ impl<'a> FormalCtx<'a> {
         // 1. Const param?
         if let Some(val) = self.params.get(name) {
             // Default to 32-bit; coerce() resizes as needed.
-            return Ok(SmtTerm { s: bv_lit(*val, 32), width: 32, signed: false });
+            return Ok(SmtTerm {
+                s: bv_lit(*val, 32),
+                width: 32,
+                signed: false,
+            });
         }
         // 2. Let binding? Inline expand.
         if let Some(val) = self.let_bindings.get(name) {
@@ -2094,10 +2288,15 @@ impl<'a> FormalCtx<'a> {
                 });
             }
         }
-        if let Some(stem) = name.strip_suffix("_can_send")
+        if let Some(stem) = name
+            .strip_suffix("_can_send")
             .or_else(|| name.strip_suffix("_valid"))
         {
-            let suffix = if name.ends_with("_can_send") { "_credit" } else { "_occ" };
+            let suffix = if name.ends_with("_can_send") {
+                "_credit"
+            } else {
+                "_occ"
+            };
             let reg = format!("{stem}{suffix}");
             if let Some(info) = self.sigs.get(&reg) {
                 let zero = bv_zero(info.width);
@@ -2133,7 +2332,11 @@ impl<'a> FormalCtx<'a> {
                 let la = coerce(ta, out_w, signed);
                 let lb = coerce(tb, out_w, signed);
                 let opname = if op == BinOp::Add { "bvadd" } else { "bvsub" };
-                Ok(SmtTerm { s: format!("({opname} {} {})", la.s, lb.s), width: out_w, signed })
+                Ok(SmtTerm {
+                    s: format!("({opname} {} {})", la.s, lb.s),
+                    width: out_w,
+                    signed,
+                })
             }
             BinOp::Mul => {
                 // Non-wrapping: result width = W(a) + W(b)
@@ -2141,7 +2344,11 @@ impl<'a> FormalCtx<'a> {
                 let signed = ta.signed || tb.signed;
                 let la = coerce(ta, out_w, signed);
                 let lb = coerce(tb, out_w, signed);
-                Ok(SmtTerm { s: format!("(bvmul {} {})", la.s, lb.s), width: out_w, signed })
+                Ok(SmtTerm {
+                    s: format!("(bvmul {} {})", la.s, lb.s),
+                    width: out_w,
+                    signed,
+                })
             }
             BinOp::AddWrap | BinOp::SubWrap | BinOp::MulWrap => {
                 // Wrapping: result width = max(W(a), W(b))
@@ -2155,7 +2362,11 @@ impl<'a> FormalCtx<'a> {
                     BinOp::MulWrap => "bvmul",
                     _ => unreachable!(),
                 };
-                Ok(SmtTerm { s: format!("({opname} {} {})", la.s, lb.s), width: common, signed })
+                Ok(SmtTerm {
+                    s: format!("({opname} {} {})", la.s, lb.s),
+                    width: common,
+                    signed,
+                })
             }
             BinOp::Div | BinOp::Mod => {
                 let common = ta.width.max(tb.width);
@@ -2169,7 +2380,11 @@ impl<'a> FormalCtx<'a> {
                     (BinOp::Mod, false) => "bvurem",
                     _ => unreachable!(),
                 };
-                Ok(SmtTerm { s: format!("({opname} {} {})", la.s, lb.s), width: common, signed })
+                Ok(SmtTerm {
+                    s: format!("({opname} {} {})", la.s, lb.s),
+                    width: common,
+                    signed,
+                })
             }
             BinOp::Eq | BinOp::Neq => {
                 let common = ta.width.max(tb.width);
@@ -2182,7 +2397,11 @@ impl<'a> FormalCtx<'a> {
                 } else {
                     format!("(ite {eq} #b0 #b1)")
                 };
-                Ok(SmtTerm { s, width: 1, signed: false })
+                Ok(SmtTerm {
+                    s,
+                    width: 1,
+                    signed: false,
+                })
             }
             BinOp::Lt | BinOp::Gt | BinOp::Lte | BinOp::Gte => {
                 let common = ta.width.max(tb.width);
@@ -2201,7 +2420,11 @@ impl<'a> FormalCtx<'a> {
                     _ => unreachable!(),
                 };
                 let cmp = format!("({opname} {} {})", la.s, lb.s);
-                Ok(SmtTerm { s: format!("(ite {cmp} #b1 #b0)"), width: 1, signed: false })
+                Ok(SmtTerm {
+                    s: format!("(ite {cmp} #b1 #b0)"),
+                    width: 1,
+                    signed: false,
+                })
             }
             BinOp::And | BinOp::Or => {
                 // Logical — both must be 1-bit BV. Reduce wider operands with `!= 0`.
@@ -2225,21 +2448,33 @@ impl<'a> FormalCtx<'a> {
                     BinOp::BitXor => "bvxor",
                     _ => unreachable!(),
                 };
-                Ok(SmtTerm { s: format!("({opname} {} {})", la.s, lb.s), width: common, signed })
+                Ok(SmtTerm {
+                    s: format!("({opname} {} {})", la.s, lb.s),
+                    width: common,
+                    signed,
+                })
             }
             BinOp::Shl => {
                 // Result width = W(a). Amount zero-extended to W(a).
                 let w = ta.width;
                 let signed = ta.signed;
                 let lb = coerce(tb, w, false);
-                Ok(SmtTerm { s: format!("(bvshl {} {})", ta.s, lb.s), width: w, signed })
+                Ok(SmtTerm {
+                    s: format!("(bvshl {} {})", ta.s, lb.s),
+                    width: w,
+                    signed,
+                })
             }
             BinOp::Shr => {
                 let w = ta.width;
                 let signed = ta.signed;
                 let lb = coerce(tb, w, false);
                 let opname = if signed { "bvashr" } else { "bvlshr" };
-                Ok(SmtTerm { s: format!("({opname} {} {})", ta.s, lb.s), width: w, signed })
+                Ok(SmtTerm {
+                    s: format!("({opname} {} {})", ta.s, lb.s),
+                    width: w,
+                    signed,
+                })
             }
             BinOp::Implies => {
                 // a implies b  ≡  !a | b
@@ -2265,10 +2500,7 @@ impl<'a> FormalCtx<'a> {
                 ))
             }
         }
-        .map_err(|e: CompileError| CompileError::general(
-            &format!("{}", e_display(&e, span)),
-            span,
-        ))
+        .map_err(|e: CompileError| CompileError::general(&format!("{}", e_display(&e, span)), span))
     }
 
     fn encode_unary(
@@ -2282,14 +2514,22 @@ impl<'a> FormalCtx<'a> {
         match op {
             UnaryOp::Not => {
                 let b = as_bv1_bool(&ta);
-                Ok(SmtTerm { s: format!("(bvxor {b} #b1)"), width: 1, signed: false })
+                Ok(SmtTerm {
+                    s: format!("(bvxor {b} #b1)"),
+                    width: 1,
+                    signed: false,
+                })
             }
-            UnaryOp::BitNot => {
-                Ok(SmtTerm { s: format!("(bvnot {})", ta.s), width: ta.width, signed: ta.signed })
-            }
-            UnaryOp::Neg => {
-                Ok(SmtTerm { s: format!("(bvneg {})", ta.s), width: ta.width, signed: true })
-            }
+            UnaryOp::BitNot => Ok(SmtTerm {
+                s: format!("(bvnot {})", ta.s),
+                width: ta.width,
+                signed: ta.signed,
+            }),
+            UnaryOp::Neg => Ok(SmtTerm {
+                s: format!("(bvneg {})", ta.s),
+                width: ta.width,
+                signed: true,
+            }),
             UnaryOp::RedAnd => {
                 // (= x ~0)
                 let all_ones = bv_all_ones(ta.width);
@@ -2309,12 +2549,18 @@ impl<'a> FormalCtx<'a> {
             }
             UnaryOp::RedXor => {
                 // Fold bit-by-bit via bvxor on extracted bits
-                if ta.width == 1 { return Ok(ta); }
+                if ta.width == 1 {
+                    return Ok(ta);
+                }
                 let mut s = format!("((_ extract 0 0) {})", ta.s);
                 for i in 1..ta.width {
                     s = format!("(bvxor {s} ((_ extract {i} {i}) {}))", ta.s);
                 }
-                Ok(SmtTerm { s, width: 1, signed: false })
+                Ok(SmtTerm {
+                    s,
+                    width: 1,
+                    signed: false,
+                })
             }
         }
     }
@@ -2338,12 +2584,13 @@ impl<'a> FormalCtx<'a> {
         };
         match n {
             "trunc" => {
-                let w = target_w.ok_or_else(|| CompileError::general(
-                    ".trunc<N>() requires a constant width argument", span,
-                ))?;
+                let w = target_w.ok_or_else(|| {
+                    CompileError::general(".trunc<N>() requires a constant width argument", span)
+                })?;
                 if w > r.width {
                     return Err(CompileError::general(
-                        ".trunc<N>() target must be ≤ current width", span,
+                        ".trunc<N>() target must be ≤ current width",
+                        span,
                     ));
                 }
                 Ok(SmtTerm {
@@ -2353,43 +2600,51 @@ impl<'a> FormalCtx<'a> {
                 })
             }
             "zext" => {
-                let w = target_w.ok_or_else(|| CompileError::general(
-                    ".zext<N>() requires a constant width argument", span,
-                ))?;
+                let w = target_w.ok_or_else(|| {
+                    CompileError::general(".zext<N>() requires a constant width argument", span)
+                })?;
                 if w < r.width {
                     return Err(CompileError::general(
-                        ".zext<N>() target must be ≥ current width", span,
+                        ".zext<N>() target must be ≥ current width",
+                        span,
                     ));
                 }
                 let pad = w - r.width;
                 Ok(SmtTerm {
-                    s: if pad == 0 { r.s.clone() }
-                       else { format!("((_ zero_extend {pad}) {})", r.s) },
+                    s: if pad == 0 {
+                        r.s.clone()
+                    } else {
+                        format!("((_ zero_extend {pad}) {})", r.s)
+                    },
                     width: w,
                     signed: false,
                 })
             }
             "sext" => {
-                let w = target_w.ok_or_else(|| CompileError::general(
-                    ".sext<N>() requires a constant width argument", span,
-                ))?;
+                let w = target_w.ok_or_else(|| {
+                    CompileError::general(".sext<N>() requires a constant width argument", span)
+                })?;
                 if w < r.width {
                     return Err(CompileError::general(
-                        ".sext<N>() target must be ≥ current width", span,
+                        ".sext<N>() target must be ≥ current width",
+                        span,
                     ));
                 }
                 let pad = w - r.width;
                 Ok(SmtTerm {
-                    s: if pad == 0 { r.s.clone() }
-                       else { format!("((_ sign_extend {pad}) {})", r.s) },
+                    s: if pad == 0 {
+                        r.s.clone()
+                    } else {
+                        format!("((_ sign_extend {pad}) {})", r.s)
+                    },
                     width: w,
                     signed: true,
                 })
             }
             "resize" => {
-                let w = target_w.ok_or_else(|| CompileError::general(
-                    ".resize<N>() requires a constant width argument", span,
-                ))?;
+                let w = target_w.ok_or_else(|| {
+                    CompileError::general(".resize<N>() requires a constant width argument", span)
+                })?;
                 let signed = r.signed;
                 Ok(coerce(r, w, signed))
             }
@@ -2409,10 +2664,8 @@ impl<'a> FormalCtx<'a> {
         args: &FormalArgs,
     ) -> Result<PropertyResult, CompileError> {
         // Detect top-level `a |=> b` — encode `a@t → b@(t+1)` directly.
-        let toplevel_implies_next = matches!(
-            &prop.expr.kind,
-            ExprKind::Binary(BinOp::ImpliesNext, _, _)
-        );
+        let toplevel_implies_next =
+            matches!(&prop.expr.kind, ExprKind::Binary(BinOp::ImpliesNext, _, _));
 
         // Determine the cycle range over which the property is well-defined:
         // - past(_, N), rose, fell need t ≥ past_depth (past values undefined).
@@ -2444,12 +2697,15 @@ impl<'a> FormalCtx<'a> {
         // the lhs sequence ends at t+N, so rhs samples at t+N+1.
         let lhs_future = if let ExprKind::Binary(BinOp::ImpliesNext, lhs, _) = &prop.expr.kind {
             max_cycle_offsets(lhs).1
-        } else { 0 };
+        } else {
+            0
+        };
 
         // Encode the property at each cycle min_t..=max_t.
         let mut per_cycle: Vec<String> = Vec::with_capacity((max_t - min_t + 1) as usize);
         for t in min_t..=max_t {
-            let bool_term = if let ExprKind::Binary(BinOp::ImpliesNext, lhs, rhs) = &prop.expr.kind {
+            let bool_term = if let ExprKind::Binary(BinOp::ImpliesNext, lhs, rhs) = &prop.expr.kind
+            {
                 // a@t → b@(t+1+lhs_future) ≡ ¬a@t ∨ b@(t+1+lhs_future)
                 let la = self.encode_expr(lhs, t, Some((1, false)))?;
                 let lb = self.encode_expr(rhs, t + 1 + lhs_future, Some((1, false)))?;
@@ -2471,7 +2727,9 @@ impl<'a> FormalCtx<'a> {
             AssertKind::Assert => "#b0",
             AssertKind::Cover => "#b1",
         };
-        let disjuncts: Vec<String> = per_cycle.iter().enumerate()
+        let disjuncts: Vec<String> = per_cycle
+            .iter()
+            .enumerate()
             .map(|(_i, p)| format!("(= {p} {matcher})"))
             .collect();
         let assertion = if disjuncts.len() == 1 {
@@ -2483,7 +2741,10 @@ impl<'a> FormalCtx<'a> {
         // Compose final SMT text
         let mut smt = String::with_capacity(base.len() + 256);
         smt.push_str(base);
-        smt.push_str(&format!("\n; ── property `{}` ({:?}) ──\n", prop.name, prop.kind));
+        smt.push_str(&format!(
+            "\n; ── property `{}` ({:?}) ──\n",
+            prop.name, prop.kind
+        ));
         smt.push_str(&format!("(assert {assertion})\n"));
         smt.push_str("(check-sat)\n");
         // We always emit get-model; the solver will ignore it on unsat/unknown for most tools.
@@ -2492,9 +2753,8 @@ impl<'a> FormalCtx<'a> {
         smt.push_str("(get-model)\n");
 
         // Shell out
-        let sr = invoke_solver(&args.solver, &smt, args.timeout).map_err(|e| {
-            CompileError::general(&format!("solver error: {e}"), prop.span)
-        })?;
+        let sr = invoke_solver(&args.solver, &smt, args.timeout)
+            .map_err(|e| CompileError::general(&format!("solver error: {e}"), prop.span))?;
 
         // Parse result
         let first_word = sr.stdout.split_ascii_whitespace().next().unwrap_or("");
@@ -2504,25 +2764,40 @@ impl<'a> FormalCtx<'a> {
                 let model = sr.stdout.splitn(2, '\n').nth(1).unwrap_or("").to_string();
                 let assignments = parse_model(&model);
                 // Determine failing cycle by evaluating per_cycle against the model.
-                let failing_cycle = find_first_failing_cycle(&prop.kind, &prop.expr, self, &assignments, args.bound);
-                let cex = render_counterexample(&prop.name, failing_cycle, self, &assignments, args.bound);
+                let failing_cycle = find_first_failing_cycle(
+                    &prop.kind,
+                    &prop.expr,
+                    self,
+                    &assignments,
+                    args.bound,
+                );
+                let cex = render_counterexample(
+                    &prop.name,
+                    failing_cycle,
+                    self,
+                    &assignments,
+                    args.bound,
+                );
                 match prop.kind {
                     AssertKind::Assert => PropertyStatus::Refuted(failing_cycle),
-                    AssertKind::Cover  => PropertyStatus::Hit(failing_cycle),
+                    AssertKind::Cover => PropertyStatus::Hit(failing_cycle),
                 }
                 .with_cex(cex)
             }
             "unsat" => match prop.kind {
                 AssertKind::Assert => PropertyStatus::Proved(args.bound).with_cex(None),
-                AssertKind::Cover  => PropertyStatus::NotReached(args.bound).with_cex(None),
+                AssertKind::Cover => PropertyStatus::NotReached(args.bound).with_cex(None),
             },
             _ => PropertyStatus::Inconclusive(
                 if sr.stdout.contains("timeout") || !sr.stderr.is_empty() {
-                    format!("solver returned `{first_word}`: {}{}", sr.stdout, sr.stderr).trim().to_string()
+                    format!("solver returned `{first_word}`: {}{}", sr.stdout, sr.stderr)
+                        .trim()
+                        .to_string()
                 } else {
                     format!("solver returned `{first_word}`")
                 },
-            ).with_cex(None),
+            )
+            .with_cex(None),
         };
 
         Ok(PropertyResult {
@@ -2535,10 +2810,15 @@ impl<'a> FormalCtx<'a> {
 }
 
 // Helper: associate a counter-example with a status without double-wrapping.
-struct StatusWithCex { status: PropertyStatus, cex: Option<String> }
+struct StatusWithCex {
+    status: PropertyStatus,
+    cex: Option<String>,
+}
 
 impl PropertyStatus {
-    fn with_cex(self, cex: Option<String>) -> StatusWithCex { StatusWithCex { status: self, cex } }
+    fn with_cex(self, cex: Option<String>) -> StatusWithCex {
+        StatusWithCex { status: self, cex }
+    }
 }
 
 // ── SMT value helpers ────────────────────────────────────────────────────────
@@ -2554,21 +2834,35 @@ fn bv_lit(value: u64, width: u32) -> String {
     // Prefer hex for widths divisible by 4, else decimal form.
     if width % 4 == 0 && width <= 64 {
         let digits = (width / 4) as usize;
-        let mask = if width >= 64 { u64::MAX } else { (1u64 << width) - 1 };
+        let mask = if width >= 64 {
+            u64::MAX
+        } else {
+            (1u64 << width) - 1
+        };
         format!("#x{:0width$x}", value & mask, width = digits)
     } else if width <= 64 {
-        let mask = if width >= 64 { u64::MAX } else { (1u64 << width) - 1 };
+        let mask = if width >= 64 {
+            u64::MAX
+        } else {
+            (1u64 << width) - 1
+        };
         format!("(_ bv{} {})", value & mask, width)
     } else {
         format!("(_ bv{value} {width})")
     }
 }
 
-fn bv_zero(width: u32) -> String { bv_lit(0, width) }
+fn bv_zero(width: u32) -> String {
+    bv_lit(0, width)
+}
 
 fn bv_all_ones(width: u32) -> String {
     if width <= 64 {
-        let v = if width == 64 { u64::MAX } else { (1u64 << width) - 1 };
+        let v = if width == 64 {
+            u64::MAX
+        } else {
+            (1u64 << width) - 1
+        };
         bv_lit(v, width)
     } else {
         format!("(bvnot {})", bv_zero(width))
@@ -2579,7 +2873,9 @@ fn bv_all_ones(width: u32) -> String {
 /// a scalar UInt/SInt/Bool/Bit. Returns None for non-scalar payloads
 /// (Vec / struct / named) — those can't be modelled in formal v1.
 fn cc_payload_width(meta: &CreditChannelMeta) -> Option<u32> {
-    let t = meta.params.iter()
+    let t = meta
+        .params
+        .iter()
         .find(|p| p.name.name == "T")
         .and_then(|p| match &p.kind {
             ParamKind::Type(te) => Some(te.clone()),
@@ -2603,15 +2899,27 @@ fn lit_to_term(l: &LitKind) -> SmtTerm {
         LitKind::Dec(v) | LitKind::Hex(v) | LitKind::Bin(v) => {
             // Intrinsic width = bit-length, or 1 for value 0.
             let w = if *v == 0 { 1 } else { 64 - v.leading_zeros() };
-            SmtTerm { s: bv_lit(*v, w), width: w, signed: false }
+            SmtTerm {
+                s: bv_lit(*v, w),
+                width: w,
+                signed: false,
+            }
         }
-        LitKind::Sized(w, v) => SmtTerm { s: bv_lit(*v, *w), width: *w, signed: false },
+        LitKind::Sized(w, v) => SmtTerm {
+            s: bv_lit(*v, *w),
+            width: *w,
+            signed: false,
+        },
         // Float literals are unreachable here in practice — FP types are rejected
         // by `check_scalar_type` before emission. Fall back to the FP32 bit
         // pattern as a 32-bit vector so this stays total.
         LitKind::Float(bits) => {
             let f = (f64::from_bits(*bits)) as f32;
-            SmtTerm { s: bv_lit(f.to_bits() as u64, 32), width: 32, signed: false }
+            SmtTerm {
+                s: bv_lit(f.to_bits() as u64, 32),
+                width: 32,
+                signed: false,
+            }
         }
     }
 }
@@ -2623,7 +2931,11 @@ fn coerce(t: SmtTerm, width: u32, signed: bool) -> SmtTerm {
     }
     if t.width < width {
         let pad = width - t.width;
-        let op = if t.signed { "sign_extend" } else { "zero_extend" };
+        let op = if t.signed {
+            "sign_extend"
+        } else {
+            "zero_extend"
+        };
         SmtTerm {
             s: format!("((_ {op} {pad}) {})", t.s),
             width,
@@ -2677,18 +2989,44 @@ fn target_root_ident(expr: &Expr) -> Option<String> {
 fn collect_idents(expr: &Expr, out: &mut HashSet<String>) {
     use ExprKind::*;
     match &expr.kind {
-        Ident(n) => { out.insert(n.clone()); }
-        Binary(_, a, b) => { collect_idents(a, out); collect_idents(b, out); }
+        Ident(n) => {
+            out.insert(n.clone());
+        }
+        Binary(_, a, b) => {
+            collect_idents(a, out);
+            collect_idents(b, out);
+        }
         Unary(_, a) => collect_idents(a, out),
-        Ternary(c, t, e) => { collect_idents(c, out); collect_idents(t, out); collect_idents(e, out); }
+        Ternary(c, t, e) => {
+            collect_idents(c, out);
+            collect_idents(t, out);
+            collect_idents(e, out);
+        }
         MethodCall(recv, _, args) => {
             collect_idents(recv, out);
-            for a in args { collect_idents(a, out); }
+            for a in args {
+                collect_idents(a, out);
+            }
         }
-        BitSlice(b, hi, lo) => { collect_idents(b, out); collect_idents(hi, out); collect_idents(lo, out); }
-        PartSelect(b, s, w, _) => { collect_idents(b, out); collect_idents(s, out); collect_idents(w, out); }
-        Concat(es) => for e in es { collect_idents(e, out); }
-        Repeat(n, x) => { collect_idents(n, out); collect_idents(x, out); }
+        BitSlice(b, hi, lo) => {
+            collect_idents(b, out);
+            collect_idents(hi, out);
+            collect_idents(lo, out);
+        }
+        PartSelect(b, s, w, _) => {
+            collect_idents(b, out);
+            collect_idents(s, out);
+            collect_idents(w, out);
+        }
+        Concat(es) => {
+            for e in es {
+                collect_idents(e, out);
+            }
+        }
+        Repeat(n, x) => {
+            collect_idents(n, out);
+            collect_idents(x, out);
+        }
         Signed(e) | Unsigned(e) | Clog2(e) | Onehot(e) => collect_idents(e, out),
         Cast(e, _) | FieldAccess(e, _) | Index(e, _) => collect_idents(e, out),
         _ => {}
@@ -2701,8 +3039,14 @@ fn and_all(conds: &[Expr]) -> Expr {
     }
     let mut acc = conds[0].clone();
     for c in conds.iter().skip(1) {
-        let span = Span { start: acc.span.start.min(c.span.start), end: acc.span.end.max(c.span.end) };
-        acc = Expr::new(ExprKind::Binary(BinOp::And, Box::new(acc), Box::new(c.clone())), span);
+        let span = Span {
+            start: acc.span.start.min(c.span.start),
+            end: acc.span.end.max(c.span.end),
+        };
+        acc = Expr::new(
+            ExprKind::Binary(BinOp::And, Box::new(acc), Box::new(c.clone())),
+            span,
+        );
     }
     acc
 }
@@ -2725,7 +3069,9 @@ fn s_span(s: &Stmt) -> Span {
     }
 }
 
-fn e_display(e: &CompileError, _sp: Span) -> String { format!("{e}") }
+fn e_display(e: &CompileError, _sp: Span) -> String {
+    format!("{e}")
+}
 
 /// Minimal constant folder for compile-time expressions.
 /// Handles literals, param refs, and common arithmetic.
@@ -2743,13 +3089,25 @@ fn fold_const_expr(expr: &Expr, params: &HashMap<String, u64>) -> Option<u64> {
                 BinOp::Add | BinOp::AddWrap => va.wrapping_add(vb),
                 BinOp::Sub | BinOp::SubWrap => va.wrapping_sub(vb),
                 BinOp::Mul | BinOp::MulWrap => va.wrapping_mul(vb),
-                BinOp::Div => if vb == 0 { return None; } else { va / vb },
-                BinOp::Mod => if vb == 0 { return None; } else { va % vb },
+                BinOp::Div => {
+                    if vb == 0 {
+                        return None;
+                    } else {
+                        va / vb
+                    }
+                }
+                BinOp::Mod => {
+                    if vb == 0 {
+                        return None;
+                    } else {
+                        va % vb
+                    }
+                }
                 BinOp::BitAnd => va & vb,
-                BinOp::BitOr  => va | vb,
+                BinOp::BitOr => va | vb,
                 BinOp::BitXor => va ^ vb,
-                BinOp::Shl    => va << (vb & 63),
-                BinOp::Shr    => va >> (vb & 63),
+                BinOp::Shl => va << (vb & 63),
+                BinOp::Shr => va >> (vb & 63),
                 _ => return None,
             })
         }
@@ -2759,7 +3117,11 @@ fn fold_const_expr(expr: &Expr, params: &HashMap<String, u64>) -> Option<u64> {
         }
         ExprKind::Clog2(inner) => {
             let v = fold_const_expr(inner, params)?;
-            Some(if v <= 1 { 1 } else { 64 - (v - 1).leading_zeros() as u64 })
+            Some(if v <= 1 {
+                1
+            } else {
+                64 - (v - 1).leading_zeros() as u64
+            })
         }
         _ => None,
     }
@@ -2774,22 +3136,39 @@ struct SolverResult {
 
 fn invoke_solver(solver: &str, smt: &str, timeout_s: u32) -> std::io::Result<SolverResult> {
     let (prog, args): (&str, Vec<String>) = match solver {
-        "z3" => ("z3", vec![
-            "-in".to_string(),
-            format!("-T:{timeout_s}"),
-            "-smt2".to_string(),
-        ]),
-        "boolector" => ("boolector", vec![
-            "--smt2".to_string(),
-            "-m".to_string(),
-            format!("--time={timeout_s}"),
-        ]),
-        "bitwuzla" => ("bitwuzla", vec![
-            "--produce-models=true".to_string(),
-            // bitwuzla -t takes milliseconds.
-            format!("-t"), format!("{}", timeout_s * 1000),
-        ]),
-        other => ("z3", vec!["-in".to_string(), format!("-T:{timeout_s}"), format!("--solver={other}")]),
+        "z3" => (
+            "z3",
+            vec![
+                "-in".to_string(),
+                format!("-T:{timeout_s}"),
+                "-smt2".to_string(),
+            ],
+        ),
+        "boolector" => (
+            "boolector",
+            vec![
+                "--smt2".to_string(),
+                "-m".to_string(),
+                format!("--time={timeout_s}"),
+            ],
+        ),
+        "bitwuzla" => (
+            "bitwuzla",
+            vec![
+                "--produce-models=true".to_string(),
+                // bitwuzla -t takes milliseconds.
+                format!("-t"),
+                format!("{}", timeout_s * 1000),
+            ],
+        ),
+        other => (
+            "z3",
+            vec![
+                "-in".to_string(),
+                format!("-T:{timeout_s}"),
+                format!("--solver={other}"),
+            ],
+        ),
     };
 
     let mut child = Command::new(prog)
@@ -2844,20 +3223,27 @@ fn parse_model(text: &str) -> HashMap<String, u64> {
                     b'(' => depth += 1,
                     b')' => {
                         depth -= 1;
-                        if depth == 0 { break; }
+                        if depth == 0 {
+                            break;
+                        }
                     }
                     _ => {}
                 }
                 j += 1;
             }
-            if j >= bytes.len() { break; }
+            if j >= bytes.len() {
+                break;
+            }
             // group spans i..=j, inclusive of both parens.
             let inner = &flat[i + needle.len()..j];
             // inner: `NAME () (_ BitVec W) VAL`
             // Extract name (first whitespace-separated token).
             let mut name_end = 0;
             for (k, c) in inner.char_indices() {
-                if c.is_whitespace() { name_end = k; break; }
+                if c.is_whitespace() {
+                    name_end = k;
+                    break;
+                }
             }
             if name_end == 0 {
                 i = j + 1;
@@ -2936,7 +3322,9 @@ fn parse_bv_literal(s: &str) -> Option<u64> {
 /// the skipped cycles.
 fn max_cycle_offsets(e: &Expr) -> (u32, u32) {
     use ExprKind::*;
-    fn cmb(a: (u32, u32), b: (u32, u32)) -> (u32, u32) { (a.0.max(b.0), a.1.max(b.1)) }
+    fn cmb(a: (u32, u32), b: (u32, u32)) -> (u32, u32) {
+        (a.0.max(b.0), a.1.max(b.1))
+    }
     match &e.kind {
         FunctionCall(name, args) if name == "past" && args.len() == 2 => {
             let n = match &args[1].kind {
@@ -2955,22 +3343,39 @@ fn max_cycle_offsets(e: &Expr) -> (u32, u32) {
             (p, n + f)
         }
         Binary(_, l, r) => cmb(max_cycle_offsets(l), max_cycle_offsets(r)),
-        Unary(_, x) | Cast(x, _) | Clog2(x) | Onehot(x) | Signed(x) | Unsigned(x)
+        Unary(_, x)
+        | Cast(x, _)
+        | Clog2(x)
+        | Onehot(x)
+        | Signed(x)
+        | Unsigned(x)
         | LatencyAt(x, _) => max_cycle_offsets(x),
-        Ternary(c, t, el) => cmb(cmb(max_cycle_offsets(c), max_cycle_offsets(t)), max_cycle_offsets(el)),
+        Ternary(c, t, el) => cmb(
+            cmb(max_cycle_offsets(c), max_cycle_offsets(t)),
+            max_cycle_offsets(el),
+        ),
         Index(b, i) => cmb(max_cycle_offsets(b), max_cycle_offsets(i)),
         BitSlice(b, _, _) => max_cycle_offsets(b),
-        PartSelect(b, s, w, _) => cmb(cmb(max_cycle_offsets(b), max_cycle_offsets(s)), max_cycle_offsets(w)),
-        Concat(xs) | FunctionCall(_, xs) => xs.iter().fold((0, 0), |a, x| cmb(a, max_cycle_offsets(x))),
+        PartSelect(b, s, w, _) => cmb(
+            cmb(max_cycle_offsets(b), max_cycle_offsets(s)),
+            max_cycle_offsets(w),
+        ),
+        Concat(xs) | FunctionCall(_, xs) => {
+            xs.iter().fold((0, 0), |a, x| cmb(a, max_cycle_offsets(x)))
+        }
         Repeat(n, x) => cmb(max_cycle_offsets(n), max_cycle_offsets(x)),
-        MethodCall(r, _, args) => cmb(max_cycle_offsets(r),
-            args.iter().fold((0, 0), |a, x| cmb(a, max_cycle_offsets(x)))),
+        MethodCall(r, _, args) => cmb(
+            max_cycle_offsets(r),
+            args.iter()
+                .fold((0, 0), |a, x| cmb(a, max_cycle_offsets(x))),
+        ),
         FieldAccess(b, _) => max_cycle_offsets(b),
-        StructLiteral(_, fs) => fs.iter().fold((0, 0), |a, fi| cmb(a, max_cycle_offsets(&fi.value))),
+        StructLiteral(_, fs) => fs
+            .iter()
+            .fold((0, 0), |a, fi| cmb(a, max_cycle_offsets(&fi.value))),
         _ => (0, 0),
     }
 }
-
 
 // ── Counterexample rendering ────────────────────────────────────────────────
 
@@ -2983,7 +3388,11 @@ fn find_first_failing_cycle(
 ) -> u32 {
     let target_bit = matches!(kind, AssertKind::Cover) as u64; // cover: want 1; assert: want 0 (failing)
     let (min_t, future_depth) = max_cycle_offsets(expr);
-    let extra = if matches!(&expr.kind, ExprKind::Binary(BinOp::ImpliesNext, _, _)) { 1 } else { 0 };
+    let extra = if matches!(&expr.kind, ExprKind::Binary(BinOp::ImpliesNext, _, _)) {
+        1
+    } else {
+        0
+    };
     let max_t = bound.saturating_sub(future_depth + extra);
     if min_t > max_t {
         return min_t.min(bound);
@@ -3006,7 +3415,9 @@ fn render_counterexample(
     _bound: u32,
 ) -> Option<String> {
     let mut lines = Vec::new();
-    lines.push(format!("Counterexample for `{prop_name}` at cycle {cycle}:"));
+    lines.push(format!(
+        "Counterexample for `{prop_name}` at cycle {cycle}:"
+    ));
     lines.push(String::new());
     // Header
     let mut names: Vec<String> = Vec::new();
@@ -3014,7 +3425,8 @@ fn render_counterexample(
     names.extend(ctx.inputs.iter().filter(|n| *n != &ctx.reset.name).cloned());
     names.extend(ctx.regs.iter().cloned());
     let header: Vec<String> = std::iter::once("cycle".to_string())
-        .chain(names.iter().cloned()).collect();
+        .chain(names.iter().cloned())
+        .collect();
     lines.push(header.join("  "));
 
     let start = cycle.saturating_sub(2);
@@ -3038,11 +3450,15 @@ fn eval_expr_numeric(
 ) -> Option<u64> {
     use ExprKind::*;
     match &expr.kind {
-        Literal(LitKind::Dec(v)) | Literal(LitKind::Hex(v)) | Literal(LitKind::Bin(v))
+        Literal(LitKind::Dec(v))
+        | Literal(LitKind::Hex(v))
+        | Literal(LitKind::Bin(v))
         | Literal(LitKind::Sized(_, v)) => Some(*v),
         Bool(b) => Some(if *b { 1 } else { 0 }),
         Ident(n) => {
-            if let Some(v) = ctx.params.get(n) { return Some(*v); }
+            if let Some(v) = ctx.params.get(n) {
+                return Some(*v);
+            }
             if let Some(val) = ctx.let_bindings.get(n) {
                 return eval_expr_numeric(val, t, ctx, assignments);
             }
@@ -3061,8 +3477,20 @@ fn eval_expr_numeric(
                 BinOp::Add | BinOp::AddWrap => va.wrapping_add(vb),
                 BinOp::Sub | BinOp::SubWrap => va.wrapping_sub(vb),
                 BinOp::Mul | BinOp::MulWrap => va.wrapping_mul(vb),
-                BinOp::Div => if vb == 0 { 0 } else { va / vb },
-                BinOp::Mod => if vb == 0 { 0 } else { va % vb },
+                BinOp::Div => {
+                    if vb == 0 {
+                        0
+                    } else {
+                        va / vb
+                    }
+                }
+                BinOp::Mod => {
+                    if vb == 0 {
+                        0
+                    } else {
+                        va % vb
+                    }
+                }
                 BinOp::Eq => (va == vb) as u64,
                 BinOp::Neq => (va != vb) as u64,
                 BinOp::Lt => (va < vb) as u64,
@@ -3070,9 +3498,9 @@ fn eval_expr_numeric(
                 BinOp::Lte => (va <= vb) as u64,
                 BinOp::Gte => (va >= vb) as u64,
                 BinOp::And => ((va != 0) && (vb != 0)) as u64,
-                BinOp::Or  => ((va != 0) || (vb != 0)) as u64,
+                BinOp::Or => ((va != 0) || (vb != 0)) as u64,
                 BinOp::BitAnd => va & vb,
-                BinOp::BitOr  => va | vb,
+                BinOp::BitOr => va | vb,
                 BinOp::BitXor => va ^ vb,
                 BinOp::Shl => va << (vb & 63),
                 BinOp::Shr => va >> (vb & 63),
@@ -3093,23 +3521,33 @@ fn eval_expr_numeric(
         }
         Ternary(c, tt, ee) => {
             let cv = eval_expr_numeric(c, t, ctx, assignments)?;
-            if cv != 0 { eval_expr_numeric(tt, t, ctx, assignments) }
-            else       { eval_expr_numeric(ee, t, ctx, assignments) }
+            if cv != 0 {
+                eval_expr_numeric(tt, t, ctx, assignments)
+            } else {
+                eval_expr_numeric(ee, t, ctx, assignments)
+            }
         }
         FunctionCall(name, args) if name == "past" && args.len() == 2 => {
             let n = match &args[1].kind {
                 Literal(LitKind::Dec(n)) | Literal(LitKind::Sized(_, n)) => *n as u32,
                 _ => return None,
             };
-            if t < n { return None; }
+            if t < n {
+                return None;
+            }
             eval_expr_numeric(&args[0], t - n, ctx, assignments)
         }
         FunctionCall(name, args) if (name == "rose" || name == "fell") && args.len() == 1 => {
-            if t < 1 { return None; }
+            if t < 1 {
+                return None;
+            }
             let now = eval_expr_numeric(&args[0], t, ctx, assignments)? & 1;
             let prev = eval_expr_numeric(&args[0], t - 1, ctx, assignments)? & 1;
-            Some(if name == "rose" { (now == 1 && prev == 0) as u64 }
-                 else                { (now == 0 && prev == 1) as u64 })
+            Some(if name == "rose" {
+                (now == 1 && prev == 0) as u64
+            } else {
+                (now == 0 && prev == 1) as u64
+            })
         }
         SvaNext(n, inner) => eval_expr_numeric(inner, t + n, ctx, assignments),
         _ => None,

--- a/src/fp_ir.rs
+++ b/src/fp_ir.rs
@@ -86,7 +86,14 @@ pub fn var(name: &str, width: u32) -> Bv {
 /// `x[hi:lo]` — result width `hi-lo+1`.
 pub fn extract(x: &Bv, hi: u32, lo: u32) -> Bv {
     assert!(hi >= lo && hi < x.width(), "extract out of range");
-    Bv::mk(hi - lo + 1, Kind::Extract { x: x.clone(), hi, lo })
+    Bv::mk(
+        hi - lo + 1,
+        Kind::Extract {
+            x: x.clone(),
+            hi,
+            lo,
+        },
+    )
 }
 /// `{a, b}` — concatenation, `a` is the high part.
 pub fn concat(a: &Bv, b: &Bv) -> Bv {
@@ -102,7 +109,14 @@ pub fn zext(x: &Bv, to: u32) -> Bv {
 }
 fn bin(op: Bin, a: &Bv, b: &Bv) -> Bv {
     assert_eq!(a.width(), b.width(), "binop width mismatch");
-    Bv::mk(a.width(), Kind::Bin { op, a: a.clone(), b: b.clone() })
+    Bv::mk(
+        a.width(),
+        Kind::Bin {
+            op,
+            a: a.clone(),
+            b: b.clone(),
+        },
+    )
 }
 pub fn add(a: &Bv, b: &Bv) -> Bv {
     bin(Bin::Add, a, b)
@@ -137,11 +151,25 @@ pub fn bnot(x: &Bv) -> Bv {
 pub fn ite(c: &Bv, t: &Bv, e: &Bv) -> Bv {
     assert_eq!(c.width(), 1, "ite condition must be 1-bit");
     assert_eq!(t.width(), e.width(), "ite arms width mismatch");
-    Bv::mk(t.width(), Kind::Ite { c: c.clone(), t: t.clone(), e: e.clone() })
+    Bv::mk(
+        t.width(),
+        Kind::Ite {
+            c: c.clone(),
+            t: t.clone(),
+            e: e.clone(),
+        },
+    )
 }
 fn cmp(op: Cmp, a: &Bv, b: &Bv) -> Bv {
     assert_eq!(a.width(), b.width(), "compare width mismatch");
-    Bv::mk(1, Kind::Cmp { op, a: a.clone(), b: b.clone() })
+    Bv::mk(
+        1,
+        Kind::Cmp {
+            op,
+            a: a.clone(),
+            b: b.clone(),
+        },
+    )
 }
 pub fn eq(a: &Bv, b: &Bv) -> Bv {
     cmp(Cmp::Eq, a, b)
@@ -189,7 +217,13 @@ pub fn not(a: &Bv) -> Bv {
 }
 /// Call another `FpFn` by name; `width` is the callee's return width.
 pub fn call(name: &str, args: &[Bv], width: u32) -> Bv {
-    Bv::mk(width, Kind::Call { name: name.to_string(), args: args.to_vec() })
+    Bv::mk(
+        width,
+        Kind::Call {
+            name: name.to_string(),
+            args: args.to_vec(),
+        },
+    )
 }
 
 /// A single FP helper: name, typed parameters, and a return expression.
@@ -224,7 +258,10 @@ fn is_leaf(b: &Bv) -> bool {
 }
 
 fn linearize(body: &Bv) -> Lin {
-    let mut lin = Lin { ids: HashMap::new(), order: Vec::new() };
+    let mut lin = Lin {
+        ids: HashMap::new(),
+        order: Vec::new(),
+    };
     fn go(b: &Bv, lin: &mut Lin) {
         if is_leaf(b) {
             return;
@@ -345,7 +382,13 @@ fn render_sv_fn(f: &FpFn) -> String {
     );
     for b in &lin.order {
         let id = lin.ids[&(Rc::as_ptr(&b.0) as usize)];
-        let _ = writeln!(s, "  logic {}_t{} = {};", sv_decl_width(b.width()), id, sv_rhs(b, &lin));
+        let _ = writeln!(
+            s,
+            "  logic {}_t{} = {};",
+            sv_decl_width(b.width()),
+            id,
+            sv_rhs(b, &lin)
+        );
     }
     let _ = writeln!(s, "  {} = {};", f.name, sv_ref(&f.body, &lin));
     let _ = writeln!(s, "endfunction");
@@ -417,8 +460,11 @@ fn smt_rhs(b: &Bv, lin: &Lin) -> String {
 
 fn render_smt_fn(f: &FpFn) -> String {
     let lin = linearize(&f.body);
-    let params: Vec<String> =
-        f.params.iter().map(|(n, w)| format!("({n} {})", smt_sort(*w))).collect();
+    let params: Vec<String> = f
+        .params
+        .iter()
+        .map(|(n, w)| format!("({n} {})", smt_sort(*w)))
+        .collect();
     let mut body = smt_ref(&f.body, &lin);
     // Wrap the temporaries as nested `let`s, innermost last.
     for b in lin.order.iter().rev() {
@@ -503,7 +549,12 @@ fn lean_rhs(b: &Bv, lin: &Lin) -> String {
         }
         // Selector is a 1-bit BV; `c == 1#1` is a Bool the `if` bit-blasts.
         Kind::Ite { c, t, e } => {
-            format!("(if {} == (BitVec.ofNat 1 1) then {} else {})", r(c), r(t), r(e))
+            format!(
+                "(if {} == (BitVec.ofNat 1 1) then {} else {})",
+                r(c),
+                r(t),
+                r(e)
+            )
         }
         Kind::Call { name, args } => {
             let a: Vec<String> = args.iter().map(|x| r(x)).collect();
@@ -515,12 +566,26 @@ fn lean_rhs(b: &Bv, lin: &Lin) -> String {
 fn render_lean_fn(f: &FpFn) -> String {
     let lin = linearize(&f.body);
     let mut s = String::new();
-    let params: Vec<String> =
-        f.params.iter().map(|(n, w)| format!("({n} : BitVec {w})")).collect();
-    let _ = writeln!(s, "def {} {} : BitVec {} :=", f.name, params.join(" "), f.ret_w);
+    let params: Vec<String> = f
+        .params
+        .iter()
+        .map(|(n, w)| format!("({n} : BitVec {w})"))
+        .collect();
+    let _ = writeln!(
+        s,
+        "def {} {} : BitVec {} :=",
+        f.name,
+        params.join(" "),
+        f.ret_w
+    );
     for b in &lin.order {
         let id = lin.ids[&(Rc::as_ptr(&b.0) as usize)];
-        let _ = writeln!(s, "  let _t{id} : BitVec {} := {}", b.width(), lean_rhs(b, &lin));
+        let _ = writeln!(
+            s,
+            "  let _t{id} : BitVec {} := {}",
+            b.width(),
+            lean_rhs(b, &lin)
+        );
     }
     let _ = writeln!(s, "  {}", lean_ref(&f.body, &lin));
     s
@@ -530,7 +595,11 @@ fn render_lean_fn(f: &FpFn) -> String {
 /// `BitVec`, dependency-free — Lean core only). Wrap in a `namespace` and proofs
 /// at the call site (see `proofs/lean_fp_equiv/`).
 pub fn render_lean(funcs: &[FpFn]) -> String {
-    funcs.iter().map(render_lean_fn).collect::<Vec<_>>().join("\n")
+    funcs
+        .iter()
+        .map(render_lean_fn)
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 #[cfg(test)]
@@ -548,7 +617,9 @@ mod tests {
         let f = FpFn::new("t", &[("a", 8), ("b", 8)], 8, body);
 
         let sv = render_sv(&[f]);
-        assert!(sv.contains("function automatic logic [7:0] t(input logic [7:0] a, input logic [7:0] b);"));
+        assert!(sv.contains(
+            "function automatic logic [7:0] t(input logic [7:0] a, input logic [7:0] b);"
+        ));
         assert!(sv.contains(" + "));
         assert!(sv.contains("[0]"));
         assert!(sv.contains("? "));
@@ -598,9 +669,20 @@ mod tests {
         let f = FpFn::new("k", &[("a", 8), ("b", 8)], 8, body);
         let lean = render_lean(&[f]);
         for needle in [
-            "BitVec.slt", "++", "BitVec.setWidth", "~~~", "&&&", "^^^", ">>>", "<<<", ".toNat",
+            "BitVec.slt",
+            "++",
+            "BitVec.setWidth",
+            "~~~",
+            "&&&",
+            "^^^",
+            ">>>",
+            "<<<",
+            ".toNat",
         ] {
-            assert!(lean.contains(needle), "Lean output missing {needle}:\n{lean}");
+            assert!(
+                lean.contains(needle),
+                "Lean output missing {needle}:\n{lean}"
+            );
         }
     }
 }

--- a/src/fp_ops.rs
+++ b/src/fp_ops.rs
@@ -47,7 +47,11 @@ fn decode(x: &Bv) -> Dec {
     Dec {
         sign,
         mant: ite(&e_is_0, &concat(&cst(0, 1), &f), &concat(&cst(1, 1), &f)),
-        eunb: ite(&e_is_0, &cst(NEG149_16, 16), &sub(&zext(&e, 16), &cst(150, 16))),
+        eunb: ite(
+            &e_is_0,
+            &cst(NEG149_16, 16),
+            &sub(&zext(&e, 16), &cst(150, 16)),
+        ),
         is_zero: and(&e_is_0, &f_z),
         is_inf: and(&e_is_ff, &f_z),
         is_nan: and(&e_is_ff, &f_nz),
@@ -119,7 +123,10 @@ fn normround(sign: &Bv, sig: &Bv, e0: &Bv) -> Bv {
     let kept = add(&kept0, &zext(&roundup, w2));
 
     // subnormal: {exp,frac} encoding carries up to the smallest normal for free.
-    let sub_res = bor(&concat(sign, &cst(0, 31)), &concat(sign, &extract(&kept, 30, 0)));
+    let sub_res = bor(
+        &concat(sign, &cst(0, 31)),
+        &concat(sign, &extract(&kept, 30, 0)),
+    );
 
     // normal: a carry into bit 24 bumps the exponent; >=255 overflows to inf.
     let carry = is1(&extract(&kept, 24, 24));
@@ -127,7 +134,10 @@ fn normround(sign: &Bv, sig: &Bv, e0: &Bv) -> Bv {
     let kept_n = ite(&carry, &lshr(&kept, &cst(1, 16)), &kept);
     let overflow = sge(&biased_n, &cst(255, 16));
     let inf = concat(sign, &concat(&cst(0xFF, 8), &cst(0, 23)));
-    let packed = concat(sign, &concat(&extract(&biased_n, 7, 0), &extract(&kept_n, 22, 0)));
+    let packed = concat(
+        sign,
+        &concat(&extract(&biased_n, 7, 0), &extract(&kept_n, 22, 0)),
+    );
     let norm_res = ite(&overflow, &inf, &packed);
 
     let zero = concat(sign, &cst(0, 31));
@@ -141,13 +151,20 @@ fn normround(sign: &Bv, sig: &Bv, e0: &Bv) -> Bv {
 // ── predicates / simple ops (as expressions for reuse) ──────────────────────
 
 fn isnan(x: &Bv) -> Bv {
-    and(&eq(&extract(x, 30, 23), &cst(0xFF, 8)), &ne(&extract(x, 22, 0), &cst(0, 23)))
+    and(
+        &eq(&extract(x, 30, 23), &cst(0xFF, 8)),
+        &ne(&extract(x, 22, 0), &cst(0, 23)),
+    )
 }
 fn iszero(x: &Bv) -> Bv {
     eq(&extract(x, 30, 0), &cst(0, 31))
 }
 fn eq_expr(a: &Bv, b: &Bv) -> Bv {
-    ite(&or(&isnan(a), &isnan(b)), &cst(0, 1), &or(&eq(a, b), &and(&iszero(a), &iszero(b))))
+    ite(
+        &or(&isnan(a), &isnan(b)),
+        &cst(0, 1),
+        &or(&eq(a, b), &and(&iszero(a), &iszero(b))),
+    )
 }
 fn lt_expr(a: &Bv, b: &Bv) -> Bv {
     let sa = extract(a, 31, 31);
@@ -156,7 +173,11 @@ fn lt_expr(a: &Bv, b: &Bv) -> Bv {
     let mb = extract(b, 30, 0);
     let same_sign_cmp = ite(&eq(&sa, &cst(0, 1)), &ult(&ma, &mb), &ugt(&ma, &mb));
     let diff_sign = ite(&ne(&sa, &sb), &is1(&sa), &same_sign_cmp);
-    ite(&or(&isnan(a), &isnan(b)), &cst(0, 1), &ite(&and(&iszero(a), &iszero(b)), &cst(0, 1), &diff_sign))
+    ite(
+        &or(&isnan(a), &isnan(b)),
+        &cst(0, 1),
+        &ite(&and(&iszero(a), &iszero(b)), &cst(0, 1), &diff_sign),
+    )
 }
 
 // ── f32 operators ───────────────────────────────────────────────────────────
@@ -179,7 +200,11 @@ fn f32_mul(p: FpCompat) -> FpFn {
         &ite(
             &or(&and(&da.is_inf, &db.is_zero), &and(&db.is_inf, &da.is_zero)),
             &n,
-            &ite(&or(&da.is_inf, &db.is_inf), &inf, &ite(&or(&da.is_zero, &db.is_zero), &zero, &rounded)),
+            &ite(
+                &or(&da.is_inf, &db.is_inf),
+                &inf,
+                &ite(&or(&da.is_zero, &db.is_zero), &zero, &rounded),
+            ),
         ),
     );
     FpFn::new("arch_f32_mul", &[("a", 32), ("b", 32)], 32, body)
@@ -202,8 +227,14 @@ fn f32_compares() -> Vec<FpFn> {
         cmp_fn("arch_f32_ne", bnot(&eq_expr(&a(), &b()))),
         cmp_fn("arch_f32_lt", lt_expr(&a(), &b())),
         cmp_fn("arch_f32_gt", lt_expr(&b(), &a())),
-        cmp_fn("arch_f32_le", or(&lt_expr(&a(), &b()), &eq_expr(&a(), &b()))),
-        cmp_fn("arch_f32_ge", or(&lt_expr(&b(), &a()), &eq_expr(&a(), &b()))),
+        cmp_fn(
+            "arch_f32_le",
+            or(&lt_expr(&a(), &b()), &eq_expr(&a(), &b())),
+        ),
+        cmp_fn(
+            "arch_f32_ge",
+            or(&lt_expr(&b(), &a()), &eq_expr(&a(), &b())),
+        ),
     ]
 }
 
@@ -277,7 +308,11 @@ fn f32_add_core(name: &str, flip_b_sign: bool, p: FpCompat) -> FpFn {
     let ge = uge(&hi_e, &lo_e);
     let raw = ite(&ge, &sub(&hi_e, &lo_e), &sub(&lo_e, &hi_e)); // fw+1
     let mw = fw + 2; // add-carry headroom
-    let mag = ite(&same_sign, &add(&zext(&hi_e, mw), &zext(&lo_e, mw)), &zext(&raw, mw));
+    let mag = ite(
+        &same_sign,
+        &add(&zext(&hi_e, mw), &zext(&lo_e, mw)),
+        &zext(&raw, mw),
+    );
     let res_sign = ite(&same_sign, &sign_hi, &ite(&ge, &sign_hi, &sign_lo));
     let e0 = sub(&eunb_hi, &cst((ADD_G + 1) as u128, 16)); // LSB exponent of mag
     let rounded = normround(&res_sign, &mag, &e0);
@@ -332,7 +367,11 @@ fn fma_f32(p: FpCompat) -> FpFn {
     );
     let same = eq(&sp, &dc.sign);
     let pt_gt = ugt(&pt, &ct);
-    let mag = ite(&same, &add(&pt, &ct), &ite(&pt_gt, &sub(&pt, &ct), &sub(&ct, &pt)));
+    let mag = ite(
+        &same,
+        &add(&pt, &ct),
+        &ite(&pt_gt, &sub(&pt, &ct), &sub(&ct, &pt)),
+    );
     let res_sign = ite(&same, &sp, &ite(&pt_gt, &sp, &dc.sign));
     let cancel = and(&bnot(&same), &eq(&pt, &ct));
     let general = ite(&cancel, &cst(0, 32), &normround(&res_sign, &mag, &e_lo));
@@ -376,12 +415,20 @@ fn i64_to_f32() -> FpFn {
     let v = var("v", 64);
     let sign = extract(&v, 63, 63);
     let mag = ite(&is1(&sign), &neg(&v), &v);
-    let body = ite(&eq(&v, &cst(0, 64)), &cst(0, 32), &normround(&sign, &mag, &cst(0, 16)));
+    let body = ite(
+        &eq(&v, &cst(0, 64)),
+        &cst(0, 32),
+        &normround(&sign, &mag, &cst(0, 16)),
+    );
     FpFn::new("arch_i64_to_f32", &[("v", 64)], 32, body)
 }
 fn u64_to_f32() -> FpFn {
     let v = var("v", 64);
-    let body = ite(&eq(&v, &cst(0, 64)), &cst(0, 32), &normround(&cst(0, 1), &v, &cst(0, 16)));
+    let body = ite(
+        &eq(&v, &cst(0, 64)),
+        &cst(0, 32),
+        &normround(&cst(0, 1), &v, &cst(0, 16)),
+    );
     FpFn::new("arch_u64_to_f32", &[("v", 64)], 32, body)
 }
 
@@ -446,7 +493,11 @@ fn f32_to_uint(p: FpCompat) -> FpFn {
         &ite(
             &d.is_zero,
             &cst(0, 64),
-            &ite(&is1(&d.sign), &cst(0, 64), &ite(&d.is_inf, &lo64(&lim), &sat)),
+            &ite(
+                &is1(&d.sign),
+                &cst(0, 64),
+                &ite(&d.is_inf, &lo64(&lim), &sat),
+            ),
         ),
     );
     FpFn::new("arch_f32_to_uint", &[("x", 32), ("n", 32)], 64, body)
@@ -483,7 +534,12 @@ fn bf16_fma() -> FpFn {
     let wc = call("arch_bf16_to_f32", &[c.clone()], 32);
     let r = call("arch_fma_f32", &[wa, wb, wc], 32);
     let body = call("arch_f32_to_bf16", &[r], 16);
-    FpFn::new("arch_fma_bf16", &[("a", 16), ("b", 16), ("c", 16)], 16, body)
+    FpFn::new(
+        "arch_fma_bf16",
+        &[("a", 16), ("b", 16), ("c", 16)],
+        16,
+        body,
+    )
 }
 fn bf16_cmp(name: &str, f32fn: &str) -> FpFn {
     let a = var("a", 16);
@@ -545,7 +601,12 @@ pub fn lean_extra_functions() -> Vec<FpFn> {
         let s = var("s", 1);
         let sig = var("sig", 48);
         let e0 = var("e0", 16);
-        FpFn::new("arch_round48", &[("s", 1), ("sig", 48), ("e0", 16)], 32, normround(&s, &sig, &e0))
+        FpFn::new(
+            "arch_round48",
+            &[("s", 1), ("sig", 48), ("e0", 16)],
+            32,
+            normround(&s, &sig, &e0),
+        )
     };
     let msb48 = {
         let sig = var("sig", 48);
@@ -556,7 +617,12 @@ pub fn lean_extra_functions() -> Vec<FpFn> {
         let s = var("s", 1);
         let sig = var("sig", 470);
         let e0 = var("e0", 16);
-        FpFn::new("arch_round470", &[("s", 1), ("sig", 470), ("e0", 16)], 32, normround(&s, &sig, &e0))
+        FpFn::new(
+            "arch_round470",
+            &[("s", 1), ("sig", 470), ("e0", 16)],
+            32,
+            normround(&s, &sig, &e0),
+        )
     };
     let msb470 = {
         let sig = var("sig", 470);
@@ -576,11 +642,23 @@ pub fn lean_extra_functions() -> Vec<FpFn> {
         let ep = add(&da.eunb, &db.eunb);
         let p_ge_c = sge(&ep, &dc.eunb);
         let e_lo = ite(&p_ge_c, &dc.eunb, &ep);
-        let pt = ite(&p_ge_c, &shl(&zext(&mp, FMA_W), &sub(&ep, &dc.eunb)), &zext(&mp, FMA_W));
-        let ct = ite(&p_ge_c, &zext(&dc.mant, FMA_W), &shl(&zext(&dc.mant, FMA_W), &sub(&dc.eunb, &ep)));
+        let pt = ite(
+            &p_ge_c,
+            &shl(&zext(&mp, FMA_W), &sub(&ep, &dc.eunb)),
+            &zext(&mp, FMA_W),
+        );
+        let ct = ite(
+            &p_ge_c,
+            &zext(&dc.mant, FMA_W),
+            &shl(&zext(&dc.mant, FMA_W), &sub(&dc.eunb, &ep)),
+        );
         let same = eq(&sp, &dc.sign);
         let pt_gt = ugt(&pt, &ct);
-        let mag = ite(&same, &add(&pt, &ct), &ite(&pt_gt, &sub(&pt, &ct), &sub(&ct, &pt)));
+        let mag = ite(
+            &same,
+            &add(&pt, &ct),
+            &ite(&pt_gt, &sub(&pt, &ct), &sub(&ct, &pt)),
+        );
         let res_sign = ite(&same, &sp, &ite(&pt_gt, &sp, &dc.sign));
         match which {
             "mag" => mag,
@@ -589,8 +667,33 @@ pub fn lean_extra_functions() -> Vec<FpFn> {
             _ => unreachable!(),
         }
     };
-    let fma_mag = FpFn::new("arch_fma_mag", &[("a", 32), ("b", 32), ("c", 32)], FMA_W, fma_part("mag"));
-    let fma_elo = FpFn::new("arch_fma_elo", &[("a", 32), ("b", 32), ("c", 32)], 16, fma_part("elo"));
-    let fma_sign = FpFn::new("arch_fma_sign", &[("a", 32), ("b", 32), ("c", 32)], 1, fma_part("sign"));
-    vec![decode_mant, decode_eunb, round48, msb48, round470, msb470, fma_mag, fma_elo, fma_sign]
+    let fma_mag = FpFn::new(
+        "arch_fma_mag",
+        &[("a", 32), ("b", 32), ("c", 32)],
+        FMA_W,
+        fma_part("mag"),
+    );
+    let fma_elo = FpFn::new(
+        "arch_fma_elo",
+        &[("a", 32), ("b", 32), ("c", 32)],
+        16,
+        fma_part("elo"),
+    );
+    let fma_sign = FpFn::new(
+        "arch_fma_sign",
+        &[("a", 32), ("b", 32), ("c", 32)],
+        1,
+        fma_part("sign"),
+    );
+    vec![
+        decode_mant,
+        decode_eunb,
+        round48,
+        msb48,
+        round470,
+        msb470,
+        fma_mag,
+        fma_elo,
+        fma_sign,
+    ]
 }

--- a/src/fp_smt_proof.rs
+++ b/src/fp_smt_proof.rs
@@ -16,8 +16,9 @@
 use crate::FpCompat;
 
 /// Operators whose generated miter z3 discharges exhaustively.
-pub const TRACTABLE: &[&str] =
-    &["eq", "ne", "lt", "le", "gt", "ge", "narrow", "widen", "to_sint", "to_uint"];
+pub const TRACTABLE: &[&str] = &[
+    "eq", "ne", "lt", "le", "gt", "ge", "narrow", "widen", "to_sint", "to_uint",
+];
 
 /// f32 add/sub — machine-proved `unsat` vs `fp.add`/`fp.sub` over all 2^64
 /// inputs (~80 s each in z3). Tractable because the bounded adder keeps the
@@ -30,8 +31,9 @@ pub const F32_ADD: &[&str] = &["add", "sub"];
 pub const ARITHMETIC: &[&str] = &["mul", "fma"];
 
 /// BF16 comparisons — route through the cheap f32 compare path; prove instantly.
-pub const BF16_CMP: &[&str] =
-    &["bf16_eq", "bf16_ne", "bf16_lt", "bf16_le", "bf16_gt", "bf16_ge"];
+pub const BF16_CMP: &[&str] = &[
+    "bf16_eq", "bf16_ne", "bf16_lt", "bf16_le", "bf16_gt", "bf16_ge",
+];
 
 /// BF16 RNE arithmetic — the §8.1 primary target. Routed through the f32
 /// datapath, but the small input space (2^32) makes the miter solver-tractable:
@@ -58,7 +60,9 @@ pub fn equiv_proof(op: &str, profile: FpCompat) -> String {
     let n16 = nan16_hex(profile);
     let mut s = String::new();
     s.push_str("(set-logic QF_FPBV)\n(define-sort F () (_ FloatingPoint 8 24))\n");
-    s.push_str(&crate::fp_ir::render_smt(&crate::fp_ops::fp_functions(profile)));
+    s.push_str(&crate::fp_ir::render_smt(&crate::fp_ops::fp_functions(
+        profile,
+    )));
 
     let pre = "(declare-fun a () (_ BitVec 32))\n(declare-fun b () (_ BitVec 32))\n\
                (define-fun fa () F ((_ to_fp 8 24) a))\n(define-fun fb () F ((_ to_fp 8 24) b))\n";

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -2016,7 +2016,11 @@ impl Builder {
                 self.walk_expr(owner, &rel, scope, e, ExprUse::Read);
             }
             TypeExpr::Clock(domain) => self.add_uses_type(owner, &domain.name, domain.span),
-            TypeExpr::Reset(_, _) | TypeExpr::Bool | TypeExpr::Bit | TypeExpr::FP32 | TypeExpr::BF16 => {}
+            TypeExpr::Reset(_, _)
+            | TypeExpr::Bool
+            | TypeExpr::Bit
+            | TypeExpr::FP32
+            | TypeExpr::BF16 => {}
             TypeExpr::Vec(inner, n) => {
                 self.walk_type(owner, scope, inner, span);
                 let rel = self.rel_for_span(n.span);

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -103,7 +103,12 @@ pub(crate) fn emit_bus_interface(b: &BusDecl) -> String {
 /// Generic emitter for constructs with name + params + ports (regfile, etc.)
 /// Constructs with additional semantic fields (kind, policy, latency) use
 /// their own per-type emitter instead — see emit_synchronizer_interface etc.
-pub(crate) fn emit_generic(keyword: &str, name: &str, params: &[ParamDecl], ports: &[PortDecl]) -> String {
+pub(crate) fn emit_generic(
+    keyword: &str,
+    name: &str,
+    params: &[ParamDecl],
+    ports: &[PortDecl],
+) -> String {
     let mut s = format!("{keyword} {name}\n");
     emit_params(&mut s, params);
     emit_ports(&mut s, ports);
@@ -187,7 +192,11 @@ pub(crate) fn emit_arbiter_interface(a: &ArbiterDecl) -> String {
                 Direction::In => "in",
                 Direction::Out => "out",
             };
-            s.push_str(&format!("    {}: {dir} {};\n", sig.name.name, type_str(&sig.ty)));
+            s.push_str(&format!(
+                "    {}: {dir} {};\n",
+                sig.name.name,
+                type_str(&sig.ty)
+            ));
         }
         s.push_str(&format!("  end ports {}\n", pa.name.name));
     }
@@ -271,11 +280,16 @@ pub(crate) fn emit_package_interface(p: &PackageDecl) -> String {
     // Function signatures (no body)
     for f in &p.functions {
         let fname = &f.name.name;
-        let params: Vec<String> = f.args.iter()
+        let params: Vec<String> = f
+            .args
+            .iter()
             .map(|fp| format!("{}: {}", fp.name.name, type_str(&fp.ty)))
             .collect();
-        out.push_str(&format!("  function {fname}({}) -> {};\n",
-            params.join(", "), type_str(&f.ret_ty)));
+        out.push_str(&format!(
+            "  function {fname}({}) -> {};\n",
+            params.join(", "),
+            type_str(&f.ret_ty)
+        ));
     }
     out.push_str(&format!("end package {name}\n"));
     out
@@ -293,21 +307,29 @@ pub(crate) fn emit_params(s: &mut String, params: &[ParamDecl]) {
         match &p.kind {
             ParamKind::Const => {
                 if let Some(ref def) = p.default {
-                    s.push_str(&format!("  {local}param {name}: const = {};\n", expr_str(def)));
+                    s.push_str(&format!(
+                        "  {local}param {name}: const = {};\n",
+                        expr_str(def)
+                    ));
                 } else {
                     s.push_str(&format!("  {local}param {name}: const;\n"));
                 }
             }
             ParamKind::WidthConst(hi, lo) => {
-                let default_str = p.default.as_ref()
+                let default_str = p
+                    .default
+                    .as_ref()
                     .map(|d| format!(" = {}", expr_str(d)))
                     .unwrap_or_default();
-                let unpacked = p.unpacked_size.as_ref()
+                let unpacked = p
+                    .unpacked_size
+                    .as_ref()
                     .map(|s| format!(" [{}]", expr_str(s)))
                     .unwrap_or_default();
                 s.push_str(&format!(
                     "  {local}param {name}[{}:{}]: const{unpacked}{default_str};\n",
-                    expr_str(hi), expr_str(lo)
+                    expr_str(hi),
+                    expr_str(lo)
                 ));
             }
             ParamKind::Type(ty) => {
@@ -317,10 +339,14 @@ pub(crate) fn emit_params(s: &mut String, params: &[ParamDecl]) {
                 ));
             }
             ParamKind::EnumConst(enum_name) => {
-                let default_str = p.default.as_ref()
+                let default_str = p
+                    .default
+                    .as_ref()
                     .map(|d| format!(" = {}", expr_str(d)))
                     .unwrap_or_default();
-                let unpacked = p.unpacked_size.as_ref()
+                let unpacked = p
+                    .unpacked_size
+                    .as_ref()
                     .map(|s| format!(" [{}]", expr_str(s)))
                     .unwrap_or_default();
                 s.push_str(&format!(
@@ -328,7 +354,9 @@ pub(crate) fn emit_params(s: &mut String, params: &[ParamDecl]) {
                 ));
             }
             ParamKind::ConstVec(ty) => {
-                let default_str = p.default.as_ref()
+                let default_str = p
+                    .default
+                    .as_ref()
                     .map(|d| format!(" = {}", expr_str(d)))
                     .unwrap_or_default();
                 s.push_str(&format!(
@@ -337,10 +365,14 @@ pub(crate) fn emit_params(s: &mut String, params: &[ParamDecl]) {
                 ));
             }
             ParamKind::Logic(ty) => {
-                let default_str = p.default.as_ref()
+                let default_str = p
+                    .default
+                    .as_ref()
                     .map(|d| format!(" = {}", expr_str(d)))
                     .unwrap_or_default();
-                let unpacked = p.unpacked_size.as_ref()
+                let unpacked = p
+                    .unpacked_size
+                    .as_ref()
                     .map(|s| format!(" [{}]", expr_str(s)))
                     .unwrap_or_default();
                 s.push_str(&format!(
@@ -421,9 +453,9 @@ pub(crate) fn emit_ports_with_deps(
             // is unpacked-Vec, causing port-shape mismatches at the
             // SV inst boundary.
             let unpacked_kw = match (p.unpacked, p.unpacked_ascending) {
-                (true, true)  => "unpacked ascending ",
+                (true, true) => "unpacked ascending ",
                 (true, false) => "unpacked ",
-                _             => "",
+                _ => "",
             };
             // Registered output ports are emitted in the canonical
             // `pipe_reg<T, N>` spelling. This includes legacy `port reg`
@@ -435,7 +467,9 @@ pub(crate) fn emit_ports_with_deps(
                     RegReset::Inherit(rst, val) | RegReset::Explicit(rst, _, _, val) => {
                         let rst_name = &rst.name;
                         let rst_val = expr_str(val);
-                        s.push_str(&format!("  port {name}: {dir} {reg_ty} reset {rst_name} => {rst_val};\n"));
+                        s.push_str(&format!(
+                            "  port {name}: {dir} {reg_ty} reset {rst_name} => {rst_val};\n"
+                        ));
                     }
                     RegReset::None => {
                         s.push_str(&format!("  port {name}: {dir} {reg_ty};\n"));
@@ -453,7 +487,8 @@ pub(crate) fn emit_ports_with_deps(
                         if let Some(set) = map.get(name) {
                             let mut sorted: Vec<&String> = set.iter().collect();
                             sorted.sort();
-                            let inner: String = sorted.iter()
+                            let inner: String = sorted
+                                .iter()
                                 .map(|s| s.as_str())
                                 .collect::<Vec<_>>()
                                 .join(", ");
@@ -464,7 +499,8 @@ pub(crate) fn emit_ports_with_deps(
                     } else if let Some(deps) = &p.comb_deps {
                         let mut sorted: Vec<&String> = deps.iter().map(|i| &i.name).collect();
                         sorted.sort();
-                        let inner: String = sorted.iter()
+                        let inner: String = sorted
+                            .iter()
                             .map(|s| s.as_str())
                             .collect::<Vec<_>>()
                             .join(", ");
@@ -475,7 +511,9 @@ pub(crate) fn emit_ports_with_deps(
                 } else {
                     String::new()
                 };
-                s.push_str(&format!("  port {name}: {dir} {unpacked_kw}{ty}{dep_suffix};\n"));
+                s.push_str(&format!(
+                    "  port {name}: {dir} {unpacked_kw}{ty}{dep_suffix};\n"
+                ));
             }
         }
     }
@@ -517,10 +555,20 @@ fn expr_str(expr: &Expr) -> String {
             LitKind::Sized(width, val) => format!("{width}'d{val}"),
             LitKind::Float(bits) => {
                 let v = f64::from_bits(*bits);
-                if v.fract() == 0.0 { format!("{v:.1}") } else { v.to_string() }
+                if v.fract() == 0.0 {
+                    format!("{v:.1}")
+                } else {
+                    v.to_string()
+                }
             }
         },
-        ExprKind::Bool(b) => if *b { "true".to_string() } else { "false".to_string() },
+        ExprKind::Bool(b) => {
+            if *b {
+                "true".to_string()
+            } else {
+                "false".to_string()
+            }
+        }
         ExprKind::Ident(name) => name.clone(),
         ExprKind::Binary(op, l, r) => format!("({} {} {})", expr_str(l), op, expr_str(r)),
         ExprKind::Clog2(inner) => format!("clog2({})", expr_str(inner)),

--- a/src/learn.rs
+++ b/src/learn.rs
@@ -26,9 +26,9 @@ use std::path::PathBuf;
 /// One recorded learning event. v1 only emits `kind: "error_fix"`.
 #[derive(Debug, Clone)]
 pub struct Event {
-    pub ts: String,          // ISO-8601 UTC
-    pub kind: String,        // "error_fix"
-    pub error_code: String,  // e.g. "width_mismatch"
+    pub ts: String,         // ISO-8601 UTC
+    pub kind: String,       // "error_fix"
+    pub error_code: String, // e.g. "width_mismatch"
     pub error_message: String,
     pub file_path: String,
     pub src_before: String,
@@ -183,7 +183,9 @@ pub fn record_failure(
         return Ok(());
     }
     let dir = learn_dir()?;
-    let pending_file = dir.join("pending").join(format!("{}.json", path_hash(file_path)));
+    let pending_file = dir
+        .join("pending")
+        .join(format!("{}.json", path_hash(file_path)));
     let ts = iso8601_now();
     let pending = PendingFailure {
         ts,
@@ -203,7 +205,9 @@ pub fn record_success_if_pending(
     src_after: &str,
 ) -> std::io::Result<Option<Event>> {
     let dir = learn_dir()?;
-    let pending_file = dir.join("pending").join(format!("{}.json", path_hash(file_path)));
+    let pending_file = dir
+        .join("pending")
+        .join(format!("{}.json", path_hash(file_path)));
     if !pending_file.exists() {
         return Ok(None);
     }
@@ -240,7 +244,10 @@ pub fn record_success_if_pending(
 fn append_event(e: &Event) -> std::io::Result<()> {
     let dir = learn_dir()?;
     let path = dir.join("events.jsonl");
-    let mut f = fs::OpenOptions::new().create(true).append(true).open(&path)?;
+    let mut f = fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)?;
     writeln!(f, "{}", event_to_json(e))?;
     Ok(())
 }
@@ -273,10 +280,7 @@ fn append_event(e: &Event) -> std::io::Result<()> {
 ///
 /// Returns the number of feature events emitted across all files. Honors
 /// `ARCH_NO_LEARN` and the store-size cap, same as error-fix events.
-pub fn harvest_features<F>(
-    ast: &crate::ast::SourceFile,
-    file_path_for: F,
-) -> std::io::Result<usize>
+pub fn harvest_features<F>(ast: &crate::ast::SourceFile, file_path_for: F) -> std::io::Result<usize>
 where
     F: Fn(&crate::ast::Item) -> String,
 {
@@ -294,7 +298,8 @@ where
             None => continue,
         };
         // Skip when there's nothing useful to retrieve.
-        if doc.is_empty() && inner_doc.is_empty() && frontmatter.is_empty() && file_inner.is_empty() {
+        if doc.is_empty() && inner_doc.is_empty() && frontmatter.is_empty() && file_inner.is_empty()
+        {
             continue;
         }
         let file = file_path_for(item);
@@ -302,12 +307,17 @@ where
         // BM25 tokenises this in `build_index` / `advise_impl`; per-class
         // separation lives in `src_before` (frontmatter) and `src_after`
         // (inner_doc) for downstream tooling that wants the structure.
-        let combined = [doc.as_str(), inner_doc.as_str(), file_inner.as_str(), frontmatter.as_str()]
-            .iter()
-            .filter(|s| !s.is_empty())
-            .copied()
-            .collect::<Vec<_>>()
-            .join("\n");
+        let combined = [
+            doc.as_str(),
+            inner_doc.as_str(),
+            file_inner.as_str(),
+            frontmatter.as_str(),
+        ]
+        .iter()
+        .filter(|s| !s.is_empty())
+        .copied()
+        .collect::<Vec<_>>()
+        .join("\n");
         new_events.push(Event {
             ts: iso8601_now(),
             kind: "feature".to_string(),
@@ -352,9 +362,7 @@ fn extract_doc(item: &crate::ast::Item) -> Option<(&'static str, String, String,
 
 /// Remove all feature events whose `file_path` matches any of `files`.
 /// Rewrites `events.jsonl` by line-filtering. O(N) per call.
-fn purge_features_for_files(
-    files: &std::collections::HashSet<String>,
-) -> std::io::Result<()> {
+fn purge_features_for_files(files: &std::collections::HashSet<String>) -> std::io::Result<()> {
     let dir = learn_dir()?;
     let path = dir.join("events.jsonl");
     if !path.exists() {
@@ -368,9 +376,9 @@ fn purge_features_for_files(
         }
         // Cheap filter: only re-parse lines that actually carry kind=feature.
         let drop = line.contains("\"kind\":\"feature\"")
-            && files.iter().any(|f| {
-                line.contains(&format!("\"file_path\":\"{}\"", escape_json_string(f)))
-            });
+            && files
+                .iter()
+                .any(|f| line.contains(&format!("\"file_path\":\"{}\"", escape_json_string(f))));
         if !drop {
             kept.push(line.to_string());
         }
@@ -387,7 +395,10 @@ pub fn build_index() -> std::io::Result<usize> {
     let dir = learn_dir()?;
     let events_path = dir.join("events.jsonl");
     if !events_path.exists() {
-        eprintln!("No events to index ({} does not exist).", events_path.display());
+        eprintln!(
+            "No events to index ({} does not exist).",
+            events_path.display()
+        );
         return Ok(0);
     }
     let raw = fs::read_to_string(&events_path)?;
@@ -402,10 +413,7 @@ pub fn build_index() -> std::io::Result<usize> {
     let mut df: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
     let mut doc_terms: Vec<Vec<String>> = Vec::with_capacity(n_docs);
     for e in &events {
-        let text = format!(
-            "{} {} {}",
-            e.error_code, e.error_message, e.diff_summary
-        );
+        let text = format!("{} {} {}", e.error_code, e.error_message, e.diff_summary);
         let terms = tokenize(&text);
         let uniq: std::collections::HashSet<_> = terms.iter().cloned().collect();
         for t in uniq {
@@ -427,7 +435,9 @@ pub fn build_index() -> std::io::Result<usize> {
     out.push_str("\"df\":{");
     let mut first = true;
     for (term, count) in &df {
-        if !first { out.push(','); }
+        if !first {
+            out.push(',');
+        }
         first = false;
         out.push_str(&format!("\"{}\":{}", escape_json_string(term), count));
     }
@@ -448,7 +458,11 @@ pub struct Match {
 /// survives any future field additions without breaking existing counts.
 pub fn event_id(e: &Event) -> String {
     let mut h: u64 = 0xcbf29ce484222325;
-    for chunk in [e.ts.as_bytes(), e.error_code.as_bytes(), e.diff_summary.as_bytes()] {
+    for chunk in [
+        e.ts.as_bytes(),
+        e.error_code.as_bytes(),
+        e.diff_summary.as_bytes(),
+    ] {
         for b in chunk {
             h ^= *b as u64;
             h = h.wrapping_mul(0x100000001b3);
@@ -474,7 +488,9 @@ fn load_counts() -> std::io::Result<std::collections::HashMap<String, u32>> {
     let trimmed = raw.trim().trim_start_matches('{').trim_end_matches('}');
     for entry in trimmed.split(',') {
         let entry = entry.trim();
-        if entry.is_empty() { continue; }
+        if entry.is_empty() {
+            continue;
+        }
         if let Some((k, v)) = entry.split_once(':') {
             let k = k.trim().trim_matches('"').to_string();
             if let Ok(n) = v.trim().parse::<u32>() {
@@ -490,7 +506,9 @@ fn save_counts(counts: &std::collections::HashMap<String, u32>) -> std::io::Resu
     let mut s = String::from("{");
     let mut first = true;
     for (k, v) in counts {
-        if !first { s.push(','); }
+        if !first {
+            s.push(',');
+        }
         first = false;
         s.push_str(&format!("\"{}\":{}", k, v));
     }
@@ -499,7 +517,9 @@ fn save_counts(counts: &std::collections::HashMap<String, u32>) -> std::io::Resu
 }
 
 fn bump_counts(ids: &[String]) -> std::io::Result<()> {
-    if ids.is_empty() { return Ok(()); }
+    if ids.is_empty() {
+        return Ok(());
+    }
     let mut counts = load_counts()?;
     for id in ids {
         *counts.entry(id.clone()).or_insert(0) += 1;
@@ -546,10 +566,7 @@ fn advise_impl(query: &str, k: usize, bump: bool) -> std::io::Result<Vec<Match>>
     let b = 0.75_f64;
     let mut scored: Vec<(f64, Event)> = Vec::with_capacity(events.len());
     for e in events {
-        let text = format!(
-            "{} {} {}",
-            e.error_code, e.error_message, e.diff_summary
-        );
+        let text = format!("{} {} {}", e.error_code, e.error_message, e.diff_summary);
         let d_terms = tokenize(&text);
         let dl = d_terms.len() as f64;
         let mut score = 0.0_f64;
@@ -571,11 +588,18 @@ fn advise_impl(query: &str, k: usize, bump: bool) -> std::io::Result<Vec<Match>>
     scored.truncate(k);
 
     let counts = load_counts().unwrap_or_default();
-    let top: Vec<Match> = scored.into_iter().map(|(s, e)| {
-        let id = event_id(&e);
-        let c = *counts.get(&id).unwrap_or(&0);
-        Match { score: s, event: e, retrieved_count: c }
-    }).collect();
+    let top: Vec<Match> = scored
+        .into_iter()
+        .map(|(s, e)| {
+            let id = event_id(&e);
+            let c = *counts.get(&id).unwrap_or(&0);
+            Match {
+                score: s,
+                event: e,
+                retrieved_count: c,
+            }
+        })
+        .collect();
 
     if bump {
         let ids: Vec<String> = top.iter().map(|m| event_id(&m.event)).collect();
@@ -723,12 +747,27 @@ fn epoch_to_utc(secs: u64) -> (u32, u32, u32, u32, u32, u32) {
     loop {
         let ly = is_leap(year);
         let year_days = if ly { 366 } else { 365 };
-        if rem < year_days { break; }
+        if rem < year_days {
+            break;
+        }
         rem -= year_days;
         year += 1;
     }
     let ly = is_leap(year);
-    let months = [31u32, if ly { 29 } else { 28 }, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+    let months = [
+        31u32,
+        if ly { 29 } else { 28 },
+        31,
+        30,
+        31,
+        30,
+        31,
+        31,
+        30,
+        31,
+        30,
+        31,
+    ];
     let mut month = 0u32;
     for (i, &ml) in months.iter().enumerate() {
         if rem < ml {
@@ -818,15 +857,22 @@ fn pending_to_json(p: &PendingFailure) -> String {
 
 fn parse_json_string(input: &[u8], pos: &mut usize) -> Option<String> {
     skip_ws(input, pos);
-    if *pos >= input.len() || input[*pos] != b'"' { return None; }
+    if *pos >= input.len() || input[*pos] != b'"' {
+        return None;
+    }
     *pos += 1;
     let mut out = String::new();
     while *pos < input.len() {
         let c = input[*pos];
-        if c == b'"' { *pos += 1; return Some(out); }
+        if c == b'"' {
+            *pos += 1;
+            return Some(out);
+        }
         if c == b'\\' {
             *pos += 1;
-            if *pos >= input.len() { return None; }
+            if *pos >= input.len() {
+                return None;
+            }
             match input[*pos] {
                 b'"' => out.push('"'),
                 b'\\' => out.push('\\'),
@@ -835,8 +881,10 @@ fn parse_json_string(input: &[u8], pos: &mut usize) -> Option<String> {
                 b'r' => out.push('\r'),
                 b't' => out.push('\t'),
                 b'u' => {
-                    if *pos + 4 >= input.len() { return None; }
-                    let hex = std::str::from_utf8(&input[*pos+1..*pos+5]).ok()?;
+                    if *pos + 4 >= input.len() {
+                        return None;
+                    }
+                    let hex = std::str::from_utf8(&input[*pos + 1..*pos + 5]).ok()?;
                     let code = u32::from_str_radix(hex, 16).ok()?;
                     out.push(char::from_u32(code)?);
                     *pos += 4;
@@ -857,11 +905,17 @@ fn parse_json_string(input: &[u8], pos: &mut usize) -> Option<String> {
 
 fn next_utf8(b: &[u8], pos: usize) -> usize {
     let c = b[pos];
-    let len = if c < 0x80 { 1 }
-        else if c < 0xc0 { 1 }
-        else if c < 0xe0 { 2 }
-        else if c < 0xf0 { 3 }
-        else { 4 };
+    let len = if c < 0x80 {
+        1
+    } else if c < 0xc0 {
+        1
+    } else if c < 0xe0 {
+        2
+    } else if c < 0xf0 {
+        3
+    } else {
+        4
+    };
     (pos + len).min(b.len())
 }
 
@@ -873,26 +927,41 @@ fn skip_ws(input: &[u8], pos: &mut usize) {
 
 fn expect_char(input: &[u8], pos: &mut usize, c: u8) -> Option<()> {
     skip_ws(input, pos);
-    if *pos >= input.len() || input[*pos] != c { return None; }
+    if *pos >= input.len() || input[*pos] != c {
+        return None;
+    }
     *pos += 1;
     Some(())
 }
 
-fn parse_object_strings(input: &[u8], pos: &mut usize) -> Option<std::collections::HashMap<String, String>> {
+fn parse_object_strings(
+    input: &[u8],
+    pos: &mut usize,
+) -> Option<std::collections::HashMap<String, String>> {
     expect_char(input, pos, b'{')?;
     let mut map = std::collections::HashMap::new();
     skip_ws(input, pos);
-    if *pos < input.len() && input[*pos] == b'}' { *pos += 1; return Some(map); }
+    if *pos < input.len() && input[*pos] == b'}' {
+        *pos += 1;
+        return Some(map);
+    }
     loop {
         let key = parse_json_string(input, pos)?;
         expect_char(input, pos, b':')?;
         let value = parse_json_string(input, pos)?;
         map.insert(key, value);
         skip_ws(input, pos);
-        if *pos >= input.len() { return None; }
+        if *pos >= input.len() {
+            return None;
+        }
         match input[*pos] {
-            b',' => { *pos += 1; }
-            b'}' => { *pos += 1; return Some(map); }
+            b',' => {
+                *pos += 1;
+            }
+            b'}' => {
+                *pos += 1;
+                return Some(map);
+            }
             _ => return None,
         }
     }
@@ -939,18 +1008,33 @@ fn parse_index(raw: &str) -> (usize, f64, std::collections::HashMap<String, usiz
         let mut p = 0usize;
         loop {
             skip_ws(b, &mut p);
-            if p >= b.len() || b[p] == b'}' { break; }
-            let key = match parse_json_string(b, &mut p) { Some(k) => k, None => break };
-            if expect_char(b, &mut p, b':').is_none() { break; }
+            if p >= b.len() || b[p] == b'}' {
+                break;
+            }
+            let key = match parse_json_string(b, &mut p) {
+                Some(k) => k,
+                None => break,
+            };
+            if expect_char(b, &mut p, b':').is_none() {
+                break;
+            }
             skip_ws(b, &mut p);
             let start = p;
-            while p < b.len() && (b[p].is_ascii_digit()) { p += 1; }
-            let n: usize = match std::str::from_utf8(&b[start..p]).ok().and_then(|s| s.parse().ok()) {
-                Some(n) => n, None => break
+            while p < b.len() && (b[p].is_ascii_digit()) {
+                p += 1;
+            }
+            let n: usize = match std::str::from_utf8(&b[start..p])
+                .ok()
+                .and_then(|s| s.parse().ok())
+            {
+                Some(n) => n,
+                None => break,
             };
             df.insert(key, n);
             skip_ws(b, &mut p);
-            if p < b.len() && b[p] == b',' { p += 1; }
+            if p < b.len() && b[p] == b',' {
+                p += 1;
+            }
         }
     }
     (n_docs, avg_dl, df)
@@ -959,14 +1043,18 @@ fn parse_index(raw: &str) -> (usize, f64, std::collections::HashMap<String, usiz
 fn scrape_usize(raw: &str, key: &str) -> Option<usize> {
     let pos = raw.find(key)? + key.len();
     let rest = &raw[pos..];
-    let end = rest.find(|c: char| !c.is_ascii_digit()).unwrap_or(rest.len());
+    let end = rest
+        .find(|c: char| !c.is_ascii_digit())
+        .unwrap_or(rest.len());
     rest[..end].parse().ok()
 }
 
 fn scrape_f64(raw: &str, key: &str) -> Option<f64> {
     let pos = raw.find(key)? + key.len();
     let rest = &raw[pos..];
-    let end = rest.find(|c: char| !c.is_ascii_digit() && c != '.' && c != '-').unwrap_or(rest.len());
+    let end = rest
+        .find(|c: char| !c.is_ascii_digit() && c != '.' && c != '-')
+        .unwrap_or(rest.len());
     rest[..end].parse().ok()
 }
 
@@ -976,7 +1064,12 @@ pub fn classify_error(msg: &str) -> String {
     let lower = msg.to_ascii_lowercase();
     if lower.contains("width mismatch") || lower.contains("arithmetic widening") {
         "width_mismatch".to_string()
-    } else if lower.contains("undefined") && (lower.contains("signal") || lower.contains("module") || lower.contains("port") || lower.contains("name")) {
+    } else if lower.contains("undefined")
+        && (lower.contains("signal")
+            || lower.contains("module")
+            || lower.contains("port")
+            || lower.contains("name"))
+    {
         "undefined_name".to_string()
     } else if lower.contains("ambiguous precedence") {
         "precedence".to_string()
@@ -1032,7 +1125,10 @@ mod tests {
 
     #[test]
     fn classify_examples() {
-        assert_eq!(classify_error("width mismatch: UInt<8> vs UInt<9>"), "width_mismatch");
+        assert_eq!(
+            classify_error("width mismatch: UInt<8> vs UInt<9>"),
+            "width_mismatch"
+        );
         assert_eq!(classify_error("undefined signal `foo`"), "undefined_name");
         assert_eq!(classify_error("ambiguous precedence: ..."), "precedence");
         assert_eq!(classify_error("something else"), "other");
@@ -1062,8 +1158,13 @@ mod tests {
             }
         }
         assert_eq!(kept.len(), 2);
-        assert!(kept[0].contains("\"kind\":\"error_fix\""), "error_fix retained");
-        assert!(kept[1].contains("\"file_path\":\"other.arch\""),
-            "untouched feature event retained");
+        assert!(
+            kept[0].contains("\"kind\":\"error_fix\""),
+            "error_fix retained"
+        );
+        assert!(
+            kept[1].contains("\"file_path\":\"other.arch\""),
+            "untouched feature event retained"
+        );
     }
 }

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -521,7 +521,7 @@ impl fmt::Display for TokenKind {
             TokenKind::GtEq => write!(f, ">="),
             TokenKind::LArrow => write!(f, "<-"),
             TokenKind::RArrow => write!(f, "->"),
-            TokenKind::PlusColon  => write!(f, "+:"),
+            TokenKind::PlusColon => write!(f, "+:"),
             TokenKind::MinusColon => write!(f, "-:"),
             TokenKind::FatArrow => write!(f, "=>"),
             TokenKind::Lt => write!(f, "<"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -902,7 +902,9 @@ fn main() -> miette::Result<()> {
                 json,
                 limit,
             } => run_graph_context(&task, &index, json, limit),
-            GraphCommand::Html { index, out, title } => run_graph_html(&index, &out, title.as_deref()),
+            GraphCommand::Html { index, out, title } => {
+                run_graph_html(&index, &out, title.as_deref())
+            }
         },
         Command::Coverage { command } => match command {
             CoverageCommand::Merge { inputs, out } => run_coverage_merge(&inputs, &out),
@@ -1162,16 +1164,18 @@ fn main() -> miette::Result<()> {
                             })
                             .cloned()
                             .collect();
-                        let mut codegen =
-                            Codegen::new(&symbols, &ast, overload_map).with_comments(comments).with_fp_compat(fp_compat);
+                        let mut codegen = Codegen::new(&symbols, &ast, overload_map)
+                            .with_comments(comments)
+                            .with_fp_compat(fp_compat);
                         let sv = codegen.generate_items(&file_items);
                         let out_path_hint =
                             o.clone().unwrap_or_else(|| files[0].with_extension("sv"));
                         let sdc = codegen.emit_sdc(&out_path_hint.to_string_lossy());
                         (sv, sdc)
                     } else {
-                        let mut codegen =
-                            Codegen::new(&symbols, &ast, overload_map).with_comments(comments).with_fp_compat(fp_compat);
+                        let mut codegen = Codegen::new(&symbols, &ast, overload_map)
+                            .with_comments(comments)
+                            .with_fp_compat(fp_compat);
                         let sv = codegen.generate();
                         let out_path_hint =
                             o.clone().unwrap_or_else(|| files[0].with_extension("sv"));
@@ -1647,9 +1651,13 @@ fn run_thread_sim_cross_check(
     ));
 
     eprintln!("=== arch sim --thread-sim both: building fsm path ===");
-    let fsm_trace = build_and_capture(arch_files, tb_files, &fsm_dir, /*parallel=*/ false, fp_compat)?;
+    let fsm_trace = build_and_capture(
+        arch_files, tb_files, &fsm_dir, /*parallel=*/ false, fp_compat,
+    )?;
     eprintln!("=== arch sim --thread-sim both: building parallel path ===");
-    let par_trace = build_and_capture(arch_files, tb_files, &par_dir, /*parallel=*/ true, fp_compat)?;
+    let par_trace = build_and_capture(
+        arch_files, tb_files, &par_dir, /*parallel=*/ true, fp_compat,
+    )?;
 
     // Filter to just the [cycle][Mod.port](in/out) debug lines, ignore
     // TB stdout. The fsm path uses --debug --depth N to optionally

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -26,7 +26,16 @@ pub struct Parser {
 
 impl Parser {
     pub fn new(tokens: Vec<Token>, source: &str) -> Self {
-        Self { tokens, pos: 0, source: source.to_string(), no_angle: false, no_lteq: false, reg_defaults: None, seq_default: None, deprecated_implies_spans: Vec::new() }
+        Self {
+            tokens,
+            pos: 0,
+            source: source.to_string(),
+            no_angle: false,
+            no_lteq: false,
+            reg_defaults: None,
+            seq_default: None,
+            deprecated_implies_spans: Vec::new(),
+        }
     }
 
     /// Check if there's a newline in the source between two byte offsets.
@@ -68,7 +77,11 @@ impl Parser {
         while !self.at_end() {
             items.push(self.parse_item()?);
         }
-        Ok(SourceFile { items, inner_doc, frontmatter })
+        Ok(SourceFile {
+            items,
+            inner_doc,
+            frontmatter,
+        })
     }
 
     /// Consume all consecutive `DocOuter` tokens at the current position
@@ -76,7 +89,11 @@ impl Parser {
     /// `\n`). Returns `None` when no `DocOuter` token is at `self.pos`.
     fn consume_outer_doc(&mut self) -> Option<String> {
         let lines = self.consume_outer_doc_lines();
-        if lines.is_empty() { None } else { Some(lines.join("\n")) }
+        if lines.is_empty() {
+            None
+        } else {
+            Some(lines.join("\n"))
+        }
     }
 
     fn consume_outer_doc_lines(&mut self) -> Vec<String> {
@@ -97,7 +114,11 @@ impl Parser {
     /// Same as `consume_outer_doc` but for `DocInner` tokens.
     fn consume_inner_doc(&mut self) -> Option<String> {
         let lines = self.consume_inner_doc_lines();
-        if lines.is_empty() { None } else { Some(lines.join("\n")) }
+        if lines.is_empty() {
+            None
+        } else {
+            Some(lines.join("\n"))
+        }
     }
 
     fn consume_inner_doc_lines(&mut self) -> Vec<String> {
@@ -320,7 +341,11 @@ impl Parser {
                 self.expect(TokenKind::Colon)?;
                 let at = self.parse_type_expr()?;
                 args.push((an, at));
-                if self.check(TokenKind::Comma) { self.advance(); } else { break; }
+                if self.check(TokenKind::Comma) {
+                    self.advance();
+                } else {
+                    break;
+                }
             }
         }
         self.expect(TokenKind::RParen)?;
@@ -375,7 +400,10 @@ impl Parser {
     ///   'credit_channel' Ident ':' ('send'|'receive') NEWLINE
     ///     ParamDecl*
     ///   'end' 'credit_channel' Ident
-    fn parse_credit_channel_block(&mut self, _parent_span: Span) -> Result<CreditChannelMeta, CompileError> {
+    fn parse_credit_channel_block(
+        &mut self,
+        _parent_span: Span,
+    ) -> Result<CreditChannelMeta, CompileError> {
         let start = self.expect(TokenKind::CreditChannel)?.span;
         let ch_name = self.expect_ident()?;
         self.expect(TokenKind::Colon)?;
@@ -386,7 +414,10 @@ impl Parser {
         } else {
             return Err(CompileError::unexpected_token(
                 "send or receive",
-                &self.peek_kind().map(|k| k.to_string()).unwrap_or("EOF".into()),
+                &self
+                    .peek_kind()
+                    .map(|k| k.to_string())
+                    .unwrap_or("EOF".into()),
                 self.peek_span(),
             ));
         };
@@ -422,13 +453,20 @@ impl Parser {
         } else {
             return Err(CompileError::unexpected_token(
                 "in or out",
-                &self.peek_kind().map(|k| k.to_string()).unwrap_or("EOF".into()),
+                &self
+                    .peek_kind()
+                    .map(|k| k.to_string())
+                    .unwrap_or("EOF".into()),
                 self.peek_span(),
             ));
         };
         let ty = self.parse_type_expr()?;
         self.expect(TokenKind::Semi)?;
-        let end_span = self.tokens.get(self.pos.saturating_sub(1)).map(|t| t.span).unwrap_or(parent_span);
+        let end_span = self
+            .tokens
+            .get(self.pos.saturating_sub(1))
+            .map(|t| t.span)
+            .unwrap_or(parent_span);
         Ok(PortDecl {
             name: sig_name,
             direction,
@@ -436,7 +474,9 @@ impl Parser {
             default: None,
             reg_info: None,
             bus_info: None,
-            shared: None, unpacked: false, unpacked_ascending: false,
+            shared: None,
+            unpacked: false,
+            unpacked_ascending: false,
             comb_deps: None,
             span: parent_span.merge(end_span),
         })
@@ -506,7 +546,9 @@ impl Parser {
 
     fn check_bus_gen_end(&self) -> bool {
         // Stop at `end generate_if` or `generate_else`
-        if self.check(TokenKind::GenerateElse) { return true; }
+        if self.check(TokenKind::GenerateElse) {
+            return true;
+        }
         self.pos + 1 < self.tokens.len()
             && self.tokens[self.pos].kind == TokenKind::End
             && self.tokens[self.pos + 1].kind == TokenKind::GenerateIf
@@ -526,11 +568,18 @@ impl Parser {
     /// `send`/`receive` name the payload-flow role (NOT wire direction):
     /// `send` = this side produces the payload (drives valid/req/payload,
     /// receives ready/ack); `receive` = consumer side.
-    fn parse_handshake_block(&mut self, parent_span: Span) -> Result<(Vec<PortDecl>, Vec<BusGenerateIf>, HandshakeMeta), CompileError> {
+    fn parse_handshake_block(
+        &mut self,
+        parent_span: Span,
+    ) -> Result<(Vec<PortDecl>, Vec<BusGenerateIf>, HandshakeMeta), CompileError> {
         // Accept both `handshake` (legacy) and `handshake_channel` (new).
         // See plan_bus_unification.md for the rename rationale.
         let is_legacy = self.check(TokenKind::Handshake);
-        let opening_tok = if is_legacy { TokenKind::Handshake } else { TokenKind::HandshakeChannel };
+        let opening_tok = if is_legacy {
+            TokenKind::Handshake
+        } else {
+            TokenKind::HandshakeChannel
+        };
         let start = self.expect(opening_tok)?.span;
         let ch_name = self.expect_ident()?;
         self.expect(TokenKind::Colon)?;
@@ -541,7 +590,10 @@ impl Parser {
         } else {
             return Err(CompileError::unexpected_token(
                 "send or receive",
-                &self.peek_kind().map(|k| k.to_string()).unwrap_or("EOF".into()),
+                &self
+                    .peek_kind()
+                    .map(|k| k.to_string())
+                    .unwrap_or("EOF".into()),
                 self.peek_span(),
             ));
         };
@@ -551,8 +603,12 @@ impl Parser {
         let variant = variant_ident.name.as_str();
         let known = matches!(
             variant,
-            "valid_ready" | "valid_only" | "ready_only" | "valid_stall"
-              | "req_ack_4phase" | "req_ack_2phase"
+            "valid_ready"
+                | "valid_only"
+                | "ready_only"
+                | "valid_stall"
+                | "req_ack_4phase"
+                | "req_ack_2phase"
         );
         if !known {
             return Err(CompileError::unexpected_token(
@@ -596,7 +652,11 @@ impl Parser {
                     self.expect(TokenKind::Colon)?;
                     let ty = self.parse_type_expr()?;
                     self.expect(TokenKind::Semi)?;
-                    let f_span_end = self.tokens.get(self.pos.saturating_sub(1)).map(|t| t.span).unwrap_or(parent_span);
+                    let f_span_end = self
+                        .tokens
+                        .get(self.pos.saturating_sub(1))
+                        .map(|t| t.span)
+                        .unwrap_or(parent_span);
                     let f_span = f_name.span.merge(f_span_end);
                     payload_names.push(f_name.clone());
                     branch_fields.push((f_name, ty, f_span));
@@ -610,7 +670,11 @@ impl Parser {
             self.expect(TokenKind::Colon)?;
             let ty = self.parse_type_expr()?;
             self.expect(TokenKind::Semi)?;
-            let f_span_end = self.tokens.get(self.pos.saturating_sub(1)).map(|t| t.span).unwrap_or(parent_span);
+            let f_span_end = self
+                .tokens
+                .get(self.pos.saturating_sub(1))
+                .map(|t| t.span)
+                .unwrap_or(parent_span);
             let f_span = f_name.span.merge(f_span_end);
             payload_names.push(f_name.clone());
             payload.push((f_name, ty, f_span));
@@ -637,7 +701,10 @@ impl Parser {
         // Synthesize flat PortDecls based on the variant. Directions are
         // relative to the channel's declared direction: `out` = producer
         // (this side drives valid/req and payload, receives ready/ack).
-        let opposite = match dir { Direction::In => Direction::Out, Direction::Out => Direction::In };
+        let opposite = match dir {
+            Direction::In => Direction::Out,
+            Direction::Out => Direction::In,
+        };
         let mut out: Vec<PortDecl> = Vec::new();
         let mk_port = |n: String, d: Direction, ty: TypeExpr, sp: Span| PortDecl {
             name: Ident { name: n, span: sp },
@@ -646,29 +713,71 @@ impl Parser {
             default: None,
             reg_info: None,
             bus_info: None,
-            shared: None, unpacked: false, unpacked_ascending: false,
+            shared: None,
+            unpacked: false,
+            unpacked_ascending: false,
             comb_deps: None,
             span: sp,
         };
         // Control signals (payload-direction = `dir`, back-signal = `opposite`).
         match variant {
             "valid_ready" => {
-                out.push(mk_port(format!("{}_valid", ch_name.name), dir, TypeExpr::Bool, block_span));
-                out.push(mk_port(format!("{}_ready", ch_name.name), opposite, TypeExpr::Bool, block_span));
+                out.push(mk_port(
+                    format!("{}_valid", ch_name.name),
+                    dir,
+                    TypeExpr::Bool,
+                    block_span,
+                ));
+                out.push(mk_port(
+                    format!("{}_ready", ch_name.name),
+                    opposite,
+                    TypeExpr::Bool,
+                    block_span,
+                ));
             }
             "valid_only" => {
-                out.push(mk_port(format!("{}_valid", ch_name.name), dir, TypeExpr::Bool, block_span));
+                out.push(mk_port(
+                    format!("{}_valid", ch_name.name),
+                    dir,
+                    TypeExpr::Bool,
+                    block_span,
+                ));
             }
             "ready_only" => {
-                out.push(mk_port(format!("{}_ready", ch_name.name), opposite, TypeExpr::Bool, block_span));
+                out.push(mk_port(
+                    format!("{}_ready", ch_name.name),
+                    opposite,
+                    TypeExpr::Bool,
+                    block_span,
+                ));
             }
             "valid_stall" => {
-                out.push(mk_port(format!("{}_valid", ch_name.name), dir, TypeExpr::Bool, block_span));
-                out.push(mk_port(format!("{}_stall", ch_name.name), opposite, TypeExpr::Bool, block_span));
+                out.push(mk_port(
+                    format!("{}_valid", ch_name.name),
+                    dir,
+                    TypeExpr::Bool,
+                    block_span,
+                ));
+                out.push(mk_port(
+                    format!("{}_stall", ch_name.name),
+                    opposite,
+                    TypeExpr::Bool,
+                    block_span,
+                ));
             }
             "req_ack_4phase" | "req_ack_2phase" => {
-                out.push(mk_port(format!("{}_req", ch_name.name), dir, TypeExpr::Bool, block_span));
-                out.push(mk_port(format!("{}_ack", ch_name.name), opposite, TypeExpr::Bool, block_span));
+                out.push(mk_port(
+                    format!("{}_req", ch_name.name),
+                    dir,
+                    TypeExpr::Bool,
+                    block_span,
+                ));
+                out.push(mk_port(
+                    format!("{}_ack", ch_name.name),
+                    opposite,
+                    TypeExpr::Bool,
+                    block_span,
+                ));
             }
             _ => unreachable!(),
         }
@@ -737,9 +846,15 @@ impl Parser {
     /// machinery exists; today arbiter ports have no such concept).
     ///
     /// See doc/plan_handshake_construct.md for the variant catalog.
-    fn parse_handshake_channel_construct_port(&mut self) -> Result<(Vec<PortDecl>, Option<PortArrayDecl>, HandshakeMeta), CompileError> {
+    fn parse_handshake_channel_construct_port(
+        &mut self,
+    ) -> Result<(Vec<PortDecl>, Option<PortArrayDecl>, HandshakeMeta), CompileError> {
         let is_legacy = self.check(TokenKind::Handshake);
-        let opening_tok = if is_legacy { TokenKind::Handshake } else { TokenKind::HandshakeChannel };
+        let opening_tok = if is_legacy {
+            TokenKind::Handshake
+        } else {
+            TokenKind::HandshakeChannel
+        };
         let start = self.expect(opening_tok)?.span;
         let ch_name = self.expect_ident()?;
         // Optional `[N]` array-count.
@@ -759,7 +874,10 @@ impl Parser {
         } else {
             return Err(CompileError::unexpected_token(
                 "send or receive",
-                &self.peek_kind().map(|k| k.to_string()).unwrap_or("EOF".into()),
+                &self
+                    .peek_kind()
+                    .map(|k| k.to_string())
+                    .unwrap_or("EOF".into()),
                 self.peek_span(),
             ));
         };
@@ -769,8 +887,12 @@ impl Parser {
         let variant = variant_ident.name.as_str();
         let known = matches!(
             variant,
-            "valid_ready" | "valid_only" | "ready_only" | "valid_stall"
-              | "req_ack_4phase" | "req_ack_2phase"
+            "valid_ready"
+                | "valid_only"
+                | "ready_only"
+                | "valid_stall"
+                | "req_ack_4phase"
+                | "req_ack_2phase"
         );
         if !known {
             return Err(CompileError::unexpected_token(
@@ -784,7 +906,9 @@ impl Parser {
         // have no per-instance conditional shape today.
         let mut payload: Vec<(Ident, TypeExpr, Span)> = Vec::new();
         loop {
-            if self.check(TokenKind::End) { break; }
+            if self.check(TokenKind::End) {
+                break;
+            }
             if self.check(TokenKind::GenerateIf) {
                 return Err(CompileError::general(
                     "`generate_if` is not supported inside a handshake_channel in an arbiter port list",
@@ -795,7 +919,11 @@ impl Parser {
             self.expect(TokenKind::Colon)?;
             let ty = self.parse_type_expr()?;
             self.expect(TokenKind::Semi)?;
-            let f_span_end = self.tokens.get(self.pos.saturating_sub(1)).map(|t| t.span).unwrap_or(start);
+            let f_span_end = self
+                .tokens
+                .get(self.pos.saturating_sub(1))
+                .map(|t| t.span)
+                .unwrap_or(start);
             let f_span = f_name.span.merge(f_span_end);
             payload.push((f_name, ty, f_span));
         }
@@ -815,7 +943,10 @@ impl Parser {
         }
         let block_span = start.merge(closing.span);
 
-        let opposite = match dir { Direction::In => Direction::Out, Direction::Out => Direction::In };
+        let opposite = match dir {
+            Direction::In => Direction::Out,
+            Direction::Out => Direction::In,
+        };
         // When inside a port array `request[N]`, the signals carry the
         // *relative* short names (`valid`, `ready`, `<payload>`) — the
         // surrounding array prepends `request_` at SV emission, matching
@@ -824,7 +955,11 @@ impl Parser {
         // name so they land as top-level ports identical to today's
         // hand-rolled `port grant_valid: out Bool;` form.
         let in_array = array_count.is_some();
-        let prefix = if in_array { String::new() } else { format!("{}_", ch_name.name) };
+        let prefix = if in_array {
+            String::new()
+        } else {
+            format!("{}_", ch_name.name)
+        };
 
         let mk_port = |n: String, d: Direction, ty: TypeExpr, sp: Span| PortDecl {
             name: Ident { name: n, span: sp },
@@ -833,7 +968,9 @@ impl Parser {
             default: None,
             reg_info: None,
             bus_info: None,
-            shared: None, unpacked: false, unpacked_ascending: false,
+            shared: None,
+            unpacked: false,
+            unpacked_ascending: false,
             comb_deps: None,
             span: sp,
         };
@@ -842,22 +979,62 @@ impl Parser {
         let mut signals: Vec<PortDecl> = Vec::new();
         match variant {
             "valid_ready" => {
-                signals.push(mk_port(format!("{prefix}valid"), dir, TypeExpr::Bool, block_span));
-                signals.push(mk_port(format!("{prefix}ready"), opposite, TypeExpr::Bool, block_span));
+                signals.push(mk_port(
+                    format!("{prefix}valid"),
+                    dir,
+                    TypeExpr::Bool,
+                    block_span,
+                ));
+                signals.push(mk_port(
+                    format!("{prefix}ready"),
+                    opposite,
+                    TypeExpr::Bool,
+                    block_span,
+                ));
             }
             "valid_only" => {
-                signals.push(mk_port(format!("{prefix}valid"), dir, TypeExpr::Bool, block_span));
+                signals.push(mk_port(
+                    format!("{prefix}valid"),
+                    dir,
+                    TypeExpr::Bool,
+                    block_span,
+                ));
             }
             "ready_only" => {
-                signals.push(mk_port(format!("{prefix}ready"), opposite, TypeExpr::Bool, block_span));
+                signals.push(mk_port(
+                    format!("{prefix}ready"),
+                    opposite,
+                    TypeExpr::Bool,
+                    block_span,
+                ));
             }
             "valid_stall" => {
-                signals.push(mk_port(format!("{prefix}valid"), dir, TypeExpr::Bool, block_span));
-                signals.push(mk_port(format!("{prefix}stall"), opposite, TypeExpr::Bool, block_span));
+                signals.push(mk_port(
+                    format!("{prefix}valid"),
+                    dir,
+                    TypeExpr::Bool,
+                    block_span,
+                ));
+                signals.push(mk_port(
+                    format!("{prefix}stall"),
+                    opposite,
+                    TypeExpr::Bool,
+                    block_span,
+                ));
             }
             "req_ack_4phase" | "req_ack_2phase" => {
-                signals.push(mk_port(format!("{prefix}req"), dir, TypeExpr::Bool, block_span));
-                signals.push(mk_port(format!("{prefix}ack"), opposite, TypeExpr::Bool, block_span));
+                signals.push(mk_port(
+                    format!("{prefix}req"),
+                    dir,
+                    TypeExpr::Bool,
+                    block_span,
+                ));
+                signals.push(mk_port(
+                    format!("{prefix}ack"),
+                    opposite,
+                    TypeExpr::Bool,
+                    block_span,
+                ));
             }
             _ => unreachable!(),
         }
@@ -870,21 +1047,36 @@ impl Parser {
         // Tier-2 protocol-SVA emission. Mirrors the bus-body path's
         // HandshakeMeta exactly, with `array_count` set for the `[N]`
         // shape so codegen can wrap the assertion in `generate for`.
-        let payload_names: Vec<Ident> = signals.iter()
+        let payload_names: Vec<Ident> = signals
+            .iter()
             // Skip the control signals (valid/ready/stall/req/ack) — those
             // are unconditionally added by the variant arms above. Anything
             // beyond that is a user-declared payload field.
             .filter(|p| {
-                let bare = if prefix.is_empty() { p.name.name.as_str() } else {
-                    p.name.name.strip_prefix(&prefix).unwrap_or(p.name.name.as_str())
+                let bare = if prefix.is_empty() {
+                    p.name.name.as_str()
+                } else {
+                    p.name
+                        .name
+                        .strip_prefix(&prefix)
+                        .unwrap_or(p.name.name.as_str())
                 };
                 !matches!(bare, "valid" | "ready" | "stall" | "req" | "ack")
             })
             .map(|p| {
-                let bare = if prefix.is_empty() { p.name.name.clone() } else {
-                    p.name.name.strip_prefix(&prefix).unwrap_or(&p.name.name).to_string()
+                let bare = if prefix.is_empty() {
+                    p.name.name.clone()
+                } else {
+                    p.name
+                        .name
+                        .strip_prefix(&prefix)
+                        .unwrap_or(&p.name.name)
+                        .to_string()
                 };
-                Ident { name: bare, span: p.span }
+                Ident {
+                    name: bare,
+                    span: p.span,
+                }
             })
             .collect();
         let meta = HandshakeMeta {
@@ -1065,8 +1257,10 @@ impl Parser {
                 Some(TokenKind::Function) => {
                     body.push(ModuleBodyItem::Function(self.parse_function()?));
                 }
-                Some(TokenKind::Ident(_)) if self.peek_str() == "shared"
-                                              && self.peek_real_kind_at(1) == Some(TokenKind::Function) => {
+                Some(TokenKind::Ident(_))
+                    if self.peek_str() == "shared"
+                        && self.peek_real_kind_at(1) == Some(TokenKind::Function) =>
+                {
                     body.push(ModuleBodyItem::Function(self.parse_function()?));
                 }
                 Some(other) => {
@@ -1115,7 +1309,9 @@ impl Parser {
     fn parse_param_decl(&mut self) -> Result<ParamDecl, CompileError> {
         // Check for `local param` prefix (local is a contextual keyword)
         let is_local = self.check_contextual("local");
-        if is_local { self.advance(); }
+        if is_local {
+            self.advance();
+        }
         let start = self.expect(TokenKind::Param)?.span;
         let name = self.expect_ident()?;
         // Optional width qualifier: param NAME[hi:lo]: const
@@ -1192,7 +1388,11 @@ impl Parser {
             None
         };
         self.expect(TokenKind::Semi)?;
-        let end_span = self.tokens.get(self.pos.saturating_sub(1)).map(|t| t.span).unwrap_or(start);
+        let end_span = self
+            .tokens
+            .get(self.pos.saturating_sub(1))
+            .map(|t| t.span)
+            .unwrap_or(start);
         Ok(ParamDecl {
             name,
             kind,
@@ -1238,8 +1438,14 @@ impl Parser {
                         let pname = self.expect_ident()?;
                         self.expect(TokenKind::Eq)?;
                         let pval = self.parse_expr()?;
-                        assigns.push(ParamAssign { name: pname, value: pval, ty: None });
-                        if !self.eat(TokenKind::Comma) { break; }
+                        assigns.push(ParamAssign {
+                            name: pname,
+                            value: pval,
+                            ty: None,
+                        });
+                        if !self.eat(TokenKind::Comma) {
+                            break;
+                        }
                     }
                     self.expect(TokenKind::Gt)?;
                     assigns
@@ -1256,7 +1462,8 @@ impl Parser {
                 if let ExprKind::Literal(LitKind::Dec(0))
                 | ExprKind::Literal(LitKind::Hex(0))
                 | ExprKind::Literal(LitKind::Bin(0))
-                | ExprKind::Literal(LitKind::Sized(_, 0)) = &count_expr.kind {
+                | ExprKind::Literal(LitKind::Sized(_, 0)) = &count_expr.kind
+                {
                     return Err(CompileError::general(
                         "Vec<BusName, N> port: N must be >= 1",
                         vec_span,
@@ -1280,8 +1487,14 @@ impl Parser {
                     let pname = self.expect_ident()?;
                     self.expect(TokenKind::Eq)?;
                     let pval = self.parse_expr()?;
-                    assigns.push(ParamAssign { name: pname, value: pval, ty: None });
-                    if !self.eat(TokenKind::Comma) { break; }
+                    assigns.push(ParamAssign {
+                        name: pname,
+                        value: pval,
+                        ty: None,
+                    });
+                    if !self.eat(TokenKind::Comma) {
+                        break;
+                    }
                 }
                 self.no_angle = old_no_angle;
                 self.expect(TokenKind::Gt)?;
@@ -1291,15 +1504,26 @@ impl Parser {
             };
             params.extend(inner_params);
             self.expect(TokenKind::Semi)?;
-            let end_span = self.tokens.get(self.pos.saturating_sub(1)).map(|t| t.span).unwrap_or(start);
+            let end_span = self
+                .tokens
+                .get(self.pos.saturating_sub(1))
+                .map(|t| t.span)
+                .unwrap_or(start);
             return Ok(PortDecl {
                 name,
                 direction: Direction::Out, // placeholder; actual directions from bus decl
                 ty: TypeExpr::Named(bus_name.clone()),
                 default: None,
                 reg_info: None,
-                bus_info: Some(BusPortInfo { bus_name, perspective, params, count }),
-                shared: None, unpacked: false, unpacked_ascending: false,
+                bus_info: Some(BusPortInfo {
+                    bus_name,
+                    perspective,
+                    params,
+                    count,
+                }),
+                shared: None,
+                unpacked: false,
+                unpacked_ascending: false,
                 comb_deps: None,
                 span: start.merge(end_span),
             });
@@ -1312,7 +1536,10 @@ impl Parser {
         } else {
             return Err(CompileError::unexpected_token(
                 "in, out, initiator, or target",
-                &self.peek_kind().map(|k| k.to_string()).unwrap_or("EOF".into()),
+                &self
+                    .peek_kind()
+                    .map(|k| k.to_string())
+                    .unwrap_or("EOF".into()),
                 self.peek_span(),
             ));
         };
@@ -1331,7 +1558,11 @@ impl Parser {
         // Only meaningful (and only legal) with `unpacked`. Flips the SV
         // unpacked dim to `[0:N-1]` for interop with upstream SV declared as
         // `logic [W-1:0] x [N]`. See arch-com#307.
-        let unpacked_ascending = if unpacked { self.eat_contextual("ascending") } else { false };
+        let unpacked_ascending = if unpacked {
+            self.eat_contextual("ascending")
+        } else {
+            false
+        };
         if unpacked && is_reg {
             return Err(CompileError::general(
                 "`unpacked` is not allowed on `port reg` / pipe_reg<T,N> ports",
@@ -1411,7 +1642,9 @@ impl Parser {
                 RegReset::None
             };
             Some(PortRegInfo {
-                init, reset, guard,
+                init,
+                reset,
+                guard,
                 latency: pipe_reg_latency.unwrap_or(1),
                 // Only the legacy `port reg` keyword sets is_reg without
                 // going through the pipe_reg<T,N> branch.
@@ -1439,7 +1672,10 @@ impl Parser {
             } else {
                 return Err(CompileError::unexpected_token(
                     "or or and",
-                    &self.peek_kind().map(|k| k.to_string()).unwrap_or("EOF".into()),
+                    &self
+                        .peek_kind()
+                        .map(|k| k.to_string())
+                        .unwrap_or("EOF".into()),
                     self.peek_span(),
                 ));
             };
@@ -1483,7 +1719,9 @@ impl Parser {
                 loop {
                     let dep_id = self.expect_ident()?;
                     deps.push(dep_id);
-                    if !self.eat(TokenKind::Comma) { break; }
+                    if !self.eat(TokenKind::Comma) {
+                        break;
+                    }
                 }
             }
             self.expect(TokenKind::RParen)?;
@@ -1492,7 +1730,11 @@ impl Parser {
             None
         };
         self.expect(TokenKind::Semi)?;
-        let end_span = self.tokens.get(self.pos.saturating_sub(1)).map(|t| t.span).unwrap_or(start);
+        let end_span = self
+            .tokens
+            .get(self.pos.saturating_sub(1))
+            .map(|t| t.span)
+            .unwrap_or(start);
         if unpacked && !matches!(ty, TypeExpr::Vec(..)) {
             return Err(CompileError::general(
                 "`unpacked` is only valid on `Vec<T,N>` ports",
@@ -1513,7 +1755,6 @@ impl Parser {
             span: start.merge(end_span),
         })
     }
-
 
     fn parse_tlm_connect_endpoint(&mut self) -> Result<(Ident, Ident), CompileError> {
         let inst = self.expect_ident()?;
@@ -1548,10 +1789,10 @@ impl Parser {
         })
     }
 
-
     /// Return true if the token `offset` positions ahead is `TokenKind::Default`.
     fn peek_default_at(&self, offset: usize) -> bool {
-        self.tokens.get(self.pos + offset)
+        self.tokens
+            .get(self.pos + offset)
             .map(|t| matches!(t.kind, TokenKind::Default))
             .unwrap_or(false)
     }
@@ -1590,14 +1831,29 @@ impl Parser {
             // Accept token (high/low) or PascalCase ident (High/Low), matching
             // the type-expression convention Reset<Sync, High> / Reset<Async, Low>.
             let level = match self.peek_kind() {
-                Some(TokenKind::High) => { self.advance(); ResetLevel::High }
-                Some(TokenKind::Low)  => { self.advance(); ResetLevel::Low }
-                Some(TokenKind::Ident(ref s)) if s == "High" => { self.advance(); ResetLevel::High }
-                Some(TokenKind::Ident(ref s)) if s == "Low"  => { self.advance(); ResetLevel::Low }
+                Some(TokenKind::High) => {
+                    self.advance();
+                    ResetLevel::High
+                }
+                Some(TokenKind::Low) => {
+                    self.advance();
+                    ResetLevel::Low
+                }
+                Some(TokenKind::Ident(ref s)) if s == "High" => {
+                    self.advance();
+                    ResetLevel::High
+                }
+                Some(TokenKind::Ident(ref s)) if s == "Low" => {
+                    self.advance();
+                    ResetLevel::Low
+                }
                 _ => {
                     return Err(CompileError::unexpected_token(
                         "high, low, High, or Low",
-                        &self.peek_kind().map(|k| k.to_string()).unwrap_or("EOF".into()),
+                        &self
+                            .peek_kind()
+                            .map(|k| k.to_string())
+                            .unwrap_or("EOF".into()),
                         self.peek_span(),
                     ));
                 }
@@ -1639,7 +1895,11 @@ impl Parser {
         let unpacked = self.eat_contextual("unpacked");
         // Optional `ascending` follows `unpacked` (mirror of port modifier).
         // See arch-com#307.
-        let unpacked_ascending = if unpacked { self.eat_contextual("ascending") } else { false };
+        let unpacked_ascending = if unpacked {
+            self.eat_contextual("ascending")
+        } else {
+            false
+        };
         // Special case for bus-typed wires (scalar or Vec): consume any
         // inline `<PARAM=val, ...>` param overrides. The bus param list
         // is stashed in `WireDecl.bus_params` so codegen can apply it to
@@ -1649,7 +1909,11 @@ impl Parser {
         // mismatch any port that overrode the same params.
         let (ty, bus_params) = self.parse_wire_type_with_bus_params()?;
         self.expect(TokenKind::Semi)?;
-        let end_span = self.tokens.get(self.pos.saturating_sub(1)).map(|t| t.span).unwrap_or(start);
+        let end_span = self
+            .tokens
+            .get(self.pos.saturating_sub(1))
+            .map(|t| t.span)
+            .unwrap_or(start);
         if unpacked && !matches!(ty, TypeExpr::Vec(..)) {
             return Err(CompileError::general(
                 "`unpacked` is only valid on `Vec<T,N>` wires",
@@ -1675,7 +1939,9 @@ impl Parser {
     /// Returns the standard TypeExpr (params stripped) plus the parsed
     /// param assignments. Empty Vec when none are present or when the
     /// type is non-bus.
-    fn parse_wire_type_with_bus_params(&mut self) -> Result<(TypeExpr, Vec<ParamAssign>), CompileError> {
+    fn parse_wire_type_with_bus_params(
+        &mut self,
+    ) -> Result<(TypeExpr, Vec<ParamAssign>), CompileError> {
         // Vec<BusName<...>, N> path: detect Vec keyword and parse manually.
         if self.check(TokenKind::KwVec) {
             self.advance();
@@ -1693,8 +1959,14 @@ impl Parser {
                         let pname = self.expect_ident()?;
                         self.expect(TokenKind::Eq)?;
                         let pval = self.parse_expr()?;
-                        assigns.push(ParamAssign { name: pname, value: pval, ty: None });
-                        if !self.eat(TokenKind::Comma) { break; }
+                        assigns.push(ParamAssign {
+                            name: pname,
+                            value: pval,
+                            ty: None,
+                        });
+                        if !self.eat(TokenKind::Comma) {
+                            break;
+                        }
                     }
                     self.expect(TokenKind::Gt)?;
                     assigns
@@ -1711,7 +1983,10 @@ impl Parser {
             let count = self.parse_expr()?;
             self.no_angle = old_no_angle;
             self.expect(TokenKind::Gt)?;
-            return Ok((TypeExpr::Vec(Box::new(elem_ty), Box::new(count)), bus_params));
+            return Ok((
+                TypeExpr::Vec(Box::new(elem_ty), Box::new(count)),
+                bus_params,
+            ));
         }
         // Scalar bus wire: `wire w: BusName<...>;`. Parse a bare ident
         // then check for inline params; if not present, fall through to
@@ -1734,8 +2009,14 @@ impl Parser {
                     let pname = self.expect_ident()?;
                     self.expect(TokenKind::Eq)?;
                     let pval = self.parse_expr()?;
-                    assigns.push(ParamAssign { name: pname, value: pval, ty: None });
-                    if !self.eat(TokenKind::Comma) { break; }
+                    assigns.push(ParamAssign {
+                        name: pname,
+                        value: pval,
+                        ty: None,
+                    });
+                    if !self.eat(TokenKind::Comma) {
+                        break;
+                    }
                 }
                 self.no_angle = old_no_angle;
                 self.expect(TokenKind::Gt)?;
@@ -1767,7 +2048,11 @@ impl Parser {
         self.expect(TokenKind::Eq)?;
         let (ty, bus_params) = self.parse_wire_type_with_bus_params()?;
         self.expect(TokenKind::Semi)?;
-        let end_span = self.tokens.get(self.pos.saturating_sub(1)).map(|t| t.span).unwrap_or(start);
+        let end_span = self
+            .tokens
+            .get(self.pos.saturating_sub(1))
+            .map(|t| t.span)
+            .unwrap_or(start);
         Ok(TypeAliasDecl {
             name,
             ty,
@@ -1800,10 +2085,7 @@ impl Parser {
         let multicycle = if self.check(TokenKind::Multicycle) {
             let mc_span = self.advance().span;
             let lit_tok = self.tokens.get(self.pos).cloned().ok_or_else(|| {
-                CompileError::general(
-                    "expected positive integer after `multicycle`",
-                    mc_span,
-                )
+                CompileError::general("expected positive integer after `multicycle`", mc_span)
             })?;
             let n_parsed: Option<u128> = match &lit_tok.kind {
                 TokenKind::DecLiteral(s) => s.replace('_', "").parse().ok(),
@@ -1861,7 +2143,11 @@ impl Parser {
         };
 
         self.expect(TokenKind::Semi)?;
-        let end_span = self.tokens.get(self.pos.saturating_sub(1)).map(|t| t.span).unwrap_or(start);
+        let end_span = self
+            .tokens
+            .get(self.pos.saturating_sub(1))
+            .map(|t| t.span)
+            .unwrap_or(start);
         Ok(RegDecl {
             name,
             ty,
@@ -1886,7 +2172,10 @@ impl Parser {
         } else {
             return Err(CompileError::unexpected_token(
                 "rising or falling",
-                &self.peek_kind().map(|k| k.to_string()).unwrap_or("EOF".into()),
+                &self
+                    .peek_kind()
+                    .map(|k| k.to_string())
+                    .unwrap_or("EOF".into()),
                 self.peek_span(),
             ));
         };
@@ -1909,7 +2198,10 @@ impl Parser {
             } else {
                 return Err(CompileError::unexpected_token(
                     "rising or falling",
-                    &self.peek_kind().map(|k| k.to_string()).unwrap_or("EOF".into()),
+                    &self
+                        .peek_kind()
+                        .map(|k| k.to_string())
+                        .unwrap_or("EOF".into()),
                     self.peek_span(),
                 ));
             };
@@ -1920,8 +2212,17 @@ impl Parser {
             }
             self.expect(TokenKind::End)?;
             self.expect(TokenKind::Seq)?;
-            let end_span = self.tokens.get(self.pos.saturating_sub(1)).map(|t| t.span).unwrap_or(start);
-            return Ok(RegBlock { clock, clock_edge, stmts, span: start.merge(end_span) });
+            let end_span = self
+                .tokens
+                .get(self.pos.saturating_sub(1))
+                .map(|t| t.span)
+                .unwrap_or(start);
+            return Ok(RegBlock {
+                clock,
+                clock_edge,
+                stmts,
+                span: start.merge(end_span),
+            });
         }
 
         // No `on` — use default clock.
@@ -1938,8 +2239,17 @@ impl Parser {
         }
         self.expect(TokenKind::End)?;
         self.expect(TokenKind::Seq)?;
-        let end_span = self.tokens.get(self.pos.saturating_sub(1)).map(|t| t.span).unwrap_or(start);
-        Ok(RegBlock { clock, clock_edge, stmts, span: start.merge(end_span) })
+        let end_span = self
+            .tokens
+            .get(self.pos.saturating_sub(1))
+            .map(|t| t.span)
+            .unwrap_or(start);
+        Ok(RegBlock {
+            clock,
+            clock_edge,
+            stmts,
+            span: start.merge(end_span),
+        })
     }
 
     fn check_end_always(&self) -> bool {
@@ -1956,7 +2266,9 @@ impl Parser {
 
         // Optional `once`
         let once = self.check_ident("once");
-        if once { self.advance(); }
+        if once {
+            self.advance();
+        }
 
         // Optional name — peek: if we see Ident followed by `on`, it's a name.
         // If we see `on` directly, no name. If we see `Ident . Ident (`, this
@@ -1980,16 +2292,26 @@ impl Parser {
                 if !self.check(TokenKind::RParen) {
                     loop {
                         args.push(self.expect_ident()?);
-                        if self.check(TokenKind::Comma) { self.advance(); } else { break; }
+                        if self.check(TokenKind::Comma) {
+                            self.advance();
+                        } else {
+                            break;
+                        }
                     }
                 }
                 self.expect(TokenKind::RParen)?;
                 // The thread's display name for `end thread X.Y` matching
                 // stays as the `port` ident; closing match accepts either
                 // form (`end thread port` or `end thread port.method`).
-                (Some(first.clone()), Some(TlmTargetBinding {
-                    port: first, method, tag_lane, args,
-                }))
+                (
+                    Some(first.clone()),
+                    Some(TlmTargetBinding {
+                        port: first,
+                        method,
+                        tag_lane,
+                        args,
+                    }),
+                )
             } else {
                 (Some(first), None)
             }
@@ -2016,7 +2338,11 @@ impl Parser {
             if !self.check(TokenKind::RParen) {
                 loop {
                     args.push(self.expect_ident()?);
-                    if self.check(TokenKind::Comma) { self.advance(); } else { break; }
+                    if self.check(TokenKind::Comma) {
+                        self.advance();
+                    } else {
+                        break;
+                    }
                 }
             }
             self.expect(TokenKind::RParen)?;
@@ -2026,7 +2352,12 @@ impl Parser {
                     port_i.span,
                 ));
             }
-            Some(TlmImplementBinding { kind, port: port_i, method: method_i, args })
+            Some(TlmImplementBinding {
+                kind,
+                port: port_i,
+                method: method_i,
+                args,
+            })
         } else {
             None
         };
@@ -2041,7 +2372,10 @@ impl Parser {
         } else {
             return Err(CompileError::unexpected_token(
                 "rising or falling",
-                &self.peek_kind().map(|k| k.to_string()).unwrap_or("EOF".into()),
+                &self
+                    .peek_kind()
+                    .map(|k| k.to_string())
+                    .unwrap_or("EOF".into()),
                 self.peek_span(),
             ));
         };
@@ -2056,7 +2390,10 @@ impl Parser {
         } else {
             return Err(CompileError::unexpected_token(
                 "high or low",
-                &self.peek_kind().map(|k| k.to_string()).unwrap_or("EOF".into()),
+                &self
+                    .peek_kind()
+                    .map(|k| k.to_string())
+                    .unwrap_or("EOF".into()),
                 self.peek_span(),
             ));
         };
@@ -2106,7 +2443,10 @@ impl Parser {
             } else {
                 return Err(CompileError::unexpected_token(
                     "`when` or `comb` after thread `default`",
-                    &self.peek_kind().map(|k| k.to_string()).unwrap_or("EOF".into()),
+                    &self
+                        .peek_kind()
+                        .map(|k| k.to_string())
+                        .unwrap_or("EOF".into()),
                     self.peek_span(),
                 ));
             }
@@ -2128,7 +2468,9 @@ impl Parser {
             let closing_name = self.expect_ident()?;
             if closing_name.name != n.name {
                 return Err(CompileError::mismatched_closing(
-                    &n.name, &closing_name.name, closing_name.span,
+                    &n.name,
+                    &closing_name.name,
+                    closing_name.span,
                 ));
             }
             // TLM target: `end thread port.method` is allowed (and
@@ -2140,7 +2482,9 @@ impl Parser {
                 let declared = tlm_target.as_ref().unwrap().method.name.clone();
                 if method_close.name != declared {
                     return Err(CompileError::mismatched_closing(
-                        &declared, &method_close.name, method_close.span,
+                        &declared,
+                        &method_close.name,
+                        method_close.span,
                     ));
                 }
             }
@@ -2148,7 +2492,11 @@ impl Parser {
         } else if once {
             // `end thread once`
             self.expect_contextual("once")?;
-            end_span = self.tokens.get(self.pos.saturating_sub(1)).map(|t| t.span).unwrap_or(end_kw_span);
+            end_span = self
+                .tokens
+                .get(self.pos.saturating_sub(1))
+                .map(|t| t.span)
+                .unwrap_or(end_kw_span);
         } else {
             end_span = end_kw_span;
         }
@@ -2251,8 +2599,8 @@ impl Parser {
             if matches!(self.peek_kind(), Some(TokenKind::DecLiteral(s)) if s == "0") {
                 let zero_end = self.tokens[self.pos].span.end;
                 self.advance(); // consume 0
-                let plus_adjacent = self.check(TokenKind::Plus)
-                    && self.tokens[self.pos].span.start == zero_end;
+                let plus_adjacent =
+                    self.check(TokenKind::Plus) && self.tokens[self.pos].span.start == zero_end;
                 if plus_adjacent {
                     let plus_span = self.advance().span; // consume +
                     return Err(CompileError::general(
@@ -2282,7 +2630,11 @@ impl Parser {
             let value = self.parse_expr()?;
             let semi_span = self.expect(TokenKind::Semi)?.span;
             let span = target.span.merge(semi_span);
-            Ok(ThreadStmt::CombAssign(CombAssign { target, value, span }))
+            Ok(ThreadStmt::CombAssign(CombAssign {
+                target,
+                value,
+                span,
+            }))
         } else if self.eat(TokenKind::LtEq) {
             let fork_start = if self.check_ident("fork") {
                 Some(self.advance().span)
@@ -2292,7 +2644,11 @@ impl Parser {
             let value = self.parse_expr()?;
             let semi_span = self.expect(TokenKind::Semi)?.span;
             let span = target.span.merge(semi_span);
-            let assign = RegAssign { target, value, span };
+            let assign = RegAssign {
+                target,
+                value,
+                span,
+            };
             if let Some(fork_start) = fork_start {
                 Ok(ThreadStmt::ForkTlmAssign(RegAssign {
                     span: fork_start.merge(semi_span),
@@ -2304,7 +2660,10 @@ impl Parser {
         } else {
             Err(CompileError::unexpected_token(
                 "= or <=",
-                &self.peek_kind().map(|k| k.to_string()).unwrap_or("EOF".into()),
+                &self
+                    .peek_kind()
+                    .map(|k| k.to_string())
+                    .unwrap_or("EOF".into()),
                 self.peek_span(),
             ))
         }
@@ -2316,7 +2675,8 @@ impl Parser {
         let cond = self.parse_expr()?;
 
         let mut then_stmts = Vec::new();
-        while !self.check_end_if() && !self.check(TokenKind::Else) && !self.check(TokenKind::ElsIf) {
+        while !self.check_end_if() && !self.check(TokenKind::Else) && !self.check(TokenKind::ElsIf)
+        {
             then_stmts.push(self.parse_thread_stmt()?);
         }
 
@@ -2337,7 +2697,11 @@ impl Parser {
             self.expect(TokenKind::If)?;
         }
 
-        let end_span = self.tokens.get(self.pos.saturating_sub(1)).map(|t| t.span).unwrap_or(start);
+        let end_span = self
+            .tokens
+            .get(self.pos.saturating_sub(1))
+            .map(|t| t.span)
+            .unwrap_or(start);
         Ok(ThreadStmt::IfElse(ThreadIfElse {
             cond,
             then_stmts,
@@ -2422,7 +2786,9 @@ impl Parser {
         let closing = self.expect_ident()?;
         if closing.name != resource.name {
             return Err(CompileError::mismatched_closing(
-                &resource.name, &closing.name, closing.span,
+                &resource.name,
+                &closing.name,
+                closing.span,
             ));
         }
 
@@ -2471,9 +2837,9 @@ impl Parser {
         let policy_ident = self.expect_ident()?;
         let policy = match policy_ident.name.as_str() {
             "round_robin" => ArbiterPolicy::RoundRobin,
-            "priority"    => ArbiterPolicy::Priority,
-            "lru"         => ArbiterPolicy::Lru,
-            "weighted"    => {
+            "priority" => ArbiterPolicy::Priority,
+            "lru" => ArbiterPolicy::Lru,
+            "weighted" => {
                 // `mutex<weighted<W>>` — inner `<W>` (param expr).
                 self.expect(TokenKind::Lt)?;
                 let w = self.parse_type_arg_expr()?;
@@ -2498,7 +2864,11 @@ impl Parser {
             self.expect_contextual("resource")?;
             let closing = self.expect_ident()?;
             if closing.name != name.name {
-                return Err(CompileError::mismatched_closing(&name.name, &closing.name, closing.span));
+                return Err(CompileError::mismatched_closing(
+                    &name.name,
+                    &closing.name,
+                    closing.span,
+                ));
             }
             closing.span
         };
@@ -2522,7 +2892,11 @@ impl Parser {
         }
         self.expect(TokenKind::End)?;
         self.expect(TokenKind::Latch)?;
-        let end_span = self.tokens.get(self.pos.saturating_sub(1)).map(|t| t.span).unwrap_or(start);
+        let end_span = self
+            .tokens
+            .get(self.pos.saturating_sub(1))
+            .map(|t| t.span)
+            .unwrap_or(start);
         Ok(LatchBlock {
             enable,
             stmts,
@@ -2546,12 +2920,21 @@ impl Parser {
             self.advance();
             self.expect(TokenKind::LParen)?;
             let path = match self.peek_kind() {
-                Some(TokenKind::StringLit(s)) => { let p = s.clone(); self.advance(); p }
-                _ => return Err(CompileError::unexpected_token(
-                    "file path string literal",
-                    &self.peek_kind().map(|k| k.to_string()).unwrap_or("EOF".into()),
-                    self.peek_span(),
-                )),
+                Some(TokenKind::StringLit(s)) => {
+                    let p = s.clone();
+                    self.advance();
+                    p
+                }
+                _ => {
+                    return Err(CompileError::unexpected_token(
+                        "file path string literal",
+                        &self
+                            .peek_kind()
+                            .map(|k| k.to_string())
+                            .unwrap_or("EOF".into()),
+                        self.peek_span(),
+                    ))
+                }
             };
             self.expect(TokenKind::RParen)?;
             Some(path)
@@ -2579,33 +2962,56 @@ impl Parser {
                 self.advance();
                 level
             }
-            _ => return Err(CompileError::unexpected_token(
-                "log level (Always/Low/Medium/High/Full/Debug)",
-                &self.peek_kind().map(|k| k.to_string()).unwrap_or("EOF".into()),
-                self.peek_span(),
-            )),
+            _ => {
+                return Err(CompileError::unexpected_token(
+                    "log level (Always/Low/Medium/High/Full/Debug)",
+                    &self
+                        .peek_kind()
+                        .map(|k| k.to_string())
+                        .unwrap_or("EOF".into()),
+                    self.peek_span(),
+                ))
+            }
         };
         self.expect(TokenKind::Comma)?;
 
         // Tag string
         let tag = match self.peek_kind() {
-            Some(TokenKind::StringLit(s)) => { let t = s.clone(); self.advance(); t }
-            _ => return Err(CompileError::unexpected_token(
-                "tag string literal",
-                &self.peek_kind().map(|k| k.to_string()).unwrap_or("EOF".into()),
-                self.peek_span(),
-            )),
+            Some(TokenKind::StringLit(s)) => {
+                let t = s.clone();
+                self.advance();
+                t
+            }
+            _ => {
+                return Err(CompileError::unexpected_token(
+                    "tag string literal",
+                    &self
+                        .peek_kind()
+                        .map(|k| k.to_string())
+                        .unwrap_or("EOF".into()),
+                    self.peek_span(),
+                ))
+            }
         };
         self.expect(TokenKind::Comma)?;
 
         // Format string
         let fmt = match self.peek_kind() {
-            Some(TokenKind::StringLit(s)) => { let f = s.clone(); self.advance(); f }
-            _ => return Err(CompileError::unexpected_token(
-                "format string literal",
-                &self.peek_kind().map(|k| k.to_string()).unwrap_or("EOF".into()),
-                self.peek_span(),
-            )),
+            Some(TokenKind::StringLit(s)) => {
+                let f = s.clone();
+                self.advance();
+                f
+            }
+            _ => {
+                return Err(CompileError::unexpected_token(
+                    "format string literal",
+                    &self
+                        .peek_kind()
+                        .map(|k| k.to_string())
+                        .unwrap_or("EOF".into()),
+                    self.peek_span(),
+                ))
+            }
         };
 
         // Optional args
@@ -2616,7 +3022,14 @@ impl Parser {
 
         let end = self.expect(TokenKind::RParen)?.span;
         self.expect(TokenKind::Semi)?;
-        Ok(LogStmt { level, tag, fmt, args, file, span: start.merge(end) })
+        Ok(LogStmt {
+            level,
+            tag,
+            fmt,
+            args,
+            file,
+            span: start.merge(end),
+        })
     }
 
     fn parse_reg_stmt(&mut self) -> Result<Stmt, CompileError> {
@@ -2666,7 +3079,11 @@ impl Parser {
             self.advance(); // consume 'until'
             let cond = self.parse_expr()?;
             let semi_span = self.expect(TokenKind::Semi)?.span;
-            return Ok(Stmt::DoUntil { body, cond, span: do_start.merge(semi_span) });
+            return Ok(Stmt::DoUntil {
+                body,
+                cond,
+                span: do_start.merge(semi_span),
+            });
         }
         // Assignment: target <= value;
         // Suppress `<=` as an infix op while parsing the target so it stays
@@ -2685,14 +3102,19 @@ impl Parser {
         let value = self.parse_expr()?;
         self.expect(TokenKind::Semi)?;
         let span = target.span.merge(value.span);
-        Ok(Stmt::Assign(RegAssign { target, value, span }))
+        Ok(Stmt::Assign(RegAssign {
+            target,
+            value,
+            span,
+        }))
     }
 
     fn parse_reg_if(&mut self, unique: bool) -> Result<Stmt, CompileError> {
         let start = self.expect(TokenKind::If)?.span;
         let cond = self.parse_expr()?;
         let mut then_stmts = Vec::new();
-        while !self.check_end_if() && !self.check(TokenKind::Else) && !self.check(TokenKind::ElsIf) {
+        while !self.check_end_if() && !self.check(TokenKind::Else) && !self.check(TokenKind::ElsIf)
+        {
             then_stmts.push(self.parse_reg_stmt()?);
         }
 
@@ -2705,7 +3127,7 @@ impl Parser {
             else_stmts.push(nested);
         } else if self.check(TokenKind::Else) {
             self.advance(); // consume `else`
-            // `else` body — parse until `end if`
+                            // `else` body — parse until `end if`
             while !self.check_end_if() {
                 else_stmts.push(self.parse_reg_stmt()?);
             }
@@ -2717,7 +3139,11 @@ impl Parser {
             self.expect(TokenKind::If)?;
         }
 
-        let end_span = self.tokens.get(self.pos.saturating_sub(1)).map(|t| t.span).unwrap_or(start);
+        let end_span = self
+            .tokens
+            .get(self.pos.saturating_sub(1))
+            .map(|t| t.span)
+            .unwrap_or(start);
         Ok(Stmt::IfElse(IfElse {
             cond,
             then_stmts,
@@ -2733,7 +3159,6 @@ impl Parser {
             && self.tokens[self.pos + 1].kind == TokenKind::If
     }
 
-
     fn parse_reg_match(&mut self, unique: bool) -> Result<Stmt, CompileError> {
         let start = self.expect(TokenKind::Match)?.span;
         let scrutinee = self.parse_expr()?;
@@ -2748,7 +3173,11 @@ impl Parser {
         }
         self.expect(TokenKind::End)?;
         self.expect(TokenKind::Match)?;
-        let end_span = self.tokens.get(self.pos.saturating_sub(1)).map(|t| t.span).unwrap_or(start);
+        let end_span = self
+            .tokens
+            .get(self.pos.saturating_sub(1))
+            .map(|t| t.span)
+            .unwrap_or(start);
         Ok(Stmt::Match(MatchStmt {
             scrutinee,
             arms,
@@ -2800,13 +3229,16 @@ impl Parser {
         }
         self.expect(TokenKind::End)?;
         self.expect(TokenKind::Comb)?;
-        let end_span = self.tokens.get(self.pos.saturating_sub(1)).map(|t| t.span).unwrap_or(start);
+        let end_span = self
+            .tokens
+            .get(self.pos.saturating_sub(1))
+            .map(|t| t.span)
+            .unwrap_or(start);
         Ok(CombBlock {
             stmts,
             span: start.merge(end_span),
         })
     }
-
 
     fn check_end_comb(&self) -> bool {
         self.pos + 1 < self.tokens.len()
@@ -2831,7 +3263,9 @@ impl Parser {
             let mut values = Vec::new();
             loop {
                 values.push(self.parse_expr()?);
-                if !self.eat(TokenKind::Comma) { break; }
+                if !self.eat(TokenKind::Comma) {
+                    break;
+                }
             }
             self.expect(TokenKind::RBrace)?;
             ForRange::ValueList(values)
@@ -2845,12 +3279,18 @@ impl Parser {
         let mut body = Vec::new();
         while !(self.check(TokenKind::End)
             && self.pos + 1 < self.tokens.len()
-            && self.tokens[self.pos + 1].kind == TokenKind::For) {
+            && self.tokens[self.pos + 1].kind == TokenKind::For)
+        {
             body.push(parse_body(self)?);
         }
         self.expect(TokenKind::End)?;
         let end_span = self.expect(TokenKind::For)?.span;
-        Ok(ForLoop { var, range, body, span: start.merge(end_span) })
+        Ok(ForLoop {
+            var,
+            range,
+            body,
+            span: start.merge(end_span),
+        })
     }
 
     fn parse_seq_for_loop(&mut self) -> Result<Stmt, CompileError> {
@@ -2878,7 +3318,9 @@ impl Parser {
             ));
         }
         let mut body = Vec::new();
-        while !(self.check(TokenKind::End) && self.peek_kind_at(self.pos + 1) == Some(TokenKind::Init)) {
+        while !(self.check(TokenKind::End)
+            && self.peek_kind_at(self.pos + 1) == Some(TokenKind::Init))
+        {
             body.push(self.parse_reg_stmt()?);
         }
         self.expect(TokenKind::End)?;
@@ -2934,7 +3376,8 @@ impl Parser {
         let start = self.expect(TokenKind::If)?.span;
         let cond = self.parse_expr()?;
         let mut then_stmts = Vec::new();
-        while !self.check_end_if() && !self.check(TokenKind::Else) && !self.check(TokenKind::ElsIf) {
+        while !self.check_end_if() && !self.check(TokenKind::Else) && !self.check(TokenKind::ElsIf)
+        {
             then_stmts.push(self.parse_comb_stmt()?);
         }
 
@@ -2955,7 +3398,11 @@ impl Parser {
             self.expect(TokenKind::If)?;
         }
 
-        let end_span = self.tokens.get(self.pos.saturating_sub(1)).map(|t| t.span).unwrap_or(start);
+        let end_span = self
+            .tokens
+            .get(self.pos.saturating_sub(1))
+            .map(|t| t.span)
+            .unwrap_or(start);
         Ok(Stmt::IfElse(IfElse {
             cond,
             then_stmts,
@@ -2976,11 +3423,18 @@ impl Parser {
             // Stmt — previously cast to Stmt for `Vec<MatchArm<Stmt>>`,
             // which forced the typecheck to recheck under seq semantics).
             let comb_stmt = self.parse_comb_stmt()?;
-            arms.push(MatchArm { pattern, body: vec![comb_stmt] });
+            arms.push(MatchArm {
+                pattern,
+                body: vec![comb_stmt],
+            });
         }
         self.expect(TokenKind::End)?;
         self.expect(TokenKind::Match)?;
-        let end_span = self.tokens.get(self.pos.saturating_sub(1)).map(|t| t.span).unwrap_or(start);
+        let end_span = self
+            .tokens
+            .get(self.pos.saturating_sub(1))
+            .map(|t| t.span)
+            .unwrap_or(start);
         Ok(Stmt::Match(MatchStmt {
             scrutinee,
             arms,
@@ -3001,7 +3455,9 @@ impl Parser {
             if !self.check(TokenKind::RBrace) {
                 fields.push(self.expect_ident()?);
                 while self.eat(TokenKind::Comma) {
-                    if self.check(TokenKind::RBrace) { break; }
+                    if self.check(TokenKind::RBrace) {
+                        break;
+                    }
                     fields.push(self.expect_ident()?);
                 }
             }
@@ -3009,10 +3465,17 @@ impl Parser {
             self.expect(TokenKind::Eq)?;
             let value = self.parse_expr()?;
             self.expect(TokenKind::Semi)?;
-            let end_span = self.tokens.get(self.pos.saturating_sub(1)).map(|t| t.span).unwrap_or(start);
+            let end_span = self
+                .tokens
+                .get(self.pos.saturating_sub(1))
+                .map(|t| t.span)
+                .unwrap_or(start);
             // Placeholder name — unused in destructuring mode. Carry the
             // span so diagnostics still have a location.
-            let placeholder = Ident { name: String::from("_destructure"), span: start };
+            let placeholder = Ident {
+                name: String::from("_destructure"),
+                span: start,
+            };
             return Ok(LetBinding {
                 name: placeholder,
                 ty: None,
@@ -3030,7 +3493,11 @@ impl Parser {
         self.expect(TokenKind::Eq)?;
         let value = self.parse_expr()?;
         self.expect(TokenKind::Semi)?;
-        let end_span = self.tokens.get(self.pos.saturating_sub(1)).map(|t| t.span).unwrap_or(start);
+        let end_span = self
+            .tokens
+            .get(self.pos.saturating_sub(1))
+            .map(|t| t.span)
+            .unwrap_or(start);
         Ok(LetBinding {
             name,
             ty,
@@ -3049,19 +3516,36 @@ impl Parser {
         let stages_ident = self.expect_ident()?;
         if stages_ident.name != "stages" {
             return Err(CompileError::unexpected_token(
-                "stages", &stages_ident.name, stages_ident.span,
+                "stages",
+                &stages_ident.name,
+                stages_ident.span,
             ));
         }
         let stages_tok = self.advance();
         let stages = match &stages_tok.kind {
-            TokenKind::DecLiteral(s) => s.parse::<u32>().map_err(|_|
-                CompileError::general("invalid stage count", stages_tok.span))?,
-            _ => return Err(CompileError::unexpected_token(
-                "integer literal", &stages_tok.kind.to_string(), stages_tok.span)),
+            TokenKind::DecLiteral(s) => s
+                .parse::<u32>()
+                .map_err(|_| CompileError::general("invalid stage count", stages_tok.span))?,
+            _ => {
+                return Err(CompileError::unexpected_token(
+                    "integer literal",
+                    &stages_tok.kind.to_string(),
+                    stages_tok.span,
+                ))
+            }
         };
         self.expect(TokenKind::Semi)?;
-        let end_span = self.tokens.get(self.pos.saturating_sub(1)).map(|t| t.span).unwrap_or(start);
-        Ok(PipeRegDecl { name, source, stages, span: start.merge(end_span) })
+        let end_span = self
+            .tokens
+            .get(self.pos.saturating_sub(1))
+            .map(|t| t.span)
+            .unwrap_or(start);
+        Ok(PipeRegDecl {
+            name,
+            source,
+            stages,
+            span: start.merge(end_span),
+        })
     }
 
     // ── Assert / Cover ────────────────────────────────────────────────────────
@@ -3074,9 +3558,20 @@ impl Parser {
     fn parse_assert_decl(&mut self) -> Result<AssertDecl, CompileError> {
         let start = self.peek_span();
         let kind = match self.peek_kind() {
-            Some(TokenKind::Assert) => { self.advance(); AssertKind::Assert }
-            Some(TokenKind::Cover)  => { self.advance(); AssertKind::Cover  }
-            _ => return Err(CompileError::general("expected assert or cover", self.peek_span())),
+            Some(TokenKind::Assert) => {
+                self.advance();
+                AssertKind::Assert
+            }
+            Some(TokenKind::Cover) => {
+                self.advance();
+                AssertKind::Cover
+            }
+            _ => {
+                return Err(CompileError::general(
+                    "expected assert or cover",
+                    self.peek_span(),
+                ))
+            }
         };
 
         // Optional label: `name :` where `:` is not followed by another `:`
@@ -3093,7 +3588,12 @@ impl Parser {
 
         let expr = self.parse_expr()?;
         let end = self.expect(TokenKind::Semi)?.span;
-        Ok(AssertDecl { kind, name, expr, span: start.merge(end) })
+        Ok(AssertDecl {
+            kind,
+            name,
+            expr,
+            span: start.merge(end),
+        })
     }
 
     fn parse_inst(&mut self) -> Result<InstDecl, CompileError> {
@@ -3127,7 +3627,11 @@ impl Parser {
                     (self.parse_expr()?, None)
                 };
                 self.expect(TokenKind::Semi)?;
-                param_assigns.push(ParamAssign { name: pname, value, ty });
+                param_assigns.push(ParamAssign {
+                    name: pname,
+                    value,
+                    ty,
+                });
             } else if matches!(self.peek_kind(), Some(TokenKind::Ident(_))) {
                 let cstart = self.peek_span();
                 let mut port_name = self.expect_ident()?;
@@ -3136,10 +3640,16 @@ impl Parser {
                 if self.eat(TokenKind::LBracket) {
                     let idx_tok = self.advance();
                     let idx = match &idx_tok.kind {
-                        TokenKind::DecLiteral(s) => s.parse::<u32>().map_err(|_|
-                            CompileError::general("invalid port index", idx_tok.span))?,
-                        _ => return Err(CompileError::unexpected_token(
-                            "integer index", &idx_tok.kind.to_string(), idx_tok.span)),
+                        TokenKind::DecLiteral(s) => s.parse::<u32>().map_err(|_| {
+                            CompileError::general("invalid port index", idx_tok.span)
+                        })?,
+                        _ => {
+                            return Err(CompileError::unexpected_token(
+                                "integer index",
+                                &idx_tok.kind.to_string(),
+                                idx_tok.span,
+                            ))
+                        }
                     };
                     self.expect(TokenKind::RBracket)?;
                     if self.eat(TokenKind::Dot) {
@@ -3175,7 +3685,10 @@ impl Parser {
                 } else {
                     return Err(CompileError::unexpected_token(
                         "<- or ->",
-                        &self.peek_kind().map(|k| k.to_string()).unwrap_or("EOF".into()),
+                        &self
+                            .peek_kind()
+                            .map(|k| k.to_string())
+                            .unwrap_or("EOF".into()),
                         self.peek_span(),
                     ));
                 };
@@ -3193,19 +3706,33 @@ impl Parser {
                         } else {
                             return Err(CompileError::unexpected_token(
                                 "Sync or Async",
-                                &self.peek_kind().map(|k| k.to_string()).unwrap_or("EOF".into()),
+                                &self
+                                    .peek_kind()
+                                    .map(|k| k.to_string())
+                                    .unwrap_or("EOF".into()),
                                 self.peek_span(),
                             ));
                         };
                         let level = if self.eat(TokenKind::Comma) {
                             match self.peek_kind() {
-                                Some(TokenKind::Ident(s)) if s == "High" => { self.advance(); ResetLevel::High }
-                                Some(TokenKind::Ident(s)) if s == "Low"  => { self.advance(); ResetLevel::Low  }
-                                _ => return Err(CompileError::unexpected_token(
-                                    "High or Low",
-                                    &self.peek_kind().map(|k| k.to_string()).unwrap_or("EOF".into()),
-                                    self.peek_span(),
-                                )),
+                                Some(TokenKind::Ident(s)) if s == "High" => {
+                                    self.advance();
+                                    ResetLevel::High
+                                }
+                                Some(TokenKind::Ident(s)) if s == "Low" => {
+                                    self.advance();
+                                    ResetLevel::Low
+                                }
+                                _ => {
+                                    return Err(CompileError::unexpected_token(
+                                        "High or Low",
+                                        &self
+                                            .peek_kind()
+                                            .map(|k| k.to_string())
+                                            .unwrap_or("EOF".into()),
+                                        self.peek_span(),
+                                    ))
+                                }
                             }
                         } else {
                             ResetLevel::High
@@ -3219,7 +3746,11 @@ impl Parser {
                     None
                 };
                 self.expect(TokenKind::Semi)?;
-                let end_span = self.tokens.get(self.pos.saturating_sub(1)).map(|t| t.span).unwrap_or(cstart);
+                let end_span = self
+                    .tokens
+                    .get(self.pos.saturating_sub(1))
+                    .map(|t| t.span)
+                    .unwrap_or(cstart);
                 connections.push(Connection {
                     port_name,
                     direction,
@@ -3230,7 +3761,10 @@ impl Parser {
             } else {
                 return Err(CompileError::unexpected_token(
                     "param or port connection",
-                    &self.peek_kind().map(|k| k.to_string()).unwrap_or("EOF".into()),
+                    &self
+                        .peek_kind()
+                        .map(|k| k.to_string())
+                        .unwrap_or("EOF".into()),
                     self.peek_span(),
                 ));
             }
@@ -3271,11 +3805,13 @@ impl Parser {
             let idx_str = match &idx_tok.kind {
                 TokenKind::DecLiteral(s) => s.clone(),
                 TokenKind::Ident(s) => s.clone(),
-                _ => return Err(CompileError::unexpected_token(
-                    "integer index or loop variable",
-                    &idx_tok.kind.to_string(),
-                    idx_tok.span,
-                )),
+                _ => {
+                    return Err(CompileError::unexpected_token(
+                        "integer index or loop variable",
+                        &idx_tok.kind.to_string(),
+                        idx_tok.span,
+                    ))
+                }
             };
             self.expect(TokenKind::RBracket)?;
             if self.eat(TokenKind::Dot) {
@@ -3305,13 +3841,20 @@ impl Parser {
         } else {
             return Err(CompileError::unexpected_token(
                 "<- or ->",
-                &self.peek_kind().map(|k| k.to_string()).unwrap_or("EOF".into()),
+                &self
+                    .peek_kind()
+                    .map(|k| k.to_string())
+                    .unwrap_or("EOF".into()),
                 self.peek_span(),
             ));
         };
         let signal = self.parse_expr()?;
         self.expect(TokenKind::Semi)?;
-        let end_span = self.tokens.get(self.pos.saturating_sub(1)).map(|t| t.span).unwrap_or(cstart);
+        let end_span = self
+            .tokens
+            .get(self.pos.saturating_sub(1))
+            .map(|t| t.span)
+            .unwrap_or(cstart);
         Ok(Connection {
             port_name,
             direction,
@@ -3344,7 +3887,10 @@ impl Parser {
             } else {
                 return Err(CompileError::unexpected_token(
                     "port connection or nested `for`",
-                    &self.peek_kind().map(|k| k.to_string()).unwrap_or("EOF".into()),
+                    &self
+                        .peek_kind()
+                        .map(|k| k.to_string())
+                        .unwrap_or("EOF".into()),
                     self.peek_span(),
                 ));
             }
@@ -3379,9 +3925,13 @@ impl Parser {
         if self.pos + 1 < self.tokens.len()
             && self.tokens[self.pos].kind == TokenKind::End
             && self.tokens[self.pos + 1].kind == TokenKind::GenerateIf
-        { return true; }
+        {
+            return true;
+        }
         // Also stop at `generate_else` so the caller can consume it
-        if self.check(TokenKind::GenerateElse) { return true; }
+        if self.check(TokenKind::GenerateElse) {
+            return true;
+        }
         false
     }
 
@@ -3422,22 +3972,26 @@ impl Parser {
                 // indexed signal.
                 Some(tok @ (TokenKind::Port | TokenKind::Reg | TokenKind::Let)) => {
                     let (kw, hint) = match tok {
-                        TokenKind::Port => ("port",
+                        TokenKind::Port => (
+                            "port",
                             "Declare ports at module scope using Vec types for \
                              per-iteration elements, e.g. `port done: out Vec<Bool, N>;` \
-                             outside, then `done -> done[i];` inside an inst here."),
-                        TokenKind::Reg => ("reg",
+                             outside, then `done -> done[i];` inside an inst here.",
+                        ),
+                        TokenKind::Reg => (
+                            "reg",
                             "Declare Vec-typed regs at module scope and index them in a \
                              seq / comb block here, e.g. `reg store: Vec<UInt<8>, N> ...;` \
-                             outside, then `store[i] <= ...;` inside generate_for."),
-                        _ => ("let",
+                             outside, then `store[i] <= ...;` inside generate_for.",
+                        ),
+                        _ => (
+                            "let",
                             "Move the let binding to module scope; reference it freely \
-                             from seq / comb inside generate_for."),
+                             from seq / comb inside generate_for.",
+                        ),
                     };
                     return Err(CompileError::general(
-                        &format!(
-                            "'{kw}' declarations are not allowed inside generate_for. {hint}"
-                        ),
+                        &format!("'{kw}' declarations are not allowed inside generate_for. {hint}"),
                         self.peek_span(),
                     ));
                 }
@@ -3523,7 +4077,6 @@ impl Parser {
         }))
     }
 
-
     /// Parse an expression inside angle brackets (no `>` or `>=` as binop)
     fn parse_type_arg_expr(&mut self) -> Result<Expr, CompileError> {
         let old = self.no_angle;
@@ -3584,7 +4137,10 @@ impl Parser {
                 } else {
                     return Err(CompileError::unexpected_token(
                         "Sync or Async",
-                        &self.peek_kind().map(|k| k.to_string()).unwrap_or("EOF".into()),
+                        &self
+                            .peek_kind()
+                            .map(|k| k.to_string())
+                            .unwrap_or("EOF".into()),
                         self.peek_span(),
                     ));
                 };
@@ -3602,7 +4158,10 @@ impl Parser {
                         _ => {
                             return Err(CompileError::unexpected_token(
                                 "High or Low",
-                                &self.peek_kind().map(|k| k.to_string()).unwrap_or("EOF".into()),
+                                &self
+                                    .peek_kind()
+                                    .map(|k| k.to_string())
+                                    .unwrap_or("EOF".into()),
                                 self.peek_span(),
                             ));
                         }
@@ -3652,7 +4211,9 @@ impl Parser {
             let span = cond.span.merge(else_expr.span);
             Ok(Expr {
                 kind: ExprKind::Ternary(Box::new(cond), Box::new(then_expr), Box::new(else_expr)),
-                span, parenthesized: false })
+                span,
+                parenthesized: false,
+            })
         } else {
             Ok(cond)
         }
@@ -3675,10 +4236,12 @@ impl Parser {
                     | ExprKind::Literal(LitKind::Hex(v))
                     | ExprKind::Literal(LitKind::Bin(v))
                     | ExprKind::Literal(LitKind::Sized(_, v)) => *v as u32,
-                    _ => return Err(CompileError::general(
-                        "`@N` latency must be an integer literal",
-                        n_expr.span,
-                    )),
+                    _ => {
+                        return Err(CompileError::general(
+                            "`@N` latency must be an integer literal",
+                            n_expr.span,
+                        ))
+                    }
                 };
                 let span = lhs.span.merge(n_expr.span);
                 lhs = Expr {
@@ -3716,7 +4279,9 @@ impl Parser {
                     let span = lhs.span.merge(self.tokens[self.pos.saturating_sub(1)].span);
                     lhs = Expr {
                         kind: ExprKind::MethodCall(Box::new(lhs), field, args),
-                        span, parenthesized: false };
+                        span,
+                        parenthesized: false,
+                    };
                 } else if self.check(TokenKind::Lt) && is_method_name(&field.name) {
                     self.advance(); // <
                     let old_no_angle = self.no_angle;
@@ -3733,12 +4298,16 @@ impl Parser {
                     let span = lhs.span.merge(self.tokens[self.pos.saturating_sub(1)].span);
                     lhs = Expr {
                         kind: ExprKind::MethodCall(Box::new(lhs), field, type_args),
-                        span, parenthesized: false };
+                        span,
+                        parenthesized: false,
+                    };
                 } else {
                     let span = lhs.span.merge(field.span);
                     lhs = Expr {
                         kind: ExprKind::FieldAccess(Box::new(lhs), field),
-                        span, parenthesized: false };
+                        span,
+                        parenthesized: false,
+                    };
                 }
                 continue;
             }
@@ -3749,21 +4318,32 @@ impl Parser {
                 // Part-select: expr[start +: width] or expr[start -: width]
                 // `+:` / `-:` may arrive as a single PlusColon/MinusColon token (no space)
                 // OR as a separate Plus/Minus + Colon token pair (with space); handle both.
-                let is_plus_colon  = self.check(TokenKind::PlusColon)
-                    || (self.check(TokenKind::Plus)  && self.peek_kind_at(self.pos + 1) == Some(TokenKind::Colon));
+                let is_plus_colon = self.check(TokenKind::PlusColon)
+                    || (self.check(TokenKind::Plus)
+                        && self.peek_kind_at(self.pos + 1) == Some(TokenKind::Colon));
                 let is_minus_colon = self.check(TokenKind::MinusColon)
-                    || (self.check(TokenKind::Minus) && self.peek_kind_at(self.pos + 1) == Some(TokenKind::Colon));
+                    || (self.check(TokenKind::Minus)
+                        && self.peek_kind_at(self.pos + 1) == Some(TokenKind::Colon));
                 if is_plus_colon || is_minus_colon {
                     let up = is_plus_colon;
                     self.advance(); // consume + or - (or +: as one token)
-                    // If spaced form, also consume the separate `:` token
-                    if self.check(TokenKind::Colon) { self.advance(); }
+                                    // If spaced form, also consume the separate `:` token
+                    if self.check(TokenKind::Colon) {
+                        self.advance();
+                    }
                     let width = self.parse_expr()?;
                     self.expect(TokenKind::RBracket)?;
                     let span = lhs.span.merge(self.tokens[self.pos.saturating_sub(1)].span);
                     lhs = Expr {
-                        kind: ExprKind::PartSelect(Box::new(lhs), Box::new(first), Box::new(width), up),
-                        span, parenthesized: false };
+                        kind: ExprKind::PartSelect(
+                            Box::new(lhs),
+                            Box::new(first),
+                            Box::new(width),
+                            up,
+                        ),
+                        span,
+                        parenthesized: false,
+                    };
                 } else if self.check(TokenKind::Colon) {
                     // bit-slice: expr[hi:lo]
                     self.advance();
@@ -3772,14 +4352,18 @@ impl Parser {
                     let span = lhs.span.merge(self.tokens[self.pos.saturating_sub(1)].span);
                     lhs = Expr {
                         kind: ExprKind::BitSlice(Box::new(lhs), Box::new(first), Box::new(lo)),
-                        span, parenthesized: false };
+                        span,
+                        parenthesized: false,
+                    };
                 } else {
                     // index: expr[i]
                     self.expect(TokenKind::RBracket)?;
                     let span = lhs.span.merge(self.tokens[self.pos.saturating_sub(1)].span);
                     lhs = Expr {
                         kind: ExprKind::Index(Box::new(lhs), Box::new(first)),
-                        span, parenthesized: false };
+                        span,
+                        parenthesized: false,
+                    };
                 }
                 continue;
             }
@@ -3790,7 +4374,9 @@ impl Parser {
                 let span = lhs.span; // approximate
                 lhs = Expr {
                     kind: ExprKind::Cast(Box::new(lhs), Box::new(ty)),
-                    span, parenthesized: false };
+                    span,
+                    parenthesized: false,
+                };
                 continue;
             }
 
@@ -3808,10 +4394,16 @@ impl Parser {
                     } else {
                         members.push(InsideMember::Single(e));
                     }
-                    if !self.eat(TokenKind::Comma) { break; }
+                    if !self.eat(TokenKind::Comma) {
+                        break;
+                    }
                 }
                 let end_span = self.expect(TokenKind::RBrace)?.span;
-                lhs = Expr { kind: ExprKind::Inside(Box::new(lhs), members), span: lhs_span.merge(end_span), parenthesized: false };
+                lhs = Expr {
+                    kind: ExprKind::Inside(Box::new(lhs), members),
+                    span: lhs_span.merge(end_span),
+                    parenthesized: false,
+                };
                 continue;
             }
 
@@ -3828,7 +4420,7 @@ impl Parser {
                 self.deprecated_implies_spans.push(self.peek_span());
             }
             self.advance(); // consume operator (first token)
-            // Wrapping operators are two tokens (+%, -%, *%); consume the trailing %
+                            // Wrapping operators are two tokens (+%, -%, *%); consume the trailing %
             if matches!(op, BinOp::AddWrap | BinOp::SubWrap | BinOp::MulWrap) {
                 self.advance(); // consume %
             }
@@ -3836,7 +4428,9 @@ impl Parser {
             let span = lhs.span.merge(rhs.span);
             lhs = Expr {
                 kind: ExprKind::Binary(op, Box::new(lhs), Box::new(rhs)),
-                span, parenthesized: false };
+                span,
+                parenthesized: false,
+            };
         }
 
         Ok(lhs)
@@ -3850,13 +4444,15 @@ impl Parser {
                 let tok = self.advance();
                 let n_tok = self.advance();
                 let n_val: u32 = match &n_tok.kind {
-                    TokenKind::DecLiteral(s) => s.parse().map_err(|_| CompileError::general(
-                        "`##N` cycle count out of range", n_tok.span,
-                    ))?,
-                    _ => return Err(CompileError::general(
-                        "`##N` requires an integer literal cycle count",
-                        n_tok.span,
-                    )),
+                    TokenKind::DecLiteral(s) => s.parse().map_err(|_| {
+                        CompileError::general("`##N` cycle count out of range", n_tok.span)
+                    })?,
+                    _ => {
+                        return Err(CompileError::general(
+                            "`##N` requires an integer literal cycle count",
+                            n_tok.span,
+                        ))
+                    }
                 };
                 if n_val == 0 {
                     return Err(CompileError::general(
@@ -3868,7 +4464,9 @@ impl Parser {
                 let span = tok.span.merge(operand.span);
                 Ok(Expr {
                     kind: ExprKind::SvaNext(n_val, Box::new(operand)),
-                    span, parenthesized: false })
+                    span,
+                    parenthesized: false,
+                })
             }
             // `not` keyword and `!` symbol are exact aliases for logical-not
             // (same token semantics, same precedence) — mirrors `&&`==`and` /
@@ -3880,7 +4478,9 @@ impl Parser {
                 let span = tok.span.merge(operand.span);
                 Ok(Expr {
                     kind: ExprKind::Unary(UnaryOp::Not, Box::new(operand)),
-                    span, parenthesized: false })
+                    span,
+                    parenthesized: false,
+                })
             }
             Some(TokenKind::Tilde) => {
                 let tok = self.advance();
@@ -3888,7 +4488,9 @@ impl Parser {
                 let span = tok.span.merge(operand.span);
                 Ok(Expr {
                     kind: ExprKind::Unary(UnaryOp::BitNot, Box::new(operand)),
-                    span, parenthesized: false })
+                    span,
+                    parenthesized: false,
+                })
             }
             Some(TokenKind::Minus) => {
                 let tok = self.advance();
@@ -3896,7 +4498,9 @@ impl Parser {
                 let span = tok.span.merge(operand.span);
                 Ok(Expr {
                     kind: ExprKind::Unary(UnaryOp::Neg, Box::new(operand)),
-                    span, parenthesized: false })
+                    span,
+                    parenthesized: false,
+                })
             }
             Some(TokenKind::Amp) => {
                 let tok = self.advance();
@@ -3904,7 +4508,9 @@ impl Parser {
                 let span = tok.span.merge(operand.span);
                 Ok(Expr {
                     kind: ExprKind::Unary(UnaryOp::RedAnd, Box::new(operand)),
-                    span, parenthesized: false })
+                    span,
+                    parenthesized: false,
+                })
             }
             Some(TokenKind::Pipe) => {
                 let tok = self.advance();
@@ -3912,7 +4518,9 @@ impl Parser {
                 let span = tok.span.merge(operand.span);
                 Ok(Expr {
                     kind: ExprKind::Unary(UnaryOp::RedOr, Box::new(operand)),
-                    span, parenthesized: false })
+                    span,
+                    parenthesized: false,
+                })
             }
             Some(TokenKind::Caret) => {
                 let tok = self.advance();
@@ -3920,7 +4528,9 @@ impl Parser {
                 let span = tok.span.merge(operand.span);
                 Ok(Expr {
                     kind: ExprKind::Unary(UnaryOp::RedXor, Box::new(operand)),
-                    span, parenthesized: false })
+                    span,
+                    parenthesized: false,
+                })
             }
             Some(TokenKind::LParen) => {
                 self.advance();
@@ -3937,7 +4547,9 @@ impl Parser {
                 let end = self.expect(TokenKind::RParen)?;
                 Ok(Expr {
                     kind: ExprKind::Clog2(Box::new(arg)),
-                    span: start.merge(end.span), parenthesized: false })
+                    span: start.merge(end.span),
+                    parenthesized: false,
+                })
             }
             // signed(expr) — same-width reinterpret to SInt
             Some(TokenKind::Signed) => {
@@ -3947,7 +4559,9 @@ impl Parser {
                 let end = self.expect(TokenKind::RParen)?;
                 Ok(Expr {
                     kind: ExprKind::Signed(Box::new(arg)),
-                    span: start.merge(end.span), parenthesized: false })
+                    span: start.merge(end.span),
+                    parenthesized: false,
+                })
             }
             // onehot(index) — one-hot decode: 1 << index
             Some(TokenKind::Onehot) => {
@@ -3957,7 +4571,9 @@ impl Parser {
                 let end = self.expect(TokenKind::RParen)?;
                 Ok(Expr {
                     kind: ExprKind::Onehot(Box::new(arg)),
-                    span: start.merge(end.span), parenthesized: false })
+                    span: start.merge(end.span),
+                    parenthesized: false,
+                })
             }
             // unsigned(expr) — same-width reinterpret to UInt
             Some(TokenKind::KwUnsigned) => {
@@ -3967,15 +4583,21 @@ impl Parser {
                 let end = self.expect(TokenKind::RParen)?;
                 Ok(Expr {
                     kind: ExprKind::Unsigned(Box::new(arg)),
-                    span: start.merge(end.span), parenthesized: false })
+                    span: start.merge(end.span),
+                    parenthesized: false,
+                })
             }
             // Bit concatenation {a, b, c} or bit replication {N{expr}}
             Some(TokenKind::LBrace) => {
                 let start = self.advance().span;
                 // Check for replication: {N{expr}} — count/ident followed by LBrace
-                let is_repeat = if let Some(TokenKind::DecLiteral(_) | TokenKind::HexLiteral(_) | TokenKind::Ident(_)) = self.peek_kind() {
+                let is_repeat = if let Some(
+                    TokenKind::DecLiteral(_) | TokenKind::HexLiteral(_) | TokenKind::Ident(_),
+                ) = self.peek_kind()
+                {
                     // Look ahead: if token after the number/ident is '{', it's replication
-                    self.pos + 1 < self.tokens.len() && self.tokens[self.pos + 1].kind == TokenKind::LBrace
+                    self.pos + 1 < self.tokens.len()
+                        && self.tokens[self.pos + 1].kind == TokenKind::LBrace
                 } else {
                     false
                 };
@@ -3987,7 +4609,9 @@ impl Parser {
                     let end = self.expect(TokenKind::RBrace)?;
                     Ok(Expr {
                         kind: ExprKind::Repeat(Box::new(count), Box::new(value)),
-                        span: start.merge(end.span), parenthesized: false })
+                        span: start.merge(end.span),
+                        parenthesized: false,
+                    })
                 } else {
                     let mut parts = Vec::new();
                     while !self.check(TokenKind::RBrace) {
@@ -3999,32 +4623,40 @@ impl Parser {
                     let end = self.expect(TokenKind::RBrace)?;
                     Ok(Expr {
                         kind: ExprKind::Concat(parts),
-                        span: start.merge(end.span), parenthesized: false })
+                        span: start.merge(end.span),
+                        parenthesized: false,
+                    })
                 }
             }
             Some(TokenKind::Todo) => {
                 let tok = self.advance();
                 Ok(Expr {
                     kind: ExprKind::Todo,
-                    span: tok.span, parenthesized: false })
+                    span: tok.span,
+                    parenthesized: false,
+                })
             }
             Some(TokenKind::True) => {
                 let tok = self.advance();
                 Ok(Expr {
                     kind: ExprKind::Bool(true),
-                    span: tok.span, parenthesized: false })
+                    span: tok.span,
+                    parenthesized: false,
+                })
             }
             Some(TokenKind::False) => {
                 let tok = self.advance();
                 Ok(Expr {
                     kind: ExprKind::Bool(false),
-                    span: tok.span, parenthesized: false })
+                    span: tok.span,
+                    parenthesized: false,
+                })
             }
-            Some(TokenKind::DecLiteral(_)) | Some(TokenKind::HexLiteral(_))
-            | Some(TokenKind::BinLiteral(_)) | Some(TokenKind::SizedLiteral(_))
-            | Some(TokenKind::FloatLiteral(_)) => {
-                self.parse_literal()
-            }
+            Some(TokenKind::DecLiteral(_))
+            | Some(TokenKind::HexLiteral(_))
+            | Some(TokenKind::BinLiteral(_))
+            | Some(TokenKind::SizedLiteral(_))
+            | Some(TokenKind::FloatLiteral(_)) => self.parse_literal(),
             Some(TokenKind::Ident(_)) | Some(TokenKind::Counter) => {
                 let ident = self.expect_ident()?;
                 // Check for enum variant: Ident::Ident
@@ -4034,7 +4666,9 @@ impl Parser {
                     let span = ident.span.merge(variant.span);
                     Ok(Expr {
                         kind: ExprKind::EnumVariant(ident, variant),
-                        span, parenthesized: false })
+                        span,
+                        parenthesized: false,
+                    })
                 }
                 // Check for struct literal: Ident { ... }
                 else if self.check(TokenKind::LBrace) {
@@ -4053,7 +4687,9 @@ impl Parser {
                     let span = ident.span.merge(end.span);
                     Ok(Expr {
                         kind: ExprKind::StructLiteral(ident, fields),
-                        span, parenthesized: false })
+                        span,
+                        parenthesized: false,
+                    })
                 } else if self.check(TokenKind::LParen) {
                     // Function call: Name(arg, ...)
                     self.advance(); // consume `(`
@@ -4068,12 +4704,16 @@ impl Parser {
                     let span = ident.span.merge(end.span);
                     Ok(Expr {
                         kind: ExprKind::FunctionCall(ident.name, call_args),
-                        span, parenthesized: false })
+                        span,
+                        parenthesized: false,
+                    })
                 } else {
                     let span = ident.span;
                     Ok(Expr {
                         kind: ExprKind::Ident(ident.name),
-                        span, parenthesized: false })
+                        span,
+                        parenthesized: false,
+                    })
                 }
             }
             // match expression: match scrutinee  pat => expr, ... end match
@@ -4090,10 +4730,16 @@ impl Parser {
                 }
                 self.expect(TokenKind::End)?;
                 self.expect(TokenKind::Match)?;
-                let end_span = self.tokens.get(self.pos.saturating_sub(1)).map(|t| t.span).unwrap_or(start);
+                let end_span = self
+                    .tokens
+                    .get(self.pos.saturating_sub(1))
+                    .map(|t| t.span)
+                    .unwrap_or(start);
                 Ok(Expr {
                     kind: ExprKind::ExprMatch(Box::new(scrutinee), arms),
-                    span: start.merge(end_span), parenthesized: false })
+                    span: start.merge(end_span),
+                    parenthesized: false,
+                })
             }
             Some(other) => Err(CompileError::unexpected_token(
                 "expression",
@@ -4108,42 +4754,47 @@ impl Parser {
         let tok = self.advance();
         let kind = match &tok.kind {
             TokenKind::DecLiteral(s) => {
-                let v = s.replace('_', "").parse::<u64>().map_err(|_| {
-                    CompileError::general("invalid decimal literal", tok.span)
-                })?;
+                let v = s
+                    .replace('_', "")
+                    .parse::<u64>()
+                    .map_err(|_| CompileError::general("invalid decimal literal", tok.span))?;
                 ExprKind::Literal(LitKind::Dec(v))
             }
             TokenKind::FloatLiteral(s) => {
-                let v = s.replace('_', "").parse::<f64>().map_err(|_| {
-                    CompileError::general("invalid float literal", tok.span)
-                })?;
+                let v = s
+                    .replace('_', "")
+                    .parse::<f64>()
+                    .map_err(|_| CompileError::general("invalid float literal", tok.span))?;
                 ExprKind::Literal(LitKind::Float(v.to_bits()))
             }
             TokenKind::HexLiteral(s) => {
-                let v = u64::from_str_radix(&s[2..].replace('_', ""), 16).map_err(|_| {
-                    CompileError::general("invalid hex literal", tok.span)
-                })?;
+                let v = u64::from_str_radix(&s[2..].replace('_', ""), 16)
+                    .map_err(|_| CompileError::general("invalid hex literal", tok.span))?;
                 ExprKind::Literal(LitKind::Hex(v))
             }
             TokenKind::BinLiteral(s) => {
-                let v = u64::from_str_radix(&s[2..].replace('_', ""), 2).map_err(|_| {
-                    CompileError::general("invalid binary literal", tok.span)
-                })?;
+                let v = u64::from_str_radix(&s[2..].replace('_', ""), 2)
+                    .map_err(|_| CompileError::general("invalid binary literal", tok.span))?;
                 ExprKind::Literal(LitKind::Bin(v))
             }
             TokenKind::SizedLiteral(s) => {
                 // format: WIDTH'BASE_CHAR VALUE
                 let parts: Vec<&str> = s.splitn(2, '\'').collect();
-                let width: u32 = parts[0].parse().map_err(|_| {
-                    CompileError::general("invalid sized literal width", tok.span)
-                })?;
+                let width: u32 = parts[0]
+                    .parse()
+                    .map_err(|_| CompileError::general("invalid sized literal width", tok.span))?;
                 let base_char = parts[1].chars().next().unwrap();
                 let digits = &parts[1][1..].replace('_', "");
                 let value = match base_char {
                     'h' | 'H' => u64::from_str_radix(digits, 16),
                     'b' | 'B' => u64::from_str_radix(digits, 2),
                     'd' | 'D' => digits.parse::<u64>(),
-                    _ => return Err(CompileError::general("invalid sized literal base", tok.span)),
+                    _ => {
+                        return Err(CompileError::general(
+                            "invalid sized literal base",
+                            tok.span,
+                        ))
+                    }
                 }
                 .map_err(|_| CompileError::general("invalid sized literal value", tok.span))?;
                 ExprKind::Literal(LitKind::Sized(width, value))
@@ -4152,7 +4803,9 @@ impl Parser {
         };
         Ok(Expr {
             kind,
-            span: tok.span, parenthesized: false })
+            span: tok.span,
+            parenthesized: false,
+        })
     }
 
     fn peek_binop(&self) -> Option<BinOp> {
@@ -4160,9 +4813,15 @@ impl Parser {
             // Don't treat `+ :` or `- :` as binary ops — they are part-select separators
             TokenKind::Plus if self.peek_kind_at(self.pos + 1) == Some(TokenKind::Colon) => None,
             TokenKind::Minus if self.peek_kind_at(self.pos + 1) == Some(TokenKind::Colon) => None,
-            TokenKind::Plus if self.peek_kind_at(self.pos + 1) == Some(TokenKind::Percent) => Some(BinOp::AddWrap),
-            TokenKind::Minus if self.peek_kind_at(self.pos + 1) == Some(TokenKind::Percent) => Some(BinOp::SubWrap),
-            TokenKind::Star if self.peek_kind_at(self.pos + 1) == Some(TokenKind::Percent) => Some(BinOp::MulWrap),
+            TokenKind::Plus if self.peek_kind_at(self.pos + 1) == Some(TokenKind::Percent) => {
+                Some(BinOp::AddWrap)
+            }
+            TokenKind::Minus if self.peek_kind_at(self.pos + 1) == Some(TokenKind::Percent) => {
+                Some(BinOp::SubWrap)
+            }
+            TokenKind::Star if self.peek_kind_at(self.pos + 1) == Some(TokenKind::Percent) => {
+                Some(BinOp::MulWrap)
+            }
             TokenKind::Plus => Some(BinOp::Add),
             TokenKind::Minus => Some(BinOp::Sub),
             TokenKind::Star => Some(BinOp::Mul),
@@ -4216,8 +4875,10 @@ impl Parser {
                 Some(TokenKind::Wire) => wires.push(self.parse_wire_decl()?),
                 Some(TokenKind::Let) => lets.push(self.parse_let_binding()?),
                 // `state [A, B, C]` — flat declaration list
-                _ if self.check_contextual("state") && self.pos + 1 < self.tokens.len()
-                    && self.tokens[self.pos + 1].kind == TokenKind::LBracket => {
+                _ if self.check_contextual("state")
+                    && self.pos + 1 < self.tokens.len()
+                    && self.tokens[self.pos + 1].kind == TokenKind::LBracket =>
+                {
                     self.advance(); // consume `state`
                     self.expect(TokenKind::LBracket)?;
                     loop {
@@ -4240,7 +4901,10 @@ impl Parser {
                     let default_span = self.tokens[self.pos].span;
                     let next_is_seq_same_line = self.pos + 1 < self.tokens.len()
                         && self.tokens[self.pos + 1].kind == TokenKind::Seq
-                        && !self.has_newline_between(default_span.end, self.tokens[self.pos + 1].span.start);
+                        && !self.has_newline_between(
+                            default_span.end,
+                            self.tokens[self.pos + 1].span.start,
+                        );
                     if next_is_seq_same_line {
                         self.parse_seq_default_decl()?;
                         continue;
@@ -4303,7 +4967,11 @@ impl Parser {
         self.expect(TokenKind::Fsm)?;
         let closing = self.expect_ident()?;
         if closing.name != name.name {
-            return Err(CompileError::mismatched_closing(&name.name, &closing.name, closing.span));
+            return Err(CompileError::mismatched_closing(
+                &name.name,
+                &closing.name,
+                closing.span,
+            ));
         }
 
         // `default state Name;` is required for real `fsm` declarations
@@ -4315,7 +4983,16 @@ impl Parser {
         // when `!common.is_interface && default_state.is_none()`).
 
         Ok(FsmDecl {
-            common: ConstructCommon { name, params, ports, asserts, span: start.merge(closing.span), doc: None, inner_doc, is_interface: false },
+            common: ConstructCommon {
+                name,
+                params,
+                ports,
+                asserts,
+                span: start.merge(closing.span),
+                doc: None,
+                inner_doc,
+                is_interface: false,
+            },
             regs,
             lets,
             wires,
@@ -4358,7 +5035,11 @@ impl Parser {
                     // `let x = expr;` inside state — shorthand for comb assignment
                     let l = self.parse_let_binding()?;
                     comb_stmts.push(Stmt::Assign(crate::ast::CombAssign {
-                        target: Expr { kind: ExprKind::Ident(l.name.name.clone()), span: l.name.span, parenthesized: false },
+                        target: Expr {
+                            kind: ExprKind::Ident(l.name.name.clone()),
+                            span: l.name.span,
+                            parenthesized: false,
+                        },
                         value: l.value,
                         span: l.span,
                     }));
@@ -4378,7 +5059,11 @@ impl Parser {
         self.expect_contextual("state")?;
         let closing = self.expect_ident()?;
         if closing.name != name.name {
-            return Err(CompileError::mismatched_closing(&name.name, &closing.name, closing.span));
+            return Err(CompileError::mismatched_closing(
+                &name.name,
+                &closing.name,
+                closing.span,
+            ));
         }
 
         Ok(StateBody {
@@ -4396,7 +5081,6 @@ impl Parser {
             && matches!(&self.tokens[self.pos + 1].kind, TokenKind::Ident(s) if s == "state")
     }
 
-
     fn parse_transition(&mut self) -> Result<Transition, CompileError> {
         let start = self.expect(TokenKind::RArrow)?.span;
         let target = self.expect_ident()?;
@@ -4404,10 +5088,18 @@ impl Parser {
         let condition = if self.eat(TokenKind::When) {
             self.parse_expr()?
         } else {
-            Expr { kind: ExprKind::Bool(true), span: target.span, parenthesized: false }
+            Expr {
+                kind: ExprKind::Bool(true),
+                span: target.span,
+                parenthesized: false,
+            }
         };
         self.expect(TokenKind::Semi)?;
-        let end_span = self.tokens.get(self.pos.saturating_sub(1)).map(|t| t.span).unwrap_or(start);
+        let end_span = self
+            .tokens
+            .get(self.pos.saturating_sub(1))
+            .map(|t| t.span)
+            .unwrap_or(start);
         Ok(Transition {
             target,
             condition,
@@ -4456,11 +5148,24 @@ impl Parser {
         self.expect(TokenKind::Pipeline)?;
         let closing = self.expect_ident()?;
         if closing.name != name.name {
-            return Err(CompileError::mismatched_closing(&name.name, &closing.name, closing.span));
+            return Err(CompileError::mismatched_closing(
+                &name.name,
+                &closing.name,
+                closing.span,
+            ));
         }
 
         Ok(PipelineDecl {
-            common: ConstructCommon { name, params, ports, asserts, span: start.merge(closing.span), doc: None, inner_doc, is_interface: false },
+            common: ConstructCommon {
+                name,
+                params,
+                ports,
+                asserts,
+                span: start.merge(closing.span),
+                doc: None,
+                inner_doc,
+                is_interface: false,
+            },
             stages,
             stall_conds,
             flush_directives,
@@ -4486,7 +5191,7 @@ impl Parser {
         // Handle todo! stage body
         if self.check(TokenKind::Todo) {
             self.advance(); // consume todo!
-            // fall through to end stage
+                            // fall through to end stage
         } else {
             while !self.check_end_stage() {
                 match self.peek_kind() {
@@ -4528,7 +5233,11 @@ impl Parser {
         self.expect(TokenKind::Stage)?;
         let closing = self.expect_ident()?;
         if closing.name != name.name {
-            return Err(CompileError::mismatched_closing(&name.name, &closing.name, closing.span));
+            return Err(CompileError::mismatched_closing(
+                &name.name,
+                &closing.name,
+                closing.span,
+            ));
         }
 
         Ok(StageDecl {
@@ -4544,7 +5253,11 @@ impl Parser {
         self.expect(TokenKind::When)?;
         let condition = self.parse_expr()?;
         self.expect(TokenKind::Semi)?;
-        let end_span = self.tokens.get(self.pos.saturating_sub(1)).map(|t| t.span).unwrap_or(start);
+        let end_span = self
+            .tokens
+            .get(self.pos.saturating_sub(1))
+            .map(|t| t.span)
+            .unwrap_or(start);
         Ok(StallDecl {
             condition,
             span: start.merge(end_span),
@@ -4561,7 +5274,11 @@ impl Parser {
         // scenarios where stale data in flushed regs is a hazard.
         let clear = self.eat_contextual("clear");
         self.expect(TokenKind::Semi)?;
-        let end_span = self.tokens.get(self.pos.saturating_sub(1)).map(|t| t.span).unwrap_or(start);
+        let end_span = self
+            .tokens
+            .get(self.pos.saturating_sub(1))
+            .map(|t| t.span)
+            .unwrap_or(start);
         Ok(FlushDecl {
             target_stage,
             condition,
@@ -4578,7 +5295,11 @@ impl Parser {
         self.expect(TokenKind::When)?;
         let condition = self.parse_expr()?;
         self.expect(TokenKind::Semi)?;
-        let end_span = self.tokens.get(self.pos.saturating_sub(1)).map(|t| t.span).unwrap_or(start);
+        let end_span = self
+            .tokens
+            .get(self.pos.saturating_sub(1))
+            .map(|t| t.span)
+            .unwrap_or(start);
         Ok(ForwardDecl {
             dest,
             source,
@@ -4620,10 +5341,12 @@ impl Parser {
                     kind = Some(match val.name.as_str() {
                         "fifo" => FifoKind::Fifo,
                         "lifo" => FifoKind::Lifo,
-                        other => return Err(CompileError::general(
-                            &format!("unknown fifo kind `{other}`; expected fifo or lifo"),
-                            val.span,
-                        )),
+                        other => {
+                            return Err(CompileError::general(
+                                &format!("unknown fifo kind `{other}`; expected fifo or lifo"),
+                                val.span,
+                            ))
+                        }
                     });
                 }
                 _ if self.check_param() => params.push(self.parse_param_decl()?),
@@ -4646,11 +5369,24 @@ impl Parser {
         self.expect(TokenKind::Fifo)?;
         let closing = self.expect_ident()?;
         if closing.name != name.name {
-            return Err(CompileError::mismatched_closing(&name.name, &closing.name, closing.span));
+            return Err(CompileError::mismatched_closing(
+                &name.name,
+                &closing.name,
+                closing.span,
+            ));
         }
 
         Ok(FifoDecl {
-            common: ConstructCommon { name, params, ports, asserts, span: start.merge(closing.span), doc: None, inner_doc, is_interface: false },
+            common: ConstructCommon {
+                name,
+                params,
+                ports,
+                asserts,
+                span: start.merge(closing.span),
+                doc: None,
+                inner_doc,
+                is_interface: false,
+            },
             kind: kind.unwrap_or(FifoKind::Fifo),
         })
     }
@@ -4716,7 +5452,11 @@ impl Parser {
         self.expect(TokenKind::Synchronizer)?;
         let closing = self.expect_ident()?;
         if closing.name != name.name {
-            return Err(CompileError::mismatched_closing(&name.name, &closing.name, closing.span));
+            return Err(CompileError::mismatched_closing(
+                &name.name,
+                &closing.name,
+                closing.span,
+            ));
         }
 
         Ok(SynchronizerDecl {
@@ -4755,21 +5495,36 @@ impl Parser {
                     self.advance();
                     // 'and' and 'latch' are both keyword tokens, handle both specially
                     let span = self.peek_span();
-                    let kind_val = match self.peek_kind() {
-                        Some(TokenKind::And) => { self.advance(); "and" }
-                        Some(TokenKind::Latch) => { self.advance(); "latch" }
-                        Some(TokenKind::Ident(_)) => {
-                            let val = self.expect_ident()?;
-                            match val.name.as_str() {
-                                "latch" => "latch",
-                                other => return Err(CompileError::general(
-                                    &format!("unknown clkgate kind `{other}`; expected latch or and"),
-                                    val.span,
-                                )),
+                    let kind_val =
+                        match self.peek_kind() {
+                            Some(TokenKind::And) => {
+                                self.advance();
+                                "and"
                             }
-                        }
-                        _ => return Err(CompileError::unexpected_token("latch or and", &format!("{:?}", self.peek_kind()), span)),
-                    };
+                            Some(TokenKind::Latch) => {
+                                self.advance();
+                                "latch"
+                            }
+                            Some(TokenKind::Ident(_)) => {
+                                let val = self.expect_ident()?;
+                                match val.name.as_str() {
+                                    "latch" => "latch",
+                                    other => return Err(CompileError::general(
+                                        &format!(
+                                            "unknown clkgate kind `{other}`; expected latch or and"
+                                        ),
+                                        val.span,
+                                    )),
+                                }
+                            }
+                            _ => {
+                                return Err(CompileError::unexpected_token(
+                                    "latch or and",
+                                    &format!("{:?}", self.peek_kind()),
+                                    span,
+                                ))
+                            }
+                        };
                     self.expect(TokenKind::Semi)?;
                     kind = Some(match kind_val {
                         "latch" => ClkGateKind::Latch,
@@ -4792,7 +5547,11 @@ impl Parser {
         self.expect(TokenKind::Clkgate)?;
         let closing = self.expect_ident()?;
         if closing.name != name.name {
-            return Err(CompileError::mismatched_closing(&name.name, &closing.name, closing.span));
+            return Err(CompileError::mismatched_closing(
+                &name.name,
+                &closing.name,
+                closing.span,
+            ));
         }
 
         Ok(ClkGateDecl {
@@ -4832,9 +5591,12 @@ impl Parser {
 
         // Phase 1: attributes (kind, read, write, collision, init)
         while !self.check_end_ram() {
-            if self.check(TokenKind::Param) || self.check(TokenKind::Port)
+            if self.check(TokenKind::Param)
+                || self.check(TokenKind::Port)
                 || self.check(TokenKind::Store)
-                || self.check(TokenKind::Assert) || self.check(TokenKind::Cover) {
+                || self.check(TokenKind::Assert)
+                || self.check(TokenKind::Cover)
+            {
                 break;
             }
             if self.check(TokenKind::Init) {
@@ -4858,14 +5620,18 @@ impl Parser {
                 let lit_span = self.peek_span();
                 let val = match self.peek_kind() {
                     Some(TokenKind::DecLiteral(s)) => {
-                        let v = s.parse::<u32>().map_err(|_| CompileError::general(
-                            "expected integer after `latency`", lit_span))?;
-                        self.advance(); v
+                        let v = s.parse::<u32>().map_err(|_| {
+                            CompileError::general("expected integer after `latency`", lit_span)
+                        })?;
+                        self.advance();
+                        v
                     }
-                    _ => return Err(CompileError::general(
-                        "expected integer after `latency`",
-                        lit_span,
-                    )),
+                    _ => {
+                        return Err(CompileError::general(
+                            "expected integer after `latency`",
+                            lit_span,
+                        ))
+                    }
                 };
                 self.expect(TokenKind::Semi)?;
                 latency = Some(val);
@@ -4892,15 +5658,20 @@ impl Parser {
                     "port_a_wins" => RamCollision::PortAWins,
                     "port_b_wins" => RamCollision::PortBWins,
                     "undefined" => RamCollision::Undefined,
-                    other => return Err(CompileError::general(
-                        &format!("unknown collision policy `{other}`"),
-                        val.span,
-                    )),
+                    other => {
+                        return Err(CompileError::general(
+                            &format!("unknown collision policy `{other}`"),
+                            val.span,
+                        ))
+                    }
                 });
             } else {
                 return Err(CompileError::unexpected_token(
                     "kind, latency, write, collision, or init",
-                    &self.peek_kind().map(|k| k.to_string()).unwrap_or("EOF".into()),
+                    &self
+                        .peek_kind()
+                        .map(|k| k.to_string())
+                        .unwrap_or("EOF".into()),
                     self.peek_span(),
                 ));
             }
@@ -4929,33 +5700,46 @@ impl Parser {
                 Some(TokenKind::Assert) | Some(TokenKind::Cover) => {
                     asserts.push(self.parse_assert_decl()?);
                 }
-                Some(other) => return Err(CompileError::unexpected_token(
-                    "port, store, init, assert, or cover",
-                    &other.to_string(),
-                    self.peek_span(),
-                )),
+                Some(other) => {
+                    return Err(CompileError::unexpected_token(
+                        "port, store, init, assert, or cover",
+                        &other.to_string(),
+                        self.peek_span(),
+                    ))
+                }
                 None => return Err(CompileError::UnexpectedEof),
             }
         }
 
-        let k = kind.ok_or_else(|| CompileError::general(
-            "ram is missing required `kind` directive",
-            name.span,
-        ))?;
-        let lat = latency.ok_or_else(|| CompileError::general(
-            "ram is missing required `latency` directive",
-            name.span,
-        ))?;
+        let k = kind.ok_or_else(|| {
+            CompileError::general("ram is missing required `kind` directive", name.span)
+        })?;
+        let lat = latency.ok_or_else(|| {
+            CompileError::general("ram is missing required `latency` directive", name.span)
+        })?;
 
         self.expect(TokenKind::End)?;
         self.expect(TokenKind::Ram)?;
         let closing = self.expect_ident()?;
         if closing.name != name.name {
-            return Err(CompileError::mismatched_closing(&name.name, &closing.name, closing.span));
+            return Err(CompileError::mismatched_closing(
+                &name.name,
+                &closing.name,
+                closing.span,
+            ));
         }
 
         Ok(RamDecl {
-            common: ConstructCommon { name, params, ports, asserts, span: start.merge(closing.span), doc: None, inner_doc, is_interface: false },
+            common: ConstructCommon {
+                name,
+                params,
+                ports,
+                asserts,
+                span: start.merge(closing.span),
+                doc: None,
+                inner_doc,
+                is_interface: false,
+            },
             kind: k,
             latency: lat,
             write_mode,
@@ -4975,8 +5759,16 @@ impl Parser {
             self.expect(TokenKind::Colon)?;
             let ty = self.parse_type_expr()?;
             self.expect(TokenKind::Semi)?;
-            let end_span = self.tokens.get(self.pos.saturating_sub(1)).map(|t| t.span).unwrap_or(start);
-            vars.push(RamStoreVar { name, ty, span: start.merge(end_span) });
+            let end_span = self
+                .tokens
+                .get(self.pos.saturating_sub(1))
+                .map(|t| t.span)
+                .unwrap_or(start);
+            vars.push(RamStoreVar {
+                name,
+                ty,
+                span: start.merge(end_span),
+            });
         }
         self.expect(TokenKind::End)?;
         self.expect(TokenKind::Store)?;
@@ -5000,7 +5792,11 @@ impl Parser {
         self.expect(TokenKind::Ports)?;
         let closing = self.expect_ident()?;
         if closing.name != name.name {
-            return Err(CompileError::mismatched_closing(&name.name, &closing.name, closing.span));
+            return Err(CompileError::mismatched_closing(
+                &name.name,
+                &closing.name,
+                closing.span,
+            ));
         }
         Ok(RamPortGroup {
             span: start.merge(closing.span),
@@ -5027,14 +5823,33 @@ impl Parser {
         } else {
             return Err(CompileError::unexpected_token(
                 "in or out",
-                &self.peek_kind().map(|k| k.to_string()).unwrap_or("EOF".into()),
+                &self
+                    .peek_kind()
+                    .map(|k| k.to_string())
+                    .unwrap_or("EOF".into()),
                 self.peek_span(),
             ));
         };
         let ty = self.parse_type_expr()?;
         self.expect(TokenKind::Semi)?;
-        let end_span = self.tokens.get(self.pos.saturating_sub(1)).map(|t| t.span).unwrap_or(start);
-        Ok(PortDecl { name, direction, ty, default: None, reg_info: None, bus_info: None, shared: None, unpacked: false, unpacked_ascending: false, comb_deps: None, span: start.merge(end_span) })
+        let end_span = self
+            .tokens
+            .get(self.pos.saturating_sub(1))
+            .map(|t| t.span)
+            .unwrap_or(start);
+        Ok(PortDecl {
+            name,
+            direction,
+            ty,
+            default: None,
+            reg_info: None,
+            bus_info: None,
+            shared: None,
+            unpacked: false,
+            unpacked_ascending: false,
+            comb_deps: None,
+            span: start.merge(end_span),
+        })
     }
 
     fn parse_ram_init(&mut self) -> Result<RamInit, CompileError> {
@@ -5101,13 +5916,17 @@ impl Parser {
                         ExprKind::Literal(LitKind::Hex(v)) => *v,
                         ExprKind::Literal(LitKind::Bin(v)) => *v,
                         ExprKind::Literal(LitKind::Sized(_, v)) => *v,
-                        _ => return Err(CompileError::general(
-                            "init array elements must be integer literals",
-                            expr.span,
-                        )),
+                        _ => {
+                            return Err(CompileError::general(
+                                "init array elements must be integer literals",
+                                expr.span,
+                            ))
+                        }
                     };
                     values.push(val);
-                    if self.check(TokenKind::Comma) { self.advance(); }
+                    if self.check(TokenKind::Comma) {
+                        self.advance();
+                    }
                 }
                 self.expect(TokenKind::RBracket)?;
                 self.expect(TokenKind::Semi)?;
@@ -5150,11 +5969,13 @@ impl Parser {
                 Some(TokenKind::Assert) | Some(TokenKind::Cover) => {
                     asserts.push(self.parse_assert_decl()?);
                 }
-                Some(other) => return Err(CompileError::unexpected_token(
-                    "port, assert, or cover",
-                    &other.to_string(),
-                    self.peek_span(),
-                )),
+                Some(other) => {
+                    return Err(CompileError::unexpected_token(
+                        "port, assert, or cover",
+                        &other.to_string(),
+                        self.peek_span(),
+                    ))
+                }
                 None => return Err(CompileError::UnexpectedEof),
             }
         }
@@ -5163,7 +5984,11 @@ impl Parser {
         self.expect(TokenKind::Cam)?;
         let closing = self.expect_ident()?;
         if closing.name != name.name {
-            return Err(CompileError::mismatched_closing(&name.name, &closing.name, closing.span));
+            return Err(CompileError::mismatched_closing(
+                &name.name,
+                &closing.name,
+                closing.span,
+            ));
         }
         let end = closing.span;
 
@@ -5173,8 +5998,12 @@ impl Parser {
                 params,
                 ports,
                 asserts,
-                span: Span { start: start.start, end: end.end },
-                doc: None, inner_doc,
+                span: Span {
+                    start: start.start,
+                    end: end.end,
+                },
+                doc: None,
+                inner_doc,
                 is_interface: false,
             },
         })
@@ -5193,8 +6022,11 @@ impl Parser {
 
         // Phase 1: attributes (kind, direction, init) — must come first
         while !self.check_end_of(TokenKind::Counter) {
-            if self.check(TokenKind::Param) || self.check(TokenKind::Port)
-                || self.check(TokenKind::Assert) || self.check(TokenKind::Cover) {
+            if self.check(TokenKind::Param)
+                || self.check(TokenKind::Port)
+                || self.check(TokenKind::Assert)
+                || self.check(TokenKind::Cover)
+            {
                 break;
             }
             if self.check(TokenKind::Init) {
@@ -5223,18 +6055,23 @@ impl Parser {
                 let val = self.expect_ident()?;
                 self.expect(TokenKind::Semi)?;
                 direction = Some(match val.name.as_str() {
-                    "up"      => CounterDirection::Up,
-                    "down"    => CounterDirection::Down,
+                    "up" => CounterDirection::Up,
+                    "down" => CounterDirection::Down,
                     "up_down" => CounterDirection::UpDown,
-                    other => return Err(CompileError::general(
-                        &format!("unknown counter direction `{other}`"),
-                        val.span,
-                    )),
+                    other => {
+                        return Err(CompileError::general(
+                            &format!("unknown counter direction `{other}`"),
+                            val.span,
+                        ))
+                    }
                 });
             } else {
                 return Err(CompileError::unexpected_token(
                     "kind, direction, or init",
-                    &self.peek_kind().map(|k| k.to_string()).unwrap_or("EOF".into()),
+                    &self
+                        .peek_kind()
+                        .map(|k| k.to_string())
+                        .unwrap_or("EOF".into()),
                     self.peek_span(),
                 ));
             }
@@ -5253,11 +6090,13 @@ impl Parser {
                 Some(TokenKind::Assert) | Some(TokenKind::Cover) => {
                     asserts.push(self.parse_assert_decl()?);
                 }
-                Some(other) => return Err(CompileError::unexpected_token(
-                    "port, assert, or cover",
-                    &other.to_string(),
-                    self.peek_span(),
-                )),
+                Some(other) => {
+                    return Err(CompileError::unexpected_token(
+                        "port, assert, or cover",
+                        &other.to_string(),
+                        self.peek_span(),
+                    ))
+                }
                 None => return Err(CompileError::UnexpectedEof),
             }
         }
@@ -5266,14 +6105,29 @@ impl Parser {
         self.expect(TokenKind::Counter)?;
         let closing = self.expect_ident()?;
         if closing.name != name.name {
-            return Err(CompileError::mismatched_closing(&name.name, &closing.name, closing.span));
+            return Err(CompileError::mismatched_closing(
+                &name.name,
+                &closing.name,
+                closing.span,
+            ));
         }
 
         let mode = mode.unwrap_or(CounterMode::Wrap);
         let direction = direction.unwrap_or(CounterDirection::Up);
         Ok(CounterDecl {
-            common: ConstructCommon { name, params, ports, asserts, span: start.merge(closing.span), doc: None, inner_doc, is_interface: false },
-            mode, direction, init,
+            common: ConstructCommon {
+                name,
+                params,
+                ports,
+                asserts,
+                span: start.merge(closing.span),
+                doc: None,
+                inner_doc,
+                is_interface: false,
+            },
+            mode,
+            direction,
+            init,
         })
     }
 
@@ -5300,9 +6154,13 @@ impl Parser {
 
         // Phase 1: attributes (policy, latency)
         while !self.check_end_of(TokenKind::Arbiter) {
-            if self.check(TokenKind::Param) || self.check(TokenKind::Port)
-                || self.check(TokenKind::Ports) || self.check(TokenKind::Hook)
-                || self.check(TokenKind::Assert) || self.check(TokenKind::Cover) {
+            if self.check(TokenKind::Param)
+                || self.check(TokenKind::Port)
+                || self.check(TokenKind::Ports)
+                || self.check(TokenKind::Hook)
+                || self.check(TokenKind::Assert)
+                || self.check(TokenKind::Cover)
+            {
                 break;
             }
             if self.check(TokenKind::Latency) {
@@ -5310,14 +6168,18 @@ impl Parser {
                 let lit_span = self.peek_span();
                 let val = match self.peek_kind() {
                     Some(TokenKind::DecLiteral(s)) => {
-                        let v = s.parse::<u32>().map_err(|_| CompileError::general(
-                            "expected integer after `latency`", lit_span))?;
-                        self.advance(); v
+                        let v = s.parse::<u32>().map_err(|_| {
+                            CompileError::general("expected integer after `latency`", lit_span)
+                        })?;
+                        self.advance();
+                        v
                     }
-                    _ => return Err(CompileError::general(
-                        "expected integer after `latency`",
-                        lit_span,
-                    )),
+                    _ => {
+                        return Err(CompileError::general(
+                            "expected integer after `latency`",
+                            lit_span,
+                        ))
+                    }
                 };
                 self.expect(TokenKind::Semi)?;
                 latency = val;
@@ -5327,12 +6189,14 @@ impl Parser {
                 self.expect(TokenKind::Semi)?;
                 policy = Some(match val.name.as_str() {
                     "round_robin" => ArbiterPolicy::RoundRobin,
-                    "priority"    => ArbiterPolicy::Priority,
-                    "lru"         => ArbiterPolicy::Lru,
+                    "priority" => ArbiterPolicy::Priority,
+                    "lru" => ArbiterPolicy::Lru,
                     "weighted" => {
                         let w = Expr {
                             kind: ExprKind::Literal(LitKind::Dec(1)),
-                            span: val.span, parenthesized: false };
+                            span: val.span,
+                            parenthesized: false,
+                        };
                         ArbiterPolicy::Weighted(w)
                     }
                     _ => ArbiterPolicy::Custom(val),
@@ -5340,7 +6204,10 @@ impl Parser {
             } else {
                 return Err(CompileError::unexpected_token(
                     "policy",
-                    &self.peek_kind().map(|k| k.to_string()).unwrap_or("EOF".into()),
+                    &self
+                        .peek_kind()
+                        .map(|k| k.to_string())
+                        .unwrap_or("EOF".into()),
                     self.peek_span(),
                 ));
             }
@@ -5375,11 +6242,13 @@ impl Parser {
                 Some(TokenKind::Assert) | Some(TokenKind::Cover) => {
                     asserts.push(self.parse_assert_decl()?);
                 }
-                Some(other) => return Err(CompileError::unexpected_token(
-                    "port, ports, handshake_channel, hook, assert, or cover",
-                    &other.to_string(),
-                    self.peek_span(),
-                )),
+                Some(other) => {
+                    return Err(CompileError::unexpected_token(
+                        "port, ports, handshake_channel, hook, assert, or cover",
+                        &other.to_string(),
+                        self.peek_span(),
+                    ))
+                }
                 None => return Err(CompileError::UnexpectedEof),
             }
         }
@@ -5388,11 +6257,24 @@ impl Parser {
         self.expect(TokenKind::Arbiter)?;
         let closing = self.expect_ident()?;
         if closing.name != name.name {
-            return Err(CompileError::mismatched_closing(&name.name, &closing.name, closing.span));
+            return Err(CompileError::mismatched_closing(
+                &name.name,
+                &closing.name,
+                closing.span,
+            ));
         }
 
         Ok(ArbiterDecl {
-            common: ConstructCommon { name, params, ports, asserts, span: start.merge(closing.span), doc: None, inner_doc, is_interface: false },
+            common: ConstructCommon {
+                name,
+                params,
+                ports,
+                asserts,
+                span: start.merge(closing.span),
+                doc: None,
+                inner_doc,
+                is_interface: false,
+            },
             port_arrays,
             policy: policy.unwrap_or(ArbiterPolicy::RoundRobin),
             hook,
@@ -5416,7 +6298,10 @@ impl Parser {
             let pname = self.expect_ident()?;
             self.expect(TokenKind::Colon)?;
             let pty = self.parse_type_expr()?;
-            params.push(crate::ast::FunctionArg { name: pname, ty: pty });
+            params.push(crate::ast::FunctionArg {
+                name: pname,
+                ty: pty,
+            });
         }
         self.expect(TokenKind::RParen)?;
 
@@ -5456,11 +6341,16 @@ impl Parser {
         self.expect(TokenKind::LParen)?;
         let mut params = Vec::new();
         while !self.check(TokenKind::RParen) {
-            if !params.is_empty() { self.expect(TokenKind::Comma)?; }
+            if !params.is_empty() {
+                self.expect(TokenKind::Comma)?;
+            }
             let pname = self.expect_ident()?;
             self.expect(TokenKind::Colon)?;
             let pty = self.parse_type_expr()?;
-            params.push(crate::ast::FunctionArg { name: pname, ty: pty });
+            params.push(crate::ast::FunctionArg {
+                name: pname,
+                ty: pty,
+            });
         }
         self.expect(TokenKind::RParen)?;
 
@@ -5472,7 +6362,9 @@ impl Parser {
         self.expect(TokenKind::LParen)?;
         let mut fn_args = Vec::new();
         while !self.check(TokenKind::RParen) {
-            if !fn_args.is_empty() { self.expect(TokenKind::Comma)?; }
+            if !fn_args.is_empty() {
+                self.expect(TokenKind::Comma)?;
+            }
             fn_args.push(self.expect_ident()?);
         }
         self.expect(TokenKind::RParen)?;
@@ -5506,11 +6398,13 @@ impl Parser {
                 Some(TokenKind::Port) => ports.push(self.parse_port_decl()?),
                 Some(TokenKind::Ports) => port_arrays.push(self.parse_port_array()?),
                 Some(TokenKind::Hook) => hooks.push(self.parse_template_hook_decl()?),
-                Some(other) => return Err(CompileError::unexpected_token(
-                    "param, port, ports, or hook",
-                    &other.to_string(),
-                    self.peek_span(),
-                )),
+                Some(other) => {
+                    return Err(CompileError::unexpected_token(
+                        "param, port, ports, or hook",
+                        &other.to_string(),
+                        self.peek_span(),
+                    ))
+                }
                 None => return Err(CompileError::UnexpectedEof),
             }
         }
@@ -5519,11 +6413,24 @@ impl Parser {
         self.expect(TokenKind::Template)?;
         let closing = self.expect_ident()?;
         if closing.name != name.name {
-            return Err(CompileError::mismatched_closing(&name.name, &closing.name, closing.span));
+            return Err(CompileError::mismatched_closing(
+                &name.name,
+                &closing.name,
+                closing.span,
+            ));
         }
 
         let span = start.merge(closing.span);
-        Ok(crate::ast::TemplateDecl { name, params, ports, port_arrays, hooks, span, doc: None, inner_doc })
+        Ok(crate::ast::TemplateDecl {
+            name,
+            params,
+            ports,
+            port_arrays,
+            hooks,
+            span,
+            doc: None,
+            inner_doc,
+        })
     }
 
     /// Parse `hook name(args) -> RetType;` (no binding — template signature only)
@@ -5534,11 +6441,16 @@ impl Parser {
         self.expect(TokenKind::LParen)?;
         let mut params = Vec::new();
         while !self.check(TokenKind::RParen) {
-            if !params.is_empty() { self.expect(TokenKind::Comma)?; }
+            if !params.is_empty() {
+                self.expect(TokenKind::Comma)?;
+            }
             let pname = self.expect_ident()?;
             self.expect(TokenKind::Colon)?;
             let pty = self.parse_type_expr()?;
-            params.push(crate::ast::FunctionArg { name: pname, ty: pty });
+            params.push(crate::ast::FunctionArg {
+                name: pname,
+                ty: pty,
+            });
         }
         self.expect(TokenKind::RParen)?;
 
@@ -5569,7 +6481,11 @@ impl Parser {
         self.expect(TokenKind::Ports)?;
         let closing = self.expect_ident()?;
         if closing.name != name.name {
-            return Err(CompileError::mismatched_closing(&name.name, &closing.name, closing.span));
+            return Err(CompileError::mismatched_closing(
+                &name.name,
+                &closing.name,
+                closing.span,
+            ));
         }
         Ok(PortArrayDecl {
             span: start.merge(closing.span),
@@ -5626,33 +6542,41 @@ impl Parser {
                 Some(TokenKind::Port) => ports.push(self.parse_port_decl()?),
                 Some(TokenKind::Kind) => {
                     self.advance(); // consume `kind`
-                    // `latch` is a reserved keyword, so handle it directly
-                    // alongside the ident path.
+                                    // `latch` is a reserved keyword, so handle it directly
+                                    // alongside the ident path.
                     let span = self.peek_span();
                     let kind_str = match self.peek_kind() {
-                        Some(TokenKind::Latch) => { self.advance(); "latch".to_string() }
+                        Some(TokenKind::Latch) => {
+                            self.advance();
+                            "latch".to_string()
+                        }
                         Some(TokenKind::Ident(_)) => self.expect_ident()?.name,
-                        Some(other) => return Err(CompileError::unexpected_token(
-                            "regfile kind (`flop` or `latch`)",
-                            &other.to_string(),
-                            span,
-                        )),
+                        Some(other) => {
+                            return Err(CompileError::unexpected_token(
+                                "regfile kind (`flop` or `latch`)",
+                                &other.to_string(),
+                                span,
+                            ))
+                        }
                         None => return Err(CompileError::UnexpectedEof),
                     };
                     self.expect(TokenKind::Semi)?;
-                    kind = match kind_str.as_str() {
-                        "flop"  => crate::ast::RegfileKind::Flop,
-                        "latch" => crate::ast::RegfileKind::Latch,
-                        other => return Err(CompileError::general(
-                            &format!("unknown regfile kind `{other}`; expected `flop` or `latch`"),
-                            span,
-                        )),
-                    };
+                    kind =
+                        match kind_str.as_str() {
+                            "flop" => crate::ast::RegfileKind::Flop,
+                            "latch" => crate::ast::RegfileKind::Latch,
+                            other => return Err(CompileError::general(
+                                &format!(
+                                    "unknown regfile kind `{other}`; expected `flop` or `latch`"
+                                ),
+                                span,
+                            )),
+                        };
                 }
                 Some(TokenKind::Ports) => {
                     let arr = self.parse_port_array()?;
                     match arr.name.name.as_str() {
-                        "read"  => read_ports  = Some(arr),
+                        "read" => read_ports = Some(arr),
                         "write" => write_ports = Some(arr),
                         other => {
                             // accept any name; use name to detect
@@ -5673,11 +6597,15 @@ impl Parser {
                     self.expect(TokenKind::Eq)?;
                     let value = self.parse_expr()?;
                     self.expect(TokenKind::Semi)?;
-                    inits.push(RegfileInit { index, value, span: init_span });
+                    inits.push(RegfileInit {
+                        index,
+                        value,
+                        span: init_span,
+                    });
                 }
                 Some(TokenKind::Forward) => {
                     self.advance(); // consume "forward"
-                    // `write_before_read: true;` or similar
+                                    // `write_before_read: true;` or similar
                     while !self.check(TokenKind::Semi) && !self.at_end() {
                         if let Some(TokenKind::True) = self.peek_kind() {
                             forward_write_before_read = true;
@@ -5689,11 +6617,13 @@ impl Parser {
                 Some(TokenKind::Assert) | Some(TokenKind::Cover) => {
                     asserts.push(self.parse_assert_decl()?);
                 }
-                Some(other) => return Err(CompileError::unexpected_token(
-                    "param, port, ports, init, forward, assert, or cover",
-                    &other.to_string(),
-                    self.peek_span(),
-                )),
+                Some(other) => {
+                    return Err(CompileError::unexpected_token(
+                        "param, port, ports, init, forward, assert, or cover",
+                        &other.to_string(),
+                        self.peek_span(),
+                    ))
+                }
                 None => return Err(CompileError::UnexpectedEof),
             }
         }
@@ -5702,11 +6632,24 @@ impl Parser {
         self.expect(TokenKind::Regfile)?;
         let closing = self.expect_ident()?;
         if closing.name != name.name {
-            return Err(CompileError::mismatched_closing(&name.name, &closing.name, closing.span));
+            return Err(CompileError::mismatched_closing(
+                &name.name,
+                &closing.name,
+                closing.span,
+            ));
         }
 
         Ok(RegfileDecl {
-            common: ConstructCommon { name, params, ports, asserts, span: start.merge(closing.span), doc: None, inner_doc, is_interface: false },
+            common: ConstructCommon {
+                name,
+                params,
+                ports,
+                asserts,
+                span: start.merge(closing.span),
+                doc: None,
+                inner_doc,
+                is_interface: false,
+            },
             read_ports,
             write_ports,
             inits,
@@ -5730,7 +6673,9 @@ impl Parser {
         let mut i = self.pos;
         while let Some(t) = self.tokens.get(i) {
             match &t.kind {
-                TokenKind::DocOuter(_) | TokenKind::DocInner(_) => { i += 1; }
+                TokenKind::DocOuter(_) | TokenKind::DocInner(_) => {
+                    i += 1;
+                }
                 other => return Some(other.clone()),
             }
         }
@@ -5810,11 +6755,12 @@ impl Parser {
         if self.check_ident(name) {
             Ok(self.advance())
         } else {
-            let span = self.tokens.get(self.pos).map(|t| t.span).unwrap_or(Span { start: 0, end: 0 });
-            Err(CompileError::general(
-                &format!("expected `{}`", name),
-                span,
-            ))
+            let span = self
+                .tokens
+                .get(self.pos)
+                .map(|t| t.span)
+                .unwrap_or(Span { start: 0, end: 0 });
+            Err(CompileError::general(&format!("expected `{}`", name), span))
         }
     }
 
@@ -5826,13 +6772,22 @@ impl Parser {
     fn is_type_start(&self) -> bool {
         matches!(
             self.peek_kind(),
-            Some(TokenKind::UInt | TokenKind::SInt | TokenKind::Bool | TokenKind::Bit
-                | TokenKind::KwVec | TokenKind::Clock | TokenKind::Reset)
+            Some(
+                TokenKind::UInt
+                    | TokenKind::SInt
+                    | TokenKind::Bool
+                    | TokenKind::Bit
+                    | TokenKind::KwVec
+                    | TokenKind::Clock
+                    | TokenKind::Reset
+            )
         )
     }
 
     fn check_param(&self) -> bool {
-        if self.check(TokenKind::Param) { return true; }
+        if self.check(TokenKind::Param) {
+            return true;
+        }
         if self.check_ident("local") {
             // Find the position of `local` after skipping any leading
             // doc comments (matching `peek_kind`'s skip semantics), then
@@ -5843,7 +6798,9 @@ impl Parser {
             while let Some(t) = self.tokens.get(i) {
                 if matches!(&t.kind, TokenKind::DocOuter(_) | TokenKind::DocInner(_)) {
                     i += 1;
-                } else { break; }
+                } else {
+                    break;
+                }
             }
             // i now points at `local`; look at the next non-doc token.
             let mut j = i + 1;
@@ -5887,7 +6844,10 @@ impl Parser {
         } else {
             Err(CompileError::unexpected_token(
                 &kind.to_string(),
-                &self.peek_kind().map(|k| k.to_string()).unwrap_or("EOF".into()),
+                &self
+                    .peek_kind()
+                    .map(|k| k.to_string())
+                    .unwrap_or("EOF".into()),
                 self.peek_span(),
             ))
         }
@@ -5896,11 +6856,11 @@ impl Parser {
     fn expect_ident(&mut self) -> Result<Ident, CompileError> {
         // Contextual keywords that are valid identifiers in non-keyword positions.
         let contextual_name = match self.peek_kind() {
-            Some(TokenKind::Op)        => Some("op"),
-            Some(TokenKind::Track)     => Some("track"),
-            Some(TokenKind::Latency)   => Some("latency"),
+            Some(TokenKind::Op) => Some("op"),
+            Some(TokenKind::Track) => Some("track"),
+            Some(TokenKind::Latency) => Some("latency"),
             Some(TokenKind::Pipelined) => Some("pipelined"),
-            Some(TokenKind::Kind)      => Some("kind"),
+            Some(TokenKind::Kind) => Some("kind"),
             _ => None,
         };
         if let Some(name) = contextual_name {
@@ -5975,14 +6935,17 @@ impl Parser {
                     self.advance(); // consume 'kind'
                     let kw = self.expect_ident()?;
                     kind = Some(match kw.name.as_str() {
-                        "singly"           => LinklistKind::Singly,
-                        "doubly"           => LinklistKind::Doubly,
-                        "circular_singly"  => LinklistKind::CircularSingly,
-                        "circular_doubly"  => LinklistKind::CircularDoubly,
-                        other => return Err(CompileError::unexpected_token(
-                            "singly, doubly, circular_singly, or circular_doubly",
-                            other, kw.span,
-                        )),
+                        "singly" => LinklistKind::Singly,
+                        "doubly" => LinklistKind::Doubly,
+                        "circular_singly" => LinklistKind::CircularSingly,
+                        "circular_doubly" => LinklistKind::CircularDoubly,
+                        other => {
+                            return Err(CompileError::unexpected_token(
+                                "singly, doubly, circular_singly, or circular_doubly",
+                                other,
+                                kw.span,
+                            ))
+                        }
                     });
                     self.eat(TokenKind::Semi);
                 }
@@ -5991,32 +6954,54 @@ impl Parser {
                     let field = self.expect_ident()?;
                     self.expect(TokenKind::Colon)?;
                     let val = match self.peek_kind() {
-                        Some(TokenKind::True)  => { self.advance(); true }
-                        Some(TokenKind::False) => { self.advance(); false }
-                        Some(TokenKind::Ident(ref s)) if s == "true"  => { self.advance(); true }
-                        Some(TokenKind::Ident(ref s)) if s == "false" => { self.advance(); false }
-                        other => return Err(CompileError::unexpected_token(
-                            "true or false",
-                            &other.map(|k| k.to_string()).unwrap_or("EOF".into()),
-                            self.peek_span(),
-                        )),
+                        Some(TokenKind::True) => {
+                            self.advance();
+                            true
+                        }
+                        Some(TokenKind::False) => {
+                            self.advance();
+                            false
+                        }
+                        Some(TokenKind::Ident(ref s)) if s == "true" => {
+                            self.advance();
+                            true
+                        }
+                        Some(TokenKind::Ident(ref s)) if s == "false" => {
+                            self.advance();
+                            false
+                        }
+                        other => {
+                            return Err(CompileError::unexpected_token(
+                                "true or false",
+                                &other.map(|k| k.to_string()).unwrap_or("EOF".into()),
+                                self.peek_span(),
+                            ))
+                        }
                     };
                     self.eat(TokenKind::Semi);
                     match field.name.as_str() {
-                        "tail"   => track_tail   = val,
+                        "tail" => track_tail = val,
                         "length" => track_length = val,
-                        other => return Err(CompileError::unexpected_token(
-                            "tail or length", other, field.span,
-                        )),
+                        other => {
+                            return Err(CompileError::unexpected_token(
+                                "tail or length",
+                                other,
+                                field.span,
+                            ))
+                        }
                     }
                 }
                 Some(TokenKind::Op) => ops.push(self.parse_op_decl()?),
                 Some(TokenKind::Assert) | Some(TokenKind::Cover) => {
                     asserts.push(self.parse_assert_decl()?);
                 }
-                Some(other) => return Err(CompileError::unexpected_token(
-                    "param, port, kind, track, op, assert, or cover", &other.to_string(), self.peek_span(),
-                )),
+                Some(other) => {
+                    return Err(CompileError::unexpected_token(
+                        "param, port, kind, track, op, assert, or cover",
+                        &other.to_string(),
+                        self.peek_span(),
+                    ))
+                }
                 None => return Err(CompileError::UnexpectedEof),
             }
         }
@@ -6025,11 +7010,24 @@ impl Parser {
         self.expect(TokenKind::Linklist)?;
         let closing = self.expect_ident()?;
         if closing.name != name.name {
-            return Err(CompileError::mismatched_closing(&name.name, &closing.name, closing.span));
+            return Err(CompileError::mismatched_closing(
+                &name.name,
+                &closing.name,
+                closing.span,
+            ));
         }
 
         Ok(LinklistDecl {
-            common: ConstructCommon { name, params, ports, asserts, span: start.merge(closing.span), doc: None, inner_doc, is_interface: false },
+            common: ConstructCommon {
+                name,
+                params,
+                ports,
+                asserts,
+                span: start.merge(closing.span),
+                doc: None,
+                inner_doc,
+                is_interface: false,
+            },
             kind: kind.unwrap_or(LinklistKind::Singly),
             track_tail,
             track_length,
@@ -6057,9 +7055,13 @@ impl Parser {
                             latency = s.parse::<u32>().unwrap_or(1);
                             self.advance();
                         }
-                        other => return Err(CompileError::unexpected_token(
-                            "integer literal", &other.map(|k| k.to_string()).unwrap_or("EOF".into()), self.peek_span(),
-                        )),
+                        other => {
+                            return Err(CompileError::unexpected_token(
+                                "integer literal",
+                                &other.map(|k| k.to_string()).unwrap_or("EOF".into()),
+                                self.peek_span(),
+                            ))
+                        }
                     }
                     self.eat(TokenKind::Semi);
                 }
@@ -6067,15 +7069,29 @@ impl Parser {
                     self.advance(); // consume 'pipelined'
                     self.expect(TokenKind::Colon)?;
                     pipelined = match self.peek_kind() {
-                        Some(TokenKind::True)  => { self.advance(); true }
-                        Some(TokenKind::False) => { self.advance(); false }
-                        Some(TokenKind::Ident(ref s)) if s == "true"  => { self.advance(); true }
-                        Some(TokenKind::Ident(ref s)) if s == "false" => { self.advance(); false }
-                        other => return Err(CompileError::unexpected_token(
-                            "true or false",
-                            &other.map(|k| k.to_string()).unwrap_or("EOF".into()),
-                            self.peek_span(),
-                        )),
+                        Some(TokenKind::True) => {
+                            self.advance();
+                            true
+                        }
+                        Some(TokenKind::False) => {
+                            self.advance();
+                            false
+                        }
+                        Some(TokenKind::Ident(ref s)) if s == "true" => {
+                            self.advance();
+                            true
+                        }
+                        Some(TokenKind::Ident(ref s)) if s == "false" => {
+                            self.advance();
+                            false
+                        }
+                        other => {
+                            return Err(CompileError::unexpected_token(
+                                "true or false",
+                                &other.map(|k| k.to_string()).unwrap_or("EOF".into()),
+                                self.peek_span(),
+                            ))
+                        }
                     };
                     self.eat(TokenKind::Semi);
                 }
@@ -6083,9 +7099,13 @@ impl Parser {
                 Some(TokenKind::Assert) | Some(TokenKind::Cover) => {
                     asserts.push(self.parse_assert_decl()?);
                 }
-                Some(other) => return Err(CompileError::unexpected_token(
-                    "latency, pipelined, port, assert, or cover", &other.to_string(), self.peek_span(),
-                )),
+                Some(other) => {
+                    return Err(CompileError::unexpected_token(
+                        "latency, pipelined, port, assert, or cover",
+                        &other.to_string(),
+                        self.peek_span(),
+                    ))
+                }
                 None => return Err(CompileError::UnexpectedEof),
             }
         }
@@ -6094,11 +7114,24 @@ impl Parser {
         self.expect(TokenKind::Op)?;
         let closing = self.expect_ident()?;
         if closing.name != name.name {
-            return Err(CompileError::mismatched_closing(&name.name, &closing.name, closing.span));
+            return Err(CompileError::mismatched_closing(
+                &name.name,
+                &closing.name,
+                closing.span,
+            ));
         }
 
         Ok(OpDecl {
-            common: ConstructCommon { name, params: Vec::new(), ports, asserts, span: start.merge(closing.span), doc: None, inner_doc: None, is_interface: false },
+            common: ConstructCommon {
+                name,
+                params: Vec::new(),
+                ports,
+                asserts,
+                span: start.merge(closing.span),
+                doc: None,
+                inner_doc: None,
+                is_interface: false,
+            },
             latency,
             pipelined,
         })
@@ -6142,9 +7175,15 @@ fn is_method_name(name: &str) -> bool {
 /// `send` and `pop`. Any mismatch (unknown channel, wrong port, etc.) is
 /// caught later at typecheck as a normal unknown-field error.
 fn desugar_cc_method_call_assigns(expr: &Expr) -> Option<Vec<CombAssign>> {
-    let ExprKind::MethodCall(recv, method, args) = &expr.kind else { return None; };
-    let ExprKind::FieldAccess(port_expr, ch_ident) = &recv.kind else { return None; };
-    if !matches!(&port_expr.kind, ExprKind::Ident(_)) { return None; }
+    let ExprKind::MethodCall(recv, method, args) = &expr.kind else {
+        return None;
+    };
+    let ExprKind::FieldAccess(port_expr, ch_ident) = &recv.kind else {
+        return None;
+    };
+    if !matches!(&port_expr.kind, ExprKind::Ident(_)) {
+        return None;
+    }
     let ch = &ch_ident.name;
     let span = expr.span;
     // Emit `port.<ch>.<wire>` (dotted). The elaborate pass
@@ -6156,7 +7195,10 @@ fn desugar_cc_method_call_assigns(expr: &Expr) -> Option<Vec<CombAssign>> {
     );
     let mk_dot = |wire: &str| -> Expr {
         Expr::new(
-            ExprKind::FieldAccess(Box::new(ch_expr.clone()), Ident::new(wire.to_string(), span)),
+            ExprKind::FieldAccess(
+                Box::new(ch_expr.clone()),
+                Ident::new(wire.to_string(), span),
+            ),
             span,
         )
     };
@@ -6165,19 +7207,39 @@ fn desugar_cc_method_call_assigns(expr: &Expr) -> Option<Vec<CombAssign>> {
     let zero_data = Expr::new(ExprKind::Literal(LitKind::Dec(0)), span);
     match method.name.as_str() {
         "send" if args.len() == 1 => Some(vec![
-            CombAssign { target: mk_dot("send_valid"), value: one.clone(), span },
-            CombAssign { target: mk_dot("send_data"),  value: args[0].clone(), span },
+            CombAssign {
+                target: mk_dot("send_valid"),
+                value: one.clone(),
+                span,
+            },
+            CombAssign {
+                target: mk_dot("send_data"),
+                value: args[0].clone(),
+                span,
+            },
         ]),
-        "pop" if args.is_empty() => Some(vec![
-            CombAssign { target: mk_dot("credit_return"), value: one, span },
-        ]),
+        "pop" if args.is_empty() => Some(vec![CombAssign {
+            target: mk_dot("credit_return"),
+            value: one,
+            span,
+        }]),
         "no_send" if args.is_empty() => Some(vec![
-            CombAssign { target: mk_dot("send_valid"), value: zero, span },
-            CombAssign { target: mk_dot("send_data"),  value: zero_data, span },
+            CombAssign {
+                target: mk_dot("send_valid"),
+                value: zero,
+                span,
+            },
+            CombAssign {
+                target: mk_dot("send_data"),
+                value: zero_data,
+                span,
+            },
         ]),
-        "no_pop" if args.is_empty() => Some(vec![
-            CombAssign { target: mk_dot("credit_return"), value: zero, span },
-        ]),
+        "no_pop" if args.is_empty() => Some(vec![CombAssign {
+            target: mk_dot("credit_return"),
+            value: zero,
+            span,
+        }]),
         _ => None,
     }
 }
@@ -6205,8 +7267,15 @@ fn desugar_cc_method_call_comb_stmt(expr: &Expr) -> Option<Stmt> {
 /// Same idea, seq-block (non-blocking) variant.
 fn desugar_cc_method_call_reg_stmt(expr: &Expr) -> Option<Stmt> {
     let assigns = desugar_cc_method_call_assigns(expr)?;
-    let reg_assigns: Vec<Stmt> = assigns.into_iter()
-        .map(|a| Stmt::Assign(RegAssign { target: a.target, value: a.value, span: a.span }))
+    let reg_assigns: Vec<Stmt> = assigns
+        .into_iter()
+        .map(|a| {
+            Stmt::Assign(RegAssign {
+                target: a.target,
+                value: a.value,
+                span: a.span,
+            })
+        })
         .collect();
     if reg_assigns.len() == 1 {
         return Some(reg_assigns.into_iter().next().unwrap());
@@ -6221,7 +7290,6 @@ fn desugar_cc_method_call_reg_stmt(expr: &Expr) -> Option<Stmt> {
     }))
 }
 
-
 fn prefix_bp() -> u8 {
     21 // unary prefix is highest
 }
@@ -6231,11 +7299,11 @@ fn infix_binding_power(op: BinOp) -> (u8, u8) {
         // `implies` has the lowest precedence; right-associative so (0,0) makes
         // `a implies b implies c` parse as `a implies (b implies c)`.
         BinOp::Implies | BinOp::ImpliesNext => (0, 0),
-        BinOp::Or  => (1, 2),
+        BinOp::Or => (1, 2),
         BinOp::And => (3, 4),
         BinOp::Eq | BinOp::Neq => (5, 6),
         BinOp::Lt | BinOp::Gt | BinOp::Lte | BinOp::Gte => (7, 8),
-        BinOp::BitOr  => (9, 10),
+        BinOp::BitOr => (9, 10),
         BinOp::BitXor => (11, 12),
         BinOp::BitAnd => (13, 14),
         BinOp::Shl | BinOp::Shr => (15, 16),
@@ -6252,10 +7320,10 @@ impl Parser {
         // Contextual keyword — checked as an ident with name "shared"
         // immediately followed by `function`.
         let shared = matches!(self.peek_kind(), Some(TokenKind::Ident(_)))
-                     && self.peek_str() == "shared"
-                     && self.peek_real_kind_at(1) == Some(TokenKind::Function);
+            && self.peek_str() == "shared"
+            && self.peek_real_kind_at(1) == Some(TokenKind::Function);
         if shared {
-            self.advance();  // consume the `shared` ident
+            self.advance(); // consume the `shared` ident
         }
         let start = self.expect(TokenKind::Function)?.span;
         let name = self.expect_ident()?;
@@ -6320,7 +7388,10 @@ impl Parser {
     /// Parse a function body: a sequence of let, return, if/elsif/else, for, or assignment statements.
     fn parse_function_body(&mut self) -> Result<Vec<FunctionBodyItem>, CompileError> {
         let mut body = Vec::new();
-        while !self.check_end_keyword() && !self.check(TokenKind::Else) && !self.check(TokenKind::ElsIf) {
+        while !self.check_end_keyword()
+            && !self.check(TokenKind::Else)
+            && !self.check(TokenKind::ElsIf)
+        {
             if self.check(TokenKind::Let) {
                 body.push(FunctionBodyItem::Let(self.parse_let_binding()?));
             } else if self.check(TokenKind::Return) {
@@ -6411,7 +7482,9 @@ impl Parser {
             let mut values = Vec::new();
             loop {
                 values.push(self.parse_expr()?);
-                if !self.eat(TokenKind::Comma) { break; }
+                if !self.eat(TokenKind::Comma) {
+                    break;
+                }
             }
             self.expect(TokenKind::RBrace)?;
             ForRange::ValueList(values)
@@ -6545,28 +7618,30 @@ impl Parser {
 /// All top-level constructs now carry a `doc` field (member-level decls
 /// — port/reg/wire/let/inst/resource — are deferred to PR-doc-1.6).
 fn attach_outer_doc(item: &mut Item, doc: Option<String>) {
-    if doc.is_none() { return; }
+    if doc.is_none() {
+        return;
+    }
     match item {
-        Item::Module(m)       => m.doc = doc,
-        Item::Fsm(f)          => f.common.doc = doc,
-        Item::Fifo(f)         => f.common.doc = doc,
-        Item::Ram(r)          => r.common.doc = doc,
-        Item::Counter(c)      => c.common.doc = doc,
-        Item::Arbiter(a)      => a.common.doc = doc,
-        Item::Pipeline(p)     => p.common.doc = doc,
-        Item::Cam(c)          => c.common.doc = doc,
-        Item::Linklist(l)     => l.common.doc = doc,
-        Item::Regfile(r)      => r.common.doc = doc,
+        Item::Module(m) => m.doc = doc,
+        Item::Fsm(f) => f.common.doc = doc,
+        Item::Fifo(f) => f.common.doc = doc,
+        Item::Ram(r) => r.common.doc = doc,
+        Item::Counter(c) => c.common.doc = doc,
+        Item::Arbiter(a) => a.common.doc = doc,
+        Item::Pipeline(p) => p.common.doc = doc,
+        Item::Cam(c) => c.common.doc = doc,
+        Item::Linklist(l) => l.common.doc = doc,
+        Item::Regfile(r) => r.common.doc = doc,
         Item::Synchronizer(s) => s.doc = doc,
-        Item::Clkgate(c)      => c.doc = doc,
-        Item::Domain(d)       => d.doc = doc,
-        Item::Struct(s)       => s.doc = doc,
-        Item::Enum(e)         => e.doc = doc,
-        Item::Function(f)     => f.doc = doc,
-        Item::Package(p)      => p.doc = doc,
-        Item::Use(u)          => u.doc = doc,
-        Item::Bus(b)          => b.doc = doc,
-        Item::Template(t)     => t.doc = doc,
+        Item::Clkgate(c) => c.doc = doc,
+        Item::Domain(d) => d.doc = doc,
+        Item::Struct(s) => s.doc = doc,
+        Item::Enum(e) => e.doc = doc,
+        Item::Function(f) => f.doc = doc,
+        Item::Package(p) => p.doc = doc,
+        Item::Use(u) => u.doc = doc,
+        Item::Bus(b) => b.doc = doc,
+        Item::Template(t) => t.doc = doc,
         Item::ExternPackage(ep) => ep.doc = doc,
     }
 }
@@ -6578,12 +7653,17 @@ fn attach_outer_doc(item: &mut Item, doc: Option<String>) {
 /// delimiter is missing or no `//!` lines are present. Per spec, the
 /// compiler stores the block verbatim — it does not parse the YAML.
 fn extract_frontmatter(lines: &[String]) -> Option<String> {
-    if lines.is_empty() { return None; }
+    if lines.is_empty() {
+        return None;
+    }
     let first_idx = lines.iter().position(|l| l.trim() == "---")?;
-    let close_idx = lines.iter().enumerate().skip(first_idx + 1)
+    let close_idx = lines
+        .iter()
+        .enumerate()
+        .skip(first_idx + 1)
         .find(|(_, l)| l.trim() == "---")
         .map(|(i, _)| i)?;
-    Some(lines[first_idx ..= close_idx].join("\n"))
+    Some(lines[first_idx..=close_idx].join("\n"))
 }
 
 #[cfg(test)]

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -152,23 +152,35 @@ pub struct BusInfo {
 impl BusInfo {
     /// Build a param map from this bus's default param values.
     pub fn default_param_map(&self) -> HashMap<String, &Expr> {
-        self.params.iter()
+        self.params
+            .iter()
             .filter_map(|pd| pd.default.as_ref().map(|d| (pd.name.name.clone(), d)))
             .collect()
     }
 
     /// Return the effective signal list after evaluating generate_if blocks
     /// using the given param map (bus defaults + port-site overrides).
-    pub fn effective_signals(&self, param_map: &HashMap<String, &Expr>) -> Vec<(String, Direction, TypeExpr)> {
+    pub fn effective_signals(
+        &self,
+        param_map: &HashMap<String, &Expr>,
+    ) -> Vec<(String, Direction, TypeExpr)> {
         let mut result = self.signals.clone();
         let mut tlm_methods = self.tlm_methods.clone();
         for gen in &self.generates {
             let cond_val = eval_bus_cond(&gen.cond, param_map);
-            let sigs = if cond_val { &gen.then_signals } else { &gen.else_signals };
+            let sigs = if cond_val {
+                &gen.then_signals
+            } else {
+                &gen.else_signals
+            };
             for s in sigs {
                 result.push((s.name.name.clone(), s.direction, s.ty.clone()));
             }
-            let methods = if cond_val { &gen.then_tlm_methods } else { &gen.else_tlm_methods };
+            let methods = if cond_val {
+                &gen.then_tlm_methods
+            } else {
+                &gen.else_tlm_methods
+            };
             tlm_methods.extend(methods.clone());
         }
         // Expand credit_channel sub-constructs into their wire protocol:
@@ -185,25 +197,33 @@ impl BusInfo {
         // abstraction get a typecheck error pointing at the scaffolding gap.
         for cc in &self.credit_channels {
             let (vd_dir, ret_dir) = match cc.role_dir {
-                Direction::Out => (Direction::Out, Direction::In),   // send role
-                Direction::In  => (Direction::In,  Direction::Out),  // receive role
+                Direction::Out => (Direction::Out, Direction::In), // send role
+                Direction::In => (Direction::In, Direction::Out),  // receive role
             };
             // Payload type: take the default of the channel's `T` param.
             // Channel-level param overrides at the bus-port-instance site
             // are a future extension.
-            let payload_ty = cc.params.iter()
+            let payload_ty = cc
+                .params
+                .iter()
                 .find(|p| p.name.name == "T")
                 .and_then(|p| match &p.kind {
                     crate::ast::ParamKind::Type(te) => Some(te.clone()),
                     _ => None,
                 })
-                .unwrap_or_else(|| TypeExpr::UInt(Box::new(Expr::new(
-                    ExprKind::Literal(LitKind::Dec(64)),
-                    cc.span,
-                ))));
+                .unwrap_or_else(|| {
+                    TypeExpr::UInt(Box::new(Expr::new(
+                        ExprKind::Literal(LitKind::Dec(64)),
+                        cc.span,
+                    )))
+                });
             let bool_ty = TypeExpr::Bool;
-            result.push((format!("{}_send_valid", cc.name.name), vd_dir, bool_ty.clone()));
-            result.push((format!("{}_send_data",  cc.name.name), vd_dir, payload_ty));
+            result.push((
+                format!("{}_send_valid", cc.name.name),
+                vd_dir,
+                bool_ty.clone(),
+            ));
+            result.push((format!("{}_send_data", cc.name.name), vd_dir, payload_ty));
             result.push((format!("{}_credit_return", cc.name.name), ret_dir, bool_ty));
         }
         // Expand tlm_method sub-constructs into their two-channel wire
@@ -221,15 +241,27 @@ impl BusInfo {
             let bool_ty = TypeExpr::Bool;
             result.push((format!("{name}_req_valid"), Direction::Out, bool_ty.clone()));
             if let Some(tag_w) = &m.out_of_order_tags {
-                result.push((format!("{name}_req_tag"), Direction::Out, TypeExpr::UInt(Box::new(tag_w.clone()))));
+                result.push((
+                    format!("{name}_req_tag"),
+                    Direction::Out,
+                    TypeExpr::UInt(Box::new(tag_w.clone())),
+                ));
             }
             for (arg_name, arg_ty) in &m.args {
-                result.push((format!("{name}_{}", arg_name.name), Direction::Out, arg_ty.clone()));
+                result.push((
+                    format!("{name}_{}", arg_name.name),
+                    Direction::Out,
+                    arg_ty.clone(),
+                ));
             }
-            result.push((format!("{name}_req_ready"), Direction::In,  bool_ty.clone()));
-            result.push((format!("{name}_rsp_valid"), Direction::In,  bool_ty.clone()));
+            result.push((format!("{name}_req_ready"), Direction::In, bool_ty.clone()));
+            result.push((format!("{name}_rsp_valid"), Direction::In, bool_ty.clone()));
             if let Some(tag_w) = &m.out_of_order_tags {
-                result.push((format!("{name}_rsp_tag"), Direction::In, TypeExpr::UInt(Box::new(tag_w.clone()))));
+                result.push((
+                    format!("{name}_rsp_tag"),
+                    Direction::In,
+                    TypeExpr::UInt(Box::new(tag_w.clone())),
+                ));
             }
             if let Some(ret_ty) = &m.ret {
                 result.push((format!("{name}_rsp_data"), Direction::In, ret_ty.clone()));
@@ -252,13 +284,11 @@ fn eval_bus_cond(expr: &Expr, param_map: &HashMap<String, &Expr>) -> bool {
                 false
             }
         }
-        ExprKind::Literal(lit) => {
-            match lit {
-                LitKind::Dec(n) | LitKind::Hex(n) | LitKind::Bin(n) => *n != 0,
-                LitKind::Sized(_, n) => *n != 0,
-                LitKind::Float(bits) => f64::from_bits(*bits) != 0.0,
-            }
-        }
+        ExprKind::Literal(lit) => match lit {
+            LitKind::Dec(n) | LitKind::Hex(n) | LitKind::Bin(n) => *n != 0,
+            LitKind::Sized(_, n) => *n != 0,
+            LitKind::Float(bits) => f64::from_bits(*bits) != 0.0,
+        },
         ExprKind::Bool(b) => *b,
         // Binary comparison / logical ops — evaluate both operands as
         // integers (when possible) and apply the op. Supports the common
@@ -267,19 +297,19 @@ fn eval_bus_cond(expr: &Expr, param_map: &HashMap<String, &Expr>) -> bool {
             use crate::ast::BinOp;
             match op {
                 BinOp::And => eval_bus_cond(l, param_map) && eval_bus_cond(r, param_map),
-                BinOp::Or  => eval_bus_cond(l, param_map) || eval_bus_cond(r, param_map),
+                BinOp::Or => eval_bus_cond(l, param_map) || eval_bus_cond(r, param_map),
                 _ => match (eval_bus_int(l, param_map), eval_bus_int(r, param_map)) {
                     (Some(lv), Some(rv)) => match op {
-                        BinOp::Eq  => lv == rv,
+                        BinOp::Eq => lv == rv,
                         BinOp::Neq => lv != rv,
-                        BinOp::Lt  => lv < rv,
-                        BinOp::Gt  => lv > rv,
+                        BinOp::Lt => lv < rv,
+                        BinOp::Gt => lv > rv,
                         BinOp::Lte => lv <= rv,
                         BinOp::Gte => lv >= rv,
                         _ => true, // conservative
                     },
                     _ => true, // conservative
-                }
+                },
             }
         }
         ExprKind::Unary(op, e) => {
@@ -298,7 +328,9 @@ fn eval_bus_cond(expr: &Expr, param_map: &HashMap<String, &Expr>) -> bool {
 fn eval_bus_int(expr: &Expr, param_map: &HashMap<String, &Expr>) -> Option<i64> {
     match &expr.kind {
         ExprKind::Literal(lit) => match lit {
-            LitKind::Dec(n) | LitKind::Hex(n) | LitKind::Bin(n) | LitKind::Sized(_, n) => Some(*n as i64),
+            LitKind::Dec(n) | LitKind::Hex(n) | LitKind::Bin(n) | LitKind::Sized(_, n) => {
+                Some(*n as i64)
+            }
             // Float literals are not valid in integer bus-condition contexts.
             LitKind::Float(_) => None,
         },
@@ -381,7 +413,13 @@ pub fn resolve(source_file: &SourceFile) -> Result<SymbolTable, Vec<CompileError
     // Built-in domain: SysDomain is always available (can be overridden by user)
     table.globals.insert(
         "SysDomain".to_string(),
-        (Symbol::Domain(DomainInfo { name: "SysDomain".to_string(), freq_mhz: None }), Span { start: 0, end: 0 }),
+        (
+            Symbol::Domain(DomainInfo {
+                name: "SysDomain".to_string(),
+                freq_mhz: None,
+            }),
+            Span { start: 0, end: 0 },
+        ),
     );
 
     // Build the set of names that have a real (non-interface) definition
@@ -394,10 +432,15 @@ pub fn resolve(source_file: &SourceFile) -> Result<SymbolTable, Vec<CompileError
     // `arch sim` errors with `duplicate definition: ClkDiv2` because the
     // `.archi` stub auto-loaded by the inst-resolver and the `.arch` real
     // module both register as separate globals.
-    let real_names: std::collections::HashSet<String> = source_file.items.iter()
+    let real_names: std::collections::HashSet<String> = source_file
+        .items
+        .iter()
         .filter_map(|it| {
-            if it.is_interface() { None }
-            else { Some(it.as_construct().name().name.clone()) }
+            if it.is_interface() {
+                None
+            } else {
+                Some(it.as_construct().name().name.clone())
+            }
         })
         .collect();
 
@@ -418,12 +461,26 @@ pub fn resolve(source_file: &SourceFile) -> Result<SymbolTable, Vec<CompileError
                 } else if table.globals.contains_key(&d.name.name) {
                     errors.push(CompileError::duplicate(&d.name.name, d.name.span));
                 } else {
-                    let freq_mhz = d.fields.iter()
+                    let freq_mhz = d
+                        .fields
+                        .iter()
                         .find(|f| f.name.name == "freq_mhz")
-                        .and_then(|f| if let ExprKind::Literal(LitKind::Dec(v)) = &f.value.kind { Some(*v) } else { None });
+                        .and_then(|f| {
+                            if let ExprKind::Literal(LitKind::Dec(v)) = &f.value.kind {
+                                Some(*v)
+                            } else {
+                                None
+                            }
+                        });
                     table.globals.insert(
                         d.name.name.clone(),
-                        (Symbol::Domain(DomainInfo { name: d.name.name.clone(), freq_mhz }), d.name.span),
+                        (
+                            Symbol::Domain(DomainInfo {
+                                name: d.name.name.clone(),
+                                freq_mhz,
+                            }),
+                            d.name.span,
+                        ),
                     );
                 }
             }
@@ -439,34 +496,44 @@ pub fn resolve(source_file: &SourceFile) -> Result<SymbolTable, Vec<CompileError
                             .map(|f| (f.name.name.clone(), f.ty.clone()))
                             .collect(),
                     };
-                    table.globals.insert(
-                        s.name.name.clone(),
-                        (Symbol::Struct(info), s.name.span),
-                    );
+                    table
+                        .globals
+                        .insert(s.name.name.clone(), (Symbol::Struct(info), s.name.span));
                 }
             }
             Item::Enum(e) => {
                 if table.globals.contains_key(&e.name.name) {
                     errors.push(CompileError::duplicate(&e.name.name, e.name.span));
                 } else {
-                    let values: Vec<Option<u64>> = e.values.iter().map(|v| {
-                        v.as_ref().and_then(|expr| match &expr.kind {
-                            crate::ast::ExprKind::Literal(crate::ast::LitKind::Dec(n)) => Some(*n),
-                            crate::ast::ExprKind::Literal(crate::ast::LitKind::Hex(n)) => Some(*n),
-                            crate::ast::ExprKind::Literal(crate::ast::LitKind::Bin(n)) => Some(*n),
-                            crate::ast::ExprKind::Literal(crate::ast::LitKind::Sized(_, n)) => Some(*n),
-                            _ => None,
+                    let values: Vec<Option<u64>> = e
+                        .values
+                        .iter()
+                        .map(|v| {
+                            v.as_ref().and_then(|expr| match &expr.kind {
+                                crate::ast::ExprKind::Literal(crate::ast::LitKind::Dec(n)) => {
+                                    Some(*n)
+                                }
+                                crate::ast::ExprKind::Literal(crate::ast::LitKind::Hex(n)) => {
+                                    Some(*n)
+                                }
+                                crate::ast::ExprKind::Literal(crate::ast::LitKind::Bin(n)) => {
+                                    Some(*n)
+                                }
+                                crate::ast::ExprKind::Literal(crate::ast::LitKind::Sized(_, n)) => {
+                                    Some(*n)
+                                }
+                                _ => None,
+                            })
                         })
-                    }).collect();
+                        .collect();
                     let info = EnumInfo {
                         name: e.name.name.clone(),
                         variants: e.variants.iter().map(|v| v.name.clone()).collect(),
                         values,
                     };
-                    table.globals.insert(
-                        e.name.name.clone(),
-                        (Symbol::Enum(info), e.name.span),
-                    );
+                    table
+                        .globals
+                        .insert(e.name.name.clone(), (Symbol::Enum(info), e.name.span));
                 }
             }
             Item::Module(m) => {
@@ -478,10 +545,9 @@ pub fn resolve(source_file: &SourceFile) -> Result<SymbolTable, Vec<CompileError
                         params: m.params.clone(),
                         ports: m.ports.clone(),
                     };
-                    table.globals.insert(
-                        m.name.name.clone(),
-                        (Symbol::Module(info), m.name.span),
-                    );
+                    table
+                        .globals
+                        .insert(m.name.name.clone(), (Symbol::Module(info), m.name.span));
                 }
             }
             Item::Fsm(f) => {
@@ -499,12 +565,15 @@ pub fn resolve(source_file: &SourceFile) -> Result<SymbolTable, Vec<CompileError
                         state_names: Vec::new(),
                         default_state: String::new(),
                     };
-                    table.globals.insert(f.name.name.clone(), (Symbol::Fsm(info), f.name.span));
+                    table
+                        .globals
+                        .insert(f.name.name.clone(), (Symbol::Fsm(info), f.name.span));
                 } else {
                     // Real fsm: enforce `default state Name;` (was a parse
                     // error pre-PR for `fsm`-stub support; moved here so
                     // the parser can accept body-less `.archi` stubs).
-                    let declared: Vec<String> = f.state_names.iter().map(|s| s.name.clone()).collect();
+                    let declared: Vec<String> =
+                        f.state_names.iter().map(|s| s.name.clone()).collect();
                     let default_state_name = match &f.default_state {
                         Some(ds) => {
                             if !declared.contains(&ds.name) {
@@ -527,7 +596,8 @@ pub fn resolve(source_file: &SourceFile) -> Result<SymbolTable, Vec<CompileError
                     for sb in &f.states {
                         for tr in &sb.transitions {
                             if !declared.contains(&tr.target.name) {
-                                errors.push(CompileError::undefined(&tr.target.name, tr.target.span));
+                                errors
+                                    .push(CompileError::undefined(&tr.target.name, tr.target.span));
                             }
                         }
                     }
@@ -537,7 +607,9 @@ pub fn resolve(source_file: &SourceFile) -> Result<SymbolTable, Vec<CompileError
                         state_names: declared,
                         default_state: default_state_name,
                     };
-                    table.globals.insert(f.name.name.clone(), (Symbol::Fsm(info), f.name.span));
+                    table
+                        .globals
+                        .insert(f.name.name.clone(), (Symbol::Fsm(info), f.name.span));
                 }
             }
             Item::Fifo(f) => {
@@ -550,7 +622,9 @@ pub fn resolve(source_file: &SourceFile) -> Result<SymbolTable, Vec<CompileError
                         ports: f.ports.clone(),
                         is_async,
                     };
-                    table.globals.insert(f.name.name.clone(), (Symbol::Fifo(info), f.name.span));
+                    table
+                        .globals
+                        .insert(f.name.name.clone(), (Symbol::Fifo(info), f.name.span));
                 }
             }
             Item::Ram(r) => {
@@ -562,15 +636,21 @@ pub fn resolve(source_file: &SourceFile) -> Result<SymbolTable, Vec<CompileError
                         kind: r.kind,
                         latency: r.latency,
                     };
-                    table.globals.insert(r.name.name.clone(), (Symbol::Ram(info), r.name.span));
+                    table
+                        .globals
+                        .insert(r.name.name.clone(), (Symbol::Ram(info), r.name.span));
                 }
             }
             Item::Cam(c) => {
                 if table.globals.contains_key(&c.name.name) {
                     errors.push(CompileError::duplicate(&c.name.name, c.name.span));
                 } else {
-                    let info = CamInfo { name: c.name.name.clone() };
-                    table.globals.insert(c.name.name.clone(), (Symbol::Cam(info), c.name.span));
+                    let info = CamInfo {
+                        name: c.name.name.clone(),
+                    };
+                    table
+                        .globals
+                        .insert(c.name.name.clone(), (Symbol::Cam(info), c.name.span));
                 }
             }
             Item::Counter(c) => {
@@ -582,7 +662,9 @@ pub fn resolve(source_file: &SourceFile) -> Result<SymbolTable, Vec<CompileError
                         mode: c.mode,
                         direction: c.direction,
                     };
-                    table.globals.insert(c.name.name.clone(), (Symbol::Counter(info), c.name.span));
+                    table
+                        .globals
+                        .insert(c.name.name.clone(), (Symbol::Counter(info), c.name.span));
                 }
             }
             Item::Arbiter(a) => {
@@ -590,24 +672,41 @@ pub fn resolve(source_file: &SourceFile) -> Result<SymbolTable, Vec<CompileError
                     errors.push(CompileError::duplicate(&a.name.name, a.name.span));
                 } else {
                     // Try to find NUM_REQ param
-                    let num_req = a.params.iter().find_map(|p| {
-                        if p.name.name == "NUM_REQ" {
-                            if let Some(Expr { kind: ExprKind::Literal(LitKind::Dec(n)), .. }) = &p.default {
-                                return Some(*n);
+                    let num_req = a
+                        .params
+                        .iter()
+                        .find_map(|p| {
+                            if p.name.name == "NUM_REQ" {
+                                if let Some(Expr {
+                                    kind: ExprKind::Literal(LitKind::Dec(n)),
+                                    ..
+                                }) = &p.default
+                                {
+                                    return Some(*n);
+                                }
                             }
-                        }
-                        None
-                    }).unwrap_or(2);
-                    let info = ArbiterInfo { name: a.name.name.clone(), num_req };
-                    table.globals.insert(a.name.name.clone(), (Symbol::Arbiter(info), a.name.span));
+                            None
+                        })
+                        .unwrap_or(2);
+                    let info = ArbiterInfo {
+                        name: a.name.name.clone(),
+                        num_req,
+                    };
+                    table
+                        .globals
+                        .insert(a.name.name.clone(), (Symbol::Arbiter(info), a.name.span));
                 }
             }
             Item::Regfile(r) => {
                 if table.globals.contains_key(&r.name.name) {
                     errors.push(CompileError::duplicate(&r.name.name, r.name.span));
                 } else {
-                    let info = RegfileInfo { name: r.name.name.clone() };
-                    table.globals.insert(r.name.name.clone(), (Symbol::Regfile(info), r.name.span));
+                    let info = RegfileInfo {
+                        name: r.name.name.clone(),
+                    };
+                    table
+                        .globals
+                        .insert(r.name.name.clone(), (Symbol::Regfile(info), r.name.span));
                 }
             }
             Item::Pipeline(p) => {
@@ -620,7 +719,9 @@ pub fn resolve(source_file: &SourceFile) -> Result<SymbolTable, Vec<CompileError
                         ports: p.ports.clone(),
                         stage_names: p.stages.iter().map(|s| s.name.name.clone()).collect(),
                     };
-                    table.globals.insert(p.name.name.clone(), (Symbol::Pipeline(info), p.name.span));
+                    table
+                        .globals
+                        .insert(p.name.name.clone(), (Symbol::Pipeline(info), p.name.span));
                 }
             }
             Item::Function(f) => {
@@ -630,27 +731,39 @@ pub fn resolve(source_file: &SourceFile) -> Result<SymbolTable, Vec<CompileError
                     ret_ty: f.ret_ty.clone(),
                     shared: f.shared,
                 };
-                if let Some((Symbol::Function(overloads), _)) = table.globals.get_mut(&f.name.name) {
+                if let Some((Symbol::Function(overloads), _)) = table.globals.get_mut(&f.name.name)
+                {
                     overloads.push(info);
                 } else if table.globals.contains_key(&f.name.name) {
                     errors.push(CompileError::duplicate(&f.name.name, f.name.span));
                 } else {
-                    table.globals.insert(f.name.name.clone(), (Symbol::Function(vec![info]), f.name.span));
+                    table.globals.insert(
+                        f.name.name.clone(),
+                        (Symbol::Function(vec![info]), f.name.span),
+                    );
                 }
             }
             Item::Linklist(l) => {
                 if table.globals.contains_key(&l.name.name) {
                     errors.push(CompileError::duplicate(&l.name.name, l.name.span));
                 } else {
-                    let info = LinklistInfo { name: l.name.name.clone(), kind: l.kind.clone() };
-                    table.globals.insert(l.name.name.clone(), (Symbol::Linklist(info), l.name.span));
+                    let info = LinklistInfo {
+                        name: l.name.name.clone(),
+                        kind: l.kind.clone(),
+                    };
+                    table
+                        .globals
+                        .insert(l.name.name.clone(), (Symbol::Linklist(info), l.name.span));
                 }
             }
             Item::Template(t) => {
                 if table.globals.contains_key(&t.name.name) {
                     errors.push(CompileError::duplicate(&t.name.name, t.name.span));
                 } else {
-                    table.globals.insert(t.name.name.clone(), (Symbol::Template(t.name.name.clone()), t.name.span));
+                    table.globals.insert(
+                        t.name.name.clone(),
+                        (Symbol::Template(t.name.name.clone()), t.name.span),
+                    );
                 }
             }
             Item::Bus(b) => {
@@ -660,15 +773,19 @@ pub fn resolve(source_file: &SourceFile) -> Result<SymbolTable, Vec<CompileError
                     let info = BusInfo {
                         name: b.name.name.clone(),
                         params: b.params.clone(),
-                        signals: b.signals.iter()
+                        signals: b
+                            .signals
+                            .iter()
                             .map(|s| (s.name.name.clone(), s.direction, s.ty.clone()))
                             .collect(),
                         generates: b.generates.clone(),
                         handshakes: b.handshakes.clone(),
                         credit_channels: b.credit_channels.clone(),
-                                tlm_methods: b.tlm_methods.clone(),
+                        tlm_methods: b.tlm_methods.clone(),
                     };
-                    table.globals.insert(b.name.name.clone(), (Symbol::Bus(info), b.name.span));
+                    table
+                        .globals
+                        .insert(b.name.name.clone(), (Symbol::Bus(info), b.name.span));
                 }
             }
             Item::Package(pkg) => {
@@ -687,12 +804,26 @@ pub fn resolve(source_file: &SourceFile) -> Result<SymbolTable, Vec<CompileError
                         } else if table.globals.contains_key(&d.name.name) {
                             errors.push(CompileError::duplicate(&d.name.name, d.name.span));
                         } else {
-                            let freq_mhz = d.fields.iter()
+                            let freq_mhz = d
+                                .fields
+                                .iter()
                                 .find(|f| f.name.name == "freq_mhz")
-                                .and_then(|f| if let ExprKind::Literal(LitKind::Dec(v)) = &f.value.kind { Some(*v) } else { None });
+                                .and_then(|f| {
+                                    if let ExprKind::Literal(LitKind::Dec(v)) = &f.value.kind {
+                                        Some(*v)
+                                    } else {
+                                        None
+                                    }
+                                });
                             table.globals.insert(
                                 d.name.name.clone(),
-                                (Symbol::Domain(DomainInfo { name: d.name.name.clone(), freq_mhz }), d.name.span),
+                                (
+                                    Symbol::Domain(DomainInfo {
+                                        name: d.name.name.clone(),
+                                        freq_mhz,
+                                    }),
+                                    d.name.span,
+                                ),
                             );
                         }
                     }
@@ -700,21 +831,35 @@ pub fn resolve(source_file: &SourceFile) -> Result<SymbolTable, Vec<CompileError
                         if table.globals.contains_key(&e.name.name) {
                             errors.push(CompileError::duplicate(&e.name.name, e.name.span));
                         } else {
-                            let values: Vec<Option<u64>> = e.values.iter().map(|v| {
-                                v.as_ref().and_then(|expr| match &expr.kind {
-                                    crate::ast::ExprKind::Literal(crate::ast::LitKind::Dec(n)) => Some(*n),
-                                    crate::ast::ExprKind::Literal(crate::ast::LitKind::Hex(n)) => Some(*n),
-                                    crate::ast::ExprKind::Literal(crate::ast::LitKind::Bin(n)) => Some(*n),
-                                    crate::ast::ExprKind::Literal(crate::ast::LitKind::Sized(_, n)) => Some(*n),
-                                    _ => None,
+                            let values: Vec<Option<u64>> = e
+                                .values
+                                .iter()
+                                .map(|v| {
+                                    v.as_ref().and_then(|expr| match &expr.kind {
+                                        crate::ast::ExprKind::Literal(
+                                            crate::ast::LitKind::Dec(n),
+                                        ) => Some(*n),
+                                        crate::ast::ExprKind::Literal(
+                                            crate::ast::LitKind::Hex(n),
+                                        ) => Some(*n),
+                                        crate::ast::ExprKind::Literal(
+                                            crate::ast::LitKind::Bin(n),
+                                        ) => Some(*n),
+                                        crate::ast::ExprKind::Literal(
+                                            crate::ast::LitKind::Sized(_, n),
+                                        ) => Some(*n),
+                                        _ => None,
+                                    })
                                 })
-                            }).collect();
+                                .collect();
                             let info = EnumInfo {
                                 name: e.name.name.clone(),
                                 variants: e.variants.iter().map(|v| v.name.clone()).collect(),
                                 values,
                             };
-                            table.globals.insert(e.name.name.clone(), (Symbol::Enum(info), e.name.span));
+                            table
+                                .globals
+                                .insert(e.name.name.clone(), (Symbol::Enum(info), e.name.span));
                         }
                     }
                     for s in &pkg.structs {
@@ -723,9 +868,15 @@ pub fn resolve(source_file: &SourceFile) -> Result<SymbolTable, Vec<CompileError
                         } else {
                             let info = StructInfo {
                                 name: s.name.name.clone(),
-                                fields: s.fields.iter().map(|f| (f.name.name.clone(), f.ty.clone())).collect(),
+                                fields: s
+                                    .fields
+                                    .iter()
+                                    .map(|f| (f.name.name.clone(), f.ty.clone()))
+                                    .collect(),
                             };
-                            table.globals.insert(s.name.name.clone(), (Symbol::Struct(info), s.name.span));
+                            table
+                                .globals
+                                .insert(s.name.name.clone(), (Symbol::Struct(info), s.name.span));
                         }
                     }
                     for b in &pkg.buses {
@@ -735,7 +886,9 @@ pub fn resolve(source_file: &SourceFile) -> Result<SymbolTable, Vec<CompileError
                             let info = BusInfo {
                                 name: b.name.name.clone(),
                                 params: b.params.clone(),
-                                signals: b.signals.iter()
+                                signals: b
+                                    .signals
+                                    .iter()
                                     .map(|s| (s.name.name.clone(), s.direction, s.ty.clone()))
                                     .collect(),
                                 generates: b.generates.clone(),
@@ -743,7 +896,9 @@ pub fn resolve(source_file: &SourceFile) -> Result<SymbolTable, Vec<CompileError
                                 credit_channels: b.credit_channels.clone(),
                                 tlm_methods: b.tlm_methods.clone(),
                             };
-                            table.globals.insert(b.name.name.clone(), (Symbol::Bus(info), b.name.span));
+                            table
+                                .globals
+                                .insert(b.name.name.clone(), (Symbol::Bus(info), b.name.span));
                         }
                     }
                     for f in &pkg.functions {
@@ -753,12 +908,17 @@ pub fn resolve(source_file: &SourceFile) -> Result<SymbolTable, Vec<CompileError
                             ret_ty: f.ret_ty.clone(),
                             shared: f.shared,
                         };
-                        if let Some((Symbol::Function(overloads), _)) = table.globals.get_mut(&f.name.name) {
+                        if let Some((Symbol::Function(overloads), _)) =
+                            table.globals.get_mut(&f.name.name)
+                        {
                             overloads.push(info);
                         } else if table.globals.contains_key(&f.name.name) {
                             errors.push(CompileError::duplicate(&f.name.name, f.name.span));
                         } else {
-                            table.globals.insert(f.name.name.clone(), (Symbol::Function(vec![info]), f.name.span));
+                            table.globals.insert(
+                                f.name.name.clone(),
+                                (Symbol::Function(vec![info]), f.name.span),
+                            );
                         }
                     }
                     for p in &pkg.params {
@@ -782,25 +942,45 @@ pub fn resolve(source_file: &SourceFile) -> Result<SymbolTable, Vec<CompileError
                 if table.globals.contains_key(&s.name.name) {
                     errors.push(CompileError::duplicate(&s.name.name, s.name.span));
                 } else {
-                    let stages = s.params.iter()
+                    let stages = s
+                        .params
+                        .iter()
                         .find(|p| p.name.name == "STAGES")
                         .and_then(|p| p.default.as_ref())
-                        .and_then(|e| if let ExprKind::Literal(LitKind::Dec(v)) = &e.kind { Some(*v) } else { None })
+                        .and_then(|e| {
+                            if let ExprKind::Literal(LitKind::Dec(v)) = &e.kind {
+                                Some(*v)
+                            } else {
+                                None
+                            }
+                        })
                         .unwrap_or(2);
-                    table.globals.insert(s.name.name.clone(), (Symbol::Synchronizer(SynchronizerInfo {
-                        name: s.name.name.clone(),
-                        stages,
-                    }), s.name.span));
+                    table.globals.insert(
+                        s.name.name.clone(),
+                        (
+                            Symbol::Synchronizer(SynchronizerInfo {
+                                name: s.name.name.clone(),
+                                stages,
+                            }),
+                            s.name.span,
+                        ),
+                    );
                 }
             }
             Item::Clkgate(c) => {
                 if table.globals.contains_key(&c.name.name) {
                     errors.push(CompileError::duplicate(&c.name.name, c.name.span));
                 } else {
-                    table.globals.insert(c.name.name.clone(), (Symbol::Clkgate(ClkGateInfo {
-                        name: c.name.name.clone(),
-                        kind: c.kind.clone(),
-                    }), c.name.span));
+                    table.globals.insert(
+                        c.name.name.clone(),
+                        (
+                            Symbol::Clkgate(ClkGateInfo {
+                                name: c.name.name.clone(),
+                                kind: c.kind.clone(),
+                            }),
+                            c.name.span,
+                        ),
+                    );
                 }
             }
         }
@@ -901,10 +1081,15 @@ pub fn resolve(source_file: &SourceFile) -> Result<SymbolTable, Vec<CompileError
                             ret_ty: f.ret_ty.clone(),
                             shared: f.shared,
                         };
-                        if let Some((Symbol::Function(overloads), _)) = table.globals.get_mut(&f.name.name) {
+                        if let Some((Symbol::Function(overloads), _)) =
+                            table.globals.get_mut(&f.name.name)
+                        {
                             overloads.push(info);
                         } else if !table.globals.contains_key(&f.name.name) {
-                            table.globals.insert(f.name.name.clone(), (Symbol::Function(vec![info]), f.name.span));
+                            table.globals.insert(
+                                f.name.name.clone(),
+                                (Symbol::Function(vec![info]), f.name.span),
+                            );
                         }
                     }
                     _ => {}
@@ -920,34 +1105,47 @@ pub fn resolve(source_file: &SourceFile) -> Result<SymbolTable, Vec<CompileError
         if let Item::Fsm(f) = item {
             let mut scope = HashMap::new();
             for p in &f.params {
-                scope.insert(p.name.name.clone(),
-                    (Symbol::Param(p.name.name.clone()), p.name.span));
+                scope.insert(
+                    p.name.name.clone(),
+                    (Symbol::Param(p.name.name.clone()), p.name.span),
+                );
             }
             for p in &f.ports {
-                scope.insert(p.name.name.clone(),
-                    (Symbol::Port(PortInfo {
-                        name: p.name.name.clone(),
-                        direction: p.direction,
-                        ty: p.ty.clone(),
-                    }), p.name.span));
+                scope.insert(
+                    p.name.name.clone(),
+                    (
+                        Symbol::Port(PortInfo {
+                            name: p.name.name.clone(),
+                            direction: p.direction,
+                            ty: p.ty.clone(),
+                        }),
+                        p.name.span,
+                    ),
+                );
             }
             for r in &f.regs {
-                scope.entry(r.name.name.clone()).or_insert_with(||
-                    (Symbol::Reg(RegInfo {
-                        name: r.name.name.clone(),
-                        ty: r.ty.clone(),
-                        reset: r.reset.clone(),
-                    }), r.name.span));
+                scope.entry(r.name.name.clone()).or_insert_with(|| {
+                    (
+                        Symbol::Reg(RegInfo {
+                            name: r.name.name.clone(),
+                            ty: r.ty.clone(),
+                            reset: r.reset.clone(),
+                        }),
+                        r.name.span,
+                    )
+                });
             }
             for l in &f.lets {
                 if l.ty.is_some() {
-                    scope.entry(l.name.name.clone()).or_insert_with(||
-                        (Symbol::Let(l.name.name.clone()), l.name.span));
+                    scope
+                        .entry(l.name.name.clone())
+                        .or_insert_with(|| (Symbol::Let(l.name.name.clone()), l.name.span));
                 }
             }
             for w in &f.wires {
-                scope.entry(w.name.name.clone()).or_insert_with(||
-                    (Symbol::Let(w.name.name.clone()), w.name.span));
+                scope
+                    .entry(w.name.name.clone())
+                    .or_insert_with(|| (Symbol::Let(w.name.name.clone()), w.name.span));
             }
             table.module_scopes.insert(f.name.name.clone(), scope);
         }

--- a/src/signal_flow.rs
+++ b/src/signal_flow.rs
@@ -10,19 +10,18 @@ use crate::lexer::Span;
 /// output connections from the multi-driver check — both sides (initiator
 /// and target) of a bus wire have `ConnectDir::Output` connections but
 /// drive *disjoint* sets of flat signals, so no real conflict exists.
-fn is_bus_port_in_child(
-    module_name: &str,
-    port_name: &str,
-    source: &SourceFile,
-) -> bool {
-    source.items.iter().find_map(|item| match item {
-        Item::Module(m) if m.name.name == module_name => Some(m.ports.as_slice()),
-        Item::Fsm(f) if f.name.name == module_name => Some(f.ports.as_slice()),
-        _ => None,
-    })
-    .and_then(|ports| ports.iter().find(|p| p.name.name == port_name))
-    .map(|p| p.bus_info.is_some())
-    .unwrap_or(false)
+fn is_bus_port_in_child(module_name: &str, port_name: &str, source: &SourceFile) -> bool {
+    source
+        .items
+        .iter()
+        .find_map(|item| match item {
+            Item::Module(m) if m.name.name == module_name => Some(m.ports.as_slice()),
+            Item::Fsm(f) if f.name.name == module_name => Some(f.ports.as_slice()),
+            _ => None,
+        })
+        .and_then(|ports| ports.iter().find(|p| p.name.name == port_name))
+        .map(|p| p.bus_info.is_some())
+        .unwrap_or(false)
 }
 
 /// One block-level drive record for a signal.
@@ -166,9 +165,7 @@ fn collect_thread_stmts(stmts: &[ThreadStmt], out: &mut HashMap<String, Span>) {
 
 fn collect_one_thread_stmt(stmt: &ThreadStmt, out: &mut HashMap<String, Span>) {
     match stmt {
-        ThreadStmt::CombAssign(a)
-        | ThreadStmt::SeqAssign(a)
-        | ThreadStmt::ForkTlmAssign(a) => {
+        ThreadStmt::CombAssign(a) | ThreadStmt::SeqAssign(a) | ThreadStmt::ForkTlmAssign(a) => {
             if let Some(name) = lhs_base_name(&a.target) {
                 out.entry(name).or_insert(a.span);
             }
@@ -204,7 +201,10 @@ fn collect_one_thread_stmt(stmt: &ThreadStmt, out: &mut HashMap<String, Span>) {
 /// `source` is used to look up child module port declarations so that
 /// bus-port connections (which are legitimately present on both the
 /// initiator and target sides of a bus wire) can be excluded.
-pub fn collect_module_drivers(m: &ModuleDecl, source: &SourceFile) -> HashMap<String, Vec<DriveEntry>> {
+pub fn collect_module_drivers(
+    m: &ModuleDecl,
+    source: &SourceFile,
+) -> HashMap<String, Vec<DriveEntry>> {
     let mut drivers: HashMap<String, Vec<DriveEntry>> = HashMap::new();
 
     // Bus and struct wires (TypeExpr::Named) are legitimately connected from
@@ -554,9 +554,7 @@ fn collect_one_stmt_read(stmt: &Stmt, out: &mut HashMap<String, Span>) {
 
 fn collect_one_thread_read(stmt: &ThreadStmt, out: &mut HashMap<String, Span>) {
     match stmt {
-        ThreadStmt::CombAssign(a)
-        | ThreadStmt::SeqAssign(a)
-        | ThreadStmt::ForkTlmAssign(a) => {
+        ThreadStmt::CombAssign(a) | ThreadStmt::SeqAssign(a) | ThreadStmt::ForkTlmAssign(a) => {
             add_expr_reads(&a.value, a.span, out);
             collect_lhs_index_reads(&a.target, a.span, out);
         }
@@ -572,7 +570,13 @@ fn collect_one_thread_read(stmt: &ThreadStmt, out: &mut HashMap<String, Span>) {
                 collect_thread_reads(b, out);
             }
         }
-        ThreadStmt::For { start, end, body, span, .. } => {
+        ThreadStmt::For {
+            start,
+            end,
+            body,
+            span,
+            ..
+        } => {
             add_expr_reads(start, *span, out);
             add_expr_reads(end, *span, out);
             collect_thread_reads(body, out);
@@ -625,7 +629,9 @@ pub fn module_comb_fwd_edges(
     let mut fwd: HashMap<String, HashSet<String>> = HashMap::new();
     let add = |from: &str, to: &str, fwd: &mut HashMap<String, HashSet<String>>| {
         if from != to {
-            fwd.entry(from.to_string()).or_default().insert(to.to_string());
+            fwd.entry(from.to_string())
+                .or_default()
+                .insert(to.to_string());
         }
     };
 

--- a/src/sim_codegen/cam.rs
+++ b/src/sim_codegen/cam.rs
@@ -5,8 +5,8 @@
 //! `entry_key_r[DEPTH]` (per-entry key). Comb match recomputes
 //! `search_mask` / `search_any` / `search_first` every cycle.
 
-use super::{SimCodegen, SimModel};
 use super::*;
+use super::{SimCodegen, SimModel};
 
 impl<'a> SimCodegen<'a> {
     pub(crate) fn gen_cam(&self, c: &CamDecl) -> SimModel {
@@ -14,33 +14,68 @@ impl<'a> SimCodegen<'a> {
         let class = format!("V{name}");
 
         // DEPTH and KEY_W are required const params (typecheck enforces).
-        let depth: u32 = c.params.iter()
+        let depth: u32 = c
+            .params
+            .iter()
             .find(|p| p.name.name == "DEPTH")
             .and_then(|p| p.default.as_ref())
-            .and_then(|e| if let ExprKind::Literal(LitKind::Dec(v)) = &e.kind { Some(*v as u32) } else { None })
+            .and_then(|e| {
+                if let ExprKind::Literal(LitKind::Dec(v)) = &e.kind {
+                    Some(*v as u32)
+                } else {
+                    None
+                }
+            })
             .unwrap_or(32);
-        let key_w: u32 = c.params.iter()
+        let key_w: u32 = c
+            .params
+            .iter()
             .find(|p| p.name.name == "KEY_W")
             .and_then(|p| p.default.as_ref())
-            .and_then(|e| if let ExprKind::Literal(LitKind::Dec(v)) = &e.kind { Some(*v as u32) } else { None })
+            .and_then(|e| {
+                if let ExprKind::Literal(LitKind::Dec(v)) = &e.kind {
+                    Some(*v as u32)
+                } else {
+                    None
+                }
+            })
             .unwrap_or(8);
         // v3: optional value payload.
         let has_value = c.params.iter().any(|p| p.name.name == "VAL_W");
-        let val_w: u32 = c.params.iter()
+        let val_w: u32 = c
+            .params
+            .iter()
             .find(|p| p.name.name == "VAL_W")
             .and_then(|p| p.default.as_ref())
-            .and_then(|e| if let ExprKind::Literal(LitKind::Dec(v)) = &e.kind { Some(*v as u32) } else { None })
+            .and_then(|e| {
+                if let ExprKind::Literal(LitKind::Dec(v)) = &e.kind {
+                    Some(*v as u32)
+                } else {
+                    None
+                }
+            })
             .unwrap_or(8);
 
         let key_ty = cpp_uint(key_w);
         let val_ty = cpp_uint(val_w);
         let mask_ty = cpp_uint(depth);
-        let idx_w = if depth <= 1 { 1 } else { 32 - (depth - 1).leading_zeros() };
+        let idx_w = if depth <= 1 {
+            1
+        } else {
+            32 - (depth - 1).leading_zeros()
+        };
         let idx_ty = cpp_uint(idx_w);
 
         let (rst_name, _is_async, is_low) = extract_reset_info(&c.ports);
-        let rst_cond = if is_low { format!("(!{})", rst_name) } else { rst_name.clone() };
-        let clk_port = c.ports.iter().find(|p| matches!(&p.ty, TypeExpr::Clock(_)))
+        let rst_cond = if is_low {
+            format!("(!{})", rst_name)
+        } else {
+            rst_name.clone()
+        };
+        let clk_port = c
+            .ports
+            .iter()
+            .find(|p| matches!(&p.ty, TypeExpr::Clock(_)))
             .map(|p| p.name.name.clone())
             .unwrap_or_else(|| "clk".to_string());
 
@@ -49,12 +84,20 @@ impl<'a> SimCodegen<'a> {
         h.push_str("#pragma once\n#include <cstdint>\n#include <cstdio>\n#include <cstring>\n#include \"verilated.h\"\n\n");
         h.push_str(&format!("class {class} {{\npublic:\n"));
         for p in &c.ports {
-            h.push_str(&format!("  {} {};\n", cpp_port_type_with_params(&p.ty, &c.params), p.name.name));
+            h.push_str(&format!(
+                "  {} {};\n",
+                cpp_port_type_with_params(&p.ty, &c.params),
+                p.name.name
+            ));
         }
         h.push('\n');
 
         // Ctor: zero ports + state.
-        let port_inits: Vec<String> = c.ports.iter().map(|p| format!("{}(0)", p.name.name)).collect();
+        let port_inits: Vec<String> = c
+            .ports
+            .iter()
+            .map(|p| format!("{}(0)", p.name.name))
+            .collect();
         let state_inits = vec!["_clk_prev(0)".to_string(), "_entry_valid_r(0)".to_string()];
         let all_inits: Vec<String> = port_inits.into_iter().chain(state_inits).collect();
         h.push_str(&format!("  {class}() : {} {{\n", all_inits.join(", ")));
@@ -63,7 +106,9 @@ impl<'a> SimCodegen<'a> {
             h.push_str("    memset(_entry_value_r, 0, sizeof(_entry_value_r));\n");
         }
         h.push_str("  }\n");
-        h.push_str(&format!("  explicit {class}(VerilatedContext*) : {class}() {{}}\n"));
+        h.push_str(&format!(
+            "  explicit {class}(VerilatedContext*) : {class}() {{}}\n"
+        ));
         h.push_str("  void eval();\n  void eval_posedge();\n  void eval_comb();\n  void final() { trace_close(); }\n");
         h.push_str("private:\n");
         h.push_str("  uint8_t _clk_prev;\n");
@@ -98,7 +143,9 @@ impl<'a> SimCodegen<'a> {
         cpp.push_str("  }\n");
         // Port 1
         cpp.push_str("  if (write_valid) {\n");
-        cpp.push_str(&format!("    {mask_ty} _bit = ({mask_ty})1 << write_idx;\n"));
+        cpp.push_str(&format!(
+            "    {mask_ty} _bit = ({mask_ty})1 << write_idx;\n"
+        ));
         cpp.push_str("    if (write_set) {\n");
         cpp.push_str("      _entry_valid_r |= _bit;\n");
         cpp.push_str("      _entry_key_r[write_idx] = write_key;\n");
@@ -112,7 +159,9 @@ impl<'a> SimCodegen<'a> {
         // Port 2 (v2)
         if has_w2 {
             cpp.push_str("  if (write2_valid) {\n");
-            cpp.push_str(&format!("    {mask_ty} _bit2 = ({mask_ty})1 << write2_idx;\n"));
+            cpp.push_str(&format!(
+                "    {mask_ty} _bit2 = ({mask_ty})1 << write2_idx;\n"
+            ));
             cpp.push_str("    if (write2_set) {\n");
             cpp.push_str("      _entry_valid_r |= _bit2;\n");
             cpp.push_str("      _entry_key_r[write2_idx] = write2_key;\n");
@@ -156,12 +205,22 @@ impl<'a> SimCodegen<'a> {
         let _ = val_ty;
 
         // Trace support — track entry_valid_r and search outputs.
-        let extra_sigs: Vec<(&str, &str, u32)> = vec![
-            ("entry_valid_r", "_entry_valid_r", depth),
-        ];
-        add_trace_to_simple_construct(&mut h, &mut cpp, &class, name, &c.ports, &extra_sigs, &c.params);
+        let extra_sigs: Vec<(&str, &str, u32)> = vec![("entry_valid_r", "_entry_valid_r", depth)];
+        add_trace_to_simple_construct(
+            &mut h,
+            &mut cpp,
+            &class,
+            name,
+            &c.ports,
+            &extra_sigs,
+            &c.params,
+        );
         h.push_str("};\n");
 
-        SimModel { class_name: class, header: h, impl_: cpp }
+        SimModel {
+            class_name: class,
+            header: h,
+            impl_: cpp,
+        }
     }
 }

--- a/src/sim_codegen/fifo.rs
+++ b/src/sim_codegen/fifo.rs
@@ -1,8 +1,8 @@
 //! `gen_fifo` emitter — extracted from `sim_codegen/mod.rs`. Follows
 //! the same submodule pattern as fsm.rs / pipeline.rs / ram.rs.
 
-use super::{SimCodegen, SimModel};
 use super::*;
+use super::{SimCodegen, SimModel};
 
 impl<'a> SimCodegen<'a> {
     pub(crate) fn gen_fifo(&self, f: &FifoDecl) -> SimModel {
@@ -11,15 +11,31 @@ impl<'a> SimCodegen<'a> {
         let is_lifo = f.kind == FifoKind::Lifo;
 
         // Resolve DEPTH and TYPE params
-        let depth: u64 = f.params.iter()
+        let depth: u64 = f
+            .params
+            .iter()
             .find(|p| p.name.name == "DEPTH")
             .and_then(|p| p.default.as_ref())
-            .and_then(|e| if let ExprKind::Literal(LitKind::Dec(v)) = &e.kind { Some(*v) } else { None })
+            .and_then(|e| {
+                if let ExprKind::Literal(LitKind::Dec(v)) = &e.kind {
+                    Some(*v)
+                } else {
+                    None
+                }
+            })
             .unwrap_or(8);
 
         // Build type-param substitution: param name → concrete TypeExpr (from default)
-        let type_param_map: std::collections::HashMap<String, TypeExpr> = f.params.iter()
-            .filter_map(|p| if let ParamKind::Type(te) = &p.kind { Some((p.name.name.clone(), te.clone())) } else { None })
+        let type_param_map: std::collections::HashMap<String, TypeExpr> = f
+            .params
+            .iter()
+            .filter_map(|p| {
+                if let ParamKind::Type(te) = &p.kind {
+                    Some((p.name.name.clone(), te.clone()))
+                } else {
+                    None
+                }
+            })
             .collect();
 
         // Internal storage (`_mem`) element type = the resolved payload type,
@@ -28,12 +44,17 @@ impl<'a> SimCodegen<'a> {
         // `.find(name == "TYPE")` never matched and `_mem` always fell back to
         // `uint32_t` — silently truncating payloads wider than 32 bits and
         // type-mismatching struct payloads.
-        let elem_ty: String = f.ports.iter()
+        let elem_ty: String = f
+            .ports
+            .iter()
             .find(|p| p.name.name == "push_data")
             .or_else(|| f.ports.iter().find(|p| p.name.name == "pop_data"))
             .map(|p| {
                 let resolved: TypeExpr = match &p.ty {
-                    TypeExpr::Named(n) => type_param_map.get(&n.name).cloned().unwrap_or_else(|| p.ty.clone()),
+                    TypeExpr::Named(n) => type_param_map
+                        .get(&n.name)
+                        .cloned()
+                        .unwrap_or_else(|| p.ty.clone()),
                     other => other.clone(),
                 };
                 cpp_internal_type_with_params(&resolved, &f.params)
@@ -41,7 +62,11 @@ impl<'a> SimCodegen<'a> {
             .unwrap_or_else(|| "uint32_t".to_string());
 
         let (rst_name, _is_async, is_low) = extract_reset_info(&f.ports);
-        let rst_cond = if is_low { format!("(!{rst_name})") } else { rst_name.clone() };
+        let rst_cond = if is_low {
+            format!("(!{rst_name})")
+        } else {
+            rst_name.clone()
+        };
         // Resolve a port's TypeExpr, substituting Named types that match type params
         let resolve_port_ty = |ty: &TypeExpr| -> String {
             if let TypeExpr::Named(n) = ty {
@@ -53,7 +78,9 @@ impl<'a> SimCodegen<'a> {
         };
 
         let mut h = String::new();
-        h.push_str("#pragma once\n#include <cstdint>\n#include <cstring>\n#include \"verilated.h\"\n\n");
+        h.push_str(
+            "#pragma once\n#include <cstdint>\n#include <cstring>\n#include \"verilated.h\"\n\n",
+        );
         h.push_str(&format!("class {class} {{\npublic:\n"));
         let port_names: HashSet<&str> = f.ports.iter().map(|p| p.name.name.as_str()).collect();
         for p in &f.ports {
@@ -62,23 +89,40 @@ impl<'a> SimCodegen<'a> {
         }
         // Add full/empty fields only if not already declared as ports
         if !is_lifo {
-            if !port_names.contains("full") { h.push_str("  uint8_t full;\n"); }
-            if !port_names.contains("empty") { h.push_str("  uint8_t empty;\n"); }
+            if !port_names.contains("full") {
+                h.push_str("  uint8_t full;\n");
+            }
+            if !port_names.contains("empty") {
+                h.push_str("  uint8_t empty;\n");
+            }
         }
         h.push('\n');
 
         // Constructor — use () for data ports, 0 for scalars
-        let mut port_inits: Vec<String> = f.ports.iter().map(|p| {
-            if matches!(p.ty, TypeExpr::Named(_)) { format!("{}()", p.name.name) }
-            else { format!("{}(0)", p.name.name) }
-        }).collect();
+        let mut port_inits: Vec<String> = f
+            .ports
+            .iter()
+            .map(|p| {
+                if matches!(p.ty, TypeExpr::Named(_)) {
+                    format!("{}()", p.name.name)
+                } else {
+                    format!("{}(0)", p.name.name)
+                }
+            })
+            .collect();
         if !is_lifo {
-            if !port_names.contains("full") { port_inits.push("full(0)".to_string()); }
-            if !port_names.contains("empty") { port_inits.push("empty(1)".to_string()); }
+            if !port_names.contains("full") {
+                port_inits.push("full(0)".to_string());
+            }
+            if !port_names.contains("empty") {
+                port_inits.push("empty(1)".to_string());
+            }
         }
         // Detect dual-clock (async FIFO): wr_clk + rd_clk on different
         // domains. Single-clock case keeps the original `_clk_prev` member.
-        let clk_ports: Vec<&str> = f.ports.iter()
+        let clk_ports: Vec<&str> = f
+            .ports
+            .iter()
             .filter(|p| matches!(&p.ty, TypeExpr::Clock(_)))
             .map(|p| p.name.name.as_str())
             .collect();
@@ -97,9 +141,13 @@ impl<'a> SimCodegen<'a> {
             port_inits.push("_wr_ptr(0)".to_string());
             port_inits.push("_rd_ptr(0)".to_string());
         }
-        h.push_str(&format!("  {class}() : {} {{\n    memset(_mem, 0, sizeof(_mem));\n  }}\n",
-            port_inits.join(", ")));
-        h.push_str(&format!("  explicit {class}(VerilatedContext*) : {class}() {{}}\n"));
+        h.push_str(&format!(
+            "  {class}() : {} {{\n    memset(_mem, 0, sizeof(_mem));\n  }}\n",
+            port_inits.join(", ")
+        ));
+        h.push_str(&format!(
+            "  explicit {class}(VerilatedContext*) : {class}() {{}}\n"
+        ));
         h.push_str("  void eval();\n  void eval_posedge();\n  void eval_comb();\n");
         if is_async {
             h.push_str("  void eval_posedge_dual(bool _wr_rising, bool _rd_rising);\n");
@@ -126,8 +174,12 @@ impl<'a> SimCodegen<'a> {
         let mut cpp = String::new();
         cpp.push_str(&format!("#include \"{class}.h\"\n\n"));
 
-        let clk_port = f.ports.iter().find(|p| matches!(&p.ty, TypeExpr::Clock(_)))
-            .map(|p| p.name.name.as_str()).unwrap_or("clk");
+        let clk_port = f
+            .ports
+            .iter()
+            .find(|p| matches!(&p.ty, TypeExpr::Clock(_)))
+            .map(|p| p.name.name.as_str())
+            .unwrap_or("clk");
 
         // eval()
         cpp.push_str(&format!("void {class}::eval() {{\n"));
@@ -142,7 +194,9 @@ impl<'a> SimCodegen<'a> {
             cpp.push_str("  bool _rd_rising = (rd_clk && !_clk_prev_rd);\n");
             cpp.push_str("  _clk_prev_wr = wr_clk;\n");
             cpp.push_str("  _clk_prev_rd = rd_clk;\n");
-            cpp.push_str("  if (_wr_rising || _rd_rising) eval_posedge_dual(_wr_rising, _rd_rising);\n");
+            cpp.push_str(
+                "  if (_wr_rising || _rd_rising) eval_posedge_dual(_wr_rising, _rd_rising);\n",
+            );
         } else {
             // Sync FIFO: edge detection lives inside eval_posedge() so
             // that when a parent module calls _inst_X.eval_posedge()
@@ -159,17 +213,23 @@ impl<'a> SimCodegen<'a> {
 
         if is_async {
             // Dual-clock posedge handler: split push/pop sides cleanly.
-            cpp.push_str(&format!("void {class}::eval_posedge_dual(bool _wr_rising, bool _rd_rising) {{\n"));
+            cpp.push_str(&format!(
+                "void {class}::eval_posedge_dual(bool _wr_rising, bool _rd_rising) {{\n"
+            ));
             cpp.push_str(&format!("  if ({rst_cond}) {{\n"));
             cpp.push_str("    _wr_ptr = 0; _rd_ptr = 0;\n");
             cpp.push_str("    return;\n  }\n");
             cpp.push_str("  if (_wr_rising && push_valid && push_ready) {\n");
             cpp.push_str(&format!("    _mem[_wr_ptr % {depth}] = push_data;\n"));
             cpp.push_str("    _wr_ptr++;\n");
-            cpp.push_str(&format!("    if (_wr_ptr >= 2u * {depth}) _wr_ptr = 0;\n  }}\n"));
+            cpp.push_str(&format!(
+                "    if (_wr_ptr >= 2u * {depth}) _wr_ptr = 0;\n  }}\n"
+            ));
             cpp.push_str("  if (_rd_rising && pop_ready && pop_valid) {\n");
             cpp.push_str("    _rd_ptr++;\n");
-            cpp.push_str(&format!("    if (_rd_ptr >= 2u * {depth}) _rd_ptr = 0;\n  }}\n"));
+            cpp.push_str(&format!(
+                "    if (_rd_ptr >= 2u * {depth}) _rd_ptr = 0;\n  }}\n"
+            ));
             cpp.push_str("}\n\n");
             // eval_posedge() — self-gating dual-clock entry point. A parent
             // module drives a sub-instance by calling _inst_X.eval_posedge()
@@ -186,7 +246,9 @@ impl<'a> SimCodegen<'a> {
             cpp.push_str("  bool _rd_rising = (rd_clk && !_clk_prev_rd);\n");
             cpp.push_str("  _clk_prev_wr = wr_clk;\n");
             cpp.push_str("  _clk_prev_rd = rd_clk;\n");
-            cpp.push_str("  if (_wr_rising || _rd_rising) eval_posedge_dual(_wr_rising, _rd_rising);\n");
+            cpp.push_str(
+                "  if (_wr_rising || _rd_rising) eval_posedge_dual(_wr_rising, _rd_rising);\n",
+            );
             cpp.push_str("}\n\n");
         } else {
             // eval_posedge() — single-clock path. Self-gates on rising
@@ -212,10 +274,14 @@ impl<'a> SimCodegen<'a> {
                 cpp.push_str("    if (push_valid && push_ready) {\n");
                 cpp.push_str(&format!("      _mem[_wr_ptr % {depth}] = push_data;\n"));
                 cpp.push_str("      _wr_ptr++;\n");
-                cpp.push_str(&format!("      if (_wr_ptr >= 2u * {depth}) _wr_ptr = 0;\n    }}\n"));
+                cpp.push_str(&format!(
+                    "      if (_wr_ptr >= 2u * {depth}) _wr_ptr = 0;\n    }}\n"
+                ));
                 cpp.push_str("    if (pop_ready && pop_valid) {\n");
                 cpp.push_str("      _rd_ptr++;\n");
-                cpp.push_str(&format!("      if (_rd_ptr >= 2u * {depth}) _rd_ptr = 0;\n    }}\n"));
+                cpp.push_str(&format!(
+                    "      if (_rd_ptr >= 2u * {depth}) _rd_ptr = 0;\n    }}\n"
+                ));
             }
             cpp.push_str("  }\n}\n\n");
         }
@@ -225,7 +291,9 @@ impl<'a> SimCodegen<'a> {
         if is_lifo {
             cpp.push_str(&format!("  push_ready = (_sp < {depth}u);\n"));
             cpp.push_str("  pop_valid  = (_sp > 0);\n");
-            cpp.push_str(&format!("  pop_data   = _mem[(_sp > 0 ? _sp - 1 : 0) % {depth}];\n"));
+            cpp.push_str(&format!(
+                "  pop_data   = _mem[(_sp > 0 ? _sp - 1 : 0) % {depth}];\n"
+            ));
         } else {
             cpp.push_str(&format!("  uint32_t _depth = {depth};\n"));
             cpp.push_str("  uint32_t _count = (_wr_ptr >= _rd_ptr)\n");
@@ -240,17 +308,25 @@ impl<'a> SimCodegen<'a> {
         cpp.push_str("}\n\n");
 
         // Trace methods
-        cpp.push_str(&format!("void {class}::trace_open(const char* filename) {{\n"));
+        cpp.push_str(&format!(
+            "void {class}::trace_open(const char* filename) {{\n"
+        ));
         cpp.push_str("  _trace_fp = fopen(filename, \"w\");\n");
         cpp.push_str("  if (!_trace_fp) return;\n");
         cpp.push_str("  fprintf(_trace_fp, \"$timescale 1ns $end\\n\");\n");
-        cpp.push_str(&format!("  fprintf(_trace_fp, \"$scope module {} $end\\n\");\n", name));
+        cpp.push_str(&format!(
+            "  fprintf(_trace_fp, \"$scope module {} $end\\n\");\n",
+            name
+        ));
         let mut sig_idx = 0usize;
         for p in &f.ports {
             let w = type_width_with_params(&p.ty, &f.params);
-            let id = vcd_id(sig_idx); sig_idx += 1;
+            let id = vcd_id(sig_idx);
+            sig_idx += 1;
             let pname = &p.name.name;
-            cpp.push_str(&format!("  fprintf(_trace_fp, \"$var wire {w} {id} {pname} $end\\n\");\n"));
+            cpp.push_str(&format!(
+                "  fprintf(_trace_fp, \"$var wire {w} {id} {pname} $end\\n\");\n"
+            ));
         }
         cpp.push_str("  fprintf(_trace_fp, \"$upscope $end\\n$enddefinitions $end\\n\");\n");
         cpp.push_str("}\n\n");
@@ -261,10 +337,14 @@ impl<'a> SimCodegen<'a> {
         sig_idx = 0;
         for p in &f.ports {
             let w = type_width_with_params(&p.ty, &f.params);
-            let id = vcd_id(sig_idx); sig_idx += 1;
+            let id = vcd_id(sig_idx);
+            sig_idx += 1;
             let pname = &p.name.name;
             if w == 1 {
-                cpp.push_str(&format!("  fprintf(_trace_fp, \"%c{}\\n\", {pname} ? '1' : '0');\n", id));
+                cpp.push_str(&format!(
+                    "  fprintf(_trace_fp, \"%c{}\\n\", {pname} ? '1' : '0');\n",
+                    id
+                ));
             } else {
                 cpp.push_str("  fprintf(_trace_fp, \"b\");\n");
                 cpp.push_str(&format!("  for (int _i = {w} - 1; _i >= 0; _i--) fprintf(_trace_fp, \"%c\", (int)(({pname} >> _i) & 1) ? '1' : '0');\n"));
@@ -276,7 +356,10 @@ impl<'a> SimCodegen<'a> {
         cpp.push_str("  if (_trace_fp) {{ fclose(_trace_fp); _trace_fp = nullptr; }}\n");
         cpp.push_str("}\n");
 
-        SimModel { class_name: class, header: h, impl_: cpp }
+        SimModel {
+            class_name: class,
+            header: h,
+            impl_: cpp,
+        }
     }
-
 }

--- a/src/sim_codegen/fsm.rs
+++ b/src/sim_codegen/fsm.rs
@@ -6,9 +6,9 @@
 
 use std::collections::{HashMap, HashSet};
 
-use crate::ast::*;
-use super::{SimCodegen, SimModel};
 use super::*;
+use super::{SimCodegen, SimModel};
+use crate::ast::*;
 
 impl<'a> SimCodegen<'a> {
     pub(crate) fn gen_fsm(&self, f: &FsmDecl) -> SimModel {
@@ -20,7 +20,8 @@ impl<'a> SimCodegen<'a> {
         // registry. Same pattern as gen_module: emit `_arch_cov[N]++;`
         // at each state's case body (state-entry coverage) and at each
         // transition's `if (cond) ...` (transition-arc coverage).
-        let cov_reg: std::cell::RefCell<CoverageRegistry> = std::cell::RefCell::new(CoverageRegistry::default());
+        let cov_reg: std::cell::RefCell<CoverageRegistry> =
+            std::cell::RefCell::new(CoverageRegistry::default());
         let cov_handle: Option<&std::cell::RefCell<CoverageRegistry>> =
             if self.coverage { Some(&cov_reg) } else { None };
 
@@ -30,11 +31,18 @@ impl<'a> SimCodegen<'a> {
         for p in &f.ports {
             if let Some(ref bi) = p.bus_info {
                 bus_port_names.insert(p.name.name.clone());
-                bus_flat.extend(flatten_bus_port(&p.name.name, bi, self.symbols, &f.common.params));
+                bus_flat.extend(flatten_bus_port(
+                    &p.name.name,
+                    bi,
+                    self.symbols,
+                    &f.common.params,
+                ));
             }
         }
 
-        let mut port_names: HashSet<String> = f.ports.iter()
+        let mut port_names: HashSet<String> = f
+            .ports
+            .iter()
             .filter(|p| p.bus_info.is_none())
             .map(|p| p.name.name.clone())
             .collect();
@@ -42,35 +50,50 @@ impl<'a> SimCodegen<'a> {
             port_names.insert(flat_name.clone());
         }
 
-        let empty_regs  = HashSet::new();
-        let empty_lets  = HashSet::new();
+        let empty_regs = HashSet::new();
+        let empty_lets = HashSet::new();
         let empty_insts = HashSet::new();
-        let empty_wide  = HashSet::new();
-        let empty_w     = HashMap::new();
+        let empty_wide = HashSet::new();
+        let empty_w = HashMap::new();
 
-        let n_states   = f.state_names.len();
+        let n_states = f.state_names.len();
         let state_bits = enum_width(n_states);
-        let state_ty   = cpp_uint(state_bits as u32);
+        let state_ty = cpp_uint(state_bits as u32);
 
-        let state_idx: HashMap<String, usize> = f.state_names.iter()
-            .enumerate().map(|(i, s)| (s.name.clone(), i)).collect();
+        let state_idx: HashMap<String, usize> = f
+            .state_names
+            .iter()
+            .enumerate()
+            .map(|(i, s)| (s.name.clone(), i))
+            .collect();
         // sim_codegen only runs for non-interface fsms; `default_state`
         // is `Some(_)` here. Interface stubs are filtered out earlier.
-        let default_idx = f.default_state.as_ref()
+        let default_idx = f
+            .default_state
+            .as_ref()
             .and_then(|ds| state_idx.get(&ds.name).copied())
             .unwrap_or(0);
 
         let (rst_name, _is_async, is_low) = extract_reset_info(&f.ports);
-        let rst_cond = if is_low { format!("(!{})", rst_name) } else { rst_name.clone() };
+        let rst_cond = if is_low {
+            format!("(!{})", rst_name)
+        } else {
+            rst_name.clone()
+        };
 
         let mut h = String::new();
-        h.push_str("#pragma once\n#include <cstdint>\n#include <cstdio>\n#include \"verilated.h\"\n\n");
+        h.push_str(
+            "#pragma once\n#include <cstdint>\n#include <cstdio>\n#include \"verilated.h\"\n\n",
+        );
         // Emit param constants as #define
         for p in &f.params {
             if matches!(p.kind, ParamKind::Const | ParamKind::WidthConst(..)) {
                 if let Some(ref def) = p.default {
                     let val = eval_const_expr_with_params(def, &f.common.params);
-                    h.push_str(&format!("#ifndef {}\n#define {} {val}ULL\n#endif\n", p.name.name, p.name.name));
+                    h.push_str(&format!(
+                        "#ifndef {}\n#define {} {val}ULL\n#endif\n",
+                        p.name.name, p.name.name
+                    ));
                 }
             }
         }
@@ -82,9 +105,13 @@ impl<'a> SimCodegen<'a> {
             is_input: bool,
             is_port_reg: bool,
         }
-        let fsm_vec_port_infos: Vec<FsmVecPortInfo> = f.ports.iter()
+        let fsm_vec_port_infos: Vec<FsmVecPortInfo> = f
+            .ports
+            .iter()
             .filter_map(|p| {
-                if let Some((elem_ty, count_str)) = vec_array_info_with_params(&p.ty, &f.common.params) {
+                if let Some((elem_ty, count_str)) =
+                    vec_array_info_with_params(&p.ty, &f.common.params)
+                {
                     let count: u64 = count_str.parse().unwrap_or(0);
                     Some(FsmVecPortInfo {
                         name: p.name.name.clone(),
@@ -98,12 +125,15 @@ impl<'a> SimCodegen<'a> {
                 }
             })
             .collect();
-        let fsm_vec_port_names: HashSet<String> = fsm_vec_port_infos.iter().map(|v| v.name.clone()).collect();
+        let fsm_vec_port_names: HashSet<String> =
+            fsm_vec_port_infos.iter().map(|v| v.name.clone()).collect();
         // All FSM Vec ports have internal C arrays `_name[N]` and always resolve to `_name` in ctx.
         // (Both input and output Vec ports, whether port-reg or not.)
         let fsm_vec_port_reg_names: HashSet<String> = fsm_vec_port_names.clone();
         // Vec-typed regs in f.regs also need array subscript in Index expressions.
-        let fsm_vec_reg_names: HashSet<String> = f.regs.iter()
+        let fsm_vec_reg_names: HashSet<String> = f
+            .regs
+            .iter()
             .filter(|r| matches!(r.ty, TypeExpr::Vec(..)))
             .map(|r| r.name.name.clone())
             .collect();
@@ -112,9 +142,14 @@ impl<'a> SimCodegen<'a> {
         fsm_vec_names.extend(fsm_vec_reg_names.iter().cloned());
 
         h.push('\n');
-        h.push_str(&format!("class {class} {{\npublic:\n  // State constants\n"));
+        h.push_str(&format!(
+            "class {class} {{\npublic:\n  // State constants\n"
+        ));
         for (i, sn) in f.state_names.iter().enumerate() {
-            h.push_str(&format!("  static const {state_ty} STATE_{} = {i};\n", sn.name.to_uppercase()));
+            h.push_str(&format!(
+                "  static const {state_ty} STATE_{} = {i};\n",
+                sn.name.to_uppercase()
+            ));
         }
         h.push('\n');
         // Port fields: Vec ports → N flat fields; bus ports → flattened signals; others → single field
@@ -126,7 +161,11 @@ impl<'a> SimCodegen<'a> {
                     h.push_str(&format!("  {} {}_{i};\n", vi.elem_ty, vi.name));
                 }
             } else {
-                h.push_str(&format!("  {} {};\n", cpp_port_type_with_params(&p.ty, &f.common.params), p.name.name));
+                h.push_str(&format!(
+                    "  {} {};\n",
+                    cpp_port_type_with_params(&p.ty, &f.common.params),
+                    p.name.name
+                ));
             }
         }
         // Flattened bus port fields
@@ -148,8 +187,14 @@ impl<'a> SimCodegen<'a> {
         // output port (no separate storage — `eval_comb` writes the port
         // directly via the let's RHS).
         for lb in &f.lets {
-            if port_names.contains(&lb.name.name) { continue; }
-            let ty = lb.ty.as_ref().map(|t| cpp_internal_type_with_params(t, &f.common.params)).unwrap_or_else(|| "uint32_t".to_string());
+            if port_names.contains(&lb.name.name) {
+                continue;
+            }
+            let ty = lb
+                .ty
+                .as_ref()
+                .map(|t| cpp_internal_type_with_params(t, &f.common.params))
+                .unwrap_or_else(|| "uint32_t".to_string());
             h.push_str(&format!("  {} {};\n", ty, lb.name.name));
         }
         // Wire declarations as public members
@@ -160,41 +205,60 @@ impl<'a> SimCodegen<'a> {
         h.push('\n');
 
         // Constructor inits: skip Vec/bus port names (they use flat fields), add flat field inits
-        let port_inits: Vec<String> = f.ports.iter()
-            .filter(|p| !fsm_vec_port_names.contains(&p.name.name) && !bus_port_names.contains(&p.name.name))
+        let port_inits: Vec<String> = f
+            .ports
+            .iter()
+            .filter(|p| {
+                !fsm_vec_port_names.contains(&p.name.name) && !bus_port_names.contains(&p.name.name)
+            })
             .map(|p| format!("{}(0)", p.name.name))
             .collect();
-        let vec_port_flat_inits: Vec<String> = fsm_vec_port_infos.iter()
+        let vec_port_flat_inits: Vec<String> = fsm_vec_port_infos
+            .iter()
             .flat_map(|vi| (0..vi.count).map(move |i| format!("{}_{i}(0)", vi.name)))
             .collect();
-        let bus_flat_inits: Vec<String> = bus_flat.iter()
-            .map(|(n, _)| format!("{n}(0)"))
-            .collect();
-        let reg_inits: Vec<String> = f.regs.iter()
-            .filter(|r| !matches!(r.ty, TypeExpr::Vec(..)))  // Vec regs use memset in ctor body
+        let bus_flat_inits: Vec<String> = bus_flat.iter().map(|(n, _)| format!("{n}(0)")).collect();
+        let reg_inits: Vec<String> = f
+            .regs
+            .iter()
+            .filter(|r| !matches!(r.ty, TypeExpr::Vec(..))) // Vec regs use memset in ctor body
             .map(|r| {
-                let init_expr = reset_value_from_reg_reset(&r.reset)
-                    .or(r.init.as_ref());
+                let init_expr = reset_value_from_reg_reset(&r.reset).or(r.init.as_ref());
                 if let Some(expr) = init_expr {
-                    let init_val = cpp_expr(expr, &Ctx::new(&empty_regs, &port_names, &empty_lets, &empty_insts, &empty_wide, &empty_w, &enum_map, &bus_port_names));
+                    let init_val = cpp_expr(
+                        expr,
+                        &Ctx::new(
+                            &empty_regs,
+                            &port_names,
+                            &empty_lets,
+                            &empty_insts,
+                            &empty_wide,
+                            &empty_w,
+                            &enum_map,
+                            &bus_port_names,
+                        ),
+                    );
                     format!("{}({})", r.name.name, init_val)
                 } else {
                     format!("{}(0)", r.name.name)
                 }
-            }).collect();
+            })
+            .collect();
         let state_inits = vec![
             "_clk_prev(0)".to_string(),
             format!("state_r({default_idx})"),
             format!("_state_r({default_idx})"),
         ];
-        let all_inits: Vec<String> = port_inits.into_iter()
+        let all_inits: Vec<String> = port_inits
+            .into_iter()
             .chain(vec_port_flat_inits)
             .chain(bus_flat_inits)
             .chain(reg_inits)
             .chain(state_inits)
             .collect();
         // Constructor body: memset internal arrays for Vec ports + Vec regs
-        let mut fsm_vec_memsets: Vec<String> = fsm_vec_port_infos.iter()
+        let mut fsm_vec_memsets: Vec<String> = fsm_vec_port_infos
+            .iter()
             .map(|vi| format!("    memset(_{}, 0, sizeof(_{}));", vi.name, vi.name))
             .collect();
         // Vec regs in FSM: public array members, initialized via memset
@@ -208,10 +272,14 @@ impl<'a> SimCodegen<'a> {
             h.push_str(&format!("  {class}() : {} {{}}\n", all_inits.join(", ")));
         } else {
             h.push_str(&format!("  {class}() : {} {{\n", all_inits.join(", ")));
-            for ms in &fsm_vec_memsets { h.push_str(&format!("{ms}\n")); }
+            for ms in &fsm_vec_memsets {
+                h.push_str(&format!("{ms}\n"));
+            }
             h.push_str("  }\n");
         }
-        h.push_str(&format!("  explicit {class}(VerilatedContext*) : {class}() {{}}\n"));
+        h.push_str(&format!(
+            "  explicit {class}(VerilatedContext*) : {class}() {{}}\n"
+        ));
         h.push_str("  void eval();\n  void eval_posedge();\n  void eval_comb();\n  void final() { trace_close(); }\nprivate:\n");
         // Private internal arrays for Vec ports
         for vi in &fsm_vec_port_infos {
@@ -224,8 +292,12 @@ impl<'a> SimCodegen<'a> {
         let mut cpp = String::new();
         cpp.push_str(&format!("#include \"{class}.h\"\n\n"));
 
-        let clk_port = f.ports.iter().find(|p| matches!(&p.ty, TypeExpr::Clock(_)))
-            .map(|p| p.name.name.as_str()).unwrap_or("clk");
+        let clk_port = f
+            .ports
+            .iter()
+            .find(|p| matches!(&p.ty, TypeExpr::Clock(_)))
+            .map(|p| p.name.name.as_str())
+            .unwrap_or("clk");
 
         cpp.push_str(&format!("void {class}::eval() {{\n"));
         cpp.push_str("  if (!_trace_fp && Verilated::traceFile() && Verilated::claimTrace())\n");
@@ -235,27 +307,58 @@ impl<'a> SimCodegen<'a> {
         cpp.push_str("}\n\n");
 
         let fsm_reg_names: HashSet<String> = f.regs.iter().map(|r| r.name.name.clone()).collect();
-        let fsm_let_names: HashSet<String> = f.lets.iter().map(|l| l.name.name.clone())
-            .chain(f.wires.iter().map(|w| w.name.name.clone())).collect();
+        let fsm_let_names: HashSet<String> = f
+            .lets
+            .iter()
+            .map(|l| l.name.name.clone())
+            .chain(f.wires.iter().map(|w| w.name.name.clone()))
+            .collect();
         let mut fsm_widths: HashMap<String, u32> = HashMap::new();
-        for p in &f.ports { fsm_widths.insert(p.name.name.clone(), type_bits_te_with_params(&p.ty, &f.common.params)); }
-        for r in &f.regs { fsm_widths.insert(r.name.name.clone(), type_bits_te_with_params(&r.ty, &f.common.params)); }
-        for l in &f.lets {
-            if let Some(ty) = &l.ty { fsm_widths.insert(l.name.name.clone(), type_bits_te_with_params(ty, &f.common.params)); }
+        for p in &f.ports {
+            fsm_widths.insert(
+                p.name.name.clone(),
+                type_bits_te_with_params(&p.ty, &f.common.params),
+            );
         }
-        for w in &f.wires { fsm_widths.insert(w.name.name.clone(), type_bits_te_with_params(&w.ty, &f.common.params)); }
+        for r in &f.regs {
+            fsm_widths.insert(
+                r.name.name.clone(),
+                type_bits_te_with_params(&r.ty, &f.common.params),
+            );
+        }
+        for l in &f.lets {
+            if let Some(ty) = &l.ty {
+                fsm_widths.insert(
+                    l.name.name.clone(),
+                    type_bits_te_with_params(ty, &f.common.params),
+                );
+            }
+        }
+        for w in &f.wires {
+            fsm_widths.insert(
+                w.name.name.clone(),
+                type_bits_te_with_params(&w.ty, &f.common.params),
+            );
+        }
         // Built-in `state` identifier inside fsm scope: read of the current
         // encoded state. Lowers to `_state_r` in sim, with width = clog2(N).
         fsm_widths.insert("state".to_string(), state_bits as u32);
-        let fsm_ident_subst: HashMap<String, String> = std::iter::once(
-            ("state".to_string(), "_state_r".to_string())
-        ).collect();
+        let fsm_ident_subst: HashMap<String, String> =
+            std::iter::once(("state".to_string(), "_state_r".to_string())).collect();
         let ctx_fsm = {
-            let mut c = Ctx::new(&fsm_reg_names, &port_names, &fsm_let_names, &empty_insts,
-                                 &empty_wide, &fsm_widths, &enum_map, &bus_port_names)
-                .with_vec_names(&fsm_vec_names)
-                .with_fsm_vec_port_regs(&fsm_vec_port_reg_names)
-                .with_ident_subst(&fsm_ident_subst);
+            let mut c = Ctx::new(
+                &fsm_reg_names,
+                &port_names,
+                &fsm_let_names,
+                &empty_insts,
+                &empty_wide,
+                &fsm_widths,
+                &enum_map,
+                &bus_port_names,
+            )
+            .with_vec_names(&fsm_vec_names)
+            .with_fsm_vec_port_regs(&fsm_vec_port_reg_names)
+            .with_ident_subst(&fsm_ident_subst);
             c.fsm_mode = true;
             c
         };
@@ -269,23 +372,32 @@ impl<'a> SimCodegen<'a> {
         for reg in &f.regs {
             let n = &reg.name.name;
             if let Some((elem_ty, count)) = vec_array_info_with_params(&reg.ty, &f.common.params) {
-                cpp.push_str(&format!("  {elem_ty} _n_{n}[{count}]; memcpy(_n_{n}, {n}, sizeof({n}));\n"));
+                cpp.push_str(&format!(
+                    "  {elem_ty} _n_{n}[{count}]; memcpy(_n_{n}, {n}, sizeof({n}));\n"
+                ));
             } else {
                 let ty = cpp_internal_type_with_params(&reg.ty, &f.common.params);
                 cpp.push_str(&format!("  {ty} _n_{n} = {n};\n"));
             }
         }
-        cpp.push_str(&format!("  if ({rst_cond}) {{\n    _n_state = {default_idx};\n"));
+        cpp.push_str(&format!(
+            "  if ({rst_cond}) {{\n    _n_state = {default_idx};\n"
+        ));
         // Reset datapath regs
         for reg in &f.regs {
-            let reset_expr = reset_value_from_reg_reset(&reg.reset)
-                .or(reg.init.as_ref());
+            let reset_expr = reset_value_from_reg_reset(&reg.reset).or(reg.init.as_ref());
             if let Some(expr) = reset_expr {
                 let n = &reg.name.name;
                 if vec_array_info_with_params(&reg.ty, &f.common.params).is_some() {
                     let init_val = cpp_expr(expr, &ctx_fsm);
-                    let count = if let TypeExpr::Vec(_, c) = &reg.ty { eval_const_expr_with_params(c, &f.common.params) } else { 0 };
-                    cpp.push_str(&format!("    for (int _i = 0; _i < {count}; _i++) _n_{n}[_i] = {init_val};\n"));
+                    let count = if let TypeExpr::Vec(_, c) = &reg.ty {
+                        eval_const_expr_with_params(c, &f.common.params)
+                    } else {
+                        0
+                    };
+                    cpp.push_str(&format!(
+                        "    for (int _i = 0; _i < {count}; _i++) _n_{n}[_i] = {init_val};\n"
+                    ));
                 } else {
                     let init_val = cpp_expr(expr, &ctx_fsm);
                     cpp.push_str(&format!("    _n_{n} = {init_val};\n"));
@@ -296,23 +408,36 @@ impl<'a> SimCodegen<'a> {
         for vi in &fsm_vec_port_infos {
             if vi.is_port_reg {
                 let p = f.ports.iter().find(|p| p.name.name == vi.name).unwrap();
-                let reset_expr = p.reg_info.as_ref().and_then(|ri| reset_value_from_reg_reset(&ri.reset).or(ri.init.as_ref()));
+                let reset_expr = p
+                    .reg_info
+                    .as_ref()
+                    .and_then(|ri| reset_value_from_reg_reset(&ri.reset).or(ri.init.as_ref()));
                 let reset_val = if let Some(expr) = reset_expr {
                     cpp_expr(expr, &ctx_fsm)
                 } else {
                     "0".to_string()
                 };
-                cpp.push_str(&format!("    for (int _i = 0; _i < {}; _i++) _{}[_i] = {};\n",
-                    vi.count, vi.name, reset_val));
+                cpp.push_str(&format!(
+                    "    for (int _i = 0; _i < {}; _i++) _{}[_i] = {};\n",
+                    vi.count, vi.name, reset_val
+                ));
             }
         }
         cpp.push_str("  } else {\n");
         let ctx_posedge = {
-            let mut c = Ctx::new(&fsm_reg_names, &port_names, &fsm_let_names, &empty_insts,
-                                 &empty_wide, &fsm_widths, &enum_map, &bus_port_names)
-                .with_vec_names(&fsm_vec_names)
-                .with_fsm_vec_port_regs(&fsm_vec_port_reg_names)
-                .with_ident_subst(&fsm_ident_subst);
+            let mut c = Ctx::new(
+                &fsm_reg_names,
+                &port_names,
+                &fsm_let_names,
+                &empty_insts,
+                &empty_wide,
+                &fsm_widths,
+                &enum_map,
+                &bus_port_names,
+            )
+            .with_vec_names(&fsm_vec_names)
+            .with_fsm_vec_port_regs(&fsm_vec_port_reg_names)
+            .with_ident_subst(&fsm_ident_subst);
             c.posedge_lhs = true;
             c.fsm_mode = true;
             c
@@ -332,7 +457,11 @@ impl<'a> SimCodegen<'a> {
             // state was never entered — useful for unreachable-state
             // diagnostics.
             if let Some(reg) = cov_handle {
-                let cidx = reg.borrow_mut().alloc("state", sb.name.span.start, format!("state {}", sb.name.name));
+                let cidx = reg.borrow_mut().alloc(
+                    "state",
+                    sb.name.span.start,
+                    format!("state {}", sb.name.name),
+                );
                 cpp.push_str(&format!("        _arch_cov[{cidx}]++;\n"));
             }
             // Emit seq_stmts for this state
@@ -355,10 +484,15 @@ impl<'a> SimCodegen<'a> {
                         format!("trans {} -> {}", sb.name.name, tr.target.name),
                     );
                     format!("_arch_cov[{cidx}]++; ")
-                } else { String::new() };
+                } else {
+                    String::new()
+                };
                 if self.debug_fsm {
                     // Escape the condition for printf literal
-                    let cond_escaped = cond.replace('\\', "\\\\").replace('"', "\\\"").replace('%', "%%");
+                    let cond_escaped = cond
+                        .replace('\\', "\\\\")
+                        .replace('"', "\\\"")
+                        .replace('%', "%%");
                     cpp.push_str(&format!(
                         "        if ({cond}) {{ {cov_bump}_n_state = {target_idx}; \
                          printf(\"[FSM][{name}] {src} -> {tgt} ({cond_lit})\\n\"); break; }}\n",
@@ -367,7 +501,9 @@ impl<'a> SimCodegen<'a> {
                         cond_lit = cond_escaped,
                     ));
                 } else {
-                    cpp.push_str(&format!("        if ({cond}) {{ {cov_bump}_n_state = {target_idx}; break; }}\n"));
+                    cpp.push_str(&format!(
+                        "        if ({cond}) {{ {cov_bump}_n_state = {target_idx}; break; }}\n"
+                    ));
                 }
             }
             cpp.push_str("        break;\n");
@@ -411,9 +547,13 @@ impl<'a> SimCodegen<'a> {
         // explicitly assign the port still produces the declared default
         // instead of holding the previous cycle's value.
         for p in &f.ports {
-            if p.direction != Direction::Out { continue; }
+            if p.direction != Direction::Out {
+                continue;
+            }
             // Skip port reg (registered output, driven in seq, not comb).
-            if p.reg_info.is_some() { continue; }
+            if p.reg_info.is_some() {
+                continue;
+            }
             if let Some(def) = &p.default {
                 let val = cpp_expr(def, &ctx_fsm);
                 cpp.push_str(&format!("  {} = {};\n", p.name.name, val));
@@ -449,18 +589,27 @@ impl<'a> SimCodegen<'a> {
         // Build flat Vec port trace signals (name_i → field name_i, width = elem_width)
         let mut fsm_flat_vec_traces: Vec<(String, String, u32)> = Vec::new();
         for vi in &fsm_vec_port_infos {
-            let elem_bits = if let TypeExpr::Vec(elem, _) = f.ports.iter()
-                .find(|p| p.name.name == vi.name).map(|p| &p.ty).unwrap() {
+            let elem_bits = if let TypeExpr::Vec(elem, _) = f
+                .ports
+                .iter()
+                .find(|p| p.name.name == vi.name)
+                .map(|p| &p.ty)
+                .unwrap()
+            {
                 type_width_with_params(elem, &f.common.params)
-            } else { 32 };
+            } else {
+                32
+            };
             for i in 0..vi.count {
                 let fname = format!("{}_{i}", vi.name);
                 fsm_flat_vec_traces.push((fname.clone(), fname, elem_bits));
             }
         }
-        let mut extra_sigs_owned: Vec<(String, String, u32)> = vec![
-            ("state_r".to_string(), "_state_r".to_string(), state_bits as u32),
-        ];
+        let mut extra_sigs_owned: Vec<(String, String, u32)> = vec![(
+            "state_r".to_string(),
+            "_state_r".to_string(),
+            state_bits as u32,
+        )];
         extra_sigs_owned.extend(fsm_flat_vec_traces);
         // Add flattened bus port signals to trace. Use the param-aware
         // width evaluator (issue #427 sibling site): if a bus's per-signal
@@ -473,16 +622,27 @@ impl<'a> SimCodegen<'a> {
             let bits = type_bits_te_with_params(flat_ty, &f.common.params);
             extra_sigs_owned.push((flat_name.clone(), flat_name.clone(), bits));
         }
-        let extra_sigs_ref: Vec<(&str, &str, u32)> = extra_sigs_owned.iter()
+        let extra_sigs_ref: Vec<(&str, &str, u32)> = extra_sigs_owned
+            .iter()
             .map(|(n, e, w)| (n.as_str(), e.as_str(), *w))
             .collect();
-        add_trace_to_simple_construct(&mut h, &mut cpp, &class, name, &f.ports, &extra_sigs_ref, &f.common.params);
+        add_trace_to_simple_construct(
+            &mut h,
+            &mut cpp,
+            &class,
+            name,
+            &f.ports,
+            &extra_sigs_ref,
+            &f.common.params,
+        );
 
         // --coverage: per-FSM counter storage + atexit dumper. Same
         // shape as gen_module's coverage emission (#132/#134).
         let n_cov = cov_reg.borrow().points.len();
         if self.coverage && n_cov > 0 {
-            h.push_str(&format!("public:\n  static uint64_t _arch_cov[{n_cov}];\n  static bool _arch_cov_dumped;\n"));
+            h.push_str(&format!(
+                "public:\n  static uint64_t _arch_cov[{n_cov}];\n  static bool _arch_cov_dumped;\n"
+            ));
             cpp.push_str(&format!("uint64_t {class}::_arch_cov[{n_cov}] = {{}};\nbool {class}::_arch_cov_dumped = false;\n\n"));
             cpp.push_str("namespace {\n");
             cpp.push_str("static void _arch_cov_dump() {\n");
@@ -495,7 +655,9 @@ impl<'a> SimCodegen<'a> {
             // lines for the FSM coverage points.
             if let Some(path) = &self.coverage_dat {
                 let path_lit = path.replace('\\', "\\\\").replace('"', "\\\"");
-                cpp.push_str(&format!("  FILE* _dat = _arch_cov_dat_open(\"{path_lit}\");\n"));
+                cpp.push_str(&format!(
+                    "  FILE* _dat = _arch_cov_dat_open(\"{path_lit}\");\n"
+                ));
             }
             for (i, p) in cov_reg.borrow().points.iter().enumerate() {
                 let (file_disp, line_no) = if let Some(sm) = &self.source_map {
@@ -519,7 +681,7 @@ impl<'a> SimCodegen<'a> {
                     let file_esc = file_disp.replace('\\', "\\\\").replace('"', "\\\"");
                     let page = match p.kind {
                         "state" | "trans" => "v_user/fsm",
-                        _                 => "v_user",
+                        _ => "v_user",
                     };
                     cpp.push_str(&format!(
                         "  if (_dat) fprintf(_dat, \"C '\" \"\\x01\" \"file\" \"\\x02\" \"{file_esc}\" \"\\x01\" \"line\" \"\\x02\" \"{line_no}\" \"\\x01\" \"page\" \"\\x02\" \"{page}\" \"\\x01\" \"comment\" \"\\x02\" \"{kind} {comment}\" \"' %llu\\n\", (unsigned long long){class}::_arch_cov[{i}]);\n",
@@ -538,6 +700,10 @@ impl<'a> SimCodegen<'a> {
 
         h.push_str("};\n");
 
-        SimModel { class_name: class, header: h, impl_: cpp }
+        SimModel {
+            class_name: class,
+            header: h,
+            impl_: cpp,
+        }
     }
 }

--- a/src/sim_codegen/linklist.rs
+++ b/src/sim_codegen/linklist.rs
@@ -1,19 +1,19 @@
 //! `gen_linklist` emitter — extracted from `sim_codegen/mod.rs`. Follows
 //! the same submodule pattern as fsm.rs / pipeline.rs / ram.rs / fifo.rs.
 
-use super::{SimCodegen, SimModel};
 use super::*;
+use super::{SimCodegen, SimModel};
 
 impl<'a> SimCodegen<'a> {
     pub(crate) fn gen_linklist(&self, l: &crate::ast::LinklistDecl) -> SimModel {
-        use crate::ast::{LinklistKind, Direction};
+        use crate::ast::{Direction, LinklistKind};
 
-        let name  = &l.name.name;
+        let name = &l.name.name;
         let class = format!("V{name}");
 
         let depth = l.param_int("DEPTH", 8) as usize;
         let handle_mask = (1u64 << crate::width::clog2(depth as u64)) - 1;
-        let cnt_mask    = (1u64 << crate::width::clog2((depth + 1) as u64)) - 1;
+        let cnt_mask = (1u64 << crate::width::clog2((depth + 1) as u64)) - 1;
 
         // Multi-head linklist support — mirror of the SV codegen in
         // src/codegen.rs::emit_linklist. When NUM_HEADS > 1, head/tail
@@ -24,26 +24,39 @@ impl<'a> SimCodegen<'a> {
         let num_heads = crate::typecheck::linklist_num_heads(l) as usize;
         let multi_head = num_heads > 1;
         // Head-addressed ops need per-head indexing + latch.
-        let is_head_addr = |on: &str| matches!(
-            on,
-            "insert_head" | "insert_tail" | "insert_after" | "delete_head" | "delete"
-        );
+        let is_head_addr = |on: &str| {
+            matches!(
+                on,
+                "insert_head" | "insert_tail" | "insert_after" | "delete_head" | "delete"
+            )
+        };
         // C++ expressions for head_r / tail_r access given either the
         // live port (`<op>_req_head_idx`) or the latched reg.
         let head_r_at = |idx_expr: &str| -> String {
-            if multi_head { format!("_head_r[{idx_expr}]") } else { "_head_r".to_string() }
+            if multi_head {
+                format!("_head_r[{idx_expr}]")
+            } else {
+                "_head_r".to_string()
+            }
         };
         let tail_r_at = |idx_expr: &str| -> String {
-            if multi_head { format!("_tail_r[{idx_expr}]") } else { "_tail_r".to_string() }
+            if multi_head {
+                format!("_tail_r[{idx_expr}]")
+            } else {
+                "_tail_r".to_string()
+            }
         };
 
-        let data_te: Option<TypeExpr> = l.params.iter()
-            .find(|p| p.name.name == "DATA")
-            .and_then(|p| match &p.kind {
-                crate::ast::ParamKind::Type(te) => Some(te.clone()),
-                _ => None,
-            });
-        let data_cpp: String = data_te.as_ref()
+        let data_te: Option<TypeExpr> =
+            l.params
+                .iter()
+                .find(|p| p.name.name == "DATA")
+                .and_then(|p| match &p.kind {
+                    crate::ast::ParamKind::Type(te) => Some(te.clone()),
+                    _ => None,
+                });
+        let data_cpp: String = data_te
+            .as_ref()
             .map(|te| cpp_port_type_with_params(te, &l.params))
             .unwrap_or_else(|| "uint32_t".to_string());
 
@@ -70,18 +83,27 @@ impl<'a> SimCodegen<'a> {
 
         // ── Header ────────────────────────────────────────────────────────────
         let mut h = String::new();
-        h.push_str("#pragma once\n#include <cstdint>\n#include <cstring>\n#include \"verilated.h\"\n\n");
+        h.push_str(
+            "#pragma once\n#include <cstdint>\n#include <cstring>\n#include \"verilated.h\"\n\n",
+        );
         h.push_str(&format!("class {class} {{\npublic:\n"));
         h.push_str("  uint8_t clk;\n  uint8_t rst;\n");
         for op in &l.ops {
             for p in &op.ports {
-                h.push_str(&format!("  {} {}_{};\n", port_cpp_ty(&p.ty), op.name.name, p.name.name));
+                h.push_str(&format!(
+                    "  {} {}_{};\n",
+                    port_cpp_ty(&p.ty),
+                    op.name.name,
+                    p.name.name
+                ));
             }
         }
         for p in &l.ports {
             match p.name.name.as_str() {
                 "clk" | "rst" => {}
-                _ => { h.push_str(&format!("  {} {};\n", port_cpp_ty(&p.ty), p.name.name)); }
+                _ => {
+                    h.push_str(&format!("  {} {};\n", port_cpp_ty(&p.ty), p.name.name));
+                }
             }
         }
         h.push('\n');
@@ -95,11 +117,15 @@ impl<'a> SimCodegen<'a> {
         for p in &l.ports {
             match p.name.name.as_str() {
                 "clk" | "rst" => {}
-                _ => { ctor_inits.push(format!("{}(0)", p.name.name)); }
+                _ => {
+                    ctor_inits.push(format!("{}(0)", p.name.name));
+                }
             }
         }
         ctor_inits.extend([
-            "_clk_prev(0)".into(), "_fl_rdp(0)".into(), "_fl_wrp(0)".into(),
+            "_clk_prev(0)".into(),
+            "_fl_rdp(0)".into(),
+            "_fl_wrp(0)".into(),
             format!("_fl_cnt({depth})"),
         ]);
         // Scalar head/tail in single-head mode; arrays are zeroed in the
@@ -110,7 +136,9 @@ impl<'a> SimCodegen<'a> {
         }
         for op in &l.ops {
             let on = &op.name.name;
-            if op.latency > 1 { ctor_inits.push(format!("_ctrl_{on}_busy(0)")); }
+            if op.latency > 1 {
+                ctor_inits.push(format!("_ctrl_{on}_busy(0)"));
+            }
             if op.ports.iter().any(|p| p.name.name == "resp_valid") {
                 ctor_inits.push(format!("_ctrl_{on}_resp_v(0)"));
             }
@@ -131,10 +159,14 @@ impl<'a> SimCodegen<'a> {
             }
         }
         h.push_str(&format!("  {class}() : {} {{\n", ctor_inits.join(", ")));
-        h.push_str(&format!("    for (int _i = 0; _i < {depth}; _i++) _fl_mem[_i] = (uint8_t)_i;\n"));
+        h.push_str(&format!(
+            "    for (int _i = 0; _i < {depth}; _i++) _fl_mem[_i] = (uint8_t)_i;\n"
+        ));
         h.push_str("    memset(_data_mem, 0, sizeof(_data_mem));\n");
         h.push_str("    memset(_next_mem, 0, sizeof(_next_mem));\n");
-        if has_doubly { h.push_str("    memset(_prev_mem, 0, sizeof(_prev_mem));\n"); }
+        if has_doubly {
+            h.push_str("    memset(_prev_mem, 0, sizeof(_prev_mem));\n");
+        }
         if multi_head {
             h.push_str("    memset(_head_r, 0, sizeof(_head_r));\n");
             h.push_str("    memset(_tail_r, 0, sizeof(_tail_r));\n");
@@ -146,7 +178,9 @@ impl<'a> SimCodegen<'a> {
         h.push_str(&format!("  uint8_t _fl_mem[{depth}];\n"));
         h.push_str(&format!("  {data_cpp} _data_mem[{depth}];\n"));
         h.push_str(&format!("  uint8_t _next_mem[{depth}];\n"));
-        if has_doubly { h.push_str(&format!("  uint8_t _prev_mem[{depth}];\n")); }
+        if has_doubly {
+            h.push_str(&format!("  uint8_t _prev_mem[{depth}];\n"));
+        }
         h.push_str("  uint8_t _fl_rdp, _fl_wrp;\n  uint8_t _fl_cnt;\n");
         if multi_head {
             h.push_str(&format!("  uint8_t _head_r[{num_heads}];\n"));
@@ -159,12 +193,18 @@ impl<'a> SimCodegen<'a> {
         }
         for op in &l.ops {
             let on = &op.name.name;
-            if op.latency > 1 { h.push_str(&format!("  uint8_t _ctrl_{on}_busy;\n")); }
+            if op.latency > 1 {
+                h.push_str(&format!("  uint8_t _ctrl_{on}_busy;\n"));
+            }
             if op.ports.iter().any(|p| p.name.name == "resp_valid") {
                 h.push_str(&format!("  uint8_t _ctrl_{on}_resp_v;\n"));
             }
             for p in op.ports.iter().filter(|p| is_out_data(p)) {
-                h.push_str(&format!("  {} _ctrl_{on}_{};\n", port_cpp_ty(&p.ty), p.name.name));
+                h.push_str(&format!(
+                    "  {} _ctrl_{on}_{};\n",
+                    port_cpp_ty(&p.ty),
+                    p.name.name
+                ));
             }
             if on == "delete_head" || on == "delete" {
                 h.push_str(&format!("  uint8_t _ctrl_{on}_slot;\n"));
@@ -208,21 +248,24 @@ impl<'a> SimCodegen<'a> {
             cpp.push_str("  full   = (_fl_cnt == 0);\n");
         }
         if has_status("length") {
-            cpp.push_str(&format!("  length = (uint8_t)(({depth} - _fl_cnt) & {cnt_mask:#x});\n"));
+            cpp.push_str(&format!(
+                "  length = (uint8_t)(({depth} - _fl_cnt) & {cnt_mask:#x});\n"
+            ));
         }
         for op in &l.ops {
             let on = &op.name.name;
             // req_ready — only if the op declares it
             if op.ports.iter().any(|p| p.name.name == "req_ready") {
                 let rdy: String = match on.as_str() {
-                    "alloc"  => "(_fl_cnt != 0)".into(),
-                    "free"   => format!("(_fl_cnt != {depth})"),
-                    "insert_tail" | "insert_head" | "insert_after" =>
-                        format!("(!_ctrl_{on}_busy && _fl_cnt != 0)"),
-                    "delete_head" | "delete" if multi_head =>
-                        format!("(!_ctrl_{on}_busy && _length_r[{on}_req_head_idx] != 0)"),
-                    "delete_head" | "delete" =>
-                        format!("(!_ctrl_{on}_busy && _fl_cnt != {depth})"),
+                    "alloc" => "(_fl_cnt != 0)".into(),
+                    "free" => format!("(_fl_cnt != {depth})"),
+                    "insert_tail" | "insert_head" | "insert_after" => {
+                        format!("(!_ctrl_{on}_busy && _fl_cnt != 0)")
+                    }
+                    "delete_head" | "delete" if multi_head => {
+                        format!("(!_ctrl_{on}_busy && _length_r[{on}_req_head_idx] != 0)")
+                    }
+                    "delete_head" | "delete" => format!("(!_ctrl_{on}_busy && _fl_cnt != {depth})"),
                     _ => "1".into(),
                 };
                 cpp.push_str(&format!("  {on}_req_ready = {rdy};\n"));
@@ -232,7 +275,10 @@ impl<'a> SimCodegen<'a> {
                 cpp.push_str(&format!("  {on}_resp_valid = _ctrl_{on}_resp_v;\n"));
             }
             for p in op.ports.iter().filter(|p| is_out_data(p)) {
-                cpp.push_str(&format!("  {on}_{} = _ctrl_{on}_{};\n", p.name.name, p.name.name));
+                cpp.push_str(&format!(
+                    "  {on}_{} = _ctrl_{on}_{};\n",
+                    p.name.name, p.name.name
+                ));
             }
         }
         cpp.push_str("}\n\n");
@@ -245,7 +291,9 @@ impl<'a> SimCodegen<'a> {
         cpp.push_str("  _clk_prev = clk;\n");
         cpp.push_str("  if (!_rising) return;\n");
         cpp.push_str("  if (rst) {\n");
-        cpp.push_str(&format!("    for (int _i = 0; _i < {depth}; _i++) _fl_mem[_i] = (uint8_t)_i;\n"));
+        cpp.push_str(&format!(
+            "    for (int _i = 0; _i < {depth}; _i++) _fl_mem[_i] = (uint8_t)_i;\n"
+        ));
         cpp.push_str("    _fl_rdp = 0; _fl_wrp = 0;\n");
         cpp.push_str(&format!("    _fl_cnt = {depth};\n"));
         if multi_head {
@@ -255,7 +303,9 @@ impl<'a> SimCodegen<'a> {
         }
         for op in &l.ops {
             let on = &op.name.name;
-            if op.latency > 1 { cpp.push_str(&format!("    _ctrl_{on}_busy = 0;\n")); }
+            if op.latency > 1 {
+                cpp.push_str(&format!("    _ctrl_{on}_busy = 0;\n"));
+            }
             if op.ports.iter().any(|p| p.name.name == "resp_valid") {
                 cpp.push_str(&format!("    _ctrl_{on}_resp_v = 0;\n"));
             }
@@ -434,9 +484,21 @@ impl<'a> SimCodegen<'a> {
         cpp.push_str("  }\n}\n");
 
         let extra_sigs: Vec<(&str, &str, u32)> = vec![];
-        add_trace_to_simple_construct(&mut h, &mut cpp, &class, name, &l.ports, &extra_sigs, &l.params);
+        add_trace_to_simple_construct(
+            &mut h,
+            &mut cpp,
+            &class,
+            name,
+            &l.ports,
+            &extra_sigs,
+            &l.params,
+        );
         h.push_str("};\n");
 
-        SimModel { class_name: class, header: h, impl_: cpp }
+        SimModel {
+            class_name: class,
+            header: h,
+            impl_: cpp,
+        }
     }
 }

--- a/src/sim_codegen/mod.rs
+++ b/src/sim_codegen/mod.rs
@@ -22,12 +22,12 @@ use crate::typecheck::enum_width;
 // Per-construct emitters split out to keep this file from growing further.
 // Each submodule extends `impl SimCodegen` with a single `gen_*` entry
 // point and calls back into the shared helpers in this file via `super::`.
+mod cam;
 mod fifo;
 mod fsm;
 mod linklist;
 mod pipeline;
 mod ram;
-mod cam;
 pub mod thread_sim;
 
 // ── Public API ────────────────────────────────────────────────────────────────
@@ -88,7 +88,9 @@ impl SourceMap {
             let next_start = self.segments.get(i + 1).map(|s| s.0).unwrap_or(usize::MAX);
             if offset >= *start && offset < next_start {
                 let local = offset.saturating_sub(*start);
-                if local > src.len() { return None; }
+                if local > src.len() {
+                    return None;
+                }
                 let line = 1 + src[..local].matches('\n').count() as u32;
                 return Some((file.as_str(), line));
             }
@@ -122,7 +124,11 @@ pub(crate) struct CoverageRegistry {
 impl CoverageRegistry {
     pub fn alloc(&mut self, kind: &'static str, span_start: usize, label: String) -> usize {
         let idx = self.points.len();
-        self.points.push(CovPoint { kind, span_start, label });
+        self.points.push(CovPoint {
+            kind,
+            span_start,
+            label,
+        });
         idx
     }
 }
@@ -133,7 +139,21 @@ impl<'a> SimCodegen<'a> {
         source: &'a SourceFile,
         overload_map: HashMap<usize, usize>,
     ) -> Self {
-        Self { symbols, source, overload_map, check_uninit: false, inputs_start_uninit: false, check_uninit_ram: false, cdc_random: false, debug: false, debug_depth: 1, debug_fsm: false, coverage: false, coverage_dat: None, source_map: None }
+        Self {
+            symbols,
+            source,
+            overload_map,
+            check_uninit: false,
+            inputs_start_uninit: false,
+            check_uninit_ram: false,
+            cdc_random: false,
+            debug: false,
+            debug_depth: 1,
+            debug_fsm: false,
+            coverage: false,
+            coverage_dat: None,
+            source_map: None,
+        }
     }
 
     pub fn coverage(mut self, enabled: bool) -> Self {
@@ -143,7 +163,9 @@ impl<'a> SimCodegen<'a> {
 
     pub fn coverage_dat(mut self, path: Option<String>) -> Self {
         self.coverage_dat = path;
-        if self.coverage_dat.is_some() { self.coverage = true; }
+        if self.coverage_dat.is_some() {
+            self.coverage = true;
+        }
         self
     }
 
@@ -208,8 +230,16 @@ impl<'a> SimCodegen<'a> {
             let candidates: Vec<&FunctionDecl> = match i {
                 Item::Function(f) => vec![f],
                 Item::Package(p) => p.functions.iter().collect(),
-                Item::Module(m) => m.body.iter()
-                    .filter_map(|b| if let ModuleBodyItem::Function(f) = b { Some(f) } else { None })
+                Item::Module(m) => m
+                    .body
+                    .iter()
+                    .filter_map(|b| {
+                        if let ModuleBodyItem::Function(f) = b {
+                            Some(f)
+                        } else {
+                            None
+                        }
+                    })
                     .collect(),
                 _ => vec![],
             };
@@ -235,28 +265,37 @@ impl<'a> SimCodegen<'a> {
             for item in &self.source.items {
                 if let Item::Module(m) = item {
                     all_module_names.push(m.name.name.clone());
-                    let children: Vec<String> = m.body.iter()
-                        .filter_map(|b| if let ModuleBodyItem::Inst(inst) = b {
-                            Some(inst.module_name.name.clone())
-                        } else { None })
+                    let children: Vec<String> = m
+                        .body
+                        .iter()
+                        .filter_map(|b| {
+                            if let ModuleBodyItem::Inst(inst) = b {
+                                Some(inst.module_name.name.clone())
+                            } else {
+                                None
+                            }
+                        })
                         .collect();
                     children_map.insert(m.name.name.clone(), children);
                 }
             }
             // Root = modules not instantiated by any other module
-            let instantiated: std::collections::HashSet<String> = children_map.values()
+            let instantiated: std::collections::HashSet<String> = children_map
+                .values()
                 .flat_map(|v| v.iter().cloned())
                 .collect();
-            let roots: Vec<String> = all_module_names.into_iter()
+            let roots: Vec<String> = all_module_names
+                .into_iter()
                 .filter(|n| !instantiated.contains(n))
                 .collect();
             // BFS up to debug_depth levels
             let mut result: std::collections::HashSet<String> = std::collections::HashSet::new();
-            let mut queue: std::collections::VecDeque<(String, u32)> = roots.into_iter()
-                .map(|n| (n, 1u32))
-                .collect();
+            let mut queue: std::collections::VecDeque<(String, u32)> =
+                roots.into_iter().map(|n| (n, 1u32)).collect();
             while let Some((mod_name, depth)) = queue.pop_front() {
-                if depth > self.debug_depth { continue; }
+                if depth > self.debug_depth {
+                    continue;
+                }
                 result.insert(mod_name.clone());
                 if depth < self.debug_depth {
                     if let Some(children) = children_map.get(&mod_name) {
@@ -281,7 +320,9 @@ impl<'a> SimCodegen<'a> {
             if let Item::Module(m) = item {
                 // Interface stubs from `.archi`: real sim model lives
                 // alongside the .archi as a separately-built artifact.
-                if m.is_interface { continue; }
+                if m.is_interface {
+                    continue;
+                }
                 models.push(self.gen_module(
                     m,
                     debug_module_set.contains(m.name.name.as_str()),
@@ -292,7 +333,9 @@ impl<'a> SimCodegen<'a> {
                 // ConstructCommon-bearing variant (Fsm, Fifo, Ram, …).
                 // Same reason as Module: real sim model is built
                 // separately alongside the `.archi`.
-                if item.is_interface() { continue; }
+                if item.is_interface() {
+                    continue;
+                }
                 if let Some(model) = item.as_construct().emit_sim(self) {
                     models.push(model);
                 }
@@ -311,7 +354,9 @@ impl<'a> SimCodegen<'a> {
                 Item::Module(m) => {
                     // Skip interface stubs from `.archi`: the pybind wrapper
                     // for the real implementation is built separately.
-                    if m.is_interface { continue; }
+                    if m.is_interface {
+                        continue;
+                    }
                     if let Some(w) = self.emit_pybind_module(m) {
                         wrappers.push(w);
                     }
@@ -319,13 +364,17 @@ impl<'a> SimCodegen<'a> {
                 Item::Fsm(f) => {
                     // Skip interface stubs from `.archi`: pybind wrapper
                     // for the real implementation is built separately.
-                    if f.common.is_interface { continue; }
+                    if f.common.is_interface {
+                        continue;
+                    }
                     if let Some(w) = self.emit_pybind_fsm(f) {
                         wrappers.push(w);
                     }
                 }
                 Item::Counter(c) => {
-                    if c.common.is_interface { continue; }
+                    if c.common.is_interface {
+                        continue;
+                    }
                     if let Some(w) = self.emit_pybind_counter(c) {
                         wrappers.push(w);
                     }
@@ -352,7 +401,9 @@ impl<'a> SimCodegen<'a> {
             }
         }
         let mut stack: Vec<String> = Vec::new();
-        for p in &m.ports { push_named(&p.ty, &mut stack); }
+        for p in &m.ports {
+            push_named(&p.ty, &mut stack);
+        }
         for item in &m.body {
             if let ModuleBodyItem::RegDecl(r) = item {
                 push_named(&r.ty, &mut stack);
@@ -362,7 +413,9 @@ impl<'a> SimCodegen<'a> {
         while let Some(name) = stack.pop() {
             if used.insert(name.clone()) {
                 if let Some(sd) = all_structs.get(&name) {
-                    for f in &sd.fields { push_named(&f.ty, &mut stack); }
+                    for f in &sd.fields {
+                        push_named(&f.ty, &mut stack);
+                    }
                 }
             }
         }
@@ -387,7 +440,9 @@ impl<'a> SimCodegen<'a> {
         for p in &m.ports {
             if let Some(ref bi) = p.bus_info {
                 match bi.count.as_ref() {
-                    None => { bus_port_names.insert(p.name.name.clone()); }
+                    None => {
+                        bus_port_names.insert(p.name.name.clone());
+                    }
                     Some(count_expr) => {
                         let n = eval_const_expr_with_params(count_expr, &m.params) as u32;
                         for i in 0..n {
@@ -400,12 +455,19 @@ impl<'a> SimCodegen<'a> {
         }
 
         // Vec port info
-        let vec_port_infos: Vec<(String, String, u64, bool)> = m.ports.iter()
+        let vec_port_infos: Vec<(String, String, u64, bool)> = m
+            .ports
+            .iter()
             .filter(|p| p.bus_info.is_none())
             .filter_map(|p| {
                 if let Some((elem_ty, count_str)) = vec_array_info_with_params(&p.ty, &m.params) {
                     let count: u64 = count_str.parse().unwrap_or(0);
-                    Some((p.name.name.clone(), elem_ty, count, p.direction == Direction::In))
+                    Some((
+                        p.name.name.clone(),
+                        elem_ty,
+                        count,
+                        p.direction == Direction::In,
+                    ))
                 } else {
                     None
                 }
@@ -418,8 +480,12 @@ impl<'a> SimCodegen<'a> {
 
         // Regular scalar ports
         for p in &m.ports {
-            if p.bus_info.is_some() { continue; }
-            if vec_port_names.contains(&p.name.name) { continue; }
+            if p.bus_info.is_some() {
+                continue;
+            }
+            if vec_port_names.contains(&p.name.name) {
+                continue;
+            }
             let field = &p.name.name;
             let width = self.port_width(&p.ty);
             let is_signed = matches!(p.ty, TypeExpr::SInt(_));
@@ -429,7 +495,9 @@ impl<'a> SimCodegen<'a> {
                 // VlWide — generate lambda-based get/set
                 bindings.push(self.emit_wide_binding(&class, field, width));
             } else {
-                bindings.push(format!("        .def_readwrite(\"{field}\", &{class}::{field})"));
+                bindings.push(format!(
+                    "        .def_readwrite(\"{field}\", &{class}::{field})"
+                ));
             }
             port_info.push((field.clone(), width, is_signed, is_input, false, false));
         }
@@ -439,7 +507,9 @@ impl<'a> SimCodegen<'a> {
             let width = self.vec_elem_width(&m.ports, base_name);
             for i in 0..*count {
                 let field = format!("{base_name}_{i}");
-                bindings.push(format!("        .def_readwrite(\"{field}\", &{class}::{field})"));
+                bindings.push(format!(
+                    "        .def_readwrite(\"{field}\", &{class}::{field})"
+                ));
                 port_info.push((field, width, false, *is_input, false, false));
             }
         }
@@ -459,7 +529,9 @@ impl<'a> SimCodegen<'a> {
             if wide_names.contains(flat_name) {
                 bindings.push(self.emit_wide_binding(&class, flat_name, width));
             } else {
-                bindings.push(format!("        .def_readwrite(\"{flat_name}\", &{class}::{flat_name})"));
+                bindings.push(format!(
+                    "        .def_readwrite(\"{flat_name}\", &{class}::{flat_name})"
+                ));
             }
             port_info.push((flat_name.clone(), width, is_signed, true, false, false));
         }
@@ -470,7 +542,9 @@ impl<'a> SimCodegen<'a> {
             if let ModuleBodyItem::RegDecl(r) = item {
                 let rname = &r.name.name;
                 // Skip if it's also a port name (port regs already handled)
-                if m.ports.iter().any(|p| p.name.name == *rname) { continue; }
+                if m.ports.iter().any(|p| p.name.name == *rname) {
+                    continue;
+                }
                 let width = self.reg_width(&r.ty);
                 let is_signed = matches!(r.ty, TypeExpr::SInt(_));
                 let cpp_field = format!("_{rname}");
@@ -528,7 +602,9 @@ auto {helper_name}(const T& self) {{
                 ParamKind::EnumConst(enum_name) => {
                     if let Some(ref def) = p.default {
                         if let ExprKind::EnumVariant(_, variant) = &def.kind {
-                            if let Some(val) = resolve_enum_variant(&enum_map, enum_name, &variant.name) {
+                            if let Some(val) =
+                                resolve_enum_variant(&enum_map, enum_name, &variant.name)
+                            {
                                 let pname = &p.name.name;
                                 bindings.push(format!(
                                     "        .def_property_readonly_static(\"{pname}\", [](py::object) {{ return {val}ULL; }})"
@@ -547,12 +623,19 @@ auto {helper_name}(const T& self) {{
         // expose edge-sensitive eval() only. Bind compatibility shims so the
         // same pybind wrapper generator can target both model APIs.
         bindings.push(format!("        .def(\"eval\", &{class}::eval)"));
-        bindings.push(format!("        .def(\"eval_comb\", &arch_pybind_detail::eval_comb<{class}>)"));
-        bindings.push(format!("        .def(\"eval_posedge\", &arch_pybind_detail::eval_posedge<{class}>)"));
-        bindings.push(format!("        .def(\"run_cycles\", &arch_pybind_detail::run_cycles<{class}>)"));
+        bindings.push(format!(
+            "        .def(\"eval_comb\", &arch_pybind_detail::eval_comb<{class}>)"
+        ));
+        bindings.push(format!(
+            "        .def(\"eval_posedge\", &arch_pybind_detail::eval_posedge<{class}>)"
+        ));
+        bindings.push(format!(
+            "        .def(\"run_cycles\", &arch_pybind_detail::run_cycles<{class}>)"
+        ));
 
         // _port_info static method
-        let port_info_entries: Vec<String> = port_info.iter()
+        let port_info_entries: Vec<String> = port_info
+            .iter()
             .map(|(n, w, s, inp, par, int)| {
                 format!(
                     "            py::make_tuple(\"{n}\", {w}, {}, {}, {}, {})",
@@ -575,9 +658,13 @@ auto {helper_name}(const T& self) {{
         let mut all_structs: HashMap<String, &StructDecl> = HashMap::new();
         for item in &self.source.items {
             match item {
-                Item::Struct(s) => { all_structs.insert(s.name.name.clone(), s); }
+                Item::Struct(s) => {
+                    all_structs.insert(s.name.name.clone(), s);
+                }
                 Item::Package(p) => {
-                    for s in &p.structs { all_structs.insert(s.name.name.clone(), s); }
+                    for s in &p.structs {
+                        all_structs.insert(s.name.name.clone(), s);
+                    }
                 }
                 _ => {}
             }
@@ -585,16 +672,23 @@ auto {helper_name}(const T& self) {{
         let used_structs = Self::collect_used_structs(m, &all_structs);
         let mut struct_bindings = String::new();
         // Iterate in source order (not HashMap order) for stable output.
-        let ordered: Vec<&StructDecl> = self.source.items.iter().flat_map(|item| -> Vec<&StructDecl> {
-            match item {
-                Item::Struct(s) => vec![s],
-                Item::Package(p) => p.structs.iter().collect(),
-                _ => vec![],
-            }
-        }).collect();
+        let ordered: Vec<&StructDecl> = self
+            .source
+            .items
+            .iter()
+            .flat_map(|item| -> Vec<&StructDecl> {
+                match item {
+                    Item::Struct(s) => vec![s],
+                    Item::Package(p) => p.structs.iter().collect(),
+                    _ => vec![],
+                }
+            })
+            .collect();
         for s in ordered {
             let sname = &s.name.name;
-            if !used_structs.contains(sname) { continue; }
+            if !used_structs.contains(sname) {
+                continue;
+            }
             // `py::module_local()` scopes the struct type to this extension
             // module so multiple pybind builds sharing struct names (e.g. two
             // cpuif variants of the same design) can coexist in one process.
@@ -611,7 +705,7 @@ auto {helper_name}(const T& self) {{
         }
 
         let cpp = format!(
-r#"// Auto-generated pybind11 wrapper for {class}
+            r#"// Auto-generated pybind11 wrapper for {class}
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 #include <cstdint>
@@ -714,7 +808,7 @@ PYBIND11_MODULE({pybind_module}, m) {{
     fn emit_wide_binding(&self, class: &str, field: &str, width: u32) -> String {
         let words = (width + 31) / 32;
         format!(
-r#"        .def_property("{field}",
+            r#"        .def_property("{field}",
             []({class}& self) -> uint64_t {{
                 uint64_t v = 0;
                 for (int i = std::min({words}u, 2u) - 1; i >= 0; i--)
@@ -1013,8 +1107,14 @@ static inline uint64_t _arch_f32_to_uint(uint32_t b, int bits){
             crate::FpCompat::Cuda => prelude
                 .replace("return 0x7FC00000u;", "return 0x7FFFFFFFu;")
                 .replace("return 0x7FC0u;", "return 0x7FFFu;")
-                .replace("if (std::isnan(f)) return INT64_MAX;", "if (std::isnan(f)) return 0;")
-                .replace("if (std::isnan(f)) return UINT64_MAX;", "if (std::isnan(f)) return 0;"),
+                .replace(
+                    "if (std::isnan(f)) return INT64_MAX;",
+                    "if (std::isnan(f)) return 0;",
+                )
+                .replace(
+                    "if (std::isnan(f)) return UINT64_MAX;",
+                    "if (std::isnan(f)) return 0;",
+                ),
         }
     }
 
@@ -1041,7 +1141,8 @@ extern "C" FILE* _arch_cov_dat_open(const char* path) {
     }
     return f;
 }
-"##.to_string()
+"##
+        .to_string()
     }
 }
 
@@ -1049,10 +1150,10 @@ extern "C" FILE* _arch_cov_dat_open(const char* path) {
 
 /// A signal to be traced in VCD output.
 pub(crate) struct TraceSignal {
-    pub(crate) vcd_name: String,    // display name in VCD scope
-    pub(crate) cpp_expr: String,    // C++ expression to read the value
-    pub(crate) width: u32,          // bit width
-    pub(crate) is_wide: bool,       // true if VlWide<N> type
+    pub(crate) vcd_name: String, // display name in VCD scope
+    pub(crate) cpp_expr: String, // C++ expression to read the value
+    pub(crate) width: u32,       // bit width
+    pub(crate) is_wide: bool,    // true if VlWide<N> type
 }
 
 /// Generate a short VCD identifier from a signal index.
@@ -1064,7 +1165,11 @@ fn vcd_id(index: usize) -> String {
 
 /// Emit trace_open / trace_dump / trace_close C++ method implementations.
 /// Returns (header_declarations, cpp_implementations).
-pub(crate) fn emit_trace_methods(class: &str, module_name: &str, signals: &[TraceSignal]) -> (String, String) {
+pub(crate) fn emit_trace_methods(
+    class: &str,
+    module_name: &str,
+    signals: &[TraceSignal],
+) -> (String, String) {
     let mut h = String::new();
     let mut cpp = String::new();
 
@@ -1073,14 +1178,23 @@ pub(crate) fn emit_trace_methods(class: &str, module_name: &str, signals: &[Trac
     h.push_str("  void trace_close();\n");
 
     // ── trace_open ──
-    cpp.push_str(&format!("void {class}::trace_open(const char* filename) {{\n"));
+    cpp.push_str(&format!(
+        "void {class}::trace_open(const char* filename) {{\n"
+    ));
     cpp.push_str("  _trace_fp = fopen(filename, \"w\");\n");
     cpp.push_str("  if (!_trace_fp) return;\n");
     cpp.push_str("  fprintf(_trace_fp, \"$timescale 1ns $end\\n\");\n");
-    cpp.push_str(&format!("  fprintf(_trace_fp, \"$scope module {} $end\\n\");\n", module_name));
+    cpp.push_str(&format!(
+        "  fprintf(_trace_fp, \"$scope module {} $end\\n\");\n",
+        module_name
+    ));
     for (i, sig) in signals.iter().enumerate() {
         let id = vcd_id(i);
-        let kind = if sig.vcd_name.starts_with('_') { "reg" } else { "wire" };
+        let kind = if sig.vcd_name.starts_with('_') {
+            "reg"
+        } else {
+            "wire"
+        };
         cpp.push_str(&format!(
             "  fprintf(_trace_fp, \"$var {} {} {} {} $end\\n\");\n",
             kind, sig.width, id, sig.vcd_name
@@ -1150,8 +1264,12 @@ fn collect_trace_signals(
     // Ports (skip bus ports and Vec ports — flattened signals added separately;
     // also skip struct/enum-typed ports, which can't be bit-shifted scalar-style)
     for p in ports {
-        if p.bus_info.is_some() { continue; }
-        if matches!(p.ty, TypeExpr::Vec(..) | TypeExpr::Named(_)) { continue; }
+        if p.bus_info.is_some() {
+            continue;
+        }
+        if matches!(p.ty, TypeExpr::Vec(..) | TypeExpr::Named(_)) {
+            continue;
+        }
         let name = &p.name.name;
         let width = type_width_with_params(&p.ty, params);
         let is_wide = wide_names.contains(name.as_str());
@@ -1164,7 +1282,9 @@ fn collect_trace_signals(
     }
     // Flattened bus signals
     for (flat_name, flat_ty) in bus_flat {
-        if matches!(flat_ty, TypeExpr::Vec(..) | TypeExpr::Named(_)) { continue; }
+        if matches!(flat_ty, TypeExpr::Vec(..) | TypeExpr::Named(_)) {
+            continue;
+        }
         let width = type_width_with_params(flat_ty, params);
         let is_wide = wide_names.contains(flat_name.as_str());
         sigs.push(TraceSignal {
@@ -1181,19 +1301,27 @@ fn collect_trace_signals(
     // Regs >64 bits use _arch_u128, not VlWide, so is_wide = false.
     for item in body {
         if let ModuleBodyItem::RegDecl(r) = item {
-            if matches!(r.ty, TypeExpr::Named(_)) { continue; }
+            if matches!(r.ty, TypeExpr::Named(_)) {
+                continue;
+            }
             let name = &r.name.name;
             if let TypeExpr::Vec(elem, count_expr) = &r.ty {
                 // Skip Vec-of-named (struct/enum element); per-element
                 // bit-shift only works for scalar elements.
-                if matches!(elem.as_ref(), TypeExpr::Named(_)) { continue; }
+                if matches!(elem.as_ref(), TypeExpr::Named(_)) {
+                    continue;
+                }
                 let elem_width = type_width_with_params(elem, params);
-                if elem_width == 0 || elem_width > 64 { continue; }
+                if elem_width == 0 || elem_width > 64 {
+                    continue;
+                }
                 // Use params-aware count (matches the field-decl path
                 // at line 4091); bare eval_const_expr returns 0 for
                 // param-based sizes, which would skip the trace silently.
                 let count = eval_const_expr_with_params(count_expr, params);
-                if count == 0 { continue; }
+                if count == 0 {
+                    continue;
+                }
                 for i in 0..count {
                     sigs.push(TraceSignal {
                         vcd_name: format!("{name}[{i}]"),
@@ -1221,13 +1349,19 @@ fn collect_trace_signals(
         match item {
             ModuleBodyItem::LetBinding(l) => {
                 // ty=None means assignment to existing port/wire — already traced, skip
-                if l.ty.is_none() { continue; }
+                if l.ty.is_none() {
+                    continue;
+                }
                 let name = &l.name.name;
-                if l.ty.as_ref().map_or(false,
-                    |t| matches!(t, TypeExpr::Vec(..) | TypeExpr::Named(_))) { continue; }
-                let width = l.ty.as_ref().map(|t| type_width_with_params(t, params)).unwrap_or(
-                    widths.get(name.as_str()).copied().unwrap_or(32)
-                );
+                if l.ty.as_ref().map_or(false, |t| {
+                    matches!(t, TypeExpr::Vec(..) | TypeExpr::Named(_))
+                }) {
+                    continue;
+                }
+                let width =
+                    l.ty.as_ref()
+                        .map(|t| type_width_with_params(t, params))
+                        .unwrap_or(widths.get(name.as_str()).copied().unwrap_or(32));
                 sigs.push(TraceSignal {
                     vcd_name: name.clone(),
                     cpp_expr: format!("_let_{name}"),
@@ -1236,7 +1370,9 @@ fn collect_trace_signals(
                 });
             }
             ModuleBodyItem::WireDecl(w) => {
-                if matches!(w.ty, TypeExpr::Vec(..) | TypeExpr::Named(_)) { continue; }
+                if matches!(w.ty, TypeExpr::Vec(..) | TypeExpr::Named(_)) {
+                    continue;
+                }
                 let name = &w.name.name;
                 let width = type_width_with_params(&w.ty, params);
                 sigs.push(TraceSignal {
@@ -1290,7 +1426,7 @@ fn collect_trace_signals(
             (UInt<PARAM>, Vec<_, PARAM>). See arch-com#447 §1 and PR #463 \
             extending #458 to the sibling helper cluster."
 )]
-#[allow(dead_code)]  // intentional landmine: present so new callers
+#[allow(dead_code)] // intentional landmine: present so new callers
                     // surface a deprecation warning at PR review time.
 fn type_width(ty: &TypeExpr) -> u32 {
     type_width_with_params(ty, &[])
@@ -1307,7 +1443,9 @@ fn type_width_with_params(ty: &TypeExpr, params: &[ParamDecl]) -> u32 {
         TypeExpr::Bit => 1,
         TypeExpr::Clock(_) => 1,
         TypeExpr::Reset { .. } => 1,
-        TypeExpr::Vec(elem, count) => type_width_with_params(elem, params) * eval_width_with_params(count, params),
+        TypeExpr::Vec(elem, count) => {
+            type_width_with_params(elem, params) * eval_width_with_params(count, params)
+        }
         _ => 32,
     }
 }
@@ -1335,8 +1473,12 @@ fn add_trace_to_simple_construct(
     // this footgun.
     let mut signals = Vec::new();
     for p in ports {
-        if matches!(p.ty, TypeExpr::Vec(..)) { continue; }  // handled as flat via extra_signals
-        if p.bus_info.is_some() { continue; }                // bus ports flattened via extra_signals
+        if matches!(p.ty, TypeExpr::Vec(..)) {
+            continue;
+        } // handled as flat via extra_signals
+        if p.bus_info.is_some() {
+            continue;
+        } // bus ports flattened via extra_signals
         let width = type_width_with_params(&p.ty, params);
         signals.push(TraceSignal {
             vcd_name: p.name.name.clone(),
@@ -1375,7 +1517,11 @@ fn eval_width(expr: &Expr) -> u32 {
         ExprKind::Literal(LitKind::Hex(n)) => *n as u32,
         ExprKind::Clog2(inner) => {
             let v = eval_width(inner);
-            if v <= 1 { 1 } else { 32 - (v - 1).leading_zeros() }
+            if v <= 1 {
+                1
+            } else {
+                32 - (v - 1).leading_zeros()
+            }
         }
         _ => 32,
     }
@@ -1389,8 +1535,11 @@ fn eval_width(expr: &Expr) -> u32 {
 /// preserves prior conservative-32 behavior).
 fn eval_width_in(expr: &Expr, ctx: &Ctx) -> u32 {
     let folded = eval_const_expr_with_params(expr, ctx.params);
-    if folded != 0 || matches!(&expr.kind,
-        ExprKind::Literal(LitKind::Dec(0)) | ExprKind::Literal(LitKind::Hex(0)))
+    if folded != 0
+        || matches!(
+            &expr.kind,
+            ExprKind::Literal(LitKind::Dec(0)) | ExprKind::Literal(LitKind::Hex(0))
+        )
     {
         folded as u32
     } else {
@@ -1399,19 +1548,21 @@ fn eval_width_in(expr: &Expr, ctx: &Ctx) -> u32 {
 }
 
 /// Number of 32-bit words needed for `bits` bits.
-fn wide_words(bits: u32) -> u32 { (bits + 31) / 32 }
+fn wide_words(bits: u32) -> u32 {
+    (bits + 31) / 32
+}
 
 /// True if a signal width requires a wide (VlWide) type.
-fn is_wide_bits(bits: u32) -> bool { bits > 64 }
+fn is_wide_bits(bits: u32) -> bool {
+    bits > 64
+}
 
 /// C++ type for a public port field.
-#[deprecated(
-    note = "use `cpp_port_type_with_params(.., &params)` — the bare form \
+#[deprecated(note = "use `cpp_port_type_with_params(.., &params)` — the bare form \
             silently buckets `UInt<PARAM>` into uint32_t even when the param \
             resolves to a wider value. See arch-com#447 §1 and PR #463 \
-            extending #458 to the sibling helper cluster."
-)]
-#[allow(dead_code)]  // intentional landmine: present so new callers
+            extending #458 to the sibling helper cluster.")]
+#[allow(dead_code)] // intentional landmine: present so new callers
                     // surface a deprecation warning at PR review time.
 fn cpp_port_type(ty: &TypeExpr) -> String {
     cpp_port_type_with_params(ty, &[])
@@ -1428,15 +1579,23 @@ fn cpp_port_type_with_params(ty: &TypeExpr, params: &[ParamDecl]) -> String {
     match ty {
         TypeExpr::UInt(w) => {
             let b = eval_width_with_params(w, params);
-            if is_wide_bits(b) { format!("VlWide<{}>", wide_words(b)) }
-            else { cpp_uint(b).to_string() }
+            if is_wide_bits(b) {
+                format!("VlWide<{}>", wide_words(b))
+            } else {
+                cpp_uint(b).to_string()
+            }
         }
         TypeExpr::SInt(w) => {
             let b = eval_width_with_params(w, params);
-            if is_wide_bits(b) { format!("VlWide<{}>", wide_words(b)) }
-            else { cpp_sint(b).to_string() }
+            if is_wide_bits(b) {
+                format!("VlWide<{}>", wide_words(b))
+            } else {
+                cpp_sint(b).to_string()
+            }
         }
-        TypeExpr::Bool | TypeExpr::Bit | TypeExpr::Clock(_) | TypeExpr::Reset(..) => "uint8_t".to_string(),
+        TypeExpr::Bool | TypeExpr::Bit | TypeExpr::Clock(_) | TypeExpr::Reset(..) => {
+            "uint8_t".to_string()
+        }
         // Floats are carried as their raw bit pattern in an unsigned integer
         // (FP32 → uint32_t, BF16 → uint16_t); arithmetic goes through the
         // `_arch_fp.h` helpers, never C++ float operators on the storage.
@@ -1453,8 +1612,11 @@ fn cpp_port_type_with_params(ty: &TypeExpr, params: &[ParamDecl]) -> String {
 /// fold (preserving prior conservative-32 behavior). arch-com#330.
 fn eval_width_with_params(expr: &Expr, params: &[ParamDecl]) -> u32 {
     let folded = eval_const_expr_with_params(expr, params);
-    if folded != 0 || matches!(&expr.kind,
-        ExprKind::Literal(LitKind::Dec(0)) | ExprKind::Literal(LitKind::Hex(0)))
+    if folded != 0
+        || matches!(
+            &expr.kind,
+            ExprKind::Literal(LitKind::Dec(0)) | ExprKind::Literal(LitKind::Hex(0))
+        )
     {
         folded as u32
     } else {
@@ -1489,10 +1651,7 @@ fn subst_expr_sim(expr: &Expr, params: &HashMap<String, &Expr>) -> Expr {
             Box::new(subst_expr_sim(l, params)),
             Box::new(subst_expr_sim(r, params)),
         ),
-        ExprKind::Unary(op, e) => ExprKind::Unary(
-            *op,
-            Box::new(subst_expr_sim(e, params)),
-        ),
+        ExprKind::Unary(op, e) => ExprKind::Unary(*op, Box::new(subst_expr_sim(e, params))),
         ExprKind::Ternary(c, t, e) => ExprKind::Ternary(
             Box::new(subst_expr_sim(c, params)),
             Box::new(subst_expr_sim(t, params)),
@@ -1505,7 +1664,11 @@ fn subst_expr_sim(expr: &Expr, params: &HashMap<String, &Expr>) -> Expr {
         ),
         _ => return expr.clone(),
     };
-    Expr { kind, span: expr.span, parenthesized: expr.parenthesized }
+    Expr {
+        kind,
+        span: expr.span,
+        parenthesized: expr.parenthesized,
+    }
 }
 
 /// Return flattened bus port signals with direction: Vec<(flat_name, Direction, TypeExpr)>.
@@ -1518,7 +1681,9 @@ fn flatten_bus_port_with_dir(
 ) -> Vec<(String, Direction, TypeExpr)> {
     let bus_name = &bi.bus_name.name;
     if let Some((crate::resolve::Symbol::Bus(info), _)) = symbols.globals.get(bus_name) {
-        let mut param_map: HashMap<String, &Expr> = info.params.iter()
+        let mut param_map: HashMap<String, &Expr> = info
+            .params
+            .iter()
             .filter_map(|pd| pd.default.as_ref().map(|d| (pd.name.name.clone(), d)))
             .collect();
         for pa in &bi.params {
@@ -1542,7 +1707,10 @@ fn flatten_bus_port_with_dir(
                 let subst_ty = subst_type_expr_sim(sty, &param_map);
                 // Target perspective flips all signal directions
                 let dir = if is_target {
-                    match sdir { Direction::In => Direction::Out, Direction::Out => Direction::In }
+                    match sdir {
+                        Direction::In => Direction::Out,
+                        Direction::Out => Direction::In,
+                    }
                 } else {
                     *sdir
                 };
@@ -1588,18 +1756,25 @@ fn expand_bus_connections(
     // `param NAME = ...` overrides applied) so that
     // `port chans: initiator Vec<B, N>;` with a param-driven N folds to a
     // concrete element count at the call site.
-    let (target_ports, target_params): (Option<&[PortDecl]>, Vec<ParamDecl>) = source.items.iter()
+    let (target_ports, target_params): (Option<&[PortDecl]>, Vec<ParamDecl>) = source
+        .items
+        .iter()
         .find_map(|item| match item {
-            Item::Module(m) if m.name.name == inst.module_name.name =>
-                Some((Some(m.ports.as_slice()), m.params.clone())),
-            Item::Fsm(f) if f.name.name == inst.module_name.name =>
-                Some((Some(f.ports.as_slice()), f.common.params.clone())),
+            Item::Module(m) if m.name.name == inst.module_name.name => {
+                Some((Some(m.ports.as_slice()), m.params.clone()))
+            }
+            Item::Fsm(f) if f.name.name == inst.module_name.name => {
+                Some((Some(f.ports.as_slice()), f.common.params.clone()))
+            }
             _ => None,
         })
         .unwrap_or((None, Vec::new()));
     let mut child_params_overridden = target_params.clone();
     for pa in &inst.param_assigns {
-        if let Some(p) = child_params_overridden.iter_mut().find(|p| p.name.name == pa.name.name) {
+        if let Some(p) = child_params_overridden
+            .iter_mut()
+            .find(|p| p.name.name == pa.name.name)
+        {
             p.default = Some(pa.value.clone());
         }
     }
@@ -1611,12 +1786,24 @@ fn expand_bus_connections(
                     let bus = bi.bus_name.name.as_str();
                     match bi.count.as_ref() {
                         None => {
-                            v.push((p.name.name.clone(), bus, bi.perspective, bi.params.as_slice()));
+                            v.push((
+                                p.name.name.clone(),
+                                bus,
+                                bi.perspective,
+                                bi.params.as_slice(),
+                            ));
                         }
                         Some(count_expr) => {
-                            let n = eval_const_expr_with_params(count_expr, &child_params_overridden) as u32;
+                            let n =
+                                eval_const_expr_with_params(count_expr, &child_params_overridden)
+                                    as u32;
                             for i in 0..n {
-                                v.push((format!("{}_{}", p.name.name, i), bus, bi.perspective, bi.params.as_slice()));
+                                v.push((
+                                    format!("{}_{}", p.name.name, i),
+                                    bus,
+                                    bi.perspective,
+                                    bi.params.as_slice(),
+                                ));
                             }
                         }
                     }
@@ -1635,8 +1822,11 @@ fn expand_bus_connections(
             for p in ports {
                 if let Some(bi) = p.bus_info.as_ref() {
                     if let Some(count_expr) = bi.count.as_ref() {
-                        let n = eval_const_expr_with_params(count_expr, &child_params_overridden) as u32;
-                        if n > 0 { v.push((p.name.name.clone(), n)); }
+                        let n = eval_const_expr_with_params(count_expr, &child_params_overridden)
+                            as u32;
+                        if n > 0 {
+                            v.push((p.name.name.clone(), n));
+                        }
                     }
                 }
             }
@@ -1646,87 +1836,138 @@ fn expand_bus_connections(
     // Parent-side Vec<Bus,N> port and wire names → counts. Used together
     // with `target_vec_of_bus_ports` to detect a whole-vec connection
     // `chans -> w` where both sides are arrays.
-    let parent_vec_of_bus_wires: HashMap<String, u32> = m.body.iter()
-        .filter_map(|i| if let ModuleBodyItem::WireDecl(w) = i {
-            if let TypeExpr::Vec(elem, size_expr) = &w.ty {
-                if let TypeExpr::Named(id) = elem.as_ref() {
-                    if matches!(symbols.globals.get(&id.name), Some((crate::resolve::Symbol::Bus(_), _))) {
-                        let n = eval_const_expr_with_params(size_expr, &m.params) as u32;
-                        if n > 0 { return Some((w.name.name.clone(), n)); }
-                    }
-                }
-            }
-            None
-        } else { None })
-        .collect();
-    // 2D bus wires: `wire edges: Vec<Vec<B, N>, M>;` → (M, N).
-    // Used by the whole-row inst connection expansion `outs -> edges[i]`,
-    // where `edges[i]` is a row (Vec<B,N>) inside a 2D wire.
-    let parent_vec_of_bus_wires_2d: HashMap<String, (u32, u32)> = m.body.iter()
-        .filter_map(|i| if let ModuleBodyItem::WireDecl(w) = i {
-            if let TypeExpr::Vec(outer_elem, outer_size) = &w.ty {
-                if let TypeExpr::Vec(inner_elem, inner_size) = outer_elem.as_ref() {
-                    if let TypeExpr::Named(id) = inner_elem.as_ref() {
-                        if matches!(symbols.globals.get(&id.name), Some((crate::resolve::Symbol::Bus(_), _))) {
-                            let m_n = eval_const_expr_with_params(outer_size, &m.params) as u32;
-                            let n_n = eval_const_expr_with_params(inner_size, &m.params) as u32;
-                            if m_n > 0 && n_n > 0 {
-                                return Some((w.name.name.clone(), (m_n, n_n)));
+    let parent_vec_of_bus_wires: HashMap<String, u32> = m
+        .body
+        .iter()
+        .filter_map(|i| {
+            if let ModuleBodyItem::WireDecl(w) = i {
+                if let TypeExpr::Vec(elem, size_expr) = &w.ty {
+                    if let TypeExpr::Named(id) = elem.as_ref() {
+                        if matches!(
+                            symbols.globals.get(&id.name),
+                            Some((crate::resolve::Symbol::Bus(_), _))
+                        ) {
+                            let n = eval_const_expr_with_params(size_expr, &m.params) as u32;
+                            if n > 0 {
+                                return Some((w.name.name.clone(), n));
                             }
                         }
                     }
                 }
+                None
+            } else {
+                None
             }
-            None
-        } else { None })
+        })
         .collect();
-    let parent_vec_of_bus_ports: HashMap<String, u32> = m.ports.iter()
+    // 2D bus wires: `wire edges: Vec<Vec<B, N>, M>;` → (M, N).
+    // Used by the whole-row inst connection expansion `outs -> edges[i]`,
+    // where `edges[i]` is a row (Vec<B,N>) inside a 2D wire.
+    let parent_vec_of_bus_wires_2d: HashMap<String, (u32, u32)> = m
+        .body
+        .iter()
+        .filter_map(|i| {
+            if let ModuleBodyItem::WireDecl(w) = i {
+                if let TypeExpr::Vec(outer_elem, outer_size) = &w.ty {
+                    if let TypeExpr::Vec(inner_elem, inner_size) = outer_elem.as_ref() {
+                        if let TypeExpr::Named(id) = inner_elem.as_ref() {
+                            if matches!(
+                                symbols.globals.get(&id.name),
+                                Some((crate::resolve::Symbol::Bus(_), _))
+                            ) {
+                                let m_n = eval_const_expr_with_params(outer_size, &m.params) as u32;
+                                let n_n = eval_const_expr_with_params(inner_size, &m.params) as u32;
+                                if m_n > 0 && n_n > 0 {
+                                    return Some((w.name.name.clone(), (m_n, n_n)));
+                                }
+                            }
+                        }
+                    }
+                }
+                None
+            } else {
+                None
+            }
+        })
+        .collect();
+    let parent_vec_of_bus_ports: HashMap<String, u32> = m
+        .ports
+        .iter()
         .filter_map(|p| {
             let bi = p.bus_info.as_ref()?;
             let count_expr = bi.count.as_ref()?;
             let n = eval_const_expr_with_params(count_expr, &m.params) as u32;
-            if n > 0 { Some((p.name.name.clone(), n)) } else { None }
+            if n > 0 {
+                Some((p.name.name.clone(), n))
+            } else {
+                None
+            }
         })
         .collect();
     // Pre-expand whole-vec inst connections (`chans -> w`) into N per-element
     // bus connections (`chans_0 -> w[0]; chans_1 -> w[1]; ...`). The body
     // loop below then expands each of those into per-signal connections via
     // the existing scalar+indexed paths.
-    let inst_connections: Vec<crate::ast::Connection> = inst.connections.iter()
+    let inst_connections: Vec<crate::ast::Connection> = inst
+        .connections
+        .iter()
         .flat_map(|c| {
-            if let Some((_, n)) = target_vec_of_bus_ports.iter().find(|(pn, _)| pn == &c.port_name.name) {
+            if let Some((_, n)) = target_vec_of_bus_ports
+                .iter()
+                .find(|(pn, _)| pn == &c.port_name.name)
+            {
                 // Whole-row connection into a 2D bus wire: `outs -> edges[m]`,
                 // where outs is Vec<B,N>, edges is Vec<Vec<B,N>,M>, m is a
                 // literal (or static-unrolled loop var). Expand to N per-element
                 // connections `outs[j] -> edges[m][j]`.
                 if let ExprKind::Index(arr, idx) = &c.signal.kind {
                     if let ExprKind::Ident(parent_name) = &arr.kind {
-                        if let Some((_m_n, n_n)) = parent_vec_of_bus_wires_2d.get(parent_name).copied() {
+                        if let Some((_m_n, n_n)) =
+                            parent_vec_of_bus_wires_2d.get(parent_name).copied()
+                        {
                             if let ExprKind::Literal(LitKind::Dec(m_idx)) = &idx.kind {
                                 if (n_n as u32) == *n {
-                                    return (0..*n).map(|j| {
-                                        let port_j = Ident::new(format!("{}_{}", c.port_name.name, j), c.port_name.span);
-                                        let parent_expr = Expr::new(
-                                            ExprKind::Index(
-                                                Box::new(Expr::new(
-                                                    ExprKind::Index(
-                                                        Box::new(Expr::new(ExprKind::Ident(parent_name.clone()), c.signal.span)),
-                                                        Box::new(Expr::new(ExprKind::Literal(LitKind::Dec(*m_idx)), c.signal.span)),
-                                                    ),
-                                                    c.signal.span,
-                                                )),
-                                                Box::new(Expr::new(ExprKind::Literal(LitKind::Dec(j as u64)), c.signal.span)),
-                                            ),
-                                            c.signal.span,
-                                        );
-                                        crate::ast::Connection {
-                                            port_name: port_j,
-                                            direction: c.direction,
-                                            signal: parent_expr,
-                                            reset_override: None,
-                                            span: c.span,
-                                        }
-                                    }).collect::<Vec<_>>();
+                                    return (0..*n)
+                                        .map(|j| {
+                                            let port_j = Ident::new(
+                                                format!("{}_{}", c.port_name.name, j),
+                                                c.port_name.span,
+                                            );
+                                            let parent_expr = Expr::new(
+                                                ExprKind::Index(
+                                                    Box::new(Expr::new(
+                                                        ExprKind::Index(
+                                                            Box::new(Expr::new(
+                                                                ExprKind::Ident(
+                                                                    parent_name.clone(),
+                                                                ),
+                                                                c.signal.span,
+                                                            )),
+                                                            Box::new(Expr::new(
+                                                                ExprKind::Literal(LitKind::Dec(
+                                                                    *m_idx,
+                                                                )),
+                                                                c.signal.span,
+                                                            )),
+                                                        ),
+                                                        c.signal.span,
+                                                    )),
+                                                    Box::new(Expr::new(
+                                                        ExprKind::Literal(LitKind::Dec(j as u64)),
+                                                        c.signal.span,
+                                                    )),
+                                                ),
+                                                c.signal.span,
+                                            );
+                                            crate::ast::Connection {
+                                                port_name: port_j,
+                                                direction: c.direction,
+                                                signal: parent_expr,
+                                                reset_override: None,
+                                                span: c.span,
+                                            }
+                                        })
+                                        .collect::<Vec<_>>();
                                 }
                             }
                         }
@@ -1736,30 +1977,44 @@ fn expand_bus_connections(
                     let parent_is_vob_wire = parent_vec_of_bus_wires.contains_key(parent_name);
                     let parent_is_vob_port = parent_vec_of_bus_ports.contains_key(parent_name);
                     if parent_is_vob_wire || parent_is_vob_port {
-                        return (0..*n).map(|i| {
-                            let port_i = Ident::new(format!("{}_{}", c.port_name.name, i), c.port_name.span);
-                            // Wire: emit Index(Ident(w), i) so downstream sees a
-                            // bus-wire-array element. Port: emit Ident("w_<i>") so
-                            // it lands at the flat per-element port name on the parent.
-                            let parent_expr = if parent_is_vob_wire {
-                                Expr::new(
-                                    ExprKind::Index(
-                                        Box::new(Expr::new(ExprKind::Ident(parent_name.clone()), c.signal.span)),
-                                        Box::new(Expr::new(ExprKind::Literal(LitKind::Dec(i as u64)), c.signal.span)),
-                                    ),
-                                    c.signal.span,
-                                )
-                            } else {
-                                Expr::new(ExprKind::Ident(format!("{}_{}", parent_name, i)), c.signal.span)
-                            };
-                            crate::ast::Connection {
-                                port_name: port_i,
-                                direction: c.direction,
-                                signal: parent_expr,
-                                reset_override: None,
-                                span: c.span,
-                            }
-                        }).collect::<Vec<_>>();
+                        return (0..*n)
+                            .map(|i| {
+                                let port_i = Ident::new(
+                                    format!("{}_{}", c.port_name.name, i),
+                                    c.port_name.span,
+                                );
+                                // Wire: emit Index(Ident(w), i) so downstream sees a
+                                // bus-wire-array element. Port: emit Ident("w_<i>") so
+                                // it lands at the flat per-element port name on the parent.
+                                let parent_expr = if parent_is_vob_wire {
+                                    Expr::new(
+                                        ExprKind::Index(
+                                            Box::new(Expr::new(
+                                                ExprKind::Ident(parent_name.clone()),
+                                                c.signal.span,
+                                            )),
+                                            Box::new(Expr::new(
+                                                ExprKind::Literal(LitKind::Dec(i as u64)),
+                                                c.signal.span,
+                                            )),
+                                        ),
+                                        c.signal.span,
+                                    )
+                                } else {
+                                    Expr::new(
+                                        ExprKind::Ident(format!("{}_{}", parent_name, i)),
+                                        c.signal.span,
+                                    )
+                                };
+                                crate::ast::Connection {
+                                    port_name: port_i,
+                                    direction: c.direction,
+                                    signal: parent_expr,
+                                    reset_override: None,
+                                    span: c.span,
+                                }
+                            })
+                            .collect::<Vec<_>>();
                     }
                 }
             }
@@ -1769,7 +2024,10 @@ fn expand_bus_connections(
 
     let mut expanded = Vec::new();
     for c in &inst_connections {
-        if let Some((_, bus_name, perspective, bus_params)) = target_bus_ports.iter().find(|(pn, _, _, _)| pn == &c.port_name.name) {
+        if let Some((_, bus_name, perspective, bus_params)) = target_bus_ports
+            .iter()
+            .find(|(pn, _, _, _)| pn == &c.port_name.name)
+        {
             // Bus connection — expand to individual signal connections
             if let Some((crate::resolve::Symbol::Bus(info), _)) = symbols.globals.get(*bus_name) {
                 // Three shapes for the parent-side signal on a whole-bus binding:
@@ -1816,10 +2074,17 @@ fn expand_bus_connections(
                                 ExprKind::Ident(arr_name),
                                 ExprKind::Literal(LitKind::Dec(m)),
                                 ExprKind::Literal(LitKind::Dec(n)),
-                            ) = (&inner_arr.kind, &inner_idx.kind, &idx.kind) {
+                            ) = (&inner_arr.kind, &inner_idx.kind, &idx.kind)
+                            {
                                 BindKind::Wire2DIndex(arr_name.clone(), *m as u32, *n as u32)
-                            } else { continue; }
-                        } else if let (ExprKind::Ident(arr_name), ExprKind::Literal(LitKind::Dec(i))) = (&arr.kind, &idx.kind) {
+                            } else {
+                                continue;
+                            }
+                        } else if let (
+                            ExprKind::Ident(arr_name),
+                            ExprKind::Literal(LitKind::Dec(i)),
+                        ) = (&arr.kind, &idx.kind)
+                        {
                             if bus_wire_names.contains(arr_name.as_str())
                                 || parent_vec_of_bus_wires.contains_key(arr_name.as_str())
                             {
@@ -1840,14 +2105,21 @@ fn expand_bus_connections(
                                 // flat name is `<port>_<i>`, mirroring
                                 // the port flattening.
                                 BindKind::FlatPort(format!("{}_{}", arr_name, i))
-                            } else { continue; }
-                        } else { continue; }
+                            } else {
+                                continue;
+                            }
+                        } else {
+                            continue;
+                        }
                     }
                     _ => continue,
                 };
                 let mut _pm = info.default_param_map();
-                for pa in *bus_params { _pm.insert(pa.name.name.clone(), &pa.value); }
-                let _eff = info.effective_signals(&_pm); for (sname, sdir, _) in &_eff {
+                for pa in *bus_params {
+                    _pm.insert(pa.name.name.clone(), &pa.value);
+                }
+                let _eff = info.effective_signals(&_pm);
+                for (sname, sdir, _) in &_eff {
                     let inst_flat = format!("{}_{}", c.port_name.name, sname);
                     // Determine actual direction from the inst's bus perspective.
                     // For initiator: bus out → inst Output, bus in → inst Input.
@@ -1876,8 +2148,14 @@ fn expand_bus_connections(
                             ExprKind::FieldAccess(
                                 Box::new(Expr::new(
                                     ExprKind::Index(
-                                        Box::new(Expr::new(ExprKind::Ident(name.clone()), c.signal.span)),
-                                        Box::new(Expr::new(ExprKind::Literal(LitKind::Dec(*i as u64)), c.signal.span)),
+                                        Box::new(Expr::new(
+                                            ExprKind::Ident(name.clone()),
+                                            c.signal.span,
+                                        )),
+                                        Box::new(Expr::new(
+                                            ExprKind::Literal(LitKind::Dec(*i as u64)),
+                                            c.signal.span,
+                                        )),
                                     ),
                                     c.signal.span,
                                 )),
@@ -1891,12 +2169,21 @@ fn expand_bus_connections(
                                     ExprKind::Index(
                                         Box::new(Expr::new(
                                             ExprKind::Index(
-                                                Box::new(Expr::new(ExprKind::Ident(name.clone()), c.signal.span)),
-                                                Box::new(Expr::new(ExprKind::Literal(LitKind::Dec(*m_idx as u64)), c.signal.span)),
+                                                Box::new(Expr::new(
+                                                    ExprKind::Ident(name.clone()),
+                                                    c.signal.span,
+                                                )),
+                                                Box::new(Expr::new(
+                                                    ExprKind::Literal(LitKind::Dec(*m_idx as u64)),
+                                                    c.signal.span,
+                                                )),
                                             ),
                                             c.signal.span,
                                         )),
-                                        Box::new(Expr::new(ExprKind::Literal(LitKind::Dec(*n_idx as u64)), c.signal.span)),
+                                        Box::new(Expr::new(
+                                            ExprKind::Literal(LitKind::Dec(*n_idx as u64)),
+                                            c.signal.span,
+                                        )),
                                     ),
                                     c.signal.span,
                                 )),
@@ -1931,7 +2218,7 @@ fn expand_bus_connections(
             type. See arch-com#447 §1 and PR #463 extending #458 to the \
             sibling helper cluster."
 )]
-#[allow(dead_code)]  // intentional landmine: present so new callers
+#[allow(dead_code)] // intentional landmine: present so new callers
                     // surface a deprecation warning at PR review time.
 fn cpp_internal_type(ty: &TypeExpr) -> String {
     cpp_internal_type_with_params(ty, &[])
@@ -1944,17 +2231,27 @@ fn cpp_internal_type_with_params(ty: &TypeExpr, params: &[ParamDecl]) -> String 
     match ty {
         TypeExpr::UInt(w) => {
             let b = eval_width_with_params(w, params);
-            if b > 128 { format!("VlWide<{}>", wide_words(b)) }
-            else if b > 64 { "_arch_u128".to_string() }
-            else { cpp_uint(b).to_string() }
+            if b > 128 {
+                format!("VlWide<{}>", wide_words(b))
+            } else if b > 64 {
+                "_arch_u128".to_string()
+            } else {
+                cpp_uint(b).to_string()
+            }
         }
         TypeExpr::SInt(w) => {
             let b = eval_width_with_params(w, params);
-            if b > 128 { format!("VlWide<{}>", wide_words(b)) }
-            else if b > 64 { "_arch_u128".to_string() }
-            else { cpp_sint(b).to_string() }
+            if b > 128 {
+                format!("VlWide<{}>", wide_words(b))
+            } else if b > 64 {
+                "_arch_u128".to_string()
+            } else {
+                cpp_sint(b).to_string()
+            }
         }
-        TypeExpr::Bool | TypeExpr::Bit | TypeExpr::Clock(_) | TypeExpr::Reset(..) => "uint8_t".to_string(),
+        TypeExpr::Bool | TypeExpr::Bit | TypeExpr::Clock(_) | TypeExpr::Reset(..) => {
+            "uint8_t".to_string()
+        }
         TypeExpr::FP32 => "uint32_t".to_string(),
         TypeExpr::BF16 => "uint16_t".to_string(),
         TypeExpr::Named(n) => n.name.clone(),
@@ -1984,7 +2281,7 @@ fn cpp_field_decl(name: &str, ty: &TypeExpr, params: &[ParamDecl]) -> String {
             helper cluster (twin of the PR #442 sites for the Vec-reg \
             storage path)."
 )]
-#[allow(dead_code)]  // intentional landmine: present so new callers
+#[allow(dead_code)] // intentional landmine: present so new callers
                     // surface a deprecation warning at PR review time.
 fn vec_array_info(ty: &TypeExpr) -> Option<(String, String)> {
     // Backward-compatible wrapper: delegate to the param-aware version
@@ -2002,14 +2299,12 @@ fn vec_array_info(ty: &TypeExpr) -> Option<(String, String)> {
 /// across `param N: const = …;` references (otherwise the result is 0
 /// and downstream code emits zero-sized C++ arrays — see the regression
 /// fixed in PR #cam-zero-array).
-#[deprecated(
-    note = "use `eval_const_expr_with_params(.., &params)` — the bare \
+#[deprecated(note = "use `eval_const_expr_with_params(.., &params)` — the bare \
             form silently miscompiles when the expression depends on \
             enclosing-construct params (Vec<_, PARAM>, UInt<PARAM>, \
             etc.). See arch-com#447 §1 and PRs #427, #439, #442 for \
-            the bug class this guards against."
-)]
-#[allow(dead_code)]  // intentional landmine: present so new callers
+            the bug class this guards against.")]
+#[allow(dead_code)] // intentional landmine: present so new callers
                     // surface a deprecation warning at PR review time.
 fn eval_const_expr(expr: &Expr) -> u64 {
     eval_const_expr_with_params(expr, &[])
@@ -2026,48 +2321,89 @@ fn stmt_indexes_vob_with_var(
     ports: &HashMap<String, u32>,
     wires: &HashMap<String, u32>,
 ) -> bool {
-    fn walk_expr(e: &Expr, var: &str, ports: &HashMap<String, u32>, wires: &HashMap<String, u32>) -> bool {
+    fn walk_expr(
+        e: &Expr,
+        var: &str,
+        ports: &HashMap<String, u32>,
+        wires: &HashMap<String, u32>,
+    ) -> bool {
         if let ExprKind::Index(arr, idx) = &e.kind {
             if let (ExprKind::Ident(arr_name), ExprKind::Ident(idx_name)) = (&arr.kind, &idx.kind) {
-                if idx_name == var && (ports.contains_key(arr_name) || wires.contains_key(arr_name)) {
+                if idx_name == var && (ports.contains_key(arr_name) || wires.contains_key(arr_name))
+                {
                     return true;
                 }
             }
         }
         match &e.kind {
-            ExprKind::Binary(_, l, r) => walk_expr(l, var, ports, wires) || walk_expr(r, var, ports, wires),
-            ExprKind::Unary(_, x) | ExprKind::Cast(x, _) | ExprKind::LatencyAt(x, _) | ExprKind::SvaNext(_, x) =>
-                walk_expr(x, var, ports, wires),
+            ExprKind::Binary(_, l, r) => {
+                walk_expr(l, var, ports, wires) || walk_expr(r, var, ports, wires)
+            }
+            ExprKind::Unary(_, x)
+            | ExprKind::Cast(x, _)
+            | ExprKind::LatencyAt(x, _)
+            | ExprKind::SvaNext(_, x) => walk_expr(x, var, ports, wires),
             ExprKind::FieldAccess(b, _) => walk_expr(b, var, ports, wires),
-            ExprKind::Index(b, i) | ExprKind::BitSlice(b, i, _) =>
-                walk_expr(b, var, ports, wires) || walk_expr(i, var, ports, wires),
-            ExprKind::PartSelect(b, lo, hi, _) =>
-                walk_expr(b, var, ports, wires) || walk_expr(lo, var, ports, wires) || walk_expr(hi, var, ports, wires),
-            ExprKind::Ternary(c, t, e2) =>
-                walk_expr(c, var, ports, wires) || walk_expr(t, var, ports, wires) || walk_expr(e2, var, ports, wires),
-            ExprKind::Concat(parts) | ExprKind::FunctionCall(_, parts) =>
-                parts.iter().any(|p| walk_expr(p, var, ports, wires)),
-            ExprKind::MethodCall(b, _, args) =>
-                walk_expr(b, var, ports, wires) || args.iter().any(|a| walk_expr(a, var, ports, wires)),
+            ExprKind::Index(b, i) | ExprKind::BitSlice(b, i, _) => {
+                walk_expr(b, var, ports, wires) || walk_expr(i, var, ports, wires)
+            }
+            ExprKind::PartSelect(b, lo, hi, _) => {
+                walk_expr(b, var, ports, wires)
+                    || walk_expr(lo, var, ports, wires)
+                    || walk_expr(hi, var, ports, wires)
+            }
+            ExprKind::Ternary(c, t, e2) => {
+                walk_expr(c, var, ports, wires)
+                    || walk_expr(t, var, ports, wires)
+                    || walk_expr(e2, var, ports, wires)
+            }
+            ExprKind::Concat(parts) | ExprKind::FunctionCall(_, parts) => {
+                parts.iter().any(|p| walk_expr(p, var, ports, wires))
+            }
+            ExprKind::MethodCall(b, _, args) => {
+                walk_expr(b, var, ports, wires)
+                    || args.iter().any(|a| walk_expr(a, var, ports, wires))
+            }
             _ => false,
         }
     }
     match stmt {
-        Stmt::Assign(a) => walk_expr(&a.target, var, ports, wires) || walk_expr(&a.value, var, ports, wires),
+        Stmt::Assign(a) => {
+            walk_expr(&a.target, var, ports, wires) || walk_expr(&a.value, var, ports, wires)
+        }
         Stmt::IfElse(ie) => {
             walk_expr(&ie.cond, var, ports, wires)
-                || ie.then_stmts.iter().any(|s| stmt_indexes_vob_with_var(s, var, ports, wires))
-                || ie.else_stmts.iter().any(|s| stmt_indexes_vob_with_var(s, var, ports, wires))
+                || ie
+                    .then_stmts
+                    .iter()
+                    .any(|s| stmt_indexes_vob_with_var(s, var, ports, wires))
+                || ie
+                    .else_stmts
+                    .iter()
+                    .any(|s| stmt_indexes_vob_with_var(s, var, ports, wires))
         }
         Stmt::Match(m) => {
             walk_expr(&m.scrutinee, var, ports, wires)
-                || m.arms.iter().any(|arm| arm.body.iter().any(|s| stmt_indexes_vob_with_var(s, var, ports, wires)))
+                || m.arms.iter().any(|arm| {
+                    arm.body
+                        .iter()
+                        .any(|s| stmt_indexes_vob_with_var(s, var, ports, wires))
+                })
         }
-        Stmt::For(f) => f.body.iter().any(|s| stmt_indexes_vob_with_var(s, var, ports, wires)),
-        Stmt::Init(ib) => ib.body.iter().any(|s| stmt_indexes_vob_with_var(s, var, ports, wires)),
-        Stmt::DoUntil { body, cond, .. } =>
+        Stmt::For(f) => f
+            .body
+            .iter()
+            .any(|s| stmt_indexes_vob_with_var(s, var, ports, wires)),
+        Stmt::Init(ib) => ib
+            .body
+            .iter()
+            .any(|s| stmt_indexes_vob_with_var(s, var, ports, wires)),
+        Stmt::DoUntil { body, cond, .. } => {
             walk_expr(cond, var, ports, wires)
-                || body.iter().any(|s| stmt_indexes_vob_with_var(s, var, ports, wires)),
+                || body
+                    .iter()
+                    .any(|s| stmt_indexes_vob_with_var(s, var, ports, wires))
+        }
         Stmt::WaitUntil(e, _) => walk_expr(e, var, ports, wires),
         Stmt::Log(l) => l.args.iter().any(|a| walk_expr(a, var, ports, wires)),
     }
@@ -2089,7 +2425,8 @@ fn eval_const_expr_with_params(expr: &Expr, params: &[ParamDecl]) -> u64 {
 /// has no SV-genvar concept, so we run a local unroll pass before
 /// walking the body.
 fn module_body_has_preserved_generate(body: &[ModuleBodyItem]) -> bool {
-    body.iter().any(|it| matches!(it, ModuleBodyItem::Generate(GenerateDecl::For(_))))
+    body.iter()
+        .any(|it| matches!(it, ModuleBodyItem::Generate(GenerateDecl::For(_))))
 }
 
 /// Sim-local unroll for preserved `Generate(For)` blocks. Walks the
@@ -2124,7 +2461,9 @@ fn flatten_preserved_generates_for_sim(
                     for git in &gf.items {
                         match git {
                             GenItem::Inst(inst) => {
-                                out.push(ModuleBodyItem::Inst(crate::elaborate::subst_inst(inst, var, i)));
+                                out.push(ModuleBodyItem::Inst(crate::elaborate::subst_inst(
+                                    inst, var, i,
+                                )));
                             }
                             // The elaborator's preservation gate today
                             // restricts preserved generate_for bodies
@@ -2172,7 +2511,11 @@ fn eval_const_expr_with_params_seen(
         }
         ExprKind::Clog2(a) => {
             let v = eval_const_expr_with_params_seen(a, params, seen_params);
-            if v <= 1 { 0 } else { 64 - (v - 1).leading_zeros() as u64 }
+            if v <= 1 {
+                0
+            } else {
+                64 - (v - 1).leading_zeros() as u64
+            }
         }
         ExprKind::Unary(op, a) => {
             let v = eval_const_expr_with_params_seen(a, params, seen_params);
@@ -2189,8 +2532,20 @@ fn eval_const_expr_with_params_seen(
                 BinOp::Add => lv.wrapping_add(rv),
                 BinOp::Sub => lv.wrapping_sub(rv),
                 BinOp::Mul => lv.wrapping_mul(rv),
-                BinOp::Div => if rv == 0 { 0 } else { lv / rv },
-                BinOp::Mod => if rv == 0 { 0 } else { lv % rv },
+                BinOp::Div => {
+                    if rv == 0 {
+                        0
+                    } else {
+                        lv / rv
+                    }
+                }
+                BinOp::Mod => {
+                    if rv == 0 {
+                        0
+                    } else {
+                        lv % rv
+                    }
+                }
                 BinOp::Shl => lv.wrapping_shl(rv as u32),
                 BinOp::Shr => lv.wrapping_shr(rv as u32),
                 BinOp::BitAnd => lv & rv,
@@ -2227,7 +2582,11 @@ fn vec_array_info_with_params(ty: &TypeExpr, params: &[ParamDecl]) -> Option<(St
 /// If `expr` is a bare identifier, return its name — used for diagnostic
 /// location strings in runtime bounds-check codegen.
 fn base_ident_name(expr: &Expr) -> Option<&str> {
-    if let ExprKind::Ident(n) = &expr.kind { Some(n.as_str()) } else { None }
+    if let ExprKind::Ident(n) = &expr.kind {
+        Some(n.as_str())
+    } else {
+        None
+    }
 }
 
 /// Local "is this expression a compile-time constant we can fold?" test.
@@ -2255,18 +2614,27 @@ fn is_const_reducible(e: &Expr) -> bool {
 fn is_thread_fsm_state_reg(name: &str) -> bool {
     // Strip leading underscores (the shadow field is _t0_state, public is t0_state)
     let trimmed = name.trim_start_matches('_');
-    if !trimmed.starts_with('t') { return false; }
-    if !trimmed.ends_with("_state") { return false; }
+    if !trimmed.starts_with('t') {
+        return false;
+    }
+    if !trimmed.ends_with("_state") {
+        return false;
+    }
     // Middle must be digits
     let mid = &trimmed[1..trimmed.len() - "_state".len()];
     !mid.is_empty() && mid.chars().all(|c| c.is_ascii_digit())
 }
 
 fn cpp_uint(bits: u32) -> &'static str {
-    if bits <= 8  { "uint8_t" }
-    else if bits <= 16 { "uint16_t" }
-    else if bits <= 32 { "uint32_t" }
-    else               { "uint64_t" }
+    if bits <= 8 {
+        "uint8_t"
+    } else if bits <= 16 {
+        "uint16_t"
+    } else if bits <= 32 {
+        "uint32_t"
+    } else {
+        "uint64_t"
+    }
 }
 
 /// Return the bit-width of a TypeExpr, or 0 if indeterminate (e.g. Vec with param size).
@@ -2282,10 +2650,15 @@ fn type_width_of(ty: &TypeExpr) -> u32 {
 
 /// Smallest C++ signed integer type that fits `bits` (up to 64).
 fn cpp_sint(bits: u32) -> &'static str {
-    if bits <= 8  { "int8_t" }
-    else if bits <= 16 { "int16_t" }
-    else if bits <= 32 { "int32_t" }
-    else               { "int64_t" }
+    if bits <= 8 {
+        "int8_t"
+    } else if bits <= 16 {
+        "int16_t"
+    } else if bits <= 32 {
+        "int32_t"
+    } else {
+        "int64_t"
+    }
 }
 
 /// Cast expression to `bits`-wide C++ type.
@@ -2310,10 +2683,15 @@ fn cast_to_signed_bits(expr: &str, bits: u32) -> String {
         format!("({})({})", cpp_sint(bits), expr)
     } else {
         let mask = (1u64 << bits) - 1;
-        let cpp_bits = if bits <= 8 { 8 }
-            else if bits <= 16 { 16 }
-            else if bits <= 32 { 32 }
-            else { 64 };
+        let cpp_bits = if bits <= 8 {
+            8
+        } else if bits <= 16 {
+            16
+        } else if bits <= 32 {
+            32
+        } else {
+            64
+        };
         let shift = cpp_bits - bits;
         let ty = cpp_sint(bits);
         format!("(({ty})(((uint64_t)({expr}) & 0x{mask:X}ULL) << {shift}) >> {shift})")
@@ -2323,7 +2701,11 @@ fn cast_to_signed_bits(expr: &str, bits: u32) -> String {
 /// Bit-range extraction from a narrow value: `(expr >> lo) & mask`.
 fn bit_range(expr: &str, hi: u32, lo: u32) -> String {
     let width = hi - lo + 1;
-    let mask = if width >= 64 { u64::MAX } else { (1u64 << width) - 1 };
+    let mask = if width >= 64 {
+        u64::MAX
+    } else {
+        (1u64 << width) - 1
+    };
     format!("(({} >> {}) & 0x{:X}ULL)", expr, lo, mask)
 }
 
@@ -2334,41 +2716,55 @@ fn bit_range_u128(expr: &str, hi: u32, lo: u32) -> String {
     if lo == 0 && width >= 128 {
         format!("({result_type})({})", expr)
     } else if lo == 0 {
-        let mask = if width >= 64 { u64::MAX } else { (1u64 << width) - 1 };
-        format!("({result_type})(((_arch_u128)({}) & (_arch_u128)0x{:X}ULL))", expr, mask)
+        let mask = if width >= 64 {
+            u64::MAX
+        } else {
+            (1u64 << width) - 1
+        };
+        format!(
+            "({result_type})(((_arch_u128)({}) & (_arch_u128)0x{:X}ULL))",
+            expr, mask
+        )
     } else {
-        let mask = if width >= 64 { u64::MAX } else { (1u64 << width) - 1 };
-        format!("({result_type})(((_arch_u128)({}) >> {}) & (_arch_u128)0x{:X}ULL)", expr, lo, mask)
+        let mask = if width >= 64 {
+            u64::MAX
+        } else {
+            (1u64 << width) - 1
+        };
+        format!(
+            "({result_type})(((_arch_u128)({}) >> {}) & (_arch_u128)0x{:X}ULL)",
+            expr, lo, mask
+        )
     }
 }
 
 /// Convert SV/ARCH format string tokens to printf equivalents.
 fn sv_fmt_to_printf(s: &str) -> String {
     s.replace("%0t", "%lu")
-     .replace("%0d", "%lld")
-     .replace("%0h", "%llx")
-     .replace("%0b", "%llu")
-     .replace("%t",  "%lu")
-     .replace("%h",  "%llx")
-     .replace("%d",  "%lld")
-     .replace("%b",  "%llu")
+        .replace("%0d", "%lld")
+        .replace("%0h", "%llx")
+        .replace("%0b", "%llu")
+        .replace("%t", "%lu")
+        .replace("%h", "%llx")
+        .replace("%d", "%lld")
+        .replace("%b", "%llu")
 }
 
 // ── Expression context ────────────────────────────────────────────────────────
 
 struct Ctx<'a> {
-    reg_names:   &'a HashSet<String>,
-    port_names:  &'a HashSet<String>,
-    let_names:   &'a HashSet<String>,
+    reg_names: &'a HashSet<String>,
+    port_names: &'a HashSet<String>,
+    let_names: &'a HashSet<String>,
     /// Map of module-scope let-binding names → their RHS expressions.
     /// Populated via `Ctx::with_let_values`. Used by `Stmt::Match` to
     /// fold `Pattern::Ident` arms into literal case labels.
-    let_values:  Option<&'a HashMap<String, Expr>>,
-    inst_names:  &'a HashSet<String>,
+    let_values: Option<&'a HashMap<String, Expr>>,
+    inst_names: &'a HashSet<String>,
     /// Signals whose type is >64 bits wide (require special handling).
-    wide_names:  &'a HashSet<String>,
+    wide_names: &'a HashSet<String>,
     /// Signal name → bit width for known signals (used for concat width inference).
-    widths:      &'a HashMap<String, u32>,
+    widths: &'a HashMap<String, u32>,
     /// Signal names whose HDL scalar type is signed.
     signed_names: &'a HashSet<String>,
     /// Signal name → floating-point format (FP32/BF16). Used to dispatch
@@ -2377,15 +2773,15 @@ struct Ctx<'a> {
     float_names: &'a HashMap<String, FpFmt>,
     posedge_lhs: bool,
     /// FSM mode: regs are public members, no `_` prefix on reads
-    fsm_mode:    bool,
-    enum_map:    &'a HashMap<String, Vec<(String, u64)>>,
+    fsm_mode: bool,
+    enum_map: &'a HashMap<String, Vec<(String, u64)>>,
     /// Bus port names (for FieldAccess rewriting: itcm.cmd_valid → itcm_cmd_valid).
-    bus_ports:   &'a HashSet<String>,
+    bus_ports: &'a HashSet<String>,
     /// Reset port name → level, for `.asserted` polarity abstraction.
     reset_levels: &'a HashMap<String, ResetLevel>,
     /// Reg/wire names whose type is Vec<T,N> — these use C array subscript `[i]`.
     /// All other subscripts on scalar UInt/SInt use bit extraction `(x >> i) & 1`.
-    vec_names:   Option<&'a HashSet<String>>,
+    vec_names: Option<&'a HashSet<String>>,
     /// Names of *2D* Vec<Vec<_,_>,_> wires/regs (today: Vec-of-Vec-of-bus
     /// `wire edges: Vec<Vec<B, N>, M>`). When the outer Index returns
     /// `_let_edges[m]`, the result is still a Vec — the inner subscript
@@ -2393,7 +2789,7 @@ struct Ctx<'a> {
     /// path for scalar types.
     vec_2d_names: Option<&'a HashSet<String>>,
     /// Vec<T,N> sizes by name (element count). Used for runtime bounds-check codegen.
-    vec_sizes:   Option<&'a HashMap<String, u64>>,
+    vec_sizes: Option<&'a HashMap<String, u64>>,
     /// FSM Vec port-regs: always resolve to `_name` (internal C array), regardless of fsm_mode.
     /// These ports have flat public fields (name_0..name_N-1) but internal storage `_name[N]`.
     fsm_vec_port_regs: Option<&'a HashSet<String>>,
@@ -2425,29 +2821,51 @@ struct Ctx<'a> {
 impl<'a> Ctx<'a> {
     #[allow(clippy::too_many_arguments)]
     fn new(
-        reg_names:  &'a HashSet<String>,
+        reg_names: &'a HashSet<String>,
         port_names: &'a HashSet<String>,
-        let_names:  &'a HashSet<String>,
+        let_names: &'a HashSet<String>,
         inst_names: &'a HashSet<String>,
         wide_names: &'a HashSet<String>,
-        widths:     &'a HashMap<String, u32>,
-        enum_map:   &'a HashMap<String, Vec<(String, u64)>>,
-        bus_ports:  &'a HashSet<String>,
+        widths: &'a HashMap<String, u32>,
+        enum_map: &'a HashMap<String, Vec<(String, u64)>>,
+        bus_ports: &'a HashSet<String>,
     ) -> Self {
-        static EMPTY_RESET_LEVELS: std::sync::OnceLock<HashMap<String, ResetLevel>> = std::sync::OnceLock::new();
-        static EMPTY_SIGNED_NAMES: std::sync::OnceLock<HashSet<String>> = std::sync::OnceLock::new();
-        static EMPTY_FLOAT_NAMES: std::sync::OnceLock<HashMap<String, FpFmt>> = std::sync::OnceLock::new();
+        static EMPTY_RESET_LEVELS: std::sync::OnceLock<HashMap<String, ResetLevel>> =
+            std::sync::OnceLock::new();
+        static EMPTY_SIGNED_NAMES: std::sync::OnceLock<HashSet<String>> =
+            std::sync::OnceLock::new();
+        static EMPTY_FLOAT_NAMES: std::sync::OnceLock<HashMap<String, FpFmt>> =
+            std::sync::OnceLock::new();
         let reset_levels = EMPTY_RESET_LEVELS.get_or_init(HashMap::new);
         let signed_names = EMPTY_SIGNED_NAMES.get_or_init(HashSet::new);
         let float_names = EMPTY_FLOAT_NAMES.get_or_init(HashMap::new);
         static EMPTY_PARAMS: &[ParamDecl] = &[];
-        Ctx { reg_names, port_names, let_names, let_values: None, inst_names, wide_names,
-              widths, signed_names, float_names, posedge_lhs: false, fsm_mode: false, enum_map, bus_ports,
-              reset_levels, vec_names: None, vec_2d_names: None, vec_sizes: None,
-              fsm_vec_port_regs: None,
-              ident_subst: None, loop_var_subst: None,
-              vec_of_bus_port_count: None, vec_of_bus_wire_count: None,
-              coverage: None, params: EMPTY_PARAMS }
+        Ctx {
+            reg_names,
+            port_names,
+            let_names,
+            let_values: None,
+            inst_names,
+            wide_names,
+            widths,
+            signed_names,
+            float_names,
+            posedge_lhs: false,
+            fsm_mode: false,
+            enum_map,
+            bus_ports,
+            reset_levels,
+            vec_names: None,
+            vec_2d_names: None,
+            vec_sizes: None,
+            fsm_vec_port_regs: None,
+            ident_subst: None,
+            loop_var_subst: None,
+            vec_of_bus_port_count: None,
+            vec_of_bus_wire_count: None,
+            coverage: None,
+            params: EMPTY_PARAMS,
+        }
     }
 
     fn with_vec_of_bus(
@@ -2517,7 +2935,10 @@ impl<'a> Ctx<'a> {
         self
     }
 
-    fn posedge(mut self) -> Self { self.posedge_lhs = true; self }
+    fn posedge(mut self) -> Self {
+        self.posedge_lhs = true;
+        self
+    }
 
     /// Resolve a name to its C++ field/variable name.
     fn resolve_name(&self, name: &str, is_lhs: bool) -> String {
@@ -2547,7 +2968,8 @@ impl<'a> Ctx<'a> {
         } else if self.inst_names.contains(name) {
             format!("_inst_{name}")
         } else if self.port_names.contains(name)
-                  && self.vec_names.map_or(false, |s| s.contains(name)) {
+            && self.vec_names.map_or(false, |s| s.contains(name))
+        {
             // Vec-typed port: header exposes flattened `name_0..name_N-1`
             // scalars for external access, but the body indexes into the
             // internal `_name[N]` array. Without this branch, a body that
@@ -2603,7 +3025,10 @@ impl<'a> Ctx<'a> {
             // indexing instead of falling into bit-shift extraction.
             ExprKind::Index(base, _) => {
                 if let ExprKind::Ident(name) = &base.kind {
-                    if self.vec_2d_names.map_or(false, |s| s.contains(name.as_str())) {
+                    if self
+                        .vec_2d_names
+                        .map_or(false, |s| s.contains(name.as_str()))
+                    {
                         return Some(name.clone());
                     }
                 }
@@ -2649,7 +3074,12 @@ fn infer_expr_width(expr: &Expr, ctx: &Ctx) -> u32 {
         ExprKind::MethodCall(base, method, _) if method.name == "reverse" => {
             infer_expr_width(base, ctx)
         }
-        ExprKind::MethodCall(_, method, args) if method.name == "trunc" || method.name == "zext" || method.name == "sext" || method.name == "resize" => {
+        ExprKind::MethodCall(_, method, args)
+            if method.name == "trunc"
+                || method.name == "zext"
+                || method.name == "sext"
+                || method.name == "resize" =>
+        {
             if let Some(w) = args.first() {
                 eval_width_in(w, ctx)
             } else {
@@ -2662,16 +3092,12 @@ fn infer_expr_width(expr: &Expr, ctx: &Ctx) -> u32 {
             h - l + 1
         }
         ExprKind::PartSelect(_, _, width, _) => eval_width_in(width, ctx),
-        ExprKind::Cast(_, ty) => {
-            match ty.as_ref() {
-                TypeExpr::UInt(w) => eval_width_in(w, ctx),
-                TypeExpr::SInt(w) => eval_width_in(w, ctx),
-                _ => 8,
-            }
-        }
-        ExprKind::Concat(parts) => {
-            parts.iter().map(|p| infer_expr_width(p, ctx)).sum()
-        }
+        ExprKind::Cast(_, ty) => match ty.as_ref() {
+            TypeExpr::UInt(w) => eval_width_in(w, ctx),
+            TypeExpr::SInt(w) => eval_width_in(w, ctx),
+            _ => 8,
+        },
+        ExprKind::Concat(parts) => parts.iter().map(|p| infer_expr_width(p, ctx)).sum(),
         ExprKind::Index(base, _) => {
             // For Vec<T, N>[i] the result width is element T's width.
             // For scalar UInt/SInt[i] (bit indexing), the result is 1 bit.
@@ -2680,11 +3106,20 @@ fn infer_expr_width(expr: &Expr, ctx: &Ctx) -> u32 {
             // 160 bits instead of 20, blowing past the 32-bit port type
             // and emitting a VlWide<6> RHS for a uint32_t port).
             if let Some(base_name) = ctx.vec_path_of_expr(base) {
-                if ctx.vec_names.map_or(false, |s| s.contains(base_name.as_str())) {
+                if ctx
+                    .vec_names
+                    .map_or(false, |s| s.contains(base_name.as_str()))
+                {
                     // Vec element width: total port/reg/field width / element count.
                     let total = ctx.widths.get(base_name.as_str()).copied().unwrap_or(0);
-                    let count = ctx.vec_sizes.and_then(|m| m.get(base_name.as_str())).copied().unwrap_or(0);
-                    if count > 0 && total > 0 { return (total as u64 / count) as u32; }
+                    let count = ctx
+                        .vec_sizes
+                        .and_then(|m| m.get(base_name.as_str()))
+                        .copied()
+                        .unwrap_or(0);
+                    if count > 0 && total > 0 {
+                        return (total as u64 / count) as u32;
+                    }
                 }
             }
             // Scalar bit index → 1 bit.
@@ -2698,8 +3133,14 @@ fn infer_expr_width(expr: &Expr, ctx: &Ctx) -> u32 {
         ExprKind::Binary(op, lhs, rhs) => {
             match op {
                 // Comparison and logical ops always produce 1-bit Bool
-                BinOp::Eq | BinOp::Neq | BinOp::Lt | BinOp::Gt |
-                BinOp::Lte | BinOp::Gte | BinOp::And | BinOp::Or => 1,
+                BinOp::Eq
+                | BinOp::Neq
+                | BinOp::Lt
+                | BinOp::Gt
+                | BinOp::Lte
+                | BinOp::Gte
+                | BinOp::And
+                | BinOp::Or => 1,
                 // Bitwise ops: result width = max of operand widths
                 BinOp::BitAnd | BinOp::BitOr | BinOp::BitXor => {
                     let lw = infer_expr_width(lhs, ctx);
@@ -2721,9 +3162,7 @@ fn infer_expr_width(expr: &Expr, ctx: &Ctx) -> u32 {
         | ExprKind::Unary(UnaryOp::RedOr, _)
         | ExprKind::Unary(UnaryOp::RedXor, _) => 1,
         ExprKind::Ternary(_, then_expr, _) => infer_expr_width(then_expr, ctx),
-        ExprKind::Signed(inner) | ExprKind::Unsigned(inner) => {
-            infer_expr_width(inner, ctx)
-        }
+        ExprKind::Signed(inner) | ExprKind::Unsigned(inner) => infer_expr_width(inner, ctx),
         ExprKind::FieldAccess(base, field) => {
             // Struct field access: look up by "<base>.<field>" key the caller
             // populated from the struct decl. Covers two shapes:
@@ -2782,15 +3221,24 @@ fn infer_expr_signed(expr: &Expr, ctx: &Ctx) -> bool {
         ExprKind::Signed(_) => true,
         ExprKind::Unsigned(_) => false,
         ExprKind::MethodCall(base, method, _)
-            if matches!(method.name.as_str(), "trunc" | "sext" | "resize" | "reverse") =>
+            if matches!(
+                method.name.as_str(),
+                "trunc" | "sext" | "resize" | "reverse"
+            ) =>
         {
             infer_expr_signed(base, ctx)
         }
         ExprKind::Unary(UnaryOp::Neg, _) => true,
         ExprKind::Unary(_, inner) => infer_expr_signed(inner, ctx),
         ExprKind::Binary(op, lhs, rhs) => match op {
-            BinOp::Eq | BinOp::Neq | BinOp::Lt | BinOp::Gt |
-            BinOp::Lte | BinOp::Gte | BinOp::And | BinOp::Or => false,
+            BinOp::Eq
+            | BinOp::Neq
+            | BinOp::Lt
+            | BinOp::Gt
+            | BinOp::Lte
+            | BinOp::Gte
+            | BinOp::And
+            | BinOp::Or => false,
             _ => infer_expr_signed(lhs, ctx) || infer_expr_signed(rhs, ctx),
         },
         ExprKind::Ternary(_, then_expr, else_expr) => {
@@ -2803,12 +3251,18 @@ fn infer_expr_signed(expr: &Expr, ctx: &Ctx) -> bool {
 /// Floating-point format of a sim signal/expression. Mirrors `Ty::FP32`/`BF16`
 /// but local to the sim backend so it can live in `Ctx`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum FpFmt { Fp32, Bf16 }
+enum FpFmt {
+    Fp32,
+    Bf16,
+}
 
 impl FpFmt {
     /// Suffix used in the `_arch_fp.h` helper names: `_arch_f32_add` / `_arch_bf16_add`.
     fn helper_tag(self) -> &'static str {
-        match self { FpFmt::Fp32 => "f32", FpFmt::Bf16 => "bf16" }
+        match self {
+            FpFmt::Fp32 => "f32",
+            FpFmt::Bf16 => "bf16",
+        }
     }
 }
 
@@ -2831,14 +3285,17 @@ fn infer_expr_float(expr: &Expr, ctx: &Ctx) -> Option<FpFmt> {
         },
         // Arithmetic preserves the float format; comparisons are not float.
         ExprKind::Binary(op, lhs, rhs) => match op {
-            BinOp::Add | BinOp::Sub | BinOp::Mul =>
-                infer_expr_float(lhs, ctx).or_else(|| infer_expr_float(rhs, ctx)),
+            BinOp::Add | BinOp::Sub | BinOp::Mul => {
+                infer_expr_float(lhs, ctx).or_else(|| infer_expr_float(rhs, ctx))
+            }
             _ => None,
         },
-        ExprKind::Ternary(_, then_expr, else_expr) =>
-            infer_expr_float(then_expr, ctx).or_else(|| infer_expr_float(else_expr, ctx)),
-        ExprKind::FunctionCall(name, args) if name == "fma" =>
-            args.first().and_then(|a| infer_expr_float(a, ctx)),
+        ExprKind::Ternary(_, then_expr, else_expr) => {
+            infer_expr_float(then_expr, ctx).or_else(|| infer_expr_float(else_expr, ctx))
+        }
+        ExprKind::FunctionCall(name, args) if name == "fma" => {
+            args.first().and_then(|a| infer_expr_float(a, ctx))
+        }
         _ => None,
     }
 }
@@ -2870,15 +3327,24 @@ fn lower_vec_method_cpp(
         sub.insert("item".to_string(), format!("{recv_b}[{i}]"));
         sub.insert("index".to_string(), format!("{i}"));
         let sub_ctx = Ctx {
-            reg_names: ctx.reg_names, port_names: ctx.port_names,
-            let_names: ctx.let_names, let_values: ctx.let_values, inst_names: ctx.inst_names,
-            wide_names: ctx.wide_names, widths: ctx.widths, signed_names: ctx.signed_names,
+            reg_names: ctx.reg_names,
+            port_names: ctx.port_names,
+            let_names: ctx.let_names,
+            let_values: ctx.let_values,
+            inst_names: ctx.inst_names,
+            wide_names: ctx.wide_names,
+            widths: ctx.widths,
+            signed_names: ctx.signed_names,
             float_names: ctx.float_names,
-            posedge_lhs: ctx.posedge_lhs, fsm_mode: ctx.fsm_mode,
-            enum_map: ctx.enum_map, bus_ports: ctx.bus_ports,
-            reset_levels: ctx.reset_levels, vec_names: ctx.vec_names,
+            posedge_lhs: ctx.posedge_lhs,
+            fsm_mode: ctx.fsm_mode,
+            enum_map: ctx.enum_map,
+            bus_ports: ctx.bus_ports,
+            reset_levels: ctx.reset_levels,
+            vec_names: ctx.vec_names,
             vec_2d_names: ctx.vec_2d_names,
-            vec_sizes: ctx.vec_sizes, fsm_vec_port_regs: ctx.fsm_vec_port_regs,
+            vec_sizes: ctx.vec_sizes,
+            fsm_vec_port_regs: ctx.fsm_vec_port_regs,
             ident_subst: None, // replaced below via a temporary binding
             loop_var_subst: ctx.loop_var_subst,
             vec_of_bus_port_count: ctx.vec_of_bus_port_count,
@@ -2888,7 +3354,10 @@ fn lower_vec_method_cpp(
         };
         // The sub map must outlive the cpp_expr call. We keep `sub` as a
         // stack-local binding whose lifetime covers the call.
-        let ctx_with_sub = Ctx { ident_subst: Some(&sub), ..sub_ctx };
+        let ctx_with_sub = Ctx {
+            ident_subst: Some(&sub),
+            ..sub_ctx
+        };
         if let Some(pred) = args.first() {
             cpp_expr(pred, &ctx_with_sub)
         } else {
@@ -2898,42 +3367,59 @@ fn lower_vec_method_cpp(
 
     match method.name.as_str() {
         "any" => {
-            if n_usize == 0 { return "false".to_string(); }
+            if n_usize == 0 {
+                return "false".to_string();
+            }
             let terms: Vec<String> = (0..n as u64).map(emit_at).collect();
             format!("({})", terms.join(" || "))
         }
         "all" => {
-            if n_usize == 0 { return "true".to_string(); }
+            if n_usize == 0 {
+                return "true".to_string();
+            }
             let terms: Vec<String> = (0..n as u64).map(emit_at).collect();
             format!("({})", terms.join(" && "))
         }
         "count" => {
-            if n_usize == 0 { return "0".to_string(); }
+            if n_usize == 0 {
+                return "0".to_string();
+            }
             let terms: Vec<String> = (0..n as u64)
                 .map(|i| format!("({} ? 1u : 0u)", emit_at(i)))
                 .collect();
             format!("({})", terms.join(" + "))
         }
         "contains" => {
-            let Some(x_expr) = args.first() else { return "false".to_string(); };
+            let Some(x_expr) = args.first() else {
+                return "false".to_string();
+            };
             let x = cpp_expr(x_expr, ctx);
-            if n_usize == 0 { return "false".to_string(); }
+            if n_usize == 0 {
+                return "false".to_string();
+            }
             let terms: Vec<String> = (0..n as u64)
-                .map(|i| format!("({recv_b}[{i}] == {x})")).collect();
+                .map(|i| format!("({recv_b}[{i}] == {x})"))
+                .collect();
             format!("({})", terms.join(" || "))
         }
         "reduce_or" => {
-            if n_usize == 0 { return "0".to_string(); }
+            if n_usize == 0 {
+                return "0".to_string();
+            }
             let terms: Vec<String> = (0..n as u64).map(|i| format!("{recv_b}[{i}]")).collect();
             format!("({})", terms.join(" | "))
         }
         "reduce_and" => {
-            if n_usize == 0 { return "0".to_string(); }
+            if n_usize == 0 {
+                return "0".to_string();
+            }
             let terms: Vec<String> = (0..n as u64).map(|i| format!("{recv_b}[{i}]")).collect();
             format!("({})", terms.join(" & "))
         }
         "reduce_xor" => {
-            if n_usize == 0 { return "0".to_string(); }
+            if n_usize == 0 {
+                return "0".to_string();
+            }
             let terms: Vec<String> = (0..n as u64).map(|i| format!("{recv_b}[{i}]")).collect();
             format!("({})", terms.join(" ^ "))
         }
@@ -2964,8 +3450,9 @@ fn is_fully_wrapped_in_parens(s: &str) -> bool {
     }
     let mut depth = 0u32;
     for (i, c) in s.char_indices() {
-        if c == '(' { depth += 1; }
-        else if c == ')' {
+        if c == '(' {
+            depth += 1;
+        } else if c == ')' {
             depth -= 1;
             if depth == 0 && i < s.len() - 1 {
                 return false; // closed before the end — not fully wrapped
@@ -3005,7 +3492,7 @@ fn cpp_expr_inner(expr: &Expr, ctx: &Ctx, is_lhs: bool) -> String {
             // as an unsigned hex constant (matches the uint32_t carrier).
             LitKind::Float(bits) => format!("0x{:X}u", (f64::from_bits(*bits) as f32).to_bits()),
         },
-        ExprKind::Bool(true)  => "1".to_string(),
+        ExprKind::Bool(true) => "1".to_string(),
         ExprKind::Bool(false) => "0".to_string(),
 
         ExprKind::Ident(name) => {
@@ -3016,7 +3503,10 @@ fn cpp_expr_inner(expr: &Expr, ctx: &Ctx, is_lhs: bool) -> String {
             }
             // Static for-loop unroll binds the loop variable to a literal
             // integer (e.g. `chans[i].v` inside `for i in 0..N-1`).
-            if let Some(v) = ctx.loop_var_subst.and_then(|c| c.borrow().get(name).copied()) {
+            if let Some(v) = ctx
+                .loop_var_subst
+                .and_then(|c| c.borrow().get(name).copied())
+            {
                 return v.to_string();
             }
             if is_lhs {
@@ -3043,10 +3533,15 @@ fn cpp_expr_inner(expr: &Expr, ctx: &Ctx, is_lhs: bool) -> String {
             if let Some(fmt) = infer_expr_float(lhs, ctx).or_else(|| infer_expr_float(rhs, ctx)) {
                 let tag = fmt.helper_tag();
                 let fop = match op {
-                    BinOp::Add => Some("add"), BinOp::Sub => Some("sub"), BinOp::Mul => Some("mul"),
-                    BinOp::Eq => Some("eq"), BinOp::Neq => Some("ne"),
-                    BinOp::Lt => Some("lt"), BinOp::Gt => Some("gt"),
-                    BinOp::Lte => Some("le"), BinOp::Gte => Some("ge"),
+                    BinOp::Add => Some("add"),
+                    BinOp::Sub => Some("sub"),
+                    BinOp::Mul => Some("mul"),
+                    BinOp::Eq => Some("eq"),
+                    BinOp::Neq => Some("ne"),
+                    BinOp::Lt => Some("lt"),
+                    BinOp::Gt => Some("gt"),
+                    BinOp::Lte => Some("le"),
+                    BinOp::Gte => Some("ge"),
                     _ => None,
                 };
                 if let Some(fop) = fop {
@@ -3072,16 +3567,24 @@ fn cpp_expr_inner(expr: &Expr, ctx: &Ctx, is_lhs: bool) -> String {
                 };
             }
             let op_str = match op {
-                BinOp::Add | BinOp::AddWrap => "+",  BinOp::Sub | BinOp::SubWrap => "-",
-                BinOp::Mul | BinOp::MulWrap => "*",  BinOp::Div   => "/",
-                BinOp::Mod    => "%",
-                BinOp::Eq     => "==", BinOp::Neq  => "!=",
-                BinOp::Lt     => "<",  BinOp::Gt   => ">",
-                BinOp::Lte    => "<=", BinOp::Gte  => ">=",
-                BinOp::And    => "&&", BinOp::Or   => "||",
-                BinOp::BitAnd => "&",  BinOp::BitOr => "|",
+                BinOp::Add | BinOp::AddWrap => "+",
+                BinOp::Sub | BinOp::SubWrap => "-",
+                BinOp::Mul | BinOp::MulWrap => "*",
+                BinOp::Div => "/",
+                BinOp::Mod => "%",
+                BinOp::Eq => "==",
+                BinOp::Neq => "!=",
+                BinOp::Lt => "<",
+                BinOp::Gt => ">",
+                BinOp::Lte => "<=",
+                BinOp::Gte => ">=",
+                BinOp::And => "&&",
+                BinOp::Or => "||",
+                BinOp::BitAnd => "&",
+                BinOp::BitOr => "|",
                 BinOp::BitXor => "^",
-                BinOp::Shl    => "<<", BinOp::Shr  => ">>",
+                BinOp::Shl => "<<",
+                BinOp::Shr => ">>",
                 BinOp::Implies | BinOp::ImpliesNext => unreachable!(),
             };
             // Runtime divide-by-zero check for / and % when the divisor is
@@ -3130,8 +3633,10 @@ fn cpp_expr_inner(expr: &Expr, ctx: &Ctx, is_lhs: bool) -> String {
                         | ExprKind::Literal(LitKind::Hex(i))
                         | ExprKind::Literal(LitKind::Bin(i))
                         | ExprKind::Literal(LitKind::Sized(_, i)) => Some(*i),
-                        ExprKind::Ident(loopvar) =>
-                            ctx.loop_var_subst.and_then(|c| c.borrow().get(loopvar).copied()).map(|v| v as u64),
+                        ExprKind::Ident(loopvar) => ctx
+                            .loop_var_subst
+                            .and_then(|c| c.borrow().get(loopvar).copied())
+                            .map(|v| v as u64),
                         _ => None,
                     };
                     if let Some(i) = idx_val {
@@ -3154,7 +3659,8 @@ fn cpp_expr_inner(expr: &Expr, ctx: &Ctx, is_lhs: bool) -> String {
                     // Bounds-checked like every other runtime index.
                     if idx_val.is_none() {
                         let fld = &field.name;
-                        if let Some(n) = ctx.vec_of_bus_port_count
+                        if let Some(n) = ctx
+                            .vec_of_bus_port_count
                             .and_then(|m| m.get(arr_name).copied())
                         {
                             let i = cpp_expr(idx, ctx);
@@ -3162,7 +3668,8 @@ fn cpp_expr_inner(expr: &Expr, ctx: &Ctx, is_lhs: bool) -> String {
                                 "(_ARCH_BCHK(({i}), {n}, \"{arr_name}[i].{fld}\"), {arr_name}_{fld}[{i}])"
                             );
                         }
-                        if let Some(n) = ctx.vec_of_bus_wire_count
+                        if let Some(n) = ctx
+                            .vec_of_bus_wire_count
                             .and_then(|m| m.get(arr_name).copied())
                         {
                             let i = cpp_expr(idx, ctx);
@@ -3198,11 +3705,17 @@ fn cpp_expr_inner(expr: &Expr, ctx: &Ctx, is_lhs: bool) -> String {
             // is correct and we keep the original simple form.
             if let TypeExpr::SInt(w) = &**ty {
                 let w_hdl = eval_width_in(w, ctx);
-                let w_cpp: u32 = if w_hdl <= 8 { 8 }
-                                 else if w_hdl <= 16 { 16 }
-                                 else if w_hdl <= 32 { 32 }
-                                 else if w_hdl <= 64 { 64 }
-                                 else { 0 };  // >64: VlWide / _arch_u128 paths
+                let w_cpp: u32 = if w_hdl <= 8 {
+                    8
+                } else if w_hdl <= 16 {
+                    16
+                } else if w_hdl <= 32 {
+                    32
+                } else if w_hdl <= 64 {
+                    64
+                } else {
+                    0
+                }; // >64: VlWide / _arch_u128 paths
                 let inner_w = infer_expr_width(inner, ctx);
                 if w_cpp > 0 && inner_w > 0 && inner_w < w_cpp {
                     let shift = w_cpp - inner_w;
@@ -3223,7 +3736,9 @@ fn cpp_expr_inner(expr: &Expr, ctx: &Ctx, is_lhs: bool) -> String {
             if is_vec {
                 let limit = ctx.expr_vec_size(base).unwrap_or(0);
                 if limit > 0 && !idx_is_const {
-                    let loc = ctx.vec_path_of_expr(base).unwrap_or_else(|| "<vec>".to_string());
+                    let loc = ctx
+                        .vec_path_of_expr(base)
+                        .unwrap_or_else(|| "<vec>".to_string());
                     format!("(_ARCH_BCHK(({i}), {limit}, \"{loc}\"), {b}[{i}])")
                 } else {
                     format!("{b}[{i}]")
@@ -3248,7 +3763,11 @@ fn cpp_expr_inner(expr: &Expr, ctx: &Ctx, is_lhs: bool) -> String {
             if base_w > 128 {
                 // VlWide<N>: use word-array bit extractor
                 let result_w = h - l + 1;
-                let result_ty = if result_w <= 64 { cpp_uint(result_w) } else { "uint64_t" };
+                let result_ty = if result_w <= 64 {
+                    cpp_uint(result_w)
+                } else {
+                    "uint64_t"
+                };
                 format!("({result_ty})_arch_vw_bits({b}.data(), {h}, {l})")
             } else if base_w > 64 {
                 bit_range_u128(&b, h, l)
@@ -3257,11 +3776,17 @@ fn cpp_expr_inner(expr: &Expr, ctx: &Ctx, is_lhs: bool) -> String {
             }
         }
 
-        ExprKind::PartSelect(base, start, width, up) => cpp_part_select(base, start, width, *up, ctx),
+        ExprKind::PartSelect(base, start, width, up) => {
+            cpp_part_select(base, start, width, *up, ctx)
+        }
 
         ExprKind::EnumVariant(enum_name, variant) => {
             if let Some(variants) = ctx.enum_map.get(&enum_name.name) {
-                let idx = variants.iter().find(|(n, _)| *n == variant.name).map(|(_, v)| *v).unwrap_or(0);
+                let idx = variants
+                    .iter()
+                    .find(|(n, _)| *n == variant.name)
+                    .map(|(_, v)| *v)
+                    .unwrap_or(0);
                 format!("{idx}")
             } else {
                 // Previously this silently emitted `0` with a C++ comment,
@@ -3274,8 +3799,10 @@ fn cpp_expr_inner(expr: &Expr, ctx: &Ctx, is_lhs: bool) -> String {
                      emitting compile-error token",
                     enum_name.name, variant.name
                 );
-                format!("_ARCH_CODEGEN_ERROR_unknown_enum_{}_{}",
-                        enum_name.name, variant.name)
+                format!(
+                    "_ARCH_CODEGEN_ERROR_unknown_enum_{}_{}",
+                    enum_name.name, variant.name
+                )
             }
         }
 
@@ -3346,10 +3873,15 @@ fn cpp_expr_inner(expr: &Expr, ctx: &Ctx, is_lhs: bool) -> String {
             if w == 0 || w > 64 {
                 inner_c
             } else {
-                let w_cpp: u32 = if w <= 8 { 8 }
-                                 else if w <= 16 { 16 }
-                                 else if w <= 32 { 32 }
-                                 else { 64 };
+                let w_cpp: u32 = if w <= 8 {
+                    8
+                } else if w <= 16 {
+                    16
+                } else if w <= 32 {
+                    32
+                } else {
+                    64
+                };
                 if w < w_cpp {
                     let pad = w_cpp - w;
                     format!("((({})({}) << {pad}) >> {pad})", cpp_sint(w), inner_c)
@@ -3406,12 +3938,16 @@ fn cpp_expr_inner(expr: &Expr, ctx: &Ctx, is_lhs: bool) -> String {
             for arm in arms.iter().rev() {
                 let val = cpp_expr(&arm.value, ctx);
                 let cond = match &arm.pattern {
-                    Pattern::Wildcard => { result = val; continue; }
+                    Pattern::Wildcard => {
+                        result = val;
+                        continue;
+                    }
                     Pattern::Ident(id) => {
                         // Mirror Stmt::Match: if the ident names a let
                         // with a literal RHS, treat as `== <literal>`;
                         // else fall through as the ternary tail (default).
-                        let folded = ctx.let_values
+                        let folded = ctx
+                            .let_values
                             .and_then(|m| m.get(&id.name))
                             .filter(|e| matches!(&e.kind, ExprKind::Literal(_)));
                         match folded {
@@ -3419,7 +3955,10 @@ fn cpp_expr_inner(expr: &Expr, ctx: &Ctx, is_lhs: bool) -> String {
                                 let lit = cpp_expr(e, ctx);
                                 format!("({s} == {lit})")
                             }
-                            None => { result = val; continue; }
+                            None => {
+                                result = val;
+                                continue;
+                            }
                         }
                     }
                     Pattern::Literal(e) => {
@@ -3428,7 +3967,11 @@ fn cpp_expr_inner(expr: &Expr, ctx: &Ctx, is_lhs: bool) -> String {
                     }
                     Pattern::EnumVariant(en, vr) => {
                         if let Some(variants) = ctx.enum_map.get(&en.name) {
-                            let idx = variants.iter().find(|(n, _)| *n == vr.name).map(|(_, v)| *v).unwrap_or(0);
+                            let idx = variants
+                                .iter()
+                                .find(|(n, _)| *n == vr.name)
+                                .map(|(_, v)| *v)
+                                .unwrap_or(0);
                             format!("({s} == {idx})")
                         } else {
                             format!("({s} == 0)")
@@ -3446,18 +3989,25 @@ fn cpp_expr_inner(expr: &Expr, ctx: &Ctx, is_lhs: bool) -> String {
 
         ExprKind::Inside(scrutinee, members) => {
             let s = cpp_expr(scrutinee, ctx);
-            let parts: Vec<String> = members.iter().map(|m| match m {
-                InsideMember::Single(e) => {
-                    let v = cpp_expr(e, ctx);
-                    format!("({s} == {v})")
-                }
-                InsideMember::Range(lo, hi) => {
-                    let l = cpp_expr(lo, ctx);
-                    let h = cpp_expr(hi, ctx);
-                    format!("({s} >= {l} && {s} <= {h})")
-                }
-            }).collect();
-            if parts.is_empty() { "0".to_string() } else { format!("({})", parts.join(" || ")) }
+            let parts: Vec<String> = members
+                .iter()
+                .map(|m| match m {
+                    InsideMember::Single(e) => {
+                        let v = cpp_expr(e, ctx);
+                        format!("({s} == {v})")
+                    }
+                    InsideMember::Range(lo, hi) => {
+                        let l = cpp_expr(lo, ctx);
+                        let h = cpp_expr(hi, ctx);
+                        format!("({s} >= {l} && {s} <= {h})")
+                    }
+                })
+                .collect();
+            if parts.is_empty() {
+                "0".to_string()
+            } else {
+                format!("({})", parts.join(" || "))
+            }
         }
     }
 }
@@ -3469,14 +4019,12 @@ fn cpp_expr_inner(expr: &Expr, ctx: &Ctx, is_lhs: bool) -> String {
 fn cpp_unary(op: &UnaryOp, operand: &Expr, ctx: &Ctx) -> String {
     let o = cpp_expr(operand, ctx);
     match op {
-        UnaryOp::Not    => format!("(!{o})"),
+        UnaryOp::Not => format!("(!{o})"),
         UnaryOp::BitNot => {
             // Use logical ! (clamped to 0/1) only for 1-bit/Bool signals.
             // For wider types use bitwise ~.
             let is_one_bit = match &operand.kind {
-                ExprKind::Ident(name) => {
-                    ctx.widths.get(name.as_str()).copied().unwrap_or(32) == 1
-                }
+                ExprKind::Ident(name) => ctx.widths.get(name.as_str()).copied().unwrap_or(32) == 1,
                 _ => false,
             };
             if is_one_bit {
@@ -3485,15 +4033,18 @@ fn cpp_unary(op: &UnaryOp, operand: &Expr, ctx: &Ctx) -> String {
                 format!("(~({o}))")
             }
         }
-        UnaryOp::Neg    => format!("(-{o})"),
+        UnaryOp::Neg => format!("(-{o})"),
         UnaryOp::RedAnd => {
             // Reduction AND: all bits set → 1
             let w = infer_expr_width(operand, ctx);
             if w > 128 {
                 let words = wide_words(w);
                 let last_bits = w % 32;
-                let last_mask = if last_bits == 0 { "0xFFFFFFFFU".to_string() }
-                                else { format!("0x{:X}U", (1u32 << last_bits) - 1) };
+                let last_mask = if last_bits == 0 {
+                    "0xFFFFFFFFU".to_string()
+                } else {
+                    format!("0x{:X}U", (1u32 << last_bits) - 1)
+                };
                 format!("[&](){{auto& _v={o};for(int _i=0;_i<{}-1;_i++)if(_v._data[_i]!=0xFFFFFFFFU)return(uint8_t)0;return(uint8_t)(_v._data[{}]=={last_mask}?1:0);}}()", words, words-1)
             } else if w <= 1 {
                 format!("({o} & 1)")
@@ -3534,7 +4085,11 @@ fn cpp_method_call(base: &Expr, method: &Ident, args: &[Expr], ctx: &Ctx) -> Str
                 let base_w = infer_expr_width(base, ctx);
                 if base_w > 128 && bits <= 64 {
                     // VlWide → narrow: extract low bits via word array
-                    format!("({})_arch_vw_bits({b}.data(), {}, 0)", cpp_uint(bits), bits - 1)
+                    format!(
+                        "({})_arch_vw_bits({b}.data(), {}, 0)",
+                        cpp_uint(bits),
+                        bits - 1
+                    )
                 } else if infer_expr_signed(base, ctx) {
                     cast_to_signed_bits(&b, bits)
                 } else {
@@ -3553,7 +4108,11 @@ fn cpp_method_call(base: &Expr, method: &Ident, args: &[Expr], ctx: &Ctx) -> Str
                     let words = wide_words(bits);
                     format!("VlWide<{words}>(static_cast<uint64_t>({b}))")
                 } else if base_w > 128 && bits <= 64 {
-                    format!("({})_arch_vw_bits({b}.data(), {}, 0)", cpp_uint(bits), bits - 1)
+                    format!(
+                        "({})_arch_vw_bits({b}.data(), {}, 0)",
+                        cpp_uint(bits),
+                        bits - 1
+                    )
                 } else {
                     format!("({})({})", cpp_uint(bits), b)
                 }
@@ -3596,7 +4155,11 @@ fn cpp_method_call(base: &Expr, method: &Ident, args: &[Expr], ctx: &Ctx) -> Str
         }
         "reverse" => {
             let base_w = infer_expr_width(base, ctx);
-            let chunk = if let Some(c) = args.first() { eval_width_in(c, ctx) } else { 1 };
+            let chunk = if let Some(c) = args.first() {
+                eval_width_in(c, ctx)
+            } else {
+                1
+            };
             if chunk == 1 {
                 // Bit-reverse: build at compile time
                 if base_w <= 64 {
@@ -3620,8 +4183,7 @@ fn cpp_method_call(base: &Expr, method: &Ident, args: &[Expr], ctx: &Ctx) -> Str
                 }
             }
         }
-        "any" | "all" | "count" | "contains"
-        | "reduce_or" | "reduce_and" | "reduce_xor" => {
+        "any" | "all" | "count" | "contains" | "reduce_or" | "reduce_and" | "reduce_xor" => {
             lower_vec_method_cpp(&b, base, method, args, ctx)
         }
         // Float conversions → `_arch_fp.h` helpers.
@@ -3661,7 +4223,11 @@ fn cpp_method_call(base: &Expr, method: &Ident, args: &[Expr], ctx: &Ctx) -> Str
             } else {
                 format!("_arch_f32_to_uint({f32bits}, {bits})")
             };
-            let cast = if signed { cpp_sint(bits) } else { cpp_uint(bits) };
+            let cast = if signed {
+                cpp_sint(bits)
+            } else {
+                cpp_uint(bits)
+            };
             format!("(({cast})({conv}))")
         }
         _ => format!("{b}.{}()", method.name),
@@ -3718,14 +4284,23 @@ fn cpp_part_select(base: &Expr, start: &Expr, width: &Expr, up: bool, ctx: &Ctx)
         if up {
             format!("({result_ty})((uint64_t)({b}) >> ({s}) & {mask_str})")
         } else {
-            format!("({result_ty})((uint64_t)({b}) >> (({s}) - {} + 1) & {mask_str})", w)
+            format!(
+                "({result_ty})((uint64_t)({b}) >> (({s}) - {} + 1) & {mask_str})",
+                w
+            )
         }
     };
-    if bchk.is_empty() { core } else { format!("({bchk}{core})") }
+    if bchk.is_empty() {
+        core
+    } else {
+        format!("({bchk}{core})")
+    }
 }
 
 fn cpp_concat(parts: &[Expr], ctx: &Ctx) -> String {
-    if parts.is_empty() { return "0".to_string(); }
+    if parts.is_empty() {
+        return "0".to_string();
+    }
     // Compute widths for each part (MSB first)
     let part_widths: Vec<u32> = parts.iter().map(|p| infer_expr_width(p, ctx)).collect();
     let total: u32 = part_widths.iter().sum();
@@ -3740,11 +4315,14 @@ fn cpp_concat(parts: &[Expr], ctx: &Ctx) -> String {
             let val = cpp_expr(part, ctx);
             // Each part is cast to uint64_t (narrow) then placed into VlWide
             stmts.push(format!(
-                "_r = _r | (VlWide<{words}>(static_cast<uint64_t>({val})) << {bit_offset});"));
+                "_r = _r | (VlWide<{words}>(static_cast<uint64_t>({val})) << {bit_offset});"
+            ));
             bit_offset += w;
         }
-        format!("[&]() -> VlWide<{words}> {{ VlWide<{words}> _r{{}}; {} return _r; }}()",
-                stmts.join(" "))
+        format!(
+            "[&]() -> VlWide<{words}> {{ VlWide<{words}> _r{{}}; {} return _r; }}()",
+            stmts.join(" ")
+        )
     } else {
         // Build expression: accumulate shifts from LSB (last part offset=0)
         let mut terms = Vec::new();
@@ -3765,7 +4343,9 @@ fn cpp_concat(parts: &[Expr], ctx: &Ctx) -> String {
 
 // ── Statement emitters ────────────────────────────────────────────────────────
 
-fn ind(n: usize) -> String { "  ".repeat(n) }
+fn ind(n: usize) -> String {
+    "  ".repeat(n)
+}
 
 /// Sim-codegen analog of `codegen::AssignCtx`. Phase 5b part 4 — drives
 /// the unified `emit_stmt` walker so seq vs comb stmt emission shares
@@ -3816,18 +4396,28 @@ fn emit_stmt(stmt: &Stmt, ctx: &Ctx, out: &mut String, indent: usize, k: SimAssi
                 }
             };
             if let Some(dst_name) = vec_name_of_expr(&a.target) {
-                if ctx.vec_names.map_or(false, |s| s.contains(dst_name.as_str())) {
+                if ctx
+                    .vec_names
+                    .map_or(false, |s| s.contains(dst_name.as_str()))
+                {
                     let lhs = cpp_expr_lhs(&a.target, ctx);
                     let rhs = cpp_expr(&a.value, ctx);
-                    let count = ctx.vec_sizes
+                    let count = ctx
+                        .vec_sizes
                         .and_then(|m| m.get(dst_name.as_str()).copied())
                         .unwrap_or(0);
                     if rhs == "0" {
-                        out.push_str(&format!("{}memset({lhs}, 0, sizeof({lhs}));\n", ind(indent)));
+                        out.push_str(&format!(
+                            "{}memset({lhs}, 0, sizeof({lhs}));\n",
+                            ind(indent)
+                        ));
                         return;
                     }
                     if let Some(rhs_name) = vec_name_of_expr(&a.value) {
-                        if ctx.vec_names.map_or(false, |s| s.contains(rhs_name.as_str())) {
+                        if ctx
+                            .vec_names
+                            .map_or(false, |s| s.contains(rhs_name.as_str()))
+                        {
                             if count > 0 {
                                 out.push_str(&format!(
                                     "{}for (size_t _i = 0; _i < {count}; ++_i) {{ {lhs}[_i] = {rhs}[_i]; }}\n",
@@ -3844,7 +4434,10 @@ fn emit_stmt(stmt: &Stmt, ctx: &Ctx, out: &mut String, indent: usize, k: SimAssi
             // resolve_name's is_lhs flag = is_seq → seq writes hit the shadow.
             if let ExprKind::Index(base, idx_expr) = &a.target.kind {
                 if let ExprKind::Ident(base_name) = &base.kind {
-                    if !ctx.vec_names.map_or(false, |s| s.contains(base_name.as_str())) {
+                    if !ctx
+                        .vec_names
+                        .map_or(false, |s| s.contains(base_name.as_str()))
+                    {
                         let resolved_base = ctx.resolve_name(base_name, is_seq);
                         let idx_cpp = cpp_expr(idx_expr, ctx);
                         let rhs = cpp_expr(&a.value, ctx);
@@ -3870,7 +4463,11 @@ fn emit_stmt(stmt: &Stmt, ctx: &Ctx, out: &mut String, indent: usize, k: SimAssi
                         let hi = eval_width_in(hi_e, ctx);
                         let lo = eval_width_in(lo_e, ctx);
                         let width = hi - lo + 1;
-                        let val_mask: u64 = if width >= 64 { u64::MAX } else { (1u64 << width) - 1 };
+                        let val_mask: u64 = if width >= 64 {
+                            u64::MAX
+                        } else {
+                            (1u64 << width) - 1
+                        };
                         let rhs = cpp_expr(&a.value, ctx);
                         out.push_str(&format!(
                             "{}{resolved_base} = ({resolved_base} & ~(uint64_t(0x{val_mask:X}ULL) << {lo})) | ((uint64_t(({rhs}) & 0x{val_mask:X}ULL)) << {lo});\n",
@@ -3902,8 +4499,13 @@ fn emit_stmt(stmt: &Stmt, ctx: &Ctx, out: &mut String, indent: usize, k: SimAssi
                         // VlWide<ceil(W/32)>. Pass the real word count so a
                         // VlWide<3> (66–96 bit) port is not written out of
                         // bounds (which clobbers the adjacent struct member).
-                        out.push_str(&format!("{}  _arch_u128_to_vl({}, {}._data, {});\n",
-                            ind(indent), rhs, target_name, wide_words(bits)));
+                        out.push_str(&format!(
+                            "{}  _arch_u128_to_vl({}, {}._data, {});\n",
+                            ind(indent),
+                            rhs,
+                            target_name,
+                            wide_words(bits)
+                        ));
                     }
                 } else {
                     out.push_str(&format!("{}{}  = {};\n", ind(indent), resolved_target, rhs));
@@ -3925,22 +4527,39 @@ fn emit_stmt(stmt: &Stmt, ctx: &Ctx, out: &mut String, indent: usize, k: SimAssi
                         // back to `default` when the let is missing or its
                         // RHS isn't a constant — preserves wildcard-binding
                         // semantics for non-let idents.
-                        let folded = ctx.let_values
+                        let folded = ctx
+                            .let_values
                             .and_then(|m| m.get(&id.name))
                             .filter(|e| matches!(&e.kind, ExprKind::Literal(_)));
                         match folded {
-                            Some(e) => (format!("case {}", cpp_expr(e, ctx)),
-                                        format!("match {}", id.name)),
-                            None    => ("default".to_string(),
-                                        format!("match {}", id.name)),
+                            Some(e) => (
+                                format!("case {}", cpp_expr(e, ctx)),
+                                format!("match {}", id.name),
+                            ),
+                            None => ("default".to_string(), format!("match {}", id.name)),
                         }
                     }
-                    Pattern::Literal(e) => (format!("case {}", cpp_expr(e, ctx)), "match lit".to_string()),
+                    Pattern::Literal(e) => (
+                        format!("case {}", cpp_expr(e, ctx)),
+                        "match lit".to_string(),
+                    ),
                     Pattern::EnumVariant(en, vr) => {
                         if let Some(variants) = ctx.enum_map.get(&en.name) {
-                            let idx = variants.iter().find(|(n, _)| *n == vr.name).map(|(_, v)| *v).unwrap_or(0);
-                            (format!("case {idx}"), format!("match {}::{}", en.name, vr.name))
-                        } else { ("default".to_string(), format!("match {}::{}", en.name, vr.name)) }
+                            let idx = variants
+                                .iter()
+                                .find(|(n, _)| *n == vr.name)
+                                .map(|(_, v)| *v)
+                                .unwrap_or(0);
+                            (
+                                format!("case {idx}"),
+                                format!("match {}::{}", en.name, vr.name),
+                            )
+                        } else {
+                            (
+                                "default".to_string(),
+                                format!("match {}::{}", en.name, vr.name),
+                            )
+                        }
                     }
                 };
                 out.push_str(&format!("{}{}: {{\n", ind(indent + 1), case_str));
@@ -3949,7 +4568,11 @@ fn emit_stmt(stmt: &Stmt, ctx: &Ctx, out: &mut String, indent: usize, k: SimAssi
                 // (per-arm spans aren't tracked on MatchArm); the label
                 // disambiguates which arm.
                 if let Some(reg) = ctx.coverage {
-                    let kind = if matches!(arm.pattern, Pattern::Wildcard | Pattern::Ident(_)) { "match-default" } else { "match-arm" };
+                    let kind = if matches!(arm.pattern, Pattern::Wildcard | Pattern::Ident(_)) {
+                        "match-default"
+                    } else {
+                        "match-arm"
+                    };
                     let cidx = reg.borrow_mut().alloc(kind, m.span.start, label);
                     out.push_str(&format!("{}  _arch_cov[{cidx}]++;\n", ind(indent + 1)));
                 }
@@ -3997,13 +4620,16 @@ fn emit_stmt(stmt: &Stmt, ctx: &Ctx, out: &mut String, indent: usize, k: SimAssi
                     Some(v)
                 };
                 if let (Some(start_lit), Some(end_lit)) = (folds_to(rs), folds_to(re)) {
-                    let touches = f.body.iter().any(|s| stmt_indexes_vob_with_var(
-                        s, var, vob_ports, vob_wires,
-                    ));
+                    let touches = f
+                        .body
+                        .iter()
+                        .any(|s| stmt_indexes_vob_with_var(s, var, vob_ports, vob_wires));
                     if touches {
                         for i in start_lit..=end_lit {
                             subst.borrow_mut().insert(var.clone(), i);
-                            for s in &f.body { emit_stmt(s, ctx, out, indent, k); }
+                            for s in &f.body {
+                                emit_stmt(s, ctx, out, indent, k);
+                            }
                         }
                         subst.borrow_mut().remove(var);
                         return;
@@ -4014,8 +4640,13 @@ fn emit_stmt(stmt: &Stmt, ctx: &Ctx, out: &mut String, indent: usize, k: SimAssi
                 ForRange::Range(rs, re) => {
                     let start = cpp_expr(rs, ctx);
                     let end = cpp_expr(re, ctx);
-                    out.push_str(&format!("{}for (int {var} = {start}; {var} <= {end}; {var}++) {{\n", ind(indent)));
-                    for s in &f.body { emit_stmt(s, ctx, out, indent + 1, k); }
+                    out.push_str(&format!(
+                        "{}for (int {var} = {start}; {var} <= {end}; {var}++) {{\n",
+                        ind(indent)
+                    ));
+                    for s in &f.body {
+                        emit_stmt(s, ctx, out, indent + 1, k);
+                    }
                     out.push_str(&format!("{}}}\n", ind(indent)));
                 }
                 ForRange::ValueList(vals) => {
@@ -4023,7 +4654,9 @@ fn emit_stmt(stmt: &Stmt, ctx: &Ctx, out: &mut String, indent: usize, k: SimAssi
                         let val = cpp_expr(v, ctx);
                         out.push_str(&format!("{}{{\n", ind(indent)));
                         out.push_str(&format!("{}int {var} = {val};\n", ind(indent + 1)));
-                        for s in &f.body { emit_stmt(s, ctx, out, indent + 1, k); }
+                        for s in &f.body {
+                            emit_stmt(s, ctx, out, indent + 1, k);
+                        }
                         out.push_str(&format!("{}}}\n", ind(indent)));
                     }
                 }
@@ -4034,9 +4667,15 @@ fn emit_stmt(stmt: &Stmt, ctx: &Ctx, out: &mut String, indent: usize, k: SimAssi
                 unreachable!("Stmt::Init reached emit_stmt(Comb) — typecheck bug");
             }
             let rst_name = &ib.reset_signal.name;
-            let is_low = ctx.reset_levels.get(rst_name.as_str())
+            let is_low = ctx
+                .reset_levels
+                .get(rst_name.as_str())
                 .map_or(false, |level| *level == ResetLevel::Low);
-            let cond = if is_low { format!("(!{})", rst_name) } else { rst_name.clone() };
+            let cond = if is_low {
+                format!("(!{})", rst_name)
+            } else {
+                rst_name.clone()
+            };
             out.push_str(&format!("{}if ({}) {{\n", ind(indent), cond));
             emit_stmts(&ib.body, ctx, out, indent + 1, k);
             out.push_str(&format!("{}}}\n", ind(indent)));
@@ -4052,7 +4691,14 @@ fn emit_stmt(stmt: &Stmt, ctx: &Ctx, out: &mut String, indent: usize, k: SimAssi
     }
 }
 
-fn emit_if_else(ie: &IfElse, ctx: &Ctx, out: &mut String, indent: usize, is_chain: bool, k: SimAssignKind) {
+fn emit_if_else(
+    ie: &IfElse,
+    ctx: &Ctx,
+    out: &mut String,
+    indent: usize,
+    is_chain: bool,
+    k: SimAssignKind,
+) {
     let cond = cpp_condition(&ie.cond, ctx);
     if is_chain {
         out.push_str(&format!("{}}} else if {} {{\n", ind(indent), cond));
@@ -4069,7 +4715,9 @@ fn emit_if_else(ie: &IfElse, ctx: &Ctx, out: &mut String, indent: usize, is_chai
     // loop converges in 1–2 iterations so this is close to cycle count.
     if let Some(reg) = ctx.coverage {
         let kind = if is_chain { "elsif" } else { "if" };
-        let idx = reg.borrow_mut().alloc(kind, ie.cond.span.start, String::new());
+        let idx = reg
+            .borrow_mut()
+            .alloc(kind, ie.cond.span.start, String::new());
         out.push_str(&format!("{}  _arch_cov[{idx}]++;\n", ind(indent)));
     }
     emit_stmts(&ie.then_stmts, ctx, out, indent + 1, k);
@@ -4122,7 +4770,9 @@ fn emit_comb_if_else(ie: &IfElse, ctx: &Ctx, out: &mut String, indent: usize, is
 }
 
 fn emit_log_stmt(l: &LogStmt, ctx: &Ctx, out: &mut String, indent: usize) {
-    let args_str: String = l.args.iter()
+    let args_str: String = l
+        .args
+        .iter()
         .map(|a| format!(", (long long)({})", cpp_expr(a, ctx)))
         .collect();
     let fmt = sv_fmt_to_printf(&l.fmt);
@@ -4130,12 +4780,20 @@ fn emit_log_stmt(l: &LogStmt, ctx: &Ctx, out: &mut String, indent: usize) {
         let fd_name = log_fd_name(path);
         format!(
             "{}if ({fd_name}) fprintf({fd_name}, \"[{}][{}] {}\\n\"{});",
-            ind(indent), l.level.name(), l.tag, fmt, args_str
+            ind(indent),
+            l.level.name(),
+            l.tag,
+            fmt,
+            args_str
         )
     } else {
         format!(
             "{}printf(\"[{}][{}] {}\\n\"{});",
-            ind(indent), l.level.name(), l.tag, fmt, args_str
+            ind(indent),
+            l.level.name(),
+            l.tag,
+            fmt,
+            args_str
         )
     };
     if l.level == LogLevel::Always {
@@ -4144,15 +4802,24 @@ fn emit_log_stmt(l: &LogStmt, ctx: &Ctx, out: &mut String, indent: usize) {
     } else {
         out.push_str(&format!(
             "{}if (Verilated::verbosity() >= {}) {{ {} }}\n",
-            ind(indent), l.level.value(), print_line
+            ind(indent),
+            l.level.value(),
+            print_line
         ));
     }
 }
 
 /// Generate a C++ file pointer name from a log file path.
 fn log_fd_name(path: &str) -> String {
-    let clean: String = path.chars()
-        .map(|c| if c.is_alphanumeric() || c == '_' { c } else { '_' })
+    let clean: String = path
+        .chars()
+        .map(|c| {
+            if c.is_alphanumeric() || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
         .collect();
     format!("_log_fd_{clean}")
 }
@@ -4164,9 +4831,22 @@ fn collect_log_files(body: &[ModuleBodyItem]) -> Vec<String> {
     fn from_comb(stmts: &[Stmt], files: &mut Vec<String>, seen: &mut HashSet<String>) {
         for s in stmts {
             match s {
-                Stmt::Log(l) => { if let Some(ref p) = l.file { if seen.insert(p.clone()) { files.push(p.clone()); } } }
-                Stmt::IfElse(ie) => { from_comb(&ie.then_stmts, files, seen); from_comb(&ie.else_stmts, files, seen); }
-                Stmt::Match(m) => { for arm in &m.arms { from_comb(&arm.body, files, seen); } }
+                Stmt::Log(l) => {
+                    if let Some(ref p) = l.file {
+                        if seen.insert(p.clone()) {
+                            files.push(p.clone());
+                        }
+                    }
+                }
+                Stmt::IfElse(ie) => {
+                    from_comb(&ie.then_stmts, files, seen);
+                    from_comb(&ie.else_stmts, files, seen);
+                }
+                Stmt::Match(m) => {
+                    for arm in &m.arms {
+                        from_comb(&arm.body, files, seen);
+                    }
+                }
                 Stmt::For(f) => from_comb(&f.body, files, seen),
                 _ => {}
             }
@@ -4175,9 +4855,22 @@ fn collect_log_files(body: &[ModuleBodyItem]) -> Vec<String> {
     fn from_seq(stmts: &[Stmt], files: &mut Vec<String>, seen: &mut HashSet<String>) {
         for s in stmts {
             match s {
-                Stmt::Log(l) => { if let Some(ref p) = l.file { if seen.insert(p.clone()) { files.push(p.clone()); } } }
-                Stmt::IfElse(ie) => { from_seq(&ie.then_stmts, files, seen); from_seq(&ie.else_stmts, files, seen); }
-                Stmt::Match(m) => { for arm in &m.arms { from_seq(&arm.body, files, seen); } }
+                Stmt::Log(l) => {
+                    if let Some(ref p) = l.file {
+                        if seen.insert(p.clone()) {
+                            files.push(p.clone());
+                        }
+                    }
+                }
+                Stmt::IfElse(ie) => {
+                    from_seq(&ie.then_stmts, files, seen);
+                    from_seq(&ie.else_stmts, files, seen);
+                }
+                Stmt::Match(m) => {
+                    for arm in &m.arms {
+                        from_seq(&arm.body, files, seen);
+                    }
+                }
                 _ => {}
             }
         }
@@ -4196,16 +4889,33 @@ fn collect_log_files(body: &[ModuleBodyItem]) -> Vec<String> {
 
 fn collect_reg_names(body: &[ModuleBodyItem], ports: &[PortDecl]) -> HashSet<String> {
     body.iter()
-        .filter_map(|i| if let ModuleBodyItem::RegDecl(r) = i { Some(r.name.name.clone()) } else { None })
+        .filter_map(|i| {
+            if let ModuleBodyItem::RegDecl(r) = i {
+                Some(r.name.name.clone())
+            } else {
+                None
+            }
+        })
         .chain(ports.iter().filter_map(|p| {
-            if p.reg_info.is_some() { Some(p.name.name.clone()) } else { None }
+            if p.reg_info.is_some() {
+                Some(p.name.name.clone())
+            } else {
+                None
+            }
         }))
         .collect()
 }
 
 fn collect_port_reg_names(ports: &[PortDecl]) -> HashSet<String> {
-    ports.iter()
-        .filter_map(|p| if p.reg_info.is_some() { Some(p.name.name.clone()) } else { None })
+    ports
+        .iter()
+        .filter_map(|p| {
+            if p.reg_info.is_some() {
+                Some(p.name.name.clone())
+            } else {
+                None
+            }
+        })
         .collect()
 }
 
@@ -4225,8 +4935,10 @@ fn emit_port_reg_public_copy(
 
     let bits = widths.get(name).copied().unwrap_or(0);
     if bits > 64 && bits <= 128 {
-        cpp.push_str(&format!("{indent}_arch_u128_to_vl(_{name}, {name}._data, {});\n",
-            wide_words(bits)));
+        cpp.push_str(&format!(
+            "{indent}_arch_u128_to_vl(_{name}, {name}._data, {});\n",
+            wide_words(bits)
+        ));
     } else {
         cpp.push_str(&format!("{indent}{name} = _{name};\n"));
     }
@@ -4246,7 +4958,9 @@ fn collect_let_names(body: &[ModuleBodyItem]) -> HashSet<String> {
                     out.insert(l.name.name.clone());
                 }
             }
-            ModuleBodyItem::WireDecl(w) => { out.insert(w.name.name.clone()); }
+            ModuleBodyItem::WireDecl(w) => {
+                out.insert(w.name.name.clone());
+            }
             _ => {}
         }
     }
@@ -4305,18 +5019,30 @@ fn collect_comb_reads(stmt: &Stmt, out: &mut std::collections::BTreeSet<String>)
         Stmt::Assign(a) => collect_expr_idents(&a.value, out),
         Stmt::IfElse(ie) => {
             collect_expr_idents(&ie.cond, out);
-            for s in &ie.then_stmts { collect_comb_reads(s, out); }
-            for s in &ie.else_stmts { collect_comb_reads(s, out); }
+            for s in &ie.then_stmts {
+                collect_comb_reads(s, out);
+            }
+            for s in &ie.else_stmts {
+                collect_comb_reads(s, out);
+            }
         }
         Stmt::Log(_) => {}
         Stmt::Match(m) => {
             collect_expr_idents(&m.scrutinee, out);
-            for arm in &m.arms { for s in &arm.body { collect_comb_reads(s, out); } }
+            for arm in &m.arms {
+                for s in &arm.body {
+                    collect_comb_reads(s, out);
+                }
+            }
         }
         Stmt::For(f) => {
-            for s in &f.body { collect_comb_reads(s, out); }
+            for s in &f.body {
+                collect_comb_reads(s, out);
+            }
         }
-            Stmt::Init(_) | Stmt::WaitUntil(..) | Stmt::DoUntil { .. } => unreachable!("seq-only Stmt variant inside comb-context walker"),
+        Stmt::Init(_) | Stmt::WaitUntil(..) | Stmt::DoUntil { .. } => {
+            unreachable!("seq-only Stmt variant inside comb-context walker")
+        }
     }
 }
 
@@ -4327,13 +5053,19 @@ fn collect_stmt_idents(stmt: &Stmt, out: &mut std::collections::BTreeSet<String>
         Stmt::Assign(a) => collect_expr_idents(&a.value, out),
         Stmt::IfElse(ie) => {
             collect_expr_idents(&ie.cond, out);
-            for s in &ie.then_stmts { collect_stmt_idents(s, out); }
-            for s in &ie.else_stmts { collect_stmt_idents(s, out); }
+            for s in &ie.then_stmts {
+                collect_stmt_idents(s, out);
+            }
+            for s in &ie.else_stmts {
+                collect_stmt_idents(s, out);
+            }
         }
         Stmt::Match(m) => {
             collect_expr_idents(&m.scrutinee, out);
             for arm in &m.arms {
-                for s in &arm.body { collect_stmt_idents(s, out); }
+                for s in &arm.body {
+                    collect_stmt_idents(s, out);
+                }
             }
         }
         Stmt::For(f) => {
@@ -4341,16 +5073,24 @@ fn collect_stmt_idents(stmt: &Stmt, out: &mut std::collections::BTreeSet<String>
                 collect_expr_idents(lo, out);
                 collect_expr_idents(hi, out);
             } else if let ForRange::ValueList(vs) = &f.range {
-                for v in vs { collect_expr_idents(v, out); }
+                for v in vs {
+                    collect_expr_idents(v, out);
+                }
             }
-            for s in &f.body { collect_stmt_idents(s, out); }
+            for s in &f.body {
+                collect_stmt_idents(s, out);
+            }
         }
         Stmt::Init(ib) => {
-            for s in &ib.body { collect_stmt_idents(s, out); }
+            for s in &ib.body {
+                collect_stmt_idents(s, out);
+            }
         }
         Stmt::WaitUntil(e, _) => collect_expr_idents(e, out),
         Stmt::DoUntil { body, cond, .. } => {
-            for s in body { collect_stmt_idents(s, out); }
+            for s in body {
+                collect_stmt_idents(s, out);
+            }
             collect_expr_idents(cond, out);
         }
         Stmt::Log(_) => {}
@@ -4359,7 +5099,9 @@ fn collect_stmt_idents(stmt: &Stmt, out: &mut std::collections::BTreeSet<String>
 
 fn collect_expr_idents(expr: &Expr, out: &mut std::collections::BTreeSet<String>) {
     match &expr.kind {
-        ExprKind::Ident(name) => { out.insert(name.clone()); }
+        ExprKind::Ident(name) => {
+            out.insert(name.clone());
+        }
         ExprKind::Binary(_, lhs, rhs) => {
             collect_expr_idents(lhs, out);
             collect_expr_idents(rhs, out);
@@ -4394,10 +5136,14 @@ fn collect_expr_idents(expr: &Expr, out: &mut std::collections::BTreeSet<String>
         }
         ExprKind::MethodCall(base, _, args) => {
             collect_expr_idents(base, out);
-            for a in args { collect_expr_idents(a, out); }
+            for a in args {
+                collect_expr_idents(a, out);
+            }
         }
         ExprKind::FunctionCall(_, args) => {
-            for a in args { collect_expr_idents(a, out); }
+            for a in args {
+                collect_expr_idents(a, out);
+            }
         }
         ExprKind::Ternary(cond, then_e, else_e) => {
             collect_expr_idents(cond, out);
@@ -4406,7 +5152,9 @@ fn collect_expr_idents(expr: &Expr, out: &mut std::collections::BTreeSet<String>
         }
         ExprKind::ExprMatch(scrut, arms) => {
             collect_expr_idents(scrut, out);
-            for arm in arms { collect_expr_idents(&arm.value, out); }
+            for arm in arms {
+                collect_expr_idents(&arm.value, out);
+            }
         }
         _ => {}
     }
@@ -4414,7 +5162,13 @@ fn collect_expr_idents(expr: &Expr, out: &mut std::collections::BTreeSet<String>
 
 fn collect_inst_names(body: &[ModuleBodyItem]) -> HashSet<String> {
     body.iter()
-        .filter_map(|i| if let ModuleBodyItem::Inst(inst) = i { Some(inst.name.name.clone()) } else { None })
+        .filter_map(|i| {
+            if let ModuleBodyItem::Inst(inst) = i {
+                Some(inst.name.name.clone())
+            } else {
+                None
+            }
+        })
         .collect()
 }
 
@@ -4442,10 +5196,15 @@ fn vec_storage_prefix<'a>(
     let_names: &HashSet<String>,
     inst_out: &HashSet<String>,
 ) -> &'a str {
-    if reg_names.contains(name) { "_" }
-    else if let_names.contains(name) { "_let_" }
-    else if inst_out.contains(name) { "" }
-    else { "_let_" }
+    if reg_names.contains(name) {
+        "_"
+    } else if let_names.contains(name) {
+        "_let_"
+    } else if inst_out.contains(name) {
+        ""
+    } else {
+        "_let_"
+    }
 }
 
 fn collect_inst_output_signals(body: &[ModuleBodyItem]) -> HashSet<String> {
@@ -4468,21 +5227,35 @@ fn collect_inst_output_signals(body: &[ModuleBodyItem]) -> HashSet<String> {
 fn collect_comb_targets(body: &[ModuleBodyItem]) -> HashSet<String> {
     fn collect_stmt_targets(stmt: &Stmt, out: &mut HashSet<String>) {
         match stmt {
-            Stmt::Assign(a) => { if let ExprKind::Ident(name) = &a.target.kind { out.insert(name.clone()); } }
+            Stmt::Assign(a) => {
+                if let ExprKind::Ident(name) = &a.target.kind {
+                    out.insert(name.clone());
+                }
+            }
             Stmt::IfElse(ie) => {
-                for s in &ie.then_stmts { collect_stmt_targets(s, out); }
-                for s in &ie.else_stmts { collect_stmt_targets(s, out); }
+                for s in &ie.then_stmts {
+                    collect_stmt_targets(s, out);
+                }
+                for s in &ie.else_stmts {
+                    collect_stmt_targets(s, out);
+                }
             }
             Stmt::Match(m) => {
                 for arm in &m.arms {
-                    for s in &arm.body { collect_stmt_targets(s, out); }
+                    for s in &arm.body {
+                        collect_stmt_targets(s, out);
+                    }
                 }
             }
             Stmt::Log(_) => {}
             Stmt::For(f) => {
-                for s in &f.body { collect_stmt_targets(s, out); }
+                for s in &f.body {
+                    collect_stmt_targets(s, out);
+                }
             }
-                Stmt::Init(_) | Stmt::WaitUntil(..) | Stmt::DoUntil { .. } => unreachable!("seq-only Stmt variant inside comb-context walker"),
+            Stmt::Init(_) | Stmt::WaitUntil(..) | Stmt::DoUntil { .. } => {
+                unreachable!("seq-only Stmt variant inside comb-context walker")
+            }
         }
     }
     let mut targets = HashSet::new();
@@ -4509,9 +5282,17 @@ fn resolve_reg_reset_info(reset: &RegReset, ports: &[PortDecl]) -> Option<(Strin
         RegReset::Inherit(sig, _) => {
             if let Some(p) = ports.iter().find(|p| p.name.name == sig.name) {
                 if let TypeExpr::Reset(kind, level) = &p.ty {
-                    Some((sig.name.clone(), *kind == ResetKind::Async, *level == ResetLevel::Low))
-                } else { None }
-            } else { None }
+                    Some((
+                        sig.name.clone(),
+                        *kind == ResetKind::Async,
+                        *level == ResetLevel::Low,
+                    ))
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
         }
     }
 }
@@ -4529,7 +5310,10 @@ fn build_enum_map(symbols: &SymbolTable) -> HashMap<String, Vec<(String, u64)>> 
     let mut m = HashMap::new();
     for (name, (sym, _)) in &symbols.globals {
         if let Symbol::Enum(info) = sym {
-            let entries: Vec<(String, u64)> = info.variants.iter().enumerate()
+            let entries: Vec<(String, u64)> = info
+                .variants
+                .iter()
+                .enumerate()
                 .map(|(i, v)| {
                     let val = info.values.get(i).and_then(|v| *v).unwrap_or(i as u64);
                     (v.clone(), val)
@@ -4547,15 +5331,20 @@ fn resolve_enum_variant(
     enum_name: &str,
     variant_name: &str,
 ) -> Option<u64> {
-    enum_map
-        .get(enum_name)
-        .and_then(|variants| {
-            variants.iter().find(|(n, _)| n == variant_name).map(|(_, v)| *v)
-        })
+    enum_map.get(enum_name).and_then(|variants| {
+        variants
+            .iter()
+            .find(|(n, _)| n == variant_name)
+            .map(|(_, v)| *v)
+    })
 }
 
 /// Build a name→width map from module ports, regs, and lets.
-fn build_widths(ports: &[PortDecl], body: &[ModuleBodyItem], params: &[ParamDecl]) -> HashMap<String, u32> {
+fn build_widths(
+    ports: &[PortDecl],
+    body: &[ModuleBodyItem],
+    params: &[ParamDecl],
+) -> HashMap<String, u32> {
     let mut m = HashMap::new();
     for p in ports {
         m.insert(p.name.name.clone(), type_bits_te_with_params(&p.ty, params));
@@ -4584,7 +5373,9 @@ fn build_widths(ports: &[PortDecl], body: &[ModuleBodyItem], params: &[ParamDecl
     }
     for item in body {
         match item {
-            ModuleBodyItem::RegDecl(r) => { m.insert(r.name.name.clone(), type_bits_te_with_params(&r.ty, params)); }
+            ModuleBodyItem::RegDecl(r) => {
+                m.insert(r.name.name.clone(), type_bits_te_with_params(&r.ty, params));
+            }
             ModuleBodyItem::WireDecl(w) => {
                 // Wires need width registration too — without this, downstream
                 // sites that consult ctx.widths (the Bool `~` masking check
@@ -4624,14 +5415,12 @@ fn build_widths(ports: &[PortDecl], body: &[ModuleBodyItem], params: &[ParamDecl
     m
 }
 
-#[deprecated(
-    note = "use `type_bits_te_with_params(.., &params)` — the bare \
+#[deprecated(note = "use `type_bits_te_with_params(.., &params)` — the bare \
             form silently miscompiles when a `UInt<W>` / `SInt<W>` \
             width is a param identifier (returns the fallback width \
             of 32 rather than the param's resolved value). See \
-            arch-com#447 §1 and PRs #427, #439, #442."
-)]
-#[allow(dead_code)]  // intentional landmine: present so new callers
+            arch-com#447 §1 and PRs #427, #439, #442.")]
+#[allow(dead_code)] // intentional landmine: present so new callers
                     // surface a deprecation warning at PR review time.
 fn type_bits_te(ty: &TypeExpr) -> u32 {
     type_bits_te_with_params(ty, &[])
@@ -4723,10 +5512,14 @@ fn build_float_names(ports: &[PortDecl], body: &[ModuleBodyItem]) -> HashMap<Str
     for item in body {
         match item {
             ModuleBodyItem::RegDecl(r) => {
-                if let Some(f) = type_float_fmt(&r.ty) { m.insert(r.name.name.clone(), f); }
+                if let Some(f) = type_float_fmt(&r.ty) {
+                    m.insert(r.name.name.clone(), f);
+                }
             }
             ModuleBodyItem::WireDecl(w) => {
-                if let Some(f) = type_float_fmt(&w.ty) { m.insert(w.name.name.clone(), f); }
+                if let Some(f) = type_float_fmt(&w.ty) {
+                    m.insert(w.name.name.clone(), f);
+                }
             }
             ModuleBodyItem::LetBinding(l) => {
                 if let Some(f) = l.ty.as_ref().and_then(type_float_fmt) {
@@ -4740,19 +5533,29 @@ fn build_float_names(ports: &[PortDecl], body: &[ModuleBodyItem]) -> HashMap<Str
 }
 
 /// Collect names whose bit width exceeds 64 (require wide handling).
-fn collect_wide_names(ports: &[PortDecl], body: &[ModuleBodyItem], params: &[ParamDecl]) -> HashSet<String> {
+fn collect_wide_names(
+    ports: &[PortDecl],
+    body: &[ModuleBodyItem],
+    params: &[ParamDecl],
+) -> HashSet<String> {
     let mut s = HashSet::new();
     for p in ports {
-        if type_bits_te_with_params(&p.ty, params) > 64 { s.insert(p.name.name.clone()); }
+        if type_bits_te_with_params(&p.ty, params) > 64 {
+            s.insert(p.name.name.clone());
+        }
     }
     for item in body {
         match item {
             ModuleBodyItem::RegDecl(r) => {
-                if type_bits_te_with_params(&r.ty, params) > 64 { s.insert(r.name.name.clone()); }
+                if type_bits_te_with_params(&r.ty, params) > 64 {
+                    s.insert(r.name.name.clone());
+                }
             }
             ModuleBodyItem::LetBinding(l) => {
                 if let Some(ty) = &l.ty {
-                    if type_bits_te_with_params(ty, params) > 64 { s.insert(l.name.name.clone()); }
+                    if type_bits_te_with_params(ty, params) > 64 {
+                        s.insert(l.name.name.clone());
+                    }
                 }
             }
             _ => {}
@@ -4829,16 +5632,28 @@ impl<'a> SimCodegen<'a> {
             // since user-written `function ... -> T` signatures typically use
             // concrete-width types; tracked as a follow-up to arch-com#463.
             let ret_ty = cpp_internal_type_with_params(&f.ret_ty, &[]);
-            let args_str: Vec<String> = f.args.iter()
-                .map(|a| format!("{} {}", cpp_internal_type_with_params(&a.ty, &[]), a.name.name))
+            let args_str: Vec<String> = f
+                .args
+                .iter()
+                .map(|a| {
+                    format!(
+                        "{} {}",
+                        cpp_internal_type_with_params(&a.ty, &[]),
+                        a.name.name
+                    )
+                })
                 .collect();
-            h.push_str(&format!("inline {ret_ty} {}({}) {{\n", f.name.name, args_str.join(", ")));
+            h.push_str(&format!(
+                "inline {ret_ty} {}({}) {{\n",
+                f.name.name,
+                args_str.join(", ")
+            ));
 
-            let empty_regs:  HashSet<String> = HashSet::new();
-            let empty_lets:  HashSet<String> = HashSet::new();
+            let empty_regs: HashSet<String> = HashSet::new();
+            let empty_lets: HashSet<String> = HashSet::new();
             let empty_insts: HashSet<String> = HashSet::new();
-            let empty_wide:  HashSet<String> = HashSet::new();
-            let enum_map    = build_enum_map(self.symbols);
+            let empty_wide: HashSet<String> = HashSet::new();
+            let enum_map = build_enum_map(self.symbols);
 
             // Build arg + local-let names as bare ports (resolve_name hits
             // them via port_names → no `_let_` prefix, matching the
@@ -4884,23 +5699,40 @@ impl<'a> SimCodegen<'a> {
             let empty_bus: HashSet<String> = HashSet::new();
             let mut local_widths: HashMap<String, u32> = HashMap::new();
             let mut local_signed_names: HashSet<String> = HashSet::new();
-            let mut arg_ports: HashSet<String> = f.args.iter().map(|a| a.name.name.clone()).collect();
+            let mut arg_ports: HashSet<String> =
+                f.args.iter().map(|a| a.name.name.clone()).collect();
             for a in &f.args {
-                local_widths.insert(a.name.name.clone(), match &a.ty {
-                    TypeExpr::UInt(w) | TypeExpr::SInt(w) => eval_width(w),
-                    TypeExpr::Bool | TypeExpr::Bit => 1,
-                    _ => 32,
-                });
+                local_widths.insert(
+                    a.name.name.clone(),
+                    match &a.ty {
+                        TypeExpr::UInt(w) | TypeExpr::SInt(w) => eval_width(w),
+                        TypeExpr::Bool | TypeExpr::Bit => 1,
+                        _ => 32,
+                    },
+                );
                 if type_is_signed_scalar(&a.ty) {
                     local_signed_names.insert(a.name.name.clone());
                 }
             }
-            collect_function_locals(&f.body, &mut arg_ports, &mut local_widths, &mut local_signed_names);
+            collect_function_locals(
+                &f.body,
+                &mut arg_ports,
+                &mut local_widths,
+                &mut local_signed_names,
+            );
             let function_loop_var_subst: std::cell::RefCell<HashMap<String, u32>> =
                 std::cell::RefCell::new(HashMap::new());
-            let ctx_base = Ctx::new(&empty_regs, &arg_ports, &empty_lets, &empty_insts,
-                                    &empty_wide, &local_widths, &enum_map, &empty_bus)
-                .with_signed_names(&local_signed_names);
+            let ctx_base = Ctx::new(
+                &empty_regs,
+                &arg_ports,
+                &empty_lets,
+                &empty_insts,
+                &empty_wide,
+                &local_widths,
+                &enum_map,
+                &empty_bus,
+            )
+            .with_signed_names(&local_signed_names);
             let ctx = Ctx {
                 loop_var_subst: Some(&function_loop_var_subst),
                 ..ctx_base
@@ -4921,8 +5753,10 @@ impl<'a> SimCodegen<'a> {
                 for item in items {
                     match item {
                         FunctionBodyItem::Let(l) => {
-                            let ty = l.ty.as_ref().map(|t| cpp_internal_type_with_params(t, &[]))
-                                .unwrap_or_else(|| "uint32_t".to_string());
+                            let ty =
+                                l.ty.as_ref()
+                                    .map(|t| cpp_internal_type_with_params(t, &[]))
+                                    .unwrap_or_else(|| "uint32_t".to_string());
                             let val = cpp_expr(&l.value, ctx);
                             out.push_str(&format!("{indent}{ty} {} = {};\n", l.name.name, val));
                         }
@@ -4937,7 +5771,13 @@ impl<'a> SimCodegen<'a> {
                             out.push_str(&format!("{indent}}}"));
                             if !ie.else_body.is_empty() {
                                 out.push_str(" else {\n");
-                                emit_fn_items(&ie.else_body, ctx, ret_ty, &format!("{indent}  "), out);
+                                emit_fn_items(
+                                    &ie.else_body,
+                                    ctx,
+                                    ret_ty,
+                                    &format!("{indent}  "),
+                                    out,
+                                );
                                 out.push_str(&format!("{indent}}}\n"));
                             } else {
                                 out.push_str("\n");
@@ -4950,7 +5790,13 @@ impl<'a> SimCodegen<'a> {
                                     let lo_s = cpp_expr(lo, ctx);
                                     let hi_s = cpp_expr(hi, ctx);
                                     out.push_str(&format!("{indent}for (int {var} = {lo_s}; {var} <= {hi_s}; {var}++) {{\n"));
-                                    emit_fn_items(&fl.body, ctx, ret_ty, &format!("{indent}  "), out);
+                                    emit_fn_items(
+                                        &fl.body,
+                                        ctx,
+                                        ret_ty,
+                                        &format!("{indent}  "),
+                                        out,
+                                    );
                                     out.push_str(&format!("{indent}}}\n"));
                                 }
                                 ForRange::ValueList(vals) => {
@@ -4958,7 +5804,13 @@ impl<'a> SimCodegen<'a> {
                                         let v = cpp_expr(val, ctx);
                                         out.push_str(&format!("{indent}{{\n"));
                                         out.push_str(&format!("{indent}  int {var} = {v};\n"));
-                                        emit_fn_items(&fl.body, ctx, ret_ty, &format!("{indent}  "), out);
+                                        emit_fn_items(
+                                            &fl.body,
+                                            ctx,
+                                            ret_ty,
+                                            &format!("{indent}  "),
+                                            out,
+                                        );
                                         out.push_str(&format!("{indent}}}\n"));
                                     }
                                 }
@@ -4977,8 +5829,10 @@ impl<'a> SimCodegen<'a> {
             for item in &f.body {
                 match item {
                     FunctionBodyItem::Let(l) => {
-                        let ty = l.ty.as_ref().map(|t| cpp_internal_type_with_params(t, &[]))
-                            .unwrap_or_else(|| "uint32_t".to_string());
+                        let ty =
+                            l.ty.as_ref()
+                                .map(|t| cpp_internal_type_with_params(t, &[]))
+                                .unwrap_or_else(|| "uint32_t".to_string());
                         let val = cpp_expr(&l.value, &ctx);
                         h.push_str(&format!("  {ty} {} = {};\n", l.name.name, val));
                     }
@@ -5015,7 +5869,11 @@ impl<'a> SimCodegen<'a> {
                                     }
                                     Pattern::EnumVariant(en, vr) => {
                                         if let Some(variants) = enum_map.get(&en.name) {
-                                            let idx = variants.iter().find(|(n, _)| *n == vr.name).map(|(_, v)| *v).unwrap_or(0);
+                                            let idx = variants
+                                                .iter()
+                                                .find(|(n, _)| *n == vr.name)
+                                                .map(|(_, v)| *v)
+                                                .unwrap_or(0);
                                             h.push_str(&format!("    case {idx}: return {val};\n"));
                                         }
                                     }
@@ -5036,7 +5894,7 @@ impl<'a> SimCodegen<'a> {
         SimModel {
             class_name: "VFunctions".to_string(),
             header: h,
-            impl_: String::new(),  // header-only
+            impl_: String::new(), // header-only
         }
     }
 }
@@ -5055,11 +5913,16 @@ fn collect_stmt_assigns(stmts: &[Stmt], out: &mut std::collections::BTreeSet<Str
                 let mut cursor: &Expr = &a.target;
                 loop {
                     match &cursor.kind {
-                        ExprKind::Ident(n) => { out.insert(n.clone()); break; }
+                        ExprKind::Ident(n) => {
+                            out.insert(n.clone());
+                            break;
+                        }
                         ExprKind::Index(base, _)
                         | ExprKind::BitSlice(base, _, _)
                         | ExprKind::PartSelect(base, _, _, _)
-                        | ExprKind::FieldAccess(base, _) => { cursor = base; }
+                        | ExprKind::FieldAccess(base, _) => {
+                            cursor = base;
+                        }
                         _ => break,
                     }
                 }
@@ -5069,7 +5932,9 @@ fn collect_stmt_assigns(stmts: &[Stmt], out: &mut std::collections::BTreeSet<Str
                 collect_stmt_assigns(&ie.else_stmts, out);
             }
             Stmt::Match(m) => {
-                for arm in &m.arms { collect_stmt_assigns(&arm.body, out); }
+                for arm in &m.arms {
+                    collect_stmt_assigns(&arm.body, out);
+                }
             }
             Stmt::Log(_) => {}
             Stmt::For(f) => {
@@ -5167,18 +6032,18 @@ impl<'a> SimCodegen<'a> {
     fn lookup_inst_ports(&self, module_name: &str) -> Vec<PortDecl> {
         for item in &self.source.items {
             let ports = match item {
-                Item::Module(m)       if m.name.name == module_name => Some(&m.ports),
-                Item::Fsm(f)          if f.name.name == module_name => Some(&f.ports),
-                Item::Fifo(f)         if f.name.name == module_name => Some(&f.ports),
-                Item::Ram(r)          if r.name.name == module_name => Some(&r.ports),
-                Item::Cam(c)          if c.name.name == module_name => Some(&c.ports),
-                Item::Counter(c)      if c.name.name == module_name => Some(&c.ports),
-                Item::Arbiter(a)      if a.name.name == module_name => Some(&a.ports),
-                Item::Regfile(r)      if r.name.name == module_name => Some(&r.ports),
-                Item::Pipeline(p)     if p.name.name == module_name => Some(&p.ports),
-                Item::Linklist(l)     if l.name.name == module_name => Some(&l.ports),
+                Item::Module(m) if m.name.name == module_name => Some(&m.ports),
+                Item::Fsm(f) if f.name.name == module_name => Some(&f.ports),
+                Item::Fifo(f) if f.name.name == module_name => Some(&f.ports),
+                Item::Ram(r) if r.name.name == module_name => Some(&r.ports),
+                Item::Cam(c) if c.name.name == module_name => Some(&c.ports),
+                Item::Counter(c) if c.name.name == module_name => Some(&c.ports),
+                Item::Arbiter(a) if a.name.name == module_name => Some(&a.ports),
+                Item::Regfile(r) if r.name.name == module_name => Some(&r.ports),
+                Item::Pipeline(p) if p.name.name == module_name => Some(&p.ports),
+                Item::Linklist(l) if l.name.name == module_name => Some(&l.ports),
                 Item::Synchronizer(s) if s.name.name == module_name => Some(&s.ports),
-                Item::Clkgate(c)      if c.name.name == module_name => Some(&c.ports),
+                Item::Clkgate(c) if c.name.name == module_name => Some(&c.ports),
                 _ => None,
             };
             if let Some(p) = ports {
@@ -5195,18 +6060,18 @@ impl<'a> SimCodegen<'a> {
     fn lookup_inst_params(&self, module_name: &str) -> Vec<ParamDecl> {
         for item in &self.source.items {
             let params = match item {
-                Item::Module(m)       if m.name.name == module_name => Some(&m.params),
-                Item::Fsm(f)          if f.name.name == module_name => Some(&f.params),
-                Item::Fifo(f)         if f.name.name == module_name => Some(&f.params),
-                Item::Ram(r)          if r.name.name == module_name => Some(&r.params),
-                Item::Cam(c)          if c.name.name == module_name => Some(&c.params),
-                Item::Counter(c)      if c.name.name == module_name => Some(&c.params),
-                Item::Arbiter(a)      if a.name.name == module_name => Some(&a.params),
-                Item::Regfile(r)      if r.name.name == module_name => Some(&r.params),
-                Item::Pipeline(p)     if p.name.name == module_name => Some(&p.params),
-                Item::Linklist(l)     if l.name.name == module_name => Some(&l.params),
+                Item::Module(m) if m.name.name == module_name => Some(&m.params),
+                Item::Fsm(f) if f.name.name == module_name => Some(&f.params),
+                Item::Fifo(f) if f.name.name == module_name => Some(&f.params),
+                Item::Ram(r) if r.name.name == module_name => Some(&r.params),
+                Item::Cam(c) if c.name.name == module_name => Some(&c.params),
+                Item::Counter(c) if c.name.name == module_name => Some(&c.params),
+                Item::Arbiter(a) if a.name.name == module_name => Some(&a.params),
+                Item::Regfile(r) if r.name.name == module_name => Some(&r.params),
+                Item::Pipeline(p) if p.name.name == module_name => Some(&p.params),
+                Item::Linklist(l) if l.name.name == module_name => Some(&l.params),
                 Item::Synchronizer(s) if s.name.name == module_name => Some(&s.params),
-                Item::Clkgate(c)      if c.name.name == module_name => Some(&c.params),
+                Item::Clkgate(c) if c.name.name == module_name => Some(&c.params),
                 _ => None,
             };
             if let Some(p) = params {
@@ -5216,7 +6081,12 @@ impl<'a> SimCodegen<'a> {
         Vec::new()
     }
 
-    pub(crate) fn gen_module(&self, m: &ModuleDecl, emit_debug: bool, debug_module_set: &std::collections::HashSet<String>) -> SimModel {
+    pub(crate) fn gen_module(
+        &self,
+        m: &ModuleDecl,
+        emit_debug: bool,
+        debug_module_set: &std::collections::HashSet<String>,
+    ) -> SimModel {
         // Sim-local flatten: SV genvar `generate_for` blocks (which the
         // elaborator preserves when an inst-bearing body's connections
         // are shape-stable) have no sim equivalent. Unroll any preserved
@@ -5241,7 +6111,8 @@ impl<'a> SimCodegen<'a> {
         // --coverage: per-module branch-coverage registry. emit_reg_if_else
         // and (later phase 1b) emit_comb_if_else allocate counter ids here.
         // Threaded into Ctx via .with_coverage(Some(&cov_reg)).
-        let cov_reg: std::cell::RefCell<CoverageRegistry> = std::cell::RefCell::new(CoverageRegistry::default());
+        let cov_reg: std::cell::RefCell<CoverageRegistry> =
+            std::cell::RefCell::new(CoverageRegistry::default());
         let cov_handle: Option<&std::cell::RefCell<CoverageRegistry>> =
             if self.coverage { Some(&cov_reg) } else { None };
 
@@ -5263,7 +6134,9 @@ impl<'a> SimCodegen<'a> {
                 // expression lookup hits a known bus prefix. N is resolved
                 // against the module's params for the param-driven case.
                 match bi.count.as_ref() {
-                    None => { bus_port_names.insert(p.name.name.clone()); }
+                    None => {
+                        bus_port_names.insert(p.name.name.clone());
+                    }
                     Some(count_expr) => {
                         let n = eval_const_expr_with_params(count_expr, &m.params) as u32;
                         for i in 0..n {
@@ -5282,7 +6155,9 @@ impl<'a> SimCodegen<'a> {
             }
         }
 
-        let mut port_names: HashSet<String> = m.ports.iter()
+        let mut port_names: HashSet<String> = m
+            .ports
+            .iter()
             .filter(|p| p.bus_info.is_none())
             .map(|p| p.name.name.clone())
             .collect();
@@ -5292,21 +6167,27 @@ impl<'a> SimCodegen<'a> {
         }
 
         // Collect reset port levels for `.asserted` polarity abstraction
-        let reset_levels: HashMap<String, ResetLevel> = m.ports.iter()
-            .filter_map(|p| if let TypeExpr::Reset(_, level) = &p.ty {
-                Some((p.name.name.clone(), *level))
-            } else { None })
+        let reset_levels: HashMap<String, ResetLevel> = m
+            .ports
+            .iter()
+            .filter_map(|p| {
+                if let TypeExpr::Reset(_, level) = &p.ty {
+                    Some((p.name.name.clone(), *level))
+                } else {
+                    None
+                }
+            })
             .collect();
 
         let mut reg_names = collect_reg_names(&m.body, &m.ports);
         reg_names.extend(collect_pipe_reg_names(&m.body));
         let port_reg_names = collect_port_reg_names(&m.ports);
-        let let_names   = collect_let_names(&m.body);
-        let let_values  = collect_let_values(&m.body, &m.params);
-        let inst_names  = collect_inst_names(&m.body);
-        let inst_out    = collect_inst_output_signals(&m.body);
-        let mut wide_names  = collect_wide_names(&m.ports, &m.body, &m.params);
-        let mut widths      = build_widths(&m.ports, &m.body, &m.params);
+        let let_names = collect_let_names(&m.body);
+        let let_values = collect_let_values(&m.body, &m.params);
+        let inst_names = collect_inst_names(&m.body);
+        let inst_out = collect_inst_output_signals(&m.body);
+        let mut wide_names = collect_wide_names(&m.ports, &m.body, &m.params);
+        let mut widths = build_widths(&m.ports, &m.body, &m.params);
         let mut signed_names = build_signed_names(&m.ports, &m.body);
         let float_names = build_float_names(&m.ports, &m.body);
 
@@ -5322,8 +6203,12 @@ impl<'a> SimCodegen<'a> {
         for (flat_name, flat_ty) in &bus_flat {
             let bits = type_bits_te_with_params(flat_ty, &m.params);
             widths.insert(flat_name.clone(), bits);
-            if type_is_signed_scalar(flat_ty) { signed_names.insert(flat_name.clone()); }
-            if bits > 64 { wide_names.insert(flat_name.clone()); }
+            if type_is_signed_scalar(flat_ty) {
+                signed_names.insert(flat_name.clone());
+            }
+            if bits > 64 {
+                wide_names.insert(flat_name.clone());
+            }
         }
 
         // Populate widths with per-struct-field keys: "ctrl_r.mode" → 4, etc.
@@ -5334,9 +6219,13 @@ impl<'a> SimCodegen<'a> {
             let mut map: HashMap<&str, &StructDecl> = HashMap::new();
             for item in &self.source.items {
                 match item {
-                    Item::Struct(s) => { map.insert(s.name.name.as_str(), s); }
+                    Item::Struct(s) => {
+                        map.insert(s.name.name.as_str(), s);
+                    }
                     Item::Package(p) => {
-                        for s in &p.structs { map.insert(s.name.name.as_str(), s); }
+                        for s in &p.structs {
+                            map.insert(s.name.name.as_str(), s);
+                        }
                     }
                     _ => {}
                 }
@@ -5390,17 +6279,37 @@ impl<'a> SimCodegen<'a> {
         }
 
         // Vec-typed reg names (use C array subscript `[i]` instead of bit extraction)
-        let mut vec_reg_names: HashSet<String> = m.body.iter()
-            .filter_map(|i| if let ModuleBodyItem::RegDecl(r) = i {
-                if matches!(r.ty, TypeExpr::Vec(..)) { Some(r.name.name.clone()) } else { None }
-            } else { None })
+        let mut vec_reg_names: HashSet<String> = m
+            .body
+            .iter()
+            .filter_map(|i| {
+                if let ModuleBodyItem::RegDecl(r) = i {
+                    if matches!(r.ty, TypeExpr::Vec(..)) {
+                        Some(r.name.name.clone())
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                }
+            })
             .collect();
 
         // Vec-typed wires also use C-array indexing internally
-        let vec_wire_names: HashSet<String> = m.body.iter()
-            .filter_map(|i| if let ModuleBodyItem::WireDecl(w) = i {
-                if matches!(w.ty, TypeExpr::Vec(..)) { Some(w.name.name.clone()) } else { None }
-            } else { None })
+        let vec_wire_names: HashSet<String> = m
+            .body
+            .iter()
+            .filter_map(|i| {
+                if let ModuleBodyItem::WireDecl(w) = i {
+                    if matches!(w.ty, TypeExpr::Vec(..)) {
+                        Some(w.name.name.clone())
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                }
+            })
             .collect();
         vec_reg_names.extend(vec_wire_names.iter().cloned());
 
@@ -5414,11 +6323,13 @@ impl<'a> SimCodegen<'a> {
         //     than truncating the inner dim to a scalar)
         //   - same shape for wires whose elem is a non-bus Vec (e.g.
         //     `Vec<Vec<UInt<W>, N>, M>`)
-        let vec_2d_names: HashSet<String> = m.body.iter()
+        let vec_2d_names: HashSet<String> = m
+            .body
+            .iter()
             .filter_map(|i| {
                 let (name, ty) = match i {
                     ModuleBodyItem::WireDecl(w) => (&w.name.name, &w.ty),
-                    ModuleBodyItem::RegDecl(r)  => (&r.name.name, &r.ty),
+                    ModuleBodyItem::RegDecl(r) => (&r.name.name, &r.ty),
                     _ => return None,
                 };
                 if let TypeExpr::Vec(elem, _) = ty {
@@ -5437,12 +6348,21 @@ impl<'a> SimCodegen<'a> {
         // Register these names in vec_reg_names so expr_is_vec recognises
         // them in the Index emitter.
         for p in &m.ports {
-            let Some(bi) = p.bus_info.as_ref() else { continue; };
-            if bi.count.is_none() { continue; }
+            let Some(bi) = p.bus_info.as_ref() else {
+                continue;
+            };
+            if bi.count.is_none() {
+                continue;
+            }
             let bus_name = &bi.bus_name.name;
-            let Some((crate::resolve::Symbol::Bus(info), _)) = self.symbols.globals.get(bus_name) else { continue; };
+            let Some((crate::resolve::Symbol::Bus(info), _)) = self.symbols.globals.get(bus_name)
+            else {
+                continue;
+            };
             let mut pm = info.default_param_map();
-            for pa in &bi.params { pm.insert(pa.name.name.clone(), &pa.value); }
+            for pa in &bi.params {
+                pm.insert(pa.name.name.clone(), &pa.value);
+            }
             for (sname, _, _) in info.effective_signals(&pm) {
                 vec_reg_names.insert(format!("{}_{}", p.name.name, sname));
             }
@@ -5454,17 +6374,31 @@ impl<'a> SimCodegen<'a> {
         // wire connected to a sub-inst Vec input port silently emits zero
         // fan-out lines (loop `for i in 0..0`), leaving the sub-inst's inputs
         // permanently default-constructed.
-        let mut vec_wire_counts: HashMap<String, u64> = m.body.iter()
-            .filter_map(|i| if let ModuleBodyItem::WireDecl(w) = i {
-                if let TypeExpr::Vec(_, count_expr) = &w.ty {
-                    Some((w.name.name.clone(), eval_const_expr_with_params(count_expr, &m.params)))
-                } else { None }
-            } else { None })
+        let mut vec_wire_counts: HashMap<String, u64> = m
+            .body
+            .iter()
+            .filter_map(|i| {
+                if let ModuleBodyItem::WireDecl(w) = i {
+                    if let TypeExpr::Vec(_, count_expr) = &w.ty {
+                        Some((
+                            w.name.name.clone(),
+                            eval_const_expr_with_params(count_expr, &m.params),
+                        ))
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                }
+            })
             .collect();
         for item in &m.body {
             if let ModuleBodyItem::RegDecl(r) = item {
                 if let TypeExpr::Vec(_, count_expr) = &r.ty {
-                    vec_wire_counts.insert(r.name.name.clone(), eval_const_expr_with_params(count_expr, &m.params));
+                    vec_wire_counts.insert(
+                        r.name.name.clone(),
+                        eval_const_expr_with_params(count_expr, &m.params),
+                    );
                 }
             }
         }
@@ -5477,7 +6411,9 @@ impl<'a> SimCodegen<'a> {
             is_input: bool,
             is_port_reg: bool,
         }
-        let mut vec_port_infos: Vec<VecPortInfo> = m.ports.iter()
+        let mut vec_port_infos: Vec<VecPortInfo> = m
+            .ports
+            .iter()
             .filter(|p| p.bus_info.is_none())
             .filter_map(|p| {
                 if let Some((elem_ty, count_str)) = vec_array_info_with_params(&p.ty, &m.params) {
@@ -5494,7 +6430,8 @@ impl<'a> SimCodegen<'a> {
                 }
             })
             .collect();
-        let bus_flat_vec_names: HashSet<String> = bus_flat.iter()
+        let bus_flat_vec_names: HashSet<String> = bus_flat
+            .iter()
             .filter_map(|(flat_name, flat_ty)| {
                 if let Some((elem_ty, count_str)) = vec_array_info_with_params(flat_ty, &m.params) {
                     let count: u64 = count_str.parse().unwrap_or(0);
@@ -5502,7 +6439,11 @@ impl<'a> SimCodegen<'a> {
                         name: flat_name.clone(),
                         elem_ty,
                         count,
-                        is_input: bus_flat_dirs.get(flat_name).copied().unwrap_or(Direction::In) == Direction::In,
+                        is_input: bus_flat_dirs
+                            .get(flat_name)
+                            .copied()
+                            .unwrap_or(Direction::In)
+                            == Direction::In,
                         is_port_reg: false,
                     });
                     Some(flat_name.clone())
@@ -5511,7 +6452,8 @@ impl<'a> SimCodegen<'a> {
                 }
             })
             .collect();
-        let vec_port_names: HashSet<String> = vec_port_infos.iter().map(|v| v.name.clone()).collect();
+        let vec_port_names: HashSet<String> =
+            vec_port_infos.iter().map(|v| v.name.clone()).collect();
         // Vec ports also use C array subscript `[i]` internally
         vec_reg_names.extend(vec_port_names.iter().cloned());
         // Unified Vec<T,N> size map: wires + regs + ports. Used by bounds-check codegen.
@@ -5523,9 +6465,13 @@ impl<'a> SimCodegen<'a> {
         // Needed by the async-reset emitter to lower `reset r => 0` for
         // Vec regs into a per-element loop instead of an invalid scalar
         // `_rf_reg = 0` (a C array isn't assignable from a scalar).
-        for r in m.body.iter().filter_map(|i|
-            if let ModuleBodyItem::RegDecl(r) = i { Some(r) } else { None })
-        {
+        for r in m.body.iter().filter_map(|i| {
+            if let ModuleBodyItem::RegDecl(r) = i {
+                Some(r)
+            } else {
+                None
+            }
+        }) {
             if let TypeExpr::Vec(_, count_expr) = &r.ty {
                 let count = eval_const_expr_with_params(count_expr, &m.params);
                 if count > 0 {
@@ -5555,11 +6501,16 @@ impl<'a> SimCodegen<'a> {
         // typed (notably TLM response payloads), record the `<wire>.<field>`
         // path so instance wiring copies the array element-by-element.
         for item in &m.body {
-            let ModuleBodyItem::WireDecl(w) = item else { continue; };
-            let TypeExpr::Named(id) = &w.ty else { continue; };
-            let Some((crate::resolve::Symbol::Bus(info), _)) =
-                self.symbols.globals.get(&id.name)
-            else { continue; };
+            let ModuleBodyItem::WireDecl(w) = item else {
+                continue;
+            };
+            let TypeExpr::Named(id) = &w.ty else {
+                continue;
+            };
+            let Some((crate::resolve::Symbol::Bus(info), _)) = self.symbols.globals.get(&id.name)
+            else {
+                continue;
+            };
             let pm = info.default_param_map();
             for (sname, _sdir, sty) in info.effective_signals(&pm) {
                 if let TypeExpr::Vec(_, count_expr) = &sty {
@@ -5576,18 +6527,29 @@ impl<'a> SimCodegen<'a> {
         // Collect reset-none reg names for --check-uninit + any guarded reg (regardless
         // of reset) so Check A can use _<name>_vinit to detect producer bugs.
         let mut uninit_regs: HashSet<String> = if self.check_uninit {
-            m.body.iter()
-                .filter_map(|i| if let ModuleBodyItem::RegDecl(r) = i {
-                    if matches!(r.reset, RegReset::None) || r.guard.is_some() {
-                        Some(r.name.name.clone())
-                    } else { None }
-                } else { None })
+            m.body
+                .iter()
+                .filter_map(|i| {
+                    if let ModuleBodyItem::RegDecl(r) = i {
+                        if matches!(r.reset, RegReset::None) || r.guard.is_some() {
+                            Some(r.name.name.clone())
+                        } else {
+                            None
+                        }
+                    } else {
+                        None
+                    }
+                })
                 .chain(m.ports.iter().filter_map(|p| {
                     if let Some(ri) = &p.reg_info {
                         if matches!(ri.reset, RegReset::None) || ri.guard.is_some() {
                             Some(p.name.name.clone())
-                        } else { None }
-                    } else { None }
+                        } else {
+                            None
+                        }
+                    } else {
+                        None
+                    }
                 }))
                 .collect()
         } else {
@@ -5614,15 +6576,20 @@ impl<'a> SimCodegen<'a> {
                 // Bus-typed port: expand flattened signals via the symbol table,
                 // apply per-signal perspective flip, track the ones that are
                 // inputs from THIS module's side.
-                let Some(ref bi) = p.bus_info else { continue; };
+                let Some(ref bi) = p.bus_info else {
+                    continue;
+                };
                 let Some(crate::resolve::Symbol::Bus(info)) =
                     self.symbols.globals.get(&bi.bus_name.name).map(|(s, _)| s)
-                    else { continue; };
+                else {
+                    continue;
+                };
                 // Build param map: bus defaults, overridden by port-site params.
-                let mut param_map: std::collections::HashMap<String, &Expr> =
-                    info.params.iter()
-                        .filter_map(|pd| pd.default.as_ref().map(|d| (pd.name.name.clone(), d)))
-                        .collect();
+                let mut param_map: std::collections::HashMap<String, &Expr> = info
+                    .params
+                    .iter()
+                    .filter_map(|pd| pd.default.as_ref().map(|d| (pd.name.name.clone(), d)))
+                    .collect();
                 for pa in &bi.params {
                     param_map.insert(pa.name.name.clone(), &pa.value);
                 }
@@ -5632,7 +6599,9 @@ impl<'a> SimCodegen<'a> {
                         crate::ast::BusPerspective::Initiator => sdir,
                         crate::ast::BusPerspective::Target => sdir.flip(),
                     };
-                    if !matches!(actual_dir, Direction::In) { continue; }
+                    if !matches!(actual_dir, Direction::In) {
+                        continue;
+                    }
                     // Clock/Reset sub-signals follow the scalar-path exclusion.
                     if matches!(&sty, TypeExpr::Clock(_) | TypeExpr::Reset(_, _)) {
                         continue;
@@ -5660,10 +6629,14 @@ impl<'a> SimCodegen<'a> {
         let mut payload_guards: HashMap<String, String> = HashMap::new();
         if self.inputs_start_uninit {
             for p in m.ports.iter() {
-                let Some(ref bi) = p.bus_info else { continue; };
+                let Some(ref bi) = p.bus_info else {
+                    continue;
+                };
                 let Some(crate::resolve::Symbol::Bus(info)) =
                     self.symbols.globals.get(&bi.bus_name.name).map(|(s, _)| s)
-                    else { continue; };
+                else {
+                    continue;
+                };
                 for hs in &info.handshakes {
                     let guard_expr = match hs.variant.name.as_str() {
                         "valid_ready" | "valid_only" | "valid_stall" => {
@@ -5681,7 +6654,8 @@ impl<'a> SimCodegen<'a> {
                         _ => continue, // ready_only: no producer-valid guard
                     };
                     for payload in &hs.payload_names {
-                        let payload_flat = format!("{}_{}_{}", p.name.name, hs.name.name, payload.name);
+                        let payload_flat =
+                            format!("{}_{}_{}", p.name.name, hs.name.name, payload.name);
                         payload_guards.insert(payload_flat, guard_expr.clone());
                     }
                 }
@@ -5690,13 +6664,23 @@ impl<'a> SimCodegen<'a> {
 
         // Collect guard-annotated regs: reg_name → guard_signal_name.
         // Used for Check A (producer bug: "guard asserts but reg never written").
-        let guarded_regs: HashMap<String, String> = m.body.iter()
-            .filter_map(|i| if let ModuleBodyItem::RegDecl(r) = i {
-                r.guard.as_ref().map(|g| (r.name.name.clone(), g.name.clone()))
-            } else { None })
+        let guarded_regs: HashMap<String, String> = m
+            .body
+            .iter()
+            .filter_map(|i| {
+                if let ModuleBodyItem::RegDecl(r) = i {
+                    r.guard
+                        .as_ref()
+                        .map(|g| (r.name.name.clone(), g.name.clone()))
+                } else {
+                    None
+                }
+            })
             .chain(m.ports.iter().filter_map(|p| {
                 p.reg_info.as_ref().and_then(|ri| {
-                    ri.guard.as_ref().map(|g| (p.name.name.clone(), g.name.clone()))
+                    ri.guard
+                        .as_ref()
+                        .map(|g| (p.name.name.clone(), g.name.clone()))
                 })
             }))
             .collect();
@@ -5704,8 +6688,16 @@ impl<'a> SimCodegen<'a> {
         // Also include inst_out in "known" names for the wide set and widths
         // (they come from sub-inst ports — we'll default them to uint32_t for now)
 
-        let insts: Vec<&InstDecl> = m.body.iter()
-            .filter_map(|i| if let ModuleBodyItem::Inst(inst) = i { Some(inst) } else { None })
+        let insts: Vec<&InstDecl> = m
+            .body
+            .iter()
+            .filter_map(|i| {
+                if let ModuleBodyItem::Inst(inst) = i {
+                    Some(inst)
+                } else {
+                    None
+                }
+            })
             .collect();
 
         // Bus-typed wires in this module — needed by expand_bus_connections so
@@ -5716,36 +6708,49 @@ impl<'a> SimCodegen<'a> {
         // `wire w: Vec<BusName, N>;`. expand_bus_connections needs to see
         // BOTH cases so that `child_port -> w` and `child_port -> w[i]`
         // both lower correctly.
-        let bus_wire_names: HashSet<String> = m.body.iter()
-            .filter_map(|i| if let ModuleBodyItem::WireDecl(w) = i {
-                let bus_named = match &w.ty {
-                    TypeExpr::Named(id) => Some(&id.name),
-                    TypeExpr::Vec(elem, _) => {
-                        if let TypeExpr::Named(id) = elem.as_ref() { Some(&id.name) } else { None }
-                    }
-                    _ => None,
-                };
-                if let Some(bn) = bus_named {
-                    if matches!(self.symbols.globals.get(bn),
-                                Some((crate::resolve::Symbol::Bus(_), _))) {
-                        // Record Vec-of-bus wire counts for the for-loop
-                        // static-unroll path.
-                        if let TypeExpr::Vec(_, size_expr) = &w.ty {
-                            let n = eval_const_expr_with_params(size_expr, &m.params) as u32;
-                            if n > 0 {
-                                vec_of_bus_wire_count_map.insert(w.name.name.clone(), n);
+        let bus_wire_names: HashSet<String> = m
+            .body
+            .iter()
+            .filter_map(|i| {
+                if let ModuleBodyItem::WireDecl(w) = i {
+                    let bus_named = match &w.ty {
+                        TypeExpr::Named(id) => Some(&id.name),
+                        TypeExpr::Vec(elem, _) => {
+                            if let TypeExpr::Named(id) = elem.as_ref() {
+                                Some(&id.name)
+                            } else {
+                                None
                             }
                         }
-                        return Some(w.name.name.clone());
+                        _ => None,
+                    };
+                    if let Some(bn) = bus_named {
+                        if matches!(
+                            self.symbols.globals.get(bn),
+                            Some((crate::resolve::Symbol::Bus(_), _))
+                        ) {
+                            // Record Vec-of-bus wire counts for the for-loop
+                            // static-unroll path.
+                            if let TypeExpr::Vec(_, size_expr) = &w.ty {
+                                let n = eval_const_expr_with_params(size_expr, &m.params) as u32;
+                                if n > 0 {
+                                    vec_of_bus_wire_count_map.insert(w.name.name.clone(), n);
+                                }
+                            }
+                            return Some(w.name.name.clone());
+                        }
                     }
+                    None
+                } else {
+                    None
                 }
-                None
-            } else { None })
+            })
             .collect();
 
         // Pre-expand bus connections: whole-bus connections like `axi_rd -> m_axi_mm2s`
         // are expanded to per-signal connections using the bus definition.
-        let expanded_conns: Vec<Vec<Connection>> = insts.iter()
+        let expanded_conns: Vec<Vec<Connection>> = insts
+            .iter()
             .map(|inst| expand_bus_connections(inst, m, self.source, self.symbols, &bus_wire_names))
             .collect();
 
@@ -5775,18 +6780,27 @@ impl<'a> SimCodegen<'a> {
                 }
             }
             for port in self.lookup_inst_ports(&inst.module_name.name) {
-                let Some(bi) = port.bus_info.as_ref() else { continue; };
+                let Some(bi) = port.bus_info.as_ref() else {
+                    continue;
+                };
                 let Some((crate::resolve::Symbol::Bus(info), _)) =
-                    self.symbols.globals.get(&bi.bus_name.name) else { continue; };
+                    self.symbols.globals.get(&bi.bus_name.name)
+                else {
+                    continue;
+                };
                 let prefixes: Vec<String> = match bi.count.as_ref() {
                     None => vec![port.name.name.clone()],
                     Some(count_expr) => {
                         let n = eval_const_expr_with_params(count_expr, &sub_params);
-                        (0..n).map(|i| format!("{}_{}", port.name.name, i)).collect()
+                        (0..n)
+                            .map(|i| format!("{}_{}", port.name.name, i))
+                            .collect()
                     }
                 };
                 let mut pm = info.default_param_map();
-                for pa in &bi.params { pm.insert(pa.name.name.clone(), &pa.value); }
+                for pa in &bi.params {
+                    pm.insert(pa.name.name.clone(), &pa.value);
+                }
                 for (sname, _, _) in info.effective_signals(&pm) {
                     for prefix in &prefixes {
                         bus_flat_port_names.insert(format!("{}_{}", prefix, sname));
@@ -5806,24 +6820,43 @@ impl<'a> SimCodegen<'a> {
         // private member emission picks the right C++ type (e.g. uint64_t
         // for a 64-bit `send_data` instead of the uint32_t fallback).
         for inst in insts.iter() {
-            for p in &m.ports { let _ = p; }  // placate borrow-check noise
+            for p in &m.ports {
+                let _ = p;
+            } // placate borrow-check noise
             for sub_port in self.lookup_inst_ports(&inst.module_name.name) {
-                let Some(bi) = &sub_port.bus_info else { continue; };
+                let Some(bi) = &sub_port.bus_info else {
+                    continue;
+                };
                 let Some((crate::resolve::Symbol::Bus(info), _)) =
-                    self.symbols.globals.get(&bi.bus_name.name) else { continue; };
+                    self.symbols.globals.get(&bi.bus_name.name)
+                else {
+                    continue;
+                };
                 // Find the parent-side connection name for this bus port.
-                let parent_name = inst.connections.iter()
+                let parent_name = inst
+                    .connections
+                    .iter()
                     .find(|c| c.port_name.name == sub_port.name.name)
-                    .and_then(|c| if let ExprKind::Ident(n) = &c.signal.kind {
-                        Some(n.clone())
-                    } else { None });
-                let Some(parent_name) = parent_name else { continue; };
+                    .and_then(|c| {
+                        if let ExprKind::Ident(n) = &c.signal.kind {
+                            Some(n.clone())
+                        } else {
+                            None
+                        }
+                    });
+                let Some(parent_name) = parent_name else {
+                    continue;
+                };
                 let mut pm = info.default_param_map();
-                for pa in &bi.params { pm.insert(pa.name.name.clone(), &pa.value); }
+                for pa in &bi.params {
+                    pm.insert(pa.name.name.clone(), &pa.value);
+                }
                 for (sname, _sdir, ty) in info.effective_signals(&pm) {
                     let subst_ty = subst_type_expr_sim(&ty, &pm);
                     let bits = type_bits_te_with_params(&subst_ty, &m.params);
-                    widths.entry(format!("{parent_name}_{sname}")).or_insert(bits);
+                    widths
+                        .entry(format!("{parent_name}_{sname}"))
+                        .or_insert(bits);
                     if type_is_signed_scalar(&subst_ty) {
                         signed_names.insert(format!("{parent_name}_{sname}"));
                     }
@@ -5844,13 +6877,24 @@ impl<'a> SimCodegen<'a> {
             }
             let sub_ports = self.lookup_inst_ports(&inst.module_name.name);
             for conn in &expanded_conns[inst_idx] {
-                if conn.direction != ConnectDir::Output { continue; }
-                let ExprKind::Ident(sig_name) = &conn.signal.kind else { continue; };
-                let Some(port) = sub_ports.iter().find(|p| p.name.name == conn.port_name.name) else { continue; };
+                if conn.direction != ConnectDir::Output {
+                    continue;
+                }
+                let ExprKind::Ident(sig_name) = &conn.signal.kind else {
+                    continue;
+                };
+                let Some(port) = sub_ports
+                    .iter()
+                    .find(|p| p.name.name == conn.port_name.name)
+                else {
+                    continue;
+                };
                 if type_is_signed_scalar(&port.ty) {
                     signed_names.insert(sig_name.clone());
                 }
-                widths.entry(sig_name.clone()).or_insert(type_bits_te_with_params(&port.ty, &sub_params));
+                widths
+                    .entry(sig_name.clone())
+                    .or_insert(type_bits_te_with_params(&port.ty, &sub_params));
             }
         }
 
@@ -5858,7 +6902,7 @@ impl<'a> SimCodegen<'a> {
         // When a sub-instance has a Vec output port and the parent connects it to a scalar
         // wire (e.g. thread lowering creates `thread_complete -> thread_complete`), we need
         // to emit flat fields and element-by-element copies instead of scalar assignments.
-        let mut inst_vec_out: HashMap<String, (String, u64)> = HashMap::new();  // sig → (elem_ty, count)
+        let mut inst_vec_out: HashMap<String, (String, u64)> = HashMap::new(); // sig → (elem_ty, count)
         for (inst_idx, inst) in insts.iter().enumerate() {
             let sub_ports = self.lookup_inst_ports(&inst.module_name.name);
             // Build the effective param map for this instance: start with
@@ -5877,8 +6921,13 @@ impl<'a> SimCodegen<'a> {
                 if conn.direction == ConnectDir::Output {
                     if let ExprKind::Ident(sig_name) = &conn.signal.kind {
                         // Check if the port on the sub-instance is a Vec type
-                        if let Some(port) = sub_ports.iter().find(|p| p.name.name == conn.port_name.name) {
-                            if let Some((elem_ty, count_str)) = vec_array_info_with_params(&port.ty, &sub_params) {
+                        if let Some(port) = sub_ports
+                            .iter()
+                            .find(|p| p.name.name == conn.port_name.name)
+                        {
+                            if let Some((elem_ty, count_str)) =
+                                vec_array_info_with_params(&port.ty, &sub_params)
+                            {
                                 let count: u64 = count_str.parse().unwrap_or(0);
                                 if count > 0 {
                                     inst_vec_out.insert(sig_name.clone(), (elem_ty, count));
@@ -5897,8 +6946,14 @@ impl<'a> SimCodegen<'a> {
             vec_reg_names.insert(name.clone());
             // Infer element width from C++ type
             let elem_bits = match elem_ty.as_str() {
-                "uint8_t" => 8, "uint16_t" => 16, "uint32_t" => 32, "uint64_t" => 64,
-                "int8_t" => 8, "int16_t" => 16, "int32_t" => 32, "int64_t" => 64,
+                "uint8_t" => 8,
+                "uint16_t" => 16,
+                "uint32_t" => 32,
+                "uint64_t" => 64,
+                "int8_t" => 8,
+                "int16_t" => 16,
+                "int32_t" => 32,
+                "int64_t" => 64,
                 _ => 32,
             };
             widths.insert(name.clone(), elem_bits * (*count as u32));
@@ -5931,7 +6986,10 @@ impl<'a> SimCodegen<'a> {
         let has_functions = self.source.items.iter().any(|i| match i {
             Item::Function(_) => true,
             Item::Package(p) => !p.functions.is_empty(),
-            Item::Module(mm) => mm.body.iter().any(|b| matches!(b, ModuleBodyItem::Function(_))),
+            Item::Module(mm) => mm
+                .body
+                .iter()
+                .any(|b| matches!(b, ModuleBodyItem::Function(_))),
             _ => false,
         });
 
@@ -5949,11 +7007,18 @@ impl<'a> SimCodegen<'a> {
                 _ => false,
             }
         }
-        let has_structs = m.body.iter().any(|i| matches!(i, ModuleBodyItem::RegDecl(r) if ty_references_named(&r.ty)))
-            || m.body.iter().any(|i| matches!(i, ModuleBodyItem::WireDecl(w) if ty_references_named(&w.ty)))
+        let has_structs = m
+            .body
+            .iter()
+            .any(|i| matches!(i, ModuleBodyItem::RegDecl(r) if ty_references_named(&r.ty)))
+            || m.body
+                .iter()
+                .any(|i| matches!(i, ModuleBodyItem::WireDecl(w) if ty_references_named(&w.ty)))
             || m.ports.iter().any(|p| ty_references_named(&p.ty));
         let mut h = String::new();
-        h.push_str(&format!("#pragma once\n#include <cstdint>\n#include <cstdio>\n#include \"verilated.h\"\n"));
+        h.push_str(&format!(
+            "#pragma once\n#include <cstdint>\n#include <cstdio>\n#include \"verilated.h\"\n"
+        ));
         if has_structs {
             h.push_str("#include \"VStructs.h\"\n");
         }
@@ -5970,14 +7035,22 @@ impl<'a> SimCodegen<'a> {
                 ParamKind::Const | ParamKind::WidthConst(..) | ParamKind::Logic(_) => {
                     if let Some(ref def) = p.default {
                         let val = eval_const_expr_with_params(def, &m.params);
-                        h.push_str(&format!("#ifndef {}\n#define {} {val}ULL\n#endif\n", p.name.name, p.name.name));
+                        h.push_str(&format!(
+                            "#ifndef {}\n#define {} {val}ULL\n#endif\n",
+                            p.name.name, p.name.name
+                        ));
                     }
                 }
                 ParamKind::EnumConst(enum_name) => {
                     if let Some(ref def) = p.default {
                         if let ExprKind::EnumVariant(_, variant) = &def.kind {
-                            if let Some(val) = resolve_enum_variant(&enum_map, enum_name, &variant.name) {
-                                h.push_str(&format!("#ifndef {}\n#define {} {val}ULL\n#endif\n", p.name.name, p.name.name));
+                            if let Some(val) =
+                                resolve_enum_variant(&enum_map, enum_name, &variant.name)
+                            {
+                                h.push_str(&format!(
+                                    "#ifndef {}\n#define {} {val}ULL\n#endif\n",
+                                    p.name.name, p.name.name
+                                ));
                             }
                         }
                     }
@@ -5998,13 +7071,25 @@ impl<'a> SimCodegen<'a> {
         let d2_arrays: Vec<(String, String, String, u64)> = {
             let mut out: Vec<(String, String, String, u64)> = Vec::new();
             for p in &m.ports {
-                let Some(bi) = p.bus_info.as_ref() else { continue; };
-                let Some(count_expr) = bi.count.as_ref() else { continue; };
+                let Some(bi) = p.bus_info.as_ref() else {
+                    continue;
+                };
+                let Some(count_expr) = bi.count.as_ref() else {
+                    continue;
+                };
                 let n = eval_const_expr_with_params(count_expr, &m.params) as u64;
-                if n == 0 { continue; }
+                if n == 0 {
+                    continue;
+                }
                 let bus_name = &bi.bus_name.name;
-                let Some((crate::resolve::Symbol::Bus(info), _)) = self.symbols.globals.get(bus_name) else { continue; };
-                let mut param_map: HashMap<String, &Expr> = info.params.iter()
+                let Some((crate::resolve::Symbol::Bus(info), _)) =
+                    self.symbols.globals.get(bus_name)
+                else {
+                    continue;
+                };
+                let mut param_map: HashMap<String, &Expr> = info
+                    .params
+                    .iter()
                     .filter_map(|pd| pd.default.as_ref().map(|d| (pd.name.name.clone(), d)))
                     .collect();
                 for pa in &bi.params {
@@ -6019,15 +7104,20 @@ impl<'a> SimCodegen<'a> {
             }
             out
         };
-        let d2_alias_names: HashSet<String> = d2_arrays.iter().flat_map(|(port, sname, _, n)| {
-            (0..*n).map(move |i| format!("{}_{}_{}", port, i, sname))
-        }).collect();
+        let d2_alias_names: HashSet<String> = d2_arrays
+            .iter()
+            .flat_map(|(port, sname, _, n)| {
+                (0..*n).map(move |i| format!("{}_{}_{}", port, i, sname))
+            })
+            .collect();
 
         // Public port fields. Vec ports preserve the source-level array as
         // `name[N]` and keep the historical flat lane names (`name_0`, ...)
         // as references into that array for backwards-compatible C++/HARC TBs.
         for p in &m.ports {
-            if p.bus_info.is_some() { continue; }
+            if p.bus_info.is_some() {
+                continue;
+            }
             if let Some(vi) = vec_port_infos.iter().find(|v| v.name == p.name.name) {
                 h.push_str(&format!("  {} {}[{}];\n", vi.elem_ty, vi.name, vi.count));
                 for i in 0..vi.count {
@@ -6046,9 +7136,13 @@ impl<'a> SimCodegen<'a> {
             }
         }
         for (flat_name, flat_ty) in &bus_flat {
-            if bus_flat_vec_names.contains(flat_name) { continue; }
+            if bus_flat_vec_names.contains(flat_name) {
+                continue;
+            }
             // Skip flat names already emitted as D2 aliases.
-            if d2_alias_names.contains(flat_name) { continue; }
+            if d2_alias_names.contains(flat_name) {
+                continue;
+            }
             let ty = cpp_port_type_with_params(flat_ty, &m.params);
             h.push_str(&format!("  {ty} {flat_name};\n"));
         }
@@ -6064,9 +7158,14 @@ impl<'a> SimCodegen<'a> {
 
         // Constructor — build init list. Struct-typed ports get the default
         // ctor (`name()`); scalar ports get `name(0)`.
-        let mut port_inits: Vec<String> = m.ports.iter()
-            .filter(|p| p.bus_info.is_none() && !wide_names.contains(&p.name.name)
-                        && !vec_port_names.contains(&p.name.name))
+        let mut port_inits: Vec<String> = m
+            .ports
+            .iter()
+            .filter(|p| {
+                p.bus_info.is_none()
+                    && !wide_names.contains(&p.name.name)
+                    && !vec_port_names.contains(&p.name.name)
+            })
             .map(|p| {
                 if matches!(p.ty, TypeExpr::Named(_)) {
                     format!("{}()", p.name.name)
@@ -6089,21 +7188,31 @@ impl<'a> SimCodegen<'a> {
         }
         // Add flattened bus signal inits — skip names that are now D2 aliases.
         for (flat_name, _) in &bus_flat {
-            if bus_flat_vec_names.contains(flat_name) { continue; }
-            if d2_alias_names.contains(flat_name) { continue; }
+            if bus_flat_vec_names.contains(flat_name) {
+                continue;
+            }
+            if d2_alias_names.contains(flat_name) {
+                continue;
+            }
             if !wide_names.contains(flat_name) {
                 port_inits.push(format!("{flat_name}(0)"));
             }
         }
         // Collect Vec-array regs that need memset in constructor body
-        let mut vec_reg_inits: Vec<String> = m.body.iter()
+        let mut vec_reg_inits: Vec<String> = m
+            .body
+            .iter()
             .filter_map(|i| {
                 if let ModuleBodyItem::RegDecl(r) = i {
                     if vec_array_info_with_params(&r.ty, &m.params).is_some() {
                         let n = &r.name.name;
                         Some(format!("    memset(_{n}, 0, sizeof(_{n}));"))
-                    } else { None }
-                } else { None }
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                }
             })
             .collect();
         // Add memset for Vec port internal arrays
@@ -6116,47 +7225,71 @@ impl<'a> SimCodegen<'a> {
         // references alias into the array, so zeroing the array also
         // zeros the aliases (no separate init needed).
         for (port, sname, _cpp_ty, _n) in &d2_arrays {
-            vec_reg_inits.push(format!("    memset({port}_{sname}, 0, sizeof({port}_{sname}));"));
+            vec_reg_inits.push(format!(
+                "    memset({port}_{sname}, 0, sizeof({port}_{sname}));"
+            ));
         }
 
-        let reg_inits: Vec<String> = m.body.iter()
-            .filter_map(|i| if let ModuleBodyItem::RegDecl(r) = i {
-                if vec_array_info_with_params(&r.ty, &m.params).is_some() {
-                    None  // handled via memset in constructor body
-                } else if matches!(r.ty, TypeExpr::Named(_)) {
-                    Some(format!("_{}()", r.name.name))  // struct default constructor
-                } else if wide_names.contains(&r.name.name) {
-                    Some(format!("_{}()", r.name.name))  // VlWide or _arch_u128 zero-inits
-                } else {
-                    let init_val = if let Some(ref init_expr) = r.init {
-                        match &init_expr.kind {
-                            ExprKind::Literal(LitKind::Dec(v)) => v.to_string(),
-                            ExprKind::Literal(LitKind::Hex(v)) => format!("0x{:X}", v),
-                            ExprKind::Literal(LitKind::Bin(v)) => v.to_string(),
-                            ExprKind::Literal(LitKind::Sized(_, v)) => v.to_string(),
-                            ExprKind::Bool(b) => if *b { "1".to_string() } else { "0".to_string() },
-                            _ => "0".to_string(),
-                        }
+        let reg_inits: Vec<String> = m
+            .body
+            .iter()
+            .filter_map(|i| {
+                if let ModuleBodyItem::RegDecl(r) = i {
+                    if vec_array_info_with_params(&r.ty, &m.params).is_some() {
+                        None // handled via memset in constructor body
+                    } else if matches!(r.ty, TypeExpr::Named(_)) {
+                        Some(format!("_{}()", r.name.name)) // struct default constructor
+                    } else if wide_names.contains(&r.name.name) {
+                        Some(format!("_{}()", r.name.name)) // VlWide or _arch_u128 zero-inits
                     } else {
-                        "0".to_string()
-                    };
-                    Some(format!("_{}({})", r.name.name, init_val))
+                        let init_val = if let Some(ref init_expr) = r.init {
+                            match &init_expr.kind {
+                                ExprKind::Literal(LitKind::Dec(v)) => v.to_string(),
+                                ExprKind::Literal(LitKind::Hex(v)) => format!("0x{:X}", v),
+                                ExprKind::Literal(LitKind::Bin(v)) => v.to_string(),
+                                ExprKind::Literal(LitKind::Sized(_, v)) => v.to_string(),
+                                ExprKind::Bool(b) => {
+                                    if *b {
+                                        "1".to_string()
+                                    } else {
+                                        "0".to_string()
+                                    }
+                                }
+                                _ => "0".to_string(),
+                            }
+                        } else {
+                            "0".to_string()
+                        };
+                        Some(format!("_{}({})", r.name.name, init_val))
+                    }
+                } else {
+                    None
                 }
-            } else { None })
+            })
             .collect();
         // port reg shadow inits (skip Vec port-regs — they use memset in ctor body)
-        let port_reg_inits: Vec<String> = m.ports.iter()
+        let port_reg_inits: Vec<String> = m
+            .ports
+            .iter()
             .filter_map(|p| {
                 let ri = p.reg_info.as_ref()?;
                 // Vec port-regs are C arrays — can't use (0) in init list
-                if vec_array_info_with_params(&p.ty, &m.params).is_some() { return None; }
+                if vec_array_info_with_params(&p.ty, &m.params).is_some() {
+                    return None;
+                }
                 let init_val = if let Some(ref init_expr) = ri.init {
                     match &init_expr.kind {
                         ExprKind::Literal(LitKind::Dec(v)) => v.to_string(),
                         ExprKind::Literal(LitKind::Hex(v)) => format!("0x{:X}", v),
                         ExprKind::Literal(LitKind::Bin(v)) => v.to_string(),
                         ExprKind::Literal(LitKind::Sized(_, v)) => v.to_string(),
-                        ExprKind::Bool(b) => if *b { "1".to_string() } else { "0".to_string() },
+                        ExprKind::Bool(b) => {
+                            if *b {
+                                "1".to_string()
+                            } else {
+                                "0".to_string()
+                            }
+                        }
                         _ => "0".to_string(),
                     }
                 } else {
@@ -6166,55 +7299,97 @@ impl<'a> SimCodegen<'a> {
             })
             .collect();
         // pipe_reg inits
-        let pipe_reg_inits: Vec<String> = m.body.iter()
-            .filter_map(|i| if let ModuleBodyItem::PipeRegDecl(p) = i {
-                let mut inits = Vec::new();
-                for i in 0..p.stages {
-                    let name = if i == p.stages - 1 {
-                        p.name.name.clone()
-                    } else {
-                        format!("{}_stg{}", p.name.name, i + 1)
-                    };
-                    inits.push(format!("_{}(0)", name));
+        let pipe_reg_inits: Vec<String> = m
+            .body
+            .iter()
+            .filter_map(|i| {
+                if let ModuleBodyItem::PipeRegDecl(p) = i {
+                    let mut inits = Vec::new();
+                    for i in 0..p.stages {
+                        let name = if i == p.stages - 1 {
+                            p.name.name.clone()
+                        } else {
+                            format!("{}_stg{}", p.name.name, i + 1)
+                        };
+                        inits.push(format!("_{}(0)", name));
+                    }
+                    Some(inits)
+                } else {
+                    None
                 }
-                Some(inits)
-            } else { None })
+            })
             .flatten()
             .collect();
         // Collect all clock ports with domain frequency info (multi-domain support)
-        let clk_ports: Vec<String> = m.ports.iter()
+        let clk_ports: Vec<String> = m
+            .ports
+            .iter()
             .filter(|p| matches!(&p.ty, TypeExpr::Clock(_)))
             .map(|p| p.name.name.clone())
             .collect();
         // Map clock port name → freq_mhz (if domain has it)
-        let clk_freqs: Vec<(String, Option<u64>)> = m.ports.iter()
-            .filter_map(|p| if let TypeExpr::Clock(domain) = &p.ty {
-                let freq = self.symbols.globals.get(&domain.name)
-                    .and_then(|(_sym, _span)| if let crate::resolve::Symbol::Domain(info) = _sym { info.freq_mhz } else { None });
-                Some((p.name.name.clone(), freq))
-            } else { None })
+        let clk_freqs: Vec<(String, Option<u64>)> = m
+            .ports
+            .iter()
+            .filter_map(|p| {
+                if let TypeExpr::Clock(domain) = &p.ty {
+                    let freq = self
+                        .symbols
+                        .globals
+                        .get(&domain.name)
+                        .and_then(|(_sym, _span)| {
+                            if let crate::resolve::Symbol::Domain(info) = _sym {
+                                info.freq_mhz
+                            } else {
+                                None
+                            }
+                        });
+                    Some((p.name.name.clone(), freq))
+                } else {
+                    None
+                }
+            })
             .collect();
         // Collect internal clock wires: clocks referenced in `seq on X rising` that are
         // not port-level clocks (i.e. derived from inst outputs, like a clock divider).
         let internal_clks: Vec<String> = {
-            let clk_set: std::collections::HashSet<&str> = clk_ports.iter().map(|s| s.as_str()).collect();
+            let clk_set: std::collections::HashSet<&str> =
+                clk_ports.iter().map(|s| s.as_str()).collect();
             let mut seen = std::collections::HashSet::new();
-            m.body.iter()
-                .filter_map(|i| if let ModuleBodyItem::RegBlock(rb) = i { Some(rb) } else { None })
+            m.body
+                .iter()
+                .filter_map(|i| {
+                    if let ModuleBodyItem::RegBlock(rb) = i {
+                        Some(rb)
+                    } else {
+                        None
+                    }
+                })
                 .filter(|rb| !clk_set.contains(rb.clock.name.as_str()))
                 .filter(|rb| seen.insert(rb.clock.name.clone()))
                 .map(|rb| rb.clock.name.clone())
                 .collect()
         };
         // all_clks = port clocks + internal derived clocks
-        let all_clks: Vec<String> = clk_ports.iter().chain(internal_clks.iter()).cloned().collect();
+        let all_clks: Vec<String> = clk_ports
+            .iter()
+            .chain(internal_clks.iter())
+            .cloned()
+            .collect();
         let has_clk = !all_clks.is_empty();
-        let clk_prev_inits: Vec<String> = all_clks.iter()
+        let clk_prev_inits: Vec<String> = all_clks
+            .iter()
             .map(|c| format!("_clk_prev_{}(0)", c))
             .collect();
-        let all_freqs_known_early = clk_freqs.len() >= 2 && clk_freqs.iter().all(|(_, f)| f.is_some());
-        let time_init = if all_freqs_known_early { vec!["time_ps(0)".to_string()] } else { vec![] };
-        let all_inits: Vec<String> = port_inits.into_iter()
+        let all_freqs_known_early =
+            clk_freqs.len() >= 2 && clk_freqs.iter().all(|(_, f)| f.is_some());
+        let time_init = if all_freqs_known_early {
+            vec!["time_ps(0)".to_string()]
+        } else {
+            vec![]
+        };
+        let all_inits: Vec<String> = port_inits
+            .into_iter()
             .chain(reg_inits)
             .chain(port_reg_inits)
             .chain(pipe_reg_inits)
@@ -6230,18 +7405,33 @@ impl<'a> SimCodegen<'a> {
         let cc_sites = crate::sim_credit_channel::collect_credit_channels(m, self.symbols);
         // Constructor always has a body (for auto-trace open)
         h.push_str(&format!("  {class}() : {} {{\n", all_inits.join(", ")));
-        for line in &vec_reg_inits { h.push_str(&format!("{line}\n")); }
+        for line in &vec_reg_inits {
+            h.push_str(&format!("{line}\n"));
+        }
         // Zero-init credit_channel synthesized fields (DEPTH for the counter).
         crate::sim_credit_channel::emit_constructor_inits(&cc_sites, &mut h);
         for path in &log_files_for_ctor {
-            h.push_str(&format!("    {} = fopen(\"{}\", \"w\");\n", log_fd_name(path), path));
+            h.push_str(&format!(
+                "    {} = fopen(\"{}\", \"w\");\n",
+                log_fd_name(path),
+                path
+            ));
         }
         // Note: VCD auto-open is deferred to first eval() call via Verilated::claimTrace()
         h.push_str("  }\n");
         // Verilator-compatible constructor: accepts VerilatedContext* but ignores it
-        h.push_str(&format!("  explicit {class}(VerilatedContext*) : {class}() {{}}\n"));
+        h.push_str(&format!(
+            "  explicit {class}(VerilatedContext*) : {class}() {{}}\n"
+        ));
         // Collect trace signals for VCD waveform support
-        let trace_signals = collect_trace_signals(&m.ports, &m.body, &wide_names, &widths, &bus_flat, &m.params);
+        let trace_signals = collect_trace_signals(
+            &m.ports,
+            &m.body,
+            &wide_names,
+            &widths,
+            &bus_flat,
+            &m.params,
+        );
         let (trace_h_decls, trace_cpp_impl) = emit_trace_methods(&class, name, &trace_signals);
 
         h.push_str("  void eval();\n");
@@ -6254,14 +7444,19 @@ impl<'a> SimCodegen<'a> {
         // Generate tick() for multi-clock modules with known frequencies
         let all_freqs_known = clk_freqs.len() >= 2 && clk_freqs.iter().all(|(_, f)| f.is_some());
         if all_freqs_known {
-            h.push_str("  void tick();  // advance one time step, auto-toggle clocks at correct ratio\n");
+            h.push_str(
+                "  void tick();  // advance one time step, auto-toggle clocks at correct ratio\n",
+            );
             h.push_str("  uint64_t time_ps;  // current simulation time in picoseconds\n");
         }
         // final(): close trace + log file handles
         h.push_str("  void final() {\n");
         h.push_str("    trace_close();\n");
         for path in &log_files_for_ctor {
-            h.push_str(&format!("    if ({fd}) fclose({fd});\n", fd = log_fd_name(path)));
+            h.push_str(&format!(
+                "    if ({fd}) fclose({fd});\n",
+                fd = log_fd_name(path)
+            ));
         }
         h.push_str("  }\n\n");
         // All members public for pybind11/testbench signal inspection
@@ -6280,16 +7475,30 @@ impl<'a> SimCodegen<'a> {
             for (inst_idx, inst) in insts.iter().enumerate() {
                 let conns = &expanded_conns[inst_idx];
                 for conn in conns {
-                    if conn.direction != ConnectDir::Output { continue; }
-                    let sig_name = if let crate::ast::ExprKind::Ident(n) = &conn.signal.kind { n.as_str() } else { continue; };
+                    if conn.direction != ConnectDir::Output {
+                        continue;
+                    }
+                    let sig_name = if let crate::ast::ExprKind::Ident(n) = &conn.signal.kind {
+                        n.as_str()
+                    } else {
+                        continue;
+                    };
                     let w = widths.get(sig_name).copied().unwrap_or(0);
-                    if w == 0 || w > 64 { continue; }
-                    if wide_names.contains(sig_name) { continue; }
-                    if vec_port_names.contains(sig_name) { continue; }
+                    if w == 0 || w > 64 {
+                        continue;
+                    }
+                    if wide_names.contains(sig_name) {
+                        continue;
+                    }
+                    if vec_port_names.contains(sig_name) {
+                        continue;
+                    }
                     // Skip Vec regs/wires (they connect to flattened
                     // sub-instance port names like `name_0..name_{n-1}`,
                     // not the bare `name`). Phase 6 v1 = scalars only.
-                    if vec_wire_counts.contains_key(sig_name) { continue; }
+                    if vec_wire_counts.contains_key(sig_name) {
+                        continue;
+                    }
                     h.push_str(&format!(
                         "  uint64_t _prev_{}_{} = 0;\n",
                         inst.name.name, conn.port_name.name
@@ -6324,7 +7533,10 @@ impl<'a> SimCodegen<'a> {
                 }
             } else if vec_port_names.contains(&p.name.name) {
                 // Vec non-reg port: also needs internal array for indexed access
-                let vi = vec_port_infos.iter().find(|v| v.name == p.name.name).unwrap();
+                let vi = vec_port_infos
+                    .iter()
+                    .find(|v| v.name == p.name.name)
+                    .unwrap();
                 h.push_str(&format!("  {} _{}[{}];\n", vi.elem_ty, vi.name, vi.count));
             }
         }
@@ -6358,11 +7570,15 @@ impl<'a> SimCodegen<'a> {
 
         // --inputs-start-uninit: inline setters mark an input as initialized when TB drives it.
         if !uninit_inputs.is_empty() {
-            h.push_str("  // --inputs-start-uninit setters (mark TB-driven inputs as initialized)\n");
+            h.push_str(
+                "  // --inputs-start-uninit setters (mark TB-driven inputs as initialized)\n",
+            );
             for p in &m.ports {
                 // Scalar non-bus input.
                 if p.bus_info.is_none() {
-                    if !uninit_inputs.contains(&p.name.name) { continue; }
+                    if !uninit_inputs.contains(&p.name.name) {
+                        continue;
+                    }
                     let pname = &p.name.name;
                     let ty = cpp_port_type_with_params(&p.ty, &m.params);
                     h.push_str(&format!(
@@ -6371,14 +7587,19 @@ impl<'a> SimCodegen<'a> {
                     continue;
                 }
                 // Bus port: emit one setter per flattened In signal.
-                let Some(ref bi) = p.bus_info else { continue; };
+                let Some(ref bi) = p.bus_info else {
+                    continue;
+                };
                 let Some(crate::resolve::Symbol::Bus(info)) =
                     self.symbols.globals.get(&bi.bus_name.name).map(|(s, _)| s)
-                    else { continue; };
-                let mut param_map: std::collections::HashMap<String, &Expr> =
-                    info.params.iter()
-                        .filter_map(|pd| pd.default.as_ref().map(|d| (pd.name.name.clone(), d)))
-                        .collect();
+                else {
+                    continue;
+                };
+                let mut param_map: std::collections::HashMap<String, &Expr> = info
+                    .params
+                    .iter()
+                    .filter_map(|pd| pd.default.as_ref().map(|d| (pd.name.name.clone(), d)))
+                    .collect();
                 for pa in &bi.params {
                     param_map.insert(pa.name.name.clone(), &pa.value);
                 }
@@ -6387,12 +7608,16 @@ impl<'a> SimCodegen<'a> {
                         crate::ast::BusPerspective::Initiator => sdir,
                         crate::ast::BusPerspective::Target => sdir.flip(),
                     };
-                    if !matches!(actual_dir, Direction::In) { continue; }
+                    if !matches!(actual_dir, Direction::In) {
+                        continue;
+                    }
                     if matches!(&sty, TypeExpr::Clock(_) | TypeExpr::Reset(_, _)) {
                         continue;
                     }
                     let flat = format!("{}_{}", p.name.name, sname);
-                    if !uninit_inputs.contains(&flat) { continue; }
+                    if !uninit_inputs.contains(&flat) {
+                        continue;
+                    }
                     let subst_ty = subst_type_expr_sim(&sty, &param_map);
                     let ty = cpp_port_type_with_params(&subst_ty, &m.params);
                     h.push_str(&format!(
@@ -6411,7 +7636,8 @@ impl<'a> SimCodegen<'a> {
                     if !l.destructure_fields.is_empty() {
                         let sname = self.infer_rhs_struct_name(&l.value, &m.ports, &m.body);
                         for bind in &l.destructure_fields {
-                            let ty = sname.as_ref()
+                            let ty = sname
+                                .as_ref()
                                 .and_then(|n| self.lookup_struct_field_ty(n, &bind.name))
                                 .map(|t| cpp_internal_type_with_params(&t, &m.params))
                                 .unwrap_or_else(|| "uint32_t".to_string());
@@ -6420,9 +7646,13 @@ impl<'a> SimCodegen<'a> {
                         continue;
                     }
                     // ty=None: assignment to existing port/wire — no new field needed
-                    if l.ty.is_none() { continue; }
-                    let ty = l.ty.as_ref().map(|t| cpp_internal_type_with_params(t, &m.params))
-                        .unwrap_or_else(|| "uint32_t".to_string());
+                    if l.ty.is_none() {
+                        continue;
+                    }
+                    let ty =
+                        l.ty.as_ref()
+                            .map(|t| cpp_internal_type_with_params(t, &m.params))
+                            .unwrap_or_else(|| "uint32_t".to_string());
                     h.push_str(&format!("  {ty} _let_{};\n", l.name.name));
                 }
                 ModuleBodyItem::WireDecl(w) => {
@@ -6460,7 +7690,11 @@ impl<'a> SimCodegen<'a> {
         for item in &m.body {
             if let ModuleBodyItem::PipeRegDecl(p) = item {
                 let w = widths.get(&p.source.name).copied().unwrap_or(32);
-                let ty = if signed_names.contains(p.source.name.as_str()) { cpp_sint(w) } else { cpp_uint(w) };
+                let ty = if signed_names.contains(p.source.name.as_str()) {
+                    cpp_sint(w)
+                } else {
+                    cpp_uint(w)
+                };
                 for i in 0..p.stages {
                     let name = if i == p.stages - 1 {
                         p.name.name.clone()
@@ -6488,8 +7722,16 @@ impl<'a> SimCodegen<'a> {
                     // (implicit bus wires + flat bus signals propagate through
                     // `widths`). Default to uint32_t when the width isn't
                     // tracked — preserves prior behaviour for plain scalars.
-                    let ty = widths.get(sig_name).copied()
-                        .map(|w| if signed_names.contains(sig_name.as_str()) { cpp_sint(w) } else { cpp_uint(w) })
+                    let ty = widths
+                        .get(sig_name)
+                        .copied()
+                        .map(|w| {
+                            if signed_names.contains(sig_name.as_str()) {
+                                cpp_sint(w)
+                            } else {
+                                cpp_uint(w)
+                            }
+                        })
                         .unwrap_or("uint32_t");
                     h.push_str(&format!("  {ty} {sig_name};\n"));
                 }
@@ -6503,8 +7745,10 @@ impl<'a> SimCodegen<'a> {
         // Private fields for comb-block intermediate signals (not ports/regs/inst_out)
         let comb_targets = collect_comb_targets(&m.body);
         for sig_name in &comb_targets {
-            if !port_names.contains(sig_name) && !reg_names.contains(sig_name)
-                && !inst_out.contains(sig_name) && !let_names.contains(sig_name)
+            if !port_names.contains(sig_name)
+                && !reg_names.contains(sig_name)
+                && !inst_out.contains(sig_name)
+                && !let_names.contains(sig_name)
             {
                 h.push_str(&format!("  uint32_t {sig_name};\n"));
             }
@@ -6512,7 +7756,10 @@ impl<'a> SimCodegen<'a> {
 
         // Sub-instance private fields
         for inst in &insts {
-            h.push_str(&format!("  V{} _inst_{};\n", inst.module_name.name, inst.name.name));
+            h.push_str(&format!(
+                "  V{} _inst_{};\n",
+                inst.module_name.name, inst.name.name
+            ));
         }
 
         // Log file handles
@@ -6528,8 +7775,12 @@ impl<'a> SimCodegen<'a> {
         if emit_debug {
             h.push_str("  // --debug port shadow copies\n");
             for p in &m.ports {
-                if p.bus_info.is_some() { continue; }  // bus flat signals handled below
-                if matches!(&p.ty, TypeExpr::Clock(_)) { continue; }
+                if p.bus_info.is_some() {
+                    continue;
+                } // bus flat signals handled below
+                if matches!(&p.ty, TypeExpr::Clock(_)) {
+                    continue;
+                }
                 let pname = &p.name.name;
                 if let Some(vi) = vec_port_infos.iter().find(|v| v.name == *pname) {
                     // Vec port: one shadow per flat element
@@ -6549,7 +7800,9 @@ impl<'a> SimCodegen<'a> {
             }
             // Bus flat signal shadows
             for (flat_name, flat_ty) in &bus_flat {
-                if matches!(flat_ty, TypeExpr::Vec(..)) { continue; }
+                if matches!(flat_ty, TypeExpr::Vec(..)) {
+                    continue;
+                }
                 let bits = type_width_of(flat_ty);
                 if bits > 64 {
                     let words = wide_words(bits);
@@ -6595,13 +7848,24 @@ impl<'a> SimCodegen<'a> {
 
         // Helper closure: emit sub-instance input assignments + eval_comb + output reads
         // Returns (input_code, comb_call, output_read_code) per inst
-        let ctx = Ctx::new(&reg_names, &port_names, &let_names, &inst_names,
-                           &wide_names, &widths, &enum_map, &bus_port_names)
-                      .with_signed_names(&signed_names).with_float_names(&float_names)
-                      .with_reset_levels(&reset_levels)
-                      .with_vec_names(&vec_reg_names).with_vec_2d_names(&vec_2d_names).with_vec_sizes(&vec_sizes)
-                      .with_let_values(&let_values)
-                      .with_params(&m.params);
+        let ctx = Ctx::new(
+            &reg_names,
+            &port_names,
+            &let_names,
+            &inst_names,
+            &wide_names,
+            &widths,
+            &enum_map,
+            &bus_port_names,
+        )
+        .with_signed_names(&signed_names)
+        .with_float_names(&float_names)
+        .with_reset_levels(&reset_levels)
+        .with_vec_names(&vec_reg_names)
+        .with_vec_2d_names(&vec_2d_names)
+        .with_vec_sizes(&vec_sizes)
+        .with_let_values(&let_values)
+        .with_params(&m.params);
 
         if insts.is_empty() {
             // No sub-instances: simple path
@@ -6654,11 +7918,17 @@ impl<'a> SimCodegen<'a> {
             let is_invariant = |conn: &crate::ast::Connection| -> bool {
                 if let crate::ast::ExprKind::Ident(name) = &conn.signal.kind {
                     // Parent ports: invariant within a cycle.
-                    if port_names.contains(name.as_str()) { return true; }
+                    if port_names.contains(name.as_str()) {
+                        return true;
+                    }
                     // Parent regs: stored value, only changes at posedge.
-                    if reg_names.contains(name.as_str()) { return true; }
+                    if reg_names.contains(name.as_str()) {
+                        return true;
+                    }
                     // Vec port elements: also invariant.
-                    if vec_port_names.contains(name.as_str()) { return true; }
+                    if vec_port_names.contains(name.as_str()) {
+                        return true;
+                    }
                 }
                 // Conservative: anything else (let, wire, expr) is variant.
                 false
@@ -6674,49 +7944,68 @@ impl<'a> SimCodegen<'a> {
                             if let Some(n) = ctx.expr_vec_size(&conn.signal) {
                                 let sig = cpp_expr(&conn.signal, &ctx);
                                 for i in 0..n {
-                                    cpp.push_str(&format!("  _inst_{}.{}_{i} = {sig}[{i}];\n",
-                                        inst.name.name, conn.port_name.name));
+                                    cpp.push_str(&format!(
+                                        "  _inst_{}.{}_{i} = {sig}[{i}];\n",
+                                        inst.name.name, conn.port_name.name
+                                    ));
                                 }
                                 continue;
                             }
                         }
                         if let crate::ast::ExprKind::Ident(src_name) = &conn.signal.kind {
                             if let Some(&n) = vec_wire_counts.get(src_name.as_str()) {
-                                let _vec_pfx = vec_storage_prefix(src_name.as_str(), &reg_names, &let_names, &inst_out);
+                                let _vec_pfx = vec_storage_prefix(
+                                    src_name.as_str(),
+                                    &reg_names,
+                                    &let_names,
+                                    &inst_out,
+                                );
                                 for i in 0..n {
-                                    cpp.push_str(&format!("  _inst_{}.{}_{i} = {_vec_pfx}{src_name}[{i}];\n",
-                                        inst.name.name, conn.port_name.name));
+                                    cpp.push_str(&format!(
+                                        "  _inst_{}.{}_{i} = {_vec_pfx}{src_name}[{i}];\n",
+                                        inst.name.name, conn.port_name.name
+                                    ));
                                 }
                                 continue;
                             }
                             if vec_port_names.contains(src_name.as_str()) {
-                                let n = vec_port_infos.iter()
+                                let n = vec_port_infos
+                                    .iter()
                                     .find(|v| v.name == *src_name)
-                                    .map(|v| v.count).unwrap_or(0);
+                                    .map(|v| v.count)
+                                    .unwrap_or(0);
                                 for i in 0..n {
-                                    cpp.push_str(&format!("  _inst_{}.{}_{i} = {src_name}_{i};\n",
-                                        inst.name.name, conn.port_name.name));
+                                    cpp.push_str(&format!(
+                                        "  _inst_{}.{}_{i} = {src_name}_{i};\n",
+                                        inst.name.name, conn.port_name.name
+                                    ));
                                 }
                                 continue;
                             }
                             if wide_names.contains(src_name.as_str()) {
                                 let resolved = ctx.resolve_name(src_name, false);
-                                cpp.push_str(&format!("  _inst_{}.{} = {};\n",
-                                    inst.name.name, conn.port_name.name, resolved));
+                                cpp.push_str(&format!(
+                                    "  _inst_{}.{} = {};\n",
+                                    inst.name.name, conn.port_name.name, resolved
+                                ));
                                 continue;
                             }
                         }
                         let sig = cpp_expr(&conn.signal, &ctx);
-                        cpp.push_str(&format!("  _inst_{}.{} = {};\n",
-                            inst.name.name, conn.port_name.name, sig));
+                        cpp.push_str(&format!(
+                            "  _inst_{}.{} = {};\n",
+                            inst.name.name, conn.port_name.name, sig
+                        ));
                     }
                 }
             }
 
-            cpp.push_str(&format!("  for (int _settle = 0; _settle < {settle_depth}; _settle++) {{\n"));
+            cpp.push_str(&format!(
+                "  for (int _settle = 0; _settle < {settle_depth}; _settle++) {{\n"
+            ));
             for &inst_idx in &inst_eval_order {
-            let inst = insts[inst_idx];
-            let conns = &expanded_conns[inst_idx];
+                let inst = insts[inst_idx];
+                let conns = &expanded_conns[inst_idx];
                 cpp.push('\n');
                 for conn in conns {
                     if conn.direction == ConnectDir::Input && !is_invariant(conn) {
@@ -6724,8 +8013,10 @@ impl<'a> SimCodegen<'a> {
                             if let Some(n) = ctx.expr_vec_size(&conn.signal) {
                                 let sig = cpp_expr(&conn.signal, &ctx);
                                 for i in 0..n {
-                                    cpp.push_str(&format!("    _inst_{}.{}_{i} = {sig}[{i}];\n",
-                                        inst.name.name, conn.port_name.name));
+                                    cpp.push_str(&format!(
+                                        "    _inst_{}.{}_{i} = {sig}[{i}];\n",
+                                        inst.name.name, conn.port_name.name
+                                    ));
                                 }
                                 continue;
                             }
@@ -6733,10 +8024,17 @@ impl<'a> SimCodegen<'a> {
                         if let crate::ast::ExprKind::Ident(src_name) = &conn.signal.kind {
                             // Vec wire/reg → inst Vec port: expand element-by-element
                             if let Some(&n) = vec_wire_counts.get(src_name.as_str()) {
-                                let _vec_pfx = vec_storage_prefix(src_name.as_str(), &reg_names, &let_names, &inst_out);
+                                let _vec_pfx = vec_storage_prefix(
+                                    src_name.as_str(),
+                                    &reg_names,
+                                    &let_names,
+                                    &inst_out,
+                                );
                                 for i in 0..n {
-                                    cpp.push_str(&format!("    _inst_{}.{}_{i} = {_vec_pfx}{src_name}[{i}];\n",
-                                        inst.name.name, conn.port_name.name));
+                                    cpp.push_str(&format!(
+                                        "    _inst_{}.{}_{i} = {_vec_pfx}{src_name}[{i}];\n",
+                                        inst.name.name, conn.port_name.name
+                                    ));
                                 }
                                 continue;
                             }
@@ -6744,25 +8042,33 @@ impl<'a> SimCodegen<'a> {
                             // parent's src is stored as flat fields
                             // `src_0..src_{n-1}`.
                             if vec_port_names.contains(src_name.as_str()) {
-                                let n = vec_port_infos.iter()
+                                let n = vec_port_infos
+                                    .iter()
                                     .find(|v| v.name == *src_name)
-                                    .map(|v| v.count).unwrap_or(0);
+                                    .map(|v| v.count)
+                                    .unwrap_or(0);
                                 for i in 0..n {
-                                    cpp.push_str(&format!("    _inst_{}.{}_{i} = {src_name}_{i};\n",
-                                        inst.name.name, conn.port_name.name));
+                                    cpp.push_str(&format!(
+                                        "    _inst_{}.{}_{i} = {src_name}_{i};\n",
+                                        inst.name.name, conn.port_name.name
+                                    ));
                                 }
                                 continue;
                             }
                             if wide_names.contains(src_name.as_str()) {
                                 let resolved = ctx.resolve_name(src_name, false);
-                                cpp.push_str(&format!("    _inst_{}.{} = {};\n",
-                                    inst.name.name, conn.port_name.name, resolved));
+                                cpp.push_str(&format!(
+                                    "    _inst_{}.{} = {};\n",
+                                    inst.name.name, conn.port_name.name, resolved
+                                ));
                                 continue;
                             }
                         }
                         let sig = cpp_expr(&conn.signal, &ctx);
-                        cpp.push_str(&format!("    _inst_{}.{} = {};\n",
-                            inst.name.name, conn.port_name.name, sig));
+                        cpp.push_str(&format!(
+                            "    _inst_{}.{} = {};\n",
+                            inst.name.name, conn.port_name.name, sig
+                        ));
                     }
                 }
                 cpp.push_str(&format!("    _inst_{}.eval_comb();\n", inst.name.name));
@@ -6772,8 +8078,10 @@ impl<'a> SimCodegen<'a> {
                             if let Some(n) = ctx.expr_vec_size(&conn.signal) {
                                 let sig = cpp_expr(&conn.signal, &ctx);
                                 for i in 0..n {
-                                    cpp.push_str(&format!("    {sig}[{i}] = _inst_{}.{}_{i};\n",
-                                        inst.name.name, conn.port_name.name));
+                                    cpp.push_str(&format!(
+                                        "    {sig}[{i}] = _inst_{}.{}_{i};\n",
+                                        inst.name.name, conn.port_name.name
+                                    ));
                                 }
                                 continue;
                             }
@@ -6794,17 +8102,32 @@ impl<'a> SimCodegen<'a> {
                                     // field directly here would be clobbered
                                     // by that sync.
                                     for i in 0..n {
-                                        cpp.push_str(&format!("    _{sig_name}[{i}] = _inst_{}.{}_{i};\n",
-                                            inst.name.name, conn.port_name.name));
+                                        cpp.push_str(&format!(
+                                            "    _{sig_name}[{i}] = _inst_{}.{}_{i};\n",
+                                            inst.name.name, conn.port_name.name
+                                        ));
                                     }
                                     if port_reg_names.contains(sig_name.as_str()) {
-                                        emit_port_reg_public_copy(&mut cpp, sig_name, &widths, Some(n), "    ");
+                                        emit_port_reg_public_copy(
+                                            &mut cpp,
+                                            sig_name,
+                                            &widths,
+                                            Some(n),
+                                            "    ",
+                                        );
                                     }
                                 } else {
-                                    let prefix = vec_storage_prefix(sig_name.as_str(), &reg_names, &let_names, &inst_out);
+                                    let prefix = vec_storage_prefix(
+                                        sig_name.as_str(),
+                                        &reg_names,
+                                        &let_names,
+                                        &inst_out,
+                                    );
                                     for i in 0..n {
-                                        cpp.push_str(&format!("    {prefix}{sig_name}[{i}] = _inst_{}.{}_{i};\n",
-                                            inst.name.name, conn.port_name.name));
+                                        cpp.push_str(&format!(
+                                            "    {prefix}{sig_name}[{i}] = _inst_{}.{}_{i};\n",
+                                            inst.name.name, conn.port_name.name
+                                        ));
                                     }
                                 }
                                 continue;
@@ -6814,13 +8137,22 @@ impl<'a> SimCodegen<'a> {
                         // Wide type (>64 bits): inst port is VlWide, parent reg is _arch_u128
                         let _out_w = if let ExprKind::Ident(n) = &conn.signal.kind {
                             widths.get(n.as_str()).copied().unwrap_or(0)
-                        } else { 0 };
-                        if _out_w > 64 {
-                            cpp.push_str(&format!("    {} = _arch_vl_to_u128(_inst_{}.{}.data(), {});\n",
-                                sig, inst.name.name, conn.port_name.name, wide_words(_out_w)));
                         } else {
-                            cpp.push_str(&format!("    {} = _inst_{}.{};\n",
-                                sig, inst.name.name, conn.port_name.name));
+                            0
+                        };
+                        if _out_w > 64 {
+                            cpp.push_str(&format!(
+                                "    {} = _arch_vl_to_u128(_inst_{}.{}.data(), {});\n",
+                                sig,
+                                inst.name.name,
+                                conn.port_name.name,
+                                wide_words(_out_w)
+                            ));
+                        } else {
+                            cpp.push_str(&format!(
+                                "    {} = _inst_{}.{};\n",
+                                sig, inst.name.name, conn.port_name.name
+                            ));
                         }
                         if let ExprKind::Ident(name) = &conn.signal.kind {
                             if port_reg_names.contains(name.as_str()) {
@@ -6842,179 +8174,243 @@ impl<'a> SimCodegen<'a> {
             cpp.push_str("  } // settle\n");
 
             if has_clk {
-            // Step 2: eval_posedge detects edges internally (after settle, so derived clocks are valid)
-            cpp.push_str("  eval_posedge();\n");
+                // Step 2: eval_posedge detects edges internally (after settle, so derived clocks are valid)
+                cpp.push_str("  eval_posedge();\n");
 
-            // Step 3: refresh sub-inst comb outputs, then parent comb (with settle loop)
-            // Hoist invariant inputs (post-posedge values for ports/regs)
-            // out of the settle loop, mirroring the optimization above.
-            for &inst_idx in &inst_eval_order {
-                let inst = insts[inst_idx];
-                let conns = &expanded_conns[inst_idx];
-                for conn in conns {
-                    if conn.direction == ConnectDir::Input && is_invariant(conn) {
-                        if !matches!(conn.signal.kind, ExprKind::Ident(_)) {
-                            if let Some(n) = ctx.expr_vec_size(&conn.signal) {
-                                let sig = cpp_expr(&conn.signal, &ctx);
-                                for i in 0..n {
-                                    cpp.push_str(&format!("  _inst_{}.{}_{i} = {sig}[{i}];\n",
-                                        inst.name.name, conn.port_name.name));
-                                }
-                                continue;
-                            }
-                        }
-                        if let crate::ast::ExprKind::Ident(src_name) = &conn.signal.kind {
-                            if let Some(&n) = vec_wire_counts.get(src_name.as_str()) {
-                                let _vec_pfx = vec_storage_prefix(src_name.as_str(), &reg_names, &let_names, &inst_out);
-                                for i in 0..n {
-                                    cpp.push_str(&format!("  _inst_{}.{}_{i} = {_vec_pfx}{src_name}[{i}];\n",
-                                        inst.name.name, conn.port_name.name));
-                                }
-                                continue;
-                            }
-                            if vec_port_names.contains(src_name.as_str()) {
-                                let n = vec_port_infos.iter()
-                                    .find(|v| v.name == *src_name)
-                                    .map(|v| v.count).unwrap_or(0);
-                                for i in 0..n {
-                                    cpp.push_str(&format!("  _inst_{}.{}_{i} = {src_name}_{i};\n",
-                                        inst.name.name, conn.port_name.name));
-                                }
-                                continue;
-                            }
-                            if wide_names.contains(src_name.as_str()) {
-                                let resolved = ctx.resolve_name(src_name, false);
-                                cpp.push_str(&format!("  _inst_{}.{} = {};\n",
-                                    inst.name.name, conn.port_name.name, resolved));
-                                continue;
-                            }
-                        }
-                        let sig = cpp_expr(&conn.signal, &ctx);
-                        cpp.push_str(&format!("  _inst_{}.{} = {};\n",
-                            inst.name.name, conn.port_name.name, sig));
-                    }
-                }
-            }
-            cpp.push_str(&format!("  for (int _settle = 0; _settle < {settle_depth}; _settle++) {{\n"));
-            for &inst_idx in &inst_eval_order {
-            let inst = insts[inst_idx];
-            let conns = &expanded_conns[inst_idx];
-                // Re-set sub-inst inputs (may have changed after posedge)
-                for conn in conns {
-                    if conn.direction == ConnectDir::Input && !is_invariant(conn) {
-                        if !matches!(conn.signal.kind, ExprKind::Ident(_)) {
-                            if let Some(n) = ctx.expr_vec_size(&conn.signal) {
-                                let sig = cpp_expr(&conn.signal, &ctx);
-                                for i in 0..n {
-                                    cpp.push_str(&format!("    _inst_{}.{}_{i} = {sig}[{i}];\n",
-                                        inst.name.name, conn.port_name.name));
-                                }
-                                continue;
-                            }
-                        }
-                        if let crate::ast::ExprKind::Ident(src_name) = &conn.signal.kind {
-                            // Vec wire/reg → inst Vec port: expand element-by-element
-                            if let Some(&n) = vec_wire_counts.get(src_name.as_str()) {
-                                let _vec_pfx = vec_storage_prefix(src_name.as_str(), &reg_names, &let_names, &inst_out);
-                                for i in 0..n {
-                                    cpp.push_str(&format!("    _inst_{}.{}_{i} = {_vec_pfx}{src_name}[{i}];\n",
-                                        inst.name.name, conn.port_name.name));
-                                }
-                                continue;
-                            }
-                            // Parent Vec PORT (input) → inst Vec port:
-                            // parent's src is stored as flat fields
-                            // `src_0..src_{n-1}`.
-                            if vec_port_names.contains(src_name.as_str()) {
-                                let n = vec_port_infos.iter()
-                                    .find(|v| v.name == *src_name)
-                                    .map(|v| v.count).unwrap_or(0);
-                                for i in 0..n {
-                                    cpp.push_str(&format!("    _inst_{}.{}_{i} = {src_name}_{i};\n",
-                                        inst.name.name, conn.port_name.name));
-                                }
-                                continue;
-                            }
-                            if wide_names.contains(src_name.as_str()) {
-                                let resolved = ctx.resolve_name(src_name, false);
-                                cpp.push_str(&format!("    _inst_{}.{} = {};\n",
-                                    inst.name.name, conn.port_name.name, resolved));
-                                continue;
-                            }
-                        }
-                        let sig = cpp_expr(&conn.signal, &ctx);
-                        cpp.push_str(&format!("    _inst_{}.{} = {};\n",
-                            inst.name.name, conn.port_name.name, sig));
-                    }
-                }
-                cpp.push_str(&format!("    _inst_{}.eval_comb();\n", inst.name.name));
-                for conn in conns {
-                    if conn.direction == ConnectDir::Output {
-                        if !matches!(conn.signal.kind, ExprKind::Ident(_)) {
-                            if let Some(n) = ctx.expr_vec_size(&conn.signal) {
-                                let sig = cpp_expr(&conn.signal, &ctx);
-                                for i in 0..n {
-                                    cpp.push_str(&format!("    {sig}[{i}] = _inst_{}.{}_{i};\n",
-                                        inst.name.name, conn.port_name.name));
-                                }
-                                continue;
-                            }
-                        }
-                        // inst Vec port → Vec wire/reg: expand element-by-element
-                        if let ExprKind::Ident(sig_name) = &conn.signal.kind {
-                            if let Some(&n) = vec_wire_counts.get(sig_name.as_str()) {
-                                if vec_port_names.contains(sig_name.as_str()) {
-                                    // Vec OUTPUT port: write to the internal
-                                    // _{name}[i] storage; the flat-field sync
-                                    // emitted at the end of eval_comb copies
-                                    // _{name}[i] → {name}_i. Writing the flat
-                                    // field directly here would be clobbered
-                                    // by that sync.
+                // Step 3: refresh sub-inst comb outputs, then parent comb (with settle loop)
+                // Hoist invariant inputs (post-posedge values for ports/regs)
+                // out of the settle loop, mirroring the optimization above.
+                for &inst_idx in &inst_eval_order {
+                    let inst = insts[inst_idx];
+                    let conns = &expanded_conns[inst_idx];
+                    for conn in conns {
+                        if conn.direction == ConnectDir::Input && is_invariant(conn) {
+                            if !matches!(conn.signal.kind, ExprKind::Ident(_)) {
+                                if let Some(n) = ctx.expr_vec_size(&conn.signal) {
+                                    let sig = cpp_expr(&conn.signal, &ctx);
                                     for i in 0..n {
-                                        cpp.push_str(&format!("    _{sig_name}[{i}] = _inst_{}.{}_{i};\n",
-                                            inst.name.name, conn.port_name.name));
+                                        cpp.push_str(&format!(
+                                            "  _inst_{}.{}_{i} = {sig}[{i}];\n",
+                                            inst.name.name, conn.port_name.name
+                                        ));
                                     }
-                                    if port_reg_names.contains(sig_name.as_str()) {
-                                        emit_port_reg_public_copy(&mut cpp, sig_name, &widths, Some(n), "    ");
-                                    }
-                                } else {
-                                    let prefix = vec_storage_prefix(sig_name.as_str(), &reg_names, &let_names, &inst_out);
-                                    for i in 0..n {
-                                        cpp.push_str(&format!("    {prefix}{sig_name}[{i}] = _inst_{}.{}_{i};\n",
-                                            inst.name.name, conn.port_name.name));
-                                    }
+                                    continue;
                                 }
-                                continue;
                             }
-                        }
-                        let sig = cpp_expr(&conn.signal, &ctx);
-                        // Wide type (>64 bits): inst port is VlWide, parent reg is _arch_u128
-                        let _out_w = if let ExprKind::Ident(n) = &conn.signal.kind {
-                            widths.get(n.as_str()).copied().unwrap_or(0)
-                        } else { 0 };
-                        if _out_w > 64 {
-                            cpp.push_str(&format!("    {} = _arch_vl_to_u128(_inst_{}.{}.data(), {});\n",
-                                sig, inst.name.name, conn.port_name.name, wide_words(_out_w)));
-                        } else {
-                            cpp.push_str(&format!("    {} = _inst_{}.{};\n",
-                                sig, inst.name.name, conn.port_name.name));
-                        }
-                        if let ExprKind::Ident(name) = &conn.signal.kind {
-                            if port_reg_names.contains(name.as_str()) {
-                                emit_port_reg_public_copy(&mut cpp, name, &widths, None, "    ");
+                            if let crate::ast::ExprKind::Ident(src_name) = &conn.signal.kind {
+                                if let Some(&n) = vec_wire_counts.get(src_name.as_str()) {
+                                    let _vec_pfx = vec_storage_prefix(
+                                        src_name.as_str(),
+                                        &reg_names,
+                                        &let_names,
+                                        &inst_out,
+                                    );
+                                    for i in 0..n {
+                                        cpp.push_str(&format!(
+                                            "  _inst_{}.{}_{i} = {_vec_pfx}{src_name}[{i}];\n",
+                                            inst.name.name, conn.port_name.name
+                                        ));
+                                    }
+                                    continue;
+                                }
+                                if vec_port_names.contains(src_name.as_str()) {
+                                    let n = vec_port_infos
+                                        .iter()
+                                        .find(|v| v.name == *src_name)
+                                        .map(|v| v.count)
+                                        .unwrap_or(0);
+                                    for i in 0..n {
+                                        cpp.push_str(&format!(
+                                            "  _inst_{}.{}_{i} = {src_name}_{i};\n",
+                                            inst.name.name, conn.port_name.name
+                                        ));
+                                    }
+                                    continue;
+                                }
+                                if wide_names.contains(src_name.as_str()) {
+                                    let resolved = ctx.resolve_name(src_name, false);
+                                    cpp.push_str(&format!(
+                                        "  _inst_{}.{} = {};\n",
+                                        inst.name.name, conn.port_name.name, resolved
+                                    ));
+                                    continue;
+                                }
                             }
+                            let sig = cpp_expr(&conn.signal, &ctx);
+                            cpp.push_str(&format!(
+                                "  _inst_{}.{} = {};\n",
+                                inst.name.name, conn.port_name.name, sig
+                            ));
                         }
-                        // --check-uninit: mark inst output as initialized
-                        if let ExprKind::Ident(name) = &conn.signal.kind {
-                            if uninit_regs.contains(name.as_str()) {
-                                cpp.push_str(&format!("    _{name}_vinit = true;\n"));
+                    }
+                }
+                cpp.push_str(&format!(
+                    "  for (int _settle = 0; _settle < {settle_depth}; _settle++) {{\n"
+                ));
+                for &inst_idx in &inst_eval_order {
+                    let inst = insts[inst_idx];
+                    let conns = &expanded_conns[inst_idx];
+                    // Re-set sub-inst inputs (may have changed after posedge)
+                    for conn in conns {
+                        if conn.direction == ConnectDir::Input && !is_invariant(conn) {
+                            if !matches!(conn.signal.kind, ExprKind::Ident(_)) {
+                                if let Some(n) = ctx.expr_vec_size(&conn.signal) {
+                                    let sig = cpp_expr(&conn.signal, &ctx);
+                                    for i in 0..n {
+                                        cpp.push_str(&format!(
+                                            "    _inst_{}.{}_{i} = {sig}[{i}];\n",
+                                            inst.name.name, conn.port_name.name
+                                        ));
+                                    }
+                                    continue;
+                                }
+                            }
+                            if let crate::ast::ExprKind::Ident(src_name) = &conn.signal.kind {
+                                // Vec wire/reg → inst Vec port: expand element-by-element
+                                if let Some(&n) = vec_wire_counts.get(src_name.as_str()) {
+                                    let _vec_pfx = vec_storage_prefix(
+                                        src_name.as_str(),
+                                        &reg_names,
+                                        &let_names,
+                                        &inst_out,
+                                    );
+                                    for i in 0..n {
+                                        cpp.push_str(&format!(
+                                            "    _inst_{}.{}_{i} = {_vec_pfx}{src_name}[{i}];\n",
+                                            inst.name.name, conn.port_name.name
+                                        ));
+                                    }
+                                    continue;
+                                }
+                                // Parent Vec PORT (input) → inst Vec port:
+                                // parent's src is stored as flat fields
+                                // `src_0..src_{n-1}`.
+                                if vec_port_names.contains(src_name.as_str()) {
+                                    let n = vec_port_infos
+                                        .iter()
+                                        .find(|v| v.name == *src_name)
+                                        .map(|v| v.count)
+                                        .unwrap_or(0);
+                                    for i in 0..n {
+                                        cpp.push_str(&format!(
+                                            "    _inst_{}.{}_{i} = {src_name}_{i};\n",
+                                            inst.name.name, conn.port_name.name
+                                        ));
+                                    }
+                                    continue;
+                                }
+                                if wide_names.contains(src_name.as_str()) {
+                                    let resolved = ctx.resolve_name(src_name, false);
+                                    cpp.push_str(&format!(
+                                        "    _inst_{}.{} = {};\n",
+                                        inst.name.name, conn.port_name.name, resolved
+                                    ));
+                                    continue;
+                                }
+                            }
+                            let sig = cpp_expr(&conn.signal, &ctx);
+                            cpp.push_str(&format!(
+                                "    _inst_{}.{} = {};\n",
+                                inst.name.name, conn.port_name.name, sig
+                            ));
+                        }
+                    }
+                    cpp.push_str(&format!("    _inst_{}.eval_comb();\n", inst.name.name));
+                    for conn in conns {
+                        if conn.direction == ConnectDir::Output {
+                            if !matches!(conn.signal.kind, ExprKind::Ident(_)) {
+                                if let Some(n) = ctx.expr_vec_size(&conn.signal) {
+                                    let sig = cpp_expr(&conn.signal, &ctx);
+                                    for i in 0..n {
+                                        cpp.push_str(&format!(
+                                            "    {sig}[{i}] = _inst_{}.{}_{i};\n",
+                                            inst.name.name, conn.port_name.name
+                                        ));
+                                    }
+                                    continue;
+                                }
+                            }
+                            // inst Vec port → Vec wire/reg: expand element-by-element
+                            if let ExprKind::Ident(sig_name) = &conn.signal.kind {
+                                if let Some(&n) = vec_wire_counts.get(sig_name.as_str()) {
+                                    if vec_port_names.contains(sig_name.as_str()) {
+                                        // Vec OUTPUT port: write to the internal
+                                        // _{name}[i] storage; the flat-field sync
+                                        // emitted at the end of eval_comb copies
+                                        // _{name}[i] → {name}_i. Writing the flat
+                                        // field directly here would be clobbered
+                                        // by that sync.
+                                        for i in 0..n {
+                                            cpp.push_str(&format!(
+                                                "    _{sig_name}[{i}] = _inst_{}.{}_{i};\n",
+                                                inst.name.name, conn.port_name.name
+                                            ));
+                                        }
+                                        if port_reg_names.contains(sig_name.as_str()) {
+                                            emit_port_reg_public_copy(
+                                                &mut cpp,
+                                                sig_name,
+                                                &widths,
+                                                Some(n),
+                                                "    ",
+                                            );
+                                        }
+                                    } else {
+                                        let prefix = vec_storage_prefix(
+                                            sig_name.as_str(),
+                                            &reg_names,
+                                            &let_names,
+                                            &inst_out,
+                                        );
+                                        for i in 0..n {
+                                            cpp.push_str(&format!(
+                                                "    {prefix}{sig_name}[{i}] = _inst_{}.{}_{i};\n",
+                                                inst.name.name, conn.port_name.name
+                                            ));
+                                        }
+                                    }
+                                    continue;
+                                }
+                            }
+                            let sig = cpp_expr(&conn.signal, &ctx);
+                            // Wide type (>64 bits): inst port is VlWide, parent reg is _arch_u128
+                            let _out_w = if let ExprKind::Ident(n) = &conn.signal.kind {
+                                widths.get(n.as_str()).copied().unwrap_or(0)
+                            } else {
+                                0
+                            };
+                            if _out_w > 64 {
+                                cpp.push_str(&format!(
+                                    "    {} = _arch_vl_to_u128(_inst_{}.{}.data(), {});\n",
+                                    sig,
+                                    inst.name.name,
+                                    conn.port_name.name,
+                                    wide_words(_out_w)
+                                ));
+                            } else {
+                                cpp.push_str(&format!(
+                                    "    {} = _inst_{}.{};\n",
+                                    sig, inst.name.name, conn.port_name.name
+                                ));
+                            }
+                            if let ExprKind::Ident(name) = &conn.signal.kind {
+                                if port_reg_names.contains(name.as_str()) {
+                                    emit_port_reg_public_copy(
+                                        &mut cpp, name, &widths, None, "    ",
+                                    );
+                                }
+                            }
+                            // --check-uninit: mark inst output as initialized
+                            if let ExprKind::Ident(name) = &conn.signal.kind {
+                                if uninit_regs.contains(name.as_str()) {
+                                    cpp.push_str(&format!("    _{name}_vinit = true;\n"));
+                                }
                             }
                         }
                     }
                 }
-            }
-            cpp.push_str("    eval_comb();\n");
-            cpp.push_str("  } // settle\n");
+                cpp.push_str("    eval_comb();\n");
+                cpp.push_str("  } // settle\n");
             } // end if has_clk
         } // end else (has insts)
 
@@ -7041,17 +8437,31 @@ impl<'a> SimCodegen<'a> {
             for (inst_idx, inst) in insts.iter().enumerate() {
                 let conns = &expanded_conns[inst_idx];
                 for conn in conns {
-                    if conn.direction != ConnectDir::Output { continue; }
+                    if conn.direction != ConnectDir::Output {
+                        continue;
+                    }
                     // Resolve parent-side storage name + width.
-                    let sig_name = if let crate::ast::ExprKind::Ident(n) = &conn.signal.kind { n.as_str() } else { continue; };
+                    let sig_name = if let crate::ast::ExprKind::Ident(n) = &conn.signal.kind {
+                        n.as_str()
+                    } else {
+                        continue;
+                    };
                     let w = widths.get(sig_name).copied().unwrap_or(0);
-                    if w == 0 || w > 64 { continue; }
-                    if wide_names.contains(sig_name) { continue; }
-                    if vec_port_names.contains(sig_name) { continue; }
+                    if w == 0 || w > 64 {
+                        continue;
+                    }
+                    if wide_names.contains(sig_name) {
+                        continue;
+                    }
+                    if vec_port_names.contains(sig_name) {
+                        continue;
+                    }
                     // Skip Vec regs/wires (they connect to flattened
                     // sub-instance port names like `name_0..name_{n-1}`,
                     // not the bare `name`). Phase 6 v1 = scalars only.
-                    if vec_wire_counts.contains_key(sig_name) { continue; }
+                    if vec_wire_counts.contains_key(sig_name) {
+                        continue;
+                    }
                     let cidx = reg.borrow_mut().alloc(
                         "toggle",
                         inst.span.start,
@@ -7084,16 +8494,40 @@ impl<'a> SimCodegen<'a> {
             cpp.push_str(&format!("  _clk_prev_{c} = {c};\n"));
         }
 
-        let reg_blocks: Vec<&RegBlock> = m.body.iter()
-            .filter_map(|i| if let ModuleBodyItem::RegBlock(rb) = i { Some(rb) } else { None })
+        let reg_blocks: Vec<&RegBlock> = m
+            .body
+            .iter()
+            .filter_map(|i| {
+                if let ModuleBodyItem::RegBlock(rb) = i {
+                    Some(rb)
+                } else {
+                    None
+                }
+            })
             .collect();
-        let reg_decls: Vec<&RegDecl> = m.body.iter()
-            .filter_map(|i| if let ModuleBodyItem::RegDecl(r) = i { Some(r) } else { None })
+        let reg_decls: Vec<&RegDecl> = m
+            .body
+            .iter()
+            .filter_map(|i| {
+                if let ModuleBodyItem::RegDecl(r) = i {
+                    Some(r)
+                } else {
+                    None
+                }
+            })
             .collect();
 
         // Collect pipe_reg declarations for _n_ temporary handling
-        let pipe_regs: Vec<&PipeRegDecl> = m.body.iter()
-            .filter_map(|i| if let ModuleBodyItem::PipeRegDecl(p) = i { Some(p) } else { None })
+        let pipe_regs: Vec<&PipeRegDecl> = m
+            .body
+            .iter()
+            .filter_map(|i| {
+                if let ModuleBodyItem::PipeRegDecl(p) = i {
+                    Some(p)
+                } else {
+                    None
+                }
+            })
             .collect();
 
         if !reg_blocks.is_empty() || !pipe_regs.is_empty() {
@@ -7103,7 +8537,9 @@ impl<'a> SimCodegen<'a> {
             for rd in &reg_decls {
                 let n = &rd.name.name;
                 if let Some((elem_ty, count)) = vec_array_info_with_params(&rd.ty, &m.params) {
-                    cpp.push_str(&format!("  {elem_ty} _n_{n}[{count}]; memcpy(_n_{n}, _{n}, sizeof(_{n}));\n"));
+                    cpp.push_str(&format!(
+                        "  {elem_ty} _n_{n}[{count}]; memcpy(_n_{n}, _{n}, sizeof(_{n}));\n"
+                    ));
                 } else {
                     let ty = cpp_internal_type_with_params(&rd.ty, &m.params);
                     cpp.push_str(&format!("  {ty} _n_{n} = _{n};\n"));
@@ -7115,7 +8551,10 @@ impl<'a> SimCodegen<'a> {
                     let n = &p.name.name;
                     if let Some(vi) = vec_port_infos.iter().find(|v| v.name == *n) {
                         // Vec port-reg: _n_ is an array, initialized by memcpy
-                        cpp.push_str(&format!("  {} _n_{n}[{}]; memcpy(_n_{n}, _{n}, sizeof(_{n}));\n", vi.elem_ty, vi.count));
+                        cpp.push_str(&format!(
+                            "  {} _n_{n}[{}]; memcpy(_n_{n}, _{n}, sizeof(_{n}));\n",
+                            vi.elem_ty, vi.count
+                        ));
                     } else {
                         let ty = cpp_internal_type_with_params(&p.ty, &m.params);
                         cpp.push_str(&format!("  {ty} _n_{n} = _{n};\n"));
@@ -7125,7 +8564,11 @@ impl<'a> SimCodegen<'a> {
             // Declare _n_ temporaries for pipe_reg stages
             for p in &pipe_regs {
                 let w = widths.get(&p.source.name).copied().unwrap_or(32);
-                let ty = if signed_names.contains(p.source.name.as_str()) { cpp_sint(w) } else { cpp_uint(w) };
+                let ty = if signed_names.contains(p.source.name.as_str()) {
+                    cpp_sint(w)
+                } else {
+                    cpp_uint(w)
+                };
                 for i in 0..p.stages {
                     let name = if i == p.stages - 1 {
                         p.name.name.clone()
@@ -7137,13 +8580,25 @@ impl<'a> SimCodegen<'a> {
             }
             cpp.push('\n');
 
-            let ctx = Ctx::new(&reg_names, &port_names, &let_names, &inst_names,
-                               &wide_names, &widths, &enum_map, &bus_port_names)
-                          .with_signed_names(&signed_names).with_float_names(&float_names)
-                          .with_vec_names(&vec_reg_names).with_vec_2d_names(&vec_2d_names).with_vec_sizes(&vec_sizes).posedge()
-                          .with_coverage(cov_handle)
-                          .with_let_values(&let_values)
-                          .with_params(&m.params);
+            let ctx = Ctx::new(
+                &reg_names,
+                &port_names,
+                &let_names,
+                &inst_names,
+                &wide_names,
+                &widths,
+                &enum_map,
+                &bus_port_names,
+            )
+            .with_signed_names(&signed_names)
+            .with_float_names(&float_names)
+            .with_vec_names(&vec_reg_names)
+            .with_vec_2d_names(&vec_2d_names)
+            .with_vec_sizes(&vec_sizes)
+            .posedge()
+            .with_coverage(cov_handle)
+            .with_let_values(&let_values)
+            .with_params(&m.params);
 
             for rb in &reg_blocks {
                 let mut assigned = std::collections::BTreeSet::new();
@@ -7154,15 +8609,21 @@ impl<'a> SimCodegen<'a> {
 
                 for name in &assigned {
                     // Look up reset from RegDecl or port reg
-                    let reset_ref: Option<&RegReset> = reg_decls.iter()
+                    let reset_ref: Option<&RegReset> = reg_decls
+                        .iter()
                         .find(|r| r.name.name == *name)
                         .map(|r| &r.reset)
-                        .or_else(|| m.ports.iter()
-                            .find(|p| p.name.name == *name && p.reg_info.is_some())
-                            .and_then(|p| p.reg_info.as_ref().map(|ri| &ri.reset)));
+                        .or_else(|| {
+                            m.ports
+                                .iter()
+                                .find(|p| p.name.name == *name && p.reg_info.is_some())
+                                .and_then(|p| p.reg_info.as_ref().map(|ri| &ri.reset))
+                        });
                     if let Some(reg_reset) = reset_ref {
                         if let Some(info) = resolve_reg_reset_info(reg_reset, &m.ports) {
-                            if reset_sig.is_none() { reset_sig = Some(info.clone()); }
+                            if reset_sig.is_none() {
+                                reset_sig = Some(info.clone());
+                            }
                             let reset_expr = reset_value_from_reg_reset(reg_reset);
                             let init_val = if let Some(expr) = reset_expr {
                                 match &expr.kind {
@@ -7173,7 +8634,13 @@ impl<'a> SimCodegen<'a> {
                                     ExprKind::Literal(LitKind::Hex(v)) => format!("0x{:X}", v),
                                     ExprKind::Literal(LitKind::Bin(v)) => v.to_string(),
                                     ExprKind::Literal(LitKind::Sized(_, v)) => v.to_string(),
-                                    ExprKind::Bool(b) => if *b { "1".to_string() } else { "0".to_string() },
+                                    ExprKind::Bool(b) => {
+                                        if *b {
+                                            "1".to_string()
+                                        } else {
+                                            "0".to_string()
+                                        }
+                                    }
                                     // Everything else — struct literals, enum
                                     // variants, idents, calls, casts — lowers
                                     // via the normal expression path. Previously
@@ -7181,10 +8648,18 @@ impl<'a> SimCodegen<'a> {
                                     // could corrupt non-literal reset values
                                     // (see #6 struct-literal reset bug).
                                     _ => {
-                                        let tmp_ctx = Ctx::new(&reg_names, &port_names,
-                                            &let_names, &inst_names, &wide_names, &widths,
-                                            &enum_map, &bus_port_names)
-                                            .with_signed_names(&signed_names).with_float_names(&float_names);
+                                        let tmp_ctx = Ctx::new(
+                                            &reg_names,
+                                            &port_names,
+                                            &let_names,
+                                            &inst_names,
+                                            &wide_names,
+                                            &widths,
+                                            &enum_map,
+                                            &bus_port_names,
+                                        )
+                                        .with_signed_names(&signed_names)
+                                        .with_float_names(&float_names);
                                         cpp_expr(expr, &tmp_ctx)
                                     }
                                 }
@@ -7208,52 +8683,66 @@ impl<'a> SimCodegen<'a> {
                         // sync-reset path is handled below; skip the async pre-gate emit
                         false
                     } else {
-                    let cond = if *is_low { format!("(!{})", rst_name) } else { rst_name.clone() };
-                    cpp.push_str(&format!("  if ({cond}) {{\n"));
-                    for (reg_name, init) in &reset_regs {
-                        // Vec-typed regs are C arrays — write each element
-                        // via a loop. `init` is a scalar broadcast value
-                        // per the ARCH spec (`reset r => 0` distributes
-                        // the scalar across every element).
-                        if vec_reg_names.contains(*reg_name) {
-                            let count = vec_sizes.get(*reg_name).copied().unwrap_or(0);
-                            if count > 0 {
-                                // For nested-Vec regs the inner dim is a C array,
-                                // not a scalar — a per-element scalar assign
-                                // `_rf[_i] = 0` fails to compile. memset zeroes
-                                // the whole storage in one shot regardless of
-                                // dimensionality; the spec's reset broadcast
-                                // semantics (scalar distributed across every
-                                // element) collapse to the zero case in
-                                // practice. For non-zero broadcasts, fall back
-                                // to the per-element-loop form (correct for
-                                // 1D, generates a compile error for nested-
-                                // Vec the user must resolve by writing the
-                                // reset by hand).
-                                if init == "0" {
-                                    cpp.push_str(&format!("    memset(_{reg_name}, 0, sizeof(_{reg_name}));\n"));
-                                    cpp.push_str(&format!("    memset(_n_{reg_name}, 0, sizeof(_n_{reg_name}));\n"));
-                                } else {
-                                    cpp.push_str(&format!("    for (size_t _i = 0; _i < {count}; ++_i) {{ _{reg_name}[_i] = {init}; _n_{reg_name}[_i] = {init}; }}\n"));
-                                }
-                            }
-                        } else if wide_names.contains(*reg_name) {
-                            let bits = widths.get(*reg_name).copied().unwrap_or(0);
-                            if bits > 128 {
-                                let words = wide_words(bits);
-                                cpp.push_str(&format!("    _{reg_name} = VlWide<{words}>({init});\n"));
-                                cpp.push_str(&format!("    _n_{reg_name} = VlWide<{words}>({init});\n"));
-                            } else {
-                                cpp.push_str(&format!("    _{reg_name} = (_arch_u128){init};\n"));
-                                cpp.push_str(&format!("    _n_{reg_name} = (_arch_u128){init};\n"));
-                            }
+                        let cond = if *is_low {
+                            format!("(!{})", rst_name)
                         } else {
-                            cpp.push_str(&format!("    _{reg_name} = {init};\n"));
-                            cpp.push_str(&format!("    _n_{reg_name} = {init};\n"));
+                            rst_name.clone()
+                        };
+                        cpp.push_str(&format!("  if ({cond}) {{\n"));
+                        for (reg_name, init) in &reset_regs {
+                            // Vec-typed regs are C arrays — write each element
+                            // via a loop. `init` is a scalar broadcast value
+                            // per the ARCH spec (`reset r => 0` distributes
+                            // the scalar across every element).
+                            if vec_reg_names.contains(*reg_name) {
+                                let count = vec_sizes.get(*reg_name).copied().unwrap_or(0);
+                                if count > 0 {
+                                    // For nested-Vec regs the inner dim is a C array,
+                                    // not a scalar — a per-element scalar assign
+                                    // `_rf[_i] = 0` fails to compile. memset zeroes
+                                    // the whole storage in one shot regardless of
+                                    // dimensionality; the spec's reset broadcast
+                                    // semantics (scalar distributed across every
+                                    // element) collapse to the zero case in
+                                    // practice. For non-zero broadcasts, fall back
+                                    // to the per-element-loop form (correct for
+                                    // 1D, generates a compile error for nested-
+                                    // Vec the user must resolve by writing the
+                                    // reset by hand).
+                                    if init == "0" {
+                                        cpp.push_str(&format!(
+                                            "    memset(_{reg_name}, 0, sizeof(_{reg_name}));\n"
+                                        ));
+                                        cpp.push_str(&format!("    memset(_n_{reg_name}, 0, sizeof(_n_{reg_name}));\n"));
+                                    } else {
+                                        cpp.push_str(&format!("    for (size_t _i = 0; _i < {count}; ++_i) {{ _{reg_name}[_i] = {init}; _n_{reg_name}[_i] = {init}; }}\n"));
+                                    }
+                                }
+                            } else if wide_names.contains(*reg_name) {
+                                let bits = widths.get(*reg_name).copied().unwrap_or(0);
+                                if bits > 128 {
+                                    let words = wide_words(bits);
+                                    cpp.push_str(&format!(
+                                        "    _{reg_name} = VlWide<{words}>({init});\n"
+                                    ));
+                                    cpp.push_str(&format!(
+                                        "    _n_{reg_name} = VlWide<{words}>({init});\n"
+                                    ));
+                                } else {
+                                    cpp.push_str(&format!(
+                                        "    _{reg_name} = (_arch_u128){init};\n"
+                                    ));
+                                    cpp.push_str(&format!(
+                                        "    _n_{reg_name} = (_arch_u128){init};\n"
+                                    ));
+                                }
+                            } else {
+                                cpp.push_str(&format!("    _{reg_name} = {init};\n"));
+                                cpp.push_str(&format!("    _n_{reg_name} = {init};\n"));
+                            }
                         }
-                    }
-                    cpp.push_str("  }\n");
-                    true
+                        cpp.push_str("  }\n");
+                        true
                     }
                 } else {
                     false
@@ -7275,8 +8764,15 @@ impl<'a> SimCodegen<'a> {
                 // catches dead clock domains where branch coverage
                 // shows 0/0 trivially.
                 if let Some(reg) = cov_handle {
-                    let idx = reg.borrow_mut().alloc("seq", rb.span.start, format!("seq @{}", rb.clock.name));
-                    cpp.push_str(&format!("{}_arch_cov[{idx}]++;\n", "  ".repeat(base_indent)));
+                    let idx = reg.borrow_mut().alloc(
+                        "seq",
+                        rb.span.start,
+                        format!("seq @{}", rb.clock.name),
+                    );
+                    cpp.push_str(&format!(
+                        "{}_arch_cov[{idx}]++;\n",
+                        "  ".repeat(base_indent)
+                    ));
                 }
 
                 if async_reset_emitted {
@@ -7288,7 +8784,11 @@ impl<'a> SimCodegen<'a> {
                     cpp.push_str(&body);
                 } else if let Some((rst_name, _is_async, is_low)) = &reset_sig {
                     // Sync reset — original gated form.
-                    let cond = if *is_low { format!("(!{})", rst_name) } else { rst_name.clone() };
+                    let cond = if *is_low {
+                        format!("(!{})", rst_name)
+                    } else {
+                        rst_name.clone()
+                    };
                     cpp.push_str(&format!("{}if ({cond}) {{\n", "  ".repeat(base_indent)));
                     for (reg_name, init) in &reset_regs {
                         if vec_reg_names.contains(*reg_name) {
@@ -7297,7 +8797,10 @@ impl<'a> SimCodegen<'a> {
                                 // memset for zero (covers nested-Vec); per-element
                                 // loop for non-zero broadcasts (works for 1D).
                                 if init == "0" {
-                                    cpp.push_str(&format!("{}memset(_n_{reg_name}, 0, sizeof(_n_{reg_name}));\n", "  ".repeat(base_indent + 1)));
+                                    cpp.push_str(&format!(
+                                        "{}memset(_n_{reg_name}, 0, sizeof(_n_{reg_name}));\n",
+                                        "  ".repeat(base_indent + 1)
+                                    ));
                                 } else {
                                     cpp.push_str(&format!("{}for (size_t _i = 0; _i < {count}; ++_i) {{ _n_{reg_name}[_i] = {init}; }}\n", "  ".repeat(base_indent + 1)));
                                 }
@@ -7306,12 +8809,21 @@ impl<'a> SimCodegen<'a> {
                             let bits = widths.get(*reg_name).copied().unwrap_or(0);
                             if bits > 128 {
                                 let words = wide_words(bits);
-                                cpp.push_str(&format!("{}_n_{reg_name} = VlWide<{words}>({init});\n", "  ".repeat(base_indent + 1)));
+                                cpp.push_str(&format!(
+                                    "{}_n_{reg_name} = VlWide<{words}>({init});\n",
+                                    "  ".repeat(base_indent + 1)
+                                ));
                             } else {
-                                cpp.push_str(&format!("{}_n_{reg_name} = (_arch_u128){init};\n", "  ".repeat(base_indent + 1)));
+                                cpp.push_str(&format!(
+                                    "{}_n_{reg_name} = (_arch_u128){init};\n",
+                                    "  ".repeat(base_indent + 1)
+                                ));
                             }
                         } else {
-                            cpp.push_str(&format!("{}_n_{reg_name} = {init};\n", "  ".repeat(base_indent + 1)));
+                            cpp.push_str(&format!(
+                                "{}_n_{reg_name} = {init};\n",
+                                "  ".repeat(base_indent + 1)
+                            ));
                         }
                     }
                     cpp.push_str(&format!("{}}} else {{\n", "  ".repeat(base_indent)));
@@ -7338,10 +8850,13 @@ impl<'a> SimCodegen<'a> {
                 }
             }
             {
-                let rst_info = m.ports.iter()
+                let rst_info = m
+                    .ports
+                    .iter()
                     .find(|p| matches!(&p.ty, TypeExpr::Reset(..)))
                     .map(|p| {
-                        let is_low = matches!(&p.ty, TypeExpr::Reset(_, level) if *level == ResetLevel::Low);
+                        let is_low =
+                            matches!(&p.ty, TypeExpr::Reset(_, level) if *level == ResetLevel::Low);
                         (p.name.name.clone(), is_low)
                     });
                 for p in &pipe_regs {
@@ -7353,22 +8868,39 @@ impl<'a> SimCodegen<'a> {
                             chain.push(format!("{}_stg{}", p.name.name, i + 1));
                         }
                     }
-                    let ctx_pe = Ctx::new(&reg_names, &port_names, &let_names, &inst_names,
-                                           &wide_names, &widths, &enum_map, &bus_port_names)
-                                       .with_signed_names(&signed_names).with_float_names(&float_names)
-                                       .with_vec_names(&vec_reg_names).with_vec_2d_names(&vec_2d_names).with_vec_sizes(&vec_sizes)
-                                       .with_let_values(&let_values)
-                                       .with_params(&m.params);
+                    let ctx_pe = Ctx::new(
+                        &reg_names,
+                        &port_names,
+                        &let_names,
+                        &inst_names,
+                        &wide_names,
+                        &widths,
+                        &enum_map,
+                        &bus_port_names,
+                    )
+                    .with_signed_names(&signed_names)
+                    .with_float_names(&float_names)
+                    .with_vec_names(&vec_reg_names)
+                    .with_vec_2d_names(&vec_2d_names)
+                    .with_vec_sizes(&vec_sizes)
+                    .with_let_values(&let_values)
+                    .with_params(&m.params);
                     let src = ctx_pe.resolve_name(&p.source.name, false);
                     if let Some((ref rst_name, is_low)) = rst_info {
-                        let cond = if is_low { format!("(!{})", rst_name) } else { rst_name.clone() };
+                        let cond = if is_low {
+                            format!("(!{})", rst_name)
+                        } else {
+                            rst_name.clone()
+                        };
                         cpp.push_str(&format!("  if ({cond}) {{\n"));
                         for name in &chain {
                             cpp.push_str(&format!("    _n_{name} = 0;\n"));
                         }
                         cpp.push_str("  } else {\n");
                         for name in &chain {
-                            let prev = if *name == chain[0] { src.clone() } else {
+                            let prev = if *name == chain[0] {
+                                src.clone()
+                            } else {
                                 let idx = chain.iter().position(|n| n == name).unwrap();
                                 format!("_{}", chain[idx - 1])
                             };
@@ -7377,7 +8909,9 @@ impl<'a> SimCodegen<'a> {
                         cpp.push_str("  }\n");
                     } else {
                         for name in &chain {
-                            let prev = if *name == chain[0] { src.clone() } else {
+                            let prev = if *name == chain[0] {
+                                src.clone()
+                            } else {
                                 let idx = chain.iter().position(|n| n == name).unwrap();
                                 format!("_{}", chain[idx - 1])
                             };
@@ -7488,7 +9022,9 @@ impl<'a> SimCodegen<'a> {
                             "  if (_{n} != _dbg_old_{n}) \
                              printf(\"[FSM][{module_name}.{label}] S%u -> S%u\\n\", \
                              (unsigned)_dbg_old_{n}, (unsigned)_{n});\n",
-                            module_name = name, label = label, n = n,
+                            module_name = name,
+                            label = label,
+                            n = n,
                         ));
                     }
                 }
@@ -7534,7 +9070,9 @@ impl<'a> SimCodegen<'a> {
                      \x20             \"{guard_sig}=1 but {reg_name} was never written\\n\");\n\
                      \x20   }}\n\
                      \x20 }}\n",
-                    guard_sig = guard_sig, reg_name = reg_name, name = name,
+                    guard_sig = guard_sig,
+                    reg_name = reg_name,
+                    name = name,
                 ));
             }
         }
@@ -7555,7 +9093,9 @@ impl<'a> SimCodegen<'a> {
         // (active-high / active-low derived from the port's polarity).
         if !cc_sites.is_empty() {
             let primary_clk = all_clks.first().cloned();
-            let rst_expr = m.ports.iter()
+            let rst_expr = m
+                .ports
+                .iter()
                 .find(|p| matches!(&p.ty, TypeExpr::Reset(_, _)))
                 .map(|p| match &p.ty {
                     TypeExpr::Reset(_, ResetLevel::Low) => format!("!{}", p.name.name),
@@ -7578,18 +9118,29 @@ impl<'a> SimCodegen<'a> {
         // For modules with sub-instances, eval_comb includes re-evaluation of the
         // inst chain so that combinational feedback settles when called from parent.
         cpp.push_str(&format!("void {class}::eval_comb() {{\n"));
-        let ctx_comb = Ctx::new(&reg_names, &port_names, &let_names, &inst_names,
-                                &wide_names, &widths, &enum_map, &bus_port_names)
-                           .with_signed_names(&signed_names).with_float_names(&float_names)
-                           .with_vec_names(&vec_reg_names).with_vec_2d_names(&vec_2d_names).with_vec_sizes(&vec_sizes)
-                           .with_coverage(cov_handle)
-                           .with_let_values(&let_values)
-                           .with_params(&m.params)
-                           .with_vec_of_bus(
-                               &vec_of_bus_port_count_map,
-                               &vec_of_bus_wire_count_map,
-                               &loop_var_subst_cell,
-                           );
+        let ctx_comb = Ctx::new(
+            &reg_names,
+            &port_names,
+            &let_names,
+            &inst_names,
+            &wide_names,
+            &widths,
+            &enum_map,
+            &bus_port_names,
+        )
+        .with_signed_names(&signed_names)
+        .with_float_names(&float_names)
+        .with_vec_names(&vec_reg_names)
+        .with_vec_2d_names(&vec_2d_names)
+        .with_vec_sizes(&vec_sizes)
+        .with_coverage(cov_handle)
+        .with_let_values(&let_values)
+        .with_params(&m.params)
+        .with_vec_of_bus(
+            &vec_of_bus_port_count_map,
+            &vec_of_bus_wire_count_map,
+            &loop_var_subst_cell,
+        );
 
         // Credit-channel combinational wires (sender can_send; receiver
         // valid/data once PR-sim-2 lands). Emit early so user comb code
@@ -7619,8 +9170,9 @@ impl<'a> SimCodegen<'a> {
                         if mname.name == "find_first" {
                             let recv_cpp = cpp_expr(recv, &ctx_comb);
                             let n = match &recv.kind {
-                                ExprKind::Ident(nm) => ctx_comb.vec_sizes
-                                    .and_then(|s| s.get(nm)).copied(),
+                                ExprKind::Ident(nm) => {
+                                    ctx_comb.vec_sizes.and_then(|s| s.get(nm)).copied()
+                                }
                                 _ => None,
                             };
                             if let Some(n) = n {
@@ -7631,15 +9183,24 @@ impl<'a> SimCodegen<'a> {
                                     sub.insert("item".to_string(), format!("{recv_cpp}[{i}]"));
                                     sub.insert("index".to_string(), format!("{i}"));
                                     let sub_ctx = Ctx {
-                                        reg_names: ctx_comb.reg_names, port_names: ctx_comb.port_names,
-                                        let_names: ctx_comb.let_names, let_values: ctx_comb.let_values, inst_names: ctx_comb.inst_names,
-                                        wide_names: ctx_comb.wide_names, widths: ctx_comb.widths, signed_names: ctx_comb.signed_names,
+                                        reg_names: ctx_comb.reg_names,
+                                        port_names: ctx_comb.port_names,
+                                        let_names: ctx_comb.let_names,
+                                        let_values: ctx_comb.let_values,
+                                        inst_names: ctx_comb.inst_names,
+                                        wide_names: ctx_comb.wide_names,
+                                        widths: ctx_comb.widths,
+                                        signed_names: ctx_comb.signed_names,
                                         float_names: ctx_comb.float_names,
-                                        posedge_lhs: ctx_comb.posedge_lhs, fsm_mode: ctx_comb.fsm_mode,
-                                        enum_map: ctx_comb.enum_map, bus_ports: ctx_comb.bus_ports,
-                                        reset_levels: ctx_comb.reset_levels, vec_names: ctx_comb.vec_names,
+                                        posedge_lhs: ctx_comb.posedge_lhs,
+                                        fsm_mode: ctx_comb.fsm_mode,
+                                        enum_map: ctx_comb.enum_map,
+                                        bus_ports: ctx_comb.bus_ports,
+                                        reset_levels: ctx_comb.reset_levels,
+                                        vec_names: ctx_comb.vec_names,
                                         vec_2d_names: ctx_comb.vec_2d_names,
-                                        vec_sizes: ctx_comb.vec_sizes, fsm_vec_port_regs: ctx_comb.fsm_vec_port_regs,
+                                        vec_sizes: ctx_comb.vec_sizes,
+                                        fsm_vec_port_regs: ctx_comb.fsm_vec_port_regs,
                                         ident_subst: Some(&sub),
                                         loop_var_subst: ctx_comb.loop_var_subst,
                                         vec_of_bus_port_count: ctx_comb.vec_of_bus_port_count,
@@ -7649,9 +9210,11 @@ impl<'a> SimCodegen<'a> {
                                     };
                                     hits.push(cpp_expr(&margs[0], &sub_ctx));
                                 }
-                                let found_expr: String = hits.iter()
+                                let found_expr: String = hits
+                                    .iter()
                                     .map(|h| format!("({h})"))
-                                    .collect::<Vec<_>>().join(" || ");
+                                    .collect::<Vec<_>>()
+                                    .join(" || ");
                                 let mut idx_expr = "0u".to_string();
                                 for i in (0..n as u64).rev() {
                                     let hit = &hits[i as usize];
@@ -7707,8 +9270,10 @@ impl<'a> SimCodegen<'a> {
                             if let Some(n) = ctx_comb.expr_vec_size(&conn.signal) {
                                 let sig = cpp_expr(&conn.signal, &ctx_comb);
                                 for i in 0..n {
-                                    cpp.push_str(&format!("  _inst_{}.{}_{i} = {sig}[{i}];\n",
-                                        inst.name.name, conn.port_name.name));
+                                    cpp.push_str(&format!(
+                                        "  _inst_{}.{}_{i} = {sig}[{i}];\n",
+                                        inst.name.name, conn.port_name.name
+                                    ));
                                 }
                                 continue;
                             }
@@ -7716,28 +9281,41 @@ impl<'a> SimCodegen<'a> {
                         if let crate::ast::ExprKind::Ident(src_name) = &conn.signal.kind {
                             // Vec wire/reg → inst Vec port: expand element-by-element
                             if let Some(&n) = vec_wire_counts.get(src_name.as_str()) {
-                                let _vec_pfx = vec_storage_prefix(src_name.as_str(), &reg_names, &let_names, &inst_out);
+                                let _vec_pfx = vec_storage_prefix(
+                                    src_name.as_str(),
+                                    &reg_names,
+                                    &let_names,
+                                    &inst_out,
+                                );
                                 for i in 0..n {
-                                    cpp.push_str(&format!("  _inst_{}.{}_{i} = {_vec_pfx}{src_name}[{i}];\n",
-                                        inst.name.name, conn.port_name.name));
+                                    cpp.push_str(&format!(
+                                        "  _inst_{}.{}_{i} = {_vec_pfx}{src_name}[{i}];\n",
+                                        inst.name.name, conn.port_name.name
+                                    ));
                                 }
                                 continue;
                             }
                             // Parent Vec PORT (input) → inst Vec port: flat field syntax
                             if vec_port_names.contains(src_name.as_str()) {
-                                let n = vec_port_infos.iter()
+                                let n = vec_port_infos
+                                    .iter()
                                     .find(|v| v.name == *src_name)
-                                    .map(|v| v.count).unwrap_or(0);
+                                    .map(|v| v.count)
+                                    .unwrap_or(0);
                                 for i in 0..n {
-                                    cpp.push_str(&format!("  _inst_{}.{}_{i} = {src_name}_{i};\n",
-                                        inst.name.name, conn.port_name.name));
+                                    cpp.push_str(&format!(
+                                        "  _inst_{}.{}_{i} = {src_name}_{i};\n",
+                                        inst.name.name, conn.port_name.name
+                                    ));
                                 }
                                 continue;
                             }
                             if wide_names.contains(src_name.as_str()) {
                                 let resolved = ctx_comb.resolve_name(src_name, false);
-                                cpp.push_str(&format!("  _inst_{}.{} = {};\n",
-                                    inst.name.name, conn.port_name.name, resolved));
+                                cpp.push_str(&format!(
+                                    "  _inst_{}.{} = {};\n",
+                                    inst.name.name, conn.port_name.name, resolved
+                                ));
                                 continue;
                             }
                         }
@@ -7745,13 +9323,22 @@ impl<'a> SimCodegen<'a> {
                         // Wide type (>64 bits): parent _arch_u128 → inst VlWide
                         let _in_w = if let ExprKind::Ident(n) = &conn.signal.kind {
                             widths.get(n.as_str()).copied().unwrap_or(0)
-                        } else { 0 };
-                        if _in_w > 64 {
-                            cpp.push_str(&format!("  _arch_u128_to_vl({}, _inst_{}.{}.data(), {});\n",
-                                sig, inst.name.name, conn.port_name.name, wide_words(_in_w)));
                         } else {
-                            cpp.push_str(&format!("  _inst_{}.{} = {};\n",
-                                inst.name.name, conn.port_name.name, sig));
+                            0
+                        };
+                        if _in_w > 64 {
+                            cpp.push_str(&format!(
+                                "  _arch_u128_to_vl({}, _inst_{}.{}.data(), {});\n",
+                                sig,
+                                inst.name.name,
+                                conn.port_name.name,
+                                wide_words(_in_w)
+                            ));
+                        } else {
+                            cpp.push_str(&format!(
+                                "  _inst_{}.{} = {};\n",
+                                inst.name.name, conn.port_name.name, sig
+                            ));
                         }
                     }
                 }
@@ -7762,8 +9349,10 @@ impl<'a> SimCodegen<'a> {
                             if let Some(n) = ctx_comb.expr_vec_size(&conn.signal) {
                                 let sig = cpp_expr(&conn.signal, &ctx_comb);
                                 for i in 0..n {
-                                    cpp.push_str(&format!("  {sig}[{i}] = _inst_{}.{}_{i};\n",
-                                        inst.name.name, conn.port_name.name));
+                                    cpp.push_str(&format!(
+                                        "  {sig}[{i}] = _inst_{}.{}_{i};\n",
+                                        inst.name.name, conn.port_name.name
+                                    ));
                                 }
                                 continue;
                             }
@@ -7777,17 +9366,32 @@ impl<'a> SimCodegen<'a> {
                                     // field, so the eval_comb-tail sync isn't
                                     // overwritten.
                                     for i in 0..n {
-                                        cpp.push_str(&format!("  _{sig_name}[{i}] = _inst_{}.{}_{i};\n",
-                                            inst.name.name, conn.port_name.name));
+                                        cpp.push_str(&format!(
+                                            "  _{sig_name}[{i}] = _inst_{}.{}_{i};\n",
+                                            inst.name.name, conn.port_name.name
+                                        ));
                                     }
                                     if port_reg_names.contains(sig_name.as_str()) {
-                                        emit_port_reg_public_copy(&mut cpp, sig_name, &widths, Some(n), "  ");
+                                        emit_port_reg_public_copy(
+                                            &mut cpp,
+                                            sig_name,
+                                            &widths,
+                                            Some(n),
+                                            "  ",
+                                        );
                                     }
                                 } else {
-                                    let prefix = vec_storage_prefix(sig_name.as_str(), &reg_names, &let_names, &inst_out);
+                                    let prefix = vec_storage_prefix(
+                                        sig_name.as_str(),
+                                        &reg_names,
+                                        &let_names,
+                                        &inst_out,
+                                    );
                                     for i in 0..n {
-                                        cpp.push_str(&format!("  {prefix}{sig_name}[{i}] = _inst_{}.{}_{i};\n",
-                                            inst.name.name, conn.port_name.name));
+                                        cpp.push_str(&format!(
+                                            "  {prefix}{sig_name}[{i}] = _inst_{}.{}_{i};\n",
+                                            inst.name.name, conn.port_name.name
+                                        ));
                                     }
                                 }
                                 continue;
@@ -7796,13 +9400,22 @@ impl<'a> SimCodegen<'a> {
                         let sig = cpp_expr(&conn.signal, &ctx_comb);
                         let _out_w = if let ExprKind::Ident(n) = &conn.signal.kind {
                             widths.get(n.as_str()).copied().unwrap_or(0)
-                        } else { 0 };
-                        if _out_w > 64 {
-                            cpp.push_str(&format!("  {} = _arch_vl_to_u128(_inst_{}.{}.data(), {});\n",
-                                sig, inst.name.name, conn.port_name.name, wide_words(_out_w)));
                         } else {
-                            cpp.push_str(&format!("  {} = _inst_{}.{};\n",
-                                sig, inst.name.name, conn.port_name.name));
+                            0
+                        };
+                        if _out_w > 64 {
+                            cpp.push_str(&format!(
+                                "  {} = _arch_vl_to_u128(_inst_{}.{}.data(), {});\n",
+                                sig,
+                                inst.name.name,
+                                conn.port_name.name,
+                                wide_words(_out_w)
+                            ));
+                        } else {
+                            cpp.push_str(&format!(
+                                "  {} = _inst_{}.{};\n",
+                                sig, inst.name.name, conn.port_name.name
+                            ));
                         }
                         if let ExprKind::Ident(name) = &conn.signal.kind {
                             if port_reg_names.contains(name.as_str()) {
@@ -7818,7 +9431,8 @@ impl<'a> SimCodegen<'a> {
         if !uninit_regs.is_empty() {
             // Collect all signal names read in comb blocks AND in let bindings
             // (let values are lowered into eval_comb too).
-            let mut comb_reads: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+            let mut comb_reads: std::collections::BTreeSet<String> =
+                std::collections::BTreeSet::new();
             for item in &m.body {
                 match item {
                     ModuleBodyItem::CombBlock(cb) => {
@@ -7865,7 +9479,8 @@ impl<'a> SimCodegen<'a> {
                         // signal — only the producer bug (valid asserted but
                         // payload never set) should fire. Non-payload inputs
                         // fall through to the unconditional check.
-                        let gate = payload_guards.get(name)
+                        let gate = payload_guards
+                            .get(name)
                             .map(|g| format!(" && {g}"))
                             .unwrap_or_default();
                         cpp.push_str(&format!(
@@ -7899,7 +9514,9 @@ impl<'a> SimCodegen<'a> {
                 // counters reflect "block evaluations" rather than
                 // "cycles where block was active".
                 if let Some(reg) = cov_handle {
-                    let idx = reg.borrow_mut().alloc("comb", cb.span.start, "comb".to_string());
+                    let idx = reg
+                        .borrow_mut()
+                        .alloc("comb", cb.span.start, "comb".to_string());
                     body.push_str(&format!("  _arch_cov[{idx}]++;\n"));
                 }
                 emit_comb_stmts(&cb.stmts, &ctx_comb, &mut body, 1);
@@ -7929,27 +9546,42 @@ impl<'a> SimCodegen<'a> {
 
         // Generate tick() for multi-clock modules with known frequencies
         if all_freqs_known {
-            let freqs: Vec<(String, u64)> = clk_freqs.iter()
+            let freqs: Vec<(String, u64)> = clk_freqs
+                .iter()
                 .map(|(name, f)| (name.clone(), f.unwrap()))
                 .collect();
 
             // Compute half-periods in picoseconds: half_period = 1e6 / (2 * freq_mhz)
             // To avoid floating point, use: half_period_ps = 500_000 / freq_mhz
-            let half_periods: Vec<(String, u64)> = freqs.iter()
+            let half_periods: Vec<(String, u64)> = freqs
+                .iter()
                 .map(|(name, f)| (name.clone(), 500_000 / f))
                 .collect();
 
             // Find GCD of all half-periods for the time step
             fn gcd(a: u64, b: u64) -> u64 {
-                if b == 0 { a } else { gcd(b, a % b) }
+                if b == 0 {
+                    a
+                } else {
+                    gcd(b, a % b)
+                }
             }
-            let step_ps = half_periods.iter().map(|(_, hp)| *hp).reduce(|a, b| gcd(a, b)).unwrap();
+            let step_ps = half_periods
+                .iter()
+                .map(|(_, hp)| *hp)
+                .reduce(|a, b| gcd(a, b))
+                .unwrap();
 
             cpp.push_str(&format!("\nvoid {class}::tick() {{\n"));
-            cpp.push_str(&format!("  // Auto-generated clock driver (step = {} ps)\n", step_ps));
+            cpp.push_str(&format!(
+                "  // Auto-generated clock driver (step = {} ps)\n",
+                step_ps
+            ));
             for (name, hp) in &half_periods {
-                cpp.push_str(&format!("  // {name}: half-period = {hp} ps ({} MHz)\n",
-                    500_000 / hp));
+                cpp.push_str(&format!(
+                    "  // {name}: half-period = {hp} ps ({} MHz)\n",
+                    500_000 / hp
+                ));
             }
             // Toggle each clock: flip when time_ps is at a half-period boundary
             for (name, hp) in &half_periods {
@@ -7967,7 +9599,11 @@ impl<'a> SimCodegen<'a> {
         let multi_clk = clk_ports.len() > 1;
         // Printf format for cycle prefix: single-clock uses "[%llu]", multi-clock uses "%s" with _dbg_hdr
         let cyc_fmt = if multi_clk { "%s" } else { "[%llu]" };
-        let cyc_arg = if multi_clk { "_dbg_hdr" } else { "(unsigned long long)_dbg_cycle" };
+        let cyc_arg = if multi_clk {
+            "_dbg_hdr"
+        } else {
+            "(unsigned long long)_dbg_cycle"
+        };
         if emit_debug {
             cpp.push_str(&format!("void {class}::_debug_log_ports() {{\n"));
             if multi_clk {
@@ -7976,9 +9612,14 @@ impl<'a> SimCodegen<'a> {
                 cpp.push_str("  snprintf(_dbg_hdr, sizeof(_dbg_hdr), \"[%llu@%s]\", (unsigned long long)_dbg_cycle, _dbg_last_clk);\n");
             }
             for p in &m.ports {
-                if p.bus_info.is_some() { continue; }
+                if p.bus_info.is_some() {
+                    continue;
+                }
                 let pname = &p.name.name;
-                let dir_str = match p.direction { Direction::In => "in", Direction::Out => "out" };
+                let dir_str = match p.direction {
+                    Direction::In => "in",
+                    Direction::Out => "out",
+                };
                 match &p.ty {
                     TypeExpr::Clock(_) => {
                         cpp.push_str(&format!("  // {pname}: clock — skipped\n"));
@@ -7990,22 +9631,16 @@ impl<'a> SimCodegen<'a> {
                 if let Some(vi) = vec_port_infos.iter().find(|v| v.name == *pname) {
                     // Vec port: compare each flat element
                     for i in 0..vi.count {
-                        cpp.push_str(&format!(
-                            "  if ({pname}_{i} != _dbg_prev_{pname}_{i}) {{\n"
-                        ));
+                        cpp.push_str(&format!("  if ({pname}_{i} != _dbg_prev_{pname}_{i}) {{\n"));
                         cpp.push_str(&format!(
                             "    printf(\"{cyc_fmt}[{name}.{pname}[{i}]]({dir}) 0x%llx -> 0x%llx\\n\",\n",
                             dir = dir_str
                         ));
-                        cpp.push_str(&format!(
-                            "           {cyc_arg},\n"
-                        ));
+                        cpp.push_str(&format!("           {cyc_arg},\n"));
                         cpp.push_str(&format!(
                             "           (unsigned long long)_dbg_prev_{pname}_{i},\n"
                         ));
-                        cpp.push_str(&format!(
-                            "           (unsigned long long){pname}_{i});\n"
-                        ));
+                        cpp.push_str(&format!("           (unsigned long long){pname}_{i});\n"));
                         cpp.push_str(&format!("    _dbg_prev_{pname}_{i} = {pname}_{i};\n"));
                         cpp.push_str("  }\n");
                     }
@@ -8035,22 +9670,16 @@ impl<'a> SimCodegen<'a> {
                         cpp.push_str("  }\n");
                     } else {
                         // Scalar port (≤64 bits)
-                        cpp.push_str(&format!(
-                            "  if ({pname} != _dbg_prev_{pname}) {{\n"
-                        ));
+                        cpp.push_str(&format!("  if ({pname} != _dbg_prev_{pname}) {{\n"));
                         cpp.push_str(&format!(
                             "    printf(\"{cyc_fmt}[{name}.{pname}]({dir}) 0x%llx -> 0x%llx\\n\",\n",
                             dir = dir_str
                         ));
-                        cpp.push_str(&format!(
-                            "           {cyc_arg},\n"
-                        ));
+                        cpp.push_str(&format!("           {cyc_arg},\n"));
                         cpp.push_str(&format!(
                             "           (unsigned long long)_dbg_prev_{pname},\n"
                         ));
-                        cpp.push_str(&format!(
-                            "           (unsigned long long){pname});\n"
-                        ));
+                        cpp.push_str(&format!("           (unsigned long long){pname});\n"));
                         cpp.push_str(&format!("    _dbg_prev_{pname} = {pname};\n"));
                         cpp.push_str("  }\n");
                     }
@@ -8083,21 +9712,15 @@ impl<'a> SimCodegen<'a> {
                     cpp.push_str(&format!("    _dbg_prev_{flat_name} = {flat_name};\n"));
                     cpp.push_str("  }\n");
                 } else {
-                    cpp.push_str(&format!(
-                        "  if ({flat_name} != _dbg_prev_{flat_name}) {{\n"
-                    ));
+                    cpp.push_str(&format!("  if ({flat_name} != _dbg_prev_{flat_name}) {{\n"));
                     cpp.push_str(&format!(
                         "    printf(\"{cyc_fmt}[{name}.{flat_name}]({dir_str}) 0x%llx -> 0x%llx\\n\",\n"
                     ));
-                    cpp.push_str(&format!(
-                        "           {cyc_arg},\n"
-                    ));
+                    cpp.push_str(&format!("           {cyc_arg},\n"));
                     cpp.push_str(&format!(
                         "           (unsigned long long)_dbg_prev_{flat_name},\n"
                     ));
-                    cpp.push_str(&format!(
-                        "           (unsigned long long){flat_name});\n"
-                    ));
+                    cpp.push_str(&format!("           (unsigned long long){flat_name});\n"));
                     cpp.push_str(&format!("    _dbg_prev_{flat_name} = {flat_name};\n"));
                     cpp.push_str("  }\n");
                 }
@@ -8113,8 +9736,12 @@ impl<'a> SimCodegen<'a> {
                 // Multi-clock: increment on any posedge, record which clock
                 cpp.push_str("  ");
                 for (i, c) in clk_ports.iter().enumerate() {
-                    if i > 0 { cpp.push_str(" else "); }
-                    cpp.push_str(&format!("if (_rising_{c}) {{ _dbg_cycle++; _dbg_last_clk = \"{c}\"; }}"));
+                    if i > 0 {
+                        cpp.push_str(" else ");
+                    }
+                    cpp.push_str(&format!(
+                        "if (_rising_{c}) {{ _dbg_cycle++; _dbg_last_clk = \"{c}\"; }}"
+                    ));
                 }
                 cpp.push_str("\n");
             }
@@ -8125,11 +9752,17 @@ impl<'a> SimCodegen<'a> {
         // its final point count. Patch the header / impl placeholders.
         let n_cov = cov_reg.borrow().points.len();
         let header_decl = if self.coverage && n_cov > 0 {
-            format!("public:\n  static uint64_t _arch_cov[{n_cov}];\n  static bool _arch_cov_dumped;\n")
-        } else { String::new() };
+            format!(
+                "public:\n  static uint64_t _arch_cov[{n_cov}];\n  static bool _arch_cov_dumped;\n"
+            )
+        } else {
+            String::new()
+        };
         let impl_defn = if self.coverage && n_cov > 0 {
             format!("uint64_t {class}::_arch_cov[{n_cov}] = {{}};\nbool {class}::_arch_cov_dumped = false;\n\n")
-        } else { String::new() };
+        } else {
+            String::new()
+        };
         h = h.replace("__ARCH_COV_HEADER_DECL__", &header_decl);
         cpp = cpp.replace("__ARCH_COV_IMPL_DEFN__", &impl_defn);
 
@@ -8153,7 +9786,9 @@ impl<'a> SimCodegen<'a> {
             // lines to the coverage.dat file.
             if let Some(path) = &self.coverage_dat {
                 let path_lit = path.replace('\\', "\\\\").replace('"', "\\\"");
-                cpp.push_str(&format!("  FILE* _dat = _arch_cov_dat_open(\"{path_lit}\");\n"));
+                cpp.push_str(&format!(
+                    "  FILE* _dat = _arch_cov_dat_open(\"{path_lit}\");\n"
+                ));
             }
             for (i, p) in cov_reg.borrow().points.iter().enumerate() {
                 let (file_disp, line_no) = if let Some(sm) = &self.source_map {
@@ -8176,10 +9811,10 @@ impl<'a> SimCodegen<'a> {
                     let file_esc = file_disp.replace('\\', "\\\\").replace('"', "\\\"");
                     let page = match p.kind {
                         "if" | "elsif" | "else" => "v_branch",
-                        "seq" | "comb"          => "v_line",
-                        "state" | "trans"       => "v_user/fsm",
-                        "toggle"                => "v_toggle",
-                        _                       => "v_user",
+                        "seq" | "comb" => "v_line",
+                        "state" | "trans" => "v_user/fsm",
+                        "toggle" => "v_toggle",
+                        _ => "v_user",
                     };
                     let comment = p.label.replace('\\', "\\\\").replace('"', "\\\"");
                     // Verilator coverage.dat field separators are \x01 (key)
@@ -8201,7 +9836,11 @@ impl<'a> SimCodegen<'a> {
             cpp.push_str("} // namespace\n\n");
         }
 
-        SimModel { class_name: class.clone(), header: h, impl_: cpp }
+        SimModel {
+            class_name: class.clone(),
+            header: h,
+            impl_: cpp,
+        }
     }
 }
 
@@ -8212,7 +9851,9 @@ impl<'a> SimCodegen<'a> {
         let name = &c.name.name;
         let class = format!("V{name}");
 
-        let max_param = c.params.iter()
+        let max_param = c
+            .params
+            .iter()
             .find(|p| p.name.name == "MAX")
             .and_then(|p| p.default.as_ref())
             .map(|e| match &e.kind {
@@ -8222,13 +9863,19 @@ impl<'a> SimCodegen<'a> {
 
         let value_port = c.ports.iter().find(|p| p.name.name == "value");
         let count_bits = value_port
-            .and_then(|vp| if let TypeExpr::UInt(w) = &vp.ty { Some(eval_width(w)) } else { None })
+            .and_then(|vp| {
+                if let TypeExpr::UInt(w) = &vp.ty {
+                    Some(eval_width(w))
+                } else {
+                    None
+                }
+            })
             .unwrap_or(8);
         let count_ty = cpp_uint(count_bits);
 
-        let has_inc    = c.ports.iter().any(|p| p.name.name == "inc");
-        let has_dec    = c.ports.iter().any(|p| p.name.name == "dec");
-        let has_clear  = c.ports.iter().any(|p| p.name.name == "clear");
+        let has_inc = c.ports.iter().any(|p| p.name.name == "inc");
+        let has_dec = c.ports.iter().any(|p| p.name.name == "dec");
+        let has_clear = c.ports.iter().any(|p| p.name.name == "clear");
         let has_at_max = c.ports.iter().any(|p| p.name.name == "at_max");
         let has_at_min = c.ports.iter().any(|p| p.name.name == "at_min");
         let has_max_port = c.ports.iter().any(|p| p.name.name == "max");
@@ -8245,23 +9892,52 @@ impl<'a> SimCodegen<'a> {
         };
 
         let (rst_name, _is_async, is_low) = extract_reset_info(&c.ports);
-        let rst_cond = if is_low { format!("(!{})", rst_name) } else { rst_name.clone() };
+        let rst_cond = if is_low {
+            format!("(!{})", rst_name)
+        } else {
+            rst_name.clone()
+        };
 
-        let init_val: u64 = c.init.as_ref()
-            .and_then(|e| if let ExprKind::Literal(LitKind::Dec(v)) = &e.kind { Some(*v) } else { None })
+        let init_val: u64 = c
+            .init
+            .as_ref()
+            .and_then(|e| {
+                if let ExprKind::Literal(LitKind::Dec(v)) = &e.kind {
+                    Some(*v)
+                } else {
+                    None
+                }
+            })
             .unwrap_or(0);
 
         let mut h = String::new();
-        h.push_str("#pragma once\n#include <cstdint>\n#include <cstdio>\n#include \"verilated.h\"\n\n");
+        h.push_str(
+            "#pragma once\n#include <cstdint>\n#include <cstdio>\n#include \"verilated.h\"\n\n",
+        );
         h.push_str(&format!("class {class} {{\npublic:\n"));
-        for p in &c.ports { h.push_str(&format!("  {} {};\n", cpp_port_type_with_params(&p.ty, &c.params), p.name.name)); }
+        for p in &c.ports {
+            h.push_str(&format!(
+                "  {} {};\n",
+                cpp_port_type_with_params(&p.ty, &c.params),
+                p.name.name
+            ));
+        }
         h.push('\n');
 
-        let port_inits: Vec<String> = c.ports.iter().map(|p| format!("{}(0)", p.name.name)).collect();
-        let state_inits = vec!["_clk_prev(0)".to_string(), format!("_count_r({})", init_val)];
+        let port_inits: Vec<String> = c
+            .ports
+            .iter()
+            .map(|p| format!("{}(0)", p.name.name))
+            .collect();
+        let state_inits = vec![
+            "_clk_prev(0)".to_string(),
+            format!("_count_r({})", init_val),
+        ];
         let all_inits: Vec<String> = port_inits.into_iter().chain(state_inits).collect();
         h.push_str(&format!("  {class}() : {} {{}}\n", all_inits.join(", ")));
-        h.push_str(&format!("  explicit {class}(VerilatedContext*) : {class}() {{}}\n"));
+        h.push_str(&format!(
+            "  explicit {class}(VerilatedContext*) : {class}() {{}}\n"
+        ));
         h.push_str("  void eval();\n  void final() { trace_close(); }\n");
         h.push_str("  void eval_posedge();\n  void eval_comb();\n");
         h.push_str("private:\n");
@@ -8271,8 +9947,12 @@ impl<'a> SimCodegen<'a> {
         let mut cpp = String::new();
         cpp.push_str(&format!("#include \"{class}.h\"\n\n"));
 
-        let clk_port = c.ports.iter().find(|p| matches!(&p.ty, TypeExpr::Clock(_)))
-            .map(|p| p.name.name.as_str()).unwrap_or("clk");
+        let clk_port = c
+            .ports
+            .iter()
+            .find(|p| matches!(&p.ty, TypeExpr::Clock(_)))
+            .map(|p| p.name.name.as_str())
+            .unwrap_or("clk");
 
         cpp.push_str(&format!("void {class}::eval() {{\n"));
         cpp.push_str("  if (!_trace_fp && Verilated::traceFile() && Verilated::claimTrace())\n");
@@ -8286,28 +9966,37 @@ impl<'a> SimCodegen<'a> {
         cpp.push_str(&format!("  _clk_prev = {clk_port};\n"));
         cpp.push_str("  if (!_rising) return;\n");
         cpp.push_str(&format!("  {count_ty} _n = _count_r;\n"));
-        cpp.push_str(&format!("  if ({rst_cond}) {{\n    _n = {init_val};\n  }} else {{\n"));
+        cpp.push_str(&format!(
+            "  if ({rst_cond}) {{\n    _n = {init_val};\n  }} else {{\n"
+        ));
 
-        use CounterDirection::*; use CounterMode::*;
+        use CounterDirection::*;
+        use CounterMode::*;
         match (c.direction, c.mode) {
             (Up, Wrap) => {
                 let inc_cond = if has_inc { "    if (inc) {" } else { "    {" };
                 cpp.push_str(&format!("{inc_cond}\n"));
-                cpp.push_str(&format!("      if (_count_r == {bound_expr}) _n = {init_val};\n"));
+                cpp.push_str(&format!(
+                    "      if (_count_r == {bound_expr}) _n = {init_val};\n"
+                ));
                 cpp.push_str("      else _n = _count_r + 1;\n");
                 cpp.push_str("    }\n");
             }
             (Down, Wrap) => {
                 let dec_cond = if has_dec { "    if (dec) {" } else { "    {" };
                 cpp.push_str(&format!("{dec_cond}\n"));
-                cpp.push_str(&format!("      if (_count_r == {init_val}) _n = {bound_expr};\n"));
+                cpp.push_str(&format!(
+                    "      if (_count_r == {init_val}) _n = {bound_expr};\n"
+                ));
                 cpp.push_str("      else _n = _count_r - 1;\n");
                 cpp.push_str("    }\n");
             }
             (Up, Saturate) => {
                 let inc_cond = if has_inc { "    if (inc) {" } else { "    {" };
                 cpp.push_str(&format!("{inc_cond}\n"));
-                cpp.push_str(&format!("      if (_count_r < {bound_expr}) _n = _count_r + 1;\n"));
+                cpp.push_str(&format!(
+                    "      if (_count_r < {bound_expr}) _n = _count_r + 1;\n"
+                ));
                 cpp.push_str("    }\n");
             }
             (Down, Saturate) => {
@@ -8317,7 +10006,9 @@ impl<'a> SimCodegen<'a> {
             }
             (Up, Gray) => {
                 cpp.push_str("    if (inc) {\n      uint32_t _bin = _count_r + 1;\n");
-                cpp.push_str(&format!("      _n = ({count_ty})(_bin ^ (_bin >> 1));\n    }}\n"));
+                cpp.push_str(&format!(
+                    "      _n = ({count_ty})(_bin ^ (_bin >> 1));\n    }}\n"
+                ));
             }
             (Up, OneHot) => {
                 let inc_cond = if has_inc { "    if (inc) {" } else { "    {" };
@@ -8335,16 +10026,22 @@ impl<'a> SimCodegen<'a> {
             }
             _ => {
                 let inc_cond = if has_inc { "    if (inc)" } else { "" };
-                cpp.push_str(&format!("    {inc_cond} _n = ({count_ty})(_count_r + 1);\n"));
+                cpp.push_str(&format!(
+                    "    {inc_cond} _n = ({count_ty})(_count_r + 1);\n"
+                ));
             }
         }
         if has_clear {
-            cpp.push_str(&format!("    if (clear) _n = {init_val}; // clear overrides inc\n"));
+            cpp.push_str(&format!(
+                "    if (clear) _n = {init_val}; // clear overrides inc\n"
+            ));
         }
         cpp.push_str("  }\n  _count_r = _n;\n}\n\n");
 
         cpp.push_str(&format!("void {class}::eval_comb() {{\n"));
-        if value_port.is_some() { cpp.push_str("  value = _count_r;\n"); }
+        if value_port.is_some() {
+            cpp.push_str("  value = _count_r;\n");
+        }
         if has_at_max {
             cpp.push_str(&format!("  at_max = (_count_r == {bound_expr}) ? 1 : 0;\n"));
         }
@@ -8355,98 +10052,163 @@ impl<'a> SimCodegen<'a> {
 
         // Add trace support
         let extra_sigs: Vec<(&str, &str, u32)> = vec![("count_r", "_count_r", count_bits)];
-        add_trace_to_simple_construct(&mut h, &mut cpp, &class, name, &c.ports, &extra_sigs, &c.params);
+        add_trace_to_simple_construct(
+            &mut h,
+            &mut cpp,
+            &class,
+            name,
+            &c.ports,
+            &extra_sigs,
+            &c.params,
+        );
         h.push_str("};\n");
 
-        SimModel { class_name: class, header: h, impl_: cpp }
+        SimModel {
+            class_name: class,
+            header: h,
+            impl_: cpp,
+        }
     }
 }
 
 // ── FSM codegen ───────────────────────────────────────────────────────────────
 
-
 // ── Regfile codegen ───────────────────────────────────────────────────────────
 
 impl<'a> SimCodegen<'a> {
     pub(crate) fn gen_regfile(&self, r: &RegfileDecl) -> SimModel {
-        let name  = &r.name.name;
+        let name = &r.name.name;
         let class = format!("V{name}");
 
-        let nregs  = r.param_int("NREGS", 32) as usize;
-        let nread  = r.read_ports.as_ref().map(|rp| r.resolve_count_expr(&rp.count_expr)).unwrap_or(1) as usize;
-        let nwrite = r.write_ports.as_ref().map(|wp| r.resolve_count_expr(&wp.count_expr)).unwrap_or(1) as usize;
+        let nregs = r.param_int("NREGS", 32) as usize;
+        let nread = r
+            .read_ports
+            .as_ref()
+            .map(|rp| r.resolve_count_expr(&rp.count_expr))
+            .unwrap_or(1) as usize;
+        let nwrite = r
+            .write_ports
+            .as_ref()
+            .map(|wp| r.resolve_count_expr(&wp.count_expr))
+            .unwrap_or(1) as usize;
 
         // C++ type for one register element (from the write data signal type)
-        let elem_cpp = r.write_ports.as_ref()
+        let elem_cpp = r
+            .write_ports
+            .as_ref()
             .and_then(|wp| wp.signals.iter().find(|s| s.name.name == "data"))
             .map(|s| cpp_internal_type_with_params(&s.ty, &r.params))
             .unwrap_or_else(|| "uint32_t".to_string());
 
         // Flat port name: "{pfx}_{sig}" when count==1, "{pfx}{i}_{sig}" otherwise
         let flat = |pfx: &str, i: usize, count: usize, sig: &str| -> String {
-            if count == 1 { format!("{pfx}_{sig}") } else { format!("{pfx}{i}_{sig}") }
+            if count == 1 {
+                format!("{pfx}_{sig}")
+            } else {
+                format!("{pfx}{i}_{sig}")
+            }
         };
 
-        let clk_port  = r.ports.iter()
+        let clk_port = r
+            .ports
+            .iter()
             .find(|p| matches!(&p.ty, TypeExpr::Clock(_)))
             .map(|p| p.name.name.clone())
             .unwrap_or_else(|| "clk".to_string());
-        let read_pfx  = r.read_ports.as_ref().map(|rp| rp.name.name.clone()).unwrap_or_else(|| "read".to_string());
-        let write_pfx = r.write_ports.as_ref().map(|wp| wp.name.name.clone()).unwrap_or_else(|| "write".to_string());
+        let read_pfx = r
+            .read_ports
+            .as_ref()
+            .map(|rp| rp.name.name.clone())
+            .unwrap_or_else(|| "read".to_string());
+        let write_pfx = r
+            .write_ports
+            .as_ref()
+            .map(|wp| wp.name.name.clone())
+            .unwrap_or_else(|| "write".to_string());
 
         // ── Header ────────────────────────────────────────────────────────────
         let mut h = String::new();
         h.push_str(&format!("#pragma once\n#include <cstdint>\n#include <cstring>\n#include \"verilated.h\"\n\nclass {class} {{\npublic:\n"));
 
         for p in &r.ports {
-            h.push_str(&format!("  {} {};\n", cpp_port_type_with_params(&p.ty, &r.params), p.name.name));
+            h.push_str(&format!(
+                "  {} {};\n",
+                cpp_port_type_with_params(&p.ty, &r.params),
+                p.name.name
+            ));
         }
         if let Some(rp) = &r.read_ports {
             for i in 0..nread {
                 for s in &rp.signals {
-                    h.push_str(&format!("  {} {};\n", cpp_port_type_with_params(&s.ty, &r.params), flat(&read_pfx, i, nread, &s.name.name)));
+                    h.push_str(&format!(
+                        "  {} {};\n",
+                        cpp_port_type_with_params(&s.ty, &r.params),
+                        flat(&read_pfx, i, nread, &s.name.name)
+                    ));
                 }
             }
         }
         if let Some(wp) = &r.write_ports {
             for i in 0..nwrite {
                 for s in &wp.signals {
-                    h.push_str(&format!("  {} {};\n", cpp_port_type_with_params(&s.ty, &r.params), flat(&write_pfx, i, nwrite, &s.name.name)));
+                    h.push_str(&format!(
+                        "  {} {};\n",
+                        cpp_port_type_with_params(&s.ty, &r.params),
+                        flat(&write_pfx, i, nwrite, &s.name.name)
+                    ));
                 }
             }
         }
         h.push('\n');
 
         // Constructor init list (all scalars = 0) + memset for rf array
-        let mut inits: Vec<String> = r.ports.iter().map(|p| format!("{}(0)", p.name.name)).collect();
+        let mut inits: Vec<String> = r
+            .ports
+            .iter()
+            .map(|p| format!("{}(0)", p.name.name))
+            .collect();
         if let Some(rp) = &r.read_ports {
-            for i in 0..nread { for s in &rp.signals { inits.push(format!("{}(0)", flat(&read_pfx, i, nread, &s.name.name))); } }
+            for i in 0..nread {
+                for s in &rp.signals {
+                    inits.push(format!("{}(0)", flat(&read_pfx, i, nread, &s.name.name)));
+                }
+            }
         }
         if let Some(wp) = &r.write_ports {
-            for i in 0..nwrite { for s in &wp.signals { inits.push(format!("{}(0)", flat(&write_pfx, i, nwrite, &s.name.name))); } }
+            for i in 0..nwrite {
+                for s in &wp.signals {
+                    inits.push(format!("{}(0)", flat(&write_pfx, i, nwrite, &s.name.name)));
+                }
+            }
         }
         inits.push("_clk_prev(0)".to_string());
-        let is_latch_init    = r.kind == crate::ast::RegfileKind::Latch;
-        let is_internal_init = is_latch_init && matches!(r.flops, crate::ast::RegfileFlops::Internal);
+        let is_latch_init = r.kind == crate::ast::RegfileKind::Latch;
+        let is_internal_init =
+            is_latch_init && matches!(r.flops, crate::ast::RegfileFlops::Internal);
         if is_internal_init {
             inits.push("_we_q(0)".to_string());
             inits.push("_waddr_q(0)".to_string());
             inits.push("_wdata_q(0)".to_string());
         }
 
-        h.push_str(&format!("  {class}() : {} {{\n    memset(_rf, 0, sizeof(_rf));\n  }}\n", inits.join(", ")));
+        h.push_str(&format!(
+            "  {class}() : {} {{\n    memset(_rf, 0, sizeof(_rf));\n  }}\n",
+            inits.join(", ")
+        ));
         h.push_str("  void eval();\n  void eval_comb();\n  void eval_posedge();\n  void final() { trace_close(); }\n\nprivate:\n");
         h.push_str("  uint8_t _clk_prev;\n");
         // Internal sample flops for kind:latch flops:internal (Ibex-style).
         // `_we_q` / `_waddr_q` / `_wdata_q` are taken on the rising edge; the
         // latch then captures during the clk-low half-cycle window (mirrors
         // the SV `always_latch if (!clk && we_q && waddr_q == k)` shape).
-        let is_latch    = r.kind == crate::ast::RegfileKind::Latch;
+        let is_latch = r.kind == crate::ast::RegfileKind::Latch;
         let is_internal = is_latch && matches!(r.flops, crate::ast::RegfileFlops::Internal);
         if is_internal {
             // Single write port assumed (matches SV codegen — same restriction).
             // For a wider data type we still match what cpp_internal_type picks.
-            let waddr_t = r.write_ports.as_ref()
+            let waddr_t = r
+                .write_ports
+                .as_ref()
                 .and_then(|wp| wp.signals.iter().find(|s| s.name.name == "addr"))
                 .map(|s| cpp_internal_type_with_params(&s.ty, &r.params))
                 .unwrap_or_else(|| "uint32_t".to_string());
@@ -8481,20 +10243,23 @@ impl<'a> SimCodegen<'a> {
         if !is_latch {
             // Init-protected addresses are immutable (mirrors SV emitter:
             // `init [k] = v;` lowers to a `waddr != k` write guard).
-            let guarded_addrs: Vec<u64> = r.inits.iter()
+            let guarded_addrs: Vec<u64> = r
+                .inits
+                .iter()
                 .filter_map(|init| match &init.index.kind {
                     ExprKind::Literal(LitKind::Dec(v)) => Some(*v),
                     _ => None,
                 })
                 .collect();
             for wi in 0..nwrite {
-                let wen   = flat(&write_pfx, wi, nwrite, "en");
+                let wen = flat(&write_pfx, wi, nwrite, "en");
                 let waddr = flat(&write_pfx, wi, nwrite, "addr");
                 let wdata = flat(&write_pfx, wi, nwrite, "data");
                 let guard = if guarded_addrs.is_empty() {
                     wen.clone()
                 } else {
-                    let parts: Vec<String> = guarded_addrs.iter()
+                    let parts: Vec<String> = guarded_addrs
+                        .iter()
                         .map(|k| format!("{waddr} != {k}"))
                         .collect();
                     format!("{wen} && {}", parts.join(" && "))
@@ -8503,7 +10268,7 @@ impl<'a> SimCodegen<'a> {
             }
         } else if is_internal {
             // Single-port sample (write port 0).
-            let wen   = flat(&write_pfx, 0, nwrite, "en");
+            let wen = flat(&write_pfx, 0, nwrite, "en");
             let waddr = flat(&write_pfx, 0, nwrite, "addr");
             let wdata = flat(&write_pfx, 0, nwrite, "data");
             cpp.push_str(&format!("  _we_q = {wen};\n"));
@@ -8530,7 +10295,7 @@ impl<'a> SimCodegen<'a> {
             } else {
                 // External flops: latch transparent whenever we is high (the
                 // SV `always_latch if (we && waddr == k)` collapses to this).
-                let wen   = flat(&write_pfx, 0, nwrite, "en");
+                let wen = flat(&write_pfx, 0, nwrite, "en");
                 let waddr = flat(&write_pfx, 0, nwrite, "addr");
                 let wdata = flat(&write_pfx, 0, nwrite, "data");
                 cpp.push_str(&format!("  if ({wen})\n"));
@@ -8541,10 +10306,12 @@ impl<'a> SimCodegen<'a> {
             let raddr = flat(&read_pfx, ri, nread, "addr");
             let rdata = flat(&read_pfx, ri, nread, "data");
             if r.forward_write_before_read && nwrite > 0 {
-                let wen   = flat(&write_pfx, 0, nwrite, "en");
+                let wen = flat(&write_pfx, 0, nwrite, "en");
                 let waddr = flat(&write_pfx, 0, nwrite, "addr");
                 let wdata = flat(&write_pfx, 0, nwrite, "data");
-                cpp.push_str(&format!("  {rdata} = ({wen} && {waddr} == {raddr}) ? {wdata} : _rf[{raddr}];\n"));
+                cpp.push_str(&format!(
+                    "  {rdata} = ({wen} && {waddr} == {raddr}) ? {wdata} : _rf[{raddr}];\n"
+                ));
             } else {
                 cpp.push_str(&format!("  {rdata} = _rf[{raddr}];\n"));
             }
@@ -8552,25 +10319,46 @@ impl<'a> SimCodegen<'a> {
         cpp.push_str("}\n");
 
         let extra_sigs: Vec<(&str, &str, u32)> = vec![];
-        add_trace_to_simple_construct(&mut h, &mut cpp, &class, name, &r.ports, &extra_sigs, &r.params);
+        add_trace_to_simple_construct(
+            &mut h,
+            &mut cpp,
+            &class,
+            name,
+            &r.ports,
+            &extra_sigs,
+            &r.params,
+        );
         h.push_str("};\n");
 
-        SimModel { class_name: class, header: h, impl_: cpp }
+        SimModel {
+            class_name: class,
+            header: h,
+            impl_: cpp,
+        }
     }
-
 
     pub(crate) fn gen_synchronizer(&self, s: &crate::ast::SynchronizerDecl) -> SimModel {
         use crate::ast::SyncKind;
 
         let class = s.name.name.clone();
 
-        let stages: usize = s.params.iter()
+        let stages: usize = s
+            .params
+            .iter()
             .find(|p| p.name.name == "STAGES")
             .and_then(|p| p.default.as_ref())
-            .and_then(|e| if let ExprKind::Literal(LitKind::Dec(v)) = &e.kind { Some(*v as usize) } else { None })
+            .and_then(|e| {
+                if let ExprKind::Literal(LitKind::Dec(v)) = &e.kind {
+                    Some(*v as usize)
+                } else {
+                    None
+                }
+            })
             .unwrap_or(2);
 
-        let clk_ports: Vec<&crate::ast::PortDecl> = s.ports.iter()
+        let clk_ports: Vec<&crate::ast::PortDecl> = s
+            .ports
+            .iter()
             .filter(|p| matches!(&p.ty, TypeExpr::Clock(_)))
             .collect();
         let src_clk = &clk_ports[0].name.name;
@@ -8584,10 +10372,20 @@ impl<'a> SimCodegen<'a> {
             _ => 32,
         };
 
-        let rst_port = s.ports.iter().find(|p| matches!(&p.ty, TypeExpr::Reset(..)));
-        let rst_is_low = rst_port.map_or(false, |rp| matches!(&rp.ty, TypeExpr::Reset(_, level) if *level == ResetLevel::Low));
+        let rst_port = s
+            .ports
+            .iter()
+            .find(|p| matches!(&p.ty, TypeExpr::Reset(..)));
+        let rst_is_low = rst_port.map_or(
+            false,
+            |rp| matches!(&rp.ty, TypeExpr::Reset(_, level) if *level == ResetLevel::Low),
+        );
         let rst_guard = rst_port.map(|rp| {
-            if rst_is_low { format!("!{}", rp.name.name) } else { rp.name.name.clone() }
+            if rst_is_low {
+                format!("!{}", rp.name.name)
+            } else {
+                rp.name.name.clone()
+            }
         });
 
         let cdc_random = self.cdc_random;
@@ -8602,36 +10400,53 @@ impl<'a> SimCodegen<'a> {
         }
         h.push_str(&format!("class {class} {{\npublic:\n"));
         for p in &s.ports {
-            h.push_str(&format!("  {} {};\n", cpp_port_type_with_params(&p.ty, &s.params), p.name.name));
+            h.push_str(&format!(
+                "  {} {};\n",
+                cpp_port_type_with_params(&p.ty, &s.params),
+                p.name.name
+            ));
         }
         h.push_str("\n  void eval();\n  void eval_posedge();\n  void eval_comb();\n  void final() { trace_close(); }\n");
         if cdc_random {
-            h.push_str("  uint8_t cdc_skip_pct = 25; // 0-100: probability of +1 cycle latency per edge\n");
+            h.push_str(
+                "  uint8_t cdc_skip_pct = 25; // 0-100: probability of +1 cycle latency per edge\n",
+            );
         }
         h.push_str("private:\n");
         h.push_str("  uint8_t _clk_prev_src;\n  uint8_t _clk_prev_dst;\n");
         h.push_str("  bool _rising_src;\n  bool _rising_dst;\n");
         match s.kind {
             SyncKind::Ff => {
-                for i in 0..stages { h.push_str(&format!("  {} _stage{};\n", data_ctype, i)); }
+                for i in 0..stages {
+                    h.push_str(&format!("  {} _stage{};\n", data_ctype, i));
+                }
             }
             SyncKind::Gray => {
-                for i in 0..stages { h.push_str(&format!("  {} _gray_stage{};\n", data_ctype, i)); }
+                for i in 0..stages {
+                    h.push_str(&format!("  {} _gray_stage{};\n", data_ctype, i));
+                }
             }
             SyncKind::Handshake => {
                 h.push_str(&format!("  {} _data_reg;\n", data_ctype));
                 h.push_str("  uint8_t _req_src;\n  uint8_t _ack_src;\n  uint8_t _ack_dst;\n");
                 for i in 0..stages {
-                    h.push_str(&format!("  uint8_t _req_sync{};\n  uint8_t _ack_sync{};\n", i, i));
+                    h.push_str(&format!(
+                        "  uint8_t _req_sync{};\n  uint8_t _ack_sync{};\n",
+                        i, i
+                    ));
                 }
             }
             SyncKind::Reset => {
-                for i in 0..stages { h.push_str(&format!("  uint8_t _stage{};\n", i)); }
+                for i in 0..stages {
+                    h.push_str(&format!("  uint8_t _stage{};\n", i));
+                }
             }
             SyncKind::Pulse => {
                 h.push_str("  uint8_t _toggle_src;\n");
                 // sync_chain needs STAGES entries + previous value for edge detect
-                for i in 0..stages { h.push_str(&format!("  uint8_t _sync{};\n", i)); }
+                for i in 0..stages {
+                    h.push_str(&format!("  uint8_t _sync{};\n", i));
+                }
                 h.push_str("  uint8_t _sync_prev;\n");
             }
         }
@@ -8649,7 +10464,9 @@ impl<'a> SimCodegen<'a> {
         cpp.push_str("    trace_open(Verilated::traceFile());\n");
         cpp.push_str(&format!("  _rising_src = ({src_clk} && !_clk_prev_src);\n"));
         cpp.push_str(&format!("  _rising_dst = ({dst_clk} && !_clk_prev_dst);\n"));
-        cpp.push_str(&format!("  _clk_prev_src = {src_clk};\n  _clk_prev_dst = {dst_clk};\n"));
+        cpp.push_str(&format!(
+            "  _clk_prev_src = {src_clk};\n  _clk_prev_dst = {dst_clk};\n"
+        ));
         if s.kind == SyncKind::Reset {
             cpp.push_str("  eval_posedge();\n  eval_comb();\n");
         } else {
@@ -8664,21 +10481,31 @@ impl<'a> SimCodegen<'a> {
             cpp.push_str(&format!("  if ({cond}) {{\n"));
             match s.kind {
                 SyncKind::Ff => {
-                    for i in 0..stages { cpp.push_str(&format!("    _stage{i} = 0;\n")); }
+                    for i in 0..stages {
+                        cpp.push_str(&format!("    _stage{i} = 0;\n"));
+                    }
                 }
                 SyncKind::Gray => {
-                    for i in 0..stages { cpp.push_str(&format!("    _gray_stage{i} = 0;\n")); }
+                    for i in 0..stages {
+                        cpp.push_str(&format!("    _gray_stage{i} = 0;\n"));
+                    }
                 }
                 SyncKind::Handshake => {
                     cpp.push_str("    _data_reg = 0; _req_src = 0; _ack_src = 0; _ack_dst = 0;\n");
-                    for i in 0..stages { cpp.push_str(&format!("    _req_sync{i} = 0; _ack_sync{i} = 0;\n")); }
+                    for i in 0..stages {
+                        cpp.push_str(&format!("    _req_sync{i} = 0; _ack_sync{i} = 0;\n"));
+                    }
                 }
                 SyncKind::Reset => {
-                    for i in 0..stages { cpp.push_str(&format!("    _stage{i} = 1;\n")); }
+                    for i in 0..stages {
+                        cpp.push_str(&format!("    _stage{i} = 1;\n"));
+                    }
                 }
                 SyncKind::Pulse => {
                     cpp.push_str("    _toggle_src = 0; _sync_prev = 0;\n");
-                    for i in 0..stages { cpp.push_str(&format!("    _sync{i} = 0;\n")); }
+                    for i in 0..stages {
+                        cpp.push_str(&format!("    _sync{i} = 0;\n"));
+                    }
                 }
             }
             if cdc_random {
@@ -8689,7 +10516,9 @@ impl<'a> SimCodegen<'a> {
         // CDC randomization: LFSR step + skip flag
         if cdc_random {
             cpp.push_str("  // LFSR-based CDC randomization (models metastability settling)\n");
-            cpp.push_str("  _cdc_lfsr = (_cdc_lfsr >> 1) ^ ((_cdc_lfsr & 1) ? 0xB4BCD35Cu : 0u);\n");
+            cpp.push_str(
+                "  _cdc_lfsr = (_cdc_lfsr >> 1) ^ ((_cdc_lfsr & 1) ? 0xB4BCD35Cu : 0u);\n",
+            );
             cpp.push_str("  bool _cdc_skip = (_cdc_lfsr % 100) < cdc_skip_pct;\n");
         }
 
@@ -8703,36 +10532,48 @@ impl<'a> SimCodegen<'a> {
         match s.kind {
             SyncKind::Ff => {
                 cpp.push_str(dst_guard);
-                for i in (1..stages).rev() { cpp.push_str(&format!("    _stage{i} = _stage{};\n", i - 1)); }
+                for i in (1..stages).rev() {
+                    cpp.push_str(&format!("    _stage{i} = _stage{};\n", i - 1));
+                }
                 cpp.push_str("    _stage0 = data_in;\n  }\n");
             }
             SyncKind::Gray => {
                 cpp.push_str(dst_guard);
-                for i in (1..stages).rev() { cpp.push_str(&format!("    _gray_stage{i} = _gray_stage{};\n", i - 1)); }
+                for i in (1..stages).rev() {
+                    cpp.push_str(&format!("    _gray_stage{i} = _gray_stage{};\n", i - 1));
+                }
                 cpp.push_str("    _gray_stage0 = data_in ^ (data_in >> 1);\n  }\n");
             }
             SyncKind::Handshake => {
                 cpp.push_str("  if (_rising_src) {\n");
                 cpp.push_str("    if (data_in != _data_reg && _req_src == _ack_src) {\n");
                 cpp.push_str("      _data_reg = data_in;\n      _req_src ^= 1;\n    }\n");
-                for i in (1..stages).rev() { cpp.push_str(&format!("    _ack_sync{i} = _ack_sync{};\n", i - 1)); }
+                for i in (1..stages).rev() {
+                    cpp.push_str(&format!("    _ack_sync{i} = _ack_sync{};\n", i - 1));
+                }
                 cpp.push_str("    _ack_sync0 = _ack_dst;\n");
                 cpp.push_str(&format!("    _ack_src = _ack_sync{};\n  }}\n", stages - 1));
                 cpp.push_str(dst_guard);
-                for i in (1..stages).rev() { cpp.push_str(&format!("    _req_sync{i} = _req_sync{};\n", i - 1)); }
+                for i in (1..stages).rev() {
+                    cpp.push_str(&format!("    _req_sync{i} = _req_sync{};\n", i - 1));
+                }
                 cpp.push_str("    _req_sync0 = _req_src;\n");
                 cpp.push_str(&format!("    _ack_dst = _req_sync{};\n  }}\n", stages - 1));
             }
             SyncKind::Reset => {
                 // Async assert is always immediate (no randomization)
                 cpp.push_str("  if (data_in) {\n");
-                for i in 0..stages { cpp.push_str(&format!("    _stage{i} = 1;\n")); }
+                for i in 0..stages {
+                    cpp.push_str(&format!("    _stage{i} = 1;\n"));
+                }
                 if cdc_random {
                     cpp.push_str("  } else if (_rising_dst && !_cdc_skip) {\n");
                 } else {
                     cpp.push_str("  } else if (_rising_dst) {\n");
                 }
-                for i in (1..stages).rev() { cpp.push_str(&format!("    _stage{i} = _stage{};\n", i - 1)); }
+                for i in (1..stages).rev() {
+                    cpp.push_str(&format!("    _stage{i} = _stage{};\n", i - 1));
+                }
                 cpp.push_str("    _stage0 = 0;\n  }\n");
             }
             SyncKind::Pulse => {
@@ -8742,7 +10583,9 @@ impl<'a> SimCodegen<'a> {
                 cpp.push_str("  }\n");
                 cpp.push_str(dst_guard);
                 cpp.push_str(&format!("    _sync_prev = _sync{};\n", stages - 1));
-                for i in (1..stages).rev() { cpp.push_str(&format!("    _sync{i} = _sync{};\n", i - 1)); }
+                for i in (1..stages).rev() {
+                    cpp.push_str(&format!("    _sync{i} = _sync{};\n", i - 1));
+                }
                 cpp.push_str("    _sync0 = _toggle_src;\n");
                 cpp.push_str("  }\n");
             }
@@ -8781,24 +10624,51 @@ impl<'a> SimCodegen<'a> {
         cpp.push_str("}\n");
 
         let extra_sigs: Vec<(&str, &str, u32)> = vec![];
-        add_trace_to_simple_construct(&mut h, &mut cpp, &class, &class, &s.ports, &extra_sigs, &s.params);
+        add_trace_to_simple_construct(
+            &mut h,
+            &mut cpp,
+            &class,
+            &class,
+            &s.ports,
+            &extra_sigs,
+            &s.params,
+        );
         h.push_str("};\n");
 
-        SimModel { class_name: class, header: h, impl_: cpp }
+        SimModel {
+            class_name: class,
+            header: h,
+            impl_: cpp,
+        }
     }
 
     pub(crate) fn gen_clkgate(&self, c: &crate::ast::ClkGateDecl) -> SimModel {
         let class = format!("V{}", c.name.name);
 
-        let clk_in = c.ports.iter().find(|p| matches!(&p.ty, TypeExpr::Clock(_)) && p.direction == Direction::In)
-            .map(|p| p.name.name.as_str()).unwrap_or("clk_in");
-        let clk_out = c.ports.iter().find(|p| matches!(&p.ty, TypeExpr::Clock(_)) && p.direction == Direction::Out)
-            .map(|p| p.name.name.as_str()).unwrap_or("clk_out");
+        let clk_in = c
+            .ports
+            .iter()
+            .find(|p| matches!(&p.ty, TypeExpr::Clock(_)) && p.direction == Direction::In)
+            .map(|p| p.name.name.as_str())
+            .unwrap_or("clk_in");
+        let clk_out = c
+            .ports
+            .iter()
+            .find(|p| matches!(&p.ty, TypeExpr::Clock(_)) && p.direction == Direction::Out)
+            .map(|p| p.name.name.as_str())
+            .unwrap_or("clk_out");
         let enable = "enable";
-        let test_en = c.ports.iter().find(|p| p.name.name == "test_en").map(|p| p.name.name.as_str());
+        let test_en = c
+            .ports
+            .iter()
+            .find(|p| p.name.name == "test_en")
+            .map(|p| p.name.name.as_str());
 
         let mut h = String::new();
-        h.push_str(&format!("#pragma once\n#include <cstdint>\nclass {} {{\npublic:\n", class));
+        h.push_str(&format!(
+            "#pragma once\n#include <cstdint>\nclass {} {{\npublic:\n",
+            class
+        ));
 
         for p in &c.ports {
             h.push_str(&format!("  uint8_t {} = 0;\n", p.name.name));
@@ -8826,11 +10696,15 @@ impl<'a> SimCodegen<'a> {
         cpp.push_str(&format!("void {}::eval_comb() {{\n", class));
         match c.kind {
             crate::ast::ClkGateKind::Latch => {
-                cpp.push_str(&format!("  if (!{clk_in}) _en_latched = ({en_expr}) ? 1 : 0;\n"));
+                cpp.push_str(&format!(
+                    "  if (!{clk_in}) _en_latched = ({en_expr}) ? 1 : 0;\n"
+                ));
                 cpp.push_str(&format!("  {clk_out} = {clk_in} & _en_latched;\n"));
             }
             crate::ast::ClkGateKind::And => {
-                cpp.push_str(&format!("  {clk_out} = {clk_in} & (({en_expr}) ? 1 : 0);\n"));
+                cpp.push_str(&format!(
+                    "  {clk_out} = {clk_in} & (({en_expr}) ? 1 : 0);\n"
+                ));
             }
         }
         cpp.push_str("}\n");
@@ -8841,7 +10715,11 @@ impl<'a> SimCodegen<'a> {
         // eval — calls both
         cpp.push_str(&format!("void {}::eval() {{ eval_comb(); }}\n", class));
 
-        SimModel { class_name: class, header: h, impl_: cpp }
+        SimModel {
+            class_name: class,
+            header: h,
+            impl_: cpp,
+        }
     }
 
     // ── Structs + Enums file ─────────────────────────────────────────────────
@@ -8860,8 +10738,12 @@ impl<'a> SimCodegen<'a> {
                 Item::Enum(e) => enums.push(e),
                 Item::Struct(s) => structs.push(s),
                 Item::Package(p) => {
-                    for e in &p.enums { enums.push(e); }
-                    for s in &p.structs { structs.push(s); }
+                    for e in &p.enums {
+                        enums.push(e);
+                    }
+                    for s in &p.structs {
+                        structs.push(s);
+                    }
                 }
                 _ => {}
             }
@@ -8871,7 +10753,10 @@ impl<'a> SimCodegen<'a> {
             // Enums are uint32_t aliases — variants are used as integer indices
             h.push_str(&format!("typedef uint32_t {};\n", e.name.name));
             for (i, v) in e.variants.iter().enumerate() {
-                h.push_str(&format!("static const uint32_t {}_{} = {}u;\n", e.name.name, v.name, i));
+                h.push_str(&format!(
+                    "static const uint32_t {}_{} = {}u;\n",
+                    e.name.name, v.name, i
+                ));
             }
             h.push('\n');
         }
@@ -8897,10 +10782,19 @@ impl<'a> SimCodegen<'a> {
         for s in &structs {
             h.push_str(&format!("struct {} {{\n", s.name.name));
             for f in &s.fields {
-                h.push_str(&format!("  {};\n", cpp_field_decl(&f.name.name, &f.ty, &[])));
+                h.push_str(&format!(
+                    "  {};\n",
+                    cpp_field_decl(&f.name.name, &f.ty, &[])
+                ));
             }
-            h.push_str(&format!("  {}() {{ std::memset(this, 0, sizeof(*this)); }}\n", s.name.name));
-            h.push_str(&format!("  explicit {}(uint64_t v) {{ (void)v; std::memset(this, 0, sizeof(*this)); }}\n", s.name.name));
+            h.push_str(&format!(
+                "  {}() {{ std::memset(this, 0, sizeof(*this)); }}\n",
+                s.name.name
+            ));
+            h.push_str(&format!(
+                "  explicit {}(uint64_t v) {{ (void)v; std::memset(this, 0, sizeof(*this)); }}\n",
+                s.name.name
+            ));
             h.push_str(&format!("  {}& operator=(uint64_t v) {{ (void)v; std::memset(this, 0, sizeof(*this)); return *this; }}\n", s.name.name));
             h.push_str("};\n\n");
         }
@@ -8919,7 +10813,11 @@ impl<'a> SimCodegen<'a> {
         for item in &self.source.items {
             match item {
                 Item::Bus(b) => buses.push(b),
-                Item::Package(p) => { for b in &p.buses { buses.push(b); } }
+                Item::Package(p) => {
+                    for b in &p.buses {
+                        buses.push(b);
+                    }
+                }
                 _ => {}
             }
         }
@@ -8930,20 +10828,25 @@ impl<'a> SimCodegen<'a> {
             // this, the param_map is empty and every conditional branch
             // folds to false, producing an empty struct that breaks any
             // sim consumer that touches a bus field.
-            let param_map: HashMap<String, &Expr> = b.params.iter()
+            let param_map: HashMap<String, &Expr> = b
+                .params
+                .iter()
                 .filter_map(|p| p.default.as_ref().map(|d| (p.name.name.clone(), d)))
                 .collect();
             let effective = crate::resolve::BusInfo {
                 name: b.name.name.clone(),
                 params: b.params.clone(),
-                signals: b.signals.iter()
+                signals: b
+                    .signals
+                    .iter()
                     .map(|p| (p.name.name.clone(), p.direction, p.ty.clone()))
                     .collect(),
                 generates: b.generates.clone(),
                 handshakes: b.handshakes.clone(),
                 credit_channels: b.credit_channels.clone(),
                 tlm_methods: b.tlm_methods.clone(),
-            }.effective_signals(&param_map);
+            }
+            .effective_signals(&param_map);
             h.push_str(&format!("struct {} {{\n", b.name.name));
             let mut field_inits = Vec::new();
             let mut ctor_body = Vec::new();
@@ -8964,11 +10867,24 @@ impl<'a> SimCodegen<'a> {
             if field_inits.is_empty() && ctor_body.is_empty() {
                 h.push_str(&format!("  {}() {{}}\n", b.name.name));
             } else if field_inits.is_empty() {
-                h.push_str(&format!("  {}() {{ {} }}\n", b.name.name, ctor_body.join(" ")));
+                h.push_str(&format!(
+                    "  {}() {{ {} }}\n",
+                    b.name.name,
+                    ctor_body.join(" ")
+                ));
             } else if ctor_body.is_empty() {
-                h.push_str(&format!("  {}() : {} {{}}\n", b.name.name, field_inits.join(", ")));
+                h.push_str(&format!(
+                    "  {}() : {} {{}}\n",
+                    b.name.name,
+                    field_inits.join(", ")
+                ));
             } else {
-                h.push_str(&format!("  {}() : {} {{ {} }}\n", b.name.name, field_inits.join(", "), ctor_body.join(" ")));
+                h.push_str(&format!(
+                    "  {}() : {} {{ {} }}\n",
+                    b.name.name,
+                    field_inits.join(", "),
+                    ctor_body.join(" ")
+                ));
             }
             h.push_str("};\n\n");
         }
@@ -8980,22 +10896,35 @@ impl<'a> SimCodegen<'a> {
         }
     }
 
-
     pub(crate) fn gen_arbiter(&self, a: &ArbiterDecl) -> SimModel {
         let name = &a.name.name;
         let class = format!("V{name}");
 
-        let num_req: u64 = a.params.iter()
+        let num_req: u64 = a
+            .params
+            .iter()
             .find(|p| p.name.name == "NUM_REQ")
             .and_then(|p| p.default.as_ref())
-            .and_then(|e| if let ExprKind::Literal(LitKind::Dec(v)) = &e.kind { Some(*v) } else { None })
+            .and_then(|e| {
+                if let ExprKind::Literal(LitKind::Dec(v)) = &e.kind {
+                    Some(*v)
+                } else {
+                    None
+                }
+            })
             .unwrap_or(2);
 
         let (rst_name, _is_async, is_low) = extract_reset_info(&a.ports);
-        let rst_cond = if is_low { format!("(!{rst_name})") } else { rst_name.clone() };
+        let rst_cond = if is_low {
+            format!("(!{rst_name})")
+        } else {
+            rst_name.clone()
+        };
 
         let mut h = String::new();
-        h.push_str("#pragma once\n#include <cstdint>\n#include <cstring>\n#include \"verilated.h\"\n\n");
+        h.push_str(
+            "#pragma once\n#include <cstdint>\n#include <cstring>\n#include \"verilated.h\"\n\n",
+        );
         h.push_str(&format!("class {class} {{\npublic:\n"));
         for p in &a.ports {
             let ty = cpp_port_type_with_params(&p.ty, &a.params);
@@ -9011,7 +10940,9 @@ impl<'a> SimCodegen<'a> {
         // scans from index 0 (highest priority) so no state is needed.
         let needs_rr_state = matches!(a.policy, ArbiterPolicy::RoundRobin | ArbiterPolicy::Lru);
 
-        let mut all_port_inits: Vec<String> = a.ports.iter()
+        let mut all_port_inits: Vec<String> = a
+            .ports
+            .iter()
             .map(|p| format!("{}(0)", p.name.name))
             .collect();
         for pa in &a.port_arrays {
@@ -9031,7 +10962,10 @@ impl<'a> SimCodegen<'a> {
             all_port_inits.push(format!("_last_grant({})", num_req.saturating_sub(1)));
         }
 
-        h.push_str(&format!("  {class}() : {} {{}}\n", all_port_inits.join(", ")));
+        h.push_str(&format!(
+            "  {class}() : {} {{}}\n",
+            all_port_inits.join(", ")
+        ));
         h.push_str("  void eval();\n  void eval_posedge();\n  void eval_comb();\n");
         h.push_str("  void final() { trace_close(); }\n");
         h.push_str("private:\n");
@@ -9048,11 +10982,18 @@ impl<'a> SimCodegen<'a> {
         let mut cpp = String::new();
         cpp.push_str(&format!("#include \"{class}.h\"\n\n"));
 
-        let clk_port = a.ports.iter().find(|p| matches!(&p.ty, TypeExpr::Clock(_)))
-            .map(|p| p.name.name.as_str()).unwrap_or("clk");
+        let clk_port = a
+            .ports
+            .iter()
+            .find(|p| matches!(&p.ty, TypeExpr::Clock(_)))
+            .map(|p| p.name.name.as_str())
+            .unwrap_or("clk");
 
-        let req_pa_name = a.port_arrays.first()
-            .map(|pa| pa.name.name.as_str()).unwrap_or("request");
+        let req_pa_name = a
+            .port_arrays
+            .first()
+            .map(|pa| pa.name.name.as_str())
+            .unwrap_or("request");
 
         // eval(): edge detection lives inside eval_posedge() so a parent
         // module's unconditional `_inst_arb.eval_posedge()` call only
@@ -9079,7 +11020,9 @@ impl<'a> SimCodegen<'a> {
             // as the first index to test, so `_last_grant = N-1`
             // makes the first post-reset cycle scan from index 0.
             let rst_val = num_req.saturating_sub(1);
-            cpp.push_str(&format!("  if ({rst_cond}) {{\n    _last_grant = {rst_val};\n  }} else {{\n"));
+            cpp.push_str(&format!(
+                "  if ({rst_cond}) {{\n    _last_grant = {rst_val};\n  }} else {{\n"
+            ));
             cpp.push_str("    if (grant_valid) _last_grant = grant_requester;\n");
             cpp.push_str("  }\n");
         }
@@ -9089,28 +11032,47 @@ impl<'a> SimCodegen<'a> {
         //               round_robin / lru rotate starting after the last grant.
         cpp.push_str(&format!("void {class}::eval_comb() {{\n"));
         cpp.push_str("  grant_valid = 0;\n  grant_requester = 0;\n");
-        cpp.push_str(&format!("  for (int _i = 0; _i < (int){num_req}; _i++) {{\n"));
+        cpp.push_str(&format!(
+            "  for (int _i = 0; _i < (int){num_req}; _i++) {{\n"
+        ));
         if needs_rr_state {
-            cpp.push_str(&format!("    int _idx = (_last_grant + 1 + _i) % {num_req};\n"));
+            cpp.push_str(&format!(
+                "    int _idx = (_last_grant + 1 + _i) % {num_req};\n"
+            ));
         } else {
             cpp.push_str("    int _idx = _i;\n");
         }
         cpp.push_str(&format!("    if (({req_pa_name}_valid >> _idx) & 1) {{\n"));
-        cpp.push_str("      grant_valid = 1;\n      grant_requester = _idx;\n      break;\n    }\n  }\n");
-        cpp.push_str(&format!("  {req_pa_name}_ready = grant_valid ? (1ULL << grant_requester) : 0;\n"));
+        cpp.push_str(
+            "      grant_valid = 1;\n      grant_requester = _idx;\n      break;\n    }\n  }\n",
+        );
+        cpp.push_str(&format!(
+            "  {req_pa_name}_ready = grant_valid ? (1ULL << grant_requester) : 0;\n"
+        ));
         cpp.push_str("}\n\n");
 
         // Trace methods
-        cpp.push_str(&format!("void {class}::trace_open(const char* filename) {{\n"));
+        cpp.push_str(&format!(
+            "void {class}::trace_open(const char* filename) {{\n"
+        ));
         cpp.push_str("  _trace_fp = fopen(filename, \"w\");\n");
         cpp.push_str("  if (!_trace_fp) return;\n");
         cpp.push_str("  fprintf(_trace_fp, \"$timescale 1ns $end\\n\");\n");
-        cpp.push_str(&format!("  fprintf(_trace_fp, \"$scope module {} $end\\n\");\n", name));
+        cpp.push_str(&format!(
+            "  fprintf(_trace_fp, \"$scope module {} $end\\n\");\n",
+            name
+        ));
         let mut sig_idx = 0usize;
         for p in &a.ports {
-            if matches!(p.ty, TypeExpr::Clock(_) | TypeExpr::Reset(..)) { continue; }
-            let id = vcd_id(sig_idx); sig_idx += 1;
-            cpp.push_str(&format!("  fprintf(_trace_fp, \"$var wire 1 {} {} $end\\n\");\n", id, p.name.name));
+            if matches!(p.ty, TypeExpr::Clock(_) | TypeExpr::Reset(..)) {
+                continue;
+            }
+            let id = vcd_id(sig_idx);
+            sig_idx += 1;
+            cpp.push_str(&format!(
+                "  fprintf(_trace_fp, \"$var wire 1 {} {} $end\\n\");\n",
+                id, p.name.name
+            ));
         }
         cpp.push_str("  fprintf(_trace_fp, \"$upscope $end\\n$enddefinitions $end\\n\");\n");
         cpp.push_str("}\n\n");
@@ -9120,10 +11082,16 @@ impl<'a> SimCodegen<'a> {
         cpp.push_str("  fprintf(_trace_fp, \"#%lu\\n\", (unsigned long)time);\n");
         sig_idx = 0;
         for p in &a.ports {
-            if matches!(p.ty, TypeExpr::Clock(_) | TypeExpr::Reset(..)) { continue; }
-            let id = vcd_id(sig_idx); sig_idx += 1;
+            if matches!(p.ty, TypeExpr::Clock(_) | TypeExpr::Reset(..)) {
+                continue;
+            }
+            let id = vcd_id(sig_idx);
+            sig_idx += 1;
             let pname = &p.name.name;
-            cpp.push_str(&format!("  fprintf(_trace_fp, \"%c{}\\n\", {pname} ? '1' : '0');\n", id));
+            cpp.push_str(&format!(
+                "  fprintf(_trace_fp, \"%c{}\\n\", {pname} ? '1' : '0');\n",
+                id
+            ));
         }
         cpp.push_str("}\n\n");
 
@@ -9131,7 +11099,10 @@ impl<'a> SimCodegen<'a> {
         cpp.push_str("  if (_trace_fp) {{ fclose(_trace_fp); _trace_fp = nullptr; }}\n");
         cpp.push_str("}\n");
 
-        SimModel { class_name: class, header: h, impl_: cpp }
+        SimModel {
+            class_name: class,
+            header: h,
+            impl_: cpp,
+        }
     }
-
 }

--- a/src/sim_codegen/pipeline.rs
+++ b/src/sim_codegen/pipeline.rs
@@ -5,9 +5,9 @@
 
 use std::collections::{HashMap, HashSet};
 
-use crate::ast::*;
-use super::{SimCodegen, SimModel};
 use super::*;
+use super::{SimCodegen, SimModel};
+use crate::ast::*;
 
 impl<'a> SimCodegen<'a> {
     pub(crate) fn gen_pipeline(&self, p: &PipelineDecl) -> SimModel {
@@ -15,19 +15,21 @@ impl<'a> SimCodegen<'a> {
         let class = format!("V{name}");
         let _enum_map = build_enum_map(self.symbols);
 
-        let port_names: HashSet<String> = p.ports.iter()
-            .map(|pt| pt.name.name.clone()).collect();
-        let stage_names: Vec<String> = p.stages.iter()
-            .map(|s| s.name.name.clone()).collect();
-        let stage_prefixes: Vec<String> = stage_names.iter()
-            .map(|s| s.to_lowercase()).collect();
-        let wait_stage_flags: Vec<bool> = p.stages.iter()
-            .map(Self::pipeline_stage_has_wait)
-            .collect();
+        let port_names: HashSet<String> = p.ports.iter().map(|pt| pt.name.name.clone()).collect();
+        let stage_names: Vec<String> = p.stages.iter().map(|s| s.name.name.clone()).collect();
+        let stage_prefixes: Vec<String> = stage_names.iter().map(|s| s.to_lowercase()).collect();
+        let wait_stage_flags: Vec<bool> =
+            p.stages.iter().map(Self::pipeline_stage_has_wait).collect();
         let has_any_wait_stage = wait_stage_flags.iter().any(|f| *f);
 
         // Flatten stage registers and let bindings
-        struct StageReg { prefixed: String, ty: String, reset_val: String, bits: u32, is_let: bool }
+        struct StageReg {
+            prefixed: String,
+            ty: String,
+            reset_val: String,
+            bits: u32,
+            is_let: bool,
+        }
         let mut all_regs: Vec<StageReg> = Vec::new();
         let mut stage_reg_names: Vec<HashSet<String>> = Vec::new();
 
@@ -40,18 +42,41 @@ impl<'a> SimCodegen<'a> {
                         let prefixed = format!("{}_{}", prefix, r.name.name);
                         let ty = cpp_internal_type_with_params(&r.ty, &p.common.params);
                         let bits = type_bits_te_with_params(&r.ty, &p.common.params);
-                        let reset_val = Self::pipeline_reset_value(&r.reset).unwrap_or("0".to_string());
+                        let reset_val =
+                            Self::pipeline_reset_value(&r.reset).unwrap_or("0".to_string());
                         names_set.insert(r.name.name.clone());
-                        all_regs.push(StageReg { prefixed, ty, reset_val, bits, is_let: false });
+                        all_regs.push(StageReg {
+                            prefixed,
+                            ty,
+                            reset_val,
+                            bits,
+                            is_let: false,
+                        });
                     }
                     ModuleBodyItem::LetBinding(l) => {
                         // ty=None means assignment to existing port/wire — skip as new binding
-                        if l.ty.is_none() { continue; }
+                        if l.ty.is_none() {
+                            continue;
+                        }
                         let prefixed = format!("{}_{}", prefix, l.name.name);
-                        let ty = if let Some(ref te) = l.ty { cpp_internal_type_with_params(te, &p.common.params) } else { "uint32_t".to_string() };
-                        let bits = if let Some(ref te) = l.ty { type_bits_te_with_params(te, &p.common.params) } else { 32 };
+                        let ty = if let Some(ref te) = l.ty {
+                            cpp_internal_type_with_params(te, &p.common.params)
+                        } else {
+                            "uint32_t".to_string()
+                        };
+                        let bits = if let Some(ref te) = l.ty {
+                            type_bits_te_with_params(te, &p.common.params)
+                        } else {
+                            32
+                        };
                         names_set.insert(l.name.name.clone());
-                        all_regs.push(StageReg { prefixed, ty, reset_val: String::new(), bits, is_let: true });
+                        all_regs.push(StageReg {
+                            prefixed,
+                            ty,
+                            reset_val: String::new(),
+                            bits,
+                            is_let: true,
+                        });
                     }
                     _ => {}
                 }
@@ -63,8 +88,11 @@ impl<'a> SimCodegen<'a> {
         let mut let_names: HashSet<String> = HashSet::new();
         let mut widths: HashMap<String, u32> = HashMap::new();
         for sr in &all_regs {
-            if sr.is_let { let_names.insert(sr.prefixed.clone()); }
-            else { reg_names.insert(sr.prefixed.clone()); }
+            if sr.is_let {
+                let_names.insert(sr.prefixed.clone());
+            } else {
+                reg_names.insert(sr.prefixed.clone());
+            }
             widths.insert(sr.prefixed.clone(), sr.bits);
         }
         for (si, prefix) in stage_prefixes.iter().enumerate() {
@@ -77,7 +105,10 @@ impl<'a> SimCodegen<'a> {
         }
         // Add port widths
         for pt in &p.ports {
-            widths.insert(pt.name.name.clone(), type_bits_te_with_params(&pt.ty, &p.common.params));
+            widths.insert(
+                pt.name.name.clone(),
+                type_bits_te_with_params(&pt.ty, &p.common.params),
+            );
         }
 
         // ── Collect implicit wires (comb-block LHS targets + inst output
@@ -85,7 +116,12 @@ impl<'a> SimCodegen<'a> {
         // be declared as members so eval_comb-emitted writes and seq-block
         // reads both compile. Type is inferred by walking the stage body
         // to find a consumer register or matching sub-port type.
-        struct ImplicitWire { name: String, prefixed: String, ty_cpp: String, bits: u32 }
+        struct ImplicitWire {
+            name: String,
+            prefixed: String,
+            ty_cpp: String,
+            bits: u32,
+        }
         let mut implicit_wires: Vec<Vec<ImplicitWire>> = Vec::new();
         for (si, stage) in p.stages.iter().enumerate() {
             let prefix = &stage_prefixes[si];
@@ -101,7 +137,9 @@ impl<'a> SimCodegen<'a> {
                                         if let ExprKind::Ident(lhs) = &a.target.kind {
                                             for it2 in &stage.body {
                                                 if let ModuleBodyItem::RegDecl(r) = it2 {
-                                                    if r.name.name == *lhs { return Some(r.ty.clone()); }
+                                                    if r.name.name == *lhs {
+                                                        return Some(r.ty.clone());
+                                                    }
                                                 }
                                             }
                                         }
@@ -118,7 +156,9 @@ impl<'a> SimCodegen<'a> {
                 for s in stmts {
                     match s {
                         Stmt::Assign(a) => {
-                            if let ExprKind::Ident(n) = &a.target.kind { out.push(n.clone()); }
+                            if let ExprKind::Ident(n) = &a.target.kind {
+                                out.push(n.clone());
+                            }
                         }
                         Stmt::IfElse(ie) => {
                             walk_comb_targets(&ie.then_stmts, out);
@@ -138,11 +178,21 @@ impl<'a> SimCodegen<'a> {
                     let mut targets = Vec::new();
                     walk_comb_targets(&cb.stmts, &mut targets);
                     for t in targets {
-                        if is_known(&t, &wires) { continue; }
-                        let ty_te = consumer_ty(&t).unwrap_or(TypeExpr::UInt(Box::new(Expr::new(ExprKind::Literal(LitKind::Dec(32)), p.span))));
+                        if is_known(&t, &wires) {
+                            continue;
+                        }
+                        let ty_te = consumer_ty(&t).unwrap_or(TypeExpr::UInt(Box::new(Expr::new(
+                            ExprKind::Literal(LitKind::Dec(32)),
+                            p.span,
+                        ))));
                         let bits = type_bits_te_with_params(&ty_te, &p.common.params);
                         let ty_cpp = cpp_internal_type_with_params(&ty_te, &p.common.params);
-                        wires.push(ImplicitWire { name: t.clone(), prefixed: format!("{prefix}_{t}"), ty_cpp, bits });
+                        wires.push(ImplicitWire {
+                            name: t.clone(),
+                            prefixed: format!("{prefix}_{t}"),
+                            ty_cpp,
+                            bits,
+                        });
                     }
                 }
             }
@@ -151,18 +201,33 @@ impl<'a> SimCodegen<'a> {
                 if let ModuleBodyItem::Inst(inst) = it {
                     let sub_ports = self.lookup_inst_ports(&inst.module_name.name);
                     for conn in &inst.connections {
-                        if conn.direction != ConnectDir::Output { continue; }
-                        let ExprKind::Ident(target) = &conn.signal.kind else { continue; };
-                        if is_known(target, &wires) { continue; }
+                        if conn.direction != ConnectDir::Output {
+                            continue;
+                        }
+                        let ExprKind::Ident(target) = &conn.signal.kind else {
+                            continue;
+                        };
+                        if is_known(target, &wires) {
+                            continue;
+                        }
                         // Type from sub-module's matching port, fall back to consumer reg.
-                        let ty_te = sub_ports.iter()
+                        let ty_te = sub_ports
+                            .iter()
                             .find(|sp| sp.name.name == conn.port_name.name)
                             .map(|sp| sp.ty.clone())
                             .or_else(|| consumer_ty(target))
-                            .unwrap_or(TypeExpr::UInt(Box::new(Expr::new(ExprKind::Literal(LitKind::Dec(32)), p.span))));
+                            .unwrap_or(TypeExpr::UInt(Box::new(Expr::new(
+                                ExprKind::Literal(LitKind::Dec(32)),
+                                p.span,
+                            ))));
                         let bits = type_bits_te_with_params(&ty_te, &p.common.params);
                         let ty_cpp = cpp_internal_type_with_params(&ty_te, &p.common.params);
-                        wires.push(ImplicitWire { name: target.clone(), prefixed: format!("{prefix}_{target}"), ty_cpp, bits });
+                        wires.push(ImplicitWire {
+                            name: target.clone(),
+                            prefixed: format!("{prefix}_{target}"),
+                            ty_cpp,
+                            bits,
+                        });
                     }
                 }
             }
@@ -179,20 +244,41 @@ impl<'a> SimCodegen<'a> {
         }
 
         // Collect insts per stage for codegen.
-        let stage_insts: Vec<Vec<&InstDecl>> = p.stages.iter()
-            .map(|s| s.body.iter().filter_map(|it| if let ModuleBodyItem::Inst(i) = it { Some(i) } else { None }).collect())
+        let stage_insts: Vec<Vec<&InstDecl>> = p
+            .stages
+            .iter()
+            .map(|s| {
+                s.body
+                    .iter()
+                    .filter_map(|it| {
+                        if let ModuleBodyItem::Inst(i) = it {
+                            Some(i)
+                        } else {
+                            None
+                        }
+                    })
+                    .collect()
+            })
             .collect();
 
         let (rst_name, _is_async, is_low) = extract_reset_info(&p.ports);
-        let rst_cond = if is_low { format!("(!{})", rst_name) } else { rst_name.clone() };
-        let clk_name = p.ports.iter()
+        let rst_cond = if is_low {
+            format!("(!{})", rst_name)
+        } else {
+            rst_name.clone()
+        };
+        let clk_name = p
+            .ports
+            .iter()
             .find(|pt| matches!(pt.ty, TypeExpr::Clock(_)))
             .map(|pt| pt.name.name.clone())
             .unwrap_or("clk".to_string());
 
         // ── Header ──
         let mut h = String::new();
-        h.push_str("#pragma once\n#include <cstdint>\n#include <cstdio>\n#include \"verilated.h\"\n");
+        h.push_str(
+            "#pragma once\n#include <cstdint>\n#include <cstdio>\n#include \"verilated.h\"\n",
+        );
         // Include sub-module headers for any insts inside stages.
         let mut included: HashSet<String> = HashSet::new();
         for stage_list in &stage_insts {
@@ -207,28 +293,47 @@ impl<'a> SimCodegen<'a> {
             if matches!(param.kind, ParamKind::Const | ParamKind::WidthConst(..)) {
                 if let Some(ref def) = param.default {
                     let val = eval_const_expr_with_params(def, &p.common.params);
-                    h.push_str(&format!("#ifndef {}\n#define {} {val}ULL\n#endif\n", param.name.name, param.name.name));
+                    h.push_str(&format!(
+                        "#ifndef {}\n#define {} {val}ULL\n#endif\n",
+                        param.name.name, param.name.name
+                    ));
                 }
             }
         }
         h.push_str(&format!("\nclass {class} {{\npublic:\n"));
         for pt in &p.ports {
-            h.push_str(&format!("  {} {};\n", cpp_port_type_with_params(&pt.ty, &p.common.params), pt.name.name));
+            h.push_str(&format!(
+                "  {} {};\n",
+                cpp_port_type_with_params(&pt.ty, &p.common.params),
+                pt.name.name
+            ));
         }
         h.push('\n');
 
         // Constructor
-        let mut inits: Vec<String> = p.ports.iter().map(|pt| format!("{}(0)", pt.name.name)).collect();
+        let mut inits: Vec<String> = p
+            .ports
+            .iter()
+            .map(|pt| format!("{}(0)", pt.name.name))
+            .collect();
         inits.push("_clk_prev(0)".to_string());
-        for sr in &all_regs { if !sr.is_let { inits.push(format!("_{}(0)", sr.prefixed)); } }
-        for prefix in &stage_prefixes { inits.push(format!("_{}_valid_r(0)", prefix)); }
+        for sr in &all_regs {
+            if !sr.is_let {
+                inits.push(format!("_{}(0)", sr.prefixed));
+            }
+        }
+        for prefix in &stage_prefixes {
+            inits.push(format!("_{}_valid_r(0)", prefix));
+        }
         for (si, prefix) in stage_prefixes.iter().enumerate() {
             if wait_stage_flags[si] {
                 inits.push(format!("_{}_fsm_state(0)", prefix));
             }
         }
         for stage_wires in &implicit_wires {
-            for w in stage_wires { inits.push(format!("{}(0)", w.prefixed)); }
+            for w in stage_wires {
+                inits.push(format!("{}(0)", w.prefixed));
+            }
         }
         h.push_str(&format!("  {class}() : {} {{}}\n\n", inits.join(", ")));
 
@@ -238,8 +343,14 @@ impl<'a> SimCodegen<'a> {
 
         h.push_str("private:\n");
         h.push_str("  uint8_t _clk_prev;\n");
-        for sr in &all_regs { if !sr.is_let { h.push_str(&format!("  {} _{};\n", sr.ty, sr.prefixed)); } }
-        for prefix in &stage_prefixes { h.push_str(&format!("  uint8_t _{}_valid_r;\n", prefix)); }
+        for sr in &all_regs {
+            if !sr.is_let {
+                h.push_str(&format!("  {} _{};\n", sr.ty, sr.prefixed));
+            }
+        }
+        for prefix in &stage_prefixes {
+            h.push_str(&format!("  uint8_t _{}_valid_r;\n", prefix));
+        }
         for (si, prefix) in stage_prefixes.iter().enumerate() {
             if wait_stage_flags[si] {
                 h.push_str(&format!("  uint32_t _{}_fsm_state;\n", prefix));
@@ -254,7 +365,10 @@ impl<'a> SimCodegen<'a> {
         // Sub-instance members (one per inst inside any stage).
         for stage_list in &stage_insts {
             for inst in stage_list {
-                h.push_str(&format!("  V{} _inst_{};\n", inst.module_name.name, inst.name.name));
+                h.push_str(&format!(
+                    "  V{} _inst_{};\n",
+                    inst.module_name.name, inst.name.name
+                ));
             }
         }
         h.push_str("};\n");
@@ -262,17 +376,25 @@ impl<'a> SimCodegen<'a> {
         // ── Implementation ──
         let mut cpp = String::new();
         cpp.push_str(&format!("#include \"V{name}.h\"\n\n"));
-        cpp.push_str(&format!("void {class}::eval() {{ eval_comb(); eval_posedge(); eval_comb(); }}\n\n"));
+        cpp.push_str(&format!(
+            "void {class}::eval() {{ eval_comb(); eval_posedge(); eval_comb(); }}\n\n"
+        ));
 
         // reset()
         cpp.push_str(&format!("void {class}::_do_reset() {{\n"));
         for sr in &all_regs {
             if !sr.is_let {
-                let v = match sr.reset_val.as_str() { "false" | "1'b0" => "0", "true" | "1'b1" => "1", other => other };
+                let v = match sr.reset_val.as_str() {
+                    "false" | "1'b0" => "0",
+                    "true" | "1'b1" => "1",
+                    other => other,
+                };
                 cpp.push_str(&format!("  _{} = {v};\n", sr.prefixed));
             }
         }
-        for prefix in &stage_prefixes { cpp.push_str(&format!("  _{}_valid_r = 0;\n", prefix)); }
+        for prefix in &stage_prefixes {
+            cpp.push_str(&format!("  _{}_valid_r = 0;\n", prefix));
+        }
         for (si, prefix) in stage_prefixes.iter().enumerate() {
             if wait_stage_flags[si] {
                 cpp.push_str(&format!("  _{}_fsm_state = 0;\n", prefix));
@@ -282,7 +404,9 @@ impl<'a> SimCodegen<'a> {
 
         // eval_posedge()
         cpp.push_str(&format!("void {class}::eval_posedge() {{\n"));
-        cpp.push_str(&format!("  bool _rising = ({clk_name} && !_clk_prev);\n  _clk_prev = {clk_name};\n"));
+        cpp.push_str(&format!(
+            "  bool _rising = ({clk_name} && !_clk_prev);\n  _clk_prev = {clk_name};\n"
+        ));
         cpp.push_str("  if (_rising) {\n");
         cpp.push_str(&format!("    if ({rst_cond}) {{ _do_reset(); }} else {{\n"));
 
@@ -291,13 +415,39 @@ impl<'a> SimCodegen<'a> {
             let prefix = &stage_prefixes[si];
             for item in &stage.body {
                 if let ModuleBodyItem::LetBinding(l) = item {
-                    let val = self.pipeline_sim_expr(&l.value, prefix, si,
-                        &stage_names, &stage_prefixes, &stage_reg_names,
-                        &port_names, &reg_names, &let_names, &widths, &_enum_map, &p.common.params);
-                    let ty = if let Some(ref te) = l.ty { cpp_internal_type_with_params(te, &p.common.params) } else { "uint32_t".to_string() };
-                    let bits = if let Some(ref te) = l.ty { type_bits_te_with_params(te, &p.common.params) } else { 32 };
-                    let mask = if bits > 0 && bits < 64 { format!(" & 0x{:X}ULL", (1u64 << bits) - 1) } else { String::new() };
-                    cpp.push_str(&format!("      {ty} {}_{} = ({val}){mask};\n", prefix, l.name.name));
+                    let val = self.pipeline_sim_expr(
+                        &l.value,
+                        prefix,
+                        si,
+                        &stage_names,
+                        &stage_prefixes,
+                        &stage_reg_names,
+                        &port_names,
+                        &reg_names,
+                        &let_names,
+                        &widths,
+                        &_enum_map,
+                        &p.common.params,
+                    );
+                    let ty = if let Some(ref te) = l.ty {
+                        cpp_internal_type_with_params(te, &p.common.params)
+                    } else {
+                        "uint32_t".to_string()
+                    };
+                    let bits = if let Some(ref te) = l.ty {
+                        type_bits_te_with_params(te, &p.common.params)
+                    } else {
+                        32
+                    };
+                    let mask = if bits > 0 && bits < 64 {
+                        format!(" & 0x{:X}ULL", (1u64 << bits) - 1)
+                    } else {
+                        String::new()
+                    };
+                    cpp.push_str(&format!(
+                        "      {ty} {}_{} = ({val}){mask};\n",
+                        prefix, l.name.name
+                    ));
                 }
             }
         }
@@ -311,31 +461,66 @@ impl<'a> SimCodegen<'a> {
         let has_global_stall = !p.stall_conds.is_empty();
         let has_any_stall = has_per_stage_stall || has_global_stall || has_any_wait_stage;
         if has_global_stall {
-            let parts: Vec<String> = p.stall_conds.iter().map(|c| {
-                self.pipeline_sim_expr(&c.condition, "", 0,
-                    &stage_names, &stage_prefixes, &stage_reg_names,
-                    &port_names, &reg_names, &let_names, &widths, &_enum_map, &p.common.params)
-            }).collect();
-            cpp.push_str(&format!("      bool _pipeline_stall = ({});\n", parts.join(" || ")));
+            let parts: Vec<String> = p
+                .stall_conds
+                .iter()
+                .map(|c| {
+                    self.pipeline_sim_expr(
+                        &c.condition,
+                        "",
+                        0,
+                        &stage_names,
+                        &stage_prefixes,
+                        &stage_reg_names,
+                        &port_names,
+                        &reg_names,
+                        &let_names,
+                        &widths,
+                        &_enum_map,
+                        &p.common.params,
+                    )
+                })
+                .collect();
+            cpp.push_str(&format!(
+                "      bool _pipeline_stall = ({});\n",
+                parts.join(" || ")
+            ));
         }
         if has_any_stall {
             for si in (0..p.stages.len()).rev() {
                 let prefix = &stage_prefixes[si];
                 let mut parts: Vec<String> = Vec::new();
                 if let Some(ref cond) = p.stages[si].stall_cond {
-                    let s = self.pipeline_sim_expr(cond, prefix, si,
-                        &stage_names, &stage_prefixes, &stage_reg_names,
-                        &port_names, &reg_names, &let_names, &widths, &_enum_map, &p.common.params);
+                    let s = self.pipeline_sim_expr(
+                        cond,
+                        prefix,
+                        si,
+                        &stage_names,
+                        &stage_prefixes,
+                        &stage_reg_names,
+                        &port_names,
+                        &reg_names,
+                        &let_names,
+                        &widths,
+                        &_enum_map,
+                        &p.common.params,
+                    );
                     parts.push(format!("({s})"));
                 }
                 if wait_stage_flags[si] {
                     parts.push(format!("(_{prefix}_fsm_state != 0)"));
                 }
-                if has_global_stall { parts.push("_pipeline_stall".to_string()); }
+                if has_global_stall {
+                    parts.push("_pipeline_stall".to_string());
+                }
                 if si + 1 < p.stages.len() {
                     parts.push(format!("_{}_stall", stage_prefixes[si + 1]));
                 }
-                let expr = if parts.is_empty() { "false".to_string() } else { parts.join(" || ") };
+                let expr = if parts.is_empty() {
+                    "false".to_string()
+                } else {
+                    parts.join(" || ")
+                };
                 cpp.push_str(&format!("      bool _{prefix}_stall = ({expr});\n"));
             }
         }
@@ -346,15 +531,32 @@ impl<'a> SimCodegen<'a> {
             let stage = &p.stages[si];
             let prefix = &stage_prefixes[si];
             if wait_stage_flags[si] {
-                self.emit_pipeline_sim_wait_stage(&mut cpp, stage, prefix, si,
-                    &stage_names, &stage_prefixes, &stage_reg_names,
-                    &port_names, &reg_names, &let_names, &widths, &_enum_map, &p.common.params, 6);
+                self.emit_pipeline_sim_wait_stage(
+                    &mut cpp,
+                    stage,
+                    prefix,
+                    si,
+                    &stage_names,
+                    &stage_prefixes,
+                    &stage_reg_names,
+                    &port_names,
+                    &reg_names,
+                    &let_names,
+                    &widths,
+                    &_enum_map,
+                    &p.common.params,
+                    6,
+                );
                 continue;
             }
             // When stall is in play, this stage advances only if not stalled.
             // valid_r propagation: if upstream is stalled, insert a bubble.
             let (open_guard, close_guard, indent_extra) = if has_any_stall {
-                (format!("      if (!_{prefix}_stall) {{\n"), "      }\n".to_string(), 2)
+                (
+                    format!("      if (!_{prefix}_stall) {{\n"),
+                    "      }\n".to_string(),
+                    2,
+                )
             } else {
                 (String::new(), String::new(), 0)
             };
@@ -366,7 +568,9 @@ impl<'a> SimCodegen<'a> {
                 let prev = &stage_prefixes[si - 1];
                 if has_any_stall {
                     // Bubble when prev stage is stalled (upstream can't deliver).
-                    cpp.push_str(&format!("{pad}_{prefix}_valid_r = _{prev}_stall ? 0 : _{prev}_valid_r;\n"));
+                    cpp.push_str(&format!(
+                        "{pad}_{prefix}_valid_r = _{prev}_stall ? 0 : _{prev}_valid_r;\n"
+                    ));
                 } else {
                     cpp.push_str(&format!("{pad}_{prefix}_valid_r = _{prev}_valid_r;\n"));
                 }
@@ -374,9 +578,22 @@ impl<'a> SimCodegen<'a> {
             for item in &stage.body {
                 if let ModuleBodyItem::RegBlock(rb) = item {
                     for stmt in &rb.stmts {
-                        self.emit_pipeline_sim_stmt(&mut cpp, stmt, prefix, si,
-                            &stage_names, &stage_prefixes, &stage_reg_names,
-                            &port_names, &reg_names, &let_names, &widths, &_enum_map, &p.common.params, 6 + indent_extra);
+                        self.emit_pipeline_sim_stmt(
+                            &mut cpp,
+                            stmt,
+                            prefix,
+                            si,
+                            &stage_names,
+                            &stage_prefixes,
+                            &stage_reg_names,
+                            &port_names,
+                            &reg_names,
+                            &let_names,
+                            &widths,
+                            &_enum_map,
+                            &p.common.params,
+                            6 + indent_extra,
+                        );
                     }
                 }
             }
@@ -384,9 +601,20 @@ impl<'a> SimCodegen<'a> {
         }
         for flush in &p.flush_directives {
             let target = flush.target_stage.name.to_lowercase();
-            let cond = self.pipeline_sim_expr(&flush.condition, "", 0,
-                &stage_names, &stage_prefixes, &stage_reg_names,
-                &port_names, &reg_names, &let_names, &widths, &_enum_map, &p.common.params);
+            let cond = self.pipeline_sim_expr(
+                &flush.condition,
+                "",
+                0,
+                &stage_names,
+                &stage_prefixes,
+                &stage_reg_names,
+                &port_names,
+                &reg_names,
+                &let_names,
+                &widths,
+                &_enum_map,
+                &p.common.params,
+            );
             cpp.push_str(&format!("      if ({cond}) {{ _{target}_valid_r = 0; }}\n"));
         }
         cpp.push_str("    }\n  }\n}\n\n");
@@ -399,52 +627,119 @@ impl<'a> SimCodegen<'a> {
                 match item {
                     ModuleBodyItem::LetBinding(l) => {
                         // ty=None means assignment to existing port/wire — skip as new binding
-                        if l.ty.is_none() { continue; }
-                        let val = self.pipeline_sim_expr(&l.value, prefix, si,
-                            &stage_names, &stage_prefixes, &stage_reg_names,
-                            &port_names, &reg_names, &let_names, &widths, &_enum_map, &p.common.params);
-                        let ty = if let Some(ref te) = l.ty { cpp_internal_type_with_params(te, &p.common.params) } else { "uint32_t".to_string() };
-                        let bits = if let Some(ref te) = l.ty { type_bits_te_with_params(te, &p.common.params) } else { 32 };
-                        let mask = if bits > 0 && bits < 64 { format!(" & 0x{:X}ULL", (1u64 << bits) - 1) } else { String::new() };
-                        cpp.push_str(&format!("  {ty} {}_{} = ({val}){mask};\n", prefix, l.name.name));
+                        if l.ty.is_none() {
+                            continue;
+                        }
+                        let val = self.pipeline_sim_expr(
+                            &l.value,
+                            prefix,
+                            si,
+                            &stage_names,
+                            &stage_prefixes,
+                            &stage_reg_names,
+                            &port_names,
+                            &reg_names,
+                            &let_names,
+                            &widths,
+                            &_enum_map,
+                            &p.common.params,
+                        );
+                        let ty = if let Some(ref te) = l.ty {
+                            cpp_internal_type_with_params(te, &p.common.params)
+                        } else {
+                            "uint32_t".to_string()
+                        };
+                        let bits = if let Some(ref te) = l.ty {
+                            type_bits_te_with_params(te, &p.common.params)
+                        } else {
+                            32
+                        };
+                        let mask = if bits > 0 && bits < 64 {
+                            format!(" & 0x{:X}ULL", (1u64 << bits) - 1)
+                        } else {
+                            String::new()
+                        };
+                        cpp.push_str(&format!(
+                            "  {ty} {}_{} = ({val}){mask};\n",
+                            prefix, l.name.name
+                        ));
                     }
                     ModuleBodyItem::CombBlock(cb) => {
                         for stmt in &cb.stmts {
-                            self.emit_pipeline_sim_comb_stmt(&mut cpp, stmt, prefix, si,
-                                &stage_names, &stage_prefixes, &stage_reg_names,
-                                &port_names, &reg_names, &let_names, &widths, &_enum_map, &p.common.params, 2);
+                            self.emit_pipeline_sim_comb_stmt(
+                                &mut cpp,
+                                stmt,
+                                prefix,
+                                si,
+                                &stage_names,
+                                &stage_prefixes,
+                                &stage_reg_names,
+                                &port_names,
+                                &reg_names,
+                                &let_names,
+                                &widths,
+                                &_enum_map,
+                                &p.common.params,
+                                2,
+                            );
                         }
                     }
                     ModuleBodyItem::Inst(inst) => {
                         let sub_ports = self.lookup_inst_ports(&inst.module_name.name);
                         // Inputs first.
                         for conn in &inst.connections {
-                            if conn.direction != ConnectDir::Input { continue; }
-                            let val = self.pipeline_sim_expr(&conn.signal, prefix, si,
-                                &stage_names, &stage_prefixes, &stage_reg_names,
-                                &port_names, &reg_names, &let_names, &widths, &_enum_map, &p.common.params);
-                            cpp.push_str(&format!("  _inst_{}.{} = {val};\n",
-                                inst.name.name, conn.port_name.name));
+                            if conn.direction != ConnectDir::Input {
+                                continue;
+                            }
+                            let val = self.pipeline_sim_expr(
+                                &conn.signal,
+                                prefix,
+                                si,
+                                &stage_names,
+                                &stage_prefixes,
+                                &stage_reg_names,
+                                &port_names,
+                                &reg_names,
+                                &let_names,
+                                &widths,
+                                &_enum_map,
+                                &p.common.params,
+                            );
+                            cpp.push_str(&format!(
+                                "  _inst_{}.{} = {val};\n",
+                                inst.name.name, conn.port_name.name
+                            ));
                         }
                         // Eval the sub-instance.
                         cpp.push_str(&format!("  _inst_{}.eval();\n", inst.name.name));
                         // Outputs to driver wires.
                         for conn in &inst.connections {
-                            if conn.direction != ConnectDir::Output { continue; }
-                            let ExprKind::Ident(target) = &conn.signal.kind else { continue; };
+                            if conn.direction != ConnectDir::Output {
+                                continue;
+                            }
+                            let ExprKind::Ident(target) = &conn.signal.kind else {
+                                continue;
+                            };
                             let lhs = if port_names.contains(target) {
                                 target.clone()
                             } else {
                                 format!("{}_{}", prefix, target)
                             };
                             // Mask to match the implicit-wire width when narrower than 64.
-                            let bits = sub_ports.iter().find(|sp| sp.name.name == conn.port_name.name)
-                                .map(|sp| type_bits_te_with_params(&sp.ty, &p.common.params)).unwrap_or(32);
+                            let bits = sub_ports
+                                .iter()
+                                .find(|sp| sp.name.name == conn.port_name.name)
+                                .map(|sp| type_bits_te_with_params(&sp.ty, &p.common.params))
+                                .unwrap_or(32);
                             let mask = if bits > 0 && bits < 64 {
                                 format!(" & 0x{:X}ULL", (1u64 << bits) - 1)
-                            } else { String::new() };
-                            cpp.push_str(&format!("  {lhs} = (_inst_{}.{}){mask};\n",
-                                inst.name.name, conn.port_name.name));
+                            } else {
+                                String::new()
+                            };
+                            cpp.push_str(&format!(
+                                "  {lhs} = (_inst_{}.{}){mask};\n",
+                                inst.name.name, conn.port_name.name
+                            ));
                         }
                     }
                     _ => {}
@@ -453,7 +748,11 @@ impl<'a> SimCodegen<'a> {
         }
         cpp.push_str("}\n");
 
-        SimModel { class_name: class, header: h, impl_: cpp }
+        SimModel {
+            class_name: class,
+            header: h,
+            impl_: cpp,
+        }
     }
 
     fn pipeline_stage_has_wait(stage: &StageDecl) -> bool {
@@ -480,11 +779,21 @@ impl<'a> SimCodegen<'a> {
 
     #[allow(clippy::too_many_arguments)]
     fn emit_pipeline_sim_wait_stage(
-        &self, cpp: &mut String, stage: &StageDecl, prefix: &str, si: usize,
-        sn: &[String], sp: &[String], srn: &[HashSet<String>],
-        pn: &HashSet<String>, rn: &HashSet<String>, ln: &HashSet<String>,
-        w: &HashMap<String, u32>, em: &HashMap<String, Vec<(String, u64)>>,
-        params: &[ParamDecl], indent: usize,
+        &self,
+        cpp: &mut String,
+        stage: &StageDecl,
+        prefix: &str,
+        si: usize,
+        sn: &[String],
+        sp: &[String],
+        srn: &[HashSet<String>],
+        pn: &HashSet<String>,
+        rn: &HashSet<String>,
+        ln: &HashSet<String>,
+        w: &HashMap<String, u32>,
+        em: &HashMap<String, Vec<(String, u64)>>,
+        params: &[ParamDecl],
+        indent: usize,
     ) {
         let mut seq_stmts: &[Stmt] = &[];
         for item in &stage.body {
@@ -540,25 +849,74 @@ impl<'a> SimCodegen<'a> {
         // wait condition is already true, fast-path through it; otherwise
         // enter state 1 and run do-until hold assignments once.
         let first = &groups[0];
-        let first_cond = self.pipeline_sim_expr(first.cond, prefix, si, sn, sp, srn, pn, rn, ln, w, em, params);
+        let first_cond = self.pipeline_sim_expr(
+            first.cond, prefix, si, sn, sp, srn, pn, rn, ln, w, em, params,
+        );
         cpp.push_str(&format!("{pad2}case 0: {{\n"));
         cpp.push_str(&format!("{pad2}  if ({upstream_valid}) {{\n"));
         for stmt in &first.pre_assigns {
-            self.emit_pipeline_sim_stmt(cpp, stmt, prefix, si, sn, sp, srn, pn, rn, ln, w, em, params, indent + 4);
+            self.emit_pipeline_sim_stmt(
+                cpp,
+                stmt,
+                prefix,
+                si,
+                sn,
+                sp,
+                srn,
+                pn,
+                rn,
+                ln,
+                w,
+                em,
+                params,
+                indent + 4,
+            );
         }
         cpp.push_str(&format!("{pad2}    if ({first_cond}) {{\n"));
         if groups.len() == 1 {
             for stmt in &trailing {
-                self.emit_pipeline_sim_stmt(cpp, stmt, prefix, si, sn, sp, srn, pn, rn, ln, w, em, params, indent + 6);
+                self.emit_pipeline_sim_stmt(
+                    cpp,
+                    stmt,
+                    prefix,
+                    si,
+                    sn,
+                    sp,
+                    srn,
+                    pn,
+                    rn,
+                    ln,
+                    w,
+                    em,
+                    params,
+                    indent + 6,
+                );
             }
-            cpp.push_str(&format!("{pad2}      _{prefix}_valid_r = {upstream_valid};\n"));
+            cpp.push_str(&format!(
+                "{pad2}      _{prefix}_valid_r = {upstream_valid};\n"
+            ));
         } else {
             cpp.push_str(&format!("{pad2}      _{prefix}_fsm_state = 2;\n"));
         }
         cpp.push_str(&format!("{pad2}    }} else {{\n"));
         cpp.push_str(&format!("{pad2}      _{prefix}_fsm_state = 1;\n"));
         for stmt in &first.hold_assigns {
-            self.emit_pipeline_sim_stmt(cpp, stmt, prefix, si, sn, sp, srn, pn, rn, ln, w, em, params, indent + 6);
+            self.emit_pipeline_sim_stmt(
+                cpp,
+                stmt,
+                prefix,
+                si,
+                sn,
+                sp,
+                srn,
+                pn,
+                rn,
+                ln,
+                w,
+                em,
+                params,
+                indent + 6,
+            );
         }
         cpp.push_str(&format!("{pad2}    }}\n"));
         cpp.push_str(&format!("{pad2}  }}\n"));
@@ -567,23 +925,70 @@ impl<'a> SimCodegen<'a> {
 
         for (gi, group) in groups.iter().enumerate() {
             let state = gi + 1;
-            let cond = self.pipeline_sim_expr(group.cond, prefix, si, sn, sp, srn, pn, rn, ln, w, em, params);
+            let cond = self.pipeline_sim_expr(
+                group.cond, prefix, si, sn, sp, srn, pn, rn, ln, w, em, params,
+            );
             cpp.push_str(&format!("{pad2}case {state}: {{\n"));
             for stmt in &group.hold_assigns {
-                self.emit_pipeline_sim_stmt(cpp, stmt, prefix, si, sn, sp, srn, pn, rn, ln, w, em, params, indent + 4);
+                self.emit_pipeline_sim_stmt(
+                    cpp,
+                    stmt,
+                    prefix,
+                    si,
+                    sn,
+                    sp,
+                    srn,
+                    pn,
+                    rn,
+                    ln,
+                    w,
+                    em,
+                    params,
+                    indent + 4,
+                );
             }
             cpp.push_str(&format!("{pad2}  if ({cond}) {{\n"));
             let is_last = gi + 1 >= groups.len();
             if is_last {
                 for stmt in &trailing {
-                    self.emit_pipeline_sim_stmt(cpp, stmt, prefix, si, sn, sp, srn, pn, rn, ln, w, em, params, indent + 4);
+                    self.emit_pipeline_sim_stmt(
+                        cpp,
+                        stmt,
+                        prefix,
+                        si,
+                        sn,
+                        sp,
+                        srn,
+                        pn,
+                        rn,
+                        ln,
+                        w,
+                        em,
+                        params,
+                        indent + 4,
+                    );
                 }
                 cpp.push_str(&format!("{pad2}    _{prefix}_fsm_state = 0;\n"));
                 cpp.push_str(&format!("{pad2}    _{prefix}_valid_r = 1;\n"));
             } else {
                 let next_group = &groups[gi + 1];
                 for stmt in &next_group.pre_assigns {
-                    self.emit_pipeline_sim_stmt(cpp, stmt, prefix, si, sn, sp, srn, pn, rn, ln, w, em, params, indent + 4);
+                    self.emit_pipeline_sim_stmt(
+                        cpp,
+                        stmt,
+                        prefix,
+                        si,
+                        sn,
+                        sp,
+                        srn,
+                        pn,
+                        rn,
+                        ln,
+                        w,
+                        em,
+                        params,
+                        indent + 4,
+                    );
                 }
                 cpp.push_str(&format!("{pad2}    _{prefix}_fsm_state = {};\n", state + 1));
             }
@@ -597,38 +1002,132 @@ impl<'a> SimCodegen<'a> {
     }
 
     fn emit_pipeline_sim_stmt(
-        &self, cpp: &mut String, stmt: &Stmt, prefix: &str, si: usize,
-        sn: &[String], sp: &[String], srn: &[HashSet<String>],
-        pn: &HashSet<String>, rn: &HashSet<String>, ln: &HashSet<String>,
-        w: &HashMap<String, u32>, em: &HashMap<String, Vec<(String, u64)>>, params: &[ParamDecl], indent: usize,
+        &self,
+        cpp: &mut String,
+        stmt: &Stmt,
+        prefix: &str,
+        si: usize,
+        sn: &[String],
+        sp: &[String],
+        srn: &[HashSet<String>],
+        pn: &HashSet<String>,
+        rn: &HashSet<String>,
+        ln: &HashSet<String>,
+        w: &HashMap<String, u32>,
+        em: &HashMap<String, Vec<(String, u64)>>,
+        params: &[ParamDecl],
+        indent: usize,
     ) {
         let pad = " ".repeat(indent);
         match stmt {
             Stmt::Assign(a) => {
                 let tgt = if let ExprKind::Ident(n) = &a.target.kind {
-                    if pn.contains(n) { n.clone() } else { format!("_{}_{}", prefix, n) }
-                } else { self.pipeline_sim_expr(&a.target, prefix, si, sn, sp, srn, pn, rn, ln, w, em, params) };
-                let val = self.pipeline_sim_expr(&a.value, prefix, si, sn, sp, srn, pn, rn, ln, w, em, params);
-                let tgt_key = if let ExprKind::Ident(n) = &a.target.kind { format!("{}_{}", prefix, n) } else { String::new() };
-                let mask = w.get(&tgt_key).and_then(|&b| if b > 0 && b < 64 { Some(format!(" & 0x{:X}ULL", (1u64 << b) - 1)) } else { None }).unwrap_or_default();
+                    if pn.contains(n) {
+                        n.clone()
+                    } else {
+                        format!("_{}_{}", prefix, n)
+                    }
+                } else {
+                    self.pipeline_sim_expr(
+                        &a.target, prefix, si, sn, sp, srn, pn, rn, ln, w, em, params,
+                    )
+                };
+                let val = self.pipeline_sim_expr(
+                    &a.value, prefix, si, sn, sp, srn, pn, rn, ln, w, em, params,
+                );
+                let tgt_key = if let ExprKind::Ident(n) = &a.target.kind {
+                    format!("{}_{}", prefix, n)
+                } else {
+                    String::new()
+                };
+                let mask = w
+                    .get(&tgt_key)
+                    .and_then(|&b| {
+                        if b > 0 && b < 64 {
+                            Some(format!(" & 0x{:X}ULL", (1u64 << b) - 1))
+                        } else {
+                            None
+                        }
+                    })
+                    .unwrap_or_default();
                 cpp.push_str(&format!("{pad}{tgt} = ({val}){mask};\n"));
             }
             Stmt::IfElse(ie) => {
-                let cond = self.pipeline_sim_expr(&ie.cond, prefix, si, sn, sp, srn, pn, rn, ln, w, em, params);
+                let cond = self.pipeline_sim_expr(
+                    &ie.cond, prefix, si, sn, sp, srn, pn, rn, ln, w, em, params,
+                );
                 cpp.push_str(&format!("{pad}if ({cond}) {{\n"));
-                for s in &ie.then_stmts { self.emit_pipeline_sim_stmt(cpp, s, prefix, si, sn, sp, srn, pn, rn, ln, w, em, params, indent+2); }
+                for s in &ie.then_stmts {
+                    self.emit_pipeline_sim_stmt(
+                        cpp,
+                        s,
+                        prefix,
+                        si,
+                        sn,
+                        sp,
+                        srn,
+                        pn,
+                        rn,
+                        ln,
+                        w,
+                        em,
+                        params,
+                        indent + 2,
+                    );
+                }
                 if !ie.else_stmts.is_empty() {
                     cpp.push_str(&format!("{pad}}} else {{\n"));
-                    for s in &ie.else_stmts { self.emit_pipeline_sim_stmt(cpp, s, prefix, si, sn, sp, srn, pn, rn, ln, w, em, params, indent+2); }
+                    for s in &ie.else_stmts {
+                        self.emit_pipeline_sim_stmt(
+                            cpp,
+                            s,
+                            prefix,
+                            si,
+                            sn,
+                            sp,
+                            srn,
+                            pn,
+                            rn,
+                            ln,
+                            w,
+                            em,
+                            params,
+                            indent + 2,
+                        );
+                    }
                 }
                 cpp.push_str(&format!("{pad}}}\n"));
             }
             Stmt::For(f) => {
                 if let ForRange::Range(ref lo_expr, ref hi_expr) = f.range {
-                    let lo = self.pipeline_sim_expr(lo_expr, prefix, si, sn, sp, srn, pn, rn, ln, w, em, params);
-                    let hi = self.pipeline_sim_expr(hi_expr, prefix, si, sn, sp, srn, pn, rn, ln, w, em, params);
-                    cpp.push_str(&format!("{pad}for (int {v} = {lo}; {v} <= {hi}; {v}++) {{\n", v=f.var.name));
-                    for s in &f.body { self.emit_pipeline_sim_stmt(cpp, s, prefix, si, sn, sp, srn, pn, rn, ln, w, em, params, indent+2); }
+                    let lo = self.pipeline_sim_expr(
+                        lo_expr, prefix, si, sn, sp, srn, pn, rn, ln, w, em, params,
+                    );
+                    let hi = self.pipeline_sim_expr(
+                        hi_expr, prefix, si, sn, sp, srn, pn, rn, ln, w, em, params,
+                    );
+                    cpp.push_str(&format!(
+                        "{pad}for (int {v} = {lo}; {v} <= {hi}; {v}++) {{\n",
+                        v = f.var.name
+                    ));
+                    for s in &f.body {
+                        self.emit_pipeline_sim_stmt(
+                            cpp,
+                            s,
+                            prefix,
+                            si,
+                            sn,
+                            sp,
+                            srn,
+                            pn,
+                            rn,
+                            ln,
+                            w,
+                            em,
+                            params,
+                            indent + 2,
+                        );
+                    }
                     cpp.push_str(&format!("{pad}}}\n"));
                 }
             }
@@ -637,27 +1136,84 @@ impl<'a> SimCodegen<'a> {
     }
 
     fn emit_pipeline_sim_comb_stmt(
-        &self, cpp: &mut String, stmt: &Stmt, prefix: &str, si: usize,
-        sn: &[String], sp: &[String], srn: &[HashSet<String>],
-        pn: &HashSet<String>, rn: &HashSet<String>, ln: &HashSet<String>,
-        w: &HashMap<String, u32>, em: &HashMap<String, Vec<(String, u64)>>, params: &[ParamDecl], indent: usize,
+        &self,
+        cpp: &mut String,
+        stmt: &Stmt,
+        prefix: &str,
+        si: usize,
+        sn: &[String],
+        sp: &[String],
+        srn: &[HashSet<String>],
+        pn: &HashSet<String>,
+        rn: &HashSet<String>,
+        ln: &HashSet<String>,
+        w: &HashMap<String, u32>,
+        em: &HashMap<String, Vec<(String, u64)>>,
+        params: &[ParamDecl],
+        indent: usize,
     ) {
         let pad = " ".repeat(indent);
         match stmt {
             Stmt::Assign(a) => {
                 let tgt = if let ExprKind::Ident(n) = &a.target.kind {
-                    if pn.contains(n) { n.clone() } else { format!("{}_{}", prefix, n) }
-                } else { self.pipeline_sim_expr(&a.target, prefix, si, sn, sp, srn, pn, rn, ln, w, em, params) };
-                let val = self.pipeline_sim_expr(&a.value, prefix, si, sn, sp, srn, pn, rn, ln, w, em, params);
+                    if pn.contains(n) {
+                        n.clone()
+                    } else {
+                        format!("{}_{}", prefix, n)
+                    }
+                } else {
+                    self.pipeline_sim_expr(
+                        &a.target, prefix, si, sn, sp, srn, pn, rn, ln, w, em, params,
+                    )
+                };
+                let val = self.pipeline_sim_expr(
+                    &a.value, prefix, si, sn, sp, srn, pn, rn, ln, w, em, params,
+                );
                 cpp.push_str(&format!("{pad}{tgt} = {val};\n"));
             }
             Stmt::IfElse(ie) => {
-                let cond = self.pipeline_sim_expr(&ie.cond, prefix, si, sn, sp, srn, pn, rn, ln, w, em, params);
+                let cond = self.pipeline_sim_expr(
+                    &ie.cond, prefix, si, sn, sp, srn, pn, rn, ln, w, em, params,
+                );
                 cpp.push_str(&format!("{pad}if ({cond}) {{\n"));
-                for s in &ie.then_stmts { self.emit_pipeline_sim_comb_stmt(cpp, s, prefix, si, sn, sp, srn, pn, rn, ln, w, em, params, indent+2); }
+                for s in &ie.then_stmts {
+                    self.emit_pipeline_sim_comb_stmt(
+                        cpp,
+                        s,
+                        prefix,
+                        si,
+                        sn,
+                        sp,
+                        srn,
+                        pn,
+                        rn,
+                        ln,
+                        w,
+                        em,
+                        params,
+                        indent + 2,
+                    );
+                }
                 if !ie.else_stmts.is_empty() {
                     cpp.push_str(&format!("{pad}}} else {{\n"));
-                    for s in &ie.else_stmts { self.emit_pipeline_sim_comb_stmt(cpp, s, prefix, si, sn, sp, srn, pn, rn, ln, w, em, params, indent+2); }
+                    for s in &ie.else_stmts {
+                        self.emit_pipeline_sim_comb_stmt(
+                            cpp,
+                            s,
+                            prefix,
+                            si,
+                            sn,
+                            sp,
+                            srn,
+                            pn,
+                            rn,
+                            ln,
+                            w,
+                            em,
+                            params,
+                            indent + 2,
+                        );
+                    }
                 }
                 cpp.push_str(&format!("{pad}}}\n"));
             }
@@ -666,89 +1222,182 @@ impl<'a> SimCodegen<'a> {
     }
 
     fn pipeline_sim_expr(
-        &self, expr: &Expr, prefix: &str, si: usize,
-        sn: &[String], sp: &[String], srn: &[HashSet<String>],
-        pn: &HashSet<String>, rn: &HashSet<String>, ln: &HashSet<String>,
-        w: &HashMap<String, u32>, em: &HashMap<String, Vec<(String, u64)>>, params: &[ParamDecl],
+        &self,
+        expr: &Expr,
+        prefix: &str,
+        si: usize,
+        sn: &[String],
+        sp: &[String],
+        srn: &[HashSet<String>],
+        pn: &HashSet<String>,
+        rn: &HashSet<String>,
+        ln: &HashSet<String>,
+        w: &HashMap<String, u32>,
+        em: &HashMap<String, Vec<(String, u64)>>,
+        params: &[ParamDecl],
     ) -> String {
         let empty = HashSet::new();
         let empty_rl: HashMap<String, ResetLevel> = HashMap::new();
         let empty_fn: HashMap<String, FpFmt> = HashMap::new();
-        let ctx = Ctx { reg_names: rn, port_names: pn, let_names: ln, let_values: None, inst_names: &empty, wide_names: &empty, widths: w, signed_names: &empty, float_names: &empty_fn, posedge_lhs: false, fsm_mode: false, enum_map: em, bus_ports: &empty, reset_levels: &empty_rl, vec_names: None, vec_2d_names: None, vec_sizes: None, fsm_vec_port_regs: None, ident_subst: None, loop_var_subst: None, vec_of_bus_port_count: None, vec_of_bus_wire_count: None, coverage: None, params };
+        let ctx = Ctx {
+            reg_names: rn,
+            port_names: pn,
+            let_names: ln,
+            let_values: None,
+            inst_names: &empty,
+            wide_names: &empty,
+            widths: w,
+            signed_names: &empty,
+            float_names: &empty_fn,
+            posedge_lhs: false,
+            fsm_mode: false,
+            enum_map: em,
+            bus_ports: &empty,
+            reset_levels: &empty_rl,
+            vec_names: None,
+            vec_2d_names: None,
+            vec_sizes: None,
+            fsm_vec_port_regs: None,
+            ident_subst: None,
+            loop_var_subst: None,
+            vec_of_bus_port_count: None,
+            vec_of_bus_wire_count: None,
+            coverage: None,
+            params,
+        };
         match &expr.kind {
             ExprKind::FieldAccess(base, field) => {
                 if let ExprKind::Ident(bn) = &base.kind {
                     if let Some(idx) = sn.iter().position(|s| s == bn) {
                         let p = &sp[idx];
                         let prefixed = format!("{}_{}", p, field.name);
-                        if rn.contains(&prefixed) { return format!("_{}", prefixed); }
-                        if ln.contains(&prefixed) { return prefixed; }
-                        if field.name == "valid_r" { return format!("_{}_valid_r", p); }
+                        if rn.contains(&prefixed) {
+                            return format!("_{}", prefixed);
+                        }
+                        if ln.contains(&prefixed) {
+                            return prefixed;
+                        }
+                        if field.name == "valid_r" {
+                            return format!("_{}_valid_r", p);
+                        }
                         return format!("_{}", prefixed);
                     }
                 }
                 cpp_expr(expr, &ctx)
             }
             ExprKind::Ident(name) => {
-                if pn.contains(name) { return name.clone(); }
-                if name == "valid_r" && !prefix.is_empty() { return format!("_{}_valid_r", prefix); }
+                if pn.contains(name) {
+                    return name.clone();
+                }
+                if name == "valid_r" && !prefix.is_empty() {
+                    return format!("_{}_valid_r", prefix);
+                }
                 if si < srn.len() && srn[si].contains(name) {
                     let prefixed = format!("{}_{}", prefix, name);
-                    if rn.contains(&prefixed) { return format!("_{}", prefixed); }
-                    if ln.contains(&prefixed) { return prefixed; }
+                    if rn.contains(&prefixed) {
+                        return format!("_{}", prefixed);
+                    }
+                    if ln.contains(&prefixed) {
+                        return prefixed;
+                    }
                 }
                 cpp_expr(expr, &ctx)
             }
             ExprKind::Concat(parts) => {
                 let mut total_bits: u32 = 0;
-                let part_widths: Vec<u32> = parts.iter().map(|p2| {
-                    let pw = self.pipeline_sim_expr_width(p2, prefix, si, srn, w, pn, params);
-                    total_bits += pw;
-                    pw
-                }).collect();
+                let part_widths: Vec<u32> = parts
+                    .iter()
+                    .map(|p2| {
+                        let pw = self.pipeline_sim_expr_width(p2, prefix, si, srn, w, pn, params);
+                        total_bits += pw;
+                        pw
+                    })
+                    .collect();
                 let _ = total_bits; // used implicitly
                 let mut result = String::from("(");
                 let mut bit_pos: u32 = part_widths.iter().sum();
                 for (i, part) in parts.iter().enumerate() {
                     bit_pos -= part_widths[i];
-                    let val = self.pipeline_sim_expr(part, prefix, si, sn, sp, srn, pn, rn, ln, w, em, params);
-                    if i > 0 { result.push_str(" | "); }
-                    if bit_pos > 0 { result.push_str(&format!("((uint64_t)({val}) << {bit_pos})")); }
-                    else { result.push_str(&format!("(uint64_t)({val})")); }
+                    let val = self.pipeline_sim_expr(
+                        part, prefix, si, sn, sp, srn, pn, rn, ln, w, em, params,
+                    );
+                    if i > 0 {
+                        result.push_str(" | ");
+                    }
+                    if bit_pos > 0 {
+                        result.push_str(&format!("((uint64_t)({val}) << {bit_pos})"));
+                    } else {
+                        result.push_str(&format!("(uint64_t)({val})"));
+                    }
                 }
                 result.push(')');
                 result
             }
             ExprKind::Binary(op, lhs, rhs) => {
-                let l = self.pipeline_sim_expr(lhs, prefix, si, sn, sp, srn, pn, rn, ln, w, em, params);
-                let r = self.pipeline_sim_expr(rhs, prefix, si, sn, sp, srn, pn, rn, ln, w, em, params);
+                let l =
+                    self.pipeline_sim_expr(lhs, prefix, si, sn, sp, srn, pn, rn, ln, w, em, params);
+                let r =
+                    self.pipeline_sim_expr(rhs, prefix, si, sn, sp, srn, pn, rn, ln, w, em, params);
                 if matches!(*op, BinOp::Implies | BinOp::ImpliesNext) {
                     return format!("(!{l} || {r})");
                 }
                 let os = match op {
-                    BinOp::Add | BinOp::AddWrap => "+", BinOp::Sub | BinOp::SubWrap => "-",
-                    BinOp::Mul | BinOp::MulWrap => "*", BinOp::Div => "/", BinOp::Mod => "%",
-                    BinOp::Eq => "==", BinOp::Neq => "!=", BinOp::Lt => "<", BinOp::Gt => ">",
-                    BinOp::Lte => "<=", BinOp::Gte => ">=", BinOp::And => "&&", BinOp::Or => "||",
-                    BinOp::BitAnd => "&", BinOp::BitOr => "|", BinOp::BitXor => "^", BinOp::Shl => "<<", BinOp::Shr => ">>",
+                    BinOp::Add | BinOp::AddWrap => "+",
+                    BinOp::Sub | BinOp::SubWrap => "-",
+                    BinOp::Mul | BinOp::MulWrap => "*",
+                    BinOp::Div => "/",
+                    BinOp::Mod => "%",
+                    BinOp::Eq => "==",
+                    BinOp::Neq => "!=",
+                    BinOp::Lt => "<",
+                    BinOp::Gt => ">",
+                    BinOp::Lte => "<=",
+                    BinOp::Gte => ">=",
+                    BinOp::And => "&&",
+                    BinOp::Or => "||",
+                    BinOp::BitAnd => "&",
+                    BinOp::BitOr => "|",
+                    BinOp::BitXor => "^",
+                    BinOp::Shl => "<<",
+                    BinOp::Shr => ">>",
                     BinOp::Implies | BinOp::ImpliesNext => unreachable!(),
                 };
                 format!("({l} {os} {r})")
             }
             ExprKind::Unary(op, inner) => {
-                let v = self.pipeline_sim_expr(inner, prefix, si, sn, sp, srn, pn, rn, ln, w, em, params);
-                match op { UnaryOp::Not => format!("(!{v})"), UnaryOp::BitNot => format!("(~{v})"), UnaryOp::Neg => format!("(-{v})"),
-                    UnaryOp::RedAnd | UnaryOp::RedOr | UnaryOp::RedXor => format!("({v})") }
+                let v = self
+                    .pipeline_sim_expr(inner, prefix, si, sn, sp, srn, pn, rn, ln, w, em, params);
+                match op {
+                    UnaryOp::Not => format!("(!{v})"),
+                    UnaryOp::BitNot => format!("(~{v})"),
+                    UnaryOp::Neg => format!("(-{v})"),
+                    UnaryOp::RedAnd | UnaryOp::RedOr | UnaryOp::RedXor => format!("({v})"),
+                }
             }
             ExprKind::MethodCall(base, method, args) => {
-                let b = self.pipeline_sim_expr(base, prefix, si, sn, sp, srn, pn, rn, ln, w, em, params);
+                let b = self
+                    .pipeline_sim_expr(base, prefix, si, sn, sp, srn, pn, rn, ln, w, em, params);
                 match method.name.as_str() {
-                    "trunc" => { if let Some(wa) = args.first() { let bits = eval_const_expr_with_params(wa, params); if bits < 64 { format!("({b} & 0x{:X}ULL)", (1u64 << bits) - 1) } else { b } } else { b } }
-                    "zext" => { format!("(uint64_t)({b})") }
+                    "trunc" => {
+                        if let Some(wa) = args.first() {
+                            let bits = eval_const_expr_with_params(wa, params);
+                            if bits < 64 {
+                                format!("({b} & 0x{:X}ULL)", (1u64 << bits) - 1)
+                            } else {
+                                b
+                            }
+                        } else {
+                            b
+                        }
+                    }
+                    "zext" => {
+                        format!("(uint64_t)({b})")
+                    }
                     "sext" => {
                         if let Some(width) = args.first() {
                             let dst_bits = eval_const_expr_with_params(width, params) as u32;
-                            let src_bits = self.pipeline_sim_expr_width(base, prefix, si, srn, w, pn, params);
+                            let src_bits =
+                                self.pipeline_sim_expr_width(base, prefix, si, srn, w, pn, params);
                             if src_bits >= dst_bits || src_bits == 0 {
                                 format!("({})({b})", cpp_uint(dst_bits))
                             } else {
@@ -762,47 +1411,104 @@ impl<'a> SimCodegen<'a> {
                             b
                         }
                     }
-                    _ => b
+                    _ => b,
                 }
             }
             ExprKind::BitSlice(base, hi, lo) => {
-                let b = self.pipeline_sim_expr(base, prefix, si, sn, sp, srn, pn, rn, ln, w, em, params);
-                let hv = eval_const_expr_with_params(hi, params); let lv = eval_const_expr_with_params(lo, params); let width = hv - lv + 1;
-                if width < 64 { format!("(({b} >> {lv}) & 0x{:X}ULL)", (1u64 << width) - 1) } else { format!("({b} >> {lv})") }
+                let b = self
+                    .pipeline_sim_expr(base, prefix, si, sn, sp, srn, pn, rn, ln, w, em, params);
+                let hv = eval_const_expr_with_params(hi, params);
+                let lv = eval_const_expr_with_params(lo, params);
+                let width = hv - lv + 1;
+                if width < 64 {
+                    format!("(({b} >> {lv}) & 0x{:X}ULL)", (1u64 << width) - 1)
+                } else {
+                    format!("({b} >> {lv})")
+                }
             }
             ExprKind::Index(base, idx) => {
-                let b = self.pipeline_sim_expr(base, prefix, si, sn, sp, srn, pn, rn, ln, w, em, params);
-                let i = self.pipeline_sim_expr(idx, prefix, si, sn, sp, srn, pn, rn, ln, w, em, params);
+                let b = self
+                    .pipeline_sim_expr(base, prefix, si, sn, sp, srn, pn, rn, ln, w, em, params);
+                let i =
+                    self.pipeline_sim_expr(idx, prefix, si, sn, sp, srn, pn, rn, ln, w, em, params);
                 format!("(({b} >> {i}) & 1)")
             }
-            ExprKind::Literal(lit) => match lit { LitKind::Dec(v) => format!("{v}"), LitKind::Hex(v) | LitKind::Bin(v) => format!("0x{v:X}"), LitKind::Sized(_, v) => format!("{v}"), LitKind::Float(bits) => format!("0x{:X}u", (f64::from_bits(*bits) as f32).to_bits()) },
-            ExprKind::Bool(b) => if *b { "1".to_string() } else { "0".to_string() },
+            ExprKind::Literal(lit) => match lit {
+                LitKind::Dec(v) => format!("{v}"),
+                LitKind::Hex(v) | LitKind::Bin(v) => format!("0x{v:X}"),
+                LitKind::Sized(_, v) => format!("{v}"),
+                LitKind::Float(bits) => {
+                    format!("0x{:X}u", (f64::from_bits(*bits) as f32).to_bits())
+                }
+            },
+            ExprKind::Bool(b) => {
+                if *b {
+                    "1".to_string()
+                } else {
+                    "0".to_string()
+                }
+            }
             ExprKind::Ternary(c, t, e) => {
-                let cv = self.pipeline_sim_expr(c, prefix, si, sn, sp, srn, pn, rn, ln, w, em, params);
-                let tv = self.pipeline_sim_expr(t, prefix, si, sn, sp, srn, pn, rn, ln, w, em, params);
-                let ev = self.pipeline_sim_expr(e, prefix, si, sn, sp, srn, pn, rn, ln, w, em, params);
+                let cv =
+                    self.pipeline_sim_expr(c, prefix, si, sn, sp, srn, pn, rn, ln, w, em, params);
+                let tv =
+                    self.pipeline_sim_expr(t, prefix, si, sn, sp, srn, pn, rn, ln, w, em, params);
+                let ev =
+                    self.pipeline_sim_expr(e, prefix, si, sn, sp, srn, pn, rn, ln, w, em, params);
                 format!("(({cv}) ? ({tv}) : ({ev}))")
             }
             ExprKind::Signed(inner) | ExprKind::Unsigned(inner) | ExprKind::Cast(inner, _) => {
                 self.pipeline_sim_expr(inner, prefix, si, sn, sp, srn, pn, rn, ln, w, em, params)
             }
-            ExprKind::Clog2(arg) => { let a = self.pipeline_sim_expr(arg, prefix, si, sn, sp, srn, pn, rn, ln, w, em, params); format!("_arch_clog2({a})") }
+            ExprKind::Clog2(arg) => {
+                let a =
+                    self.pipeline_sim_expr(arg, prefix, si, sn, sp, srn, pn, rn, ln, w, em, params);
+                format!("_arch_clog2({a})")
+            }
             _ => cpp_expr(expr, &ctx),
         }
     }
 
-    fn pipeline_sim_expr_width(&self, expr: &Expr, prefix: &str, si: usize, srn: &[HashSet<String>], w: &HashMap<String, u32>, pn: &HashSet<String>, params: &[ParamDecl]) -> u32 {
+    fn pipeline_sim_expr_width(
+        &self,
+        expr: &Expr,
+        prefix: &str,
+        si: usize,
+        srn: &[HashSet<String>],
+        w: &HashMap<String, u32>,
+        pn: &HashSet<String>,
+        params: &[ParamDecl],
+    ) -> u32 {
         match &expr.kind {
             ExprKind::Ident(name) => {
-                if pn.contains(name) { return *w.get(name).unwrap_or(&8); }
-                if si < srn.len() && srn[si].contains(name) { return *w.get(&format!("{}_{}", prefix, name)).unwrap_or(&8); }
+                if pn.contains(name) {
+                    return *w.get(name).unwrap_or(&8);
+                }
+                if si < srn.len() && srn[si].contains(name) {
+                    return *w.get(&format!("{}_{}", prefix, name)).unwrap_or(&8);
+                }
                 *w.get(name).unwrap_or(&8)
             }
             ExprKind::FieldAccess(base, field) => {
-                if let ExprKind::Ident(bn) = &base.kind { *w.get(&format!("{}_{}", bn.to_lowercase(), field.name)).unwrap_or(&8) } else { 8 }
+                if let ExprKind::Ident(bn) = &base.kind {
+                    *w.get(&format!("{}_{}", bn.to_lowercase(), field.name))
+                        .unwrap_or(&8)
+                } else {
+                    8
+                }
             }
-            ExprKind::MethodCall(_, method, args) => match method.name.as_str() { "trunc"|"zext"|"sext"|"resize" => args.first().map(|a| eval_const_expr_with_params(a, params) as u32).unwrap_or(8), _ => 8 },
-            ExprKind::BitSlice(_, hi, lo) => { let h = eval_const_expr_with_params(hi, params); let l = eval_const_expr_with_params(lo, params); (h - l + 1) as u32 }
+            ExprKind::MethodCall(_, method, args) => match method.name.as_str() {
+                "trunc" | "zext" | "sext" | "resize" => args
+                    .first()
+                    .map(|a| eval_const_expr_with_params(a, params) as u32)
+                    .unwrap_or(8),
+                _ => 8,
+            },
+            ExprKind::BitSlice(_, hi, lo) => {
+                let h = eval_const_expr_with_params(hi, params);
+                let l = eval_const_expr_with_params(lo, params);
+                (h - l + 1) as u32
+            }
             ExprKind::Literal(LitKind::Sized(ww, _)) => *ww,
             _ => 8,
         }
@@ -810,14 +1516,12 @@ impl<'a> SimCodegen<'a> {
 
     fn pipeline_reset_value(reset: &RegReset) -> Option<String> {
         match reset {
-            RegReset::Explicit(_, _, _, val) | RegReset::Inherit(_, val) => {
-                match &val.kind {
-                    ExprKind::Literal(LitKind::Dec(v)) => Some(format!("{v}")),
-                    ExprKind::Literal(LitKind::Hex(v)) => Some(format!("0x{v:X}")),
-                    ExprKind::Bool(b) => Some(if *b { "1".to_string() } else { "0".to_string() }),
-                    _ => Some("0".to_string()),
-                }
-            }
+            RegReset::Explicit(_, _, _, val) | RegReset::Inherit(_, val) => match &val.kind {
+                ExprKind::Literal(LitKind::Dec(v)) => Some(format!("{v}")),
+                ExprKind::Literal(LitKind::Hex(v)) => Some(format!("0x{v:X}")),
+                ExprKind::Bool(b) => Some(if *b { "1".to_string() } else { "0".to_string() }),
+                _ => Some("0".to_string()),
+            },
             _ => Some("0".to_string()),
         }
     }

--- a/src/sim_codegen/ram.rs
+++ b/src/sim_codegen/ram.rs
@@ -5,8 +5,8 @@
 
 use std::collections::HashMap;
 
-use super::{SimCodegen, SimModel};
 use super::*;
+use super::{SimCodegen, SimModel};
 
 impl<'a> SimCodegen<'a> {
     pub(crate) fn gen_ram(&self, r: &RamDecl) -> SimModel {
@@ -14,7 +14,9 @@ impl<'a> SimCodegen<'a> {
         let class = format!("V{name}");
 
         // Extract DEPTH param
-        let depth: u64 = r.params.iter()
+        let depth: u64 = r
+            .params
+            .iter()
             .find(|p| p.name.name == "DEPTH")
             .and_then(|p| p.default.as_ref())
             .map(|e| match &e.kind {
@@ -25,7 +27,9 @@ impl<'a> SimCodegen<'a> {
 
         // Build type-param map: param name → resolved TypeExpr
         // e.g. `param T: type = UInt<54>` → "T" → UInt<54>
-        let type_params: HashMap<String, &TypeExpr> = r.params.iter()
+        let type_params: HashMap<String, &TypeExpr> = r
+            .params
+            .iter()
             .filter_map(|p| {
                 if let ParamKind::Type(ty) = &p.kind {
                     Some((p.name.name.clone(), ty))
@@ -45,20 +49,33 @@ impl<'a> SimCodegen<'a> {
         };
 
         // Extract data width from output port signal type
-        let data_bits: u32 = r.port_groups.iter()
+        let data_bits: u32 = r
+            .port_groups
+            .iter()
             .flat_map(|pg| pg.signals.iter())
             .find(|s| s.direction == Direction::Out)
             .map(|s| resolve_sig_bits(&s.ty))
             .unwrap_or(32);
 
-        let elem_ty = if data_bits > 128 { format!("VlWide<{}>", wide_words(data_bits)) }
-                      else if data_bits > 64 { "_arch_u128".to_string() }
-                      else { cpp_uint(data_bits).to_string() };
-        let port_elem_ty = if data_bits > 64 { format!("VlWide<{}>", wide_words(data_bits)) } else { cpp_uint(data_bits).to_string() };
+        let elem_ty = if data_bits > 128 {
+            format!("VlWide<{}>", wide_words(data_bits))
+        } else if data_bits > 64 {
+            "_arch_u128".to_string()
+        } else {
+            cpp_uint(data_bits).to_string()
+        };
+        let port_elem_ty = if data_bits > 64 {
+            format!("VlWide<{}>", wide_words(data_bits))
+        } else {
+            cpp_uint(data_bits).to_string()
+        };
         let is_wide = data_bits > 64;
 
         // Flatten port groups into (full_name, direction)
-        struct FlatSig { full_name: String, dir: Direction }
+        struct FlatSig {
+            full_name: String,
+            dir: Direction,
+        }
         let mut flat_sigs: Vec<FlatSig> = Vec::new();
         for pg in &r.port_groups {
             for sig in &pg.signals {
@@ -68,7 +85,10 @@ impl<'a> SimCodegen<'a> {
                 });
             }
         }
-        let out_sigs: Vec<&FlatSig> = flat_sigs.iter().filter(|s| s.dir == Direction::Out).collect();
+        let out_sigs: Vec<&FlatSig> = flat_sigs
+            .iter()
+            .filter(|s| s.dir == Direction::Out)
+            .collect();
 
         // ── Header ──
         let mut h = String::new();
@@ -80,15 +100,25 @@ impl<'a> SimCodegen<'a> {
             let ty_str: String = if fs.dir == Direction::Out {
                 port_elem_ty.clone()
             } else {
-                let orig_ty = r.port_groups.iter()
-                    .flat_map(|pg| pg.signals.iter().map(move |s| (format!("{}_{}", pg.name.name, s.name.name), &s.ty)))
+                let orig_ty = r
+                    .port_groups
+                    .iter()
+                    .flat_map(|pg| {
+                        pg.signals
+                            .iter()
+                            .map(move |s| (format!("{}_{}", pg.name.name, s.name.name), &s.ty))
+                    })
                     .find(|(n, _)| *n == fs.full_name)
                     .map(|(_, ty)| ty);
                 match orig_ty {
                     Some(TypeExpr::Bool) => "uint8_t".to_string(),
                     Some(ty) => {
                         let b = resolve_sig_bits(ty);
-                        if b > 64 { port_elem_ty.clone() } else { cpp_uint(b).to_string() }
+                        if b > 64 {
+                            port_elem_ty.clone()
+                        } else {
+                            cpp_uint(b).to_string()
+                        }
                     }
                     None => "uint32_t".to_string(),
                 }
@@ -99,7 +129,8 @@ impl<'a> SimCodegen<'a> {
         h.push('\n');
         h.push_str(&format!("  {class}() : clk(0)"));
         for fs in &flat_sigs {
-            if is_wide && fs.dir == Direction::Out { /* VlWide memset below */ } else {
+            if is_wide && fs.dir == Direction::Out { /* VlWide memset below */
+            } else {
                 h.push_str(&format!(", {}(0)", fs.full_name));
             }
         }
@@ -135,8 +166,12 @@ impl<'a> SimCodegen<'a> {
                 h.push_str(&format!("{depth}"));
                 h.push_str(") {\n");
                 match format {
-                    FileFormat::Hex => h.push_str("          _mem[_i] = strtoull(_line, NULL, 16);\n"),
-                    FileFormat::Bin => h.push_str("          _mem[_i] = strtoull(_line, NULL, 2);\n"),
+                    FileFormat::Hex => {
+                        h.push_str("          _mem[_i] = strtoull(_line, NULL, 16);\n")
+                    }
+                    FileFormat::Bin => {
+                        h.push_str("          _mem[_i] = strtoull(_line, NULL, 2);\n")
+                    }
                 }
                 if uninit_ram_check {
                     h.push_str("          _mem_valid[_i] = true;\n");
@@ -156,14 +191,23 @@ impl<'a> SimCodegen<'a> {
         }
         for fs in &out_sigs {
             if is_wide {
-                h.push_str(&format!("    memset(&{}, 0, sizeof({}));\n", fs.full_name, fs.full_name));
+                h.push_str(&format!(
+                    "    memset(&{}, 0, sizeof({}));\n",
+                    fs.full_name, fs.full_name
+                ));
             }
         }
         for fs in &out_sigs {
             if is_wide {
-                h.push_str(&format!("    memset(&_r_{}, 0, sizeof(_r_{}));\n", fs.full_name, fs.full_name));
+                h.push_str(&format!(
+                    "    memset(&_r_{}, 0, sizeof(_r_{}));\n",
+                    fs.full_name, fs.full_name
+                ));
                 if r.latency == 2 {
-                    h.push_str(&format!("    memset(&_r2_{}, 0, sizeof(_r2_{}));\n", fs.full_name, fs.full_name));
+                    h.push_str(&format!(
+                        "    memset(&_r2_{}, 0, sizeof(_r2_{}));\n",
+                        fs.full_name, fs.full_name
+                    ));
                 }
             } else {
                 h.push_str(&format!("    _r_{} = 0;\n", fs.full_name));
@@ -173,7 +217,9 @@ impl<'a> SimCodegen<'a> {
             }
         }
         h.push_str("  }\n");
-        h.push_str(&format!("  explicit {class}(VerilatedContext*) : {class}() {{}}\n"));
+        h.push_str(&format!(
+            "  explicit {class}(VerilatedContext*) : {class}() {{}}\n"
+        ));
         h.push_str("  void eval();\n  void eval_posedge();\n  void eval_comb();\n  void final() { trace_close(); }\n");
         h.push_str("private:\n");
         h.push_str("  uint8_t _clk_prev;\n");
@@ -195,13 +241,23 @@ impl<'a> SimCodegen<'a> {
         // --check-uninit-ram: helpers to mark writes valid and warn on uninit reads.
         // Read check uses a static guard so each RAM warns at most once per run.
         let write_mark = |addr: &str| -> String {
-            if uninit_ram_check { format!("    _mem_valid[{addr}] = true;\n") } else { String::new() }
+            if uninit_ram_check {
+                format!("    _mem_valid[{addr}] = true;\n")
+            } else {
+                String::new()
+            }
         };
         let write_mark_indented = |addr: &str, indent: &str| -> String {
-            if uninit_ram_check { format!("{indent}_mem_valid[{addr}] = true;\n") } else { String::new() }
+            if uninit_ram_check {
+                format!("{indent}_mem_valid[{addr}] = true;\n")
+            } else {
+                String::new()
+            }
         };
         let read_check = |addr: &str, indent: &str| -> String {
-            if !uninit_ram_check { return String::new(); }
+            if !uninit_ram_check {
+                return String::new();
+            }
             format!(
                 "{indent}if (!_mem_valid[{addr}]) {{ static bool _w = false; if (!_w) {{ fprintf(stderr, \"WARNING: read of uninitialized RAM cell '{name}[%d]' (no prior write, no init)\\n\", (int)({addr})); _w = true; }} }}\n"
             )
@@ -224,17 +280,31 @@ impl<'a> SimCodegen<'a> {
                 let pg = &r.port_groups[0];
                 let pfx = &pg.name.name;
                 let has_wen = pg.signals.iter().any(|s| s.name.name == "wen");
-                let wdata_name = pg.signals.iter()
-                    .find(|s| s.direction == Direction::In && (s.name.name == "wdata" || s.name.name == "data"))
+                let wdata_name = pg
+                    .signals
+                    .iter()
+                    .find(|s| {
+                        s.direction == Direction::In
+                            && (s.name.name == "wdata" || s.name.name == "data")
+                    })
                     .map(|s| format!("{pfx}_{}", s.name.name))
                     .unwrap_or_else(|| format!("{pfx}_wdata"));
-                let out_name = out_sigs.first().map(|s| s.full_name.as_str()).unwrap_or("rdata");
+                let out_name = out_sigs
+                    .first()
+                    .map(|s| s.full_name.as_str())
+                    .unwrap_or("rdata");
                 let addr_expr = format!("{pfx}_addr");
 
                 cpp.push_str(&format!("  if ({pfx}_en) {{\n"));
                 if has_wen {
-                    cpp.push_str(&format!("    if ({pfx}_wen) {{ _mem[{pfx}_addr] = {wdata_name};{mark} }}\n",
-                        mark = if uninit_ram_check { format!(" _mem_valid[{pfx}_addr] = true;") } else { String::new() }));
+                    cpp.push_str(&format!(
+                        "    if ({pfx}_wen) {{ _mem[{pfx}_addr] = {wdata_name};{mark} }}\n",
+                        mark = if uninit_ram_check {
+                            format!(" _mem_valid[{pfx}_addr] = true;")
+                        } else {
+                            String::new()
+                        }
+                    ));
                     match r.latency {
                         1 | 2 => {
                             cpp.push_str(&format!("    if (!{pfx}_wen) {{\n"));
@@ -254,27 +324,46 @@ impl<'a> SimCodegen<'a> {
                 }
             }
             RamKind::SimpleDual => {
-                let wr_pg = r.port_groups.iter().find(|pg|
-                    pg.signals.iter().any(|s| s.direction == Direction::In && (s.name.name == "data" || s.name.name == "wdata"))
-                ).unwrap_or(&r.port_groups[1]);
-                let rd_pg = r.port_groups.iter().find(|pg|
-                    pg.signals.iter().any(|s| s.direction == Direction::Out)
-                ).unwrap_or(&r.port_groups[0]);
+                let wr_pg = r
+                    .port_groups
+                    .iter()
+                    .find(|pg| {
+                        pg.signals.iter().any(|s| {
+                            s.direction == Direction::In
+                                && (s.name.name == "data" || s.name.name == "wdata")
+                        })
+                    })
+                    .unwrap_or(&r.port_groups[1]);
+                let rd_pg = r
+                    .port_groups
+                    .iter()
+                    .find(|pg| pg.signals.iter().any(|s| s.direction == Direction::Out))
+                    .unwrap_or(&r.port_groups[0]);
 
                 let wpfx = &wr_pg.name.name;
                 let rpfx = &rd_pg.name.name;
-                let w_data_name = wr_pg.signals.iter()
-                    .find(|s| s.direction == Direction::In && (s.name.name == "data" || s.name.name == "wdata"))
+                let w_data_name = wr_pg
+                    .signals
+                    .iter()
+                    .find(|s| {
+                        s.direction == Direction::In
+                            && (s.name.name == "data" || s.name.name == "wdata")
+                    })
                     .map(|s| format!("{wpfx}_{}", s.name.name))
                     .unwrap_or_else(|| format!("{wpfx}_data"));
-                let out_name = out_sigs.first().map(|s| s.full_name.as_str()).unwrap_or("rd_port_data");
+                let out_name = out_sigs
+                    .first()
+                    .map(|s| s.full_name.as_str())
+                    .unwrap_or("rd_port_data");
                 let wr_addr = format!("{wpfx}_addr");
                 let rd_addr = format!("{rpfx}_addr");
 
                 // Write path
                 cpp.push_str(&format!("  if ({wpfx}_en) {{\n"));
                 if is_wide {
-                    cpp.push_str(&format!("    memcpy(&_mem[{wpfx}_addr], &{w_data_name}, sizeof({elem_ty}));\n"));
+                    cpp.push_str(&format!(
+                        "    memcpy(&_mem[{wpfx}_addr], &{w_data_name}, sizeof({elem_ty}));\n"
+                    ));
                 } else {
                     cpp.push_str(&format!("    _mem[{wpfx}_addr] = {w_data_name};\n"));
                 }
@@ -296,7 +385,9 @@ impl<'a> SimCodegen<'a> {
                 }
                 if r.latency == 2 {
                     if is_wide {
-                        cpp.push_str(&format!("  memcpy(&_r2_{out_name}, &_r_{out_name}, sizeof({elem_ty}));\n"));
+                        cpp.push_str(&format!(
+                            "  memcpy(&_r2_{out_name}, &_r_{out_name}, sizeof({elem_ty}));\n"
+                        ));
                     } else {
                         cpp.push_str(&format!("  _r2_{out_name} = _r_{out_name};\n"));
                     }
@@ -306,11 +397,18 @@ impl<'a> SimCodegen<'a> {
                 for pg in &r.port_groups {
                     let pfx = &pg.name.name;
                     let has_wen = pg.signals.iter().any(|s| s.name.name == "wen");
-                    let wdata_name = pg.signals.iter()
-                        .find(|s| s.direction == Direction::In && (s.name.name == "wdata" || s.name.name == "data"))
+                    let wdata_name = pg
+                        .signals
+                        .iter()
+                        .find(|s| {
+                            s.direction == Direction::In
+                                && (s.name.name == "wdata" || s.name.name == "data")
+                        })
                         .map(|s| format!("{pfx}_{}", s.name.name))
                         .unwrap_or_else(|| format!("{pfx}_wdata"));
-                    let out_name = pg.signals.iter()
+                    let out_name = pg
+                        .signals
+                        .iter()
                         .find(|s| s.direction == Direction::Out)
                         .map(|s| format!("{pfx}_{}", s.name.name));
                     let addr = format!("{pfx}_addr");
@@ -332,7 +430,9 @@ impl<'a> SimCodegen<'a> {
                                 if is_wide {
                                     cpp.push_str(&format!("      memcpy(&_r_{out_name}, &_mem[{pfx}_addr], sizeof({elem_ty}));\n"));
                                 } else {
-                                    cpp.push_str(&format!("      _r_{out_name} = _mem[{pfx}_addr];\n"));
+                                    cpp.push_str(&format!(
+                                        "      _r_{out_name} = _mem[{pfx}_addr];\n"
+                                    ));
                                 }
                                 cpp.push_str("    }\n");
                             } else {
@@ -356,9 +456,15 @@ impl<'a> SimCodegen<'a> {
                 if r.latency == 2 {
                     for fs in &out_sigs {
                         if is_wide {
-                            cpp.push_str(&format!("  memcpy(&_r2_{}, &_r_{}, sizeof({elem_ty}));\n", fs.full_name, fs.full_name));
+                            cpp.push_str(&format!(
+                                "  memcpy(&_r2_{}, &_r_{}, sizeof({elem_ty}));\n",
+                                fs.full_name, fs.full_name
+                            ));
                         } else {
-                            cpp.push_str(&format!("  _r2_{} = _r_{};\n", fs.full_name, fs.full_name));
+                            cpp.push_str(&format!(
+                                "  _r2_{} = _r_{};\n",
+                                fs.full_name, fs.full_name
+                            ));
                         }
                     }
                 }
@@ -369,10 +475,15 @@ impl<'a> SimCodegen<'a> {
                 if r.latency >= 1 {
                     let pg = &r.port_groups[0];
                     let rpfx = &pg.name.name;
-                    let out_name = out_sigs.first().map(|s| s.full_name.as_str()).unwrap_or("data");
+                    let out_name = out_sigs
+                        .first()
+                        .map(|s| s.full_name.as_str())
+                        .unwrap_or("data");
                     let has_en = pg.signals.iter().any(|s| s.name.name == "en");
                     if has_en {
-                        cpp.push_str(&format!("  if ({rpfx}_en) _r_{out_name} = _mem[{rpfx}_addr];\n"));
+                        cpp.push_str(&format!(
+                            "  if ({rpfx}_en) _r_{out_name} = _mem[{rpfx}_addr];\n"
+                        ));
                     } else {
                         cpp.push_str(&format!("  _r_{out_name} = _mem[{rpfx}_addr];\n"));
                     }
@@ -388,31 +499,44 @@ impl<'a> SimCodegen<'a> {
         for fs in &out_sigs {
             match r.latency {
                 0 => {
-                    let rpfx = r.port_groups.iter()
-                        .find(|pg| pg.signals.iter().any(|s| {
-                            s.direction == Direction::Out
-                                && format!("{}_{}", pg.name.name, s.name.name) == fs.full_name
-                        }))
+                    let rpfx = r
+                        .port_groups
+                        .iter()
+                        .find(|pg| {
+                            pg.signals.iter().any(|s| {
+                                s.direction == Direction::Out
+                                    && format!("{}_{}", pg.name.name, s.name.name) == fs.full_name
+                            })
+                        })
                         .map(|pg| pg.name.name.as_str())
                         .unwrap_or("access");
                     let rd_addr = format!("{rpfx}_addr");
                     cpp.push_str(&read_check(&rd_addr, "  "));
                     if is_wide {
-                        cpp.push_str(&format!("  memcpy(&{}, &_mem[{rpfx}_addr], sizeof({}));\n", fs.full_name, fs.full_name));
+                        cpp.push_str(&format!(
+                            "  memcpy(&{}, &_mem[{rpfx}_addr], sizeof({}));\n",
+                            fs.full_name, fs.full_name
+                        ));
                     } else {
                         cpp.push_str(&format!("  {} = _mem[{rpfx}_addr];\n", fs.full_name));
                     }
                 }
                 1 => {
                     if is_wide {
-                        cpp.push_str(&format!("  memcpy(&{}, &_r_{}, sizeof({}));\n", fs.full_name, fs.full_name, fs.full_name));
+                        cpp.push_str(&format!(
+                            "  memcpy(&{}, &_r_{}, sizeof({}));\n",
+                            fs.full_name, fs.full_name, fs.full_name
+                        ));
                     } else {
                         cpp.push_str(&format!("  {} = _r_{};\n", fs.full_name, fs.full_name));
                     }
                 }
                 2 => {
                     if is_wide {
-                        cpp.push_str(&format!("  memcpy(&{}, &_r2_{}, sizeof({}));\n", fs.full_name, fs.full_name, fs.full_name));
+                        cpp.push_str(&format!(
+                            "  memcpy(&{}, &_r2_{}, sizeof({}));\n",
+                            fs.full_name, fs.full_name, fs.full_name
+                        ));
                     } else {
                         cpp.push_str(&format!("  {} = _r2_{};\n", fs.full_name, fs.full_name));
                     }
@@ -423,9 +547,21 @@ impl<'a> SimCodegen<'a> {
         cpp.push_str("}\n");
 
         let extra_sigs: Vec<(&str, &str, u32)> = vec![];
-        add_trace_to_simple_construct(&mut h, &mut cpp, &class, name, &r.ports, &extra_sigs, &r.params);
+        add_trace_to_simple_construct(
+            &mut h,
+            &mut cpp,
+            &class,
+            name,
+            &r.ports,
+            &extra_sigs,
+            &r.params,
+        );
         h.push_str("};\n");
 
-        SimModel { class_name: class, header: h, impl_: cpp }
+        SimModel {
+            class_name: class,
+            header: h,
+            impl_: cpp,
+        }
     }
 }

--- a/src/sim_codegen/thread_sim.rs
+++ b/src/sim_codegen/thread_sim.rs
@@ -29,9 +29,9 @@
 //   - Predicate / expression shapes: idents, literals, !/~, all binops
 
 use crate::ast::{
-    ArbiterPolicy, BinOp, CombAssign, ForRange, Stmt, Direction, Expr, ExprKind, IfElseOf,
-    LitKind, ModuleBodyItem, ModuleDecl, RegAssign, ResetLevel,
-    ParamDecl, ThreadBlock, ThreadStmt, TypeExpr, UnaryOp,
+    ArbiterPolicy, BinOp, CombAssign, Direction, Expr, ExprKind, ForRange, IfElseOf, LitKind,
+    ModuleBodyItem, ModuleDecl, ParamDecl, RegAssign, ResetLevel, Stmt, ThreadBlock, ThreadStmt,
+    TypeExpr, UnaryOp,
 };
 use crate::diagnostics::CompileWarning;
 use crate::sim_codegen::SimModel;
@@ -91,7 +91,10 @@ enum WaitKind {
     /// already this thread (priority-arbitrated; lower thread index
     /// wins ties because pass 2 of the scheduler resumes slots in
     /// declaration order). On resume the coroutine claims the holder.
-    LockAcquire(String /* resource name */, usize /* this thread index */),
+    LockAcquire(
+        String, /* resource name */
+        usize,  /* this thread index */
+    ),
 }
 
 struct ForLoopInfo {
@@ -113,7 +116,12 @@ struct ThreadInfo {
     branches: Vec<Branch>,
 }
 
-pub fn gen_module_thread(m: &ModuleDecl, debug: bool, wave: bool, num_os_threads: u32) -> Result<SimModel, String> {
+pub fn gen_module_thread(
+    m: &ModuleDecl,
+    debug: bool,
+    wave: bool,
+    num_os_threads: u32,
+) -> Result<SimModel, String> {
     let mut sink = Vec::new();
     gen_module_thread_with_warnings(m, debug, wave, num_os_threads, &mut sink)
 }
@@ -134,17 +142,24 @@ pub fn gen_module_thread_with_warnings(
     // which is what makes --thread-sim=both cross-check practical.
     let class = format!("V{}", m.name.name);
 
-    let threads: Vec<&ThreadBlock> = m.body.iter().filter_map(|i| match i {
-        ModuleBodyItem::Thread(t) => Some(t),
-        _ => None,
-    }).collect();
+    let threads: Vec<&ThreadBlock> = m
+        .body
+        .iter()
+        .filter_map(|i| match i {
+            ModuleBodyItem::Thread(t) => Some(t),
+            _ => None,
+        })
+        .collect();
     if threads.is_empty() {
         return Err(format!("module `{}` has no thread blocks", class));
     }
     validate_wide_thread_sim_exprs(m, &class)?;
     for (i, t) in threads.iter().enumerate() {
         if t.tlm_target.is_some() || t.implement.is_some() {
-            return Err(format!("module `{}` thread #{}: TLM/implement not yet supported", class, i));
+            return Err(format!(
+                "module `{}` thread #{}: TLM/implement not yet supported",
+                class, i
+            ));
         }
     }
 
@@ -156,10 +171,12 @@ pub fn gen_module_thread_with_warnings(
             | ModuleBodyItem::CombBlock(_)
             | ModuleBodyItem::RegBlock(_)
             | ModuleBodyItem::Resource(_) => {}
-            _ => return Err(format!(
-                "module `{}`: thread sim does not yet support this body item kind",
-                class
-            )),
+            _ => {
+                return Err(format!(
+                    "module `{}`: thread sim does not yet support this body item kind",
+                    class
+                ))
+            }
         }
     }
     // Partition each thread body into segments + collected branches.
@@ -168,9 +185,14 @@ pub fn gen_module_thread_with_warnings(
         let mut branches: Vec<Branch> = Vec::new();
         let main_segs = partition(&t.body, &mut branches, ti)
             .map_err(|e| format!("module `{}` thread #{}: {}", class, ti, e))?;
-        thread_infos.push(ThreadInfo { main_segs, branches });
+        thread_infos.push(ThreadInfo {
+            main_segs,
+            branches,
+        });
     }
-    let resource_count = m.body.iter()
+    let resource_count = m
+        .body
+        .iter()
         .filter(|item| matches!(item, ModuleBodyItem::Resource(_)))
         .count();
     if resource_count > 0 && threads.len() > 64 {
@@ -182,11 +204,15 @@ pub fn gen_module_thread_with_warnings(
     }
 
     // Ports + regs as fields.
-    let clk_name = m.ports.iter()
+    let clk_name = m
+        .ports
+        .iter()
         .find(|p| matches!(&p.ty, TypeExpr::Clock(_)))
         .map(|p| p.name.name.clone())
         .ok_or_else(|| format!("module `{}` has no clock port", class))?;
-    let (rst_name, rst_active_low) = m.ports.iter()
+    let (rst_name, rst_active_low) = m
+        .ports
+        .iter()
         .find_map(|p| match &p.ty {
             TypeExpr::Reset(_, lvl) => Some((p.name.name.clone(), matches!(lvl, ResetLevel::Low))),
             _ => None,
@@ -206,7 +232,10 @@ pub fn gen_module_thread_with_warnings(
     for p in &m.params {
         if let Some(def) = &p.default {
             let val = eval_const_with_params(def, &m.params);
-            header.push_str(&format!("  static constexpr uint64_t {} = {}ULL;\n", p.name.name, val));
+            header.push_str(&format!(
+                "  static constexpr uint64_t {} = {}ULL;\n",
+                p.name.name, val
+            ));
         }
     }
     if !m.params.is_empty() {
@@ -224,13 +253,20 @@ pub fn gen_module_thread_with_warnings(
     for item in &m.body {
         if let ModuleBodyItem::RegDecl(r) = item {
             if let TypeExpr::Vec(elem, count_expr) = &r.ty {
-                let elem_ty = port_or_reg_cpp_ty_with_params(elem, &m.params)
-                    .map_err(|e| format!("module `{}` reg `{}` element: {}", class, r.name.name, e))?;
+                let elem_ty = port_or_reg_cpp_ty_with_params(elem, &m.params).map_err(|e| {
+                    format!("module `{}` reg `{}` element: {}", class, r.name.name, e)
+                })?;
                 let count = eval_const_with_params(count_expr, &m.params);
                 if count == 0 {
-                    return Err(format!("module `{}` reg `{}`: Vec count = 0 (param resolution not yet supported)", class, r.name.name));
+                    return Err(format!(
+                        "module `{}` reg `{}`: Vec count = 0 (param resolution not yet supported)",
+                        class, r.name.name
+                    ));
                 }
-                header.push_str(&format!("  {} {}[{}] = {{}};\n", elem_ty, r.name.name, count));
+                header.push_str(&format!(
+                    "  {} {}[{}] = {{}};\n",
+                    elem_ty, r.name.name, count
+                ));
                 vec_reg_info.push((r.name.name.clone(), elem_ty, count));
             } else {
                 let cpp_ty = port_or_reg_cpp_ty_with_params(&r.ty, &m.params)
@@ -248,7 +284,9 @@ pub fn gen_module_thread_with_warnings(
         m.ports.iter().map(|p| p.name.name.as_str()).collect();
     for item in &m.body {
         if let ModuleBodyItem::LetBinding(lb) = item {
-            if port_names_set.contains(lb.name.name.as_str()) { continue; }
+            if port_names_set.contains(lb.name.name.as_str()) {
+                continue;
+            }
             // For typed lets, infer width; for untyped (target=port),
             // the previous filter already skipped them.
             let cpp_ty = match &lb.ty {
@@ -279,8 +317,14 @@ pub fn gen_module_thread_with_warnings(
         for br in &info.branches {
             // Branch slot starts in Done so the scheduler skips it
             // until the parent's fork-launch resets it.
-            header.push_str(&format!("    _t{i}_br{}_slot.kind = arch_rt::WaitKind::Done;\n", br.id));
-            header.push_str(&format!("    _sched_{i}.slots.push_back(&_t{i}_br{}_slot);\n", br.id));
+            header.push_str(&format!(
+                "    _t{i}_br{}_slot.kind = arch_rt::WaitKind::Done;\n",
+                br.id
+            ));
+            header.push_str(&format!(
+                "    _sched_{i}.slots.push_back(&_t{i}_br{}_slot);\n",
+                br.id
+            ));
         }
     }
     // Initial settle — run each per-thread scheduler in declaration
@@ -296,7 +340,9 @@ pub fn gen_module_thread_with_warnings(
         // signals _end_barrier. The main TB-driving thread (caller of
         // eval()) coordinates by hitting both barriers per posedge.
         for (i, _) in thread_infos.iter().enumerate() {
-            header.push_str(&format!("    _worker_{i} = std::thread([this]{{ _worker_loop_{i}(); }});\n"));
+            header.push_str(&format!(
+                "    _worker_{i} = std::thread([this]{{ _worker_loop_{i}(); }});\n"
+            ));
         }
     }
     header.push_str("  }\n");
@@ -307,7 +353,9 @@ pub fn gen_module_thread_with_warnings(
         header.push_str("    _shutdown.store(true, std::memory_order_release);\n");
         header.push_str("    _start_barrier.wait();\n");
         for (i, _) in thread_infos.iter().enumerate() {
-            header.push_str(&format!("    if (_worker_{i}.joinable()) _worker_{i}.join();\n"));
+            header.push_str(&format!(
+                "    if (_worker_{i}.joinable()) _worker_{i}.join();\n"
+            ));
         }
     }
     for (i, info) in thread_infos.iter().enumerate() {
@@ -325,7 +373,8 @@ pub fn gen_module_thread_with_warnings(
         // Auto-open VCD on first eval if Verilated::traceFile() is set
         // (TB convention: arch sim --wave out.vcd passes +trace+out.vcd
         // which the verilated.cpp stub captures into traceFile()).
-        header.push_str("    if (!_trace_fp && Verilated::traceFile() && Verilated::claimTrace())\n");
+        header
+            .push_str("    if (!_trace_fp && Verilated::traceFile() && Verilated::claimTrace())\n");
         header.push_str("      trace_open(Verilated::traceFile());\n");
     }
     // Detect rising edge of clk (Verilator convention) and run the
@@ -346,7 +395,7 @@ pub fn gen_module_thread_with_warnings(
     if wave {
         header.push_str("      if (_trace_fp) trace_dump(_trace_time++);\n");
     }
-    header.push_str("      return;\n");  // _do_posedge settled comb via its own eval() at the end
+    header.push_str("      return;\n"); // _do_posedge settled comb via its own eval() at the end
     header.push_str("    }\n");
     // Comb-only eval (clk falling or steady) — falls through to the
     // segment switches and module-level comb below, then logs at end.
@@ -431,7 +480,10 @@ pub fn gen_module_thread_with_warnings(
         if let ModuleBodyItem::RegDecl(r) = item {
             if let TypeExpr::Vec(_, count_expr) = &r.ty {
                 let count = eval_const_with_params(count_expr, &m.params);
-                header.push_str(&format!("      for (uint64_t _i = 0; _i < {count}; _i++) {} [_i] = 0;\n", r.name.name));
+                header.push_str(&format!(
+                    "      for (uint64_t _i = 0; _i < {count}; _i++) {} [_i] = 0;\n",
+                    r.name.name
+                ));
             } else {
                 header.push_str(&format!("      {} = 0;\n", r.name.name));
             }
@@ -440,15 +492,23 @@ pub fn gen_module_thread_with_warnings(
     for (i, info) in thread_infos.iter().enumerate() {
         header.push_str(&format!("      _slot_{i}.thread.destroy();\n"));
         header.push_str(&format!("      _slot_{i}.thread = _make_thread_{i}();\n"));
-        header.push_str(&format!("      _slot_{i}.kind = arch_rt::WaitKind::Ready;\n"));
+        header.push_str(&format!(
+            "      _slot_{i}.kind = arch_rt::WaitKind::Ready;\n"
+        ));
         header.push_str(&format!("      _slot_{i}.cycles_remaining = 0;\n"));
         header.push_str(&format!("      _slot_{i}.pred = nullptr;\n"));
         header.push_str(&format!("      _seg_{i} = 0;\n"));
         // Branch slots return to Done so they don't run until next fork-launch.
         for br in &info.branches {
             header.push_str(&format!("      _t{i}_br{}_slot.thread.destroy();\n", br.id));
-            header.push_str(&format!("      _t{i}_br{}_slot.kind = arch_rt::WaitKind::Done;\n", br.id));
-            header.push_str(&format!("      _t{i}_br{}_slot.cycles_remaining = 0;\n", br.id));
+            header.push_str(&format!(
+                "      _t{i}_br{}_slot.kind = arch_rt::WaitKind::Done;\n",
+                br.id
+            ));
+            header.push_str(&format!(
+                "      _t{i}_br{}_slot.cycles_remaining = 0;\n",
+                br.id
+            ));
             header.push_str(&format!("      _t{i}_br{}_slot.pred = nullptr;\n", br.id));
             header.push_str(&format!("      _t{i}_br{}_seg = 0;\n", br.id));
         }
@@ -496,14 +556,22 @@ pub fn gen_module_thread_with_warnings(
             }
             header.push_str(&format!("      _slot_{ti}.thread.destroy();\n"));
             header.push_str(&format!("      _slot_{ti}.thread = _make_thread_{ti}();\n"));
-            header.push_str(&format!("      _slot_{ti}.kind = arch_rt::WaitKind::Ready;\n"));
+            header.push_str(&format!(
+                "      _slot_{ti}.kind = arch_rt::WaitKind::Ready;\n"
+            ));
             header.push_str(&format!("      _slot_{ti}.cycles_remaining = 0;\n"));
             header.push_str(&format!("      _slot_{ti}.pred = nullptr;\n"));
             header.push_str(&format!("      _seg_{ti} = 0;\n"));
             // Reset this thread's branches too.
             for br in &thread_infos[ti].branches {
-                header.push_str(&format!("      _t{ti}_br{}_slot.thread.destroy();\n", br.id));
-                header.push_str(&format!("      _t{ti}_br{}_slot.kind = arch_rt::WaitKind::Done;\n", br.id));
+                header.push_str(&format!(
+                    "      _t{ti}_br{}_slot.thread.destroy();\n",
+                    br.id
+                ));
+                header.push_str(&format!(
+                    "      _t{ti}_br{}_slot.kind = arch_rt::WaitKind::Done;\n",
+                    br.id
+                ));
                 header.push_str(&format!("      _t{ti}_br{}_seg = 0;\n", br.id));
             }
             header.push_str("    }\n");
@@ -543,15 +611,22 @@ pub fn gen_module_thread_with_warnings(
         // the TB can call after reset.
         header.push_str(&format!("  void _dbg_log_ports() {{\n"));
         for p in &m.ports {
-            if matches!(&p.ty, TypeExpr::Clock(_)) { continue; }
+            if matches!(&p.ty, TypeExpr::Clock(_)) {
+                continue;
+            }
             let pname = &p.name.name;
-            let dir = match p.direction { Direction::In => "in", Direction::Out => "out" };
+            let dir = match p.direction {
+                Direction::In => "in",
+                Direction::Out => "out",
+            };
             let bits = match &p.ty {
                 TypeExpr::Bool | TypeExpr::Bit | TypeExpr::Reset(..) => 1,
                 TypeExpr::UInt(w) => eval_const_with_params(w, &m.params),
-                _ => continue,  // Vec / wide / bus skipped in Phase 5 spike
+                _ => continue, // Vec / wide / bus skipped in Phase 5 spike
             };
-            if bits == 0 || bits > 64 { continue; }
+            if bits == 0 || bits > 64 {
+                continue;
+            }
             header.push_str(&format!("    if ({pname} != _dbg_prev_{pname}) {{\n"));
             header.push_str(&format!(
                 "      printf(\"[%llu][{mod}.{pname}]({dir}) 0x%llx -> 0x%llx\\n\", \
@@ -579,7 +654,9 @@ pub fn gen_module_thread_with_warnings(
                 TypeExpr::UInt(w) => eval_const_with_params(w, &m.params) as u32,
                 _ => continue,
             };
-            if width == 0 || width > 64 { continue; }
+            if width == 0 || width > 64 {
+                continue;
+            }
             signals.push(crate::sim_codegen::TraceSignal {
                 vcd_name: p.name.name.clone(),
                 cpp_expr: p.name.name.clone(),
@@ -600,7 +677,9 @@ pub fn gen_module_thread_with_warnings(
                         TypeExpr::UInt(w) => eval_const_with_params(w, &m.params) as u32,
                         _ => continue,
                     };
-                    if elem_width == 0 || elem_width > 64 { continue; }
+                    if elem_width == 0 || elem_width > 64 {
+                        continue;
+                    }
                     let count = eval_const_with_params(count_expr, &m.params);
                     for i in 0..count {
                         signals.push(crate::sim_codegen::TraceSignal {
@@ -616,7 +695,9 @@ pub fn gen_module_thread_with_warnings(
                         TypeExpr::UInt(w) => eval_const_with_params(w, &m.params) as u32,
                         _ => continue,
                     };
-                    if width == 0 || width > 64 { continue; }
+                    if width == 0 || width > 64 {
+                        continue;
+                    }
                     signals.push(crate::sim_codegen::TraceSignal {
                         vcd_name: r.name.name.clone(),
                         cpp_expr: r.name.name.clone(),
@@ -699,10 +780,15 @@ pub fn gen_module_thread_with_warnings(
     if debug {
         header.push_str("  uint64_t _dbg_cycle = 0;\n");
         for p in &m.ports {
-            if matches!(&p.ty, TypeExpr::Clock(_)) { continue; }
+            if matches!(&p.ty, TypeExpr::Clock(_)) {
+                continue;
+            }
             let cpp_ty = port_or_reg_cpp_ty_with_params(&p.ty, &m.params)
                 .map_err(|e| format!("module `{}` port `{}`: {}", class, p.name.name, e))?;
-            header.push_str(&format!("  {}\n", field_decl(&cpp_ty, &format!("_dbg_prev_{}", p.name.name))));
+            header.push_str(&format!(
+                "  {}\n",
+                field_decl(&cpp_ty, &format!("_dbg_prev_{}", p.name.name))
+            ));
         }
     }
     // Per-user-thread scheduler. Each owns its main slot + its fork
@@ -734,8 +820,14 @@ pub fn gen_module_thread_with_warnings(
     // lowered lock arbiters.
     for item in &m.body {
         if let ModuleBodyItem::Resource(r) = item {
-            header.push_str(&format!("  uint64_t _resource_{}_req_mask = 0;\n", r.name.name));
-            header.push_str(&format!("  int32_t _resource_{}_holder = -1;\n", r.name.name));
+            header.push_str(&format!(
+                "  uint64_t _resource_{}_req_mask = 0;\n",
+                r.name.name
+            ));
+            header.push_str(&format!(
+                "  int32_t _resource_{}_holder = -1;\n",
+                r.name.name
+            ));
             match &r.policy {
                 ArbiterPolicy::Priority => {}
                 ArbiterPolicy::RoundRobin => {
@@ -750,7 +842,10 @@ pub fn gen_module_thread_with_warnings(
                         "  uint32_t _resource_{}_lru_order[{}] = {{{}}};\n",
                         r.name.name,
                         threads.len(),
-                        (0..threads.len()).map(|i| i.to_string()).collect::<Vec<_>>().join(", ")
+                        (0..threads.len())
+                            .map(|i| i.to_string())
+                            .collect::<Vec<_>>()
+                            .join(", ")
                     ));
                 }
                 ArbiterPolicy::Weighted(weight) => {
@@ -764,11 +859,17 @@ pub fn gen_module_thread_with_warnings(
                         "  uint32_t _resource_{}_credits[{}] = {{{}}};\n",
                         r.name.name,
                         threads.len(),
-                        std::iter::repeat(credit.to_string()).take(threads.len()).collect::<Vec<_>>().join(", ")
+                        std::iter::repeat(credit.to_string())
+                            .take(threads.len())
+                            .collect::<Vec<_>>()
+                            .join(", ")
                     ));
                 }
                 ArbiterPolicy::Custom(_) => {
-                    header.push_str(&format!("  uint64_t _resource_{}_last_grant_onehot = 0;\n", r.name.name));
+                    header.push_str(&format!(
+                        "  uint64_t _resource_{}_last_grant_onehot = 0;\n",
+                        r.name.name
+                    ));
                 }
             }
         }
@@ -815,7 +916,11 @@ pub fn gen_module_thread_with_warnings(
                 body_cpp.push_str(&format!("{pad2}{lhs} = {rhs};\n"));
             }
             for ie in &seg.entry_seq_if {
-                emit_seq_if(ie, &mut body_cpp, ind + if seg.for_loop.is_some() {2} else {0})?;
+                emit_seq_if(
+                    ie,
+                    &mut body_cpp,
+                    ind + if seg.for_loop.is_some() { 2 } else { 0 },
+                )?;
             }
             // Wait.
             match &seg.wait_kind {
@@ -844,14 +949,22 @@ pub fn gen_module_thread_with_warnings(
                     // tick resumes it. Then wait until all branch slots
                     // are Done.
                     for &bid in branch_ids {
-                        body_cpp.push_str(&format!("{pad2}_t{ti}_br{bid}_slot.thread.destroy();\n"));
-                        body_cpp.push_str(&format!("{pad2}_t{ti}_br{bid}_slot.thread = _t{ti}_br{bid}_make();\n"));
-                        body_cpp.push_str(&format!("{pad2}_t{ti}_br{bid}_slot.kind = arch_rt::WaitKind::Ready;\n"));
-                        body_cpp.push_str(&format!("{pad2}_t{ti}_br{bid}_slot.cycles_remaining = 0;\n"));
+                        body_cpp
+                            .push_str(&format!("{pad2}_t{ti}_br{bid}_slot.thread.destroy();\n"));
+                        body_cpp.push_str(&format!(
+                            "{pad2}_t{ti}_br{bid}_slot.thread = _t{ti}_br{bid}_make();\n"
+                        ));
+                        body_cpp.push_str(&format!(
+                            "{pad2}_t{ti}_br{bid}_slot.kind = arch_rt::WaitKind::Ready;\n"
+                        ));
+                        body_cpp.push_str(&format!(
+                            "{pad2}_t{ti}_br{bid}_slot.cycles_remaining = 0;\n"
+                        ));
                         body_cpp.push_str(&format!("{pad2}_t{ti}_br{bid}_slot.pred = nullptr;\n"));
                         body_cpp.push_str(&format!("{pad2}_t{ti}_br{bid}_seg = 0;\n"));
                     }
-                    let pred = branch_ids.iter()
+                    let pred = branch_ids
+                        .iter()
                         .map(|b| format!("_t{ti}_br{b}_slot.kind == arch_rt::WaitKind::Done"))
                         .collect::<Vec<_>>()
                         .join(" && ");
@@ -859,7 +972,11 @@ pub fn gen_module_thread_with_warnings(
                         "{pad2}co_await arch_rt::wait_until(&_slot_{ti}, [this]{{ return {pred}; }});\n"
                     ));
                 }
-                WaitKind::IfElseJoin { cond, then_branch, else_branch } => {
+                WaitKind::IfElseJoin {
+                    cond,
+                    then_branch,
+                    else_branch,
+                } => {
                     emit_ifelse_join_wait(
                         &mut body_cpp,
                         &pad2,
@@ -880,7 +997,9 @@ pub fn gen_module_thread_with_warnings(
                     body_cpp.push_str(&format!(
                         "{pad2}  co_await arch_rt::wait_until(&_slot_{ti}, [this]{{ return _resource_{res}_can_acquire({my_id}); }});\n"
                     ));
-                    body_cpp.push_str(&format!("{pad2}  if (_resource_{res}_can_acquire({my_id})) {{\n"));
+                    body_cpp.push_str(&format!(
+                        "{pad2}  if (_resource_{res}_can_acquire({my_id})) {{\n"
+                    ));
                     body_cpp.push_str(&format!("{pad2}    _resource_{res}_claim({my_id});\n"));
                     body_cpp.push_str(&format!("{pad2}    break;\n"));
                     body_cpp.push_str(&format!("{pad2}  }}\n"));
@@ -901,7 +1020,11 @@ pub fn gen_module_thread_with_warnings(
                 body_cpp.push_str(&format!("{pad2}{lhs} = {rhs};\n"));
             }
             for ie in &seg.post_wait_seq_if {
-                emit_seq_if(ie, &mut body_cpp, ind + if seg.for_loop.is_some() {2} else {0})?;
+                emit_seq_if(
+                    ie,
+                    &mut body_cpp,
+                    ind + if seg.for_loop.is_some() { 2 } else { 0 },
+                )?;
             }
             if seg.for_loop.is_some() {
                 let pad_close = " ".repeat(ind);
@@ -920,7 +1043,8 @@ pub fn gen_module_thread_with_warnings(
         // sit at Done until the parent's next fork-launch resets them.
         for br in &info.branches {
             header.push_str(&format!(
-                "  arch_rt::ArchThread _t{ti}_br{}_make() {{\n", br.id
+                "  arch_rt::ArchThread _t{ti}_br{}_make() {{\n",
+                br.id
             ));
             for (si, seg) in br.segs.iter().enumerate() {
                 let pad = "    ";
@@ -932,7 +1056,11 @@ pub fn gen_module_thread_with_warnings(
                         v = fl.var
                     ));
                 }
-                let pad2 = if seg.for_loop.is_some() { "      " } else { "    " };
+                let pad2 = if seg.for_loop.is_some() {
+                    "      "
+                } else {
+                    "    "
+                };
                 header.push_str(&format!("{pad2}_t{ti}_br{}_seg = {si};\n", br.id));
                 for sa in &seg.entry_seq {
                     let lhs = expr_to_cpp(&sa.target)?;
@@ -952,7 +1080,8 @@ pub fn gen_module_thread_with_warnings(
                     WaitKind::Cycles(n) => {
                         let n_str = expr_to_cpp(n)?;
                         header.push_str(&format!(
-                            "{pad2}co_await arch_rt::wait_cycles(&_t{ti}_br{}_slot, {n_str});\n", br.id
+                            "{pad2}co_await arch_rt::wait_cycles(&_t{ti}_br{}_slot, {n_str});\n",
+                            br.id
                         ));
                     }
                     WaitKind::Terminal => {
@@ -967,14 +1096,19 @@ pub fn gen_module_thread_with_warnings(
                         // visibility).
                         if !seg.hold_comb.is_empty() {
                             header.push_str(&format!(
-                                "{pad2}co_await arch_rt::wait_cycles(&_t{ti}_br{}_slot, 1);\n", br.id
+                                "{pad2}co_await arch_rt::wait_cycles(&_t{ti}_br{}_slot, 1);\n",
+                                br.id
                             ));
                         }
                     }
                     WaitKind::ForkJoin(_) => {
                         return Err("nested fork/join inside fork branch not yet supported".into());
                     }
-                    WaitKind::IfElseJoin { cond, then_branch, else_branch } => {
+                    WaitKind::IfElseJoin {
+                        cond,
+                        then_branch,
+                        else_branch,
+                    } => {
                         emit_ifelse_join_wait(
                             &mut header,
                             pad2,
@@ -1054,7 +1188,11 @@ pub fn gen_module_thread_with_warnings(
 // `branches`; the caller passes a fresh Vec at the top level.
 // `thread_id` identifies the owning thread (used as priority for
 // LockAcquire — lower id wins).
-fn partition(body: &[ThreadStmt], branches: &mut Vec<Branch>, thread_id: usize) -> Result<Vec<Segment>, String> {
+fn partition(
+    body: &[ThreadStmt],
+    branches: &mut Vec<Branch>,
+    thread_id: usize,
+) -> Result<Vec<Segment>, String> {
     let mut segs: Vec<Segment> = Vec::new();
     let mut cur = new_segment();
 
@@ -1100,7 +1238,10 @@ fn partition(body: &[ThreadStmt], branches: &mut Vec<Branch>, thread_id: usize) 
                         cur.entry_seq_if.push(ie.clone());
                     }
                     IfKind::Mixed => {
-                        return Err("mixed CombAssign + SeqAssign inside `if/else` not yet supported".into());
+                        return Err(
+                            "mixed CombAssign + SeqAssign inside `if/else` not yet supported"
+                                .into(),
+                        );
                     }
                     IfKind::Empty => {}
                 }
@@ -1113,24 +1254,38 @@ fn partition(body: &[ThreadStmt], branches: &mut Vec<Branch>, thread_id: usize) 
                 cur.wait_kind = WaitKind::Cycles(n.clone());
                 segs.push(std::mem::replace(&mut cur, new_segment()));
             }
-            ThreadStmt::For { var, start, end, body, .. } => {
+            ThreadStmt::For {
+                var,
+                start,
+                end,
+                body,
+                ..
+            } => {
                 if !contains_wait(body) {
-                    return Err("`for` without internal `wait` is unusual; use `for` in comb instead. \
-                        Phase 2 thread-sim only handles `for` containing a wait.".into());
+                    return Err(
+                        "`for` without internal `wait` is unusual; use `for` in comb instead. \
+                        Phase 2 thread-sim only handles `for` containing a wait."
+                            .into(),
+                    );
                 }
                 // Flush any pending pre-loop hold/seq into a 1-cycle yield
                 // segment if non-empty (so the held outputs get a cycle to
                 // settle before the loop). For Phase 2, error if pending.
                 if !cur.hold_comb.is_empty() || !cur.entry_seq.is_empty() {
-                    return Err("`for` preceded by un-flushed comb/seq assigns not yet supported \
-                        (insert a `wait` before the for loop)".into());
+                    return Err(
+                        "`for` preceded by un-flushed comb/seq assigns not yet supported \
+                        (insert a `wait` before the for loop)"
+                            .into(),
+                    );
                 }
                 // Partition the loop body — Phase 2 supports a body with
                 // exactly one wait (like BurstRead). The loop body is then
                 // a single segment that gets wrapped in a C++ for loop.
                 let inner = partition(body, branches, thread_id)?;
                 if inner.len() != 1 {
-                    return Err("`for` body must contain exactly one wait segment in Phase 2".into());
+                    return Err(
+                        "`for` body must contain exactly one wait segment in Phase 2".into(),
+                    );
                 }
                 let mut inner_seg = inner.into_iter().next().unwrap();
                 inner_seg.for_loop = Some(ForLoopInfo {
@@ -1144,9 +1299,15 @@ fn partition(body: &[ThreadStmt], branches: &mut Vec<Branch>, thread_id: usize) 
                 // Flush any pending into a 1-cycle yield segment so the
                 // pre-fork holds get a chance to settle. Phase 3a: error
                 // if pending (force user to put a wait before fork).
-                if !cur.hold_comb.is_empty() || !cur.entry_seq.is_empty() || !cur.entry_seq_if.is_empty() {
-                    return Err("fork preceded by un-flushed comb/seq assigns not yet supported \
-                        (insert a wait before the fork)".into());
+                if !cur.hold_comb.is_empty()
+                    || !cur.entry_seq.is_empty()
+                    || !cur.entry_seq_if.is_empty()
+                {
+                    return Err(
+                        "fork preceded by un-flushed comb/seq assigns not yet supported \
+                        (insert a wait before the fork)"
+                            .into(),
+                    );
                 }
                 // Allocate a Branch per branch body, partition each.
                 let mut branch_ids: Vec<usize> = Vec::new();
@@ -1164,9 +1325,15 @@ fn partition(body: &[ThreadStmt], branches: &mut Vec<Branch>, thread_id: usize) 
                 // Flush pending into a state before the lock, since the
                 // pre-lock CombAssigns/SeqAssigns shouldn't be held while
                 // waiting to acquire the resource.
-                if !cur.hold_comb.is_empty() || !cur.entry_seq.is_empty() || !cur.entry_seq_if.is_empty() {
-                    return Err("`lock` preceded by un-flushed comb/seq assigns not yet supported \
-                        (insert a wait before the lock)".into());
+                if !cur.hold_comb.is_empty()
+                    || !cur.entry_seq.is_empty()
+                    || !cur.entry_seq_if.is_empty()
+                {
+                    return Err(
+                        "`lock` preceded by un-flushed comb/seq assigns not yet supported \
+                        (insert a wait before the lock)"
+                            .into(),
+                    );
                 }
                 // Acquire segment: wait until lock is free or already held by us.
                 cur.wait_kind = WaitKind::LockAcquire(resource.name.clone(), thread_id);
@@ -1189,8 +1356,14 @@ fn partition(body: &[ThreadStmt], branches: &mut Vec<Branch>, thread_id: usize) 
                 // Phase 4 scope: body must contain only CombAssign,
                 // SeqAssign, IfElse (no nested waits, no for-loops,
                 // no fork/join). This covers the axi_dma_thread case.
-                if !cur.hold_comb.is_empty() || !cur.entry_seq.is_empty() || !cur.entry_seq_if.is_empty() {
-                    return Err("`do until` preceded by un-flushed comb/seq assigns not yet supported".into());
+                if !cur.hold_comb.is_empty()
+                    || !cur.entry_seq.is_empty()
+                    || !cur.entry_seq_if.is_empty()
+                {
+                    return Err(
+                        "`do until` preceded by un-flushed comb/seq assigns not yet supported"
+                            .into(),
+                    );
                 }
                 if contains_wait(body) {
                     return Err("`do until` body containing nested `wait` not yet supported".into());
@@ -1202,22 +1375,24 @@ fn partition(body: &[ThreadStmt], branches: &mut Vec<Branch>, thread_id: usize) 
                     match s {
                         ThreadStmt::CombAssign(a) => hold_comb.push(Stmt::Assign(a.clone())),
                         ThreadStmt::SeqAssign(a) => post_seq.push(a.clone()),
-                        ThreadStmt::IfElse(ie) => {
-                            match classify_ifelse(ie) {
-                                IfKind::PureComb => {
-                                    let comb_ie = lower_thread_ifelse_to_comb(ie)?;
-                                    hold_comb.push(Stmt::IfElse(comb_ie));
-                                }
-                                IfKind::PureSeq => post_seq_if.push(ie.clone()),
-                                IfKind::Mixed => return Err(
-                                    "mixed comb+seq IfElse inside `do until` body not yet supported".into()),
-                                IfKind::Empty => {}
+                        ThreadStmt::IfElse(ie) => match classify_ifelse(ie) {
+                            IfKind::PureComb => {
+                                let comb_ie = lower_thread_ifelse_to_comb(ie)?;
+                                hold_comb.push(Stmt::IfElse(comb_ie));
                             }
+                            IfKind::PureSeq => post_seq_if.push(ie.clone()),
+                            IfKind::Mixed => return Err(
+                                "mixed comb+seq IfElse inside `do until` body not yet supported"
+                                    .into(),
+                            ),
+                            IfKind::Empty => {}
+                        },
+                        _ => {
+                            return Err(format!(
+                                "stmt kind not supported inside `do until` body: {:?}",
+                                std::mem::discriminant(s)
+                            ))
                         }
-                        _ => return Err(format!(
-                            "stmt kind not supported inside `do until` body: {:?}",
-                            std::mem::discriminant(s)
-                        )),
                     }
                 }
                 cur.hold_comb = hold_comb;
@@ -1226,7 +1401,12 @@ fn partition(body: &[ThreadStmt], branches: &mut Vec<Branch>, thread_id: usize) 
                 cur.wait_kind = WaitKind::Until(cond.clone());
                 segs.push(std::mem::replace(&mut cur, new_segment()));
             }
-            other => return Err(format!("thread stmt not yet supported: {:?}", std::mem::discriminant(other))),
+            other => {
+                return Err(format!(
+                    "thread stmt not yet supported: {:?}",
+                    std::mem::discriminant(other)
+                ))
+            }
         }
     }
     // Trailing segment: if it's pure-seq (no held comb), fold its
@@ -1246,8 +1426,10 @@ fn partition(body: &[ThreadStmt], branches: &mut Vec<Branch>, thread_id: usize) 
                 prev.wait_kind,
                 WaitKind::Until(_) | WaitKind::Cycles(_) | WaitKind::IfElseJoin { .. }
             ) {
-                prev.post_wait_seq.extend(std::mem::take(&mut cur.entry_seq));
-                prev.post_wait_seq_if.extend(std::mem::take(&mut cur.entry_seq_if));
+                prev.post_wait_seq
+                    .extend(std::mem::take(&mut cur.entry_seq));
+                prev.post_wait_seq_if
+                    .extend(std::mem::take(&mut cur.entry_seq_if));
             } else {
                 cur.wait_kind = WaitKind::Terminal;
                 segs.push(cur);
@@ -1276,7 +1458,12 @@ fn new_segment() -> Segment {
     }
 }
 
-enum IfKind { PureComb, PureSeq, Mixed, Empty }
+enum IfKind {
+    PureComb,
+    PureSeq,
+    Mixed,
+    Empty,
+}
 
 fn classify_ifelse(ie: &IfElseOf<ThreadStmt>) -> IfKind {
     let (mut has_comb, mut has_seq) = (false, false);
@@ -1328,8 +1515,12 @@ fn lower_thread_ifelse_to_comb(ie: &IfElseOf<ThreadStmt>) -> Result<IfElseOf<Stm
 
 fn emit_branch_launch(out: &mut String, pad: &str, ti: usize, bid: usize) {
     out.push_str(&format!("{pad}_t{ti}_br{bid}_slot.thread.destroy();\n"));
-    out.push_str(&format!("{pad}_t{ti}_br{bid}_slot.thread = _t{ti}_br{bid}_make();\n"));
-    out.push_str(&format!("{pad}_t{ti}_br{bid}_slot.kind = arch_rt::WaitKind::Ready;\n"));
+    out.push_str(&format!(
+        "{pad}_t{ti}_br{bid}_slot.thread = _t{ti}_br{bid}_make();\n"
+    ));
+    out.push_str(&format!(
+        "{pad}_t{ti}_br{bid}_slot.kind = arch_rt::WaitKind::Ready;\n"
+    ));
     out.push_str(&format!("{pad}_t{ti}_br{bid}_slot.cycles_remaining = 0;\n"));
     out.push_str(&format!("{pad}_t{ti}_br{bid}_slot.pred = nullptr;\n"));
     out.push_str(&format!("{pad}_t{ti}_br{bid}_seg = 0;\n"));
@@ -1373,14 +1564,22 @@ fn emit_seq_stmt(s: &crate::ast::Stmt, out: &mut String, indent: usize) -> Resul
         Stmt::IfElse(ie) => {
             let cond = expr_to_cpp_bool(&ie.cond)?;
             out.push_str(&format!("{pad}if ({cond}) {{\n"));
-            for s in &ie.then_stmts { emit_seq_stmt(s, out, indent + 2)?; }
+            for s in &ie.then_stmts {
+                emit_seq_stmt(s, out, indent + 2)?;
+            }
             if !ie.else_stmts.is_empty() {
                 out.push_str(&format!("{pad}}} else {{\n"));
-                for s in &ie.else_stmts { emit_seq_stmt(s, out, indent + 2)?; }
+                for s in &ie.else_stmts {
+                    emit_seq_stmt(s, out, indent + 2)?;
+                }
             }
             out.push_str(&format!("{pad}}}\n"));
         }
-        _ => return Err(format!("module-level seq stmt kind not yet supported by thread sim")),
+        _ => {
+            return Err(format!(
+                "module-level seq stmt kind not yet supported by thread sim"
+            ))
+        }
     }
     Ok(())
 }
@@ -1396,10 +1595,14 @@ fn emit_comb_stmt(cs: &Stmt, out: &mut String, indent: usize) -> Result<(), Stri
         Stmt::IfElse(ie) => {
             let cond = expr_to_cpp_bool(&ie.cond)?;
             out.push_str(&format!("{pad}if ({cond}) {{\n"));
-            for s in &ie.then_stmts { emit_comb_stmt(s, out, indent + 2)?; }
+            for s in &ie.then_stmts {
+                emit_comb_stmt(s, out, indent + 2)?;
+            }
             if !ie.else_stmts.is_empty() {
                 out.push_str(&format!("{pad}}} else {{\n"));
-                for s in &ie.else_stmts { emit_comb_stmt(s, out, indent + 2)?; }
+                for s in &ie.else_stmts {
+                    emit_comb_stmt(s, out, indent + 2)?;
+                }
             }
             out.push_str(&format!("{pad}}}\n"));
         }
@@ -1478,8 +1681,15 @@ fn expr_to_cpp(e: &Expr) -> Result<String, String> {
             // hold the right width). Emit the receiver verbatim.
             match method.name.as_str() {
                 "trunc" | "zext" | "sext" | "resize" => expr_to_cpp(recv),
-                _ => Err(format!("method `.{}()` not yet supported by thread sim", method.name)),
-            }.map(|s| { let _ = args; s })
+                _ => Err(format!(
+                    "method `.{}()` not yet supported by thread sim",
+                    method.name
+                )),
+            }
+            .map(|s| {
+                let _ = args;
+                s
+            })
         }
         ExprKind::BitSlice(base, hi, lo) => {
             // base[hi:lo] — extract bits. C++ equivalent:
@@ -1487,7 +1697,9 @@ fn expr_to_cpp(e: &Expr) -> Result<String, String> {
             let b = expr_to_cpp(base)?;
             let h = expr_to_cpp(hi)?;
             let l = expr_to_cpp(lo)?;
-            Ok(format!("(({b}) >> ({l}) & ((1ull << (({h}) - ({l}) + 1)) - 1))"))
+            Ok(format!(
+                "(({b}) >> ({l}) & ((1ull << (({h}) - ({l}) + 1)) - 1))"
+            ))
         }
         ExprKind::Binary(op, lhs, rhs) => {
             let l = expr_to_cpp(lhs)?;
@@ -1498,17 +1710,27 @@ fn expr_to_cpp(e: &Expr) -> Result<String, String> {
                 BinOp::Mul | BinOp::MulWrap => "*",
                 BinOp::Div => "/",
                 BinOp::Mod => "%",
-                BinOp::Eq => "==", BinOp::Neq => "!=",
-                BinOp::Lt => "<",  BinOp::Gt => ">",
-                BinOp::Lte => "<=", BinOp::Gte => ">=",
-                BinOp::And => "&&", BinOp::Or => "||",
-                BinOp::BitAnd => "&", BinOp::BitOr => "|", BinOp::BitXor => "^",
-                BinOp::Shl => "<<", BinOp::Shr => ">>",
+                BinOp::Eq => "==",
+                BinOp::Neq => "!=",
+                BinOp::Lt => "<",
+                BinOp::Gt => ">",
+                BinOp::Lte => "<=",
+                BinOp::Gte => ">=",
+                BinOp::And => "&&",
+                BinOp::Or => "||",
+                BinOp::BitAnd => "&",
+                BinOp::BitOr => "|",
+                BinOp::BitXor => "^",
+                BinOp::Shl => "<<",
+                BinOp::Shr => ">>",
                 _ => return Err(format!("binop {:?} not yet supported", op)),
             };
             Ok(format!("({} {} {})", l, op_str, r))
         }
-        _ => Err(format!("expr shape not supported: {:?}", std::mem::discriminant(&e.kind))),
+        _ => Err(format!(
+            "expr shape not supported: {:?}",
+            std::mem::discriminant(&e.kind)
+        )),
     }
 }
 
@@ -1521,8 +1743,14 @@ fn expr_to_cpp_bool(e: &Expr) -> Result<String, String> {
         ExprKind::Binary(op, _, _) => {
             let s = expr_to_cpp(e)?;
             match op {
-                BinOp::Eq | BinOp::Neq | BinOp::Lt | BinOp::Gt
-                | BinOp::Lte | BinOp::Gte | BinOp::And | BinOp::Or => Ok(s),
+                BinOp::Eq
+                | BinOp::Neq
+                | BinOp::Lt
+                | BinOp::Gt
+                | BinOp::Lte
+                | BinOp::Gte
+                | BinOp::And
+                | BinOp::Or => Ok(s),
                 _ => Ok(format!("({} != 0)", s)),
             }
         }
@@ -1532,7 +1760,9 @@ fn expr_to_cpp_bool(e: &Expr) -> Result<String, String> {
 
 fn port_or_reg_cpp_ty_with_params(ty: &TypeExpr, params: &[ParamDecl]) -> Result<String, String> {
     match ty {
-        TypeExpr::Clock(_) | TypeExpr::Reset(..) | TypeExpr::Bool | TypeExpr::Bit => Ok("uint8_t".to_string()),
+        TypeExpr::Clock(_) | TypeExpr::Reset(..) | TypeExpr::Bool | TypeExpr::Bit => {
+            Ok("uint8_t".to_string())
+        }
         TypeExpr::UInt(w) => uint_cpp_ty(eval_const_with_params(w, params)),
         TypeExpr::SInt(w) => int_cpp_ty(eval_const_with_params(w, params)),
         other => Err(format!("type {:?} not supported", other)),
@@ -1604,7 +1834,9 @@ fn expr_uses_wide_name(expr: &Expr, wide_names: &HashSet<String>) -> bool {
             expr_uses_wide_name(base, wide_names)
                 || args.iter().any(|arg| expr_uses_wide_name(arg, wide_names))
         }
-        ExprKind::Concat(parts) => parts.iter().any(|part| expr_uses_wide_name(part, wide_names)),
+        ExprKind::Concat(parts) => parts
+            .iter()
+            .any(|part| expr_uses_wide_name(part, wide_names)),
         ExprKind::Literal(_) | ExprKind::Bool(_) => false,
         _ => false,
     }
@@ -1726,7 +1958,9 @@ fn validate_thread_stmt_wide_exprs(
         ThreadStmt::WaitCycles(expr, _) => {
             validate_wide_expr(expr, wide_names, class, "wait-cycles count")?;
         }
-        ThreadStmt::For { start, end, body, .. } => {
+        ThreadStmt::For {
+            start, end, body, ..
+        } => {
             validate_wide_expr(start, wide_names, class, "for-range start")?;
             validate_wide_expr(end, wide_names, class, "for-range end")?;
             for stmt in body {
@@ -1818,16 +2052,19 @@ fn eval_const_with_params(e: &Expr, params: &[ParamDecl]) -> u64 {
         ExprKind::Literal(LitKind::Hex(v)) => *v,
         ExprKind::Literal(LitKind::Bin(v)) => *v,
         ExprKind::Literal(LitKind::Sized(_, v)) => *v,
-        ExprKind::Ident(name) => {
-            params.iter()
-                .find(|p| p.name.name == *name)
-                .and_then(|p| p.default.as_ref())
-                .map(|d| eval_const_with_params(d, params))
-                .unwrap_or(0)
-        }
+        ExprKind::Ident(name) => params
+            .iter()
+            .find(|p| p.name.name == *name)
+            .and_then(|p| p.default.as_ref())
+            .map(|d| eval_const_with_params(d, params))
+            .unwrap_or(0),
         ExprKind::Clog2(a) => {
             let v = eval_const_with_params(a, params);
-            if v <= 1 { 0 } else { 64 - (v - 1).leading_zeros() as u64 }
+            if v <= 1 {
+                0
+            } else {
+                64 - (v - 1).leading_zeros() as u64
+            }
         }
         ExprKind::Unary(op, a) => {
             let v = eval_const_with_params(a, params);
@@ -1845,8 +2082,20 @@ fn eval_const_with_params(e: &Expr, params: &[ParamDecl]) -> u64 {
                 BinOp::Add | BinOp::AddWrap => lv.wrapping_add(rv),
                 BinOp::Sub | BinOp::SubWrap => lv.wrapping_sub(rv),
                 BinOp::Mul | BinOp::MulWrap => lv.wrapping_mul(rv),
-                BinOp::Div => if rv == 0 { 0 } else { lv / rv },
-                BinOp::Mod => if rv == 0 { 0 } else { lv % rv },
+                BinOp::Div => {
+                    if rv == 0 {
+                        0
+                    } else {
+                        lv / rv
+                    }
+                }
+                BinOp::Mod => {
+                    if rv == 0 {
+                        0
+                    } else {
+                        lv % rv
+                    }
+                }
                 BinOp::Shl => lv.wrapping_shl(rv as u32),
                 BinOp::Shr => lv.wrapping_shr(rv as u32),
                 BinOp::BitAnd => lv & rv,
@@ -1867,7 +2116,12 @@ fn uint_cpp_ty(bits: u64) -> Result<String, String> {
         17..=32 => "uint32_t".to_string(),
         33..=64 => "uint64_t".to_string(),
         65..=1024 => format!("VlWide<{}>", wide_words(bits)),
-        _ => return Err(format!("UInt<{}> > 1024 bits not supported by thread sim", bits)),
+        _ => {
+            return Err(format!(
+                "UInt<{}> > 1024 bits not supported by thread sim",
+                bits
+            ))
+        }
     })
 }
 
@@ -1879,14 +2133,21 @@ fn int_cpp_ty(bits: u64) -> Result<String, String> {
         17..=32 => "int32_t".to_string(),
         33..=64 => "int64_t".to_string(),
         65..=1024 => format!("VlWide<{}>", wide_words(bits)),
-        _ => return Err(format!("SInt<{}> > 1024 bits not supported by thread sim", bits)),
+        _ => {
+            return Err(format!(
+                "SInt<{}> > 1024 bits not supported by thread sim",
+                bits
+            ))
+        }
     })
 }
 
 fn collect_thread_driven_outputs(threads: &[&ThreadBlock], m: &ModuleDecl) -> Vec<String> {
     use std::collections::HashSet;
     let mut out: HashSet<String> = HashSet::new();
-    let port_outs: HashSet<&str> = m.ports.iter()
+    let port_outs: HashSet<&str> = m
+        .ports
+        .iter()
         .filter(|p| p.direction == Direction::Out && p.reg_info.is_none())
         .map(|p| p.name.name.as_str())
         .collect();
@@ -1895,7 +2156,9 @@ fn collect_thread_driven_outputs(threads: &[&ThreadBlock], m: &ModuleDecl) -> Ve
             match s {
                 ThreadStmt::CombAssign(a) => {
                     if let ExprKind::Ident(n) = &a.target.kind {
-                        if port_outs.contains(n.as_str()) { out.insert(n.clone()); }
+                        if port_outs.contains(n.as_str()) {
+                            out.insert(n.clone());
+                        }
                     }
                 }
                 ThreadStmt::IfElse(ie) => {
@@ -1906,42 +2169,60 @@ fn collect_thread_driven_outputs(threads: &[&ThreadBlock], m: &ModuleDecl) -> Ve
                 | ThreadStmt::Lock { body, .. }
                 | ThreadStmt::DoUntil { body, .. } => walk(body, port_outs, out),
                 ThreadStmt::ForkJoin(branches, _) => {
-                    for b in branches { walk(b, port_outs, out); }
+                    for b in branches {
+                        walk(b, port_outs, out);
+                    }
                 }
                 _ => {}
             }
         }
     }
-    for t in threads { walk(&t.body, &port_outs, &mut out); }
+    for t in threads {
+        walk(&t.body, &port_outs, &mut out);
+    }
     let mut v: Vec<String> = out.into_iter().collect();
     v.sort();
     v
 }
 
-fn emit_resource_helpers(header: &mut String, m: &ModuleDecl, num_threads: usize) -> Result<(), String> {
+fn emit_resource_helpers(
+    header: &mut String,
+    m: &ModuleDecl,
+    num_threads: usize,
+) -> Result<(), String> {
     for item in &m.body {
-        let ModuleBodyItem::Resource(r) = item else { continue; };
+        let ModuleBodyItem::Resource(r) = item else {
+            continue;
+        };
         let res = &r.name.name;
         header.push_str(&format!("  uint32_t _resource_{res}_select() {{\n"));
         header.push_str(&format!("    uint64_t _req = _resource_{res}_req_mask;\n"));
         header.push_str("    if (_req == 0) return 0xffffffffu;\n");
         match &r.policy {
             ArbiterPolicy::Priority => {
-                header.push_str(&format!("    for (uint32_t _idx = 0; _idx < {num_threads}; _idx++) {{\n"));
+                header.push_str(&format!(
+                    "    for (uint32_t _idx = 0; _idx < {num_threads}; _idx++) {{\n"
+                ));
                 header.push_str("      if ((_req >> _idx) & 1ULL) return _idx;\n");
                 header.push_str("    }\n");
                 header.push_str("    return 0xffffffffu;\n");
             }
             ArbiterPolicy::RoundRobin => {
-                header.push_str(&format!("    for (uint32_t _step = 0; _step < {num_threads}; _step++) {{\n"));
+                header.push_str(&format!(
+                    "    for (uint32_t _step = 0; _step < {num_threads}; _step++) {{\n"
+                ));
                 header.push_str(&format!("      uint32_t _idx = (_resource_{res}_last_grant + 1 + _step) % {num_threads};\n"));
                 header.push_str("      if ((_req >> _idx) & 1ULL) return _idx;\n");
                 header.push_str("    }\n");
                 header.push_str("    return 0xffffffffu;\n");
             }
             ArbiterPolicy::Lru => {
-                header.push_str(&format!("    for (uint32_t _rank = 0; _rank < {num_threads}; _rank++) {{\n"));
-                header.push_str(&format!("      uint32_t _idx = _resource_{res}_lru_order[_rank];\n"));
+                header.push_str(&format!(
+                    "    for (uint32_t _rank = 0; _rank < {num_threads}; _rank++) {{\n"
+                ));
+                header.push_str(&format!(
+                    "      uint32_t _idx = _resource_{res}_lru_order[_rank];\n"
+                ));
                 header.push_str("      if ((_req >> _idx) & 1ULL) return _idx;\n");
                 header.push_str("    }\n");
                 header.push_str("    return 0xffffffffu;\n");
@@ -1949,13 +2230,17 @@ fn emit_resource_helpers(header: &mut String, m: &ModuleDecl, num_threads: usize
             ArbiterPolicy::Weighted(weight) => {
                 let credit = eval_const_with_params(weight, &m.params).max(1);
                 header.push_str("    bool _has_credit = false;\n");
-                header.push_str(&format!("    for (uint32_t _idx = 0; _idx < {num_threads}; _idx++) {{\n"));
+                header.push_str(&format!(
+                    "    for (uint32_t _idx = 0; _idx < {num_threads}; _idx++) {{\n"
+                ));
                 header.push_str(&format!("      if (((_req >> _idx) & 1ULL) && _resource_{res}_credits[_idx] != 0) _has_credit = true;\n"));
                 header.push_str("    }\n");
                 header.push_str("    if (!_has_credit) {\n");
                 header.push_str(&format!("      for (uint32_t _idx = 0; _idx < {num_threads}; _idx++) _resource_{res}_credits[_idx] = {credit};\n"));
                 header.push_str("    }\n");
-                header.push_str(&format!("    for (uint32_t _step = 0; _step < {num_threads}; _step++) {{\n"));
+                header.push_str(&format!(
+                    "    for (uint32_t _step = 0; _step < {num_threads}; _step++) {{\n"
+                ));
                 header.push_str(&format!("      uint32_t _idx = (_resource_{res}_last_grant + 1 + _step) % {num_threads};\n"));
                 header.push_str(&format!("      if (((_req >> _idx) & 1ULL) && _resource_{res}_credits[_idx] != 0) return _idx;\n"));
                 header.push_str("    }\n");
@@ -1987,24 +2272,42 @@ fn emit_resource_helpers(header: &mut String, m: &ModuleDecl, num_threads: usize
                     fn_ident.name,
                     args.join(", ")
                 ));
-                header.push_str(&format!("    for (int32_t _idx = (int32_t){num_threads} - 1; _idx >= 0; --_idx) {{\n"));
-                header.push_str("      if ((_grant_onehot >> (uint32_t)_idx) & 1ULL) return (uint32_t)_idx;\n");
+                header.push_str(&format!(
+                    "    for (int32_t _idx = (int32_t){num_threads} - 1; _idx >= 0; --_idx) {{\n"
+                ));
+                header.push_str(
+                    "      if ((_grant_onehot >> (uint32_t)_idx) & 1ULL) return (uint32_t)_idx;\n",
+                );
                 header.push_str("    }\n");
                 header.push_str("    return 0xffffffffu;\n");
             }
         }
         header.push_str("  }\n");
-        header.push_str(&format!("  bool _resource_{res}_can_acquire(uint32_t _tid) {{\n"));
-        header.push_str(&format!("    if (_resource_{res}_holder == (int32_t)_tid) return true;\n"));
-        header.push_str(&format!("    if (_resource_{res}_holder != -1) return false;\n"));
+        header.push_str(&format!(
+            "  bool _resource_{res}_can_acquire(uint32_t _tid) {{\n"
+        ));
+        header.push_str(&format!(
+            "    if (_resource_{res}_holder == (int32_t)_tid) return true;\n"
+        ));
+        header.push_str(&format!(
+            "    if (_resource_{res}_holder != -1) return false;\n"
+        ));
         header.push_str(&format!("    return _resource_{res}_select() == _tid;\n"));
         header.push_str("  }\n");
-        header.push_str(&format!("  void _resource_{res}_note_request(uint32_t _tid) {{\n"));
-        header.push_str(&format!("    _resource_{res}_req_mask |= (1ULL << _tid);\n"));
+        header.push_str(&format!(
+            "  void _resource_{res}_note_request(uint32_t _tid) {{\n"
+        ));
+        header.push_str(&format!(
+            "    _resource_{res}_req_mask |= (1ULL << _tid);\n"
+        ));
         header.push_str("  }\n");
         header.push_str(&format!("  void _resource_{res}_claim(uint32_t _tid) {{\n"));
-        header.push_str(&format!("    _resource_{res}_req_mask &= ~(1ULL << _tid);\n"));
-        header.push_str(&format!("    if (_resource_{res}_holder == (int32_t)_tid) return;\n"));
+        header.push_str(&format!(
+            "    _resource_{res}_req_mask &= ~(1ULL << _tid);\n"
+        ));
+        header.push_str(&format!(
+            "    if (_resource_{res}_holder == (int32_t)_tid) return;\n"
+        ));
         header.push_str(&format!("    _resource_{res}_holder = (int32_t)_tid;\n"));
         match &r.policy {
             ArbiterPolicy::Priority => {}
@@ -2018,19 +2321,27 @@ fn emit_resource_helpers(header: &mut String, m: &ModuleDecl, num_threads: usize
                 header.push_str(&format!("      _resource_{res}_lru_order[_pos] = _resource_{res}_lru_order[_pos + 1];\n"));
                 header.push_str("      _pos++;\n");
                 header.push_str("    }\n");
-                header.push_str(&format!("    _resource_{res}_lru_order[{num_threads} - 1] = _tid;\n"));
+                header.push_str(&format!(
+                    "    _resource_{res}_lru_order[{num_threads} - 1] = _tid;\n"
+                ));
             }
             ArbiterPolicy::Weighted(_) => {
                 header.push_str(&format!("    if (_resource_{res}_credits[_tid] != 0) _resource_{res}_credits[_tid]--;\n"));
                 header.push_str(&format!("    _resource_{res}_last_grant = _tid;\n"));
             }
             ArbiterPolicy::Custom(_) => {
-                header.push_str(&format!("    _resource_{res}_last_grant_onehot = (1ULL << _tid);\n"));
+                header.push_str(&format!(
+                    "    _resource_{res}_last_grant_onehot = (1ULL << _tid);\n"
+                ));
             }
         }
         header.push_str("  }\n");
-        header.push_str(&format!("  void _resource_{res}_release(uint32_t _tid) {{\n"));
-        header.push_str(&format!("    if (_resource_{res}_holder == (int32_t)_tid) _resource_{res}_holder = -1;\n"));
+        header.push_str(&format!(
+            "  void _resource_{res}_release(uint32_t _tid) {{\n"
+        ));
+        header.push_str(&format!(
+            "    if (_resource_{res}_holder == (int32_t)_tid) _resource_{res}_holder = -1;\n"
+        ));
         header.push_str("  }\n");
     }
     Ok(())
@@ -2049,7 +2360,10 @@ fn emit_resource_reset(
     match &r.policy {
         ArbiterPolicy::Priority => {}
         ArbiterPolicy::RoundRobin => {
-            header.push_str(&format!("{pad}_resource_{res}_last_grant = {};\n", num_threads.saturating_sub(1)));
+            header.push_str(&format!(
+                "{pad}_resource_{res}_last_grant = {};\n",
+                num_threads.saturating_sub(1)
+            ));
         }
         ArbiterPolicy::Lru => {
             for idx in 0..num_threads {
@@ -2058,9 +2372,14 @@ fn emit_resource_reset(
         }
         ArbiterPolicy::Weighted(weight) => {
             let credit = eval_const_with_params(weight, params).max(1);
-            header.push_str(&format!("{pad}_resource_{res}_last_grant = {};\n", num_threads.saturating_sub(1)));
+            header.push_str(&format!(
+                "{pad}_resource_{res}_last_grant = {};\n",
+                num_threads.saturating_sub(1)
+            ));
             for idx in 0..num_threads {
-                header.push_str(&format!("{pad}_resource_{res}_credits[{idx}] = {credit};\n"));
+                header.push_str(&format!(
+                    "{pad}_resource_{res}_credits[{idx}] = {credit};\n"
+                ));
             }
         }
         ArbiterPolicy::Custom(_) => {

--- a/src/sim_credit_channel.rs
+++ b/src/sim_credit_channel.rs
@@ -47,13 +47,17 @@ pub enum CreditChannelRole {
 pub fn collect_credit_channels(m: &ModuleDecl, symbols: &SymbolTable) -> Vec<CreditChannelSite> {
     let mut out = Vec::new();
     for p in &m.ports {
-        let Some(ref bi) = p.bus_info else { continue; };
-        let Some((Symbol::Bus(info), _)) = symbols.globals.get(&bi.bus_name.name) else { continue; };
+        let Some(ref bi) = p.bus_info else {
+            continue;
+        };
+        let Some((Symbol::Bus(info), _)) = symbols.globals.get(&bi.bus_name.name) else {
+            continue;
+        };
         for cc in &info.credit_channels {
             let role = match (cc.role_dir, bi.perspective) {
                 (Direction::Out, BusPerspective::Initiator)
-                | (Direction::In, BusPerspective::Target)    => CreditChannelRole::Sender,
-                _                                             => CreditChannelRole::Receiver,
+                | (Direction::In, BusPerspective::Target) => CreditChannelRole::Sender,
+                _ => CreditChannelRole::Receiver,
             };
             out.push(CreditChannelSite {
                 port_name: p.name.name.clone(),
@@ -115,8 +119,10 @@ pub fn emit_constructor_inits(sites: &[CreditChannelSite], cpp: &mut String) {
                 // below when we have one, else fall through to 0.
                 let depth = depth_literal(&s.channel).unwrap_or(0);
                 cpp.push_str(&format!("  __{port}_{ch}_credit = {depth};\n"));
-                cpp.push_str(&format!("  __{port}_{ch}_can_send = {};\n",
-                    if depth != 0 { 1 } else { 0 }));
+                cpp.push_str(&format!(
+                    "  __{port}_{ch}_can_send = {};\n",
+                    if depth != 0 { 1 } else { 0 }
+                ));
             }
             CreditChannelRole::Receiver => {
                 let port = &s.port_name;
@@ -127,7 +133,9 @@ pub fn emit_constructor_inits(sites: &[CreditChannelSite], cpp: &mut String) {
                 cpp.push_str(&format!("  __{port}_{ch}_occ  = 0;\n"));
                 cpp.push_str(&format!("  __{port}_{ch}_valid = 0;\n"));
                 cpp.push_str(&format!("  __{port}_{ch}_data  = 0;\n"));
-                cpp.push_str(&format!("  for (uint32_t _i = 0; _i < {depth}; _i++) __{port}_{ch}_buf[_i] = 0;\n"));
+                cpp.push_str(&format!(
+                    "  for (uint32_t _i = 0; _i < {depth}; _i++) __{port}_{ch}_buf[_i] = 0;\n"
+                ));
             }
         }
     }
@@ -161,11 +169,19 @@ pub fn emit_posedge_updates(
                 cpp.push_str("  {\n");
                 if let Some(r) = rst_active {
                     cpp.push_str(&format!("    if ({r}) {{ {credit} = {depth}; }}\n"));
-                    cpp.push_str(&format!("    else if ({send_valid} && !{credit_ret}) {credit}--;\n"));
-                    cpp.push_str(&format!("    else if (!{send_valid} &&  {credit_ret}) {credit}++;\n"));
+                    cpp.push_str(&format!(
+                        "    else if ({send_valid} && !{credit_ret}) {credit}--;\n"
+                    ));
+                    cpp.push_str(&format!(
+                        "    else if (!{send_valid} &&  {credit_ret}) {credit}++;\n"
+                    ));
                 } else {
-                    cpp.push_str(&format!("    if ({send_valid} && !{credit_ret}) {credit}--;\n"));
-                    cpp.push_str(&format!("    else if (!{send_valid} &&  {credit_ret}) {credit}++;\n"));
+                    cpp.push_str(&format!(
+                        "    if ({send_valid} && !{credit_ret}) {credit}--;\n"
+                    ));
+                    cpp.push_str(&format!(
+                        "    else if (!{send_valid} &&  {credit_ret}) {credit}++;\n"
+                    ));
                 }
                 cpp.push_str("  }\n");
             }
@@ -174,23 +190,29 @@ pub fn emit_posedge_updates(
                 let ch = &s.channel.name.name;
                 let head = format!("__{port}_{ch}_head");
                 let tail = format!("__{port}_{ch}_tail");
-                let occ  = format!("__{port}_{ch}_occ");
+                let occ = format!("__{port}_{ch}_occ");
                 let valid = format!("__{port}_{ch}_valid");
                 let buf = format!("__{port}_{ch}_buf");
                 let push = format!("{port}_{ch}_send_valid");
-                let pushd= format!("{port}_{ch}_send_data");
+                let pushd = format!("{port}_{ch}_send_data");
                 let pop_drv = format!("{port}_{ch}_credit_return");
                 let (_data_ty, depth) = receiver_field_types(&s.channel);
                 cpp.push_str("  {\n");
                 if let Some(r) = rst_active {
-                    cpp.push_str(&format!("    if ({r}) {{ {head} = 0; {tail} = 0; {occ} = 0; }}\n"));
+                    cpp.push_str(&format!(
+                        "    if ({r}) {{ {head} = 0; {tail} = 0; {occ} = 0; }}\n"
+                    ));
                     cpp.push_str("    else {\n");
                 } else {
                     cpp.push_str("    {\n");
                 }
-                cpp.push_str(&format!("      uint8_t _pop_fire = ({pop_drv} && {valid}) ? 1 : 0;\n"));
+                cpp.push_str(&format!(
+                    "      uint8_t _pop_fire = ({pop_drv} && {valid}) ? 1 : 0;\n"
+                ));
                 cpp.push_str(&format!("      if ({push}) {{ {buf}[{tail}] = {pushd}; {tail} = ({tail} + 1) % {depth}; }}\n"));
-                cpp.push_str(&format!("      if (_pop_fire) {head} = ({head} + 1) % {depth};\n"));
+                cpp.push_str(&format!(
+                    "      if (_pop_fire) {head} = ({head} + 1) % {depth};\n"
+                ));
                 cpp.push_str(&format!("      if ({push} && !_pop_fire) {occ}++;\n"));
                 cpp.push_str(&format!("      else if (!{push} && _pop_fire) {occ}--;\n"));
                 cpp.push_str("    }\n");
@@ -240,9 +262,14 @@ pub fn emit_comb_updates(sites: &[CreditChannelSite], cpp: &mut String) {
 fn receiver_field_types(cc: &CreditChannelMeta) -> (&'static str, u64) {
     use crate::ast::{ExprKind, LitKind, ParamKind};
     // Pick cpp type based on T's declared bit width.
-    let t_ty = cc.params.iter()
+    let t_ty = cc
+        .params
+        .iter()
         .find(|p| p.name.name == "T")
-        .and_then(|p| match &p.kind { ParamKind::Type(te) => Some(te), _ => None });
+        .and_then(|p| match &p.kind {
+            ParamKind::Type(te) => Some(te),
+            _ => None,
+        });
     let w = t_ty.and_then(|te| match te {
         TypeExpr::UInt(w) | TypeExpr::SInt(w) => match &w.kind {
             ExprKind::Literal(LitKind::Dec(v))
@@ -255,7 +282,7 @@ fn receiver_field_types(cc: &CreditChannelMeta) -> (&'static str, u64) {
         _ => None,
     });
     let cpp_ty = match w {
-        Some(n) if n <= 8  => "uint8_t",
+        Some(n) if n <= 8 => "uint8_t",
         Some(n) if n <= 16 => "uint16_t",
         Some(n) if n <= 32 => "uint32_t",
         _ => "uint64_t",
@@ -270,7 +297,8 @@ fn receiver_field_types(cc: &CreditChannelMeta) -> (&'static str, u64) {
 /// leaving the counter at DEPTH evaluated from the port-site param map.
 fn depth_literal(cc: &CreditChannelMeta) -> Option<u64> {
     use crate::ast::{ExprKind, LitKind};
-    cc.params.iter()
+    cc.params
+        .iter()
         .find(|p| p.name.name == "DEPTH")
         .and_then(|p| p.default.as_ref())
         .and_then(|e| match &e.kind {
@@ -285,7 +313,8 @@ fn depth_literal(cc: &CreditChannelMeta) -> Option<u64> {
 /// Convenience: C++ type for the payload type of a credit_channel.
 /// Uses the declared `T` param default; no port-site override.
 pub fn payload_cpp_type(cc: &CreditChannelMeta) -> Option<TypeExpr> {
-    cc.params.iter()
+    cc.params
+        .iter()
         .find(|p| p.name.name == "T")
         .and_then(|p| match &p.kind {
             crate::ast::ParamKind::Type(te) => Some(te.clone()),

--- a/src/type_alias.rs
+++ b/src/type_alias.rs
@@ -34,14 +34,17 @@ pub fn resolve_type_aliases(mut ast: SourceFile) -> Result<SourceFile, Vec<Compi
             }
         }
     }
-    if errors.is_empty() { Ok(ast) } else { Err(errors) }
+    if errors.is_empty() {
+        Ok(ast)
+    } else {
+        Err(errors)
+    }
 }
 
 /// Resolved alias table: `name -> (TypeExpr, bus_params)`.
 type AliasMap = HashMap<String, (TypeExpr, Vec<ParamAssign>)>;
 
-const PRIMITIVE_TYPE_NAMES: &[&str] =
-    &["UInt", "SInt", "Bool", "Bit", "Clock", "Reset", "Vec"];
+const PRIMITIVE_TYPE_NAMES: &[&str] = &["UInt", "SInt", "Bool", "Bit", "Clock", "Reset", "Vec"];
 
 fn resolve_module(m: &mut ModuleDecl) -> Result<(), Vec<CompileError>> {
     let mut errors: Vec<CompileError> = Vec::new();
@@ -130,7 +133,11 @@ fn resolve_module(m: &mut ModuleDecl) -> Result<(), Vec<CompileError>> {
         // single bogus alias that was already errored on above).
     }
 
-    if errors.is_empty() { Ok(()) } else { Err(errors) }
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(errors)
+    }
 }
 
 /// Walk a TypeExpr; replace every `Named(name)` that matches an alias
@@ -196,7 +203,9 @@ fn alias_bus_params(ty: &TypeExpr, aliases: &AliasMap) -> Vec<ParamAssign> {
     let mut cur = ty;
     loop {
         match cur {
-            TypeExpr::Vec(inner, _) => { cur = inner; }
+            TypeExpr::Vec(inner, _) => {
+                cur = inner;
+            }
             TypeExpr::Named(ident) => {
                 if let Some((_, bus_params)) = aliases.get(&ident.name) {
                     return bus_params.clone();
@@ -496,8 +505,10 @@ fn substitute_in_expr(e: &mut Expr, aliases: &AliasMap, errors: &mut Vec<Compile
             substitute_in_expr(n, aliases, errors);
             substitute_in_expr(v, aliases, errors);
         }
-        ExprKind::Clog2(inner) | ExprKind::Onehot(inner)
-        | ExprKind::Signed(inner) | ExprKind::Unsigned(inner) => {
+        ExprKind::Clog2(inner)
+        | ExprKind::Onehot(inner)
+        | ExprKind::Signed(inner)
+        | ExprKind::Unsigned(inner) => {
             substitute_in_expr(inner, aliases, errors);
         }
         ExprKind::LatencyAt(inner, _) => substitute_in_expr(inner, aliases, errors),

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -15,7 +15,7 @@ pub enum Ty {
     FP32,
     /// bfloat16 (1+8+7 = 16 bits). Stored/carried as 16 bits.
     BF16,
-    Clock(String), // domain name
+    Clock(String),                // domain name
     Reset(ResetKind, ResetLevel), // always concrete (Param resolved during elaboration)
     Vec(Box<Ty>, u32),
     Struct(String),
@@ -35,14 +35,20 @@ impl Ty {
 #[derive(Clone)]
 pub(crate) enum HandshakePayloadGuard {
     Field(String),
-    ReqAck2PhasePending { req_field: String, ack_field: String },
+    ReqAck2PhasePending {
+        req_field: String,
+        ack_field: String,
+    },
 }
 
 impl HandshakePayloadGuard {
     fn display(&self, port: &str) -> String {
         match self {
             HandshakePayloadGuard::Field(field) => format!("{port}.{field}"),
-            HandshakePayloadGuard::ReqAck2PhasePending { req_field, ack_field } => {
+            HandshakePayloadGuard::ReqAck2PhasePending {
+                req_field,
+                ack_field,
+            } => {
                 format!("({port}.{req_field} != {port}.{ack_field})")
             }
         }
@@ -72,9 +78,16 @@ impl Ty {
             Ty::FP32 => "FP32".to_string(),
             Ty::BF16 => "BF16".to_string(),
             Ty::Clock(d) => format!("Clock<{d}>"),
-            Ty::Reset(k, l) => format!("Reset<{}, {}>",
-                match k { ResetKind::Sync => "Sync", ResetKind::Async => "Async" },
-                match l { ResetLevel::High => "High", ResetLevel::Low => "Low" },
+            Ty::Reset(k, l) => format!(
+                "Reset<{}, {}>",
+                match k {
+                    ResetKind::Sync => "Sync",
+                    ResetKind::Async => "Async",
+                },
+                match l {
+                    ResetLevel::High => "High",
+                    ResetLevel::Low => "Low",
+                },
             ),
             Ty::Vec(inner, n) => format!("Vec<{}, {n}>", inner.display()),
             Ty::Struct(name) => name.clone(),
@@ -126,7 +139,9 @@ impl<'a> TypeChecker<'a> {
         }
     }
 
-    pub fn check(mut self) -> Result<(Vec<CompileWarning>, HashMap<usize, usize>), Vec<CompileError>> {
+    pub fn check(
+        mut self,
+    ) -> Result<(Vec<CompileWarning>, HashMap<usize, usize>), Vec<CompileError>> {
         // Global pre-pass: scan every compile-time expression for divide-by-zero
         // whose divisor is a reducible constant. Catches bad param defaults, etc.
         // Runs before per-item checks so reported errors sort naturally.
@@ -164,19 +179,19 @@ impl<'a> TypeChecker<'a> {
 
     fn item_params(item: &Item) -> Vec<ParamDecl> {
         match item {
-            Item::Module(m)       => m.params.clone(),
-            Item::Fsm(f)          => f.params.clone(),
-            Item::Fifo(f)         => f.params.clone(),
-            Item::Ram(r)          => r.params.clone(),
-            Item::Cam(c)          => c.params.clone(),
-            Item::Counter(c)      => c.params.clone(),
-            Item::Arbiter(a)      => a.params.clone(),
-            Item::Regfile(r)      => r.params.clone(),
-            Item::Pipeline(p)     => p.params.clone(),
-            Item::Linklist(l)     => l.params.clone(),
+            Item::Module(m) => m.params.clone(),
+            Item::Fsm(f) => f.params.clone(),
+            Item::Fifo(f) => f.params.clone(),
+            Item::Ram(r) => r.params.clone(),
+            Item::Cam(c) => c.params.clone(),
+            Item::Counter(c) => c.params.clone(),
+            Item::Arbiter(a) => a.params.clone(),
+            Item::Regfile(r) => r.params.clone(),
+            Item::Pipeline(p) => p.params.clone(),
+            Item::Linklist(l) => l.params.clone(),
             Item::Synchronizer(s) => s.params.clone(),
-            Item::Clkgate(c)      => c.params.clone(),
-            Item::Package(p)      => p.params.clone(),
+            Item::Clkgate(c) => c.params.clone(),
+            Item::Package(p) => p.params.clone(),
             _ => Vec::new(),
         }
     }
@@ -193,18 +208,24 @@ impl<'a> TypeChecker<'a> {
             // Pick a span for the warning: the span of the first owning
             // module in the SCC (top-level module if vec![]). Fall back
             // to the first item's span.
-            let span: Span = scc.owning_modules.iter()
+            let span: Span = scc
+                .owning_modules
+                .iter()
                 .filter_map(|mn| {
                     self.source.items.iter().find_map(|it| {
                         if let Item::Module(m) = it {
-                            if &m.name.name == mn { return Some(m.span); }
+                            if &m.name.name == mn {
+                                return Some(m.span);
+                            }
                         }
                         None
                     })
                 })
                 .next()
                 .unwrap_or_else(|| {
-                    self.source.items.first()
+                    self.source
+                        .items
+                        .first()
                         .map(|it| it.span())
                         .unwrap_or(Span { start: 0, end: 0 })
                 });
@@ -222,15 +243,15 @@ impl<'a> TypeChecker<'a> {
                 path_str.join(" -> "),
                 if path_str.is_empty() { String::new() } else { format!(" -> {}", path_str[0]) },
             );
-            self.warnings.push(CompileWarning {
-                message: msg,
-                span,
-            });
+            self.warnings.push(CompileWarning { message: msg, span });
         }
         // Summary line emitted as a single warning so it shows up in the
         // standard warning stream.
         if analysis.total_sccs > 0 {
-            let span = self.source.items.first()
+            let span = self
+                .source
+                .items
+                .first()
                 .map(|it| it.span())
                 .unwrap_or(Span { start: 0, end: 0 });
             let summary = format!(
@@ -260,36 +281,59 @@ impl<'a> TypeChecker<'a> {
         let mut kind_of: std::collections::HashMap<String, &'static str> =
             std::collections::HashMap::new();
         for p in &m.ports {
-            let k = if p.reg_info.is_some() { "port_reg" }
-                    else if p.direction == Direction::In { "input_port" }
-                    else { "comb_port" };
+            let k = if p.reg_info.is_some() {
+                "port_reg"
+            } else if p.direction == Direction::In {
+                "input_port"
+            } else {
+                "comb_port"
+            };
             kind_of.insert(p.name.name.clone(), k);
         }
         for item in &m.body {
             match item {
-                ModuleBodyItem::RegDecl(r)     => { kind_of.insert(r.name.name.clone(), "reg"); }
-                ModuleBodyItem::PipeRegDecl(p) => { kind_of.insert(p.name.name.clone(), "pipe_reg"); }
-                ModuleBodyItem::WireDecl(w)    => { kind_of.insert(w.name.name.clone(), "wire"); }
-                ModuleBodyItem::LetBinding(l)  => { kind_of.insert(l.name.name.clone(), "let"); }
-                ModuleBodyItem::Inst(i)        => { kind_of.insert(i.name.name.clone(), "inst_name"); }
+                ModuleBodyItem::RegDecl(r) => {
+                    kind_of.insert(r.name.name.clone(), "reg");
+                }
+                ModuleBodyItem::PipeRegDecl(p) => {
+                    kind_of.insert(p.name.name.clone(), "pipe_reg");
+                }
+                ModuleBodyItem::WireDecl(w) => {
+                    kind_of.insert(w.name.name.clone(), "wire");
+                }
+                ModuleBodyItem::LetBinding(l) => {
+                    kind_of.insert(l.name.name.clone(), "let");
+                }
+                ModuleBodyItem::Inst(i) => {
+                    kind_of.insert(i.name.name.clone(), "inst_name");
+                }
                 _ => {}
             }
         }
 
         for item in &m.body {
-            let inst = match item { ModuleBodyItem::Inst(i) => i, _ => continue };
+            let inst = match item {
+                ModuleBodyItem::Inst(i) => i,
+                _ => continue,
+            };
             // Resolve the target — only regfile constructs matter.
             let target = self.source.items.iter().find_map(|it| match it {
-                Item::Regfile(rf) if rf.name.name == inst.module_name.name => Some((rf.kind, rf.flops)),
+                Item::Regfile(rf) if rf.name.name == inst.module_name.name => {
+                    Some((rf.kind, rf.flops))
+                }
                 _ => None,
             });
-            let Some((crate::ast::RegfileKind::Latch, flops)) = target else { continue };
+            let Some((crate::ast::RegfileKind::Latch, flops)) = target else {
+                continue;
+            };
             // `flops: internal` means the regfile auto-emits its own wdata_q /
             // waddr_q sample flops + per-row ICG, so the caller is allowed to
             // drive write pins combinationally — skip the static flop-source
             // check entirely. (`flops: external` is the default; caller must
             // pre-flop, which is the property this check enforces.)
-            if matches!(flops, crate::ast::RegfileFlops::Internal) { continue; }
+            if matches!(flops, crate::ast::RegfileFlops::Internal) {
+                continue;
+            }
 
             for c in &inst.connections {
                 // Latch-RF write-port pins follow the "<pfx>_addr" / "<pfx>_addr"
@@ -299,8 +343,12 @@ impl<'a> TypeChecker<'a> {
                 let pname = &c.port_name.name;
                 let is_addr = pname.ends_with("_addr") || pname.ends_with("_waddr");
                 let is_data = pname.ends_with("_data") || pname.ends_with("_wdata");
-                if !(is_addr || is_data) { continue; }
-                if c.direction != ConnectDir::Input { continue; }
+                if !(is_addr || is_data) {
+                    continue;
+                }
+                if c.direction != ConnectDir::Input {
+                    continue;
+                }
 
                 // Walk the signal expression: accept Ident, Member, Index by
                 // const ident; reject anything else (Binary / Unary / arbitrary
@@ -312,8 +360,8 @@ impl<'a> TypeChecker<'a> {
                 };
                 let pin_label = if is_addr { "addr" } else { "data" };
                 match what {
-                    Some("reg") | Some("port_reg") | Some("pipe_reg")
-                    | Some("input_port") | Some("inst_name") | Some("inst_output") => {
+                    Some("reg") | Some("port_reg") | Some("pipe_reg") | Some("input_port")
+                    | Some("inst_name") | Some("inst_output") => {
                         // OK — register-typed source (or boundary trust).
                     }
                     Some("wire") | Some("let") => {
@@ -357,15 +405,15 @@ impl<'a> TypeChecker<'a> {
     pub(crate) fn check_const_div_zero(&mut self) {
         fn params_of(item: &Item) -> &[ParamDecl] {
             match item {
-                Item::Module(m)       => &m.params,
-                Item::Fsm(f)          => &f.params,
-                Item::Fifo(f)         => &f.params,
-                Item::Ram(r)          => &r.params,
-                Item::Cam(c)          => &c.params,
-                Item::Counter(c)      => &c.params,
-                Item::Arbiter(a)      => &a.params,
-                Item::Regfile(r)      => &r.params,
-                Item::Pipeline(p)     => &p.params,
+                Item::Module(m) => &m.params,
+                Item::Fsm(f) => &f.params,
+                Item::Fifo(f) => &f.params,
+                Item::Ram(r) => &r.params,
+                Item::Cam(c) => &c.params,
+                Item::Counter(c) => &c.params,
+                Item::Arbiter(a) => &a.params,
+                Item::Regfile(r) => &r.params,
+                Item::Pipeline(p) => &p.params,
                 Item::Synchronizer(s) => &s.params,
                 _ => &[],
             }
@@ -394,13 +442,19 @@ impl<'a> TypeChecker<'a> {
         }
         for sp in report_sites {
             self.errors.push(CompileError::General {
-                message: "divide by zero in constant expression: divisor evaluates to 0".to_string(),
+                message: "divide by zero in constant expression: divisor evaluates to 0"
+                    .to_string(),
                 span: span_to_source_span(sp),
             });
         }
     }
 
-    fn scan_expr_for_div_zero(&self, e: &Expr, local_types: &HashMap<String, Ty>, out: &mut Vec<Span>) {
+    fn scan_expr_for_div_zero(
+        &self,
+        e: &Expr,
+        local_types: &HashMap<String, Ty>,
+        out: &mut Vec<Span>,
+    ) {
         match &e.kind {
             ExprKind::Binary(op, lhs, rhs) => {
                 self.scan_expr_for_div_zero(lhs, local_types, out);
@@ -431,14 +485,20 @@ impl<'a> TypeChecker<'a> {
             }
             ExprKind::MethodCall(base, _, args) => {
                 self.scan_expr_for_div_zero(base, local_types, out);
-                for a in args { self.scan_expr_for_div_zero(a, local_types, out); }
+                for a in args {
+                    self.scan_expr_for_div_zero(a, local_types, out);
+                }
             }
             ExprKind::FunctionCall(_, args) => {
-                for a in args { self.scan_expr_for_div_zero(a, local_types, out); }
+                for a in args {
+                    self.scan_expr_for_div_zero(a, local_types, out);
+                }
             }
             ExprKind::Clog2(a) => self.scan_expr_for_div_zero(a, local_types, out),
             ExprKind::Concat(parts) => {
-                for p in parts { self.scan_expr_for_div_zero(p, local_types, out); }
+                for p in parts {
+                    self.scan_expr_for_div_zero(p, local_types, out);
+                }
             }
             ExprKind::FieldAccess(base, _) => self.scan_expr_for_div_zero(base, local_types, out),
             _ => {}
@@ -517,10 +577,16 @@ impl<'a> TypeChecker<'a> {
         }
         for item in &m.body {
             match item {
-                ModuleBodyItem::RegDecl(r)    => float_decls.push((&r.ty, r.name.span, r.name.name.clone())),
-                ModuleBodyItem::WireDecl(w)   => float_decls.push((&w.ty, w.name.span, w.name.name.clone())),
+                ModuleBodyItem::RegDecl(r) => {
+                    float_decls.push((&r.ty, r.name.span, r.name.name.clone()))
+                }
+                ModuleBodyItem::WireDecl(w) => {
+                    float_decls.push((&w.ty, w.name.span, w.name.name.clone()))
+                }
                 ModuleBodyItem::LetBinding(l) => {
-                    if let Some(t) = l.ty.as_ref() { float_decls.push((t, l.name.span, l.name.name.clone())); }
+                    if let Some(t) = l.ty.as_ref() {
+                        float_decls.push((t, l.name.span, l.name.name.clone()));
+                    }
                 }
                 _ => {}
             }
@@ -546,8 +612,20 @@ impl<'a> TypeChecker<'a> {
                         RegReset::None => None,
                     };
                     if let Some(v) = val {
-                        if matches!(&v.kind, ExprKind::Literal(LitKind::Dec(_) | LitKind::Hex(_) | LitKind::Bin(_) | LitKind::Sized(_, _))) {
-                            let tn = if matches!(r.ty, TypeExpr::FP32) { "FP32" } else { "BF16" };
+                        if matches!(
+                            &v.kind,
+                            ExprKind::Literal(
+                                LitKind::Dec(_)
+                                    | LitKind::Hex(_)
+                                    | LitKind::Bin(_)
+                                    | LitKind::Sized(_, _)
+                            )
+                        ) {
+                            let tn = if matches!(r.ty, TypeExpr::FP32) {
+                                "FP32"
+                            } else {
+                                "BF16"
+                            };
                             self.errors.push(CompileError::general(
                                 &format!("float `reg {}: {tn}` reset value must be a float literal (e.g. `=> 0.0`), not an integer literal", r.name.name),
                                 v.span,
@@ -562,11 +640,24 @@ impl<'a> TypeChecker<'a> {
         let mut driven: HashSet<String> = HashSet::new();
 
         // Collect reg names for comb target validation (includes port reg ports)
-        let reg_names: HashSet<String> = m.body.iter().filter_map(|item| {
-            if let ModuleBodyItem::RegDecl(r) = item { Some(r.name.name.clone()) } else { None }
-        }).chain(m.ports.iter().filter_map(|p| {
-            if p.reg_info.is_some() { Some(p.name.name.clone()) } else { None }
-        })).collect();
+        let reg_names: HashSet<String> = m
+            .body
+            .iter()
+            .filter_map(|item| {
+                if let ModuleBodyItem::RegDecl(r) = item {
+                    Some(r.name.name.clone())
+                } else {
+                    None
+                }
+            })
+            .chain(m.ports.iter().filter_map(|p| {
+                if p.reg_info.is_some() {
+                    Some(p.name.name.clone())
+                } else {
+                    None
+                }
+            }))
+            .collect();
 
         // Validate `guard <sig>` annotations: signal must exist in scope and be Bool.
         self.check_guards(m);
@@ -592,7 +683,9 @@ impl<'a> TypeChecker<'a> {
             if p.bus_info.is_some() {
                 // Bus ports: validate bus exists, register as a special type
                 if let Some(ref bi) = p.bus_info {
-                    if let Some((crate::resolve::Symbol::Bus(_), _)) = self.symbols.globals.get(&bi.bus_name.name) {
+                    if let Some((crate::resolve::Symbol::Bus(_), _)) =
+                        self.symbols.globals.get(&bi.bus_name.name)
+                    {
                         local_types.insert(p.name.name.clone(), Ty::Bus(bi.bus_name.name.clone()));
                     } else {
                         self.errors.push(CompileError::general(
@@ -642,10 +735,11 @@ impl<'a> TypeChecker<'a> {
                                 self.symbols.globals.get(sname)
                             {
                                 for bind in &l.destructure_fields {
-                                    if let Some((_, fty)) = info.fields.iter()
-                                        .find(|(fname, _)| fname == &bind.name)
+                                    if let Some((_, fty)) =
+                                        info.fields.iter().find(|(fname, _)| fname == &bind.name)
                                     {
-                                        let bty = self.resolve_type_expr(fty, &m.name.name, &local_types);
+                                        let bty =
+                                            self.resolve_type_expr(fty, &m.name.name, &local_types);
                                         local_types.insert(bind.name.clone(), bty);
                                     }
                                 }
@@ -730,7 +824,13 @@ impl<'a> TypeChecker<'a> {
                 }
                 ModuleBodyItem::CombBlock(cb) => {
                     for stmt in &cb.stmts {
-                        self.check_comb_stmt(stmt, &m.name.name, &local_types, &mut driven, &reg_names);
+                        self.check_comb_stmt(
+                            stmt,
+                            &m.name.name,
+                            &local_types,
+                            &mut driven,
+                            &reg_names,
+                        );
                     }
                     self.check_comb_latch(&cb.stmts, cb.span);
                 }
@@ -747,7 +847,10 @@ impl<'a> TypeChecker<'a> {
                         let Ty::Struct(sname) = &rhs_ty else {
                             if rhs_ty != Ty::Error {
                                 self.errors.push(CompileError::general(
-                                    &format!("destructuring `let` requires a struct-typed RHS, got `{}`", rhs_ty.display()),
+                                    &format!(
+                                        "destructuring `let` requires a struct-typed RHS, got `{}`",
+                                        rhs_ty.display()
+                                    ),
                                     l.value.span,
                                 ));
                             }
@@ -787,7 +890,10 @@ impl<'a> TypeChecker<'a> {
                             let field = info.fields.iter().find(|(fname, _)| fname == &bind.name);
                             if field.is_none() {
                                 self.errors.push(CompileError::general(
-                                    &format!("struct `{}` has no field named `{}`", sname, bind.name),
+                                    &format!(
+                                        "struct `{}` has no field named `{}`",
+                                        sname, bind.name
+                                    ),
                                     bind.span,
                                 ));
                                 continue;
@@ -811,9 +917,16 @@ impl<'a> TypeChecker<'a> {
                         // `let x = expr;` without type annotation — assign to existing port/wire
                         let name = &l.name.name;
                         // Check if it's an input port
-                        let is_input_port = m.ports.iter().any(|p| &p.name.name == name && p.direction == Direction::In);
+                        let is_input_port = m
+                            .ports
+                            .iter()
+                            .any(|p| &p.name.name == name && p.direction == Direction::In);
                         // Check if it's an output port (non-reg)
-                        let is_output_port = m.ports.iter().any(|p| &p.name.name == name && p.direction == Direction::Out && p.reg_info.is_none());
+                        let is_output_port = m.ports.iter().any(|p| {
+                            &p.name.name == name
+                                && p.direction == Direction::Out
+                                && p.reg_info.is_none()
+                        });
                         // Check if it's a reg (declared reg or port-reg)
                         let is_reg = reg_names.contains(name);
 
@@ -829,9 +942,12 @@ impl<'a> TypeChecker<'a> {
                             ));
                         } else if is_output_port {
                             // Comb assignment to output port
-                            let rhs_ty = self.resolve_expr_type(&l.value, &m.name.name, &local_types);
+                            let rhs_ty =
+                                self.resolve_expr_type(&l.value, &m.name.name, &local_types);
                             if let Some(port_ty) = local_types.get(name).cloned() {
-                                if rhs_ty != Ty::Error && rhs_ty != Ty::Todo && port_ty != rhs_ty
+                                if rhs_ty != Ty::Error
+                                    && rhs_ty != Ty::Todo
+                                    && port_ty != rhs_ty
                                     && !types_compatible(&port_ty, &rhs_ty)
                                 {
                                     self.errors.push(CompileError::type_mismatch(
@@ -851,9 +967,12 @@ impl<'a> TypeChecker<'a> {
                             }
                         } else if local_types.contains_key(name) {
                             // Wire or previously declared let
-                            let rhs_ty = self.resolve_expr_type(&l.value, &m.name.name, &local_types);
+                            let rhs_ty =
+                                self.resolve_expr_type(&l.value, &m.name.name, &local_types);
                             if let Some(wire_ty) = local_types.get(name).cloned() {
-                                if rhs_ty != Ty::Error && rhs_ty != Ty::Todo && wire_ty != rhs_ty
+                                if rhs_ty != Ty::Error
+                                    && rhs_ty != Ty::Todo
+                                    && wire_ty != rhs_ty
                                     && !types_compatible(&wire_ty, &rhs_ty)
                                 {
                                     self.errors.push(CompileError::type_mismatch(
@@ -881,8 +1000,12 @@ impl<'a> TypeChecker<'a> {
                     } else {
                         let ty = self.resolve_expr_type(&l.value, &m.name.name, &local_types);
                         if let Some(declared_ty) = &l.ty {
-                            let expected = self.resolve_type_expr(declared_ty, &m.name.name, &local_types);
-                            if expected != Ty::Error && ty != Ty::Error && ty != Ty::Todo && expected != ty
+                            let expected =
+                                self.resolve_type_expr(declared_ty, &m.name.name, &local_types);
+                            if expected != Ty::Error
+                                && ty != Ty::Error
+                                && ty != Ty::Todo
+                                && expected != ty
                                 && !types_compatible(&expected, &ty)
                             {
                                 self.errors.push(CompileError::type_mismatch(
@@ -926,12 +1049,18 @@ impl<'a> TypeChecker<'a> {
                     }
                     if !local_types.contains_key(&p.source.name) {
                         self.errors.push(CompileError::general(
-                            &format!("pipe_reg '{}': source signal '{}' not found", p.name.name, p.source.name),
+                            &format!(
+                                "pipe_reg '{}': source signal '{}' not found",
+                                p.name.name, p.source.name
+                            ),
                             p.source.span,
                         ));
                     }
                     // Update type from pre-pass placeholder (Ty::Error) to actual source type
-                    let ty = local_types.get(&p.source.name).cloned().unwrap_or(Ty::Error);
+                    let ty = local_types
+                        .get(&p.source.name)
+                        .cloned()
+                        .unwrap_or(Ty::Error);
                     local_types.insert(p.name.name.clone(), ty);
                     driven.insert(p.name.name.clone());
                 }
@@ -957,10 +1086,12 @@ impl<'a> TypeChecker<'a> {
                             // check_inst_decl's static-inst handling.
                             let inst_module_ports: Option<&[crate::ast::PortDecl]> =
                                 self.source.items.iter().find_map(|item| match item {
-                                    Item::Module(m2) if m2.name.name == inst.module_name.name
-                                        => Some(m2.ports.as_slice()),
-                                    Item::Fsm(f2) if f2.name.name == inst.module_name.name
-                                        => Some(f2.ports.as_slice()),
+                                    Item::Module(m2) if m2.name.name == inst.module_name.name => {
+                                        Some(m2.ports.as_slice())
+                                    }
+                                    Item::Fsm(f2) if f2.name.name == inst.module_name.name => {
+                                        Some(f2.ports.as_slice())
+                                    }
                                     _ => None,
                                 });
                             for conn in &inst.connections {
@@ -986,7 +1117,8 @@ impl<'a> TypeChecker<'a> {
                                     // a loop variable, conservatively mark ALL N
                                     // (each sibling unroll iteration fills one).
                                     let inst_bus_info = inst_module_ports.and_then(|ports| {
-                                        ports.iter()
+                                        ports
+                                            .iter()
                                             .find(|p| p.name.name == conn.port_name.name)
                                             .and_then(|p| p.bus_info.as_ref())
                                     });
@@ -1003,10 +1135,18 @@ impl<'a> TypeChecker<'a> {
                                                 ExprKind::Ident(n) => vec![n.clone()],
                                                 ExprKind::Index(arr, idx) => {
                                                     if let ExprKind::Ident(arr_name) = &arr.kind {
-                                                        if let ExprKind::Literal(LitKind::Dec(i)) = &idx.kind {
+                                                        if let ExprKind::Literal(LitKind::Dec(i)) =
+                                                            &idx.kind
+                                                        {
                                                             vec![format!("{}_{}", arr_name, i)]
-                                                        } else if let Some(&n) = self.vec_of_bus_ports.get(arr_name) {
-                                                            (0..n).map(|i| format!("{}_{}", arr_name, i)).collect()
+                                                        } else if let Some(&n) =
+                                                            self.vec_of_bus_ports.get(arr_name)
+                                                        {
+                                                            (0..n)
+                                                                .map(|i| {
+                                                                    format!("{}_{}", arr_name, i)
+                                                                })
+                                                                .collect()
                                                         } else {
                                                             Vec::new()
                                                         }
@@ -1023,7 +1163,10 @@ impl<'a> TypeChecker<'a> {
                                                         BusPerspective::Target => (*sdir).flip(),
                                                     };
                                                     if inst_dir == Direction::Out {
-                                                        driven.insert(format!("{}_{}", prefix, sname));
+                                                        driven.insert(format!(
+                                                            "{}_{}",
+                                                            prefix, sname
+                                                        ));
                                                     }
                                                 }
                                             }
@@ -1042,28 +1185,38 @@ impl<'a> TypeChecker<'a> {
                     // bodies is light in Phase 1 (the spike emitter rejects
                     // unsupported shapes itself).
                     let vob_ports = self.vec_of_bus_ports.clone();
-                    fn mark_target(target: &crate::ast::Expr, driven: &mut HashSet<String>,
-                                   vob_ports: &HashMap<String, u32>) {
+                    fn mark_target(
+                        target: &crate::ast::Expr,
+                        driven: &mut HashSet<String>,
+                        vob_ports: &HashMap<String, u32>,
+                    ) {
                         // Bare Ident, `bus.sig`, `arr[i].sig`, `arr[i]` all flow
                         // through expr_flat_name_tc / expr_root_name_tc the same
                         // way they do for comb-block targets — ensures bus-port
                         // outputs assigned inside thread bodies satisfy the
                         // driver-completeness check.
                         let root = TypeChecker::expr_root_name_tc(target);
-                        if !root.is_empty() { driven.insert(root.clone()); }
+                        if !root.is_empty() {
+                            driven.insert(root.clone());
+                        }
                         let flat = TypeChecker::expr_flat_name_tc(target);
-                        if !flat.is_empty() && flat != root { driven.insert(flat.clone()); }
+                        if !flat.is_empty() && flat != root {
+                            driven.insert(flat.clone());
+                        }
                         // Indexed Vec-of-bus target with a non-literal idx —
                         // mirror the comb-block handling: mark every flat copy.
                         if let crate::ast::ExprKind::FieldAccess(base, field) = &target.kind {
                             if let crate::ast::ExprKind::Index(arr, idx) = &base.kind {
                                 if let crate::ast::ExprKind::Ident(arr_name) = &arr.kind {
-                                    let is_lit = matches!(&idx.kind,
-                                        crate::ast::ExprKind::Literal(_));
+                                    let is_lit =
+                                        matches!(&idx.kind, crate::ast::ExprKind::Literal(_));
                                     if !is_lit {
                                         if let Some(&n) = vob_ports.get(arr_name) {
                                             for i in 0..n {
-                                                driven.insert(format!("{}_{}_{}", arr_name, i, field.name));
+                                                driven.insert(format!(
+                                                    "{}_{}_{}",
+                                                    arr_name, i, field.name
+                                                ));
                                             }
                                         }
                                     }
@@ -1071,23 +1224,36 @@ impl<'a> TypeChecker<'a> {
                             }
                         }
                     }
-                    fn walk_thread(stmts: &[crate::ast::ThreadStmt], driven: &mut HashSet<String>,
-                                   vob_ports: &HashMap<String, u32>) {
+                    fn walk_thread(
+                        stmts: &[crate::ast::ThreadStmt],
+                        driven: &mut HashSet<String>,
+                        vob_ports: &HashMap<String, u32>,
+                    ) {
                         use crate::ast::ThreadStmt;
                         for s in stmts {
                             match s {
-                                ThreadStmt::CombAssign(a) => mark_target(&a.target, driven, vob_ports),
-                                ThreadStmt::SeqAssign(a)  => mark_target(&a.target, driven, vob_ports),
-                                ThreadStmt::ForkTlmAssign(a) => mark_target(&a.target, driven, vob_ports),
+                                ThreadStmt::CombAssign(a) => {
+                                    mark_target(&a.target, driven, vob_ports)
+                                }
+                                ThreadStmt::SeqAssign(a) => {
+                                    mark_target(&a.target, driven, vob_ports)
+                                }
+                                ThreadStmt::ForkTlmAssign(a) => {
+                                    mark_target(&a.target, driven, vob_ports)
+                                }
                                 ThreadStmt::IfElse(ie) => {
                                     walk_thread(&ie.then_stmts, driven, vob_ports);
                                     walk_thread(&ie.else_stmts, driven, vob_ports);
                                 }
                                 ThreadStmt::For { body, .. }
                                 | ThreadStmt::Lock { body, .. }
-                                | ThreadStmt::DoUntil { body, .. } => walk_thread(body, driven, vob_ports),
+                                | ThreadStmt::DoUntil { body, .. } => {
+                                    walk_thread(body, driven, vob_ports)
+                                }
                                 ThreadStmt::ForkJoin(branches, _) => {
-                                    for b in branches { walk_thread(b, driven, vob_ports); }
+                                    for b in branches {
+                                        walk_thread(b, driven, vob_ports);
+                                    }
                                 }
                                 _ => {}
                             }
@@ -1148,7 +1314,8 @@ impl<'a> TypeChecker<'a> {
 
         // Multi-driver check (SFG Check 1, closes #375)
         let sfg_drivers = crate::signal_flow::collect_module_drivers(m, self.source);
-        self.errors.extend(crate::signal_flow::check_multi_driver(m, &sfg_drivers));
+        self.errors
+            .extend(crate::signal_flow::check_multi_driver(m, &sfg_drivers));
 
         // Check all output ports are driven
         for p in &m.ports {
@@ -1156,14 +1323,22 @@ impl<'a> TypeChecker<'a> {
                 // Bus port: check each output signal is driven (flattened name: port_signal).
                 // For Vec<Bus,N> ports, check each of the N copies independently.
                 let bus_name = &bi.bus_name.name;
-                if let Some((crate::resolve::Symbol::Bus(info), _)) = self.symbols.globals.get(bus_name) {
+                if let Some((crate::resolve::Symbol::Bus(info), _)) =
+                    self.symbols.globals.get(bus_name)
+                {
                     let mut pm = info.default_param_map();
-                    for pa in &bi.params { pm.insert(pa.name.name.clone(), &pa.value); }
+                    for pa in &bi.params {
+                        pm.insert(pa.name.name.clone(), &pa.value);
+                    }
                     let eff = info.effective_signals(&pm);
                     let prefixes: Vec<String> = match bi.count.as_ref() {
                         None => vec![p.name.name.clone()],
                         Some(_) => {
-                            let n = self.vec_of_bus_ports.get(&p.name.name).copied().unwrap_or(0);
+                            let n = self
+                                .vec_of_bus_ports
+                                .get(&p.name.name)
+                                .copied()
+                                .unwrap_or(0);
                             (0..n).map(|i| format!("{}_{}", p.name.name, i)).collect()
                         }
                     };
@@ -1195,10 +1370,16 @@ impl<'a> TypeChecker<'a> {
 
         // ── CDC check: detect cross-domain register reads ─────────────────────
         // Build clock port → domain name map
-        let clk_domain: HashMap<String, String> = m.ports.iter()
-            .filter_map(|p| if let TypeExpr::Clock(domain) = &p.ty {
-                Some((p.name.name.clone(), domain.name.clone()))
-            } else { None })
+        let clk_domain: HashMap<String, String> = m
+            .ports
+            .iter()
+            .filter_map(|p| {
+                if let TypeExpr::Clock(domain) = &p.ty {
+                    Some((p.name.name.clone(), domain.name.clone()))
+                } else {
+                    None
+                }
+            })
             .collect();
 
         // Phase 1 RDC + the surrounding CDC pass share this gate.
@@ -1260,7 +1441,9 @@ impl<'a> TypeChecker<'a> {
                                 // Check if any seq block in a different domain reads this target
                                 for item2 in &m.body {
                                     if let ModuleBodyItem::RegBlock(rb) = item2 {
-                                        if let Some(consumer_domain) = clk_domain.get(&rb.clock.name) {
+                                        if let Some(consumer_domain) =
+                                            clk_domain.get(&rb.clock.name)
+                                        {
                                             let mut seq_reads = HashSet::new();
                                             Self::collect_stmt_reads(&rb.stmts, &mut seq_reads);
                                             if seq_reads.contains(target) {
@@ -1306,18 +1489,30 @@ impl<'a> TypeChecker<'a> {
             // makes async cross-domain reset dangerous doesn't apply. If
             // false-negatives become an issue, broaden by removing the
             // is-async filter below.
-            let async_reset_ports: HashSet<String> = m.ports.iter()
-                .filter_map(|p| if let TypeExpr::Reset(ResetKind::Async, _) = &p.ty {
-                    Some(p.name.name.clone())
-                } else { None })
+            let async_reset_ports: HashSet<String> = m
+                .ports
+                .iter()
+                .filter_map(|p| {
+                    if let TypeExpr::Reset(ResetKind::Async, _) = &p.ty {
+                        Some(p.name.name.clone())
+                    } else {
+                        None
+                    }
+                })
                 .collect();
             // Tracks (reset_signal_name → set of (clock_domain, conflict span)).
             // Span carries the first reg-decl that introduced each domain so
             // the diagnostic can point at the offending site. Both inline
             // `reg` decls and `port reg` decls participate.
-            let mut reset_users: HashMap<String, Vec<(String, crate::lexer::Span)>> = HashMap::new();
-            let record_reset = |sig: &str, reg_name: &str, span: crate::lexer::Span,
-                                    reset_users: &mut HashMap<String, Vec<(String, crate::lexer::Span)>>| {
+            let mut reset_users: HashMap<String, Vec<(String, crate::lexer::Span)>> =
+                HashMap::new();
+            let record_reset = |sig: &str,
+                                reg_name: &str,
+                                span: crate::lexer::Span,
+                                reset_users: &mut HashMap<
+                String,
+                Vec<(String, crate::lexer::Span)>,
+            >| {
                 if let Some(domain) = reg_domain.get(reg_name) {
                     let entry = reset_users.entry(sig.to_string()).or_default();
                     if !entry.iter().any(|(d, _)| d == domain) {
@@ -1332,7 +1527,9 @@ impl<'a> TypeChecker<'a> {
                         RegReset::Explicit(s, _, _, _) => s.name.clone(),
                         RegReset::Inherit(s, _) => s.name.clone(),
                     };
-                    if !async_reset_ports.contains(&sig_name) { continue; }
+                    if !async_reset_ports.contains(&sig_name) {
+                        continue;
+                    }
                     record_reset(&sig_name, &rd.name.name, rd.name.span, &mut reset_users);
                 }
             }
@@ -1343,7 +1540,9 @@ impl<'a> TypeChecker<'a> {
                         RegReset::Explicit(s, _, _, _) => s.name.clone(),
                         RegReset::Inherit(s, _) => s.name.clone(),
                     };
-                    if !async_reset_ports.contains(&sig_name) { continue; }
+                    if !async_reset_ports.contains(&sig_name) {
+                        continue;
+                    }
                     record_reset(&sig_name, &p.name.name, p.name.span, &mut reset_users);
                 }
             }
@@ -1449,225 +1648,282 @@ impl<'a> TypeChecker<'a> {
     /// Extracted from `check_module`'s main pass for readability — the
     /// original arm was 122 lines.
     pub(crate) fn check_inst_decl(&mut self, inst: &InstDecl, driven: &mut HashSet<String>) {
-            self.check_snake_case(&inst.name);
-            // Find the target construct's bus port info for whole-bus expansion
-            let target_bus_ports: Vec<(String, String)> = self.source.items.iter()
-                .find_map(|item| match item {
-                    Item::Module(m2) if m2.name.name == inst.module_name.name => Some(m2.ports.as_slice()),
-                    Item::Fsm(f2) if f2.name.name == inst.module_name.name => Some(f2.ports.as_slice()),
-                    _ => None,
-                })
-                .map(|ports| ports.iter()
-                    .filter_map(|p| p.bus_info.as_ref().map(|bi| (p.name.name.clone(), bi.bus_name.name.clone())))
-                    .collect())
-                .unwrap_or_default();
+        self.check_snake_case(&inst.name);
+        // Find the target construct's bus port info for whole-bus expansion
+        let target_bus_ports: Vec<(String, String)> = self
+            .source
+            .items
+            .iter()
+            .find_map(|item| match item {
+                Item::Module(m2) if m2.name.name == inst.module_name.name => {
+                    Some(m2.ports.as_slice())
+                }
+                Item::Fsm(f2) if f2.name.name == inst.module_name.name => Some(f2.ports.as_slice()),
+                _ => None,
+            })
+            .map(|ports| {
+                ports
+                    .iter()
+                    .filter_map(|p| {
+                        p.bus_info
+                            .as_ref()
+                            .map(|bi| (p.name.name.clone(), bi.bus_name.name.clone()))
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
 
-            // Check for unconnected ports on the instantiated construct.
-            //
-            // Bus ports can be connected in one of two shapes:
-            //   (a) whole-bus: `p -> tb;` — connection.port_name == "p"
-            //   (b) per-field: `p.cmd_valid <- x; p.cmd_addr <- y;` —
-            //       the parser concatenates base.field, producing
-            //       port_name == "p_cmd_valid", "p_cmd_addr", ...
-            // For the per-field shape we consider the bus port connected
-            // if any connection's port_name starts with `<bus_port>_`.
-            {
-                let child_ports: Option<&[PortDecl]> = self.source.items.iter()
-                    .find_map(|item| match item {
-                        Item::Module(m2) if m2.name.name == inst.module_name.name => Some(m2.ports.as_slice()),
-                        Item::Fsm(f2)    if f2.name.name == inst.module_name.name => Some(f2.ports.as_slice()),
-                        Item::Pipeline(p2) if p2.name.name == inst.module_name.name => Some(p2.ports.as_slice()),
-                        _ => None,
-                    });
-                if let Some(ports) = child_ports {
-                    let connected: std::collections::HashSet<&str> = inst.connections.iter()
-                        .map(|c| c.port_name.name.as_str())
-                        .collect();
-                    for port in ports {
-                        // Skip Clock and Reset ports — they may be handled via domain defaults
-                        let is_infra = matches!(&port.ty, TypeExpr::Clock(_) | TypeExpr::Reset(_, _));
-                        if is_infra { continue; }
-                        let name = port.name.name.as_str();
-                        let is_connected = if port.bus_info.is_some() {
-                            // Accept whole-bus OR per-field bindings.
-                            let prefix = format!("{}_", name);
-                            connected.contains(name)
-                                || connected.iter().any(|c| c.starts_with(&prefix))
+        // Check for unconnected ports on the instantiated construct.
+        //
+        // Bus ports can be connected in one of two shapes:
+        //   (a) whole-bus: `p -> tb;` — connection.port_name == "p"
+        //   (b) per-field: `p.cmd_valid <- x; p.cmd_addr <- y;` —
+        //       the parser concatenates base.field, producing
+        //       port_name == "p_cmd_valid", "p_cmd_addr", ...
+        // For the per-field shape we consider the bus port connected
+        // if any connection's port_name starts with `<bus_port>_`.
+        {
+            let child_ports: Option<&[PortDecl]> =
+                self.source.items.iter().find_map(|item| match item {
+                    Item::Module(m2) if m2.name.name == inst.module_name.name => {
+                        Some(m2.ports.as_slice())
+                    }
+                    Item::Fsm(f2) if f2.name.name == inst.module_name.name => {
+                        Some(f2.ports.as_slice())
+                    }
+                    Item::Pipeline(p2) if p2.name.name == inst.module_name.name => {
+                        Some(p2.ports.as_slice())
+                    }
+                    _ => None,
+                });
+            if let Some(ports) = child_ports {
+                let connected: std::collections::HashSet<&str> = inst
+                    .connections
+                    .iter()
+                    .map(|c| c.port_name.name.as_str())
+                    .collect();
+                for port in ports {
+                    // Skip Clock and Reset ports — they may be handled via domain defaults
+                    let is_infra = matches!(&port.ty, TypeExpr::Clock(_) | TypeExpr::Reset(_, _));
+                    if is_infra {
+                        continue;
+                    }
+                    let name = port.name.name.as_str();
+                    let is_connected = if port.bus_info.is_some() {
+                        // Accept whole-bus OR per-field bindings.
+                        let prefix = format!("{}_", name);
+                        connected.contains(name) || connected.iter().any(|c| c.starts_with(&prefix))
+                    } else {
+                        connected.contains(name)
+                    };
+                    if !is_connected {
+                        if port.direction == Direction::In {
+                            self.errors.push(CompileError::general(
+                                &format!(
+                                    "input port `{}` of `{}` is not connected in inst `{}`",
+                                    name, inst.module_name.name, inst.name.name
+                                ),
+                                inst.span,
+                            ));
                         } else {
-                            connected.contains(name)
-                        };
-                        if !is_connected {
-                            if port.direction == Direction::In {
-                                self.errors.push(CompileError::general(
-                                    &format!(
-                                        "input port `{}` of `{}` is not connected in inst `{}`",
-                                        name, inst.module_name.name, inst.name.name
-                                    ),
-                                    inst.span,
-                                ));
-                            } else {
-                                self.warnings.push(CompileWarning {
-                                    message: format!(
-                                        "output port `{}` of `{}` is not connected in inst `{}`",
-                                        name, inst.module_name.name, inst.name.name
-                                    ),
-                                    span: inst.span,
-                                });
+                            self.warnings.push(CompileWarning {
+                                message: format!(
+                                    "output port `{}` of `{}` is not connected in inst `{}`",
+                                    name, inst.module_name.name, inst.name.name
+                                ),
+                                span: inst.span,
+                            });
+                        }
+                    }
+                }
+            }
+        }
+
+        // Base names of the child's Vec-of-bus ports (`port mm: ...
+        // Vec<Bus, N>`). The parser flattens a per-element connection
+        // `mm[k] <- ...` into port_name `mm_<k>`, so to credit the right
+        // parent driver below we must recognise `mm_<k>` as element k of
+        // the child's `mm` port. We only need to know which child ports are
+        // Vec-of-bus (count present) — not the concrete N — so this avoids
+        // resolving a possibly param-dependent count here.
+        let child_vob_bases: Vec<String> = self
+            .source
+            .items
+            .iter()
+            .find_map(|item| match item {
+                Item::Module(m2) if m2.name.name == inst.module_name.name => {
+                    Some(m2.ports.as_slice())
+                }
+                Item::Fsm(f2) if f2.name.name == inst.module_name.name => Some(f2.ports.as_slice()),
+                Item::Pipeline(p2) if p2.name.name == inst.module_name.name => {
+                    Some(p2.ports.as_slice())
+                }
+                _ => None,
+            })
+            .map(|ports| {
+                ports
+                    .iter()
+                    .filter(|p| p.bus_info.as_ref().map_or(false, |bi| bi.count.is_some()))
+                    .map(|p| p.name.name.clone())
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        // Mark connected output ports as driven
+        for conn in &inst.connections {
+            // Resolve the child bus port this connection targets. Whole-bus
+            // (`mm <- ...`) keeps the port name verbatim; per-element
+            // (`mm[k] <- ...`, flattened to `mm_<k>`) strips the trailing
+            // `_<idx>` back to the Vec-of-bus base `mm`.
+            let conn_port_base: String = child_vob_bases
+                .iter()
+                .find_map(|base| {
+                    let rest = conn.port_name.name.strip_prefix(&format!("{base}_"))?;
+                    rest.parse::<u32>().ok().map(|_| base.clone())
+                })
+                .unwrap_or_else(|| conn.port_name.name.clone());
+            if conn.direction == ConnectDir::Output {
+                if let ExprKind::Ident(name) = &conn.signal.kind {
+                    driven.insert(name.clone());
+                }
+                // Bus port FieldAccess: itcm.cmd_valid → driven itcm_cmd_valid
+                let flat = Self::expr_flat_name_tc(&conn.signal);
+                if !flat.is_empty() {
+                    driven.insert(flat);
+                }
+                // Packed Vec-of-bus port-element drive:
+                // `Index(Ident("<base>_<sig>"), <i>)` from the thread-wrapper
+                // emission credits the per-element flat name `<base>_<i>_<sig>`
+                // that the undriven-port check looks for. Detect when the
+                // base ident matches a `<vobport>_<sig>` pair.
+                if let ExprKind::Index(arr, idx) = &conn.signal.kind {
+                    if let (ExprKind::Ident(arr_name), ExprKind::Literal(LitKind::Dec(i))) =
+                        (&arr.kind, &idx.kind)
+                    {
+                        // Try every Vec-of-bus port name as a prefix.
+                        for (vobport, _n) in self.vec_of_bus_ports.iter() {
+                            let prefix = format!("{vobport}_");
+                            if let Some(sig) = arr_name.strip_prefix(&prefix) {
+                                driven.insert(format!("{vobport}_{i}_{sig}"));
                             }
                         }
                     }
                 }
             }
-
-            // Base names of the child's Vec-of-bus ports (`port mm: ...
-            // Vec<Bus, N>`). The parser flattens a per-element connection
-            // `mm[k] <- ...` into port_name `mm_<k>`, so to credit the right
-            // parent driver below we must recognise `mm_<k>` as element k of
-            // the child's `mm` port. We only need to know which child ports are
-            // Vec-of-bus (count present) — not the concrete N — so this avoids
-            // resolving a possibly param-dependent count here.
-            let child_vob_bases: Vec<String> = self.source.items.iter()
-                .find_map(|item| match item {
-                    Item::Module(m2) if m2.name.name == inst.module_name.name => Some(m2.ports.as_slice()),
-                    Item::Fsm(f2)    if f2.name.name == inst.module_name.name => Some(f2.ports.as_slice()),
-                    Item::Pipeline(p2) if p2.name.name == inst.module_name.name => Some(p2.ports.as_slice()),
-                    _ => None,
-                })
-                .map(|ports| ports.iter()
-                    .filter(|p| p.bus_info.as_ref().map_or(false, |bi| bi.count.is_some()))
-                    .map(|p| p.name.name.clone())
-                    .collect())
-                .unwrap_or_default();
-
-            // Mark connected output ports as driven
-            for conn in &inst.connections {
-                // Resolve the child bus port this connection targets. Whole-bus
-                // (`mm <- ...`) keeps the port name verbatim; per-element
-                // (`mm[k] <- ...`, flattened to `mm_<k>`) strips the trailing
-                // `_<idx>` back to the Vec-of-bus base `mm`.
-                let conn_port_base: String = child_vob_bases.iter()
-                    .find_map(|base| {
-                        let rest = conn.port_name.name.strip_prefix(&format!("{base}_"))?;
-                        rest.parse::<u32>().ok().map(|_| base.clone())
-                    })
-                    .unwrap_or_else(|| conn.port_name.name.clone());
-                if conn.direction == ConnectDir::Output {
-                    if let ExprKind::Ident(name) = &conn.signal.kind {
-                        driven.insert(name.clone());
-                    }
-                    // Bus port FieldAccess: itcm.cmd_valid → driven itcm_cmd_valid
-                    let flat = Self::expr_flat_name_tc(&conn.signal);
-                    if !flat.is_empty() {
-                        driven.insert(flat);
-                    }
-                    // Packed Vec-of-bus port-element drive:
-                    // `Index(Ident("<base>_<sig>"), <i>)` from the thread-wrapper
-                    // emission credits the per-element flat name `<base>_<i>_<sig>`
-                    // that the undriven-port check looks for. Detect when the
-                    // base ident matches a `<vobport>_<sig>` pair.
-                    if let ExprKind::Index(arr, idx) = &conn.signal.kind {
-                        if let (ExprKind::Ident(arr_name), ExprKind::Literal(LitKind::Dec(i)))
-                            = (&arr.kind, &idx.kind)
-                        {
-                            // Try every Vec-of-bus port name as a prefix.
-                            for (vobport, _n) in self.vec_of_bus_ports.iter() {
-                                let prefix = format!("{vobport}_");
-                                if let Some(sig) = arr_name.strip_prefix(&prefix) {
-                                    driven.insert(format!("{vobport}_{i}_{sig}"));
-                                }
+            // Whole-bus connection: axi_rd -> m_axi_mm2s expands to N signals.
+            // The inst's bus port drives/receives signals based on its perspective.
+            // We need to mark parent signals as "driven" when the inst OUTPUTS them.
+            if let Some((_, bus_name)) = target_bus_ports
+                .iter()
+                .find(|(pn, _)| *pn == conn_port_base)
+            {
+                if let Some((crate::resolve::Symbol::Bus(info), _)) =
+                    self.symbols.globals.get(bus_name)
+                {
+                    // Find the inst's bus port perspective, params, and Vec count.
+                    let inst_bus_info = self
+                        .source
+                        .items
+                        .iter()
+                        .find_map(|item| match item {
+                            Item::Module(m2) if m2.name.name == inst.module_name.name => {
+                                Some(m2.ports.as_slice())
                             }
-                        }
-                    }
-                }
-                // Whole-bus connection: axi_rd -> m_axi_mm2s expands to N signals.
-                // The inst's bus port drives/receives signals based on its perspective.
-                // We need to mark parent signals as "driven" when the inst OUTPUTS them.
-                if let Some((_, bus_name)) = target_bus_ports.iter().find(|(pn, _)| *pn == conn_port_base) {
-                    if let Some((crate::resolve::Symbol::Bus(info), _)) = self.symbols.globals.get(bus_name) {
-                        // Find the inst's bus port perspective, params, and Vec count.
-                        let inst_bus_info = self.source.items.iter()
-                            .find_map(|item| match item {
-                                Item::Module(m2) if m2.name.name == inst.module_name.name => Some(m2.ports.as_slice()),
-                                Item::Fsm(f2) if f2.name.name == inst.module_name.name => Some(f2.ports.as_slice()),
-                                _ => None,
-                            })
-                            .and_then(|ports| ports.iter()
+                            Item::Fsm(f2) if f2.name.name == inst.module_name.name => {
+                                Some(f2.ports.as_slice())
+                            }
+                            _ => None,
+                        })
+                        .and_then(|ports| {
+                            ports
+                                .iter()
                                 .find(|p| p.name.name == conn_port_base)
-                                .and_then(|p| p.bus_info.as_ref()));
-                        let inst_perspective = inst_bus_info.map(|bi| bi.perspective);
-                        // Inst port's Vec count (Some(N) means `port: ... Vec<Bus, N>`).
-                        let inst_vec_count: Option<u32> = inst_bus_info
-                            .and_then(|bi| bi.count.as_ref())
-                            .and_then(|ce| {
-                                let empty: HashMap<String, Ty> = HashMap::new();
-                                self.eval_const_expr(ce, &empty).map(|v| v as u32)
-                            });
+                                .and_then(|p| p.bus_info.as_ref())
+                        });
+                    let inst_perspective = inst_bus_info.map(|bi| bi.perspective);
+                    // Inst port's Vec count (Some(N) means `port: ... Vec<Bus, N>`).
+                    let inst_vec_count: Option<u32> = inst_bus_info
+                        .and_then(|bi| bi.count.as_ref())
+                        .and_then(|ce| {
+                            let empty: HashMap<String, Ty> = HashMap::new();
+                            self.eval_const_expr(ce, &empty).map(|v| v as u32)
+                        });
 
-                        // Resolve the parent-side base prefix(es):
-                        //   * `Ident("w")`           → `w`            (scalar bus wire/port)
-                        //                              or when inst port is Vec<Bus,N> and
-                        //                              `w` is also Vec<Bus,N>: expand to
-                        //                              `w_0`, `w_1`, ..., `w_{N-1}`.
-                        //   * `Index(Ident("v"), i)` → `v_<i>`        (Vec-of-bus element)
-                        let sig_bases: Vec<String> = match &conn.signal.kind {
-                            ExprKind::Ident(n) => {
-                                // Whole-Vec forwarding: child port `m: ... Vec<Bus,N>`
-                                // wired to parent ident `n` that is itself a Vec-of-Bus
-                                // port. Expand to N per-element prefixes so the
-                                // undriven-port check sees `n_0_<sig>`, `n_1_<sig>`, ...
-                                // (which is what the prefixes loop at the module-level
-                                // undriven check produces for a Vec<Bus,N> parent port).
-                                if let Some(n_count) = inst_vec_count {
-                                    if self.vec_of_bus_ports.get(n).copied() == Some(n_count) {
-                                        (0..n_count).map(|i| format!("{}_{}", n, i)).collect()
-                                    } else {
-                                        vec![n.clone()]
-                                    }
+                    // Resolve the parent-side base prefix(es):
+                    //   * `Ident("w")`           → `w`            (scalar bus wire/port)
+                    //                              or when inst port is Vec<Bus,N> and
+                    //                              `w` is also Vec<Bus,N>: expand to
+                    //                              `w_0`, `w_1`, ..., `w_{N-1}`.
+                    //   * `Index(Ident("v"), i)` → `v_<i>`        (Vec-of-bus element)
+                    let sig_bases: Vec<String> = match &conn.signal.kind {
+                        ExprKind::Ident(n) => {
+                            // Whole-Vec forwarding: child port `m: ... Vec<Bus,N>`
+                            // wired to parent ident `n` that is itself a Vec-of-Bus
+                            // port. Expand to N per-element prefixes so the
+                            // undriven-port check sees `n_0_<sig>`, `n_1_<sig>`, ...
+                            // (which is what the prefixes loop at the module-level
+                            // undriven check produces for a Vec<Bus,N> parent port).
+                            if let Some(n_count) = inst_vec_count {
+                                if self.vec_of_bus_ports.get(n).copied() == Some(n_count) {
+                                    (0..n_count).map(|i| format!("{}_{}", n, i)).collect()
                                 } else {
                                     vec![n.clone()]
                                 }
+                            } else {
+                                vec![n.clone()]
                             }
-                            ExprKind::Index(arr, idx) => {
-                                if let (ExprKind::Ident(arr_name), ExprKind::Literal(LitKind::Dec(i))) = (&arr.kind, &idx.kind) {
-                                    vec![format!("{}_{}", arr_name, i)]
-                                } else { Vec::new() }
+                        }
+                        ExprKind::Index(arr, idx) => {
+                            if let (ExprKind::Ident(arr_name), ExprKind::Literal(LitKind::Dec(i))) =
+                                (&arr.kind, &idx.kind)
+                            {
+                                vec![format!("{}_{}", arr_name, i)]
+                            } else {
+                                Vec::new()
                             }
-                            _ => Vec::new(),
-                        };
-                        if !sig_bases.is_empty() {
-                            let mut pm = info.default_param_map();
-                            if let Some(bi) = inst_bus_info {
-                                for pa in &bi.params { pm.insert(pa.name.name.clone(), &pa.value); }
+                        }
+                        _ => Vec::new(),
+                    };
+                    if !sig_bases.is_empty() {
+                        let mut pm = info.default_param_map();
+                        if let Some(bi) = inst_bus_info {
+                            for pa in &bi.params {
+                                pm.insert(pa.name.name.clone(), &pa.value);
                             }
-                            let eff = info.effective_signals(&pm);
-                            for sig_base in &sig_bases {
-                                for (sname, sdir, _) in &eff {
-                                    // Determine actual direction from inst's perspective
-                                    let inst_dir = match inst_perspective {
-                                        Some(BusPerspective::Initiator) => *sdir,
-                                        Some(BusPerspective::Target) => (*sdir).flip(),
-                                        None => *sdir,
-                                    };
-                                    // If signal is an output FROM the inst, it drives the parent wire/port
-                                    if inst_dir == Direction::Out {
-                                        driven.insert(format!("{}_{}", sig_base, sname));
-                                    }
+                        }
+                        let eff = info.effective_signals(&pm);
+                        for sig_base in &sig_bases {
+                            for (sname, sdir, _) in &eff {
+                                // Determine actual direction from inst's perspective
+                                let inst_dir = match inst_perspective {
+                                    Some(BusPerspective::Initiator) => *sdir,
+                                    Some(BusPerspective::Target) => (*sdir).flip(),
+                                    None => *sdir,
+                                };
+                                // If signal is an output FROM the inst, it drives the parent wire/port
+                                if inst_dir == Direction::Out {
+                                    driven.insert(format!("{}_{}", sig_base, sname));
                                 }
                             }
                         }
                     }
                 }
             }
+        }
     }
     pub(crate) fn check_handshake_reads(&mut self, m: &ModuleDecl) {
         use std::collections::HashMap as Map;
         // port_name -> Vec<(channel_name, guard, payload_field_names)>
         let mut info: Map<String, Vec<(String, HandshakePayloadGuard, Vec<String>)>> = Map::new();
         for p in &m.ports {
-            let Some(ref bi) = p.bus_info else { continue; };
+            let Some(ref bi) = p.bus_info else {
+                continue;
+            };
             let Some(crate::resolve::Symbol::Bus(binfo)) =
                 self.symbols.globals.get(&bi.bus_name.name).map(|(s, _)| s)
-                else { continue; };
+            else {
+                continue;
+            };
             for hs in &binfo.handshakes {
                 let guard = match hs.variant.name.as_str() {
                     "valid_ready" | "valid_only" | "valid_stall" => {
@@ -1682,17 +1938,21 @@ impl<'a> TypeChecker<'a> {
                     },
                     _ => continue,
                 };
-                let payloads: Vec<String> = hs.payload_names.iter()
-                    .map(|i| i.name.clone())
-                    .collect();
+                let payloads: Vec<String> =
+                    hs.payload_names.iter().map(|i| i.name.clone()).collect();
                 info.entry(p.name.name.clone()).or_default().push((
                     hs.name.name.clone(),
                     guard,
-                    payloads.into_iter().map(|n| format!("{}_{}", hs.name.name, n)).collect(),
+                    payloads
+                        .into_iter()
+                        .map(|n| format!("{}_{}", hs.name.name, n))
+                        .collect(),
                 ));
             }
         }
-        if info.is_empty() { return; }
+        if info.is_empty() {
+            return;
+        }
 
         for item in &m.body {
             match item {
@@ -1753,7 +2013,9 @@ impl<'a> TypeChecker<'a> {
                     self.walk_comb_for_hs_reads(s, enclosing, info);
                 }
             }
-                Stmt::Init(_) | Stmt::WaitUntil(..) | Stmt::DoUntil { .. } => unreachable!("seq-only Stmt variant inside comb-context walker"),
+            Stmt::Init(_) | Stmt::WaitUntil(..) | Stmt::DoUntil { .. } => {
+                unreachable!("seq-only Stmt variant inside comb-context walker")
+            }
             Stmt::Log(_) => {}
         }
     }
@@ -1827,7 +2089,10 @@ impl<'a> TypeChecker<'a> {
                         for (ch_name, guard, payload_fields) in channels {
                             if payload_fields.iter().any(|pf| pf == &field.name) {
                                 let needs_guard = guard.display(port);
-                                if !enclosing.iter().any(|c| cond_contains_guard(c, port, guard)) {
+                                if !enclosing
+                                    .iter()
+                                    .any(|c| cond_contains_guard(c, port, guard))
+                                {
                                     let span = if expr.span.start == 0 && expr.span.end == 0 {
                                         default_span
                                     } else {
@@ -1882,10 +2147,14 @@ impl<'a> TypeChecker<'a> {
             }
             ExprKind::MethodCall(b, _, args) => {
                 self.check_expr_for_unguarded_payload(b, enclosing, info, default_span);
-                for a in args { self.check_expr_for_unguarded_payload(a, enclosing, info, default_span); }
+                for a in args {
+                    self.check_expr_for_unguarded_payload(a, enclosing, info, default_span);
+                }
             }
             ExprKind::FunctionCall(_, args) => {
-                for a in args { self.check_expr_for_unguarded_payload(a, enclosing, info, default_span); }
+                for a in args {
+                    self.check_expr_for_unguarded_payload(a, enclosing, info, default_span);
+                }
             }
             ExprKind::Ternary(c, t, e) => {
                 self.check_expr_for_unguarded_payload(c, enclosing, info, default_span);
@@ -1902,7 +2171,12 @@ impl<'a> TypeChecker<'a> {
             ExprKind::ExprMatch(s, arms) => {
                 self.check_expr_for_unguarded_payload(s, enclosing, info, default_span);
                 for arm in arms {
-                    self.check_expr_for_unguarded_payload(&arm.value, enclosing, info, default_span);
+                    self.check_expr_for_unguarded_payload(
+                        &arm.value,
+                        enclosing,
+                        info,
+                        default_span,
+                    );
                 }
             }
             _ => {}
@@ -1913,7 +2187,11 @@ impl<'a> TypeChecker<'a> {
         // Find the template in the source file
         let tmpl = self.source.items.iter().find_map(|item| {
             if let Item::Template(t) = item {
-                if t.name.name == tmpl_name.name { Some(t) } else { None }
+                if t.name.name == tmpl_name.name {
+                    Some(t)
+                } else {
+                    None
+                }
             } else {
                 None
             }
@@ -1934,8 +2212,10 @@ impl<'a> TypeChecker<'a> {
             let found = m.params.iter().any(|mp| mp.name.name == tp.name.name);
             if !found {
                 self.errors.push(CompileError::general(
-                    &format!("module `{}` is missing param `{}` required by template `{}`",
-                             m.name.name, tp.name.name, tmpl.name.name),
+                    &format!(
+                        "module `{}` is missing param `{}` required by template `{}`",
+                        m.name.name, tp.name.name, tmpl.name.name
+                    ),
                     m.name.span,
                 ));
             }
@@ -1947,8 +2227,10 @@ impl<'a> TypeChecker<'a> {
             match found {
                 None => {
                     self.errors.push(CompileError::general(
-                        &format!("module `{}` is missing port `{}` required by template `{}`",
-                                 m.name.name, tp.name.name, tmpl.name.name),
+                        &format!(
+                            "module `{}` is missing port `{}` required by template `{}`",
+                            m.name.name, tp.name.name, tmpl.name.name
+                        ),
                         m.name.span,
                     ));
                 }
@@ -1969,8 +2251,10 @@ impl<'a> TypeChecker<'a> {
             let found = m.hooks.iter().any(|mh| mh.hook_name.name == th.name.name);
             if !found {
                 self.errors.push(CompileError::general(
-                    &format!("module `{}` is missing hook `{}` required by template `{}`",
-                             m.name.name, th.name.name, tmpl.name.name),
+                    &format!(
+                        "module `{}` is missing hook `{}` required by template `{}`",
+                        m.name.name, th.name.name, tmpl.name.name
+                    ),
                     m.name.span,
                 ));
             }
@@ -1992,9 +2276,13 @@ impl<'a> TypeChecker<'a> {
     ///     `synthesized` flag needed.
     pub(crate) fn check_port_reg_timing(&mut self, m: &ModuleDecl) {
         // Collect names of *legacy-form* registered output ports only.
-        let port_reg_names: HashSet<String> = m.ports.iter()
-            .filter(|p| p.direction == Direction::Out
-                     && p.reg_info.as_ref().is_some_and(|ri| ri.legacy_port_reg))
+        let port_reg_names: HashSet<String> = m
+            .ports
+            .iter()
+            .filter(|p| {
+                p.direction == Direction::Out
+                    && p.reg_info.as_ref().is_some_and(|ri| ri.legacy_port_reg)
+            })
             .map(|p| p.name.name.clone())
             .collect();
         if port_reg_names.is_empty() {
@@ -2002,18 +2290,26 @@ impl<'a> TypeChecker<'a> {
         }
 
         // Collect internal register names (potential state variables)
-        let internal_reg_names: HashSet<String> = m.body.iter()
-            .filter_map(|item| if let ModuleBodyItem::RegDecl(r) = item {
-                Some(r.name.name.clone())
-            } else {
-                None
+        let internal_reg_names: HashSet<String> = m
+            .body
+            .iter()
+            .filter_map(|item| {
+                if let ModuleBodyItem::RegDecl(r) = item {
+                    Some(r.name.name.clone())
+                } else {
+                    None
+                }
             })
             .collect();
 
         // Collect registered output spans for warning locations.
-        let port_reg_spans: HashMap<String, Span> = m.ports.iter()
-            .filter(|p| p.direction == Direction::Out
-                     && p.reg_info.as_ref().is_some_and(|ri| ri.legacy_port_reg))
+        let port_reg_spans: HashMap<String, Span> = m
+            .ports
+            .iter()
+            .filter(|p| {
+                p.direction == Direction::Out
+                    && p.reg_info.as_ref().is_some_and(|ri| ri.legacy_port_reg)
+            })
             .map(|p| (p.name.name.clone(), p.span))
             .collect();
 
@@ -2023,8 +2319,12 @@ impl<'a> TypeChecker<'a> {
             if let ModuleBodyItem::RegBlock(rb) = item {
                 for stmt in &rb.stmts {
                     self.find_state_dependent_port_reg_assigns(
-                        stmt, &port_reg_names, &internal_reg_names,
-                        &port_reg_spans, &mut warned, false,
+                        stmt,
+                        &port_reg_names,
+                        &internal_reg_names,
+                        &port_reg_spans,
+                        &mut warned,
+                        false,
                     );
                 }
             }
@@ -2071,12 +2371,22 @@ impl<'a> TypeChecker<'a> {
                         }
                     }
                     self.find_state_dependent_port_reg_assigns(
-                        s, port_reg_names, reg_names, port_reg_spans, warned, in_state,
+                        s,
+                        port_reg_names,
+                        reg_names,
+                        port_reg_spans,
+                        warned,
+                        in_state,
                     );
                 }
                 for s in &ie.else_stmts {
                     self.find_state_dependent_port_reg_assigns(
-                        s, port_reg_names, reg_names, port_reg_spans, warned, in_state,
+                        s,
+                        port_reg_names,
+                        reg_names,
+                        port_reg_spans,
+                        warned,
+                        in_state,
                     );
                 }
             }
@@ -2086,7 +2396,12 @@ impl<'a> TypeChecker<'a> {
                 for arm in &ms.arms {
                     for s in &arm.body {
                         self.find_state_dependent_port_reg_assigns(
-                            s, port_reg_names, reg_names, port_reg_spans, warned, in_state,
+                            s,
+                            port_reg_names,
+                            reg_names,
+                            port_reg_spans,
+                            warned,
+                            in_state,
                         );
                     }
                 }
@@ -2094,7 +2409,12 @@ impl<'a> TypeChecker<'a> {
             Stmt::For(fl) => {
                 for s in &fl.body {
                     self.find_state_dependent_port_reg_assigns(
-                        s, port_reg_names, reg_names, port_reg_spans, warned, inside_state_if,
+                        s,
+                        port_reg_names,
+                        reg_names,
+                        port_reg_spans,
+                        warned,
+                        inside_state_if,
                     );
                 }
             }
@@ -2127,7 +2447,9 @@ impl<'a> TypeChecker<'a> {
         // Build name → TypeExpr map for all in-scope signals
         let mut sig_types: HashMap<String, TypeExpr> = HashMap::new();
         for p in &m.ports {
-            if p.bus_info.is_some() { continue; }
+            if p.bus_info.is_some() {
+                continue;
+            }
             sig_types.insert(p.name.name.clone(), p.ty.clone());
         }
         for item in &m.body {
@@ -2204,8 +2526,16 @@ impl<'a> TypeChecker<'a> {
         Self::collect_assigned_roots_tc(&rb.stmts, &mut assigned);
 
         // Gather reg declarations for assigned registers
-        let reg_decls: Vec<&RegDecl> = m.body.iter()
-            .filter_map(|i| if let ModuleBodyItem::RegDecl(r) = i { Some(r) } else { None })
+        let reg_decls: Vec<&RegDecl> = m
+            .body
+            .iter()
+            .filter_map(|i| {
+                if let ModuleBodyItem::RegDecl(r) = i {
+                    Some(r)
+                } else {
+                    None
+                }
+            })
             .collect();
 
         // Resolved reset info: (signal_name, kind, level)
@@ -2218,7 +2548,9 @@ impl<'a> TypeChecker<'a> {
         let mut first_reset: Option<ResetProps> = None;
 
         for name in &assigned {
-            if name.is_empty() { continue; }
+            if name.is_empty() {
+                continue;
+            }
             let rd = match reg_decls.iter().find(|r| r.name.name == *name) {
                 Some(rd) => rd,
                 None => continue,
@@ -2234,14 +2566,20 @@ impl<'a> TypeChecker<'a> {
                             (sig.name.clone(), *k, *l)
                         } else {
                             self.errors.push(CompileError::general(
-                                &format!("`{}` reset signal `{}` is not a Reset port", name, sig.name),
+                                &format!(
+                                    "`{}` reset signal `{}` is not a Reset port",
+                                    name, sig.name
+                                ),
                                 sig.span,
                             ));
                             continue;
                         }
                     } else {
                         self.errors.push(CompileError::general(
-                            &format!("`{}` reset signal `{}` not found in module ports", name, sig.name),
+                            &format!(
+                                "`{}` reset signal `{}` not found in module ports",
+                                name, sig.name
+                            ),
                             sig.span,
                         ));
                         continue;
@@ -2282,7 +2620,11 @@ impl<'a> TypeChecker<'a> {
                     ));
                 }
             } else {
-                first_reset = Some(ResetProps { signal, kind, level });
+                first_reset = Some(ResetProps {
+                    signal,
+                    kind,
+                    level,
+                });
             }
         }
     }
@@ -2322,8 +2664,12 @@ impl<'a> TypeChecker<'a> {
         match &expr.kind {
             ExprKind::Ident(n) => n.clone(),
             ExprKind::FieldAccess(base, _) => Self::expr_root_name_tc(base),
-            ExprKind::Index(base, _) | ExprKind::BitSlice(base, _, _) | ExprKind::PartSelect(base, _, _, _) => Self::expr_root_name_tc(base),
-            ExprKind::LatencyAt(inner, _) | ExprKind::SvaNext(_, inner) => Self::expr_root_name_tc(inner),
+            ExprKind::Index(base, _)
+            | ExprKind::BitSlice(base, _, _)
+            | ExprKind::PartSelect(base, _, _, _) => Self::expr_root_name_tc(base),
+            ExprKind::LatencyAt(inner, _) | ExprKind::SvaNext(_, inner) => {
+                Self::expr_root_name_tc(inner)
+            }
             _ => String::new(),
         }
     }
@@ -2332,14 +2678,18 @@ impl<'a> TypeChecker<'a> {
     /// (e.g. `itcm.cmd_valid` → `"itcm_cmd_valid"`). Used for bus port driven tracking.
     fn expr_flat_name_tc(expr: &Expr) -> String {
         match &expr.kind {
-            ExprKind::LatencyAt(inner, _) | ExprKind::SvaNext(_, inner) => Self::expr_flat_name_tc(inner),
+            ExprKind::LatencyAt(inner, _) | ExprKind::SvaNext(_, inner) => {
+                Self::expr_flat_name_tc(inner)
+            }
             ExprKind::Ident(n) => n.clone(),
             ExprKind::FieldAccess(base, field) => {
                 if let ExprKind::Ident(base_name) = &base.kind {
                     format!("{}_{}", base_name, field.name)
                 // Indexed bus: m_axi[0].valid → m_axi_0_valid
                 } else if let ExprKind::Index(arr, idx) = &base.kind {
-                    if let (ExprKind::Ident(arr_name), ExprKind::Literal(LitKind::Dec(i))) = (&arr.kind, &idx.kind) {
+                    if let (ExprKind::Ident(arr_name), ExprKind::Literal(LitKind::Dec(i))) =
+                        (&arr.kind, &idx.kind)
+                    {
                         format!("{}_{}_{}", arr_name, i, field.name)
                     } else {
                         Self::expr_root_name_tc(base)
@@ -2348,7 +2698,9 @@ impl<'a> TypeChecker<'a> {
                     Self::expr_root_name_tc(base)
                 }
             }
-            ExprKind::Index(base, _) | ExprKind::BitSlice(base, _, _) | ExprKind::PartSelect(base, _, _, _) => Self::expr_flat_name_tc(base),
+            ExprKind::Index(base, _)
+            | ExprKind::BitSlice(base, _, _)
+            | ExprKind::PartSelect(base, _, _, _) => Self::expr_flat_name_tc(base),
             _ => String::new(),
         }
     }
@@ -2364,7 +2716,9 @@ impl<'a> TypeChecker<'a> {
             Ty::Enum(_, w) => Some(*w),
             Ty::Vec(inner, count) => self.type_total_width(inner).map(|w| w * count),
             Ty::Struct(name) => {
-                if let Some((crate::resolve::Symbol::Struct(info), _)) = self.symbols.globals.get(name) {
+                if let Some((crate::resolve::Symbol::Struct(info), _)) =
+                    self.symbols.globals.get(name)
+                {
                     let mut total = 0u32;
                     for (_, field_ty) in &info.fields {
                         let w = self.type_expr_width(field_ty)?;
@@ -2393,13 +2747,17 @@ impl<'a> TypeChecker<'a> {
                 Some(iw * n)
             }
             TypeExpr::Named(ident) => {
-                if let Some((crate::resolve::Symbol::Struct(info), _)) = self.symbols.globals.get(&ident.name) {
+                if let Some((crate::resolve::Symbol::Struct(info), _)) =
+                    self.symbols.globals.get(&ident.name)
+                {
                     let mut total = 0u32;
                     for (_, field_ty) in &info.fields {
                         total += self.type_expr_width(field_ty)?;
                     }
                     Some(total)
-                } else if let Some((crate::resolve::Symbol::Enum(info), _)) = self.symbols.globals.get(&ident.name) {
+                } else if let Some((crate::resolve::Symbol::Enum(info), _)) =
+                    self.symbols.globals.get(&ident.name)
+                {
                     Some(enum_width(info.variants.len()))
                 } else {
                     None
@@ -2422,28 +2780,42 @@ impl<'a> TypeChecker<'a> {
             // Check RegDecl
             for item in &m.body {
                 if let ModuleBodyItem::RegDecl(r) = item {
-                    if r.name.name != *name { continue; }
+                    if r.name.name != *name {
+                        continue;
+                    }
                     let sig = match &r.reset {
-                        RegReset::Inherit(sig, _) | RegReset::Explicit(sig, _, _, _) => Some(sig.name.clone()),
+                        RegReset::Inherit(sig, _) | RegReset::Explicit(sig, _, _, _) => {
+                            Some(sig.name.clone())
+                        }
                         RegReset::None => None,
                     };
-                    if let Some(s) = sig { reset_signals.insert(s); }
+                    if let Some(s) = sig {
+                        reset_signals.insert(s);
+                    }
                 }
             }
             // Check port reg
             for p in &m.ports {
-                if p.name.name != *name { continue; }
+                if p.name.name != *name {
+                    continue;
+                }
                 if let Some(ri) = &p.reg_info {
                     let sig = match &ri.reset {
-                        RegReset::Inherit(sig, _) | RegReset::Explicit(sig, _, _, _) => Some(sig.name.clone()),
+                        RegReset::Inherit(sig, _) | RegReset::Explicit(sig, _, _, _) => {
+                            Some(sig.name.clone())
+                        }
                         RegReset::None => None,
                     };
-                    if let Some(s) = sig { reset_signals.insert(s); }
+                    if let Some(s) = sig {
+                        reset_signals.insert(s);
+                    }
                 }
             }
         }
 
-        if reset_signals.is_empty() { return; }
+        if reset_signals.is_empty() {
+            return;
+        }
 
         // Check top-level stmts for `if reset_signal { ... }` or `if ~reset_signal { ... }`
         for stmt in &rb.stmts {
@@ -2451,7 +2823,11 @@ impl<'a> TypeChecker<'a> {
                 let tested = match &ie.cond.kind {
                     ExprKind::Ident(id) => Some(id.clone()),
                     ExprKind::Unary(crate::ast::UnaryOp::Not, inner) => {
-                        if let ExprKind::Ident(id) = &inner.kind { Some(id.clone()) } else { None }
+                        if let ExprKind::Ident(id) = &inner.kind {
+                            Some(id.clone())
+                        } else {
+                            None
+                        }
                     }
                     _ => None,
                 };
@@ -2471,7 +2847,13 @@ impl<'a> TypeChecker<'a> {
         }
     }
 
-    pub(crate) fn check_width_compatible(&mut self, lhs_ty: &Ty, rhs_ty: &Ty, name: &str, span: Span) {
+    pub(crate) fn check_width_compatible(
+        &mut self,
+        lhs_ty: &Ty,
+        rhs_ty: &Ty,
+        name: &str,
+        span: Span,
+    ) {
         // Floating-point: no implicit conversion. The target and RHS must be the
         // exact same float type; a float can't be assigned to/from a non-float
         // either. (Errors and todo! propagate silently.)
@@ -2491,7 +2873,11 @@ impl<'a> TypeChecker<'a> {
         }
         match (lhs_ty, rhs_ty) {
             (Ty::UInt(lw), Ty::UInt(rw)) if rw > lw => {
-                let hint = if *rw == lw + 1 { " (arithmetic widening)" } else { "" };
+                let hint = if *rw == lw + 1 {
+                    " (arithmetic widening)"
+                } else {
+                    ""
+                };
                 self.errors.push(CompileError::general(
                     &format!(
                         "width mismatch: `{name}` is UInt<{lw}> but RHS is UInt<{rw}>{hint}; \
@@ -2501,7 +2887,11 @@ impl<'a> TypeChecker<'a> {
                 ));
             }
             (Ty::SInt(lw), Ty::SInt(rw)) if rw > lw => {
-                let hint = if *rw == lw + 1 { " (arithmetic widening)" } else { "" };
+                let hint = if *rw == lw + 1 {
+                    " (arithmetic widening)"
+                } else {
+                    ""
+                };
                 self.errors.push(CompileError::general(
                     &format!(
                         "width mismatch: `{name}` is SInt<{lw}> but RHS is SInt<{rw}>{hint}; \
@@ -2515,8 +2905,14 @@ impl<'a> TypeChecker<'a> {
     }
 
     /// Emit an error when an enum match is not exhaustive (no wildcard and missing variants).
-    pub(crate) fn check_match_exhaustive(&mut self, scrutinee: &Expr, patterns: &[Pattern], span: Span,
-                              module_name: &str, local_types: &HashMap<String, Ty>) {
+    pub(crate) fn check_match_exhaustive(
+        &mut self,
+        scrutinee: &Expr,
+        patterns: &[Pattern],
+        span: Span,
+        module_name: &str,
+        local_types: &HashMap<String, Ty>,
+    ) {
         let scrutinee_ty = self.resolve_expr_type(scrutinee, module_name, local_types);
         let enum_name = match &scrutinee_ty {
             Ty::Enum(name, _) => name.clone(),
@@ -2525,11 +2921,20 @@ impl<'a> TypeChecker<'a> {
         if patterns.iter().any(|p| matches!(p, Pattern::Wildcard)) {
             return; // wildcard covers everything
         }
-        let covered: HashSet<String> = patterns.iter().filter_map(|p| {
-            if let Pattern::EnumVariant(_, variant) = p { Some(variant.name.clone()) } else { None }
-        }).collect();
+        let covered: HashSet<String> = patterns
+            .iter()
+            .filter_map(|p| {
+                if let Pattern::EnumVariant(_, variant) = p {
+                    Some(variant.name.clone())
+                } else {
+                    None
+                }
+            })
+            .collect();
         if let Some((Symbol::Enum(info), _)) = self.symbols.globals.get(&enum_name).cloned() {
-            let missing: Vec<String> = info.variants.iter()
+            let missing: Vec<String> = info
+                .variants
+                .iter()
                 .filter(|v| !covered.contains(*v))
                 .map(|v| format!("`{enum_name}::{v}`"))
                 .collect();
@@ -2554,7 +2959,14 @@ impl<'a> TypeChecker<'a> {
         driven: &mut HashSet<String>,
     ) {
         let empty_regs: HashSet<String> = HashSet::new();
-        self.check_stmt(stmt, module_name, local_types, driven, BlockKind::Seq, &empty_regs);
+        self.check_stmt(
+            stmt,
+            module_name,
+            local_types,
+            driven,
+            BlockKind::Seq,
+            &empty_regs,
+        );
     }
 
     /// Unified `Stmt` typecheck walker for both `comb` and `seq` (and seq's
@@ -2585,7 +2997,11 @@ impl<'a> TypeChecker<'a> {
         match stmt {
             Stmt::Assign(a) => {
                 let name = Self::expr_root_name_tc(&a.target);
-                let target_name = if name.is_empty() { format!("{:?}", a.target.kind) } else { name.clone() };
+                let target_name = if name.is_empty() {
+                    format!("{:?}", a.target.kind)
+                } else {
+                    name.clone()
+                };
                 // Comb-only: `reg` targets must be assigned in seq, not comb.
                 if in_comb && reg_names.contains(&target_name) {
                     self.errors.push(CompileError::general(
@@ -2596,9 +3012,13 @@ impl<'a> TypeChecker<'a> {
                         a.span,
                     ));
                 }
-                if !target_name.is_empty() { driven.insert(target_name.clone()); }
+                if !target_name.is_empty() {
+                    driven.insert(target_name.clone());
+                }
                 let flat = Self::expr_flat_name_tc(&a.target);
-                if flat != target_name { driven.insert(flat.clone()); }
+                if flat != target_name {
+                    driven.insert(flat.clone());
+                }
                 // Vec-of-bus indexed write with a non-literal index — e.g.
                 // `chans[i].sig = ...` inside a `for i in 0..N` loop. The
                 // root name alone ("chans") doesn't satisfy the per-copy
@@ -2610,11 +3030,13 @@ impl<'a> TypeChecker<'a> {
                 if let ExprKind::FieldAccess(base, field) = &a.target.kind {
                     if let ExprKind::Index(arr, idx) = &base.kind {
                         if let ExprKind::Ident(arr_name) = &arr.kind {
-                            let is_literal = matches!(&idx.kind,
-                                ExprKind::Literal(LitKind::Dec(_)) |
-                                ExprKind::Literal(LitKind::Hex(_)) |
-                                ExprKind::Literal(LitKind::Bin(_)) |
-                                ExprKind::Literal(LitKind::Sized(..)));
+                            let is_literal = matches!(
+                                &idx.kind,
+                                ExprKind::Literal(LitKind::Dec(_))
+                                    | ExprKind::Literal(LitKind::Hex(_))
+                                    | ExprKind::Literal(LitKind::Bin(_))
+                                    | ExprKind::Literal(LitKind::Sized(..))
+                            );
                             if !is_literal {
                                 if let Some(&n) = self.vec_of_bus_ports.get(arr_name) {
                                     for i in 0..n {
@@ -2633,10 +3055,18 @@ impl<'a> TypeChecker<'a> {
                 // behavior); seq uses resolve_expr_type to handle Index /
                 // BitSlice correctly.
                 let lhs_ty: Option<Ty> = if in_comb {
-                    if is_indexed { None } else { local_types.get(&target_name).cloned() }
+                    if is_indexed {
+                        None
+                    } else {
+                        local_types.get(&target_name).cloned()
+                    }
                 } else {
                     let t = self.resolve_expr_type(&a.target, module_name, local_types);
-                    if t != Ty::Error && local_types.contains_key(&target_name) { Some(t) } else { None }
+                    if t != Ty::Error && local_types.contains_key(&target_name) {
+                        Some(t)
+                    } else {
+                        None
+                    }
                 };
                 if let Some(lhs_ty) = lhs_ty {
                     self.check_width_compatible(&lhs_ty, &rhs_ty, &target_name, a.span);
@@ -2662,11 +3092,25 @@ impl<'a> TypeChecker<'a> {
                     // branches are not multi-driven. Merge after.
                     let mut then_driven = driven.clone();
                     for s in &ie.then_stmts {
-                        self.check_stmt(s, module_name, local_types, &mut then_driven, block_kind, reg_names);
+                        self.check_stmt(
+                            s,
+                            module_name,
+                            local_types,
+                            &mut then_driven,
+                            block_kind,
+                            reg_names,
+                        );
                     }
                     let mut else_driven = driven.clone();
                     for s in &ie.else_stmts {
-                        self.check_stmt(s, module_name, local_types, &mut else_driven, block_kind, reg_names);
+                        self.check_stmt(
+                            s,
+                            module_name,
+                            local_types,
+                            &mut else_driven,
+                            block_kind,
+                            reg_names,
+                        );
                     }
                     for nm in then_driven.iter().chain(else_driven.iter()) {
                         driven.insert(nm.clone());
@@ -2682,7 +3126,13 @@ impl<'a> TypeChecker<'a> {
             }
             Stmt::Match(m) => {
                 let patterns: Vec<Pattern> = m.arms.iter().map(|a| a.pattern.clone()).collect();
-                self.check_match_exhaustive(&m.scrutinee, &patterns, m.span, module_name, local_types);
+                self.check_match_exhaustive(
+                    &m.scrutinee,
+                    &patterns,
+                    m.span,
+                    module_name,
+                    local_types,
+                );
                 for arm in &m.arms {
                     for s in &arm.body {
                         self.check_stmt(s, module_name, local_types, driven, block_kind, reg_names);
@@ -2707,17 +3157,22 @@ impl<'a> TypeChecker<'a> {
                     ));
                     return;
                 }
-                let valid_reset = self.source.items.iter().find_map(|item| {
-                    if let Item::Module(m) = item {
-                        if m.name.name == module_name {
-                            return Some(m.ports.iter().any(|p| {
-                                p.name.name == ib.reset_signal.name
-                                    && matches!(&p.ty, TypeExpr::Reset(_, _))
-                            }));
+                let valid_reset = self
+                    .source
+                    .items
+                    .iter()
+                    .find_map(|item| {
+                        if let Item::Module(m) = item {
+                            if m.name.name == module_name {
+                                return Some(m.ports.iter().any(|p| {
+                                    p.name.name == ib.reset_signal.name
+                                        && matches!(&p.ty, TypeExpr::Reset(_, _))
+                                }));
+                            }
                         }
-                    }
-                    None
-                }).unwrap_or(false);
+                        None
+                    })
+                    .unwrap_or(false);
                 if !valid_reset {
                     self.errors.push(CompileError::general(
                         &format!(
@@ -2796,22 +3251,34 @@ impl<'a> TypeChecker<'a> {
                 }
             }
             Stmt::IfElse(ie) => {
-                for s in &ie.then_stmts { Self::reject_bare_assign_in_for(s, in_for, errors); }
-                for s in &ie.else_stmts { Self::reject_bare_assign_in_for(s, in_for, errors); }
+                for s in &ie.then_stmts {
+                    Self::reject_bare_assign_in_for(s, in_for, errors);
+                }
+                for s in &ie.else_stmts {
+                    Self::reject_bare_assign_in_for(s, in_for, errors);
+                }
             }
             Stmt::For(f) => {
-                for s in &f.body { Self::reject_bare_assign_in_for(s, true, errors); }
+                for s in &f.body {
+                    Self::reject_bare_assign_in_for(s, true, errors);
+                }
             }
             Stmt::Match(m) => {
                 for arm in &m.arms {
-                    for s in &arm.body { Self::reject_bare_assign_in_for(s, in_for, errors); }
+                    for s in &arm.body {
+                        Self::reject_bare_assign_in_for(s, in_for, errors);
+                    }
                 }
             }
             Stmt::Init(ib) => {
-                for s in &ib.body { Self::reject_bare_assign_in_for(s, in_for, errors); }
+                for s in &ib.body {
+                    Self::reject_bare_assign_in_for(s, in_for, errors);
+                }
             }
             Stmt::DoUntil { body, .. } => {
-                for s in body { Self::reject_bare_assign_in_for(s, in_for, errors); }
+                for s in body {
+                    Self::reject_bare_assign_in_for(s, in_for, errors);
+                }
             }
             _ => {}
         }
@@ -2852,12 +3319,22 @@ impl<'a> TypeChecker<'a> {
         driven: &mut HashSet<String>,
         reg_names: &HashSet<String>,
     ) {
-        self.check_stmt(stmt, module_name, local_types, driven, BlockKind::Comb, reg_names);
+        self.check_stmt(
+            stmt,
+            module_name,
+            local_types,
+            driven,
+            BlockKind::Comb,
+            reg_names,
+        );
     }
 
     /// Check for latches: signals assigned on some but not all paths in a comb block.
     /// Returns (all_assigned, fully_assigned) for the statement list.
-    fn comb_latch_targets(stmts: &[Stmt], symbols: &crate::resolve::SymbolTable) -> (HashSet<String>, HashSet<String>) {
+    fn comb_latch_targets(
+        stmts: &[Stmt],
+        symbols: &crate::resolve::SymbolTable,
+    ) -> (HashSet<String>, HashSet<String>) {
         let mut all = HashSet::new();
         let mut full = HashSet::new();
 
@@ -2873,7 +3350,8 @@ impl<'a> TypeChecker<'a> {
                 Stmt::IfElse(ie) => {
                     let (then_all, then_full) = Self::comb_latch_targets(&ie.then_stmts, symbols);
                     let (else_all, else_full) = Self::comb_latch_targets(&ie.else_stmts, symbols);
-                    all.extend(then_all); all.extend(else_all);
+                    all.extend(then_all);
+                    all.extend(else_all);
                     // Const-true cond (e.g. desugared `port.ch.no_send()` /
                     // `.send(x)` wrappers): the then-branch is unconditional,
                     // promote its assigns to full regardless of an empty else.
@@ -2881,7 +3359,9 @@ impl<'a> TypeChecker<'a> {
                         ExprKind::Literal(LitKind::Sized(_, n)) if *n != 0)
                         || matches!(&ie.cond.kind, ExprKind::Literal(LitKind::Dec(n)) if *n != 0);
                     if cond_is_true {
-                        for name in &then_full { full.insert(name.clone()); }
+                        for name in &then_full {
+                            full.insert(name.clone());
+                        }
                     } else {
                         // A signal is fully assigned through an if/else only if
                         // assigned on BOTH branches.  No else = empty else_full.
@@ -2891,8 +3371,13 @@ impl<'a> TypeChecker<'a> {
                     }
                 }
                 Stmt::Match(m) => {
-                    let has_wildcard = m.arms.iter().any(|a| matches!(a.pattern, Pattern::Wildcard));
-                    let arm_results: Vec<(HashSet<String>, HashSet<String>)> = m.arms.iter()
+                    let has_wildcard = m
+                        .arms
+                        .iter()
+                        .any(|a| matches!(a.pattern, Pattern::Wildcard));
+                    let arm_results: Vec<(HashSet<String>, HashSet<String>)> = m
+                        .arms
+                        .iter()
                         .map(|arm| {
                             // Comb match arm bodies are Vec<Stmt> — extract assign targets.
                             let mut arm_all = HashSet::new();
@@ -2916,12 +3401,24 @@ impl<'a> TypeChecker<'a> {
                     let mut is_exhaustive = has_wildcard || m.unique;
                     if !is_exhaustive {
                         // Check if all arms are EnumVariant patterns covering every variant
-                        let covered: HashSet<String> = m.arms.iter().filter_map(|a| {
-                            if let Pattern::EnumVariant(_, v) = &a.pattern { Some(v.name.clone()) } else { None }
-                        }).collect();
+                        let covered: HashSet<String> = m
+                            .arms
+                            .iter()
+                            .filter_map(|a| {
+                                if let Pattern::EnumVariant(_, v) = &a.pattern {
+                                    Some(v.name.clone())
+                                } else {
+                                    None
+                                }
+                            })
+                            .collect();
                         // Find the enum name from the first EnumVariant pattern
                         if let Some(enum_name) = m.arms.iter().find_map(|a| {
-                            if let Pattern::EnumVariant(e, _) = &a.pattern { Some(e.name.clone()) } else { None }
+                            if let Pattern::EnumVariant(e, _) = &a.pattern {
+                                Some(e.name.clone())
+                            } else {
+                                None
+                            }
                         }) {
                             if let Some((Symbol::Enum(info), _)) = symbols.globals.get(&enum_name) {
                                 is_exhaustive = info.variants.iter().all(|v| covered.contains(v));
@@ -2930,8 +3427,10 @@ impl<'a> TypeChecker<'a> {
                     }
                     if is_exhaustive {
                         if let Some(first_full) = arm_results.first().map(|(_, f)| f.clone()) {
-                            let intersection: HashSet<String> = arm_results.iter()
-                                .fold(first_full, |acc, (_, f)| acc.intersection(f).cloned().collect());
+                            let intersection: HashSet<String> =
+                                arm_results.iter().fold(first_full, |acc, (_, f)| {
+                                    acc.intersection(f).cloned().collect()
+                                });
                             full.extend(intersection);
                         }
                     }
@@ -2948,7 +3447,9 @@ impl<'a> TypeChecker<'a> {
                         }
                     }
                 }
-                    Stmt::Init(_) | Stmt::WaitUntil(..) | Stmt::DoUntil { .. } => unreachable!("seq-only Stmt variant inside comb-context walker"),
+                Stmt::Init(_) | Stmt::WaitUntil(..) | Stmt::DoUntil { .. } => {
+                    unreachable!("seq-only Stmt variant inside comb-context walker")
+                }
                 Stmt::Log(_) => {}
             }
         }
@@ -3030,7 +3531,8 @@ impl<'a> TypeChecker<'a> {
                         }
                     }
                 } else {
-                    self.errors.push(CompileError::undefined(&ident.name, ident.span));
+                    self.errors
+                        .push(CompileError::undefined(&ident.name, ident.span));
                     Ty::Error
                 }
             }
@@ -3071,9 +3573,13 @@ impl<'a> TypeChecker<'a> {
                     TypeExpr::SInt(w) => eval_type_width_expr(w).map(Ty::SInt).unwrap_or(Ty::Error),
                     TypeExpr::Bool | TypeExpr::Bit => Ty::Bool,
                     TypeExpr::Named(ident) => {
-                        if let Some((crate::resolve::Symbol::Struct(_), _)) = self.symbols.globals.get(&ident.name) {
+                        if let Some((crate::resolve::Symbol::Struct(_), _)) =
+                            self.symbols.globals.get(&ident.name)
+                        {
                             Ty::Struct(ident.name.clone())
-                        } else if let Some((crate::resolve::Symbol::Enum(info), _)) = self.symbols.globals.get(&ident.name) {
+                        } else if let Some((crate::resolve::Symbol::Enum(info), _)) =
+                            self.symbols.globals.get(&ident.name)
+                        {
                             Ty::Enum(ident.name.clone(), enum_width(info.variants.len()))
                         } else {
                             Ty::Error
@@ -3153,8 +3659,12 @@ impl<'a> TypeChecker<'a> {
                     UnaryOp::RedAnd | UnaryOp::RedOr | UnaryOp::RedXor => Ty::Bool,
                 }
             }
-            ExprKind::FieldAccess(base, field) => self.resolve_field_access_type(base, field, expr.span, module_name, local_types),
-            ExprKind::MethodCall(base, method, args) => self.resolve_method_call_type(base, method, args, module_name, local_types),
+            ExprKind::FieldAccess(base, field) => {
+                self.resolve_field_access_type(base, field, expr.span, module_name, local_types)
+            }
+            ExprKind::MethodCall(base, method, args) => {
+                self.resolve_method_call_type(base, method, args, module_name, local_types)
+            }
             ExprKind::Cast(inner, ty) => {
                 let src_ty = self.resolve_expr_type(inner, module_name, local_types);
                 let dst_ty = self.resolve_type_expr(ty, module_name, local_types);
@@ -3209,7 +3719,11 @@ impl<'a> TypeChecker<'a> {
                 match (hi_val, lo_val) {
                     (Some(h), Some(l)) if h >= l => {
                         let w = (h - l + 1) as u32;
-                        if let Ty::SInt(_) = base_ty { Ty::SInt(w) } else { Ty::UInt(w) }
+                        if let Ty::SInt(_) = base_ty {
+                            Ty::SInt(w)
+                        } else {
+                            Ty::UInt(w)
+                        }
                     }
                     _ => Ty::Error,
                 }
@@ -3247,7 +3761,13 @@ impl<'a> TypeChecker<'a> {
             }
             ExprKind::ExprMatch(scrutinee, arms) => {
                 let patterns: Vec<Pattern> = arms.iter().map(|a| a.pattern.clone()).collect();
-                self.check_match_exhaustive(scrutinee, &patterns, expr.span, module_name, local_types);
+                self.check_match_exhaustive(
+                    scrutinee,
+                    &patterns,
+                    expr.span,
+                    module_name,
+                    local_types,
+                );
                 // Return type from first non-wildcard arm
                 for arm in arms {
                     return self.resolve_expr_type(&arm.value, module_name, local_types);
@@ -3256,13 +3776,16 @@ impl<'a> TypeChecker<'a> {
             }
             ExprKind::Concat(parts) => {
                 // Total width = sum of each part's width (Bool=1, UInt<N>=N, else 1)
-                let total: u32 = parts.iter().map(|p| {
-                    match self.resolve_expr_type(p, module_name, local_types) {
-                        Ty::UInt(w) | Ty::SInt(w) => w,
-                        Ty::Bool => 1,
-                        _ => 1,
-                    }
-                }).sum();
+                let total: u32 = parts
+                    .iter()
+                    .map(
+                        |p| match self.resolve_expr_type(p, module_name, local_types) {
+                            Ty::UInt(w) | Ty::SInt(w) => w,
+                            Ty::Bool => 1,
+                            _ => 1,
+                        },
+                    )
+                    .sum();
                 Ty::UInt(total)
             }
             ExprKind::Repeat(count, value) => {
@@ -3278,7 +3801,11 @@ impl<'a> TypeChecker<'a> {
             ExprKind::Clog2(arg) => {
                 // $clog2 returns a compile-time constant width value
                 if let Some(v) = self.eval_const_expr(arg, local_types) {
-                    let bits = if v == 0 { 1 } else { 64 - v.leading_zeros() as u64 };
+                    let bits = if v == 0 {
+                        1
+                    } else {
+                        64 - v.leading_zeros() as u64
+                    };
                     Ty::UInt(bits as u32)
                 } else {
                     Ty::UInt(32) // fallback: treat as generic integer
@@ -3302,7 +3829,10 @@ impl<'a> TypeChecker<'a> {
                     Ty::Enum(_, w) => Ty::SInt(w),
                     _ => {
                         self.errors.push(CompileError::general(
-                            &format!("signed() requires UInt, SInt, or Bool operand, got {}", inner_ty.display()),
+                            &format!(
+                                "signed() requires UInt, SInt, or Bool operand, got {}",
+                                inner_ty.display()
+                            ),
                             expr.span,
                         ));
                         Ty::Error
@@ -3317,7 +3847,10 @@ impl<'a> TypeChecker<'a> {
                     Ty::Enum(_, w) => Ty::UInt(w),
                     _ => {
                         self.errors.push(CompileError::general(
-                            &format!("unsigned() requires UInt, SInt, or Bool operand, got {}", inner_ty.display()),
+                            &format!(
+                                "unsigned() requires UInt, SInt, or Bool operand, got {}",
+                                inner_ty.display()
+                            ),
                             expr.span,
                         ));
                         Ty::Error
@@ -3337,7 +3870,9 @@ impl<'a> TypeChecker<'a> {
                 self.resolve_expr_type(scrutinee, module_name, local_types);
                 for m in members {
                     match m {
-                        InsideMember::Single(e) => { self.resolve_expr_type(e, module_name, local_types); }
+                        InsideMember::Single(e) => {
+                            self.resolve_expr_type(e, module_name, local_types);
+                        }
                         InsideMember::Range(lo, hi) => {
                             self.resolve_expr_type(lo, module_name, local_types);
                             self.resolve_expr_type(hi, module_name, local_types);
@@ -3361,7 +3896,9 @@ impl<'a> TypeChecker<'a> {
                     let ta = self.resolve_expr_type(&call_args[0], module_name, local_types);
                     let tb = self.resolve_expr_type(&call_args[1], module_name, local_types);
                     let tc = self.resolve_expr_type(&call_args[2], module_name, local_types);
-                    if ta == Ty::Error || tb == Ty::Error || tc == Ty::Error { return Ty::Error; }
+                    if ta == Ty::Error || tb == Ty::Error || tc == Ty::Error {
+                        return Ty::Error;
+                    }
                     if !ta.is_float() || tb != ta || tc != ta {
                         self.errors.push(CompileError::general(
                             &format!("`fma` requires three operands of the same float type, got {}, {}, {}",
@@ -3396,7 +3933,9 @@ impl<'a> TypeChecker<'a> {
                 if name == "rose" || name == "fell" {
                     if !self.in_sva_context {
                         self.errors.push(CompileError::general(
-                            &format!("`{name}(...)` is only legal inside `assert` / `cover` bodies"),
+                            &format!(
+                                "`{name}(...)` is only legal inside `assert` / `cover` bodies"
+                            ),
                             expr.span,
                         ));
                         return Ty::Error;
@@ -3411,7 +3950,10 @@ impl<'a> TypeChecker<'a> {
                     let inner = self.resolve_expr_type(&call_args[0], module_name, local_types);
                     if inner != Ty::Bool && inner != Ty::Error && inner != Ty::Todo {
                         self.errors.push(CompileError::general(
-                            &format!("`{name}(expr)` requires Bool argument, got {}", inner.display()),
+                            &format!(
+                                "`{name}(expr)` requires Bool argument, got {}",
+                                inner.display()
+                            ),
                             call_args[0].span,
                         ));
                     }
@@ -3461,7 +4003,8 @@ impl<'a> TypeChecker<'a> {
                 }
                 if let Some((Symbol::Function(overloads), _)) = self.symbols.globals.get(name) {
                     // Resolve argument types first.
-                    let arg_tys: Vec<Ty> = call_args.iter()
+                    let arg_tys: Vec<Ty> = call_args
+                        .iter()
                         .map(|a| {
                             let mut lt = local_types.clone();
                             self.resolve_expr_type(a, module_name, &mut lt)
@@ -3471,23 +4014,28 @@ impl<'a> TypeChecker<'a> {
                     // Find matching overload: same arity, compatible types.
                     let overloads = overloads.clone(); // detach borrow so we can call &mut self methods
                     let chosen = overloads.iter().enumerate().find(|(_, ov)| {
-                        if ov.arg_types.len() != arg_tys.len() { return false; }
-                        ov.arg_types.iter().zip(arg_tys.iter()).all(|(expected_te, actual_ty)| {
-                            match (expected_te, actual_ty) {
-                                (TypeExpr::UInt(we), Ty::UInt(wa)) => {
-                                    // Compare widths when the expression is a simple literal.
-                                    eval_type_width_expr(we).map_or(true, |ew| ew == *wa)
+                        if ov.arg_types.len() != arg_tys.len() {
+                            return false;
+                        }
+                        ov.arg_types
+                            .iter()
+                            .zip(arg_tys.iter())
+                            .all(|(expected_te, actual_ty)| {
+                                match (expected_te, actual_ty) {
+                                    (TypeExpr::UInt(we), Ty::UInt(wa)) => {
+                                        // Compare widths when the expression is a simple literal.
+                                        eval_type_width_expr(we).map_or(true, |ew| ew == *wa)
+                                    }
+                                    (TypeExpr::SInt(we), Ty::SInt(wa)) => {
+                                        eval_type_width_expr(we).map_or(true, |ew| ew == *wa)
+                                    }
+                                    (TypeExpr::Bool, Ty::Bool) => true,
+                                    (TypeExpr::Bit, Ty::UInt(1)) => true,
+                                    (TypeExpr::UInt(_), Ty::Todo)
+                                    | (TypeExpr::SInt(_), Ty::Todo) => true,
+                                    _ => false,
                                 }
-                                (TypeExpr::SInt(we), Ty::SInt(wa)) => {
-                                    eval_type_width_expr(we).map_or(true, |ew| ew == *wa)
-                                }
-                                (TypeExpr::Bool, Ty::Bool) => true,
-                                (TypeExpr::Bit,  Ty::UInt(1)) => true,
-                                (TypeExpr::UInt(_), Ty::Todo)
-                                | (TypeExpr::SInt(_), Ty::Todo) => true,
-                                _ => false,
-                            }
-                        })
+                            })
                     });
 
                     match chosen {
@@ -3500,12 +4048,18 @@ impl<'a> TypeChecker<'a> {
                         }
                         None => {
                             // No exact type match; try arity-only match as fallback.
-                            if let Some(ov) = overloads.iter().find(|ov| ov.arg_types.len() == call_args.len()) {
+                            if let Some(ov) = overloads
+                                .iter()
+                                .find(|ov| ov.arg_types.len() == call_args.len())
+                            {
                                 let ret_ty = ov.ret_ty.clone();
                                 self.resolve_type_expr(&ret_ty, module_name, local_types)
                             } else {
                                 self.errors.push(CompileError::general(
-                                    &format!("no matching overload for `{name}` with {} argument(s)", call_args.len()),
+                                    &format!(
+                                        "no matching overload for `{name}` with {} argument(s)",
+                                        call_args.len()
+                                    ),
                                     expr.span,
                                 ));
                                 Ty::Error
@@ -3577,7 +4131,8 @@ impl<'a> TypeChecker<'a> {
         if let Ty::Bus(name) = &base_ty {
             if let Some((sym, _)) = self.symbols.globals.get(name) {
                 if let crate::resolve::Symbol::Bus(info) = sym {
-                    let _eff = info.effective_signals(&info.default_param_map()); for (sname, _dir, sty) in &_eff {
+                    let _eff = info.effective_signals(&info.default_param_map());
+                    for (sname, _dir, sty) in &_eff {
                         if sname == &field.name {
                             return self.resolve_type_expr(sty, module_name, local_types);
                         }
@@ -3660,7 +4215,10 @@ impl<'a> TypeChecker<'a> {
                             }
                             if (method.name == "zext" || method.name == "sext") && target_w == sw {
                                 self.errors.push(CompileError::general(
-                                    &format!(".{}<{}>() on a {}-bit value is a no-op — remove the cast", method.name, target_w, sw),
+                                    &format!(
+                                        ".{}<{}>() on a {}-bit value is a no-op — remove the cast",
+                                        method.name, target_w, sw
+                                    ),
                                     method.span,
                                 ));
                                 return Ty::Error;
@@ -3692,12 +4250,20 @@ impl<'a> TypeChecker<'a> {
             // `.to_sint<N>()` convert a float to an integer (toward-zero,
             // saturating per the RISC-V profile — see doc/plan_fp_types.md §6).
             "to_fp32" | "to_bf16" => {
-                let target = if method.name == "to_fp32" { Ty::FP32 } else { Ty::BF16 };
+                let target = if method.name == "to_fp32" {
+                    Ty::FP32
+                } else {
+                    Ty::BF16
+                };
                 match &base_ty {
                     Ty::FP32 | Ty::BF16 | Ty::UInt(_) | Ty::SInt(_) | Ty::Bool => {
                         if base_ty == target {
                             self.errors.push(CompileError::general(
-                                &format!(".{}() on a {} value is a no-op — remove the cast", method.name, target.display()),
+                                &format!(
+                                    ".{}() on a {} value is a no-op — remove the cast",
+                                    method.name,
+                                    target.display()
+                                ),
                                 method.span,
                             ));
                             return Ty::Error;
@@ -3708,7 +4274,11 @@ impl<'a> TypeChecker<'a> {
                     Ty::Error => Ty::Error,
                     _ => {
                         self.errors.push(CompileError::general(
-                            &format!(".{}() requires a float or integer operand, got {}", method.name, base_ty.display()),
+                            &format!(
+                                ".{}() requires a float or integer operand, got {}",
+                                method.name,
+                                base_ty.display()
+                            ),
                             method.span,
                         ));
                         Ty::Error
@@ -3718,7 +4288,11 @@ impl<'a> TypeChecker<'a> {
             "to_uint" | "to_sint" => {
                 if !base_ty.is_float() && !matches!(base_ty, Ty::Todo | Ty::Error) {
                     self.errors.push(CompileError::general(
-                        &format!(".{}<N>() requires a floating-point operand, got {}", method.name, base_ty.display()),
+                        &format!(
+                            ".{}<N>() requires a floating-point operand, got {}",
+                            method.name,
+                            base_ty.display()
+                        ),
                         method.span,
                     ));
                     return Ty::Error;
@@ -3726,13 +4300,20 @@ impl<'a> TypeChecker<'a> {
                 if let Some(width_expr) = args.first() {
                     if let Some(w) = self.eval_const_expr(width_expr, local_types) {
                         let target_w = w as u32;
-                        if method.name == "to_uint" { Ty::UInt(target_w) } else { Ty::SInt(target_w) }
+                        if method.name == "to_uint" {
+                            Ty::UInt(target_w)
+                        } else {
+                            Ty::SInt(target_w)
+                        }
                     } else {
                         Ty::Error
                     }
                 } else {
                     self.errors.push(CompileError::general(
-                        &format!(".{}<N>() requires a width type argument, e.g. .{}<32>()", method.name, method.name),
+                        &format!(
+                            ".{}<N>() requires a width type argument, e.g. .{}<32>()",
+                            method.name, method.name
+                        ),
                         method.span,
                     ));
                     Ty::Error
@@ -3754,7 +4335,10 @@ impl<'a> TypeChecker<'a> {
                                 Ty::Bool => 1,
                                 _ => {
                                     self.errors.push(CompileError::general(
-                                        &format!(".reverse(N) requires UInt/SInt/Bool base, got {}", base_ty.display()),
+                                        &format!(
+                                            ".reverse(N) requires UInt/SInt/Bool base, got {}",
+                                            base_ty.display()
+                                        ),
                                         method.span,
                                     ));
                                     return Ty::Error;
@@ -3784,14 +4368,17 @@ impl<'a> TypeChecker<'a> {
             // Vec reduction + predicate methods (plan_vec_methods.md v1, PR #1 subset).
             // `item` is the per-iteration element, `index` is the position (UInt<clog2(N)>).
             // Both are injected into the predicate's local scope during checking.
-            "any" | "all" | "count" | "contains"
-            | "reduce_or" | "reduce_and" | "reduce_xor" | "find_first" => {
+            "any" | "all" | "count" | "contains" | "reduce_or" | "reduce_and" | "reduce_xor"
+            | "find_first" => {
                 let (elem_ty, n) = match &base_ty {
                     Ty::Vec(inner, count) => ((**inner).clone(), *count),
                     _ => {
                         self.errors.push(CompileError::general(
-                            &format!("`.{}(...)` requires a Vec<T,N> receiver, got {}",
-                                method.name, base_ty.display()),
+                            &format!(
+                                "`.{}(...)` requires a Vec<T,N> receiver, got {}",
+                                method.name,
+                                base_ty.display()
+                            ),
                             method.span,
                         ));
                         return Ty::Error;
@@ -3799,19 +4386,27 @@ impl<'a> TypeChecker<'a> {
                 };
                 if n == 0 {
                     self.errors.push(CompileError::general(
-                        &format!("`.{}(...)` on a zero-length Vec has no meaningful result", method.name),
+                        &format!(
+                            "`.{}(...)` on a zero-length Vec has no meaningful result",
+                            method.name
+                        ),
                         method.span,
                     ));
                     return Ty::Error;
                 }
                 let idx_w = crate::width::index_width(n as u64);
-                let pred_needed = !matches!(method.name.as_str(),
-                    "reduce_or" | "reduce_and" | "reduce_xor" | "contains");
+                let pred_needed = !matches!(
+                    method.name.as_str(),
+                    "reduce_or" | "reduce_and" | "reduce_xor" | "contains"
+                );
 
                 if pred_needed {
                     if args.len() != 1 {
                         self.errors.push(CompileError::general(
-                            &format!("`.{}(pred)` takes exactly 1 argument (the predicate)", method.name),
+                            &format!(
+                                "`.{}(pred)` takes exactly 1 argument (the predicate)",
+                                method.name
+                            ),
                             method.span,
                         ));
                         return Ty::Error;
@@ -3836,7 +4431,9 @@ impl<'a> TypeChecker<'a> {
                         self.errors.push(CompileError::general(
                             &format!(
                                 "`.{}` predicate must be Bool, got {}",
-                                method.name, pred_ty.display()),
+                                method.name,
+                                pred_ty.display()
+                            ),
                             args[0].span,
                         ));
                         return Ty::Error;
@@ -3852,8 +4449,7 @@ impl<'a> TypeChecker<'a> {
                     let arg_ty = self.resolve_expr_type(&args[0], module_name, local_types);
                     // Basic element-type compatibility (same kind + width).
                     let compatible = match (&elem_ty, &arg_ty) {
-                        (Ty::UInt(a), Ty::UInt(b))
-                        | (Ty::SInt(a), Ty::SInt(b)) => a == b,
+                        (Ty::UInt(a), Ty::UInt(b)) | (Ty::SInt(a), Ty::SInt(b)) => a == b,
                         (Ty::Bool, Ty::Bool) => true,
                         _ => elem_ty == arg_ty,
                     };
@@ -3898,8 +4494,11 @@ impl<'a> TypeChecker<'a> {
                             Ty::SInt(w) => Ty::SInt(*w),
                             _ => {
                                 self.errors.push(CompileError::general(
-                                    &format!("`.{}()` requires UInt/SInt/Bool element type, got `{}`",
-                                        method.name, elem_ty.display()),
+                                    &format!(
+                                        "`.{}()` requires UInt/SInt/Bool element type, got `{}`",
+                                        method.name,
+                                        elem_ty.display()
+                                    ),
                                     method.span,
                                 ));
                                 return Ty::Error;
@@ -3912,16 +4511,27 @@ impl<'a> TypeChecker<'a> {
             _ => Ty::Error,
         }
     }
-    pub(crate) fn check_precedence_ambiguity(&mut self, op: BinOp, lhs: &Expr, rhs: &Expr, span: Span) {
+    pub(crate) fn check_precedence_ambiguity(
+        &mut self,
+        op: BinOp,
+        lhs: &Expr,
+        rhs: &Expr,
+        span: Span,
+    ) {
         let is_bitwise = matches!(op, BinOp::BitAnd | BinOp::BitOr | BinOp::BitXor);
-        let is_comparison = matches!(op, BinOp::Eq | BinOp::Neq | BinOp::Lt | BinOp::Gt | BinOp::Lte | BinOp::Gte);
+        let is_comparison = matches!(
+            op,
+            BinOp::Eq | BinOp::Neq | BinOp::Lt | BinOp::Gt | BinOp::Lte | BinOp::Gte
+        );
 
         // Case 1: comparison with unparenthesized bitwise child
         // e.g. `a & b == c` — ARCH parses as (a & b) == c, SV parses as a & (b == c)
         if is_comparison {
             for child in [lhs, rhs] {
                 if let ExprKind::Binary(child_op, _, _) = &child.kind {
-                    if matches!(child_op, BinOp::BitAnd | BinOp::BitOr | BinOp::BitXor) && !child.parenthesized {
+                    if matches!(child_op, BinOp::BitAnd | BinOp::BitOr | BinOp::BitXor)
+                        && !child.parenthesized
+                    {
                         self.errors.push(CompileError::general(
                             &format!(
                                 "ambiguous precedence: bitwise '{}' inside comparison '{}' — add parentheses (ARCH and SystemVerilog parse this differently)",
@@ -3939,7 +4549,11 @@ impl<'a> TypeChecker<'a> {
         if is_bitwise {
             for child in [lhs, rhs] {
                 if let ExprKind::Binary(child_op, _, _) = &child.kind {
-                    if matches!(child_op, BinOp::Eq | BinOp::Neq | BinOp::Lt | BinOp::Gt | BinOp::Lte | BinOp::Gte) && !child.parenthesized {
+                    if matches!(
+                        child_op,
+                        BinOp::Eq | BinOp::Neq | BinOp::Lt | BinOp::Gt | BinOp::Lte | BinOp::Gte
+                    ) && !child.parenthesized
+                    {
                         self.errors.push(CompileError::general(
                             &format!(
                                 "ambiguous precedence: comparison '{}' inside bitwise '{}' — add parentheses (ARCH and SystemVerilog parse this differently)",
@@ -3966,9 +4580,15 @@ impl<'a> TypeChecker<'a> {
         // there is no implicit float conversion (use `.to_fp32()`/`.to_bf16()`).
         if lt.is_float() || rt.is_float() {
             let sym = match op {
-                BinOp::Add => "+", BinOp::Sub => "-", BinOp::Mul => "*",
-                BinOp::Eq => "==", BinOp::Neq => "!=", BinOp::Lt => "<",
-                BinOp::Gt => ">", BinOp::Lte => "<=", BinOp::Gte => ">=",
+                BinOp::Add => "+",
+                BinOp::Sub => "-",
+                BinOp::Mul => "*",
+                BinOp::Eq => "==",
+                BinOp::Neq => "!=",
+                BinOp::Lt => "<",
+                BinOp::Gt => ">",
+                BinOp::Lte => "<=",
+                BinOp::Gte => ">=",
                 _ => "<op>",
             };
             match op {
@@ -4012,9 +4632,7 @@ impl<'a> TypeChecker<'a> {
         }
 
         match op {
-            BinOp::Eq | BinOp::Neq | BinOp::Lt | BinOp::Gt | BinOp::Lte | BinOp::Gte => {
-                Ty::Bool
-            }
+            BinOp::Eq | BinOp::Neq | BinOp::Lt | BinOp::Gt | BinOp::Lte | BinOp::Gte => Ty::Bool,
             BinOp::And | BinOp::Or | BinOp::Implies | BinOp::ImpliesNext => Ty::Bool,
             BinOp::Add | BinOp::Sub => {
                 let lw = lt.width().unwrap_or(1);
@@ -4060,7 +4678,11 @@ impl<'a> TypeChecker<'a> {
                 // Bool is UInt<1>; bitwise ops on two 1-bit types stay Bool.
                 let lw = lt.width().unwrap_or(1);
                 let rw = rt.width().unwrap_or(1);
-                if lw.max(rw) == 1 { Ty::Bool } else { Ty::UInt(lw.max(rw)) }
+                if lw.max(rw) == 1 {
+                    Ty::Bool
+                } else {
+                    Ty::UInt(lw.max(rw))
+                }
             }
             BinOp::Shl | BinOp::Shr => lt.clone(),
         }
@@ -4116,16 +4738,28 @@ impl<'a> TypeChecker<'a> {
             ExprKind::Binary(BinOp::Div, lhs, rhs) => {
                 let l = self.eval_const_expr(lhs, local_types)?;
                 let r = self.eval_const_expr(rhs, local_types)?;
-                if r == 0 { None } else { Some(l / r) }
+                if r == 0 {
+                    None
+                } else {
+                    Some(l / r)
+                }
             }
             ExprKind::Binary(BinOp::Mod, lhs, rhs) => {
                 let l = self.eval_const_expr(lhs, local_types)?;
                 let r = self.eval_const_expr(rhs, local_types)?;
-                if r == 0 { None } else { Some(l % r) }
+                if r == 0 {
+                    None
+                } else {
+                    Some(l % r)
+                }
             }
             ExprKind::Clog2(arg) => {
                 let v = self.eval_const_expr(arg, local_types)?;
-                if v <= 1 { Some(1) } else { Some(64 - (v - 1).leading_zeros() as u64) }
+                if v <= 1 {
+                    Some(1)
+                } else {
+                    Some(64 - (v - 1).leading_zeros() as u64)
+                }
             }
             _ => None,
         }
@@ -4167,20 +4801,36 @@ impl<'a> TypeChecker<'a> {
             guard_sig: Option<String>,
         }
 
-        let async_resets: HashSet<String> = m.ports.iter()
-            .filter_map(|p| if let TypeExpr::Reset(ResetKind::Async, _) = &p.ty {
-                Some(p.name.name.clone())
-            } else { None })
+        let async_resets: HashSet<String> = m
+            .ports
+            .iter()
+            .filter_map(|p| {
+                if let TypeExpr::Reset(ResetKind::Async, _) = &p.ty {
+                    Some(p.name.name.clone())
+                } else {
+                    None
+                }
+            })
             .collect();
-        let sync_resets: HashSet<String> = m.ports.iter()
-            .filter_map(|p| if let TypeExpr::Reset(ResetKind::Sync, _) = &p.ty {
-                Some(p.name.name.clone())
-            } else { None })
+        let sync_resets: HashSet<String> = m
+            .ports
+            .iter()
+            .filter_map(|p| {
+                if let TypeExpr::Reset(ResetKind::Sync, _) = &p.ty {
+                    Some(p.name.name.clone())
+                } else {
+                    None
+                }
+            })
             .collect();
         let kind_of_reset = |sig: &str| -> Option<ResetKind> {
-            if async_resets.contains(sig) { Some(ResetKind::Async) }
-            else if sync_resets.contains(sig) { Some(ResetKind::Sync) }
-            else { None }
+            if async_resets.contains(sig) {
+                Some(ResetKind::Async)
+            } else if sync_resets.contains(sig) {
+                Some(ResetKind::Sync)
+            } else {
+                None
+            }
         };
 
         let mut flop_info: HashMap<String, FlopInfo> = HashMap::new();
@@ -4195,38 +4845,56 @@ impl<'a> TypeChecker<'a> {
             if let ModuleBodyItem::RegDecl(rd) = item {
                 let sig = extract_reset_sig(&rd.reset);
                 let kind = sig.as_deref().and_then(kind_of_reset);
-                flop_info.insert(rd.name.name.clone(), FlopInfo {
-                    reset_sig: sig,
-                    reset_kind: kind,
-                    decl_span: rd.name.span,
-                    guard_sig: rd.guard.as_ref().map(|g| g.name.clone()),
-                });
+                flop_info.insert(
+                    rd.name.name.clone(),
+                    FlopInfo {
+                        reset_sig: sig,
+                        reset_kind: kind,
+                        decl_span: rd.name.span,
+                        guard_sig: rd.guard.as_ref().map(|g| g.name.clone()),
+                    },
+                );
             }
         }
         for p in &m.ports {
             if let Some(ri) = &p.reg_info {
                 let sig = extract_reset_sig(&ri.reset);
                 let kind = sig.as_deref().and_then(kind_of_reset);
-                flop_info.insert(p.name.name.clone(), FlopInfo {
-                    reset_sig: sig,
-                    reset_kind: kind,
-                    decl_span: p.name.span,
-                    guard_sig: ri.guard.as_ref().map(|g| g.name.clone()),
-                });
+                flop_info.insert(
+                    p.name.name.clone(),
+                    FlopInfo {
+                        reset_sig: sig,
+                        reset_kind: kind,
+                        decl_span: p.name.span,
+                        guard_sig: ri.guard.as_ref().map(|g| g.name.clone()),
+                    },
+                );
             }
         }
         // Fast path: if no async-reset flops exist, no domain originated,
         // no violation possible. Skip the heavier work.
-        let any_async = flop_info.values().any(|fi| matches!(fi.reset_kind, Some(ResetKind::Async)));
-        if !any_async { return; }
+        let any_async = flop_info
+            .values()
+            .any(|fi| matches!(fi.reset_kind, Some(ResetKind::Async)));
+        if !any_async {
+            return;
+        }
 
         let flop_set: HashSet<String> = flop_info.keys().cloned().collect();
 
         // 2. Build let-binding transitive flop reads. A `let x = expr;` is
         //    a combinational wire; if `expr` reads flop r, then any
         //    consumer reading `x` is effectively reading r.
-        let lets: Vec<&LetBinding> = m.body.iter()
-            .filter_map(|i| if let ModuleBodyItem::LetBinding(l) = i { Some(l) } else { None })
+        let lets: Vec<&LetBinding> = m
+            .body
+            .iter()
+            .filter_map(|i| {
+                if let ModuleBodyItem::LetBinding(l) = i {
+                    Some(l)
+                } else {
+                    None
+                }
+            })
             .collect();
         let let_names: HashSet<String> = lets.iter().map(|l| l.name.name.clone()).collect();
         let mut let_deps: HashMap<String, HashSet<String>> = HashMap::new();
@@ -4254,7 +4922,9 @@ impl<'a> TypeChecker<'a> {
                 let entry = let_deps.get_mut(&l.name.name).unwrap();
                 let before = entry.len();
                 entry.extend(to_add);
-                if entry.len() != before { changed = true; }
+                if entry.len() != before {
+                    changed = true;
+                }
             }
         }
 
@@ -4262,7 +4932,9 @@ impl<'a> TypeChecker<'a> {
         //    seq block, collect rhs reads; flops feed directly, lets feed
         //    transitively via let_deps.
         let mut flop_deps: HashMap<String, HashSet<String>> = HashMap::new();
-        for f in &flop_set { flop_deps.insert(f.clone(), HashSet::new()); }
+        for f in &flop_set {
+            flop_deps.insert(f.clone(), HashSet::new());
+        }
 
         fn walk_seq_assigns(
             stmts: &[Stmt],
@@ -4330,7 +5002,9 @@ impl<'a> TypeChecker<'a> {
         while changed {
             changed = false;
             for (name, info) in &flop_info {
-                if matches!(info.reset_kind, Some(ResetKind::Async)) { continue; }
+                if matches!(info.reset_kind, Some(ResetKind::Async)) {
+                    continue;
+                }
                 let deps = flop_deps.get(name).cloned().unwrap_or_default();
                 let mut new_reach: HashSet<String> = HashSet::new();
                 for src in &deps {
@@ -4374,7 +5048,11 @@ impl<'a> TypeChecker<'a> {
                                  `{my_reset}` but its data input transitively reads from \
                                  register(s) reset by async signal(s) {} — async reset \
                                  domains cannot be crossed without a `synchronizer kind reset`.",
-                                foreign.iter().map(|d| format!("`{d}`")).collect::<Vec<_>>().join(", ")
+                                foreign
+                                    .iter()
+                                    .map(|d| format!("`{d}`"))
+                                    .collect::<Vec<_>>()
+                                    .join(", ")
                             ),
                             info.decl_span,
                         ));
@@ -4398,14 +5076,18 @@ impl<'a> TypeChecker<'a> {
                         // those domains, gating the unreset data).
                         let waived_by_guard = info.guard_sig.as_ref().and_then(|g| {
                             let gi = flop_info.get(g)?;
-                            if !matches!(gi.reset_kind, Some(ResetKind::Async)) { return None; }
+                            if !matches!(gi.reset_kind, Some(ResetKind::Async)) {
+                                return None;
+                            }
                             let g_reset = gi.reset_sig.as_ref()?;
                             // Every reach domain must equal the guard's
                             // reset signal — otherwise the guard doesn't
                             // protect the foreign domain(s) we cross.
                             if r.iter().all(|d| d == g_reset) {
                                 Some((g.clone(), g_reset.clone()))
-                            } else { None }
+                            } else {
+                                None
+                            }
                         });
                         if waived_by_guard.is_some() {
                             continue;
@@ -4421,15 +5103,26 @@ impl<'a> TypeChecker<'a> {
                         let domain_phrase = if domains.len() == 1 {
                             format!("async reset domain `{}`", domains[0])
                         } else {
-                            format!("multiple async reset domains ({})",
-                                domains.iter().map(|d| format!("`{d}`")).collect::<Vec<_>>().join(", "))
+                            format!(
+                                "multiple async reset domains ({})",
+                                domains
+                                    .iter()
+                                    .map(|d| format!("`{d}`"))
+                                    .collect::<Vec<_>>()
+                                    .join(", ")
+                            )
                         };
                         // Hint about the issue-#260 waiver path when the
                         // user has a guard but it doesn't qualify (so they
                         // can fix the guard's reset rather than reaching
                         // for `pragma rdc_safe`).
-                        let guard_hint = match (&info.guard_sig, info.guard_sig.as_ref().and_then(|g| flop_info.get(g))) {
-                            (Some(g), Some(gi)) if !matches!(gi.reset_kind, Some(ResetKind::Async)) => {
+                        let guard_hint = match (
+                            &info.guard_sig,
+                            info.guard_sig.as_ref().and_then(|g| flop_info.get(g)),
+                        ) {
+                            (Some(g), Some(gi))
+                                if !matches!(gi.reset_kind, Some(ResetKind::Async)) =>
+                            {
                                 format!(" (Note: `guard {g}` is present but `{g}` is not async-reset, so the guard waiver does not apply.)")
                             }
                             (Some(g), None) => {
@@ -4461,8 +5154,17 @@ impl<'a> TypeChecker<'a> {
         // clock pulses on `clk_out`. Walk every inst whose target
         // construct is a `clkgate` and compute reach for the parent-side
         // signal driving its `enable` port. Non-empty → violation.
-        let clkgate_constructs: HashSet<String> = self.source.items.iter()
-            .filter_map(|it| if let Item::Clkgate(c) = it { Some(c.name.name.clone()) } else { None })
+        let clkgate_constructs: HashSet<String> = self
+            .source
+            .items
+            .iter()
+            .filter_map(|it| {
+                if let Item::Clkgate(c) = it {
+                    Some(c.name.name.clone())
+                } else {
+                    None
+                }
+            })
             .collect();
         if !clkgate_constructs.is_empty() {
             let reach_for_signal = |sig: &Expr| -> HashSet<String> {
@@ -4470,10 +5172,14 @@ impl<'a> TypeChecker<'a> {
                 Self::collect_expr_reads(sig, &mut reads);
                 let mut acc: HashSet<String> = HashSet::new();
                 for r in &reads {
-                    if let Some(rr) = reach.get(r) { acc.extend(rr.iter().cloned()); }
+                    if let Some(rr) = reach.get(r) {
+                        acc.extend(rr.iter().cloned());
+                    }
                     if let Some(ld) = let_deps.get(r) {
                         for f in ld {
-                            if let Some(rr) = reach.get(f) { acc.extend(rr.iter().cloned()); }
+                            if let Some(rr) = reach.get(f) {
+                                acc.extend(rr.iter().cloned());
+                            }
                         }
                     }
                 }
@@ -4481,9 +5187,13 @@ impl<'a> TypeChecker<'a> {
             };
             for item in &m.body {
                 if let ModuleBodyItem::Inst(inst) = item {
-                    if !clkgate_constructs.contains(&inst.module_name.name) { continue; }
+                    if !clkgate_constructs.contains(&inst.module_name.name) {
+                        continue;
+                    }
                     for conn in &inst.connections {
-                        if conn.port_name.name != "enable" { continue; }
+                        if conn.port_name.name != "enable" {
+                            continue;
+                        }
                         let domains = reach_for_signal(&conn.signal);
                         if !domains.is_empty() {
                             let mut sorted: Vec<String> = domains.into_iter().collect();
@@ -4491,8 +5201,14 @@ impl<'a> TypeChecker<'a> {
                             let domain_phrase = if sorted.len() == 1 {
                                 format!("async reset domain `{}`", sorted[0])
                             } else {
-                                format!("async reset domains ({})",
-                                    sorted.iter().map(|d| format!("`{d}`")).collect::<Vec<_>>().join(", "))
+                                format!(
+                                    "async reset domains ({})",
+                                    sorted
+                                        .iter()
+                                        .map(|d| format!("`{d}`"))
+                                        .collect::<Vec<_>>()
+                                        .join(", ")
+                                )
                             };
                             self.errors.push(CompileError::general(
                                 &format!(
@@ -4544,44 +5260,77 @@ impl<'a> TypeChecker<'a> {
         // diagnostic. A heterogeneous group (some reset, some data
         // synchronisers off the same source) gets the more general
         // "RDC/CDC" wording.
-        let sync_kinds: HashMap<String, SyncKind> = self.source.items.iter()
-            .filter_map(|it| if let Item::Synchronizer(s) = it {
-                Some((s.name.name.clone(), s.kind))
-            } else { None })
+        let sync_kinds: HashMap<String, SyncKind> = self
+            .source
+            .items
+            .iter()
+            .filter_map(|it| {
+                if let Item::Synchronizer(s) = it {
+                    Some((s.name.name.clone(), s.kind))
+                } else {
+                    None
+                }
+            })
             .collect();
-        if sync_kinds.is_empty() { return; }
+        if sync_kinds.is_empty() {
+            return;
+        }
         // Per-port clock domain map (rebuilt locally — independent of
         // phase 1's CDC gate so a single-clock module with reconvergent
         // syncs into that one domain still trips).
-        let clk_domain: HashMap<String, String> = m.ports.iter()
-            .filter_map(|p| if let TypeExpr::Clock(domain) = &p.ty {
-                Some((p.name.name.clone(), domain.name.clone()))
-            } else { None })
+        let clk_domain: HashMap<String, String> = m
+            .ports
+            .iter()
+            .filter_map(|p| {
+                if let TypeExpr::Clock(domain) = &p.ty {
+                    Some((p.name.name.clone(), domain.name.clone()))
+                } else {
+                    None
+                }
+            })
             .collect();
         // Build let-binding indirection map: `let x = expr;` lets the
         // source-tracing pass walk through `x` to its underlying source
         // registers, catching common-source-via-comb cases (Aldec article
         // 2140's bit-slice / common-source-register patterns).
-        let let_map: HashMap<String, &Expr> = m.body.iter()
-            .filter_map(|i| if let ModuleBodyItem::LetBinding(l) = i {
-                Some((l.name.name.clone(), &l.value))
-            } else { None })
+        let let_map: HashMap<String, &Expr> = m
+            .body
+            .iter()
+            .filter_map(|i| {
+                if let ModuleBodyItem::LetBinding(l) = i {
+                    Some((l.name.name.clone(), &l.value))
+                } else {
+                    None
+                }
+            })
             .collect();
         // Per-sync-instance terminal source-register set (after walking
         // through bit-slice, concat, unary/binary, let bindings). For
         // each terminal source ident, group by (ident, dest_domain).
         #[allow(clippy::type_complexity)]
-        let mut groups: HashMap<(String, String), Vec<(String, SyncKind, crate::lexer::Span)>> = HashMap::new();
+        let mut groups: HashMap<
+            (String, String),
+            Vec<(String, SyncKind, crate::lexer::Span)>,
+        > = HashMap::new();
         for item in &m.body {
-            let ModuleBodyItem::Inst(inst) = item else { continue; };
-            let Some(kind) = sync_kinds.get(&inst.module_name.name) else { continue; };
+            let ModuleBodyItem::Inst(inst) = item else {
+                continue;
+            };
+            let Some(kind) = sync_kinds.get(&inst.module_name.name) else {
+                continue;
+            };
             let mut src_set: HashSet<String> = HashSet::new();
             let mut dst_clk_sig: Option<String> = None;
             for conn in &inst.connections {
                 match conn.port_name.name.as_str() {
                     "data_in" => {
                         let mut visited = HashSet::new();
-                        Self::collect_source_idents(&conn.signal, &let_map, &mut visited, &mut src_set);
+                        Self::collect_source_idents(
+                            &conn.signal,
+                            &let_map,
+                            &mut visited,
+                            &mut src_set,
+                        );
                     }
                     "dst_clk" => {
                         if let ExprKind::Ident(n) = &conn.signal.kind {
@@ -4591,13 +5340,21 @@ impl<'a> TypeChecker<'a> {
                     _ => {}
                 }
             }
-            if src_set.is_empty() { continue; }
-            let Some(clk) = dst_clk_sig else { continue; };
-            let Some(dom) = clk_domain.get(&clk) else { continue; };
+            if src_set.is_empty() {
+                continue;
+            }
+            let Some(clk) = dst_clk_sig else {
+                continue;
+            };
+            let Some(dom) = clk_domain.get(&clk) else {
+                continue;
+            };
             for src in &src_set {
-                groups.entry((src.clone(), dom.clone()))
-                    .or_default()
-                    .push((inst.name.name.clone(), *kind, inst.span));
+                groups.entry((src.clone(), dom.clone())).or_default().push((
+                    inst.name.name.clone(),
+                    *kind,
+                    inst.span,
+                ));
             }
         }
         // Sort for deterministic diagnostics across HashMap iteration.
@@ -4610,14 +5367,21 @@ impl<'a> TypeChecker<'a> {
         let mut reported_inst_sets: HashSet<Vec<String>> = HashSet::new();
         for key in sorted_keys {
             let users = &groups[&key];
-            if users.len() < 2 { continue; }
+            if users.len() < 2 {
+                continue;
+            }
             let mut inst_set: Vec<String> = users.iter().map(|(n, _, _)| n.clone()).collect();
             inst_set.sort();
             inst_set.dedup();
-            if inst_set.len() < 2 { continue; }
-            if !reported_inst_sets.insert(inst_set.clone()) { continue; }
+            if inst_set.len() < 2 {
+                continue;
+            }
+            if !reported_inst_sets.insert(inst_set.clone()) {
+                continue;
+            }
             let (source, domain) = key;
-            let inst_list = inst_set.iter()
+            let inst_list = inst_set
+                .iter()
                 .map(|n| format!("`{n}`"))
                 .collect::<Vec<_>>()
                 .join(", ");
@@ -4629,9 +5393,9 @@ impl<'a> TypeChecker<'a> {
             let any_reset = users.iter().any(|(_, k, _)| *k == SyncKind::Reset);
             let any_data = users.iter().any(|(_, k, _)| *k != SyncKind::Reset);
             let (label, sync_word, settle_word) = match (any_reset, any_data) {
-                (true,  false) => ("RDC",     "reset synchronisers", "deassert"),
-                (false, true)  => ("CDC",     "synchronisers",       "settle"),
-                _              => ("RDC/CDC", "synchronisers",       "settle"),
+                (true, false) => ("RDC", "reset synchronisers", "deassert"),
+                (false, true) => ("CDC", "synchronisers", "settle"),
+                _ => ("RDC/CDC", "synchronisers", "settle"),
             };
             self.errors.push(CompileError::general(
                 &format!(
@@ -4683,13 +5447,23 @@ impl<'a> TypeChecker<'a> {
                 Self::collect_source_idents(base, let_map, visited, out);
                 Self::collect_source_idents(idx, let_map, visited, out);
             }
-            ExprKind::BitSlice(base, _, _) => Self::collect_source_idents(base, let_map, visited, out),
-            ExprKind::PartSelect(base, _, _, _) => Self::collect_source_idents(base, let_map, visited, out),
-            ExprKind::FieldAccess(base, _) => Self::collect_source_idents(base, let_map, visited, out),
+            ExprKind::BitSlice(base, _, _) => {
+                Self::collect_source_idents(base, let_map, visited, out)
+            }
+            ExprKind::PartSelect(base, _, _, _) => {
+                Self::collect_source_idents(base, let_map, visited, out)
+            }
+            ExprKind::FieldAccess(base, _) => {
+                Self::collect_source_idents(base, let_map, visited, out)
+            }
             ExprKind::Cast(e, _) => Self::collect_source_idents(e, let_map, visited, out),
-            ExprKind::Signed(e) | ExprKind::Unsigned(e) => Self::collect_source_idents(e, let_map, visited, out),
+            ExprKind::Signed(e) | ExprKind::Unsigned(e) => {
+                Self::collect_source_idents(e, let_map, visited, out)
+            }
             ExprKind::Concat(parts) => {
-                for p in parts { Self::collect_source_idents(p, let_map, visited, out); }
+                for p in parts {
+                    Self::collect_source_idents(p, let_map, visited, out);
+                }
             }
             ExprKind::Repeat(n, e) => {
                 Self::collect_source_idents(n, let_map, visited, out);
@@ -4701,13 +5475,19 @@ impl<'a> TypeChecker<'a> {
                 Self::collect_source_idents(e, let_map, visited, out);
             }
             ExprKind::FunctionCall(_, args) => {
-                for a in args { Self::collect_source_idents(a, let_map, visited, out); }
+                for a in args {
+                    Self::collect_source_idents(a, let_map, visited, out);
+                }
             }
             ExprKind::MethodCall(base, _, args) => {
                 Self::collect_source_idents(base, let_map, visited, out);
-                for a in args { Self::collect_source_idents(a, let_map, visited, out); }
+                for a in args {
+                    Self::collect_source_idents(a, let_map, visited, out);
+                }
             }
-            ExprKind::Clog2(e) | ExprKind::Onehot(e) => Self::collect_source_idents(e, let_map, visited, out),
+            ExprKind::Clog2(e) | ExprKind::Onehot(e) => {
+                Self::collect_source_idents(e, let_map, visited, out)
+            }
             _ => {}
         }
     }
@@ -4744,18 +5524,18 @@ impl<'a> TypeChecker<'a> {
         let lookup_ports = |name: &str| -> Vec<PortDecl> {
             for item in &self.source.items {
                 let ports = match item {
-                    Item::Module(m)       if m.name.name == name => Some(&m.ports),
-                    Item::Fsm(f)          if f.name.name == name => Some(&f.ports),
-                    Item::Fifo(f)         if f.name.name == name => Some(&f.ports),
-                    Item::Ram(r)          if r.name.name == name => Some(&r.ports),
-                    Item::Cam(c)          if c.name.name == name => Some(&c.ports),
-                    Item::Counter(c)      if c.name.name == name => Some(&c.ports),
-                    Item::Arbiter(a)      if a.name.name == name => Some(&a.ports),
-                    Item::Regfile(r)      if r.name.name == name => Some(&r.ports),
-                    Item::Pipeline(p)     if p.name.name == name => Some(&p.ports),
-                    Item::Linklist(l)     if l.name.name == name => Some(&l.ports),
+                    Item::Module(m) if m.name.name == name => Some(&m.ports),
+                    Item::Fsm(f) if f.name.name == name => Some(&f.ports),
+                    Item::Fifo(f) if f.name.name == name => Some(&f.ports),
+                    Item::Ram(r) if r.name.name == name => Some(&r.ports),
+                    Item::Cam(c) if c.name.name == name => Some(&c.ports),
+                    Item::Counter(c) if c.name.name == name => Some(&c.ports),
+                    Item::Arbiter(a) if a.name.name == name => Some(&a.ports),
+                    Item::Regfile(r) if r.name.name == name => Some(&r.ports),
+                    Item::Pipeline(p) if p.name.name == name => Some(&p.ports),
+                    Item::Linklist(l) if l.name.name == name => Some(&l.ports),
                     Item::Synchronizer(s) if s.name.name == name => Some(&s.ports),
-                    Item::Clkgate(c)      if c.name.name == name => Some(&c.ports),
+                    Item::Clkgate(c) if c.name.name == name => Some(&c.ports),
                     _ => None,
                 };
                 if let Some(p) = ports {
@@ -4765,20 +5545,32 @@ impl<'a> TypeChecker<'a> {
             Vec::new()
         };
         for item in &m.body {
-            let ModuleBodyItem::Inst(inst) = item else { continue; };
+            let ModuleBodyItem::Inst(inst) = item else {
+                continue;
+            };
             let sub_ports = lookup_ports(&inst.module_name.name);
             for conn in &inst.connections {
-                let port = sub_ports.iter().find(|p| p.name.name == conn.port_name.name);
-                let Some(port) = port else { continue; };
-                if !matches!(&port.ty, TypeExpr::Reset(_, _)) { continue; }
-                if conn.direction != ConnectDir::Input { continue; }
+                let port = sub_ports
+                    .iter()
+                    .find(|p| p.name.name == conn.port_name.name);
+                let Some(port) = port else {
+                    continue;
+                };
+                if !matches!(&port.ty, TypeExpr::Reset(_, _)) {
+                    continue;
+                }
+                if conn.direction != ConnectDir::Input {
+                    continue;
+                }
                 // Direct reset source → trust. A reset-type cast such as
                 // `rst as Reset<Async, Low>` is an instantiation-time reset
                 // annotation, not reset-combining logic; peel through it so
                 // legacy reset-override examples stay legal. Real logic under
                 // the cast, e.g. `(rst_a | rst_b) as Reset<Async>`, remains a
                 // combiner and is still rejected.
-                if Self::is_direct_reset_inst_signal(&conn.signal) { continue; }
+                if Self::is_direct_reset_inst_signal(&conn.signal) {
+                    continue;
+                }
                 self.errors.push(CompileError::general(
                     &format!(
                         "RDC violation: inst `{inst_name}` (instance of `{sub}`) has its \
@@ -4820,8 +5612,14 @@ impl<'a> TypeChecker<'a> {
         // Find the instantiated module's definition
         let child_module = self.source.items.iter().find_map(|item| {
             if let Item::Module(m) = item {
-                if m.name.name == inst.module_name.name { Some(m) } else { None }
-            } else { None }
+                if m.name.name == inst.module_name.name {
+                    Some(m)
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
         });
         let child_module = match child_module {
             Some(m) => m,
@@ -4829,10 +5627,16 @@ impl<'a> TypeChecker<'a> {
         };
 
         // Build child module's clock port → domain map
-        let child_clk_domain: HashMap<String, String> = child_module.ports.iter()
-            .filter_map(|p| if let TypeExpr::Clock(domain) = &p.ty {
-                Some((p.name.name.clone(), domain.name.clone()))
-            } else { None })
+        let child_clk_domain: HashMap<String, String> = child_module
+            .ports
+            .iter()
+            .filter_map(|p| {
+                if let TypeExpr::Clock(domain) = &p.ty {
+                    Some((p.name.name.clone(), domain.name.clone()))
+                } else {
+                    None
+                }
+            })
             .collect();
 
         if child_clk_domain.is_empty() {
@@ -4881,7 +5685,11 @@ impl<'a> TypeChecker<'a> {
                     let mut reads = HashSet::new();
                     Self::collect_stmt_reads(&rb.stmts, &mut reads);
                     for read_name in &reads {
-                        if child_module.ports.iter().any(|p| p.name.name == *read_name && p.direction == Direction::In) {
+                        if child_module
+                            .ports
+                            .iter()
+                            .any(|p| p.name.name == *read_name && p.direction == Direction::In)
+                        {
                             child_port_domain.insert(read_name.clone(), domain.clone());
                         }
                     }
@@ -4903,7 +5711,8 @@ impl<'a> TypeChecker<'a> {
                 let mut targets = HashSet::new();
                 Self::collect_comb_stmt_targets(&cb.stmts, &mut targets);
                 // If all register reads are from the same domain, targets inherit that domain
-                let domains: HashSet<&String> = reads.iter()
+                let domains: HashSet<&String> = reads
+                    .iter()
                     .filter_map(|r| parent_reg_domain.get(r))
                     .collect();
                 if domains.len() == 1 {
@@ -4916,23 +5725,38 @@ impl<'a> TypeChecker<'a> {
         }
 
         // Build connection map: inst port name → connected signal name
-        let conn_signal: HashMap<String, String> = inst.connections.iter()
+        let conn_signal: HashMap<String, String> = inst
+            .connections
+            .iter()
             .filter_map(|c| {
                 if let ExprKind::Ident(sig_name) = &c.signal.kind {
                     Some((c.port_name.name.clone(), sig_name.clone()))
-                } else { None }
+                } else {
+                    None
+                }
             })
             .collect();
 
         // Find which clock domain each inst clock port is connected to
-        let inst_clk_mapping: HashMap<String, String> = inst.connections.iter()
+        let inst_clk_mapping: HashMap<String, String> = inst
+            .connections
+            .iter()
             .filter_map(|c| {
-                let child_port = child_module.ports.iter().find(|p| p.name.name == c.port_name.name)?;
+                let child_port = child_module
+                    .ports
+                    .iter()
+                    .find(|p| p.name.name == c.port_name.name)?;
                 if let TypeExpr::Clock(_) = &child_port.ty {
                     if let ExprKind::Ident(sig_name) = &c.signal.kind {
-                        parent_clk_domain.get(sig_name).map(|d| (c.port_name.name.clone(), d.clone()))
-                    } else { None }
-                } else { None }
+                        parent_clk_domain
+                            .get(sig_name)
+                            .map(|d| (c.port_name.name.clone(), d.clone()))
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                }
             })
             .collect();
 
@@ -4941,7 +5765,11 @@ impl<'a> TypeChecker<'a> {
             let port_name = &conn.port_name.name;
 
             // Skip clock and reset ports
-            if let Some(child_port) = child_module.ports.iter().find(|p| p.name.name == *port_name) {
+            if let Some(child_port) = child_module
+                .ports
+                .iter()
+                .find(|p| p.name.name == *port_name)
+            {
                 if matches!(&child_port.ty, TypeExpr::Clock(_) | TypeExpr::Reset(..)) {
                     continue;
                 }
@@ -4955,12 +5783,16 @@ impl<'a> TypeChecker<'a> {
 
             // Map child domain to parent domain via clock connections
             // Find which parent clock is connected to the child clock in this domain
-            let expected_parent_domain = inst_clk_mapping.iter()
-                .find_map(|(child_clk, parent_domain)| {
-                    if child_clk_domain.get(child_clk) == Some(child_domain) {
-                        Some(parent_domain.as_str())
-                    } else { None }
-                });
+            let expected_parent_domain =
+                inst_clk_mapping
+                    .iter()
+                    .find_map(|(child_clk, parent_domain)| {
+                        if child_clk_domain.get(child_clk) == Some(child_domain) {
+                            Some(parent_domain.as_str())
+                        } else {
+                            None
+                        }
+                    });
 
             let expected_parent_domain = match expected_parent_domain {
                 Some(d) => d,
@@ -5039,7 +5871,9 @@ impl<'a> TypeChecker<'a> {
                     }
                 }
                 Stmt::Log(l) => {
-                    for arg in &l.args { Self::collect_expr_reads(arg, out); }
+                    for arg in &l.args {
+                        Self::collect_expr_reads(arg, out);
+                    }
                 }
                 Stmt::For(f) => {
                     Self::collect_stmt_reads(&f.body, out);
@@ -5060,7 +5894,9 @@ impl<'a> TypeChecker<'a> {
 
     fn collect_expr_reads(expr: &Expr, out: &mut HashSet<String>) {
         match &expr.kind {
-            ExprKind::Ident(name) => { out.insert(name.clone()); }
+            ExprKind::Ident(name) => {
+                out.insert(name.clone());
+            }
             ExprKind::Binary(_, lhs, rhs) => {
                 Self::collect_expr_reads(lhs, out);
                 Self::collect_expr_reads(rhs, out);
@@ -5083,10 +5919,14 @@ impl<'a> TypeChecker<'a> {
             ExprKind::FieldAccess(base, _) => Self::collect_expr_reads(base, out),
             ExprKind::MethodCall(base, _, args) => {
                 Self::collect_expr_reads(base, out);
-                for a in args { Self::collect_expr_reads(a, out); }
+                for a in args {
+                    Self::collect_expr_reads(a, out);
+                }
             }
             ExprKind::FunctionCall(_, args) => {
-                for a in args { Self::collect_expr_reads(a, out); }
+                for a in args {
+                    Self::collect_expr_reads(a, out);
+                }
             }
             ExprKind::Ternary(cond, then_e, else_e) => {
                 Self::collect_expr_reads(cond, out);
@@ -5095,11 +5935,15 @@ impl<'a> TypeChecker<'a> {
             }
             ExprKind::Match(scrut, arms) => {
                 Self::collect_expr_reads(scrut, out);
-                for arm in arms { Self::collect_stmt_reads(&arm.body, out); }
+                for arm in arms {
+                    Self::collect_stmt_reads(&arm.body, out);
+                }
             }
             ExprKind::ExprMatch(scrut, arms) => {
                 Self::collect_expr_reads(scrut, out);
-                for arm in arms { Self::collect_expr_reads(&arm.value, out); }
+                for arm in arms {
+                    Self::collect_expr_reads(&arm.value, out);
+                }
             }
             ExprKind::Inside(scrut, members) => {
                 Self::collect_expr_reads(scrut, out);
@@ -5129,15 +5973,21 @@ impl<'a> TypeChecker<'a> {
                 }
                 Stmt::Match(m) => {
                     Self::collect_expr_reads(&m.scrutinee, out);
-                    for arm in &m.arms { Self::collect_comb_stmt_reads(&arm.body, out); }
+                    for arm in &m.arms {
+                        Self::collect_comb_stmt_reads(&arm.body, out);
+                    }
                 }
                 Stmt::Log(l) => {
-                    for arg in &l.args { Self::collect_expr_reads(arg, out); }
+                    for arg in &l.args {
+                        Self::collect_expr_reads(arg, out);
+                    }
                 }
                 Stmt::For(f) => {
                     Self::collect_comb_stmt_reads(&f.body, out);
                 }
-                    Stmt::Init(_) | Stmt::WaitUntil(..) | Stmt::DoUntil { .. } => unreachable!("seq-only Stmt variant inside comb-context walker"),
+                Stmt::Init(_) | Stmt::WaitUntil(..) | Stmt::DoUntil { .. } => {
+                    unreachable!("seq-only Stmt variant inside comb-context walker")
+                }
             }
         }
     }
@@ -5146,19 +5996,28 @@ impl<'a> TypeChecker<'a> {
     fn collect_comb_stmt_targets(stmts: &[Stmt], out: &mut HashSet<String>) {
         for stmt in stmts {
             match stmt {
-                Stmt::Assign(a) => { let name = Self::expr_root_name_tc(&a.target); if !name.is_empty() { out.insert(name); } }
+                Stmt::Assign(a) => {
+                    let name = Self::expr_root_name_tc(&a.target);
+                    if !name.is_empty() {
+                        out.insert(name);
+                    }
+                }
                 Stmt::IfElse(ie) => {
                     Self::collect_comb_stmt_targets(&ie.then_stmts, out);
                     Self::collect_comb_stmt_targets(&ie.else_stmts, out);
                 }
                 Stmt::Match(m) => {
-                    for arm in &m.arms { Self::collect_comb_stmt_targets(&arm.body, out); }
+                    for arm in &m.arms {
+                        Self::collect_comb_stmt_targets(&arm.body, out);
+                    }
                 }
                 Stmt::Log(_) => {}
                 Stmt::For(f) => {
                     Self::collect_comb_stmt_targets(&f.body, out);
                 }
-                    Stmt::Init(_) | Stmt::WaitUntil(..) | Stmt::DoUntil { .. } => unreachable!("seq-only Stmt variant inside comb-context walker"),
+                Stmt::Init(_) | Stmt::WaitUntil(..) | Stmt::DoUntil { .. } => {
+                    unreachable!("seq-only Stmt variant inside comb-context walker")
+                }
             }
         }
     }
@@ -5176,7 +6035,9 @@ impl<'a> TypeChecker<'a> {
             if let (Some(h), Some(l), Some(default)) = (
                 crate::elaborate::try_eval_i64(hi, &empty),
                 crate::elaborate::try_eval_i64(lo, &empty),
-                p.default.as_ref().and_then(|d| crate::elaborate::try_eval_i64(d, &empty)),
+                p.default
+                    .as_ref()
+                    .and_then(|d| crate::elaborate::try_eval_i64(d, &empty)),
             ) {
                 let width = (h - l + 1).max(0) as u32;
                 if width < 64 && default as u64 >= (1u64 << width) {
@@ -5294,7 +6155,10 @@ impl<'a> TypeChecker<'a> {
         for sb in &f.states {
             if sb.transitions.is_empty() {
                 self.errors.push(CompileError::general(
-                    &format!("state `{}` has no transitions (dead-end state)", sb.name.name),
+                    &format!(
+                        "state `{}` has no transitions (dead-end state)",
+                        sb.name.name
+                    ),
                     sb.name.span,
                 ));
             }
@@ -5336,12 +6200,15 @@ impl<'a> TypeChecker<'a> {
         // v2: optional dual-write port. If any write2_* port is present,
         // all four must be, so codegen can assume the full bundle.
         let w2_names = ["write2_valid", "write2_idx", "write2_key", "write2_set"];
-        let w2_present: Vec<bool> = w2_names.iter()
+        let w2_present: Vec<bool> = w2_names
+            .iter()
             .map(|n| c.ports.iter().any(|p| p.name.name == *n))
             .collect();
         let has_w2 = w2_present.iter().any(|b| *b);
         if has_w2 && !w2_present.iter().all(|b| *b) {
-            let missing: Vec<&str> = w2_names.iter().zip(&w2_present)
+            let missing: Vec<&str> = w2_names
+                .iter()
+                .zip(&w2_present)
                 .filter(|(_, present)| !**present)
                 .map(|(name, _)| *name)
                 .collect();
@@ -5355,17 +6222,25 @@ impl<'a> TypeChecker<'a> {
         }
         // v3: optional value payload. Activation = VAL_W param + write_value
         // + read_value (and write2_value if dual-write is enabled).
-        let has_val_w     = c.params.iter().any(|p| p.name.name == "VAL_W");
+        let has_val_w = c.params.iter().any(|p| p.name.name == "VAL_W");
         let has_write_val = c.ports.iter().any(|p| p.name.name == "write_value");
-        let has_read_val  = c.ports.iter().any(|p| p.name.name == "read_value");
-        let has_w2_val    = c.ports.iter().any(|p| p.name.name == "write2_value");
+        let has_read_val = c.ports.iter().any(|p| p.name.name == "read_value");
+        let has_w2_val = c.ports.iter().any(|p| p.name.name == "write2_value");
         if has_val_w || has_write_val || has_read_val || has_w2_val {
             // Any one present → all required (matched to the active write port set).
             let mut missing: Vec<&str> = Vec::new();
-            if !has_val_w     { missing.push("param VAL_W");      }
-            if !has_write_val { missing.push("port write_value"); }
-            if !has_read_val  { missing.push("port read_value");  }
-            if has_w2 && !has_w2_val { missing.push("port write2_value"); }
+            if !has_val_w {
+                missing.push("param VAL_W");
+            }
+            if !has_write_val {
+                missing.push("port write_value");
+            }
+            if !has_read_val {
+                missing.push("port read_value");
+            }
+            if has_w2 && !has_w2_val {
+                missing.push("port write2_value");
+            }
             if !missing.is_empty() {
                 self.errors.push(CompileError::general(
                     &format!(
@@ -5423,14 +6298,20 @@ impl<'a> TypeChecker<'a> {
         // true_dual requires exactly 2 port groups
         if r.kind == crate::ast::RamKind::TrueDual && r.port_groups.len() != 2 {
             self.errors.push(CompileError::general(
-                &format!("true_dual ram `{}` must have exactly 2 port groups", r.name.name),
+                &format!(
+                    "true_dual ram `{}` must have exactly 2 port groups",
+                    r.name.name
+                ),
                 r.name.span,
             ));
         }
         // simple_dual requires exactly 2 port groups
         if r.kind == crate::ast::RamKind::SimpleDual && r.port_groups.len() != 2 {
             self.errors.push(CompileError::general(
-                &format!("simple_dual ram `{}` must have exactly 2 port groups", r.name.name),
+                &format!(
+                    "simple_dual ram `{}` must have exactly 2 port groups",
+                    r.name.name
+                ),
                 r.name.span,
             ));
         }
@@ -5448,7 +6329,10 @@ impl<'a> TypeChecker<'a> {
                 for s in &pg.signals {
                     if s.name.name == "wen" || s.name.name == "wdata" {
                         self.errors.push(CompileError::general(
-                            &format!("rom `{}` must not have write signal `{}`", r.name.name, s.name.name),
+                            &format!(
+                                "rom `{}` must not have write signal `{}`",
+                                r.name.name, s.name.name
+                            ),
                             s.name.span,
                         ));
                     }
@@ -5469,8 +6353,14 @@ impl<'a> TypeChecker<'a> {
         }
 
         // Required port names
-        let required = ["push_valid", "push_ready", "push_data",
-                        "pop_valid",  "pop_ready",  "pop_data"];
+        let required = [
+            "push_valid",
+            "push_ready",
+            "push_data",
+            "pop_valid",
+            "pop_ready",
+            "pop_data",
+        ];
         let present: Vec<&str> = f.ports.iter().map(|p| p.name.name.as_str()).collect();
         for req in &required {
             if !present.contains(req) {
@@ -5484,7 +6374,10 @@ impl<'a> TypeChecker<'a> {
         // Require a type parameter for memory element width.
         // Without it, push_data/pop_data widths won't propagate to the
         // internal memory array, producing silently wrong codegen.
-        let has_type_param = f.params.iter().any(|p| matches!(p.kind, crate::ast::ParamKind::Type(_)));
+        let has_type_param = f
+            .params
+            .iter()
+            .any(|p| matches!(p.kind, crate::ast::ParamKind::Type(_)));
         if !has_type_param {
             self.errors.push(CompileError::general(
                 &format!(
@@ -5520,8 +6413,16 @@ impl<'a> TypeChecker<'a> {
         }
 
         // Must have exactly two clock ports from different domains
-        let clk_ports: Vec<(&Ident, &Ident)> = s.ports.iter()
-            .filter_map(|p| if let TypeExpr::Clock(domain) = &p.ty { Some((&p.name, domain)) } else { None })
+        let clk_ports: Vec<(&Ident, &Ident)> = s
+            .ports
+            .iter()
+            .filter_map(|p| {
+                if let TypeExpr::Clock(domain) = &p.ty {
+                    Some((&p.name, domain))
+                } else {
+                    None
+                }
+            })
             .collect();
         if clk_ports.len() != 2 {
             self.errors.push(CompileError::general(
@@ -5540,7 +6441,10 @@ impl<'a> TypeChecker<'a> {
         for req in &["data_in", "data_out"] {
             if !port_names.contains(req) {
                 self.errors.push(CompileError::general(
-                    &format!("synchronizer `{}` is missing required port `{req}`", s.name.name),
+                    &format!(
+                        "synchronizer `{}` is missing required port `{req}`",
+                        s.name.name
+                    ),
                     s.name.span,
                 ));
             }
@@ -5552,7 +6456,10 @@ impl<'a> TypeChecker<'a> {
                 if let ExprKind::Literal(LitKind::Dec(v)) = &default.kind {
                     if *v < 2 {
                         self.errors.push(CompileError::general(
-                            &format!("synchronizer `{}`: STAGES must be >= 2 (got {})", s.name.name, v),
+                            &format!(
+                                "synchronizer `{}`: STAGES must be >= 2 (got {})",
+                                s.name.name, v
+                            ),
                             stages_param.name.span,
                         ));
                     }
@@ -5580,13 +6487,19 @@ impl<'a> TypeChecker<'a> {
                 }
                 SyncKind::Reset if !is_single_bit => {
                     self.errors.push(CompileError::general(
-                        &format!("synchronizer `{}`: `kind reset` requires single-bit (Bool) data ports", s.name.name),
+                        &format!(
+                            "synchronizer `{}`: `kind reset` requires single-bit (Bool) data ports",
+                            s.name.name
+                        ),
                         data_in.span,
                     ));
                 }
                 SyncKind::Pulse if !is_single_bit => {
                     self.errors.push(CompileError::general(
-                        &format!("synchronizer `{}`: `kind pulse` requires single-bit (Bool) data ports", s.name.name),
+                        &format!(
+                            "synchronizer `{}`: `kind pulse` requires single-bit (Bool) data ports",
+                            s.name.name
+                        ),
                         data_in.span,
                     ));
                 }
@@ -5607,29 +6520,41 @@ impl<'a> TypeChecker<'a> {
         }
 
         // Must have exactly one Clock input and one Clock output with matching domain
-        let clk_in_ports: Vec<&crate::ast::PortDecl> = c.ports.iter()
+        let clk_in_ports: Vec<&crate::ast::PortDecl> = c
+            .ports
+            .iter()
             .filter(|p| matches!(&p.ty, TypeExpr::Clock(_)) && p.direction == Direction::In)
             .collect();
-        let clk_out_ports: Vec<&crate::ast::PortDecl> = c.ports.iter()
+        let clk_out_ports: Vec<&crate::ast::PortDecl> = c
+            .ports
+            .iter()
             .filter(|p| matches!(&p.ty, TypeExpr::Clock(_)) && p.direction == Direction::Out)
             .collect();
 
         if clk_in_ports.len() != 1 {
             self.errors.push(CompileError::general(
-                &format!("clkgate `{}` must have exactly 1 Clock input port", c.name.name),
+                &format!(
+                    "clkgate `{}` must have exactly 1 Clock input port",
+                    c.name.name
+                ),
                 c.name.span,
             ));
         }
         if clk_out_ports.len() != 1 {
             self.errors.push(CompileError::general(
-                &format!("clkgate `{}` must have exactly 1 Clock output port", c.name.name),
+                &format!(
+                    "clkgate `{}` must have exactly 1 Clock output port",
+                    c.name.name
+                ),
                 c.name.span,
             ));
         }
 
         // Check domains match
         if clk_in_ports.len() == 1 && clk_out_ports.len() == 1 {
-            if let (TypeExpr::Clock(d_in), TypeExpr::Clock(d_out)) = (&clk_in_ports[0].ty, &clk_out_ports[0].ty) {
+            if let (TypeExpr::Clock(d_in), TypeExpr::Clock(d_out)) =
+                (&clk_in_ports[0].ty, &clk_out_ports[0].ty)
+            {
                 if d_in.name != d_out.name {
                     self.errors.push(CompileError::general(
                         &format!("clkgate `{}`: input clock domain `{}` must match output clock domain `{}`",
@@ -5641,10 +6566,16 @@ impl<'a> TypeChecker<'a> {
         }
 
         // Must have enable port (Bool input)
-        let has_enable = c.ports.iter().any(|p| p.name.name == "enable" && p.direction == Direction::In);
+        let has_enable = c
+            .ports
+            .iter()
+            .any(|p| p.name.name == "enable" && p.direction == Direction::In);
         if !has_enable {
             self.errors.push(CompileError::general(
-                &format!("clkgate `{}` is missing required `enable: in Bool` port", c.name.name),
+                &format!(
+                    "clkgate `{}` is missing required `enable: in Bool` port",
+                    c.name.name
+                ),
                 c.name.span,
             ));
         }
@@ -5690,7 +6621,10 @@ impl<'a> TypeChecker<'a> {
         if let ArbiterPolicy::Custom(ref fn_ident) = a.policy {
             if a.hook.is_none() {
                 self.errors.push(CompileError::general(
-                    &format!("custom policy `{}` requires a `hook grant_select` declaration", fn_ident.name),
+                    &format!(
+                        "custom policy `{}` requires a `hook grant_select` declaration",
+                        fn_ident.name
+                    ),
                     fn_ident.span,
                 ));
                 return;
@@ -5699,7 +6633,10 @@ impl<'a> TypeChecker<'a> {
             // Verify the hook's bound function name matches the policy name
             if hook.fn_name.name != fn_ident.name {
                 self.errors.push(CompileError::general(
-                    &format!("hook function `{}` does not match policy name `{}`", hook.fn_name.name, fn_ident.name),
+                    &format!(
+                        "hook function `{}` does not match policy name `{}`",
+                        hook.fn_name.name, fn_ident.name
+                    ),
                     hook.fn_name.span,
                 ));
             }
@@ -5720,7 +6657,8 @@ impl<'a> TypeChecker<'a> {
             // Verify hook argument bindings reference declared ports or params
             let port_names: Vec<&str> = a.ports.iter().map(|p| p.name.name.as_str()).collect();
             let param_names: Vec<&str> = a.params.iter().map(|p| p.name.name.as_str()).collect();
-            let hook_param_names: Vec<&str> = hook.params.iter().map(|p| p.name.name.as_str()).collect();
+            let hook_param_names: Vec<&str> =
+                hook.params.iter().map(|p| p.name.name.as_str()).collect();
             // Hook parameter names must not shadow arbiter port names — the
             // codegen emits the function inside the module, so a name collision
             // produces SV VARHIDDEN warnings.
@@ -5742,7 +6680,10 @@ impl<'a> TypeChecker<'a> {
                     && !param_names.contains(&arg.name.as_str())
                 {
                     self.errors.push(CompileError::general(
-                        &format!("hook argument `{}` is not a hook parameter, port, or param", arg.name),
+                        &format!(
+                            "hook argument `{}` is not a hook parameter, port, or param",
+                            arg.name
+                        ),
                         arg.span,
                     ));
                 }
@@ -5794,10 +6735,14 @@ impl<'a> TypeChecker<'a> {
     ) {
         match item {
             ModuleBodyItem::CombBlock(cb) => {
-                for s in &cb.stmts { self.walk_pipeline_comb_stmt(s, cur_idx, stage_idx, cur_name); }
+                for s in &cb.stmts {
+                    self.walk_pipeline_comb_stmt(s, cur_idx, stage_idx, cur_name);
+                }
             }
             ModuleBodyItem::RegBlock(rb) => {
-                for s in &rb.stmts { self.walk_pipeline_stmt(s, cur_idx, stage_idx, cur_name); }
+                for s in &rb.stmts {
+                    self.walk_pipeline_stmt(s, cur_idx, stage_idx, cur_name);
+                }
             }
             ModuleBodyItem::LetBinding(lb) => {
                 self.check_pipeline_cross_stage_expr(&lb.value, cur_idx, stage_idx, cur_name);
@@ -5815,8 +6760,11 @@ impl<'a> TypeChecker<'a> {
     }
 
     fn walk_pipeline_comb_stmt(
-        &mut self, s: &Stmt, cur_idx: usize,
-        stage_idx: &HashMap<&str, usize>, cur_name: &str,
+        &mut self,
+        s: &Stmt,
+        cur_idx: usize,
+        stage_idx: &HashMap<&str, usize>,
+        cur_name: &str,
     ) {
         match s {
             Stmt::Assign(a) => {
@@ -5824,16 +6772,23 @@ impl<'a> TypeChecker<'a> {
             }
             Stmt::IfElse(ie) => {
                 self.check_pipeline_cross_stage_expr(&ie.cond, cur_idx, stage_idx, cur_name);
-                for s in &ie.then_stmts { self.walk_pipeline_comb_stmt(s, cur_idx, stage_idx, cur_name); }
-                for s in &ie.else_stmts { self.walk_pipeline_comb_stmt(s, cur_idx, stage_idx, cur_name); }
+                for s in &ie.then_stmts {
+                    self.walk_pipeline_comb_stmt(s, cur_idx, stage_idx, cur_name);
+                }
+                for s in &ie.else_stmts {
+                    self.walk_pipeline_comb_stmt(s, cur_idx, stage_idx, cur_name);
+                }
             }
             _ => {}
         }
     }
 
     fn walk_pipeline_stmt(
-        &mut self, s: &Stmt, cur_idx: usize,
-        stage_idx: &HashMap<&str, usize>, cur_name: &str,
+        &mut self,
+        s: &Stmt,
+        cur_idx: usize,
+        stage_idx: &HashMap<&str, usize>,
+        cur_name: &str,
     ) {
         match s {
             Stmt::Assign(a) => {
@@ -5841,16 +6796,23 @@ impl<'a> TypeChecker<'a> {
             }
             Stmt::IfElse(ie) => {
                 self.check_pipeline_cross_stage_expr(&ie.cond, cur_idx, stage_idx, cur_name);
-                for s in &ie.then_stmts { self.walk_pipeline_stmt(s, cur_idx, stage_idx, cur_name); }
-                for s in &ie.else_stmts { self.walk_pipeline_stmt(s, cur_idx, stage_idx, cur_name); }
+                for s in &ie.then_stmts {
+                    self.walk_pipeline_stmt(s, cur_idx, stage_idx, cur_name);
+                }
+                for s in &ie.else_stmts {
+                    self.walk_pipeline_stmt(s, cur_idx, stage_idx, cur_name);
+                }
             }
             _ => {}
         }
     }
 
     pub(crate) fn check_pipeline_cross_stage_expr(
-        &mut self, expr: &Expr, cur_idx: usize,
-        stage_idx: &HashMap<&str, usize>, cur_name: &str,
+        &mut self,
+        expr: &Expr,
+        cur_idx: usize,
+        stage_idx: &HashMap<&str, usize>,
+        cur_name: &str,
     ) {
         match &expr.kind {
             ExprKind::FieldAccess(base, _field) => {
@@ -5882,8 +6844,12 @@ impl<'a> TypeChecker<'a> {
                 self.check_pipeline_cross_stage_expr(l, cur_idx, stage_idx, cur_name);
                 self.check_pipeline_cross_stage_expr(r, cur_idx, stage_idx, cur_name);
             }
-            ExprKind::Unary(_, e) | ExprKind::Cast(e, _) | ExprKind::Clog2(e)
-            | ExprKind::Onehot(e) | ExprKind::Signed(e) | ExprKind::Unsigned(e)
+            ExprKind::Unary(_, e)
+            | ExprKind::Cast(e, _)
+            | ExprKind::Clog2(e)
+            | ExprKind::Onehot(e)
+            | ExprKind::Signed(e)
+            | ExprKind::Unsigned(e)
             | ExprKind::LatencyAt(e, _)
             | ExprKind::SvaNext(_, e) => {
                 self.check_pipeline_cross_stage_expr(e, cur_idx, stage_idx, cur_name);
@@ -5908,7 +6874,9 @@ impl<'a> TypeChecker<'a> {
                 self.check_pipeline_cross_stage_expr(e, cur_idx, stage_idx, cur_name);
             }
             ExprKind::Concat(xs) | ExprKind::FunctionCall(_, xs) => {
-                for x in xs { self.check_pipeline_cross_stage_expr(x, cur_idx, stage_idx, cur_name); }
+                for x in xs {
+                    self.check_pipeline_cross_stage_expr(x, cur_idx, stage_idx, cur_name);
+                }
             }
             ExprKind::Repeat(n, x) => {
                 self.check_pipeline_cross_stage_expr(n, cur_idx, stage_idx, cur_name);
@@ -5916,7 +6884,9 @@ impl<'a> TypeChecker<'a> {
             }
             ExprKind::MethodCall(recv, _, args) => {
                 self.check_pipeline_cross_stage_expr(recv, cur_idx, stage_idx, cur_name);
-                for a in args { self.check_pipeline_cross_stage_expr(a, cur_idx, stage_idx, cur_name); }
+                for a in args {
+                    self.check_pipeline_cross_stage_expr(a, cur_idx, stage_idx, cur_name);
+                }
             }
             _ => {}
         }
@@ -5938,8 +6908,14 @@ impl<'a> TypeChecker<'a> {
             self.check_pascal_case(&stage.name);
 
             // Every stage must have at least one RegDecl + RegBlock (always on)
-            let has_reg = stage.body.iter().any(|i| matches!(i, ModuleBodyItem::RegDecl(_)));
-            let has_always = stage.body.iter().any(|i| matches!(i, ModuleBodyItem::RegBlock(_)));
+            let has_reg = stage
+                .body
+                .iter()
+                .any(|i| matches!(i, ModuleBodyItem::RegDecl(_)));
+            let has_always = stage
+                .body
+                .iter()
+                .any(|i| matches!(i, ModuleBodyItem::RegBlock(_)));
 
             if !has_reg || !has_always {
                 self.errors.push(CompileError::general(
@@ -5978,7 +6954,8 @@ impl<'a> TypeChecker<'a> {
         // breaks timing. Hazard expressions (stall_cond / flush /
         // forward) live outside `stage.body` and are intentionally
         // exempt.
-        let stage_idx: HashMap<&str, usize> = stage_names.iter()
+        let stage_idx: HashMap<&str, usize> = stage_names
+            .iter()
             .enumerate()
             .map(|(i, n)| (*n, i))
             .collect();
@@ -6048,11 +7025,15 @@ impl<'a> TypeChecker<'a> {
     /// breaks the comb path. See the call site for the rationale.
     fn check_pipeline_no_comb_input_to_output(&mut self, p: &PipelineDecl) {
         use std::collections::HashSet;
-        let input_ports: HashSet<String> = p.ports.iter()
+        let input_ports: HashSet<String> = p
+            .ports
+            .iter()
             .filter(|pt| pt.direction == Direction::In)
             .map(|pt| pt.name.name.clone())
             .collect();
-        let output_ports: HashSet<String> = p.ports.iter()
+        let output_ports: HashSet<String> = p
+            .ports
+            .iter()
             .filter(|pt| pt.direction == Direction::Out)
             .map(|pt| pt.name.name.clone())
             .collect();
@@ -6068,8 +7049,12 @@ impl<'a> TypeChecker<'a> {
         for stage in &p.stages {
             for item in &stage.body {
                 match item {
-                    ModuleBodyItem::RegDecl(r) => { reg_names.insert(r.name.name.clone()); }
-                    ModuleBodyItem::PipeRegDecl(pr) => { reg_names.insert(pr.name.name.clone()); }
+                    ModuleBodyItem::RegDecl(r) => {
+                        reg_names.insert(r.name.name.clone());
+                    }
+                    ModuleBodyItem::PipeRegDecl(pr) => {
+                        reg_names.insert(pr.name.name.clone());
+                    }
                     _ => {}
                 }
             }
@@ -6087,7 +7072,11 @@ impl<'a> TypeChecker<'a> {
                         drivers.push((lb.name.name.clone(), reads, lb.name.span));
                     }
                     ModuleBodyItem::CombBlock(cb) => {
-                        Self::collect_pipeline_comb_drivers(&cb.stmts, &HashSet::new(), &mut drivers);
+                        Self::collect_pipeline_comb_drivers(
+                            &cb.stmts,
+                            &HashSet::new(),
+                            &mut drivers,
+                        );
                     }
                     _ => {}
                 }
@@ -6117,7 +7106,8 @@ impl<'a> TypeChecker<'a> {
                 continue;
             }
             let direct_input = reads.iter().find(|id| input_ports.contains(*id)).cloned();
-            let via = reads.iter()
+            let via = reads
+                .iter()
                 .find(|id| tainted.contains(*id) && !input_ports.contains(*id))
                 .cloned();
             let src_desc = match (&direct_input, &via) {
@@ -6141,7 +7131,11 @@ impl<'a> TypeChecker<'a> {
     fn collect_pipeline_comb_drivers(
         stmts: &[Stmt],
         guards: &std::collections::HashSet<String>,
-        out: &mut Vec<(String, std::collections::HashSet<String>, crate::lexer::Span)>,
+        out: &mut Vec<(
+            String,
+            std::collections::HashSet<String>,
+            crate::lexer::Span,
+        )>,
     ) {
         use crate::comb_graph::collect_expr_idents;
         for s in stmts {
@@ -6234,9 +7228,15 @@ impl<'a> TypeChecker<'a> {
     /// enums / structs / functions. Each contained item is checked the
     /// same way it would be at top level.
     pub(crate) fn check_package(&mut self, pkg: &crate::ast::PackageDecl) {
-        for e in &pkg.enums { self.check_enum(e); }
-        for s in &pkg.structs { self.check_struct(s); }
-        for f in &pkg.functions { self.check_function(f); }
+        for e in &pkg.enums {
+            self.check_enum(e);
+        }
+        for s in &pkg.structs {
+            self.check_struct(s);
+        }
+        for f in &pkg.functions {
+            self.check_function(f);
+        }
     }
 
     /// Extern packages have no ARCH-side values to validate.
@@ -6255,32 +7255,50 @@ impl<'a> TypeChecker<'a> {
 
         // Required params: DEPTH (const) and DATA (type)
         let has_depth = l.params.iter().any(|p| p.name.name == "DEPTH");
-        let has_data  = l.params.iter().any(|p| p.name.name == "DATA");
+        let has_data = l.params.iter().any(|p| p.name.name == "DATA");
         if !has_depth {
             self.errors.push(CompileError::general(
-                &format!("linklist `{}` is missing required param `DEPTH: const`", l.name.name),
+                &format!(
+                    "linklist `{}` is missing required param `DEPTH: const`",
+                    l.name.name
+                ),
                 l.name.span,
             ));
         }
         if !has_data {
             self.errors.push(CompileError::general(
-                &format!("linklist `{}` is missing required param `DATA: type`", l.name.name),
+                &format!(
+                    "linklist `{}` is missing required param `DATA: type`",
+                    l.name.name
+                ),
                 l.name.span,
             ));
         }
 
         // Required ports: clk and rst
-        let has_clk = l.ports.iter().any(|p| matches!(&p.ty, crate::ast::TypeExpr::Clock(_)));
-        let has_rst = l.ports.iter().any(|p| matches!(&p.ty, crate::ast::TypeExpr::Reset(_, _)));
+        let has_clk = l
+            .ports
+            .iter()
+            .any(|p| matches!(&p.ty, crate::ast::TypeExpr::Clock(_)));
+        let has_rst = l
+            .ports
+            .iter()
+            .any(|p| matches!(&p.ty, crate::ast::TypeExpr::Reset(_, _)));
         if !has_clk {
             self.errors.push(CompileError::general(
-                &format!("linklist `{}` is missing required `clk: in Clock<...>` port", l.name.name),
+                &format!(
+                    "linklist `{}` is missing required `clk: in Clock<...>` port",
+                    l.name.name
+                ),
                 l.name.span,
             ));
         }
         if !has_rst {
             self.errors.push(CompileError::general(
-                &format!("linklist `{}` is missing required `rst: in Reset<...>` port", l.name.name),
+                &format!(
+                    "linklist `{}` is missing required `rst: in Reset<...>` port",
+                    l.name.name
+                ),
                 l.name.span,
             ));
         }
@@ -6288,7 +7306,9 @@ impl<'a> TypeChecker<'a> {
         // `prev` op requires doubly or circular_doubly
         for op in &l.ops {
             self.check_snake_case(&op.name);
-            for p in &op.ports { self.check_snake_case(&p.name); }
+            for p in &op.ports {
+                self.check_snake_case(&p.name);
+            }
 
             if op.name.name == "prev"
                 && !matches!(l.kind, LinklistKind::Doubly | LinklistKind::CircularDoubly)
@@ -6309,14 +7329,25 @@ impl<'a> TypeChecker<'a> {
             // there is no codegen arm for it. Keep this list in lockstep with the
             // dispatch arms in emit_ll_op_controller.
             let known_ops = [
-                "alloc", "free", "insert_head", "insert_tail", "insert_after",
-                "delete_head", "delete", "read_data", "write_data", "next", "prev",
+                "alloc",
+                "free",
+                "insert_head",
+                "insert_tail",
+                "insert_after",
+                "delete_head",
+                "delete",
+                "read_data",
+                "write_data",
+                "next",
+                "prev",
             ];
             if !known_ops.contains(&op.name.name.as_str()) {
                 self.errors.push(CompileError::general(
                     &format!(
                         "linklist `{}`: unknown op `{}`; known ops: {}",
-                        l.name.name, op.name.name, known_ops.join(", ")
+                        l.name.name,
+                        op.name.name,
+                        known_ops.join(", ")
                     ),
                     op.name.span,
                 ));
@@ -6324,7 +7355,10 @@ impl<'a> TypeChecker<'a> {
 
             if op.latency == 0 {
                 self.errors.push(CompileError::general(
-                    &format!("linklist `{}`: op `{}` latency must be ≥ 1", l.name.name, op.name.name),
+                    &format!(
+                        "linklist `{}`: op `{}` latency must be ≥ 1",
+                        l.name.name, op.name.name
+                    ),
                     op.name.span,
                 ));
             }
@@ -6348,9 +7382,17 @@ impl<'a> TypeChecker<'a> {
         // the controller knows which head to index. When NUM_HEADS == 1,
         // the port must NOT appear (back-compat + avoids confusion).
         let num_heads = linklist_num_heads(l);
-        let head_idx_w = if num_heads <= 1 { 0 } else { clog2_u32(num_heads) };
+        let head_idx_w = if num_heads <= 1 {
+            0
+        } else {
+            clog2_u32(num_heads)
+        };
         let head_addressed = [
-            "insert_head", "insert_tail", "insert_after", "delete_head", "delete",
+            "insert_head",
+            "insert_tail",
+            "insert_after",
+            "delete_head",
+            "delete",
         ];
         for op in &l.ops {
             let has_head_idx = op.ports.iter().any(|p| p.name.name == "req_head_idx");
@@ -6461,13 +7503,17 @@ impl<'a> TypeChecker<'a> {
                         self.warnings.push(CompileWarning {
                             message: format!(
                                 "function `{}`: return type mismatch (declared {}, got {})",
-                                f.name.name, expected_ret.display(), ret_ty.display()
+                                f.name.name,
+                                expected_ret.display(),
+                                ret_ty.display()
                             ),
                             span: expr.span,
                         });
                     }
                 }
-                FunctionBodyItem::IfElse(_) | FunctionBodyItem::For(_) | FunctionBodyItem::Assign(_) => {
+                FunctionBodyItem::IfElse(_)
+                | FunctionBodyItem::For(_)
+                | FunctionBodyItem::Assign(_) => {
                     // Type checking for control flow in functions is deferred
                     // (expressions within are checked by the SV backend)
                 }
@@ -6547,8 +7593,7 @@ fn cond_contains_guard(cond: &Expr, port: &str, guard: &HandshakePayloadGuard) -
                         && expr_is_port_field(rhs, port, req_field)))
         }
         ExprKind::Binary(BinOp::And, lhs, rhs) | ExprKind::Binary(BinOp::BitAnd, lhs, rhs) => {
-            cond_contains_guard(lhs, port, guard)
-                || cond_contains_guard(rhs, port, guard)
+            cond_contains_guard(lhs, port, guard) || cond_contains_guard(rhs, port, guard)
         }
         _ => false,
     }
@@ -6585,17 +7630,27 @@ enum OpClass {
 fn classify(op: BinOp) -> OpClass {
     match op {
         BinOp::BitAnd | BinOp::BitOr | BinOp::BitXor => OpClass::Bitwise,
-        BinOp::Eq | BinOp::Neq | BinOp::Lt | BinOp::Gt | BinOp::Lte | BinOp::Gte => OpClass::Comparison,
+        BinOp::Eq | BinOp::Neq | BinOp::Lt | BinOp::Gt | BinOp::Lte | BinOp::Gte => {
+            OpClass::Comparison
+        }
         BinOp::And | BinOp::Or | BinOp::Implies | BinOp::ImpliesNext => OpClass::Logical,
         BinOp::Shl | BinOp::Shr => OpClass::Shift,
-        BinOp::Add | BinOp::Sub | BinOp::Mul | BinOp::Div | BinOp::Mod
-            | BinOp::AddWrap | BinOp::SubWrap | BinOp::MulWrap => OpClass::Arith,
+        BinOp::Add
+        | BinOp::Sub
+        | BinOp::Mul
+        | BinOp::Div
+        | BinOp::Mod
+        | BinOp::AddWrap
+        | BinOp::SubWrap
+        | BinOp::MulWrap => OpClass::Arith,
     }
 }
 
 /// If `child` is a naked Binary expression, return its operator class + span.
 fn naked_binary_class(child: &Expr) -> Option<(OpClass, BinOp, Span)> {
-    if child.parenthesized { return None; }
+    if child.parenthesized {
+        return None;
+    }
     if let ExprKind::Binary(op, _, _) = &child.kind {
         Some((classify(*op), *op, child.span))
     } else {
@@ -6671,7 +7726,13 @@ fn check_precedence_expr(e: &Expr, errors: &mut Vec<CompileError>) {
                         // Only warn when the binary is arithmetic/bitwise/shift/comparison
                         // (logical is usually intended as the boolean result).
                         let bc = classify(*bop);
-                        if matches!(bc, OpClass::Arith | OpClass::Bitwise | OpClass::Shift | OpClass::Comparison) {
+                        if matches!(
+                            bc,
+                            OpClass::Arith
+                                | OpClass::Bitwise
+                                | OpClass::Shift
+                                | OpClass::Comparison
+                        ) {
                             errors.push(CompileError::general(
                                 &format!(
                                     "ambiguous precedence: ternary branch contains a `{bop}` expression — wrap branch in parens: `... ? ... : (expr)` or wrap the whole ternary"
@@ -6702,10 +7763,14 @@ fn check_precedence_expr(e: &Expr, errors: &mut Vec<CompileError>) {
             check_precedence_expr(width, errors);
         }
         ExprKind::FunctionCall(_, args) => {
-            for a in args { check_precedence_expr(a, errors); }
+            for a in args {
+                check_precedence_expr(a, errors);
+            }
         }
         ExprKind::Concat(parts) => {
-            for p in parts { check_precedence_expr(p, errors); }
+            for p in parts {
+                check_precedence_expr(p, errors);
+            }
         }
         ExprKind::Repeat(n, expr) => {
             check_precedence_expr(n, errors);
@@ -6715,7 +7780,9 @@ fn check_precedence_expr(e: &Expr, errors: &mut Vec<CompileError>) {
         ExprKind::Cast(inner, _) => check_precedence_expr(inner, errors),
         ExprKind::MethodCall(base, _, args) => {
             check_precedence_expr(base, errors);
-            for a in args { check_precedence_expr(a, errors); }
+            for a in args {
+                check_precedence_expr(a, errors);
+            }
         }
         ExprKind::Clog2(inner) => check_precedence_expr(inner, errors),
         ExprKind::Signed(inner) | ExprKind::Unsigned(inner) => check_precedence_expr(inner, errors),
@@ -6784,17 +7851,25 @@ fn check_precedence_in_item(item: &Item, errors: &mut Vec<CompileError>) {
             }
             Stmt::IfElse(ie) => {
                 check_precedence_expr(&ie.cond, errors);
-                for s in &ie.then_stmts { walk_stmt(s, errors); }
-                for s in &ie.else_stmts { walk_stmt(s, errors); }
+                for s in &ie.then_stmts {
+                    walk_stmt(s, errors);
+                }
+                for s in &ie.else_stmts {
+                    walk_stmt(s, errors);
+                }
             }
             Stmt::Match(m) => {
                 check_precedence_expr(&m.scrutinee, errors);
                 for arm in &m.arms {
-                    for s in &arm.body { walk_stmt(s, errors); }
+                    for s in &arm.body {
+                        walk_stmt(s, errors);
+                    }
                 }
             }
             Stmt::Log(l) => {
-                for a in &l.args { check_precedence_expr(a, errors); }
+                for a in &l.args {
+                    check_precedence_expr(a, errors);
+                }
             }
             Stmt::For(fl) => {
                 match &fl.range {
@@ -6803,19 +7878,27 @@ fn check_precedence_in_item(item: &Item, errors: &mut Vec<CompileError>) {
                         check_precedence_expr(e, errors);
                     }
                     ForRange::ValueList(vs) => {
-                        for v in vs { check_precedence_expr(v, errors); }
+                        for v in vs {
+                            check_precedence_expr(v, errors);
+                        }
                     }
                 }
-                for s in &fl.body { walk_stmt(s, errors); }
+                for s in &fl.body {
+                    walk_stmt(s, errors);
+                }
             }
             Stmt::Init(ib) => {
-                for s in &ib.body { walk_stmt(s, errors); }
+                for s in &ib.body {
+                    walk_stmt(s, errors);
+                }
             }
             Stmt::WaitUntil(expr, _) => {
                 check_precedence_expr(expr, errors);
             }
             Stmt::DoUntil { body, cond, .. } => {
-                for s in body { walk_stmt(s, errors); }
+                for s in body {
+                    walk_stmt(s, errors);
+                }
                 check_precedence_expr(cond, errors);
             }
         }
@@ -6829,17 +7912,25 @@ fn check_precedence_in_item(item: &Item, errors: &mut Vec<CompileError>) {
             }
             Stmt::IfElse(ie) => {
                 check_precedence_expr(&ie.cond, errors);
-                for s in &ie.then_stmts { walk_comb(s, errors); }
-                for s in &ie.else_stmts { walk_comb(s, errors); }
+                for s in &ie.then_stmts {
+                    walk_comb(s, errors);
+                }
+                for s in &ie.else_stmts {
+                    walk_comb(s, errors);
+                }
             }
             Stmt::Match(m) => {
                 check_precedence_expr(&m.scrutinee, errors);
                 for arm in &m.arms {
-                    for s in &arm.body { walk_comb(s, errors); }
+                    for s in &arm.body {
+                        walk_comb(s, errors);
+                    }
                 }
             }
             Stmt::Log(l) => {
-                for a in &l.args { check_precedence_expr(a, errors); }
+                for a in &l.args {
+                    check_precedence_expr(a, errors);
+                }
             }
             Stmt::For(fl) => {
                 match &fl.range {
@@ -6848,12 +7939,18 @@ fn check_precedence_in_item(item: &Item, errors: &mut Vec<CompileError>) {
                         check_precedence_expr(e, errors);
                     }
                     ForRange::ValueList(vs) => {
-                        for v in vs { check_precedence_expr(v, errors); }
+                        for v in vs {
+                            check_precedence_expr(v, errors);
+                        }
                     }
                 }
-                for s in &fl.body { walk_comb(s, errors); }
+                for s in &fl.body {
+                    walk_comb(s, errors);
+                }
             }
-                Stmt::Init(_) | Stmt::WaitUntil(..) | Stmt::DoUntil { .. } => unreachable!("seq-only Stmt variant inside comb-context walker"),
+            Stmt::Init(_) | Stmt::WaitUntil(..) | Stmt::DoUntil { .. } => {
+                unreachable!("seq-only Stmt variant inside comb-context walker")
+            }
         }
     }
 
@@ -6861,22 +7958,32 @@ fn check_precedence_in_item(item: &Item, errors: &mut Vec<CompileError>) {
         for it in body {
             match it {
                 ModuleBodyItem::RegDecl(r) => {
-                    if let Some(ref e) = r.init { check_precedence_expr(e, errors); }
+                    if let Some(ref e) = r.init {
+                        check_precedence_expr(e, errors);
+                    }
                 }
                 ModuleBodyItem::LetBinding(l) => {
                     check_precedence_expr(&l.value, errors);
                 }
                 ModuleBodyItem::CombBlock(cb) => {
-                    for s in &cb.stmts { walk_comb(s, errors); }
+                    for s in &cb.stmts {
+                        walk_comb(s, errors);
+                    }
                 }
                 ModuleBodyItem::RegBlock(rb) => {
-                    for s in &rb.stmts { walk_stmt(s, errors); }
+                    for s in &rb.stmts {
+                        walk_stmt(s, errors);
+                    }
                 }
                 ModuleBodyItem::LatchBlock(lb) => {
-                    for s in &lb.stmts { walk_stmt(s, errors); }
+                    for s in &lb.stmts {
+                        walk_stmt(s, errors);
+                    }
                 }
                 ModuleBodyItem::Inst(inst) => {
-                    for c in &inst.connections { check_precedence_expr(&c.signal, errors); }
+                    for c in &inst.connections {
+                        check_precedence_expr(&c.signal, errors);
+                    }
                 }
                 ModuleBodyItem::Assert(a) => {
                     check_precedence_expr(&a.expr, errors);
@@ -6889,25 +7996,43 @@ fn check_precedence_in_item(item: &Item, errors: &mut Vec<CompileError>) {
     match item {
         Item::Module(m) => walk_body(&m.body, errors),
         Item::Fsm(f) => {
-            for l in &f.lets { check_precedence_expr(&l.value, errors); }
+            for l in &f.lets {
+                check_precedence_expr(&l.value, errors);
+            }
             for r in &f.regs {
-                if let Some(ref e) = r.init { check_precedence_expr(e, errors); }
+                if let Some(ref e) = r.init {
+                    check_precedence_expr(e, errors);
+                }
             }
             for sb in &f.states {
-                for s in &sb.seq_stmts { walk_stmt(s, errors); }
-                for s in &sb.comb_stmts { walk_comb(s, errors); }
-                for tr in &sb.transitions { check_precedence_expr(&tr.condition, errors); }
+                for s in &sb.seq_stmts {
+                    walk_stmt(s, errors);
+                }
+                for s in &sb.comb_stmts {
+                    walk_comb(s, errors);
+                }
+                for tr in &sb.transitions {
+                    check_precedence_expr(&tr.condition, errors);
+                }
             }
-            for s in &f.default_seq { walk_stmt(s, errors); }
-            for s in &f.default_comb { walk_comb(s, errors); }
-            for a in &f.asserts { check_precedence_expr(&a.expr, errors); }
+            for s in &f.default_seq {
+                walk_stmt(s, errors);
+            }
+            for s in &f.default_comb {
+                walk_comb(s, errors);
+            }
+            for a in &f.asserts {
+                check_precedence_expr(&a.expr, errors);
+            }
         }
         Item::Function(f) => {
             for it in &f.body {
                 match it {
                     FunctionBodyItem::Let(l) => check_precedence_expr(&l.value, errors),
                     FunctionBodyItem::Return(e) => check_precedence_expr(e, errors),
-                    FunctionBodyItem::IfElse(_) | FunctionBodyItem::For(_) | FunctionBodyItem::Assign(_) => {}
+                    FunctionBodyItem::IfElse(_)
+                    | FunctionBodyItem::For(_)
+                    | FunctionBodyItem::Assign(_) => {}
                 }
             }
         }
@@ -6966,8 +8091,12 @@ pub fn enum_width(num_variants: usize) -> u32 {
 /// this param (matches DEPTH).
 pub fn linklist_num_heads(l: &crate::ast::LinklistDecl) -> u32 {
     use crate::ast::{ExprKind, LitKind};
-    let Some(p) = l.params.iter().find(|p| p.name.name == "NUM_HEADS") else { return 1; };
-    let Some(def) = &p.default else { return 1; };
+    let Some(p) = l.params.iter().find(|p| p.name.name == "NUM_HEADS") else {
+        return 1;
+    };
+    let Some(def) = &p.default else {
+        return 1;
+    };
     match &def.kind {
         ExprKind::Literal(LitKind::Dec(v))
         | ExprKind::Literal(LitKind::Hex(v))

--- a/src/width.rs
+++ b/src/width.rs
@@ -14,7 +14,11 @@
 /// is 0 for n=0 or n=1 — degenerate; most callers want
 /// [`index_width`] instead, which floors to 1).
 pub fn clog2(n: u64) -> u32 {
-    if n <= 1 { 0 } else { (n - 1).ilog2() + 1 }
+    if n <= 1 {
+        0
+    } else {
+        (n - 1).ilog2() + 1
+    }
 }
 
 /// Width in bits to *address* an array of `n` items, with a 1-bit

--- a/tests/formal_test.rs
+++ b/tests/formal_test.rs
@@ -6,18 +6,28 @@
 use std::process::Command;
 
 fn z3_available() -> bool {
-    Command::new("z3").arg("--version").output().map(|o| o.status.success()).unwrap_or(false)
+    Command::new("z3")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
 }
 
 fn solver_available(name: &str) -> bool {
-    Command::new(name).arg("--help").output().map(|_| true).unwrap_or(false)
+    Command::new(name)
+        .arg("--help")
+        .output()
+        .map(|_| true)
+        .unwrap_or(false)
 }
 
 /// Run `arch formal <file> [extra...]` and return (exit_code, stdout_stderr_combined).
 fn run_formal(file: &str, extra: &[&str]) -> (i32, String) {
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_arch"));
     cmd.arg("formal").arg(file);
-    for a in extra { cmd.arg(a); }
+    for a in extra {
+        cmd.arg(a);
+    }
     let out = cmd.output().expect("failed to spawn arch");
     let merged = format!(
         "{}\n{}",
@@ -30,7 +40,9 @@ fn run_formal(file: &str, extra: &[&str]) -> (i32, String) {
 fn run_build(file: &std::path::Path, extra: &[String]) -> (i32, String) {
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_arch"));
     cmd.arg("build").arg(file);
-    for a in extra { cmd.arg(a); }
+    for a in extra {
+        cmd.arg(a);
+    }
     let out = cmd.output().expect("failed to spawn arch");
     let merged = format!(
         "{}\n{}",
@@ -47,8 +59,12 @@ fn run_build_with_env(
 ) -> (i32, String) {
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_arch"));
     cmd.arg("build").arg(file);
-    for (key, value) in envs { cmd.env(key, value); }
-    for a in extra { cmd.arg(a); }
+    for (key, value) in envs {
+        cmd.env(key, value);
+    }
+    for a in extra {
+        cmd.arg(a);
+    }
     let out = cmd.output().expect("failed to spawn arch");
     let merged = format!(
         "{}\n{}",
@@ -60,7 +76,10 @@ fn run_build_with_env(
 
 #[test]
 fn formal_counter_simple_proves() {
-    if !z3_available() { eprintln!("skipping: z3 not in PATH"); return; }
+    if !z3_available() {
+        eprintln!("skipping: z3 not in PATH");
+        return;
+    }
     let (code, out) = run_formal("tests/formal/counter_simple.arch", &["--bound", "5"]);
     assert_eq!(code, 0, "expected exit 0 (all PROVED); got {code}\n{out}");
     assert!(out.contains("PROVED"), "expected PROVED in output:\n{out}");
@@ -68,7 +87,10 @@ fn formal_counter_simple_proves() {
 
 #[test]
 fn formal_counter_bounded_proves() {
-    if !z3_available() { eprintln!("skipping: z3 not in PATH"); return; }
+    if !z3_available() {
+        eprintln!("skipping: z3 not in PATH");
+        return;
+    }
     let (code, out) = run_formal("tests/formal/counter_bounded.arch", &["--bound", "30"]);
     assert_eq!(code, 0, "expected exit 0; got {code}\n{out}");
     assert!(out.contains("PROVED"));
@@ -76,16 +98,25 @@ fn formal_counter_bounded_proves() {
 
 #[test]
 fn formal_counter_overflow_refutes() {
-    if !z3_available() { eprintln!("skipping: z3 not in PATH"); return; }
+    if !z3_available() {
+        eprintln!("skipping: z3 not in PATH");
+        return;
+    }
     let (code, out) = run_formal("tests/formal/counter_overflow.arch", &["--bound", "20"]);
     assert_eq!(code, 1, "expected exit 1 (REFUTED); got {code}\n{out}");
     assert!(out.contains("REFUTED"), "expected REFUTED:\n{out}");
-    assert!(out.contains("Counterexample"), "expected counterexample:\n{out}");
+    assert!(
+        out.contains("Counterexample"),
+        "expected counterexample:\n{out}"
+    );
 }
 
 #[test]
 fn formal_cover_hit() {
-    if !z3_available() { eprintln!("skipping: z3 not in PATH"); return; }
+    if !z3_available() {
+        eprintln!("skipping: z3 not in PATH");
+        return;
+    }
     let (code, out) = run_formal("tests/formal/cover_hit.arch", &["--bound", "20"]);
     assert_eq!(code, 0, "expected exit 0 (HIT); got {code}\n{out}");
     assert!(out.contains("HIT"));
@@ -93,7 +124,10 @@ fn formal_cover_hit() {
 
 #[test]
 fn formal_cover_not_reached() {
-    if !z3_available() { eprintln!("skipping: z3 not in PATH"); return; }
+    if !z3_available() {
+        eprintln!("skipping: z3 not in PATH");
+        return;
+    }
     // Bound 3 is too small for a 4-bit counter to reach 8 (takes 8 increments).
     let (code, out) = run_formal("tests/formal/cover_hit.arch", &["--bound", "3"]);
     assert_eq!(code, 1, "expected exit 1 (NOT REACHED); got {code}\n{out}");
@@ -102,7 +136,10 @@ fn formal_cover_not_reached() {
 
 #[test]
 fn formal_guard_pass() {
-    if !z3_available() { eprintln!("skipping: z3 not in PATH"); return; }
+    if !z3_available() {
+        eprintln!("skipping: z3 not in PATH");
+        return;
+    }
     let (code, out) = run_formal("tests/formal/guard_pass.arch", &["--bound", "10"]);
     assert_eq!(code, 0, "expected exit 0; got {code}\n{out}");
     assert!(out.contains("PROVED"));
@@ -110,7 +147,10 @@ fn formal_guard_pass() {
 
 #[test]
 fn formal_guard_fail() {
-    if !z3_available() { eprintln!("skipping: z3 not in PATH"); return; }
+    if !z3_available() {
+        eprintln!("skipping: z3 not in PATH");
+        return;
+    }
     let (code, out) = run_formal("tests/formal/guard_fail.arch", &["--bound", "10"]);
     assert_eq!(code, 1, "expected exit 1; got {code}\n{out}");
     assert!(out.contains("REFUTED"));
@@ -118,7 +158,10 @@ fn formal_guard_fail() {
 
 #[test]
 fn formal_emit_smt_file() {
-    if !z3_available() { eprintln!("skipping: z3 not in PATH"); return; }
+    if !z3_available() {
+        eprintln!("skipping: z3 not in PATH");
+        return;
+    }
     let out_path = std::env::temp_dir().join("arch_formal_emit_test.smt2");
     let _ = std::fs::remove_file(&out_path);
     let (_code, _out) = run_formal(
@@ -133,8 +176,14 @@ fn formal_emit_smt_file() {
 
 #[test]
 fn formal_solver_parity_boolector() {
-    if !z3_available() { eprintln!("skipping: z3 not in PATH"); return; }
-    if !solver_available("boolector") { eprintln!("skipping: boolector not in PATH"); return; }
+    if !z3_available() {
+        eprintln!("skipping: z3 not in PATH");
+        return;
+    }
+    if !solver_available("boolector") {
+        eprintln!("skipping: boolector not in PATH");
+        return;
+    }
     let (code, out) = run_formal(
         "tests/formal/counter_simple.arch",
         &["--bound", "5", "--solver", "boolector"],
@@ -145,8 +194,14 @@ fn formal_solver_parity_boolector() {
 
 #[test]
 fn formal_solver_parity_bitwuzla() {
-    if !z3_available() { eprintln!("skipping: z3 not in PATH"); return; }
-    if !solver_available("bitwuzla") { eprintln!("skipping: bitwuzla not in PATH"); return; }
+    if !z3_available() {
+        eprintln!("skipping: z3 not in PATH");
+        return;
+    }
+    if !solver_available("bitwuzla") {
+        eprintln!("skipping: bitwuzla not in PATH");
+        return;
+    }
     let (code, out) = run_formal(
         "tests/formal/counter_simple.arch",
         &["--bound", "5", "--solver", "bitwuzla"],
@@ -157,7 +212,10 @@ fn formal_solver_parity_bitwuzla() {
 
 #[test]
 fn formal_hier_adder_proves() {
-    if !z3_available() { eprintln!("skipping: z3 not in PATH"); return; }
+    if !z3_available() {
+        eprintln!("skipping: z3 not in PATH");
+        return;
+    }
     let (code, out) = run_formal(
         "tests/formal/hier_adder_proves.arch",
         &["--top", "HierTop", "--bound", "5"],
@@ -168,7 +226,10 @@ fn formal_hier_adder_proves() {
 
 #[test]
 fn formal_hier_adder_refutes() {
-    if !z3_available() { eprintln!("skipping: z3 not in PATH"); return; }
+    if !z3_available() {
+        eprintln!("skipping: z3 not in PATH");
+        return;
+    }
     let (code, out) = run_formal(
         "tests/formal/hier_adder_refutes.arch",
         &["--top", "HierTopBad", "--bound", "5"],
@@ -180,7 +241,10 @@ fn formal_hier_adder_refutes() {
 
 #[test]
 fn formal_hier_counter_proves() {
-    if !z3_available() { eprintln!("skipping: z3 not in PATH"); return; }
+    if !z3_available() {
+        eprintln!("skipping: z3 not in PATH");
+        return;
+    }
     let (code, out) = run_formal(
         "tests/formal/hier_counter_proves.arch",
         &["--top", "HierCounterTop", "--bound", "25"],
@@ -191,19 +255,28 @@ fn formal_hier_counter_proves() {
 
 #[test]
 fn formal_hier_multi_inst_proves() {
-    if !z3_available() { eprintln!("skipping: z3 not in PATH"); return; }
+    if !z3_available() {
+        eprintln!("skipping: z3 not in PATH");
+        return;
+    }
     let (code, out) = run_formal(
         "tests/formal/hier_multi_inst_proves.arch",
         &["--top", "HierMultiTop", "--bound", "25"],
     );
     assert_eq!(code, 0, "expected exit 0; got {code}\n{out}");
     // Both properties should PROVE.
-    assert!(out.matches("PROVED").count() >= 2, "expected 2 PROVEDs:\n{out}");
+    assert!(
+        out.matches("PROVED").count() >= 2,
+        "expected 2 PROVEDs:\n{out}"
+    );
 }
 
 #[test]
 fn formal_credit_channel_active_proves() {
-    if !z3_available() { eprintln!("skipping: z3 not in PATH"); return; }
+    if !z3_available() {
+        eprintln!("skipping: z3 not in PATH");
+        return;
+    }
     // Active-traffic version of the occupancy invariant: sender drives
     // send_valid via can_send gating, receiver drives credit_return via
     // valid gating. Also asserts the derived-signal equivalences
@@ -214,13 +287,19 @@ fn formal_credit_channel_active_proves() {
         &["--top", "CreditPairActive", "--bound", "8"],
     );
     assert_eq!(code, 0, "expected exit 0 (PROVED); got {code}\n{out}");
-    assert_eq!(out.matches("PROVED").count(), 3,
-               "expected 3 PROVEDs (credit_balance, can_send_iff_credit, valid_iff_occ):\n{out}");
+    assert_eq!(
+        out.matches("PROVED").count(),
+        3,
+        "expected 3 PROVEDs (credit_balance, can_send_iff_credit, valid_iff_occ):\n{out}"
+    );
 }
 
 #[test]
 fn formal_credit_channel_invariant_proves() {
-    if !z3_available() { eprintln!("skipping: z3 not in PATH"); return; }
+    if !z3_available() {
+        eprintln!("skipping: z3 not in PATH");
+        return;
+    }
     // PR-hf4 Phase 1 end-to-end: the credit_channel occupancy invariant
     // (`credit + occ == DEPTH`) proves on a 2-module hierarchical design
     // where flatten_for_formal carries the channel state across the
@@ -230,13 +309,19 @@ fn formal_credit_channel_invariant_proves() {
         &["--top", "CreditPair", "--bound", "8"],
     );
     assert_eq!(code, 0, "expected exit 0 (PROVED); got {code}\n{out}");
-    assert!(out.contains("credit_balance"), "expected credit_balance label:\n{out}");
+    assert!(
+        out.contains("credit_balance"),
+        "expected credit_balance label:\n{out}"
+    );
     assert!(out.contains("PROVED"), "expected PROVED in output:\n{out}");
 }
 
 #[test]
 fn construct_proof_smt_fifo_and_arbiter_checks() {
-    if !z3_available() { eprintln!("skipping: z3 not in PATH"); return; }
+    if !z3_available() {
+        eprintln!("skipping: z3 not in PATH");
+        return;
+    }
     let td = tempfile::tempdir().expect("tempdir");
     let arch_path = td.path().join("Constructs.arch");
     let sv_path = td.path().join("Constructs.sv");
@@ -283,10 +368,20 @@ end arbiter BusArbiter
         "--construct-proof-smt-solver=z3".to_string(),
     ];
     let (code, out) = run_build(&arch_path, &args);
-    assert_eq!(code, 0, "expected construct SMT check to pass; got {code}\n{out}");
-    assert!(out.contains("Construct SMT proof OK"), "expected solver check output:\n{out}");
+    assert_eq!(
+        code, 0,
+        "expected construct SMT check to pass; got {code}\n{out}"
+    );
+    assert!(
+        out.contains("Construct SMT proof OK"),
+        "expected solver check output:\n{out}"
+    );
     let smt = std::fs::read_to_string(&smt_path).expect("read smt");
-    assert_eq!(smt.matches("(check-sat)").count(), 2, "expected FIFO+arbiter queries:\n{smt}");
+    assert_eq!(
+        smt.matches("(check-sat)").count(),
+        2,
+        "expected FIFO+arbiter queries:\n{smt}"
+    );
     assert!(smt.contains("; fifo TxQueue"));
     assert!(smt.contains("TxQueue_fifo_0_next_wr_ptr"));
     assert!(smt.contains("TxQueue_fifo_0_write_index"));
@@ -415,7 +510,10 @@ end fifo NonPow2Queue
             "(rdPtr + 1) % Fifo.ptrMod NonPow2Queue_fifo",
             "(rdPtr + 1) % NonPow2Queue_fifo.depth",
         );
-    assert_ne!(proof, bad_proof, "expected proof mutation to change pointer wrap");
+    assert_ne!(
+        proof, bad_proof,
+        "expected proof mutation to change pointer wrap"
+    );
     std::fs::write(&bad_proof_path, bad_proof).expect("write bad proof");
 
     let output = Command::new(&home_lake)
@@ -444,11 +542,20 @@ end fifo NonPow2Queue
 
 #[test]
 fn formal_sva_temporal_proves() {
-    if !z3_available() { eprintln!("skipping: z3 not in PATH"); return; }
+    if !z3_available() {
+        eprintln!("skipping: z3 not in PATH");
+        return;
+    }
     let (code, out) = run_formal("tests/formal/sva_temporal_proves.arch", &["--bound", "5"]);
     assert_eq!(code, 0, "expected exit 0; got {code}\n{out}");
-    assert!(out.contains("gnt_follows_req"), "missing property name in output:\n{out}");
-    assert!(out.contains("req_implies_next_gnt"), "missing |=> property:\n{out}");
+    assert!(
+        out.contains("gnt_follows_req"),
+        "missing property name in output:\n{out}"
+    );
+    assert!(
+        out.contains("req_implies_next_gnt"),
+        "missing |=> property:\n{out}"
+    );
     // Both asserts should PROVE; cover should HIT.
     let proved = out.matches("PROVED").count();
     assert!(proved >= 2, "expected ≥2 PROVED (got {proved}):\n{out}");
@@ -457,7 +564,10 @@ fn formal_sva_temporal_proves() {
 
 #[test]
 fn formal_sva_temporal_refutes() {
-    if !z3_available() { eprintln!("skipping: z3 not in PATH"); return; }
+    if !z3_available() {
+        eprintln!("skipping: z3 not in PATH");
+        return;
+    }
     let (code, out) = run_formal("tests/formal/sva_temporal_refutes.arch", &["--bound", "5"]);
     assert_eq!(code, 1, "expected exit 1 (REFUTED); got {code}\n{out}");
     assert!(out.contains("REFUTED"), "expected REFUTED:\n{out}");
@@ -465,7 +575,10 @@ fn formal_sva_temporal_refutes() {
 
 #[test]
 fn formal_sva_phase2_proves() {
-    if !z3_available() { eprintln!("skipping: z3 not in PATH"); return; }
+    if !z3_available() {
+        eprintln!("skipping: z3 not in PATH");
+        return;
+    }
     let (code, out) = run_formal("tests/formal/sva_phase2_proves.arch", &["--bound", "8"]);
     assert_eq!(code, 0, "expected exit 0; got {code}\n{out}");
     for prop in ["rose_implies_a_edge", "fell_implies_a_edge", "next_chain"] {
@@ -477,7 +590,10 @@ fn formal_sva_phase2_proves() {
 
 #[test]
 fn formal_sva_phase2_refutes() {
-    if !z3_available() { eprintln!("skipping: z3 not in PATH"); return; }
+    if !z3_available() {
+        eprintln!("skipping: z3 not in PATH");
+        return;
+    }
     let (code, out) = run_formal("tests/formal/sva_phase2_refutes.arch", &["--bound", "8"]);
     assert_eq!(code, 1, "expected exit 1 (REFUTED); got {code}\n{out}");
     assert!(out.contains("REFUTED"), "expected REFUTED:\n{out}");

--- a/tests/fp_test.rs
+++ b/tests/fp_test.rs
@@ -70,16 +70,37 @@ fn fp_build_emits_helpers_and_dispatch() {
         String::from_utf8_lossy(&out.stderr),
     );
     let sv = std::fs::read_to_string(td.path().join("FpArith.sv")).expect("read FpArith.sv");
-    assert!(sv.contains("function automatic logic [31:0] arch_f32_add"), "f32 add helper missing:\n{sv}");
-    assert!(sv.contains("function automatic logic [15:0] arch_bf16_add"), "bf16 add helper missing");
-    assert!(sv.contains("assign sum = arch_f32_add(a, b);"), "f32 add not dispatched:\n{sv}");
-    assert!(sv.contains("assign prod = arch_f32_mul(a, b);"), "f32 mul not dispatched");
-    assert!(sv.contains("assign hsum = arch_bf16_add(ha, hb);"), "bf16 add not dispatched");
+    assert!(
+        sv.contains("function automatic logic [31:0] arch_f32_add"),
+        "f32 add helper missing:\n{sv}"
+    );
+    assert!(
+        sv.contains("function automatic logic [15:0] arch_bf16_add"),
+        "bf16 add helper missing"
+    );
+    assert!(
+        sv.contains("assign sum = arch_f32_add(a, b);"),
+        "f32 add not dispatched:\n{sv}"
+    );
+    assert!(
+        sv.contains("assign prod = arch_f32_mul(a, b);"),
+        "f32 mul not dispatched"
+    );
+    assert!(
+        sv.contains("assign hsum = arch_bf16_add(ha, hb);"),
+        "bf16 add not dispatched"
+    );
     assert!(sv.contains("arch_fma_f32(a, b, c)"), "fma not dispatched");
-    assert!(sv.contains("arch_bf16_to_f32(ha)"), "bf16->f32 conversion not dispatched");
+    assert!(
+        sv.contains("arch_bf16_to_f32(ha)"),
+        "bf16->f32 conversion not dispatched"
+    );
     // FP32 and BF16 ports are packed bit vectors.
     assert!(sv.contains("input logic [31:0] a"), "FP32 port width wrong");
-    assert!(sv.contains("input logic [15:0] ha"), "BF16 port width wrong");
+    assert!(
+        sv.contains("input logic [15:0] ha"),
+        "BF16 port width wrong"
+    );
 }
 
 /// The no-implicit-conversion rule: mixing FP32 and BF16 in an operator,
@@ -96,8 +117,15 @@ end module Bad
     let td = tempfile::tempdir().expect("tempdir");
     let path = td.path().join("Bad.arch");
     std::fs::write(&path, src).unwrap();
-    let out = arch().arg("check").arg(&path).output().expect("run arch check");
-    assert!(!out.status.success(), "mixing FP32 and BF16 must be a type error");
+    let out = arch()
+        .arg("check")
+        .arg(&path)
+        .output()
+        .expect("run arch check");
+    assert!(
+        !out.status.success(),
+        "mixing FP32 and BF16 must be a type error"
+    );
     let combined = format!(
         "{}{}",
         String::from_utf8_lossy(&out.stdout),
@@ -121,8 +149,15 @@ end module Bad2
     let td = tempfile::tempdir().expect("tempdir");
     let path = td.path().join("Bad2.arch");
     std::fs::write(&path, src).unwrap();
-    let out = arch().arg("check").arg(&path).output().expect("run arch check");
-    assert!(!out.status.success(), "FP32 -> BF16 assignment without cast must error");
+    let out = arch()
+        .arg("check")
+        .arg(&path)
+        .output()
+        .expect("run arch check");
+    assert!(
+        !out.status.success(),
+        "FP32 -> BF16 assignment without cast must error"
+    );
 }
 
 /// Registered FP32 accumulator simulates correctly, including a float-literal
@@ -182,7 +217,11 @@ fn fp_unsupported_positions_rejected() {
         let td = tempfile::tempdir().expect("tempdir");
         let path = td.path().join("M.arch");
         std::fs::write(&path, src).unwrap();
-        let out = arch().arg("check").arg(&path).output().expect("run arch check");
+        let out = arch()
+            .arg("check")
+            .arg(&path)
+            .output()
+            .expect("run arch check");
         assert!(
             !out.status.success(),
             "float in {label} position must be rejected in v1\nsrc:\n{src}"
@@ -198,8 +237,15 @@ fn fp_reg_integer_reset_rejected() {
     let td = tempfile::tempdir().expect("tempdir");
     let path = td.path().join("M.arch");
     std::fs::write(&path, src).unwrap();
-    let out = arch().arg("check").arg(&path).output().expect("run arch check");
-    assert!(!out.status.success(), "integer reset for a float reg must be rejected");
+    let out = arch()
+        .arg("check")
+        .arg(&path)
+        .output()
+        .expect("run arch check");
+    assert!(
+        !out.status.success(),
+        "integer reset for a float reg must be rejected"
+    );
 }
 
 /// Differential equivalence (doc/plan_fp_types.md §8.2): the emitted
@@ -247,10 +293,22 @@ fn fp_rtl_differential_equiv_verilator() {
     let tb = format!("{manifest}/tests/fp_v1/rtl_diff/tb_fp_diff.sv");
     let dpi = format!("{manifest}/tests/fp_v1/rtl_diff/dpi_ref.cpp");
     let vout = std::process::Command::new("verilator")
-        .args(["--binary", "--timing", "-Wno-WIDTH", "-Wno-UNOPTFLAT",
-               "-Wno-WIDTHTRUNC", "-Wno-WIDTHEXPAND", "-Wno-SHORTREAL",
-               "-Wno-BLKANDNBLK", "-Wno-UNUSEDSIGNAL", "-Wno-MULTITOP",
-               "--top-module", "tb", "-o", "sim_diff"])
+        .args([
+            "--binary",
+            "--timing",
+            "-Wno-WIDTH",
+            "-Wno-UNOPTFLAT",
+            "-Wno-WIDTHTRUNC",
+            "-Wno-WIDTHEXPAND",
+            "-Wno-SHORTREAL",
+            "-Wno-BLKANDNBLK",
+            "-Wno-UNUSEDSIGNAL",
+            "-Wno-MULTITOP",
+            "--top-module",
+            "tb",
+            "-o",
+            "sim_diff",
+        ])
         .arg("-Mdir")
         .arg(&obj)
         .arg(&sv)
@@ -301,7 +359,10 @@ fn fp_smt_equivalence_proofs() {
         return;
     }
     let z3ver = {
-        let o = std::process::Command::new("z3").arg("--version").output().unwrap();
+        let o = std::process::Command::new("z3")
+            .arg("--version")
+            .output()
+            .unwrap();
         String::from_utf8_lossy(&o.stdout).trim().to_string()
     };
 
@@ -332,7 +393,8 @@ fn fp_smt_equivalence_proofs() {
         let first = res.lines().next().unwrap_or("").trim();
         cert.push_str(&format!("{op}: {first}\n"));
         assert_eq!(
-            first, "unsat",
+            first,
+            "unsat",
             "generated SMT proof {op} did not discharge as unsat (got {first:?})\nstderr:\n{}",
             String::from_utf8_lossy(&out.stderr)
         );
@@ -357,7 +419,11 @@ fn fp_smt_equivalence_proofs() {
 #[test]
 fn fp_smt_arith_proofs() {
     fn z3_available() -> bool {
-        std::process::Command::new("z3").arg("--version").output().map(|o| o.status.success()).unwrap_or(false)
+        std::process::Command::new("z3")
+            .arg("--version")
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
     }
     if !z3_available() {
         eprintln!("skipping fp_smt_arith_proofs: z3 not in PATH");
@@ -373,10 +439,22 @@ fn fp_smt_arith_proofs() {
         let smt = arch::fp_smt_proof::equiv_proof(op, arch::FpCompat::Riscv);
         let path = td.path().join(format!("{op}.smt2"));
         std::fs::write(&path, smt).unwrap();
-        let out = std::process::Command::new("z3").arg("-T:600").arg(&path).output().unwrap();
-        let first = String::from_utf8_lossy(&out.stdout).lines().next().unwrap_or("").trim().to_string();
+        let out = std::process::Command::new("z3")
+            .arg("-T:600")
+            .arg(&path)
+            .output()
+            .unwrap();
+        let first = String::from_utf8_lossy(&out.stdout)
+            .lines()
+            .next()
+            .unwrap_or("")
+            .trim()
+            .to_string();
         eprintln!("arith proof {op}: {first}");
-        assert_eq!(first, "unsat", "arith proof {op} did not discharge as unsat (got {first:?})");
+        assert_eq!(
+            first, "unsat",
+            "arith proof {op} did not discharge as unsat (got {first:?})"
+        );
     }
 }
 
@@ -392,24 +470,67 @@ fn fp_compat_build_profiles() {
     // default = riscv
     let td = tempfile::tempdir().unwrap();
     let sv = td.path().join("d.sv");
-    let out = arch().arg("build").arg(&arch_src).arg("-o").arg(&sv).output().unwrap();
-    assert!(out.status.success(), "default build failed: {}", String::from_utf8_lossy(&out.stderr));
+    let out = arch()
+        .arg("build")
+        .arg(&arch_src)
+        .arg("-o")
+        .arg(&sv)
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "default build failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
     let d = std::fs::read_to_string(&sv).unwrap();
-    assert!(d.contains("32'h7FC00000") && d.contains("16'h7FC0"), "riscv NaN constants missing");
-    assert!(!d.contains("32'h7FFFFFFF"), "default must not use the cuda NaN pattern");
+    assert!(
+        d.contains("32'h7FC00000") && d.contains("16'h7FC0"),
+        "riscv NaN constants missing"
+    );
+    assert!(
+        !d.contains("32'h7FFFFFFF"),
+        "default must not use the cuda NaN pattern"
+    );
 
     // cuda
     let sv2 = td.path().join("c.sv");
-    let out2 = arch().arg("build").arg(&arch_src).arg("--fp-compat=cuda").arg("-o").arg(&sv2).output().unwrap();
-    assert!(out2.status.success(), "cuda build failed: {}", String::from_utf8_lossy(&out2.stderr));
+    let out2 = arch()
+        .arg("build")
+        .arg(&arch_src)
+        .arg("--fp-compat=cuda")
+        .arg("-o")
+        .arg(&sv2)
+        .output()
+        .unwrap();
+    assert!(
+        out2.status.success(),
+        "cuda build failed: {}",
+        String::from_utf8_lossy(&out2.stderr)
+    );
     let c = std::fs::read_to_string(&sv2).unwrap();
-    assert!(c.contains("32'h7FFFFFFF") && c.contains("16'h7FFF"), "cuda NaN constants missing");
-    assert!(!c.contains("32'h7FC00000"), "cuda must not use the riscv NaN pattern");
+    assert!(
+        c.contains("32'h7FFFFFFF") && c.contains("16'h7FFF"),
+        "cuda NaN constants missing"
+    );
+    assert!(
+        !c.contains("32'h7FC00000"),
+        "cuda must not use the riscv NaN pattern"
+    );
     // (NaN->int = 0 under cuda is checked behaviorally by fp_compat_sim_profiles)
 
     // invalid profile rejected
-    let bad = arch().arg("build").arg(&arch_src).arg("--fp-compat=nvidia").arg("-o").arg(td.path().join("x.sv")).output().unwrap();
-    assert!(!bad.status.success(), "invalid --fp-compat must be rejected");
+    let bad = arch()
+        .arg("build")
+        .arg(&arch_src)
+        .arg("--fp-compat=nvidia")
+        .arg("-o")
+        .arg(td.path().join("x.sv"))
+        .output()
+        .unwrap();
+    assert!(
+        !bad.status.success(),
+        "invalid --fp-compat must be rejected"
+    );
     assert!(String::from_utf8_lossy(&bad.stderr).contains("expected `riscv` or `cuda`"));
 }
 
@@ -424,18 +545,33 @@ fn fp_compat_sim_profiles() {
     let run = |extra: &[&str], dir: &str| -> String {
         let td = tempfile::tempdir().unwrap();
         let mut c = arch();
-        c.arg("sim").arg(&arch_src).arg("--tb").arg(&tb).arg("--outdir").arg(td.path().join(dir));
-        for a in extra { c.arg(a); }
+        c.arg("sim")
+            .arg(&arch_src)
+            .arg("--tb")
+            .arg(&tb)
+            .arg("--outdir")
+            .arg(td.path().join(dir));
+        for a in extra {
+            c.arg(a);
+        }
         let o = c.output().unwrap();
-        assert!(o.status.success(), "sim failed: {}", String::from_utf8_lossy(&o.stderr));
+        assert!(
+            o.status.success(),
+            "sim failed: {}",
+            String::from_utf8_lossy(&o.stderr)
+        );
         String::from_utf8_lossy(&o.stdout).to_string()
     };
 
     let riscv = run(&[], "r");
-    assert!(riscv.contains("nan_out=0x7FC00000 nan_to_int=2147483647"),
-        "riscv profile wrong:\n{riscv}");
+    assert!(
+        riscv.contains("nan_out=0x7FC00000 nan_to_int=2147483647"),
+        "riscv profile wrong:\n{riscv}"
+    );
 
     let cuda = run(&["--fp-compat=cuda"], "c");
-    assert!(cuda.contains("nan_out=0x7FFFFFFF nan_to_int=0"),
-        "cuda profile wrong:\n{cuda}");
+    assert!(
+        cuda.contains("nan_out=0x7FFFFFFF nan_to_int=0"),
+        "cuda profile wrong:\n{cuda}"
+    );
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -466,7 +466,10 @@ end fsm BadFsm
     let symbols = resolve::resolve(&ast).expect("resolve");
     let checker = TypeChecker::new(&symbols, &ast);
     let result = checker.check();
-    assert!(result.is_err(), "fsm with port named 'state_r' should error");
+    assert!(
+        result.is_err(),
+        "fsm with port named 'state_r' should error"
+    );
 }
 
 // ── FIFO ──────────────────────────────────────────────────────────────────────
@@ -996,7 +999,8 @@ end ram BadLatRam
     assert!(result.is_err(), "latency 3 RAM should be rejected");
     let errs = result.err().unwrap();
     assert!(
-        errs.iter().any(|e| format!("{e:?}").contains("latency 3 is out of range")),
+        errs.iter()
+            .any(|e| format!("{e:?}").contains("latency 3 is out of range")),
         "error should name the out-of-range latency: {errs:?}"
     );
 }
@@ -27835,8 +27839,8 @@ fn test_graph_tlm_method_callers_resolve_through_bus_port_type() {
     let td = tempfile::tempdir().expect("tempdir");
     let graph = td.path().join("graph");
     let arch_bin = env!("CARGO_BIN_EXE_arch");
-    let src = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-        .join("tests/axi_dma_tlm/TlmOneToOne.arch");
+    let src =
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/axi_dma_tlm/TlmOneToOne.arch");
 
     let index = std::process::Command::new(arch_bin)
         .args(["graph", "index"])
@@ -28127,7 +28131,6 @@ end pipeline GuardRegPipe
         "a register used as a combinational mux select on an output must be accepted"
     );
 }
-
 
 // ────────────────────────────────────────────────────────────────────
 // NIC-400 GPV (PR #551) + C-channel clock-gate (PR #555) — coverage


### PR DESCRIPTION
Pure mechanical `cargo fmt` (rustfmt 1.8.0) over the whole codebase. **No semantic change** — every hunk is whitespace/brace/comma reflow.

### Why
`main` is not rustfmt-clean under the current toolchain, so any feature branch that runs `cargo fmt` produces a diff dominated by formatting churn. Landing this baseline first lets follow-up feature PRs show a minimal, reviewable semantic diff.

### Verification
- `cargo build --release` — clean.
- `cargo test --release` — all suites green (677 integration + others).

### Note
This touches many files, so it will conflict with other in-flight branches; they'll need a trivial `git merge main` + `cargo fmt` to reconcile.