### PR TITLE
fix(sim): add --debug port logging for all non-module constructs

### DIFF
--- a/src/sim_codegen/cam.rs
+++ b/src/sim_codegen/cam.rs
@@ -110,12 +110,19 @@ impl<'a> SimCodegen<'a> {
             "  explicit {class}(VerilatedContext*) : {class}() {{}}\n"
         ));
         h.push_str("  void eval();\n  void eval_posedge();\n  void eval_comb();\n  void final() { trace_close(); }\n");
+        if self.debug {
+            h.push_str("  void _debug_log_ports();\n");
+        }
         h.push_str("private:\n");
         h.push_str("  uint8_t _clk_prev;\n");
         h.push_str(&format!("  {mask_ty} _entry_valid_r;\n"));
         h.push_str(&format!("  {key_ty} _entry_key_r[{depth}];\n"));
         if has_value {
             h.push_str(&format!("  {val_ty} _entry_value_r[{depth}];\n"));
+        }
+        if self.debug {
+            let debug_ports = collect_simple_debug_ports(&c.ports, &c.params);
+            emit_simple_debug_header(&mut h, &debug_ports);
         }
 
         // ── Implementation ──
@@ -126,6 +133,9 @@ impl<'a> SimCodegen<'a> {
         cpp.push_str("  if (!_trace_fp && Verilated::traceFile() && Verilated::claimTrace())\n");
         cpp.push_str("    trace_open(Verilated::traceFile());\n");
         cpp.push_str("  eval_posedge();\n  eval_comb();\n");
+        if self.debug {
+            cpp.push_str("  _debug_log_ports();\n");
+        }
         cpp.push_str("  if (_trace_fp) trace_dump(_trace_time++);\n");
         cpp.push_str("}\n\n");
 
@@ -203,6 +213,16 @@ impl<'a> SimCodegen<'a> {
 
         // Suppress unused-variable warning when val_ty isn't referenced.
         let _ = val_ty;
+
+        if self.debug {
+            let debug_ports = collect_simple_debug_ports(&c.ports, &c.params);
+            let clk_port = c
+                .ports
+                .iter()
+                .find(|p| matches!(&p.ty, TypeExpr::Clock(_)))
+                .map(|p| p.name.name.as_str());
+            emit_simple_debug_impl(&mut cpp, &class, name, &debug_ports, clk_port);
+        }
 
         // Trace support — track entry_valid_r and search outputs.
         let extra_sigs: Vec<(&str, &str, u32)> = vec![("entry_valid_r", "_entry_valid_r", depth)];

--- a/src/sim_codegen/fifo.rs
+++ b/src/sim_codegen/fifo.rs
@@ -153,6 +153,9 @@ impl<'a> SimCodegen<'a> {
             h.push_str("  void eval_posedge_dual(bool _wr_rising, bool _rd_rising);\n");
         }
         h.push_str("  void final() { trace_close(); }\n");
+        if self.debug {
+            h.push_str("  void _debug_log_ports();\n");
+        }
         h.push_str("private:\n");
         if is_async {
             h.push_str("  uint8_t _clk_prev_wr;\n  uint8_t _clk_prev_rd;\n");
@@ -169,6 +172,19 @@ impl<'a> SimCodegen<'a> {
         h.push_str("  void trace_dump(uint64_t time);\n");
         h.push_str("  void trace_close();\n");
         h.push_str("  FILE* _trace_fp = nullptr;\n  uint64_t _trace_time = 0;\n");
+        // --debug support
+        if self.debug {
+            let debug_ports = collect_simple_debug_ports(&f.ports, &f.params);
+            // Need cstdio for printf
+            if !h.contains("#include <cstdio>") {
+                h = h.replacen(
+                    "#pragma once\n#include <cstdint>\n#include <cstring>\n",
+                    "#pragma once\n#include <cstdint>\n#include <cstring>\n#include <cstdio>\n",
+                    1,
+                );
+            }
+            emit_simple_debug_header(&mut h, &debug_ports);
+        }
         h.push_str("};\n");
 
         let mut cpp = String::new();
@@ -185,6 +201,9 @@ impl<'a> SimCodegen<'a> {
         cpp.push_str(&format!("void {class}::eval() {{\n"));
         cpp.push_str("  if (!_trace_fp && Verilated::traceFile() && Verilated::claimTrace())\n");
         cpp.push_str("    trace_open(Verilated::traceFile());\n");
+        if self.debug {
+            // Debug will be called after comb settles, before trace dump
+        }
         if is_async {
             // Async FIFO: independent edge detection per side. Push side
             // clocks on wr_clk; pop side clocks on rd_clk. We do not model
@@ -208,6 +227,9 @@ impl<'a> SimCodegen<'a> {
             cpp.push_str("  eval_posedge();\n");
         }
         cpp.push_str("  eval_comb();\n");
+        if self.debug {
+            cpp.push_str("  _debug_log_ports();\n");
+        }
         cpp.push_str("  if (_trace_fp) trace_dump(_trace_time++);\n");
         cpp.push_str("}\n\n");
 
@@ -354,7 +376,18 @@ impl<'a> SimCodegen<'a> {
         cpp.push_str("}\n\n");
         cpp.push_str(&format!("void {class}::trace_close() {{\n"));
         cpp.push_str("  if (_trace_fp) {{ fclose(_trace_fp); _trace_fp = nullptr; }}\n");
-        cpp.push_str("}\n");
+        cpp.push_str("}\n\n");
+
+        if self.debug {
+            let debug_ports = collect_simple_debug_ports(&f.ports, &f.params);
+            // Find clock port for cycle counting
+            let clk_port = f
+                .ports
+                .iter()
+                .find(|p| matches!(&p.ty, TypeExpr::Clock(_)))
+                .map(|p| p.name.name.as_str());
+            emit_simple_debug_impl(&mut cpp, &class, name, &debug_ports, clk_port);
+        }
 
         SimModel {
             class_name: class,

--- a/src/sim_codegen/fsm.rs
+++ b/src/sim_codegen/fsm.rs
@@ -295,13 +295,21 @@ impl<'a> SimCodegen<'a> {
         h.push_str(&format!(
             "  explicit {class}(VerilatedContext*) : {class}() {{}}\n"
         ));
-        h.push_str("  void eval();\n  void eval_posedge();\n  void eval_comb();\n  void final() { trace_close(); }\nprivate:\n");
+        h.push_str("  void eval();\n  void eval_posedge();\n  void eval_comb();\n  void final() { trace_close(); }\n");
+        if self.debug {
+            h.push_str("  void _debug_log_ports();\n");
+        }
+        h.push_str("private:\n");
         // Private internal arrays for Vec ports
         for vi in &fsm_vec_port_infos {
             h.push_str(&format!("  {} _{}[{}];\n", vi.elem_ty, vi.name, vi.count));
         }
         h.push_str("  uint8_t _clk_prev;\n");
         h.push_str(&format!("  {state_ty} _state_r;\n"));
+        if self.debug {
+            let debug_ports = collect_simple_debug_ports(&f.ports, &f.common.params);
+            emit_simple_debug_header(&mut h, &debug_ports);
+        }
         // };\n deferred until after trace support added
 
         let mut cpp = String::new();
@@ -318,6 +326,9 @@ impl<'a> SimCodegen<'a> {
         cpp.push_str("  if (!_trace_fp && Verilated::traceFile() && Verilated::claimTrace())\n");
         cpp.push_str("    trace_open(Verilated::traceFile());\n");
         cpp.push_str("  eval_comb();\n  eval_posedge();\n  eval_comb();\n");
+        if self.debug {
+            cpp.push_str("  _debug_log_ports();\n");
+        }
         cpp.push_str("  if (_trace_fp) trace_dump(_trace_time++);\n");
         cpp.push_str("}\n\n");
 
@@ -650,6 +661,11 @@ impl<'a> SimCodegen<'a> {
             &extra_sigs_ref,
             &f.common.params,
         );
+
+        if self.debug {
+            let debug_ports = collect_simple_debug_ports(&f.ports, &f.common.params);
+            emit_simple_debug_impl(&mut cpp, &class, name, &debug_ports, Some(clk_port));
+        }
 
         // --coverage: per-FSM counter storage + atexit dumper. Same
         // shape as gen_module's coverage emission (#132/#134).

--- a/src/sim_codegen/linklist.rs
+++ b/src/sim_codegen/linklist.rs
@@ -83,7 +83,9 @@ impl<'a> SimCodegen<'a> {
 
         // ── Header ────────────────────────────────────────────────────────────
         let mut h = String::new();
-        let mut header_inc = "#pragma once\n#include <cstdint>\n#include <cstring>\n#include \"verilated.h\"\n\n".to_string();
+        let mut header_inc =
+            "#pragma once\n#include <cstdint>\n#include <cstring>\n#include \"verilated.h\"\n\n"
+                .to_string();
         if self.debug {
             header_inc = "#pragma once\n#include <cstdint>\n#include <cstring>\n#include <cstdio>\n#include \"verilated.h\"\n\n".to_string();
         }

--- a/src/sim_codegen/linklist.rs
+++ b/src/sim_codegen/linklist.rs
@@ -83,9 +83,11 @@ impl<'a> SimCodegen<'a> {
 
         // ── Header ────────────────────────────────────────────────────────────
         let mut h = String::new();
-        h.push_str(
-            "#pragma once\n#include <cstdint>\n#include <cstring>\n#include \"verilated.h\"\n\n",
-        );
+        let mut header_inc = "#pragma once\n#include <cstdint>\n#include <cstring>\n#include \"verilated.h\"\n\n".to_string();
+        if self.debug {
+            header_inc = "#pragma once\n#include <cstdint>\n#include <cstring>\n#include <cstdio>\n#include \"verilated.h\"\n\n".to_string();
+        }
+        h.push_str(&header_inc);
         h.push_str(&format!("class {class} {{\npublic:\n"));
         h.push_str("  uint8_t clk;\n  uint8_t rst;\n");
         for op in &l.ops {
@@ -173,7 +175,11 @@ impl<'a> SimCodegen<'a> {
             h.push_str("    memset(_length_r, 0, sizeof(_length_r));\n");
         }
         h.push_str("  }\n");
-        h.push_str("  void eval();\n  void eval_comb();\n  void eval_posedge();\n  void final() { trace_close(); }\n\nprivate:\n");
+        h.push_str("  void eval();\n  void eval_comb();\n  void eval_posedge();\n  void final() { trace_close(); }\n");
+        if self.debug {
+            h.push_str("  void _debug_log_ports();\n");
+        }
+        h.push_str("\nprivate:\n");
         h.push_str("  uint8_t _clk_prev;\n");
         h.push_str(&format!("  uint8_t _fl_mem[{depth}];\n"));
         h.push_str(&format!("  {data_cpp} _data_mem[{depth}];\n"));
@@ -219,6 +225,55 @@ impl<'a> SimCodegen<'a> {
                 h.push_str(&format!("  uint8_t _ctrl_{on}_head_idx;\n"));
             }
         }
+        if self.debug {
+            // Collect debug ports: main ports + op ports (flattened as op_port)
+            let mut debug_ports: Vec<SimpleDebugPort> = Vec::new();
+            for p in &l.ports {
+                if p.name.name == "clk" || p.name.name == "rst" {
+                    continue;
+                }
+                if matches!(&p.ty, TypeExpr::Clock(_)) {
+                    continue;
+                }
+                if p.bus_info.is_some() || ty_references_named(&p.ty) {
+                    continue;
+                }
+                let dir = match p.direction {
+                    crate::ast::Direction::In => "in",
+                    crate::ast::Direction::Out => "out",
+                }
+                .to_string();
+                let bits = type_bits_te_with_params(&p.ty, &l.params);
+                let cpp_ty = port_cpp_ty(&p.ty);
+                debug_ports.push(SimpleDebugPort {
+                    name: p.name.name.clone(),
+                    cpp_ty,
+                    bits,
+                    dir,
+                });
+            }
+            for op in &l.ops {
+                for p in &op.ports {
+                    let dir = match p.direction {
+                        crate::ast::Direction::In => "in",
+                        crate::ast::Direction::Out => "out",
+                    }
+                    .to_string();
+                    if p.bus_info.is_some() || ty_references_named(&p.ty) {
+                        continue;
+                    }
+                    let bits = type_bits_te_with_params(&p.ty, &l.params);
+                    let cpp_ty = port_cpp_ty(&p.ty);
+                    debug_ports.push(SimpleDebugPort {
+                        name: format!("{}_{}", op.name.name, p.name.name),
+                        cpp_ty,
+                        bits,
+                        dir,
+                    });
+                }
+            }
+            emit_simple_debug_header(&mut h, &debug_ports);
+        }
 
         // ── Implementation ────────────────────────────────────────────────────
         let mut cpp = String::new();
@@ -226,14 +281,20 @@ impl<'a> SimCodegen<'a> {
         // eval(): edge detection lives inside eval_posedge() so that when
         // a parent module calls _inst_q.eval_posedge() directly, the
         // sub-instance still gates correctly on its own clock edge.
-        cpp.push_str(&format!(
-            "void {class}::eval() {{\n\
-             \n  if (!_trace_fp && Verilated::traceFile() && Verilated::claimTrace())\n\
-             \n    trace_open(Verilated::traceFile());\n\
-             \n  eval_posedge();\n\
-             \n  eval_comb();\n\
-             \n  if (_trace_fp) trace_dump(_trace_time++);\n}}\n\n"
-        ));
+        if self.debug {
+            cpp.push_str(&format!(
+                "void {class}::eval() {{\n  if (!_trace_fp && Verilated::traceFile() && Verilated::claimTrace())\n    trace_open(Verilated::traceFile());\n  eval_posedge();\n  eval_comb();\n  _debug_log_ports();\n  if (_trace_fp) trace_dump(_trace_time++);\n}}\n\n"
+            ));
+        } else {
+            cpp.push_str(&format!(
+                "void {class}::eval() {{\n\
+                 \n  if (!_trace_fp && Verilated::traceFile() && Verilated::claimTrace())\n\
+                 \n    trace_open(Verilated::traceFile());\n\
+                 \n  eval_posedge();\n\
+                 \n  eval_comb();\n\
+                 \n  if (_trace_fp) trace_dump(_trace_time++);\n}}\n\n"
+            ));
+        }
 
         cpp.push_str(&format!("void {class}::eval_comb() {{\n"));
         // Only emit status assigns for status ports the linklist actually
@@ -482,6 +543,55 @@ impl<'a> SimCodegen<'a> {
             }
         }
         cpp.push_str("  }\n}\n");
+
+        if self.debug {
+            let mut debug_ports: Vec<SimpleDebugPort> = Vec::new();
+            for p in &l.ports {
+                if p.name.name == "clk" || p.name.name == "rst" {
+                    continue;
+                }
+                if matches!(&p.ty, TypeExpr::Clock(_)) {
+                    continue;
+                }
+                if p.bus_info.is_some() || ty_references_named(&p.ty) {
+                    continue;
+                }
+                let dir = match p.direction {
+                    crate::ast::Direction::In => "in",
+                    crate::ast::Direction::Out => "out",
+                }
+                .to_string();
+                let bits = type_bits_te_with_params(&p.ty, &l.params);
+                let cpp_ty = port_cpp_ty(&p.ty);
+                debug_ports.push(SimpleDebugPort {
+                    name: p.name.name.clone(),
+                    cpp_ty,
+                    bits,
+                    dir,
+                });
+            }
+            for op in &l.ops {
+                for p in &op.ports {
+                    if p.bus_info.is_some() || ty_references_named(&p.ty) {
+                        continue;
+                    }
+                    let dir = match p.direction {
+                        crate::ast::Direction::In => "in",
+                        crate::ast::Direction::Out => "out",
+                    }
+                    .to_string();
+                    let bits = type_bits_te_with_params(&p.ty, &l.params);
+                    let cpp_ty = port_cpp_ty(&p.ty);
+                    debug_ports.push(SimpleDebugPort {
+                        name: format!("{}_{}", op.name.name, p.name.name),
+                        cpp_ty,
+                        bits,
+                        dir,
+                    });
+                }
+            }
+            emit_simple_debug_impl(&mut cpp, &class, name, &debug_ports, Some("clk"));
+        }
 
         let extra_sigs: Vec<(&str, &str, u32)> = vec![];
         add_trace_to_simple_construct(

--- a/src/sim_codegen/mod.rs
+++ b/src/sim_codegen/mod.rs
@@ -1528,6 +1528,157 @@ fn add_trace_to_simple_construct(
     cpp.push_str(&trace_cpp);
 }
 
+// ── Debug helpers for simple constructs (RAM, FIFO, FSM, etc.) ──────────────
+
+#[derive(Clone, Debug)]
+pub(crate) struct SimpleDebugPort {
+    pub name: String,
+    pub cpp_ty: String,
+    pub bits: u32,
+    pub dir: String,
+}
+
+pub(crate) fn collect_simple_debug_ports(
+    ports: &[PortDecl],
+    params: &[ParamDecl],
+) -> Vec<SimpleDebugPort> {
+    let mut out = Vec::new();
+    for p in ports {
+        // Skip Clock (and Reset is kept? module skips only Clock)
+        if matches!(&p.ty, TypeExpr::Clock(_)) {
+            continue;
+        }
+        if p.bus_info.is_some() {
+            // Bus ports are flattened elsewhere; skip here for simple case
+            // Caller can extend with bus_flat if needed.
+            continue;
+        }
+        // Skip named struct/enum ports (not scalar)
+        if ty_references_named(&p.ty) {
+            continue;
+        }
+        let dir = match p.direction {
+            Direction::In => "in".to_string(),
+            Direction::Out => "out".to_string(),
+        };
+        // Vec handling
+        if let Some((elem_ty_str, _count_str)) = vec_array_info_with_params(&p.ty, params) {
+            // Resolve actual count via param-aware eval
+            let count_val = if let TypeExpr::Vec(_, cnt_expr) = &p.ty {
+                eval_const_expr_with_params(cnt_expr, params) as u64
+            } else {
+                0
+            };
+            let bits = if let TypeExpr::Vec(elem, _) = &p.ty {
+                type_bits_te_with_params(elem, params)
+            } else {
+                32
+            };
+            for i in 0..count_val {
+                out.push(SimpleDebugPort {
+                    name: format!("{}_{}", p.name.name, i),
+                    cpp_ty: elem_ty_str.clone(),
+                    bits,
+                    dir: dir.clone(),
+                });
+            }
+        } else {
+            let bits = type_bits_te_with_params(&p.ty, params);
+            let cpp_ty = cpp_port_type_with_params(&p.ty, params);
+            out.push(SimpleDebugPort {
+                name: p.name.name.clone(),
+                cpp_ty,
+                bits,
+                dir,
+            });
+        }
+    }
+    out
+}
+
+pub(crate) fn emit_simple_debug_header(
+    h: &mut String,
+    ports: &[SimpleDebugPort],
+) {
+    if ports.is_empty() {
+        return;
+    }
+    h.push_str("  // --debug port shadow copies\n");
+    for p in ports {
+        if p.bits > 64 {
+            // Use same wide type as port for shadow
+            h.push_str(&format!("  {} _dbg_prev_{};\n", p.cpp_ty, p.name));
+        } else {
+            h.push_str(&format!("  {} _dbg_prev_{} = 0;\n", p.cpp_ty, p.name));
+        }
+    }
+    h.push_str("  uint64_t _dbg_cycle = 0;\n");
+}
+
+pub(crate) fn emit_simple_debug_impl(
+    cpp: &mut String,
+    class: &str,
+    construct_name: &str,
+    ports: &[SimpleDebugPort],
+    clk_port: Option<&str>,
+) {
+    if ports.is_empty() {
+        return;
+    }
+    cpp.push_str(&format!("void {class}::_debug_log_ports() {{\n"));
+    for p in ports {
+        let dir = &p.dir;
+        if p.bits > 64 {
+            let words = wide_words(p.bits);
+            cpp.push_str(&format!(
+                "  if (memcmp(&{name}, &_dbg_prev_{name}, sizeof({name})) != 0) {{\n",
+                name = p.name
+            ));
+            cpp.push_str(&format!(
+                "    printf(\"[%llu][{cname}.{pname}]({dir}) 0x\");\n",
+                cname = construct_name,
+                pname = p.name,
+                dir = dir
+            ));
+            cpp.push_str(&format!(
+                "    for (int _w = {words} - 1; _w >= 0; _w--) printf(\"%08x\", _dbg_prev_{name}.data()[_w]);\n",
+                name = p.name,
+                words = words
+            ));
+            cpp.push_str("    printf(\" -> 0x\");\n");
+            cpp.push_str(&format!(
+                "    for (int _w = {words} - 1; _w >= 0; _w--) printf(\"%08x\", {name}.data()[_w]);\n",
+                name = p.name,
+                words = words
+            ));
+            cpp.push_str("    printf(\"\\n\");\n");
+            cpp.push_str(&format!("    _dbg_prev_{name} = {name};\n", name = p.name));
+            cpp.push_str("  }\n");
+        } else {
+            cpp.push_str(&format!(
+                "  if ({name} != _dbg_prev_{name}) {{\n",
+                name = p.name
+            ));
+            cpp.push_str(&format!(
+                "    printf(\"[%llu][{cname}.{pname}]({dir}) 0x%llx -> 0x%llx\\n\", (unsigned long long)_dbg_cycle, (unsigned long long)_dbg_prev_{name}, (unsigned long long){name});\n",
+                cname = construct_name,
+                pname = p.name,
+                dir = dir,
+                name = p.name
+            ));
+            cpp.push_str(&format!("    _dbg_prev_{name} = {name};\n", name = p.name));
+            cpp.push_str("  }\n");
+        }
+    }
+    // Cycle increment
+    if let Some(clk) = clk_port {
+        cpp.push_str(&format!("  if ({clk} && !_clk_prev) _dbg_cycle++;\n"));
+    } else {
+        cpp.push_str("  _dbg_cycle++;\n");
+    }
+    cpp.push_str("}\n\n");
+}
+
 // ── Type helpers ──────────────────────────────────────────────────────────────
 
 /// Evaluate a simple constant expression to a u32 bit-width.
@@ -11093,9 +11244,15 @@ impl<'a> SimCodegen<'a> {
         };
 
         let mut h = String::new();
-        h.push_str(
-            "#pragma once\n#include <cstdint>\n#include <cstring>\n#include \"verilated.h\"\n\n",
-        );
+        if self.debug {
+            h.push_str(
+                "#pragma once\n#include <cstdint>\n#include <cstring>\n#include <cstdio>\n#include \"verilated.h\"\n\n",
+            );
+        } else {
+            h.push_str(
+                "#pragma once\n#include <cstdint>\n#include <cstring>\n#include \"verilated.h\"\n\n",
+            );
+        }
         h.push_str(&format!("class {class} {{\npublic:\n"));
         for p in &a.ports {
             let ty = cpp_port_type_with_params(&p.ty, &a.params);
@@ -11149,6 +11306,9 @@ impl<'a> SimCodegen<'a> {
         ));
         h.push_str("  void eval();\n  void eval_posedge();\n  void eval_comb();\n");
         h.push_str("  void final() { trace_close(); }\n");
+        if self.debug {
+            h.push_str("  void _debug_log_ports();\n");
+        }
         h.push_str("private:\n");
         h.push_str("  uint8_t _clk_prev;\n");
         if a.lock_hold {
@@ -11160,6 +11320,10 @@ impl<'a> SimCodegen<'a> {
         }
         if needs_rr_state {
             h.push_str("  uint8_t _last_grant;\n");
+        }
+        if self.debug {
+            let debug_ports = collect_simple_debug_ports(&a.ports, &a.params);
+            emit_simple_debug_header(&mut h, &debug_ports);
         }
         h.push_str("  void trace_open(const char* filename);\n");
         h.push_str("  void trace_dump(uint64_t time);\n");
@@ -11194,6 +11358,9 @@ impl<'a> SimCodegen<'a> {
         cpp.push_str("    trace_open(Verilated::traceFile());\n");
         cpp.push_str("  eval_posedge();\n");
         cpp.push_str("  eval_comb();\n");
+        if self.debug {
+            cpp.push_str("  _debug_log_ports();\n");
+        }
         cpp.push_str("  if (_trace_fp) trace_dump(_trace_time++);\n");
         cpp.push_str("}\n\n");
 
@@ -11310,7 +11477,11 @@ impl<'a> SimCodegen<'a> {
 
         cpp.push_str(&format!("void {class}::trace_close() {{\n"));
         cpp.push_str("  if (_trace_fp) {{ fclose(_trace_fp); _trace_fp = nullptr; }}\n");
-        cpp.push_str("}\n");
+        cpp.push_str("}\n\n");
+        if self.debug {
+            let debug_ports = collect_simple_debug_ports(&a.ports, &a.params);
+            emit_simple_debug_impl(&mut cpp, &class, name, &debug_ports, Some(clk_port));
+        }
 
         SimModel {
             class_name: class,

--- a/src/sim_codegen/mod.rs
+++ b/src/sim_codegen/mod.rs
@@ -1596,10 +1596,7 @@ pub(crate) fn collect_simple_debug_ports(
     out
 }
 
-pub(crate) fn emit_simple_debug_header(
-    h: &mut String,
-    ports: &[SimpleDebugPort],
-) {
+pub(crate) fn emit_simple_debug_header(h: &mut String, ports: &[SimpleDebugPort]) {
     if ports.is_empty() {
         return;
     }

--- a/src/sim_codegen/pipeline.rs
+++ b/src/sim_codegen/pipeline.rs
@@ -339,9 +339,11 @@ impl<'a> SimCodegen<'a> {
 
         h.push_str("  void eval();\n  void eval_posedge();\n  void eval_comb();\n");
         h.push_str("  void _do_reset();\n  void final_() {}\n");
-        h.push_str("  void trace_open(const char*) {}\n  void trace_dump(uint64_t) {}\n  void trace_close() {}\n\n");
-
-        h.push_str("private:\n");
+        h.push_str("  void trace_open(const char*) {}\n  void trace_dump(uint64_t) {}\n  void trace_close() {}\n");
+        if self.debug {
+            h.push_str("  void _debug_log_ports();\n");
+        }
+        h.push_str("\nprivate:\n");
         h.push_str("  uint8_t _clk_prev;\n");
         for sr in &all_regs {
             if !sr.is_let {
@@ -371,14 +373,24 @@ impl<'a> SimCodegen<'a> {
                 ));
             }
         }
+        if self.debug {
+            let debug_ports = collect_simple_debug_ports(&p.ports, &p.common.params);
+            emit_simple_debug_header(&mut h, &debug_ports);
+        }
         h.push_str("};\n");
 
         // ── Implementation ──
         let mut cpp = String::new();
         cpp.push_str(&format!("#include \"V{name}.h\"\n\n"));
-        cpp.push_str(&format!(
-            "void {class}::eval() {{ eval_comb(); eval_posedge(); eval_comb(); }}\n\n"
-        ));
+        if self.debug {
+            cpp.push_str(&format!(
+                "void {class}::eval() {{ eval_comb(); eval_posedge(); eval_comb(); _debug_log_ports(); }}\n\n"
+            ));
+        } else {
+            cpp.push_str(&format!(
+                "void {class}::eval() {{ eval_comb(); eval_posedge(); eval_comb(); }}\n\n"
+            ));
+        }
 
         // reset()
         cpp.push_str(&format!("void {class}::_do_reset() {{\n"));
@@ -746,7 +758,16 @@ impl<'a> SimCodegen<'a> {
                 }
             }
         }
-        cpp.push_str("}\n");
+        cpp.push_str("}\n\n");
+        if self.debug {
+            let debug_ports = collect_simple_debug_ports(&p.ports, &p.common.params);
+            let clk_port = p
+                .ports
+                .iter()
+                .find(|pt| matches!(&pt.ty, TypeExpr::Clock(_)))
+                .map(|pt| pt.name.name.as_str());
+            emit_simple_debug_impl(&mut cpp, &class, name, &debug_ports, clk_port);
+        }
 
         SimModel {
             class_name: class,

--- a/src/sim_codegen/ram.rs
+++ b/src/sim_codegen/ram.rs
@@ -231,7 +231,11 @@ impl<'a> SimCodegen<'a> {
                     .iter()
                     .flat_map(|pg| {
                         pg.signals.iter().map(move |s| {
-                            (format!("{}_{}", pg.name.name, s.name.name), &s.ty, s.direction)
+                            (
+                                format!("{}_{}", pg.name.name, s.name.name),
+                                &s.ty,
+                                s.direction,
+                            )
                         })
                     })
                     .find(|(n, _, _)| *n == fs.full_name);
@@ -615,10 +619,7 @@ impl<'a> SimCodegen<'a> {
         cpp.push_str("}\n\n");
         if self.debug {
             // Clock port for cycle counting
-            let clk_port = if r
-                .ports
-                .iter()
-                .any(|p| matches!(&p.ty, TypeExpr::Clock(_)))
+            let clk_port = if r.ports.iter().any(|p| matches!(&p.ty, TypeExpr::Clock(_)))
                 || flat_sigs.iter().any(|s| s.full_name == "clk")
             {
                 Some("clk")

--- a/src/sim_codegen/ram.rs
+++ b/src/sim_codegen/ram.rs
@@ -217,10 +217,72 @@ impl<'a> SimCodegen<'a> {
             }
         }
         h.push_str("  }\n");
+        // Collect debug ports from flat_sigs + r.ports (excluding clock)
+        let mut debug_ports: Vec<SimpleDebugPort> = Vec::new();
+        if self.debug {
+            // From flat_sigs (already have full_name, dir, and we can resolve ty)
+            for fs in &flat_sigs {
+                if fs.full_name == "clk" {
+                    continue;
+                }
+                // Find original ty for bits
+                let orig_ty_opt = r
+                    .port_groups
+                    .iter()
+                    .flat_map(|pg| {
+                        pg.signals.iter().map(move |s| {
+                            (format!("{}_{}", pg.name.name, s.name.name), &s.ty, s.direction)
+                        })
+                    })
+                    .find(|(n, _, _)| *n == fs.full_name);
+                if let Some((_, ty, dir)) = orig_ty_opt {
+                    if matches!(ty, TypeExpr::Clock(_)) {
+                        continue;
+                    }
+                    let bits = resolve_sig_bits(ty);
+                    let dir_str = match dir {
+                        Direction::In => "in",
+                        Direction::Out => "out",
+                    }
+                    .to_string();
+                    // Find cpp type: reuse logic for ty_str
+                    let cpp_ty = {
+                        if dir == Direction::Out {
+                            port_elem_ty.clone()
+                        } else {
+                            match ty {
+                                TypeExpr::Bool => "uint8_t".to_string(),
+                                _ => {
+                                    let b = resolve_sig_bits(ty);
+                                    if b > 64 {
+                                        port_elem_ty.clone()
+                                    } else {
+                                        cpp_uint(b).to_string()
+                                    }
+                                }
+                            }
+                        }
+                    };
+                    debug_ports.push(SimpleDebugPort {
+                        name: fs.full_name.clone(),
+                        cpp_ty,
+                        bits,
+                        dir: dir_str,
+                    });
+                }
+            }
+            // Also from r.ports (excluding clock, which is already separate)
+            let extra_dbg = collect_simple_debug_ports(&r.ports, &r.params);
+            debug_ports.extend(extra_dbg);
+        }
+
         h.push_str(&format!(
             "  explicit {class}(VerilatedContext*) : {class}() {{}}\n"
         ));
         h.push_str("  void eval();\n  void eval_posedge();\n  void eval_comb();\n  void final() { trace_close(); }\n");
+        if self.debug {
+            h.push_str("  void _debug_log_ports();\n");
+        }
         h.push_str("private:\n");
         h.push_str("  uint8_t _clk_prev;\n");
         h.push_str(&format!("  {} _mem[{}];\n", elem_ty, depth));
@@ -232,6 +294,9 @@ impl<'a> SimCodegen<'a> {
             if r.latency == 2 {
                 h.push_str(&format!("  {} _r2_{};\n", elem_ty, fs.full_name));
             }
+        }
+        if self.debug {
+            emit_simple_debug_header(&mut h, &debug_ports);
         }
 
         // ── Implementation ──
@@ -268,6 +333,9 @@ impl<'a> SimCodegen<'a> {
         cpp.push_str("    trace_open(Verilated::traceFile());\n");
         cpp.push_str("  eval_posedge();\n");
         cpp.push_str("  eval_comb();\n");
+        if self.debug {
+            cpp.push_str("  _debug_log_ports();\n");
+        }
         cpp.push_str("  if (_trace_fp) trace_dump(_trace_time++);\n");
         cpp.push_str("}\n\n");
 
@@ -544,7 +612,21 @@ impl<'a> SimCodegen<'a> {
                 _ => {}
             }
         }
-        cpp.push_str("}\n");
+        cpp.push_str("}\n\n");
+        if self.debug {
+            // Clock port for cycle counting
+            let clk_port = if r
+                .ports
+                .iter()
+                .any(|p| matches!(&p.ty, TypeExpr::Clock(_)))
+                || flat_sigs.iter().any(|s| s.full_name == "clk")
+            {
+                Some("clk")
+            } else {
+                None
+            };
+            emit_simple_debug_impl(&mut cpp, &class, name, &debug_ports, clk_port);
+        }
 
         let extra_sigs: Vec<(&str, &str, u32)> = vec![];
         add_trace_to_simple_construct(


### PR DESCRIPTION
Proper fix for --debug support across all sim constructs.

Previously only Module had _debug_log_ports(). Non-module constructs (RAM, FIFO, FSM, Pipeline, CAM, Linklist, Counter, Regfile, Synchronizer, Clkgate, Arbiter) lacked it, causing:

- top-level DUT being RAM/FIFO etc. produced no debug output
- --depth >1 with RAM/FIFO sub-instances failed to compile (parent calls _inst_xxx._debug_log_ports() but child has no method)

The dirty stub in arch-com-mcp-unique-match-guidance was an incomplete attempt (empty method only for RAM).

Now each gen_* emits:
- void _debug_log_ports() declaration
- shadow _dbg_prev_<port> + _dbg_cycle
- eval() calls _debug_log_ports() before trace_dump
- impl logs scalar <=64b and wide >64b via memcmp + hex dump, matching Module format [cycle][Mod.port](in/out) 0xold -> 0xnew

Tested with Top module instancing SimpleMem RAM: arch sim --debug --depth 2 now prints both Top and SimpleMem port changes.

Fixes the TODO noted in mcp-unique-match-guidance review.