### PR TITLE
test(typecheck): cover match wildcard-last rule for expression matches

### DIFF
--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -29172,3 +29172,55 @@ end module BadWidthName
         "expected an unknown-width diagnostic, got:\n{rendered}"
     );
 }
+
+#[test]
+fn test_match_wildcard_not_last_errors_in_expression_match() {
+    // The wildcard-last rule must also fire for the *expression* match form
+    // (`let x: T = match ... end match`), which lowers to `ExprKind::ExprMatch`
+    // and is checked at a separate call site from statement matches. #634 wired
+    // this path but shipped tests only for statement (`comb`) matches.
+    let source = r#"
+module ExprBadOrder
+  port c: in UInt<2>;
+  port o: out UInt<8>;
+  let o_val: UInt<8> = match c
+      0 => 10,
+      _ => 0,
+      1 => 20,
+    end match;
+  comb
+    o = o_val;
+  end comb
+end module ExprBadOrder
+"#;
+    let errs = typecheck_source(source)
+        .expect_err("expected unreachable-arm error for expression match with `_` not last");
+    assert!(
+        format!("{errs:?}").contains("unreachable match arm"),
+        "expression match must also enforce wildcard-last"
+    );
+}
+
+#[test]
+fn test_match_wildcard_last_accepted_in_expression_match() {
+    // Companion to the above: `_` as the final arm of an expression match
+    // type-checks cleanly.
+    let source = r#"
+module ExprGoodOrder
+  port c: in UInt<2>;
+  port o: out UInt<8>;
+  let o_val: UInt<8> = match c
+      0 => 10,
+      1 => 20,
+      _ => 0,
+    end match;
+  comb
+    o = o_val;
+  end comb
+end module ExprGoodOrder
+"#;
+    assert!(
+        typecheck_source(source).is_ok(),
+        "an expression match with `_` as the final arm must type-check"
+    );
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -29093,3 +29093,55 @@ end module IntBadOrder
         "non-enum match must also enforce wildcard-last"
     );
 }
+
+#[test]
+fn test_match_wildcard_not_last_errors_in_expression_match() {
+    // The wildcard-last rule must also fire for the *expression* match form
+    // (`let x: T = match ... end match`), which lowers to `ExprKind::ExprMatch`
+    // and is checked at a separate call site from statement matches. #634 wired
+    // this path but shipped tests only for statement (`comb`) matches.
+    let source = r#"
+module ExprBadOrder
+  port c: in UInt<2>;
+  port o: out UInt<8>;
+  let o_val: UInt<8> = match c
+      0 => 10,
+      _ => 0,
+      1 => 20,
+    end match;
+  comb
+    o = o_val;
+  end comb
+end module ExprBadOrder
+"#;
+    let errs = typecheck_source(source)
+        .expect_err("expected unreachable-arm error for expression match with `_` not last");
+    assert!(
+        format!("{errs:?}").contains("unreachable match arm"),
+        "expression match must also enforce wildcard-last"
+    );
+}
+
+#[test]
+fn test_match_wildcard_last_accepted_in_expression_match() {
+    // Companion to the above: `_` as the final arm of an expression match
+    // type-checks cleanly.
+    let source = r#"
+module ExprGoodOrder
+  port c: in UInt<2>;
+  port o: out UInt<8>;
+  let o_val: UInt<8> = match c
+      0 => 10,
+      1 => 20,
+      _ => 0,
+    end match;
+  comb
+    o = o_val;
+  end comb
+end module ExprGoodOrder
+"#;
+    assert!(
+        typecheck_source(source).is_ok(),
+        "an expression match with `_` as the final arm must type-check"
+    );
+}


### PR DESCRIPTION
## Summary

Closes a test-coverage gap in the match wildcard-last rule shipped in [#634](https://github.com/arch-hdl-lang/arch-com/pull/634). Found during the 2026-06-30 daily PR review.

#634 added the rule that a `_` wildcard must be the final arm of a `match`, and wired the check for **both** match forms:
- statement matches (`Stmt::Match`, checked in `check_stmt`), and
- expression matches (`ExprKind::ExprMatch`, checked separately in `resolve_expr_type` at `typecheck.rs:3797`).

Its PR body explicitly claims the rule "fires for every match form … and for expression matches (`ExprMatch`)", but all four shipped tests only exercise the **statement** (`comb`) form. The expression-match call site — the `let x: T = match … end match` RHS — had no regression test.

## What this adds

Two tests over the expression-match form:
- `test_match_wildcard_not_last_errors_in_expression_match` — `_` before a later arm → `unreachable match arm` error (mirrors the existing statement-match test).
- `test_match_wildcard_last_accepted_in_expression_match` — `_` as the final arm type-checks cleanly.

I verified the behavior manually on a fresh binary before writing the tests (the expression-match path does enforce the rule — this is pure coverage, no behavior change). Guards against a future refactor silently dropping the check at the `ExprMatch` call site while the statement-match tests stay green.

## Verification

- `cargo test --release --test integration_test test_match_wildcard` → **5/5 pass** (3 existing + 2 new).
- `cargo fmt --check` clean.
- Test-only change; no `src/` touched.