### PR TITLE
ci: require COMPILER_STATUS.md update on version bump (release-doc check)

### DIFF
--- a/.github/workflows/release-doc.yml
+++ b/.github/workflows/release-doc.yml
@@ -1,0 +1,57 @@
+name: release-doc
+
+# A version bump in Cargo.toml must update doc/COMPILER_STATUS.md in the same
+# PR (matching version banner + a per-release highlights block). Release PRs
+# repeatedly landed as Cargo-only, stranding the status doc a release behind —
+# the exact drift the daily review keeps catching. Logic lives in
+# scripts/check_release_doc.sh (locally runnable:
+# `scripts/check_release_doc.sh origin/main`); this workflow just wires it up
+# and handles the `release-doc-exempt` label escape hatch, which isn't visible
+# to a local `git diff` and has to be read from the PR event payload here.
+#
+# NB: runs on EVERY PR to main, deliberately with no `paths:` filter — same
+# reasoning as doc-drift.yml. This job is intended to become a REQUIRED status
+# check under main's branch protection, and a required check that is
+# path-filtered never reports on PRs outside those paths, leaving them stuck
+# "Expected — waiting for status" and unmergeable. When the version is
+# unchanged the script exits 0 immediately, so running unconditionally is cheap
+# and correct.
+on:
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: release-doc-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  release-doc:
+    name: release doc
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check for release-doc-exempt label
+        id: label-check
+        env:
+          PR_LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
+        run: |
+          echo "PR labels: ${PR_LABELS}"
+          if echo "${PR_LABELS}" | grep -q '"release-doc-exempt"'; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Skip (release-doc-exempt label present)
+        if: steps.label-check.outputs.skip == 'true'
+        run: |
+          echo "PR is labeled 'release-doc-exempt' — skipping release doc check."
+          echo "This label is for a rare bare re-publish version bump that ships"
+          echo "no user-facing change and therefore needs no highlights block."
+
+      - name: Run release doc check
+        if: steps.label-check.outputs.skip != 'true'
+        run: scripts/check_release_doc.sh "origin/${{ github.event.pull_request.base.ref }}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,6 +107,19 @@ never said so. Rules:
   with pointers to the relevant spec docs. Pure internal refactors of a
   surface file with no user-facing syntax/semantics change (e.g. the planned
   parser/elaborate splits) can use the `no-doc-needed` PR label to skip it.
