### PR TITLE
feat(threads): re-enable comb overlap optimization with lock-state tagging (part of #501)

### DIFF
--- a/doc/thread_spec_section.md
+++ b/doc/thread_spec_section.md
@@ -504,8 +504,9 @@ The overlap is Mealy-style: the next state's outputs respond to the transition c
 
 The overlap also does not apply to:
 - multi-transition states (fork/join dispatch, `if`/`else` dispatch) — the successor is condition-dependent
-- TLM target return states
 - terminal states of `thread once` (self-loop; nothing to overlap)
+
+TLM method target threads are lowered by a dedicated response-router path and do not participate in the overlap.  As with each state's own comb arm, a thread's `default_when` condition does not gate the overlap arm — `default_when` preempts the *seq* side (state register and registered assigns) only.
 
 ## 20.16  Auto-Emitted Spec-Contract SVA (`--auto-thread-asserts`)
 

--- a/doc/thread_spec_section.md
+++ b/doc/thread_spec_section.md
@@ -475,7 +475,39 @@ The merge fires `ar_done_r <= 1` on the same clock edge as the `ar_ready` handsh
 
 If the seq assign appears after a multi-transition state (e.g. inside a `for` loop), the compiler uses the loop exit condition as the guard instead of every iteration.
 
-## 20.15  Auto-Emitted Spec-Contract SVA (`--auto-thread-asserts`)
+## 20.15  Comb Overlap Across State Transitions
+
+When a state's single conditional transition fires (`wait until cond` or `do..until cond`), the compiler additionally drives the **next state's comb outputs during the transition cycle**.  This removes the dead cycle between back-to-back states:
+
+```arch
+thread on clk rising, rst_n low
+  ar_valid = 1;
+  ar_addr  = 32'd100;
+  wait until ar_ready;   // ← the cycle ar_ready is high, r_ready is ALREADY driven
+
+  r_ready = 1;
+  wait until r_valid;
+  data_r <= r_data;
+end thread
+```
+
+The generated comb block contains an overlap arm alongside the normal per-state arm:
+
+```sv
+if (_t0_state == _t0_S1_wait_until) r_ready = 1;                 // normal
+if (_t0_state == _t0_S0_wait_until && ar_ready) r_ready = 1;     // overlap
+```
+
+The overlap is Mealy-style: the next state's outputs respond to the transition condition combinationally, one cycle before the state register advances.  Register values read by those outputs are the *pre-transition* values (the transition edge has not fired yet).
+
+**The overlap never applies when the next state is inside a `lock` body.** Lock-body outputs are gated by the arbiter grant (§20.8, §20.13); driving them from the preceding state would leak critical-section signals before the grant cycle.  Transitions *into* a lock block therefore always take the full cycle — the lock's own zero-cycle grant path (§20.13) is the mechanism that removes lock-entry latency, not the overlap.
+
+The overlap also does not apply to:
+- multi-transition states (fork/join dispatch, `if`/`else` dispatch) — the successor is condition-dependent
+- TLM target return states
+- terminal states of `thread once` (self-loop; nothing to overlap)
+
+## 20.16  Auto-Emitted Spec-Contract SVA (`--auto-thread-asserts`)
 
 Off-by-default flag on `arch build` / `arch sim` / `arch formal`. When set, the thread lowerer emits SVA properties anchored to the lowered state register `_t{i}_state` and per-thread counter `_t{i}_cnt`. They encode contracts the source spelled out (`wait until`, `wait N cycle`, `fork/join` branches) but the lowered comb+seq blob has lost — no downstream pass can recover them.
 

--- a/src/elaborate.rs
+++ b/src/elaborate.rs
@@ -5854,10 +5854,54 @@ fn lower_module_threads(
                 }));
             }
 
