### PR TITLE
fix(#636): param-width sized literal — type as UInt<W> + emit valid SV cast

### DIFF
--- a/doc/ARCH_HDL_Specification.md
+++ b/doc/ARCH_HDL_Specification.md
@@ -722,6 +722,10 @@ A module is the fundamental unit of design in Arch. Every module follows the sam
 | //                                  `NAME[i]` reads as a packed part-select.   |
 |                                                                                |
 | // local param NAME: const = expr;  // derived — emits `localparam` (not overridable) |
+| //                                  // valid in module, ram, counter, arbiter |
+| //                                                                             |
+| // A param-width sized literal `NAME'dV` (e.g. `W'd0`, `ADDR_WIDTH'd42`) is    |
+| // typed `UInt<NAME>` — same widening rules as a concrete `8'd0`.              |
 |                                                                                |
 | //                                                                             |
 |                                                                                |

--- a/doc/Arch_AI_Reference_Card.md
+++ b/doc/Arch_AI_Reference_Card.md
@@ -331,6 +331,7 @@ Call:        FnName(arg1, arg2)    // overload-resolved by argument types
 Enum:        E::Variant
 Struct lit:  S { f: val }
 Sized lit:   8'hFF  16'd1024  4'b1010   // Verilog-style
+Param lit:   W'd0  ADDR_WIDTH'd42        // param-width prefix → typed UInt<W>
 todo!        // compilable placeholder; warns at compile, aborts at sim runtime
 ```
 

--- a/skills/arch-programming/references/ARCH_HDL_Specification.md
+++ b/skills/arch-programming/references/ARCH_HDL_Specification.md
@@ -722,6 +722,10 @@ A module is the fundamental unit of design in Arch. Every module follows the sam
 | //                                  `NAME[i]` reads as a packed part-select.   |
 |                                                                                |
 | // local param NAME: const = expr;  // derived — emits `localparam` (not overridable) |
+| //                                  // valid in module, ram, counter, arbiter |
+| //                                                                             |
+| // A param-width sized literal `NAME'dV` (e.g. `W'd0`, `ADDR_WIDTH'd42`) is    |
+| // typed `UInt<NAME>` — same widening rules as a concrete `8'd0`.              |
 |                                                                                |
 | //                                                                             |
 |                                                                                |

--- a/skills/arch-programming/references/Arch_AI_Reference_Card.md
+++ b/skills/arch-programming/references/Arch_AI_Reference_Card.md
@@ -331,6 +331,7 @@ Call:        FnName(arg1, arg2)    // overload-resolved by argument types
 Enum:        E::Variant
 Struct lit:  S { f: val }
 Sized lit:   8'hFF  16'd1024  4'b1010   // Verilog-style
+Param lit:   W'd0  ADDR_WIDTH'd42        // param-width prefix → typed UInt<W>
 todo!        // compilable placeholder; warns at compile, aborts at sim runtime
 ```
 

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -5737,7 +5737,13 @@ impl<'a> Codegen<'a> {
                 LitKind::Hex(v) => format!("'h{v:X}"),
                 LitKind::Bin(v) => format!("'b{v:b}"),
                 LitKind::Sized(w, v) => format!("{w}'d{v}"),
-                LitKind::ParamSized(name, v) => format!("{name}'d{v}"),
+                // A param-width literal that survives to codegen still has a
+                // symbolic width (the module kept `param W` rather than being
+                // monomorphized). `W'd{v}` is NOT legal SystemVerilog — a
+                // sized-literal width must be a constant number, not a
+                // parameter. Emit a size cast `W'({v})` instead, which is the
+                // legal parameterized form and carries the same value.
+                LitKind::ParamSized(name, v) => format!("{name}'({v})"),
                 // Float literal (FP32 by default) → 32-bit binary32 bit pattern.
                 LitKind::Float(bits) => {
                     format!("32'h{:08X}", (f64::from_bits(*bits) as f32).to_bits())

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -3641,7 +3641,26 @@ impl<'a> TypeChecker<'a> {
                     Ty::UInt(bits)
                 }
                 LitKind::Sized(w, _) => Ty::UInt(*w),
-                LitKind::ParamSized(_, _) => Ty::UInt(32),
+                LitKind::ParamSized(name, _) => {
+                    // A param-width sized literal `W'dN` has type `UInt<W>`.
+                    // Resolve the width identifier against the active param
+                    // environment (the same mechanism that turns a `UInt<W>`
+                    // port into `UInt<8>`). Top-level modules never run
+                    // `subst_expr_params`, so the literal still arrives here as
+                    // `ParamSized`; without this it defaulted to `UInt<32>`,
+                    // which spuriously rejected `W'd0` into a `UInt<W>` target
+                    // for any W != 32. Fall back to 32 only when the param is
+                    // genuinely unbound (generic context).
+                    let ident = Expr {
+                        kind: ExprKind::Ident(name.clone()),
+                        span: expr.span,
+                        parenthesized: false,
+                    };
+                    match self.eval_const_expr(&ident, local_types) {
+                        Some(w) if w > 0 => Ty::UInt(w as u32),
+                        _ => Ty::UInt(32),
+                    }
+                }
                 // Float literals default to FP32; BF16 values are written via an
                 // explicit `.to_bf16()` conversion (no implicit float narrowing).
                 LitKind::Float(_) => Ty::FP32,

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -29170,3 +29170,29 @@ end module ParamLitTrunc
         "expected a width-mismatch error, got: {errs:?}"
     );
 }
