### PR TITLE
fix(codegen): hoist non-atomic sext/zext receivers into a temp (#827 P4.1)

### DIFF
--- a/src/codegen/method_call.rs
+++ b/src/codegen/method_call.rs
@@ -117,6 +117,26 @@ impl<'a> Codegen<'a> {
                         // `infer_sv_width_str`; measure the emitted form.
                         MethodCallHost::Pipeline => format!("$bits({rb})"),
                     };
+                    // arch#827 B1/B2: this expansion references the
+                    // receiver twice — once indexed at its own top bit,
+                    // once whole — which does not compose bare for a
+                    // `Concat`/`Repeat`/`FunctionCall`/`MethodCall` base
+                    // (`signed({a, b}).sext<32>()`, B2) or a
+                    // non-constant-indexed `Index` base (`din[sel].sext<12>()`,
+                    // B1). Bind it to a named temp first, the same
+                    // "bind to a `let`" fix `hoist_slice_base` applies to a
+                    // non-portable `BitSlice`/`PartSelect` base — see
+                    // `is_atomic_sext_receiver` for exactly which bases are
+                    // safe bare and why this can't just reuse that helper
+                    // or `is_atomic_index_base`.
+                    let rb = if Self::is_atomic_sext_receiver(recv) {
+                        rb
+                    } else {
+                        let in_loop = self.base_references_live_loop_var(recv);
+                        let tmp = format!("arch_idx_base_{}", self.next_index_hoist_id());
+                        self.push_hoist_temp_in_loop(sw.clone(), tmp.clone(), rb, in_loop);
+                        tmp
+                    };
                     format!("{{{{({w}-{sw}){{{rb}[{sw}-1]}}}}, {rb}}}")
                 } else {
                     b

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -6854,6 +6854,72 @@ impl<'a> Codegen<'a> {
         }
     }
 
+    /// True when `.sext<N>()`'s replicand (`base`, already run through
+    /// `unwrap_reinterpret_cast`) is safe to reference bare — twice, once
+    /// indexed at its own top bit (`base[sw-1]`) and once whole — in the
+    /// hand-emitted `{{(w-sw){base[sw-1]}}, base}` expansion (arch#827
+    /// B1/B2). `sext`'s emitter builds that string directly rather than
+    /// going through `hoist_slice_base`/the `ExprKind::Index` codegen arm,
+    /// so it needs its own atomicity check rather than inheriting theirs
+    /// automatically — see below for why the two existing checks
+    /// (`is_bare_selectable_slice_base`, `is_atomic_index_base`) are each
+    /// close but not quite right here.
+    ///
+    /// `Concat`/`Repeat`/`FunctionCall`/`MethodCall` bases are never atomic
+    /// — same reasoning `hoist_slice_base` documents for `BitSlice`/
+    /// `PartSelect`: none of them compose with a further `[...]` select on
+    /// either frontend.
+    ///
+    /// A non-constant-indexed `Index` (`din[sel]`) is *also* not atomic
+    /// here, even though both `is_bare_selectable_slice_base` and
+    /// `is_atomic_index_base` classify bare `Index` as safe. Verified
+    /// against raw hand-written SV, independent of any ARCH codegen path:
+    /// `din[sel]` (a dynamic/indexed select into a packed multi-dim array,
+    /// which is how a `Vec` element read with a runtime index lowers)
+    /// does not compose with a further select layered on top — Icarus
+    /// 12.0 rejects `din[sel][7]` and `din[sel][7:4]` identically
+    /// ("reference... not allowed in a constant expression"), and binding
+    /// `din[sel]` to a plain temp first (`logic [7:0] t = din[sel]; ...
+    /// t[7] ...`) fixes both. A *constant*-indexed `Index` (`din[2]`) is
+    /// fine bare — it folds to a plain element reference.
+    ///
+    /// This predicate is deliberately scoped to `sext`'s own hand-rolled
+    /// emission rather than folded into `is_bare_selectable_slice_base`/
+    /// `is_atomic_index_base`: those two are also reached from the bare
+    /// `ExprKind::Index` codegen arm and `hoist_slice_base` respectively,
+    /// used far beyond synthesized sext/zext, and widening them to also
+    /// catch a non-const-indexed `Index` base is a separate, wider-blast-
+    /// radius fix — `din[sel][7]`/`din[sel][7:4]` written directly by a
+    /// user hits the identical bug today, tracked as a follow-up rather
+    /// than folded into this one.
+    ///
+    /// `ExprKind::LatencyAt(inner, n)` (`pipe_reg` `@N` read, e.g.
+    /// `x_pipe@1`) is atomic when `inner` is itself a plain identifier:
+    /// codegen's own `LatencyAt` arm (below) renders that shape to a bare
+    /// name — the pipe_reg's source, its final flop, or a synthesized
+    /// `{name}_stg{n}` — never anything requiring a select. Found via a
+    /// real crash: `tests/cvdp/iir_filter.arch`'s `x_pipe@1.sext<48>()`
+    /// has `LatencyAt` fall through this predicate's `_ => false` arm,
+    /// hoisting it into `logic [$bits(x_pipe_stg1)-1:0] arch_idx_base_1;`
+    /// — a `$bits(<plain identifier>)` *declaration* width, which
+    /// segfaults Icarus 12.0 outright (reproduced in isolation with just
+    /// `logic [$bits(x)-1:0] t; assign t = x;`, independent of sext or
+    /// pipe_reg — a `$bits()`-in-declaration-width crash, not a `sext`
+    /// bug). The pre-fix code never hit this because it never hoisted
+    /// `LatencyAt` at all; avoiding the hoist here avoids the crash the
+    /// same way. `n` doesn't need checking — it's already a parsed `u32`,
+    /// not a runtime expression, so there is no non-constant case.
+    fn is_atomic_sext_receiver(base: &Expr) -> bool {
+        match &base.kind {
+            ExprKind::Ident(_) | ExprKind::SynthIdent(_, _) | ExprKind::FieldAccess(_, _) => true,
+            ExprKind::Index(_, idx) => literal_expr_u64(idx).is_some(),
+            ExprKind::LatencyAt(inner, _) => {
+                matches!(inner.kind, ExprKind::Ident(_) | ExprKind::SynthIdent(_, _))
+            }
+            _ => false,
+        }
+    }
+
     /// True if `e` contains a bare `Ident` whose name is in `names`.
     /// Conservative and shallow-recursive (walks every expression kind that
     /// can appear inside an arithmetic/logical sub-expression) — used only to
