### PR TITLE
fix(formal): counterexamples blamed the wrong cycle for float properties

### DIFF
--- a/src/formal.rs
+++ b/src/formal.rs
@@ -3369,10 +3369,8 @@ impl<'a> FormalCtx<'a> {
                 unreachable!("assumes are hypotheses, filtered before run_property")
             }
         };
-        let disjuncts: Vec<String> = per_cycle
-            .iter()
-            .enumerate()
-            .map(|(_i, p)| format!("(= {p} {matcher})"))
+        let disjuncts: Vec<String> = (0..per_cycle.len())
+            .map(|i| format!("(= __prop_{} {matcher})", min_t + i as u32))
             .collect();
         let assertion = if disjuncts.len() == 1 {
             disjuncts.into_iter().next().unwrap()
@@ -3380,13 +3378,23 @@ impl<'a> FormalCtx<'a> {
             format!("(or {})", disjuncts.join(" "))
         };
 
-        // Compose final SMT text
+        // Compose final SMT text. Each cycle's property bit is bound to a
+        // named constant `__prop_<t>` so the failing cycle can be read
+        // directly from the solver model — the numeric evaluator cannot
+        // evaluate float-helper applications, and guessing from inputs
+        // rendered the WRONG cycle's (arbitrary) values as counterexamples.
         let mut smt = String::with_capacity(base.len() + 256);
         smt.push_str(base);
         smt.push_str(&format!(
             "\n; ── property `{}` ({:?}) ──\n",
             prop.name, prop.kind
         ));
+        for (i, p) in per_cycle.iter().enumerate() {
+            let t = min_t + i as u32;
+            smt.push_str(&format!(
+                "(declare-fun __prop_{t} () (_ BitVec 1))\n(assert (= __prop_{t} {p}))\n"
+            ));
+        }
         smt.push_str(&format!("(assert {assertion})\n"));
         smt.push_str("(check-sat)\n");
         // We always emit get-model; the solver will ignore it on unsat/unknown for most tools.
@@ -4315,11 +4323,21 @@ fn find_first_failing_cycle(
     if min_t > max_t {
         return min_t.min(bound);
     }
+    // Primary: the named per-cycle property bits from the model.
     for t in min_t..=max_t {
-        let v = eval_expr_numeric(expr, t, ctx, assignments).unwrap_or(0);
-        let bit = v & 1;
-        if bit == target_bit {
-            return t;
+        if let Some(v) = assignments.get(&format!("__prop_{t}")) {
+            if (v & 1) == target_bit {
+                return t;
+            }
+        }
+    }
+    // Fallback (older models without the named bits): numeric evaluation —
+    // skip cycles the evaluator cannot decide instead of claiming them.
+    for t in min_t..=max_t {
+        if let Some(v) = eval_expr_numeric(expr, t, ctx, assignments) {
+            if (v & 1) == target_bit {
+                return t;
+            }
         }
     }
     max_t

--- a/tests/fp_test.rs
+++ b/tests/fp_test.rs
@@ -1854,3 +1854,58 @@ fn fp_negative_literal_coercion() {
         assert!(sv.contains(needle), "missing `{needle}`:\n{sv}");
     }
 }
+
+/// Certified no-saturation: with range assumes the E4M3 narrowing property
+/// `!is_nan(y_w)` PROVES (overflow unreachable — riscv maps overflow to
+/// NaN); with the assumes stripped it REFUTES. Locks the assume-constrained
+/// overflow-certification pattern end-to-end. z3-gated.
+#[test]
+fn fp_formal_no_saturation_certified() {
+    fn z3_available() -> bool {
+        std::process::Command::new("z3")
+            .arg("--version")
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+    }
+    if !z3_available() {
+        eprintln!("skipping fp_formal_no_saturation_certified: z3 not in PATH");
+        return;
+    }
+    let run = |src: &str| -> (bool, String) {
+        let td = tempfile::tempdir().expect("tempdir");
+        let path = td.path().join("M.arch");
+        std::fs::write(&path, src).unwrap();
+        let out = arch()
+            .arg("formal")
+            .arg(&path)
+            .arg("--solver")
+            .arg("z3")
+            .arg("--bound")
+            .arg("2")
+            .output()
+            .expect("run arch formal");
+        let all = format!(
+            "{}{}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        );
+        (out.status.success(), all)
+    };
+    let src = std::fs::read_to_string("tests/fp_v1/FpNoSat.arch").unwrap();
+    let (ok, all) = run(&src);
+    assert!(
+        ok && all.contains("PROVED"),
+        "constrained no-sat must prove:\n{all}"
+    );
+    let stripped: String = src
+        .lines()
+        .filter(|l| !l.trim_start().starts_with("assume"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let (ok, all) = run(&stripped);
+    assert!(
+        !ok && all.contains("REFUTED"),
+        "unconstrained must refute:\n{all}"
+    );
+}

--- a/tests/fp_v1/FpNoSat.arch
+++ b/tests/fp_v1/FpNoSat.arch
@@ -1,0 +1,26 @@
+// Certified absence of narrowing overflow: under the riscv profile E4M3
+// overflow -> NaN 0x7F, so `!is_nan` == "the narrow never saturates".
+// With the range assumes the property PROVES (|sum| <= 256 < 480);
+// without them it REFUTES with a genuine counterexample (NaN input or an
+// overflowing pair). Also the regression fixture for the failing-cycle
+// fix: pre-fix, float asserts always blamed cycle 0 and rendered that
+// cycle's arbitrary model values as the counterexample.
+module FpNoSat
+  port clk: in Clock<Sys>;
+  port rst: in Reset<Sync>;
+  port qa: in FP8E4M3;
+  port qb: in FP8E4M3;
+  port y: out FP8E4M3;
+  wire acc: FP32;
+  wire y_w: FP8E4M3;
+  comb acc = qa.to_fp32() + qb.to_fp32(); end comb
+  comb y_w = acc.to_fp8e4m3(); end comb
+  comb y = y_w; end comb
+
+  assume qa_rng: (qa >= -128.0) and (qa <= 128.0);
+  assume qb_rng: (qb >= -128.0) and (qb <= 128.0);
+
+  // riscv profile: E4M3 narrowing overflow produces NaN 0x7F, so
+  // "never NaN" == "the narrow never saturates" — certified.
+  assert no_sat: !is_nan(y_w);
+end module FpNoSat


### PR DESCRIPTION
## Summary

Found while running the certified-no-overflow example for the paper: a refuted float property printed a **counterexample that provably satisfies the property** (`qa=qb=0xC0`, i.e. −2 + −2 = −4 — pinning those values makes the property PROVE).

### Root cause
`find_first_failing_cycle` evaluates the property against the model numerically and treats *cannot evaluate* (`unwrap_or(0)`) as *fails here*. The numeric evaluator can't evaluate float-helper applications, so every refuted float assert claimed **cycle 0** and rendered that cycle's arbitrary (non-violating) model values.

### Fix
Bind each unrolled cycle's property bit to a named constant (`__prop_<t>`) in the query and read the failing cycle **directly from the solver model**. The numeric path stays as a fallback but now skips undecidable cycles instead of claiming them. Post-fix the same probe reports a genuine counterexample (−448 + −52 = −500 > the OCP overflow threshold 480; unconstrained variant finds `qa=0x7F`, the E4M3 NaN itself).

**Verdicts were never affected** — PROVED/REFUTED come from the solver's sat/unsat; this is a diagnostics-correctness fix.

### Also adds
`FpNoSat.arch` + `fp_formal_no_saturation_certified` (z3-gated): the assume-constrained overflow-certification pattern — `!is_nan(y_w)` under the riscv profile **PROVES** narrowing never saturates for stated ranges, and **REFUTES** without them. This is the paper's worked example.

### Verification
Fast gate green before PR: **945 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)