### PR TITLE
fix(deps): let an explicit `use` win over name-based inst discovery

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2893,6 +2893,46 @@ fn resolve_use_imports(files: &[PathBuf]) -> miette::Result<Vec<PathBuf>> {
             }
         }
 
+        // An explicit `use` names the file that provides a construct, so it
+        // must win over the name-based `inst` discovery below. Seed the
+        // defined-name set from the `use` targets before that discovery runs;
+        // otherwise a construct reachable by both routes is pulled in twice
+        // and the build dies with `duplicate definition`.
+        //
+        // This is the only way to disambiguate when two files in a directory
+        // define the same construct: without it, discovery silently resolves
+        // `inst c: X` to whichever file happens to be called `X.arch`, and
+        // `use` cannot override that choice.
+        for dep in &deps {
+            let Ok(dep_src) = fs::read_to_string(dep) else {
+                continue;
+            };
+            let Ok(dep_tokens) = lexer::tokenize(&dep_src) else {
+                continue;
+            };
+            let mut dep_parser = parser::Parser::new(dep_tokens, &dep_src);
+            let Ok(dep_parsed) = dep_parser.parse_source_file() else {
+                continue;
+            };
+            for item in &dep_parsed.items {
+                match item {
+                    Item::Domain(_)
+                    | Item::Struct(_)
+                    | Item::Enum(_)
+                    | Item::Function(_)
+                    | Item::Package(_)
+                    | Item::Use(_)
+                    | Item::ExternPackage(_) => {}
+                    Item::Bus(b) => {
+                        all_defined_buses.insert(b.name.name.clone());
+                    }
+                    instantiable => {
+                        all_defined_modules.insert(instantiable.as_construct().name().name.clone());
+                    }
+                }
+            }
+        }
+
         // Track every construct name defined across all input files, so the
         // `.archi` auto-discovery below does NOT pull in a (possibly stale)
         // interface stub for a construct that is ALREADY defined in-source —

