### PR TITLE
fix(sim): lower runtime-bound ranged part-selects correctly (closes #847)

### DIFF
--- a/src/sim_codegen/expr_codegen.rs
+++ b/src/sim_codegen/expr_codegen.rs
@@ -42,6 +42,126 @@ pub(super) fn cast_to_signed_bits(expr: &str, bits: u32) -> String {
     }
 }
 
+/// Structural equality over the small expression grammar that appears in
+/// bit-slice bounds (idents, integer literals, arithmetic over them).
+/// Conservative: false on anything unrecognized.
+fn slice_bound_expr_eq(a: &Expr, b: &Expr) -> bool {
+    fn lit_u64(l: &LitKind) -> Option<u64> {
+        match l {
+            LitKind::Dec(v) | LitKind::Hex(v) | LitKind::Bin(v) => Some(*v),
+            LitKind::Sized(_, v) | LitKind::ParamSized(_, v) => Some(*v),
+            LitKind::Float(_) | LitKind::TypedFloat(_, _) => None,
+        }
+    }
+    match (&a.kind, &b.kind) {
+        (ExprKind::Ident(x), ExprKind::Ident(y)) => x == y,
+        (ExprKind::Literal(x), ExprKind::Literal(y)) => {
+            matches!((lit_u64(x), lit_u64(y)), (Some(u), Some(v)) if u == v)
+        }
+        (ExprKind::Binary(o1, l1, r1), ExprKind::Binary(o2, l2, r2)) => {
+            o1 == o2 && slice_bound_expr_eq(l1, l2) && slice_bound_expr_eq(r1, r2)
+        }
+        (ExprKind::Unary(o1, e1), ExprKind::Unary(o2, e2)) => {
+            o1 == o2 && slice_bound_expr_eq(e1, e2)
+        }
+        (ExprKind::Clog2(x), ExprKind::Clog2(y)) => slice_bound_expr_eq(x, y),
+        _ => false,
+    }
+}
+
+/// Constant width of a `[hi:lo]` slice when derivable (arch#847):
+/// - both bounds const-fold (params included) → `hi - lo + 1`
+/// - `hi` ≡ `lo` structurally → 1 (e.g. `wem[i:i]` in a `for`)
+/// - `hi` = `lo + k` / `k + lo` with `k` const → `k + 1`
+///   (e.g. `din[i*8+7 : i*8]`)
+/// - `lo` = `hi - k` with `k` const → `k + 1`
+/// Returns None when the width genuinely depends on a runtime value
+/// (e.g. `d[i:0]`) — callers fall back to a runtime mask.
+pub(super) fn try_slice_const_width(hi: &Expr, lo: &Expr, ctx: &Ctx) -> Option<u32> {
+    if let (Some(h), Some(l)) = (
+        try_eval_const_expr_with_params(hi, ctx.params),
+        try_eval_const_expr_with_params(lo, ctx.params),
+    ) {
+        return h.checked_sub(l).map(|d| d as u32 + 1);
+    }
+    if slice_bound_expr_eq(hi, lo) {
+        return Some(1);
+    }
+    if let ExprKind::Binary(BinOp::Add, a, b) = &hi.kind {
+        if slice_bound_expr_eq(a, lo) {
+            if let Some(k) = try_eval_const_expr_with_params(b, ctx.params) {
+                return Some(k as u32 + 1);
+            }
+        }
+        if slice_bound_expr_eq(b, lo) {
+            if let Some(k) = try_eval_const_expr_with_params(a, ctx.params) {
+                return Some(k as u32 + 1);
+            }
+        }
+    }
+    if let ExprKind::Binary(BinOp::Sub, a, b) = &lo.kind {
+        if slice_bound_expr_eq(a, hi) {
+            if let Some(k) = try_eval_const_expr_with_params(b, ctx.params) {
+                return Some(k as u32 + 1);
+            }
+        }
+    }
+    None
+}
+
+/// Emit a bit-slice read whose bounds are not compile-time foldable
+/// (e.g. loop-variable slices `wem[i:i]`, `din[i*8+7:i*8]` inside a
+/// `for`). The shift amount is the runtime lo expression; the mask comes
+/// from the structural slice width when derivable, else the runtime
+/// `_arch_slice_mask` helper. arch#847: the old path const-folded these
+/// through `eval_width_in`, whose 32-default emitted a fixed `>> 32`
+/// with a 1-bit mask.
+fn runtime_bit_slice(b: &str, base: &Expr, hi: &Expr, lo: &Expr, ctx: &Ctx) -> String {
+    let hi_cpp = cpp_expr(hi, ctx);
+    let lo_cpp = cpp_expr(lo, ctx);
+    let width = try_slice_const_width(hi, lo, ctx);
+    let base_w = infer_expr_width(base, ctx);
+    // Runtime bounds check on the MSB — typecheck can only verify
+    // compile-time bounds, mirroring the variable part-select policy.
+    let bchk = if base_w > 0 {
+        let loc = base_ident_name(base).unwrap_or("<slice>");
+        format!("_ARCH_BCHK(({hi_cpp}), {base_w}, \"{loc}[hi:lo]\"), ")
+    } else {
+        String::new()
+    };
+    let core = if base_w > 128 {
+        format!("_arch_vw_bits({b}.data(), ({hi_cpp}), ({lo_cpp}))")
+    } else if base_w > 64 {
+        match width {
+            Some(w) => {
+                let mask = if w >= 64 { u64::MAX } else { (1u64 << w) - 1 };
+                format!(
+                    "({})(((_arch_u128)({b}) >> ({lo_cpp})) & (_arch_u128)0x{mask:X}ULL)",
+                    cpp_uint(w)
+                )
+            }
+            None => format!(
+                "(uint64_t)(((_arch_u128)({b}) >> ({lo_cpp})) & (_arch_u128)_arch_slice_mask(({hi_cpp}), ({lo_cpp})))"
+            ),
+        }
+    } else {
+        match width {
+            Some(w) => {
+                let mask = if w >= 64 { u64::MAX } else { (1u64 << w) - 1 };
+                format!("((({b}) >> ({lo_cpp})) & 0x{mask:X}ULL)")
+            }
+            None => {
+                format!("((({b}) >> ({lo_cpp})) & _arch_slice_mask(({hi_cpp}), ({lo_cpp})))")
+            }
+        }
+    };
+    if bchk.is_empty() {
+        core
+    } else {
+        format!("({bchk}{core})")
+    }
+}
+
 /// Bit-range extraction from a narrow value: `(expr >> lo) & mask`.
 pub(super) fn bit_range(expr: &str, hi: u32, lo: u32) -> String {
     let width = hi - lo + 1;
@@ -460,9 +580,14 @@ pub(super) fn infer_expr_width(expr: &Expr, ctx: &Ctx) -> u32 {
             }
         }
         ExprKind::BitSlice(_, hi, lo) => {
-            let h = eval_width_in(hi, ctx);
-            let l = eval_width_in(lo, ctx);
-            h - l + 1
+            // Structural width first (handles runtime bounds like
+            // `din[i*8+7:i*8]` → 8 — arch#847); legacy 32-default
+            // fallback for shapes it can't classify.
+            try_slice_const_width(hi, lo, ctx).unwrap_or_else(|| {
+                let h = eval_width_in(hi, ctx);
+                let l = eval_width_in(lo, ctx);
+                h - l + 1
+            })
         }
         ExprKind::PartSelect(_, _, width, _) => eval_width_in(width, ctx),
         ExprKind::Cast(_, ty) => match ty.as_ref() {
@@ -1210,8 +1335,14 @@ pub(super) fn cpp_expr_inner(expr: &Expr, ctx: &Ctx, is_lhs: bool) -> String {
 
         ExprKind::BitSlice(base, hi, lo) => {
             let b = cpp_expr(base, ctx);
-            let h = eval_width_in(hi, ctx);
-            let l = eval_width_in(lo, ctx);
+            let (Some(h), Some(l)) = (
+                try_eval_const_expr_with_params(hi, ctx.params),
+                try_eval_const_expr_with_params(lo, ctx.params),
+            ) else {
+                // Runtime bounds (loop-var slices) — arch#847.
+                return runtime_bit_slice(&b, base, hi, lo, ctx);
+            };
+            let (h, l) = (h as u32, l as u32);
             let base_w = infer_expr_width(base, ctx);
             // Static slice: hi/lo are compile-time. Bounds checked by typecheck.
             if base_w > 128 {

--- a/src/sim_codegen/pybind.rs
+++ b/src/sim_codegen/pybind.rs
@@ -845,6 +845,14 @@ static inline uint64_t _arch_vw_bits(const uint32_t* data, uint32_t hi, uint32_t
     return v & mask;
 }
 
+/// Mask covering bits [hi:lo] of a <=64-bit value. Used by runtime-bound
+/// bit-slices (arch#847) when the slice width itself is not compile-time
+/// derivable.
+static inline uint64_t _arch_slice_mask(uint64_t hi, uint64_t lo) {
+    uint64_t w = hi - lo + 1;
+    return (w >= 64) ? ~0ULL : ((1ULL << w) - 1ULL);
+}
+
 /// Ceiling log2 helper.
 static inline uint32_t _arch_clog2(uint64_t v) {
     if (v <= 1) return 1;

--- a/src/sim_codegen/stmt_codegen.rs
+++ b/src/sim_codegen/stmt_codegen.rs
@@ -46,6 +46,24 @@ pub(super) fn assigned_base_ident(expr: &Expr) -> Option<&str> {
     }
 }
 
+/// Width of a bit-slice-assignment base. `infer_expr_width`'s Index arm
+/// divides the widths-map entry by the element count, but `build_widths`
+/// registers Vec-typed regs/ports with the scalar default (32), so a
+/// Vec-element base (`mem[addr][hi:lo]`) computes to 0 and the RMW arm
+/// never fires (arch#847). Resolve the element width from the declared
+/// Vec type instead.
+fn slice_lhs_base_width(base: &Expr, ctx: &Ctx) -> u32 {
+    if let ExprKind::Index(inner, _) = &base.kind {
+        if let ExprKind::Ident(name) = &inner.kind {
+            if let Some(TypeExpr::Vec(elem, _)) = ctx.decl_types.and_then(|m| m.get(name.as_str()))
+            {
+                return type_bits_te_with_params(elem, ctx.params);
+            }
+        }
+    }
+    infer_expr_width(base, ctx)
+}
+
 pub(super) fn emit_vinit_mark_for_target(
     target: &Expr,
     ctx: &Ctx,
@@ -151,14 +169,17 @@ pub(super) fn emit_stmt(stmt: &Stmt, ctx: &Ctx, out: &mut String, indent: usize,
                     }
                 }
             }
-            // Bit-slice LHS: name[hi:lo] = val. Lower to mask-and-OR rather
-            // than the read-side `((name >> lo) & mask)` (an rvalue — gcc /
-            // clang reject as "expression is not assignable"). Only the
+            // Bit-slice LHS: name[hi:lo] = val (or name[idx][hi:lo] for a
+            // Vec-element base). Lower to mask-and-OR (read-modify-write)
+            // rather than the read-side `((name >> lo) & mask)` (an rvalue —
+            // gcc/clang reject as "expression is not assignable"). Only the
             // narrow scalar and Vec-element base cases are handled here;
             // wider-than-64 bases keep the generic path and would need their
-            // own arms.
+            // own arms. Slice bounds may be runtime expressions (loop vars,
+            // arch#847): the shift is emitted symbolically and the mask
+            // comes from the structural slice width.
             if let ExprKind::BitSlice(base, hi_e, lo_e) = &a.target.kind {
-                let base_w = infer_expr_width(base, ctx);
+                let base_w = slice_lhs_base_width(base, ctx);
                 if base_w > 0 && base_w <= 64 {
                     let resolved_base = match &base.kind {
                         ExprKind::Ident(base_name) => ctx.resolve_name(base_name, is_seq),
@@ -166,19 +187,46 @@ pub(super) fn emit_stmt(stmt: &Stmt, ctx: &Ctx, out: &mut String, indent: usize,
                         _ => String::new(),
                     };
                     if !resolved_base.is_empty() {
-                        let hi = eval_width_in(hi_e, ctx);
-                        let lo = eval_width_in(lo_e, ctx);
-                        let width = hi - lo + 1;
-                        let val_mask: u64 = if width >= 64 {
-                            u64::MAX
-                        } else {
-                            (1u64 << width) - 1
+                        let lo_str = match try_eval_const_expr_with_params(lo_e, ctx.params) {
+                            Some(v) => v.to_string(),
+                            None => format!("({})", cpp_expr(lo_e, ctx)),
                         };
+                        // Runtime-bound slices can't be verified by typecheck —
+                        // abort on an out-of-range MSB like every other
+                        // runtime access.
+                        let hi_is_const =
+                            try_eval_const_expr_with_params(hi_e, ctx.params).is_some();
+                        if !hi_is_const {
+                            let hi_cpp = cpp_expr(hi_e, ctx);
+                            let loc = assigned_base_ident(&a.target).unwrap_or("<slice>");
+                            out.push_str(&format!(
+                                "{}_ARCH_BCHK(({hi_cpp}), {base_w}, \"{loc}[hi:lo]\");\n",
+                                ind(indent)
+                            ));
+                        }
                         let rhs = cpp_expr(&a.value, ctx);
-                        out.push_str(&format!(
-                            "{}{resolved_base} = ({resolved_base} & ~(uint64_t(0x{val_mask:X}ULL) << {lo})) | ((uint64_t(({rhs}) & 0x{val_mask:X}ULL)) << {lo});\n",
-                            ind(indent)
-                        ));
+                        match try_slice_const_width(hi_e, lo_e, ctx) {
+                            Some(width) => {
+                                let val_mask: u64 = if width >= 64 {
+                                    u64::MAX
+                                } else {
+                                    (1u64 << width) - 1
+                                };
+                                out.push_str(&format!(
+                                    "{}{resolved_base} = ({resolved_base} & ~(uint64_t(0x{val_mask:X}ULL) << {lo_str})) | ((uint64_t(({rhs}) & 0x{val_mask:X}ULL)) << {lo_str});\n",
+                                    ind(indent)
+                                ));
+                            }
+                            None => {
+                                // Width itself depends on a runtime value:
+                                // compute the mask at runtime.
+                                let hi_cpp = cpp_expr(hi_e, ctx);
+                                out.push_str(&format!(
+                                    "{}{resolved_base} = ({resolved_base} & ~(_arch_slice_mask(({hi_cpp}), {lo_str}) << {lo_str})) | ((uint64_t({rhs}) & _arch_slice_mask(({hi_cpp}), {lo_str})) << {lo_str});\n",
+                                    ind(indent)
+                                ));
+                            }
+                        }
                         if is_seq {
                             emit_vinit_mark_for_target(&a.target, ctx, out, indent);
                         }

--- a/tests/arch_sim_manifest.json
+++ b/tests/arch_sim_manifest.json
@@ -74,6 +74,15 @@
       ]
     },
     {
+      "name": "sim_ranged_slice_regression",
+      "arch_files": [
+        "tests/sim_ranged_slice_regression.arch"
+      ],
+      "tb_files": [
+        "tests/sim_ranged_slice_regression_tb.cpp"
+      ]
+    },
+    {
       "name": "thread__basic_thread",
       "arch_files": [
         "tests/thread/basic_thread.arch"

--- a/tests/sim_ranged_slice_regression.arch
+++ b/tests/sim_ranged_slice_regression.arch
@@ -1,0 +1,53 @@
+// Regression test for arch#847: seq assignment to a ranged part-select
+// with runtime (loop-variable) slice bounds.
+//
+// Pre-fix: the sim C++ emitter const-folded slice bounds through
+// `eval_width_in`, whose 32-default turned every runtime bound into a
+// literal 32. Three symptoms on `mem[addr][(i*8+7):(i*8)] <= din[...]`
+// inside `for i in 0..3` with `if wem[i:i]`:
+//   1. the LHS was emitted as a shift-and-mask READ expression (an
+//      rvalue — "expression is not assignable" from gcc/clang),
+//   2. the lane mask was 1 bit instead of the 8-bit slice width,
+//   3. the `wem[i:i]` condition shifted by 32 instead of `i`.
+// Distilled from tests/e203/e203_itcm_ram.arch (found during PR #843's
+// long verify).
+//
+// Post-fix: the LHS lowers to read-modify-write on the next-cycle
+// shadow with a structural 8-bit mask and a symbolic `i*8` shift; the
+// RHS/condition slices shift by their runtime bound.
+
+module sim_ranged_slice_regression
+  port clk:   in Clock<SysDomain>;
+  port rst_n: in Reset<Async, Low>;
+
+  port cs:   in Bool;
+  port we:   in Bool;
+  port addr: in UInt<3>;
+  port wem:  in UInt<4>;
+  port din:  in UInt<32>;
+  port dout: out UInt<32>;
+
+  reg mem: Vec<UInt<32>, 8> reset none;
+  reg addr_r: UInt<3> reset none;
+
+  default seq on clk rising;
+
+  seq
+    // Read: latch address when cs=1 and we=0
+    if cs & (~we)
+      addr_r <= addr;
+    end if
+
+    // Write: byte-masked when cs=1 and we=1
+    if cs & we
+      for i in 0..3
+        if wem[i:i]
+          mem[addr][(i * 8 + 7):(i * 8)] <= din[(i * 8 + 7):(i * 8)];
+        end if
+      end for
+    end if
+  end seq
+
+  // Output is combinational from registered address
+  let dout = mem[addr_r];
+end module sim_ranged_slice_regression

--- a/tests/sim_ranged_slice_regression_tb.cpp
+++ b/tests/sim_ranged_slice_regression_tb.cpp
@@ -1,0 +1,52 @@
+// arch#847 regression: byte-masked write through runtime-bound ranged
+// part-selects (`mem[addr][(i*8+7):(i*8)] <= din[...]` under
+// `if wem[i:i]`) must update exactly the masked byte lanes.
+#include "Vsim_ranged_slice_regression.h"
+#include <cstdio>
+static Vsim_ranged_slice_regression dut;
+static int pass = 0, fail = 0;
+#define CHECK(c, m, ...) do { if (c) { printf("  PASS: " m "\n", ##__VA_ARGS__); ++pass; } \
+                              else  { printf("  FAIL: " m "\n", ##__VA_ARGS__); ++fail; } } while (0)
+
+static void tick() {
+    dut.clk = 0; dut.eval();
+    dut.clk = 1; dut.eval();
+}
+
+int main() {
+    dut.clk = 0; dut.rst_n = 1;
+    dut.cs = 0; dut.we = 0; dut.addr = 0; dut.wem = 0; dut.din = 0;
+    dut.eval();
+
+    // Full-mask write of a distinctive pattern to addr 5.
+    dut.cs = 1; dut.we = 1; dut.addr = 5; dut.wem = 0xF;
+    dut.din = 0x11223344u;
+    tick();
+
+    // Byte-masked write: only lanes 0 and 3.
+    dut.wem = 0x9; dut.din = 0xAABBCC99u;
+    tick();
+
+    // Read back addr 5: lane 3 = 0xAA, lanes 2..1 unchanged, lane 0 = 0x99.
+    dut.we = 0; dut.wem = 0; tick();
+    CHECK(dut.dout == 0xAA223399u,
+          "masked lanes 0+3 written, 1+2 preserved (got 0x%08x)", (unsigned)dut.dout);
+
+    // wem=0 write must change nothing.
+    dut.we = 1; dut.wem = 0x0; dut.din = 0xFFFFFFFFu; tick();
+    dut.we = 0; tick();
+    CHECK(dut.dout == 0xAA223399u,
+          "wem=0 write is a no-op (got 0x%08x)", (unsigned)dut.dout);
+
+    // Single-lane write to a different address; addr 5 stays intact.
+    dut.we = 1; dut.addr = 2; dut.wem = 0x4; dut.din = 0x00DD0000u; tick();
+    dut.we = 0; tick();
+    CHECK(dut.dout == 0x00DD0000u,
+          "lane-2-only write to fresh word (got 0x%08x)", (unsigned)dut.dout);
+    dut.addr = 5; tick();
+    CHECK(dut.dout == 0xAA223399u,
+          "addr 5 untouched by write to addr 2 (got 0x%08x)", (unsigned)dut.dout);
+
+    printf("=== %d pass / %d fail ===\n", pass, fail);
+    return fail == 0 ? 0 : 1;
+}

--- a/tests/sim_ranged_slice_test.rs
+++ b/tests/sim_ranged_slice_test.rs
@@ -1,0 +1,84 @@
+//! Regression coverage for arch#847 — seq assignment to a ranged
+//! part-select with runtime (loop-variable) slice bounds.
+//!
+//! Pre-fix, the sim C++ emitter const-folded slice bounds through a
+//! 32-default, so `mem[addr][(i*8+7):(i*8)] <= din[(i*8+7):(i*8)];`
+//! under `if wem[i:i]` inside `for i in 0..3` emitted a non-assignable
+//! read expression (the sim model did not even compile), a 1-bit lane
+//! mask, and a `wem >> 32` condition. Found on the e203 ITCM/DTCM RAM
+//! fixtures during PR #843's long verify.
+
+use std::process::Command;
+
+fn arch() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_arch"))
+}
+
+/// End-to-end: the sim model compiles AND byte-masked write semantics
+/// are correct (masked lanes written, unmasked lanes preserved).
+#[test]
+fn runtime_ranged_slice_seq_write_sim() {
+    let td = tempfile::tempdir().expect("tempdir");
+    let out = arch()
+        .arg("sim")
+        .arg("tests/sim_ranged_slice_regression.arch")
+        .arg("--tb")
+        .arg("tests/sim_ranged_slice_regression_tb.cpp")
+        .arg("--outdir")
+        .arg(td.path())
+        .output()
+        .expect("run arch sim");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        out.status.success(),
+        "arch sim should pass for sim_ranged_slice_regression\nstdout:\n{stdout}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stderr),
+    );
+    assert!(
+        stdout.contains("4 pass / 0 fail"),
+        "expected all 4 masked-write checks to pass; got:\n{stdout}"
+    );
+}
+
+/// The e203 ITCM RAM — the original arch#847 reproducer — must produce
+/// a sim model the host C++ compiler accepts. Guard the codegen shape:
+/// no rvalue-assignment, byte-wide lane mask, per-bit `wem` shift.
+#[test]
+fn e203_itcm_ram_sim_model_compiles() {
+    let td = tempfile::tempdir().expect("tempdir");
+    let out = arch()
+        .arg("sim")
+        .arg("tests/e203/e203_itcm_ram.arch")
+        .arg("--outdir")
+        .arg(td.path())
+        .output()
+        .expect("run arch sim codegen");
+    assert!(
+        out.status.success(),
+        "arch sim codegen should succeed for e203_itcm_ram\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stderr),
+    );
+    let model = td.path().join("Ve203_itcm_ram.cpp");
+    let cc = Command::new("c++")
+        .arg("-std=c++17")
+        .arg("-fsyntax-only")
+        .arg("-I")
+        .arg(td.path())
+        .arg(&model)
+        .output()
+        .expect("run host c++ syntax check");
+    assert!(
+        cc.status.success(),
+        "generated sim model must be valid C++\n{}",
+        String::from_utf8_lossy(&cc.stderr),
+    );
+    let cpp = std::fs::read_to_string(&model).expect("read model");
+    assert!(
+        cpp.contains("& 0xFFULL"),
+        "byte lane writes should use an 8-bit mask:\n{cpp}"
+    );
+    assert!(
+        !cpp.contains("wem >> 32"),
+        "wem lane-enable must shift by the loop var, not a folded 32:\n{cpp}"
+    );
+}


### PR DESCRIPTION
Closes #847.

## Problem

The C++ sim codegen emitted non-compilable code for seq assignments whose target is a ranged part-select with runtime (loop-variable) bounds:

```arch
for i in 0..7
  if wem[i:i]
    mem[addr][(i * 8 + 7):(i * 8)] <= din[(i * 8 + 7):(i * 8)];
  end if
end for
```

produced

```cpp
if ((wem >> 32) & 0x1ULL) {
  (((..., _mem[addr]) >> 32) & 0x1ULL)  = ((din >> 32) & 0x1ULL);   // rvalue LHS — does not compile
}
```

Three symptoms, one root cause: every slice bound went through `eval_width_in`, whose 32-default silently const-folds anything it can't evaluate — so the LHS became a read expression, the lane mask collapsed to 1 bit, and the `wem[i:i]` shift became a literal 32. The emitted SV from `arch build` was already correct; only the sim model was broken. `tests/e203/e203_itcm_ram.arch` and `e203_dtcm_ram.arch` both failed sim-compile this way (found during #843's long verify).

## Fix (internal codegen only — no user-facing syntax/semantics change)

- **`expr_codegen.rs` read path**: `BitSlice` with non-const bounds now emits a symbolic shift by the runtime lo bound, with the mask taken from a structural slice-width analysis (`[x:x]` → 1, `[x+k:x]` → k+1, `[x:x-k]` → k+1, plus the existing param-aware const fold). When the width itself is runtime (e.g. `d[i:0]`), a new `_arch_slice_mask` runtime helper computes it. Runtime bounds also get an `_ARCH_BCHK` MSB check, mirroring the variable part-select policy (typecheck can only verify compile-time bounds). **Constant-bound slices emit exactly as before.**
- **`infer_expr_width`**: uses the same structural width, so `din[i*8+7:i*8]` reports 8 bits instead of 1.
- **`stmt_codegen.rs` LHS arm**: the bit-slice read-modify-write lowering now (a) fires for Vec-element bases — `infer_expr_width` returned 0 for `mem[addr]` because `build_widths` registers Vec regs with the scalar default 32, so the arm was skipped and the broken generic path ran — and (b) emits the shift symbolically for runtime bounds. The RMW targets the next-cycle shadow (`_n_mem[addr]`), which is memcpy'd from the current state at cycle entry, so partial-lane nonblocking semantics are exact.
- **`pybind.rs`** (`verilated.h` template): adds `_arch_slice_mask`.

Emitted code for the repro now:

```cpp
if (_ARCH_BCHK((i), 8, "wem[hi:lo]"), (((wem) >> (i)) & 0x1ULL)) {
  _ARCH_BCHK((...i * 8 + 7...), 64, "mem[hi:lo]");
  (..., _n_mem[addr]) = ((..., _n_mem[addr]) & ~(uint64_t(0xFFULL) << (i * 8...))) | (...);
}
```

## Verification

Fast gate (pre-PR):
- `cargo build --release` + full `cargo test --release`: green. (Two pre-existing failures in `formal_test` — `construct_proof_lean_*` — are local Lean-toolchain environment issues; confirmed identical on unmodified `origin/main`.)
- `arch sim tests/e203/e203_itcm_ram.arch` and `e203_dtcm_ram.arch` → `c++ -std=c++17 -fsyntax-only` clean (previously: "expression is not assignable").
- Functional check: byte-masked write TB against the ITCM model — masked lanes written, unmasked lanes preserved, `wem=0` is a no-op.

New regression coverage:
- `tests/sim_ranged_slice_regression.arch` + `_tb.cpp` — distilled byte-masked RAM, registered in `tests/arch_sim_manifest.json`.
- `tests/sim_ranged_slice_test.rs` — (1) end-to-end `arch sim --tb` semantics run; (2) e203 ITCM model host-C++ syntax check + shape guards (8-bit lane mask present, no `wem >> 32`).

Long verify (post-PR, running): `tools/run_arch_regression.py --release --pattern 'e203/*'` — will report results in a follow-up comment.