### PR TITLE
fix(codegen): size arithmetic slice-hoist temp with ARCH's widened width (closes #896)

### DIFF
--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -6677,6 +6677,41 @@ impl<'a> Codegen<'a> {
                     format!("({lw} > {rw} ? {lw} : {rw})")
                 }
             }
+            // Widening arithmetic. The ARCH type system widens `a + b` / `a - b`
+            // to `max(w_a, w_b) + 1` and `a * b` to `w_a + w_b` (typecheck.rs,
+            // `binop_result_ty`), matching IEEE 1800 §11.6 plus the carry/product
+            // bit. SV's *self-determined* width — what `$bits(a + b)` reports —
+            // does NOT include those bits, so the `_ => $bits(...)` fallback
+            // under-sizes a hoist temp. A slice reaching the widened high bit
+            // then drops it: iverilog reads X, Verilator flags the select as
+            // out-of-range — a silent build-vs-sim divergence for code that
+            // `arch check` and `arch sim` both accept and compute correctly.
+            // Only reachable since #813 P1 (#875) let arithmetic bases be
+            // sliced at all. Non-widening ops (Div/Mod → lhs, bitwise/shift →
+            // max/lhs) already agree with `$bits`, so they keep the fallback.
+            ExprKind::Binary(BinOp::Add | BinOp::Sub, lhs, rhs) => {
+                let lw = self.infer_sv_width_str_in(lhs, emit, signal_width);
+                let rw = self.infer_sv_width_str_in(rhs, emit, signal_width);
+                match (lw.parse::<u64>().ok(), rw.parse::<u64>().ok()) {
+                    (Some(l), Some(r)) => (l.max(r) + 1).to_string(),
+                    _ => {
+                        let m = if lw == rw {
+                            lw
+                        } else {
+                            format!("({lw} > {rw} ? {lw} : {rw})")
+                        };
+                        format!("{} + 1", Self::paren_width(&m))
+                    }
+                }
+            }
+            ExprKind::Binary(BinOp::Mul, lhs, rhs) => {
+                let lw = self.infer_sv_width_str_in(lhs, emit, signal_width);
+                let rw = self.infer_sv_width_str_in(rhs, emit, signal_width);
+                match (lw.parse::<u64>().ok(), rw.parse::<u64>().ok()) {
+                    (Some(l), Some(r)) => (l + r).to_string(),
+                    _ => format!("{} + {}", Self::paren_width(&lw), Self::paren_width(&rw)),
+                }
+            }
             // Concat/Repeat width for the arch#807 slice-base hoist temp:
             // sum of part widths / count*value-width. Recurse into parts
             // rather than falling to `$bits({...})` on the whole

--- a/tests/icarus_portability/WidenArithSliceHoist.arch
+++ b/tests/icarus_portability/WidenArithSliceHoist.arch
@@ -1,0 +1,25 @@
+// Regression fixture: slicing into the WIDENED high bits of an arithmetic
+// base. The ARCH type system widens `a + b` to `UInt<9>` and `a * b` to
+// `UInt<16>` (typecheck.rs `binop_result_ty`), so `(a + b)[8]` and
+// `(a * b)[15:8]` are legal — `arch check` and `arch sim` both compute them
+// correctly. Codegen hoists the arithmetic base to a temp (#813 P1/#875);
+// before the width fix the temp was sized with `$bits(a + b)`, i.e. SV's
+// self-determined width (8 bits, no carry), so the carry/product-high bits
+// were silently dropped: iverilog read X, Verilator flagged an out-of-range
+// select. This fixture drives a slice/index that actually reaches those
+// bits; the existing arch#650 IdxArithHoist fixture never does.
+// See tests/integration_test.rs
+// `test_widening_arith_slice_hoist_behavioral_equivalence_verilator_and_iverilog`.
+module WidenArithSliceHoist
+  port a: in UInt<8>;
+  port b: in UInt<8>;
+  port add_carry: out Bool;      // bit 8 of (a + b) — the carry
+  port add_ps:    out UInt<4>;   // (a + b)[5 +: 4], reaches bit 8
+  port mul_hi:    out UInt<8>;   // (a * b)[15:8] — the product high byte
+  port mul_top:   out Bool;      // bit 15 of (a * b)
+
+  let add_carry = (a + b)[8];
+  let add_ps    = (a + b)[5 +: 4];
+  let mul_hi    = (a * b)[15:8];
+  let mul_top   = (a * b)[15];
+end module WidenArithSliceHoist

