### PR TITLE
fix(sim): preserve >64-bit runtime bit-slices from >64-bit bases (closes #868)

### DIFF
--- a/src/sim_codegen/expr_codegen.rs
+++ b/src/sim_codegen/expr_codegen.rs
@@ -130,9 +130,29 @@ fn runtime_bit_slice(b: &str, base: &Expr, hi: &Expr, lo: &Expr, ctx: &Ctx) -> S
         String::new()
     };
     let core = if base_w > 128 {
-        format!("_arch_vw_bits({b}.data(), ({hi_cpp}), ({lo_cpp}))")
+        // VlWide base. `_arch_vw_bits` caps its width at 64 and returns a
+        // `uint64_t`; for a derivable slice width > 64 (and for an unknown
+        // width, conservatively) use the 128-bit reader so bits 64+ survive
+        // (arch#868).
+        match width {
+            Some(w) if w <= 64 => {
+                format!("_arch_vw_bits({b}.data(), ({hi_cpp}), ({lo_cpp}))")
+            }
+            _ => format!("_arch_vw_bits128({b}.data(), ({hi_cpp}), ({lo_cpp}))"),
+        }
     } else if base_w > 64 {
         match width {
+            // arch#868: a slice width > 64 needs a full 128-bit mask and a
+            // 128-bit result; the old `u64::MAX` mask + `cpp_uint` (uint64_t)
+            // silently zeroed slice bits 64+.
+            Some(w) if w > 64 => {
+                let mask = if w >= 128 {
+                    "~(_arch_u128)0".to_string()
+                } else {
+                    format!("(((_arch_u128)1 << {w}) - 1)")
+                };
+                format!("((_arch_u128)((((_arch_u128)({b})) >> ({lo_cpp})) & {mask}))")
+            }
             Some(w) => {
                 let mask = if w >= 64 { u64::MAX } else { (1u64 << w) - 1 };
                 format!(
@@ -141,7 +161,7 @@ fn runtime_bit_slice(b: &str, base: &Expr, hi: &Expr, lo: &Expr, ctx: &Ctx) -> S
                 )
             }
             None => format!(
-                "(uint64_t)(((_arch_u128)({b}) >> ({lo_cpp})) & (_arch_u128)_arch_slice_mask(({hi_cpp}), ({lo_cpp})))"
+                "(_arch_u128)(((_arch_u128)({b}) >> ({lo_cpp})) & _arch_slice_mask128(({hi_cpp}), ({lo_cpp})))"
             ),
         }
     } else {

--- a/src/sim_codegen/pybind.rs
+++ b/src/sim_codegen/pybind.rs
@@ -754,12 +754,16 @@ struct VlWide {
     uint32_t _data[WORDS];
     VlWide()                    { memset(_data, 0, sizeof(_data)); }
     VlWide(const VlWide& o)     { memcpy(_data, o._data, sizeof(_data)); }
-    /// Construct from a 64-bit integer (zero-extends into MSB words).
-    explicit VlWide(uint64_t v) { memset(_data, 0, sizeof(_data));
-        _data[0] = (uint32_t)v; if (WORDS > 1) _data[1] = (uint32_t)(v >> 32); }
+    /// Construct from an integer (zero-extends into MSB words). The parameter
+    /// is 128-bit so a >64-bit input (unsigned __int128) fills words 0..3
+    /// instead of narrowing through a uint64_t overload and silently dropping
+    /// bits 64+ (arch#868); a uint64_t or literal argument promotes cleanly,
+    /// so there is a single integer overload and no ambiguity.
+    explicit VlWide(unsigned __int128 v) { memset(_data, 0, sizeof(_data));
+        for (int i = 0; i < WORDS && i < 4; i++) _data[i] = (uint32_t)(v >> (32 * i)); }
     VlWide& operator=(const VlWide& o) { memcpy(_data, o._data, sizeof(_data)); return *this; }
-    VlWide& operator=(uint64_t v)      { memset(_data, 0, sizeof(_data));
-        _data[0] = (uint32_t)v; if (WORDS > 1) _data[1] = (uint32_t)(v >> 32); return *this; }
+    VlWide& operator=(unsigned __int128 v) { memset(_data, 0, sizeof(_data));
+        for (int i = 0; i < WORDS && i < 4; i++) _data[i] = (uint32_t)(v >> (32 * i)); return *this; }
     uint32_t*       data()       { return _data; }
     const uint32_t* data() const { return _data; }
 
@@ -851,6 +855,39 @@ static inline uint64_t _arch_vw_bits(const uint32_t* data, uint32_t hi, uint32_t
 static inline uint64_t _arch_slice_mask(uint64_t hi, uint64_t lo) {
     uint64_t w = hi - lo + 1;
     return (w >= 64) ? ~0ULL : ((1ULL << w) - 1ULL);
+}
+
+/// 128-bit sibling of `_arch_slice_mask`: mask covering bits [hi:lo] of a
+/// value up to 128 bits wide. Used by runtime-bound bit-slices (arch#868)
+/// whose derivable width is not known but whose base exceeds 64 bits, so a
+/// 64-bit mask would silently zero slice bits 64+.
+static inline _arch_u128 _arch_slice_mask128(uint64_t hi, uint64_t lo) {
+    uint64_t w = hi - lo + 1;
+    return (w >= 128) ? ~(_arch_u128)0 : (((_arch_u128)1 << w) - 1);
+}
+
+/// 128-bit sibling of `_arch_vw_bits`: extract up to 128 bits [hi:lo] from a
+/// VlWide `_data` array into an `_arch_u128`. Used by runtime-bound bit-slices
+/// (arch#868) from a >128-bit base whose derivable width exceeds 64 bits —
+/// `_arch_vw_bits` caps the width at 64 and returns `uint64_t`, silently
+/// truncating such a result.
+///
+/// Words are shifted into place individually (the first by a right shift of
+/// `b0`, the rest by a positive left shift) so no `_arch_u128` shift ever
+/// reaches 128 (which would be UB): for width <= 128 the largest left shift
+/// is `32*(wtop-w0) - b0 < 128`. Reads are bounded to `[w0 .. wtop]`, the
+/// exact source words spanning the (capped) window, so no read runs past the
+/// meaningful payload.
+static inline _arch_u128 _arch_vw_bits128(const uint32_t* data, uint32_t hi, uint32_t lo) {
+    uint32_t width = hi - lo + 1; if (width > 128) width = 128;
+    uint32_t w0 = lo >> 5, b0 = lo & 31;
+    uint32_t wtop = (lo + width - 1) >> 5;
+    _arch_u128 v = (_arch_u128)data[w0] >> b0;
+    for (uint32_t wi = w0 + 1; wi <= wtop; wi++) {
+        v |= (_arch_u128)data[wi] << (32 * (wi - w0) - b0);
+    }
+    _arch_u128 mask = (width >= 128) ? ~(_arch_u128)0 : (((_arch_u128)1 << width) - 1);
+    return v & mask;
 }
 
 /// Ceiling log2 helper.

--- a/tests/arch_sim_manifest.json
+++ b/tests/arch_sim_manifest.json
@@ -83,6 +83,24 @@
       ]
     },
     {
+      "name": "sim_wide_runtime_slice_u128",
+      "arch_files": [
+        "tests/sim_wide_runtime_slice_u128.arch"
+      ],
+      "tb_files": [
+        "tests/sim_wide_runtime_slice_u128_tb.cpp"
+      ]
+    },
+    {
+      "name": "sim_wide_runtime_slice_vlwide",
+      "arch_files": [
+        "tests/sim_wide_runtime_slice_vlwide.arch"
+      ],
+      "tb_files": [
+        "tests/sim_wide_runtime_slice_vlwide_tb.cpp"
+      ]
+    },
+    {
       "name": "sim_bus_vec_elem_width",
       "arch_files": [
         "tests/sim_bus_vec_elem_width.arch"

--- a/tests/sim_wide_runtime_slice_test.rs
+++ b/tests/sim_wide_runtime_slice_test.rs
@@ -1,0 +1,70 @@
+//! Regression coverage for arch#868 — a runtime-bound bit-slice whose
+//! derivable width exceeds 64 bits, taken from a base wider than 64 bits,
+//! was silently truncated to 64 bits in the native `arch sim` model
+//! (a wrong value, no warning, no abort). This is a gap in the arch#847
+//! runtime-part-select fix: two independent 64-bit caps in
+//! `runtime_bit_slice` — a `u64::MAX` mask and a `uint64_t` result cast
+//! (plus `_arch_vw_bits` / `_arch_slice_mask`, both 64-bit-only) — zeroed
+//! slice bits 64+.
+//!
+//! `v[(i + 79) : i]` has a runtime lo `i` and a derivable width of 80.
+
+use std::process::Command;
+
+fn arch() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_arch"))
+}
+
+/// 65..128-bit base (`_arch_u128` carrier): a width-80 runtime slice must
+/// preserve all 80 bits (bits 64..79 were the ones being dropped).
+#[test]
+fn runtime_wide_slice_u128_base_sim() {
+    let td = tempfile::tempdir().expect("tempdir");
+    let out = arch()
+        .arg("sim")
+        .arg("tests/sim_wide_runtime_slice_u128.arch")
+        .arg("--tb")
+        .arg("tests/sim_wide_runtime_slice_u128_tb.cpp")
+        .arg("--outdir")
+        .arg(td.path())
+        .output()
+        .expect("run arch sim");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        out.status.success(),
+        "arch sim should pass for sim_wide_runtime_slice_u128\nstdout:\n{stdout}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stderr),
+    );
+    assert!(
+        stdout.contains("2 pass / 0 fail"),
+        "expected both width-80 u128-base slice checks to pass; got:\n{stdout}"
+    );
+}
+
+/// >128-bit base (`VlWide` carrier): a width-80 runtime slice must route
+/// through `_arch_vw_bits128` (not the width-capping `_arch_vw_bits`) so
+/// bits 64..79 survive. Covers both a sub-word lo (`i=16`) and a
+/// word-aligned lo (`i=64`).
+#[test]
+fn runtime_wide_slice_vlwide_base_sim() {
+    let td = tempfile::tempdir().expect("tempdir");
+    let out = arch()
+        .arg("sim")
+        .arg("tests/sim_wide_runtime_slice_vlwide.arch")
+        .arg("--tb")
+        .arg("tests/sim_wide_runtime_slice_vlwide_tb.cpp")
+        .arg("--outdir")
+        .arg(td.path())
+        .output()
+        .expect("run arch sim");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        out.status.success(),
+        "arch sim should pass for sim_wide_runtime_slice_vlwide\nstdout:\n{stdout}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stderr),
+    );
+    assert!(
+        stdout.contains("2 pass / 0 fail"),
+        "expected both width-80 VlWide-base slice checks to pass; got:\n{stdout}"
+    );
+}

