### PR TITLE
fix(typecheck): guard variable part-select base against silent miscompile (arch#653 item 1)

### DIFF
--- a/doc/COMPILER_STATUS.md
+++ b/doc/COMPILER_STATUS.md
@@ -5,7 +5,7 @@
 >
 > **0.70.6 release highlights:**
 > - **Icarus-portable CVDP generation guidance** — ARCH MCP and skill instructions now steer generated code away from indexed casts/conversions, nested signed-extension chains, and direct slices of arithmetic expressions that Icarus rejects or mishandles.
-> - **Safer type checking for portable slices** — `arch check` now rejects direct bit-slicing of non-portable expression bases such as arithmetic expressions and points users toward wrapping arithmetic or named typed intermediates.
+> - **Safer type checking for portable slices** — `arch check` now rejects direct bit-slicing *and variable part-selecting* (`(expr)[start +: w]`) of non-portable expression bases such as arithmetic expressions and points users toward wrapping arithmetic or named typed intermediates. (The part-select guard closes a silent miscompile where `(a + b)[start +: w]` emitted `a + b[start +: w]`.)
 > - **Parameterized sized literals** — literals such as `W'd0` now resolve to the positive integer value of `W` instead of falling back to `UInt<32>`, with a clear diagnostic for non-positive widths. SV codegen emits the legal size-cast form `W'(0)` (a parameter is not a valid sized-literal width — Verilator and iverilog both reject `W'd0`).
 >
 > **0.70.4 release highlights:**

--- a/skills/arch-programming/references/COMPILER_STATUS.md
+++ b/skills/arch-programming/references/COMPILER_STATUS.md
@@ -5,7 +5,7 @@
 >
 > **0.70.6 release highlights:**
 > - **Icarus-portable CVDP generation guidance** — ARCH MCP and skill instructions now steer generated code away from indexed casts/conversions, nested signed-extension chains, and direct slices of arithmetic expressions that Icarus rejects or mishandles.
-> - **Safer type checking for portable slices** — `arch check` now rejects direct bit-slicing of non-portable expression bases such as arithmetic expressions and points users toward wrapping arithmetic or named typed intermediates.
+> - **Safer type checking for portable slices** — `arch check` now rejects direct bit-slicing *and variable part-selecting* (`(expr)[start +: w]`) of non-portable expression bases such as arithmetic expressions and points users toward wrapping arithmetic or named typed intermediates. (The part-select guard closes a silent miscompile where `(a + b)[start +: w]` emitted `a + b[start +: w]`.)
 > - **Parameterized sized literals** — literals such as `W'd0` now resolve to the positive integer value of `W` instead of falling back to `UInt<32>`, with a clear diagnostic for non-positive widths. SV codegen emits the legal size-cast form `W'(0)` (a parameter is not a valid sized-literal width — Verilator and iverilog both reject `W'd0`).
 >
 > **0.70.4 release highlights:**

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -3771,7 +3771,24 @@ impl<'a> TypeChecker<'a> {
                     _ => Ty::Error,
                 }
             }