-            // TODO: Comb overlap optimization (drive next state's outputs on
-            // transition cycle) — disabled pending proper lock-state awareness.
-            // Re-enable when lock body states are tagged to prevent overlap
-            // from leaking lock-guarded outputs into preceding states.
+            // Comb overlap: when this state's single conditional transition
+            // fires, also drive the next state's comb outputs in the same
+            // cycle. This lets back-to-back states pipeline without a dead
+            // cycle. Restricted to next states that are NOT lock bodies
+            // (issue #501): a lock-guarded state's outputs must never appear
+            // before the grant cycle, so overlapping into a lock body would
+            // leak critical-section outputs into the preceding state.
+            // Multi-transition and TLM-return states are skipped — their
+            // successor is condition-dependent, not the natural next state.
+            if raw.multi_transitions.is_empty() && raw.terminal_return.is_none() {
+                if let Some(ref trans_cond) = raw.transition_cond {
+                    let next_si = if let Some(folded_tgt) = raw.folded_exit_target {
+                        folded_tgt
+                    } else if si + 1 < n_states {
+                        si + 1
+                    } else if t.once {
+                        si // terminal once-state: self-loop, nothing to overlap
+                    } else {
+                        0
+                    };
+                    let overlap_target =
+                        raw_states
+                            .get(next_si)
+                            .filter(|_| next_si != si)
+                            .filter(|next| {
+                                !next.is_folded && !next.is_lock_body && !next.comb_stmts.is_empty()
+                            });
+                    if let Some(next) = overlap_target {
+                        let next_comb =
+                            transform_shared_or_assigns(&next.comb_stmts, &shared_signals, sp);
+                        let overlap_cond = Expr::new(
+                            ExprKind::Binary(
+                                BinOp::And,
+                                Box::new(state_cond.clone()),
+                                Box::new(trans_cond.clone()),
+                            ),
+                            sp,
+                        );
+                        all_thread_comb.push(Stmt::IfElse(IfElse {
+                            cond: overlap_cond,
+                            then_stmts: next_comb,
+                            else_stmts: Vec::new(),
+                            unique: false,
+                            span: sp,
+                        }));
+                    }
+                }
+            }
         }
     }
 
@@ -7688,6 +7732,12 @@ struct ThreadFsmState {
     /// `ExitConditions` records the arms that leave a multi-transition
     /// construct already nested inside the lock body.
     lock_release_info: Option<LockReleaseInfo>,
+    /// True when this state belongs to a `lock` body (issue #501).  The comb
+    /// overlap optimization must not drive a lock-guarded state's outputs
+    /// during the preceding state's transition cycle: the first body state's
+    /// outputs are grant-gated, and driving any lock-body outputs before the
+    /// lock is held would leak them into states outside the critical section.
+    is_lock_body: bool,
 }
 
 #[derive(Clone)]
@@ -8217,6 +8267,7 @@ fn redirect_fallthrough_to_return(states: &mut Vec<ThreadFsmState>, return_idx: 
             no_fold_into_prev: false,
             lock_release: None,
             lock_release_info: None,
+            is_lock_body: false,
         });
         return;
     };
@@ -8534,6 +8585,7 @@ fn flush_pending_thread_state(
         no_fold_into_prev: false,
         lock_release: None,
         lock_release_info: None,
+        is_lock_body: false,
     });
     true
 }
@@ -8843,6 +8895,7 @@ fn partition_thread_body_impl(
                         no_fold_into_prev: nfip,
                         lock_release: None,
                         lock_release_info: None,
+                        is_lock_body: false,
                     });
                 } else {
                     // No dead-skid state created; reset next_state_no_fold
@@ -8863,6 +8916,7 @@ fn partition_thread_body_impl(
                     no_fold_into_prev: false,
                     lock_release: None,
                     lock_release_info: None,
+                    is_lock_body: false,
                 });
                 let _ = sp; // span retained for parity with the prior arm
             }
@@ -8916,6 +8970,7 @@ fn partition_thread_body_impl(
                         no_fold_into_prev: false,
                         lock_release: None,
                         lock_release_info: None,
+                        is_lock_body: false,
                     });
                 } else if let Some(idx) = merged_fast_idx {
                     no_trailing_merge_from = Some(idx);
@@ -8943,6 +8998,7 @@ fn partition_thread_body_impl(
                             no_fold_into_prev: false,
                             lock_release: None,
                             lock_release_info: None,
+                            is_lock_body: false,
                         });
                         fast_region = Some((fast_idx, cond));
                         continue;
@@ -8989,6 +9045,7 @@ fn partition_thread_body_impl(
                         no_fold_into_prev: false,
                         lock_release: None,
                         lock_release_info: None,
+                        is_lock_body: false,
                     });
                     // Step 3: recursively partition `then_stmts` and append at then_base.
                     // Empty branches (§II.10.4) skip the recursive call —