--- a/tests/sim_wide_runtime_slice_u128.arch
+++ b/tests/sim_wide_runtime_slice_u128.arch
@@ -1,0 +1,12 @@
+// arch#868 regression: a runtime-bound bit-slice whose derivable width
+// exceeds 64 bits, taken from a 65..128-bit base, must NOT be truncated
+// to 64 bits in the native sim model. `v[(i + 79) : i]` has runtime lo
+// `i` and derivable width 80; pre-fix the sim emitter masked with a
+// 64-bit constant and cast the result to `uint64_t`, silently zeroing
+// slice bits 64..79.
+module WideRuntimeSlice
+  port v: in UInt<128>;
+  port i: in UInt<7>;
+  port o: out UInt<80>;
+  comb o = v[(i + 79) : i]; end comb
+end module WideRuntimeSlice

--- a/tests/sim_wide_runtime_slice_u128_tb.cpp
+++ b/tests/sim_wide_runtime_slice_u128_tb.cpp
@@ -1,0 +1,27 @@
+// arch#868 regression TB: runtime-bound width-80 slice of a 128-bit base.
+#include "VWideRuntimeSlice.h"
+#include <cstdio>
+static VWideRuntimeSlice dut;
+static int pass = 0, fail = 0;
+#define CHECK(c, m, ...) do { if (c) { printf("  PASS: " m "\n", ##__VA_ARGS__); ++pass; } \
+                              else  { printf("  FAIL: " m "\n", ##__VA_ARGS__); ++fail; } } while (0)
+
+int main() {
+    _arch_u128 v = ((_arch_u128)0xABCDEF0123456789ULL << 64) | (_arch_u128)0x9ABCDEF012345678ULL;
+    dut.v = v;
+
+    // i = 0: o = v[79:0] = 0x6789_9ABCDEF012345678
+    dut.i = 0; dut.eval();
+    const uint32_t* d = dut.o.data();
+    CHECK(d[0] == 0x12345678u && d[1] == 0x9abcdef0u && (d[2] & 0xffff) == 0x6789u,
+          "i=0: v[79:0] = 0x%04x_%08x%08x", d[2] & 0xffff, d[1], d[0]);
+
+    // i = 48: o = v[127:48] = 0xABCD_EF012345_67899ABC (top 80 bits)
+    dut.i = 48; dut.eval();
+    d = dut.o.data();
+    CHECK(d[0] == 0x67899ABCu && d[1] == 0xEF012345u && (d[2] & 0xffff) == 0xABCDu,
+          "i=48: v[127:48] = 0x%04x_%08x%08x", d[2] & 0xffff, d[1], d[0]);
+
+    printf("=== %d pass / %d fail ===\n", pass, fail);
+    return fail == 0 ? 0 : 1;
+}

--- a/tests/sim_wide_runtime_slice_vlwide.arch
+++ b/tests/sim_wide_runtime_slice_vlwide.arch
@@ -1,0 +1,10 @@
+// arch#868 regression: same as the u128 case but for a >128-bit
+// (VlWide) base. Pre-fix the sim emitter routed this through
+// `_arch_vw_bits`, which caps its width at 64 and returns `uint64_t`,
+// truncating a width-80 slice. Post-fix it uses `_arch_vw_bits128`.
+module WideVlRuntimeSlice
+  port v: in UInt<160>;
+  port i: in UInt<8>;
+  port o: out UInt<80>;
+  comb o = v[(i + 79) : i]; end comb
+end module WideVlRuntimeSlice

--- a/tests/sim_wide_runtime_slice_vlwide_tb.cpp
+++ b/tests/sim_wide_runtime_slice_vlwide_tb.cpp
@@ -1,0 +1,30 @@
+// arch#868 regression TB: runtime-bound width-80 slice of a 160-bit
+// (VlWide<5>) base. The 160-bit input cannot be driven through the
+// scalar assignment path, so load the backing words directly.
+#include "VWideVlRuntimeSlice.h"
+#include <cstdio>
+static VWideVlRuntimeSlice dut;
+static int pass = 0, fail = 0;
+#define CHECK(c, m, ...) do { if (c) { printf("  PASS: " m "\n", ##__VA_ARGS__); ++pass; } \
+                              else  { printf("  FAIL: " m "\n", ##__VA_ARGS__); ++fail; } } while (0)
+
+int main() {
+    uint32_t* vw = dut.v.data();
+    vw[0] = 0x11111111u; vw[1] = 0x22222222u; vw[2] = 0x33333333u;
+    vw[3] = 0x44444444u; vw[4] = 0x55555555u;
+
+    // i = 16 (b0 != 0): o = v[95:16], width 80.
+    dut.i = 16; dut.eval();
+    const uint32_t* d = dut.o.data();
+    CHECK(d[0] == 0x22221111u && d[1] == 0x33332222u && (d[2] & 0xffff) == 0x3333u,
+          "i=16: v[95:16] = 0x%04x_%08x%08x", d[2] & 0xffff, d[1], d[0]);
+
+    // i = 64 (word-aligned lo, b0 == 0): o = v[143:64], width 80.
+    dut.i = 64; dut.eval();
+    d = dut.o.data();
+    CHECK(d[0] == 0x33333333u && d[1] == 0x44444444u && (d[2] & 0xffff) == 0x5555u,
+          "i=64: v[143:64] = 0x%04x_%08x%08x", d[2] & 0xffff, d[1], d[0]);
+
+    printf("=== %d pass / %d fail ===\n", pass, fail);
+    return fail == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

Fixes a **silent miscompile** in the native `arch sim` model: a runtime-bound
bit-slice whose derivable width exceeds 64 bits, taken from a base wider than
64 bits, was silently truncated to 64 bits — a wrong value, no warning, no
abort. This is a gap in the arch#847 runtime-part-select fix.

`v[(i + 79) : i]` (runtime lo `i`, derivable width 80) on a `UInt<128>` base
returned `0x0000_9abcdef012345678` instead of the correct
`0x6789_9abcdef012345678` (bits 64..79 zeroed).

**Only the sim model changes** — no `arch build` / SystemVerilog codegen and
no user-facing syntax or semantics change.

## Root cause

Two independent 64-bit caps in `sim_codegen::expr_codegen::runtime_bit_slice`'s
`base_w > 64` arm:

- the mask was `u64::MAX` for any width `>= 64`, zeroing slice bits 64+;
- the result was cast via `cpp_uint(w)` = `uint64_t` for anything `> 32`.

The `None` (unknown-width) branch cast to `uint64_t` and used the 64-bit-only
`_arch_slice_mask`; the `base_w > 128` (VlWide) arm used `_arch_vw_bits`, which
also caps width at 64 and returns `uint64_t`. Separately, `VlWide`'s only
integer `operator=` took `uint64_t`, so a >64-bit input assigned as
`dut.v = v` narrowed and dropped bits 64+ before the DUT ever saw it.

## Fix

- `runtime_bit_slice`: for a derivable width `> 64` emit an `_arch_u128` result
  with a 128-bit mask; the unknown-width and VlWide paths use 128-bit helpers.
  The `<= 64`-bit path (verified by the arch#847 tests) is left unchanged.
- Add `_arch_slice_mask128` and `_arch_vw_bits128` sim-runtime helpers (128-bit
  siblings of `_arch_slice_mask` / `_arch_vw_bits`). `_arch_vw_bits128` shifts
  each source word into place individually so no `__int128` shift ever reaches
  128 (which is UB), and bounds its reads to the exact source words needed.
- Widen `VlWide`'s integer constructor/`operator=` parameter from `uint64_t` to
  `unsigned __int128` (fills words 0..3). A `uint64_t` or literal argument
  promotes cleanly, so there is a single integer overload and no ambiguity.

## Verification

Before: `o = 0x0000_9abcdef012345678`
After:  `o = 0x6789_9abcdef012345678` (matches the Verilator reference
`assign o = v[i +: 80]`).

New regression test `tests/sim_wide_runtime_slice_test.rs` (fixtures registered
in `tests/arch_sim_manifest.json`) covers a width-80 runtime slice from a
128-bit `_arch_u128` base (the issue repro) and from a 160-bit `VlWide` base
(both a sub-word and a word-aligned lo). Fast gate green: `cargo build
--release`, and `cargo test --release --test sim_wide_runtime_slice_test --test
sim_ranged_slice_test` (4/4 pass).

Closes #868
