### PR TITLE
fix(codegen): lower .reverse<C>() to portable reversed-chunk concat (closes #808)

### DIFF
--- a/doc/COMPILER_STATUS.md
+++ b/doc/COMPILER_STATUS.md
@@ -172,7 +172,7 @@ analysis, doc comments) remain directly under `doc/`.
 | Reduction `&x \|x ^x` | ✅ Unary prefix on `UInt<N>`/`SInt<N>`; result is `Bool`; emits SV `&expr`, `\|expr`, `^expr` |
 | Field access `.field` | ✅ |
 | Array index `[i]` | ✅ |
-| `.trunc<N>()` / `.zext<N>()` / `.sext<N>()` / `expr[hi:lo]` bit-slice / `.reverse(N)` | ✅ | `.reverse(N)` reverses in N-bit chunks; emits SV `{<<N{expr}}`; type checker enforces width divisible by N |
+| `.trunc<N>()` / `.zext<N>()` / `.sext<N>()` / `expr[hi:lo]` bit-slice / `.reverse(N)` | ✅ | `.reverse(N)` reverses in N-bit chunks; emits an ordinary reversed-chunk concat (`{x[0 +: N], x[N +: N], …}`) — the SV streaming operator `{<<N{x}}` is rejected by Icarus in any context (arch#808); type checker enforces width divisible by N |
 | `signed(expr)` / `unsigned(expr)` | ✅ | Same-width reinterpret cast: `signed(UInt<8>)` → `SInt<8>`, `unsigned(SInt<8>)` → `UInt<8>`; emits `$signed()`/`$unsigned()` in SV; eliminates `.sext<N>()` when entering signed arithmetic chains |
 | `as` cast | ✅ | Width-checked: source and target must have same total bit width; emits SV `Type'(expr)`; struct-to-struct casts supported for same-width packed structs |
 | Struct literals | ✅ |

--- a/skills/arch-programming/references/COMPILER_STATUS.md
+++ b/skills/arch-programming/references/COMPILER_STATUS.md
@@ -172,7 +172,7 @@ analysis, doc comments) remain directly under `doc/`.
 | Reduction `&x \|x ^x` | ✅ Unary prefix on `UInt<N>`/`SInt<N>`; result is `Bool`; emits SV `&expr`, `\|expr`, `^expr` |
 | Field access `.field` | ✅ |
 | Array index `[i]` | ✅ |
