### PR TITLE
feat(fp): scaled_dot — the OCP MX block dot product (phase 3)

### DIFF
--- a/doc/ARCH_HDL_Specification.md
+++ b/doc/ARCH_HDL_Specification.md
@@ -321,7 +321,7 @@ The Arch type system enforces four independent safety dimensions simultaneously.
 
   **E8M0**             8 bits               OCP MX block **scale** type — an unsigned biased exponent (bias 127) denoting 2^(e-127). **Not a float**: no sign, no mantissa, no infinity, and **no zero** (`0x00` is the minimum scale 2^-127). `0xFF` is NaN. See §3.10.
 
-  **ScaledVec\<E,N,S\>**  \|S\| + N × \|E\|    Block-scaled vector — N narrow elements sharing one scale, packed as `{scale, P[N-1..0]}` (MXFP4 = 136 bits). **No arithmetic, no ordered compares, no indexing** — OCP MX defines only the block dot product; `==`/`!=` are an *encoding* compare. Convert with `scaled_quantize<Fmt>` / `scaled_dequantize`. See §3.11.
+  **ScaledVec\<E,N,S\>**  \|S\| + N × \|E\|    Block-scaled vector — N narrow elements sharing one scale, packed as `{scale, P[N-1..0]}` (MXFP4 = 136 bits). **No arithmetic, no ordered compares, no indexing** — OCP MX defines only the block dot product; `==`/`!=` are an *encoding* compare. Convert with `scaled_quantize<Fmt>` / `scaled_dequantize`; `scaled_dot(a,b)` is the block dot product. See §3.11.
 
   **Clock\<D\>**       1 bit                Carries clock-domain tag D. Cannot appear in arithmetic.
 
@@ -1050,9 +1050,9 @@ element `0` in the low bits, matching the `Vec` convention above. Width is
 8 + 128 = **136 bits**.
 
 **No arithmetic, no ordering, no indexing.** OCP MX §6 defines exactly one
-operation on blocks --- the dot product `X^A · X^B · Σᵢ(Pᵢ^A × Pᵢ^B)` --- and
-no add, multiply or ordered compare. ARCH refuses all of them at the type
-checker rather than inventing semantics:
+operation on blocks --- the dot product `X^A · X^B · Σᵢ(Pᵢ^A × Pᵢ^B)`, exposed
+as `scaled_dot` (§3.11.2) --- and no add, multiply or ordered compare. ARCH
+refuses all of them at the type checker rather than inventing semantics:
 
 ```arch
 y = a + b;    // error: no arithmetic on a block-scaled vector
@@ -1177,10 +1177,54 @@ comb
 end comb
 ```
 
