### PR TITLE
ci: pin rust toolchain (1.94.0) + enforce cargo fmt --check

### DIFF
--- a/.github/workflows/rustfmt.yml
+++ b/.github/workflows/rustfmt.yml
@@ -1,0 +1,39 @@
+name: rustfmt
+
+# Fails if any Rust source is not formatted by the pinned rustfmt (see
+# rust-toolchain.toml). Non-mutating: it only checks. Run `cargo fmt` locally
+# to fix. Keep the toolchain version below in sync with rust-toolchain.toml.
+on:
+  push:
+    branches: [main]
+    paths:
+      - '**/*.rs'
+      - 'rustfmt.toml'
+      - 'rust-toolchain.toml'
+      - '.github/workflows/rustfmt.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - '**/*.rs'
+      - 'rustfmt.toml'
+      - 'rust-toolchain.toml'
+      - '.github/workflows/rustfmt.yml'
+
+concurrency:
+  group: rustfmt-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  fmt-check:
+    name: cargo fmt --check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pinned Rust toolchain + rustfmt
+        uses: dtolnay/rust-toolchain@1.94.0
+        with:
+          components: rustfmt
+
+      - name: cargo fmt --all --check
+        run: cargo fmt --all --check

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,18 @@
+# Pin the Rust toolchain — and therefore rustfmt — so formatting is byte-for-byte
+# identical across every contributor, autonomous agent, and CI run.
+#
+# Why this exists: rustfmt's output changes between toolchain versions. When the
+# repo had no pin, different rustfmt versions formatted the same code differently,
+# which produced large *spurious* formatting diffs and merge conflicts that buried
+# the real changes. Pinning makes `cargo fmt` deterministic everywhere, so the CI
+# `cargo fmt --check` (.github/workflows/rustfmt.yml) can be trusted.
+#
+# To upgrade: bump `channel` here, run `cargo fmt` over the tree, and commit the
+# (re)formatting together with the bump in one dedicated PR — never mixed with a
+# feature change. Keep this version in sync with the toolchain in
+# .github/workflows/rustfmt.yml.
+#
+# 1.94.0 ships rustfmt 1.8.0.
+[toolchain]
+channel = "1.94.0"
+components = ["rustfmt"]


### PR DESCRIPTION
Implements the two structural fixes for the formatting-churn problem (the root cause of the recent wave of spurious diffs and merge conflicts).

## Root cause
It was **rustfmt version skew**, not "people forget to run fmt": main had been formatted by an older rustfmt, nothing pinned the version, so anyone on a newer rustfmt (1.8.0) reformatted entire files. Evidence: before the rustfmt-baseline landed, `cargo fmt` rewrote ~45 files; after it, `cargo fmt --check` on main is clean and `cargo fmt` is idempotent.

## What this does
1. **`rust-toolchain.toml`** — pins the toolchain (and therefore rustfmt) to **1.94.0** (= rustfmt 1.8.0). Now `cargo fmt` is byte-identical for every contributor, autonomous agent, and CI run, so skew can't reappear.
2. **`.github/workflows/rustfmt.yml`** — runs `cargo fmt --all --check` on PRs/main touching Rust. Non-mutating (it only checks; it never rewrites your tree), mirrors the existing `skill-snapshots` job. main is already clean under the pin, so it's green from day one.

## Deliberately *not* done
No auto-formatting pre-commit hook — that mutates the tree under you, fights partial staging, is unreliable for agents in fresh worktrees, and wouldn't have prevented this incident (skew would still bite). A non-mutating CI check + a version pin is the standard, robust combination.

## Verification
- With the pin active: `rustfmt --version` → `1.8.0-stable`.
- `cargo fmt --all --check` → exit 0 (clean) on current main.
- `rustfmt.yml` parses as valid YAML.

## Upgrading later
Bump `channel` in `rust-toolchain.toml`, run `cargo fmt` over the tree, and commit the reformatting together with the bump in one dedicated PR (keep the version in the workflow in sync). Never mix a toolchain bump with a feature change.