### PR TITLE
test(pipelined): pin recursive-walker reach for operator-nested nested calls

### DIFF
--- a/tests/pipelined_operators_test.rs
+++ b/tests/pipelined_operators_test.rs
@@ -324,6 +324,36 @@ end module M
     );
 }
 
+/// A pipelined call nested *below an operator* inside a pipelined argument
+/// must also be rejected — not just direct arg nesting. This exercises the
+/// recursive descent in `expr_contains_pipelined_call` (the `Ternary` branch
+/// here): were any interior branch to stop recursing, only the direct-nesting
+/// test above would still fail, so this pins the walker's recursive reach.
+#[test]
+fn nested_pipelined_call_below_operator_is_rejected() {
+    let src = r#"
+module M
+  port clk: in Clock<Sys>;
+  port rst: in Reset<Sync, High>;
+  port sel: in Bool;
+  port a: in FP32;
+  port b: in FP32;
+  port c: in FP32;
+  port out: out pipe_reg<FP32, 6>;
+  seq on clk rising
+    out@6 <= fma<pipelined, 6>(sel ? fma<pipelined, 6>(a, b, c) : a, b, c);
+  end seq
+end module M
+"#;
+    let out = run_check(src);
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        normalize(&stderr).contains("nested pipelined calls are not supported"),
+        "got:\n{stderr}"
+    );
+}
+
 /// Direct comb-context consumption of a latency-N result is rejected.
 #[test]
 fn comb_context_consumption_is_rejected() {


### PR DESCRIPTION
## What

Adds one regression test, `nested_pipelined_call_below_operator_is_rejected`, to `tests/pipelined_operators_test.rs`.

## Why

The nested-pipelined-call rejection shipped in #732 relies on a recursive descent (`expr_contains_pipelined_call` in `src/typecheck.rs`) that walks *through* operator/ternary/index/etc. nodes to find a pipelined call anywhere inside a pipelined argument. The two tests that shipped with #732 only cover a call nested **directly** as an argument — that case is caught even if every interior recursion branch were stubbed to `=> false`. So the walker's whole reason for existing (finding nesting below operators) is currently unverified.

This test nests `fma<pipelined, 6>(...)` below a ternary inside the outer call's argument. Verified on a fresh build of current `origin/main` (e772632):
- **This shape** → rejected with `nested pipelined calls are not supported` (exercises the `Ternary` recursion branch).
- Confirmed adjacent: a call nested below a binary `+` is also rejected, though via the earlier mixed-latency-alignment check (cycle-6 ⊕ cycle-0), so the ternary form is the cleaner probe of *this* diagnostic.

Test-only; no source change. A future refactor of the walker that stops descending through operator nodes now fails a test instead of silently re-admitting latency-losing nesting.

## Validation

- `cargo fmt --check` — clean
- `cargo test --release --test pipelined_operators_test` — 14 passed