### PR TITLE
fix(codegen): pipeline .resize<N>() emits bare N'(expr), matching mod.rs

### DIFF
--- a/src/codegen/pipeline.rs
+++ b/src/codegen/pipeline.rs
@@ -1738,11 +1738,12 @@ impl<'a> Codegen<'a> {
                         if let Some(width) = args.first() {
                             let w = self.emit_expr_str(width);
                             let wp = Self::paren_width(&w);
-                            if self.expr_is_signed(base) {
-                                format!("{wp}'($signed({b}))")
-                            } else {
-                                format!("{wp}'($unsigned({b}))")
-                            }
+                            // Bare size cast, no `$signed`/`$unsigned` wrapper —
+                            // the wrapper self-determines its argument (LRM
+                            // §11.6.1, §20.5), truncating e.g. `a * b` to
+                            // operand width BEFORE the cast widens. Must match
+                            // the canonical emission in mod.rs ("resize").
+                            format!("{wp}'({b})")
                         } else {
                             b
                         }
@@ -2096,11 +2097,12 @@ impl<'a> Codegen<'a> {
                         if let Some(width) = args.first() {
                             let w = self.emit_expr_str(width);
                             let wp = Self::paren_width(&w);
-                            if self.expr_is_signed(base) {
-                                format!("{wp}'($signed({b}))")
-                            } else {
-                                format!("{wp}'($unsigned({b}))")
-                            }
+                            // Bare size cast, no `$signed`/`$unsigned` wrapper —
+                            // the wrapper self-determines its argument (LRM
+                            // §11.6.1, §20.5), truncating e.g. `a * b` to
+                            // operand width BEFORE the cast widens. Must match
+                            // the canonical emission in mod.rs ("resize").
+                            format!("{wp}'({b})")
                         } else {
                             b
                         }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -4128,6 +4128,84 @@ end pipeline SextPipe
     );
 }
 
+/// `.resize<N>()` in a pipeline stage expression must emit a bare `N'(expr)`
+/// size cast, never `N'($unsigned(expr))` / `N'($signed(expr))`: the wrapper
+/// evaluates its argument in self-determined context (LRM §11.6.1, §20.5),
+/// truncating a multiply to operand width BEFORE the cast widens — silently
+/// dropping the product's upper bits (native sim keeps them, so the SV
+/// diverged). Mirrors the canonical emission in codegen/mod.rs.
+#[test]
+fn test_pipeline_stage_resize_of_mul_is_bare_size_cast() {
+    let source = r#"
+domain D
+  freq_mhz: 100
+end domain D
+pipeline ResizeMulPipe
+  port clk: in Clock<D>;
+  port rst: in Reset<Sync>;
+  port a: in UInt<16>;
+  port b: in UInt<16>;
+  port y: out UInt<32>;
+  stage S
+    reg prod: UInt<32> reset rst => 0;
+    seq on clk rising
+      prod <= (a * b).resize<32>();
+    end seq
+    comb
+      y = prod;
+    end comb
+  end stage S
+end pipeline ResizeMulPipe
+"#;
+    let sv = compile_to_sv(source);
+    assert!(
+        sv.contains("32'((a * b))"),
+        "pipeline stage .resize<32>() of a multiply must emit a bare size cast:\n{sv}"
+    );
+    assert!(
+        !sv.contains("$unsigned") && !sv.contains("$signed"),
+        "pipeline .resize must not wrap in $signed/$unsigned (self-determined \
+         context truncates the product before the cast widens):\n{sv}"
+    );
+}
+
+/// Same guarantee for the pipeline's module-level expression emitter, which
+/// handles `stall when` / `flush` / `forward` conditions.
+#[test]
+fn test_pipeline_stall_cond_resize_of_mul_is_bare_size_cast() {
+    let source = r#"
+domain D
+  freq_mhz: 100
+end domain D
+pipeline StallResizePipe
+  port clk: in Clock<D>;
+  port rst: in Reset<Sync>;
+  port a: in UInt<16>;
+  port b: in UInt<16>;
+  port y: out UInt<32>;
+  stage S
+    stall when ((a * b).resize<32>() > 100)
+    reg prod: UInt<32> reset rst => 0;
+    seq on clk rising
+      prod <= (a * b).resize<32>();
+    end seq
+    comb
+      y = prod;
+    end comb
+  end stage S
+end pipeline StallResizePipe
+"#;
+    let sv = compile_to_sv(source);
+    assert!(
+        sv.contains("assign s_stall = (32'((a * b)) > 100);"),
+        "stall-when .resize<32>() of a multiply must emit a bare size cast:\n{sv}"
+    );
+    assert!(
+        !sv.contains("$unsigned") && !sv.contains("$signed"),
+        "pipeline .resize must not wrap in $signed/$unsigned:\n{sv}"
+    );
+}
+
 #[test]
 fn test_pipeline_comb_match_emits_case() {
     let source = r#"


### PR DESCRIPTION
## Summary

The `resize` method-call emission in `src/codegen/mod.rs` was previously corrected to emit a bare `N'(expr)` size cast, with a detailed comment explaining why `N'($signed(expr))` / `N'($unsigned(expr))` is wrong: `$signed`/`$unsigned` evaluate their argument in **self-determined** context (LRM §11.6.1, §20.5), truncating e.g. `a * b` to operand width *before* the outer cast widens — silently losing the product's upper bits.

However, `src/codegen/pipeline.rs` has two duplicate expression emitters (`emit_pipeline_stage_expr_str` for in-stage expressions, `emit_pipeline_expr_str` for module-level `stall when`/`flush`/`forward` conditions) that still emitted the old wrapped form. This PR brings both in line with mod.rs.

## Demonstrated miscompile

```arch
stage S
  reg prod: UInt<32> reset rst => 0;
  seq on clk rising
    prod <= (a * b).resize<32>();   // a, b: UInt<16>
  end seq
```

With `a = b = 0x100`:
- **Before**: emitted `32'($unsigned((a * b)))` — Verilator 5.048 computes `y = 0x0` (16-bit self-determined product truncates), while native `arch sim` computes `y = 0x10000`. Silent divergence.
- **After**: emits `32'((a * b))` — Verilator computes `y = 0x10000`, matching native sim.

The bare size cast forwards context-determined evaluation through the arithmetic (both operands widen to N before the multiply) and still inherits signedness from the expression itself, so non-arithmetic receivers are unaffected.

## Changes

- Both `"resize"` arms in `src/codegen/pipeline.rs` now emit `{wp}'({b})`, with a comment pointing at the canonical emission in mod.rs.
- Two SV-codegen regression tests in `tests/integration_test.rs`, one per pipeline emitter (stage expression, and stall-when condition).

## Verification

- `cargo test` green (the two `construct_proof_lean_*` failures are a pre-existing local-environment issue — unbuilt `ArchConstructProof` Lean package — and fail identically on pristine `origin/main`).
- End-to-end smoke: fixture built with the fixed compiler, Verilated, and run — output matches native sim (`0x10000`).

Internal codegen fix only — no user-facing syntax or semantics change (no doc/ update needed; no lexer/parser/ast files touched).

## Follow-up (not in this PR)

The method-call emission match now exists in three near-identical copies (mod.rs + two in pipeline.rs), which is how this fix originally missed the siblings. Deduplicating them into one shared emitter would prevent a recurrence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)