### PR TITLE
fix: preserve same-cycle semaphore handoff

### DIFF
--- a/src/elaborate.rs
+++ b/src/elaborate.rs
@@ -4461,12 +4461,11 @@ fn lower_module_threads(
                 unpacked_ascending: false,
                 span: sp,
             }));
-            // Release is an edge-qualified event. Keeping it combinational
-            // lets the lock exit condition depend on grant while the arbiter
-            // consumes release to produce grant, creating a real comb loop
-            // for tight re-locks (arch#709). The registered event is still
-            // visible during the following comb phase, so the arbiter can
-            // hand off immediately after the edge without adding a bubble.
+            // Release is an edge-qualified event. The arbiter-facing copy is
+            // registered so a lock exit condition can depend on grant
+            // without creating a release -> grant -> release comb loop
+            // (arch#709). A separate combinational release intent below is
+            // used for semaphore holder bookkeeping.
             merged_body.push(ModuleBodyItem::RegDecl(RegDecl {
                 name: Ident::new(format!("_{}_release_{}", res_name, ti), sp),
                 ty: TypeExpr::Bool,
@@ -4474,6 +4473,18 @@ fn lower_module_threads(
                 reset: RegReset::Inherit(Ident::new(rst_name.clone(), sp), make_zero_expr(sp)),
                 guard: None,
                 multicycle: None,
+                span: sp,
+            }));
+            // Combinational release intent is used only by semaphore holder
+            // bookkeeping. The registered release event above remains the
+            // arbiter-facing signal so tight re-locks cannot form a
+            // release -> grant -> release combinational loop.
+            merged_body.push(ModuleBodyItem::WireDecl(WireDecl {
+                bus_params: Vec::new(),
+                name: Ident::new(format!("_{}_release_pending_{}", res_name, ti), sp),
+                ty: TypeExpr::Bool,
+                unpacked: false,
+                unpacked_ascending: false,
                 span: sp,
             }));
         }
