### PR TITLE
Reject nested pipelined operator calls

### DIFF
--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -3663,6 +3663,107 @@ impl<'a> TypeChecker<'a> {
         }
     }
 
+    /// Returns whether an expression contains a latency-bearing operator call
+    /// below its root. Pipelined calls currently lower to a single register
+    /// cascade at their binding site, so composing one inside another call
+    /// would silently turn the inner result into a combinational expression
+    /// during lowering. Reject the composition until the IR can represent
+    /// the required intermediate pipeline and latency.
+    fn expr_contains_pipelined_call(expr: &Expr) -> bool {
+        match &expr.kind {
+            ExprKind::PipelinedCall(_, _, _) => true,
+            ExprKind::Binary(_, a, b) => {
+                Self::expr_contains_pipelined_call(a) || Self::expr_contains_pipelined_call(b)
+            }
+            ExprKind::Unary(_, e)
+            | ExprKind::Cast(e, _)
+            | ExprKind::LatencyAt(e, _)
+            | ExprKind::SvaNext(_, e)
+            | ExprKind::Signed(e)
+            | ExprKind::Unsigned(e)
+            | ExprKind::Clog2(e)
+            | ExprKind::Onehot(e)
+            | ExprKind::Repeat(e, _) => Self::expr_contains_pipelined_call(e),
+            ExprKind::FieldAccess(e, _) => Self::expr_contains_pipelined_call(e),
+            ExprKind::MethodCall(recv, _, args) => {
+                Self::expr_contains_pipelined_call(recv)
+                    || args.iter().any(Self::expr_contains_pipelined_call)
+            }
+            ExprKind::Index(base, idx) => {
+                Self::expr_contains_pipelined_call(base) || Self::expr_contains_pipelined_call(idx)
+            }
+            ExprKind::BitSlice(base, hi, lo) | ExprKind::PartSelect(base, hi, lo, _) => {
+                Self::expr_contains_pipelined_call(base)
+                    || Self::expr_contains_pipelined_call(hi)
+                    || Self::expr_contains_pipelined_call(lo)
+            }
+            ExprKind::StructLiteral(_, fields) => fields
+                .iter()
+                .any(|f| Self::expr_contains_pipelined_call(&f.value)),
+            ExprKind::Match(scrut, arms) => {
+                Self::expr_contains_pipelined_call(scrut)
+                    || arms
+                        .iter()
+                        .any(|arm| arm.body.iter().any(Self::stmt_contains_pipelined_call))
+            }
+            ExprKind::ExprMatch(scrut, arms) => {
+                Self::expr_contains_pipelined_call(scrut)
+                    || arms
+                        .iter()
+                        .any(|arm| Self::expr_contains_pipelined_call(&arm.value))
+            }
+            ExprKind::Concat(xs) | ExprKind::FunctionCall(_, xs) => {
+                xs.iter().any(Self::expr_contains_pipelined_call)
+            }
+            ExprKind::Inside(e, members) => {
+                Self::expr_contains_pipelined_call(e)
+                    || members.iter().any(|member| match member {
+                        InsideMember::Single(v) => Self::expr_contains_pipelined_call(v),
+                        InsideMember::Range(lo, hi) => {
+                            Self::expr_contains_pipelined_call(lo)
+                                || Self::expr_contains_pipelined_call(hi)
+                        }
+                    })
+            }
+            ExprKind::Ternary(c, t, e) => {
+                Self::expr_contains_pipelined_call(c)
+                    || Self::expr_contains_pipelined_call(t)
+                    || Self::expr_contains_pipelined_call(e)
+            }
+            ExprKind::Literal(_)
+            | ExprKind::Ident(_)
+            | ExprKind::SynthIdent(_, _)
+            | ExprKind::EnumVariant(_, _)
+            | ExprKind::Todo
+            | ExprKind::Bool(_) => false,
+        }
+    }
+
+    fn stmt_contains_pipelined_call(stmt: &Stmt) -> bool {
+        match stmt {
+            Stmt::Assign(a) => Self::expr_contains_pipelined_call(&a.value),
+            Stmt::IfElse(ie) => {
+                Self::expr_contains_pipelined_call(&ie.cond)
+                    || ie.then_stmts.iter().any(Self::stmt_contains_pipelined_call)
+                    || ie.else_stmts.iter().any(Self::stmt_contains_pipelined_call)
+            }
+            Stmt::Match(m) => {
+                Self::expr_contains_pipelined_call(&m.scrutinee)
+                    || m.arms
+                        .iter()
+                        .any(|arm| arm.body.iter().any(Self::stmt_contains_pipelined_call))
+            }
+            Stmt::Log(l) => l.args.iter().any(Self::expr_contains_pipelined_call),
+            Stmt::For(f) => f.body.iter().any(Self::stmt_contains_pipelined_call),
+            Stmt::Init(i) => i.body.iter().any(Self::stmt_contains_pipelined_call),
+            Stmt::WaitUntil(e, _) => Self::expr_contains_pipelined_call(e),
+            Stmt::DoUntil { body, cond, .. } => {
+                body.iter().any(Self::stmt_contains_pipelined_call)
+                    || Self::expr_contains_pipelined_call(cond)
+            }
+        }
+    }
+
     /// Rejects combining operands materializing at different cycle offsets
     /// in a single expression (e.g. `acc@6 + x` where `x` is latency-0),
     /// per the proposal's "no auto-alignment in v1" rule. Reports the
