### PR TITLE
ci(nightly): drop nonexistent zlibc from Verilator source-build deps

### DIFF
--- a/.github/workflows/nightly-equivalence.yml
+++ b/.github/workflows/nightly-equivalence.yml
@@ -81,7 +81,7 @@ jobs:
         if: steps.verilator_check.outputs.ok != 'true' && steps.cache_verilator_build.outputs.cache-hit != 'true'
         run: |
           sudo apt-get install -y -qq git make autoconf g++ flex bison ccache \
-            libgoogle-perftools-dev numactl perl-doc libfl2 libfl-dev zlibc zlib1g zlib1g-dev
+            libgoogle-perftools-dev numactl perl-doc libfl2 libfl-dev zlib1g zlib1g-dev
           git clone --depth 1 --branch v5.034 https://github.com/verilator/verilator /tmp/verilator-src
           cd /tmp/verilator-src
           autoconf


### PR DESCRIPTION
Third nightly run reached the new Verilator source-build fallback (post-#674) and died at `apt-get install`: `E: Unable to locate package zlibc` — that package was dropped from Ubuntu after 18.04 (it lingers in old Verilator install docs). `zlib1g`/`zlib1g-dev` are sufficient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)