### PR TITLE
fix(sim): dispatch native narrows to sub-8-bit MX formats (closes #867)

### DIFF
--- a/src/sim_codegen/expr_codegen.rs
+++ b/src/sim_codegen/expr_codegen.rs
@@ -1898,6 +1898,57 @@ pub(super) fn cpp_method_call(base: &Expr, method: &Ident, args: &[Expr], ctx: &
                 }
             }
         },
+        // Sub-8-bit MX narrows mirror the fp8 arms: widen any source float to
+        // f32 (exact for every fp8/bf16/sub-8b value and every fp-relevant
+        // integer, all below 2^24), then one correctly-rounded narrow.
+        "to_fp4e2m1" => match infer_expr_float(base, ctx) {
+            Some(FpFmt::Fp32) => format!("_arch_f32_to_e2m1({b})"),
+            Some(FpFmt::E2m1) => b,
+            Some(FpFmt::Bf16) => format!("_arch_f32_to_e2m1(_arch_bf16_to_f32({b}))"),
+            Some(FpFmt::E4m3) => format!("_arch_f32_to_e2m1(_arch_e4m3_to_f32({b}))"),
+            Some(FpFmt::E5m2) => format!("_arch_f32_to_e2m1(_arch_e5m2_to_f32({b}))"),
+            Some(FpFmt::E2m3) => format!("_arch_f32_to_e2m1(_arch_e2m3_to_f32({b}))"),
+            Some(FpFmt::E3m2) => format!("_arch_f32_to_e2m1(_arch_e3m2_to_f32({b}))"),
+            None => {
+                if infer_expr_signed(base, ctx) {
+                    format!("_arch_f32_to_e2m1(_arch_i_to_f32((int64_t)({b})))")
+                } else {
+                    format!("_arch_f32_to_e2m1(_arch_u_to_f32((uint64_t)({b})))")
+                }
+            }
+        },
+        "to_fp6e2m3" => match infer_expr_float(base, ctx) {
+            Some(FpFmt::Fp32) => format!("_arch_f32_to_e2m3({b})"),
+            Some(FpFmt::E2m3) => b,
+            Some(FpFmt::Bf16) => format!("_arch_f32_to_e2m3(_arch_bf16_to_f32({b}))"),
+            Some(FpFmt::E4m3) => format!("_arch_f32_to_e2m3(_arch_e4m3_to_f32({b}))"),
+            Some(FpFmt::E5m2) => format!("_arch_f32_to_e2m3(_arch_e5m2_to_f32({b}))"),
+            Some(FpFmt::E2m1) => format!("_arch_f32_to_e2m3(_arch_e2m1_to_f32({b}))"),
+            Some(FpFmt::E3m2) => format!("_arch_f32_to_e2m3(_arch_e3m2_to_f32({b}))"),
+            None => {
+                if infer_expr_signed(base, ctx) {
+                    format!("_arch_f32_to_e2m3(_arch_i_to_f32((int64_t)({b})))")
+                } else {
+                    format!("_arch_f32_to_e2m3(_arch_u_to_f32((uint64_t)({b})))")
+                }
+            }
+        },
+        "to_fp6e3m2" => match infer_expr_float(base, ctx) {
+            Some(FpFmt::Fp32) => format!("_arch_f32_to_e3m2({b})"),
+            Some(FpFmt::E3m2) => b,
+            Some(FpFmt::Bf16) => format!("_arch_f32_to_e3m2(_arch_bf16_to_f32({b}))"),
+            Some(FpFmt::E4m3) => format!("_arch_f32_to_e3m2(_arch_e4m3_to_f32({b}))"),
+            Some(FpFmt::E5m2) => format!("_arch_f32_to_e3m2(_arch_e5m2_to_f32({b}))"),
+            Some(FpFmt::E2m1) => format!("_arch_f32_to_e3m2(_arch_e2m1_to_f32({b}))"),
+            Some(FpFmt::E2m3) => format!("_arch_f32_to_e3m2(_arch_e2m3_to_f32({b}))"),
+            None => {
+                if infer_expr_signed(base, ctx) {
+                    format!("_arch_f32_to_e3m2(_arch_i_to_f32((int64_t)({b})))")
+                } else {
+                    format!("_arch_f32_to_e3m2(_arch_u_to_f32((uint64_t)({b})))")
+                }
+            }
+        },
         "to_uint" | "to_sint" => {
             let bits = args.first().map(|w| eval_width_in(w, ctx)).unwrap_or(32);
             let signed = method.name == "to_sint";

--- a/tests/sim_fp_narrow_mx_regression.arch
+++ b/tests/sim_fp_narrow_mx_regression.arch
@@ -1,0 +1,22 @@
+//! Regression coverage for arch#867 — native `arch sim` narrowing
+//! conversions to the sub-8-bit MX formats.
+//!
+//! Pre-fix, `src/sim_codegen/expr_codegen.rs::cpp_method_call` had
+//! dispatch arms for `to_fp8e4m3`/`to_fp8e5m2` but NONE for the three
+//! sub-8-bit narrows, so `x.to_fp4e2m1()` (and the E2M3/E3M2 siblings)
+//! fell through to the verbatim `{b}.{method}()` fallback and emitted
+//! `x.to_fp4e2m1()` straight into the generated C++ — which does not
+//! compile (`member reference base type 'uint32_t' ... is not a
+//! structure or union`). `arch build` (SV) already handled all three.
+//! The runtime helpers (`_arch_f32_to_e2m1/e2m3/e3m2`) already existed.
+module sim_fp_narrow_mx_regression
+  port x: in FP32;
+  port y1: out FP4E2M1;
+  port y2: out FP6E2M3;
+  port y3: out FP6E3M2;
+  comb
+    y1 = x.to_fp4e2m1();
+    y2 = x.to_fp6e2m3();
+    y3 = x.to_fp6e3m2();
+  end comb
+end module sim_fp_narrow_mx_regression

--- a/tests/sim_fp_narrow_mx_regression_tb.cpp
+++ b/tests/sim_fp_narrow_mx_regression_tb.cpp
@@ -1,0 +1,38 @@
+// arch#867 regression: native-sim FP32 -> sub-8-bit MX narrows
+// (`to_fp4e2m1` / `to_fp6e2m3` / `to_fp6e3m2`) must compile and
+// round-trip. Reference codes come from the OCP MX format tables and
+// match the widen-direction values the FP/MX review recorded.
+#include "Vsim_fp_narrow_mx_regression.h"
+#include <cstdio>
+#include <cstring>
+#include <cstdint>
+static Vsim_fp_narrow_mx_regression dut;
+static int pass = 0, fail = 0;
+static uint32_t f2b(float f) { uint32_t b; memcpy(&b, &f, 4); return b; }
+#define CHECK(c, m, ...) do { if (c) { printf("  PASS: " m "\n", ##__VA_ARGS__); ++pass; } \
+                              else  { printf("  FAIL: " m "\n", ##__VA_ARGS__); ++fail; } } while (0)
+
+int main() {
+    // FP4E2M1: value set +-{0,0.5,1,1.5,2,3,4,6}, code = s exp[1:0] man.
+    dut.x = f2b(0.5f);  dut.eval();
+    CHECK(dut.y1 == 0x1, "0.5 -> E2M1 0x1 (got 0x%x)", (unsigned)dut.y1);
+    dut.x = f2b(6.0f);  dut.eval();
+    CHECK(dut.y1 == 0x7, "6.0 -> E2M1 0x7 max finite (got 0x%x)", (unsigned)dut.y1);
+    dut.x = f2b(-6.0f); dut.eval();
+    CHECK(dut.y1 == 0xF, "-6.0 -> E2M1 0xF (got 0x%x)", (unsigned)dut.y1);
+
+    // FP6E2M3: 1+2+3, bias 1, max finite 7.5 (code 0x1F = 0 11 111).
+    dut.x = f2b(1.0f);  dut.eval();
+    CHECK(dut.y2 == 0x08, "1.0 -> E2M3 0x08 (got 0x%x)", (unsigned)dut.y2);
+    dut.x = f2b(7.5f);  dut.eval();
+    CHECK(dut.y2 == 0x1F, "7.5 -> E2M3 0x1F max finite (got 0x%x)", (unsigned)dut.y2);
+
+    // FP6E3M2: 1+3+2, bias 3. 1.0 = 0 011 00 = 0x0C.
+    dut.x = f2b(1.0f);  dut.eval();
+    CHECK(dut.y3 == 0x0C, "1.0 -> E3M2 0x0C (got 0x%x)", (unsigned)dut.y3);
+    dut.x = f2b(-1.0f); dut.eval();
+    CHECK(dut.y3 == 0x2C, "-1.0 -> E3M2 0x2C (got 0x%x)", (unsigned)dut.y3);
+
+    printf("=== %d pass / %d fail ===\n", pass, fail);
+    return fail == 0 ? 0 : 1;
+}

--- a/tests/sim_fp_narrow_mx_test.rs
+++ b/tests/sim_fp_narrow_mx_test.rs
@@ -1,0 +1,55 @@
+//! Regression coverage for arch#867 — native `arch sim` narrowing
+//! conversions to the sub-8-bit MX formats (`to_fp4e2m1`,
+//! `to_fp6e2m3`, `to_fp6e3m2`).
+//!
+//! Pre-fix the sim C++ method emitter had no dispatch arm for these
+//! three narrows, so the method call was emitted verbatim into the
+//! generated C++ (`x.to_fp4e2m1()` on a `uint32_t`) and the sim model
+//! failed to compile. `arch build` (SV) already handled all three.
+
+use std::process::Command;
+
+fn arch() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_arch"))
+}
+
+/// End-to-end: the sim model compiles AND every FP32 -> sub-8-bit MX
+/// narrow round-trips to the reference code.
+#[test]
+fn sim_fp32_to_mx_narrows_roundtrip() {
+    let td = tempfile::tempdir().expect("tempdir");
+    let out = arch()
+        .arg("sim")
+        .arg("tests/sim_fp_narrow_mx_regression.arch")
+        .arg("--tb")
+        .arg("tests/sim_fp_narrow_mx_regression_tb.cpp")
+        .arg("--outdir")
+        .arg(td.path())
+        .output()
+        .expect("run arch sim");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        out.status.success(),
+        "arch sim should pass for sim_fp_narrow_mx_regression\nstdout:\n{stdout}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stderr),
+    );
+    assert!(
+        stdout.contains("7 pass / 0 fail"),
+        "expected all 7 narrow checks to pass; got:\n{stdout}"
+    );
+    // Guard the codegen shape: the narrows must lower to the runtime
+    // helpers, never fall through to a verbatim `.to_fp4e2m1()` call.
+    let model = td.path().join("Vsim_fp_narrow_mx_regression.cpp");
+    let cpp = std::fs::read_to_string(&model).expect("read sim model");
+    assert!(
+        cpp.contains("_arch_f32_to_e2m1(") && cpp.contains("_arch_f32_to_e2m3(")
+            && cpp.contains("_arch_f32_to_e3m2("),
+        "narrows must lower to the _arch_f32_to_* helpers:\n{cpp}"
+    );
+    assert!(
+        !cpp.contains(".to_fp4e2m1()")
+            && !cpp.contains(".to_fp6e2m3()")
+            && !cpp.contains(".to_fp6e3m2()"),
+        "no narrow may be emitted verbatim as a C++ method call:\n{cpp}"
+    );
+}

--- a/tests/sim_fp_narrow_mx_test.rs
+++ b/tests/sim_fp_narrow_mx_test.rs
@@ -42,7 +42,8 @@ fn sim_fp32_to_mx_narrows_roundtrip() {
     let model = td.path().join("Vsim_fp_narrow_mx_regression.cpp");
     let cpp = std::fs::read_to_string(&model).expect("read sim model");
     assert!(
-        cpp.contains("_arch_f32_to_e2m1(") && cpp.contains("_arch_f32_to_e2m3(")
+        cpp.contains("_arch_f32_to_e2m1(")
+            && cpp.contains("_arch_f32_to_e2m3(")
             && cpp.contains("_arch_f32_to_e3m2("),
         "narrows must lower to the _arch_f32_to_* helpers:\n{cpp}"
     );


### PR DESCRIPTION
## Summary

`arch sim`'s native C++ method emitter had no dispatch arm for the three sub-8-bit MX narrowing conversions, so the method call was emitted verbatim into generated C++ and the sim model failed to compile. This adds the three missing arms.

Closes #867.

## Root cause

`cpp_method_call` in `src/sim_codegen/expr_codegen.rs` handled the fp8 narrows `to_fp8e4m3` / `to_fp8e5m2` but not `to_fp4e2m1` / `to_fp6e2m3` / `to_fp6e3m2`. Those fell through to the verbatim `{recv}.{method}()` fallback and emitted e.g. `x.to_fp4e2m1()` on a `uint32_t` FP32 bit-pattern:

```
member reference base type 'uint32_t' (aka 'unsigned int') is not a structure or union
```

`arch build` (SV, `src/codegen/method_call.rs` ~L245-253) already handled all three correctly — only the native-sim narrow path was broken. **The C++ runtime helpers already existed** (`_arch_f32_to_e2m1` / `_arch_f32_to_e2m3` / `_arch_f32_to_e3m2` in `src/sim_codegen/pybind.rs`); this was purely a **missing 3-arm dispatch**, no new runtime code.

## Fix

Three new dispatch arms mirroring the fp8 arms exactly: widen any source float (or fp-relevant integer) to f32 — exact for every fp8/bf16/sub-8b value and every integer below 2^24 — then one correctly-rounded narrow to the target format. Internal sim codegen only; no user-facing syntax or semantics change.

## Test

New native-sim integration regression `tests/sim_fp_narrow_mx_test.rs` (+ `.arch` / `_tb.cpp`) builds+sims a module narrowing FP32 to each of the three formats and asserts the round-tripped codes against the OCP MX tables:

- E2M1: `0.5 -> 0x1`, `6.0 -> 0x7` (max finite), `-6.0 -> 0xF`
- E2M3: `1.0 -> 0x08`, `7.5 -> 0x1F` (max finite)
- E3M2: `1.0 -> 0x0C`, `-1.0 -> 0x2C`

It also guards the codegen shape (the `_arch_f32_to_*` helpers are used; no narrow is emitted verbatim as a C++ method call).

## Verification

- `cargo build --release`: green
- `cargo test --release --test sim_fp_narrow_mx_test`: pass (7/7 checks)
- Manual repro (`x.to_fp4e2m1()` etc.) compiles and round-trips post-fix