### PR TITLE
process: fix-PR lifecycle rules + stranded-PR sweep script

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,31 @@ and `claude/*` branches: it warns on overlap at push time but **never blocks**
 (bypass with `--no-verify`, or `CLAIM_CHECK_SKIP=1` to skip just the claim
 scan). Delete-only pushes (`git push --delete`) skip the hook entirely.
 
+## Fix-PR lifecycle (finish work you start)
+
+The repo finds bugs faster than it books them. Two audits (2026-07) showed the
+leak is at the last two stages, not in the finding: a fix PR (#643) sat
+unmerged while its bug shipped live for a week, and 3 of 5 issues in the
+"correctness backlog" turned out to be phantoms — already fixed by PRs that
+never said so. Rules:
+
+- **A PR that fixes a live bug must say `closes #N` in its body.** A fix that
+  merges without closing its issue creates a phantom: the issue outlives the
+  bug and someone later re-investigates it from scratch (#437, #462, #557 all
+  aged 4–6 weeks this way).
+- **A PR fixing a live miscompile gets same-day review-or-merge.** Track it on
+  the issue until it lands — "PR opened" is not "bug closed". If it must wait
+  on a maintainer decision, label it `awaiting-decision` and say why in the PR.
+- **Re-reproduce before you fix.** Before working a backlog issue, confirm it
+  still reproduces on a freshly built binary from current `origin/main`. If it
+  doesn't, bisect to the fixing commit if cheap and close the issue with that
+  evidence — a NOT-REPRODUCIBLE finding is a valid, valuable outcome.
+- **Sweep for stranded PRs**: `scripts/green_pr_sweep.sh` lists open PRs that
+  are green, mergeable, and ≥1 day old across arch-com + harc-com — finished
+  work nobody landed. The mirror image of `claim_check.sh` (duplicate work at
+  the start ↔ stranded work at the end). Run it in every review session;
+  advisory, never merges anything itself.
+
 ## Project Overview
 
 `arch-com` is a compiler for **ARCH**, a purpose-built hardware description language (HDL) for micro-architecture work. The compiler ingests `.arch` source files and emits deterministic, readable SystemVerilog. The language is explicitly designed to be generated correctly by LLMs from natural-language hardware descriptions.

--- a/scripts/green_pr_sweep.sh
+++ b/scripts/green_pr_sweep.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────────────────
+# green_pr_sweep.sh — the stranded-PR sweep.
+#
+# Lists every open PR with its CI verdict, mergeability, and age, and calls out
+# PRs that are GREEN + CLEAN + older than a day: those are finished work that
+# nobody merged. The mirror image of claim_check.sh — that one catches
+# duplicate work before it starts; this one catches completed work that never
+# landed (the PR #643 failure mode: a fix PR sat unmerged and its bug shipped
+# live for a week).
+#
+# Usage:
+#   scripts/green_pr_sweep.sh                  # arch-com + harc-com
+#   scripts/green_pr_sweep.sh owner/repo ...   # explicit repo list
+#
+# Advisory, like claim_check.sh — it informs, it does not merge.
+# ─────────────────────────────────────────────────────────────────────────────
+set -euo pipefail
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "green-pr-sweep: gh CLI not found" >&2
+  exit 1
+fi
+
+repos=("$@")
+[ ${#repos[@]} -gt 0 ] || repos=(arch-hdl-lang/arch-com arch-hdl-lang/harc-com)
+
+stranded=0
+
+for repo in "${repos[@]}"; do
+  echo "== ${repo} =="
+  gh pr list --repo "$repo" --state open \
+    --json number,title,createdAt,isDraft,labels,mergeStateStatus,statusCheckRollup \
+    --jq '
+      .[] |
+      ([ .statusCheckRollup[]?
+         | (.conclusion // .state // "PENDING")
+         | ascii_upcase ]) as $cs |
+      ([ .labels[]?.name ] | any(. == "awaiting-decision")) as $parked |
+      (if ($cs | any(. == "FAILURE" or . == "ERROR" or . == "TIMED_OUT" or . == "CANCELLED")) then "RED"
+       elif ($cs | any(. == "PENDING" or . == "QUEUED" or . == "IN_PROGRESS" or . == "")) then "PENDING"
+       elif ($cs | length) == 0 then "NO-CI"
+       else "GREEN" end) as $ci |
+      (((now - (.createdAt | fromdate)) / 86400) | floor) as $age |
+      (if .isDraft then "DRAFT"
+       elif $parked then "PARKED"
+       elif $ci == "GREEN" and .mergeStateStatus != "DIRTY" and $age >= 1 then "STRANDED?"
+       else "" end) as $flag |
+      [ "#\(.number)",
+        $ci,
+        .mergeStateStatus,
+        "\($age)d",
+        $flag,
+        (.title | .[0:70]) ]
+      | @tsv
+    ' | column -t -s $'\t' || echo "  (query failed for ${repo})"
+
+  n="$(gh pr list --repo "$repo" --state open \
+        --json number,createdAt,isDraft,labels,mergeStateStatus,statusCheckRollup \
+        --jq '
+          [ .[] | select(.isDraft | not)
+            | select([ .labels[]?.name ] | any(. == "awaiting-decision") | not)
+            | select(.mergeStateStatus != "DIRTY")
+            | select(((now - (.createdAt | fromdate)) / 86400) >= 1)
+            | select(
+                ([ .statusCheckRollup[]? | (.conclusion // .state // "PENDING") | ascii_upcase ])
+                | (length > 0 and all(. == "SUCCESS" or . == "SKIPPED" or . == "NEUTRAL"))
+              )
+          ] | length
+        ' 2>/dev/null || echo 0)"
+  stranded=$((stranded + n))
+  echo
+done
+
+if [ "$stranded" -gt 0 ]; then
+  echo "green-pr-sweep: ⚠ ${stranded} PR(s) look STRANDED (green, mergeable, ≥1 day old)."
+  echo "                Merge them, or say in the PR why they wait — finished work"
+  echo "                sitting unmerged is how fixed bugs ship live (see PR #643)."
+else
+  echo "green-pr-sweep: ✓ no stranded PRs."
+fi


### PR DESCRIPTION
## Summary

Implements the P2 (fix-PR pipeline) items from the 2026-07-11 improvement plan. Process/docs + one advisory script — no compiler code touched.

## Why

Two audits this month showed the bug pipeline leaks at the *last* stages, not in the finding:
- PR #643's fix sat unmerged for a week while its bug (invalid-SV `W'd5`) shipped live, until it was re-discovered and re-fixed (#652).
- 3 of 5 issues in the correctness backlog were phantoms: #437 and #462 were already fixed by PRs that never said `closes #N` (#438, 4f0a8fa), and #557's reported symptom was fixed while its flip-side soundness hole went unnoticed.

## Changes

- **CLAUDE.md — new "Fix-PR lifecycle" section**: `closes #N` required on fix PRs; same-day review-or-merge for live-miscompile fixes (or label `awaiting-decision` with a reason); re-reproduce on fresh main before working a backlog issue; run the sweep in every review session.
- **scripts/green_pr_sweep.sh**: lists open PRs with CI verdict / mergeability / age across arch-com + harc-com and flags green+mergeable+≥1-day-old ones as STRANDED. PRs labeled `awaiting-decision` show as PARKED. Advisory only — never merges. Mirror image of `claim_check.sh`.
- Created the `awaiting-decision` label in both repos and applied it to PR #642 (decision-gated proposal), so the sweep starts clean.

Verified: script runs against both repos (`#642 GREEN CLEAN 12d PARKED`, no stranded PRs), `bash -n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)