@@ -4675,18 +4686,20 @@ fn lower_module_threads(
                 let held_ident = Expr::new(ExprKind::Ident(held_name.clone()), sp);
                 let req_ident = Expr::new(ExprKind::Ident(format!("_{}_req_{}", res_name, ti)), sp);
                 // #696: a semaphore slot is freed by the end-of-lock-body release
-                // pulse (`_<res>_release_<ti>`), NOT only by the request wire
+                // pulse (`_<res>_release_pending_<ti>`), NOT only by the request wire
                 // deasserting. A thread that re-locks back-to-back (tight loop)
                 // never deasserts `req_i` across `end lock`, so `held_i & req_i`
                 // alone would pin the slot forever and starve waiting contenders.
-                // Gate the hold on `!release_i` so the slot rotates on the pulse,
-                // matching the arbiter hold-latch (which already consumes the same
-                // pulse via `request_release`, see lock-release-pulse generation).
+                // Gate the hold on combinational release intent so the slot
+                // is free immediately after the releasing edge. The
+                // arbiter-facing release register is intentionally separate:
+                // it breaks the tight re-lock comb loop without adding a
+                // semaphore handoff bubble.
                 let not_release = Expr::new(
                     ExprKind::Unary(
                         UnaryOp::Not,
                         Box::new(Expr::new(
-                            ExprKind::Ident(format!("_{}_release_{}", res_name, ti)),
+                            ExprKind::Ident(format!("_{}_release_pending_{}", res_name, ti)),
                             sp,
                         )),
                     ),
@@ -5174,6 +5187,7 @@ fn lower_module_threads(
         // the absorbing predecessor's cond-exit arm. Names are constructed
         // post-rename, so grant/cnt idents inside reused exit conditions are
         // already per-thread.
+        #[derive(Clone)]
         enum LockReleaseFire {
             Never,
             Conditional(Expr),
@@ -5256,7 +5270,7 @@ fn lower_module_threads(
                 // Unconditional exit: released every cycle spent in this state.
                 (si, LockReleaseFire::Unconditional)
             };
-            let stmt = match fire {
+            let stmt = match fire.clone() {
                 LockReleaseFire::Never => continue,
                 LockReleaseFire::Conditional(cond) => {
                     // Anchor the wrapper (and the assign inside it) to the
@@ -5281,6 +5295,27 @@ fn lower_module_threads(
                 LockReleaseFire::Unconditional => rel_assign,
             };
             raw_states[target_idx].seq_stmts.push(stmt);
+
+            let pending_assign = Stmt::Assign(CombAssign {
+                target: Expr::new(
+                    ExprKind::Ident(format!("_{}_release_pending_{}", res, ti)),
+                    rel_sp,
+                ),
+                value: Expr::new(ExprKind::Literal(LitKind::Dec(1)), rel_sp),
+                span: rel_sp,
+            });
+            let pending_stmt = match fire {
+                LockReleaseFire::Never => continue,
+                LockReleaseFire::Conditional(cond) => Stmt::IfElse(IfElse {
+                    cond: cond.clone(),
+                    then_stmts: vec![pending_assign],
+                    else_stmts: Vec::new(),
+                    unique: false,
+                    span: cond.span,
+                }),
+                LockReleaseFire::Unconditional => pending_assign,
+            };
+            raw_states[target_idx].comb_stmts.push(pending_stmt);
         }
 
         let n_states = raw_states.len();
@@ -6097,6 +6132,14 @@ fn lower_module_threads(
         for ti in 0..threads.len() {
             merged_comb.push(Stmt::Assign(CombAssign {
                 target: Expr::new(ExprKind::Ident(format!("_{}_req_{}", res_name, ti)), sp),
+                value: Expr::new(ExprKind::Bool(false), sp),
+                span: sp,
+            }));
+            merged_comb.push(Stmt::Assign(CombAssign {
+                target: Expr::new(
+                    ExprKind::Ident(format!("_{}_release_pending_{}", res_name, ti)),
+                    sp,
+                ),
                 value: Expr::new(ExprKind::Bool(false), sp),
                 span: sp,
             }));

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -17856,18 +17856,22 @@ fn test_semaphore_n2_synthesizes_holder_tracking() {
 }
 
 // arch#696 regression (structural): the per-thread `held` slot register must
-// be freed by the end-of-lock-body release pulse (`_pool_release_<ti>`), not
-// only when the request wire deasserts. A thread that re-locks back-to-back
-// (tight loop) never deasserts `req`, so `held & req` alone would pin the slot
-// and starve waiting contenders. The next-state must gate on `!release`.
+// be freed by the combinational end-of-lock-body release intent
+// (`_pool_release_pending_<ti>`), not only when the request wire deasserts.
+// A thread that re-locks back-to-back (tight loop) never deasserts `req`, so
+// `held & req` alone would pin the slot and starve waiting contenders. The
+// arbiter still receives the registered `_pool_release_<ti>` event so the
+// tight re-lock path remains free of combinational feedback.
 #[test]
 fn test_semaphore_slot_freed_by_release_pulse_696() {
     let sv = compile_to_sv(&semaphore_pool_source("2", "round_robin"));
     assert!(
-        sv.contains("_pool_req_0 && !_pool_release_0")
-            && sv.contains("_pool_req_1 && !_pool_release_1"),
-        "arch#696: each semaphore `held` next-state must gate on `!_pool_release_<ti>` \
-         so a back-to-back re-lock frees its slot; found un-gated hold:\n{sv}"
+        sv.contains("_pool_req_0 && !_pool_release_pending_0")
+            && sv.contains("_pool_req_1 && !_pool_release_pending_1")
+            && sv.contains("_pool_release_packed[0] = _pool_release_0"),
+        "arch#696: each semaphore `held` next-state must gate on combinational \
+         release intent while the arbiter receives the registered release event; \
+         found an incorrectly gated hold:\n{sv}"
     );
 }
 


### PR DESCRIPTION
## Summary

- keep semaphore holder clearing on the combinational end-of-lock release edge
- retain the registered release event for the lock arbiter, avoiding the tight re-lock combinational loop fixed by #709
- update the #696 structural regression to assert both release paths

## Root cause

After the release event was registered to break the arbiter release/grant feedback loop, semaphore `held_i` state also consumed that registered event. The holder therefore stayed occupied until the following clock edge, inserting a one-cycle vacancy before a waiter could be admitted. This contradicted the documented same-cycle release→regrant contract for semaphore slots.

The fix emits a separate combinational `_release_pending_i` signal for semaphore holder bookkeeping while keeping `_release_i` registered for the arbiter-facing path.

## Validation

- `cargo fmt -- --check`
- `git diff --check`
- `cargo test --release --test integration_test` — 748 passed
- required `scripts/pre_pr_review.sh mark` and `check` passed

Code-review pass completed with no additional actionable findings.