### PR TITLE
Fix parameter-sized literal SystemVerilog codegen

### DIFF
--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -5619,6 +5619,7 @@ impl<'a> Codegen<'a> {
                 bits.to_string()
             }
             ExprKind::Literal(LitKind::Sized(w, _)) => w.to_string(),
+            ExprKind::Literal(LitKind::ParamSized(name, _)) => name.clone(),
             ExprKind::MethodCall(_, method, args)
                 if matches!(method.name.as_str(), "trunc" | "zext" | "sext" | "resize") =>
             {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -152,6 +152,29 @@ end module SimpleAlu
 }
 
 #[test]
+fn test_param_sized_literal_width_cast_is_valid_systemverilog() {
+    let source = r#"
+module ParamSizedWrapWidth
+  param SCORE_WIDTH: const = 12;
+  port score: in UInt<SCORE_WIDTH>;
+  port magnitude: out UInt<SCORE_WIDTH>;
+  comb
+    magnitude = SCORE_WIDTH'd0 -% score;
+  end comb
+end module ParamSizedWrapWidth
+"#;
+    let sv = compile_to_sv(source);
+    assert!(
+        sv.contains("SCORE_WIDTH'(SCORE_WIDTH'($unsigned(0)) - score)"),
+        "parameter-sized literal should drive the wrapping width cast:\n{sv}"
+    );
+    assert!(
+        !sv.contains("$bits(SCORE_WIDTH'd0)") && !sv.contains("SCORE_WIDTH'd0"),
+        "parameter-sized literals must not be passed to $bits:\n{sv}"
+    );
+}
+
+#[test]
 fn test_todo_placeholder() {
     let source = r#"
 domain SysDomain


### PR DESCRIPTION
Fixes parameter-sized literal emission such as SCORE_WIDTH'd0, which produced invalid or non-portable SystemVerilog and could also be passed to $bits().

Changes:
- emit parameter-sized literals as size casts (`SCORE_WIDTH'(0)`)
- teach width inference about parameter-sized literals
- add an integration regression covering wrapping arithmetic

Validation:
- cargo test --locked --test integration_test test_param_sized_literal_width_cast_is_valid_systemverilog -- --exact
- cargo build --release --locked

This is required by fpt26-accel before pinning the released ARCH toolchain.