@@ -9324,6 +9381,7 @@ fn partition_thread_body_impl(
                     no_fold_into_prev: false,
                     lock_release: None,
                     lock_release_info: None,
+                    is_lock_body: false,
                 });
             }
             ThreadStmt::Return(e, ret_span) => {
@@ -9356,6 +9414,7 @@ fn partition_thread_body_impl(
                                 no_fold_into_prev: false,
                                 lock_release: None,
                                 lock_release_info: None,
+                                is_lock_body: false,
                             });
                         }
                     } else {
@@ -9524,6 +9583,7 @@ fn partition_thread_body_impl(
                 no_fold_into_prev: nfip,
                 lock_release: None,
                 lock_release_info: None,
+                is_lock_body: false,
             });
         }
     }
@@ -9580,6 +9640,7 @@ fn lower_fork_join(
             no_fold_into_prev: false,
             lock_release: None,
             lock_release_info: None,
+            is_lock_body: false,
         });
         branch_states.push(states);
     }
@@ -9730,6 +9791,7 @@ fn lower_fork_join(
             no_fold_into_prev: false,
             lock_release: None,
             lock_release_info: None,
+            is_lock_body: false,
         });
     }
 
@@ -10167,9 +10229,12 @@ fn lower_thread_lock(
 
     let mut body_states = partition_thread_body_with_loop_ids(body, span, cnt_width, loop_id_gen)?;
 
-    // Add req=1 to all body states
+    // Add req=1 to all body states, and tag them as lock-guarded so the comb
+    // overlap optimization never drives their outputs from a preceding state
+    // (issue #501).
     for bs in &mut body_states {
         bs.comb_stmts.insert(0, req_assign.clone());
+        bs.is_lock_body = true;
     }
 
     // First body state: gate comb outputs AND transition on grant.
@@ -10285,6 +10350,7 @@ fn lower_thread_lock(
             no_fold_into_prev: false,
             lock_release: Some(resource_name.to_string()),
             lock_release_info: Some(LockReleaseInfo::AllTransitions),
+            is_lock_body: true,
         });
     }
 

