### PR TITLE
fix(codegen): preserve unsigned param-sized literals

### DIFF
--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -5741,12 +5741,15 @@ impl<'a> Codegen<'a> {
                 // SystemVerilog — the size of a sized literal must be a decimal
                 // *number*, not a parameter reference (both Verilator and
                 // iverilog reject `W'd5` with a syntax error). Emit the legal
-                // parameterized form instead: a size cast `W'(5)`, which carries
-                // the identical value and width. (The type checker already
-                // resolves the ARCH type to `UInt<W>` via
+                // parameterized form instead: a size cast, but keep the operand
+                // explicitly unsigned. Plain `W'(15)` parses, yet it behaves like
+                // a signed 4-bit value (`-1`) while `4'd15` is unsigned `15`.
+                // `W'($unsigned(15))` preserves the original literal semantics
+                // while staying valid under both Verilator and iverilog. (The
+                // type checker already resolves the ARCH type to `UInt<W>` via
                 // `resolve_param_sized_literal_width`; this is the SV-surface
                 // counterpart.)
-                LitKind::ParamSized(name, v) => format!("{name}'({v})"),
+                LitKind::ParamSized(name, v) => format!("{name}'($unsigned({v}))"),
                 // Float literal (FP32 by default) → 32-bit binary32 bit pattern.
                 LitKind::Float(bits) => {
                     format!("32'h{:08X}", (f64::from_bits(*bits) as f32).to_bits())

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -29431,25 +29431,30 @@ end module ExprGoodOrder
 #[test]
 fn test_param_sized_literal_emits_valid_sv_size_cast() {
     // A param-width sized literal (`W'd5`) that survives to SV codegen must be
-    // emitted as a legal SystemVerilog size cast `W'(5)`, NOT the invalid
-    // `W'd5` form (a sized-literal width must be a decimal number, not a
-    // parameter — Verilator and iverilog both reject `W'd5` with a syntax
-    // error). Regression for the codegen half of the #636 param-sized-literal
-    // feature (typecheck half fixed in #651).
+    // emitted as a legal SystemVerilog size cast with an explicitly unsigned
+    // payload, NOT the invalid `W'd5` form. Bare `W'(15)` parses, but it
+    // behaves like signed 4-bit `-1`; `W'($unsigned(15))` preserves the
+    // original unsigned-sized-literal semantics while still compiling under
+    // Verilator and iverilog. Regression for the codegen half of the #636
+    // param-sized-literal feature (typecheck half fixed in #651).
     let source = r#"
 module ParamSizedEmit
-  param W: const = 8;
-  port x: out UInt<8>;
-  let x = W'd5;
+  param W: const = 4;
+  port x: out UInt<4>;
+  let x = W'd15;
 end module ParamSizedEmit
 "#;
     let sv = compile_to_sv(source);
     assert!(
-        sv.contains("assign x = W'(5);"),
-        "expected a size-cast `W'(5)`, got:\n{sv}"
+        sv.contains("assign x = W'($unsigned(15));"),
+        "expected an unsigned size-cast `W'($unsigned(15))`, got:\n{sv}"
     );
     assert!(
-        !sv.contains("W'd5"),
-        "must not emit the invalid parameter-width sized literal `W'd5`:\n{sv}"
+        !sv.contains("W'd15"),
+        "must not emit the invalid parameter-width sized literal `W'd15`:\n{sv}"
+    );
+    assert!(
+        !sv.contains("W'(15)"),
+        "must not emit a signed size-cast that changes literal semantics:\n{sv}"
     );
 }


### PR DESCRIPTION
## Summary

Fix SystemVerilog code generation for ARCH parameter-width sized literals.

## Root cause

`W'd15` is not valid SystemVerilog when `W` is a parameter, so codegen must use a size cast. A bare `W'(15)` is syntactically valid but is treated as a signed value when the high bit is set, changing the semantics of an unsigned ARCH literal. The generated form is now `W'($unsigned(15))`, which is valid under Verilator and iverilog and preserves the original unsigned value.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --test integration_test` (698 passed)
- Pre-PR code review completed; no remaining findings
