### PR TITLE
fix(sim): resolve Vec element widths from declared types (closes #858, #859)

### DIFF
--- a/src/sim_codegen/expr_codegen.rs
+++ b/src/sim_codegen/expr_codegen.rs
@@ -608,7 +608,24 @@ pub(super) fn infer_expr_width(expr: &Expr, ctx: &Ctx) -> u32 {
                     .vec_names
                     .map_or(false, |s| s.contains(base_name.as_str()))
                 {
-                    // Vec element width: total port/reg/field width / element count.
+                    // Preferred: element width from the declared `Vec<T, N>`
+                    // type, param-aware. The total/count fallback below is
+                    // wrong for declared Vecs — `build_widths` registers
+                    // Vec-typed regs/ports at the scalar default 32, not the
+                    // packed total, so `Vec<UInt<32>,4>[i]` computed 8 and
+                    // any count > 32 computed 0 (arch#858).
+                    if let Some(elem_ty) = sim_expr_decl_type(expr, ctx) {
+                        if let Some(w) = scalar_type_bits_with_params(&elem_ty, ctx.params) {
+                            if w > 0 {
+                                return w;
+                            }
+                        }
+                    }
+                    // Fallback: total width / element count. Correct for the
+                    // names whose widths-map entry IS a packed total —
+                    // inst-output Vec wires (registered as elem_bits * count
+                    // in mod.rs) — and for ctxs built without decl_types
+                    // (e.g. pipeline stage bodies).
                     let total = ctx.widths.get(base_name.as_str()).copied().unwrap_or(0);
                     let count = ctx
                         .vec_sizes

--- a/src/sim_codegen/mod.rs
+++ b/src/sim_codegen/mod.rs
@@ -3228,14 +3228,32 @@ impl<'a> SimCodegen<'a> {
                 if l.ty.is_none() {
                     // ty=None: assignment to existing port or wire
                     let name = &l.name.name;
-                    let target = if port_names.contains(name) {
-                        // Output port — public field, plain name
-                        name.clone()
+                    if port_names.contains(name) {
+                        // Output port — public field, plain name. Wide ports
+                        // need the same 65–128-bit conversion stmt_codegen's
+                        // comb arm applies: expression-context RHS is
+                        // _arch_u128, the port is VlWide<ceil(W/32)>, and a
+                        // bare assignment truncates through uint64_t
+                        // (`let y = {a, b};` with y: out UInt<128> dropped
+                        // the high word pair — found while fixing arch#858).
+                        if wide_names.contains(name.as_str()) {
+                            let bits = widths.get(name.as_str()).copied().unwrap_or(0);
+                            if bits > 128 {
+                                // >128 bits: both sides are VlWide<N> — direct assign.
+                                cpp.push_str(&format!("  {name} = {val};\n"));
+                            } else {
+                                cpp.push_str(&format!(
+                                    "  _arch_u128_to_vl({val}, {name}._data, {});\n",
+                                    wide_words(bits)
+                                ));
+                            }
+                        } else {
+                            cpp.push_str(&format!("  {name} = {val};\n"));
+                        }
                     } else {
                         // Wire — private field with _let_ prefix
-                        format!("_let_{name}")
-                    };
-                    cpp.push_str(&format!("  {target} = {val};\n"));
+                        cpp.push_str(&format!("  _let_{name} = {val};\n"));
+                    }
                 } else {
                     cpp.push_str(&format!("  _let_{} = {};\n", l.name.name, val));
                 }

--- a/src/sim_codegen/stmt_codegen.rs
+++ b/src/sim_codegen/stmt_codegen.rs
@@ -46,24 +46,6 @@ pub(super) fn assigned_base_ident(expr: &Expr) -> Option<&str> {
     }
 }
 
-/// Width of a bit-slice-assignment base. `infer_expr_width`'s Index arm
-/// divides the widths-map entry by the element count, but `build_widths`
-/// registers Vec-typed regs/ports with the scalar default (32), so a
-/// Vec-element base (`mem[addr][hi:lo]`) computes to 0 and the RMW arm
-/// never fires (arch#847). Resolve the element width from the declared
-/// Vec type instead.
-fn slice_lhs_base_width(base: &Expr, ctx: &Ctx) -> u32 {
-    if let ExprKind::Index(inner, _) = &base.kind {
-        if let ExprKind::Ident(name) = &inner.kind {
-            if let Some(TypeExpr::Vec(elem, _)) = ctx.decl_types.and_then(|m| m.get(name.as_str()))
-            {
-                return type_bits_te_with_params(elem, ctx.params);
-            }
-        }
-    }
-    infer_expr_width(base, ctx)
-}
-
 pub(super) fn emit_vinit_mark_for_target(
     target: &Expr,
     ctx: &Ctx,
@@ -179,7 +161,11 @@ pub(super) fn emit_stmt(stmt: &Stmt, ctx: &Ctx, out: &mut String, indent: usize,
             // arch#847): the shift is emitted symbolically and the mask
             // comes from the structural slice width.
             if let ExprKind::BitSlice(base, hi_e, lo_e) = &a.target.kind {
-                let base_w = slice_lhs_base_width(base, ctx);
+                // A Vec-element base (`mem[addr][hi:lo]`, arch#847) resolves
+                // through infer_expr_width's Index arm, which reads the
+                // declared element type since arch#858 (the former local
+                // decl_types workaround here folded into that shared path).
+                let base_w = infer_expr_width(base, ctx);
                 if base_w > 0 && base_w <= 64 {
                     let resolved_base = match &base.kind {
                         ExprKind::Ident(base_name) => ctx.resolve_name(base_name, is_seq),

--- a/src/sim_codegen/width.rs
+++ b/src/sim_codegen/width.rs
@@ -325,6 +325,25 @@ pub(super) fn cpp_uint(bits: u32) -> &'static str {
     }
 }
 
+/// Bit-width of a *scalar* TypeExpr, param-aware. Returns `None` for
+/// aggregate / non-value types (Vec, Named, Clock, Reset) instead of
+/// inventing a default, so callers can fall back explicitly. Unlike
+/// `type_bits_te_with_params` (whose `_ => 32` arm is exactly the trap
+/// arch#858 fell into for Vec), a `None` here can never be mistaken for
+/// a real width.
+pub(super) fn scalar_type_bits_with_params(ty: &TypeExpr, params: &[ParamDecl]) -> Option<u32> {
+    match ty {
+        TypeExpr::UInt(w) | TypeExpr::SInt(w) => Some(eval_width_with_params(w, params)),
+        TypeExpr::Bool | TypeExpr::Bit => Some(1),
+        TypeExpr::FP32 => Some(32),
+        TypeExpr::BF16 => Some(16),
+        TypeExpr::FP8E4M3 | TypeExpr::FP8E5M2 | TypeExpr::E8M0 => Some(8),
+        TypeExpr::FP6E2M3 | TypeExpr::FP6E3M2 => Some(6),
+        TypeExpr::FP4E2M1 => Some(4),
+        TypeExpr::Vec(..) | TypeExpr::Named(_) | TypeExpr::Clock(_) | TypeExpr::Reset(..) => None,
+    }
+}
+
 /// Return the bit-width of a TypeExpr, or 0 if indeterminate (e.g. Vec with param size).
 pub(super) fn type_width_of(ty: &TypeExpr) -> u32 {
     match ty {

--- a/tests/arch_sim_manifest.json
+++ b/tests/arch_sim_manifest.json
@@ -83,6 +83,15 @@
       ]
     },
     {
+      "name": "sim_vec_elem_width_regression",
+      "arch_files": [
+        "tests/sim_vec_elem_width_regression.arch"
+      ],
+      "tb_files": [
+        "tests/sim_vec_elem_width_regression_tb.cpp"
+      ]
+    },
+    {
       "name": "thread__basic_thread",
       "arch_files": [
         "tests/thread/basic_thread.arch"

--- a/tests/sim_vec_elem_width_regression.arch
+++ b/tests/sim_vec_elem_width_regression.arch
@@ -1,0 +1,44 @@
+// Regression test: `infer_expr_width`'s Index arm computed a Vec
+// element's width as widths[name] / count, but `build_widths` registers
+// Vec-typed regs/ports at the scalar default 32 — NOT the packed total —
+// so `Vec<UInt<32>, 4>[i]` inferred 8 and `Vec<UInt<64>, 8>[i]`
+// inferred 4. Symptoms distilled here:
+//   1. concat of Vec elements got wrong shift positions
+//      (`{v[1], v[0]}` emitted `v[1] << 8` instead of `<< 32`),
+//   2. runtime bit-select on a Vec element got a wrong `_ARCH_BCHK`
+//      bound (aborting on legal bit indices >= the bogus width), and
+//      for counts > 32 the inferred width was 0, silently skipping the
+//      bounds check entirely.
+// Post-fix: the element width resolves from the declared Vec type.
+
+module sim_vec_elem_width_regression
+  port clk:   in Clock<SysDomain>;
+  port rst_n: in Reset<Async, Low>;
+
+  port wr_en:    in Bool;
+  port wr_idx:   in UInt<2>;
+  port wr_lo:    in UInt<32>;
+  port wr_idx_w: in UInt<3>;
+  port wr_hi:    in UInt<64>;
+  port bit_sel:  in UInt<6>;
+
+  port rd_pair: out UInt<64>;
+  port rd_cat:  out UInt<128>;
+  port rd_bit:  out UInt<1>;
+
+  reg v: Vec<UInt<32>, 4> reset none;
+  reg w: Vec<UInt<64>, 8> reset none;
+
+  default seq on clk rising;
+
+  seq
+    if wr_en
+      v[wr_idx] <= wr_lo;
+      w[wr_idx_w] <= wr_hi;
+    end if
+  end seq
+
+  let rd_pair = {v[1], v[0]};
+  let rd_cat = {w[1], w[0]};
+  let rd_bit = w[0][bit_sel];
+end module sim_vec_elem_width_regression

--- a/tests/sim_vec_elem_width_regression_tb.cpp
+++ b/tests/sim_vec_elem_width_regression_tb.cpp
@@ -1,0 +1,72 @@
+// Vec-element width-inference regression: concat of Vec elements must
+// shift by the declared element width (32 / 64 bits), not by
+// widths[name]/count (8 / 4 pre-fix), and a runtime bit-select on a
+// Vec<UInt<64>,_> element must accept legal bit indices up to 63.
+#include "Vsim_vec_elem_width_regression.h"
+#include <cstdint>
+#include <cstdio>
+static Vsim_vec_elem_width_regression dut;
+static int pass = 0, fail = 0;
+#define CHECK(c, m, ...) do { if (c) { printf("  PASS: " m "\n", ##__VA_ARGS__); ++pass; } \
+                              else  { printf("  FAIL: " m "\n", ##__VA_ARGS__); ++fail; } } while (0)
+
+static void tick() {
+    dut.clk = 0; dut.eval();
+    dut.clk = 1; dut.eval();
+}
+
+static void write_lo(unsigned idx, uint32_t val) {
+    dut.wr_en = 1; dut.wr_idx = idx; dut.wr_lo = val; tick(); dut.wr_en = 0;
+}
+
+int main() {
+    dut.clk = 0; dut.rst_n = 1;
+    dut.wr_en = 0; dut.wr_idx = 0; dut.wr_lo = 0;
+    dut.wr_idx_w = 0; dut.wr_hi = 0; dut.bit_sel = 0;
+    dut.eval();
+
+    // v[0] and v[1] get distinct byte patterns; {v[1], v[0]} must place
+    // v[1] at bits [63:32].
+    dut.wr_en = 1;
+    dut.wr_idx = 0; dut.wr_lo = 0xAAAA5555u;
+    dut.wr_idx_w = 0; dut.wr_hi = 0x123456789ABCDEF0ull;
+    tick();
+    dut.wr_idx = 1; dut.wr_lo = 0xDEADBEEFu;
+    dut.wr_idx_w = 1; dut.wr_hi = 0x0FEDCBA987654321ull;
+    tick();
+    dut.wr_en = 0; dut.eval();
+
+    CHECK(dut.rd_pair == 0xDEADBEEFAAAA5555ull,
+          "{v[1], v[0]} concat shifts by 32 (got 0x%016llx)",
+          (unsigned long long)dut.rd_pair);
+
+    // {w[1], w[0]} is 128 bits: w[0] in words 0..1, w[1] in words 2..3.
+    uint64_t cat_lo = (uint64_t)dut.rd_cat._data[0]
+                    | ((uint64_t)dut.rd_cat._data[1] << 32);
+    uint64_t cat_hi = (uint64_t)dut.rd_cat._data[2]
+                    | ((uint64_t)dut.rd_cat._data[3] << 32);
+    CHECK(cat_lo == 0x123456789ABCDEF0ull,
+          "{w[1], w[0]} low 64 bits = w[0] (got 0x%016llx)",
+          (unsigned long long)cat_lo);
+    CHECK(cat_hi == 0x0FEDCBA987654321ull,
+          "{w[1], w[0]} high 64 bits = w[1] (got 0x%016llx)",
+          (unsigned long long)cat_hi);
+
+    // Runtime bit-select on a 64-bit Vec element: indices >= 4 are legal
+    // (pre-fix the _ARCH_BCHK bound was the bogus inferred width 4, so
+    // bit 60 aborted the sim).
+    dut.bit_sel = 60; dut.eval();   // w[0] bit 60 of 0x123456789ABCDEF0 = 1
+    CHECK(dut.rd_bit == 1, "w[0][60] reads bit 60 (got %u)", (unsigned)dut.rd_bit);
+    dut.bit_sel = 63; dut.eval();   // bit 63 = 0
+    CHECK(dut.rd_bit == 0, "w[0][63] reads bit 63 (got %u)", (unsigned)dut.rd_bit);
+
+    // Overwrite v[1] only; concat must track it.
+    write_lo(1, 0x01020304u);
+    dut.eval();
+    CHECK(dut.rd_pair == 0x01020304AAAA5555ull,
+          "concat tracks v[1] rewrite (got 0x%016llx)",
+          (unsigned long long)dut.rd_pair);
+
+    printf("=== %d pass / %d fail ===\n", pass, fail);
+    return fail == 0 ? 0 : 1;
+}

--- a/tests/sim_vec_elem_width_test.rs
+++ b/tests/sim_vec_elem_width_test.rs
@@ -1,0 +1,84 @@
+//! Regression coverage for arch#858 — Vec element width inference in the
+//! sim C++ emitter.
+//!
+//! Pre-fix, `infer_expr_width`'s Index arm divided the widths-map entry
+//! by the element count, but `build_widths` registers Vec-typed
+//! regs/ports at the scalar default 32 (not the packed total), so
+//! `Vec<UInt<32>,4>[i]` inferred 8 and `Vec<UInt<64>,8>[i]` inferred 4:
+//! concats of Vec elements shifted by the wrong positions, and a runtime
+//! bit-select on a 64-bit element aborted with a bogus `[0..4)` bounds
+//! check. Also covers the wide-`let` follow-on found while fixing it:
+//! `let y = {a, b};` into a 65–128-bit output port truncated through
+//! uint64_t instead of converting via `_arch_u128_to_vl`.
+
+use std::process::Command;
+
+fn arch() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_arch"))
+}
+
+/// End-to-end: concat shift positions track the declared element width
+/// (32- and 64-bit elements, 64- and 128-bit concat results), and legal
+/// runtime bit indices up to 63 on a Vec<UInt<64>,_> element don't trip
+/// the bounds check.
+#[test]
+fn vec_elem_width_concat_and_bitsel_sim() {
+    let td = tempfile::tempdir().expect("tempdir");
+    let out = arch()
+        .arg("sim")
+        .arg("tests/sim_vec_elem_width_regression.arch")
+        .arg("--tb")
+        .arg("tests/sim_vec_elem_width_regression_tb.cpp")
+        .arg("--outdir")
+        .arg(td.path())
+        .output()
+        .expect("run arch sim");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        out.status.success(),
+        "arch sim should pass for sim_vec_elem_width_regression\nstdout:\n{stdout}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stderr),
+    );
+    assert!(
+        stdout.contains("6 pass / 0 fail"),
+        "expected all 6 element-width checks to pass; got:\n{stdout}"
+    );
+}
+
+/// Codegen shape: the runtime bit-select on a Vec<UInt<64>,8> element
+/// must emit an `_ARCH_BCHK` bound of 64 (the declared element width),
+/// not widths[name]/count = 4, and the 128-bit concat must shift the
+/// high element by 64.
+#[test]
+fn vec_elem_width_codegen_shape() {
+    let td = tempfile::tempdir().expect("tempdir");
+    let out = arch()
+        .arg("sim")
+        .arg("tests/sim_vec_elem_width_regression.arch")
+        .arg("--outdir")
+        .arg(td.path())
+        .output()
+        .expect("run arch sim codegen");
+    assert!(
+        out.status.success(),
+        "arch sim codegen should succeed\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stderr),
+    );
+    let model = td.path().join("Vsim_vec_elem_width_regression.cpp");
+    let cpp = std::fs::read_to_string(&model).expect("read model");
+    assert!(
+        cpp.contains(", 64, \"<bitsel>[i]\")"),
+        "runtime bit-select on a 64-bit Vec element must bound-check \
+         against 64:\n{cpp}"
+    );
+    assert!(
+        cpp.contains("<< 64"),
+        "128-bit concat of Vec<UInt<64>,_> elements must shift the high \
+         element by 64:\n{cpp}"
+    );
+    assert!(
+        cpp.contains("_arch_u128_to_vl"),
+        "let-bound 65-128-bit output port must convert through \
+         _arch_u128_to_vl, not truncate through uint64_t:\n{cpp}"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes two sim-model-only miscompiles (emitted SV from `arch build` is unaffected — SV codegen has its own width resolution):

**#858 — Vec element width inference.** `infer_expr_width`'s `Index` arm computed a Vec element's width as `widths[name] / count`, but `build_widths` registers Vec-typed regs/ports at the scalar default 32 (`type_bits_te_with_params` has no Vec arm). So `Vec<UInt<32>,4>[i]` inferred 8, `Vec<UInt<64>,8>[i]` inferred 4, and any count > 32 inferred 0. Reproduced on a fresh binary: `{v[1], v[0]}` emitted `v[1] << 8` (result `0x000000deafbeff55` instead of `0xDEADBEEFAAAA5555`), and a legal read of bit 60 of a 64-bit element hard-aborted with `ARCH-ERROR: index 60 out of bounds [0..4)`; counts > 32 silently *skipped* the bounds check instead (`base_w > 0` gate).

**#859 — wide-`let` output-port truncation** (found while testing, Vec-independent). `let y = {a, b};` with `y: out UInt<128>` assigned an `_arch_u128` RHS straight into a `VlWide<4>` port, truncating through `uint64_t` — bits 64–127 silently zeroed.

## Fix

- `expr_codegen`: the `Index` arm resolves the element width from the declared `Vec<T,N>` type (`sim_expr_decl_type`, param-aware) via a new `width.rs` helper `scalar_type_bits_with_params` that returns `None` for aggregate types instead of inventing a 32 default. The `total/count` computation stays as **fallback** for the names whose widths-map entry IS a packed total — inst-output Vec wires (`elem_bits * count` in mod.rs) — and for ctxs built without `decl_types` (pipeline stage bodies), so those paths are byte-identical.
- `stmt_codegen`: the #847 local `slice_lhs_base_width` workaround folds into the now-correct shared path (both #847 regression tests still pass).
- `mod.rs` let emission: apply the same `_arch_u128_to_vl` conversion as `stmt_codegen`'s comb arm for 65–128-bit let-bound output ports (>128-bit stays direct VlWide assign).

## Call-site audit

Consumers of `infer_expr_width` on Index expressions all improve or are unchanged: concat shift positions, Shl/Shr widths, `~` masking, wide-path classification, `_ARCH_BCHK` gating/bounds, and the bit-slice LHS RMW arm. Known remaining niche: a Vec-typed **bus field** whose element width is an unresolvable bus param still degrades (to 32, vs `32/count` pre-fix — no worse); noted rather than fixed since the bus decl_types entries are pre-substitution.

## Verification (fast gate — green before PR)

- `cargo build --release` clean; full `cargo test --release`: **19/19 targets, 0 failures** (incl. both #847 tests with the workaround removed).
- New regression fixture `sim_vec_elem_width_regression` passes 6/6 end-to-end (32/64-bit element concats into 64/128-bit results, runtime bit-select at 60/63, wide-let conversion) plus codegen-shape assertions (`_ARCH_BCHK(..., 64, ...)`, `<< 64`, `_arch_u128_to_vl`). Pre-fix binary fails 4 of 6 and aborts on the bit-select.

Long verification (full regression sweep) runs post-open per fast-gate-before-PR ordering; follow-ups will be pushed here if it surfaces anything.

closes #858
closes #859

🤖 Generated with [Claude Code](https://claude.com/claude-code)