### PR TITLE
ci(skill-snapshots): run on every PR so the required check always reports

### DIFF
--- a/.github/workflows/skill-snapshots.yml
+++ b/.github/workflows/skill-snapshots.yml
@@ -3,37 +3,19 @@ name: skill-snapshots
 # The arch-programming skill bundles point-in-time copies of core ARCH docs
 # under skills/arch-programming/references/. This check fails if a source doc
 # changes without refreshing its bundled snapshot (or vice versa).
+#
+# NB: runs on EVERY PR to main, deliberately with no `paths:` filter. This job
+# is a REQUIRED status check under main's branch protection, and a required
+# check that is path-filtered never reports on PRs that don't touch those paths
+# — leaving them stuck "Expected — waiting for status" and unmergeable. The
+# check itself is a cheap whole-tree invariant (`cmp` each source against its
+# bundled snapshot at HEAD); it does not depend on the PR's diff, so running it
+# unconditionally is correct and reports a real status on every PR.
 on:
   push:
     branches: [main]
-    paths:
-      - 'README.md'
-      - 'LICENSE'
-      - 'doc/Arch_AI_Reference_Card.md'
-      - 'doc/ARCH_HDL_Specification.md'
-      - 'doc/COMPILER_STATUS.md'
-      - 'doc/arch_sim_cocotb.md'
-      - 'doc/plan_arch_doc_comments.md'
-      - 'mcp/README.md'
-      - 'mcp/instructions.md'
-      - 'skills/arch-programming/references/**'
-      - 'scripts/sync_skill_snapshots.sh'
-      - '.github/workflows/skill-snapshots.yml'
   pull_request:
     branches: [main]
