### PR TITLE
fix(lexer): remove redundant alternative in SizedLiteral regex

### DIFF
--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -369,7 +369,7 @@ pub enum TokenKind {
     #[regex(r"0b[01][01_]*", |lex| lex.slice().to_string())]
     BinLiteral(String),
 
-    #[regex(r"[a-zA-Z_][a-zA-Z0-9_]*'[bhd][0-9a-fA-F_]+|[0-9]+[a-zA-Z_][a-zA-Z0-9_]*'[bhd][0-9a-fA-F_]+|[0-9]+'[bhd][0-9a-fA-F_]+", |lex| lex.slice().to_string())]
+    #[regex(r"[a-zA-Z_][a-zA-Z0-9_]*'[bhd][0-9a-fA-F_]+|[0-9]+'[bhd][0-9a-fA-F_]+", |lex| lex.slice().to_string())]
     SizedLiteral(String),
 
     // Float literal: must contain a decimal point (and may have an exponent),


### PR DESCRIPTION
Second alternative [0-9]+[a-zA-Z_][a-zA-Z0-9_]*'[bhd][0-9a-fA-F_]+
is unreachable since ARCH param names can't start with digit.
First alternative already covers W'd0, third covers 8'hAB etc.

Fixes remaining-findings.md low: Lexer regex has redundant alternative
