### PR TITLE
doc: document semaphore<N, policy> resource in ebnf + canonical spec

### DIFF
--- a/doc/ARCH_HDL_Specification.md
+++ b/doc/ARCH_HDL_Specification.md
@@ -2146,6 +2146,27 @@ simulator), the scheduler honours the declared mutex policy directly,
 so `arch sim --thread-sim both` is an exact cross-check against the
 FSM-lowered path for all five policy choices.
 
+**Bounded concurrency: `semaphore<N, policy>`.** A resource may instead be
+declared `semaphore<N, policy>`, which admits **up to `N` concurrent
+holders** rather than one (the counting generalization of `mutex`):
+
+```
+resource pool: semaphore<4, round_robin>;   // at most 4 threads inside a lock at once
+```
+
+`N` is a const expression evaluated at elaboration time and may reference a
+module param (e.g. `semaphore<WORKERS, round_robin>`); it must fold to `>= 1`
+(`semaphore<0, ...>` is a compile error). `policy` reuses the same three-policy
+grammar as `mutex` (`round_robin`, `priority`, `lru`) and decides which waiting
+thread is admitted when a slot frees. **`semaphore<1, policy>` is semantically
+identical to `mutex<policy>`** and the compiler lowers the two identically, so
+the hold-stability and same-cycle release→re-grant guarantees above apply
+per-slot to a semaphore. The canonical use is limiting concurrency onto a
+shared multi-port structure (banked buses, N-port memories, "only 4 of 32
+threads in the AR phase"). See `doc/thread_spec_section.md` §20.8.4 for the
+per-slot arbitration details. `lock`/`end lock` syntax is unchanged; the `lock`
+block simply acquires one of the `N` slots.
+
 **Nested lock blocks are a compile error.** Nesting would allow a higher-priority thread to enter a critical section that a lower-priority thread is already executing (mutual exclusion violation). Sequential (non-nested) lock usage is safe.
 
 Ports driven inside `lock` blocks that are also driven by other threads must be declared `shared(or)`.

--- a/doc/arch.ebnf
+++ b/doc/arch.ebnf
@@ -343,9 +343,16 @@ thread_assign = lvalue "=" expr ";"
               | lvalue "<=" [ "fork" ] expr ";"
               ;
 
-(* Resource for mutual exclusion across threads (used by thread_lock).
-   Only three policies accepted by the mutex arbiter — a subset of arbiter_policy. *)
-resource_decl = "resource" ident ":" "mutex" "<" mutex_policy ">" ";" ;
+(* Resource for mutual exclusion / bounded concurrency across threads
+   (used by thread_lock). `mutex<policy>` admits exactly one holder;
+   `semaphore<N, policy>` admits up to N concurrent holders (N is a const
+   expr, may reference a module param, must be >= 1; semaphore<1, policy>
+   lowers identically to mutex<policy>). Both reuse the same three-policy
+   grammar — a subset of arbiter_policy. See thread_spec_section.md §20.8.4. *)
+resource_decl = "resource" ident ":" resource_kind ";" ;
+
+resource_kind = "mutex" "<" mutex_policy ">"
+              | "semaphore" "<" expr "," mutex_policy ">" ;   (* expr = const, must fold to >= 1 *)
 
 mutex_policy = "round_robin" | "priority" | "lru" ;
 
@@ -889,4 +896,5 @@ comment = "//" { any_char_except_newline } newline ;
    Contextual keywords (lexed as identifiers, given meaning by position):
    async, cycle, direction, do, file, fifo, fork, in, join, lifo, lock, mutex,
    once, out, policy, pragma, priority, read_first, resource, round_robin,
+   semaphore,
    state, transition, until, wait, write, write_before_read *)

