### PR TITLE
fix(interface): emit .archi stubs that round-trip and keep the full surface

### DIFF
--- a/src/interface.rs
+++ b/src/interface.rs
@@ -19,7 +19,17 @@ pub fn emit_interface(item: &Item) -> Option<String> {
 /// params + ports). Wrapper kept here so the trait impl can take a
 /// uniform `fn(&RegfileDecl) -> String`.
 pub(crate) fn emit_regfile_interface(r: &RegfileDecl) -> String {
-    emit_generic("regfile", &r.name.name, &r.params, &r.ports)
+    let name = &r.name.name;
+    let mut s = format!("regfile {name}\n");
+    emit_params(&mut s, &r.params);
+    emit_ports(&mut s, &r.ports);
+    // `ports[N] read` / `ports[M] write` carry the whole access surface; the
+    // generic emitter dropped them, so a consumer saw only the scalar ports.
+    for pa in [&r.read_ports, &r.write_ports].into_iter().flatten() {
+        emit_port_array(&mut s, pa);
+    }
+    s.push_str(&format!("end regfile {name}\n"));
+    s
 }
 
 pub(crate) fn emit_module_interface(m: &ModuleDecl) -> String {
@@ -159,8 +169,56 @@ pub(crate) fn emit_ram_interface(r: &RamDecl) -> String {
     s.push_str(&format!("  latency {};\n", r.latency));
     emit_params(&mut s, &r.params);
     emit_ports(&mut s, &r.ports);
+    // Access-port groups (`ports rd { addr; en; data; }`). These are the ram's
+    // real signal surface — omitting them left a stub the compiler rejects
+    // outright ("ram `X` has no port groups"), so no ram could be consumed
+    // through separate compilation at all. Mirrors the arbiter port-array emit
+    // below.
+    emit_port_group(&mut s, &r.port_groups);
     s.push_str(&format!("end ram {name}\n"));
     s
+}
+
+/// Emit `ports <name> … end ports <name>` blocks for constructs whose signal
+/// surface lives in a group rather than in `ConstructCommon.ports`.
+fn emit_port_group(s: &mut String, groups: &[RamPortGroup]) {
+    for pg in groups {
+        s.push_str(&format!("  ports {}\n", pg.name.name));
+        for sig in &pg.signals {
+            let dir = match sig.direction {
+                Direction::In => "in",
+                Direction::Out => "out",
+            };
+            s.push_str(&format!(
+                "    {}: {dir} {};\n",
+                sig.name.name,
+                type_str(&sig.ty)
+            ));
+        }
+        s.push_str(&format!("  end ports {}\n", pg.name.name));
+    }
+}
+
+/// Emit an indexed `ports[N] <name> … end ports <name>` array, as used by
+/// arbiter requesters and regfile read/write ports.
+fn emit_port_array(s: &mut String, pa: &PortArrayDecl) {
+    s.push_str(&format!(
+        "  ports[{}] {}\n",
+        expr_str(&pa.count_expr),
+        pa.name.name
+    ));
+    for sig in &pa.signals {
+        let dir = match sig.direction {
+            Direction::In => "in",
+            Direction::Out => "out",
+        };
+        s.push_str(&format!(
+            "    {}: {dir} {};\n",
+            sig.name.name,
+            type_str(&sig.ty)
+        ));
+    }
+    s.push_str(&format!("  end ports {}\n", pa.name.name));
 }
 
 pub(crate) fn emit_arbiter_interface(a: &ArbiterDecl) -> String {
@@ -170,7 +228,9 @@ pub(crate) fn emit_arbiter_interface(a: &ArbiterDecl) -> String {
         ArbiterPolicy::Priority => "priority".to_string(),
         ArbiterPolicy::Lru => "lru".to_string(),
         ArbiterPolicy::Weighted(w) => format!("weighted<{}>", expr_str(w)),
-        ArbiterPolicy::Custom(fn_name) => format!("custom {}", fn_name.name),
+        // Source syntax is a bare `policy <FnName>;` — there is no `custom`
+        // keyword, and emitting one produced a stub the parser rejects.
+        ArbiterPolicy::Custom(fn_name) => fn_name.name.clone(),
     };
     let mut s = format!("arbiter {name}\n");
     s.push_str(&format!("  policy {policy};\n"));
@@ -185,20 +245,7 @@ pub(crate) fn emit_arbiter_interface(a: &ArbiterDecl) -> String {
     // an array of per-requester valid/ready signals — which is
     // information the inst-site connection writer needs.
     for pa in &a.port_arrays {
-        let count = expr_str(&pa.count_expr);
-        s.push_str(&format!("  ports[{count}] {}\n", pa.name.name));
-        for sig in &pa.signals {
-            let dir = match sig.direction {
-                Direction::In => "in",
-                Direction::Out => "out",
-            };
-            s.push_str(&format!(
-                "    {}: {dir} {};\n",
-                sig.name.name,
-                type_str(&sig.ty)
-            ));
-        }
-        s.push_str(&format!("  end ports {}\n", pa.name.name));
+        emit_port_array(&mut s, pa);
     }
     s.push_str(&format!("end arbiter {name}\n"));
     s
@@ -236,6 +283,28 @@ pub(crate) fn emit_linklist_interface(l: &LinklistDecl) -> String {
     }
     emit_params(&mut s, &l.params);
     emit_ports(&mut s, &l.ports);
+    // `op` blocks are most of a linklist's surface — each contributes flattened
+    // `<op>_<port>` pins at the inst site. Dropping them left consumers unable
+    // to see (or connect) any of them.
+    for op in &l.ops {
+        s.push_str(&format!("  op {}\n", op.name.name));
+        s.push_str(&format!("    latency: {};\n", op.latency));
+        if op.pipelined {
+            s.push_str("    pipelined: true;\n");
+        }
+        for p in &op.ports {
+            let dir = match p.direction {
+                Direction::In => "in",
+                Direction::Out => "out",
+            };
+            s.push_str(&format!(
+                "    port {}: {dir} {};\n",
+                p.name.name,
+                type_str(&p.ty)
+            ));
+        }
+        s.push_str(&format!("  end op {}\n", op.name.name));
+    }
     s.push_str(&format!("end linklist {name}\n"));
     s
 }
@@ -253,11 +322,15 @@ pub(crate) fn emit_struct(s: &StructDecl) -> String {
 pub(crate) fn emit_enum(e: &EnumDecl) -> String {
     let name = &e.name.name;
     let mut out = format!("enum {name}\n");
+    // Variants are comma-separated with no trailing comma — `;` terminators
+    // produced a stub the parser rejects, which also made every `package`
+    // containing an enum unreadable.
     for (i, v) in e.variants.iter().enumerate() {
+        let sep = if i + 1 == e.variants.len() { "" } else { "," };
         if let Some(Some(ref val)) = e.values.get(i) {
-            out.push_str(&format!("  {} = {};\n", v.name, expr_str(val)));
+            out.push_str(&format!("  {} = {}{sep}\n", v.name, expr_str(val)));
         } else {
-            out.push_str(&format!("  {};\n", v.name));
+            out.push_str(&format!("  {}{sep}\n", v.name));
         }
     }
     out.push_str(&format!("end enum {name}\n"));

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -7593,8 +7593,12 @@ impl<'a> TypeChecker<'a> {
         }
         // ROM validation
         if r.kind == crate::ast::RamKind::Rom {
-            // ROM must have init
-            if r.init.is_none() {
+            // ROM must have init — but the contents are implementation data,
+            // not interface. An `.archi` stub deliberately omits them (a
+            // `file(...)` path would not even resolve from the consumer's
+            // directory), so requiring one here made every rom unusable
+            // through separate compilation.
+            if r.init.is_none() && !r.common.is_interface {
                 self.errors.push(CompileError::general(
                     &format!("rom `{}` must have an init clause", r.name.name),
                     r.name.span,
@@ -7900,17 +7904,21 @@ impl<'a> TypeChecker<'a> {
         }
         // Validate hook for custom policy
         if let ArbiterPolicy::Custom(ref fn_ident) = a.policy {
-            if a.hook.is_none() {
-                self.errors.push(CompileError::general(
-                    &format!(
-                        "custom policy `{}` requires a `hook grant_select` declaration",
-                        fn_ident.name
-                    ),
-                    fn_ident.span,
-                ));
+            // The hook binds a policy function defined alongside the arbiter
+            // body; an `.archi` stub carries neither, and emitting the hook
+            // would only move the failure to "unknown function".
+            let Some(hook) = a.hook.as_ref() else {
+                if !a.common.is_interface {
+                    self.errors.push(CompileError::general(
+                        &format!(
+                            "custom policy `{}` requires a `hook grant_select` declaration",
+                            fn_ident.name
+                        ),
+                        fn_ident.span,
+                    ));
+                }
                 return;
-            }
-            let hook = a.hook.as_ref().unwrap();
+            };
             // Verify the hook's bound function name matches the policy name
             if hook.fn_name.name != fn_ident.name {
                 self.errors.push(CompileError::general(
@@ -8176,6 +8184,15 @@ impl<'a> TypeChecker<'a> {
 
     pub(crate) fn check_pipeline(&mut self, p: &PipelineDecl) {
         self.check_pascal_case(&p.name);
+
+        // An `.archi` stub has no stages, so the body-driven checks below
+        // (every output driven, every stage registered) would reject a
+        // perfectly good interface. Same short-circuit as `check_module` and
+        // `check_fsm`; the port signature is still recorded for parent-side
+        // instantiation checking.
+        if p.common.is_interface {
+            return;
+        }
 
         for param in &p.params {
             self.check_upper_snake(&param.name);

--- a/tests/interface_roundtrip_test.rs
+++ b/tests/interface_roundtrip_test.rs
@@ -1,0 +1,145 @@
+//! Every `.archi` interface stub `arch build` emits must be a valid input to
+//! the compiler that emitted it (#815).
+//!
+//! The failure mode this guards is quiet: a stub that drops part of a
+//! construct's surface still *parses*, so nothing complains until a consumer
+//! tries to connect the missing pins — and since #797 landed, that surfaces as
+//! a confidently-wrong "not a port of" error against a port that does exist.
+//!
+//! The sweep is corpus-driven rather than a fixed fixture list so a newly added
+//! construct kind is covered automatically.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn arch() -> &'static str {
+    env!("CARGO_BIN_EXE_arch")
+}
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+/// `arch build` the source into `work`, then `arch check` each emitted
+/// `.archi` on its own. Returns one message per stub that fails to re-check.
+fn roundtrip_failures(source: &Path, work: &Path) -> Vec<String> {
+    std::fs::create_dir_all(work).expect("mkdir work");
+    let file_name = source.file_name().expect("file name");
+    std::fs::copy(source, work.join(file_name)).expect("copy source");
+
+    let built = Command::new(arch())
+        .current_dir(work)
+        .args(["build", &file_name.to_string_lossy(), "-o", "out.sv"])
+        .output()
+        .expect("run arch build");
+    if !built.status.success() {
+        // A source that does not build is out of scope here; other suites
+        // cover that. Only the emitted stubs are under test.
+        return Vec::new();
+    }
+
+    let mut failures = Vec::new();
+    let mut stubs: Vec<PathBuf> = std::fs::read_dir(work)
+        .expect("read work")
+        .filter_map(|e| e.ok().map(|e| e.path()))
+        .filter(|p| p.extension().is_some_and(|x| x == "archi"))
+        .collect();
+    stubs.sort();
+
+    for stub in stubs {
+        let stub_name = stub
+            .file_name()
+            .expect("stub name")
+            .to_string_lossy()
+            .to_string();
+        let out = Command::new(arch())
+            .current_dir(work)
+            .args(["check", &stub_name])
+            .output()
+            .expect("run arch check");
+        if !out.status.success() {
+            let combined = format!(
+                "{}{}",
+                String::from_utf8_lossy(&out.stdout),
+                String::from_utf8_lossy(&out.stderr)
+            );
+            let detail = combined
+                .lines()
+                .find(|l| l.contains('×'))
+                .unwrap_or("<no diagnostic>")
+                .trim()
+                .to_string();
+            failures.push(format!("{stub_name} (from {}): {detail}", source.display()));
+        }
+    }
+    failures
+}
+
+/// Sources whose stubs are known not to round-trip yet, with the issue that
+/// tracks each. Listing them keeps the sweep green without hiding them.
+fn known_bad(source: &Path) -> Option<&'static str> {
+    let name = source.file_name()?.to_string_lossy().to_string();
+    match name.as_str() {
+        // A `package` stub emits bodyless `function f(...) -> T;` signatures,
+        // which the parser rejects. Fixing it needs either a function-body
+        // pretty-printer or a parser that accepts signatures in `.archi`.
+        "TestPkg.arch" => Some("#819"),
+        _ => None,
+    }
+}
+
+#[test]
+fn every_emitted_archi_stub_reparses() {
+    let root = repo_root();
+    let tmp = std::env::temp_dir().join(format!("arch_archi_roundtrip_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&tmp);
+
+    let mut sources: Vec<PathBuf> = Vec::new();
+    for dir in ["tests", "examples"] {
+        collect_arch_sources(&root.join(dir), &mut sources);
+    }
+    sources.sort();
+    assert!(
+        sources.len() > 50,
+        "expected a substantial corpus, found {} sources — did the layout change?",
+        sources.len()
+    );
+
+    let mut failures = Vec::new();
+    let mut skipped = 0usize;
+    for (idx, source) in sources.iter().enumerate() {
+        if known_bad(source).is_some() {
+            skipped += 1;
+            continue;
+        }
+        failures.extend(roundtrip_failures(source, &tmp.join(idx.to_string())));
+    }
+    let _ = std::fs::remove_dir_all(&tmp);
+
+    assert!(
+        failures.is_empty(),
+        "{} emitted .archi stub(s) do not re-check ({} known-bad skipped).\n\
+         An interface stub must be a valid input to the compiler that wrote it.\n{}",
+        failures.len(),
+        skipped,
+        failures.join("\n")
+    );
+}
+
+fn collect_arch_sources(dir: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.filter_map(Result::ok) {
+        let path = entry.path();
+        if path.is_dir() {
+            // One level of nesting covers examples/nic400 etc. without
+            // dragging in the large generated corpora under tests/.
+            if dir.ends_with("examples") {
+                collect_arch_sources(&path, out);
+            }
+        } else if path.extension().is_some_and(|x| x == "arch") {
+            out.push(path);
+        }
+    }
+}


### PR DESCRIPTION
Closes #815.

## Problem

An emitted `.archi` was not a valid input to the compiler that wrote it. Round-tripping every stub the corpus produces (`arch build`, then `arch check` each `.archi` on its own) surfaced **13 bad stubs** across **six distinct defects**:

| construct | defect | symptom |
|---|---|---|
| `ram` | drops `ports` access groups | stub rejected: "ram `X` has no port groups" — **no ram was usable via separate compilation at all** (6 designs) |
| `linklist` | drops every `op` block | stub parses; consumer gets a **false** "not a port of" on real pins |
| `regfile` | drops `ports[N] read` / `write` arrays | same silent loss |
| `arbiter` (custom policy) | emits `policy custom <Fn>;` | no such keyword — stub does not parse |
| `enum` | `;` variant separators, grammar wants `,` | stub does not parse; also breaks every `package` containing an enum |
| `pipeline` | no `is_interface` short-circuit in `check_pipeline` | stub rejected: "output port X is not driven" |

The `linklist` case is the one that bites hardest today. Before #797 it was invisible; now the missing surface produces a confidently-wrong diagnostic:

```
× inst `l` connects `alloc_req_valid`, which is not a port of `SchedList`
```

`alloc_req_valid` is a real port. It just wasn't in the stub.

## Fix

Emit the missing surfaces, and stop requiring implementation detail from an interface.

Two checks demanded things a stub cannot carry: a rom had to have its `init` (whose `file(...)` path wouldn't resolve from the consumer's directory anyway), and a custom-policy arbiter had to have a `hook grant_select` binding a function the stub doesn't contain. Both are now skipped for `is_interface` items. Rewriting the arbiter guard also removed an `unwrap` that the exemption would otherwise have turned into a **panic** — the round-trip sweep caught that before it shipped.

Port-group emission is factored into `emit_port_group` / `emit_port_array`, the latter shared with the arbiter path that already did this correctly (and whose comment explains exactly why it matters).

## Verification

End to end, through `ARCH_LIB_PATH` stubs — both previously failed:

| consumer | before | after |
|---|---|---|
| rom (`RomLut`) | `× ram RomLut has no port groups` | `OK: no errors` |
| linklist (`SchedList`) | `× connects alloc_req_valid, which is not a port` | `OK: no errors` |

- **New sweep `tests/interface_roundtrip_test.rs`** asserts every emitted stub re-checks. Corpus-driven rather than a fixture list, so a new construct kind is covered without anyone remembering to add one. Confirmed it **fails with 13 bad stubs** without this change.
- Corpus: 791 pass / 98 fail, unchanged from `main`.
- 788 integration tests green; `cargo fmt --check` and `cargo clippy` clean.

## Left out deliberately

A `package` emits bodyless `function f(...) -> T;` signatures the parser rejects. Fixing it needs a design decision — emit function bodies, or teach the parser to accept signatures in `.archi` — not a mechanical change. Filed as #819 and listed in the sweep's `known_bad` table, so removing that entry is the acceptance test for it.

## Note

Open PR #741 also touches `src/interface.rs` (inference-safe RAM/FIFO RTL). Different concern, incidental file overlap — flagging for whoever lands it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)