### PR TITLE
Support local param in ram/counter/arbiter and param-width sized literals

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -329,14 +329,13 @@ pub struct PortDecl {
     /// Per-output combinational-dependency annotation (issue #246
     /// Phase 2). Only legal on output ports without `reg_info` (i.e.
     /// comb-driven outputs). Three states:
-    ///   - `None`           — no annotation. Analyzer falls back to
-    ///                        the opaque "every comb input feeds this
-    ///                        output" over-approximation.
-    ///   - `Some(vec![])`   — pure: comb-driven but depends on no
-    ///                        inputs (e.g. constant). No incoming
-    ///                        comb edges.
-    ///   - `Some(vec![..])` — precise: depends only on the listed
-    ///                        input port names.
+    /// - `None` — no annotation. Analyzer falls back to the opaque
+    ///   "every comb input feeds this output" over-approximation.
+    /// - `Some(vec![])` — pure: comb-driven but depends on no inputs
+    ///   (e.g. constant). No incoming comb edges.
+    /// - `Some(vec![..])` — precise: depends only on the listed input
+    ///   port names.
+    ///
     /// Carried verbatim through `.archi` emit / parse so consumers
     /// (`comb_graph::expand_inst`) can synthesize precise cross-
     /// boundary edges instead of the opaque every-in-feeds-every-out

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1189,6 +1189,10 @@ pub enum LitKind {
     Hex(u64),
     Bin(u64),
     Sized(u32, u64), // width, value
+    /// Sized literal whose width is a param/local-param identifier, e.g.
+    /// `SCORE_WIDTH'd0`. The first element is the param name; the second
+    /// is the literal value. The width is resolved during elaboration.
+    ParamSized(String, u64),
     /// Floating-point literal, e.g. `1.5`, `3.0e-2`. The decimal value is
     /// parsed to an f64 (exact enough for source literals); the concrete
     /// FP32/BF16 bit pattern is produced by rounding to the context type at

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -3436,8 +3436,9 @@ impl<'a> Codegen<'a> {
     }
 
     /// For each `reg ... guard <sig>` in the module, emit:
-    ///   1. A shadow `_<reg>_written` flag, set on any seq-block commit for the reg.
-    ///   2. An SVA contract `<sig> |-> _<reg>_written` (in translate_off).
+    /// 1. A shadow `_<reg>_written` flag, set on any seq-block commit for the reg.
+    /// 2. An SVA contract `<sig> |-> _<reg>_written` (in translate_off).
+    ///
     /// This catches the producer-bug pattern: `valid` asserts but data was never
     /// written. Verilator `--assert` and EBMC formal both consume this.
     ///
@@ -3777,14 +3778,14 @@ impl<'a> Codegen<'a> {
     /// - `hs`        — channel metadata (variant, name, array shape).
     /// - `clk`       — already-resolved clock signal name (no edge keyword).
     /// - `rst_active`— already-resolved active-level reset expression
-    ///                 (e.g. `rst` or `!rst_n`); `None` skips `disable iff`.
+    ///   (e.g. `rst` or `!rst_n`); `None` skips `disable iff`.
     /// - `sig_prefix`— prefix for the per-variant control signals; the
-    ///                 helper appends `_valid`/`_ready`/etc. For the bus
-    ///                 path this is `<port>_<chname>`; for arbiters it is
-    ///                 just `<chname>` (signals are top-level).
+    ///   helper appends `_valid`/`_ready`/etc. For the bus
+    ///   path this is `<port>_<chname>`; for arbiters it is
+    ///   just `<chname>` (signals are top-level).
     /// - `label_stem`— middle of `_auto_hs_<stem>_<rule>` for SV labels.
-    ///                 Bus-path stem is `<port>_<chname>`; arbiter is
-    ///                 `<chname>` (plus a per-lane suffix when arrayed).
+    ///   Bus-path stem is `<port>_<chname>`; arbiter is
+    ///   `<chname>` (plus a per-lane suffix when arrayed).
     /// - `mod_name`  — enclosing construct name for the `$fatal` message.
     ///
     /// When `hs.array_count` is `Some(expr)`, the property is wrapped in
@@ -3976,10 +3977,9 @@ impl<'a> Codegen<'a> {
     /// 1. `logic [W-1:0] __<port>_<ch>_credit;` — the credit register,
     ///    width = clog2(DEPTH+1).
     /// 2. An `always_ff` block that resets the counter to DEPTH on reset
-    ///    and updates it each cycle:
-    ///       -1 when send_valid && !credit_return
-    ///       +1 when credit_return && !send_valid
-    ///       no change when both fire in the same cycle (plan §Lowering).
+    ///    and updates it each cycle: `-1` when `send_valid && !credit_return`,
+    ///    `+1` when `credit_return && !send_valid`, no change when both fire
+    ///    in the same cycle (plan §Lowering).
     /// 3. `wire __<port>_<ch>_can_send = __<port>_<ch>_credit != 0;` —
     ///    combinational current-cycle availability. Users whose design
     ///    needs a timing-relief flop will opt in via the upcoming

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -2147,7 +2147,7 @@ impl<'a> Codegen<'a> {
                 ExprKind::Literal(lit) => {
                     let val = match lit {
                         LitKind::Dec(v) | LitKind::Hex(v) | LitKind::Bin(v) => *v as i64,
-                        LitKind::Sized(_, v) => *v as i64,
+                        LitKind::Sized(_, v) | LitKind::ParamSized(_, v) => *v as i64,
                         LitKind::Float(_) => return None, // not an integer constant
                     };
                     Some(val)
@@ -2180,6 +2180,7 @@ impl<'a> Codegen<'a> {
                 ExprKind::Literal(lit) => match lit {
                     LitKind::Dec(v) | LitKind::Hex(v) | LitKind::Bin(v) => format!("{v}"),
                     LitKind::Sized(w, v) => format!("{w}'{v}"),
+                    LitKind::ParamSized(name, v) => format!("{name}'{v}"),
                     LitKind::Float(bits) => format!("f{bits}"),
                 },
                 ExprKind::Binary(op, lhs, rhs) => {
@@ -2197,7 +2198,7 @@ impl<'a> Codegen<'a> {
                 ExprKind::Literal(lit) => {
                     let val = match lit {
                         LitKind::Dec(v) | LitKind::Hex(v) | LitKind::Bin(v) => *v as i64,
-                        LitKind::Sized(_, v) => *v as i64,
+                        LitKind::Sized(_, v) | LitKind::ParamSized(_, v) => *v as i64,
                         LitKind::Float(_) => {
                             terms.push((sign, None, expr_key(expr)));
                             return;
@@ -5736,6 +5737,7 @@ impl<'a> Codegen<'a> {
                 LitKind::Hex(v) => format!("'h{v:X}"),
                 LitKind::Bin(v) => format!("'b{v:b}"),
                 LitKind::Sized(w, v) => format!("{w}'d{v}"),
+                LitKind::ParamSized(name, v) => format!("{name}'d{v}"),
                 // Float literal (FP32 by default) → 32-bit binary32 bit pattern.
                 LitKind::Float(bits) => {
                     format!("32'h{:08X}", (f64::from_bits(*bits) as f32).to_bits())

--- a/src/elaborate.rs
+++ b/src/elaborate.rs
@@ -11085,6 +11085,26 @@ fn subst_expr_params(expr: &Expr, param_map: &HashMap<String, &Expr>) -> Expr {
                 .map(|part| subst_expr_params(part, param_map))
                 .collect(),
         ),
+        ExprKind::Literal(LitKind::ParamSized(name, value)) => {
+            // Resolve the param-width identifier to a concrete width.
+            if let Some(width) = eval_const_expr_from_param_map_for_lower(
+                &Expr {
+                    kind: ExprKind::Ident(name.clone()),
+                    span: expr.span,
+                    parenthesized: false,
+                },
+                param_map,
+            ) {
+                return Expr {
+                    kind: ExprKind::Literal(LitKind::Sized(width as u32, *value)),
+                    span: expr.span,
+                    parenthesized: expr.parenthesized,
+                };
+            }
+            // If the param can't be resolved yet, keep it as ParamSized.
+            // The typechecker will catch the unresolved reference.
+            ExprKind::Literal(LitKind::ParamSized(name.clone(), *value))
+        }
         _ => return expr.clone(),
     };
     Expr {

--- a/src/formal.rs
+++ b/src/formal.rs
@@ -2910,6 +2910,11 @@ fn lit_to_term(l: &LitKind) -> SmtTerm {
             width: *w,
             signed: false,
         },
+        LitKind::ParamSized(_, v) => SmtTerm {
+            s: bv_lit(*v, 32),
+            width: 32,
+            signed: false,
+        },
         // Float literals are unreachable here in practice — FP types are rejected
         // by `check_scalar_type` before emission. Fall back to the FP32 bit
         // pattern as a 32-bit vector so this stays total.

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -553,6 +553,7 @@ fn expr_str(expr: &Expr) -> String {
             LitKind::Hex(v) => format!("0x{:X}", v),
             LitKind::Bin(v) => format!("0b{:b}", v),
             LitKind::Sized(width, val) => format!("{width}'d{val}"),
+            LitKind::ParamSized(name, val) => format!("{name}'d{val}"),
             LitKind::Float(bits) => {
                 let v = f64::from_bits(*bits);
                 if v.fract() == 0.0 {

--- a/src/learn.rs
+++ b/src/learn.rs
@@ -646,6 +646,7 @@ pub fn print_stats() -> std::io::Result<()> {
 /// - `code == Some(c)`: event's error_code equals `c`
 /// - `substr == Some(s)`: `s` appears in diff_summary, error_message, or file_path
 /// - `older_than_days == Some(d)`: event timestamp is older than `d` days ago
+///
 /// If `dry_run` is true, nothing is written; just counts.
 pub fn prune(
     code: Option<&str>,

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -369,7 +369,7 @@ pub enum TokenKind {
     #[regex(r"0b[01][01_]*", |lex| lex.slice().to_string())]
     BinLiteral(String),
 
-    #[regex(r"[0-9]+'[bhd][0-9a-fA-F_]+", |lex| lex.slice().to_string())]
+    #[regex(r"[a-zA-Z_][a-zA-Z0-9_]*'[bhd][0-9a-fA-F_]+|[0-9]+[a-zA-Z_][a-zA-Z0-9_]*'[bhd][0-9a-fA-F_]+|[0-9]+'[bhd][0-9a-fA-F_]+", |lex| lex.slice().to_string())]
     SizedLiteral(String),
 
     // Float literal: must contain a decimal point (and may have an exponent),
@@ -731,6 +731,13 @@ mod tests {
         assert_eq!(tokens[1].kind, TokenKind::HexLiteral("0xFF".into()));
         assert_eq!(tokens[2].kind, TokenKind::BinLiteral("0b1010".into()));
         assert_eq!(tokens[3].kind, TokenKind::SizedLiteral("8'hAB".into()));
+    }
+
+    #[test]
+    fn test_param_sized_literals() {
+        let tokens = tokenize("W'd0 SCORE_WIDTH'd42").unwrap();
+        assert_eq!(tokens[0].kind, TokenKind::SizedLiteral("W'd0".into()));
+        assert_eq!(tokens[1].kind, TokenKind::SizedLiteral("SCORE_WIDTH'd42".into()));
     }
 
     #[test]

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -737,7 +737,10 @@ mod tests {
     fn test_param_sized_literals() {
         let tokens = tokenize("W'd0 SCORE_WIDTH'd42").unwrap();
         assert_eq!(tokens[0].kind, TokenKind::SizedLiteral("W'd0".into()));
-        assert_eq!(tokens[1].kind, TokenKind::SizedLiteral("SCORE_WIDTH'd42".into()));
+        assert_eq!(
+            tokens[1].kind,
+            TokenKind::SizedLiteral("SCORE_WIDTH'd42".into())
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -2391,11 +2391,12 @@ sys.exit(0 if ok else 1)
 /// dependency files prepended.
 /// Locate the shipped standard library directory containing curated bus
 /// definitions (BusAxiStream, BusAxiLite, BusApb, etc.). Resolution:
-///   1. `ARCH_STDLIB_PATH` env override (absolute path to stdlib/)
-///   2. Disabled entirely if `ARCH_NO_STDLIB=1`
-///   3. `<exe>/../stdlib/` — matches `cargo run` layout (target/debug/arch → ../../stdlib)
-///   4. `<exe>/../../stdlib/` — matches cargo workspace runs
-///   5. `<exe>/../share/arch/stdlib/` — matches Unix `<prefix>/bin/arch` installs
+/// 1. `ARCH_STDLIB_PATH` env override (absolute path to stdlib/)
+/// 2. Disabled entirely if `ARCH_NO_STDLIB=1`
+/// 3. `<exe>/../stdlib/` — matches `cargo run` layout (target/debug/arch → ../../stdlib)
+/// 4. `<exe>/../../stdlib/` — matches cargo workspace runs
+/// 5. `<exe>/../share/arch/stdlib/` — matches Unix `<prefix>/bin/arch` installs
+///
 /// Returns None if none of these resolve to an existing directory.
 fn resolve_stdlib_dir() -> Option<PathBuf> {
     if std::env::var("ARCH_NO_STDLIB").is_ok() {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -4779,10 +4779,8 @@ impl Parser {
             }
             TokenKind::SizedLiteral(s) => {
                 // format: WIDTH'BASE_CHAR VALUE
+                // WIDTH may be a numeric literal or a param identifier
                 let parts: Vec<&str> = s.splitn(2, '\'').collect();
-                let width: u32 = parts[0]
-                    .parse()
-                    .map_err(|_| CompileError::general("invalid sized literal width", tok.span))?;
                 let base_char = parts[1].chars().next().unwrap();
                 let digits = &parts[1][1..].replace('_', "");
                 let value = match base_char {
@@ -4797,7 +4795,24 @@ impl Parser {
                     }
                 }
                 .map_err(|_| CompileError::general("invalid sized literal value", tok.span))?;
-                ExprKind::Literal(LitKind::Sized(width, value))
+
+                // Try numeric width first; if that fails, treat as param identifier
+                match parts[0].parse::<u32>() {
+                    Ok(width) => ExprKind::Literal(LitKind::Sized(width, value)),
+                    Err(_) => {
+                        let width_str = parts[0];
+                        if !width_str.is_empty()
+                            && width_str.chars().all(|c| c.is_alphanumeric() || c == '_')
+                        {
+                            ExprKind::Literal(LitKind::ParamSized(width_str.to_string(), value))
+                        } else {
+                            return Err(CompileError::general(
+                                "invalid sized literal width",
+                                tok.span,
+                            ));
+                        }
+                    }
+                }
             }
             _ => unreachable!(),
         };
@@ -5678,8 +5693,8 @@ impl Parser {
             }
         }
 
-        // Phase 2: params
-        while !self.check_end_ram() && self.check(TokenKind::Param) {
+        // Phase 2: params (including `local param`)
+        while !self.check_end_ram() && self.check_param() {
             params.push(self.parse_param_decl()?);
         }
 
@@ -6078,8 +6093,8 @@ impl Parser {
             }
         }
 
-        // Phase 2: params
-        while !self.check_end_of(TokenKind::Counter) && self.check(TokenKind::Param) {
+        // Phase 2: params (including `local param`)
+        while !self.check_end_of(TokenKind::Counter) && self.check_param() {
             params.push(self.parse_param_decl()?);
         }
 
@@ -6214,8 +6229,8 @@ impl Parser {
             }
         }
 
-        // Phase 2: params
-        while !self.check_end_of(TokenKind::Arbiter) && self.check(TokenKind::Param) {
+        // Phase 2: params (including `local param`)
+        while !self.check_end_of(TokenKind::Arbiter) && self.check_param() {
             params.push(self.parse_param_decl()?);
         }
 

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -328,9 +328,11 @@ fn eval_bus_cond(expr: &Expr, param_map: &HashMap<String, &Expr>) -> bool {
 fn eval_bus_int(expr: &Expr, param_map: &HashMap<String, &Expr>) -> Option<i64> {
     match &expr.kind {
         ExprKind::Literal(lit) => match lit {
-            LitKind::Dec(n) | LitKind::Hex(n) | LitKind::Bin(n) | LitKind::Sized(_, n) | LitKind::ParamSized(_, n) => {
-                Some(*n as i64)
-            }
+            LitKind::Dec(n)
+            | LitKind::Hex(n)
+            | LitKind::Bin(n)
+            | LitKind::Sized(_, n)
+            | LitKind::ParamSized(_, n) => Some(*n as i64),
             // Float literals are not valid in integer bus-condition contexts.
             LitKind::Float(_) => None,
         },

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -286,7 +286,7 @@ fn eval_bus_cond(expr: &Expr, param_map: &HashMap<String, &Expr>) -> bool {
         }
         ExprKind::Literal(lit) => match lit {
             LitKind::Dec(n) | LitKind::Hex(n) | LitKind::Bin(n) => *n != 0,
-            LitKind::Sized(_, n) => *n != 0,
+            LitKind::Sized(_, n) | LitKind::ParamSized(_, n) => *n != 0,
             LitKind::Float(bits) => f64::from_bits(*bits) != 0.0,
         },
         ExprKind::Bool(b) => *b,
@@ -328,7 +328,7 @@ fn eval_bus_cond(expr: &Expr, param_map: &HashMap<String, &Expr>) -> bool {
 fn eval_bus_int(expr: &Expr, param_map: &HashMap<String, &Expr>) -> Option<i64> {
     match &expr.kind {
         ExprKind::Literal(lit) => match lit {
-            LitKind::Dec(n) | LitKind::Hex(n) | LitKind::Bin(n) | LitKind::Sized(_, n) => {
+            LitKind::Dec(n) | LitKind::Hex(n) | LitKind::Bin(n) | LitKind::Sized(_, n) | LitKind::ParamSized(_, n) => {
                 Some(*n as i64)
             }
             // Float literals are not valid in integer bus-condition contexts.

--- a/src/sim_codegen/mod.rs
+++ b/src/sim_codegen/mod.rs
@@ -3498,7 +3498,7 @@ fn cpp_expr_inner(expr: &Expr, ctx: &Ctx, is_lhs: bool) -> String {
             LitKind::Dec(v) => format!("{v}"),
             LitKind::Hex(v) => format!("0x{v:X}"),
             LitKind::Bin(v) => format!("{v}"),
-            LitKind::Sized(_, v) => format!("{v}"),
+            LitKind::Sized(_, v) | LitKind::ParamSized(_, v) => format!("{v}"),
             // Float literals are FP32 by default — emit the binary32 bit pattern
             // as an unsigned hex constant (matches the uint32_t carrier).
             LitKind::Float(bits) => format!("0x{:X}u", (f64::from_bits(*bits) as f32).to_bits()),

--- a/src/sim_codegen/pipeline.rs
+++ b/src/sim_codegen/pipeline.rs
@@ -1437,7 +1437,7 @@ impl<'a> SimCodegen<'a> {
             ExprKind::Literal(lit) => match lit {
                 LitKind::Dec(v) => format!("{v}"),
                 LitKind::Hex(v) | LitKind::Bin(v) => format!("0x{v:X}"),
-                LitKind::Sized(_, v) => format!("{v}"),
+                LitKind::Sized(_, v) | LitKind::ParamSized(_, v) => format!("{v}"),
                 LitKind::Float(bits) => {
                     format!("0x{:X}u", (f64::from_bits(*bits) as f32).to_bits())
                 }

--- a/src/thread_map.rs
+++ b/src/thread_map.rs
@@ -964,6 +964,7 @@ fn lit_label(lit: &LitKind) -> String {
         LitKind::Hex(v) => format!("0x{v:x}"),
         LitKind::Bin(v) => format!("0b{v:b}"),
         LitKind::Sized(w, v) => format!("{w}'d{v}"),
+        LitKind::ParamSized(name, v) => format!("{name}'d{v}"),
         LitKind::Float(bits) => f64::from_bits(*bits).to_string(),
     }
 }

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -1628,20 +1628,6 @@ impl<'a> TypeChecker<'a> {
         self.check_handshake_reads(m);
     }
 
-    /// Compile-time lint: if a module has a bus port whose bus declares one or
-    /// more `handshake` channels, every read of a payload signal inside
-    /// comb/seq/latch blocks should sit under an `if <port>.<valid>` (or the
-    /// variant's `<port>.<req>`) conditional.
-    ///
-    /// v1 scope:
-    /// - Recognized guards: the exact valid/req field access (`port.ch_valid`),
-    ///   either directly as the if-condition or as an AND-conjunct of it.
-    /// - Does NOT trace let-bindings: `let g = port.ch_valid; if g ...` is a
-    ///   known false-positive and documented in the plan. If this becomes
-    ///   noisy, extend by resolving single-ident let RHS before matching.
-    /// - Variants with no valid signal (`ready_only`) are skipped entirely;
-    ///   `req_ack_2phase` uses the pending-transfer guard (`req != ack`).
-
     /// Check an `inst` declaration: validates port connections (unconnected
     /// inputs error, unconnected outputs warn), expands whole-bus connections
     /// to per-signal driven entries, and marks output signals as driven.
@@ -1911,6 +1897,19 @@ impl<'a> TypeChecker<'a> {
             }
         }
     }
+    /// Compile-time lint: if a module has a bus port whose bus declares one or
+    /// more `handshake` channels, every read of a payload signal inside
+    /// comb/seq/latch blocks should sit under an `if <port>.<valid>` (or the
+    /// variant's `<port>.<req>`) conditional.
+    ///
+    /// v1 scope:
+    /// - Recognized guards: the exact valid/req field access (`port.ch_valid`),
+    ///   either directly as the if-condition or as an AND-conjunct of it.
+    /// - Does NOT trace let-bindings: `let g = port.ch_valid; if g ...` is a
+    ///   known false-positive and documented in the plan. If this becomes
+    ///   noisy, extend by resolving single-ident let RHS before matching.
+    /// - Variants with no valid signal (`ready_only`) are skipped entirely;
+    ///   `req_ack_2phase` uses the pending-transfer guard (`req != ack`).
     pub(crate) fn check_handshake_reads(&mut self, m: &ModuleDecl) {
         use std::collections::HashMap as Map;
         // port_name -> Vec<(channel_name, guard, payload_field_names)>
@@ -4110,10 +4109,6 @@ impl<'a> TypeChecker<'a> {
         }
     }
 
-    /// Detects expressions where ARCH and SV precedence differ and the user
-    /// has not added parentheses. Specifically: bitwise ops (`&`, `|`, `^`)
-    /// mixed with comparison ops (`==`, `!=`, `<`, `>`, `<=`, `>=`) as children.
-
     /// Resolve `ExprKind::FieldAccess(base, field)` — the type of a `.field`
     /// access on a struct, bus, or `Reset.asserted` polarity-abstracted bool.
     /// Extracted from `resolve_expr_type` for readability — the original arm
@@ -4544,6 +4539,9 @@ impl<'a> TypeChecker<'a> {
             _ => Ty::Error,
         }
     }
+    /// Detects expressions where ARCH and SV precedence differ and the user
+    /// has not added parentheses. Specifically: bitwise ops (`&`, `|`, `^`)
+    /// mixed with comparison ops (`==`, `!=`, `<`, `>`, `<=`, `>=`) as children.
     pub(crate) fn check_precedence_ambiguity(
         &mut self,
         op: BinOp,
@@ -7594,14 +7592,15 @@ impl<'a> TypeChecker<'a> {
 /// condition properly guards a payload read.
 ///
 /// Accepted patterns:
-///   - `port.valid` / `port.req`                 (exact level guard)
-///   - `port.req != port.ack`                    (2-phase pending guard)
-///   - `guard && X`                              (AND conjunct, either side)
-///   - `(guard) && X`                            (parens are transparent in AST)
+/// - `port.valid` / `port.req`                 (exact level guard)
+/// - `port.req != port.ack`                    (2-phase pending guard)
+/// - `guard && X`                              (AND conjunct, either side)
+/// - `(guard) && X`                            (parens are transparent in AST)
+///
 /// Not accepted:
-///   - `port.valid || X`                         (not guaranteed)
-///   - `let g = port.valid; if g ...`            (v1 does not trace lets)
-///   - `!port.valid` / else branch               (negation not modeled)
+/// - `port.valid || X`                         (not guaranteed)
+/// - `let g = port.valid; if g ...`            (v1 does not trace lets)
+/// - `!port.valid` / else branch               (negation not modeled)
 fn cond_contains_guard(cond: &Expr, port: &str, guard: &HandshakePayloadGuard) -> bool {
     match &cond.kind {
         ExprKind::FieldAccess(base, field) => {

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -3641,6 +3641,7 @@ impl<'a> TypeChecker<'a> {
                     Ty::UInt(bits)
                 }
                 LitKind::Sized(w, _) => Ty::UInt(*w),
+                LitKind::ParamSized(_, _) => Ty::UInt(32),
                 // Float literals default to FP32; BF16 values are written via an
                 // explicit `.to_bf16()` conversion (no implicit float narrowing).
                 LitKind::Float(_) => Ty::FP32,


### PR DESCRIPTION
## Summary

Two ARCH language extensions to enable param-derived RTL in ram blocks and module bodies.

### 1. `local param` in ram/counter/arbiter blocks

The parsers for `ram`, `counter`, and `arbiter` used `check(TokenKind::Param)` which only matched `param` but not `local param`. Switch to `check_param()` which handles both forms, matching `module` behavior.

**Before** (error):
```arch
ram SoftmaxExpLut
  param DEPTH: const = 16385;
  local param ADDR_WIDTH: const = DEPTH > 1 ? $clog2(DEPTH) : 1;  // error: unexpected token
```

**After** (works):
```arch
ram SoftmaxExpLut
  param DEPTH: const = 16385;
  local param ADDR_WIDTH: const = DEPTH > 1 ? $clog2(DEPTH) : 1;  // OK
```

### 2. Param-width sized literals (e.g. `W'd0`, `SCORE_WIDTH'd42`)

The lexer regex for `SizedLiteral` only matched numeric width prefixes (`[0-9]+'[bhd]...`). Extend it to also match identifier prefixes (`[a-zA-Z_][a-zA-Z0-9_]*'[bhd]...`). Add new `LitKind::ParamSized(String, u64)` variant to the AST. The parser tries numeric width first, falls back to param identifier. During elaboration, `subst_expr_params` resolves `ParamSized(name, value)` to `Sized(width, value)` by looking up the param in the param map. All 12 downstream match arms handle `ParamSized` with the value and a fallback width of 32.

### Files changed

- `src/lexer.rs` — extended SizedLiteral regex + test
- `src/ast.rs` — new `LitKind::ParamSized` variant
- `src/parser.rs` — ram/counter/arbiter use `check_param()`; parser handles param-width literals
- `src/elaborate.rs` — `subst_expr_params` resolves `ParamSized` to `Sized`
- `src/codegen/mod.rs`, `src/formal.rs`, `src/interface.rs`, `src/resolve.rs`, `src/sim_codegen/mod.rs`, `src/sim_codegen/pipeline.rs`, `src/thread_map.rs`, `src/typecheck.rs` — handle `ParamSized` in match arms

### Testing

- Lexer unit test for param-width literals
- Minimal reproducers verified: `local param` in ram, `W'd0` in module, param-derived Vec widths
- Full project ARCH sources pass `arch check` (SoftmaxEngine, SoftmaxExpLut, AttentionTileEngine, etc.)
