### PR TITLE
fix(formal): model sub-module `port reg` instead of dropping it (#821)

### DIFF
--- a/src/formal.rs
+++ b/src/formal.rs
@@ -363,6 +363,62 @@ fn flatten_for_formal(
                         _ => {}
                     }
                 }
+                // `port reg o: out T` (and its `out pipe_reg<T,1>` spelling)
+                // is a PortDecl, not a RegDecl body item, so the body walk
+                // below never sees it and no register is emitted for it.
+                // Left alone, the sub's `o <= ...` would be port-mapped
+                // straight onto the parent signal, land in `reg_writes`
+                // under a name that is not in `self.regs`, and be silently
+                // DROPPED by emit_base — leaving the parent signal declared
+                // but unconstrained, i.e. a free variable that admits
+                // spurious counterexamples (issue #821).
+                //
+                // Model it the way the RTL actually behaves: a register
+                // local to the instance, driving the parent signal
+                // combinationally. Treating the port name as a local makes
+                // every reference inside the sub (reads and the seq write)
+                // resolve to `<inst>_<port>`.
+                let mut carried_port_regs: Vec<(&PortDecl, String)> = Vec::new();
+                for p in &sub.ports {
+                    let Some(ri) = &p.reg_info else { continue };
+                    if ri.latency != 1 {
+                        return Err(CompileError::general(
+                            &format!(
+                                "hierarchical formal: inst `{}` port `{}` declares `pipe_reg<_, {}>`; \
+                                 `arch formal` v1 models only single-cycle port registers (latency 1). \
+                                 Refactor the sub-module to expose an explicit `reg` chain.",
+                                inst.name.name, p.name.name, ri.latency,
+                            ),
+                            inst.span,
+                        ));
+                    }
+                    let Some(parent_expr) = port_map.get(&p.name.name) else {
+                        continue;
+                    };
+                    let ExprKind::Ident(parent_name) = &parent_expr.kind else {
+                        return Err(CompileError::general(
+                            &format!(
+                                "hierarchical formal: inst `{}.{}` is a registered output port and \
+                                 must connect to a simple identifier in v1 (got a complex \
+                                 expression); refactor the parent to a named wire",
+                                inst.name.name, p.name.name,
+                            ),
+                            inst.span,
+                        ));
+                    };
+                    locals.insert(p.name.name.clone());
+                    carried_port_regs.push((p, parent_name.clone()));
+                }
+                // `subst_expr_for_formal` consults `port_map` BEFORE `locals`,
+                // so a carried port reg must be dropped from the port map or
+                // every reference to it — including the `seq` write that is
+                // the whole point — would still be rewritten to the parent
+                // signal and dropped. Removing it lets the `locals` path
+                // rewrite `o` to `<inst>_o`; the parent connection is driven
+                // instead by the `let` emitted alongside the RegDecl below.
+                for (p, _) in &carried_port_regs {
+                    port_map.remove(&p.name.name);
+                }
 
                 let prefix = format!("{}_", inst.name.name);
                 let new_body_start = new_body.len();
@@ -472,6 +528,43 @@ fn flatten_for_formal(
                         }
                         _ => unreachable!("validate_sub_for_formal rejects other items"),
                     }
