### PR TITLE
fix(formal): assert<bound_err> no longer proves false bounds past overflow (+ phase 4 MX quantization bounds)

### DIFF
--- a/doc/ARCH_HDL_Specification.md
+++ b/doc/ARCH_HDL_Specification.md
@@ -887,7 +887,8 @@ Rules and honest limits:
 - ULP goals are checked via the sound relative form `N·2⁻ᵖ` (for normal values `ulp(x) > 2⁻ᵖ·|x|`), conservative by at most 2×.
 - Cones are feedforward comb arithmetic: `+ - *`, `fma`, float conversions, signals, float literals. Registers, ternaries, and comparisons inside the cone are rejected (bounded unrolling of accumulators is future work).
 - Relative/ULP goals over ranges that permit **cancellation** are legitimately unprovable (relative error is unbounded near zero) — the engine reports INCONCLUSIVE with the best derivable absolute enclosure, never a false proof.
-- NaN/Inf/overflow are outside the real-valued analysis; the bit-level property classes above cover them.
+- **A narrowing conversion in the cone must be provably in range.** The engine models each format as `float<precision, min_exponent>`, which bounds precision and the smallest exponent but has **no largest** one — so left to itself it reasons about an idealized format of unbounded range and never sees overflow. Real narrow formats saturate (`FP4`/`FP6`, and fp8 under `--fp-compat=cuda`) or produce NaN/Inf (fp8 under `riscv`), where the error is nothing like a rounding error. Each narrow therefore carries a side condition `|input| ≤ max_finite`, discharged by the engine alongside the goal; a cone whose assumed ranges reach past that point reports INCONCLUSIVE naming the format and its limit, never a proof. (Before this was enforced, a cone narrowing `[1000, 2000]` to `FP8E4M3` — largest finite 448 — proved a bound of 64 while the hardware returned NaN.)
+- NaN/Inf are outside the real-valued analysis; the bit-level property classes above cover them.
 
 **Compatibility profile.** `arch build|sim --fp-compat=riscv|cuda` (default `riscv`) selects the special-value corners. Both profiles share an identical RNE arithmetic core and differ only in the canonical NaN bit patterns (`0x7FC00000`/`0x7FC0` vs `0x7FFFFFFF`/`0x7FFF`; for fp8 see the FP8 paragraph above), the NaN→int result (type-max vs `0`), and the fp8 narrowing-overflow behavior (non-saturating vs `satfinite` — see the FP8 paragraph above).
 
@@ -1220,6 +1221,47 @@ A NaN scale (`0xFF`) on either operand makes the result NaN, which falls out of
 the scale multiply rather than needing a rule. An all-zero block dots to `+0`,
 not NaN --- E8M0 has no zero, so the minimum-scale path multiplies a zero sum
 by the finite `2⁻¹²⁷`.
