### PR TITLE
fix(fp): negative float literals now context-type in narrow slots

### DIFF
--- a/src/elaborate/mod.rs
+++ b/src/elaborate/mod.rs
@@ -907,6 +907,24 @@ fn coerce_narrow_reset(reset: &mut RegReset, fmt: FloatLitFmt, errors: &mut Vec<
 /// largest finite is a compile error (runtime overflow behavior depends on
 /// `--fp-compat`, so a source constant must not fold profile-dependently).
 fn coerce_narrow_lit(e: &mut Expr, fmt: FloatLitFmt, errors: &mut Vec<CompileError>) {
+    // Negative literals: `-1.5` parses as Neg(Float). Fold the sign into
+    // the value and coerce the whole node (the encoders carry the sign in
+    // the bit pattern), so `let x: BF16 = -1.5;`, `reset rst => -1.0`, and
+    // range assumes like `a >= -1.0` all context-type.
+    if let ExprKind::Unary(crate::ast::UnaryOp::Neg, inner) = &e.kind {
+        if let ExprKind::Literal(LitKind::Float(bits)) = &inner.kind {
+            let bits = *bits;
+            let mut folded = Expr::new(
+                ExprKind::Literal(LitKind::Float((-f64::from_bits(bits)).to_bits())),
+                e.span,
+            );
+            coerce_narrow_lit(&mut folded, fmt, errors);
+            if matches!(folded.kind, ExprKind::Literal(LitKind::TypedFloat(_, _))) {
+                *e = folded;
+            }
+            return;
+        }
+    }
     if let ExprKind::Literal(LitKind::Float(bits)) = &e.kind {
         let v = f64::from_bits(*bits);
         let rounded: Option<u64> = match fmt {

--- a/tests/fp_test.rs
+++ b/tests/fp_test.rs
@@ -1829,3 +1829,28 @@ fn fp_bound_err_builtins_fenced() {
         "error should say it's a spec builtin"
     );
 }
+
+/// Negative float literals context-type in narrow slots: `-1.5` parses as
+/// Neg(Float) and previously never coerced anywhere (typed let, reset,
+/// compares, range assumes all errored with "expected BF16, found FP32").
+#[test]
+fn fp_negative_literal_coercion() {
+    let src = "module NegLit\n  port clk: in Clock<Sys>;\n  port rst: in Reset<Sync>;\n  port a: in FP8E4M3;\n  port o: out BF16;\n  port g: out Bool;\n  let x: BF16 = -1.5;\n  reg r: BF16 reset rst => -0.5;\n  seq on clk rising\n    r <= r;\n  end seq\n  comb o = x + r; end comb\n  comb g = a >= -1.0; end comb\nend module NegLit\n";
+    let td = tempfile::tempdir().expect("tempdir");
+    let path = td.path().join("NegLit.arch");
+    std::fs::write(&path, src).unwrap();
+    let out = arch()
+        .arg("build")
+        .arg(&path)
+        .output()
+        .expect("run arch build");
+    assert!(
+        out.status.success(),
+        "negative narrow literals must coerce:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let sv = std::fs::read_to_string(td.path().join("NegLit.sv")).unwrap();
+    for needle in ["16'hBFC0", "16'hBF00", "arch_e4m3_ge(a, 8'hB8)"] {
+        assert!(sv.contains(needle), "missing `{needle}`:\n{sv}");
+    }
+}


### PR DESCRIPTION
## Summary

`-1.5` parses as `Neg(Float)` and the narrow-literal coercer only matched bare literals — so **negative literals never context-typed in any narrow-float slot** (typed `let`, reg `reset`, compares, `assume` ranges), erroring with `expected BF16, found FP32`. Latent since the original BF16 context-typed-literal work; surfaced writing `assume a >= -1.0` for the fp8 add-associativity error-bound analysis.

### Fix
One arm at the single choke point (`coerce_narrow_lit`): fold the sign into the value and coerce the whole unary node — the CR encoders already carry signs in the bit pattern, and overflow diagnostics are preserved (`-500.0` on E4M3 still rejects).

### Verification
- New `fp_negative_literal_coercion` test pins the emitted patterns for all three slot shapes: `let x: BF16 = -1.5` → `16'hBFC0`, `reset rst => -0.5` → `16'hBF00`, `a >= -1.0` → `arch_e4m3_ge(a, 8'hB8)`.
- Fast gate green before PR: **944 passed, 0 failed**.
- No doc change needed: the spec already documents negative literals as legal in these slots — this makes reality match it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)