+
+#[test]
+fn test_param_sized_literal_emits_valid_sv_size_cast() {
+    // A param-width sized literal that survives to SV codegen (top-level
+    // module keeps `param W` symbolic) must emit a legal SystemVerilog size
+    // cast `W'(5)`, NOT `W'd5` — the latter is rejected by Verilator because a
+    // sized-literal width must be a constant number, not a parameter (#636).
+    let source = r#"
+module ParamLitSv
+  param W: const = 8;
+  port o: out UInt<W>;
+  comb
+    o = W'd5;
+  end comb
+end module ParamLitSv
+"#;
+    let sv = compile_to_sv(source);
+    assert!(
+        sv.contains("W'(5)"),
+        "expected size-cast `W'(5)` in emitted SV, got:\n{sv}"
+    );
+    assert!(
+        !sv.contains("W'd5"),
+        "must not emit invalid `W'd5` (illegal SV literal width):\n{sv}"
+    );
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -29093,3 +29093,80 @@ end module IntBadOrder
         "non-enum match must also enforce wildcard-last"
     );
 }
+
+#[test]
+fn test_param_sized_literal_types_as_param_width() {
+    // Regression for the param-width sized-literal (`W'dN`) feature (#636):
+    // a `W'dN` literal must be typed `UInt<W>`, not a fixed `UInt<32>`.
+    // Top-level modules never run `subst_expr_params`, so the literal reaches
+    // the type checker as `LitKind::ParamSized` and its width must be resolved
+    // from the active param environment.
+
+    // W = 8: `W'd0` into a `UInt<8>` reg/port must type-check (previously
+    // failed with "RHS is UInt<32>").
+    let ok_small = r#"
+module ParamLitSmall
+  param W: const = 8;
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  reg r: UInt<W> reset rst => W'd0;
+  port o: out UInt<W>;
+  seq on clk rising
+    r <= W'd5;
+  end seq
+  comb
+    o = r;
+  end comb
+end module ParamLitSmall
+"#;
+    typecheck_source(ok_small).expect("W'd0 / W'd5 must type as UInt<W> for W=8");
+
+    // W = 48 (> 32): also fine — exercises the wider-than-default path.
+    let ok_wide = r#"
+module ParamLitWide
+  param W: const = 48;
+  port o: out UInt<W>;
+  comb
+    o = W'd5;
+  end comb
+end module ParamLitWide
+"#;
+    typecheck_source(ok_wide).expect("W'd5 must type as UInt<48> for W=48");
+
+    // Genuine over-width assignment must STILL be rejected: a `W'dN` literal
+    // (W=8) behaves exactly like the concrete `8'dN`, which widens losslessly
+    // into a wider target — so this case is accepted, matching `8'd5`.
+    let widen_ok = r#"
+module ParamLitWiden
+  param W: const = 8;
+  port o: out UInt<16>;
+  comb
+    o = W'd5;
+  end comb
+end module ParamLitWiden
+"#;
+    typecheck_source(widen_ok)
+        .expect("W'd5 (UInt<8>) widening into UInt<16> matches concrete 8'd5 semantics");
+}
+
+#[test]
+fn test_param_sized_literal_overwidth_still_rejected() {
+    // The fix must not make `W'dN` more permissive than a concrete sized
+    // literal: a wider param literal into a narrower target must still require
+    // an explicit `.trunc<N>()`, exactly as `32'd5` into `UInt<16>` does.
+    let source = r#"
+module ParamLitTrunc
+  param W: const = 32;
+  port o: out UInt<16>;
+  comb
+    o = W'd5;
+  end comb
+end module ParamLitTrunc
+"#;
+    let errs = typecheck_source(source)
+        .expect_err("W'd5 with W=32 into UInt<16> must require explicit trunc");
+    assert!(
+        format!("{errs:?}").contains("width mismatch"),
+        "expected a width-mismatch error, got: {errs:?}"
+    );
+}


