### PR TITLE
feat(codegen): bind fma<pipelined, 6> to comb+retime staged implementation (proposal phase 3)

### DIFF
--- a/doc/ARCH_HDL_Specification.md
+++ b/doc/ARCH_HDL_Specification.md
@@ -845,14 +845,47 @@ acc_out@6 <= fma(a, b, c);
 //          `fma<pipelined, 6>(...)`?
 ```
 
-**Codegen status.** As of this writing, `arch build` / `arch sim` accept
-`<pipelined, N>` through `arch check` (parsing, registry resolution, and all
-latency-typing rules above are fully enforced) but do not yet bind the call
-to a retimed staged datapath — `arch build`/`arch sim` refuse with an
-explicit "not yet implemented" error rather than silently falling back to an
-un-retimed comb cone. Landing the staged RTL and its sequential-equivalence
-proof is tracked separately; check `arch ops` / the compiler's release notes
-for current status.
+**Codegen status.** `arch build` / `arch sim` bind every registry entry that
+carries a codegen implementation (currently `fma<FP32, 6>`) to the following
+shape: the ordinary combinational operator (`fma(a, b, c)` — the same helper
+bare `fma` calls) feeds the `pipe_reg<T, N>` register cascade the call is
+bound to, i.e. the emitted RTL is *comb operator + N register stages*, not a
+hand-split staged datapath:
+
+```systemverilog
+always_ff @(posedge clk) begin
+  acc_out_stg1 <= arch_fma_f32(a, b, acc_in);  // stage 1: the comb operator
+  acc_out_stg2 <= acc_out_stg1;                // stages 2..N-1: passthrough
+  ...
+  acc_out      <= acc_out_stg5;                // final tap
+end
+```
+
+The native-sim backend mirrors this exactly (the same N-deep shift structure,
+evaluated on the same clock-edge semantics). **Sequential equivalence to the
+comb operator holds by construction**: the staged form is a pure N-cycle
+delay of a value computed by the same already-verified comb IR node, not an
+independently written pipeline that could diverge from it — there is no
+separate "staged datapath" to prove equivalent, only the comb operator (already
+verified — see the FP correctness work referenced in §3.8) plus an ordinary
+register cascade (already verified — same as any other `pipe_reg` write).
+Cross-backend (native-sim ⇄ Verilator-on-emitted-SV) lock-step agreement is
+regression-tested (random operands, back-to-back throughput, mid-stream
+reset).
+
+The **timing win** (the entire point of `<pipelined, N>` over a delay-lined
+comb call) comes from downstream synthesis retiming the register cascade
+across the comb cone — the compiler emits the *shape* that synthesis can
+retime, it does not perform the retiming itself. A registry entry's
+characterized fmax (`arch ops`, `doc/generated/pipelined_ops.md`) reflects
+that downstream synthesis result, not something visible in the emitted RTL
+directly; see `tests/fp_v1/synth/README.md` for the characterization flow and
+its current reproducibility caveats.
+
+A registry row that typechecks but has no codegen binding wired yet (a future
+row landed ahead of its codegen support) still refuses explicitly at `arch
+build` / `arch sim` — "not yet implemented" — rather than silently falling
+back to an un-retimed comb cone; there is no such row today.
 
 **4. Modules**
 

--- a/doc/Arch_AI_Reference_Card.md
+++ b/doc/Arch_AI_Reference_Card.md
@@ -271,7 +271,7 @@ end seq
 let s: FP32 = acc_out@6;                          // consumer reads at latency 6
 ```
 
-`acc@6 <= fma(a,b,c)` (comb `fma` delayed via a pipe_reg tap, not `<pipelined, 6>`) still compiles — same values, just not retimed — but warns: *"did you mean `fma<pipelined, 6>(...)`?"*. Codegen for `<pipelined, N>` (binding to real staged RTL) is not yet implemented as of this writing — `arch check` accepts the surface, `arch build`/`arch sim` refuse explicitly rather than silently emitting an un-retimed comb cone.
+`acc@6 <= fma(a,b,c)` (comb `fma` delayed via a pipe_reg tap, not `<pipelined, 6>`) still compiles — same values, just not retimed — but warns: *"did you mean `fma<pipelined, 6>(...)`?"*. Codegen binds `<pipelined, N>` to the comb operator feeding the `pipe_reg` register cascade (`arch build`/`arch sim` both; sequential equivalence to the comb operator holds by construction — no separately-verified staged datapath). The clock-frequency win comes from downstream synthesis retiming that emitted shape, not from anything the compiler does to the RTL directly.
 
 **Vec methods** (parallel-reduction; fully unrolled; no runtime iteration):
 

--- a/doc/generated/pipelined_ops.md
+++ b/doc/generated/pipelined_ops.md
@@ -9,4 +9,4 @@ Generated listing of the compiler's pipelined-operator implementation registry (
 
 | operator | profile | stages | status | fmax (ng45, typ) | impl | notes |
 |---|---|---|---|---|---|---|
-| `fma` | FP32 | 6 | verified | ~260 MHz | `builtin:fma_f32_s6` | sticky-fold FMA, buffered (Yosys abc: buffer -N 8; upsize; dnsize); 6-stage is the characterized knee vs. 7/10 stages |
+| `fma` | FP32 | 6 | verified | ~260 MHz (external run — see notes) | `builtin:fma_f32_s6` | sticky-fold FMA, buffered (Yosys abc: buffer -N 8; upsize; dnsize) — an EXTERNAL Nangate45 (typ.) Yosys+OpenSTA+Liberty characterization not reproducible by this repo's checked-in flow (no Liberty/OpenSTA in the dev/CI sandbox); 6-stage is the characterized knee vs. 7/10 stages. Codegen = comb `fma` IR + 6 pipe_reg stages, retimed downstream by synthesis (sequential equivalence holds by construction — see this module's doc comment). Reproducible logic-depth proxy (not fmax): tests/fp_v1/synth/run_synth.sh --stages 6 F32Fma, documented in tests/fp_v1/synth/README.md 'Staged/pipelined operators' |

--- a/doc/proposal_pipelined_operators.md
+++ b/doc/proposal_pipelined_operators.md
@@ -4,6 +4,12 @@
 > sign-off), with the conservative v1 answers to both open questions (explicit
 > alignment; `.archpipe` schedule-only). Implementation proceeds per the phase
 > plan below; spec sections land with the implementation PRs, not this doc.
+>
+> **Phases 1–3 DONE (2026-07-12).** `fma<pipelined, 6>` type-checks *and*
+> builds/sims end-to-end on both backends — see phase 3 in "Implementation
+> phases" below for the clarified comb+retime implementation form and where
+> the verification obligation and characterization honesty live. Phases 4–5
+> (`.archpipe` loader, generalizing beyond `fma`) are not started.
 
 Status: design proposal / discussion. No implementation in this note. User-facing
 syntax + type-system change — requires sign-off before any code, and a spec update
@@ -277,14 +283,35 @@ registered depth and that any consumer of `acc_out` reads it at latency 6.
 
 1. **Registry + `arch ops` + enforcement** — table, type-check lookup, enumerated
    error, generated spec section. (No new datapath; wire the existing 6-stage.)
+   **DONE.**
 2. **`fma<pipelined, N>` surface + latency typing** — parser, latency on exprs, the
-   alignment check, codegen binding to `pipe_reg`.
+   alignment check, codegen binding to `pipe_reg`. **DONE.**
 3. **Builtin 6-stage as a `verified` entry** — productize the staging schedule;
    land the sequential-equiv proof obligation that sets `status=verified`.
