### PR TITLE
feat(typecheck): require match `_` wildcard to be the last arm

### DIFF
--- a/doc/ARCH_HDL_Specification.md
+++ b/doc/ARCH_HDL_Specification.md
@@ -523,6 +523,8 @@ Every signal in Arch has exactly one driver --- the block (comb or reg) that ass
 > ◈ **No implicit latches.** The compiler verifies that every signal assigned in a `comb` block is assigned on ALL control paths. A missing `else` branch or incomplete `match` is a compile error: *"signal \`x\` is not assigned on all control paths in comb block (infers a latch)."* The common default-then-override pattern is safe: `x = 0; if sel / x = a; end if` --- the unconditional default covers the missing else. An exhaustive enum `match` (all variants listed without `_` wildcard) also satisfies this check.
 >
 > ◈ **Comb match uses `=` syntax.** In `comb` blocks, `match` arms use `=` (combinational assign). In `seq` blocks, arms use `<=` (register assign). Enum exhaustiveness is checked in both contexts.
+>
+> ◈ **A `_` wildcard must be the last arm.** `match` arms are tested in source order (priority semantics — see §4.2.1d). The wildcard `_` matches every remaining value, so any arm written after it is unreachable, and a `match` may contain at most one `_`. Both are compile errors: *"unreachable match arm: the wildcard `_` already matches every value — make `_` the last arm, or remove the arm(s) after it."* A bare identifier arm such as `FOO =>` is **not** a wildcard — it compares the scrutinee against the named constant `FOO`, so it is refutable and may appear in any position. Requiring `_` last makes a `match` mean the same thing regardless of arm order, and stops an AI from silently burying live arms beneath an early default.
 
 **3.5 Vec Methods**
 
@@ -987,6 +989,8 @@ end match
 ```
 
 The emitted SystemVerilog uses `unique if (...)` and `unique case (...)` respectively. Use `unique` when you know the conditions cannot overlap and want the synthesis tool to optimize accordingly. Omit it when conditions may overlap and priority resolution is required.
+
+Because `match` arms resolve by priority, a `_` wildcard must be the final arm (§3.4). This holds for `unique match` as well: a non-final `_` would overlap every following arm, contradicting the mutual exclusivity that `unique` asserts.
 
 **4.2.2 Bit Concatenation and Replication**
 

--- a/doc/Arch_AI_Reference_Card.md
+++ b/doc/Arch_AI_Reference_Card.md
@@ -119,6 +119,8 @@ unique match opcode
 end match
 ```
 
+`match` arms are **priority-ordered**: the `_` wildcard must be the **last** arm (an arm after `_` is an unreachable-pattern compile error, and at most one `_` is allowed). A bare name (`FOO =>`) is a constant comparison, not a catch-all, so it may go anywhere.
+
 `match` in `comb` uses `=`; in `seq` uses `<=`. Exhaustive enum match (all variants listed) satisfies the latch check without needing `_` wildcard:
 
 ```

--- a/skills/arch-programming/references/ARCH_HDL_Specification.md
+++ b/skills/arch-programming/references/ARCH_HDL_Specification.md
@@ -523,6 +523,8 @@ Every signal in Arch has exactly one driver --- the block (comb or reg) that ass
 > ◈ **No implicit latches.** The compiler verifies that every signal assigned in a `comb` block is assigned on ALL control paths. A missing `else` branch or incomplete `match` is a compile error: *"signal \`x\` is not assigned on all control paths in comb block (infers a latch)."* The common default-then-override pattern is safe: `x = 0; if sel / x = a; end if` --- the unconditional default covers the missing else. An exhaustive enum `match` (all variants listed without `_` wildcard) also satisfies this check.
 >
 > ◈ **Comb match uses `=` syntax.** In `comb` blocks, `match` arms use `=` (combinational assign). In `seq` blocks, arms use `<=` (register assign). Enum exhaustiveness is checked in both contexts.
+>
+> ◈ **A `_` wildcard must be the last arm.** `match` arms are tested in source order (priority semantics — see §4.2.1d). The wildcard `_` matches every remaining value, so any arm written after it is unreachable, and a `match` may contain at most one `_`. Both are compile errors: *"unreachable match arm: the wildcard `_` already matches every value — make `_` the last arm, or remove the arm(s) after it."* A bare identifier arm such as `FOO =>` is **not** a wildcard — it compares the scrutinee against the named constant `FOO`, so it is refutable and may appear in any position. Requiring `_` last makes a `match` mean the same thing regardless of arm order, and stops an AI from silently burying live arms beneath an early default.
 
 **3.5 Vec Methods**
 
@@ -987,6 +989,8 @@ end match
 ```
 
 The emitted SystemVerilog uses `unique if (...)` and `unique case (...)` respectively. Use `unique` when you know the conditions cannot overlap and want the synthesis tool to optimize accordingly. Omit it when conditions may overlap and priority resolution is required.
