### PR TITLE
Prepare ARCH 0.71.0 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,7 +75,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arch"
-version = "0.70.8"
+version = "0.71.0"
 dependencies = [
  "clap",
  "insta",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arch"
-version = "0.70.8"
+version = "0.71.0"
 edition = "2021"
 description = "Compiler for the ARCH hardware description language"
 license = "LGPL-3.0-or-later"


### PR DESCRIPTION
Version bump 0.70.8 → 0.71.0. Release content since 0.70.8 is the FP verification artifact set referenced by the paper:

- **Value-level RNE anchor** (R1+R2, #722): `roundNE_f32` proved round-to-nearest-even against a dyadic real-valued spec (nearest among all finite patterns, ties-to-even, IEEE overflow threshold), core-only Lean.
- **End-to-end fma value semantics** (R3, #723): `arch_fma_f32_correct` — the sticky-fold fma is nearest to the exact `a·b+c` of its decoded operands, with exact sign; overflow companion included.
- **Renderer-faithfulness miters** (#728, #729): Yosys reads the emitted SV and a solver proves it equivalent to `render_smt` — all 24 exposed operators `unsat`, fmas via a sound 510-way alignment-gap split.
- **Nangate45 timing flow archive** (#726): the paper's synthesis numbers now reproducible (scripts, tool versions, Liberty provenance by sha256, reproduction check).
- Plus #724, #725 fixes.

After merge, tagging the merge commit `v0.71.0` fires the release pipeline; the paper's §8 Artifact paragraph will pin this release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)