### PR TITLE
test(typecheck): cover unknown param-width literal names

### DIFF
--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -29152,3 +29152,23 @@ end module BadWidth
         "must not fall back to the bogus UInt<32> mismatch:\n{rendered}"
     );
 }
+
+#[test]
+fn test_param_sized_literal_rejects_unknown_width_name() {
+    let source = r#"
+module BadWidthName
+  port o: out UInt<32>;
+  comb
+    o = TYPO'd5;
+  end comb
+end module BadWidthName
+"#;
+    let errs = typecheck_source(source).expect_err("expected unknown width-name error");
+    let rendered = format!("{errs:?}");
+    assert!(
+        rendered.contains(
+            "sized literal width param `TYPO` must resolve to a positive integer constant"
+        ),
+        "expected an unknown-width diagnostic, got:\n{rendered}"
+    );
+}


### PR DESCRIPTION
## Summary

- add a regression test that a misspelled param-width prefix like `TYPO'd5` is rejected

## Why

`main` already rejects unknown param-width literal names through `resolve_param_sized_literal_width`, but there was no direct regression test covering that typo path. This adds that test so we keep the helpful diagnostic and avoid regressing back to silent acceptance.

## Review

Findings: none.

Open questions: none.

Validation gaps: focused regression only; I did not rerun the full suite.

## Verification

- `cargo fmt --check`
- `cargo test --release --test integration_test param_sized_literal`
