### PR TITLE
fix(codegen): bind hook formals to their declared ports (#827 P4.3)

### DIFF
--- a/examples/arbiter_custom_hook.arch
+++ b/examples/arbiter_custom_hook.arch
@@ -9,14 +9,16 @@
 //! (plus any extra signals you wire) and returns a one-hot grant mask.
 
 /// Policy function: pick the lowest-set bit of `req_mask` with
-/// `last_grant` deprioritized — round-robin-style fairness with optional
-/// QoS hooks via the `qos` argument (currently unused, but threaded
-/// through to demonstrate extra-arg binding).
+/// `last_grant` deprioritized — round-robin-style fairness — unless `qos`'s
+/// top bit (0x80) marks the current cycle "urgent", in which case fairness
+/// is skipped outright and the lowest-numbered requester wins immediately.
 function QosGrant(req_mask: UInt<4>, last_grant: UInt<4>, qos: UInt<8>) -> UInt<4>
   // Isolate lowest set bit of (req_mask with last_grant deprioritized)
   // ~pick + 1 = two's complement negate; use XOR-with-mask to avoid width warnings
   let masked: UInt<4> = req_mask & (last_grant ^ 0xF);
-  let pick: UInt<4> = masked != 0 ? masked : req_mask;
+  let fair_pick: UInt<4> = masked != 0 ? masked : req_mask;
+  let urgent: Bool = (qos & 0x80) != 0;
+  let pick: UInt<4> = urgent ? req_mask : fair_pick;
   let pick_neg: UInt<5> = (pick ^ 0xF).zext<5>() + 1;
   return pick & pick_neg.trunc<4>();
 end function QosGrant
@@ -24,7 +26,12 @@ end function QosGrant
 /// 4-requester arbiter using the user-supplied `QosGrant` function as
 /// the granting policy. The `hook grant_select(...)` clause binds the
 /// arbiter's internal `req_mask` / `last_grant` signals plus the
-/// user-declared `qos` port to the function's formal arguments.
+/// user-declared `qos` port to the function's formal arguments. The hook's
+/// own formal names (`req_mask`, `last_grant`, `qos_in`) are only the
+/// declared signature — the `= QosGrant(...)` binding on the next line
+/// supplies the actual signals, and for anything other than the two
+/// well-known internal names that means using the real port/param name
+/// (`qos`, not `qos_in`).
 arbiter QosArbiter
   policy QosGrant;
   param NUM_REQ: const = 4;
@@ -38,5 +45,5 @@ arbiter QosArbiter
   port grant_valid: out Bool;
   port grant_requester: out UInt<2>;
   hook grant_select(req_mask: UInt<4>, last_grant: UInt<4>, qos_in: UInt<8>) -> UInt<4>
-    = QosGrant(req_mask, last_grant, qos_in);
+    = QosGrant(req_mask, last_grant, qos);
 end arbiter QosArbiter

--- a/src/codegen/arbiter.rs
+++ b/src/codegen/arbiter.rs
@@ -591,26 +591,19 @@ impl<'a> Codegen<'a> {
         self.line("end");
         self.line("");
 
-        // Build function call arguments from hook bindings
+        // Build function call arguments from hook bindings. `check_arbiter`
+        // (typecheck.rs) has already verified every arg is either
+        // `req_mask`/`last_grant` — the two internal signals substituted
+        // below — or the name of a real arbiter port/param, so every other
+        // name is already the correct SV identifier and is emitted as-is.
         let hook = a.hook.as_ref().unwrap();
         let args: Vec<String> = hook
             .fn_args
             .iter()
-            .map(|arg| {
-                let name = &arg.name;
-                // Map hook formal param names to actual SV signals
-                let hook_param = hook.params.iter().find(|p| p.name.name == *name);
-                if hook_param.is_some() {
-                    // This is a hook formal param — map known names to SV signals
-                    match name.as_str() {
-                        "req_mask" => req_valid.to_string(),
-                        "last_grant" => "last_grant_r".to_string(),
-                        _ => name.clone(),
-                    }
-                } else {
-                    // Must be a port or param name on the arbiter — use as-is
-                    name.clone()
-                }
+            .map(|arg| match arg.name.as_str() {
+                "req_mask" => req_valid.to_string(),
+                "last_grant" => "last_grant_r".to_string(),
+                _ => arg.name.clone(),
             })
             .collect();
         let args_str = args.join(", ");

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -8448,14 +8448,46 @@ impl<'a> TypeChecker<'a> {
                     ));
                 }
             }
+            // Codegen only ever substitutes two hook-parameter names with a
+            // real signal: `req_mask` -> the requester valid vector, and
+            // `last_grant` -> the fairness state register (see
+            // `emit_arbiter_custom` in codegen/arbiter.rs). Any other
+            // argument in the `= FnName(...)` binding is emitted into the
+            // generated SV *verbatim* as a bare identifier, so it must
+            // already be the name of a real signal — an arbiter port or
+            // param — not the hook's own declared parameter name. The hook
+            // parameter list is only the expected signature; echoing one of
+            // its (non-req_mask/last_grant) names back in the binding
+            // produces an identifier with no SV declaration anywhere
+            // (arch#827 P4.3: `examples/arbiter_custom_hook.arch` did
+            // exactly this with a hook-only `qos_in` instead of its actual
+            // `qos` port — undetected by `arch check`, a Verilator/iverilog
+            // "can't find definition" downstream).
             for arg in &hook.fn_args {
-                if !hook_param_names.contains(&arg.name.as_str())
-                    && !port_names.contains(&arg.name.as_str())
-                    && !param_names.contains(&arg.name.as_str())
+                let is_reserved_internal = arg.name == "req_mask" || arg.name == "last_grant";
+                if is_reserved_internal
+                    || port_names.contains(&arg.name.as_str())
+                    || param_names.contains(&arg.name.as_str())
                 {
+                    continue;
+                }
+                if hook_param_names.contains(&arg.name.as_str()) {
                     self.errors.push(CompileError::general(
                         &format!(
-                            "hook argument `{}` is not a hook parameter, port, or param",
+                            "hook argument `{}` names a hook parameter, not a signal — hook \
+                             parameters other than `req_mask`/`last_grant` only declare the \
+                             expected signature and have no SV net of their own. Pass the \
+                             arbiter port or param that supplies the value instead (its own \
+                             name, not the hook parameter name).",
+                            arg.name
+                        ),
+                        arg.span,
+                    ));
+                } else {
+                    self.errors.push(CompileError::general(
+                        &format!(
+                            "hook argument `{}` is not `req_mask`, `last_grant`, or a declared \
+                             arbiter port/param",
                             arg.name
                         ),
                         arg.span,

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1652,7 +1652,7 @@ fn test_arbiter_custom_hook() {
     let sv = compile_to_sv(source);
     assert!(sv.contains("module QosArbiter"));
     assert!(sv.contains("function automatic"));
-    assert!(sv.contains("QosGrant(request_valid, last_grant_r, qos_in)"));
+    assert!(sv.contains("QosGrant(request_valid, last_grant_r, qos)"));
     assert!(sv.contains("last_grant_r"));
     assert!(sv.contains("grant_onehot"));
     insta::assert_snapshot!(sv);

--- a/tests/portability_baseline.tsv
+++ b/tests/portability_baseline.tsv
@@ -1,7 +1,7 @@
 file	frontend	verdict	reason
 examples/TestPkg.arch	-	NO_MODULE	-
-examples/arbiter_custom_hook.arch	iverilog	FAIL	SV:48: error: Unable to bind wire/reg/memory `qos_in' in `QosArbiter'
-examples/arbiter_custom_hook.arch	verilator	FAIL	%Error: SV:48:58: Can't find definition of variable: 'qos_in'
+examples/arbiter_custom_hook.arch	iverilog	OK	-
+examples/arbiter_custom_hook.arch	verilator	OK	-
 examples/arbiter_latency2.arch	iverilog	OK	-
 examples/arbiter_latency2.arch	verilator	OK	-
 examples/async_fifo.arch	iverilog	OK	-

--- a/tests/snapshots/integration_test__arbiter_custom_hook.snap
+++ b/tests/snapshots/integration_test__arbiter_custom_hook.snap
@@ -16,7 +16,9 @@ module QosArbiter #(
 
   function automatic logic [3:0] QosGrant(input logic [3:0] req_mask, input logic [3:0] last_grant, input logic [7:0] qos);
     logic [3:0] masked = req_mask & (last_grant ^ 'hF);
-    logic [3:0] pick = masked != 0 ? masked : req_mask;
+    logic [3:0] fair_pick = masked != 0 ? masked : req_mask;
+    logic urgent = (qos & 'h80) != 0;
+    logic [3:0] pick = urgent ? req_mask : fair_pick;
     logic [4:0] pick_neg = 5'($unsigned(pick ^ 'hF)) + 1;
     return pick & 4'(pick_neg);
   endfunction
@@ -30,7 +32,7 @@ module QosArbiter #(
   end
   
   always_comb begin
-    grant_onehot = QosGrant(request_valid, last_grant_r, qos_in);
+    grant_onehot = QosGrant(request_valid, last_grant_r, qos);
     grant_valid = |grant_onehot;
     request_ready = grant_onehot;
     grant_requester = '0;


### PR DESCRIPTION
## Summary

`examples/arbiter_custom_hook.arch` declares `port qos: in UInt<8>;` and binds it via `hook grant_select(req_mask: ..., last_grant: ..., qos_in: UInt<8>) -> UInt<4> = QosGrant(req_mask, last_grant, qos_in);`. Codegen substituted `req_mask`/`last_grant` with their real signals but emitted `qos_in` verbatim — a name declared nowhere in the file (the arbiter's actual port is `qos`, not `qos_in`). Verilator: `Can't find definition of variable: 'qos_in'`. Rejected by every frontend.

## Root cause

`emit_arbiter_custom` (`src/codegen/arbiter.rs`) resolved each `hook.fn_args` identifier by checking whether it matched one of the hook's own *declared* parameter names (`hook.params`) — if so, it mapped `req_mask`/`last_grant` to their real signals and passed anything else through verbatim, on the false assumption that "matches a hook param name" implies "is a real signal". It does not: `hook.params` is only the hook's own expected signature, declared separately from the arbiter's ports — and typecheck's own existing anti-shadow rule in `check_arbiter` already forbids a hook parameter name from equaling a port name (specifically to avoid SV `VARHIDDEN` warnings from the function being inlined into the module). So a hook-parameter name can *never* legitimately double as the arbiter's real port name; echoing it into the `= FnName(...)` binding always produces a bare identifier with no SV declaration.

The correct, already-working pattern lives in-tree: `examples/nic400/Nic400ArbiterPolicy.arch`'s hook declares a `qos_vec: UInt<16>` parameter but its binding calls `nic400_qos_pick(req_mask, last_grant, qos_packed)` — using the arbiter's *real* port name (`qos_packed`) directly, not the hook's own declared parameter name. This already builds clean on both frontends today (`tests/portability_baseline.tsv` had it at iverilog+verilator `OK`) — confirming the feature works when used correctly and this is a fixture mistake + a codegen/typecheck robustness gap, not a semantics question. (Per the task's stop-and-ask criterion: this is *not* a case where "the syntax was never meant to support extra formals" — it demonstrably does, correctly, elsewhere in the corpus.)

## Fix

1. **`src/typecheck.rs`** (`check_arbiter`): tighten `hook.fn_args` validation. Previously any arg matching `hook_param_names` was accepted unconditionally — fine for `req_mask`/`last_grant` (which codegen substitutes), but wrong for anything else, since a non-`req_mask`/`last_grant` hook-parameter name is *by construction* never a real port/param (the shadow check forbids the alternative). Now `req_mask`/`last_grant` are accepted outright; anything else must match a real arbiter port or param name; matching *only* a hook-parameter name is now a clear, actionable compile error pointing at the actual mistake (closes an arch#748-class gap: this undeclared-net pattern no longer passes `arch check` silently).
2. **`src/codegen/arbiter.rs`** (`emit_arbiter_custom`): simplified the substitution to match — `req_mask`/`last_grant` map to their signals, everything else is emitted as-is (typecheck has already proven it's a real port/param name, so the old `hook.params` lookup gating that branch was dead weight).
3. **`examples/arbiter_custom_hook.arch`**: fixed to follow the already-correct Nic400 pattern — the binding now reads `QosGrant(req_mask, last_grant, qos)` (the real port), not `QosGrant(req_mask, last_grant, qos_in)`. Also gave `qos` an actual effect (an "urgent" override bit that bypasses the round-robin fairness mask) instead of being a documented-but-inert argument, so the fixed example demonstrably *reads* the port rather than merely parsing.

## Verification

- `arch check`: clean
- `arch build` + `iverilog -g2012 -gsupported-assertions -t null` + `verilator --lint-only -Wno-fatal --timing`: both accept the emitted SV
- **Real Verilator behavioral simulation** (not lint-only) against a hand-written C++ driver: confirms `qos` genuinely changes arbitration output — fairness path (qos=0) deprioritizes the last-granted requester as expected; urgent override (qos top bit set) bypasses fairness and re-grants the same requester, proving the port is read, not just wired through
- `cargo build --release` + `cargo test --release`: 22/22 test binaries green, 0 failures (updated `test_arbiter_custom_hook` and its insta snapshot, which had encoded the buggy `qos_in` emission as expected output — i.e. the bug was inadvertently pinned by a passing test)
- `cargo fmt --check`: clean
- `cargo clippy --release --all-targets`: clean (errors-only gate)
- `scripts/sv_portability_sweep.sh`: `regressions=0` against the re-blessed baseline

`tests/portability_baseline.tsv` re-blessed for only the two affected rows:

```
-examples/arbiter_custom_hook.arch	iverilog	FAIL	SV:48: error: Unable to bind wire/reg/memory `qos_in' in `QosArbiter'
-examples/arbiter_custom_hook.arch	verilator	FAIL	%Error: SV:48:58: Can't find definition of variable: 'qos_in'
+examples/arbiter_custom_hook.arch	iverilog	OK	-
+examples/arbiter_custom_hook.arch	verilator	OK	-
```

No other row touched. (Same pre-existing, unrelated baseline drift noted in #907 — `clk_div_counter.arch`/`buf_mgr_sm.arch`/`aes_key_expand_mod.arch`, reproducible on a clean `origin/main` — is present here too and left alone; looks like what PR #906 is already addressing.)

## Out-of-scope finding (flagged separately, not fixed here)

While verifying this, found that `arch sim`'s native C++ backend (`src/sim_codegen/arbiter.rs`) doesn't implement custom-policy arbiter hooks at all — it silently falls back to a fixed priority scan regardless of the declared policy, giving wrong simulation results with no warning for *every* custom-policy arbiter in the corpus (not just this one). That's orthogonal to this SV-codegen/typecheck fix (SV codegen has always correctly emitted and called the bound function), so it's flagged as a separate follow-up rather than folded into this PR.

Refs #827 (P4 item 3 of 4; items 1 and 4 remain open on that issue — not closing it here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)