### PR TITLE
ci: doc-drift check — grammar-surface PRs must touch doc/ (P6)

### DIFF
--- a/.github/workflows/doc-drift.yml
+++ b/.github/workflows/doc-drift.yml
@@ -1,0 +1,56 @@
+name: doc-drift
+
+# Grammar-surface PRs (src/lexer.rs, src/parser.rs, src/ast.rs) must also
+# touch doc/ in the same PR. Doc drift — features landing without spec
+# updates — is the most recurring finding in this repo's daily reviews.
+# Logic lives in scripts/check_doc_drift.sh (locally runnable:
+# `scripts/check_doc_drift.sh origin/main`); this workflow just wires it up
+# and handles the `no-doc-needed` label escape hatch, which isn't visible to
+# a local `git diff` and has to be read from the PR event payload here.
+#
+# NB: runs on EVERY PR to main, deliberately with no `paths:` filter. This
+# job is intended to become a REQUIRED status check under main's branch
+# protection, and a required check that is path-filtered never reports on
+# PRs that don't touch those paths — leaving them stuck "Expected — waiting
+# for status" and unmergeable. When no surface file changed, the script
+# exits 0 immediately, so running unconditionally is cheap and correct.
+on:
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: doc-drift-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  doc-drift:
+    name: doc drift
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check for no-doc-needed label
+        id: label-check
+        env:
+          PR_LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
+        run: |
+          echo "PR labels: ${PR_LABELS}"
+          if echo "${PR_LABELS}" | grep -q '"no-doc-needed"'; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Skip (no-doc-needed label present)
+        if: steps.label-check.outputs.skip == 'true'
+        run: |
+          echo "PR is labeled 'no-doc-needed' — skipping doc drift check."
+          echo "This label is for pure internal refactors of a grammar-surface"
+          echo "file (e.g. src/parser.rs) with no user-facing syntax/semantics"
+          echo "change, such as the planned parser/elaborate splits."
+
+      - name: Run doc drift check
+        if: steps.label-check.outputs.skip != 'true'
+        run: scripts/check_doc_drift.sh "origin/${{ github.event.pull_request.base.ref }}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,13 @@ never said so. Rules:
   still reproduces on a freshly built binary from current `origin/main`. If it
   doesn't, bisect to the fixing commit if cheap and close the issue with that
   evidence — a NOT-REPRODUCIBLE finding is a valid, valuable outcome.