-            ExprKind::PartSelect(_base, _start, width, _up) => {
+            ExprKind::PartSelect(base, _start, width, _up) => {
+                // A variable part-select `(base)[start +: w]` lowers to
+                // `base[start +: w]` in SV, which requires `base` to be a
+                // selectable reference — the same restriction the `BitSlice`
+                // arm above enforces via `is_portable_bit_slice_base`. Without
+                // this guard a low-precedence base silently miscompiles: e.g.
+                // `(a + b)[start +: w]` emits `a + b[start +: w]`, which parses
+                // as `a + (b[start +: w])` (the select binds to `b` alone) with
+                // no diagnostic. The parenthesized form is not an escape either
+                // — Verilator/iverilog reject `(a + b)[start +: w]` — so the
+                // only valid lowering is a named intermediate.
+                if !Self::is_portable_bit_slice_base(base) {
+                    self.errors.push(CompileError::general(
+                        "cannot part-select this expression directly; SystemVerilog backends cannot portably emit `(expr)[start +: width]`. For same-width modular arithmetic, use wrapping operators such as `+%` or `-%`; otherwise assign the expression to a typed `let`/wire first and part-select the named value.",
+                        base.span,
+                    ));
+                    return Ty::Error;
+                }
                 // width is const; result type is UInt<width>
                 match self.eval_const_expr(width, local_types) {
                     Some(w) if w > 0 => Ty::UInt(w as u32),

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -29276,3 +29276,81 @@ end module ParamSizedEmit
         "must not emit the invalid parameter-width sized literal `W'd5`:\n{sv}"
     );
 }
+
+#[test]
+fn test_part_select_arithmetic_expression_errors_with_wrapping_hint() {
+    // arch#653 item 1: a variable part-select `(expr)[start +: w]` on a
+    // low-precedence base silently miscompiled — `(a + b)[2 +: 3]` emitted
+    // `a + b[2 +: 3]` (the select binds to `b` alone) with NO diagnostic,
+    // because the `PartSelect` arm was never wired to #651's
+    // `is_portable_bit_slice_base` guard (only `BitSlice` was). This mirrors
+    // the bit-slice guard onto part-selects.
+    let source = r#"
+module PartSelectArithmeticExpr
+  port a: in UInt<8>;
+  port b: in UInt<8>;
+  port y: out UInt<3>;
+  let y = (a + b)[2 +: 3];
+end module PartSelectArithmeticExpr
+"#;
+    let tokens = lexer::tokenize(source).expect("lexer error");
+    let mut parser = Parser::new(tokens, source);
+    let parsed_ast = parser.parse_source_file().expect("parse error");
+    let ast = elaborate::elaborate(parsed_ast).expect("elaborate error");
+    let symbols = resolve::resolve(&ast).expect("resolve error");
+    let checker = TypeChecker::new(&symbols, &ast);
+    let errors = checker
+        .check()
+        .expect_err("arithmetic-expression part-select should error");
+    let rendered = format!("{errors:?}");
+    assert!(
+        rendered.contains("cannot part-select this expression directly"),
+        "got:\n{rendered}"
+    );
+    assert!(rendered.contains("+%"));
+    assert!(rendered.contains("-%"));
+
+    // A shift base is likewise low-precedence and must be rejected.
+    let shift_src = r#"
+module PartSelectShiftExpr
+  port a: in UInt<8>;
+  port s: in UInt<3>;
+  port y: out UInt<2>;
+  let y = (a >> 1)[s +: 2];
+end module PartSelectShiftExpr
+"#;
+    let tokens = lexer::tokenize(shift_src).expect("lexer error");
+    let mut parser = Parser::new(tokens, shift_src);
+    let parsed_ast = parser.parse_source_file().expect("parse error");
+    let ast = elaborate::elaborate(parsed_ast).expect("elaborate error");
+    let symbols = resolve::resolve(&ast).expect("resolve error");
+    let checker = TypeChecker::new(&symbols, &ast);
+    let errors = checker
+        .check()
+        .expect_err("shift-expression part-select should error");
+    assert!(
+        format!("{errors:?}").contains("cannot part-select this expression directly"),
+        "shift base must be rejected"
+    );
+}
+
+#[test]
+fn test_part_select_named_value_base_accepted() {
+    // The `let`-first form the diagnostic recommends must type-check cleanly
+    // and emit a bare `name[start +: width]` — the only portable lowering.
+    let source = r#"
+module PartSelectNamed
+  port a: in UInt<8>;
+  port b: in UInt<8>;
+  port s: in UInt<3>;
+  port y: out UInt<3>;
+  let sum: UInt<9> = a + b;
+  let y = sum[s +: 3];
+end module PartSelectNamed
+"#;
+    let sv = compile_to_sv(source);
+    assert!(
+        sv.contains("assign y = sum[s +: 3];"),
+        "expected a bare named-value part-select, got:\n{sv}"
+    );
+}


### PR DESCRIPTION
## Summary

Closes item 1 of #653 — a **silent miscompile**. A variable part-select `(expr)[start +: w]` on a low-precedence base passed `arch check` and emitted precedence-wrong SV with no diagnostic:

```arch
let ps = (a + b)[2 +: 3];
```
```sv
assign ps = a + b[2 +: 3];   // parses as a + (b[2 +: 3]) — the select binds to b alone. WRONG.
```
`(a >> 1)[s +: 2]` similarly emitted `a >> 1[s +: 2]`.

## Root cause

#651 added `is_portable_bit_slice_base` and wired it into the `ExprKind::BitSlice` arm of `resolve_expr_type`, so `(a + b)[hi:lo]` is correctly rejected. But the sibling `ExprKind::PartSelect` arm bound `_base` and never consulted the guard — so part-selects of the same non-portable bases slipped through and miscompiled. The parenthesized form is not an escape either (Verilator/iverilog reject `(a + b)[start +: w]`), so the only valid lowering is a named intermediate.

## Fix

Mirror the BitSlice guard onto the PartSelect arm, reusing `is_portable_bit_slice_base` **unchanged**, with a part-select-specific message:

```
cannot part-select this expression directly; SystemVerilog backends cannot
portably emit `(expr)[start +: width]`. For same-width modular arithmetic,
use wrapping operators such as `+%` or `-%`; otherwise assign the
expression to a typed `let`/wire first and part-select the named value.
```

Portable bases are unaffected — `sum[s +: 3]` (named), `a[i][s +: w]` (Index base), `{a,b}[s +: w]` (Concat), etc. still type-check and emit the bare `name[start +: w]`.

## Scope & blast radius

- **User-facing** (new typecheck rejection) — implemented with maintainer sign-off, mirroring the already-approved #651 BitSlice convention. `is_portable_bit_slice_base` itself is untouched.
- **Item 2 of #653** (reconciling the portable set with codegen's no-paren list for *chained bit-slice* bases like `a[7:4][1:0]`) is a separate, lower-severity portability question — **left open**, not in this PR.
- **Zero blast radius:** no `.arch` fixture in `tests/` or the `cvdp`/`realbench`/`backend_equiv` corpora part-selects a non-portable base (verified by grep).

## Verification

- `cargo build --release`
- `cargo test --release --test integration_test -- part_select bit_slice_arithmetic` → 4/4 pass
  - `test_part_select_arithmetic_expression_errors_with_wrapping_hint` (arith + shift bases rejected)
  - `test_part_select_named_value_base_accepted` (named base still emits bare `sum[s +: 3]`)
  - existing `test_bit_slice_arithmetic_expression_errors_with_wrapping_hint` still green
- End-to-end: `(a+b)[2+:3]` now errors at `arch check`; `sum[s +: 3]` builds + is Verilator-clean.
- Docs: `doc/COMPILER_STATUS.md` + skills snapshot updated (part-select guard).
- Full regression sweep running post-open per commit-before-verify ordering; will follow up if anything surfaces.

Found + fixed during the 2026-07-10 automated daily review.