### PR TITLE
fix(e203): make the pc_rtvec reset vector live in e203_ifu_ifetch

### DIFF
--- a/tests/e203/e203_core_top_tb.cpp
+++ b/tests/e203/e203_core_top_tb.cpp
@@ -34,7 +34,7 @@
 //            tests/e203/e203_lsu.arch tests/e203/e203_biu.arch \
 //            --tb tests/e203/e203_core_top_tb.cpp
 //
-// ── KNOWN ISSUE 1 (arch#800): pc_rtvec is dead inside e203_ifu_ifetch, so the
+// ── arch#800 (FIXED): pc_rtvec is honoured inside e203_ifu_ifetch, so the
 // core boots from 0x0 rather than the reset vector. Test 2 pins that; every
 // address expectation below is written against the 0x0 boot address.
 //
@@ -107,7 +107,7 @@ static void reset(const Cfg& c) {
     dut->rst_n = 0;
     dut->clk = 0;
     dut->test_mode = 0;
-    dut->pc_rtvec = 0x80000000;
+    dut->pc_rtvec = 0x00000000;  // ITCM-region reset vector (arch#800: now honoured)
     dut->core_mhartid = 0;
     dut->dbg_irq_r = 0;
     dut->lcl_irq_r = 0;
@@ -179,6 +179,11 @@ static void reset(const Cfg& c) {
     for (int i = 0; i < 3; i++) tick();
     dut->rst_n = 1;
     settle();
+    // The reset vector arms one cycle after release (arch#800), so the boot
+    // fetch is offered from here on. Tick once so tests observe a running
+    // fetch unit rather than the arming cycle.
+    tick();
+    settle();
 }
 
 // No peripheral bus should ever see an instruction fetch.
@@ -244,13 +249,16 @@ int main() {
     check_peripherals_quiet("reset");
     check_lsu_quiet("reset");
 
-    // ── Test 2: pc_rtvec is dead (KNOWN ISSUE 1 / arch#800) ──────────
-    printf("Test 2: pc_rtvec reset vector (KNOWN ISSUE 1)\n");
-    CHECK(dut->inspect_pc == 0x0,
-          "KNOWN ISSUE arch#800: the core boots from 0x0, not pc_rtvec 0x80000000; got 0x%08x",
+    // ── Test 2: the pc_rtvec reset vector is honoured (arch#800) ─────
+    printf("Test 2: pc_rtvec reset vector\n");
+    // Driven to 0x0 by reset() so the boot fetch stays in the ITCM region.
+    // Before arch#800 `pc_rtvec` was ignored entirely and the core booted from
+    // pc_r + incr regardless; the e203_ifu_ifetch tb covers a non-zero vector
+    // directly, which is where that would show most plainly.
+    CHECK(dut->inspect_pc == 0x0, "the core should boot at the reset vector 0x0, got 0x%08x",
           dut->inspect_pc);
-    CHECK(dut->ifu2itcm_icb_cmd_addr == 0x0002,
-          "the boot fetch address should be 0x0002, not derived from pc_rtvec; got 0x%04x",
+    CHECK(dut->ifu2itcm_icb_cmd_addr == 0x0000,
+          "the boot fetch should target the reset vector 0x0000, got 0x%04x",
           dut->ifu2itcm_icb_cmd_addr);
 
     // ── Test 3: Boot fetch reaches the ITCM ICB port ─────────────────
@@ -277,7 +285,7 @@ int main() {
         tick(); settle();
         CHECK(dut->mem_icb_cmd_valid == 1, "the fetch should emerge on the MEM ICB port, got %d",
               dut->mem_icb_cmd_valid);
-        CHECK(dut->mem_icb_cmd_addr == 0x00000002, "mem_icb_cmd_addr should be the fetch pc 0x2, got 0x%08x",
+        CHECK(dut->mem_icb_cmd_addr == 0x00000000, "mem_icb_cmd_addr should be the fetch pc 0x0, got 0x%08x",
               dut->mem_icb_cmd_addr);
         CHECK(dut->mem_icb_cmd_read == 1, "an instruction fetch must be a read, got mem_icb_cmd_read %d",
               dut->mem_icb_cmd_read);
@@ -319,14 +327,14 @@ int main() {
     for (int i = 0; i < 3; i++) {
         tick(); settle();
         CHECK(dut->ifu2itcm_icb_cmd_valid == 1, "cmd_valid must stay asserted under backpressure (cycle %d)", i);
-        CHECK(dut->ifu2itcm_icb_cmd_addr == 0x0002, "cmd_addr must stay stable under backpressure (cycle %d)", i);
+        CHECK(dut->ifu2itcm_icb_cmd_addr == 0x0000, "cmd_addr must stay stable under backpressure (cycle %d)", i);
         CHECK(dut->inspect_pc == 0x0, "the pc must not advance while stalled (cycle %d), got 0x%08x",
               i, dut->inspect_pc);
     }
     dut->ifu2itcm_icb_cmd_ready = 1;
     settle();
     tick(); settle();
-    CHECK(dut->inspect_pc == 0x2, "the pc should advance once the command handshakes, got 0x%08x",
+    CHECK(dut->inspect_pc == 0x0, "the pc should advance once the command handshakes, got 0x%08x",
           dut->inspect_pc);
 
     // ── Test 8: Fetch pipeline lockup (KNOWN ISSUE 2) ────────────────
@@ -352,7 +360,7 @@ int main() {
         CHECK(dut->ifu2itcm_icb_cmd_valid == 0,
               "KNOWN ISSUE 2: fetching never resumes (cycle %d), got cmd_valid %d",
               i, dut->ifu2itcm_icb_cmd_valid);
-        CHECK(dut->inspect_pc == 0x2, "the pc stays frozen at 0x2 while locked (cycle %d), got 0x%08x",
+        CHECK(dut->inspect_pc == 0x0, "the pc stays frozen at the reset vector 0x0 while locked (cycle %d), got 0x%08x",
               i, dut->inspect_pc);
         check_lsu_quiet("lockup");
         check_peripherals_quiet("lockup");

--- a/tests/e203/e203_ifu_ifetch.arch
+++ b/tests/e203/e203_ifu_ifetch.arch
@@ -72,8 +72,11 @@ module e203_ifu_ifetch
   let ifu_ir_o_hsked: Bool = ifu_o_valid & ifu_o_ready;
 
   // ── Reset flag (synced rst_n) ────────────────────────────────────────
-  // Reference: sirv_gnrl_dffrs(1'b0, ...) — resets to 1, captures 0
-  reg reset_flag_r: Bool reset rst_n => false;
+  // Reference: sirv_gnrl_dffrs(1'b0, ...) — resets to 1, captures 0.
+  // Must reset to true: it is the one-shot that arms `reset_req_r`, which in
+  // turn selects `pc_rtvec` as the first fetch address and holds fetch off
+  // while reset is asserted. Resetting it to false left both dead (arch#800).
+  reg reset_flag_r: Bool reset rst_n => true;
   seq on clk rising
     reset_flag_r <= false;
   end seq

--- a/tests/e203/e203_ifu_ifetch_tb.cpp
+++ b/tests/e203/e203_ifu_ifetch_tb.cpp
@@ -15,16 +15,14 @@
 //   arch sim tests/e203/e203_ifu_ifetch.arch tests/e203/e203_ifu_minidec.arch \
 //            tests/e203/e203_ifu_litebpu.arch --tb tests/e203/e203_ifu_ifetch_tb.cpp
 //
-// KNOWN ISSUE — the pc_rtvec reset vector is currently dead in this fixture, so
-// no check below asserts on it. `reset_flag_r` is declared `reset rst_n =>
-// false` and assigned `<= false`, so it is false in every cycle; the reference
-// design uses sirv_gnrl_dffrs (a DFF that *sets* on reset), and the ARCH
-// comment on the register says as much ("resets to 1, captures 0"). Because
-// `reset_req_set = (~reset_req_r) & reset_flag_r` can therefore never fire,
-// `ifu_reset_req` is never true and the `ifu_reset_req ? pc_rtvec : pc_r` arm
-// of the PC mux is unreachable. The core boots from 0x0 instead of pc_rtvec.
-// Fixing that is a design change to the fixture, not test hygiene, so it is
-// reported separately rather than baked into this tb as expected behavior.
+// BOOT BEHAVIOUR — `pc_rtvec` is the reset vector. `reset_flag_r` resets to
+// true (mirroring the reference `sirv_gnrl_dffrs`, a DFF that *sets* on
+// reset), which arms `reset_req_r`; that both holds fetch off while reset is
+// asserted and selects `pc_rtvec` for the first fetch. Arming costs one cycle
+// after release, so `reset()` below ticks once and the first offered fetch is
+// the reset vector, not `pc_r + incr`. Test 2 covers this directly.
+// Before arch#800 the register reset to false, so both effects were dead and
+// the core booted from 0x0 whatever `pc_rtvec` was driven to.
 
 #include "Ve203_ifu_ifetch.h"
 #include <cstdio>
@@ -41,6 +39,11 @@ static int fail_count = 0;
 
 static Ve203_ifu_ifetch* dut;
 
+// Reset vector used by `reset()`. Zero keeps the sequential-fetch tests below
+// on the same PCs they used before the reset vector worked; Test 2 drives a
+// non-zero vector explicitly to prove it is honoured.
+static const uint32_t BOOT_PC = 0x00000000u;
+
 // RV32 `add x3, x1, x2` — rs1=1, rs2=2, bits[1:0]=11 so minidec sees rv32.
 static const uint32_t RV32_ADD_X3_X1_X2 = 0x002081B3u;
 // RVC `c.li x10, 0` — bits[1:0]=01, so minidec sees a 16-bit instruction.
@@ -53,7 +56,7 @@ static void tick() {
 
 static void reset() {
     dut->rst_n = 0;
-    dut->pc_rtvec = 0x80000000;
+    dut->pc_rtvec = BOOT_PC;
     dut->ifu_req_ready = 1;
     dut->ifu_rsp_valid = 0;
     dut->ifu_rsp_err = 0;
@@ -77,6 +80,11 @@ static void reset() {
     dut->dec2ifu_remu = 0;
     for (int i = 0; i < 3; i++) tick();
     dut->rst_n = 1;
+    dut->eval();
+    // Arming `reset_req_r` costs one cycle after release; the fetch offered
+    // after it is the reset vector, so the first request every test sees is
+    // BOOT_PC rather than pc_r + incr.
+    tick();
     dut->eval();
 }
 
@@ -111,19 +119,25 @@ int main() {
     // A fetch is offered immediately: nothing is outstanding and halt is low.
     CHECK(dut->ifu_req_valid == 1, "req_valid should be 1 after reset, got %d", dut->ifu_req_valid);
 
-    // ── Test 2: Sequential RV32 fetch advances PC by 4 ───────────────
-    printf("Test 2: Sequential RV32 fetch\n");
+    // ── Test 2: Boot fetch targets the reset vector, then PC += 4 ────
+    printf("Test 2: Boot fetch at the reset vector, then sequential RV32\n");
     reset();
     dut->ifu_rsp_instr = RV32_ADD_X3_X1_X2;
     dut->eval();
-    CHECK(dut->ifu_req_seq == 1, "req_seq should be 1 for a sequential fetch, got %d", dut->ifu_req_seq);
+    // The first fetch after reset is the reset vector, so it is *not*
+    // sequential — `ifu_req_seq` excludes it via `~ifu_reset_req`. Before
+    // arch#800 this fetch did not exist and the unit started at pc_r + incr.
+    CHECK(dut->ifu_req_seq == 0, "the boot fetch should be non-sequential, got req_seq %d", dut->ifu_req_seq);
     CHECK(dut->ifu_req_seq_rv32 == 1, "req_seq_rv32 should be 1 for an RV32 instr, got %d", dut->ifu_req_seq_rv32);
-    CHECK(dut->ifu_req_pc == 0x4, "first req_pc should be 0x4 (pc 0 + 4), got 0x%08x", dut->ifu_req_pc);
-    CHECK(dut->ifu_req_last_pc == 0x0, "req_last_pc should be the current pc 0x0, got 0x%08x", dut->ifu_req_last_pc);
-    tick();                       // request handshake
+    CHECK(dut->ifu_req_pc == BOOT_PC, "boot req_pc should be the reset vector 0x%08x, got 0x%08x",
+          BOOT_PC, dut->ifu_req_pc);
+    tick();                       // boot request handshake
     dut->eval();
-    CHECK(dut->inspect_pc == 0x4, "pc should advance to 0x4, got 0x%08x", dut->inspect_pc);
-    CHECK(dut->ifu_req_pc == 0x8, "next req_pc should be 0x8, got 0x%08x", dut->ifu_req_pc);
+    CHECK(dut->inspect_pc == BOOT_PC, "pc should land on the reset vector 0x%08x, got 0x%08x",
+          BOOT_PC, dut->inspect_pc);
+    CHECK(dut->ifu_req_seq == 1, "the fetch after boot should be sequential, got req_seq %d", dut->ifu_req_seq);
+    CHECK(dut->ifu_req_pc == BOOT_PC + 4, "next req_pc should be 0x%08x (RV32 +4), got 0x%08x",
+          BOOT_PC + 4, dut->ifu_req_pc);
 
     // ── Test 3: Single outstanding request ───────────────────────────
     // After a request handshake the unit must not offer another fetch until
@@ -133,7 +147,7 @@ int main() {
     for (int i = 0; i < 3; i++) {
         tick(); dut->eval();
         CHECK(dut->ifu_req_valid == 0, "req_valid must stay 0 with no response (cycle %d)", i);
-        CHECK(dut->inspect_pc == 0x4, "pc must not advance while stalled, got 0x%08x", dut->inspect_pc);
+        CHECK(dut->inspect_pc == BOOT_PC, "pc must not advance while stalled, got 0x%08x", dut->inspect_pc);
     }
 
     // ── Test 4: Response delivers the instruction to decode ──────────
@@ -147,7 +161,7 @@ int main() {
     CHECK(dut->ifu_o_valid == 1, "o_valid should be 1 after a response, got %d", dut->ifu_o_valid);
     CHECK(dut->ifu_o_ir == RV32_ADD_X3_X1_X2, "o_ir should be 0x%08x, got 0x%08x",
           RV32_ADD_X3_X1_X2, dut->ifu_o_ir);
-    CHECK(dut->ifu_o_pc == 0x4, "o_pc should be the fetched pc 0x4, got 0x%08x", dut->ifu_o_pc);
+    CHECK(dut->ifu_o_pc == BOOT_PC, "o_pc should be the fetched pc 0x%08x, got 0x%08x", BOOT_PC, dut->ifu_o_pc);
     CHECK(dut->ifu_o_pc_vld == 1, "o_pc_vld should be 1, got %d", dut->ifu_o_pc_vld);
     CHECK(dut->ifu_o_rs1idx == 1, "o_rs1idx should be 1 (add x3,x1,x2), got %d", dut->ifu_o_rs1idx);
     CHECK(dut->ifu_o_rs2idx == 2, "o_rs2idx should be 2 (add x3,x1,x2), got %d", dut->ifu_o_rs2idx);
@@ -177,9 +191,15 @@ int main() {
     dut->ifu_rsp_instr = RVC_LI_X10_0;
     dut->eval();
     CHECK(dut->ifu_req_seq_rv32 == 0, "req_seq_rv32 should be 0 for a 16-bit instr, got %d", dut->ifu_req_seq_rv32);
-    CHECK(dut->ifu_req_pc == 0x2, "RVC req_pc should be 0x2 (pc 0 + 2), got 0x%08x", dut->ifu_req_pc);
-    tick(); dut->eval();
-    CHECK(dut->inspect_pc == 0x2, "pc should advance by 2 for RVC, got 0x%08x", dut->inspect_pc);
+    // The boot fetch goes to the reset vector regardless of instruction width;
+    // the 2-byte increment shows on the fetch after it.
+    CHECK(dut->ifu_req_pc == BOOT_PC, "boot req_pc should be the reset vector 0x%08x, got 0x%08x",
+          BOOT_PC, dut->ifu_req_pc);
+    tick(); dut->eval();           // boot request handshake
+    CHECK(dut->inspect_pc == BOOT_PC, "pc should land on the reset vector 0x%08x, got 0x%08x",
+          BOOT_PC, dut->inspect_pc);
+    CHECK(dut->ifu_req_pc == BOOT_PC + 2, "RVC next req_pc should be 0x%08x (pc + 2), got 0x%08x",
+          BOOT_PC + 2, dut->ifu_req_pc);
 
     // ── Test 7: Bus error is captured with the instruction ───────────
     printf("Test 7: Bus error capture\n");
@@ -239,6 +259,33 @@ int main() {
     dut->eval();
     tick(); dut->eval();
     CHECK(dut->ifu_halt_ack == 0, "halt_ack should clear when halt_req drops, got %d", dut->ifu_halt_ack);
+
+    // ── Test 10: A non-zero reset vector is honoured ─────────────────
+    // The regression this file exists to hold: before arch#800 `pc_rtvec` was
+    // dead — `reset_flag_r` reset to false, so `reset_req_r` never armed and
+    // the boot fetch came from pc_r + incr no matter what the vector said.
+    // Driving a vector far from 0 makes that unmistakable.
+    printf("Test 10: Non-zero reset vector\n");
+    reset();
+    dut->pc_rtvec = 0x80000000;
+    // Present an RV32 instruction so the post-boot increment is 4; the width
+    // comes from whatever minidec sees on ifu_rsp_instr, and 0 decodes as RVC.
+    dut->ifu_rsp_instr = RV32_ADD_X3_X1_X2;
+    dut->rst_n = 0;
+    for (int i = 0; i < 3; i++) tick();
+    dut->rst_n = 1;
+    dut->eval();
+    CHECK(dut->ifu_req_valid == 0, "fetch should be held off until the reset request arms, got %d",
+          dut->ifu_req_valid);
+    tick();
+    dut->eval();
+    CHECK(dut->ifu_req_valid == 1, "a boot fetch should be offered once armed, got %d", dut->ifu_req_valid);
+    CHECK(dut->ifu_req_pc == 0x80000000u, "boot req_pc should be pc_rtvec 0x80000000, got 0x%08x",
+          dut->ifu_req_pc);
+    tick();
+    dut->eval();
+    CHECK(dut->inspect_pc == 0x80000000u, "pc should land on the reset vector, got 0x%08x", dut->inspect_pc);
+    CHECK(dut->ifu_req_pc == 0x80000004u, "next req_pc should be 0x80000004, got 0x%08x", dut->ifu_req_pc);
 
     printf("\n=== e203_ifu_ifetch: %d failure(s) ===\n", fail_count);
     return fail_count ? 1 : 0;

--- a/tests/e203/e203_ifu_top_tb.cpp
+++ b/tests/e203/e203_ifu_top_tb.cpp
@@ -51,8 +51,9 @@
 // while KNOWN ISSUE 1 holds ifu_o_valid low; noted here so it is not
 // rediscovered.
 //
-// ── KNOWN ISSUE 4 (pre-existing, arch#800): the pc_rtvec reset vector is dead
-// in e203_ifu_ifetch, so the fetch unit boots from 0x0 rather than pc_rtvec.
+// ── arch#800 (FIXED): the pc_rtvec reset vector works — the fetch unit boots
+// from pc_rtvec. This tb drives it to 0x0000 so the boot fetch stays in the
+// ITCM region; the arming cycle after reset release is absorbed in reset().
 // Every PC expectation below is written against the 0x0 boot address.
 //
 // Two further top-level inputs, itcm_nohold and ifu2itcm_holdup, are declared
@@ -92,7 +93,7 @@ static void tick() {
 static void reset(uint32_t indic) {
     dut->rst_n = 0;
     dut->itcm_nohold = 0;
-    dut->pc_rtvec = 0x80000000;
+    dut->pc_rtvec = 0x00000000;  // ITCM-region reset vector (arch#800: now honoured)
     dut->ifu2itcm_holdup = 0;
     dut->itcm_region_indic = indic;
     dut->ifu2itcm_icb_cmd_ready = 1;
@@ -123,6 +124,11 @@ static void reset(uint32_t indic) {
     dut->clk = 0;
     for (int i = 0; i < 3; i++) tick();
     dut->rst_n = 1;
+    settle();
+    // The reset vector arms one cycle after release (arch#800), so the boot
+    // fetch is offered from here on. Tick once so tests observe a running
+    // fetch unit rather than the arming cycle.
+    tick();
     settle();
 }
 
@@ -155,7 +161,7 @@ int main() {
           dut->ifu2itcm_icb_cmd_valid);
     CHECK(dut->ifu2biu_icb_cmd_valid == 0, "biu cmd_valid should be 0 for a pc in the ITCM region, got %d",
           dut->ifu2biu_icb_cmd_valid);
-    CHECK(dut->ifu2itcm_icb_cmd_addr == 0x0002, "itcm cmd_addr should be 0x0002, got 0x%04x",
+    CHECK(dut->ifu2itcm_icb_cmd_addr == 0x0000, "itcm cmd_addr should be the reset vector 0x0000, got 0x%04x",
           dut->ifu2itcm_icb_cmd_addr);
 
     // ── Test 3: BIU region decode ────────────────────────────────────
@@ -167,7 +173,7 @@ int main() {
           dut->ifu2biu_icb_cmd_valid);
     CHECK(dut->ifu2itcm_icb_cmd_valid == 0, "itcm cmd_valid should be 0 for a pc outside the ITCM region, got %d",
           dut->ifu2itcm_icb_cmd_valid);
-    CHECK(dut->ifu2biu_icb_cmd_addr == 0x00000002, "biu cmd_addr should be the full 32-bit pc 0x00000002, got 0x%08x",
+    CHECK(dut->ifu2biu_icb_cmd_addr == 0x00000000, "biu cmd_addr should be the full 32-bit pc 0x00000000, got 0x%08x",
           dut->ifu2biu_icb_cmd_addr);
 
     // Redirect the PC into the ITCM region and the routing must flip back, with
@@ -192,14 +198,14 @@ int main() {
     for (int i = 0; i < 3; i++) {
         tick(); settle();
         CHECK(dut->ifu2itcm_icb_cmd_valid == 1, "cmd_valid must stay asserted under backpressure (cycle %d)", i);
-        CHECK(dut->ifu2itcm_icb_cmd_addr == 0x0002, "cmd_addr must stay stable under backpressure (cycle %d)", i);
+        CHECK(dut->ifu2itcm_icb_cmd_addr == 0x0000, "cmd_addr must stay stable under backpressure (cycle %d)", i);
         CHECK(dut->inspect_pc == 0x0, "pc must not advance while the command is stalled (cycle %d), got 0x%08x",
               i, dut->inspect_pc);
     }
     dut->ifu2itcm_icb_cmd_ready = 1;
     settle();
     tick(); settle();
-    CHECK(dut->inspect_pc == 0x2, "pc should advance to 0x2 once the command handshakes, got 0x%08x",
+    CHECK(dut->inspect_pc == 0x0, "pc should land on the reset vector 0x0 once the command handshakes, got 0x%08x",
           dut->inspect_pc);
     CHECK(dut->ifu2itcm_icb_cmd_valid == 0, "cmd_valid should drop with a fetch outstanding, got %d",
           dut->ifu2itcm_icb_cmd_valid);
@@ -225,12 +231,16 @@ int main() {
           dut->ifu2itcm_icb_rsp_ready);
     CHECK(dut->_let_ifu_rsp_valid_w == 1, "the bridge should present a valid response to ifetch, got %d",
           dut->_let_ifu_rsp_valid_w);
-    // KNOWN ISSUE 2: the request was for 0x0002 (word 0), so the correct half is
-    // rdata[31:0] == RV32_ADD_X3_X1_X2. The design selects on the *next* fetch
-    // address (0x0004, bit 2 set) and captures rdata[63:32] instead.
-    CHECK(dut->_let_ifu_rsp_instr_w == 0xAAAAAAAAu,
-          "KNOWN ISSUE 2: half-select follows the next fetch_pc, expected 0xAAAAAAAA, got 0x%08x",
-          dut->_let_ifu_rsp_instr_w);
+    // KNOWN ISSUE 2 is unchanged — e203_ifu_ift2icb still selects the 64->32
+    // half with `fetch_pc[2]`, the address of the *next* request rather than
+    // the outstanding one — but this scenario no longer exposes it. Since
+    // arch#800 the boot fetch targets the reset vector 0x0000 and the pc that
+    // follows is below 4, so bit 2 is clear and the off-by-one happens to pick
+    // the correct half. Do NOT read this passing check as the half-select
+    // being fixed; a reset vector with bit 2 set would still show the bug.
+    CHECK(dut->_let_ifu_rsp_instr_w == RV32_ADD_X3_X1_X2,
+          "at the reset vector the half-select lands on rdata[31:0]; expected 0x%08x, got 0x%08x",
+          RV32_ADD_X3_X1_X2, dut->_let_ifu_rsp_instr_w);
 
     // ── Test 6: The fetch pipeline locks up on that response ─────────
     // KNOWN ISSUE 1. Pinned as observed behavior so a future fix flips this
@@ -241,7 +251,7 @@ int main() {
         CHECK(dut->ifu_o_valid == 0, "KNOWN ISSUE 1: ifu_o_valid stays 0 (cycle %d), got %d", i, dut->ifu_o_valid);
         CHECK(dut->ifu2itcm_icb_rsp_ready == 0, "KNOWN ISSUE 1: the buffer never drains (cycle %d)", i);
         CHECK(dut->ifu2itcm_icb_cmd_valid == 0, "KNOWN ISSUE 1: no new command is issued (cycle %d)", i);
-        CHECK(dut->inspect_pc == 0x2, "pc stays frozen at 0x2 while locked (cycle %d), got 0x%08x",
+        CHECK(dut->inspect_pc == 0x0, "pc stays frozen at the reset vector 0x0 while locked (cycle %d), got 0x%08x",
               i, dut->inspect_pc);
     }
 
@@ -302,6 +312,16 @@ int main() {
     reset(0x00000000);
     CHECK(dut->ifu2itcm_icb_cmd_valid == 1, "a fetch should be offered before halting, got %d",
           dut->ifu2itcm_icb_cmd_valid);
+    // Drain the boot fetch — request and response — before halting.
+    // `ifu_halt_req` gates `ifu_new_req` only; `ifu_reset_req` bypasses it,
+    // matching the reference, so the reset-vector fetch is deliberately not
+    // haltable, and `halt_ack` additionally needs nothing outstanding.
+    tick(); settle();                       // boot command handshake
+    dut->ifu2itcm_icb_rsp_valid = 1;
+    settle();
+    tick();
+    dut->ifu2itcm_icb_rsp_valid = 0;
+    settle();                               // boot response drained
     dut->ifu_halt_req = 1;
     settle();
     CHECK(dut->ifu2itcm_icb_cmd_valid == 0, "halt_req should suppress the ICB command, got %d",
@@ -317,7 +337,7 @@ int main() {
     settle();
     tick(); settle();
     CHECK(dut->ifu_halt_ack == 0, "halt_ack should clear when halt_req drops, got %d", dut->ifu_halt_ack);
-    CHECK(dut->inspect_pc == 0x2, "fetching should resume after halt, pc should be 0x2, got 0x%08x",
+    CHECK(dut->inspect_pc == 0x0, "fetching should resume after halt, pc should be 0x0, got 0x%08x",
           dut->inspect_pc);
 
     printf("\n=== e203_ifu_top: %d failure(s) ===\n", fail_count);

--- a/tests/e203/e203_soc_top_tb.cpp
+++ b/tests/e203/e203_soc_top_tb.cpp
@@ -51,7 +51,7 @@
 // Test 5 pins the actual behavior. Same family as the already-filed arch#869
 // (dtcm wr_be zeroes unwritten lanes).
 //
-// ── KNOWN ISSUE 3 (arch#800): pc_rtvec is dead inside e203_ifu_ifetch, so the
+// ── arch#800 (FIXED): pc_rtvec is honoured inside e203_ifu_ifetch, so the
 // core boots from 0x0. The SoC memory map puts the ITCM at 0x0000_xxxx, so the
 // boot fetch does land in the ITCM; all address expectations below assume the
 // 0x0 boot address.
@@ -97,7 +97,7 @@ static void reset() {
     dut->rst_n = 0;
     dut->timer_rst = 1;
     dut->clk = 0;
-    dut->pc_rtvec = 0x80000000;
+    dut->pc_rtvec = 0x00000000;  // ITCM-region reset vector (arch#800: now honoured)
     dut->itcm_wr_en = 0;
     dut->itcm_wr_addr = 0;
     dut->itcm_wr_data = 0;
@@ -119,6 +119,11 @@ static void reset() {
     for (int i = 0; i < 3; i++) tick();
     dut->rst_n = 1;
     dut->timer_rst = 0;
+    settle();
+    // The reset vector arms one cycle after release (arch#800), so the boot
+    // fetch is offered from here on. Tick once so tests observe a running
+    // fetch unit rather than the arming cycle.
+    tick();
     settle();
 }
 
@@ -234,7 +239,7 @@ int main() {
           ITCM_WORD1, ITCM_WORD0, (unsigned long long)dut->_let_ifu2itcm_icb_rsp_rdata);
     CHECK(dut->_let_ifu2itcm_icb_cmd_valid == 1, "the fetch should still be offered, got cmd_valid %d",
           dut->_let_ifu2itcm_icb_cmd_valid);
-    CHECK(dut->_let_ifu2itcm_icb_cmd_addr == 0x0002, "the boot fetch address should be 0x0002, got 0x%04x",
+    CHECK(dut->_let_ifu2itcm_icb_cmd_addr == 0x0000, "the boot fetch address should be the reset vector 0x0000, got 0x%04x",
           dut->_let_ifu2itcm_icb_cmd_addr);
 
     // A later word must not disturb the first two.
@@ -251,11 +256,11 @@ int main() {
     tick(); settle();
     CHECK(dut->_let_ifu2itcm_icb_rsp_valid == 1, "the ITCM should answer the fetch, got rsp_valid %d",
           dut->_let_ifu2itcm_icb_rsp_valid);
-    CHECK(dut->inspect_pc == 0x2, "the pc should have advanced to 0x2, got 0x%08x", dut->inspect_pc);
+    CHECK(dut->inspect_pc == 0x0, "the pc should have landed on the reset vector 0x0, got 0x%08x", dut->inspect_pc);
     for (int i = 0; i < 8; i++) {
         tick(); settle();
-        CHECK(dut->inspect_pc == 0x2,
-              "KNOWN ISSUE 1: the pc stays frozen at 0x2 (cycle %d), got 0x%08x", i, dut->inspect_pc);
+        CHECK(dut->inspect_pc == 0x0,
+              "the pc stays frozen at the reset vector 0x0 (cycle %d), got 0x%08x", i, dut->inspect_pc);
         CHECK(dut->_let_ifu2itcm_icb_cmd_valid == 0,
               "KNOWN ISSUE 1: fetching never resumes (cycle %d), got cmd_valid %d",
               i, dut->_let_ifu2itcm_icb_cmd_valid);


### PR DESCRIPTION
Closes #800.

## The bug

`reset_flag_r` was declared `reset rst_n => false` and assigned `<= false`, so it was false in every cycle. The reference is `sirv_gnrl_dffrs` — a DFF that **sets** on reset — and the fixture's own comment says so ("resets to 1, captures 0"). With `reset_req_set = (~reset_req_r) & reset_flag_r` unable to fire, two things were dead:

- the `ifu_reset_req ? pc_rtvec` arm of the PC mux — the core booted from `0x0` whatever `pc_rtvec` was driven to;
- the `(~reset_flag_r)` term in `ifu_new_req`, which should hold fetch off during reset — the unit offered a fetch immediately.

#843 has since plumbed `pc_rtvec` soc_top → core_top → ifu_top → ifetch, so this was a live input at the SoC boundary silently discarded at the leaf.

| | before | after |
|---|---|---|
| `pc_rtvec = 0x80000000`, first `req_pc` | `0x00000002` | **`0x80000000`** |
| `req_valid` during reset | 1 | **0** |

## What changes behaviourally

A boot fetch now exists at all. Fetch is held off for one arming cycle after reset release; the first request then targets the reset vector and is non-sequential (`ifu_req_seq` excludes it); sequential fetching proceeds from there. Previously that fetch simply did not happen and the unit started at `pc_r + incr`.

## Testbenches

Four asserted the old behaviour. This is the flip-on-fix the #882 tbs were written for.

- **`e203_ifu_top` / `e203_core_top` / `e203_soc_top`** — drive `pc_rtvec` to `0x0000` so the boot fetch stays in the ITCM region, absorb the arming cycle in their `reset()` helpers, and expect the boot address at the vector instead of at `pc+2`. `core_top`'s "pc_rtvec is dead" test becomes a "pc_rtvec is honoured" test.
- **`e203_ifu_ifetch_tb`** — loses its `// KNOWN ISSUE` block and gains **Test 10**, driving a non-zero vector (`0x80000000`) and checking that fetch is suppressed until armed, that the boot request targets the vector, and that the pc advances from it. That is the coverage the file previously and deliberately omitted, and it is the regression guard for this issue.

## Two things worth knowing before reading those tbs

**`e203_ifu_top` Test 9 now drains the boot fetch before asserting halt.** `ifu_halt_req` gates `ifu_new_req` only — `ifu_reset_req` bypasses it, matching the reference — so the reset-vector fetch is deliberately *not* haltable, and `halt_ack` additionally needs nothing outstanding.

**`e203_ifu_top`'s KNOWN ISSUE 2 is unchanged but no longer exposed.** The ITCM 64→32 half-select still keys on `fetch_pc[2]` — the *next* request's address rather than the outstanding one. With the boot fetch at `0x0000` the following pc is below 4, so bit 2 is clear and the off-by-one happens to select the correct half. The check and its comment now say this explicitly, so a reader does not mistake the pass for a fix. A reset vector with bit 2 set would still show the bug.

## Verification

- Full e203 harness: **39/39 pass** (39/39 before too — but four of those were asserting the bug).
- 816 integration tests green.
- Verilator lint on the rebuilt `e203_ifu_ifetch` SV: 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)