+                }
+
+                // Emit the carried `port reg`s collected above: one prefixed
+                // RegDecl each, plus a let binding so the parent-side signal
+                // observes the registered value. `reg <inst>_<port>` +
+                // `let <parent> = <inst>_<port>` is exactly what `port reg`
+                // means in the RTL (always_ff drives it; the connection
+                // observes it). See the #821 note above.
+                for (p, parent_name) in carried_port_regs {
+                    let ri = p.reg_info.as_ref().expect("collected with reg_info");
+                    let new_init = ri
+                        .init
+                        .as_ref()
+                        .map(|e| subst_expr_for_formal(e, &port_map, &locals, &prefix));
+                    let new_reset =
+                        subst_reg_reset_for_formal(&ri.reset, &port_map, &locals, &prefix);
+                    let reg_name = format!("{prefix}{}", p.name.name);
+                    new_body.push(ModuleBodyItem::RegDecl(RegDecl {
+                        name: Ident::new(reg_name.clone(), p.name.span),
+                        ty: p.ty.clone(),
+                        init: new_init,
+                        reset: new_reset,
+                        guard: ri.guard.clone(),
+                        multicycle: None,
+                        span: p.span,
+                    }));
+                    new_body.push(ModuleBodyItem::LetBinding(LetBinding {
+                        name: Ident::new(parent_name, p.name.span),
+                        ty: Some(p.ty.clone()),
+                        value: Expr {
+                            kind: ExprKind::Ident(reg_name),
+                            span: p.span,
+                            parenthesized: false,
+                        },
+                        span: p.span,
+                        destructure_fields: Vec::new(),
+                    }));
                 }
 
                 // Rewrite SynthIdent strings in items appended for this
@@ -1709,15 +1802,28 @@ impl<'a> FormalCtx<'a> {
                 offenders.push((ca.target.as_str(), ca.span, "comb"));
             }
         }
+        // A `seq` write must land on something `emit_base` will actually
+        // emit a transition for, and that loop iterates `self.regs` — NOT
+        // `self.sigs`. A target that is in `sigs` but is not a register is
+        // therefore silently DROPPED, and because it *is* declared it
+        // becomes an unconstrained free variable, admitting spurious
+        // counterexamples. That is the #821 failure mode, and it is strictly
+        // worse than a refusal, so check membership in `regs` here rather
+        // than settling for `sigs`.
         for (target, writes) in &self.reg_writes {
-            if self.sigs.contains_key(target) || self.let_bindings.contains_key(target) {
+            if self.regs.iter().any(|r| r == target) {
                 continue;
             }
             let span = writes
                 .first()
                 .map(|(_, v)| v.span)
                 .unwrap_or(self.module.span);
-            offenders.push((target.as_str(), span, "seq"));
+            let kind = if self.sigs.contains_key(target) || self.let_bindings.contains_key(target) {
+                "seq-nonreg"
+            } else {
+                "seq"
+            };
+            offenders.push((target.as_str(), span, kind));
         }
 
         // `reg_writes` is a HashMap, so sort for a deterministic choice of
@@ -1755,6 +1861,21 @@ impl<'a> FormalCtx<'a> {
                      modelled (`<port>.<channel>.send(..)` / `.no_send()` / `.pop()` / \
                      `.no_pop()`); plain bus signals, handshake groups and `tlm_method` \
                      bundles are not encoded yet"
+                ),
+                span,
+            );
+        }
+        if block == "seq-nonreg" {
+            // In `sigs` but not a register: `emit_base` would emit no
+            // transition for it, so the write vanishes and the (declared)
+            // signal is left unconstrained — a free variable that admits
+            // spurious counterexamples. Refuse instead (issue #821).
+            return CompileError::general(
+                &format!(
+                    "`seq` block assigns to `{target}`, which `arch formal` v1 does not \
+                     model as a register — the write would be silently dropped and \
+                     `{target}` left unconstrained, which can produce a spurious \
+                     counterexample. Declare `{target}` as a `reg`, or drive it from one"
                 ),
                 span,
             );

--- a/tests/formal/hier_port_reg_proves.arch
+++ b/tests/formal/hier_port_reg_proves.arch
@@ -1,0 +1,33 @@
+// Issue #821: a sub-module `port reg` output used to be silently dropped
+// during flattening. `flatten_for_formal` walks the sub's BODY, and a
+// `port reg` is a PortDecl rather than a RegDecl body item, so no register
+// was emitted for it; the sub's `o <= 7` was port-mapped straight onto the
+// parent wire, landed in `reg_writes` under a name absent from `self.regs`,
+// and `emit_base` (which iterates `regs`) dropped it. The parent wire was
+// then DECLARED but never CONSTRAINED — a free variable — so this
+// trivially-true property REFUTED with a bogus counterexample.
+//
+// `o` only ever holds 0 (reset) or 7, so `w <= 7` must PROVE.
+
+module SubReg
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port reg o: out UInt<8> reset rst => 0;
+  seq on clk rising
+    o <= 8'd7;
+  end seq
+end module SubReg
+
+module HierPortReg
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  wire w: UInt<8>;
+
+  inst u0: SubReg
+    clk <- clk;
+    rst <- rst;
+    o -> w;
+  end inst u0
+
+  assert w_bounded: w <= 8'd7;
+end module HierPortReg

--- a/tests/formal/hier_port_reg_refutes.arch
+++ b/tests/formal/hier_port_reg_refutes.arch
@@ -1,0 +1,34 @@
+// Negative control for issue #821, and the more important half of the pair.
+//
+// The #821 fix must not merely flip REFUTED to PROVED — a carried sub-module
+// `port reg` that were modelled as a constant, or whose `seq` write still
+// failed to land, would ALSO make the sibling fixture pass. Here the
+// register genuinely reaches 7, so `w <= 6` is genuinely false and must
+// REFUTE at cycle 1 (cycle 0 is held at the reset value 0).
+//
+// During development this fixture caught exactly that: an intermediate fix
+// declared the register but left the write port-mapped, so the reg held its
+// reset value 0 forever and BOTH `w <= 7` and `w <= 6` "passed".
+
+module SubRegBad
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port reg o: out UInt<8> reset rst => 0;
+  seq on clk rising
+    o <= 8'd7;
+  end seq
+end module SubRegBad
+
+module HierPortRegBad
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  wire w: UInt<8>;
+
+  inst u0: SubRegBad
+    clk <- clk;
+    rst <- rst;
+    o -> w;
+  end inst u0
+
+  assert w_too_tight: w <= 8'd6;
+end module HierPortRegBad

--- a/tests/formal_test.rs
+++ b/tests/formal_test.rs
@@ -722,6 +722,43 @@ fn formal_replay_confirms_genuine_refutations() {
     );
 }
 
