### PR TITLE
test(comb-graph): pin union-grounding fold path against Verilator (#780 follow-up)

### DIFF
--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -26750,6 +26750,91 @@ fn test_comb_loop_mutually_exclusive_branch_write_not_promoted() {
 }
 
 #[test]
+fn test_cond_only_grounded_fold_not_flagged_and_verilator_confirms_acyclic() {
+    // arch#780, NEGATIVE direction: a self-fold (`p = q +% p;`) whose ONLY
+    // prior establishment of `p` is a CONDITIONAL, single-arm write
+    // (`if c: p = 8; end if`) read AFTER the `if` must NOT be flagged. The
+    // grounding here flows solely through `ever_written`'s UNION across the
+    // if/else arms (src/comb_graph.rs); it is the one #780 shape that
+    // distinguishes union grounding from intersection — every other
+    // "not flagged" fold fixture grounds its accumulator with an
+    // UNCONDITIONAL init (`x = 0;`) that would survive an intersection
+    // merge too. This is the load-bearing companion to
+    // `test_comb_loop_mutually_exclusive_branch_write_not_promoted` (which
+    // pins the read-INSIDE-a-branch case as still flagged): here the read
+    // is AFTER the branch, where the union-merged grounding legitimately
+    // applies. If `ever_written` were ever "hardened" to intersect across
+    // arms, `p` would stop being grounded and this acyclic fold would
+    // regress to a FALSE POSITIVE — this test is the tripwire.
+    //
+    // Independently attested (not just an `arch check` self-opinion): the
+    // generated SV draws zero `UNOPTFLAT` from Verilator, because a
+    // blocking-assigned-before-read variable inside one `always_comb` is a
+    // local sequential value, not a module-net self-dependency — exactly
+    // the semantics the fold-artifact filter models.
+    let arch_bin = env!("CARGO_BIN_EXE_arch");
+    let src = "tests/regression/issues/cond_fold_grounded_780/CondFoldGrounded.arch";
+
+    let check = std::process::Command::new(arch_bin)
+        .arg("check")
+        .arg(src)
+        .output()
+        .expect("run arch check");
+    let check_stderr = String::from_utf8_lossy(&check.stderr);
+    assert!(
+        !check_stderr.contains("combinational feedback cycle ("),
+        "conditional-only grounded fold must NOT be flagged as a comb \
+         cycle (union grounding); stderr:\n{check_stderr}"
+    );
+
+    if std::process::Command::new("verilator")
+        .arg("--version")
+        .output()
+        .is_err()
+    {
+        eprintln!(
+            "skipping Verilator acyclic cross-check for \
+             CondFoldGrounded: verilator not found"
+        );
+        return;
+    }
+
+    let td = tempfile::tempdir().expect("tempdir");
+    let sv_out = td.path().join("CondFoldGrounded.sv");
+    let build = std::process::Command::new(arch_bin)
+        .arg("build")
+        .arg(src)
+        .arg("-o")
+        .arg(&sv_out)
+        .output()
+        .expect("build CondFoldGrounded SV");
+    assert!(
+        build.status.success(),
+        "arch build should pass\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&build.stdout),
+        String::from_utf8_lossy(&build.stderr)
+    );
+
+    let lint = std::process::Command::new("verilator")
+        .arg("--lint-only")
+        .arg("--assert")
+        .arg("-Wno-fatal")
+        .arg("-Wno-DECLFILENAME")
+        .arg("--top-module")
+        .arg("CondFoldGrounded")
+        .arg(&sv_out)
+        .output()
+        .expect("verilate CondFoldGrounded");
+    let lint_stderr = String::from_utf8_lossy(&lint.stderr);
+    assert!(
+        !lint_stderr.contains("UNOPTFLAT"),
+        "Verilator must NOT report UNOPTFLAT — this fold is genuinely \
+         acyclic, confirming `arch check`'s silence is correct and not a \
+         missed real loop; stderr:\n{lint_stderr}"
+    );
+}
+
+#[test]
 fn test_shared_reduction_fixtures_have_no_comb_loop_false_positive() {
     // End-to-end regression on the two real fixtures that surfaced this
     // false positive in the pre-#775 full-corpus warning sweep: threads

--- a/tests/regression/issues/cond_fold_grounded_780/CondFoldGrounded.arch
+++ b/tests/regression/issues/cond_fold_grounded_780/CondFoldGrounded.arch
@@ -1,0 +1,39 @@
+// arch#780 regression anchor (NEGATIVE / not-a-loop direction): a signal
+// whose ONLY prior establishment is a CONDITIONAL, single-arm write —
+// union-merged out of the `if` into `ever_written` — and which is then
+// read after the `if` in a blocking self-fold (`p = q +% p;`) must NOT be
+// flagged as a combinational feedback cycle.
+//
+// This pins the "union, not intersection" claim in `ever_written`'s doc
+// comment (src/comb_graph.rs): every other #780 "not flagged" fixture
+// grounds its fold accumulator with an UNCONDITIONAL init before the read
+// (`x = 0;` / `m_val = 0;`), which survives an intersection merge too;
+// only THIS shape distinguishes union grounding from intersection. If
+// `ever_written` were ever "hardened" to intersect across arms, `p` would
+// stop being grounded here and this acyclic fold would regress to a false
+// positive.
+//
+// Independently attested as NOT a real loop (matching `arch check`'s
+// silence) via Verilator: `verilator --lint-only` on the generated SV
+// emits zero `UNOPTFLAT` — because a blocking-assigned-before-read
+// variable inside one `always_comb` is a local sequential value, not a
+// module-net self-dependency. See
+// test_cond_only_grounded_fold_not_flagged_and_verilator_confirms_acyclic
+// in tests/integration_test.rs.
+module CondFoldGrounded
+  port c: in Bool;
+  port qin: in UInt<8>;
+  port pout: out UInt<8>;
+
+  wire p: UInt<8>;
+  wire q: UInt<8>;
+
+  comb
+    q = qin;
+    if c
+      p = 8;
+    end if
+    p = q +% p;
+    pout = p;
+  end comb
+end module CondFoldGrounded


### PR DESCRIPTION
## Summary

Test-only follow-up to **#789** (the #780 fold-artifact filter). Adds a **Verilator-attested** regression test that fills the one coverage gap in that fix's most subtle, load-bearing path.

## The gap

`is_fold_artifact` suppresses a false comb-cycle warning when every SCC-internal edge is "grounded" — i.e. its source identifier is in `ever_written`. `ever_written` is a **union** across `if`/`else` arms (and propagates out of `for`). The soundness of union-not-intersection is argued in the `ever_written` doc comment, but **every existing "not flagged" fold fixture grounds its accumulator with an *unconditional* init** (`x = 0;`, `m_val = 0;`) — which survives an *intersection* merge too. So none of them actually exercise, or would catch a regression of, the union path.

## What the test pins

A self-fold whose **only** prior establishment of `p` is a **conditional single-arm write**, read *after* the `if`:

```arch
comb
  q = qin;
  if c
    p = 8;        // grounds p ONLY via the then-arm union
  end if
  p = q +% p;     // read AFTER the branch → union grounding applies
  pout = p;
end comb
```

Under the current (correct) union semantics `p` is grounded ⇒ not flagged. If `ever_written` were ever "hardened" to intersect across arms, `p` would stop being grounded and this acyclic fold would regress to a **false positive**. This test is the tripwire.

The test asserts both directions of ground truth:
- `arch check` stays silent (no `combinational feedback cycle`), **and**
- independently, `verilator --lint-only` draws **zero `UNOPTFLAT`** on the generated SV — confirming the fold is genuinely acyclic (a blocking-assigned-before-read variable in one `always_comb` is a local sequential value, not a module-net self-dependency, which is exactly the semantics the filter models).

It is the negative companion to the two existing anchors:
- `test_comb_loop_mutually_exclusive_branch_write_not_promoted` — read *inside* a branch → still flagged.
- `test_cross_instance_comb_loop_780_still_flagged_and_verilator_confirms_real` — real loop → flagged + UNOPTFLAT.

## Verification

- New test passes with Verilator present (attests acyclic) and skips cleanly when absent.
- Full `integration_test` target: **775 passed, 0 failed**.
- `cargo fmt --check` clean.
- Test-only change; **no compiler behavior modified**.

Found during the daily merged-PR review of #789. Not fixing a bug — hardening coverage of a just-landed, subtle correctness path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)