### PR TITLE
fix(cocotb): restore TestSuccess compatibility

### DIFF
--- a/python/arch_cocotb/result.py
+++ b/python/arch_cocotb/result.py
@@ -1,0 +1,5 @@
+"""Legacy cocotb result exceptions supported by the native shim."""
+
+
+class TestSuccess(Exception):
+    """Raise to end a test early with a passing result."""

--- a/python/arch_cocotb/runner.py
+++ b/python/arch_cocotb/runner.py
@@ -7,6 +7,7 @@ import traceback
 
 from arch_cocotb.decorators import _test_registry
 from arch_cocotb.dut import ArchDUT
+from arch_cocotb.result import TestSuccess
 from arch_cocotb.simulator import ArchSimulator
 from arch_cocotb.triggers import with_timeout
 
@@ -82,6 +83,9 @@ def run_registered_tests(model_class, time_unit_ns=1):
 
 
 def _classify_result(options, error):
+    if isinstance(error, TestSuccess):
+        return "PASS"
+
     expect_error = None if options is None else options.expect_error
     expect_fail = False if options is None else options.expect_fail
 

--- a/python/cocotb_shim/cocotb/result.py
+++ b/python/cocotb_shim/cocotb/result.py
@@ -1,0 +1,6 @@
+"""Compatibility result exceptions for legacy cocotb tests."""
+
+from arch_cocotb.result import TestSuccess
+from arch_cocotb.triggers import SimTimeoutError
+
+__all__ = ["SimTimeoutError", "TestSuccess"]

--- a/python/tests/test_runner.py
+++ b/python/tests/test_runner.py
@@ -1,0 +1,9 @@
+import unittest
+
+from arch_cocotb.result import TestSuccess
+from arch_cocotb.runner import _classify_result
+
+
+class RunnerResultTests(unittest.TestCase):
+    def test_test_success_is_a_passing_result(self):
+        self.assertEqual(_classify_result(None, TestSuccess("done")), "PASS")


### PR DESCRIPTION
Stacked on ARCH #743 (base branch is a temporary ref at #743's head because the original source branch is no longer published).

Restores the legacy `cocotb.result.TestSuccess` compatibility shim and treats it as a passing early-exit result in the native runner. Adds a regression test and keeps the embedded runtime self-contained.

Validation:
- Python unittest discovery: 11 passed
- direct `cocotb.result.TestSuccess` import/classification probe
- `cargo test --test embedded_cocotb_runtime_test -- --nocapture`: 1 passed
- `git diff --check`
- independent review: no findings; reviewer `019fb779-f256-7852-8194-bc55103e7c16`