### PR TITLE
fix(check): validate inst connections name a real port of child (fix #797)

### DIFF
--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -6888,7 +6888,11 @@ impl<'a> TypeChecker<'a> {
         }
         for i in 1..=n {
             for j in 1..=m {
-                let cost = if a_chars[i - 1] == b_chars[j - 1] { 0 } else { 1 };
+                let cost = if a_chars[i - 1] == b_chars[j - 1] {
+                    0
+                } else {
+                    1
+                };
                 dp[i][j] = (dp[i - 1][j] + 1)
                     .min(dp[i][j - 1] + 1)
                     .min(dp[i - 1][j - 1] + cost);
@@ -6974,7 +6978,8 @@ impl<'a> TypeChecker<'a> {
                         let count = self
                             .eval_const_expr(&pa.count_expr, &HashMap::new())
                             .map(|v| v as u32);
-                        let sigs: Vec<String> = pa.signals.iter().map(|s| s.name.name.clone()).collect();
+                        let sigs: Vec<String> =
+                            pa.signals.iter().map(|s| s.name.name.clone()).collect();
                         port_array_bases.insert(pa.name.name.clone(), (count, sigs));
                     }
                 }
@@ -6984,7 +6989,8 @@ impl<'a> TypeChecker<'a> {
                             let count = self
                                 .eval_const_expr(&pa.count_expr, &HashMap::new())
                                 .map(|v| v as u32);
-                            let sigs: Vec<String> = pa.signals.iter().map(|s| s.name.name.clone()).collect();
+                            let sigs: Vec<String> =
+                                pa.signals.iter().map(|s| s.name.name.clone()).collect();
                             port_array_bases.insert(pa.name.name.clone(), (count, sigs));
                         }
                     }
@@ -7121,7 +7127,9 @@ impl<'a> TypeChecker<'a> {
                                 if let Some(und_pos) = rest.find('_') {
                                     let (idx_part, sig_part_with_und) = rest.split_at(und_pos);
                                     let sig_part = &sig_part_with_und[1..];
-                                    if idx_part.parse::<u32>().is_ok() && signals.contains(&sig_part.to_string()) {
+                                    if idx_part.parse::<u32>().is_ok()
+                                        && signals.contains(&sig_part.to_string())
+                                    {
                                         is_valid = true;
                                         break;
                                     }

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -7009,9 +7009,26 @@ impl<'a> TypeChecker<'a> {
             }
         }
 
+        // Ram port groups: `ports rd_port ... end ports rd_port` → `rd_port_addr`.
+        let mut ram_port_groups: BTreeMap<String, Vec<String>> = BTreeMap::new();
+        if let Some(Item::Ram(r)) = self.find_item_by_name(&inst.module_name.name) {
+            if r.is_interface && r.port_groups.is_empty() {
+                return;
+            }
+            for pg in &r.port_groups {
+                let sigs: Vec<String> = pg.signals.iter().map(|s| s.name.name.clone()).collect();
+                ram_port_groups.insert(pg.name.name.clone(), sigs);
+            }
+        }
+
         // Candidate pool for did_you_mean: base names + flattened bus signals (scalar, non-permissive).
         let mut candidates_set: BTreeSet<String> = base_names.clone();
         candidates_set.extend(linklist_op_ports.iter().cloned());
+        for (base, signals) in &ram_port_groups {
+            for sig in signals {
+                candidates_set.insert(format!("{}_{}", base, sig));
+            }
+        }
         for (base, (signals, permissive)) in &bus_map {
             if *permissive {
                 continue;
@@ -7150,6 +7167,17 @@ impl<'a> TypeChecker<'a> {
                                     is_valid = true;
                                     break;
                                 }
+                            }
+                        }
+                    }
+                }
+                // Ram port groups: `rd_port_addr`.
+                if !is_valid {
+                    for (base, signals) in &ram_port_groups {
+                        if let Some(suffix) = cname.strip_prefix(&format!("{}_", base)) {
+                            if signals.contains(&suffix.to_string()) {
+                                is_valid = true;
+                                break;
                             }
                         }
                     }

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 
 use crate::ast::*;
 use crate::diagnostics::{span_to_source_span, CompileError, CompileWarning};
@@ -1126,6 +1126,7 @@ impl<'a> TypeChecker<'a> {
                     for gi in items {
                         if let crate::ast::GenItem::Inst(inst) = gi {
                             self.check_inst_param_constraints(inst);
+                            self.validate_inst_ports(inst);
                             // Look up the instantiated module's bus ports so we can
                             // mark per-bus-signal flat names for bus-typed inst-outputs
                             // (`inst_port -> outer_vec[loop_var]`), mirroring
@@ -1219,6 +1220,14 @@ impl<'a> TypeChecker<'a> {
                                         }
                                     }
                                 }
+                            }
+                        }
+                    }
+                    if let crate::ast::GenerateDecl::If(gi) = gen {
+                        for gi in &gi.else_items {
+                            if let crate::ast::GenItem::Inst(inst) = gi {
+                                self.check_inst_param_constraints(inst);
+                                self.validate_inst_ports(inst);
                             }
                         }
                     }
@@ -1775,6 +1784,9 @@ impl<'a> TypeChecker<'a> {
                 }
             }
         }
+
+        // Validate connections → ports (reverse direction) before driven marking.
+        self.validate_inst_ports(inst);
 
         // Base names of the child's Vec-of-bus ports (`port mm: ...
         // Vec<Bus, N>`). The parser flattens a per-element connection
