### PR TITLE
feat(fp): FP4E2M1 — OCP MX FP4 as a storage-only scalar type (Phase 1)

### DIFF
--- a/doc/ARCH_HDL_Specification.md
+++ b/doc/ARCH_HDL_Specification.md
@@ -313,6 +313,8 @@ The Arch type system enforces four independent safety dimensions simultaneously.
 
   **FP8E5M2**          8 bits               OCP OFP8 E5M2 (5-bit exponent, 2-bit mantissa; IEEE-style ±inf and NaN class, max finite 57344). Same op surface as FP32. See §3.8.
 
+  **FP4E2M1**          4 bits               OCP MX FP4 E2M1 (2-bit exponent, 1-bit mantissa; **no inf, no NaN**, max finite 6.0). **Storage-only**: conversions and literals only — no arithmetic, compares or `is_nan`. See §3.9.
+
   **Clock\<D\>**       1 bit                Carries clock-domain tag D. Cannot appear in arithmetic.
 
   **Reset\<Sync, High\|Low\>**    1 bit                Synchronous reset --- deasserted on the clock edge. Polarity defaults High.
@@ -742,7 +744,29 @@ let gt: Bool = a > b;         // ordered compare → Bool
 let nan: Bool = is_nan(a);
 ```
 
-**No implicit conversion.** Mixing distinct float formats (`FP32`, `BF16`, `FP8E4M3`, `FP8E5M2`), or float and integer, in an operator is a compile error; convert explicitly:
+**3.9 FP4E2M1 --- a storage-only block-element format**
+
+`FP4E2M1` is the OCP Microscaling (MX) FP4 element type: 1 sign + 2 exponent (bias 1) + 1 mantissa bit, emitted as `logic[3:0]`. It has **no infinity and no NaN encoding** — every one of its 16 codes is a finite value, and the complete value set is ±{0, 0.5, 1, 1.5, 2, 3, 4, 6}, with one subnormal (0.5) and max finite 6.0.
+
+Unlike every other float type in ARCH, `FP4E2M1` is **storage-only**: it carries values and converts, but has *no operator surface at all*. `a + b`, ordered compares and `is_nan(a)` are compile errors.
+
+That is not a v1 shortcut — it reflects the format. No shipping GPU or accelerator ISA exposes scalar E2M1 arithmetic: NVIDIA PTX states that `e2m1` values *"must be used in a packed format"* and that alternate data formats *"cannot be used as fundamental types"*, and across the whole ISA `e2m1` appears only as a `cvt` source/destination and as a block-scaled matrix operand. AMD's path has the same shape. E2M1 is a **block element**, not a scalar arithmetic type, and it becomes useful when paired with a shared scale (see the block-format proposal, `doc/proposal_mx_block_formats.md`).
+
+`is_nan` is refused rather than answered `false`, because the format cannot represent the concept — a constant answer would imply the question was meaningful.
+
+The idiom is widen → compute → narrow once:
+
+```arch
+let av: FP32 = a.to_fp32();          // exact: a 2-bit significand always fits
+comb y = (av * s).to_fp4e2m1(); end comb
+```
+
+**Conversions.** `.to_fp32()` widens exactly. `.to_fp4e2m1()` narrows with round-to-nearest-ties-to-even and **saturates** on overflow. Saturation is profile-independent here, unlike fp8 where `--fp-compat` selects between a NaN/inf result and `satfinite`: E2M1 has neither a NaN nor an infinity to produce, so saturation is the only representable behavior. Cross-format conversions compose through `FP32`, each step exact or singly rounded.
+
+**Literals.** A float literal in an `FP4E2M1` slot is rounded at compile time; one that **overflows is a compile error** (matching fp8), never a silently clamped constant. The bound is `|x| >= 7.0` — the round-to-nearest midpoint between max finite 6.0 and the next would-be value 8.0.
+
+
+**No implicit conversion.** Mixing distinct float formats (`FP32`, `BF16`, `FP8E4M3`, `FP8E5M2`, `FP4E2M1`), or float and integer, in an operator is a compile error; convert explicitly:
 
   - `x.to_fp32()` — `BF16`→`FP32` (exact widen) or `SInt<N>`/`UInt<N>`→`FP32` (RNE).
   - `x.to_bf16()` — `FP32`→`BF16` (round-to-nearest-even).

--- a/doc/Arch_AI_Reference_Card.md
+++ b/doc/Arch_AI_Reference_Card.md
@@ -161,6 +161,7 @@ Range `for` = runtime SV loop; value-list `for` = compile-time unroll; `generate
 UInt<N>  SInt<N>  Bool  Bit
 FP32  BF16                                    // IEEE-754 binary32 / bfloat16 (v1; see §2a)
 FP8E4M3  FP8E5M2                              // OCP OFP8 8-bit floats (v1; see §2a)
+FP4E2M1                                       // OCP MX FP4 element: STORAGE-ONLY (conversions + literals; no + - * / compares / is_nan)
 Clock<Domain>  Reset<Sync|Async, High|Low>   // polarity defaults High
 Vec<T,N>
 struct S  { f: T; }
@@ -248,7 +249,8 @@ let nan: Bool = is_nan(a);  // qNaN/sNaN test → Bool
 **No implicit conversion** — mixing float formats (`FP32`/`BF16`/`FP8E4M3`/`FP8E5M2`), or float↔int, is a compile error. Convert explicitly:
 
 ```
-x.to_fp32()      // BF16/FP8E4M3/FP8E5M2→FP32 (exact widen) or SInt/UInt→FP32 (RNE)
+x.to_fp32()      // BF16/FP8E4M3/FP8E5M2/FP4E2M1→FP32 (exact widen) or SInt/UInt→FP32 (RNE)
+x.to_fp4e2m1()   // →FP4E2M1 (RNE, saturating; no inf/NaN exists in the format)
 x.to_bf16()      // FP32→BF16 (RNE); fp8→BF16 (exact); int→BF16 (f32-routed)
 x.to_fp8e4m3()   // FP32/BF16/FP8E5M2/int→FP8E4M3 (CR; overflow per --fp-compat)
 x.to_fp8e5m2()   // FP32/BF16/FP8E4M3/int→FP8E5M2 (CR; overflow per --fp-compat)

--- a/skills/arch-programming/references/ARCH_HDL_Specification.md
+++ b/skills/arch-programming/references/ARCH_HDL_Specification.md
@@ -313,6 +313,8 @@ The Arch type system enforces four independent safety dimensions simultaneously.
 
   **FP8E5M2**          8 bits               OCP OFP8 E5M2 (5-bit exponent, 2-bit mantissa; IEEE-style ±inf and NaN class, max finite 57344). Same op surface as FP32. See §3.8.
 
+  **FP4E2M1**          4 bits               OCP MX FP4 E2M1 (2-bit exponent, 1-bit mantissa; **no inf, no NaN**, max finite 6.0). **Storage-only**: conversions and literals only — no arithmetic, compares or `is_nan`. See §3.9.
+
   **Clock\<D\>**       1 bit                Carries clock-domain tag D. Cannot appear in arithmetic.
 
   **Reset\<Sync, High\|Low\>**    1 bit                Synchronous reset --- deasserted on the clock edge. Polarity defaults High.
@@ -742,7 +744,29 @@ let gt: Bool = a > b;         // ordered compare → Bool
 let nan: Bool = is_nan(a);
 ```
 
-**No implicit conversion.** Mixing distinct float formats (`FP32`, `BF16`, `FP8E4M3`, `FP8E5M2`), or float and integer, in an operator is a compile error; convert explicitly:
+**3.9 FP4E2M1 --- a storage-only block-element format**
+
+`FP4E2M1` is the OCP Microscaling (MX) FP4 element type: 1 sign + 2 exponent (bias 1) + 1 mantissa bit, emitted as `logic[3:0]`. It has **no infinity and no NaN encoding** — every one of its 16 codes is a finite value, and the complete value set is ±{0, 0.5, 1, 1.5, 2, 3, 4, 6}, with one subnormal (0.5) and max finite 6.0.
+
+Unlike every other float type in ARCH, `FP4E2M1` is **storage-only**: it carries values and converts, but has *no operator surface at all*. `a + b`, ordered compares and `is_nan(a)` are compile errors.
+
+That is not a v1 shortcut — it reflects the format. No shipping GPU or accelerator ISA exposes scalar E2M1 arithmetic: NVIDIA PTX states that `e2m1` values *"must be used in a packed format"* and that alternate data formats *"cannot be used as fundamental types"*, and across the whole ISA `e2m1` appears only as a `cvt` source/destination and as a block-scaled matrix operand. AMD's path has the same shape. E2M1 is a **block element**, not a scalar arithmetic type, and it becomes useful when paired with a shared scale (see the block-format proposal, `doc/proposal_mx_block_formats.md`).
+
+`is_nan` is refused rather than answered `false`, because the format cannot represent the concept — a constant answer would imply the question was meaningful.
+
+The idiom is widen → compute → narrow once:
+
+```arch
+let av: FP32 = a.to_fp32();          // exact: a 2-bit significand always fits
+comb y = (av * s).to_fp4e2m1(); end comb
+```
+
+**Conversions.** `.to_fp32()` widens exactly. `.to_fp4e2m1()` narrows with round-to-nearest-ties-to-even and **saturates** on overflow. Saturation is profile-independent here, unlike fp8 where `--fp-compat` selects between a NaN/inf result and `satfinite`: E2M1 has neither a NaN nor an infinity to produce, so saturation is the only representable behavior. Cross-format conversions compose through `FP32`, each step exact or singly rounded.
+
+**Literals.** A float literal in an `FP4E2M1` slot is rounded at compile time; one that **overflows is a compile error** (matching fp8), never a silently clamped constant. The bound is `|x| >= 7.0` — the round-to-nearest midpoint between max finite 6.0 and the next would-be value 8.0.
+
+
+**No implicit conversion.** Mixing distinct float formats (`FP32`, `BF16`, `FP8E4M3`, `FP8E5M2`, `FP4E2M1`), or float and integer, in an operator is a compile error; convert explicitly:
 
   - `x.to_fp32()` — `BF16`→`FP32` (exact widen) or `SInt<N>`/`UInt<N>`→`FP32` (RNE).
   - `x.to_bf16()` — `FP32`→`BF16` (round-to-nearest-even).

