### PR TITLE
fix(threads): emit lock request wires from their own always_comb (#709)

### DIFF
--- a/src/elaborate/mod.rs
+++ b/src/elaborate/mod.rs
@@ -5638,13 +5638,43 @@ fn lower_module_threads(
     // Per-thread state-guarded comb assigns
     merged_comb.extend(all_thread_comb);
     if !merged_comb.is_empty() {
-        merged_body.insert(
-            0,
-            ModuleBodyItem::CombBlock(CombBlock {
-                stmts: merged_comb,
-                span: sp,
-            }),
-        );
+        // arch#709: emit the lock request wires from their own always_comb so
+        // the block's grant reads can't fabricate a grant -> req dependency
+        // edge and lint as a combinational loop. Falls back to the single
+        // merged block when the split isn't provably semantics-preserving.
+        let req_names: HashSet<String> = all_resources
+            .iter()
+            .flat_map(|res| (0..n_threads).map(move |ti| format!("_{}_req_{}", res, ti)))
+            .collect();
+        match split_lock_req_comb(&merged_comb, &req_names) {
+            Some((req_stmts, rest_stmts)) => {
+                if !rest_stmts.is_empty() {
+                    merged_body.insert(
+                        0,
+                        ModuleBodyItem::CombBlock(CombBlock {
+                            stmts: rest_stmts,
+                            span: sp,
+                        }),
+                    );
+                }
+                merged_body.insert(
+                    0,
+                    ModuleBodyItem::CombBlock(CombBlock {
+                        stmts: req_stmts,
+                        span: sp,
+                    }),
+                );
+            }
+            None => {
+                merged_body.insert(
+                    0,
+                    ModuleBodyItem::CombBlock(CombBlock {
+                        stmts: merged_comb,
+                        span: sp,
+                    }),
+                );
+            }
+        }
     }
 
     // Prepend parent-module function clones so thread-body calls inside
@@ -6955,6 +6985,225 @@ fn collect_comb_stmt_signals(stmts: &[Stmt]) -> (HashSet<String>, HashSet<String
 
     walk(stmts, &mut comb_driven, &mut all_read);
     (comb_driven, all_read)
+}
+
+/// arch#709: peel the `_<res>_req_<ti>` lock-request assignments out of the
+/// merged thread `always_comb` into a block of their own.
+///
+/// The merged block writes both the lock request wires and ordinary
+/// combinational outputs, and the latter are routinely gated on
+/// `_<res>_grant_<ti>` (that is what a `lock` body *is*). Verilator models an
+/// `always_comb` as a single dependency-graph vertex, so every read of the
+/// block feeds every write of it — fabricating a `grant -> req` edge that
+/// closes the arbiter's `req -> grant` path into a cycle and reports it as
+/// `UNOPTFLAT: Circular combinational logic` on the grant wires. The bit-level
+/// graph is acyclic (`req` is a function of the thread state registers alone),
+/// which is why `arch check`'s per-signal comb-loop detector is silent, but the
+/// emitted SV still lints as a combinational loop.
+///
+/// Splitting removes the false edge: the request block reads only state
+/// registers, and the remaining block's grant reads no longer reach a request
+/// wire. Where a request genuinely *is* derived from a grant, the guard travels
+/// with the request assignment into the new block and the edge — a real one —
+/// survives.
+///
+/// Returns `None` when the split is not known to be semantics-preserving, in
+/// which case the caller keeps the single merged block (today's output):
+///
+///   - a moved statement's guard or right-hand side reads a signal that the
+///     merged block itself drives. Within one block that read sees the value
+///     assigned so far in statement order; across two blocks it would see the
+///     other block's settled value instead.
+///   - a request assignment sits inside a statement kind this pass does not
+///     know how to duplicate structurally.
+///
+/// The partition is by assignment target, so the two blocks drive disjoint
+/// signal sets (no multiple-driver hazard) and statement order — hence
+/// last-write-wins — is preserved within each.
+fn split_lock_req_comb(
+    stmts: &[Stmt],
+    req_names: &HashSet<String>,
+) -> Option<(Vec<Stmt>, Vec<Stmt>)> {
+    if req_names.is_empty() {
+        return None;
+    }
+    let (driven, _) = collect_comb_stmt_signals(stmts);
+
+    // An expression is safe to re-evaluate in the split-off block iff it reads
+    // nothing the merged block drives.
+    fn expr_safe(e: &Expr, driven: &HashSet<String>) -> bool {
+        let mut reads = HashSet::new();
+        collect_expr_reads(e, &mut reads);
+        reads.is_disjoint(driven)
+    }
+
+    /// `Some((req_half, rest_half))`, or `None` to abandon the split.
+    fn split_stmt(
+        s: &Stmt,
+        req_names: &HashSet<String>,
+        driven: &HashSet<String>,
+    ) -> Option<(Option<Stmt>, Option<Stmt>)> {
+        match s {
+            Stmt::Assign(a) => {
+                let is_req = expr_root_name(&a.target)
+                    .map(|n| req_names.contains(&n))
+                    .unwrap_or(false);
+                if !is_req {
+                    return Some((None, Some(s.clone())));
+                }
+                // The target's own name is the signal being moved; only the
+                // reads inside its index/select expressions matter here.
+                let mut target_reads = HashSet::new();
+                collect_expr_index_reads(&a.target, &mut target_reads);
+                if !expr_safe(&a.value, driven) || !target_reads.is_disjoint(driven) {
+                    return None;
+                }
+                Some((Some(s.clone()), None))
+            }
+            Stmt::IfElse(ie) => {
+                let (then_req, then_rest) = split_list(&ie.then_stmts, req_names, driven)?;
+                let (else_req, else_rest) = split_list(&ie.else_stmts, req_names, driven)?;
+                let req_half = if then_req.is_empty() && else_req.is_empty() {
+                    None
+                } else {
+                    if !expr_safe(&ie.cond, driven) {
+                        return None;
+                    }
+                    Some(Stmt::IfElse(IfElse {
+                        cond: ie.cond.clone(),
+                        then_stmts: then_req,
+                        else_stmts: else_req,
+                        unique: ie.unique,
+                        span: ie.span,
+                    }))
+                };
+                let rest_half = if then_rest.is_empty() && else_rest.is_empty() {
+                    None
+                } else {
+                    Some(Stmt::IfElse(IfElse {
+                        cond: ie.cond.clone(),
+                        then_stmts: then_rest,
+                        else_stmts: else_rest,
+                        unique: ie.unique,
+                        span: ie.span,
+                    }))
+                };
+                Some((req_half, rest_half))
+            }
+            Stmt::Match(m) => {
+                let mut req_arms = Vec::new();
+                let mut rest_arms = Vec::new();
+                let mut any_req = false;
+                let mut any_rest = false;
+                for arm in &m.arms {
+                    let (arm_req, arm_rest) = split_list(&arm.body, req_names, driven)?;
+                    any_req |= !arm_req.is_empty();
+                    any_rest |= !arm_rest.is_empty();
+                    req_arms.push(MatchArm {
+                        pattern: arm.pattern.clone(),
+                        body: arm_req,
+                    });
+                    rest_arms.push(MatchArm {
+                        pattern: arm.pattern.clone(),
+                        body: arm_rest,
+                    });
+                }
+                let req_half = if any_req {
+                    if !expr_safe(&m.scrutinee, driven) {
+                        return None;
+                    }
+                    Some(Stmt::Match(MatchStmt {
+                        scrutinee: m.scrutinee.clone(),
+                        arms: req_arms,
+                        unique: m.unique,
+                        span: m.span,
+                    }))
+                } else {
+                    None
+                };
+                let rest_half = if any_rest {
+                    Some(Stmt::Match(MatchStmt {
+                        scrutinee: m.scrutinee.clone(),
+                        arms: rest_arms,
+                        unique: m.unique,
+                        span: m.span,
+                    }))
+                } else {
+                    None
+                };
+                Some((req_half, rest_half))
+            }
+            Stmt::For(f) => {
+                let (body_req, body_rest) = split_list(&f.body, req_names, driven)?;
+                let req_half = if body_req.is_empty() {
+                    None
+                } else {
+                    let range_safe = match &f.range {
+                        ForRange::Range(start, end) => {
+                            expr_safe(start, driven) && expr_safe(end, driven)
+                        }
+                        ForRange::ValueList(values) => values.iter().all(|v| expr_safe(v, driven)),
+                    };
+                    if !range_safe {
+                        return None;
+                    }
+                    Some(Stmt::For(ForLoop {
+                        var: f.var.clone(),
+                        range: f.range.clone(),
+                        body: body_req,
+                        span: f.span,
+                    }))
+                };
+                let rest_half = if body_rest.is_empty() {
+                    None
+                } else {
+                    Some(Stmt::For(ForLoop {
+                        var: f.var.clone(),
+                        range: f.range.clone(),
+                        body: body_rest,
+                        span: f.span,
+                    }))
+                };
+                Some((req_half, rest_half))
+            }
+            // Statement kinds the merged thread comb block never uses for lock
+            // requests. If one ever does contain a request assignment, abandon
+            // the split rather than guess at its duplication semantics.
+            other => {
+                let (driven_here, _) = collect_comb_stmt_signals(std::slice::from_ref(other));
+                if driven_here.is_disjoint(req_names) {
+                    Some((None, Some(other.clone())))
+                } else {
+                    None
+                }
+            }
+        }
+    }
+
+    fn split_list(
+        stmts: &[Stmt],
+        req_names: &HashSet<String>,
+        driven: &HashSet<String>,
+    ) -> Option<(Vec<Stmt>, Vec<Stmt>)> {
+        let mut req = Vec::new();
+        let mut rest = Vec::new();
+        for s in stmts {
+            let (r, o) = split_stmt(s, req_names, driven)?;
+            if let Some(r) = r {
+                req.push(r);
+            }
+            if let Some(o) = o {
+                rest.push(o);
+            }
+        }
+        Some((req, rest))
+    }
+
+    let (req_stmts, rest_stmts) = split_list(stmts, req_names, &driven)?;
+    if req_stmts.is_empty() {
+        return None;
+    }
+    Some((req_stmts, rest_stmts))
 }
 
 fn collect_thread_signals(

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -18789,6 +18789,149 @@ fn test_tight_relock_release_event_is_registered_709() {
     );
 }
 
+/// Extract the body of each `always_comb` block in `sv`, in source order.
+fn always_comb_bodies(sv: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut cur: Option<String> = None;
+    let mut depth = 0usize;
+    for line in sv.lines() {
+        let t = line.trim();
+        if cur.is_none() {
+            if t == "always_comb begin" {
+                cur = Some(String::new());
+                depth = 1;
+            }
+            continue;
+        }
+        depth += t.matches("begin").count();
+        depth -= t.matches("end").count().min(depth);
+        if depth == 0 {
+            out.push(cur.take().unwrap());
+        } else {
+            cur.as_mut().unwrap().push_str(line);
+            cur.as_mut().unwrap().push('\n');
+        }
+    }
+    out
+}
+
+#[test]
+fn test_lock_request_comb_block_is_isolated_709() {
+    // arch#709: the merged thread `always_comb` used to write the lock request
+    // wires *and* the grant-gated lock-body outputs. Verilator treats an
+    // always block as one dependency-graph vertex, so that bundling fabricates
+    // a grant -> req edge, closing the arbiter's req -> grant path into a
+    // reported combinational loop (UNOPTFLAT) even though the bit-level graph
+    // is acyclic. The request wires must be emitted from a block of their own
+    // that reads no grant.
+    let source = r#"
+        module LockReqSplit709
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync, High>;
+          port ready: in Bool;
+          port bus_valid: out Bool;
+          resource pool: mutex<round_robin>;
+
+          thread T0 on clk rising, rst high
+            lock pool
+              bus_valid = 1;
+              wait until ready;
+            end lock pool
+          end thread T0
+
+          thread T1 on clk rising, rst high
+            lock pool
+              bus_valid = 1;
+              wait until ready;
+            end lock pool
+          end thread T1
+        end module LockReqSplit709
+    "#;
+    let sv = compile_to_sv(source);
+    let blocks = always_comb_bodies(&sv);
+    let req_blocks: Vec<&String> = blocks
+        .iter()
+        .filter(|b| b.contains("_pool_req_0"))
+        .collect();
+    assert_eq!(
+        req_blocks.len(),
+        1,
+        "lock requests must be driven from exactly one always_comb:\n{sv}"
+    );
+    assert!(
+        !req_blocks[0].contains("_pool_grant_"),
+        "the lock-request always_comb must not read any grant wire \
+         (that read is what Verilator turns into a false grant -> req edge):\n{}",
+        req_blocks[0]
+    );
+    // The lock-body outputs are still grant-gated — in a different block.
+    assert!(
+        sv.contains("if (_pool_grant_0) begin"),
+        "lock-body outputs must still be gated on the grant:\n{sv}"
+    );
+    assert!(
+        comb_loop_warnings(source).is_empty(),
+        "lock lowering must not report a combinational SCC"
+    );
+}
+
+#[test]
+fn test_lock_lowering_is_unoptflat_clean_709() {
+    // The end-to-end gate for arch#709: Verilator must not report circular
+    // combinational logic for lock-using designs. `resource_lock.arch` (a
+    // `mutex<priority>` whose lock bodies drive a shared bus) and
+    // `semaphore_relock_rr.arch` (the tight re-lock idiom from the issue) both
+    // tripped UNOPTFLAT before the request block was split out.
+    if std::process::Command::new("verilator")
+        .arg("--version")
+        .output()
+        .is_err()
+    {
+        eprintln!("skipping lock UNOPTFLAT check: verilator not found");
+        return;
+    }
+    let arch_bin = env!("CARGO_BIN_EXE_arch");
+    for (src, top) in [
+        ("tests/thread/resource_lock.arch", "SharedBus"),
+        ("tests/thread/semaphore_relock_rr.arch", "SemaphoreRelock"),
+        ("tests/thread/mutex_release_rr.arch", "MutexRel"),
+    ] {
+        let td = tempfile::tempdir().expect("tempdir");
+        let sv_out = td.path().join(format!("{top}.sv"));
+        let build = std::process::Command::new(arch_bin)
+            .arg("build")
+            .arg(src)
+            .arg("-o")
+            .arg(&sv_out)
+            .output()
+            .expect("build lock fixture SV");
+        assert!(
+            build.status.success(),
+            "arch build {src} should pass\nstderr:\n{}",
+            String::from_utf8_lossy(&build.stderr)
+        );
+        let verilate = std::process::Command::new("verilator")
+            .arg("--cc")
+            .arg("-Wno-fatal")
+            .arg("--top-module")
+            .arg(top)
+            .arg("-Mdir")
+            .arg(td.path().join("obj_dir"))
+            .arg(&sv_out)
+            .output()
+            .expect("run verilator");
+        let log = format!(
+            "{}{}",
+            String::from_utf8_lossy(&verilate.stdout),
+            String::from_utf8_lossy(&verilate.stderr)
+        );
+        assert!(
+            !log.contains("UNOPTFLAT"),
+            "{src} must lint free of circular combinational logic:\n{log}"
+        );
+    }
+}
+
 #[test]
 fn test_mutex_tight_relock_single_requester_no_bubble_709() {
     // Runtime regression for the timing contract: one requester should


### PR DESCRIPTION
## Summary

Emit the `_<res>_req_<ti>` lock-request wires from their own `always_comb` instead of bundling them into the merged thread comb block. This clears the `UNOPTFLAT: Circular combinational logic` that Verilator reports on the lock arbiter's grant wires for every lock-using design.

closes #709

## Root cause — the loop is false, and it is not tight-loop-specific

#709 was filed against a *real* loop through the combinational release wire. #714 (registered `_release_i`) and #719 (separate combinational `_release_pending_i`) fixed that one: `arch check`'s per-signal comb-loop detector has been silent on the repro ever since. Neither PR said `closes #709`, so the issue outlived its fix.

What still fires is a different, weaker defect. The merged thread `always_comb` writes both the lock request wires and the lock-body outputs, and the latter are gated on `_<res>_grant_<ti>` — that is what a `lock` body *is*:

```sv
always_comb begin
  _shared_bus_req_0 = 1'b0;                 // function of _t0_state alone
  ...
  if (_t0_state == _t0_S0_wait_until) begin
    _shared_bus_req_0 = 1;
    if (_shared_bus_grant_0) begin          // <-- grant read, same block
      bus_valid = 1;
    end
  end
end
```

Verilator models an always block as a single dependency-graph vertex, so every read of the block feeds every write of it. That fabricates a `grant -> req` edge which closes the arbiter's genuine `req -> grant` path into a cycle:

```
_pool_grant_2 -> ALWAYS(thread comb) -> _pool_req_0 -> _pool_waiting_0
  -> _pool_req_packed -> ALWAYS(arbiter) -> _pool_grant_packed -> _pool_admit_0 -> _pool_grant_0
```

At bit granularity the graph is acyclic (`req` is a function of the thread state registers alone), which is why `arch check` is silent and why simulation has always been correct — but the emitted synthesizable SV still lints as a combinational loop.

Two corrections to the issue as filed, both now covered by regressions:
- It is **not** confined to the tight re-lock idiom. Sweeping every lock-using fixture in the repo, 6 tripped UNOPTFLAT — including `resource_lock.arch` and `mutex_release_{rr,pri}` / `mutex_hold_preempt_{rr,pri}`, none of which are tight re-lock. Whether Verilator's internal always-block splitting happens to rescue a given design is what decided it, not the source idiom.
- It is **not** evidence of a real loop, so the options the issue lists — registering a handshake edge (costs a cycle), a lint waiver pragma, or diagnosing the idiom at `arch check` — all address something that isn't there.

## Fix

`split_lock_req_comb` partitions the merged comb statement list by assignment target, preserving guard nesting, and `lower_threads` emits the two halves as two `always_comb` blocks. The request block then reads only state registers; the remaining block's grant reads no longer reach a request wire. Where a request genuinely *is* derived from a grant, the guard travels with the request assignment into the new block and that (real) edge survives.

The split is skipped — output falls back to today's single block — when it is not provably semantics-preserving: when a moved statement's guard or RHS reads a signal the merged block itself drives (in one block that read sees the value assigned so far in statement order; across two blocks it would see the other block's settled value), or when a request assignment sits inside a statement kind the pass can't duplicate structurally. No fixture in the corpus hits the fallback.

Internal codegen only — no user-facing syntax or semantics change. The two blocks drive disjoint signal sets, so there is no multiple-driver hazard, and statement order (hence last-write-wins) is unchanged within each.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --release`
- Verilator 5.048 sweep over all 21 lock-using fixtures in the repo: **6 UNOPTFLAT-dirty before, 0 after**. Same for the issue's own `semaphore<2, round_robin>` and `mutex<round_robin>` tight-re-lock repros.
- New regressions: `test_lock_request_comb_block_is_isolated_709` (structural — exactly one comb block drives the requests, and it reads no grant) and `test_lock_lowering_is_unoptflat_clean_709` (end-to-end Verilator gate over three fixtures, skipped when verilator is absent).

## Follow-on

The note that #709 blocks promoting the comb-loop diagnostic from warning to error is stale — `arch check` reports no cycle for any of the affected fixtures, and hasn't since #714.
