### PR TITLE
fix(sim): deterministic member order in emitted C++ sim models

### DIFF
--- a/src/elaborate/mod.rs
+++ b/src/elaborate/mod.rs
@@ -8752,7 +8752,10 @@ fn partition_thread_body_impl(
                 // the same critical section simultaneously.  Reject at compile time.
                 let inner_resources = collect_locked_resources(body);
                 if !inner_resources.is_empty() {
-                    let names: Vec<&str> = inner_resources.iter().map(|s| s.as_str()).collect();
+                    // Sort for a deterministic diagnostic — HashSet iteration
+                    // order is not stable.
+                    let mut names: Vec<&str> = inner_resources.iter().map(|s| s.as_str()).collect();
+                    names.sort_unstable();
                     return Err(CompileError::general(
                         &format!(
                             "nested lock blocks are not supported (inner lock(s): {}); \

--- a/src/sim_codegen/mod.rs
+++ b/src/sim_codegen/mod.rs
@@ -2083,7 +2083,10 @@ impl<'a> SimCodegen<'a> {
         }
 
         // Private fields for sub-instance output wires
-        for sig_name in &inst_out {
+        // Sort for deterministic output — HashSet iteration order is not stable.
+        let mut sorted_inst_out: Vec<&String> = inst_out.iter().collect();
+        sorted_inst_out.sort();
+        for sig_name in sorted_inst_out {
             if !port_names.contains(sig_name) && !reg_names.contains(sig_name)
                 // Bus wires are handled via the struct-typed `_let_<name>`
                 // field emitted above; a fallback `uint32_t <name>;` here
@@ -2121,8 +2124,11 @@ impl<'a> SimCodegen<'a> {
         crate::sim_credit_channel::emit_header_fields(&cc_sites, &mut h);
 
         // Private fields for comb-block intermediate signals (not ports/regs/inst_out)
+        // Sort for deterministic output — HashSet iteration order is not stable.
         let comb_targets = collect_comb_targets(&m.body);
-        for sig_name in &comb_targets {
+        let mut sorted_comb_targets: Vec<&String> = comb_targets.iter().collect();
+        sorted_comb_targets.sort();
+        for sig_name in sorted_comb_targets {
             if !port_names.contains(sig_name)
                 && !reg_names.contains(sig_name)
                 && !inst_out.contains(sig_name)
@@ -2947,7 +2953,10 @@ impl<'a> SimCodegen<'a> {
 
             // Guard Check A: for each `reg ... guard <sig>`, warn if guard asserts
             // but the reg has never been written. Fires once per module per signal.
-            for (reg_name, guard_sig) in &guarded_regs {
+            // Sort for deterministic output — HashMap iteration order is not stable.
+            let mut sorted_guarded_regs: Vec<(&String, &String)> = guarded_regs.iter().collect();
+            sorted_guarded_regs.sort();
+            for (reg_name, guard_sig) in sorted_guarded_regs {
                 let guard_cpp = if reg_decls.iter().any(|r| r.name.name == *guard_sig)
                     || m.ports
                         .iter()


### PR DESCRIPTION
## Summary

Fixes nondeterministic declaration order of struct members in emitted C++ sim models (`V_*.h`), first observed as phantom diffs in `scripts/refactor_diff.sh` runs: lock-arbiter signal fields (`_<res>_grant_packed` / `_grant_valid` / `_grant_requester`, `drive_sel`-style comb intermediates) shuffled order between compiler invocations while the field *set* stayed identical.

## Root cause

Four sites iterate a `std::collections::HashSet`/`HashMap` directly into generated output. std's `RandomState` hasher is randomly seeded per process, so every `arch` invocation could emit a different (functionally identical) order:

| Site | Collection | Leaks into |
|---|---|---|
| `sim_codegen/mod.rs` "private fields for sub-instance output wires" | `inst_out: HashSet<String>` | header struct members (the lock-arbiter grant sinks are inst outputs of the synthesized `_arb_inst_*`) |
| `sim_codegen/mod.rs` "private fields for comb-block intermediate signals" | `collect_comb_targets(): HashSet<String>` | header struct members |
| `sim_codegen/mod.rs` "Guard Check A" | `guarded_regs: HashMap<String, String>` | guard-violation check blocks in the `.cpp` |
| `elaborate/mod.rs` nested-lock rejection | `collect_locked_resources(): HashSet<String>` | error-message resource list |

Fix: collect to a `Vec` and sort before iterating, matching the existing `sorted_reads` / `sorted_resources` pattern elsewhere in the codebase. `.sv` / `.archi` emission was never affected (those paths already iterate AST order or pre-sorted collections).

One diagnostic correction to the original report: the nondeterminism is **per-process**, not per-build. Two runs of the *same* pre-fix binary on `tests/thread/resource_lock.arch` produced differently-ordered `V_SharedBus_threads.h` (the earlier "stable across 3 re-runs" observation was a small-sample coincidence — with 3 fields only a few orders are reachable). This doesn't change the fix, but it explains why `refactor_diff.sh` reported a *different* set of affected files on each run: every compiler invocation is an independent coin flip.

## Verification

Pre-fix (base `6538336`, two independent worktree builds with separate target dirs):
- same binary, 2 runs → `V_SharedBus_threads.h` differs (grant field order only)
- cross-build → differs the same way

Post-fix (`cargo build` at this branch in the same two independent worktrees):
- 10 repeated runs × 2 fixtures (`tests/thread/resource_lock.arch`, `tests/backend_equiv/Fx3ThreadVecParamW.arch`) → all byte-identical
- cross-build (worktree A binary vs worktree B binary) → byte-identical
- `cargo test --release`: green except `construct_proof_lean_finds_home_elan_when_lake_not_on_path` and `construct_proof_lean_non_power_two_fifo_catches_depth_wrap_bug`, which fail identically at the unmodified base commit on this machine (pre-existing local Lean-toolchain issue, unrelated).

## Effect on `scripts/refactor_diff.sh`

Once this lands, repeated runs of the script report identical (zero spurious) results — **provided both the base ref and HEAD contain this commit**. A comparison whose *base ref* predates this fix will still show the phantom `.h` reorder diffs, because the base-built binary still emits random order; rebase or pick a post-fix base in that case.

Internal codegen-determinism fix only — no user-facing syntax or semantics change; sim behavior is unaffected (all generated code accesses members by name; C++ struct member order is not observable to the TB API).
