### PR TITLE
Fix tight lock release combinational loop

### DIFF
--- a/src/codegen/arbiter.rs
+++ b/src/codegen/arbiter.rs
@@ -173,13 +173,11 @@ impl<'a> Codegen<'a> {
         // happens in the same cycle (matching the coroutine thread sim).
         if a.lock_hold {
             // The request port array carries a third `release` signal for
-            // lock arbiters: the owner's last lock-body state pulses it
-            // when its exit transition fires. Clearing the hold on release
-            // (instead of waiting for request_valid to deassert) lets a
-            // thread that releases and immediately re-requests — a
-            // back-to-back `lock` in a loop, whose request wire never
-            // drops — still hand the next re-arbitration to a waiting
-            // contender.
+            // lock arbiters. It is a registered one-cycle event from the
+            // thread FSM, so the arbiter can observe release after the edge
+            // without creating a combinational release/grant loop. The
+            // combinational owner fast path below is suppressed while the
+            // event is high, allowing immediate post-edge re-arbitration.
             let release_sig = a
                 .port_arrays
                 .first()
@@ -467,7 +465,7 @@ impl<'a> Codegen<'a> {
             // asserted; the rotating scan below only runs when the
             // resource is free (arb_found gates it).
             self.line(&format!(
-                "if (hold_valid_r && {req_valid}[hold_owner_r]) begin"
+                "if (hold_valid_r && {req_valid}[hold_owner_r] && !request_release[hold_owner_r]) begin"
             ));
             self.indent += 1;
             self.line("arb_found = 1'b1;");
@@ -523,7 +521,7 @@ impl<'a> Codegen<'a> {
             // not preempt a held lock. The priority scan below only runs
             // when the resource is free (grant_valid gates it).
             self.line(&format!(
-                "if (hold_valid_r && {req_valid}[hold_owner_r]) begin"
+                "if (hold_valid_r && {req_valid}[hold_owner_r] && !request_release[hold_owner_r]) begin"
             ));
             self.indent += 1;
             self.line(&format!("{grant_valid_sig} = 1'b1;"));
@@ -624,7 +622,7 @@ impl<'a> Codegen<'a> {
             // Current owner keeps the grant while its request stays
             // asserted; the hook only arbitrates when the resource is free.
             self.line(&format!(
-                "if (hold_valid_r && {req_valid}[hold_owner_r]) grant_onehot = {}'(1) << hold_owner_r;",
+                "if (hold_valid_r && {req_valid}[hold_owner_r] && !request_release[hold_owner_r]) grant_onehot = {}'(1) << hold_owner_r;",
                 num_req
             ));
             self.line(&format!("else grant_onehot = {fn_name}({args_str});"));

--- a/src/elaborate.rs
+++ b/src/elaborate.rs
@@ -4461,12 +4461,19 @@ fn lower_module_threads(
                 unpacked_ascending: false,
                 span: sp,
             }));
-            merged_body.push(ModuleBodyItem::WireDecl(WireDecl {
-                bus_params: Vec::new(),
+            // Release is an edge-qualified event. Keeping it combinational
+            // lets the lock exit condition depend on grant while the arbiter
+            // consumes release to produce grant, creating a real comb loop
+            // for tight re-locks (arch#709). The registered event is still
+            // visible during the following comb phase, so the arbiter can
+            // hand off immediately after the edge without adding a bubble.
+            merged_body.push(ModuleBodyItem::RegDecl(RegDecl {
                 name: Ident::new(format!("_{}_release_{}", res_name, ti), sp),
                 ty: TypeExpr::Bool,
-                unpacked: false,
-                unpacked_ascending: false,
+                init: Some(make_zero_expr(sp)),
+                reset: RegReset::Inherit(Ident::new(rst_name.clone(), sp), make_zero_expr(sp)),
+                guard: None,
+                multicycle: None,
                 span: sp,
             }));
         }
@@ -4990,6 +4997,20 @@ fn lower_module_threads(
     // ── Per-thread state machines ──────────────────────────────────────
     let mut all_thread_comb: Vec<Stmt> = Vec::new();
     let mut all_thread_seq: Vec<Stmt> = Vec::new();
+    // Release signals are registered one-cycle events. Clear every event at
+    // the start of the merged sequential block; state-specific lock-exit
+    // assignments appended below override this default on the firing edge.
+    let mut release_resources: Vec<&String> = all_resources.iter().collect();
+    release_resources.sort();
+    for res_name in release_resources {
+        for ti in 0..threads.len() {
+            all_thread_seq.push(Stmt::Assign(RegAssign {
+                target: Expr::new(ExprKind::Ident(format!("_{}_release_{}", res_name, ti)), sp),
+                value: Expr::new(ExprKind::Bool(false), sp),
+                span: sp,
+            }));
+        }
+    }
     let mut thread_map_threads: Vec<crate::thread_map::ThreadMapThread> = Vec::new();
     // Per-state `localparam` decls (one set per thread). Issue #247: make
     // thread-lowered FSMs debuggable by giving each state a descriptive
@@ -5141,22 +5162,23 @@ fn lower_module_threads(
         // `is_folded` and skipped during codegen — it becomes unreachable.
         fold_wait_until_exit_assignments(&mut raw_states, t.once);
 
-        // Lock release pulses: for each state marked as the last state of a
-        // `lock` body, emit `_<res>_release_<ti> = 1` combinationally when
-        // that state's exit transition fires. The arbiter's hold latch
-        // clears on this pulse, so a thread that releases and immediately
-        // re-requests (back-to-back `lock` in a loop — its request wire
-        // never deasserts) still lets a waiting contender win the next
-        // re-arbitration. Runs AFTER the fold pass: a folded (absorbed)
-        // last state relocates its pulse into the absorbing predecessor's
-        // cond-exit arm. Names are constructed post-rename, so grant/cnt
-        // idents inside the reused exit conditions are already per-thread.
+        // Lock release events: for each state marked as the last state of a
+        // `lock` body, emit `_<res>_release_<ti> <= 1` sequentially when that
+        // state's exit transition fires. The event is registered so the
+        // release condition may depend on grant without feeding a
+        // combinational release -> grant -> release loop (arch#709). The
+        // arbiter consumes the event in its next ownership update and ignores
+        // the old owner during the following comb phase, preserving immediate
+        // uncontended reacquisition and post-edge handoff. Runs AFTER the
+        // fold pass: a folded (absorbed) last state relocates its event into
+        // the absorbing predecessor's cond-exit arm. Names are constructed
+        // post-rename, so grant/cnt idents inside reused exit conditions are
+        // already per-thread.
         enum LockReleaseFire {
             Never,
             Conditional(Expr),
             Unconditional,
         }
-
         for si in 0..raw_states.len() {
             let Some(res) = raw_states[si].lock_release.clone() else {
                 continue;
@@ -5176,7 +5198,7 @@ fn lower_module_threads(
                     })
                 })
                 .unwrap_or(sp);
-            let rel_assign = Stmt::Assign(CombAssign {
+            let rel_assign = Stmt::Assign(RegAssign {
                 target: Expr::new(ExprKind::Ident(format!("_{}_release_{}", res, ti)), rel_sp),
                 value: Expr::new(ExprKind::Literal(LitKind::Dec(1)), rel_sp),
                 span: rel_sp,
@@ -5258,7 +5280,7 @@ fn lower_module_threads(
                 }
                 LockReleaseFire::Unconditional => rel_assign,
             };
-            raw_states[target_idx].comb_stmts.push(stmt);
+            raw_states[target_idx].seq_stmts.push(stmt);
         }
 
         let n_states = raw_states.len();
@@ -5952,16 +5974,13 @@ fn lower_module_threads(
             }));
         }
     }
-    // Default lock req = 0 / release = 0
+    // Default lock req = 0. Release events are registered and are cleared by
+    // the merged sequential block above before state-specific release events
+    // override them on the same edge.
     for res_name in &all_resources {
         for ti in 0..threads.len() {
             merged_comb.push(Stmt::Assign(CombAssign {
                 target: Expr::new(ExprKind::Ident(format!("_{}_req_{}", res_name, ti)), sp),
-                value: Expr::new(ExprKind::Bool(false), sp),
-                span: sp,
-            }));
-            merged_comb.push(Stmt::Assign(CombAssign {
-                target: Expr::new(ExprKind::Ident(format!("_{}_release_{}", res_name, ti)), sp),
                 value: Expr::new(ExprKind::Bool(false), sp),
                 span: sp,
             }));

--- a/src/sim_codegen/mod.rs
+++ b/src/sim_codegen/mod.rs
@@ -11235,10 +11235,11 @@ impl<'a> SimCodegen<'a> {
         cpp.push_str("  grant_valid = 0;\n  grant_requester = 0;\n");
         if a.lock_hold {
             // Current owner keeps the grant while its request stays
-            // asserted; the policy scan below only runs when the
-            // resource is free (grant_valid gates it).
+            // asserted and no registered release event is active. The
+            // policy scan below then re-arbitrates immediately after the
+            // release edge, matching the SV arbiter without a bubble.
             cpp.push_str(&format!(
-                "  if (_hold_valid && (({req_pa_name}_valid >> _hold_owner) & 1)) {{\n"
+                "  if (_hold_valid && (({req_pa_name}_valid >> _hold_owner) & 1) && !(({req_pa_name}_release >> _hold_owner) & 1)) {{\n"
             ));
             cpp.push_str("    grant_valid = 1;\n    grant_requester = _hold_owner;\n  }\n");
         }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -18182,6 +18182,88 @@ fn test_semaphore_thread_sim_both_backends_independently_pass() {
 }
 
 #[test]
+fn test_tight_relock_release_event_is_registered_709() {
+    // arch#709 regression: a tight re-lock used to connect the combinational
+    // lock-exit release pulse back through grant -> admit -> release. The
+    // release event must be registered, and the arbiter's owner fast path must
+    // be disabled while that post-edge event is active so re-arbitration can
+    // still happen without an inserted bubble.
+    let source = r#"
+        module SemaphoreRelock709
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync, High>;
+          resource pool: semaphore<2, round_robin>;
+
+          thread T0 on clk rising, rst high
+            lock pool
+              wait 1 cycle;
+            end lock pool
+          end thread T0
+
+          thread T1 on clk rising, rst high
+            lock pool
+              wait 1 cycle;
+            end lock pool
+          end thread T1
+
+          thread T2 on clk rising, rst high
+            lock pool
+              wait 1 cycle;
+            end lock pool
+          end thread T2
+        end module SemaphoreRelock709
+    "#;
+    let sv = compile_to_sv(source);
+    assert!(
+        sv.contains("logic _pool_release_0 = 0"),
+        "lock release must be a registered signal with an initializer:\n{sv}"
+    );
+    assert!(
+        sv.contains("_pool_release_0 <= 1")
+            && sv.contains("_pool_release_1 <= 1")
+            && sv.contains("_pool_release_2 <= 1"),
+        "each lock exit must emit a sequential release event:\n{sv}"
+    );
+    assert!(
+        sv.contains("!request_release[hold_owner_r]"),
+        "the arbiter must re-arbitrate while the registered release event is active:\n{sv}"
+    );
+    assert!(
+        comb_loop_warnings(source).is_empty(),
+        "tight re-lock lowering must not report a combinational SCC"
+    );
+}
+
+#[test]
+fn test_mutex_tight_relock_single_requester_no_bubble_709() {
+    // Runtime regression for the timing contract: one requester should
+    // reacquire immediately after its lock body exits when no contender is
+    // active. The registered release event must not create a bubble.
+    let arch_bin = env!("CARGO_BIN_EXE_arch");
+    let td = tempfile::tempdir().expect("tempdir");
+    let out = std::process::Command::new(arch_bin)
+        .arg("sim")
+        .arg("tests/thread/semaphore_relock_single.arch")
+        .arg("--tb")
+        .arg("tests/thread/tb_semaphore_relock_single.cpp")
+        .arg("--outdir")
+        .arg(td.path())
+        .output()
+        .expect("run single-requester tight-relock simulation");
+    assert!(
+        out.status.success(),
+        "single-requester tight-relock simulation should pass\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&out.stdout).contains("PASS MutexRelockSingle709"),
+        "single requester must make progress every cycle:\n{}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+}
+
+#[test]
 fn test_semaphore_verilator_behavior() {
     // sim<->SV lock-step: build the same semaphore_basic.arch fixture to SV
     // and run it through Verilator with the identical TB source (arch's

--- a/tests/thread/semaphore_relock_single.arch
+++ b/tests/thread/semaphore_relock_single.arch
@@ -1,0 +1,19 @@
+// arch#709 regression: one requester must reacquire a mutex without a
+// bubble when no other requester is active.
+module MutexRelockSingle709
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync, High>;
+  port count: out UInt<16>;
+
+  resource pool: mutex<round_robin>;
+
+  reg count_r: UInt<16> reset rst => 0;
+  comb count = count_r; end comb
+
+  thread T on clk rising, rst high
+    lock pool
+      count_r <= count_r +% 1;
+      wait 1 cycle;
+    end lock pool
+  end thread T
+end module MutexRelockSingle709

--- a/tests/thread/tb_semaphore_relock_single.cpp
+++ b/tests/thread/tb_semaphore_relock_single.cpp
@@ -1,0 +1,39 @@
+// arch#709 regression TB: a lone mutex requester must make progress every cycle
+// after reset; registering the release event must not insert a reacquisition
+// bubble when no contender is present.
+#include "VMutexRelockSingle709.h"
+#include <cstdio>
+
+static VMutexRelockSingle709 dut;
+
+static void tick() {
+    dut.clk = 0;
+    dut.eval();
+    dut.clk = 1;
+    dut.eval();
+}
+
+int main() {
+    dut.rst = 1;
+    tick();
+    dut.rst = 0;
+
+    unsigned previous = dut.count;
+    unsigned increments = 0;
+    for (int cycle = 0; cycle < 20; ++cycle) {
+        tick();
+        unsigned current = dut.count;
+        if (current != previous + 1) {
+            std::printf(
+                "FAIL MutexRelockSingle709: bubble at cycle %d (previous=%u current=%u)\n",
+                cycle, previous, current);
+            return 1;
+        }
+        previous = current;
+        ++increments;
+    }
+
+    std::printf("increments=%u final_count=%u\n", increments, previous);
+    std::printf("PASS MutexRelockSingle709\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary

- Register synthesized lock release events instead of driving them combinationally.
- Suppress the held-owner fast path during the release event so re-arbitration happens immediately after the edge.
- Keep native simulation aligned with generated SystemVerilog and add issue #709 regressions.

## Root cause

A tight lock/re-lock path could feed the lock exit condition through release, grant, and admission back into itself, producing a combinational SCC. Registering the release event breaks that loop without inserting a no-contender reacquisition bubble.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --release --test integration_test` (742 passed)
- New structural and single-requester no-bubble regressions pass
- Existing semaphore Verilator/native simulations pass
- `cargo test --release` has two unrelated pre-existing Lean search-path failures (`ArchConstructProof` unavailable)

Issue: #709