### PR TITLE
Bump arch version to 0.70.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,7 +75,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arch"
-version = "0.70.6"
+version = "0.70.7"
 dependencies = [
  "clap",
  "insta",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arch"
-version = "0.70.6"
+version = "0.70.7"
 edition = "2021"
 description = "Compiler for the ARCH hardware description language"
 license = "LGPL-3.0-or-later"

--- a/doc/COMPILER_STATUS.md
+++ b/doc/COMPILER_STATUS.md
@@ -1,7 +1,10 @@
 # ARCH Compiler — Status & Roadmap
 
-> Last updated: 2026-07-05
-> Compiler version: 0.70.6
+> Last updated: 2026-07-11
+> Compiler version: 0.70.7
+>
+> **0.70.7 release highlights:**
+> - **Param-sized literal follow-through** — the `0.70.6` param-width literal work now carries through typecheck and formal: `W'dN` is typed using the positive integer value of `W`, non-positive widths get a targeted diagnostic instead of a fallback `UInt<32>` mismatch, unknown width names are rejected clearly, and `arch formal` resolves param-sized literal widths instead of dropping them on the SMT path.
 >
 > **0.70.6 release highlights:**
 > - **Icarus-portable CVDP generation guidance** — ARCH MCP and skill instructions now steer generated code away from indexed casts/conversions, nested signed-extension chains, and direct slices of arithmetic expressions that Icarus rejects or mishandles.

--- a/skills/arch-programming/references/COMPILER_STATUS.md
+++ b/skills/arch-programming/references/COMPILER_STATUS.md
@@ -1,7 +1,10 @@
 # ARCH Compiler — Status & Roadmap
 
-> Last updated: 2026-07-05
-> Compiler version: 0.70.6
+> Last updated: 2026-07-11
+> Compiler version: 0.70.7
+>
+> **0.70.7 release highlights:**
+> - **Param-sized literal follow-through** — the `0.70.6` param-width literal work now carries through typecheck and formal: `W'dN` is typed using the positive integer value of `W`, non-positive widths get a targeted diagnostic instead of a fallback `UInt<32>` mismatch, unknown width names are rejected clearly, and `arch formal` resolves param-sized literal widths instead of dropping them on the SMT path.
 >
 > **0.70.6 release highlights:**
 > - **Icarus-portable CVDP generation guidance** — ARCH MCP and skill instructions now steer generated code away from indexed casts/conversions, nested signed-extension chains, and direct slices of arithmetic expressions that Icarus rejects or mishandles.


### PR DESCRIPTION
## Summary
- bump the crate version to `0.70.7`
- refresh compiler status docs for the 0.70.7 patch release
- document the param-sized literal typecheck/formal follow-through shipped after 0.70.6

## Verification
- `cargo test --release`