--- a/tests/icarus_portability/tb_widen_arith_slice_hoist.sv
+++ b/tests/icarus_portability/tb_widen_arith_slice_hoist.sv
@@ -1,0 +1,38 @@
+// Regression: slices into the widened high bits of `a + b` / `a * b`
+// behavioral check under Icarus. Pre-fix the hoist temp was 8 bits and
+// every high-bit read returned X.
+module tb;
+  logic [7:0] a, b;
+  logic add_carry, mul_top;
+  logic [3:0] add_ps;
+  logic [7:0] mul_hi;
+
+  WidenArithSliceHoist dut(.a(a), .b(b), .add_carry(add_carry),
+                           .add_ps(add_ps), .mul_hi(mul_hi), .mul_top(mul_top));
+
+  task check(input [7:0] va, vb, input exp_carry, input [3:0] exp_ps,
+             input [7:0] exp_hi, input exp_top);
+    begin
+      a = va; b = vb; #1;
+      if (add_carry !== exp_carry || add_ps !== exp_ps ||
+          mul_hi !== exp_hi || mul_top !== exp_top) begin
+        $display("FAIL a=%0d b=%0d: carry=%b(exp %b) ps=%0d(exp %0d) hi=%0d(exp %0d) top=%b(exp %b)",
+                 va, vb, add_carry, exp_carry, add_ps, exp_ps, mul_hi, exp_hi, mul_top, exp_top);
+        $finish(1);
+      end
+    end
+  endtask
+
+  initial begin
+    // a+b=300=9'b1_0010_1100 (carry 1), a*b=20000=16'h4E20 (hi 0x4E, top 0)
+    check(8'd200, 8'd100, 1'b1, 4'd9,  8'd78,  1'b0);
+    // a+b=510=9'b1_1111_1110 (carry 1), a*b=65025=16'hFE01 (hi 0xFE, top 1)
+    check(8'd255, 8'd255, 1'b1, 4'd15, 8'd254, 1'b1);
+    // a+b=200=9'b0_1100_1000 (carry 0, [8:5]=0110=6), a*b=10000=16'h2710 (hi 0x27)
+    check(8'd100, 8'd100, 1'b0, 4'd6,  8'd39,  1'b0);
+    // all zero
+    check(8'd0,   8'd0,   1'b0, 4'd0,  8'd0,   1'b0);
+    $display("PASS");
+    $finish(0);
+  end
+endmodule

