### PR TITLE
feat(fp): FP6E2M3 and FP6E3M2 — OCP MX FP6 as storage-only types

### DIFF
--- a/doc/ARCH_HDL_Specification.md
+++ b/doc/ARCH_HDL_Specification.md
@@ -315,6 +315,10 @@ The Arch type system enforces four independent safety dimensions simultaneously.
 
   **FP4E2M1**          4 bits               OCP MX FP4 E2M1 (2-bit exponent, 1-bit mantissa; **no inf, no NaN**, max finite 6.0). **Storage-only**: conversions and literals only — no arithmetic, compares or `is_nan`. See §3.9.
 
+  **FP6E2M3**          6 bits               OCP MX FP6 E2M3 (2-bit exponent, 3-bit mantissa; **no inf, no NaN**, max finite 7.5). **Storage-only**. See §3.9.
+
+  **FP6E3M2**          6 bits               OCP MX FP6 E3M2 (3-bit exponent, 2-bit mantissa; **no inf, no NaN**, max finite 28.0). **Storage-only**. See §3.9.
+
   **Clock\<D\>**       1 bit                Carries clock-domain tag D. Cannot appear in arithmetic.
 
   **Reset\<Sync, High\|Low\>**    1 bit                Synchronous reset --- deasserted on the clock edge. Polarity defaults High.
@@ -744,9 +748,17 @@ let gt: Bool = a > b;         // ordered compare → Bool
 let nan: Bool = is_nan(a);
 ```
 
-**3.9 FP4E2M1 --- a storage-only block-element format**
+**3.9 FP4E2M1 / FP6E2M3 / FP6E3M2 --- storage-only block-element formats**
 
-`FP4E2M1` is the OCP Microscaling (MX) FP4 element type: 1 sign + 2 exponent (bias 1) + 1 mantissa bit, emitted as `logic[3:0]`. It has **no infinity and no NaN encoding** — every one of its 16 codes is a finite value, and the complete value set is ±{0, 0.5, 1, 1.5, 2, 3, 4, 6}, with one subnormal (0.5) and max finite 6.0.
+ARCH provides the three sub-8-bit OCP Microscaling (MX) element types. All share one contract, described here in terms of `FP4E2M1`; `FP6E2M3` and `FP6E3M2` differ only in their field split and bounds.
+
+| Type | S/E/M | Bias | Max finite | Min subnormal | SV |
+|---|---|---|---|---|---|
+| `FP4E2M1` | 1/2/1 | 1 | 6.0 | 0.5 | `logic[3:0]` |
+| `FP6E2M3` | 1/2/3 | 1 | 7.5 | 0.125 | `logic[5:0]` |
+| `FP6E3M2` | 1/3/2 | 3 | 28.0 | 0.0625 | `logic[5:0]` |
+
+`FP4E2M1` is the OCP MX FP4 element type: 1 sign + 2 exponent (bias 1) + 1 mantissa bit, emitted as `logic[3:0]`. It has **no infinity and no NaN encoding** — every one of its 16 codes is a finite value, and the complete value set is ±{0, 0.5, 1, 1.5, 2, 3, 4, 6}, with one subnormal (0.5) and max finite 6.0.
 
 Unlike every other float type in ARCH, `FP4E2M1` is **storage-only**: it carries values and converts, but has *no operator surface at all*. `a + b`, ordered compares and `is_nan(a)` are compile errors.
 
@@ -758,7 +770,7 @@ The idiom is widen → compute → narrow once:
 
 ```arch
 let av: FP32 = a.to_fp32();          // exact: a 2-bit significand always fits
-comb y = (av * s).to_fp4e2m1(); end comb
+comb y = (av * s).to_fp4e2m1(); end comb   // or .to_fp6e2m3() / .to_fp6e3m2()
 ```
 
 **Conversions.** `.to_fp32()` widens exactly. `.to_fp4e2m1()` narrows with round-to-nearest-ties-to-even and **saturates** on overflow. Saturation is profile-independent here, unlike fp8 where `--fp-compat` selects between a NaN/inf result and `satfinite`: E2M1 has neither a NaN nor an infinity to produce, so saturation is the only representable behavior. Cross-format conversions compose through `FP32`, each step exact or singly rounded.

--- a/doc/Arch_AI_Reference_Card.md
+++ b/doc/Arch_AI_Reference_Card.md
@@ -161,7 +161,7 @@ Range `for` = runtime SV loop; value-list `for` = compile-time unroll; `generate
 UInt<N>  SInt<N>  Bool  Bit
 FP32  BF16                                    // IEEE-754 binary32 / bfloat16 (v1; see §2a)
 FP8E4M3  FP8E5M2                              // OCP OFP8 8-bit floats (v1; see §2a)
-FP4E2M1                                       // OCP MX FP4 element: STORAGE-ONLY (conversions + literals; no + - * / compares / is_nan)
+FP4E2M1  FP6E2M3  FP6E3M2                     // OCP MX sub-8-bit elements: STORAGE-ONLY (conversions + literals; no + - * / compares / is_nan)
 Clock<Domain>  Reset<Sync|Async, High|Low>   // polarity defaults High
 Vec<T,N>
 struct S  { f: T; }
@@ -251,6 +251,7 @@ let nan: Bool = is_nan(a);  // qNaN/sNaN test → Bool
 ```
 x.to_fp32()      // BF16/FP8E4M3/FP8E5M2/FP4E2M1→FP32 (exact widen) or SInt/UInt→FP32 (RNE)
 x.to_fp4e2m1()   // →FP4E2M1 (RNE, saturating; no inf/NaN exists in the format)
+x.to_fp6e2m3()  x.to_fp6e3m2()   // →FP6 (same storage-only rules)
 x.to_bf16()      // FP32→BF16 (RNE); fp8→BF16 (exact); int→BF16 (f32-routed)
 x.to_fp8e4m3()   // FP32/BF16/FP8E5M2/int→FP8E4M3 (CR; overflow per --fp-compat)
 x.to_fp8e5m2()   // FP32/BF16/FP8E4M3/int→FP8E5M2 (CR; overflow per --fp-compat)

--- a/skills/arch-programming/references/ARCH_HDL_Specification.md
+++ b/skills/arch-programming/references/ARCH_HDL_Specification.md
@@ -315,6 +315,10 @@ The Arch type system enforces four independent safety dimensions simultaneously.
 
   **FP4E2M1**          4 bits               OCP MX FP4 E2M1 (2-bit exponent, 1-bit mantissa; **no inf, no NaN**, max finite 6.0). **Storage-only**: conversions and literals only — no arithmetic, compares or `is_nan`. See §3.9.
 
+  **FP6E2M3**          6 bits               OCP MX FP6 E2M3 (2-bit exponent, 3-bit mantissa; **no inf, no NaN**, max finite 7.5). **Storage-only**. See §3.9.
+
+  **FP6E3M2**          6 bits               OCP MX FP6 E3M2 (3-bit exponent, 2-bit mantissa; **no inf, no NaN**, max finite 28.0). **Storage-only**. See §3.9.
+
   **Clock\<D\>**       1 bit                Carries clock-domain tag D. Cannot appear in arithmetic.
 
   **Reset\<Sync, High\|Low\>**    1 bit                Synchronous reset --- deasserted on the clock edge. Polarity defaults High.
@@ -744,9 +748,17 @@ let gt: Bool = a > b;         // ordered compare → Bool
 let nan: Bool = is_nan(a);
 ```
 
-**3.9 FP4E2M1 --- a storage-only block-element format**
+**3.9 FP4E2M1 / FP6E2M3 / FP6E3M2 --- storage-only block-element formats**
 
-`FP4E2M1` is the OCP Microscaling (MX) FP4 element type: 1 sign + 2 exponent (bias 1) + 1 mantissa bit, emitted as `logic[3:0]`. It has **no infinity and no NaN encoding** — every one of its 16 codes is a finite value, and the complete value set is ±{0, 0.5, 1, 1.5, 2, 3, 4, 6}, with one subnormal (0.5) and max finite 6.0.
+ARCH provides the three sub-8-bit OCP Microscaling (MX) element types. All share one contract, described here in terms of `FP4E2M1`; `FP6E2M3` and `FP6E3M2` differ only in their field split and bounds.
+
+| Type | S/E/M | Bias | Max finite | Min subnormal | SV |
+|---|---|---|---|---|---|
+| `FP4E2M1` | 1/2/1 | 1 | 6.0 | 0.5 | `logic[3:0]` |
+| `FP6E2M3` | 1/2/3 | 1 | 7.5 | 0.125 | `logic[5:0]` |
+| `FP6E3M2` | 1/3/2 | 3 | 28.0 | 0.0625 | `logic[5:0]` |
+
+`FP4E2M1` is the OCP MX FP4 element type: 1 sign + 2 exponent (bias 1) + 1 mantissa bit, emitted as `logic[3:0]`. It has **no infinity and no NaN encoding** — every one of its 16 codes is a finite value, and the complete value set is ±{0, 0.5, 1, 1.5, 2, 3, 4, 6}, with one subnormal (0.5) and max finite 6.0.
 
 Unlike every other float type in ARCH, `FP4E2M1` is **storage-only**: it carries values and converts, but has *no operator surface at all*. `a + b`, ordered compares and `is_nan(a)` are compile errors.
 
@@ -758,7 +770,7 @@ The idiom is widen → compute → narrow once:
 
 ```arch
 let av: FP32 = a.to_fp32();          // exact: a 2-bit significand always fits
-comb y = (av * s).to_fp4e2m1(); end comb
+comb y = (av * s).to_fp4e2m1(); end comb   // or .to_fp6e2m3() / .to_fp6e3m2()
 ```
 
 **Conversions.** `.to_fp32()` widens exactly. `.to_fp4e2m1()` narrows with round-to-nearest-ties-to-even and **saturates** on overflow. Saturation is profile-independent here, unlike fp8 where `--fp-compat` selects between a NaN/inf result and `satfinite`: E2M1 has neither a NaN nor an infinity to produce, so saturation is the only representable behavior. Cross-format conversions compose through `FP32`, each step exact or singly rounded.