+   **DONE, with a clarified implementation form** (maintainer note,
+   2026-07-12): the "6-stage" characterization is the proven combinational
+   sticky-fold `fma` cone plus N output register stages, **retimed by
+   downstream synthesis** — not a hand-split staged datapath. So
+   `builtin:fma_f32_s6` lowers (both `arch build` and `arch sim`) to the comb
+   `fma` operator feeding the existing `pipe_reg<T, N>` register cascade; no
+   bespoke staged-datapath codegen exists or is needed (`src/pipelined_ops.rs`
+   module doc comment). Sequential equivalence to the comb operator holds *by
+   construction* (a pure N-cycle delay of an already-verified comb IR node),
+   which is the verification obligation this phase closes — locked by a
+   randomized lock-step regression test (native-sim ⇄ Verilator-on-emitted-SV,
+   `tests/pipelined_fma_lockstep_test.rs`) rather than a separate formal
+   equivalence proof (there is no second implementation to prove equivalent
+   to the first). The registry's `~260 MHz` fmax figure remains an
+   **external** Yosys+OpenSTA+Nangate45 characterization; this repo's
+   checked-in synthesis flow (`tests/fp_v1/synth/run_synth.sh --stages N
+   MODULE`) cannot reproduce it without a Liberty file and OpenSTA (neither
+   available in this repo's sandboxes) — see `tests/fp_v1/synth/README.md`
+   "Staged/pipelined operators" for what the checked-in flow *does*
+   reproduce (a logic-depth proxy) and why.
 4. **`.archpipe` loader + verification gate** — file format, `ARCH_LIB_PATH`
-   discovery, `unverified` warning path, `arch formal` promotion.
+   discovery, `unverified` warning path, `arch formal` promotion. Not started.
 5. **Generalize beyond fma** — `mul_pipe`, `add_pipe`; additional characterized
-   depths.
+   depths. Not started.
 
 ## Open questions
 

--- a/skills/arch-programming/references/ARCH_HDL_Specification.md
+++ b/skills/arch-programming/references/ARCH_HDL_Specification.md
@@ -845,14 +845,47 @@ acc_out@6 <= fma(a, b, c);
 //          `fma<pipelined, 6>(...)`?
 ```
 
-**Codegen status.** As of this writing, `arch build` / `arch sim` accept
-`<pipelined, N>` through `arch check` (parsing, registry resolution, and all
-latency-typing rules above are fully enforced) but do not yet bind the call
-to a retimed staged datapath — `arch build`/`arch sim` refuse with an
-explicit "not yet implemented" error rather than silently falling back to an
-un-retimed comb cone. Landing the staged RTL and its sequential-equivalence
-proof is tracked separately; check `arch ops` / the compiler's release notes
-for current status.
+**Codegen status.** `arch build` / `arch sim` bind every registry entry that
+carries a codegen implementation (currently `fma<FP32, 6>`) to the following
+shape: the ordinary combinational operator (`fma(a, b, c)` — the same helper
+bare `fma` calls) feeds the `pipe_reg<T, N>` register cascade the call is
+bound to, i.e. the emitted RTL is *comb operator + N register stages*, not a
+hand-split staged datapath:
+
+```systemverilog
+always_ff @(posedge clk) begin
+  acc_out_stg1 <= arch_fma_f32(a, b, acc_in);  // stage 1: the comb operator
+  acc_out_stg2 <= acc_out_stg1;                // stages 2..N-1: passthrough
+  ...
+  acc_out      <= acc_out_stg5;                // final tap
+end
+```
+
+The native-sim backend mirrors this exactly (the same N-deep shift structure,
+evaluated on the same clock-edge semantics). **Sequential equivalence to the
+comb operator holds by construction**: the staged form is a pure N-cycle
+delay of a value computed by the same already-verified comb IR node, not an
+independently written pipeline that could diverge from it — there is no
+separate "staged datapath" to prove equivalent, only the comb operator (already
+verified — see the FP correctness work referenced in §3.8) plus an ordinary
+register cascade (already verified — same as any other `pipe_reg` write).
+Cross-backend (native-sim ⇄ Verilator-on-emitted-SV) lock-step agreement is
+regression-tested (random operands, back-to-back throughput, mid-stream
+reset).
+
+The **timing win** (the entire point of `<pipelined, N>` over a delay-lined
+comb call) comes from downstream synthesis retiming the register cascade
+across the comb cone — the compiler emits the *shape* that synthesis can
+retime, it does not perform the retiming itself. A registry entry's
+characterized fmax (`arch ops`, `doc/generated/pipelined_ops.md`) reflects
+that downstream synthesis result, not something visible in the emitted RTL
+directly; see `tests/fp_v1/synth/README.md` for the characterization flow and
+its current reproducibility caveats.
+
+A registry row that typechecks but has no codegen binding wired yet (a future
+row landed ahead of its codegen support) still refuses explicitly at `arch
+build` / `arch sim` — "not yet implemented" — rather than silently falling
+back to an un-retimed comb cone; there is no such row today.
 
 **4. Modules**
 

--- a/skills/arch-programming/references/Arch_AI_Reference_Card.md
+++ b/skills/arch-programming/references/Arch_AI_Reference_Card.md
@@ -271,7 +271,7 @@ end seq
 let s: FP32 = acc_out@6;                          // consumer reads at latency 6
 ```
 
-`acc@6 <= fma(a,b,c)` (comb `fma` delayed via a pipe_reg tap, not `<pipelined, 6>`) still compiles — same values, just not retimed — but warns: *"did you mean `fma<pipelined, 6>(...)`?"*. Codegen for `<pipelined, N>` (binding to real staged RTL) is not yet implemented as of this writing — `arch check` accepts the surface, `arch build`/`arch sim` refuse explicitly rather than silently emitting an un-retimed comb cone.
+`acc@6 <= fma(a,b,c)` (comb `fma` delayed via a pipe_reg tap, not `<pipelined, 6>`) still compiles — same values, just not retimed — but warns: *"did you mean `fma<pipelined, 6>(...)`?"*. Codegen binds `<pipelined, N>` to the comb operator feeding the `pipe_reg` register cascade (`arch build`/`arch sim` both; sequential equivalence to the comb operator holds by construction — no separately-verified staged datapath). The clock-frequency win comes from downstream synthesis retiming that emitted shape, not from anything the compiler does to the RTL directly.
 
 **Vec methods** (parallel-reduction; fully unrolled; no runtime iteration):
 

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -5703,16 +5703,18 @@ impl<'a> Codegen<'a> {
     /// Core expression emitter — never adds outer parens itself.
     fn emit_expr_inner(&self, expr: &Expr) -> String {
         match &expr.kind {
-            // Retimed-datapath codegen for `<pipelined, N>` calls is not
-            // implemented yet (proposal phase 3 — see
-            // `pipelined_ops::find_pipelined_calls`, called before codegen
-            // starts so this arm should be unreachable in practice; kept
+            // `pipelined_ops::lower_pipelined_calls` (proposal phase 3)
+            // rewrites every codegen-backed `PipelinedCall` into a plain
+            // `FunctionCall` before codegen starts, and
+            // `main.rs::lower_pipelined_calls_before_codegen` refuses to
+            // proceed (with a clear error) for any row lacking a codegen
+            // binding. So this arm should be unreachable in practice; kept
             // as a loud backstop rather than silently falling back to a
             // comb cone, which would misrepresent an un-retimed operator
-            // as pipelined).
+            // as pipelined.
             ExprKind::PipelinedCall(name, _, stages) => unreachable!(
                 "codegen reached `{name}<pipelined, {stages}>(...)` — this should have been \
-                 rejected by pipelined_ops::find_pipelined_calls before codegen started"
+                 lowered by pipelined_ops::lower_pipelined_calls before codegen started"
             ),
             // `q@K` on RHS lowers to the K-th tap of the pipe_reg
             // chain (`q` being the final flop, source being the input

--- a/src/main.rs
+++ b/src/main.rs
@@ -510,38 +510,35 @@ impl MultiSource {
     }
 }
 
-/// Codegen-side backstop for `arch build` / `arch sim` (not `arch check`,
-/// which fully supports `<pipelined, N>` through typecheck): refuses to
-/// proceed into SV or sim codegen if the program still contains any
-/// `fma<pipelined, N>(...)`-style call. Binding these to a real retimed
-/// staged datapath is proposal phase 3
-/// (doc/proposal_pipelined_operators.md) — `builtin:fma_f32_s6` today is a
-/// single combinational cone, not staged RTL; see
-/// `pipelined_ops` module docs for the investigation that established
-/// this. Surfacing a clear, explicit error here is safer than silently
-/// falling back to comb + delay-line, which would compute correct values
-/// but misrepresent an un-retimed cone as the requested pipelined
-/// operator — and would risk the two backends (SV, sim) diverging if
-/// either one's fallback ever drifted from the other's.
-fn reject_pipelined_calls_before_codegen(
-    ast: &arch::ast::SourceFile,
+/// Codegen-side binding for `arch build` / `arch sim` (not `arch check`,
+/// which fully supports `<pipelined, N>` through typecheck alone): rewrites
+/// every `fma<pipelined, N>(...)`-style call reaching codegen into the
+/// plain comb call the registry's `codegen_impl` binds it to (proposal
+/// phase 3, `doc/proposal_pipelined_operators.md` — see `pipelined_ops`
+/// module docs for the comb+retime shape and why no bespoke staged-datapath
+/// codegen is needed). Registry rows that typecheck but have no
+/// `codegen_impl` wired yet (`codegen_impl: None` — a future row landed
+/// ahead of its codegen support) still refuse loudly here, exactly like
+/// the phase-2 backstop did unconditionally, rather than silently falling
+/// back to comb + delay-line (which would compute correct values but
+/// misrepresent an un-retimed cone as the requested pipelined operator).
+fn lower_pipelined_calls_before_codegen(
+    ast: &mut arch::ast::SourceFile,
     ms: &MultiSource,
 ) -> miette::Result<()> {
-    let found = arch::pipelined_ops::find_pipelined_calls(ast);
-    if let Some(f) = found.into_iter().next() {
+    arch::pipelined_ops::lower_pipelined_calls(ast).map_err(|f| {
         let err = CompileError::general(
             &format!(
                 "`{}<pipelined, {}>(...)` typechecks (`arch check` accepts it) but codegen for \
-                 pipelined operators is not yet implemented — the retimed staged datapath and its \
-                 equivalence proof are proposal phase 3 (doc/proposal_pipelined_operators.md), not yet \
-                 landed. Tracked in the phase-2 PR; not supported by `arch build` / `arch sim` yet.",
+                 this depth is not yet implemented — no `codegen_impl` is wired for this registry \
+                 row (doc/proposal_pipelined_operators.md phase 3/4). Not supported by \
+                 `arch build` / `arch sim` yet.",
                 f.operator, f.stages
             ),
             f.span,
         );
-        return Err(ms.report_error(err));
-    }
-    Ok(())
+        ms.report_error(err)
+    })
 }
 
 fn thread_map_sources_from_multi(ms: &MultiSource) -> Vec<arch::thread_map::ThreadMapSource> {
@@ -1177,13 +1174,14 @@ fn main() -> miette::Result<()> {
                         arch::thread_map::ThreadMap::default(),
                     ))
                 });
-                let (ast, symbols, overload_map) = run_check_multi_opts_with_thread_map(
+                let (mut ast, symbols, overload_map) = run_check_multi_opts_with_thread_map(
                     &ms,
                     false,
                     auto_thread_asserts,
                     thread_map_store.clone(),
                 )?;
-                reject_pipelined_calls_before_codegen(&ast, &ms)?;
+                lower_pipelined_calls_before_codegen(&mut ast, &ms)?;
+                let ast = ast;
                 let thread_map_sources = thread_map_sources_from_multi(&ms);
 
                 let comments = lexer::extract_comments(&ms.combined);
@@ -1881,7 +1879,7 @@ fn run_sim_opts(
     // 1. Parse + type-check
     let all_files = resolve_use_imports(arch_files)?;
     let ms = MultiSource::from_files(&all_files)?;
-    let (ast, symbols, overload_map) = if param_overrides.is_empty() {
+    let (mut ast, symbols, overload_map) = if param_overrides.is_empty() {
         run_check_multi_opts(
             &ms,
             thread_sim_parallel,
@@ -1895,7 +1893,8 @@ fn run_sim_opts(
             param_overrides,
         )?
     };
-    reject_pipelined_calls_before_codegen(&ast, &ms)?;
+    lower_pipelined_calls_before_codegen(&mut ast, &ms)?;
+    let ast = ast;
 
     // 2. Set up output directory
     let build_dir = outdir

--- a/src/pipelined_ops.rs
+++ b/src/pipelined_ops.rs
@@ -6,27 +6,47 @@
 //!
 //! Phase 2 (this module, additionally) wires up the `fma<pipelined, N>`
 //! call surface, parsed as `ast::ExprKind::PipelinedCall`, and its latency
-//! typing (see `typecheck.rs`'s `PipelinedCall` handling). Codegen —
-//! binding the call to an actual retimed staged datapath in `arch build`
-//! / `arch sim` — is deferred: `builtin:fma_f32_s6` today is a single
-//! combinational cone (`src/fp_ops.rs`), not staged RTL; "6-stage" is
-//! purely a downstream Yosys synthesis-retiming characterization the
-//! compiler never sees. Productizing a real staged schedule with an
-//! equivalence proof is proposal phase 3. `find_pipelined_calls` below is
-//! the codegen-side backstop: `arch build` / `arch sim` scan the
-//! elaborated module bodies for any `PipelinedCall` and refuse with a
-//! clear "not yet implemented" error rather than silently falling back to
-//! comb + delay-line (which would be functionally correct but would
-//! misrepresent an un-retimed cone as the requested pipelined operator).
-//! `arch check` does not run this scan — typecheck alone is fully
-//! supported.
+//! typing (see `typecheck.rs`'s `PipelinedCall` handling).
+//!
+//! Phase 3 (this module, additionally) binds `builtin:fma_f32_s6` to a
+//! real codegen shape: **the existing verified combinational sticky-fold
+//! FMA (`src/fp_ops.rs`, called the same way bare `fma(a,b,c)` is) feeding
+//! the N-deep `pipe_reg` register chain the call is bound to.** The
+//! characterized "6-stage, ~260 MHz" datapath in the registry notes is
+//! this exact shape — comb cone + N output register stages — run through
+//! Yosys/abc retiming (`buffer -N 8; upsize; dnsize`); the compiler does
+//! not need to hand-split the datapath because retiming does that job
+//! downstream. Concretely: `lower_pipelined_calls` (below) rewrites every
+//! `PipelinedCall(op, args, N)` reaching codegen into a plain
+//! `FunctionCall(op, args)` — the `elaborate::lower_pipe_reg_ports` cascade
+//! rewrite (which runs *before* typecheck) has already turned
+//! `acc@N <= op<pipelined, N>(args)` into `acc_stg1 <= op<pipelined, N>(args); acc_stg2 <= acc_stg1; ...`,
+//! so once the call itself collapses to the ordinary comb form, the
+//! existing pipe_reg register-cascade codegen (shared by `arch build` and
+//! `arch sim` — both already emit N flops per pipe_reg port) does the
+//! rest, with **no bespoke staged-datapath codegen required**. Sequential
+//! equivalence to the comb operator is therefore true *by construction*:
+//! the retimed datapath is a pure N-cycle delay of a value computed by the
+//! same trusted comb IR node, not an independent hand-written pipeline
+//! that could diverge from it.
+//!
+//! `lower_pipelined_calls` only performs this rewrite for registry entries
+//! whose `codegen_impl` is `Some(_)`. Entries with `codegen_impl: None`
+//! (future registry rows added ahead of their codegen support landing)
+//! still hit the same "typechecks but codegen is not yet implemented"
+//! error `arch build` / `arch sim` used to raise unconditionally — so a
+//! future un-wired row fails loudly instead of silently falling back to
+//! an un-retimed comb cone. `arch check` never calls this pass — typecheck
+//! alone is fully supported for any registered row regardless of codegen
+//! status.
 //!
 //! The registry key is `(operator, profile, stages)`. Entries carry a
 //! verification `status`: `verified` means the staged IR has been proven
-//! sequentially equivalent to the trusted combinational operator (see
-//! phase 3 of the proposal for wiring the FMA proof obligation);
-//! `unverified` entries (added by future `.archpipe` loading, phase 4) are
-//! usable only with an explicit opt-in.
+//! sequentially equivalent to the trusted combinational operator — true by
+//! construction for `builtin:fma_f32_s6` per the paragraph above, since
+//! the "staged IR" *is* the comb IR plus registers, not a separate
+//! datapath; `unverified` entries (added by future `.archpipe` loading,
+//! phase 4) are usable only with an explicit opt-in.
 
 use std::fmt;
 
@@ -75,6 +95,14 @@ pub struct PipelinedOpEntry {
     pub impl_id: &'static str,
     /// Free-text characterization / provenance notes.
     pub notes: Option<&'static str>,
+    /// Codegen binding: the name of the plain combinational operator this
+    /// entry retimes (e.g. `Some("fma")` — codegen calls it exactly the
+    /// way bare `fma(a, b, c)` is called, then relies on the surrounding
+    /// `pipe_reg` cascade for the N register stages). `None` means the
+    /// entry has typecheck support (via `lookup`) but no codegen binding
+    /// yet — `arch build` / `arch sim` refuse with a "not yet implemented"
+    /// error rather than silently emitting an un-retimed comb cone.
+    pub codegen_impl: Option<&'static str>,
 }
 
 /// The compiler-owned builtin registry.
@@ -92,12 +120,21 @@ pub const BUILTIN_REGISTRY: &[PipelinedOpEntry] = &[PipelinedOpEntry {
     profile: "FP32",
     stages: 6,
     status: VerifyStatus::Verified,
-    fmax_ng45_typ: Some("~260 MHz"),
+    fmax_ng45_typ: Some("~260 MHz (external run — see notes)"),
     impl_id: "builtin:fma_f32_s6",
     notes: Some(
-        "sticky-fold FMA, buffered (Yosys abc: buffer -N 8; upsize; dnsize); \
-         6-stage is the characterized knee vs. 7/10 stages",
+        "sticky-fold FMA, buffered (Yosys abc: buffer -N 8; upsize; dnsize) — an \
+         EXTERNAL Nangate45 (typ.) Yosys+OpenSTA+Liberty characterization not \
+         reproducible by this repo's checked-in flow (no Liberty/OpenSTA in \
+         the dev/CI sandbox); 6-stage is the characterized knee vs. 7/10 \
+         stages. Codegen = comb `fma` IR + 6 pipe_reg stages, retimed \
+         downstream by synthesis (sequential equivalence holds by \
+         construction — see this module's doc comment). Reproducible \
+         logic-depth proxy (not fmax): tests/fp_v1/synth/run_synth.sh \
+         --stages 6 F32Fma, documented in tests/fp_v1/synth/README.md \
+         'Staged/pipelined operators'",
     ),
+    codegen_impl: Some("fma"),
 }];
 
 /// Returns the builtin registry rows, sorted deterministically by
@@ -433,6 +470,218 @@ fn scan_expr(expr: &crate::ast::Expr, out: &mut Vec<FoundPipelinedCall>) {
         }
         Literal(_) | Ident(_) | SynthIdent(_, _) | EnumVariant(_, _) | Todo | Bool(_) => {}
     }
+}
+
+/// Resolves the codegen binding for `(operator, stages)` — Phase 3. Scans
+/// every registry row matching `operator`/`stages` (profile-agnostic: the
+/// bound comb function, e.g. `"fma"`, is itself polymorphic over profile
+/// the same way bare `fma(a, b, c)` is, so codegen does not need to
+/// rediscover the profile typecheck already resolved). Returns:
+///
+/// - `Ok(fn_name)` if at least one matching row has `codegen_impl: Some(_)`.
+/// - `Err(())` if every matching row (there must be at least one — a
+///   program reaching this call already passed typecheck's `lookup`) has
+///   `codegen_impl: None`: a registered-but-not-yet-implemented row, which
+///   must fail loudly rather than silently falling back to an un-retimed
+///   comb cone.
+fn resolve_codegen_impl(operator: &str, stages: u32) -> Result<&'static str, ()> {
+    BUILTIN_REGISTRY
+        .iter()
+        .filter(|e| e.operator == operator && e.stages == stages)
+        .find_map(|e| e.codegen_impl)
+        .ok_or(())
+}
+
+/// Phase-3 codegen-facing lowering: rewrites every `PipelinedCall(op, args, N)`
+/// reachable from a module's `comb`/`seq`/`latch` blocks or `let` bindings
+/// into the plain `FunctionCall(op, args)` the existing comb-operator
+/// codegen (`arch build` and `arch sim` alike) already fully supports.
+///
+/// Must run **after** typecheck (which validated the `(operator, profile,
+/// stages)` registry lookup and all the latency-alignment / binding rules)
+/// and **after** `elaborate::lower_pipe_reg_ports` (which already turned
+/// `acc@N <= op<pipelined, N>(args)` into the register cascade
+/// `acc_stg1 <= op<pipelined, N>(args); acc_stg2 <= acc_stg1; ...; acc <= acc_stg{N-1};`
+/// — so by the time this pass runs, every remaining `PipelinedCall` sits as
+/// the direct RHS of the first cascade stage, and stripping it down to the
+/// bare comb call is sufficient: the surrounding N-deep register chain
+/// (already emitted by ordinary pipe_reg codegen) supplies the retiming.
+///
+/// Returns the first registry-lacks-codegen error encountered (mirroring
+/// the Phase 2 `reject_pipelined_calls_before_codegen` error text) so
+/// `arch build` / `arch sim` can still refuse loudly for any future
+/// registry row added ahead of its codegen support landing. `arch check`
+/// must not call this — it only cares about typecheck's `lookup`, not
+/// codegen availability.
+pub fn lower_pipelined_calls(
+    source: &mut crate::ast::SourceFile,
+) -> Result<(), FoundPipelinedCall> {
+    use crate::ast::{Item, ModuleBodyItem};
+    for item in &mut source.items {
+        if let Item::Module(m) = item {
+            for bi in &mut m.body {
+                match bi {
+                    ModuleBodyItem::CombBlock(cb) => lower_stmts(&mut cb.stmts)?,
+                    ModuleBodyItem::RegBlock(rb) => lower_stmts(&mut rb.stmts)?,
+                    ModuleBodyItem::LatchBlock(lb) => lower_stmts(&mut lb.stmts)?,
+                    ModuleBodyItem::LetBinding(l) => lower_expr(&mut l.value)?,
+                    _ => {}
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn lower_stmts(stmts: &mut [crate::ast::Stmt]) -> Result<(), FoundPipelinedCall> {
+    for s in stmts {
+        lower_stmt(s)?;
+    }
+    Ok(())
+}
+
+fn lower_stmt(stmt: &mut crate::ast::Stmt) -> Result<(), FoundPipelinedCall> {
+    use crate::ast::Stmt;
+    match stmt {
+        Stmt::Assign(a) => lower_expr(&mut a.value)?,
+        Stmt::IfElse(ie) => {
+            lower_expr(&mut ie.cond)?;
+            lower_stmts(&mut ie.then_stmts)?;
+            lower_stmts(&mut ie.else_stmts)?;
+        }
+        Stmt::Match(m) => {
+            lower_expr(&mut m.scrutinee)?;
+            for arm in &mut m.arms {
+                lower_stmts(&mut arm.body)?;
+            }
+        }
+        Stmt::Log(l) => {
+            for a in &mut l.args {
+                lower_expr(a)?;
+            }
+        }
+        Stmt::For(f) => lower_stmts(&mut f.body)?,
+        Stmt::Init(i) => lower_stmts(&mut i.body)?,
+        Stmt::WaitUntil(e, _) => lower_expr(e)?,
+        Stmt::DoUntil { body, cond, .. } => {
+            lower_stmts(body)?;
+            lower_expr(cond)?;
+        }
+    }
+    Ok(())
+}
+
+fn lower_expr(expr: &mut crate::ast::Expr) -> Result<(), FoundPipelinedCall> {
+    use crate::ast::ExprKind::*;
+    // First recurse into children so a `PipelinedCall` nested inside a
+    // larger expression (not just the direct RHS of a cascade stage) is
+    // also lowered — matches `scan_expr`'s traversal shape.
+    match &mut expr.kind {
+        Binary(_, a, b) => {
+            lower_expr(a)?;
+            lower_expr(b)?;
+        }
+        Unary(_, e)
+        | Cast(e, _)
+        | LatencyAt(e, _)
+        | SvaNext(_, e)
+        | Signed(e)
+        | Unsigned(e)
+        | Clog2(e)
+        | Onehot(e)
+        | Repeat(e, _) => lower_expr(e)?,
+        FieldAccess(e, _) => lower_expr(e)?,
+        MethodCall(recv, _, args) => {
+            lower_expr(recv)?;
+            for a in args {
+                lower_expr(a)?;
+            }
+        }
+        Index(base, idx) => {
+            lower_expr(base)?;
+            lower_expr(idx)?;
+        }
+        BitSlice(base, hi, lo) => {
+            lower_expr(base)?;
+            lower_expr(hi)?;
+            lower_expr(lo)?;
+        }
+        PartSelect(base, start, width, _) => {
+            lower_expr(base)?;
+            lower_expr(start)?;
+            lower_expr(width)?;
+        }
+        StructLiteral(_, fields) => {
+            for f in fields {
+                lower_expr(&mut f.value)?;
+            }
+        }
+        Match(scrut, arms) => {
+            lower_expr(scrut)?;
+            for arm in arms {
+                lower_stmts(&mut arm.body)?;
+            }
+        }
+        ExprMatch(scrut, arms) => {
+            lower_expr(scrut)?;
+            for arm in arms {
+                lower_expr(&mut arm.value)?;
+            }
+        }
+        Concat(xs) | FunctionCall(_, xs) => {
+            for x in xs {
+                lower_expr(x)?;
+            }
+        }
+        Inside(e, members) => {
+            lower_expr(e)?;
+            for m in members {
+                match m {
+                    crate::ast::InsideMember::Single(v) => lower_expr(v)?,
+                    crate::ast::InsideMember::Range(lo, hi) => {
+                        lower_expr(lo)?;
+                        lower_expr(hi)?;
+                    }
+                }
+            }
+        }
+        Ternary(c, t, e) => {
+            lower_expr(c)?;
+            lower_expr(t)?;
+            lower_expr(e)?;
+        }
+        PipelinedCall(_, args, _) => {
+            for a in args {
+                lower_expr(a)?;
+            }
+        }
+        Literal(_) | Ident(_) | SynthIdent(_, _) | EnumVariant(_, _) | Todo | Bool(_) => {}
+    }
+    // Now lower this node itself, if it is a PipelinedCall.
+    if let PipelinedCall(name, _, stages) = &expr.kind {
+        let (name, stages) = (name.clone(), *stages);
+        match resolve_codegen_impl(&name, stages) {
+            Ok(fn_name) => {
+                // Replace `PipelinedCall(name, args, stages)` with the
+                // equivalent bare `FunctionCall(name, args)` — see the
+                // module doc comment: the N register stages are supplied
+                // by the surrounding pipe_reg cascade, not by this node.
+                let old = std::mem::replace(&mut expr.kind, Todo);
+                let PipelinedCall(_, args, _) = old else {
+                    unreachable!("matched PipelinedCall above")
+                };
+                expr.kind = FunctionCall(fn_name.to_string(), args);
+            }
+            Err(()) => {
+                return Err(FoundPipelinedCall {
+                    operator: name,
+                    stages,
+                    span: expr.span,
+                });
+            }
+        }
+    }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src/sim_codegen/mod.rs
+++ b/src/sim_codegen/mod.rs
@@ -3487,14 +3487,14 @@ fn cpp_expr_lhs(expr: &Expr, ctx: &Ctx) -> String {
 
 fn cpp_expr_inner(expr: &Expr, ctx: &Ctx, is_lhs: bool) -> String {
     match &expr.kind {
-        // See the matching arm in codegen/mod.rs::emit_expr_inner: retimed
-        // sim stepping for `<pipelined, N>` calls is proposal phase 3, not
-        // yet implemented. `pipelined_ops::find_pipelined_calls` rejects
-        // these before sim codegen starts, so this is a loud backstop, not
-        // the primary error path.
+        // See the matching arm in codegen/mod.rs::emit_expr_inner:
+        // `pipelined_ops::lower_pipelined_calls` (proposal phase 3)
+        // rewrites every codegen-backed `PipelinedCall` into a plain
+        // `FunctionCall` before sim codegen starts, so this is a loud
+        // backstop, not the primary error path.
         ExprKind::PipelinedCall(name, _, stages) => unreachable!(
             "sim codegen reached `{name}<pipelined, {stages}>(...)` — this should have been \
-             rejected by pipelined_ops::find_pipelined_calls before codegen started"
+             lowered by pipelined_ops::lower_pipelined_calls before codegen started"
         ),
         // Latency annotation: transparent to sim emission. The assignment
         // site handles directing the write to stage 0 of the pipe chain;

--- a/tests/fp_v1/synth/README.md
+++ b/tests/fp_v1/synth/README.md
@@ -12,7 +12,8 @@ It complements the correctness work (`tests/fp_v1/smt_proof`,
 ## Running
 
 ```
-tests/fp_v1/synth/run_synth.sh [outdir]
+tests/fp_v1/synth/run_synth.sh [outdir]                    # combinational sweep, all FP ops
+tests/fp_v1/synth/run_synth.sh --stages N MODULE [outdir]  # staged/pipelined operator (phase 3)
 ```
 
 Requires `yosys` (≥0.30) and `python3`. Builds a fresh release `arch` by default
@@ -33,35 +34,104 @@ written back into the repo tree.
 4. yosys `synth -flatten` → `abc -fast -g <2-input gates>` → `ltp` (longest
    topological path = logic depth) + `stat` (cell count).
 
-## Results (yosys 0.33, `abc -fast`, 2-input generic gates)
+## Results (yosys 0.64, `abc -fast`, 2-input generic gates)
+
+Regenerated 2026-07-12 (proposal-phase-3 pass over this flow) after fixing a
+yosys-version-drift bug in this script: yosys 0.64's `stat`/`ltp` text no
+longer matches the phrasing (`"Number of cells:"`) an older 0.33-era version
+of this script parsed, so every row below silently printed `?` until the
+parser was updated to match 0.64's plain `"<N> cells"` format. The absolute
+numbers therefore also shifted from the previously-committed 0.33 table
+(different yosys/abc version ⇒ different optimization result) — this is the
+**current, reproducible-on-this-toolchain** table; re-run the script yourself
+to confirm.
 
 | operator | gate cells (area proxy) | logic depth (levels) |
 |---|---:|---:|
-| `bf16_to_f32` (widen) | 30 | 5 |
-| `f32_to_bf16` (narrow) | 90 | 9 |
-| `bf16_mul` | 2,242 | 143 |
-| `f32_mul` | 5,948 | 147 |
-| `f32_add` | 4,270 | 183 |
-| `f32_sub` | 4,269 | 183 |
-| `bf16_add` | 3,797 | 192 |
-| `bf16_sub` | 3,764 | 194 |
-| `bf16_fma` | 32,077 | 236 |
-| `f32_fma` | 38,064 | 235 |
+| `bf16_to_f32` (widen) | 22 | 5 |
+| `f32_to_bf16` (narrow) | 83 | 17 |
+| `bf16_mul` | 1,124 | 110 |
+| `f32_mul` | 4,864 | 186 |
+| `f32_add` | 1,814 | 169 |
+| `f32_sub` | 1,820 | 178 |
+| `bf16_add` | 1,015 | 124 |
+| `bf16_sub` | 1,073 | 128 |
+| `bf16_fma` | 3,799 | 279 |
+| `f32_fma` | 8,927 | 301 |
 
 ### Reading it
 
-- **Conversions are nearly free** (depth 5–9) — field manipulation + one round.
-- **Multiply is shallower than add** (147 vs 183). The bounded f32 adder's serial
-  chain (exponent compare → barrel-shift align → add → leading-zero count →
-  normalize shift → round) is the long pole; the multiplier's partial-product
-  tree reduces in ~log depth.
+- **Conversions are nearly free** (depth 5–17) — field manipulation + one round.
+- **Multiply is shallower than add** (186 vs 169–178 — note add/sub depth is
+  now *below* multiply on this yosys version's optimization result, the
+  opposite ranking from the 0.33-era table; see the caveats below on why
+  cross-operator depth ranking is the only robust signal, not multiply-vs-add
+  ordering specifically). The bounded f32 adder's serial chain (exponent
+  compare → barrel-shift align → add → leading-zero count → normalize shift →
+  round) and the multiplier's partial-product-tree reduction both live in the
+  100–300-level range.
 - **bf16 arith ≈ f32 arith in depth**, because bf16 = widen→f32 op→narrow: it
-  *reuses* the f32 datapath. bf16 has fewer cells (narrower significand) but the
-  same critical-path structure, and add/sub edge slightly deeper than f32 from
-  the extra narrow stage.
-- **FMA is the critical operator** — depth ~235, ~32–38k gates — from the
-  exact-wide 470-bit alignment + normalization (the design trades area/depth for
-  not needing sticky-fold logic; the same width that keeps the Lean proof clean).
+  *reuses* the f32 datapath. bf16 has fewer cells (narrower significand) but
+  broadly the same critical-path structure.
+- **FMA is the critical operator** — depth ~279–301, the deepest of any op —
+  from `fma()`'s bounded sticky-fold alignment (`src/fp_ops.rs::fma_f32`,
+  *not* the exact-wide 470-bit reference kept only for the Lean/SMT proof
+  miter — see that function's doc comment) plus normalization/rounding. This
+  is exactly the operator the pipelined-operator registry
+  (`doc/proposal_pipelined_operators.md`) targets for retiming — see
+  "Staged/pipelined operators" below.
+
+## Staged/pipelined operators (`--stages N MODULE`, proposal phase 3)
+
+`doc/proposal_pipelined_operators.md`'s registry carries a characterized fmax
+per `(operator, profile, stages)` row — today just `fma<FP32, 6>`, noted as
+"~260 MHz (Yosys abc: `buffer -N 8; upsize; dnsize`)". That figure comes from
+an **external** run: Yosys + OpenSTA against a Nangate45 (typ.) Liberty file,
+which this repo's checked-in flow cannot reproduce — neither a Liberty file
+nor OpenSTA is available in this repo's dev/CI sandboxes, only open-source
+`yosys`/`abc` with generic 2-input gates.
+
+`run_synth.sh --stages 6 F32Fma` emits the same shape `arch build` binds
+`fma<pipelined, 6>` to (comb `arch_fma_f32` feeding the 6-deep `pipe_reg`
+cascade — see `src/pipelined_ops.rs` module docs), then runs it through
+`abc -fast -g <gates>`, whose default script always includes ABC's `dretime`
+sequential-retiming pass (`yosys -h abc`) — the generic-gate-mapping analogue
+of the registry note's recipe, minus the `-liberty`/`-constr`-driven
+`buffer`/`upsize`/`dnsize` steps (those require a cell library).
+
+**Reproduced here (yosys 0.64, generic gates, 2026-07-12):**
+
+| module | cells | dff bits | `ltp -noff` (logic-depth proxy) |
+|---|---:|---:|---:|
+| `F32FmaS6` (`fma<pipelined, 6>`, 6 stages) | 10,640 | 384 | 485 |
+
+**This is not the ~260 MHz figure, and is not claimed to be.** Two honest
+findings from reproducing this locally:
+
+1. Open-source `abc`'s `dretime` (no `-liberty`, no `-D` delay target) does
+   **not** redistribute the register cascade across the comb cone in this
+   environment — `ltp -noff`'s reported longest path (485 levels) runs from
+   a primary input straight into the *first* cascade register
+   (`y_stg1`), i.e. still the un-rebalanced full comb depth, matching the
+   un-staged `f32_fma` combinational depth (301, `F32Fma`, table above) plus
+   the DFF-insertion overhead from `synth -flatten`'s technology mapping.
+   Passing `-D <ps>` to `abc -fast` (which the `abc` help says substitutes
+   `dretime` for `dretime; retime -o {D}`) was tried and made no observed
+   difference either, in this yosys/abc build.
+2. Achieving the registry's ~260 MHz figure requires the `-liberty`/`-constr`
+   ABC script variant (`strash; dretime; map {D}; buffer; upsize {D}; dnsize
+   {D}; stime -p`) against a real cell library plus OpenSTA for the
+   post-map static timing report — neither of which ships in this repo's
+   sandbox. The ~260 MHz number in the registry (`src/pipelined_ops.rs`)
+   is retained as the external-run characterization it always was; this
+   section documents, rather than silently omits, that the checked-in flow
+   does not reproduce it, and reports what it *does* reproduce (a
+   logic-depth proxy) instead of fabricating a substitute fmax number.
+
+If a Liberty file and OpenSTA become available in a future environment, wire
+`abc -liberty <cells.lib> -constr <constr>` and an OpenSTA `report_checks`
+pass into the `--stages` branch of `run_synth.sh` and replace this section
+with the real, reproducible fmax.
 
 ## Caveats
 

--- a/tests/fp_v1/synth/run_synth.sh
+++ b/tests/fp_v1/synth/run_synth.sh
@@ -13,13 +13,39 @@
 # binary fresh by default (the repo's no-stale-binary rule); set ARCH_BIN to
 # reuse one you trust.
 #
-# Usage:   tests/fp_v1/synth/run_synth.sh [outdir]
-# Output:  a results table on stdout; per-op logs under <outdir> (default: a
-#          temp dir). Nothing is written back into the repo tree.
+# Usage (combinational sweep, all FP operators):
+#   tests/fp_v1/synth/run_synth.sh [outdir]
+#
+# Usage (staged/pipelined operator — proposal phase 3,
+# doc/proposal_pipelined_operators.md — registry characterization flow):
+#   tests/fp_v1/synth/run_synth.sh --stages N MODULE [outdir]
+#
+#   Emits a `port reg`/`pipe_reg<T,N>` wrapper around the registry operator
+#   (currently only `F32Fma` → `fma<pipelined, N>`), builds it through `arch
+#   build` (comb helper + N-deep register cascade — see `src/pipelined_ops.rs`
+#   module docs for why this shape is sufficient, no separate staged-datapath
+#   codegen exists), and runs it through the same yosys flow with the ABC
+#   `dretime` sequential-retiming pass exercised (the `abc -fast` default
+#   script always runs `strash; dretime; map`, per `yosys -h abc`) — the
+#   generic-gate-mapping analogue of the registry note's
+#   "Yosys abc: buffer -N 8; upsize; dnsize" recipe (that exact recipe is an
+#   ABC `-liberty`/`-constr` script variant; no Liberty file or OpenSTA is
+#   available in this repo's CI/dev sandboxes, so it is not reproduced here —
+#   see README.md's "Staged/pipelined operators" section for what IS
+#   reproducible with the checked-in toolchain).
 set -euo pipefail
 
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 repo="$(cd "$here/../../.." && pwd)"
+
+stages=""
+stage_module=""
+if [[ "${1:-}" == "--stages" ]]; then
+  stages="$2"
+  stage_module="$3"
+  shift 3
+fi
+
 outdir="${1:-$(mktemp -d)}"
 mkdir -p "$outdir"
 
@@ -27,6 +53,69 @@ if [[ -z "${ARCH_BIN:-}" ]]; then
   echo "# building arch (release)…" >&2
   ( cd "$repo" && cargo build --release --bin arch >&2 )
   ARCH_BIN="$repo/target/release/arch"
+fi
+
+# ── Staged/pipelined-operator mode (--stages N MODULE) ─────────────────────
+if [[ -n "$stages" ]]; then
+  case "$stage_module" in
+    F32Fma)
+      emit_stage() {
+        cat > "$outdir/$1.arch" <<EOF
+module $1
+  port clk: in Clock<Sys>;
+  port rst: in Reset<Sync, High>;
+  port a: in FP32;
+  port b: in FP32;
+  port c: in FP32;
+  port y: out pipe_reg<FP32, $stages>;
+
+  seq on clk rising
+    y@$stages <= fma<pipelined, $stages>(a, b, c);
+  end seq
+end module $1
+EOF
+      }
+      ;;
+    *)
+      echo "unknown --stages MODULE '$stage_module' (only F32Fma is registered — see \`arch ops\`)" >&2
+      exit 1
+      ;;
+  esac
+  t="${stage_module}S${stages}"
+  emit_stage "$t"
+  "$ARCH_BIN" build "$outdir/$t.arch" -o "$outdir/$t.sv" >&2
+  python3 "$here/hoist_decls.py" < "$outdir/$t.sv" > "$outdir/$t.v"
+  cat > "$outdir/_$t.ys" <<EOF
+read_verilog -sv $t.v
+hierarchy -top $t
+proc
+synth -top $t -flatten
+abc -fast -g AND,OR,XOR,NAND,NOR,XNOR,ANDNOT,ORNOT,MUX
+opt_clean
+stat
+ltp -noff
+EOF
+  ( cd "$outdir" && yosys "_$t.ys" > "log_$t.txt" 2>&1 )
+
+  cells=$(grep -m1 -E "^[[:space:]]*[0-9]+ cells$" "$outdir/log_$t.txt" | grep -oE "[0-9]+" || echo "?")
+  dffs=$(grep -oE '[0-9]+[[:space:]]+\$_S?DFF[A-Z_]*_' "$outdir/log_$t.txt" | grep -oE '^[0-9]+' | awk '{s+=$1} END{print s+0}' || echo 0)
+  depth=$(grep -m1 "Longest topological path" "$outdir/log_$t.txt" | grep -oE "length=[0-9]+" | grep -oE "[0-9]+" || echo "?")
+  printf '\n%-16s %12s %12s %12s\n' "module" "cells" "dff-bits" "ltp -noff"
+  printf '%-16s %12s %12s %12s\n' "------" "-----" "--------" "---------"
+  printf '%-16s %12s %12s %12s\n' "$t" "$cells" "$dffs" "$depth"
+  echo
+  echo "# stages=$stages; dff-bits is the total flip-flop bit count post-synth"
+  echo "# (cascade regs + reset mux logic; not simply (stages-1)*32 — abc's mapping"
+  echo "# folds the reset-select mux into extra \$_SDFF*_ cells)."
+  echo "# 'ltp -noff' is the longest FF-excluded topological path in the *whole*"
+  echo "# flattened netlist, i.e. still the un-rebalanced input->first-register comb"
+  echo "# depth (open-source abc's default 'dretime' pass did not redistribute"
+  echo "# registers across the comb cone with generic 2-input gates / no -liberty"
+  echo "# target in this environment — see README.md 'Staged/pipelined operators'"
+  echo "# section for the honest reproducibility statement). This is a logic-depth"
+  echo "# proxy, NOT an fmax number."
+  echo "# logs + netlists in: $outdir"
+  exit 0
 fi
 
 emit() { printf '%s\n' "$2" > "$outdir/$1.arch"; }
@@ -78,13 +167,13 @@ for t in "${ops[@]}"; do
   "$ARCH_BIN" build "$outdir/$t.arch" -o "$outdir/$t.sv" >&2
   python3 "$here/hoist_decls.py" < "$outdir/$t.sv" > "$outdir/$t.v"
   sed "s/TOP/$t/g" "$here/flow.ys.tmpl" > "$outdir/_$t.ys"
-  ( cd "$outdir" && yosys -q "_$t.ys" > "log_$t.txt" 2>&1 )
+  ( cd "$outdir" && yosys "_$t.ys" > "log_$t.txt" 2>&1 )
 done
 
 printf '\n%-12s %12s %12s\n' "operator" "cells" "depth"
 printf '%-12s %12s %12s\n' "--------" "-----" "-----"
 for t in "${ops[@]}"; do
-  cells=$(grep -m1 "Number of cells:" "$outdir/log_$t.txt" | grep -oE "[0-9]+" || echo "?")
+  cells=$(grep -m1 -E "^[[:space:]]*[0-9]+ cells$" "$outdir/log_$t.txt" | grep -oE "[0-9]+" || echo "?")
   depth=$(grep -m1 "Longest topological path" "$outdir/log_$t.txt" | grep -oE "length=[0-9]+" | grep -oE "[0-9]+" || echo "?")
   printf '%-12s %12s %12s\n' "$t" "$cells" "$depth"
 done

--- a/tests/pipelined_fma_lockstep_test.rs
+++ b/tests/pipelined_fma_lockstep_test.rs
@@ -1,0 +1,352 @@
+//! `fma<pipelined, 6>` codegen (proposal phase 3,
+//! `doc/proposal_pipelined_operators.md`) — cross-backend verification.
+//!
+//! `src/pipelined_ops.rs`'s module doc comment argues sequential equivalence
+//! to the comb `fma` operator holds *by construction*: the "staged IR" is
+//! literally the comb operator feeding the ordinary `pipe_reg` register
+//! cascade, not an independently hand-written pipeline that could diverge.
+//! This file is the empirical half of that verification obligation:
+//!
+//! - [`pipelined_fma_latency_is_exactly_six_native_sim`]: the native-sim
+//!   result appears at exactly cycle `t+6` for an input driven at cycle `t`,
+//!   not `t+5` or `t+7`.
+//! - [`pipelined_fma_lockstep_sim_vs_verilator`]: a >=1000-cycle randomized,
+//!   back-to-back-throughput lock-step run — same stimulus fed to the
+//!   native-sim backend and to Verilator on the emitted SV, every-cycle
+//!   output compared bit-for-bit, including a mid-stream reset pulse.
+//!   Skips cleanly when Verilator is not installed.
+
+fn arch() -> std::process::Command {
+    std::process::Command::new(env!("CARGO_BIN_EXE_arch"))
+}
+
+fn verilator_available() -> bool {
+    std::process::Command::new("verilator")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+const MODULE_SRC: &str = r#"
+module F32FmaPipe6Lockstep
+  port clk: in Clock<Sys>;
+  port rst: in Reset<Sync, High>;
+  port a: in FP32;
+  port b: in FP32;
+  port c: in FP32;
+  port y: out pipe_reg<FP32, 6> reset rst => 0.0;
+
+  seq on clk rising
+    y@6 <= fma<pipelined, 6>(a, b, c);
+  end seq
+end module F32FmaPipe6Lockstep
+"#;
+
+/// Deterministic stimulus generator shared verbatim (byte-for-byte, via
+/// string interpolation of the same Rust `const`) between the native-sim and
+/// Verilator testbenches below — the whole point of the lock-step check is
+/// that both backends see *identical* inputs, so any output divergence is a
+/// backend bug, not a stimulus mismatch. `hash` is the public-domain
+/// murmur3-style integer finalizer (splitmix-adjacent bit-mixing, no
+/// dependency on either backend's own RNG); operating on the full 32-bit
+/// range means many cycles land on NaN/Inf/subnormal bit patterns, not just
+/// "nice" floats — deliberately, since `fma` must be bit-exact there too.
+const STIM_CPP: &str = r#"
+static inline uint32_t lockstep_hash(uint32_t x) {
+    x ^= x >> 16; x *= 0x7feb352du;
+    x ^= x >> 15; x *= 0x846ca68bu;
+    x ^= x >> 16;
+    return x;
+}
+static inline void gen_stim(int cyc, uint32_t &a, uint32_t &b, uint32_t &c, int &rst) {
+    a = lockstep_hash((uint32_t)cyc * 3u + 1u);
+    b = lockstep_hash((uint32_t)cyc * 3u + 2u);
+    c = lockstep_hash((uint32_t)cyc * 3u + 3u);
+    // Mid-stream reset pulse (back-to-back inputs keep flowing before/after).
+    rst = (cyc >= 700 && cyc < 703) ? 1 : 0;
+}
+"#;
+
+const TOTAL_CYCLES: usize = 1200;
+
+fn tb_native() -> String {
+    format!(
+        r#"
+#include "VF32FmaPipe6Lockstep.h"
+#include <cstdio>
+#include <cstdint>
+{STIM_CPP}
+int main() {{
+    VF32FmaPipe6Lockstep dut;
+    dut.rst = 1; dut.a = 0; dut.b = 0; dut.c = 0;
+    dut.clk = 0; dut.eval();
+    dut.clk = 1; dut.eval();
+    dut.rst = 0;
+    for (int cyc = 0; cyc < {TOTAL_CYCLES}; cyc++) {{
+        uint32_t a, b, c; int rst;
+        gen_stim(cyc, a, b, c, rst);
+        dut.a = a; dut.b = b; dut.c = c; dut.rst = (unsigned)rst;
+        dut.clk = 0; dut.eval();
+        dut.clk = 1; dut.eval();
+        printf("%d %u %08x\n", cyc, (unsigned)dut.rst, (unsigned)dut.y);
+    }}
+    return 0;
+}}
+"#
+    )
+}
+
+fn tb_verilator() -> String {
+    format!(
+        r#"
+#include "VF32FmaPipe6Lockstep.h"
+#include <cstdio>
+#include <cstdint>
+{STIM_CPP}
+int main() {{
+    VF32FmaPipe6Lockstep dut;
+    dut.rst = 1; dut.a = 0; dut.b = 0; dut.c = 0;
+    dut.clk = 0; dut.eval();
+    dut.clk = 1; dut.eval();
+    dut.rst = 0;
+    for (int cyc = 0; cyc < {TOTAL_CYCLES}; cyc++) {{
+        uint32_t a, b, c; int rst;
+        gen_stim(cyc, a, b, c, rst);
+        dut.a = a; dut.b = b; dut.c = c; dut.rst = (unsigned)rst;
+        dut.clk = 0; dut.eval();
+        dut.clk = 1; dut.eval();
+        printf("%d %u %08x\n", cyc, (unsigned)dut.rst, (unsigned)dut.y);
+    }}
+    return 0;
+}}
+"#
+    )
+}
+
+/// Latency-exactness: a single fma driven for one cycle then held constant
+/// (comb inputs stay stable) must surface at the output register at exactly
+/// cycle index 6 (0-indexed from the first clocked input), not 5 or 7.
+#[test]
+fn pipelined_fma_latency_is_exactly_six_native_sim() {
+    let td = tempfile::tempdir().expect("tempdir");
+    let arch_path = td.path().join("F32FmaPipe6Lockstep.arch");
+    std::fs::write(&arch_path, MODULE_SRC).expect("write .arch");
+
+    let tb_path = td.path().join("tb.cpp");
+    std::fs::write(
+        &tb_path,
+        r#"
+#include "VF32FmaPipe6Lockstep.h"
+#include <cstdio>
+union F32 { float f; unsigned u; };
+static unsigned f32(float x) { F32 v; v.f = x; return v.u; }
+static float f32_from(unsigned u) { F32 v; v.u = u; return v.f; }
+int main() {
+    VF32FmaPipe6Lockstep dut;
+    dut.rst = 1; dut.a = 0; dut.b = 0; dut.c = 0;
+    dut.clk = 0; dut.eval();
+    dut.clk = 1; dut.eval();
+    dut.rst = 0;
+    dut.a = f32(2.0f);
+    dut.b = f32(3.0f);
+    dut.c = f32(1.0f);
+    for (int cyc = 0; cyc < 10; cyc++) {
+        dut.clk = 0; dut.eval();
+        dut.clk = 1; dut.eval();
+        printf("%d %.6f\n", cyc, f32_from(dut.y));
+    }
+    return 0;
+}
+"#,
+    )
+    .expect("write tb.cpp");
+
+    let out = arch()
+        .arg("sim")
+        .arg(&arch_path)
+        .arg("--tb")
+        .arg(&tb_path)
+        .arg("--outdir")
+        .arg(td.path())
+        .output()
+        .expect("run arch sim");
+    assert!(
+        out.status.success(),
+        "arch sim should build/run\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    // fma(2,3,1) = 7. Cycles 0..4 must NOT show 7.0 (result not arrived
+    // yet); cycle 5 (the 6th posedge after the input was driven, 0-indexed)
+    // must show 7.0 — and hold from there on (comb inputs are stable).
+    let lines: Vec<&str> = stdout
+        .lines()
+        .filter(|l| l.starts_with(char::is_numeric))
+        .collect();
+    assert!(lines.len() >= 10, "expected 10 cycle lines, got:\n{stdout}");
+    for (cyc, line) in lines.iter().enumerate().take(10) {
+        let val: f32 = line
+            .split_whitespace()
+            .nth(1)
+            .expect("cycle value field")
+            .parse()
+            .expect("parse cycle value");
+        if cyc < 5 {
+            assert!(
+                (val - 7.0).abs() > 1e-6,
+                "cycle {cyc} should NOT yet show fma result 7.0 (latency-6 not \
+                 reached), got {val} — full output:\n{stdout}"
+            );
+        } else {
+            assert!(
+                (val - 7.0).abs() < 1e-6,
+                "cycle {cyc} should show fma(2,3,1)=7.0 (latency-6 reached), \
+                 got {val} — full output:\n{stdout}"
+            );
+        }
+    }
+}
+
+/// The main lock-step check: >=1000 cycles, randomized full-32-bit operand
+/// coverage, back-to-back inputs every cycle (throughput=1, no bubbles), and
+/// a mid-stream reset pulse (cycles 700..703) — native sim and Verilator
+/// (on the same `arch build` SV) must agree bit-for-bit on `y` and on `rst`
+/// echo, every single cycle.
+#[test]
+fn pipelined_fma_lockstep_sim_vs_verilator() {
+    if !verilator_available() {
+        eprintln!("skipping pipelined_fma_lockstep_sim_vs_verilator: verilator not in PATH");
+        return;
+    }
+
+    let td = tempfile::tempdir().expect("tempdir");
+    let arch_path = td.path().join("F32FmaPipe6Lockstep.arch");
+    std::fs::write(&arch_path, MODULE_SRC).expect("write .arch");
+
+    // ── Native sim run ──────────────────────────────────────────────────
+    let native_tb = td.path().join("tb_native.cpp");
+    std::fs::write(&native_tb, tb_native()).expect("write native tb");
+    let native_outdir = td.path().join("native_out");
+    std::fs::create_dir_all(&native_outdir).unwrap();
+    let sim_out = arch()
+        .arg("sim")
+        .arg(&arch_path)
+        .arg("--tb")
+        .arg(&native_tb)
+        .arg("--outdir")
+        .arg(&native_outdir)
+        .output()
+        .expect("run arch sim");
+    assert!(
+        sim_out.status.success(),
+        "arch sim should build/run\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&sim_out.stdout),
+        String::from_utf8_lossy(&sim_out.stderr)
+    );
+    let native_stdout = String::from_utf8_lossy(&sim_out.stdout).to_string();
+
+    // ── SV build + Verilator run ────────────────────────────────────────
+    let sv_path = td.path().join("F32FmaPipe6Lockstep.sv");
+    let build_out = arch()
+        .arg("build")
+        .arg(&arch_path)
+        .arg("-o")
+        .arg(&sv_path)
+        .output()
+        .expect("run arch build");
+    assert!(
+        build_out.status.success(),
+        "arch build should succeed (phase 3: fma<pipelined, 6> now binds to \
+         comb+cascade codegen)\nstderr:\n{}",
+        String::from_utf8_lossy(&build_out.stderr)
+    );
+
+    let verilator_tb = td.path().join("tb_verilator.cpp");
+    std::fs::write(&verilator_tb, tb_verilator()).expect("write verilator tb");
+    let obj_dir = td.path().join("obj_dir");
+    let verilate = std::process::Command::new("verilator")
+        .arg("--cc")
+        .arg("--exe")
+        .arg("--build")
+        .arg("--sv")
+        .arg("--assert")
+        .arg("-Wno-fatal")
+        .arg("-Wno-WIDTH")
+        .arg("-Wno-DECLFILENAME")
+        .arg("--top-module")
+        .arg("F32FmaPipe6Lockstep")
+        .arg("-Mdir")
+        .arg(&obj_dir)
+        .arg(&sv_path)
+        .arg(&verilator_tb)
+        .output()
+        .expect("verilate");
+    assert!(
+        verilate.status.success(),
+        "Verilator build should pass\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&verilate.stdout),
+        String::from_utf8_lossy(&verilate.stderr)
+    );
+    let exe = obj_dir.join("VF32FmaPipe6Lockstep");
+    let run = std::process::Command::new(&exe)
+        .output()
+        .expect("run verilated sim");
+    assert!(
+        run.status.success(),
+        "Verilator sim should pass\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    let sv_stdout = String::from_utf8_lossy(&run.stdout).to_string();
+
+    // ── Lock-step comparison ────────────────────────────────────────────
+    let native_lines: Vec<&str> = native_stdout.lines().collect();
+    let sv_lines: Vec<&str> = sv_stdout.lines().collect();
+    assert_eq!(
+        native_lines.len(),
+        TOTAL_CYCLES,
+        "native sim should print exactly {TOTAL_CYCLES} lines, got {}:\n{native_stdout}",
+        native_lines.len()
+    );
+    assert_eq!(
+        sv_lines.len(),
+        TOTAL_CYCLES,
+        "Verilator should print exactly {TOTAL_CYCLES} lines, got {}:\n{sv_stdout}",
+        sv_lines.len()
+    );
+    let mut mismatches = Vec::new();
+    for cyc in 0..TOTAL_CYCLES {
+        if native_lines[cyc] != sv_lines[cyc] {
+            mismatches.push(format!(
+                "cycle {cyc}: native=`{}` sv=`{}`",
+                native_lines[cyc], sv_lines[cyc]
+            ));
+        }
+    }
+    assert!(
+        mismatches.is_empty(),
+        "sim/SV lock-step mismatch(es) — sequential-equivalence-by-construction \
+         violated ({} of {TOTAL_CYCLES} cycles differ):\n{}",
+        mismatches.len(),
+        mismatches.join("\n")
+    );
+
+    // Sanity: the reset pulse must actually have been exercised by both
+    // backends (not a vacuously-passing empty-diff from a stimulus bug) —
+    // `y` must return to the reset value (0.0 = 0x00000000) at some cycle
+    // shortly after the 700..703 reset pulse, then diverge from it again
+    // once fresh post-reset results arrive 6 cycles later.
+    let post_reset_zero = native_lines
+        .iter()
+        .skip(703)
+        .take(6)
+        .any(|l| l.ends_with(" 00000000"));
+    assert!(
+        post_reset_zero,
+        "expected a reset-value (0x00000000) cycle shortly after the mid-stream \
+         reset pulse in native sim output — reset pulse may not have been \
+         exercised:\n{native_stdout}"
+    );
+}

--- a/tests/pipelined_operators_test.rs
+++ b/tests/pipelined_operators_test.rs
@@ -1,13 +1,14 @@
-//! `fma<pipelined, N>` surface + latency typing (proposal phase 2,
-//! `doc/proposal_pipelined_operators.md`).
+//! `fma<pipelined, N>` surface + latency typing (proposal phase 2) and its
+//! codegen binding (proposal phase 3), `doc/proposal_pipelined_operators.md`.
 //!
 //! Covers: parser accept/reject, registry-miss error text, the
 //! binding/consistency mismatch error, the mixed-latency-expression error,
 //! comb-context rejection, the delay-line "did you mean" warning, and the
-//! worked example end-to-end through `arch check` (codegen is deferred —
-//! see the module doc comment on `src/pipelined_ops.rs` — so `arch build`
-//! is asserted to fail with the explicit deferred-codegen error, not to
-//! succeed).
+//! worked example end-to-end through `arch check` AND (phase 3) `arch
+//! build`, which now binds the call to comb `fma` + the pipe_reg register
+//! cascade — see the module doc comment on `src/pipelined_ops.rs`.
+//! Cross-backend (sim ⇄ Verilator) lock-step equivalence and the
+//! latency-exactness check live in `tests/pipelined_fma_lockstep_test.rs`.
 
 use std::io::Write;
 use std::process::Command;
@@ -47,18 +48,6 @@ fn normalize(s: &str) -> String {
         .join(" ")
 }
 
-fn run_build(src: &str) -> std::process::Output {
-    let (td, path) = write_arch(src);
-    let out_sv = td.path().join("M.sv");
-    arch()
-        .arg("build")
-        .arg(&path)
-        .arg("-o")
-        .arg(&out_sv)
-        .output()
-        .expect("run arch build")
-}
-
 const WORKED_EXAMPLE: &str = r#"
 module DotProductStep
   port clk: in Clock<Sys>;
@@ -87,22 +76,66 @@ fn worked_example_passes_check() {
     );
 }
 
-/// Codegen is explicitly deferred (proposal phase 3 — no staged RTL exists
-/// yet for `builtin:fma_f32_s6`, only a synthesis-retiming characterization
-/// the compiler never sees). `arch build` must refuse loudly, not silently
-/// fall back to a comb cone.
+/// Phase 3: `arch build` now binds `fma<pipelined, 6>` to the comb `fma`
+/// helper (`arch_fma_f32`) feeding the 6-deep pipe_reg register cascade —
+/// see `src/pipelined_ops.rs` module docs for why no bespoke staged-datapath
+/// codegen is needed (the cascade already exists for ordinary `pipe_reg`
+/// ports; this just supplies its stage-1 input from the comb operator
+/// instead of a plain `let`/assignment).
 #[test]
-fn worked_example_build_is_explicitly_deferred() {
-    let out = run_build(WORKED_EXAMPLE);
+fn worked_example_builds_comb_plus_cascade() {
+    let (_td, path) = write_arch(WORKED_EXAMPLE);
+    let sv_path = path.with_extension("sv");
+    let out = arch()
+        .arg("build")
+        .arg(&path)
+        .arg("-o")
+        .arg(&sv_path)
+        .output()
+        .expect("run arch build");
     assert!(
-        !out.status.success(),
-        "arch build must refuse pipelined-call codegen until phase 3 lands"
+        out.status.success(),
+        "arch build should bind fma<pipelined, 6> to comb+cascade (phase 3)\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
     );
-    let stderr = String::from_utf8_lossy(&out.stderr);
+    let sv = std::fs::read_to_string(&sv_path).expect("read emitted SV");
+    // Stage 1 gets the comb call; stages 2..N are pure passthrough; the
+    // final `acc_out` register (declared latency-1, per
+    // `elaborate::lower_pipe_reg_ports`) is the last stage of the cascade.
     assert!(
-        normalize(&stderr).contains("codegen for pipelined operators is not yet implemented"),
-        "expected explicit deferred-codegen error, got:\n{stderr}"
+        sv.contains("acc_out_stg1 <= arch_fma_f32(a, b, acc_in);"),
+        "expected comb fma feeding stage 1, got:\n{sv}"
     );
+    for k in 2..=5 {
+        assert!(
+            sv.contains(&format!(
+                "acc_out_stg{k} <= acc_out_stg{prev};",
+                prev = k - 1
+            )),
+            "expected passthrough cascade stage {k}, got:\n{sv}"
+        );
+    }
+    assert!(
+        sv.contains("acc_out <= acc_out_stg5;"),
+        "expected final tap from stage 5, got:\n{sv}"
+    );
+    // No leftover `pipelined` surface text should reach the SV — it must
+    // have been fully lowered to the plain comb call.
+    assert!(
+        !sv.contains("pipelined"),
+        "no trace of the `<pipelined, N>` surface should reach emitted SV, got:\n{sv}"
+    );
+}
+
+/// `arch ops` — the registry entry now shows `verified` end-to-end, and
+/// codegen actually exists for it (phase 3 closes the loop the registry's
+/// `status` field promised).
+#[test]
+fn arch_ops_shows_verified_fma_row() {
+    let out = arch().arg("ops").output().expect("run arch ops");
+    assert!(out.status.success(), "arch ops should succeed");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("fma") && stdout.contains("FP32") && stdout.contains("verified"));
 }
 
 /// Bare `fma(a, b, c)` (no `<pipelined, N>`) is completely unaffected —

--- a/tests/pipelined_ops_cli_test.rs
+++ b/tests/pipelined_ops_cli_test.rs
@@ -45,7 +45,12 @@ fn ops_text_listing_snapshot() {
     assert_eq!(cells[3], "verified");
     assert_eq!(cells[4], "~260");
     assert_eq!(cells[5], "MHz");
-    assert_eq!(cells[6], "builtin:fma_f32_s6");
+    // fmax cell is now an annotated "~260 MHz (external run — see notes)"
+    // (proposal phase 3 — see src/pipelined_ops.rs registry entry notes for
+    // why this repo's checked-in synth flow doesn't reproduce it), so the
+    // `impl` column has shifted further right; only its value (the last
+    // whitespace-split cell) is a stable assertion target.
+    assert_eq!(cells.last().copied(), Some("builtin:fma_f32_s6"));
     assert!(stdout.contains("fma<FP32, 6>:"));
 }
 
@@ -73,5 +78,7 @@ fn ops_markdown_listing_is_well_formed() {
     assert!(stdout.starts_with("<!-- GENERATED FILE. DO NOT EDIT BY HAND."));
     assert!(stdout
         .contains("| operator | profile | stages | status | fmax (ng45, typ) | impl | notes |"));
-    assert!(stdout.contains("| `fma` | FP32 | 6 | verified | ~260 MHz | `builtin:fma_f32_s6` |"));
+    assert!(stdout.contains(
+        "| `fma` | FP32 | 6 | verified | ~260 MHz (external run — see notes) | `builtin:fma_f32_s6` |"
+    ));
 }


### PR DESCRIPTION
## Summary

Phase 3 of `doc/proposal_pipelined_operators.md`: `arch build` / `arch sim` now bind `fma<pipelined, 6>` to a real codegen shape instead of refusing with the phase-2 "not yet implemented" backstop.

Per the maintainer-clarified implementation form (2026-07-12), the characterized "6-stage" FMA is **the proven combinational sticky-fold `fma()` operator plus N output register stages, retimed downstream by synthesis** — not a hand-split staged datapath. Concretely:

- New pass `pipelined_ops::lower_pipelined_calls` (runs after typecheck and after `elaborate::lower_pipe_reg_ports`'s pipe_reg cascade rewrite, before codegen) rewrites every codegen-backed `PipelinedCall` into the plain `FunctionCall` the existing pipe_reg register-cascade codegen already fully supports, for both the SV backend and the native-sim backend. **No bespoke staged-datapath codegen is needed** — the emitted shape is `acc_stg1 <= arch_fma_f32(a,b,c); acc_stg2 <= acc_stg1; ...; acc <= acc_stg5;`.
- Registry entries without a codegen binding (`codegen_impl: None`) still refuse loudly with the "not yet implemented" error — a future registry row added ahead of its codegen support fails loudly, not silently.
- Sequential equivalence to the comb operator holds **by construction**: the staged form is a pure N-cycle delay of an already-verified comb IR node, not an independently written pipeline. Locked by a randomized lock-step regression test (`tests/pipelined_fma_lockstep_test.rs`) comparing native sim against Verilator on the emitted SV — 1200 cycles, full-32-bit-range randomized operands, back-to-back throughput, mid-stream reset pulse, bit-exact agreement every cycle.
- `tests/fp_v1/synth/run_synth.sh` gets a `--stages N MODULE` characterization mode. While extending it, found and fixed a yosys-0.64-vs-0.33 log-format drift bug that had been silently breaking the *existing* combinational sweep's cell/depth parsing (every row was printing `?`); both the refreshed combinational table and the new staged-mode numbers in `tests/fp_v1/synth/README.md` are freshly reproduced on this toolchain.
- The registry's `~260 MHz` fmax figure is an **external** Yosys+OpenSTA+Nangate45-Liberty characterization. This repo's sandbox has neither a Liberty file nor OpenSTA, so the checked-in `--stages` flow cannot reproduce it — documented explicitly (registry notes + README) rather than fabricated; the checked-in flow instead reports and documents a logic-depth proxy (`ltp -noff` = 485, dff-bits = 384, cells = 10,640 for the 6-stage FMA).
- Spec, AI reference card, and proposal doc updated from "type-checks but does not yet build" to the real comb+retime semantics; `doc/generated/pipelined_ops.md` regenerated; arch-programming skill snapshots refreshed.

## Test plan

- [x] `cargo build --release` clean
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --release --all-targets` — no new warnings in any touched file (pre-existing warnings elsewhere untouched)
- [x] `cargo test --release` — full suite green, including `lake build` under `proofs/lean_thread_lowering` for the two Lean-replay tests
- [x] New/updated tests: `tests/pipelined_fma_lockstep_test.rs` (latency-exactness + 1200-cycle sim⇄Verilator lock-step, skips cleanly without Verilator), `tests/pipelined_operators_test.rs` (worked example now builds successfully, asserts the exact comb+cascade SV shape, `arch ops` shows `verified`), `tests/pipelined_ops_cli_test.rs` (updated for the new registry notes text)
- [x] Manually verified `arch build`/`arch sim` on the worked example: SV shows `acc_out_stg1 <= arch_fma_f32(a, b, acc_in);` cascading through 5 stages; native sim shows `fma(2,3,1)=7.0` landing at exactly cycle 5 (6th posedge), not before

🤖 Generated with [Claude Code](https://claude.com/claude-code)