### PR TITLE
fix(comb-loop): give each top-level module its own graph namespace

### DIFF
--- a/src/comb_graph.rs
+++ b/src/comb_graph.rs
@@ -1198,7 +1198,10 @@ pub struct WholeDesignAnalysis {
 /// 1. Identify top-level modules (modules not instantiated anywhere).
 /// 2. For each top-level, recursively flatten the instance hierarchy into
 ///    a directed node-and-edge set, where each node is `(inst_path, signal)`.
-/// 3. Run Tarjan's SCC.
+///    Each top gets its own graph — tops are mutually unconnected, so a
+///    namespace shared across them can only fabricate cycles out of
+///    same-named signals in unrelated modules.
+/// 3. Run Tarjan's SCC per top.
 /// 4. Tag each non-trivial SCC with the set of owning-parent paths;
 ///    classify as suppressed if any owning module has the pragma.
 pub fn analyze_whole_design(source: &SourceFile, symbols: &SymbolTable) -> WholeDesignAnalysis {
@@ -1220,60 +1223,78 @@ pub fn analyze_whole_design(source: &SourceFile, symbols: &SymbolTable) -> Whole
         }
     }
 
-    let top_levels: Vec<&ModuleDecl> = module_by_name
+    // Source declaration order, not `module_by_name` iteration order: the
+    // latter is a `HashMap`, so which top-level module got analyzed (and
+    // blamed) first was nondeterministic across runs.
+    let top_levels: Vec<&ModuleDecl> = source
+        .items
         .iter()
-        .filter(|(name, _)| inst_count.get(**name).copied().unwrap_or(0) == 0)
-        .map(|(_, m)| *m)
+        .filter_map(|it| match it {
+            Item::Module(m) if inst_count.get(m.name.name.as_str()).copied().unwrap_or(0) == 0 => {
+                Some(m)
+            }
+            _ => None,
+        })
         .collect();
 
-    // ── Step 2: build the flat graph ──────────────────────────────────────
-    let mut builder = GraphBuilder::default();
-    for top in &top_levels {
-        builder.expand_module(top, vec![], symbols, source);
-    }
-
-    // ── Step 3: Tarjan SCC ────────────────────────────────────────────────
-    let sccs_raw = tarjan_scc(&builder.adj, builder.next_id);
-
-    // ── Step 4: classify SCCs ─────────────────────────────────────────────
     let mut out_sccs: Vec<CombScc> = Vec::new();
     let mut suppressed = 0usize;
     let mut total = 0usize;