--- a/tests/icarus_portability/tb_widen_arith_slice_hoist_verilator.cpp
+++ b/tests/icarus_portability/tb_widen_arith_slice_hoist_verilator.cpp
@@ -1,0 +1,34 @@
+// Regression: slices into the widened high bits of `a + b` / `a * b`
+// behavioral check under Verilator.
+#include "VWidenArithSliceHoist.h"
+#include "verilated.h"
+#include <cstdio>
+
+int main(int argc, char** argv) {
+    Verilated::commandArgs(argc, argv);
+    VWidenArithSliceHoist* dut = new VWidenArithSliceHoist;
+    int fails = 0;
+    auto check = [&](int a, int b, int carry, int ps, int hi, int top) {
+        dut->a = a;
+        dut->b = b;
+        dut->eval();
+        if (dut->add_carry != carry || dut->add_ps != ps ||
+            dut->mul_hi != hi || dut->mul_top != top) {
+            printf("FAIL a=%d b=%d: carry=%d(exp %d) ps=%d(exp %d) hi=%d(exp %d) top=%d(exp %d)\n",
+                   a, b, dut->add_carry, carry, dut->add_ps, ps,
+                   dut->mul_hi, hi, dut->mul_top, top);
+            fails++;
+        }
+    };
+    check(200, 100, 1, 9,  78,  0);
+    check(255, 255, 1, 15, 254, 1);
+    check(100, 100, 0, 6,  39,  0);
+    check(0,   0,   0, 0,  0,   0);
+    delete dut;
+    if (fails) {
+        printf("FAILURES: %d\n", fails);
+        return 1;
+    }
+    printf("PASS\n");
+    return 0;
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -34080,6 +34080,135 @@ fn test_index_arithmetic_hoist_behavioral_equivalence_verilator_and_iverilog() {
     let _ = cases;
 }
 
+/// Regression for the slice-base hoist temp width: a bit-slice/index reaching
+/// the WIDENED high bits of an arithmetic base (`(a + b)[8]`, `(a * b)[15:8]`).
+/// The ARCH type system widens `a + b` to `UInt<9>` and `a * b` to `UInt<16>`,
+/// so those selects are legal and `arch sim` computes them correctly. Codegen
+/// hoists the arithmetic base to a temp (#813 P1); the temp had been sized with
+/// `$bits(a + b)` — SV's self-determined width (8 bits, no carry) — silently
+/// dropping the widened high bit: iverilog read X, Verilator flagged the select
+/// as out-of-range, a build-vs-sim divergence. The fix sizes the temp with
+/// ARCH's widened width (`max(w) + 1` for add/sub, `w_l + w_r` for mul). Only a
+/// real simulation run distinguishes right from wrong, since the pre-fix SV
+/// still *compiled* under iverilog (X-valued). Skips gracefully if neither
+/// simulator is installed, matching this file's convention.
+#[test]
+fn test_widening_arith_slice_hoist_behavioral_equivalence_verilator_and_iverilog() {
+    let has_verilator = std::process::Command::new("verilator")
+        .arg("--version")
+        .output()
+        .is_ok();
+    let has_iverilog = std::process::Command::new("iverilog")
+        .arg("-V")
+        .output()
+        .is_ok();
+    if !has_verilator && !has_iverilog {
+        eprintln!(
+            "skipping widening-arith slice-hoist dual-sim behavioral check: \
+             neither verilator nor iverilog found"
+        );
+        return;
+    }
+
+    let td = tempfile::tempdir().expect("tempdir");
+    let sv_out = td.path().join("WidenArithSliceHoist.sv");
+    let arch_bin = env!("CARGO_BIN_EXE_arch");
+
+    let build = std::process::Command::new(arch_bin)
+        .arg("build")
+        .arg("tests/icarus_portability/WidenArithSliceHoist.arch")
+        .arg("-o")
+        .arg(&sv_out)
+        .output()
+        .expect("build WidenArithSliceHoist SV");
+    assert!(
+        build.status.success(),
+        "arch build should pass\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&build.stdout),
+        String::from_utf8_lossy(&build.stderr)
+    );
+
+    // The hoist temp for `a + b` must be 9 bits and for `a * b` 16 bits —
+    // never a `[($bits(...))-1:0]` declaration (SV self-determined width,
+    // 8 bits, the pre-fix bug). Match the parenthesized declaration shape so
+    // prose in the fixture that mentions the builtin can't false-positive.
+    let sv = std::fs::read_to_string(&sv_out).expect("read SV");
+    assert!(
+        !sv.contains("[($bits(a + b))-1:0]") && !sv.contains("[($bits(a * b))-1:0]"),
+        "arithmetic hoist temp must not be sized by SV self-determined \
+         `$bits(...)` (drops the widened high bit):\n{sv}"
+    );
+    assert!(
+        sv.contains("[9-1:0] arch_idx_base") && sv.contains("[16-1:0] arch_idx_base"),
+        "expected 9-bit (add) and 16-bit (mul) hoist temps:\n{sv}"
+    );
+
+    if has_iverilog {
+        let vvp_out = td.path().join("widen_arith.vvp");
+        let compile = std::process::Command::new("iverilog")
+            .arg("-g2012")
+            .arg("-s")
+            .arg("tb")
+            .arg("-o")
+            .arg(&vvp_out)
+            .arg(&sv_out)
+            .arg("tests/icarus_portability/tb_widen_arith_slice_hoist.sv")
+            .output()
+            .expect("iverilog compile WidenArithSliceHoist");
+        assert!(
+            compile.status.success(),
+            "iverilog compile should pass\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&compile.stdout),
+            String::from_utf8_lossy(&compile.stderr)
+        );
+        let run = std::process::Command::new("vvp")
+            .arg(&vvp_out)
+            .output()
+            .expect("run iverilog WidenArithSliceHoist");
+        let stdout = String::from_utf8_lossy(&run.stdout);
+        assert!(
+            run.status.success() && stdout.contains("PASS"),
+            "iverilog sim should confirm widened-slice values\nstdout:\n{stdout}\nstderr:\n{}",
+            String::from_utf8_lossy(&run.stderr)
+        );
+    }
+
+    if has_verilator {
+        let obj_dir = td.path().join("obj_dir_widen");
+        let verilate = std::process::Command::new("verilator")
+            .arg("--cc")
+            .arg("--exe")
+            .arg("--build")
+            .arg("-Wno-fatal")
+            .arg("-Wno-DECLFILENAME")
+            .arg("-Wno-UNUSEDSIGNAL")
+            .arg("--top-module")
+            .arg("WidenArithSliceHoist")
+            .arg("-Mdir")
+            .arg(&obj_dir)
+            .arg(&sv_out)
+            .arg("tests/icarus_portability/tb_widen_arith_slice_hoist_verilator.cpp")
+            .output()
+            .expect("verilate WidenArithSliceHoist");
+        assert!(
+            verilate.status.success(),
+            "Verilator build should pass\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&verilate.stdout),
+            String::from_utf8_lossy(&verilate.stderr)
+        );
+        let exe = obj_dir.join("VWidenArithSliceHoist");
+        let run = std::process::Command::new(&exe)
+            .output()
+            .expect("run Verilator WidenArithSliceHoist");
+        let stdout = String::from_utf8_lossy(&run.stdout);
+        assert!(
+            run.status.success() && stdout.contains("PASS"),
+            "Verilator sim should confirm widened-slice values\nstdout:\n{stdout}\nstderr:\n{}",
+            String::from_utf8_lossy(&run.stderr)
+        );
+    }
+}
+
 /// Follow-on discovery while implementing arch#650: `.trunc()`/`.zext()`/
 /// `.resize()` (SV size-cast) and `.sext()`/plain `{a, b}`/`{N{a}}` (SV
 /// concat/replication) are *also* rejected by Icarus when directly
@@ -35631,8 +35760,11 @@ end module LoopVarHoist861
     let for_open = sv
         .find("for (int i = 0; i <= 3; i++) begin")
         .expect("loop opener");
+    // Width is ARCH's widened `UInt<8> + UInt<8>` → `UInt<9>` (9 bits), not
+    // SV's self-determined `$bits(a + v[i])` (8 bits) — see the slice-hoist
+    // width fix. Bit 3 is in range either way, so this is shape-only here.
     let decl = sv
-        .find("logic [($bits(a + v[i]))-1:0] arch_idx_base_0;")
+        .find("logic [9-1:0] arch_idx_base_0;")
         .unwrap_or_else(|| panic!("hoist temp declaration missing:\n{sv}"));
     let first_stmt = sv.find("arch_idx_base_0 = a + v[i];").expect("assignment");
     assert!(


### PR DESCRIPTION
Closes #896.

## Summary

A bit-slice or index reaching the **widened high bits** of an arithmetic base — `(a + b)[8]` (carry), `(a * b)[15:8]` (product high byte) — silently miscompiled in `arch build`.

The ARCH type system widens `a + b` (`UInt<8>+UInt<8>`) to `UInt<9>` and `a * b` to `UInt<16>`, so those selects are legal: **`arch check` accepts them and `arch sim` computes them correctly.** Only the emitted SV was wrong.

| | `(a+b)[8:1]`, a=200 b=100 (sum 300) |
|---|---|
| arch sim | `hi=150 carry=1` ✅ |
| iverilog (emitted SV) | `hi=X carry=X` ❌ |
| Verilator (emitted SV) | rejects — out-of-range select ❌ |

## Root cause

Codegen hoists the arithmetic base to a temp (#813 P1 / #875) sized with `$bits(a + b)`:
```systemverilog
logic [($bits(a + b))-1:0] arch_idx_base_0;   // $bits(a+b) == 8 in SV; the carry is gone
assign arch_idx_base_0 = a + b;
assign carry = arch_idx_base_0[8:8];          // out of range
```
`$bits(a + b)` is SV's **self-determined** width (8 bits, IEEE 1800 §11.6), which excludes ARCH's carry/product bits. In `infer_sv_width_str_in` the wrapping ops (`AddWrap`/`SubWrap`/`MulWrap`, correctly `max(w)`) had arms but the non-wrapping `Add`/`Sub`/`Mul` fell through to the `$bits(...)` fallback.

Only reachable since #875 (#813 P1) let arithmetic bases be sliced; before that it was an `arch check` error.

## Fix

Add `Add`/`Sub`/`Mul` arms mirroring the type checker (`binop_result_ty`, typecheck.rs):
- `Add`/`Sub` → `max(w_l, w_r) + 1`
- `Mul` → `w_l + w_r`

with numeric folding when both operand widths are literals (`[9-1:0]`, `[16-1:0]`) and a symbolic form otherwise. `Div`/`Mod` (→ lhs) and bitwise/shift (→ max/lhs) already agree with `$bits` and keep the fallback. **Internal codegen only — no user-facing syntax or semantics change.**

## Verification

- New `tests/icarus_portability/WidenArithSliceHoist.arch` + dual-sim testbenches, wired into `tests/integration_test.rs` as `test_widening_arith_slice_hoist_behavioral_equivalence_verilator_and_iverilog`. Confirmed **iverilog == Verilator == arch sim** across four vectors (carry-set, carry-clear, product-high, all-zero).
- Fast gate: `cargo build --release`, `cargo fmt --check` clean, full `cargo test --test integration_test` — **817 passed, 0 failed**.
- Updated the arch#861 loop-var shape assertion (`$bits(a + v[i])` → `[9-1:0]`); bit 3 is in range either way, so shape-only there.

Found during the 2026-08-11 daily review sweep. Full `cargo test` running as post-open long verification.