### PR TITLE
fix(typecheck): reject compares on storage-only sub-8-bit float formats

### DIFF
--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -5363,6 +5363,26 @@ impl<'a> TypeChecker<'a> {
                         ));
                         return Ty::Error;
                     }
+                    // Storage-only formats are carriers with no operators —
+                    // spec §3.9. Refuse a compare here, with a span, rather
+                    // than letting each backend interpolate an `arch_<tag>_lt`
+                    // / `arch_<tag>_eq` that nothing defines — those failures
+                    // surface in Verilator / z3 / g++ with no source location.
+                    // (E8M0 is already caught by the gate above, so this arm
+                    // only reaches genuine storage-only floats here.)
+                    let carrier = if lt.is_float() { &lt } else { &rt };
+                    if !carrier.is_float_arith() {
+                        self.errors.push(CompileError::general(
+                            &format!(
+                                "operator `{sym}` is not supported on {} — it is a storage-only \
+                                 float format (conversions and literals only). Convert with \
+                                 `.to_fp32()`, compute, then convert back",
+                                carrier.display()
+                            ),
+                            _span,
+                        ));
+                        return Ty::Error;
+                    }
                     return Ty::Bool;
                 }
                 BinOp::Add | BinOp::Sub | BinOp::Mul => {

--- a/tests/fp_test.rs
+++ b/tests/fp_test.rs
@@ -2144,6 +2144,36 @@ fn fp4_arithmetic_is_rejected_at_typecheck() {
             "must fail at typecheck, not by emitting a missing operator:\n{out}"
         );
     }
+
+    // Ordered / equality comparisons are storage-only errors too (spec §3.9).
+    // Before the fix these passed `arch check` and then emitted calls to
+    // undefined SV helpers (`arch_e2m1_lt`, `arch_e2m1_eq`). The output of a
+    // compare is Bool, so use a Bool port here.
+    for (name, op, helper) in [
+        ("lt", "a < b", "arch_e2m1_lt"),
+        ("gt", "a > b", "arch_e2m1_gt"),
+        ("lte", "a <= b", "arch_e2m1_le"),
+        ("gte", "a >= b", "arch_e2m1_ge"),
+        ("eq", "a == b", "arch_e2m1_eq"),
+        ("neq", "a != b", "arch_e2m1_ne"),
+    ] {
+        let (ok, out) = check_src(
+            &format!("fp4_cmp_{name}"),
+            &format!(
+                "module A\n  port a: in FP4E2M1;\n  port b: in FP4E2M1;\n  \
+                 port y: out Bool;\n  comb y = {op}; end comb\nend module A\n"
+            ),
+        );
+        assert!(!ok, "`{op}` on FP4E2M1 must be rejected:\n{out}");
+        assert!(
+            out.contains("storage-only float format"),
+            "`{op}`: message should name the storage-only rule:\n{out}"
+        );
+        assert!(
+            !out.contains(helper),
+            "must fail at typecheck, not by emitting a missing operator `{helper}`:\n{out}"
+        );
+    }
 }
 
 /// `is_nan` is refused with an accurate reason. E2M1 has no NaN encoding, so
@@ -2264,6 +2294,22 @@ fn fp6_arithmetic_and_is_nan_are_rejected() {
             out.contains("no NaN encoding"),
             "{ty}: reason must be the missing encoding:\n{out}"
         );
+
+        // Ordered / equality comparisons are storage-only errors too (§3.9).
+        for op in ["a < b", "a == b"] {
+            let (ok, out) = check_src(
+                &format!("fp6_cmp_{ty}_{}", op.replace(' ', "")),
+                &format!(
+                    "module A\n  port a: in {ty};\n  port b: in {ty};\n  \
+                     port y: out Bool;\n  comb y = {op}; end comb\nend module A\n"
+                ),
+            );
+            assert!(!ok, "{ty}: `{op}` must be rejected:\n{out}");
+            assert!(
+                out.contains("storage-only float format"),
+                "{ty}: `{op}` message should name the storage-only rule:\n{out}"
+            );
+        }
     }
 }
 


### PR DESCRIPTION
Closes #866

## Bug
Ordered/equality comparisons (`<`, `>`, `<=`, `>=`, `==`, `!=`) on the storage-only sub-8-bit float formats `FP4E2M1`, `FP6E2M3`, `FP6E3M2` passed `arch check` and then emitted calls to **undefined** SV helper functions (`arch_e2m1_lt`, `arch_e2m1_eq`, …). Those failures surfaced only downstream in Verilator / z3 / g++ with no source location — a soundness hole where the compiler accepts an invalid program.

Spec §3.9 makes these compares compile errors: storage-only formats are carriers supporting conversions and literals only, no operators.

## Root cause
In `src/typecheck.rs`, the float binary-op handler splits into arms. The `Add | Sub | Mul` arm carries a storage-only guard (`if !carrier.is_float_arith() { … reject … }`), but the sibling compare arm (`Eq | Neq | Lt | Gt | Lte | Gte`) only checked for a type mismatch and then returned `Bool` — it never applied that guard. So a compare on a storage-only float format fell through as accepted, and each backend later interpolated an `arch_<tag>_lt`/`_eq` helper that nothing defines.

## Fix
Mirror the exact storage-only guard from the arithmetic arm into the compare arm, emitting the same spanned "storage-only float format" error. E8M0 is still caught by its own earlier gate (it returns before reaching this arm), so there is no double-report.

This is an internal checker fix that **conforms the compiler to the existing spec §3.9** — no user-facing syntax or semantics change (only `src/typecheck.rs` + a test, so the `doc drift` check does not apply).

## Before / after (repro from the issue)
```arch
module Cmp
  port a: in FP4E2M1; port b: in FP4E2M1;
  port lt: out Bool; port eq: out Bool;
  comb lt = a < b; eq = a == b; end comb
end module Cmp
```
- **Before:** `arch check` → `OK: no errors`, then `arch build` emits undefined `arch_e2m1_lt`/`arch_e2m1_eq`.
- **After:** `arch check` rejects both compares with `operator `<` is not supported on FP4E2M1 — it is a storage-only float format …`, pointing at each compare. Confirmed for FP4E2M1, FP6E2M3, FP6E3M2. A legal `FP32` compare is still accepted.

## Tests
- Extended `fp4_arithmetic_is_rejected_at_typecheck` in `tests/fp_test.rs` with all six comparison operators for FP4E2M1, asserting rejection with the storage-only message and that no `arch_e2m1_*` helper is emitted.
- Extended `fp6_arithmetic_and_is_nan_are_rejected` with `<` and `==` rows for both FP6 formats.

## Verification
- `cargo build --release` — clean.
- `cargo test --release --test fp_test` — 57 passed, 0 failed.
- Manual repro above confirmed on the freshly built worktree binary.