### PR TITLE
fix(check): reject ARCH identifiers colliding with SV reserved words (#827 P4.2)

### DIFF
--- a/doc/ARCH_HDL_Specification.md
+++ b/doc/ARCH_HDL_Specification.md
@@ -129,6 +129,10 @@ For genuinely library-style reuse that doesn't fit a built-in pattern — custom
   **Reset ports**                           typed Reset\<Sync\|Async, High\|Low\>   rst: in Reset\<Sync\> (polarity defaults High; e.g. Reset\<Sync, Low\> for active-low)
   -------------------------------------------------------------------------------------------------------
 
+The casing conventions above are recommended, not compiler-enforced — but one naming rule *is* a hard compile error, not a style suggestion: **an ARCH identifier must not collide with an IEEE 1800-2017 SystemVerilog reserved word** (`always`, `case`, `class`, `logic`, `priority`, `table`, `wire`, and the rest of LRM Annex B's ~240-word keyword list). Arch performs no identifier renaming pass — a declared name (module, port, `reg`/`wire`/`let`, `param`, instance, struct/enum, function, `arbiter`/`regfile`/`ram` port-group array signal, ...) is emitted verbatim as the SV identifier of the same spelling — so a name that collides is not a style nit, it is SV that no frontend (Verilator, Icarus, or otherwise) can parse. `arch check` rejects the collision at the same declaration site and severity as ARCH's own reserved-keyword check (e.g. `'handshake' is a reserved ARCH keyword and cannot be used as an identifier`): `reg table: Vec<UInt<8>, 4> reset none;` fails with `'table' is a reserved SystemVerilog keyword (IEEE 1800-2017) and cannot be used as an identifier here`, since `table`/`endtable` are the SV user-defined-primitive keywords. Rename the identifier (a trailing underscore, an `s_`/`my_` prefix, or a more descriptive name all work).
+
+Verified against Verilator 5.048 and Icarus Verilog 12.0 (parse/elaborate-only): both reject an SV-keyword-named identifier unconditionally, so this rule needs no per-tool carve-out (arch#827 P4.2).
+
 **2.2 Literals**
 
 +-----------------------------------------------------------------------------------+

--- a/doc/Arch_AI_Reference_Card.md
+++ b/doc/Arch_AI_Reference_Card.md
@@ -37,6 +37,8 @@ keyword Name
 end keyword Name
 ```
 
+**Identifiers:** casing (PascalCase modules, snake_case signals, UPPER_SNAKE params) is a recommendation, not enforced. One naming rule *is* a hard error: an identifier must not collide with an IEEE 1800-2017 SystemVerilog reserved word (`always`, `case`, `logic`, `priority`, `table`, `wire`, ... ~240 total) — every declared name is emitted verbatim as the SV identifier of the same spelling, so `reg table: ...` fails `arch check` with `'table' is a reserved SystemVerilog keyword`. Rename it (`table_`, `s_table`, `lut`, ...).
+
 **Signal assignment:**
 
 ```

--- a/examples/reset_init_on.arch
+++ b/examples/reset_init_on.arch
@@ -17,25 +17,25 @@ module SyncHighInitOn
   port out2:  out UInt<8>;
   port out3:  out UInt<8>;
 
-  reg table: Vec<UInt<8>, 4> reset none;
+  reg entries: Vec<UInt<8>, 4> reset none;
 
   seq on clk rising
     init on rst.asserted
       for i in 0..3
-        table[i] <= i.trunc<8>();
+        entries[i] <= i.trunc<8>();
       end for
     end init
 
     if en
-      table[0] <= (table[0] + 1).trunc<8>();
+      entries[0] <= (entries[0] + 1).trunc<8>();
     end if
   end seq
 
   comb
-    out0 = table[0];
-    out1 = table[1];
-    out2 = table[2];
-    out3 = table[3];
+    out0 = entries[0];
+    out1 = entries[1];
+    out2 = entries[2];
+    out3 = entries[3];
   end comb
 
 end module SyncHighInitOn
@@ -50,25 +50,25 @@ module AsyncLowInitOn
   port out2:  out UInt<8>;
   port out3:  out UInt<8>;
 
-  reg table: Vec<UInt<8>, 4> reset none;
+  reg entries: Vec<UInt<8>, 4> reset none;
 
   seq on clk rising
     init on rst_n.asserted
       for i in 0..3
-        table[i] <= i.trunc<8>();
+        entries[i] <= i.trunc<8>();
       end for
     end init
 
     if en
-      table[0] <= (table[0] + 1).trunc<8>();
+      entries[0] <= (entries[0] + 1).trunc<8>();
     end if
   end seq
 
   comb
-    out0 = table[0];
-    out1 = table[1];
-    out2 = table[2];
-    out3 = table[3];
+    out0 = entries[0];
+    out1 = entries[1];
+    out2 = entries[2];
+    out3 = entries[3];
   end comb
 
 end module AsyncLowInitOn

--- a/skills/arch-programming/references/ARCH_HDL_Specification.md
+++ b/skills/arch-programming/references/ARCH_HDL_Specification.md
@@ -129,6 +129,10 @@ For genuinely library-style reuse that doesn't fit a built-in pattern — custom
   **Reset ports**                           typed Reset\<Sync\|Async, High\|Low\>   rst: in Reset\<Sync\> (polarity defaults High; e.g. Reset\<Sync, Low\> for active-low)
   -------------------------------------------------------------------------------------------------------
 
+The casing conventions above are recommended, not compiler-enforced — but one naming rule *is* a hard compile error, not a style suggestion: **an ARCH identifier must not collide with an IEEE 1800-2017 SystemVerilog reserved word** (`always`, `case`, `class`, `logic`, `priority`, `table`, `wire`, and the rest of LRM Annex B's ~240-word keyword list). Arch performs no identifier renaming pass — a declared name (module, port, `reg`/`wire`/`let`, `param`, instance, struct/enum, function, `arbiter`/`regfile`/`ram` port-group array signal, ...) is emitted verbatim as the SV identifier of the same spelling — so a name that collides is not a style nit, it is SV that no frontend (Verilator, Icarus, or otherwise) can parse. `arch check` rejects the collision at the same declaration site and severity as ARCH's own reserved-keyword check (e.g. `'handshake' is a reserved ARCH keyword and cannot be used as an identifier`): `reg table: Vec<UInt<8>, 4> reset none;` fails with `'table' is a reserved SystemVerilog keyword (IEEE 1800-2017) and cannot be used as an identifier here`, since `table`/`endtable` are the SV user-defined-primitive keywords. Rename the identifier (a trailing underscore, an `s_`/`my_` prefix, or a more descriptive name all work).
+
+Verified against Verilator 5.048 and Icarus Verilog 12.0 (parse/elaborate-only): both reject an SV-keyword-named identifier unconditionally, so this rule needs no per-tool carve-out (arch#827 P4.2).
+
 **2.2 Literals**
 
 +-----------------------------------------------------------------------------------+

--- a/skills/arch-programming/references/Arch_AI_Reference_Card.md
+++ b/skills/arch-programming/references/Arch_AI_Reference_Card.md
@@ -37,6 +37,8 @@ keyword Name
 end keyword Name
 ```
 
+**Identifiers:** casing (PascalCase modules, snake_case signals, UPPER_SNAKE params) is a recommendation, not enforced. One naming rule *is* a hard error: an identifier must not collide with an IEEE 1800-2017 SystemVerilog reserved word (`always`, `case`, `logic`, `priority`, `table`, `wire`, ... ~240 total) — every declared name is emitted verbatim as the SV identifier of the same spelling, so `reg table: ...` fails `arch check` with `'table' is a reserved SystemVerilog keyword`. Rename it (`table_`, `s_table`, `lut`, ...).
+
 **Signal assignment:**
 
 ```

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -7218,10 +7218,88 @@ impl<'a> TypeChecker<'a> {
     }
 
     // Naming convention checks removed — style is a convention (LLM defaults
-    // to snake_case), not a compiler-enforced rule.
-    pub(crate) fn check_pascal_case(&mut self, _ident: &Ident) {}
-    pub(crate) fn check_snake_case(&mut self, _ident: &Ident) {}
-    pub(crate) fn check_upper_snake(&mut self, _ident: &Ident) {}
+    // to snake_case), not a compiler-enforced rule. All three still funnel
+    // through `check_not_sv_reserved`, which is *not* a style check: every
+    // declared ARCH name reaches one of these three calls (module/construct
+    // names -> pascal, ports/signals/insts -> snake, params -> upper_snake),
+    // so this is the one place that sees the full set of names the compiler
+    // is about to emit verbatim as SV identifiers.
+    pub(crate) fn check_pascal_case(&mut self, ident: &Ident) {
+        self.check_not_sv_reserved(ident);
+    }
+    pub(crate) fn check_snake_case(&mut self, ident: &Ident) {
+        self.check_not_sv_reserved(ident);
+    }
+    pub(crate) fn check_upper_snake(&mut self, ident: &Ident) {
+        self.check_not_sv_reserved(ident);
+    }
+
+    /// Reject an ARCH identifier that collides with an IEEE 1800-2017
+    /// SystemVerilog reserved word. ARCH performs no renaming pass — a
+    /// declared name is emitted as an SV identifier of the same spelling —
+    /// so an SV keyword used as an ARCH name produces SV that no frontend
+    /// can parse, regardless of how well-typed the ARCH source is. Mirrors
+    /// `Parser::expect_ident`'s ARCH-keyword-collision diagnostic
+    /// (parser.rs) in both severity (hard error) and message shape, but
+    /// necessarily lives here instead: ARCH's own keywords get a dedicated
+    /// lexer `TokenKind` and so never reach `expect_ident`'s `Ident` arm at
+    /// all, while SV keywords are ordinary ARCH `Ident` tokens — some of
+    /// which are legitimately used ARCH *value* tokens in non-declaration
+    /// position (e.g. `policy priority;`, where `priority` is an SV
+    /// keyword but is matched and discarded, never stored as a declared
+    /// name). Gating on the naming-convention call sites — which by
+    /// construction only ever see identifiers already stored as a
+    /// declared name in the AST — keeps the check scoped to names that
+    /// actually reach codegen, without flagging value-position tokens.
+    /// (arch#827 P4.2: `reg table: ...` in `examples/reset_init_on.arch`
+    /// reached codegen untouched and emitted `logic [3:0][7:0] table;`,
+    /// rejected by both Verilator and Icarus — `table`/`endtable` are the
+    /// SV user-defined-primitive keywords.)
+    pub(crate) fn check_not_sv_reserved(&mut self, ident: &Ident) {
+        if is_sv_reserved_word(&ident.name) {
+            self.errors.push(CompileError::general(
+                &format!(
+                    "'{}' is a reserved SystemVerilog keyword (IEEE 1800-2017) and cannot be \
+                     used as an identifier here — ARCH emits it verbatim as an SV identifier. \
+                     Rename it (e.g. '{}_', 's_{}', or 'my_{}').",
+                    ident.name, ident.name, ident.name, ident.name
+                ),
+                ident.span,
+            ));
+        }
+    }
+
+    /// Same check as `check_not_sv_reserved`, but for a `ports[N] array_name
+    /// ... sig: dir Type; ... end ports array_name` sub-signal (arbiter/
+    /// regfile/RAM/template port groups). The sub-signal's own name is
+    /// never emitted as a standalone SV identifier — codegen always
+    /// flattens it with the array's own name first (`{array}_{signal}`,
+    /// e.g. `emit_arbiter`/`emit_regfile`/`emit_ram`: `request` + `release`
+    /// -> `request_release`), so checking the bare sub-name against the SV
+    /// reserved-word list produces false positives on names that are
+    /// perfectly safe once flattened. Concretely: `synthesize_lock_arbiter`
+    /// (elaborate/threads.rs) generates a `release` sub-signal for every
+    /// `mutex`/`semaphore` lowering — bare `release` collides with SV's
+    /// `release` keyword, but the emitted `request_release` does not, and
+    /// all 29 lock/mutex/semaphore fixtures in the corpus already sit at
+    /// iverilog+verilator `OK` in `tests/portability_baseline.tsv` (arch#827
+    /// P4.2 sweep caught this as 29 false-positive regressions before this
+    /// flattened-name check replaced the bare one).
+    pub(crate) fn check_array_signal_not_sv_reserved(&mut self, array_name: &Ident, sig: &Ident) {
+        let flattened = format!("{}_{}", array_name.name, sig.name);
+        if is_sv_reserved_word(&flattened) {
+            self.errors.push(CompileError::general(
+                &format!(
+                    "'{}' (ports[] signal `{}` in array `{}`) is a reserved SystemVerilog \
+                     keyword (IEEE 1800-2017) once flattened to its emitted SV name — ARCH \
+                     emits it verbatim as an SV identifier. Rename the array or the signal \
+                     (e.g. '{}_evt', 's_{}', or 'my_{}').",
+                    flattened, sig.name, array_name.name, sig.name, sig.name, sig.name
+                ),
+                sig.span,
+            ));
+        }
+    }
 
     /// Check that a WidthConst param's default value fits in the declared width.
     pub(crate) fn check_width_const_overflow(&mut self, p: &ParamDecl) {
@@ -8033,7 +8111,7 @@ impl<'a> TypeChecker<'a> {
         for pg in &r.port_groups {
             self.check_snake_case(&pg.name);
             for s in &pg.signals {
-                self.check_snake_case(&s.name);
+                self.check_array_signal_not_sv_reserved(&pg.name, &s.name);
             }
         }
         // Require at least one port group
@@ -8377,7 +8455,7 @@ impl<'a> TypeChecker<'a> {
         for pa in &a.port_arrays {
             self.check_snake_case(&pa.name);
             for s in &pa.signals {
-                self.check_snake_case(&s.name);
+                self.check_array_signal_not_sv_reserved(&pa.name, &s.name);
             }
         }
         // Validate latency
@@ -8484,13 +8562,13 @@ impl<'a> TypeChecker<'a> {
         if let Some(rp) = &r.read_ports {
             self.check_snake_case(&rp.name);
             for s in &rp.signals {
-                self.check_snake_case(&s.name);
+                self.check_array_signal_not_sv_reserved(&rp.name, &s.name);
             }
         }
         if let Some(wp) = &r.write_ports {
             self.check_snake_case(&wp.name);
             for s in &wp.signals {
-                self.check_snake_case(&s.name);
+                self.check_array_signal_not_sv_reserved(&wp.name, &s.name);
             }
         }
     }
@@ -9092,7 +9170,7 @@ impl<'a> TypeChecker<'a> {
         for pa in &t.port_arrays {
             self.check_snake_case(&pa.name);
             for s in &pa.signals {
-                self.check_snake_case(&s.name);
+                self.check_array_signal_not_sv_reserved(&pa.name, &s.name);
             }
         }
         for h in &t.hooks {
@@ -9924,6 +10002,270 @@ fn check_precedence_in_item(item: &Item, errors: &mut Vec<CompileError>) {
         }
         _ => {}
     }
+}
+
+/// IEEE 1800-2017 SystemVerilog reserved words (LRM Annex B, "Keywords").
+/// Used by `check_not_sv_reserved` to hard-reject an ARCH identifier that
+/// collides with one — unlike the naming-convention *lint* just below
+/// (opt-in, warning-only, casing-only), this check is unconditional and
+/// severity-matches the ARCH-keyword-collision error in
+/// `Parser::expect_ident`: ARCH performs no renaming pass, so a name on
+/// this list reaching codegen is not a style problem, it is SV that no
+/// frontend can parse. Only currently-reserved keywords are listed (not
+/// Annex C's "reserved for future use" set, which no shipping frontend
+/// actually rejects today).
+fn is_sv_reserved_word(name: &str) -> bool {
+    matches!(
+        name,
+        "accept_on"
+            | "alias"
+            | "always"
+            | "always_comb"
+            | "always_ff"
+            | "always_latch"
+            | "and"
+            | "assert"
+            | "assign"
+            | "assume"
+            | "automatic"
+            | "before"
+            | "begin"
+            | "bind"
+            | "bins"
+            | "binsof"
+            | "bit"
+            | "break"
+            | "buf"
+            | "bufif0"
+            | "bufif1"
+            | "byte"
+            | "case"
+            | "casex"
+            | "casez"
+            | "cell"
+            | "chandle"
+            | "checker"
+            | "class"
+            | "clocking"
+            | "cmos"
+            | "config"
+            | "const"
+            | "constraint"
+            | "context"
+            | "continue"
+            | "cover"
+            | "covergroup"
+            | "coverpoint"
+            | "cross"
+            | "deassign"
+            | "default"
+            | "defparam"
+            | "design"
+            | "disable"
+            | "dist"
+            | "do"
+            | "edge"
+            | "else"
+            | "end"
+            | "endcase"
+            | "endchecker"
+            | "endclass"
+            | "endclocking"
+            | "endconfig"
+            | "endfunction"
+            | "endgenerate"
+            | "endgroup"
+            | "endinterface"
+            | "endmodule"
+            | "endpackage"
+            | "endprimitive"
+            | "endprogram"
+            | "endproperty"
+            | "endspecify"
+            | "endsequence"
+            | "endtable"
+            | "endtask"
+            | "enum"
+            | "event"
+            | "eventually"
+            | "expect"
+            | "export"
+            | "extends"
+            | "extern"
+            | "final"
+            | "first_match"
+            | "for"
+            | "force"
+            | "foreach"
+            | "forever"
+            | "fork"
+            | "forkjoin"
+            | "function"
+            | "generate"
+            | "genvar"
+            | "global"
+            | "highz0"
+            | "highz1"
+            | "if"
+            | "iff"
+            | "ifnone"
+            | "ignore_bins"
+            | "illegal_bins"
+            | "implements"
+            | "implies"
+            | "import"
+            | "incdir"
+            | "include"
+            | "initial"
+            | "inout"
+            | "input"
+            | "inside"
+            | "instance"
+            | "int"
+            | "integer"
+            | "interconnect"
+            | "interface"
+            | "intersect"
+            | "join"
+            | "join_any"
+            | "join_none"
+            | "large"
+            | "let"
+            | "liblist"
+            | "library"
+            | "local"
+            | "localparam"
+            | "logic"
+            | "longint"
+            | "macromodule"
+            | "matches"
+            | "medium"
+            | "modport"
+            | "module"
+            | "nand"
+            | "negedge"
+            | "nettype"
+            | "new"
+            | "nexttime"
+            | "nmos"
+            | "nor"
+            | "noshowcancelled"
+            | "not"
+            | "notif0"
+            | "notif1"
+            | "null"
+            | "or"
+            | "output"
+            | "package"
+            | "packed"
+            | "parameter"
+            | "pmos"
+            | "posedge"
+            | "primitive"
+            | "priority"
+            | "program"
+            | "property"
+            | "protected"
+            | "pull0"
+            | "pull1"
+            | "pulldown"
+            | "pullup"
+            | "pulsestyle_ondetect"
+            | "pulsestyle_onevent"
+            | "pure"
+            | "rand"
+            | "randc"
+            | "randcase"
+            | "randsequence"
+            | "rcmos"
+            | "real"
+            | "realtime"
+            | "ref"
+            | "reg"
+            | "reject_on"
+            | "release"
+            | "repeat"
+            | "restrict"
+            | "return"
+            | "rnmos"
+            | "rpmos"
+            | "rtran"
+            | "rtranif0"
+            | "rtranif1"
+            | "s_always"
+            | "s_eventually"
+            | "s_nexttime"
+            | "s_until"
+            | "s_until_with"
+            | "scalared"
+            | "sequence"
+            | "shortint"
+            | "shortreal"
+            | "showcancelled"
+            | "signed"
+            | "small"
+            | "soft"
+            | "solve"
+            | "specify"
+            | "specparam"
+            | "static"
+            | "string"
+            | "strong"
+            | "strong0"
+            | "strong1"
+            | "struct"
+            | "super"
+            | "supply0"
+            | "supply1"
+            | "sync_accept_on"
+            | "sync_reject_on"
+            | "table"
+            | "tagged"
+            | "task"
+            | "this"
+            | "throughout"
+            | "time"
+            | "timeprecision"
+            | "timeunit"
+            | "tran"
+            | "tranif0"
+            | "tranif1"
+            | "tri"
+            | "tri0"
+            | "tri1"
+            | "triand"
+            | "trior"
+            | "trireg"
+            | "type"
+            | "typedef"
+            | "union"
+            | "unique"
+            | "unique0"
+            | "unsigned"
+            | "until"
+            | "until_with"
+            | "untyped"
+            | "use"
+            | "uwire"
+            | "var"
+            | "vectored"
+            | "virtual"
+            | "void"
+            | "wait"
+            | "wait_order"
+            | "wand"
+            | "weak"
+            | "weak0"
+            | "weak1"
+            | "while"
+            | "wildcard"
+            | "wire"
+            | "with"
+            | "within"
+            | "wor"
+            | "xnor"
+            | "xor"
+    )
 }
 
 // ── Naming-convention lint (issue #648, opt-in via `--lint-naming`) ───────────

--- a/tests/portability_baseline.tsv
+++ b/tests/portability_baseline.tsv
@@ -160,8 +160,8 @@ examples/reduction_ops.arch	iverilog	OK	-
 examples/reduction_ops.arch	verilator	OK	-
 examples/reset_asserted.arch	iverilog	OK	-
 examples/reset_asserted.arch	verilator	OK	-
-examples/reset_init_on.arch	iverilog	FAIL	SV:19: syntax error
-examples/reset_init_on.arch	verilator	FAIL	%Error: SV:19:21: syntax error, unexpected table
+examples/reset_init_on.arch	iverilog	OK	-
+examples/reset_init_on.arch	verilator	OK	-
 examples/reset_low.arch	iverilog	OK	-
 examples/reset_low.arch	verilator	OK	-
 examples/rom_lut.arch	iverilog	OK	-


### PR DESCRIPTION
## Summary

`examples/reset_init_on.arch` declared `reg table: Vec<UInt<8>, 4> reset none;`, which emits `logic [3:0][7:0] table;` — `table`/`endtable` are the SV user-defined-primitive keywords, rejected by **both** Verilator and Icarus. This was invisible because nothing in CI compiled `arch build` output until the #827 P1-P3 portability sweep (PR #878) landed.

ARCH already has a hard-error diagnostic for the ARCH-keyword-collision case (`Parser::expect_ident`'s `'handshake' is a reserved ARCH keyword and cannot be used as an identifier`), but that path never sees SV keywords: an ARCH keyword gets its own lexer `TokenKind` and so never reaches `expect_ident`'s `Ident` arm, while an SV keyword like `table` or `priority` is an ordinary ARCH `Ident` token — and some of those (`policy priority;`) are legitimate ARCH *value* tokens in non-declaration position, not declared names. So this PR adds the new check at a different, more precise integration point: `check_pascal_case` / `check_snake_case` / `check_upper_snake` in `typecheck.rs`, which are already called at *every* declaration site in the grammar (module/construct names, ports, `reg`/`wire`/`let`, params, instances, struct/enum, function names/args, ...) and are otherwise no-ops per the standing "naming style is a convention, not enforced" decision. Same severity and message shape as the ARCH-keyword diagnostic.

## Corpus impact (required by the task: sweep before deciding)

A naive bare-name check produced **29 false-positive regressions** — all from `synthesize_lock_arbiter` (elaborate/threads.rs), which generates a `release` sub-signal for every `mutex`/`semaphore` lowering. Bare `release` collides with SV's `release` keyword, but codegen always *flattens* array port-group sub-signals with the array's own name first (`{array}_{signal}`, e.g. `request_release`), and the flattened name does not collide. All 29 affected fixtures were already `iverilog`+`verilator` OK in the baseline (no real bug). Fixed by checking the **flattened** name for `ports[N] name ... sig: ...; end ports name` sub-signals (arbiter/regfile/RAM/template port groups) instead of the bare sub-name — see `check_array_signal_not_sv_reserved`.

After that fix, a full `arch check` sweep over `tests/` + `examples/` (912 files) found **exactly one true positive**: `table` in both modules of `examples/reset_init_on.arch`, and zero false positives. Fixed that one fixture (`table` -> `entries`); both frontends now accept the emitted SV.

## Baseline

`tests/portability_baseline.tsv` re-blessed for only the two affected rows:

```
-examples/reset_init_on.arch	iverilog	FAIL	SV:19: syntax error
-examples/reset_init_on.arch	verilator	FAIL	%Error: SV:19:21: syntax error, unexpected table
+examples/reset_init_on.arch	iverilog	OK	-
+examples/reset_init_on.arch	verilator	OK	-
```

No other row touched. Note for reviewers: a fresh sweep on this branch (and independently confirmed on a clean, unmodified `origin/main` build) also shows pre-existing, unrelated drift on `examples/clk_div_counter.arch`, `tests/buf_mgr_sm/buf_mgr_sm.arch`, and `tests/aes/aes_key_expand_mod.arch` — this predates this PR and looks like exactly what PR #906 ("prune stale rows when a file's row shape changes") is already addressing, so it's left untouched here. Two more rows appear as `new` (not a diff) because `origin/main` gained `tests/fp_v1/MxQuantBound.arch` and `tests/icarus_portability/AdjacentUnary.arch` since the baseline was last blessed — also not this PR's to bless.

## Docs

`doc/ARCH_HDL_Specification.md` §2.1 and `doc/Arch_AI_Reference_Card.md` updated: this is a hard-error rule, unlike the recommended (unenforced) casing conventions around it.

## Verification

- `cargo build --release` + `cargo test --release`: 22/22 binaries green (0 failures)
- `cargo fmt --check`: clean
- `cargo clippy --release --all-targets`: clean (errors-only gate)
- Dual-frontend on the fixed fixture: `iverilog -g2012 -gsupported-assertions -t null` and `verilator --lint-only -Wno-fatal --timing` both accept the emitted SV
- `scripts/sv_portability_sweep.sh`: `regressions=0` against the re-blessed baseline

Refs #827 (P4 item 2 of 4; items 1 and 4 remain open on that issue — not closing it here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)