--- a/skills/arch-programming/references/Arch_AI_Reference_Card.md
+++ b/skills/arch-programming/references/Arch_AI_Reference_Card.md
@@ -161,7 +161,7 @@ Range `for` = runtime SV loop; value-list `for` = compile-time unroll; `generate
 UInt<N>  SInt<N>  Bool  Bit
 FP32  BF16                                    // IEEE-754 binary32 / bfloat16 (v1; see §2a)
 FP8E4M3  FP8E5M2                              // OCP OFP8 8-bit floats (v1; see §2a)
-FP4E2M1                                       // OCP MX FP4 element: STORAGE-ONLY (conversions + literals; no + - * / compares / is_nan)
+FP4E2M1  FP6E2M3  FP6E3M2                     // OCP MX sub-8-bit elements: STORAGE-ONLY (conversions + literals; no + - * / compares / is_nan)
 Clock<Domain>  Reset<Sync|Async, High|Low>   // polarity defaults High
 Vec<T,N>
 struct S  { f: T; }
@@ -251,6 +251,7 @@ let nan: Bool = is_nan(a);  // qNaN/sNaN test → Bool
 ```
 x.to_fp32()      // BF16/FP8E4M3/FP8E5M2/FP4E2M1→FP32 (exact widen) or SInt/UInt→FP32 (RNE)
 x.to_fp4e2m1()   // →FP4E2M1 (RNE, saturating; no inf/NaN exists in the format)
