### PR TITLE
fix(codegen): emit valid SV size-cast for param-width sized literals (`W'(5)`)

### DIFF
--- a/doc/COMPILER_STATUS.md
+++ b/doc/COMPILER_STATUS.md
@@ -6,7 +6,7 @@
 > **0.70.6 release highlights:**
 > - **Icarus-portable CVDP generation guidance** — ARCH MCP and skill instructions now steer generated code away from indexed casts/conversions, nested signed-extension chains, and direct slices of arithmetic expressions that Icarus rejects or mishandles.
 > - **Safer type checking for portable slices** — `arch check` now rejects direct bit-slicing of non-portable expression bases such as arithmetic expressions and points users toward wrapping arithmetic or named typed intermediates.
-> - **Parameterized sized literals** — literals such as `W'd0` now resolve to the positive integer value of `W` instead of falling back to `UInt<32>`, with a clear diagnostic for non-positive widths.
+> - **Parameterized sized literals** — literals such as `W'd0` now resolve to the positive integer value of `W` instead of falling back to `UInt<32>`, with a clear diagnostic for non-positive widths. SV codegen emits the legal size-cast form `W'(0)` (a parameter is not a valid sized-literal width — Verilator and iverilog both reject `W'd0`).
 >
 > **0.70.4 release highlights:**
 > - **Lean construct proof expansion** — construct certificates now cover bus `credit_channel` accounting in Lean and SMT, strengthen round-robin arbiter certificates with a bounded scan witness, add one-step thread effect replay, and add reusable Lean theorem libraries for async FIFO Gray-code decoding and abstract pipeline valid/stall/flush behavior.

--- a/skills/arch-programming/references/COMPILER_STATUS.md
+++ b/skills/arch-programming/references/COMPILER_STATUS.md
@@ -6,7 +6,7 @@
 > **0.70.6 release highlights:**
 > - **Icarus-portable CVDP generation guidance** — ARCH MCP and skill instructions now steer generated code away from indexed casts/conversions, nested signed-extension chains, and direct slices of arithmetic expressions that Icarus rejects or mishandles.
 > - **Safer type checking for portable slices** — `arch check` now rejects direct bit-slicing of non-portable expression bases such as arithmetic expressions and points users toward wrapping arithmetic or named typed intermediates.
-> - **Parameterized sized literals** — literals such as `W'd0` now resolve to the positive integer value of `W` instead of falling back to `UInt<32>`, with a clear diagnostic for non-positive widths.
+> - **Parameterized sized literals** — literals such as `W'd0` now resolve to the positive integer value of `W` instead of falling back to `UInt<32>`, with a clear diagnostic for non-positive widths. SV codegen emits the legal size-cast form `W'(0)` (a parameter is not a valid sized-literal width — Verilator and iverilog both reject `W'd0`).
 >
 > **0.70.4 release highlights:**
 > - **Lean construct proof expansion** — construct certificates now cover bus `credit_channel` accounting in Lean and SMT, strengthen round-robin arbiter certificates with a bounded scan witness, add one-step thread effect replay, and add reusable Lean theorem libraries for async FIFO Gray-code decoding and abstract pipeline valid/stall/flush behavior.

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -5737,7 +5737,16 @@ impl<'a> Codegen<'a> {
                 LitKind::Hex(v) => format!("'h{v:X}"),
                 LitKind::Bin(v) => format!("'b{v:b}"),
                 LitKind::Sized(w, v) => format!("{w}'d{v}"),
-                LitKind::ParamSized(name, v) => format!("{name}'d{v}"),
+                // A parameter-width sized literal (`W'd5`) is NOT legal
+                // SystemVerilog — the size of a sized literal must be a decimal
+                // *number*, not a parameter reference (both Verilator and
+                // iverilog reject `W'd5` with a syntax error). Emit the legal
+                // parameterized form instead: a size cast `W'(5)`, which carries
+                // the identical value and width. (The type checker already
+                // resolves the ARCH type to `UInt<W>` via
+                // `resolve_param_sized_literal_width`; this is the SV-surface
+                // counterpart.)
+                LitKind::ParamSized(name, v) => format!("{name}'({v})"),
                 // Float literal (FP32 by default) → 32-bit binary32 bit pattern.
                 LitKind::Float(bits) => {
                     format!("32'h{:08X}", (f64::from_bits(*bits) as f32).to_bits())

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -29224,3 +29224,29 @@ end module ExprGoodOrder
         "an expression match with `_` as the final arm must type-check"
     );
 }
