### PR TITLE
Prepare ARCH 0.70.8 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,7 +75,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arch"
-version = "0.70.7"
+version = "0.70.8"
 dependencies = [
  "clap",
  "insta",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arch"
-version = "0.70.7"
+version = "0.70.8"
 edition = "2021"
 description = "Compiler for the ARCH hardware description language"
 license = "LGPL-3.0-or-later"

--- a/doc/COMPILER_STATUS.md
+++ b/doc/COMPILER_STATUS.md
@@ -1,9 +1,12 @@
 # ARCH Compiler — Status & Roadmap
 
-> Last updated: 2026-07-11
-> Compiler version: 0.70.7
+> Last updated: 2026-07-15
+> Compiler version: 0.70.8
 >
-> **Unreleased (since 0.70.7):**
+> **0.70.8 release highlights:**
+> - **Typed FP parameters and constant evaluation** (#693, #694, #700) — module-scope FP wires and typed FP local parameters now resolve consistently in SystemVerilog and native simulation, including compile-time integer-to-FP conversion. This enables parameterized BF16-to-fixed conversion such as `local param SCALE_FP: FP32 = SCALE_INT.to_fp32();`.
+> - **Parameterized expression evaluation fixes** (#707) — `$clog2` inside ternary parameter expressions now evaluates correctly, unblocking derived-width declarations such as `N > 1 ? $clog2(N) : 1`.
+> - **Atomic thread comb overlap** — when a conditional transition exposes a simple conditional successor state's combinational handshake outputs in the same cycle, lowering now also executes that successor's sequential acceptance body on the same edge. This prevents `ready` from acknowledging a payload that the FSM silently drops. Auto-emitted thread assertions account for same-edge successor completion; dispatch, counter-wait, and unconditional-action successors remain non-overlapped.
 > - **Pipeline wait-stage idle fast-path no longer drops inter-wait assignments** (#590) — a `pipeline` stage with two or more sequential `wait`s was silently dropping any assignment between the first and second wait whenever the idle-state (state 0) fast path fired (i.e. the first wait's condition was already true the cycle the stage accepted new data). Fixed identically in both backends: `src/codegen/pipeline.rs` (SV) and `src/sim_codegen/pipeline.rs` (native sim) now emit the second wait group's pre-assigns on the state-0 → state-2 fast-path edge, mirroring the existing state-1 → state-2 slow-path edge. New compile-time warning (`arch check`/`build`/`sim`) fires when a register is assigned both immediately before the first wait and immediately after it — that pair can now land on the same clock edge via the fast path, so the pre-wait value may never be architecturally observable (last write wins). `thread` construct's `wait until` lowering was checked for the same bug class and found clean — see `doc/thread_lowering_algorithm.md` §4/4d.1: every inter-wait assignment gets its own dedicated FSM state that always executes for exactly one cycle before advancing (no idle/upstream-valid fast-path shortcut exists for threads), so there is no edge that can skip it.
 >
 > **0.70.7 release highlights:**

--- a/doc/thread_lowering_proof.md
+++ b/doc/thread_lowering_proof.md
@@ -384,12 +384,20 @@ edge):
    port-output valuation `μ_O` from `(μ_I, μ_R, μ_S, ⟨PC_i⟩)`:
    - Each thread `i` in state `s = PC_i` contributes the comb statements of
      `K_i[s]`, gated implicitly by `_t_i_state == s`.
+   - If `K_i[s]` has one conditional transition `c`, `c` is true, and its
+     successor `u` is an eligible simple conditional state (not folded,
+     lock-guarded, multi-transition, counter-wait, unconditional, or
+     terminal), the thread also contributes `K_i[u].comb`. This is the
+     canonical atomic-overlap rule from the thread specification §20.15.
    - For `shared(or)` signals, multiple drivers are OR-reduced.
    - For `lock` resources, the priority arbiter computes `_r_grant_i`.
 
 2. **Seq-update preparation.** Compute the next-register valuation
    `μ'_R` by evaluating the seq statements of `K_i[s]` and any merged trailing
-   assignments (themselves guarded by transition conditions).
+   assignments (themselves guarded by transition conditions). Under the same
+   atomic-overlap rule, evaluate `K_i[u].seq` under guard `c` on the current
+   pre-edge valuation. This pairs an overlapped `ready` with its sequential
+   payload acceptance on the same edge.
 
 3. **PC advance.** For each thread `i` with `K_i[s] = ⟨_, _, τ, w, M⟩`:
    - If `M ≠ ∅`: select the unique `(c, t) ∈ M` with `μ ⊨ c ⇒ true` (priority
@@ -397,6 +405,9 @@ edge):
    - Else if `τ = c` and `μ ⊨ c ⇒ true`: `PC_i' ← next(s, t.once)`.
    - Else if `w = n` and `c_cnt_i = 0`: `PC_i' ← next(s, t.once)`.
    - Else: `PC_i' ← s`.
+   - For an atomic overlap from `s` to `u`, first apply the `s → u` update;
+     then, if `K_i[u].τ` is true in the same pre-edge valuation, apply
+     `u → next(u, t.once)`. The latter nonblocking state write has priority.
    - Where `next(s, once) = s+1` if `s+1 < |K_i|`, `s` if `once ∧ s = |K_i|−1`,
      else `0`.
 
@@ -453,9 +464,14 @@ lowered module.  The one-cycle target step `Γ̂ ─[μ_I]→ Γ̂'` proceeds as
 
 1. Combinational evaluation activates, for each `(i, s)` with `s_i == s`,
    the `IfElse` arm carrying `K_i[s].comb`; defaults of `0` apply otherwise.
+   An eligible `s → u` atomic overlap additionally activates `K_i[u].comb`
+   under `state==s && c`.
 2. The merged `RegBlock` activates, for each `i`: if `default_when_i`
    predicate holds, its body fires and `_t_i_state <= 0`; otherwise the
-   per-state chain fires as in `transition_logic` of §I.3.
+   per-state chain fires as in `transition_logic` of §I.3. For an eligible
+   overlap, the `state==s` arm contains a guarded copy of `K_i[u]`'s complete
+   sequential body after the ordinary `s → u` write, preserving
+   last-nonblocking-write priority when `u` also completes.
 3. Reset assigns `_t_i_state <= 0` and reset-bearing registers to their
    declared reset values.
 
@@ -518,7 +534,9 @@ for each `i`, the block guarded by `s_i == ŝ` where `ŝ = Γ̂.s_i = Γ.PC_i`. 
 the partitioning invariant (II.4 below), the comb statements of `K_i[ŝ]` are
 *exactly* those scheduled in source state `PC_i = ŝ`.  Both run on the same
 register valuation (`Γ.μ_R = Γ̂.μ_R`) and same input stream, so they produce
-the same wire values.  For `shared(or)` signals, both source and target
+the same wire values. If the atomic-overlap predicate holds, both semantics
+also evaluate the eligible successor's comb statements under the identical
+`state==ŝ && transition_cond` guard. For `shared(or)` signals, both source and target
 specify the OR-reduction of all per-thread driver values; for the priority
 arbiter, both define `_r_grant_i = _r_req_i ∧ ¬⋁_{j<i} _r_grant_j`.  Hence
 `μ_O^src = μ_O^tgt`.  ∎(a)
@@ -528,7 +546,9 @@ arbiter, both define `_r_grant_i = _r_req_i ∧ ¬⋁_{j<i} _r_grant_j`.  Hence
 guard the trailing seq stmts by the wait condition of the predecessor; this is
 identical to scheduling the source's trailing block one cycle after the
 predecessor's wait fires (zero dead cycle), and the source semantics is
-defined to do exactly that (II.5).  For `shared(or)` seq signals, each thread
+defined to do exactly that (II.5). For an atomic overlap, both semantics also
+evaluate the eligible successor's full sequential body under the predecessor
+transition guard, using the same pre-edge valuation and statement order. For `shared(or)` seq signals, each thread
 contributes a per-cycle value; the target reduces via `x <= ⋁_i _x_in_i`,
 which equals the source's defined OR-of-drivers semantics.  ∎(b)
 
@@ -542,6 +562,12 @@ target's `transition_logic`:
 | `M = [(c_j, t_j)]`        | `PC' = t_j` for least `j` with `μ ⊨ c_j` | `if (c_0)…; if (c_1)…`       |
 | none (unconditional)       | `PC' = next`                        | `_state <= next`                 |
 | `default_when` fires       | `PC' = 0`                           | `if (cond) {…; _state<=0}`       |
+
+For an eligible atomic overlap, both sides additionally execute the simple
+successor's conditional transition on the same edge. Thus the final PC is
+either the successor or its natural next state; the guarded successor body is
+emitted after the predecessor's state write, so SystemVerilog/ARCH
+last-nonblocking-write semantics matches the source rule in §II.1.1.
 
 The *priority semantics* of the multi-target case warrants a remark.  The
 target emits an unguarded sequence of `IfElse` statements inside the `seq`
@@ -1259,4 +1285,3 @@ formal contract for the planned arch-sim alternate path (`arch sim` without
   `--auto-thread-asserts` properties (`_auto_thread_*`) are different —
   they're emitted *during* `lower_threads` and their correctness is *part
   of* this proof, established as Corollaries W/C/B in §II.11.
-

--- a/doc/thread_spec_section.md
+++ b/doc/thread_spec_section.md
@@ -498,12 +498,13 @@ if (_t0_state == _t0_S1_wait_until) r_ready = 1;                 // normal
 if (_t0_state == _t0_S0_wait_until && ar_ready) r_ready = 1;     // overlap
 ```
 
-The overlap is Mealy-style: the next state's outputs respond to the transition condition combinationally, one cycle before the state register advances.  Register values read by those outputs are the *pre-transition* values (the transition edge has not fired yet).
+The overlap is Mealy-style: the next state's outputs respond to the transition condition combinationally. The next state's sequential body also executes on that edge, so a ready/valid successor cannot advertise `ready` without consuming an already asserted `valid` and its payload. If the successor's own transition condition is true, the state register advances through that successor on the same edge. Register values read by the overlapped comb and sequential logic are the *pre-transition* values.
 
 **The overlap never applies when the next state is inside a `lock` body.** Lock-body outputs are gated by the arbiter grant (§20.8, §20.13); driving them from the preceding state would leak critical-section signals before the grant cycle.  Transitions *into* a lock block therefore always take the full cycle — the lock's own zero-cycle grant path (§20.13) is the mechanism that removes lock-entry latency, not the overlap.
 
 The overlap also does not apply to:
 - multi-transition states (fork/join dispatch, `if`/`else` dispatch) — the successor is condition-dependent
+- successor states that are multi-transition dispatches, counter-based `wait N cycle` states, or unconditional action states — only a successor with one conditional transition has defined atomic-overlap semantics
 - terminal states of `thread once` (self-loop; nothing to overlap)
 
 TLM method target threads are lowered by a dedicated response-router path and do not participate in the overlap.  As with each state's own comb arm, a thread's `default_when` condition does not gate the overlap arm — `default_when` preempts the *seq* side (state register and registered assigns) only.
@@ -514,7 +515,7 @@ Off-by-default flag on `arch build` / `arch sim` / `arch formal`. When set, the 
 
 | Source construct | Property class | SVA shape |
 |---|---|---|
-| `wait until <cond>` | `_auto_thread_t{i}_wait_until_s{si}` | `(rst_inactive && state==si && cond) \|=> state==next` |
+| `wait until <cond>` | `_auto_thread_t{i}_wait_until_s{si}` | `(rst_inactive && state==si && cond) \|=> state==next` (or the overlapped successor's exit state when it also completes on that edge) |
 | `wait <N> cycle` | `_auto_thread_t{i}_wait_stay_s{si}` + `_..._wait_done_s{si}` | stay (`cnt!=0` ⇒ stay) and done (`cnt==0` ⇒ advance) |
 | `fork`/`join` branches | `_auto_thread_t{i}_branch_s{si}_b{bi}` | per-(cond, target) `(rst_inactive && state==si && cond) \|=> state==target` |
 

--- a/skills/arch-programming/references/COMPILER_STATUS.md
+++ b/skills/arch-programming/references/COMPILER_STATUS.md
@@ -1,9 +1,12 @@
 # ARCH Compiler — Status & Roadmap
 
-> Last updated: 2026-07-11
-> Compiler version: 0.70.7
+> Last updated: 2026-07-15
+> Compiler version: 0.70.8
 >
-> **Unreleased (since 0.70.7):**
+> **0.70.8 release highlights:**
+> - **Typed FP parameters and constant evaluation** (#693, #694, #700) — module-scope FP wires and typed FP local parameters now resolve consistently in SystemVerilog and native simulation, including compile-time integer-to-FP conversion. This enables parameterized BF16-to-fixed conversion such as `local param SCALE_FP: FP32 = SCALE_INT.to_fp32();`.
+> - **Parameterized expression evaluation fixes** (#707) — `$clog2` inside ternary parameter expressions now evaluates correctly, unblocking derived-width declarations such as `N > 1 ? $clog2(N) : 1`.
+> - **Atomic thread comb overlap** — when a conditional transition exposes a simple conditional successor state's combinational handshake outputs in the same cycle, lowering now also executes that successor's sequential acceptance body on the same edge. This prevents `ready` from acknowledging a payload that the FSM silently drops. Auto-emitted thread assertions account for same-edge successor completion; dispatch, counter-wait, and unconditional-action successors remain non-overlapped.
 > - **Pipeline wait-stage idle fast-path no longer drops inter-wait assignments** (#590) — a `pipeline` stage with two or more sequential `wait`s was silently dropping any assignment between the first and second wait whenever the idle-state (state 0) fast path fired (i.e. the first wait's condition was already true the cycle the stage accepted new data). Fixed identically in both backends: `src/codegen/pipeline.rs` (SV) and `src/sim_codegen/pipeline.rs` (native sim) now emit the second wait group's pre-assigns on the state-0 → state-2 fast-path edge, mirroring the existing state-1 → state-2 slow-path edge. New compile-time warning (`arch check`/`build`/`sim`) fires when a register is assigned both immediately before the first wait and immediately after it — that pair can now land on the same clock edge via the fast path, so the pre-wait value may never be architecturally observable (last write wins). `thread` construct's `wait until` lowering was checked for the same bug class and found clean — see `doc/thread_lowering_algorithm.md` §4/4d.1: every inter-wait assignment gets its own dedicated FSM state that always executes for exactly one cycle before advancing (no idle/upstream-valid fast-path shortcut exists for threads), so there is no edge that can skip it.
 >
 > **0.70.7 release highlights:**

--- a/src/elaborate.rs
+++ b/src/elaborate.rs
@@ -5551,8 +5551,49 @@ fn lower_module_threads(
             }
         }
 
+        // A comb-overlapped successor is active during the predecessor's
+        // transition cycle. Its sequential body must therefore run on that
+        // same edge as well; otherwise a ready/valid successor advertises
+        // acceptance without consuming the payload. Restrict overlap to a
+        // simple conditional successor: dispatch and counter states need
+        // entry-value forwarding before they can be collapsed safely.
+        let overlap_targets: Vec<Option<usize>> = raw_states
+            .iter()
+            .enumerate()
+            .map(|(si, raw)| {
+                if !raw.multi_transitions.is_empty()
+                    || raw.terminal_return.is_some()
+                    || raw.transition_cond.is_none()
+                {
+                    return None;
+                }
+                let next_si = if let Some(folded_tgt) = raw.folded_exit_target {
+                    folded_tgt
+                } else if si + 1 < n_states {
+                    si + 1
+                } else if t.once {
+                    si
+                } else {
+                    0
+                };
+                raw_states.get(next_si).and_then(|next| {
+                    (next_si != si
+                        && !next.is_folded
+                        && !next.is_lock_body
+                        && next.transition_cond.is_some()
+                        && next.multi_transitions.is_empty()
+                        && next.wait_cycles.is_none()
+                        && next.terminal_return.is_none()
+                        && !next.comb_stmts.is_empty())
+                    .then_some(next_si)
+                })
+            })
+            .collect();
+
         // State transition always_ff
         let mut seq_stmts: Vec<Stmt> = Vec::new();
+        let mut seq_stmt_pos_by_state: Vec<Option<usize>> = vec![None; n_states];
+        let mut state_bodies: Vec<Option<Vec<Stmt>>> = vec![None; n_states];
         for (si, raw) in raw_states.iter().enumerate() {
             // Issue #306: skip states that were absorbed into a preceding
             // wait_until exit arm.  They are unreachable at runtime.
@@ -5751,10 +5792,26 @@ fn lower_module_threads(
                 } else if let Some(ref cond) = raw.transition_cond {
                     // wait_until cond — guard fires ⇒ FSM advances next edge.
                     let antecedent = mk_bin(BinOp::And, in_state.clone(), cond.clone());
+                    let mut consequent = state_eq(next_state);
+                    if let Some(overlap_si) = overlap_targets[si] {
+                        let overlap = &raw_states[overlap_si];
+                        let overlap_next = if let Some(folded_tgt) = overlap.folded_exit_target {
+                            folded_tgt
+                        } else if overlap_si + 1 < n_states {
+                            overlap_si + 1
+                        } else if t.once {
+                            overlap_si
+                        } else {
+                            0
+                        };
+                        if overlap_next != overlap_si {
+                            consequent = mk_bin(BinOp::Or, consequent, state_eq(overlap_next));
+                        }
+                    }
                     push_assert(
                         format!("_auto_thread_t{}_wait_until_s{}", ti, si),
                         antecedent,
-                        state_eq(next_state),
+                        consequent,
                         &mut auto_asserts,
                     );
                 } else if raw.wait_cycles.is_some() {
@@ -5784,9 +5841,36 @@ fn lower_module_threads(
                 // ("|=> next") and add noise without catching anything new.
             }
 
+            state_bodies[si] = Some(body.clone());
+            seq_stmt_pos_by_state[si] = Some(seq_stmts.len());
             seq_stmts.push(Stmt::IfElse(IfElse {
                 cond: state_cond,
                 then_stmts: body,
+                else_stmts: Vec::new(),
+                unique: false,
+                span: sp,
+            }));
+        }
+
+        for (si, target) in overlap_targets.iter().enumerate() {
+            let Some(target_si) = target else {
+                continue;
+            };
+            let Some(source_pos) = seq_stmt_pos_by_state[si] else {
+                continue;
+            };
+            let Some(target_body) = state_bodies[*target_si].clone() else {
+                continue;
+            };
+            let Some(transition_cond) = raw_states[si].transition_cond.clone() else {
+                continue;
+            };
+            let Stmt::IfElse(source_guard) = &mut seq_stmts[source_pos] else {
+                unreachable!("thread state lowering always emits an if guard");
+            };
+            source_guard.then_stmts.push(Stmt::IfElse(IfElse {
+                cond: transition_cond,
+                then_stmts: target_body,
                 else_stmts: Vec::new(),
                 unique: false,
                 span: sp,
@@ -5867,25 +5951,9 @@ fn lower_module_threads(
             // only set by the TLM response-router partition path, whose
             // states never reach this loop, but the guard keeps overlap
             // correct if that ever changes.
-            if raw.multi_transitions.is_empty() && raw.terminal_return.is_none() {
+            if let Some(next_si) = overlap_targets[si] {
                 if let Some(ref trans_cond) = raw.transition_cond {
-                    let next_si = if let Some(folded_tgt) = raw.folded_exit_target {
-                        folded_tgt
-                    } else if si + 1 < n_states {
-                        si + 1
-                    } else if t.once {
-                        si // terminal once-state: self-loop, nothing to overlap
-                    } else {
-                        0
-                    };
-                    let overlap_target =
-                        raw_states
-                            .get(next_si)
-                            .filter(|_| next_si != si)
-                            .filter(|next| {
-                                !next.is_folded && !next.is_lock_body && !next.comb_stmts.is_empty()
-                            });
-                    if let Some(next) = overlap_target {
+                    if let Some(next) = raw_states.get(next_si) {
                         let next_comb =
                             transform_shared_or_assigns(&next.comb_stmts, &shared_signals, sp);
                         let overlap_cond = Expr::new(

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -31529,6 +31529,115 @@ end module BasicThread
 }
 
 #[test]
+fn test_thread_comb_overlap_consumes_successor_handshake() {
+    // The successor's ready output and its sequential acceptance logic are one
+    // atomic cycle. If `start` and `valid` are both high, advertising `ready`
+    // from S0 must also capture the payload and advance past S1 on that edge.
+    let source = r#"
+module OverlapHandshake
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync, High>;
+  port start: in Bool;
+  port valid: in Bool;
+  port payload: in UInt<8>;
+  port ready: out Bool;
+  port captured: out pipe_reg<UInt<8>, 1> reset rst => 0;
+  port captured_valid: out pipe_reg<Bool, 1> reset rst => false;
+
+  thread on clk rising, rst high
+    default comb
+      ready = false;
+    end default
+
+    wait until start;
+    do
+      ready = true;
+    until valid;
+    captured <= payload;
+    captured_valid <= true;
+    wait 1 cycle;
+    captured_valid <= false;
+  end thread
+end module OverlapHandshake
+"#;
+    let sv = compile_to_sv(source);
+    let compact = sv.split_whitespace().collect::<Vec<_>>().join(" ");
+    assert!(
+        compact.contains("if (_t0_state == _t0_S0_wait_until) begin if (start) begin _t0_state <= _t0_S1_wait_until; end if (start) begin if (valid) begin captured <= payload;"),
+        "overlap must execute the successor handshake body on the same edge:\n{sv}"
+    );
+}
+
+#[test]
+fn test_thread_comb_overlap_skips_for_loop_successor() {
+    let source = r#"
+module OverlapFor
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync, High>;
+  port start: in Bool;
+  port valid: in Bool;
+  port payload: in UInt<8>;
+  port length: in UInt<4>;
+  port ready: out Bool;
+  port captured: out pipe_reg<UInt<8>, 1> reset rst => 0;
+
+  thread on clk rising, rst high
+    default comb
+      ready = false;
+    end default
+    wait until start;
+    for i in 0..length-1
+      do
+        ready = true;
+      until valid;
+      captured <= payload;
+    end for
+    wait 1 cycle;
+  end thread
+end module OverlapFor
+"#;
+    let sv = compile_to_sv(source);
+    assert!(
+        !sv.contains("_t0_state == _t0_S0_wait_until && start"),
+        "for-loop dispatch must not overlap its ready/counter body into S0:\n{sv}"
+    );
+}
+
+#[test]
+fn test_thread_comb_overlap_auto_assert_allows_successor_completion() {
+    let source = r#"
+module OverlapAssert
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync, High>;
+  port start: in Bool;
+  port valid: in Bool;
+  port ready: out Bool;
+
+  thread on clk rising, rst high
+    default comb
+      ready = false;
+    end default
+    wait until start;
+    do
+      ready = true;
+    until valid;
+    wait 1 cycle;
+  end thread
+end module OverlapAssert
+"#;
+    let opts = elaborate::ThreadLowerOpts {
+        auto_asserts: true,
+        ..Default::default()
+    };
+    let sv = compile_to_sv_with_opts(source, &opts);
+    let compact = sv.split_whitespace().collect::<Vec<_>>().join(" ");
+    assert!(
+        compact.contains("|=> (_t0_state == _t0_S1_wait_until || _t0_state == _t0_S2_wait_cycles)"),
+        "source wait assertion must allow the overlapped successor to complete:\n{sv}"
+    );
+}
+
+#[test]
 fn test_thread_comb_overlap_never_enters_lock_body() {
     // Issue #501: the overlap optimization must NOT drive a lock body state's
     // outputs from the preceding state.  Lock-body outputs are grant-gated;


### PR DESCRIPTION
## Summary
- bump ARCH to v0.70.8 and document the FP parameter and parameter-expression fixes
- make simple thread comb overlap atomic so an asserted ready cannot drop an already-valid payload
- keep dispatch, counter-wait, unconditional-action, and lock-body successors non-overlapped
- update auto-thread assertions, the thread specification, lowering proof, and skill snapshot

## Validation
- cargo test --release
- cargo clippy --release --all-targets
- cargo fmt -- --check
- scripts/sync_skill_snapshots.sh check
- FPT26 attention-decode-verilator-smoke using the v0.70.8 candidate binary

The FPT downstream smoke caught the original regression: the first overlapped ready/valid beat was acknowledged but not consumed. Both the native scheduling smoke and register-driver smoke pass with this fix.