### PR TITLE
refactor(codegen): remove dead push_hoist_temp wrapper

### DIFF
--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -6920,12 +6920,9 @@ impl<'a> Codegen<'a> {
     /// `index_hoist_temps` / `HoistScope`). Pushed in generation order,
     /// which is also dependency order: a nested hoist is created while the
     /// outer hoist's RHS is being emitted, so it lands ahead of it.
-    fn push_hoist_temp(&self, width: String, name: String, rhs: String) {
-        self.push_hoist_temp_in_loop(width, name, rhs, false);
-    }
-
-    /// `push_hoist_temp` for a temp whose RHS references a live runtime
-    /// `for`-loop iterator — see `HoistTemp::in_loop` (arch#861).
+    ///
+    /// `in_loop` flags a temp whose RHS references a live runtime `for`-loop
+    /// iterator — see `HoistTemp::in_loop` (arch#861).
     fn push_hoist_temp_in_loop(&self, width: String, name: String, rhs: String, in_loop: bool) {
         self.index_hoist_temps.borrow_mut().push(HoistTemp {
             width,


### PR DESCRIPTION
## What

Removes the unused `push_hoist_temp` wrapper in `src/codegen/mod.rs`.

## Why

The non-loop `push_hoist_temp(width, name, rhs)` wrapper simply forwarded
to `push_hoist_temp_in_loop(width, name, rhs, false)`. Once all four call
sites moved to `push_hoist_temp_in_loop` directly (during the arch#861
loop-var-dependent slice-base hoist work), the wrapper had zero callers and
has produced a `method \`push_hoist_temp\` is never used` warning on every
`cargo build --release` since.

```
warning: method `push_hoist_temp` is never used
    --> src/codegen/mod.rs:6923:8
```

## Change

- Delete the 4-line wrapper.
- Fold its "in generation/dependency order" doc comment into the surviving
  `push_hoist_temp_in_loop`, and inline the `in_loop` note that the wrapper's
  comment used to carry.

Pure dead-code removal — cannot change any emitted output.

## Verification

- `cargo build --release` — clean, warning gone, no new warnings.
- `cargo test --release --test integration_test hoist` — 29 passed, 0 failed,
  including all slice-hoist behavioral-equivalence tests (Verilator + iverilog).

Found during the 2026-08-12 automated daily code-review sweep.