### PR TITLE
Document unique match guidance for MCP helpers

### DIFF
--- a/doc/Arch_AI_Reference_Card.md
+++ b/doc/Arch_AI_Reference_Card.md
@@ -323,7 +323,8 @@ SVA-only:    |->  (overlap implication, same-cycle)
              // use `(!a) || b` for plain Boolean implication.
              // The legacy `implies` keyword is a deprecated alias for `|->`.
 Ternary:     cond ? a : b      // right-associative; chains for priority muxes
-Match:       match x { E::A => val1, E::B => val2, _ => default }
+Match expr:  match x { E::A => val1, E::B => val2, _ => default }
+Match stmt:  match x ... end match; add `unique` when arms are mutually exclusive
 Set member:  expr inside {val1, val2, lo..hi}   // returns Bool, emits SV inside
 Field:       s.field
 Index:       a[i]
@@ -332,6 +333,23 @@ Enum:        E::Variant
 Struct lit:  S { f: val }
 Sized lit:   8'hFF  16'd1024  4'b1010   // Verilog-style
 todo!        // compilable placeholder; warns at compile, aborts at sim runtime
+```
+
+For truth-table, K-map, minterm/don't-care, mux-input, decoder, or opcode
+logic, prefer `unique match` or named minterm `let`s before hand-simplifying.
+This keeps the case structure visible and avoids Boolean-minimization slips.
+Use plain `match` when priority order matters.
+
+Statement-form example:
+
+```
+comb
+  unique match sel
+    0 => y = a;
+    1 => y = b;
+    _ => y = 0;
+  end match
+end comb
 ```
 
 ---

--- a/mcp/instructions.md
+++ b/mcp/instructions.md
@@ -47,6 +47,7 @@ Common mistakes to avoid:
 - 'inside' operator: expr inside {val1, val2, lo..hi} — returns Bool, set membership
 - 'for i in {a, b, c}' — compile-time unrolled value-list iteration (inside comb/seq blocks)
 - 'unique if' and 'unique match' assert mutual exclusivity to synthesis (parallel mux): use 'unique if sel == 0 ... end if' or 'unique match opcode ... end match'; emits SV 'unique if' / 'unique case'
+- For truth-table, K-map, minterm/don't-care, mux-input, decoder, or opcode logic, prefer `unique match` or named minterm `let`s before hand-simplifying; this keeps case structure visible and avoids Boolean-minimization slips. Use plain `match` when priority order matters.
 - .trunc<N>() errors if N >= source width (not truncating); .zext<N>()/.sext<N>() error if N <= source width (not extending)
 - signed(x) / unsigned(x): same-width reinterpret cast (no width arg needed); prefer signed(x) over x.sext<N>() when entering signed arithmetic chains
 - Wrapping arithmetic operators +%, -%, *% give result width = max(W(a),W(b)) with no widening — prefer these over .trunc<N>() when the intent is modular arithmetic: 'let x: UInt<8> = a +% b;' instead of 'let x: UInt<8> = (a + b).trunc<8>();'

--- a/skills/arch-programming/references/Arch_AI_Reference_Card.md
+++ b/skills/arch-programming/references/Arch_AI_Reference_Card.md
@@ -323,7 +323,8 @@ SVA-only:    |->  (overlap implication, same-cycle)
              // use `(!a) || b` for plain Boolean implication.
              // The legacy `implies` keyword is a deprecated alias for `|->`.
 Ternary:     cond ? a : b      // right-associative; chains for priority muxes
-Match:       match x { E::A => val1, E::B => val2, _ => default }
+Match expr:  match x { E::A => val1, E::B => val2, _ => default }
+Match stmt:  match x ... end match; add `unique` when arms are mutually exclusive
 Set member:  expr inside {val1, val2, lo..hi}   // returns Bool, emits SV inside
 Field:       s.field
 Index:       a[i]
@@ -332,6 +333,23 @@ Enum:        E::Variant
 Struct lit:  S { f: val }
 Sized lit:   8'hFF  16'd1024  4'b1010   // Verilog-style
 todo!        // compilable placeholder; warns at compile, aborts at sim runtime
+```
+
+For truth-table, K-map, minterm/don't-care, mux-input, decoder, or opcode
+logic, prefer `unique match` or named minterm `let`s before hand-simplifying.
+This keeps the case structure visible and avoids Boolean-minimization slips.
+Use plain `match` when priority order matters.
+
+Statement-form example:
+
+```
+comb
+  unique match sel
+    0 => y = a;
+    1 => y = b;
+    _ => y = 0;
+  end match
+end comb
 ```
 
 ---

--- a/skills/arch-programming/references/mcp_instructions.md
+++ b/skills/arch-programming/references/mcp_instructions.md
@@ -47,6 +47,7 @@ Common mistakes to avoid:
 - 'inside' operator: expr inside {val1, val2, lo..hi} — returns Bool, set membership
 - 'for i in {a, b, c}' — compile-time unrolled value-list iteration (inside comb/seq blocks)
 - 'unique if' and 'unique match' assert mutual exclusivity to synthesis (parallel mux): use 'unique if sel == 0 ... end if' or 'unique match opcode ... end match'; emits SV 'unique if' / 'unique case'
+- For truth-table, K-map, minterm/don't-care, mux-input, decoder, or opcode logic, prefer `unique match` or named minterm `let`s before hand-simplifying; this keeps case structure visible and avoids Boolean-minimization slips. Use plain `match` when priority order matters.
 - .trunc<N>() errors if N >= source width (not truncating); .zext<N>()/.sext<N>() error if N <= source width (not extending)
 - signed(x) / unsigned(x): same-width reinterpret cast (no width arg needed); prefer signed(x) over x.sext<N>() when entering signed arithmetic chains
 - Wrapping arithmetic operators +%, -%, *% give result width = max(W(a),W(b)) with no widening — prefer these over .trunc<N>() when the intent is modular arithmetic: 'let x: UInt<8> = a +% b;' instead of 'let x: UInt<8> = (a + b).trunc<8>();'


### PR DESCRIPTION
## Summary

- Clarify the expression reference card by separating expression-form `match` from statement-form `match`.
- Add a `unique match` statement example to the MCP/skill reference card.
- Nudge agents toward `unique match` or named minterm `let`s for truth-table, K-map, minterm, mux-input, decoder, and opcode logic before hand-simplifying.

## Why

VerilogEval-style combinational problems can fail when agents jump straight to hand-minimized Boolean equations. The ARCH language already supports `unique match`; this change makes that safer representation easier for agents to discover through the MCP helper and mirrored skill docs.

## Validation

- `git diff --check origin/main...HEAD`
- `/Users/shuqingzhao/github/arch-release-tools/v0.70.4/bin/arch check tests/cvdp/alu_seq.arch`
- `scripts/pre_pr_review.sh mark`
- `scripts/pre_pr_review.sh check`