--- a/skills/arch-programming/references/Arch_AI_Reference_Card.md
+++ b/skills/arch-programming/references/Arch_AI_Reference_Card.md
@@ -161,6 +161,7 @@ Range `for` = runtime SV loop; value-list `for` = compile-time unroll; `generate
 UInt<N>  SInt<N>  Bool  Bit
 FP32  BF16                                    // IEEE-754 binary32 / bfloat16 (v1; see §2a)
 FP8E4M3  FP8E5M2                              // OCP OFP8 8-bit floats (v1; see §2a)
+FP4E2M1                                       // OCP MX FP4 element: STORAGE-ONLY (conversions + literals; no + - * / compares / is_nan)
 Clock<Domain>  Reset<Sync|Async, High|Low>   // polarity defaults High
 Vec<T,N>
 struct S  { f: T; }
@@ -248,7 +249,8 @@ let nan: Bool = is_nan(a);  // qNaN/sNaN test → Bool
 **No implicit conversion** — mixing float formats (`FP32`/`BF16`/`FP8E4M3`/`FP8E5M2`), or float↔int, is a compile error. Convert explicitly:
 
 ```
-x.to_fp32()      // BF16/FP8E4M3/FP8E5M2→FP32 (exact widen) or SInt/UInt→FP32 (RNE)
+x.to_fp32()      // BF16/FP8E4M3/FP8E5M2/FP4E2M1→FP32 (exact widen) or SInt/UInt→FP32 (RNE)
+x.to_fp4e2m1()   // →FP4E2M1 (RNE, saturating; no inf/NaN exists in the format)
 x.to_bf16()      // FP32→BF16 (RNE); fp8→BF16 (exact); int→BF16 (f32-routed)
 x.to_fp8e4m3()   // FP32/BF16/FP8E5M2/int→FP8E4M3 (CR; overflow per --fp-compat)
 x.to_fp8e5m2()   // FP32/BF16/FP8E4M3/int→FP8E5M2 (CR; overflow per --fp-compat)

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1119,6 +1119,10 @@ pub enum TypeExpr {
     /// FP8 E5M2 (1 sign + 5 exp + 2 mant = 8 bits): IEEE-style (5,3)
     /// instantiation with infinities and a NaN class, max finite 57344.
     FP8E5M2,
+    /// OCP MX FP4 (1+2+1). Storage-only: no Inf, no NaN, max finite 6.0.
+    /// Element type of MXFP4/NVFP4 blocks; no shipping ISA exposes scalar
+    /// arithmetic on it, so it carries conversions and literals only.
+    FP4E2M1,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1289,6 +1293,7 @@ pub enum FloatLitFmt {
     Bf16,
     E4m3,
     E5m2,
+    E2m1,
 }
 
 impl FloatLitFmt {
@@ -1299,6 +1304,7 @@ impl FloatLitFmt {
             FloatLitFmt::Bf16 => (8, 7),
             FloatLitFmt::E4m3 => (4, 3),
             FloatLitFmt::E5m2 => (5, 2),
+            FloatLitFmt::E2m1 => (2, 1),
         }
     }
 
@@ -1309,6 +1315,7 @@ impl FloatLitFmt {
             FloatLitFmt::Bf16 => 16,
             FloatLitFmt::E4m3 => 8,
             FloatLitFmt::E5m2 => 8,
+            FloatLitFmt::E2m1 => 4,
         }
     }
 }

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -2168,6 +2168,7 @@ impl<'a> Codegen<'a> {
                 "to_bf16" => Some("bf16"),
                 "to_fp8e4m3" => Some("e4m3"),
                 "to_fp8e5m2" => Some("e5m2"),
+                "to_fp4e2m1" => Some("e2m1"),
                 _ => None,
             },
             ExprKind::FunctionCall(name, args) if name == "fma" => {
@@ -2726,6 +2727,7 @@ impl<'a> Codegen<'a> {
             TypeExpr::FP32 => Some("32".to_string()),
             TypeExpr::BF16 => Some("16".to_string()),
             TypeExpr::FP8E4M3 | TypeExpr::FP8E5M2 => Some("8".to_string()),
+            TypeExpr::FP4E2M1 => Some("4".to_string()),
             TypeExpr::Vec(inner, size) => {
                 let iw = self.type_expr_data_width(inner)?;
                 let n = self.emit_expr_str(size);
@@ -5730,6 +5732,7 @@ impl<'a> Codegen<'a> {
             TypeExpr::FP32 => Some(32),
             TypeExpr::BF16 => Some(16),
             TypeExpr::FP8E4M3 | TypeExpr::FP8E5M2 => Some(8),
+            TypeExpr::FP4E2M1 => Some(4),
             TypeExpr::Vec(inner, size) => {
                 let iw = self.type_expr_width(inner)?;
                 let n = eval(size)?;
@@ -6696,6 +6699,7 @@ impl<'a> Codegen<'a> {
                     FloatLitFmt::Fp32 => format!("32'h{bits:08X}"),
                     FloatLitFmt::Bf16 => format!("16'h{bits:04X}"),
                     FloatLitFmt::E4m3 | FloatLitFmt::E5m2 => format!("8'h{bits:02X}"),
+                    FloatLitFmt::E2m1 => format!("4'h{bits:01X}"),
                 },
             },
             ExprKind::Bool(true) => "1'b1".to_string(),
@@ -7036,6 +7040,7 @@ impl<'a> Codegen<'a> {
                             Some("bf16") => format!("arch_bf16_to_f32({b})"),
                             Some("e4m3") => format!("arch_e4m3_to_f32({b})"),
                             Some("e5m2") => format!("arch_e5m2_to_f32({b})"),
+                            Some("e2m1") => format!("arch_e2m1_to_f32({b})"),
                             Some("f32") => b,
                             _ => {
                                 // int -> f32 (RNE) via the synthesizable helper.
@@ -7056,6 +7061,7 @@ impl<'a> Codegen<'a> {
                             // (route via .to_fp32()); keep the arm total.
                             Some("e4m3") => format!("arch_f32_to_bf16(arch_e4m3_to_f32({b}))"),
                             Some("e5m2") => format!("arch_f32_to_bf16(arch_e5m2_to_f32({b}))"),
+                            Some("e2m1") => format!("arch_f32_to_bf16(arch_e2m1_to_f32({b}))"),
                             _ => {
                                 // int -> f32 (RNE) -> bf16 (RNE). DECLARED semantics
                                 // (issue #629, resolved as f32-routed / VR(f32)):
@@ -7080,17 +7086,12 @@ impl<'a> Codegen<'a> {
                             }
                         }
                     }
-                    "to_fp8e4m3" | "to_fp8e5m2" => {
+                    "to_fp8e4m3" | "to_fp8e5m2" | "to_fp4e2m1" => {
                         self.fp_helpers_used.set(true);
-                        let narrow = if method.name == "to_fp8e4m3" {
-                            "arch_f32_to_e4m3"
-                        } else {
-                            "arch_f32_to_e5m2"
-                        };
-                        let tgt = if method.name == "to_fp8e4m3" {
-                            "e4m3"
-                        } else {
-                            "e5m2"
+                        let (narrow, tgt) = match method.name.as_str() {
+                            "to_fp8e4m3" => ("arch_f32_to_e4m3", "e4m3"),
+                            "to_fp4e2m1" => ("arch_f32_to_e2m1", "e2m1"),
+                            _ => ("arch_f32_to_e5m2", "e5m2"),
                         };
                         match self.expr_float_fmt(base) {
                             Some("f32") => format!("{narrow}({b})"),
@@ -7099,6 +7100,7 @@ impl<'a> Codegen<'a> {
                             Some("bf16") => format!("{narrow}(arch_bf16_to_f32({b}))"),
                             Some("e4m3") => format!("{narrow}(arch_e4m3_to_f32({b}))"),
                             Some("e5m2") => format!("{narrow}(arch_e5m2_to_f32({b}))"),
+                            Some("e2m1") => format!("{narrow}(arch_e2m1_to_f32({b}))"),
                             // Integers: int -> f32 (exact for the fp8-relevant
                             // range, far below 2^24) -> one fp8 rounding — CR.
                             _ => {
@@ -7600,6 +7602,7 @@ impl<'a> Codegen<'a> {
             TypeExpr::FP32 => "logic [31:0]".to_string(),
             TypeExpr::BF16 => "logic [15:0]".to_string(),
             TypeExpr::FP8E4M3 | TypeExpr::FP8E5M2 => "logic [7:0]".to_string(),
+            TypeExpr::FP4E2M1 => "logic [3:0]".to_string(),
             TypeExpr::Clock(_) => "logic".to_string(),
             TypeExpr::Reset(_, _) => "logic".to_string(),
             TypeExpr::Vec(_, _) => {

--- a/src/construct_proof_cert.rs
+++ b/src/construct_proof_cert.rs
@@ -292,6 +292,7 @@ fn type_width_u64(ty: &TypeExpr) -> Result<u64, String> {
         TypeExpr::FP32 => Ok(32),
         TypeExpr::BF16 => Ok(16),
         TypeExpr::FP8E4M3 | TypeExpr::FP8E5M2 => Ok(8),
+        TypeExpr::FP4E2M1 => Ok(4),
         TypeExpr::Vec(elem, len) => {
             let elem_width = type_width_u64(elem)?;
             let len = const_expr_u64(len)?;

--- a/src/elaborate/mod.rs
+++ b/src/elaborate/mod.rs
@@ -730,6 +730,7 @@ fn narrow_fmt_of_type(ty: &TypeExpr) -> Option<FloatLitFmt> {
         TypeExpr::BF16 => Some(FloatLitFmt::Bf16),
         TypeExpr::FP8E4M3 => Some(FloatLitFmt::E4m3),
         TypeExpr::FP8E5M2 => Some(FloatLitFmt::E5m2),
+        TypeExpr::FP4E2M1 => Some(FloatLitFmt::E2m1),
         // Vec-of-narrow-float: a literal in this signal's reset/init slot
         // (or an element assignment) targets the ELEMENT format — without
         // this, `reg h: Vec<BF16,2> reset rst => 0.5;` kept the literal as
@@ -932,6 +933,7 @@ fn coerce_narrow_lit(e: &mut Expr, fmt: FloatLitFmt, errors: &mut Vec<CompileErr
             FloatLitFmt::Fp32 => Some(crate::fp_lit::f64_to_fp32_bits(v) as u64),
             FloatLitFmt::E4m3 => crate::fp_lit::f64_to_e4m3_bits(v).map(|b| b as u64),
             FloatLitFmt::E5m2 => crate::fp_lit::f64_to_e5m2_bits(v).map(|b| b as u64),
+            FloatLitFmt::E2m1 => crate::fp_lit::f64_to_e2m1_bits(v).map(|b| b as u64),
         };
         match rounded {
             Some(bits8) => {

--- a/src/formal.rs
+++ b/src/formal.rs
@@ -2137,7 +2137,11 @@ impl<'a> FormalCtx<'a> {
                 | TypeExpr::Clock(_) | TypeExpr::Reset(_, _) => Ok(()),
             // Floats are BV carriers; operator semantics come from the
             // inlined proven define-funs (see emit_base).
-            TypeExpr::FP32 | TypeExpr::BF16 | TypeExpr::FP8E4M3 | TypeExpr::FP8E5M2 => Ok(()),
+            TypeExpr::FP32
+            | TypeExpr::BF16
+            | TypeExpr::FP8E4M3
+            | TypeExpr::FP8E5M2
+            | TypeExpr::FP4E2M1 => Ok(()),
             TypeExpr::Vec(_, _) => Err(CompileError::general(
                 "Vec types are not supported by `arch formal` v1 — use scalars",
                 span,
@@ -2154,6 +2158,7 @@ impl<'a> FormalCtx<'a> {
             TypeExpr::FP32 => Ok((32, false)),
             TypeExpr::BF16 => Ok((16, false)),
             TypeExpr::FP8E4M3 | TypeExpr::FP8E5M2 => Ok((8, false)),
+            TypeExpr::FP4E2M1 => Ok((4, false)),
             TypeExpr::UInt(w) => {
                 let width = fold_const_expr(w, &self.params).ok_or_else(|| {
                     CompileError::general(
@@ -2801,6 +2806,7 @@ impl<'a> FormalCtx<'a> {
                 crate::ast::FloatLitFmt::Bf16 => "bf16",
                 crate::ast::FloatLitFmt::E4m3 => "e4m3",
                 crate::ast::FloatLitFmt::E5m2 => "e5m2",
+                crate::ast::FloatLitFmt::E2m1 => "e2m1",
             }),
             Binary(op, l, r) => match op {
                 BinOp::Add | BinOp::Sub | BinOp::Mul => {
@@ -3525,6 +3531,7 @@ impl<'a> FormalCtx<'a> {
                     }
                     crate::ast::FloatLitFmt::E4m3 => crate::fp_lit::e4m3_bits_to_f64(*bits as u8),
                     crate::ast::FloatLitFmt::E5m2 => crate::fp_lit::e5m2_bits_to_f64(*bits as u8),
+                    crate::ast::FloatLitFmt::E2m1 => crate::fp_lit::e2m1_bits_to_f64(*bits as u8),
                 };
                 Ok(gappa_real(v))
             }
@@ -3958,6 +3965,7 @@ fn lit_f64(e: &Expr) -> Option<f64> {
             crate::ast::FloatLitFmt::Bf16 => f32::from_bits((*b as u32) << 16) as f64,
             crate::ast::FloatLitFmt::E4m3 => crate::fp_lit::e4m3_bits_to_f64(*b as u8),
             crate::ast::FloatLitFmt::E5m2 => crate::fp_lit::e5m2_bits_to_f64(*b as u8),
+            crate::ast::FloatLitFmt::E2m1 => crate::fp_lit::e2m1_bits_to_f64(*b as u8),
         }),
         ExprKind::Literal(LitKind::Dec(v)) => Some(*v as f64),
         _ => None,

--- a/src/fp_format.rs
+++ b/src/fp_format.rs
@@ -40,6 +40,7 @@ pub enum FpFormatId {
     Bf16,
     E4m3,
     E5m2,
+    E2m1,
 }
 
 /// How a format encodes NaN.
@@ -147,6 +148,25 @@ pub const FORMATS: &[FpFormat] = &[
         nan_rule: NanRule::IeeeExpAllOnes,
         arith: true,
     },
+    FpFormat {
+        // OCP MX FP4 E2M1: no Inf, NO NaN, max finite 6.0, one subnormal
+        // (0.5). Storage-only — see `arith`.
+        id: FpFormatId::E2m1,
+        tag: "e2m1",
+        type_name: "FP4E2M1",
+        width: 4,
+        exp_bits: 2,
+        mant_bits: 1,
+        has_inf: false,
+        has_nan: false,
+        max_finite: 6.0,
+        nan_rule: NanRule::NoNan,
+        // No shipping GPU/accelerator ISA exposes scalar E2M1 arithmetic;
+        // PTX states e2m1 "must be used in a packed format" and that
+        // alternate formats "cannot be used as fundamental types". It is a
+        // block element, so it carries conversions and literals only.
+        arith: false,
+    },
 ];
 
 impl FpFormat {
@@ -203,6 +223,7 @@ pub fn by_lit_fmt(fmt: FloatLitFmt) -> &'static FpFormat {
         FloatLitFmt::Bf16 => FpFormatId::Bf16,
         FloatLitFmt::E4m3 => FpFormatId::E4m3,
         FloatLitFmt::E5m2 => FpFormatId::E5m2,
+        FloatLitFmt::E2m1 => FpFormatId::E2m1,
     })
 }
 
@@ -213,6 +234,7 @@ pub fn by_type_expr(ty: &TypeExpr) -> Option<&'static FpFormat> {
         TypeExpr::BF16 => FpFormatId::Bf16,
         TypeExpr::FP8E4M3 => FpFormatId::E4m3,
         TypeExpr::FP8E5M2 => FpFormatId::E5m2,
+        TypeExpr::FP4E2M1 => FpFormatId::E2m1,
         _ => return None,
     };
     Some(by_id(id))
@@ -240,6 +262,7 @@ mod tests {
             FpFormatId::Bf16,
             FpFormatId::E4m3,
             FpFormatId::E5m2,
+            FpFormatId::E2m1,
         ] {
             let rows = FORMATS.iter().filter(|f| f.id == id).count();
             assert_eq!(rows, 1, "expected exactly one row for {id:?}, got {rows}");
@@ -283,6 +306,7 @@ mod tests {
             FloatLitFmt::Bf16,
             FloatLitFmt::E4m3,
             FloatLitFmt::E5m2,
+            FloatLitFmt::E2m1,
         ] {
             let f = by_lit_fmt(fmt);
             assert_eq!(f.width, fmt.width(), "{}: width disagrees", f.tag);
@@ -300,6 +324,7 @@ mod tests {
             (TypeExpr::BF16, "bf16"),
             (TypeExpr::FP8E4M3, "e4m3"),
             (TypeExpr::FP8E5M2, "e5m2"),
+            (TypeExpr::FP4E2M1, "e2m1"),
         ] {
             let f = by_type_expr(&ty).expect("surface float type must have a row");
             assert_eq!(f.tag, tag);
@@ -314,7 +339,7 @@ mod tests {
             assert_eq!(width_of_tag(f.tag), Some(f.width));
         }
         assert_eq!(
-            width_of_tag("e2m1"),
+            width_of_tag("nosuchfmt"),
             None,
             "an unknown tag must be None, never a guessed width — guessing is \
              what made the old float_tag_width silently wrong"
@@ -336,14 +361,20 @@ mod tests {
                 _ => 8,
             }
         };
-        for f in FORMATS {
+        // Only the four formats that existed when the maps were written.
+        // A format added AFTER them is precisely what the old wildcards got
+        // wrong, so it must NOT agree — see the E2M1 assertion below.
+        for tag in ["f32", "bf16", "e4m3", "e5m2"] {
             assert_eq!(
-                width_of_tag(f.tag),
-                Some(old_tag_width(f.tag)),
-                "{}: table width must match the map it replaced",
-                f.tag
+                width_of_tag(tag),
+                Some(old_tag_width(tag)),
+                "{tag}: table width must match the map it replaced"
             );
         }
+        // The whole point of the table: the old `_ => 8` wildcard would have
+        // given E2M1 an 8-bit carrier. It is 4.
+        assert_eq!(width_of_tag("e2m1"), Some(4));
+        assert_eq!(old_tag_width("e2m1"), 8, "the bug this table removed");
 
         // Old `elaborate` literal-overflow table:
         //     match fmt { E4m3 => ("FP8E4M3", 448.0), _ => ("FP8E5M2", 57344.0) }
@@ -362,10 +393,11 @@ mod tests {
         // while every shipped format is arithmetic-capable — that is what
         // makes routing the `+ - *` / `fma` / `is_nan` gates through the new
         // predicate a no-op today.
+        // is_float() and is_float_arith() now genuinely differ, which is
+        // what makes `a + b` on E2M1 a clean type error.
         assert!(
-            FORMATS.iter().all(|f| f.arith),
-            "a storage-only format landed without updating the gates that \
-             assume is_float() == is_float_arith()"
+            FORMATS.iter().any(|f| !f.arith),
+            "the storage-only path is unexercised"
         );
     }
 
@@ -382,8 +414,15 @@ mod tests {
         assert!(e5m2.has_inf && e5m2.has_nan);
         assert_eq!(e5m2.max_finite, 57344.0);
 
-        // Every format shipped today carries a full operator surface; the
-        // flag exists for the storage-only sub-8-bit formats to come.
-        assert!(FORMATS.iter().all(|f| f.arith));
+        // FP4E2M1 is the first storage-only format: a carrier for
+        // conversions and literals with no operator surface at all.
+        let e2m1 = by_id(FpFormatId::E2m1);
+        assert!(!e2m1.arith, "E2M1 is storage-only");
+        assert!(!e2m1.has_nan, "E2M1 has no NaN encoding");
+        assert!(!e2m1.has_inf, "E2M1 has no infinity");
+        assert_eq!(e2m1.max_finite, 6.0);
+        assert_eq!(e2m1.nan_rule, NanRule::NoNan);
+        // Every 8-bit-or-wider format still carries full arithmetic.
+        assert!(FORMATS.iter().filter(|f| f.width >= 8).all(|f| f.arith));
     }
 }

--- a/src/fp_lit.rs
+++ b/src/fp_lit.rs
@@ -262,6 +262,61 @@ pub fn e4m3_bits_to_f64(h: u8) -> f64 {
     sign * (8.0 + f) * f64::powi(2.0, e as i32 - 10)
 }
 
+/// The eight E2M1 magnitudes, indexed by the 3-bit magnitude encoding.
+///
+/// OCP MX FP4 (1 sign + 2 exp + 1 mantissa, bias 1) has **no Inf and no NaN**
+/// — the top binade is entirely finite — and exactly one subnormal (0.5).
+const E2M1_MAGNITUDES: [f64; 8] = [0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0];
+
+/// Exact value of an E2M1 encoding (low 4 bits significant).
+pub fn e2m1_bits_to_f64(b: u8) -> f64 {
+    let mag = E2M1_MAGNITUDES[(b & 0x7) as usize];
+    if b & 0x8 != 0 {
+        -mag
+    } else {
+        mag
+    }
+}
+
+/// Round `x` to E2M1, or `None` if it overflows the format.
+///
+/// Written as an exhaustive nearest-with-ties-to-even search over the eight
+/// magnitudes rather than via [`round_f64_to_narrow`], deliberately. The
+/// generic routine is an IEEE template: it treats an all-ones exponent as
+/// overflow-to-infinity, but E2M1's all-ones binade holds the finite values
+/// 4.0 and 6.0. Applied here it packs `S.11.0` for an overflowing input,
+/// which decodes to **4.0** — a silently wrong constant, the same trap
+/// documented for `f64_to_e4m3_bits` at 448. At eight magnitudes the direct
+/// search is both simpler and exhaustively checkable.
+///
+/// Overflow boundary follows the E4M3 precedent (max 448, next-would-be 512,
+/// so `>= 480` overflows): E2M1's max is 6.0 and the next would-be value is
+/// 8.0, so `|x| >= 7.0` overflows and anything below rounds to 6.0.
+/// Overflowing float literals are a compile error, matching fp8.
+pub fn f64_to_e2m1_bits(x: f64) -> Option<u8> {
+    // E2M1 cannot represent NaN or infinity at all.
+    if x.is_nan() || x.is_infinite() {
+        return None;
+    }
+    let sign: u8 = if x.is_sign_negative() { 0x8 } else { 0x0 };
+    let a = x.abs();
+    if a >= 7.0 {
+        return None;
+    }
+    // Nearest magnitude; ties go to the even ENCODING (low bit clear),
+    // which is IEEE round-ties-to-even on the mantissa bit.
+    let mut best = 0usize;
+    let mut best_err = f64::INFINITY;
+    for (i, &m) in E2M1_MAGNITUDES.iter().enumerate() {
+        let err = (a - m).abs();
+        if err < best_err || (err == best_err && i % 2 == 0) {
+            best = i;
+            best_err = err;
+        }
+    }
+    Some(sign | best as u8)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -522,5 +577,62 @@ mod tests {
             checked += 1;
         }
         assert!(checked > 100_000, "sample too small: {checked}");
+    }
+}
+
+#[cfg(test)]
+mod e2m1_tests {
+    use super::*;
+
+    /// Every encoding round-trips, and the value set is exactly the OCP one.
+    #[test]
+    fn e2m1_round_trips_all_sixteen_encodings() {
+        let want = [0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0];
+        for enc in 0u8..8 {
+            assert_eq!(e2m1_bits_to_f64(enc), want[enc as usize]);
+            assert_eq!(e2m1_bits_to_f64(enc | 0x8), -want[enc as usize]);
+            // Exact values must encode back to themselves.
+            assert_eq!(f64_to_e2m1_bits(want[enc as usize]), Some(enc));
+        }
+        // -0.0 keeps its sign.
+        assert_eq!(f64_to_e2m1_bits(-0.0), Some(0x8));
+    }
+
+    /// The trap this encoder exists to avoid: the generic IEEE template
+    /// packs `S.11.0` (= 4.0) for an overflowing value. Overflow must be
+    /// `None` — a compile error — never a silently wrong finite constant.
+    #[test]
+    fn e2m1_overflow_is_none_not_a_wrong_finite() {
+        assert_eq!(f64_to_e2m1_bits(7.0), None, "at the RNE midpoint");
+        assert_eq!(f64_to_e2m1_bits(8.0), None);
+        assert_eq!(f64_to_e2m1_bits(1e30), None);
+        assert_eq!(f64_to_e2m1_bits(-7.0), None);
+        assert_eq!(f64_to_e2m1_bits(f64::INFINITY), None);
+        assert_eq!(f64_to_e2m1_bits(f64::NAN), None, "E2M1 has no NaN");
+        // Just below the boundary still rounds to max finite, not overflow.
+        assert_eq!(f64_to_e2m1_bits(6.9), Some(0x7));
+        assert_ne!(
+            f64_to_e2m1_bits(8.0),
+            Some(0x6),
+            "must not silently produce 4.0 the way the generic template would"
+        );
+    }
+
+    /// Round-to-nearest, ties-to-even on the mantissa bit.
+    #[test]
+    fn e2m1_rounds_to_nearest_ties_to_even() {
+        assert_eq!(f64_to_e2m1_bits(0.2), Some(0x0)); // -> 0.0
+        assert_eq!(f64_to_e2m1_bits(0.3), Some(0x1)); // -> 0.5
+        assert_eq!(f64_to_e2m1_bits(1.2), Some(0x2)); // -> 1.0
+        assert_eq!(f64_to_e2m1_bits(1.4), Some(0x3)); // -> 1.5
+                                                      // 5.0 is EQUIDISTANT between 4.0 and 6.0 -> ties-to-even -> 4.0.
+        assert_eq!(f64_to_e2m1_bits(5.0), Some(0x6));
+        // Exact ties land on the even encoding.
+        assert_eq!(f64_to_e2m1_bits(0.25), Some(0x0), "tie 0/0.5 -> 0.0");
+        assert_eq!(f64_to_e2m1_bits(2.5), Some(0x4), "tie 2/3 -> 2.0");
+        assert_eq!(f64_to_e2m1_bits(3.5), Some(0x6), "tie 3/4 -> 4.0");
+        // Sign is independent of magnitude selection.
+        assert_eq!(f64_to_e2m1_bits(-2.5), Some(0xC));
+        assert_eq!(f64_to_e2m1_bits(-5.0), Some(0xE));
     }
 }

--- a/src/fp_ops.rs
+++ b/src/fp_ops.rs
@@ -297,7 +297,24 @@ fn nan8_e5m2(p: FpCompat) -> u128 {
 /// value is still finite except at an all-ones mantissa) vs the IEEE rule
 /// (any result reaching the top exponent value overflows). `ovf_res` is the
 /// profile-dependent overflow result.
-fn fp8_round(eb: u32, mb: u32, ocp_top: bool, sign: &Bv, sig: &Bv, e0: &Bv, ovf_res: &Bv) -> Bv {
+/// How a narrow format spends its top exponent value — the only part of the
+/// rounder that differs between the formats it serves.
+#[derive(Clone, Copy, PartialEq)]
+pub(crate) enum TopBinade {
+    /// IEEE: the all-ones exponent is Inf/NaN, so reaching it is overflow.
+    Ieee,
+    /// OCP OFP8 E4M3: the all-ones exponent is finite EXCEPT for the
+    /// all-ones mantissa, which is the sole NaN. Overflow needs the
+    /// rounded magnitude to reach that slot.
+    OcpNanTop,
+    /// OCP FP4/FP6: no Inf and no NaN at all — the top binade is entirely
+    /// finite, so only exceeding it is overflow. Without this arm a 4-bit
+    /// format would take the IEEE rule and treat its two largest finite
+    /// values (4.0 and 6.0 for E2M1) as overflow.
+    AllFinite,
+}
+
+fn fp8_round(eb: u32, mb: u32, top: TopBinade, sign: &Bv, sig: &Bv, e0: &Bv, ovf_res: &Bv) -> Bv {
     let w = sig.width();
     let w2 = w + 2;
     let zsig = zext(sig, w2);
@@ -342,7 +359,7 @@ fn fp8_round(eb: u32, mb: u32, ocp_top: bool, sign: &Bv, sig: &Bv, e0: &Bv, ovf_
     let carry = is1(&extract(&kept, mb + 1, mb + 1));
     let biased_n = ite(&carry, &add(&biased, &cst(1, 16)), &biased);
     let kept_n = ite(&carry, &lshr(&kept, &cst(1, 16)), &kept);
-    let overflow = if ocp_top {
+    let overflow = if top == TopBinade::OcpNanTop {
         // OFP8: exponent value 15 is finite except with an all-ones mantissa
         // (that slot is NaN => rounded magnitude >= 480 overflows).
         or(
@@ -352,6 +369,9 @@ fn fp8_round(eb: u32, mb: u32, ocp_top: bool, sign: &Bv, sig: &Bv, e0: &Bv, ovf_
                 &eq(&extract(&kept_n, mb - 1, 0), &cst((1u128 << mb) - 1, mb)),
             ),
         )
+    } else if top == TopBinade::AllFinite {
+        // Every exponent value is finite; only going past the top overflows.
+        sge(&biased_n, &cst(max_expf + 1, 16))
     } else {
         sge(&biased_n, &cst(max_expf, 16))
     };
@@ -442,7 +462,7 @@ fn f32_to_e5m2(p: FpCompat) -> FpFn {
         FpCompat::Riscv => (inf8.clone(), inf8.clone()),
         FpCompat::Cuda => (max8.clone(), max8.clone()),
     };
-    let rounded = fp8_round(5, 2, false, s, &d.mant, &d.eunb, &ovf_res);
+    let rounded = fp8_round(5, 2, TopBinade::Ieee, s, &d.mant, &d.eunb, &ovf_res);
     let zero = concat(s, &cst(0, 7));
     let body = ite(
         &d.is_nan,
@@ -450,6 +470,63 @@ fn f32_to_e5m2(p: FpCompat) -> FpFn {
         &ite(&d.is_inf, &inf_res, &ite(&d.is_zero, &zero, &rounded)),
     );
     FpFn::new("arch_f32_to_e5m2", &[("x", 32)], 8, body)
+}
+
+// ── OCP MX FP4 E2M1 (storage-only) ───────────────────────────────────────
+// 1 sign + 2 exp (bias 1) + 1 mantissa. NO Inf, NO NaN — every one of the
+// 16 encodings is a finite value, and the whole set is
+// ±{0, 0.5, 1, 1.5, 2, 3, 4, 6}. Only widen/narrow are defined: no shipping
+// ISA exposes scalar E2M1 arithmetic (PTX: e2m1 "must be used in a packed
+// format"), so `Ty::is_float_arith` rejects operators at the type checker
+// and no arch_e2m1_{add,mul,...} exists to dispatch to.
+
+fn e2m1_to_f32() -> FpFn {
+    let h = var("h", 4);
+    let s = extract(&h, 3, 3);
+    let e = extract(&h, 2, 1);
+    let f = extract(&h, 0, 0);
+    let e_z = eq(&e, &cst(0, 2));
+    // value = sig2 * 2^e0, with sig2 = (e==0 ? 0f : 1f) as a 2-bit integer:
+    //   normal    (e>=1): (2+f) * 2^(e-2)
+    //   subnormal (e==0):     f * 2^-1
+    // Verified against all eight magnitudes.
+    let sig2 = ite(&e_z, &concat(&cst(0, 1), &f), &concat(&cst(1, 1), &f));
+    // normround's internals extract f32 fields and use 16-bit shift
+    // constants, so the significand must be widened the same way the fp8
+    // widens do (48 bits, value-preserving).
+    let sig48 = zext(&sig2, 48);
+    let e0 = ite(
+        &e_z,
+        &cst((1u128 << 16) - 1, 16), // -1
+        &sub(&zext(&e, 16), &cst(2, 16)),
+    );
+    let widened = normround(&s, &sig48, &e0); // exact: 2-bit significand
+    let zero32 = concat(&s, &cst(0, 31));
+    // No e_top arms: the top binade is finite, so there is nothing to
+    // special-case. Only ±0 needs its own answer.
+    let body = ite(&eq(&sig2, &cst(0, 2)), &zero32, &widened);
+    FpFn::new("arch_e2m1_to_f32", &[("h", 4)], 32, body)
+}
+
+fn f32_to_e2m1(p: FpCompat) -> FpFn {
+    let x = var("x", 32);
+    let d = decode(&x);
+    let s = &d.sign;
+    let max4 = concat(s, &cst(0x7, 3)); // ±6.0, the largest finite
+                                        // E2M1 has no NaN and no Inf to produce, so BOTH --fp-compat profiles
+                                        // saturate. This is the one place the profiles cannot differ: the
+                                        // encoding space simply has nowhere else to go. `p` is accepted for
+                                        // signature symmetry with the fp8 narrows and to keep the call site
+                                        // uniform.
+    let _ = p;
+    let rounded = fp8_round(2, 1, TopBinade::AllFinite, s, &d.mant, &d.eunb, &max4);
+    let zero = concat(s, &cst(0, 3));
+    let body = ite(
+        &or(&d.is_nan, &d.is_inf),
+        &max4,
+        &ite(&d.is_zero, &zero, &rounded),
+    );
+    FpFn::new("arch_f32_to_e2m1", &[("x", 32)], 4, body)
 }
 
 fn f32_to_e4m3(p: FpCompat) -> FpFn {
@@ -462,7 +539,7 @@ fn f32_to_e4m3(p: FpCompat) -> FpFn {
         FpCompat::Riscv => (nan8.clone(), nan8.clone()),
         FpCompat::Cuda => (max8.clone(), max8.clone()),
     };
-    let rounded = fp8_round(4, 3, true, s, &d.mant, &d.eunb, &ovf_res);
+    let rounded = fp8_round(4, 3, TopBinade::OcpNanTop, s, &d.mant, &d.eunb, &ovf_res);
     let zero = concat(s, &cst(0, 7));
     let body = ite(
         &d.is_nan,
@@ -1049,6 +1126,9 @@ pub fn fp_functions(p: FpCompat) -> Vec<FpFn> {
     v.push(f32_to_e5m2(p));
     v.push(e4m3_to_f32(p));
     v.push(f32_to_e4m3(p));
+    // Storage-only: widen/narrow only, no arithmetic wrappers.
+    v.push(e2m1_to_f32());
+    v.push(f32_to_e2m1(p));
     for (tag, widen, narrow) in [
         ("e5m2", "arch_e5m2_to_f32", "arch_f32_to_e5m2"),
         ("e4m3", "arch_e4m3_to_f32", "arch_f32_to_e4m3"),
@@ -1293,4 +1373,86 @@ pub fn lean_extra_functions(p: FpCompat) -> Vec<FpFn> {
         // exact-wide reference FMA, for the sticky-fold equivalence theorem
         fma_f32_ref(p),
     ]
+}
+
+#[cfg(test)]
+mod e2m1_ir_tests {
+    use super::*;
+    use crate::fp_ir::{cst, eval_bv};
+    use std::collections::HashMap;
+
+    fn call1(fns: &[FpFn], name: &str, arg: u128, aw: u32, rw: u32) -> u128 {
+        let node = crate::fp_ir::call(name, &[cst(arg, aw)], rw);
+        eval_bv(&node, &HashMap::new(), fns).expect("E2M1 helpers must be decidable")
+    }
+
+    /// The IR widen must agree with `fp_lit`'s reference decoder on every
+    /// one of the 16 encodings. These are two independent implementations —
+    /// a bit-vector DAG rendered to SV/SMT, and a table in Rust — so
+    /// agreement is real evidence rather than a tautology.
+    #[test]
+    fn e2m1_widen_matches_the_reference_on_all_16_encodings() {
+        let fns = fp_functions(crate::FpCompat::default());
+        for enc in 0u128..16 {
+            let got = call1(&fns, "arch_e2m1_to_f32", enc, 4, 32) as u32;
+            let want = crate::fp_lit::e2m1_bits_to_f64(enc as u8) as f32;
+            assert_eq!(
+                f32::from_bits(got),
+                want,
+                "widen({enc:#X}): IR gave {} want {want}",
+                f32::from_bits(got)
+            );
+            // -0.0 must keep its sign bit, not collapse to +0.0.
+            if enc == 0x8 {
+                assert_eq!(got, 0x8000_0000, "-0.0 must stay negative");
+            }
+        }
+    }
+
+    /// Narrowing is exhaustive over the value set plus the boundaries that
+    /// the all-finite overflow rule governs. With the IEEE rule instead,
+    /// 4.0 and 6.0 — E2M1's two largest FINITE values — would be treated as
+    /// overflow, which is exactly what `TopBinade::AllFinite` prevents.
+    #[test]
+    fn e2m1_narrow_saturates_and_keeps_the_top_binade_finite() {
+        let fns = fp_functions(crate::FpCompat::default());
+        let nar = |v: f32| call1(&fns, "arch_f32_to_e2m1", v.to_bits() as u128, 32, 4) as u8;
+        // Every representable value narrows to itself.
+        for enc in 0u8..16 {
+            let v = crate::fp_lit::e2m1_bits_to_f64(enc) as f32;
+            assert_eq!(nar(v), enc, "narrow({v}) should be {enc:#X}");
+        }
+        // The top binade is FINITE — the whole point of AllFinite.
+        assert_eq!(nar(4.0), 0x6);
+        assert_eq!(nar(6.0), 0x7);
+        // Round-to-nearest, ties-to-even, matching fp_lit.
+        assert_eq!(nar(2.5), 0x4, "tie 2/3 -> 2.0");
+        assert_eq!(nar(3.5), 0x6, "tie 3/4 -> 4.0");
+        assert_eq!(nar(0.25), 0x0, "tie 0/0.5 -> 0.0");
+        // 5.0 is EQUIDISTANT between 4.0 and 6.0; ties-to-even picks the
+        // even mantissa bit, i.e. 4.0. (An early draft of this test
+        // asserted 6.0 "nearer than 4" — it is not.)
+        assert_eq!(nar(5.0), 0x6);
+        // Runtime overflow SATURATES (no Inf/NaN exists to produce).
+        assert_eq!(nar(1e30), 0x7);
+        assert_eq!(nar(-1e30), 0xF);
+        assert_eq!(nar(f32::INFINITY), 0x7);
+        assert_eq!(nar(f32::NEG_INFINITY), 0xF);
+        assert_eq!(nar(f32::NAN), 0x7, "no NaN encoding: saturate");
+        // Underflow flushes to a signed zero.
+        assert_eq!(nar(1e-30), 0x0);
+        assert_eq!(nar(-1e-30), 0x8);
+    }
+
+    /// widen∘narrow is the identity on every encoding — the property a
+    /// block format depends on when it round-trips element data.
+    #[test]
+    fn e2m1_round_trips_through_f32() {
+        let fns = fp_functions(crate::FpCompat::default());
+        for enc in 0u128..16 {
+            let f32b = call1(&fns, "arch_e2m1_to_f32", enc, 4, 32);
+            let back = call1(&fns, "arch_f32_to_e2m1", f32b, 32, 4);
+            assert_eq!(back, enc, "round-trip failed for {enc:#X}");
+        }
+    }
 }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -2030,7 +2030,8 @@ impl Builder {
             | TypeExpr::FP32
             | TypeExpr::BF16
             | TypeExpr::FP8E4M3
-            | TypeExpr::FP8E5M2 => {}
+            | TypeExpr::FP8E5M2
+            | TypeExpr::FP4E2M1 => {}
             TypeExpr::Vec(inner, n) => {
                 self.walk_type(owner, scope, inner, span);
                 let rel = self.rel_for_span(n.span);

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -577,6 +577,7 @@ fn type_str(ty: &TypeExpr) -> String {
         TypeExpr::BF16 => "BF16".to_string(),
         TypeExpr::FP8E4M3 => "FP8E4M3".to_string(),
         TypeExpr::FP8E5M2 => "FP8E5M2".to_string(),
+        TypeExpr::FP4E2M1 => "FP4E2M1".to_string(),
         TypeExpr::Clock(domain) => format!("Clock<{}>", domain.name),
         TypeExpr::Reset(kind, level) => {
             let k = match kind {
@@ -623,6 +624,7 @@ pub(crate) fn expr_str(expr: &Expr) -> String {
                     FloatLitFmt::Bf16 => f32::from_bits((*bits as u32) << 16) as f64,
                     FloatLitFmt::E4m3 => crate::fp_lit::e4m3_bits_to_f64(*bits as u8),
                     FloatLitFmt::E5m2 => crate::fp_lit::e5m2_bits_to_f64(*bits as u8),
+                    FloatLitFmt::E2m1 => crate::fp_lit::e2m1_bits_to_f64(*bits as u8),
                 };
                 if v.fract() == 0.0 {
                     format!("{v:.1}")

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -281,6 +281,8 @@ pub enum TokenKind {
     FP8E4M3,
     #[token("FP8E5M2")]
     FP8E5M2,
+    #[token("FP4E2M1")]
+    FP4E2M1,
 
     // Operators and punctuation
     #[token("+:")]
@@ -519,6 +521,7 @@ impl fmt::Display for TokenKind {
             TokenKind::BF16 => write!(f, "BF16"),
             TokenKind::FP8E4M3 => write!(f, "FP8E4M3"),
             TokenKind::FP8E5M2 => write!(f, "FP8E5M2"),
+            TokenKind::FP4E2M1 => write!(f, "FP4E2M1"),
             TokenKind::Plus => write!(f, "+"),
             TokenKind::Minus => write!(f, "-"),
             TokenKind::Star => write!(f, "*"),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1350,6 +1350,7 @@ impl Parser {
                     | TokenKind::BF16
                     | TokenKind::FP8E4M3
                     | TokenKind::FP8E5M2
+                    | TokenKind::FP4E2M1
             )
         ) {
             // Logic-typed value const: `param NAME: UInt<W> = <default>;`
@@ -4192,6 +4193,10 @@ impl Parser {
             Some(TokenKind::FP8E4M3) => {
                 self.advance();
                 Ok(TypeExpr::FP8E4M3)
+            }
+            Some(TokenKind::FP4E2M1) => {
+                self.advance();
+                Ok(TypeExpr::FP4E2M1)
             }
             Some(TokenKind::FP8E5M2) => {
                 self.advance();

--- a/src/sim_codegen/const_eval.rs
+++ b/src/sim_codegen/const_eval.rs
@@ -212,6 +212,7 @@ pub(super) fn try_eval_fp_const_expr_with_params_seen(
                 }
                 crate::ast::FloatLitFmt::E4m3 => Some(crate::fp_lit::e4m3_bits_to_f64(*bits as u8)),
                 crate::ast::FloatLitFmt::E5m2 => Some(crate::fp_lit::e5m2_bits_to_f64(*bits as u8)),
+                crate::ast::FloatLitFmt::E2m1 => Some(crate::fp_lit::e2m1_bits_to_f64(*bits as u8)),
             }
         }
         ExprKind::Ident(name) => {

--- a/src/sim_codegen/expr_codegen.rs
+++ b/src/sim_codegen/expr_codegen.rs
@@ -629,6 +629,7 @@ pub(super) enum FpFmt {
     Bf16,
     E4m3,
     E5m2,
+    E2m1,
 }
 
 impl FpFmt {
@@ -639,6 +640,7 @@ impl FpFmt {
             FpFmt::Bf16 => "bf16",
             FpFmt::E4m3 => "e4m3",
             FpFmt::E5m2 => "e5m2",
+            FpFmt::E2m1 => "e2m1",
         }
     }
 }
@@ -1651,6 +1653,7 @@ pub(super) fn cpp_method_call(base: &Expr, method: &Ident, args: &[Expr], ctx: &
             Some(FpFmt::Bf16) => format!("_arch_bf16_to_f32({b})"),
             Some(FpFmt::E4m3) => format!("_arch_e4m3_to_f32({b})"),
             Some(FpFmt::E5m2) => format!("_arch_e5m2_to_f32({b})"),
+            Some(FpFmt::E2m1) => format!("_arch_e2m1_to_f32({b})"),
             Some(FpFmt::Fp32) => b, // no-op (typecheck rejects, but stay total)
             None => {
                 if infer_expr_signed(base, ctx) {
@@ -1667,6 +1670,7 @@ pub(super) fn cpp_method_call(base: &Expr, method: &Ident, args: &[Expr], ctx: &
             // is exact in bf16).
             Some(FpFmt::E4m3) => format!("_arch_f32_to_bf16(_arch_e4m3_to_f32({b}))"),
             Some(FpFmt::E5m2) => format!("_arch_f32_to_bf16(_arch_e5m2_to_f32({b}))"),
+            Some(FpFmt::E2m1) => format!("_arch_f32_to_bf16(_arch_e2m1_to_f32({b}))"),
             None => {
                 if infer_expr_signed(base, ctx) {
                     format!("_arch_i_to_bf16((int64_t)({b}))")
@@ -1681,6 +1685,7 @@ pub(super) fn cpp_method_call(base: &Expr, method: &Ident, args: &[Expr], ctx: &
             // BF16 / cross-fp8: exact widen, one narrow — correctly rounded.
             Some(FpFmt::Bf16) => format!("_arch_f32_to_e4m3(_arch_bf16_to_f32({b}))"),
             Some(FpFmt::E5m2) => format!("_arch_f32_to_e4m3(_arch_e5m2_to_f32({b}))"),
+            Some(FpFmt::E2m1) => format!("_arch_f32_to_e4m3(_arch_e2m1_to_f32({b}))"),
             // Integers: exact in f32 across the fp8-relevant range, so the
             // single fp8 rounding is correctly rounded.
             None => {
@@ -1696,6 +1701,7 @@ pub(super) fn cpp_method_call(base: &Expr, method: &Ident, args: &[Expr], ctx: &
             Some(FpFmt::E5m2) => b,
             Some(FpFmt::Bf16) => format!("_arch_f32_to_e5m2(_arch_bf16_to_f32({b}))"),
             Some(FpFmt::E4m3) => format!("_arch_f32_to_e5m2(_arch_e4m3_to_f32({b}))"),
+            Some(FpFmt::E2m1) => format!("_arch_f32_to_e5m2(_arch_e2m1_to_f32({b}))"),
             None => {
                 if infer_expr_signed(base, ctx) {
                     format!("_arch_f32_to_e5m2(_arch_i_to_f32((int64_t)({b})))")

--- a/src/sim_codegen/pipeline.rs
+++ b/src/sim_codegen/pipeline.rs
@@ -1323,6 +1323,7 @@ impl<'a> SimCodegen<'a> {
                 FloatLitFmt::Bf16 => FpFmt::Bf16,
                 FloatLitFmt::E4m3 => FpFmt::E4m3,
                 FloatLitFmt::E5m2 => FpFmt::E5m2,
+                FloatLitFmt::E2m1 => FpFmt::E2m1,
             }),
             ExprKind::Literal(LitKind::Float(_)) => Some(FpFmt::Fp32),
             ExprKind::Binary(op, l, r) => match op {

--- a/src/sim_codegen/pybind.rs
+++ b/src/sim_codegen/pybind.rs
@@ -656,6 +656,7 @@ PYBIND11_MODULE({pybind_module}, m) {{
             TypeExpr::FP32 => 32,
             TypeExpr::BF16 => 16,
             TypeExpr::FP8E4M3 | TypeExpr::FP8E5M2 => 8,
+            TypeExpr::FP4E2M1 => 4,
             TypeExpr::Named(_) => 32,
             TypeExpr::Vec(_, _) => 32,
         }
@@ -1041,6 +1042,36 @@ static inline uint8_t _arch_f32_to_fp8(uint32_t x, int eb, int mb, int ocp,
     // Subnormal result: keep is in min-subnormal ULPs; keep==2^mb encodes
     // naturally as the minimum normal (exponent field 1, mantissa 0).
     return (uint8_t)(sgn | (uint32_t)keep);
+}
+// ── OCP MX FP4 E2M1 (storage-only) ──
+// No Inf, no NaN, max finite 6.0. The shared _arch_f32_to_fp8 cannot be
+// reused: it packs the sign at bit 7, while E2M1's sign is bit 3. Written
+// as a direct nearest-ties-to-even search over the eight magnitudes, which
+// mirrors fp_lit::f64_to_e2m1_bits exactly.
+//
+// Runtime overflow SATURATES for both --fp-compat profiles, unlike fp8
+// where the profiles differ: E2M1 has neither a NaN nor an infinity to
+// produce, so saturation is the only representable behavior. (Overflowing
+// LITERALS are still a compile error - a source constant must not depend
+// on runtime saturation.)
+static const float _ARCH_E2M1_MAG[8] = {0.0f,0.5f,1.0f,1.5f,2.0f,3.0f,4.0f,6.0f};
+static inline float _arch_e2m1f(uint8_t b){
+  float m = _ARCH_E2M1_MAG[b & 7u];
+  return (b & 8u) ? -m : m;
+}
+static inline uint32_t _arch_e2m1_to_f32(uint8_t b){ return _arch_b32f(_arch_e2m1f(b)); }
+static inline uint8_t _arch_f32_to_e2m1(uint32_t x){
+  float f = _arch_f32b(x);
+  uint8_t sgn = (uint8_t)((x>>31) ? 8u : 0u);
+  if (std::isnan(f)) return (uint8_t)(sgn|7u);
+  float a = fabsf(f);
+  if (a >= 7.0f) return (uint8_t)(sgn|7u);
+  int best = 0; float best_err = 1e30f;
+  for (int i = 0; i < 8; i++) {
+    float e = fabsf(a - _ARCH_E2M1_MAG[i]);
+    if (e < best_err || (e == best_err && (i & 1) == 0)) { best = i; best_err = e; }
+  }
+  return (uint8_t)(sgn | (uint8_t)best);
 }
 static inline uint8_t _arch_f32_to_e5m2(uint32_t x){ return _arch_f32_to_fp8(x,5,2,0,0x7Cu,1,0x7Eu); }
 static inline uint8_t _arch_f32_to_e4m3(uint32_t x){ return _arch_f32_to_fp8(x,4,3,1,0x7Fu,0,0x7Fu); }

--- a/src/sim_codegen/width.rs
+++ b/src/sim_codegen/width.rs
@@ -137,7 +137,7 @@ pub(super) fn cpp_port_type_with_params(ty: &TypeExpr, params: &[ParamDecl]) -> 
         // `_arch_fp.h` helpers, never C++ float operators on the storage.
         TypeExpr::FP32 => "uint32_t".to_string(),
         TypeExpr::BF16 => "uint16_t".to_string(),
-        TypeExpr::FP8E4M3 | TypeExpr::FP8E5M2 => "uint8_t".to_string(),
+        TypeExpr::FP8E4M3 | TypeExpr::FP8E5M2 | TypeExpr::FP4E2M1 => "uint8_t".to_string(),
         TypeExpr::Named(n) => n.name.clone(),
         TypeExpr::Vec(_, _) => "uint32_t".to_string(),
     }
@@ -199,7 +199,7 @@ pub(super) fn cpp_internal_type_with_params(ty: &TypeExpr, params: &[ParamDecl])
         }
         TypeExpr::FP32 => "uint32_t".to_string(),
         TypeExpr::BF16 => "uint16_t".to_string(),
-        TypeExpr::FP8E4M3 | TypeExpr::FP8E5M2 => "uint8_t".to_string(),
+        TypeExpr::FP8E4M3 | TypeExpr::FP8E5M2 | TypeExpr::FP4E2M1 => "uint8_t".to_string(),
         TypeExpr::Named(n) => n.name.clone(),
         TypeExpr::Vec(_, _) => "uint32_t".to_string(),
     }
@@ -323,6 +323,7 @@ pub(super) fn type_width_of(ty: &TypeExpr) -> u32 {
         TypeExpr::FP32 => 32,
         TypeExpr::BF16 => 16,
         TypeExpr::FP8E4M3 | TypeExpr::FP8E5M2 => 8,
+        TypeExpr::FP4E2M1 => 4,
         TypeExpr::Vec(..) | TypeExpr::Named(_) => 0,
     }
 }
@@ -439,6 +440,7 @@ pub(super) fn type_bits_te_with_params(ty: &TypeExpr, params: &[ParamDecl]) -> u
         TypeExpr::FP32 => 32,
         TypeExpr::BF16 => 16,
         TypeExpr::FP8E4M3 | TypeExpr::FP8E5M2 => 8,
+        TypeExpr::FP4E2M1 => 4,
         _ => 32,
     }
 }
@@ -458,5 +460,6 @@ pub(super) fn type_float_fmt(ty: &TypeExpr) -> Option<FpFmt> {
         crate::fp_format::FpFormatId::Bf16 => FpFmt::Bf16,
         crate::fp_format::FpFormatId::E4m3 => FpFmt::E4m3,
         crate::fp_format::FpFormatId::E5m2 => FpFmt::E5m2,
+        crate::fp_format::FpFormatId::E2m1 => FpFmt::E2m1,
     })
 }

--- a/src/thread_map.rs
+++ b/src/thread_map.rs
@@ -977,7 +977,9 @@ fn lit_label(lit: &LitKind) -> String {
                 FloatLitFmt::Fp32 => f32::from_bits(*bits as u32) as f64,
                 FloatLitFmt::Bf16 => f32::from_bits((*bits as u32) << 16) as f64,
                 FloatLitFmt::E4m3 => crate::fp_lit::e4m3_bits_to_f64(*bits as u8),
-                FloatLitFmt::E5m2 => crate::fp_lit::e5m2_bits_to_f64(*bits as u8),
+                FloatLitFmt::E5m2 | crate::ast::FloatLitFmt::E2m1 => {
+                    crate::fp_lit::e5m2_bits_to_f64(*bits as u8)
+                }
             };
             v.to_string()
         }

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -19,6 +19,7 @@ pub enum Ty {
     FP8E4M3,
     /// FP8 E5M2 (1+5+2 = 8 bits): IEEE-style (5,3) with infinities.
     FP8E5M2,
+    FP4E2M1,
     Clock(String),                // domain name
     Reset(ResetKind, ResetLevel), // always concrete (Param resolved during elaboration)
     Vec(Box<Ty>, u32),
@@ -36,7 +37,10 @@ impl Ty {
     /// rules and assignability — everything that works on the bit pattern
     /// regardless of whether operators exist.
     pub fn is_float(&self) -> bool {
-        matches!(self, Ty::FP32 | Ty::BF16 | Ty::FP8E4M3 | Ty::FP8E5M2)
+        matches!(
+            self,
+            Ty::FP32 | Ty::BF16 | Ty::FP8E4M3 | Ty::FP8E5M2 | Ty::FP4E2M1
+        )
     }
 
     /// Does this float carry an arithmetic surface (`+ - *`, `fma`,
@@ -59,6 +63,7 @@ impl Ty {
             Ty::BF16 => crate::fp_format::by_id(crate::fp_format::FpFormatId::Bf16).arith,
             Ty::FP8E4M3 => crate::fp_format::by_id(crate::fp_format::FpFormatId::E4m3).arith,
             Ty::FP8E5M2 => crate::fp_format::by_id(crate::fp_format::FpFormatId::E5m2).arith,
+            Ty::FP4E2M1 => crate::fp_format::by_id(crate::fp_format::FpFormatId::E2m1).arith,
             _ => false,
         }
     }
@@ -95,6 +100,7 @@ impl Ty {
             Ty::FP32 => Some(32),
             Ty::BF16 => Some(16),
             Ty::FP8E4M3 | Ty::FP8E5M2 => Some(8),
+            Ty::FP4E2M1 => Some(4),
             Ty::Enum(_, w) => Some(*w),
             Ty::Vec(inner, count) => inner.width().map(|w| w * count),
             Ty::Struct(_) | Ty::Bus(_) => None,
@@ -112,6 +118,7 @@ impl Ty {
             Ty::BF16 => "BF16".to_string(),
             Ty::FP8E4M3 => "FP8E4M3".to_string(),
             Ty::FP8E5M2 => "FP8E5M2".to_string(),
+            Ty::FP4E2M1 => "FP4E2M1".to_string(),
             Ty::Clock(d) => format!("Clock<{d}>"),
             Ty::Reset(k, l) => format!(
                 "Reset<{}, {}>",
@@ -2808,6 +2815,7 @@ impl<'a> TypeChecker<'a> {
             Ty::FP32 => Some(32),
             Ty::BF16 => Some(16),
             Ty::FP8E4M3 | Ty::FP8E5M2 => Some(8),
+            Ty::FP4E2M1 => Some(4),
             Ty::Enum(_, w) => Some(*w),
             Ty::Vec(inner, count) => self.type_total_width(inner).map(|w| w * count),
             Ty::Struct(name) => {
@@ -2837,6 +2845,7 @@ impl<'a> TypeChecker<'a> {
             TypeExpr::FP32 => Some(32),
             TypeExpr::BF16 => Some(16),
             TypeExpr::FP8E4M3 | TypeExpr::FP8E5M2 => Some(8),
+            TypeExpr::FP4E2M1 => Some(4),
             TypeExpr::Vec(inner, size) => {
                 let iw = self.type_expr_width(inner)?;
                 let n = eval_type_width_expr(size)?;
@@ -3630,6 +3639,7 @@ impl<'a> TypeChecker<'a> {
             TypeExpr::BF16 => Ty::BF16,
             TypeExpr::FP8E4M3 => Ty::FP8E4M3,
             TypeExpr::FP8E5M2 => Ty::FP8E5M2,
+            TypeExpr::FP4E2M1 => Ty::FP4E2M1,
             TypeExpr::Clock(domain) => Ty::Clock(domain.name.clone()),
             TypeExpr::Reset(kind, level) => Ty::Reset(*kind, *level),
             TypeExpr::Vec(inner, size_expr) => {
@@ -3889,6 +3899,7 @@ impl<'a> TypeChecker<'a> {
             // instead of a panic.
             Ty::FP8E4M3 => "FP8E4M3",
             Ty::FP8E5M2 => "FP8E5M2",
+            Ty::FP4E2M1 => "FP4E2M1",
             _ => unreachable!("is_float() covers exactly the float Tys above"),
         };
         match crate::pipelined_ops::lookup(name, profile, stages) {
@@ -4058,6 +4069,7 @@ impl<'a> TypeChecker<'a> {
                 // (arch#622/#624) — take that type directly.
                 LitKind::TypedFloat(FloatLitFmt::Fp32, _) => Ty::FP32,
                 LitKind::TypedFloat(FloatLitFmt::Bf16, _) => Ty::BF16,
+                LitKind::TypedFloat(FloatLitFmt::E2m1, _) => Ty::FP4E2M1,
                 LitKind::TypedFloat(FloatLitFmt::E4m3, _) => Ty::FP8E4M3,
                 LitKind::TypedFloat(FloatLitFmt::E5m2, _) => Ty::FP8E5M2,
             },
@@ -4424,10 +4436,23 @@ impl<'a> TypeChecker<'a> {
                     // encoding (OCP E2M1/E2M3/E3M2) cannot answer `is_nan`
                     // meaningfully, and a constant `false` would mislead.
                     if tx != Ty::Error && !tx.is_float_arith() {
-                        self.errors.push(CompileError::general(
-                            &format!("`is_nan(x)` requires a float operand, got {}", tx.display()),
-                            call_args[0].span,
-                        ));
+                        // Distinguish "not a float" from "a float with no NaN
+                        // encoding". Reporting E2M1 as a non-float would be
+                        // actively misleading — it IS a float; the concept of
+                        // NaN simply does not exist in it, which is why a
+                        // constant `false` would be the wrong answer too.
+                        let msg = if tx.is_float() {
+                            format!(
+                                "`is_nan(x)` is not available on {} — the format has no NaN \
+                                 encoding, so the question has no answer. Convert with \
+                                 `.to_fp32()` if you need to test a widened value",
+                                tx.display()
+                            )
+                        } else {
+                            format!("`is_nan(x)` requires a float operand, got {}", tx.display())
+                        };
+                        self.errors
+                            .push(CompileError::general(&msg, call_args[0].span));
                         return Ty::Error;
                     }
                     return Ty::Bool;
@@ -4854,7 +4879,10 @@ impl<'a> TypeChecker<'a> {
                 // (≤4-bit significands fit bf16's 8, and both fp8 exponent
                 // ranges sit inside bf16's) — implemented as widen-to-f32
                 // then narrow, both steps exact.
-                if matches!(base_ty, Ty::FP8E4M3 | Ty::FP8E5M2) {
+                // FP4E2M1 joins the same family: widening to f32 is exact
+                // (a 2-bit significand fits trivially), and E2M1 -> bf16 is
+                // exact for the same reason the fp8 cases are.
+                if matches!(base_ty, Ty::FP8E4M3 | Ty::FP8E5M2 | Ty::FP4E2M1) {
                     return target;
                 }
                 match &base_ty {
@@ -4894,11 +4922,11 @@ impl<'a> TypeChecker<'a> {
             // overflow applies (riscv non-saturating / cuda satfinite).
             // Cross-fp8 (e4m3 <-> e5m2) also composes exactly: the widen is
             // exact, one narrow rounds.
-            "to_fp8e4m3" | "to_fp8e5m2" => {
-                let target = if method.name == "to_fp8e4m3" {
-                    Ty::FP8E4M3
-                } else {
-                    Ty::FP8E5M2
+            "to_fp8e4m3" | "to_fp8e5m2" | "to_fp4e2m1" => {
+                let target = match method.name.as_str() {
+                    "to_fp8e4m3" => Ty::FP8E4M3,
+                    "to_fp4e2m1" => Ty::FP4E2M1,
+                    _ => Ty::FP8E5M2,
                 };
                 match &base_ty {
                     t if *t == target => {
@@ -4916,6 +4944,7 @@ impl<'a> TypeChecker<'a> {
                     | Ty::BF16
                     | Ty::FP8E4M3
                     | Ty::FP8E5M2
+                    | Ty::FP4E2M1
                     | Ty::UInt(_)
                     | Ty::SInt(_)
                     | Ty::Bool => target,

--- a/tests/fp_test.rs
+++ b/tests/fp_test.rs
@@ -1952,3 +1952,162 @@ fn fp_formal_vacuity_guard() {
         "vacuous proof must be a hard failure (exit 1):\n{all}"
     );
 }
+
+// ── FP4E2M1 (OCP MX FP4) — storage-only ──────────────────────────────────
+//
+// The contract is as much about what is REJECTED as what works: E2M1 is a
+// carrier for conversions and literals, with no operator surface at all.
+
+/// Helper: run `arch check` on inline source, returning combined output and
+/// whether it succeeded.
+fn check_src(name: &str, src: &str) -> (bool, String) {
+    let dir = std::env::temp_dir().join("arch_fp4_tests");
+    std::fs::create_dir_all(&dir).expect("mkdir");
+    let path = dir.join(format!("{name}.arch"));
+    std::fs::write(&path, src).expect("write fixture");
+    let out = arch().arg("check").arg(&path).output().expect("run check");
+    let merged = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    // miette word-wraps diagnostics AND prefixes continuation lines with a
+    // box-drawing gutter, so a phrase can straddle a break as
+    // "storage-only float | format". Strip the gutter glyphs first, then
+    // collapse whitespace, before any substring matching.
+    let stripped: String = merged
+        .chars()
+        .map(|c| {
+            if "│┃|╭╰─▲·".contains(c) {
+                ' '
+            } else {
+                c
+            }
+        })
+        .collect();
+    let flat = stripped.split_whitespace().collect::<Vec<_>>().join(" ");
+    (out.status.success(), flat)
+}
+
+/// The conversion surface works end-to-end: widen, narrow, compute-in-FP32,
+/// and a context-typed literal.
+#[test]
+fn fp4_conversion_surface_checks_and_builds() {
+    let out = arch()
+        .arg("check")
+        .arg("tests/fp_v1/Fp4Convert.arch")
+        .output()
+        .expect("run arch check");
+    assert!(
+        out.status.success(),
+        "Fp4Convert.arch should check\n{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    // SV must lower conversions to the proven helpers — NOT to the integer
+    // path. Before the E2M1 conversion arms existed, `a.to_fp32()` emitted
+    // `arch_u64_to_f32(...)`, reinterpreting the 4-bit float as an integer,
+    // and `.to_fp4e2m1()` leaked ARCH syntax into the SV verbatim.
+    let dir = std::env::temp_dir().join("arch_fp4_build");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).expect("mkdir");
+    let sv_path = dir.join("Fp4Convert.sv");
+    let out = arch()
+        .arg("build")
+        .arg("tests/fp_v1/Fp4Convert.arch")
+        .arg("-o")
+        .arg(&sv_path)
+        .output()
+        .expect("run arch build");
+    assert!(
+        out.status.success(),
+        "build failed:\n{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let sv = std::fs::read_to_string(&sv_path).expect("emitted SV");
+    assert!(
+        sv.contains("arch_e2m1_to_f32("),
+        "widen must use the proven helper:\n{sv}"
+    );
+    assert!(
+        sv.contains("arch_f32_to_e2m1("),
+        "narrow must use the proven helper:\n{sv}"
+    );
+    assert!(
+        !sv.contains("to_fp4e2m1()"),
+        "ARCH method syntax must not leak into SV:\n{sv}"
+    );
+    assert!(
+        !sv.contains("arch_u64_to_f32(64'($unsigned(a)))"),
+        "a float must never be widened through the INTEGER path:\n{sv}"
+    );
+    assert!(sv.contains("logic [3:0]"), "E2M1 is a 4-bit carrier:\n{sv}");
+}
+
+/// Arithmetic is a clean, spanned type error — not a dangling
+/// `arch_e2m1_add` discovered later by Verilator / z3 / g++.
+#[test]
+fn fp4_arithmetic_is_rejected_at_typecheck() {
+    for (name, op) in [("add", "a + b"), ("sub", "a - b"), ("mul", "a * b")] {
+        let (ok, out) = check_src(
+            &format!("fp4_arith_{name}"),
+            &format!(
+                "module A\n  port a: in FP4E2M1;\n  port b: in FP4E2M1;\n  \
+                 port y: out FP4E2M1;\n  comb y = {op}; end comb\nend module A\n"
+            ),
+        );
+        assert!(!ok, "`{op}` on FP4E2M1 must be rejected:\n{out}");
+        assert!(
+            out.contains("storage-only float format"),
+            "`{op}`: message should name the storage-only rule:\n{out}"
+        );
+        assert!(
+            !out.contains("arch_e2m1_add"),
+            "must fail at typecheck, not by emitting a missing operator:\n{out}"
+        );
+    }
+}
+
+/// `is_nan` is refused with an accurate reason. E2M1 has no NaN encoding, so
+/// answering a constant `false` would mislead — and calling it "not a float"
+/// would be wrong, since it is one.
+#[test]
+fn fp4_is_nan_is_rejected_as_unrepresentable_not_as_non_float() {
+    let (ok, out) = check_src(
+        "fp4_isnan",
+        "module A\n  port a: in FP4E2M1;\n  port y: out Bool;\n  \
+         comb y = is_nan(a); end comb\nend module A\n",
+    );
+    assert!(!ok, "is_nan on FP4E2M1 must be rejected:\n{out}");
+    assert!(
+        out.contains("no NaN encoding"),
+        "reason must be the missing encoding, not 'requires a float':\n{out}"
+    );
+    assert!(
+        !out.contains("requires a float operand"),
+        "FP4E2M1 IS a float — that message would be wrong:\n{out}"
+    );
+}
+
+/// An overflowing literal is a compile error, never a silently wrong finite
+/// constant. The generic IEEE rounder would have packed `S.11.0` = 4.0.
+#[test]
+fn fp4_overflowing_literal_is_a_compile_error() {
+    let (ok, out) = check_src(
+        "fp4_lit_overflow",
+        "module A\n  port y: out FP4E2M1;\n  comb y = 8.0; end comb\nend module A\n",
+    );
+    assert!(!ok, "8.0 overflows FP4E2M1 (max 6.0):\n{out}");
+    assert!(
+        out.contains("FP4E2M1") && out.contains("6"),
+        "diagnostic should name the format and its bound:\n{out}"
+    );
+    // In-range literals still work.
+    let (ok, out) = check_src(
+        "fp4_lit_ok",
+        "module A\n  port y: out FP4E2M1;\n  comb y = 1.5; end comb\nend module A\n",
+    );
+    assert!(ok, "1.5 is exactly representable in E2M1:\n{out}");
+}

--- a/tests/fp_v1/Fp4Convert.arch
+++ b/tests/fp_v1/Fp4Convert.arch
@@ -1,0 +1,26 @@
+// FP4E2M1 (OCP MX FP4) storage-only surface: literals and conversions only.
+//
+// E2M1 is 1 sign + 2 exp + 1 mantissa with NO Inf and NO NaN — the entire
+// value set is ±{0, 0.5, 1, 1.5, 2, 3, 4, 6}. No shipping GPU/accelerator
+// ISA exposes scalar arithmetic on it (PTX: e2m1 "must be used in a packed
+// format"), so ARCH models it as a carrier: `+ - *`, compares and `is_nan`
+// are compile errors, and the value must be widened to FP32 to compute.
+module Fp4Convert
+  port a: in FP4E2M1;
+  port s: in FP32;
+
+  port wide:   out FP32;      // widen (exact — a 2-bit significand fits)
+  port narrow: out FP4E2M1;   // narrow (RNE, saturating: no Inf/NaN exists)
+  port viaf32: out FP4E2M1;   // compute in FP32, come back
+  port lit:    out FP4E2M1;   // a context-typed literal
+
+  let av: FP32 = a.to_fp32();
+
+  comb
+    wide   = av;
+    narrow = s.to_fp4e2m1();
+    // The storage-only idiom: widen, compute, narrow once.
+    viaf32 = (av + s).to_fp4e2m1();
+    lit    = 1.5;
+  end comb
+end module Fp4Convert


### PR DESCRIPTION
Phase 1 of the approved block-scaled format design ([#824](https://github.com/arch-hdl-lang/arch-com/pull/824)), on top of the Phase 0 table ([#830](https://github.com/arch-hdl-lang/arch-com/pull/830)) and the `is_nan`/tag-resolution hardening ([#833](https://github.com/arch-hdl-lang/arch-com/pull/833)).

`FP4E2M1` is the OCP Microscaling FP4 element: 1 sign + 2 exponent (bias 1) + 1 mantissa, **no infinity and no NaN**, max finite 6.0, value set ±{0, 0.5, 1, 1.5, 2, 3, 4, 6}.

## Storage-only is the format, not a shortcut

No shipping GPU or accelerator ISA exposes scalar E2M1 arithmetic. PTX states e2m1 values *"must be used in a packed format"* and that alternate formats *"cannot be used as fundamental types"*; across the ISA it appears only as a `cvt` source/destination and a block-scaled matrix operand. E2M1 is a **block element**, not a scalar arithmetic type.

So the surface is conversions and literals only:

| | |
|---|---|
| `a + b` | clean type error **with a span**, via the `is_float`/`is_float_arith` split from #830 — not a dangling `arch_e2m1_add` found later by Verilator/z3/g++ with no source location |
| `is_nan(a)` | refused as *"the format has no NaN encoding"* — not answered `false` (which would imply the question was meaningful), and not *"requires a float operand"* (which would be wrong: FP4E2M1 **is** a float) |
| `.to_fp32()` / `.to_fp4e2m1()` | lower to the proven `arch_e2m1_to_f32` / `arch_f32_to_e2m1` helpers |

## Two places the existing machinery was wrong for a 4-bit format

**`fp8_round`'s overflow rule was 2-way** (IEEE / OCP-NaN-top). E2M1's top binade is entirely **finite**, so it needed a third arm, `TopBinade::AllFinite`. Under the IEEE rule its two largest finite values — 4.0 and 6.0 — would have been treated as overflow.

**The generic literal rounder is an IEEE template** that treats an all-ones exponent as overflow-to-infinity. Applied to E2M1 it packs `S.11.0`, which decodes to **4.0** — a silently wrong constant, the same trap already documented for `f64_to_e4m3_bits` at 448. Literals therefore use a direct nearest-ties-to-even search over the eight magnitudes: simpler, and exhaustively checkable. Overflow (`|x| >= 7.0`, the RNE midpoint between 6.0 and the next would-be 8.0) is a compile error, matching fp8.

Runtime narrowing **saturates under both `--fp-compat` profiles** — the one conversion where the profiles cannot differ, since E2M1 has neither a NaN nor an infinity to produce.

## Verification

- **`.sv` and `.archi` output is byte-identical to main** across the 1680-file regression corpus; the only `.h` changes are **additive** (new C++ helpers, zero removed lines). Checked with `refactor_diff.sh --keep` and a per-extension diff audit.
- Emitted SV is **Verilator-clean**.
- IR widen/narrow checked against `fp_lit`'s **independent** reference on all 16 encodings, plus a widen∘narrow round-trip — two separate implementations (a bit-vector DAG and a Rust table), so agreement is evidence rather than tautology.
- Four integration tests pin the storage-only contract, including that SV lowers conversions to the proven helpers rather than the **integer** path.
- Full `cargo test`: 17 suites, 0 failures. `cargo fmt --check` clean.

## Bugs the tests caught before merge

1. **SV widened the 4-bit float through the integer path** (`arch_u64_to_f32(64'($unsigned(a)))`) and leaked `.to_fp4e2m1()` as literal ARCH syntax into the SV. Same silent-miscompile class as the #770 audit.
2. **5.0 is equidistant** between 4.0 and 6.0 — I had asserted it rounds to 6.0 "nearer than 4". Ties-to-even gives 4.0; the IR was right and my expectation was wrong in *both* the fp_lit and IR tests.
3. **`origin/main` moved five commits** mid-work; the byte-diff surfaced `.reverse()` changes that weren't mine, so I **rebased** rather than soft-reset — the arch#770 clobber the repo docs warn about.

## Scope

E8M0 (the block scale type) and the hand-written SMT round spec are the remaining Phase 1 items, deferred to a follow-up as the design phases them. E8M0 in particular needs a separate type concept: `mb = 0` panics `fp8_round`, and a sign bit is assumed throughout the float path.

Spec §3.9 and the reference card document the format; skill snapshots re-synced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)