+
+#[test]
+fn test_param_sized_literal_emits_valid_sv_size_cast() {
+    // A param-width sized literal (`W'd5`) that survives to SV codegen must be
+    // emitted as a legal SystemVerilog size cast `W'(5)`, NOT the invalid
+    // `W'd5` form (a sized-literal width must be a decimal number, not a
+    // parameter — Verilator and iverilog both reject `W'd5` with a syntax
+    // error). Regression for the codegen half of the #636 param-sized-literal
+    // feature (typecheck half fixed in #651).
+    let source = r#"
+module ParamSizedEmit
+  param W: const = 8;
+  port x: out UInt<8>;
+  let x = W'd5;
+end module ParamSizedEmit
+"#;
+    let sv = compile_to_sv(source);
+    assert!(
+        sv.contains("assign x = W'(5);"),
+        "expected a size-cast `W'(5)`, got:\n{sv}"
+    );
+    assert!(
+        !sv.contains("W'd5"),
+        "must not emit the invalid parameter-width sized literal `W'd5`:\n{sv}"
+    );
+}


### PR DESCRIPTION
## Summary

`arch build` emits **invalid SystemVerilog** for parameter-width sized literals. A sized-literal width must be a decimal *number*, not a parameter reference, so `W'd5` is a syntax error in both Verilator and iverilog:

```
$ arch build PsOk.arch          # module PsOk with `param W: const = 8; let x = W'd5;`
  assign x = W'd5;
$ verilator --lint-only PsOk.sv
%Error: syntax error, unexpected INTEGER NUMBER, expecting ',' or ';'
$ iverilog -g2012 PsOk.sv
   error: syntax error
```

This emits the legal **size-cast** form `W'(5)` instead — identical value and width, clean under `verilator --lint-only` and `iverilog -g2012`:

```
  assign x = W'(5);
```

## Context

The param-sized-literal feature (`W'dN`) shipped in #636 with two bugs. #651 ("Prepare ARCH 0.70.6 Icarus portability fixes") fixed the **type-checker** half (`W'dN` now types as `UInt<W>` via `resolve_param_sized_literal_width`) but shipped 0.70.6 with the **codegen** half still emitting the invalid `W'd5`. Since #651 was explicitly preparing 0.70.6 for a CVDP/VerilogEval rerun where Verilator/iverilog portability is the goal, this gap directly undermines that goal for any design using `W'dN` in a top-level (symbolic-param) module.

The stalled, unmerged #643 already diagnosed this exact issue as *"Bug 2 — a pure internal codegen fix (emit valid SV), autonomously in scope"*. #643's Bug 1 was superseded by #651's independent fix, so only this one-line emit fix remains. This PR extracts just that.

## Changes

- `src/codegen/mod.rs`: `LitKind::ParamSized` SV emit `{name}'d{v}` → `{name}'({v})`. The internal `expr_key` dedup-string site (~line 2183) is deliberately left unchanged — it produces a hash key, not SV output.
- `tests/integration_test.rs`: `test_param_sized_literal_emits_valid_sv_size_cast` — asserts `W'(5)` is emitted and `W'd5` never appears.
- `doc/COMPILER_STATUS.md`: note the size-cast emission on the existing param-sized-literal line.

## Validation

- `cargo build --release`
- `cargo test --release --test integration_test param_sized_literal` (both tests pass)
- End-to-end: `arch build` → `verilator --lint-only` CLEAN + `iverilog -g2012` CLEAN
- Full regression sweep running post-open per commit-before-verify ordering; will follow up if anything surfaces.

Found during the 2026-07-06 automated daily PR review (reviewing #651).