### PR TITLE
chore(hooks): pre-commit guard — commit from a worktree, not the shared primary checkout

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Enforce that ordinary work happens in a *linked git worktree*, not the shared
+# PRIMARY checkout. Two sessions/agents editing one working tree is what lets a
+# `git add -A` sweep up a neighbor's files and a half-finished edit break your
+# build (see the incident write-up in CLAUDE.md "Claim work / worktrees").
+#
+# IMPORTANT — this is a CLIENT-SIDE GUARD ONLY. Whether a commit was authored in
+# a worktree is not recorded in the commit, so this cannot be enforced
+# server-side or in CI. It requires `core.hooksPath=.githooks` (set by
+# scripts/setup_hooks.sh / documented in the README).
+#
+# Bypass for a legitimate one-off (solo clone, maintenance, automation):
+#     WORKTREE_ENFORCE_SKIP=1 git commit ...        # or: git commit --no-verify
+
+[[ "${WORKTREE_ENFORCE_SKIP:-0}" == 1 ]] && exit 0
+
+git_dir="$(cd "$(git rev-parse --git-dir)" && pwd -P)"
+common_dir="$(cd "$(git rev-parse --git-common-dir)" && pwd -P)"
+
+# Linked worktree (git-dir lives under .git/worktrees/<name>) → always allowed.
+[[ "$git_dir" != "$common_dir" ]] && exit 0
+
+# We are in the PRIMARY checkout. It is reserved for the codex pipeline, which
+# commits here on codex/* branches; allow those. Everyone else must use a
+# linked worktree.
+branch="$(git branch --show-current 2>/dev/null || true)"
+case "$branch" in
+  codex/*) exit 0 ;;
+esac
+
+cat >&2 <<EOF
+✗ pre-commit: refusing to commit in the PRIMARY checkout (branch: ${branch:-DETACHED}).
+
+  The primary checkout ($common_dir) is shared by concurrent sessions/agents.
+  Committing here risks 'git add -A' picking up a neighbor's in-progress files
+  and their half-finished code breaking your build. Work in your own worktree:
+
+      git worktree add ../arch-wt-<name> -b <your-branch>
+      cd ../arch-wt-<name>     # then re-run your commit there
+
+  Legitimate one-off (solo clone / maintenance / automation):
+      WORKTREE_ENFORCE_SKIP=1 git commit ...        # or: git commit --no-verify
+EOF
+exit 1

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -22,13 +22,10 @@ common_dir="$(cd "$(git rev-parse --git-common-dir)" && pwd -P)"
 # Linked worktree (git-dir lives under .git/worktrees/<name>) → always allowed.
 [[ "$git_dir" != "$common_dir" ]] && exit 0
 
-# We are in the PRIMARY checkout. It is reserved for the codex pipeline, which
-# commits here on codex/* branches; allow those. Everyone else must use a
-# linked worktree.
+# We are in the PRIMARY checkout — blocked for everyone (no per-branch or
+# per-pipeline exceptions). Automation that must commit here sets the explicit
+# WORKTREE_ENFORCE_SKIP=1 bypass above.
 branch="$(git branch --show-current 2>/dev/null || true)"
-case "$branch" in
-  codex/*) exit 0 ;;
-esac
 
 cat >&2 <<EOF
 ✗ pre-commit: refusing to commit in the PRIMARY checkout (branch: ${branch:-DETACHED}).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,9 +19,13 @@ accept any findings before opening the PR.
 
 After the review pass is complete, run `scripts/pre_pr_review.sh mark` to record
 the reviewed HEAD. Run `scripts/pre_pr_review.sh check` before creating the PR.
-Use `git config core.hooksPath .githooks` in local clones to install the
-versioned `.githooks/pre-push` hook. The hook blocks pushes from `codex/*`
-branches when the review marker is missing or stale.
+Run `scripts/setup_hooks.sh` in local clones to install the versioned hooks
+(`core.hooksPath=.githooks`). The `pre-push` hook blocks pushes from `codex/*`
+branches when the review marker is missing or stale. The `pre-commit` hook
+refuses commits in the shared **primary** checkout (so concurrent agents don't
+share one working tree) — work in your own linked worktree
+(`git worktree add ../arch-wt-<name> -b <branch>`); `codex/*` branches and
+`WORKTREE_ENFORCE_SKIP=1` are exempt.
 
 After opening a PR, run `scripts/monitor_pr_ci.sh [pr-number-or-url]`. If any
 check fails, inspect the linked logs, fix the branch, push the fix, and rerun

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,8 +24,8 @@ Run `scripts/setup_hooks.sh` in local clones to install the versioned hooks
 branches when the review marker is missing or stale. The `pre-commit` hook
 refuses commits in the shared **primary** checkout (so concurrent agents don't
 share one working tree) — work in your own linked worktree
-(`git worktree add ../arch-wt-<name> -b <branch>`); `codex/*` branches and
-`WORKTREE_ENFORCE_SKIP=1` are exempt.
+(`git worktree add ../arch-wt-<name> -b <branch>`). No branch is exempt;
+automation that must commit in the primary sets `WORKTREE_ENFORCE_SKIP=1`.
 
 After opening a PR, run `scripts/monitor_pr_ci.sh [pr-number-or-url]`. If any
 check fails, inspect the linked logs, fix the branch, push the fix, and rerun

--- a/README.md
+++ b/README.md
@@ -316,9 +316,15 @@ See `doc/ARCH_HDL_Specification.md` for the full language reference and `doc/COM
 Install the versioned local git hooks with:
 
 ```sh
-git config core.hooksPath .githooks
-chmod +x .githooks/pre-push scripts/pre_pr_review.sh
+scripts/setup_hooks.sh        # sets core.hooksPath=.githooks and chmods the hooks
 ```
+
+This installs two guards: `pre-push` (the PR-review-marker gate below) and
+`pre-commit`, which keeps work out of the shared **primary** checkout — commit
+from your own linked worktree (`git worktree add ../arch-wt-<name> -b <branch>`)
+so concurrent sessions don't share one working tree. Both are client-side guards
+(bypass `pre-commit` for a one-off with `WORKTREE_ENFORCE_SKIP=1` or
+`git commit --no-verify`).
 
 Before opening a PR, run a code-review pass against the branch diff, address or
 accept the findings, then record the reviewed HEAD:

--- a/scripts/setup_hooks.sh
+++ b/scripts/setup_hooks.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Install the versioned local git hooks for this clone. Run once per clone.
+set -euo pipefail
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+git config core.hooksPath .githooks
+chmod +x .githooks/* scripts/pre_pr_review.sh 2>/dev/null || true
+
+echo "Installed git hooks (core.hooksPath=.githooks):"
+echo "  pre-commit  — keep work out of the shared PRIMARY checkout; commit from a"
+echo "                linked worktree instead (bypass: WORKTREE_ENFORCE_SKIP=1)"
+echo "  pre-push    — PR-review-marker + duplicate-work (claim-check) gates"


### PR DESCRIPTION
Adds a client-side guard so concurrent sessions/agents stop sharing the primary working tree — the failure mode where one session's `git add -A` sweeps up a neighbor's in-progress files and their half-finished code breaks your build (it just happened: a Claude session and the codex pipeline both editing the primary checkout).

## What it does
`.githooks/pre-commit` refuses a commit made in the **primary** checkout (detected via `git-dir == git-common-dir`). Linked worktrees are always allowed. **No branch is exempt** — the only escape is the explicit bypass `WORKTREE_ENFORCE_SKIP=1` (or `git commit --no-verify`) for solo clones / maintenance / automation.

Plus `scripts/setup_hooks.sh` (one-stop installer: sets `core.hooksPath=.githooks`, chmods the hooks) and README/AGENTS docs.

## Verified
Tested in throwaway repos:
| Context | Result |
|---|---|
| linked worktree (any branch) | ✅ allowed (dogfooded — this PR was committed from a worktree) |
| primary + `claude/*` | ⛔ blocked |
| primary + `codex/*` | ⛔ blocked |
| `WORKTREE_ENFORCE_SKIP=1` | ✅ allowed |

## ⚠️ Action required for the codex pipeline before/at merge
The codex pipeline currently commits in the **primary** checkout (it's on a `codex/*` branch there now). With no exemption, **its commits will start failing** once this lands. Before merging, codex must do one of:
- run in its own linked worktree (preferred — true isolation), or
- export `WORKTREE_ENFORCE_SKIP=1` in its commit step.

## Limitation (by design)
Client-side only. Worktree-ness is not recorded in the commit, so this cannot be enforced server-side or in CI, and it's bypassable with `--no-verify`. It requires `core.hooksPath=.githooks` (run `scripts/setup_hooks.sh` once per clone). It's a guard rail that catches the accident, not a hard boundary — true isolation comes from each agent having its own worktree/clone.