@@ -3730,6 +3831,13 @@ impl<'a> TypeChecker<'a> {
             .map(|a| self.resolve_expr_type(a, module_name, local_types))
             .collect();
         if arg_tys.iter().any(|t| *t == Ty::Error) {
+            return Ty::Error;
+        }
+        if call_args.iter().any(Self::expr_contains_pipelined_call) {
+            self.errors.push(CompileError::general(
+                "nested pipelined calls are not supported; bind the inner result to a pipe_reg tap before consuming it",
+                span,
+            ));
             return Ty::Error;
         }
         let ta = &arg_tys[0];

--- a/tests/pipelined_fma_lockstep_test.rs
+++ b/tests/pipelined_fma_lockstep_test.rs
@@ -150,7 +150,7 @@ int main() {{
 }
 
 #[test]
-fn staged_ops_falls_back_for_nested_pipelined_arguments() {
+fn nested_pipelined_arguments_are_rejected() {
     let td = tempfile::tempdir().expect("tempdir");
     let arch_path = td.path().join("NestedFmaPipe6.arch");
     let sv_path = td.path().join("NestedFmaPipe6.sv");
@@ -165,20 +165,15 @@ fn staged_ops_falls_back_for_nested_pipelined_arguments() {
         .output()
         .expect("run arch build");
     assert!(
-        out.status.success(),
-        "nested pipelined args should fall back to cascade instead of panicking\nstdout:\n{}\nstderr:\n{}",
+        !out.status.success(),
+        "nested pipelined args should be rejected instead of silently losing latency\nstdout:\n{}\nstderr:\n{}",
         String::from_utf8_lossy(&out.stdout),
         String::from_utf8_lossy(&out.stderr)
     );
     assert!(
-        String::from_utf8_lossy(&out.stderr).contains("nested pipelined call"),
-        "fallback warning should identify the unsupported staged shape\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stderr).contains("nested pipelined calls are not supported"),
+        "error should identify the unsupported staged shape\nstderr:\n{}",
         String::from_utf8_lossy(&out.stderr)
-    );
-    let sv = std::fs::read_to_string(&sv_path).expect("read generated SV");
-    assert!(
-        !sv.contains("pipelined"),
-        "raw pipelined AST node reached SV codegen"
     );
 }
 

--- a/tests/pipelined_operators_test.rs
+++ b/tests/pipelined_operators_test.rs
@@ -294,6 +294,36 @@ end module M
     );
 }
 
+/// Nested pipelined calls must be rejected until lowering can preserve the
+/// inner call's latency instead of silently treating it as combinational.
+#[test]
+fn nested_pipelined_call_is_rejected() {
+    let src = r#"
+module M
+  port clk: in Clock<Sys>;
+  port rst: in Reset<Sync, High>;
+  port a: in FP32;
+  port b: in FP32;
+  port c: in FP32;
+  port out: out pipe_reg<FP32, 6>;
+  seq on clk rising
+    out@6 <= fma<pipelined, 6>(
+      fma<pipelined, 6>(a, b, c),
+      fma<pipelined, 6>(a, b, c),
+      fma<pipelined, 6>(a, b, c)
+    );
+  end seq
+end module M
+"#;
+    let out = run_check(src);
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        normalize(&stderr).contains("nested pipelined calls are not supported"),
+        "got:\n{stderr}"
+    );
+}
+
 /// Direct comb-context consumption of a latency-N result is rejected.
 #[test]
 fn comb_context_consumption_is_rejected() {


### PR DESCRIPTION
## What changed

Reject nested `<pipelined, N>` calls during type checking and update the staged-operator regression tests to expect a clear diagnostic.

## Why

PR #727 avoided a staged-emission panic, but nested latency-bearing calls were then lowered as combinational calls inside the outer cascade. That silently discarded the inner pipeline latency.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo test --test pipelined_operators_test --test pipelined_fma_lockstep_test` — 20 passed
- `cargo test` — 68 unit tests passed; two unrelated Lean replay tests require the generated `ArchConstructProof` module in the worktree