### PR TITLE
fix(typecheck): recurse pipeline output-coverage into exhaustive if/else (closes #557)

### DIFF
--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -7147,6 +7147,18 @@ impl<'a> TypeChecker<'a> {
             for item in &stage.body {
                 if let ModuleBodyItem::CombBlock(cb) = item {
                     Self::collect_comb_stmt_targets(&cb.stmts, &mut driven);
+                    // `collect_comb_stmt_targets` above only tells us a target
+                    // is assigned on SOME path (e.g. one arm of an if/else) —
+                    // it doesn't confirm every control path assigns it. Since
+                    // `wire` isn't legal in a stage and `reg` can't be
+                    // assigned in `comb`, an output port is the only
+                    // comb-assignable target here, so `check_comb_latch`
+                    // (the same no-implicit-latch analysis module bodies
+                    // use) doubles as the pipeline stage's latch guard: a
+                    // partial if/match with no covering else/wildcard arm is
+                    // reported as "infers a latch" instead of being silently
+                    // accepted or mis-reported as "not driven". See #557.
+                    self.check_comb_latch(&cb.stmts, cb.span);
                 }
                 if let ModuleBodyItem::Inst(inst) = item {
                     for conn in &inst.connections {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -3566,6 +3566,256 @@ end pipeline RegPipe
     );
 }
 
+/// `arch check` rejects `source` with a diagnostic whose Display/Debug text
+/// contains `needle`; returns the joined error text for failure messages.
+fn pipeline_check_err_contains(source: &str, needle: &str) {
+    let tokens = lexer::tokenize(source).expect("lex");
+    let mut parser = Parser::new(tokens, source);
+    let ast = parser.parse_source_file().expect("parse");
+    let elaborated = elaborate::elaborate(ast).expect("elaborate");
+    let symbols = resolve::resolve(&elaborated).expect("resolve");
+    let checker = arch::typecheck::TypeChecker::new(&symbols, &elaborated);
+    let errs = checker
+        .check()
+        .expect_err("expected pipeline typecheck to reject source");
+    let msg = errs.iter().map(|e| format!("{e:?}")).collect::<String>();
+    assert!(
+        msg.contains(needle),
+        "expected diagnostic containing `{needle}`, got: {msg}"
+    );
+}
+
+// Issue #557: the pipeline output-coverage check only recognized a
+// top-level `Stmt::Assign` with a bare `Ident` as "driving" an output —
+// an output assigned inside an exhaustive `if`/`else` (or `match`) was
+// wrongly rejected as "not driven", even though the identical shape in a
+// plain `module` type-checks clean. The fix makes `check_pipeline` reuse
+// `collect_comb_stmt_targets` (recursive) for coverage AND run
+// `check_comb_latch` (the same no-implicit-latch analysis module bodies
+// use) so a genuinely partial branch set is still caught — now reported
+// as "infers a latch" instead of the previous misleading "not driven".
+// These tests are differential pairs: exhaustive (accept) vs. the same
+// shape missing one arm (reject as latch), at increasing nesting depth
+// and across both `if`/`else` and `match`.
+
+#[test]
+fn test_pipeline_allows_exhaustive_if_else_output() {
+    // Exact repro from GH issue #557.
+    let source = r#"
+domain D
+  freq_mhz: 100
+end domain D
+pipeline PipeIfElse
+  port clk: in Clock<D>;
+  port rst: in Reset<Sync>;
+  port a: in UInt<8>;
+  port o: out UInt<8>;
+  stage S
+    reg held: UInt<8> reset rst => 0;
+    reg sel_r: Bool reset rst => false;
+    seq on clk rising
+      held <= a;
+      sel_r <= false;
+    end seq
+    comb
+      if sel_r
+        o = held;
+      else
+        o = held;
+      end if
+    end comb
+  end stage S
+end pipeline PipeIfElse
+"#;
+    assert!(
+        pipeline_checks_ok(source),
+        "an output driven on every arm of an exhaustive if/else must be accepted"
+    );
+}
+
+#[test]
+fn test_pipeline_rejects_partial_if_output_as_latch() {
+    // Same shape as above but with the `else` arm dropped — `o` is only
+    // driven on one control path. Must still be rejected, and with the
+    // proper latch diagnostic (not the old misleading "not driven").
+    let source = r#"
+domain D
+  freq_mhz: 100
+end domain D
+pipeline PipePartialIf
+  port clk: in Clock<D>;
+  port rst: in Reset<Sync>;
+  port a: in UInt<8>;
+  port o: out UInt<8>;
+  stage S
+    reg held: UInt<8> reset rst => 0;
+    reg sel_r: Bool reset rst => false;
+    seq on clk rising
+      held <= a;
+      sel_r <= false;
+    end seq
+    comb
+      if sel_r
+        o = held;
+      end if
+    end comb
+  end stage S
+end pipeline PipePartialIf
+"#;
+    pipeline_check_err_contains(source, "infers a latch");
+}
+
+#[test]
+fn test_pipeline_allows_nested_exhaustive_if_else_output() {
+    // Two-level nested if/else where every leaf path assigns `o`.
+    let source = r#"
+domain D
+  freq_mhz: 100
+end domain D
+pipeline PipeNestedIf
+  port clk: in Clock<D>;
+  port rst: in Reset<Sync>;
+  port a: in UInt<8>;
+  port o: out UInt<8>;
+  stage S
+    reg held: UInt<8> reset rst => 0;
+    reg sel_r: Bool reset rst => false;
+    reg sel2_r: Bool reset rst => false;
+    seq on clk rising
+      held <= a;
+      sel_r <= false;
+      sel2_r <= false;
+    end seq
+    comb
+      if sel_r
+        if sel2_r
+          o = held;
+        else
+          o = held +% 1;
+        end if
+      else
+        o = held;
+      end if
+    end comb
+  end stage S
+end pipeline PipeNestedIf
+"#;
+    assert!(
+        pipeline_checks_ok(source),
+        "an output driven on every leaf path of a nested exhaustive if/else must be accepted"
+    );
+}
+
+#[test]
+fn test_pipeline_rejects_nested_partial_if_as_latch() {
+    // Same nested shape but the inner if is missing its else — `o` is
+    // undriven on the `sel_r && !sel2_r` path.
+    let source = r#"
+domain D
+  freq_mhz: 100
+end domain D
+pipeline PipeNestedIfPartial
+  port clk: in Clock<D>;
+  port rst: in Reset<Sync>;
+  port a: in UInt<8>;
+  port o: out UInt<8>;
+  stage S
+    reg held: UInt<8> reset rst => 0;
+    reg sel_r: Bool reset rst => false;
+    reg sel2_r: Bool reset rst => false;
+    seq on clk rising
+      held <= a;
+      sel_r <= false;
+      sel2_r <= false;
+    end seq
+    comb
+      if sel_r
+        if sel2_r
+          o = held;
+        end if
+      else
+        o = held;
+      end if
+    end comb
+  end stage S
+end pipeline PipeNestedIfPartial
+"#;
+    pipeline_check_err_contains(source, "infers a latch");
+}
+
+#[test]
+fn test_pipeline_allows_exhaustive_match_output() {
+    // `match` covering every enum variant (no wildcard needed).
+    let source = r#"
+domain D
+  freq_mhz: 100
+end domain D
+enum SelKind
+  A,
+  B
+end enum SelKind
+pipeline PipeMatch
+  port clk: in Clock<D>;
+  port rst: in Reset<Sync>;
+  port a: in UInt<8>;
+  port o: out UInt<8>;
+  stage S
+    reg held: UInt<8> reset rst => 0;
+    reg sel_r: SelKind reset rst => SelKind::A;
+    seq on clk rising
+      held <= a;
+      sel_r <= SelKind::A;
+    end seq
+    comb
+      match sel_r
+        SelKind::A => o = held;
+        SelKind::B => o = held +% 1;
+      end match
+    end comb
+  end stage S
+end pipeline PipeMatch
+"#;
+    assert!(
+        pipeline_checks_ok(source),
+        "an output driven on every arm of an exhaustive match must be accepted"
+    );
+}
+
+#[test]
+fn test_pipeline_rejects_partial_match_as_latch() {
+    // Missing the `B` arm entirely, and no wildcard — `o` is undriven when
+    // `sel_r == SelKind::B`.
+    let source = r#"
+domain D
+  freq_mhz: 100
+end domain D
+enum SelKind
+  A,
+  B
+end enum SelKind
+pipeline PipeMatchPartial
+  port clk: in Clock<D>;
+  port rst: in Reset<Sync>;
+  port a: in UInt<8>;
+  port o: out UInt<8>;
+  stage S
+    reg held: UInt<8> reset rst => 0;
+    reg sel_r: SelKind reset rst => SelKind::A;
+    seq on clk rising
+      held <= a;
+      sel_r <= SelKind::A;
+    end seq
+    comb
+      match sel_r
+        SelKind::A => o = held;
+      end match
+    end comb
+  end stage S
+end pipeline PipeMatchPartial
+"#;
+    pipeline_check_err_contains(source, "infers a latch");
+}
+
 #[test]
 fn test_pipeline_sim_codegen_sign_extends_sext() {
     let source = r#"


### PR DESCRIPTION
## Summary

- `check_pipeline`'s output-coverage check already recurses into `if`/`match`/`for`
  via `collect_comb_stmt_targets` (someone fixed the shallow top-level-only walk
  since #557 was filed on 2026-06-11 — confirmed by reproducing both the old
  repro, which now passes, and grepping the current source). But that recursive
  "driven on *some* path" collection alone is unsound as a latch guard: it now
  silently *accepts* a partial `if` (no `else`) driving an output, with zero
  diagnostic — a real implicit-latch bug that used to be caught (with a
  misleading "not driven" message) is now caught by nothing at all.
- Fix: run `check_comb_latch` — the same no-implicit-latch analysis module
  bodies already use — on every pipeline stage `comb` block, exactly as
  recommended in #557. Since `wire` isn't legal inside a stage and `reg` can't
  be assigned in `comb`, an output port is the only comb-assignable target in
  a stage, so this closes the gap cleanly: exhaustive `if`/`else` (and
  exhaustive `match`) is accepted, and any non-exhaustive branch set is
  rejected with `signal \`x\` is not assigned on all control paths in comb
  block (infers a latch)`.
- No suppression pragma, waiver, or allowlist — this is a checker-soundness
  fix that reuses the existing module-body latch analysis.

## Root cause detail

`src/typecheck.rs`, `check_pipeline`'s output-coverage loop already called the
recursive `collect_comb_stmt_targets` helper. That only proves a target is
assigned on *some* control path, not *every* path, so a partial `if`/`match`
was marked "driven" and slipped through with no error — the flip-side
soundness gap #557 explicitly warned a naive fix would introduce. Added a
`self.check_comb_latch(&cb.stmts, cb.span)` call alongside the existing
coverage collection to restore (and correctly diagnose) that guard.

## Test plan

- [x] `arch check` on the exact #557 repro (exhaustive if/else) now compiles clean
- [x] New differential test pairs in `tests/integration_test.rs` (exhaustive
      accepted / one-arm-short rejected as "infers a latch"), covering:
      - flat `if`/`else`
      - two-level nested `if`/`else`
      - exhaustive `enum` `match` vs. a `match` missing an arm with no wildcard
- [x] `cargo build --release` clean
- [x] `cargo test --release` full suite green (2 pre-existing Lean
      `ArchConstructProof` failures were a fresh-worktree `lake build` cache
      gap, fixed by running `lake build` under `proofs/lean_thread_lowering`,
      unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
