### PR TITLE
fix(interface): stop emitting .archi for packages

### DIFF
--- a/doc/ARCH_HDL_Specification.md
+++ b/doc/ARCH_HDL_Specification.md
@@ -9268,6 +9268,8 @@ end module SubModule
 
 The `.archi` file is valid ARCH syntax and can be parsed by the compiler directly. It is named by **module name** (not source filename), so `fifo_async_r2w_sync.arch` (which defines `synchronizer r2w_sync`) generates `r2w_sync.archi`.
 
+**Packages emit no `.archi`.** A `package` declares types, buses and functions — never an instantiable construct — so it never takes part in the construct-name resolution `.archi` exists for, and nothing would read one: `use` resolves only `<name>.arch`, and the `.archi` lookups in §30.2 are keyed on the *construct* name rather than the enclosing package's. A consumer of a package therefore needs its `.arch`, reached with `use <Package>;`. (A bus declared inside a package is still discoverable by its own name per §30.2, since that search keys on the bus.)
+
 **30.2 Dependency Discovery**
 
 When the compiler encounters `inst sub: SubModule` and `SubModule` is not defined in the input files, it automatically searches for:
@@ -9277,6 +9279,8 @@ When the compiler encounters `inst sub: SubModule` and `SubModule` is not define
 3. `SubModule.arch` or `SubModule.archi` in directories listed in `ARCH_LIB_PATH` (colon-separated)
 
 The same discovery applies to **bus port types**. A port declaration `port m: initiator BusName` or `port m: target BusName` whose `BusName` is not defined in the input files triggers the identical search for `BusName.arch` / `BusName.archi` (input directory, then `ARCH_LIB_PATH`, then the stdlib). This means `arch check ModuleWithBusPort.arch` resolves the bus on its own — there is no need to also pass the bus source. An explicit `use BusName;` takes precedence: when the bus is named in a `use`, that declaration drives resolution and the fallback bus scan is skipped, so a stale build-emitted `BusName.archi` in the source directory cannot shadow it. Emitted bus `.archi` files are round-trippable — bus members are written as bare `name: dir Type;`, matching the `bus` body grammar.
+
+**`use` takes precedence for `inst` targets too.** Discovery above is keyed on the filename, so when two files in a directory define the same construct it would otherwise resolve to whichever one is named after it — silently, and possibly not the intended one. Naming the provider with `use <file>;` suppresses the filename lookup for the constructs that file supplies, which is the way to disambiguate when a name is defined more than once.
 
 This enables separate compilation workflows:
 

--- a/skills/arch-programming/references/ARCH_HDL_Specification.md
+++ b/skills/arch-programming/references/ARCH_HDL_Specification.md
@@ -9268,6 +9268,8 @@ end module SubModule
 
 The `.archi` file is valid ARCH syntax and can be parsed by the compiler directly. It is named by **module name** (not source filename), so `fifo_async_r2w_sync.arch` (which defines `synchronizer r2w_sync`) generates `r2w_sync.archi`.
 
+**Packages emit no `.archi`.** A `package` declares types, buses and functions — never an instantiable construct — so it never takes part in the construct-name resolution `.archi` exists for, and nothing would read one: `use` resolves only `<name>.arch`, and the `.archi` lookups in §30.2 are keyed on the *construct* name rather than the enclosing package's. A consumer of a package therefore needs its `.arch`, reached with `use <Package>;`. (A bus declared inside a package is still discoverable by its own name per §30.2, since that search keys on the bus.)
+
 **30.2 Dependency Discovery**
 
 When the compiler encounters `inst sub: SubModule` and `SubModule` is not defined in the input files, it automatically searches for:
@@ -9277,6 +9279,8 @@ When the compiler encounters `inst sub: SubModule` and `SubModule` is not define
 3. `SubModule.arch` or `SubModule.archi` in directories listed in `ARCH_LIB_PATH` (colon-separated)
 
 The same discovery applies to **bus port types**. A port declaration `port m: initiator BusName` or `port m: target BusName` whose `BusName` is not defined in the input files triggers the identical search for `BusName.arch` / `BusName.archi` (input directory, then `ARCH_LIB_PATH`, then the stdlib). This means `arch check ModuleWithBusPort.arch` resolves the bus on its own — there is no need to also pass the bus source. An explicit `use BusName;` takes precedence: when the bus is named in a `use`, that declaration drives resolution and the fallback bus scan is skipped, so a stale build-emitted `BusName.archi` in the source directory cannot shadow it. Emitted bus `.archi` files are round-trippable — bus members are written as bare `name: dir Type;`, matching the `bus` body grammar.
