### PR TITLE
docs(clippy): clean up doc-comment layout (bucket 2)

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -329,14 +329,13 @@ pub struct PortDecl {
     /// Per-output combinational-dependency annotation (issue #246
     /// Phase 2). Only legal on output ports without `reg_info` (i.e.
     /// comb-driven outputs). Three states:
-    ///   - `None`           — no annotation. Analyzer falls back to
-    ///                        the opaque "every comb input feeds this
-    ///                        output" over-approximation.
-    ///   - `Some(vec![])`   — pure: comb-driven but depends on no
-    ///                        inputs (e.g. constant). No incoming
-    ///                        comb edges.
-    ///   - `Some(vec![..])` — precise: depends only on the listed
-    ///                        input port names.
+    /// - `None` — no annotation. Analyzer falls back to the opaque
+    ///   "every comb input feeds this output" over-approximation.
+    /// - `Some(vec![])` — pure: comb-driven but depends on no inputs
+    ///   (e.g. constant). No incoming comb edges.
+    /// - `Some(vec![..])` — precise: depends only on the listed input
+    ///   port names.
+    ///
     /// Carried verbatim through `.archi` emit / parse so consumers
     /// (`comb_graph::expand_inst`) can synthesize precise cross-
     /// boundary edges instead of the opaque every-in-feeds-every-out

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -3436,8 +3436,9 @@ impl<'a> Codegen<'a> {
     }
 
     /// For each `reg ... guard <sig>` in the module, emit:
-    ///   1. A shadow `_<reg>_written` flag, set on any seq-block commit for the reg.
-    ///   2. An SVA contract `<sig> |-> _<reg>_written` (in translate_off).
+    /// 1. A shadow `_<reg>_written` flag, set on any seq-block commit for the reg.
+    /// 2. An SVA contract `<sig> |-> _<reg>_written` (in translate_off).
+    ///
     /// This catches the producer-bug pattern: `valid` asserts but data was never
     /// written. Verilator `--assert` and EBMC formal both consume this.
     ///
@@ -3777,14 +3778,14 @@ impl<'a> Codegen<'a> {
     /// - `hs`        — channel metadata (variant, name, array shape).
     /// - `clk`       — already-resolved clock signal name (no edge keyword).
     /// - `rst_active`— already-resolved active-level reset expression
-    ///                 (e.g. `rst` or `!rst_n`); `None` skips `disable iff`.
+    ///   (e.g. `rst` or `!rst_n`); `None` skips `disable iff`.
     /// - `sig_prefix`— prefix for the per-variant control signals; the
-    ///                 helper appends `_valid`/`_ready`/etc. For the bus
-    ///                 path this is `<port>_<chname>`; for arbiters it is
-    ///                 just `<chname>` (signals are top-level).
+    ///   helper appends `_valid`/`_ready`/etc. For the bus
+    ///   path this is `<port>_<chname>`; for arbiters it is
+    ///   just `<chname>` (signals are top-level).
     /// - `label_stem`— middle of `_auto_hs_<stem>_<rule>` for SV labels.
-    ///                 Bus-path stem is `<port>_<chname>`; arbiter is
-    ///                 `<chname>` (plus a per-lane suffix when arrayed).
+    ///   Bus-path stem is `<port>_<chname>`; arbiter is
+    ///   `<chname>` (plus a per-lane suffix when arrayed).
     /// - `mod_name`  — enclosing construct name for the `$fatal` message.
     ///
     /// When `hs.array_count` is `Some(expr)`, the property is wrapped in
@@ -3976,10 +3977,9 @@ impl<'a> Codegen<'a> {
     /// 1. `logic [W-1:0] __<port>_<ch>_credit;` — the credit register,
     ///    width = clog2(DEPTH+1).
     /// 2. An `always_ff` block that resets the counter to DEPTH on reset
-    ///    and updates it each cycle:
-    ///       -1 when send_valid && !credit_return
-    ///       +1 when credit_return && !send_valid
-    ///       no change when both fire in the same cycle (plan §Lowering).
+    ///    and updates it each cycle: `-1` when `send_valid && !credit_return`,
+    ///    `+1` when `credit_return && !send_valid`, no change when both fire
+    ///    in the same cycle (plan §Lowering).
     /// 3. `wire __<port>_<ch>_can_send = __<port>_<ch>_credit != 0;` —
     ///    combinational current-cycle availability. Users whose design
     ///    needs a timing-relief flop will opt in via the upcoming

--- a/src/learn.rs
+++ b/src/learn.rs
@@ -646,6 +646,7 @@ pub fn print_stats() -> std::io::Result<()> {
 /// - `code == Some(c)`: event's error_code equals `c`
 /// - `substr == Some(s)`: `s` appears in diff_summary, error_message, or file_path
 /// - `older_than_days == Some(d)`: event timestamp is older than `d` days ago
+///
 /// If `dry_run` is true, nothing is written; just counts.
 pub fn prune(
     code: Option<&str>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -2391,11 +2391,12 @@ sys.exit(0 if ok else 1)
 /// dependency files prepended.
 /// Locate the shipped standard library directory containing curated bus
 /// definitions (BusAxiStream, BusAxiLite, BusApb, etc.). Resolution:
-///   1. `ARCH_STDLIB_PATH` env override (absolute path to stdlib/)
-///   2. Disabled entirely if `ARCH_NO_STDLIB=1`
-///   3. `<exe>/../stdlib/` — matches `cargo run` layout (target/debug/arch → ../../stdlib)
-///   4. `<exe>/../../stdlib/` — matches cargo workspace runs
-///   5. `<exe>/../share/arch/stdlib/` — matches Unix `<prefix>/bin/arch` installs
+/// 1. `ARCH_STDLIB_PATH` env override (absolute path to stdlib/)
+/// 2. Disabled entirely if `ARCH_NO_STDLIB=1`
+/// 3. `<exe>/../stdlib/` — matches `cargo run` layout (target/debug/arch → ../../stdlib)
+/// 4. `<exe>/../../stdlib/` — matches cargo workspace runs
+/// 5. `<exe>/../share/arch/stdlib/` — matches Unix `<prefix>/bin/arch` installs
+///
 /// Returns None if none of these resolve to an existing directory.
 fn resolve_stdlib_dir() -> Option<PathBuf> {
     if std::env::var("ARCH_NO_STDLIB").is_ok() {

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -1628,20 +1628,6 @@ impl<'a> TypeChecker<'a> {
         self.check_handshake_reads(m);
     }
 
-    /// Compile-time lint: if a module has a bus port whose bus declares one or
-    /// more `handshake` channels, every read of a payload signal inside
-    /// comb/seq/latch blocks should sit under an `if <port>.<valid>` (or the
-    /// variant's `<port>.<req>`) conditional.
-    ///
-    /// v1 scope:
-    /// - Recognized guards: the exact valid/req field access (`port.ch_valid`),
-    ///   either directly as the if-condition or as an AND-conjunct of it.
-    /// - Does NOT trace let-bindings: `let g = port.ch_valid; if g ...` is a
-    ///   known false-positive and documented in the plan. If this becomes
-    ///   noisy, extend by resolving single-ident let RHS before matching.
-    /// - Variants with no valid signal (`ready_only`) are skipped entirely;
-    ///   `req_ack_2phase` uses the pending-transfer guard (`req != ack`).
-
     /// Check an `inst` declaration: validates port connections (unconnected
     /// inputs error, unconnected outputs warn), expands whole-bus connections
     /// to per-signal driven entries, and marks output signals as driven.
@@ -1911,6 +1897,19 @@ impl<'a> TypeChecker<'a> {
             }
         }
     }
+    /// Compile-time lint: if a module has a bus port whose bus declares one or
+    /// more `handshake` channels, every read of a payload signal inside
+    /// comb/seq/latch blocks should sit under an `if <port>.<valid>` (or the
+    /// variant's `<port>.<req>`) conditional.
+    ///
+    /// v1 scope:
+    /// - Recognized guards: the exact valid/req field access (`port.ch_valid`),
+    ///   either directly as the if-condition or as an AND-conjunct of it.
+    /// - Does NOT trace let-bindings: `let g = port.ch_valid; if g ...` is a
+    ///   known false-positive and documented in the plan. If this becomes
+    ///   noisy, extend by resolving single-ident let RHS before matching.
+    /// - Variants with no valid signal (`ready_only`) are skipped entirely;
+    ///   `req_ack_2phase` uses the pending-transfer guard (`req != ack`).
     pub(crate) fn check_handshake_reads(&mut self, m: &ModuleDecl) {
         use std::collections::HashMap as Map;
         // port_name -> Vec<(channel_name, guard, payload_field_names)>
@@ -4110,10 +4109,6 @@ impl<'a> TypeChecker<'a> {
         }
     }
 
-    /// Detects expressions where ARCH and SV precedence differ and the user
-    /// has not added parentheses. Specifically: bitwise ops (`&`, `|`, `^`)
-    /// mixed with comparison ops (`==`, `!=`, `<`, `>`, `<=`, `>=`) as children.
-
     /// Resolve `ExprKind::FieldAccess(base, field)` — the type of a `.field`
     /// access on a struct, bus, or `Reset.asserted` polarity-abstracted bool.
     /// Extracted from `resolve_expr_type` for readability — the original arm
@@ -4544,6 +4539,9 @@ impl<'a> TypeChecker<'a> {
             _ => Ty::Error,
         }
     }
+    /// Detects expressions where ARCH and SV precedence differ and the user
+    /// has not added parentheses. Specifically: bitwise ops (`&`, `|`, `^`)
+    /// mixed with comparison ops (`==`, `!=`, `<`, `>`, `<=`, `>=`) as children.
     pub(crate) fn check_precedence_ambiguity(
         &mut self,
         op: BinOp,
@@ -7594,14 +7592,15 @@ impl<'a> TypeChecker<'a> {
 /// condition properly guards a payload read.
 ///
 /// Accepted patterns:
-///   - `port.valid` / `port.req`                 (exact level guard)
-///   - `port.req != port.ack`                    (2-phase pending guard)
-///   - `guard && X`                              (AND conjunct, either side)
-///   - `(guard) && X`                            (parens are transparent in AST)
+/// - `port.valid` / `port.req`                 (exact level guard)
+/// - `port.req != port.ack`                    (2-phase pending guard)
+/// - `guard && X`                              (AND conjunct, either side)
+/// - `(guard) && X`                            (parens are transparent in AST)
+///
 /// Not accepted:
-///   - `port.valid || X`                         (not guaranteed)
-///   - `let g = port.valid; if g ...`            (v1 does not trace lets)
-///   - `!port.valid` / else branch               (negation not modeled)
+/// - `port.valid || X`                         (not guaranteed)
+/// - `let g = port.valid; if g ...`            (v1 does not trace lets)
+/// - `!port.valid` / else branch               (negation not modeled)
 fn cond_contains_guard(cond: &Expr, port: &str, guard: &HandshakePayloadGuard) -> bool {
     match &cond.kind {
         ExprKind::FieldAccess(base, field) => {


### PR DESCRIPTION
Cleans up the doc-comment-layout clippy lints that survived `cargo clippy --fix` (they aren't machine-applicable). Comments only — no code or behavior change.

## Lints fixed (34 → 0)
- `doc_overindented_list_items` (14)
- `doc_lazy_continuation` (14)
- `empty_line_after_doc_comments` (2)

## What changed
- **Alignment-formatted lists → standard markdown**: de-indent `-`/`1.` markers to the base column and set wrapped continuation lines to a 2-space indent (they were aligned to the em-dash, which markdown over-indents); separate trailing paragraphs from lists with a blank `///` line.
- **codegen credit-counter doc**: the `-1`/`+1` sub-lines were read by markdown as bullets — folded them into item 2's continuation and backticked them.
- **The two `empty_line_after_doc_comments` were not layout issues — they were orphaned doc comments** stranded above unrelated functions by past refactors. Relocated each to the function it actually describes (both were undocumented):
  - the handshake-payload-read lint doc → `check_handshake_reads`
  - the precedence-ambiguity doc → `check_precedence_ambiguity`

## Scope note
This is **bucket 2** of the clippy backlog (doc layout). The mechanical auto-fixable lints (bucket 1, ~110) are on the separate `claude/clippy-autofix` branch; the structural `#[allow]`/idiom items (buckets 3–4) are not addressed here.

## Verification
- Scoped `cargo clippy -W doc_lazy_continuation -W doc_overindented_list_items -W empty_line_after_doc_comments` → **0 warnings** (was 34).
- `cargo fmt --check` clean, `cargo build --release` clean.