--- a/skills/arch-programming/references/ARCH_HDL_Specification.md
+++ b/skills/arch-programming/references/ARCH_HDL_Specification.md
@@ -2146,6 +2146,27 @@ simulator), the scheduler honours the declared mutex policy directly,
 so `arch sim --thread-sim both` is an exact cross-check against the
 FSM-lowered path for all five policy choices.
 
+**Bounded concurrency: `semaphore<N, policy>`.** A resource may instead be
+declared `semaphore<N, policy>`, which admits **up to `N` concurrent
+holders** rather than one (the counting generalization of `mutex`):
+
+```
+resource pool: semaphore<4, round_robin>;   // at most 4 threads inside a lock at once
+```
+
+`N` is a const expression evaluated at elaboration time and may reference a
+module param (e.g. `semaphore<WORKERS, round_robin>`); it must fold to `>= 1`
+(`semaphore<0, ...>` is a compile error). `policy` reuses the same three-policy
+grammar as `mutex` (`round_robin`, `priority`, `lru`) and decides which waiting
+thread is admitted when a slot frees. **`semaphore<1, policy>` is semantically
+identical to `mutex<policy>`** and the compiler lowers the two identically, so
+the hold-stability and same-cycle release→re-grant guarantees above apply
+per-slot to a semaphore. The canonical use is limiting concurrency onto a
+shared multi-port structure (banked buses, N-port memories, "only 4 of 32
+threads in the AR phase"). See `doc/thread_spec_section.md` §20.8.4 for the
+per-slot arbitration details. `lock`/`end lock` syntax is unchanged; the `lock`
+block simply acquires one of the `N` slots.
+
 **Nested lock blocks are a compile error.** Nesting would allow a higher-priority thread to enter a critical section that a lower-priority thread is already executing (mutual exclusion violation). Sequential (non-nested) lock usage is safe.
 
 Ports driven inside `lock` blocks that are also driven by other threads must be declared `shared(or)`.


### PR DESCRIPTION
## Summary

`semaphore<N, policy>` shipped in #689 (parser + typecheck, per `doc/thread_spec_section.md` §20.8.4) but the two docs that describe the `resource` grammar for a *general* audience were never updated and still describe only `mutex<policy>`:

- **`doc/arch.ebnf`** — the formal grammar's `resource_decl` allowed only `mutex`.
- **`doc/ARCH_HDL_Specification.md` §7a.3** — the canonical spec (declared canonical in #686) has a full inline `resource`/`mutex` policy section but no mention of `semaphore`.

This is doc-consistency catch-up, found during the daily review of the 24h merge batch. #689 itself did satisfy the doc-drift gate (it updated the AI reference card + thread spec section), but the coarse gate can't tell that the *formal grammar* and the *canonical spec* were left behind.

## Changes
- `arch.ebnf`: `resource_decl` now delegates to `resource_kind = mutex<policy> | semaphore<expr, policy>`; `semaphore` added to the contextual-keyword list. `N` uses `expr` (const-folded, must be ≥ 1), consistent with how `UInt<expr>` widths are written elsewhere.
- `ARCH_HDL_Specification.md` §7a.3: new *Bounded concurrency: `semaphore<N, policy>`* paragraph — N holders, param-referencing N, the ≥1 rule, three-policy reuse, and `semaphore<1, policy>` ≡ `mutex<policy>`.

## Verification
No syntax/semantics change — pure documentation of already-merged, already-approved grammar. Verified on a fresh `origin/main` binary:
- `semaphore<2, {round_robin,priority,lru}>` type-check OK
- `semaphore<0, ...>` and `semaphore<_, weighted<W>>` rejected (matches the documented 3-policy set + ≥1 rule)

`cargo test --release` green (doc-only; no code paths touched).

## Note for maintainers (separate, pre-existing)
While reviewing §7a.3 I found the mutex policy table advertises `mutex<weighted<W>>`, but the parser rejects it (`mutex<MyFn>` custom hooks *do* work). Not touched here — needs a decision (implement weighted-mutex vs. de-document). Flagging for a follow-up.