### PR TITLE
feat(fp): lower scaled_quantize / scaled_dequantize in both backends

### DIFF
--- a/doc/ARCH_HDL_Specification.md
+++ b/doc/ARCH_HDL_Specification.md
@@ -321,7 +321,7 @@ The Arch type system enforces four independent safety dimensions simultaneously.
 
   **E8M0**             8 bits               OCP MX block **scale** type — an unsigned biased exponent (bias 127) denoting 2^(e-127). **Not a float**: no sign, no mantissa, no infinity, and **no zero** (`0x00` is the minimum scale 2^-127). `0xFF` is NaN. See §3.10.
 
-  **ScaledVec\<E,N,S\>**  \|S\| + N × \|E\|    Block-scaled vector — N narrow elements sharing one scale, packed as `{scale, P[N-1..0]}` (MXFP4 = 136 bits). **No arithmetic, no compares, no indexing** — OCP MX defines only the block dot product. See §3.11.
+  **ScaledVec\<E,N,S\>**  \|S\| + N × \|E\|    Block-scaled vector — N narrow elements sharing one scale, packed as `{scale, P[N-1..0]}` (MXFP4 = 136 bits). **No arithmetic, no ordered compares, no indexing** — OCP MX defines only the block dot product; `==`/`!=` are an *encoding* compare. Convert with `scaled_quantize<Fmt>` / `scaled_dequantize`. See §3.11.
 
   **Clock\<D\>**       1 bit                Carries clock-domain tag D. Cannot appear in arithmetic.
 
@@ -1113,8 +1113,74 @@ The MX named formats all fix `N = 32` and an `E8M0` scale. Other `N` values
 are legal in the framework --- `ScaledVec<FP4E2M1, 16, E8M0>` is a well-formed
 type --- they simply may not be called MXFP4.
 
