### PR TITLE
fix(sim): preserve reset polarity in eval contexts

### DIFF
--- a/src/sim_codegen/mod.rs
+++ b/src/sim_codegen/mod.rs
@@ -3083,6 +3083,11 @@ impl<'a> Ctx<'a> {
         self
     }
 
+    fn with_reset_levels(mut self, reset_levels: &'a HashMap<String, ResetLevel>) -> Self {
+        self.reset_levels = reset_levels;
+        self
+    }
+
     fn with_vec_names(mut self, vec_names: &'a HashSet<String>) -> Self {
         self.vec_names = Some(vec_names);
         self
@@ -6520,6 +6525,22 @@ impl<'a> SimCodegen<'a> {
             port_names.insert(flat_name.clone());
         }
 
+        // Keep `.asserted` polarity-aware in every generated C++ expression
+        // context. The eval() refactor moved expression emission into
+        // eval_posedge()/eval_comb(), so both contexts need the module's reset
+        // port map explicitly.
+        let reset_levels: HashMap<String, ResetLevel> = m
+            .ports
+            .iter()
+            .filter_map(|p| {
+                if let TypeExpr::Reset(_, level) = &p.ty {
+                    Some((p.name.name.clone(), *level))
+                } else {
+                    None
+                }
+            })
+            .collect();
+
         let mut reg_names = collect_reg_names(&m.body, &m.ports);
         reg_names.extend(collect_pipe_reg_names(&m.body));
         let port_reg_names = collect_port_reg_names(&m.ports);
@@ -8514,6 +8535,7 @@ impl<'a> SimCodegen<'a> {
             )
             .with_signed_names(&signed_names)
             .with_float_names(&float_names)
+            .with_reset_levels(&reset_levels)
             .with_vec_names(&vec_reg_names)
             .with_vec_2d_names(&vec_2d_names)
             .with_vec_sizes(&vec_sizes)
@@ -8582,6 +8604,7 @@ impl<'a> SimCodegen<'a> {
                                             &bus_port_names,
                                         )
                                         .with_signed_names(&signed_names)
+                                        .with_reset_levels(&reset_levels)
                                         .with_float_names(&float_names);
                                         cpp_expr(expr, &tmp_ctx)
                                     }
@@ -8803,6 +8826,7 @@ impl<'a> SimCodegen<'a> {
                     )
                     .with_signed_names(&signed_names)
                     .with_float_names(&float_names)
+                    .with_reset_levels(&reset_levels)
                     .with_vec_names(&vec_reg_names)
                     .with_vec_2d_names(&vec_2d_names)
                     .with_vec_sizes(&vec_sizes)
@@ -9063,6 +9087,7 @@ impl<'a> SimCodegen<'a> {
         )
         .with_signed_names(&signed_names)
         .with_float_names(&float_names)
+        .with_reset_levels(&reset_levels)
         .with_vec_names(&vec_reg_names)
         .with_vec_2d_names(&vec_2d_names)
         .with_vec_sizes(&vec_sizes)

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -19913,6 +19913,57 @@ fn test_sim_codegen_async_reset_fires_outside_rising_edge() {
 }
 
 #[test]
+fn test_sim_codegen_reset_asserted_uses_reset_polarity() {
+    // Regression for the eval() → eval_posedge()/eval_comb() refactor: those
+    // Ctx instances must retain the module's reset polarity map so
+    // `rst.asserted` means `rst` while `rst_n.asserted` means `!rst_n`.
+    let source = "
+        domain SysDomain
+          freq_mhz: 100
+        end domain SysDomain
+
+        module HighRst
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync>;
+          port q: out Bool;
+          reg q_r: Bool reset none;
+          seq on clk rising
+            if rst.asserted
+              q_r <= 0;
+            end if
+          end seq
+          let q = q_r;
+        end module HighRst
+
+        module LowRst
+          port clk: in Clock<SysDomain>;
+          port rst_n: in Reset<Sync, Low>;
+          port q: out Bool;
+          reg q_r: Bool reset none;
+          seq on clk rising
+            if rst_n.asserted
+              q_r <= 0;
+            end if
+          end seq
+          let q = q_r;
+        end module LowRst
+    ";
+    let sim = compile_to_sim_h(source, false);
+    assert!(
+        sim.contains("if (rst)"),
+        "active-high `.asserted` must use rst:\n{sim}"
+    );
+    assert!(
+        sim.contains("if (!rst_n)"),
+        "active-low `.asserted` must invert rst_n:\n{sim}"
+    );
+    assert!(
+        !sim.contains("rst.asserted") && !sim.contains("rst_n.asserted"),
+        "native sim must not emit unresolved `.asserted` field access:\n{sim}"
+    );
+}
+
+#[test]
 fn test_sim_codegen_collect_assigns_walks_indexed_lhs() {
     // Regression: `collect_stmt_assigns` only handled `Ident` and
     // `FieldAccess` LHS forms, so `q[hi:lo] <= ...` and `q[i] <= ...`


### PR DESCRIPTION
## Summary

Restore reset-polarity context in native simulator code generation after #701 moved expression emission into `eval_posedge()` and `eval_comb()`.

Without this map, `rst.asserted` and active-low `rst_n.asserted` could be emitted as unresolved C++ field accesses instead of polarity-aware reset conditions.

## Changes

- Restore the `Ctx::with_reset_levels` builder.
- Propagate the module reset map through posedge, combinational, and reset-expression contexts.
- Add active-high and active-low regression coverage.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --release --test integration_test` (737 passed)
- `git diff --check`

Independent review completed by separate agent; no findings.