--- a/tests/construct_name_collision_test.rs
+++ b/tests/construct_name_collision_test.rs
@@ -1,0 +1,204 @@
+//! Guard against ambiguous `inst` resolution (#814).
+//!
+//! `inst c: X` is resolved by looking for a file literally called `X.arch` in
+//! the same directory. When a *second* file there also defines `X`, the
+//! compiler takes the filename match and never mentions the other one, so the
+//! instance silently binds to a module the author did not mean. Since #797
+//! that surfaces as a confidently-wrong "`p` is not a port of `X`" naming
+//! ports that do exist — on the other `X`.
+//!
+//! Two files defining the same construct name is not itself a problem: most
+//! of the corpus is standalone single-file cases, and 156 `verilog_eval`
+//! problems all declare `TopModule` by design. It only becomes one when some
+//! file in the same directory *instantiates* the ambiguous name. The fix in
+//! that case is an explicit `use <file>;`, which takes precedence over
+//! filename discovery.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
+
+#[test]
+fn ambiguous_inst_targets_are_disambiguated_by_use() {
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let mut dirs: Vec<PathBuf> = Vec::new();
+    for top in ["tests", "examples"] {
+        collect_dirs(&root.join(top), &mut dirs);
+    }
+    dirs.sort();
+
+    let mut offenders: Vec<String> = Vec::new();
+    let mut checked_dirs = 0usize;
+
+    for dir in &dirs {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            continue;
+        };
+        let mut files: Vec<PathBuf> = entries
+            .filter_map(Result::ok)
+            .map(|e| e.path())
+            .filter(|p| p.extension().is_some_and(|x| x == "arch"))
+            .collect();
+        if files.len() < 2 {
+            continue;
+        }
+        files.sort();
+        checked_dirs += 1;
+
+        let parsed: Vec<(String, Source)> = files
+            .iter()
+            .filter_map(|f| {
+                let text = std::fs::read_to_string(f).ok()?;
+                let name = f.file_name()?.to_string_lossy().to_string();
+                Some((name, Source::scan(&text)))
+            })
+            .collect();
+
+        // construct name -> files defining it, within this directory
+        let mut defs: BTreeMap<&str, Vec<&str>> = BTreeMap::new();
+        for (file, src) in &parsed {
+            for c in &src.constructs {
+                defs.entry(c.as_str()).or_default().push(file.as_str());
+            }
+        }
+
+        let rel = dir
+            .strip_prefix(&root)
+            .unwrap_or(dir)
+            .to_string_lossy()
+            .replace('\\', "/");
+
+        for (file, src) in &parsed {
+            for target in &src.insts {
+                // Defined locally: no discovery happens, no ambiguity.
+                if src.constructs.contains(target) {
+                    continue;
+                }
+                let Some(providers) = defs.get(target.as_str()) else {
+                    continue;
+                };
+                if providers.len() < 2 {
+                    continue;
+                }
+                // Discovery only fires when a file is literally named after
+                // the construct. Where it can't (e.g. tests/aes declares
+                // PascalCase constructs in snake_case files), the unit is
+                // built by passing sources together and there is nothing to
+                // resolve ambiguously.
+                let discoverable = format!("{target}.arch");
+                if !providers.iter().any(|p| *p == discoverable) {
+                    continue;
+                }
+                // An explicit `use` names the provider and wins over the
+                // filename lookup, so the binding is unambiguous.
+                if !src.uses.is_empty() {
+                    continue;
+                }
+                offenders.push(format!(
+                    "{rel}/{file}: `inst … : {target}` is ambiguous — {} both define it; \
+                     add `use <file>;` to name the intended one",
+                    providers.join(" and ")
+                ));
+            }
+        }
+    }
+
+    assert!(
+        checked_dirs > 5,
+        "expected several multi-file directories, saw {checked_dirs} — did the layout change?"
+    );
+    assert!(
+        offenders.is_empty(),
+        "{} ambiguous inst target(s); resolution would silently pick the \
+         filename match.\n{}",
+        offenders.len(),
+        offenders.join("\n")
+    );
+}
+
+struct Source {
+    constructs: BTreeSet<String>,
+    insts: BTreeSet<String>,
+    uses: BTreeSet<String>,
+}
+
+impl Source {
+    /// Column-0 construct declarations, `inst <name>: <Target>` targets, and
+    /// `use <file>;` imports. A lint-grade scan: every construct in the corpus
+    /// is declared at column 0, and `inst` lines are unambiguous enough that a
+    /// full parse would not change the result.
+    fn scan(text: &str) -> Self {
+        const KEYWORDS: &[&str] = &[
+            "module",
+            "fsm",
+            "pipeline",
+            "fifo",
+            "ram",
+            "cam",
+            "counter",
+            "arbiter",
+            "regfile",
+            "linklist",
+            "bus",
+            "synchronizer",
+            "clkgate",
+            "template",
+        ];
+        let ident = |s: &str| !s.is_empty() && s.chars().all(|c| c.is_alphanumeric() || c == '_');
+
+        let mut constructs = BTreeSet::new();
+        let mut insts = BTreeSet::new();
+        let mut uses = BTreeSet::new();
+
+        for line in text.lines() {
+            let trimmed = line.trim();
+            if let Some(rest) = trimmed.strip_prefix("use ") {
+                let name = rest.trim_end_matches(';').trim();
+                if ident(name) {
+                    uses.insert(name.to_string());
+                }
+                continue;
+            }
+            if let Some(rest) = trimmed.strip_prefix("inst ") {
+                if let Some((_, target)) = rest.split_once(':') {
+                    let target = target.trim();
+                    if ident(target) {
+                        insts.insert(target.to_string());
+                    }
+                }
+                continue;
+            }
+            // Declarations sit at column 0; nested blocks are indented.
+            if line.starts_with(char::is_whitespace) {
+                continue;
+            }
+            let mut parts = line.split_whitespace();
+            if let (Some(kw), Some(name)) = (parts.next(), parts.next()) {
+                if KEYWORDS.contains(&kw) && ident(name) {
+                    constructs.insert(name.to_string());
+                }
+            }
+        }
+
+        Source {
+            constructs,
+            insts,
+            uses,
+        }
+    }
+}
+
+fn collect_dirs(dir: &Path, out: &mut Vec<PathBuf>) {
+    if !dir.is_dir() {
+        return;
+    }
+    out.push(dir.to_path_buf());
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.filter_map(Result::ok) {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_dirs(&path, out);
+        }
+    }
+}