+
+**`use` takes precedence for `inst` targets too.** Discovery above is keyed on the filename, so when two files in a directory define the same construct it would otherwise resolve to whichever one is named after it — silently, and possibly not the intended one. Naming the provider with `use <file>;` suppresses the filename lookup for the constructs that file supplies, which is the way to disambiguate when a name is defined more than once.
 
 This enables separate compilation workflows:
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1761,10 +1761,14 @@ impl_construct_direct!(
     iface = crate::interface::emit_bus_interface,
     check = check_bus
 );
+// No `iface`: a package has no `.archi` form. Nothing can consume one —
+// `use` resolves only `<name>.arch`, and the `.archi`-aware `inst` / bus
+// lookups key on the *construct* filename, never the package's. A package
+// also cannot declare a module, so it never participates in the module-name
+// resolution `.archi` exists for. See #819.
 impl_construct_direct!(
     PackageDecl,
     "package",
-    iface = crate::interface::emit_package_interface,
     check = check_package,
     emit_sv = emit_package
 );

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -337,42 +337,6 @@ pub(crate) fn emit_enum(e: &EnumDecl) -> String {
     out
 }
 
-pub(crate) fn emit_package_interface(p: &PackageDecl) -> String {
-    let name = &p.name.name;
-    let mut out = format!("package {name}\n");
-    // Params
-    emit_params(&mut out, &p.params);
-    // Enums
-    for e in &p.enums {
-        out.push_str(&indent(&emit_enum(e)));
-    }
-    // Structs
-    for s in &p.structs {
-        out.push_str(&indent(&emit_struct(s)));
-    }
-    // Function signatures (no body)
-    for f in &p.functions {
-        let fname = &f.name.name;
-        let params: Vec<String> = f
-            .args
-            .iter()
-            .map(|fp| format!("{}: {}", fp.name.name, type_str(&fp.ty)))
-            .collect();
-        out.push_str(&format!(
-            "  function {fname}({}) -> {};\n",
-            params.join(", "),
-            type_str(&f.ret_ty)
-        ));
-    }
-    out.push_str(&format!("end package {name}\n"));
-    out
-}
-
-/// Indent each line by 2 spaces (for nesting structs/enums inside packages).
-fn indent(s: &str) -> String {
-    s.lines().map(|l| format!("  {l}\n")).collect()
-}
-
 pub(crate) fn emit_params(s: &mut String, params: &[ParamDecl]) {
     for p in params {
         let local = if p.is_local { "local " } else { "" };

--- a/tests/interface_roundtrip_test.rs
+++ b/tests/interface_roundtrip_test.rs
@@ -75,19 +75,6 @@ fn roundtrip_failures(source: &Path, work: &Path) -> Vec<String> {
     failures
 }
 
-/// Sources whose stubs are known not to round-trip yet, with the issue that
-/// tracks each. Listing them keeps the sweep green without hiding them.
-fn known_bad(source: &Path) -> Option<&'static str> {
-    let name = source.file_name()?.to_string_lossy().to_string();
-    match name.as_str() {
-        // A `package` stub emits bodyless `function f(...) -> T;` signatures,
-        // which the parser rejects. Fixing it needs either a function-body
-        // pretty-printer or a parser that accepts signatures in `.archi`.
-        "TestPkg.arch" => Some("#819"),
-        _ => None,
-    }
-}
-
 #[test]
 fn every_emitted_archi_stub_reparses() {
     let root = repo_root();
@@ -106,22 +93,16 @@ fn every_emitted_archi_stub_reparses() {
     );
 
     let mut failures = Vec::new();
-    let mut skipped = 0usize;
     for (idx, source) in sources.iter().enumerate() {
-        if known_bad(source).is_some() {
-            skipped += 1;
-            continue;
-        }
         failures.extend(roundtrip_failures(source, &tmp.join(idx.to_string())));
     }
     let _ = std::fs::remove_dir_all(&tmp);
 
     assert!(
         failures.is_empty(),
-        "{} emitted .archi stub(s) do not re-check ({} known-bad skipped).\n\
+        "{} emitted .archi stub(s) do not re-check.\n\
          An interface stub must be a valid input to the compiler that wrote it.\n{}",
         failures.len(),
-        skipped,
         failures.join("\n")
     );
 }
@@ -142,4 +123,64 @@ fn collect_arch_sources(dir: &Path, out: &mut Vec<PathBuf>) {
             out.push(path);
         }
     }