+- **Grammar-surface changes must update doc/ in the same PR.** PRs touching
+  `src/lexer.rs`, `src/parser.rs`, or `src/ast.rs` are checked by CI
+  (`scripts/check_doc_drift.sh`, workflow `doc-drift`, check name `doc
+  drift`) — if none of the changed files are under `doc/`, the check fails
+  with pointers to the relevant spec docs. Pure internal refactors of a
+  surface file with no user-facing syntax/semantics change (e.g. the planned
+  parser/elaborate splits) can use the `no-doc-needed` PR label to skip it.
 - **Sweep for stranded PRs**: `scripts/green_pr_sweep.sh` lists open PRs that
   are green, mergeable, and ≥1 day old across arch-com + harc-com — finished
   work nobody landed. The mirror image of `claim_check.sh` (duplicate work at

--- a/scripts/check_doc_drift.sh
+++ b/scripts/check_doc_drift.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# check_doc_drift.sh — grammar-surface PRs must also touch doc/.
+#
+# Usage:
+#   scripts/check_doc_drift.sh <base-ref>   # e.g. origin/main
+#
+# Rationale: doc drift (spec updates lagging behind language/compiler changes)
+# is the most recurring finding in this repo's daily reviews — features land
+# without spec updates and doc/ rots. This script enforces a narrow, precise
+# rule: IF a PR touches a "grammar-surface" file AND touches no file under
+# doc/, THEN fail. It does not try to catch every doc-relevant change —
+# precision over recall, because a noisy required check gets bypassed
+# (`no-doc-needed`) and eventually ignored entirely.
+#
+# SURFACE_FILES is deliberately narrow: src/lexer.rs, src/parser.rs,
+# src/ast.rs. These three are the actual grammar surface — new syntax, new
+# AST node shapes, new token kinds. Deliberately EXCLUDED: typecheck.rs,
+# elaborate.rs, and the codegen backends. Those files change constantly for
+# internal reasons (bug fixes, refactors, new lowering strategies) that carry
+# no user-facing syntax/semantics delta, and are far higher-churn than the
+# grammar files — including them would flag nearly every PR and make the
+# check noise instead of signal. Widening the list (e.g. adding
+# src/typecheck.rs once it stabilizes, or the codegen dirs when doc coverage
+# there catches up) is a one-line edit to SURFACE_FILES below.
+#
+# Escape hatch: PRs whose GitHub Actions job sees the `no-doc-needed` label
+# skip this check entirely (see .github/workflows/doc-drift.yml — the label
+# check happens in the workflow, not here, since a label isn't visible to a
+# local `git diff`). Apply it for pure internal refactors that touch a
+# surface file without changing user-facing syntax/semantics — e.g. the
+# planned parser/elaborate splits.
+#
+# Locally runnable so contributors can pre-check before pushing:
+#   scripts/check_doc_drift.sh origin/main
+
+set -euo pipefail
+
+# Grammar-surface files: precision over recall (see header rationale above).
+SURFACE_FILES=(
+  "src/lexer.rs"
+  "src/parser.rs"
+  "src/ast.rs"
+)
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/check_doc_drift.sh <base-ref>
+
+Computes the diff between <base-ref> and HEAD. If any grammar-surface file
+(src/lexer.rs, src/parser.rs, src/ast.rs) changed and no file under doc/
+changed, fails with an actionable message.
+
+Example:
+  scripts/check_doc_drift.sh origin/main
+USAGE
+}
+
+if [[ $# -ne 1 || "$1" == "-h" || "$1" == "--help" ]]; then
+  usage >&2
+  exit 2
+fi
+
+base_ref="$1"
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+# Use a three-dot diff (merge-base...HEAD) so the check reflects only this
+# branch's changes, not unrelated commits that landed on base_ref meanwhile.
+changed_files="$(git diff --name-only "${base_ref}...HEAD" 2>/dev/null || true)"
+
+if [[ -z "$changed_files" ]]; then
+  echo "check_doc_drift: no changes vs ${base_ref}; nothing to check."
+  exit 0
+fi
+
+surface_hit=""
+for f in "${SURFACE_FILES[@]}"; do
+  if grep -qxF "$f" <<<"$changed_files"; then
+    surface_hit="${surface_hit}${surface_hit:+, }${f}"
+  fi
+done
+
+if [[ -z "$surface_hit" ]]; then
+  echo "check_doc_drift: no grammar-surface file changed; pass."
+  exit 0
+fi
+
+if grep -q '^doc/' <<<"$changed_files"; then
+  echo "check_doc_drift: grammar-surface file(s) changed (${surface_hit}) and doc/ was also updated; pass."
+  exit 0
+fi
+
+cat >&2 <<EOF
+check_doc_drift: FAIL
+
+This PR changes grammar-surface file(s): ${surface_hit}
+but touches no file under doc/.
+
+Changes to src/lexer.rs, src/parser.rs, or src/ast.rs usually mean new or
+changed syntax, which the spec needs to reflect. Two ways to resolve this:
+
+  1. If this change affects user-facing syntax or semantics, update the
+     relevant spec doc in the same PR (doc/ARCH_HDL_Specification.docx,
+     doc/Arch_AI_Reference_Card.docx, doc/thread_spec_section.md, spec.md,
+     or whichever doc/ file documents the affected construct).
+
+  2. If this is a pure internal refactor of a surface file with NO
+     user-facing syntax/semantics change (e.g. an AST node internal
+     reshuffle, a parser implementation detail), add the 'no-doc-needed'
+     label to this PR to skip this check.
+
+See CLAUDE.md's "Fix-PR lifecycle" section for details.
+EOF
+exit 1


### PR DESCRIPTION
## Summary

P6 improvement-plan item (maintainer-approved 2026-07-12): a CI check that PRs
touching syntax-surface `src/` files must also touch `doc/`. Doc drift —
features landing without spec updates — is the most recurring finding in this
repo's daily reviews.

- **Logic in a script**: `scripts/check_doc_drift.sh <base-ref>` diffs
  `base-ref...HEAD` and fails if a grammar-surface file changed with no
  `doc/` file also changed. Locally runnable:
  `scripts/check_doc_drift.sh origin/main`.
- **Surface list (precision over recall)**: `src/lexer.rs`, `src/parser.rs`,
  `src/ast.rs` only — the actual grammar surface (new syntax, new AST node
  shapes, new tokens). Deliberately excludes `typecheck.rs`, `elaborate.rs`,
  and codegen backends: those churn constantly for internal reasons with no
  user-facing syntax delta, and including them would flag nearly every PR,
  turning a required check into noise that gets bypassed. Widening the list
  is a one-line edit (documented in the script header).
- **Escape hatch**: `no-doc-needed` PR label (created on the repo,
  description: "Skips doc-drift CI for pure internal refactors of
  grammar-surface files (no syntax/semantics change)") skips the check. The
  failure message names the label. Internal refactors — e.g. the upcoming
  parser/elaborate splits — will need it routinely.
- **Workflow** `.github/workflows/doc-drift.yml`: runs on every
  `pull_request` to `main`, no `paths:` filter (so it always reports once it
  becomes a required check — see `skill-snapshots.yml` for the same
  pattern/rationale). Uses `actions/checkout@v4` with `fetch-depth: 0` so
  `origin/main` is available for the diff. Job/check name is `doc drift`
  (short, stable, meant for branch protection).
- **Docs**: added a bullet to CLAUDE.md's "Fix-PR lifecycle" section.

## Self-test evidence (local, on a scratch branch off origin/main)

- Touch `src/parser.rs` only → script exits 1 with the actionable failure
  message. ✅
- Touch `src/parser.rs` + `doc/x.md` → exits 0, "pass". ✅
- Touch `src/typecheck.rs` only (non-surface file) → exits 0, "pass" (no
  surface file changed). ✅
- `bash -n scripts/check_doc_drift.sh` → clean. `shellcheck` not available in
  this environment, so I hand-reviewed quoting/arrays/`set -euo pipefail`
  instead.
- The `no-doc-needed` label path can't be tested locally (it depends on the
  GitHub Actions event payload, not `git diff`); I read the workflow's label
  logic carefully but it validates for real on the first PR that uses the
  label.

## What's next

This PR itself only touches `.github/workflows/`, `scripts/`, and
`CLAUDE.md` — no `src/` grammar files — so the `doc drift` check should pass
trivially on itself, which is the first live validation of the workflow.
Once it's confirmed green here, the maintainer will add `doc drift` to
main's required status checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)