-| `.trunc<N>()` / `.zext<N>()` / `.sext<N>()` / `expr[hi:lo]` bit-slice / `.reverse(N)` | ✅ | `.reverse(N)` reverses in N-bit chunks; emits SV `{<<N{expr}}`; type checker enforces width divisible by N |
+| `.trunc<N>()` / `.zext<N>()` / `.sext<N>()` / `expr[hi:lo]` bit-slice / `.reverse(N)` | ✅ | `.reverse(N)` reverses in N-bit chunks; emits an ordinary reversed-chunk concat (`{x[0 +: N], x[N +: N], …}`) — the SV streaming operator `{<<N{x}}` is rejected by Icarus in any context (arch#808); type checker enforces width divisible by N |
 | `signed(expr)` / `unsigned(expr)` | ✅ | Same-width reinterpret cast: `signed(UInt<8>)` → `SInt<8>`, `unsigned(SInt<8>)` → `UInt<8>`; emits `$signed()`/`$unsigned()` in SV; eliminates `.sext<N>()` when entering signed arithmetic chains |
 | `as` cast | ✅ | Width-checked: source and target must have same total bit width; emits SV `Type'(expr)`; struct-to-struct casts supported for same-width packed structs |
 | Struct literals | ✅ |

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -6365,6 +6365,241 @@ impl<'a> Codegen<'a> {
         Some(tmp)
     }
 
+    /// Params of the construct currently being emitted (module / fsm /
+    /// pipeline), for `eval_const_u32` width resolution. `None` when the
+    /// current construct can't be found by name — callers fall back
+    /// conservatively.
+    fn current_construct_params(&self) -> Option<&[ParamDecl]> {
+        self.source.items.iter().find_map(|item| match item {
+            Item::Module(m) if m.name.name == self.current_construct => {
+                Some(m.params.as_slice())
+            }
+            Item::Fsm(f) if f.name.name == self.current_construct => Some(f.params.as_slice()),
+            Item::Pipeline(p) if p.name.name == self.current_construct => {
+                Some(p.params.as_slice())
+            }
+            _ => None,
+        })
+    }
+
+    /// Numeric bit-width of a `TypeExpr`, const-evaluating the width
+    /// sub-expression through `params` (unlike `type_expr_width`, which
+    /// only folds literals). Covers just the shapes a `.reverse()`
+    /// receiver can legally have (typecheck restricts it to
+    /// UInt/SInt/Bool) — everything else is `None`.
+    fn type_expr_width_const(&self, ty: &TypeExpr, params: &[ParamDecl]) -> Option<u32> {
+        match ty {
+            TypeExpr::UInt(w) | TypeExpr::SInt(w) => self.eval_const_u32(w, params),
+            TypeExpr::Bool | TypeExpr::Bit => Some(1),
+            _ => None,
+        }
+    }
+
+    /// Declared `TypeExpr` of a plain identifier in the current
+    /// module/fsm scope (ports, regs, typed lets, wires). Pipelines have
+    /// no `module_scopes` entry (resolve.rs builds those for modules and
+    /// fsms only) — the pipeline emitters resolve through the pipeline's
+    /// own AST via `pipeline_ident_type` instead.
+    fn construct_ident_type(&self, name: &str) -> Option<TypeExpr> {
+        let scope = self.symbols.module_scopes.get(&self.current_construct)?;
+        match scope.get(name)? {
+            (Symbol::Port(p), _) => Some(p.ty.clone()),
+            (Symbol::Reg(r), _) => Some(r.ty.clone()),
+            (Symbol::Let(_), _) => {
+                self.source.items.iter().find_map(|item| match item {
+                    Item::Module(m) if m.name.name == self.current_construct => {
+                        m.body.iter().find_map(|bi| match bi {
+                            ModuleBodyItem::LetBinding(l) if l.name.name == name => l.ty.clone(),
+                            ModuleBodyItem::WireDecl(wd) if wd.name.name == name => {
+                                Some(wd.ty.clone())
+                            }
+                            _ => None,
+                        })
+                    }
+                    Item::Fsm(f) if f.name.name == self.current_construct => f
+                        .lets
+                        .iter()
+                        .find(|l| l.name.name == name)
+                        .and_then(|l| l.ty.clone())
+                        .or_else(|| {
+                            f.wires
+                                .iter()
+                                .find(|w| w.name.name == name)
+                                .map(|w| w.ty.clone())
+                        }),
+                    _ => None,
+                })
+            }
+            _ => None,
+        }
+    }
+
+    /// Numeric bit-width of a `.reverse()` receiver — `None` when it
+    /// can't be proven here (the caller then falls back to the
+    /// streaming-concat emission, i.e. the pre-arch#808 Verilator-only
+    /// behavior). `lookup_ident` abstracts over module/fsm scope lookup
+    /// vs the pipeline emitters' stage-aware lookup.
+    fn reverse_recv_width_u32(
+        &self,
+        recv: &Expr,
+        params: &[ParamDecl],
+        lookup_ident: &dyn Fn(&str) -> Option<TypeExpr>,
+    ) -> Option<u32> {
+        match &recv.kind {
+            ExprKind::Ident(n) => self.type_expr_width_const(&lookup_ident(n)?, params),
+            ExprKind::SynthIdent(_, ty) => self.type_expr_width_const(ty, params),
+            ExprKind::Signed(inner) | ExprKind::Unsigned(inner) => {
+                self.reverse_recv_width_u32(inner, params, lookup_ident)
+            }
+            ExprKind::Cast(_, ty) => self.type_expr_width_const(ty, params),
+            ExprKind::Literal(LitKind::Sized(w, _)) => Some(*w as u32),
+            // Unsized literals: minimum bit width from the value, never 0
+            // bits — same rule as `infer_sv_width_str`.
+            ExprKind::Literal(LitKind::Dec(v) | LitKind::Hex(v) | LitKind::Bin(v)) => {
+                Some(if *v == 0 { 1 } else { 64 - v.leading_zeros() })
+            }
+            ExprKind::MethodCall(inner, method, margs) => match method.name.as_str() {
+                "trunc" | "zext" | "sext" | "resize" => self.eval_const_u32(margs.first()?, params),
+                "reverse" => self.reverse_recv_width_u32(inner, params, lookup_ident),
+                _ => None,
+            },
+            ExprKind::BitSlice(_, hi, lo) => {
+                let h = self.eval_const_u32(hi, params)?;
+                let l = self.eval_const_u32(lo, params)?;
+                (h >= l).then(|| h - l + 1)
+            }
+            ExprKind::PartSelect(_, _, w, _) => self.eval_const_u32(w, params),
+            // `v[i].reverse<C>()` — the element width of an
+            // identifier-typed `Vec` receiver.
+            ExprKind::Index(base, _) => match &base.kind {
+                ExprKind::Ident(n) => match lookup_ident(n)? {
+                    TypeExpr::Vec(inner, _) => self.type_expr_width_const(&inner, params),
+                    _ => None,
+                },
+                _ => None,
+            },
+            // Operator result widths — these MUST mirror typecheck's
+            // `resolve_expr_type` rules (IEEE 1800 §11.6) exactly: the
+            // width computed here sizes both the hoist temp and the
+            // chunk part-selects, so a divergence from the checked type
+            // would be a silent miscompile, not merely a portability
+            // miss. Anything uncertain returns `None` (streaming-concat
+            // fallback).
+            ExprKind::Binary(op, l, r) => {
+                let lw = self.reverse_recv_width_u32(l, params, lookup_ident);
+                let rw = self.reverse_recv_width_u32(r, params, lookup_ident);
+                match op {
+                    BinOp::Eq
+                    | BinOp::Neq
+                    | BinOp::Lt
+                    | BinOp::Gt
+                    | BinOp::Lte
+                    | BinOp::Gte
+                    | BinOp::And
+                    | BinOp::Or
+                    | BinOp::Implies
+                    | BinOp::ImpliesNext => Some(1),
+                    BinOp::Add | BinOp::Sub => Some(lw?.max(rw?) + 1),
+                    BinOp::AddWrap | BinOp::SubWrap | BinOp::MulWrap => Some(lw?.max(rw?)),
+                    BinOp::Mul => Some(lw? + rw?),
+                    BinOp::Div | BinOp::Mod => lw,
+                    BinOp::BitAnd | BinOp::BitOr | BinOp::BitXor => Some(lw?.max(rw?)),
+                    BinOp::Shl | BinOp::Shr => lw,
+                }
+            }
+            ExprKind::Unary(op, operand) => match op {
+                UnaryOp::Not | UnaryOp::RedAnd | UnaryOp::RedOr | UnaryOp::RedXor => Some(1),
+                UnaryOp::BitNot => self.reverse_recv_width_u32(operand, params, lookup_ident),
+                // typecheck: `-UInt<w>` → `SInt<w+1>`, `-SInt<w>` → `SInt<w>`
+                // — receiver signedness isn't tracked here, so bail.
+                UnaryOp::Neg => None,
+            },
+            // typecheck takes the then-branch type.
+            ExprKind::Ternary(_, then_e, _) => {
+                self.reverse_recv_width_u32(then_e, params, lookup_ident)
+            }
+            ExprKind::Concat(parts) => parts.iter().try_fold(0u32, |acc, p| {
+                Some(acc + self.reverse_recv_width_u32(p, params, lookup_ident)?)
+            }),
+            ExprKind::Repeat(count, value) => Some(
+                self.eval_const_u32(count, params)?
+                    * self.reverse_recv_width_u32(value, params, lookup_ident)?,
+            ),
+            _ => None,
+        }
+    }
+
+    /// arch#808: portable lowering for `.reverse<C>()`. Icarus Verilog
+    /// (12.0) rejects the SV streaming-concat operator `{<<C{x}}` in
+    /// every context, so when the receiver width `w` is known, emit an
+    /// ordinary concatenation of the receiver's C-bit chunks in reversed
+    /// order — bit-identical to `{<<C{x}}` (the receiver's lowest chunk
+    /// lands most-significant; verified exhaustively against Verilator
+    /// for chunks 1/2/4 over all 8-bit inputs) and accepted by both
+    /// simulators. `w == c` (single chunk) is the identity — still
+    /// emitted as a singleton concat `{x}` so the result stays an
+    /// unsigned self-determined vector, exactly like the streaming form.
+    fn emit_reverse_chunks(sel: &str, w: u32, c: u32) -> String {
+        if w == c {
+            return format!("{{{sel}}}");
+        }
+        let parts: Vec<String> = (0..w / c)
+            .map(|i| {
+                if c == 1 {
+                    format!("{sel}[{i}]")
+                } else {
+                    format!("{sel}[{} +: {c}]", i * c)
+                }
+            })
+            .collect();
+        format!("{{{}}}", parts.join(", "))
+    }
+
+    /// Attempt the arch#808 portable `.reverse<chunk>()` lowering in the
+    /// main (module/fsm) expression emitter. `None` — the caller keeps
+    /// the streaming-concat emission — when the chunk or receiver width
+    /// can't be const-resolved here, the divisibility doesn't hold
+    /// (typecheck rejects both upstream), or the receiver needs a hoist
+    /// temp but references a live runtime `for`-loop variable
+    /// (module-scope temps can't see loop-locals; same guard as the
+    /// `Index`/`BitSlice` hoists).
+    fn try_emit_reverse_chunked(&self, base: &Expr, chunk: &Expr) -> Option<String> {
+        let params = self.current_construct_params()?;
+        let c = self.eval_const_u32(chunk, params)?;
+        let unwrapped = Self::unwrap_reinterpret_cast(base);
+        let w =
+            self.reverse_recv_width_u32(unwrapped, params, &|n| self.construct_ident_type(n))?;
+        if c == 0 || w == 0 || w % c != 0 {
+            return None;
+        }
+        let sel = match &unwrapped.kind {
+            // Directly part-selectable SV shapes — the same family the
+            // `Index` emitter treats as atomic (minus literals, which
+            // can't take a select at all).
+            ExprKind::Ident(_)
+            | ExprKind::SynthIdent(_, _)
+            | ExprKind::Index(_, _)
+            | ExprKind::FieldAccess(_, _) => self.emit_expr_str(unwrapped),
+            // Anything else (a computation, literal, cast, or `{...}`
+            // shape) can't take a part-select — hoist it to a named
+            // module-scope temp, the same mechanism arch#650/#807 use.
+            _ => {
+                if !self.runtime_for_loop_vars.is_empty()
+                    && Self::expr_references_any(unwrapped, &self.runtime_for_loop_vars)
+                {
+                    return None;
+                }
+                let tmp = format!("arch_idx_base_{}", self.next_index_hoist_id());
+                let rhs = self.emit_expr_str(unwrapped);
+                let mut hoists = self.index_hoist_lines.borrow_mut();
+                hoists.push(format!("logic [{w}-1:0] {tmp};"));
+                hoists.push(format!("assign {tmp} = {rhs};"));
+                tmp
+            }
+        };
+        Some(Self::emit_reverse_chunks(&sel, w, c))
+    }
+
     /// Emit an expression, wrapping in parens only when its precedence is
     /// below `parent_prec` (i.e. the context requires tighter binding).
     fn emit_expr_prec(&self, expr: &Expr, parent_prec: u8) -> String {
@@ -6771,8 +7006,18 @@ impl<'a> Codegen<'a> {
                     // as_clock removed — use `as Clock<Domain>` cast syntax // identity — 1-bit logic used as clock
                     "reverse" => {
                         if let Some(chunk) = args.first() {
-                            let c = self.emit_expr_str(chunk);
-                            format!("{{<<{c}{{{b}}}}}")
+                            // arch#808: Icarus rejects `{<<N{x}}` in every
+                            // context; prefer the portable chunked-concat
+                            // lowering whenever the receiver width resolves
+                            // (typecheck guarantees const chunk + width, so
+                            // the streaming fallback should be unreachable
+                            // for checked input — kept for safety).
+                            if let Some(s) = self.try_emit_reverse_chunked(base, chunk) {
+                                s
+                            } else {
+                                let c = self.emit_expr_str(chunk);
+                                format!("{{<<{c}{{{b}}}}}")
+                            }
                         } else {
                             b
                         }

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -6371,13 +6371,9 @@ impl<'a> Codegen<'a> {
     /// conservatively.
     fn current_construct_params(&self) -> Option<&[ParamDecl]> {
         self.source.items.iter().find_map(|item| match item {
-            Item::Module(m) if m.name.name == self.current_construct => {
-                Some(m.params.as_slice())
-            }
+            Item::Module(m) if m.name.name == self.current_construct => Some(m.params.as_slice()),
             Item::Fsm(f) if f.name.name == self.current_construct => Some(f.params.as_slice()),
-            Item::Pipeline(p) if p.name.name == self.current_construct => {
-                Some(p.params.as_slice())
-            }
+            Item::Pipeline(p) if p.name.name == self.current_construct => Some(p.params.as_slice()),
             _ => None,
         })
     }
@@ -6405,31 +6401,27 @@ impl<'a> Codegen<'a> {
         match scope.get(name)? {
             (Symbol::Port(p), _) => Some(p.ty.clone()),
             (Symbol::Reg(r), _) => Some(r.ty.clone()),
-            (Symbol::Let(_), _) => {
-                self.source.items.iter().find_map(|item| match item {
-                    Item::Module(m) if m.name.name == self.current_construct => {
-                        m.body.iter().find_map(|bi| match bi {
-                            ModuleBodyItem::LetBinding(l) if l.name.name == name => l.ty.clone(),
-                            ModuleBodyItem::WireDecl(wd) if wd.name.name == name => {
-                                Some(wd.ty.clone())
-                            }
-                            _ => None,
-                        })
-                    }
-                    Item::Fsm(f) if f.name.name == self.current_construct => f
-                        .lets
-                        .iter()
-                        .find(|l| l.name.name == name)
-                        .and_then(|l| l.ty.clone())
-                        .or_else(|| {
-                            f.wires
-                                .iter()
-                                .find(|w| w.name.name == name)
-                                .map(|w| w.ty.clone())
-                        }),
-                    _ => None,
-                })
-            }
+            (Symbol::Let(_), _) => self.source.items.iter().find_map(|item| match item {
+                Item::Module(m) if m.name.name == self.current_construct => {
+                    m.body.iter().find_map(|bi| match bi {
+                        ModuleBodyItem::LetBinding(l) if l.name.name == name => l.ty.clone(),
+                        ModuleBodyItem::WireDecl(wd) if wd.name.name == name => Some(wd.ty.clone()),
+                        _ => None,
+                    })
+                }
+                Item::Fsm(f) if f.name.name == self.current_construct => f
+                    .lets
+                    .iter()
+                    .find(|l| l.name.name == name)
+                    .and_then(|l| l.ty.clone())
+                    .or_else(|| {
+                        f.wires
+                            .iter()
+                            .find(|w| w.name.name == name)
+                            .map(|w| w.ty.clone())
+                    }),
+                _ => None,
+            }),
             _ => None,
         }
     }

--- a/src/codegen/pipeline.rs
+++ b/src/codegen/pipeline.rs
@@ -7,6 +7,72 @@
 use super::*;
 
 impl<'a> Codegen<'a> {
+    /// arch#808 (pipeline emitters): declared type of a `.reverse()`
+    /// receiver signal inside the current pipeline — the hinted stage's
+    /// regs/lets first (stage-scoped emitter), then ports. Pipelines
+    /// have no `module_scopes` entry (resolve.rs builds those for
+    /// modules and fsms only), so this resolves through the pipeline's
+    /// own AST instead.
+    fn pipeline_ident_type(p: &PipelineDecl, name: &str, stage: Option<usize>) -> Option<TypeExpr> {
+        if let Some(si) = stage {
+            if let Some(ty) = Self::pipeline_stage_signal_type(p.stages.get(si)?, name) {
+                return Some(ty);
+            }
+        }
+        p.ports
+            .iter()
+            .find(|pt| pt.name.name == name)
+            .map(|pt| pt.ty.clone())
+    }
+
+    /// Declared type of a reg / typed let inside one pipeline stage.
+    fn pipeline_stage_signal_type(stage: &StageDecl, name: &str) -> Option<TypeExpr> {
+        stage.body.iter().find_map(|item| match item {
+            ModuleBodyItem::RegDecl(r) if r.name.name == name => Some(r.ty.clone()),
+            ModuleBodyItem::LetBinding(l) if l.name.name == name => l.ty.clone(),
+            _ => None,
+        })
+    }
+
+    /// arch#808 portable `.reverse()` lowering for the two pipeline
+    /// expression emitters — see `emit_reverse_chunks` (mod.rs) for the
+    /// equivalence argument. `emitted_base` is the receiver as already
+    /// emitted by the calling emitter (stage-name rewriting applied);
+    /// only plain signal references (Ident / stage FieldAccess) are
+    /// attempted, so it is always a part-selectable identifier. `None`
+    /// keeps the streaming-concat form (pre-arch#808 behavior,
+    /// Verilator-only).
+    fn try_emit_pipeline_reverse_chunked(
+        &self,
+        base: &Expr,
+        chunk: &Expr,
+        emitted_base: &str,
+        stage: Option<usize>,
+    ) -> Option<String> {
+        let p = self.source.items.iter().find_map(|item| match item {
+            Item::Pipeline(p) if p.name.name == self.current_construct => Some(p),
+            _ => None,
+        })?;
+        let params: &[ParamDecl] = &p.params;
+        let c = self.eval_const_u32(chunk, params)?;
+        let ty = match &base.kind {
+            ExprKind::Ident(n) => Self::pipeline_ident_type(p, n, stage)?,
+            ExprKind::FieldAccess(sb, field) => {
+                let ExprKind::Ident(stage_name) = &sb.kind else {
+                    return None;
+                };
+                let st = p.stages.iter().find(|s| s.name.name == *stage_name)?;
+                Self::pipeline_stage_signal_type(st, &field.name)?
+            }
+            _ => return None,
+        };
+        let w = self.type_expr_width_const(&ty, params)?;
+        if c == 0 || w == 0 || w % c != 0 {
+            return None;
+        }
+        Some(Self::emit_reverse_chunks(emitted_base, w, c))
+    }
+
     fn emit_pipeline_inst(
         &mut self,
         inst: &InstDecl,
@@ -1683,8 +1749,21 @@ impl<'a> Codegen<'a> {
                     }
                     "reverse" => {
                         if let Some(chunk) = args.first() {
-                            let c = self.emit_expr_str(chunk);
-                            format!("{{<<{c}{{{b}}}}}")
+                            // arch#808: prefer the Icarus-portable
+                            // chunked-concat lowering; receivers whose
+                            // width can't be resolved from the pipeline
+                            // AST keep the streaming form.
+                            if let Some(s) = self.try_emit_pipeline_reverse_chunked(
+                                base,
+                                chunk,
+                                &b,
+                                Some(current_stage_idx),
+                            ) {
+                                s
+                            } else {
+                                let c = self.emit_expr_str(chunk);
+                                format!("{{<<{c}{{{b}}}}}")
+                            }
                         } else {
                             b
                         }
@@ -2028,8 +2107,20 @@ impl<'a> Codegen<'a> {
                     }
                     "reverse" => {
                         if let Some(chunk) = args.first() {
-                            let c = self.emit_expr_str(chunk);
-                            format!("{{<<{c}{{{b}}}}}")
+                            // arch#808: prefer the Icarus-portable
+                            // chunked-concat lowering; receivers whose
+                            // width can't be resolved from the pipeline
+                            // AST keep the streaming form. This emitter
+                            // has no current stage — ports (and explicit
+                            // `Stage.field` references) only.
+                            if let Some(s) =
+                                self.try_emit_pipeline_reverse_chunked(base, chunk, &b, None)
+                            {
+                                s
+                            } else {
+                                let c = self.emit_expr_str(chunk);
+                                format!("{{<<{c}{{{b}}}}}")
+                            }
                         } else {
                             b
                         }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -385,7 +385,10 @@ end module RevBit
         sv.contains("assign y = {a[0], a[1], a[2], a[3], a[4], a[5], a[6], a[7]};"),
         "expected per-bit reversed concat, got:\n{sv}"
     );
-    assert!(!sv.contains("{<<"), "streaming operator must not appear:\n{sv}");
+    assert!(
+        !sv.contains("{<<"),
+        "streaming operator must not appear:\n{sv}"
+    );
 }
 
 #[test]
@@ -402,7 +405,10 @@ end module RevChunk
         sv.contains("assign y = {a[0 +: 4], a[4 +: 4]};"),
         "expected reversed 4-bit chunk part-selects, got:\n{sv}"
     );
-    assert!(!sv.contains("{<<"), "streaming operator must not appear:\n{sv}");
+    assert!(
+        !sv.contains("{<<"),
+        "streaming operator must not appear:\n{sv}"
+    );
 }
 
 #[test]
@@ -422,7 +428,10 @@ end module RevFull
         sv.contains("assign y = {a};"),
         "expected singleton-concat identity, got:\n{sv}"
     );
-    assert!(!sv.contains("{<<"), "streaming operator must not appear:\n{sv}");
+    assert!(
+        !sv.contains("{<<"),
+        "streaming operator must not appear:\n{sv}"
+    );
 }
 
 #[test]
@@ -443,7 +452,10 @@ end module RevParam
         sv.contains("assign y = {p[0 +: 2], p[2 +: 2], p[4 +: 2], p[6 +: 2]};"),
         "expected param-width receiver chunked, got:\n{sv}"
     );
-    assert!(!sv.contains("{<<"), "streaming operator must not appear:\n{sv}");
+    assert!(
+        !sv.contains("{<<"),
+        "streaming operator must not appear:\n{sv}"
+    );
 }
 
 #[test]
@@ -473,7 +485,10 @@ end module RevXor
         ),
         "expected chunk part-selects on the hoist temp, got:\n{sv}"
     );
