### PR TITLE
feat(check): opt-in --lint-naming convention lint (closes #648)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -42,6 +42,17 @@ enum Command {
         /// Input .arch file(s)
         #[arg(required = true)]
         files: Vec<PathBuf>,
+        /// Opt-in naming-convention lint (issue #648): PascalCase for
+        /// construct names, snake_case for ports/regs/wires/lets/function
+        /// args, UPPER_SNAKE for params. Warning-only — never fails the
+        /// build (spec §2.1: naming conventions are recommended, not
+        /// compiler-enforced). Bare `--lint-naming` or `--lint-naming=warn`
+        /// enable it; `--lint-naming=off` (or omitting the flag) disables
+        /// it. `--lint-naming=error` is intentionally rejected — there is
+        /// no hard-error mode. Suppress per-file with a
+        /// `// arch-lint-naming: off` source-line pragma.
+        #[arg(long, num_args = 0..=1, require_equals = true, default_missing_value = "warn")]
+        lint_naming: Option<String>,
     },
     /// Rebuild the learning retrieval index over ~/.arch/learn/events.jsonl
     LearnIndex,
@@ -184,6 +195,11 @@ enum Command {
         /// `--assert` to get free spec-derived coverage.
         #[arg(long)]
         auto_thread_asserts: bool,
+        /// Opt-in naming-convention lint (issue #648) — see `arch check
+        /// --help` for the full rule set. Warning-only; never fails the
+        /// build.
+        #[arg(long, num_args = 0..=1, require_equals = true, default_missing_value = "warn")]
+        lint_naming: Option<String>,
         /// Only emit constructs from the original input .arch files, not
         /// from dependency files auto-discovered via `inst` / `use`.
         /// Avoids MODDUP when sub-modules are also built as standalone
@@ -495,6 +511,23 @@ impl MultiSource {
         }
 
         Ok(MultiSource { segments, combined })
+    }
+
+    /// Filenames whose source contains a `// arch-lint-naming: off` line
+    /// (exact match after trimming whitespace). Used to suppress
+    /// `--lint-naming` diagnostics for a single file — see issue #648's
+    /// acceptance criteria. Purely a raw-text scan over each segment's
+    /// original source, independent of parsing/AST, so it can't itself
+    /// introduce a naming-lint false positive or affect any other pass.
+    fn naming_lint_suppressed_files(&self) -> std::collections::HashSet<String> {
+        self.segments
+            .iter()
+            .filter(|(_, _, _, src)| {
+                src.lines()
+                    .any(|line| line.trim() == "// arch-lint-naming: off")
+            })
+            .map(|(_, _, name, _)| name.clone())
+            .collect()
     }
 
     /// Find which file a byte offset belongs to and return (filename, file_source, local_offset).
@@ -866,17 +899,43 @@ where
     result
 }
 