@@ -6920,12 +6986,16 @@ impl<'a> Codegen<'a> {
     /// `index_hoist_temps` / `HoistScope`). Pushed in generation order,
     /// which is also dependency order: a nested hoist is created while the
     /// outer hoist's RHS is being emitted, so it lands ahead of it.
-    fn push_hoist_temp(&self, width: String, name: String, rhs: String) {
-        self.push_hoist_temp_in_loop(width, name, rhs, false);
-    }
-
-    /// `push_hoist_temp` for a temp whose RHS references a live runtime
-    /// `for`-loop iterator — see `HoistTemp::in_loop` (arch#861).
+    ///
+    /// `in_loop` is `true` when `rhs` references a live runtime `for`-loop
+    /// iterator — see `HoistTemp::in_loop` (arch#861). There used to be a
+    /// `push_hoist_temp` convenience wrapper that hardcoded `in_loop:
+    /// false`; arch#861 retrofitted every existing hoist site (the
+    /// `Index` arm, `hoist_slice_base_in`) to compute a real `in_loop`
+    /// instead, and every hoist site added since (this one included) needs
+    /// the same check, so nothing has called the always-false wrapper in
+    /// a long time — removed as dead code rather than kept around as an
+    /// easy-to-reach-for-but-wrong shortcut for a future hoist site.
     fn push_hoist_temp_in_loop(&self, width: String, name: String, rhs: String, in_loop: bool) {
         self.index_hoist_temps.borrow_mut().push(HoistTemp {
             width,

--- a/tests/icarus_portability/SextConcatHoist.arch
+++ b/tests/icarus_portability/SextConcatHoist.arch
@@ -1,0 +1,22 @@
+// arch#827 B2 regression fixture: `.sext<N>()`'s hand-emitted
+// `{{(w-sw){recv[sw-1]}}, recv}` expansion referenced a `Concat` receiver
+// bare, twice — `y = signed({a, b}).sext<32>()` emitted
+// `{{(32-12){{a, b}[12-1]}}, {a, b}}`, applying `[12-1]` directly to an
+// unparenthesized `{a, b}` literal, which is a syntax error on Icarus 12.0
+// (and would be on Verilator too outside its size-cast/replicate special
+// cases). Hit 5 of 6 `tests/e203` top modules in #827's sweep. Binding the
+// `Concat` to a temp first — the same fix `hoist_slice_base` already
+// applies to a `Concat`/`Repeat` `BitSlice`/`PartSelect` base (#807) —
+// makes it portable.
+//
+// See tests/integration_test.rs's
+// `test_sext_concat_hoist_behavioral_equivalence_verilator_and_iverilog`.
+module SextConcatHoist
+  port a: in UInt<6>;
+  port b: in UInt<6>;
+  port y: out SInt<32>;
+
+  comb
+    y = signed({a, b}).sext<32>();
+  end comb
+end module SextConcatHoist

--- a/tests/icarus_portability/SextIndexHoist.arch
+++ b/tests/icarus_portability/SextIndexHoist.arch
@@ -1,0 +1,30 @@
+// arch#827 B1 regression fixture: `.sext<N>()`'s hand-emitted
+// `{{(w-sw){recv[sw-1]}}, recv}` expansion referenced a non-constant-indexed
+// `Index` receiver (a runtime `Vec` element read) bare, twice. `din[sel]`
+// lowers to a dynamic select into a packed multi-dim array; a further
+// select layered on top of that (the sext expansion's own `[sw-1]`) is
+// rejected by Icarus 12.0 — verified against raw hand-written SV,
+// independent of ARCH codegen: `din[sel][7]` and `din[sel][7:4]` both fail
+// elaboration ("reference... not allowed in a constant expression"), and
+// binding `din[sel]` to a temp first fixes both. Verilator has always
+// accepted the bare form, which is why this shipped unnoticed (#827's
+// sweep found 17 designs in this class).
+//
+// `y_const_idx` is the negative case: a *constant*-indexed `Index`
+// receiver folds to a plain element reference and does not need hoisting
+// — `is_atomic_sext_receiver` must not hoist it, or every ordinary
+// `x.sext<N>()` call gains a pointless temp.
+//
+// See tests/integration_test.rs's
+// `test_sext_index_hoist_behavioral_equivalence_verilator_and_iverilog`.
+module SextIndexHoist
+  port sel: in UInt<2>;
+  port din: in Vec<SInt<8>, 4>;
+  port y_runtime_idx: out SInt<12>;
+  port y_const_idx: out SInt<12>;
+
+  comb
+    y_runtime_idx = din[sel].sext<12>();
+    y_const_idx = din[2].sext<12>();
+  end comb
+end module SextIndexHoist

--- a/tests/icarus_portability/SextLoopVarHoist.arch
+++ b/tests/icarus_portability/SextLoopVarHoist.arch
@@ -1,0 +1,23 @@
+// arch#827 P4.1 loop-var regression fixture: a `.sext<N>()` receiver that
+// references a live runtime `for`-loop iterator (`din[i]`, `i` the loop
+// var). `is_atomic_sext_receiver` still says "hoist" (a non-constant Index
+// base), and `push_hoist_temp_in_loop` — the same arch#861 split already
+// used by the `ExprKind::Index` codegen arm and `hoist_slice_base` — puts
+// the declaration at the top of the loop body and the assignment in place
+// as a blocking assign, since a module-scope temp can't see the
+// loop-local `i`. This is *not* a bail-to-bare-emission fallback (the
+// receiver is never emitted un-hoisted); it is a different, still-fully-
+// portable placement of the same hoist.
+//
+// See tests/integration_test.rs's
+// `test_sext_loop_var_hoist_behavioral_equivalence_verilator_and_iverilog`.
+module SextLoopVarHoist
+  port din: in Vec<SInt<8>, 4>;
+  port dout: out Vec<SInt<12>, 4>;
+
+  comb
+    for i in 0..3
+      dout[i] = din[i].sext<12>();
+    end for
+  end comb
+end module SextLoopVarHoist

--- a/tests/icarus_portability/tb_sext_concat_hoist.sv
+++ b/tests/icarus_portability/tb_sext_concat_hoist.sv
@@ -1,0 +1,31 @@
+// arch#827 B2 regression: `.sext<N>()` on a `Concat` receiver behavioral
+// check under Icarus. Pre-fix this design was a straight syntax error on
+// iverilog (`{a, b}[12-1]` — a select applied to an unparenthesized brace
+// literal); this confirms the hoisted form also computes the values
+// ARCH's own semantics dictate.
+module tb;
+  logic [5:0] a, b;
+  logic signed [31:0] y;
+
+  SextConcatHoist dut(.a(a), .b(b), .y(y));
+
+  task check(input [5:0] va, vb, input signed [31:0] exp);
+    begin
+      a = va; b = vb; #1;
+      if (y !== exp) begin
+        $display("FAIL a=%0d b=%0d: y=%0d expect=%0d", va, vb, y, exp);
+        $finish(1);
+      end
+    end
+  endtask
+
+  initial begin
+    check(6'd0,  6'd1,  32'sd1);
+    check(6'h3F, 6'h3F, -32'sd1);
+    check(6'h20, 6'd0,  -32'sd2048);
+    check(6'h1F, 6'h3F, 32'sd2047);
+
+    $display("PASS");
+    $finish(0);
+  end
+endmodule

--- a/tests/icarus_portability/tb_sext_concat_hoist_verilator.cpp
+++ b/tests/icarus_portability/tb_sext_concat_hoist_verilator.cpp
@@ -1,0 +1,36 @@
+// arch#827 B2 regression: `.sext<N>()` on a `Concat` receiver behavioral
+// check under Verilator. Same vectors/expectations as the Icarus TB
+// (tb_sext_concat_hoist.sv).
+#include "VSextConcatHoist.h"
+#include "verilated.h"
+#include <cstdio>
+
+int main(int argc, char** argv) {
+    Verilated::commandArgs(argc, argv);
+    VSextConcatHoist* dut = new VSextConcatHoist;
+    int fails = 0;
+
+    auto check = [&](int32_t got, int32_t expect, const char* label) {
+        if (got != expect) {
+            printf("FAIL %s: got=%d expect=%d\n", label, got, expect);
+            fails++;
+        }
+    };
+
+    dut->a = 0x00; dut->b = 0x01; dut->eval();
+    check(dut->y, 1, "case1");
+
+    dut->a = 0x3F; dut->b = 0x3F; dut->eval();
+    check(dut->y, -1, "case2");
+
+    dut->a = 0x20; dut->b = 0x00; dut->eval();
+    check(dut->y, -2048, "case3");
+
+    dut->a = 0x1F; dut->b = 0x3F; dut->eval();
+    check(dut->y, 2047, "case4");
+
+    delete dut;
+    if (fails) { printf("FAILURES: %d\n", fails); return 1; }
+    printf("PASS\n");
+    return 0;
+}

--- a/tests/icarus_portability/tb_sext_index_hoist.sv
+++ b/tests/icarus_portability/tb_sext_index_hoist.sv
@@ -1,0 +1,44 @@
+// arch#827 B1 regression: `.sext<N>()` on a runtime-indexed `Vec` element
+// behavioral check under Icarus. Pre-fix this design failed to even
+// *compile* on iverilog ("reference to a wire or reg... not allowed in a
+// constant expression"); this confirms the hoisted form also computes the
+// same values ARCH's own semantics dictate.
+// din = {5, -1, -128, 127} (elements 0..3).
+module tb;
+  logic [1:0] sel;
+  logic signed [3:0][7:0] din;
+  logic signed [11:0] y_runtime_idx, y_const_idx;
+
+  SextIndexHoist dut(.sel(sel), .din(din),
+                      .y_runtime_idx(y_runtime_idx), .y_const_idx(y_const_idx));
+
+  task check(input [1:0] s, input signed [11:0] exp_runtime);
+    begin
+      sel = s; #1;
+      if (y_runtime_idx !== exp_runtime) begin
+        $display("FAIL sel=%0d: y_runtime_idx=%0d expect=%0d", s, y_runtime_idx, exp_runtime);
+        $finish(1);
+      end
+      // y_const_idx always reads din[2] regardless of sel.
+      if (y_const_idx !== -12'sd128) begin
+        $display("FAIL sel=%0d: y_const_idx=%0d expect=-128", s, y_const_idx);
+        $finish(1);
+      end
+    end
+  endtask
+
+  initial begin
+    din[0] = 8'sd5;
+    din[1] = -8'sd1;
+    din[2] = 8'sh80;   // -128
+    din[3] = 8'sd127;
+
+    check(2'd0, 12'sd5);
+    check(2'd1, -12'sd1);
+    check(2'd2, -12'sd128);
+    check(2'd3, 12'sd127);
+
+    $display("PASS");
+    $finish(0);
+  end
+endmodule

--- a/tests/icarus_portability/tb_sext_index_hoist_verilator.cpp
+++ b/tests/icarus_portability/tb_sext_index_hoist_verilator.cpp
@@ -1,0 +1,45 @@
+// arch#827 B1 regression: `.sext<N>()` on a runtime-indexed `Vec` element
+// behavioral check under Verilator. Same vectors/expectations as the
+// Icarus TB (tb_sext_index_hoist.sv).
+#include "VSextIndexHoist.h"
+#include "verilated.h"
+#include <cstdio>
+
+int main(int argc, char** argv) {
+    Verilated::commandArgs(argc, argv);
+    VSextIndexHoist* dut = new VSextIndexHoist;
+    int fails = 0;
+
+    auto check = [&](int got, int expect, const char* label) {
+        if (got != expect) {
+            printf("FAIL %s: got=%d expect=%d\n", label, got, expect);
+            fails++;
+        }
+    };
+
+    // din packed as [3:0][7:0] signed; Verilator flattens a small packed
+    // array port like this into a single scalar data member sized to the
+    // total bit width (32 bits here), laid out with element 0 in the low
+    // byte — same order as the SV literal `din[0]`/`din[1]`/... indices.
+    uint8_t d0 = 5, d1 = (uint8_t)-1, d2 = 0x80, d3 = 127;
+    dut->din = (uint32_t)d0 | ((uint32_t)d1 << 8) | ((uint32_t)d2 << 16) | ((uint32_t)d3 << 24);
+
+    dut->sel = 0; dut->eval();
+    check((int16_t)(dut->y_runtime_idx << 4) >> 4, 5, "sel0 runtime");
+    check((int16_t)(dut->y_const_idx << 4) >> 4, -128, "sel0 const");
+
+    dut->sel = 1; dut->eval();
+    check((int16_t)(dut->y_runtime_idx << 4) >> 4, -1, "sel1 runtime");
+
+    dut->sel = 2; dut->eval();
+    check((int16_t)(dut->y_runtime_idx << 4) >> 4, -128, "sel2 runtime");
+
+    dut->sel = 3; dut->eval();
+    check((int16_t)(dut->y_runtime_idx << 4) >> 4, 127, "sel3 runtime");
+    check((int16_t)(dut->y_const_idx << 4) >> 4, -128, "sel3 const");
+
+    delete dut;
+    if (fails) { printf("FAILURES: %d\n", fails); return 1; }
+    printf("PASS\n");
+    return 0;
+}

--- a/tests/icarus_portability/tb_sext_loop_var_hoist.sv
+++ b/tests/icarus_portability/tb_sext_loop_var_hoist.sv
@@ -1,0 +1,37 @@
+// arch#827 P4.1 loop-var regression: `.sext<N>()` on a receiver that
+// references a live runtime `for`-loop iterator, behavioral check under
+// Icarus. Confirms the in-loop hoist split (declare at loop top, assign
+// in place) computes the same values as the non-loop hoist.
+// din = {5, -1, -128, 127} (elements 0..3).
+module tb;
+  logic signed [3:0][7:0] din;
+  logic signed [3:0][11:0] dout;
+
+  SextLoopVarHoist dut(.din(din), .dout(dout));
+
+  initial begin
+    din[0] = 8'sd5;
+    din[1] = -8'sd1;
+    din[2] = 8'sh80;   // -128
+    din[3] = 8'sd127;
+    #1;
+    if (dout[0] !== 12'sd5) begin
+      $display("FAIL dout[0]: got=%0d expect=5", dout[0]);
+      $finish(1);
+    end
+    if (dout[1] !== -12'sd1) begin
+      $display("FAIL dout[1]: got=%0d expect=-1", dout[1]);
+      $finish(1);
+    end
+    if (dout[2] !== -12'sd128) begin
+      $display("FAIL dout[2]: got=%0d expect=-128", dout[2]);
+      $finish(1);
+    end
+    if (dout[3] !== 12'sd127) begin
+      $display("FAIL dout[3]: got=%0d expect=127", dout[3]);
+      $finish(1);
+    end
+    $display("PASS");
+    $finish(0);
+  end
+endmodule

--- a/tests/icarus_portability/tb_sext_loop_var_hoist_verilator.cpp
+++ b/tests/icarus_portability/tb_sext_loop_var_hoist_verilator.cpp
@@ -1,0 +1,45 @@
+// arch#827 P4.1 loop-var regression: `.sext<N>()` on a receiver that
+// references a live runtime `for`-loop iterator, behavioral check under
+// Verilator. Same vectors/expectations as the Icarus TB
+// (tb_sext_loop_var_hoist.sv).
+//
+// Verilator flattens packed multi-dimensional arrays to a single integer:
+// `logic [3:0][7:0] din` is one 32-bit word, `logic [3:0][11:0] dout`
+// (48 bits) is one 64-bit word; element i occupies bits [w*i +: w].
+#include "VSextLoopVarHoist.h"
+#include "verilated.h"
+#include <cstdio>
+#include <cstdint>
+
+int main(int argc, char** argv) {
+    Verilated::commandArgs(argc, argv);
+    VSextLoopVarHoist* dut = new VSextLoopVarHoist;
+    int fails = 0;
+
+    auto check = [&](int32_t got, int32_t expect, const char* label) {
+        if (got != expect) {
+            printf("FAIL %s: got=%d expect=%d\n", label, got, expect);
+            fails++;
+        }
+    };
+    auto elem12 = [](uint64_t word, int i) -> int32_t {
+        uint32_t v = (uint32_t)((word >> (12 * i)) & 0xFFF);
+        // sign-extend from 12 bits
+        if (v & 0x800) v |= 0xFFFFF000u;
+        return (int32_t)v;
+    };
+
+    uint32_t d0 = 5, d1 = (uint32_t)(uint8_t)-1, d2 = 0x80, d3 = 127;
+    dut->din = d0 | (d1 << 8) | (d2 << 16) | (d3 << 24);
+    dut->eval();
+
+    check(elem12(dut->dout, 0), 5, "dout[0]");
+    check(elem12(dut->dout, 1), -1, "dout[1]");
+    check(elem12(dut->dout, 2), -128, "dout[2]");
+    check(elem12(dut->dout, 3), 127, "dout[3]");
+
+    delete dut;
+    if (fails) { printf("FAILURES: %d\n", fails); return 1; }
+    printf("PASS\n");
+    return 0;
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -36491,3 +36491,406 @@ fn test_adjacent_unary_behavioral_equivalence_verilator_and_iverilog() {
         );
     }
 }
+
+// ---------------------------------------------------------------------
+// arch#827 P4.1 — the compiler's own `.sext<N>()` expansion bypassed the
+// base-hoist that user-written slices get (#811/#813 P1), reintroducing
+// exactly the non-portable forms those fixed: a `Concat` receiver
+// (B2, `signed({a, b}).sext<32>()`) and a non-constant-indexed `Index`
+// receiver (B1, `din[sel].sext<12>()`). `.zext`/`.trunc`/`.resize` never
+// apply a further select to their receiver (just a size-cast wrapper
+// around the whole expression, which composes with anything), so only
+// `sext` needed a fix.
+// ---------------------------------------------------------------------
+
+/// Emitted-shape check (no simulator required, so it runs on the PR gate):
+/// a `.sext<N>()` receiver that is a `Concat`, `FunctionCall`, or
+/// `MethodCall`, or a non-constant-indexed `Index`, must be bound to an
+/// `arch_idx_base_<n>` temp before the sign-bit index / whole-value reuse;
+/// a constant-indexed `Index` must stay bare (hoisting it would be
+/// pointless noise on every ordinary `.sext()` call).
+#[test]
+fn test_sext_receiver_hoists() {
+    let cases: [(&str, &[&str], bool); 5] = [
+        (
+            "module SextIdxRuntimeHoist\n  port sel: in UInt<2>;\n  port din: in Vec<SInt<8>, 4>;\n  port dout: out SInt<12>;\n  comb\n    dout = din[sel].sext<12>();\n  end comb\nend module SextIdxRuntimeHoist\n",
+            &["assign arch_idx_base_0 = din[sel];", "arch_idx_base_0[8-1]", "}, arch_idx_base_0}"],
+            true,
+        ),
+        (
+            "module SextIdxConstNoHoist\n  port din: in Vec<SInt<8>, 4>;\n  port dout: out SInt<12>;\n  comb\n    dout = din[2].sext<12>();\n  end comb\nend module SextIdxConstNoHoist\n",
+            &["din[2][8-1]", "}, din[2]}"],
+            false,
+        ),
+        (
+            "module SextConcatHoistShape\n  port a: in UInt<6>;\n  port b: in UInt<6>;\n  port y: out SInt<32>;\n  comb\n    y = signed({a, b}).sext<32>();\n  end comb\nend module SextConcatHoistShape\n",
+            &["assign arch_idx_base_0 = {a, b};", "arch_idx_base_0[12-1]", "}, arch_idx_base_0}"],
+            true,
+        ),
+        (
+            "function Ident8(v: UInt<8>) -> UInt<8>\n  return v;\nend function Ident8\n\nmodule SextFuncCallHoistShape\n  port a: in UInt<8>;\n  port y: out SInt<12>;\n  comb\n    y = signed(Ident8(a)).sext<12>();\n  end comb\nend module SextFuncCallHoistShape\n",
+            &["assign arch_idx_base_0 = Ident8(a);"],
+            true,
+        ),
+        // A `pipe_reg` `@N` read is atomic: codegen's `LatencyAt` arm
+        // renders it to a bare name, so it needs no hoist. Hoisting it
+        // anyway is not merely redundant — the temp's declared width is
+        // `$bits(<that bare name>)`, and `logic [$bits(x)-1:0] t;`
+        // segfaults Icarus 12.0 outright (verified in isolation, exit
+        // 139; an Icarus `$bits`-in-declaration-width bug, unrelated to
+        // sext). Guards the `_ => false` fallthrough that let it hoist.
+        (
+            "module SextPipeRegNoHoist\n  port clk: in Clock<SysDomain>;\n  port rst: in Reset<Sync, High>;\n  port x:   in  SInt<16>;\n  port y:   out SInt<48>;\n\n  default seq on clk rising;\n\n  pipe_reg x_pipe: x stages 2;\n\n  comb\n    y = x_pipe@1.sext<48>();\n  end comb\nend module SextPipeRegNoHoist\n",
+            &["x_pipe_stg1[$bits(x_pipe_stg1)-1]", "}, x_pipe_stg1}"],
+            false,
+        ),
+    ];
+    for (source, expected_fragments, expect_hoist) in cases {
+        let sv = compile_to_sv(source);
+        if expect_hoist {
+            for frag in expected_fragments {
+                assert!(
+                    sv.contains(frag),
+                    "expected `{frag}` in hoisted sext output, got:\n{sv}"
+                );
+            }
+        } else {
+            assert!(
+                !sv.contains("arch_idx_base"),
+                "constant-indexed sext receiver should not hoist, got:\n{sv}"
+            );
+            for frag in expected_fragments {
+                assert!(
+                    sv.contains(frag),
+                    "expected bare `{frag}` in non-hoisted sext output, got:\n{sv}"
+                );
+            }
+        }
+    }
+}
+
+/// Dual-simulator behavioral check (arch#827 B1): the hoisted `.sext<N>()`
+/// receiver must not just *compile* on both simulators, it must agree
+/// with ARCH's own sign-extension semantics on actual values, for both a
+/// runtime-indexed `Vec` element and a constant-indexed one. Skips
+/// gracefully if neither simulator is installed.
+#[test]
+fn test_sext_index_hoist_behavioral_equivalence_verilator_and_iverilog() {
+    let has_verilator = std::process::Command::new("verilator")
+        .arg("--version")
+        .output()
+        .is_ok();
+    let has_iverilog = std::process::Command::new("iverilog")
+        .arg("-V")
+        .output()
+        .is_ok();
+    if !has_verilator && !has_iverilog {
+        eprintln!(
+            "skipping arch#827 B1 sext-index hoist dual-sim behavioral check: \
+             neither verilator nor iverilog found"
+        );
+        return;
+    }
+
+    let td = tempfile::tempdir().expect("tempdir");
+    let sv_out = td.path().join("SextIndexHoist.sv");
+    let arch_bin = env!("CARGO_BIN_EXE_arch");
+
+    let build = std::process::Command::new(arch_bin)
+        .arg("build")
+        .arg("tests/icarus_portability/SextIndexHoist.arch")
+        .arg("-o")
+        .arg(&sv_out)
+        .output()
+        .expect("build SextIndexHoist SV");
+    assert!(
+        build.status.success(),
+        "arch build should pass\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&build.stdout),
+        String::from_utf8_lossy(&build.stderr)
+    );
+
+    if has_iverilog {
+        let vvp_out = td.path().join("sext_index.vvp");
+        let compile = std::process::Command::new("iverilog")
+            .arg("-g2012")
+            .arg("-s")
+            .arg("tb")
+            .arg("-o")
+            .arg(&vvp_out)
+            .arg(&sv_out)
+            .arg("tests/icarus_portability/tb_sext_index_hoist.sv")
+            .output()
+            .expect("iverilog compile SextIndexHoist");
+        assert!(
+            compile.status.success(),
+            "iverilog compile should pass (arch#827 B1 regression)\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&compile.stdout),
+            String::from_utf8_lossy(&compile.stderr)
+        );
+        let run = std::process::Command::new("vvp")
+            .arg(&vvp_out)
+            .output()
+            .expect("run iverilog SextIndexHoist");
+        let stdout = String::from_utf8_lossy(&run.stdout);
+        assert!(
+            run.status.success() && stdout.contains("PASS"),
+            "iverilog sim should confirm sext-index semantics\nstdout:\n{stdout}\nstderr:\n{}",
+            String::from_utf8_lossy(&run.stderr)
+        );
+    }
+
+    if has_verilator {
+        let obj_dir = td.path().join("obj_dir_sext_index");
+        let verilate = std::process::Command::new("verilator")
+            .arg("--cc")
+            .arg("--exe")
+            .arg("--build")
+            .arg("-Wno-fatal")
+            .arg("-Wno-DECLFILENAME")
+            .arg("-Wno-WIDTHTRUNC")
+            .arg("--top-module")
+            .arg("SextIndexHoist")
+            .arg("-Mdir")
+            .arg(&obj_dir)
+            .arg(&sv_out)
+            .arg("tests/icarus_portability/tb_sext_index_hoist_verilator.cpp")
+            .output()
+            .expect("verilate SextIndexHoist");
+        assert!(
+            verilate.status.success(),
+            "Verilator build should pass\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&verilate.stdout),
+            String::from_utf8_lossy(&verilate.stderr)
+        );
+        let exe = obj_dir.join("VSextIndexHoist");
+        let run = std::process::Command::new(&exe)
+            .output()
+            .expect("run Verilator SextIndexHoist");
+        let stdout = String::from_utf8_lossy(&run.stdout);
+        assert!(
+            run.status.success() && stdout.contains("PASS"),
+            "Verilator sim should confirm sext-index semantics\nstdout:\n{stdout}\nstderr:\n{}",
+            String::from_utf8_lossy(&run.stderr)
+        );
+    }
+}
+
+/// Dual-simulator behavioral check (arch#827 B2): the hoisted `.sext<N>()`
+/// `Concat` receiver must not just *compile* on both simulators, it must
+/// agree with ARCH's own sign-extension semantics on actual values. Skips
+/// gracefully if neither simulator is installed.
+#[test]
+fn test_sext_concat_hoist_behavioral_equivalence_verilator_and_iverilog() {
+    let has_verilator = std::process::Command::new("verilator")
+        .arg("--version")
+        .output()
+        .is_ok();
+    let has_iverilog = std::process::Command::new("iverilog")
+        .arg("-V")
+        .output()
+        .is_ok();
+    if !has_verilator && !has_iverilog {
+        eprintln!(
+            "skipping arch#827 B2 sext-concat hoist dual-sim behavioral check: \
+             neither verilator nor iverilog found"
+        );
+        return;
+    }
+
+    let td = tempfile::tempdir().expect("tempdir");
+    let sv_out = td.path().join("SextConcatHoist.sv");
+    let arch_bin = env!("CARGO_BIN_EXE_arch");
+
+    let build = std::process::Command::new(arch_bin)
+        .arg("build")
+        .arg("tests/icarus_portability/SextConcatHoist.arch")
+        .arg("-o")
+        .arg(&sv_out)
+        .output()
+        .expect("build SextConcatHoist SV");
+    assert!(
+        build.status.success(),
+        "arch build should pass\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&build.stdout),
+        String::from_utf8_lossy(&build.stderr)
+    );
+
+    if has_iverilog {
+        let vvp_out = td.path().join("sext_concat.vvp");
+        let compile = std::process::Command::new("iverilog")
+            .arg("-g2012")
+            .arg("-s")
+            .arg("tb")
+            .arg("-o")
+            .arg(&vvp_out)
+            .arg(&sv_out)
+            .arg("tests/icarus_portability/tb_sext_concat_hoist.sv")
+            .output()
+            .expect("iverilog compile SextConcatHoist");
+        assert!(
+            compile.status.success(),
+            "iverilog compile should pass (arch#827 B2 regression)\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&compile.stdout),
+            String::from_utf8_lossy(&compile.stderr)
+        );
+        let run = std::process::Command::new("vvp")
+            .arg(&vvp_out)
+            .output()
+            .expect("run iverilog SextConcatHoist");
+        let stdout = String::from_utf8_lossy(&run.stdout);
+        assert!(
+            run.status.success() && stdout.contains("PASS"),
+            "iverilog sim should confirm sext-concat semantics\nstdout:\n{stdout}\nstderr:\n{}",
+            String::from_utf8_lossy(&run.stderr)
+        );
+    }
+
+    if has_verilator {
+        let obj_dir = td.path().join("obj_dir_sext_concat");
+        let verilate = std::process::Command::new("verilator")
+            .arg("--cc")
+            .arg("--exe")
+            .arg("--build")
+            .arg("-Wno-fatal")
+            .arg("-Wno-DECLFILENAME")
+            .arg("-Wno-WIDTHTRUNC")
+            .arg("--top-module")
+            .arg("SextConcatHoist")
+            .arg("-Mdir")
+            .arg(&obj_dir)
+            .arg(&sv_out)
+            .arg("tests/icarus_portability/tb_sext_concat_hoist_verilator.cpp")
+            .output()
+            .expect("verilate SextConcatHoist");
+        assert!(
+            verilate.status.success(),
+            "Verilator build should pass\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&verilate.stdout),
+            String::from_utf8_lossy(&verilate.stderr)
+        );
+        let exe = obj_dir.join("VSextConcatHoist");
+        let run = std::process::Command::new(&exe)
+            .output()
+            .expect("run Verilator SextConcatHoist");
+        let stdout = String::from_utf8_lossy(&run.stdout);
+        assert!(
+            run.status.success() && stdout.contains("PASS"),
+            "Verilator sim should confirm sext-concat semantics\nstdout:\n{stdout}\nstderr:\n{}",
+            String::from_utf8_lossy(&run.stderr)
+        );
+    }
+}
+
+/// Dual-simulator behavioral check (arch#827 P4.1 loop-var residual): a
+/// `.sext<N>()` receiver referencing a live runtime `for`-loop iterator
+/// still hoists — via the same arch#861 in-loop declare/assign split the
+/// `ExprKind::Index` codegen arm and `hoist_slice_base` already use — and
+/// still computes the same values as the non-loop cases. This is *not* a
+/// bail-to-bare-emission fallback: the receiver is never emitted
+/// un-hoisted, just placed differently (declaration at the loop top,
+/// assignment in place) because a module-scope temp can't see the
+/// loop-local iterator. Skips gracefully if neither simulator is
+/// installed.
+#[test]
+fn test_sext_loop_var_hoist_behavioral_equivalence_verilator_and_iverilog() {
+    let has_verilator = std::process::Command::new("verilator")
+        .arg("--version")
+        .output()
+        .is_ok();
+    let has_iverilog = std::process::Command::new("iverilog")
+        .arg("-V")
+        .output()
+        .is_ok();
+    if !has_verilator && !has_iverilog {
+        eprintln!(
+            "skipping arch#827 P4.1 sext loop-var hoist dual-sim behavioral check: \
+             neither verilator nor iverilog found"
+        );
+        return;
+    }
+
+    let td = tempfile::tempdir().expect("tempdir");
+    let sv_out = td.path().join("SextLoopVarHoist.sv");
+    let arch_bin = env!("CARGO_BIN_EXE_arch");
+
+    let build = std::process::Command::new(arch_bin)
+        .arg("build")
+        .arg("tests/icarus_portability/SextLoopVarHoist.arch")
+        .arg("-o")
+        .arg(&sv_out)
+        .output()
+        .expect("build SextLoopVarHoist SV");
+    assert!(
+        build.status.success(),
+        "arch build should pass\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&build.stdout),
+        String::from_utf8_lossy(&build.stderr)
+    );
+
+    if has_iverilog {
+        let vvp_out = td.path().join("sext_loop_var.vvp");
+        let compile = std::process::Command::new("iverilog")
+            .arg("-g2012")
+            .arg("-gsupported-assertions")
+            .arg("-s")
+            .arg("tb")
+            .arg("-o")
+            .arg(&vvp_out)
+            .arg(&sv_out)
+            .arg("tests/icarus_portability/tb_sext_loop_var_hoist.sv")
+            .output()
+            .expect("iverilog compile SextLoopVarHoist");
+        assert!(
+            compile.status.success(),
+            "iverilog compile should pass (arch#827 P4.1 loop-var regression)\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&compile.stdout),
+            String::from_utf8_lossy(&compile.stderr)
+        );
+        let run = std::process::Command::new("vvp")
+            .arg(&vvp_out)
+            .output()
+            .expect("run iverilog SextLoopVarHoist");
+        let stdout = String::from_utf8_lossy(&run.stdout);
+        assert!(
+            run.status.success() && stdout.contains("PASS"),
+            "iverilog sim should confirm sext loop-var semantics\nstdout:\n{stdout}\nstderr:\n{}",
+            String::from_utf8_lossy(&run.stderr)
+        );
+    }
+
+    if has_verilator {
+        let obj_dir = td.path().join("obj_dir_sext_loop_var");
+        let verilate = std::process::Command::new("verilator")
+            .arg("--cc")
+            .arg("--exe")
+            .arg("--build")
+            .arg("-Wno-fatal")
+            .arg("-Wno-DECLFILENAME")
+            .arg("-Wno-WIDTHTRUNC")
+            .arg("--top-module")
+            .arg("SextLoopVarHoist")
+            .arg("-Mdir")
+            .arg(&obj_dir)
+            .arg(&sv_out)
+            .arg("tests/icarus_portability/tb_sext_loop_var_hoist_verilator.cpp")
+            .output()
+            .expect("verilate SextLoopVarHoist");
+        assert!(
+            verilate.status.success(),
+            "Verilator build should pass\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&verilate.stdout),
+            String::from_utf8_lossy(&verilate.stderr)
+        );
+        let exe = obj_dir.join("VSextLoopVarHoist");
+        let run = std::process::Command::new(&exe)
+            .output()
+            .expect("run Verilator SextLoopVarHoist");
+        let stdout = String::from_utf8_lossy(&run.stdout);
+        assert!(
+            run.status.success() && stdout.contains("PASS"),
+            "Verilator sim should confirm sext loop-var semantics\nstdout:\n{stdout}\nstderr:\n{}",
+            String::from_utf8_lossy(&run.stderr)
+        );
+    }
+}

--- a/tests/portability_baseline.tsv
+++ b/tests/portability_baseline.tsv
@@ -217,6 +217,8 @@ tests/aes/aes_sbox.arch	iverilog	OK	-
 tests/aes/aes_sbox.arch	verilator	OK	-
 tests/aes/domain.arch	-	NO_MODULE	-
 tests/aes/xtime.arch	-	BUILD_FAIL	Error:   × .trunc<8>() on a 8-bit value is a no-op — remove the cast
+tests/arbiter_custom_policy/CustomRrArb4.arch	iverilog	OK	-
+tests/arbiter_custom_policy/CustomRrArb4.arch	verilator	OK	-
 tests/arbiter_rr_nonpow2/RRArb3.arch	iverilog	OK	-
 tests/arbiter_rr_nonpow2/RRArb3.arch	verilator	OK	-
 tests/assert_cover/counter_check.arch	iverilog	FAIL	SV:20: syntax error
@@ -391,7 +393,7 @@ tests/cam_dual_basic.arch	verilator	OK	-
 tests/cam_lookup.arch	-	BUILD_FAIL	Error:   × 2 errors
 tests/cam_value_basic.arch	iverilog	OK	-
 tests/cam_value_basic.arch	verilator	OK	-
-tests/cvdp/16qam_demapper.arch	iverilog	FAIL	SV:64: error: A reference to a wire or reg (`gi') is not allowed in a constant expression.
+tests/cvdp/16qam_demapper.arch	iverilog	OK	-
 tests/cvdp/16qam_demapper.arch	verilator	OK	-
 tests/cvdp/16qam_mapper.arch	iverilog	FAIL	SV:33: error: A reference to a wire or reg (`j') is not allowed in a constant expression.
 tests/cvdp/16qam_mapper.arch	verilator	OK	-
@@ -702,7 +704,7 @@ tests/cvdp/line_buffer.arch	iverilog	OK	-
 tests/cvdp/line_buffer.arch	verilator	OK	-
 tests/cvdp/load_store_unit.arch	iverilog	OK	-
 tests/cvdp/load_store_unit.arch	verilator	OK	-
-tests/cvdp/low_pass_filter.arch	iverilog	FAIL	SV:63: error: A reference to a wire or reg (`i') is not allowed in a constant expression.
+tests/cvdp/low_pass_filter.arch	iverilog	OK	-
 tests/cvdp/low_pass_filter.arch	verilator	OK	-
 tests/cvdp/lru_counter_policy.arch	iverilog	FAIL	SV:55: error: A reference to a wire or reg (`idx') is not allowed in a constant expression.
 tests/cvdp/lru_counter_policy.arch	verilator	OK	-
@@ -932,7 +934,7 @@ tests/e203/e203_clkgate.arch	iverilog	OK	-
 tests/e203/e203_clkgate.arch	verilator	OK	-
 tests/e203/e203_core.arch	iverilog	OK	-
 tests/e203/e203_core.arch	verilator	OK	-
-tests/e203/e203_core_top.arch	iverilog	FAIL	SV:1175: syntax error
+tests/e203/e203_core_top.arch	iverilog	OK	-
 tests/e203/e203_core_top.arch	verilator	OK	-
 tests/e203/e203_cpu.arch	iverilog	OK	-
 tests/e203/e203_cpu.arch	verilator	OK	-
@@ -948,7 +950,7 @@ tests/e203/e203_dtcm_ram.arch	iverilog	FAIL	SV:36: error: A reference to a wire 
 tests/e203/e203_dtcm_ram.arch	verilator	OK	-
 tests/e203/e203_extend_csr.arch	iverilog	OK	-
 tests/e203/e203_extend_csr.arch	verilator	OK	-
-tests/e203/e203_exu.arch	iverilog	FAIL	SV:443: syntax error
+tests/e203/e203_exu.arch	iverilog	OK	-
 tests/e203/e203_exu.arch	verilator	OK	-
 tests/e203/e203_exu_agu.arch	iverilog	OK	-
 tests/e203/e203_exu_agu.arch	verilator	OK	-
@@ -972,7 +974,7 @@ tests/e203/e203_exu_commit.arch	iverilog	OK	-
 tests/e203/e203_exu_commit.arch	verilator	OK	-
 tests/e203/e203_exu_csr.arch	iverilog	OK	-
 tests/e203/e203_exu_csr.arch	verilator	OK	-
-tests/e203/e203_exu_decode.arch	iverilog	FAIL	SV:443: syntax error
+tests/e203/e203_exu_decode.arch	iverilog	OK	-
 tests/e203/e203_exu_decode.arch	verilator	OK	-
 tests/e203/e203_exu_disp.arch	iverilog	OK	-
 tests/e203/e203_exu_disp.arch	verilator	OK	-
@@ -990,7 +992,7 @@ tests/e203/e203_exu_oitf.arch	iverilog	OK	-
 tests/e203/e203_exu_oitf.arch	verilator	OK	-
 tests/e203/e203_exu_regfile.arch	iverilog	OK	-
 tests/e203/e203_exu_regfile.arch	verilator	OK	-
-tests/e203/e203_exu_top.arch	iverilog	FAIL	SV:443: syntax error
+tests/e203/e203_exu_top.arch	iverilog	OK	-
 tests/e203/e203_exu_top.arch	verilator	OK	-
 tests/e203/e203_exu_wbck.arch	iverilog	OK	-
 tests/e203/e203_exu_wbck.arch	verilator	OK	-
@@ -1002,9 +1004,9 @@ tests/e203/e203_icb2apb.arch	iverilog	OK	-
 tests/e203/e203_icb2apb.arch	verilator	OK	-
 tests/e203/e203_icb_arbt.arch	iverilog	OK	-
 tests/e203/e203_icb_arbt.arch	verilator	OK	-
-tests/e203/e203_ifu.arch	iverilog	FAIL	SV:1015: syntax error
+tests/e203/e203_ifu.arch	iverilog	OK	-
 tests/e203/e203_ifu.arch	verilator	OK	-
-tests/e203/e203_ifu_ifetch.arch	iverilog	FAIL	SV:521: syntax error
+tests/e203/e203_ifu_ifetch.arch	iverilog	OK	-
 tests/e203/e203_ifu_ifetch.arch	verilator	OK	-
 tests/e203/e203_ifu_ift2icb.arch	iverilog	OK	-
 tests/e203/e203_ifu_ift2icb.arch	verilator	OK	-
@@ -1012,9 +1014,9 @@ tests/e203/e203_ifu_litebpu.arch	iverilog	OK	-
 tests/e203/e203_ifu_litebpu.arch	verilator	OK	-
 tests/e203/e203_ifu_litedec.arch	iverilog	OK	-
 tests/e203/e203_ifu_litedec.arch	verilator	OK	-
-tests/e203/e203_ifu_minidec.arch	iverilog	FAIL	SV:443: syntax error
+tests/e203/e203_ifu_minidec.arch	iverilog	OK	-
 tests/e203/e203_ifu_minidec.arch	verilator	OK	-
-tests/e203/e203_ifu_top.arch	iverilog	FAIL	SV:1015: syntax error
+tests/e203/e203_ifu_top.arch	iverilog	OK	-
 tests/e203/e203_ifu_top.arch	verilator	OK	-
 tests/e203/e203_irq_ctrl.arch	iverilog	OK	-
 tests/e203/e203_irq_ctrl.arch	verilator	OK	-
@@ -1035,7 +1037,7 @@ tests/e203/e203_ppi.arch	iverilog	OK	-
 tests/e203/e203_ppi.arch	verilator	OK	-
 tests/e203/e203_reset_ctrl.arch	iverilog	OK	-
 tests/e203/e203_reset_ctrl.arch	verilator	OK	-
-tests/e203/e203_soc_top.arch	iverilog	FAIL	SV:1856: syntax error
+tests/e203/e203_soc_top.arch	iverilog	FAIL	SV:3703: sorry: constant selects in always_* processes are not currently supported (all bits will be included).
 tests/e203/e203_soc_top.arch	verilator	OK	-
 tests/e203/e203_spi.arch	iverilog	OK	-
 tests/e203/e203_spi.arch	verilator	OK	-
@@ -1103,8 +1105,8 @@ tests/fp_v1/E8m0Scale.arch	iverilog	OK	-
 tests/fp_v1/E8m0Scale.arch	verilator	OK	-
 tests/fp_v1/Fp4Convert.arch	iverilog	OK	-
 tests/fp_v1/Fp4Convert.arch	verilator	OK	-
-tests/fp_v1/Fp6Convert.arch	iverilog	FAIL	SV:2716: syntax error
-tests/fp_v1/Fp6Convert.arch	verilator	FAIL	%Error: SV:2716:22: syntax error, unexpected cross
+tests/fp_v1/Fp6Convert.arch	iverilog	FAIL	SV:2727: syntax error
+tests/fp_v1/Fp6Convert.arch	verilator	FAIL	%Error: SV:2727:22: syntax error, unexpected cross
 tests/fp_v1/Fp8Arith.arch	iverilog	OK	-
 tests/fp_v1/Fp8Arith.arch	verilator	OK	-
 tests/fp_v1/Fp8Convert.arch	iverilog	OK	-
@@ -1117,8 +1119,8 @@ tests/fp_v1/FpAcc.arch	iverilog	OK	-
 tests/fp_v1/FpAcc.arch	verilator	OK	-
 tests/fp_v1/FpArith.arch	iverilog	OK	-
 tests/fp_v1/FpArith.arch	verilator	OK	-
-tests/fp_v1/FpBoundErr.arch	iverilog	FAIL	SV:2721: syntax error
-tests/fp_v1/FpBoundErr.arch	verilator	FAIL	%Error: SV:2721:16: syntax error, unexpected STRENGTH keyword (strong1/etc)
+tests/fp_v1/FpBoundErr.arch	iverilog	FAIL	SV:2732: syntax error
+tests/fp_v1/FpBoundErr.arch	verilator	FAIL	%Error: SV:2732:16: syntax error, unexpected STRENGTH keyword (strong1/etc)
 tests/fp_v1/FpBoundErrCancel.arch	iverilog	OK	-
 tests/fp_v1/FpBoundErrCancel.arch	verilator	OK	-
 tests/fp_v1/FpBusMod.arch	iverilog	OK	-
@@ -1127,7 +1129,7 @@ tests/fp_v1/FpComposite.arch	iverilog	OK	-
 tests/fp_v1/FpComposite.arch	verilator	OK	-
 tests/fp_v1/FpFormalBad.arch	iverilog	OK	-
 tests/fp_v1/FpFormalBad.arch	verilator	OK	-
-tests/fp_v1/FpFormalProps.arch	iverilog	FAIL	SV:2741: syntax error
+tests/fp_v1/FpFormalProps.arch	iverilog	FAIL	SV:2752: syntax error
 tests/fp_v1/FpFormalProps.arch	verilator	OK	-
 tests/fp_v1/FpFsm.arch	iverilog	OK	-
 tests/fp_v1/FpFsm.arch	verilator	OK	-
@@ -1174,8 +1176,16 @@ tests/icarus_portability/PipeSliceHoist.arch	iverilog	OK	-
 tests/icarus_portability/PipeSliceHoist.arch	verilator	OK	-
 tests/icarus_portability/SeqSliceHoist.arch	iverilog	OK	-
 tests/icarus_portability/SeqSliceHoist.arch	verilator	OK	-
+tests/icarus_portability/SextConcatHoist.arch	iverilog	OK	-
+tests/icarus_portability/SextConcatHoist.arch	verilator	OK	-
+tests/icarus_portability/SextIndexHoist.arch	iverilog	OK	-
+tests/icarus_portability/SextIndexHoist.arch	verilator	OK	-
+tests/icarus_portability/SextLoopVarHoist.arch	iverilog	OK	-
+tests/icarus_portability/SextLoopVarHoist.arch	verilator	OK	-
 tests/icarus_portability/UniversalSliceHoist.arch	iverilog	OK	-
 tests/icarus_portability/UniversalSliceHoist.arch	verilator	OK	-
+tests/icarus_portability/WidenArithSliceHoist.arch	iverilog	OK	-
+tests/icarus_portability/WidenArithSliceHoist.arch	verilator	OK	-
 tests/if_wait_for_in_then.arch	iverilog	OK	-
 tests/if_wait_for_in_then.arch	verilator	OK	-
 tests/inst_vec_port_regression.arch	iverilog	OK	-


### PR DESCRIPTION
Implements **#827 P4.1** — "apply the existing base-hoist to compiler-synthesized sext/zext replicands".

## The bug

The sign-extension expansion emits its receiver **twice** — once indexed at its own top bit, once whole:

```
{{(W-SW){recv[SW-1]}}, recv}
```

That composes only when `recv` is safe to select into bare. #811 taught the *user-written* slice path to hoist a non-portable base into a temp; the compiler's own sext expansion never learned it, and re-introduced exactly the construct #811 removed.

`arch check` accepts the source, Verilator accepts the output, iverilog 12.0 rejects it:

```arch
y = signed({a, b}).sext<32>();          // B2
dout = din[sel].sext<12>();             // B1
```
```systemverilog
{{(32-12){{a, b}[12-1]}}, {a, b}}       // iverilog: syntax error
{{(12-8){din[sel][8-1]}}, din[sel]}     // iverilog: "not allowed in a constant expression"
```

## The fix

Bind a non-atomic receiver to a hoist temp first — the same "bind to a `let`" treatment `hoist_slice_base` already applies to a non-portable `BitSlice`/`PartSelect` base — then replicate the temp's sign bit.

`is_atomic_sext_receiver` documents which bases stay bare, and why this can't just reuse `is_bare_selectable_slice_base`/`is_atomic_index_base`: both classify a bare `Index` as safe (wrong here — iverilog rejects `din[sel][7]` and `din[sel][7:4]` identically), and both are reached from far beyond synthesized sext, so widening them is a separate, wider-blast-radius fix. A user writing `din[sel][7]` directly hits the same bug today; noted as a follow-up rather than folded in.

### The `LatencyAt` case cuts the other way

A `pipe_reg` `@N` read is **atomic and must not hoist**. It renders to a bare name, so hoisting sizes the temp `$bits(<bare name>)` — and `logic [$bits(x)-1:0] t;` **segfaults iverilog 12.0 outright** (exit 139), reproducible with no sext or `pipe_reg` involved:

```systemverilog
module m(input logic [15:0] x, output logic [15:0] y);
  logic [$bits(x)-1:0] t;   // iverilog 12.0: Segmentation fault
  assign t = x; assign y = t;
endmodule
```

An Icarus declaration-width bug, not a sext bug — but the pre-fix code never hit it because it never hoisted `LatencyAt` at all. Caught by `tests/cvdp/iir_filter.arch` (`x_pipe@1.sext<48>()`), which was `OK` in the baseline and **stays** `OK`.

## Scope

Internal codegen only — **no user-facing syntax or semantics change**. Rebased on #897, whose widened-width fix this composes with correctly: `sw` flows through `infer_sv_width_str`, so an arithmetic sext receiver gets the correctly widened temp.

## Verification

**Portability sweep** (920 files across `tests` + `examples`, 1720 rows, iverilog 12.0 + Verilator 5.048):

```
SUMMARY  regressions=0  improvements=10  changed=0  skipped=0
```

All 10 improvements are `iverilog FAIL -> OK`, each with a matching B1/B2 baseline signature:

| Design | Baseline error |
|---|---|
| `cvdp/16qam_demapper` | `` reference to a wire or reg (`gi') `` |
| `cvdp/low_pass_filter` | `` reference to a wire or reg (`i') `` |
| `e203/e203_core_top` | `SV:1175: syntax error` |
| `e203/e203_exu` | `SV:443: syntax error` |
| `e203/e203_exu_decode` | `SV:443: syntax error` |
| `e203/e203_exu_top` | `SV:443: syntax error` |
| `e203/e203_ifu` | `SV:1015: syntax error` |
| `e203/e203_ifu_ifetch` | `SV:521: syntax error` |
| `e203/e203_ifu_minidec` | `SV:443: syntax error` |
| `e203/e203_ifu_top` | `SV:1015: syntax error` |

Baseline re-blessed after reviewing every line; a follow-up verification sweep reports **no drift** (exit 0).

Two non-gated diffs, both explained and neither a regression (the verdict diff compares column 3 only):
* `e203_soc_top` stays `FAIL`, but its first error moves from `SV:1856: syntax error` (the B2 class, now fixed) to `SV:3703: sorry: constant selects in always_* processes` — a genuine Icarus limitation (#827 class D). Fixing the earlier error exposed the later one.
* `fp_v1/{Fp6Convert, FpBoundErr, FpFormalProps}` shift +11 SV lines from the added hoist declarations; same pre-existing class-C errors.

> **Note on scale:** #827 estimated this class at 22 designs. The measured delta against the *current* baseline is **10** — the baseline has moved since that issue was written, and some designs in the original count still fail for unrelated reasons (the class-C user-assertion gap). Reporting the measurement, not the estimate.

**Tests:** `cargo test` green across 22 suites, including 3 new dual-sim fixtures under `tests/icarus_portability/` (index, concat, loop-var) verified **iverilog == Verilator**, plus shape assertions covering the hoist/no-hoist split including the `LatencyAt` case.

Two `construct_proof_lean_*` failures are **pre-existing and unrelated** — they fail identically on unmodified `origin/main` (local Lean replay exits 1), verified against a clean baseline worktree.

Also filed #923: blessing from a long `--out-dir` can leak a machine-specific absolute path into the baseline (`arch`'s error renderer wraps at ~80 cols, truncating the path before the `/corpus/` segment the sanitizer matches on). Worked around here by blessing from a short out-dir.

Part of #827.