### PR TITLE
ci: nightly dual-backend equivalence sweep (closes #244)

### DIFF
--- a/.github/workflows/nightly-equivalence.yml
+++ b/.github/workflows/nightly-equivalence.yml
@@ -1,0 +1,111 @@
+name: nightly-equivalence
+
+# Dual-backend (SV+Verilator vs native arch sim) equivalence sweep.
+# Closes #244: this schedules the EXISTING backend-equivalence machinery
+# (tools/run_arch_regression.py + tests/backend_equiv/run.sh) on a nightly
+# cadence instead of only ad hoc on developer machines. It does not invent
+# a new comparison framework.
+#
+# See scripts/nightly_equivalence.py for the glue: it runs the broad
+# regression gate (check -> build -> Verilator lint -> arch sim, with real
+# C++ TBs for units in tests/arch_sim_manifest.json) under bounded
+# parallelism, then serially re-runs anything that failed once before
+# reporting a real divergence — Verilator is known to be flaky under
+# parallel load ("Broken pipe" class failures), so a nightly that reports
+# every transient blip as red gets ignored.
+
+on:
+  schedule:
+    # 09:00 UTC nightly.
+    - cron: '0 9 * * *'
+  workflow_dispatch: {}
+
+concurrency:
+  group: nightly-equivalence-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  equivalence-sweep:
+    name: dual-backend equivalence sweep
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry and build artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: nightly-equiv-cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            nightly-equiv-cargo-${{ runner.os }}-
+
+      - name: Install Verilator (apt)
+        id: apt_verilator
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq verilator
+          echo "version=$(verilator --version | awk '{print $2}')" >> "$GITHUB_OUTPUT"
+
+      - name: Check Verilator version
+        id: verilator_check
+        run: |
+          ver="${{ steps.apt_verilator.outputs.version }}"
+          major="${ver%%.*}"
+          echo "apt-provided Verilator: $ver"
+          if [ "${major:-0}" -ge 5 ]; then
+            echo "ok=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "ok=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Fallback path if a future ubuntu-latest image regresses to a <5.x
+      # apt package: build and cache a known-good Verilator release. This
+      # step is skipped entirely while apt keeps providing 5.x (the common
+      # case today), so it costs nothing on the happy path.
+      - name: Cache built Verilator (fallback)
+        if: steps.verilator_check.outputs.ok != 'true'
+        id: cache_verilator_build
+        uses: actions/cache@v4
+        with:
+          path: /opt/verilator-built
+          key: verilator-build-v5.034-${{ runner.os }}
+
+      - name: Build Verilator from source (fallback)
+        if: steps.verilator_check.outputs.ok != 'true' && steps.cache_verilator_build.outputs.cache-hit != 'true'
+        run: |
+          sudo apt-get install -y -qq git make autoconf g++ flex bison ccache \
+            libgoogle-perftools-dev numactl perl-doc libfl2 libfl-dev zlibc zlib1g zlib1g-dev
+          git clone --depth 1 --branch v5.034 https://github.com/verilator/verilator /tmp/verilator-src
+          cd /tmp/verilator-src
+          autoconf
+          ./configure --prefix=/opt/verilator-built
+          make -j"$(nproc)"
+          sudo make install PREFIX=/opt/verilator-built
+
+      - name: Use fallback Verilator on PATH (fallback)
+        if: steps.verilator_check.outputs.ok != 'true'
+        run: echo "/opt/verilator-built/bin" >> "$GITHUB_PATH"
+
+      - name: Verilator version (final)
+        run: verilator --version
+
+      - name: Build arch (release)
+        run: cargo build --release
+
+      - name: Run nightly dual-backend equivalence sweep
+        run: python3 scripts/nightly_equivalence.py --jobs 2
+
+      - name: Upload scratch logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: nightly-equivalence-logs
+          path: /tmp/arch-nightly-equiv-*/
+          retention-days: 7

--- a/scripts/nightly_equivalence.py
+++ b/scripts/nightly_equivalence.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""Nightly dual-backend equivalence sweep glue (closes #244).
+
+Reuses the existing broad backend gate (`tools/run_arch_regression.py`,
+which for every unit runs `arch check` -> `arch build` -> Verilator lint on
+the emitted SV -> `arch sim` — a real C++ testbench run when the unit has an
+entry in `tests/arch_sim_manifest.json`, giving true behavioral coverage of
+both the SV and native-sim backends for those units) plus the dedicated
+`tests/backend_equiv/` torture-fixture suite (Vec<Bus>+thread+generate+param
+interaction fixtures, each a `check`/`build`/`sim` pass across both
+backends).
+
+This script does not invent a new comparison framework; it schedules the
+existing ones and adds flake-hardening on top of `run_arch_regression.py`:
+bounded parallelism for the main sweep, then one automatic *serial* re-run
+of anything that failed before it is reported as a real divergence. The
+known failure mode (documented in harc-com, same class applies here) is
+transient Verilator failures ("Broken pipe" and friends) under parallel
+load — a single random fixture going red per run. A serial re-run absorbs
+that class; anything still red after the retry is a real regression.
+
+Writes a GitHub Actions job summary (if GITHUB_STEP_SUMMARY is set) listing
+which fixtures diverged for real vs. which were flaky and passed on retry,
+so a red night is actionable without downloading logs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def run(cmd: list[str], **kwargs) -> subprocess.CompletedProcess:
+    print(f"[run] {' '.join(cmd)}", flush=True)
+    return subprocess.run(cmd, **kwargs)
+
+
+def load_summary(work_dir: Path) -> dict:
+    return json.loads((work_dir / "summary.json").read_text())
+
+
+def failed_unit_names(summary: dict) -> list[str]:
+    return sorted(
+        r["name"]
+        for r in summary["results"]
+        if r["status"] not in {"pass", "skip_check_failed"}
+    )
+
+
+def write_retry_baseline(path: Path, names: list[str]) -> None:
+    payload = {"units": [{"name": n} for n in names]}
+    path.write_text(json.dumps(payload, indent=2) + "\n")
+
+
+def append_summary(lines: list[str]) -> None:
+    text = "\n".join(lines) + "\n"
+    print(text)
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_path:
+        with open(summary_path, "a") as f:
+            f.write(text)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--jobs", type=int, default=2, help="Parallelism for the main sweep (bounded to survive Verilator flakiness under load).")
+    parser.add_argument("--work-dir", type=Path, default=None, help="Scratch dir; defaults to a fresh tempdir.")
+    parser.add_argument("--baseline", type=Path, default=Path("tests/arch_regression_baseline.json"))
+    parser.add_argument("--sim-manifest", type=Path, default=Path("tests/arch_sim_manifest.json"))
+    parser.add_argument("--skip-backend-equiv", action="store_true", help="Skip tests/backend_equiv/run.sh (for quick local smoke checks).")
+    parser.add_argument("--pattern", action="append", default=[], help="Restrict run_arch_regression.py to matching unit paths (repeatable). Useful for a fast local smoke run.")
+    args = parser.parse_args()
+
+    root = repo_root()
+    work_dir = args.work_dir or Path(tempfile.mkdtemp(prefix="arch-nightly-equiv-"))
+    work_dir.mkdir(parents=True, exist_ok=True)
+    arch_bin = root / "target" / "release" / "arch"
+
+    summary_lines = ["# Nightly dual-backend equivalence sweep", ""]
+
+    # --- Main sweep: bounded parallelism ---
+    main_cmd = [
+        sys.executable,
+        str(root / "tools" / "run_arch_regression.py"),
+        "--arch-bin", str(arch_bin),
+        "--work-dir", str(work_dir / "main"),
+        "--jobs", str(args.jobs),
+        "--sim-manifest", str(args.sim_manifest),
+        "--allow-failures",  # we triage failures ourselves below
+    ]
+    # --pattern narrows discovery for a fast local smoke run; the baseline
+    # (grouped-directory unit names) doesn't line up with raw file globs, so
+    # skip it in that mode. Full nightly runs use the baseline as intended.
+    if args.pattern:
+        for pat in args.pattern:
+            main_cmd += ["--pattern", pat]
+    else:
+        main_cmd += ["--baseline", str(args.baseline)]
+    proc = run(main_cmd, cwd=root)
+    main_summary = load_summary(work_dir / "main")
+    total_units = len(main_summary["results"])
+    first_failures = failed_unit_names(main_summary)
+
+    real_failures: list[str] = []
+    flaky_passed: list[str] = []
+
+    if first_failures:
+        print(f"[nightly] {len(first_failures)}/{total_units} unit(s) failed on first pass; retrying serially to filter flakes", flush=True)
+        retry_baseline = work_dir / "retry_baseline.json"
+        write_retry_baseline(retry_baseline, first_failures)
+        retry_cmd = [
+            sys.executable,
+            str(root / "tools" / "run_arch_regression.py"),
+            "--arch-bin", str(arch_bin),
+            "--work-dir", str(work_dir / "retry"),
+            "--jobs", "1",
+            "--baseline", str(retry_baseline),
+            "--sim-manifest", str(args.sim_manifest),
+            "--allow-failures",
+        ]
+        run(retry_cmd, cwd=root)
+        retry_summary = load_summary(work_dir / "retry")
+        still_failing = set(failed_unit_names(retry_summary))
+        for name in first_failures:
+            if name in still_failing:
+                real_failures.append(name)
+            else:
+                flaky_passed.append(name)
+    else:
+        print(f"[nightly] all {total_units} units passed on first pass, no retry needed", flush=True)
+
+    # --- Dedicated equivalence torture fixtures ---
+    backend_equiv_ok = True
+    backend_equiv_out = ""
+    if not args.skip_backend_equiv:
+        be = run(
+            ["bash", "./run.sh"],
+            cwd=root / "tests" / "backend_equiv",
+            env={**os.environ, "ARCH": str(arch_bin)},
+            capture_output=True,
+            text=True,
+        )
+        backend_equiv_out = be.stdout + be.stderr
+        print(backend_equiv_out)
+        backend_equiv_ok = be.returncode == 0
+
+    # --- Summary ---
+    summary_lines.append(f"Main sweep: {total_units} unit(s), jobs={args.jobs}, baseline={args.baseline}")
+    summary_lines.append("")
+    if real_failures:
+        summary_lines.append(f"## Real divergences ({len(real_failures)}) — failed on first pass AND serial retry")
+        summary_lines.append("")
+        summary_lines.append("| Unit | Failed step |")
+        summary_lines.append("|---|---|")
+        by_name = {r["name"]: r for r in load_summary(work_dir / "retry")["results"]}
+        for name in real_failures:
+            result = by_name.get(name, {})
+            steps = [s for s in result.get("steps", []) if s["status"] not in {"pass", "skip"}]
+            step_name = steps[-1]["name"] if steps else "runner"
+            summary_lines.append(f"| `{name}` | {step_name} |")
+        summary_lines.append("")
+    else:
+        summary_lines.append("No real divergences in the main sweep.")
+        summary_lines.append("")
+
+    if flaky_passed:
+        summary_lines.append(f"## Flaky (passed on serial retry) ({len(flaky_passed)})")
+        summary_lines.append("")
+        summary_lines.append("These failed under `--jobs {}` on the first pass but passed when re-run serially — ".format(args.jobs))
+        summary_lines.append("consistent with known Verilator-under-parallel-load flakiness, not a real regression.")
+        summary_lines.append("")
+        for name in flaky_passed:
+            summary_lines.append(f"- `{name}`")
+        summary_lines.append("")
+
+    summary_lines.append("## backend_equiv torture fixtures")
+    summary_lines.append("")
+    summary_lines.append("PASS" if backend_equiv_ok else "FAIL — see job log for `tests/backend_equiv/run.sh` output")
+    summary_lines.append("")
+
+    append_summary(summary_lines)
+
+    ok = not real_failures and backend_equiv_ok
+    if not ok:
+        print("[nightly] FAILED: real divergence(s) found or backend_equiv fixtures broken", file=sys.stderr)
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/nightly-equivalence.yml`: a nightly cron (09:00 UTC) + `workflow_dispatch` job that builds `arch` fresh and runs the dual-backend equivalence sweep. Closes #244.
- Adds `scripts/nightly_equivalence.py`: the glue script. It does **not** invent a new comparison framework — it schedules and hardens the existing machinery:
  - `tools/run_arch_regression.py` (the broad backend gate documented in `doc/arch_regression_runner.md`): for every unit in `tests/arch_regression_baseline.json` (185 grouped units spanning `tests/`) it runs `arch check` → `arch build` → Verilator lint on the emitted SV → `arch sim`. For the 16 units listed in `tests/arch_sim_manifest.json` this is a **real behavioral run** against a hand-written C++ testbench (true dual-backend coverage: SV-via-Verilator-lint + native-sim-via-real-TB on the same design); the rest get a generated-C++-compiles smoke check on the sim side.
  - `tests/backend_equiv/run.sh`: the dedicated Vec\<Bus\>+thread+generate+param-width torture-fixture suite (16 fixtures) that stacks the compiler's load-bearing composition axes and already exercises check/build/sim across both backends.

  I investigated `harc sim --check-backends` (the true per-cycle SV-vs-sim trace-diff tool referenced in code comments) — that flag lives in the harc-com repo, not here, so it's out of scope for an arch-com-only workflow. `tools/vcd_diff.py` exists as a standalone VCD comparator but nothing in-repo currently wires it into an automated broad sweep, so I left it alone rather than build new wiring under a "reuse aggressively" mandate.

## Verilator sourcing

- Primary: apt (`ubuntu-latest` currently ships Verilator 5.x — locally I have 5.048, and Ubuntu 24.04's `verilator` apt package is 5.020+, comfortably satisfying the `--assert`/SVA features this repo's CLAUDE.md calls out).
- The workflow checks the apt-installed major version and only falls back to building+caching Verilator v5.034 from source (via `actions/cache`, keyed on `verilator-build-v5.034-<os>`) if apt ever regresses below 5.x. That fallback path is untested in this PR (apt provides 5.x today) but is there so a future ubuntu-latest image bump can't silently break the job.
- iverilog is not used by the reused harness, so no sourcing concern there.

## Flake hardening (P3 requirement)

- Main sweep runs with bounded parallelism (`--jobs 2`) to reduce the known "Broken pipe" / random-fixture-red failure mode under parallel Verilator load.
- Any unit that fails on the first pass is automatically re-run **serially** (`--jobs 1`) via a small retry baseline (unit-name intersection against `run_arch_regression.py --baseline`). Only units that fail on *both* passes are reported as real divergences; units that pass on retry are reported separately as "flaky, passed on retry."
- `GITHUB_STEP_SUMMARY` gets a markdown report distinguishing "real divergences" (with the specific failing step) from "flaky" units and the `backend_equiv` pass/fail — a red night is actionable without downloading logs.

## Validated locally

- `cargo build --release` — clean build.
- `python3 scripts/nightly_equivalence.py --jobs 2 --pattern 'cam_*.arch' --pattern 'if_wait_for_in_then*'` — smoke run over 5 real units (including 2 manifest-TB behavioral units), all pass, correct summary output, exit 0.
- Retry-triage logic unit-tested directly (`failed_unit_names`/`write_retry_baseline`), then end-to-end with a shadowed broken `verilator` binary on `PATH`: first pass fails, serial retry correctly re-fails, script reports it as a real divergence in the markdown summary and exits 1.
- `tests/backend_equiv/run.sh` run standalone: 16/16 pass.

**Deferred to CI** (not practical to validate locally): the full 185-unit baseline sweep end-to-end (multi-minute run, and I didn't want to burn the local machine reproducing GitHub Actions' exact runner environment), the apt-Verilator-version-on-ubuntu-latest assumption, and the source-build fallback path.

## Test plan

- [ ] Confirm the `nightly-equivalence` workflow run (triggered via `workflow_dispatch` on this branch) completes and produces a sane `GITHUB_STEP_SUMMARY`.
- [ ] Confirm apt-provided Verilator on `ubuntu-latest` is detected as ≥5.x (fallback path should not trigger).
- [ ] After merge, first scheduled nightly run on `main` should be green (or produce an actionable summary if not).

🤖 Generated with [Claude Code](https://claude.com/claude-code)