### PR TITLE
fix: preserve lock release transition provenance

### DIFF
--- a/src/elaborate.rs
+++ b/src/elaborate.rs
@@ -5066,6 +5066,13 @@ fn lower_module_threads(
                 for (ref mut cond, _) in &mut state.multi_transitions {
                     rename_ident_in_expr(cond, old, new);
                 }
+                if let Some(LockReleaseInfo::ExitConditions(conditions)) =
+                    &mut state.lock_release_info
+                {
+                    for cond in conditions {
+                        rename_ident_in_expr(cond, old, new);
+                    }
+                }
             }
         }
         // Lock signals
@@ -5084,6 +5091,13 @@ fn lower_module_threads(
                 }
                 for (ref mut cond, _) in &mut state.multi_transitions {
                     rename_ident_in_expr(cond, &grant_old, &grant_new);
+                }
+                if let Some(LockReleaseInfo::ExitConditions(conditions)) =
+                    &mut state.lock_release_info
+                {
+                    for cond in conditions {
+                        rename_ident_in_expr(cond, &grant_old, &grant_new);
+                    }
                 }
             }
         }
@@ -5178,25 +5192,28 @@ fn lower_module_threads(
                         .map_or(LockReleaseFire::Never, LockReleaseFire::Conditional),
                 )
             } else if !raw_states[si].multi_transitions.is_empty() {
-                // A multi-transition state can contain both a back-edge into
-                // the lock body and an exit to the following statement.  The
-                // release pulse must only fire for the latter: clearing the
-                // arbiter hold latch on a loop-back lets another requester
-                // enter while this thread is still in its critical section.
-                let mut exit_disj: Option<Expr> = None;
-                for (cond, target) in &raw_states[si].multi_transitions {
-                    if !thread_target_is_special(*target) && *target < raw_states.len() {
-                        continue;
-                    }
+                // The lock lowering records whether these arms were created
+                // by a construct inside the lock body or by a construct
+                // outside it.  A lock used as an outer `for` body must
+                // release on every arm (including the outer loop-back), while
+                // a `for` nested inside the lock must release only on the
+                // nested loop's exit arm.
+                let release_conditions: Vec<Expr> = match raw_states[si].lock_release_info.as_ref()
+                {
+                    Some(LockReleaseInfo::AllTransitions) | None => raw_states[si]
+                        .multi_transitions
+                        .iter()
+                        .map(|(cond, _)| cond.clone())
+                        .collect(),
+                    Some(LockReleaseInfo::ExitConditions(conditions)) => conditions.clone(),
+                };
+                let exit_disj = release_conditions.into_iter().reduce(|acc, cond| {
                     let cond_sp = cond.span;
-                    exit_disj = Some(match exit_disj {
-                        None => cond.clone(),
-                        Some(acc) => Expr::new(
-                            ExprKind::Binary(BinOp::Or, Box::new(acc), Box::new(cond.clone())),
-                            cond_sp,
-                        ),
-                    });
-                }
+                    Expr::new(
+                        ExprKind::Binary(BinOp::Or, Box::new(acc), Box::new(cond)),
+                        cond_sp,
+                    )
+                });
                 (
                     si,
                     exit_disj.map_or(LockReleaseFire::Never, LockReleaseFire::Conditional),
@@ -7646,6 +7663,18 @@ struct ThreadFsmState {
     /// holding". Without it, a re-locking thread would never rotate the
     /// grant to a waiting contender.
     lock_release: Option<String>,
+    /// Transition provenance for the lock-release pulse. `AllTransitions`
+    /// means every arm of a later multi-transition state leaves this lock
+    /// body (for example, a lock used as the body of an outer `for`).
+    /// `ExitConditions` records the arms that leave a multi-transition
+    /// construct already nested inside the lock body.
+    lock_release_info: Option<LockReleaseInfo>,
+}
+
+#[derive(Clone)]
+enum LockReleaseInfo {
+    AllTransitions,
+    ExitConditions(Vec<Expr>),
 }
 
 /// Issue #306: fold `wait until` exit assignments.
@@ -8168,6 +8197,7 @@ fn redirect_fallthrough_to_return(states: &mut Vec<ThreadFsmState>, return_idx: 
             is_folded: false,
             no_fold_into_prev: false,
             lock_release: None,
+            lock_release_info: None,
         });
         return;
     };
@@ -8484,6 +8514,7 @@ fn flush_pending_thread_state(
         is_folded: false,
         no_fold_into_prev: false,
         lock_release: None,
+        lock_release_info: None,
     });
     true
 }
@@ -8792,6 +8823,7 @@ fn partition_thread_body_impl(
                         is_folded: false,
                         no_fold_into_prev: nfip,
                         lock_release: None,
+                        lock_release_info: None,
                     });
                 } else {
                     // No dead-skid state created; reset next_state_no_fold
@@ -8811,6 +8843,7 @@ fn partition_thread_body_impl(
                     is_folded: false,
                     no_fold_into_prev: false,
                     lock_release: None,
+                    lock_release_info: None,
                 });
                 let _ = sp; // span retained for parity with the prior arm
             }
