### PR TITLE
fix(formal): preserve signedness through singleton concat/repeat in cex replay

### DIFF
--- a/src/formal.rs
+++ b/src/formal.rs
@@ -5173,6 +5173,11 @@ impl FormalCtx<'_> {
                 let parts: Option<Vec<NumVal>> =
                     es.iter().map(|p| self.replay_raw(p, t, m, fns)).collect();
                 let parts = parts?;
+                // Mirror the encoder: a singleton {a} passes the sole part
+                // through unchanged, keeping its signedness.
+                if parts.len() == 1 {
+                    return parts.into_iter().next();
+                }
                 let total: u32 = parts.iter().map(|p| p.width).sum();
                 if total > 64 {
                     return None;
@@ -5189,6 +5194,11 @@ impl FormalCtx<'_> {
                     return None;
                 }
                 let xt = self.replay_raw(x, t, m, fns)?;
+                // Mirror the encoder: {1{x}} passes the operand through
+                // unchanged, keeping its signedness.
+                if n_v == 1 {
+                    return Some(xt);
+                }
                 let total = xt.width.checked_mul(n_v as u32)?;
                 if total > 64 {
                     return None;
@@ -5820,6 +5830,65 @@ end module ReplayNot
             ctx.replay_check(prop, &m, 0, 1, 0, &fns),
             ReplayVerdict::Contradicted,
             "8-bit ~5 is 250: the property holds, so a sat claim contradicts"
+        );
+    }
+
+    #[test]
+    fn replay_preserves_signedness_through_singleton_concat_and_repeat() {
+        // The encoder passes a singleton {a} / {1{x}} through unchanged,
+        // keeping the operand's signed flag; the replay mirror used to fall
+        // into the general concat/repeat arms and force `signed: false`.
+        // With x=200, `{1{signed(x)}} > 1` is a bvsgt in the query
+        // (-56 > 1, false → violated → Confirmed), but a signedness-lossy
+        // replay does 200 > 1 unsigned (true → property holds) and
+        // manufactures a false Contradicted → EncodingUnsound.
+        let src = r#"
+module ReplaySignRep
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port x: in UInt<8>;
+  port o: out Bool;
+  comb o = {1{signed(x)}} > 1; end comb
+  assert pos: {1{signed(x)}} > 1;
+end module ReplaySignRep
+"#;
+        let (ast, symbols) = parse_and_resolve(src);
+        let ctx = build_ctx(&ast, &symbols);
+        let prop = &ctx.properties[0];
+        let fns = crate::fp_ops::fp_functions(crate::FpCompat::default());
+        let m = model(&[("x_0", 200), ("x_1", 200)]);
+        assert_eq!(
+            ctx.replay_check(prop, &m, 0, 1, 0, &fns),
+            ReplayVerdict::Confirmed(0),
+            "signed(200) as SInt<8> is -56: the signed compare is violated"
+        );
+        // And the property genuinely holds for a positive value — replay
+        // must agree with the encoder there too (Contradicted on a bogus
+        // sat claim), still through the signed compare.
+        let m = model(&[("x_0", 5), ("x_1", 5)]);
+        assert_eq!(
+            ctx.replay_check(prop, &m, 0, 1, 0, &fns),
+            ReplayVerdict::Contradicted
+        );
+
+        // Same divergence through the singleton-Concat shape {signed(x)}.
+        let src = r#"
+module ReplaySignCat
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port x: in UInt<8>;
+  port o: out Bool;
+  comb o = {signed(x)} > 1; end comb
+  assert pos: {signed(x)} > 1;
+end module ReplaySignCat
+"#;
+        let (ast, symbols) = parse_and_resolve(src);
+        let ctx = build_ctx(&ast, &symbols);
+        let prop = &ctx.properties[0];
+        let m = model(&[("x_0", 200), ("x_1", 200)]);
+        assert_eq!(
+            ctx.replay_check(prop, &m, 0, 1, 0, &fns),
+            ReplayVerdict::Confirmed(0)
         );
     }
 


### PR DESCRIPTION
## Summary

Fixes a signedness divergence between the SMT encoder and the counterexample-replay evaluator introduced in #817 (part of the #803 Layer-B trust work), found in post-merge review of #817.

`encode_raw` has two early-returns that pass the operand's `SmtTerm` through **unchanged**:
- `Concat` with `parts.len() == 1` returns the sole part (preserving its `signed` flag);
- `Repeat` with folded count 1 returns the operand term as-is.

The replay mirror `replay_raw` had no such special cases — its general `Concat`/`Repeat` arms return `nv(v, total, false)`, forcing `signed: false` in both singleton shapes. Both are parser-reachable: `{a}` parses as a 1-element concat, and `{1{x}}` (or a param-dependent `{N{x}}` elaborated to N=1) is a count-1 repeat.

**Consequence:** for e.g. `{1{signed(x)}} > 1` inside an assert, the query does a signed compare (`bvsgt`) while replay compared unsigned — a decidably-wrong replay value that can report a wrong Confirmed cycle or, worse, manufacture a false Contradicted → `PropertyStatus::EncodingUnsound` (exit 3, hard CI failure). This violates the replay's width- and signedness-exact contract: replay must never fabricate a contradiction.

## Fix

Mirror the encoder's early-returns in `replay_raw`: singleton `Concat` returns its sole part unchanged; count-1 `Repeat` returns the evaluated operand unchanged — both preserving width and signedness.

## Testing

- New unit test `replay_preserves_signedness_through_singleton_concat_and_repeat`: asserts `{1{signed(x)}} > 1` (and the `{signed(x)}` concat shape) with x=200 — signed(200) as SInt<8> is −56, so the signed compare is violated → replay must report `Confirmed(0)`, and `Contradicted` only when the property genuinely holds (x=5). **Verified the test fails without the fix** (the lossy replay judged the property as holding and produced the false-Contradicted path).
- `cargo build` + `cargo test` green (the two `construct_proof_lean_*` failures are pre-existing local-environment failures — they fail identically on a clean checkout).

Refs #817, #803.