### PR TITLE
ci: add cargo test + clippy PR gates (P3 hardening)

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -26,8 +26,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+      # `cargo clippy` resolves the toolchain via rust-toolchain.toml's pin
+      # (1.94.0), overriding whatever toolchain the action installs — so the
+      # installed toolchain must match that pin and carry the clippy
+      # component, same as rustfmt.yml does for rustfmt.
+      - name: Install pinned Rust toolchain + clippy
+        uses: dtolnay/rust-toolchain@1.94.0
         with:
           components: clippy
 

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -1,0 +1,46 @@
+name: clippy
+
+# Errors-only clippy gate: fails only on deny-by-default lints (e.g.
+# `clippy::never_loop`), which are always real bugs. Does NOT run with
+# `-D warnings` — as of this workflow's introduction the tree carries ~200
+# pre-existing warn-level warnings (185 in the lib, 6 in the `arch` bin, 11 in
+# tests/integration_test.rs; see the PR description that introduced this
+# workflow for the full count). Promoting to `-D warnings` is tracked as a
+# follow-up once that backlog is cleaned up incrementally — see the PR body
+# for the plan. Until then this job only guards against new deny-level
+# regressions, which `cargo clippy` catches without any extra flags.
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: clippy-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  clippy:
+    name: cargo clippy (errors only)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - name: Cache cargo build
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: cargo-clippy-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            cargo-clippy-${{ runner.os }}-
+
+      - name: cargo clippy --release --all-targets
+        run: cargo clippy --release --all-targets

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -48,8 +48,9 @@ jobs:
       - name: cargo build --release
         run: cargo build --release
 
-      - name: cargo test --release
-        run: cargo test --release
+      # `cargo test --release` runs unconditionally in the `test` workflow
+      # (.github/workflows/test.yml) on every PR/push, so it is not repeated
+      # here — this job only needs the release binary for the sim sweep below.
 
       - name: Run sim sweep (parallel)
         # `--keep` preserves the per-test work dirs even on success so the

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,57 @@
+name: test
+
+# The main correctness gate: builds the compiler and runs the full `cargo
+# test` suite. Runs on every PR and every push to main (no path filter) so it
+# can be safely wired up as a required status check — a path-filtered
+# workflow never reports on PRs outside its filter, which would leave a
+# required check permanently pending on e.g. docs-only PRs.
+#
+# Dependency policy: the runner does NOT install verilator, iverilog, z3, the
+# Lean/lake toolchain, or pybind11. Every test that shells out to one of
+# those tools already skip-cleanly (eprintln + early return) when the tool is
+# absent from PATH — see tests/common/mod.rs and the `skipping: ... not
+# found` guards throughout tests/integration_test.rs and tests/fp_test.rs.
+# This matches the existing convention in examples.yml, which also runs
+# `cargo test --release` without installing any of those tools. Leaving them
+# uninstalled keeps the gate fast and avoids new flakiness from pinning
+# distro-packaged versions of large external tools; it trades away some
+# coverage (Verilator/iverilog parity legs, z3 differential/SMT proofs, Lean
+# proof-replay tests) that already runs on contributor/agent machines with
+# those tools installed. If reviewers want that coverage in CI, it belongs in
+# a slower opt-in/nightly tier, not this PR gate.
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: test-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  cargo-test:
+    name: cargo test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo build
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: cargo-test-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            cargo-test-${{ runner.os }}-
+
+      - name: cargo build --release
+        run: cargo build --release
+
+      - name: cargo test --release
+        run: cargo test --release

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -3819,10 +3819,10 @@ impl<'a> TypeChecker<'a> {
                     local_types,
                 );
                 // Return type from first non-wildcard arm