-    for scc in sccs_raw {
-        // Filter: size > 1 OR (size == 1 with self-loop)
-        let is_cycle = scc.len() > 1 || (scc.len() == 1 && builder.adj[scc[0]].contains(&scc[0]));
-        if !is_cycle {
-            continue;
-        }
-        total += 1;
 
-        let mut owning_paths: HashSet<InstPath> = HashSet::new();
-        let mut owning_modules: HashSet<String> = HashSet::new();
-        let mut nodes: Vec<NodeKey> = Vec::with_capacity(scc.len());
-        for nid in &scc {
-            let key = builder.node_by_id[*nid].clone();
-            owning_paths.insert(key.path.clone());
-            if let Some(mname) = builder.owning_module(&key.path) {
-                owning_modules.insert(mname);
+    // ── Steps 2-4, once per top-level module ──────────────────────────────
+    //
+    // Each top-level module gets its OWN graph. Every top used to be
+    // expanded into one shared builder at the same root path (`vec![]`), so
+    // all tops shared a single `(inst_path, signal)` namespace: `ModA`'s `p`
+    // and `ModB`'s `p` interned to the same node. Distinct top-level modules
+    // are by definition unconnected — no combinational path can run between
+    // them — so the only thing a shared namespace could produce was a
+    // fabricated cycle stitched out of same-named signals in unrelated
+    // modules (`arch check A.arch B.arch` warning where `A` alone and `B`
+    // alone are both clean), plus misattribution via `path_owner[vec![]]`,
+    // which the last-expanded top overwrote.
+    for top in &top_levels {
+        let mut builder = GraphBuilder::default();
+        builder.expand_module(top, vec![], symbols, source);
+        let sccs_raw = tarjan_scc(&builder.adj, builder.next_id);
+
+        for scc in sccs_raw {
+            // Filter: size > 1 OR (size == 1 with self-loop)
+            let is_cycle =
+                scc.len() > 1 || (scc.len() == 1 && builder.adj[scc[0]].contains(&scc[0]));
+            if !is_cycle {
+                continue;
             }
-            nodes.push(key);
+            total += 1;
+
+            let mut owning_paths: HashSet<InstPath> = HashSet::new();
+            let mut owning_modules: HashSet<String> = HashSet::new();
+            let mut nodes: Vec<NodeKey> = Vec::with_capacity(scc.len());
+            for nid in &scc {
+                let key = builder.node_by_id[*nid].clone();
+                owning_paths.insert(key.path.clone());
+                if let Some(mname) = builder.owning_module(&key.path) {
+                    owning_modules.insert(mname);
+                }
+                nodes.push(key);
+            }
+            // Suppression: any owning module has `pragma comb_loops_allowed;`.
+            let blessed = owning_modules.iter().any(|mn| {
+                module_by_name
+                    .get(mn.as_str())
+                    .map(|m| m.comb_loops_allowed)
+                    .unwrap_or(false)
+            });
+            if blessed {
+                suppressed += 1;
+                continue;
+            }
+            out_sccs.push(CombScc {
+                nodes,
+                owning_paths,
+                owning_modules,
+            });
         }
-        // Suppression: any owning module has `pragma comb_loops_allowed;`.
-        let blessed = owning_modules.iter().any(|mn| {
-            module_by_name
-                .get(mn.as_str())
-                .map(|m| m.comb_loops_allowed)
-                .unwrap_or(false)
-        });
-        if blessed {
-            suppressed += 1;
-            continue;
-        }
-        out_sccs.push(CombScc {
-            nodes,
-            owning_paths,
-            owning_modules,
-        });
     }
 
     WholeDesignAnalysis {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -24352,6 +24352,106 @@ fn test_comb_loop_through_register_not_flagged() {
 }
 
 #[test]
+fn test_sibling_top_modules_sharing_signal_names_is_not_a_cycle() {
+    // Two INDEPENDENT top-level modules, each individually acyclic, that
+    // happen to use the same signal names. ModA: q -> p. ModB: p -> q.
+    // Neither has a loop; they are not connected to each other at all.
+    //
+    // Every top-level module used to be expanded into one shared graph at
+    // the same root path (`vec![]`), so `ModA.p` and `ModB.p` interned to
+    // a single node and the two acyclic chains stitched into a fabricated
+    // `p -> q -> p` cycle. Reproduced from the CLI as
+    // `arch check ModA.arch ModB.arch` warning while each file alone was
+    // clean — common signal names (`valid`, `ready`, `cnt`) make this easy
+    // to hit on any multi-file design.
+    let source = r#"
+        module ModA
+          port i: in UInt<8>;
+          port o: out UInt<8>;
+          wire p: UInt<8>;
+          wire q: UInt<8>;
+          comb
+            q = i;
+            p = q +% 1;
+            o = p;
+          end comb
+        end module ModA
+
+        module ModB
+          port i: in UInt<8>;
+          port o: out UInt<8>;
+          wire p: UInt<8>;
+          wire q: UInt<8>;
+          comb
+            p = i;
+            q = p +% 1;
+            o = q;
+          end comb
+        end module ModB
+    "#;
+    let ws = comb_loop_warnings(source);
+    let cycle_msgs: Vec<_> = ws
+        .iter()
+        .filter(|m| m.contains("combinational feedback cycle ("))
+        .collect();
+    assert!(
+        cycle_msgs.is_empty(),
+        "two unconnected acyclic top modules must not fabricate a cycle, but got: {:?}",
+        ws
+    );
+}
+
+#[test]
+fn test_comb_loop_attributed_to_the_owning_top_module() {
+    // The cycle lives in `Loop2`, which is declared SECOND. `path_owner`
+    // was keyed on the shared root path `vec![]`, so whichever top was
+    // expanded last overwrote the entry and the warning named the wrong
+    // module — here it blamed the acyclic `Filler`.
+    let source = r#"
+        module Filler
+          port x: in UInt<8>;
+          port y: out UInt<8>;
+          comb
+            y = x;
+          end comb
+        end module Filler
+
+        module Loop2
+          port i: in UInt<8>;
+          port o: out UInt<8>;
+          wire a: UInt<8>;
+          wire b: UInt<8>;
+          comb
+            a = b +% i;
+            b = a +% 1;
+            o = a;
+          end comb
+        end module Loop2
+    "#;
+    let ws = comb_loop_warnings(source);
+    let cycle_msgs: Vec<_> = ws
+        .iter()
+        .filter(|m| m.contains("combinational feedback cycle ("))
+        .collect();
+    assert_eq!(
+        cycle_msgs.len(),
+        1,
+        "expected exactly one cycle warning, got: {:?}",
+        ws
+    );
+    assert!(
+        cycle_msgs[0].contains("[Loop2]"),
+        "cycle is in Loop2 and must be attributed to it, got: {:?}",
+        cycle_msgs[0]
+    );
+    assert!(
+        !cycle_msgs[0].contains("Filler"),
+        "acyclic Filler must not be blamed, got: {:?}",
+        cycle_msgs[0]
+    );
+}
+
+#[test]
 fn test_interface_module_treated_as_opaque() {
     // A module loaded purely as an `.archi` interface stub (no body) is
     // treated as opaque: every output assumed to depend on every input.


### PR DESCRIPTION
## Summary

`analyze_whole_design` expanded **every** top-level module into one shared `GraphBuilder` at the same root instance path (`vec![]`), so all top-level modules shared a single `(inst_path, signal)` node namespace — `ModA`'s `p` and `ModB`'s `p` interned to the same node.

Distinct top-level modules are by definition unconnected, so no combinational path can run between them. The shared namespace could therefore only do harm, in two ways.

### 1. False positives (the reason this matters)

Two individually-acyclic top-level modules that happen to use the same signal names get their chains stitched into a cycle that exists in neither:

```arch
module ModA          module ModB
  ...                  ...
  q = i;               p = i;
  p = q +% 1;          q = p +% 1;
  o = p;               o = q;
```

`ModA` is `q → p`. `ModB` is `p → q`. Each is a straight line; neither has a loop.

```
$ arch check ModA.arch          → OK: no errors
$ arch check ModB.arch          → OK: no errors
$ arch check ModA.arch ModB.arch
warning: whole-design combinational feedback cycle (2 nodes) involving modules [ModB]; cycle: p -> q -> p
```

Since the repo convention is one construct per file, multi-file invocation is the normal way to check a design — and common HDL signal names (`valid`, `ready`, `cnt`, `state`) make the collision easy to hit.

### 2. Misattribution

`path_owner` is keyed on the instance path, so the entry for `vec![]` was overwritten by whichever top was expanded last. A cycle in one module got reported as `involving modules [SomeOtherModule]`, naming an **acyclic** module and pointing the warning span at that module's declaration. Note in the repro above that the fabricated cycle is blamed on `ModB` — arbitrarily.

## Fix

Each top-level module now gets its own `GraphBuilder` and its own Tarjan run; the per-SCC classification is unchanged and results aggregate across tops.

Node display and warning text are untouched, so single-top designs — the common case, and what every existing test covers — produce byte-identical output.

Also switches top-level discovery from iterating `module_by_name` (a `HashMap`, hence nondeterministic order) to source declaration order. That nondeterminism meant *which* module got blamed could vary between runs of the same input.

## Trade-off

`per_output_cache` memoizes each child module's comb-dep map and now lives per-top rather than being shared across all tops, so a module instantiated under two different top-level modules has its body walked once per top instead of once total. This is a body walk over already-parsed AST during `arch check`, bounded by (number of tops × distinct child modules); it did not move the wall clock on the full suite. Correct attribution is worth more than the shared cache — and a cache shared across tops is exactly what conflated their namespaces in the first place.

## Testing

- `test_sibling_top_modules_sharing_signal_names_is_not_a_cycle` — the false-positive repro above.
- `test_comb_loop_attributed_to_the_owning_top_module` — cycle in the second-declared module must name that module, not the acyclic first one.

Both were **verified to fail without the src change** (reverted `comb_graph.rs`, kept the tests, confirmed both fail) so they genuinely pin the behavior.

Full suite green: 750/750 `integration_test` (including all 13 pre-existing comb-loop tests), 68 lib, 23 fp, 14 param-where, 14+3+7 pipelined-ops. `cargo fmt --check` clean.

`formal_test` has 2 failing Lean tests (`unknown module prefix 'ArchConstructProof'`) — pre-existing and environmental, confirmed identical on unmodified `origin/main` in this worktree; the Lean `.lake/build` dir doesn't exist here.

## Scope

Internal analysis fix — no user-facing syntax or semantics change, no grammar surface touched (`comb_graph.rs` only), so no doc update applies. The comb-loop check remains a **warning**; this PR does not change its severity.

Found while investigating whether the comb-loop detector needed attention as a follow-up to the diagnostics work in #750/#748.