+**3.11.2 `scaled_dot` --- the block dot product**
+
+```arch
+scaled_dot(a, b)      // two blocks of the SAME type -> FP32
+```
+
+The one operation OCP MX §6.2 defines normatively. Both operands must have the
+same `ScaledVec` type; a dot across different element formats or block sizes
+has no spec meaning and is a compile error. The result is `FP32` --- the spec
+leaves accumulator precision implementation-defined and ARCH picks `FP32`.
+
+The value is the spec's factored form:
+
+> `X^A · X^B · Σᵢ (Pᵢ^A × Pᵢ^B)`
+
+**Every element-pair product is exact**, so all rounding in a block dot happens
+in the summation and none in the multiplies. This is not an approximation
+argument: the widest element significand is `FP8E4M3`'s 4 bits, needing at most
+8 of `FP32`'s 24, and the widest exponent span is `FP8E5M2`'s `2⁻³² … 2³¹·⁶`,
+comfortably inside `FP32`'s normals. It is machine-checked exhaustively for all
+five element formats (`fp_smt_proof::MX_DOT`), jointly with `arch_f32_mul`
+returning that exact product.
+
+**Accumulation order is defined, not left open.** `FP32` addition is not
+associative, so an unstated order would be an unstated result. ARCH sums
+**balanced pairwise**: each round adds adjacent values, a lone trailing value
+passes through untouched, repeat until one remains. This is `⌈log₂ N⌉` deep
+rather than `N` --- what a dot-product datapath synthesizes to anyway --- and
+pairwise summation's error grows as `O(log N)` against a serial accumulator's
+`O(N)`. A lone value is *carried*, never padded with a zero: adding `0.0` is
+not a no-op in `FP32` (it turns `-0.0` into `+0.0`).
+
+**The two scales are applied one at a time**, as `(Σ ⊗ X^A) ⊗ X^B`, not as a
+pre-formed `X^A · X^B`. Each scale is a power of two, so each multiply is
+exact absent overflow --- but the two E8M0 scales span `2⁻¹²⁷ … 2¹²⁷`, so their
+*product* spans `2⁻²⁵⁴ … 2²⁵⁴` and can overflow to infinity or flush to zero
+even when the final result is perfectly representable. Applying them
+separately has a strictly wider exact domain.
+
+A NaN scale (`0xFF`) on either operand makes the result NaN, which falls out of
+the scale multiply rather than needing a rule. An all-zero block dots to `+0`,
+not NaN --- E8M0 has no zero, so the minimum-scale path multiplies a zero sum
+by the finite `2⁻¹²⁷`.
+
 **Not yet implemented:** `rtz` / `rna` rounding (they need their own element
 rounders in each backend, with their own overflow rules --- arch#890), the `exact` scale
 policy and `stochastic` rounding (see §3.11 for why both are deferred),
-`scaled_dot`, and the `UE4M3` scale.
+and the `UE4M3` scale.
 
 **3.12 Package-scope type aliases**
 

--- a/skills/arch-programming/references/ARCH_HDL_Specification.md
+++ b/skills/arch-programming/references/ARCH_HDL_Specification.md
@@ -321,7 +321,7 @@ The Arch type system enforces four independent safety dimensions simultaneously.
 
   **E8M0**             8 bits               OCP MX block **scale** type — an unsigned biased exponent (bias 127) denoting 2^(e-127). **Not a float**: no sign, no mantissa, no infinity, and **no zero** (`0x00` is the minimum scale 2^-127). `0xFF` is NaN. See §3.10.
 
-  **ScaledVec\<E,N,S\>**  \|S\| + N × \|E\|    Block-scaled vector — N narrow elements sharing one scale, packed as `{scale, P[N-1..0]}` (MXFP4 = 136 bits). **No arithmetic, no ordered compares, no indexing** — OCP MX defines only the block dot product; `==`/`!=` are an *encoding* compare. Convert with `scaled_quantize<Fmt>` / `scaled_dequantize`. See §3.11.
+  **ScaledVec\<E,N,S\>**  \|S\| + N × \|E\|    Block-scaled vector — N narrow elements sharing one scale, packed as `{scale, P[N-1..0]}` (MXFP4 = 136 bits). **No arithmetic, no ordered compares, no indexing** — OCP MX defines only the block dot product; `==`/`!=` are an *encoding* compare. Convert with `scaled_quantize<Fmt>` / `scaled_dequantize`; `scaled_dot(a,b)` is the block dot product. See §3.11.
 
   **Clock\<D\>**       1 bit                Carries clock-domain tag D. Cannot appear in arithmetic.
 
@@ -1050,9 +1050,9 @@ element `0` in the low bits, matching the `Vec` convention above. Width is
 8 + 128 = **136 bits**.
 
 **No arithmetic, no ordering, no indexing.** OCP MX §6 defines exactly one
-operation on blocks --- the dot product `X^A · X^B · Σᵢ(Pᵢ^A × Pᵢ^B)` --- and
-no add, multiply or ordered compare. ARCH refuses all of them at the type
-checker rather than inventing semantics:
+operation on blocks --- the dot product `X^A · X^B · Σᵢ(Pᵢ^A × Pᵢ^B)`, exposed
+as `scaled_dot` (§3.11.2) --- and no add, multiply or ordered compare. ARCH
+refuses all of them at the type checker rather than inventing semantics:
 
 ```arch
 y = a + b;    // error: no arithmetic on a block-scaled vector
@@ -1177,10 +1177,54 @@ comb
 end comb
 ```
 
+**3.11.2 `scaled_dot` --- the block dot product**
+
+```arch
+scaled_dot(a, b)      // two blocks of the SAME type -> FP32
+```
+
+The one operation OCP MX §6.2 defines normatively. Both operands must have the
+same `ScaledVec` type; a dot across different element formats or block sizes
+has no spec meaning and is a compile error. The result is `FP32` --- the spec
+leaves accumulator precision implementation-defined and ARCH picks `FP32`.
+
+The value is the spec's factored form:
+
+> `X^A · X^B · Σᵢ (Pᵢ^A × Pᵢ^B)`
+
+**Every element-pair product is exact**, so all rounding in a block dot happens
+in the summation and none in the multiplies. This is not an approximation
+argument: the widest element significand is `FP8E4M3`'s 4 bits, needing at most
+8 of `FP32`'s 24, and the widest exponent span is `FP8E5M2`'s `2⁻³² … 2³¹·⁶`,
+comfortably inside `FP32`'s normals. It is machine-checked exhaustively for all
+five element formats (`fp_smt_proof::MX_DOT`), jointly with `arch_f32_mul`
+returning that exact product.
+
+**Accumulation order is defined, not left open.** `FP32` addition is not
+associative, so an unstated order would be an unstated result. ARCH sums
+**balanced pairwise**: each round adds adjacent values, a lone trailing value
+passes through untouched, repeat until one remains. This is `⌈log₂ N⌉` deep
+rather than `N` --- what a dot-product datapath synthesizes to anyway --- and
+pairwise summation's error grows as `O(log N)` against a serial accumulator's
+`O(N)`. A lone value is *carried*, never padded with a zero: adding `0.0` is
+not a no-op in `FP32` (it turns `-0.0` into `+0.0`).
+
+**The two scales are applied one at a time**, as `(Σ ⊗ X^A) ⊗ X^B`, not as a
+pre-formed `X^A · X^B`. Each scale is a power of two, so each multiply is
+exact absent overflow --- but the two E8M0 scales span `2⁻¹²⁷ … 2¹²⁷`, so their
+*product* spans `2⁻²⁵⁴ … 2²⁵⁴` and can overflow to infinity or flush to zero
+even when the final result is perfectly representable. Applying them
+separately has a strictly wider exact domain.
+
+A NaN scale (`0xFF`) on either operand makes the result NaN, which falls out of
+the scale multiply rather than needing a rule. An all-zero block dots to `+0`,
+not NaN --- E8M0 has no zero, so the minimum-scale path multiplies a zero sum
+by the finite `2⁻¹²⁷`.
+
 **Not yet implemented:** `rtz` / `rna` rounding (they need their own element
 rounders in each backend, with their own overflow rules --- arch#890), the `exact` scale
 policy and `stochastic` rounding (see §3.11 for why both are deferred),
-`scaled_dot`, and the `UE4M3` scale.
+and the `UE4M3` scale.
 
 **3.12 Package-scope type aliases**
 

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -6150,25 +6150,6 @@ impl<'a> Codegen<'a> {
     ///
     /// Mirrors `typecheck::TypeChecker::type_expr_width`. Kept private to
     /// codegen for now — promote to a shared util if a third caller appears.
-    /// Resolve a `ScaledVec<Elem, N, Scale>` surface type to the block shape
-    /// the helper emitters are keyed on.
-    ///
-    /// `None` — never a guess — when `N` does not fold to a literal or a
-    /// member type is not a legal block member. Both callers turn that into a
-    /// panic rather than a fallback: typecheck has already accepted the type,
-    /// so a `None` is a compiler bug, and inventing a shape here is precisely
-    /// how phase 2a shipped a 40-bit SV port against an 8-bit sim variable.
-    fn block_shape_of_type(&self, ty: &TypeExpr) -> Option<crate::fp_block::BlockShape> {
-        let TypeExpr::ScaledVec(elem, size, scale) = ty else {
-            return None;
-        };
-        let n = match &size.kind {
-            ExprKind::Literal(LitKind::Dec(n)) | ExprKind::Literal(LitKind::Hex(n)) => *n as u32,
-            _ => return None,
-        };
-        crate::fp_block::shape_of(elem, n, scale)
-    }
-
     fn type_expr_width(&self, ty: &TypeExpr) -> Option<u32> {
         let eval = |e: &Expr| match &e.kind {
             ExprKind::Literal(LitKind::Dec(n)) | ExprKind::Literal(LitKind::Hex(n)) => {
@@ -7240,7 +7221,7 @@ impl<'a> Codegen<'a> {
             // comes from the EXPRESSION's own format argument, not from the
             // assignment target, so nothing here has to be inferred.
             ExprKind::ScaledQuantize(value, fmt, policy, round) => {
-                let shape = self.block_shape_of_type(fmt).unwrap_or_else(|| {
+                let shape = crate::fp_block::shape_of_type(fmt).unwrap_or_else(|| {
                     panic!(
                         "scaled_quantize format has no resolvable block shape — \
                          typecheck accepts only `ScaledVec` formats, so this means the \
@@ -7950,7 +7931,7 @@ impl<'a> Codegen<'a> {
             let shape = self
                 .expr_decl_type(&args[0])
                 .as_ref()
-                .and_then(|t| self.block_shape_of_type(t))
+                .and_then(|t| crate::fp_block::shape_of_type(t))
                 .unwrap_or_else(|| {
                     panic!(
                         "scaled_dequantize operand has no resolvable block shape — \
@@ -7962,6 +7943,26 @@ impl<'a> Codegen<'a> {
             self.fp_helpers_used.set(true);
             self.block_helpers.borrow_mut().insert(h);
             return format!("{}({})", h.sv_name(), arg_strs[0]);
+        }
+        // `scaled_dot(a, b)` → the generated block helper. Unlike quantize /
+        // dequantize this returns a scalar FP32, so it stays an ordinary
+        // expression on both backends rather than needing a statement form.
+        if name == "scaled_dot" && args.len() == 2 {
+            let shape = self
+                .expr_decl_type(&args[0])
+                .as_ref()
+                .and_then(|t| crate::fp_block::shape_of_type(t))
+                .unwrap_or_else(|| {
+                    panic!(
+                        "scaled_dot operand has no resolvable block shape — typecheck accepts \
+                         only matching `ScaledVec` operands, so this means the block size did \
+                         not fold to a literal (arch#884 phase 3)"
+                    )
+                });
+            let h = crate::fp_block::BlockHelper::Dot { shape };
+            self.fp_helpers_used.set(true);
+            self.block_helpers.borrow_mut().insert(h);
+            return format!("{}({}, {})", h.sv_name(), arg_strs[0], arg_strs[1]);
         }
         // Built-in SVA: past/rose/fell → SV $past/$rose/$fell
         if name == "past" || name == "rose" || name == "fell" {

--- a/src/fp_block.rs
+++ b/src/fp_block.rs
@@ -1,5 +1,6 @@
 //! Block-scaled (`ScaledVec`) operations — the `scaled_quantize` /
-//! `scaled_dequantize` lowering shared by `arch build` and `arch sim`.
+//! `scaled_dequantize` / `scaled_dot` lowering shared by `arch build` and
+//! `arch sim`.
 //!
 //! **Why one module emits both backends.** The numerics here are *not* new:
 //! every float operation used below is an existing helper with an exhaustive
@@ -26,6 +27,13 @@
 //!    A power-of-two multiply is exact in FP32, so the element narrow that
 //!    follows rounds exactly once, from the true `v_i / X`. That single
 //!    rounding is what makes the round-trip error bound provable (arch#884).
+//!
+//! `scaled_dot` (phase 3) rests on the same principle from the other side:
+//! every element-pair product is *exact* in FP32 — machine-checked
+//! exhaustively per format by `fp_smt_proof::MX_DOT` — so all of a block dot's
+//! rounding is in the summation. That is what makes [`dot_schedule`]'s choice
+//! of accumulation order the only implementation freedom left, and therefore
+//! worth defining rather than leaving open.
 //!
 //! Layout is the one fixed in phase 2a (`fp_format::scaled_vec_width`):
 //! `{ scale[SW-1:0], P[N-1], …, P[1], P[0] }` — scale in the high bits,
@@ -78,6 +86,9 @@ pub enum BlockHelper {
     },
     /// Block → `Vec<FP32, N>`.
     Dequantize { shape: BlockShape },
+    /// Block · block → `FP32`. The one operation OCP MX defines normatively
+    /// (§6.2): `X^A · X^B · Σᵢ(Pᵢ^A × Pᵢ^B)`.
+    Dot { shape: BlockShape },
 }
 
 /// Resolve a `ScaledVec<Elem, N, Scale>` surface type to a block shape.
@@ -103,6 +114,28 @@ pub fn shape_of(elem: &TypeExpr, n: u32, scale: &TypeExpr) -> Option<BlockShape>
         _ => return None,
     };
     Some(BlockShape { elem, n, scale })
+}
+
+/// Resolve a `ScaledVec<Elem, N, Scale>` **TypeExpr** to a block shape.
+///
+/// The one resolver both backends use. It was briefly duplicated per emitter,
+/// which is how a block ends up sized one way in the SV and another in the
+/// sim; there is nothing here worth having two copies of.
+///
+/// `None` — never a guess — when the type is not a block, `N` does not fold to
+/// a literal, or a member type is not a legal block member. Callers turn that
+/// into a panic: typecheck has already accepted the type, so a `None` is a
+/// compiler bug rather than a user error.
+pub fn shape_of_type(ty: &TypeExpr) -> Option<BlockShape> {
+    let TypeExpr::ScaledVec(elem, size, scale) = ty else {
+        return None;
+    };
+    let n = match &size.kind {
+        crate::ast::ExprKind::Literal(crate::ast::LitKind::Dec(n))
+        | crate::ast::ExprKind::Literal(crate::ast::LitKind::Hex(n)) => *n as u32,
+        _ => return None,
+    };
+    shape_of(elem, n, scale)
 }
 
 impl BlockShape {
@@ -143,7 +176,9 @@ impl BlockShape {
 impl BlockHelper {
     fn shape(self) -> BlockShape {
         match self {
-            BlockHelper::Quantize { shape, .. } | BlockHelper::Dequantize { shape } => shape,
+            BlockHelper::Quantize { shape, .. }
+            | BlockHelper::Dequantize { shape }
+            | BlockHelper::Dot { shape } => shape,
         }
     }
 
@@ -167,6 +202,9 @@ impl BlockHelper {
                 s.n,
                 s.scale.tag(),
             ),
+            BlockHelper::Dot { .. } => {
+                format!("arch_scaled_dot_{}_{}_{}", s.elem_tag(), s.n, s.scale.tag(),)
+            }
         }
     }
 
@@ -190,6 +228,49 @@ fn round_tag(r: RoundMode) -> &'static str {
     }
 }
 
+/// The summation schedule for a block dot product of `n` elements.
+///
+/// **This is a definition, not a derivation.** OCP MX §6.2 fixes the dot's
+/// *value* as `X^A · X^B · Σᵢ(Pᵢ^A × Pᵢ^B)` but leaves the accumulation
+/// implementation-defined — and FP32 addition is not associative, so an
+/// unstated order is an unstated result. ARCH defines it here, once, and both
+/// backends render this same schedule.
+///
+/// The order is **balanced pairwise**: each round adds adjacent pairs, a lone
+/// trailing value passes through untouched, repeat until one remains. Chosen
+/// over a running serial accumulator because it is what a dot-product datapath
+/// synthesizes to anyway (⌈log₂ N⌉ deep rather than N), and because pairwise
+/// summation has a strictly smaller error bound — `O(log N)` growth against
+/// serial's `O(N)`.
+///
+/// Temps `0..n` are the element-pair products; each returned `(l, r)` defines
+/// the next temp in order, so temp `n + k` is `adds[k]`. Returns the adds and
+/// the index of the final temp (which is `0` when `n == 1`: no adds at all).
+fn dot_schedule(n: u32) -> (Vec<(usize, usize)>, usize) {
+    let mut cur: Vec<usize> = (0..n as usize).collect();
+    let mut adds: Vec<(usize, usize)> = Vec::new();
+    let mut next_id = n as usize;
+    while cur.len() > 1 {
+        let mut nxt = Vec::with_capacity(cur.len().div_ceil(2));
+        let mut i = 0;
+        while i + 1 < cur.len() {
+            adds.push((cur[i], cur[i + 1]));
+            nxt.push(next_id);
+            next_id += 1;
+            i += 2;
+        }
+        if i < cur.len() {
+            // Odd count: the last value skips this round rather than being
+            // paired with an implicit zero. Adding zero is not a no-op in
+            // FP32 (it turns -0.0 into +0.0), so a "harmless" pad would be a
+            // real value change.
+            nxt.push(cur[i]);
+        }
+        cur = nxt;
+    }
+    (adds, cur[0])
+}
+
 /// `[hi:0]` in the `logic [hi:0] ` declaration style `render_sv` uses.
 fn sv_w(bits: u32) -> String {
     if bits == 1 {
@@ -211,7 +292,70 @@ pub fn sv_definition(h: BlockHelper) -> String {
             round,
         } => sv_quantize(shape, policy, round),
         BlockHelper::Dequantize { shape } => sv_dequantize(shape),
+        BlockHelper::Dot { shape } => sv_dot(shape),
     }
+}
+
+/// `scaled_dot` — OCP MX §6.2's `X^A · X^B · Σᵢ(Pᵢ^A × Pᵢ^B)`.
+///
+/// The summation tree is **unrolled at generation time** rather than emitted
+/// as a loop over an array. That is what makes the two backends comparable by
+/// inspection: both print the identical sequence of named temporaries from
+/// the identical [`dot_schedule`], so a reviewer can diff them line for line
+/// and a divergence cannot hide inside differing loop semantics.
+fn sv_dot(s: BlockShape) -> String {
+    let name = BlockHelper::Dot { shape: s }.sv_name();
+    let (bw, ew, sw) = (s.bits(), s.elem_width(), s.scale.width());
+    let (n, tag) = (s.n, s.elem_tag());
+    let (adds, last) = dot_schedule(n);
+    let mut o = String::new();
+    let _ = writeln!(
+        o,
+        "// {name}: OCP MX \u{a7}6.2 block dot, X^A * X^B * sum(P^A_i * P^B_i)."
+    );
+    let _ = writeln!(
+        o,
+        "function automatic logic {}{name}(input logic {}a, input logic {}b);",
+        sv_w(32),
+        sv_w(bw),
+        sv_w(bw)
+    );
+    for t in 0..(n as usize + adds.len()) {
+        let _ = writeln!(o, "  logic {}t{t};", sv_w(32));
+    }
+    // Element-pair products. EXACT in FP32 for every element format — the
+    // widest significand product is E4M3's 4x4 = 8 bits against FP32's 24,
+    // and the widest exponent range is E5M2's 2^-32 .. 2^31.6, comfortably
+    // inside FP32's normals. So every rounding in a block dot happens in the
+    // summation below, none in these multiplies (`fp_block_dot_products_are_exact`).
+    for i in 0..n as usize {
+        let _ = writeln!(
+            o,
+            "  t{i} = arch_f32_mul(arch_{tag}_to_f32(a[{lo} +: {ew}]), \
+             arch_{tag}_to_f32(b[{lo} +: {ew}]));",
+            lo = i * ew as usize
+        );
+    }
+    for (k, (l, r)) in adds.iter().enumerate() {
+        let _ = writeln!(o, "  t{} = arch_f32_add(t{l}, t{r});", n as usize + k);
+    }
+    // Scales applied ONE AT A TIME, not as a pre-formed `X^A * X^B`.
+    // Each is a power of two, so each multiply is exact absent over/underflow
+    // — but forming `X^A * X^B` first can overflow to Inf or flush to zero
+    // (the two E8M0 exponents span 2^-127..2^127, so their product spans
+    // 2^-254..2^254, well outside FP32) even when the final result is
+    // perfectly representable. Applying them separately has a strictly wider
+    // exact domain. A NaN scale (0xFF) widens to NaN and poisons the result
+    // here, which is the block value rule.
+    let _ = writeln!(
+        o,
+        "  {name} = arch_f32_mul(arch_f32_mul(t{last}, arch_e8m0_to_f32(a[{hi}:{lo}])), \
+         arch_e8m0_to_f32(b[{hi}:{lo}]));",
+        hi = bw - 1,
+        lo = bw - sw
+    );
+    let _ = writeln!(o, "endfunction");
+    o
 }
 
 fn sv_quantize(s: BlockShape, policy: ScalePolicy, round: RoundMode) -> String {
@@ -415,7 +559,67 @@ pub fn cpp_definition(h: BlockHelper) -> String {
             round,
         } => cpp_quantize(shape, policy, round),
         BlockHelper::Dequantize { shape } => cpp_dequantize(shape),
+        BlockHelper::Dot { shape } => cpp_dot(shape),
     }
+}
+
+/// C++ twin of [`sv_dot`]. Same schedule, same temp numbering, same order of
+/// scale application — compare the two side by side.
+///
+/// Returns by value (unlike quantize/dequantize): the result is a scalar
+/// `FP32`, so it composes as an ordinary expression on both backends. Both
+/// block operands are template parameters because the same block type has
+/// different C++ storage as a port and as an internal wire, and a dot can mix
+/// the two.
+fn cpp_dot(s: BlockShape) -> String {
+    let name = BlockHelper::Dot { shape: s }.cpp_name();
+    let (bw, ew, sw) = (s.bits(), s.elem_width(), s.scale.width());
+    let (n, tag) = (s.n, s.elem_tag());
+    let nw = cpp_words(bw);
+    let (adds, last) = dot_schedule(n);
+    let mut o = String::new();
+    let _ = writeln!(
+        o,
+        "// {name}: OCP MX §6.2 block dot. Mirrors sv_dot in src/fp_block.rs."
+    );
+    let _ = writeln!(o, "template <typename BA, typename BB>");
+    let _ = writeln!(
+        o,
+        "static inline uint32_t {name}(const BA& a, const BB& b) {{"
+    );
+    let _ = writeln!(o, "  uint32_t _wa[{nw}], _wb[{nw}];");
+    let _ = writeln!(o, "  _arch_blk_get(_wa, {nw}, a);");
+    let _ = writeln!(o, "  _arch_blk_get(_wb, {nw}, b);");
+    // Exact products — see the note in sv_dot.
+    for i in 0..n as usize {
+        let _ = writeln!(
+            o,
+            "  uint32_t t{i} = _arch_f32_mul(_arch_{tag}_to_f32((uint8_t)_arch_blk_ext(_wa, {lo}u, {ew}u)), \
+             _arch_{tag}_to_f32((uint8_t)_arch_blk_ext(_wb, {lo}u, {ew}u)));",
+            lo = i * ew as usize
+        );
+    }
+    for (k, (l, r)) in adds.iter().enumerate() {
+        let _ = writeln!(
+            o,
+            "  uint32_t t{} = _arch_f32_add(t{l}, t{r});",
+            n as usize + k
+        );
+    }
+    // Scales one at a time — see the note in sv_dot.
+    let _ = writeln!(
+        o,
+        "  uint32_t xa = _arch_e8m0_to_f32((uint8_t)_arch_blk_ext(_wa, {lo}u, {sw}u));",
+        lo = bw - sw
+    );
+    let _ = writeln!(
+        o,
+        "  uint32_t xb = _arch_e8m0_to_f32((uint8_t)_arch_blk_ext(_wb, {lo}u, {sw}u));",
+        lo = bw - sw
+    );
+    let _ = writeln!(o, "  return _arch_f32_mul(_arch_f32_mul(t{last}, xa), xb);");
+    let _ = writeln!(o, "}}");
+    o
 }
 
 fn cpp_quantize(s: BlockShape, policy: ScalePolicy, round: RoundMode) -> String {

--- a/src/fp_smt_proof.rs
+++ b/src/fp_smt_proof.rs
@@ -142,6 +142,41 @@ pub const MX_CONV: &[&str] = &[
 /// (non-finite to `0xFF`, zero/subnormal to the minimum scale `0x00`).
 pub const MX_SCALE_CONV: &[&str] = &["e8m0_widen", "e8m0_narrow"];
 
+/// **The phase-3 gate for `scaled_dot`** (OCP MX §6.2): every element-pair
+/// product in a block dot is *exact* in FP32.
+///
+/// This is the theorem that makes the dot's error story simple enough to
+/// state — **all rounding in a block dot happens in the accumulation, none in
+/// the multiplies**. It is what lets ARCH define an accumulation order and
+/// have that definition mean something: if the products themselves rounded,
+/// the order would not be the only implementation choice left.
+///
+/// It is true for a structural reason, and the proof checks the reason rather
+/// than restating it. The widest element significand is E4M3's 4 bits, so a
+/// product needs at most 8 of FP32's 24; and the widest exponent span is
+/// E5M2's `2^-32 … 2^31.6`, comfortably inside FP32's normal range, so no
+/// subnormal truncation and no overflow either.
+///
+/// Exactness is expressed **without mentioning reals**: a rounded result is
+/// exact iff rounding toward `-∞` and toward `+∞` agree, since an inexact
+/// value falls strictly between two neighbours and the two modes pick
+/// different ones. (`RTZ`/`RTP` would *not* work — both round a negative
+/// value toward `+∞`, so they agree vacuously on every negative product.)
+///
+/// Each query proves two things at once, and needs both to be worth anything:
+/// the mathematical product is representable, *and* `arch_f32_mul` actually
+/// returns it. The second half is normally out of reach — general FP32
+/// multiplier equivalence is SAT-hard — but here both operands are confined
+/// to a widened 4-to-8-bit grid, so the space is 2^8 to 2^16 pairs rather
+/// than 2^64.
+pub const MX_DOT: &[&str] = &[
+    "e2m1_dot_exact",
+    "e2m3_dot_exact",
+    "e3m2_dot_exact",
+    "e4m3_dot_exact",
+    "e5m2_dot_exact",
+];
+
 /// An OCP all-finite storage format, described by constants transcribed from
 /// the OCP spec's value tables rather than recomputed from `(eb, mb)`.
 ///
@@ -393,6 +428,30 @@ pub fn equiv_proof(op: &str, profile: FpCompat) -> String {
             );
         }
         // ── bf16: spec on (_ FloatingPoint 8 8); RTL routes widen->f32->narrow ──
+        // ── Phase 3: block-dot element products are exact (see MX_DOT) ──
+        _ if op.ends_with("_dot_exact") => {
+            let tag = op.trim_end_matches("_dot_exact");
+            let w = crate::fp_format::by_tag(tag)
+                .unwrap_or_else(|| panic!("unknown element format `{tag}` in {op}"))
+                .width;
+            s.push_str(&format!(
+                "(declare-fun pa () (_ BitVec {w}))\n\
+                 (declare-fun pb () (_ BitVec {w}))\n\
+                 (define-fun fa () F ((_ to_fp 8 24) (arch_{tag}_to_f32 pa)))\n\
+                 (define-fun fb () F ((_ to_fp 8 24) (arch_{tag}_to_f32 pb)))\n\
+                 (define-fun down () F (fp.mul RTN fa fb))\n\
+                 (define-fun up   () F (fp.mul RTP fa fb))\n\
+                 (define-fun spec () F (fp.mul RNE fa fb))\n\
+                 (define-fun rr () (_ BitVec 32) (arch_f32_mul (arch_{tag}_to_f32 pa) (arch_{tag}_to_f32 pb)))\n\
+                 (assert (not (and\n\
+                   ; 1. the mathematical product is representable in FP32:\n\
+                   ;    rounding down and rounding up land on the same value.\n\
+                   (= down up)\n\
+                   ; 2. and `arch_f32_mul` actually returns it.\n\
+                   (ite (fp.isNaN spec) (= rr {n32}) (= ((_ to_fp 8 24) rr) spec)))))\n\
+                 (check-sat)\n"
+            ));
+        }
         _ if op.starts_with("bf16_") => {
             let bpre = "(declare-fun a () (_ BitVec 16))\n(declare-fun b () (_ BitVec 16))\n\
                         (define-fun ga () (_ FloatingPoint 8 8) ((_ to_fp 8 8) a))\n\

--- a/src/sim_codegen/expr_codegen.rs
+++ b/src/sim_codegen/expr_codegen.rs
@@ -1616,6 +1616,38 @@ pub(super) fn cpp_expr_inner(expr: &Expr, ctx: &Ctx, is_lhs: bool) -> String {
         }
         ExprKind::FunctionCall(name, args) => {
             let arg_strs: Vec<String> = args.iter().map(|a| cpp_expr(a, ctx)).collect();
+            // `scaled_dot(a, b)` returns a scalar FP32, so unlike quantize /
+            // dequantize (whose aggregate results need a statement form) it
+            // lowers as an ordinary call expression here.
+            if name == "scaled_dot" && args.len() == 2 {
+                let shape = ctx
+                    .decl_types
+                    .and_then(|m| match &args[0].kind {
+                        ExprKind::Ident(n) => m.get(n.as_str()),
+                        _ => None,
+                    })
+                    .and_then(|t| crate::fp_block::shape_of_type(t))
+                    .unwrap_or_else(|| {
+                        panic!(
+                            "scaled_dot operand has no resolvable block shape — typecheck \
+                             accepts only matching `ScaledVec` operands, so this means the \
+                             operand is not a plain signal name or its block size did not \
+                             fold to a literal (arch#884 phase 3)"
+                        )
+                    });
+                let h = crate::fp_block::BlockHelper::Dot { shape };
+                match ctx.block_helpers {
+                    Some(reg) => {
+                        reg.borrow_mut().insert(h);
+                    }
+                    None => panic!(
+                        "`{}` is needed here but this sim context has no block-helper \
+                         registry, so its definition would never be emitted (arch#884).",
+                        h.cpp_name()
+                    ),
+                }
+                return format!("{}({}, {})", h.cpp_name(), arg_strs[0], arg_strs[1]);
+            }
             format!("{name}({})", arg_strs.join(", "))
         }
 

--- a/src/sim_codegen/stmt_codegen.rs
+++ b/src/sim_codegen/stmt_codegen.rs
@@ -26,21 +26,6 @@ pub(super) enum SimAssignKind {
     Comb,
 }
 
-/// Resolve a `ScaledVec<Elem, N, Scale>` TypeExpr to the block shape the
-/// helper emitters are keyed on. `None` — never a guess — when `N` does not
-/// fold to a literal or a member type is not a legal block member; the caller
-/// turns that into a panic, because typecheck has already accepted the type.
-fn block_shape_of_type(ty: &TypeExpr) -> Option<crate::fp_block::BlockShape> {
-    let TypeExpr::ScaledVec(elem, size, scale) = ty else {
-        return None;
-    };
-    let n = match &size.kind {
-        ExprKind::Literal(LitKind::Dec(n)) | ExprKind::Literal(LitKind::Hex(n)) => *n as u32,
-        _ => return None,
-    };
-    crate::fp_block::shape_of(elem, n, scale)
-}
-
 /// Record `h` as needed by this module and return its C++ name.
 fn use_block_helper(h: crate::fp_block::BlockHelper, ctx: &Ctx) -> String {
     match ctx.block_helpers {
@@ -72,7 +57,7 @@ fn emit_scaled_block_assign(
 ) -> Option<()> {
     match &a.value.kind {
         ExprKind::ScaledQuantize(v, fmt, policy, round) => {
-            let shape = block_shape_of_type(fmt.as_ref()).unwrap_or_else(|| {
+            let shape = crate::fp_block::shape_of_type(fmt.as_ref()).unwrap_or_else(|| {
                 panic!(
                     "scaled_quantize format has no resolvable block shape — typecheck \
                      accepts only `ScaledVec` formats, so this means the block size did \
@@ -99,7 +84,7 @@ fn emit_scaled_block_assign(
                     ExprKind::Ident(n) => m.get(n.as_str()),
                     _ => None,
                 })
-                .and_then(block_shape_of_type)
+                .and_then(|t| crate::fp_block::shape_of_type(t))
                 .unwrap_or_else(|| {
                     panic!(
                         "scaled_dequantize operand has no resolvable block shape — typecheck \

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -4615,6 +4615,54 @@ impl<'a> TypeChecker<'a> {
                         }
                     };
                 }
+                // `scaled_dot(a, b) -> FP32` — the block dot product, the one
+                // operation OCP MX §6.2 defines normatively. Needs no type
+                // annotation: both operand types are fully known, and the
+                // result is always FP32 (the spec's accumulate precision is
+                // implementation-defined and ARCH picks FP32).
+                if name == "scaled_dot" {
+                    if call_args.len() != 2 {
+                        self.errors.push(CompileError::general(
+                            "`scaled_dot(a, b)` takes exactly 2 arguments (two blocks)",
+                            expr.span,
+                        ));
+                        return Ty::Error;
+                    }
+                    let at = self.resolve_expr_type(&call_args[0], module_name, local_types);
+                    let bt = self.resolve_expr_type(&call_args[1], module_name, local_types);
+                    if matches!(at, Ty::Todo | Ty::Error) || matches!(bt, Ty::Todo | Ty::Error) {
+                        return Ty::Error;
+                    }
+                    for (t, e) in [(&at, &call_args[0]), (&bt, &call_args[1])] {
+                        if !matches!(t, Ty::ScaledVec(..)) {
+                            self.errors.push(CompileError::general(
+                                &format!(
+                                    "`scaled_dot(a, b)` requires `ScaledVec` operands, got {}",
+                                    t.display()
+                                ),
+                                e.span,
+                            ));
+                            return Ty::Error;
+                        }
+                    }
+                    // Both blocks must be the SAME type. A dot over mismatched
+                    // element formats or block sizes has no spec meaning, and
+                    // silently widening one side would invent semantics — the
+                    // same reason `+` on blocks is refused outright.
+                    if at != bt {
+                        self.errors.push(CompileError::general(
+                            &format!(
+                                "`scaled_dot` requires matching block types: left is {}, \
+                                 right is {}",
+                                at.display(),
+                                bt.display()
+                            ),
+                            expr.span,
+                        ));
+                        return Ty::Error;
+                    }
+                    return Ty::FP32;
+                }
                 // A bare `scaled_quantize(v)` reaches the generic call path
                 // because the parser only builds `ExprKind::ScaledQuantize`
                 // when `<` follows the name. That form has no meaning: the

--- a/tests/fp_test.rs
+++ b/tests/fp_test.rs
@@ -1359,6 +1359,22 @@ fn fp8_smt_proofs() {
 /// than transcribed. All 9 of its mutants are killed, and three direct queries
 /// confirm the subtlety that has no analogue in any other format: code `0x00`
 /// is the 2^-127 f32 *subnormal*, not a zero.
+///
+/// `MX_DOT` is the phase-3 gate for `scaled_dot`: every element-pair product
+/// is exact in FP32, so **all rounding in a block dot is in the accumulation
+/// and none in the multiplies**. Each query proves that jointly with
+/// `arch_f32_mul` returning the product — normally out of reach, since general
+/// FP32 multiplier equivalence is SAT-hard, but tractable here because both
+/// operands are confined to a widened 4-to-8-bit grid. All five `unsat` in
+/// under 3 s.
+///
+/// Mutation-tested when written (2026-08-11, z3 4.15.4). Both halves bite:
+/// swapping `arch_f32_mul` for `arch_f32_add` is `sat` (the operator conjunct
+/// constrains), and replacing the widened element operands with unrestricted
+/// FP32 is `sat` *with the operator conjunct removed* (the exactness conjunct
+/// is not vacuous — it holds because of the operand grid, not by
+/// construction). Weakening mutations were considered and rejected as invalid:
+/// a spec that asserts less cannot produce `sat`.
 #[test]
 fn mx_storage_smt_proofs() {
     fn z3_available() -> bool {
@@ -1377,6 +1393,7 @@ fn mx_storage_smt_proofs() {
         for op in arch::fp_smt_proof::MX_CONV
             .iter()
             .chain(arch::fp_smt_proof::MX_SCALE_CONV.iter())
+            .chain(arch::fp_smt_proof::MX_DOT.iter())
         {
             let smt = arch::fp_smt_proof::equiv_proof(op, profile);
             let path = td.path().join(format!("{op}_{profile:?}.smt2"));
@@ -1724,6 +1741,14 @@ fn fp_assign_literal_coercion() {
 /// proven operators, no solver FP theory involved. Covers fp8+bf16 ops,
 /// compares, fma, is_nan, an exact-widen conversion, and a float reg reset.
 /// The Bad fixture locks refutation + float counterexamples. z3-gated.
+///
+/// Both invocations pass an explicit `--timeout` rather than relying on the
+/// 60 s default. The default is tuned for an interactive run on an idle
+/// machine; these queries use ~37 s of it, and the margin disappears when the
+/// test binary is running its other z3-backed tests in parallel — which is
+/// how this became a latent flake (arch#841) and how adding the `MX_DOT`
+/// miters surfaced it. Raising the cap here costs nothing when the queries
+/// converge, which is the normal case.
 #[test]
 fn fp_formal_float_props() {
     fn z3_available() -> bool {
@@ -1742,6 +1767,8 @@ fn fp_formal_float_props() {
         .arg("tests/fp_v1/FpFormalProps.arch")
         .arg("--solver")
         .arg("z3")
+        .arg("--timeout")
+        .arg("300")
         .arg("--bound")
         .arg("3")
         .output()
@@ -1766,6 +1793,8 @@ fn fp_formal_float_props() {
         .arg("tests/fp_v1/FpFormalBad.arch")
         .arg("--solver")
         .arg("z3")
+        .arg("--timeout")
+        .arg("300")
         .arg("--bound")
         .arg("2")
         .output()
@@ -2782,6 +2811,32 @@ fn fp_scaled_quant_round_trip_sim() {
         inf.get("q4f").map(|s| s.split(' ').nth(1).unwrap_or("")),
         Some("000000ff"),
         "an Inf input must also set the block scale to NaN:\n{stdout}"
+    );
+
+    // `scaled_dot` (phase 3). The `pow2` block is exactly representable in
+    // FP8E4M3, so `dot8` must be the EXACT sum of squares of the inputs:
+    // 1+4+16+0.25+64+0.0625+0+4 = 89.3125 = 0x42B2A000. Anything else means
+    // either the products or the scale application lost information, and both
+    // are supposed to be exact here.
+    assert_eq!(
+        pow2.get("dot").map(|s| s.split(' ').nth(2).unwrap_or("")),
+        Some("42b2a000"),
+        "an exactly-representable block must dot to the exact sum of squares:\n{stdout}"
+    );
+    // A dot with a NaN scale is NaN — the scale multiply poisons it, so this
+    // needs no separate rule.
+    assert!(
+        nan.get("dot")
+            .map_or(false, |l| l.split(' ').all(|w| w == "7fc00000")),
+        "every dot involving a NaN-scaled block is NaN:\n{stdout}"
+    );
+    // An all-zero block dots to +0, NOT to NaN: E8M0 has no zero, so the
+    // minimum-scale path multiplies a zero sum by the finite 2^-127.
+    assert!(
+        zeros
+            .get("dot")
+            .map_or(false, |l| l.split(' ').all(|w| w == "00000000")),
+        "an all-zero block must dot to +0:\n{stdout}"
     );
 
     // `floor_pow2` vs `ceil_pow2`: identical when the block maximum is

--- a/tests/fp_v1/ScaledQuant.arch
+++ b/tests/fp_v1/ScaledQuant.arch
@@ -31,9 +31,21 @@ module ScaledQuant
   port back6: out Vec<FP32, 8>;
   port back8: out Vec<FP32, 8>;
 
+  // `scaled_dot` (phase 3): the one operation OCP MX §6.2 defines
+  // normatively. `dot4s` dots the block against ITSELF (a sum of squares,
+  // so a sign error anywhere shows up); `dot4x` dots two DIFFERENT blocks,
+  // which is what exercises the two-scale path.
+  port dot4:  out FP32;
+  port dot6:  out FP32;
+  port dot8:  out FP32;
+  port dot4x: out FP32;
+
   wire b4: B4;
   wire b6: B6;
   wire b8: B8;
+  // A second B4 block from a different vector, so `dot4x` has two
+  // independent scales to combine rather than squaring one.
+  wire b4b: B4;
 
   comb
     b4 = scaled_quantize<B4>(v);
@@ -55,5 +67,15 @@ module ScaledQuant
     back4 = scaled_dequantize(b4);
     back6 = scaled_dequantize(b6);
     back8 = scaled_dequantize(b8);
+
+    // The `ceil_pow2` block reuses `v`'s values under a different scale, so
+    // `b4b` differs from `b4` in BOTH the scale and the element codes — the
+    // two-scale path is genuinely exercised rather than squaring one scale.
+    b4b = scaled_quantize<B4, ceil_pow2, rne>(v);
+
+    dot4  = scaled_dot(b4, b4);
+    dot6  = scaled_dot(b6, b6);
+    dot8  = scaled_dot(b8, b8);
+    dot4x = scaled_dot(b4, b4b);
   end comb
 end module ScaledQuant

--- a/tests/fp_v1/rtl_diff/tb_scaled_quant.sv
+++ b/tests/fp_v1/rtl_diff/tb_scaled_quant.sv
@@ -22,11 +22,13 @@ module tb;
   logic [71:0]      q8;
   logic [23:0]      q4s;
   logic [7:0][31:0] back4, back6, back8;
+  logic [31:0]      dot4, dot6, dot8, dot4x;
 
   ScaledQuant dut (
     .v(v), .v4(v4),
     .q4_floor(q4_floor), .q4_ceil(q4_ceil), .q6(q6), .q8(q8), .q4s(q4s),
-    .back4(back4), .back6(back6), .back8(back8)
+    .back4(back4), .back6(back6), .back8(back8),
+    .dot4(dot4), .dot6(dot6), .dot8(dot8), .dot4x(dot4x)
   );
 
   string       names [NC];
@@ -110,6 +112,7 @@ module tb;
       show_vec("b4 ", back4, 8);
       show_vec("b6 ", back6, 8);
       show_vec("b8 ", back8, 8);
+      $display("dot %h %h %h %h", dot4, dot6, dot8, dot4x);
     end
     $finish;
   end

--- a/tests/fp_v1/tb_scaled_quant.cpp
+++ b/tests/fp_v1/tb_scaled_quant.cpp
@@ -121,6 +121,9 @@ int main() {
     print_vec("b4 ", dut.back4, 8);
     print_vec("b6 ", dut.back6, 8);
     print_vec("b8 ", dut.back8, 8);
+    // scaled_dot results are scalar FP32 — print the raw bits, same as any
+    // other word, so the SV twin has nothing format-specific to reproduce.
+    printf("dot %08x %08x %08x %08x\n", dut.dot4, dut.dot6, dut.dot8, dut.dot4x);
   }
   return 0;
 }


### PR DESCRIPTION
Phase 3 of the MX/NVFP4 design, completing the operation set: 2a (#872) the type, 2b (#891) the conversions, and this the one operation OCP MX §6.2 defines normatively.

```arch
d = scaled_dot(a, b)      // two blocks of the SAME type -> FP32
```

No type annotation needed — both operand types are fully known and the result is always FP32. Mismatched element formats or block sizes are a compile error: a dot across them has no spec meaning, and widening one side would invent semantics.

Closes #894.

## All the rounding is in the summation

`scaled_dot` computes the spec's factored form `X^A · X^B · Σ(P^A_i × P^B_i)`, and **every element-pair product is exact in FP32**. Not an approximation argument: the widest element significand is E4M3's 4 bits, needing at most 8 of FP32's 24, and the widest exponent span is E5M2's `2^-32 … 2^31.6`, comfortably inside FP32's normals.

`fp_smt_proof::MX_DOT` machine-checks this exhaustively for all five element formats — **five `unsat`, each under 3 s**. Exactness is expressed without mentioning reals: a result is exact iff rounding toward `-∞` and toward `+∞` agree. (`RTZ`/`RTP` would *not* work — both round a negative value toward `+∞`, so they agree vacuously on every negative product.) Each query proves that jointly with `arch_f32_mul` returning the product — normally out of reach, since general FP32 multiplier equivalence is SAT-hard, but tractable here because both operands are confined to a widened 4-to-8-bit grid.

**Mutation-tested**, since `unsat` alone is not evidence:

| Mutation | Result | What it shows |
|---|---|---|
| `arch_f32_mul` → `arch_f32_add` | `sat` | the operator conjunct constrains |
| widened operands → unrestricted FP32, operator conjunct removed | `sat` | the exactness conjunct is not vacuous — it holds because of the operand grid |

Weakening mutations were considered and rejected as invalid: a spec that asserts less cannot produce `sat`.

## Two things that had to be defined, not left open

**Accumulation order.** FP32 addition is not associative, so an unstated order is an unstated result — and the exactness theorem above is exactly what makes the order the *only* implementation freedom left. `dot_schedule` defines it once and both backends render that same schedule: balanced pairwise, with a lone trailing value **carried rather than padded** (adding `0.0` is not a no-op — it turns `-0.0` into `+0.0`). Pairwise over serial because it is what a dot-product datapath synthesizes to anyway (`⌈log₂ N⌉` deep, not `N`) and its error grows as `O(log N)` rather than `O(N)`.

**Scale application order.** The two scales are applied one at a time, as `(Σ ⊗ X^A) ⊗ X^B`, not as a pre-formed `X^A · X^B`. Each is a power of two so each multiply is exact absent overflow — but the two E8M0 scales span `2^-127 … 2^127`, so their *product* spans `2^-254 … 2^254` and can overflow to infinity or flush to zero even when the final result is perfectly representable. Applying them separately has a strictly wider exact domain.

The summation tree is unrolled at generation time rather than emitted as a loop, so both backends print the identical sequence of named temporaries from the identical schedule and a reviewer can diff them line for line.

## Verification

- The cross-backend fixture now carries four dots (three self-dots plus one across two independently-scaled blocks), so `fp_scaled_quant_sv_matches_sim` covers them: **90 transcript lines, Verilator-on-emitted-SV vs native sim, byte-identical**.
- Value assertions pin an exactly-representable block dotting to the exact sum of squares (89.3125), a NaN-scaled block dotting to NaN, and an all-zero block dotting to `+0` — *not* NaN, since E8M0 has no zero.
- `cargo test` full suite green; `cargo fmt --check` clean.

## Two incidental fixes

**Folded the duplicated block-shape resolver.** Phase 2b left one copy in the SV emitter and one in the sim emitter; they are now one `fp_block::shape_of_type`. Two copies of "how wide is this block" is precisely how a block ends up sized one way in the SV and another in the sim.

**`fp_formal_float_props` now passes an explicit `--timeout`.** It relied on `arch formal`'s 60 s default while using ~37 s of it, so the margin vanished under parallel load — the latent flake in #841. Adding ten more z3 invocations to the same test binary surfaced it, so this PR fixes it rather than shipping a flakier CI.

Spec §3.11.2 documents the surface, the exactness theorem, and both order decisions with their reasons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)