-                for arm in arms {
-                    return self.resolve_expr_type(&arm.value, module_name, local_types);
+                match arms.first() {
+                    Some(arm) => self.resolve_expr_type(&arm.value, module_name, local_types),
+                    None => Ty::Error,
                 }
-                Ty::Error
             }
             ExprKind::Concat(parts) => {
                 // Total width = sum of each part's width (Bool=1, UInt<N>=N, else 1)


### PR DESCRIPTION
## Summary

Adds the two CI gates called out in the P3 hardening workstream: a `cargo test` PR gate and an errors-only `clippy` gate. Also does a small amount of housekeeping to keep the new gate from duplicating existing CI work.

- **New `.github/workflows/test.yml`** — `cargo build --release` + `cargo test --release`, triggered on every PR and every push to `main` with **no path filter**. This is deliberate: a path-filtered workflow never reports on PRs it doesn't match, which leaves a required status check permanently "expected" on e.g. docs-only PRs. Uses `actions/cache` on `~/.cargo/registry`, `~/.cargo/git`, and `target` (same pattern as the existing `examples.yml`).
- **New `.github/workflows/clippy.yml`** — `cargo clippy --release --all-targets`, same trigger/caching shape.
- **`.github/workflows/examples.yml`** — removed its embedded `cargo test --release` step (kept `cargo build --release`, which the sim sweep still needs) since `test.yml` now owns that unconditionally; avoids running the full test suite twice on every `src/**`-touching PR.
- **`src/typecheck.rs`** — fixed the pre-existing `clippy::never_loop` deny-by-default error in `ExprMatch` type resolution (`for arm in arms { return ...; }` always returned on the first iteration, so the loop was dead code hiding a bug-shaped construct). Restructured to `match arms.first() { Some(arm) => ..., None => Ty::Error }`. **Behavior-preserving** — the old loop never iterated past the first arm regardless of its contents, identical to `arms.first()`; this is an internal codegen/typecheck-internals fix with zero surface-visible semantic change, per repo policy for autonomous compiler-bug fixes.

## Task 1 — cargo test gate: dependency handling

Ran the full suite locally first (`cargo test --release`, 8-core Apple Silicon):

- **711** integration tests, **50** lib unit tests, **16** fp tests, **23** formal tests — all pass except 2.
- The 2 failures are `formal_test.rs::construct_proof_lean_finds_home_elan_when_lake_not_on_path` and `construct_proof_lean_non_power_two_fifo_catches_depth_wrap_bug`. Root cause: these tests already skip cleanly (`eprintln!("skipping: ~/.elan/bin/lake not installed")`) when `~/.elan/bin/lake` is absent from `$HOME` — but on *this* dev/agent worktree, Lean/elan happens to be installed globally at `~/.elan`, while the worktree-local `proofs/lean_thread_lowering/.lake/build` artifact (gitignored) hasn't been built, so the tests find `lake` but the replay fails to resolve the `ArchConstructProof` module. This is a known fresh-worktree artifact (documented in CLAUDE.md), **not a CI concern**: GitHub's `ubuntu-latest` runners have no Lean/elan installed at all, so `~/.elan/bin/lake` won't exist and both tests will self-skip via their existing guard. Verified the rest of the suite is 100% green with only those two excluded (`--skip <name>` locally): **021 formal + 16 fp + 711 integration + 50 lib, 0 failures**.
- **No extra tools are installed in CI** — verilator, iverilog, z3, Lean/lake, and pybind11 are all left uninstalled, matching the existing convention already established by `examples.yml` (which also runs `cargo test --release` without installing any of them). Every test that shells out to one of these tools has an existing skip-if-missing guard (see `tests/common/mod.rs`, and the `"skipping: ... not found"` checks scattered through `tests/integration_test.rs` / `tests/fp_test.rs`). This is a deliberate choice over apt-installing verilator/iverilog/z3: it keeps the gate's behavior identical to the already-proven-green `examples.yml` job, avoids new flakiness from distro-packaged tool versions, and keeps runtime down. Coverage that only runs with those tools present (Verilator/iverilog parity legs, z3 differential/SMT equivalence proofs, Lean proof-replay) is **not exercised by this gate** — logging that here per the "no silent coverage claims" instruction. If reviewers want that coverage in CI, it belongs in a separate, slower opt-in/nightly tier, not this PR-blocking gate.
- **Timing**: full suite (all tests, tools present) took **~5m30s** wall locally (`cargo build --release` ~55s–1m22s cold, `cargo test --release` ~5m29s, dominated by `fp_test.rs`'s z3-based SMT equivalence proofs at ~268-382s — which won't even run in CI since z3 isn't installed there, so CI should be meaningfully faster than the local number). This is comfortably inside the ~15 min time-box, so the full suite lands in this gate with nothing deferred to a nightly tier for now. If CI turns out slower than expected (shared/2-core runners, cache misses), the `fp_test.rs` SMT-proof tests are the obvious first candidate to carve out.

## Task 2 — clippy gate: warning count and gate level

- `cargo clippy --release --all-targets` (before the fix): **1 deny-by-default error** (`clippy::never_loop` in `typecheck.rs`, fixed above) + **185 warnings in the lib**, **6 in the `arch` bin**, **11 in `tests/integration_test.rs`** (~200 total unique warnings; `fp_test.rs`/`formal_test.rs` targets were clean).
- ~200 is well past the "≤30, fix them all" threshold, so per the task's pragmatic split: **gate on errors-only** (`cargo clippy --release --all-targets`, no `-D warnings`). Deny-by-default lints like `never_loop` already fail the build without any extra flag — verified locally (`echo $?` after the plain command was `1` before the fix, `0` after). This catches new deny-level regressions without requiring a ~200-warning cleanup in this PR.
- **Follow-up** (not done here): promote to `cargo clippy --all-targets -- -D warnings` once the existing warning backlog is cleaned up incrementally. Tracked as a comment in `clippy.yml`.

## Task 3 — skill-snapshot enforcement investigation (report only)

- The `skill-snapshots` workflow (`.github/workflows/skill-snapshots.yml`) itself **is** a real enforcement check: it runs `scripts/sync_skill_snapshots.sh check`, which does `exit 1` on any drift between a source doc and its bundled skill snapshot. This is not a soft-pass — a drifted snapshot makes the job fail red on the PR.
- The gap is **branch protection**, not the workflow: `gh api repos/arch-hdl-lang/arch-com/branches/main/protection` returns **404 "Branch not protected"** — `main` currently has **no branch protection configured at all**. That means *none* of the existing checks (`rustfmt`, `examples`, `cla`, `skill-snapshots`, and now `test`/`clippy` from this PR) are required status checks; a PR can be merged regardless of their outcome.
- **No code change needed for this** — it's a repo settings change only the maintainer can apply (Settings → Branches → branch protection rule for `main` → "Require status checks to pass before merging"). See job names below for what to select.

## Job names for branch protection

- `test / cargo test`
- `clippy / cargo clippy (errors only)`
- (pre-existing, for reference) `rustfmt / cargo fmt --check`, `examples / examples/run_sims.sh`, `skill-snapshots / skill snapshots in sync`

## Test plan

- [x] `cargo build --release` — clean
- [x] `cargo test --release` — 021 formal (2 skip-if-CI, self-skip via existing guard) + 16 fp + 711 integration + 50 lib, all green
- [x] `cargo fmt --all --check` — clean
- [x] `cargo clippy --release --all-targets` — exit 0, no deny-level errors (was failing before the `never_loop` fix)
- [x] YAML sanity-checked with `python3 -c "import yaml; yaml.safe_load(...)"` for all 3 touched/added workflow files
- [ ] Watch `gh pr checks` on this PR itself — the new `test`/`clippy` workflows exercising themselves for the first time is the real end-to-end validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)