+
+**3.11.3 Quantization error bounds**
+
+Block quantization error is a per-element question once the shared scale `X`
+is fixed, and it is scale-invariant: writing `u = v/X` (exact, since `X` is a
+power of two), the round trip is `X · widen(narrow(u))` and the error in units
+of `X` is `|narrow(u) − u|`. `assert<bound_err>` (§3.8) discharges that
+directly, with the `assume` range on `u` encoding which binade the scale
+policy put the block maximum in:
+
+| policy | block maximum lands in |
+|---|---|
+| `floor_pow2` (OCP §6.3) | `[2^emax, 2^(emax+1))` |
+| `ceil_pow2` (NVIDIA) | `(2^(emax−1), 2^emax]` |
+
+where `emax` is the element format's top binade exponent. Machine-checked
+bounds, in units of the block's shared scale — each is half the grid spacing
+of the binade the policy lands in (`tests/fp_v1/MxQuantBound.arch`):
+
+| element | `emax` | max finite | `ceil_pow2` | `floor_pow2` |
+|---|---|---|---|---|
+| `FP4E2M1` | 2 | 6.0 | 0.5 | 1.0 |
+| `FP6E3M2` | 4 | 28.0 | 1.0 | 2.0 |
+| `FP8E4M3` | 8 | 448.0 | 8.0 | 16.0 |
+
+**Read the two columns carefully: they are the same error.** `ceil_pow2`'s
+bound is half of `floor_pow2`'s in units of *its own* scale, but its scale is
+twice as large, so both policies have the same worst-case rounding error in
+real terms. Choosing `ceil_pow2` does not buy accuracy.
+
+What actually separates them is **saturation**. `floor_pow2` normalizes the
+block maximum into `[2^emax, 2^(emax+1))`, and the format's largest
+representable value — `(2 − 2^−mant) · 2^emax` — sits strictly inside that
+interval, so any element above it clamps. `ceil_pow2` lands one binade lower
+and structurally cannot reach it. That is why saturation is routine under
+`floor_pow2` rather than a corner case, and it is the real trade-off: the top
+element codes go unused under `ceil_pow2` in exchange for never clamping.
+
+The bound is only claimed where no element saturates; extending a
+`floor_pow2` range across the saturation point makes it INCONCLUSIVE rather
+than silently wrong (§3.8, in-range side condition).
 
 **Not yet implemented:** `rtz` / `rna` rounding (they need their own element
 rounders in each backend, with their own overflow rules --- arch#890), the `exact` scale

--- a/skills/arch-programming/references/ARCH_HDL_Specification.md
+++ b/skills/arch-programming/references/ARCH_HDL_Specification.md
@@ -887,7 +887,8 @@ Rules and honest limits:
 - ULP goals are checked via the sound relative form `N·2⁻ᵖ` (for normal values `ulp(x) > 2⁻ᵖ·|x|`), conservative by at most 2×.
 - Cones are feedforward comb arithmetic: `+ - *`, `fma`, float conversions, signals, float literals. Registers, ternaries, and comparisons inside the cone are rejected (bounded unrolling of accumulators is future work).
 - Relative/ULP goals over ranges that permit **cancellation** are legitimately unprovable (relative error is unbounded near zero) — the engine reports INCONCLUSIVE with the best derivable absolute enclosure, never a false proof.
-- NaN/Inf/overflow are outside the real-valued analysis; the bit-level property classes above cover them.
+- **A narrowing conversion in the cone must be provably in range.** The engine models each format as `float<precision, min_exponent>`, which bounds precision and the smallest exponent but has **no largest** one — so left to itself it reasons about an idealized format of unbounded range and never sees overflow. Real narrow formats saturate (`FP4`/`FP6`, and fp8 under `--fp-compat=cuda`) or produce NaN/Inf (fp8 under `riscv`), where the error is nothing like a rounding error. Each narrow therefore carries a side condition `|input| ≤ max_finite`, discharged by the engine alongside the goal; a cone whose assumed ranges reach past that point reports INCONCLUSIVE naming the format and its limit, never a proof. (Before this was enforced, a cone narrowing `[1000, 2000]` to `FP8E4M3` — largest finite 448 — proved a bound of 64 while the hardware returned NaN.)
+- NaN/Inf are outside the real-valued analysis; the bit-level property classes above cover them.
 
 **Compatibility profile.** `arch build|sim --fp-compat=riscv|cuda` (default `riscv`) selects the special-value corners. Both profiles share an identical RNE arithmetic core and differ only in the canonical NaN bit patterns (`0x7FC00000`/`0x7FC0` vs `0x7FFFFFFF`/`0x7FFF`; for fp8 see the FP8 paragraph above), the NaN→int result (type-max vs `0`), and the fp8 narrowing-overflow behavior (non-saturating vs `satfinite` — see the FP8 paragraph above).
 
@@ -1220,6 +1221,47 @@ A NaN scale (`0xFF`) on either operand makes the result NaN, which falls out of
 the scale multiply rather than needing a rule. An all-zero block dots to `+0`,
 not NaN --- E8M0 has no zero, so the minimum-scale path multiplies a zero sum
 by the finite `2⁻¹²⁷`.
+
+**3.11.3 Quantization error bounds**
+
+Block quantization error is a per-element question once the shared scale `X`
+is fixed, and it is scale-invariant: writing `u = v/X` (exact, since `X` is a
+power of two), the round trip is `X · widen(narrow(u))` and the error in units
+of `X` is `|narrow(u) − u|`. `assert<bound_err>` (§3.8) discharges that
+directly, with the `assume` range on `u` encoding which binade the scale
+policy put the block maximum in:
+
+| policy | block maximum lands in |
+|---|---|
+| `floor_pow2` (OCP §6.3) | `[2^emax, 2^(emax+1))` |
+| `ceil_pow2` (NVIDIA) | `(2^(emax−1), 2^emax]` |
+
+where `emax` is the element format's top binade exponent. Machine-checked
+bounds, in units of the block's shared scale — each is half the grid spacing
+of the binade the policy lands in (`tests/fp_v1/MxQuantBound.arch`):
+
+| element | `emax` | max finite | `ceil_pow2` | `floor_pow2` |
+|---|---|---|---|---|
+| `FP4E2M1` | 2 | 6.0 | 0.5 | 1.0 |
+| `FP6E3M2` | 4 | 28.0 | 1.0 | 2.0 |
+| `FP8E4M3` | 8 | 448.0 | 8.0 | 16.0 |
+
+**Read the two columns carefully: they are the same error.** `ceil_pow2`'s
+bound is half of `floor_pow2`'s in units of *its own* scale, but its scale is
+twice as large, so both policies have the same worst-case rounding error in
+real terms. Choosing `ceil_pow2` does not buy accuracy.
+
+What actually separates them is **saturation**. `floor_pow2` normalizes the
+block maximum into `[2^emax, 2^(emax+1))`, and the format's largest
+representable value — `(2 − 2^−mant) · 2^emax` — sits strictly inside that
+interval, so any element above it clamps. `ceil_pow2` lands one binade lower
+and structurally cannot reach it. That is why saturation is routine under
+`floor_pow2` rather than a corner case, and it is the real trade-off: the top
+element codes go unused under `ceil_pow2` in exchange for never clamping.
+
+The bound is only claimed where no element saturates; extending a
+`floor_pow2` range across the saturation point makes it INCONCLUSIVE rather
+than silently wrong (§3.8, in-range side condition).
 
 **Not yet implemented:** `rtz` / `rna` rounding (they need their own element
 rounders in each backend, with their own overflow rules --- arch#890), the `exact` scale

--- a/src/formal.rs
+++ b/src/formal.rs
@@ -2886,6 +2886,15 @@ impl<'a> FormalCtx<'a> {
                 "to_bf16" => Some("bf16"),
                 "to_fp8e4m3" => Some("e4m3"),
                 "to_fp8e5m2" => Some("e5m2"),
+                // The sub-8-bit OCP MX storage formats. Their TYPES were
+                // already accepted by formal (`check_scalar_type`), and their
+                // narrows are the same proven `arch_f32_to_*` helpers every
+                // other backend calls — only these two dispatch tables were
+                // never extended when the formats landed, so a property
+                // mentioning `.to_fp4e2m1()` was refused outright.
+                "to_fp4e2m1" => Some("e2m1"),
+                "to_fp6e2m3" => Some("e2m3"),
+                "to_fp6e3m2" => Some("e3m2"),
                 _ => None,
             },
             LatencyAt(inner, _) => self.expr_float_tag(inner),
@@ -3231,12 +3240,13 @@ impl<'a> FormalCtx<'a> {
                     }),
                 };
             }