### PR DESCRIPTION
Two bugs in the param-width sized-literal feature shipped in #636 (`W'd0`, `ADDR_WIDTH'd42`, …). Found during the 2026-06-29 daily PR review. The feature was **non-functional for its headline use case** and **emitted invalid SystemVerilog**.

---

## Bug 1 — type checker types `W'dN` as `UInt<32>`, not `UInt<W>`

The PR's own motivating example fails type-check for any `W != 32`:

```arch
reg r: UInt<W> reset rst => W'd0;
r <= W'd0;   // × width mismatch: `r` is UInt<8> but RHS is UInt<32>
```

**Root cause.** `elaborate` runs before `typecheck`, but `subst_expr_params` (which resolves `ParamSized → Sized`) only fires when a module is monomorphized as a sub-instance. A top-level module's `param W` default is never substituted into expression literals, so `W'd0` reaches the checker as `LitKind::ParamSized`, and the arm at `typecheck.rs:3644` hardcoded `Ty::UInt(32)`, ignoring the width — even though the *type* `UInt<W>` is resolved correctly. The asymmetry is the bug.

**Fix.** Resolve the width identifier via the existing `eval_const_expr` helper (same mechanism that resolves `UInt<W>`). `W'dN` now types as `UInt<W>`, behaving identically to a concrete `W'dN`: lossless widening into a wider target allowed (= `8'd5`→`UInt<16>`), narrowing still needs explicit `.trunc<N>()` (= `32'd5`→`UInt<16>` error). Falls back to `UInt<32>` only when the param is genuinely unbound.

| case | before | after |
|---|---|---|
| `W'd0` → `UInt<W>`, W=8 | ❌ error | ✅ ok |
| `W'd5` → `UInt<W>`, W=48 | ✅ ok | ✅ ok |
| `W'd5` (W=8) → `UInt<16>` | ❌ error | ✅ ok (lossless, = `8'd5`) |
| `W'd5` (W=32) → `UInt<16>` | ❌ error | ❌ error (needs `.trunc`) ✓ |

---

## Bug 2 — codegen emits invalid SystemVerilog `W'd5`

A param-width literal that survives to SV codegen (top-level module keeps `param W` symbolic) was emitted as `W'd5`:

```sv
assign o = W'd5;
// %Error: syntax error, unexpected INTEGER NUMBER  (Verilator 5.048)
```

This is **not legal SystemVerilog** — a sized-literal width must be a constant *number*, not a parameter. Pre-existing in #636 and independent of Bug 1 (the `W=32` case emitted invalid `W'd5` on `main` too).

**Fix.** Emit the legal parameterized form — a size cast `W'(5)` — which carries the same value. Only `src/codegen/mod.rs` changes; `interface.rs` (`.archi` files are *ARCH* syntax, where `W'd5` is correct) and `thread_map.rs` (debug labels) are deliberately untouched.

Verified: `verilator --lint-only` clean; `arch sim` yields `o=5` for `W=8`.

---

## Tests / docs

- `tests/integration_test.rs`: **+3** regression tests (type as `UInt<W>`; over-width still rejected; SV emits `W'(5)` not `W'd5`).
- Full `cargo test --release` green except the two pre-existing Lean/elan env failures (`construct_proof_lean_*` — no toolchain locally).
- `cargo fmt --check` clean.
- #636 shipped the feature undocumented; this adds param-width-literal + `local param`-in-`ram`/`counter`/`arbiter` notes to the spec + reference card and refreshes the skill snapshots.

---

## ⚠️ Maintainer sign-off requested (Bug 1 only)

Per `CLAUDE.md`, **Bug 1** touches type-system surface behavior (the type inferred for a literal). It's bug-completion — `W'dN` becomes consistent with the concrete-`N'dN` rule and the feature's documented intent — but flagging for confirmation. **Bug 2** is a pure internal codegen fix (emit valid SV), autonomously in scope.