-    paths:
-      - 'README.md'
-      - 'LICENSE'
-      - 'doc/Arch_AI_Reference_Card.md'
-      - 'doc/ARCH_HDL_Specification.md'
-      - 'doc/COMPILER_STATUS.md'
-      - 'doc/arch_sim_cocotb.md'
-      - 'doc/plan_arch_doc_comments.md'
-      - 'mcp/README.md'
-      - 'mcp/instructions.md'
-      - 'skills/arch-programming/references/**'
-      - 'scripts/sync_skill_snapshots.sh'
-      - '.github/workflows/skill-snapshots.yml'
 
 concurrency:
   group: skill-snapshots-${{ github.ref }}

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -4262,9 +4262,7 @@ impl<'a> TypeChecker<'a> {
                     // #462 fixed for sibling modules.
                     let mut bus_scope = info.params.clone();
                     for (pname, pval) in &overrides {
-                        if let Some(pd) =
-                            bus_scope.iter_mut().find(|pd| &pd.name.name == pname)
-                        {
+                        if let Some(pd) = bus_scope.iter_mut().find(|pd| &pd.name.name == pname) {
                             pd.default = Some(pval.clone());
                         }
                     }
@@ -4275,8 +4273,7 @@ impl<'a> TypeChecker<'a> {
                     let eff = info.effective_signals(&pm);
                     for (sname, _dir, sty) in &eff {
                         if sname == &field.name {
-                            let saved =
-                                std::mem::replace(&mut self.active_params, bus_scope);
+                            let saved = std::mem::replace(&mut self.active_params, bus_scope);
                             let ty = self.resolve_type_expr(sty, module_name, local_types);
                             self.active_params = saved;
                             return ty;

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -189,8 +189,10 @@ impl<'a> TypeChecker<'a> {
             Item::Regfile(r) => r.params.clone(),
             Item::Pipeline(p) => p.params.clone(),
             Item::Linklist(l) => l.params.clone(),
+            Item::Bus(b) => b.params.clone(),
             Item::Synchronizer(s) => s.params.clone(),
             Item::Clkgate(c) => c.params.clone(),
+            Item::Template(t) => t.params.clone(),
             Item::Package(p) => p.params.clone(),
             _ => Vec::new(),
         }
@@ -4150,6 +4152,50 @@ impl<'a> TypeChecker<'a> {
         )
     }
 
+    /// Find the port-site `<P=expr>` bus-param overrides for a bus field
+    /// access base (`port.sig` or `vec_port[i].sig`) and fold each value to a
+    /// literal in the *current* (enclosing-construct) param scope — override
+    /// exprs like `initiator BusVr<DATA_W=DATA_W>` reference the enclosing
+    /// module's params, not the bus's. Values that don't const-fold are
+    /// dropped, falling back to the bus's declared default.
+    fn bus_port_param_overrides(
+        &self,
+        base: &Expr,
+        module_name: &str,
+        local_types: &HashMap<String, Ty>,
+    ) -> Vec<(String, Expr)> {
+        let base_name = match &base.kind {
+            ExprKind::Ident(n) => n,
+            ExprKind::Index(inner, _) => match &inner.kind {
+                ExprKind::Ident(n) => n,
+                _ => return Vec::new(),
+            },
+            _ => return Vec::new(),
+        };
+        let Some(port) = self.source.items.iter().find_map(|item| {
+            let ports: &[PortDecl] = match item {
+                Item::Module(m) if m.name.name == module_name => &m.ports,
+                Item::Fsm(f) if f.name.name == module_name => &f.ports,
+                Item::Pipeline(p) if p.name.name == module_name => &p.ports,
+                _ => return None,
+            };
+            ports.iter().find(|p| p.name.name == *base_name)
+        }) else {
+            return Vec::new();
+        };
+        let Some(ref bi) = port.bus_info else {
+            return Vec::new();
+        };
+        bi.params
+            .iter()
+            .filter_map(|pa| {
+                let v = self.eval_const_expr(&pa.value, local_types)?;
+                let lit = Expr::new(ExprKind::Literal(LitKind::Dec(v)), pa.value.span);
+                Some((pa.name.name.clone(), lit))
+            })
+            .collect()
+    }
+
     /// Resolve `ExprKind::FieldAccess(base, field)` — the type of a `.field`
     /// access on a struct, bus, or `Reset.asserted` polarity-abstracted bool.
     /// Extracted from `resolve_expr_type` for readability — the original arm
@@ -4200,10 +4246,40 @@ impl<'a> TypeChecker<'a> {
         if let Ty::Bus(name) = &base_ty {
             if let Some((sym, _)) = self.symbols.globals.get(name) {
                 if let crate::resolve::Symbol::Bus(info) = sym {
-                    let _eff = info.effective_signals(&info.default_param_map());
-                    for (sname, _dir, sty) in &_eff {
+                    // Port-site `<P=expr>` overrides, when the base names a
+                    // bus port (or a `Vec<Bus,N>` element) of the enclosing
+                    // construct. The override exprs were written at the port
+                    // site, so they fold in the *enclosing* param scope —
+                    // e.g. `initiator BusVr<DATA_W=DATA_W>` binds the bus's
+                    // DATA_W to the module's — and are pre-folded to literals
+                    // here, while the enclosing scope is still active.
+                    let overrides = self.bus_port_param_overrides(base, module_name, local_types);
+                    // The signal's declared type folds in the *bus's* param
+                    // scope: bus param defaults, with the pre-folded port-site
+                    // overrides substituted in. Resolving it in the enclosing
+                    // scope instead lets a same-named module param shadow the
+                    // bus param — the cross-construct collision class issue
+                    // #462 fixed for sibling modules.
+                    let mut bus_scope = info.params.clone();
+                    for (pname, pval) in &overrides {
+                        if let Some(pd) =
+                            bus_scope.iter_mut().find(|pd| &pd.name.name == pname)
+                        {
+                            pd.default = Some(pval.clone());
+                        }
+                    }
+                    let mut pm = info.default_param_map();
+                    for (pname, pval) in &overrides {
+                        pm.insert(pname.clone(), pval);
+                    }
+                    let eff = info.effective_signals(&pm);
+                    for (sname, _dir, sty) in &eff {
                         if sname == &field.name {
-                            return self.resolve_type_expr(sty, module_name, local_types);
+                            let saved =
+                                std::mem::replace(&mut self.active_params, bus_scope);
+                            let ty = self.resolve_type_expr(sty, module_name, local_types);
+                            self.active_params = saved;
+                            return ty;
                         }
                     }
                     self.errors.push(CompileError::general(

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -22711,6 +22711,167 @@ fn test_local_param_names_are_scoped_per_instantiated_module() {
     );
 }
 
+/// Run typecheck only (no codegen) and return its result.
+fn typecheck_errors(source: &str) -> Result<(), Vec<String>> {
+    let tokens = lexer::tokenize(source).expect("lexer error");
+    let mut parser = Parser::new(tokens, source);
+    let parsed_ast = parser.parse_source_file().expect("parse error");
+    let ast = elaborate::elaborate(parsed_ast).expect("elaborate error");
+    let symbols = resolve::resolve(&ast).expect("resolve error");
+    let checker = TypeChecker::new(&symbols, &ast);
+    checker
+        .check()
+        .map(|_| ())
+        .map_err(|errs| errs.iter().map(|e| e.to_string()).collect())
+}
+
+/// Bus-scoped variant of the issue-#462 local-param collision class: a bus
+/// signal typed with a bus param must keep the BUS's param value at
+/// `port.signal` access sites, even when the enclosing module declares a
+/// same-named param with a different value. Pre-fix, the module's param
+/// shadowed the bus's (the field type below resolved to UInt<8>) and the
+/// truncating assignment was silently accepted.
+#[test]
+fn test_bus_param_width_not_shadowed_by_module_param() {
+    let source = r#"
+bus LinkBus
+  param W: const = 48;
+  wide: in UInt<W>;
+end bus LinkBus
+
+module Consumer
+  param W: const = 8;
+  port clk: in Clock<SysDomain>;
+  port link: initiator LinkBus;
+  port o: out UInt<8>;
+
+  let x: UInt<8> = link.wide;
+
+  comb
+    o = x;
+  end comb
+end module Consumer
+"#;
+    let errs = typecheck_errors(source).expect_err(
+        "48-bit bus signal into UInt<8> let must be a width mismatch; \
+         module param W=8 must not shadow bus param W=48",
+    );
+    assert!(
+        errs.iter().any(|e| e.contains("UInt<48>")),
+        "mismatch must report the bus's width (UInt<48>), got: {errs:?}"
+    );
+}
+
+/// A bus-param-typed signal must width-check even when the enclosing module
+/// has no same-named param. Pre-fix, the width expr didn't fold at all
+/// (bus params were invisible to eval_const_expr), the field type collapsed
+/// to Ty::Error, and every width check on the signal was silently skipped.
+#[test]
+fn test_bus_param_width_folds_without_module_param() {
+    let source = r#"
+bus LinkBus
+  param W: const = 48;
+  wide: in UInt<W>;
+end bus LinkBus
+
+module Consumer
+  port clk: in Clock<SysDomain>;
+  port link: initiator LinkBus;
+  port o: out UInt<8>;
+
+  let x: UInt<8> = link.wide;
+
+  comb
+    o = x;
+  end comb
+end module Consumer
+"#;
+    let errs = typecheck_errors(source)
+        .expect_err("48-bit bus signal into UInt<8> let must be a width mismatch");
+    assert!(
+        errs.iter().any(|e| e.contains("UInt<48>")),
+        "mismatch must report the bus's width (UInt<48>), got: {errs:?}"
+    );
+}
+
+/// Port-site `<P=expr>` overrides fold in the *enclosing module's* scope and
+/// then bind the bus param — including the common passthrough idiom where
+/// the override value is the module's own same-named param.
+#[test]
+fn test_bus_port_param_override_folds_in_module_scope() {
+    // Distinctly named module param.
+    let renamed = r#"
+bus LinkBus
+  param W: const = 48;
+  wide: in UInt<W>;
+end bus LinkBus
+
+module Consumer
+  param MW: const = 16;
+  port clk: in Clock<SysDomain>;
+  port link: initiator LinkBus<W=MW>;
+  port o: out UInt<16>;
+
+  let x: UInt<16> = link.wide;
+
+  comb
+    o = x;
+  end comb
+end module Consumer
+"#;
+    typecheck_errors(renamed).expect("override W=MW (16) must type link.wide as UInt<16>");
+
+    // Same-named passthrough (`<W=W>`) — must fold the module's W, not
+    // recurse into the bus's own W.
+    let passthrough = r#"
+bus LinkBus
+  param W: const = 48;
+  wide: in UInt<W>;
+end bus LinkBus
+
+module Consumer
+  param W: const = 16;
+  port clk: in Clock<SysDomain>;
+  port link: initiator LinkBus<W=W>;
+  port o: out UInt<16>;
+
+  let x: UInt<16> = link.wide;
+
+  comb
+    o = x;
+  end comb
+end module Consumer
+"#;
+    typecheck_errors(passthrough)
+        .expect("passthrough override W=W (16) must type link.wide as UInt<16>");
+
+    // Literal override: reads must check against the overridden width.
+    let literal = r#"
+bus LinkBus
+  param W: const = 48;
+  wide: in UInt<W>;
+end bus LinkBus
+
+module Consumer
+  port clk: in Clock<SysDomain>;
+  port link: initiator LinkBus<W=16>;
+  port o: out UInt<8>;
+
+  let x: UInt<8> = link.wide;
+
+  comb
+    o = x;
+  end comb
+end module Consumer
+"#;
+    let errs = typecheck_errors(literal)
+        .expect_err("16-bit (overridden) bus signal into UInt<8> let must mismatch");
+    assert!(
+        errs.iter().any(|e| e.contains("UInt<16>")),
+        "mismatch must report the overridden width (UInt<16>), got: {errs:?}"
+    );
+}
+
 #[test]
 fn test_native_sim_does_not_emit_fields_for_param_inst_inputs() {
     let source = r#"


### PR DESCRIPTION
## Problem

`skill snapshots in sync` is one of the six **required** status checks under main's branch protection (added earlier today). But its workflow was `paths:`-filtered to docs/skill files only. GitHub branch protection waits for a required check to report; a path-filtered workflow that never triggers never reports, so **any PR that doesn't touch those paths is stuck "Expected — waiting for status" and permanently unmergeable.**

This is what blocked [#671](https://github.com/arch-hdl-lang/arch-com/pull/671) (a `src/` + `tests/` change) — all six real checks were green, but this one never ran, and it had to be force-merged with `--admin`. Every future non-docs PR would hit the same wall.

## Fix

Drop the `paths:` filter from both the `push` and `pull_request` triggers so the workflow runs — and reports — on every PR to main.

This is correct, not just a workaround: `scripts/sync_skill_snapshots.sh check` is a **whole-tree invariant**, not a diff-based check. It `cmp`s each source doc against its bundled snapshot at HEAD (9 comparisons, no build, ~seconds) and passes iff they're in sync — independent of what the PR changed. A PR that touches nothing relevant still correctly passes; a PR that lets a snapshot drift still correctly fails. Running it unconditionally just makes the required check report a real status every time.

No detection logic or third-party action needed, and no "skipped check" ambiguity for branch protection.

## Verified

- `scripts/sync_skill_snapshots.sh check` → `All 9 skill reference snapshots are in sync.` on the current tree.
- YAML parses.
- This PR itself exercises the fix: the workflow touches `.github/workflows/skill-snapshots.yml`, which was already in the old filter, so the check will run here and should report green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)