### PR TITLE
fix(comb-graph): distinguish in-block read-after-write from feedback in whole-design comb-loop analysis (pre-req for arch#709 follow-up)

### DIFF
--- a/src/comb_graph.rs
+++ b/src/comb_graph.rs
@@ -1839,15 +1839,45 @@ impl GraphBuilder {
     /// LHS base names. Conditions count as reads of every then/else target.
     fn scan_assignments(&mut self, stmts: &[Stmt], path: &InstPath, bus_ports: &HashSet<String>) {
         let mut cond_stack: Vec<HashSet<String>> = Vec::new();
-        self.scan_assignments_inner(stmts, path, bus_ports, &mut cond_stack);
+        let mut written: HashSet<String> = HashSet::new();
+        self.scan_assignments_inner(stmts, path, bus_ports, &mut cond_stack, &mut written);
     }
 
+    /// `written` tracks, in the block's sequential (blocking-assignment)
+    /// order, which LHS base names are DEFINITELY assigned by some earlier
+    /// statement reached so far in this same comb-block scope. It is used
+    /// to distinguish two shapes that both read a signal on the RHS of its
+    /// own assignment:
+    ///
+    ///   * `x = x <op> t0;` where an EARLIER statement in the same block
+    ///     already assigned `x` (e.g. a sequential-fold reduction:
+    ///     `x = <identity>; x = x <op> t0; x = x <op> t1; …`, the SV shape
+    ///     `shared(or)`/`shared(and)` thread lowering emits into one
+    ///     `always_comb`). Blocking-assignment semantics mean this read
+    ///     sees the in-block value just established by the earlier write —
+    ///     NOT a dependency on `x`'s own value from outside/before this
+    ///     block. No graph edge (arch#709 follow-up false positive).
+    ///   * `x = x <op> y;` as the FIRST assignment to `x` in the block (or
+    ///     on a control-flow path where no earlier write is guaranteed —
+    ///     see the `IfElse`/`Match` handling below). This reads `x`'s
+    ///     pre-block value with nothing to break the cycle: a genuine
+    ///     combinational self-dependency. Still produces the edge.
+    ///
+    /// Promotion to "definitely written" across control flow must stay
+    /// conservative (favor still emitting the edge over silently dropping
+    /// a real one): a name is only promoted out of an `if`/`else` when
+    /// BOTH arms wrote it (a bare `if` with no `else` promotes nothing —
+    /// same as the empty-else case falling out of the intersection with
+    /// the untouched clone), and only out of a `match` when EVERY arm
+    /// wrote it. Writes inside a `for` body are treated as branch-local
+    /// (never promoted to the enclosing scope) for the same reason.
     fn scan_assignments_inner(
         &mut self,
         stmts: &[Stmt],
         path: &InstPath,
         bus_ports: &HashSet<String>,
         cond_stack: &mut Vec<HashSet<String>>,
+        written: &mut HashSet<String>,
     ) {
         for stmt in stmts {
             match stmt {
@@ -1860,11 +1890,17 @@ impl GraphBuilder {
                     collect_expr_idents_bus(&a.value, bus_ports, &mut rhs);
                     // RHS for index/bit-slice on LHS also contributes to deps.
                     collect_lhs_index_reads(&a.target, &mut rhs);
+                    let already_written = written.contains(&lhs);
                     let to = self.intern(NodeKey {
                         path: path.clone(),
-                        signal: lhs,
+                        signal: lhs.clone(),
                     });
                     for id in &rhs {
+                        // Self-read of a signal already assigned earlier in
+                        // this block: in-block value, not a feedback edge.
+                        if already_written && id.as_str() == lhs.as_str() {
+                            continue;
+                        }
                         let from = self.intern(NodeKey {
                             path: path.clone(),
                             signal: id.clone(),
@@ -1873,6 +1909,9 @@ impl GraphBuilder {
                     }
                     for conds in cond_stack.iter() {
                         for id in conds {
+                            if already_written && id.as_str() == lhs.as_str() {
+                                continue;
+                            }
                             let from = self.intern(NodeKey {
                                 path: path.clone(),
                                 signal: id.clone(),
@@ -1880,26 +1919,64 @@ impl GraphBuilder {
                             self.add_edge(from, to);
                         }
                     }
+                    written.insert(lhs);
                 }
                 Stmt::IfElse(ife) => {
                     let mut cond_ids = HashSet::new();
                     collect_expr_idents_bus(&ife.cond, bus_ports, &mut cond_ids);
                     cond_stack.push(cond_ids);
-                    self.scan_assignments_inner(&ife.then_stmts, path, bus_ports, cond_stack);
-                    self.scan_assignments_inner(&ife.else_stmts, path, bus_ports, cond_stack);
+                    let mut then_written = written.clone();
+                    self.scan_assignments_inner(
+                        &ife.then_stmts,
+                        path,
+                        bus_ports,
+                        cond_stack,
+                        &mut then_written,
+                    );
+                    let mut else_written = written.clone();
+                    self.scan_assignments_inner(
+                        &ife.else_stmts,
+                        path,
+                        bus_ports,
+                        cond_stack,
+                        &mut else_written,
+                    );
                     cond_stack.pop();
+                    // Only promote names written on BOTH arms — mutually
+                    // exclusive paths don't guarantee each other's writes.
+                    *written = then_written.intersection(&else_written).cloned().collect();
                 }
                 Stmt::Match(m) => {
                     let mut scrut_ids = HashSet::new();
                     collect_expr_idents_bus(&m.scrutinee, bus_ports, &mut scrut_ids);
                     cond_stack.push(scrut_ids);
+                    let mut arm_written: Option<HashSet<String>> = None;
                     for arm in &m.arms {
-                        self.scan_assignments_inner(&arm.body, path, bus_ports, cond_stack);
+                        let mut aw = written.clone();
+                        self.scan_assignments_inner(
+                            &arm.body, path, bus_ports, cond_stack, &mut aw,
+                        );
+                        arm_written = Some(match arm_written {
+                            Some(acc) => acc.intersection(&aw).cloned().collect(),
+                            None => aw,
+                        });
                     }
                     cond_stack.pop();
+                    if let Some(merged) = arm_written {
+                        *written = merged;
+                    }
                 }
                 Stmt::For(f) => {
-                    self.scan_assignments_inner(&f.body, path, bus_ports, cond_stack);
+                    // Loop trip count isn't evaluated here; treat the body as
+                    // branch-local so a write inside it never gets promoted.
+                    let mut body_written = written.clone();
+                    self.scan_assignments_inner(
+                        &f.body,
+                        path,
+                        bus_ports,
+                        cond_stack,
+                        &mut body_written,
+                    );
                 }
                 _ => {}
             }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -26632,6 +26632,149 @@ fn test_comb_loop_fsm_output_default_expr_deps_included() {
     );
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Pre-req for arch#709 follow-up (promotion of the whole-design comb-loop
+// warning to an error): a same-comb-block sequential-fold reduction
+// (`x = <identity>; x = x <op> t0; x = x <op> t1; …`, the exact shape the
+// `shared(or)`/`shared(and)` thread lowering emits into one `always_comb`)
+// is last-write-wins blocking-assignment dataflow, NOT hardware feedback —
+// `scan_assignments_inner` must not fabricate a self-edge for an in-block
+// read-after-write. A read-BEFORE-any-in-block-write of the same signal is
+// still a genuine self-dependency and must still be flagged.
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_comb_loop_inblock_read_after_write_fold_not_flagged() {
+    // Minimal hand-written repro of the fold shape (identity default, then
+    // two guarded `x = x <op> in;` re-assignments to the SAME wire, nested
+    // in independent `if` blocks — exactly what the shared(or) thread
+    // lowering emits). No earlier version of this check should warn; this
+    // pins the fix.
+    let source = r#"
+        module M
+          port c0: in UInt<1>;
+          port c1: in UInt<1>;
+          port i0: in UInt<1>;
+          port i1: in UInt<1>;
+          port o: out UInt<1>;
+          wire x: UInt<1>;
+          comb
+            x = 0;
+            if c0
+              x = x or i0;
+            end if
+            if c1
+              x = x or i1;
+            end if
+            o = x;
+          end comb
+        end module M
+    "#;
+    let ws = comb_loop_warnings(source);
+    let cycle_msgs: Vec<_> = ws
+        .iter()
+        .filter(|m| m.contains("combinational feedback cycle ("))
+        .collect();
+    assert!(
+        cycle_msgs.is_empty(),
+        "sequential in-block fold (x = 0; x = x or i0; x = x or i1;) is \
+         blocking-assignment dataflow, not feedback — must not warn; got: {:?}",
+        ws
+    );
+}
+
+#[test]
+fn test_comb_loop_read_before_first_inblock_write_still_flagged() {
+    // Dual of the above: `x` is read on the RHS of its OWN first (and only)
+    // assignment in the block, with no earlier write establishing an
+    // in-block value. There is no register to break this dependency on
+    // itself — a genuine combinational self-loop that must still warn.
+    let source = r#"
+        module M
+          port i: in UInt<1>;
+          port o: out UInt<1>;
+          wire x: UInt<1>;
+          comb
+            x = x and i;
+            o = x;
+          end comb
+        end module M
+    "#;
+    let ws = comb_loop_warnings(source);
+    let cycle_msgs: Vec<_> = ws
+        .iter()
+        .filter(|m| m.contains("combinational feedback cycle ("))
+        .collect();
+    assert!(
+        !cycle_msgs.is_empty(),
+        "x = x and i; with no earlier in-block write of x is a genuine \
+         self-loop and must still be flagged; got: {:?}",
+        ws
+    );
+}
+
+#[test]
+fn test_comb_loop_mutually_exclusive_branch_write_not_promoted() {
+    // A write to `x` in ONE arm of an if/else must NOT be treated as
+    // "already written" for a self-read of `x` in the OTHER (mutually
+    // exclusive) arm — that read sees x's pre-block value on the path
+    // where the write-arm did not execute, which is a genuine self-loop.
+    // Guards against an unsound over-generalization of the fold fix.
+    let source = r#"
+        module M
+          port c: in UInt<1>;
+          port i: in UInt<1>;
+          port o: out UInt<1>;
+          wire x: UInt<1>;
+          comb
+            if c
+              x = i;
+            else
+              x = x and i;
+            end if
+            o = x;
+          end comb
+        end module M
+    "#;
+    let ws = comb_loop_warnings(source);
+    let cycle_msgs: Vec<_> = ws
+        .iter()
+        .filter(|m| m.contains("combinational feedback cycle ("))
+        .collect();
+    assert!(
+        !cycle_msgs.is_empty(),
+        "else-arm reads x with no write on that path (the then-arm's write \
+         is on a mutually exclusive path) — must still be flagged; got: {:?}",
+        ws
+    );
+}
+
+#[test]
+fn test_shared_reduction_fixtures_have_no_comb_loop_false_positive() {
+    // End-to-end regression on the two real fixtures that surfaced this
+    // false positive in the pre-#775 full-corpus warning sweep: threads
+    // driving a `shared(or)`/`shared(and)` port lower to a sequential fold
+    // inside one always_comb block in the synthesized `_threads` submodule
+    // ("_threads.r_ready -> _threads.r_ready" / "...all_ready -> ..."),
+    // which is not real hardware feedback.
+    for source in [
+        include_str!("thread/shared_reduction.arch"),
+        include_str!("thread/shared_and_reduction.arch"),
+    ] {
+        let ws = comb_loop_warnings(source);
+        let cycle_msgs: Vec<_> = ws
+            .iter()
+            .filter(|m| m.contains("combinational feedback cycle ("))
+            .collect();
+        assert!(
+            cycle_msgs.is_empty(),
+            "shared-reduction thread lowering must not fabricate a comb-loop \
+             warning from its in-block fold; got: {:?}",
+            ws
+        );
+    }
+}
+
 // ─── multicycle reg annotation (Phase A) ─────────────────────────────────────
 //
 // Parse + AST + SDC emission only. Phase B will add input-feeding-tree


### PR DESCRIPTION
## Summary

Pre-req for promoting the whole-design combinational-feedback-cycle
warning to an error (arch#709 follow-up intent — **promotion itself is
NOT in this PR**, it needs maintainer sign-off after the inventory
below). arch#709 (tight-loop lock comb cycle) was fixed by #775; this
PR fixes a second, unrelated false-positive class a pre-#775
full-corpus sweep found, then re-sweeps the whole corpus post-#775 +
post-this-fix to build the complete inventory promotion would need.

- `tests/thread/shared_reduction.arch` and `shared_and_reduction.arch`
  warn `whole-design combinational feedback cycle (1 nodes):
  _threads.r_ready -> _threads.r_ready`. Threads driving a
  `shared(or)`/`shared(and)` port lower to a **sequential fold inside
  ONE `always_comb` block** in the synthesized `_threads` submodule:

  ```systemverilog
  always_comb begin
    r_ready = 0;
    if (_t0_state == _t0_S0_wait_until) r_ready = r_ready | 1;
    if (_t1_state == _t1_S0_wait_until) r_ready = r_ready | 1;
  end
  ```

  Last-write-wins blocking-assignment dataflow — not hardware
  feedback. The whole-design comb graph (`src/comb_graph.rs`)
  over-approximated by adding a self-edge whenever a signal appeared
  on both sides of its own assignment, regardless of whether an
  earlier statement in the same block already gave it an in-block
  value.

## Fix design (Task A)

`GraphBuilder::scan_assignments_inner` now threads a `written:
HashSet<String>` alongside the existing `cond_stack`, tracking — in
the block's sequential order — which LHS names are **definitely**
assigned by an earlier statement reached so far in the same scope.

- A self-read (`id == lhs`, on the RHS or via an enclosing
  `if`/`match` condition) of a name already in `written` is the
  in-block blocking-assignment value, not a dependency on the signal's
  own external/previous value → **no edge**.
- A self-read with **no** earlier in-block write is still a genuine
  self-dependency (nothing breaks the cycle) → **edge is still added**.
  This is the whole fix: read-before-first-write vs. read-after-write.
- Promotion across control flow is deliberately conservative (favor
  still emitting the edge over silently dropping a real one): a name
  is promoted out of an `if`/`else` only when **both** arms wrote it
  (a bare `if` with no `else` promotes nothing — same as the
  empty-else case falling out of the then/else intersection); out of
  a `match` only when **every** arm wrote it. Writes inside a `for`
  body are treated as branch-local and never promoted to the
  enclosing scope (the loop bound isn't evaluated at this pass, and
  `for` bodies bring in an unrelated, bigger false-positive class —
  see #780).

### Test evidence (both directions)

`tests/integration_test.rs`:

- `test_comb_loop_inblock_read_after_write_fold_not_flagged` — the
  fold shape (`x = 0; if c0 x = x or i0; if c1 x = x or i1;`) no
  longer warns.
- `test_comb_loop_read_before_first_inblock_write_still_flagged` —
  `x = x and i;` as the first (only) statement, no earlier write, still
  warns.
- `test_comb_loop_mutually_exclusive_branch_write_not_promoted` — a
  write to `x` in ONE if/else arm must not suppress a self-read of `x`
  in the OTHER (mutually exclusive) arm; guards the conservative
  promotion logic against being over-generalized (this is exactly the
  distinction the prompt's caution called out).
- `test_shared_reduction_fixtures_have_no_comb_loop_false_positive` —
  end-to-end: both real fixtures now produce zero comb-loop warnings.

Scope: `comb_graph.rs` only, purely an internal diagnostic fix — no
grammar/semantics change, no doc update required.

## Task B — #709 class verified gone post-#775

Fresh `target/release/arch` build on current `main` (this branch is
rebased on top of #777/#778, i.e. current `main` tip at push time).

```
$ arch check tests/axi_dma_thread/ThreadS2mm.arch
OK: no errors
$ arch check tests/axi_dma_thread/ThreadMm2s.arch
OK: no errors
```

Both compile and build (`arch build`) with **zero** warnings — the
`b_ready`/`r_ready` lock-arbiter self-cycle #775 fixed does not
recur. (Aside, out of scope: the checked-in `tests/axi_dma_thread/*.sv`
reference files are stale relative to their `.arch` sources — predates
this branch, unrelated to comb-graph work, not touched here.)

**Full-corpus sweep** (`tools/run_arch_regression.py`, `--skip-verilator
--skip-sim --skip-sim-compile`, stderr logs kept):

- Curated baseline (`tests/arch_regression_baseline.json`, 187 units,
  179 discovered/ran): **zero** `combinational feedback` hits.
- Full discovery (no `--baseline`, all 655 units under `tests/`, incl.
  directories the curated baseline doesn't cover — `backend_equiv`,
  `cvdp`, `e203`, etc.): **9 units** still emit the warning. None match
  the #709 shape (a lock/arbiter `*_ready` single-node self-cycle) —
  confirming #709's own class is fully gone. The 9 are cataloged below;
  none are fixed by this PR (different root causes — see Task C).

## Task C — Fx3ThreadVecParamW characterization

**The originally-cited fixture does not reproduce.**
`tests/backend_equiv/Fx3ThreadVecParamW.arch` produces **zero**
comb-loop warnings on current `main`, both standalone and grouped with
all 25 sibling `backend_equiv/*.arch` files (the way
`tools/run_arch_regression.py`'s directory-grouping runs them). It also
has **zero** occurrences of a signal literally named `m` anywhere in
its source — it is structurally incapable of producing an `m -> o -> m`
cycle.

The fixture that actually produces that exact warning shape is a
different file in the same directory: **`Fx9MiniFabric.arch`** (`port
m: target Vec<BusVr<...>, LANES>`, `port o: initiator
Vec<BusVr<...>, LANES>`) — `combinational feedback cycle (2 nodes): o
-> m -> o`. Given #755 (merged before this work started) specifically
fixed a nondeterministic cross-top-level-module misattribution bug of
this exact shape ("blamed on `ModB`" when the real cycle was in a
sibling module), the most likely explanation is the original
pre-#775-sweep observation was made against a pre-#755 (or otherwise
stale) binary and picked up that misattribution. Not chasing this
further — `Fx3ThreadVecParamW.arch` itself is clean today either way.

**Verdict on the real fixture (`Fx9MiniFabric.arch`): over-approximation,
NOT real hardware feedback.**

- Generated SV: `m_ready[i] = o_ready[i]; o_valid[i] = m_valid[i];
  o_data[i] = m_data[i];` for `i` in `0..LANES-1` — six genuinely
  distinct flattened signals (`m_ready`, `m_valid`, `m_data`,
  `o_ready`, `o_valid`, `o_data`), straight-line, no real loop.
- `verilator --lint-only --top-module Fx9MiniFabric` on the generated
  SV: **zero `UNOPTFLAT`** warnings.
- Root cause: `collect_expr_idents_bus`/`lhs_base_name_bus`'s
  bus-field-qualification only recognizes `FieldAccess(Ident(port),
  field)` — a bare bus port — not `FieldAccess(Index(Ident(port), i),
  field)`, a `Vec<Bus,N>` **element** field access. So `m[i].ready`,
  `m[i].valid`, `o[i].ready`, `o[i].valid` all collapse to two
  whole-port nodes `m`/`o`, fabricating the cross-field cycle.

**Different root cause from Task A** (Vec-of-Bus element/field
granularity vs. same-node statement-order read-after-write) → **not**
fixed in this PR. Filed as **#780**, alongside 6 more fixtures the
full-corpus sweep turned up sharing the same broader "Vec-index /
bit-slice / `for`-loop-iteration granularity is not modeled" family
(`gf_mul8`, `cvdp_prbs_gen`, `onebit_ecc` + `sipo_top`, `prim_max_find`,
`programmable_interrupt_controller`, `t_hamming_tx`) — all individually
confirmed over-approximations via the same Verilator-lint-shows-zero-
UNOPTFLAT method.

**One more finding, unrelated to any of the above: a REAL bug.**
`tests/e203/e203_ifu_ifetch.arch` + `e203_ifu_ift2icb.arch` (grouped
under `e203_ifu`) show an 8-node cycle. Unlike everything above,
Verilator's own `UNOPTFLAT` **fires** on the generated SV
(`Circular combinational logic: 'e203_ifu.ifu_req_ready_w'`, path
through `icb.stall_pipe` / `ifetch.ifu_rsp2ir_ready`) — a genuine
combinational coupling between `ifu_req_ready` and `ifu_rsp_ready`
across the two instances. Per repo convention this is a live
design-correctness finding, not something to fix inside this PR (would
need E203 IFU/ICB protocol context to know which signal was meant to
be registered) or paper over with a pragma. Filed as **#781**.

## Promotion blast radius

**Not zero.** If the whole-design comb-loop warning became an error
today (after this PR, on current `main`), the following would newly
hard-fail `arch check`/`arch build`:

| Fixture | Cause | Tracking |
|---|---|---|
| `tests/backend_equiv/Fx9MiniFabric.arch` | Vec-of-Bus field granularity | #780 |
| `tests/cvdp/gf_mul8.arch` | Vec-index granularity | #780 |
| `tests/cvdp/cvdp_prbs_gen.arch` | bit-slice granularity | #780 |
| `tests/cvdp/onebit_ecc.arch` (+ `sipo_top.arch` via inst) | bit-slice granularity | #780 |
| `tests/cvdp/prim_max_find.arch` | `for`-loop iteration + cond_stack | #780 |
| `tests/cvdp/programmable_interrupt_controller.arch` | `for`-loop iteration + cond_stack | #780 |
| `tests/cvdp/t_hamming_tx.arch` | bit-slice granularity | #780 |
| `tests/e203/e203_ifu_ifetch.arch` + `e203_ifu_ift2icb.arch` | **REAL** feedback loop | #781 |

8 fixture files (9 counting the `sipo_top` duplicate attribution) block
promotion — 7 need a checker fix (#780), 1 needs an actual design fix
(#781, and is same-day-review priority once someone picks it up per
repo convention for live bugs). This PR's fix does eliminate the two
fixtures it targeted (`shared_reduction.arch`,
`shared_and_reduction.arch`) plus confirms arch#709's own class is
fully gone — promotion is closer but still blocked on #780 and #781.

## Fast gate

- `cargo build --release` — clean.
- `cargo fmt --check` — clean.
- `cargo clippy --release --all-targets` — no new warnings (repo's
  clippy CI is errors-only / deny-level-lints-only; this PR introduces
  none).
- `cargo test --release` — full suite green (762 `integration_test` +
  23 `formal_test`, incl. the 2 Lean construct-proof replay tests after
  `lake build` in `proofs/lean_thread_lowering`, + all other binaries).

Ref #709 (already closed; referenced for context on the pending
promotion, not closed by this PR). See #780 and #781 for the follow-up
work promotion is actually blocked on.
