### PR TITLE
feat(lang): fma<pipelined, N> surface + latency typing (proposal phase 2)

### DIFF
--- a/doc/ARCH_HDL_Specification.md
+++ b/doc/ARCH_HDL_Specification.md
@@ -757,6 +757,103 @@ The rule is **uniform across all slots**: `let`, `init`, reset, port defaults, a
 
 **Compatibility profile.** `arch build|sim --fp-compat=riscv|cuda` (default `riscv`) selects the special-value corners. Both profiles share an identical RNE arithmetic core and differ only in the canonical NaN bit pattern (`0x7FC00000`/`0x7FC0` vs `0x7FFFFFFF`/`0x7FFF`) and the NaN→int result (type-max vs `0`).
 
+**3.8a Pipelined operators (`<pipelined, N>`)**
+
+The float builtins above (`fma`, and any future registry-backed operator) are
+combinational by default: `fma(a, b, c)` lowers to a single comb cone, correct
+but capped at whatever clock a same-cycle multiply-add-normalize datapath can
+close at. For operators the compiler has a *characterized, staged*
+implementation for, an explicit pipelined variant is available:
+
+```
+fma<pipelined, N>(a, b, c)
+```
+
+`pipelined` is a reserved keyword (shared with `pipeline` / `pipe_reg`); `N`
+is the declared pipeline depth, a **compile-time integer literal** (v1
+restriction — no const-param-resolvable expressions yet, matching
+`pipe_reg<T, N>`'s existing literal-only depth). The compiler looks up
+`(operator, type-profile, N)` in a built-in implementation registry; a miss
+is a hard error enumerating the depths that *do* exist for that operator/type
+pair:
+
+```
+error: no pipelined implementation of fma<FP32> with 5 stages
+  available depths: {6}      (run `arch ops` to list all)
+```
+
+Run `arch ops` (or `arch ops --pipelined`) to list every registered
+`(operator, profile, depth)` combination, its verification status, and its
+characterized fmax — the concrete set is intentionally kept out of this
+normative section (it churns as implementations are added) and lives in the
+generated `doc/generated/pipelined_ops.md` instead.
+
+**The call's depth is authoritative; the tap is a consistency check.** A
+`<pipelined, N>` call produces a value with latency `N` — it must be bound
+into a `pipe_reg<T, N>`-typed target via the matching `@N` tap, exactly like
+any other pipe_reg write:
+
+```
+port acc_out: out pipe_reg<FP32, 6>;
+seq on clk rising
+  acc_out@6 <= fma<pipelined, 6>(a, b, acc_in);
+end seq
+```
+
+The `6` in `<pipelined, 6>` is the single source of truth for the operator's
+latency — it is *not* inferred from the `pipe_reg` declaration or the `@N`
+tap. If the tap and the call disagree, it's an error naming both numbers:
+
+```
+acc_out@6 <= fma<pipelined, 4>(a, b, c);
+// error: latency-4 result bound at @6
+```
+
+An untapped (bare) target is likewise an error — a latency-`N` (`N > 0`)
+result has no cycle to land on without an explicit `@N`. And a `<pipelined,
+N>` call is rejected outright in a `comb` block or a `let` binding (both are
+always combinational, latency-0 contexts):
+
+```
+let x: FP32 = fma<pipelined, 6>(a, b, c);
+// error: `fma<pipelined, 6>(...)` produces a latency-6 result and cannot be
+//        used in a `let` binding (always combinational); bind it in a `seq`
+//        block via `target@6 <= fma<pipelined, 6>(...)`
+```
+
+**No auto-alignment (v1).** Combining operands that materialize at different
+cycle offsets in one expression — including a `<pipelined, N>` call's own
+arguments — is a compile error naming both cycles; there is no automatic
+delay-line insertion to align them. If you need aligned operands, tap each
+one explicitly at the same `@N` first:
+
+```
+let bad: FP32 = fadd(acc@6, x);   // error: operands at cycle 6 and cycle 0
+```
+
+**The delay-line trap.** `pipe_reg<T, N>` is a delay line — N flops shifting
+a *value* — not an operator retimer. Writing a bare comb call into a pipe_reg
+tap still compiles and is still correct (the flops just delay the comb
+result), but it does **not** distribute the operator's logic across the
+stages, so it does not get the pipelined variant's timing benefit. This is
+almost always a mistake, so the compiler warns (not errors — the form stays
+legal, matching existing `pipe_reg` delay-line semantics):
+
+```
+acc_out@6 <= fma(a, b, c);
+// warning: comb `fma` delayed 6 cycles via `@6`; did you mean
+//          `fma<pipelined, 6>(...)`?
+```
+
+**Codegen status.** As of this writing, `arch build` / `arch sim` accept
+`<pipelined, N>` through `arch check` (parsing, registry resolution, and all
+latency-typing rules above are fully enforced) but do not yet bind the call
+to a retimed staged datapath — `arch build`/`arch sim` refuse with an
+explicit "not yet implemented" error rather than silently falling back to an
+un-retimed comb cone. Landing the staged RTL and its sequential-equivalence
+proof is tracked separately; check `arch ops` / the compiler's release notes
+for current status.
+
 **4. Modules**
 
 A module is the fundamental unit of design in Arch. Every module follows the same four-section schema --- params, ports, body, optional verification. This regularity is intentional: an AI encountering any Arch construct can immediately orient itself using the same mental model.

--- a/doc/Arch_AI_Reference_Card.md
+++ b/doc/Arch_AI_Reference_Card.md
@@ -261,6 +261,18 @@ x.to_uint<N>()   // float→UInt<N>: toward-zero, per-N saturating, negatives/Na
 | `riscv` (default) | `0x7FC00000` / `0x7FC0` | type max |
 | `cuda` | `0x7FFFFFFF` / `0x7FFF` | `0` |
 
+**Pipelined operators (`<pipelined, N>`)** — `fma(a,b,c)` is combinational (latency 0). For a registry-backed staged implementation, declare the depth in the call: `fma<pipelined, N>(...)`. `N` is a compile-time integer literal, looked up against `(operator, profile, N)` in the compiler's builtin registry (`arch ops` lists what's registered). The call's depth is authoritative — bind the result into a matching `pipe_reg<T, N>` tap; a mismatch, an untapped target, or comb/`let` use is a compile error. No auto-alignment: combining a tapped and an untapped operand in one expression errors, naming both cycles.
+
+```
+port acc_out: out pipe_reg<FP32, 6>;
+seq on clk rising
+  acc_out@6 <= fma<pipelined, 6>(a, b, acc_in);  // 6 = declared depth, checked against @6
+end seq
+let s: FP32 = acc_out@6;                          // consumer reads at latency 6
+```
+
+`acc@6 <= fma(a,b,c)` (comb `fma` delayed via a pipe_reg tap, not `<pipelined, 6>`) still compiles — same values, just not retimed — but warns: *"did you mean `fma<pipelined, 6>(...)`?"*. Codegen for `<pipelined, N>` (binding to real staged RTL) is not yet implemented as of this writing — `arch check` accepts the surface, `arch build`/`arch sim` refuse explicitly rather than silently emitting an un-retimed comb cone.
+
 **Vec methods** (parallel-reduction; fully unrolled; no runtime iteration):
 
 ```

--- a/skills/arch-programming/references/ARCH_HDL_Specification.md
+++ b/skills/arch-programming/references/ARCH_HDL_Specification.md
@@ -757,6 +757,103 @@ The rule is **uniform across all slots**: `let`, `init`, reset, port defaults, a
 
 **Compatibility profile.** `arch build|sim --fp-compat=riscv|cuda` (default `riscv`) selects the special-value corners. Both profiles share an identical RNE arithmetic core and differ only in the canonical NaN bit pattern (`0x7FC00000`/`0x7FC0` vs `0x7FFFFFFF`/`0x7FFF`) and the NaN→int result (type-max vs `0`).
 
+**3.8a Pipelined operators (`<pipelined, N>`)**
+
+The float builtins above (`fma`, and any future registry-backed operator) are
+combinational by default: `fma(a, b, c)` lowers to a single comb cone, correct
+but capped at whatever clock a same-cycle multiply-add-normalize datapath can
+close at. For operators the compiler has a *characterized, staged*
+implementation for, an explicit pipelined variant is available:
+
+```
+fma<pipelined, N>(a, b, c)
+```
+
+`pipelined` is a reserved keyword (shared with `pipeline` / `pipe_reg`); `N`
+is the declared pipeline depth, a **compile-time integer literal** (v1
+restriction — no const-param-resolvable expressions yet, matching
+`pipe_reg<T, N>`'s existing literal-only depth). The compiler looks up
+`(operator, type-profile, N)` in a built-in implementation registry; a miss
+is a hard error enumerating the depths that *do* exist for that operator/type
+pair:
+
+```
+error: no pipelined implementation of fma<FP32> with 5 stages
+  available depths: {6}      (run `arch ops` to list all)
+```
+
+Run `arch ops` (or `arch ops --pipelined`) to list every registered
+`(operator, profile, depth)` combination, its verification status, and its
+characterized fmax — the concrete set is intentionally kept out of this
+normative section (it churns as implementations are added) and lives in the
+generated `doc/generated/pipelined_ops.md` instead.
+
+**The call's depth is authoritative; the tap is a consistency check.** A
+`<pipelined, N>` call produces a value with latency `N` — it must be bound
+into a `pipe_reg<T, N>`-typed target via the matching `@N` tap, exactly like
+any other pipe_reg write:
+
+```
+port acc_out: out pipe_reg<FP32, 6>;
+seq on clk rising
+  acc_out@6 <= fma<pipelined, 6>(a, b, acc_in);
+end seq
+```
+
+The `6` in `<pipelined, 6>` is the single source of truth for the operator's
+latency — it is *not* inferred from the `pipe_reg` declaration or the `@N`
+tap. If the tap and the call disagree, it's an error naming both numbers:
+
+```
+acc_out@6 <= fma<pipelined, 4>(a, b, c);
+// error: latency-4 result bound at @6
+```
+
+An untapped (bare) target is likewise an error — a latency-`N` (`N > 0`)
+result has no cycle to land on without an explicit `@N`. And a `<pipelined,
+N>` call is rejected outright in a `comb` block or a `let` binding (both are
+always combinational, latency-0 contexts):
+
+```
+let x: FP32 = fma<pipelined, 6>(a, b, c);
+// error: `fma<pipelined, 6>(...)` produces a latency-6 result and cannot be
+//        used in a `let` binding (always combinational); bind it in a `seq`
+//        block via `target@6 <= fma<pipelined, 6>(...)`
+```
+
+**No auto-alignment (v1).** Combining operands that materialize at different
+cycle offsets in one expression — including a `<pipelined, N>` call's own
+arguments — is a compile error naming both cycles; there is no automatic
+delay-line insertion to align them. If you need aligned operands, tap each
+one explicitly at the same `@N` first:
+
+```
+let bad: FP32 = fadd(acc@6, x);   // error: operands at cycle 6 and cycle 0
+```
+
+**The delay-line trap.** `pipe_reg<T, N>` is a delay line — N flops shifting
+a *value* — not an operator retimer. Writing a bare comb call into a pipe_reg
+tap still compiles and is still correct (the flops just delay the comb
+result), but it does **not** distribute the operator's logic across the
+stages, so it does not get the pipelined variant's timing benefit. This is
+almost always a mistake, so the compiler warns (not errors — the form stays
+legal, matching existing `pipe_reg` delay-line semantics):
+
+```
+acc_out@6 <= fma(a, b, c);
+// warning: comb `fma` delayed 6 cycles via `@6`; did you mean
+//          `fma<pipelined, 6>(...)`?
+```
+
+**Codegen status.** As of this writing, `arch build` / `arch sim` accept
+`<pipelined, N>` through `arch check` (parsing, registry resolution, and all
+latency-typing rules above are fully enforced) but do not yet bind the call
+to a retimed staged datapath — `arch build`/`arch sim` refuse with an
+explicit "not yet implemented" error rather than silently falling back to an
+un-retimed comb cone. Landing the staged RTL and its sequential-equivalence
+proof is tracked separately; check `arch ops` / the compiler's release notes
+for current status.
+
 **4. Modules**
 
 A module is the fundamental unit of design in Arch. Every module follows the same four-section schema --- params, ports, body, optional verification. This regularity is intentional: an AI encountering any Arch construct can immediately orient itself using the same mental model.

--- a/skills/arch-programming/references/Arch_AI_Reference_Card.md
+++ b/skills/arch-programming/references/Arch_AI_Reference_Card.md
@@ -261,6 +261,18 @@ x.to_uint<N>()   // float→UInt<N>: toward-zero, per-N saturating, negatives/Na
 | `riscv` (default) | `0x7FC00000` / `0x7FC0` | type max |
 | `cuda` | `0x7FFFFFFF` / `0x7FFF` | `0` |
 
+**Pipelined operators (`<pipelined, N>`)** — `fma(a,b,c)` is combinational (latency 0). For a registry-backed staged implementation, declare the depth in the call: `fma<pipelined, N>(...)`. `N` is a compile-time integer literal, looked up against `(operator, profile, N)` in the compiler's builtin registry (`arch ops` lists what's registered). The call's depth is authoritative — bind the result into a matching `pipe_reg<T, N>` tap; a mismatch, an untapped target, or comb/`let` use is a compile error. No auto-alignment: combining a tapped and an untapped operand in one expression errors, naming both cycles.
+
+```
+port acc_out: out pipe_reg<FP32, 6>;
+seq on clk rising
+  acc_out@6 <= fma<pipelined, 6>(a, b, acc_in);  // 6 = declared depth, checked against @6
+end seq
+let s: FP32 = acc_out@6;                          // consumer reads at latency 6
+```
+
+`acc@6 <= fma(a,b,c)` (comb `fma` delayed via a pipe_reg tap, not `<pipelined, 6>`) still compiles — same values, just not retimed — but warns: *"did you mean `fma<pipelined, 6>(...)`?"*. Codegen for `<pipelined, N>` (binding to real staged RTL) is not yet implemented as of this writing — `arch check` accepts the surface, `arch build`/`arch sim` refuse explicitly rather than silently emitting an un-retimed comb cone.
+
 **Vec methods** (parallel-reduction; fully unrolled; no runtime iteration):
 
 ```

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1154,6 +1154,17 @@ pub enum ExprKind {
     Unsigned(Box<Expr>),
     /// Pure combinational function call: Name(arg, ...)
     FunctionCall(String, Vec<Expr>),
+    /// Pipelined-operator call: `Name<pipelined, N>(arg, ...)` — proposal
+    /// `doc/proposal_pipelined_operators.md` phase 2. `N` (the third field)
+    /// is the declared pipeline depth, a compile-time integer literal (v1
+    /// restriction — no const-param-resolvable expressions yet). Resolved
+    /// against `pipelined_ops::lookup(operator, profile, N)` at typecheck
+    /// time; the call's result carries latency `N` (composes with the
+    /// existing `LatencyAt` / `@N` tap machinery). Distinct from bare
+    /// `FunctionCall` so the delay-line trap described in the proposal's
+    /// Motivation section (`acc@6 <= fma(a,b,c)` silently NOT being
+    /// retimed) cannot be written by accident.
+    PipelinedCall(String, Vec<Expr>, u32),
     /// SVA delay-shift: `##N expr`. Inside an `assert`/`cover` body, shifts
     /// the cycle of `expr` forward by `N` (i.e. evaluates `expr` at cycle
     /// `t + N` when the surrounding property is checked at cycle `t`).

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -5703,6 +5703,17 @@ impl<'a> Codegen<'a> {
     /// Core expression emitter — never adds outer parens itself.
     fn emit_expr_inner(&self, expr: &Expr) -> String {
         match &expr.kind {
+            // Retimed-datapath codegen for `<pipelined, N>` calls is not
+            // implemented yet (proposal phase 3 — see
+            // `pipelined_ops::find_pipelined_calls`, called before codegen
+            // starts so this arm should be unreachable in practice; kept
+            // as a loud backstop rather than silently falling back to a
+            // comb cone, which would misrepresent an un-retimed operator
+            // as pipelined).
+            ExprKind::PipelinedCall(name, _, stages) => unreachable!(
+                "codegen reached `{name}<pipelined, {stages}>(...)` — this should have been \
+                 rejected by pipelined_ops::find_pipelined_calls before codegen started"
+            ),
             // `q@K` on RHS lowers to the K-th tap of the pipe_reg
             // chain (`q` being the final flop, source being the input
             // before any flop). Numbering counts cycles of delay from

--- a/src/elaborate.rs
+++ b/src/elaborate.rs
@@ -10173,12 +10173,15 @@ fn make_zero_expr(sp: Span) -> Expr {
 // Called from main.rs after `lower_threads` so every other elaboration
 // pass sees the original unexpanded form.
 
-pub fn lower_pipe_reg_ports(ast: SourceFile) -> Result<SourceFile, Vec<CompileError>> {
+pub fn lower_pipe_reg_ports(
+    ast: SourceFile,
+) -> Result<(SourceFile, Vec<crate::diagnostics::CompileWarning>), Vec<CompileError>> {
     let mut new_items: Vec<Item> = Vec::with_capacity(ast.items.len());
     let mut errors: Vec<CompileError> = Vec::new();
+    let mut warnings: Vec<crate::diagnostics::CompileWarning> = Vec::new();
     for item in ast.items {
         match item {
-            Item::Module(m) => match lower_pipe_reg_module(m) {
+            Item::Module(m) => match lower_pipe_reg_module(m, &mut warnings) {
                 Ok(new_m) => new_items.push(Item::Module(new_m)),
                 Err(mut errs) => errors.append(&mut errs),
             },
@@ -10188,11 +10191,14 @@ pub fn lower_pipe_reg_ports(ast: SourceFile) -> Result<SourceFile, Vec<CompileEr
     if !errors.is_empty() {
         return Err(errors);
     }
-    Ok(SourceFile {
-        items: new_items,
-        inner_doc: None,
-        frontmatter: None,
-    })
+    Ok((
+        SourceFile {
+            items: new_items,
+            inner_doc: None,
+            frontmatter: None,
+        },
+        warnings,
+    ))
 }
 
 struct PipePortInfoLocal {
@@ -10204,7 +10210,10 @@ struct PipePortInfoLocal {
     span: Span,
 }
 
-fn lower_pipe_reg_module(mut m: ModuleDecl) -> Result<ModuleDecl, Vec<CompileError>> {
+fn lower_pipe_reg_module(
+    mut m: ModuleDecl,
+    warnings: &mut Vec<crate::diagnostics::CompileWarning>,
+) -> Result<ModuleDecl, Vec<CompileError>> {
     // Collect metadata for every pipe_reg port (latency >= 1).
     // Ports with latency == 1 still participate in the @N validation —
     // legacy `port reg` is equivalent to `pipe_reg<T, 1>`.
@@ -10241,7 +10250,13 @@ fn lower_pipe_reg_module(mut m: ModuleDecl) -> Result<ModuleDecl, Vec<CompileErr
     let mut errors: Vec<CompileError> = Vec::new();
     for bi in &m.body {
         if let ModuleBodyItem::RegBlock(rb) = bi {
-            validate_pipe_assignments(&rb.stmts, &all_pipe_ports, &pipe_depths, &mut errors);
+            validate_pipe_assignments(
+                &rb.stmts,
+                &all_pipe_ports,
+                &pipe_depths,
+                &mut errors,
+                warnings,
+            );
         }
         if let ModuleBodyItem::CombBlock(cb) = bi {
             validate_comb_pipe_refs(
@@ -10325,9 +10340,10 @@ fn validate_pipe_assignments(
     ports: &[PipePortInfoLocal],
     pipe_depths: &std::collections::HashMap<String, u32>,
     errors: &mut Vec<CompileError>,
+    warnings: &mut Vec<crate::diagnostics::CompileWarning>,
 ) {
     for s in stmts {
-        validate_pipe_assign_stmt(s, ports, pipe_depths, errors);
+        validate_pipe_assign_stmt(s, ports, pipe_depths, errors, warnings);
     }
 }
 
@@ -10336,6 +10352,7 @@ fn validate_pipe_assign_stmt(
     ports: &[PipePortInfoLocal],
     pipe_depths: &std::collections::HashMap<String, u32>,
     errors: &mut Vec<CompileError>,
+    warnings: &mut Vec<crate::diagnostics::CompileWarning>,
 ) {
     match stmt {
         Stmt::Assign(a) => {
@@ -10343,13 +10360,55 @@ fn validate_pipe_assign_stmt(
             // pipe_reg port. Validate per the error matrix.
             let (target_name, latency_opt) = match &a.target.kind {
                 ExprKind::LatencyAt(inner, n) => match &inner.kind {
-                    ExprKind::Ident(name) => (name.clone(), Some(*n)),
-                    _ => return,
+                    ExprKind::Ident(name) => (Some(name.clone()), Some(*n)),
+                    _ => (None, None),
                 },
-                ExprKind::Ident(name) => (name.clone(), None),
-                _ => return,
+                ExprKind::Ident(name) => (Some(name.clone()), None),
+                _ => (None, None),
             };
-            let Some(pp) = ports.iter().find(|p| p.name == target_name) else {
+            let pp = target_name
+                .as_ref()
+                .and_then(|n| ports.iter().find(|p| &p.name == n));
+            // `doc/proposal_pipelined_operators.md` §2: the call is
+            // authoritative for latency, the `@N` tap is a consistency
+            // check against it. Checked here — *before* the cascade
+            // rewrite below, which would otherwise strip the `@N` off the
+            // target, leaving nothing left for typecheck to compare
+            // against — and independent of whether the target happens to
+            // be a recognized `pipe_reg` port (a bare `reg` target is
+            // equally required to be tapped: a 1-cycle flop can't hold an
+            // N>1-cycle-delayed value).
+            if let ExprKind::PipelinedCall(name, _, call_stages) = &a.value.kind {
+                let declared_depth = pp.map(|p| p.latency);
+                match (latency_opt, declared_depth) {
+                    (Some(n), _) if n != *call_stages => {
+                        errors.push(CompileError::general(
+                            &format!("latency-{call_stages} result bound at @{n}"),
+                            a.span,
+                        ));
+                    }
+                    (Some(_), Some(depth)) if depth != *call_stages => {
+                        // Tapped at the right N, but the port itself is
+                        // declared a different depth — still a mismatch.
+                        errors.push(CompileError::general(
+                            &format!("latency-{call_stages} result bound at @{depth}"),
+                            a.span,
+                        ));
+                    }
+                    (None, _) => {
+                        errors.push(CompileError::general(
+                            &format!(
+                                "`{name}<pipelined, {call_stages}>(...)` produces a latency-{call_stages} \
+                                 result — it must be bound via a tapped target, e.g. \
+                                 `target@{call_stages} <= {name}<pipelined, {call_stages}>(...)`"
+                            ),
+                            a.span,
+                        ));
+                    }
+                    _ => {}
+                }
+            }
+            let Some(pp) = pp else {
                 return;
             };
             match latency_opt {
@@ -10373,20 +10432,44 @@ fn validate_pipe_assign_stmt(
                 }
                 _ => {}
             }
+            // Optional warning (doc/proposal_pipelined_operators.md §2,
+            // "No silent retiming of arbitrary exprs"): a bare comb call
+            // delayed via a pipe_reg tap is legal (unchanged delay-line
+            // semantics — the flop cascade just holds the *result*) but is
+            // almost always a "meant the pipelined variant" mistake. Only
+            // fires for tapped writes into an *actual* pipe_reg port
+            // (`pp` is `Some` here), and only when the callee is a
+            // registered pipelined operator.
+            if let ExprKind::FunctionCall(name, _) = &a.value.kind {
+                if pp.latency >= 1
+                    && crate::pipelined_ops::BUILTIN_REGISTRY
+                        .iter()
+                        .any(|e| e.operator == *name)
+                {
+                    warnings.push(crate::diagnostics::CompileWarning {
+                        message: format!(
+                            "comb `{name}` delayed {depth} cycles via `@{depth}`; did you mean \
+                             `{name}<pipelined, {depth}>(...)`?",
+                            depth = pp.latency
+                        ),
+                        span: a.span,
+                    });
+                }
+            }
             // RHS `q@K` for pipe_reg `q`: K must be 0..=N.
             validate_rhs_latency_with_depths(&a.value, pipe_depths, errors);
         }
         Stmt::IfElse(ie) => {
-            validate_pipe_assignments(&ie.then_stmts, ports, pipe_depths, errors);
-            validate_pipe_assignments(&ie.else_stmts, ports, pipe_depths, errors);
+            validate_pipe_assignments(&ie.then_stmts, ports, pipe_depths, errors, warnings);
+            validate_pipe_assignments(&ie.else_stmts, ports, pipe_depths, errors, warnings);
         }
         Stmt::Match(m) => {
             for arm in &m.arms {
-                validate_pipe_assignments(&arm.body, ports, pipe_depths, errors);
+                validate_pipe_assignments(&arm.body, ports, pipe_depths, errors, warnings);
             }
         }
-        Stmt::For(f) => validate_pipe_assignments(&f.body, ports, pipe_depths, errors),
-        Stmt::Init(ib) => validate_pipe_assignments(&ib.body, ports, pipe_depths, errors),
+        Stmt::For(f) => validate_pipe_assignments(&f.body, ports, pipe_depths, errors, warnings),
+        Stmt::Init(ib) => validate_pipe_assignments(&ib.body, ports, pipe_depths, errors, warnings),
         _ => {}
     }
 }

--- a/src/formal.rs
+++ b/src/formal.rs
@@ -1994,6 +1994,21 @@ impl<'a> FormalCtx<'a> {
             // `q@0` is the same as `q` at t. Non-@0 reads are rejected by
             // typecheck before reaching formal emission.
             LatencyAt(inner, _) => self.encode_raw(inner, t),
+            // `fma<pipelined, N>(...)` — the retimed staged datapath (and
+            // its sequential-equivalence proof obligation vs. the trusted
+            // comb operator) is proposal phase 3
+            // (doc/proposal_pipelined_operators.md), not yet implemented.
+            // Reject explicitly rather than silently encoding it as the
+            // comb operator, which would misrepresent an unverified
+            // pipeline as formally checked.
+            PipelinedCall(name, _, stages) => Err(CompileError::general(
+                &format!(
+                    "`{name}<pipelined, {stages}>(...)` is not yet supported by `arch formal` \
+                     — the staged datapath and its equivalence proof obligation land in a \
+                     later phase of doc/proposal_pipelined_operators.md"
+                ),
+                expr.span,
+            )),
             // SVA `##N expr` — forward cycle-shift. Encode `expr` at
             // cycle `t + N`. run_property clamps max_t so this never
             // goes out of the unrolled range.

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1964,6 +1964,14 @@ impl Builder {
                     self.walk_expr(owner, rel, scope, arg, ExprUse::Read);
                 }
             }
+            ExprKind::PipelinedCall(_name, args, _stages) => {
+                // Registry-resolved builtin operator (e.g. `fma<pipelined, N>`),
+                // not a user construct — no `calls` edge to a construct, just
+                // walk operand reads like a plain FunctionCall.
+                for arg in args {
+                    self.walk_expr(owner, rel, scope, arg, ExprUse::Read);
+                }
+            }
             ExprKind::Ternary(c, t, e) => {
                 self.walk_expr(owner, rel, scope, c, ExprUse::Read);
                 self.walk_expr(owner, rel, scope, t, ExprUse::Read);

--- a/src/main.rs
+++ b/src/main.rs
@@ -510,6 +510,40 @@ impl MultiSource {
     }
 }
 
+/// Codegen-side backstop for `arch build` / `arch sim` (not `arch check`,
+/// which fully supports `<pipelined, N>` through typecheck): refuses to
+/// proceed into SV or sim codegen if the program still contains any
+/// `fma<pipelined, N>(...)`-style call. Binding these to a real retimed
+/// staged datapath is proposal phase 3
+/// (doc/proposal_pipelined_operators.md) — `builtin:fma_f32_s6` today is a
+/// single combinational cone, not staged RTL; see
+/// `pipelined_ops` module docs for the investigation that established
+/// this. Surfacing a clear, explicit error here is safer than silently
+/// falling back to comb + delay-line, which would compute correct values
+/// but misrepresent an un-retimed cone as the requested pipelined
+/// operator — and would risk the two backends (SV, sim) diverging if
+/// either one's fallback ever drifted from the other's.
+fn reject_pipelined_calls_before_codegen(
+    ast: &arch::ast::SourceFile,
+    ms: &MultiSource,
+) -> miette::Result<()> {
+    let found = arch::pipelined_ops::find_pipelined_calls(ast);
+    if let Some(f) = found.into_iter().next() {
+        let err = CompileError::general(
+            &format!(
+                "`{}<pipelined, {}>(...)` typechecks (`arch check` accepts it) but codegen for \
+                 pipelined operators is not yet implemented — the retimed staged datapath and its \
+                 equivalence proof are proposal phase 3 (doc/proposal_pipelined_operators.md), not yet \
+                 landed. Tracked in the phase-2 PR; not supported by `arch build` / `arch sim` yet.",
+                f.operator, f.stages
+            ),
+            f.span,
+        );
+        return Err(ms.report_error(err));
+    }
+    Ok(())
+}
+
 fn thread_map_sources_from_multi(ms: &MultiSource) -> Vec<arch::thread_map::ThreadMapSource> {
     ms.segments
         .iter()
@@ -1149,6 +1183,7 @@ fn main() -> miette::Result<()> {
                     auto_thread_asserts,
                     thread_map_store.clone(),
                 )?;
+                reject_pipelined_calls_before_codegen(&ast, &ms)?;
                 let thread_map_sources = thread_map_sources_from_multi(&ms);
 
                 let comments = lexer::extract_comments(&ms.combined);
@@ -1860,6 +1895,7 @@ fn run_sim_opts(
             param_overrides,
         )?
     };
+    reject_pipelined_calls_before_codegen(&ast, &ms)?;
 
     // 2. Set up output directory
     let build_dir = outdir
@@ -3681,7 +3717,7 @@ fn run_check_multi_opts_with_thread_map_and_params(
     }
 
     // Lower `pipe_reg<T, N>` ports with N > 1 into an N-stage cascade.
-    let ast = elaborate::lower_pipe_reg_ports(ast).map_err(|errs| {
+    let (ast, pipe_reg_warnings) = elaborate::lower_pipe_reg_ports(ast).map_err(|errs| {
         let err = errs.into_iter().next().unwrap();
         ms.report_error(err)
     })?;
@@ -3701,10 +3737,11 @@ fn run_check_multi_opts_with_thread_map_and_params(
 
     // Type check
     let checker = TypeChecker::new(&symbols, &ast);
-    let (warnings, overload_map) = checker.check().map_err(|errs| {
+    let (mut warnings, overload_map) = checker.check().map_err(|errs| {
         let err = errs.into_iter().next().unwrap();
         ms.report_error(err)
     })?;
+    warnings.extend(pipe_reg_warnings);
 
     for w in &warnings {
         let (filename, _, local_offset) = ms.locate(w.span.start);

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -4690,6 +4690,58 @@ impl Parser {
                         span,
                         parenthesized: false,
                     })
+                } else if self.check(TokenKind::Lt)
+                    && matches!(self.peek_real_kind_at(1), Some(TokenKind::Pipelined))
+                {
+                    // Pipelined-operator call: Name<pipelined, N>(arg, ...)
+                    // (doc/proposal_pipelined_operators.md phase 2). Only
+                    // triggers on the exact `< pipelined , <int> >` shape —
+                    // any other `<` after an identifier falls through to
+                    // ordinary comparison-operator / plain-call parsing
+                    // below, so `a < b` and `fma(a,b,c)` are unaffected.
+                    self.advance(); // consume `<`
+                    self.expect(TokenKind::Pipelined)?;
+                    self.expect(TokenKind::Comma)?;
+                    // v1 restriction: depth must be a literal integer token
+                    // written directly in the call, mirroring how
+                    // `pipe_reg<T, N>` requires a literal depth today — not
+                    // a const-param-resolvable expression.
+                    let depth_span = self.peek_span();
+                    let old_no_angle = self.no_angle;
+                    self.no_angle = true;
+                    let depth_expr = self.parse_expr()?;
+                    self.no_angle = old_no_angle;
+                    let stages: u32 = match &depth_expr.kind {
+                        ExprKind::Literal(LitKind::Dec(n))
+                        | ExprKind::Literal(LitKind::Hex(n))
+                        | ExprKind::Literal(LitKind::Bin(n))
+                        | ExprKind::Literal(LitKind::Sized(_, n)) => *n as u32,
+                        _ => {
+                            return Err(CompileError::general(
+                                &format!(
+                                    "`{}<pipelined, N>(...)` requires N to be a compile-time integer literal",
+                                    ident.name
+                                ),
+                                depth_span,
+                            ));
+                        }
+                    };
+                    self.expect(TokenKind::Gt)?;
+                    self.expect(TokenKind::LParen)?;
+                    let mut call_args = Vec::new();
+                    while !self.check(TokenKind::RParen) {
+                        call_args.push(self.parse_expr()?);
+                        if !self.eat(TokenKind::Comma) {
+                            break;
+                        }
+                    }
+                    let end = self.expect(TokenKind::RParen)?;
+                    let span = ident.span.merge(end.span);
+                    Ok(Expr {
+                        kind: ExprKind::PipelinedCall(ident.name, call_args, stages),
+                        span,
+                        parenthesized: false,
+                    })
                 } else if self.check(TokenKind::LParen) {
                     // Function call: Name(arg, ...)
                     self.advance(); // consume `(`

--- a/src/pipelined_ops.rs
+++ b/src/pipelined_ops.rs
@@ -4,10 +4,22 @@
 //! the registry table, a type-check-facing lookup with an enumerated miss
 //! error, and the data behind the `arch ops` CLI listing.
 //!
-//! This module intentionally does **not** wire up the `fma<pipelined, N>`
-//! call surface or latency typing (§2 of the proposal) — that is phase 2.
-//! `lookup` is exposed for phase 2's typecheck integration and is exercised
-//! directly by tests in the meantime.
+//! Phase 2 (this module, additionally) wires up the `fma<pipelined, N>`
+//! call surface, parsed as `ast::ExprKind::PipelinedCall`, and its latency
+//! typing (see `typecheck.rs`'s `PipelinedCall` handling). Codegen —
+//! binding the call to an actual retimed staged datapath in `arch build`
+//! / `arch sim` — is deferred: `builtin:fma_f32_s6` today is a single
+//! combinational cone (`src/fp_ops.rs`), not staged RTL; "6-stage" is
+//! purely a downstream Yosys synthesis-retiming characterization the
+//! compiler never sees. Productizing a real staged schedule with an
+//! equivalence proof is proposal phase 3. `find_pipelined_calls` below is
+//! the codegen-side backstop: `arch build` / `arch sim` scan the
+//! elaborated module bodies for any `PipelinedCall` and refuse with a
+//! clear "not yet implemented" error rather than silently falling back to
+//! comb + delay-line (which would be functionally correct but would
+//! misrepresent an un-retimed cone as the requested pipelined operator).
+//! `arch check` does not run this scan — typecheck alone is fully
+//! supported.
 //!
 //! The registry key is `(operator, profile, stages)`. Entries carry a
 //! verification `status`: `verified` means the staged IR has been proven
@@ -259,6 +271,168 @@ pub fn format_markdown_table() -> String {
         ));
     }
     out
+}
+
+/// A `PipelinedCall` found by [`find_pipelined_calls`]: the operator name,
+/// declared depth, and source span, for building the deferred-codegen
+/// error message.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FoundPipelinedCall {
+    pub operator: String,
+    pub stages: u32,
+    pub span: crate::lexer::Span,
+}
+
+/// Scans every `module` in `source` for `PipelinedCall` expressions
+/// (`fma<pipelined, N>(...)` and friends) reachable from `comb`/`seq`/
+/// `latch` block statements. Used by `arch build` / `arch sim` (not
+/// `arch check`) to refuse compilation with a clear, explicit error before
+/// codegen — see the module doc comment above for why codegen can't yet
+/// bind these calls to a real staged datapath.
+///
+/// Scope note: only module `comb`/`seq`/`latch` blocks are scanned — the
+/// only context the proposal's surface syntax and worked example cover in
+/// phase 2. Other constructs (`fsm`, `pipeline`, `thread`, ...) don't
+/// support the pipelined-operator surface yet.
+pub fn find_pipelined_calls(source: &crate::ast::SourceFile) -> Vec<FoundPipelinedCall> {
+    use crate::ast::{Item, ModuleBodyItem};
+    let mut out = Vec::new();
+    for item in &source.items {
+        if let Item::Module(m) = item {
+            for bi in &m.body {
+                match bi {
+                    ModuleBodyItem::CombBlock(cb) => scan_stmts(&cb.stmts, &mut out),
+                    ModuleBodyItem::RegBlock(rb) => scan_stmts(&rb.stmts, &mut out),
+                    ModuleBodyItem::LatchBlock(lb) => scan_stmts(&lb.stmts, &mut out),
+                    ModuleBodyItem::LetBinding(l) => scan_expr(&l.value, &mut out),
+                    _ => {}
+                }
+            }
+        }
+    }
+    out
+}
+
+fn scan_stmts(stmts: &[crate::ast::Stmt], out: &mut Vec<FoundPipelinedCall>) {
+    use crate::ast::Stmt;
+    for s in stmts {
+        match s {
+            Stmt::Assign(a) => scan_expr(&a.value, out),
+            Stmt::IfElse(ie) => {
+                scan_expr(&ie.cond, out);
+                scan_stmts(&ie.then_stmts, out);
+                scan_stmts(&ie.else_stmts, out);
+            }
+            Stmt::Match(m) => {
+                scan_expr(&m.scrutinee, out);
+                for arm in &m.arms {
+                    scan_stmts(&arm.body, out);
+                }
+            }
+            Stmt::Log(l) => {
+                for a in &l.args {
+                    scan_expr(a, out);
+                }
+            }
+            Stmt::For(f) => scan_stmts(&f.body, out),
+            Stmt::Init(i) => scan_stmts(&i.body, out),
+            Stmt::WaitUntil(e, _) => scan_expr(e, out),
+            Stmt::DoUntil { body, cond, .. } => {
+                scan_stmts(body, out);
+                scan_expr(cond, out);
+            }
+        }
+    }
+}
+
+fn scan_expr(expr: &crate::ast::Expr, out: &mut Vec<FoundPipelinedCall>) {
+    use crate::ast::ExprKind::*;
+    match &expr.kind {
+        PipelinedCall(name, args, stages) => {
+            out.push(FoundPipelinedCall {
+                operator: name.clone(),
+                stages: *stages,
+                span: expr.span,
+            });
+            for a in args {
+                scan_expr(a, out);
+            }
+        }
+        Binary(_, a, b) => {
+            scan_expr(a, out);
+            scan_expr(b, out);
+        }
+        Unary(_, e)
+        | Cast(e, _)
+        | LatencyAt(e, _)
+        | SvaNext(_, e)
+        | Signed(e)
+        | Unsigned(e)
+        | Clog2(e)
+        | Onehot(e)
+        | Repeat(e, _) => scan_expr(e, out),
+        FieldAccess(e, _) => scan_expr(e, out),
+        MethodCall(recv, _, args) => {
+            scan_expr(recv, out);
+            for a in args {
+                scan_expr(a, out);
+            }
+        }
+        Index(base, idx) => {
+            scan_expr(base, out);
+            scan_expr(idx, out);
+        }
+        BitSlice(base, hi, lo) => {
+            scan_expr(base, out);
+            scan_expr(hi, out);
+            scan_expr(lo, out);
+        }
+        PartSelect(base, start, width, _) => {
+            scan_expr(base, out);
+            scan_expr(start, out);
+            scan_expr(width, out);
+        }
+        StructLiteral(_, fields) => {
+            for f in fields {
+                scan_expr(&f.value, out);
+            }
+        }
+        Match(scrut, arms) => {
+            scan_expr(scrut, out);
+            for arm in arms {
+                scan_stmts(&arm.body, out);
+            }
+        }
+        ExprMatch(scrut, arms) => {
+            scan_expr(scrut, out);
+            for arm in arms {
+                scan_expr(&arm.value, out);
+            }
+        }
+        Concat(xs) | FunctionCall(_, xs) => {
+            for x in xs {
+                scan_expr(x, out);
+            }
+        }
+        Inside(e, members) => {
+            scan_expr(e, out);
+            for m in members {
+                match m {
+                    crate::ast::InsideMember::Single(v) => scan_expr(v, out),
+                    crate::ast::InsideMember::Range(lo, hi) => {
+                        scan_expr(lo, out);
+                        scan_expr(hi, out);
+                    }
+                }
+            }
+        }
+        Ternary(c, t, e) => {
+            scan_expr(c, out);
+            scan_expr(t, out);
+            scan_expr(e, out);
+        }
+        Literal(_) | Ident(_) | SynthIdent(_, _) | EnumVariant(_, _) | Todo | Bool(_) => {}
+    }
 }
 
 #[cfg(test)]

--- a/src/sim_codegen/mod.rs
+++ b/src/sim_codegen/mod.rs
@@ -3487,6 +3487,15 @@ fn cpp_expr_lhs(expr: &Expr, ctx: &Ctx) -> String {
 
 fn cpp_expr_inner(expr: &Expr, ctx: &Ctx, is_lhs: bool) -> String {
     match &expr.kind {
+        // See the matching arm in codegen/mod.rs::emit_expr_inner: retimed
+        // sim stepping for `<pipelined, N>` calls is proposal phase 3, not
+        // yet implemented. `pipelined_ops::find_pipelined_calls` rejects
+        // these before sim codegen starts, so this is a loud backstop, not
+        // the primary error path.
+        ExprKind::PipelinedCall(name, _, stages) => unreachable!(
+            "sim codegen reached `{name}<pipelined, {stages}>(...)` — this should have been \
+             rejected by pipelined_ops::find_pipelined_calls before codegen started"
+        ),
         // Latency annotation: transparent to sim emission. The assignment
         // site handles directing the write to stage 0 of the pipe chain;
         // reads of `q@0` collapse to the final-output field of the pipe.

--- a/src/thread_map.rs
+++ b/src/thread_map.rs
@@ -205,6 +205,10 @@ pub fn expr_label(expr: &Expr) -> String {
             let args = args.iter().map(expr_label).collect::<Vec<_>>().join(", ");
             format!("{}({})", name, args)
         }
+        ExprKind::PipelinedCall(name, args, stages) => {
+            let args = args.iter().map(expr_label).collect::<Vec<_>>().join(", ");
+            format!("{}<pipelined, {}>({})", name, stages, args)
+        }
         ExprKind::Concat(parts) => {
             let parts = parts.iter().map(expr_label).collect::<Vec<_>>().join(", ");
             format!("{{{parts}}}")

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -1053,6 +1053,21 @@ impl<'a> TypeChecker<'a> {
                         // Do NOT insert into local_types or driven here — handled above per case
                     } else {
                         let ty = self.resolve_expr_type(&l.value, &m.name.name, &local_types);
+                        // `let` bindings are always a fixed combinational
+                        // expression (spec: "declaration (fixed combinational
+                        // expr)") — a latency-N (N>0) `<pipelined, N>` result
+                        // has no cycle to land on here; it must be bound in a
+                        // `seq` block via an `@N` tap.
+                        if let ExprKind::PipelinedCall(name, _, call_stages) = &l.value.kind {
+                            self.errors.push(CompileError::general(
+                                &format!(
+                                    "`{name}<pipelined, {call_stages}>(...)` produces a latency-{call_stages} \
+                                     result and cannot be used in a `let` binding (always combinational); \
+                                     bind it in a `seq` block via `target@{call_stages} <= {name}<pipelined, {call_stages}>(...)`"
+                                ),
+                                l.value.span,
+                            ));
+                        }
                         if let Some(declared_ty) = &l.ty {
                             let expected =
                                 self.resolve_type_expr(declared_ty, &m.name.name, &local_types);
@@ -3135,6 +3150,7 @@ impl<'a> TypeChecker<'a> {
                 }
 
                 let rhs_ty = self.resolve_expr_type(&a.value, module_name, local_types);
+                self.check_pipelined_call_binding(a, in_comb);
                 let is_indexed = !matches!(&a.target.kind, ExprKind::Ident(_));
                 // LHS-type lookup: comb uses local_types directly so missing
                 // entries silently skip the width check (matches historical
@@ -3625,6 +3641,187 @@ impl<'a> TypeChecker<'a> {
         }
     }
 
+    /// The cycle offset an expression's value materializes at, per the
+    /// `LatencyAt`/`PipelinedCall` machinery (`doc/proposal_pipelined_operators.md`
+    /// §2). `0` for any expression not explicitly annotated — i.e. a plain
+    /// signal read or a comb result. Used by [`Self::check_operand_latency_alignment`]
+    /// to reject mixed-latency combinations without auto-alignment (v1: no
+    /// auto-inserted delay lines — see the proposal's "Mixed-latency
+    /// expressions" decision).
+    fn expr_latency_tc(expr: &Expr) -> u32 {
+        match &expr.kind {
+            ExprKind::PipelinedCall(_, _, n) => *n,
+            ExprKind::LatencyAt(_, n) => *n,
+            _ => 0,
+        }
+    }
+
+    /// Rejects combining operands materializing at different cycle offsets
+    /// in a single expression (e.g. `acc@6 + x` where `x` is latency-0),
+    /// per the proposal's "no auto-alignment in v1" rule. Reports the
+    /// *first* mismatching pair found, phrased like the proposal's
+    /// `fadd(acc@6, x)` example: "operands at cycle 6 and cycle 0".
+    fn check_operand_latency_alignment(&mut self, operands: &[&Expr], span: Span) {
+        let mut first: Option<(u32, Span)> = None;
+        for op in operands {
+            let lat = Self::expr_latency_tc(op);
+            match &first {
+                None => first = Some((lat, op.span)),
+                Some((f, _)) if *f != lat => {
+                    self.errors.push(CompileError::general(
+                        &format!("operands at cycle {} and cycle {}", f, lat),
+                        span,
+                    ));
+                    return;
+                }
+                _ => {}
+            }
+        }
+    }
+
+    /// Typecheck resolution for `Name<pipelined, N>(args...)` —
+    /// `doc/proposal_pipelined_operators.md` §2. Reuses the same operand
+    /// type-profile detection each registry operator's bare comb form
+    /// already uses (currently only `fma`), resolves `(operator, profile, N)`
+    /// against `pipelined_ops::lookup`, and returns the operator's normal
+    /// result type. The call's own latency (`N`) is not carried in `Ty` —
+    /// callers recover it structurally via [`Self::expr_latency_tc`], which
+    /// treats a `PipelinedCall` node itself as materializing at cycle `N`.
+    fn resolve_pipelined_call_type(
+        &mut self,
+        name: &str,
+        call_args: &[Expr],
+        stages: u32,
+        span: Span,
+        module_name: &str,
+        local_types: &HashMap<String, Ty>,
+    ) -> Ty {
+        if name != "fma" {
+            self.errors.push(CompileError::general(
+                &format!(
+                    "`{name}<pipelined, {stages}>(...)` — `{name}` is not a registry-backed \
+                     pipelined operator; only `fma` is registered today (run `arch ops` to list all)"
+                ),
+                span,
+            ));
+            return Ty::Error;
+        }
+        // Same arity/type-profile rule as bare `fma(a, b, c)` (see the
+        // `FunctionCall` arm below) — three same-float-type operands.
+        if call_args.len() != 3 {
+            self.errors.push(CompileError::general(
+                &format!(
+                    "`fma<pipelined, {stages}>(a, b, c)` takes 3 arguments, got {}",
+                    call_args.len()
+                ),
+                span,
+            ));
+            return Ty::Error;
+        }
+        let arg_tys: Vec<Ty> = call_args
+            .iter()
+            .map(|a| self.resolve_expr_type(a, module_name, local_types))
+            .collect();
+        if arg_tys.iter().any(|t| *t == Ty::Error) {
+            return Ty::Error;
+        }
+        let ta = &arg_tys[0];
+        if !ta.is_float() || arg_tys[1] != *ta || arg_tys[2] != *ta {
+            self.errors.push(CompileError::general(
+                &format!(
+                    "`fma<pipelined, {stages}>` requires three operands of the same float type, got {}, {}, {}",
+                    arg_tys[0].display(), arg_tys[1].display(), arg_tys[2].display()
+                ),
+                span,
+            ));
+            return Ty::Error;
+        }
+        // The pipelined call's own inputs are combinational (cycle-0) reads
+        // — no auto-alignment, so mixed-latency operands are rejected here
+        // the same way they are for any other multi-operand call.
+        let arg_refs: Vec<&Expr> = call_args.iter().collect();
+        self.check_operand_latency_alignment(&arg_refs, span);
+
+        let profile = match ta {
+            Ty::FP32 => "FP32",
+            Ty::BF16 => "BF16",
+            _ => unreachable!("is_float() already restricted ta to FP32/BF16"),
+        };
+        match crate::pipelined_ops::lookup(name, profile, stages) {
+            Ok(_entry) => ta.clone(),
+            Err(miss) => {
+                // Reuse LookupMiss's Display verbatim — it already renders
+                // the exact enumerated-miss error text specified in
+                // doc/proposal_pipelined_operators.md §1.
+                self.errors
+                    .push(CompileError::general(&miss.to_string(), span));
+                Ty::Error
+            }
+        }
+    }
+
+    /// Enforces the comb-context restriction and the optional delay-line
+    /// warning from `doc/proposal_pipelined_operators.md` §2 for one
+    /// assignment statement (`target <op> value;`).
+    ///
+    /// - A bare `PipelinedCall` (latency N>0) directly assigned in a
+    ///   `comb` block is an error — it has no cycle to land on.
+    /// - The optional delay-line warning: `acc@N <= fma(a,b,c)` (comb fma,
+    ///   *not* `<pipelined, N>`) written into an `@N` (N>=1) tap compiles
+    ///   (unchanged pipe_reg delay-line semantics) but warns, since it's
+    ///   almost always a "did you mean `fma<pipelined, N>`?" mistake — the
+    ///   delay-line trap the proposal's Motivation section describes.
+    ///
+    /// The seq-context binding/consistency rule ("latency-M result bound
+    /// at @N", "must be bound via a tapped target") is enforced earlier,
+    /// in `elaborate::validate_pipe_assign_stmt` — it runs *before* the
+    /// pipe_reg cascade rewrite strips the `@N` off the target, which by
+    /// the time this function runs has already happened for any
+    /// `PipelinedCall` reaching a seq assignment (a program that failed
+    /// that check never reaches typecheck at all).
+    fn check_pipelined_call_binding(&mut self, a: &Assign, in_comb: bool) {
+        let target_latency = match &a.target.kind {
+            ExprKind::LatencyAt(_, n) => Some(*n),
+            _ => None,
+        };
+        match &a.value.kind {
+            ExprKind::PipelinedCall(name, _, call_stages) => {
+                if in_comb {
+                    self.errors.push(CompileError::general(
+                        &format!(
+                            "`{name}<pipelined, {call_stages}>(...)` produces a latency-{call_stages} \
+                             result and cannot be used in a `comb` block; bind it in a `seq` block via \
+                             `target@{call_stages} <= {name}<pipelined, {call_stages}>(...)`"
+                        ),
+                        a.span,
+                    ));
+                }
+            }
+            ExprKind::FunctionCall(name, _) if !in_comb => {
+                // Optional warning (proposal §2, "No silent retiming of
+                // arbitrary exprs"): a bare comb call delayed via a
+                // pipe_reg tap is legal (unchanged delay-line semantics)
+                // but is almost always meant to be the pipelined variant.
+                if let Some(target_n) = target_latency {
+                    if target_n >= 1
+                        && crate::pipelined_ops::BUILTIN_REGISTRY
+                            .iter()
+                            .any(|e| e.operator == name)
+                    {
+                        self.warnings.push(CompileWarning {
+                            message: format!(
+                                "comb `{name}` delayed {target_n} cycles via `@{target_n}`; did you mean \
+                                 `{name}<pipelined, {target_n}>(...)`?"
+                            ),
+                            span: a.span,
+                        });
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
     fn resolve_expr_type(
         &mut self,
         expr: &Expr,
@@ -3650,6 +3847,14 @@ impl<'a> TypeChecker<'a> {
                 // target context is known.
                 self.resolve_expr_type(inner, module_name, local_types)
             }
+            ExprKind::PipelinedCall(name, call_args, stages) => self.resolve_pipelined_call_type(
+                name,
+                call_args,
+                *stages,
+                expr.span,
+                module_name,
+                local_types,
+            ),
             ExprKind::SynthIdent(_, ty) => {
                 // SynthIdent carries its own type — used by the
                 // credit_channel dispatch pass (PR #3b-v). No symbol-table
@@ -3739,6 +3944,7 @@ impl<'a> TypeChecker<'a> {
                 self.check_precedence_ambiguity(*op, lhs, rhs, expr.span);
                 let lt = self.resolve_expr_type(lhs, module_name, local_types);
                 let rt = self.resolve_expr_type(rhs, module_name, local_types);
+                self.check_operand_latency_alignment(&[lhs.as_ref(), rhs.as_ref()], expr.span);
                 self.binop_result_type(*op, &lt, &rt, expr.span)
             }
             ExprKind::Unary(op, operand) => {
@@ -4018,6 +4224,10 @@ impl<'a> TypeChecker<'a> {
                         ));
                         return Ty::Error;
                     }
+                    self.check_operand_latency_alignment(
+                        &[&call_args[0], &call_args[1], &call_args[2]],
+                        expr.span,
+                    );
                     return ta;
                 }
                 if name == "is_nan" {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -65,7 +65,7 @@ fn compile_to_sv_with_opts(source: &str, opts: &elaborate::ThreadLowerOpts) -> S
     let ast = elaborate::lower_tlm_target_threads(ast).expect("tlm_target lowering error");
     let ast = elaborate::lower_tlm_initiator_calls(ast).expect("tlm_initiator lowering error");
     let ast = elaborate::lower_threads_with_opts(ast, opts).expect("lower_threads error");
-    let ast = elaborate::lower_pipe_reg_ports(ast).expect("lower_pipe_reg_ports error");
+    let ast = (elaborate::lower_pipe_reg_ports(ast).expect("lower_pipe_reg_ports error")).0;
     let ast = elaborate::lower_credit_channel_dispatch(ast).expect("credit_channel dispatch error");
     let symbols = resolve::resolve(&ast).expect("resolve error");
     let checker = TypeChecker::new(&symbols, &ast);
@@ -82,7 +82,7 @@ fn warnings_after_full_lower(source: &str) -> Vec<String> {
     let ast = elaborate::lower_tlm_target_threads(ast).expect("tlm_target lowering error");
     let ast = elaborate::lower_tlm_initiator_calls(ast).expect("tlm_initiator lowering error");
     let ast = elaborate::lower_threads(ast).expect("lower_threads error");
-    let ast = elaborate::lower_pipe_reg_ports(ast).expect("lower_pipe_reg_ports error");
+    let ast = (elaborate::lower_pipe_reg_ports(ast).expect("lower_pipe_reg_ports error")).0;
     let ast = elaborate::lower_credit_channel_dispatch(ast).expect("credit_channel dispatch error");
     let symbols = resolve::resolve(&ast).expect("resolve error");
     let checker = TypeChecker::new(&symbols, &ast);
@@ -6662,7 +6662,7 @@ fn compile_to_sim_h(source: &str, inputs_start_uninit: bool) -> String {
     let ast = arch::elaborate::lower_tlm_target_threads(ast).expect("tlm target lowering");
     let ast = arch::elaborate::lower_tlm_initiator_calls(ast).expect("tlm initiator lowering");
     let ast = arch::elaborate::lower_threads(ast).expect("lower threads error");
-    let ast = arch::elaborate::lower_pipe_reg_ports(ast).expect("lower pipe_reg error");
+    let ast = (arch::elaborate::lower_pipe_reg_ports(ast).expect("lower pipe_reg error")).0;
     let ast = arch::elaborate::lower_credit_channel_dispatch(ast).expect("cc dispatch error");
     let symbols = arch::resolve::resolve(&ast).expect("resolve error");
     let checker = arch::typecheck::TypeChecker::new(&symbols, &ast);
@@ -6690,7 +6690,7 @@ fn compile_to_thread_sim_result(source: &str) -> Result<String, String> {
     let ast = arch::elaborate::elaborate(parsed_ast).expect("elaborate error");
     let ast = arch::elaborate::lower_tlm_target_threads(ast).expect("tlm target lowering");
     let ast = arch::elaborate::lower_tlm_initiator_calls(ast).expect("tlm initiator lowering");
-    let ast = arch::elaborate::lower_pipe_reg_ports(ast).expect("lower pipe_reg error");
+    let ast = (arch::elaborate::lower_pipe_reg_ports(ast).expect("lower pipe_reg error")).0;
     let ast = arch::elaborate::lower_credit_channel_dispatch(ast).expect("cc dispatch error");
     let symbols = arch::resolve::resolve(&ast).expect("resolve error");
     let checker = arch::typecheck::TypeChecker::new(&symbols, &ast);
@@ -6730,7 +6730,7 @@ fn compile_to_thread_sim_collect_warnings(source: &str) -> Vec<arch::diagnostics
     let ast = arch::elaborate::elaborate(parsed_ast).expect("elaborate error");
     let ast = arch::elaborate::lower_tlm_target_threads(ast).expect("tlm target lowering");
     let ast = arch::elaborate::lower_tlm_initiator_calls(ast).expect("tlm initiator lowering");
-    let ast = arch::elaborate::lower_pipe_reg_ports(ast).expect("lower pipe_reg error");
+    let ast = (arch::elaborate::lower_pipe_reg_ports(ast).expect("lower pipe_reg error")).0;
     let ast = arch::elaborate::lower_credit_channel_dispatch(ast).expect("cc dispatch error");
     let symbols = arch::resolve::resolve(&ast).expect("resolve error");
     let checker = arch::typecheck::TypeChecker::new(&symbols, &ast);
@@ -7227,7 +7227,7 @@ fn test_check_port_reg_timing_skips_synthesized_thread_lowered_regs() {
     let ast = arch::elaborate::lower_tlm_target_threads(ast).expect("tlm target lowering");
     let ast = arch::elaborate::lower_tlm_initiator_calls(ast).expect("tlm initiator lowering");
     let ast = arch::elaborate::lower_threads(ast).expect("thread lowering");
-    let ast = arch::elaborate::lower_pipe_reg_ports(ast).expect("pipe_reg lowering");
+    let ast = (arch::elaborate::lower_pipe_reg_ports(ast).expect("pipe_reg lowering")).0;
     let ast = arch::elaborate::lower_credit_channel_dispatch(ast).expect("credit_channel lowering");
     let symbols = arch::resolve::resolve(&ast).expect("resolve");
     let checker = arch::typecheck::TypeChecker::new(&symbols, &ast);
@@ -10164,7 +10164,7 @@ fn test_port_reg_deprecation_warning_fires() {
     let ast = parser.parse_source_file().expect("parse");
     let ast = arch::elaborate::elaborate(ast).expect("elaborate");
     let ast = arch::elaborate::lower_threads(ast).expect("lower threads");
-    let ast = arch::elaborate::lower_pipe_reg_ports(ast).expect("lower pipe_reg");
+    let ast = (arch::elaborate::lower_pipe_reg_ports(ast).expect("lower pipe_reg")).0;
     let symbols = arch::resolve::resolve(&ast).expect("resolve");
     let (warnings, _) = arch::typecheck::TypeChecker::new(&symbols, &ast)
         .check()
@@ -10196,7 +10196,7 @@ fn test_pipe_reg_port_no_deprecation_warning() {
     let ast = parser.parse_source_file().expect("parse");
     let ast = arch::elaborate::elaborate(ast).expect("elaborate");
     let ast = arch::elaborate::lower_threads(ast).expect("lower threads");
-    let ast = arch::elaborate::lower_pipe_reg_ports(ast).expect("lower pipe_reg");
+    let ast = (arch::elaborate::lower_pipe_reg_ports(ast).expect("lower pipe_reg")).0;
     let symbols = arch::resolve::resolve(&ast).expect("resolve");
     let (warnings, _) = arch::typecheck::TypeChecker::new(&symbols, &ast)
         .check()
@@ -10266,7 +10266,7 @@ fn test_handshake_legacy_keyword_emits_deprecation_warning() {
     let ast = parser.parse_source_file().expect("parse");
     let ast = arch::elaborate::elaborate(ast).expect("elaborate");
     let ast = arch::elaborate::lower_threads(ast).expect("lower threads");
-    let ast = arch::elaborate::lower_pipe_reg_ports(ast).expect("lower pipe_reg");
+    let ast = (arch::elaborate::lower_pipe_reg_ports(ast).expect("lower pipe_reg")).0;
     let symbols = arch::resolve::resolve(&ast).expect("resolve");
     let (warnings, _) = arch::typecheck::TypeChecker::new(&symbols, &ast)
         .check()
@@ -10304,7 +10304,7 @@ fn test_handshake_channel_no_deprecation_warning() {
     let ast = parser.parse_source_file().expect("parse");
     let ast = arch::elaborate::elaborate(ast).expect("elaborate");
     let ast = arch::elaborate::lower_threads(ast).expect("lower threads");
-    let ast = arch::elaborate::lower_pipe_reg_ports(ast).expect("lower pipe_reg");
+    let ast = (arch::elaborate::lower_pipe_reg_ports(ast).expect("lower pipe_reg")).0;
     let symbols = arch::resolve::resolve(&ast).expect("resolve");
     let (warnings, _) = arch::typecheck::TypeChecker::new(&symbols, &ast)
         .check()
@@ -19069,7 +19069,7 @@ fn test_thread_sim_rejects_wide_arithmetic_until_codegen_supports_it() {
     let ast = arch::elaborate::elaborate(parsed_ast).expect("elaborate error");
     let ast = arch::elaborate::lower_tlm_target_threads(ast).expect("tlm target lowering");
     let ast = arch::elaborate::lower_tlm_initiator_calls(ast).expect("tlm initiator lowering");
-    let ast = arch::elaborate::lower_pipe_reg_ports(ast).expect("lower pipe_reg error");
+    let ast = (arch::elaborate::lower_pipe_reg_ports(ast).expect("lower pipe_reg error")).0;
     let ast = arch::elaborate::lower_credit_channel_dispatch(ast).expect("cc dispatch error");
     let m = ast
         .items
@@ -21150,7 +21150,7 @@ end module Parent
     let ast = elaborate::lower_tlm_initiator_calls(ast).expect("tlm_initiator lowering");
     let ast = elaborate::lower_threads_with_opts(ast, &elaborate::ThreadLowerOpts::default())
         .expect("lower_threads");
-    let ast = elaborate::lower_pipe_reg_ports(ast).expect("lower_pipe_reg_ports");
+    let ast = (elaborate::lower_pipe_reg_ports(ast).expect("lower_pipe_reg_ports")).0;
     let ast = elaborate::lower_credit_channel_dispatch(ast).expect("credit_channel dispatch");
     let symbols = resolve::resolve(&ast).expect("resolve");
     let checker = TypeChecker::new(&symbols, &ast);
@@ -21228,7 +21228,7 @@ end module Parent
     let ast = elaborate::lower_tlm_initiator_calls(ast).expect("tlm_initiator lowering");
     let ast = elaborate::lower_threads_with_opts(ast, &elaborate::ThreadLowerOpts::default())
         .expect("lower_threads");
-    let ast = elaborate::lower_pipe_reg_ports(ast).expect("lower_pipe_reg_ports");
+    let ast = (elaborate::lower_pipe_reg_ports(ast).expect("lower_pipe_reg_ports")).0;
     let ast = elaborate::lower_credit_channel_dispatch(ast).expect("credit_channel dispatch");
     let symbols = resolve::resolve(&ast)
         .expect("resolve must accept fsm interface stub (no default_state validation)");
@@ -25043,7 +25043,7 @@ fn compile_to_sv_with_sdc(source: &str) -> (String, Option<String>) {
     let ast = elaborate::lower_tlm_initiator_calls(ast).expect("tlm_initiator lowering error");
     let ast = elaborate::lower_threads_with_opts(ast, &elaborate::ThreadLowerOpts::default())
         .expect("lower_threads error");
-    let ast = elaborate::lower_pipe_reg_ports(ast).expect("lower_pipe_reg_ports error");
+    let ast = (elaborate::lower_pipe_reg_ports(ast).expect("lower_pipe_reg_ports error")).0;
     let ast = elaborate::lower_credit_channel_dispatch(ast).expect("credit_channel dispatch error");
     let symbols = resolve::resolve(&ast).expect("resolve error");
     let checker = TypeChecker::new(&symbols, &ast);
@@ -26916,7 +26916,7 @@ fn typecheck_source(source: &str) -> Result<(), Vec<arch::diagnostics::CompileEr
     let ast = elaborate::lower_tlm_initiator_calls(ast).expect("tlm_initiator");
     let ast = elaborate::lower_threads_with_opts(ast, &elaborate::ThreadLowerOpts::default())
         .expect("lower_threads");
-    let ast = elaborate::lower_pipe_reg_ports(ast).expect("lower_pipe_reg");
+    let ast = (elaborate::lower_pipe_reg_ports(ast).expect("lower_pipe_reg")).0;
     let ast = elaborate::lower_credit_channel_dispatch(ast).expect("credit_channel");
     let symbols = resolve::resolve(&ast).expect("resolve");
     let checker = TypeChecker::new(&symbols, &ast);

--- a/tests/pipelined_operators_test.rs
+++ b/tests/pipelined_operators_test.rs
@@ -1,0 +1,340 @@
+//! `fma<pipelined, N>` surface + latency typing (proposal phase 2,
+//! `doc/proposal_pipelined_operators.md`).
+//!
+//! Covers: parser accept/reject, registry-miss error text, the
+//! binding/consistency mismatch error, the mixed-latency-expression error,
+//! comb-context rejection, the delay-line "did you mean" warning, and the
+//! worked example end-to-end through `arch check` (codegen is deferred —
+//! see the module doc comment on `src/pipelined_ops.rs` — so `arch build`
+//! is asserted to fail with the explicit deferred-codegen error, not to
+//! succeed).
+
+use std::io::Write;
+use std::process::Command;
+
+fn arch() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_arch"))
+}
+
+/// Writes `src` to a temp `.arch` file and returns (tempdir, path) — the
+/// tempdir must be kept alive for the path to remain valid.
+fn write_arch(src: &str) -> (tempfile::TempDir, std::path::PathBuf) {
+    let td = tempfile::tempdir().expect("tempdir");
+    let path = td.path().join("M.arch");
+    let mut f = std::fs::File::create(&path).expect("create temp .arch");
+    f.write_all(src.as_bytes()).expect("write temp .arch");
+    (td, path)
+}
+
+fn run_check(src: &str) -> std::process::Output {
+    let (_td, path) = write_arch(src);
+    arch()
+        .arg("check")
+        .arg(&path)
+        .output()
+        .expect("run arch check")
+}
+
+/// miette word-wraps rendered error text (inserting a `│` continuation
+/// marker at the start of each wrapped line), so a literal multi-word
+/// substring can straddle a line break. Drop the continuation markers and
+/// collapse all whitespace runs to a single space before substring-matching
+/// so assertions are wrap-insensitive.
+fn normalize(s: &str) -> String {
+    s.split_whitespace()
+        .filter(|tok| *tok != "│")
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn run_build(src: &str) -> std::process::Output {
+    let (td, path) = write_arch(src);
+    let out_sv = td.path().join("M.sv");
+    arch()
+        .arg("build")
+        .arg(&path)
+        .arg("-o")
+        .arg(&out_sv)
+        .output()
+        .expect("run arch build")
+}
+
+const WORKED_EXAMPLE: &str = r#"
+module DotProductStep
+  port clk: in Clock<Sys>;
+  port rst: in Reset<Sync, High>;
+  port a:   in FP32;
+  port b:   in FP32;
+  port acc_in: in FP32;
+  port acc_out: out pipe_reg<FP32, 6>;
+
+  seq on clk rising
+    acc_out@6 <= fma<pipelined, 6>(a, b, acc_in);
+  end seq
+end module DotProductStep
+"#;
+
+/// The proposal's worked example: `arch check` accepts the surface,
+/// resolves the registry entry, and validates the `@6` tap against the
+/// declared depth `6`.
+#[test]
+fn worked_example_passes_check() {
+    let out = run_check(WORKED_EXAMPLE);
+    assert!(
+        out.status.success(),
+        "worked example should pass `arch check`\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+/// Codegen is explicitly deferred (proposal phase 3 — no staged RTL exists
+/// yet for `builtin:fma_f32_s6`, only a synthesis-retiming characterization
+/// the compiler never sees). `arch build` must refuse loudly, not silently
+/// fall back to a comb cone.
+#[test]
+fn worked_example_build_is_explicitly_deferred() {
+    let out = run_build(WORKED_EXAMPLE);
+    assert!(
+        !out.status.success(),
+        "arch build must refuse pipelined-call codegen until phase 3 lands"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        normalize(&stderr).contains("codegen for pipelined operators is not yet implemented"),
+        "expected explicit deferred-codegen error, got:\n{stderr}"
+    );
+}
+
+/// Bare `fma(a, b, c)` (no `<pipelined, N>`) is completely unaffected —
+/// same comb semantics as before this feature landed.
+#[test]
+fn bare_fma_unaffected() {
+    let src = r#"
+module M
+  port a: in FP32;
+  port b: in FP32;
+  port c: in FP32;
+  port o: out FP32;
+  comb
+    o = fma(a, b, c);
+  end comb
+end module M
+"#;
+    let out = run_check(src);
+    assert!(
+        out.status.success(),
+        "bare fma should still typecheck\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+/// Parser reject: depth must be a compile-time integer literal.
+#[test]
+fn parser_rejects_non_literal_depth() {
+    let src = r#"
+module M
+  port a: in FP32;
+  port b: in FP32;
+  port c: in FP32;
+  port o: out FP32;
+  comb
+    o = fma<pipelined, x>(a, b, c);
+  end comb
+end module M
+"#;
+    let out = run_check(src);
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        normalize(&stderr).contains("requires N to be a compile-time integer literal"),
+        "got:\n{stderr}"
+    );
+}
+
+/// Parser/typecheck reject: `<pipelined, N>` on a callee that isn't a
+/// registry-backed operator.
+#[test]
+fn unknown_callee_rejected() {
+    let src = r#"
+module M
+  port a: in UInt<8>;
+  port b: in UInt<8>;
+  port o: out UInt<8>;
+  comb
+    o = foo<pipelined, 6>(a, b);
+  end comb
+end module M
+"#;
+    let out = run_check(src);
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        normalize(&stderr).contains("`foo` is not a registry-backed pipelined operator"),
+        "got:\n{stderr}"
+    );
+}
+
+/// Registry-miss error text must match `pipelined_ops::LookupMiss`'s
+/// `Display` verbatim (reused, not reformatted, per the proposal).
+#[test]
+fn registry_miss_error_is_verbatim() {
+    let src = r#"
+module M
+  port clk: in Clock<Sys>;
+  port rst: in Reset<Sync, High>;
+  port a: in FP32;
+  port b: in FP32;
+  port c: in FP32;
+  port acc_out: out pipe_reg<FP32, 5>;
+  seq on clk rising
+    acc_out@5 <= fma<pipelined, 5>(a, b, c);
+  end seq
+end module M
+"#;
+    let out = run_check(src);
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        normalize(&stderr).contains("no pipelined implementation of fma<FP32> with 5 stages"),
+        "got:\n{stderr}"
+    );
+    assert!(
+        normalize(&stderr).contains("available depths: {6} (run `arch ops` to list all)"),
+        "got:\n{stderr}"
+    );
+}
+
+/// Binding mismatch: `acc@6 <= fma<pipelined, 4>(...)` — call depth (4)
+/// must equal the tap depth (6).
+#[test]
+fn binding_latency_mismatch_is_rejected() {
+    let src = r#"
+module M
+  port clk: in Clock<Sys>;
+  port rst: in Reset<Sync, High>;
+  port a: in FP32;
+  port b: in FP32;
+  port c: in FP32;
+  port acc_out: out pipe_reg<FP32, 6>;
+  seq on clk rising
+    acc_out@6 <= fma<pipelined, 4>(a, b, c);
+  end seq
+end module M
+"#;
+    let out = run_check(src);
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        normalize(&stderr).contains("latency-4 result bound at @6"),
+        "got:\n{stderr}"
+    );
+}
+
+/// Mixed-expression mismatch: combining a latency-6 tap read with a
+/// latency-0 operand in one expression is rejected, naming both cycles.
+#[test]
+fn mixed_latency_expression_is_rejected() {
+    let src = r#"
+module M
+  port clk: in Clock<Sys>;
+  port rst: in Reset<Sync, High>;
+  port a: in FP32;
+  port b: in FP32;
+  port c: in FP32;
+  port x: in FP32;
+  port acc_out: out pipe_reg<FP32, 6>;
+  port bad: out FP32;
+  seq on clk rising
+    acc_out@6 <= fma<pipelined, 6>(a, b, c);
+  end seq
+  comb
+    bad = acc_out@6 + x;
+  end comb
+end module M
+"#;
+    let out = run_check(src);
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        normalize(&stderr).contains("operands at cycle 6 and cycle 0"),
+        "got:\n{stderr}"
+    );
+}
+
+/// Direct comb-context consumption of a latency-N result is rejected.
+#[test]
+fn comb_context_consumption_is_rejected() {
+    let src = r#"
+module M
+  port a: in FP32;
+  port b: in FP32;
+  port c: in FP32;
+  port out1: out FP32;
+  comb
+    out1 = fma<pipelined, 6>(a, b, c);
+  end comb
+end module M
+"#;
+    let out = run_check(src);
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        normalize(&stderr).contains("cannot be used in a `comb` block"),
+        "got:\n{stderr}"
+    );
+}
+
+/// `let` bindings are always combinational — a latency-N `<pipelined, N>`
+/// result cannot be bound there either.
+#[test]
+fn let_binding_consumption_is_rejected() {
+    let src = r#"
+module M
+  port a: in FP32;
+  port b: in FP32;
+  port c: in FP32;
+  port out1: out FP32;
+  let x: FP32 = fma<pipelined, 6>(a, b, c);
+  comb
+    out1 = x;
+  end comb
+end module M
+"#;
+    let out = run_check(src);
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        normalize(&stderr).contains("cannot be used in a `let` binding"),
+        "got:\n{stderr}"
+    );
+}
+
+/// Delay-line trap: `acc@6 <= fma(a,b,c)` (comb fma, *not* pipelined) still
+/// compiles (unchanged pipe_reg delay-line semantics) but warns.
+#[test]
+fn delay_line_trap_warns_not_errors() {
+    let src = r#"
+module M
+  port clk: in Clock<Sys>;
+  port rst: in Reset<Sync, High>;
+  port a: in FP32;
+  port b: in FP32;
+  port c: in FP32;
+  port acc_out: out pipe_reg<FP32, 6>;
+  seq on clk rising
+    acc_out@6 <= fma(a, b, c);
+  end seq
+end module M
+"#;
+    let out = run_check(src);
+    assert!(
+        out.status.success(),
+        "delay-line form should still compile\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        normalize(&stderr).contains("did you mean `fma<pipelined, 6>(...)`?"),
+        "got:\n{stderr}"
+    );
+}


### PR DESCRIPTION
## Summary

Implements **phase 2** of `doc/proposal_pipelined_operators.md` (APPROVED 2026-07-12; phase 1 registry merged in #678): the `fma<pipelined, N>` call surface, its latency typing, and the binding/consistency + no-auto-alignment rules from the proposal's §2. Phase 3 (verified staged datapath) and later phases are explicitly out of scope for this PR.

## What landed

**Parser.** `Name<pipelined, N>(args...)` parses to a new `ExprKind::PipelinedCall` only when the callee is immediately followed by the exact `< pipelined , <int literal> >` shape — any other `<` after an identifier (comparisons, plain calls) is unaffected. `N` is literal-only in v1, mirroring `pipe_reg<T, N>`'s existing depth restriction.

**Typecheck / latency rules** (`src/typecheck.rs`, `src/elaborate.rs`):
- Registry resolution via `pipelined_ops::lookup`; a miss reuses `LookupMiss`'s `Display` **verbatim**:
  ```
  error: no pipelined implementation of fma<FP32> with 5 stages
    available depths: {6}      (run `arch ops` to list all)
  ```
- Binding/consistency: `acc@N <= fma<pipelined, M>(...)` requires `N == M` — `error: latency-4 result bound at @6`. This is enforced in `elaborate::validate_pipe_assign_stmt`, *before* the pipe_reg cascade rewrite strips the `@N` off the target (the call is authoritative; the tap is a consistency check).
- Mixed-latency expressions (binary ops, `fma` args, pipelined-call args) combining different cycle offsets are rejected — `error: operands at cycle 6 and cycle 0`. No auto-alignment in v1, per the proposal's decided answer.
- A latency-N (N>0) result used in a `comb` block or a `let` binding is rejected with a clear error naming the required `seq`/`@N` form.
- Optional warning (implemented): `acc@N <= fma(a,b,c)` (comb `fma` delayed via a pipe_reg tap, *not* `<pipelined, N>`) still compiles — unchanged delay-line semantics, correct values — but warns: `did you mean fma<pipelined, N>(...)?`.

**Codegen — deferred, with reason.** Investigated whether `builtin:fma_f32_s6` is real staged RTL or a synthesis artifact: it is a single combinational cone (`src/fp_ops.rs`, sticky-fold FMA IR) — "6-stage" is purely a downstream Yosys retiming characterization (`buffer -N 8; upsize; dnsize`) the compiler never sees or controls. There is no staged structure either backend can bind to or step cycle-accurately today. Productizing a real staged schedule with a sequential-equivalence proof is proposal **phase 3**.

`arch check` fully accepts `<pipelined, N>` — parsing, registry resolution, and every latency rule above are enforced. `arch build` / `arch sim` refuse **explicitly**, via a new pre-codegen scan (`pipelined_ops::find_pipelined_calls`), rather than silently falling back to an un-retimed comb cone — a silent fallback would risk the two backends' fallback behavior drifting apart (breaking the sim⇄SV equivalence guarantee) and would misrepresent an un-retimed cone as the requested pipelined operator.

**Docs.** New `doc/ARCH_HDL_Specification.md` §3.8a (full syntax, rules, codegen status); `doc/Arch_AI_Reference_Card.md` compact example. Skill snapshots refreshed via `scripts/sync_skill_snapshots.sh refresh`.

**Tests.** `tests/pipelined_operators_test.rs` — 11 new tests: parser accept/reject (bad depth token, non-registry callee), the registry-miss error text (verbatim), the binding-mismatch error, the mixed-expression latency error, comb-context and let-binding rejection, the delay-line "did you mean" warning, and the proposal's worked example end-to-end (`arch check` passes; `arch build` explicitly refuses with the deferred-codegen error, not a silent success).

## Test plan
- [x] `cargo build --release` — clean
- [x] `cargo test --release` — 816 passing (65 lib + 23 formal + 714 integration + 11 new + 3 `arch ops` CLI), 0 failed
- [x] `cargo fmt -- --check` — clean
- [x] `cargo clippy --release --all-targets` — no new warnings in any file this PR touches (all pre-existing warnings are in unrelated, untouched lines of `tests/integration_test.rs`)
- [x] Manual smoke test of the worked example (`arch check` passes; `arch build` fails with the explicit deferred-codegen message) plus all 6 error/warning shapes above, run against a freshly built binary from this worktree

🤖 Generated with [Claude Code](https://claude.com/claude-code)