### PR TITLE
ci(nightly): add help2man to Verilator source-build deps

### DIFF
--- a/.github/workflows/nightly-equivalence.yml
+++ b/.github/workflows/nightly-equivalence.yml
@@ -88,7 +88,8 @@ jobs:
         if: steps.verilator_check.outputs.ok != 'true' && steps.cache_verilator_build.outputs.cache-hit != 'true'
         run: |
           sudo apt-get install -y -qq git make autoconf g++ flex bison ccache \
-            libgoogle-perftools-dev numactl perl-doc libfl2 libfl-dev zlib1g zlib1g-dev
+            help2man libgoogle-perftools-dev numactl perl-doc libfl2 libfl-dev \
+            zlib1g zlib1g-dev
           git clone --depth 1 --branch v5.034 https://github.com/verilator/verilator /tmp/verilator-src
           cd /tmp/verilator-src
           autoconf


### PR DESCRIPTION
Fourth nightly run: Verilator 5.034 compiled and linked successfully in the fallback (~5 min with ccache), but `make` exits 2 on the man-page target — `help2man: not found` (Error 127 at verilator_gantt.1). Add `help2man` to the apt dependency list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)