### PR TITLE
fix: avoid staged-ops panic on nested pipelined calls

### DIFF
--- a/src/pipelined_ops.rs
+++ b/src/pipelined_ops.rs
@@ -764,13 +764,24 @@ fn lower_staged_sites(
         };
         for s in &rb.stmts {
             let Stmt::Assign(a) = s else { continue };
-            let ExprKind::PipelinedCall(op, _, n) = &a.value.kind else {
+            let ExprKind::PipelinedCall(op, args, n) = &a.value.kind else {
                 continue;
             };
             let ExprKind::Ident(t) = &a.target.kind else {
                 continue;
             };
             if let Some(base) = t.strip_suffix("_stg1") {
+                if args.iter().any(expr_contains_pipelined_call) {
+                    out.fallbacks.push(StagedFallback {
+                        operator: op.clone(),
+                        stages: *n,
+                        reason: "nested pipelined call (staged emission requires scalar \
+                                 combinational arguments)"
+                            .to_string(),
+                        span: a.span,
+                    });
+                    continue;
+                }
                 if rb.clock_edge == ClockEdge::Falling {
                     out.fallbacks.push(StagedFallback {
                         operator: op.clone(),
@@ -985,6 +996,12 @@ fn lower_staged_sites(
             args,
         });
     }
+}
+
+fn expr_contains_pipelined_call(expr: &crate::ast::Expr) -> bool {
+    let mut found = Vec::new();
+    scan_expr(expr, &mut found);
+    !found.is_empty()
 }
 
 fn lower_stmts(stmts: &mut [crate::ast::Stmt]) -> Result<(), FoundPipelinedCall> {

--- a/tests/pipelined_fma_lockstep_test.rs
+++ b/tests/pipelined_fma_lockstep_test.rs
@@ -43,6 +43,31 @@ module F32FmaPipe6Lockstep
 end module F32FmaPipe6Lockstep
 "#;
 
+const NESTED_MODULE_SRC: &str = r#"
+module NestedFmaPipe6
+  port clk: in Clock<Sys>;
+  port rst: in Reset<Sync, High>;
+  port a: in FP32;
+  port b: in FP32;
+  port c: in FP32;
+  port d: in FP32;
+  port e: in FP32;
+  port f: in FP32;
+  port g: in FP32;
+  port h: in FP32;
+  port i: in FP32;
+  port y: out pipe_reg<FP32, 6> reset rst => 0.0;
+
+  seq on clk rising
+    y@6 <= fma<pipelined, 6>(
+      fma<pipelined, 6>(a, b, c),
+      fma<pipelined, 6>(d, e, f),
+      fma<pipelined, 6>(g, h, i)
+    );
+  end seq
+end module NestedFmaPipe6
+"#;
+
 /// Deterministic stimulus generator shared verbatim (byte-for-byte, via
 /// string interpolation of the same Rust `const`) between the native-sim and
 /// Verilator testbenches below — the whole point of the lock-step check is
@@ -122,6 +147,39 @@ int main() {{
 }}
 "#
     )
+}
+
+#[test]
+fn staged_ops_falls_back_for_nested_pipelined_arguments() {
+    let td = tempfile::tempdir().expect("tempdir");
+    let arch_path = td.path().join("NestedFmaPipe6.arch");
+    let sv_path = td.path().join("NestedFmaPipe6.sv");
+    std::fs::write(&arch_path, NESTED_MODULE_SRC).expect("write .arch");
+
+    let out = arch()
+        .arg("build")
+        .arg("--staged-ops")
+        .arg(&arch_path)
+        .arg("-o")
+        .arg(&sv_path)
+        .output()
+        .expect("run arch build");
+    assert!(
+        out.status.success(),
+        "nested pipelined args should fall back to cascade instead of panicking\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&out.stderr).contains("nested pipelined call"),
+        "fallback warning should identify the unsupported staged shape\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let sv = std::fs::read_to_string(&sv_path).expect("read generated SV");
+    assert!(
+        !sv.contains("pipelined"),
+        "raw pipelined AST node reached SV codegen"
+    );
 }
 
 /// Latency-exactness: a single fma driven for one cycle then held constant


### PR DESCRIPTION
## Summary

- Detect nested `fma<pipelined, 6>` calls inside staged-call arguments.
- Warn and preserve the full cascade lowering for unsupported nested shapes.
- Add an end-to-end regression test proving `arch build --staged-ops` succeeds without reaching the raw `PipelinedCall` codegen backstop.

## Root cause

The staged lowering pass replaced the outer pipelined call with a validity bit and saved its arguments for the generated SV instance. Nested pipelined calls inside those saved arguments were therefore skipped by the normal lowering walk. Codegen later encountered the untouched AST node and panicked at its intentional unreachable arm.

## Validation

- `cargo fmt -- --check`
- `git diff --check`
- `cargo test --release --test pipelined_fma_lockstep_test -- --nocapture` (7 passed)
- Pre-PR review marker recorded and checked against `origin/main`