+- **A version bump must update `doc/COMPILER_STATUS.md` in the same PR.** The
+  release PR is where the package `version` in `Cargo.toml` bumps, and the
+  convention is that it also updates the status doc's `> Compiler version:`
+  banner and adds a `> **<version> release highlights:**` block. Release PRs
+  kept landing as Cargo-only (0.71.0 shipped with the banner stuck at 0.70.8),
+  stranding the status doc a release behind. CI now enforces the coupling
+  (`scripts/check_release_doc.sh`, workflow `release-doc`, check name `release
+  doc`): if a PR changes the Cargo version, `doc/COMPILER_STATUS.md` must carry
+  a matching banner and highlights block, or the check fails with the exact
+  lines to add. Remember to re-sync the skill snapshot
+  (`scripts/sync_skill_snapshots.sh refresh`) after editing the status doc. A
+  rare bare re-publish bump with no user-facing change can use the
+  `release-doc-exempt` PR label to skip it.
 - **Sweep for stranded PRs**: `scripts/green_pr_sweep.sh` lists open PRs that
   are green, mergeable, and ≥1 day old across arch-com + harc-com — finished
   work nobody landed. The mirror image of `claim_check.sh` (duplicate work at

--- a/scripts/check_release_doc.sh
+++ b/scripts/check_release_doc.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# check_release_doc.sh — a version bump must update COMPILER_STATUS.md in lock-step.
+#
+# Usage:
+#   scripts/check_release_doc.sh <base-ref>   # e.g. origin/main
+#
+# Rationale: the release PR is where the compiler version bumps, and the
+# convention is that it ALSO updates doc/COMPILER_STATUS.md — the version
+# banner and a per-release highlights block. In practice release PRs keep
+# landing as Cargo-only (0.71.0 shipped with the banner stuck at 0.70.8 and no
+# highlights block; a follow-up doc PR had to reconcile it — the exact drift
+# the daily review keeps catching). This check makes the coupling mechanical
+# instead of relying on reviewer vigilance.
+#
+# The rule, narrow and precise (precision over recall — a noisy required check
+# gets bypassed and then ignored):
+#
+#   IF this PR changes the package `version` in Cargo.toml
+#   THEN doc/COMPILER_STATUS.md on this branch MUST have:
+#        (a) a banner line `> Compiler version: <new-version>`, and
+#        (b) a highlights heading `> **<new-version> release highlights:**`
+#   ELSE fail with an actionable message.
+#
+# It does NOT judge the prose of the highlights — only that the version banner
+# matches Cargo.toml and a block for that version exists. The skill-snapshot
+# copy of COMPILER_STATUS.md is kept in sync by a separate check
+# (scripts/sync_skill_snapshots.sh), so we deliberately don't duplicate that
+# here.
+#
+# Escape hatch: PRs whose GitHub Actions job sees the `release-doc-exempt`
+# label skip this check entirely (see .github/workflows/release-doc.yml — the
+# label check happens in the workflow, not here, since a label isn't visible to
+# a local `git diff`). Apply it for a rare bare re-publish bump that
+# intentionally ships no user-facing change.
+#
+# Locally runnable so contributors can pre-check before pushing:
+#   scripts/check_release_doc.sh origin/main
+
+set -euo pipefail
+
+STATUS_DOC="doc/COMPILER_STATUS.md"
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/check_release_doc.sh <base-ref>
+
+If this branch bumps the package `version` in Cargo.toml relative to <base-ref>,
+requires doc/COMPILER_STATUS.md to carry a matching version banner and a
+per-release highlights block. Otherwise passes.
+
+Example:
+  scripts/check_release_doc.sh origin/main
+USAGE
+}
+
+if [[ $# -ne 1 || "$1" == "-h" || "$1" == "--help" ]]; then
+  usage >&2
+  exit 2
+fi
+
+base_ref="$1"
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+# Extract the package version (first line-anchored `version = "..."`, which is
+# the [package] version — dependency versions are never line-anchored at column
+# 0 in this Cargo.toml). Reads from a git blob so it works pre-commit too.
+pkg_version() { # $1 = git ref, or "" for the working tree
+  local ref="$1" content
+  if [[ -n "$ref" ]]; then
+    content="$(git show "${ref}:Cargo.toml" 2>/dev/null || true)"
+  else
+    content="$(cat Cargo.toml 2>/dev/null || true)"
+  fi
+  printf '%s\n' "$content" \
+    | grep -m1 -E '^version[[:space:]]*=[[:space:]]*"' \
+    | sed -E 's/^version[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/'
+}
+
+base_version="$(pkg_version "$base_ref")"
+head_version="$(pkg_version "")" # working tree = HEAD in CI checkout
+
+if [[ -z "$head_version" ]]; then
+  echo "check_release_doc: could not read package version from Cargo.toml; skipping." >&2
+  exit 0
+fi
+
+if [[ "$base_version" == "$head_version" ]]; then
+  echo "check_release_doc: package version unchanged (${head_version:-?}); not a release PR; pass."
+  exit 0
+fi
+
+echo "check_release_doc: version bump detected: ${base_version:-<none>} -> ${head_version}"
+
+if [[ ! -f "$STATUS_DOC" ]]; then
+  cat >&2 <<EOF
+check_release_doc: FAIL
+
+This PR bumps the package version to ${head_version}, but ${STATUS_DOC} does
+not exist. The release PR must update the status doc's banner and highlights.
+EOF
+  exit 1
+fi
+
+banner_line="> Compiler version: ${head_version}"
+highlights_line="> **${head_version} release highlights:**"
+
+missing=""
+grep -qxF "$banner_line" "$STATUS_DOC" || missing="${missing}  - banner line:      ${banner_line}"$'\n'
+grep -qxF "$highlights_line" "$STATUS_DOC" || missing="${missing}  - highlights block: ${highlights_line}"$'\n'
+
+if [[ -z "$missing" ]]; then
+  echo "check_release_doc: ${STATUS_DOC} carries the ${head_version} banner and highlights block; pass."
+  exit 0
+fi
+
+cat >&2 <<EOF
+check_release_doc: FAIL
+
+This PR bumps the package version to ${head_version}, but ${STATUS_DOC} is
+missing the matching release update. Expected (verbatim) line(s):
+
+${missing}
+The release PR must update ${STATUS_DOC} in lock-step with the Cargo bump:
+
+  1. Set the banner to:  ${banner_line}
+     (and refresh the "> Last updated:" date).
+  2. Add a highlights block headed:  ${highlights_line}
+     summarizing the user-facing changes merged since the previous release.
+  3. Re-sync the skill snapshot:  scripts/sync_skill_snapshots.sh refresh
+
+If this is a rare bare re-publish bump that ships no user-facing change, add
+the 'release-doc-exempt' label to this PR to skip this check.
+
+See CLAUDE.md's "Release" notes and the daily-review "document consistency"
+duty for context.
+EOF
+exit 1


### PR DESCRIPTION
## Problem

Release PRs keep landing as **Cargo-only**. The 0.71.0 release ([#730](https://github.com/arch-hdl-lang/arch-com/pull/730)) bumped `Cargo.toml`/`Cargo.lock` but did not update `doc/COMPILER_STATUS.md` — the banner stayed at `0.70.8` with no `0.71.0 release highlights` block, so a follow-up doc PR ([#731](https://github.com/arch-hdl-lang/arch-com/pull/731)) had to reconcile it. This banner/highlights drift is a recurring daily-review finding; relying on reviewer vigilance hasn't fixed it.

## Fix

Make the coupling mechanical, modeled on the existing `doc-drift` gate (`precision over recall` — a narrow, verbatim rule that won't false-fire and get bypassed):

- **`scripts/check_release_doc.sh`** — if a PR changes the package `version` in `Cargo.toml` relative to the base ref, `doc/COMPILER_STATUS.md` on the branch **must** carry both:
  - the banner line `> Compiler version: <new-version>`, and
  - a highlights heading `> **<new-version> release highlights:**`

  otherwise it fails with the exact lines to add. Version unchanged ⇒ immediate pass, so it's cheap to run on every PR. Locally runnable: `scripts/check_release_doc.sh origin/main`.
- **`.github/workflows/release-doc.yml`** — wires it up on every PR to `main` (no `paths:` filter, matching `doc-drift.yml`, so it can safely become a required status check without wedging unrelated PRs at "waiting for status"). Escape hatch: the `release-doc-exempt` label for a rare bare re-publish bump with no user-facing change.
- **`CLAUDE.md`** — documents the new check next to `doc-drift`.

## Verification

Ran the check in three scenarios:

| Scenario | Result |
|---|---|
| No version bump (this PR) | ✅ pass — "package version unchanged" |
| Simulated #730: bump Cargo to 0.72.0, leave banner at 0.71.0 | ❌ **fail** with actionable message listing the missing banner + highlights lines |
| Also bump banner + highlights to 0.72.0 | ✅ pass |

This PR itself does not bump the version, so the new `release doc` check passes on it.

## Follow-up (not in this PR)

Once merged and observed green, `release doc` is a good candidate to add to `main`'s required-status-checks set (currently 7), alongside `doc drift`. Left to a maintainer since branch-protection changes are outside CI.