-**Not yet implemented:** `scaled_quantize` / `scaled_dequantize` (with scale
-policy and rounding parameters), `scaled_dot`, and the `UE4M3` scale.
+**3.11.1 `scaled_quantize` / `scaled_dequantize`**
+
+The two conversions between a `Vec<FP32, N>` and a block:
+
+```arch
+scaled_quantize<Fmt>(v)                      // Vec<FP32,N> -> Fmt
+scaled_quantize<Fmt, policy, rounding>(v)    // ... with explicit selectors
+scaled_dequantize(b)                         // block -> Vec<FP32,N>
+```
+
+**The output format is spelled, never inferred.** A `Vec<FP32, N>` operand
+says nothing about which element format or scale to quantize into --- MXFP4
+and MXFP8 are equally valid results --- so `Fmt` is a required type argument.
+It may be an alias (`scaled_quantize<MXFP4>(v)`, the normal form) or written
+inline. The operand's length must equal the format's `N`; quantizing 32
+values into a 16-element block is a compile error, not a truncation.
+
+`scaled_dequantize` needs no annotation: `N` and the formats all come from
+the block's own type. It yields `Vec<FP32, N>` with the scale already
+applied, and is the only way to read an element (§3.11).
+
+| Selector | Values | Default |
+|---|---|---|
+| `policy` | `floor_pow2`, `ceil_pow2` | `floor_pow2` |
+| `rounding` | `rne` (`rtz`, `rna` reserved) | `rne` |
+
+`floor_pow2` is the OCP §6.3 rule: the shared scale is the largest power of
+two that normalizes the block maximum into the element format's top binade.
+Because that binade's largest *representable* value is below its top, some
+elements saturate --- routine under this policy, not a corner case.
+`ceil_pow2` rounds the scale up instead when the block maximum is not already
+a power of two, trading the top element codes for fewer saturations.
+
+Semantics, all of which follow from `E8M0` having no zero and reserving
+`0xFF` for NaN:
+
+  - An **all-zero** block gets the *minimum* scale `0x00` (which denotes
+    `2^-127`, not zero) and zero elements.
+  - A block containing **any NaN or infinity** gets the NaN scale `0xFF`; its
+    element bits are then don't-care, and `scaled_dequantize` yields NaN in
+    every lane regardless of them.
+  - Dequantizing a finite element under a finite scale **saturates** to
+    ±`FP32` max rather than overflowing to infinity. An element that is
+    itself Inf or NaN (`FP8E5M2` / `FP8E4M3` can be) keeps its own result.
+  - Element narrowing inherits the element format's own overflow rule and the
+    `--fp-compat` profile --- so an out-of-range value saturates for the
+    all-finite formats (`FP4E2M1`, `FP6E2M3`, `FP6E3M2`) and becomes that
+    format's NaN for `FP8E4M3`.
+
+Scaling by the reciprocal scale is an exact power-of-two multiply in FP32, so
+each element is rounded **once**, from the true `vᵢ / X`.
+
+Both conversions are combinational and must be the whole right-hand side of
+an assignment. To index an element, bind the result first:
+
+```arch
+wire all: Vec<FP32, 32>;
+comb
+  blk = scaled_quantize<MXFP4, ceil_pow2, rne>(v);
+  all = scaled_dequantize(blk);
+  e   = all[3];
+end comb
+```
+
+**Not yet implemented:** `rtz` / `rna` rounding (they need their own element
+rounders in each backend, with their own overflow rules --- arch#890), the `exact` scale
+policy and `stochastic` rounding (see §3.11 for why both are deferred),
+`scaled_dot`, and the `UE4M3` scale.
 
 **3.12 Package-scope type aliases**
 

--- a/skills/arch-programming/references/ARCH_HDL_Specification.md
+++ b/skills/arch-programming/references/ARCH_HDL_Specification.md
@@ -321,7 +321,7 @@ The Arch type system enforces four independent safety dimensions simultaneously.
 
   **E8M0**             8 bits               OCP MX block **scale** type — an unsigned biased exponent (bias 127) denoting 2^(e-127). **Not a float**: no sign, no mantissa, no infinity, and **no zero** (`0x00` is the minimum scale 2^-127). `0xFF` is NaN. See §3.10.
 
-  **ScaledVec\<E,N,S\>**  \|S\| + N × \|E\|    Block-scaled vector — N narrow elements sharing one scale, packed as `{scale, P[N-1..0]}` (MXFP4 = 136 bits). **No arithmetic, no compares, no indexing** — OCP MX defines only the block dot product. See §3.11.
+  **ScaledVec\<E,N,S\>**  \|S\| + N × \|E\|    Block-scaled vector — N narrow elements sharing one scale, packed as `{scale, P[N-1..0]}` (MXFP4 = 136 bits). **No arithmetic, no ordered compares, no indexing** — OCP MX defines only the block dot product; `==`/`!=` are an *encoding* compare. Convert with `scaled_quantize<Fmt>` / `scaled_dequantize`. See §3.11.
 
   **Clock\<D\>**       1 bit                Carries clock-domain tag D. Cannot appear in arithmetic.
 
@@ -1113,8 +1113,74 @@ The MX named formats all fix `N = 32` and an `E8M0` scale. Other `N` values
 are legal in the framework --- `ScaledVec<FP4E2M1, 16, E8M0>` is a well-formed
 type --- they simply may not be called MXFP4.
 
-**Not yet implemented:** `scaled_quantize` / `scaled_dequantize` (with scale
-policy and rounding parameters), `scaled_dot`, and the `UE4M3` scale.
+**3.11.1 `scaled_quantize` / `scaled_dequantize`**
+
+The two conversions between a `Vec<FP32, N>` and a block:
+
+```arch
+scaled_quantize<Fmt>(v)                      // Vec<FP32,N> -> Fmt
+scaled_quantize<Fmt, policy, rounding>(v)    // ... with explicit selectors
+scaled_dequantize(b)                         // block -> Vec<FP32,N>
+```
+
+**The output format is spelled, never inferred.** A `Vec<FP32, N>` operand
+says nothing about which element format or scale to quantize into --- MXFP4
+and MXFP8 are equally valid results --- so `Fmt` is a required type argument.
+It may be an alias (`scaled_quantize<MXFP4>(v)`, the normal form) or written
+inline. The operand's length must equal the format's `N`; quantizing 32
+values into a 16-element block is a compile error, not a truncation.
+
+`scaled_dequantize` needs no annotation: `N` and the formats all come from
+the block's own type. It yields `Vec<FP32, N>` with the scale already
+applied, and is the only way to read an element (§3.11).
+
+| Selector | Values | Default |
+|---|---|---|
+| `policy` | `floor_pow2`, `ceil_pow2` | `floor_pow2` |
+| `rounding` | `rne` (`rtz`, `rna` reserved) | `rne` |
+
+`floor_pow2` is the OCP §6.3 rule: the shared scale is the largest power of
+two that normalizes the block maximum into the element format's top binade.
+Because that binade's largest *representable* value is below its top, some
+elements saturate --- routine under this policy, not a corner case.
+`ceil_pow2` rounds the scale up instead when the block maximum is not already
+a power of two, trading the top element codes for fewer saturations.
+
+Semantics, all of which follow from `E8M0` having no zero and reserving
+`0xFF` for NaN:
+
+  - An **all-zero** block gets the *minimum* scale `0x00` (which denotes
+    `2^-127`, not zero) and zero elements.
+  - A block containing **any NaN or infinity** gets the NaN scale `0xFF`; its
+    element bits are then don't-care, and `scaled_dequantize` yields NaN in
+    every lane regardless of them.
+  - Dequantizing a finite element under a finite scale **saturates** to
+    ±`FP32` max rather than overflowing to infinity. An element that is
+    itself Inf or NaN (`FP8E5M2` / `FP8E4M3` can be) keeps its own result.
+  - Element narrowing inherits the element format's own overflow rule and the
+    `--fp-compat` profile --- so an out-of-range value saturates for the
+    all-finite formats (`FP4E2M1`, `FP6E2M3`, `FP6E3M2`) and becomes that
+    format's NaN for `FP8E4M3`.
+
+Scaling by the reciprocal scale is an exact power-of-two multiply in FP32, so
+each element is rounded **once**, from the true `vᵢ / X`.
+
+Both conversions are combinational and must be the whole right-hand side of
+an assignment. To index an element, bind the result first:
+
+```arch
+wire all: Vec<FP32, 32>;
+comb
+  blk = scaled_quantize<MXFP4, ceil_pow2, rne>(v);
+  all = scaled_dequantize(blk);
+  e   = all[3];
+end comb
+```
+
+**Not yet implemented:** `rtz` / `rna` rounding (they need their own element
+rounders in each backend, with their own overflow rules --- arch#890), the `exact` scale
+policy and `stochastic` rounding (see §3.11 for why both are deferred),
+`scaled_dot`, and the `UE4M3` scale.
 
 **3.12 Package-scope type aliases**
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1161,6 +1161,28 @@ pub enum TypeExpr {
     ScaledVec(Box<TypeExpr>, Box<Expr>, Box<TypeExpr>),
 }
 
+/// Shared-scale selection policy for `scaled_quantize` (proposal §3.1).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum ScalePolicy {
+    /// OCP §6.3: largest power of two <= amax. The default (decision #1).
+    FloorPow2,
+    /// NVIDIA: round the scale UP instead, trading the top element codes
+    /// for fewer saturations.
+    CeilPow2,
+}
+
+/// Element rounding mode for `scaled_quantize`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum RoundMode {
+    /// Round to nearest, ties to even. The default, and the only mode OCP
+    /// requires to be available.
+    Rne,
+    /// Round toward zero.
+    Rtz,
+    /// Round to nearest, ties away from zero.
+    Rna,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ResetKind {
     Sync,
@@ -1252,6 +1274,15 @@ pub enum ExprKind {
     /// Motivation section (`acc@6 <= fma(a,b,c)` silently NOT being
     /// retimed) cannot be written by accident.
     PipelinedCall(String, Vec<Expr>, u32),
+    /// `scaled_quantize<Fmt, policy, rounding>(v)` — quantize a
+    /// `Vec<FP32, N>` into a block of the EXPLICITLY named format.
+    ///
+    /// The format is spelled at the call site rather than inferred: a
+    /// `Vec<FP32,N>` argument says nothing about the element format or the
+    /// scale, so `MXFP4` and `MXFP8` are equally valid outputs and there is
+    /// nothing to infer from. Carrying a `TypeExpr` inside an expression is
+    /// why this needs its own variant — it is the first expression that can.
+    ScaledQuantize(Box<Expr>, Box<TypeExpr>, ScalePolicy, RoundMode),
     /// SVA delay-shift: `##N expr`. Inside an `assert`/`cover` body, shifts
     /// the cycle of `expr` forward by `N` (i.e. evaluates `expr` at cycle
     /// `t + N` when the surrounding property is checked at cycle `t`).

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -174,6 +174,11 @@ pub struct Codegen<'a> {
     /// Set when any FP32/BF16 operation was emitted, so the `arch_f32_*` /
     /// `arch_bf16_*` SystemVerilog helper package is prepended to the output.
     fp_helpers_used: std::cell::Cell<bool>,
+    /// `ScaledVec` block helpers referenced by this design, one per distinct
+    /// (op, element, N, scale, policy, rounding). A `BTreeSet` so the emitted
+    /// prefix is byte-stable run to run — `scripts/refactor_diff.sh` diffs
+    /// emitted SV, so a `HashSet` here would show up as spurious churn.
+    block_helpers: std::cell::RefCell<std::collections::BTreeSet<crate::fp_block::BlockHelper>>,
     /// Staged pipelined-operator sites (`arch build --staged-ops`,
     /// proposal phase 3.5) — see `pipelined_ops::StagedSite`. Empty in
     /// cascade mode. `staged_emitted` records that at least one instance
@@ -416,6 +421,7 @@ impl<'a> Codegen<'a> {
             bus_wires: std::collections::HashMap::new(),
             reset_ports: std::collections::HashMap::new(),
             fp_helpers_used: std::cell::Cell::new(false),
+            block_helpers: std::cell::RefCell::new(std::collections::BTreeSet::new()),
             staged_sites: Vec::new(),
             staged_emitted: std::cell::Cell::new(false),
             fp_compat: crate::FpCompat::default(),
@@ -657,6 +663,24 @@ impl<'a> Codegen<'a> {
             self.out = prefix;
         }
 
+        // Prepend the `ScaledVec` block helpers, then the FP helpers they
+        // call. Order matters: SV requires a function to be declared before
+        // use at `$unit` scope, and the block helpers call `arch_f32_mul` and
+        // friends, so the FP block must end up FIRST in the file. Prepending
+        // the blocks before the FP helpers achieves that.
+        if !self.block_helpers.borrow().is_empty() {
+            let mut prefix = String::from(
+                "// ── ScaledVec block helpers — generated from src/fp_block.rs, which\n\
+                 // emits this SystemVerilog and the matching arch-sim C++ from ONE\n\
+                 // descriptor. Do not edit by hand. ──\n",
+            );
+            for h in self.block_helpers.borrow().iter() {
+                prefix.push_str(&crate::fp_block::sv_definition(*h));
+                prefix.push('\n');
+            }
+            prefix.push_str(&self.out);
+            self.out = prefix;
+        }
         // Prepend the floating-point helper functions if any FP op was emitted.
         if self.fp_helpers_used.get() {
             let mut prefix = fp::fp_sv_helpers(self.fp_compat);
@@ -6126,6 +6150,25 @@ impl<'a> Codegen<'a> {
     ///
     /// Mirrors `typecheck::TypeChecker::type_expr_width`. Kept private to
     /// codegen for now — promote to a shared util if a third caller appears.
+    /// Resolve a `ScaledVec<Elem, N, Scale>` surface type to the block shape
+    /// the helper emitters are keyed on.
+    ///
+    /// `None` — never a guess — when `N` does not fold to a literal or a
+    /// member type is not a legal block member. Both callers turn that into a
+    /// panic rather than a fallback: typecheck has already accepted the type,
+    /// so a `None` is a compiler bug, and inventing a shape here is precisely
+    /// how phase 2a shipped a 40-bit SV port against an 8-bit sim variable.
+    fn block_shape_of_type(&self, ty: &TypeExpr) -> Option<crate::fp_block::BlockShape> {
+        let TypeExpr::ScaledVec(elem, size, scale) = ty else {
+            return None;
+        };
+        let n = match &size.kind {
+            ExprKind::Literal(LitKind::Dec(n)) | ExprKind::Literal(LitKind::Hex(n)) => *n as u32,
+            _ => return None,
+        };
+        crate::fp_block::shape_of(elem, n, scale)
+    }
+
     fn type_expr_width(&self, ty: &TypeExpr) -> Option<u32> {
         let eval = |e: &Expr| match &e.kind {
             ExprKind::Literal(LitKind::Dec(n)) | ExprKind::Literal(LitKind::Hex(n)) => {
@@ -7193,6 +7236,26 @@ impl<'a> Codegen<'a> {
             // as a loud backstop rather than silently falling back to a
             // comb cone, which would misrepresent an un-retimed operator
             // as pipelined.
+            // `scaled_quantize<Fmt, policy, rounding>(v)` — the block shape
+            // comes from the EXPRESSION's own format argument, not from the
+            // assignment target, so nothing here has to be inferred.
+            ExprKind::ScaledQuantize(value, fmt, policy, round) => {
+                let shape = self.block_shape_of_type(fmt).unwrap_or_else(|| {
+                    panic!(
+                        "scaled_quantize format has no resolvable block shape — \
+                         typecheck accepts only `ScaledVec` formats, so this means the \
+                         block size did not fold to a literal (arch#884)"
+                    )
+                });
+                let h = crate::fp_block::BlockHelper::Quantize {
+                    shape,
+                    policy: *policy,
+                    round: *round,
+                };
+                self.fp_helpers_used.set(true);
+                self.block_helpers.borrow_mut().insert(h);
+                format!("{}({})", h.sv_name(), self.emit_expr_str(value))
+            }
             ExprKind::PipelinedCall(name, _, stages) => unreachable!(
                 "codegen reached `{name}<pipelined, {stages}>(...)` — this should have been \
                  lowered by pipelined_ops::lower_pipelined_calls before codegen started"
@@ -7878,6 +7941,28 @@ impl<'a> Codegen<'a> {
             return out_wire.clone();
         }
         let arg_strs: Vec<String> = args.iter().map(emit_arg).collect();
+        // `scaled_dequantize(b)` → the generated block helper. The shape comes
+        // from the OPERAND's declared type; typecheck has already refused a
+        // non-block operand, so a `None` here means the block's `N` did not
+        // fold to a literal, which is a real limitation and must not be
+        // guessed at.
+        if name == "scaled_dequantize" && args.len() == 1 {
+            let shape = self
+                .expr_decl_type(&args[0])
+                .as_ref()
+                .and_then(|t| self.block_shape_of_type(t))
+                .unwrap_or_else(|| {
+                    panic!(
+                        "scaled_dequantize operand has no resolvable block shape — \
+                         typecheck accepts only `ScaledVec` operands, so this means the \
+                         block size did not fold to a literal (arch#884)"
+                    )
+                });
+            let h = crate::fp_block::BlockHelper::Dequantize { shape };
+            self.fp_helpers_used.set(true);
+            self.block_helpers.borrow_mut().insert(h);
+            return format!("{}({})", h.sv_name(), arg_strs[0]);
+        }
         // Built-in SVA: past/rose/fell → SV $past/$rose/$fell
         if name == "past" || name == "rose" || name == "fell" {
             return format!("${name}({})", arg_strs.join(", "));

--- a/src/formal.rs
+++ b/src/formal.rs
@@ -2449,6 +2449,11 @@ impl<'a> FormalCtx<'a> {
             // Latency annotation is transparent to SMT: at timepoint t,
             // `q@0` is the same as `q` at t. Non-@0 reads are rejected by
             // typecheck before reaching formal emission.
+            ScaledQuantize(..) => Err(CompileError::general(
+                "`scaled_quantize` is not yet supported by `arch formal` \
+                 (arch#884 phase 2b)",
+                expr.span,
+            )),
             LatencyAt(inner, _) => self.encode_raw(inner, t),
             // `fma<pipelined, N>(...)` — the retimed staged datapath (and
             // its sequential-equivalence proof obligation vs. the trusted

--- a/src/fp_block.rs
+++ b/src/fp_block.rs
@@ -1,0 +1,723 @@
+//! Block-scaled (`ScaledVec`) operations — the `scaled_quantize` /
+//! `scaled_dequantize` lowering shared by `arch build` and `arch sim`.
+//!
+//! **Why one module emits both backends.** The numerics here are *not* new:
+//! every float operation used below is an existing helper with an exhaustive
+//! SMT miter behind it (`arch_e8m0_to_f32`, `arch_f32_to_e8m0`,
+//! `arch_f32_mul`, `arch_f32_to_<elem>`, `arch_<elem>_to_f32` — see
+//! `src/fp_ops.rs` and `src/fp_smt_proof.rs`). What is new is the *glue*:
+//! a magnitude reduction, an exponent subtraction, and the bit packing. Glue
+//! is exactly where an SV emitter and a C++ emitter written in different
+//! files drift, so both renderings live here, adjacent, generated from one
+//! descriptor. `fp_block_sv_and_cpp_agree_on_shape` pins their structure and
+//! the `tests/fp_v1/rtl_diff` harness pins their *values* by running the
+//! emitted SV under Verilator against this same C++ as the DPI reference.
+//!
+//! **The glue carries no float semantics of its own.** Two deliberate
+//! choices make that true:
+//!
+//! 1. The block maximum is an **unsigned integer** max over the sign-cleared
+//!    words. For non-negative IEEE-754, bit-pattern order *is* numeric order,
+//!    and every NaN sorts above `+Inf` — so one integer compare yields both
+//!    the magnitude maximum and the "any non-finite in this block" test, with
+//!    no float compare and therefore no NaN-ordering subtlety to get wrong.
+//! 2. The per-element division by the shared scale is done as a multiply by
+//!    `2^-(code-127) == 2^((254-code)-127)`, i.e. by *another E8M0 code*.
+//!    A power-of-two multiply is exact in FP32, so the element narrow that
+//!    follows rounds exactly once, from the true `v_i / X`. That single
+//!    rounding is what makes the round-trip error bound provable (arch#884).
+//!
+//! Layout is the one fixed in phase 2a (`fp_format::scaled_vec_width`):
+//! `{ scale[SW-1:0], P[N-1], …, P[1], P[0] }` — scale in the high bits,
+//! element `i` at `[i*EW +: EW]`.
+
+use crate::ast::{RoundMode, ScalePolicy, TypeExpr};
+use crate::fp_format::{by_type_expr, FpFormatId};
+use std::fmt::Write as _;
+
+/// The scale format of a block. One variant today; `UE4M3` (NVFP4) joins it
+/// in phase 5. An enum rather than a bool so that addition forces every
+/// `match` here to be revisited — the shared-exponent arithmetic below is
+/// specific to E8M0's "same bias as FP32, no zero, `0xFF` is NaN" shape.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum BlockScale {
+    E8m0,
+}
+
+impl BlockScale {
+    fn tag(self) -> &'static str {
+        match self {
+            BlockScale::E8m0 => "e8m0",
+        }
+    }
+    fn width(self) -> u32 {
+        match self {
+            BlockScale::E8m0 => 8,
+        }
+    }
+}
+
+/// A block's static shape: what `scaled_dequantize` needs, and the part of
+/// `scaled_quantize` that is not a policy knob.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct BlockShape {
+    pub elem: FpFormatId,
+    pub n: u32,
+    pub scale: BlockScale,
+}
+
+/// One emitted helper. Ordered so the emitters can keep a `BTreeSet` and
+/// produce byte-identical output run to run.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum BlockHelper {
+    /// `Vec<FP32, N>` → block.
+    Quantize {
+        shape: BlockShape,
+        policy: ScalePolicy,
+        round: RoundMode,
+    },
+    /// Block → `Vec<FP32, N>`.
+    Dequantize { shape: BlockShape },
+}
+
+/// Resolve a `ScaledVec<Elem, N, Scale>` surface type to a block shape.
+///
+/// Returns `None` for anything the block predicates reject, so a caller can
+/// never silently proceed on a half-understood type — the failure mode that
+/// turned `ScaledVec<UInt<8>,4,E8M0>` into a 40-bit SV port against an 8-bit
+/// sim variable in phase 2a.
+pub fn shape_of(elem: &TypeExpr, n: u32, scale: &TypeExpr) -> Option<BlockShape> {
+    let elem = by_type_expr(elem)?.id;
+    if !matches!(
+        elem,
+        FpFormatId::E2m1
+            | FpFormatId::E2m3
+            | FpFormatId::E3m2
+            | FpFormatId::E4m3
+            | FpFormatId::E5m2
+    ) {
+        return None;
+    }
+    let scale = match scale {
+        TypeExpr::E8M0 => BlockScale::E8m0,
+        _ => return None,
+    };
+    Some(BlockShape { elem, n, scale })
+}
+
+impl BlockShape {
+    fn desc(self) -> &'static crate::fp_format::FpFormat {
+        crate::fp_format::FORMATS
+            .iter()
+            .find(|f| f.id == self.elem)
+            .expect("FpFormatId always has a row — fp_format::FORMATS is total over the enum")
+    }
+    fn elem_tag(self) -> &'static str {
+        self.desc().tag
+    }
+    fn elem_width(self) -> u32 {
+        self.desc().width
+    }
+    /// Total packed width, `scale_w + N * elem_w`.
+    pub fn bits(self) -> u32 {
+        self.scale.width() + self.n * self.elem_width()
+    }
+    /// Width of the `Vec<FP32, N>` side, packed.
+    fn vec_bits(self) -> u32 {
+        self.n * 32
+    }
+    /// The element format's top normal binade exponent: `floor(log2(max))`.
+    ///
+    /// Derived from `max_finite` rather than hand-tabled, so it cannot drift
+    /// from the format table. E2M1's max is `6.0 = 1.5 * 2^2` → 2; E5M2's is
+    /// `57344 = 1.75 * 2^15` → 15. This is the amount the block's shared
+    /// exponent is shifted down by, so that the largest element in the block
+    /// normalizes into the format's top binade (OCP §6.3).
+    fn elem_emax(self) -> u32 {
+        let m = self.desc().max_finite;
+        debug_assert!(m > 0.0 && m.is_finite());
+        m.log2().floor() as u32
+    }
+}
+
+impl BlockHelper {
+    fn shape(self) -> BlockShape {
+        match self {
+            BlockHelper::Quantize { shape, .. } | BlockHelper::Dequantize { shape } => shape,
+        }
+    }
+
+    /// The SystemVerilog function name. The C++ name is this with a leading
+    /// underscore, matching the existing `arch_f32_mul` / `_arch_f32_mul`
+    /// convention.
+    pub fn sv_name(self) -> String {
+        let s = self.shape();
+        match self {
+            BlockHelper::Quantize { policy, round, .. } => format!(
+                "arch_scaled_quantize_{}_{}_{}_{}_{}",
+                s.elem_tag(),
+                s.n,
+                s.scale.tag(),
+                policy_tag(policy),
+                round_tag(round),
+            ),
+            BlockHelper::Dequantize { .. } => format!(
+                "arch_scaled_dequantize_{}_{}_{}",
+                s.elem_tag(),
+                s.n,
+                s.scale.tag(),
+            ),
+        }
+    }
+
+    pub fn cpp_name(self) -> String {
+        format!("_{}", self.sv_name())
+    }
+}
+
+fn policy_tag(p: ScalePolicy) -> &'static str {
+    match p {
+        ScalePolicy::FloorPow2 => "floor",
+        ScalePolicy::CeilPow2 => "ceil",
+    }
+}
+
+fn round_tag(r: RoundMode) -> &'static str {
+    match r {
+        RoundMode::Rne => "rne",
+        RoundMode::Rtz => "rtz",
+        RoundMode::Rna => "rna",
+    }
+}
+
+/// `[hi:0]` in the `logic [hi:0] ` declaration style `render_sv` uses.
+fn sv_w(bits: u32) -> String {
+    if bits == 1 {
+        String::new()
+    } else {
+        format!("[{}:0] ", bits - 1)
+    }
+}
+
+// ── SystemVerilog ───────────────────────────────────────────────────────────
+
+/// The `$unit`-scope SV definition. Emitted alongside `fp::fp_sv_helpers`,
+/// which supplies every `arch_*` callee referenced here.
+pub fn sv_definition(h: BlockHelper) -> String {
+    match h {
+        BlockHelper::Quantize {
+            shape,
+            policy,
+            round,
+        } => sv_quantize(shape, policy, round),
+        BlockHelper::Dequantize { shape } => sv_dequantize(shape),
+    }
+}
+
+fn sv_quantize(s: BlockShape, policy: ScalePolicy, round: RoundMode) -> String {
+    assert_eq!(
+        round,
+        RoundMode::Rne,
+        "only RNE narrowing is lowered today; typecheck refuses the others \
+         (arch#890) — reaching here means that gate was removed \
+         without adding the rounder variants"
+    );
+    let name = BlockHelper::Quantize {
+        shape: s,
+        policy,
+        round,
+    }
+    .sv_name();
+    let (bw, vw, ew, sw) = (s.bits(), s.vec_bits(), s.elem_width(), s.scale.width());
+    let (n, emax) = (s.n, s.elem_emax());
+    let tag = s.elem_tag();
+    let mut o = String::new();
+    let _ = writeln!(
+        o,
+        "// {name}: Vec<FP32,{n}> -> {{scale, P[{}..0]}}. OCP MX \u{a7}6.3 conversion.",
+        n - 1
+    );
+    let _ = writeln!(
+        o,
+        "function automatic logic {}{name}(input logic {}v);",
+        sv_w(bw),
+        sv_w(vw)
+    );
+    let _ = writeln!(o, "  logic {}amax;", sv_w(32));
+    let _ = writeln!(o, "  logic {}mag;", sv_w(32));
+    let _ = writeln!(o, "  logic {}inv;", sv_w(32));
+    let _ = writeln!(o, "  logic {}ecode;", sv_w(8));
+    let _ = writeln!(o, "  logic {}code;", sv_w(8));
+    let _ = writeln!(o, "  logic {}r;", sv_w(bw));
+    // 1. amax as an unsigned integer max of |v_i| — see the module header.
+    let _ = writeln!(o, "  amax = {}'h0;", 32);
+    let _ = writeln!(o, "  for (int unsigned i = 0; i < {n}; i = i + 1) begin");
+    let _ = writeln!(o, "    mag = v[i*32 +: 32] & 32'h7FFFFFFF;");
+    let _ = writeln!(o, "    if (mag > amax) amax = mag;");
+    let _ = writeln!(o, "  end");
+    let _ = writeln!(o, "  r = {bw}'h0;");
+    // 2. Non-finite anywhere in the block => NaN scale, element bits are
+    //    don't-care by the block value rule and are emitted as zero.
+    let _ = writeln!(o, "  if (amax >= 32'h7F800000) begin");
+    let _ = writeln!(o, "    r[{}:{}] = 8'hFF;", bw - 1, bw - sw);
+    // 3. All-zero block => minimum scale, zero elements.
+    let _ = writeln!(o, "  end else if (amax == 32'h0) begin");
+    let _ = writeln!(o, "    r[{}:{}] = 8'h00;", bw - 1, bw - sw);
+    let _ = writeln!(o, "  end else begin");
+    let _ = writeln!(o, "    ecode = arch_f32_to_e8m0(amax);");
+    if policy == ScalePolicy::CeilPow2 {
+        // Round the scale UP when amax is not already an exact power of two.
+        // `arch_e8m0_to_f32(ecode)` is the floor power of two as an f32 bit
+        // pattern; both operands are finite and positive, so the unsigned
+        // compare is the numeric compare. `0xFE` is the largest non-NaN code.
+        let _ = writeln!(
+            o,
+            "    if (amax > arch_e8m0_to_f32(ecode) && ecode != 8'hFE) ecode = ecode + 8'h01;"
+        );
+    }
+    // 4. Shift the shared exponent down so the block maximum normalizes into
+    //    the element format's top binade; clamp underflow at the minimum
+    //    scale (overflow is structurally impossible: ecode <= 0xFE, emax >= 2).
+    let _ = writeln!(
+        o,
+        "    code = (ecode > 8'd{emax}) ? (ecode - 8'd{emax}) : 8'h00;"
+    );
+    // 5. Multiply by the reciprocal scale, itself an E8M0 code, so the
+    //    scaling is exact and the narrow below rounds exactly once.
+    let _ = writeln!(o, "    inv = arch_e8m0_to_f32(8'd254 - code);");
+    let _ = writeln!(o, "    for (int unsigned i = 0; i < {n}; i = i + 1) begin");
+    let _ = writeln!(
+        o,
+        "      r[i*{ew} +: {ew}] = arch_f32_to_{tag}(arch_f32_mul(v[i*32 +: 32], inv));"
+    );
+    let _ = writeln!(o, "    end");
+    let _ = writeln!(o, "    r[{}:{}] = code;", bw - 1, bw - sw);
+    let _ = writeln!(o, "  end");
+    let _ = writeln!(o, "  {name} = r;");
+    let _ = writeln!(o, "endfunction");
+    o
+}
+
+fn sv_dequantize(s: BlockShape) -> String {
+    let name = BlockHelper::Dequantize { shape: s }.sv_name();
+    let (bw, vw, ew, sw) = (s.bits(), s.vec_bits(), s.elem_width(), s.scale.width());
+    let (n, tag) = (s.n, s.elem_tag());
+    let mut o = String::new();
+    let _ = writeln!(o, "// {name}: block -> Vec<FP32,{n}>, scale applied.");
+    let _ = writeln!(
+        o,
+        "function automatic logic {}{name}(input logic {}b);",
+        sv_w(vw),
+        sv_w(bw)
+    );
+    let _ = writeln!(o, "  logic {}x;", sv_w(32));
+    let _ = writeln!(o, "  logic {}w;", sv_w(32));
+    let _ = writeln!(o, "  logic {}p;", sv_w(32));
+    let _ = writeln!(o, "  logic {}r;", sv_w(vw));
+    // A NaN scale (code 0xFF) widens to a NaN f32, so every product below is
+    // NaN and the element bits are ignored: the block value rule falls out of
+    // the multiply rather than needing a branch.
+    let _ = writeln!(o, "  x = arch_e8m0_to_f32(b[{}:{}]);", bw - 1, bw - sw);
+    let _ = writeln!(o, "  r = {vw}'h0;");
+    let _ = writeln!(o, "  for (int unsigned i = 0; i < {n}; i = i + 1) begin");
+    let _ = writeln!(o, "    w = arch_{tag}_to_f32(b[i*{ew} +: {ew}]);");
+    let _ = writeln!(o, "    p = arch_f32_mul(x, w);");
+    // A finite element scaled by a finite scale saturates to +-FP32_MAX
+    // rather than overflowing to infinity. An element that is ITSELF Inf or
+    // NaN (E4M3/E5M2 can be) keeps its own non-finite result — hence the
+    // guard on `w` and not just on the product.
+    let _ = writeln!(
+        o,
+        "    if (p[30:23] == 8'hFF && p[22:0] == 23'h0 && w[30:23] != 8'hFF)"
+    );
+    let _ = writeln!(o, "      p = {{p[31], 31'h7F7FFFFF}};");
+    let _ = writeln!(o, "    r[i*32 +: 32] = p;");
+    let _ = writeln!(o, "  end");
+    let _ = writeln!(o, "  {name} = r;");
+    let _ = writeln!(o, "endfunction");
+    o
+}
+
+// ── C++ (arch sim) ──────────────────────────────────────────────────────────
+
+/// Bit insert/extract over a little-endian `uint32_t` word array, matching
+/// `VlWide`'s layout (`_data[0]` is bits 31:0).
+///
+/// Bit-at-a-time on purpose: element widths are 4, 6 and 8 bits, and 6 does
+/// not divide 32, so a field can straddle a word boundary. A width-agnostic
+/// loop is obviously correct where a shift-and-mask fast path would need a
+/// straddle case that only FP6 blocks exercise.
+/// Bit and word access over a little-endian `uint32_t` array, matching
+/// `VlWide`'s layout (`_data[0]` is bits 31:0).
+///
+/// `_arch_blk_ins`/`_arch_blk_ext` work a bit at a time on purpose: element
+/// widths are 4, 6 and 8 bits, and 6 does not divide 32, so a field can
+/// straddle a word boundary. A width-agnostic loop is obviously correct where
+/// a shift-and-mask fast path would need a straddle case that only FP6 blocks
+/// exercise.
+///
+/// `_arch_blk_get`/`_arch_blk_put` are overloaded rather than switched on a
+/// width, because the sim gives one block type TWO different C++
+/// representations: a 72-bit block is `VlWide<3>` as a port but `_arch_u128`
+/// as an internal wire. Any width table here would therefore be right for
+/// ports and wrong for wires — the `_ => 32` failure shape again. Letting the
+/// destination's own type select the overload means there is nothing to keep
+/// in sync: the scalar overload takes `unsigned __int128`, which every
+/// `uint8/16/32/64_t` and `_arch_u128` promotes to, and the `VlWide<W>`
+/// template is the more specialized match for wide storage.
+pub const CPP_PRELUDE: &str = "\
+// ── ScaledVec block bit access (see src/fp_block.rs) ──
+static inline void _arch_blk_ins(uint32_t* w, unsigned lo, unsigned width, uint32_t val) {
+  for (unsigned k = 0; k < width; ++k) {
+    unsigned b = lo + k;
+    w[b >> 5] = (w[b >> 5] & ~(1u << (b & 31))) | (((val >> k) & 1u) << (b & 31));
+  }
+}
+static inline uint32_t _arch_blk_ext(const uint32_t* w, unsigned lo, unsigned width) {
+  uint32_t r = 0;
+  for (unsigned k = 0; k < width; ++k) {
+    unsigned b = lo + k;
+    r |= ((w[b >> 5] >> (b & 31)) & 1u) << k;
+  }
+  return r;
+}
+static inline void _arch_blk_get(uint32_t* w, int nw, unsigned __int128 v) {
+  for (int k = 0; k < nw; ++k) w[k] = (k < 4) ? (uint32_t)(v >> (32 * k)) : 0u;
+}
+template <int W> static inline void _arch_blk_get(uint32_t* w, int nw, const VlWide<W>& v) {
+  for (int k = 0; k < nw; ++k) w[k] = (k < W) ? v.data()[k] : 0u;
+}
+template <typename T> static inline void _arch_blk_put(T& dst, const uint32_t* w, int nw) {
+  unsigned __int128 acc = 0;
+  for (int k = 0; k < nw && k < 4; ++k) acc |= ((unsigned __int128)w[k]) << (32 * k);
+  dst = (T)acc;
+}
+template <int W> static inline void _arch_blk_put(VlWide<W>& dst, const uint32_t* w, int nw) {
+  for (int k = 0; k < W; ++k) dst.data()[k] = (k < nw) ? w[k] : 0u;
+}
+";
+
+fn cpp_words(bits: u32) -> u32 {
+    bits.div_ceil(32)
+}
+
+/// The C++ definition. Signature is `(input, output&)` rather than a return
+/// value because both sides are aggregates in the sim: a wide block is a
+/// `VlWide` or an `_arch_u128`, and a `Vec<FP32,N>` is a plain C array,
+/// neither of which composes into an expression the way the SV function
+/// return does. The block side is a template parameter so the caller's own
+/// storage type selects the access overload — see [`CPP_PRELUDE`].
+pub fn cpp_definition(h: BlockHelper) -> String {
+    match h {
+        BlockHelper::Quantize {
+            shape,
+            policy,
+            round,
+        } => cpp_quantize(shape, policy, round),
+        BlockHelper::Dequantize { shape } => cpp_dequantize(shape),
+    }
+}
+
+fn cpp_quantize(s: BlockShape, policy: ScalePolicy, round: RoundMode) -> String {
+    assert_eq!(
+        round,
+        RoundMode::Rne,
+        "only RNE narrowing is lowered today; typecheck refuses the others \
+         (arch#890) — reaching here means that gate was removed \
+         without adding the rounder variants"
+    );
+    let name = BlockHelper::Quantize {
+        shape: s,
+        policy,
+        round,
+    }
+    .cpp_name();
+    let (bw, ew, sw) = (s.bits(), s.elem_width(), s.scale.width());
+    let (n, emax, tag) = (s.n, s.elem_emax(), s.elem_tag());
+    let nw = cpp_words(bw);
+    let mut o = String::new();
+    let _ = writeln!(
+        o,
+        "// {name}: Vec<FP32,{n}> -> block ({bw} bits). Mirrors sv_quantize in src/fp_block.rs."
+    );
+    let _ = writeln!(o, "template <typename BT>");
+    let _ = writeln!(
+        o,
+        "static inline void {name}(const uint32_t* v, BT& out) {{"
+    );
+    let _ = writeln!(o, "  uint32_t _w[{nw}];");
+    let _ = writeln!(o, "  for (int k = 0; k < {nw}; ++k) _w[k] = 0u;");
+    let _ = writeln!(o, "  uint32_t amax = 0u;");
+    let _ = writeln!(o, "  for (unsigned i = 0; i < {n}u; ++i) {{");
+    let _ = writeln!(o, "    uint32_t mag = v[i] & 0x7FFFFFFFu;");
+    let _ = writeln!(o, "    if (mag > amax) amax = mag;");
+    let _ = writeln!(o, "  }}");
+    let _ = writeln!(o, "  if (amax >= 0x7F800000u) {{");
+    let _ = writeln!(o, "    _arch_blk_ins(_w, {}u, {sw}u, 0xFFu);", bw - sw);
+    let _ = writeln!(o, "  }} else if (amax == 0u) {{");
+    let _ = writeln!(o, "    _arch_blk_ins(_w, {}u, {sw}u, 0x00u);", bw - sw);
+    let _ = writeln!(o, "  }} else {{");
+    let _ = writeln!(o, "    uint8_t ecode = _arch_f32_to_e8m0(amax);");
+    if policy == ScalePolicy::CeilPow2 {
+        let _ = writeln!(
+            o,
+            "    if (amax > _arch_e8m0_to_f32(ecode) && ecode != 0xFEu) ecode = (uint8_t)(ecode + 1u);"
+        );
+    }
+    let _ = writeln!(
+        o,
+        "    uint8_t code = (ecode > {emax}u) ? (uint8_t)(ecode - {emax}u) : (uint8_t)0u;"
+    );
+    let _ = writeln!(
+        o,
+        "    uint32_t inv = _arch_e8m0_to_f32((uint8_t)(254u - code));"
+    );
+    let _ = writeln!(o, "    for (unsigned i = 0; i < {n}u; ++i) {{");
+    let _ = writeln!(
+        o,
+        "      uint32_t p = (uint32_t)_arch_f32_to_{tag}(_arch_f32_mul(v[i], inv));"
+    );
+    let _ = writeln!(o, "      _arch_blk_ins(_w, i * {ew}u, {ew}u, p);");
+    let _ = writeln!(o, "    }}");
+    let _ = writeln!(
+        o,
+        "    _arch_blk_ins(_w, {}u, {sw}u, (uint32_t)code);",
+        bw - sw
+    );
+    let _ = writeln!(o, "  }}");
+    let _ = writeln!(o, "  _arch_blk_put(out, _w, {nw});");
+    let _ = writeln!(o, "}}");
+    o
+}
+
+fn cpp_dequantize(s: BlockShape) -> String {
+    let name = BlockHelper::Dequantize { shape: s }.cpp_name();
+    let (bw, ew, sw) = (s.bits(), s.elem_width(), s.scale.width());
+    let (n, tag) = (s.n, s.elem_tag());
+    let nw = cpp_words(bw);
+    let mut o = String::new();
+    let _ = writeln!(
+        o,
+        "// {name}: block ({bw} bits) -> Vec<FP32,{n}>. Mirrors sv_dequantize in src/fp_block.rs."
+    );
+    let _ = writeln!(o, "template <typename BT>");
+    let _ = writeln!(
+        o,
+        "static inline void {name}(const BT& b, uint32_t* out) {{"
+    );
+    let _ = writeln!(o, "  uint32_t _w[{nw}];");
+    let _ = writeln!(o, "  _arch_blk_get(_w, {nw}, b);");
+    let _ = writeln!(
+        o,
+        "  uint32_t x = _arch_e8m0_to_f32((uint8_t)_arch_blk_ext(_w, {}u, {sw}u));",
+        bw - sw
+    );
+    let _ = writeln!(o, "  for (unsigned i = 0; i < {n}u; ++i) {{");
+    let _ = writeln!(
+        o,
+        "    uint32_t w = _arch_{tag}_to_f32((uint8_t)_arch_blk_ext(_w, i * {ew}u, {ew}u));"
+    );
+    let _ = writeln!(o, "    uint32_t p = _arch_f32_mul(x, w);");
+    let _ = writeln!(
+        o,
+        "    if ((p & 0x7FFFFFFFu) == 0x7F800000u && (w & 0x7F800000u) != 0x7F800000u)"
+    );
+    let _ = writeln!(o, "      p = (p & 0x80000000u) | 0x7F7FFFFFu;");
+    let _ = writeln!(o, "    out[i] = p;");
+    let _ = writeln!(o, "  }}");
+    let _ = writeln!(o, "}}");
+    o
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn shape(elem: FpFormatId, n: u32) -> BlockShape {
+        BlockShape {
+            elem,
+            n,
+            scale: BlockScale::E8m0,
+        }
+    }
+
+    /// `elem_emax` is derived from `max_finite` rather than hand-tabled, so
+    /// pin every value it can produce. These are the amounts the shared
+    /// exponent is shifted by; an off-by-one here is a silent 2x scale error
+    /// across the whole block.
+    #[test]
+    fn fp_block_emax_matches_each_format_top_binade() {
+        for (id, want, why) in [
+            (FpFormatId::E2m1, 2u32, "max 6.0 = 1.5 * 2^2"),
+            (FpFormatId::E2m3, 2, "max 7.5 = 1.875 * 2^2"),
+            (FpFormatId::E3m2, 4, "max 28 = 1.75 * 2^4"),
+            (FpFormatId::E4m3, 8, "max 448 = 1.75 * 2^8"),
+            (FpFormatId::E5m2, 15, "max 57344 = 1.75 * 2^15"),
+        ] {
+            assert_eq!(shape(id, 32).elem_emax(), want, "{id:?}: {why}");
+        }
+    }
+
+    /// The packed width must agree with `fp_format::scaled_vec_width`, which
+    /// is what the type checker and both backends size ports from. Two
+    /// independent width computations for one layout is exactly the phase-2a
+    /// divergence this keeps closed.
+    #[test]
+    fn fp_block_bits_agree_with_scaled_vec_width() {
+        for (id, ty) in [
+            (FpFormatId::E2m1, TypeExpr::FP4E2M1),
+            (FpFormatId::E2m3, TypeExpr::FP6E2M3),
+            (FpFormatId::E3m2, TypeExpr::FP6E3M2),
+            (FpFormatId::E4m3, TypeExpr::FP8E4M3),
+            (FpFormatId::E5m2, TypeExpr::FP8E5M2),
+        ] {
+            for n in [1u32, 4, 16, 32] {
+                assert_eq!(
+                    Some(shape(id, n).bits()),
+                    crate::fp_format::scaled_vec_width(&ty, n, &TypeExpr::E8M0),
+                    "{id:?} x {n}"
+                );
+            }
+        }
+        // MXFP4 is the headline number from the proposal.
+        assert_eq!(shape(FpFormatId::E2m1, 32).bits(), 136);
+    }
+
+    /// `shape_of` must reject exactly what the type checker rejects. A `None`
+    /// here is a refusal; a `Some` for a non-block type would resurrect the
+    /// "measured fine in one backend, `unwrap_or(0)` in the other" divergence.
+    #[test]
+    fn fp_block_shape_of_rejects_non_block_members() {
+        assert!(shape_of(&TypeExpr::FP4E2M1, 32, &TypeExpr::E8M0).is_some());
+        assert!(shape_of(&TypeExpr::FP32, 32, &TypeExpr::E8M0).is_none());
+        assert!(shape_of(&TypeExpr::BF16, 32, &TypeExpr::E8M0).is_none());
+        assert!(shape_of(&TypeExpr::Bool, 32, &TypeExpr::E8M0).is_none());
+        // FP8E4M3 is a legal ELEMENT but NVFP4's scale is UE4M3, a different
+        // format — so it must not be accepted in the scale slot.
+        assert!(shape_of(&TypeExpr::FP4E2M1, 32, &TypeExpr::FP8E4M3).is_none());
+    }
+
+    /// The two renderings are generated from one descriptor, so what has to
+    /// be pinned is that they stay *structurally* parallel: same constants,
+    /// same branch order, same helper callees. Values are pinned separately
+    /// by the Verilator differential harness, which runs the emitted SV
+    /// against this same C++ as the DPI reference.
+    #[test]
+    fn fp_block_sv_and_cpp_agree_on_shape() {
+        for policy in [ScalePolicy::FloorPow2, ScalePolicy::CeilPow2] {
+            for (id, tag) in [
+                (FpFormatId::E2m1, "e2m1"),
+                (FpFormatId::E2m3, "e2m3"),
+                (FpFormatId::E3m2, "e3m2"),
+                (FpFormatId::E4m3, "e4m3"),
+                (FpFormatId::E5m2, "e5m2"),
+            ] {
+                let s = shape(id, 32);
+                let q = BlockHelper::Quantize {
+                    shape: s,
+                    policy,
+                    round: RoundMode::Rne,
+                };
+                let (sv, cpp) = (sv_definition(q), cpp_definition(q));
+                // Both must call the SAME numeric helpers — the whole point
+                // of the design is that neither invents arithmetic.
+                for callee in ["f32_to_e8m0", "e8m0_to_f32", "f32_mul"] {
+                    assert!(sv.contains(callee), "SV {tag} must call {callee}");
+                    assert!(cpp.contains(callee), "C++ {tag} must call {callee}");
+                }
+                assert!(sv.contains(&format!("arch_f32_to_{tag}(")));
+                assert!(cpp.contains(&format!("_arch_f32_to_{tag}(")));
+                // Same shared constants on both sides.
+                assert!(sv.contains("7F800000") && cpp.contains("7F800000u"));
+                assert!(sv.contains("8'd254 - code") && cpp.contains("254u - code"));
+                let emax = s.elem_emax();
+                assert!(sv.contains(&format!("8'd{emax}")));
+                assert!(cpp.contains(&format!("{emax}u")));
+                // The ceil bump is present iff the policy asks for it.
+                assert_eq!(
+                    sv.contains("ecode + 8'h01"),
+                    policy == ScalePolicy::CeilPow2
+                );
+                assert_eq!(cpp.contains("ecode + 1u"), policy == ScalePolicy::CeilPow2);
+
+                let d = BlockHelper::Dequantize { shape: s };
+                let (dsv, dcpp) = (sv_definition(d), cpp_definition(d));
+                assert!(dsv.contains(&format!("arch_{tag}_to_f32(")));
+                assert!(dcpp.contains(&format!("_arch_{tag}_to_f32(")));
+                // Saturation to +-FP32_MAX, guarded on a finite element.
+                assert!(dsv.contains("7F7FFFFF") && dcpp.contains("7F7FFFFFu"));
+            }
+        }
+    }
+
+    /// The emitted C++ must NOT name a concrete block storage type. The sim
+    /// gives one block type two different C++ representations — a 72-bit
+    /// block is `VlWide<3>` as a port but `_arch_u128` as an internal wire —
+    /// so any storage type baked in here would be right for one and a silent
+    /// truncation for the other. The destination's own type must select the
+    /// access overload.
+    #[test]
+    fn fp_block_cpp_is_generic_over_block_storage() {
+        for bits_case in [
+            shape(FpFormatId::E2m1, 4),  // 24 bits — a scalar either way
+            shape(FpFormatId::E4m3, 8),  // 72 bits — VlWide as a port, _arch_u128 as a wire
+            shape(FpFormatId::E2m1, 32), // 136 bits — VlWide either way
+        ] {
+            for cpp in [
+                cpp_definition(BlockHelper::Quantize {
+                    shape: bits_case,
+                    policy: ScalePolicy::FloorPow2,
+                    round: RoundMode::Rne,
+                }),
+                cpp_definition(BlockHelper::Dequantize { shape: bits_case }),
+            ] {
+                assert!(
+                    cpp.contains("template <typename BT>"),
+                    "block side must be a template parameter:\n{cpp}"
+                );
+                for banned in ["VlWide<", "_arch_u128", "uint64_t& ", "uint32_t& "] {
+                    assert!(
+                        !cpp.contains(banned),
+                        "emitted C++ names the concrete storage type `{banned}`, which is \
+                         right for only one of port/wire storage:\n{cpp}"
+                    );
+                }
+                // …and it must route through the overloaded accessors.
+                assert!(cpp.contains("_arch_blk_get(") || cpp.contains("_arch_blk_put("));
+            }
+        }
+    }
+
+    /// Names must be unique per (op, element, N, scale, policy, rounding) —
+    /// a collision would silently give two different designs one definition.
+    #[test]
+    fn fp_block_names_are_injective() {
+        let mut seen = std::collections::BTreeSet::new();
+        for id in [
+            FpFormatId::E2m1,
+            FpFormatId::E2m3,
+            FpFormatId::E3m2,
+            FpFormatId::E4m3,
+            FpFormatId::E5m2,
+        ] {
+            for n in [4u32, 16, 32] {
+                for policy in [ScalePolicy::FloorPow2, ScalePolicy::CeilPow2] {
+                    let s = shape(id, n);
+                    assert!(seen.insert(
+                        BlockHelper::Quantize {
+                            shape: s,
+                            policy,
+                            round: RoundMode::Rne
+                        }
+                        .sv_name()
+                    ));
+                    // Dequantize does not depend on policy, so the second
+                    // insert is expected to collide — assert it does, which
+                    // is what makes the emitters' dedup correct.
+                    let d = BlockHelper::Dequantize { shape: s }.sv_name();
+                    assert_eq!(seen.insert(d), policy == ScalePolicy::FloorPow2);
+                }
+            }
+        }
+    }
+}

--- a/src/fp_format.rs
+++ b/src/fp_format.rs
@@ -34,7 +34,10 @@ use crate::ast::{FloatLitFmt, TypeExpr};
 
 /// Canonical identifier for a floating-point format. Exhaustively matchable,
 /// unlike the `&'static str` dispatch tags.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+// `Ord` is derived so a backend can hold a `BTreeSet` of the block helpers it
+// needs and emit them in a stable order — deterministic output is a CI gate
+// (`scripts/refactor_diff.sh`), not a nicety.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum FpFormatId {
     Fp32,
     Bf16,

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1964,6 +1964,11 @@ impl Builder {
                     self.walk_expr(owner, rel, scope, arg, ExprUse::Read);
                 }
             }
+            // Reads flow through the value being quantized; the format and
+            // selectors are compile-time, not signal reads.
+            ExprKind::ScaledQuantize(v, _, _, _) => {
+                self.walk_expr(owner, rel, scope, v, use_kind);
+            }
             ExprKind::PipelinedCall(_name, args, _stages) => {
                 // Registry-resolved builtin operator (e.g. `fma<pipelined, N>`),
                 // not a user construct — no `calls` edge to a construct, just

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub mod construct_proof_cert;
 pub mod diagnostics;
 pub mod elaborate;
 pub mod formal;
+pub mod fp_block;
 pub mod fp_format;
 pub mod fp_ir;
 pub mod fp_lit;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -4186,14 +4186,14 @@ impl Parser {
                 self.advance();
                 self.expect(TokenKind::Lt)?;
                 let width = self.parse_type_arg_expr()?;
-                self.expect(TokenKind::Gt)?;
+                self.expect_angle_close()?;
                 Ok(TypeExpr::UInt(Box::new(width)))
             }
             Some(TokenKind::SInt) => {
                 self.advance();
                 self.expect(TokenKind::Lt)?;
                 let width = self.parse_type_arg_expr()?;
-                self.expect(TokenKind::Gt)?;
+                self.expect_angle_close()?;
                 Ok(TypeExpr::SInt(Box::new(width)))
             }
             Some(TokenKind::Bool) => {
@@ -4240,7 +4240,7 @@ impl Parser {
                 self.advance();
                 self.expect(TokenKind::Lt)?;
                 let domain = self.expect_ident()?;
-                self.expect(TokenKind::Gt)?;
+                self.expect_angle_close()?;
                 Ok(TypeExpr::Clock(domain))
             }
             Some(TokenKind::Reset) => {
@@ -4286,7 +4286,7 @@ impl Parser {
                 } else {
                     ResetLevel::High // default
                 };
-                self.expect(TokenKind::Gt)?;
+                self.expect_angle_close()?;
                 Ok(TypeExpr::Reset(kind, level))
             }
             Some(TokenKind::KwVec) => {
@@ -4295,7 +4295,7 @@ impl Parser {
                 let elem = self.parse_type_expr()?;
                 self.expect(TokenKind::Comma)?;
                 let size = self.parse_type_arg_expr()?;
-                self.expect(TokenKind::Gt)?;
+                self.expect_angle_close()?;
                 Ok(TypeExpr::Vec(Box::new(elem), Box::new(size)))
             }
             // `ScaledVec<Elem, N, Scale>` — a block-scaled vector. Three
@@ -4309,7 +4309,7 @@ impl Parser {
                 let size = self.parse_type_arg_expr()?;
                 self.expect(TokenKind::Comma)?;
                 let scale = self.parse_type_expr()?;
-                self.expect(TokenKind::Gt)?;
+                self.expect_angle_close()?;
                 Ok(TypeExpr::ScaledVec(
                     Box::new(elem),
                     Box::new(size),
@@ -4874,6 +4874,82 @@ impl Parser {
                     let span = ident.span.merge(end.span);
                     Ok(Expr {
                         kind: ExprKind::PipelinedCall(ident.name, call_args, stages),
+                        span,
+                        parenthesized: false,
+                    })
+                } else if ident.name == "scaled_quantize" && self.check(TokenKind::Lt) {
+                    // `scaled_quantize<policy, rounding>(v)` — the block
+                    // quantizer's optional policy/rounding selectors.
+                    //
+                    // Gated on the callee NAME rather than on a token shape:
+                    // `<` after an identifier is otherwise a comparison, and
+                    // `scaled_quantize` is a reserved builtin, so there is no
+                    // expression this can steal. (`fma<pipelined, N>` gates on
+                    // the `pipelined` keyword instead, which is the same
+                    // narrowness by a different route.)
+                    //
+                    // The selectors ride along as trailing `Ident` args, the
+                    // convention `MethodCall` already documents ("type_args
+                    // encoded as exprs"), so no new ExprKind is needed.
+                    self.advance(); // consume `<`
+                                    // The output format is MANDATORY and comes first; the two
+                                    // selectors are optional and default to the OCP §6.3
+                                    // policy with RNE.
+                    let fmt = self.parse_type_expr()?;
+                    let (policy, rounding) = if self.eat(TokenKind::Comma) {
+                        let p = self.expect_ident()?;
+                        self.expect(TokenKind::Comma)?;
+                        let r = self.expect_ident()?;
+                        let policy = match p.name.as_str() {
+                            "floor_pow2" => ScalePolicy::FloorPow2,
+                            "ceil_pow2" => ScalePolicy::CeilPow2,
+                            other => {
+                                return Err(CompileError::general(
+                                    &format!(
+                                        "unknown scale policy `{other}` — expected `floor_pow2` \
+                                         (OCP §6.3, the default) or `ceil_pow2` (NVIDIA). \
+                                         `exact` is reserved for a non-power-of-two scale \
+                                         (`UE4M3`) and is not implemented"
+                                    ),
+                                    p.span,
+                                ))
+                            }
+                        };
+                        let rounding = match r.name.as_str() {
+                            "rne" => RoundMode::Rne,
+                            "rtz" => RoundMode::Rtz,
+                            "rna" => RoundMode::Rna,
+                            other => {
+                                return Err(CompileError::general(
+                                    &format!(
+                                        "unknown rounding mode `{other}` — expected `rne` (the \
+                                         default), `rtz` or `rna`. `stochastic` is not \
+                                         implemented: it needs an entropy source, which is a \
+                                         datapath question rather than a rounding-mode one"
+                                    ),
+                                    r.span,
+                                ))
+                            }
+                        };
+                        (policy, rounding)
+                    } else {
+                        (ScalePolicy::FloorPow2, RoundMode::Rne)
+                    };
+                    // `expect_angle_close`, not `expect(Gt)`: the format may
+                    // be written inline (`scaled_quantize<ScaledVec<..>>(v)`),
+                    // which the lexer munches into a single `>>`.
+                    self.expect_angle_close()?;
+                    self.expect(TokenKind::LParen)?;
+                    let value = self.parse_expr()?;
+                    let end = self.expect(TokenKind::RParen)?;
+                    let span = ident.span.merge(end.span);
+                    Ok(Expr {
+                        kind: ExprKind::ScaledQuantize(
+                            Box::new(value),
+                            Box::new(fmt),
+                            policy,
+                            rounding,
+                        ),
                         span,
                         parenthesized: false,
                     })
@@ -7042,6 +7118,33 @@ impl Parser {
         let tok = self.tokens[self.pos].clone();
         self.pos += 1;
         tok
+    }
+
+    /// Consume the `>` that closes an angle-bracket list, splitting a `>>`
+    /// token when the list's last element is itself angle-bracketed.
+    ///
+    /// The lexer maximal-munches `>>` into a shift, which no other construct
+    /// ever hits: `Vec<Vec<T,N>,M>` closes with `>` after a `,`, and a type in
+    /// a port declaration is followed by `;`. `scaled_quantize<Fmt>` is the
+    /// first place a *type* can end immediately before a closing `>`, so
+    /// `scaled_quantize<ScaledVec<FP4E2M1, 4, E8M0>>(v)` would otherwise be a
+    /// parse error — and the obvious workaround (declare an alias) must not be
+    /// mandatory just because of a tokenizer artifact. Rewriting the token in
+    /// place, rather than pushing back a synthetic one, keeps spans honest:
+    /// the remaining `>` keeps the second character's position.
+    fn expect_angle_close(&mut self) -> Result<Token, CompileError> {
+        if self.check(TokenKind::Shr) {
+            let tok = self.tokens[self.pos].clone();
+            let mut rest = tok.clone();
+            rest.kind = TokenKind::Gt;
+            rest.span.start += 1;
+            self.tokens[self.pos] = rest;
+            let mut first = tok;
+            first.kind = TokenKind::Gt;
+            first.span.end = first.span.start + 1;
+            return Ok(first);
+        }
+        self.expect(TokenKind::Gt)
     }
 
     fn expect(&mut self, kind: TokenKind) -> Result<Token, CompileError> {

--- a/src/pipelined_ops.rs
+++ b/src/pipelined_ops.rs
@@ -492,6 +492,7 @@ fn scan_stmts(stmts: &[crate::ast::Stmt], out: &mut Vec<FoundPipelinedCall>) {
 fn scan_expr(expr: &crate::ast::Expr, out: &mut Vec<FoundPipelinedCall>) {
     use crate::ast::ExprKind::*;
     match &expr.kind {
+        ScaledQuantize(v, _, _, _) => scan_expr(v, out),
         PipelinedCall(name, args, stages) => {
             out.push(FoundPipelinedCall {
                 operator: name.clone(),
@@ -1048,6 +1049,7 @@ fn lower_expr(expr: &mut crate::ast::Expr) -> Result<(), FoundPipelinedCall> {
     // larger expression (not just the direct RHS of a cascade stage) is
     // also lowered — matches `scan_expr`'s traversal shape.
     match &mut expr.kind {
+        ScaledQuantize(v, _, _, _) => lower_expr(v)?,
         Binary(_, a, b) => {
             lower_expr(a)?;
             lower_expr(b)?;

--- a/src/sim_codegen/expr_codegen.rs
+++ b/src/sim_codegen/expr_codegen.rs
@@ -307,6 +307,13 @@ pub(super) struct Ctx<'a> {
     pub(super) decl_types: Option<&'a HashMap<String, TypeExpr>>,
     /// Struct name -> field list, for FieldAccess float resolution.
     pub(super) struct_defs: Option<&'a HashMap<String, Vec<(String, TypeExpr)>>>,
+    /// `ScaledVec` block helpers this module referenced. The statement
+    /// emitter records each distinct (op, element, N, scale, policy,
+    /// rounding) here; `gen_module` then emits one definition per entry
+    /// ahead of the class methods. Same interior-mutability shape as
+    /// `coverage` above. A `BTreeSet` keeps the emitted order stable.
+    pub(super) block_helpers:
+        Option<&'a std::cell::RefCell<std::collections::BTreeSet<crate::fp_block::BlockHelper>>>,
 }
 
 impl<'a> Ctx<'a> {
@@ -359,6 +366,7 @@ impl<'a> Ctx<'a> {
             vinit_regs: None,
             decl_types: None,
             struct_defs: None,
+            block_helpers: None,
         }
     }
 
@@ -437,6 +445,16 @@ impl<'a> Ctx<'a> {
         reg: Option<&'a std::cell::RefCell<CoverageRegistry>>,
     ) -> Self {
         self.coverage = reg;
+        self
+    }
+
+    pub(super) fn with_block_helpers(
+        mut self,
+        reg: Option<
+            &'a std::cell::RefCell<std::collections::BTreeSet<crate::fp_block::BlockHelper>>,
+        >,
+    ) -> Self {
+        self.block_helpers = reg;
         self
     }
 
@@ -938,6 +956,7 @@ pub(super) fn lower_vec_method_cpp(
             vinit_regs: ctx.vinit_regs,
             decl_types: ctx.decl_types,
             struct_defs: ctx.struct_defs,
+            block_helpers: None,
         };
         // The sub map must outlive the cpp_expr call. We keep `sub` as a
         // stack-local binding whose lifetime covers the call.
@@ -1060,6 +1079,10 @@ pub(super) fn cpp_expr_inner(expr: &Expr, ctx: &Ctx, is_lhs: bool) -> String {
         // rewrites every codegen-backed `PipelinedCall` into a plain
         // `FunctionCall` before sim codegen starts, so this is a loud
         // backstop, not the primary error path.
+        ExprKind::ScaledQuantize(..) => unreachable!(
+            "scaled_quantize reached sim codegen: typecheck must refuse it \
+             until phase 2b lowering lands (arch#884)"
+        ),
         ExprKind::PipelinedCall(name, _, stages) => unreachable!(
             "sim codegen reached `{name}<pipelined, {stages}>(...)` — this should have been \
              lowered by pipelined_ops::lower_pipelined_calls before codegen started"

--- a/src/sim_codegen/mod.rs
+++ b/src/sim_codegen/mod.rs
@@ -421,6 +421,15 @@ impl<'a> SimCodegen<'a> {
         let cov_handle: Option<&std::cell::RefCell<CoverageRegistry>> =
             if self.coverage { Some(&cov_reg) } else { None };
 
+        // `ScaledVec` block helpers referenced by this module's comb/seq
+        // bodies. Collected while emitting statements, then emitted as
+        // definitions ahead of the class methods (the `__ARCH_BLOCK_HELPERS__`
+        // placeholder below) — the set is not known until the bodies are
+        // walked, exactly like the coverage counter array above.
+        let block_helpers: std::cell::RefCell<
+            std::collections::BTreeSet<crate::fp_block::BlockHelper>,
+        > = std::cell::RefCell::new(std::collections::BTreeSet::new());
+
         // Collect bus port names and flattened signals (with direction for debug)
         let mut bus_port_names: HashSet<String> = HashSet::new();
         let mut bus_flat: Vec<(String, TypeExpr)> = Vec::new();
@@ -2280,6 +2289,8 @@ impl<'a> SimCodegen<'a> {
         // ── Implementation ────────────────────────────────────────────────────
         let mut cpp = String::new();
         cpp.push_str(&format!("#include \"{class}.h\"\n\n"));
+        // Patched after the bodies are emitted — see `block_helpers` above.
+        cpp.push_str("__ARCH_BLOCK_HELPERS__");
 
         if self.coverage {
             cpp.push_str("__ARCH_COV_IMPL_DEFN__");
@@ -2553,6 +2564,7 @@ impl<'a> SimCodegen<'a> {
             .with_vec_sizes(&vec_sizes)
             .posedge()
             .with_coverage(cov_handle)
+            .with_block_helpers(Some(&block_helpers))
             .with_let_values(&let_values)
             .with_params(&m.params)
             .with_vinit_regs(&vinit_regs);
@@ -3110,6 +3122,7 @@ impl<'a> SimCodegen<'a> {
         .with_vec_2d_names(&vec_2d_names)
         .with_vec_sizes(&vec_sizes)
         .with_coverage(cov_handle)
+        .with_block_helpers(Some(&block_helpers))
         .with_let_values(&let_values)
         .with_params(&m.params)
         .with_vec_of_bus(
@@ -3202,6 +3215,7 @@ impl<'a> SimCodegen<'a> {
                                         vinit_regs: ctx_comb.vinit_regs,
                                         decl_types: ctx_comb.decl_types,
                                         struct_defs: ctx_comb.struct_defs,
+                                        block_helpers: ctx_comb.block_helpers,
                                     };
                                     hits.push(cpp_expr(&margs[0], &sub_ctx));
                                 }
@@ -3973,6 +3987,29 @@ impl<'a> SimCodegen<'a> {
         };
         h = h.replace("__ARCH_COV_HEADER_DECL__", &header_decl);
         cpp = cpp.replace("__ARCH_COV_IMPL_DEFN__", &impl_defn);
+
+        // `ScaledVec` block helpers. `static inline` at file scope, so a
+        // helper shared by several modules is defined once per translation
+        // unit with no ODR conflict — the same treatment the FP runtime gets.
+        let block_defs = {
+            let used = block_helpers.borrow();
+            if used.is_empty() {
+                String::new()
+            } else {
+                let mut s = String::from(
+                    "// ── ScaledVec block helpers — generated from src/fp_block.rs, which\n\
+                     // emits this C++ and the matching `arch build` SystemVerilog from ONE\n\
+                     // descriptor. Do not edit by hand. ──\n",
+                );
+                s.push_str(crate::fp_block::CPP_PRELUDE);
+                for helper in used.iter() {
+                    s.push_str(&crate::fp_block::cpp_definition(*helper));
+                    s.push('\n');
+                }
+                s
+            }
+        };
+        cpp = cpp.replace("__ARCH_BLOCK_HELPERS__", &block_defs);
 
         // --coverage: per-class atexit dumper. Registered via a static
         // initializer so a normal exit (return from main) flushes the

--- a/src/sim_codegen/pipeline.rs
+++ b/src/sim_codegen/pipeline.rs
@@ -1387,6 +1387,7 @@ impl<'a> SimCodegen<'a> {
             vinit_regs: None,
             decl_types: None,
             struct_defs: None,
+            block_helpers: None,
         };
         match &expr.kind {
             ExprKind::FieldAccess(base, field) => {

--- a/src/sim_codegen/stmt_codegen.rs
+++ b/src/sim_codegen/stmt_codegen.rs
@@ -26,6 +26,97 @@ pub(super) enum SimAssignKind {
     Comb,
 }
 
+/// Resolve a `ScaledVec<Elem, N, Scale>` TypeExpr to the block shape the
+/// helper emitters are keyed on. `None` — never a guess — when `N` does not
+/// fold to a literal or a member type is not a legal block member; the caller
+/// turns that into a panic, because typecheck has already accepted the type.
+fn block_shape_of_type(ty: &TypeExpr) -> Option<crate::fp_block::BlockShape> {
+    let TypeExpr::ScaledVec(elem, size, scale) = ty else {
+        return None;
+    };
+    let n = match &size.kind {
+        ExprKind::Literal(LitKind::Dec(n)) | ExprKind::Literal(LitKind::Hex(n)) => *n as u32,
+        _ => return None,
+    };
+    crate::fp_block::shape_of(elem, n, scale)
+}
+
+/// Record `h` as needed by this module and return its C++ name.
+fn use_block_helper(h: crate::fp_block::BlockHelper, ctx: &Ctx) -> String {
+    match ctx.block_helpers {
+        Some(reg) => {
+            reg.borrow_mut().insert(h);
+        }
+        // A context that never registered a collector cannot emit the
+        // definition, so a call would compile to an undeclared identifier.
+        // Fail loudly at compile time rather than at the user's C++ build.
+        None => panic!(
+            "`{}` is needed here but this sim context has no block-helper \
+             registry, so its definition would never be emitted (arch#884). \
+             The construct emitting this statement must thread \
+             `Ctx::with_block_helpers` through.",
+            h.cpp_name()
+        ),
+    }
+    h.cpp_name()
+}
+
+/// Emit `dst = scaled_quantize<Fmt,...>(v)` or `dst = scaled_dequantize(b)`
+/// as a call statement. Returns `Some(())` when this statement was one of
+/// those and has been emitted, `None` to fall through to normal assignment.
+fn emit_scaled_block_assign(
+    a: &crate::ast::RegAssign,
+    ctx: &Ctx,
+    out: &mut String,
+    indent: usize,
+) -> Option<()> {
+    match &a.value.kind {
+        ExprKind::ScaledQuantize(v, fmt, policy, round) => {
+            let shape = block_shape_of_type(fmt.as_ref()).unwrap_or_else(|| {
+                panic!(
+                    "scaled_quantize format has no resolvable block shape — typecheck \
+                     accepts only `ScaledVec` formats, so this means the block size did \
+                     not fold to a literal (arch#884)"
+                )
+            });
+            let name = use_block_helper(
+                crate::fp_block::BlockHelper::Quantize {
+                    shape,
+                    policy: *policy,
+                    round: *round,
+                },
+                ctx,
+            );
+            let src = cpp_expr(v.as_ref(), ctx);
+            let dst = cpp_expr_lhs(&a.target, ctx);
+            out.push_str(&format!("{}{name}({src}, {dst});\n", ind(indent)));
+            Some(())
+        }
+        ExprKind::FunctionCall(fname, args) if fname == "scaled_dequantize" && args.len() == 1 => {
+            let shape = ctx
+                .decl_types
+                .and_then(|m| match &args[0].kind {
+                    ExprKind::Ident(n) => m.get(n.as_str()),
+                    _ => None,
+                })
+                .and_then(block_shape_of_type)
+                .unwrap_or_else(|| {
+                    panic!(
+                        "scaled_dequantize operand has no resolvable block shape — typecheck \
+                         accepts only `ScaledVec` operands, so this means the operand is not a \
+                         plain signal name or its block size did not fold to a literal (arch#884)"
+                    )
+                });
+            let name = use_block_helper(crate::fp_block::BlockHelper::Dequantize { shape }, ctx);
+            let src = cpp_expr(&args[0], ctx);
+            let dst = cpp_expr_lhs(&a.target, ctx);
+            out.push_str(&format!("{}{name}({src}, {dst});\n", ind(indent)));
+            Some(())
+        }
+        _ => None,
+    }
+}
+
 pub(super) fn emit_stmts(
     stmts: &[Stmt],
     ctx: &Ctx,
@@ -67,6 +158,21 @@ pub(super) fn emit_stmt(stmt: &Stmt, ctx: &Ctx, out: &mut String, indent: usize,
     let is_seq = k == SimAssignKind::Seq;
     match stmt {
         Stmt::Assign(a) => {
+            // `ScaledVec` block ops. Emitted as a STATEMENT, not an
+            // expression: both sides are aggregates in the sim (a block wider
+            // than 64 bits is a `VlWide`, a `Vec<FP32,N>` is a C array), so
+            // the generated helper takes the destination by reference. The SV
+            // backend can use a plain function return because a packed array
+            // and a packed vector are assignment-compatible there; C++ has no
+            // such equivalence, which is why the two backends differ in shape
+            // here and nowhere else.
+            if let Some(call) = emit_scaled_block_assign(a, ctx, out, indent) {
+                let _ = call;
+                if is_seq {
+                    emit_vinit_mark_for_target(&a.target, ctx, out, indent);
+                }
+                return;
+            }
             // Whole-Vec assignment: C arrays are not assignable in C++, so
             // lower `dst <= src_vec;` / `dst = src_vec;` to an element copy.
             // This is hit by TLM Vec payloads, e.g. `data <= m.read4(...)`

--- a/src/thread_map.rs
+++ b/src/thread_map.rs
@@ -205,6 +205,9 @@ pub fn expr_label(expr: &Expr) -> String {
             let args = args.iter().map(expr_label).collect::<Vec<_>>().join(", ");
             format!("{}({})", name, args)
         }
+        ExprKind::ScaledQuantize(v, _, _, _) => {
+            format!("scaled_quantize({})", expr_label(v))
+        }
         ExprKind::PipelinedCall(name, args, stages) => {
             let args = args.iter().map(expr_label).collect::<Vec<_>>().join(", ");
             format!("{}<pipelined, {}>({})", name, stages, args)

--- a/src/type_alias.rs
+++ b/src/type_alias.rs
@@ -506,6 +506,15 @@ fn substitute_in_expr(e: &mut Expr, aliases: &AliasMap, errors: &mut Vec<Compile
                 substitute_in_expr(a, aliases, errors);
             }
         }
+        // `scaled_quantize<Fmt, ...>(v)` is the first expression that carries
+        // a TYPE, so it is the first that needs alias substitution inside an
+        // expression. Without this arm `scaled_quantize<MXFP4>(v)` keeps a
+        // dangling `Named("MXFP4")` that no later pass can resolve — the
+        // aliases are substituted and then removed before typecheck runs.
+        ExprKind::ScaledQuantize(value, fmt, _, _) => {
+            substitute_in_expr(value, aliases, errors);
+            substitute_type(fmt.as_mut(), aliases, errors);
+        }
         ExprKind::Index(a, b) => {
             substitute_in_expr(a, aliases, errors);
             substitute_in_expr(b, aliases, errors);

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -3803,6 +3803,8 @@ impl<'a> TypeChecker<'a> {
     fn expr_latency_tc(expr: &Expr) -> u32 {
         match &expr.kind {
             ExprKind::PipelinedCall(_, _, n) => *n,
+            // Combinational: the block quantizer adds no pipeline stages.
+            ExprKind::ScaledQuantize(_, _, _, _) => 0,
             ExprKind::LatencyAt(_, n) => *n,
             _ => 0,
         }
@@ -3817,6 +3819,8 @@ impl<'a> TypeChecker<'a> {
     fn expr_contains_pipelined_call(expr: &Expr) -> bool {
         match &expr.kind {
             ExprKind::PipelinedCall(_, _, _) => true,
+            // Not a pipelined call; recurse into the value being quantized.
+            ExprKind::ScaledQuantize(v, _, _, _) => Self::expr_contains_pipelined_call(v),
             ExprKind::Binary(_, a, b) => {
                 Self::expr_contains_pipelined_call(a) || Self::expr_contains_pipelined_call(b)
             }
@@ -4099,6 +4103,75 @@ impl<'a> TypeChecker<'a> {
         local_types: &HashMap<String, Ty>,
     ) -> Ty {
         match &expr.kind {
+            // `scaled_quantize<Fmt, policy, rounding>(v)` — the output format
+            // is named at the call site, never inferred: a `Vec<FP32,N>`
+            // argument says nothing about the element format or scale.
+            ExprKind::ScaledQuantize(v, fmt, _policy, rounding) => {
+                let vt = self.resolve_expr_type(v, module_name, local_types);
+                let n_in = match &vt {
+                    Ty::Vec(elem, n) if **elem == Ty::FP32 => Some(*n),
+                    Ty::Todo | Ty::Error => return Ty::Error,
+                    other => {
+                        self.errors.push(CompileError::general(
+                            &format!(
+                                "`scaled_quantize` requires a `Vec<FP32, N>` operand, got {}",
+                                other.display()
+                            ),
+                            v.span,
+                        ));
+                        None
+                    }
+                };
+                // The named format must be a block, and its N must match the
+                // input length — quantizing 32 values into a 16-element block
+                // is a silent data loss otherwise.
+                self.check_scaled_vec_members(fmt, expr.span);
+                let out = self.resolve_type_expr(fmt, module_name, local_types);
+                match (&out, n_in) {
+                    (Ty::ScaledVec(_, n_out, _), Some(n_in)) if *n_out != n_in => {
+                        self.errors.push(CompileError::general(
+                            &format!(
+                                "`scaled_quantize` block size mismatch: operand is \
+                                 `Vec<FP32, {n_in}>` but the named format holds {n_out} elements"
+                            ),
+                            expr.span,
+                        ));
+                        return Ty::Error;
+                    }
+                    (Ty::ScaledVec(..), _) => {}
+                    (Ty::Error, _) => return Ty::Error,
+                    (other, _) => {
+                        self.errors.push(CompileError::general(
+                            &format!(
+                                "`scaled_quantize<Fmt, ...>` requires a `ScaledVec` format, got {}",
+                                other.display()
+                            ),
+                            expr.span,
+                        ));
+                        return Ty::Error;
+                    }
+                }
+                // Only RNE narrowing is lowered. `rtz`/`rna` are refused HERE
+                // rather than at parse so the surface stays forward-compatible
+                // and the diagnostic can explain the actual blocker: the
+                // element narrow (`arch_f32_to_e2m1` and its siblings) is a
+                // single round-to-nearest-even rounder in each backend, each
+                // pinned by an exhaustive SMT miter, and the other two modes
+                // are separate rounders with genuinely different overflow
+                // behaviour (RTZ on E5M2 must give max-finite, not Inf). That
+                // is its own piece of work, not glue — see arch#890.
+                if *rounding != crate::ast::RoundMode::Rne {
+                    self.errors.push(CompileError::general(
+                        "`scaled_quantize` supports only `rne` rounding today (arch#890). \
+                         `rtz` and `rna` need their own element rounders in both backends — \
+                         each with its own overflow rule and equivalence proof — rather than \
+                         a flag on the existing one",
+                        expr.span,
+                    ));
+                    return Ty::Error;
+                }
+                out
+            }
             ExprKind::SvaNext(_, inner) => {
                 if !self.in_sva_context {
                     self.errors.push(CompileError::general(
@@ -4513,6 +4586,52 @@ impl<'a> TypeChecker<'a> {
                         return Ty::Error;
                     }
                     return t;
+                }
+                // `scaled_dequantize(b) -> Vec<FP32, N>` — the whole block,
+                // scale already applied (`v_i = X * P_i`). Fully inferable:
+                // N comes from the block type. This is also the ONLY way to
+                // read an element, which is why indexing a block is refused.
+                if name == "scaled_dequantize" {
+                    if call_args.len() != 1 {
+                        self.errors.push(CompileError::general(
+                            "`scaled_dequantize(b)` takes exactly 1 argument (the block)",
+                            expr.span,
+                        ));
+                        return Ty::Error;
+                    }
+                    let bt = self.resolve_expr_type(&call_args[0], module_name, local_types);
+                    return match bt {
+                        Ty::ScaledVec(_, n, _) => Ty::Vec(Box::new(Ty::FP32), n),
+                        Ty::Todo | Ty::Error => Ty::Error,
+                        other => {
+                            self.errors.push(CompileError::general(
+                                &format!(
+                                    "`scaled_dequantize(b)` requires a `ScaledVec` operand, got {}",
+                                    other.display()
+                                ),
+                                expr.span,
+                            ));
+                            Ty::Error
+                        }
+                    };
+                }
+                // A bare `scaled_quantize(v)` reaches the generic call path
+                // because the parser only builds `ExprKind::ScaledQuantize`
+                // when `<` follows the name. That form has no meaning: the
+                // output format is spelled, never inferred, since a
+                // `Vec<FP32,N>` operand says nothing about which element
+                // format or scale to quantize into — `MXFP4` and `MXFP8` are
+                // equally valid results.
+                if name == "scaled_quantize" {
+                    self.errors.push(CompileError::general(
+                        "`scaled_quantize` needs its output format named: \
+                         `scaled_quantize<MXFP4>(v)`. The format cannot be inferred from a \
+                         `Vec<FP32, N>` operand — every block format holds FP32 inputs. \
+                         Optional selectors follow it: \
+                         `scaled_quantize<MXFP4, ceil_pow2, rne>(v)`",
+                        expr.span,
+                    ));
+                    return Ty::Error;
                 }
                 // Built-in float intrinsics. `fma(a, b, c)` is a single-rounded
                 // fused multiply-add (a*b + c); all three operands must be the

--- a/tests/fp_test.rs
+++ b/tests/fp_test.rs
@@ -2713,3 +2713,312 @@ fn scaled_vec_member_constraints_and_equality() {
         "cross-format block compare must be rejected:\n{err}"
     );
 }
+
+// ── ScaledVec phase 2b: scaled_quantize / scaled_dequantize (arch#884) ──────
+
+/// Round-trip through a block in the native sim.
+///
+/// `arch sim` alone cannot tell a wrong-but-consistent lowering from a right
+/// one, so this test asserts the *values*: `pow2` inputs must survive
+/// unchanged (the shared scale is exact and every element is representable),
+/// while the sub-ULP inputs must quantize to zero rather than wrap.
+#[test]
+fn fp_scaled_quant_round_trip_sim() {
+    let td = tempfile::tempdir().expect("tempdir");
+    let out = arch()
+        .arg("sim")
+        .arg("tests/fp_v1/ScaledQuant.arch")
+        .arg("--tb")
+        .arg("tests/fp_v1/tb_scaled_quant.cpp")
+        .arg("--outdir")
+        .arg(td.path())
+        .output()
+        .expect("run arch sim");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        out.status.success(),
+        "block quantize sim failed:\n{stdout}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let t = transcript(&stdout);
+
+    // `pow2`: max is 8.0, so the E8M0 scale is exact and every input is a
+    // representable E2M1 multiple of it — except 0.25 and 0.125 relative to
+    // the scale, which are exact ties and round to even (zero).
+    let pow2 = case_block(&t, "pow2");
+    assert_eq!(
+        pow2.get("b8 ").map(String::as_str),
+        Some("3f800000 c0000000 40800000 3f000000 41000000 be800000 00000000 40000000"),
+        "FP8E4M3 has the range to carry this block exactly:\n{stdout}"
+    );
+
+    // An all-zero block takes the MINIMUM scale 0x00, never the NaN scale —
+    // E8M0 has no zero encoding, which is the trap this pins.
+    let zeros = case_block(&t, "zeros");
+    let q4f = zeros.get("q4f").expect("q4f line");
+    assert!(
+        q4f.ends_with("00000000"),
+        "all-zero block must use scale 0x00, not 0xFF; got `{q4f}`\n{stdout}"
+    );
+
+    // A NaN anywhere forces the NaN scale 0xFF (high byte of the 40-bit
+    // block = word 1), and dequantizing then yields NaN in every lane.
+    let nan = case_block(&t, "nan");
+    assert_eq!(
+        nan.get("q4f").map(|s| s.split(' ').nth(1).unwrap_or("")),
+        Some("000000ff"),
+        "a NaN input must set the block scale to NaN:\n{stdout}"
+    );
+    assert!(
+        nan.get("b4 ")
+            .map_or(false, |l| l.split(' ').all(|w| w == "7fc00000")),
+        "with a NaN scale every dequantized lane is NaN:\n{stdout}"
+    );
+
+    // Inf takes the same path: `arch_f32_to_e8m0` maps every non-finite to
+    // 0xFF, so an Inf block is indistinguishable from a NaN block.
+    let inf = case_block(&t, "inf");
+    assert_eq!(
+        inf.get("q4f").map(|s| s.split(' ').nth(1).unwrap_or("")),
+        Some("000000ff"),
+        "an Inf input must also set the block scale to NaN:\n{stdout}"
+    );
+
+    // `floor_pow2` vs `ceil_pow2`: identical when the block maximum is
+    // already a power of two, different when it is not. A policy selector
+    // that changed nothing would pass every other assertion here.
+    let nonpow2 = case_block(&t, "nonpow2");
+    assert_eq!(
+        pow2.get("q4f"),
+        pow2.get("q4c"),
+        "on a power-of-two maximum the two scale policies must agree:\n{stdout}"
+    );
+    assert_ne!(
+        nonpow2.get("q4f"),
+        nonpow2.get("q4c"),
+        "on a non-power-of-two maximum the two scale policies must differ:\n{stdout}"
+    );
+}
+
+/// **The phase-2 gate (§8).** `arch build` and `arch sim` emit the block
+/// conversion from one descriptor (`src/fp_block.rs`), rendered once as
+/// SystemVerilog and once as C++. This runs the SAME design and the SAME
+/// vectors through both — Verilator on the emitted `.sv`, the native sim on
+/// the emitted C++ — and byte-compares the transcripts.
+///
+/// A structural test cannot replace this: the two renderings could agree on
+/// every constant and callee and still disagree on a value, because the
+/// languages differ in part-select semantics, integer promotion and shift
+/// behaviour. Skips cleanly when Verilator is not installed.
+#[test]
+fn fp_scaled_quant_sv_matches_sim() {
+    fn verilator_available() -> bool {
+        std::process::Command::new("verilator")
+            .arg("--version")
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+    }
+    if !verilator_available() {
+        eprintln!("skipping fp_scaled_quant_sv_matches_sim: verilator not in PATH");
+        return;
+    }
+    let manifest = env!("CARGO_MANIFEST_DIR");
+    let td = tempfile::tempdir().expect("tempdir");
+
+    // ── sim side ──
+    let sim = arch()
+        .arg("sim")
+        .arg(format!("{manifest}/tests/fp_v1/ScaledQuant.arch"))
+        .arg("--tb")
+        .arg(format!("{manifest}/tests/fp_v1/tb_scaled_quant.cpp"))
+        .arg("--outdir")
+        .arg(td.path().join("sim"))
+        .output()
+        .expect("run arch sim");
+    assert!(
+        sim.status.success(),
+        "arch sim failed:\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&sim.stdout),
+        String::from_utf8_lossy(&sim.stderr)
+    );
+    let sim_txt = transcript(&String::from_utf8_lossy(&sim.stdout));
+
+    // ── built-SV side ──
+    let sv = td.path().join("ScaledQuant.sv");
+    let build = arch()
+        .arg("build")
+        .arg(format!("{manifest}/tests/fp_v1/ScaledQuant.arch"))
+        .arg("-o")
+        .arg(&sv)
+        .output()
+        .expect("run arch build");
+    assert!(
+        build.status.success(),
+        "arch build failed:\nstderr:\n{}",
+        String::from_utf8_lossy(&build.stderr)
+    );
+    let obj = td.path().join("obj");
+    let tb = format!("{manifest}/tests/fp_v1/rtl_diff/tb_scaled_quant.sv");
+    let vout = std::process::Command::new("verilator")
+        .args([
+            "--binary",
+            "--timing",
+            "-Wno-WIDTH",
+            "-Wno-UNOPTFLAT",
+            "-Wno-WIDTHTRUNC",
+            "-Wno-WIDTHEXPAND",
+            "-Wno-UNUSEDSIGNAL",
+            "-Wno-MULTITOP",
+            "-Wno-DECLFILENAME",
+            "-Wno-TIMESCALEMOD",
+            "--top-module",
+            "tb",
+            "-o",
+            "sim_sq",
+        ])
+        .arg("-Mdir")
+        .arg(&obj)
+        .arg(&sv)
+        .arg(&tb)
+        .output()
+        .expect("run verilator");
+    assert!(
+        vout.status.success(),
+        "verilator build failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&vout.stdout),
+        String::from_utf8_lossy(&vout.stderr)
+    );
+    let run = std::process::Command::new(obj.join("sim_sq"))
+        .output()
+        .expect("run verilated sim");
+    let sv_txt = transcript(&String::from_utf8_lossy(&run.stdout));
+
+    assert!(
+        !sim_txt.is_empty() && sim_txt.lines().count() > 40,
+        "sim transcript is suspiciously short — a passing comparison of two \
+         empty transcripts would be vacuous:\n{sim_txt}"
+    );
+    if sim_txt != sv_txt {
+        // Report the first differing line rather than two 80-line blobs.
+        let first = sim_txt
+            .lines()
+            .zip(sv_txt.lines())
+            .enumerate()
+            .find(|(_, (a, b))| a != b)
+            .map(|(i, (a, b))| format!("line {}:\n  sim: {a}\n  sv : {b}", i + 1))
+            .unwrap_or_else(|| "transcripts differ in length".to_string());
+        panic!(
+            "arch build and arch sim disagree on the block conversion.\n{first}\n\n\
+             --- sim ---\n{sim_txt}\n--- sv ---\n{sv_txt}"
+        );
+    }
+}
+
+/// `scaled_quantize` needs its output format spelled — it cannot be inferred
+/// from a `Vec<FP32,N>`, since every block format takes FP32 inputs.
+#[test]
+fn fp_scaled_quant_bare_call_errors() {
+    let src = r#"module BareQ
+  port v: in Vec<FP32, 4>;
+  port o: out ScaledVec<FP4E2M1, 4, E8M0>;
+  comb o = scaled_quantize(v); end comb
+end module BareQ
+"#;
+    let err = check_err(src, "BareQ.arch");
+    assert!(
+        err.contains("needs its output format named"),
+        "a bare `scaled_quantize(v)` must say the format is required:\n{err}"
+    );
+}
+
+/// `rtz`/`rna` parse (the surface is forward-compatible) but are refused with
+/// the actual reason, not a generic "unsupported".
+#[test]
+fn fp_scaled_quant_non_rne_rounding_errors() {
+    let src = r#"module RtzQ
+  port v: in Vec<FP32, 4>;
+  port o: out ScaledVec<FP4E2M1, 4, E8M0>;
+  comb o = scaled_quantize<ScaledVec<FP4E2M1, 4, E8M0>, floor_pow2, rtz>(v); end comb
+end module RtzQ
+"#;
+    let err = check_err(src, "RtzQ.arch");
+    assert!(
+        err.contains("only `rne` rounding") && err.contains("890"),
+        "non-RNE rounding must be refused with the follow-up issue:\n{err}"
+    );
+}
+
+/// Quantizing into a block whose N differs from the operand length is silent
+/// data loss, so it is a type error.
+#[test]
+fn fp_scaled_quant_block_size_mismatch_errors() {
+    let src = r#"module SizeQ
+  port v: in Vec<FP32, 8>;
+  port o: out ScaledVec<FP4E2M1, 4, E8M0>;
+  comb o = scaled_quantize<ScaledVec<FP4E2M1, 4, E8M0>>(v); end comb
+end module SizeQ
+"#;
+    let err = check_err(src, "SizeQ.arch");
+    assert!(
+        err.contains("block size mismatch"),
+        "N mismatch must be rejected:\n{err}"
+    );
+}
+
+/// Run `arch check` on `src` and return the combined diagnostics, asserting
+/// the check failed.
+fn check_err(src: &str, file: &str) -> String {
+    let td = tempfile::tempdir().expect("tempdir");
+    let path = td.path().join(file);
+    std::fs::write(&path, src).unwrap();
+    let out = arch()
+        .arg("check")
+        .arg(&path)
+        .output()
+        .expect("run arch check");
+    assert!(
+        !out.status.success(),
+        "expected `arch check` to fail on {file}"
+    );
+    format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    )
+}
+
+/// Strip the simulator's own epilogue (Verilator prints a `- ...` report
+/// block after `$finish`) so the two backends' transcripts are comparable.
+fn transcript(stdout: &str) -> String {
+    stdout
+        .lines()
+        .take_while(|l| !l.starts_with("- "))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Index a transcript by case name: `== <name>` starts a block, and each
+/// following line is `<signal> <words...>`.
+fn case_block<'a>(t: &'a str, name: &str) -> std::collections::HashMap<String, String> {
+    let mut out = std::collections::HashMap::new();
+    let mut in_case = false;
+    for line in t.lines() {
+        if let Some(n) = line.strip_prefix("== ") {
+            if in_case {
+                break;
+            }
+            in_case = n == name;
+            continue;
+        }
+        if in_case {
+            let (sig, words) = line.split_at(3);
+            out.insert(sig.to_string(), words.trim_start().to_string());
+        }
+    }
+    assert!(
+        !out.is_empty(),
+        "case `{name}` not found in transcript:\n{t}"
+    );
+    out
+}

--- a/tests/fp_v1/ScaledQuant.arch
+++ b/tests/fp_v1/ScaledQuant.arch
@@ -1,0 +1,59 @@
+// `scaled_quantize` / `scaled_dequantize` — the OCP MX block conversion pair
+// (phase 2b, arch#884).
+//
+// This fixture exists to be run through BOTH backends against one testbench
+// vector set and byte-compared: `arch build` emits SystemVerilog helpers and
+// `arch sim` emits C++ helpers, and both are generated from the single
+// descriptor in `src/fp_block.rs`. That is the phase-2 gate (§8), and it is
+// why the ports below deliberately span all three C++ storage buckets a block
+// can land in — 24 bits (`uint32_t`), 40/56 bits (`uint64_t`) and 72 bits
+// (`VlWide<3>`). A bucket that only one backend gets right is exactly the
+// phase-2a divergence this pins shut.
+
+package MxFmt
+  type B4  = ScaledVec<FP4E2M1, 8, E8M0>;   // 8 + 8*4 = 40 bits
+  type B6  = ScaledVec<FP6E3M2, 8, E8M0>;   // 8 + 8*6 = 56 bits
+  type B8  = ScaledVec<FP8E4M3, 8, E8M0>;   // 8 + 8*8 = 72 bits (wide)
+  type B4S = ScaledVec<FP4E2M1, 4, E8M0>;   // 8 + 4*4 = 24 bits
+end package MxFmt
+
+module ScaledQuant
+  port v:  in Vec<FP32, 8>;
+  port v4: in Vec<FP32, 4>;
+
+  port q4_floor: out B4;
+  port q4_ceil:  out B4;                    // same block, ceil_pow2 scale
+  port q6:       out B6;
+  port q8:       out B8;
+  port q4s:      out B4S;
+
+  port back4: out Vec<FP32, 8>;
+  port back6: out Vec<FP32, 8>;
+  port back8: out Vec<FP32, 8>;
+
+  wire b4: B4;
+  wire b6: B6;
+  wire b8: B8;
+
+  comb
+    b4 = scaled_quantize<B4>(v);
+    b6 = scaled_quantize<B6>(v);
+    b8 = scaled_quantize<B8>(v);
+
+    q4_floor = b4;
+    q6       = b6;
+    q8       = b8;
+
+    // `ceil_pow2` rounds the shared scale UP when the block maximum is not
+    // already a power of two, trading the top element codes for fewer
+    // saturations. Same input, same block type — only the policy differs.
+    q4_ceil = scaled_quantize<B4, ceil_pow2, rne>(v);
+
+    q4s = scaled_quantize<B4S>(v4);
+
+    // Dequantize is the only way to read an element: `X * widen(P_i)`.
+    back4 = scaled_dequantize(b4);
+    back6 = scaled_dequantize(b6);
+    back8 = scaled_dequantize(b8);
+  end comb
+end module ScaledQuant

--- a/tests/fp_v1/rtl_diff/tb_scaled_quant.sv
+++ b/tests/fp_v1/rtl_diff/tb_scaled_quant.sv
@@ -1,0 +1,116 @@
+// SystemVerilog twin of `tests/fp_v1/tb_scaled_quant.cpp`.
+//
+// Drives the SAME vectors into the SAME design and prints the SAME
+// transcript, so `fp_scaled_quant_sv_matches_sim` can byte-compare the two.
+// That comparison is the phase-2 gate (§8 of arch#884): `arch build` and
+// `arch sim` emit the block conversion from one descriptor in
+// `src/fp_block.rs`, and this is what proves the two renderings agree on
+// values rather than merely on shape.
+//
+// Blocks print as 32-bit words LSB-first because a 72-bit `%h` has no
+// portable C++ counterpart. Keep the vector table below in lock-step with
+// the C++ one — same order, same hex.
+`timescale 1ns/1ps
+
+module tb;
+  localparam int NC = 9;
+
+  logic [7:0][31:0] v;
+  logic [3:0][31:0] v4;
+  logic [39:0]      q4_floor, q4_ceil;
+  logic [55:0]      q6;
+  logic [71:0]      q8;
+  logic [23:0]      q4s;
+  logic [7:0][31:0] back4, back6, back8;
+
+  ScaledQuant dut (
+    .v(v), .v4(v4),
+    .q4_floor(q4_floor), .q4_ceil(q4_ceil), .q6(q6), .q8(q8), .q4s(q4s),
+    .back4(back4), .back6(back6), .back8(back8)
+  );
+
+  string       names [NC];
+  logic [31:0] vecs  [NC][8];
+  logic [31:0] vec4s [NC][4];
+
+  // Print one signal as `name` followed by `words` 32-bit words, LSB first.
+  // `val` is passed at the widest block size (72 bits) and sliced here, so
+  // one task serves every block width.
+  task automatic show(input string name, input logic [71:0] val, input int words);
+    $write("%s", name);
+    for (int w = 0; w < words; w++) $write(" %h", val[w*32 +: 32]);
+    $write("\n");
+  endtask
+
+  task automatic show_vec(input string name, input logic [7:0][31:0] val, input int n);
+    $write("%s", name);
+    for (int i = 0; i < n; i++) $write(" %h", val[i]);
+    $write("\n");
+  endtask
+
+  initial begin
+    // Powers of two throughout: floor_pow2 and ceil_pow2 must agree.
+    names[0] = "pow2";
+    vecs[0]  = '{32'h3F800000, 32'hC0000000, 32'h40800000, 32'h3F000000,
+                 32'h41000000, 32'hBE800000, 32'h00000000, 32'h40000000};
+    vec4s[0] = '{32'h3F800000, 32'h40000000, 32'h40800000, 32'h3F000000};
+    // Max 6.0 is not a power of two: the two scale policies must differ.
+    names[1] = "nonpow2";
+    vecs[1]  = '{32'h3F800000, 32'hC0000000, 32'h40400000, 32'h3F000000,
+                 32'h40C00000, 32'hBE800000, 32'h00000000, 32'h40800000};
+    vec4s[1] = '{32'h40C00000, 32'h40400000, 32'h3FC00000, 32'h3F400000};
+    // All zero: minimum scale 0x00 and zero elements, NOT a NaN scale.
+    names[2] = "zeros";
+    vecs[2]  = '{32'h0, 32'h0, 32'h0, 32'h0, 32'h0, 32'h0, 32'h0, 32'h0};
+    vec4s[2] = '{32'h0, 32'h0, 32'h0, 32'h0};
+    // Signed zeros only — still an all-zero block by magnitude.
+    names[3] = "negzero";
+    vecs[3]  = '{32'h80000000, 32'h0, 32'h80000000, 32'h0,
+                 32'h0, 32'h80000000, 32'h0, 32'h0};
+    vec4s[3] = '{32'h80000000, 32'h0, 32'h0, 32'h0};
+    // One NaN anywhere forces the NaN scale 0xFF; element bits are
+    // don't-care and must still agree bit for bit across backends.
+    names[4] = "nan";
+    vecs[4]  = '{32'h3F800000, 32'h7FC00000, 32'h40400000, 32'h3F000000,
+                 32'h40C00000, 32'hBE800000, 32'h00000000, 32'h40800000};
+    vec4s[4] = '{32'h3F800000, 32'h7FC00000, 32'h3F800000, 32'h3F800000};
+    // Inf likewise: `arch_f32_to_e8m0` maps every non-finite to 0xFF.
+    names[5] = "inf";
+    vecs[5]  = '{32'h3F800000, 32'h7F800000, 32'h40400000, 32'h3F000000,
+                 32'h40C00000, 32'hBE800000, 32'h00000000, 32'h40800000};
+    vec4s[5] = '{32'hFF800000, 32'h3F800000, 32'h3F800000, 32'h3F800000};
+    // Subnormals: the shared scale underflows and clamps at 0x00.
+    names[6] = "subnormal";
+    vecs[6]  = '{32'h00000001, 32'h00000002, 32'h007FFFFF, 32'h00400000,
+                 32'h00000000, 32'h00000003, 32'h00800000, 32'h00000001};
+    vec4s[6] = '{32'h00000001, 32'h00000002, 32'h00000003, 32'h00000004};
+    // Huge magnitudes: the scale saturates near the top of E8M0 and the
+    // dequantized product is the saturation case (decision #5).
+    names[7] = "huge";
+    vecs[7]  = '{32'h7F7FFFFF, 32'h7F000000, 32'h3F800000, 32'h00000000,
+                 32'hFF7FFFFF, 32'h40000000, 32'h40800000, 32'h41000000};
+    vec4s[7] = '{32'h7F7FFFFF, 32'h3F800000, 32'h00000000, 32'h40000000};
+    // Wide dynamic range inside one block: the small elements must
+    // quantize to zero rather than to a wrapped code.
+    names[8] = "range";
+    vecs[8]  = '{32'h44800000, 32'h3A83126F, 32'hC4000000, 32'h00000000,
+                 32'h3F800000, 32'hB8D1B717, 32'h43800000, 32'h40000000};
+    vec4s[8] = '{32'h44800000, 32'h3A83126F, 32'h3F800000, 32'h00000000};
+
+    for (int c = 0; c < NC; c++) begin
+      for (int i = 0; i < 8; i++) v[i]  = vecs[c][i];
+      for (int i = 0; i < 4; i++) v4[i] = vec4s[c][i];
+      #1;
+      $display("== %s", names[c]);
+      show("q4f", {32'b0, q4_floor}, 2);
+      show("q4c", {32'b0, q4_ceil},  2);
+      show("q6 ", {16'b0, q6},       2);
+      show("q8 ", q8,                3);
+      show("q4s", {48'b0, q4s},      1);
+      show_vec("b4 ", back4, 8);
+      show_vec("b6 ", back6, 8);
+      show_vec("b8 ", back8, 8);
+    end
+    $finish;
+  end
+endmodule

--- a/tests/fp_v1/tb_scaled_quant.cpp
+++ b/tests/fp_v1/tb_scaled_quant.cpp
@@ -1,0 +1,126 @@
+// arch-sim side of the `scaled_quantize` / `scaled_dequantize` cross-backend
+// check (phase 2b, arch#884).
+//
+// Prints one line per (vector, signal) in a format the SystemVerilog
+// testbench `rtl_diff/tb_scaled_quant.sv` reproduces EXACTLY, so
+// `fp_scaled_quant_sv_matches_sim` can byte-compare the two transcripts.
+// Every block is printed as 32-bit words LSB-first — a `%h` of a 72-bit
+// value has no portable C++ counterpart, and words make a mismatch land on
+// the specific word rather than on one long string.
+//
+// The vector set is chosen to exercise the branches the block conversion
+// actually has: an all-zero block (minimum scale, zero elements), a block
+// containing a NaN and one containing an Inf (both force the NaN scale
+// 0xFF and don't-care elements), subnormal inputs, a power-of-two maximum
+// (where floor_pow2 and ceil_pow2 must agree) and a non-power-of-two
+// maximum (where they must differ), and magnitudes far enough apart that
+// the small elements quantize to zero.
+#include "VScaledQuant.h"
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+
+static VScaledQuant dut;
+
+// Blocks land in three C++ storage buckets depending on width; print each
+// uniformly as words so the transcript shape does not depend on the bucket.
+static void print_words(const char *name, uint64_t v, int words) {
+  printf("%s", name);
+  for (int w = 0; w < words; ++w)
+    printf(" %08x", (uint32_t)(v >> (32 * w)));
+  printf("\n");
+}
+template <int W>
+static void print_words(const char *name, const VlWide<W> &v, int words) {
+  printf("%s", name);
+  for (int w = 0; w < words; ++w)
+    printf(" %08x", const_cast<VlWide<W> &>(v).data()[w]);
+  printf("\n");
+}
+static void print_vec(const char *name, const uint32_t *v, int n) {
+  printf("%s", name);
+  for (int i = 0; i < n; ++i)
+    printf(" %08x", v[i]);
+  printf("\n");
+}
+
+struct Case {
+  const char *why;
+  uint32_t v[8];  // raw FP32 bit patterns
+  uint32_t v4[4];
+};
+
+// Raw bit patterns, never float literals. Two reasons: a testbench written
+// with `0.001f` asserts the C++ decimal parse as well as the DUT, and the
+// SystemVerilog twin (`rtl_diff/tb_scaled_quant.sv`) has to drive the SAME
+// bits — with hex on both sides the two vector tables diff line for line.
+//
+//   1.0=3F800000  -2.0=C0000000   4.0=40800000   0.5=3F000000  8.0=41000000
+//  -0.25=BE800000  2.0=40000000   3.0=40400000   6.0=40C00000  1.5=3FC00000
+//   0.75=3F400000  1024=44800000  0.001=3A83126F -512=C4000000
+//  -0.0001=B8D1B717 256=43800000
+int main() {
+  const Case cases[] = {
+      // Powers of two throughout: floor_pow2 and ceil_pow2 must agree.
+      {"pow2",
+       {0x3F800000u, 0xC0000000u, 0x40800000u, 0x3F000000u, 0x41000000u, 0xBE800000u,
+        0x00000000u, 0x40000000u},
+       {0x3F800000u, 0x40000000u, 0x40800000u, 0x3F000000u}},
+      // Max 6.0 is not a power of two: the two scale policies must differ.
+      {"nonpow2",
+       {0x3F800000u, 0xC0000000u, 0x40400000u, 0x3F000000u, 0x40C00000u, 0xBE800000u,
+        0x00000000u, 0x40800000u},
+       {0x40C00000u, 0x40400000u, 0x3FC00000u, 0x3F400000u}},
+      // All zero: minimum scale 0x00 and zero elements, NOT a NaN scale.
+      {"zeros", {0, 0, 0, 0, 0, 0, 0, 0}, {0, 0, 0, 0}},
+      // Signed zeros only — still an all-zero block by magnitude.
+      {"negzero",
+       {0x80000000u, 0, 0x80000000u, 0, 0, 0x80000000u, 0, 0},
+       {0x80000000u, 0, 0, 0}},
+      // One NaN anywhere forces the NaN scale 0xFF; element bits are
+      // don't-care and must still agree bit for bit across backends.
+      {"nan",
+       {0x3F800000u, 0x7FC00000u, 0x40400000u, 0x3F000000u, 0x40C00000u, 0xBE800000u,
+        0x00000000u, 0x40800000u},
+       {0x3F800000u, 0x7FC00000u, 0x3F800000u, 0x3F800000u}},
+      // Inf likewise: `arch_f32_to_e8m0` maps every non-finite to 0xFF.
+      {"inf",
+       {0x3F800000u, 0x7F800000u, 0x40400000u, 0x3F000000u, 0x40C00000u, 0xBE800000u,
+        0x00000000u, 0x40800000u},
+       {0xFF800000u, 0x3F800000u, 0x3F800000u, 0x3F800000u}},
+      // Subnormals: the shared scale underflows and clamps at 0x00.
+      {"subnormal",
+       {1u, 2u, 0x007FFFFFu, 0x00400000u, 0u, 3u, 0x00800000u, 1u},
+       {1u, 2u, 3u, 4u}},
+      // Huge magnitudes: the scale saturates near the top of E8M0 and the
+      // dequantized product is the saturation case (decision #5).
+      {"huge",
+       {0x7F7FFFFFu, 0x7F000000u, 0x3F800000u, 0x00000000u, 0xFF7FFFFFu, 0x40000000u,
+        0x40800000u, 0x41000000u},
+       {0x7F7FFFFFu, 0x3F800000u, 0x00000000u, 0x40000000u}},
+      // Wide dynamic range inside one block: the small elements must
+      // quantize to zero rather than to a wrapped code.
+      {"range",
+       {0x44800000u, 0x3A83126Fu, 0xC4000000u, 0x00000000u, 0x3F800000u, 0xB8D1B717u,
+        0x43800000u, 0x40000000u},
+       {0x44800000u, 0x3A83126Fu, 0x3F800000u, 0x00000000u}},
+  };
+
+  for (const Case &c : cases) {
+    for (int i = 0; i < 8; ++i)
+      dut.v[i] = c.v[i];
+    for (int i = 0; i < 4; ++i)
+      dut.v4[i] = c.v4[i];
+    dut.eval();
+    printf("== %s\n", c.why);
+    print_words("q4f", dut.q4_floor, 2);
+    print_words("q4c", dut.q4_ceil, 2);
+    print_words("q6 ", dut.q6, 2);
+    print_words("q8 ", dut.q8, 3);
+    print_words("q4s", dut.q4s, 1);
+    print_vec("b4 ", dut.back4, 8);
+    print_vec("b6 ", dut.back6, 8);
+    print_vec("b8 ", dut.back8, 8);
+  }
+  return 0;
+}


### PR DESCRIPTION
Phase 2b of the MX/NVFP4 block-format design. Phase 2a (#872) shipped the `ScaledVec` type; this ships the two conversions between it and `Vec<FP32, N>`, lowered in `arch build` and `arch sim`.

```arch
scaled_quantize<MXFP4>(v)                    // Vec<FP32,32> -> block
scaled_quantize<MXFP4, ceil_pow2, rne>(v)    // explicit selectors
scaled_dequantize(b)                         // block -> Vec<FP32,32>
```

The output format is spelled, never inferred: a `Vec<FP32,N>` operand says nothing about which element format or scale to target, so `MXFP4` and `MXFP8` are equally valid results.

Closes #884.

## One descriptor, two renderings

`src/fp_block.rs` owns the lowering and emits **both** the SystemVerilog and the arch-sim C++ from one descriptor, because glue is exactly where two emitters in two files drift.

The numerics are not new — every float operation used is an existing helper with an exhaustive SMT miter behind it (#856): `arch_f32_to_e8m0`, `arch_e8m0_to_f32`, `arch_f32_mul`, and the per-format narrows. What is new is the reduction, the exponent arithmetic and the bit packing. Two choices keep that glue free of float semantics of its own:

- The block maximum is an **unsigned integer** max over sign-cleared words. For non-negative IEEE-754 the bit order *is* the numeric order, and every NaN sorts above `+Inf` — so one integer compare yields both the magnitude maximum and the "any non-finite in this block" test. No float compare, no NaN-ordering rule to get wrong.
- The per-element division by the shared scale is a multiply by `2^-(code-127)`, itself an E8M0 code (`254 - code`). A power-of-two multiply is exact in FP32, so the element narrow rounds **exactly once**, from the true `v_i / X`. That single rounding is what makes the round-trip bound provable.

## The §8 gate: measured, not asserted

`fp_scaled_quant_sv_matches_sim` runs the same design and the same vectors through Verilator on the emitted `.sv` and through the native sim on the emitted C++, then byte-compares the transcripts — **81 lines, identical**.

A structural test cannot replace this. The two renderings could agree on every constant and callee and still disagree on a value, because the languages differ in part-select semantics, integer promotion and shift behaviour. Vectors cover the all-zero block, NaN and Inf blocks, subnormals, saturation, and a power-of-two vs non-power-of-two maximum — the last pair being where the two scale policies must *agree* and must *differ* respectively, so a policy selector that changed nothing would not pass.

## Two defects found and fixed while building this

**The C++ block type is not a function of its width.** The sim gives one block type two representations: a 72-bit block is `VlWide<3>` as a port but `_arch_u128` as an internal wire. A width table in the emitter was right for ports and a silent truncation for wires — the `_ => 32` shape again, and I had written it myself. The emitted helper is now a template whose block side is selected by the destination's own type, so there is no second table to keep in sync. `fp_block_cpp_is_generic_over_block_storage` fails if a concrete storage type reappears.

**`>>` closed no angle-bracket list.** `scaled_quantize<ScaledVec<..>>(v)` is the first place in the language where a type can end immediately before a closing `>`, and the lexer maximal-munches that into a shift token. Added `expect_angle_close`, used by the type-expression closers, so writing the format inline no longer needs an alias to work around the tokenizer.

## Scope

`rtz` / `rna` parse but are refused by typecheck with the actual reason and a pointer to #890. They need their own element rounders in each backend, with per-format overflow rules (RTZ on E5M2 must give max-finite, not Inf) and their own equivalence proofs — 10 new narrow variants across two backends. That is its own piece of work, not a flag on the existing rounder, so it is filed rather than half-built here.

`exact` policy, `stochastic` rounding, `scaled_dot` (phase 3) and `UE4M3` (phase 5) stay deferred for the reasons recorded in #884.

## Verification

- `cargo test` — 1159 tests, 0 failures, on the rebased tree.
- `cargo fmt --check` clean.
- `fp_scaled_quant_sv_matches_sim` — Verilator 5.048 vs native sim, byte-identical.
- Emitted SV passes `verilator --lint-only` and `--binary`.
- Spec §3.11.1 documents the surface, selectors and special-value rules; the type-table row is corrected (`==`/`!=` are an encoding compare, so "no compares" was stale from before #872). Skill snapshots re-synced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)