+
+Because `match` arms resolve by priority, a `_` wildcard must be the final arm (§3.4). This holds for `unique match` as well: a non-final `_` would overlap every following arm, contradicting the mutual exclusivity that `unique` asserts.
 
 **4.2.2 Bit Concatenation and Replication**
 

--- a/skills/arch-programming/references/Arch_AI_Reference_Card.md
+++ b/skills/arch-programming/references/Arch_AI_Reference_Card.md
@@ -119,6 +119,8 @@ unique match opcode
 end match
 ```
 
+`match` arms are **priority-ordered**: the `_` wildcard must be the **last** arm (an arm after `_` is an unreachable-pattern compile error, and at most one `_` is allowed). A bare name (`FOO =>`) is a constant comparison, not a catch-all, so it may go anywhere.
+
 `match` in `comb` uses `=`; in `seq` uses `<=`. Exhaustive enum match (all variants listed) satisfies the latch check without needing `_` wildcard:
 
 ```

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -2913,12 +2913,45 @@ impl<'a> TypeChecker<'a> {
         module_name: &str,
         local_types: &HashMap<String, Ty>,
     ) {
+        // `_` (wildcard) must be the final arm, and may appear at most once.
+        // Match arms resolve by priority (source order; `unique match` only
+        // asserts mutual exclusivity), so `_` matches every remaining value and
+        // any arm written after it is unreachable. A bare identifier arm
+        // (`FOO =>`) is a constant comparison (lowered to `s == FOO`), not a
+        // catch-all, so it is unrestricted. This applies to every match — enum
+        // or integer/literal — so it runs before the enum-only logic below.
+        // Both spellings of the wildcard (`Pattern::Wildcard` and the bare
+        // identifier `_`) count, mirroring codegen's `default` lowering.
+        let is_wildcard = |p: &Pattern| {
+            matches!(p, Pattern::Wildcard) || matches!(p, Pattern::Ident(id) if id.name == "_")
+        };
+        let wildcard_idxs: Vec<usize> = patterns
+            .iter()
+            .enumerate()
+            .filter(|(_, p)| is_wildcard(p))
+            .map(|(i, _)| i)
+            .collect();
+        if wildcard_idxs.len() > 1 {
+            self.errors.push(CompileError::general(
+                "duplicate wildcard arm: a `match` may contain at most one `_`",
+                span,
+            ));
+        } else if let Some(&first) = wildcard_idxs.first() {
+            if first != patterns.len() - 1 {
+                self.errors.push(CompileError::general(
+                    "unreachable match arm: the wildcard `_` already matches every \
+                     value — make `_` the last arm, or remove the arm(s) after it",
+                    span,
+                ));
+            }
+        }
+
         let scrutinee_ty = self.resolve_expr_type(scrutinee, module_name, local_types);
         let enum_name = match &scrutinee_ty {
             Ty::Enum(name, _) => name.clone(),
             _ => return, // only check enum matches
         };
-        if patterns.iter().any(|p| matches!(p, Pattern::Wildcard)) {
+        if patterns.iter().any(is_wildcard) {
             return; // wildcard covers everything
         }
         let covered: HashSet<String> = patterns

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -28988,3 +28988,108 @@ int main() {\n\
         "both ternary arms should be hit by the smoke bench:\n{coverage_text}"
     );
 }
+
+#[test]
+fn test_match_wildcard_not_last_is_unreachable_error() {
+    // `_` before a later arm: that arm is unreachable (priority semantics).
+    let source = r#"
+enum Color
+  Red,
+  Green,
+  Blue,
+end enum Color
+
+module BadOrder
+  port c: in Color;
+  port o: out UInt<8>;
+  comb
+    match c
+      Color::Red  => o = 1;
+      _           => o = 0;
+      Color::Blue => o = 3;
+    end match
+  end comb
+end module BadOrder
+"#;
+    let errs = typecheck_source(source).expect_err("expected an unreachable-arm error");
+    let msg = format!("{errs:?}");
+    assert!(
+        msg.contains("unreachable match arm"),
+        "expected unreachable-wildcard-arm diagnostic, got: {msg}"
+    );
+}
+
+#[test]
+fn test_match_wildcard_last_is_accepted() {
+    let source = r#"
+enum Color
+  Red,
+  Green,
+  Blue,
+end enum Color
+
+module GoodOrder
+  port c: in Color;
+  port o: out UInt<8>;
+  comb
+    match c
+      Color::Red  => o = 1;
+      Color::Blue => o = 3;
+      _           => o = 0;
+    end match
+  end comb
+end module GoodOrder
+"#;
+    assert!(
+        typecheck_source(source).is_ok(),
+        "a match with `_` as the final arm must type-check"
+    );
+}
+
+#[test]
+fn test_match_duplicate_wildcard_is_error() {
+    let source = r#"
+module DupWild
+  port c: in UInt<2>;
+  port o: out UInt<8>;
+  comb
+    match c
+      0 => o = 1;
+      _ => o = 2;
+      _ => o = 3;
+    end match
+  end comb
+end module DupWild
+"#;
+    let errs = typecheck_source(source).expect_err("expected a duplicate-wildcard error");
+    assert!(
+        format!("{errs:?}").contains("duplicate wildcard arm"),
+        "expected duplicate-wildcard diagnostic, got: {:?}",
+        typecheck_source(source)
+    );
+}
+
+#[test]
+fn test_match_wildcard_not_last_errors_for_non_enum_too() {
+    // The rule applies to every match, not only enum matches: this integer
+    // match places `_` before a literal arm.
+    let source = r#"
+module IntBadOrder
+  port c: in UInt<2>;
+  port o: out UInt<8>;
+  comb
+    match c
+      0 => o = 1;
+      _ => o = 0;
+      1 => o = 2;
+    end match
+  end comb
+end module IntBadOrder
+"#;
+    let errs =
+        typecheck_source(source).expect_err("expected unreachable-arm error for non-enum match");
+    assert!(
+        format!("{errs:?}").contains("unreachable match arm"),
+        "non-enum match must also enforce wildcard-last"
+    );
+}


### PR DESCRIPTION
Implements the agreed match-wildcard rule (spec wording approved first).

## Rule
`match` arms resolve by **priority** (source order; `unique match` only asserts mutual exclusivity), so the `_` wildcard matches every remaining value:
- an arm after `_` is **unreachable** → compile error,
- a second `_` → compile error (at most one per match).

A bare identifier arm (`FOO =>`) is a **constant comparison** (`s == FOO`), not a catch-all, so it is unrestricted — only `_` must be last.

```
unreachable match arm: the wildcard `_` already matches every value —
make `_` the last arm, or remove the arm(s) after it
duplicate wildcard arm: a `match` may contain at most one `_`
```

## Implementation
- The check lives at the **top of `check_match_exhaustive`**, before its enum-only early-return, so it fires for every match form — comb/seq statement matches (`Stmt::Match`) and expression matches (`ExprMatch`) — and for non-enum (integer/literal) matches too.
- Recognizes **both** spellings of the wildcard (`Pattern::Wildcard` and the bare identifier `_`), matching codegen's `default` lowering; the exhaustiveness short-circuit now uses the same predicate (previously it only saw `Pattern::Wildcard`).
- No user-facing syntax change; this is a new **rejection** of programs that were previously accepted but produced dead arms. Spec updated as part of the change.

## Docs
- `doc/ARCH_HDL_Specification.md` §3.4 (new callout) + §4.2.1d (cross-reference)
- `doc/Arch_AI_Reference_Card.md` (match rules line)
- skill-reference snapshots refreshed

## Tests
4 typecheck tests: `_`-not-last (enum), `_`-last accepted, duplicate `_`, and `_`-not-last on a non-enum match.

## Verification
- `cargo test --test integration_test test_match_` → 4/4 pass.
- Snapshots in sync, `cargo fmt --check` clean.
- Full `cargo test --release` sweep running to catch any in-tree corpus that had `_` not-last (reported in a follow-up comment if any surface).