### PR TITLE
fix(fp): wire FP types not recognized in SV codegen

### DIFF
--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -2050,7 +2050,7 @@ impl<'a> Codegen<'a> {
         None
     }
 
-    /// Float format of a `let` binding by AST lookup (modules + fsms).
+    /// Float format of a `let`/`wire` binding by AST lookup (modules + fsms).
     fn let_binding_float_fmt(&self, name: &str) -> Option<&'static str> {
         let fmt_of = |t: &TypeExpr| match t {
             TypeExpr::FP32 => Some("f32"),
@@ -2061,10 +2061,14 @@ impl<'a> Codegen<'a> {
             match item {
                 Item::Module(m) if m.name.name == self.current_construct => {
                     for bi in &m.body {
-                        if let ModuleBodyItem::LetBinding(l) = bi {
-                            if l.name.name == name {
+                        match bi {
+                            ModuleBodyItem::LetBinding(l) if l.name.name == name => {
                                 return l.ty.as_ref().and_then(|t| fmt_of(t));
                             }
+                            ModuleBodyItem::WireDecl(w) if w.name.name == name => {
+                                return fmt_of(&w.ty);
+                            }
+                            _ => {}
                         }
                     }
                 }
@@ -2103,13 +2107,17 @@ impl<'a> Codegen<'a> {
             match item {
                 Item::Module(m) if m.name.name == self.current_construct => {
                     for bi in &m.body {
-                        if let ModuleBodyItem::LetBinding(l) = bi {
-                            if l.name.name == name {
+                        match bi {
+                            ModuleBodyItem::LetBinding(l) if l.name.name == name => {
                                 return l
                                     .ty
                                     .as_ref()
                                     .map_or(false, |t| matches!(t, TypeExpr::SInt(_)));
                             }
+                            ModuleBodyItem::WireDecl(w) if w.name.name == name => {
+                                return matches!(w.ty, TypeExpr::SInt(_));
+                            }
+                            _ => {}
                         }
                     }
                 }

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -1080,6 +1080,16 @@ pub fn resolve(source_file: &SourceFile) -> Result<SymbolTable, Vec<CompileError
                             );
                         }
                     }
+                    ModuleBodyItem::WireDecl(w) => {
+                        if scope.contains_key(&w.name.name) {
+                            errors.push(CompileError::duplicate(&w.name.name, w.name.span));
+                        } else {
+                            scope.insert(
+                                w.name.name.clone(),
+                                (Symbol::Let(w.name.name.clone()), w.name.span),
+                            );
+                        }
+                    }
                     ModuleBodyItem::Function(f) => {
                         // Register module-local functions in globals so they're
                         // callable from expressions within this module.


### PR DESCRIPTION
- resolve.rs: Module scope didn't include WireDecl, only RegDecl/LetBinding
  → wires with BF16/FP32 type not found in module_scopes, causing
    ident_float_fmt to return None
  → FP mul emitted as integer '*' returning 0 in Verilator

- codegen/mod.rs: let_binding_float_fmt only checked LetBinding, not WireDecl
  → wire FP types not recognized even when in scope

Fix both to include WireDecl. Verified:

  Before: Bf16ToFixed Verilator SV returned 0 for 1.0 -> 0, fixed=0
          scaled_fp = fp_val * scale_fp (integer mul)
          AttentionDecodeShell Verilator FAIL got 0 expected -7192

  After:  Bf16ToFixed Verilator returns 4096 for 1.0, scaled_fp = arch_f32_mul(...)
          All arch and Verilator cosims PASS

Repro: TestMul2.arch with wire FP32 mul