+/// Issue #821: a sub-module `port reg` output was silently dropped during
+/// flattening, leaving the parent wire declared but unconstrained — a free
+/// variable that produced a SPURIOUS REFUTED on a trivially-true property.
+///
+/// The pair matters more than either half: a fix that modelled the carried
+/// register as a constant, or that declared it without landing the `seq`
+/// write, would make the "proves" case pass while silently breaking the
+/// "refutes" case. Both directions are asserted.
+#[test]
+fn formal_hier_port_reg_is_modelled_not_dropped() {
+    if !z3_available() {
+        eprintln!("skipping: z3 not in PATH");
+        return;
+    }
+    // `o` holds 0 (reset) or 7, so `w <= 7` is true and must PROVE.
+    let (code, out) = run_formal(
+        "tests/formal/hier_port_reg_proves.arch",
+        &["--top", "HierPortReg", "--bound", "4"],
+    );
+    assert_eq!(code, 0, "expected exit 0 (PROVED); got {code}\n{out}");
+    assert!(out.contains("PROVED"), "expected PROVED:\n{out}");
+
+    // The register genuinely reaches 7, so `w <= 6` is false and must
+    // REFUTE — at cycle 1, since cycle 0 is held at the reset value 0.
+    // This is the half that catches a fix which merely flips the verdict.
+    let (code, out) = run_formal(
+        "tests/formal/hier_port_reg_refutes.arch",
+        &["--top", "HierPortRegBad", "--bound", "4"],
+    );
+    assert_eq!(code, 1, "expected exit 1 (REFUTED); got {code}\n{out}");
+    assert!(out.contains("REFUTED"), "expected REFUTED:\n{out}");
+    assert!(
+        out.contains("at cycle 1"),
+        "expected the violation at cycle 1 (cycle 0 is reset-held):\n{out}"
+    );
+}
+
 /// Issue #818: a write to a plain (non-credit_channel) bus signal used to
 /// panic in `emit_base` on `self.sigs[tgt]` (exit 101). It must now be a
 /// clean "unsupported in v1" compile error.