+}
+
+/// A `package` has no `.archi` form, and emitting one was worse than emitting
+/// nothing: the file could not be consumed by any code path (#819).
+///
+/// `use` resolves only `<name>.arch`, and the `.archi`-aware `inst` / bus
+/// lookups key on the *construct* filename rather than the package's, so a
+/// `TestPkg.archi` was written and never read. A package also cannot declare a
+/// module — the parser accepts only param / domain / enum / struct / bus /
+/// function — so it never takes part in the module-name resolution `.archi`
+/// exists for.
+#[test]
+fn packages_emit_no_archi_but_still_emit_sv_and_resolve() {
+    let root = repo_root();
+    let tmp = std::env::temp_dir().join(format!("arch_pkg_no_archi_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&tmp);
+    std::fs::create_dir_all(&tmp).expect("mkdir");
+    for f in ["TestPkg.arch", "pkg_user.arch"] {
+        std::fs::copy(root.join("examples").join(f), tmp.join(f)).expect("copy fixture");
+    }
+
+    let out = Command::new(arch())
+        .current_dir(&tmp)
+        .args(["build", "TestPkg.arch", "-o", "TestPkg.sv"])
+        .output()
+        .expect("run arch build");
+    assert!(out.status.success(), "package build failed");
+
+    let stubs: Vec<String> = std::fs::read_dir(&tmp)
+        .expect("read dir")
+        .filter_map(|e| e.ok().map(|e| e.path()))
+        .filter(|p| p.extension().is_some_and(|x| x == "archi"))
+        .map(|p| p.file_name().unwrap().to_string_lossy().to_string())
+        .collect();
+    assert!(
+        stubs.is_empty(),
+        "a package must not emit an .archi, got {stubs:?}"
+    );
+
+    // The SV package is still emitted — this removes the interface stub only.
+    let sv = std::fs::read_to_string(tmp.join("TestPkg.sv")).expect("read sv");
+    assert!(
+        sv.contains("package TestPkg"),
+        "SV package body should still be emitted:\n{sv}"
+    );
+
+    // And a consumer still resolves the package through its `.arch`.
+    let out = Command::new(arch())
+        .current_dir(&tmp)
+        .args(["check", "pkg_user.arch"])
+        .output()
+        .expect("run arch check");
+    assert!(
+        out.status.success(),
+        "package consumer should still check clean: {}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let _ = std::fs::remove_dir_all(&tmp);
 }


### PR DESCRIPTION
Closes #819.

## Why removal rather than a parser fix

#819 was filed as "the package stub emits bodyless `function` signatures the parser rejects." Working a concrete example showed the parse failure is the second problem, not the first: **nothing can consume a package `.archi` on any code path.**

- `use <name>;` resolves only `<name>.arch` (`src/main.rs`), never `.archi`.
- The two `.archi`-aware discovery paths key on the *construct* filename — `<inst_target>.archi` and `<bus_name>.archi` — never the package's.

Verified rather than inferred:

```
$ ls lib/          →  TestPkg.archi        # stub only
$ ARCH_LIB_PATH=$PWD/lib arch check pkg_user.arch
Error:   × undefined name: `AluOp`

$ cp TestPkg.arch lib/                     # real source alongside
$ ARCH_LIB_PATH=$PWD/lib arch check pkg_user.arch
OK: no errors
```

So teaching the parser a bodyless-`function` production would only make a file nobody reads parse.

## Can a package ever need `.archi`?

`.archi` exists for cross-file construct resolution, and a package cannot take part in it. The parser accepts only `param` / `domain` / `enum` / `struct` / `bus` / `function` inside a package:

```
$ arch check P.arch          # package containing a module
Error:   × unexpected token: expected param, domain, enum, struct, bus, or function,
  │ found module
 6 │   module Inner
```

The one package member that *does* participate in `.archi` lookup is `bus` — and it is found by its own filename, not the package's, so a package stub was never a route for it. Bus-in-package resolves today through `use` + `.arch`; confirmed with a fixture.

## Change

- `PackageDecl` drops its `iface` registration, so `emit_interface()` returns `None` (same shape `TemplateDecl` already uses).
- `emit_package_interface` and the now-dead `indent` helper are removed.
- `emit_sv` is untouched — the SV package body is unaffected.

## Result

This clears the last exception in the round-trip sweep added with #815. `tests/interface_roundtrip_test.rs` no longer carries a `known_bad` table and now asserts without qualification that **every** emitted stub re-checks.

New `packages_emit_no_archi_but_still_emit_sv_and_resolve` pins all three properties: no `.archi` written, SV package still emitted, consumer still resolves.

## Verification

- Round-trip sweep: 2 tests green, zero exceptions.
- 788 integration tests green; `cargo fmt --check` and `cargo clippy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)