### PR TITLE
doc: declare the .md spec canonical; retire stale .docx references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,8 +36,9 @@ the failure is unrelated or explicitly accepted.
 
 `arch-com` is a compiler for **ARCH**, a purpose-built hardware description language (HDL) for micro-architecture work. The compiler ingests `.arch` source files and emits deterministic, readable SystemVerilog. The language is explicitly designed to be generated correctly by LLMs from natural-language hardware descriptions.
 
-Full specification: `doc/ARCH_HDL_Specification.docx`
-Compact AI reference: `doc/Arch_AI_Reference_Card.docx`
+Full specification: `doc/ARCH_HDL_Specification.md` (canonical — greppable,
+diffable, CI-checked via the skill-snapshot sync; no binary twin exists)
+Compact AI reference: `doc/Arch_AI_Reference_Card.md`
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,8 +110,9 @@ never said so. Rules:
 
 `arch-com` is a compiler for **ARCH**, a purpose-built hardware description language (HDL) for micro-architecture work. The compiler ingests `.arch` source files and emits deterministic, readable SystemVerilog. The language is explicitly designed to be generated correctly by LLMs from natural-language hardware descriptions.
 
-Full specification: `doc/ARCH_HDL_Specification.docx`
-Compact AI reference: `doc/Arch_AI_Reference_Card.docx`
+Full specification: `doc/ARCH_HDL_Specification.md` (canonical — greppable,
+diffable, CI-checked via the skill-snapshot sync; no binary twin exists)
+Compact AI reference: `doc/Arch_AI_Reference_Card.md`
 
 ---
 

--- a/doc/ARCH_HDL_Specification.md
+++ b/doc/ARCH_HDL_Specification.md
@@ -4,6 +4,12 @@ Hardware Description Language
 
 Language Specification · v0.60.0 · May 2026
 
+> **Canonical source.** This Markdown file is the normative ARCH language
+> specification. There is no binary (.docx) twin — historical references to
+> one are stale. User-facing language changes must update this file in the
+> same PR (see CLAUDE.md, "Fix-PR lifecycle"); the bundled skill snapshot
+> under `skills/arch-programming/references/` is kept in sync by CI.
+
 *A purpose-built micro-architecture HDL --- clean RTL semantics, strong types, and first-class pipelines, FSMs, FIFOs, and arbiters. Incorrect design patterns --- multiple drivers, undriven ports, clock-domain crossings, width mismatches --- are compile-time errors, never runtime surprises. Designed to be generated correctly by AI without prior training.*
 
 **1. Design Philosophy**

--- a/skills/arch-programming/references/ARCH_HDL_Specification.md
+++ b/skills/arch-programming/references/ARCH_HDL_Specification.md
@@ -4,6 +4,12 @@ Hardware Description Language
 
 Language Specification · v0.60.0 · May 2026
 
+> **Canonical source.** This Markdown file is the normative ARCH language
+> specification. There is no binary (.docx) twin — historical references to
+> one are stale. User-facing language changes must update this file in the
+> same PR (see CLAUDE.md, "Fix-PR lifecycle"); the bundled skill snapshot
+> under `skills/arch-programming/references/` is kept in sync by CI.
+
 *A purpose-built micro-architecture HDL --- clean RTL semantics, strong types, and first-class pipelines, FSMs, FIFOs, and arbiters. Incorrect design patterns --- multiple drivers, undriven ports, clock-domain crossings, width mismatches --- are compile-time errors, never runtime surprises. Designed to be generated correctly by AI without prior training.*
 
 **1. Design Philosophy**


### PR DESCRIPTION
P6 item from the improvement plan: make the Markdown spec canonical, retire the .docx twins.

Investigation result: the .docx files are not in the repo at all — only stale references survived (AGENTS.md + CLAUDE.md "Full specification: doc/ARCH_HDL_Specification.docx"). The .md files are the maintained reality (every user-facing change lands in them; the skill-snapshot CI check keeps the bundled copies in sync).

Changes: canonical-source note at the top of doc/ARCH_HDL_Specification.md; AGENTS.md + CLAUDE.md pointers updated to the .md files; skill snapshots refreshed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)