### PR TITLE
style(proof): silence FMA-equivalence lint warnings

### DIFF
--- a/proofs/lean_fp_equiv/ArchFpEquiv/Fma.lean
+++ b/proofs/lean_fp_equiv/ArchFpEquiv/Fma.lean
@@ -58,7 +58,7 @@ theorem fma_inf_prod (a b c : BitVec 32)
 
 /-- A finite product plus an infinite addend gives the addend's infinity. -/
 theorem fma_inf_c (a b c : BitVec 32)
-    (hna : isNaN a = false) (hnb : isNaN b = false) (hnc : isNaN c = false)
+    (hna : isNaN a = false) (hnb : isNaN b = false) (_hnc : isNaN c = false)
     (hpa : isInf a = false) (hpb : isInf b = false) (hci : isInf c = true) :
     arch_fma_f32 a b c = sgn c ++ (0xFF#8 ++ 0#23) := by
   unfold isNaN isInf expField fracField sgn arch_fma_f32 at *

--- a/proofs/lean_fp_equiv/ArchFpEquiv/FmaMag470Nat.lean
+++ b/proofs/lean_fp_equiv/ArchFpEquiv/FmaMag470Nat.lean
@@ -73,7 +73,7 @@ theorem fma_mag470_same_nat (a b c : BitVec 32)
     intro A B hA hB; omega
   simp only [fmaSigHi98, fmaSigLo98, fmaDiff98, fmaSel98, fpEunb, fpMant24] at hd ⊢
   unfold arch_fma_mag
-  simp only [hsame, beq_self_eq_true, BitVec.ofBool_true, ite_self]
+  simp only [hsame, beq_self_eq_true, BitVec.ofBool_true]
   rw [if_pos (by decide : ((1 : BitVec 1) == 1#1) = true)]
   generalize hsb : BitVec.sle
       (if (BitVec.ofBool (BitVec.extractLsb 30 23 c == 0#8) == 1#1) = true then 65387#16
@@ -85,7 +85,7 @@ theorem fma_mag470_same_nat (a b c : BitVec 32)
   simp only [ofBool_beq_one] at hd ⊢
   cases sb
   · -- sb = false: c is the higher operand (its field is shifted, product unshifted)
-    simp only [reduceIte, Bool.false_eq_true, if_false] at hd ⊢
+    simp only [Bool.false_eq_true, if_false] at hd ⊢
     rw [setWidth470_toNat _ (by omega : (16 : Nat) ≤ 470), BitVec.toNat_add,
         setWidth470_toNat _ (by omega : (48 : Nat) ≤ 470), setWidth470_shift_toNat _ _ (by omega),
         hsw48, Nat.mod_eq_of_lt
@@ -151,7 +151,7 @@ theorem fma_mag470_diff_nat (a b c : BitVec 32)
   simp only [ofBool_beq_one] at hd ⊢
   cases sb
   · -- sb = false: c is the higher operand (its field is shifted, product unshifted)
-    simp only [reduceIte, Bool.false_eq_true, if_false] at hd ⊢
+    simp only [Bool.false_eq_true, if_false] at hd ⊢
     rw [setWidth470_toNat _ (by omega : (16 : Nat) ≤ 470),
         setWidth470_toNat _ (by omega : (48 : Nat) ≤ 470),
         setWidth470_shift_toNat _ _ (by omega), hsw48]

--- a/proofs/lean_fp_equiv/ArchFpEquiv/FmaRefSpecial.lean
+++ b/proofs/lean_fp_equiv/ArchFpEquiv/FmaRefSpecial.lean
@@ -51,7 +51,7 @@ theorem fma_ref_inf_prod (a b c : BitVec 32)
 
 /-- A finite product plus an infinite addend gives the addend's infinity (reference). -/
 theorem fma_ref_inf_c (a b c : BitVec 32)
-    (hna : isNaN a = false) (hnb : isNaN b = false) (hnc : isNaN c = false)
+    (hna : isNaN a = false) (hnb : isNaN b = false) (_hnc : isNaN c = false)
     (hpa : isInf a = false) (hpb : isInf b = false) (hci : isInf c = true) :
     arch_fma_f32_ref a b c = sgn c ++ (0xFF#8 ++ 0#23) := by
   unfold isNaN isInf expField fracField sgn arch_fma_f32_ref at *


### PR DESCRIPTION
Follow-up to #639 (cosmetic only). An adversarial audit of the FMA bit-exactness proof flagged a few benign linter warnings; this clears them so the proof builds warning-clean (aside from the expected `2^470` exponent-threshold notices).

- `FmaMag470Nat.lean`: drop three unused `simp` arguments (`ite_self` ×1, `reduceIte` ×2).
- `Fma.lean` / `FmaRefSpecial.lean`: rename the unused `hnc` parameter of `fma_inf_c` / `fma_ref_inf_c` to `_hnc` (kept in the signature so positional call sites are unchanged).

No statement or proof term changes. `#print axioms arch_fma_f32_eq_ref` is unchanged (standard three + `bv_decide` certificates), still `sorry`-free, full project green (23 modules).