### PR TITLE
fix(tlm): mixed-class fork groups rejected; document out_of_order tag bound (part of #500)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -370,6 +370,8 @@ Initiators call as a direct RHS inside a thread: `d <= m.read(addr);`. Targets i
 
 Concurrency is structural: multiple direct worker threads, `generate_for` workers, or one direct-call `fork ... and ... join` thread lower to a request arbiter and response router. Blocking routes by issue-order FIFO; `out_of_order tags N` routes by hidden tag wires. Do not generate `Future<T>`, `await`, `Token<T>`, `pipelined`, or `burst` syntax.
 
+A `fork ... and ... join` group must be class-uniform (all `blocking` or all `out_of_order`) — mixing classes in one group is a compile-time error, not a warning. `out_of_order tags N` sets the `req_tag`/`rsp_tag` carrier's bit width directly (not a tag count via `$clog2`); keep `N <= 8` even though the compiler doesn't enforce it (see spec §22.2.3a/§22.2.3b).
+
 ---
 
 ## Compiler Architecture (to build)

--- a/doc/ARCH_HDL_Specification.md
+++ b/doc/ARCH_HDL_Specification.md
@@ -7538,6 +7538,28 @@ end thread driver
 
 For `out_of_order tags N`, the bus flattens two extra wires per method: `<method>_req_tag` and `<method>_rsp_tag`. The initiator cohort assigns one tag per worker and routes response data by `rsp_tag`. A target TLM thread latches `req_tag` with the method arguments and echoes it on `rsp_tag`.
 
+**22.2.3a Mixed-Class Fork Groups Are Rejected**
+
+A direct-call `fork ... and ... join` issue group (§22.2.2) must use one concurrency class across every branch: all `blocking`, or all `out_of_order` on methods with the same `tags N`-bearing declaration shape. Placing one `blocking` call and one `out_of_order` call in the same fork group is a compile-time error:
+
+```
+fork issue group mixes blocking and out_of_order calls (`m.read` is blocking,
+`m.read_ooo` is out_of_order tags 2); split into separate fork groups or make
+the classes uniform
+```
+
+Split the branches into two separate `fork ... and ... join` threads instead — one per class — or change the method declarations so every branch in the group calls methods of the same class. RHS-fork groups (`dst <= fork port.method(args); ... join all;`, §22.2.2) already require every forked issue in the group to target one method, so they cannot mix classes either; that restriction predates this one and is unchanged.
+
+This restriction exists because the generated-thread cohort lowering groups direct-call fork branches by `(port, method)` and only recognizes a cohort once two or more branches share one method. A fork group that mixes classes always calls two *different* methods (concurrency mode is fixed per `tlm_method` declaration), so each class's branch count is checked independently — an unbalanced mix (e.g. two `blocking` branches plus one `out_of_order` branch) could satisfy the cohort check for the repeated class while the compiler had no path left to lower the other branch at all. The check above runs before cohort grouping and rejects every mixed-class shape up front, regardless of how many branches each class has.
+
+**22.2.3b `out_of_order tags N` --- Recommended Bound**
+
+`N` in `tlm_method name(args) -> Ret: out_of_order tags N;` is the literal bit width of the two compiler-generated carrier wires, `<method>_req_tag` and `<method>_rsp_tag` --- it is not a count of tags that the compiler widens with `$clog2`. A cohort or fork group with `W` outstanding workers needs `N` such that `2^N >= W`; the compiler checks this at lowering time and rejects an undersized `N` with `` `{port}.{method}` has {W} workers but only {2^N} out-of-order tags; increase `tags` width ``. Because `N` sets the carrier width directly, it is also the width of every downstream tag-drive mux and per-response tag comparator the lowering generates.
+
+**Recommended cap: `N <= 8`** (256 addressable tags). Every current worker cohort, `fork ... and ... join` group, and RHS-fork group in the test suite and examples uses a single-digit number of outstanding requests, so 8 bits of tag space is generous headroom for TLM's intended fast-prototyping role (see the positioning note in §22.1) without carrying unused carrier width through request/response plumbing.
+
+The compiler does not enforce this cap today. `tags 64` and `tags 128` both compile cleanly, each producing an exactly `N`-bit-wide `req_tag`/`rsp_tag` carrier (`logic [63:0]` / `logic [127:0]`) with no truncation, silent promotion, or width mismatch; the internal tag-capacity check (`tag_slots = 2^N`) explicitly guards `N >= 64` against a wrapping left-shift, so there is no overflow defect at large `N` either. Treat `N <= 8` as design guidance to keep generated hardware lean, not as a compiler-checked limit.
+
 **22.2.4 Generated Code Shape**
 
 Grouped/looped initiator call sites are lowered to one generated driver per
@@ -7647,6 +7669,7 @@ Use the implemented forms above for all current RTL-backed TLM work:
 - Use counted `for` loops for repeated serialized direct blocking call sites inside one initiator thread; runtime bounds are supported for the serialized case.
 - Use `lock RESOURCE ... end lock RESOURCE` plus `resource RESOURCE: mutex<round_robin>;` when independent workers share a TLM method and require round-robin request arbitration.
 - Express multiple outstanding requests with worker threads, `generate_for` workers, direct-call `fork ... and ... join`, or RHS-fork groups.
+- Keep every branch of one `fork ... and ... join` group the same concurrency class (§22.2.3a); keep `out_of_order tags N` at `N <= 8` (§22.2.3b).
 
 **25. AI-Assisted Hardware Design Workflow**
 

--- a/doc/Arch_AI_Reference_Card.md
+++ b/doc/Arch_AI_Reference_Card.md
@@ -1292,6 +1292,8 @@ end module LoadPair
 
 Supported cohort shapes: multiple direct named worker threads, `generate_for` worker threads, and one direct-call `fork ... and ... join` thread. Blocking cohorts route responses by issue-order FIFO. `out_of_order tags N` cohorts drive `<method>_req_tag` and route by `<method>_rsp_tag`; target threads latch and echo the tag.
 
+A `fork ... and ... join` group must be class-uniform: every branch `blocking`, or every branch `out_of_order`. Mixing classes in one group is a compile error (`fork issue group mixes blocking and out_of_order calls ...`) — split into separate fork groups instead. RHS-fork groups already require every issue to target one method, so they cannot mix classes either.
+
 Timed multiple-outstanding issue in one thread:
 
 ```
@@ -1344,7 +1346,9 @@ Refining TLM into explicit threads:
 
 Use explicit threads when the protocol needs separate channels, beat-by-beat burst interleaving, registered ready paths for timing closure, protocol-specific retry/error/cancel rules, or area/power tuning beyond the generic TLM driver.
 
-Current restrictions: thread-body call sites only; direct RHS call only (`dst <= m.method(args);` or `dst <= fork m.method(args);`); runtime-loop and conditional-branch TLM calls are serialized direct blocking assignments; one call per worker/forked issue; same clock/reset per cohort; literal tag count only; RHS-fork offsets require literal `wait N cycle;`; RHS-fork tails after `join all;` are compute-only; no nested/composed TLM calls; no dynamic-length TLM return types; no `pipelined`; no first-class `burst`; no `Future<T>`/`await`.
+`out_of_order tags N` sizing: `N` is the literal bit width of the generated `<method>_req_tag` / `<method>_rsp_tag` carrier, not a tag count — a cohort/fork group of `W` outstanding workers needs `2^N >= W`. Recommended cap: `N <= 8` (256 tags); the compiler does not enforce this (`tags 64`, `tags 128` both build cleanly with an `N`-bit carrier), but a needlessly large `N` widens every tag wire, drive mux, and response comparator for no prototyping benefit.
+
+Current restrictions: thread-body call sites only; direct RHS call only (`dst <= m.method(args);` or `dst <= fork m.method(args);`); runtime-loop and conditional-branch TLM calls are serialized direct blocking assignments; one call per worker/forked issue; same clock/reset per cohort; literal tag count only; all branches of one `fork ... and ... join` group must be the same concurrency class (no mixing `blocking` and `out_of_order`); RHS-fork offsets require literal `wait N cycle;`; RHS-fork tails after `join all;` are compute-only; no nested/composed TLM calls; no dynamic-length TLM return types; no `pipelined`; no first-class `burst`; no `Future<T>`/`await`.
 
 Full spec: `doc/ARCH_HDL_Specification.md` §18d and §22. Design history / remaining work: `doc/archive/plan_tlm_method.md`.
 

--- a/skills/arch-programming/references/ARCH_HDL_Specification.md
+++ b/skills/arch-programming/references/ARCH_HDL_Specification.md
@@ -7538,6 +7538,28 @@ end thread driver
 
 For `out_of_order tags N`, the bus flattens two extra wires per method: `<method>_req_tag` and `<method>_rsp_tag`. The initiator cohort assigns one tag per worker and routes response data by `rsp_tag`. A target TLM thread latches `req_tag` with the method arguments and echoes it on `rsp_tag`.
 
+**22.2.3a Mixed-Class Fork Groups Are Rejected**
+
+A direct-call `fork ... and ... join` issue group (§22.2.2) must use one concurrency class across every branch: all `blocking`, or all `out_of_order` on methods with the same `tags N`-bearing declaration shape. Placing one `blocking` call and one `out_of_order` call in the same fork group is a compile-time error:
+
+```
+fork issue group mixes blocking and out_of_order calls (`m.read` is blocking,
+`m.read_ooo` is out_of_order tags 2); split into separate fork groups or make
+the classes uniform
+```
+
+Split the branches into two separate `fork ... and ... join` threads instead — one per class — or change the method declarations so every branch in the group calls methods of the same class. RHS-fork groups (`dst <= fork port.method(args); ... join all;`, §22.2.2) already require every forked issue in the group to target one method, so they cannot mix classes either; that restriction predates this one and is unchanged.
+
+This restriction exists because the generated-thread cohort lowering groups direct-call fork branches by `(port, method)` and only recognizes a cohort once two or more branches share one method. A fork group that mixes classes always calls two *different* methods (concurrency mode is fixed per `tlm_method` declaration), so each class's branch count is checked independently — an unbalanced mix (e.g. two `blocking` branches plus one `out_of_order` branch) could satisfy the cohort check for the repeated class while the compiler had no path left to lower the other branch at all. The check above runs before cohort grouping and rejects every mixed-class shape up front, regardless of how many branches each class has.
+
+**22.2.3b `out_of_order tags N` --- Recommended Bound**
+
+`N` in `tlm_method name(args) -> Ret: out_of_order tags N;` is the literal bit width of the two compiler-generated carrier wires, `<method>_req_tag` and `<method>_rsp_tag` --- it is not a count of tags that the compiler widens with `$clog2`. A cohort or fork group with `W` outstanding workers needs `N` such that `2^N >= W`; the compiler checks this at lowering time and rejects an undersized `N` with `` `{port}.{method}` has {W} workers but only {2^N} out-of-order tags; increase `tags` width ``. Because `N` sets the carrier width directly, it is also the width of every downstream tag-drive mux and per-response tag comparator the lowering generates.
+
+**Recommended cap: `N <= 8`** (256 addressable tags). Every current worker cohort, `fork ... and ... join` group, and RHS-fork group in the test suite and examples uses a single-digit number of outstanding requests, so 8 bits of tag space is generous headroom for TLM's intended fast-prototyping role (see the positioning note in §22.1) without carrying unused carrier width through request/response plumbing.
+
+The compiler does not enforce this cap today. `tags 64` and `tags 128` both compile cleanly, each producing an exactly `N`-bit-wide `req_tag`/`rsp_tag` carrier (`logic [63:0]` / `logic [127:0]`) with no truncation, silent promotion, or width mismatch; the internal tag-capacity check (`tag_slots = 2^N`) explicitly guards `N >= 64` against a wrapping left-shift, so there is no overflow defect at large `N` either. Treat `N <= 8` as design guidance to keep generated hardware lean, not as a compiler-checked limit.
+
 **22.2.4 Generated Code Shape**
 
 Grouped/looped initiator call sites are lowered to one generated driver per
@@ -7647,6 +7669,7 @@ Use the implemented forms above for all current RTL-backed TLM work:
 - Use counted `for` loops for repeated serialized direct blocking call sites inside one initiator thread; runtime bounds are supported for the serialized case.
 - Use `lock RESOURCE ... end lock RESOURCE` plus `resource RESOURCE: mutex<round_robin>;` when independent workers share a TLM method and require round-robin request arbitration.
 - Express multiple outstanding requests with worker threads, `generate_for` workers, direct-call `fork ... and ... join`, or RHS-fork groups.
+- Keep every branch of one `fork ... and ... join` group the same concurrency class (§22.2.3a); keep `out_of_order tags N` at `N <= 8` (§22.2.3b).
 
 **25. AI-Assisted Hardware Design Workflow**
 

--- a/skills/arch-programming/references/Arch_AI_Reference_Card.md
+++ b/skills/arch-programming/references/Arch_AI_Reference_Card.md
@@ -1292,6 +1292,8 @@ end module LoadPair
 
 Supported cohort shapes: multiple direct named worker threads, `generate_for` worker threads, and one direct-call `fork ... and ... join` thread. Blocking cohorts route responses by issue-order FIFO. `out_of_order tags N` cohorts drive `<method>_req_tag` and route by `<method>_rsp_tag`; target threads latch and echo the tag.
 
+A `fork ... and ... join` group must be class-uniform: every branch `blocking`, or every branch `out_of_order`. Mixing classes in one group is a compile error (`fork issue group mixes blocking and out_of_order calls ...`) — split into separate fork groups instead. RHS-fork groups already require every issue to target one method, so they cannot mix classes either.
+
 Timed multiple-outstanding issue in one thread:
 
 ```
@@ -1344,7 +1346,9 @@ Refining TLM into explicit threads:
 
 Use explicit threads when the protocol needs separate channels, beat-by-beat burst interleaving, registered ready paths for timing closure, protocol-specific retry/error/cancel rules, or area/power tuning beyond the generic TLM driver.
 
-Current restrictions: thread-body call sites only; direct RHS call only (`dst <= m.method(args);` or `dst <= fork m.method(args);`); runtime-loop and conditional-branch TLM calls are serialized direct blocking assignments; one call per worker/forked issue; same clock/reset per cohort; literal tag count only; RHS-fork offsets require literal `wait N cycle;`; RHS-fork tails after `join all;` are compute-only; no nested/composed TLM calls; no dynamic-length TLM return types; no `pipelined`; no first-class `burst`; no `Future<T>`/`await`.
+`out_of_order tags N` sizing: `N` is the literal bit width of the generated `<method>_req_tag` / `<method>_rsp_tag` carrier, not a tag count — a cohort/fork group of `W` outstanding workers needs `2^N >= W`. Recommended cap: `N <= 8` (256 tags); the compiler does not enforce this (`tags 64`, `tags 128` both build cleanly with an `N`-bit carrier), but a needlessly large `N` widens every tag wire, drive mux, and response comparator for no prototyping benefit.
+
+Current restrictions: thread-body call sites only; direct RHS call only (`dst <= m.method(args);` or `dst <= fork m.method(args);`); runtime-loop and conditional-branch TLM calls are serialized direct blocking assignments; one call per worker/forked issue; same clock/reset per cohort; literal tag count only; all branches of one `fork ... and ... join` group must be the same concurrency class (no mixing `blocking` and `out_of_order`); RHS-fork offsets require literal `wait N cycle;`; RHS-fork tails after `join all;` are compute-only; no nested/composed TLM calls; no dynamic-length TLM return types; no `pipelined`; no first-class `burst`; no `Future<T>`/`await`.
 
 Full spec: `doc/ARCH_HDL_Specification.md` §18d and §22. Design history / remaining work: `doc/archive/plan_tlm_method.md`.
 

--- a/src/elaborate.rs
+++ b/src/elaborate.rs
@@ -12255,7 +12255,26 @@ pub fn lower_tlm_initiator_calls(ast: SourceFile) -> Result<SourceFile, Vec<Comp
                         if t.tlm_target.is_some() || t.implement.is_some() {
                             continue;
                         }
-                        for dt in direct_tlm_threads(t, &port_buses, &port_methods) {
+                        let dts = direct_tlm_threads(t, &port_buses, &port_methods);
+                        // A `fork ... and ... join` direct-call group is
+                        // recognized here when `dts.len() > 1` (see
+                        // `direct_tlm_threads`). Grouping downstream keys
+                        // purely by `(port, method)`, so a group that mixes
+                        // `blocking` and `out_of_order` calls across
+                        // different methods can partially satisfy the
+                        // same-method cohort size check for whichever class
+                        // happens to repeat, while the minority-class
+                        // branch(es) are silently dropped instead of being
+                        // lowered. Reject mixed-class groups up front with a
+                        // clean diagnostic — see #500 Gap 1 and
+                        // doc/ARCH_HDL_Specification.md §22.2.2.
+                        if dts.len() > 1 {
+                            if let Some(e) = check_fork_join_uniform_tlm_class(&dts) {
+                                errors.push(e);
+                                continue;
+                            }
+                        }
+                        for dt in dts {
                             direct_groups
                                 .entry((dt.call.port.clone(), dt.call.method.clone()))
                                 .or_default()
@@ -12521,6 +12540,53 @@ fn direct_tlm_threads(
         }
         _ => Vec::new(),
     }
+}
+
+/// Human-readable class label for a TLM method's concurrency mode, used in
+/// the mixed-class fork-group diagnostic below. `blocking` methods print as
+/// `blocking`; `out_of_order tags N` methods print with the literal tag
+/// count when it resolves, otherwise just `out_of_order`.
+fn tlm_mode_label(meta: &TlmMethodMeta) -> String {
+    match &meta.out_of_order_tags {
+        Some(tags) => match literal_expr_u64(tags) {
+            Some(n) => format!("out_of_order tags {n}"),
+            None => "out_of_order".to_string(),
+        },
+        None => meta.mode.name.clone(),
+    }
+}
+
+/// Reject a direct-call `fork ... and ... join` TLM issue group (see
+/// `direct_tlm_threads`) that mixes `blocking` and `out_of_order tags N`
+/// calls. See doc/ARCH_HDL_Specification.md §22.2.2 and arch-com #500 Gap 1:
+/// the downstream `(port, method)` cohort grouping in
+/// `lower_tlm_initiator_calls` only recognizes a same-method cohort when at
+/// least two branches share one `(port, method)` key, so a mixed-class group
+/// can partially satisfy that check for whichever class happens to repeat
+/// while silently dropping the minority-class branch(es) instead of
+/// lowering them. Uniform-class groups (the only supported shape) return
+/// `None`.
+fn check_fork_join_uniform_tlm_class(dts: &[DirectTlmThread]) -> Option<CompileError> {
+    let first = dts.first()?;
+    let first_is_ooo = first.call.method_meta.out_of_order_tags.is_some();
+    for dt in &dts[1..] {
+        let is_ooo = dt.call.method_meta.out_of_order_tags.is_some();
+        if is_ooo != first_is_ooo {
+            return Some(CompileError::general(
+                &format!(
+                    "fork issue group mixes blocking and out_of_order calls (`{}.{}` is {}, `{}.{}` is {}); split into separate fork groups or make the classes uniform",
+                    first.call.port,
+                    first.call.method,
+                    tlm_mode_label(&first.call.method_meta),
+                    dt.call.port,
+                    dt.call.method,
+                    tlm_mode_label(&dt.call.method_meta),
+                ),
+                dt.thread.span,
+            ));
+        }
+    }
+    None
 }
 
 fn direct_tlm_assign_thread(

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -13336,6 +13336,198 @@ fn test_tlm_fork_join_workers_share_method() {
     );
 }
 
+/// Lower a source string through the same pipeline stages as
+/// `compile_to_sv` up to (and including) TLM initiator lowering, without
+/// panicking on error. Used by the mixed-class `fork ... and ... join`
+/// rejection tests below (arch-com #500 Gap 1), where the point under test
+/// is the `Err` returned by `lower_tlm_initiator_calls` itself.
+fn lower_tlm_initiator_calls_result(
+    source: &str,
+) -> Result<arch::ast::SourceFile, Vec<arch::diagnostics::CompileError>> {
+    let tokens = lexer::tokenize(source).expect("lexer error");
+    let mut parser = Parser::new(tokens, source);
+    let parsed_ast = parser.parse_source_file().expect("parse error");
+    let ast = elaborate::elaborate(parsed_ast).expect("elaborate error");
+    let ast = elaborate::lower_tlm_target_threads(ast).expect("tlm_target lowering error");
+    elaborate::lower_tlm_initiator_calls(ast)
+}
+
+// arch-com #500 Gap 1: a `fork ... and ... join` direct-call TLM issue group
+// that mixes a `blocking` call and an `out_of_order tags N` call must be
+// rejected with a clean diagnostic naming both classes, not silently lowered
+// or partially dropped. See doc/ARCH_HDL_Specification.md §22.2.2.
+//
+// Before the fix, the balanced 1-blocking/1-out_of_order shape below hit a
+// confusing internal message ("v1 TLM initiator thread body only supports
+// SeqAssign statements ... (found Discriminant(7))") because neither call
+// repeated its `(port, method)` key often enough to be recognized as a
+// same-method cohort. The unbalanced 2-blocking/1-out_of_order shape
+// (`test_tlm_fork_join_mixed_class_partial_cohort_rejected` below) was worse:
+// the 2 blocking calls *did* form a valid same-method cohort, so the
+// `out_of_order` branch was silently dropped from the lowered thread instead
+// of erroring at the TLM lowering stage at all (it later fell through to an
+// unrelated "output port not driven" diagnostic with no mention of the
+// mixed-class root cause).
+
+#[test]
+fn test_tlm_fork_join_mixed_class_blocking_then_ooo_rejected() {
+    let source = "
+        bus Mem
+          tlm_method read(addr: UInt<32>) -> UInt<64>: blocking;
+          tlm_method read_ooo(addr: UInt<32>) -> UInt<64>: out_of_order tags 2;
+        end bus Mem
+
+        use Mem;
+
+        module MixedBlockingThenOoo
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync>;
+          port m:   initiator Mem;
+          reg   addr: Vec<UInt<32>, 2> reset rst => 0;
+          reg   data: Vec<UInt<64>, 2> reset rst => 0;
+          thread workers on clk rising, rst high
+            fork
+              data[0] <= m.read(addr[0]);
+            and
+              data[1] <= m.read_ooo(addr[1]);
+            join
+          end thread workers
+        end module MixedBlockingThenOoo
+    ";
+    let errs = lower_tlm_initiator_calls_result(source)
+        .expect_err("mixed blocking/out_of_order fork group must be rejected");
+    assert!(!errs.is_empty(), "expected at least one error");
+    let msg = errs[0].to_string();
+    assert!(
+        msg.contains("fork issue group mixes blocking and out_of_order calls"),
+        "error should name the mixed-class fork group: {msg}"
+    );
+    assert!(
+        msg.contains("split into separate fork groups or make the classes uniform"),
+        "error should suggest the fix: {msg}"
+    );
+}
+
+#[test]
+fn test_tlm_fork_join_mixed_class_ooo_then_blocking_rejected() {
+    // Same defect, opposite branch order — the diagnostic must not depend
+    // on which class appears first in the fork group.
+    let source = "
+        bus Mem
+          tlm_method read(addr: UInt<32>) -> UInt<64>: blocking;
+          tlm_method read_ooo(addr: UInt<32>) -> UInt<64>: out_of_order tags 2;
+        end bus Mem
+
+        use Mem;
+
+        module MixedOooThenBlocking
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync>;
+          port m:   initiator Mem;
+          reg   addr: Vec<UInt<32>, 2> reset rst => 0;
+          reg   data: Vec<UInt<64>, 2> reset rst => 0;
+          thread workers on clk rising, rst high
+            fork
+              data[0] <= m.read_ooo(addr[0]);
+            and
+              data[1] <= m.read(addr[1]);
+            join
+          end thread workers
+        end module MixedOooThenBlocking
+    ";
+    let errs = lower_tlm_initiator_calls_result(source)
+        .expect_err("mixed out_of_order/blocking fork group must be rejected");
+    assert!(!errs.is_empty(), "expected at least one error");
+    let msg = errs[0].to_string();
+    assert!(
+        msg.contains("fork issue group mixes blocking and out_of_order calls"),
+        "error should name the mixed-class fork group: {msg}"
+    );
+}
+
+#[test]
+fn test_tlm_fork_join_mixed_class_partial_cohort_rejected() {
+    // 2 blocking branches on `read` (which alone would form a valid
+    // same-method cohort) plus 1 `out_of_order` branch on `read_ooo`. Before
+    // the fix, this silently dropped the `read_ooo` branch from the lowered
+    // thread entirely instead of erroring during TLM lowering.
+    let source = "
+        bus Mem
+          tlm_method read(addr: UInt<32>) -> UInt<64>: blocking;
+          tlm_method read_ooo(addr: UInt<32>) -> UInt<64>: out_of_order tags 2;
+        end bus Mem
+
+        use Mem;
+
+        module Mixed3Way
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync>;
+          port m:   initiator Mem;
+          reg   addr: Vec<UInt<32>, 3> reset rst => 0;
+          reg   data: Vec<UInt<64>, 3> reset rst => 0;
+          thread workers on clk rising, rst high
+            fork
+              data[0] <= m.read(addr[0]);
+            and
+              data[1] <= m.read(addr[1]);
+            and
+              data[2] <= m.read_ooo(addr[2]);
+            join
+          end thread workers
+        end module Mixed3Way
+    ";
+    let errs = lower_tlm_initiator_calls_result(source)
+        .expect_err("partial-cohort mixed-class fork group must be rejected");
+    assert!(!errs.is_empty(), "expected at least one error");
+    let msg = errs[0].to_string();
+    assert!(
+        msg.contains("fork issue group mixes blocking and out_of_order calls"),
+        "error should name the mixed-class fork group, not silently drop the \
+         out_of_order branch: {msg}"
+    );
+}
+
+#[test]
+fn test_tlm_rhs_fork_mixed_methods_already_rejected() {
+    // RHS-fork groups (`dst <= fork port.method(args); ... join all;`) are
+    // separately restricted to a single method per group (see
+    // `inline_lower_tlm_fork_join_all`), so mixing `blocking` and
+    // `out_of_order` methods there was already rejected before this change.
+    // Locked here as a control alongside the direct-call fork/join fix so
+    // the two related restrictions don't drift apart undocumented.
+    let source = "
+        bus Mem
+          tlm_method read(addr: UInt<32>) -> UInt<64>: blocking;
+          tlm_method read_ooo(addr: UInt<32>) -> UInt<64>: out_of_order tags 2;
+        end bus Mem
+
+        use Mem;
+
+        module RhsForkMixedMethods
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync>;
+          port m:   initiator Mem;
+          reg   d0: UInt<64> reset rst => 0;
+          reg   d1: UInt<64> reset rst => 0;
+
+          thread driver on clk rising, rst high
+            d0 <= fork m.read(32'h1000);
+            wait 1 cycle;
+            d1 <= fork m.read_ooo(32'h2000);
+            join all;
+          end thread driver
+        end module RhsForkMixedMethods
+    ";
+    let errs = lower_tlm_initiator_calls_result(source)
+        .expect_err("RHS-fork group spanning two methods must be rejected");
+    assert!(!errs.is_empty(), "expected at least one error");
+    let msg = errs[0].to_string();
+    assert!(
+        msg.contains("v1 forked TLM groups must target one method"),
+        "error should mention the one-method restriction: {msg}"
+    );
+}
+
 #[test]
 fn test_tlm_rhs_fork_join_all_workers_share_method() {
     let source = "


### PR DESCRIPTION
## Summary

Two items from the #500 TLM-inventory triage (maintainer-approved 2026-07-13):

### Gap 1 — mixed-class `fork ... and ... join` groups (rejected)

**Before-state (characterized on a fresh `cargo build --release` binary, all four repro shapes reproduced via `arch check`):**

- **Balanced 1-blocking/1-out_of_order** fork group (either branch order) already failed, but with an unrelated internal-looking message:
  ```
  v1 TLM initiator thread body only supports SeqAssign statements,
  serialized `for` loops, compute-only `if` branches, and `lock` blocks
  around them (found Discriminant(7)). Refactor more complex control flow
  into a `thread` without TLM calls.
  ```
  Root cause: `lower_tlm_initiator_calls` groups direct-call fork branches by `(port, method)` and only recognizes a "cohort" once ≥2 branches share one method. A mixed-class group always calls two *different* methods (mode is fixed per `tlm_method` declaration), so neither class's group reaches cohort size — the whole thread falls through to the single-thread inline lowering path, which doesn't handle `ForkJoin` at all and errors generically.
- **Unbalanced mixes** (e.g. 2 `blocking` branches + 1 `out_of_order` branch) were worse — not a compile error at the TLM lowering stage at all. The 2 blocking branches alone satisfy the same-method cohort check, so `lower_tlm_initiator_cohort` lowers *only* that pair; the `out_of_order` branch is silently dropped from the emitted thread. This surfaced downstream as an unrelated, confusing diagnostic:
  ```
  output port `m_read_ooo_req_valid` is not driven
  ```
  with zero mention of the mixed-class root cause. (4-branch 2-blocking/2-out_of_order shows the same silent drop.)

This is not provably sound — it's an elaboration-level defect (a whole branch's lowering silently vanishes), currently masked only because SV emission happens to require every declared bus port to be driven. Per the maintainer's decision rule, this closes the gap by **rejecting** mixed-class groups at TLM-lowering time with a clean, explicit diagnostic, before cohort grouping ever runs:

```
fork issue group mixes blocking and out_of_order calls (`m.read` is
blocking, `m.read_ooo` is out_of_order tags 2); split into separate fork
groups or make the classes uniform
```

Uniform-class fork/join groups (all `blocking` or all `out_of_order` — the only previously-supported shape) are unaffected; controls verified unchanged (`_tlm_pool_m_read_fifo` cohort lowering still emitted, existing 96 TLM integration tests still pass). RHS-fork groups (`dst <= fork port.method(args); ... join all;`) were already restricted to one method per group (`v1 forked TLM groups must target one method`), so they could never mix classes — verified as an unaffected control, now locked with a regression test.

New spec section §22.2.3a explains the restriction and why. CLAUDE.md, `doc/Arch_AI_Reference_Card.md`, and the `arch-programming` skill's doc snapshots are updated to match.

### Gap 2 — `out_of_order tags N` bound (documented)

Characterization (verified via generated SV, not assumed):

- `N` is the **literal bit width** of the compiler-generated `<method>_req_tag` / `<method>_rsp_tag` carrier wires directly — **not** a tag count that gets `$clog2`-widened. `tlm_method read(...) -> ...: out_of_order tags 2;` emits `logic [1:0] m_read_req_tag`; a cohort/fork group of `W` outstanding workers needs `2^N >= W`, which the compiler already enforces at lowering time (`"... has {n} workers but only {tag_slots} out-of-order tags; increase tags width"`).
- `tags 64` and `tags 128` **both build cleanly today** — exactly `N`-bit carriers (`logic [63:0]` / `logic [127:0]`), no truncation, silent promotion, or width mismatch.
- No overflow defect found at large `N`: all three lowering call sites that compute `tag_slots = 1u128 << N` explicitly guard `N >= 64` by clamping to `u128::MAX` instead of shifting, so there's no wrapping-shift bug. Nothing here needed a separate filed issue per the "STOP on defect" instruction — there wasn't one.

Documented recommendation: **N ≤ 8** (256 tags) — generous headroom above any current TLM prototyping fan-out, not compiler-enforced. New spec §22.2.3b + CLAUDE.md note + reference-card note. harc-com mirror is flagged for the daily review per the maintainer's triage comment (no harc-com changes in this PR).

## Test plan

- [x] `scripts/claim_check.sh --grep "tlm fork"` / `--grep "mixed-class"` — no overlap before starting
- [x] Fresh `cargo build --release`
- [x] `cargo test --release` — full suite, 752 integration tests + 68 unit + 23 formal (incl. the 2 Lean-backed construct-proof tests, after `lake build` in `proofs/lean_thread_lowering`) + all other suites, all green
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --release --all-targets` — clean (pre-existing unrelated warnings only)
- [x] `scripts/sync_skill_snapshots.sh check` — in sync after refresh
- [x] `scripts/check_doc_drift.sh origin/main` — passes (no grammar-surface files touched; doc files did change)
- [x] 4 new regression tests for Gap 1 (`test_tlm_fork_join_mixed_class_blocking_then_ooo_rejected`, `..._ooo_then_blocking_rejected`, `..._partial_cohort_rejected`, `test_tlm_rhs_fork_mixed_methods_already_rejected` as a control), all locking exact error text

Refs #500 (Gap 1, Gap 2). Does not close #500 — Gaps 3/4 and the exemplar/template items remain open per the triage comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)