+x.to_fp6e2m3()  x.to_fp6e3m2()   // →FP6 (same storage-only rules)
 x.to_bf16()      // FP32→BF16 (RNE); fp8→BF16 (exact); int→BF16 (f32-routed)
 x.to_fp8e4m3()   // FP32/BF16/FP8E5M2/int→FP8E4M3 (CR; overflow per --fp-compat)
 x.to_fp8e5m2()   // FP32/BF16/FP8E4M3/int→FP8E5M2 (CR; overflow per --fp-compat)

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1123,6 +1123,10 @@ pub enum TypeExpr {
     /// Element type of MXFP4/NVFP4 blocks; no shipping ISA exposes scalar
     /// arithmetic on it, so it carries conversions and literals only.
     FP4E2M1,
+    /// OCP MX FP6 (1+2+3). Storage-only: no Inf, no NaN, max finite 7.5.
+    FP6E2M3,
+    /// OCP MX FP6 (1+3+2). Storage-only: no Inf, no NaN, max finite 28.0.
+    FP6E3M2,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1294,6 +1298,8 @@ pub enum FloatLitFmt {
     E4m3,
     E5m2,
     E2m1,
+    E2m3,
+    E3m2,
 }
 
 impl FloatLitFmt {
@@ -1305,6 +1311,8 @@ impl FloatLitFmt {
             FloatLitFmt::E4m3 => (4, 3),
             FloatLitFmt::E5m2 => (5, 2),
             FloatLitFmt::E2m1 => (2, 1),
+            FloatLitFmt::E2m3 => (2, 3),
+            FloatLitFmt::E3m2 => (3, 2),
         }
     }
 
@@ -1316,6 +1324,8 @@ impl FloatLitFmt {
             FloatLitFmt::E4m3 => 8,
             FloatLitFmt::E5m2 => 8,
             FloatLitFmt::E2m1 => 4,
+            FloatLitFmt::E2m3 => 6,
+            FloatLitFmt::E3m2 => 6,
         }
     }
 }

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -2169,6 +2169,8 @@ impl<'a> Codegen<'a> {
                 "to_fp8e4m3" => Some("e4m3"),
                 "to_fp8e5m2" => Some("e5m2"),
                 "to_fp4e2m1" => Some("e2m1"),
+                "to_fp6e2m3" => Some("e2m3"),
+                "to_fp6e3m2" => Some("e3m2"),
                 _ => None,
             },
             ExprKind::FunctionCall(name, args) if name == "fma" => {
@@ -2728,6 +2730,7 @@ impl<'a> Codegen<'a> {
             TypeExpr::BF16 => Some("16".to_string()),
             TypeExpr::FP8E4M3 | TypeExpr::FP8E5M2 => Some("8".to_string()),
             TypeExpr::FP4E2M1 => Some("4".to_string()),
+            TypeExpr::FP6E2M3 | TypeExpr::FP6E3M2 => Some("6".to_string()),
             TypeExpr::Vec(inner, size) => {
                 let iw = self.type_expr_data_width(inner)?;
                 let n = self.emit_expr_str(size);
@@ -5733,6 +5736,7 @@ impl<'a> Codegen<'a> {
             TypeExpr::BF16 => Some(16),
             TypeExpr::FP8E4M3 | TypeExpr::FP8E5M2 => Some(8),
             TypeExpr::FP4E2M1 => Some(4),
+            TypeExpr::FP6E2M3 | TypeExpr::FP6E3M2 => Some(6),
             TypeExpr::Vec(inner, size) => {
                 let iw = self.type_expr_width(inner)?;
                 let n = eval(size)?;
@@ -6700,6 +6704,7 @@ impl<'a> Codegen<'a> {
                     FloatLitFmt::Bf16 => format!("16'h{bits:04X}"),
                     FloatLitFmt::E4m3 | FloatLitFmt::E5m2 => format!("8'h{bits:02X}"),
                     FloatLitFmt::E2m1 => format!("4'h{bits:01X}"),
+                    FloatLitFmt::E2m3 | FloatLitFmt::E3m2 => format!("6'h{bits:02X}"),
                 },
             },
             ExprKind::Bool(true) => "1'b1".to_string(),
@@ -7041,6 +7046,8 @@ impl<'a> Codegen<'a> {
                             Some("e4m3") => format!("arch_e4m3_to_f32({b})"),
                             Some("e5m2") => format!("arch_e5m2_to_f32({b})"),
                             Some("e2m1") => format!("arch_e2m1_to_f32({b})"),
+                            Some("e2m3") => format!("arch_e2m3_to_f32({b})"),
+                            Some("e3m2") => format!("arch_e3m2_to_f32({b})"),
                             Some("f32") => b,
                             _ => {
                                 // int -> f32 (RNE) via the synthesizable helper.
@@ -7062,6 +7069,8 @@ impl<'a> Codegen<'a> {
                             Some("e4m3") => format!("arch_f32_to_bf16(arch_e4m3_to_f32({b}))"),
                             Some("e5m2") => format!("arch_f32_to_bf16(arch_e5m2_to_f32({b}))"),
                             Some("e2m1") => format!("arch_f32_to_bf16(arch_e2m1_to_f32({b}))"),
+                            Some("e2m3") => format!("arch_f32_to_bf16(arch_e2m3_to_f32({b}))"),
+                            Some("e3m2") => format!("arch_f32_to_bf16(arch_e3m2_to_f32({b}))"),
                             _ => {
                                 // int -> f32 (RNE) -> bf16 (RNE). DECLARED semantics
                                 // (issue #629, resolved as f32-routed / VR(f32)):
@@ -7086,11 +7095,13 @@ impl<'a> Codegen<'a> {
                             }
                         }
                     }
-                    "to_fp8e4m3" | "to_fp8e5m2" | "to_fp4e2m1" => {
+                    "to_fp8e4m3" | "to_fp8e5m2" | "to_fp4e2m1" | "to_fp6e2m3" | "to_fp6e3m2" => {
                         self.fp_helpers_used.set(true);
                         let (narrow, tgt) = match method.name.as_str() {
                             "to_fp8e4m3" => ("arch_f32_to_e4m3", "e4m3"),
                             "to_fp4e2m1" => ("arch_f32_to_e2m1", "e2m1"),
+                            "to_fp6e2m3" => ("arch_f32_to_e2m3", "e2m3"),
+                            "to_fp6e3m2" => ("arch_f32_to_e3m2", "e3m2"),
                             _ => ("arch_f32_to_e5m2", "e5m2"),
                         };
                         match self.expr_float_fmt(base) {
@@ -7101,6 +7112,8 @@ impl<'a> Codegen<'a> {
                             Some("e4m3") => format!("{narrow}(arch_e4m3_to_f32({b}))"),
                             Some("e5m2") => format!("{narrow}(arch_e5m2_to_f32({b}))"),
                             Some("e2m1") => format!("{narrow}(arch_e2m1_to_f32({b}))"),
+                            Some("e2m3") => format!("{narrow}(arch_e2m3_to_f32({b}))"),
+                            Some("e3m2") => format!("{narrow}(arch_e3m2_to_f32({b}))"),
                             // Integers: int -> f32 (exact for the fp8-relevant
                             // range, far below 2^24) -> one fp8 rounding — CR.
                             _ => {
@@ -7603,6 +7616,7 @@ impl<'a> Codegen<'a> {
             TypeExpr::BF16 => "logic [15:0]".to_string(),
             TypeExpr::FP8E4M3 | TypeExpr::FP8E5M2 => "logic [7:0]".to_string(),
             TypeExpr::FP4E2M1 => "logic [3:0]".to_string(),
+            TypeExpr::FP6E2M3 | TypeExpr::FP6E3M2 => "logic [5:0]".to_string(),
             TypeExpr::Clock(_) => "logic".to_string(),
             TypeExpr::Reset(_, _) => "logic".to_string(),
             TypeExpr::Vec(_, _) => {

--- a/src/construct_proof_cert.rs
+++ b/src/construct_proof_cert.rs
@@ -293,6 +293,7 @@ fn type_width_u64(ty: &TypeExpr) -> Result<u64, String> {
         TypeExpr::BF16 => Ok(16),
         TypeExpr::FP8E4M3 | TypeExpr::FP8E5M2 => Ok(8),
         TypeExpr::FP4E2M1 => Ok(4),
+        TypeExpr::FP6E2M3 | TypeExpr::FP6E3M2 => Ok(6),
         TypeExpr::Vec(elem, len) => {
             let elem_width = type_width_u64(elem)?;
             let len = const_expr_u64(len)?;

--- a/src/elaborate/mod.rs
+++ b/src/elaborate/mod.rs
@@ -731,6 +731,8 @@ fn narrow_fmt_of_type(ty: &TypeExpr) -> Option<FloatLitFmt> {
         TypeExpr::FP8E4M3 => Some(FloatLitFmt::E4m3),
         TypeExpr::FP8E5M2 => Some(FloatLitFmt::E5m2),
         TypeExpr::FP4E2M1 => Some(FloatLitFmt::E2m1),
+        TypeExpr::FP6E2M3 => Some(FloatLitFmt::E2m3),
+        TypeExpr::FP6E3M2 => Some(FloatLitFmt::E3m2),
         // Vec-of-narrow-float: a literal in this signal's reset/init slot
         // (or an element assignment) targets the ELEMENT format — without
         // this, `reg h: Vec<BF16,2> reset rst => 0.5;` kept the literal as
@@ -934,6 +936,8 @@ fn coerce_narrow_lit(e: &mut Expr, fmt: FloatLitFmt, errors: &mut Vec<CompileErr
             FloatLitFmt::E4m3 => crate::fp_lit::f64_to_e4m3_bits(v).map(|b| b as u64),
             FloatLitFmt::E5m2 => crate::fp_lit::f64_to_e5m2_bits(v).map(|b| b as u64),
             FloatLitFmt::E2m1 => crate::fp_lit::f64_to_e2m1_bits(v).map(|b| b as u64),
+            FloatLitFmt::E2m3 => crate::fp_lit::f64_to_e2m3_bits(v).map(|b| b as u64),
+            FloatLitFmt::E3m2 => crate::fp_lit::f64_to_e3m2_bits(v).map(|b| b as u64),
         };
         match rounded {
             Some(bits8) => {

--- a/src/formal.rs
+++ b/src/formal.rs
@@ -2141,7 +2141,9 @@ impl<'a> FormalCtx<'a> {
             | TypeExpr::BF16
             | TypeExpr::FP8E4M3
             | TypeExpr::FP8E5M2
-            | TypeExpr::FP4E2M1 => Ok(()),
+            | TypeExpr::FP4E2M1
+            | TypeExpr::FP6E2M3
+            | TypeExpr::FP6E3M2 => Ok(()),
             TypeExpr::Vec(_, _) => Err(CompileError::general(
                 "Vec types are not supported by `arch formal` v1 — use scalars",
                 span,
@@ -2159,6 +2161,7 @@ impl<'a> FormalCtx<'a> {
             TypeExpr::BF16 => Ok((16, false)),
             TypeExpr::FP8E4M3 | TypeExpr::FP8E5M2 => Ok((8, false)),
             TypeExpr::FP4E2M1 => Ok((4, false)),
+            TypeExpr::FP6E2M3 | TypeExpr::FP6E3M2 => Ok((6, false)),
             TypeExpr::UInt(w) => {
                 let width = fold_const_expr(w, &self.params).ok_or_else(|| {
                     CompileError::general(
@@ -2807,6 +2810,8 @@ impl<'a> FormalCtx<'a> {
                 crate::ast::FloatLitFmt::E4m3 => "e4m3",
                 crate::ast::FloatLitFmt::E5m2 => "e5m2",
                 crate::ast::FloatLitFmt::E2m1 => "e2m1",
+                crate::ast::FloatLitFmt::E2m3 => "e2m3",
+                crate::ast::FloatLitFmt::E3m2 => "e3m2",
             }),
             Binary(op, l, r) => match op {
                 BinOp::Add | BinOp::Sub | BinOp::Mul => {
@@ -3532,6 +3537,8 @@ impl<'a> FormalCtx<'a> {
                     crate::ast::FloatLitFmt::E4m3 => crate::fp_lit::e4m3_bits_to_f64(*bits as u8),
                     crate::ast::FloatLitFmt::E5m2 => crate::fp_lit::e5m2_bits_to_f64(*bits as u8),
                     crate::ast::FloatLitFmt::E2m1 => crate::fp_lit::e2m1_bits_to_f64(*bits as u8),
+                    crate::ast::FloatLitFmt::E2m3 => crate::fp_lit::e2m3_bits_to_f64(*bits as u8),
+                    crate::ast::FloatLitFmt::E3m2 => crate::fp_lit::e3m2_bits_to_f64(*bits as u8),
                 };
                 Ok(gappa_real(v))
             }
@@ -3966,6 +3973,8 @@ fn lit_f64(e: &Expr) -> Option<f64> {
             crate::ast::FloatLitFmt::E4m3 => crate::fp_lit::e4m3_bits_to_f64(*b as u8),
             crate::ast::FloatLitFmt::E5m2 => crate::fp_lit::e5m2_bits_to_f64(*b as u8),
             crate::ast::FloatLitFmt::E2m1 => crate::fp_lit::e2m1_bits_to_f64(*b as u8),
+            crate::ast::FloatLitFmt::E2m3 => crate::fp_lit::e2m3_bits_to_f64(*b as u8),
+            crate::ast::FloatLitFmt::E3m2 => crate::fp_lit::e3m2_bits_to_f64(*b as u8),
         }),
         ExprKind::Literal(LitKind::Dec(v)) => Some(*v as f64),
         _ => None,

--- a/src/fp_format.rs
+++ b/src/fp_format.rs
@@ -41,6 +41,8 @@ pub enum FpFormatId {
     E4m3,
     E5m2,
     E2m1,
+    E2m3,
+    E3m2,
 }
 
 /// How a format encodes NaN.
@@ -167,6 +169,34 @@ pub const FORMATS: &[FpFormat] = &[
         // block element, so it carries conversions and literals only.
         arith: false,
     },
+    FpFormat {
+        // OCP MX FP6 E2M3: no Inf, no NaN, max finite 7.5. Storage-only.
+        id: FpFormatId::E2m3,
+        tag: "e2m3",
+        type_name: "FP6E2M3",
+        width: 6,
+        exp_bits: 2,
+        mant_bits: 3,
+        has_inf: false,
+        has_nan: false,
+        max_finite: 7.5,
+        nan_rule: NanRule::NoNan,
+        arith: false,
+    },
+    FpFormat {
+        // OCP MX FP6 E3M2: no Inf, no NaN, max finite 28.0. Storage-only.
+        id: FpFormatId::E3m2,
+        tag: "e3m2",
+        type_name: "FP6E3M2",
+        width: 6,
+        exp_bits: 3,
+        mant_bits: 2,
+        has_inf: false,
+        has_nan: false,
+        max_finite: 28.0,
+        nan_rule: NanRule::NoNan,
+        arith: false,
+    },
 ];
 
 impl FpFormat {
@@ -224,6 +254,8 @@ pub fn by_lit_fmt(fmt: FloatLitFmt) -> &'static FpFormat {
         FloatLitFmt::E4m3 => FpFormatId::E4m3,
         FloatLitFmt::E5m2 => FpFormatId::E5m2,
         FloatLitFmt::E2m1 => FpFormatId::E2m1,
+        FloatLitFmt::E2m3 => FpFormatId::E2m3,
+        FloatLitFmt::E3m2 => FpFormatId::E3m2,
     })
 }
 
@@ -235,6 +267,8 @@ pub fn by_type_expr(ty: &TypeExpr) -> Option<&'static FpFormat> {
         TypeExpr::FP8E4M3 => FpFormatId::E4m3,
         TypeExpr::FP8E5M2 => FpFormatId::E5m2,
         TypeExpr::FP4E2M1 => FpFormatId::E2m1,
+        TypeExpr::FP6E2M3 => FpFormatId::E2m3,
+        TypeExpr::FP6E3M2 => FpFormatId::E3m2,
         _ => return None,
     };
     Some(by_id(id))
@@ -263,6 +297,8 @@ mod tests {
             FpFormatId::E4m3,
             FpFormatId::E5m2,
             FpFormatId::E2m1,
+            FpFormatId::E2m3,
+            FpFormatId::E3m2,
         ] {
             let rows = FORMATS.iter().filter(|f| f.id == id).count();
             assert_eq!(rows, 1, "expected exactly one row for {id:?}, got {rows}");
@@ -307,6 +343,8 @@ mod tests {
             FloatLitFmt::E4m3,
             FloatLitFmt::E5m2,
             FloatLitFmt::E2m1,
+            FloatLitFmt::E2m3,
+            FloatLitFmt::E3m2,
         ] {
             let f = by_lit_fmt(fmt);
             assert_eq!(f.width, fmt.width(), "{}: width disagrees", f.tag);
@@ -325,6 +363,8 @@ mod tests {
             (TypeExpr::FP8E4M3, "e4m3"),
             (TypeExpr::FP8E5M2, "e5m2"),
             (TypeExpr::FP4E2M1, "e2m1"),
+            (TypeExpr::FP6E2M3, "e2m3"),
+            (TypeExpr::FP6E3M2, "e3m2"),
         ] {
             let f = by_type_expr(&ty).expect("surface float type must have a row");
             assert_eq!(f.tag, tag);

--- a/src/fp_lit.rs
+++ b/src/fp_lit.rs
@@ -317,6 +317,94 @@ pub fn f64_to_e2m1_bits(x: f64) -> Option<u8> {
     Some(sign | best as u8)
 }
 
+/// Magnitudes of an all-finite OCP narrow format, indexed by its magnitude
+/// encoding. `exp_bits`/`mant_bits` describe the field split; bias is the
+/// IEEE `2^(eb-1)-1`.
+fn all_finite_magnitudes(exp_bits: u32, mant_bits: u32) -> Vec<f64> {
+    let bias = (1i32 << (exp_bits - 1)) - 1;
+    let mant_n = 1u32 << mant_bits;
+    let mut out = Vec::with_capacity(((1u32 << exp_bits) * mant_n) as usize);
+    for e in 0..(1u32 << exp_bits) {
+        for m in 0..mant_n {
+            let v = if e == 0 {
+                // subnormal: 2^(1-bias) * (m / 2^mant_bits)
+                2f64.powi(1 - bias) * (m as f64 / mant_n as f64)
+            } else {
+                2f64.powi(e as i32 - bias) * (1.0 + m as f64 / mant_n as f64)
+            };
+            out.push(v);
+        }
+    }
+    out
+}
+
+/// Round `x` to an all-finite OCP narrow format (no Inf, no NaN), or `None`
+/// on overflow.
+///
+/// Shared by FP6 E2M3/E3M2 and, in spirit, FP4 E2M1. `round_f64_to_narrow`
+/// cannot serve these: its IEEE template treats an all-ones exponent as
+/// overflow-to-infinity, but in these formats that binade is entirely
+/// FINITE, so it would pack a silently wrong constant (the trap documented
+/// for `f64_to_e4m3_bits` at 448 and `f64_to_e2m1_bits` at 8.0).
+///
+/// The overflow boundary is the round-to-nearest midpoint between the max
+/// finite and the next would-be value, consistent with E4M3 (max 448, next
+/// 512, so `>= 480` overflows).
+fn f64_to_all_finite_bits(x: f64, exp_bits: u32, mant_bits: u32) -> Option<u8> {
+    if x.is_nan() || x.is_infinite() {
+        return None;
+    }
+    let mags = all_finite_magnitudes(exp_bits, mant_bits);
+    let max_finite = *mags.last().expect("non-empty");
+    // The next would-be magnitude is one ulp of the top binade above max.
+    let top_ulp = max_finite - mags[mags.len() - 2];
+    let overflow_at = max_finite + top_ulp / 2.0;
+    let sign_bit: u8 = 1 << (exp_bits + mant_bits);
+    let sign = if x.is_sign_negative() { sign_bit } else { 0 };
+    let a = x.abs();
+    if a >= overflow_at {
+        return None;
+    }
+    let mut best = 0usize;
+    let mut best_err = f64::INFINITY;
+    for (i, &m) in mags.iter().enumerate() {
+        let err = (a - m).abs();
+        if err < best_err || (err == best_err && i % 2 == 0) {
+            best = i;
+            best_err = err;
+        }
+    }
+    Some(sign | best as u8)
+}
+
+fn all_finite_bits_to_f64(b: u8, exp_bits: u32, mant_bits: u32) -> f64 {
+    let sign_bit: u8 = 1 << (exp_bits + mant_bits);
+    let mags = all_finite_magnitudes(exp_bits, mant_bits);
+    let mag = mags[(b & (sign_bit - 1)) as usize];
+    if b & sign_bit != 0 {
+        -mag
+    } else {
+        mag
+    }
+}
+
+/// Round `x` to OCP FP6 E2M3 (max finite 7.5); `None` on overflow.
+pub fn f64_to_e2m3_bits(x: f64) -> Option<u8> {
+    f64_to_all_finite_bits(x, 2, 3)
+}
+/// Exact value of an E2M3 encoding (low 6 bits significant).
+pub fn e2m3_bits_to_f64(b: u8) -> f64 {
+    all_finite_bits_to_f64(b, 2, 3)
+}
+/// Round `x` to OCP FP6 E3M2 (max finite 28.0); `None` on overflow.
+pub fn f64_to_e3m2_bits(x: f64) -> Option<u8> {
+    f64_to_all_finite_bits(x, 3, 2)
+}
+/// Exact value of an E3M2 encoding (low 6 bits significant).
+pub fn e3m2_bits_to_f64(b: u8) -> f64 {
+    all_finite_bits_to_f64(b, 3, 2)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -634,5 +722,63 @@ mod e2m1_tests {
         // Sign is independent of magnitude selection.
         assert_eq!(f64_to_e2m1_bits(-2.5), Some(0xC));
         assert_eq!(f64_to_e2m1_bits(-5.0), Some(0xE));
+    }
+}
+
+#[cfg(test)]
+mod fp6_tests {
+    use super::*;
+
+    /// Both FP6 formats round-trip every encoding, and the value sets match
+    /// the OCP spec (E2M3 max 7.5, E3M2 max 28.0, both all-finite).
+    #[test]
+    fn fp6_round_trips_all_64_encodings() {
+        for (eb, mb, enc_f, dec_f, max) in [
+            (
+                2u32,
+                3u32,
+                f64_to_e2m3_bits as fn(f64) -> Option<u8>,
+                e2m3_bits_to_f64 as fn(u8) -> f64,
+                7.5f64,
+            ),
+            (
+                3,
+                2,
+                f64_to_e3m2_bits as fn(f64) -> Option<u8>,
+                e3m2_bits_to_f64 as fn(u8) -> f64,
+                28.0,
+            ),
+        ] {
+            let sign_bit: u8 = 1 << (eb + mb);
+            for enc in 0u8..sign_bit {
+                let v = dec_f(enc);
+                assert_eq!(enc_f(v), Some(enc), "eb{eb}mb{mb}: enc {enc:#X} value {v}");
+                // Negative counterpart keeps the magnitude, flips the sign.
+                assert_eq!(dec_f(enc | sign_bit), -v, "eb{eb}mb{mb}: -{v}");
+            }
+            // Max finite matches the spec exactly.
+            assert_eq!(dec_f(sign_bit - 1), max, "eb{eb}mb{mb}: max finite");
+            // -0.0 keeps its sign.
+            assert_eq!(enc_f(-0.0), Some(sign_bit));
+        }
+    }
+
+    /// Overflow is `None` (a compile error), never a silently wrong finite
+    /// value — the trap the generic IEEE template falls into for a format
+    /// whose top binade is entirely finite.
+    #[test]
+    fn fp6_overflow_is_none() {
+        // E2M3: max 7.5, top ulp 0.5, so the RNE midpoint is 7.75.
+        assert_eq!(f64_to_e2m3_bits(7.5), Some(0x1F));
+        assert_eq!(f64_to_e2m3_bits(7.7), Some(0x1F));
+        assert_eq!(f64_to_e2m3_bits(7.75), None, "at the RNE midpoint");
+        assert_eq!(f64_to_e2m3_bits(8.0), None);
+        assert_eq!(f64_to_e2m3_bits(f64::INFINITY), None);
+        assert_eq!(f64_to_e2m3_bits(f64::NAN), None, "FP6 has no NaN");
+        // E3M2: max 28.0, top ulp 4.0, so the midpoint is 30.0.
+        assert_eq!(f64_to_e3m2_bits(28.0), Some(0x1F));
+        assert_eq!(f64_to_e3m2_bits(29.0), Some(0x1F));
+        assert_eq!(f64_to_e3m2_bits(30.0), None, "at the RNE midpoint");
+        assert_eq!(f64_to_e3m2_bits(-30.0), None);
     }
 }

--- a/src/fp_ops.rs
+++ b/src/fp_ops.rs
@@ -529,6 +529,54 @@ fn f32_to_e2m1(p: FpCompat) -> FpFn {
     FpFn::new("arch_f32_to_e2m1", &[("x", 32)], 4, body)
 }
 
+// ── OCP MX FP6 E2M3 / E3M2 (storage-only) ────────────────────────────────
+// Same shape as FP4 E2M1: all-finite (no Inf, no NaN), conversions only.
+// Generic over the field split, since nothing here is format-specific once
+// TopBinade::AllFinite exists.
+
+fn fp6_to_f32(name: &str, eb: u32, mb: u32) -> FpFn {
+    let w = 1 + eb + mb;
+    let h = var("h", w);
+    let s = extract(&h, w - 1, w - 1);
+    let e = extract(&h, w - 2, mb);
+    let f = extract(&h, mb - 1, 0);
+    let e_z = eq(&e, &cst(0, eb));
+    let bias: u128 = (1u128 << (eb - 1)) - 1;
+    // value = sig * 2^e0 with sig = (e==0 ? 0f : 1f), an (mb+1)-bit integer:
+    //   normal    (e>=1): (2^mb + f) * 2^(e - bias - mb)
+    //   subnormal (e==0):          f * 2^(1 - bias - mb)
+    let sig = ite(&e_z, &concat(&cst(0, 1), &f), &concat(&cst(1, 1), &f));
+    let sig48 = zext(&sig, 48);
+    let sub_e0 = (1u128 << 16) - (bias + mb as u128 - 1); // 1 - bias - mb
+    let e0 = ite(
+        &e_z,
+        &cst(sub_e0, 16),
+        &sub(&zext(&e, 16), &cst(bias + mb as u128, 16)),
+    );
+    let widened = normround(&s, &sig48, &e0); // exact: <=4-bit significand
+    let zero32 = concat(&s, &cst(0, 31));
+    let body = ite(&eq(&sig, &cst(0, mb + 1)), &zero32, &widened);
+    FpFn::new(name, &[("h", w)], 32, body)
+}
+
+fn f32_to_fp6(name: &str, eb: u32, mb: u32) -> FpFn {
+    let w = 1 + eb + mb;
+    let x = var("x", 32);
+    let d = decode(&x);
+    let s = &d.sign;
+    let maxmag = (1u128 << (w - 1)) - 1;
+    let max6 = concat(s, &cst(maxmag, w - 1));
+    // No NaN and no Inf exist, so both --fp-compat profiles saturate.
+    let rounded = fp8_round(eb, mb, TopBinade::AllFinite, s, &d.mant, &d.eunb, &max6);
+    let zero = concat(s, &cst(0, w - 1));
+    let body = ite(
+        &or(&d.is_nan, &d.is_inf),
+        &max6,
+        &ite(&d.is_zero, &zero, &rounded),
+    );
+    FpFn::new(name, &[("x", 32)], w, body)
+}
+
 fn f32_to_e4m3(p: FpCompat) -> FpFn {
     let x = var("x", 32);
     let d = decode(&x);
@@ -1129,6 +1177,10 @@ pub fn fp_functions(p: FpCompat) -> Vec<FpFn> {
     // Storage-only: widen/narrow only, no arithmetic wrappers.
     v.push(e2m1_to_f32());
     v.push(f32_to_e2m1(p));
+    v.push(fp6_to_f32("arch_e2m3_to_f32", 2, 3));
+    v.push(f32_to_fp6("arch_f32_to_e2m3", 2, 3));
+    v.push(fp6_to_f32("arch_e3m2_to_f32", 3, 2));
+    v.push(f32_to_fp6("arch_f32_to_e3m2", 3, 2));
     for (tag, widen, narrow) in [
         ("e5m2", "arch_e5m2_to_f32", "arch_f32_to_e5m2"),
         ("e4m3", "arch_e4m3_to_f32", "arch_f32_to_e4m3"),
@@ -1454,5 +1506,77 @@ mod e2m1_ir_tests {
             let back = call1(&fns, "arch_f32_to_e2m1", f32b, 32, 4);
             assert_eq!(back, enc, "round-trip failed for {enc:#X}");
         }
+    }
+}
+
+#[cfg(test)]
+mod fp6_ir_tests {
+    use super::*;
+    use crate::fp_ir::{cst, eval_bv};
+    use std::collections::HashMap;
+
+    fn call1(fns: &[FpFn], name: &str, arg: u128, aw: u32, rw: u32) -> u128 {
+        let node = crate::fp_ir::call(name, &[cst(arg, aw)], rw);
+        eval_bv(&node, &HashMap::new(), fns).expect("FP6 helpers must be decidable")
+    }
+
+    /// Both FP6 formats: the IR widen must agree with `fp_lit`'s independent
+    /// reference on every one of the 64 encodings, and widen∘narrow must be
+    /// the identity. Two separate implementations — a bit-vector DAG and a
+    /// Rust table — so agreement is evidence, not tautology.
+    #[test]
+    fn fp6_ir_matches_reference_and_round_trips() {
+        let fns = fp_functions(crate::FpCompat::default());
+        for (widen, narrow, dec, max_enc) in [
+            (
+                "arch_e2m3_to_f32",
+                "arch_f32_to_e2m3",
+                crate::fp_lit::e2m3_bits_to_f64 as fn(u8) -> f64,
+                0x3Fu128,
+            ),
+            (
+                "arch_e3m2_to_f32",
+                "arch_f32_to_e3m2",
+                crate::fp_lit::e3m2_bits_to_f64 as fn(u8) -> f64,
+                0x3F,
+            ),
+        ] {
+            for enc in 0..=max_enc {
+                let got = call1(&fns, widen, enc, 6, 32) as u32;
+                let want = dec(enc as u8) as f32;
+                assert_eq!(
+                    f32::from_bits(got),
+                    want,
+                    "{widen}({enc:#X}) = {} want {want}",
+                    f32::from_bits(got)
+                );
+                // widen -> narrow is the identity.
+                let back = call1(&fns, narrow, got as u128, 32, 6);
+                assert_eq!(back, enc, "{narrow} round-trip failed for {enc:#X}");
+            }
+            // -0.0 keeps its sign through the widen.
+            assert_eq!(call1(&fns, widen, 0x20, 6, 32), 0x8000_0000);
+        }
+    }
+
+    /// The top binade is FINITE in both formats — under the IEEE rule its
+    /// largest values would be treated as overflow. Runtime narrowing
+    /// saturates, since neither format has a NaN or an infinity.
+    #[test]
+    fn fp6_top_binade_is_finite_and_overflow_saturates() {
+        let fns = fp_functions(crate::FpCompat::default());
+        let nar = |n: &str, v: f32| call1(&fns, n, v.to_bits() as u128, 32, 6) as u8;
+        // E2M3 max 7.5, E3M2 max 28.0 — both must narrow to the max code.
+        assert_eq!(nar("arch_f32_to_e2m3", 7.5), 0x1F);
+        assert_eq!(nar("arch_f32_to_e3m2", 28.0), 0x1F);
+        // Saturation, not Inf/NaN.
+        assert_eq!(nar("arch_f32_to_e2m3", 1e30), 0x1F);
+        assert_eq!(nar("arch_f32_to_e3m2", 1e30), 0x1F);
+        assert_eq!(nar("arch_f32_to_e2m3", f32::INFINITY), 0x1F);
+        assert_eq!(nar("arch_f32_to_e2m3", f32::NAN), 0x1F);
+        assert_eq!(nar("arch_f32_to_e3m2", -1e30), 0x3F, "sign preserved");
+        // Underflow flushes to a signed zero.
+        assert_eq!(nar("arch_f32_to_e2m3", 1e-30), 0x00);
+        assert_eq!(nar("arch_f32_to_e2m3", -1e-30), 0x20);
     }
 }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -2031,7 +2031,9 @@ impl Builder {
             | TypeExpr::BF16
             | TypeExpr::FP8E4M3
             | TypeExpr::FP8E5M2
-            | TypeExpr::FP4E2M1 => {}
+            | TypeExpr::FP4E2M1
+            | TypeExpr::FP6E2M3
+            | TypeExpr::FP6E3M2 => {}
             TypeExpr::Vec(inner, n) => {
                 self.walk_type(owner, scope, inner, span);
                 let rel = self.rel_for_span(n.span);

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -578,6 +578,8 @@ fn type_str(ty: &TypeExpr) -> String {
         TypeExpr::FP8E4M3 => "FP8E4M3".to_string(),
         TypeExpr::FP8E5M2 => "FP8E5M2".to_string(),
         TypeExpr::FP4E2M1 => "FP4E2M1".to_string(),
+        TypeExpr::FP6E2M3 => "FP6E2M3".to_string(),
+        TypeExpr::FP6E3M2 => "FP6E3M2".to_string(),
         TypeExpr::Clock(domain) => format!("Clock<{}>", domain.name),
         TypeExpr::Reset(kind, level) => {
             let k = match kind {
@@ -625,6 +627,8 @@ pub(crate) fn expr_str(expr: &Expr) -> String {
                     FloatLitFmt::E4m3 => crate::fp_lit::e4m3_bits_to_f64(*bits as u8),
                     FloatLitFmt::E5m2 => crate::fp_lit::e5m2_bits_to_f64(*bits as u8),
                     FloatLitFmt::E2m1 => crate::fp_lit::e2m1_bits_to_f64(*bits as u8),
+                    FloatLitFmt::E2m3 => crate::fp_lit::e2m3_bits_to_f64(*bits as u8),
+                    FloatLitFmt::E3m2 => crate::fp_lit::e3m2_bits_to_f64(*bits as u8),
                 };
                 if v.fract() == 0.0 {
                     format!("{v:.1}")

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -283,6 +283,10 @@ pub enum TokenKind {
     FP8E5M2,
     #[token("FP4E2M1")]
     FP4E2M1,
+    #[token("FP6E2M3")]
+    FP6E2M3,
+    #[token("FP6E3M2")]
+    FP6E3M2,
 
     // Operators and punctuation
     #[token("+:")]
@@ -522,6 +526,8 @@ impl fmt::Display for TokenKind {
             TokenKind::FP8E4M3 => write!(f, "FP8E4M3"),
             TokenKind::FP8E5M2 => write!(f, "FP8E5M2"),
             TokenKind::FP4E2M1 => write!(f, "FP4E2M1"),
+            TokenKind::FP6E2M3 => write!(f, "FP6E2M3"),
+            TokenKind::FP6E3M2 => write!(f, "FP6E3M2"),
             TokenKind::Plus => write!(f, "+"),
             TokenKind::Minus => write!(f, "-"),
             TokenKind::Star => write!(f, "*"),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1351,6 +1351,8 @@ impl Parser {
                     | TokenKind::FP8E4M3
                     | TokenKind::FP8E5M2
                     | TokenKind::FP4E2M1
+                    | TokenKind::FP6E2M3
+                    | TokenKind::FP6E3M2
             )
         ) {
             // Logic-typed value const: `param NAME: UInt<W> = <default>;`
@@ -4193,6 +4195,14 @@ impl Parser {
             Some(TokenKind::FP8E4M3) => {
                 self.advance();
                 Ok(TypeExpr::FP8E4M3)
+            }
+            Some(TokenKind::FP6E2M3) => {
+                self.advance();
+                Ok(TypeExpr::FP6E2M3)
+            }
+            Some(TokenKind::FP6E3M2) => {
+                self.advance();
+                Ok(TypeExpr::FP6E3M2)
             }
             Some(TokenKind::FP4E2M1) => {
                 self.advance();

--- a/src/sim_codegen/const_eval.rs
+++ b/src/sim_codegen/const_eval.rs
@@ -213,6 +213,8 @@ pub(super) fn try_eval_fp_const_expr_with_params_seen(
                 crate::ast::FloatLitFmt::E4m3 => Some(crate::fp_lit::e4m3_bits_to_f64(*bits as u8)),
                 crate::ast::FloatLitFmt::E5m2 => Some(crate::fp_lit::e5m2_bits_to_f64(*bits as u8)),
                 crate::ast::FloatLitFmt::E2m1 => Some(crate::fp_lit::e2m1_bits_to_f64(*bits as u8)),
+                crate::ast::FloatLitFmt::E2m3 => Some(crate::fp_lit::e2m3_bits_to_f64(*bits as u8)),
+                crate::ast::FloatLitFmt::E3m2 => Some(crate::fp_lit::e3m2_bits_to_f64(*bits as u8)),
             }
         }
         ExprKind::Ident(name) => {

--- a/src/sim_codegen/expr_codegen.rs
+++ b/src/sim_codegen/expr_codegen.rs
@@ -630,6 +630,8 @@ pub(super) enum FpFmt {
     E4m3,
     E5m2,
     E2m1,
+    E2m3,
+    E3m2,
 }
 
 impl FpFmt {
@@ -641,6 +643,8 @@ impl FpFmt {
             FpFmt::E4m3 => "e4m3",
             FpFmt::E5m2 => "e5m2",
             FpFmt::E2m1 => "e2m1",
+            FpFmt::E2m3 => "e2m3",
+            FpFmt::E3m2 => "e3m2",
         }
     }
 }
@@ -1654,6 +1658,8 @@ pub(super) fn cpp_method_call(base: &Expr, method: &Ident, args: &[Expr], ctx: &
             Some(FpFmt::E4m3) => format!("_arch_e4m3_to_f32({b})"),
             Some(FpFmt::E5m2) => format!("_arch_e5m2_to_f32({b})"),
             Some(FpFmt::E2m1) => format!("_arch_e2m1_to_f32({b})"),
+            Some(FpFmt::E2m3) => format!("_arch_e2m3_to_f32({b})"),
+            Some(FpFmt::E3m2) => format!("_arch_e3m2_to_f32({b})"),
             Some(FpFmt::Fp32) => b, // no-op (typecheck rejects, but stay total)
             None => {
                 if infer_expr_signed(base, ctx) {
@@ -1671,6 +1677,8 @@ pub(super) fn cpp_method_call(base: &Expr, method: &Ident, args: &[Expr], ctx: &
             Some(FpFmt::E4m3) => format!("_arch_f32_to_bf16(_arch_e4m3_to_f32({b}))"),
             Some(FpFmt::E5m2) => format!("_arch_f32_to_bf16(_arch_e5m2_to_f32({b}))"),
             Some(FpFmt::E2m1) => format!("_arch_f32_to_bf16(_arch_e2m1_to_f32({b}))"),
+            Some(FpFmt::E2m3) => format!("_arch_f32_to_bf16(_arch_e2m3_to_f32({b}))"),
+            Some(FpFmt::E3m2) => format!("_arch_f32_to_bf16(_arch_e3m2_to_f32({b}))"),
             None => {
                 if infer_expr_signed(base, ctx) {
                     format!("_arch_i_to_bf16((int64_t)({b}))")
@@ -1686,6 +1694,8 @@ pub(super) fn cpp_method_call(base: &Expr, method: &Ident, args: &[Expr], ctx: &
             Some(FpFmt::Bf16) => format!("_arch_f32_to_e4m3(_arch_bf16_to_f32({b}))"),
             Some(FpFmt::E5m2) => format!("_arch_f32_to_e4m3(_arch_e5m2_to_f32({b}))"),
             Some(FpFmt::E2m1) => format!("_arch_f32_to_e4m3(_arch_e2m1_to_f32({b}))"),
+            Some(FpFmt::E2m3) => format!("_arch_f32_to_e4m3(_arch_e2m3_to_f32({b}))"),
+            Some(FpFmt::E3m2) => format!("_arch_f32_to_e4m3(_arch_e3m2_to_f32({b}))"),
             // Integers: exact in f32 across the fp8-relevant range, so the
             // single fp8 rounding is correctly rounded.
             None => {
@@ -1702,6 +1712,8 @@ pub(super) fn cpp_method_call(base: &Expr, method: &Ident, args: &[Expr], ctx: &
             Some(FpFmt::Bf16) => format!("_arch_f32_to_e5m2(_arch_bf16_to_f32({b}))"),
             Some(FpFmt::E4m3) => format!("_arch_f32_to_e5m2(_arch_e4m3_to_f32({b}))"),
             Some(FpFmt::E2m1) => format!("_arch_f32_to_e5m2(_arch_e2m1_to_f32({b}))"),
+            Some(FpFmt::E2m3) => format!("_arch_f32_to_e5m2(_arch_e2m3_to_f32({b}))"),
+            Some(FpFmt::E3m2) => format!("_arch_f32_to_e5m2(_arch_e3m2_to_f32({b}))"),
             None => {
                 if infer_expr_signed(base, ctx) {
                     format!("_arch_f32_to_e5m2(_arch_i_to_f32((int64_t)({b})))")

--- a/src/sim_codegen/pipeline.rs
+++ b/src/sim_codegen/pipeline.rs
@@ -1324,6 +1324,8 @@ impl<'a> SimCodegen<'a> {
                 FloatLitFmt::E4m3 => FpFmt::E4m3,
                 FloatLitFmt::E5m2 => FpFmt::E5m2,
                 FloatLitFmt::E2m1 => FpFmt::E2m1,
+                FloatLitFmt::E2m3 => FpFmt::E2m3,
+                FloatLitFmt::E3m2 => FpFmt::E3m2,
             }),
             ExprKind::Literal(LitKind::Float(_)) => Some(FpFmt::Fp32),
             ExprKind::Binary(op, l, r) => match op {

--- a/src/sim_codegen/pybind.rs
+++ b/src/sim_codegen/pybind.rs
@@ -657,6 +657,7 @@ PYBIND11_MODULE({pybind_module}, m) {{
             TypeExpr::BF16 => 16,
             TypeExpr::FP8E4M3 | TypeExpr::FP8E5M2 => 8,
             TypeExpr::FP4E2M1 => 4,
+            TypeExpr::FP6E2M3 | TypeExpr::FP6E3M2 => 6,
             TypeExpr::Named(_) => 32,
             TypeExpr::Vec(_, _) => 32,
         }
@@ -1073,6 +1074,43 @@ static inline uint8_t _arch_f32_to_e2m1(uint32_t x){
   }
   return (uint8_t)(sgn | (uint8_t)best);
 }
+// ── OCP MX FP6 E2M3 / E3M2 (storage-only) ──
+// Same shape as E2M1: all-finite, so overflow saturates under BOTH
+// --fp-compat profiles. Generic over the field split; mirrors
+// fp_lit::f64_to_all_finite_bits exactly.
+static inline float _arch_fp6_mag(int idx, int eb, int mb){
+  int bias = (1 << (eb - 1)) - 1;
+  int mant_n = 1 << mb;
+  int e = idx / mant_n, m = idx % mant_n;
+  if (e == 0) return (float)(ldexp(1.0, 1 - bias) * ((double)m / mant_n));
+  return (float)(ldexp(1.0, e - bias) * (1.0 + (double)m / mant_n));
+}
+static inline float _arch_fp6f(uint8_t b, int eb, int mb){
+  int sign_bit = 1 << (eb + mb);
+  float m = _arch_fp6_mag(b & (sign_bit - 1), eb, mb);
+  return (b & sign_bit) ? -m : m;
+}
+static inline uint8_t _arch_f32_to_fp6(uint32_t x, int eb, int mb){
+  int sign_bit = 1 << (eb + mb);
+  int n = sign_bit;
+  float f = _arch_f32b(x);
+  uint8_t sgn = (uint8_t)((x>>31) ? sign_bit : 0);
+  float maxf = _arch_fp6_mag(n - 1, eb, mb);
+  float top_ulp = maxf - _arch_fp6_mag(n - 2, eb, mb);
+  if (std::isnan(f)) return (uint8_t)(sgn | (n - 1));
+  float a = fabsf(f);
+  if (a >= maxf + top_ulp / 2.0f) return (uint8_t)(sgn | (n - 1));
+  int best = 0; float best_err = 1e30f;
+  for (int i = 0; i < n; i++) {
+    float e = fabsf(a - _arch_fp6_mag(i, eb, mb));
+    if (e < best_err || (e == best_err && (i & 1) == 0)) { best = i; best_err = e; }
+  }
+  return (uint8_t)(sgn | (uint8_t)best);
+}
+static inline uint32_t _arch_e2m3_to_f32(uint8_t b){ return _arch_b32f(_arch_fp6f(b,2,3)); }
+static inline uint32_t _arch_e3m2_to_f32(uint8_t b){ return _arch_b32f(_arch_fp6f(b,3,2)); }
+static inline uint8_t _arch_f32_to_e2m3(uint32_t x){ return _arch_f32_to_fp6(x,2,3); }
+static inline uint8_t _arch_f32_to_e3m2(uint32_t x){ return _arch_f32_to_fp6(x,3,2); }
 static inline uint8_t _arch_f32_to_e5m2(uint32_t x){ return _arch_f32_to_fp8(x,5,2,0,0x7Cu,1,0x7Eu); }
 static inline uint8_t _arch_f32_to_e4m3(uint32_t x){ return _arch_f32_to_fp8(x,4,3,1,0x7Fu,0,0x7Fu); }
 static inline uint8_t _arch_e5m2_add(uint8_t a,uint8_t b){ return _arch_f32_to_e5m2(_arch_b32f(_arch_e5m2f(a)+_arch_e5m2f(b))); }

--- a/src/sim_codegen/width.rs
+++ b/src/sim_codegen/width.rs
@@ -137,7 +137,11 @@ pub(super) fn cpp_port_type_with_params(ty: &TypeExpr, params: &[ParamDecl]) -> 
         // `_arch_fp.h` helpers, never C++ float operators on the storage.
         TypeExpr::FP32 => "uint32_t".to_string(),
         TypeExpr::BF16 => "uint16_t".to_string(),
-        TypeExpr::FP8E4M3 | TypeExpr::FP8E5M2 | TypeExpr::FP4E2M1 => "uint8_t".to_string(),
+        TypeExpr::FP8E4M3
+        | TypeExpr::FP8E5M2
+        | TypeExpr::FP4E2M1
+        | TypeExpr::FP6E2M3
+        | TypeExpr::FP6E3M2 => "uint8_t".to_string(),
         TypeExpr::Named(n) => n.name.clone(),
         TypeExpr::Vec(_, _) => "uint32_t".to_string(),
     }
@@ -199,7 +203,11 @@ pub(super) fn cpp_internal_type_with_params(ty: &TypeExpr, params: &[ParamDecl])
         }
         TypeExpr::FP32 => "uint32_t".to_string(),
         TypeExpr::BF16 => "uint16_t".to_string(),
-        TypeExpr::FP8E4M3 | TypeExpr::FP8E5M2 | TypeExpr::FP4E2M1 => "uint8_t".to_string(),
+        TypeExpr::FP8E4M3
+        | TypeExpr::FP8E5M2
+        | TypeExpr::FP4E2M1
+        | TypeExpr::FP6E2M3
+        | TypeExpr::FP6E3M2 => "uint8_t".to_string(),
         TypeExpr::Named(n) => n.name.clone(),
         TypeExpr::Vec(_, _) => "uint32_t".to_string(),
     }
@@ -324,6 +332,7 @@ pub(super) fn type_width_of(ty: &TypeExpr) -> u32 {
         TypeExpr::BF16 => 16,
         TypeExpr::FP8E4M3 | TypeExpr::FP8E5M2 => 8,
         TypeExpr::FP4E2M1 => 4,
+        TypeExpr::FP6E2M3 | TypeExpr::FP6E3M2 => 6,
         TypeExpr::Vec(..) | TypeExpr::Named(_) => 0,
     }
 }
@@ -461,5 +470,7 @@ pub(super) fn type_float_fmt(ty: &TypeExpr) -> Option<FpFmt> {
         crate::fp_format::FpFormatId::E4m3 => FpFmt::E4m3,
         crate::fp_format::FpFormatId::E5m2 => FpFmt::E5m2,
         crate::fp_format::FpFormatId::E2m1 => FpFmt::E2m1,
+        crate::fp_format::FpFormatId::E2m3 => FpFmt::E2m3,
+        crate::fp_format::FpFormatId::E3m2 => FpFmt::E3m2,
     })
 }

--- a/src/thread_map.rs
+++ b/src/thread_map.rs
@@ -977,9 +977,10 @@ fn lit_label(lit: &LitKind) -> String {
                 FloatLitFmt::Fp32 => f32::from_bits(*bits as u32) as f64,
                 FloatLitFmt::Bf16 => f32::from_bits((*bits as u32) << 16) as f64,
                 FloatLitFmt::E4m3 => crate::fp_lit::e4m3_bits_to_f64(*bits as u8),
-                FloatLitFmt::E5m2 | crate::ast::FloatLitFmt::E2m1 => {
-                    crate::fp_lit::e5m2_bits_to_f64(*bits as u8)
-                }
+                FloatLitFmt::E5m2
+                | crate::ast::FloatLitFmt::E2m1
+                | crate::ast::FloatLitFmt::E2m3
+                | crate::ast::FloatLitFmt::E3m2 => crate::fp_lit::e5m2_bits_to_f64(*bits as u8),
             };
             v.to_string()
         }

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -20,6 +20,8 @@ pub enum Ty {
     /// FP8 E5M2 (1+5+2 = 8 bits): IEEE-style (5,3) with infinities.
     FP8E5M2,
     FP4E2M1,
+    FP6E2M3,
+    FP6E3M2,
     Clock(String),                // domain name
     Reset(ResetKind, ResetLevel), // always concrete (Param resolved during elaboration)
     Vec(Box<Ty>, u32),
@@ -39,7 +41,13 @@ impl Ty {
     pub fn is_float(&self) -> bool {
         matches!(
             self,
-            Ty::FP32 | Ty::BF16 | Ty::FP8E4M3 | Ty::FP8E5M2 | Ty::FP4E2M1
+            Ty::FP32
+                | Ty::BF16
+                | Ty::FP8E4M3
+                | Ty::FP8E5M2
+                | Ty::FP4E2M1
+                | Ty::FP6E2M3
+                | Ty::FP6E3M2
         )
     }
 
@@ -64,6 +72,8 @@ impl Ty {
             Ty::FP8E4M3 => crate::fp_format::by_id(crate::fp_format::FpFormatId::E4m3).arith,
             Ty::FP8E5M2 => crate::fp_format::by_id(crate::fp_format::FpFormatId::E5m2).arith,
             Ty::FP4E2M1 => crate::fp_format::by_id(crate::fp_format::FpFormatId::E2m1).arith,
+            Ty::FP6E2M3 => crate::fp_format::by_id(crate::fp_format::FpFormatId::E2m3).arith,
+            Ty::FP6E3M2 => crate::fp_format::by_id(crate::fp_format::FpFormatId::E3m2).arith,
             _ => false,
         }
     }
@@ -101,6 +111,7 @@ impl Ty {
             Ty::BF16 => Some(16),
             Ty::FP8E4M3 | Ty::FP8E5M2 => Some(8),
             Ty::FP4E2M1 => Some(4),
+            Ty::FP6E2M3 | Ty::FP6E3M2 => Some(6),
             Ty::Enum(_, w) => Some(*w),
             Ty::Vec(inner, count) => inner.width().map(|w| w * count),
             Ty::Struct(_) | Ty::Bus(_) => None,
@@ -119,6 +130,8 @@ impl Ty {
             Ty::FP8E4M3 => "FP8E4M3".to_string(),
             Ty::FP8E5M2 => "FP8E5M2".to_string(),
             Ty::FP4E2M1 => "FP4E2M1".to_string(),
+            Ty::FP6E2M3 => "FP6E2M3".to_string(),
+            Ty::FP6E3M2 => "FP6E3M2".to_string(),
             Ty::Clock(d) => format!("Clock<{d}>"),
             Ty::Reset(k, l) => format!(
                 "Reset<{}, {}>",
@@ -2816,6 +2829,7 @@ impl<'a> TypeChecker<'a> {
             Ty::BF16 => Some(16),
             Ty::FP8E4M3 | Ty::FP8E5M2 => Some(8),
             Ty::FP4E2M1 => Some(4),
+            Ty::FP6E2M3 | Ty::FP6E3M2 => Some(6),
             Ty::Enum(_, w) => Some(*w),
             Ty::Vec(inner, count) => self.type_total_width(inner).map(|w| w * count),
             Ty::Struct(name) => {
@@ -2846,6 +2860,7 @@ impl<'a> TypeChecker<'a> {
             TypeExpr::BF16 => Some(16),
             TypeExpr::FP8E4M3 | TypeExpr::FP8E5M2 => Some(8),
             TypeExpr::FP4E2M1 => Some(4),
+            TypeExpr::FP6E2M3 | TypeExpr::FP6E3M2 => Some(6),
             TypeExpr::Vec(inner, size) => {
                 let iw = self.type_expr_width(inner)?;
                 let n = eval_type_width_expr(size)?;
@@ -3640,6 +3655,8 @@ impl<'a> TypeChecker<'a> {
             TypeExpr::FP8E4M3 => Ty::FP8E4M3,
             TypeExpr::FP8E5M2 => Ty::FP8E5M2,
             TypeExpr::FP4E2M1 => Ty::FP4E2M1,
+            TypeExpr::FP6E2M3 => Ty::FP6E2M3,
+            TypeExpr::FP6E3M2 => Ty::FP6E3M2,
             TypeExpr::Clock(domain) => Ty::Clock(domain.name.clone()),
             TypeExpr::Reset(kind, level) => Ty::Reset(*kind, *level),
             TypeExpr::Vec(inner, size_expr) => {
@@ -3900,6 +3917,8 @@ impl<'a> TypeChecker<'a> {
             Ty::FP8E4M3 => "FP8E4M3",
             Ty::FP8E5M2 => "FP8E5M2",
             Ty::FP4E2M1 => "FP4E2M1",
+            Ty::FP6E2M3 => "FP6E2M3",
+            Ty::FP6E3M2 => "FP6E3M2",
             _ => unreachable!("is_float() covers exactly the float Tys above"),
         };
         match crate::pipelined_ops::lookup(name, profile, stages) {
@@ -4070,6 +4089,8 @@ impl<'a> TypeChecker<'a> {
                 LitKind::TypedFloat(FloatLitFmt::Fp32, _) => Ty::FP32,
                 LitKind::TypedFloat(FloatLitFmt::Bf16, _) => Ty::BF16,
                 LitKind::TypedFloat(FloatLitFmt::E2m1, _) => Ty::FP4E2M1,
+                LitKind::TypedFloat(FloatLitFmt::E2m3, _) => Ty::FP6E2M3,
+                LitKind::TypedFloat(FloatLitFmt::E3m2, _) => Ty::FP6E3M2,
                 LitKind::TypedFloat(FloatLitFmt::E4m3, _) => Ty::FP8E4M3,
                 LitKind::TypedFloat(FloatLitFmt::E5m2, _) => Ty::FP8E5M2,
             },
@@ -4882,7 +4903,10 @@ impl<'a> TypeChecker<'a> {
                 // FP4E2M1 joins the same family: widening to f32 is exact
                 // (a 2-bit significand fits trivially), and E2M1 -> bf16 is
                 // exact for the same reason the fp8 cases are.
-                if matches!(base_ty, Ty::FP8E4M3 | Ty::FP8E5M2 | Ty::FP4E2M1) {
+                if matches!(
+                    base_ty,
+                    Ty::FP8E4M3 | Ty::FP8E5M2 | Ty::FP4E2M1 | Ty::FP6E2M3 | Ty::FP6E3M2
+                ) {
                     return target;
                 }
                 match &base_ty {
@@ -4922,10 +4946,12 @@ impl<'a> TypeChecker<'a> {
             // overflow applies (riscv non-saturating / cuda satfinite).
             // Cross-fp8 (e4m3 <-> e5m2) also composes exactly: the widen is
             // exact, one narrow rounds.
-            "to_fp8e4m3" | "to_fp8e5m2" | "to_fp4e2m1" => {
+            "to_fp8e4m3" | "to_fp8e5m2" | "to_fp4e2m1" | "to_fp6e2m3" | "to_fp6e3m2" => {
                 let target = match method.name.as_str() {
                     "to_fp8e4m3" => Ty::FP8E4M3,
                     "to_fp4e2m1" => Ty::FP4E2M1,
+                    "to_fp6e2m3" => Ty::FP6E2M3,
+                    "to_fp6e3m2" => Ty::FP6E3M2,
                     _ => Ty::FP8E5M2,
                 };
                 match &base_ty {
@@ -4945,6 +4971,8 @@ impl<'a> TypeChecker<'a> {
                     | Ty::FP8E4M3
                     | Ty::FP8E5M2
                     | Ty::FP4E2M1
+                    | Ty::FP6E2M3
+                    | Ty::FP6E3M2
                     | Ty::UInt(_)
                     | Ty::SInt(_)
                     | Ty::Bool => target,

--- a/tests/fp_test.rs
+++ b/tests/fp_test.rs
@@ -2111,3 +2111,110 @@ fn fp4_overflowing_literal_is_a_compile_error() {
     );
     assert!(ok, "1.5 is exactly representable in E2M1:\n{out}");
 }
+
+// ── FP6 E2M3 / E3M2 — storage-only, same contract as FP4E2M1 ────────────
+
+/// The FP6 conversion surface works, and SV lowers to the proven helpers
+/// rather than the integer path.
+#[test]
+fn fp6_conversion_surface_checks_and_builds() {
+    let out = arch()
+        .arg("check")
+        .arg("tests/fp_v1/Fp6Convert.arch")
+        .output()
+        .expect("run arch check");
+    assert!(
+        out.status.success(),
+        "Fp6Convert.arch should check\n{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let dir = std::env::temp_dir().join("arch_fp6_build");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).expect("mkdir");
+    let sv_path = dir.join("Fp6Convert.sv");
+    let out = arch()
+        .arg("build")
+        .arg("tests/fp_v1/Fp6Convert.arch")
+        .arg("-o")
+        .arg(&sv_path)
+        .output()
+        .expect("run arch build");
+    assert!(out.status.success(), "build failed: {out:?}");
+    let sv = std::fs::read_to_string(&sv_path).expect("emitted SV");
+    for helper in [
+        "arch_e2m3_to_f32(",
+        "arch_e3m2_to_f32(",
+        "arch_f32_to_e2m3(",
+        "arch_f32_to_e3m2(",
+    ] {
+        assert!(sv.contains(helper), "SV must use {helper}:\n{sv}");
+    }
+    assert!(
+        !sv.contains("to_fp6e2m3()") && !sv.contains("to_fp6e3m2()"),
+        "ARCH method syntax must not leak into SV:\n{sv}"
+    );
+    assert!(sv.contains("logic [5:0]"), "FP6 is a 6-bit carrier:\n{sv}");
+}
+
+/// Arithmetic and `is_nan` are rejected for both FP6 formats, with the same
+/// storage-only reasoning as FP4E2M1.
+#[test]
+fn fp6_arithmetic_and_is_nan_are_rejected() {
+    for ty in ["FP6E2M3", "FP6E3M2"] {
+        let (ok, out) = check_src(
+            &format!("fp6_arith_{ty}"),
+            &format!(
+                "module A\n  port a: in {ty};\n  port b: in {ty};\n  \
+                 port y: out {ty};\n  comb y = a + b; end comb\nend module A\n"
+            ),
+        );
+        assert!(!ok, "{ty}: `+` must be rejected:\n{out}");
+        assert!(
+            out.contains("storage-only float format"),
+            "{ty}: message should name the storage-only rule:\n{out}"
+        );
+
+        let (ok, out) = check_src(
+            &format!("fp6_isnan_{ty}"),
+            &format!(
+                "module A\n  port a: in {ty};\n  port y: out Bool;\n  \
+                 comb y = is_nan(a); end comb\nend module A\n"
+            ),
+        );
+        assert!(!ok, "{ty}: is_nan must be rejected:\n{out}");
+        assert!(
+            out.contains("no NaN encoding"),
+            "{ty}: reason must be the missing encoding:\n{out}"
+        );
+    }
+}
+
+/// Overflowing literals are compile errors at each format's own bound —
+/// the generic IEEE rounder would have produced a silently wrong finite.
+#[test]
+fn fp6_overflowing_literals_are_compile_errors() {
+    // E2M3 max 7.5 (RNE midpoint 7.75); E3M2 max 28.0 (midpoint 30.0).
+    for (ty, ok_lit, bad_lit) in [("FP6E2M3", "7.5", "8.0"), ("FP6E3M2", "28.0", "32.0")] {
+        let (ok, out) = check_src(
+            &format!("fp6_lit_bad_{ty}"),
+            &format!(
+                "module A\n  port y: out {ty};\n  comb y = {bad_lit}; end comb\nend module A\n"
+            ),
+        );
+        assert!(!ok, "{ty}: {bad_lit} overflows:\n{out}");
+        assert!(
+            out.contains(ty),
+            "{ty}: diagnostic should name the format:\n{out}"
+        );
+
+        let (ok, out) = check_src(
+            &format!("fp6_lit_ok_{ty}"),
+            &format!(
+                "module A\n  port y: out {ty};\n  comb y = {ok_lit}; end comb\nend module A\n"
+            ),
+        );
+        assert!(ok, "{ty}: {ok_lit} is exactly representable:\n{out}");
+    }
+}

--- a/tests/fp_v1/Fp6Convert.arch
+++ b/tests/fp_v1/Fp6Convert.arch
@@ -1,0 +1,28 @@
+// OCP MX FP6 (E2M3 and E3M2) — storage-only, same contract as FP4E2M1.
+//
+// E2M3: 1+2+3, bias 1, max finite 7.5.  E3M2: 1+3+2, bias 3, max 28.0.
+// Both are all-finite (no Inf, no NaN), so they carry conversions and
+// literals only; arithmetic and `is_nan` are compile errors and the value
+// must be widened to FP32 to compute.
+module Fp6Convert
+  port a: in FP6E2M3;
+  port b: in FP6E3M2;
+  port s: in FP32;
+
+  port wide_a: out FP32;
+  port wide_b: out FP32;
+  port narrow_a: out FP6E2M3;
+  port cross:    out FP6E3M2;   // E2M3 -> FP32 -> E3M2
+  port lit:      out FP6E2M3;
+
+  let av: FP32 = a.to_fp32();
+  let bv: FP32 = b.to_fp32();
+
+  comb
+    wide_a   = av;
+    wide_b   = bv;
+    narrow_a = s.to_fp6e2m3();
+    cross    = av.to_fp6e3m2();
+    lit      = 7.5;              // exactly the E2M3 max finite
+  end comb
+end module Fp6Convert


### PR DESCRIPTION
Part of [#837](https://github.com/arch-hdl-lang/arch-com/issues/837) (Phase 1 remainder). Completes the sub-8-bit OCP MX element set alongside FP4E2M1 ([#836](https://github.com/arch-hdl-lang/arch-com/pull/836)).

| Type | S/E/M | Bias | Max finite | Min subnormal |
|---|---|---|---|---|
| `FP6E2M3` | 1/2/3 | 1 | 7.5 | 0.125 |
| `FP6E3M2` | 1/3/2 | 3 | 28.0 | 0.0625 |

Both are **all-finite** — no Inf, no NaN — so they carry the same storage-only contract as FP4E2M1: conversions and literals only, with arithmetic and `is_nan` rejected as spanned compile errors via the `is_float`/`is_float_arith` split.

## Mostly mechanical — which is the point

This is the payoff from the Phase 0 table ([#830](https://github.com/arch-hdl-lang/arch-com/pull/830)): the format table drove dispatch, `TopBinade::AllFinite` already existed from FP4, and **the compiler enumerated all 26 sites** needing arms rather than letting any land silently.

Two pieces I generalized rather than copy-pasted:

- **`f64_to_all_finite_bits(x, exp_bits, mant_bits)`** — one literal encoder for any all-finite OCP format. It *derives* the magnitude set and the overflow boundary (the RNE midpoint between max-finite and the next would-be value), so E2M3 overflows at 7.75 and E3M2 at 30.0 by computation, not tabulation. `round_f64_to_narrow` still can't serve these: its IEEE template treats an all-ones exponent as overflow-to-infinity, but here that binade is entirely finite.
- **`fp6_to_f32` / `f32_to_fp6`** — generic IR over `(eb, mb)`; nothing is format-specific once the all-finite rule exists.

## Verification

- **All 128 encodings** of both formats round-trip against `fp_lit`'s **independent** reference — a bit-vector DAG versus a Rust table, so agreement is evidence rather than tautology.
- The top binade stays **finite**: under the IEEE rule, 7.5 and 28.0 would have been treated as overflow.
- SV emits `logic [5:0]` with the proven helpers; **Verilator-clean**.
- **`.sv` and `.archi` byte-identical to main** across the 1680-file corpus; `.h` changes additive only (zero removed lines).
- 3 integration tests + 4 unit-test groups; full `cargo fmt --check` clean.

## One disclosure

A full `cargo test` run had **`fp_formal_float_props` fail once**. It passes in isolation and across a full `fp_test` run (53/53), and measurement shows it is **not** caused by this change:

| | mean | range | preamble |
|---|---|---|---|
| `origin/main` | 37.1s | 30.8–44.9s | 121 lines |
| this branch | 38.4s | 35.0–41.4s | 125 lines |

Overlapping distributions, +4 lines of SMT. The real finding is that the test sits at **~62% of its 60s default solver timeout** and is load-sensitive under parallel CI. Filed with the measurements as [#841](https://github.com/arch-hdl-lang/arch-com/issues/841) rather than left as a "re-run CI" annoyance.

Spec §3.9 now covers all three sub-8-bit formats in one table; reference card updated; skill snapshots re-synced.

Remaining on #837: **E8M0** (the real design work — no sign, no mantissa, and no *zero*, so it cannot ride the float path) and the hand-written **SMT round specs**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)