### PR TITLE
fix(sim): substitute bus params into decl_types; warn on unresolvable Vec element widths (closes #862)

### DIFF
--- a/src/sim_codegen/expr_codegen.rs
+++ b/src/sim_codegen/expr_codegen.rs
@@ -619,6 +619,20 @@ pub(super) fn infer_expr_width(expr: &Expr, ctx: &Ctx) -> u32 {
                             if w > 0 {
                                 return w;
                             }
+                        } else if matches!(elem_ty, TypeExpr::UInt(_) | TypeExpr::SInt(_)) {
+                            // A declared scalar element whose width won't
+                            // const-fold means the total/count fallback below
+                            // is a guess, not a resolution — say so instead
+                            // of silently degrading (aggregate elements — 2D
+                            // Vec, struct — fall through without noise; the
+                            // fallback is the intended path for those).
+                            eprintln!(
+                                "warning: sim codegen: element width of Vec \
+                                 '{base_name}' could not be resolved from its \
+                                 declared type; falling back to packed-width/\
+                                 count inference — concat / shift positions \
+                                 derived from this may be incorrect"
+                            );
                         }
                     }
                     // Fallback: total width / element count. Correct for the

--- a/src/sim_codegen/mod.rs
+++ b/src/sim_codegen/mod.rs
@@ -506,12 +506,25 @@ impl<'a> SimCodegen<'a> {
             // Bus ports contribute compound "port.signal" keys with each
             // signal's declared type, so float bus fields (`s.data + ...`)
             // dispatch float ops instead of integer ops on the bit pattern.
+            // Bus params are substituted (defaults overridden by the
+            // port-site binding, same recipe as flatten_bus_port_with_dir):
+            // the raw declaration types carry bus-param idents that are
+            // meaningless at module scope, which silently degraded any
+            // width resolved through decl_types — e.g. a Vec<UInt<W>,N>
+            // signal's element width (arch#858).
             if let Some(bi) = &p.bus_info {
                 if let Some((crate::resolve::Symbol::Bus(bd), _)) =
                     self.symbols.globals.get(&bi.bus_name.name)
                 {
-                    for (sig, _dir, sty) in &bd.signals {
-                        decl_types.insert(format!("{}.{}", p.name.name, sig), sty.clone());
+                    let mut bus_param_map = bd.default_param_map();
+                    for pa in &bi.params {
+                        bus_param_map.insert(pa.name.name.clone(), &pa.value);
+                    }
+                    for (sig, _dir, sty) in &bd.effective_signals(&bus_param_map) {
+                        decl_types.insert(
+                            format!("{}.{}", p.name.name, sig),
+                            subst_type_expr_sim(sty, &bus_param_map),
+                        );
                     }
                 }
             }

--- a/src/sim_codegen/width.rs
+++ b/src/sim_codegen/width.rs
@@ -326,14 +326,17 @@ pub(super) fn cpp_uint(bits: u32) -> &'static str {
 }
 
 /// Bit-width of a *scalar* TypeExpr, param-aware. Returns `None` for
-/// aggregate / non-value types (Vec, Named, Clock, Reset) instead of
-/// inventing a default, so callers can fall back explicitly. Unlike
-/// `type_bits_te_with_params` (whose `_ => 32` arm is exactly the trap
-/// arch#858 fell into for Vec), a `None` here can never be mistaken for
-/// a real width.
+/// aggregate / non-value types (Vec, Named, Clock, Reset) AND for
+/// UInt/SInt widths the const evaluator cannot fold, instead of
+/// inventing a default, so callers can fall back explicitly (and warn).
+/// Unlike `type_bits_te_with_params` (whose `_ => 32` arm is exactly
+/// the trap arch#858 fell into for Vec) or `eval_width`'s silent 32,
+/// a `None` here can never be mistaken for a real width.
 pub(super) fn scalar_type_bits_with_params(ty: &TypeExpr, params: &[ParamDecl]) -> Option<u32> {
     match ty {
-        TypeExpr::UInt(w) | TypeExpr::SInt(w) => Some(eval_width_with_params(w, params)),
+        TypeExpr::UInt(w) | TypeExpr::SInt(w) => {
+            try_eval_const_expr_with_params(w, params).map(|v| v as u32)
+        }
         TypeExpr::Bool | TypeExpr::Bit => Some(1),
         TypeExpr::FP32 => Some(32),
         TypeExpr::BF16 => Some(16),

--- a/tests/arch_sim_manifest.json
+++ b/tests/arch_sim_manifest.json
@@ -83,6 +83,15 @@
       ]
     },
     {
+      "name": "sim_bus_vec_elem_width",
+      "arch_files": [
+        "tests/sim_bus_vec_elem_width.arch"
+      ],
+      "tb_files": [
+        "tests/sim_bus_vec_elem_width_tb.cpp"
+      ]
+    },
+    {
       "name": "sim_vec_elem_width_regression",
       "arch_files": [
         "tests/sim_vec_elem_width_regression.arch"

--- a/tests/sim_bus_vec_elem_width.arch
+++ b/tests/sim_bus_vec_elem_width.arch
@@ -1,0 +1,21 @@
+// arch#858 follow-up: Vec-typed BUS field element widths must resolve
+// through the port-site param binding. decl_types used to store the raw
+// bus signal declaration types, so `Vec<UInt<W>, 4>` kept the bus-param
+// ident `W` — meaningless at module scope — and the element width
+// silently degraded (here: concat shifted s.data[1] by 32 instead of
+// 16, pushing it out of the 32-bit result entirely). The types are now
+// substituted with the same recipe as flatten_bus_port_with_dir, and
+// an unresolvable scalar element width warns instead of guessing.
+
+bus VecStream
+  param W: const = 8;
+  data:  in Vec<UInt<W>, 4>;
+  valid: in Bool;
+end bus VecStream
+
+module sim_bus_vec_elem_width
+  port s: initiator VecStream<W=16>;
+  port cat: out UInt<32>;
+
+  let cat = {s.data[1], s.data[0]};
+end module sim_bus_vec_elem_width

--- a/tests/sim_bus_vec_elem_width_tb.cpp
+++ b/tests/sim_bus_vec_elem_width_tb.cpp
@@ -1,0 +1,27 @@
+// arch#858 follow-up: concat of Vec-typed bus-field elements must shift
+// by the bus-param-substituted element width (16), not a degraded guess.
+#include "Vsim_bus_vec_elem_width.h"
+#include <cstdint>
+#include <cstdio>
+static Vsim_bus_vec_elem_width dut;
+static int pass = 0, fail = 0;
+#define CHECK(c, m, ...) do { if (c) { printf("  PASS: " m "\n", ##__VA_ARGS__); ++pass; } \
+                              else  { printf("  FAIL: " m "\n", ##__VA_ARGS__); ++fail; } } while (0)
+
+int main() {
+    dut.s_data[0] = 0xBEEF;
+    dut.s_data[1] = 0xDEAD;
+    dut.s_valid = 1;
+    dut.eval();
+    CHECK(dut.cat == 0xDEADBEEFu,
+          "{s.data[1], s.data[0]} shifts by the bound W=16 (got 0x%08x)",
+          (unsigned)dut.cat);
+
+    dut.s_data[1] = 0x1234;
+    dut.eval();
+    CHECK(dut.cat == 0x1234BEEFu,
+          "concat tracks s.data[1] rewrite (got 0x%08x)", (unsigned)dut.cat);
+
+    printf("=== %d pass / %d fail ===\n", pass, fail);
+    return fail == 0 ? 0 : 1;
+}

--- a/tests/sim_vec_elem_width_test.rs
+++ b/tests/sim_vec_elem_width_test.rs
@@ -45,6 +45,42 @@ fn vec_elem_width_concat_and_bitsel_sim() {
     );
 }
 
+/// Vec-typed BUS field: the element width must resolve through the
+/// port-site bus-param binding (`VecStream<W=16>` → 16-bit elements).
+/// Pre-fix, decl_types stored the raw declaration type `Vec<UInt<W>,4>`
+/// whose bus-param ident is meaningless at module scope, so the width
+/// silently degraded and `{s.data[1], s.data[0]}` shifted the high
+/// element out of the 32-bit result entirely.
+#[test]
+fn bus_vec_field_elem_width_sim() {
+    let td = tempfile::tempdir().expect("tempdir");
+    let out = arch()
+        .arg("sim")
+        .arg("tests/sim_bus_vec_elem_width.arch")
+        .arg("--tb")
+        .arg("tests/sim_bus_vec_elem_width_tb.cpp")
+        .arg("--outdir")
+        .arg(td.path())
+        .output()
+        .expect("run arch sim");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "arch sim should pass for sim_bus_vec_elem_width\nstdout:\n{stdout}\nstderr:\n{stderr}",
+    );
+    assert!(
+        stdout.contains("2 pass / 0 fail"),
+        "expected both bus-field checks to pass; got:\n{stdout}"
+    );
+    // The width resolved through the substituted binding — the
+    // unresolvable-element-width warning must NOT fire.
+    assert!(
+        !stderr.contains("could not be resolved"),
+        "element width should resolve via the bus-param binding, not warn:\n{stderr}"
+    );
+}
+
 /// Codegen shape: the runtime bit-select on a Vec<UInt<64>,8> element
 /// must emit an `_ARCH_BCHK` bound of 64 (the declared element width),
 /// not widths[name]/count = 4, and the 128-bit concat must shift the


### PR DESCRIPTION
## Summary

Follow-up to #858 / PR #860, promoting its documented "known accepted niche" to a fix per review feedback: **a Vec-typed bus field's element width must not silently degrade.**

Reproduced at PR #860's HEAD: a `Vec<UInt<W>, 4>` bus signal bound at the port site as `VecStream<W=16>` resolved its element type as `UInt<W>` with `W` meaningless at module scope; the width evaluator's silent 32-fallback then shifted `{s.data[1], s.data[0]}`'s high element clean out of the 32-bit result (`0x0000beef` instead of `0xDEADBEEF`) — with no diagnostic anywhere.

## Fix

1. **Resolve correctly** (mod.rs): bus-port `decl_types` entries now carry bus-param-substituted signal types, using the exact recipe `flatten_bus_port_with_dir` already uses (bus defaults overridden by the port-site binding, `effective_signals` + `subst_type_expr_sim`). Substituted types may still reference enclosing-module params — those resolve later through the param-aware width helpers, matching #427's established pattern.
2. **Never guess silently** (width.rs): `scalar_type_bits_with_params` now returns `None` for UInt/SInt widths the const evaluator cannot fold, instead of `eval_width`'s silent 32. No resolution regression: the const evaluator folds a strict superset of `eval_width`'s shapes (literals, params, `$clog2`, arithmetic, ternary).
3. **Warn on fallback** (expr_codegen): when a declared *scalar* Vec element width fails to fold, the Index arm emits a warning (matching the existing unknown-ident warning style) before using the packed-width/count fallback. Aggregate elements (2D Vec, struct) fall through without noise — the fallback is the intended path for those.

Sim-model-only; `arch build` SV output unaffected.

## Verification (fast gate — green before PR)

- Full `cargo test --release`: all targets green (incl. the new `bus_vec_field_elem_width_sim`, which also asserts the warning does **not** fire when the binding resolves).
- New fixture `sim_bus_vec_elem_width` verified **failing at PR #860's HEAD** (`0x0000beef`, both checks) and passing post-fix (`0xdeadbeef`), registered in `tests/arch_sim_manifest.json` so the nightly equivalence sweep exercises it.

Long verification (full 179-unit regression sweep + backend_equiv) runs post-open per fast-gate-before-PR ordering; follow-ups will be pushed here if it surfaces anything.

closes #862

🤖 Generated with [Claude Code](https://claude.com/claude-code)