### PR DESCRIPTION
closes #821

`arch formal` reported a **false REFUTED** on a valid hierarchical design — a sub-module registered output was silently discarded during flattening, leaving the parent signal declared but never constrained.

## Root cause

`flatten_for_formal` walks the sub-module's **body**, but `port reg o: out T` (and its `out pipe_reg<T,1>` spelling) is a `PortDecl`, **not** a `RegDecl` body item — so no register was ever emitted for it. The sub's `o <= 7` was port-mapped straight onto the parent signal, landed in `reg_writes` under a name absent from `self.regs`, and `emit_base` — which iterates `regs`, not `sigs` — dropped the write.

The parent signal was then a **free variable**, so the solver "found" a counterexample by assigning it a value it can never hold. Confirmed before the fix via `--emit-smt`: `w_0/w_1/w_2` declared with **zero** constraints and no sub-module state at all.

Both spellings reproduced identically, so this was not confined to the deprecated syntax.

## The fix

Model it the way the RTL behaves — a register local to the instance, driving the parent signal combinationally. A carried `port reg` becomes a prefixed `reg <inst>_<port>` (carrying the sub's type, init, reset and guard, reset-substituted through the connection map) plus `let <parent> = <inst>_<port>`. That is precisely what `port reg` means: `always_ff` drives it, the connection observes it.

**The subtle part, and why my first attempt was wrong:** substitution consults `port_map` **before** `locals`, so adding the port name to `locals` was not enough — every reference, *including the `seq` write that is the whole point*, was still rewritten to the parent name and still dropped. The carried port must also be **removed from `port_map`**. Without that the register was declared but held its reset value forever, and the trivially-true property passed **for the wrong reason**.

That intermediate state is worth calling out, because it looked like success: the original repro flipped REFUTED → PROVED while the design was still mismodelled. Only the negative fixture exposed it.

`pipe_reg<T,N>` with N > 1 is now an explicit error rather than a silent mismodel.

## Before / after

```
$ arch formal repro.arch --top HierPortReg --bound 4     # assert w <= 7, o holds 0 or 7
-  [Assert] w_bounded   REFUTED  — at cycle 0            # spurious
+  [Assert] w_bounded   PROVED   — up to bound 4
```
and the SMT now carries the transition:
```
(assert (= u0_o_1 (ite (= rst_0 #b1) 0 (ite (= #b1 #b1) #x07 u0_o_0))))
(assert (= w_0 u0_o_0))
```

## Also: tightened the #818 target check

A `seq` write whose target is in `sigs` but **not** in `regs` is now refused — dropped by `emit_base` while the signal stays declared, i.e. the same free-variable hazard one predicate over. **Honest caveat:** with this fix the #821 path no longer reaches that guard, so it is defense-in-depth against future flattening changes, not a second live fix.

## Tests

A **proves/refutes fixture pair**, and the negative half is the load-bearing one: a fix that modelled the carried register as a constant, or declared it without landing the write, would make the positive case pass while silently breaking the negative one. It asserts REFUTED **at cycle 1** specifically (cycle 0 is reset-held) — that is what caught the bad intermediate fix.

Also verified by hand: multi-instance prefix separation (`u0_o`/`u1_o` now appear as distinct registers in the counterexample table), binding to a parent **output port** rather than a wire, and the `pipe_reg` spelling.

Fast gate: `cargo fmt --check` clean, `cargo build --release`, full `cargo test` — 16 suites, 0 failures.

Found while fixing #818; reported by the #803/#817 counterexample-replay corpus sweep. Note replay does **not** catch this class — it reads the wire's value from the model and confirms the bogus counterexample, which is the documented v1 gap in #817 and a concrete argument for the deferred model cross-validator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)