-    assert!(!sv.contains("{<<"), "streaming operator must not appear:\n{sv}");
+    assert!(
+        !sv.contains("{<<"),
+        "streaming operator must not appear:\n{sv}"
+    );
 }
 
 #[test]
@@ -521,7 +536,10 @@ end pipeline RevPipe
         ),
         "expected cross-stage reg receiver bit-reversed, got:\n{sv}"
     );
-    assert!(!sv.contains("{<<"), "streaming operator must not appear:\n{sv}");
+    assert!(
+        !sv.contains("{<<"),
+        "streaming operator must not appear:\n{sv}"
+    );
 }
 
 #[test]

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -359,6 +359,171 @@ end module RepeatPartSelect
     );
 }
 
+// ── arch#808: `.reverse<C>()` portable chunked-concat lowering ──────────────
+//
+// Icarus Verilog (12.0) rejects the SV streaming-concat operator
+// (`{<<C{x}}`) in every context — `assign y = {<<1{a}};` alone is a syntax
+// error — while Verilator accepts it. Typecheck guarantees the chunk size
+// and receiver width are compile-time constants with width % chunk == 0, so
+// codegen lowers `.reverse<C>()` to an ordinary concatenation of the
+// receiver's C-bit chunks in reversed order (the receiver's lowest chunk
+// lands most-significant — verified bit-identical to `{<<C{x}}` against
+// Verilator across all 256 8-bit inputs for chunks 1/2/4/8). These tests
+// pin every emission shape; none of them may contain a streaming operator.
+
+#[test]
+fn test_reverse_bit_emits_chunked_concat() {
+    let source = r#"
+module RevBit
+  port a: in UInt<8>;
+  port y: out UInt<8>;
+  let y = a.reverse<1>();
+end module RevBit
+"#;
+    let sv = compile_to_sv(source);
+    assert!(
+        sv.contains("assign y = {a[0], a[1], a[2], a[3], a[4], a[5], a[6], a[7]};"),
+        "expected per-bit reversed concat, got:\n{sv}"
+    );
+    assert!(!sv.contains("{<<"), "streaming operator must not appear:\n{sv}");
+}
+
+#[test]
+fn test_reverse_chunked_emits_part_selects() {
+    let source = r#"
+module RevChunk
+  port a: in UInt<8>;
+  port y: out UInt<8>;
+  let y = a.reverse<4>();
+end module RevChunk
+"#;
+    let sv = compile_to_sv(source);
+    assert!(
+        sv.contains("assign y = {a[0 +: 4], a[4 +: 4]};"),
+        "expected reversed 4-bit chunk part-selects, got:\n{sv}"
+    );
+    assert!(!sv.contains("{<<"), "streaming operator must not appear:\n{sv}");
+}
+
+#[test]
+fn test_reverse_full_width_emits_singleton_concat() {
+    // Chunk == full width is the identity; emitted as a singleton concat
+    // `{a}` (not bare `a`) so the result stays an unsigned self-determined
+    // vector, exactly like the streaming form it replaces.
+    let source = r#"
+module RevFull
+  port a: in UInt<8>;
+  port y: out UInt<8>;
+  let y = a.reverse<8>();
+end module RevFull
+"#;
+    let sv = compile_to_sv(source);
+    assert!(
+        sv.contains("assign y = {a};"),
+        "expected singleton-concat identity, got:\n{sv}"
+    );
+    assert!(!sv.contains("{<<"), "streaming operator must not appear:\n{sv}");
+}
+
+#[test]
+fn test_reverse_param_width_receiver_resolves() {
+    // The receiver's declared width is a const param — codegen must
+    // const-resolve it (same rules typecheck used to admit the call) and
+    // still emit the portable form, not fall back to the streaming operator.
+    let source = r#"
+module RevParam
+  param W: const = 8;
+  port p: in UInt<W>;
+  port y: out UInt<8>;
+  let y = p.reverse<2>();
+end module RevParam
+"#;
+    let sv = compile_to_sv(source);
+    assert!(
+        sv.contains("assign y = {p[0 +: 2], p[2 +: 2], p[4 +: 2], p[6 +: 2]};"),
+        "expected param-width receiver chunked, got:\n{sv}"
+    );
+    assert!(!sv.contains("{<<"), "streaming operator must not appear:\n{sv}");
+}
+
+#[test]
+fn test_reverse_computed_receiver_hoists_to_named_temp() {
+    // A computation receiver can't take a part-select — it is hoisted to a
+    // named module-scope temp (same mechanism as the arch#650/#807 hoists),
+    // then chunk-selected. Width of `a ^ b` mirrors typecheck's
+    // max-width rule.
+    let source = r#"
+module RevXor
+  port a: in UInt<8>;
+  port b: in UInt<8>;
+  port y: out UInt<8>;
+  let y = (a ^ b).reverse<2>();
+end module RevXor
+"#;
+    let sv = compile_to_sv(source);
+    assert!(
+        sv.contains("logic [8-1:0] arch_idx_base_0;")
+            && sv.contains("assign arch_idx_base_0 = a ^ b;"),
+        "expected an 8-bit hoist temp for the xor receiver, got:\n{sv}"
+    );
+    assert!(
+        sv.contains(
+            "assign y = {arch_idx_base_0[0 +: 2], arch_idx_base_0[2 +: 2], \
+             arch_idx_base_0[4 +: 2], arch_idx_base_0[6 +: 2]};"
+        ),
+        "expected chunk part-selects on the hoist temp, got:\n{sv}"
+    );
+    assert!(!sv.contains("{<<"), "streaming operator must not appear:\n{sv}");
+}
+
+#[test]
+fn test_reverse_in_pipeline_stage_emits_chunked_concat() {
+    // The two pipeline expression emitters have their own `.reverse()`
+    // arms (pipelines get no `module_scopes` entry, so widths resolve
+    // through the pipeline AST: ports + stage regs/lets). Covers both a
+    // port receiver and a cross-stage `Stage.field` receiver.
+    let source = r#"
+domain SysDomain
+end domain SysDomain
+
+pipeline RevPipe
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port din: in UInt<8>;
+  port dout: out UInt<8>;
+
+  stage S1
+    reg r1: UInt<8> init 0 reset rst => 0;
+    seq on clk rising
+      r1 <= din.reverse<2>();
+    end seq
+  end stage S1
+
+  stage S2
+    reg r2: UInt<8> init 0 reset rst => 0;
+    seq on clk rising
+      r2 <= S1.r1.reverse<1>();
+    end seq
+    comb
+      dout = r2;
+    end comb
+  end stage S2
+end pipeline RevPipe
+"#;
+    let sv = compile_to_sv(source);
+    assert!(
+        sv.contains("{din[0 +: 2], din[2 +: 2], din[4 +: 2], din[6 +: 2]}"),
+        "expected port receiver chunked in stage seq, got:\n{sv}"
+    );
+    assert!(
+        sv.contains(
+            "{s1_r1[0], s1_r1[1], s1_r1[2], s1_r1[3], s1_r1[4], s1_r1[5], s1_r1[6], s1_r1[7]}"
+        ),
+        "expected cross-stage reg receiver bit-reversed, got:\n{sv}"
+    );
+    assert!(!sv.contains("{<<"), "streaming operator must not appear:\n{sv}");
+}
+
 #[test]
 fn test_part_select_additive_base_rejected() {
     // arch#653 item 1: `ExprKind::PartSelect` (`[start +: w]` / `[start -: w]`)


### PR DESCRIPTION
## Summary

Closes #808. Also delivers **P2 of #813** ("Portable `.reverse()` lowering") as a standalone, codegen-internal fix — no language-surface change, no target-dialect flag; the portable form works on both simulators so it is emitted unconditionally.

Icarus Verilog 12.0 rejects the SV streaming-concatenation operator (`{<<N{x}}`) in **every** context — `assign y = {<<1{a}};` alone is a syntax error — while Verilator accepts it. Every design using `.reverse<C>()` therefore emitted Verilator-only SV.

Typecheck already guarantees the chunk size and receiver width are compile-time constants with `width % chunk == 0`, so all three emission sites (main expression emitter, plus the two pipeline expression emitters) now lower `.reverse<C>()` to an ordinary concatenation of the receiver's C-bit chunks in reversed order:

| Source | Emitted SV |
|---|---|
| `a.reverse<1>()` (UInt<8>) | `{a[0], a[1], a[2], a[3], a[4], a[5], a[6], a[7]}` |
| `a.reverse<4>()` (UInt<8>) | `{a[0 +: 4], a[4 +: 4]}` |
| `a.reverse<8>()` (UInt<8>) | `{a}` — identity; singleton concat keeps the unsigned self-determined result kind |
| `(a ^ b).reverse<2>()` | hoisted: `logic [8-1:0] arch_idx_base_0; assign arch_idx_base_0 = a ^ b;` then chunk-selects on the temp |

Design notes:

- **Non-part-selectable receivers** (computations, literals, casts) hoist to a named module-scope temp — the same `index_hoist_lines` mechanism the arch#650/#807 fixes use, including the runtime-`for`-loop-variable guard.
- **Receiver widths are const-resolved** against the construct's params, mirroring typecheck's IEEE 1800 §11.6 result-width rules exactly (the width sizes both the hoist temp and the part-selects, so a divergence would be a miscompile — the rules are copied from `resolve_expr_type`, with a comment pinning them together). Any receiver whose width can't be proven falls back to the previous streaming-concat emission — no regression; that corner was Verilator-only before and stays so.
- **Pipelines** have no `module_scopes` entry (resolve.rs builds those for modules/fsms only), so the pipeline emitters resolve widths through the pipeline AST: ports + stage regs/typed lets, covering both port receivers and cross-stage `Stage.field` receivers.

## Verification

- **Fast gate**: `cargo build --release` clean; full `cargo test --release` green except two pre-existing `construct_proof_lean_*` failures in `tests/formal_test.rs` that reproduce identically on unmodified `origin/main` in a fresh worktree (local Lean toolchain state, unrelated).
- **Bit-equivalence**: Verilator 5.048 simulation compares the newly emitted SV against reference `{<<C{x}}` expressions for **all 256 8-bit inputs** at chunks 1/2/4/8, including the hoisted-receiver shape — all match.
- **Native-sim consistency**: the same 256-input sweep through `arch sim` (whose C++ chunk-reverse lowering is untouched) matches an independent reference reversal on all five shapes.
- **Icarus**: `iverilog -g2012` accepts every emitted shape (module let/comb, param-width receiver, hoisted receiver, pipeline stage seq for both port and cross-stage receivers). Before this fix it rejected all of them.
- **New tests**: 6 integration tests pin every emission shape and assert `{<<` never appears.

`doc/COMPILER_STATUS.md` row for `.reverse(N)` updated (it documented the streaming-concat emission) + skill snapshot re-synced.

## Out of scope (pre-existing, noted while here)

- The two pipeline emitters still use the `N'($signed(...))` form for `.resize()` that mod.rs's emitter replaced (self-determined-context product truncation) — separate issue, being tracked independently.
- The existing arch#650/#807 hoist mechanism can drop `logic`/`assign` lines *inside* an `always_comb` body when the consuming statement sits in a real always block (e.g. under `if`) — Icarus then warns "procedural assign cannot be synthesized" and evaluates the RHS once. Pre-existing behavior shared by this PR's hoist path; belongs with the #813 discussion of universalizing the hoist.