@@ -8863,6 +8896,7 @@ fn partition_thread_body_impl(
                         is_folded: false,
                         no_fold_into_prev: false,
                         lock_release: None,
+                        lock_release_info: None,
                     });
                 } else if let Some(idx) = merged_fast_idx {
                     no_trailing_merge_from = Some(idx);
@@ -8889,6 +8923,7 @@ fn partition_thread_body_impl(
                             is_folded: false,
                             no_fold_into_prev: false,
                             lock_release: None,
+                            lock_release_info: None,
                         });
                         fast_region = Some((fast_idx, cond));
                         continue;
@@ -8934,6 +8969,7 @@ fn partition_thread_body_impl(
                         is_folded: false,
                         no_fold_into_prev: false,
                         lock_release: None,
+                        lock_release_info: None,
                     });
                     // Step 3: recursively partition `then_stmts` and append at then_base.
                     // Empty branches (§II.10.4) skip the recursive call —
@@ -9268,6 +9304,7 @@ fn partition_thread_body_impl(
                     is_folded: false,
                     no_fold_into_prev: false,
                     lock_release: None,
+                    lock_release_info: None,
                 });
             }
             ThreadStmt::Return(e, ret_span) => {
@@ -9299,6 +9336,7 @@ fn partition_thread_body_impl(
                                 is_folded: false,
                                 no_fold_into_prev: false,
                                 lock_release: None,
+                                lock_release_info: None,
                             });
                         }
                     } else {
@@ -9466,6 +9504,7 @@ fn partition_thread_body_impl(
                 is_folded: false,
                 no_fold_into_prev: nfip,
                 lock_release: None,
+                lock_release_info: None,
             });
         }
     }
@@ -9521,6 +9560,7 @@ fn lower_fork_join(
             is_folded: false,
             no_fold_into_prev: false,
             lock_release: None,
+            lock_release_info: None,
         });
         branch_states.push(states);
     }
@@ -9670,6 +9710,7 @@ fn lower_fork_join(
             is_folded: false,
             no_fold_into_prev: false,
             lock_release: None,
+            lock_release_info: None,
         });
     }
 
@@ -10183,7 +10224,30 @@ fn lower_thread_lock(
     // Mark the last body state so merged-module generation can emit the
     // combinational release pulse when its exit transition fires (see the
     // `lock_release` field doc).
+    let release_info = body_states.last().map(|last| {
+        if last.multi_transitions.is_empty() {
+            // No multi-transition was created inside the lock body. If an
+            // enclosing construct (for example, a loop around this lock)
+            // later expands this state into multiple arms, every arm exits
+            // the lock body and must release the arbiter hold.
+            LockReleaseInfo::AllTransitions
+        } else {
+            // Multi-transitions already present here were created inside the
+            // lock body. Only arms that leave this local body-state vector
+            // release the lock; internal loop-back arms keep the hold latch.
+            let exit_conditions = last
+                .multi_transitions
+                .iter()
+                .filter(|(_, target)| {
+                    thread_target_is_special(*target) || *target >= body_states.len()
+                })
+                .map(|(cond, _)| cond.clone())
+                .collect();
+            LockReleaseInfo::ExitConditions(exit_conditions)
+        }
+    });
     if let Some(last) = body_states.last_mut() {
+        last.lock_release_info = release_info;
         last.lock_release = Some(resource_name.to_string());
     }
 
@@ -10201,6 +10265,7 @@ fn lower_thread_lock(
             is_folded: false,
             no_fold_into_prev: false,
             lock_release: Some(resource_name.to_string()),
+            lock_release_info: Some(LockReleaseInfo::AllTransitions),
         });
     }
 