-            "to_bf16" | "to_fp8e4m3" | "to_fp8e5m2" => {
-                let (helper, tgt, w) = match n {
-                    "to_bf16" => ("arch_f32_to_bf16", "bf16", 16),
-                    "to_fp8e4m3" => ("arch_f32_to_e4m3", "e4m3", 8),
-                    _ => ("arch_f32_to_e5m2", "e5m2", 8),
-                };
+            "to_bf16" | "to_fp8e4m3" | "to_fp8e5m2" | "to_fp4e2m1" | "to_fp6e2m3"
+            | "to_fp6e3m2" => {
+                // Widths come from the format table, never a literal: `8` was
+                // right for both fp8s and is wrong for FP4 (4) and FP6 (6),
+                // which is precisely the wildcard shape the table removed.
+                let (helper, tgt) = narrow_target(n);
+                let w = float_tag_width(tgt);
                 // Any float source composes through f32 (widen exact); the
                 // target's narrow is the single rounding.
                 return match recv_tag {
@@ -3413,8 +3423,8 @@ impl<'a> FormalCtx<'a> {
         // Build definitions for the signal's cone, rounded + exact.
         let mut defs: Vec<String> = Vec::new();
         let mut done: HashSet<String> = HashSet::new();
-        let mut fmts_used: HashSet<&'static str> = HashSet::new();
-        self.emit_gappa_defs(&goal.sig, &mut defs, &mut done, &mut fmts_used, prop.span)?;
+        let mut gctx = GappaCtx::default();
+        self.emit_gappa_defs(&goal.sig, &mut defs, &mut done, &mut gctx, prop.span)?;
 
         // Hypotheses from range-shaped assumes over the cone's free ports.
         let mut hyps: Vec<String> = Vec::new();
@@ -3439,12 +3449,17 @@ impl<'a> FormalCtx<'a> {
             ));
         }
 
+        // Iterate the formats the cone actually used, not a hardcoded list —
+        // the old list silently dropped the `@rnd_` definition for any format
+        // outside it, which gappa would then reject as an unknown identifier
+        // (or, worse, the cone would never reach here at all). Sorted so the
+        // emitted script is byte-stable.
         let mut header = String::new();
-        for f in ["f32", "bf16", "e4m3", "e5m2"] {
-            if fmts_used.contains(f) {
-                let (p, emin) = gappa_fmt_params(f);
-                header.push_str(&format!("@rnd_{f} = float<{p},{emin},ne>;\n"));
-            }
+        let mut used: Vec<&str> = gctx.fmts.iter().copied().collect();
+        used.sort_unstable();
+        for f in used {
+            let (p, emin) = gappa_fmt_params(f);
+            header.push_str(&format!("@rnd_{f} = float<{p},{emin},ne>;\n"));
         }
         let defs_s = defs.join("\n");
         let hyp_s = hyps.join(" /\\ ");
@@ -3485,6 +3500,54 @@ impl<'a> FormalCtx<'a> {
                 String::from_utf8_lossy(&out.stderr).to_string(),
             ))
         };
+
+        // ── Soundness side-conditions: no narrow in the cone may overflow ──
+        //
+        // Gappa's `float<p,emin,ne>` bounds precision and the smallest
+        // exponent, but has no largest one — it reasons about an idealized
+        // format of unbounded range and so never models overflow. The real
+        // hardware saturates (FP4/FP6, and fp8 under `--fp-compat=cuda`) or
+        // produces NaN/Inf (fp8 under riscv), and in both cases the error is
+        // nothing like the rounding error gappa computed.
+        //
+        // Before arch#898 this was simply assumed, and a cone narrowing
+        // `[1000, 2000]` to FP8E4M3 (max finite 448) reported PROVED for a
+        // bound of 64 while `arch sim` returned NaN. Each narrow now carries
+        // an explicit obligation `|input| <= max_finite`, and a bound is only
+        // reported PROVED if every one of them is discharged.
+        //
+        // This matters most where MX quantization analysis is headed: under
+        // `floor_pow2` the block maximum normalizes ABOVE the element
+        // format's largest representable value, so saturation is routine
+        // rather than exceptional.
+        for (tag, input) in &gctx.narrows {
+            let d = crate::fp_format::by_tag(tag).unwrap_or_else(|| {
+                unreachable!("narrow target `{tag}` has no row in fp_format::FORMATS")
+            });
+            let max = gappa_real(d.max_finite);
+            let rng_script = format!("{header}\n{defs_s}\n\n{{ {hyp_s} -> |{input}| <= {max} }}\n");
+            if std::env::var("GAPPA_DEBUG").is_ok() {
+                eprintln!(
+                    "--- gappa range obligation for {} ---\n{rng_script}",
+                    prop.name
+                );
+            }
+            let in_range = run(&rng_script).map(|(ok, _)| ok).unwrap_or(false);
+            if !in_range {
+                return Ok(PropertyResult {
+                    name: prop.name.clone(),
+                    kind: prop.kind.clone(),
+                    status: PropertyStatus::Inconclusive(format!(
+                        "cannot show the narrow to {} stays in range (|input| <= {}, its \
+                         largest finite value) — gappa models an unbounded exponent range, \
+                         so a bound proved past that point would not describe the \
+                         saturating hardware. Tighten the `assume` ranges on the cone inputs.",
+                        d.type_name, d.max_finite
+                    )),
+                    counterexample: None,
+                });
+            }
+        }
 
         let (ok, err) = run(&script)
             .map_err(|e| CompileError::general(&format!("failed to run gappa: {e}"), prop.span))?;
@@ -3533,7 +3596,7 @@ impl<'a> FormalCtx<'a> {
         sig: &str,
         defs: &mut Vec<String>,
         done: &mut HashSet<String>,
-        fmts: &mut HashSet<&'static str>,
+        gctx: &mut GappaCtx,
         span: Span,
     ) -> Result<(), CompileError> {
         if done.contains(sig) {
@@ -3549,10 +3612,10 @@ impl<'a> FormalCtx<'a> {
         let mut deps: HashSet<String> = HashSet::new();
         collect_idents(&expr, &mut deps);
         for d in &deps {
-            self.emit_gappa_defs(d, defs, done, fmts, span)?;
+            self.emit_gappa_defs(d, defs, done, gctx, span)?;
         }
-        let rounded = self.gappa_expr(&expr, true, fmts, span)?;
-        let exact = self.gappa_expr(&expr, false, fmts, span)?;
+        let rounded = self.gappa_expr(&expr, true, gctx, span)?;
+        let exact = self.gappa_expr(&expr, false, gctx, span)?;
         defs.push(format!("{sig} = {rounded};"));
         defs.push(format!("M_{sig} = {exact};"));
         Ok(())
@@ -3600,7 +3663,7 @@ impl<'a> FormalCtx<'a> {
         &self,
         e: &Expr,
         rounded: bool,
-        fmts: &mut HashSet<&'static str>,
+        gctx: &mut GappaCtx,
         span: Span,
     ) -> Result<String, CompileError> {
         use ExprKind::*;
@@ -3647,11 +3710,11 @@ impl<'a> FormalCtx<'a> {
                         span,
                     ));
                 }
-                let ga = self.gappa_expr(a, rounded, fmts, span)?;
-                let gb = self.gappa_expr(b, rounded, fmts, span)?;
+                let ga = self.gappa_expr(a, rounded, gctx, span)?;
+                let gb = self.gappa_expr(b, rounded, gctx, span)?;
                 let raw = format!("({ga} {osym} {gb})");
                 Ok(if rounded {
-                    wrap_impl_rounding(tag, &raw, fmts)
+                    wrap_impl_rounding(tag, &raw, gctx)
                 } else {
                     raw
                 })
@@ -3661,29 +3724,35 @@ impl<'a> FormalCtx<'a> {
                     .iter()
                     .find_map(|a| self.expr_float_tag(a))
                     .unwrap_or("f32");
-                let ga = self.gappa_expr(&cargs[0], rounded, fmts, span)?;
-                let gb = self.gappa_expr(&cargs[1], rounded, fmts, span)?;
-                let gc = self.gappa_expr(&cargs[2], rounded, fmts, span)?;
+                let ga = self.gappa_expr(&cargs[0], rounded, gctx, span)?;
+                let gb = self.gappa_expr(&cargs[1], rounded, gctx, span)?;
+                let gc = self.gappa_expr(&cargs[2], rounded, gctx, span)?;
                 let raw = format!("({ga} * {gb} + {gc})");
                 Ok(if rounded {
-                    wrap_impl_rounding(tag, &raw, fmts)
+                    wrap_impl_rounding(tag, &raw, gctx)
                 } else {
                     raw
                 })
             }
             MethodCall(base, m, _) => {
-                let gb_r = self.gappa_expr(base, rounded, fmts, span)?;
+                let gb_r = self.gappa_expr(base, rounded, gctx, span)?;
                 match m.name.as_str() {
                     // Exact widen: identity over ℝ.
                     "to_fp32" => Ok(gb_r),
-                    "to_bf16" | "to_fp8e4m3" | "to_fp8e5m2" => {
-                        let tgt = match m.name.as_str() {
-                            "to_bf16" => "bf16",
-                            "to_fp8e4m3" => "e4m3",
-                            _ => "e5m2",
-                        };
+                    "to_bf16" | "to_fp8e4m3" | "to_fp8e5m2" | "to_fp4e2m1"
+                    | "to_fp6e2m3" | "to_fp6e3m2" => {
+                        let (_, tgt) = narrow_target(m.name.as_str());
                         if rounded {
-                            fmts.insert(tgt);
+                            gctx.fmts.insert(tgt);
+                            // Gappa's `float<p,emin,ne>` has a minimum but NO
+                            // MAXIMUM: it models an idealized format with an
+                            // unbounded exponent above, so it never sees
+                            // overflow, saturation, or a NaN/Inf result. Its
+                            // bound is therefore valid only where this narrow
+                            // does not overflow — record that as a proof
+                            // obligation to discharge separately rather than
+                            // assuming it (arch#898).
+                            gctx.narrows.push((tgt, gb_r.clone()));
                             Ok(format!("rnd_{tgt}({gb_r})"))
                         } else {
                             Ok(gb_r)
@@ -3697,7 +3766,7 @@ impl<'a> FormalCtx<'a> {
                     )),
                 }
             }
-            LatencyAt(inner, _) => self.gappa_expr(inner, rounded, fmts, span),
+            LatencyAt(inner, _) => self.gappa_expr(inner, rounded, gctx, span),
             _ => Err(CompileError::general(
                 "assert<bound_err> cones support + - * fma, float conversions, signals, and float literals only",
                 span,
@@ -4155,24 +4224,66 @@ fn parse_bound_goal(e: &Expr) -> Result<BoundGoal, String> {
 
 /// Faithful implementation rounding for one op: f32 ops round once; the
 /// narrow formats round through f32 first (the VR(f32) datapath).
-fn wrap_impl_rounding(tag: &'static str, raw: &str, fmts: &mut HashSet<&'static str>) -> String {
-    fmts.insert("f32");
+fn wrap_impl_rounding(tag: &'static str, raw: &str, gctx: &mut GappaCtx) -> String {
+    gctx.fmts.insert("f32");
     if tag == "f32" {
         format!("rnd_f32{raw}")
     } else {
-        fmts.insert(tag);
+        gctx.fmts.insert(tag);
         format!("rnd_{tag}(rnd_f32{raw})")
     }
 }
 
-/// (precision, emin) per format for gappa's `float<p,emin,ne>`.
-fn gappa_fmt_params(tag: &str) -> (u32, i32) {
-    match tag {
-        "f32" => (24, -149),
-        "bf16" => (8, -133),
-        "e4m3" => (4, -9),
-        _ => (3, -16),
+/// `.to_<fmt>()` → (narrowing helper, dispatch tag). One table for all three
+/// places formal dispatches conversions — the SMT encoder, the gappa cone
+/// renderer and counterexample replay — because keeping three copies in step
+/// is how the sub-8-bit formats came to be accepted by `check_scalar_type`
+/// while every one of these tables still rejected them.
+fn narrow_target(m: &str) -> (&'static str, &'static str) {
+    match m {
+        "to_bf16" => ("arch_f32_to_bf16", "bf16"),
+        "to_fp8e4m3" => ("arch_f32_to_e4m3", "e4m3"),
+        "to_fp8e5m2" => ("arch_f32_to_e5m2", "e5m2"),
+        "to_fp4e2m1" => ("arch_f32_to_e2m1", "e2m1"),
+        "to_fp6e2m3" => ("arch_f32_to_e2m3", "e2m3"),
+        "to_fp6e3m2" => ("arch_f32_to_e3m2", "e3m2"),
+        other => unreachable!("narrow_target called on non-narrowing method `{other}`"),
     }
+}
+
+/// What a `bound_err` cone accumulated while being rendered to gappa.
+///
+/// `fmts` drives the `@rnd_*` header. `narrows` is the soundness half: one
+/// entry per narrowing conversion in the cone, holding the target format and
+/// the gappa expression flowing into it, so that "this narrow does not
+/// overflow" can be **discharged** rather than assumed (arch#898).
+#[derive(Default)]
+struct GappaCtx {
+    fmts: HashSet<&'static str>,
+    narrows: Vec<(&'static str, String)>,
+}
+
+/// (precision, emin) per format for gappa's `float<p,emin,ne>`, DERIVED from
+/// the format table rather than tabulated here.
+///
+/// The previous hand-written map ended in `_ => (3, -16)`, so any format
+/// without an explicit arm silently borrowed E5M2's parameters — the
+/// silent-wildcard class of arch#829/#858, except that here the consequence
+/// is a *certified numeric bound computed for the wrong format*, which is
+/// worse than a crash. `gappa_fmt_params_reproduce_the_hand_table` pins that
+/// this derivation reproduces all four original entries exactly.
+///
+/// `p` is the significand width including the implicit bit; `emin` is the
+/// exponent of the smallest subnormal, `(1 - bias) - mant_bits`.
+fn gappa_fmt_params(tag: &str) -> (u32, i32) {
+    let d = crate::fp_format::by_tag(tag).unwrap_or_else(|| {
+        unreachable!(
+            "float dispatch tag `{tag}` has no row in fp_format::FORMATS — \
+             add the format to the table"
+        )
+    });
+    let bias = (1i32 << (d.exp_bits - 1)) - 1;
+    (d.mant_bits + 1, (1 - bias) - d.mant_bits as i32)
 }
 
 /// Exact real literal in gappa's `<mantissa>b<exponent>` notation.
@@ -5794,12 +5905,13 @@ impl FormalCtx<'_> {
                     None => None,
                 };
             }
-            "to_bf16" | "to_fp8e4m3" | "to_fp8e5m2" => {
-                let (helper, tgt, w) = match n {
-                    "to_bf16" => ("arch_f32_to_bf16", "bf16", 16),
-                    "to_fp8e4m3" => ("arch_f32_to_e4m3", "e4m3", 8),
-                    _ => ("arch_f32_to_e5m2", "e5m2", 8),
-                };
+            "to_bf16" | "to_fp8e4m3" | "to_fp8e5m2" | "to_fp4e2m1" | "to_fp6e2m3"
+            | "to_fp6e3m2" => {
+                // Widths come from the format table, never a literal: `8` was
+                // right for both fp8s and is wrong for FP4 (4) and FP6 (6),
+                // which is precisely the wildcard shape the table removed.
+                let (helper, tgt) = narrow_target(n);
+                let w = float_tag_width(tgt);
                 return match recv_tag {
                     Some(src) if src == tgt => Some(r),
                     Some("f32") => {
@@ -5905,6 +6017,69 @@ mod tests {
     //! produce an unsound query, so the z3-gated integration tests only
     //! cover the CONFIRMED path (every genuine REFUTED must stay REFUTED).
     use super::*;
+
+    /// `gappa_fmt_params` is now derived from `fp_format::FORMATS`. It
+    /// replaced a hand-written map whose `_ => (3, -16)` wildcard handed
+    /// E5M2's parameters to any format without an explicit arm — and the
+    /// consequence there is not a crash but a *certified numeric bound
+    /// computed for the wrong format*. Pin that the derivation reproduces
+    /// every original entry, and that the formats it newly reaches get the
+    /// values their encodings actually imply.
+    #[test]
+    fn gappa_fmt_params_reproduce_the_hand_table() {
+        // The four entries the hand-written map had, verbatim.
+        for (tag, want) in [
+            ("f32", (24u32, -149i32)),
+            ("bf16", (8, -133)),
+            ("e4m3", (4, -9)),
+            ("e5m2", (3, -16)),
+        ] {
+            assert_eq!(gappa_fmt_params(tag), want, "{tag} must be unchanged");
+        }
+        // The sub-8-bit formats the wildcard would have silently given
+        // E5M2's (3, -16). Smallest subnormal is `(1 - bias) - mant_bits`:
+        // E2M1 bias 1, mant 1 -> 2^-1; E2M3 bias 1, mant 3 -> 2^-3;
+        // E3M2 bias 3, mant 2 -> 2^-4.
+        for (tag, want) in [
+            ("e2m1", (2u32, -1i32)),
+            ("e2m3", (4, -3)),
+            ("e3m2", (3, -4)),
+        ] {
+            assert_ne!(
+                gappa_fmt_params(tag),
+                (3, -16),
+                "{tag} must not inherit E5M2's parameters"
+            );
+            assert_eq!(gappa_fmt_params(tag), want);
+        }
+    }
+
+    /// Every narrowing method formal dispatches must resolve to a helper and
+    /// a tag that the format table knows. A method added to one of the three
+    /// dispatch sites but not to this table is a compile error rather than a
+    /// silent refusal, which is how the sub-8-bit formats stayed unreachable
+    /// from `arch formal` after they shipped everywhere else.
+    #[test]
+    fn narrow_target_covers_every_narrowing_method() {
+        for m in [
+            "to_bf16",
+            "to_fp8e4m3",
+            "to_fp8e5m2",
+            "to_fp4e2m1",
+            "to_fp6e2m3",
+            "to_fp6e3m2",
+        ] {
+            let (helper, tag) = narrow_target(m);
+            assert!(helper.starts_with("arch_f32_to_"), "{m}: {helper}");
+            assert!(
+                crate::fp_format::by_tag(tag).is_some(),
+                "{m}: tag `{tag}` has no format row"
+            );
+            // The helper name and the tag must agree, or a conversion
+            // silently narrows to a different format than it reports.
+            assert_eq!(helper, format!("arch_f32_to_{tag}"), "{m}");
+        }
+    }
 
     fn parse_and_resolve(src: &str) -> (crate::ast::SourceFile, SymbolTable) {
         let tokens = crate::lexer::tokenize(src).expect("lexer error");

--- a/tests/fp_test.rs
+++ b/tests/fp_test.rs
@@ -3077,3 +3077,169 @@ fn case_block<'a>(t: &'a str, name: &str) -> std::collections::HashMap<String, S
     );
     out
 }
+
+// ── MX block-quantization error bounds (phase 4, arch#788 + arch#898) ───────
+
+/// **The phase-4 deliverable**: machine-checked numeric bounds on MX block
+/// quantization error, per element format and per scale policy.
+///
+/// A block's round-trip error is a per-element question once the shared scale
+/// `X` is fixed, and it is scale-invariant — with `u = v/X` (exact, `X` being
+/// a power of two) the error in units of `X` is `|narrow(u) - u|`. Each
+/// property in the fixture bounds one element that way, with the `assume`
+/// range encoding which binade the scale policy put the block maximum in.
+///
+/// **What the certified numbers actually say** — and it is not what "ceil is
+/// more accurate" would suggest. `ceil_pow2`'s bound is half of
+/// `floor_pow2`'s *in units of its own scale*, but `ceil_pow2`'s scale is
+/// twice as large, so **the two policies give the same worst-case error in
+/// real terms**. What separates them is saturation: `floor_pow2` admits block
+/// maxima above the element format's largest representable value, and those
+/// elements clamp. That is why #884 called saturation routine under
+/// `floor_pow2` rather than a corner case.
+///
+/// The last property is the one that must NOT prove. Before #898 it did:
+/// gappa models `float<p,emin,ne>` with no maximum exponent, so it never saw
+/// overflow and certified a rounding-error bound for a saturating region.
+/// z3/gappa-gated.
+#[test]
+fn fp_mx_quant_bounds() {
+    fn have(bin: &str) -> bool {
+        std::process::Command::new("which")
+            .arg(bin)
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+    }
+    let gappa_ok = have("gappa")
+        || std::env::var_os("HOME")
+            .map(|h| std::path::Path::new(&h).join("bin/gappa").exists())
+            .unwrap_or(false);
+    if !have("z3") || !gappa_ok {
+        eprintln!("skipping fp_mx_quant_bounds: z3/gappa not available");
+        return;
+    }
+    let out = arch()
+        .arg("formal")
+        .arg("tests/fp_v1/MxQuantBound.arch")
+        .arg("--solver")
+        .arg("z3")
+        .arg("--bound")
+        .arg("1")
+        .arg("--error-engine")
+        .arg("gappa")
+        .output()
+        .expect("run arch formal");
+    let all = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    // The recorded bounds, in units of the block's shared scale. Each is half
+    // the grid spacing of the binade its policy lands in, so a change to the
+    // rounding, the format table, or the policy's range lands here.
+    //
+    //   format  emax  max finite   ceil bound   floor bound
+    //   E2M1     2       6.0          0.5           1.0
+    //   E3M2     4      28.0          1.0           2.0
+    //   E4M3     8     448.0          8.0          16.0
+    for (prop, encl) in [
+        ("e2m1_ceil", "[-1b-1"),
+        ("e2m1_floor", "[-1, 1]"),
+        ("e3m2_ceil", "[-1, 1]"),
+        ("e3m2_floor", "[-2, 2]"),
+        ("e4m3_ceil", "[-8, 8]"),
+        ("e4m3_floor", "[-16, 16]"),
+    ] {
+        let line = all
+            .lines()
+            .find(|l| l.contains(prop))
+            .unwrap_or_else(|| panic!("no report line for `{prop}`:\n{all}"));
+        assert!(
+            line.contains("PROVED"),
+            "`{prop}` must prove:\n{line}\n\nfull report:\n{all}"
+        );
+        assert!(
+            line.contains(encl),
+            "`{prop}` derived a different enclosure than recorded (expected {encl}):\n{line}"
+        );
+    }
+
+    // Saturation must be refused, not certified. This is the arch#898
+    // regression pin: gappa's format model has no maximum exponent, so
+    // without the in-range obligation it proves a rounding bound for a region
+    // where the hardware clamps (or, for fp8 under riscv, returns NaN).
+    let sat = all
+        .lines()
+        .find(|l| l.contains("e2m1_sat"))
+        .unwrap_or_else(|| panic!("no report line for `e2m1_sat`:\n{all}"));
+    assert!(
+        sat.contains("INCONCLUSIVE"),
+        "a bound across E2M1's saturation point must NOT be proved:\n{sat}"
+    );
+    assert!(
+        sat.contains("stays in range") && sat.contains("6"),
+        "the refusal must name the range it could not establish:\n{sat}"
+    );
+}
+
+/// arch#898 regression, stated as the original reproducer: a cone narrowing
+/// `[1000, 2000]` to FP8E4M3 (largest finite 448). `arch sim` returns NaN for
+/// every input in that range, so the bound of 64 the engine used to prove was
+/// simply false. Kept separate from the fixture above because this is the
+/// *bug*, not the feature — it should stay pinned even if the MX bounds are
+/// later reorganized.
+#[test]
+fn fp_bound_err_refuses_overflowing_narrow() {
+    fn have(bin: &str) -> bool {
+        std::process::Command::new("which")
+            .arg(bin)
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+    }
+    let gappa_ok = have("gappa")
+        || std::env::var_os("HOME")
+            .map(|h| std::path::Path::new(&h).join("bin/gappa").exists())
+            .unwrap_or(false);
+    if !have("z3") || !gappa_ok {
+        eprintln!("skipping fp_bound_err_refuses_overflowing_narrow: z3/gappa not available");
+        return;
+    }
+    let src = r#"module SatProbe
+  port clk: in Clock<Sys>;
+  port rst: in Reset<Sync>;
+  port x: in FP32;
+  port y: out FP32;
+  wire y_w: FP32;
+  comb y_w = x.to_fp8e4m3().to_fp32(); end comb
+  comb y = y_w; end comb
+  assume x_rng: (x >= 1000.0) and (x <= 2000.0);
+  assert<bound_err> y_abs: abs(y_w - exact(y_w)) <= 64.0;
+end module SatProbe
+"#;
+    let td = tempfile::tempdir().expect("tempdir");
+    let path = td.path().join("SatProbe.arch");
+    std::fs::write(&path, src).unwrap();
+    let out = arch()
+        .arg("formal")
+        .arg(&path)
+        .arg("--solver")
+        .arg("z3")
+        .arg("--bound")
+        .arg("1")
+        .arg("--error-engine")
+        .arg("gappa")
+        .output()
+        .expect("run arch formal");
+    let all = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        all.contains("y_abs") && all.contains("INCONCLUSIVE"),
+        "a bound over a range that overflows FP8E4M3 must not be PROVED:\n{all}"
+    );
+}

--- a/tests/fp_v1/MxQuantBound.arch
+++ b/tests/fp_v1/MxQuantBound.arch
@@ -1,0 +1,97 @@
+// MX block-quantization error bounds, machine-checked by the gappa error
+// engine (phase 4 of the MX design; arch#788's `assert<bound_err>` path).
+//
+// A block's round-trip error is a per-ELEMENT question once the shared scale
+// X is fixed, and it is scale-invariant: writing u = v/X (exact, since X is a
+// power of two), the round trip is `X * widen(narrow(u))` and the error in
+// units of X is `|narrow(u) - u|`. So each property below bounds one element
+// of a block, in units of its block's scale, with the `assume` range encoding
+// which scale policy chose X:
+//
+//   floor_pow2 (OCP §6.3)  =>  the block maximum lands in [2^emax, 2^(emax+1))
+//   ceil_pow2  (NVIDIA)    =>  the block maximum lands in (2^(emax-1), 2^emax]
+//
+// where emax is the element format's top binade exponent (2 for E2M1, 4 for
+// E3M2, 8 for E4M3).
+//
+// WHAT THE CERTIFIED NUMBERS SHOW. The two policies do NOT differ in rounding
+// accuracy: ceil_pow2's bound is half of floor_pow2's *in units of its own
+// scale*, but its scale is twice as large, so the two bounds are the SAME
+// error in real terms. What actually separates them is saturation —
+// floor_pow2 admits block maxima above the element format's largest
+// representable value (6.0 for E2M1) and those elements clamp, while
+// ceil_pow2 structurally cannot reach that region. `sat_*` below locks that:
+// extending the floor range across the saturation point makes the bound
+// unprovable rather than silently wrong (arch#898).
+
+module MxQuantBound
+  port clk: in Clock<Sys>;
+  port rst: in Reset<Sync>;
+
+  port u4c: in FP32;
+  port u4f: in FP32;
+  port u6c: in FP32;
+  port u6f: in FP32;
+  port u8c: in FP32;
+  port u8f: in FP32;
+  port sat: in FP32;
+
+  port y4c: out FP32;
+  port y4f: out FP32;
+  port y6c: out FP32;
+  port y6f: out FP32;
+  port y8c: out FP32;
+  port y8f: out FP32;
+  port ysat: out FP32;
+
+  wire q4c: FP32;
+  wire q4f: FP32;
+  wire q6c: FP32;
+  wire q6f: FP32;
+  wire q8c: FP32;
+  wire q8f: FP32;
+  wire qsat: FP32;
+
+  // One element's quantize -> dequantize round trip, in units of the scale.
+  comb q4c = u4c.to_fp4e2m1().to_fp32(); end comb
+  comb q4f = u4f.to_fp4e2m1().to_fp32(); end comb
+  comb q6c = u6c.to_fp6e3m2().to_fp32(); end comb
+  comb q6f = u6f.to_fp6e3m2().to_fp32(); end comb
+  comb q8c = u8c.to_fp8e4m3().to_fp32(); end comb
+  comb q8f = u8f.to_fp8e4m3().to_fp32(); end comb
+  comb qsat = sat.to_fp4e2m1().to_fp32(); end comb
+
+  comb y4c = q4c; end comb
+  comb y4f = q4f; end comb
+  comb y6c = q6c; end comb
+  comb y6f = q6f; end comb
+  comb y8c = q8c; end comb
+  comb y8f = q8f; end comb
+  comb ysat = qsat; end comb
+
+  // E2M1: emax 2, max finite 6.0
+  assume u4c_rng: (u4c >= 2.0) and (u4c <= 4.0);
+  assume u4f_rng: (u4f >= 4.0) and (u4f <= 6.0);
+  // E3M2: emax 4, max finite 28.0
+  assume u6c_rng: (u6c >= 8.0) and (u6c <= 16.0);
+  assume u6f_rng: (u6f >= 16.0) and (u6f <= 28.0);
+  // E4M3: emax 8, max finite 448.0
+  assume u8c_rng: (u8c >= 128.0) and (u8c <= 256.0);
+  assume u8f_rng: (u8f >= 256.0) and (u8f <= 448.0);
+  // floor_pow2's FULL range reaches past 6.0, where E2M1 saturates.
+  assume sat_rng: (sat >= 4.0) and (sat <= 7.9);
+
+  // Half the grid spacing of the binade each policy lands in. Note the pairs:
+  // ceil's bound is half of floor's, but ceil's scale is twice as large, so
+  // these are the same real error.
+  assert<bound_err> e2m1_ceil:  abs(q4c - exact(q4c)) <= 0.5;
+  assert<bound_err> e2m1_floor: abs(q4f - exact(q4f)) <= 1.0;
+  assert<bound_err> e3m2_ceil:  abs(q6c - exact(q6c)) <= 1.0;
+  assert<bound_err> e3m2_floor: abs(q6f - exact(q6f)) <= 2.0;
+  assert<bound_err> e4m3_ceil:  abs(q8c - exact(q8c)) <= 8.0;
+  assert<bound_err> e4m3_floor: abs(q8f - exact(q8f)) <= 16.0;
+
+  // Must NOT prove: the range crosses E2M1's 6.0 saturation point, where a
+  // rounding-error model does not describe the hardware.
+  assert<bound_err> e2m1_sat: abs(qsat - exact(qsat)) <= 1.0;
+end module MxQuantBound


### PR DESCRIPTION
Two things, in the order I found them: a soundness bug in the `assert<bound_err>` error engine, and — once it was fixed — phase 4 of the MX design, the machine-checked quantization-error bounds.

Closes #898.

## The bug: a false PROVED

I went looking for a way to express MX block-quantization error as a `bound_err` cone. Before building on the engine I probed whether it models saturation. It does not:

```arch
comb y_w = x.to_fp8e4m3().to_fp32(); end comb
assume x_rng: (x >= 1000.0) and (x <= 2000.0);
assert<bound_err> y_abs: abs(y_w - exact(y_w)) <= 64.0;
```

```
[Assert] y_abs   PROVED  — error bound proved; derived y_w - x in [-64, 64]
```

FP8E4M3's largest finite value is **448**. `arch sim` on the same design returns `nan` for every input in that range. The proved bound of 64 is simply false.

**Cause.** Gappa models a format as `float<precision, min_exponent, ne>` — precision and the *smallest* exponent, with no largest one. So it reasons about an idealized format of unbounded range and never sees overflow, saturation, or a NaN/Inf result. Nothing constrained the narrow's input to the target's representable range.

This was invisible for `f32`/`bf16` cones (max ~3.4e38, so an assume range rarely reaches it), which is why it survived since #788. It is a live hazard for every narrow format.

**Fix.** Gappa's model is valid only below overflow, so that is now a proof obligation rather than an assumption: each narrowing conversion carries `|input| ≤ max_finite`, discharged alongside the goal. A cone whose ranges reach past it reports INCONCLUSIVE naming the format and its limit. The existing `FpBoundErr` fixture still proves all four properties with unchanged enclosures.

**Two related defects in the same code:**

- `gappa_fmt_params` ended in `_ => (3, -16)` — any format without an explicit arm silently borrowed E5M2's parameters. Unlike the usual `_ => 32` cases this does not crash; it *certifies a numeric bound computed for the wrong format*. Now derived from `fp_format::FORMATS` as `(mant_bits + 1, (1 − bias) − mant_bits)`, which reproduces all four original entries exactly (pinned by a test).
- The `@rnd_` header iterated a hardcoded four-format list, so any format outside it silently lost its rounding definition.

## Sub-8-bit conversions reachable from `arch formal`

`.to_fp4e2m1()` / `.to_fp6e2m3()` / `.to_fp6e3m2()` were refused outright. The FP4/FP6 *types* were already accepted by `check_scalar_type`, but none of the three method-dispatch tables — SMT encoder, gappa cone renderer, counterexample replay — was extended when the formats landed. All three now share one `narrow_target` table, since three copies drifting is exactly how this happened.

## Phase 4: the recorded bounds

Block quantization error is a per-element question once the shared scale `X` is fixed, and it is scale-invariant: with `u = v/X` (exact, `X` a power of two) the error in units of `X` is `|narrow(u) − u|`. The `assume` range on `u` encodes which binade the scale policy put the block maximum in.

| element | `emax` | max finite | `ceil_pow2` | `floor_pow2` |
|---|---|---|---|---|
| `FP4E2M1` | 2 | 6.0 | 0.5 | 1.0 |
| `FP6E3M2` | 4 | 28.0 | 1.0 | 2.0 |
| `FP8E4M3` | 8 | 448.0 | 8.0 | 16.0 |

All six PROVED, each with a derived enclosure exactly equal to the asserted bound.

**The two columns are the same error**, which is not what "ceil is more accurate" would suggest. `ceil_pow2`'s bound is half of `floor_pow2`'s *in units of its own scale*, but its scale is twice as large — so choosing `ceil_pow2` buys no accuracy at all.

What separates the policies is **saturation**. `floor_pow2` normalizes the block maximum into `[2^emax, 2^(emax+1))`, and the largest representable value `(2 − 2^−mant)·2^emax` sits strictly *inside* that interval, so elements above it clamp. `ceil_pow2` lands a binade lower and structurally cannot reach it. That is the real trade-off — the top element codes go unused in exchange for never clamping — and it is why #884 called saturation routine under `floor_pow2` rather than a corner case.

The seventh property in the fixture is the one that must **not** prove: a `floor_pow2` range extended across E2M1's 6.0 saturation point. Before this change, it proved.

## Verification

- `cargo test` full suite green; `cargo fmt --check` clean.
- `fp_mx_quant_bounds` pins all six bounds *and* their derived enclosures, so a change to the rounding, the format table, or a policy range lands there.
- `fp_bound_err_refuses_overflowing_narrow` pins the original reproducer separately — that is the *bug*, not the feature, and should stay pinned even if the MX fixture is later reorganized.
- Two unit tests: `gappa_fmt_params` reproduces the hand table and does not hand E5M2's parameters to the sub-8-bit formats; `narrow_target` covers every narrowing method and agrees with the format table.

Spec §3.8 documents the in-range condition among the engine's honest limits; §3.11.3 records the bounds and the policy analysis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)