### PR TITLE
fix(e203): rewire the four stale integration wrappers against the real ICB fabric

### DIFF
--- a/tests/e203/e203_biu.arch
+++ b/tests/e203/e203_biu.arch
@@ -261,31 +261,31 @@ module e203_biu
 
   // ── Response from selected target ────────────────────────────────────
   let rsp_valid_from_target: Bool =
-      (sel_ppi_r   & ppi_icb_rsp_valid)   |
-      (sel_clint_r & clint_icb_rsp_valid) |
-      (sel_plic_r  & plic_icb_rsp_valid)  |
-      (sel_fio_r   & fio_icb_rsp_valid)   |
-      (sel_mem_r   & mem_icb_rsp_valid);
+      (tgt_ppi_r   & ppi_icb_rsp_valid)   |
+      (tgt_clint_r & clint_icb_rsp_valid) |
+      (tgt_plic_r  & plic_icb_rsp_valid)  |
+      (tgt_fio_r   & fio_icb_rsp_valid)   |
+      (tgt_mem_r   & mem_icb_rsp_valid);
 
   let rsp_err_from_target: Bool =
-      (sel_ppi_r   & ppi_icb_rsp_err)   |
-      (sel_clint_r & clint_icb_rsp_err) |
-      (sel_plic_r  & plic_icb_rsp_err)  |
-      (sel_fio_r   & fio_icb_rsp_err)   |
-      (sel_mem_r   & mem_icb_rsp_err);
+      (tgt_ppi_r   & ppi_icb_rsp_err)   |
+      (tgt_clint_r & clint_icb_rsp_err) |
+      (tgt_plic_r  & plic_icb_rsp_err)  |
+      (tgt_fio_r   & fio_icb_rsp_err)   |
+      (tgt_mem_r   & mem_icb_rsp_err);
 
   let rsp_excl_ok_from_target: Bool =
-      (sel_ppi_r   & ppi_icb_rsp_excl_ok)   |
-      (sel_clint_r & clint_icb_rsp_excl_ok) |
-      (sel_plic_r  & plic_icb_rsp_excl_ok)  |
-      (sel_fio_r   & fio_icb_rsp_excl_ok)   |
-      (sel_mem_r   & mem_icb_rsp_excl_ok);
+      (tgt_ppi_r   & ppi_icb_rsp_excl_ok)   |
+      (tgt_clint_r & clint_icb_rsp_excl_ok) |
+      (tgt_plic_r  & plic_icb_rsp_excl_ok)  |
+      (tgt_fio_r   & fio_icb_rsp_excl_ok)   |
+      (tgt_mem_r   & mem_icb_rsp_excl_ok);
 
   let rsp_rdata_from_target: UInt<32> =
-      sel_ppi_r   ? ppi_icb_rsp_rdata   :
-      sel_clint_r ? clint_icb_rsp_rdata :
-      sel_plic_r  ? plic_icb_rsp_rdata  :
-      sel_fio_r   ? fio_icb_rsp_rdata   :
+      tgt_ppi_r   ? ppi_icb_rsp_rdata   :
+      tgt_clint_r ? clint_icb_rsp_rdata :
+      tgt_plic_r  ? plic_icb_rsp_rdata  :
+      tgt_fio_r   ? fio_icb_rsp_rdata   :
                     mem_icb_rsp_rdata;
 
   // ── Response ready from selected initiator ──────────────────────────

--- a/tests/e203/e203_biu.sv
+++ b/tests/e203/e203_biu.sv
@@ -1,10 +1,24 @@
-// E203 HBirdv2 Bus Interface Unit
-// Priority arbiter (LSU > IFU), outstanding transaction tracking,
-// address-based splitter to downstream targets (PPI/CLINT/PLIC/FIO/MEM),
-// IFU-to-peripheral error detection with zero-cycle error response.
-//
-// Verify: submodule-audit applied. Implements sirv_gnrl_icb_arbt +
-// sirv_gnrl_icb_buffer + sirv_gnrl_icb_splt behavior inline.
+// domain SysDomain
+//   freq_mhz: 100
+
+// domain SysDomain
+//   freq_mhz: 100
+
+// domain SysDomain
+//   freq_mhz: 100
+
+// domain SysDomain
+//   freq_mhz: 100
+
+// domain SysDomain
+//   freq_mhz: 100
+
+// domain SysDomain
+//   freq_mhz: 100
+
+// domain SysDomain
+//   freq_mhz: 100
+
 module e203_biu (
   input logic clk,
   input logic rst_n,
@@ -132,62 +146,56 @@ module e203_biu (
   input logic [31:0] mem_icb_rsp_rdata
 );
 
-  // ── LSU to BIU ──────────────────────────────────────────────────────
-  // ── IFU to BIU ──────────────────────────────────────────────────────
-  // ── PPI downstream ──────────────────────────────────────────────────
-  // ── CLINT downstream ────────────────────────────────────────────────
-  // ── PLIC downstream ─────────────────────────────────────────────────
-  // ── FIO downstream ──────────────────────────────────────────────────
-  // ── MEM downstream ──────────────────────────────────────────────────
-  // ── Arbitration: LSU priority over IFU ──────────────────────────────
-  // Both requestors have ICB command buses. LSU wins if both request.
   logic lsu_win;
-  assign lsu_win = lsu2biu_icb_cmd_valid;
   logic ifu_req;
-  assign ifu_req = ifu2biu_icb_cmd_valid;
   logic arb_valid;
-  assign arb_valid = lsu_win | ifu_req;
-  // Mux command from winning initiator
   logic [31:0] arb_addr;
-  assign arb_addr = lsu_win ? lsu2biu_icb_cmd_addr : ifu2biu_icb_cmd_addr;
   logic arb_read;
-  assign arb_read = lsu_win ? lsu2biu_icb_cmd_read : ifu2biu_icb_cmd_read;
   logic [31:0] arb_wdata;
-  assign arb_wdata = lsu_win ? lsu2biu_icb_cmd_wdata : ifu2biu_icb_cmd_wdata;
   logic [3:0] arb_wmask;
-  assign arb_wmask = lsu_win ? lsu2biu_icb_cmd_wmask : ifu2biu_icb_cmd_wmask;
   logic [1:0] arb_burst;
-  assign arb_burst = lsu_win ? lsu2biu_icb_cmd_burst : ifu2biu_icb_cmd_burst;
   logic [1:0] arb_beat;
-  assign arb_beat = lsu_win ? lsu2biu_icb_cmd_beat : ifu2biu_icb_cmd_beat;
   logic arb_lock;
-  assign arb_lock = lsu_win ? lsu2biu_icb_cmd_lock : ifu2biu_icb_cmd_lock;
   logic arb_excl;
-  assign arb_excl = lsu_win ? lsu2biu_icb_cmd_excl : ifu2biu_icb_cmd_excl;
   logic [1:0] arb_size;
-  assign arb_size = lsu_win ? lsu2biu_icb_cmd_size : ifu2biu_icb_cmd_size;
-  // ── Address decode (upper 16 bits match region indicator) ────────────
   logic is_ppi;
-  assign is_ppi = ppi_icb_enable & (arb_addr[31:16] == ppi_region_indic[31:16]);
   logic is_clint;
-  assign is_clint = clint_icb_enable & (arb_addr[31:16] == clint_region_indic[31:16]);
   logic is_plic;
-  assign is_plic = plic_icb_enable & (arb_addr[31:16] == plic_region_indic[31:16]);
   logic is_fio;
-  assign is_fio = fio_icb_enable & (arb_addr[31:16] == fio_region_indic[31:16]);
   logic is_mem;
-  assign is_mem = mem_icb_enable & ~is_ppi & ~is_clint & ~is_plic & ~is_fio;
-  // ── IFU error: IFU accessing peripheral space ───────────────────────
   logic ifu_access;
-  assign ifu_access = ~lsu_win & arb_valid;
   logic ifu_to_peri;
-  assign ifu_to_peri = ifu_access & ~is_mem;
-  // ── Downstream ready mux ────────────────────────────────────────────
   logic arb_cmd_ready;
+  logic cmd_accept;
+  logic downstream_cmd_ready;
+  logic out_flag_set;
+  logic out_flag_clr;
+  logic can_accept;
+  logic rsp_valid_from_target;
+  logic rsp_err_from_target;
+  logic rsp_excl_ok_from_target;
+  logic [31:0] rsp_rdata_from_target;
+  logic rsp_ready_from_initiator;
+  assign lsu_win = lsu2biu_icb_cmd_valid;
+  assign ifu_req = ifu2biu_icb_cmd_valid;
+  assign arb_valid = lsu_win | ifu_req;
+  assign arb_addr = lsu_win ? lsu2biu_icb_cmd_addr : ifu2biu_icb_cmd_addr;
+  assign arb_read = lsu_win ? lsu2biu_icb_cmd_read : ifu2biu_icb_cmd_read;
+  assign arb_wdata = lsu_win ? lsu2biu_icb_cmd_wdata : ifu2biu_icb_cmd_wdata;
+  assign arb_wmask = lsu_win ? lsu2biu_icb_cmd_wmask : ifu2biu_icb_cmd_wmask;
+  assign arb_burst = lsu_win ? lsu2biu_icb_cmd_burst : ifu2biu_icb_cmd_burst;
+  assign arb_beat = lsu_win ? lsu2biu_icb_cmd_beat : ifu2biu_icb_cmd_beat;
+  assign arb_lock = lsu_win ? lsu2biu_icb_cmd_lock : ifu2biu_icb_cmd_lock;
+  assign arb_excl = lsu_win ? lsu2biu_icb_cmd_excl : ifu2biu_icb_cmd_excl;
+  assign arb_size = lsu_win ? lsu2biu_icb_cmd_size : ifu2biu_icb_cmd_size;
+  assign is_ppi = ppi_icb_enable & (arb_addr[31:16] == ppi_region_indic[31:16]);
+  assign is_clint = clint_icb_enable & (arb_addr[31:16] == clint_region_indic[31:16]);
+  assign is_plic = plic_icb_enable & (arb_addr[31:16] == plic_region_indic[31:16]);
+  assign is_fio = fio_icb_enable & (arb_addr[31:16] == fio_region_indic[31:16]);
+  assign is_mem = mem_icb_enable & ~is_ppi & ~is_clint & ~is_plic & ~is_fio;
+  assign ifu_access = ~lsu_win & arb_valid;
+  assign ifu_to_peri = ifu_access & ~is_mem;
   assign arb_cmd_ready = (is_ppi & ppi_icb_cmd_ready) | (is_clint & clint_icb_cmd_ready) | (is_plic & plic_icb_cmd_ready) | (is_fio & fio_icb_cmd_ready) | (is_mem & mem_icb_cmd_ready);
-  // ── Command pipeline register (CMD_DP=1) ────────────────────────────
-  // The arbiter accepts a command, which is registered before going to
-  // the splitter/downstream. This matches sirv_gnrl_icb_buffer behavior.
   logic cmd_valid_r;
   logic [31:0] cmd_addr_r;
   logic cmd_read_r;
@@ -204,9 +212,17 @@ module e203_biu (
   logic tgt_plic_r;
   logic tgt_fio_r;
   logic tgt_mem_r;
-  // Command acceptance: when arbiter wins AND downstream ready
-  logic cmd_accept;
   assign cmd_accept = arb_valid & arb_cmd_ready & ~ifu_to_peri;
+  assign downstream_cmd_ready = (tgt_ppi_r & ppi_icb_cmd_ready) | (tgt_clint_r & clint_icb_cmd_ready) | (tgt_plic_r & plic_icb_cmd_ready) | (tgt_fio_r & fio_icb_cmd_ready) | (tgt_mem_r & mem_icb_cmd_ready);
+  logic out_flag_r;
+  assign out_flag_set = cmd_accept;
+  assign out_flag_clr = rsp_valid_from_target & rsp_ready_from_initiator;
+  assign can_accept = ~cmd_valid_r | downstream_cmd_ready;
+  assign rsp_valid_from_target = (tgt_ppi_r & ppi_icb_rsp_valid) | (tgt_clint_r & clint_icb_rsp_valid) | (tgt_plic_r & plic_icb_rsp_valid) | (tgt_fio_r & fio_icb_rsp_valid) | (tgt_mem_r & mem_icb_rsp_valid);
+  assign rsp_err_from_target = (tgt_ppi_r & ppi_icb_rsp_err) | (tgt_clint_r & clint_icb_rsp_err) | (tgt_plic_r & plic_icb_rsp_err) | (tgt_fio_r & fio_icb_rsp_err) | (tgt_mem_r & mem_icb_rsp_err);
+  assign rsp_excl_ok_from_target = (tgt_ppi_r & ppi_icb_rsp_excl_ok) | (tgt_clint_r & clint_icb_rsp_excl_ok) | (tgt_plic_r & plic_icb_rsp_excl_ok) | (tgt_fio_r & fio_icb_rsp_excl_ok) | (tgt_mem_r & mem_icb_rsp_excl_ok);
+  assign rsp_rdata_from_target = tgt_ppi_r ? ppi_icb_rsp_rdata : tgt_clint_r ? clint_icb_rsp_rdata : tgt_plic_r ? plic_icb_rsp_rdata : tgt_fio_r ? fio_icb_rsp_rdata : mem_icb_rsp_rdata;
+  assign rsp_ready_from_initiator = tgt_lsu_r ? lsu2biu_icb_rsp_ready : ifu2biu_icb_rsp_ready;
   always_ff @(posedge clk or negedge rst_n) begin
     if ((!rst_n)) begin
       cmd_addr_r <= 0;
@@ -244,20 +260,10 @@ module e203_biu (
         tgt_fio_r <= is_fio;
         tgt_mem_r <= is_mem;
       end else if (cmd_valid_r & downstream_cmd_ready) begin
-        // Clear valid when command is consumed by downstream handshake
         cmd_valid_r <= 1'b0;
       end
     end
   end
-  // ── Downstream ready for pipelined command ──────────────────────────
-  logic downstream_cmd_ready;
-  assign downstream_cmd_ready = (tgt_ppi_r & ppi_icb_cmd_ready) | (tgt_clint_r & clint_icb_cmd_ready) | (tgt_plic_r & plic_icb_cmd_ready) | (tgt_fio_r & fio_icb_cmd_ready) | (tgt_mem_r & mem_icb_cmd_ready);
-  // ── Outstanding response tracking (OUTS_NUM=1) ──────────────────────
-  logic out_flag_r;
-  logic out_flag_set;
-  assign out_flag_set = cmd_accept;
-  logic out_flag_clr;
-  assign out_flag_clr = rsp_valid_from_target & rsp_ready_from_initiator;
   always_ff @(posedge clk or negedge rst_n) begin
     if ((!rst_n)) begin
       out_flag_r <= 1'b0;
@@ -269,30 +275,8 @@ module e203_biu (
       end
     end
   end
-  // ── Inititator ready: gated by pipeline vacancy ─────────────────────
-  // FIFO_CUT_READY=1: ready is registered (cut). We can accept when
-  // there's no outstanding pipelined command OR it's being consumed.
-  logic can_accept;
-  assign can_accept = ~cmd_valid_r | downstream_cmd_ready;
-  // ── Response from selected target ────────────────────────────────────
-  logic rsp_valid_from_target;
-  assign rsp_valid_from_target = (sel_ppi_r & ppi_icb_rsp_valid) | (sel_clint_r & clint_icb_rsp_valid) | (sel_plic_r & plic_icb_rsp_valid) | (sel_fio_r & fio_icb_rsp_valid) | (sel_mem_r & mem_icb_rsp_valid);
-  logic rsp_err_from_target;
-  assign rsp_err_from_target = (sel_ppi_r & ppi_icb_rsp_err) | (sel_clint_r & clint_icb_rsp_err) | (sel_plic_r & plic_icb_rsp_err) | (sel_fio_r & fio_icb_rsp_err) | (sel_mem_r & mem_icb_rsp_err);
-  logic rsp_excl_ok_from_target;
-  assign rsp_excl_ok_from_target = (sel_ppi_r & ppi_icb_rsp_excl_ok) | (sel_clint_r & clint_icb_rsp_excl_ok) | (sel_plic_r & plic_icb_rsp_excl_ok) | (sel_fio_r & fio_icb_rsp_excl_ok) | (sel_mem_r & mem_icb_rsp_excl_ok);
-  logic [31:0] rsp_rdata_from_target;
-  assign rsp_rdata_from_target = sel_ppi_r ? ppi_icb_rsp_rdata : sel_clint_r ? clint_icb_rsp_rdata : sel_plic_r ? plic_icb_rsp_rdata : sel_fio_r ? fio_icb_rsp_rdata : mem_icb_rsp_rdata;
-  // ── Response ready from selected initiator ──────────────────────────
-  logic rsp_ready_from_initiator;
-  assign rsp_ready_from_initiator = tgt_lsu_r ? lsu2biu_icb_rsp_ready : ifu2biu_icb_rsp_ready;
-  // ── IFU error response (zero-cycle: rsp_valid tracks cmd_valid) ─────
-  // When IFU accesses peripheral space, generate immediate error response.
-  // The request is NOT forwarded to any downstream target.
-  // ── Combinational outputs ────────────────────────────────────────────
   always_comb begin
     biu_active = cmd_valid_r | out_flag_r | arb_valid;
-    // ── Arbiter ready back to initiators (gated by pipeline vacancy) ──
     if (lsu_win) begin
       lsu2biu_icb_cmd_ready = can_accept & arb_cmd_ready & ~ifu_to_peri;
       ifu2biu_icb_cmd_ready = 1'b0;
@@ -300,7 +284,6 @@ module e203_biu (
       lsu2biu_icb_cmd_ready = 1'b0;
       ifu2biu_icb_cmd_ready = can_accept & arb_cmd_ready & ~ifu_to_peri;
     end
-    // ── Commands to downstream from pipelined register ────────────────
     ppi_icb_cmd_valid = cmd_valid_r & tgt_ppi_r;
     ppi_icb_cmd_addr = tgt_ppi_r ? cmd_addr_r : 0;
     ppi_icb_cmd_read = tgt_ppi_r ? cmd_read_r : 1'b0;
@@ -351,15 +334,12 @@ module e203_biu (
     mem_icb_cmd_lock = tgt_mem_r ? cmd_lock_r : 1'b0;
     mem_icb_cmd_excl = tgt_mem_r ? cmd_excl_r : 1'b0;
     mem_icb_cmd_size = tgt_mem_r ? cmd_size_r : 0;
-    // ── Response ready to selected downstream ─────────────────────────
     ppi_icb_rsp_ready = tgt_ppi_r & rsp_ready_from_initiator;
     clint_icb_rsp_ready = tgt_clint_r & rsp_ready_from_initiator;
     plic_icb_rsp_ready = tgt_plic_r & rsp_ready_from_initiator;
     fio_icb_rsp_ready = tgt_fio_r & rsp_ready_from_initiator;
     mem_icb_rsp_ready = tgt_mem_r & rsp_ready_from_initiator;
-    // Response to LSU/IFU: mux from selected target, or IFU error
     if (ifu_to_peri) begin
-      // IFU error: zero-cycle error response to IFU
       lsu2biu_icb_rsp_valid = 1'b0;
       lsu2biu_icb_rsp_err = 1'b0;
       lsu2biu_icb_rsp_excl_ok = 1'b0;

--- a/tests/e203/e203_core_top.arch
+++ b/tests/e203/e203_core_top.arch
@@ -1,181 +1,704 @@
-// E203 Core Top-Level Integration
-// Full integration: IFU + EXU + LSU + BIU + ITCM + DTCM + CLINT
-// Testbench loads instructions into ITCM via write port, then
-// the IFU fetches and the core executes autonomously.
+// E203 HBirdv2 core top — hierarchical integration fixture (second-generation).
+// Mirrors reference e203_core.v: e203_ifu_top + e203_exu_top + e203_lsu + e203_biu
+// wired through the real ICB fabric. TCMs, CLINT and peripherals are external —
+// they attach to the exported ICB buses (see e203_soc_top).
+// Single-clock simplification: clk drives all four sub-units and clk_aon.
 
 module e203_core_top
-  param XLEN: const = 32;
+  port clk:       in Clock<SysDomain>;
+  port rst_n:     in Reset<Async, Low>;
+  port test_mode: in Bool;
 
-  port clk:   in Clock<SysDomain>;
-  port rst_n: in Reset<Async, Low>;
+  // ── Status / inspect ───────────────────────────────────────────────
+  port inspect_pc:  out UInt<32>;
+  port core_wfi:    out Bool;
+  port tm_stop:     out Bool;
+  port core_cgstop: out Bool;
+  port tcm_cgstop:  out Bool;
+  port exu_active:  out Bool;
+  port ifu_active:  out Bool;
+  port lsu_active:  out Bool;
+  port biu_active:  out Bool;
 
-  // ── ITCM write port (for testbench to load program) ────────────────
-  port itcm_wr_en:   in Bool;
-  port itcm_wr_addr: in UInt<14>;
-  port itcm_wr_data: in UInt<32>;
+  // ── Boot / hart config ─────────────────────────────────────────────
+  port pc_rtvec:     in UInt<32>;
+  port core_mhartid: in UInt<32>;
 
-  // ── Branch redirect from EXU to IFU ────────────────────────────────
-  port exu_redirect:    in Bool;
-  port exu_redirect_pc: in UInt<32>;
+  // ── Interrupts ─────────────────────────────────────────────────────
+  port dbg_irq_r: in Bool;
+  port lcl_irq_r: in Bool;
+  port evt_r:     in Bool;
+  port ext_irq_r: in Bool;
+  port sft_irq_r: in Bool;
+  port tmr_irq_r: in Bool;
 
-  // ── Status outputs ─────────────────────────────────────────────────
-  port commit_valid: out Bool;
-  port o_instr:      out UInt<32>;
-  port o_pc:         out UInt<32>;
-  port o_valid:      out Bool;
-  port tmr_irq:      out Bool;
+  // ── Debug CSR interface ────────────────────────────────────────────
+  port wr_dcsr_ena:     out Bool;
+  port wr_dpc_ena:      out Bool;
+  port wr_dscratch_ena: out Bool;
+  port wr_csr_nxt:      out UInt<32>;
+  port dcsr_r:          in  UInt<32>;
+  port dpc_r:           in  UInt<32>;
+  port dscratch_r:      in  UInt<32>;
+  port cmt_dpc:         out UInt<32>;
+  port cmt_dpc_ena:     out Bool;
+  port cmt_dcause:      out UInt<3>;
+  port cmt_dcause_ena:  out Bool;
+  port dbg_mode:        in  Bool;
+  port dbg_halt_r:      in  Bool;
+  port dbg_step_r:      in  Bool;
+  port dbg_ebreakm_r:   in  Bool;
+  port dbg_stopcycle:   in  Bool;
 
-  // ── ITCM ───────────────────────────────────────────────────────────
-  inst itcm: e203_itcm
-    clk     <- clk;
-    rst_n   <- rst_n;
-    rd_en   <- itcm_fetch_rd_en;
-    rd_addr <- itcm_fetch_rd_addr;
-    rd_data -> itcm_fetch_rd_data;
-    wr_en   <- itcm_wr_mux_en;
-    wr_addr <- itcm_wr_mux_addr;
-    wr_data <- itcm_wr_mux_data;
-  end inst itcm
+  // ── ITCM: region + IFU fetch ICB (64-bit) ──────────────────────────
+  port itcm_region_indic: in UInt<32>;
+  port ifu2itcm_holdup:   in Bool;
+  port ifu2itcm_icb_cmd_valid: out Bool;
+  port ifu2itcm_icb_cmd_ready: in  Bool;
+  port ifu2itcm_icb_cmd_addr:  out UInt<16>;
+  port ifu2itcm_icb_rsp_valid: in  Bool;
+  port ifu2itcm_icb_rsp_ready: out Bool;
+  port ifu2itcm_icb_rsp_err:   in  Bool;
+  port ifu2itcm_icb_rsp_rdata: in  UInt<64>;
+
+  // ── ITCM: LSU access ICB (32-bit) ──────────────────────────────────
+  port lsu2itcm_icb_cmd_valid: out Bool;
+  port lsu2itcm_icb_cmd_ready: in  Bool;
+  port lsu2itcm_icb_cmd_addr:  out UInt<16>;
+  port lsu2itcm_icb_cmd_read:  out Bool;
+  port lsu2itcm_icb_cmd_wdata: out UInt<32>;
+  port lsu2itcm_icb_cmd_wmask: out UInt<4>;
+  port lsu2itcm_icb_cmd_lock:  out Bool;
+  port lsu2itcm_icb_cmd_excl:  out Bool;
+  port lsu2itcm_icb_cmd_size:  out UInt<2>;
+  port lsu2itcm_icb_rsp_valid: in  Bool;
+  port lsu2itcm_icb_rsp_ready: out Bool;
+  port lsu2itcm_icb_rsp_err:   in  Bool;
+  port lsu2itcm_icb_rsp_excl_ok: in Bool;
+  port lsu2itcm_icb_rsp_rdata: in  UInt<32>;
+
+  // ── DTCM: LSU access ICB (32-bit) ──────────────────────────────────
+  port dtcm_region_indic: in UInt<32>;
+  port lsu2dtcm_icb_cmd_valid: out Bool;
+  port lsu2dtcm_icb_cmd_ready: in  Bool;
+  port lsu2dtcm_icb_cmd_addr:  out UInt<16>;
+  port lsu2dtcm_icb_cmd_read:  out Bool;
+  port lsu2dtcm_icb_cmd_wdata: out UInt<32>;
+  port lsu2dtcm_icb_cmd_wmask: out UInt<4>;
+  port lsu2dtcm_icb_cmd_lock:  out Bool;
+  port lsu2dtcm_icb_cmd_excl:  out Bool;
+  port lsu2dtcm_icb_cmd_size:  out UInt<2>;
+  port lsu2dtcm_icb_rsp_valid: in  Bool;
+  port lsu2dtcm_icb_rsp_ready: out Bool;
+  port lsu2dtcm_icb_rsp_err:   in  Bool;
+  port lsu2dtcm_icb_rsp_excl_ok: in Bool;
+  port lsu2dtcm_icb_rsp_rdata: in  UInt<32>;
+
+  // ── PPI ICB (private peripherals) ──────────────────────────────────
+  port ppi_region_indic: in UInt<32>;
+  port ppi_icb_enable:   in Bool;
+  port ppi_icb_cmd_valid: out Bool;
+  port ppi_icb_cmd_ready: in  Bool;
+  port ppi_icb_cmd_addr:  out UInt<32>;
+  port ppi_icb_cmd_read:  out Bool;
+  port ppi_icb_cmd_wdata: out UInt<32>;
+  port ppi_icb_cmd_wmask: out UInt<4>;
+  port ppi_icb_cmd_lock:  out Bool;
+  port ppi_icb_cmd_excl:  out Bool;
+  port ppi_icb_cmd_size:  out UInt<2>;
+  port ppi_icb_cmd_burst: out UInt<2>;
+  port ppi_icb_cmd_beat:  out UInt<2>;
+  port ppi_icb_rsp_valid: in  Bool;
+  port ppi_icb_rsp_ready: out Bool;
+  port ppi_icb_rsp_err:   in  Bool;
+  port ppi_icb_rsp_excl_ok: in Bool;
+  port ppi_icb_rsp_rdata: in  UInt<32>;
+
+  // ── CLINT ICB ──────────────────────────────────────────────────────
+  port clint_region_indic: in UInt<32>;
+  port clint_icb_enable:   in Bool;
+  port clint_icb_cmd_valid: out Bool;
+  port clint_icb_cmd_ready: in  Bool;
+  port clint_icb_cmd_addr:  out UInt<32>;
+  port clint_icb_cmd_read:  out Bool;
+  port clint_icb_cmd_wdata: out UInt<32>;
+  port clint_icb_cmd_wmask: out UInt<4>;
+  port clint_icb_cmd_lock:  out Bool;
+  port clint_icb_cmd_excl:  out Bool;
+  port clint_icb_cmd_size:  out UInt<2>;
+  port clint_icb_cmd_burst: out UInt<2>;
+  port clint_icb_cmd_beat:  out UInt<2>;
+  port clint_icb_rsp_valid: in  Bool;
+  port clint_icb_rsp_ready: out Bool;
+  port clint_icb_rsp_err:   in  Bool;
+  port clint_icb_rsp_excl_ok: in Bool;
+  port clint_icb_rsp_rdata: in  UInt<32>;
+
+  // ── PLIC ICB ───────────────────────────────────────────────────────
+  port plic_region_indic: in UInt<32>;
+  port plic_icb_enable:   in Bool;
+  port plic_icb_cmd_valid: out Bool;
+  port plic_icb_cmd_ready: in  Bool;
+  port plic_icb_cmd_addr:  out UInt<32>;
+  port plic_icb_cmd_read:  out Bool;
+  port plic_icb_cmd_wdata: out UInt<32>;
+  port plic_icb_cmd_wmask: out UInt<4>;
+  port plic_icb_cmd_lock:  out Bool;
+  port plic_icb_cmd_excl:  out Bool;
+  port plic_icb_cmd_size:  out UInt<2>;
+  port plic_icb_cmd_burst: out UInt<2>;
+  port plic_icb_cmd_beat:  out UInt<2>;
+  port plic_icb_rsp_valid: in  Bool;
+  port plic_icb_rsp_ready: out Bool;
+  port plic_icb_rsp_err:   in  Bool;
+  port plic_icb_rsp_excl_ok: in Bool;
+  port plic_icb_rsp_rdata: in  UInt<32>;
+
+  // ── FIO ICB (fast I/O) ─────────────────────────────────────────────
+  port fio_region_indic: in UInt<32>;
+  port fio_icb_enable:   in Bool;
+  port fio_icb_cmd_valid: out Bool;
+  port fio_icb_cmd_ready: in  Bool;
+  port fio_icb_cmd_addr:  out UInt<32>;
+  port fio_icb_cmd_read:  out Bool;
+  port fio_icb_cmd_wdata: out UInt<32>;
+  port fio_icb_cmd_wmask: out UInt<4>;
+  port fio_icb_cmd_lock:  out Bool;
+  port fio_icb_cmd_excl:  out Bool;
+  port fio_icb_cmd_size:  out UInt<2>;
+  port fio_icb_cmd_burst: out UInt<2>;
+  port fio_icb_cmd_beat:  out UInt<2>;
+  port fio_icb_rsp_valid: in  Bool;
+  port fio_icb_rsp_ready: out Bool;
+  port fio_icb_rsp_err:   in  Bool;
+  port fio_icb_rsp_excl_ok: in Bool;
+  port fio_icb_rsp_rdata: in  UInt<32>;
+
+  // ── MEM ICB (external memory) ──────────────────────────────────────
+  port mem_icb_enable:   in Bool;
+  port mem_icb_cmd_valid: out Bool;
+  port mem_icb_cmd_ready: in  Bool;
+  port mem_icb_cmd_addr:  out UInt<32>;
+  port mem_icb_cmd_read:  out Bool;
+  port mem_icb_cmd_wdata: out UInt<32>;
+  port mem_icb_cmd_wmask: out UInt<4>;
+  port mem_icb_cmd_lock:  out Bool;
+  port mem_icb_cmd_excl:  out Bool;
+  port mem_icb_cmd_size:  out UInt<2>;
+  port mem_icb_cmd_burst: out UInt<2>;
+  port mem_icb_cmd_beat:  out UInt<2>;
+  port mem_icb_rsp_valid: in  Bool;
+  port mem_icb_rsp_ready: out Bool;
+  port mem_icb_rsp_err:   in  Bool;
+  port mem_icb_rsp_excl_ok: in Bool;
+  port mem_icb_rsp_rdata: in  UInt<32>;
+
+  // ── NICE coprocessor interface ─────────────────────────────────────
+  port nice_mem_holdup: in Bool;
+  port nice_req_valid:  out Bool;
+  port nice_req_ready:  in  Bool;
+  port nice_req_inst:   out UInt<32>;
+  port nice_req_rs1:    out UInt<32>;
+  port nice_req_rs2:    out UInt<32>;
+  port nice_rsp_multicyc_valid: in  Bool;
+  port nice_rsp_multicyc_ready: out Bool;
+  port nice_rsp_multicyc_dat:   in  UInt<32>;
+  port nice_rsp_multicyc_err:   in  Bool;
+  port nice_icb_cmd_valid: in  Bool;
+  port nice_icb_cmd_ready: out Bool;
+  port nice_icb_cmd_addr:  in  UInt<32>;
+  port nice_icb_cmd_read:  in  Bool;
+  port nice_icb_cmd_wdata: in  UInt<32>;
+  port nice_icb_cmd_size:  in  UInt<2>;
+  port nice_icb_rsp_valid: out Bool;
+  port nice_icb_rsp_ready: in  Bool;
+  port nice_icb_rsp_rdata: out UInt<32>;
+  port nice_icb_rsp_err:   out Bool;
+
+  // ── Internal wires: IFU -> EXU instruction channel ─────────────────
+  wire ifu_o_valid:      Bool;
+  wire ifu_o_ready:      Bool;
+  wire ifu_o_ir:         UInt<32>;
+  wire ifu_o_pc:         UInt<32>;
+  wire ifu_o_pc_vld:     Bool;
+  wire ifu_o_misalgn:    Bool;
+  wire ifu_o_buserr:     Bool;
+  wire ifu_o_rs1idx:     UInt<5>;
+  wire ifu_o_rs2idx:     UInt<5>;
+  wire ifu_o_prdt_taken: Bool;
+  wire ifu_o_muldiv_b2b: Bool;
+
+  // ── WFI halt / pipe flush (EXU -> IFU) ─────────────────────────────
+  wire wfi_halt_ifu_req: Bool;
+  wire wfi_halt_ifu_ack: Bool;
+  wire pipe_flush_req:     Bool;
+  wire pipe_flush_ack:     Bool;
+  wire pipe_flush_add_op1: UInt<32>;
+  wire pipe_flush_add_op2: UInt<32>;
+  wire pipe_flush_pc:      UInt<32>;
+
+  // ── OITF / regfile / decode feedback (EXU -> IFU) ──────────────────
+  wire oitf_empty:    Bool;
+  wire rf2ifu_x1:     UInt<32>;
+  wire rf2ifu_rs1:    UInt<32>;
+  wire dec2ifu_rden:  Bool;
+  wire dec2ifu_rs1en: Bool;
+  wire dec2ifu_rdidx: UInt<5>;
+  wire dec2ifu_mulhsu: Bool;
+  wire dec2ifu_div:   Bool;
+  wire dec2ifu_rem:   Bool;
+  wire dec2ifu_divu:  Bool;
+  wire dec2ifu_remu:  Bool;
+  wire itcm_nohold:   Bool;
+
+  // ── LSU writeback channel (LSU -> EXU) ─────────────────────────────
+  wire lsu_o_valid:       Bool;
+  wire lsu_o_ready:       Bool;
+  wire lsu_o_wbck_wdat:   UInt<32>;
+  wire lsu_o_wbck_itag:   UInt<1>;
+  wire lsu_o_wbck_err:    Bool;
+  wire lsu_o_cmt_ld:      Bool;
+  wire lsu_o_cmt_st:      Bool;
+  wire lsu_o_cmt_badaddr: UInt<32>;
+  wire lsu_o_cmt_buserr:  Bool;
+
+  // ── AGU ICB (EXU -> LSU) ───────────────────────────────────────────
+  wire agu_icb_cmd_valid:    Bool;
+  wire agu_icb_cmd_ready:    Bool;
+  wire agu_icb_cmd_addr:     UInt<32>;
+  wire agu_icb_cmd_read:     Bool;
+  wire agu_icb_cmd_wdata:    UInt<32>;
+  wire agu_icb_cmd_wmask:    UInt<4>;
+  wire agu_icb_cmd_lock:     Bool;
+  wire agu_icb_cmd_excl:     Bool;
+  wire agu_icb_cmd_size:     UInt<2>;
+  wire agu_icb_cmd_back2agu: Bool;
+  wire agu_icb_cmd_usign:    Bool;
+  wire agu_icb_cmd_itag:     Bool;
+  wire agu_icb_rsp_valid:    Bool;
+  wire agu_icb_rsp_ready:    Bool;
+  wire agu_icb_rsp_err:      Bool;
+  wire agu_icb_rsp_excl_ok:  Bool;
+  wire agu_icb_rsp_rdata:    UInt<32>;
+
+  // ── Commit / exception (EXU -> LSU) ────────────────────────────────
+  wire commit_mret: Bool;
+  wire commit_trap: Bool;
+  wire excp_active: Bool;
+
+  // ── LSU <-> BIU ICB ────────────────────────────────────────────────
+  wire lsu2biu_icb_cmd_valid: Bool;
+  wire lsu2biu_icb_cmd_ready: Bool;
+  wire lsu2biu_icb_cmd_addr:  UInt<32>;
+  wire lsu2biu_icb_cmd_read:  Bool;
+  wire lsu2biu_icb_cmd_wdata: UInt<32>;
+  wire lsu2biu_icb_cmd_wmask: UInt<4>;
+  wire lsu2biu_icb_cmd_lock:  Bool;
+  wire lsu2biu_icb_cmd_excl:  Bool;
+  wire lsu2biu_icb_cmd_size:  UInt<2>;
+  wire lsu2biu_icb_rsp_valid: Bool;
+  wire lsu2biu_icb_rsp_ready: Bool;
+  wire lsu2biu_icb_rsp_err:   Bool;
+  wire lsu2biu_icb_rsp_excl_ok: Bool;
+  wire lsu2biu_icb_rsp_rdata: UInt<32>;
+
+  // ── IFU <-> BIU ICB (external fetch path) ──────────────────────────
+  wire ifu2biu_icb_cmd_valid: Bool;
+  wire ifu2biu_icb_cmd_ready: Bool;
+  wire ifu2biu_icb_cmd_addr:  UInt<32>;
+  wire ifu2biu_icb_rsp_valid: Bool;
+  wire ifu2biu_icb_rsp_ready: Bool;
+  wire ifu2biu_icb_rsp_err:   Bool;
+  wire ifu2biu_icb_rsp_rdata: UInt<32>;
+
+  // Dangling outputs (reference leaves these unconnected too)
+  wire ifu2biu_icb_rsp_excl_ok_nc: Bool;
+  wire nice_icb_rsp_excl_ok_nc:    Bool;
+
+  // Width bridges: EXU itag is Bool, LSU carries UInt<1>; wbck itag widens to 5.
+  let agu_icb_cmd_itag_u: UInt<1> = agu_icb_cmd_itag ? 1 : 0;
+  let lsu_o_wbck_itag_x:  UInt<5> = lsu_o_wbck_itag.zext<5>();
 
   // ── IFU ────────────────────────────────────────────────────────────
   inst ifu: e203_ifu_top
-    clk              <- clk;
-    rst_n            <- rst_n;
-    o_ready          <- true;
-    exu_redirect     <- exu_redirect;
-    exu_redirect_pc  <- exu_redirect_pc;
-    itcm_cmd_ready   <- true;
-    itcm_rsp_valid   <- itcm_rsp_valid_d;
-    itcm_rsp_data    <- itcm_fetch_rd_data;
-    oitf_empty       <- true;
-    ir_empty         <- true;
-    ir_rs1en         <- false;
-    jalr_rs1idx_cam_irrdidx <- false;
-    ir_valid_clr     <- false;
-    rf2bpu_x1        <- 0;
-    rf2bpu_rs1       <- 0;
-    o_valid          -> ifu_o_valid;
-    o_instr          -> ifu_o_instr;
-    o_pc             -> ifu_o_pc;
-    o_bus_err        -> ifu_bus_err;
-    itcm_cmd_valid   -> itcm_cmd_valid;
-    itcm_cmd_addr    -> itcm_cmd_addr;
-    itcm_rsp_ready   -> ifu_rsp_ready;
-    bpu_wait         -> ifu_bpu_wait;
-    bpu2rf_rs1_ena   -> ifu_bpu_rs1_ena;
-    prdt_taken       -> ifu_prdt_taken;
-    prdt_pc_add_op1  -> ifu_pc_op1;
-    prdt_pc_add_op2  -> ifu_pc_op2;
-    dec_is_bjp       -> ifu_dec_bjp;
-    dec_is_lui       -> ifu_dec_lui;
-    dec_is_auipc     -> ifu_dec_auipc;
+    clk               <- clk;
+    rst_n             <- rst_n;
+    itcm_nohold       <- itcm_nohold;
+    pc_rtvec          <- pc_rtvec;
+    ifu2itcm_holdup   <- ifu2itcm_holdup;
+    itcm_region_indic <- itcm_region_indic;
+    ifu2itcm_icb_cmd_valid -> ifu2itcm_icb_cmd_valid;
+    ifu2itcm_icb_cmd_ready <- ifu2itcm_icb_cmd_ready;
+    ifu2itcm_icb_cmd_addr  -> ifu2itcm_icb_cmd_addr;
+    ifu2itcm_icb_rsp_valid <- ifu2itcm_icb_rsp_valid;
+    ifu2itcm_icb_rsp_ready -> ifu2itcm_icb_rsp_ready;
+    ifu2itcm_icb_rsp_err   <- ifu2itcm_icb_rsp_err;
+    ifu2itcm_icb_rsp_rdata <- ifu2itcm_icb_rsp_rdata;
+    ifu2biu_icb_cmd_valid  -> ifu2biu_icb_cmd_valid;
+    ifu2biu_icb_cmd_ready  <- ifu2biu_icb_cmd_ready;
+    ifu2biu_icb_cmd_addr   -> ifu2biu_icb_cmd_addr;
+    ifu2biu_icb_rsp_valid  <- ifu2biu_icb_rsp_valid;
+    ifu2biu_icb_rsp_ready  -> ifu2biu_icb_rsp_ready;
+    ifu2biu_icb_rsp_err    <- ifu2biu_icb_rsp_err;
+    ifu2biu_icb_rsp_rdata  <- ifu2biu_icb_rsp_rdata;
+    ifu_o_ir         -> ifu_o_ir;
+    ifu_o_pc         -> ifu_o_pc;
+    ifu_o_pc_vld     -> ifu_o_pc_vld;
+    ifu_o_misalgn    -> ifu_o_misalgn;
+    ifu_o_buserr     -> ifu_o_buserr;
+    ifu_o_rs1idx     -> ifu_o_rs1idx;
+    ifu_o_rs2idx     -> ifu_o_rs2idx;
+    ifu_o_prdt_taken -> ifu_o_prdt_taken;
+    ifu_o_muldiv_b2b -> ifu_o_muldiv_b2b;
+    ifu_o_valid      -> ifu_o_valid;
+    ifu_o_ready      <- ifu_o_ready;
+    pipe_flush_ack     -> pipe_flush_ack;
+    pipe_flush_req     <- pipe_flush_req;
+    pipe_flush_add_op1 <- pipe_flush_add_op1;
+    pipe_flush_add_op2 <- pipe_flush_add_op2;
+    pipe_flush_pc      <- pipe_flush_pc;
+    ifu_halt_req <- wfi_halt_ifu_req;
+    ifu_halt_ack -> wfi_halt_ifu_ack;
+    oitf_empty    <- oitf_empty;
+    rf2ifu_x1     <- rf2ifu_x1;
+    rf2ifu_rs1    <- rf2ifu_rs1;
+    dec2ifu_rden  <- dec2ifu_rden;
+    dec2ifu_rs1en <- dec2ifu_rs1en;
+    dec2ifu_rdidx <- dec2ifu_rdidx;
+    dec2ifu_mulhsu <- dec2ifu_mulhsu;
+    dec2ifu_div    <- dec2ifu_div;
+    dec2ifu_rem    <- dec2ifu_rem;
+    dec2ifu_divu   <- dec2ifu_divu;
+    dec2ifu_remu   <- dec2ifu_remu;
+    inspect_pc -> inspect_pc;
+    ifu_active -> ifu_active;
   end inst ifu
 
   // ── EXU ────────────────────────────────────────────────────────────
   inst exu: e203_exu_top
-    clk        <- clk;
-    rst_n      <- rst_n;
-    ifu_valid  <- ifu_o_valid;
-    ifu_instr  <- ifu_o_instr;
-    ifu_pc     <- ifu_o_pc;
-    ifu_ready  -> exu_ifu_ready;
-    o_bjp_valid -> exu_bjp_valid;
-    o_bjp_taken -> exu_bjp_taken;
-    o_bjp_tgt   -> exu_bjp_tgt;
-    lsu_valid   -> exu_lsu_valid;
-    lsu_ready   <- true;
-    lsu_addr    -> exu_lsu_addr;
-    lsu_wdata   -> exu_lsu_wdata;
-    lsu_load    -> exu_lsu_load;
-    lsu_store   -> exu_lsu_store;
-    lsu_resp_valid <- false;
-    lsu_resp_data  <- 0;
-    o_commit_valid -> exu_commit_valid;
+    clk     <- clk;
+    clk_aon <- clk;
+    rst_n   <- rst_n;
+    test_mode <- test_mode;
+    i_valid      <- ifu_o_valid;
+    i_ready      -> ifu_o_ready;
+    i_ir         <- ifu_o_ir;
+    i_pc         <- ifu_o_pc;
+    i_pc_vld     <- ifu_o_pc_vld;
+    i_misalgn    <- ifu_o_misalgn;
+    i_buserr     <- ifu_o_buserr;
+    i_prdt_taken <- ifu_o_prdt_taken;
+    i_muldiv_b2b <- ifu_o_muldiv_b2b;
+    i_rs1idx     <- ifu_o_rs1idx;
+    i_rs2idx     <- ifu_o_rs2idx;
+    pipe_flush_req     -> pipe_flush_req;
+    pipe_flush_ack     <- pipe_flush_ack;
+    pipe_flush_add_op1 -> pipe_flush_add_op1;
+    pipe_flush_add_op2 -> pipe_flush_add_op2;
+    pipe_flush_pc      -> pipe_flush_pc;
+    wfi_halt_ifu_req -> wfi_halt_ifu_req;
+    wfi_halt_ifu_ack <- wfi_halt_ifu_ack;
+    lsu_o_valid       <- lsu_o_valid;
+    lsu_o_ready       -> lsu_o_ready;
+    lsu_o_wbck_wdat   <- lsu_o_wbck_wdat;
+    lsu_o_wbck_itag   <- lsu_o_wbck_itag_x;
+    lsu_o_wbck_err    <- lsu_o_wbck_err;
+    lsu_o_cmt_ld      <- lsu_o_cmt_ld;
+    lsu_o_cmt_st      <- lsu_o_cmt_st;
+    lsu_o_cmt_badaddr <- lsu_o_cmt_badaddr;
+    lsu_o_cmt_buserr  <- lsu_o_cmt_buserr;
+    agu_icb_cmd_valid    -> agu_icb_cmd_valid;
+    agu_icb_cmd_ready    <- agu_icb_cmd_ready;
+    agu_icb_cmd_addr     -> agu_icb_cmd_addr;
+    agu_icb_cmd_read     -> agu_icb_cmd_read;
+    agu_icb_cmd_wdata    -> agu_icb_cmd_wdata;
+    agu_icb_cmd_wmask    -> agu_icb_cmd_wmask;
+    agu_icb_cmd_lock     -> agu_icb_cmd_lock;
+    agu_icb_cmd_excl     -> agu_icb_cmd_excl;
+    agu_icb_cmd_size     -> agu_icb_cmd_size;
+    agu_icb_cmd_back2agu -> agu_icb_cmd_back2agu;
+    agu_icb_cmd_usign    -> agu_icb_cmd_usign;
+    agu_icb_cmd_itag     -> agu_icb_cmd_itag;
+    agu_icb_rsp_valid    <- agu_icb_rsp_valid;
+    agu_icb_rsp_ready    -> agu_icb_rsp_ready;
+    agu_icb_rsp_err      <- agu_icb_rsp_err;
+    agu_icb_rsp_excl_ok  <- agu_icb_rsp_excl_ok;
+    agu_icb_rsp_rdata    <- agu_icb_rsp_rdata;
+    dbg_mode      <- dbg_mode;
+    dbg_halt_r    <- dbg_halt_r;
+    dbg_step_r    <- dbg_step_r;
+    dbg_ebreakm_r <- dbg_ebreakm_r;
+    dbg_stopcycle <- dbg_stopcycle;
+    dbg_irq_r <- dbg_irq_r;
+    lcl_irq_r <- lcl_irq_r;
+    evt_r     <- evt_r;
+    ext_irq_r <- ext_irq_r;
+    sft_irq_r <- sft_irq_r;
+    tmr_irq_r <- tmr_irq_r;
+    cmt_dpc        -> cmt_dpc;
+    cmt_dpc_ena    -> cmt_dpc_ena;
+    cmt_dcause     -> cmt_dcause;
+    cmt_dcause_ena -> cmt_dcause_ena;
+    wr_dcsr_ena     -> wr_dcsr_ena;
+    wr_dpc_ena      -> wr_dpc_ena;
+    wr_dscratch_ena -> wr_dscratch_ena;
+    wr_csr_nxt      -> wr_csr_nxt;
+    dcsr_r     <- dcsr_r;
+    dpc_r      <- dpc_r;
+    dscratch_r <- dscratch_r;
+    core_wfi -> core_wfi;
+    rf2ifu_x1     -> rf2ifu_x1;
+    rf2ifu_rs1    -> rf2ifu_rs1;
+    dec2ifu_rden  -> dec2ifu_rden;
+    dec2ifu_rs1en -> dec2ifu_rs1en;
+    dec2ifu_rdidx -> dec2ifu_rdidx;
+    dec2ifu_mulhsu -> dec2ifu_mulhsu;
+    dec2ifu_div    -> dec2ifu_div;
+    dec2ifu_rem    -> dec2ifu_rem;
+    dec2ifu_divu   -> dec2ifu_divu;
+    dec2ifu_remu   -> dec2ifu_remu;
+    oitf_empty  -> oitf_empty;
+    exu_active  -> exu_active;
+    excp_active -> excp_active;
+    commit_mret -> commit_mret;
+    commit_trap -> commit_trap;
+    core_mhartid <- core_mhartid;
+    tm_stop      -> tm_stop;
+    itcm_nohold  -> itcm_nohold;
+    core_cgstop  -> core_cgstop;
+    tcm_cgstop   -> tcm_cgstop;
+    nice_req_valid -> nice_req_valid;
+    nice_req_ready <- nice_req_ready;
+    nice_req_inst  -> nice_req_inst;
+    nice_req_rs1   -> nice_req_rs1;
+    nice_req_rs2   -> nice_req_rs2;
+    nice_rsp_multicyc_valid <- nice_rsp_multicyc_valid;
+    nice_rsp_multicyc_ready -> nice_rsp_multicyc_ready;
+    nice_rsp_multicyc_dat   <- nice_rsp_multicyc_dat;
+    nice_rsp_multicyc_err   <- nice_rsp_multicyc_err;
   end inst exu
 
   // ── LSU ────────────────────────────────────────────────────────────
-  inst lsu: e203_lsu_ctrl
-    addr     <- exu_lsu_addr;
-    wdata    <- exu_lsu_wdata;
-    funct3   <- 2;
-    is_load  <- exu_lsu_load;
-    is_store <- exu_lsu_store;
-    mem_addr  -> lsu_mem_addr;
-    mem_wdata -> lsu_mem_wdata;
-    mem_wstrb -> lsu_mem_wstrb;
-    mem_wen   -> lsu_mem_wen;
-    mem_rdata <- biu_lsu_rdata;
-    load_result -> lsu_load_result;
+  inst lsu: e203_lsu
+    clk   <- clk;
+    rst_n <- rst_n;
+    commit_mret <- commit_mret;
+    commit_trap <- commit_trap;
+    excp_active <- excp_active;
+    lsu_active  -> lsu_active;
+    itcm_region_indic <- itcm_region_indic;
+    dtcm_region_indic <- dtcm_region_indic;
+    lsu_o_valid       -> lsu_o_valid;
+    lsu_o_ready       <- lsu_o_ready;
+    lsu_o_wbck_wdat   -> lsu_o_wbck_wdat;
+    lsu_o_wbck_itag   -> lsu_o_wbck_itag;
+    lsu_o_wbck_err    -> lsu_o_wbck_err;
+    lsu_o_cmt_ld      -> lsu_o_cmt_ld;
+    lsu_o_cmt_st      -> lsu_o_cmt_st;
+    lsu_o_cmt_badaddr -> lsu_o_cmt_badaddr;
+    lsu_o_cmt_buserr  -> lsu_o_cmt_buserr;
+    agu_icb_cmd_valid    <- agu_icb_cmd_valid;
+    agu_icb_cmd_ready    -> agu_icb_cmd_ready;
+    agu_icb_cmd_addr     <- agu_icb_cmd_addr;
+    agu_icb_cmd_read     <- agu_icb_cmd_read;
+    agu_icb_cmd_wdata    <- agu_icb_cmd_wdata;
+    agu_icb_cmd_wmask    <- agu_icb_cmd_wmask;
+    agu_icb_cmd_lock     <- agu_icb_cmd_lock;
+    agu_icb_cmd_excl     <- agu_icb_cmd_excl;
+    agu_icb_cmd_size     <- agu_icb_cmd_size;
+    agu_icb_cmd_back2agu <- agu_icb_cmd_back2agu;
+    agu_icb_cmd_usign    <- agu_icb_cmd_usign;
+    agu_icb_cmd_itag     <- agu_icb_cmd_itag_u;
+    agu_icb_rsp_valid    -> agu_icb_rsp_valid;
+    agu_icb_rsp_ready    <- agu_icb_rsp_ready;
+    agu_icb_rsp_err      -> agu_icb_rsp_err;
+    agu_icb_rsp_excl_ok  -> agu_icb_rsp_excl_ok;
+    agu_icb_rsp_rdata    -> agu_icb_rsp_rdata;
+    itcm_icb_cmd_valid -> lsu2itcm_icb_cmd_valid;
+    itcm_icb_cmd_ready <- lsu2itcm_icb_cmd_ready;
+    itcm_icb_cmd_addr  -> lsu2itcm_icb_cmd_addr;
+    itcm_icb_cmd_read  -> lsu2itcm_icb_cmd_read;
+    itcm_icb_cmd_wdata -> lsu2itcm_icb_cmd_wdata;
+    itcm_icb_cmd_wmask -> lsu2itcm_icb_cmd_wmask;
+    itcm_icb_cmd_lock  -> lsu2itcm_icb_cmd_lock;
+    itcm_icb_cmd_excl  -> lsu2itcm_icb_cmd_excl;
+    itcm_icb_cmd_size  -> lsu2itcm_icb_cmd_size;
+    itcm_icb_rsp_valid <- lsu2itcm_icb_rsp_valid;
+    itcm_icb_rsp_ready -> lsu2itcm_icb_rsp_ready;
+    itcm_icb_rsp_err   <- lsu2itcm_icb_rsp_err;
+    itcm_icb_rsp_excl_ok <- lsu2itcm_icb_rsp_excl_ok;
+    itcm_icb_rsp_rdata <- lsu2itcm_icb_rsp_rdata;
+    dtcm_icb_cmd_valid -> lsu2dtcm_icb_cmd_valid;
+    dtcm_icb_cmd_ready <- lsu2dtcm_icb_cmd_ready;
+    dtcm_icb_cmd_addr  -> lsu2dtcm_icb_cmd_addr;
+    dtcm_icb_cmd_read  -> lsu2dtcm_icb_cmd_read;
+    dtcm_icb_cmd_wdata -> lsu2dtcm_icb_cmd_wdata;
+    dtcm_icb_cmd_wmask -> lsu2dtcm_icb_cmd_wmask;
+    dtcm_icb_cmd_lock  -> lsu2dtcm_icb_cmd_lock;
+    dtcm_icb_cmd_excl  -> lsu2dtcm_icb_cmd_excl;
+    dtcm_icb_cmd_size  -> lsu2dtcm_icb_cmd_size;
+    dtcm_icb_rsp_valid <- lsu2dtcm_icb_rsp_valid;
+    dtcm_icb_rsp_ready -> lsu2dtcm_icb_rsp_ready;
+    dtcm_icb_rsp_err   <- lsu2dtcm_icb_rsp_err;
+    dtcm_icb_rsp_excl_ok <- lsu2dtcm_icb_rsp_excl_ok;
+    dtcm_icb_rsp_rdata <- lsu2dtcm_icb_rsp_rdata;
+    biu_icb_cmd_valid -> lsu2biu_icb_cmd_valid;
+    biu_icb_cmd_ready <- lsu2biu_icb_cmd_ready;
+    biu_icb_cmd_addr  -> lsu2biu_icb_cmd_addr;
+    biu_icb_cmd_read  -> lsu2biu_icb_cmd_read;
+    biu_icb_cmd_wdata -> lsu2biu_icb_cmd_wdata;
+    biu_icb_cmd_wmask -> lsu2biu_icb_cmd_wmask;
+    biu_icb_cmd_lock  -> lsu2biu_icb_cmd_lock;
+    biu_icb_cmd_excl  -> lsu2biu_icb_cmd_excl;
+    biu_icb_cmd_size  -> lsu2biu_icb_cmd_size;
+    biu_icb_rsp_valid <- lsu2biu_icb_rsp_valid;
+    biu_icb_rsp_ready -> lsu2biu_icb_rsp_ready;
+    biu_icb_rsp_err   <- lsu2biu_icb_rsp_err;
+    biu_icb_rsp_excl_ok <- lsu2biu_icb_rsp_excl_ok;
+    biu_icb_rsp_rdata <- lsu2biu_icb_rsp_rdata;
+    nice_mem_holdup <- nice_mem_holdup;
+    nice_icb_cmd_valid <- nice_icb_cmd_valid;
+    nice_icb_cmd_ready -> nice_icb_cmd_ready;
+    nice_icb_cmd_addr  <- nice_icb_cmd_addr;
+    nice_icb_cmd_read  <- nice_icb_cmd_read;
+    nice_icb_cmd_wdata <- nice_icb_cmd_wdata;
+    nice_icb_cmd_wmask <- 0;
+    nice_icb_cmd_lock  <- false;
+    nice_icb_cmd_excl  <- false;
+    nice_icb_cmd_size  <- nice_icb_cmd_size;
+    nice_icb_rsp_valid -> nice_icb_rsp_valid;
+    nice_icb_rsp_ready <- nice_icb_rsp_ready;
+    nice_icb_rsp_err   -> nice_icb_rsp_err;
+    nice_icb_rsp_excl_ok -> nice_icb_rsp_excl_ok_nc;
+    nice_icb_rsp_rdata -> nice_icb_rsp_rdata;
   end inst lsu
 
   // ── BIU ────────────────────────────────────────────────────────────
-  inst bus_: e203_biu
-    lsu_addr   <- lsu_mem_addr;
-    lsu_wdata  <- lsu_mem_wdata;
-    lsu_wstrb  <- lsu_mem_wstrb;
-    lsu_wen    <- lsu_mem_wen;
-    lsu_ren    <- exu_lsu_load;
-    itcm_rd_data <- itcm_fetch_rd_data;
-    dtcm_rd_data <- dtcm_rd_data;
-    lsu_rdata    -> biu_lsu_rdata;
-    itcm_rd_en   -> biu_itcm_rd_en;
-    itcm_rd_addr -> biu_itcm_rd_addr;
-    itcm_wr_en   -> biu_itcm_wr_en;
-    itcm_wr_addr -> biu_itcm_wr_addr;
-    itcm_wr_data -> biu_itcm_wr_data;
-    dtcm_rd_en   -> biu_dtcm_rd_en;
-    dtcm_rd_addr -> biu_dtcm_rd_addr;
-    dtcm_wr_en   -> biu_dtcm_wr_en;
-    dtcm_wr_addr -> biu_dtcm_wr_addr;
-    dtcm_wr_data -> biu_dtcm_wr_data;
-    dtcm_wr_be   -> biu_dtcm_wr_be;
-  end inst bus_
-
-  // ── DTCM ───────────────────────────────────────────────────────────
-  inst dtcm: e203_dtcm
-    clk     <- clk;
-    rst_n   <- rst_n;
-    rd_en   <- biu_dtcm_rd_en;
-    rd_addr <- biu_dtcm_rd_addr;
-    rd_dout -> dtcm_rd_data;
-    wr_en   <- biu_dtcm_wr_en;
-    wr_be   <- biu_dtcm_wr_be;
-    wr_addr <- biu_dtcm_wr_addr;
-    wr_din  <- biu_dtcm_wr_data;
-  end inst dtcm
-
-  // ── CLINT Timer ────────────────────────────────────────────────────
-  inst timer: e203_clint_timer
-    clk       <- clk;
-    rst       <- false;
-    reg_addr  <- 0;
-    reg_wdata <- 0;
-    reg_wen   <- false;
-    reg_rdata -> timer_rdata;
-    tmr_irq   -> tmr_irq;
-  end inst timer
-
-  // ── ITCM fetch: IFU cmd → ITCM read port ──────────────────────────
-  // ITCM rsp_valid: delay cmd_valid by 1 cycle (ITCM latency 1)
-  reg itcm_rsp_valid_r: Bool init false reset rst_n=>false;
-
-  seq on clk rising
-    itcm_rsp_valid_r <= itcm_cmd_valid;
-  end seq
-
-  // ── ITCM write mux: testbench loader vs BIU store ─────────────────
-  let itcm_wr_mux_en:   Bool     = itcm_wr_en | biu_itcm_wr_en;
-  let itcm_wr_mux_addr: UInt<14> = itcm_wr_en ? itcm_wr_addr : biu_itcm_wr_addr;
-  let itcm_wr_mux_data: UInt<32> = itcm_wr_en ? itcm_wr_data : biu_itcm_wr_data;
-  let itcm_fetch_rd_en:   Bool     = itcm_cmd_valid;
-  let itcm_fetch_rd_addr: UInt<14> = itcm_cmd_addr;
-  let itcm_rsp_valid_d:   Bool     = itcm_rsp_valid_r;
-
-  comb
-    o_valid      = ifu_o_valid;
-    o_instr      = ifu_o_instr;
-    o_pc         = ifu_o_pc;
-    commit_valid = exu_commit_valid;
-  end comb
+  inst biu: e203_biu
+    clk   <- clk;
+    rst_n <- rst_n;
+    biu_active -> biu_active;
+    lsu2biu_icb_cmd_valid <- lsu2biu_icb_cmd_valid;
+    lsu2biu_icb_cmd_ready -> lsu2biu_icb_cmd_ready;
+    lsu2biu_icb_cmd_addr  <- lsu2biu_icb_cmd_addr;
+    lsu2biu_icb_cmd_read  <- lsu2biu_icb_cmd_read;
+    lsu2biu_icb_cmd_wdata <- lsu2biu_icb_cmd_wdata;
+    lsu2biu_icb_cmd_wmask <- lsu2biu_icb_cmd_wmask;
+    lsu2biu_icb_cmd_lock  <- lsu2biu_icb_cmd_lock;
+    lsu2biu_icb_cmd_excl  <- lsu2biu_icb_cmd_excl;
+    lsu2biu_icb_cmd_size  <- lsu2biu_icb_cmd_size;
+    lsu2biu_icb_cmd_burst <- 0;
+    lsu2biu_icb_cmd_beat  <- 0;
+    lsu2biu_icb_rsp_valid -> lsu2biu_icb_rsp_valid;
+    lsu2biu_icb_rsp_ready <- lsu2biu_icb_rsp_ready;
+    lsu2biu_icb_rsp_err   -> lsu2biu_icb_rsp_err;
+    lsu2biu_icb_rsp_excl_ok -> lsu2biu_icb_rsp_excl_ok;
+    lsu2biu_icb_rsp_rdata -> lsu2biu_icb_rsp_rdata;
+    ifu2biu_icb_cmd_valid <- ifu2biu_icb_cmd_valid;
+    ifu2biu_icb_cmd_ready -> ifu2biu_icb_cmd_ready;
+    ifu2biu_icb_cmd_addr  <- ifu2biu_icb_cmd_addr;
+    ifu2biu_icb_cmd_read  <- true;
+    ifu2biu_icb_cmd_wdata <- 0;
+    ifu2biu_icb_cmd_wmask <- 0;
+    ifu2biu_icb_cmd_lock  <- false;
+    ifu2biu_icb_cmd_excl  <- false;
+    ifu2biu_icb_cmd_size  <- 2;
+    ifu2biu_icb_cmd_burst <- 0;
+    ifu2biu_icb_cmd_beat  <- 0;
+    ifu2biu_icb_rsp_valid -> ifu2biu_icb_rsp_valid;
+    ifu2biu_icb_rsp_ready <- ifu2biu_icb_rsp_ready;
+    ifu2biu_icb_rsp_err   -> ifu2biu_icb_rsp_err;
+    ifu2biu_icb_rsp_excl_ok -> ifu2biu_icb_rsp_excl_ok_nc;
+    ifu2biu_icb_rsp_rdata -> ifu2biu_icb_rsp_rdata;
+    ppi_region_indic <- ppi_region_indic;
+    ppi_icb_enable   <- ppi_icb_enable;
+    ppi_icb_cmd_valid -> ppi_icb_cmd_valid;
+    ppi_icb_cmd_ready <- ppi_icb_cmd_ready;
+    ppi_icb_cmd_addr  -> ppi_icb_cmd_addr;
+    ppi_icb_cmd_read  -> ppi_icb_cmd_read;
+    ppi_icb_cmd_wdata -> ppi_icb_cmd_wdata;
+    ppi_icb_cmd_wmask -> ppi_icb_cmd_wmask;
+    ppi_icb_cmd_lock  -> ppi_icb_cmd_lock;
+    ppi_icb_cmd_excl  -> ppi_icb_cmd_excl;
+    ppi_icb_cmd_size  -> ppi_icb_cmd_size;
+    ppi_icb_cmd_burst -> ppi_icb_cmd_burst;
+    ppi_icb_cmd_beat  -> ppi_icb_cmd_beat;
+    ppi_icb_rsp_valid <- ppi_icb_rsp_valid;
+    ppi_icb_rsp_ready -> ppi_icb_rsp_ready;
+    ppi_icb_rsp_err   <- ppi_icb_rsp_err;
+    ppi_icb_rsp_excl_ok <- ppi_icb_rsp_excl_ok;
+    ppi_icb_rsp_rdata <- ppi_icb_rsp_rdata;
+    clint_region_indic <- clint_region_indic;
+    clint_icb_enable   <- clint_icb_enable;
+    clint_icb_cmd_valid -> clint_icb_cmd_valid;
+    clint_icb_cmd_ready <- clint_icb_cmd_ready;
+    clint_icb_cmd_addr  -> clint_icb_cmd_addr;
+    clint_icb_cmd_read  -> clint_icb_cmd_read;
+    clint_icb_cmd_wdata -> clint_icb_cmd_wdata;
+    clint_icb_cmd_wmask -> clint_icb_cmd_wmask;
+    clint_icb_cmd_lock  -> clint_icb_cmd_lock;
+    clint_icb_cmd_excl  -> clint_icb_cmd_excl;
+    clint_icb_cmd_size  -> clint_icb_cmd_size;
+    clint_icb_cmd_burst -> clint_icb_cmd_burst;
+    clint_icb_cmd_beat  -> clint_icb_cmd_beat;
+    clint_icb_rsp_valid <- clint_icb_rsp_valid;
+    clint_icb_rsp_ready -> clint_icb_rsp_ready;
+    clint_icb_rsp_err   <- clint_icb_rsp_err;
+    clint_icb_rsp_excl_ok <- clint_icb_rsp_excl_ok;
+    clint_icb_rsp_rdata <- clint_icb_rsp_rdata;
+    plic_region_indic <- plic_region_indic;
+    plic_icb_enable   <- plic_icb_enable;
+    plic_icb_cmd_valid -> plic_icb_cmd_valid;
+    plic_icb_cmd_ready <- plic_icb_cmd_ready;
+    plic_icb_cmd_addr  -> plic_icb_cmd_addr;
+    plic_icb_cmd_read  -> plic_icb_cmd_read;
+    plic_icb_cmd_wdata -> plic_icb_cmd_wdata;
+    plic_icb_cmd_wmask -> plic_icb_cmd_wmask;
+    plic_icb_cmd_lock  -> plic_icb_cmd_lock;
+    plic_icb_cmd_excl  -> plic_icb_cmd_excl;
+    plic_icb_cmd_size  -> plic_icb_cmd_size;
+    plic_icb_cmd_burst -> plic_icb_cmd_burst;
+    plic_icb_cmd_beat  -> plic_icb_cmd_beat;
+    plic_icb_rsp_valid <- plic_icb_rsp_valid;
+    plic_icb_rsp_ready -> plic_icb_rsp_ready;
+    plic_icb_rsp_err   <- plic_icb_rsp_err;
+    plic_icb_rsp_excl_ok <- plic_icb_rsp_excl_ok;
+    plic_icb_rsp_rdata <- plic_icb_rsp_rdata;
+    fio_region_indic <- fio_region_indic;
+    fio_icb_enable   <- fio_icb_enable;
+    fio_icb_cmd_valid -> fio_icb_cmd_valid;
+    fio_icb_cmd_ready <- fio_icb_cmd_ready;
+    fio_icb_cmd_addr  -> fio_icb_cmd_addr;
+    fio_icb_cmd_read  -> fio_icb_cmd_read;
+    fio_icb_cmd_wdata -> fio_icb_cmd_wdata;
+    fio_icb_cmd_wmask -> fio_icb_cmd_wmask;
+    fio_icb_cmd_lock  -> fio_icb_cmd_lock;
+    fio_icb_cmd_excl  -> fio_icb_cmd_excl;
+    fio_icb_cmd_size  -> fio_icb_cmd_size;
+    fio_icb_cmd_burst -> fio_icb_cmd_burst;
+    fio_icb_cmd_beat  -> fio_icb_cmd_beat;
+    fio_icb_rsp_valid <- fio_icb_rsp_valid;
+    fio_icb_rsp_ready -> fio_icb_rsp_ready;
+    fio_icb_rsp_err   <- fio_icb_rsp_err;
+    fio_icb_rsp_excl_ok <- fio_icb_rsp_excl_ok;
+    fio_icb_rsp_rdata <- fio_icb_rsp_rdata;
+    mem_icb_enable   <- mem_icb_enable;
+    mem_icb_cmd_valid -> mem_icb_cmd_valid;
+    mem_icb_cmd_ready <- mem_icb_cmd_ready;
+    mem_icb_cmd_addr  -> mem_icb_cmd_addr;
+    mem_icb_cmd_read  -> mem_icb_cmd_read;
+    mem_icb_cmd_wdata -> mem_icb_cmd_wdata;
+    mem_icb_cmd_wmask -> mem_icb_cmd_wmask;
+    mem_icb_cmd_lock  -> mem_icb_cmd_lock;
+    mem_icb_cmd_excl  -> mem_icb_cmd_excl;
+    mem_icb_cmd_size  -> mem_icb_cmd_size;
+    mem_icb_cmd_burst -> mem_icb_cmd_burst;
+    mem_icb_cmd_beat  -> mem_icb_cmd_beat;
+    mem_icb_rsp_valid <- mem_icb_rsp_valid;
+    mem_icb_rsp_ready -> mem_icb_rsp_ready;
+    mem_icb_rsp_err   <- mem_icb_rsp_err;
+    mem_icb_rsp_excl_ok <- mem_icb_rsp_excl_ok;
+    mem_icb_rsp_rdata <- mem_icb_rsp_rdata;
+  end inst biu
 
 end module e203_core_top

--- a/tests/e203/e203_core_top.sv
+++ b/tests/e203/e203_core_top.sv
@@ -1,222 +1,670 @@
-// E203 Core Top-Level Integration
-// Full integration: IFU + EXU + LSU + BIU + ITCM + DTCM + CLINT
-// Testbench loads instructions into ITCM via write port, then
-// the IFU fetches and the core executes autonomously.
-module CoreTop #(
-  parameter int XLEN = 32
-) (
+// domain SysDomain
+//   freq_mhz: 100
+
+// domain SysDomain
+//   freq_mhz: 100
+
+// domain SysDomain
+//   freq_mhz: 100
+
+// domain SysDomain
+//   freq_mhz: 100
+
+// domain SysDomain
+//   freq_mhz: 100
+
+// domain SysDomain
+//   freq_mhz: 100
+
+// domain SysDomain
+//   freq_mhz: 100
+
+module e203_core_top (
   input logic clk,
   input logic rst_n,
-  input logic itcm_wr_en,
-  input logic [14-1:0] itcm_wr_addr,
-  input logic [32-1:0] itcm_wr_data,
-  input logic exu_redirect,
-  input logic [32-1:0] exu_redirect_pc,
-  output logic commit_valid,
-  output logic [32-1:0] o_instr,
-  output logic [32-1:0] o_pc,
-  output logic o_valid,
-  output logic tmr_irq
+  input logic test_mode,
+  output logic [31:0] inspect_pc,
+  output logic core_wfi,
+  output logic tm_stop,
+  output logic core_cgstop,
+  output logic tcm_cgstop,
+  output logic exu_active,
+  output logic ifu_active,
+  output logic lsu_active,
+  output logic biu_active,
+  input logic [31:0] pc_rtvec,
+  input logic [31:0] core_mhartid,
+  input logic dbg_irq_r,
+  input logic lcl_irq_r,
+  input logic evt_r,
+  input logic ext_irq_r,
+  input logic sft_irq_r,
+  input logic tmr_irq_r,
+  output logic wr_dcsr_ena,
+  output logic wr_dpc_ena,
+  output logic wr_dscratch_ena,
+  output logic [31:0] wr_csr_nxt,
+  input logic [31:0] dcsr_r,
+  input logic [31:0] dpc_r,
+  input logic [31:0] dscratch_r,
+  output logic [31:0] cmt_dpc,
+  output logic cmt_dpc_ena,
+  output logic [2:0] cmt_dcause,
+  output logic cmt_dcause_ena,
+  input logic dbg_mode,
+  input logic dbg_halt_r,
+  input logic dbg_step_r,
+  input logic dbg_ebreakm_r,
+  input logic dbg_stopcycle,
+  input logic [31:0] itcm_region_indic,
+  input logic ifu2itcm_holdup,
+  output logic ifu2itcm_icb_cmd_valid,
+  input logic ifu2itcm_icb_cmd_ready,
+  output logic [15:0] ifu2itcm_icb_cmd_addr,
+  input logic ifu2itcm_icb_rsp_valid,
+  output logic ifu2itcm_icb_rsp_ready,
+  input logic ifu2itcm_icb_rsp_err,
+  input logic [63:0] ifu2itcm_icb_rsp_rdata,
+  output logic lsu2itcm_icb_cmd_valid,
+  input logic lsu2itcm_icb_cmd_ready,
+  output logic [15:0] lsu2itcm_icb_cmd_addr,
+  output logic lsu2itcm_icb_cmd_read,
+  output logic [31:0] lsu2itcm_icb_cmd_wdata,
+  output logic [3:0] lsu2itcm_icb_cmd_wmask,
+  output logic lsu2itcm_icb_cmd_lock,
+  output logic lsu2itcm_icb_cmd_excl,
+  output logic [1:0] lsu2itcm_icb_cmd_size,
+  input logic lsu2itcm_icb_rsp_valid,
+  output logic lsu2itcm_icb_rsp_ready,
+  input logic lsu2itcm_icb_rsp_err,
+  input logic lsu2itcm_icb_rsp_excl_ok,
+  input logic [31:0] lsu2itcm_icb_rsp_rdata,
+  input logic [31:0] dtcm_region_indic,
+  output logic lsu2dtcm_icb_cmd_valid,
+  input logic lsu2dtcm_icb_cmd_ready,
+  output logic [15:0] lsu2dtcm_icb_cmd_addr,
+  output logic lsu2dtcm_icb_cmd_read,
+  output logic [31:0] lsu2dtcm_icb_cmd_wdata,
+  output logic [3:0] lsu2dtcm_icb_cmd_wmask,
+  output logic lsu2dtcm_icb_cmd_lock,
+  output logic lsu2dtcm_icb_cmd_excl,
+  output logic [1:0] lsu2dtcm_icb_cmd_size,
+  input logic lsu2dtcm_icb_rsp_valid,
+  output logic lsu2dtcm_icb_rsp_ready,
+  input logic lsu2dtcm_icb_rsp_err,
+  input logic lsu2dtcm_icb_rsp_excl_ok,
+  input logic [31:0] lsu2dtcm_icb_rsp_rdata,
+  input logic [31:0] ppi_region_indic,
+  input logic ppi_icb_enable,
+  output logic ppi_icb_cmd_valid,
+  input logic ppi_icb_cmd_ready,
+  output logic [31:0] ppi_icb_cmd_addr,
+  output logic ppi_icb_cmd_read,
+  output logic [31:0] ppi_icb_cmd_wdata,
+  output logic [3:0] ppi_icb_cmd_wmask,
+  output logic ppi_icb_cmd_lock,
+  output logic ppi_icb_cmd_excl,
+  output logic [1:0] ppi_icb_cmd_size,
+  output logic [1:0] ppi_icb_cmd_burst,
+  output logic [1:0] ppi_icb_cmd_beat,
+  input logic ppi_icb_rsp_valid,
+  output logic ppi_icb_rsp_ready,
+  input logic ppi_icb_rsp_err,
+  input logic ppi_icb_rsp_excl_ok,
+  input logic [31:0] ppi_icb_rsp_rdata,
+  input logic [31:0] clint_region_indic,
+  input logic clint_icb_enable,
+  output logic clint_icb_cmd_valid,
+  input logic clint_icb_cmd_ready,
+  output logic [31:0] clint_icb_cmd_addr,
+  output logic clint_icb_cmd_read,
+  output logic [31:0] clint_icb_cmd_wdata,
+  output logic [3:0] clint_icb_cmd_wmask,
+  output logic clint_icb_cmd_lock,
+  output logic clint_icb_cmd_excl,
+  output logic [1:0] clint_icb_cmd_size,
+  output logic [1:0] clint_icb_cmd_burst,
+  output logic [1:0] clint_icb_cmd_beat,
+  input logic clint_icb_rsp_valid,
+  output logic clint_icb_rsp_ready,
+  input logic clint_icb_rsp_err,
+  input logic clint_icb_rsp_excl_ok,
+  input logic [31:0] clint_icb_rsp_rdata,
+  input logic [31:0] plic_region_indic,
+  input logic plic_icb_enable,
+  output logic plic_icb_cmd_valid,
+  input logic plic_icb_cmd_ready,
+  output logic [31:0] plic_icb_cmd_addr,
+  output logic plic_icb_cmd_read,
+  output logic [31:0] plic_icb_cmd_wdata,
+  output logic [3:0] plic_icb_cmd_wmask,
+  output logic plic_icb_cmd_lock,
+  output logic plic_icb_cmd_excl,
+  output logic [1:0] plic_icb_cmd_size,
+  output logic [1:0] plic_icb_cmd_burst,
+  output logic [1:0] plic_icb_cmd_beat,
+  input logic plic_icb_rsp_valid,
+  output logic plic_icb_rsp_ready,
+  input logic plic_icb_rsp_err,
+  input logic plic_icb_rsp_excl_ok,
+  input logic [31:0] plic_icb_rsp_rdata,
+  input logic [31:0] fio_region_indic,
+  input logic fio_icb_enable,
+  output logic fio_icb_cmd_valid,
+  input logic fio_icb_cmd_ready,
+  output logic [31:0] fio_icb_cmd_addr,
+  output logic fio_icb_cmd_read,
+  output logic [31:0] fio_icb_cmd_wdata,
+  output logic [3:0] fio_icb_cmd_wmask,
+  output logic fio_icb_cmd_lock,
+  output logic fio_icb_cmd_excl,
+  output logic [1:0] fio_icb_cmd_size,
+  output logic [1:0] fio_icb_cmd_burst,
+  output logic [1:0] fio_icb_cmd_beat,
+  input logic fio_icb_rsp_valid,
+  output logic fio_icb_rsp_ready,
+  input logic fio_icb_rsp_err,
+  input logic fio_icb_rsp_excl_ok,
+  input logic [31:0] fio_icb_rsp_rdata,
+  input logic mem_icb_enable,
+  output logic mem_icb_cmd_valid,
+  input logic mem_icb_cmd_ready,
+  output logic [31:0] mem_icb_cmd_addr,
+  output logic mem_icb_cmd_read,
+  output logic [31:0] mem_icb_cmd_wdata,
+  output logic [3:0] mem_icb_cmd_wmask,
+  output logic mem_icb_cmd_lock,
+  output logic mem_icb_cmd_excl,
+  output logic [1:0] mem_icb_cmd_size,
+  output logic [1:0] mem_icb_cmd_burst,
+  output logic [1:0] mem_icb_cmd_beat,
+  input logic mem_icb_rsp_valid,
+  output logic mem_icb_rsp_ready,
+  input logic mem_icb_rsp_err,
+  input logic mem_icb_rsp_excl_ok,
+  input logic [31:0] mem_icb_rsp_rdata,
+  input logic nice_mem_holdup,
+  output logic nice_req_valid,
+  input logic nice_req_ready,
+  output logic [31:0] nice_req_inst,
+  output logic [31:0] nice_req_rs1,
+  output logic [31:0] nice_req_rs2,
+  input logic nice_rsp_multicyc_valid,
+  output logic nice_rsp_multicyc_ready,
+  input logic [31:0] nice_rsp_multicyc_dat,
+  input logic nice_rsp_multicyc_err,
+  input logic nice_icb_cmd_valid,
+  output logic nice_icb_cmd_ready,
+  input logic [31:0] nice_icb_cmd_addr,
+  input logic nice_icb_cmd_read,
+  input logic [31:0] nice_icb_cmd_wdata,
+  input logic [1:0] nice_icb_cmd_size,
+  output logic nice_icb_rsp_valid,
+  input logic nice_icb_rsp_ready,
+  output logic [31:0] nice_icb_rsp_rdata,
+  output logic nice_icb_rsp_err
 );
 
-  // ── ITCM write port (for testbench to load program) ────────────────
-  // ── Branch redirect from EXU to IFU ────────────────────────────────
-  // ── Status outputs ─────────────────────────────────────────────────
-  // ── ITCM ───────────────────────────────────────────────────────────
-  logic [32-1:0] itcm_fetch_rd_data;
-  E203Itcm itcm (
-    .clk(clk),
-    .rst_n(rst_n),
-    .rd_en(itcm_fetch_rd_en),
-    .rd_addr(itcm_fetch_rd_addr),
-    .rd_data(itcm_fetch_rd_data),
-    .wr_en(itcm_wr_mux_en),
-    .wr_addr(itcm_wr_mux_addr),
-    .wr_data(itcm_wr_mux_data)
-  );
-  // ── IFU ────────────────────────────────────────────────────────────
+  logic [0:0] agu_icb_cmd_itag_u;
+  logic [4:0] lsu_o_wbck_itag_x;
   logic ifu_o_valid;
-  logic [32-1:0] ifu_o_instr;
-  logic [32-1:0] ifu_o_pc;
-  logic ifu_bus_err;
-  logic itcm_cmd_valid;
-  logic [14-1:0] itcm_cmd_addr;
-  logic ifu_rsp_ready;
-  logic ifu_bpu_wait;
-  logic ifu_bpu_rs1_ena;
-  logic ifu_prdt_taken;
-  logic [32-1:0] ifu_pc_op1;
-  logic [32-1:0] ifu_pc_op2;
-  logic ifu_dec_bjp;
-  logic ifu_dec_lui;
-  logic ifu_dec_auipc;
-  IfuTop ifu (
+  logic ifu_o_ready;
+  logic [31:0] ifu_o_ir;
+  logic [31:0] ifu_o_pc;
+  logic ifu_o_pc_vld;
+  logic ifu_o_misalgn;
+  logic ifu_o_buserr;
+  logic [4:0] ifu_o_rs1idx;
+  logic [4:0] ifu_o_rs2idx;
+  logic ifu_o_prdt_taken;
+  logic ifu_o_muldiv_b2b;
+  logic wfi_halt_ifu_req;
+  logic wfi_halt_ifu_ack;
+  logic pipe_flush_req;
+  logic pipe_flush_ack;
+  logic [31:0] pipe_flush_add_op1;
+  logic [31:0] pipe_flush_add_op2;
+  logic [31:0] pipe_flush_pc;
+  logic oitf_empty;
+  logic [31:0] rf2ifu_x1;
+  logic [31:0] rf2ifu_rs1;
+  logic dec2ifu_rden;
+  logic dec2ifu_rs1en;
+  logic [4:0] dec2ifu_rdidx;
+  logic dec2ifu_mulhsu;
+  logic dec2ifu_div;
+  logic dec2ifu_rem;
+  logic dec2ifu_divu;
+  logic dec2ifu_remu;
+  logic itcm_nohold;
+  logic lsu_o_valid;
+  logic lsu_o_ready;
+  logic [31:0] lsu_o_wbck_wdat;
+  logic [0:0] lsu_o_wbck_itag;
+  logic lsu_o_wbck_err;
+  logic lsu_o_cmt_ld;
+  logic lsu_o_cmt_st;
+  logic [31:0] lsu_o_cmt_badaddr;
+  logic lsu_o_cmt_buserr;
+  logic agu_icb_cmd_valid;
+  logic agu_icb_cmd_ready;
+  logic [31:0] agu_icb_cmd_addr;
+  logic agu_icb_cmd_read;
+  logic [31:0] agu_icb_cmd_wdata;
+  logic [3:0] agu_icb_cmd_wmask;
+  logic agu_icb_cmd_lock;
+  logic agu_icb_cmd_excl;
+  logic [1:0] agu_icb_cmd_size;
+  logic agu_icb_cmd_back2agu;
+  logic agu_icb_cmd_usign;
+  logic agu_icb_cmd_itag;
+  logic agu_icb_rsp_valid;
+  logic agu_icb_rsp_ready;
+  logic agu_icb_rsp_err;
+  logic agu_icb_rsp_excl_ok;
+  logic [31:0] agu_icb_rsp_rdata;
+  logic commit_mret;
+  logic commit_trap;
+  logic excp_active;
+  logic lsu2biu_icb_cmd_valid;
+  logic lsu2biu_icb_cmd_ready;
+  logic [31:0] lsu2biu_icb_cmd_addr;
+  logic lsu2biu_icb_cmd_read;
+  logic [31:0] lsu2biu_icb_cmd_wdata;
+  logic [3:0] lsu2biu_icb_cmd_wmask;
+  logic lsu2biu_icb_cmd_lock;
+  logic lsu2biu_icb_cmd_excl;
+  logic [1:0] lsu2biu_icb_cmd_size;
+  logic lsu2biu_icb_rsp_valid;
+  logic lsu2biu_icb_rsp_ready;
+  logic lsu2biu_icb_rsp_err;
+  logic lsu2biu_icb_rsp_excl_ok;
+  logic [31:0] lsu2biu_icb_rsp_rdata;
+  logic ifu2biu_icb_cmd_valid;
+  logic ifu2biu_icb_cmd_ready;
+  logic [31:0] ifu2biu_icb_cmd_addr;
+  logic ifu2biu_icb_rsp_valid;
+  logic ifu2biu_icb_rsp_ready;
+  logic ifu2biu_icb_rsp_err;
+  logic [31:0] ifu2biu_icb_rsp_rdata;
+  logic ifu2biu_icb_rsp_excl_ok_nc;
+  logic nice_icb_rsp_excl_ok_nc;
+  assign agu_icb_cmd_itag_u = agu_icb_cmd_itag ? 1 : 0;
+  assign lsu_o_wbck_itag_x = 5'($unsigned(lsu_o_wbck_itag));
+  e203_ifu_top ifu (
     .clk(clk),
     .rst_n(rst_n),
-    .o_ready(1'b1),
-    .exu_redirect(exu_redirect),
-    .exu_redirect_pc(exu_redirect_pc),
-    .itcm_cmd_ready(1'b1),
-    .itcm_rsp_valid(itcm_rsp_valid_d),
-    .itcm_rsp_data(itcm_fetch_rd_data),
-    .oitf_empty(1'b1),
-    .ir_empty(1'b1),
-    .ir_rs1en(1'b0),
-    .jalr_rs1idx_cam_irrdidx(1'b0),
-    .ir_valid_clr(1'b0),
-    .rf2bpu_x1(0),
-    .rf2bpu_rs1(0),
-    .o_valid(ifu_o_valid),
-    .o_instr(ifu_o_instr),
-    .o_pc(ifu_o_pc),
-    .o_bus_err(ifu_bus_err),
-    .itcm_cmd_valid(itcm_cmd_valid),
-    .itcm_cmd_addr(itcm_cmd_addr),
-    .itcm_rsp_ready(ifu_rsp_ready),
-    .bpu_wait(ifu_bpu_wait),
-    .bpu2rf_rs1_ena(ifu_bpu_rs1_ena),
-    .prdt_taken(ifu_prdt_taken),
-    .prdt_pc_add_op1(ifu_pc_op1),
-    .prdt_pc_add_op2(ifu_pc_op2),
-    .dec_is_bjp(ifu_dec_bjp),
-    .dec_is_lui(ifu_dec_lui),
-    .dec_is_auipc(ifu_dec_auipc)
+    .itcm_nohold(itcm_nohold),
+    .pc_rtvec(pc_rtvec),
+    .ifu2itcm_holdup(ifu2itcm_holdup),
+    .itcm_region_indic(itcm_region_indic),
+    .ifu2itcm_icb_cmd_valid(ifu2itcm_icb_cmd_valid),
+    .ifu2itcm_icb_cmd_ready(ifu2itcm_icb_cmd_ready),
+    .ifu2itcm_icb_cmd_addr(ifu2itcm_icb_cmd_addr),
+    .ifu2itcm_icb_rsp_valid(ifu2itcm_icb_rsp_valid),
+    .ifu2itcm_icb_rsp_ready(ifu2itcm_icb_rsp_ready),
+    .ifu2itcm_icb_rsp_err(ifu2itcm_icb_rsp_err),
+    .ifu2itcm_icb_rsp_rdata(ifu2itcm_icb_rsp_rdata),
+    .ifu2biu_icb_cmd_valid(ifu2biu_icb_cmd_valid),
+    .ifu2biu_icb_cmd_ready(ifu2biu_icb_cmd_ready),
+    .ifu2biu_icb_cmd_addr(ifu2biu_icb_cmd_addr),
+    .ifu2biu_icb_rsp_valid(ifu2biu_icb_rsp_valid),
+    .ifu2biu_icb_rsp_ready(ifu2biu_icb_rsp_ready),
+    .ifu2biu_icb_rsp_err(ifu2biu_icb_rsp_err),
+    .ifu2biu_icb_rsp_rdata(ifu2biu_icb_rsp_rdata),
+    .ifu_o_ir(ifu_o_ir),
+    .ifu_o_pc(ifu_o_pc),
+    .ifu_o_pc_vld(ifu_o_pc_vld),
+    .ifu_o_misalgn(ifu_o_misalgn),
+    .ifu_o_buserr(ifu_o_buserr),
+    .ifu_o_rs1idx(ifu_o_rs1idx),
+    .ifu_o_rs2idx(ifu_o_rs2idx),
+    .ifu_o_prdt_taken(ifu_o_prdt_taken),
+    .ifu_o_muldiv_b2b(ifu_o_muldiv_b2b),
+    .ifu_o_valid(ifu_o_valid),
+    .ifu_o_ready(ifu_o_ready),
+    .pipe_flush_ack(pipe_flush_ack),
+    .pipe_flush_req(pipe_flush_req),
+    .pipe_flush_add_op1(pipe_flush_add_op1),
+    .pipe_flush_add_op2(pipe_flush_add_op2),
+    .pipe_flush_pc(pipe_flush_pc),
+    .ifu_halt_req(wfi_halt_ifu_req),
+    .ifu_halt_ack(wfi_halt_ifu_ack),
+    .oitf_empty(oitf_empty),
+    .rf2ifu_x1(rf2ifu_x1),
+    .rf2ifu_rs1(rf2ifu_rs1),
+    .dec2ifu_rden(dec2ifu_rden),
+    .dec2ifu_rs1en(dec2ifu_rs1en),
+    .dec2ifu_rdidx(dec2ifu_rdidx),
+    .dec2ifu_mulhsu(dec2ifu_mulhsu),
+    .dec2ifu_div(dec2ifu_div),
+    .dec2ifu_rem(dec2ifu_rem),
+    .dec2ifu_divu(dec2ifu_divu),
+    .dec2ifu_remu(dec2ifu_remu),
+    .inspect_pc(inspect_pc),
+    .ifu_active(ifu_active)
   );
-  // ── EXU ────────────────────────────────────────────────────────────
-  logic exu_ifu_ready;
-  logic exu_bjp_valid;
-  logic exu_bjp_taken;
-  logic [32-1:0] exu_bjp_tgt;
-  logic exu_lsu_valid;
-  logic [32-1:0] exu_lsu_addr;
-  logic [32-1:0] exu_lsu_wdata;
-  logic exu_lsu_load;
-  logic exu_lsu_store;
-  logic exu_commit_valid;
-  ExuTop exu (
+  e203_exu_top exu (
+    .clk(clk),
+    .clk_aon(clk),
+    .rst_n(rst_n),
+    .test_mode(test_mode),
+    .i_valid(ifu_o_valid),
+    .i_ready(ifu_o_ready),
+    .i_ir(ifu_o_ir),
+    .i_pc(ifu_o_pc),
+    .i_pc_vld(ifu_o_pc_vld),
+    .i_misalgn(ifu_o_misalgn),
+    .i_buserr(ifu_o_buserr),
+    .i_prdt_taken(ifu_o_prdt_taken),
+    .i_muldiv_b2b(ifu_o_muldiv_b2b),
+    .i_rs1idx(ifu_o_rs1idx),
+    .i_rs2idx(ifu_o_rs2idx),
+    .pipe_flush_req(pipe_flush_req),
+    .pipe_flush_ack(pipe_flush_ack),
+    .pipe_flush_add_op1(pipe_flush_add_op1),
+    .pipe_flush_add_op2(pipe_flush_add_op2),
+    .pipe_flush_pc(pipe_flush_pc),
+    .wfi_halt_ifu_req(wfi_halt_ifu_req),
+    .wfi_halt_ifu_ack(wfi_halt_ifu_ack),
+    .lsu_o_valid(lsu_o_valid),
+    .lsu_o_ready(lsu_o_ready),
+    .lsu_o_wbck_wdat(lsu_o_wbck_wdat),
+    .lsu_o_wbck_itag(lsu_o_wbck_itag_x),
+    .lsu_o_wbck_err(lsu_o_wbck_err),
+    .lsu_o_cmt_ld(lsu_o_cmt_ld),
+    .lsu_o_cmt_st(lsu_o_cmt_st),
+    .lsu_o_cmt_badaddr(lsu_o_cmt_badaddr),
+    .lsu_o_cmt_buserr(lsu_o_cmt_buserr),
+    .agu_icb_cmd_valid(agu_icb_cmd_valid),
+    .agu_icb_cmd_ready(agu_icb_cmd_ready),
+    .agu_icb_cmd_addr(agu_icb_cmd_addr),
+    .agu_icb_cmd_read(agu_icb_cmd_read),
+    .agu_icb_cmd_wdata(agu_icb_cmd_wdata),
+    .agu_icb_cmd_wmask(agu_icb_cmd_wmask),
+    .agu_icb_cmd_lock(agu_icb_cmd_lock),
+    .agu_icb_cmd_excl(agu_icb_cmd_excl),
+    .agu_icb_cmd_size(agu_icb_cmd_size),
+    .agu_icb_cmd_back2agu(agu_icb_cmd_back2agu),
+    .agu_icb_cmd_usign(agu_icb_cmd_usign),
+    .agu_icb_cmd_itag(agu_icb_cmd_itag),
+    .agu_icb_rsp_valid(agu_icb_rsp_valid),
+    .agu_icb_rsp_ready(agu_icb_rsp_ready),
+    .agu_icb_rsp_err(agu_icb_rsp_err),
+    .agu_icb_rsp_excl_ok(agu_icb_rsp_excl_ok),
+    .agu_icb_rsp_rdata(agu_icb_rsp_rdata),
+    .dbg_mode(dbg_mode),
+    .dbg_halt_r(dbg_halt_r),
+    .dbg_step_r(dbg_step_r),
+    .dbg_ebreakm_r(dbg_ebreakm_r),
+    .dbg_stopcycle(dbg_stopcycle),
+    .dbg_irq_r(dbg_irq_r),
+    .lcl_irq_r(lcl_irq_r),
+    .evt_r(evt_r),
+    .ext_irq_r(ext_irq_r),
+    .sft_irq_r(sft_irq_r),
+    .tmr_irq_r(tmr_irq_r),
+    .cmt_dpc(cmt_dpc),
+    .cmt_dpc_ena(cmt_dpc_ena),
+    .cmt_dcause(cmt_dcause),
+    .cmt_dcause_ena(cmt_dcause_ena),
+    .wr_dcsr_ena(wr_dcsr_ena),
+    .wr_dpc_ena(wr_dpc_ena),
+    .wr_dscratch_ena(wr_dscratch_ena),
+    .wr_csr_nxt(wr_csr_nxt),
+    .dcsr_r(dcsr_r),
+    .dpc_r(dpc_r),
+    .dscratch_r(dscratch_r),
+    .core_wfi(core_wfi),
+    .rf2ifu_x1(rf2ifu_x1),
+    .rf2ifu_rs1(rf2ifu_rs1),
+    .dec2ifu_rden(dec2ifu_rden),
+    .dec2ifu_rs1en(dec2ifu_rs1en),
+    .dec2ifu_rdidx(dec2ifu_rdidx),
+    .dec2ifu_mulhsu(dec2ifu_mulhsu),
+    .dec2ifu_div(dec2ifu_div),
+    .dec2ifu_rem(dec2ifu_rem),
+    .dec2ifu_divu(dec2ifu_divu),
+    .dec2ifu_remu(dec2ifu_remu),
+    .oitf_empty(oitf_empty),
+    .exu_active(exu_active),
+    .excp_active(excp_active),
+    .commit_mret(commit_mret),
+    .commit_trap(commit_trap),
+    .core_mhartid(core_mhartid),
+    .tm_stop(tm_stop),
+    .itcm_nohold(itcm_nohold),
+    .core_cgstop(core_cgstop),
+    .tcm_cgstop(tcm_cgstop),
+    .nice_req_valid(nice_req_valid),
+    .nice_req_ready(nice_req_ready),
+    .nice_req_inst(nice_req_inst),
+    .nice_req_rs1(nice_req_rs1),
+    .nice_req_rs2(nice_req_rs2),
+    .nice_rsp_multicyc_valid(nice_rsp_multicyc_valid),
+    .nice_rsp_multicyc_ready(nice_rsp_multicyc_ready),
+    .nice_rsp_multicyc_dat(nice_rsp_multicyc_dat),
+    .nice_rsp_multicyc_err(nice_rsp_multicyc_err)
+  );
+  e203_lsu lsu (
     .clk(clk),
     .rst_n(rst_n),
-    .ifu_valid(ifu_o_valid),
-    .ifu_instr(ifu_o_instr),
-    .ifu_pc(ifu_o_pc),
-    .ifu_ready(exu_ifu_ready),
-    .o_bjp_valid(exu_bjp_valid),
-    .o_bjp_taken(exu_bjp_taken),
-    .o_bjp_tgt(exu_bjp_tgt),
-    .lsu_valid(exu_lsu_valid),
-    .lsu_ready(1'b1),
-    .lsu_addr(exu_lsu_addr),
-    .lsu_wdata(exu_lsu_wdata),
-    .lsu_load(exu_lsu_load),
-    .lsu_store(exu_lsu_store),
-    .lsu_resp_valid(1'b0),
-    .lsu_resp_data(0),
-    .o_commit_valid(exu_commit_valid)
+    .commit_mret(commit_mret),
+    .commit_trap(commit_trap),
+    .excp_active(excp_active),
+    .lsu_active(lsu_active),
+    .itcm_region_indic(itcm_region_indic),
+    .dtcm_region_indic(dtcm_region_indic),
+    .lsu_o_valid(lsu_o_valid),
+    .lsu_o_ready(lsu_o_ready),
+    .lsu_o_wbck_wdat(lsu_o_wbck_wdat),
+    .lsu_o_wbck_itag(lsu_o_wbck_itag),
+    .lsu_o_wbck_err(lsu_o_wbck_err),
+    .lsu_o_cmt_ld(lsu_o_cmt_ld),
+    .lsu_o_cmt_st(lsu_o_cmt_st),
+    .lsu_o_cmt_badaddr(lsu_o_cmt_badaddr),
+    .lsu_o_cmt_buserr(lsu_o_cmt_buserr),
+    .agu_icb_cmd_valid(agu_icb_cmd_valid),
+    .agu_icb_cmd_ready(agu_icb_cmd_ready),
+    .agu_icb_cmd_addr(agu_icb_cmd_addr),
+    .agu_icb_cmd_read(agu_icb_cmd_read),
+    .agu_icb_cmd_wdata(agu_icb_cmd_wdata),
+    .agu_icb_cmd_wmask(agu_icb_cmd_wmask),
+    .agu_icb_cmd_lock(agu_icb_cmd_lock),
+    .agu_icb_cmd_excl(agu_icb_cmd_excl),
+    .agu_icb_cmd_size(agu_icb_cmd_size),
+    .agu_icb_cmd_back2agu(agu_icb_cmd_back2agu),
+    .agu_icb_cmd_usign(agu_icb_cmd_usign),
+    .agu_icb_cmd_itag(agu_icb_cmd_itag_u),
+    .agu_icb_rsp_valid(agu_icb_rsp_valid),
+    .agu_icb_rsp_ready(agu_icb_rsp_ready),
+    .agu_icb_rsp_err(agu_icb_rsp_err),
+    .agu_icb_rsp_excl_ok(agu_icb_rsp_excl_ok),
+    .agu_icb_rsp_rdata(agu_icb_rsp_rdata),
+    .itcm_icb_cmd_valid(lsu2itcm_icb_cmd_valid),
+    .itcm_icb_cmd_ready(lsu2itcm_icb_cmd_ready),
+    .itcm_icb_cmd_addr(lsu2itcm_icb_cmd_addr),
+    .itcm_icb_cmd_read(lsu2itcm_icb_cmd_read),
+    .itcm_icb_cmd_wdata(lsu2itcm_icb_cmd_wdata),
+    .itcm_icb_cmd_wmask(lsu2itcm_icb_cmd_wmask),
+    .itcm_icb_cmd_lock(lsu2itcm_icb_cmd_lock),
+    .itcm_icb_cmd_excl(lsu2itcm_icb_cmd_excl),
+    .itcm_icb_cmd_size(lsu2itcm_icb_cmd_size),
+    .itcm_icb_rsp_valid(lsu2itcm_icb_rsp_valid),
+    .itcm_icb_rsp_ready(lsu2itcm_icb_rsp_ready),
+    .itcm_icb_rsp_err(lsu2itcm_icb_rsp_err),
+    .itcm_icb_rsp_excl_ok(lsu2itcm_icb_rsp_excl_ok),
+    .itcm_icb_rsp_rdata(lsu2itcm_icb_rsp_rdata),
+    .dtcm_icb_cmd_valid(lsu2dtcm_icb_cmd_valid),
+    .dtcm_icb_cmd_ready(lsu2dtcm_icb_cmd_ready),
+    .dtcm_icb_cmd_addr(lsu2dtcm_icb_cmd_addr),
+    .dtcm_icb_cmd_read(lsu2dtcm_icb_cmd_read),
+    .dtcm_icb_cmd_wdata(lsu2dtcm_icb_cmd_wdata),
+    .dtcm_icb_cmd_wmask(lsu2dtcm_icb_cmd_wmask),
+    .dtcm_icb_cmd_lock(lsu2dtcm_icb_cmd_lock),
+    .dtcm_icb_cmd_excl(lsu2dtcm_icb_cmd_excl),
+    .dtcm_icb_cmd_size(lsu2dtcm_icb_cmd_size),
+    .dtcm_icb_rsp_valid(lsu2dtcm_icb_rsp_valid),
+    .dtcm_icb_rsp_ready(lsu2dtcm_icb_rsp_ready),
+    .dtcm_icb_rsp_err(lsu2dtcm_icb_rsp_err),
+    .dtcm_icb_rsp_excl_ok(lsu2dtcm_icb_rsp_excl_ok),
+    .dtcm_icb_rsp_rdata(lsu2dtcm_icb_rsp_rdata),
+    .biu_icb_cmd_valid(lsu2biu_icb_cmd_valid),
+    .biu_icb_cmd_ready(lsu2biu_icb_cmd_ready),
+    .biu_icb_cmd_addr(lsu2biu_icb_cmd_addr),
+    .biu_icb_cmd_read(lsu2biu_icb_cmd_read),
+    .biu_icb_cmd_wdata(lsu2biu_icb_cmd_wdata),
+    .biu_icb_cmd_wmask(lsu2biu_icb_cmd_wmask),
+    .biu_icb_cmd_lock(lsu2biu_icb_cmd_lock),
+    .biu_icb_cmd_excl(lsu2biu_icb_cmd_excl),
+    .biu_icb_cmd_size(lsu2biu_icb_cmd_size),
+    .biu_icb_rsp_valid(lsu2biu_icb_rsp_valid),
+    .biu_icb_rsp_ready(lsu2biu_icb_rsp_ready),
+    .biu_icb_rsp_err(lsu2biu_icb_rsp_err),
+    .biu_icb_rsp_excl_ok(lsu2biu_icb_rsp_excl_ok),
+    .biu_icb_rsp_rdata(lsu2biu_icb_rsp_rdata),
+    .nice_mem_holdup(nice_mem_holdup),
+    .nice_icb_cmd_valid(nice_icb_cmd_valid),
+    .nice_icb_cmd_ready(nice_icb_cmd_ready),
+    .nice_icb_cmd_addr(nice_icb_cmd_addr),
+    .nice_icb_cmd_read(nice_icb_cmd_read),
+    .nice_icb_cmd_wdata(nice_icb_cmd_wdata),
+    .nice_icb_cmd_wmask(0),
+    .nice_icb_cmd_lock(1'b0),
+    .nice_icb_cmd_excl(1'b0),
+    .nice_icb_cmd_size(nice_icb_cmd_size),
+    .nice_icb_rsp_valid(nice_icb_rsp_valid),
+    .nice_icb_rsp_ready(nice_icb_rsp_ready),
+    .nice_icb_rsp_err(nice_icb_rsp_err),
+    .nice_icb_rsp_excl_ok(nice_icb_rsp_excl_ok_nc),
+    .nice_icb_rsp_rdata(nice_icb_rsp_rdata)
   );
-  // ── LSU ────────────────────────────────────────────────────────────
-  logic [32-1:0] lsu_mem_addr;
-  logic [32-1:0] lsu_mem_wdata;
-  logic [4-1:0] lsu_mem_wstrb;
-  logic lsu_mem_wen;
-  logic [32-1:0] lsu_load_result;
-  LsuCtrl lsu (
-    .addr(exu_lsu_addr),
-    .wdata(exu_lsu_wdata),
-    .funct3(2),
-    .is_load(exu_lsu_load),
-    .is_store(exu_lsu_store),
-    .mem_addr(lsu_mem_addr),
-    .mem_wdata(lsu_mem_wdata),
-    .mem_wstrb(lsu_mem_wstrb),
-    .mem_wen(lsu_mem_wen),
-    .mem_rdata(biu_lsu_rdata),
-    .load_result(lsu_load_result)
-  );
-  // ── BIU ────────────────────────────────────────────────────────────
-  logic [32-1:0] biu_lsu_rdata;
-  logic biu_itcm_rd_en;
-  logic [14-1:0] biu_itcm_rd_addr;
-  logic biu_itcm_wr_en;
-  logic [14-1:0] biu_itcm_wr_addr;
-  logic [32-1:0] biu_itcm_wr_data;
-  logic biu_dtcm_rd_en;
-  logic [14-1:0] biu_dtcm_rd_addr;
-  logic biu_dtcm_wr_en;
-  logic [14-1:0] biu_dtcm_wr_addr;
-  logic [32-1:0] biu_dtcm_wr_data;
-  logic [4-1:0] biu_dtcm_wr_be;
-  Biu bus (
-    .lsu_addr(lsu_mem_addr),
-    .lsu_wdata(lsu_mem_wdata),
-    .lsu_wstrb(lsu_mem_wstrb),
-    .lsu_wen(lsu_mem_wen),
-    .lsu_ren(exu_lsu_load),
-    .itcm_rd_data(itcm_fetch_rd_data),
-    .dtcm_rd_data(dtcm_rd_data),
-    .lsu_rdata(biu_lsu_rdata),
-    .itcm_rd_en(biu_itcm_rd_en),
-    .itcm_rd_addr(biu_itcm_rd_addr),
-    .itcm_wr_en(biu_itcm_wr_en),
-    .itcm_wr_addr(biu_itcm_wr_addr),
-    .itcm_wr_data(biu_itcm_wr_data),
-    .dtcm_rd_en(biu_dtcm_rd_en),
-    .dtcm_rd_addr(biu_dtcm_rd_addr),
-    .dtcm_wr_en(biu_dtcm_wr_en),
-    .dtcm_wr_addr(biu_dtcm_wr_addr),
-    .dtcm_wr_data(biu_dtcm_wr_data),
-    .dtcm_wr_be(biu_dtcm_wr_be)
-  );
-  // ── DTCM ───────────────────────────────────────────────────────────
-  logic [32-1:0] dtcm_rd_data;
-  Dtcm dtcm (
+  e203_biu biu (
     .clk(clk),
     .rst_n(rst_n),
-    .rd_en(biu_dtcm_rd_en),
-    .rd_addr(biu_dtcm_rd_addr),
-    .rd_dout(dtcm_rd_data),
-    .wr_en(biu_dtcm_wr_en),
-    .wr_be(biu_dtcm_wr_be),
-    .wr_addr(biu_dtcm_wr_addr),
-    .wr_din(biu_dtcm_wr_data)
+    .biu_active(biu_active),
+    .lsu2biu_icb_cmd_valid(lsu2biu_icb_cmd_valid),
+    .lsu2biu_icb_cmd_ready(lsu2biu_icb_cmd_ready),
+    .lsu2biu_icb_cmd_addr(lsu2biu_icb_cmd_addr),
+    .lsu2biu_icb_cmd_read(lsu2biu_icb_cmd_read),
+    .lsu2biu_icb_cmd_wdata(lsu2biu_icb_cmd_wdata),
+    .lsu2biu_icb_cmd_wmask(lsu2biu_icb_cmd_wmask),
+    .lsu2biu_icb_cmd_lock(lsu2biu_icb_cmd_lock),
+    .lsu2biu_icb_cmd_excl(lsu2biu_icb_cmd_excl),
+    .lsu2biu_icb_cmd_size(lsu2biu_icb_cmd_size),
+    .lsu2biu_icb_cmd_burst(0),
+    .lsu2biu_icb_cmd_beat(0),
+    .lsu2biu_icb_rsp_valid(lsu2biu_icb_rsp_valid),
+    .lsu2biu_icb_rsp_ready(lsu2biu_icb_rsp_ready),
+    .lsu2biu_icb_rsp_err(lsu2biu_icb_rsp_err),
+    .lsu2biu_icb_rsp_excl_ok(lsu2biu_icb_rsp_excl_ok),
+    .lsu2biu_icb_rsp_rdata(lsu2biu_icb_rsp_rdata),
+    .ifu2biu_icb_cmd_valid(ifu2biu_icb_cmd_valid),
+    .ifu2biu_icb_cmd_ready(ifu2biu_icb_cmd_ready),
+    .ifu2biu_icb_cmd_addr(ifu2biu_icb_cmd_addr),
+    .ifu2biu_icb_cmd_read(1'b1),
+    .ifu2biu_icb_cmd_wdata(0),
+    .ifu2biu_icb_cmd_wmask(0),
+    .ifu2biu_icb_cmd_lock(1'b0),
+    .ifu2biu_icb_cmd_excl(1'b0),
+    .ifu2biu_icb_cmd_size(2),
+    .ifu2biu_icb_cmd_burst(0),
+    .ifu2biu_icb_cmd_beat(0),
+    .ifu2biu_icb_rsp_valid(ifu2biu_icb_rsp_valid),
+    .ifu2biu_icb_rsp_ready(ifu2biu_icb_rsp_ready),
+    .ifu2biu_icb_rsp_err(ifu2biu_icb_rsp_err),
+    .ifu2biu_icb_rsp_excl_ok(ifu2biu_icb_rsp_excl_ok_nc),
+    .ifu2biu_icb_rsp_rdata(ifu2biu_icb_rsp_rdata),
+    .ppi_region_indic(ppi_region_indic),
+    .ppi_icb_enable(ppi_icb_enable),
+    .ppi_icb_cmd_valid(ppi_icb_cmd_valid),
+    .ppi_icb_cmd_ready(ppi_icb_cmd_ready),
+    .ppi_icb_cmd_addr(ppi_icb_cmd_addr),
+    .ppi_icb_cmd_read(ppi_icb_cmd_read),
+    .ppi_icb_cmd_wdata(ppi_icb_cmd_wdata),
+    .ppi_icb_cmd_wmask(ppi_icb_cmd_wmask),
+    .ppi_icb_cmd_lock(ppi_icb_cmd_lock),
+    .ppi_icb_cmd_excl(ppi_icb_cmd_excl),
+    .ppi_icb_cmd_size(ppi_icb_cmd_size),
+    .ppi_icb_cmd_burst(ppi_icb_cmd_burst),
+    .ppi_icb_cmd_beat(ppi_icb_cmd_beat),
+    .ppi_icb_rsp_valid(ppi_icb_rsp_valid),
+    .ppi_icb_rsp_ready(ppi_icb_rsp_ready),
+    .ppi_icb_rsp_err(ppi_icb_rsp_err),
+    .ppi_icb_rsp_excl_ok(ppi_icb_rsp_excl_ok),
+    .ppi_icb_rsp_rdata(ppi_icb_rsp_rdata),
+    .clint_region_indic(clint_region_indic),
+    .clint_icb_enable(clint_icb_enable),
+    .clint_icb_cmd_valid(clint_icb_cmd_valid),
+    .clint_icb_cmd_ready(clint_icb_cmd_ready),
+    .clint_icb_cmd_addr(clint_icb_cmd_addr),
+    .clint_icb_cmd_read(clint_icb_cmd_read),
+    .clint_icb_cmd_wdata(clint_icb_cmd_wdata),
+    .clint_icb_cmd_wmask(clint_icb_cmd_wmask),
+    .clint_icb_cmd_lock(clint_icb_cmd_lock),
+    .clint_icb_cmd_excl(clint_icb_cmd_excl),
+    .clint_icb_cmd_size(clint_icb_cmd_size),
+    .clint_icb_cmd_burst(clint_icb_cmd_burst),
+    .clint_icb_cmd_beat(clint_icb_cmd_beat),
+    .clint_icb_rsp_valid(clint_icb_rsp_valid),
+    .clint_icb_rsp_ready(clint_icb_rsp_ready),
+    .clint_icb_rsp_err(clint_icb_rsp_err),
+    .clint_icb_rsp_excl_ok(clint_icb_rsp_excl_ok),
+    .clint_icb_rsp_rdata(clint_icb_rsp_rdata),
+    .plic_region_indic(plic_region_indic),
+    .plic_icb_enable(plic_icb_enable),
+    .plic_icb_cmd_valid(plic_icb_cmd_valid),
+    .plic_icb_cmd_ready(plic_icb_cmd_ready),
+    .plic_icb_cmd_addr(plic_icb_cmd_addr),
+    .plic_icb_cmd_read(plic_icb_cmd_read),
+    .plic_icb_cmd_wdata(plic_icb_cmd_wdata),
+    .plic_icb_cmd_wmask(plic_icb_cmd_wmask),
+    .plic_icb_cmd_lock(plic_icb_cmd_lock),
+    .plic_icb_cmd_excl(plic_icb_cmd_excl),
+    .plic_icb_cmd_size(plic_icb_cmd_size),
+    .plic_icb_cmd_burst(plic_icb_cmd_burst),
+    .plic_icb_cmd_beat(plic_icb_cmd_beat),
+    .plic_icb_rsp_valid(plic_icb_rsp_valid),
+    .plic_icb_rsp_ready(plic_icb_rsp_ready),
+    .plic_icb_rsp_err(plic_icb_rsp_err),
+    .plic_icb_rsp_excl_ok(plic_icb_rsp_excl_ok),
+    .plic_icb_rsp_rdata(plic_icb_rsp_rdata),
+    .fio_region_indic(fio_region_indic),
+    .fio_icb_enable(fio_icb_enable),
+    .fio_icb_cmd_valid(fio_icb_cmd_valid),
+    .fio_icb_cmd_ready(fio_icb_cmd_ready),
+    .fio_icb_cmd_addr(fio_icb_cmd_addr),
+    .fio_icb_cmd_read(fio_icb_cmd_read),
+    .fio_icb_cmd_wdata(fio_icb_cmd_wdata),
+    .fio_icb_cmd_wmask(fio_icb_cmd_wmask),
+    .fio_icb_cmd_lock(fio_icb_cmd_lock),
+    .fio_icb_cmd_excl(fio_icb_cmd_excl),
+    .fio_icb_cmd_size(fio_icb_cmd_size),
+    .fio_icb_cmd_burst(fio_icb_cmd_burst),
+    .fio_icb_cmd_beat(fio_icb_cmd_beat),
+    .fio_icb_rsp_valid(fio_icb_rsp_valid),
+    .fio_icb_rsp_ready(fio_icb_rsp_ready),
+    .fio_icb_rsp_err(fio_icb_rsp_err),
+    .fio_icb_rsp_excl_ok(fio_icb_rsp_excl_ok),
+    .fio_icb_rsp_rdata(fio_icb_rsp_rdata),
+    .mem_icb_enable(mem_icb_enable),
+    .mem_icb_cmd_valid(mem_icb_cmd_valid),
+    .mem_icb_cmd_ready(mem_icb_cmd_ready),
+    .mem_icb_cmd_addr(mem_icb_cmd_addr),
+    .mem_icb_cmd_read(mem_icb_cmd_read),
+    .mem_icb_cmd_wdata(mem_icb_cmd_wdata),
+    .mem_icb_cmd_wmask(mem_icb_cmd_wmask),
+    .mem_icb_cmd_lock(mem_icb_cmd_lock),
+    .mem_icb_cmd_excl(mem_icb_cmd_excl),
+    .mem_icb_cmd_size(mem_icb_cmd_size),
+    .mem_icb_cmd_burst(mem_icb_cmd_burst),
+    .mem_icb_cmd_beat(mem_icb_cmd_beat),
+    .mem_icb_rsp_valid(mem_icb_rsp_valid),
+    .mem_icb_rsp_ready(mem_icb_rsp_ready),
+    .mem_icb_rsp_err(mem_icb_rsp_err),
+    .mem_icb_rsp_excl_ok(mem_icb_rsp_excl_ok),
+    .mem_icb_rsp_rdata(mem_icb_rsp_rdata)
   );
-  // ── CLINT Timer ────────────────────────────────────────────────────
-  logic [32-1:0] timer_rdata;
-  ClintTimer timer (
-    .clk(clk),
-    .rst(1'b0),
-    .reg_addr(0),
-    .reg_wdata(0),
-    .reg_wen(1'b0),
-    .reg_rdata(timer_rdata),
-    .tmr_irq(tmr_irq)
-  );
-  // ── ITCM fetch: IFU cmd → ITCM read port ──────────────────────────
-  // ITCM rsp_valid: delay cmd_valid by 1 cycle (ITCM latency 1)
-  logic itcm_rsp_valid_r = 1'b0;
-  always_ff @(posedge clk or negedge rst_n) begin
-    if ((!rst_n)) begin
-      itcm_rsp_valid_r <= 1'b0;
-    end else begin
-      itcm_rsp_valid_r <= itcm_cmd_valid;
-    end
-  end
-  // ── ITCM write mux: testbench loader vs BIU store ─────────────────
-  logic itcm_wr_mux_en;
-  assign itcm_wr_mux_en = (itcm_wr_en | biu_itcm_wr_en);
-  logic [14-1:0] itcm_wr_mux_addr;
-  assign itcm_wr_mux_addr = (itcm_wr_en) ? (itcm_wr_addr) : (biu_itcm_wr_addr);
-  logic [32-1:0] itcm_wr_mux_data;
-  assign itcm_wr_mux_data = (itcm_wr_en) ? (itcm_wr_data) : (biu_itcm_wr_data);
-  logic itcm_fetch_rd_en;
-  assign itcm_fetch_rd_en = itcm_cmd_valid;
-  logic [14-1:0] itcm_fetch_rd_addr;
-  assign itcm_fetch_rd_addr = itcm_cmd_addr;
-  logic itcm_rsp_valid_d;
-  assign itcm_rsp_valid_d = itcm_rsp_valid_r;
-  assign o_valid = ifu_o_valid;
-  assign o_instr = ifu_o_instr;
-  assign o_pc = ifu_o_pc;
-  assign commit_valid = exu_commit_valid;
 
 endmodule
 

--- a/tests/e203/e203_exu_top.arch
+++ b/tests/e203/e203_exu_top.arch
@@ -1,7 +1,6 @@
-// E203 Execution Unit Top-Level
-// Integrates: Decode → Dispatch → ALU/MulDiv → Wbck → Regfile
-// With OITF for long-pipe (MulDiv) hazard tracking.
-// Single-issue, in-order pipeline with valid/ready handshake.
+// E203 HBirdv2 EXU top — hierarchical integration fixture (second-generation).
+// Same real-fabric wiring as e203_exu.arch, per reference e203_exu.v:
+// Decode -> Dispatch -> ALU/OITF -> LongpWbck -> Wbck -> Commit, plus CSR and regfile.
 
 module e203_exu_top
   param XLEN: const = 32;
@@ -9,336 +8,1000 @@ module e203_exu_top
   port clk:   in Clock<SysDomain>;
   port rst_n: in Reset<Async, Low>;
 
-  // ── IFU interface ──────────────────────────────────────────────────
-  port ifu_valid:    in  Bool;
-  port ifu_ready:    out Bool;
-  port ifu_instr:    in  UInt<32>;
-  port ifu_pc:       in  UInt<32>;
+  // ══════════════════════════════════════════════════════════════════════
+  // IFU interface
+  // ══════════════════════════════════════════════════════════════════════
+  port i_valid:       in  Bool;
+  port i_ready:       out Bool;
+  port i_ir:          in  UInt<32>;
+  port i_pc:          in  UInt<32>;
+  port i_pc_vld:      in  Bool;
+  port i_misalgn:     in  Bool;
+  port i_buserr:      in  Bool;
+  port i_prdt_taken:  in  Bool;
+  port i_muldiv_b2b:  in  Bool;
+  port i_rs1idx:      in  UInt<5>;
+  port i_rs2idx:      in  UInt<5>;
 
-  // ── Branch feedback to IFU ─────────────────────────────────────────
-  port o_bjp_valid:  out Bool;
-  port o_bjp_taken:  out Bool;
-  port o_bjp_tgt:    out UInt<32>;
+  // ══════════════════════════════════════════════════════════════════════
+  // Pipe flush interface
+  // ══════════════════════════════════════════════════════════════════════
+  port pipe_flush_req:     out Bool;
+  port pipe_flush_ack:     in  Bool;
+  port pipe_flush_add_op1: out UInt<32>;
+  port pipe_flush_add_op2: out UInt<32>;
+  port pipe_flush_pc:      out UInt<32>;
 
-  // ── LSU interface ──────────────────────────────────────────────────
-  port lsu_valid:    out Bool;
-  port lsu_ready:    in  Bool;
-  port lsu_addr:     out UInt<32>;
-  port lsu_wdata:    out UInt<32>;
-  port lsu_load:     out Bool;
-  port lsu_store:    out Bool;
-  port lsu_resp_valid: in Bool;
-  port lsu_resp_data:  in UInt<32>;
+  // ══════════════════════════════════════════════════════════════════════
+  // LSU writeback interface
+  // ══════════════════════════════════════════════════════════════════════
+  port lsu_o_valid:        in  Bool;
+  port lsu_o_ready:        out Bool;
+  port lsu_o_wbck_wdat:    in  UInt<32>;
+  port lsu_o_wbck_itag:    in  UInt<5>;
+  port lsu_o_wbck_err:     in  Bool;
+  port lsu_o_cmt_ld:       in  Bool;
+  port lsu_o_cmt_st:       in  Bool;
+  port lsu_o_cmt_badaddr:  in  UInt<32>;
+  port lsu_o_cmt_buserr:   in  Bool;
 
-  // ── Commit status ──────────────────────────────────────────────────
-  port o_commit_valid: out Bool;
+  // ══════════════════════════════════════════════════════════════════════
+  // AGU ICB command interface
+  // ══════════════════════════════════════════════════════════════════════
+  port agu_icb_cmd_valid:  out Bool;
+  port agu_icb_cmd_ready:  in  Bool;
+  port agu_icb_cmd_addr:   out UInt<32>;
+  port agu_icb_cmd_read:   out Bool;
+  port agu_icb_cmd_wdata:  out UInt<32>;
+  port agu_icb_cmd_wmask:  out UInt<4>;
+  port agu_icb_cmd_lock:   out Bool;
+  port agu_icb_cmd_excl:   out Bool;
+  port agu_icb_cmd_size:   out UInt<2>;
+  port agu_icb_cmd_back2agu: out Bool;
+  port agu_icb_cmd_usign:  out Bool;
+  port agu_icb_cmd_itag:   out Bool;
 
-  // ── Decode ─────────────────────────────────────────────────────────
+  // AGU ICB response interface
+  port agu_icb_rsp_valid:  in  Bool;
+  port agu_icb_rsp_ready:  out Bool;
+  port agu_icb_rsp_rdata:  in  UInt<32>;
+  port agu_icb_rsp_err:    in  Bool;
+  port agu_icb_rsp_excl_ok: in Bool;
+
+  // ══════════════════════════════════════════════════════════════════════
+  // Debug signals
+  // ══════════════════════════════════════════════════════════════════════
+  port dbg_mode:      in Bool;
+  port dbg_halt_r:    in Bool;
+  port dbg_step_r:    in Bool;
+  port dbg_ebreakm_r: in Bool;
+  port dbg_stopcycle:  in Bool;
+
+  // ══════════════════════════════════════════════════════════════════════
+  // IRQ inputs
+  // ══════════════════════════════════════════════════════════════════════
+  port dbg_irq_r: in Bool;
+  port lcl_irq_r: in Bool;
+  port evt_r:     in Bool;
+  port ext_irq_r: in Bool;
+  port sft_irq_r: in Bool;
+  port tmr_irq_r: in Bool;
+
+  // ══════════════════════════════════════════════════════════════════════
+  // CSR debug interface
+  // ══════════════════════════════════════════════════════════════════════
+  port cmt_dpc:         out UInt<32>;
+  port cmt_dpc_ena:     out Bool;
+  port cmt_dcause:      out UInt<3>;
+  port cmt_dcause_ena:  out Bool;
+  port wr_dcsr_ena:     out Bool;
+  port wr_dpc_ena:      out Bool;
+  port wr_dscratch_ena: out Bool;
+  port wr_csr_nxt:      out UInt<32>;
+  port dcsr_r:          in  UInt<32>;
+  port dpc_r:           in  UInt<32>;
+  port dscratch_r:      in  UInt<32>;
+
+  // ══════════════════════════════════════════════════════════════════════
+  // WFI signals
+  // ══════════════════════════════════════════════════════════════════════
+  port wfi_halt_ifu_req: out Bool;
+  port wfi_halt_ifu_ack: in  Bool;
+  port core_wfi:         out Bool;
+
+  // ══════════════════════════════════════════════════════════════════════
+  // Regfile to IFU
+  // ══════════════════════════════════════════════════════════════════════
+  port rf2ifu_x1:       out UInt<32>;
+  port rf2ifu_rs1:      out UInt<32>;
+  port dec2ifu_rden:    out Bool;
+  port dec2ifu_rs1en:   out Bool;
+  port dec2ifu_rdidx:   out UInt<5>;
+  port dec2ifu_mulhsu:  out Bool;
+  port dec2ifu_div:     out Bool;
+  port dec2ifu_rem:     out Bool;
+  port dec2ifu_divu:    out Bool;
+  port dec2ifu_remu:    out Bool;
+
+  // ══════════════════════════════════════════════════════════════════════
+  // Misc status/control
+  // ══════════════════════════════════════════════════════════════════════
+  port oitf_empty:     out Bool;
+  port exu_active:     out Bool;
+  port excp_active:    out Bool;
+  port commit_mret:    out Bool;
+  port commit_trap:    out Bool;
+  port core_mhartid:   in  UInt<32>;
+  port tm_stop:        out Bool;
+  port itcm_nohold:    out Bool;
+  port core_cgstop:    out Bool;
+  port tcm_cgstop:     out Bool;
+
+  // NICE coprocessor interface
+  port nice_req_valid:          out Bool;
+  port nice_req_ready:          in  Bool;
+  port nice_req_inst:           out UInt<32>;
+  port nice_req_rs1:            out UInt<32>;
+  port nice_req_rs2:            out UInt<32>;
+  port nice_rsp_multicyc_valid: in  Bool;
+  port nice_rsp_multicyc_ready: out Bool;
+  port nice_rsp_multicyc_dat:   in  UInt<32>;
+  port nice_rsp_multicyc_err:   in  Bool;
+
+  port test_mode:      in  Bool;
+  port clk_aon:        in  Clock<SysDomain>;
+
+  // ════════════════════════════════════════════════════════════════════
+  // Internal wires -- Decode outputs
+  // ════════════════════════════════════════════════════════════════════
+  wire dec_rs1_idx: UInt<5>;
+  wire dec_rs2_idx: UInt<5>;
+  wire dec_rd_idx:  UInt<5>;
+  wire dec_imm:     UInt<32>;
+  wire dec_bjp:     Bool;
+  wire dec_mul:     Bool;
+  wire dec_mulhsu:  Bool;
+  wire dec_div:     Bool;
+  wire dec_divu:    Bool;
+  wire dec_rem:     Bool;
+  wire dec_remu:    Bool;
+  wire dec_rs1_en:  Bool;
+  wire dec_rs2_en:  Bool;
+  wire dec_rd_en:   Bool;
+  wire dec_rs1x0:   Bool;
+  wire dec_rs2x0:   Bool;
+  wire dec_info:    UInt<32>;
+  wire dec_pc_out:  UInt<32>;
+  wire dec_misalgn: Bool;
+  wire dec_buserr_out: Bool;
+  wire dec_ilegl:   Bool;
+  wire dec_nice:    Bool;
+  wire dec_nice_cmt_off_ilgl: Bool;
+  wire dec_rv32:    Bool;
+  wire dec_jal:     Bool;
+  wire dec_jalr:    Bool;
+  wire dec_bxx:     Bool;
+  wire dec_jalr_rs1idx: UInt<5>;
+  wire dec_bjp_imm: UInt<32>;
+
+  // ════════════════════════════════════════════════════════════════════
+  // Internal wires -- Regfile read data
+  // ════════════════════════════════════════════════════════════════════
+  wire rf_rs1_data: UInt<32>;
+  wire rf_rs2_data: UInt<32>;
+
+  // ════════════════════════════════════════════════════════════════════
+  // Internal wires -- Dispatch outputs
+  // ════════════════════════════════════════════════════════════════════
+  wire disp_rdy: Bool;
+  wire disp_wfi_halt_exu_ack: Bool;
+
+  // Dispatch -> ALU
+  wire disp_alu_valid:   Bool;
+  wire disp_alu_rs1:     UInt<32>;
+  wire disp_alu_rs2:     UInt<32>;
+  wire disp_alu_pc:      UInt<32>;
+  wire disp_alu_imm:     UInt<32>;
+  wire disp_alu_rdidx:   UInt<5>;
+  wire disp_alu_rdwen:   Bool;
+  wire disp_alu_info:    UInt<32>;
+  wire disp_alu_itag:    UInt<1>;
+  wire disp_alu_misalgn: Bool;
+  wire disp_alu_buserr:  Bool;
+  wire disp_alu_ilegl:   Bool;
+
+  // Dispatch -> OITF
+  wire disp_oitf_rs1fpu_w: Bool;
+  wire disp_oitf_rs2fpu_w: Bool;
+  wire disp_oitf_rs3fpu_w: Bool;
+  wire disp_oitf_rdfpu_w:  Bool;
+  wire disp_oitf_rs1en_w:  Bool;
+  wire disp_oitf_rs2en_w:  Bool;
+  wire disp_oitf_rs3en_w:  Bool;
+  wire disp_oitf_rdwen_w:  Bool;
+  wire disp_oitf_rs1idx_w: UInt<5>;
+  wire disp_oitf_rs2idx_w: UInt<5>;
+  wire disp_oitf_rs3idx_w: UInt<5>;
+  wire disp_oitf_rdidx_w:  UInt<5>;
+  wire disp_oitf_pc_w:     UInt<32>;
+
+  // ════════════════════════════════════════════════════════════════════
+  // Internal wires -- OITF
+  // ════════════════════════════════════════════════════════════════════
+  wire oitf_dis_ready:  Bool;
+  wire oitf_dis_ptr:    UInt<1>;
+  wire oitf_ret_ptr:    UInt<1>;
+  wire oitf_ret_rdidx:  UInt<5>;
+  wire oitf_ret_rdwen:  Bool;
+  wire oitf_ret_rdfpu:  Bool;
+  wire oitf_ret_pc:     UInt<32>;
+  wire oitf_match_rs1:  Bool;
+  wire oitf_match_rs2:  Bool;
+  wire oitf_match_rs3:  Bool;
+  wire oitf_match_rd:   Bool;
+  wire oitf_is_empty:   Bool;
+
+  // ════════════════════════════════════════════════════════════════════
+  // Internal wires -- ALU outputs
+  // ════════════════════════════════════════════════════════════════════
+  wire alu_o_ready:    Bool;
+  wire alu_longpipe:   Bool;
+  wire alu_wdat:       UInt<32>;
+  wire alu_rdidx:      UInt<5>;
+  wire alu_wbck_valid: Bool;
+  // ALU commit outputs
+  wire alu_cmt_valid:       Bool;
+  wire alu_cmt_pc_vld:      Bool;
+  wire alu_cmt_pc:          UInt<32>;
+  wire alu_cmt_instr:       UInt<32>;
+  wire alu_cmt_imm:         UInt<32>;
+  wire alu_cmt_rv32:        Bool;
+  wire alu_cmt_bjp:         Bool;
+  wire alu_cmt_mret:        Bool;
+  wire alu_cmt_dret:        Bool;
+  wire alu_cmt_ecall:       Bool;
+  wire alu_cmt_ebreak:      Bool;
+  wire alu_cmt_fencei:      Bool;
+  wire alu_cmt_wfi:         Bool;
+  wire alu_cmt_ifu_misalgn: Bool;
+  wire alu_cmt_ifu_buserr:  Bool;
+  wire alu_cmt_ifu_ilegl:   Bool;
+  wire alu_cmt_bjp_prdt:    Bool;
+  wire alu_cmt_bjp_rslv:    Bool;
+  wire alu_cmt_misalgn:     Bool;
+  wire alu_cmt_ld:          Bool;
+  wire alu_cmt_stamo:       Bool;
+  wire alu_cmt_buserr:      Bool;
+  wire alu_cmt_badaddr:     UInt<32>;
+  // ALU CSR interface
+  wire alu_csr_ena:          Bool;
+  wire alu_csr_wr_en:        Bool;
+  wire alu_csr_rd_en:        Bool;
+  wire alu_csr_idx:          UInt<12>;
+  wire alu_wbck_csr_dat:     UInt<32>;
+  // ALU NICE
+  wire alu_nice_longp_wbck_valid: Bool;
+  wire alu_nice_longp_wbck_ready: Bool;
+  wire alu_nice_o_itag:           UInt<1>;
+  // ALU misc wires
+  wire amo_wait_w:         Bool;
+  wire oitf_empty_w:       Bool;
+  wire pipe_flush_pulse_w: Bool;
+  wire read_csr_dat_w:     UInt<32>;
+  // Glue wires - ALU outputs to wbck input
+  wire alu_done_valid: Bool;
+
+  // ════════════════════════════════════════════════════════════════════
+  // Internal wires -- LongpWbck outputs
+  // ════════════════════════════════════════════════════════════════════
+  wire longp_wbck_valid: Bool;
+  wire longp_wbck_wdat:  UInt<32>;
+  wire longp_wbck_rdidx: UInt<5>;
+  wire longp_wbck_flags: UInt<5>;
+  wire longp_wbck_rdfpu: Bool;
+  wire longp_lsu_ready:  Bool;
+  wire longp_nice_ready: Bool;
+
+  // LongpWbck exception outputs
+  wire longp_excp_valid:   Bool;
+  wire longp_excp_insterr: Bool;
+  wire longp_excp_ld:      Bool;
+  wire longp_excp_st:      Bool;
+  wire longp_excp_buserr:  Bool;
+  wire longp_excp_badaddr: UInt<32>;
+  wire longp_excp_pc:      UInt<32>;
+  wire longp_excp_ready_from_commit: Bool;
+
+  // ════════════════════════════════════════════════════════════════════
+  // Internal wires -- Wbck outputs
+  // ════════════════════════════════════════════════════════════════════
+  wire wbck_alu_ready:   Bool;
+  wire wbck_longp_ready: Bool;
+  wire wbck_rf_ena:      Bool;
+  wire wbck_rf_wdat:     UInt<32>;
+  wire wbck_rf_rdidx:    UInt<5>;
+
+  // ════════════════════════════════════════════════════════════════════
+  // Internal wires -- Commit outputs
+  // ════════════════════════════════════════════════════════════════════
+  wire commit_alu_ready:     Bool;
+  wire commit_mret_w:        Bool;
+  wire commit_trap_w:        Bool;
+  wire core_wfi_w:           Bool;
+  wire nonflush_cmt_ena_w:   Bool;
+  wire excp_active_w:        Bool;
+  wire wfi_halt_ifu_req_w:   Bool;
+  wire wfi_halt_exu_req_w:   Bool;
+  wire cmt_badaddr_w:        UInt<32>;
+  wire cmt_badaddr_ena_w:    Bool;
+  wire cmt_epc_w:            UInt<32>;
+  wire cmt_epc_ena_w:        Bool;
+  wire cmt_cause_w:          UInt<32>;
+  wire cmt_cause_ena_w:      Bool;
+  wire cmt_instret_ena_w:    Bool;
+  wire cmt_status_ena_w:     Bool;
+  wire cmt_dpc_w:            UInt<32>;
+  wire cmt_dpc_ena_w:        Bool;
+  wire cmt_dcause_w:         UInt<3>;
+  wire cmt_dcause_ena_w:     Bool;
+  wire cmt_mret_ena_w:       Bool;
+  wire flush_pulse_w:        Bool;
+  wire flush_req_w:          Bool;
+  wire pipe_flush_req_w:     Bool;
+  wire pipe_flush_add_op1_w: UInt<32>;
+  wire pipe_flush_add_op2_w: UInt<32>;
+  wire pipe_flush_pc_w:      UInt<32>;
+
+  // ════════════════════════════════════════════════════════════════════
+  // Internal wires -- CSR outputs
+  // ════════════════════════════════════════════════════════════════════
+  wire csr_rdata:          UInt<32>;
+  wire csr_mtvec_val:      UInt<32>;
+  wire csr_mepc_val:       UInt<32>;
+  wire csr_dpc_val:        UInt<32>;
+  wire csr_access_ilgl_w:  Bool;
+  wire csr_nice_xs_off:    Bool;
+  wire csr_tm_stop:        Bool;
+  wire csr_core_cgstop:    Bool;
+  wire csr_tcm_cgstop:     Bool;
+  wire csr_itcm_nohold:    Bool;
+  wire csr_mdv_nob2b:      Bool;
+  wire csr_status_mie:     Bool;
+  wire csr_mtie:           Bool;
+  wire csr_msie:           Bool;
+  wire csr_meie:           Bool;
+  wire csr_wr_dcsr_ena:    Bool;
+  wire csr_wr_dpc_ena:     Bool;
+  wire csr_wr_dscratch_ena: Bool;
+  wire csr_wr_csr_nxt:     UInt<32>;
+  wire csr_u_mode:         Bool;
+  wire csr_s_mode:         Bool;
+  wire csr_h_mode:         Bool;
+  wire csr_m_mode:         Bool;
+
+  // ════════════════════════════════════════════════════════════════════
+  // Internal wires -- Regfile
+  // ════════════════════════════════════════════════════════════════════
+  wire rf_x1_r: UInt<32>;
+
+  // ════════════════════════════════════════════════════════════════════
+  // Internal wires -- Glue
+  // ════════════════════════════════════════════════════════════════════
+  wire disp_valid_gated:    Bool;
+  wire oitf_dis_ena:        Bool;
+  wire oitf_ret_ena:        Bool;
+
+  // ════════════════════════════════════════════════════════════════════
+  // 1. Decode
+  // ════════════════════════════════════════════════════════════════════
   inst dec: e203_exu_decode
-    instr <- ifu_instr;
-    o_rs1_idx  -> dec_rs1_idx;
-    o_rs2_idx  -> dec_rs2_idx;
-    o_rd_idx   -> dec_rd_idx;
-    o_imm      -> dec_imm;
-    o_alu      -> dec_alu;
-    o_bjp      -> dec_bjp;
-    o_agu      -> dec_agu;
-    o_alu_add  -> dec_alu_add;
-    o_alu_sub  -> dec_alu_sub;
-    o_alu_xor  -> dec_alu_xor;
-    o_alu_sll  -> dec_alu_sll;
-    o_alu_srl  -> dec_alu_srl;
-    o_alu_sra  -> dec_alu_sra;
-    o_alu_or   -> dec_alu_or;
-    o_alu_and  -> dec_alu_and;
-    o_alu_slt  -> dec_alu_slt;
-    o_alu_sltu -> dec_alu_sltu;
-    o_alu_lui  -> dec_alu_lui;
-    o_beq      -> dec_beq;
-    o_bne      -> dec_bne;
-    o_blt      -> dec_blt;
-    o_bge      -> dec_bge;
-    o_bltu     -> dec_bltu;
-    o_bgeu     -> dec_bgeu;
-    o_jump     -> dec_jump;
-    o_load     -> dec_load;
-    o_store    -> dec_store;
-    o_rs1_en   -> dec_rs1_en;
-    o_rs2_en   -> dec_rs2_en;
-    o_rd_en    -> dec_rd_en;
-    o_mul      -> dec_mul;
-    o_mulh     -> dec_mulh;
-    o_mulhsu   -> dec_mulhsu;
-    o_mulhu    -> dec_mulhu;
-    o_div      -> dec_div;
-    o_divu     -> dec_divu;
-    o_rem      -> dec_rem;
-    o_remu     -> dec_remu;
+    // Inputs
+    i_instr      <- i_ir;
+    i_pc         <- i_pc;
+    i_prdt_taken <- i_prdt_taken;
+    i_misalgn    <- i_misalgn;
+    i_buserr     <- i_buserr;
+    i_muldiv_b2b <- i_muldiv_b2b;
+    dbg_mode     <- dbg_mode;
+    nice_xs_off  <- 0;
+    // Reference-design outputs
+    dec_rs1idx   -> dec_rs1_idx;
+    dec_rs2idx   -> dec_rs2_idx;
+    dec_rdidx    -> dec_rd_idx;
+    dec_imm      -> dec_imm;
+    dec_bjp      -> dec_bjp;
+    dec_rs1en    -> dec_rs1_en;
+    dec_rs2en    -> dec_rs2_en;
+    dec_rdwen    -> dec_rd_en;
+    dec_mul      -> dec_mul;
+    dec_mulhsu   -> dec_mulhsu;
+    dec_div      -> dec_div;
+    dec_divu     -> dec_divu;
+    dec_rem      -> dec_rem;
+    dec_remu     -> dec_remu;
+    dec_rs1x0    -> dec_rs1x0;
+    dec_rs2x0    -> dec_rs2x0;
+    dec_info     -> dec_info;
+    dec_pc       -> dec_pc_out;
+    dec_misalgn  -> dec_misalgn;
+    dec_buserr   -> dec_buserr_out;
+    dec_ilegl    -> dec_ilegl;
+    dec_nice     -> dec_nice;
+    nice_cmt_off_ilgl_o -> dec_nice_cmt_off_ilgl;
+    dec_rv32     -> dec_rv32;
+    dec_jal      -> dec_jal;
+    dec_jalr     -> dec_jalr;
+    dec_bxx      -> dec_bxx;
+    dec_jalr_rs1idx -> dec_jalr_rs1idx;
+    dec_bjp_imm  -> dec_bjp_imm;
+    // Simplified control outputs
   end inst dec
 
-  // ── Regfile (2R1W) ────────────────────────────────────────────────
-  inst rf: e203_exu_regfile
-    clk   <- clk;
-    rst_n <- rst_n;
-    test_mode <- false;
-    read0_addr <- dec_rs1_idx;
-    read0_data -> rf_rs1_data;
-    read1_addr <- dec_rs2_idx;
-    read1_data -> rf_rs2_data;
-    write_en   <- wbck_rf_ena;
-    write_addr <- wbck_rf_rdidx;
-    write_data <- wbck_rf_wdat;
-  end inst rf
-
-  // ── OITF (Outstanding Instruction Track FIFO) ─────────────────────
-  inst oitf: e203_exu_oitf
-    clk   <- clk;
-    rst_n <- rst_n;
-    // Allocate on muldiv dispatch
-    dis_ena    <- oitf_dis_ena;
-    dis_rd_idx <- disp_mdv_rdidx;
-    dis_rd_en  <- disp_mdv_rd_en;
-    dis_ready  -> oitf_dis_ready;
-    // Deallocate on muldiv writeback
-    ret_ena    <- oitf_ret_ena;
-    ret_rd_idx -> oitf_ret_rd_idx;
-    ret_rd_en  -> oitf_ret_rd_en;
-    // Hazard check against new instruction
-    chk_rs1_idx <- dec_rs1_idx;
-    chk_rs1_en  <- dec_rs1_en;
-    chk_rs2_idx <- dec_rs2_idx;
-    chk_rs2_en  <- dec_rs2_en;
-    chk_rd_idx  <- dec_rd_idx;
-    chk_rd_en   <- dec_rd_en;
-    raw_dep     -> oitf_raw_dep;
-    waw_dep     -> oitf_waw_dep;
-    dep_stall   -> oitf_dep_stall;
-    oitf_empty  -> oitf_is_empty;
-  end inst oitf
-
-  // ── Dispatch ───────────────────────────────────────────────────────
+  // ════════════════════════════════════════════════════════════════════
+  // 2. Dispatch
+  // ════════════════════════════════════════════════════════════════════
   inst disp: e203_exu_disp
-    disp_valid <- disp_valid_gated;
-    disp_ready -> disp_rdy;
-    i_rs1      <- rf_rs1_data;
-    i_rs2      <- rf_rs2_data;
-    i_pc       <- ifu_pc;
-    i_imm      <- dec_imm;
-    i_rd_idx   <- dec_rd_idx;
-    i_rd_en    <- dec_rd_en;
-    i_rs2_en   <- dec_rs2_en;
-    i_alu      <- dec_alu;
-    i_bjp      <- dec_bjp;
-    i_agu      <- dec_agu;
-    i_load     <- dec_load;
-    i_store    <- dec_store;
-    i_mul      <- dec_mul;
-    i_mulh     <- dec_mulh;
-    i_mulhsu   <- dec_mulhsu;
-    i_mulhu    <- dec_mulhu;
-    i_div      <- dec_div;
-    i_divu     <- dec_divu;
-    i_rem      <- dec_rem;
-    i_remu     <- dec_remu;
-    i_alu_add  <- dec_alu_add;
-    i_alu_sub  <- dec_alu_sub;
-    i_alu_xor  <- dec_alu_xor;
-    i_alu_sll  <- dec_alu_sll;
-    i_alu_srl  <- dec_alu_srl;
-    i_alu_sra  <- dec_alu_sra;
-    i_alu_or   <- dec_alu_or;
-    i_alu_and  <- dec_alu_and;
-    i_alu_slt  <- dec_alu_slt;
-    i_alu_sltu <- dec_alu_sltu;
-    i_alu_lui  <- dec_alu_lui;
-    i_beq      <- dec_beq;
-    i_bne      <- dec_bne;
-    i_blt      <- dec_blt;
-    i_bge      <- dec_bge;
-    i_bltu     <- dec_bltu;
-    i_bgeu     <- dec_bgeu;
-    i_jump     <- dec_jump;
-    alu_valid  -> disp_alu_valid;
-    alu_ready  <- alu_o_ready;
-    alu_rs1    -> disp_alu_rs1;
-    alu_rs2    -> disp_alu_rs2;
-    alu_pc     -> disp_alu_pc;
-    alu_imm    -> disp_alu_imm;
-    alu_rdidx  -> disp_alu_rdidx;
-    alu_op_add -> disp_alu_op_add;
-    alu_op_sub -> disp_alu_op_sub;
-    alu_op_xor -> disp_alu_op_xor;
-    alu_op_sll -> disp_alu_op_sll;
-    alu_op_srl -> disp_alu_op_srl;
-    alu_op_sra -> disp_alu_op_sra;
-    alu_op_or  -> disp_alu_op_or;
-    alu_op_and -> disp_alu_op_and;
-    alu_op_slt -> disp_alu_op_slt;
-    alu_op_sltu -> disp_alu_op_sltu;
-    alu_op_lui -> disp_alu_op_lui;
-    alu_is_bjp -> disp_alu_is_bjp;
-    alu_beq    -> disp_alu_beq;
-    alu_bne    -> disp_alu_bne;
-    alu_blt    -> disp_alu_blt;
-    alu_bge    -> disp_alu_bge;
-    alu_bltu   -> disp_alu_bltu;
-    alu_bgeu   -> disp_alu_bgeu;
-    alu_is_jump -> disp_alu_is_jump;
-    alu_is_agu -> disp_alu_is_agu;
-    mdv_valid  -> disp_mdv_valid;
-    mdv_ready  <- mdv_i_ready;
-    mdv_rs1    -> disp_mdv_rs1;
-    mdv_rs2    -> disp_mdv_rs2;
-    mdv_rdidx  -> disp_mdv_rdidx;
-    mdv_rd_en  -> disp_mdv_rd_en;
-    mdv_mul    -> disp_mdv_mul;
-    mdv_mulh   -> disp_mdv_mulh;
-    mdv_mulhsu -> disp_mdv_mulhsu;
-    mdv_mulhu  -> disp_mdv_mulhu;
-    mdv_div    -> disp_mdv_div;
-    mdv_divu   -> disp_mdv_divu;
-    mdv_rem    -> disp_mdv_rem;
-    mdv_remu   -> disp_mdv_remu;
-    lsu_valid  -> disp_lsu_valid;
-    lsu_ready  <- lsu_ready;
-    lsu_rs1    -> disp_lsu_rs1;
-    lsu_rs2    -> disp_lsu_rs2;
-    lsu_imm    -> disp_lsu_imm;
-    lsu_load   -> disp_lsu_load;
-    lsu_store  -> disp_lsu_store;
+    clk   <- clk;
+    rst_n <- rst_n;
+
+    // WFI halt interface
+    wfi_halt_exu_req <- wfi_halt_exu_req_w;
+    wfi_halt_exu_ack -> disp_wfi_halt_exu_ack;
+
+    // OITF status
+    oitf_empty <- oitf_is_empty;
+    amo_wait   <- amo_wait_w;
+
+    // Dispatch input (from decode)
+    disp_i_valid   <- disp_valid_gated;
+    disp_i_ready   -> disp_rdy;
+    disp_i_rs1x0   <- dec_rs1x0;
+    disp_i_rs2x0   <- dec_rs2x0;
+    disp_i_rs1en   <- dec_rs1_en;
+    disp_i_rs2en   <- dec_rs2_en;
+    disp_i_rs1idx  <- i_rs1idx;
+    disp_i_rs2idx  <- i_rs2idx;
+    disp_i_rs1     <- rf_rs1_data;
+    disp_i_rs2     <- rf_rs2_data;
+    disp_i_rdwen   <- dec_rd_en;
+    disp_i_rdidx   <- dec_rd_idx;
+    disp_i_info    <- dec_info;
+    disp_i_imm     <- dec_imm;
+    disp_i_pc      <- dec_pc_out;
+    disp_i_misalgn <- dec_misalgn;
+    disp_i_buserr  <- dec_buserr_out;
+    disp_i_ilegl   <- dec_ilegl;
+
+    // ALU dispatch output
+    disp_o_alu_valid    -> disp_alu_valid;
+    disp_o_alu_ready    <- alu_o_ready;
+    disp_o_alu_longpipe <- alu_longpipe;
+    disp_o_alu_rs1      -> disp_alu_rs1;
+    disp_o_alu_rs2      -> disp_alu_rs2;
+    disp_o_alu_rdwen    -> disp_alu_rdwen;
+    disp_o_alu_rdidx    -> disp_alu_rdidx;
+    disp_o_alu_info     -> disp_alu_info;
+    disp_o_alu_imm      -> disp_alu_imm;
+    disp_o_alu_pc       -> disp_alu_pc;
+    disp_o_alu_itag     -> disp_alu_itag;
+    disp_o_alu_misalgn  -> disp_alu_misalgn;
+    disp_o_alu_buserr   -> disp_alu_buserr;
+    disp_o_alu_ilegl    -> disp_alu_ilegl;
+
+    // OITF hazard check inputs
+    oitfrd_match_disprs1 <- oitf_match_rs1;
+    oitfrd_match_disprs2 <- oitf_match_rs2;
+    oitfrd_match_disprs3 <- oitf_match_rs3;
+    oitfrd_match_disprd  <- oitf_match_rd;
+
+    // OITF dispatch interface
+    disp_oitf_ptr    <- oitf_dis_ptr;
+    disp_oitf_ena    -> oitf_dis_ena;
+    disp_oitf_ready  <- oitf_dis_ready;
+    disp_oitf_rs1fpu -> disp_oitf_rs1fpu_w;
+    disp_oitf_rs2fpu -> disp_oitf_rs2fpu_w;
+    disp_oitf_rs3fpu -> disp_oitf_rs3fpu_w;
+    disp_oitf_rdfpu  -> disp_oitf_rdfpu_w;
+    disp_oitf_rs1en  -> disp_oitf_rs1en_w;
+    disp_oitf_rs2en  -> disp_oitf_rs2en_w;
+    disp_oitf_rs3en  -> disp_oitf_rs3en_w;
+    disp_oitf_rdwen  -> disp_oitf_rdwen_w;
+    disp_oitf_rs1idx -> disp_oitf_rs1idx_w;
+    disp_oitf_rs2idx -> disp_oitf_rs2idx_w;
+    disp_oitf_rs3idx -> disp_oitf_rs3idx_w;
+    disp_oitf_rdidx  -> disp_oitf_rdidx_w;
+    disp_oitf_pc     -> disp_oitf_pc_w;
   end inst disp
 
-  // ── ALU ────────────────────────────────────────────────────────────
-  inst alu: e203_exu_alu
+  // ════════════════════════════════════════════════════════════════════
+  // 3. OITF (Outstanding Instruction Track FIFO)
+  // ════════════════════════════════════════════════════════════════════
+  inst oitf_u: e203_exu_oitf
     clk   <- clk;
     rst_n <- rst_n;
-    i_valid   <- disp_alu_valid;
-    i_ready   -> alu_o_ready;
-    i_rs1     <- disp_alu_rs1;
-    i_rs2     <- disp_alu_rs2;
-    i_pc      <- disp_alu_pc;
-    i_imm     <- disp_alu_imm;
-    i_rdidx   <- disp_alu_rdidx;
-    i_alu     <- true;
-    i_alu_add <- disp_alu_op_add;
-    i_alu_sub <- disp_alu_op_sub;
-    i_alu_xor <- disp_alu_op_xor;
-    i_alu_sll <- disp_alu_op_sll;
-    i_alu_srl <- disp_alu_op_srl;
-    i_alu_sra <- disp_alu_op_sra;
-    i_alu_or  <- disp_alu_op_or;
-    i_alu_and <- disp_alu_op_and;
-    i_alu_slt <- disp_alu_op_slt;
-    i_alu_sltu <- disp_alu_op_sltu;
-    i_alu_lui <- disp_alu_op_lui;
-    i_bjp     <- disp_alu_is_bjp;
-    i_beq     <- disp_alu_beq;
-    i_bne     <- disp_alu_bne;
-    i_blt     <- disp_alu_blt;
-    i_bge     <- disp_alu_bge;
-    i_bltu    <- disp_alu_bltu;
-    i_bgeu    <- disp_alu_bgeu;
-    i_jump    <- disp_alu_is_jump;
-    i_agu     <- disp_alu_is_agu;
-    i_agu_swap <- false;
-    i_agu_add  <- false;
-    i_agu_and  <- false;
-    i_agu_or   <- false;
-    i_agu_xor  <- false;
-    i_agu_max  <- false;
-    i_agu_min  <- false;
-    i_agu_maxu <- false;
-    i_agu_minu <- false;
-    i_agu_sbf_0_ena <- false;
-    i_agu_sbf_0_nxt <- 0;
-    i_agu_sbf_1_ena <- false;
-    i_agu_sbf_1_nxt <- 0;
-    o_valid   -> alu_done_valid;
-    o_ready   <- wbck_alu_ready;
-    o_wdat    -> alu_wdat;
-    o_rdidx   -> alu_rdidx;
-    o_bjp_taken -> alu_bjp_taken;
-    o_bjp_tgt   -> alu_bjp_tgt;
-    o_bjp_lnk   -> alu_bjp_lnk;
-  end inst alu
 
-  // ── MulDiv ─────────────────────────────────────────────────────────
-  inst mdv: e203_exu_muldiv
-    clk   <- clk;
-    rst_n <- rst_n;
-    i_valid  <- mdv_dispatch_valid;
-    i_ready  -> mdv_i_ready;
-    i_rs1    <- disp_mdv_rs1;
-    i_rs2    <- disp_mdv_rs2;
-    i_mul    <- disp_mdv_mul;
-    i_mulh   <- disp_mdv_mulh;
-    i_mulhsu <- disp_mdv_mulhsu;
-    i_mulhu  <- disp_mdv_mulhu;
-    i_div    <- disp_mdv_div;
-    i_divu   <- disp_mdv_divu;
-    i_rem    <- disp_mdv_rem;
-    i_remu   <- disp_mdv_remu;
-    o_valid  -> mdv_done_valid;
-    o_ready  <- wbck_longp_ready;
-    o_wdat   -> mdv_wdat;
-  end inst mdv
+    dis_ready -> oitf_dis_ready;
+    dis_ena   <- oitf_dis_ena;
+    ret_ena   <- oitf_ret_ena;
 
-  // ── Writeback arbiter (replaces ExuCommit) ─────────────────────────
-  inst wbck: e203_exu_wbck
+    dis_ptr -> oitf_dis_ptr;
+    ret_ptr -> oitf_ret_ptr;
+
+    ret_rdidx -> oitf_ret_rdidx;
+    ret_rdwen -> oitf_ret_rdwen;
+    ret_rdfpu -> oitf_ret_rdfpu;
+    ret_pc    -> oitf_ret_pc;
+
+    disp_i_rs1en  <- disp_oitf_rs1en_w;
+    disp_i_rs2en  <- disp_oitf_rs2en_w;
+    disp_i_rs3en  <- disp_oitf_rs3en_w;
+    disp_i_rdwen  <- disp_oitf_rdwen_w;
+    disp_i_rs1fpu <- disp_oitf_rs1fpu_w;
+    disp_i_rs2fpu <- disp_oitf_rs2fpu_w;
+    disp_i_rs3fpu <- disp_oitf_rs3fpu_w;
+    disp_i_rdfpu  <- disp_oitf_rdfpu_w;
+    disp_i_rs1idx <- disp_oitf_rs1idx_w;
+    disp_i_rs2idx <- disp_oitf_rs2idx_w;
+    disp_i_rs3idx <- disp_oitf_rs3idx_w;
+    disp_i_rdidx  <- disp_oitf_rdidx_w;
+    disp_i_pc     <- disp_oitf_pc_w;
+
+    oitfrd_match_disprs1 -> oitf_match_rs1;
+    oitfrd_match_disprs2 -> oitf_match_rs2;
+    oitfrd_match_disprs3 -> oitf_match_rs3;
+    oitfrd_match_disprd  -> oitf_match_rd;
+    oitf_empty           -> oitf_is_empty;
+  end inst oitf_u
+
+  // ════════════════════════════════════════════════════════════════════
+  // 4. ALU execution
+  // ════════════════════════════════════════════════════════════════════
+  inst alu_u: e203_exu_alu
+    clk        <- clk;
+    rst_n      <- rst_n;
+    // Dispatch inputs
+    i_valid    <- disp_alu_valid;
+    i_ready    -> alu_o_ready;
+    i_longpipe -> alu_longpipe;
+    i_rs1      <- disp_alu_rs1;
+    i_rs2      <- disp_alu_rs2;
+    i_imm      <- disp_alu_imm;
+    i_info     <- disp_alu_info;
+    i_pc       <- disp_alu_pc;
+    i_instr    <- i_ir;
+    i_pc_vld   <- i_pc_vld;
+    i_rdidx    <- disp_alu_rdidx;
+    i_rdwen    <- disp_alu_rdwen;
+    i_itag     <- disp_alu_itag;
+    i_ilegl    <- disp_alu_ilegl;
+    i_buserr   <- disp_alu_buserr;
+    i_misalgn  <- disp_alu_misalgn;
+    // Control
+    nice_xs_off <- csr_nice_xs_off;
+    amo_wait    <- amo_wait_w;
+    oitf_empty  <- oitf_empty_w;
+    flush_req   <- flush_req_w;
+    flush_pulse <- pipe_flush_pulse_w;
+    mdv_nob2b   <- csr_mdv_nob2b;
+    i_nice_cmt_off_ilgl <- false;
+    // Commit outputs
+    cmt_o_valid       -> alu_cmt_valid;
+    cmt_o_ready       <- commit_alu_ready;
+    cmt_o_pc_vld      -> alu_cmt_pc_vld;
+    cmt_o_pc          -> alu_cmt_pc;
+    cmt_o_instr       -> alu_cmt_instr;
+    cmt_o_imm         -> alu_cmt_imm;
+    cmt_o_rv32        -> alu_cmt_rv32;
+    cmt_o_bjp         -> alu_cmt_bjp;
+    cmt_o_mret        -> alu_cmt_mret;
+    cmt_o_dret        -> alu_cmt_dret;
+    cmt_o_ecall       -> alu_cmt_ecall;
+    cmt_o_ebreak      -> alu_cmt_ebreak;
+    cmt_o_fencei      -> alu_cmt_fencei;
+    cmt_o_wfi         -> alu_cmt_wfi;
+    cmt_o_ifu_misalgn -> alu_cmt_ifu_misalgn;
+    cmt_o_ifu_buserr  -> alu_cmt_ifu_buserr;
+    cmt_o_ifu_ilegl   -> alu_cmt_ifu_ilegl;
+    cmt_o_bjp_prdt    -> alu_cmt_bjp_prdt;
+    cmt_o_bjp_rslv    -> alu_cmt_bjp_rslv;
+    cmt_o_misalgn     -> alu_cmt_misalgn;
+    cmt_o_ld          -> alu_cmt_ld;
+    cmt_o_stamo       -> alu_cmt_stamo;
+    cmt_o_buserr      -> alu_cmt_buserr;
+    cmt_o_badaddr     -> alu_cmt_badaddr;
+    // Writeback outputs
+    wbck_o_valid  -> alu_wbck_valid;
+    wbck_o_ready  <- wbck_alu_ready;
+    wbck_o_wdat   -> alu_wdat;
+    wbck_o_rdidx  -> alu_rdidx;
+    // CSR interface
+    csr_ena           -> alu_csr_ena;
+    csr_wr_en         -> alu_csr_wr_en;
+    csr_rd_en         -> alu_csr_rd_en;
+    csr_idx           -> alu_csr_idx;
+    nonflush_cmt_ena  <- nonflush_cmt_ena_w;
+    csr_access_ilgl   <- csr_access_ilgl_w;
+    read_csr_dat      <- read_csr_dat_w;
+    wbck_csr_dat      -> alu_wbck_csr_dat;
+    // AGU ICB
+    agu_icb_cmd_valid    -> agu_icb_cmd_valid;
+    agu_icb_cmd_ready    <- agu_icb_cmd_ready;
+    agu_icb_cmd_addr     -> agu_icb_cmd_addr;
+    agu_icb_cmd_read     -> agu_icb_cmd_read;
+    agu_icb_cmd_wdata    -> agu_icb_cmd_wdata;
+    agu_icb_cmd_wmask    -> agu_icb_cmd_wmask;
+    agu_icb_cmd_lock     -> agu_icb_cmd_lock;
+    agu_icb_cmd_excl     -> agu_icb_cmd_excl;
+    agu_icb_cmd_size     -> agu_icb_cmd_size;
+    agu_icb_cmd_back2agu -> agu_icb_cmd_back2agu;
+    agu_icb_cmd_usign    -> agu_icb_cmd_usign;
+    agu_icb_cmd_itag     -> agu_icb_cmd_itag;
+    agu_icb_rsp_valid    <- agu_icb_rsp_valid;
+    agu_icb_rsp_ready    -> agu_icb_rsp_ready;
+    agu_icb_rsp_err      <- agu_icb_rsp_err;
+    agu_icb_rsp_excl_ok  <- agu_icb_rsp_excl_ok;
+    agu_icb_rsp_rdata    <- agu_icb_rsp_rdata;
+    // NICE
+    nice_req_valid          -> nice_req_valid;
+    nice_req_ready          <- nice_req_ready;
+    nice_req_instr          -> nice_req_inst;
+    nice_req_rs1            -> nice_req_rs1;
+    nice_req_rs2            -> nice_req_rs2;
+    nice_rsp_multicyc_valid <- nice_rsp_multicyc_valid;
+    nice_rsp_multicyc_ready -> nice_rsp_multicyc_ready;
+    nice_longp_wbck_valid   -> alu_nice_longp_wbck_valid;
+    nice_longp_wbck_ready   <- alu_nice_longp_wbck_ready;
+    nice_o_itag             -> alu_nice_o_itag;
+  end inst alu_u
+
+  // ════════════════════════════════════════════════════════════════════
+  // 5. Long-pipe writeback collector (LSU + MulDiv -> single port)
+  // ════════════════════════════════════════════════════════════════════
+  inst longp_u: e203_exu_longpwbck
     clk   <- clk;
     rst_n <- rst_n;
-    // ALU path (lower priority)
-    alu_wbck_i_valid <- alu_done_valid;
-    alu_wbck_i_ready -> wbck_alu_ready;
-    alu_wbck_i_wdat  <- alu_wdat;
-    alu_wbck_i_rdidx <- alu_rdidx;
-    // Long-pipe path (higher priority) — MulDiv results
-    longp_wbck_i_valid <- mdv_done_valid;
-    longp_wbck_i_ready -> wbck_longp_ready;
-    longp_wbck_i_wdat  <- mdv_wdat;
-    longp_wbck_i_flags <- 0;
-    longp_wbck_i_rdidx <- oitf_ret_rd_idx;
-    longp_wbck_i_rdfpu <- false;
-    // RF write port
+
+    // LSU writeback input
+    lsu_wbck_i_valid <- lsu_o_valid;
+    lsu_wbck_i_ready -> longp_lsu_ready;
+    lsu_wbck_i_wdat  <- lsu_o_wbck_wdat;
+    lsu_wbck_i_itag  <- lsu_o_wbck_itag.trunc<1>();
+    lsu_wbck_i_err   <- lsu_o_wbck_err;
+
+    // LSU commit info
+    lsu_cmt_i_buserr  <- lsu_o_cmt_buserr;
+    lsu_cmt_i_badaddr <- lsu_o_cmt_badaddr;
+    lsu_cmt_i_ld      <- lsu_o_cmt_ld;
+    lsu_cmt_i_st      <- lsu_o_cmt_st;
+
+    // Merged writeback output
+    longp_wbck_o_valid -> longp_wbck_valid;
+    longp_wbck_o_ready <- wbck_longp_ready;
+    longp_wbck_o_wdat  -> longp_wbck_wdat;
+    longp_wbck_o_flags -> longp_wbck_flags;
+    longp_wbck_o_rdidx -> longp_wbck_rdidx;
+    longp_wbck_o_rdfpu -> longp_wbck_rdfpu;
+
+    // Exception output
+    longp_excp_o_valid   -> longp_excp_valid;
+    longp_excp_o_ready   <- longp_excp_ready_from_commit;
+    longp_excp_o_insterr -> longp_excp_insterr;
+    longp_excp_o_ld      -> longp_excp_ld;
+    longp_excp_o_st      -> longp_excp_st;
+    longp_excp_o_buserr  -> longp_excp_buserr;
+    longp_excp_o_badaddr -> longp_excp_badaddr;
+    longp_excp_o_pc      -> longp_excp_pc;
+
+    // OITF interface
+    oitf_empty     <- oitf_is_empty;
+    oitf_ret_ptr   <- oitf_ret_ptr;
+    oitf_ret_rdidx <- oitf_ret_rdidx;
+    oitf_ret_pc    <- oitf_ret_pc;
+    oitf_ret_rdwen <- oitf_ret_rdwen;
+    oitf_ret_rdfpu <- oitf_ret_rdfpu;
+    oitf_ret_ena   -> oitf_ret_ena;
+
+    // NICE writeback input (stub)
+    nice_longp_wbck_i_valid <- false;
+    nice_longp_wbck_i_ready -> longp_nice_ready;
+    nice_longp_wbck_i_wdat  <- 0;
+    nice_longp_wbck_i_itag  <- 0;
+    nice_longp_wbck_i_err   <- false;
+  end inst longp_u
+
+  // ════════════════════════════════════════════════════════════════════
+  // 6. Writeback arbiter (ALU vs long-pipe -> regfile)
+  // ════════════════════════════════════════════════════════════════════
+  inst wbck_u: e203_exu_wbck
+    clk   <- clk;
+    rst_n <- rst_n;
+    alu_wbck_i_valid  <- alu_done_valid;
+    alu_wbck_i_ready  -> wbck_alu_ready;
+    alu_wbck_i_wdat   <- alu_wdat;
+    alu_wbck_i_rdidx  <- alu_rdidx;
+    longp_wbck_i_valid  <- longp_wbck_valid;
+    longp_wbck_i_ready  -> wbck_longp_ready;
+    longp_wbck_i_wdat   <- longp_wbck_wdat;
+    longp_wbck_i_flags  <- 0;
+    longp_wbck_i_rdidx  <- longp_wbck_rdidx;
+    longp_wbck_i_rdfpu  <- false;
     rf_wbck_o_ena   -> wbck_rf_ena;
     rf_wbck_o_wdat  -> wbck_rf_wdat;
     rf_wbck_o_rdidx -> wbck_rf_rdidx;
-  end inst wbck
+  end inst wbck_u
 
-  // ── Glue logic ────────────────────────────────────────────────────
-  wire disp_valid_gated: Bool;
-  wire oitf_dis_ena: Bool;
-  wire oitf_ret_ena: Bool;
-  wire mdv_dispatch_valid: Bool;
+  // ════════════════════════════════════════════════════════════════════
+  // 7. Commit stage
+  // ════════════════════════════════════════════════════════════════════
+  inst commit_u: e203_exu_commit
+    clk   <- clk;
+    rst_n <- rst_n;
 
+    // Commit status outputs
+    commit_mret      -> commit_mret_w;
+    commit_trap      -> commit_trap_w;
+    core_wfi         -> core_wfi_w;
+    nonflush_cmt_ena -> nonflush_cmt_ena_w;
+    excp_active      -> excp_active_w;
+
+    // AMO wait
+    amo_wait <- amo_wait_w;
+    // WFI halt interface
+    wfi_halt_ifu_req -> wfi_halt_ifu_req_w;
+    wfi_halt_exu_req -> wfi_halt_exu_req_w;
+    wfi_halt_ifu_ack <- wfi_halt_ifu_ack;
+    wfi_halt_exu_ack <- disp_wfi_halt_exu_ack;
+
+    // Interrupt inputs
+    dbg_irq_r    <- dbg_irq_r;
+    lcl_irq_r    <- lcl_irq_r;
+    ext_irq_r    <- ext_irq_r;
+    sft_irq_r    <- sft_irq_r;
+    tmr_irq_r    <- tmr_irq_r;
+    evt_r        <- evt_r;
+    status_mie_r <- csr_status_mie;
+    mtie_r       <- csr_mtie;
+    msie_r       <- csr_msie;
+    meie_r       <- csr_meie;
+
+    // ALU commit input channel (wired from ALU cmt_o_* outputs)
+    alu_cmt_i_valid       <- alu_cmt_valid;
+    alu_cmt_i_ready       -> commit_alu_ready;
+    alu_cmt_i_pc          <- alu_cmt_pc;
+    alu_cmt_i_instr       <- alu_cmt_instr;
+    alu_cmt_i_pc_vld      <- alu_cmt_pc_vld;
+    alu_cmt_i_imm         <- alu_cmt_imm;
+    alu_cmt_i_rv32        <- alu_cmt_rv32;
+    alu_cmt_i_bjp         <- alu_cmt_bjp;
+    alu_cmt_i_wfi         <- alu_cmt_wfi;
+    alu_cmt_i_fencei      <- alu_cmt_fencei;
+    alu_cmt_i_mret        <- alu_cmt_mret;
+    alu_cmt_i_dret        <- alu_cmt_dret;
+    alu_cmt_i_ecall       <- alu_cmt_ecall;
+    alu_cmt_i_ebreak      <- alu_cmt_ebreak;
+    alu_cmt_i_ifu_misalgn <- alu_cmt_ifu_misalgn;
+    alu_cmt_i_ifu_buserr  <- alu_cmt_ifu_buserr;
+    alu_cmt_i_ifu_ilegl   <- alu_cmt_ifu_ilegl;
+    alu_cmt_i_bjp_prdt    <- alu_cmt_bjp_prdt;
+    alu_cmt_i_bjp_rslv    <- alu_cmt_bjp_rslv;
+    alu_cmt_i_misalgn     <- alu_cmt_misalgn;
+    alu_cmt_i_ld          <- alu_cmt_ld;
+    alu_cmt_i_stamo       <- alu_cmt_stamo;
+    alu_cmt_i_buserr      <- alu_cmt_buserr;
+    alu_cmt_i_badaddr     <- alu_cmt_badaddr;
+
+    // CSR commit outputs
+    cmt_badaddr     -> cmt_badaddr_w;
+    cmt_badaddr_ena -> cmt_badaddr_ena_w;
+    cmt_epc         -> cmt_epc_w;
+    cmt_epc_ena     -> cmt_epc_ena_w;
+    cmt_cause       -> cmt_cause_w;
+    cmt_cause_ena   -> cmt_cause_ena_w;
+    cmt_instret_ena -> cmt_instret_ena_w;
+    cmt_status_ena  -> cmt_status_ena_w;
+    cmt_dpc         -> cmt_dpc_w;
+    cmt_dpc_ena     -> cmt_dpc_ena_w;
+    cmt_dcause      -> cmt_dcause_w;
+    cmt_dcause_ena  -> cmt_dcause_ena_w;
+    cmt_mret_ena    -> cmt_mret_ena_w;
+
+    // CSR read inputs
+    csr_epc_r   <- csr_mepc_val;
+    csr_dpc_r   <- csr_dpc_val;
+    csr_mtvec_r <- csr_mtvec_val;
+
+    // Debug mode inputs
+    dbg_mode      <- dbg_mode;
+    dbg_halt_r    <- dbg_halt_r;
+    dbg_step_r    <- dbg_step_r;
+    dbg_ebreakm_r <- dbg_ebreakm_r;
+    oitf_empty    <- oitf_is_empty;
+
+    // Privilege mode inputs
+    u_mode <- csr_u_mode;
+    s_mode <- csr_s_mode;
+    h_mode <- csr_h_mode;
+    m_mode <- csr_m_mode;
+
+    // Long-pipe exception input
+    longp_excp_i_ready   -> longp_excp_ready_from_commit;
+    longp_excp_i_valid   <- longp_excp_valid;
+    longp_excp_i_ld      <- longp_excp_ld;
+    longp_excp_i_st      <- longp_excp_st;
+    longp_excp_i_buserr  <- longp_excp_buserr;
+    longp_excp_i_badaddr <- longp_excp_badaddr;
+    longp_excp_i_insterr <- longp_excp_insterr;
+    longp_excp_i_pc      <- longp_excp_pc;
+
+    // Flush outputs
+    flush_pulse       -> flush_pulse_w;
+    flush_req         -> flush_req_w;
+    pipe_flush_ack    <- pipe_flush_ack;
+    pipe_flush_req    -> pipe_flush_req_w;
+    pipe_flush_add_op1 -> pipe_flush_add_op1_w;
+    pipe_flush_add_op2 -> pipe_flush_add_op2_w;
+    pipe_flush_pc     -> pipe_flush_pc_w;
+  end inst commit_u
+
+  // ════════════════════════════════════════════════════════════════════
+  // 8. CSR register file
+  // ════════════════════════════════════════════════════════════════════
+  inst csr_u: e203_exu_csr
+    clk     <- clk;
+    rst_n   <- rst_n;
+    clk_aon <- clk_aon;
+
+    // CSR access interface
+    nonflush_cmt_ena <- nonflush_cmt_ena_w;
+    csr_ena      <- alu_csr_ena;
+    csr_wr_en    <- alu_csr_wr_en;
+    csr_rd_en    <- alu_csr_rd_en;
+    csr_idx      <- alu_csr_idx;
+    csr_access_ilgl -> csr_access_ilgl_w;
+    read_csr_dat -> csr_rdata;
+    wbck_csr_dat <- alu_wbck_csr_dat;
+
+    // Control outputs
+    nice_xs_off  -> csr_nice_xs_off;
+    tm_stop      -> csr_tm_stop;
+    core_cgstop  -> csr_core_cgstop;
+    tcm_cgstop   -> csr_tcm_cgstop;
+    itcm_nohold  -> csr_itcm_nohold;
+    mdv_nob2b    -> csr_mdv_nob2b;
+
+    // Hart ID
+    core_mhartid <- core_mhartid[0:0];
+
+    // Interrupt status
+    ext_irq_r    <- ext_irq_r;
+    sft_irq_r    <- sft_irq_r;
+    tmr_irq_r    <- tmr_irq_r;
+    status_mie_r -> csr_status_mie;
+    mtie_r       -> csr_mtie;
+    msie_r       -> csr_msie;
+    meie_r       -> csr_meie;
+
+    // Debug CSR interface
+    wr_dcsr_ena     -> csr_wr_dcsr_ena;
+    wr_dpc_ena      -> csr_wr_dpc_ena;
+    wr_dscratch_ena -> csr_wr_dscratch_ena;
+    dcsr_r          <- dcsr_r;
+    dpc_r           <- dpc_r;
+    dscratch_r      <- dscratch_r;
+    wr_csr_nxt      -> csr_wr_csr_nxt;
+
+    // Debug mode
+    dbg_mode     <- dbg_mode;
+    dbg_stopcycle <- dbg_stopcycle;
+
+    // Privilege mode outputs
+    u_mode -> csr_u_mode;
+    s_mode -> csr_s_mode;
+    h_mode -> csr_h_mode;
+    m_mode -> csr_m_mode;
+
+    // Commit inputs
+    cmt_badaddr     <- cmt_badaddr_w;
+    cmt_badaddr_ena <- cmt_badaddr_ena_w;
+    cmt_epc         <- cmt_epc_w;
+    cmt_epc_ena     <- cmt_epc_ena_w;
+    cmt_cause       <- cmt_cause_w;
+    cmt_cause_ena   <- cmt_cause_ena_w;
+    cmt_status_ena  <- cmt_status_ena_w;
+    cmt_instret_ena <- cmt_instret_ena_w;
+    cmt_mret_ena    <- cmt_mret_ena_w;
+
+    // CSR vector outputs
+    csr_epc_r   -> csr_mepc_val;
+    csr_dpc_r   -> csr_dpc_val;
+    csr_mtvec_r -> csr_mtvec_val;
+  end inst csr_u
+
+  // ════════════════════════════════════════════════════════════════════
+  // 9. Integer register file (2R1W)
+  // ════════════════════════════════════════════════════════════════════
+  inst rf_u: e203_exu_regfile
+    clk       <- clk;
+    rst_n     <- rst_n;
+    test_mode <- test_mode;
+
+    read_src1_idx <- dec_rs1_idx;
+    read_src1_dat -> rf_rs1_data;
+    read_src2_idx <- dec_rs2_idx;
+    read_src2_dat -> rf_rs2_data;
+
+    wbck_dest_wen <- wbck_rf_ena;
+    wbck_dest_idx <- wbck_rf_rdidx;
+    wbck_dest_dat <- wbck_rf_wdat;
+
+    x1_r -> rf_x1_r;
+  end inst rf_u
+
+  // ════════════════════════════════════════════════════════════════════
+  // Glue logic
+  // ════════════════════════════════════════════════════════════════════
   comb
-    // Gate dispatch on OITF hazard stall
-    disp_valid_gated = ifu_valid & ~oitf_dep_stall;
-    ifu_ready = disp_rdy & ~oitf_dep_stall;
+    // Gate dispatch valid
+    disp_valid_gated = i_valid;
+    i_ready = disp_rdy;
 
-    // OITF allocate: when muldiv dispatches successfully
-    oitf_dis_ena = disp_mdv_valid & mdv_i_ready & oitf_dis_ready;
+    // Pipe flush: from commit unit
+    pipe_flush_req     = pipe_flush_req_w;
+    pipe_flush_add_op1 = pipe_flush_add_op1_w;
+    pipe_flush_add_op2 = pipe_flush_add_op2_w;
+    pipe_flush_pc      = pipe_flush_pc_w;
 
-    // Gate muldiv dispatch on OITF availability
-    mdv_dispatch_valid = disp_mdv_valid & oitf_dis_ready;
+    // LSU writeback ready
+    lsu_o_ready = longp_lsu_ready;
 
-    // OITF deallocate: when muldiv result is written back
-    oitf_ret_ena = mdv_done_valid & wbck_longp_ready;
+    // OITF empty status
+    oitf_empty = oitf_is_empty;
 
-    // BJP feedback
-    o_bjp_valid = alu_done_valid & alu_bjp_taken;
-    o_bjp_taken = alu_bjp_taken;
-    o_bjp_tgt   = alu_bjp_tgt;
+    // Regfile to IFU
+    rf2ifu_x1  = rf_x1_r;
+    rf2ifu_rs1 = rf_rs1_data;
 
-    // LSU interface
-    lsu_valid = disp_lsu_valid;
-    lsu_addr  = disp_lsu_rs1 + disp_lsu_imm;
-    lsu_wdata = disp_lsu_rs2;
-    lsu_load  = disp_lsu_load;
-    lsu_store = disp_lsu_store;
+    // Decode to IFU feedback
+    dec2ifu_rden   = dec_rd_en & (~disp_oitf_rdfpu_w);
+    dec2ifu_rs1en  = dec_rs1_en & (~disp_oitf_rs1fpu_w);
+    dec2ifu_rdidx  = dec_rd_idx;
+    dec2ifu_mulhsu = dec_mulhsu;
+    dec2ifu_div    = dec_div;
+    dec2ifu_rem    = dec_rem;
+    dec2ifu_divu   = dec_divu;
+    dec2ifu_remu   = dec_remu;
 
-    // Commit status — either ALU or long-pipe completes
-    o_commit_valid = (alu_done_valid & wbck_alu_ready) | (mdv_done_valid & wbck_longp_ready);
+    // Status outputs from commit
+    exu_active       = (~oitf_is_empty) | i_valid | excp_active_w;
+    excp_active      = excp_active_w;
+    commit_mret      = commit_mret_w;
+    commit_trap      = commit_trap_w;
+    core_wfi         = core_wfi_w;
+    wfi_halt_ifu_req = wfi_halt_ifu_req_w;
+
+    // CSR control outputs
+    tm_stop     = csr_tm_stop;
+    itcm_nohold = csr_itcm_nohold;
+    core_cgstop = csr_core_cgstop;
+    tcm_cgstop  = csr_tcm_cgstop;
+
+    // CSR debug outputs
+    cmt_dpc         = cmt_dpc_w;
+    cmt_dpc_ena     = cmt_dpc_ena_w;
+    cmt_dcause      = cmt_dcause_w;
+    cmt_dcause_ena  = cmt_dcause_ena_w;
+    wr_dcsr_ena     = csr_wr_dcsr_ena;
+    wr_dpc_ena      = csr_wr_dpc_ena;
+    wr_dscratch_ena = csr_wr_dscratch_ena;
+    wr_csr_nxt      = csr_wr_csr_nxt;
+
+    // Glue: ALU outputs to wbck input
+    alu_done_valid = alu_wbck_valid;
+
+    // Glue: misc wires
+    oitf_empty_w       = oitf_is_empty;
+    pipe_flush_pulse_w = flush_pulse_w;
+    read_csr_dat_w     = csr_rdata;
   end comb
 
 end module e203_exu_top

--- a/tests/e203/e203_exu_top.sv
+++ b/tests/e203/e203_exu_top.sv
@@ -1,433 +1,783 @@
-// E203 Execution Unit Top-Level
-// Integrates: Decode → Dispatch → ALU/MulDiv → Wbck → Regfile
-// With OITF for long-pipe (MulDiv) hazard tracking.
-// Single-issue, in-order pipeline with valid/ready handshake.
-module ExuTop #(
+// domain SysDomain
+//   freq_mhz: 100
+
+// domain SysDomain
+//   freq_mhz: 100
+
+// domain SysDomain
+//   freq_mhz: 100
+
+// domain SysDomain
+//   freq_mhz: 100
+
+// domain SysDomain
+//   freq_mhz: 100
+
+// domain SysDomain
+//   freq_mhz: 100
+
+// domain SysDomain
+//   freq_mhz: 100
+
+module e203_exu_top #(
   parameter int XLEN = 32
 ) (
   input logic clk,
   input logic rst_n,
-  input logic ifu_valid,
-  output logic ifu_ready,
-  input logic [32-1:0] ifu_instr,
-  input logic [32-1:0] ifu_pc,
-  output logic o_bjp_valid,
-  output logic o_bjp_taken,
-  output logic [32-1:0] o_bjp_tgt,
-  output logic lsu_valid,
-  input logic lsu_ready,
-  output logic [32-1:0] lsu_addr,
-  output logic [32-1:0] lsu_wdata,
-  output logic lsu_load,
-  output logic lsu_store,
-  input logic lsu_resp_valid,
-  input logic [32-1:0] lsu_resp_data,
-  output logic o_commit_valid
+  input logic i_valid,
+  output logic i_ready,
+  input logic [31:0] i_ir,
+  input logic [31:0] i_pc,
+  input logic i_pc_vld,
+  input logic i_misalgn,
+  input logic i_buserr,
+  input logic i_prdt_taken,
+  input logic i_muldiv_b2b,
+  input logic [4:0] i_rs1idx,
+  input logic [4:0] i_rs2idx,
+  output logic pipe_flush_req,
+  input logic pipe_flush_ack,
+  output logic [31:0] pipe_flush_add_op1,
+  output logic [31:0] pipe_flush_add_op2,
+  output logic [31:0] pipe_flush_pc,
+  input logic lsu_o_valid,
+  output logic lsu_o_ready,
+  input logic [31:0] lsu_o_wbck_wdat,
+  input logic [4:0] lsu_o_wbck_itag,
+  input logic lsu_o_wbck_err,
+  input logic lsu_o_cmt_ld,
+  input logic lsu_o_cmt_st,
+  input logic [31:0] lsu_o_cmt_badaddr,
+  input logic lsu_o_cmt_buserr,
+  output logic agu_icb_cmd_valid,
+  input logic agu_icb_cmd_ready,
+  output logic [31:0] agu_icb_cmd_addr,
+  output logic agu_icb_cmd_read,
+  output logic [31:0] agu_icb_cmd_wdata,
+  output logic [3:0] agu_icb_cmd_wmask,
+  output logic agu_icb_cmd_lock,
+  output logic agu_icb_cmd_excl,
+  output logic [1:0] agu_icb_cmd_size,
+  output logic agu_icb_cmd_back2agu,
+  output logic agu_icb_cmd_usign,
+  output logic agu_icb_cmd_itag,
+  input logic agu_icb_rsp_valid,
+  output logic agu_icb_rsp_ready,
+  input logic [31:0] agu_icb_rsp_rdata,
+  input logic agu_icb_rsp_err,
+  input logic agu_icb_rsp_excl_ok,
+  input logic dbg_mode,
+  input logic dbg_halt_r,
+  input logic dbg_step_r,
+  input logic dbg_ebreakm_r,
+  input logic dbg_stopcycle,
+  input logic dbg_irq_r,
+  input logic lcl_irq_r,
+  input logic evt_r,
+  input logic ext_irq_r,
+  input logic sft_irq_r,
+  input logic tmr_irq_r,
+  output logic [31:0] cmt_dpc,
+  output logic cmt_dpc_ena,
+  output logic [2:0] cmt_dcause,
+  output logic cmt_dcause_ena,
+  output logic wr_dcsr_ena,
+  output logic wr_dpc_ena,
+  output logic wr_dscratch_ena,
+  output logic [31:0] wr_csr_nxt,
+  input logic [31:0] dcsr_r,
+  input logic [31:0] dpc_r,
+  input logic [31:0] dscratch_r,
+  output logic wfi_halt_ifu_req,
+  input logic wfi_halt_ifu_ack,
+  output logic core_wfi,
+  output logic [31:0] rf2ifu_x1,
+  output logic [31:0] rf2ifu_rs1,
+  output logic dec2ifu_rden,
+  output logic dec2ifu_rs1en,
+  output logic [4:0] dec2ifu_rdidx,
+  output logic dec2ifu_mulhsu,
+  output logic dec2ifu_div,
+  output logic dec2ifu_rem,
+  output logic dec2ifu_divu,
+  output logic dec2ifu_remu,
+  output logic oitf_empty,
+  output logic exu_active,
+  output logic excp_active,
+  output logic commit_mret,
+  output logic commit_trap,
+  input logic [31:0] core_mhartid,
+  output logic tm_stop,
+  output logic itcm_nohold,
+  output logic core_cgstop,
+  output logic tcm_cgstop,
+  output logic nice_req_valid,
+  input logic nice_req_ready,
+  output logic [31:0] nice_req_inst,
+  output logic [31:0] nice_req_rs1,
+  output logic [31:0] nice_req_rs2,
+  input logic nice_rsp_multicyc_valid,
+  output logic nice_rsp_multicyc_ready,
+  input logic [31:0] nice_rsp_multicyc_dat,
+  input logic nice_rsp_multicyc_err,
+  input logic test_mode,
+  input logic clk_aon
 );
 
-  // ── IFU interface ──────────────────────────────────────────────────
-  // ── Branch feedback to IFU ─────────────────────────────────────────
-  // ── LSU interface ──────────────────────────────────────────────────
-  // ── Commit status ──────────────────────────────────────────────────
-  // ── Decode ─────────────────────────────────────────────────────────
-  logic [5-1:0] dec_rs1_idx;
-  logic [5-1:0] dec_rs2_idx;
-  logic [5-1:0] dec_rd_idx;
-  logic [32-1:0] dec_imm;
-  logic dec_alu;
+  logic [4:0] dec_rs1_idx;
+  logic [4:0] dec_rs2_idx;
+  logic [4:0] dec_rd_idx;
+  logic [31:0] dec_imm;
   logic dec_bjp;
-  logic dec_agu;
-  logic dec_alu_add;
-  logic dec_alu_sub;
-  logic dec_alu_xor;
-  logic dec_alu_sll;
-  logic dec_alu_srl;
-  logic dec_alu_sra;
-  logic dec_alu_or;
-  logic dec_alu_and;
-  logic dec_alu_slt;
-  logic dec_alu_sltu;
-  logic dec_alu_lui;
-  logic dec_beq;
-  logic dec_bne;
-  logic dec_blt;
-  logic dec_bge;
-  logic dec_bltu;
-  logic dec_bgeu;
-  logic dec_jump;
-  logic dec_load;
-  logic dec_store;
-  logic dec_rs1_en;
-  logic dec_rs2_en;
-  logic dec_rd_en;
   logic dec_mul;
-  logic dec_mulh;
   logic dec_mulhsu;
-  logic dec_mulhu;
   logic dec_div;
   logic dec_divu;
   logic dec_rem;
   logic dec_remu;
-  ExuDecode dec (
-    .instr(ifu_instr),
-    .o_rs1_idx(dec_rs1_idx),
-    .o_rs2_idx(dec_rs2_idx),
-    .o_rd_idx(dec_rd_idx),
-    .o_imm(dec_imm),
-    .o_alu(dec_alu),
-    .o_bjp(dec_bjp),
-    .o_agu(dec_agu),
-    .o_alu_add(dec_alu_add),
-    .o_alu_sub(dec_alu_sub),
-    .o_alu_xor(dec_alu_xor),
-    .o_alu_sll(dec_alu_sll),
-    .o_alu_srl(dec_alu_srl),
-    .o_alu_sra(dec_alu_sra),
-    .o_alu_or(dec_alu_or),
-    .o_alu_and(dec_alu_and),
-    .o_alu_slt(dec_alu_slt),
-    .o_alu_sltu(dec_alu_sltu),
-    .o_alu_lui(dec_alu_lui),
-    .o_beq(dec_beq),
-    .o_bne(dec_bne),
-    .o_blt(dec_blt),
-    .o_bge(dec_bge),
-    .o_bltu(dec_bltu),
-    .o_bgeu(dec_bgeu),
-    .o_jump(dec_jump),
-    .o_load(dec_load),
-    .o_store(dec_store),
-    .o_rs1_en(dec_rs1_en),
-    .o_rs2_en(dec_rs2_en),
-    .o_rd_en(dec_rd_en),
-    .o_mul(dec_mul),
-    .o_mulh(dec_mulh),
-    .o_mulhsu(dec_mulhsu),
-    .o_mulhu(dec_mulhu),
-    .o_div(dec_div),
-    .o_divu(dec_divu),
-    .o_rem(dec_rem),
-    .o_remu(dec_remu)
-  );
-  // ── Regfile (2R1W) ────────────────────────────────────────────────
-  logic [32-1:0] rf_rs1_data;
-  logic [32-1:0] rf_rs2_data;
-  ExuRegfile rf (
-    .clk(clk),
-    .rst_n(rst_n),
-    .test_mode(1'b0),
-    .read0_addr(dec_rs1_idx),
-    .read0_data(rf_rs1_data),
-    .read1_addr(dec_rs2_idx),
-    .read1_data(rf_rs2_data),
-    .write_en(wbck_rf_ena),
-    .write_addr(wbck_rf_rdidx),
-    .write_data(wbck_rf_wdat)
-  );
-  // ── OITF (Outstanding Instruction Track FIFO) ─────────────────────
+  logic dec_rs1_en;
+  logic dec_rs2_en;
+  logic dec_rd_en;
+  logic dec_rs1x0;
+  logic dec_rs2x0;
+  logic [31:0] dec_info;
+  logic [31:0] dec_pc_out;
+  logic dec_misalgn;
+  logic dec_buserr_out;
+  logic dec_ilegl;
+  logic dec_nice;
+  logic dec_nice_cmt_off_ilgl;
+  logic dec_rv32;
+  logic dec_jal;
+  logic dec_jalr;
+  logic dec_bxx;
+  logic [4:0] dec_jalr_rs1idx;
+  logic [31:0] dec_bjp_imm;
+  logic [31:0] rf_rs1_data;
+  logic [31:0] rf_rs2_data;
+  logic disp_rdy;
+  logic disp_wfi_halt_exu_ack;
+  logic disp_alu_valid;
+  logic [31:0] disp_alu_rs1;
+  logic [31:0] disp_alu_rs2;
+  logic [31:0] disp_alu_pc;
+  logic [31:0] disp_alu_imm;
+  logic [4:0] disp_alu_rdidx;
+  logic disp_alu_rdwen;
+  logic [31:0] disp_alu_info;
+  logic [0:0] disp_alu_itag;
+  logic disp_alu_misalgn;
+  logic disp_alu_buserr;
+  logic disp_alu_ilegl;
+  logic disp_oitf_rs1fpu_w;
+  logic disp_oitf_rs2fpu_w;
+  logic disp_oitf_rs3fpu_w;
+  logic disp_oitf_rdfpu_w;
+  logic disp_oitf_rs1en_w;
+  logic disp_oitf_rs2en_w;
+  logic disp_oitf_rs3en_w;
+  logic disp_oitf_rdwen_w;
+  logic [4:0] disp_oitf_rs1idx_w;
+  logic [4:0] disp_oitf_rs2idx_w;
+  logic [4:0] disp_oitf_rs3idx_w;
+  logic [4:0] disp_oitf_rdidx_w;
+  logic [31:0] disp_oitf_pc_w;
   logic oitf_dis_ready;
-  logic [5-1:0] oitf_ret_rd_idx;
-  logic oitf_ret_rd_en;
-  logic oitf_raw_dep;
-  logic oitf_waw_dep;
-  logic oitf_dep_stall;
+  logic [0:0] oitf_dis_ptr;
+  logic [0:0] oitf_ret_ptr;
+  logic [4:0] oitf_ret_rdidx;
+  logic oitf_ret_rdwen;
+  logic oitf_ret_rdfpu;
+  logic [31:0] oitf_ret_pc;
+  logic oitf_match_rs1;
+  logic oitf_match_rs2;
+  logic oitf_match_rs3;
+  logic oitf_match_rd;
   logic oitf_is_empty;
-  ExuOitf oitf (
+  logic alu_o_ready;
+  logic alu_longpipe;
+  logic [31:0] alu_wdat;
+  logic [4:0] alu_rdidx;
+  logic alu_wbck_valid;
+  logic alu_cmt_valid;
+  logic alu_cmt_pc_vld;
+  logic [31:0] alu_cmt_pc;
+  logic [31:0] alu_cmt_instr;
+  logic [31:0] alu_cmt_imm;
+  logic alu_cmt_rv32;
+  logic alu_cmt_bjp;
+  logic alu_cmt_mret;
+  logic alu_cmt_dret;
+  logic alu_cmt_ecall;
+  logic alu_cmt_ebreak;
+  logic alu_cmt_fencei;
+  logic alu_cmt_wfi;
+  logic alu_cmt_ifu_misalgn;
+  logic alu_cmt_ifu_buserr;
+  logic alu_cmt_ifu_ilegl;
+  logic alu_cmt_bjp_prdt;
+  logic alu_cmt_bjp_rslv;
+  logic alu_cmt_misalgn;
+  logic alu_cmt_ld;
+  logic alu_cmt_stamo;
+  logic alu_cmt_buserr;
+  logic [31:0] alu_cmt_badaddr;
+  logic alu_csr_ena;
+  logic alu_csr_wr_en;
+  logic alu_csr_rd_en;
+  logic [11:0] alu_csr_idx;
+  logic [31:0] alu_wbck_csr_dat;
+  logic alu_nice_longp_wbck_valid;
+  logic alu_nice_longp_wbck_ready;
+  logic [0:0] alu_nice_o_itag;
+  logic amo_wait_w;
+  logic oitf_empty_w;
+  logic pipe_flush_pulse_w;
+  logic [31:0] read_csr_dat_w;
+  logic alu_done_valid;
+  logic longp_wbck_valid;
+  logic [31:0] longp_wbck_wdat;
+  logic [4:0] longp_wbck_rdidx;
+  logic [4:0] longp_wbck_flags;
+  logic longp_wbck_rdfpu;
+  logic longp_lsu_ready;
+  logic longp_nice_ready;
+  logic longp_excp_valid;
+  logic longp_excp_insterr;
+  logic longp_excp_ld;
+  logic longp_excp_st;
+  logic longp_excp_buserr;
+  logic [31:0] longp_excp_badaddr;
+  logic [31:0] longp_excp_pc;
+  logic longp_excp_ready_from_commit;
+  logic wbck_alu_ready;
+  logic wbck_longp_ready;
+  logic wbck_rf_ena;
+  logic [31:0] wbck_rf_wdat;
+  logic [4:0] wbck_rf_rdidx;
+  logic commit_alu_ready;
+  logic commit_mret_w;
+  logic commit_trap_w;
+  logic core_wfi_w;
+  logic nonflush_cmt_ena_w;
+  logic excp_active_w;
+  logic wfi_halt_ifu_req_w;
+  logic wfi_halt_exu_req_w;
+  logic [31:0] cmt_badaddr_w;
+  logic cmt_badaddr_ena_w;
+  logic [31:0] cmt_epc_w;
+  logic cmt_epc_ena_w;
+  logic [31:0] cmt_cause_w;
+  logic cmt_cause_ena_w;
+  logic cmt_instret_ena_w;
+  logic cmt_status_ena_w;
+  logic [31:0] cmt_dpc_w;
+  logic cmt_dpc_ena_w;
+  logic [2:0] cmt_dcause_w;
+  logic cmt_dcause_ena_w;
+  logic cmt_mret_ena_w;
+  logic flush_pulse_w;
+  logic flush_req_w;
+  logic pipe_flush_req_w;
+  logic [31:0] pipe_flush_add_op1_w;
+  logic [31:0] pipe_flush_add_op2_w;
+  logic [31:0] pipe_flush_pc_w;
+  logic [31:0] csr_rdata;
+  logic [31:0] csr_mtvec_val;
+  logic [31:0] csr_mepc_val;
+  logic [31:0] csr_dpc_val;
+  logic csr_access_ilgl_w;
+  logic csr_nice_xs_off;
+  logic csr_tm_stop;
+  logic csr_core_cgstop;
+  logic csr_tcm_cgstop;
+  logic csr_itcm_nohold;
+  logic csr_mdv_nob2b;
+  logic csr_status_mie;
+  logic csr_mtie;
+  logic csr_msie;
+  logic csr_meie;
+  logic csr_wr_dcsr_ena;
+  logic csr_wr_dpc_ena;
+  logic csr_wr_dscratch_ena;
+  logic [31:0] csr_wr_csr_nxt;
+  logic csr_u_mode;
+  logic csr_s_mode;
+  logic csr_h_mode;
+  logic csr_m_mode;
+  logic [31:0] rf_x1_r;
+  logic disp_valid_gated;
+  logic oitf_dis_ena;
+  logic oitf_ret_ena;
+  e203_exu_decode dec (
+    .i_instr(i_ir),
+    .i_pc(i_pc),
+    .i_prdt_taken(i_prdt_taken),
+    .i_misalgn(i_misalgn),
+    .i_buserr(i_buserr),
+    .i_muldiv_b2b(i_muldiv_b2b),
+    .dbg_mode(dbg_mode),
+    .nice_xs_off(0),
+    .dec_rs1idx(dec_rs1_idx),
+    .dec_rs2idx(dec_rs2_idx),
+    .dec_rdidx(dec_rd_idx),
+    .dec_imm(dec_imm),
+    .dec_bjp(dec_bjp),
+    .dec_rs1en(dec_rs1_en),
+    .dec_rs2en(dec_rs2_en),
+    .dec_rdwen(dec_rd_en),
+    .dec_mul(dec_mul),
+    .dec_mulhsu(dec_mulhsu),
+    .dec_div(dec_div),
+    .dec_divu(dec_divu),
+    .dec_rem(dec_rem),
+    .dec_remu(dec_remu),
+    .dec_rs1x0(dec_rs1x0),
+    .dec_rs2x0(dec_rs2x0),
+    .dec_info(dec_info),
+    .dec_pc(dec_pc_out),
+    .dec_misalgn(dec_misalgn),
+    .dec_buserr(dec_buserr_out),
+    .dec_ilegl(dec_ilegl),
+    .dec_nice(dec_nice),
+    .nice_cmt_off_ilgl_o(dec_nice_cmt_off_ilgl),
+    .dec_rv32(dec_rv32),
+    .dec_jal(dec_jal),
+    .dec_jalr(dec_jalr),
+    .dec_bxx(dec_bxx),
+    .dec_jalr_rs1idx(dec_jalr_rs1idx),
+    .dec_bjp_imm(dec_bjp_imm)
+  );
+  e203_exu_disp disp (
     .clk(clk),
     .rst_n(rst_n),
-    .dis_ena(oitf_dis_ena),
-    .dis_rd_idx(disp_mdv_rdidx),
-    .dis_rd_en(disp_mdv_rd_en),
+    .wfi_halt_exu_req(wfi_halt_exu_req_w),
+    .wfi_halt_exu_ack(disp_wfi_halt_exu_ack),
+    .oitf_empty(oitf_is_empty),
+    .amo_wait(amo_wait_w),
+    .disp_i_valid(disp_valid_gated),
+    .disp_i_ready(disp_rdy),
+    .disp_i_rs1x0(dec_rs1x0),
+    .disp_i_rs2x0(dec_rs2x0),
+    .disp_i_rs1en(dec_rs1_en),
+    .disp_i_rs2en(dec_rs2_en),
+    .disp_i_rs1idx(i_rs1idx),
+    .disp_i_rs2idx(i_rs2idx),
+    .disp_i_rs1(rf_rs1_data),
+    .disp_i_rs2(rf_rs2_data),
+    .disp_i_rdwen(dec_rd_en),
+    .disp_i_rdidx(dec_rd_idx),
+    .disp_i_info(dec_info),
+    .disp_i_imm(dec_imm),
+    .disp_i_pc(dec_pc_out),
+    .disp_i_misalgn(dec_misalgn),
+    .disp_i_buserr(dec_buserr_out),
+    .disp_i_ilegl(dec_ilegl),
+    .disp_o_alu_valid(disp_alu_valid),
+    .disp_o_alu_ready(alu_o_ready),
+    .disp_o_alu_longpipe(alu_longpipe),
+    .disp_o_alu_rs1(disp_alu_rs1),
+    .disp_o_alu_rs2(disp_alu_rs2),
+    .disp_o_alu_rdwen(disp_alu_rdwen),
+    .disp_o_alu_rdidx(disp_alu_rdidx),
+    .disp_o_alu_info(disp_alu_info),
+    .disp_o_alu_imm(disp_alu_imm),
+    .disp_o_alu_pc(disp_alu_pc),
+    .disp_o_alu_itag(disp_alu_itag),
+    .disp_o_alu_misalgn(disp_alu_misalgn),
+    .disp_o_alu_buserr(disp_alu_buserr),
+    .disp_o_alu_ilegl(disp_alu_ilegl),
+    .oitfrd_match_disprs1(oitf_match_rs1),
+    .oitfrd_match_disprs2(oitf_match_rs2),
+    .oitfrd_match_disprs3(oitf_match_rs3),
+    .oitfrd_match_disprd(oitf_match_rd),
+    .disp_oitf_ptr(oitf_dis_ptr),
+    .disp_oitf_ena(oitf_dis_ena),
+    .disp_oitf_ready(oitf_dis_ready),
+    .disp_oitf_rs1fpu(disp_oitf_rs1fpu_w),
+    .disp_oitf_rs2fpu(disp_oitf_rs2fpu_w),
+    .disp_oitf_rs3fpu(disp_oitf_rs3fpu_w),
+    .disp_oitf_rdfpu(disp_oitf_rdfpu_w),
+    .disp_oitf_rs1en(disp_oitf_rs1en_w),
+    .disp_oitf_rs2en(disp_oitf_rs2en_w),
+    .disp_oitf_rs3en(disp_oitf_rs3en_w),
+    .disp_oitf_rdwen(disp_oitf_rdwen_w),
+    .disp_oitf_rs1idx(disp_oitf_rs1idx_w),
+    .disp_oitf_rs2idx(disp_oitf_rs2idx_w),
+    .disp_oitf_rs3idx(disp_oitf_rs3idx_w),
+    .disp_oitf_rdidx(disp_oitf_rdidx_w),
+    .disp_oitf_pc(disp_oitf_pc_w)
+  );
+  e203_exu_oitf oitf_u (
+    .clk(clk),
+    .rst_n(rst_n),
     .dis_ready(oitf_dis_ready),
+    .dis_ena(oitf_dis_ena),
     .ret_ena(oitf_ret_ena),
-    .ret_rd_idx(oitf_ret_rd_idx),
-    .ret_rd_en(oitf_ret_rd_en),
-    .chk_rs1_idx(dec_rs1_idx),
-    .chk_rs1_en(dec_rs1_en),
-    .chk_rs2_idx(dec_rs2_idx),
-    .chk_rs2_en(dec_rs2_en),
-    .chk_rd_idx(dec_rd_idx),
-    .chk_rd_en(dec_rd_en),
-    .raw_dep(oitf_raw_dep),
-    .waw_dep(oitf_waw_dep),
-    .dep_stall(oitf_dep_stall),
+    .dis_ptr(oitf_dis_ptr),
+    .ret_ptr(oitf_ret_ptr),
+    .ret_rdidx(oitf_ret_rdidx),
+    .ret_rdwen(oitf_ret_rdwen),
+    .ret_rdfpu(oitf_ret_rdfpu),
+    .ret_pc(oitf_ret_pc),
+    .disp_i_rs1en(disp_oitf_rs1en_w),
+    .disp_i_rs2en(disp_oitf_rs2en_w),
+    .disp_i_rs3en(disp_oitf_rs3en_w),
+    .disp_i_rdwen(disp_oitf_rdwen_w),
+    .disp_i_rs1fpu(disp_oitf_rs1fpu_w),
+    .disp_i_rs2fpu(disp_oitf_rs2fpu_w),
+    .disp_i_rs3fpu(disp_oitf_rs3fpu_w),
+    .disp_i_rdfpu(disp_oitf_rdfpu_w),
+    .disp_i_rs1idx(disp_oitf_rs1idx_w),
+    .disp_i_rs2idx(disp_oitf_rs2idx_w),
+    .disp_i_rs3idx(disp_oitf_rs3idx_w),
+    .disp_i_rdidx(disp_oitf_rdidx_w),
+    .disp_i_pc(disp_oitf_pc_w),
+    .oitfrd_match_disprs1(oitf_match_rs1),
+    .oitfrd_match_disprs2(oitf_match_rs2),
+    .oitfrd_match_disprs3(oitf_match_rs3),
+    .oitfrd_match_disprd(oitf_match_rd),
     .oitf_empty(oitf_is_empty)
   );
-  // Allocate on muldiv dispatch
-  // Deallocate on muldiv writeback
-  // Hazard check against new instruction
-  // ── Dispatch ───────────────────────────────────────────────────────
-  logic disp_rdy;
-  logic disp_alu_valid;
-  logic [32-1:0] disp_alu_rs1;
-  logic [32-1:0] disp_alu_rs2;
-  logic [32-1:0] disp_alu_pc;
-  logic [32-1:0] disp_alu_imm;
-  logic [5-1:0] disp_alu_rdidx;
-  logic disp_alu_op_add;
-  logic disp_alu_op_sub;
-  logic disp_alu_op_xor;
-  logic disp_alu_op_sll;
-  logic disp_alu_op_srl;
-  logic disp_alu_op_sra;
-  logic disp_alu_op_or;
-  logic disp_alu_op_and;
-  logic disp_alu_op_slt;
-  logic disp_alu_op_sltu;
-  logic disp_alu_op_lui;
-  logic disp_alu_is_bjp;
-  logic disp_alu_beq;
-  logic disp_alu_bne;
-  logic disp_alu_blt;
-  logic disp_alu_bge;
-  logic disp_alu_bltu;
-  logic disp_alu_bgeu;
-  logic disp_alu_is_jump;
-  logic disp_alu_is_agu;
-  logic disp_mdv_valid;
-  logic [32-1:0] disp_mdv_rs1;
-  logic [32-1:0] disp_mdv_rs2;
-  logic [5-1:0] disp_mdv_rdidx;
-  logic disp_mdv_rd_en;
-  logic disp_mdv_mul;
-  logic disp_mdv_mulh;
-  logic disp_mdv_mulhsu;
-  logic disp_mdv_mulhu;
-  logic disp_mdv_div;
-  logic disp_mdv_divu;
-  logic disp_mdv_rem;
-  logic disp_mdv_remu;
-  logic disp_lsu_valid;
-  logic [32-1:0] disp_lsu_rs1;
-  logic [32-1:0] disp_lsu_rs2;
-  logic [32-1:0] disp_lsu_imm;
-  logic disp_lsu_load;
-  logic disp_lsu_store;
-  ExuDisp disp (
-    .disp_valid(disp_valid_gated),
-    .disp_ready(disp_rdy),
-    .i_rs1(rf_rs1_data),
-    .i_rs2(rf_rs2_data),
-    .i_pc(ifu_pc),
-    .i_imm(dec_imm),
-    .i_rd_idx(dec_rd_idx),
-    .i_rd_en(dec_rd_en),
-    .i_rs2_en(dec_rs2_en),
-    .i_alu(dec_alu),
-    .i_bjp(dec_bjp),
-    .i_agu(dec_agu),
-    .i_load(dec_load),
-    .i_store(dec_store),
-    .i_mul(dec_mul),
-    .i_mulh(dec_mulh),
-    .i_mulhsu(dec_mulhsu),
-    .i_mulhu(dec_mulhu),
-    .i_div(dec_div),
-    .i_divu(dec_divu),
-    .i_rem(dec_rem),
-    .i_remu(dec_remu),
-    .i_alu_add(dec_alu_add),
-    .i_alu_sub(dec_alu_sub),
-    .i_alu_xor(dec_alu_xor),
-    .i_alu_sll(dec_alu_sll),
-    .i_alu_srl(dec_alu_srl),
-    .i_alu_sra(dec_alu_sra),
-    .i_alu_or(dec_alu_or),
-    .i_alu_and(dec_alu_and),
-    .i_alu_slt(dec_alu_slt),
-    .i_alu_sltu(dec_alu_sltu),
-    .i_alu_lui(dec_alu_lui),
-    .i_beq(dec_beq),
-    .i_bne(dec_bne),
-    .i_blt(dec_blt),
-    .i_bge(dec_bge),
-    .i_bltu(dec_bltu),
-    .i_bgeu(dec_bgeu),
-    .i_jump(dec_jump),
-    .alu_valid(disp_alu_valid),
-    .alu_ready(alu_o_ready),
-    .alu_rs1(disp_alu_rs1),
-    .alu_rs2(disp_alu_rs2),
-    .alu_pc(disp_alu_pc),
-    .alu_imm(disp_alu_imm),
-    .alu_rdidx(disp_alu_rdidx),
-    .alu_op_add(disp_alu_op_add),
-    .alu_op_sub(disp_alu_op_sub),
-    .alu_op_xor(disp_alu_op_xor),
-    .alu_op_sll(disp_alu_op_sll),
-    .alu_op_srl(disp_alu_op_srl),
-    .alu_op_sra(disp_alu_op_sra),
-    .alu_op_or(disp_alu_op_or),
-    .alu_op_and(disp_alu_op_and),
-    .alu_op_slt(disp_alu_op_slt),
-    .alu_op_sltu(disp_alu_op_sltu),
-    .alu_op_lui(disp_alu_op_lui),
-    .alu_is_bjp(disp_alu_is_bjp),
-    .alu_beq(disp_alu_beq),
-    .alu_bne(disp_alu_bne),
-    .alu_blt(disp_alu_blt),
-    .alu_bge(disp_alu_bge),
-    .alu_bltu(disp_alu_bltu),
-    .alu_bgeu(disp_alu_bgeu),
-    .alu_is_jump(disp_alu_is_jump),
-    .alu_is_agu(disp_alu_is_agu),
-    .mdv_valid(disp_mdv_valid),
-    .mdv_ready(mdv_i_ready),
-    .mdv_rs1(disp_mdv_rs1),
-    .mdv_rs2(disp_mdv_rs2),
-    .mdv_rdidx(disp_mdv_rdidx),
-    .mdv_rd_en(disp_mdv_rd_en),
-    .mdv_mul(disp_mdv_mul),
-    .mdv_mulh(disp_mdv_mulh),
-    .mdv_mulhsu(disp_mdv_mulhsu),
-    .mdv_mulhu(disp_mdv_mulhu),
-    .mdv_div(disp_mdv_div),
-    .mdv_divu(disp_mdv_divu),
-    .mdv_rem(disp_mdv_rem),
-    .mdv_remu(disp_mdv_remu),
-    .lsu_valid(disp_lsu_valid),
-    .lsu_ready(lsu_ready),
-    .lsu_rs1(disp_lsu_rs1),
-    .lsu_rs2(disp_lsu_rs2),
-    .lsu_imm(disp_lsu_imm),
-    .lsu_load(disp_lsu_load),
-    .lsu_store(disp_lsu_store)
-  );
-  // ── ALU ────────────────────────────────────────────────────────────
-  logic alu_o_ready;
-  logic alu_done_valid;
-  logic [32-1:0] alu_wdat;
-  logic [5-1:0] alu_rdidx;
-  logic alu_bjp_taken;
-  logic [32-1:0] alu_bjp_tgt;
-  logic [32-1:0] alu_bjp_lnk;
-  ExuAlu alu (
+  e203_exu_alu alu_u (
     .clk(clk),
     .rst_n(rst_n),
     .i_valid(disp_alu_valid),
     .i_ready(alu_o_ready),
+    .i_longpipe(alu_longpipe),
     .i_rs1(disp_alu_rs1),
     .i_rs2(disp_alu_rs2),
-    .i_pc(disp_alu_pc),
     .i_imm(disp_alu_imm),
+    .i_info(disp_alu_info),
+    .i_pc(disp_alu_pc),
+    .i_instr(i_ir),
+    .i_pc_vld(i_pc_vld),
     .i_rdidx(disp_alu_rdidx),
-    .i_alu(1'b1),
-    .i_alu_add(disp_alu_op_add),
-    .i_alu_sub(disp_alu_op_sub),
-    .i_alu_xor(disp_alu_op_xor),
-    .i_alu_sll(disp_alu_op_sll),
-    .i_alu_srl(disp_alu_op_srl),
-    .i_alu_sra(disp_alu_op_sra),
-    .i_alu_or(disp_alu_op_or),
-    .i_alu_and(disp_alu_op_and),
-    .i_alu_slt(disp_alu_op_slt),
-    .i_alu_sltu(disp_alu_op_sltu),
-    .i_alu_lui(disp_alu_op_lui),
-    .i_bjp(disp_alu_is_bjp),
-    .i_beq(disp_alu_beq),
-    .i_bne(disp_alu_bne),
-    .i_blt(disp_alu_blt),
-    .i_bge(disp_alu_bge),
-    .i_bltu(disp_alu_bltu),
-    .i_bgeu(disp_alu_bgeu),
-    .i_jump(disp_alu_is_jump),
-    .i_agu(disp_alu_is_agu),
-    .i_agu_swap(1'b0),
-    .i_agu_add(1'b0),
-    .i_agu_and(1'b0),
-    .i_agu_or(1'b0),
-    .i_agu_xor(1'b0),
-    .i_agu_max(1'b0),
-    .i_agu_min(1'b0),
-    .i_agu_maxu(1'b0),
-    .i_agu_minu(1'b0),
-    .i_agu_sbf_0_ena(1'b0),
-    .i_agu_sbf_0_nxt(0),
-    .i_agu_sbf_1_ena(1'b0),
-    .i_agu_sbf_1_nxt(0),
-    .o_valid(alu_done_valid),
-    .o_ready(wbck_alu_ready),
-    .o_wdat(alu_wdat),
-    .o_rdidx(alu_rdidx),
-    .o_bjp_taken(alu_bjp_taken),
-    .o_bjp_tgt(alu_bjp_tgt),
-    .o_bjp_lnk(alu_bjp_lnk)
+    .i_rdwen(disp_alu_rdwen),
+    .i_itag(disp_alu_itag),
+    .i_ilegl(disp_alu_ilegl),
+    .i_buserr(disp_alu_buserr),
+    .i_misalgn(disp_alu_misalgn),
+    .nice_xs_off(csr_nice_xs_off),
+    .amo_wait(amo_wait_w),
+    .oitf_empty(oitf_empty_w),
+    .flush_req(flush_req_w),
+    .flush_pulse(pipe_flush_pulse_w),
+    .mdv_nob2b(csr_mdv_nob2b),
+    .i_nice_cmt_off_ilgl(1'b0),
+    .cmt_o_valid(alu_cmt_valid),
+    .cmt_o_ready(commit_alu_ready),
+    .cmt_o_pc_vld(alu_cmt_pc_vld),
+    .cmt_o_pc(alu_cmt_pc),
+    .cmt_o_instr(alu_cmt_instr),
+    .cmt_o_imm(alu_cmt_imm),
+    .cmt_o_rv32(alu_cmt_rv32),
+    .cmt_o_bjp(alu_cmt_bjp),
+    .cmt_o_mret(alu_cmt_mret),
+    .cmt_o_dret(alu_cmt_dret),
+    .cmt_o_ecall(alu_cmt_ecall),
+    .cmt_o_ebreak(alu_cmt_ebreak),
+    .cmt_o_fencei(alu_cmt_fencei),
+    .cmt_o_wfi(alu_cmt_wfi),
+    .cmt_o_ifu_misalgn(alu_cmt_ifu_misalgn),
+    .cmt_o_ifu_buserr(alu_cmt_ifu_buserr),
+    .cmt_o_ifu_ilegl(alu_cmt_ifu_ilegl),
+    .cmt_o_bjp_prdt(alu_cmt_bjp_prdt),
+    .cmt_o_bjp_rslv(alu_cmt_bjp_rslv),
+    .cmt_o_misalgn(alu_cmt_misalgn),
+    .cmt_o_ld(alu_cmt_ld),
+    .cmt_o_stamo(alu_cmt_stamo),
+    .cmt_o_buserr(alu_cmt_buserr),
+    .cmt_o_badaddr(alu_cmt_badaddr),
+    .wbck_o_valid(alu_wbck_valid),
+    .wbck_o_ready(wbck_alu_ready),
+    .wbck_o_wdat(alu_wdat),
+    .wbck_o_rdidx(alu_rdidx),
+    .csr_ena(alu_csr_ena),
+    .csr_wr_en(alu_csr_wr_en),
+    .csr_rd_en(alu_csr_rd_en),
+    .csr_idx(alu_csr_idx),
+    .nonflush_cmt_ena(nonflush_cmt_ena_w),
+    .csr_access_ilgl(csr_access_ilgl_w),
+    .read_csr_dat(read_csr_dat_w),
+    .wbck_csr_dat(alu_wbck_csr_dat),
+    .agu_icb_cmd_valid(agu_icb_cmd_valid),
+    .agu_icb_cmd_ready(agu_icb_cmd_ready),
+    .agu_icb_cmd_addr(agu_icb_cmd_addr),
+    .agu_icb_cmd_read(agu_icb_cmd_read),
+    .agu_icb_cmd_wdata(agu_icb_cmd_wdata),
+    .agu_icb_cmd_wmask(agu_icb_cmd_wmask),
+    .agu_icb_cmd_lock(agu_icb_cmd_lock),
+    .agu_icb_cmd_excl(agu_icb_cmd_excl),
+    .agu_icb_cmd_size(agu_icb_cmd_size),
+    .agu_icb_cmd_back2agu(agu_icb_cmd_back2agu),
+    .agu_icb_cmd_usign(agu_icb_cmd_usign),
+    .agu_icb_cmd_itag(agu_icb_cmd_itag),
+    .agu_icb_rsp_valid(agu_icb_rsp_valid),
+    .agu_icb_rsp_ready(agu_icb_rsp_ready),
+    .agu_icb_rsp_err(agu_icb_rsp_err),
+    .agu_icb_rsp_excl_ok(agu_icb_rsp_excl_ok),
+    .agu_icb_rsp_rdata(agu_icb_rsp_rdata),
+    .nice_req_valid(nice_req_valid),
+    .nice_req_ready(nice_req_ready),
+    .nice_req_instr(nice_req_inst),
+    .nice_req_rs1(nice_req_rs1),
+    .nice_req_rs2(nice_req_rs2),
+    .nice_rsp_multicyc_valid(nice_rsp_multicyc_valid),
+    .nice_rsp_multicyc_ready(nice_rsp_multicyc_ready),
+    .nice_longp_wbck_valid(alu_nice_longp_wbck_valid),
+    .nice_longp_wbck_ready(alu_nice_longp_wbck_ready),
+    .nice_o_itag(alu_nice_o_itag)
   );
-  // ── MulDiv ─────────────────────────────────────────────────────────
-  logic mdv_i_ready;
-  logic mdv_done_valid;
-  logic [32-1:0] mdv_wdat;
-  ExuMuldiv mdv (
+  e203_exu_longpwbck longp_u (
     .clk(clk),
     .rst_n(rst_n),
-    .i_valid(mdv_dispatch_valid),
-    .i_ready(mdv_i_ready),
-    .i_rs1(disp_mdv_rs1),
-    .i_rs2(disp_mdv_rs2),
-    .i_mul(disp_mdv_mul),
-    .i_mulh(disp_mdv_mulh),
-    .i_mulhsu(disp_mdv_mulhsu),
-    .i_mulhu(disp_mdv_mulhu),
-    .i_div(disp_mdv_div),
-    .i_divu(disp_mdv_divu),
-    .i_rem(disp_mdv_rem),
-    .i_remu(disp_mdv_remu),
-    .o_valid(mdv_done_valid),
-    .o_ready(wbck_longp_ready),
-    .o_wdat(mdv_wdat)
+    .lsu_wbck_i_valid(lsu_o_valid),
+    .lsu_wbck_i_ready(longp_lsu_ready),
+    .lsu_wbck_i_wdat(lsu_o_wbck_wdat),
+    .lsu_wbck_i_itag(1'(lsu_o_wbck_itag)),
+    .lsu_wbck_i_err(lsu_o_wbck_err),
+    .lsu_cmt_i_buserr(lsu_o_cmt_buserr),
+    .lsu_cmt_i_badaddr(lsu_o_cmt_badaddr),
+    .lsu_cmt_i_ld(lsu_o_cmt_ld),
+    .lsu_cmt_i_st(lsu_o_cmt_st),
+    .longp_wbck_o_valid(longp_wbck_valid),
+    .longp_wbck_o_ready(wbck_longp_ready),
+    .longp_wbck_o_wdat(longp_wbck_wdat),
+    .longp_wbck_o_flags(longp_wbck_flags),
+    .longp_wbck_o_rdidx(longp_wbck_rdidx),
+    .longp_wbck_o_rdfpu(longp_wbck_rdfpu),
+    .longp_excp_o_valid(longp_excp_valid),
+    .longp_excp_o_ready(longp_excp_ready_from_commit),
+    .longp_excp_o_insterr(longp_excp_insterr),
+    .longp_excp_o_ld(longp_excp_ld),
+    .longp_excp_o_st(longp_excp_st),
+    .longp_excp_o_buserr(longp_excp_buserr),
+    .longp_excp_o_badaddr(longp_excp_badaddr),
+    .longp_excp_o_pc(longp_excp_pc),
+    .oitf_empty(oitf_is_empty),
+    .oitf_ret_ptr(oitf_ret_ptr),
+    .oitf_ret_rdidx(oitf_ret_rdidx),
+    .oitf_ret_pc(oitf_ret_pc),
+    .oitf_ret_rdwen(oitf_ret_rdwen),
+    .oitf_ret_rdfpu(oitf_ret_rdfpu),
+    .oitf_ret_ena(oitf_ret_ena),
+    .nice_longp_wbck_i_valid(1'b0),
+    .nice_longp_wbck_i_ready(longp_nice_ready),
+    .nice_longp_wbck_i_wdat(0),
+    .nice_longp_wbck_i_itag(0),
+    .nice_longp_wbck_i_err(1'b0)
   );
-  // ── Writeback arbiter (replaces ExuCommit) ─────────────────────────
-  logic wbck_alu_ready;
-  logic wbck_longp_ready;
-  logic wbck_rf_ena;
-  logic [32-1:0] wbck_rf_wdat;
-  logic [5-1:0] wbck_rf_rdidx;
-  ExuWbck wbck (
+  e203_exu_wbck wbck_u (
     .clk(clk),
     .rst_n(rst_n),
     .alu_wbck_i_valid(alu_done_valid),
     .alu_wbck_i_ready(wbck_alu_ready),
     .alu_wbck_i_wdat(alu_wdat),
     .alu_wbck_i_rdidx(alu_rdidx),
-    .longp_wbck_i_valid(mdv_done_valid),
+    .longp_wbck_i_valid(longp_wbck_valid),
     .longp_wbck_i_ready(wbck_longp_ready),
-    .longp_wbck_i_wdat(mdv_wdat),
+    .longp_wbck_i_wdat(longp_wbck_wdat),
     .longp_wbck_i_flags(0),
-    .longp_wbck_i_rdidx(oitf_ret_rd_idx),
+    .longp_wbck_i_rdidx(longp_wbck_rdidx),
     .longp_wbck_i_rdfpu(1'b0),
     .rf_wbck_o_ena(wbck_rf_ena),
     .rf_wbck_o_wdat(wbck_rf_wdat),
     .rf_wbck_o_rdidx(wbck_rf_rdidx)
   );
-  // ALU path (lower priority)
-  // Long-pipe path (higher priority) — MulDiv results
-  // RF write port
-  // ── Glue logic ────────────────────────────────────────────────────
-  logic disp_valid_gated;
-  logic oitf_dis_ena;
-  logic oitf_ret_ena;
-  logic mdv_dispatch_valid;
-  assign disp_valid_gated = (ifu_valid & (~oitf_dep_stall));
-  assign ifu_ready = (disp_rdy & (~oitf_dep_stall));
-  assign oitf_dis_ena = ((disp_mdv_valid & mdv_i_ready) & oitf_dis_ready);
-  assign mdv_dispatch_valid = (disp_mdv_valid & oitf_dis_ready);
-  assign oitf_ret_ena = (mdv_done_valid & wbck_longp_ready);
-  assign o_bjp_valid = (alu_done_valid & alu_bjp_taken);
-  assign o_bjp_taken = alu_bjp_taken;
-  assign o_bjp_tgt = alu_bjp_tgt;
-  assign lsu_valid = disp_lsu_valid;
-  assign lsu_addr = (disp_lsu_rs1 + disp_lsu_imm);
-  assign lsu_wdata = disp_lsu_rs2;
-  assign lsu_load = disp_lsu_load;
-  assign lsu_store = disp_lsu_store;
-  assign o_commit_valid = ((alu_done_valid & wbck_alu_ready) | (mdv_done_valid & wbck_longp_ready));
+  e203_exu_commit commit_u (
+    .clk(clk),
+    .rst_n(rst_n),
+    .commit_mret(commit_mret_w),
+    .commit_trap(commit_trap_w),
+    .core_wfi(core_wfi_w),
+    .nonflush_cmt_ena(nonflush_cmt_ena_w),
+    .excp_active(excp_active_w),
+    .amo_wait(amo_wait_w),
+    .wfi_halt_ifu_req(wfi_halt_ifu_req_w),
+    .wfi_halt_exu_req(wfi_halt_exu_req_w),
+    .wfi_halt_ifu_ack(wfi_halt_ifu_ack),
+    .wfi_halt_exu_ack(disp_wfi_halt_exu_ack),
+    .dbg_irq_r(dbg_irq_r),
+    .lcl_irq_r(lcl_irq_r),
+    .ext_irq_r(ext_irq_r),
+    .sft_irq_r(sft_irq_r),
+    .tmr_irq_r(tmr_irq_r),
+    .evt_r(evt_r),
+    .status_mie_r(csr_status_mie),
+    .mtie_r(csr_mtie),
+    .msie_r(csr_msie),
+    .meie_r(csr_meie),
+    .alu_cmt_i_valid(alu_cmt_valid),
+    .alu_cmt_i_ready(commit_alu_ready),
+    .alu_cmt_i_pc(alu_cmt_pc),
+    .alu_cmt_i_instr(alu_cmt_instr),
+    .alu_cmt_i_pc_vld(alu_cmt_pc_vld),
+    .alu_cmt_i_imm(alu_cmt_imm),
+    .alu_cmt_i_rv32(alu_cmt_rv32),
+    .alu_cmt_i_bjp(alu_cmt_bjp),
+    .alu_cmt_i_wfi(alu_cmt_wfi),
+    .alu_cmt_i_fencei(alu_cmt_fencei),
+    .alu_cmt_i_mret(alu_cmt_mret),
+    .alu_cmt_i_dret(alu_cmt_dret),
+    .alu_cmt_i_ecall(alu_cmt_ecall),
+    .alu_cmt_i_ebreak(alu_cmt_ebreak),
+    .alu_cmt_i_ifu_misalgn(alu_cmt_ifu_misalgn),
+    .alu_cmt_i_ifu_buserr(alu_cmt_ifu_buserr),
+    .alu_cmt_i_ifu_ilegl(alu_cmt_ifu_ilegl),
+    .alu_cmt_i_bjp_prdt(alu_cmt_bjp_prdt),
+    .alu_cmt_i_bjp_rslv(alu_cmt_bjp_rslv),
+    .alu_cmt_i_misalgn(alu_cmt_misalgn),
+    .alu_cmt_i_ld(alu_cmt_ld),
+    .alu_cmt_i_stamo(alu_cmt_stamo),
+    .alu_cmt_i_buserr(alu_cmt_buserr),
+    .alu_cmt_i_badaddr(alu_cmt_badaddr),
+    .cmt_badaddr(cmt_badaddr_w),
+    .cmt_badaddr_ena(cmt_badaddr_ena_w),
+    .cmt_epc(cmt_epc_w),
+    .cmt_epc_ena(cmt_epc_ena_w),
+    .cmt_cause(cmt_cause_w),
+    .cmt_cause_ena(cmt_cause_ena_w),
+    .cmt_instret_ena(cmt_instret_ena_w),
+    .cmt_status_ena(cmt_status_ena_w),
+    .cmt_dpc(cmt_dpc_w),
+    .cmt_dpc_ena(cmt_dpc_ena_w),
+    .cmt_dcause(cmt_dcause_w),
+    .cmt_dcause_ena(cmt_dcause_ena_w),
+    .cmt_mret_ena(cmt_mret_ena_w),
+    .csr_epc_r(csr_mepc_val),
+    .csr_dpc_r(csr_dpc_val),
+    .csr_mtvec_r(csr_mtvec_val),
+    .dbg_mode(dbg_mode),
+    .dbg_halt_r(dbg_halt_r),
+    .dbg_step_r(dbg_step_r),
+    .dbg_ebreakm_r(dbg_ebreakm_r),
+    .oitf_empty(oitf_is_empty),
+    .u_mode(csr_u_mode),
+    .s_mode(csr_s_mode),
+    .h_mode(csr_h_mode),
+    .m_mode(csr_m_mode),
+    .longp_excp_i_ready(longp_excp_ready_from_commit),
+    .longp_excp_i_valid(longp_excp_valid),
+    .longp_excp_i_ld(longp_excp_ld),
+    .longp_excp_i_st(longp_excp_st),
+    .longp_excp_i_buserr(longp_excp_buserr),
+    .longp_excp_i_badaddr(longp_excp_badaddr),
+    .longp_excp_i_insterr(longp_excp_insterr),
+    .longp_excp_i_pc(longp_excp_pc),
+    .flush_pulse(flush_pulse_w),
+    .flush_req(flush_req_w),
+    .pipe_flush_ack(pipe_flush_ack),
+    .pipe_flush_req(pipe_flush_req_w),
+    .pipe_flush_add_op1(pipe_flush_add_op1_w),
+    .pipe_flush_add_op2(pipe_flush_add_op2_w),
+    .pipe_flush_pc(pipe_flush_pc_w)
+  );
+  e203_exu_csr csr_u (
+    .clk(clk),
+    .rst_n(rst_n),
+    .clk_aon(clk_aon),
+    .nonflush_cmt_ena(nonflush_cmt_ena_w),
+    .csr_ena(alu_csr_ena),
+    .csr_wr_en(alu_csr_wr_en),
+    .csr_rd_en(alu_csr_rd_en),
+    .csr_idx(alu_csr_idx),
+    .csr_access_ilgl(csr_access_ilgl_w),
+    .read_csr_dat(csr_rdata),
+    .wbck_csr_dat(alu_wbck_csr_dat),
+    .nice_xs_off(csr_nice_xs_off),
+    .tm_stop(csr_tm_stop),
+    .core_cgstop(csr_core_cgstop),
+    .tcm_cgstop(csr_tcm_cgstop),
+    .itcm_nohold(csr_itcm_nohold),
+    .mdv_nob2b(csr_mdv_nob2b),
+    .core_mhartid(core_mhartid[0:0]),
+    .ext_irq_r(ext_irq_r),
+    .sft_irq_r(sft_irq_r),
+    .tmr_irq_r(tmr_irq_r),
+    .status_mie_r(csr_status_mie),
+    .mtie_r(csr_mtie),
+    .msie_r(csr_msie),
+    .meie_r(csr_meie),
+    .wr_dcsr_ena(csr_wr_dcsr_ena),
+    .wr_dpc_ena(csr_wr_dpc_ena),
+    .wr_dscratch_ena(csr_wr_dscratch_ena),
+    .dcsr_r(dcsr_r),
+    .dpc_r(dpc_r),
+    .dscratch_r(dscratch_r),
+    .wr_csr_nxt(csr_wr_csr_nxt),
+    .dbg_mode(dbg_mode),
+    .dbg_stopcycle(dbg_stopcycle),
+    .u_mode(csr_u_mode),
+    .s_mode(csr_s_mode),
+    .h_mode(csr_h_mode),
+    .m_mode(csr_m_mode),
+    .cmt_badaddr(cmt_badaddr_w),
+    .cmt_badaddr_ena(cmt_badaddr_ena_w),
+    .cmt_epc(cmt_epc_w),
+    .cmt_epc_ena(cmt_epc_ena_w),
+    .cmt_cause(cmt_cause_w),
+    .cmt_cause_ena(cmt_cause_ena_w),
+    .cmt_status_ena(cmt_status_ena_w),
+    .cmt_instret_ena(cmt_instret_ena_w),
+    .cmt_mret_ena(cmt_mret_ena_w),
+    .csr_epc_r(csr_mepc_val),
+    .csr_dpc_r(csr_dpc_val),
+    .csr_mtvec_r(csr_mtvec_val)
+  );
+  e203_exu_regfile rf_u (
+    .clk(clk),
+    .rst_n(rst_n),
+    .test_mode(test_mode),
+    .read_src1_idx(dec_rs1_idx),
+    .read_src1_dat(rf_rs1_data),
+    .read_src2_idx(dec_rs2_idx),
+    .read_src2_dat(rf_rs2_data),
+    .wbck_dest_wen(wbck_rf_ena),
+    .wbck_dest_idx(wbck_rf_rdidx),
+    .wbck_dest_dat(wbck_rf_wdat),
+    .x1_r(rf_x1_r)
+  );
+  assign disp_valid_gated = i_valid;
+  assign i_ready = disp_rdy;
+  assign pipe_flush_req = pipe_flush_req_w;
+  assign pipe_flush_add_op1 = pipe_flush_add_op1_w;
+  assign pipe_flush_add_op2 = pipe_flush_add_op2_w;
+  assign pipe_flush_pc = pipe_flush_pc_w;
+  assign lsu_o_ready = longp_lsu_ready;
+  assign oitf_empty = oitf_is_empty;
+  assign rf2ifu_x1 = rf_x1_r;
+  assign rf2ifu_rs1 = rf_rs1_data;
+  assign dec2ifu_rden = dec_rd_en & ~disp_oitf_rdfpu_w;
+  assign dec2ifu_rs1en = dec_rs1_en & ~disp_oitf_rs1fpu_w;
+  assign dec2ifu_rdidx = dec_rd_idx;
+  assign dec2ifu_mulhsu = dec_mulhsu;
+  assign dec2ifu_div = dec_div;
+  assign dec2ifu_rem = dec_rem;
+  assign dec2ifu_divu = dec_divu;
+  assign dec2ifu_remu = dec_remu;
+  assign exu_active = ~oitf_is_empty | i_valid | excp_active_w;
+  assign excp_active = excp_active_w;
+  assign commit_mret = commit_mret_w;
+  assign commit_trap = commit_trap_w;
+  assign core_wfi = core_wfi_w;
+  assign wfi_halt_ifu_req = wfi_halt_ifu_req_w;
+  assign tm_stop = csr_tm_stop;
+  assign itcm_nohold = csr_itcm_nohold;
+  assign core_cgstop = csr_core_cgstop;
+  assign tcm_cgstop = csr_tcm_cgstop;
+  assign cmt_dpc = cmt_dpc_w;
+  assign cmt_dpc_ena = cmt_dpc_ena_w;
+  assign cmt_dcause = cmt_dcause_w;
+  assign cmt_dcause_ena = cmt_dcause_ena_w;
+  assign wr_dcsr_ena = csr_wr_dcsr_ena;
+  assign wr_dpc_ena = csr_wr_dpc_ena;
+  assign wr_dscratch_ena = csr_wr_dscratch_ena;
+  assign wr_csr_nxt = csr_wr_csr_nxt;
+  assign alu_done_valid = alu_wbck_valid;
+  assign oitf_empty_w = oitf_is_empty;
+  assign pipe_flush_pulse_w = flush_pulse_w;
+  assign read_csr_dat_w = csr_rdata;
 
 endmodule
 
-// Gate dispatch on OITF hazard stall
-// OITF allocate: when muldiv dispatches successfully
-// Gate muldiv dispatch on OITF availability
-// OITF deallocate: when muldiv result is written back
-// BJP feedback
-// LSU interface
-// Commit status — either ALU or long-pipe completes

--- a/tests/e203/e203_ifu_top.arch
+++ b/tests/e203/e203_ifu_top.arch
@@ -1,119 +1,171 @@
-// E203 HBirdv2 IFU Top — wires IfuIfetch, IfuMinidec, LiteBpu, Ift2Icb
-// Simplified: no RVC (16-bit) support, ITCM-only fetch path.
+// E203 HBirdv2 IFU top — hierarchical integration fixture (second-generation).
+// Same real-fabric wiring as e203_ifu.arch: e203_ifu_ifetch (PC gen + fetch FSM)
+// + e203_ifu_ift2icb (fetch-to-ICB bridge), per reference e203_ifu.v.
 
 module e203_ifu_top
   port clk:   in Clock<SysDomain>;
   port rst_n: in Reset<Async, Low>;
 
-  // Output to EXU: decoded instruction
-  port o_valid:   out Bool;
-  port o_ready:   in  Bool;
-  port o_instr:   out UInt<32>;
-  port o_pc:      out UInt<32>;
-  port o_bus_err: out Bool;
+  // ── Inspect / status ───────────────────────────────────────────────
+  port inspect_pc:  out UInt<32>;
+  port ifu_active:  out Bool;
 
-  // Branch redirect from EXU
-  port exu_redirect:    in Bool;
-  port exu_redirect_pc: in UInt<32>;
+  // ── ITCM config ────────────────────────────────────────────────────
+  port itcm_nohold:      in Bool;
+  port pc_rtvec:         in UInt<32>;
+  port ifu2itcm_holdup:  in Bool;
+  port itcm_region_indic: in UInt<32>;
 
-  // ITCM interface
-  port itcm: initiator ItcmIcb;
+  // ── ITCM ICB master ────────────────────────────────────────────────
+  port ifu2itcm_icb_cmd_valid: out Bool;
+  port ifu2itcm_icb_cmd_ready: in  Bool;
+  port ifu2itcm_icb_cmd_addr:  out UInt<16>;
+  port ifu2itcm_icb_rsp_valid: in  Bool;
+  port ifu2itcm_icb_rsp_ready: out Bool;
+  port ifu2itcm_icb_rsp_err:   in  Bool;
+  port ifu2itcm_icb_rsp_rdata: in  UInt<64>;
 
-  // OITF/regfile inputs for BPU
-  port oitf_empty:              in Bool;
-  port ir_empty:                in Bool;
-  port ir_rs1en:                in Bool;
-  port jalr_rs1idx_cam_irrdidx: in Bool;
-  port ir_valid_clr:            in Bool;
-  port rf2bpu_x1:               in UInt<32>;
-  port rf2bpu_rs1:              in UInt<32>;
+  // ── BIU ICB master (external memory path) ──────────────────────────
+  port ifu2biu_icb_cmd_valid: out Bool;
+  port ifu2biu_icb_cmd_ready: in  Bool;
+  port ifu2biu_icb_cmd_addr:  out UInt<32>;
+  port ifu2biu_icb_rsp_valid: in  Bool;
+  port ifu2biu_icb_rsp_ready: out Bool;
+  port ifu2biu_icb_rsp_err:   in  Bool;
+  port ifu2biu_icb_rsp_rdata: in  UInt<32>;
 
-  // BPU outputs
-  port bpu_wait:        out Bool;
-  port bpu2rf_rs1_ena:  out Bool;
-  port prdt_taken:      out Bool;
-  port prdt_pc_add_op1: out UInt<32>;
-  port prdt_pc_add_op2: out UInt<32>;
+  // ── Instruction output to decode ───────────────────────────────────
+  port ifu_o_ir:          out UInt<32>;
+  port ifu_o_pc:          out UInt<32>;
+  port ifu_o_pc_vld:      out Bool;
+  port ifu_o_misalgn:     out Bool;
+  port ifu_o_buserr:      out Bool;
+  port ifu_o_rs1idx:      out UInt<5>;
+  port ifu_o_rs2idx:      out UInt<5>;
+  port ifu_o_prdt_taken:  out Bool;
+  port ifu_o_muldiv_b2b:  out Bool;
+  port ifu_o_valid:       out Bool;
+  port ifu_o_ready:       in  Bool;
 
-  // Mini-decoder classification (used by EXU for decode hints)
-  port dec_is_bjp:   out Bool;
-  port dec_is_lui:   out Bool;
-  port dec_is_auipc: out Bool;
+  // ── Pipe flush ─────────────────────────────────────────────────────
+  port pipe_flush_ack:     out Bool;
+  port pipe_flush_req:     in  Bool;
+  port pipe_flush_add_op1: in  UInt<32>;
+  port pipe_flush_add_op2: in  UInt<32>;
+  port pipe_flush_pc:      in  UInt<32>;
 
-  // ── IfuIfetch: PC generation + fetch state machine ──────────────────
+  // ── Halt ───────────────────────────────────────────────────────────
+  port ifu_halt_req: in  Bool;
+  port ifu_halt_ack: out Bool;
+
+  // ── OITF / regfile / decode feedback ───────────────────────────────
+  port oitf_empty:    in Bool;
+  port rf2ifu_x1:     in UInt<32>;
+  port rf2ifu_rs1:    in UInt<32>;
+  port dec2ifu_rden:  in Bool;
+  port dec2ifu_rs1en: in Bool;
+  port dec2ifu_rdidx: in UInt<5>;
+  port dec2ifu_mulhsu: in Bool;
+  port dec2ifu_div:    in Bool;
+  port dec2ifu_rem:    in Bool;
+  port dec2ifu_divu:   in Bool;
+  port dec2ifu_remu:   in Bool;
+
+  // ── Hardwired outputs ──────────────────────────────────────────────
+  let ifu_active = true;
+
+  // ── Internal wires: ifetch <-> ift2icb ─────────────────────────────
+  wire ifu_req_valid_w:    Bool;
+  wire ifu_req_ready_w:    Bool;
+  wire ifu_req_pc_w:       UInt<32>;
+  wire ifu_rsp_valid_w:    Bool;
+  wire ifu_rsp_ready_w:    Bool;
+  wire ifu_rsp_instr_w:    UInt<32>;
+
+  // ── Ifetch -> ift2icb wires (seq/last_pc) ────────────────────────────
+  wire ifu_req_seq_w:      Bool;
+  wire ifu_req_seq_rv32_w: Bool;
+  wire ifu_req_last_pc_w:  UInt<32>;
+  wire ifu_rsp_err_w:      Bool;
+
+  // ── e203_ifu_ifetch: PC generation + fetch state machine ───────────
   inst ifetch: e203_ifu_ifetch
-    clk         <- clk;
-    rst         <- rst_n;
-    req_ready   <- icb_req_ready;
-    rsp_valid   <- icb_rsp_valid;
-    rsp_instr   <- icb_rsp_instr;
-    rsp_err     <- false;
-    o_ready     <- o_ready;
-    redirect    <- exu_redirect;
-    redirect_pc <- exu_redirect_pc;
-    req_valid   -> ifetch_req_valid;
-    req_addr    -> ifetch_req_addr;
-    rsp_ready   -> ifetch_rsp_ready;
-    o_valid     -> o_valid;
-    o_instr     -> o_instr;
-    o_pc        -> o_pc;
-    o_bus_err   -> o_bus_err;
+    clk              <- clk;
+    rst_n            <- rst_n;
+    pc_rtvec         <- pc_rtvec;
+    ifu_req_ready    <- ifu_req_ready_w;
+    ifu_rsp_valid    <- ifu_rsp_valid_w;
+    ifu_rsp_err      <- false;
+    ifu_rsp_instr    <- ifu_rsp_instr_w;
+    ifu_o_ready      <- ifu_o_ready;
+    pipe_flush_req     <- pipe_flush_req;
+    pipe_flush_add_op1 <- pipe_flush_add_op1;
+    pipe_flush_add_op2 <- pipe_flush_add_op2;
+    pipe_flush_pc      <- pipe_flush_pc;
+    ifu_halt_req     <- ifu_halt_req;
+    oitf_empty       <- oitf_empty;
+    rf2ifu_x1        <- rf2ifu_x1;
+    rf2ifu_rs1       <- rf2ifu_rs1;
+    dec2ifu_rs1en    <- dec2ifu_rs1en;
+    dec2ifu_rden     <- dec2ifu_rden;
+    dec2ifu_rdidx    <- dec2ifu_rdidx;
+    dec2ifu_mulhsu   <- dec2ifu_mulhsu;
+    dec2ifu_div      <- dec2ifu_div;
+    dec2ifu_rem      <- dec2ifu_rem;
+    dec2ifu_divu     <- dec2ifu_divu;
+    dec2ifu_remu     <- dec2ifu_remu;
+    inspect_pc       -> inspect_pc;
+    ifu_req_valid    -> ifu_req_valid_w;
+    ifu_req_pc       -> ifu_req_pc_w;
+    ifu_req_seq      -> ifu_req_seq_w;
+    ifu_req_seq_rv32 -> ifu_req_seq_rv32_w;
+    ifu_req_last_pc  -> ifu_req_last_pc_w;
+    ifu_rsp_ready    -> ifu_rsp_ready_w;
+    ifu_o_ir         -> ifu_o_ir;
+    ifu_o_pc         -> ifu_o_pc;
+    ifu_o_pc_vld     -> ifu_o_pc_vld;
+    ifu_o_rs1idx     -> ifu_o_rs1idx;
+    ifu_o_rs2idx     -> ifu_o_rs2idx;
+    ifu_o_prdt_taken -> ifu_o_prdt_taken;
+    ifu_o_misalgn    -> ifu_o_misalgn;
+    ifu_o_buserr     -> ifu_o_buserr;
+    ifu_o_muldiv_b2b -> ifu_o_muldiv_b2b;
+    ifu_o_valid      -> ifu_o_valid;
+    pipe_flush_ack   -> pipe_flush_ack;
+    ifu_halt_ack     -> ifu_halt_ack;
   end inst ifetch
 
-  // ── Ift2Icb: fetch-to-ITCM bridge ──────────────────────────────────
+  // ── e203_ifu_ift2icb: fetch-to-ITCM ICB bridge ────────────────────
   inst icb: e203_ifu_ift2icb
     clk            <- clk;
     rst_n          <- rst_n;
-    ifu_req_valid  <- ifetch_req_valid;
-    ifu_req_pc     <- ifetch_req_addr;
-    ifu_rsp_ready  <- ifetch_rsp_ready;
-    itcm.cmd_ready <- itcm.cmd_ready;
-    itcm.rsp_valid <- itcm.rsp_valid;
-    itcm.rsp_data  <- itcm.rsp_data;
-    ifu_req_ready  -> icb_req_ready;
-    ifu_rsp_valid  -> icb_rsp_valid;
-    ifu_rsp_instr  -> icb_rsp_instr;
-    itcm.cmd_valid -> itcm.cmd_valid;
-    itcm.cmd_addr  -> itcm.cmd_addr;
-    itcm.rsp_ready -> itcm.rsp_ready;
+    itcm_nohold    <- itcm_nohold;
+    ifu_req_valid  <- ifu_req_valid_w;
+    ifu_req_pc     <- ifu_req_pc_w;
+    ifu_req_seq       <- ifu_req_seq_w;
+    ifu_req_seq_rv32  <- ifu_req_seq_rv32_w;
+    ifu_req_last_pc   <- ifu_req_last_pc_w;
+    ifu_rsp_ready  <- ifu_rsp_ready_w;
+    itcm_region_indic <- itcm_region_indic;
+    ifu2itcm_icb_cmd_ready <- ifu2itcm_icb_cmd_ready;
+    ifu2itcm_icb_rsp_valid <- ifu2itcm_icb_rsp_valid;
+    ifu2itcm_icb_rsp_err   <- ifu2itcm_icb_rsp_err;
+    ifu2itcm_icb_rsp_rdata <- ifu2itcm_icb_rsp_rdata;
+    ifu2biu_icb_cmd_ready  <- ifu2biu_icb_cmd_ready;
+    ifu2biu_icb_rsp_valid  <- ifu2biu_icb_rsp_valid;
+    ifu2biu_icb_rsp_err    <- ifu2biu_icb_rsp_err;
+    ifu2biu_icb_rsp_rdata  <- ifu2biu_icb_rsp_rdata;
+    ifu2itcm_holdup        <- ifu2itcm_holdup;
+    ifu_req_ready  -> ifu_req_ready_w;
+    ifu_rsp_valid  -> ifu_rsp_valid_w;
+    ifu_rsp_err    -> ifu_rsp_err_w;
+    ifu_rsp_instr  -> ifu_rsp_instr_w;
+    ifu2itcm_icb_cmd_valid -> ifu2itcm_icb_cmd_valid;
+    ifu2itcm_icb_cmd_addr  -> ifu2itcm_icb_cmd_addr;
+    ifu2itcm_icb_rsp_ready -> ifu2itcm_icb_rsp_ready;
+    ifu2biu_icb_cmd_valid  -> ifu2biu_icb_cmd_valid;
+    ifu2biu_icb_cmd_addr   -> ifu2biu_icb_cmd_addr;
+    ifu2biu_icb_rsp_ready  -> ifu2biu_icb_rsp_ready;
   end inst icb
-
-  // ── IfuMinidec: classify fetched instruction ────────────────────────
-  inst mdec: e203_ifu_minidec
-    instr      <- o_instr;
-    o_is_bjp   -> dec_is_bjp;
-    o_is_jal   -> mdec_is_jal;
-    o_is_jalr  -> mdec_is_jalr;
-    o_is_bxx   -> mdec_is_bxx;
-    o_is_lui   -> dec_is_lui;
-    o_is_auipc -> dec_is_auipc;
-    o_bjp_imm  -> mdec_bjp_imm;
-    o_rs1_idx  -> mdec_rs1_idx;
-  end inst mdec
-
-  // ── LiteBpu: static branch prediction ──────────────────────────────
-  inst bpu: e203_ifu_litebpu
-    clk                       <- clk;
-    rst_n                     <- rst_n;
-    pc                        <- o_pc;
-    dec_jal                   <- mdec_is_jal;
-    dec_jalr                  <- mdec_is_jalr;
-    dec_bxx                   <- mdec_is_bxx;
-    dec_bjp_imm               <- mdec_bjp_imm.zext<32>();
-    dec_jalr_rs1idx           <- mdec_rs1_idx;
-    oitf_empty                <- oitf_empty;
-    ir_empty                  <- ir_empty;
-    ir_rs1en                  <- ir_rs1en;
-    jalr_rs1idx_cam_irrdidx   <- jalr_rs1idx_cam_irrdidx;
-    dec_i_valid               <- o_valid;
-    ir_valid_clr              <- ir_valid_clr;
-    rf2bpu_x1                 <- rf2bpu_x1;
-    rf2bpu_rs1                <- rf2bpu_rs1;
-    prdt_taken                -> prdt_taken;
-    prdt_pc_add_op1           -> prdt_pc_add_op1;
-    prdt_pc_add_op2           -> prdt_pc_add_op2;
-    bpu_wait                  -> bpu_wait;
-    bpu2rf_rs1_ena            -> bpu2rf_rs1_ena;
-  end inst bpu
 
 end module e203_ifu_top

--- a/tests/e203/e203_ifu_top.sv
+++ b/tests/e203/e203_ifu_top.sv
@@ -1,126 +1,164 @@
-// E203 HBirdv2 IFU Top — wires IfuIfetch, IfuMinidec, LiteBpu, Ift2Icb
-// Simplified: no RVC (16-bit) support, ITCM-only fetch path.
-module IfuTop (
+// domain SysDomain
+//   freq_mhz: 100
+
+// domain SysDomain
+//   freq_mhz: 100
+
+// domain SysDomain
+//   freq_mhz: 100
+
+// domain SysDomain
+//   freq_mhz: 100
+
+// domain SysDomain
+//   freq_mhz: 100
+
+// domain SysDomain
+//   freq_mhz: 100
+
+// domain SysDomain
+//   freq_mhz: 100
+
+module e203_ifu_top (
   input logic clk,
   input logic rst_n,
-  output logic o_valid,
-  input logic o_ready,
-  output logic [32-1:0] o_instr,
-  output logic [32-1:0] o_pc,
-  output logic o_bus_err,
-  input logic exu_redirect,
-  input logic [32-1:0] exu_redirect_pc,
-  output logic itcm_cmd_valid,
-  output logic [14-1:0] itcm_cmd_addr,
-  input logic itcm_cmd_ready,
-  input logic itcm_rsp_valid,
-  input logic [32-1:0] itcm_rsp_data,
-  output logic itcm_rsp_ready,
+  output logic [31:0] inspect_pc,
+  output logic ifu_active,
+  input logic itcm_nohold,
+  input logic [31:0] pc_rtvec,
+  input logic ifu2itcm_holdup,
+  input logic [31:0] itcm_region_indic,
+  output logic ifu2itcm_icb_cmd_valid,
+  input logic ifu2itcm_icb_cmd_ready,
+  output logic [15:0] ifu2itcm_icb_cmd_addr,
+  input logic ifu2itcm_icb_rsp_valid,
+  output logic ifu2itcm_icb_rsp_ready,
+  input logic ifu2itcm_icb_rsp_err,
+  input logic [63:0] ifu2itcm_icb_rsp_rdata,
+  output logic ifu2biu_icb_cmd_valid,
+  input logic ifu2biu_icb_cmd_ready,
+  output logic [31:0] ifu2biu_icb_cmd_addr,
+  input logic ifu2biu_icb_rsp_valid,
+  output logic ifu2biu_icb_rsp_ready,
+  input logic ifu2biu_icb_rsp_err,
+  input logic [31:0] ifu2biu_icb_rsp_rdata,
+  output logic [31:0] ifu_o_ir,
+  output logic [31:0] ifu_o_pc,
+  output logic ifu_o_pc_vld,
+  output logic ifu_o_misalgn,
+  output logic ifu_o_buserr,
+  output logic [4:0] ifu_o_rs1idx,
+  output logic [4:0] ifu_o_rs2idx,
+  output logic ifu_o_prdt_taken,
+  output logic ifu_o_muldiv_b2b,
+  output logic ifu_o_valid,
+  input logic ifu_o_ready,
+  output logic pipe_flush_ack,
+  input logic pipe_flush_req,
+  input logic [31:0] pipe_flush_add_op1,
+  input logic [31:0] pipe_flush_add_op2,
+  input logic [31:0] pipe_flush_pc,
+  input logic ifu_halt_req,
+  output logic ifu_halt_ack,
   input logic oitf_empty,
-  input logic ir_empty,
-  input logic ir_rs1en,
-  input logic jalr_rs1idx_cam_irrdidx,
-  input logic ir_valid_clr,
-  input logic [32-1:0] rf2bpu_x1,
-  input logic [32-1:0] rf2bpu_rs1,
-  output logic bpu_wait,
-  output logic bpu2rf_rs1_ena,
-  output logic prdt_taken,
-  output logic [32-1:0] prdt_pc_add_op1,
-  output logic [32-1:0] prdt_pc_add_op2,
-  output logic dec_is_bjp,
-  output logic dec_is_lui,
-  output logic dec_is_auipc
+  input logic [31:0] rf2ifu_x1,
+  input logic [31:0] rf2ifu_rs1,
+  input logic dec2ifu_rden,
+  input logic dec2ifu_rs1en,
+  input logic [4:0] dec2ifu_rdidx,
+  input logic dec2ifu_mulhsu,
+  input logic dec2ifu_div,
+  input logic dec2ifu_rem,
+  input logic dec2ifu_divu,
+  input logic dec2ifu_remu
 );
 
-  // Output to EXU: decoded instruction
-  // Branch redirect from EXU
-  // ITCM interface
-  // OITF/regfile inputs for BPU
-  // BPU outputs
-  // Mini-decoder classification (used by EXU for decode hints)
-  // ── IfuIfetch: PC generation + fetch state machine ──────────────────
-  logic ifetch_req_valid;
-  logic [32-1:0] ifetch_req_addr;
-  logic ifetch_rsp_ready;
-  IfuIfetch ifetch (
-    .clk(clk),
-    .rst(rst_n),
-    .req_ready(icb_req_ready),
-    .rsp_valid(icb_rsp_valid),
-    .rsp_instr(icb_rsp_instr),
-    .rsp_err(1'b0),
-    .o_ready(o_ready),
-    .redirect(exu_redirect),
-    .redirect_pc(exu_redirect_pc),
-    .req_valid(ifetch_req_valid),
-    .req_addr(ifetch_req_addr),
-    .rsp_ready(ifetch_rsp_ready),
-    .o_valid(o_valid),
-    .o_instr(o_instr),
-    .o_pc(o_pc),
-    .o_bus_err(o_bus_err)
-  );
-  // ── Ift2Icb: fetch-to-ITCM bridge ──────────────────────────────────
-  logic icb_req_ready;
-  logic icb_rsp_valid;
-  logic [32-1:0] icb_rsp_instr;
-  Ift2Icb icb (
+  assign ifu_active = 1'b1;
+  logic ifu_req_valid_w;
+  logic ifu_req_ready_w;
+  logic [31:0] ifu_req_pc_w;
+  logic ifu_rsp_valid_w;
+  logic ifu_rsp_ready_w;
+  logic [31:0] ifu_rsp_instr_w;
+  logic ifu_req_seq_w;
+  logic ifu_req_seq_rv32_w;
+  logic [31:0] ifu_req_last_pc_w;
+  logic ifu_rsp_err_w;
+  e203_ifu_ifetch ifetch (
     .clk(clk),
     .rst_n(rst_n),
-    .ifu_req_valid(ifetch_req_valid),
-    .ifu_req_pc(ifetch_req_addr),
-    .ifu_rsp_ready(ifetch_rsp_ready),
-    .itcm_cmd_ready(itcm_cmd_ready),
-    .itcm_rsp_valid(itcm_rsp_valid),
-    .itcm_rsp_data(itcm_rsp_data),
-    .ifu_req_ready(icb_req_ready),
-    .ifu_rsp_valid(icb_rsp_valid),
-    .ifu_rsp_instr(icb_rsp_instr),
-    .itcm_cmd_valid(itcm_cmd_valid),
-    .itcm_cmd_addr(itcm_cmd_addr),
-    .itcm_rsp_ready(itcm_rsp_ready)
-  );
-  // ── IfuMinidec: classify fetched instruction ────────────────────────
-  logic mdec_is_jal;
-  logic mdec_is_jalr;
-  logic mdec_is_bxx;
-  logic signed [21-1:0] mdec_bjp_imm;
-  logic [5-1:0] mdec_rs1_idx;
-  IfuMinidec mdec (
-    .instr(o_instr),
-    .o_is_bjp(dec_is_bjp),
-    .o_is_jal(mdec_is_jal),
-    .o_is_jalr(mdec_is_jalr),
-    .o_is_bxx(mdec_is_bxx),
-    .o_is_lui(dec_is_lui),
-    .o_is_auipc(dec_is_auipc),
-    .o_bjp_imm(mdec_bjp_imm),
-    .o_rs1_idx(mdec_rs1_idx)
-  );
-  // ── LiteBpu: static branch prediction ──────────────────────────────
-  LiteBpu bpu (
-    .clk(clk),
-    .rst_n(rst_n),
-    .pc(o_pc),
-    .dec_jal(mdec_is_jal),
-    .dec_jalr(mdec_is_jalr),
-    .dec_bxx(mdec_is_bxx),
-    .dec_bjp_imm(32'($unsigned(mdec_bjp_imm))),
-    .dec_jalr_rs1idx(mdec_rs1_idx),
+    .pc_rtvec(pc_rtvec),
+    .ifu_req_ready(ifu_req_ready_w),
+    .ifu_rsp_valid(ifu_rsp_valid_w),
+    .ifu_rsp_err(1'b0),
+    .ifu_rsp_instr(ifu_rsp_instr_w),
+    .ifu_o_ready(ifu_o_ready),
+    .pipe_flush_req(pipe_flush_req),
+    .pipe_flush_add_op1(pipe_flush_add_op1),
+    .pipe_flush_add_op2(pipe_flush_add_op2),
+    .pipe_flush_pc(pipe_flush_pc),
+    .ifu_halt_req(ifu_halt_req),
     .oitf_empty(oitf_empty),
-    .ir_empty(ir_empty),
-    .ir_rs1en(ir_rs1en),
-    .jalr_rs1idx_cam_irrdidx(jalr_rs1idx_cam_irrdidx),
-    .dec_i_valid(o_valid),
-    .ir_valid_clr(ir_valid_clr),
-    .rf2bpu_x1(rf2bpu_x1),
-    .rf2bpu_rs1(rf2bpu_rs1),
-    .prdt_taken(prdt_taken),
-    .prdt_pc_add_op1(prdt_pc_add_op1),
-    .prdt_pc_add_op2(prdt_pc_add_op2),
-    .bpu_wait(bpu_wait),
-    .bpu2rf_rs1_ena(bpu2rf_rs1_ena)
+    .rf2ifu_x1(rf2ifu_x1),
+    .rf2ifu_rs1(rf2ifu_rs1),
+    .dec2ifu_rs1en(dec2ifu_rs1en),
+    .dec2ifu_rden(dec2ifu_rden),
+    .dec2ifu_rdidx(dec2ifu_rdidx),
+    .dec2ifu_mulhsu(dec2ifu_mulhsu),
+    .dec2ifu_div(dec2ifu_div),
+    .dec2ifu_rem(dec2ifu_rem),
+    .dec2ifu_divu(dec2ifu_divu),
+    .dec2ifu_remu(dec2ifu_remu),
+    .inspect_pc(inspect_pc),
+    .ifu_req_valid(ifu_req_valid_w),
+    .ifu_req_pc(ifu_req_pc_w),
+    .ifu_req_seq(ifu_req_seq_w),
+    .ifu_req_seq_rv32(ifu_req_seq_rv32_w),
+    .ifu_req_last_pc(ifu_req_last_pc_w),
+    .ifu_rsp_ready(ifu_rsp_ready_w),
+    .ifu_o_ir(ifu_o_ir),
+    .ifu_o_pc(ifu_o_pc),
+    .ifu_o_pc_vld(ifu_o_pc_vld),
+    .ifu_o_rs1idx(ifu_o_rs1idx),
+    .ifu_o_rs2idx(ifu_o_rs2idx),
+    .ifu_o_prdt_taken(ifu_o_prdt_taken),
+    .ifu_o_misalgn(ifu_o_misalgn),
+    .ifu_o_buserr(ifu_o_buserr),
+    .ifu_o_muldiv_b2b(ifu_o_muldiv_b2b),
+    .ifu_o_valid(ifu_o_valid),
+    .pipe_flush_ack(pipe_flush_ack),
+    .ifu_halt_ack(ifu_halt_ack)
+  );
+  e203_ifu_ift2icb icb (
+    .clk(clk),
+    .rst_n(rst_n),
+    .itcm_nohold(itcm_nohold),
+    .ifu_req_valid(ifu_req_valid_w),
+    .ifu_req_pc(ifu_req_pc_w),
+    .ifu_req_seq(ifu_req_seq_w),
+    .ifu_req_seq_rv32(ifu_req_seq_rv32_w),
+    .ifu_req_last_pc(ifu_req_last_pc_w),
+    .ifu_rsp_ready(ifu_rsp_ready_w),
+    .itcm_region_indic(itcm_region_indic),
+    .ifu2itcm_icb_cmd_ready(ifu2itcm_icb_cmd_ready),
+    .ifu2itcm_icb_rsp_valid(ifu2itcm_icb_rsp_valid),
+    .ifu2itcm_icb_rsp_err(ifu2itcm_icb_rsp_err),
+    .ifu2itcm_icb_rsp_rdata(ifu2itcm_icb_rsp_rdata),
+    .ifu2biu_icb_cmd_ready(ifu2biu_icb_cmd_ready),
+    .ifu2biu_icb_rsp_valid(ifu2biu_icb_rsp_valid),
+    .ifu2biu_icb_rsp_err(ifu2biu_icb_rsp_err),
+    .ifu2biu_icb_rsp_rdata(ifu2biu_icb_rsp_rdata),
+    .ifu2itcm_holdup(ifu2itcm_holdup),
+    .ifu_req_ready(ifu_req_ready_w),
+    .ifu_rsp_valid(ifu_rsp_valid_w),
+    .ifu_rsp_err(ifu_rsp_err_w),
+    .ifu_rsp_instr(ifu_rsp_instr_w),
+    .ifu2itcm_icb_cmd_valid(ifu2itcm_icb_cmd_valid),
+    .ifu2itcm_icb_cmd_addr(ifu2itcm_icb_cmd_addr),
+    .ifu2itcm_icb_rsp_ready(ifu2itcm_icb_rsp_ready),
+    .ifu2biu_icb_cmd_valid(ifu2biu_icb_cmd_valid),
+    .ifu2biu_icb_cmd_addr(ifu2biu_icb_cmd_addr),
+    .ifu2biu_icb_rsp_ready(ifu2biu_icb_rsp_ready)
   );
 
 endmodule

--- a/tests/e203/e203_soc_top.arch
+++ b/tests/e203/e203_soc_top.arch
@@ -1,20 +1,28 @@
-// E203 SoC Top-Level Integration
-// Connects: CoreTop + ICB Arbiter + SRAM + PPI + FIO + GPIO + UART + SPI
-//           + DebugModule + IrqCtrl
-// The core's internal BIU handles ITCM/DTCM. External bus accesses
-// (peripherals, SRAM) go through the ICB fabric.
+// E203 SoC top — hierarchical integration fixture (second-generation).
+// e203_core_top (real ICB fabric) + ITCM/DTCM controller+RAM pairs + CLINT
+// timer + peripheral fabric: PPI ICB -> APB bridge (GPIO/UART/SPI), FIO ICB
+// -> fast I/O, MEM ICB -> arbiter -> SRAM, plus IRQ ctrl and debug module.
+// Memory map (BIU matches addr[31:16] against each region indic):
+//   ITCM 0x0000_xxxx (core boots at 0x0), DTCM 0x9000_xxxx,
+//   PPI 0x1000_xxxx, CLINT 0x0200_xxxx, FIO 0x0300_xxxx, rest -> MEM/SRAM.
 
 module e203_soc_top
 
   port clk:   in Clock<SysDomain>;
   port rst_n: in Reset<Async, Low>;
+  // The CLINT timer is the one Reset<Sync, High> island in this Async-Low
+  // SoC; RDC phase 2d requires a plain Reset source, so it gets its own pin.
+  port timer_rst: in Reset<Sync, High>;
 
-  // ── ITCM loader (testbench) ────────────────────────────────────
+  // ── Boot ───────────────────────────────────────────────────────
+  port pc_rtvec: in UInt<32>;
+
+  // ── ITCM loader (testbench writes program via ext2itcm ICB) ────
   port itcm_wr_en:   in Bool;
   port itcm_wr_addr: in UInt<14>;
   port itcm_wr_data: in UInt<32>;
 
-  // ── External ICB master (from core BIU, directly wired for SoC) ──
+  // ── External ICB master (second SRAM-fabric master, via arbiter) ─
   port ext_cmd_valid: in Bool;
   port ext_cmd_addr:  in UInt<32>;
   port ext_cmd_wdata: in UInt<32>;
@@ -40,7 +48,7 @@ module e203_soc_top
   port fio_out_0: out UInt<32>;
   port fio_out_1: out UInt<32>;
 
-  // ── Debug interface ────────────────────────────────────────────
+  // ── Debug interface (APB) ──────────────────────────────────────
   port dbg_psel:    in  Bool;
   port dbg_penable: in  Bool;
   port dbg_paddr:   in  UInt<32>;
@@ -49,128 +57,644 @@ module e203_soc_top
   port dbg_prdata:  out UInt<32>;
 
   // ── Status ─────────────────────────────────────────────────────
-  port core_commit: out Bool;
-  port core_instr:  out UInt<32>;
-  port core_pc:     out UInt<32>;
-  port core_valid:  out Bool;
-  port gpio_irq:    out Bool;
-  port uart_irq:    out Bool;
-  port spi_irq:     out Bool;
+  port inspect_pc: out UInt<32>;
+  port core_wfi:   out Bool;
+  port gpio_irq:   out Bool;
+  port uart_irq:   out Bool;
+  port spi_irq:    out Bool;
 
-  // ── Bus interconnect wires (driven in comb, consumed by inst) ──
-  wire bus_cmd_ready: Bool;
-  wire bus_rsp_valid: Bool;
-  wire bus_rsp_rdata: UInt<32>;
-  wire bus_rsp_err:   Bool;
+  // ── Core <-> ITCM ctrl ─────────────────────────────────────────
+  wire ifu2itcm_icb_cmd_valid: Bool;
+  wire ifu2itcm_icb_cmd_ready: Bool;
+  wire ifu2itcm_icb_cmd_addr:  UInt<16>;
+  wire ifu2itcm_icb_rsp_valid: Bool;
+  wire ifu2itcm_icb_rsp_ready: Bool;
+  wire ifu2itcm_icb_rsp_err:   Bool;
+  wire ifu2itcm_icb_rsp_rdata: UInt<64>;
+  wire ifu2itcm_holdup:        Bool;
+  wire lsu2itcm_icb_cmd_valid: Bool;
+  wire lsu2itcm_icb_cmd_ready: Bool;
+  wire lsu2itcm_icb_cmd_addr:  UInt<16>;
+  wire lsu2itcm_icb_cmd_read:  Bool;
+  wire lsu2itcm_icb_cmd_wdata: UInt<32>;
+  wire lsu2itcm_icb_cmd_wmask: UInt<4>;
+  wire lsu2itcm_icb_rsp_valid: Bool;
+  wire lsu2itcm_icb_rsp_ready: Bool;
+  wire lsu2itcm_icb_rsp_err:   Bool;
+  wire lsu2itcm_icb_rsp_rdata: UInt<32>;
+
+  // ── Core <-> DTCM ctrl ─────────────────────────────────────────
+  wire lsu2dtcm_icb_cmd_valid: Bool;
+  wire lsu2dtcm_icb_cmd_ready: Bool;
+  wire lsu2dtcm_icb_cmd_addr:  UInt<16>;
+  wire lsu2dtcm_icb_cmd_read:  Bool;
+  wire lsu2dtcm_icb_cmd_wdata: UInt<32>;
+  wire lsu2dtcm_icb_cmd_wmask: UInt<4>;
+  wire lsu2dtcm_icb_rsp_valid: Bool;
+  wire lsu2dtcm_icb_rsp_ready: Bool;
+  wire lsu2dtcm_icb_rsp_err:   Bool;
+  wire lsu2dtcm_icb_rsp_rdata: UInt<32>;
+
+  // ── TCM RAM interfaces ─────────────────────────────────────────
+  wire itcm_ram_cs:   Bool;
+  wire itcm_ram_we:   Bool;
+  wire itcm_ram_addr: UInt<13>;
+  wire itcm_ram_wem:  UInt<8>;
+  wire itcm_ram_din:  UInt<64>;
+  wire itcm_ram_dout: UInt<64>;
+  wire clk_itcm_ram_nc: Bool;
+  wire dtcm_ram_cs:   Bool;
+  wire dtcm_ram_we:   Bool;
+  wire dtcm_ram_addr: UInt<14>;
+  wire dtcm_ram_wem:  UInt<4>;
+  wire dtcm_ram_din:  UInt<32>;
+  wire dtcm_ram_dout: UInt<32>;
+  wire clk_dtcm_ram_nc: Bool;
+  wire itcm_active_nc: Bool;
+  wire dtcm_active_nc: Bool;
+
+  // ── Core PPI / CLINT / FIO / MEM ICBs ──────────────────────────
+  wire ppi_icb_cmd_valid: Bool;
+  wire ppi_icb_cmd_ready: Bool;
+  wire ppi_icb_cmd_addr:  UInt<32>;
+  wire ppi_icb_cmd_read:  Bool;
+  wire ppi_icb_cmd_wdata: UInt<32>;
+  wire ppi_icb_cmd_wmask: UInt<4>;
+  wire ppi_icb_rsp_valid: Bool;
+  wire ppi_icb_rsp_ready: Bool;
+  wire ppi_icb_rsp_err:   Bool;
+  wire ppi_icb_rsp_rdata: UInt<32>;
+
+  wire clint_icb_cmd_valid: Bool;
+  wire clint_icb_cmd_addr:  UInt<32>;
+  wire clint_icb_cmd_read:  Bool;
+  wire clint_icb_cmd_wdata: UInt<32>;
+  wire clint_icb_rsp_ready: Bool;
+
+  wire fio_icb_cmd_valid: Bool;
+  wire fio_icb_cmd_ready: Bool;
+  wire fio_icb_cmd_addr:  UInt<32>;
+  wire fio_icb_cmd_read:  Bool;
+  wire fio_icb_cmd_wdata: UInt<32>;
+  wire fio_icb_cmd_wmask: UInt<4>;
+  wire fio_icb_rsp_valid: Bool;
+  wire fio_icb_rsp_ready: Bool;
+  wire fio_icb_rsp_err:   Bool;
+  wire fio_icb_rsp_rdata: UInt<32>;
+
+  wire mem_icb_cmd_valid: Bool;
+  wire mem_icb_cmd_ready: Bool;
+  wire mem_icb_cmd_addr:  UInt<32>;
+  wire mem_icb_cmd_read:  Bool;
+  wire mem_icb_cmd_wdata: UInt<32>;
+  wire mem_icb_cmd_wmask: UInt<4>;
+  wire mem_icb_rsp_valid: Bool;
+  wire mem_icb_rsp_ready: Bool;
+  wire mem_icb_rsp_err:   Bool;
+  wire mem_icb_rsp_rdata: UInt<32>;
+
+  // Unused core outputs (kept on wires so every connection is explicit)
+  wire tm_stop_nc:      Bool;
+  wire core_cgstop_nc:  Bool;
+  wire tcm_cgstop:      Bool;
+  wire exu_active_nc:   Bool;
+  wire ifu_active_nc:   Bool;
+  wire lsu_active_nc:   Bool;
+  wire biu_active_nc:   Bool;
+  wire wr_dcsr_ena_nc:     Bool;
+  wire wr_dpc_ena_nc:      Bool;
+  wire wr_dscratch_ena_nc: Bool;
+  wire wr_csr_nxt_nc:      UInt<32>;
+  wire cmt_dpc_nc:         UInt<32>;
+  wire cmt_dpc_ena_nc:     Bool;
+  wire cmt_dcause_nc:      UInt<3>;
+  wire cmt_dcause_ena_nc:  Bool;
+  wire lsu2itcm_icb_cmd_lock_nc: Bool;
+  wire lsu2itcm_icb_cmd_excl_nc: Bool;
+  wire lsu2itcm_icb_cmd_size_nc: UInt<2>;
+  wire lsu2dtcm_icb_cmd_lock_nc: Bool;
+  wire lsu2dtcm_icb_cmd_excl_nc: Bool;
+  wire lsu2dtcm_icb_cmd_size_nc: UInt<2>;
+  wire ppi_icb_cmd_lock_nc:  Bool;
+  wire ppi_icb_cmd_excl_nc:  Bool;
+  wire ppi_icb_cmd_size_nc:  UInt<2>;
+  wire ppi_icb_cmd_burst_nc: UInt<2>;
+  wire ppi_icb_cmd_beat_nc:  UInt<2>;
+  wire clint_icb_cmd_wmask_nc: UInt<4>;
+  wire clint_icb_cmd_lock_nc:  Bool;
+  wire clint_icb_cmd_excl_nc:  Bool;
+  wire clint_icb_cmd_size_nc:  UInt<2>;
+  wire clint_icb_cmd_burst_nc: UInt<2>;
+  wire clint_icb_cmd_beat_nc:  UInt<2>;
+  wire plic_icb_cmd_valid_nc: Bool;
+  wire plic_icb_cmd_addr_nc:  UInt<32>;
+  wire plic_icb_cmd_read_nc:  Bool;
+  wire plic_icb_cmd_wdata_nc: UInt<32>;
+  wire plic_icb_cmd_wmask_nc: UInt<4>;
+  wire plic_icb_cmd_lock_nc:  Bool;
+  wire plic_icb_cmd_excl_nc:  Bool;
+  wire plic_icb_cmd_size_nc:  UInt<2>;
+  wire plic_icb_cmd_burst_nc: UInt<2>;
+  wire plic_icb_cmd_beat_nc:  UInt<2>;
+  wire plic_icb_rsp_ready_nc: Bool;
+  wire fio_icb_cmd_lock_nc:  Bool;
+  wire fio_icb_cmd_excl_nc:  Bool;
+  wire fio_icb_cmd_size_nc:  UInt<2>;
+  wire fio_icb_cmd_burst_nc: UInt<2>;
+  wire fio_icb_cmd_beat_nc:  UInt<2>;
+  wire mem_icb_cmd_lock_nc:  Bool;
+  wire mem_icb_cmd_excl_nc:  Bool;
+  wire mem_icb_cmd_size_nc:  UInt<2>;
+  wire mem_icb_cmd_burst_nc: UInt<2>;
+  wire mem_icb_cmd_beat_nc:  UInt<2>;
+  wire nice_req_valid_nc: Bool;
+  wire nice_req_inst_nc:  UInt<32>;
+  wire nice_req_rs1_nc:   UInt<32>;
+  wire nice_req_rs2_nc:   UInt<32>;
+  wire nice_rsp_multicyc_ready_nc: Bool;
+  wire nice_icb_cmd_ready_nc: Bool;
+  wire nice_icb_rsp_valid_nc: Bool;
+  wire nice_icb_rsp_rdata_nc: UInt<32>;
+  wire nice_icb_rsp_err_nc:   Bool;
+
+  // ── IRQ / debug wires ──────────────────────────────────────────
+  wire tmr_irq_w:    Bool;
+  wire gpio_irq_w:   Bool;
+  wire uart_irq_w:   Bool;
+  wire spi_irq_w:    Bool;
+  wire irq_req_w:    Bool;
+  wire irq_cause_w:  UInt<32>;
+  wire irq_mip_meip: Bool;
+  wire irq_mip_mtip: Bool;
+  wire irq_mip_msip: Bool;
+  wire dbg_halt_req:   Bool;
+  wire dbg_resume_req: Bool;
+  wire dbg_prdata_w:   UInt<32>;
+  wire dbg_pready_w:   Bool;
+  wire dbg_reg_addr_w:  UInt<16>;
+  wire dbg_reg_wdata_w: UInt<32>;
+  wire dbg_reg_wen_w:   Bool;
+
+  // ── APB fabric wires (PPI bridge -> GPIO/UART/SPI) ─────────────
+  wire gpio_psel:    Bool;
+  wire gpio_penable: Bool;
+  wire gpio_paddr:   UInt<32>;
+  wire gpio_pwdata:  UInt<32>;
+  wire gpio_pwrite:  Bool;
+  wire gpio_prdata_w: UInt<32>;
+  wire gpio_pready_w: Bool;
+  wire uart_psel:    Bool;
+  wire uart_penable: Bool;
+  wire uart_paddr:   UInt<32>;
+  wire uart_pwdata:  UInt<32>;
+  wire uart_pwrite:  Bool;
+  wire uart_prdata_w: UInt<32>;
+  wire uart_pready_w: Bool;
+  wire spi_psel:    Bool;
+  wire spi_penable: Bool;
+  wire spi_paddr:   UInt<32>;
+  wire spi_pwdata:  UInt<32>;
+  wire spi_pwrite:  Bool;
+  wire spi_prdata_w: UInt<32>;
+  wire spi_pready_w: Bool;
+  wire apb3_psel_w:    Bool;
+  wire apb3_penable_w: Bool;
+  wire apb3_paddr_w:   UInt<32>;
+  wire apb3_pwdata_w:  UInt<32>;
+  wire apb3_pwrite_w:  Bool;
+
+  // ── SRAM fabric wires (core MEM ICB + ext port -> arbiter -> SRAM) ──
+  wire arbt_s_cmd_valid: Bool;
+  wire arbt_s_cmd_addr:  UInt<32>;
+  wire arbt_s_cmd_wdata: UInt<32>;
+  wire arbt_s_cmd_wmask: UInt<4>;
+  wire arbt_s_cmd_read:  Bool;
+  wire arbt_s_rsp_ready: Bool;
+  wire sram_ready:       Bool;
+  wire sram_rsp_valid:   Bool;
+  wire sram_rsp_rdata:   UInt<32>;
+  wire sram_rsp_err:     Bool;
+  wire gpio_out_w: UInt<32>;
+  wire gpio_oe_w:  UInt<32>;
+  wire uart_tx_w:  Bool;
+  wire spi_sclk_w: Bool;
+  wire spi_mosi_w: Bool;
+  wire spi_cs_n_w: Bool;
+  wire fio_out_0_w: UInt<32>;
+  wire fio_out_1_w: UInt<32>;
+  wire fio_out_2_w: UInt<32>;
+  wire fio_out_3_w: UInt<32>;
+
+  // ── TB loader -> ext2itcm ICB adapter (word addr -> byte addr) ──
+  let ext2itcm_cmd_addr: UInt<16> = itcm_wr_addr.zext<16>() << 2;
+
+  // ── CLINT ICB -> timer register adapter (fixed 1-cycle response) ──
+  let clint_reg_addr: UInt<4> = clint_icb_cmd_addr[5:2];
+  let clint_reg_wen:  Bool    = clint_icb_cmd_valid & (!clint_icb_cmd_read);
+  wire clint_reg_rdata: UInt<32>;
+  reg clint_rsp_valid_r: Bool     reset rst_n => false;
+  reg clint_rsp_rdata_r: UInt<32> reset rst_n => 0;
+  seq on clk rising
+    clint_rsp_valid_r <= clint_icb_cmd_valid;
+    clint_rsp_rdata_r <= clint_reg_rdata;
+  end seq
 
   // ══════════════════════════════════════════════════════════════
-  // CPU Core
+  // CPU core (IFU + EXU + LSU + BIU on the real ICB fabric)
   // ══════════════════════════════════════════════════════════════
   inst core: e203_core_top
-    clk            <- clk;
-    rst_n          <- rst_n;
-    itcm_wr_en     <- itcm_wr_en;
-    itcm_wr_addr   <- itcm_wr_addr;
-    itcm_wr_data   <- itcm_wr_data;
-    exu_redirect   <- false;
-    exu_redirect_pc <- 0;
-    commit_valid   -> core_commit_w;
-    o_instr        -> core_instr_w;
-    o_pc           -> core_pc_w;
-    o_valid        -> core_valid_w;
-    tmr_irq        -> tmr_irq_w;
+    clk       <- clk;
+    rst_n     <- rst_n;
+    test_mode <- false;
+    inspect_pc  -> inspect_pc;
+    core_wfi    -> core_wfi;
+    tm_stop     -> tm_stop_nc;
+    core_cgstop -> core_cgstop_nc;
+    tcm_cgstop  -> tcm_cgstop;
+    exu_active  -> exu_active_nc;
+    ifu_active  -> ifu_active_nc;
+    lsu_active  -> lsu_active_nc;
+    biu_active  -> biu_active_nc;
+    pc_rtvec     <- pc_rtvec;
+    core_mhartid <- 0;
+    dbg_irq_r <- dbg_halt_req;
+    lcl_irq_r <- false;
+    evt_r     <- false;
+    ext_irq_r <- irq_mip_meip;
+    sft_irq_r <- irq_mip_msip;
+    tmr_irq_r <- irq_mip_mtip;
+    wr_dcsr_ena     -> wr_dcsr_ena_nc;
+    wr_dpc_ena      -> wr_dpc_ena_nc;
+    wr_dscratch_ena -> wr_dscratch_ena_nc;
+    wr_csr_nxt      -> wr_csr_nxt_nc;
+    dcsr_r     <- 0;
+    dpc_r      <- 0;
+    dscratch_r <- 0;
+    cmt_dpc        -> cmt_dpc_nc;
+    cmt_dpc_ena    -> cmt_dpc_ena_nc;
+    cmt_dcause     -> cmt_dcause_nc;
+    cmt_dcause_ena -> cmt_dcause_ena_nc;
+    dbg_mode      <- false;
+    dbg_halt_r    <- dbg_halt_req;
+    dbg_step_r    <- false;
+    dbg_ebreakm_r <- false;
+    dbg_stopcycle <- false;
+    itcm_region_indic <- 0;
+    ifu2itcm_holdup   <- ifu2itcm_holdup;
+    ifu2itcm_icb_cmd_valid -> ifu2itcm_icb_cmd_valid;
+    ifu2itcm_icb_cmd_ready <- ifu2itcm_icb_cmd_ready;
+    ifu2itcm_icb_cmd_addr  -> ifu2itcm_icb_cmd_addr;
+    ifu2itcm_icb_rsp_valid <- ifu2itcm_icb_rsp_valid;
+    ifu2itcm_icb_rsp_ready -> ifu2itcm_icb_rsp_ready;
+    ifu2itcm_icb_rsp_err   <- ifu2itcm_icb_rsp_err;
+    ifu2itcm_icb_rsp_rdata <- ifu2itcm_icb_rsp_rdata;
+    lsu2itcm_icb_cmd_valid -> lsu2itcm_icb_cmd_valid;
+    lsu2itcm_icb_cmd_ready <- lsu2itcm_icb_cmd_ready;
+    lsu2itcm_icb_cmd_addr  -> lsu2itcm_icb_cmd_addr;
+    lsu2itcm_icb_cmd_read  -> lsu2itcm_icb_cmd_read;
+    lsu2itcm_icb_cmd_wdata -> lsu2itcm_icb_cmd_wdata;
+    lsu2itcm_icb_cmd_wmask -> lsu2itcm_icb_cmd_wmask;
+    lsu2itcm_icb_cmd_lock  -> lsu2itcm_icb_cmd_lock_nc;
+    lsu2itcm_icb_cmd_excl  -> lsu2itcm_icb_cmd_excl_nc;
+    lsu2itcm_icb_cmd_size  -> lsu2itcm_icb_cmd_size_nc;
+    lsu2itcm_icb_rsp_valid <- lsu2itcm_icb_rsp_valid;
+    lsu2itcm_icb_rsp_ready -> lsu2itcm_icb_rsp_ready;
+    lsu2itcm_icb_rsp_err   <- lsu2itcm_icb_rsp_err;
+    lsu2itcm_icb_rsp_excl_ok <- false;
+    lsu2itcm_icb_rsp_rdata <- lsu2itcm_icb_rsp_rdata;
+    dtcm_region_indic <- 0x90000000;
+    lsu2dtcm_icb_cmd_valid -> lsu2dtcm_icb_cmd_valid;
+    lsu2dtcm_icb_cmd_ready <- lsu2dtcm_icb_cmd_ready;
+    lsu2dtcm_icb_cmd_addr  -> lsu2dtcm_icb_cmd_addr;
+    lsu2dtcm_icb_cmd_read  -> lsu2dtcm_icb_cmd_read;
+    lsu2dtcm_icb_cmd_wdata -> lsu2dtcm_icb_cmd_wdata;
+    lsu2dtcm_icb_cmd_wmask -> lsu2dtcm_icb_cmd_wmask;
+    lsu2dtcm_icb_cmd_lock  -> lsu2dtcm_icb_cmd_lock_nc;
+    lsu2dtcm_icb_cmd_excl  -> lsu2dtcm_icb_cmd_excl_nc;
+    lsu2dtcm_icb_cmd_size  -> lsu2dtcm_icb_cmd_size_nc;
+    lsu2dtcm_icb_rsp_valid <- lsu2dtcm_icb_rsp_valid;
+    lsu2dtcm_icb_rsp_ready -> lsu2dtcm_icb_rsp_ready;
+    lsu2dtcm_icb_rsp_err   <- lsu2dtcm_icb_rsp_err;
+    lsu2dtcm_icb_rsp_excl_ok <- false;
+    lsu2dtcm_icb_rsp_rdata <- lsu2dtcm_icb_rsp_rdata;
+    ppi_region_indic <- 0x10000000;
+    ppi_icb_enable   <- true;
+    ppi_icb_cmd_valid -> ppi_icb_cmd_valid;
+    ppi_icb_cmd_ready <- ppi_icb_cmd_ready;
+    ppi_icb_cmd_addr  -> ppi_icb_cmd_addr;
+    ppi_icb_cmd_read  -> ppi_icb_cmd_read;
+    ppi_icb_cmd_wdata -> ppi_icb_cmd_wdata;
+    ppi_icb_cmd_wmask -> ppi_icb_cmd_wmask;
+    ppi_icb_cmd_lock  -> ppi_icb_cmd_lock_nc;
+    ppi_icb_cmd_excl  -> ppi_icb_cmd_excl_nc;
+    ppi_icb_cmd_size  -> ppi_icb_cmd_size_nc;
+    ppi_icb_cmd_burst -> ppi_icb_cmd_burst_nc;
+    ppi_icb_cmd_beat  -> ppi_icb_cmd_beat_nc;
+    ppi_icb_rsp_valid <- ppi_icb_rsp_valid;
+    ppi_icb_rsp_ready -> ppi_icb_rsp_ready;
+    ppi_icb_rsp_err   <- ppi_icb_rsp_err;
+    ppi_icb_rsp_excl_ok <- false;
+    ppi_icb_rsp_rdata <- ppi_icb_rsp_rdata;
+    clint_region_indic <- 0x02000000;
+    clint_icb_enable   <- true;
+    clint_icb_cmd_valid -> clint_icb_cmd_valid;
+    clint_icb_cmd_ready <- true;
+    clint_icb_cmd_addr  -> clint_icb_cmd_addr;
+    clint_icb_cmd_read  -> clint_icb_cmd_read;
+    clint_icb_cmd_wdata -> clint_icb_cmd_wdata;
+    clint_icb_cmd_wmask -> clint_icb_cmd_wmask_nc;
+    clint_icb_cmd_lock  -> clint_icb_cmd_lock_nc;
+    clint_icb_cmd_excl  -> clint_icb_cmd_excl_nc;
+    clint_icb_cmd_size  -> clint_icb_cmd_size_nc;
+    clint_icb_cmd_burst -> clint_icb_cmd_burst_nc;
+    clint_icb_cmd_beat  -> clint_icb_cmd_beat_nc;
+    clint_icb_rsp_valid <- clint_rsp_valid_r;
+    clint_icb_rsp_ready -> clint_icb_rsp_ready;
+    clint_icb_rsp_err   <- false;
+    clint_icb_rsp_excl_ok <- false;
+    clint_icb_rsp_rdata <- clint_rsp_rdata_r;
+    plic_region_indic <- 0x0C000000;
+    plic_icb_enable   <- false;
+    plic_icb_cmd_valid -> plic_icb_cmd_valid_nc;
+    plic_icb_cmd_ready <- true;
+    plic_icb_cmd_addr  -> plic_icb_cmd_addr_nc;
+    plic_icb_cmd_read  -> plic_icb_cmd_read_nc;
+    plic_icb_cmd_wdata -> plic_icb_cmd_wdata_nc;
+    plic_icb_cmd_wmask -> plic_icb_cmd_wmask_nc;
+    plic_icb_cmd_lock  -> plic_icb_cmd_lock_nc;
+    plic_icb_cmd_excl  -> plic_icb_cmd_excl_nc;
+    plic_icb_cmd_size  -> plic_icb_cmd_size_nc;
+    plic_icb_cmd_burst -> plic_icb_cmd_burst_nc;
+    plic_icb_cmd_beat  -> plic_icb_cmd_beat_nc;
+    plic_icb_rsp_valid <- false;
+    plic_icb_rsp_ready -> plic_icb_rsp_ready_nc;
+    plic_icb_rsp_err   <- false;
+    plic_icb_rsp_excl_ok <- false;
+    plic_icb_rsp_rdata <- 0;
+    fio_region_indic <- 0x03000000;
+    fio_icb_enable   <- true;
+    fio_icb_cmd_valid -> fio_icb_cmd_valid;
+    fio_icb_cmd_ready <- fio_icb_cmd_ready;
+    fio_icb_cmd_addr  -> fio_icb_cmd_addr;
+    fio_icb_cmd_read  -> fio_icb_cmd_read;
+    fio_icb_cmd_wdata -> fio_icb_cmd_wdata;
+    fio_icb_cmd_wmask -> fio_icb_cmd_wmask;
+    fio_icb_cmd_lock  -> fio_icb_cmd_lock_nc;
+    fio_icb_cmd_excl  -> fio_icb_cmd_excl_nc;
+    fio_icb_cmd_size  -> fio_icb_cmd_size_nc;
+    fio_icb_cmd_burst -> fio_icb_cmd_burst_nc;
+    fio_icb_cmd_beat  -> fio_icb_cmd_beat_nc;
+    fio_icb_rsp_valid <- fio_icb_rsp_valid;
+    fio_icb_rsp_ready -> fio_icb_rsp_ready;
+    fio_icb_rsp_err   <- fio_icb_rsp_err;
+    fio_icb_rsp_excl_ok <- false;
+    fio_icb_rsp_rdata <- fio_icb_rsp_rdata;
+    mem_icb_enable   <- true;
+    mem_icb_cmd_valid -> mem_icb_cmd_valid;
+    mem_icb_cmd_ready <- mem_icb_cmd_ready;
+    mem_icb_cmd_addr  -> mem_icb_cmd_addr;
+    mem_icb_cmd_read  -> mem_icb_cmd_read;
+    mem_icb_cmd_wdata -> mem_icb_cmd_wdata;
+    mem_icb_cmd_wmask -> mem_icb_cmd_wmask;
+    mem_icb_cmd_lock  -> mem_icb_cmd_lock_nc;
+    mem_icb_cmd_excl  -> mem_icb_cmd_excl_nc;
+    mem_icb_cmd_size  -> mem_icb_cmd_size_nc;
+    mem_icb_cmd_burst -> mem_icb_cmd_burst_nc;
+    mem_icb_cmd_beat  -> mem_icb_cmd_beat_nc;
+    mem_icb_rsp_valid <- mem_icb_rsp_valid;
+    mem_icb_rsp_ready -> mem_icb_rsp_ready;
+    mem_icb_rsp_err   <- mem_icb_rsp_err;
+    mem_icb_rsp_excl_ok <- false;
+    mem_icb_rsp_rdata <- mem_icb_rsp_rdata;
+    nice_mem_holdup <- false;
+    nice_req_valid  -> nice_req_valid_nc;
+    nice_req_ready  <- false;
+    nice_req_inst   -> nice_req_inst_nc;
+    nice_req_rs1    -> nice_req_rs1_nc;
+    nice_req_rs2    -> nice_req_rs2_nc;
+    nice_rsp_multicyc_valid <- false;
+    nice_rsp_multicyc_ready -> nice_rsp_multicyc_ready_nc;
+    nice_rsp_multicyc_dat   <- 0;
+    nice_rsp_multicyc_err   <- false;
+    nice_icb_cmd_valid <- false;
+    nice_icb_cmd_ready -> nice_icb_cmd_ready_nc;
+    nice_icb_cmd_addr  <- 0;
+    nice_icb_cmd_read  <- true;
+    nice_icb_cmd_wdata <- 0;
+    nice_icb_cmd_size  <- 0;
+    nice_icb_rsp_valid -> nice_icb_rsp_valid_nc;
+    nice_icb_rsp_ready <- true;
+    nice_icb_rsp_rdata -> nice_icb_rsp_rdata_nc;
+    nice_icb_rsp_err   -> nice_icb_rsp_err_nc;
   end inst core
 
   // ══════════════════════════════════════════════════════════════
-  // ICB Bus Arbiter: M0=external port, M1=unused → Slave bus
+  // ITCM: controller + RAM (loader enters via ext2itcm ICB)
+  // ══════════════════════════════════════════════════════════════
+  inst itcm_ctrl: e203_itcm_ctrl
+    clk   <- clk;
+    rst_n <- rst_n;
+    test_mode  <- false;
+    tcm_cgstop <- tcm_cgstop;
+    itcm_active -> itcm_active_nc;
+    ifu2itcm_icb_cmd_valid <- ifu2itcm_icb_cmd_valid;
+    ifu2itcm_icb_cmd_ready -> ifu2itcm_icb_cmd_ready;
+    ifu2itcm_icb_cmd_addr  <- ifu2itcm_icb_cmd_addr;
+    ifu2itcm_icb_cmd_read  <- true;
+    ifu2itcm_icb_cmd_wdata <- 0;
+    ifu2itcm_icb_cmd_wmask <- 0;
+    ifu2itcm_icb_rsp_valid -> ifu2itcm_icb_rsp_valid;
+    ifu2itcm_icb_rsp_ready <- ifu2itcm_icb_rsp_ready;
+    ifu2itcm_icb_rsp_err   -> ifu2itcm_icb_rsp_err;
+    ifu2itcm_icb_rsp_rdata -> ifu2itcm_icb_rsp_rdata;
+    ifu2itcm_holdup        -> ifu2itcm_holdup;
+    lsu2itcm_icb_cmd_valid <- lsu2itcm_icb_cmd_valid;
+    lsu2itcm_icb_cmd_ready -> lsu2itcm_icb_cmd_ready;
+    lsu2itcm_icb_cmd_addr  <- lsu2itcm_icb_cmd_addr;
+    lsu2itcm_icb_cmd_read  <- lsu2itcm_icb_cmd_read;
+    lsu2itcm_icb_cmd_wdata <- lsu2itcm_icb_cmd_wdata;
+    lsu2itcm_icb_cmd_wmask <- lsu2itcm_icb_cmd_wmask;
+    lsu2itcm_icb_rsp_valid -> lsu2itcm_icb_rsp_valid;
+    lsu2itcm_icb_rsp_ready <- lsu2itcm_icb_rsp_ready;
+    lsu2itcm_icb_rsp_err   -> lsu2itcm_icb_rsp_err;
+    lsu2itcm_icb_rsp_rdata -> lsu2itcm_icb_rsp_rdata;
+    ext2itcm_icb_cmd_valid <- itcm_wr_en;
+    ext2itcm_icb_cmd_ready -> ext2itcm_cmd_ready_nc;
+    ext2itcm_icb_cmd_addr  <- ext2itcm_cmd_addr;
+    ext2itcm_icb_cmd_read  <- false;
+    ext2itcm_icb_cmd_wdata <- itcm_wr_data;
+    ext2itcm_icb_cmd_wmask <- 15;
+    ext2itcm_icb_rsp_valid -> ext2itcm_rsp_valid_nc;
+    ext2itcm_icb_rsp_ready <- true;
+    ext2itcm_icb_rsp_err   -> ext2itcm_rsp_err_nc;
+    ext2itcm_icb_rsp_rdata -> ext2itcm_rsp_rdata_nc;
+    itcm_ram_cs   -> itcm_ram_cs;
+    itcm_ram_we   -> itcm_ram_we;
+    itcm_ram_addr -> itcm_ram_addr;
+    itcm_ram_wem  -> itcm_ram_wem;
+    itcm_ram_din  -> itcm_ram_din;
+    itcm_ram_dout <- itcm_ram_dout;
+    clk_itcm_ram  -> clk_itcm_ram_nc;
+  end inst itcm_ctrl
+
+  wire ext2itcm_cmd_ready_nc: Bool;
+  wire ext2itcm_rsp_valid_nc: Bool;
+  wire ext2itcm_rsp_err_nc:   Bool;
+  wire ext2itcm_rsp_rdata_nc: UInt<32>;
+
+  inst itcm_ram: e203_itcm_ram
+    clk   <- clk;
+    rst_n <- rst_n;
+    sd <- false;
+    ds <- false;
+    ls <- false;
+    cs   <- itcm_ram_cs;
+    we   <- itcm_ram_we;
+    addr <- itcm_ram_addr;
+    wem  <- itcm_ram_wem;
+    din  <- itcm_ram_din;
+    dout -> itcm_ram_dout;
+  end inst itcm_ram
+
+  // ══════════════════════════════════════════════════════════════
+  // DTCM: controller + RAM (no external master)
+  // ══════════════════════════════════════════════════════════════
+  inst dtcm_ctrl: e203_dtcm_ctrl
+    clk   <- clk;
+    rst_n <- rst_n;
+    test_mode  <- false;
+    tcm_cgstop <- tcm_cgstop;
+    dtcm_active -> dtcm_active_nc;
+    lsu2dtcm_icb_cmd_valid <- lsu2dtcm_icb_cmd_valid;
+    lsu2dtcm_icb_cmd_ready -> lsu2dtcm_icb_cmd_ready;
+    lsu2dtcm_icb_cmd_addr  <- lsu2dtcm_icb_cmd_addr;
+    lsu2dtcm_icb_cmd_read  <- lsu2dtcm_icb_cmd_read;
+    lsu2dtcm_icb_cmd_wdata <- lsu2dtcm_icb_cmd_wdata;
+    lsu2dtcm_icb_cmd_wmask <- lsu2dtcm_icb_cmd_wmask;
+    lsu2dtcm_icb_rsp_valid -> lsu2dtcm_icb_rsp_valid;
+    lsu2dtcm_icb_rsp_ready <- lsu2dtcm_icb_rsp_ready;
+    lsu2dtcm_icb_rsp_err   -> lsu2dtcm_icb_rsp_err;
+    lsu2dtcm_icb_rsp_rdata -> lsu2dtcm_icb_rsp_rdata;
+    ext2dtcm_icb_cmd_valid <- false;
+    ext2dtcm_icb_cmd_ready -> ext2dtcm_cmd_ready_nc;
+    ext2dtcm_icb_cmd_addr  <- 0;
+    ext2dtcm_icb_cmd_read  <- true;
+    ext2dtcm_icb_cmd_wdata <- 0;
+    ext2dtcm_icb_cmd_wmask <- 0;
+    ext2dtcm_icb_rsp_valid -> ext2dtcm_rsp_valid_nc;
+    ext2dtcm_icb_rsp_ready <- true;
+    ext2dtcm_icb_rsp_err   -> ext2dtcm_rsp_err_nc;
+    ext2dtcm_icb_rsp_rdata -> ext2dtcm_rsp_rdata_nc;
+    dtcm_ram_cs   -> dtcm_ram_cs;
+    dtcm_ram_we   -> dtcm_ram_we;
+    dtcm_ram_addr -> dtcm_ram_addr;
+    dtcm_ram_wem  -> dtcm_ram_wem;
+    dtcm_ram_din  -> dtcm_ram_din;
+    dtcm_ram_dout <- dtcm_ram_dout;
+    clk_dtcm_ram  -> clk_dtcm_ram_nc;
+  end inst dtcm_ctrl
+
+  wire ext2dtcm_cmd_ready_nc: Bool;
+  wire ext2dtcm_rsp_valid_nc: Bool;
+  wire ext2dtcm_rsp_err_nc:   Bool;
+  wire ext2dtcm_rsp_rdata_nc: UInt<32>;
+
+  inst dtcm_ram: e203_dtcm_ram
+    clk   <- clk;
+    rst_n <- rst_n;
+    sd <- false;
+    ds <- false;
+    ls <- false;
+    cs   <- dtcm_ram_cs;
+    we   <- dtcm_ram_we;
+    addr <- dtcm_ram_addr;
+    wem  <- dtcm_ram_wem;
+    din  <- dtcm_ram_din;
+    dout -> dtcm_ram_dout;
+  end inst dtcm_ram
+
+  // ══════════════════════════════════════════════════════════════
+  // CLINT timer (behind the ICB -> register adapter above)
+  // ══════════════════════════════════════════════════════════════
+  inst timer: e203_clint_timer
+    clk       <- clk;
+    rst       <- timer_rst;
+    reg_addr  <- clint_reg_addr;
+    reg_wdata <- clint_icb_cmd_wdata;
+    reg_wen   <- clint_reg_wen;
+    reg_rdata -> clint_reg_rdata;
+    tmr_irq   -> tmr_irq_w;
+  end inst timer
+
+  // ══════════════════════════════════════════════════════════════
+  // SRAM fabric: core MEM ICB (m0) + external port (m1) -> arbiter -> SRAM
   // ══════════════════════════════════════════════════════════════
   inst arbt: e203_icb_arbt
     clk   <- clk;
     rst_n <- rst_n;
-    m0_cmd_valid <- ext_cmd_valid;
-    m0_cmd_addr  <- ext_cmd_addr;
-    m0_cmd_wdata <- ext_cmd_wdata;
-    m0_cmd_wmask <- ext_cmd_wmask;
-    m0_cmd_read  <- ext_cmd_read;
-    m0_cmd_ready -> arbt_m0_ready;
-    m0_rsp_valid -> arbt_m0_rsp_valid;
-    m0_rsp_ready <- true;
-    m0_rsp_rdata -> arbt_m0_rsp_rdata;
-    m0_rsp_err   -> arbt_m0_rsp_err;
-    m1_cmd_valid <- false;
-    m1_cmd_addr  <- 0;
-    m1_cmd_wdata <- 0;
-    m1_cmd_wmask <- 0;
-    m1_cmd_read  <- false;
-    m1_cmd_ready -> arbt_m1_ready;
-    m1_rsp_valid -> arbt_m1_rsp_valid;
+    m0_cmd_valid <- mem_icb_cmd_valid;
+    m0_cmd_addr  <- mem_icb_cmd_addr;
+    m0_cmd_wdata <- mem_icb_cmd_wdata;
+    m0_cmd_wmask <- mem_icb_cmd_wmask;
+    m0_cmd_read  <- mem_icb_cmd_read;
+    m0_cmd_ready -> mem_icb_cmd_ready;
+    m0_rsp_valid -> mem_icb_rsp_valid;
+    m0_rsp_ready <- mem_icb_rsp_ready;
+    m0_rsp_rdata -> mem_icb_rsp_rdata;
+    m0_rsp_err   -> mem_icb_rsp_err;
+    m1_cmd_valid <- ext_cmd_valid;
+    m1_cmd_addr  <- ext_cmd_addr;
+    m1_cmd_wdata <- ext_cmd_wdata;
+    m1_cmd_wmask <- ext_cmd_wmask;
+    m1_cmd_read  <- ext_cmd_read;
+    m1_cmd_ready -> ext_cmd_ready;
+    m1_rsp_valid -> ext_rsp_valid;
     m1_rsp_ready <- true;
-    m1_rsp_rdata -> arbt_m1_rsp_rdata;
-    m1_rsp_err   -> arbt_m1_rsp_err;
-    s_cmd_valid -> bus_cmd_valid;
-    s_cmd_ready <- bus_cmd_ready;
-    s_cmd_addr  -> bus_cmd_addr;
-    s_cmd_wdata -> bus_cmd_wdata;
-    s_cmd_wmask -> bus_cmd_wmask;
-    s_cmd_read  -> bus_cmd_read;
-    s_rsp_valid <- bus_rsp_valid;
-    s_rsp_ready -> bus_rsp_ready;
-    s_rsp_rdata <- bus_rsp_rdata;
-    s_rsp_err   <- bus_rsp_err;
+    m1_rsp_rdata -> ext_rsp_rdata;
+    m1_rsp_err   -> ext_rsp_err;
+    s_cmd_valid -> arbt_s_cmd_valid;
+    s_cmd_ready <- sram_ready;
+    s_cmd_addr  -> arbt_s_cmd_addr;
+    s_cmd_wdata -> arbt_s_cmd_wdata;
+    s_cmd_wmask -> arbt_s_cmd_wmask;
+    s_cmd_read  -> arbt_s_cmd_read;
+    s_rsp_valid <- sram_rsp_valid;
+    s_rsp_ready -> arbt_s_rsp_ready;
+    s_rsp_rdata <- sram_rsp_rdata;
+    s_rsp_err   <- sram_rsp_err;
   end inst arbt
 
-  // Address decode (combinational — valid only while bus_cmd_valid)
-  let sel_sram: Bool = bus_cmd_addr[31:28] == 2;
-  let sel_ppi:  Bool = bus_cmd_addr[31:28] == 1;
-  let sel_fio:  Bool = bus_cmd_addr[31:28] == 3;
-
-  // Latched peripheral select for response mux (holds after cmd completes)
-  reg sel_sram_r: Bool init false reset rst_n=>false;
-  reg sel_ppi_r:  Bool init false reset rst_n=>false;
-  reg sel_fio_r:  Bool init false reset rst_n=>false;
-
-  seq on clk rising
-    if bus_cmd_valid & bus_cmd_ready
-      sel_sram_r <= sel_sram;
-      sel_ppi_r  <= sel_ppi;
-      sel_fio_r  <= sel_fio;
-    end if
-  end seq
-
-  // ══════════════════════════════════════════════════════════════
-  // SRAM Controller
-  // ══════════════════════════════════════════════════════════════
   inst sram: e203_sram_ctrl
     clk           <- clk;
     rst_n         <- rst_n;
-    icb_cmd_valid <- bus_cmd_valid & sel_sram;
+    icb_cmd_valid <- arbt_s_cmd_valid;
     icb_cmd_ready -> sram_ready;
-    icb_cmd_addr  <- bus_cmd_addr;
-    icb_cmd_wdata <- bus_cmd_wdata;
-    icb_cmd_wmask <- bus_cmd_wmask;
-    icb_cmd_read  <- bus_cmd_read;
+    icb_cmd_addr  <- arbt_s_cmd_addr;
+    icb_cmd_wdata <- arbt_s_cmd_wdata;
+    icb_cmd_wmask <- arbt_s_cmd_wmask;
+    icb_cmd_read  <- arbt_s_cmd_read;
     icb_rsp_valid -> sram_rsp_valid;
-    icb_rsp_ready <- bus_rsp_ready;
+    icb_rsp_ready <- arbt_s_rsp_ready;
     icb_rsp_rdata -> sram_rsp_rdata;
     icb_rsp_err   -> sram_rsp_err;
   end inst sram
 
   // ══════════════════════════════════════════════════════════════
-  // Fast I/O
+  // Fast I/O (core FIO ICB)
   // ══════════════════════════════════════════════════════════════
   inst fio: e203_fio
     clk           <- clk;
     rst_n         <- rst_n;
-    icb_cmd_valid <- bus_cmd_valid & sel_fio;
-    icb_cmd_ready -> fio_ready;
-    icb_cmd_addr  <- bus_cmd_addr;
-    icb_cmd_wdata <- bus_cmd_wdata;
-    icb_cmd_wmask <- bus_cmd_wmask;
-    icb_cmd_read  <- bus_cmd_read;
-    icb_rsp_valid -> fio_rsp_valid;
-    icb_rsp_ready <- bus_rsp_ready;
-    icb_rsp_rdata -> fio_rsp_rdata;
-    icb_rsp_err   -> fio_rsp_err;
+    icb_cmd_valid <- fio_icb_cmd_valid;
+    icb_cmd_ready -> fio_icb_cmd_ready;
+    icb_cmd_addr  <- fio_icb_cmd_addr;
+    icb_cmd_wdata <- fio_icb_cmd_wdata;
+    icb_cmd_wmask <- fio_icb_cmd_wmask;
+    icb_cmd_read  <- fio_icb_cmd_read;
+    icb_rsp_valid -> fio_icb_rsp_valid;
+    icb_rsp_ready <- fio_icb_rsp_ready;
+    icb_rsp_rdata -> fio_icb_rsp_rdata;
+    icb_rsp_err   -> fio_icb_rsp_err;
     fio_in_0      <- fio_in_0;
     fio_in_1      <- fio_in_1;
     fio_out_0     -> fio_out_0_w;
@@ -180,21 +704,21 @@ module e203_soc_top
   end inst fio
 
   // ══════════════════════════════════════════════════════════════
-  // PPI: ICB → APB bridge with 4-slave address decode
+  // PPI: ICB -> APB bridge with 4-slave decode (core PPI ICB)
   // ══════════════════════════════════════════════════════════════
   inst ppi: e203_ppi
     clk           <- clk;
     rst_n         <- rst_n;
-    icb_cmd_valid <- bus_cmd_valid & sel_ppi;
-    icb_cmd_ready -> ppi_ready;
-    icb_cmd_addr  <- bus_cmd_addr;
-    icb_cmd_wdata <- bus_cmd_wdata;
-    icb_cmd_wmask <- bus_cmd_wmask;
-    icb_cmd_read  <- bus_cmd_read;
-    icb_rsp_valid -> ppi_rsp_valid;
-    icb_rsp_ready <- bus_rsp_ready;
-    icb_rsp_rdata -> ppi_rsp_rdata;
-    icb_rsp_err   -> ppi_rsp_err;
+    icb_cmd_valid <- ppi_icb_cmd_valid;
+    icb_cmd_ready -> ppi_icb_cmd_ready;
+    icb_cmd_addr  <- ppi_icb_cmd_addr;
+    icb_cmd_wdata <- ppi_icb_cmd_wdata;
+    icb_cmd_wmask <- ppi_icb_cmd_wmask;
+    icb_cmd_read  <- ppi_icb_cmd_read;
+    icb_rsp_valid -> ppi_icb_rsp_valid;
+    icb_rsp_ready <- ppi_icb_rsp_ready;
+    icb_rsp_rdata -> ppi_icb_rsp_rdata;
+    icb_rsp_err   -> ppi_icb_rsp_err;
     apb0_psel     -> gpio_psel;
     apb0_penable  -> gpio_penable;
     apb0_paddr    -> gpio_paddr;
@@ -226,7 +750,7 @@ module e203_soc_top
   end inst ppi
 
   // ══════════════════════════════════════════════════════════════
-  // GPIO Peripheral
+  // GPIO / UART / SPI peripherals (APB)
   // ══════════════════════════════════════════════════════════════
   inst gpio_p: e203_gpio
     clk     <- clk;
@@ -244,9 +768,6 @@ module e203_soc_top
     gpio_irq -> gpio_irq_w;
   end inst gpio_p
 
-  // ══════════════════════════════════════════════════════════════
-  // UART Peripheral
-  // ══════════════════════════════════════════════════════════════
   inst uart_p: e203_uart
     clk     <- clk;
     rst_n   <- rst_n;
@@ -262,9 +783,6 @@ module e203_soc_top
     uart_irq -> uart_irq_w;
   end inst uart_p
 
-  // ══════════════════════════════════════════════════════════════
-  // SPI Peripheral
-  // ══════════════════════════════════════════════════════════════
   inst spi_p: e203_spi
     clk     <- clk;
     rst_n   <- rst_n;
@@ -283,7 +801,7 @@ module e203_soc_top
   end inst spi_p
 
   // ══════════════════════════════════════════════════════════════
-  // Interrupt Controller
+  // Interrupt controller (feeds the core's irq inputs)
   // ══════════════════════════════════════════════════════════════
   inst irq: e203_irq_ctrl
     clk          <- clk;
@@ -296,7 +814,7 @@ module e203_soc_top
     mie_mtie     <- true;
     mie_msie     <- true;
     pipe_flush_ack <- false;
-    commit_valid   <- core_commit_w;
+    commit_valid   <- false;
     irq_req      -> irq_req_w;
     irq_cause    -> irq_cause_w;
     mip_meip     -> irq_mip_meip;
@@ -305,7 +823,7 @@ module e203_soc_top
   end inst irq
 
   // ══════════════════════════════════════════════════════════════
-  // Debug Module
+  // Debug module (halt request feeds the core's debug inputs)
   // ══════════════════════════════════════════════════════════════
   inst dbg: e203_debug_module
     clk          <- clk;
@@ -327,61 +845,20 @@ module e203_soc_top
     dbg_reg_rdata <- 0;
   end inst dbg
 
-  // ══════════════════════════════════════════════════════════════
-  // Bus response mux
-  // ══════════════════════════════════════════════════════════════
+  // ── Pin fan-out ────────────────────────────────────────────────
   comb
-    // Command-path mux: use combinational sel (valid while cmd active)
-    if sel_sram
-      bus_cmd_ready = sram_ready;
-    elsif sel_ppi
-      bus_cmd_ready = ppi_ready;
-    elsif sel_fio
-      bus_cmd_ready = fio_ready;
-    else
-      bus_cmd_ready = true;
-    end if
-
-    // Response-path mux: use latched sel (holds after cmd completes)
-    if sel_sram_r
-      bus_rsp_valid = sram_rsp_valid;
-      bus_rsp_rdata = sram_rsp_rdata;
-      bus_rsp_err   = sram_rsp_err;
-    elsif sel_ppi_r
-      bus_rsp_valid = ppi_rsp_valid;
-      bus_rsp_rdata = ppi_rsp_rdata;
-      bus_rsp_err   = ppi_rsp_err;
-    elsif sel_fio_r
-      bus_rsp_valid = fio_rsp_valid;
-      bus_rsp_rdata = fio_rsp_rdata;
-      bus_rsp_err   = fio_rsp_err;
-    else
-      bus_rsp_valid = false;
-      bus_rsp_rdata = 0;
-      bus_rsp_err   = true;
-    end if
-
-    ext_cmd_ready = arbt_m0_ready;
-    ext_rsp_valid = arbt_m0_rsp_valid;
-    ext_rsp_rdata = arbt_m0_rsp_rdata;
-    ext_rsp_err   = arbt_m0_rsp_err;
-
-    core_commit = core_commit_w;
-    core_instr  = core_instr_w;
-    core_pc     = core_pc_w;
-    core_valid  = core_valid_w;
-    gpio_out    = gpio_out_w;
-    gpio_oe     = gpio_oe_w;
-    gpio_irq    = gpio_irq_w;
-    uart_tx     = uart_tx_w;
-    uart_irq    = uart_irq_w;
-    spi_sclk    = spi_sclk_w;
-    spi_mosi    = spi_mosi_w;
-    spi_cs_n    = spi_cs_n_w;
-    spi_irq     = spi_irq_w;
-    fio_out_0   = fio_out_0_w;
-    fio_out_1   = fio_out_1_w;
-    dbg_prdata  = dbg_prdata_w;
+    gpio_out  = gpio_out_w;
+    gpio_oe   = gpio_oe_w;
+    gpio_irq  = gpio_irq_w;
+    uart_tx   = uart_tx_w;
+    uart_irq  = uart_irq_w;
+    spi_sclk  = spi_sclk_w;
+    spi_mosi  = spi_mosi_w;
+    spi_cs_n  = spi_cs_n_w;
+    spi_irq   = spi_irq_w;
+    fio_out_0 = fio_out_0_w;
+    fio_out_1 = fio_out_1_w;
+    dbg_prdata = dbg_prdata_w;
   end comb
 
 end module e203_soc_top

--- a/tests/e203/e203_soc_top.sv
+++ b/tests/e203/e203_soc_top.sv
@@ -1,186 +1,656 @@
-// E203 SoC Top-Level Integration
-// Connects: CoreTop + ICB Arbiter + SRAM + PPI + FIO + GPIO + UART + SPI
-//           + DebugModule + IrqCtrl
-// The core's internal BIU handles ITCM/DTCM. External bus accesses
-// (peripherals, SRAM) go through the ICB fabric.
-module SocTop (
+// domain SysDomain
+//   freq_mhz: 100
+
+// domain SysDomain
+//   freq_mhz: 100
+
+// domain SysDomain
+//   freq_mhz: 100
+
+// domain SysDomain
+//   freq_mhz: 100
+
+// domain SysDomain
+//   freq_mhz: 100
+
+// domain SysDomain
+//   freq_mhz: 100
+
+// domain SysDomain
+//   freq_mhz: 100
+
+module e203_soc_top (
   input logic clk,
   input logic rst_n,
+  input logic timer_rst,
+  input logic [31:0] pc_rtvec,
   input logic itcm_wr_en,
-  input logic [14-1:0] itcm_wr_addr,
-  input logic [32-1:0] itcm_wr_data,
+  input logic [13:0] itcm_wr_addr,
+  input logic [31:0] itcm_wr_data,
   input logic ext_cmd_valid,
-  input logic [32-1:0] ext_cmd_addr,
-  input logic [32-1:0] ext_cmd_wdata,
-  input logic [4-1:0] ext_cmd_wmask,
+  input logic [31:0] ext_cmd_addr,
+  input logic [31:0] ext_cmd_wdata,
+  input logic [3:0] ext_cmd_wmask,
   input logic ext_cmd_read,
   output logic ext_cmd_ready,
   output logic ext_rsp_valid,
-  output logic [32-1:0] ext_rsp_rdata,
+  output logic [31:0] ext_rsp_rdata,
   output logic ext_rsp_err,
-  input logic [32-1:0] gpio_in,
-  output logic [32-1:0] gpio_out,
-  output logic [32-1:0] gpio_oe,
+  input logic [31:0] gpio_in,
+  output logic [31:0] gpio_out,
+  output logic [31:0] gpio_oe,
   output logic uart_tx,
   input logic uart_rx,
   output logic spi_sclk,
   output logic spi_mosi,
   input logic spi_miso,
   output logic spi_cs_n,
-  input logic [32-1:0] fio_in_0,
-  input logic [32-1:0] fio_in_1,
-  output logic [32-1:0] fio_out_0,
-  output logic [32-1:0] fio_out_1,
+  input logic [31:0] fio_in_0,
+  input logic [31:0] fio_in_1,
+  output logic [31:0] fio_out_0,
+  output logic [31:0] fio_out_1,
   input logic dbg_psel,
   input logic dbg_penable,
-  input logic [32-1:0] dbg_paddr,
-  input logic [32-1:0] dbg_pwdata,
+  input logic [31:0] dbg_paddr,
+  input logic [31:0] dbg_pwdata,
   input logic dbg_pwrite,
-  output logic [32-1:0] dbg_prdata,
-  output logic core_commit,
-  output logic [32-1:0] core_instr,
-  output logic [32-1:0] core_pc,
-  output logic core_valid,
+  output logic [31:0] dbg_prdata,
+  output logic [31:0] inspect_pc,
+  output logic core_wfi,
   output logic gpio_irq,
   output logic uart_irq,
   output logic spi_irq
 );
 
-  // ── ITCM loader (testbench) ────────────────────────────────────
-  // ── External ICB master (from core BIU, directly wired for SoC) ──
-  // ── External pins ──────────────────────────────────────────────
-  // ── Debug interface ────────────────────────────────────────────
-  // ── Status ─────────────────────────────────────────────────────
-  // ── Bus interconnect wires (driven in comb, consumed by inst) ──
-  logic bus_cmd_ready;
-  logic bus_rsp_valid;
-  logic [32-1:0] bus_rsp_rdata;
-  logic bus_rsp_err;
-  // ══════════════════════════════════════════════════════════════
-  // CPU Core
-  // ══════════════════════════════════════════════════════════════
-  logic core_commit_w;
-  logic [32-1:0] core_instr_w;
-  logic [32-1:0] core_pc_w;
-  logic core_valid_w;
+  logic [15:0] ext2itcm_cmd_addr;
+  logic [3:0] clint_reg_addr;
+  logic clint_reg_wen;
+  logic ifu2itcm_icb_cmd_valid;
+  logic ifu2itcm_icb_cmd_ready;
+  logic [15:0] ifu2itcm_icb_cmd_addr;
+  logic ifu2itcm_icb_rsp_valid;
+  logic ifu2itcm_icb_rsp_ready;
+  logic ifu2itcm_icb_rsp_err;
+  logic [63:0] ifu2itcm_icb_rsp_rdata;
+  logic ifu2itcm_holdup;
+  logic lsu2itcm_icb_cmd_valid;
+  logic lsu2itcm_icb_cmd_ready;
+  logic [15:0] lsu2itcm_icb_cmd_addr;
+  logic lsu2itcm_icb_cmd_read;
+  logic [31:0] lsu2itcm_icb_cmd_wdata;
+  logic [3:0] lsu2itcm_icb_cmd_wmask;
+  logic lsu2itcm_icb_rsp_valid;
+  logic lsu2itcm_icb_rsp_ready;
+  logic lsu2itcm_icb_rsp_err;
+  logic [31:0] lsu2itcm_icb_rsp_rdata;
+  logic lsu2dtcm_icb_cmd_valid;
+  logic lsu2dtcm_icb_cmd_ready;
+  logic [15:0] lsu2dtcm_icb_cmd_addr;
+  logic lsu2dtcm_icb_cmd_read;
+  logic [31:0] lsu2dtcm_icb_cmd_wdata;
+  logic [3:0] lsu2dtcm_icb_cmd_wmask;
+  logic lsu2dtcm_icb_rsp_valid;
+  logic lsu2dtcm_icb_rsp_ready;
+  logic lsu2dtcm_icb_rsp_err;
+  logic [31:0] lsu2dtcm_icb_rsp_rdata;
+  logic itcm_ram_cs;
+  logic itcm_ram_we;
+  logic [12:0] itcm_ram_addr;
+  logic [7:0] itcm_ram_wem;
+  logic [63:0] itcm_ram_din;
+  logic [63:0] itcm_ram_dout;
+  logic clk_itcm_ram_nc;
+  logic dtcm_ram_cs;
+  logic dtcm_ram_we;
+  logic [13:0] dtcm_ram_addr;
+  logic [3:0] dtcm_ram_wem;
+  logic [31:0] dtcm_ram_din;
+  logic [31:0] dtcm_ram_dout;
+  logic clk_dtcm_ram_nc;
+  logic itcm_active_nc;
+  logic dtcm_active_nc;
+  logic ppi_icb_cmd_valid;
+  logic ppi_icb_cmd_ready;
+  logic [31:0] ppi_icb_cmd_addr;
+  logic ppi_icb_cmd_read;
+  logic [31:0] ppi_icb_cmd_wdata;
+  logic [3:0] ppi_icb_cmd_wmask;
+  logic ppi_icb_rsp_valid;
+  logic ppi_icb_rsp_ready;
+  logic ppi_icb_rsp_err;
+  logic [31:0] ppi_icb_rsp_rdata;
+  logic clint_icb_cmd_valid;
+  logic [31:0] clint_icb_cmd_addr;
+  logic clint_icb_cmd_read;
+  logic [31:0] clint_icb_cmd_wdata;
+  logic clint_icb_rsp_ready;
+  logic fio_icb_cmd_valid;
+  logic fio_icb_cmd_ready;
+  logic [31:0] fio_icb_cmd_addr;
+  logic fio_icb_cmd_read;
+  logic [31:0] fio_icb_cmd_wdata;
+  logic [3:0] fio_icb_cmd_wmask;
+  logic fio_icb_rsp_valid;
+  logic fio_icb_rsp_ready;
+  logic fio_icb_rsp_err;
+  logic [31:0] fio_icb_rsp_rdata;
+  logic mem_icb_cmd_valid;
+  logic mem_icb_cmd_ready;
+  logic [31:0] mem_icb_cmd_addr;
+  logic mem_icb_cmd_read;
+  logic [31:0] mem_icb_cmd_wdata;
+  logic [3:0] mem_icb_cmd_wmask;
+  logic mem_icb_rsp_valid;
+  logic mem_icb_rsp_ready;
+  logic mem_icb_rsp_err;
+  logic [31:0] mem_icb_rsp_rdata;
+  logic tm_stop_nc;
+  logic core_cgstop_nc;
+  logic tcm_cgstop;
+  logic exu_active_nc;
+  logic ifu_active_nc;
+  logic lsu_active_nc;
+  logic biu_active_nc;
+  logic wr_dcsr_ena_nc;
+  logic wr_dpc_ena_nc;
+  logic wr_dscratch_ena_nc;
+  logic [31:0] wr_csr_nxt_nc;
+  logic [31:0] cmt_dpc_nc;
+  logic cmt_dpc_ena_nc;
+  logic [2:0] cmt_dcause_nc;
+  logic cmt_dcause_ena_nc;
+  logic lsu2itcm_icb_cmd_lock_nc;
+  logic lsu2itcm_icb_cmd_excl_nc;
+  logic [1:0] lsu2itcm_icb_cmd_size_nc;
+  logic lsu2dtcm_icb_cmd_lock_nc;
+  logic lsu2dtcm_icb_cmd_excl_nc;
+  logic [1:0] lsu2dtcm_icb_cmd_size_nc;
+  logic ppi_icb_cmd_lock_nc;
+  logic ppi_icb_cmd_excl_nc;
+  logic [1:0] ppi_icb_cmd_size_nc;
+  logic [1:0] ppi_icb_cmd_burst_nc;
+  logic [1:0] ppi_icb_cmd_beat_nc;
+  logic [3:0] clint_icb_cmd_wmask_nc;
+  logic clint_icb_cmd_lock_nc;
+  logic clint_icb_cmd_excl_nc;
+  logic [1:0] clint_icb_cmd_size_nc;
+  logic [1:0] clint_icb_cmd_burst_nc;
+  logic [1:0] clint_icb_cmd_beat_nc;
+  logic plic_icb_cmd_valid_nc;
+  logic [31:0] plic_icb_cmd_addr_nc;
+  logic plic_icb_cmd_read_nc;
+  logic [31:0] plic_icb_cmd_wdata_nc;
+  logic [3:0] plic_icb_cmd_wmask_nc;
+  logic plic_icb_cmd_lock_nc;
+  logic plic_icb_cmd_excl_nc;
+  logic [1:0] plic_icb_cmd_size_nc;
+  logic [1:0] plic_icb_cmd_burst_nc;
+  logic [1:0] plic_icb_cmd_beat_nc;
+  logic plic_icb_rsp_ready_nc;
+  logic fio_icb_cmd_lock_nc;
+  logic fio_icb_cmd_excl_nc;
+  logic [1:0] fio_icb_cmd_size_nc;
+  logic [1:0] fio_icb_cmd_burst_nc;
+  logic [1:0] fio_icb_cmd_beat_nc;
+  logic mem_icb_cmd_lock_nc;
+  logic mem_icb_cmd_excl_nc;
+  logic [1:0] mem_icb_cmd_size_nc;
+  logic [1:0] mem_icb_cmd_burst_nc;
+  logic [1:0] mem_icb_cmd_beat_nc;
+  logic nice_req_valid_nc;
+  logic [31:0] nice_req_inst_nc;
+  logic [31:0] nice_req_rs1_nc;
+  logic [31:0] nice_req_rs2_nc;
+  logic nice_rsp_multicyc_ready_nc;
+  logic nice_icb_cmd_ready_nc;
+  logic nice_icb_rsp_valid_nc;
+  logic [31:0] nice_icb_rsp_rdata_nc;
+  logic nice_icb_rsp_err_nc;
   logic tmr_irq_w;
-  CoreTop core (
-    .clk(clk),
-    .rst_n(rst_n),
-    .itcm_wr_en(itcm_wr_en),
-    .itcm_wr_addr(itcm_wr_addr),
-    .itcm_wr_data(itcm_wr_data),
-    .exu_redirect(1'b0),
-    .exu_redirect_pc(0),
-    .commit_valid(core_commit_w),
-    .o_instr(core_instr_w),
-    .o_pc(core_pc_w),
-    .o_valid(core_valid_w),
-    .tmr_irq(tmr_irq_w)
-  );
-  // ══════════════════════════════════════════════════════════════
-  // ICB Bus Arbiter: M0=external port, M1=unused → Slave bus
-  // ══════════════════════════════════════════════════════════════
-  logic arbt_m0_ready;
-  logic arbt_m0_rsp_valid;
-  logic [32-1:0] arbt_m0_rsp_rdata;
-  logic arbt_m0_rsp_err;
-  logic arbt_m1_ready;
-  logic arbt_m1_rsp_valid;
-  logic [32-1:0] arbt_m1_rsp_rdata;
-  logic arbt_m1_rsp_err;
-  logic bus_cmd_valid;
-  logic [32-1:0] bus_cmd_addr;
-  logic [32-1:0] bus_cmd_wdata;
-  logic [4-1:0] bus_cmd_wmask;
-  logic bus_cmd_read;
-  logic bus_rsp_ready;
-  IcbArbt arbt (
-    .clk(clk),
-    .rst_n(rst_n),
-    .m0_cmd_valid(ext_cmd_valid),
-    .m0_cmd_addr(ext_cmd_addr),
-    .m0_cmd_wdata(ext_cmd_wdata),
-    .m0_cmd_wmask(ext_cmd_wmask),
-    .m0_cmd_read(ext_cmd_read),
-    .m0_cmd_ready(arbt_m0_ready),
-    .m0_rsp_valid(arbt_m0_rsp_valid),
-    .m0_rsp_ready(1'b1),
-    .m0_rsp_rdata(arbt_m0_rsp_rdata),
-    .m0_rsp_err(arbt_m0_rsp_err),
-    .m1_cmd_valid(1'b0),
-    .m1_cmd_addr(0),
-    .m1_cmd_wdata(0),
-    .m1_cmd_wmask(0),
-    .m1_cmd_read(1'b0),
-    .m1_cmd_ready(arbt_m1_ready),
-    .m1_rsp_valid(arbt_m1_rsp_valid),
-    .m1_rsp_ready(1'b1),
-    .m1_rsp_rdata(arbt_m1_rsp_rdata),
-    .m1_rsp_err(arbt_m1_rsp_err),
-    .s_cmd_valid(bus_cmd_valid),
-    .s_cmd_ready(bus_cmd_ready),
-    .s_cmd_addr(bus_cmd_addr),
-    .s_cmd_wdata(bus_cmd_wdata),
-    .s_cmd_wmask(bus_cmd_wmask),
-    .s_cmd_read(bus_cmd_read),
-    .s_rsp_valid(bus_rsp_valid),
-    .s_rsp_ready(bus_rsp_ready),
-    .s_rsp_rdata(bus_rsp_rdata),
-    .s_rsp_err(bus_rsp_err)
-  );
-  // Address decode
-  logic sel_sram;
-  assign sel_sram = (bus_cmd_addr[31:28] == 2);
-  logic sel_ppi;
-  assign sel_ppi = (bus_cmd_addr[31:28] == 1);
-  logic sel_fio;
-  assign sel_fio = (bus_cmd_addr[31:28] == 3);
-  // ══════════════════════════════════════════════════════════════
-  // SRAM Controller
-  // ══════════════════════════════════════════════════════════════
+  logic gpio_irq_w;
+  logic uart_irq_w;
+  logic spi_irq_w;
+  logic irq_req_w;
+  logic [31:0] irq_cause_w;
+  logic irq_mip_meip;
+  logic irq_mip_mtip;
+  logic irq_mip_msip;
+  logic dbg_halt_req;
+  logic dbg_resume_req;
+  logic [31:0] dbg_prdata_w;
+  logic dbg_pready_w;
+  logic [15:0] dbg_reg_addr_w;
+  logic [31:0] dbg_reg_wdata_w;
+  logic dbg_reg_wen_w;
+  logic gpio_psel;
+  logic gpio_penable;
+  logic [31:0] gpio_paddr;
+  logic [31:0] gpio_pwdata;
+  logic gpio_pwrite;
+  logic [31:0] gpio_prdata_w;
+  logic gpio_pready_w;
+  logic uart_psel;
+  logic uart_penable;
+  logic [31:0] uart_paddr;
+  logic [31:0] uart_pwdata;
+  logic uart_pwrite;
+  logic [31:0] uart_prdata_w;
+  logic uart_pready_w;
+  logic spi_psel;
+  logic spi_penable;
+  logic [31:0] spi_paddr;
+  logic [31:0] spi_pwdata;
+  logic spi_pwrite;
+  logic [31:0] spi_prdata_w;
+  logic spi_pready_w;
+  logic apb3_psel_w;
+  logic apb3_penable_w;
+  logic [31:0] apb3_paddr_w;
+  logic [31:0] apb3_pwdata_w;
+  logic apb3_pwrite_w;
+  logic arbt_s_cmd_valid;
+  logic [31:0] arbt_s_cmd_addr;
+  logic [31:0] arbt_s_cmd_wdata;
+  logic [3:0] arbt_s_cmd_wmask;
+  logic arbt_s_cmd_read;
+  logic arbt_s_rsp_ready;
   logic sram_ready;
   logic sram_rsp_valid;
-  logic [32-1:0] sram_rsp_rdata;
+  logic [31:0] sram_rsp_rdata;
   logic sram_rsp_err;
-  SramCtrl sram (
+  logic [31:0] gpio_out_w;
+  logic [31:0] gpio_oe_w;
+  logic uart_tx_w;
+  logic spi_sclk_w;
+  logic spi_mosi_w;
+  logic spi_cs_n_w;
+  logic [31:0] fio_out_0_w;
+  logic [31:0] fio_out_1_w;
+  logic [31:0] fio_out_2_w;
+  logic [31:0] fio_out_3_w;
+  assign ext2itcm_cmd_addr = 16'($unsigned(itcm_wr_addr)) << 2;
+  assign clint_reg_addr = clint_icb_cmd_addr[5:2];
+  assign clint_reg_wen = clint_icb_cmd_valid & !clint_icb_cmd_read;
+  logic [31:0] clint_reg_rdata;
+  logic clint_rsp_valid_r;
+  logic [31:0] clint_rsp_rdata_r;
+  logic ext2itcm_cmd_ready_nc;
+  logic ext2itcm_rsp_valid_nc;
+  logic ext2itcm_rsp_err_nc;
+  logic [31:0] ext2itcm_rsp_rdata_nc;
+  logic ext2dtcm_cmd_ready_nc;
+  logic ext2dtcm_rsp_valid_nc;
+  logic ext2dtcm_rsp_err_nc;
+  logic [31:0] ext2dtcm_rsp_rdata_nc;
+  always_ff @(posedge clk or negedge rst_n) begin
+    if ((!rst_n)) begin
+      clint_rsp_rdata_r <= 0;
+      clint_rsp_valid_r <= 1'b0;
+    end else begin
+      clint_rsp_valid_r <= clint_icb_cmd_valid;
+      clint_rsp_rdata_r <= clint_reg_rdata;
+    end
+  end
+  e203_core_top core (
     .clk(clk),
     .rst_n(rst_n),
-    .icb_cmd_valid((bus_cmd_valid & sel_sram)),
+    .test_mode(1'b0),
+    .inspect_pc(inspect_pc),
+    .core_wfi(core_wfi),
+    .tm_stop(tm_stop_nc),
+    .core_cgstop(core_cgstop_nc),
+    .tcm_cgstop(tcm_cgstop),
+    .exu_active(exu_active_nc),
+    .ifu_active(ifu_active_nc),
+    .lsu_active(lsu_active_nc),
+    .biu_active(biu_active_nc),
+    .pc_rtvec(pc_rtvec),
+    .core_mhartid(0),
+    .dbg_irq_r(dbg_halt_req),
+    .lcl_irq_r(1'b0),
+    .evt_r(1'b0),
+    .ext_irq_r(irq_mip_meip),
+    .sft_irq_r(irq_mip_msip),
+    .tmr_irq_r(irq_mip_mtip),
+    .wr_dcsr_ena(wr_dcsr_ena_nc),
+    .wr_dpc_ena(wr_dpc_ena_nc),
+    .wr_dscratch_ena(wr_dscratch_ena_nc),
+    .wr_csr_nxt(wr_csr_nxt_nc),
+    .dcsr_r(0),
+    .dpc_r(0),
+    .dscratch_r(0),
+    .cmt_dpc(cmt_dpc_nc),
+    .cmt_dpc_ena(cmt_dpc_ena_nc),
+    .cmt_dcause(cmt_dcause_nc),
+    .cmt_dcause_ena(cmt_dcause_ena_nc),
+    .dbg_mode(1'b0),
+    .dbg_halt_r(dbg_halt_req),
+    .dbg_step_r(1'b0),
+    .dbg_ebreakm_r(1'b0),
+    .dbg_stopcycle(1'b0),
+    .itcm_region_indic(0),
+    .ifu2itcm_holdup(ifu2itcm_holdup),
+    .ifu2itcm_icb_cmd_valid(ifu2itcm_icb_cmd_valid),
+    .ifu2itcm_icb_cmd_ready(ifu2itcm_icb_cmd_ready),
+    .ifu2itcm_icb_cmd_addr(ifu2itcm_icb_cmd_addr),
+    .ifu2itcm_icb_rsp_valid(ifu2itcm_icb_rsp_valid),
+    .ifu2itcm_icb_rsp_ready(ifu2itcm_icb_rsp_ready),
+    .ifu2itcm_icb_rsp_err(ifu2itcm_icb_rsp_err),
+    .ifu2itcm_icb_rsp_rdata(ifu2itcm_icb_rsp_rdata),
+    .lsu2itcm_icb_cmd_valid(lsu2itcm_icb_cmd_valid),
+    .lsu2itcm_icb_cmd_ready(lsu2itcm_icb_cmd_ready),
+    .lsu2itcm_icb_cmd_addr(lsu2itcm_icb_cmd_addr),
+    .lsu2itcm_icb_cmd_read(lsu2itcm_icb_cmd_read),
+    .lsu2itcm_icb_cmd_wdata(lsu2itcm_icb_cmd_wdata),
+    .lsu2itcm_icb_cmd_wmask(lsu2itcm_icb_cmd_wmask),
+    .lsu2itcm_icb_cmd_lock(lsu2itcm_icb_cmd_lock_nc),
+    .lsu2itcm_icb_cmd_excl(lsu2itcm_icb_cmd_excl_nc),
+    .lsu2itcm_icb_cmd_size(lsu2itcm_icb_cmd_size_nc),
+    .lsu2itcm_icb_rsp_valid(lsu2itcm_icb_rsp_valid),
+    .lsu2itcm_icb_rsp_ready(lsu2itcm_icb_rsp_ready),
+    .lsu2itcm_icb_rsp_err(lsu2itcm_icb_rsp_err),
+    .lsu2itcm_icb_rsp_excl_ok(1'b0),
+    .lsu2itcm_icb_rsp_rdata(lsu2itcm_icb_rsp_rdata),
+    .dtcm_region_indic('h90000000),
+    .lsu2dtcm_icb_cmd_valid(lsu2dtcm_icb_cmd_valid),
+    .lsu2dtcm_icb_cmd_ready(lsu2dtcm_icb_cmd_ready),
+    .lsu2dtcm_icb_cmd_addr(lsu2dtcm_icb_cmd_addr),
+    .lsu2dtcm_icb_cmd_read(lsu2dtcm_icb_cmd_read),
+    .lsu2dtcm_icb_cmd_wdata(lsu2dtcm_icb_cmd_wdata),
+    .lsu2dtcm_icb_cmd_wmask(lsu2dtcm_icb_cmd_wmask),
+    .lsu2dtcm_icb_cmd_lock(lsu2dtcm_icb_cmd_lock_nc),
+    .lsu2dtcm_icb_cmd_excl(lsu2dtcm_icb_cmd_excl_nc),
+    .lsu2dtcm_icb_cmd_size(lsu2dtcm_icb_cmd_size_nc),
+    .lsu2dtcm_icb_rsp_valid(lsu2dtcm_icb_rsp_valid),
+    .lsu2dtcm_icb_rsp_ready(lsu2dtcm_icb_rsp_ready),
+    .lsu2dtcm_icb_rsp_err(lsu2dtcm_icb_rsp_err),
+    .lsu2dtcm_icb_rsp_excl_ok(1'b0),
+    .lsu2dtcm_icb_rsp_rdata(lsu2dtcm_icb_rsp_rdata),
+    .ppi_region_indic('h10000000),
+    .ppi_icb_enable(1'b1),
+    .ppi_icb_cmd_valid(ppi_icb_cmd_valid),
+    .ppi_icb_cmd_ready(ppi_icb_cmd_ready),
+    .ppi_icb_cmd_addr(ppi_icb_cmd_addr),
+    .ppi_icb_cmd_read(ppi_icb_cmd_read),
+    .ppi_icb_cmd_wdata(ppi_icb_cmd_wdata),
+    .ppi_icb_cmd_wmask(ppi_icb_cmd_wmask),
+    .ppi_icb_cmd_lock(ppi_icb_cmd_lock_nc),
+    .ppi_icb_cmd_excl(ppi_icb_cmd_excl_nc),
+    .ppi_icb_cmd_size(ppi_icb_cmd_size_nc),
+    .ppi_icb_cmd_burst(ppi_icb_cmd_burst_nc),
+    .ppi_icb_cmd_beat(ppi_icb_cmd_beat_nc),
+    .ppi_icb_rsp_valid(ppi_icb_rsp_valid),
+    .ppi_icb_rsp_ready(ppi_icb_rsp_ready),
+    .ppi_icb_rsp_err(ppi_icb_rsp_err),
+    .ppi_icb_rsp_excl_ok(1'b0),
+    .ppi_icb_rsp_rdata(ppi_icb_rsp_rdata),
+    .clint_region_indic('h2000000),
+    .clint_icb_enable(1'b1),
+    .clint_icb_cmd_valid(clint_icb_cmd_valid),
+    .clint_icb_cmd_ready(1'b1),
+    .clint_icb_cmd_addr(clint_icb_cmd_addr),
+    .clint_icb_cmd_read(clint_icb_cmd_read),
+    .clint_icb_cmd_wdata(clint_icb_cmd_wdata),
+    .clint_icb_cmd_wmask(clint_icb_cmd_wmask_nc),
+    .clint_icb_cmd_lock(clint_icb_cmd_lock_nc),
+    .clint_icb_cmd_excl(clint_icb_cmd_excl_nc),
+    .clint_icb_cmd_size(clint_icb_cmd_size_nc),
+    .clint_icb_cmd_burst(clint_icb_cmd_burst_nc),
+    .clint_icb_cmd_beat(clint_icb_cmd_beat_nc),
+    .clint_icb_rsp_valid(clint_rsp_valid_r),
+    .clint_icb_rsp_ready(clint_icb_rsp_ready),
+    .clint_icb_rsp_err(1'b0),
+    .clint_icb_rsp_excl_ok(1'b0),
+    .clint_icb_rsp_rdata(clint_rsp_rdata_r),
+    .plic_region_indic('hC000000),
+    .plic_icb_enable(1'b0),
+    .plic_icb_cmd_valid(plic_icb_cmd_valid_nc),
+    .plic_icb_cmd_ready(1'b1),
+    .plic_icb_cmd_addr(plic_icb_cmd_addr_nc),
+    .plic_icb_cmd_read(plic_icb_cmd_read_nc),
+    .plic_icb_cmd_wdata(plic_icb_cmd_wdata_nc),
+    .plic_icb_cmd_wmask(plic_icb_cmd_wmask_nc),
+    .plic_icb_cmd_lock(plic_icb_cmd_lock_nc),
+    .plic_icb_cmd_excl(plic_icb_cmd_excl_nc),
+    .plic_icb_cmd_size(plic_icb_cmd_size_nc),
+    .plic_icb_cmd_burst(plic_icb_cmd_burst_nc),
+    .plic_icb_cmd_beat(plic_icb_cmd_beat_nc),
+    .plic_icb_rsp_valid(1'b0),
+    .plic_icb_rsp_ready(plic_icb_rsp_ready_nc),
+    .plic_icb_rsp_err(1'b0),
+    .plic_icb_rsp_excl_ok(1'b0),
+    .plic_icb_rsp_rdata(0),
+    .fio_region_indic('h3000000),
+    .fio_icb_enable(1'b1),
+    .fio_icb_cmd_valid(fio_icb_cmd_valid),
+    .fio_icb_cmd_ready(fio_icb_cmd_ready),
+    .fio_icb_cmd_addr(fio_icb_cmd_addr),
+    .fio_icb_cmd_read(fio_icb_cmd_read),
+    .fio_icb_cmd_wdata(fio_icb_cmd_wdata),
+    .fio_icb_cmd_wmask(fio_icb_cmd_wmask),
+    .fio_icb_cmd_lock(fio_icb_cmd_lock_nc),
+    .fio_icb_cmd_excl(fio_icb_cmd_excl_nc),
+    .fio_icb_cmd_size(fio_icb_cmd_size_nc),
+    .fio_icb_cmd_burst(fio_icb_cmd_burst_nc),
+    .fio_icb_cmd_beat(fio_icb_cmd_beat_nc),
+    .fio_icb_rsp_valid(fio_icb_rsp_valid),
+    .fio_icb_rsp_ready(fio_icb_rsp_ready),
+    .fio_icb_rsp_err(fio_icb_rsp_err),
+    .fio_icb_rsp_excl_ok(1'b0),
+    .fio_icb_rsp_rdata(fio_icb_rsp_rdata),
+    .mem_icb_enable(1'b1),
+    .mem_icb_cmd_valid(mem_icb_cmd_valid),
+    .mem_icb_cmd_ready(mem_icb_cmd_ready),
+    .mem_icb_cmd_addr(mem_icb_cmd_addr),
+    .mem_icb_cmd_read(mem_icb_cmd_read),
+    .mem_icb_cmd_wdata(mem_icb_cmd_wdata),
+    .mem_icb_cmd_wmask(mem_icb_cmd_wmask),
+    .mem_icb_cmd_lock(mem_icb_cmd_lock_nc),
+    .mem_icb_cmd_excl(mem_icb_cmd_excl_nc),
+    .mem_icb_cmd_size(mem_icb_cmd_size_nc),
+    .mem_icb_cmd_burst(mem_icb_cmd_burst_nc),
+    .mem_icb_cmd_beat(mem_icb_cmd_beat_nc),
+    .mem_icb_rsp_valid(mem_icb_rsp_valid),
+    .mem_icb_rsp_ready(mem_icb_rsp_ready),
+    .mem_icb_rsp_err(mem_icb_rsp_err),
+    .mem_icb_rsp_excl_ok(1'b0),
+    .mem_icb_rsp_rdata(mem_icb_rsp_rdata),
+    .nice_mem_holdup(1'b0),
+    .nice_req_valid(nice_req_valid_nc),
+    .nice_req_ready(1'b0),
+    .nice_req_inst(nice_req_inst_nc),
+    .nice_req_rs1(nice_req_rs1_nc),
+    .nice_req_rs2(nice_req_rs2_nc),
+    .nice_rsp_multicyc_valid(1'b0),
+    .nice_rsp_multicyc_ready(nice_rsp_multicyc_ready_nc),
+    .nice_rsp_multicyc_dat(0),
+    .nice_rsp_multicyc_err(1'b0),
+    .nice_icb_cmd_valid(1'b0),
+    .nice_icb_cmd_ready(nice_icb_cmd_ready_nc),
+    .nice_icb_cmd_addr(0),
+    .nice_icb_cmd_read(1'b1),
+    .nice_icb_cmd_wdata(0),
+    .nice_icb_cmd_size(0),
+    .nice_icb_rsp_valid(nice_icb_rsp_valid_nc),
+    .nice_icb_rsp_ready(1'b1),
+    .nice_icb_rsp_rdata(nice_icb_rsp_rdata_nc),
+    .nice_icb_rsp_err(nice_icb_rsp_err_nc)
+  );
+  e203_itcm_ctrl itcm_ctrl (
+    .clk(clk),
+    .rst_n(rst_n),
+    .test_mode(1'b0),
+    .tcm_cgstop(tcm_cgstop),
+    .itcm_active(itcm_active_nc),
+    .ifu2itcm_icb_cmd_valid(ifu2itcm_icb_cmd_valid),
+    .ifu2itcm_icb_cmd_ready(ifu2itcm_icb_cmd_ready),
+    .ifu2itcm_icb_cmd_addr(ifu2itcm_icb_cmd_addr),
+    .ifu2itcm_icb_cmd_read(1'b1),
+    .ifu2itcm_icb_cmd_wdata(0),
+    .ifu2itcm_icb_cmd_wmask(0),
+    .ifu2itcm_icb_rsp_valid(ifu2itcm_icb_rsp_valid),
+    .ifu2itcm_icb_rsp_ready(ifu2itcm_icb_rsp_ready),
+    .ifu2itcm_icb_rsp_err(ifu2itcm_icb_rsp_err),
+    .ifu2itcm_icb_rsp_rdata(ifu2itcm_icb_rsp_rdata),
+    .ifu2itcm_holdup(ifu2itcm_holdup),
+    .lsu2itcm_icb_cmd_valid(lsu2itcm_icb_cmd_valid),
+    .lsu2itcm_icb_cmd_ready(lsu2itcm_icb_cmd_ready),
+    .lsu2itcm_icb_cmd_addr(lsu2itcm_icb_cmd_addr),
+    .lsu2itcm_icb_cmd_read(lsu2itcm_icb_cmd_read),
+    .lsu2itcm_icb_cmd_wdata(lsu2itcm_icb_cmd_wdata),
+    .lsu2itcm_icb_cmd_wmask(lsu2itcm_icb_cmd_wmask),
+    .lsu2itcm_icb_rsp_valid(lsu2itcm_icb_rsp_valid),
+    .lsu2itcm_icb_rsp_ready(lsu2itcm_icb_rsp_ready),
+    .lsu2itcm_icb_rsp_err(lsu2itcm_icb_rsp_err),
+    .lsu2itcm_icb_rsp_rdata(lsu2itcm_icb_rsp_rdata),
+    .ext2itcm_icb_cmd_valid(itcm_wr_en),
+    .ext2itcm_icb_cmd_ready(ext2itcm_cmd_ready_nc),
+    .ext2itcm_icb_cmd_addr(ext2itcm_cmd_addr),
+    .ext2itcm_icb_cmd_read(1'b0),
+    .ext2itcm_icb_cmd_wdata(itcm_wr_data),
+    .ext2itcm_icb_cmd_wmask(15),
+    .ext2itcm_icb_rsp_valid(ext2itcm_rsp_valid_nc),
+    .ext2itcm_icb_rsp_ready(1'b1),
+    .ext2itcm_icb_rsp_err(ext2itcm_rsp_err_nc),
+    .ext2itcm_icb_rsp_rdata(ext2itcm_rsp_rdata_nc),
+    .itcm_ram_cs(itcm_ram_cs),
+    .itcm_ram_we(itcm_ram_we),
+    .itcm_ram_addr(itcm_ram_addr),
+    .itcm_ram_wem(itcm_ram_wem),
+    .itcm_ram_din(itcm_ram_din),
+    .itcm_ram_dout(itcm_ram_dout),
+    .clk_itcm_ram(clk_itcm_ram_nc)
+  );
+  e203_itcm_ram itcm_ram (
+    .clk(clk),
+    .rst_n(rst_n),
+    .sd(1'b0),
+    .ds(1'b0),
+    .ls(1'b0),
+    .cs(itcm_ram_cs),
+    .we(itcm_ram_we),
+    .addr(itcm_ram_addr),
+    .wem(itcm_ram_wem),
+    .din(itcm_ram_din),
+    .dout(itcm_ram_dout)
+  );
+  e203_dtcm_ctrl dtcm_ctrl (
+    .clk(clk),
+    .rst_n(rst_n),
+    .test_mode(1'b0),
+    .tcm_cgstop(tcm_cgstop),
+    .dtcm_active(dtcm_active_nc),
+    .lsu2dtcm_icb_cmd_valid(lsu2dtcm_icb_cmd_valid),
+    .lsu2dtcm_icb_cmd_ready(lsu2dtcm_icb_cmd_ready),
+    .lsu2dtcm_icb_cmd_addr(lsu2dtcm_icb_cmd_addr),
+    .lsu2dtcm_icb_cmd_read(lsu2dtcm_icb_cmd_read),
+    .lsu2dtcm_icb_cmd_wdata(lsu2dtcm_icb_cmd_wdata),
+    .lsu2dtcm_icb_cmd_wmask(lsu2dtcm_icb_cmd_wmask),
+    .lsu2dtcm_icb_rsp_valid(lsu2dtcm_icb_rsp_valid),
+    .lsu2dtcm_icb_rsp_ready(lsu2dtcm_icb_rsp_ready),
+    .lsu2dtcm_icb_rsp_err(lsu2dtcm_icb_rsp_err),
+    .lsu2dtcm_icb_rsp_rdata(lsu2dtcm_icb_rsp_rdata),
+    .ext2dtcm_icb_cmd_valid(1'b0),
+    .ext2dtcm_icb_cmd_ready(ext2dtcm_cmd_ready_nc),
+    .ext2dtcm_icb_cmd_addr(0),
+    .ext2dtcm_icb_cmd_read(1'b1),
+    .ext2dtcm_icb_cmd_wdata(0),
+    .ext2dtcm_icb_cmd_wmask(0),
+    .ext2dtcm_icb_rsp_valid(ext2dtcm_rsp_valid_nc),
+    .ext2dtcm_icb_rsp_ready(1'b1),
+    .ext2dtcm_icb_rsp_err(ext2dtcm_rsp_err_nc),
+    .ext2dtcm_icb_rsp_rdata(ext2dtcm_rsp_rdata_nc),
+    .dtcm_ram_cs(dtcm_ram_cs),
+    .dtcm_ram_we(dtcm_ram_we),
+    .dtcm_ram_addr(dtcm_ram_addr),
+    .dtcm_ram_wem(dtcm_ram_wem),
+    .dtcm_ram_din(dtcm_ram_din),
+    .dtcm_ram_dout(dtcm_ram_dout),
+    .clk_dtcm_ram(clk_dtcm_ram_nc)
+  );
+  e203_dtcm_ram dtcm_ram (
+    .clk(clk),
+    .rst_n(rst_n),
+    .sd(1'b0),
+    .ds(1'b0),
+    .ls(1'b0),
+    .cs(dtcm_ram_cs),
+    .we(dtcm_ram_we),
+    .addr(dtcm_ram_addr),
+    .wem(dtcm_ram_wem),
+    .din(dtcm_ram_din),
+    .dout(dtcm_ram_dout)
+  );
+  e203_clint_timer timer (
+    .clk(clk),
+    .rst(timer_rst),
+    .reg_addr(clint_reg_addr),
+    .reg_wdata(clint_icb_cmd_wdata),
+    .reg_wen(clint_reg_wen),
+    .reg_rdata(clint_reg_rdata),
+    .tmr_irq(tmr_irq_w)
+  );
+  e203_icb_arbt arbt (
+    .clk(clk),
+    .rst_n(rst_n),
+    .m0_cmd_valid(mem_icb_cmd_valid),
+    .m0_cmd_addr(mem_icb_cmd_addr),
+    .m0_cmd_wdata(mem_icb_cmd_wdata),
+    .m0_cmd_wmask(mem_icb_cmd_wmask),
+    .m0_cmd_read(mem_icb_cmd_read),
+    .m0_cmd_ready(mem_icb_cmd_ready),
+    .m0_rsp_valid(mem_icb_rsp_valid),
+    .m0_rsp_ready(mem_icb_rsp_ready),
+    .m0_rsp_rdata(mem_icb_rsp_rdata),
+    .m0_rsp_err(mem_icb_rsp_err),
+    .m1_cmd_valid(ext_cmd_valid),
+    .m1_cmd_addr(ext_cmd_addr),
+    .m1_cmd_wdata(ext_cmd_wdata),
+    .m1_cmd_wmask(ext_cmd_wmask),
+    .m1_cmd_read(ext_cmd_read),
+    .m1_cmd_ready(ext_cmd_ready),
+    .m1_rsp_valid(ext_rsp_valid),
+    .m1_rsp_ready(1'b1),
+    .m1_rsp_rdata(ext_rsp_rdata),
+    .m1_rsp_err(ext_rsp_err),
+    .s_cmd_valid(arbt_s_cmd_valid),
+    .s_cmd_ready(sram_ready),
+    .s_cmd_addr(arbt_s_cmd_addr),
+    .s_cmd_wdata(arbt_s_cmd_wdata),
+    .s_cmd_wmask(arbt_s_cmd_wmask),
+    .s_cmd_read(arbt_s_cmd_read),
+    .s_rsp_valid(sram_rsp_valid),
+    .s_rsp_ready(arbt_s_rsp_ready),
+    .s_rsp_rdata(sram_rsp_rdata),
+    .s_rsp_err(sram_rsp_err)
+  );
+  e203_sram_ctrl sram (
+    .clk(clk),
+    .rst_n(rst_n),
+    .icb_cmd_valid(arbt_s_cmd_valid),
     .icb_cmd_ready(sram_ready),
-    .icb_cmd_addr(bus_cmd_addr),
-    .icb_cmd_wdata(bus_cmd_wdata),
-    .icb_cmd_wmask(bus_cmd_wmask),
-    .icb_cmd_read(bus_cmd_read),
+    .icb_cmd_addr(arbt_s_cmd_addr),
+    .icb_cmd_wdata(arbt_s_cmd_wdata),
+    .icb_cmd_wmask(arbt_s_cmd_wmask),
+    .icb_cmd_read(arbt_s_cmd_read),
     .icb_rsp_valid(sram_rsp_valid),
-    .icb_rsp_ready(bus_rsp_ready),
+    .icb_rsp_ready(arbt_s_rsp_ready),
     .icb_rsp_rdata(sram_rsp_rdata),
     .icb_rsp_err(sram_rsp_err)
   );
-  // ══════════════════════════════════════════════════════════════
-  // Fast I/O
-  // ══════════════════════════════════════════════════════════════
-  logic fio_ready;
-  logic fio_rsp_valid;
-  logic [32-1:0] fio_rsp_rdata;
-  logic fio_rsp_err;
-  logic [32-1:0] fio_out_0_w;
-  logic [32-1:0] fio_out_1_w;
-  logic [32-1:0] fio_out_2_w;
-  logic [32-1:0] fio_out_3_w;
-  Fio fio (
+  e203_fio fio (
     .clk(clk),
     .rst_n(rst_n),
-    .icb_cmd_valid((bus_cmd_valid & sel_fio)),
-    .icb_cmd_ready(fio_ready),
-    .icb_cmd_addr(bus_cmd_addr),
-    .icb_cmd_wdata(bus_cmd_wdata),
-    .icb_cmd_wmask(bus_cmd_wmask),
-    .icb_cmd_read(bus_cmd_read),
-    .icb_rsp_valid(fio_rsp_valid),
-    .icb_rsp_ready(bus_rsp_ready),
-    .icb_rsp_rdata(fio_rsp_rdata),
-    .icb_rsp_err(fio_rsp_err),
+    .icb_cmd_valid(fio_icb_cmd_valid),
+    .icb_cmd_ready(fio_icb_cmd_ready),
+    .icb_cmd_addr(fio_icb_cmd_addr),
+    .icb_cmd_wdata(fio_icb_cmd_wdata),
+    .icb_cmd_wmask(fio_icb_cmd_wmask),
+    .icb_cmd_read(fio_icb_cmd_read),
+    .icb_rsp_valid(fio_icb_rsp_valid),
+    .icb_rsp_ready(fio_icb_rsp_ready),
+    .icb_rsp_rdata(fio_icb_rsp_rdata),
+    .icb_rsp_err(fio_icb_rsp_err),
     .fio_in_0(fio_in_0),
     .fio_in_1(fio_in_1),
     .fio_out_0(fio_out_0_w),
@@ -188,46 +658,19 @@ module SocTop (
     .fio_out_2(fio_out_2_w),
     .fio_out_3(fio_out_3_w)
   );
-  // ══════════════════════════════════════════════════════════════
-  // PPI: ICB → APB bridge with 4-slave address decode
-  // ══════════════════════════════════════════════════════════════
-  logic ppi_ready;
-  logic ppi_rsp_valid;
-  logic [32-1:0] ppi_rsp_rdata;
-  logic ppi_rsp_err;
-  logic gpio_psel;
-  logic gpio_penable;
-  logic [32-1:0] gpio_paddr;
-  logic [32-1:0] gpio_pwdata;
-  logic gpio_pwrite;
-  logic uart_psel;
-  logic uart_penable;
-  logic [32-1:0] uart_paddr;
-  logic [32-1:0] uart_pwdata;
-  logic uart_pwrite;
-  logic spi_psel;
-  logic spi_penable;
-  logic [32-1:0] spi_paddr;
-  logic [32-1:0] spi_pwdata;
-  logic spi_pwrite;
-  logic apb3_psel_w;
-  logic apb3_penable_w;
-  logic [32-1:0] apb3_paddr_w;
-  logic [32-1:0] apb3_pwdata_w;
-  logic apb3_pwrite_w;
-  Ppi ppi (
+  e203_ppi ppi (
     .clk(clk),
     .rst_n(rst_n),
-    .icb_cmd_valid((bus_cmd_valid & sel_ppi)),
-    .icb_cmd_ready(ppi_ready),
-    .icb_cmd_addr(bus_cmd_addr),
-    .icb_cmd_wdata(bus_cmd_wdata),
-    .icb_cmd_wmask(bus_cmd_wmask),
-    .icb_cmd_read(bus_cmd_read),
-    .icb_rsp_valid(ppi_rsp_valid),
-    .icb_rsp_ready(bus_rsp_ready),
-    .icb_rsp_rdata(ppi_rsp_rdata),
-    .icb_rsp_err(ppi_rsp_err),
+    .icb_cmd_valid(ppi_icb_cmd_valid),
+    .icb_cmd_ready(ppi_icb_cmd_ready),
+    .icb_cmd_addr(ppi_icb_cmd_addr),
+    .icb_cmd_wdata(ppi_icb_cmd_wdata),
+    .icb_cmd_wmask(ppi_icb_cmd_wmask),
+    .icb_cmd_read(ppi_icb_cmd_read),
+    .icb_rsp_valid(ppi_icb_rsp_valid),
+    .icb_rsp_ready(ppi_icb_rsp_ready),
+    .icb_rsp_rdata(ppi_icb_rsp_rdata),
+    .icb_rsp_err(ppi_icb_rsp_err),
     .apb0_psel(gpio_psel),
     .apb0_penable(gpio_penable),
     .apb0_paddr(gpio_paddr),
@@ -257,15 +700,7 @@ module SocTop (
     .apb3_prdata(0),
     .apb3_pready(1'b1)
   );
-  // ══════════════════════════════════════════════════════════════
-  // GPIO Peripheral
-  // ══════════════════════════════════════════════════════════════
-  logic [32-1:0] gpio_prdata_w;
-  logic gpio_pready_w;
-  logic [32-1:0] gpio_out_w;
-  logic [32-1:0] gpio_oe_w;
-  logic gpio_irq_w;
-  Gpio gpio_p (
+  e203_gpio gpio_p (
     .clk(clk),
     .rst_n(rst_n),
     .psel(gpio_psel),
@@ -280,14 +715,7 @@ module SocTop (
     .gpio_oe(gpio_oe_w),
     .gpio_irq(gpio_irq_w)
   );
-  // ══════════════════════════════════════════════════════════════
-  // UART Peripheral
-  // ══════════════════════════════════════════════════════════════
-  logic [32-1:0] uart_prdata_w;
-  logic uart_pready_w;
-  logic uart_tx_w;
-  logic uart_irq_w;
-  Uart uart_p (
+  e203_uart uart_p (
     .clk(clk),
     .rst_n(rst_n),
     .psel(uart_psel),
@@ -301,16 +729,7 @@ module SocTop (
     .uart_rx(uart_rx),
     .uart_irq(uart_irq_w)
   );
-  // ══════════════════════════════════════════════════════════════
-  // SPI Peripheral
-  // ══════════════════════════════════════════════════════════════
-  logic [32-1:0] spi_prdata_w;
-  logic spi_pready_w;
-  logic spi_sclk_w;
-  logic spi_mosi_w;
-  logic spi_cs_n_w;
-  logic spi_irq_w;
-  Spi spi_p (
+  e203_spi spi_p (
     .clk(clk),
     .rst_n(rst_n),
     .psel(spi_psel),
@@ -326,15 +745,7 @@ module SocTop (
     .spi_cs_n(spi_cs_n_w),
     .spi_irq(spi_irq_w)
   );
-  // ══════════════════════════════════════════════════════════════
-  // Interrupt Controller
-  // ══════════════════════════════════════════════════════════════
-  logic irq_req_w;
-  logic [32-1:0] irq_cause_w;
-  logic irq_mip_meip;
-  logic irq_mip_mtip;
-  logic irq_mip_msip;
-  IrqCtrl irq (
+  e203_irq_ctrl irq (
     .clk(clk),
     .rst_n(rst_n),
     .ext_irq_i(gpio_irq_w),
@@ -345,24 +756,14 @@ module SocTop (
     .mie_mtie(1'b1),
     .mie_msie(1'b1),
     .pipe_flush_ack(1'b0),
-    .commit_valid(core_commit_w),
+    .commit_valid(1'b0),
     .irq_req(irq_req_w),
     .irq_cause(irq_cause_w),
     .mip_meip(irq_mip_meip),
     .mip_mtip(irq_mip_mtip),
     .mip_msip(irq_mip_msip)
   );
-  // ══════════════════════════════════════════════════════════════
-  // Debug Module
-  // ══════════════════════════════════════════════════════════════
-  logic [32-1:0] dbg_prdata_w;
-  logic dbg_pready_w;
-  logic dbg_halt_req;
-  logic dbg_resume_req;
-  logic [16-1:0] dbg_reg_addr_w;
-  logic [32-1:0] dbg_reg_wdata_w;
-  logic dbg_reg_wen_w;
-  DebugModule dbg (
+  e203_debug_module dbg (
     .clk(clk),
     .rst_n(rst_n),
     .psel(dbg_psel),
@@ -381,52 +782,18 @@ module SocTop (
     .dbg_reg_wen(dbg_reg_wen_w),
     .dbg_reg_rdata(0)
   );
-  // ══════════════════════════════════════════════════════════════
-  // Bus response mux
-  // ══════════════════════════════════════════════════════════════
-  always_comb begin
-    if (sel_sram) begin
-      bus_cmd_ready = sram_ready;
-      bus_rsp_valid = sram_rsp_valid;
-      bus_rsp_rdata = sram_rsp_rdata;
-      bus_rsp_err = sram_rsp_err;
-    end else if (sel_ppi) begin
-      bus_cmd_ready = ppi_ready;
-      bus_rsp_valid = ppi_rsp_valid;
-      bus_rsp_rdata = ppi_rsp_rdata;
-      bus_rsp_err = ppi_rsp_err;
-    end else if (sel_fio) begin
-      bus_cmd_ready = fio_ready;
-      bus_rsp_valid = fio_rsp_valid;
-      bus_rsp_rdata = fio_rsp_rdata;
-      bus_rsp_err = fio_rsp_err;
-    end else begin
-      bus_cmd_ready = 1'b1;
-      bus_rsp_valid = 1'b0;
-      bus_rsp_rdata = 0;
-      bus_rsp_err = 1'b1;
-    end
-    ext_cmd_ready = arbt_m0_ready;
-    ext_rsp_valid = arbt_m0_rsp_valid;
-    ext_rsp_rdata = arbt_m0_rsp_rdata;
-    ext_rsp_err = arbt_m0_rsp_err;
-    core_commit = core_commit_w;
-    core_instr = core_instr_w;
-    core_pc = core_pc_w;
-    core_valid = core_valid_w;
-    gpio_out = gpio_out_w;
-    gpio_oe = gpio_oe_w;
-    gpio_irq = gpio_irq_w;
-    uart_tx = uart_tx_w;
-    uart_irq = uart_irq_w;
-    spi_sclk = spi_sclk_w;
-    spi_mosi = spi_mosi_w;
-    spi_cs_n = spi_cs_n_w;
-    spi_irq = spi_irq_w;
-    fio_out_0 = fio_out_0_w;
-    fio_out_1 = fio_out_1_w;
-    dbg_prdata = dbg_prdata_w;
-  end
+  assign gpio_out = gpio_out_w;
+  assign gpio_oe = gpio_oe_w;
+  assign gpio_irq = gpio_irq_w;
+  assign uart_tx = uart_tx_w;
+  assign uart_irq = uart_irq_w;
+  assign spi_sclk = spi_sclk_w;
+  assign spi_mosi = spi_mosi_w;
+  assign spi_cs_n = spi_cs_n_w;
+  assign spi_irq = spi_irq_w;
+  assign fio_out_0 = fio_out_0_w;
+  assign fio_out_1 = fio_out_1_w;
+  assign dbg_prdata = dbg_prdata_w;
 
 endmodule
 


### PR DESCRIPTION
## Summary

Fixes #798 by rewiring, per the maintainer's call on the issue, the four first-generation integration wrappers against the current (post-2026-05-03) leaf-module surfaces — the real ICB fabric — instead of deleting them.

- **e203_ifu_top / e203_exu_top** — rebuilt as real-fabric integrations of the current leaves, using the same wiring proven in `e203_ifu.arch` / `e203_exu.arch` (the reference RTL's own hierarchy levels; the old wrappers connected ports that no longer exist).
- **e203_core_top** — rebuilt to mirror reference `e203_core.v`: `ifu_top` + `exu_top` + `e203_lsu` + `e203_biu` wired through the real AGU/LSU/IFU ICB fabric, exporting the ITCM/DTCM/PPI/CLINT/PLIC/FIO/MEM ICBs. Width seams bridged explicitly (`agu_icb_cmd_itag` Bool→UInt<1>, `lsu_o_wbck_itag` UInt<1>→UInt<5>).
- **e203_soc_top** — rebuilt on the new core: `e203_itcm_ctrl`+`e203_itcm_ram` (TB loader enters via the ext2itcm ICB), `e203_dtcm_ctrl`+`e203_dtcm_ram`, CLINT timer behind an ICB→register adapter, and the existing (already-valid) peripheral fabric now driven by the core's dedicated ICBs: PPI→APB bridge (GPIO/UART/SPI), FIO, MEM→arbiter→SRAM, IRQ ctrl, debug module.

## Drive-by fix: latent undefined identifiers in e203_biu

Verilator lint of the emitted SV surfaced that `e203_biu.arch`'s response mux referenced five undeclared `sel_*_r` names (the declared registers are `tgt_*_r`). `arch check` accepts undefined value identifiers (#748), so this never failed before — the emitted SV was un-elaboratable. Renamed to the declared registers. This is fresh evidence for #748's severity: the corpus carried an un-lintable artifact for ~3 months.

## Notes

- The CLINT timer is the one `Reset<Sync, High>` island in an Async-Low SoC; RDC phase 2d rejects any non-identifier Reset drive, so it gets a dedicated `timer_rst` input pin.
- The 4 `*_tb.cpp` companions remain dead PascalCase-header testbenches — that's #799's separate corpus decision, untouched here.
- Regenerated the five `.sv` artifacts with the current emitter (formatting drift from the older emitter's output is expected; precedent 46db3f6d).

## Verification

- `arch check` over the whole 62-unit `tests/e203` group: clean (this restores directory grouping in `tools/run_arch_regression.py`, ending per-file fallback for the directory).
- `arch build` + full-hierarchy Verilator 5.048 `--lint-only` of `e203_soc_top` (32 modules): no errors; remaining 4 warnings pre-date this change (2 WIDTHEXPAND in `e203_exu_decode`, 2 UNOPTFLAT on the known apparent ifetch↔ift2icb loop, same topology as `e203_ifu.arch`).
- Long verification (regression harness over tests/e203) running post-open; follow-ups will be pushed if it surfaces anything.

closes #798

🤖 Generated with [Claude Code](https://claude.com/claude-code)