### PR TITLE
doc: sync COMPILER_STATUS to 0.71.0 (banner + release highlights)

### DIFF
--- a/doc/COMPILER_STATUS.md
+++ b/doc/COMPILER_STATUS.md
@@ -1,7 +1,13 @@
 # ARCH Compiler — Status & Roadmap
 
-> Last updated: 2026-07-15
-> Compiler version: 0.70.8
+> Last updated: 2026-07-27
+> Compiler version: 0.71.0
+>
+> **0.71.0 release highlights:**
+> - **`semaphore<N, policy>` thread resource** (part of #501) — `resource`/`lock` in a `thread` now supports counting semaphores admitting up to `N` concurrent holders (`N` a const expr; module params allowed), across the full policy vocabulary (`round_robin | priority | lru | weighted<W> | MyFn`). `semaphore<1, policy>` lowers bit-identically to `mutex<policy>`. Same-cycle lock handoff is preserved so a release pulse and a waiting grant can land on the same edge (#719). See `doc/thread_spec_section.md` §20.8.4 and `doc/Arch_AI_Reference_Card.md`.
+> - **`--staged-ops`: staged SV emission for pipelined operators** (#720, proposal phase 3.5) — `arch build --staged-ops` emits pipelined operators (e.g. `fma<pipelined, N>`) as a per-stage registered pipeline instead of the default combinational cascade, letting downstream synthesis meet timing without manual retiming. Shapes the staged renderer does not yet support (nested pipelined calls in a call's arguments, falling-edge clocks, conditional call sites, arity/schedule mismatches) fall back to the cascade lowering with a warning rather than failing — the nested-argument case previously panicked at the codegen backstop and is now handled (#727). Default emission (no flag) is unchanged.
+> - **`arch sim --debug` covers all non-module constructs** (#725) — port-change logging under `--debug` now fires for `fsm`, `pipeline`, `fifo`, `ram`, `arbiter`, `thread`, and `bus`-bearing constructs, not just plain `module`s, so I/O tracing works uniformly across the construct set.
+> - **Formal FP verification — end-to-end value semantics + renderer faithfulness** (#722, #723, #728, #729) — `arch_fma_f32` is proved in Lean to be the round-to-nearest-even of the exact real product-sum `a·b+c` (R1–R3), and SMT renderer-faithfulness miters prove the emitted SystemVerilog is bit-equivalent to `render_smt` for all FP operators including both FMAs and the integer conversions (24/24 unsat). The RTL and the formally-checked model render from one in-Rust IR, so they cannot drift.
 >
 > **0.70.8 release highlights:**
 > - **Typed FP parameters and constant evaluation** (#693, #694, #700) — module-scope FP wires and typed FP local parameters now resolve consistently in SystemVerilog and native simulation, including compile-time integer-to-FP conversion. This enables parameterized BF16-to-fixed conversion such as `local param SCALE_FP: FP32 = SCALE_INT.to_fp32();`.

--- a/skills/arch-programming/references/COMPILER_STATUS.md
+++ b/skills/arch-programming/references/COMPILER_STATUS.md
@@ -1,7 +1,13 @@
 # ARCH Compiler — Status & Roadmap
 
-> Last updated: 2026-07-15
-> Compiler version: 0.70.8
+> Last updated: 2026-07-27
+> Compiler version: 0.71.0
+>
+> **0.71.0 release highlights:**
+> - **`semaphore<N, policy>` thread resource** (part of #501) — `resource`/`lock` in a `thread` now supports counting semaphores admitting up to `N` concurrent holders (`N` a const expr; module params allowed), across the full policy vocabulary (`round_robin | priority | lru | weighted<W> | MyFn`). `semaphore<1, policy>` lowers bit-identically to `mutex<policy>`. Same-cycle lock handoff is preserved so a release pulse and a waiting grant can land on the same edge (#719). See `doc/thread_spec_section.md` §20.8.4 and `doc/Arch_AI_Reference_Card.md`.
+> - **`--staged-ops`: staged SV emission for pipelined operators** (#720, proposal phase 3.5) — `arch build --staged-ops` emits pipelined operators (e.g. `fma<pipelined, N>`) as a per-stage registered pipeline instead of the default combinational cascade, letting downstream synthesis meet timing without manual retiming. Shapes the staged renderer does not yet support (nested pipelined calls in a call's arguments, falling-edge clocks, conditional call sites, arity/schedule mismatches) fall back to the cascade lowering with a warning rather than failing — the nested-argument case previously panicked at the codegen backstop and is now handled (#727). Default emission (no flag) is unchanged.
+> - **`arch sim --debug` covers all non-module constructs** (#725) — port-change logging under `--debug` now fires for `fsm`, `pipeline`, `fifo`, `ram`, `arbiter`, `thread`, and `bus`-bearing constructs, not just plain `module`s, so I/O tracing works uniformly across the construct set.
+> - **Formal FP verification — end-to-end value semantics + renderer faithfulness** (#722, #723, #728, #729) — `arch_fma_f32` is proved in Lean to be the round-to-nearest-even of the exact real product-sum `a·b+c` (R1–R3), and SMT renderer-faithfulness miters prove the emitted SystemVerilog is bit-equivalent to `render_smt` for all FP operators including both FMAs and the integer conversions (24/24 unsat). The RTL and the formally-checked model render from one in-Rust IR, so they cannot drift.
 >
 > **0.70.8 release highlights:**
 > - **Typed FP parameters and constant evaluation** (#693, #694, #700) — module-scope FP wires and typed FP local parameters now resolve consistently in SystemVerilog and native simulation, including compile-time integer-to-FP conversion. This enables parameterized BF16-to-fixed conversion such as `local param SCALE_FP: FP32 = SCALE_INT.to_fp32();`.


### PR DESCRIPTION
## Summary

The 0.71.0 release (PR #730) bumped `Cargo.toml`/`Cargo.lock` but did **not** update `doc/COMPILER_STATUS.md`. Its version banner still read `0.70.8` with no `0.71.0 release highlights` block — breaking the per-release convention that the 0.70.8 release PR (#716) followed (that PR updated both the banner and the highlights).

Found during the daily merged-PR review (document-consistency pass).

## Change

- Bump the banner `Compiler version: 0.70.8` → `0.71.0` and refresh `Last updated` to 2026-07-27.
- Add a `0.71.0 release highlights` block summarizing the user-facing changes merged in the release window (0.70.8 release → 0.71.0 release):
  - `semaphore<N, policy>` thread resource + same-cycle handoff (#719)
  - `--staged-ops` staged SV emission for pipelined operators, incl. the nested-argument fallback fix (#720, #727)
  - `--debug` port logging for all non-module constructs (#725)
  - end-to-end FP value-semantics + renderer-faithfulness proofs (#722, #723, #728, #729)
- Re-sync the arch-programming skill snapshot via `scripts/sync_skill_snapshots.sh refresh` (both copies stay identical; `check` passes).

## Scope / safety

Docs only — no `src/` or grammar-surface files touched, so the `doc-drift` check does not apply. The highlights are grounded in the actual merged PRs in the release window; no new claims about unshipped behavior.