### PR TITLE
feat(check): promote whole-design combinational loops from warning to error

### DIFF
--- a/doc/ARCH_HDL_Specification.md
+++ b/doc/ARCH_HDL_Specification.md
@@ -1817,6 +1817,45 @@ end module M
 
 `pragma cdc_safe;` is the long-standing CDC opt-out and incidentally suppresses the structural cross-clock RDC rule (phase 1) because the two checks overlap. `pragma rdc_safe;` is the dedicated RDC opt-out — it suppresses *every* RDC phase, including 2a–2d which `cdc_safe` does not touch. Either pragma alone is enough to silence phase 1; both can coexist on the same module. Use these only when the design has been externally analysed (Synopsys SpyGlass, Cadence Conformal) and the violations are provably safe in the surrounding integration. Unknown pragma names error at parse time, so a typo on `rdc_safe` is caught before compile.
 
+**5.4a Whole-Design Combinational Feedback Loops**
+
+Beyond the per-module comb-loop check that computes a bounded simulation settle depth, the compiler runs a separate whole-design analysis: it builds one directed combinational-dependency graph spanning the *entire* elaborated design — starting from every top-level module (one never instantiated anywhere) and flattening the full instance hierarchy — and runs Tarjan's strongly-connected-components algorithm over it. Nodes are keyed by `(inst_path, signal)`, so the same signal name at different points in the hierarchy is never conflated. Any SCC with more than one node, or a single node with a self-loop, is a genuine combinational feedback cycle: a signal whose value depends — combinationally, with no register anywhere on the path — on itself.
+
+**This is a compile error.** `arch check`, `arch build`, `arch sim`, and `arch formal` all fail with a nonzero exit and report the cycle (the participating signals, in dependency order, and the modules that own them):
+
+```
+error: whole-design combinational feedback cycle (2 nodes) involving modules [Top]; cycle: w1 -> w2 -> w1
+```
+
+A combinational cycle has no well-defined steady-state value in general (it depends on gate delays, which ARCH's zero-delay semantics do not model) and synthesis tools flag the equivalent SV as `UNOPTFLAT`. There is no correct simulation or synthesis result to fall back to, so — like `Vec`/bit-select bounds violations and const-expression divide-by-zero — this is a hard error, not a lint.
+
+*(Severity history: this diagnostic shipped in 2026 as a warning while the checker's false-positive rate on real designs was being driven down — same-comb-block read-after-write folding, cross-instance port bugs, and range/element/for-loop granularity all produced spurious cycles early on. Once a full-corpus sweep showed zero remaining false positives on real designs, it was promoted to an error.)*
+
+**Escape hatch for intentional cycles: `pragma comb_loops_allowed;`**
+
+Some designs contain a combinational cycle on purpose — most commonly a caller that has already proven (by construction, or by external timing/formal analysis) that the loop settles within the available combinational budget, or a construct deliberately modeled with an idealized zero-delay feedback path. Bless the owning module:
+
+```
+module M
+  pragma comb_loops_allowed;
+  ...
+end module M
+```
+
+Any SCC that passes through an instance owned by a module carrying this pragma is suppressed — it does not fail the build, and does not appear as a per-cycle diagnostic. `arch check` still emits one informational summary line reporting the totals:
+
+```
+arch check: 1 comb SCC(s) found; 1 suppressed by pragma; 0 unblessed (warnings)
+```
+
+Suppression is whole-module, not per-signal-pair — there is no equivalent of `pragma comb_loop a, b;` scoped to a specific signal pair; blessing a module blesses every cycle that touches any of its instances. Use it sparingly and only once the cycle has been independently verified safe (e.g. via `arch formal`, or an external STA/lint pass) — a design that legitimately needs the pragma is rare, and the pragma is a documented escape hatch, not a general-purpose suppression for diagnosing false positives (a false positive should be filed as a compiler bug instead).
+
+**Scope and known limitations:**
+
+- **Interface-only (`.archi`) stub modules are treated as opaque:** every output is assumed to depend on every input except registered (`port reg` / `pipe_reg`) outputs, which are correctly excluded since a register breaks the combinational path. This is a safe over-approximation — it can produce a cycle report when the real (unseen) module body is actually pipelined — but never misses a real cycle.
+- **Non-`module`/non-`fsm` constructs** (`fifo`, `ram`, `arbiter`, etc.) use a per-output dependency map where available (arbiters, for example, correctly model that the grant/`ready` outputs depend combinationally on the request `valid` inputs); constructs without a precise per-output map fall back to the same conservative port-set over-approximation as interface stubs.
+- **No per-signal-pair blessing.** The pragma is module-scoped only, as described above.
+
 **5.5 Tristate and Bidirectional I/O** *(planned)*
 
 Inside a chip, all signals are unidirectional. Tristate (high-impedance) behavior only exists at the **pad ring** — the boundary between the chip and the outside world. Common examples include I2C (open-drain SDA/SCL), bidirectional data buses, and GPIO pins.

--- a/doc/COMPILER_STATUS.md
+++ b/doc/COMPILER_STATUS.md
@@ -1,6 +1,6 @@
 # ARCH Compiler — Status & Roadmap
 
-> Last updated: 2026-07-27
+> Last updated: 2026-08-06
 > Compiler version: 0.71.0
 >
 > **0.71.0 release highlights:**
@@ -8,6 +8,8 @@
 > - **`--staged-ops`: staged SV emission for pipelined operators** (#720, proposal phase 3.5) — `arch build --staged-ops` emits pipelined operators (e.g. `fma<pipelined, N>`) as a per-stage registered pipeline instead of the default combinational cascade, letting downstream synthesis meet timing without manual retiming. Unsupported staging shapes such as falling-edge clocks, conditional call sites, and arity/schedule mismatches fall back to the cascade lowering with a warning. Nested latency-bearing pipelined calls are rejected during type checking because treating the inner call as combinational would discard its latency (#732). Default emission (no flag) is unchanged.
 > - **`arch sim --debug` covers all non-module constructs** (#725) — port-change logging under `--debug` now fires for `fsm`, `pipeline`, `fifo`, `ram`, `arbiter`, `thread`, and `bus`-bearing constructs, not just plain `module`s, so I/O tracing works uniformly across the construct set.
 > - **Formal FP verification — end-to-end value semantics + renderer faithfulness** (#722, #723, #728, #729) — `arch_fma_f32` is proved in Lean to be the round-to-nearest-even of the exact real product-sum `a·b+c` (R1–R3), and SMT renderer-faithfulness miters prove the emitted SystemVerilog is bit-equivalent to `render_smt` for all FP operators including both FMAs and the integer conversions (24/24 unsat). The RTL and the formally-checked model render from one in-Rust IR, so they cannot drift.
+>
+> **2026-08-06:** Whole-design combinational feedback-loop detection (issue #246) promoted from warning to **error** — `arch check`/`build`/`sim`/`formal` now all fail with a nonzero exit when an unblessed comb-SCC is found, instead of succeeding with a warning. The diagnostic shipped as a warning while its false-positive rate on real designs was being driven down (#783 in-block read-after-write folding, #785 the one genuine real-design loop found in the E203 IFU corpus — a port bug, independently fixed, not a checker artifact — and #789 range/element/for-loop granularity); a fresh full-corpus sweep immediately before the flip showed zero remaining false positives on real designs, with only a dedicated synthetic regression fixture (`tests/regression/issues/cross_instance_comb_loop_780/`) still triggering it. The `pragma comb_loops_allowed;` escape hatch for intentionally cyclic designs is unchanged and stays non-fatal. See `doc/ARCH_HDL_Specification.md` §5.4a for the full write-up (newly added — this diagnostic and its pragma had no dedicated spec section before this change).
 >
 > **0.70.8 release highlights:**
 > - **Typed FP parameters and constant evaluation** (#693, #694, #700) — module-scope FP wires and typed FP local parameters now resolve consistently in SystemVerilog and native simulation, including compile-time integer-to-FP conversion. This enables parameterized BF16-to-fixed conversion such as `local param SCALE_FP: FP32 = SCALE_INT.to_fp32();`.

--- a/skills/arch-programming/references/ARCH_HDL_Specification.md
+++ b/skills/arch-programming/references/ARCH_HDL_Specification.md
@@ -1817,6 +1817,45 @@ end module M
 
 `pragma cdc_safe;` is the long-standing CDC opt-out and incidentally suppresses the structural cross-clock RDC rule (phase 1) because the two checks overlap. `pragma rdc_safe;` is the dedicated RDC opt-out — it suppresses *every* RDC phase, including 2a–2d which `cdc_safe` does not touch. Either pragma alone is enough to silence phase 1; both can coexist on the same module. Use these only when the design has been externally analysed (Synopsys SpyGlass, Cadence Conformal) and the violations are provably safe in the surrounding integration. Unknown pragma names error at parse time, so a typo on `rdc_safe` is caught before compile.
 
+**5.4a Whole-Design Combinational Feedback Loops**
+
+Beyond the per-module comb-loop check that computes a bounded simulation settle depth, the compiler runs a separate whole-design analysis: it builds one directed combinational-dependency graph spanning the *entire* elaborated design — starting from every top-level module (one never instantiated anywhere) and flattening the full instance hierarchy — and runs Tarjan's strongly-connected-components algorithm over it. Nodes are keyed by `(inst_path, signal)`, so the same signal name at different points in the hierarchy is never conflated. Any SCC with more than one node, or a single node with a self-loop, is a genuine combinational feedback cycle: a signal whose value depends — combinationally, with no register anywhere on the path — on itself.
+
+**This is a compile error.** `arch check`, `arch build`, `arch sim`, and `arch formal` all fail with a nonzero exit and report the cycle (the participating signals, in dependency order, and the modules that own them):
+
+```
+error: whole-design combinational feedback cycle (2 nodes) involving modules [Top]; cycle: w1 -> w2 -> w1
+```
+
+A combinational cycle has no well-defined steady-state value in general (it depends on gate delays, which ARCH's zero-delay semantics do not model) and synthesis tools flag the equivalent SV as `UNOPTFLAT`. There is no correct simulation or synthesis result to fall back to, so — like `Vec`/bit-select bounds violations and const-expression divide-by-zero — this is a hard error, not a lint.
+
+*(Severity history: this diagnostic shipped in 2026 as a warning while the checker's false-positive rate on real designs was being driven down — same-comb-block read-after-write folding, cross-instance port bugs, and range/element/for-loop granularity all produced spurious cycles early on. Once a full-corpus sweep showed zero remaining false positives on real designs, it was promoted to an error.)*
+
+**Escape hatch for intentional cycles: `pragma comb_loops_allowed;`**
+
+Some designs contain a combinational cycle on purpose — most commonly a caller that has already proven (by construction, or by external timing/formal analysis) that the loop settles within the available combinational budget, or a construct deliberately modeled with an idealized zero-delay feedback path. Bless the owning module:
+
+```
+module M
+  pragma comb_loops_allowed;
+  ...
+end module M
+```
+
+Any SCC that passes through an instance owned by a module carrying this pragma is suppressed — it does not fail the build, and does not appear as a per-cycle diagnostic. `arch check` still emits one informational summary line reporting the totals:
+
+```
+arch check: 1 comb SCC(s) found; 1 suppressed by pragma; 0 unblessed (warnings)
+```
+
+Suppression is whole-module, not per-signal-pair — there is no equivalent of `pragma comb_loop a, b;` scoped to a specific signal pair; blessing a module blesses every cycle that touches any of its instances. Use it sparingly and only once the cycle has been independently verified safe (e.g. via `arch formal`, or an external STA/lint pass) — a design that legitimately needs the pragma is rare, and the pragma is a documented escape hatch, not a general-purpose suppression for diagnosing false positives (a false positive should be filed as a compiler bug instead).
+
+**Scope and known limitations:**
+
+- **Interface-only (`.archi`) stub modules are treated as opaque:** every output is assumed to depend on every input except registered (`port reg` / `pipe_reg`) outputs, which are correctly excluded since a register breaks the combinational path. This is a safe over-approximation — it can produce a cycle report when the real (unseen) module body is actually pipelined — but never misses a real cycle.
+- **Non-`module`/non-`fsm` constructs** (`fifo`, `ram`, `arbiter`, etc.) use a per-output dependency map where available (arbiters, for example, correctly model that the grant/`ready` outputs depend combinationally on the request `valid` inputs); constructs without a precise per-output map fall back to the same conservative port-set over-approximation as interface stubs.
+- **No per-signal-pair blessing.** The pragma is module-scoped only, as described above.
+
 **5.5 Tristate and Bidirectional I/O** *(planned)*
 
 Inside a chip, all signals are unidirectional. Tristate (high-impedance) behavior only exists at the **pad ring** — the boundary between the chip and the outside world. Common examples include I2C (open-drain SDA/SCL), bidirectional data buses, and GPIO pins.

--- a/skills/arch-programming/references/COMPILER_STATUS.md
+++ b/skills/arch-programming/references/COMPILER_STATUS.md
@@ -1,6 +1,6 @@
 # ARCH Compiler — Status & Roadmap
 
-> Last updated: 2026-07-27
+> Last updated: 2026-08-06
 > Compiler version: 0.71.0
 >
 > **0.71.0 release highlights:**
@@ -8,6 +8,8 @@
 > - **`--staged-ops`: staged SV emission for pipelined operators** (#720, proposal phase 3.5) — `arch build --staged-ops` emits pipelined operators (e.g. `fma<pipelined, N>`) as a per-stage registered pipeline instead of the default combinational cascade, letting downstream synthesis meet timing without manual retiming. Unsupported staging shapes such as falling-edge clocks, conditional call sites, and arity/schedule mismatches fall back to the cascade lowering with a warning. Nested latency-bearing pipelined calls are rejected during type checking because treating the inner call as combinational would discard its latency (#732). Default emission (no flag) is unchanged.
 > - **`arch sim --debug` covers all non-module constructs** (#725) — port-change logging under `--debug` now fires for `fsm`, `pipeline`, `fifo`, `ram`, `arbiter`, `thread`, and `bus`-bearing constructs, not just plain `module`s, so I/O tracing works uniformly across the construct set.
 > - **Formal FP verification — end-to-end value semantics + renderer faithfulness** (#722, #723, #728, #729) — `arch_fma_f32` is proved in Lean to be the round-to-nearest-even of the exact real product-sum `a·b+c` (R1–R3), and SMT renderer-faithfulness miters prove the emitted SystemVerilog is bit-equivalent to `render_smt` for all FP operators including both FMAs and the integer conversions (24/24 unsat). The RTL and the formally-checked model render from one in-Rust IR, so they cannot drift.
+>
+> **2026-08-06:** Whole-design combinational feedback-loop detection (issue #246) promoted from warning to **error** — `arch check`/`build`/`sim`/`formal` now all fail with a nonzero exit when an unblessed comb-SCC is found, instead of succeeding with a warning. The diagnostic shipped as a warning while its false-positive rate on real designs was being driven down (#783 in-block read-after-write folding, #785 the one genuine real-design loop found in the E203 IFU corpus — a port bug, independently fixed, not a checker artifact — and #789 range/element/for-loop granularity); a fresh full-corpus sweep immediately before the flip showed zero remaining false positives on real designs, with only a dedicated synthetic regression fixture (`tests/regression/issues/cross_instance_comb_loop_780/`) still triggering it. The `pragma comb_loops_allowed;` escape hatch for intentionally cyclic designs is unchanged and stays non-fatal. See `doc/ARCH_HDL_Specification.md` §5.4a for the full write-up (newly added — this diagnostic and its pragma had no dedicated spec section before this change).
 >
 > **0.70.8 release highlights:**
 > - **Typed FP parameters and constant evaluation** (#693, #694, #700) — module-scope FP wires and typed FP local parameters now resolve consistently in SystemVerilog and native simulation, including compile-time integer-to-FP conversion. This enables parameterized BF16-to-fixed conversion such as `local param SCALE_FP: FP32 = SCALE_INT.to_fp32();`.

--- a/src/comb_graph.rs
+++ b/src/comb_graph.rs
@@ -1165,7 +1165,7 @@ pub fn analyze_module(
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Whole-design comb-loop analysis (issue #246, MVP)
+// Whole-design comb-loop analysis (issue #246; promoted warning -> error 2026-08)
 //
 // Builds ONE directed combinational-dependency graph that spans the entire
 // elaborated design starting from each top-level module (modules that are
@@ -1174,8 +1174,11 @@ pub fn analyze_module(
 //
 // Tarjan's SCC is then run over the graph and any SCC with size > 1 (or a
 // single-node SCC with a self-loop) is reported as a combinational feedback
-// cycle. SCCs that pass through any instance OWNED by a module with
-// `pragma comb_loops_allowed;` are suppressed.
+// cycle — a hard compile error (`arch check`/`build`/`sim`/`formal` all fail
+// with a nonzero exit). SCCs that pass through any instance OWNED by a
+// module with `pragma comb_loops_allowed;` are suppressed and stay
+// non-fatal; that pragma is the documented escape hatch for intentional
+// cycles (see `doc/ARCH_HDL_Specification.md`).
 //
 // Limitations of this MVP (deferred to a follow-up PR):
 //   - Extern / interface-only modules (`.archi` stubs) are treated as

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -209,16 +209,22 @@ impl<'a> TypeChecker<'a> {
         }
     }
 
-    /// Issue #246 MVP: warn on every comb-feedback SCC found in the
-    /// whole-design instance-flat graph. Blessed-by-pragma SCCs are
-    /// silently suppressed.
+    /// Issue #246 MVP promoted to a hard error (2026-08): every unblessed
+    /// comb-feedback SCC found in the whole-design instance-flat graph is
+    /// now a `CompileError`, so `arch check`/`build`/`sim`/`formal` fail
+    /// with a nonzero exit. Blessed-by-pragma SCCs (`pragma
+    /// comb_loops_allowed;` on an owning module) remain the documented
+    /// escape hatch for intentional cycles and stay non-fatal — they are
+    /// silently suppressed here exactly as before (see
+    /// `comb_graph::analyze_whole_design`, which never adds a suppressed
+    /// SCC to `analysis.sccs` in the first place).
     fn check_whole_design_comb_loops(&mut self) {
         let analysis = crate::comb_graph::analyze_whole_design(self.source, self.symbols);
         if analysis.sccs.is_empty() && analysis.total_sccs == 0 {
             return;
         }
         for scc in &analysis.sccs {
-            // Pick a span for the warning: the span of the first owning
+            // Pick a span for the error: the span of the first owning
             // module in the SCC (top-level module if vec![]). Fall back
             // to the first item's span.
             let span: Span = scc
@@ -256,10 +262,18 @@ impl<'a> TypeChecker<'a> {
                 path_str.join(" -> "),
                 if path_str.is_empty() { String::new() } else { format!(" -> {}", path_str[0]) },
             );
-            self.warnings.push(CompileWarning { message: msg, span });
+            self.errors.push(CompileError::general(&msg, span));
         }
-        // Summary line emitted as a single warning so it shows up in the
-        // standard warning stream.
+        // Summary line: still non-fatal (a plain warning) when every SCC
+        // found was suppressed by the pragma — that's the "blessed, stay
+        // quiet" path. Once at least one SCC is unblessed the compile is
+        // already failing (per-SCC errors above), so the summary is
+        // pushed alongside them as an error too; note `TypeChecker::check`
+        // returns `Err(self.errors)` and drops `self.warnings` entirely in
+        // that branch, and only the *first* error in the Vec is surfaced
+        // by the CLI (arch#750, batch diagnostics), so this summary
+        // typically won't be the line printed to the user — it's kept for
+        // callers that inspect the full error list.
         if analysis.total_sccs > 0 {
             let span = self
                 .source
@@ -268,15 +282,24 @@ impl<'a> TypeChecker<'a> {
                 .map(|it| it.span())
                 .unwrap_or(Span { start: 0, end: 0 });
             let summary = format!(
-                "arch check: {} comb SCC(s) found; {} suppressed by pragma; {} unblessed (warnings)",
+                "arch check: {} comb SCC(s) found; {} suppressed by pragma; {} unblessed ({})",
                 analysis.total_sccs,
                 analysis.suppressed,
                 analysis.sccs.len(),
+                if analysis.sccs.is_empty() {
+                    "warnings"
+                } else {
+                    "errors"
+                },
             );
-            self.warnings.push(CompileWarning {
-                message: summary,
-                span,
-            });
+            if analysis.sccs.is_empty() {
+                self.warnings.push(CompileWarning {
+                    message: summary,
+                    span,
+                });
+            } else {
+                self.errors.push(CompileError::general(&summary, span));
+            }
         }
     }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -7061,6 +7061,28 @@ fn warnings_from(source: &str) -> Vec<String> {
     warnings.into_iter().map(|w| w.message).collect()
 }
 
+/// Like `warnings_from`, but for sources where `check()` is expected to
+/// FAIL (severity promotion, 2026-08: whole-design comb-SCC diagnostic is
+/// now a `CompileError`, not a `CompileWarning`). Panics if `check()`
+/// unexpectedly succeeds — callers use this specifically to assert the
+/// fatal path, mirroring `warnings_from`'s shape so existing message-text
+/// assertions (cycle nodes, module list, etc.) carry over unchanged.
+fn errors_from(source: &str) -> Vec<String> {
+    let tokens = arch::lexer::tokenize(source).expect("lexer error");
+    let mut parser = arch::parser::Parser::new(tokens, source);
+    let parsed_ast = parser.parse_source_file().expect("parse error");
+    let ast = arch::elaborate::elaborate(parsed_ast).expect("elaborate error");
+    let symbols = arch::resolve::resolve(&ast).expect("resolve error");
+    let checker = arch::typecheck::TypeChecker::new(&symbols, &ast);
+    match checker.check() {
+        Ok(_) => panic!(
+            "expected type check to FAIL with a comb-loop error (severity \
+             promotion, 2026-08), but it succeeded"
+        ),
+        Err(errs) => errs.into_iter().map(|e| e.to_string()).collect(),
+    }
+}
+
 #[test]
 fn test_handshake_tier15_unguarded_payload_warns() {
     let source = "
@@ -24867,7 +24889,9 @@ fn test_thread_state_names_distinguish_wait_until_vs_wait_cycles() {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Issue #246: whole-design combinational feedback-loop detection (MVP).
+// Issue #246: whole-design combinational feedback-loop detection (MVP;
+// promoted warning -> error 2026-08, see `errors_from`/`comb_loop_errors`
+// below).
 // ─────────────────────────────────────────────────────────────────────────────
 
 fn comb_loop_warnings(source: &str) -> Vec<String> {
@@ -24877,11 +24901,21 @@ fn comb_loop_warnings(source: &str) -> Vec<String> {
         .collect()
 }
 
+/// `comb_loop_warnings`'s counterpart for sources with a genuine unblessed
+/// SCC: `check()` now fails, so this reads the message text out of the
+/// `Err` list instead of the (now unreachable in that case) `Ok` warnings.
+fn comb_loop_errors(source: &str) -> Vec<String> {
+    errors_from(source)
+        .into_iter()
+        .filter(|m| m.contains("combinational feedback cycle") || m.starts_with("arch check:"))
+        .collect()
+}
+
 #[test]
 fn test_comb_loop_within_module_detected() {
     // Self-driving comb cycle inside a single module: a depends on b,
     // b depends on a. The whole-design check should surface it as a
-    // warning.
+    // compile error (severity promotion, 2026-08 — was a warning).
     let source = r#"
         module M
           port i: in UInt<1>;
@@ -24895,11 +24929,11 @@ fn test_comb_loop_within_module_detected() {
           end comb
         end module M
     "#;
-    let ws = comb_loop_warnings(source);
+    let ws = comb_loop_errors(source);
     assert!(
         ws.iter()
             .any(|m| m.contains("combinational feedback cycle")),
-        "expected a comb-loop warning, got: {:?}",
+        "expected a comb-loop error, got: {:?}",
         ws
     );
 }
@@ -24908,7 +24942,8 @@ fn test_comb_loop_within_module_detected() {
 fn test_comb_loop_across_two_instances_detected() {
     // Cross-instance loop: A.out -> B.in -> B.out -> A.in.
     // The current per-module analyzer silently absorbs this as
-    // settle_depth=2; the new whole-design analyzer should warn.
+    // settle_depth=2; the whole-design analyzer must flag it as a
+    // compile error (severity promotion, 2026-08 — was a warning).
     let source = r#"
         module Cell
           port i: in UInt<1>;
@@ -24939,11 +24974,11 @@ fn test_comb_loop_across_two_instances_detected() {
           end comb
         end module Top
     "#;
-    let ws = comb_loop_warnings(source);
+    let ws = comb_loop_errors(source);
     assert!(
         ws.iter()
             .any(|m| m.contains("combinational feedback cycle")),
-        "expected a comb-loop warning, got: {:?}",
+        "expected a comb-loop error, got: {:?}",
         ws
     );
 }
@@ -25099,8 +25134,9 @@ fn test_sibling_top_modules_sharing_signal_names_is_not_a_cycle() {
 fn test_comb_loop_attributed_to_the_owning_top_module() {
     // The cycle lives in `Loop2`, which is declared SECOND. `path_owner`
     // was keyed on the shared root path `vec![]`, so whichever top was
-    // expanded last overwrote the entry and the warning named the wrong
-    // module — here it blamed the acyclic `Filler`.
+    // expanded last overwrote the entry and the diagnostic named the wrong
+    // module — here it blamed the acyclic `Filler`. (Severity promotion,
+    // 2026-08: this is now a compile error, not a warning.)
     let source = r#"
         module Filler
           port x: in UInt<8>;
@@ -25122,7 +25158,7 @@ fn test_comb_loop_attributed_to_the_owning_top_module() {
           end comb
         end module Loop2
     "#;
-    let ws = comb_loop_warnings(source);
+    let ws = comb_loop_errors(source);
     let cycle_msgs: Vec<_> = ws
         .iter()
         .filter(|m| m.contains("combinational feedback cycle ("))
@@ -25130,7 +25166,7 @@ fn test_comb_loop_attributed_to_the_owning_top_module() {
     assert_eq!(
         cycle_msgs.len(),
         1,
-        "expected exactly one cycle warning, got: {:?}",
+        "expected exactly one cycle error, got: {:?}",
         ws
     );
     assert!(
@@ -25206,12 +25242,17 @@ fn test_interface_module_treated_as_opaque() {
     }
     let symbols = arch::resolve::resolve(&ast).expect("resolve error");
     let checker = arch::typecheck::TypeChecker::new(&symbols, &ast);
-    let (warnings, _) = checker.check().expect("type check error");
-    let ws: Vec<String> = warnings.into_iter().map(|w| w.message).collect();
+    // Severity promotion, 2026-08: the whole-design comb-SCC diagnostic is
+    // now a compile error, so `check()` fails instead of returning Ok with
+    // a warning attached.
+    let errs = checker
+        .check()
+        .expect_err("expected type check to fail with a comb-loop error");
+    let ws: Vec<String> = errs.into_iter().map(|e| e.to_string()).collect();
     assert!(
         ws.iter()
             .any(|m| m.contains("combinational feedback cycle")),
-        "expected opaque-interface module to participate in a detected cycle; warnings: {:?}",
+        "expected opaque-interface module to participate in a detected cycle; errors: {:?}",
         ws
     );
 }
@@ -25899,8 +25940,9 @@ fn test_archi_comb_dep_empty_marks_output_pure() {
 fn test_archi_comb_dep_absent_falls_back_to_opaque() {
     // A stub WITHOUT the annotation must keep today's opaque "every
     // output depends on every input" behavior. Two such stubs cross-
-    // wired should fire the cycle warning (regression guard for the
-    // pre-annotation behavior).
+    // wired should fire the cycle diagnostic (regression guard for the
+    // pre-annotation behavior). Severity promotion, 2026-08: this is now
+    // a compile error, not a warning.
     let source = r#"
         module Stub
           port i: in  UInt<1>;
@@ -25948,8 +25990,10 @@ fn test_archi_comb_dep_absent_falls_back_to_opaque() {
     }
     let symbols = arch::resolve::resolve(&ast).expect("resolve");
     let checker = arch::typecheck::TypeChecker::new(&symbols, &ast);
-    let (warnings, _) = checker.check().expect("type check");
-    let ws: Vec<String> = warnings.into_iter().map(|w| w.message).collect();
+    let errs = checker
+        .check()
+        .expect_err("expected type check to fail with a comb-loop error");
+    let ws: Vec<String> = errs.into_iter().map(|e| e.to_string()).collect();
     assert!(
         ws.iter()
             .any(|m| m.contains("combinational feedback cycle")),
@@ -26121,7 +26165,7 @@ fn test_comb_loop_bodied_real_cycle_still_detected() {
           end comb
         end module Top
     "#;
-    let ws = comb_loop_warnings(source);
+    let ws = comb_loop_errors(source);
     let cycle_msgs: Vec<_> = ws
         .iter()
         .filter(|m| m.contains("combinational feedback cycle ("))
@@ -26129,7 +26173,7 @@ fn test_comb_loop_bodied_real_cycle_still_detected() {
     assert!(
         !cycle_msgs.is_empty(),
         "real cycle (u1.out_a ← w2; u2.out_b ← w1) must still fire; \
-         warnings: {:?}",
+         errors: {:?}",
         ws
     );
 }
@@ -26403,7 +26447,7 @@ fn test_comb_loop_fsm_real_cycle_still_detected() {
           end comb
         end module Top
     "#;
-    let ws = comb_loop_warnings(source);
+    let ws = comb_loop_errors(source);
     let cycle_msgs: Vec<_> = ws
         .iter()
         .filter(|m| m.contains("combinational feedback cycle ("))
@@ -26411,7 +26455,7 @@ fn test_comb_loop_fsm_real_cycle_still_detected() {
     assert!(
         !cycle_msgs.is_empty(),
         "real cycle (u1.out_a ← w2; u2.out_b ← w1) through fsm \
-         must still fire; warnings: {:?}",
+         must still fire; errors: {:?}",
         ws
     );
 }
@@ -26515,7 +26559,7 @@ fn test_comb_loop_fsm_default_comb_deps_included() {
     "#;
     // The cross-wire w1 → in_z → out_a → w1 is a legitimate cycle.
     // Per-output FSM walker must include in_z in out_a's dep set.
-    let ws = comb_loop_warnings(source);
+    let ws = comb_loop_errors(source);
     let cycle_msgs: Vec<_> = ws
         .iter()
         .filter(|m| m.contains("combinational feedback cycle ("))
@@ -26523,7 +26567,7 @@ fn test_comb_loop_fsm_default_comb_deps_included() {
     assert!(
         !cycle_msgs.is_empty(),
         "default_comb reads in_z driving out_a; w1 → in_z → out_a → w1 \
-         must fire as a comb cycle; warnings: {:?}",
+         must fire as a comb cycle; errors: {:?}",
         ws
     );
 }
@@ -26572,7 +26616,7 @@ fn test_comb_loop_fsm_output_default_expr_deps_included() {
           end comb
         end module Top
     "#;
-    let ws = comb_loop_warnings(source);
+    let ws = comb_loop_errors(source);
     let cycle_msgs: Vec<_> = ws
         .iter()
         .filter(|m| m.contains("combinational feedback cycle ("))
@@ -26580,11 +26624,13 @@ fn test_comb_loop_fsm_output_default_expr_deps_included() {
     assert!(
         !cycle_msgs.is_empty(),
         "out_a's default expression reads in_y; w1 → in_y → out_a → w1 \
-         must fire as a comb cycle; warnings: {:?}",
+         must fire as a comb cycle; errors: {:?}",
         ws
     );
 
     // And the dual: with cross-wire through in_a (NOT a dep), no cycle.
+    // Acyclic, so `check()` still succeeds — the warning-based helper is
+    // correct here and stays unchanged.
     let source2 = r#"
         fsm Cell
           port clk: in Clock<SysDomain>;
@@ -26688,7 +26734,8 @@ fn test_comb_loop_read_before_first_inblock_write_still_flagged() {
     // Dual of the above: `x` is read on the RHS of its OWN first (and only)
     // assignment in the block, with no earlier write establishing an
     // in-block value. There is no register to break this dependency on
-    // itself — a genuine combinational self-loop that must still warn.
+    // itself — a genuine combinational self-loop that must still be
+    // flagged (compile error, severity promotion 2026-08 — was a warning).
     let source = r#"
         module M
           port i: in UInt<1>;
@@ -26700,7 +26747,7 @@ fn test_comb_loop_read_before_first_inblock_write_still_flagged() {
           end comb
         end module M
     "#;
-    let ws = comb_loop_warnings(source);
+    let ws = comb_loop_errors(source);
     let cycle_msgs: Vec<_> = ws
         .iter()
         .filter(|m| m.contains("combinational feedback cycle ("))
@@ -26736,7 +26783,7 @@ fn test_comb_loop_mutually_exclusive_branch_write_not_promoted() {
           end comb
         end module M
     "#;
-    let ws = comb_loop_warnings(source);
+    let ws = comb_loop_errors(source);
     let cycle_msgs: Vec<_> = ws
         .iter()
         .filter(|m| m.contains("combinational feedback cycle ("))
@@ -26883,7 +26930,7 @@ fn test_vec_of_bus_field_through_index_real_cycle_still_flagged() {
           end comb
         end module M
     "#;
-    let ws = comb_loop_warnings(source);
+    let ws = comb_loop_errors(source);
     let cycle_msgs: Vec<_> = ws
         .iter()
         .filter(|m| m.contains("combinational feedback cycle ("))
@@ -26957,7 +27004,7 @@ fn test_direct_rhs_mutual_read_before_write_still_flagged() {
           end comb
         end module M
     "#;
-    let ws = comb_loop_warnings(source);
+    let ws = comb_loop_errors(source);
     let cycle_msgs: Vec<_> = ws
         .iter()
         .filter(|m| m.contains("combinational feedback cycle ("))
@@ -27092,7 +27139,7 @@ fn test_for_loop_cond_stack_ungrounded_fold_still_flagged() {
           end comb
         end module M
     "#;
-    let ws = comb_loop_warnings(source);
+    let ws = comb_loop_errors(source);
     let cycle_msgs: Vec<_> = ws
         .iter()
         .filter(|m| m.contains("combinational feedback cycle ("))
@@ -27128,7 +27175,7 @@ fn test_overlapping_bitslice_self_read_on_first_touch_still_flagged() {
           end comb
         end module M
     "#;
-    let ws = comb_loop_warnings(source);
+    let ws = comb_loop_errors(source);
     let cycle_msgs: Vec<_> = ws
         .iter()
         .filter(|m| m.contains("combinational feedback cycle ("))
@@ -27272,10 +27319,21 @@ fn test_cross_instance_comb_loop_780_still_flagged_and_verilator_confirms_real()
     // combinational feedback loop. `arch check` must still flag it (the
     // #780 fold-artifact filter is scoped to same-comb-block sequential
     // collapsing only; cross-instance edges are always "not grounded",
-    // see `GraphBuilder::add_edge`), and — independently of `arch check`'s
-    // own opinion — `verilator --lint-only --assert` on the generated SV
-    // must fire `UNOPTFLAT` on the same wires, confirming this is a real
-    // hardware loop and not merely a self-consistent checker artifact.
+    // see `GraphBuilder::add_edge`).
+    //
+    // Severity change (2026-08): the whole-design comb-SCC diagnostic was
+    // promoted from warning to error once the prerequisite false-positive
+    // fixes (#783, #785, #789) drove the corpus blast radius to zero real
+    // designs. `arch check` now EXITS NONZERO on this fixture instead of
+    // succeeding with a warning on stderr. `arch build` fails the same way
+    // (typecheck runs before codegen), so no SV is ever emitted for this
+    // fixture anymore — the old second half of this test, which built the
+    // SV and independently cross-checked Verilator's `UNOPTFLAT` lint on
+    // it, is no longer reachable and has been dropped. The Verilator
+    // cross-check served its purpose during the warning era (proving the
+    // diagnostic wasn't merely a self-consistent checker artifact); now
+    // that the same condition is a hard compile error, the compiler
+    // refusing to build the design at all is the stronger guarantee.
     let arch_bin = env!("CARGO_BIN_EXE_arch");
     let src = "tests/regression/issues/cross_instance_comb_loop_780/CrossInstanceLoop.arch";
 
@@ -27286,23 +27344,17 @@ fn test_cross_instance_comb_loop_780_still_flagged_and_verilator_confirms_real()
         .expect("run arch check");
     let check_stderr = String::from_utf8_lossy(&check.stderr);
     assert!(
+        !check.status.success(),
+        "expected the synthetic cross-instance loop to fail `arch check` \
+         now that the diagnostic is an error, not a warning; stderr:\n{check_stderr}"
+    );
+    assert!(
         check_stderr.contains("combinational feedback cycle ("),
         "expected the synthetic cross-instance loop to still be flagged \
          after the #780 fold-artifact filter; stderr:\n{check_stderr}"
     );
 
-    if std::process::Command::new("verilator")
-        .arg("--version")
-        .output()
-        .is_err()
-    {
-        eprintln!(
-            "skipping Verilator UNOPTFLAT cross-check for \
-             CrossInstanceLoop: verilator not found"
-        );
-        return;
-    }
-
+    // `arch build` must fail the same way — same typecheck pass runs first.
     let td = tempfile::tempdir().expect("tempdir");
     let sv_out = td.path().join("CrossInstanceLoop.sv");
     let build = std::process::Command::new(arch_bin)
@@ -27311,30 +27363,17 @@ fn test_cross_instance_comb_loop_780_still_flagged_and_verilator_confirms_real()
         .arg("-o")
         .arg(&sv_out)
         .output()
-        .expect("build CrossInstanceLoop SV");
+        .expect("run arch build");
+    let build_stderr = String::from_utf8_lossy(&build.stderr);
     assert!(
-        build.status.success(),
-        "arch build should pass\nstdout:\n{}\nstderr:\n{}",
+        !build.status.success(),
+        "expected `arch build` to also fail on the unblessed comb loop\nstdout:\n{}\nstderr:\n{}",
         String::from_utf8_lossy(&build.stdout),
-        String::from_utf8_lossy(&build.stderr)
+        build_stderr
     );
-
-    let lint = std::process::Command::new("verilator")
-        .arg("--lint-only")
-        .arg("--assert")
-        .arg("-Wno-fatal")
-        .arg("-Wno-DECLFILENAME")
-        .arg("--top-module")
-        .arg("CrossInstanceLoop")
-        .arg(&sv_out)
-        .output()
-        .expect("verilate CrossInstanceLoop");
-    let lint_stderr = String::from_utf8_lossy(&lint.stderr);
     assert!(
-        lint_stderr.contains("UNOPTFLAT"),
-        "expected Verilator UNOPTFLAT on the genuine cross-instance loop \
-         (confirming this is a real hardware cycle, not just an arch \
-         check self-consistency artifact); stderr:\n{lint_stderr}"
+        build_stderr.contains("combinational feedback cycle ("),
+        "expected `arch build`'s failure to be the comb-loop error; stderr:\n{build_stderr}"
     );
 }
 
@@ -32481,7 +32520,19 @@ fn test_comb_graph_cycles_with_parent_intermediates_need_four_settle_passes() {
     let ast = elaborate::elaborate(parsed_ast).expect("elaborate error");
     let symbols = resolve::resolve(&ast).expect("resolve error");
     let checker = TypeChecker::new(&symbols, &ast);
-    let _ = checker.check().expect("type check error");
+    // NOTE: this fixture's A<->B cross-instance cycle (wa/wb) is a genuine
+    // whole-design comb-SCC, so `checker.check()` now returns `Err` here
+    // (severity promotion, 2026-08 — see `test_comb_loop_across_two_
+    // instances_detected` for the dedicated detection-assertion coverage
+    // of exactly this shape). That's unrelated to what THIS test actually
+    // exercises: `analyze_module`'s settle_depth calculation below, run
+    // directly against `ast`/`symbols` and independent of
+    // `TypeChecker::check`'s Ok/Err. The result was already discarded
+    // (`let _ = ...`) before this change — it was only ever a
+    // well-typedness smoke gate, not an assertion under test — so it's
+    // left unconsumed rather than `.expect()`-ing an outcome this test
+    // doesn't care about.
+    let _ = checker.check();
     let top = ast
         .items
         .iter()


### PR DESCRIPTION
## Summary

Promotes the whole-design combinational-feedback-loop diagnostic (issue #246) from a compile *warning* to a compile *error*. `arch check`/`build`/`sim`/`formal` now all fail with a nonzero exit when an unblessed comb-SCC is found, instead of succeeding with a warning on stderr. The `pragma comb_loops_allowed;` escape hatch for intentionally cyclic designs is unchanged and stays non-fatal.

Maintainer-approved 2026-08-03 after a three-PR prerequisite chain (#783, #785, #789) drove the false-positive rate on real designs to zero.

## Go/no-go sweep evidence

**Pre-flip** (fresh release build off `origin/main` @ `01fad2d6`, before any code change): ran `arch check` over the full corpus —
- `tests/` (656 units, `tools/run_arch_regression.py --skip-verilator --skip-sim --skip-sim-compile`): 583 pass, 73 `skip_check_failed` (pre-existing, unrelated to this change)
- `examples/` (107 units): 98 pass, 9 `skip_check_failed` (pre-existing, unrelated)
- `doc/examples/`, `stdlib/` (4 stray files): all clean

Grepped every log for `"combinational feedback"` — the **only** hit anywhere in the corpus was the synthetic anchor `tests/regression/issues/cross_instance_comb_loop_780/CrossInstanceLoop.arch`. Zero real-design blast radius, confirming the maintainer's prior finding independently. Safe to flip.

**Post-flip**: re-ran the same sweep after the change — identical result: only the synthetic anchor fires, and it now fires as a hard error (nonzero exit) instead of a warning.

## The pragma escape hatch — preserved exactly

`comb_graph::analyze_whole_design` already excludes pragma-blessed SCCs from the fatal list (`WholeDesignAnalysis::sccs` only ever contains unblessed SCCs; blessed ones are counted in `suppressed` and skipped). `check_whole_design_comb_loops` in `src/typecheck.rs` was not touched in that respect — it still iterates the same (already-filtered) list, just pushes the resulting diagnostics to `self.errors` instead of `self.warnings`. A suppressed-only result (all SCCs blessed) still surfaces a non-fatal informational summary warning, unchanged: `test_comb_loop_suppressed_by_pragma` passes without modification.

## Test changes: 16 tests converted + 1 anchor updated (17 total)

Initial investigation found the flip breaks 16 tests beyond the single synthetic anchor test, all for the same reason: each asserted "genuine unblessed loop → `check()` still succeeds, with a warning containing the cycle text" via helpers (`warnings_from`/`comb_loop_warnings`, or direct `checker.check().expect("type check error")`) that `.expect()` the `Ok` branch — now that `check()` returns `Err` for these, the `.expect()` panicked instead of returning warnings. This was flagged and the maintainer confirmed: *"Every one of those 16 is a correct-DETECTION pin ... converting them to assert the error path IS the promotion, not extra scope."*

All 16 are now converted via new `errors_from`/`comb_loop_errors` test helpers (mirroring the existing `warnings_from`/`comb_loop_warnings`) that assert the `Err` path instead. **Every converted test still asserts the loop IS DETECTED with the same cycle/diagnostic text and module attribution** — only the severity/exit expectation changed (`Ok`+warning → `Err`+error); none were deleted, `#[ignore]`d, weakened, or genericized.

15 of the 16 are pure detection-assertion tests, mechanically converted:
```
test_archi_comb_dep_absent_falls_back_to_opaque
test_comb_loop_across_two_instances_detected
test_comb_loop_attributed_to_the_owning_top_module
test_comb_loop_bodied_real_cycle_still_detected
test_comb_loop_fsm_default_comb_deps_included
test_comb_loop_fsm_output_default_expr_deps_included
test_comb_loop_fsm_real_cycle_still_detected
test_comb_loop_mutually_exclusive_branch_write_not_promoted
test_comb_loop_read_before_first_inblock_write_still_flagged
test_comb_loop_within_module_detected
test_direct_rhs_mutual_read_before_write_still_flagged
test_for_loop_cond_stack_ungrounded_fold_still_flagged
test_interface_module_treated_as_opaque
test_overlapping_bitslice_self_read_on_first_touch_still_flagged
test_vec_of_bus_field_through_index_real_cycle_still_flagged
```

The 16th, `test_comb_graph_cycles_with_parent_intermediates_need_four_settle_passes`, is different in kind and called out explicitly rather than silently folded in with the rest: it doesn't assert comb-loop detection at all — it exercises the unrelated per-module `analyze_module` settle-depth calculation on a fixture that happens to also contain a genuine whole-design loop. Its `checker.check()` call result was already discarded (`let _ = ...`) before this change; it's now left unconsumed (comment added explaining why) rather than `.expect()`-ing an `Ok` outcome the test never actually inspected. No assertion under test changed.

Plus the sanctioned anchor test update: `test_cross_instance_comb_loop_780_still_flagged_and_verilator_confirms_real` now asserts `arch check` and `arch build` both exit nonzero with the cycle text in stderr. The old Verilator UNOPTFLAT cross-check is dropped since `arch build` no longer emits SV for this fixture (typecheck now fails before codegen runs) — the compiler outright refusing to build the design is the stronger guarantee that superseded it.

**Suite total**: 774 passed / 0 failed in `tests/integration_test.rs`, matching the pre-flip baseline (758 passed + 16 failed = 774 total → 774 passed + 0 failed after conversion).

## Spec diff summary

- `doc/ARCH_HDL_Specification.md` — new **§5.4a Whole-Design Combinational Feedback Loops**, inserted after §5.4 (RDC), following the same subsection-lettering convention as §5.2a/§8.2a. Documents: what the analysis does (Tarjan SCC over the full flattened instance hierarchy), that it's now a hard compile error with an example diagnostic, the severity history (promoted from warning once the false-positive rate hit zero), the `pragma comb_loops_allowed;` escape hatch with an example and its informational summary-line format, and known scope/limitations (opaque interface stubs, port-set over-approximation fallback, no per-signal-pair blessing). **This diagnostic and its pragma had no dedicated spec coverage at all before this PR** — confirmed by grep, this was a pre-existing gap this PR also closes.
- `doc/COMPILER_STATUS.md` — new dated highlight entry (2026-08-06) summarizing the change and pointing to §5.4a; `Last updated` bumped.
- `doc/Arch_AI_Reference_Card.md` — unchanged. It has only a tangential mention of "the comb-loop checker" (in the pipeline-output-rule rationale) and, like the existing `cdc_safe`/`rdc_safe` pragmas, has no dedicated pragma-reference section to extend — consistent with the existing convention there, no change needed.
- `skills/arch-programming/references/{ARCH_HDL_Specification,COMPILER_STATUS}.md` — refreshed via `scripts/sync_skill_snapshots.sh refresh` (required, these are checked in CI on every PR).

## Fast gate (all green on the squashed commit)

- `cargo build --release`: clean
- `cargo test --release --test integration_test --no-fail-fast`: **774 passed, 0 failed**
- `cargo fmt --check`: clean (one pre-existing formatting diff in the touched region of `src/typecheck.rs` fixed)
- `cargo clippy --release --all-targets`: exits 0 (repo's clippy CI gate is errors-only, i.e. deny-by-default lints only; all reported items are pre-existing style lints elsewhere in the file, none in the diff)
- `scripts/check_doc_drift.sh origin/main`: pass (no grammar-surface file touched)
- `scripts/check_release_doc.sh origin/main`: pass (not a version bump)

Two pre-existing, unrelated local-environment-only test failures were observed and are NOT part of this diff's blast radius (confirmed disjoint subsystems + `git diff origin/main...HEAD --stat` scope):
- `formal_test.rs`: 2 Lean/`lake` toolchain tests fail locally because the `proofs/lean_thread_lowering` Lean project isn't built in this sandbox (`unknown module prefix 'ArchConstructProof'`) — `tests/test.yml`'s own header comment documents that CI intentionally has no Lean/lake installed and these tests skip cleanly there.
- `fp_test.rs`: 1 floating-point formal-property test (`fp_formal_float_props`, z3-dependent) — unrelated FP subsystem.

## Files changed
```
doc/ARCH_HDL_Specification.md
doc/COMPILER_STATUS.md
skills/arch-programming/references/ARCH_HDL_Specification.md
skills/arch-programming/references/COMPILER_STATUS.md
src/comb_graph.rs
src/typecheck.rs
tests/integration_test.rs
```

`git diff origin/main...HEAD --stat` confirmed to list exactly these 7 files, nothing else.

closes #246

Long verification (`scripts/nightly_equivalence.py`, `examples/run_sims.sh`) to follow as a comment on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)