--- a/tests/cvdp/sipo_top.arch
+++ b/tests/cvdp/sipo_top.arch
@@ -1,3 +1,14 @@
+// This directory contains two different modules named
+// `serial_in_parallel_out_8bit`: the standalone CVDP problem in
+// serial_in_parallel_out_8bit.arch (ports clock/serial_in/parallel_out) and
+// the parameterized variant this top instantiates, in
+// sipo_top_sipo_sub.arch. Both names are load-bearing for the CVDP harness,
+// which maps problems by SV TOPLEVEL, so neither can be renamed.
+//
+// Name-based `inst` discovery would resolve to the same-named file; the
+// explicit `use` below names the right one and suppresses that lookup.
+use sipo_top_sipo_sub;
+
 module sipo_top
   param DATA_WIDTH: const = 16;
   param SHIFT_DIRECTION: const = 1;
@@ -26,7 +37,7 @@ module sipo_top
     param SHIFT_DIRECTION = SHIFT_DIRECTION;
     clk          <- clk;
     rst          <- reset_n;
-    serial_in    <- serial_in;
+    sin          <- serial_in;
     shift_en     <- shift_en;
     done         -> sipo_done;
     parallel_out -> sipo_pout;


### PR DESCRIPTION
Closes #814.

## Problem

`inst c: X` resolves by looking for a file literally called `X.arch`. When a second file in the same directory also defines `X`, the compiler takes the filename match and never mentions the other one — the instance silently binds to a module the author did not mean.

Since #797 landed, that surfaces as a confidently-wrong diagnostic:

```
× inst `uut_sipo` connects `clk`, which is not a port of
  `serial_in_parallel_out_8bit` (did you mean `clock`?)
```

`clk` *is* a port — on the other `serial_in_parallel_out_8bit`.

`use <file>;` is the natural way to say which one you mean, but it did not work. `resolve_use_imports` processes one file at a time: it seeds `all_defined_modules` from that file's own items, then runs inst discovery. A `use` target is only *queued* at that point, not yet parsed, so discovery still fired and pulled in the same-named file — turning the silent-wrong-binding into a hard `duplicate definition` error instead.

## Fix

Seed the defined-name set from the `use` targets before discovery runs, so an explicit import takes precedence over filename guessing. That is what an explicit dependency declaration is for. Cost is re-parsing the `use` targets once; `use` is rare.

## The in-tree instance

`tests/cvdp/` holds two different modules named `serial_in_parallel_out_8bit`:

| file | ports |
|---|---|
| `serial_in_parallel_out_8bit.arch` | `clock`, `serial_in`, `parallel_out` |
| `sipo_top_sipo_sub.arch` | `clk`, `rst`, `sin`, `shift_en`, `done`, `parallel_out` (+ `WIDTH`) |

`sipo_top.arch` instantiates the second. **Neither can be renamed** — the CVDP harness maps problems by SV top-module name, and it already handles this collision on its own side (`_dedupe_redeclared_modules`). Moving one into a subdirectory is out too: the harness globs `CVDP_DIR/*.sv` and does not recurse.

So `sipo_top.arch` names its provider with `use sipo_top_sipo_sub;`, with a comment explaining why, and its `serial_in` pin is corrected to the sub's actual `sin`. Result:

| | before | after |
|---|---|---|
| `arch check` | `× connects clk, which is not a port of …` | `OK: no errors` |
| `arch build` + Verilator lint | failing at lint since before #797 | **0 errors** |

## Guard

`tests/construct_name_collision_test.rs`. Worth being explicit about what it does **not** flag, because the obvious version of this test is unusable: two files defining the same construct name is completely normal here — all 156 `verilog_eval` problems declare `TopModule`, and `tests/rdc` reuses `M` / `Top` / `Sub` across dozens of standalone cases. My first attempt flagged ~200 of those.

It fires only on the combination that can actually bind silently to the wrong module:

1. a file instantiates name `X`, and does not define `X` itself, **and**
2. two or more files in that directory define `X`, **and**
3. one of them is literally `X.arch` (so discovery would resolve it — in `tests/aes`, PascalCase constructs live in snake_case files, so discovery can never fire and the unit is built by passing sources together), **and**
4. the instantiating file has no `use`.

Confirmed it fails if the `use` is removed from `sipo_top.arch`.

## Verification

- Corpus: **792 pass / 97 fail**, one better than the pre-#797 baseline — `sipo_top` restored, no other file moved.
- 788 integration tests green; `cargo fmt --check` and `cargo clippy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)