### PR TITLE
fix(formal): preserve param-sized literal widths in SMT emission

### DIFF
--- a/src/formal.rs
+++ b/src/formal.rs
@@ -2048,7 +2048,7 @@ impl<'a> FormalCtx<'a> {
                     expr.span,
                 ))
             }
-            Literal(l) => Ok(lit_to_term(l)),
+            Literal(l) => lit_to_term(l, &self.params, expr.span),
             Bool(b) => Ok(SmtTerm {
                 s: if *b { "#b1".to_string() } else { "#b0".to_string() },
                 width: 1,
@@ -2894,37 +2894,51 @@ fn cc_payload_width(meta: &CreditChannelMeta) -> Option<u32> {
     }
 }
 
-fn lit_to_term(l: &LitKind) -> SmtTerm {
+fn lit_to_term(
+    l: &LitKind,
+    params: &HashMap<String, u64>,
+    span: Span,
+) -> Result<SmtTerm, CompileError> {
     match l {
         LitKind::Dec(v) | LitKind::Hex(v) | LitKind::Bin(v) => {
             // Intrinsic width = bit-length, or 1 for value 0.
             let w = if *v == 0 { 1 } else { 64 - v.leading_zeros() };
-            SmtTerm {
+            Ok(SmtTerm {
                 s: bv_lit(*v, w),
                 width: w,
                 signed: false,
-            }
+            })
         }
-        LitKind::Sized(w, v) => SmtTerm {
+        LitKind::Sized(w, v) => Ok(SmtTerm {
             s: bv_lit(*v, *w),
             width: *w,
             signed: false,
-        },
-        LitKind::ParamSized(_, v) => SmtTerm {
-            s: bv_lit(*v, 32),
-            width: 32,
-            signed: false,
-        },
+        }),
+        LitKind::ParamSized(name, v) => {
+            let Some(width) = params.get(name).copied().map(|w| w as u32) else {
+                return Err(CompileError::general(
+                    &format!(
+                        "param-sized literal width `{name}` is not a resolvable const parameter"
+                    ),
+                    span,
+                ));
+            };
+            Ok(SmtTerm {
+                s: bv_lit(*v, width),
+                width,
+                signed: false,
+            })
+        }
         // Float literals are unreachable here in practice — FP types are rejected
         // by `check_scalar_type` before emission. Fall back to the FP32 bit
         // pattern as a 32-bit vector so this stays total.
         LitKind::Float(bits) => {
             let f = (f64::from_bits(*bits)) as f32;
-            SmtTerm {
+            Ok(SmtTerm {
                 s: bv_lit(f.to_bits() as u64, 32),
                 width: 32,
                 signed: false,
-            }
+            })
         }
     }
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -25275,6 +25275,80 @@ fn test_native_sim_vec_inst_input_wire_param_sized_fanout() {
 }
 
 #[test]
+fn test_param_sized_literal_uses_param_width_in_check_build_and_formal() {
+    // Regression for PR #636. `W'd0` parsed, but the typechecker/formal backend
+    // still treated it as UInt<32>, so the new syntax failed in normal module
+    // code and widened SMT literals silently.
+    let td = tempfile::tempdir().expect("tempdir");
+    let src = td.path().join("ParamSized.arch");
+    let sv_out = td.path().join("ParamSized.sv");
+    let smt_out = td.path().join("ParamSized.smt2");
+    std::fs::write(
+        &src,
+        r#"
+module ParamSized
+  param W: const = 5;
+  port o: out UInt<W>;
+  let o = W'd0;
+end module ParamSized
+"#,
+    )
+    .expect("write source");
+
+    let arch_bin = env!("CARGO_BIN_EXE_arch");
+
+    let check = std::process::Command::new(arch_bin)
+        .arg("check")
+        .arg(&src)
+        .output()
+        .expect("run arch check");
+    assert!(
+        check.status.success(),
+        "arch check should accept param-sized literals at the resolved width\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&check.stdout),
+        String::from_utf8_lossy(&check.stderr)
+    );
+
+    let build = std::process::Command::new(arch_bin)
+        .arg("build")
+        .arg(&src)
+        .arg("-o")
+        .arg(&sv_out)
+        .output()
+        .expect("run arch build");
+    assert!(
+        build.status.success(),
+        "arch build should preserve param-sized literals in SV\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&build.stdout),
+        String::from_utf8_lossy(&build.stderr)
+    );
+    let sv = std::fs::read_to_string(&sv_out).expect("read SV");
+    assert!(
+        sv.contains("assign o = W'($unsigned(0));"),
+        "expected emitted SV to use the legal param-width size cast form:\n{sv}"
+    );
+
+    let formal = std::process::Command::new(arch_bin)
+        .arg("formal")
+        .arg(&src)
+        .arg("--emit-smt")
+        .arg(&smt_out)
+        .output()
+        .expect("run arch formal");
+    assert!(
+        formal.status.success(),
+        "arch formal should accept param-sized literals and resolve their width\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&formal.stdout),
+        String::from_utf8_lossy(&formal.stderr)
+    );
+    let smt = std::fs::read_to_string(&smt_out).expect("read SMT");
+    assert!(
+        smt.contains("(_ bv0 5)"),
+        "expected SMT emission to use the resolved 5-bit width, not a fallback width:\n{smt}"
+    );
+}
+
+#[test]
 fn test_native_sim_bool_not_pipe_reg_outputs_and_ampamp() {
     // Regression for arch-com#492. Native sim used to tokenize `&&` as
     // bitwise `&` plus reduction `&` on the RHS, then infer


### PR DESCRIPTION
## Summary
- resolve `ParamSized` literals in `arch formal` using the active const-param map instead of a fallback 32-bit width
- propagate a targeted compile error when the width name is not resolvable in the formal backend
- add an integration regression that checks `arch check`, `arch build`, and `arch formal --emit-smt` together for `W'd0`

## Review
Findings: none.

Open questions: none.

Validation gaps: only the focused regression test and a direct `arch formal --emit-smt` repro were run locally.

## Validation
- `cargo fmt --all --check`
- `cargo test --test integration_test test_param_sized_literal_uses_param_width_in_check_build_and_formal -- --exact --nocapture`
- `cargo run --release -- formal /tmp/param_sized_module.arch --emit-smt /tmp/param_sized_module.smt2`