+/// Resolve the `--lint-naming[=warn|off]` CLI value into an enabled/disabled
+/// bool. `None` (flag absent) and `Some("off")` both mean disabled — the
+/// lint is opt-in, so both spellings of "don't run it" collapse to the same
+/// behavior. `error` is intentionally rejected: the naming lint has no
+/// hard-error mode (spec §2.1 — naming conventions are recommended, not
+/// compiler-enforced), so `--lint-naming=error` would silently imply a
+/// severity this lint can never produce.
+fn resolve_lint_naming_flag(value: Option<String>) -> miette::Result<bool> {
+    match value.as_deref() {
+        None | Some("off") => Ok(false),
+        Some("warn") => Ok(true),
+        Some(other) => Err(miette::miette!(
+            "--lint-naming: expected `warn` or `off`, got `{other}` — this lint is warning-only \
+             in v1 (see issue #648 Non-goals); there is no error-severity mode"
+        )),
+    }
+}
+
 fn main() -> miette::Result<()> {
     let cli = Cli::parse();
 
     match cli.command {
-        Command::Check { files } => learn_wrap(&files, || {
-            let all_files = resolve_use_imports(&files)?;
-            let ms = MultiSource::from_files(&all_files)?;
-            run_check_multi(&ms)?;
-            eprintln!("OK: no errors");
-            Ok(())
-        }),
+        Command::Check { files, lint_naming } => {
+            let lint_naming = resolve_lint_naming_flag(lint_naming)?;
+            learn_wrap(&files, || {
+                let all_files = resolve_use_imports(&files)?;
+                let ms = MultiSource::from_files(&all_files)?;
+                run_check_multi_opts(
+                    &ms,
+                    /*skip_lower_threads=*/ false,
+                    /*auto_thread_asserts=*/ false,
+                    lint_naming,
+                )?;
+                eprintln!("OK: no errors");
+                Ok(())
+            })
+        }
         Command::LearnIndex => {
             let n = arch::learn::build_index().into_diagnostic()?;
             eprintln!("Indexed {} events.", n);
@@ -1171,11 +1230,13 @@ fn main() -> miette::Result<()> {
             check_construct_proof_smt,
             construct_proof_smt_solver,
             auto_thread_asserts,
+            lint_naming,
             no_inline_deps,
             fp_compat,
             staged_ops,
         } => {
             let fp_compat = arch::FpCompat::parse(&fp_compat).map_err(|e| miette::miette!(e))?;
+            let lint_naming = resolve_lint_naming_flag(lint_naming)?;
             let files_for_learn = files.clone();
             learn_wrap(&files_for_learn, move || {
                 if matches!(emit_thread_map, Some(Some(_))) && files.len() > 1 && o.is_none() {
@@ -1230,6 +1291,7 @@ fn main() -> miette::Result<()> {
                     &ms,
                     false,
                     auto_thread_asserts,
+                    lint_naming,
                     thread_map_store.clone(),
                 )?;
                 let staged_sites =
@@ -1677,6 +1739,7 @@ fn main() -> miette::Result<()> {
                     &ms,
                     false,
                     auto_thread_asserts,
+                    /*lint_naming=*/ false,
                     thread_map_store.clone(),
                 )?;
                 if need_thread_proof_lean {
@@ -1942,12 +2005,14 @@ fn run_sim_opts(
             &ms,
             thread_sim_parallel,
             /*auto_thread_asserts=*/ false,
+            /*lint_naming=*/ false,
         )?
     } else {
         run_check_multi_opts_with_param_overrides(
             &ms,
             thread_sim_parallel,
             /*auto_thread_asserts=*/ false,
+            /*lint_naming=*/ false,
             param_overrides,
         )?
     };
@@ -3520,6 +3585,7 @@ fn run_check_multi(
 )> {
     run_check_multi_opts(
         ms, /*skip_lower_threads=*/ false, /*auto_thread_asserts=*/ false,
+        /*lint_naming=*/ false,
     )
 }
 
@@ -3527,6 +3593,7 @@ fn run_check_multi_opts(
     ms: &MultiSource,
     skip_lower_threads: bool,
     auto_thread_asserts: bool,
+    lint_naming: bool,
 ) -> miette::Result<(
     arch::ast::SourceFile,
     resolve::SymbolTable,
@@ -3536,6 +3603,7 @@ fn run_check_multi_opts(
         ms,
         skip_lower_threads,
         auto_thread_asserts,
+        lint_naming,
         None,
         None,
     )
@@ -3545,6 +3613,7 @@ fn run_check_multi_opts_with_thread_map(
     ms: &MultiSource,
     skip_lower_threads: bool,
     auto_thread_asserts: bool,
+    lint_naming: bool,
     thread_map: Option<std::rc::Rc<std::cell::RefCell<arch::thread_map::ThreadMap>>>,
 ) -> miette::Result<(
     arch::ast::SourceFile,
@@ -3555,6 +3624,7 @@ fn run_check_multi_opts_with_thread_map(
         ms,
         skip_lower_threads,
         auto_thread_asserts,
+        lint_naming,
         thread_map,
         None,
     )
@@ -3564,6 +3634,7 @@ fn run_check_multi_opts_with_param_overrides(
     ms: &MultiSource,
     skip_lower_threads: bool,
     auto_thread_asserts: bool,
+    lint_naming: bool,
     param_overrides: &std::collections::HashMap<String, u64>,
 ) -> miette::Result<(
     arch::ast::SourceFile,
@@ -3574,6 +3645,7 @@ fn run_check_multi_opts_with_param_overrides(
         ms,
         skip_lower_threads,
         auto_thread_asserts,
+        lint_naming,
         None,
         Some(param_overrides),
     )
@@ -3583,6 +3655,7 @@ fn run_check_multi_opts_with_thread_map_and_params(
     ms: &MultiSource,
     skip_lower_threads: bool,
     auto_thread_asserts: bool,
+    lint_naming: bool,
     thread_map: Option<std::rc::Rc<std::cell::RefCell<arch::thread_map::ThreadMap>>>,
     param_overrides: Option<&std::collections::HashMap<String, u64>>,
 ) -> miette::Result<(
@@ -3663,6 +3736,31 @@ fn run_check_multi_opts_with_thread_map_and_params(
         let err = prec_errors.into_iter().next().unwrap();
         return Err(ms.report_error(err));
     }
+
+    // Naming-convention lint (issue #648), opt-in via `--lint-naming`. Runs
+    // on the same pre-elaboration `parsed_ast` as `check_precedence` above,
+    // for the same reason: compiler-synthesized identifiers (thread
+    // lowering, generate expansion, credit-channel dispatch, ...) don't
+    // exist yet at this stage, so there's nothing to spuriously flag. This
+    // whole block is a no-op unless `lint_naming` is set — absent the flag,
+    // `naming_warnings` stays empty and `arch check`/`arch build` behavior
+    // and emitted output are unaffected. Collected here (rather than
+    // returned as an error) and merged into `warnings` below, since a
+    // naming violation must never fail the build (spec §2.1: naming
+    // conventions are recommended, not compiler-enforced).
+    let naming_warnings = if lint_naming {
+        let mut w = arch::typecheck::check_naming(&parsed_ast);
+        let suppressed = ms.naming_lint_suppressed_files();
+        if !suppressed.is_empty() {
+            w.retain(|warn| {
+                let (filename, _, _) = ms.locate(warn.span.start);
+                !suppressed.contains(filename)
+            });
+        }
+        w
+    } else {
+        Vec::new()
+    };
 
     if let Some(overrides) = param_overrides {
         apply_top_param_overrides(&mut parsed_ast, overrides)?;
@@ -3799,6 +3897,7 @@ fn run_check_multi_opts_with_thread_map_and_params(
         ms.report_error(err)
     })?;
     warnings.extend(pipe_reg_warnings);
+    warnings.extend(naming_warnings);
 
     for w in &warnings {
         let (filename, _, local_offset) = ms.locate(w.span.start);

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -9082,6 +9082,452 @@ fn check_precedence_in_item(item: &Item, errors: &mut Vec<CompileError>) {
     }
 }
 
+// ── Naming-convention lint (issue #648, opt-in via `--lint-naming`) ───────────
+//
+// Spec §2.1's naming table is documented as "recommended, not
+// compiler-enforced" and a standing maintainer decision keeps it that way —
+// this pass is purely opt-in, warning-only, and never runs unless the CLI
+// flag is passed. Absent the flag, `arch check`/`arch build` behavior and
+// emitted output are completely unchanged (this function is never called).
+//
+// Casing classification is pure string logic — no type information needed —
+// so, like `check_precedence`, this walks the *parsed* `SourceFile` before
+// elaboration. That timing isn't just a performance shortcut: it structurally
+// avoids ever seeing a compiler-synthesized identifier (thread-lowering's
+// `_threads` submodules, `__ri0`-style internal regs, credit-channel dispatch
+// wires, generate-expanded `w_0`/`w_1` suffixes, ...), because none of those
+// exist yet at this stage — they're all inserted by passes in `elaborate.rs`
+// that run *after* this one. The single exception is the parser's own
+// `_destructure` placeholder name on struct-destructuring `let` bindings
+// (`LetBinding::destructure_fields`) — that placeholder is synthesized by
+// `parser.rs` itself and so *is* present pre-elaboration; it's explicitly
+// skipped in `check_let_binding_naming` below (its real user-written names
+// live in `destructure_fields`, which are checked individually instead).
+
+/// PascalCase: `FetchUnit`, `AluOp`, `AXIBridge` (acronym prefix),
+/// `Axi4Bridge` (digit mid-word). First char uppercase; every char
+/// alphanumeric (no separators).
+fn is_pascal_case(name: &str) -> bool {
+    matches!(name.chars().next(), Some(c) if c.is_ascii_uppercase())
+        && name.chars().all(|c| c.is_ascii_alphanumeric())
+}
+
+/// snake_case: `pc_next`, `req_valid`, `fifo2_ptr` (digit mid-word). First
+/// char lowercase; every char lowercase/digit/underscore.
+fn is_snake_case(name: &str) -> bool {
+    matches!(name.chars().next(), Some(c) if c.is_ascii_lowercase())
+        && name
+            .chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_')
+}
+
+/// UPPER_SNAKE: `XLEN`, `CACHE_DEPTH`. First char uppercase; every char
+/// uppercase/digit/underscore.
+fn is_upper_snake(name: &str) -> bool {
+    matches!(name.chars().next(), Some(c) if c.is_ascii_uppercase())
+        && name
+            .chars()
+            .all(|c| c.is_ascii_uppercase() || c.is_ascii_digit() || c == '_')
+}
+
+/// Best-effort PascalCase rewrite, used only for the diagnostic's suggested
+/// name. Underscore-joined input (`MODULE_FOO`) is split on `_` and each
+/// part is title-cased unless it looks like an acronym (all-caps/digits,
+/// kept verbatim). No-underscore input (`moduleFoo`) is left alone except
+/// for capitalizing the first character, which preserves intentional
+/// internal capitalization (`moduleFoo` -> `ModuleFoo`, not `Modulefoo`).
+fn suggest_pascal_case(name: &str) -> String {
+    if name.contains('_') {
+        name.split('_')
+            .filter(|part| !part.is_empty())
+            .map(|part| {
+                if part.chars().all(|c| !c.is_ascii_lowercase()) {
+                    part.to_string()
+                } else {
+                    capitalize_first(part)
+                }
+            })
+            .collect()
+    } else {
+        capitalize_first(name)
+    }
+}
+
+fn capitalize_first(s: &str) -> String {
+    let mut chars = s.chars();
+    match chars.next() {
+        Some(c) => c.to_ascii_uppercase().to_string() + chars.as_str(),
+        None => String::new(),
+    }
+}
+
+/// Best-effort snake_case rewrite: inserts `_` at lower->upper and
+/// upper-run->upper+lower boundaries (so `AXIBridge` -> `axi_bridge`, not
+/// `a_x_i_bridge`), lowercases everything, and collapses/trims `_` runs.
+fn suggest_snake_case(name: &str) -> String {
+    let chars: Vec<char> = name.chars().collect();
+    let mut out = String::new();
+    for (i, &c) in chars.iter().enumerate() {
+        if c == '_' {
+            if !out.is_empty() && !out.ends_with('_') {
+                out.push('_');
+            }
+            continue;
+        }
+        if c.is_ascii_uppercase() {
+            let prev = if i > 0 { Some(chars[i - 1]) } else { None };
+            let next = chars.get(i + 1).copied();
+            let boundary = match prev {
+                Some(p) => {
+                    p.is_ascii_lowercase()
+                        || p.is_ascii_digit()
+                        || (p.is_ascii_uppercase() && next.is_some_and(|n| n.is_ascii_lowercase()))
+                }
+                None => false,
+            };
+            if boundary && !out.is_empty() && !out.ends_with('_') {
+                out.push('_');
+            }
+            out.push(c.to_ascii_lowercase());
+        } else {
+            out.push(c);
+        }
+    }
+    out.trim_matches('_').to_string()
+}
+
+/// Best-effort UPPER_SNAKE rewrite: same word-boundary logic as
+/// `suggest_snake_case`, upper-cased.
+fn suggest_upper_snake(name: &str) -> String {
+    suggest_snake_case(name).to_ascii_uppercase()
+}
+
+fn naming_warning(
+    warnings: &mut Vec<CompileWarning>,
+    category: &str,
+    ident: &Ident,
+    convention: &str,
+    suggestion: String,
+) {
+    warnings.push(CompileWarning {
+        message: format!(
+            "{category} `{}` should be {convention} (e.g. `{suggestion}`) — see naming conventions",
+            ident.name
+        ),
+        span: ident.span,
+    });
+}
+
+fn check_pascal_naming(warnings: &mut Vec<CompileWarning>, category: &str, ident: &Ident) {
+    if !is_pascal_case(&ident.name) {
+        naming_warning(
+            warnings,
+            category,
+            ident,
+            "PascalCase",
+            suggest_pascal_case(&ident.name),
+        );
+    }
+}
+
+fn check_snake_naming(warnings: &mut Vec<CompileWarning>, category: &str, ident: &Ident) {
+    if !is_snake_case(&ident.name) {
+        naming_warning(
+            warnings,
+            category,
+            ident,
+            "snake_case",
+            suggest_snake_case(&ident.name),
+        );
+    }
+}
+
+fn check_upper_snake_naming(warnings: &mut Vec<CompileWarning>, category: &str, ident: &Ident) {
+    if !is_upper_snake(&ident.name) {
+        naming_warning(
+            warnings,
+            category,
+            ident,
+            "UPPER_SNAKE",
+            suggest_upper_snake(&ident.name),
+        );
+    }
+}
+
+fn check_params_naming(warnings: &mut Vec<CompileWarning>, params: &[ParamDecl]) {
+    for p in params {
+        check_upper_snake_naming(warnings, "param", &p.name);
+    }
+}
+
+fn check_ports_naming(warnings: &mut Vec<CompileWarning>, ports: &[PortDecl]) {
+    for p in ports {
+        check_snake_naming(warnings, "port", &p.name);
+    }
+}
+
+/// `let` bindings: the ordinary single-name form is checked directly; the
+/// struct-destructuring form (`let {a, b, c} = expr;`) carries a
+/// parser-synthesized `_destructure` placeholder in `name` (see the module
+/// comment above) — skip that and check the real user-written names in
+/// `destructure_fields` instead.
+fn check_let_binding_naming(warnings: &mut Vec<CompileWarning>, l: &LetBinding) {
+    if l.destructure_fields.is_empty() {
+        check_snake_naming(warnings, "let binding", &l.name);
+    } else {
+        for f in &l.destructure_fields {
+            check_snake_naming(warnings, "let binding", f);
+        }
+    }
+}
+
+fn check_function_naming(warnings: &mut Vec<CompileWarning>, f: &FunctionDecl) {
+    for a in &f.args {
+        check_snake_naming(warnings, "function arg", &a.name);
+    }
+    check_function_body_naming(warnings, &f.body);
+}
+
+fn check_function_body_naming(warnings: &mut Vec<CompileWarning>, body: &[FunctionBodyItem]) {
+    for item in body {
+        match item {
+            FunctionBodyItem::Let(l) => check_let_binding_naming(warnings, l),
+            FunctionBodyItem::IfElse(ie) => {
+                check_function_body_naming(warnings, &ie.then_body);
+                check_function_body_naming(warnings, &ie.else_body);
+            }
+            FunctionBodyItem::For(fl) => check_function_body_naming(warnings, &fl.body),
+            FunctionBodyItem::Return(_) | FunctionBodyItem::Assign(_) => {}
+        }
+    }
+}
+
+fn check_gen_items_naming(warnings: &mut Vec<CompileWarning>, items: &[GenItem]) {
+    for item in items {
+        match item {
+            GenItem::Port(p) => check_snake_naming(warnings, "port", &p.name),
+            GenItem::Wire(w) => check_snake_naming(warnings, "wire", &w.name),
+            GenItem::Inst(_)
+            | GenItem::TlmConnect(_)
+            | GenItem::Thread(_)
+            | GenItem::Assert(_)
+            | GenItem::Seq(_)
+            | GenItem::Comb(_) => {}
+        }
+    }
+}
+
+fn check_generate_naming(warnings: &mut Vec<CompileWarning>, g: &GenerateDecl) {
+    match g {
+        GenerateDecl::For(gf) => check_gen_items_naming(warnings, &gf.items),
+        GenerateDecl::If(gi) => {
+            check_gen_items_naming(warnings, &gi.then_items);
+            check_gen_items_naming(warnings, &gi.else_items);
+        }
+    }
+}
+
+/// Walk a module (or pipeline stage) body for reg/wire/let naming —
+/// shared by `Item::Module` and `PipelineDecl`'s per-stage bodies, both of
+/// which are `Vec<ModuleBodyItem>`.
+fn check_module_body_naming(warnings: &mut Vec<CompileWarning>, body: &[ModuleBodyItem]) {
+    for item in body {
+        match item {
+            ModuleBodyItem::RegDecl(r) => check_snake_naming(warnings, "reg", &r.name),
+            ModuleBodyItem::WireDecl(w) => check_snake_naming(warnings, "wire", &w.name),
+            ModuleBodyItem::PipeRegDecl(p) => check_snake_naming(warnings, "reg", &p.name),
+            ModuleBodyItem::LetBinding(l) => check_let_binding_naming(warnings, l),
+            ModuleBodyItem::Function(f) => check_function_naming(warnings, f),
+            ModuleBodyItem::Generate(g) => check_generate_naming(warnings, g),
+            ModuleBodyItem::RegBlock(_)
+            | ModuleBodyItem::LatchBlock(_)
+            | ModuleBodyItem::CombBlock(_)
+            | ModuleBodyItem::Inst(_)
+            | ModuleBodyItem::Thread(_)
+            | ModuleBodyItem::Resource(_)
+            | ModuleBodyItem::Assert(_)
+            | ModuleBodyItem::TlmConnect(_)
+            | ModuleBodyItem::TypeAlias(_) => {}
+        }
+    }
+}
+
+/// Walk one top-level `Item` for naming-convention violations. See the
+/// module comment above for scope/timing rationale.
+///
+/// Construct-name (PascalCase) coverage matches issue #648's enumerated
+/// list exactly: module, fsm, fifo, ram, cam, counter, arbiter, regfile,
+/// pipeline, linklist, bus, synchronizer, clkgate, struct, enum, package,
+/// domain. `function` and `template` aren't in that list (no documented
+/// casing convention for either), so their own names aren't checked here —
+/// but their params/ports/args are still real `param`/`port`/signal
+/// declarations, so those nested categories are still checked.
+///
+/// `.archi` interface stubs (`is_interface == true`) are skipped entirely:
+/// they're compiler-emitted mirrors of a construct already declared (and
+/// already linted) in its originating `.arch` file, so linting the stub too
+/// would just double-report the same violation.
+fn check_naming_in_item(item: &Item, warnings: &mut Vec<CompileWarning>) {
+    match item {
+        Item::Domain(d) => check_pascal_naming(warnings, "domain", &d.name),
+        Item::Struct(s) => check_pascal_naming(warnings, "struct", &s.name),
+        Item::Enum(e) => check_pascal_naming(warnings, "enum", &e.name),
+        Item::Module(m) => {
+            if m.is_interface {
+                return;
+            }
+            check_pascal_naming(warnings, "module", &m.name);
+            check_params_naming(warnings, &m.params);
+            check_ports_naming(warnings, &m.ports);
+            check_module_body_naming(warnings, &m.body);
+        }
+        Item::Fsm(f) => {
+            if f.is_interface {
+                return;
+            }
+            check_pascal_naming(warnings, "fsm", &f.name);
+            check_params_naming(warnings, &f.params);
+            check_ports_naming(warnings, &f.ports);
+            for r in &f.regs {
+                check_snake_naming(warnings, "reg", &r.name);
+            }
+            for w in &f.wires {
+                check_snake_naming(warnings, "wire", &w.name);
+            }
+            for l in &f.lets {
+                check_let_binding_naming(warnings, l);
+            }
+        }
+        Item::Fifo(x) => {
+            if x.is_interface {
+                return;
+            }
+            check_pascal_naming(warnings, "fifo", &x.name);
+            check_params_naming(warnings, &x.params);
+            check_ports_naming(warnings, &x.ports);
+        }
+        Item::Ram(x) => {
+            if x.is_interface {
+                return;
+            }
+            check_pascal_naming(warnings, "ram", &x.name);
+            check_params_naming(warnings, &x.params);
+            check_ports_naming(warnings, &x.ports);
+            for pg in &x.port_groups {
+                check_ports_naming(warnings, &pg.signals);
+            }
+        }
+        Item::Cam(x) => {
+            if x.is_interface {
+                return;
+            }
+            check_pascal_naming(warnings, "cam", &x.name);
+            check_params_naming(warnings, &x.params);
+            check_ports_naming(warnings, &x.ports);
+        }
+        Item::Counter(x) => {
+            if x.is_interface {
+                return;
+            }
+            check_pascal_naming(warnings, "counter", &x.name);
+            check_params_naming(warnings, &x.params);
+            check_ports_naming(warnings, &x.ports);
+        }
+        Item::Arbiter(x) => {
+            if x.is_interface {
+                return;
+            }
+            check_pascal_naming(warnings, "arbiter", &x.name);
+            check_params_naming(warnings, &x.params);
+            check_ports_naming(warnings, &x.ports);
+            for pa in &x.port_arrays {
+                check_ports_naming(warnings, &pa.signals);
+            }
+        }
+        Item::Regfile(x) => {
+            if x.is_interface {
+                return;
+            }
+            check_pascal_naming(warnings, "regfile", &x.name);
+            check_params_naming(warnings, &x.params);
+            check_ports_naming(warnings, &x.ports);
+            if let Some(rp) = &x.read_ports {
+                check_ports_naming(warnings, &rp.signals);
+            }
+            if let Some(wp) = &x.write_ports {
+                check_ports_naming(warnings, &wp.signals);
+            }
+        }
+        Item::Pipeline(x) => {
+            if x.is_interface {
+                return;
+            }
+            check_pascal_naming(warnings, "pipeline", &x.name);
+            check_params_naming(warnings, &x.params);
+            check_ports_naming(warnings, &x.ports);
+            for stage in &x.stages {
+                check_module_body_naming(warnings, &stage.body);
+            }
+        }
+        Item::Linklist(x) => {
+            if x.is_interface {
+                return;
+            }
+            check_pascal_naming(warnings, "linklist", &x.name);
+            check_params_naming(warnings, &x.params);
+            check_ports_naming(warnings, &x.ports);
+        }
+        Item::Function(f) => check_function_naming(warnings, f),
+        Item::Template(t) => {
+            check_params_naming(warnings, &t.params);
+            check_ports_naming(warnings, &t.ports);
+            for pa in &t.port_arrays {
+                check_ports_naming(warnings, &pa.signals);
+            }
+        }
+        Item::Synchronizer(x) => {
+            check_pascal_naming(warnings, "synchronizer", &x.name);
+            check_params_naming(warnings, &x.params);
+            check_ports_naming(warnings, &x.ports);
+        }
+        Item::Clkgate(x) => {
+            check_pascal_naming(warnings, "clkgate", &x.name);
+            check_params_naming(warnings, &x.params);
+            check_ports_naming(warnings, &x.ports);
+        }
+        Item::Bus(x) => {
+            check_pascal_naming(warnings, "bus", &x.name);
+            check_params_naming(warnings, &x.params);
+            check_ports_naming(warnings, &x.signals);
+            for g in &x.generates {
+                check_ports_naming(warnings, &g.then_signals);
+                check_ports_naming(warnings, &g.else_signals);
+            }
+            for cc in &x.credit_channels {
+                check_params_naming(warnings, &cc.params);
+            }
+        }
+        Item::Package(x) => {
+            check_pascal_naming(warnings, "package", &x.name);
+            check_params_naming(warnings, &x.params);
+        }
+        Item::Use(_) | Item::ExternPackage(_) => {}
+    }
+}
+
+/// Run the naming-convention lint (issue #648) on a parsed `SourceFile`,
+/// pre-elaboration. Opt-in only — callers gate this behind `--lint-naming`;
+/// it is never invoked otherwise. Warning-only: naming conventions remain
+/// "recommended, not compiler-enforced" per spec §2.1, so this never
+/// produces a hard error regardless of how many violations are found.
+pub fn check_naming(source: &SourceFile) -> Vec<CompileWarning> {
+    let mut warnings = Vec::new();
+    for item in &source.items {
+        check_naming_in_item(item, &mut warnings);
+    }
+    warnings
+}
+
 /// Evaluate a simple literal type-width expression (e.g. the `8` in `UInt<8>`).
 /// Returns `None` for non-literal expressions (params, arithmetic, etc.).
 fn eval_type_width_expr(e: &Expr) -> Option<u32> {

--- a/tests/naming_lint_test.rs
+++ b/tests/naming_lint_test.rs
@@ -1,0 +1,708 @@
+//! Tests for the opt-in naming-convention lint (issue #648, `--lint-naming`).
+//!
+//! Two layers:
+//!   - Library-level: parse a snippet and call `arch::typecheck::check_naming`
+//!     directly. The lint is pure casing logic over the *parsed* (pre-
+//!     elaboration) AST, so no resolve/typecheck/elaborate is needed — this
+//!     mirrors how `param_where_constraints.rs` tests `check_precedence`-style
+//!     passes.
+//!   - CLI-level: exercise the `--lint-naming` flag itself (opt-in gating,
+//!     `warn`/`off`/`error` values, the per-file suppression pragma, and
+//!     byte-identical codegen with/without the flag) via the built binary.
+
+use arch::lexer;
+use arch::parser::Parser;
+use arch::typecheck;
+
+/// Parse `source` and run the naming lint. Panics on a parse error (every
+/// fixture below is meant to parse cleanly — semantic validity doesn't
+/// matter since `check_naming` never resolves/typechecks).
+fn naming_warnings(source: &str) -> Vec<String> {
+    let tokens = lexer::tokenize(source).expect("lexer error");
+    let mut parser = Parser::new(tokens, source);
+    let ast = parser.parse_source_file().expect("parse error");
+    typecheck::check_naming(&ast)
+        .into_iter()
+        .map(|w| w.message)
+        .collect()
+}
+
+fn assert_no_warnings(source: &str) {
+    let warnings = naming_warnings(source);
+    assert!(
+        warnings.is_empty(),
+        "expected zero naming warnings, got: {warnings:?}"
+    );
+}
+
+/// Assert exactly one warning fires and its message equals `expected`
+/// verbatim (exact-text check, not just `contains`).
+fn assert_one_warning(source: &str, expected: &str) {
+    let warnings = naming_warnings(source);
+    assert_eq!(warnings, vec![expected.to_string()]);
+}
+
+// ── module (PascalCase) ────────────────────────────────────────────────────
+
+const MODULE_TMPL: &str = r#"
+module {NAME}
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port a: in Bool;
+  port y: out Bool;
+  comb
+    y = a;
+  end comb
+end module {NAME}
+"#;
+
+#[test]
+fn module_pascal_case_conforming_is_silent() {
+    assert_no_warnings(&MODULE_TMPL.replace("{NAME}", "FetchUnit"));
+}
+
+#[test]
+fn module_acronym_prefix_is_silent() {
+    // AXIBridge / FIFOCtrl-style acronym prefixes are legitimate PascalCase.
+    assert_no_warnings(&MODULE_TMPL.replace("{NAME}", "AXIBridge"));
+    assert_no_warnings(&MODULE_TMPL.replace("{NAME}", "FIFOCtrl"));
+}
+
+#[test]
+fn module_camelcase_violation_flagged_with_exact_text() {
+    assert_one_warning(
+        &MODULE_TMPL.replace("{NAME}", "moduleFoo"),
+        "module `moduleFoo` should be PascalCase (e.g. `ModuleFoo`) — see naming conventions",
+    );
+}
+
+#[test]
+fn module_snake_case_violation_suggests_titlecase_join() {
+    assert_one_warning(
+        &MODULE_TMPL.replace("{NAME}", "fetch_unit"),
+        "module `fetch_unit` should be PascalCase (e.g. `FetchUnit`) — see naming conventions",
+    );
+}
+
+// ── port (snake_case) ──────────────────────────────────────────────────────
+
+#[test]
+fn port_snake_case_conforming_is_silent() {
+    assert_no_warnings(
+        r#"
+module M
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port req_valid: in Bool;
+  port fifo2_ptr: out UInt<8>;
+  comb
+    fifo2_ptr = req_valid.zext<8>();
+  end comb
+end module M
+"#,
+    );
+}
+
+#[test]
+fn port_pascal_case_violation_flagged() {
+    assert_one_warning(
+        r#"
+module M
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port ReqValid: in Bool;
+  port y: out Bool;
+  comb
+    y = ReqValid;
+  end comb
+end module M
+"#,
+        "port `ReqValid` should be snake_case (e.g. `req_valid`) — see naming conventions",
+    );
+}
+
+// ── param (UPPER_SNAKE) ────────────────────────────────────────────────────
+
+#[test]
+fn param_upper_snake_conforming_is_silent() {
+    assert_no_warnings(
+        r#"
+module M
+  param XLEN: const = 32;
+  local param CACHE_DEPTH: const = 4;
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port a: in UInt<XLEN>;
+  port y: out UInt<XLEN>;
+  comb
+    y = a;
+  end comb
+end module M
+"#,
+    );
+}
+
+#[test]
+fn param_lowercase_violation_flagged() {
+    assert_one_warning(
+        r#"
+module M
+  param cache_depth: const = 4;
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port a: in Bool;
+  port y: out Bool;
+  comb
+    y = a;
+  end comb
+end module M
+"#,
+        "param `cache_depth` should be UPPER_SNAKE (e.g. `CACHE_DEPTH`) — see naming conventions",
+    );
+}
+
+// ── reg / wire (snake_case) ────────────────────────────────────────────────
+
+#[test]
+fn reg_wire_conforming_is_silent() {
+    assert_no_warnings(
+        r#"
+module M
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port a: in Bool;
+  port y: out Bool;
+  reg state_reg: Bool reset rst => 0;
+  wire next_state: Bool;
+  comb
+    next_state = a;
+    y = state_reg;
+  end comb
+  seq on clk rising
+    state_reg <= next_state;
+  end seq
+end module M
+"#,
+    );
+}
+
+#[test]
+fn reg_violation_flagged() {
+    let warnings = naming_warnings(
+        r#"
+module M
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port a: in Bool;
+  port y: out Bool;
+  reg StateReg: Bool reset rst => 0;
+  comb
+    y = a;
+  end comb
+  seq on clk rising
+    StateReg <= a;
+  end seq
+end module M
+"#,
+    );
+    assert_eq!(
+        warnings,
+        vec!["reg `StateReg` should be snake_case (e.g. `state_reg`) — see naming conventions"]
+    );
+}
+
+#[test]
+fn wire_violation_flagged() {
+    assert_one_warning(
+        r#"
+module M
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port a: in Bool;
+  port y: out Bool;
+  wire NextState: Bool;
+  comb
+    NextState = a;
+    y = NextState;
+  end comb
+end module M
+"#,
+        "wire `NextState` should be snake_case (e.g. `next_state`) — see naming conventions",
+    );
+}
+
+// ── let binding (snake_case), including struct destructuring ──────────────
+
+#[test]
+fn let_binding_violation_flagged() {
+    assert_one_warning(
+        r#"
+module M
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port a: in UInt<8>;
+  port y: out UInt<8>;
+  let ComputedVal: UInt<8> = a;
+  comb
+    y = ComputedVal;
+  end comb
+end module M
+"#,
+        "let binding `ComputedVal` should be snake_case (e.g. `computed_val`) — see naming conventions",
+    );
+}
+
+#[test]
+fn destructure_let_checks_field_names_not_placeholder() {
+    // The parser stores a synthesized `_destructure` placeholder in
+    // `LetBinding::name` for this form; it must never itself be flagged.
+    // The real user-written names live in `destructure_fields` and *are*
+    // checked individually.
+    let warnings = naming_warnings(
+        r#"
+struct Pair
+  FieldA: UInt<8>;
+  FieldB: UInt<8>;
+end struct Pair
+
+module M
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port p: in Pair;
+  port y: out UInt<8>;
+  let {FieldA, FieldB} = p;
+  comb
+    y = FieldA +% FieldB;
+  end comb
+end module M
+"#,
+    );
+    assert!(
+        !warnings.iter().any(|w| w.contains("_destructure")),
+        "parser's synthesized destructure placeholder leaked into a diagnostic: {warnings:?}"
+    );
+    assert_eq!(
+        warnings,
+        vec![
+            "let binding `FieldA` should be snake_case (e.g. `field_a`) — see naming conventions",
+            "let binding `FieldB` should be snake_case (e.g. `field_b`) — see naming conventions",
+        ]
+    );
+}
+
+#[test]
+fn destructure_let_conforming_is_silent() {
+    assert_no_warnings(
+        r#"
+struct Pair
+  a: UInt<8>;
+  b: UInt<8>;
+end struct Pair
+
+module M
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port p: in Pair;
+  port y: out UInt<8>;
+  let {a, b} = p;
+  comb
+    y = a +% b;
+  end comb
+end module M
+"#,
+    );
+}
+
+// ── function args / locals (snake_case) ────────────────────────────────────
+
+#[test]
+fn function_arg_and_local_violation_flagged() {
+    let warnings = naming_warnings(
+        r#"
+module M
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port a: in UInt<8>;
+  port y: out UInt<8>;
+
+  function helperFn(InputArg: UInt<8>) -> UInt<8>
+    let LocalTmp: UInt<8> = InputArg;
+    return LocalTmp;
+  end function helperFn
+
+  comb
+    y = helperFn(a);
+  end comb
+end module M
+"#,
+    );
+    assert_eq!(
+        warnings,
+        vec![
+            "function arg `InputArg` should be snake_case (e.g. `input_arg`) — see naming conventions",
+            "let binding `LocalTmp` should be snake_case (e.g. `local_tmp`) — see naming conventions",
+        ]
+    );
+}
+
+#[test]
+fn function_conforming_is_silent_including_function_name_itself() {
+    // `function` names have no documented casing convention (not in issue
+    // #648's construct-name list) — a camelCase function name must not be
+    // flagged, only its args/locals are in scope.
+    assert_no_warnings(
+        r#"
+module M
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port a: in UInt<8>;
+  port y: out UInt<8>;
+
+  function helperFn(input_arg: UInt<8>) -> UInt<8>
+    let local_tmp: UInt<8> = input_arg;
+    return local_tmp;
+  end function helperFn
+
+  comb
+    y = helperFn(a);
+  end comb
+end module M
+"#,
+    );
+}
+
+// ── other first-class constructs (PascalCase names) ─────────────────────────
+
+#[test]
+fn fsm_pascal_case() {
+    assert_one_warning(
+        r#"
+fsm vending_machine
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port active: out Bool;
+
+  state [Idle, Running]
+  default state Idle;
+
+  default
+    comb
+      active = false;
+    end comb
+  end default
+
+  state Idle
+    -> Running when true;
+  end state Idle
+
+  state Running
+    comb
+      active = true;
+    end comb
+    -> Idle when true;
+  end state Running
+end fsm vending_machine
+"#,
+        "fsm `vending_machine` should be PascalCase (e.g. `VendingMachine`) — see naming conventions",
+    );
+}
+
+#[test]
+fn fifo_pascal_case() {
+    assert_one_warning(
+        r#"
+fifo tx_queue
+  param DEPTH: const = 8;
+  param T: type = UInt<8>;
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port push_valid: in Bool;
+  port push_ready: out Bool;
+  port push_data: in T;
+  port pop_valid: out Bool;
+  port pop_ready: in Bool;
+  port pop_data: out T;
+end fifo tx_queue
+"#,
+        "fifo `tx_queue` should be PascalCase (e.g. `TxQueue`) — see naming conventions",
+    );
+}
+
+#[test]
+fn arbiter_pascal_case_and_port_array_signals() {
+    let warnings = naming_warnings(
+        r#"
+arbiter bus_arbiter
+  policy round_robin;
+  param N: const = 4;
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  ports[N] req
+    Valid: in Bool;
+    ready: out Bool;
+  end ports req
+  port grant_valid: out Bool;
+  port grant_requester: out UInt<2>;
+end arbiter bus_arbiter
+"#,
+    );
+    assert_eq!(
+        warnings,
+        vec![
+            "arbiter `bus_arbiter` should be PascalCase (e.g. `BusArbiter`) — see naming conventions",
+            "port `Valid` should be snake_case (e.g. `valid`) — see naming conventions",
+        ]
+    );
+}
+
+#[test]
+fn bus_pascal_case_and_signal_snake_case() {
+    let warnings = naming_warnings(
+        r#"
+bus axi_lite
+  param ADDR_W: const = 32;
+  AwValid: out Bool;
+  aw_ready: in Bool;
+end bus axi_lite
+"#,
+    );
+    assert_eq!(
+        warnings,
+        vec![
+            "bus `axi_lite` should be PascalCase (e.g. `AxiLite`) — see naming conventions",
+            "port `AwValid` should be snake_case (e.g. `aw_valid`) — see naming conventions",
+        ]
+    );
+}
+
+#[test]
+fn struct_and_enum_pascal_case() {
+    assert_one_warning(
+        r#"
+struct my_pair
+  a: UInt<8>;
+  b: UInt<8>;
+end struct my_pair
+"#,
+        "struct `my_pair` should be PascalCase (e.g. `MyPair`) — see naming conventions",
+    );
+    assert_one_warning(
+        r#"
+enum alu_op
+  Add,
+  Sub,
+end enum alu_op
+"#,
+        "enum `alu_op` should be PascalCase (e.g. `AluOp`) — see naming conventions",
+    );
+}
+
+#[test]
+fn domain_pascal_case() {
+    assert_one_warning(
+        r#"
+domain my_domain
+  freq_mhz: 100
+end domain my_domain
+"#,
+        "domain `my_domain` should be PascalCase (e.g. `MyDomain`) — see naming conventions",
+    );
+}
+
+#[test]
+fn template_name_unchecked_but_params_and_ports_checked() {
+    // `template` isn't in issue #648's construct-name list (no documented
+    // casing convention for it), so its own name must be silent — but its
+    // params/ports are still real `param`/`port` declarations.
+    let warnings = naming_warnings(
+        r#"
+template my_interface
+  param num_req: const;
+  port clk: in Clock<SysDomain>;
+  port GrantValid: out Bool;
+end template my_interface
+"#,
+    );
+    assert_eq!(
+        warnings,
+        vec![
+            "param `num_req` should be UPPER_SNAKE (e.g. `NUM_REQ`) — see naming conventions",
+            "port `GrantValid` should be snake_case (e.g. `grant_valid`) — see naming conventions",
+        ]
+    );
+}
+
+// ── generate blocks (ports/wires declared inside `generate for`/`if`) ──────
+
+#[test]
+fn generate_for_port_and_wire_checked() {
+    let warnings = naming_warnings(
+        r#"
+module M
+  param N: const = 2;
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+
+  generate_for i in 0..N-1
+    wire GenWire: Bool;
+    comb
+      GenWire = true;
+    end comb
+  end generate_for
+end module M
+"#,
+    );
+    assert_eq!(
+        warnings,
+        vec!["wire `GenWire` should be snake_case (e.g. `gen_wire`) — see naming conventions"]
+    );
+}
+
+// ── `.archi` interface stubs are skipped entirely ──────────────────────────
+
+#[test]
+fn is_interface_stub_is_skipped() {
+    let source = MODULE_TMPL.replace("{NAME}", "fetchUnit");
+    let tokens = lexer::tokenize(&source).expect("lexer error");
+    let mut parser = Parser::new(tokens, &source);
+    let mut ast = parser.parse_source_file().expect("parse error");
+    // Simulates the post-parse tagger main.rs applies to items loaded from
+    // a `.archi` interface stub (port-only mirror of an already-linted
+    // `.arch` file) — must not be double-reported.
+    for item in &mut ast.items {
+        item.set_is_interface(true);
+    }
+    let warnings = typecheck::check_naming(&ast);
+    assert!(
+        warnings.is_empty(),
+        "is_interface item must be skipped entirely, got: {warnings:?}"
+    );
+}
+
+// ── CLI-level: flag plumbing, opt-in guarantee, suppression pragma ─────────
+
+mod cli {
+    use std::process::Command;
+
+    const BAD_MODULE: &str = r#"
+module fetchUnit
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port ReqValid: in Bool;
+  port dataOut: out UInt<8>;
+  comb
+    dataOut = ReqValid.zext<8>();
+  end comb
+end module fetchUnit
+"#;
+
+    fn run_check(path: &std::path::Path, extra: &[&str]) -> (i32, String) {
+        let mut cmd = Command::new(env!("CARGO_BIN_EXE_arch"));
+        cmd.arg("check").arg(path);
+        for a in extra {
+            cmd.arg(a);
+        }
+        let out = cmd.output().expect("run arch check");
+        let mut combined = String::from_utf8_lossy(&out.stdout).into_owned();
+        combined.push_str(&String::from_utf8_lossy(&out.stderr));
+        (out.status.code().unwrap_or(-1), combined)
+    }
+
+    #[test]
+    fn absent_flag_emits_zero_naming_warnings() {
+        let td = tempfile::tempdir().expect("tempdir");
+        let path = td.path().join("Bad.arch");
+        std::fs::write(&path, BAD_MODULE).expect("write");
+        let (code, out) = run_check(&path, &[]);
+        assert_eq!(code, 0, "output: {out}");
+        assert!(
+            !out.contains("see naming conventions"),
+            "flag absent must never emit naming diagnostics: {out}"
+        );
+    }
+
+    #[test]
+    fn bare_flag_and_explicit_warn_both_enable_the_lint() {
+        let td = tempfile::tempdir().expect("tempdir");
+        let path = td.path().join("Bad.arch");
+        std::fs::write(&path, BAD_MODULE).expect("write");
+
+        let (code_bare, out_bare) = run_check(&path, &["--lint-naming"]);
+        assert_eq!(code_bare, 0, "output: {out_bare}");
+        assert!(out_bare.contains(
+            "module `fetchUnit` should be PascalCase (e.g. `FetchUnit`) — see naming conventions"
+        ));
+        assert!(out_bare.contains(
+            "port `ReqValid` should be snake_case (e.g. `req_valid`) — see naming conventions"
+        ));
+        assert!(out_bare.contains(
+            "port `dataOut` should be snake_case (e.g. `data_out`) — see naming conventions"
+        ));
+
+        let (code_warn, out_warn) = run_check(&path, &["--lint-naming=warn"]);
+        assert_eq!(code_warn, 0, "output: {out_warn}");
+        assert_eq!(out_bare, out_warn, "bare flag and `=warn` must agree");
+    }
+
+    #[test]
+    fn explicit_off_is_silent() {
+        let td = tempfile::tempdir().expect("tempdir");
+        let path = td.path().join("Bad.arch");
+        std::fs::write(&path, BAD_MODULE).expect("write");
+        let (code, out) = run_check(&path, &["--lint-naming=off"]);
+        assert_eq!(code, 0, "output: {out}");
+        assert!(!out.contains("see naming conventions"));
+    }
+
+    #[test]
+    fn error_severity_is_rejected_not_silently_accepted() {
+        let td = tempfile::tempdir().expect("tempdir");
+        let path = td.path().join("Bad.arch");
+        std::fs::write(&path, BAD_MODULE).expect("write");
+        let (code, out) = run_check(&path, &["--lint-naming=error"]);
+        assert_ne!(code, 0, "output: {out}");
+        assert!(
+            out.contains("--lint-naming: expected `warn` or `off`"),
+            "output: {out}"
+        );
+    }
+
+    #[test]
+    fn per_file_suppression_pragma_silences_the_lint() {
+        let td = tempfile::tempdir().expect("tempdir");
+        let path = td.path().join("Bad.arch");
+        let source = format!("// arch-lint-naming: off\n{BAD_MODULE}");
+        std::fs::write(&path, source).expect("write");
+        let (code, out) = run_check(&path, &["--lint-naming=warn"]);
+        assert_eq!(code, 0, "output: {out}");
+        assert!(!out.contains("see naming conventions"), "output: {out}");
+    }
+
+    #[test]
+    fn build_emission_is_byte_identical_regardless_of_flag_value() {
+        let td = tempfile::tempdir().expect("tempdir");
+        let arch_path = td.path().join("Bad.arch");
+        std::fs::write(&arch_path, BAD_MODULE).expect("write");
+
+        let run_build = |extra: &[&str]| -> Vec<u8> {
+            let out_path = td.path().join(format!("out_{}.sv", extra.join("_")));
+            let mut cmd = Command::new(env!("CARGO_BIN_EXE_arch"));
+            cmd.arg("build").arg(&arch_path).arg("-o").arg(&out_path);
+            for a in extra {
+                cmd.arg(a);
+            }
+            let status = cmd.status().expect("run arch build");
+            assert!(status.success());
+            std::fs::read(&out_path).expect("read sv output")
+        };
+
+        let no_flag = run_build(&[]);
+        let warn = run_build(&["--lint-naming=warn"]);
+        let off = run_build(&["--lint-naming=off"]);
+        assert_eq!(
+            no_flag, warn,
+            "SV emission must not depend on --lint-naming"
+        );
+        assert_eq!(no_flag, off, "SV emission must not depend on --lint-naming");
+    }
+}


### PR DESCRIPTION
## Summary

Adds `arch::typecheck::check_naming`, a pure identifier-casing lint over the parsed (pre-elaboration) `SourceFile`, gated behind a new `--lint-naming` flag on `arch check` / `arch build`.

Closes #648.

Rules (per spec §2.1's naming table / the issue's "Proposed behavior" list):

- **Construct names → PascalCase**: `module`, `fsm`, `fifo`, `ram`, `cam`, `counter`, `arbiter`, `regfile`, `pipeline`, `linklist`, `bus`, `synchronizer`, `clkgate`, `struct`, `enum`, `package`, `domain`. (`function`/`template` aren't in the issue's construct-name list — no documented casing convention for either — so their own names are left unchecked; their nested `param`/`port` declarations still are.)
- **Signals → snake_case**: ports, `reg`, `wire`, `let` bindings (including struct-destructuring field names), module-local function args/locals.
- **Params/consts → UPPER_SNAKE**: every `param` declaration, wherever it's nested (module/construct/bus/template/credit_channel).

Not attempted (per the issue's own Non-goals): `Clock<Domain>`/`Reset<...>` port *type*-shape enforcement — this is purely identifier casing.

## Opt-in / non-enforcement guarantee

Spec §2.1 and the standing maintainer decision say naming conventions are recommended, not compiler-enforced — this lint is strictly opt-in and warning-only:

- **Flag absent (default): zero behavior change.** No new diagnostics, byte-identical `arch build` emission — verified by `cli::build_emission_is_byte_identical_regardless_of_flag_value`, which diffs SV output with no flag / `--lint-naming=warn` / `--lint-naming=off` and asserts all three are byte-for-byte identical.
- `--lint-naming` (bare) or `--lint-naming=warn`: enables the lint. Violations are warnings only — printed through the same `warning: ... (file:line)` path as every other compiler warning — and never fail the build.
- `--lint-naming=off`: explicit disable, same as omitting the flag.
- `--lint-naming=error` **is rejected outright** with a clear CLI error. There is no error-severity mode in v1 (issue Non-goals: "Not a hard compile error in v1").
- `// arch-lint-naming: off` as a source line anywhere in a file suppresses the lint for that file (per the issue's acceptance criteria, ahead of a possible future default-on promotion). Implemented as a raw-text scan over each file's original source — independent of parsing, so it can't itself introduce a false positive.

## Compiler-synthesized-identifier exemption

The lint walks the AST at the same stage as the existing `check_precedence` pass — **before** elaboration (`generate` expansion, thread lowering, credit-channel dispatch, TLM lowering). This isn't just a performance shortcut: it structurally means compiler-synthesized identifiers (`_threads` submodules, `__ri0`-style internal thread-lowering regs, generate-expanded `w_0`/`w_1` suffixes, credit-channel dispatch wires, ...) **never exist in the AST this pass sees**, so there's nothing to spuriously flag.

The one exception: the *parser itself* synthesizes a `_destructure` placeholder name in `LetBinding::name` for struct-destructuring `let {a, b} = expr;` bindings (see the doc comment on `LetBinding::destructure_fields`), and that placeholder *is* present pre-elaboration. It's explicitly skipped; the real user-written names in `destructure_fields` are checked individually instead (`check_let_binding_naming`, covered by `destructure_let_checks_field_names_not_placeholder`, which asserts `_destructure` never appears in a diagnostic).

`.archi` interface-stub items (`is_interface == true`) are skipped entirely — they're compiler-emitted mirrors of a construct already declared (and already linted) in its originating `.arch` file; linting the stub too would just double-report the same violation.

## Corpus dry-run (the key datum)

Ran `arch check <file> --lint-naming=warn` per-file over every `.arch` file under `tests/` + `examples/` (886 files). No fixtures were modified — this is read-only reporting, as requested.

- **886 files total**: 790 checked successfully standalone, 96 failed to check standalone (missing sibling `inst` dependencies not auto-discoverable without a prior `.archi` build, or intentionally-invalid negative-test fixtures) and are **not** included below — this is a known undercount.
- Raw warning count across the 790 successfully-checked files: 768. Some fixtures pull in a shared dependency file (e.g. `e203_ifu.arch` → `e203_ifu_ifetch.arch`) that also gets checked standalone elsewhere, double-counting a handful of violations. Deduplicating by the diagnostic's actual `(file:offset)`:

**613 unique violations across 337 distinct files** (42.7% of the 790 checkable files have ≥1 violation).

By category:

| category | count |
|---|---:|
| module | 299 |
| port | 174 |
| let binding | 57 |
| reg | 25 |
| param | 23 |
| fsm | 13 |
| wire | 8 |
| cam | 6 |
| synchronizer | 5 |
| pipeline | 1 |
| linklist | 1 |
| arbiter | 1 |

By convention: 326 PascalCase, 264 snake_case, 23 UPPER_SNAKE.

**Categorized sample:**

```
tests/e203/e203_cpu_top.arch    | module `e203_cpu_top` should be PascalCase (e.g. `E203CpuTop`)
tests/e203/e203_exu_decode.arch | module `e203_exu_decode` should be PascalCase (e.g. `E203ExuDecode`)
tests/mac_table.arch            | module `mac_table` should be PascalCase (e.g. `MacTable`)
tests/cvdp/pipelined_adder_32bit.arch | port `A` should be snake_case (e.g. `a`)
tests/cvdp/SR_flipflop.arch     | port `i_S` should be snake_case (e.g. `i_s`)
tests/cvdp/barrel_shifter.arch  | param `data_width` should be UPPER_SNAKE (e.g. `DATA_WIDTH`)
tests/cvdp/signedadder.arch     | let binding `ST_IDLE` should be snake_case (e.g. `st_idle`)
tests/e203/e203_ifu_ifetch.arch | wire `_nc_mulhsu` should be snake_case (e.g. `nc_mulhsu`)
tests/formal/hier_adder_proves.arch | let binding `_check` should be snake_case (e.g. `check`)
tests/cvdp/bus_arbiter_rr.arch  | arbiter `bus_arbiter_rr` should be PascalCase (e.g. `BusArbiterRr`)
```

**What this tells the maintainer, per the task's own framing:**

1. **Module-name PascalCase is the single biggest source of violations (299/613, ~49%)**, concentrated almost entirely in `tests/e203/*` (a ported RISC-V core whose module names deliberately mirror upstream SV: `e203_cpu_top`, `e203_exu_decode`, ...) and `tests/cvdp/*` (benchmark fixtures also named after upstream/spec identifiers). This is *exactly* the tension the issue itself calls out via #251 — SV-interop naming (matching an upstream module name so `arch build -o auto` lines up) legitimately conflicts with PascalCase-for-modules. A default-on promotion of this specific rule would likely need either a per-file/per-module escape hatch used routinely, or scoping it down to "recommend, don't warn" for ported/interop modules.
2. **Port violations (174, ~28%) cluster in `tests/cvdp/*`**, mostly single/double-letter uppercase names (`A`, `B`, `S`, `Co`, `i_S`, `o_Q`) mirroring textbook/spec notation from academic-style benchmark problems — again a deliberate external-reference match, not sloppiness.
3. **A handful of `let`-bound values use UPPER_SNAKE names for what are conceptually FSM-state constants** (`ST_IDLE`, `ST_LOAD`, ...) — declared via `let` rather than `param const`, so they land in the snake_case bucket. Worth flagging as a possible future policy question (should constant-valued `let`s get param-like treatment?) rather than something this PR should silently special-case.
4. **Two real leading-underscore user-written violations surfaced** (`let _check`, `wire _nc_mulhsu`) — confirms the compiler-synthesized-identifier exemption is working precisely as scoped: only the parser's own `_destructure` placeholder is exempted, not underscore-prefixed style choices in general, so these get (correctly, in this implementation's judgment) flagged as real, fixable violations.

No fixture was modified to accommodate this data — reporting only, as instructed.

## Tests

`tests/naming_lint_test.rs` (31 tests, all passing):

- Library-level tests calling `check_naming` directly, one conforming + one violating case (exact message text) per category: module (incl. acronym-prefix `AXIBridge`/`FIFOCtrl` silence), port (incl. digit-mid-word `fifo2_ptr` silence), param, reg, wire, let binding, function arg/local.
- Destructuring-`let` coverage: violating field names flagged individually, `_destructure` placeholder never leaks into a diagnostic, conforming case silent.
- Representative spot-checks for fsm/fifo/arbiter/bus/struct/enum/domain/template (template's own name unchecked, its params/ports still checked) and `generate_for` body ports/wires.
- `is_interface` stub skip (simulated via `Item::set_is_interface`).
- CLI-level: flag absent → zero diagnostics; bare flag and `=warn` agree; `=off` silent; `=error` rejected with the documented message; suppression pragma silences a file with real violations; `arch build` SV output is byte-identical across no-flag/`=warn`/`=off`.

## Verification

- `cargo build --release`: clean.
- `cargo test --release`: full suite green (lib: 72/72, formal_test: 25/25 — required a one-time `lake build` in `proofs/lean_thread_lowering/` in this fresh worktree, unrelated to this change — integration_test: 774/774, naming_lint_test: 31/31, module_layout_test/param_where_constraints/pipelined_*: all green, fp_test: 46/46 in isolation). One `fp_test::fp_formal_float_props` run flaked under heavy shared-machine load (SMT solver hit the default 60s timeout on `add_comm`, unrelated FP formal-proofs area this PR never touches); reproduced the flake, then reproduced a clean pass both in isolation and with `--test-threads=1` (46/46, 846s) once contention was removed — confirmed pre-existing/environmental, not a regression.
- `cargo fmt --all --check`: clean.
- `cargo clippy --release --all-targets`: zero errors; zero new warnings (all pre-existing warnings are in `tests/integration_test.rs`, none in the files this PR touches).
- `scripts/claim_check.sh --grep "naming"` / `--grep "648"`: clear before starting. `--grep "lint"` hit two unrelated PRs (SV lint-dependency resolution, FMA proof lint cleanup) — no true overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
