### PR TITLE
fix(codegen): emit bare `{N{a}}[hi:lo]` repeat-base bit-slice (arch#653 item 2)

### DIFF
--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -6185,6 +6185,12 @@ impl<'a> Codegen<'a> {
                 // because bit-select doesn't compose with the parenthesized
                 // expression — but `func()[hi:lo]` is valid (function-call
                 // result is an "lvalue-like" form per the SV grammar).
+                // Repeat (replication `{N{a}}`) is the same grammar class as
+                // Concat (multiple_concatenation): Verilator/iverilog accept
+                // `{2{a}}[hi:lo]` bare but reject `({2{a}})[hi:lo]`. Without
+                // this arm the paren'd form is emitted and fails Verilator with
+                // a syntax error even though typecheck's
+                // `is_portable_bit_slice_base` classifies Repeat as portable.
                 let b = if matches!(
                     base.kind,
                     ExprKind::Ident(_)
@@ -6193,6 +6199,7 @@ impl<'a> Codegen<'a> {
                         | ExprKind::Index(_, _)
                         | ExprKind::FieldAccess(_, _)
                         | ExprKind::Concat(_)
+                        | ExprKind::Repeat(_, _)
                         | ExprKind::FunctionCall(_, _)
                         | ExprKind::MethodCall(_, _, _)
                 ) {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -213,6 +213,32 @@ end module SliceArithmeticExpr
 }
 
 #[test]
+fn test_repeat_base_bit_slice_emits_bare_no_parens() {
+    // arch#653 item 2: a replication `{N{a}}` as a bit-slice base is classified
+    // portable by typecheck's `is_portable_bit_slice_base`, but codegen used to
+    // wrap it in parens — `({2{a}})[3:0]` — which Verilator/iverilog reject as a
+    // syntax error (the guardrail's own Icarus-portability goal defeated). Repeat
+    // is the same grammar class as Concat, so the bare form `{2{a}}[3:0]` is
+    // legal SV and must be emitted without the enclosing parens.
+    let source = r#"
+module RepeatSlice
+  port a: in UInt<4>;
+  port y: out UInt<4>;
+  let y = {2{a}}[3:0];
+end module RepeatSlice
+"#;
+    let sv = compile_to_sv(source);
+    assert!(
+        sv.contains("assign y = {2{a}}[3:0];"),
+        "expected bare repeat-slice, got:\n{sv}"
+    );
+    assert!(
+        !sv.contains("({2{a}})[3:0]"),
+        "repeat-slice base must not be parenthesized (Verilator syntax error), got:\n{sv}"
+    );
+}
+
+#[test]
 fn test_bang_prefix_is_logical_not_alias() {
     // arch#496: `!` is a symbolic alias for the `not` keyword (logical-not),
     // exactly parallel to `&&`==`and` / `||`==`or` (#493). It must lower to


### PR DESCRIPTION
## Summary

Fixes the **internal-only** half of arch#653 item 2. A replication `{N{a}}` used as a bit-slice base is classified portable by typecheck's `is_portable_bit_slice_base`, but codegen wrapped it in parens — `({2{a}})[3:0]` — which Verilator/iverilog reject as a syntax error. This defeated #651's own Icarus-portability goal for the `Repeat` case: the design passes `arch check` but `arch build` produces un-lintable SV.

`Repeat` is the same SV grammar class as `Concat` (`multiple_concatenation`), which was already on codegen's bit-slice no-paren allowlist. This adds `Repeat` to that allowlist so the bare, legal form `{2{a}}[3:0]` is emitted.

## Verification (fresh release build, Verilator 5.048)

| form | result |
|---|---|
| `({2{a}})[3:0]` (before) | ❌ Verilator syntax error |
| `{2{a}}[3:0]` (after) | ✅ Verilator-clean |

Repro used:
```arch
module RepeatSlice
  port a: in UInt<4>;
  port y: out UInt<4>;
  let y = {2{a}}[3:0];
end module RepeatSlice
```

Adds `test_repeat_base_bit_slice_emits_bare_no_parens` asserting the bare emission and the absence of the paren'd form.

## Scope

Pure internal codegen; **no user-facing syntax/semantics change**. The two user-facing items in arch#653 — (1) guarding the `PartSelect` base against the same silent miscompile, and (2) removing `BitSlice`/`PartSelect`/`Bool`/`EnumVariant` from the portable-base set — change type-system rules and remain **deferred for maintainer sign-off** per CLAUDE.md.

Found during the 2026-07-08 automated daily review.