--- a/src/elaborate.rs
+++ b/src/elaborate.rs
@@ -5861,8 +5861,12 @@ fn lower_module_threads(
             // (issue #501): a lock-guarded state's outputs must never appear
             // before the grant cycle, so overlapping into a lock body would
             // leak critical-section outputs into the preceding state.
-            // Multi-transition and TLM-return states are skipped — their
-            // successor is condition-dependent, not the natural next state.
+            // Multi-transition states are skipped — their successor is
+            // condition-dependent, not the natural next state. The
+            // terminal_return guard is defensive: today `terminal_return` is
+            // only set by the TLM response-router partition path, whose
+            // states never reach this loop, but the guard keeps overlap
+            // correct if that ever changes.
             if raw.multi_transitions.is_empty() && raw.terminal_return.is_none() {
                 if let Some(ref trans_cond) = raw.transition_cond {
                     let next_si = if let Some(folded_tgt) = raw.folded_exit_target {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -31481,3 +31481,109 @@ end module ParamSizedEmit
         "must not emit a signed size-cast that changes literal semantics:\n{sv}"
     );
 }
+
+#[test]
+fn test_thread_comb_overlap_drives_next_state_outputs() {
+    // Issue #501: the comb overlap optimization drives the NEXT state's comb
+    // outputs during the transition cycle of a `wait until` state, removing
+    // the dead cycle between back-to-back states.  For the classic AXI read
+    // loop, `r_ready` (state S1's output) must already assert while S0's
+    // `ar_ready` handshake completes, and the wrap-around transition
+    // (S1 -> S0) must re-assert `ar_valid` during the `r_valid` cycle.
+    let source = r#"
+module BasicThread
+  port clk:      in Clock<SysDomain>;
+  port rst_n:    in Reset<Async, Low>;
+  port ar_valid: out Bool;
+  port ar_addr:  out UInt<32>;
+  port ar_ready: in Bool;
+  port r_ready:  out Bool;
+  port r_valid:  in Bool;
+  port r_data:   in UInt<32>;
+  port data_out: out UInt<32>;
+
+  reg data_r: UInt<32> reset rst_n => 0;
+
+  let data_out = data_r;
+
+  thread on clk rising, rst_n low
+    ar_valid = 1;
+    ar_addr  = 32'd100;
+    wait until ar_ready;
+
+    r_ready = 1;
+    wait until r_valid;
+    data_r <= r_data;
+  end thread
+end module BasicThread
+"#;
+    let sv = compile_to_sv(source);
+    assert!(
+        sv.contains("_t0_state == _t0_S0_wait_until && ar_ready"),
+        "expected overlap arm driving S1's outputs during S0's transition cycle:\n{sv}"
+    );
+    assert!(
+        sv.contains("_t0_state == _t0_S1_wait_until && r_valid"),
+        "expected wrap-around overlap arm driving S0's outputs during S1's transition cycle:\n{sv}"
+    );
+}
+
+#[test]
+fn test_thread_comb_overlap_never_enters_lock_body() {
+    // Issue #501: the overlap optimization must NOT drive a lock body state's
+    // outputs from the preceding state.  Lock-body outputs are grant-gated;
+    // overlapping them into the prior state would leak critical-section
+    // drives before the arbiter grant.  Every state in this fixture either
+    // is a lock body or transitions INTO one, so no overlap arm
+    // (`_tN_state == <state> && <cond>` in the comb block) may be emitted.
+    let source = r#"
+module SharedBus
+  port clk:      in Clock<SysDomain>;
+  port rst_n:    in Reset<Async, Low>;
+  port bus_valid: out Bool;
+  port bus_addr:  out UInt<32>;
+  port bus_ready: in Bool;
+  port done_0:   out Bool;
+  port done_1:   out Bool;
+
+  resource shared_bus : mutex<priority>;
+
+  thread Writer_0 on clk rising, rst_n low
+    lock shared_bus
+      bus_valid = 1;
+      bus_addr  = 32'h1000;
+      wait until bus_ready;
+      bus_valid = 0;
+    end lock shared_bus
+    done_0 = 1;
+    wait until bus_ready;
+  end thread Writer_0
+
+  thread Writer_1 on clk rising, rst_n low
+    lock shared_bus
+      bus_valid = 1;
+      bus_addr  = 32'h2000;
+      wait until bus_ready;
+      bus_valid = 0;
+    end lock shared_bus
+    done_1 = 1;
+    wait until bus_ready;
+  end thread Writer_1
+end module SharedBus
+"#;
+    let sv = compile_to_sv(source);
+    for ti in 0..2 {
+        for si in 0..3 {
+            for line in sv.lines() {
+                let state_eq = format!("_t{ti}_state == _t{ti}_S{si}");
+                if line.contains(&state_eq) && line.contains(" && ") {
+                    panic!(
+                        "overlap arm leaked into/next to lock body state \
+                         (t{ti} S{si}): `{}`\nfull SV:\n{sv}",
+                        line.trim()
+                    );
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements the codegen-TODO item from #501: re-enables the comb overlap optimization for lowered threads, disabled since the zero-cycle-lock change (c4b77f0) because it could leak lock-guarded outputs into preceding states.

- `lower_thread_lock` now tags every state it produces with a new `ThreadFsmState::is_lock_body` flag (including the empty-body fallback state).
- The overlap optimization is re-enabled at the old TODO site in `lower_module_threads`: for a state with a single conditional transition, the next state's comb outputs are additionally driven under `state == si && trans_cond` during the transition cycle, removing the dead cycle between back-to-back thread states (e.g. back-to-back handshakes: `r_ready` now asserts during the `ar_ready` cycle in the AXI read-loop fixture).

## Safety guards
- **Next state is a lock body → no overlap.** Grant-gated outputs never appear before the arbiter grant cycle. This is the #501 fix: lock states are now tagged, so the optimization is provably scoped away from critical sections.
- Multi-transition (fork/join, if-dispatch) and TLM terminal-return states are skipped — their successor is condition-dependent.
- Folded states (#306) are skipped; `folded_exit_target` is used as the effective successor, mirroring the seq-side next-state computation exactly.
- Terminal once-state self-loops are skipped.

## Testing
- Full `cargo test --release` green (the only failures in my run were 2 Lean-replay tests failing for environment reasons — fresh worktree without `lake build`; re-verified separately).
- New regression tests:
  - `test_thread_comb_overlap_drives_next_state_outputs` — overlap arms present on the AXI read-loop fixture.
  - `test_thread_comb_overlap_never_enters_lock_body` — a lock-heavy two-writer mutex fixture emits **zero** overlap arms (every transition lands in a lock body).
- Long verification (sim⇄Verilator lock-step on lock-heavy fixtures + thread TB sims) running post-push; follow-up commit if anything surfaces.

Part of #501 (one item of the tracking issue — do not auto-close).

🤖 Generated with [Claude Code](https://claude.com/claude-code)