@@ -6825,7 +6837,7 @@ impl<'a> TypeChecker<'a> {
     /// Find the top-level construct item declaring `name` (module, fsm,
     /// fifo, ram, arbiter, pipeline, bus, ...). Used by the instantiation-
     /// site `where` check to look up the target's `ParamDecl` list.
-    fn find_item_by_name(&self, name: &str) -> Option<&Item> {
+    fn find_item_by_name(&self, name: &str) -> Option<&'a Item> {
         self.source.items.iter().find(|item| match item {
             Item::Module(m) => m.name.name == name,
             Item::Fsm(f) => f.name.name == name,
@@ -6843,6 +6855,314 @@ impl<'a> TypeChecker<'a> {
             Item::Template(t) => t.name.name == name,
             _ => false,
         })
+    }
+
+    fn child_ports(&self, child_name: &str) -> Option<&'a [PortDecl]> {
+        let item = self.find_item_by_name(child_name)?;
+        match item {
+            Item::Module(m) => Some(&m.ports),
+            Item::Fsm(f) => Some(&f.ports),
+            Item::Pipeline(p) => Some(&p.ports),
+            Item::Fifo(f) => Some(&f.ports),
+            Item::Ram(r) => Some(&r.ports),
+            Item::Cam(c) => Some(&c.ports),
+            Item::Counter(c) => Some(&c.ports),
+            Item::Arbiter(a) => Some(&a.ports),
+            Item::Regfile(r) => Some(&r.ports),
+            Item::Linklist(l) => Some(&l.ports),
+            _ => None,
+        }
+    }
+
+    fn levenshtein(a: &str, b: &str) -> usize {
+        let a_chars: Vec<char> = a.chars().collect();
+        let b_chars: Vec<char> = b.chars().collect();
+        let n = a_chars.len();
+        let m = b_chars.len();
+        let mut dp = vec![vec![0; m + 1]; n + 1];
+        for i in 0..=n {
+            dp[i][0] = i;
+        }
+        for j in 0..=m {
+            dp[0][j] = j;
+        }
+        for i in 1..=n {
+            for j in 1..=m {
+                let cost = if a_chars[i - 1] == b_chars[j - 1] { 0 } else { 1 };
+                dp[i][j] = (dp[i - 1][j] + 1)
+                    .min(dp[i][j - 1] + 1)
+                    .min(dp[i - 1][j - 1] + cost);
+            }
+        }
+        dp[n][m]
+    }
+
+    fn did_you_mean(target: &str, candidates: &[String]) -> Option<String> {
+        candidates
+            .iter()
+            .map(|c| (Self::levenshtein(target, c), c))
+            .filter(|(d, _)| *d > 0 && *d <= 3)
+            .min_by_key(|(d, c)| (*d, (*c).clone()))
+            .map(|(_, c)| c.clone())
+    }
+
+    fn validate_inst_ports(&mut self, inst: &InstDecl) {
+        let Some(ports) = self.child_ports(&inst.module_name.name) else {
+            return;
+        };
+
+        // Build lookups.
+        let base_names: BTreeSet<String> = ports.iter().map(|p| p.name.name.clone()).collect();
+
+        let mut bus_map: BTreeMap<String, (Vec<String>, bool)> = BTreeMap::new();
+        for p in ports {
+            if let Some(bi) = &p.bus_info {
+                let bus_name = &bi.bus_name.name;
+                if let Some((Symbol::Bus(info), _)) = self.symbols.globals.get(bus_name) {
+                    let mut param_map = info.default_param_map();
+                    for pa in &bi.params {
+                        param_map.insert(pa.name.name.clone(), &pa.value);
+                    }
+                    let eff = info.effective_signals(&param_map);
+                    let signals: Vec<String> = eff.into_iter().map(|(s, _, _)| s).collect();
+                    let permissive = !info.handshakes.is_empty()
+                        || !info.credit_channels.is_empty()
+                        || !info.tlm_methods.is_empty()
+                        || signals.is_empty();
+                    bus_map.insert(p.name.name.clone(), (signals, permissive));
+                } else {
+                    bus_map.insert(p.name.name.clone(), (Vec::new(), true));
+                }
+            }
+        }
+
+        let mut vec_scalar_bases: BTreeMap<String, Option<u32>> = BTreeMap::new();
+        for p in ports {
+            if p.bus_info.is_none() {
+                if let TypeExpr::Vec(_, size_expr) = &p.ty {
+                    let count = self
+                        .eval_const_expr(size_expr, &HashMap::new())
+                        .map(|v| v as u32);
+                    vec_scalar_bases.insert(p.name.name.clone(), count);
+                }
+            }
+        }
+
+        let mut vob_bases: BTreeMap<String, (Option<u32>, Vec<String>, bool)> = BTreeMap::new();
+        for p in ports {
+            if let Some(bi) = &p.bus_info {
+                if let Some(count_expr) = &bi.count {
+                    let count = self
+                        .eval_const_expr(count_expr, &HashMap::new())
+                        .map(|v| v as u32);
+                    let (signals, permissive) = bus_map
+                        .get(&p.name.name)
+                        .cloned()
+                        .unwrap_or((Vec::new(), true));
+                    vob_bases.insert(p.name.name.clone(), (count, signals, permissive));
+                }
+            }
+        }
+
+        // Port-array bases for Arbiter / Regfile `ports[N]` style: `request[N] valid/ready` → `request0_valid`.
+        // These are not `Vec` nor `Bus` but `PortArrayDecl`.
+        let mut port_array_bases: BTreeMap<String, (Option<u32>, Vec<String>)> = BTreeMap::new();
+        if let Some(item) = self.find_item_by_name(&inst.module_name.name) {
+            match item {
+                Item::Arbiter(a) => {
+                    for pa in &a.port_arrays {
+                        let count = self
+                            .eval_const_expr(&pa.count_expr, &HashMap::new())
+                            .map(|v| v as u32);
+                        let sigs: Vec<String> = pa.signals.iter().map(|s| s.name.name.clone()).collect();
+                        port_array_bases.insert(pa.name.name.clone(), (count, sigs));
+                    }
+                }
+                Item::Regfile(r) => {
+                    for pa_opt in [&r.read_ports, &r.write_ports] {
+                        if let Some(pa) = pa_opt {
+                            let count = self
+                                .eval_const_expr(&pa.count_expr, &HashMap::new())
+                                .map(|v| v as u32);
+                            let sigs: Vec<String> = pa.signals.iter().map(|s| s.name.name.clone()).collect();
+                            port_array_bases.insert(pa.name.name.clone(), (count, sigs));
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        // Linklist op ports: `op insert_tail { port req_valid }` → `insert_tail_req_valid`.
+        let mut linklist_op_ports: BTreeSet<String> = BTreeSet::new();
+        if let Some(Item::Linklist(l)) = self.find_item_by_name(&inst.module_name.name) {
+            for op in &l.ops {
+                for p in &op.ports {
+                    linklist_op_ports.insert(format!("{}_{}", op.name.name, p.name.name));
+                }
+            }
+        }
+
+        // Candidate pool for did_you_mean: base names + flattened bus signals (scalar, non-permissive).
+        let mut candidates_set: BTreeSet<String> = base_names.clone();
+        candidates_set.extend(linklist_op_ports.iter().cloned());
+        for (base, (signals, permissive)) in &bus_map {
+            if *permissive {
+                continue;
+            }
+            if vob_bases.contains_key(base) {
+                continue;
+            }
+            for sig in signals {
+                candidates_set.insert(format!("{}_{}", base, sig));
+            }
+        }
+        let candidates: Vec<String> = candidates_set.into_iter().collect();
+
+        for conn in &inst.connections {
+            let cname = conn.port_name.name.as_str();
+            let mut is_valid = false;
+            if base_names.contains(cname) || linklist_op_ports.contains(cname) {
+                is_valid = true;
+            } else {
+                // Scalar bus per-field.
+                for (base, (signals, permissive)) in &bus_map {
+                    if vob_bases.contains_key(base) {
+                        continue;
+                    }
+                    if let Some(suffix) = cname.strip_prefix(&format!("{}_", base)) {
+                        if *permissive {
+                            is_valid = true;
+                            break;
+                        } else if signals.contains(&suffix.to_string()) {
+                            is_valid = true;
+                            break;
+                        }
+                    }
+                }
+                // Vec scalar per-element.
+                if !is_valid {
+                    for (base, count_opt) in &vec_scalar_bases {
+                        if let Some(suffix) = cname.strip_prefix(&format!("{}_", base)) {
+                            if suffix.parse::<u32>().is_ok() {
+                                if let Some(n) = count_opt {
+                                    if let Ok(idx) = suffix.parse::<u32>() {
+                                        if idx < *n {
+                                            is_valid = true;
+                                            break;
+                                        } else {
+                                            // Out-of-bounds idx still considered valid here;
+                                            // bounds are checked elsewhere. Treat as valid to avoid duplicate error.
+                                            is_valid = true;
+                                            break;
+                                        }
+                                    }
+                                } else {
+                                    is_valid = true;
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }
+                // Vec<Bus>.
+                if !is_valid {
+                    for (base, (_count_opt, signals, permissive)) in &vob_bases {
+                        if let Some(rest) = cname.strip_prefix(&format!("{}_", base)) {
+                            if rest.parse::<u32>().is_ok() {
+                                // base_<idx>
+                                is_valid = true;
+                                break;
+                            } else {
+                                let mut parts = rest.splitn(2, '_');
+                                let idxp = parts.next().unwrap();
+                                if let Some(sigp) = parts.next() {
+                                    if idxp.parse::<u32>().is_ok()
+                                        && (*permissive || signals.contains(&sigp.to_string()))
+                                    {
+                                        is_valid = true;
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+                        // Also handle `base{idx}_{signal}` without underscore before idx (e.g., chans0_valid from `chans[0].valid`).
+                        if cname.starts_with(base) {
+                            let rest2 = &cname[base.len()..];
+                            if !rest2.is_empty() && rest2.chars().next().unwrap().is_ascii_digit() {
+                                if let Some(und_pos) = rest2.find('_') {
+                                    let (idx_part, sig_part_with_und) = rest2.split_at(und_pos);
+                                    let sig_part = &sig_part_with_und[1..];
+                                    if idx_part.parse::<u32>().is_ok()
+                                        && (*permissive || signals.contains(&sig_part.to_string()))
+                                    {
+                                        is_valid = true;
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                // Port-array bases (Arbiter / Regfile `ports[N]`): `request0_valid` and `request_valid` whole-vector.
+                if !is_valid {
+                    for (base, (_count_opt, signals)) in &port_array_bases {
+                        // Whole-vector per-signal: `request_valid` (base + "_" + signal) – valid for any count.
+                        if let Some(suffix) = cname.strip_prefix(&format!("{}_", base)) {
+                            if signals.contains(&suffix.to_string()) {
+                                is_valid = true;
+                                break;
+                            }
+                        }
+                        // Indexed form: `request0_valid` (base + idx + "_" + signal)
+                        if cname.starts_with(base) {
+                            let rest = &cname[base.len()..];
+                            if !rest.is_empty() && rest.chars().next().unwrap().is_ascii_digit() {
+                                if let Some(und_pos) = rest.find('_') {
+                                    let (idx_part, sig_part_with_und) = rest.split_at(und_pos);
+                                    let sig_part = &sig_part_with_und[1..];
+                                    if idx_part.parse::<u32>().is_ok() && signals.contains(&sig_part.to_string()) {
+                                        is_valid = true;
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                // Vec<Bus> per-signal whole-vector: `mm_valid` (base + "_" + signal) for packed vector.
+                if !is_valid {
+                    for (base, (_count_opt, signals, permissive)) in &vob_bases {
+                        if let Some(suffix) = cname.strip_prefix(&format!("{}_", base)) {
+                            if *permissive || signals.contains(&suffix.to_string()) {
+                                // This covers `mm_valid`, `mm_data` etc. It also matches `mm_0`? But `mm_0` suffix is numeric, not a signal, so not in signals and not permissive (signals not empty) → not valid here, but already handled above as base_<idx>.
+                                // So only per-signal whole-vector will be true.
+                                // Need to ensure suffix is a signal, not numeric idx.
+                                if signals.contains(&suffix.to_string()) || *permissive {
+                                    is_valid = true;
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            if !is_valid {
+                let span = if conn.port_name.span.start != 0 || conn.port_name.span.end != 0 {
+                    conn.port_name.span
+                } else {
+                    conn.span
+                };
+                let mut msg = format!(
+                    "inst `{}` connects `{}`, which is not a port of `{}`",
+                    inst.name.name, conn.port_name.name, inst.module_name.name
+                );
+                if let Some(sugg) = Self::did_you_mean(cname, &candidates) {
+                    msg.push_str(&format!(" (did you mean `{}`?)", sugg));
+                }
+                self.errors.push(CompileError::general(&msg, span));
+            }
+        }
     }
 
     /// Instantiation-site `where` clause check (issue #600). Evaluates

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -6912,6 +6912,24 @@ impl<'a> TypeChecker<'a> {
             .map(|(_, c)| c.clone())
     }
 
+    /// `cname.strip_prefix(&format!("{base}_"))` without building the prefix.
+    ///
+    /// `validate_inst_ports` runs this per (connection x candidate base) across
+    /// several passes, and children like `e203_biu` carry 124 ports, so the
+    /// throwaway `String` per comparison is worth avoiding.
+    fn strip_base_prefix<'s>(cname: &'s str, base: &str) -> Option<&'s str> {
+        cname.strip_prefix(base)?.strip_prefix('_')
+    }
+
+    /// Split `"<idx>_<signal>"` for the flattened per-element bus shapes:
+    /// `chans_0_valid` -> `(0, "valid")`. Signal names contain underscores of
+    /// their own, so only the first one splits. The index is returned so
+    /// callers can bounds-check it against the element count.
+    fn split_idx_signal(rest: &str) -> Option<(u32, &str)> {
+        let (idx, signal) = rest.split_once('_')?;
+        Some((idx.parse::<u32>().ok()?, signal))
+    }
+
     fn validate_inst_ports(&mut self, inst: &InstDecl) {
         let Some(ports) = self.child_ports(&inst.module_name.name) else {
             return;
@@ -7014,6 +7032,15 @@ impl<'a> TypeChecker<'a> {
         // Ram port groups: `ports rd_port ... end ports rd_port` → `rd_port_addr`.
         let mut ram_port_groups: BTreeMap<String, Vec<String>> = BTreeMap::new();
         if let Some(Item::Ram(r)) = self.find_item_by_name(&inst.module_name.name) {
+            // A `.archi` ram stub loses its `ports` groups — `arch build` does
+            // not round-trip them — so every group pin (`rd_addr`, `rd_en`, …)
+            // would look unknown. Skipping the whole instance is deliberate:
+            // narrowing this to "leave ram_port_groups empty" would stack one
+            // bogus error per group pin.
+            //
+            // Unreachable without an existing error, since a ram with no port
+            // groups is already rejected outright ("ram `X` has no port
+            // groups"); this only keeps that diagnostic from being buried.
             if r.is_interface && r.port_groups.is_empty() {
                 return;
             }
@@ -7055,7 +7082,7 @@ impl<'a> TypeChecker<'a> {
                     if vob_bases.contains_key(base) {
                         continue;
                     }
-                    if let Some(suffix) = strip_base_prefix(cname, base) {
+                    if let Some(suffix) = Self::strip_base_prefix(cname, base) {
                         if *permissive || signals.iter().any(|s| s == suffix) {
                             is_valid = true;
                             break;
@@ -7070,7 +7097,7 @@ impl<'a> TypeChecker<'a> {
                 // index rather than risk a false positive.
                 if !is_valid {
                     for (base, count_opt) in &vec_scalar_bases {
-                        let Some(suffix) = strip_base_prefix(cname, base) else {
+                        let Some(suffix) = Self::strip_base_prefix(cname, base) else {
                             continue;
                         };
                         let Ok(idx) = suffix.parse::<u32>() else {
@@ -7086,26 +7113,31 @@ impl<'a> TypeChecker<'a> {
                 //   `mm_0`            whole element
                 //   `mm_0_cmd_valid`  element + signal
                 //   `mm_cmd_valid`    whole vector, one signal
+                // Element indices are bounds-checked on the same terms as the
+                // scalar-Vec case above: strict when the count is const,
+                // permissive otherwise.
                 if !is_valid {
-                    for (base, (_count_opt, signals, permissive)) in &vob_bases {
+                    for (base, (count_opt, signals, permissive)) in &vob_bases {
                         let known = |sig: &str| *permissive || signals.iter().any(|s| s == sig);
-                        if let Some(rest) = strip_base_prefix(cname, base) {
-                            if rest.parse::<u32>().is_ok()
-                                || split_idx_signal(rest).is_some_and(|(_, sig)| known(sig))
-                                || known(rest)
-                            {
+                        let in_range = |idx: u32| count_opt.is_none_or(|n| idx < n);
+                        if let Some(rest) = Self::strip_base_prefix(cname, base) {
+                            let whole_element = rest.parse::<u32>().is_ok_and(in_range);
+                            let element_signal = Self::split_idx_signal(rest)
+                                .is_some_and(|(idx, sig)| in_range(idx) && known(sig));
+                            if whole_element || element_signal || known(rest) {
                                 is_valid = true;
                                 break;
                             }
                         }
                         // `mm0_cmd_valid` — no underscore before the index, as
                         // produced by `chans[0].valid`.
-                        if let Some((_, sig)) = cname.strip_prefix(base).and_then(split_idx_signal)
+                        if cname
+                            .strip_prefix(base)
+                            .and_then(Self::split_idx_signal)
+                            .is_some_and(|(idx, sig)| in_range(idx) && known(sig))
                         {
-                            if known(sig) {
-                                is_valid = true;
-                                break;
-                            }
+                            is_valid = true;
+                            break;
                         }
                     }
                 }
@@ -7114,10 +7146,10 @@ impl<'a> TypeChecker<'a> {
                 if !is_valid {
                     for (base, (_count_opt, signals)) in &port_array_bases {
                         let known = |sig: &str| signals.iter().any(|s| s == sig);
-                        if strip_base_prefix(cname, base).is_some_and(known)
+                        if Self::strip_base_prefix(cname, base).is_some_and(known)
                             || cname
                                 .strip_prefix(base)
-                                .and_then(split_idx_signal)
+                                .and_then(Self::split_idx_signal)
                                 .is_some_and(|(_, sig)| known(sig))
                         {
                             is_valid = true;
@@ -7128,7 +7160,7 @@ impl<'a> TypeChecker<'a> {
                 // Ram port groups: `rd_port_addr`.
                 if !is_valid {
                     for (base, signals) in &ram_port_groups {
-                        if strip_base_prefix(cname, base)
+                        if Self::strip_base_prefix(cname, base)
                             .is_some_and(|sig| signals.iter().any(|s| s == sig))
                         {
                             is_valid = true;
@@ -9865,23 +9897,6 @@ fn float_slot_type_name(ty: &TypeExpr) -> Option<&'static str> {
 /// True if `e` is a bare integer literal (`Dec`/`Hex`/`Bin`/`Sized`) — used to
 /// reject the "integer literal into a float slot" foot-gun consistently
 /// across `reset` (arch#620/#623), `init` and port `default` (arch#622/#624).
-/// `cname.strip_prefix(&format!("{base}_"))` without building the prefix.
-///
-/// `validate_inst_ports` runs this per (connection x candidate base) across
-/// several passes, and children like `e203_biu` carry 124 ports, so the
-/// throwaway `String` per comparison is worth avoiding.
-fn strip_base_prefix<'s>(cname: &'s str, base: &str) -> Option<&'s str> {
-    cname.strip_prefix(base)?.strip_prefix('_')
-}
-
-/// Split `"<idx>_<signal>"` into its parts, for the flattened per-element bus
-/// shapes (`chans_0_valid` -> `("0", "valid")`). Signal names contain
-/// underscores of their own, so the split is limited to the first one.
-fn split_idx_signal(rest: &str) -> Option<(u32, &str)> {
-    let (idx, signal) = rest.split_once('_')?;
-    Some((idx.parse::<u32>().ok()?, signal))
-}
-
 fn is_bare_int_literal(e: &Expr) -> bool {
     matches!(
         &e.kind,

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -1223,9 +1223,13 @@ impl<'a> TypeChecker<'a> {
                             }
                         }
                     }
-                    if let crate::ast::GenerateDecl::If(gi) = gen {
-                        for gi in &gi.else_items {
-                            if let crate::ast::GenItem::Inst(inst) = gi {
+                    // The loop above walks the taken branch's items; a
+                    // `generate if` also carries an else-branch that no check
+                    // previously reached, so instances there escaped both the
+                    // `where`-constraint check and port validation.
+                    if let crate::ast::GenerateDecl::If(gen_if) = gen {
+                        for else_item in &gen_if.else_items {
+                            if let crate::ast::GenItem::Inst(inst) = else_item {
                                 self.check_inst_param_constraints(inst);
                                 self.validate_inst_ports(inst);
                             }
@@ -6879,34 +6883,32 @@ impl<'a> TypeChecker<'a> {
         let b_chars: Vec<char> = b.chars().collect();
         let n = a_chars.len();
         let m = b_chars.len();
-        let mut dp = vec![vec![0; m + 1]; n + 1];
-        for i in 0..=n {
-            dp[i][0] = i;
-        }
-        for j in 0..=m {
-            dp[0][j] = j;
-        }
+        // Two rolling rows rather than the full (n+1)x(m+1) matrix.
+        let mut prev: Vec<usize> = (0..=m).collect();
+        let mut cur = vec![0usize; m + 1];
         for i in 1..=n {
+            cur[0] = i;
             for j in 1..=m {
-                let cost = if a_chars[i - 1] == b_chars[j - 1] {
-                    0
-                } else {
-                    1
-                };
-                dp[i][j] = (dp[i - 1][j] + 1)
-                    .min(dp[i][j - 1] + 1)
-                    .min(dp[i - 1][j - 1] + cost);
+                let cost = usize::from(a_chars[i - 1] != b_chars[j - 1]);
+                cur[j] = (prev[j] + 1).min(cur[j - 1] + 1).min(prev[j - 1] + cost);
             }
+            std::mem::swap(&mut prev, &mut cur);
         }
-        dp[n][m]
+        prev[m]
     }
 
+    /// Closest candidate within edit distance 3, or None.
+    ///
+    /// Ties resolve to the lexicographically smallest candidate so the rendered
+    /// diagnostic is byte-identical across runs — `candidates` is built from
+    /// `BTreeSet`s for the same reason. See #756 for the class of bug this
+    /// avoids.
     fn did_you_mean(target: &str, candidates: &[String]) -> Option<String> {
         candidates
             .iter()
             .map(|c| (Self::levenshtein(target, c), c))
             .filter(|(d, _)| *d > 0 && *d <= 3)
-            .min_by_key(|(d, c)| (*d, (*c).clone()))
+            .min_by(|(da, ca), (db, cb)| da.cmp(db).then_with(|| ca.cmp(cb)))
             .map(|(_, c)| c.clone())
     }
 
@@ -7053,132 +7055,84 @@ impl<'a> TypeChecker<'a> {
                     if vob_bases.contains_key(base) {
                         continue;
                     }
-                    if let Some(suffix) = cname.strip_prefix(&format!("{}_", base)) {
-                        if *permissive {
-                            is_valid = true;
-                            break;
-                        } else if signals.contains(&suffix.to_string()) {
+                    if let Some(suffix) = strip_base_prefix(cname, base) {
+                        if *permissive || signals.iter().any(|s| s == suffix) {
                             is_valid = true;
                             break;
                         }
                     }
                 }
-                // Vec scalar per-element.
+                // Vec scalar per-element: `data_0` for `port data: Vec<T, N>`.
+                // When N is a compile-time constant the index is bounds-checked
+                // here — `data_9` into a `Vec<T, 4>` names no port, and nothing
+                // downstream catches it (verified: it reaches Verilator as a
+                // bogus pin). When N is not const-evaluable, accept any numeric
+                // index rather than risk a false positive.
                 if !is_valid {
                     for (base, count_opt) in &vec_scalar_bases {
-                        if let Some(suffix) = cname.strip_prefix(&format!("{}_", base)) {
-                            if suffix.parse::<u32>().is_ok() {
-                                if let Some(n) = count_opt {
-                                    if let Ok(idx) = suffix.parse::<u32>() {
-                                        if idx < *n {
-                                            is_valid = true;
-                                            break;
-                                        } else {
-                                            // Out-of-bounds idx still considered valid here;
-                                            // bounds are checked elsewhere. Treat as valid to avoid duplicate error.
-                                            is_valid = true;
-                                            break;
-                                        }
-                                    }
-                                } else {
-                                    is_valid = true;
-                                    break;
-                                }
-                            }
+                        let Some(suffix) = strip_base_prefix(cname, base) else {
+                            continue;
+                        };
+                        let Ok(idx) = suffix.parse::<u32>() else {
+                            continue;
+                        };
+                        if (*count_opt).is_none_or(|n| idx < n) {
+                            is_valid = true;
+                            break;
                         }
                     }
                 }
-                // Vec<Bus>.
+                // Vec<Bus>, in all three flattened shapes:
+                //   `mm_0`            whole element
+                //   `mm_0_cmd_valid`  element + signal
+                //   `mm_cmd_valid`    whole vector, one signal
                 if !is_valid {
                     for (base, (_count_opt, signals, permissive)) in &vob_bases {
-                        if let Some(rest) = cname.strip_prefix(&format!("{}_", base)) {
-                            if rest.parse::<u32>().is_ok() {
-                                // base_<idx>
+                        let known = |sig: &str| *permissive || signals.iter().any(|s| s == sig);
+                        if let Some(rest) = strip_base_prefix(cname, base) {
+                            if rest.parse::<u32>().is_ok()
+                                || split_idx_signal(rest).is_some_and(|(_, sig)| known(sig))
+                                || known(rest)
+                            {
                                 is_valid = true;
                                 break;
-                            } else {
-                                let mut parts = rest.splitn(2, '_');
-                                let idxp = parts.next().unwrap();
-                                if let Some(sigp) = parts.next() {
-                                    if idxp.parse::<u32>().is_ok()
-                                        && (*permissive || signals.contains(&sigp.to_string()))
-                                    {
-                                        is_valid = true;
-                                        break;
-                                    }
-                                }
                             }
                         }
-                        // Also handle `base{idx}_{signal}` without underscore before idx (e.g., chans0_valid from `chans[0].valid`).
-                        if cname.starts_with(base) {
-                            let rest2 = &cname[base.len()..];
-                            if !rest2.is_empty() && rest2.chars().next().unwrap().is_ascii_digit() {
-                                if let Some(und_pos) = rest2.find('_') {
-                                    let (idx_part, sig_part_with_und) = rest2.split_at(und_pos);
-                                    let sig_part = &sig_part_with_und[1..];
-                                    if idx_part.parse::<u32>().is_ok()
-                                        && (*permissive || signals.contains(&sig_part.to_string()))
-                                    {
-                                        is_valid = true;
-                                        break;
-                                    }
-                                }
+                        // `mm0_cmd_valid` — no underscore before the index, as
+                        // produced by `chans[0].valid`.
+                        if let Some((_, sig)) = cname.strip_prefix(base).and_then(split_idx_signal)
+                        {
+                            if known(sig) {
+                                is_valid = true;
+                                break;
                             }
                         }
                     }
                 }
-                // Port-array bases (Arbiter / Regfile `ports[N]`): `request0_valid` and `request_valid` whole-vector.
+                // Arbiter / Regfile `ports[N]` groups: `request_valid` (whole
+                // vector) and `request0_valid` (indexed).
                 if !is_valid {
                     for (base, (_count_opt, signals)) in &port_array_bases {
-                        // Whole-vector per-signal: `request_valid` (base + "_" + signal) – valid for any count.
-                        if let Some(suffix) = cname.strip_prefix(&format!("{}_", base)) {
-                            if signals.contains(&suffix.to_string()) {
-                                is_valid = true;
-                                break;
-                            }
-                        }
-                        // Indexed form: `request0_valid` (base + idx + "_" + signal)
-                        if cname.starts_with(base) {
-                            let rest = &cname[base.len()..];
-                            if !rest.is_empty() && rest.chars().next().unwrap().is_ascii_digit() {
-                                if let Some(und_pos) = rest.find('_') {
-                                    let (idx_part, sig_part_with_und) = rest.split_at(und_pos);
-                                    let sig_part = &sig_part_with_und[1..];
-                                    if idx_part.parse::<u32>().is_ok()
-                                        && signals.contains(&sig_part.to_string())
-                                    {
-                                        is_valid = true;
-                                        break;
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-                // Vec<Bus> per-signal whole-vector: `mm_valid` (base + "_" + signal) for packed vector.
-                if !is_valid {
-                    for (base, (_count_opt, signals, permissive)) in &vob_bases {
-                        if let Some(suffix) = cname.strip_prefix(&format!("{}_", base)) {
-                            if *permissive || signals.contains(&suffix.to_string()) {
-                                // This covers `mm_valid`, `mm_data` etc. It also matches `mm_0`? But `mm_0` suffix is numeric, not a signal, so not in signals and not permissive (signals not empty) → not valid here, but already handled above as base_<idx>.
-                                // So only per-signal whole-vector will be true.
-                                // Need to ensure suffix is a signal, not numeric idx.
-                                if signals.contains(&suffix.to_string()) || *permissive {
-                                    is_valid = true;
-                                    break;
-                                }
-                            }
+                        let known = |sig: &str| signals.iter().any(|s| s == sig);
+                        if strip_base_prefix(cname, base).is_some_and(known)
+                            || cname
+                                .strip_prefix(base)
+                                .and_then(split_idx_signal)
+                                .is_some_and(|(_, sig)| known(sig))
+                        {
+                            is_valid = true;
+                            break;
                         }
                     }
                 }
                 // Ram port groups: `rd_port_addr`.
                 if !is_valid {
                     for (base, signals) in &ram_port_groups {
-                        if let Some(suffix) = cname.strip_prefix(&format!("{}_", base)) {
-                            if signals.contains(&suffix.to_string()) {
-                                is_valid = true;
-                                break;
-                            }
+                        if strip_base_prefix(cname, base)
+                            .is_some_and(|sig| signals.iter().any(|s| s == sig))
+                        {
+                            is_valid = true;
+                            break;
                         }
                     }
                 }
@@ -9911,6 +9865,23 @@ fn float_slot_type_name(ty: &TypeExpr) -> Option<&'static str> {
 /// True if `e` is a bare integer literal (`Dec`/`Hex`/`Bin`/`Sized`) — used to
 /// reject the "integer literal into a float slot" foot-gun consistently
 /// across `reset` (arch#620/#623), `init` and port `default` (arch#622/#624).
+/// `cname.strip_prefix(&format!("{base}_"))` without building the prefix.
+///
+/// `validate_inst_ports` runs this per (connection x candidate base) across
+/// several passes, and children like `e203_biu` carry 124 ports, so the
+/// throwaway `String` per comparison is worth avoiding.
+fn strip_base_prefix<'s>(cname: &'s str, base: &str) -> Option<&'s str> {
+    cname.strip_prefix(base)?.strip_prefix('_')
+}
+
+/// Split `"<idx>_<signal>"` into its parts, for the flattened per-element bus
+/// shapes (`chans_0_valid` -> `("0", "valid")`). Signal names contain
+/// underscores of their own, so the split is limited to the first one.
+fn split_idx_signal(rest: &str) -> Option<(u32, &str)> {
+    let (idx, signal) = rest.split_once('_')?;
+    Some((idx.parse::<u32>().ok()?, signal))
+}
+
 fn is_bare_int_literal(e: &Expr) -> bool {
     matches!(
         &e.kind,

--- a/tests/e203/e203_exu.arch
+++ b/tests/e203/e203_exu.arch
@@ -159,37 +159,13 @@ module e203_exu
   wire dec_rs2_idx: UInt<5>;
   wire dec_rd_idx:  UInt<5>;
   wire dec_imm:     UInt<32>;
-  wire dec_alu:     Bool;
   wire dec_bjp:     Bool;
-  wire dec_agu:     Bool;
-  wire dec_alu_add: Bool;
-  wire dec_alu_sub: Bool;
-  wire dec_alu_xor: Bool;
-  wire dec_alu_sll: Bool;
-  wire dec_alu_srl: Bool;
-  wire dec_alu_sra: Bool;
-  wire dec_alu_or:  Bool;
-  wire dec_alu_and: Bool;
-  wire dec_alu_slt: Bool;
-  wire dec_alu_sltu: Bool;
-  wire dec_alu_lui: Bool;
-  wire dec_beq:     Bool;
-  wire dec_bne:     Bool;
-  wire dec_blt:     Bool;
-  wire dec_bge:     Bool;
-  wire dec_bltu:    Bool;
-  wire dec_bgeu:    Bool;
-  wire dec_jump:    Bool;
   wire dec_mul:     Bool;
-  wire dec_mulh:    Bool;
   wire dec_mulhsu:  Bool;
-  wire dec_mulhu:   Bool;
   wire dec_div:     Bool;
   wire dec_divu:    Bool;
   wire dec_rem:     Bool;
   wire dec_remu:    Bool;
-  wire dec_load:    Bool;
-  wire dec_store:   Bool;
   wire dec_rs1_en:  Bool;
   wire dec_rs2_en:  Bool;
   wire dec_rd_en:   Bool;
@@ -460,30 +436,6 @@ module e203_exu
     dec_jalr_rs1idx -> dec_jalr_rs1idx;
     dec_bjp_imm  -> dec_bjp_imm;
     // Simplified control outputs
-    o_alu        -> dec_alu;
-    o_agu        -> dec_agu;
-    o_alu_add    -> dec_alu_add;
-    o_alu_sub    -> dec_alu_sub;
-    o_alu_xor    -> dec_alu_xor;
-    o_alu_sll    -> dec_alu_sll;
-    o_alu_srl    -> dec_alu_srl;
-    o_alu_sra    -> dec_alu_sra;
-    o_alu_or     -> dec_alu_or;
-    o_alu_and    -> dec_alu_and;
-    o_alu_slt    -> dec_alu_slt;
-    o_alu_sltu   -> dec_alu_sltu;
-    o_alu_lui    -> dec_alu_lui;
-    o_beq        -> dec_beq;
-    o_bne        -> dec_bne;
-    o_blt        -> dec_blt;
-    o_bge        -> dec_bge;
-    o_bltu       -> dec_bltu;
-    o_bgeu       -> dec_bgeu;
-    o_jump       -> dec_jump;
-    o_mulh       -> dec_mulh;
-    o_mulhu      -> dec_mulhu;
-    o_load       -> dec_load;
-    o_store      -> dec_store;
   end inst dec
 
   // ════════════════════════════════════════════════════════════════════

--- a/tests/issue797_test.rs
+++ b/tests/issue797_test.rs
@@ -52,9 +52,20 @@ fn unknown_scalar_port_is_error() {
         end module Top
     "#;
     let errs = errors_from_source(src);
-    assert!(errs.iter().any(|e| e.contains("this_port_does_not_exist") && e.contains("not a port of")), "bad pin not reported: {:?}", errs);
+    assert!(
+        errs.iter()
+            .any(|e| e.contains("this_port_does_not_exist") && e.contains("not a port of")),
+        "bad pin not reported: {:?}",
+        errs
+    );
     // No suggestion for distant name (distance 24 >3)
-    assert!(!errs.iter().any(|e| e.contains("this_port_does_not_exist") && e.contains("did you mean")), "should not suggest for distant name: {:?}", errs);
+    assert!(
+        !errs
+            .iter()
+            .any(|e| e.contains("this_port_does_not_exist") && e.contains("did you mean")),
+        "should not suggest for distant name: {:?}",
+        errs
+    );
 }
 
 #[test]
@@ -110,7 +121,11 @@ fn did_you_mean_is_deterministic() {
     assert_eq!(errs1, errs2, "determinism failed");
     let all = errs1.join("\n");
     // abe distance 1 to both abc and abd, should pick lexicographically smallest abc
-    assert!(all.contains("did you mean `abc`"), "expected deterministic suggestion abc, got: {:?}", errs1);
+    assert!(
+        all.contains("did you mean `abc`"),
+        "expected deterministic suggestion abc, got: {:?}",
+        errs1
+    );
 }
 
 #[test]
@@ -135,7 +150,11 @@ fn multiple_unknown_ports_all_reported() {
     "#;
     let errs = errors_from_source(src);
     // Should have 3 bad pins + 1 unconnected d (since d not connected) = 4, but at least 3 bad
-    assert!(errs.iter().filter(|e| e.contains("not a port of")).count() == 3, "expected 3 bad pin errors, got: {:?}", errs);
+    assert!(
+        errs.iter().filter(|e| e.contains("not a port of")).count() == 3,
+        "expected 3 bad pin errors, got: {:?}",
+        errs
+    );
 }
 
 #[test]
@@ -161,7 +180,12 @@ fn bus_per_field_typo_is_error() {
         end module ParentB
     "#;
     let errs = errors_from_source(src);
-    assert!(errs.iter().any(|e| e.contains("p_fake") && e.contains("not a port of")), "bus fake not reported: {:?}", errs);
+    assert!(
+        errs.iter()
+            .any(|e| e.contains("p_fake") && e.contains("not a port of")),
+        "bus fake not reported: {:?}",
+        errs
+    );
 }
 
 #[test]
@@ -195,8 +219,15 @@ fn bus_handshake_per_field_still_valid() {
     // This should not error for valid fields.
     let errs = errors_from_source(src);
     // Filter out unrelated errors (like unconnected warnings are not errors)
-    let not_port_errs: Vec<_> = errs.iter().filter(|e| e.contains("not a port of")).collect();
-    assert!(not_port_errs.is_empty(), "handshake valid fields should not error, got: {:?}", errs);
+    let not_port_errs: Vec<_> = errs
+        .iter()
+        .filter(|e| e.contains("not a port of"))
+        .collect();
+    assert!(
+        not_port_errs.is_empty(),
+        "handshake valid fields should not error, got: {:?}",
+        errs
+    );
 }
 
 #[test]
@@ -275,7 +306,12 @@ fn vec_bus_per_element_signal_with_underscores() {
         end module TopVec2
     "#;
     let errs = errors_from_source(src_bad);
-    assert!(errs.iter().any(|e| e.contains("mm_0_cmd_fake") && e.contains("not a port of")), "vec bus signal typo not reported: {:?}", errs);
+    assert!(
+        errs.iter()
+            .any(|e| e.contains("mm_0_cmd_fake") && e.contains("not a port of")),
+        "vec bus signal typo not reported: {:?}",
+        errs
+    );
 }
 
 #[test]
@@ -339,7 +375,12 @@ fn generate_for_inst_unknown_port() {
         end module Top
     "#;
     let errs = errors_from_source(src);
-    assert!(errs.iter().any(|e| e.contains("bad") && e.contains("not a port of")), "generate bad pin not reported: {:?}", errs);
+    assert!(
+        errs.iter()
+            .any(|e| e.contains("bad") && e.contains("not a port of")),
+        "generate bad pin not reported: {:?}",
+        errs
+    );
 }
 
 #[test]
@@ -405,7 +446,11 @@ fn unresolvable_child_kind_is_skipped_not_flagged() {
     // Our child_ports for synchronizer returns None (since not in match), so bogus should NOT be flagged as not-a-port
     // It may still be flagged as undefined? But our logic skips, so zero not-a-port errors
     let not_port = errs.iter().filter(|e| e.contains("not a port of")).count();
-    assert_eq!(not_port, 0, "synchronizer bogus should be skipped, got: {:?}", errs);
+    assert_eq!(
+        not_port, 0,
+        "synchronizer bogus should be skipped, got: {:?}",
+        errs
+    );
 }
 
 #[test]

--- a/tests/issue797_test.rs
+++ b/tests/issue797_test.rs
@@ -482,6 +482,33 @@ fn vec_data_element_index_out_of_range_is_error() {
     check_err_contains(src, &["data_9", "not a port of"]);
 }
 
+#[test]
+fn vec_bus_element_index_out_of_range_is_error() {
+    // Same rule as the scalar-Vec case: `mm_9` on a `Vec<MyBus, 2>` names no
+    // port. Kept in step with `vec_data_element_index_out_of_range_is_error` so
+    // the two Vec flavours cannot drift apart.
+    let src = r#"
+        bus MyBus
+          valid: out Bool;
+          data: out UInt<8>;
+        end bus MyBus
+        module ChildVec
+          port mm: target Vec<MyBus, 2>;
+          comb
+            mm[0].valid = true; mm[0].data = 8'h00;
+            mm[1].valid = true; mm[1].data = 8'h01;
+          end comb
+        end module ChildVec
+        module TopVec
+          wire w: MyBus;
+          inst c: ChildVec
+            mm_9 <- w;
+          end inst c
+        end module TopVec
+    "#;
+    check_err_contains(src, &["mm_9", "not a port of"]);
+}
+
 /// The `.archi` separate-compilation path, end to end through the CLI.
 ///
 /// `.archi` discovery lives in `src/main.rs`, so an in-process test cannot
@@ -490,7 +517,9 @@ fn vec_data_element_index_out_of_range_is_error() {
 /// *only* via `ARCH_LIB_PATH`, which is the route the e203 corpus depends on.
 #[test]
 fn archi_child_via_arch_lib_path_unknown_port() {
-    let tmp = std::env::temp_dir().join("arch_issue797_archi");
+    // Per-process directory: the path is otherwise global, and concurrent
+    // `cargo test` runs on one machine would race on the create/remove.
+    let tmp = std::env::temp_dir().join(format!("arch_issue797_archi_{}", std::process::id()));
     let lib = tmp.join("lib");
     let work = tmp.join("work");
     let _ = std::fs::remove_dir_all(&tmp);

--- a/tests/issue797_test.rs
+++ b/tests/issue797_test.rs
@@ -1,8 +1,11 @@
+//! Coverage for #797 — `inst` connections must name a real port of the child.
+
 use arch::elaborate;
 use arch::lexer;
 use arch::parser::Parser;
 use arch::resolve;
 use arch::typecheck::TypeChecker;
+use std::process::Command;
 
 fn errors_from_source(source: &str) -> Vec<String> {
     let tokens = lexer::tokenize(source).expect("lex");
@@ -454,26 +457,100 @@ fn unresolvable_child_kind_is_skipped_not_flagged() {
 }
 
 #[test]
-fn archi_child_via_same_dir() {
-    // ARCH_LIB_PATH case is covered by CLI test, but same-dir .archi is also via SourceFile inclusion when both files passed together.
-    // This test ensures a parent that misspells a child port from a child defined in same SourceFile is caught (basic).
-    // The full ARCH_LIB_PATH test requires filesystem + env var, tested via CLI; here we just ensure child_ports works for in-source child.
+fn vec_data_element_index_out_of_range_is_error() {
+    // `data_9` on a `Vec<UInt<8>, 4>` names no port. Nothing downstream catches
+    // it — before this check it reached Verilator as a bogus pin — so the
+    // element index is bounds-checked here whenever the count is const.
     let src = r#"
         module Leaf
-          port d: in UInt<8>;
-          port q: out UInt<8>;
-          comb q = d; end comb
+          port data: out Vec<UInt<8>, 4>;
+          comb
+            for i in 0..3
+              data[i] = 0;
+            end for
+          end comb
         end module Leaf
         module Top
-          port a: in UInt<8>;
           port y: out UInt<8>;
           wire w: UInt<8>;
           inst c: Leaf
-            dd <- a;
-            q -> w;
+            data_9 -> w;
           end inst c
           comb y = w; end comb
         end module Top
     "#;
-    check_err_contains(src, &["dd", "did you mean `d`"]);
+    check_err_contains(src, &["data_9", "not a port of"]);
+}
+
+/// The `.archi` separate-compilation path, end to end through the CLI.
+///
+/// `.archi` discovery lives in `src/main.rs`, so an in-process test cannot
+/// reach it — it would silently exercise the in-source lookup instead and
+/// prove nothing. This drives the real binary with a stub that is reachable
+/// *only* via `ARCH_LIB_PATH`, which is the route the e203 corpus depends on.
+#[test]
+fn archi_child_via_arch_lib_path_unknown_port() {
+    let tmp = std::env::temp_dir().join("arch_issue797_archi");
+    let lib = tmp.join("lib");
+    let work = tmp.join("work");
+    let _ = std::fs::remove_dir_all(&tmp);
+    std::fs::create_dir_all(&lib).expect("mkdir lib");
+    std::fs::create_dir_all(&work).expect("mkdir work");
+
+    std::fs::write(
+        lib.join("Leaf.archi"),
+        "module Leaf\n  port d: in UInt<8>;\n  port q: out UInt<8>;\nend module Leaf\n",
+    )
+    .expect("write stub");
+
+    // Every real port stays connected and the bogus pin is added alongside, so
+    // the unknown-port error is the *only* diagnostic. Misspelling `d` outright
+    // would also raise "input port `d` is not connected", and the CLI currently
+    // displays just the first error (#750), masking what this test is for.
+    let parent = |extra: &str| {
+        format!(
+            "module Top\n  port a: in UInt<8>;\n  port y: out UInt<8>;\n  wire w: UInt<8>;\n\
+             \x20 inst c: Leaf\n    d <- a;\n    q -> w;\n{extra}  end inst c\n\
+             \x20 comb\n    y = w;\n  end comb\nend module Top\n"
+        )
+    };
+
+    let run = || {
+        Command::new(env!("CARGO_BIN_EXE_arch"))
+            .current_dir(&work)
+            .env("ARCH_LIB_PATH", &lib)
+            .args(["check", "Top.arch"])
+            .output()
+            .expect("failed to run `arch check`")
+    };
+
+    // Bogus pin against the ARCH_LIB_PATH-only stub.
+    std::fs::write(work.join("Top.arch"), parent("    dd <- a;\n")).expect("write parent");
+    let out = run();
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        !out.status.success(),
+        "expected a check failure, got success: {combined}"
+    );
+    assert!(
+        combined.contains("is not a port of `Leaf`") && combined.contains("did you mean `d`"),
+        "expected the unknown-port error with a suggestion, got: {combined}"
+    );
+
+    // Negative twin: the same stub with no bogus pin must pass, so the test
+    // cannot succeed merely because every `.archi` child errors.
+    std::fs::write(work.join("Top.arch"), parent("")).expect("write parent");
+    let out = run();
+    assert!(
+        out.status.success(),
+        "correctly-spelled pin should check clean, got: {}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let _ = std::fs::remove_dir_all(&tmp);
 }

--- a/tests/issue797_test.rs
+++ b/tests/issue797_test.rs
@@ -1,0 +1,434 @@
+use arch::elaborate;
+use arch::lexer;
+use arch::parser::Parser;
+use arch::resolve;
+use arch::typecheck::TypeChecker;
+
+fn errors_from_source(source: &str) -> Vec<String> {
+    let tokens = lexer::tokenize(source).expect("lex");
+    let mut parser = Parser::new(tokens, source);
+    let ast = parser.parse_source_file().expect("parse");
+    let ast = elaborate::elaborate(ast).expect("elaborate");
+    let symbols = resolve::resolve(&ast).expect("resolve");
+    let checker = TypeChecker::new(&symbols, &ast);
+    match checker.check() {
+        Ok(_) => vec![],
+        Err(errs) => errs.into_iter().map(|e| e.to_string()).collect(),
+    }
+}
+
+fn check_ok(source: &str) {
+    let errs = errors_from_source(source);
+    assert!(errs.is_empty(), "expected OK, got errors: {:?}", errs);
+}
+
+fn check_err_contains(source: &str, substrs: &[&str]) {
+    let errs = errors_from_source(source);
+    assert!(!errs.is_empty(), "expected errors but got OK");
+    let all = errs.join("\n");
+    for s in substrs {
+        assert!(all.contains(s), "expected '{}' in errors: {:?}", s, errs);
+    }
+}
+
+#[test]
+fn unknown_scalar_port_is_error() {
+    let src = r#"
+        module Child
+          port d: in UInt<8>;
+          port q: out UInt<8>;
+          comb q = d; end comb
+        end module Child
+        module Top
+          port a: in UInt<8>;
+          port y: out UInt<8>;
+          wire w: UInt<8>;
+          inst c: Child
+            d <- a;
+            q -> w;
+            this_port_does_not_exist <- a;
+          end inst c
+          comb y = w; end comb
+        end module Top
+    "#;
+    let errs = errors_from_source(src);
+    assert!(errs.iter().any(|e| e.contains("this_port_does_not_exist") && e.contains("not a port of")), "bad pin not reported: {:?}", errs);
+    // No suggestion for distant name (distance 24 >3)
+    assert!(!errs.iter().any(|e| e.contains("this_port_does_not_exist") && e.contains("did you mean")), "should not suggest for distant name: {:?}", errs);
+}
+
+#[test]
+fn did_you_mean_suggests_closest_port() {
+    let src = r#"
+        module Child2
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync, High>;
+          port d: in UInt<8>;
+          port q: out UInt<8>;
+          comb q = d; end comb
+        end module Child2
+        module Top2
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync, High>;
+          port a: in UInt<8>;
+          port y: out UInt<8>;
+          wire w: UInt<8>;
+          inst c: Child2
+            clk <- clk;
+            rst <- rst;
+            d <- a;
+            clok <- a;
+          end inst c
+          comb y = w; end comb
+        end module Top2
+    "#;
+    check_err_contains(src, &["clok", "did you mean `clk`"]);
+}
+
+#[test]
+fn did_you_mean_is_deterministic() {
+    let src = r#"
+        module Child
+          port abc: in UInt<8>;
+          port abd: in UInt<8>;
+          port q: out UInt<8>;
+          comb q = abc + abd; end comb
+        end module Child
+        module Top
+          port a: in UInt<8>;
+          port y: out UInt<8>;
+          wire w: UInt<8>;
+          inst c: Child
+            abe <- a;
+            q -> w;
+          end inst c
+          comb y = w; end comb
+        end module Top
+    "#;
+    let errs1 = errors_from_source(src);
+    let errs2 = errors_from_source(src);
+    assert_eq!(errs1, errs2, "determinism failed");
+    let all = errs1.join("\n");
+    // abe distance 1 to both abc and abd, should pick lexicographically smallest abc
+    assert!(all.contains("did you mean `abc`"), "expected deterministic suggestion abc, got: {:?}", errs1);
+}
+
+#[test]
+fn multiple_unknown_ports_all_reported() {
+    let src = r#"
+        module Child
+          port d: in UInt<8>;
+          port q: out UInt<8>;
+          comb q = d; end comb
+        end module Child
+        module Top
+          port a: in UInt<8>;
+          port y: out UInt<8>;
+          wire w: UInt<8>;
+          inst c: Child
+            bad1 <- a;
+            bad2 <- a;
+            bad3 <- a;
+          end inst c
+          comb y = w; end comb
+        end module Top
+    "#;
+    let errs = errors_from_source(src);
+    // Should have 3 bad pins + 1 unconnected d (since d not connected) = 4, but at least 3 bad
+    assert!(errs.iter().filter(|e| e.contains("not a port of")).count() == 3, "expected 3 bad pin errors, got: {:?}", errs);
+}
+
+#[test]
+fn bus_per_field_typo_is_error() {
+    let src = r#"
+        bus MyBus
+          cmd: out UInt<8>;
+          resp: in UInt<8>;
+        end bus MyBus
+        module ChildB
+          port p: target MyBus;
+          comb p.resp = p.cmd; end comb
+        end module ChildB
+        module ParentB
+          port a: in UInt<8>;
+          port b: out UInt<8>;
+          wire w: UInt<8>;
+          inst c: ChildB
+            p.cmd <- a;
+            p.fake <- a;
+          end inst c
+          comb b = w; end comb
+        end module ParentB
+    "#;
+    let errs = errors_from_source(src);
+    assert!(errs.iter().any(|e| e.contains("p_fake") && e.contains("not a port of")), "bus fake not reported: {:?}", errs);
+}
+
+#[test]
+fn bus_handshake_per_field_still_valid() {
+    let src = r#"
+        bus HsBus
+          handshake ch: send kind: valid_ready
+            len: UInt<8>;
+            data: UInt<32>;
+          end handshake ch
+        end bus HsBus
+        module ChildHs
+          port p: target HsBus;
+          comb p.ch_valid = false; p.ch_data = 32'h00; end comb
+        end module ChildHs
+        module ParentHs
+          port a: in UInt<8>;
+          port b: in UInt<32>;
+          wire w_valid: Bool;
+          inst c: ChildHs
+            p.ch_valid <- w_valid;
+            p.ch_len <- a;
+            p.ch_data <- b;
+          end inst c
+        end module ParentHs
+    "#;
+    // Should be OK (handshake bus permissive, but valid fields)
+    // Note we use p.ch_len vs len? The handshake payload fields are ch_len, ch_data
+    // The bus signal names are ch_len etc.
+    // Use the correct flattened names via bus handshake: p.ch_valid etc.
+    // This should not error for valid fields.
+    let errs = errors_from_source(src);
+    // Filter out unrelated errors (like unconnected warnings are not errors)
+    let not_port_errs: Vec<_> = errs.iter().filter(|e| e.contains("not a port of")).collect();
+    assert!(not_port_errs.is_empty(), "handshake valid fields should not error, got: {:?}", errs);
+}
+
+#[test]
+fn vec_bus_whole_and_per_element_still_valid() {
+    let src = r#"
+        bus MyBus
+          valid: out Bool;
+          data: out UInt<8>;
+        end bus MyBus
+        module ChildVec
+          port mm: target Vec<MyBus, 2>;
+          comb
+            mm[0].valid = true; mm[0].data = 8'h00;
+            mm[1].valid = true; mm[1].data = 8'h01;
+          end comb
+        end module ChildVec
+        module TopVec
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync, High>;
+          wire w: MyBus;
+          wire w2: MyBus;
+          inst c: ChildVec
+            mm_0 <- w;
+            mm_1 <- w2;
+          end inst c
+        end module TopVec
+    "#;
+    // mm_0 and mm_1 are per-element whole-bus connections, should be valid
+    // We use mm_0 syntax directly (parser flattens chans[0] -> chans_0)
+    check_ok(src);
+}
+
+#[test]
+fn vec_bus_per_element_signal_with_underscores() {
+    // mm_0_cmd_valid must be valid — guards splitn(2, '_')
+    let src = r#"
+        bus MyBus
+          cmd_valid: out Bool;
+          cmd_data: out UInt<8>;
+        end bus MyBus
+        module ChildVec2
+          port mm: target Vec<MyBus, 2>;
+          comb
+            mm[0].cmd_valid = true; mm[0].cmd_data = 8'h00;
+            mm[1].cmd_valid = true; mm[1].cmd_data = 8'h01;
+          end comb
+        end module ChildVec2
+        module TopVec2
+          port a: in Bool;
+          port b: in UInt<8>;
+          inst c: ChildVec2
+            mm_0_cmd_valid <- a;
+            mm_0_cmd_data <- b;
+            mm_1_cmd_valid <- a;
+          end inst c
+        end module TopVec2
+    "#;
+    check_ok(src);
+    // Typo on that signal should error
+    let src_bad = r#"
+        bus MyBus
+          cmd_valid: out Bool;
+          cmd_data: out UInt<8>;
+        end bus MyBus
+        module ChildVec2
+          port mm: target Vec<MyBus, 2>;
+          comb
+            mm[0].cmd_valid = true; mm[0].cmd_data = 8'h00;
+          end comb
+        end module ChildVec2
+        module TopVec2
+          port a: in Bool;
+          inst c: ChildVec2
+            mm_0_cmd_fake <- a;
+          end inst c
+        end module TopVec2
+    "#;
+    let errs = errors_from_source(src_bad);
+    assert!(errs.iter().any(|e| e.contains("mm_0_cmd_fake") && e.contains("not a port of")), "vec bus signal typo not reported: {:?}", errs);
+}
+
+#[test]
+fn vec_data_per_element_valid() {
+    let src_ok = r#"
+        module Child
+          port data: out Vec<UInt<8>, 4>;
+          comb data[0]=8'h00; data[1]=8'h01; data[2]=8'h02; data[3]=8'h03; end comb
+        end module Child
+        module Top
+          port y: out UInt<8>;
+          wire w: UInt<8>;
+          inst c: Child
+            data_0 -> w;
+          end inst c
+          comb y = w; end comb
+        end module Top
+    "#;
+    // data_0 is valid per-element
+    let errs = errors_from_source(src_ok);
+    let not_port = errs.iter().filter(|e| e.contains("not a port of")).count();
+    assert_eq!(not_port, 0, "data_0 should be valid, got: {:?}", errs);
+
+    let src_bad = r#"
+        module Child
+          port data: out Vec<UInt<8>, 4>;
+          comb data[0]=8'h00; end comb
+        end module Child
+        module Top
+          port y: out UInt<8>;
+          wire w: UInt<8>;
+          inst c: Child
+            data_typo -> w;
+          end inst c
+          comb y = w; end comb
+        end module Top
+    "#;
+    check_err_contains(src_bad, &["data_typo", "not a port of"]);
+}
+
+#[test]
+fn generate_for_inst_unknown_port() {
+    let src = r#"
+        module Child
+          port d: in UInt<8>;
+          port q: out UInt<8>;
+          comb q = d; end comb
+        end module Child
+        module Top
+          param N: const = 2;
+          port a: in UInt<8>;
+          port y: out UInt<8>;
+          wire w: UInt<8>;
+          generate_for i in 0..N-1
+            inst c_i: Child
+              d <- a;
+              bad <- a;
+            end inst c_i
+          end generate_for
+          comb y = w; end comb
+        end module Top
+    "#;
+    let errs = errors_from_source(src);
+    assert!(errs.iter().any(|e| e.contains("bad") && e.contains("not a port of")), "generate bad pin not reported: {:?}", errs);
+}
+
+#[test]
+fn pipeline_child_unknown_port() {
+    let src = r#"
+        pipeline MyPipe
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync, High>;
+          port d: in UInt<8>;
+          port q: out UInt<8>;
+          stage S0
+            comb q = d; end comb
+          end stage S0
+        end pipeline MyPipe
+        module Top
+          port clk: in Clock<SysDomain>;
+          port rst: in Reset<Sync, High>;
+          port a: in UInt<8>;
+          port y: out UInt<8>;
+          wire w: UInt<8>;
+          inst c: MyPipe
+            clk <- clk;
+            rst <- rst;
+            d <- a;
+            bad <- a;
+          end inst c
+          comb y = w; end comb
+        end module Top
+    "#;
+    check_err_contains(src, &["bad", "not a port of", "MyPipe"]);
+}
+
+#[test]
+fn unresolvable_child_kind_is_skipped_not_flagged() {
+    // synchronizer has no ConstructCommon ports to validate against; even a bogus pin should not be flagged via not-a-port
+    // It should instead be validated via other means or skipped. Our child_ports returns Some for synchronizer? Actually synchronizer has common, so it has ports, but we skip bus/sync/clkGate/template in child_ports? No, we return Some for synchronizer via common, so it would be validated. The plan says synchronizer should be skipped.
+    // The plan's test says synchronizer or clkgate should be skipped (no port list to validate). Let's test synchronizer: it has ports clk_in, clk_out etc, but our child_ports returns Some for it, so bogus pin would be flagged. The plan's test expects zero errors for synchronizer bogus pin.
+    // However our implementation now includes synchronizer? Let's check: child_ports returns Some for synchronizer? In our code, we match Item::Synchronizer? No, we only handle Module/Fsm/Pipeline/Fifo/Ram/Cam/Counter/Arbiter/Regfile/Linklist. We do NOT handle Synchronizer/Clkgate/Bus/Template. So synchronizer returns None, so validate skips. Good.
+    let src = r#"
+        synchronizer MySync
+          port clk_in: in Clock<SysDomain>;
+          port clk_out: in Clock<OtherDomain>;
+          port d: in Bool;
+          port q: out Bool;
+        end synchronizer MySync
+        module Top
+          port clk1: in Clock<SysDomain>;
+          port clk2: in Clock<OtherDomain>;
+          port a: in Bool;
+          port y: out Bool;
+          wire w: Bool;
+          inst s: MySync
+            clk_in <- clk1;
+            clk_out <- clk2;
+            d <- a;
+            bogus <- a;
+            q -> w;
+          end inst s
+          comb y = w; end comb
+        end module Top
+    "#;
+    let errs = errors_from_source(src);
+    // Our child_ports for synchronizer returns None (since not in match), so bogus should NOT be flagged as not-a-port
+    // It may still be flagged as undefined? But our logic skips, so zero not-a-port errors
+    let not_port = errs.iter().filter(|e| e.contains("not a port of")).count();
+    assert_eq!(not_port, 0, "synchronizer bogus should be skipped, got: {:?}", errs);
+}
+
+#[test]
+fn archi_child_via_same_dir() {
+    // ARCH_LIB_PATH case is covered by CLI test, but same-dir .archi is also via SourceFile inclusion when both files passed together.
+    // This test ensures a parent that misspells a child port from a child defined in same SourceFile is caught (basic).
+    // The full ARCH_LIB_PATH test requires filesystem + env var, tested via CLI; here we just ensure child_ports works for in-source child.
+    let src = r#"
+        module Leaf
+          port d: in UInt<8>;
+          port q: out UInt<8>;
+          comb q = d; end comb
+        end module Leaf
+        module Top
+          port a: in UInt<8>;
+          port y: out UInt<8>;
+          wire w: UInt<8>;
+          inst c: Leaf
+            dd <- a;
+            q -> w;
+          end inst c
+          comb y = w; end comb
+        end module Top
+    "#;
+    check_err_contains(src, &["dd", "did you mean `d`"]);
+}


### PR DESCRIPTION
Validates the `connections→ports` direction in `check_inst_decl`: each `inst` `port_name` must be a port of the child (exact, bus per-field, Vec element, Vec<Bus> per-element/per-field, arbiter PortArray `request0_valid`/`request_valid`, ram port groups, and linklist op ports). Unknown pins now error with `inst I connects X, which is not a port of C` plus a deterministic `did you mean` hint (Levenshtein ≤3, `BTreeSet` candidate pool, lexicographic tie-break).

Vec element indices are bounds-checked when the count is const-evaluable — `data_9` on a `port data: Vec<UInt<8>, 4>` names no port and previously reached Verilator as a bogus pin. A non-const count stays permissive.

Hoists validation into `validate_inst_ports` and calls it from the Module inst arm, the Generate arm, and the `generate if` else-branch (which no check previously reached, so instances there escaped the `where`-constraint check too).

Fixes #797.

Plan: `doc/plan_fix_797_inst_unknown_port.md` (r3)
Tests: `tests/issue797_test.rs` — 14, including a CLI test that drives the real binary against an `ARCH_LIB_PATH`-only `.archi` stub (the separate-compilation route e203 depends on; an in-process test cannot reach `main.rs` discovery), with a negative twin.

## Corpus impact

Swept every `.arch` under `tests/` and `examples/`, before vs after: **789 pass / 97 fail** either way, with two files changing state.

**`tests/e203/e203_exu.arch` — rewired in this PR.** Removed 24 dead `o_alu`/`o_agu`/… → `dec_alu` connections plus their wire declarations. These referenced the pre-rewrite decode surface (now `dec_info`); each had exactly two references in the file — the declaration and the bogus connection — and zero readers, so they were write-only dead nets. After the fix `arch check` passes and Verilator lint on the emitted SV is clean (0 errors).

**`tests/cvdp/sipo_top.arch` — newly fails `arch check`, and it is a true positive.** `tests/cvdp/` contains two different modules both named `serial_in_parallel_out_8bit`:

| file | ports |
|---|---|
| `serial_in_parallel_out_8bit.arch` | `clock`, `serial_in`, `parallel_out` |
| `sipo_top_sipo_sub.arch` | `clk`, `rst`, `sin`, `shift_en`, `done`, `parallel_out` (+ `param WIDTH`) |

`sipo_top.arch` instantiates the second; `find_item_by_name` is first-match-wins and resolves the first. That unit **already failed** at `verilator_lint` before this PR, so the net effect is to move the failure earlier with a precise message instead of a downstream pin mismatch. The duplicate-name fixture is filed separately — with colliding names this check will validate against an arbitrary definition and can emit a confidently-wrong suggestion.

## Not fixed here: #750

An earlier revision of this description claimed to fix #750. It does not, and the claim has been removed.

`TypeChecker` has always accumulated every diagnostic into `self.errors`; #750 is about `src/main.rs` displaying only the first, across ~10 call sites. This PR touches no reporting code, so the CLI still shows 1 of N:

```
$ arch check T.arch     # three bogus pins
$ ... | grep -c "which is not a port of"
1
```

That matters for this feature specifically — someone repairing a drifted module sees one error per rebuild. Worth landing #750 next; it is a separate, mechanical diff.