--- a/src/elaborate.rs
+++ b/src/elaborate.rs
@@ -5137,6 +5137,12 @@ fn lower_module_threads(
         // last state relocates its pulse into the absorbing predecessor's
         // cond-exit arm. Names are constructed post-rename, so grant/cnt
         // idents inside the reused exit conditions are already per-thread.
+        enum LockReleaseFire {
+            Never,
+            Conditional(Expr),
+            Unconditional,
+        }
+
         for si in 0..raw_states.len() {
             let Some(res) = raw_states[si].lock_release.clone() else {
                 continue;
@@ -5161,15 +5167,29 @@ fn lower_module_threads(
                 value: Expr::new(ExprKind::Literal(LitKind::Dec(1)), rel_sp),
                 span: rel_sp,
             });
-            let (target_idx, fire): (usize, Option<Expr>) = if raw_states[si].is_folded {
+            let (target_idx, fire): (usize, LockReleaseFire) = if raw_states[si].is_folded {
                 // Absorbed into the preceding wait_until state's exit arm;
                 // the fold fires on that state's transition condition.
-                (si - 1, raw_states[si - 1].transition_cond.clone())
+                (
+                    si - 1,
+                    raw_states[si - 1]
+                        .transition_cond
+                        .clone()
+                        .map_or(LockReleaseFire::Never, LockReleaseFire::Conditional),
+                )
             } else if !raw_states[si].multi_transitions.is_empty() {
-                let mut disj: Option<Expr> = None;
-                for (cond, _) in &raw_states[si].multi_transitions {
+                // A multi-transition state can contain both a back-edge into
+                // the lock body and an exit to the following statement.  The
+                // release pulse must only fire for the latter: clearing the
+                // arbiter hold latch on a loop-back lets another requester
+                // enter while this thread is still in its critical section.
+                let mut exit_disj: Option<Expr> = None;
+                for (cond, target) in &raw_states[si].multi_transitions {
+                    if !thread_target_is_special(*target) && *target < raw_states.len() {
+                        continue;
+                    }
                     let cond_sp = cond.span;
-                    disj = Some(match disj {
+                    exit_disj = Some(match exit_disj {
                         None => cond.clone(),
                         Some(acc) => Expr::new(
                             ExprKind::Binary(BinOp::Or, Box::new(acc), Box::new(cond.clone())),
@@ -5177,25 +5197,29 @@ fn lower_module_threads(
                         ),
                     });
                 }
-                (si, disj)
+                (
+                    si,
+                    exit_disj.map_or(LockReleaseFire::Never, LockReleaseFire::Conditional),
+                )
             } else if let Some(ref c) = raw_states[si].transition_cond {
-                (si, Some(c.clone()))
+                (si, LockReleaseFire::Conditional(c.clone()))
             } else if raw_states[si].wait_cycles.is_some() {
                 // Counter-based wait exits when the per-thread counter hits 0.
                 let cnt_id = Expr::new(ExprKind::Ident(format!("_t{}_cnt", ti)), sp);
                 (
                     si,
-                    Some(Expr::new(
+                    LockReleaseFire::Conditional(Expr::new(
                         ExprKind::Binary(BinOp::Eq, Box::new(cnt_id), Box::new(make_zero_expr(sp))),
                         sp,
                     )),
                 )
             } else {
                 // Unconditional exit: released every cycle spent in this state.
-                (si, None)
+                (si, LockReleaseFire::Unconditional)
             };
             let stmt = match fire {
-                Some(cond) => {
+                LockReleaseFire::Never => continue,
+                LockReleaseFire::Conditional(cond) => {
                     // Anchor the wrapper (and the assign inside it) to the
                     // fire condition's span — for the folded case that span
                     // belongs to the absorbing predecessor state, keeping
@@ -5215,7 +5239,7 @@ fn lower_module_threads(
                         span: wrap_sp,
                     })
                 }
-                None => rel_assign,
+                LockReleaseFire::Unconditional => rel_assign,
             };
             raw_states[target_idx].comb_stmts.push(stmt);
         }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -17421,6 +17421,46 @@ fn test_lock_arbiter_emits_hold_latch_user_arbiter_does_not() {
 }
 
 #[test]
+fn test_lock_release_ignores_internal_for_loop_back_edge() {
+    let sv = compile_to_sv(
+        r#"
+        module LockLoopRelease
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync, High>;
+          port ready: in Bool;
+          port busy: out Bool;
+
+          resource pool: mutex<priority>;
+
+          thread once T0 on clk rising, rst high
+            lock pool
+              for i in 0..1
+                busy = 1;
+                wait until ready;
+              end for
+            end lock pool
+          end thread T0
+        end module LockLoopRelease
+    "#,
+    );
+
+    assert!(
+        sv.contains("_pool_release_0"),
+        "lock with a multi-transition body should emit a release pulse:\n{sv}"
+    );
+    assert!(
+        sv.contains("if (ready && _t0_loop_cnt_0 >= 1'(1))"),
+        "release must be guarded by the loop exit condition:\n{sv}"
+    );
+    assert!(
+        !sv.contains(
+            "if ((ready && _t0_loop_cnt_0 < 1'(1)) || (ready && _t0_loop_cnt_0 >= 1'(1)))"
+        ),
+        "release must not include the internal loop-back condition:\n{sv}"
+    );
+}
+
+#[test]
 fn test_thread_wait_elsif_chain_fuses_to_single_dispatch() {
     // An `elsif` parses as a nested `else { if ... }`. The wait-dispatch
     // fusion should flatten that chain so later arms do not pay an extra


### PR DESCRIPTION
## Summary

- Preserve whether lock-body multi-transitions are internal loop edges or true exits.
- Release mutex/arbiter hold on every arm when a lock is the body of an enclosing loop.
- Release only on exit arms for loops nested inside the lock body.
- Add a regression test and restore both AXI read-beat interleaving tests.

## Validation

- 
- 
- 
running 3 tests
test test_axi_read_beat_interleave_example_compiles ... ok
test test_axi_read_beat_interleave_arch_sim_behavior ... ok
test test_axi_read_beat_interleave_verilator_behavior ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 738 filtered out; finished in 7.82s (3 passed)
- 
running 1 test
test test_lock_release_ignores_internal_for_loop_back_edge ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 740 filtered out; finished in 0.00s (1 passed)
- 
