### PR TITLE
feat(inst): add `auto;` auto-connect directive

### DIFF
--- a/doc/ARCH_HDL_Specification.md
+++ b/doc/ARCH_HDL_Specification.md
@@ -2049,6 +2049,26 @@ The compiler validates that the default value fits within the declared range. Co
 >
 > ◈ **Port group member syntax.** For constructs with named port groups (e.g. `regfile` with `ports[N] read`), connections use dot notation: `write.en <- wr_en;` (flattened to `write_en`). For indexed port groups, use bracket-dot notation: `read[0].addr <- sel;` (flattened to `read0_addr`). The index must be an integer literal. Both forms are resolved at parse time --- the rest of the compiler sees only the flattened name.
 >
+> ◈ **`auto;` --- auto-connect by name.** A single `auto;` line inside an `inst` body connects every child port that the explicit connections left unconnected to the **identically-named** signal in the enclosing scope. Explicit connections always win, wherever they appear relative to the directive:
+>
+> ```
+> inst alu0: Alu
+>   a <- Decode.rs1_fwd;    // explicit where the names differ
+>   b <- Decode.rs2_val;
+>   auto;                   // clk <- clk, rst <- rst, en <- en, result -> result, ...
+> end inst alu0
+> ```
+>
+> `auto;` is a **front-end desugar**: elaboration rewrites it into ordinary connections before every later pass, so emitted SystemVerilog, simulation, and formal output are byte-identical to the hand-written connection list. Run `arch check --explain-auto` (also on `build` / `sim` / `formal`) to print exactly what each directive expanded to.
+>
+> **What it fills:** ordinary ports (including `Clock`, `Reset`, `Vec`, struct and enum types), whole `bus` ports (`initiator` / `target`, including `Vec<Bus, N>`), and `ports[N]` groups by their flattened names (`read0_addr`, and `write_en` for a literal count-1 group).
+>
+> **In scope** are the enclosing construct's ports, its `reg` / `wire` / `let` / `pipe_reg` declarations, the flattened fields of its bus ports and bus wires, and the targets of *explicit* inst output connections. Names created by another inst's `auto;` are deliberately **not** in scope, so expansion never depends on inst order.
+>
+> **Both safety invariants are preserved, not weakened.** A port with no identically-named signal in scope is a compile error (*"auto-connect: no signal \`a\` in scope for input port \`a\` of \`Alu\` in inst \`u0\`"*) --- `auto;` never leaves a port dangling, and never silently declares a new net. And before each fill the port type is compared against the declared signal type: a definite mismatch --- differing width, signedness, `Vec` length, reset kind or polarity, clock domain, or named type --- is an error naming both sides, with the `rst <- rst as Reset<Async, Low>` override suggested for the reset case. The comparison is deliberately conservative: when a width stays param-dependent, or the name comes from an inst-output wire with no declaration, `auto;` defers to the ordinary connection checks rather than inventing a type rule.
+>
+> `auto` is a **contextual** keyword recognized only as a complete `auto;` statement inside an inst body --- it remains a legal identifier everywhere else, so a port genuinely named `auto` still connects as `auto <- en;`. Two `auto;` lines in one inst body, or an `auto;` inside an inst-body `for` loop, are compile errors.
+>
 > ◈ **Whole-bus connections.** When an inst's bus port connects to a parent bus port (or wire), a single connection expands to all signals in the bus definition: `axi_rd -> m_axi_mm2s;` expands to `axi_rd_ar_valid -> m_axi_mm2s_ar_valid`, etc. Signal directions are derived from the bus definition and the port's perspective (`initiator` or `target`). This works for both `module` and `fsm` constructs.
 >
 > ◈ **Prototype TLM connect sugar.** For early design-phase TLM binding, a module may write `connect cpu.mem -> ram.mem;` after both instances are declared. The left endpoint must be an instantiated `initiator` bus port and each right endpoint an instantiated `target` bus port of the same bus type. Elaboration creates private bus wires and appends ordinary whole-bus inst connections, so generated SV remains the same flattened req/rsp signal protocol. `connect` is legal at module scope and inside `generate_for` / `generate_if`; generated suffix names are expanded first (`connect src_i.m -> dst_i.s;` becomes independent `src_0.m -> dst_0.s`, `src_1.m -> dst_1.s`, ... links). Blocking TLM buses also support one-initiator-to-many-target address decode by repeating ordinary connect statements and overriding each target instance's address-map params:

--- a/doc/Arch_AI_Reference_Card.md
+++ b/doc/Arch_AI_Reference_Card.md
@@ -474,8 +474,11 @@ inst u: Name
   read[0].addr <- sel;       // indexed: read[0].addr → read0_addr
   read[1].data -> out_b;     // index must be integer literal
   axi_rd   -> m_axi_mm2s;   // whole-bus connection (expands per-signal)
+  auto;                     // fill every REMAINING port from the same-named signal
 end inst u
 ```
+
+**`auto;`** connects each still-unconnected child port to the identically-named in-scope signal (ports, `reg`/`wire`/`let`/`pipe_reg`, flattened bus fields, `ports[N]` groups, whole buses). Explicit connections always win, wherever they sit relative to the directive. It is a pure desugar — the emitted SV is identical to writing the lines by hand; `--explain-auto` prints the expansion. **No name match is an error** (never a dangling port, never a silently-created net), and a definite type mismatch — width, signedness, `Vec` length, reset kind/polarity, clock domain — is an error too; param-dependent widths defer to the normal checks. `auto` stays a legal identifier: only a bare `auto;` inside an inst body is the directive.
 
 Hierarchical refs **FORBIDDEN**: `inst_name.port` is a compile error. Connect outputs with `-> wire` and use `wire` in enclosing scope.
 

--- a/examples/auto_connect.arch
+++ b/examples/auto_connect.arch
@@ -1,0 +1,92 @@
+//! ---
+//! tags: [inst, auto-connect, hierarchy, tutorial]
+//! ---
+//!
+//! `auto;` — auto-connect by name inside an `inst` body.
+//!
+//! A single `auto;` line wires every child port the explicit connections
+//! left unconnected to the identically-named signal in scope. Explicit
+//! connections always win, wherever they sit relative to the directive.
+//!
+//! This is the shape `auto;` exists for: two sub-instances whose `clk`,
+//! `rst` and `en` plumbing is pure boilerplate, and exactly one connection
+//! per instance that actually carries design intent (`din <- ...`). Without
+//! the directive, `Top` would spell out 8 connections instead of 2.
+//!
+//! `auto;` is a front-end desugar — the emitted SystemVerilog is identical
+//! to writing every connection by hand. Run `arch build --explain-auto` to
+//! print what each directive expanded to.
+
+/// 100 MHz system clock domain (single-clock design).
+domain SysDomain
+  freq_mhz: 100
+end domain SysDomain
+
+/// Running 8-bit accumulator: `sum += din` while `en` is high.
+module Accum
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port en: in Bool;
+  port din: in UInt<8>;
+  port sum: out UInt<8>;
+
+  reg acc: UInt<8> reset rst => 0;
+
+  seq on clk rising
+    if en
+      acc <= acc +% din;
+    end if
+  end seq
+
+  comb
+    sum = acc;
+  end comb
+end module Accum
+
+/// Registers `din` doubled (wrapping), one cycle behind, while `en` is high.
+module Doubler
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port en: in Bool;
+  port din: in UInt<8>;
+  port dbl: out UInt<8>;
+
+  reg r: UInt<8> reset rst => 0;
+
+  seq on clk rising
+    if en
+      r <= din +% din;
+    end if
+  end seq
+
+  comb
+    dbl = r;
+  end comb
+end module Doubler
+
+/// Feeds one input to both leaves and exposes both results.
+///
+/// Every connection below is either name-identical (filled by `auto;`) or
+/// written out because the names genuinely differ.
+module AutoConnectTop
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port en: in Bool;
+  port sample: in UInt<8>;
+  port sum: out UInt<8>;
+  port dbl: out UInt<8>;
+
+  // `din` differs from the parent's `sample`, so it stays explicit; `clk`,
+  // `rst`, `en` and `sum` are name-identical and `auto;` fills them.
+  inst acc0: Accum
+    din <- sample;
+    auto;
+  end inst acc0
+
+  // Same shape for the second leaf — the directive is order-independent, so
+  // it can sit before the explicit line just as well.
+  inst dbl0: Doubler
+    auto;
+    din <- sample;
+  end inst dbl0
+end module AutoConnectTop

--- a/examples/auto_connect.sv
+++ b/examples/auto_connect.sv
@@ -1,0 +1,102 @@
+//! ---
+//! tags: [inst, auto-connect, hierarchy, tutorial]
+//! ---
+//!
+//! `auto;` — auto-connect by name inside an `inst` body.
+//!
+//! A single `auto;` line wires every child port the explicit connections
+//! left unconnected to the identically-named signal in scope. Explicit
+//! connections always win, wherever they sit relative to the directive.
+//!
+//! This is the shape `auto;` exists for: two sub-instances whose `clk`,
+//! `rst` and `en` plumbing is pure boilerplate, and exactly one connection
+//! per instance that actually carries design intent (`din <- ...`). Without
+//! the directive, `Top` would spell out 8 connections instead of 2.
+//!
+//! `auto;` is a front-end desugar — the emitted SystemVerilog is identical
+//! to writing every connection by hand. Run `arch build --explain-auto` to
+//! print what each directive expanded to.
+/// 100 MHz system clock domain (single-clock design).
+// domain SysDomain
+//   freq_mhz: 100
+
+/// Running 8-bit accumulator: `sum += din` while `en` is high.
+module Accum (
+  input logic clk,
+  input logic rst,
+  input logic en,
+  input logic [7:0] din,
+  output logic [7:0] sum
+);
+
+  logic [7:0] acc;
+  always_ff @(posedge clk) begin
+    if (rst) begin
+      acc <= 0;
+    end else begin
+      if (en) begin
+        acc <= 8'(acc + din);
+      end
+    end
+  end
+  assign sum = acc;
+
+endmodule
+
+/// Registers `din` doubled (wrapping), one cycle behind, while `en` is high.
+module Doubler (
+  input logic clk,
+  input logic rst,
+  input logic en,
+  input logic [7:0] din,
+  output logic [7:0] dbl
+);
+
+  logic [7:0] r;
+  always_ff @(posedge clk) begin
+    if (rst) begin
+      r <= 0;
+    end else begin
+      if (en) begin
+        r <= 8'(din + din);
+      end
+    end
+  end
+  assign dbl = r;
+
+endmodule
+
+/// Feeds one input to both leaves and exposes both results.
+///
+/// Every connection below is either name-identical (filled by `auto;`) or
+/// written out because the names genuinely differ.
+module AutoConnectTop (
+  input logic clk,
+  input logic rst,
+  input logic en,
+  input logic [7:0] sample,
+  output logic [7:0] sum,
+  output logic [7:0] dbl
+);
+
+  // `din` differs from the parent's `sample`, so it stays explicit; `clk`,
+  // `rst`, `en` and `sum` are name-identical and `auto;` fills them.
+  Accum acc0 (
+    .din(sample),
+    .clk(clk),
+    .rst(rst),
+    .en(en),
+    .sum(sum)
+  );
+  // Same shape for the second leaf — the directive is order-independent, so
+  // it can sit before the explicit line just as well.
+  Doubler dbl0 (
+    .din(sample),
+    .clk(clk),
+    .rst(rst),
+    .en(en),
+    .dbl(dbl)
+  );
+
+endmodule
+

--- a/examples/auto_connect_tb.cpp
+++ b/examples/auto_connect_tb.cpp
@@ -1,0 +1,112 @@
+// Testbench for examples/auto_connect.arch — the `auto;` auto-connect
+// directive.
+//
+// `auto;` is a front-end desugar, so the interesting property is not that
+// the design simulates but that it simulates *exactly as if every
+// connection had been written by hand*. This tb pins the behaviour that
+// only correct clk/rst/en/output wiring can produce:
+//
+//   - reset drives both leaves to 0            (rst reached both instances)
+//   - with en=0 nothing moves                  (en reached both instances)
+//   - with en=1 the accumulator sums samples   (din/sum wired, clk ticking)
+//   - the doubler tracks 2*sample one cycle late
+//
+// A mis-filled or missing auto-connection shows up here as a stuck or
+// wrong output rather than a compile error.
+
+#include "VAutoConnectTop.h"
+#include "verilated.h"
+#include <cstdio>
+
+int main(int argc, char** argv) {
+    Verilated::commandArgs(argc, argv);
+    VAutoConnectTop* dut = new VAutoConnectTop;
+
+    int errors = 0;
+
+    auto tick = [&]() {
+        dut->clk = 0; dut->eval();
+        dut->clk = 1; dut->eval();
+    };
+
+    // ── Reset ────────────────────────────────────────────────────────────
+    // Only reaches the leaves if `auto;` filled `rst` on both instances.
+    dut->clk = 0;
+    dut->rst = 1;
+    dut->en = 0;
+    dut->sample = 0;
+    dut->eval();
+    tick(); tick();
+    dut->rst = 0;
+
+    if (dut->sum != 0 || dut->dbl != 0) {
+        printf("FAIL: after reset expected sum=0 dbl=0, got sum=%d dbl=%d\n",
+               (int)dut->sum, (int)dut->dbl);
+        errors++;
+    } else {
+        printf("PASS: reset reached both auto-connected instances\n");
+    }
+
+    // ── en = 0 holds ─────────────────────────────────────────────────────
+    // Only holds if `auto;` filled `en` on both instances; a dangling `en`
+    // would float/optimise to a constant and let the regs move.
+    dut->sample = 7;
+    dut->en = 0;
+    tick(); tick(); tick();
+    if (dut->sum != 0 || dut->dbl != 0) {
+        printf("FAIL: en=0 should hold, got sum=%d dbl=%d\n",
+               (int)dut->sum, (int)dut->dbl);
+        errors++;
+    } else {
+        printf("PASS: en=0 holds both instances\n");
+    }
+
+    // ── Accumulate ───────────────────────────────────────────────────────
+    // sum must track the running total of `sample`, and dbl must track
+    // 2*sample delayed by one cycle.
+    dut->en = 1;
+    int expect_sum = 0;
+    const int samples[] = {7, 3, 10, 200, 100};
+    int prev_sample = 7;   // value present when en went high
+
+    for (int i = 0; i < 5; i++) {
+        dut->sample = samples[i];
+        dut->eval();
+        tick();
+
+        expect_sum = (expect_sum + samples[i]) & 0xFF;
+        int expect_dbl = (samples[i] + samples[i]) & 0xFF;
+        (void)prev_sample;
+
+        if ((int)dut->sum != expect_sum) {
+            printf("FAIL: step %d: sum got %d, expected %d\n",
+                   i, (int)dut->sum, expect_sum);
+            errors++;
+        }
+        if ((int)dut->dbl != expect_dbl) {
+            printf("FAIL: step %d: dbl got %d, expected %d\n",
+                   i, (int)dut->dbl, expect_dbl);
+            errors++;
+        }
+        prev_sample = samples[i];
+    }
+    if (errors == 0) {
+        printf("PASS: accumulate + double through auto-connected ports\n");
+    }
+
+    // ── Wrapping is preserved ────────────────────────────────────────────
+    // 8-bit wrapping add: the sum above already crossed 255 (7+3+10+200+100
+    // = 320 -> 64), so a width-mismatched auto-connection would have shown
+    // up as a different value in the loop.
+    if (expect_sum != 64) {
+        printf("FAIL: tb self-check: expected wrapped sum 64, computed %d\n",
+               expect_sum);
+        errors++;
+    }
+
+    dut->final();
+    delete dut;
+
+    if (errors == 0) { printf("\nALL TESTS PASSED\n"); return 0; }
+    else             { printf("\n%d TESTS FAILED\n", errors); return 1; }
+}

--- a/skills/arch-programming/references/ARCH_HDL_Specification.md
+++ b/skills/arch-programming/references/ARCH_HDL_Specification.md
@@ -2049,6 +2049,26 @@ The compiler validates that the default value fits within the declared range. Co
 >
 > ◈ **Port group member syntax.** For constructs with named port groups (e.g. `regfile` with `ports[N] read`), connections use dot notation: `write.en <- wr_en;` (flattened to `write_en`). For indexed port groups, use bracket-dot notation: `read[0].addr <- sel;` (flattened to `read0_addr`). The index must be an integer literal. Both forms are resolved at parse time --- the rest of the compiler sees only the flattened name.
 >
+> ◈ **`auto;` --- auto-connect by name.** A single `auto;` line inside an `inst` body connects every child port that the explicit connections left unconnected to the **identically-named** signal in the enclosing scope. Explicit connections always win, wherever they appear relative to the directive:
+>
+> ```
+> inst alu0: Alu
+>   a <- Decode.rs1_fwd;    // explicit where the names differ
+>   b <- Decode.rs2_val;
+>   auto;                   // clk <- clk, rst <- rst, en <- en, result -> result, ...
+> end inst alu0
+> ```
+>
+> `auto;` is a **front-end desugar**: elaboration rewrites it into ordinary connections before every later pass, so emitted SystemVerilog, simulation, and formal output are byte-identical to the hand-written connection list. Run `arch check --explain-auto` (also on `build` / `sim` / `formal`) to print exactly what each directive expanded to.
+>
+> **What it fills:** ordinary ports (including `Clock`, `Reset`, `Vec`, struct and enum types), whole `bus` ports (`initiator` / `target`, including `Vec<Bus, N>`), and `ports[N]` groups by their flattened names (`read0_addr`, and `write_en` for a literal count-1 group).
+>
+> **In scope** are the enclosing construct's ports, its `reg` / `wire` / `let` / `pipe_reg` declarations, the flattened fields of its bus ports and bus wires, and the targets of *explicit* inst output connections. Names created by another inst's `auto;` are deliberately **not** in scope, so expansion never depends on inst order.
+>
+> **Both safety invariants are preserved, not weakened.** A port with no identically-named signal in scope is a compile error (*"auto-connect: no signal \`a\` in scope for input port \`a\` of \`Alu\` in inst \`u0\`"*) --- `auto;` never leaves a port dangling, and never silently declares a new net. And before each fill the port type is compared against the declared signal type: a definite mismatch --- differing width, signedness, `Vec` length, reset kind or polarity, clock domain, or named type --- is an error naming both sides, with the `rst <- rst as Reset<Async, Low>` override suggested for the reset case. The comparison is deliberately conservative: when a width stays param-dependent, or the name comes from an inst-output wire with no declaration, `auto;` defers to the ordinary connection checks rather than inventing a type rule.
+>
+> `auto` is a **contextual** keyword recognized only as a complete `auto;` statement inside an inst body --- it remains a legal identifier everywhere else, so a port genuinely named `auto` still connects as `auto <- en;`. Two `auto;` lines in one inst body, or an `auto;` inside an inst-body `for` loop, are compile errors.
+>
 > ◈ **Whole-bus connections.** When an inst's bus port connects to a parent bus port (or wire), a single connection expands to all signals in the bus definition: `axi_rd -> m_axi_mm2s;` expands to `axi_rd_ar_valid -> m_axi_mm2s_ar_valid`, etc. Signal directions are derived from the bus definition and the port's perspective (`initiator` or `target`). This works for both `module` and `fsm` constructs.
 >
 > ◈ **Prototype TLM connect sugar.** For early design-phase TLM binding, a module may write `connect cpu.mem -> ram.mem;` after both instances are declared. The left endpoint must be an instantiated `initiator` bus port and each right endpoint an instantiated `target` bus port of the same bus type. Elaboration creates private bus wires and appends ordinary whole-bus inst connections, so generated SV remains the same flattened req/rsp signal protocol. `connect` is legal at module scope and inside `generate_for` / `generate_if`; generated suffix names are expanded first (`connect src_i.m -> dst_i.s;` becomes independent `src_0.m -> dst_0.s`, `src_1.m -> dst_1.s`, ... links). Blocking TLM buses also support one-initiator-to-many-target address decode by repeating ordinary connect statements and overriding each target instance's address-map params:

--- a/skills/arch-programming/references/Arch_AI_Reference_Card.md
+++ b/skills/arch-programming/references/Arch_AI_Reference_Card.md
@@ -474,8 +474,11 @@ inst u: Name
   read[0].addr <- sel;       // indexed: read[0].addr → read0_addr
   read[1].data -> out_b;     // index must be integer literal
   axi_rd   -> m_axi_mm2s;   // whole-bus connection (expands per-signal)
+  auto;                     // fill every REMAINING port from the same-named signal
 end inst u
 ```
+
+**`auto;`** connects each still-unconnected child port to the identically-named in-scope signal (ports, `reg`/`wire`/`let`/`pipe_reg`, flattened bus fields, `ports[N]` groups, whole buses). Explicit connections always win, wherever they sit relative to the directive. It is a pure desugar — the emitted SV is identical to writing the lines by hand; `--explain-auto` prints the expansion. **No name match is an error** (never a dangling port, never a silently-created net), and a definite type mismatch — width, signedness, `Vec` length, reset kind/polarity, clock domain — is an error too; param-dependent widths defer to the normal checks. `auto` stays a legal identifier: only a bare `auto;` inside an inst body is the directive.
 
 Hierarchical refs **FORBIDDEN**: `inst_name.port` is a compile error. Connect outputs with `-> wire` and use `wire` in enclosing scope.
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -945,6 +945,14 @@ pub struct InstDecl {
     /// `flatten_inst_for_loops` runs, this is empty and downstream
     /// passes see only `connections`.
     pub for_loops: Vec<InstForLoop>,
+    /// Span of an `auto;` directive in the inst body (`None` when absent).
+    /// `auto;` fills every child port left unconnected by the explicit
+    /// connections with the identically-named parent-scope signal. The
+    /// `elaborate::auto_connect` pass expands it into ordinary
+    /// `Connection`s right after `elaborate()`, so every downstream pass
+    /// (resolve, typecheck, all three backends) sees a fully explicit
+    /// connection set and this field is inert.
+    pub auto_connect: Option<Span>,
     pub span: Span,
 }
 
@@ -1521,6 +1529,87 @@ impl Ident {
 impl Item {
     pub fn span(&self) -> Span {
         self.as_construct().span()
+    }
+
+    /// The construct's declared `port` list, or `&[]` for items that have no
+    /// port boundary (`domain`, `struct`, `enum`, `function`, `bus`,
+    /// `package`, `use`, `extern package`).
+    ///
+    /// Note this is the *`port`-declaration* list only: `regfile` / `arbiter`
+    /// / `template` also expose `ports[N] <group>` arrays, which live in
+    /// separate fields and are reachable via [`Item::port_arrays`].
+    pub fn ports(&self) -> &[PortDecl] {
+        match self {
+            // Own `ports` field.
+            Item::Module(m) => &m.ports,
+            Item::Synchronizer(s) => &s.ports,
+            Item::Clkgate(c) => &c.ports,
+            Item::Template(t) => &t.ports,
+            // `ports` via `Deref<Target = ConstructCommon>`.
+            Item::Fsm(f) => &f.ports,
+            Item::Fifo(f) => &f.ports,
+            Item::Ram(r) => &r.ports,
+            Item::Cam(c) => &c.ports,
+            Item::Counter(c) => &c.ports,
+            Item::Arbiter(a) => &a.ports,
+            Item::Regfile(r) => &r.ports,
+            Item::Pipeline(p) => &p.ports,
+            Item::Linklist(l) => &l.ports,
+            Item::Domain(_)
+            | Item::Struct(_)
+            | Item::Enum(_)
+            | Item::Function(_)
+            | Item::Bus(_)
+            | Item::Package(_)
+            | Item::Use(_)
+            | Item::ExternPackage(_) => &[],
+        }
+    }
+
+    /// The construct's declared `param` list, or `&[]` for items that carry
+    /// no params (`domain`, `struct`, `enum`, `function`, `use`, `extern
+    /// package`).
+    pub fn params(&self) -> &[ParamDecl] {
+        match self {
+            Item::Module(m) => &m.params,
+            Item::Fsm(f) => &f.params,
+            Item::Fifo(f) => &f.params,
+            Item::Ram(r) => &r.params,
+            Item::Cam(c) => &c.params,
+            Item::Counter(c) => &c.params,
+            Item::Arbiter(a) => &a.params,
+            Item::Regfile(r) => &r.params,
+            Item::Pipeline(p) => &p.params,
+            Item::Linklist(l) => &l.params,
+            Item::Bus(b) => &b.params,
+            Item::Synchronizer(s) => &s.params,
+            Item::Clkgate(c) => &c.params,
+            Item::Template(t) => &t.params,
+            Item::Package(p) => &p.params,
+            Item::Domain(_)
+            | Item::Struct(_)
+            | Item::Enum(_)
+            | Item::Function(_)
+            | Item::Use(_)
+            | Item::ExternPackage(_) => &[],
+        }
+    }
+
+    /// The construct's `ports[N] <group> ... end ports <group>` arrays.
+    /// Only `regfile` (read/write groups), `arbiter` and `template` have
+    /// them; every other item returns an empty vec.
+    ///
+    /// Connections to these groups are flattened at parse time to
+    /// `<group><i>_<signal>` (or `<group>_<signal>` for a literal count-1
+    /// group — see `elaborate::normalize_count1_portarray_conns`), so the
+    /// rest of the compiler only ever sees the flat names.
+    pub fn port_arrays(&self) -> Vec<&PortArrayDecl> {
+        match self {
+            Item::Regfile(r) => r.read_ports.iter().chain(r.write_ports.iter()).collect(),
+            Item::Arbiter(a) => a.port_arrays.iter().collect(),
+            Item::Template(t) => t.port_arrays.iter().collect(),
+            _ => Vec::new(),
+        }
     }
 
     /// Centralized accessor that converts an `Item` to its trait object —

--- a/src/elaborate/auto_connect.rs
+++ b/src/elaborate/auto_connect.rs
@@ -1,0 +1,832 @@
+//! `auto;` expansion — the auto-connect directive inside `inst` bodies.
+//!
+//! `auto;` fills every child port that the explicit connections left
+//! unconnected with the identically-named signal from the enclosing scope.
+//! It is a **pure front-end desugar**: this pass rewrites each `auto;` into
+//! ordinary [`Connection`]s, so resolve, typecheck, and all three backends
+//! (SV, sim, formal) see exactly what a hand-written inst body would have
+//! produced. Nothing downstream knows `auto;` exists.
+//!
+//! Where it runs
+//! -------------
+//! Immediately after [`crate::elaborate::elaborate`] and before the TLM /
+//! thread lowerings. That point matters:
+//!
+//! - inst-body `for` loops are already flattened into `connections`, and
+//!   `generate` blocks are expanded, so the explicit connection set is final;
+//! - `lower_tlm_connects` (the `connect a.m -> b.s;` sugar) has already
+//!   appended its whole-bus connections, so `auto;` correctly treats those
+//!   ports as connected;
+//! - module variants are monomorphized, so child param defaults are literals
+//!   and the type gate below can actually resolve widths.
+//!
+//! What it fills
+//! -------------
+//! | child port | synthesized connection |
+//! |---|---|
+//! | `in T` / `out T` (incl. `Clock`, `Reset`, `Vec`, struct, enum) | `p <- p` / `p -> p` |
+//! | `initiator`/`target` bus, incl. `Vec<Bus, N>` | whole-bus `p -> p` (`ConnectDir::Output`, the shape `lower_tlm_connects` uses; per-signal directions come from the bus decl at expansion) |
+//! | `ports[N] <g>` arrays (regfile / arbiter / template) | one connection per flattened `<g><i>_<sig>` name |
+//!
+//! Safety
+//! ------
+//! Two invariants are preserved, not weakened:
+//!
+//! 1. **All ports connected.** A port with no identically-named signal in
+//!    scope is an error — `auto;` never silently leaves a port dangling.
+//! 2. **No implicit conversion.** Before synthesizing, the child port type
+//!    and the parent declaration type are compared structurally; a definite
+//!    mismatch (differing width, signedness, `Vec` length, reset kind or
+//!    polarity, clock domain, named type) is an error naming both sides.
+//!    Comparison is deliberately conservative: when either side stays
+//!    param-dependent, or the parent name comes from an inst-output wire
+//!    with no declaration, the pass defers to the ordinary connection checks
+//!    rather than inventing a new type rule here.
+
+use std::collections::{HashMap, HashSet};
+
+use crate::ast::*;
+use crate::diagnostics::{CompileError, CompileWarning};
+use crate::lexer::Span;
+use crate::resolve::BusInfo;
+
+use super::try_eval_i64;
+
+/// One expanded `auto;` site, for `--explain-auto`.
+pub struct AutoConnectNote {
+    pub inst_name: String,
+    pub module_name: String,
+    /// Rendered connections in synthesis order (`"clk <- clk"`).
+    pub conns: Vec<String>,
+}
+
+/// A child construct's connectable surface.
+struct ChildInfo {
+    ports: Vec<PortDecl>,
+    port_arrays: Vec<PortArrayDecl>,
+    params: Vec<ParamDecl>,
+}
+
+/// A bus-shaped declaration in the parent scope (port or wire).
+#[derive(Clone)]
+struct BusShape {
+    bus_name: String,
+    /// `Vec<Bus, N>` element count; `None` for a scalar bus.
+    count: Option<Expr>,
+}
+
+/// One name visible in the enclosing scope.
+#[derive(Clone, Default)]
+struct ScopeEntry {
+    /// Declared type, when there is one. `None` means the name exists but
+    /// its type is unknown here (an inst-output wire that codegen
+    /// auto-declares), which disables the type gate for that name.
+    ty: Option<TypeExpr>,
+    bus: Option<BusShape>,
+}
+
+/// Expand every `auto;` in the file.
+///
+/// `best_effort` (used by the `arch graph` path, which runs on an
+/// un-elaborated AST) downgrades every diagnostic to "skip this port": the
+/// graph shows the connections it can resolve rather than failing the
+/// command. The compile pipeline always passes `false`.
+pub fn expand_auto_connect(
+    mut ast: SourceFile,
+    best_effort: bool,
+) -> Result<(SourceFile, Vec<AutoConnectNote>, Vec<CompileWarning>), Vec<CompileError>> {
+    if !ast_has_auto_connect(&ast) {
+        return Ok((ast, Vec::new(), Vec::new()));
+    }
+
+    let children: HashMap<String, ChildInfo> = ast
+        .items
+        .iter()
+        .filter(|item| !item.ports().is_empty() || !item.port_arrays().is_empty())
+        .map(|item| {
+            (
+                item.as_construct().name().name.clone(),
+                ChildInfo {
+                    ports: item.ports().to_vec(),
+                    port_arrays: item.port_arrays().into_iter().cloned().collect(),
+                    params: item.params().to_vec(),
+                },
+            )
+        })
+        .collect();
+
+    let buses: HashMap<String, BusInfo> = ast
+        .items
+        .iter()
+        .filter_map(|item| match item {
+            Item::Bus(b) => Some((b.name.name.clone(), BusInfo::from_decl(b))),
+            _ => None,
+        })
+        .collect();
+
+    let mut cx = Cx {
+        children,
+        buses,
+        best_effort,
+        errors: Vec::new(),
+        notes: Vec::new(),
+        warnings: Vec::new(),
+    };
+
+    for item in ast.items.iter_mut() {
+        match item {
+            Item::Module(m) => {
+                let params = param_defaults(&m.params);
+                let scope = cx.collect_scope(&m.ports, &m.body, &params);
+                let mut body = std::mem::take(&mut m.body);
+                cx.walk_body(&mut body, &scope, &params);
+                m.body = body;
+            }
+            Item::Pipeline(p) => {
+                let params = param_defaults(&p.params);
+                let ports = p.ports.clone();
+                for stage in p.stages.iter_mut() {
+                    let scope = cx.collect_scope(&ports, &stage.body, &params);
+                    let mut body = std::mem::take(&mut stage.body);
+                    cx.walk_body(&mut body, &scope, &params);
+                    stage.body = body;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    if cx.errors.is_empty() {
+        Ok((ast, cx.notes, cx.warnings))
+    } else {
+        Err(cx.errors)
+    }
+}
+
+fn ast_has_auto_connect(ast: &SourceFile) -> bool {
+    fn in_body(body: &[ModuleBodyItem]) -> bool {
+        body.iter().any(|it| match it {
+            ModuleBodyItem::Inst(i) => i.auto_connect.is_some(),
+            ModuleBodyItem::Generate(g) => gen_items(g).iter().any(|gi| match gi {
+                GenItem::Inst(i) => i.auto_connect.is_some(),
+                _ => false,
+            }),
+            _ => false,
+        })
+    }
+    ast.items.iter().any(|item| match item {
+        Item::Module(m) => in_body(&m.body),
+        Item::Pipeline(p) => p.stages.iter().any(|s| in_body(&s.body)),
+        _ => false,
+    })
+}
+
+fn gen_items(g: &GenerateDecl) -> Vec<&GenItem> {
+    match g {
+        GenerateDecl::For(gf) => gf.items.iter().collect(),
+        GenerateDecl::If(gi) => gi.then_items.iter().chain(gi.else_items.iter()).collect(),
+    }
+}
+
+fn gen_items_mut(g: &mut GenerateDecl) -> Vec<&mut GenItem> {
+    match g {
+        GenerateDecl::For(gf) => gf.items.iter_mut().collect(),
+        GenerateDecl::If(gi) => gi
+            .then_items
+            .iter_mut()
+            .chain(gi.else_items.iter_mut())
+            .collect(),
+    }
+}
+
+/// Const-foldable param defaults of the enclosing construct, used to resolve
+/// widths and counts on the *parent* side.
+fn param_defaults(params: &[ParamDecl]) -> HashMap<String, i64> {
+    let mut out: HashMap<String, i64> = HashMap::new();
+    // Two passes so a derived default (`param B: const = A * 2;`) resolves
+    // against an earlier param regardless of declaration order.
+    for _ in 0..2 {
+        for p in params {
+            if let Some(d) = &p.default {
+                if let Some(v) = try_eval_i64(d, &out) {
+                    out.insert(p.name.name.clone(), v);
+                }
+            }
+        }
+    }
+    out
+}
+
+struct Cx {
+    children: HashMap<String, ChildInfo>,
+    buses: HashMap<String, BusInfo>,
+    best_effort: bool,
+    errors: Vec<CompileError>,
+    notes: Vec<AutoConnectNote>,
+    warnings: Vec<CompileWarning>,
+}
+
+impl Cx {
+    fn error(&mut self, msg: String, span: Span) {
+        if !self.best_effort {
+            self.errors.push(CompileError::general(&msg, span));
+        }
+    }
+
+    /// Every name visible to an inst in this body: ports (with bus fields
+    /// flattened), `reg` / `wire` / `let` / `pipe_reg` declarations, and the
+    /// targets of *explicit* inst output connections (codegen auto-declares
+    /// those wires). Names introduced by another inst's `auto;` are
+    /// deliberately excluded, so expansion is order-independent.
+    fn collect_scope(
+        &self,
+        ports: &[PortDecl],
+        body: &[ModuleBodyItem],
+        params: &HashMap<String, i64>,
+    ) -> HashMap<String, ScopeEntry> {
+        let mut scope: HashMap<String, ScopeEntry> = HashMap::new();
+
+        for p in ports {
+            let entry = ScopeEntry {
+                ty: Some(p.ty.clone()),
+                bus: p.bus_info.as_ref().map(|bi| BusShape {
+                    bus_name: bi.bus_name.name.clone(),
+                    count: bi.count.clone(),
+                }),
+            };
+            self.insert_with_bus_fields(&mut scope, &p.name.name, entry, params);
+        }
+
+        let add_body = |body: &[ModuleBodyItem], scope: &mut HashMap<String, ScopeEntry>| {
+            for item in body {
+                match item {
+                    ModuleBodyItem::RegDecl(r) => {
+                        scope.entry(r.name.name.clone()).or_insert(ScopeEntry {
+                            ty: Some(r.ty.clone()),
+                            bus: None,
+                        });
+                    }
+                    ModuleBodyItem::WireDecl(w) => {
+                        let bus = bus_shape_of_type(&w.ty, &self.buses);
+                        let entry = ScopeEntry {
+                            ty: Some(w.ty.clone()),
+                            bus,
+                        };
+                        self.insert_with_bus_fields(scope, &w.name.name, entry, params);
+                    }
+                    ModuleBodyItem::LetBinding(l) => {
+                        scope.entry(l.name.name.clone()).or_insert(ScopeEntry {
+                            ty: l.ty.clone(),
+                            bus: None,
+                        });
+                    }
+                    ModuleBodyItem::PipeRegDecl(p) => {
+                        scope.entry(p.name.name.clone()).or_default();
+                    }
+                    ModuleBodyItem::Inst(inst) => {
+                        for c in &inst.connections {
+                            if c.direction == ConnectDir::Output {
+                                if let ExprKind::Ident(n) = &c.signal.kind {
+                                    scope.entry(n.clone()).or_default();
+                                }
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        };
+        add_body(body, &mut scope);
+        // Items inside a surviving `generate` block are visible at module
+        // scope in the emitted SV, so an inst-output wire declared there
+        // counts too.
+        for item in body {
+            if let ModuleBodyItem::Generate(g) = item {
+                for gi in gen_items(g) {
+                    match gi {
+                        GenItem::Wire(w) => {
+                            let bus = bus_shape_of_type(&w.ty, &self.buses);
+                            let entry = ScopeEntry {
+                                ty: Some(w.ty.clone()),
+                                bus,
+                            };
+                            self.insert_with_bus_fields(&mut scope, &w.name.name, entry, params);
+                        }
+                        GenItem::Inst(inst) => {
+                            for c in &inst.connections {
+                                if c.direction == ConnectDir::Output {
+                                    if let ExprKind::Ident(n) = &c.signal.kind {
+                                        scope.entry(n.clone()).or_default();
+                                    }
+                                }
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+        scope
+    }
+
+    /// Insert a name, plus — for a bus-shaped declaration — the flattened
+    /// `<name>_<sig>` / `<name>_<i>_<sig>` field names that a per-field
+    /// connection would target.
+    fn insert_with_bus_fields(
+        &self,
+        scope: &mut HashMap<String, ScopeEntry>,
+        name: &str,
+        entry: ScopeEntry,
+        params: &HashMap<String, i64>,
+    ) {
+        let bus = entry.bus.clone();
+        scope.insert(name.to_string(), entry);
+        let Some(shape) = bus else { return };
+        let Some(info) = self.buses.get(&shape.bus_name) else {
+            return;
+        };
+        let pm = info.default_param_map();
+        let prefixes: Vec<String> = match &shape.count {
+            None => vec![name.to_string()],
+            Some(count) => match try_eval_i64(count, params) {
+                Some(n) if n > 0 => (0..n).map(|i| format!("{name}_{i}")).collect(),
+                _ => vec![name.to_string()],
+            },
+        };
+        for prefix in prefixes {
+            for (sig, _, ty) in info.effective_signals(&pm) {
+                scope
+                    .entry(format!("{prefix}_{sig}"))
+                    .or_insert(ScopeEntry {
+                        ty: Some(ty.clone()),
+                        bus: None,
+                    });
+            }
+        }
+    }
+
+    fn walk_body(
+        &mut self,
+        body: &mut [ModuleBodyItem],
+        scope: &HashMap<String, ScopeEntry>,
+        params: &HashMap<String, i64>,
+    ) {
+        for item in body.iter_mut() {
+            match item {
+                ModuleBodyItem::Inst(inst) => self.expand_inst(inst, scope, params),
+                ModuleBodyItem::Generate(g) => {
+                    for gi in gen_items_mut(g) {
+                        if let GenItem::Inst(inst) = gi {
+                            self.expand_inst(inst, scope, params);
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    fn expand_inst(
+        &mut self,
+        inst: &mut InstDecl,
+        scope: &HashMap<String, ScopeEntry>,
+        parent_params: &HashMap<String, i64>,
+    ) {
+        let Some(auto_span) = inst.auto_connect else {
+            return;
+        };
+        let Some(child) = self.children.get(&inst.module_name.name) else {
+            self.error(
+                format!(
+                    "auto-connect: cannot resolve ports of `{}` in inst `{}` \
+                     (no definition and no `{}.archi` interface found)",
+                    inst.module_name.name, inst.name.name, inst.module_name.name
+                ),
+                auto_span,
+            );
+            return;
+        };
+        // Cloned so the borrow on `self.children` ends here — the fill loop
+        // needs `&mut self` for diagnostics.
+        let ports = child.ports.clone();
+        let port_arrays = child.port_arrays.clone();
+        let child_params = self.child_param_map(child, inst, parent_params);
+
+        let connected: HashSet<String> = inst
+            .connections
+            .iter()
+            .map(|c| c.port_name.name.clone())
+            .collect();
+
+        let mut fills: Vec<Connection> = Vec::new();
+
+        for port in &ports {
+            if let Some(bi) = &port.bus_info {
+                if is_bus_connected(&connected, &port.name.name) {
+                    continue;
+                }
+                self.fill_bus_port(
+                    port,
+                    bi,
+                    inst,
+                    scope,
+                    &child_params,
+                    parent_params,
+                    auto_span,
+                    &mut fills,
+                );
+                continue;
+            }
+            if connected.contains(&port.name.name) {
+                continue;
+            }
+            self.fill_plain_port(
+                port,
+                &port.name.name,
+                port.direction,
+                inst,
+                scope,
+                &child_params,
+                parent_params,
+                auto_span,
+                &mut fills,
+            );
+        }
+
+        for group in &port_arrays {
+            let Some(n) = try_eval_i64(&group.count_expr, &child_params) else {
+                self.error(
+                    format!(
+                        "auto-connect: cannot resolve count for port group `{}` of `{}` \
+                         in inst `{}` — connect its signals explicitly",
+                        group.name.name, inst.module_name.name, inst.name.name
+                    ),
+                    auto_span,
+                );
+                continue;
+            };
+            // A literal count-1 group flattens to `<g>_<sig>` (see
+            // `normalize_count1_portarray_conns`); every other count uses
+            // `<g><i>_<sig>`.
+            let count1 = matches!(&group.count_expr.kind, ExprKind::Literal(LitKind::Dec(1)));
+            for i in 0..n.max(0) {
+                for sig in &group.signals {
+                    let flat = if count1 {
+                        format!("{}_{}", group.name.name, sig.name.name)
+                    } else {
+                        format!("{}{}_{}", group.name.name, i, sig.name.name)
+                    };
+                    // Accept either spelling as "already connected": the
+                    // normalization only runs over module bodies, so a
+                    // pipeline-stage inst may still carry `<g>0_<sig>`.
+                    let alt = format!("{}{}_{}", group.name.name, i, sig.name.name);
+                    if connected.contains(&flat) || connected.contains(&alt) {
+                        continue;
+                    }
+                    self.fill_plain_port(
+                        sig,
+                        &flat,
+                        sig.direction,
+                        inst,
+                        scope,
+                        &child_params,
+                        parent_params,
+                        auto_span,
+                        &mut fills,
+                    );
+                }
+            }
+        }
+
+        if fills.is_empty() {
+            self.warnings.push(CompileWarning {
+                message: format!(
+                    "`auto;` in inst `{}` filled no ports — every port of `{}` is already \
+                     connected explicitly",
+                    inst.name.name, inst.module_name.name
+                ),
+                span: auto_span,
+            });
+        } else {
+            self.notes.push(AutoConnectNote {
+                inst_name: inst.name.name.clone(),
+                module_name: inst.module_name.name.clone(),
+                conns: fills.iter().map(render_conn).collect(),
+            });
+        }
+        inst.connections.extend(fills);
+        inst.auto_connect = None;
+    }
+
+    /// The child's effective param values: its own defaults with the
+    /// inst-site `param NAME = ...;` overrides applied on top (evaluated in
+    /// the parent's param scope, where they are written).
+    fn child_param_map(
+        &self,
+        child: &ChildInfo,
+        inst: &InstDecl,
+        parent_params: &HashMap<String, i64>,
+    ) -> HashMap<String, i64> {
+        let mut map = param_defaults(&child.params);
+        for pa in &inst.param_assigns {
+            if let Some(v) = try_eval_i64(&pa.value, parent_params) {
+                map.insert(pa.name.name.clone(), v);
+            }
+        }
+        map
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn fill_plain_port(
+        &mut self,
+        port: &PortDecl,
+        flat_name: &str,
+        direction: Direction,
+        inst: &InstDecl,
+        scope: &HashMap<String, ScopeEntry>,
+        child_params: &HashMap<String, i64>,
+        parent_params: &HashMap<String, i64>,
+        auto_span: Span,
+        fills: &mut Vec<Connection>,
+    ) {
+        let Some(entry) = scope.get(flat_name) else {
+            self.error(
+                format!(
+                    "auto-connect: no signal `{}` in scope for {} port `{}` of `{}` in inst \
+                     `{}` — declare `{}` or connect the port explicitly",
+                    flat_name,
+                    dir_word(direction),
+                    flat_name,
+                    inst.module_name.name,
+                    inst.name.name,
+                    flat_name,
+                ),
+                auto_span,
+            );
+            return;
+        };
+        if let Some(parent_ty) = &entry.ty {
+            if let Some((pt, st)) = type_conflict(&port.ty, child_params, parent_ty, parent_params)
+            {
+                let hint = if matches!(port.ty, TypeExpr::Reset(_, _)) {
+                    format!(
+                        " — connect it explicitly as `{flat_name} <- {flat_name} as {pt}` if the \
+                         reset really is re-typed here"
+                    )
+                } else {
+                    " — connect it explicitly with the cast you intend".to_string()
+                };
+                self.error(
+                    format!(
+                        "auto-connect: type mismatch for port `{}` of `{}` in inst `{}`: port is \
+                         {}, signal `{}` is {}{}",
+                        flat_name, inst.module_name.name, inst.name.name, pt, flat_name, st, hint,
+                    ),
+                    auto_span,
+                );
+                return;
+            }
+        }
+        fills.push(mk_conn(
+            flat_name,
+            match direction {
+                Direction::In => ConnectDir::Input,
+                Direction::Out => ConnectDir::Output,
+            },
+            auto_span,
+        ));
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn fill_bus_port(
+        &mut self,
+        port: &PortDecl,
+        bi: &BusPortInfo,
+        inst: &InstDecl,
+        scope: &HashMap<String, ScopeEntry>,
+        child_params: &HashMap<String, i64>,
+        parent_params: &HashMap<String, i64>,
+        auto_span: Span,
+        fills: &mut Vec<Connection>,
+    ) {
+        let name = &port.name.name;
+        let Some(entry) = scope.get(name) else {
+            self.error(
+                format!(
+                    "auto-connect: no signal `{}` in scope for bus port `{}` of `{}` in inst \
+                     `{}` — declare a `{}` port or wire, or connect the bus explicitly",
+                    name, name, inst.module_name.name, inst.name.name, bi.bus_name.name,
+                ),
+                auto_span,
+            );
+            return;
+        };
+        let Some(shape) = &entry.bus else {
+            self.error(
+                format!(
+                    "auto-connect: `{}` is not a `{}` bus in this scope but port `{}` of `{}` \
+                     in inst `{}` is — connect the bus explicitly",
+                    name, bi.bus_name.name, name, inst.module_name.name, inst.name.name,
+                ),
+                auto_span,
+            );
+            return;
+        };
+        if shape.bus_name != bi.bus_name.name {
+            self.error(
+                format!(
+                    "auto-connect: bus type mismatch for port `{}` of `{}` in inst `{}`: port is \
+                     `{}`, signal `{}` is `{}`",
+                    name,
+                    inst.module_name.name,
+                    inst.name.name,
+                    bi.bus_name.name,
+                    name,
+                    shape.bus_name,
+                ),
+                auto_span,
+            );
+            return;
+        }
+        // `Vec<Bus, N>` on one side only, or a different N, is a definite
+        // mismatch; an unresolvable count on either side defers.
+        let child_n = bi.count.as_ref().map(|c| try_eval_i64(c, child_params));
+        let parent_n = shape.count.as_ref().map(|c| try_eval_i64(c, parent_params));
+        let mismatched = match (&child_n, &parent_n) {
+            (None, Some(_)) | (Some(_), None) => true,
+            (Some(Some(a)), Some(Some(b))) => a != b,
+            _ => false,
+        };
+        if mismatched {
+            let render = |n: &Option<Option<i64>>| match n {
+                None => "a scalar bus".to_string(),
+                Some(Some(v)) => format!("`Vec<{}, {}>`", bi.bus_name.name, v),
+                Some(None) => format!("`Vec<{}, ...>`", bi.bus_name.name),
+            };
+            self.error(
+                format!(
+                    "auto-connect: bus shape mismatch for port `{}` of `{}` in inst `{}`: port is \
+                     {}, signal `{}` is {}",
+                    name,
+                    inst.module_name.name,
+                    inst.name.name,
+                    render(&child_n),
+                    name,
+                    render(&parent_n),
+                ),
+                auto_span,
+            );
+            return;
+        }
+        // Whole-bus connections are always recorded as `Output` — the
+        // per-signal directions come from the bus declaration when the
+        // connection is expanded. Same convention as the `connect` sugar in
+        // `elaborate::tlm::push_tlm_connect_connection`.
+        fills.push(mk_conn(name, ConnectDir::Output, auto_span));
+    }
+}
+
+fn dir_word(d: Direction) -> &'static str {
+    match d {
+        Direction::In => "input",
+        Direction::Out => "output",
+    }
+}
+
+fn mk_conn(name: &str, direction: ConnectDir, span: Span) -> Connection {
+    Connection {
+        port_name: Ident::new(name.to_string(), span),
+        direction,
+        signal: Expr::new(ExprKind::Ident(name.to_string()), span),
+        reset_override: None,
+        span,
+    }
+}
+
+fn render_conn(c: &Connection) -> String {
+    let arrow = match c.direction {
+        ConnectDir::Input => "<-",
+        ConnectDir::Output => "->",
+    };
+    format!("{} {} {}", c.port_name.name, arrow, c.port_name.name)
+}
+
+/// A bus port is connected either whole (`p -> w;`) or field-by-field
+/// (`p.cmd_valid <- x;`, flattened to `p_cmd_valid`).
+fn is_bus_connected(connected: &HashSet<String>, name: &str) -> bool {
+    let prefix = format!("{name}_");
+    connected.contains(name) || connected.iter().any(|c| c.starts_with(&prefix))
+}
+
+/// Recognize a bus-typed `wire`: `wire w: BusName;` or `wire w: Vec<BusName, N>;`.
+fn bus_shape_of_type(ty: &TypeExpr, buses: &HashMap<String, BusInfo>) -> Option<BusShape> {
+    match ty {
+        TypeExpr::Named(id) if buses.contains_key(&id.name) => Some(BusShape {
+            bus_name: id.name.clone(),
+            count: None,
+        }),
+        TypeExpr::Vec(inner, count) => match inner.as_ref() {
+            TypeExpr::Named(id) if buses.contains_key(&id.name) => Some(BusShape {
+                bus_name: id.name.clone(),
+                count: Some((**count).clone()),
+            }),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+/// Compare a child port type against a parent declaration type.
+///
+/// Returns `Some((port_ty, signal_ty))` — both rendered for the diagnostic —
+/// only on a **definite** mismatch. Anything that cannot be decided here
+/// (param-dependent width, cross-category comparison such as `Named` vs
+/// `UInt`, unknown parent type) returns `None` and defers to the ordinary
+/// connection checks, so this gate never invents a type rule of its own.
+fn type_conflict(
+    port: &TypeExpr,
+    port_params: &HashMap<String, i64>,
+    sig: &TypeExpr,
+    sig_params: &HashMap<String, i64>,
+) -> Option<(String, String)> {
+    if !definitely_differs(port, port_params, sig, sig_params) {
+        return None;
+    }
+    Some((render_ty(port, port_params), render_ty(sig, sig_params)))
+}
+
+fn definitely_differs(
+    a: &TypeExpr,
+    ap: &HashMap<String, i64>,
+    b: &TypeExpr,
+    bp: &HashMap<String, i64>,
+) -> bool {
+    use TypeExpr::*;
+    match (a, b) {
+        (Reset(k1, l1), Reset(k2, l2)) => k1 != k2 || l1 != l2,
+        (Clock(d1), Clock(d2)) => d1.name != d2.name,
+        (UInt(w1), UInt(w2)) | (SInt(w1), SInt(w2)) => {
+            match (try_eval_i64(w1, ap), try_eval_i64(w2, bp)) {
+                (Some(x), Some(y)) => x != y,
+                _ => false,
+            }
+        }
+        // Signedness is never implicit in ARCH.
+        (UInt(_), SInt(_)) | (SInt(_), UInt(_)) => true,
+        // A 1-bit `UInt` against `Bool`/`Bit` is a spelling difference, not a
+        // mismatch — any other width is. Each width is evaluated against its
+        // OWN side's param map.
+        (UInt(w), Bool) | (UInt(w), Bit) => {
+            matches!(try_eval_i64(w, ap), Some(n) if n != 1)
+        }
+        (Bool, UInt(w)) | (Bit, UInt(w)) => {
+            matches!(try_eval_i64(w, bp), Some(n) if n != 1)
+        }
+        (Vec(t1, n1), Vec(t2, n2)) => {
+            let len_differs = match (try_eval_i64(n1, ap), try_eval_i64(n2, bp)) {
+                (Some(x), Some(y)) => x != y,
+                _ => false,
+            };
+            len_differs || definitely_differs(t1, ap, t2, bp)
+        }
+        (Named(x), Named(y)) => x.name != y.name,
+        // Float / MX formats are distinct types with no implicit conversion.
+        (FP32, FP32) | (BF16, BF16) => false,
+        (FP32, BF16) | (BF16, FP32) => true,
+        _ => false,
+    }
+}
+
+fn render_ty(ty: &TypeExpr, params: &HashMap<String, i64>) -> String {
+    use TypeExpr::*;
+    match ty {
+        UInt(w) => match try_eval_i64(w, params) {
+            Some(n) => format!("UInt<{n}>"),
+            None => "UInt<...>".to_string(),
+        },
+        SInt(w) => match try_eval_i64(w, params) {
+            Some(n) => format!("SInt<{n}>"),
+            None => "SInt<...>".to_string(),
+        },
+        Bool => "Bool".to_string(),
+        Bit => "Bit".to_string(),
+        Clock(d) => format!("Clock<{}>", d.name),
+        Reset(k, l) => format!(
+            "Reset<{}, {}>",
+            match k {
+                ResetKind::Sync => "Sync",
+                ResetKind::Async => "Async",
+            },
+            match l {
+                ResetLevel::High => "High",
+                ResetLevel::Low => "Low",
+            }
+        ),
+        Vec(t, n) => match try_eval_i64(n, params) {
+            Some(c) => format!("Vec<{}, {}>", render_ty(t, params), c),
+            None => format!("Vec<{}, ...>", render_ty(t, params)),
+        },
+        Named(id) => id.name.clone(),
+        other => format!("{other:?}"),
+    }
+}

--- a/src/elaborate/auto_connect.rs
+++ b/src/elaborate/auto_connect.rs
@@ -386,6 +386,60 @@ impl Cx {
         }
     }
 
+    /// Is this bus port already bound by an explicit connection?
+    ///
+    /// A bus port binds either whole (`p -> w;`) or field-by-field
+    /// (`p.cmd_valid <- x;`, which the parser flattens to `p_cmd_valid`).
+    /// Deciding that from a bare `p_` **prefix** would be wrong: a sibling
+    /// port literally named `p_extra` also starts with `p_`, so connecting
+    /// *it* would suppress the auto-fill of bus port `p` and leave `p`
+    /// dangling — a silent wrong answer, which is exactly what `auto;` must
+    /// never produce. So match against the precise set of names this port
+    /// can flatten to, derived from the bus declaration.
+    fn bus_port_connected(
+        &self,
+        connected: &HashSet<String>,
+        port_name: &str,
+        bi: &BusPortInfo,
+        child_params: &HashMap<String, i64>,
+    ) -> bool {
+        // Whole-bus binding.
+        if connected.contains(port_name) {
+            return true;
+        }
+        let Some(info) = self.buses.get(&bi.bus_name.name) else {
+            // The bus declaration isn't in this compilation unit, so the
+            // field names are unknowable here. The design won't elaborate
+            // anyway; fall back to the prefix test rather than assume the
+            // port is unconnected and double-drive it.
+            let prefix = format!("{port_name}_");
+            return connected.iter().any(|c| c.starts_with(&prefix));
+        };
+        let mut pm = info.default_param_map();
+        for pa in &bi.params {
+            pm.insert(pa.name.name.clone(), &pa.value);
+        }
+        let signals = info.effective_signals(&pm);
+        // `Vec<Bus, N>` flattens per element (`p_0_<sig>`); a scalar bus
+        // flattens directly (`p_<sig>`). An unresolvable count falls back to
+        // the scalar spelling.
+        let prefixes: Vec<String> = match bi.count.as_ref() {
+            None => vec![port_name.to_string()],
+            Some(count) => match try_eval_i64(count, child_params) {
+                Some(n) if n > 0 => (0..n).map(|i| format!("{port_name}_{i}")).collect(),
+                _ => vec![port_name.to_string()],
+            },
+        };
+        prefixes.iter().any(|p| {
+            // `p` alone covers a per-element whole-bus binding (`mm[0] <- w`
+            // flattens to `mm_0`).
+            connected.contains(p)
+                || signals
+                    .iter()
+                    .any(|(sig, _, _)| connected.contains(&format!("{p}_{sig}")))
+        })
+    }
+
     fn expand_inst(
         &mut self,
         inst: &mut InstDecl,
@@ -422,7 +476,7 @@ impl Cx {
 
         for port in &ports {
             if let Some(bi) = &port.bus_info {
-                if is_bus_connected(&connected, &port.name.name) {
+                if self.bus_port_connected(&connected, &port.name.name, bi, &child_params) {
                     continue;
                 }
                 self.fill_bus_port(
@@ -709,13 +763,6 @@ fn render_conn(c: &Connection) -> String {
         ConnectDir::Output => "->",
     };
     format!("{} {} {}", c.port_name.name, arrow, c.port_name.name)
-}
-
-/// A bus port is connected either whole (`p -> w;`) or field-by-field
-/// (`p.cmd_valid <- x;`, flattened to `p_cmd_valid`).
-fn is_bus_connected(connected: &HashSet<String>, name: &str) -> bool {
-    let prefix = format!("{name}_");
-    connected.contains(name) || connected.iter().any(|c| c.starts_with(&prefix))
 }
 
 /// Recognize a bus-typed `wire`: `wire w: BusName;` or `wire w: Vec<BusName, N>;`.

--- a/src/elaborate/mod.rs
+++ b/src/elaborate/mod.rs
@@ -61,6 +61,12 @@ pub use threads::{lower_threads, lower_threads_with_opts, ThreadLowerOpts};
 // resolving unchanged; `lower_tlm_connects` has no external caller —
 // bumped `fn` → `pub(super) fn` and re-imported as a plain `use` so this
 // file's existing bare call site is untouched.
+// `auto;` auto-connect expansion — rewrites the directive into ordinary
+// inst connections right after `elaborate()`, so every downstream pass sees
+// a fully explicit connection set. See `auto_connect.rs` for the rules.
+mod auto_connect;
+pub use auto_connect::{expand_auto_connect, AutoConnectNote};
+
 mod tlm;
 use tlm::lower_tlm_connects;
 pub use tlm::{lower_tlm_initiator_calls, lower_tlm_target_threads};
@@ -2266,6 +2272,10 @@ pub(crate) fn subst_inst(inst: &InstDecl, var: &str, val: i64) -> InstDecl {
             .iter()
             .map(|fl| subst_inst_for_loop(fl, var, val))
             .collect(),
+        // `auto;` carries through unrolling: every unrolled copy of the inst
+        // auto-connects against the parent scope independently. The directive
+        // has no loop-var content to substitute.
+        auto_connect: inst.auto_connect,
         span: inst.span,
     }
 }

--- a/src/elaborate/threads.rs
+++ b/src/elaborate/threads.rs
@@ -1030,6 +1030,7 @@ fn lower_module_threads(
             name: Ident::new(inst_name, sp),
             module_name: Ident::new(arb_module_name, sp),
             param_assigns: Vec::new(),
+            auto_connect: None,
             connections: vec![
                 Connection {
                     port_name: Ident::new("clk".to_string(), sp),
@@ -2513,6 +2514,7 @@ fn lower_module_threads(
     let inst = InstDecl {
         name: Ident::new("_threads".to_string(), sp),
         module_name: Ident::new(merged_name, sp),
+        auto_connect: None,
         param_assigns: m
             .params
             .iter()

--- a/src/elaborate/tlm.rs
+++ b/src/elaborate/tlm.rs
@@ -5591,6 +5591,7 @@ fn lower_indexed_tlm_target_group(
         name: mk_ident(format!("{arb_prefix}_inst")),
         module_name: mk_ident(arb_module_name),
         param_assigns: Vec::new(),
+        auto_connect: None,
         connections: vec![
             Connection {
                 port_name: mk_ident("clk".to_string()),

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1511,7 +1511,7 @@ impl Builder {
     }
 
     fn add_params_ports(&mut self, item: &Item, owner: &str, rel: &str, scope: &str) {
-        for p in item_params(item) {
+        for p in item.params() {
             let id = param_id(rel, scope, &p.name.name);
             self.add_node(NodeRecord {
                 id: id.clone(),
@@ -1531,7 +1531,7 @@ impl Builder {
                 self.walk_type(owner, scope, ty, p.span);
             }
         }
-        for p in item_ports(item) {
+        for p in item.ports() {
             let id = port_id(rel, scope, &p.name.name);
             let mut attrs = BTreeMap::new();
             attrs.insert(
@@ -2165,46 +2165,6 @@ impl SourceMap {
 enum ExprUse {
     Read,
     Write,
-}
-
-fn item_params(item: &Item) -> &[ParamDecl] {
-    match item {
-        Item::Module(m) => &m.params,
-        Item::Fsm(f) => &f.params,
-        Item::Fifo(f) => &f.params,
-        Item::Ram(r) => &r.params,
-        Item::Cam(c) => &c.params,
-        Item::Counter(c) => &c.params,
-        Item::Arbiter(a) => &a.params,
-        Item::Regfile(r) => &r.params,
-        Item::Pipeline(p) => &p.params,
-        Item::Linklist(l) => &l.params,
-        Item::Bus(b) => &b.params,
-        Item::Synchronizer(s) => &s.params,
-        Item::Clkgate(c) => &c.params,
-        Item::Template(t) => &t.params,
-        Item::Package(p) => &p.params,
-        _ => &[],
-    }
-}
-
-fn item_ports(item: &Item) -> &[PortDecl] {
-    match item {
-        Item::Module(m) => &m.ports,
-        Item::Fsm(f) => &f.ports,
-        Item::Fifo(f) => &f.ports,
-        Item::Ram(r) => &r.ports,
-        Item::Cam(c) => &c.ports,
-        Item::Counter(c) => &c.ports,
-        Item::Arbiter(a) => &a.ports,
-        Item::Regfile(r) => &r.ports,
-        Item::Pipeline(p) => &p.ports,
-        Item::Linklist(l) => &l.ports,
-        Item::Synchronizer(s) => &s.ports,
-        Item::Clkgate(c) => &c.ports,
-        Item::Template(t) => &t.ports,
-        _ => &[],
-    }
 }
 
 fn line_col(src: &str, byte: usize) -> (usize, usize) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,6 +77,11 @@ enum Command {
         /// `// arch-lint-naming: off` source-line pragma.
         #[arg(long, num_args = 0..=1, require_equals = true, default_missing_value = "warn")]
         lint_naming: Option<String>,
+        /// Print the connections each `auto;` directive expanded to, one
+        /// note per `inst`. Diagnostic only — the expansion itself always
+        /// runs (`auto;` is a front-end desugar into ordinary connections).
+        #[arg(long)]
+        explain_auto: bool,
     },
     /// Rebuild the learning retrieval index over ~/.arch/learn/events.jsonl
     LearnIndex,
@@ -244,6 +249,11 @@ enum Command {
         /// `--assert` to get free spec-derived coverage.
         #[arg(long)]
         auto_thread_asserts: bool,
+        /// Print the connections each `auto;` directive expanded to, one
+        /// note per `inst`. Diagnostic only — the expansion itself always
+        /// runs (`auto;` is a front-end desugar into ordinary connections).
+        #[arg(long)]
+        explain_auto: bool,
         /// Opt-in naming-convention lint (issue #648) — see `arch check
         /// --help` for the full rule set. Warning-only; never fails the
         /// build.
@@ -363,6 +373,11 @@ enum Command {
         /// help for the property set. Picked up by Verilator `--assert`.
         #[arg(long)]
         auto_thread_asserts: bool,
+        /// Print the connections each `auto;` directive expanded to, one
+        /// note per `inst`. Diagnostic only — the expansion itself always
+        /// runs (`auto;` is a front-end desugar into ordinary connections).
+        #[arg(long)]
+        explain_auto: bool,
         /// Override a module param default: --param NAME=VALUE (repeatable).
         /// Value must be an integer literal. The override is applied before
         /// sim codegen and also passed to the C++ compiler as -DNAME=VALUE
@@ -422,6 +437,11 @@ enum Command {
         /// by construction). See `arch build` help for the property set.
         #[arg(long)]
         auto_thread_asserts: bool,
+        /// Print the connections each `auto;` directive expanded to, one
+        /// note per `inst`. Diagnostic only — the expansion itself always
+        /// runs (`auto;` is a front-end desugar into ordinary connections).
+        #[arg(long)]
+        explain_auto: bool,
         /// Floating-point special-value compatibility profile (doc/archive/plan_fp_types.md
         /// §6.2): `riscv` (default) or `cuda`. Accepted for parity with `build`/`sim`.
         #[arg(long = "fp-compat", default_value = "riscv")]
@@ -1020,7 +1040,11 @@ fn main() -> miette::Result<()> {
     let cli = Cli::parse();
 
     match cli.command {
-        Command::Check { files, lint_naming } => {
+        Command::Check {
+            files,
+            lint_naming,
+            explain_auto,
+        } => {
             let lint_naming = resolve_lint_naming_flag(lint_naming)?;
             learn_wrap(&files, || {
                 let all_files = resolve_use_imports(&files)?;
@@ -1029,6 +1053,7 @@ fn main() -> miette::Result<()> {
                     &ms,
                     /*skip_lower_threads=*/ false,
                     /*auto_thread_asserts=*/ false,
+                    explain_auto,
                     lint_naming,
                 )?;
                 eprintln!("OK: no errors");
@@ -1218,6 +1243,7 @@ fn main() -> miette::Result<()> {
             test,
             pybind_module_name,
             auto_thread_asserts,
+            explain_auto,
             param_overrides,
             fp_compat,
         } => {
@@ -1272,6 +1298,7 @@ fn main() -> miette::Result<()> {
                         pybind,
                         test.as_deref(),
                         pybind_module_name.as_deref(),
+                        explain_auto,
                         &param_overrides_map,
                         fp_compat,
                     )
@@ -1296,6 +1323,7 @@ fn main() -> miette::Result<()> {
                         pybind,
                         test.as_deref(),
                         pybind_module_name.as_deref(),
+                        explain_auto,
                         &param_overrides_map,
                         fp_compat,
                     )
@@ -1329,6 +1357,7 @@ fn main() -> miette::Result<()> {
             check_construct_proof_smt,
             construct_proof_smt_solver,
             auto_thread_asserts,
+            explain_auto,
             lint_naming,
             no_inline_deps,
             no_auto_asserts,
@@ -1413,6 +1442,7 @@ fn main() -> miette::Result<()> {
                     &ms,
                     false,
                     effective_auto_thread_asserts,
+                    explain_auto,
                     lint_naming,
                     thread_map_store.clone(),
                 )?;
@@ -1978,6 +2008,7 @@ fn main() -> miette::Result<()> {
             thread_proof_only,
             timeout,
             auto_thread_asserts,
+            explain_auto,
             fp_compat,
             error_engine,
         } => {
@@ -2008,6 +2039,7 @@ fn main() -> miette::Result<()> {
                     &ms,
                     false,
                     auto_thread_asserts,
+                    explain_auto,
                     /*lint_naming=*/ false,
                     thread_map_store.clone(),
                 )?;
@@ -2180,6 +2212,7 @@ fn build_and_capture(
         /*test_file*/ None,
         /*pybind_module_name_override*/ None,
         /*no_exit*/ true,
+        /*explain_auto*/ false,
         &std::collections::HashMap::new(),
         fp_compat,
     )?;
@@ -2214,6 +2247,7 @@ fn run_sim(
     pybind: bool,
     test_file: Option<&std::path::Path>,
     pybind_module_name_override: Option<&str>,
+    explain_auto: bool,
     param_overrides: &std::collections::HashMap<String, u64>,
     fp_compat: arch::FpCompat,
 ) -> miette::Result<()> {
@@ -2237,6 +2271,7 @@ fn run_sim(
         test_file,
         pybind_module_name_override,
         /*no_exit=*/ false,
+        explain_auto,
         param_overrides,
         fp_compat,
     )
@@ -2276,6 +2311,7 @@ fn run_sim_opts(
     test_file: Option<&std::path::Path>,
     pybind_module_name_override: Option<&str>,
     no_exit: bool,
+    explain_auto: bool,
     param_overrides: &std::collections::HashMap<String, u64>,
     fp_compat: arch::FpCompat,
 ) -> miette::Result<()> {
@@ -2287,6 +2323,7 @@ fn run_sim_opts(
             &ms,
             thread_sim_parallel,
             /*auto_thread_asserts=*/ false,
+            explain_auto,
             /*lint_naming=*/ false,
         )?
     } else {
@@ -2294,6 +2331,7 @@ fn run_sim_opts(
             &ms,
             thread_sim_parallel,
             /*auto_thread_asserts=*/ false,
+            explain_auto,
             /*lint_naming=*/ false,
             param_overrides,
         )?
@@ -2882,34 +2920,6 @@ fn resolve_stdlib_dir() -> Option<PathBuf> {
 /// items that carry no ports (struct, enum, function, bus, package, …).
 /// Used by the dep-discovery scan to find `initiator`/`target` bus-port
 /// type references the `inst` scan cannot see.
-fn item_ports(item: &Item) -> &[arch::ast::PortDecl] {
-    match item {
-        // Own `ports` field.
-        Item::Module(m) => &m.ports,
-        Item::Synchronizer(s) => &s.ports,
-        Item::Clkgate(c) => &c.ports,
-        Item::Template(t) => &t.ports,
-        // `ports` via `Deref<Target = ConstructCommon>`.
-        Item::Fsm(f) => &f.ports,
-        Item::Fifo(f) => &f.ports,
-        Item::Ram(r) => &r.ports,
-        Item::Cam(c) => &c.ports,
-        Item::Counter(c) => &c.ports,
-        Item::Arbiter(a) => &a.ports,
-        Item::Regfile(r) => &r.ports,
-        Item::Pipeline(p) => &p.ports,
-        Item::Linklist(l) => &l.ports,
-        Item::Domain(_)
-        | Item::Struct(_)
-        | Item::Enum(_)
-        | Item::Function(_)
-        | Item::Bus(_)
-        | Item::Package(_)
-        | Item::Use(_)
-        | Item::ExternPackage(_) => &[],
-    }
-}
-
 fn resolve_use_imports(files: &[PathBuf]) -> miette::Result<Vec<PathBuf>> {
     use std::collections::HashSet;
 
@@ -3129,7 +3139,7 @@ fn resolve_use_imports(files: &[PathBuf]) -> miette::Result<Vec<PathBuf>> {
         // bus's `.arch`/`.archi` sits right next to it.
         let mut bus_refs: Vec<String> = Vec::new();
         for item in &parsed.items {
-            for port in item_ports(item) {
+            for port in item.ports() {
                 if let Some(bus) = &port.bus_info {
                     bus_refs.push(bus.bus_name.name.clone());
                 }
@@ -3728,6 +3738,14 @@ fn parse_graph_source_ast(ms: &MultiSource) -> miette::Result<arch::ast::SourceF
             item.set_is_interface(true);
         }
     }
+    // Expand `auto;` so the graph shows the same edges the compiler sees.
+    // Best-effort: this AST is *not* elaborated (no generate expansion, no
+    // monomorphization), so ports whose shape depends on a param may not
+    // resolve here. Those are silently skipped rather than failing the
+    // command — `arch check` is where auto-connect errors get reported.
+    let parsed_ast = arch::elaborate::expand_auto_connect(parsed_ast, /*best_effort=*/ true)
+        .map(|(ast, _, _)| ast)
+        .unwrap_or_else(|_| unreachable!("best-effort auto-connect never errors"));
     Ok(parsed_ast)
 }
 
@@ -3899,7 +3917,7 @@ fn run_check_multi(
 )> {
     run_check_multi_opts(
         ms, /*skip_lower_threads=*/ false, /*auto_thread_asserts=*/ false,
-        /*lint_naming=*/ false,
+        /*explain_auto=*/ false, /*lint_naming=*/ false,
     )
 }
 
@@ -3907,6 +3925,7 @@ fn run_check_multi_opts(
     ms: &MultiSource,
     skip_lower_threads: bool,
     auto_thread_asserts: bool,
+    explain_auto: bool,
     lint_naming: bool,
 ) -> miette::Result<(
     arch::ast::SourceFile,
@@ -3917,6 +3936,7 @@ fn run_check_multi_opts(
         ms,
         skip_lower_threads,
         auto_thread_asserts,
+        explain_auto,
         lint_naming,
         None,
         None,
@@ -3927,6 +3947,7 @@ fn run_check_multi_opts_with_thread_map(
     ms: &MultiSource,
     skip_lower_threads: bool,
     auto_thread_asserts: bool,
+    explain_auto: bool,
     lint_naming: bool,
     thread_map: Option<std::rc::Rc<std::cell::RefCell<arch::thread_map::ThreadMap>>>,
 ) -> miette::Result<(
@@ -3938,6 +3959,7 @@ fn run_check_multi_opts_with_thread_map(
         ms,
         skip_lower_threads,
         auto_thread_asserts,
+        explain_auto,
         lint_naming,
         thread_map,
         None,
@@ -3948,6 +3970,7 @@ fn run_check_multi_opts_with_param_overrides(
     ms: &MultiSource,
     skip_lower_threads: bool,
     auto_thread_asserts: bool,
+    explain_auto: bool,
     lint_naming: bool,
     param_overrides: &std::collections::HashMap<String, u64>,
 ) -> miette::Result<(
@@ -3959,6 +3982,7 @@ fn run_check_multi_opts_with_param_overrides(
         ms,
         skip_lower_threads,
         auto_thread_asserts,
+        explain_auto,
         lint_naming,
         None,
         Some(param_overrides),
@@ -3969,6 +3993,7 @@ fn run_check_multi_opts_with_thread_map_and_params(
     ms: &MultiSource,
     skip_lower_threads: bool,
     auto_thread_asserts: bool,
+    explain_auto: bool,
     lint_naming: bool,
     thread_map: Option<std::rc::Rc<std::cell::RefCell<arch::thread_map::ThreadMap>>>,
     param_overrides: Option<&std::collections::HashMap<String, u64>>,
@@ -4094,6 +4119,30 @@ fn run_check_multi_opts_with_thread_map_and_params(
     // Elaborate (expand generate blocks)
     let ast = elaborate::elaborate(parsed_ast).map_err(|errs| ms.report_errors(errs))?;
 
+    // Expand `auto;` inside inst bodies into ordinary connections. Runs
+    // here — after elaboration, before every lowering — because at this
+    // point inst-body `for` loops are flattened, generate blocks expanded,
+    // `connect` sugar appended, and module variants monomorphized (so child
+    // port widths resolve). Everything downstream sees a fully explicit
+    // connection set.
+    let (ast, auto_notes, auto_warnings) =
+        elaborate::expand_auto_connect(ast, /*best_effort=*/ false)
+            .map_err(|errs| ms.report_errors(errs))?;
+    if explain_auto {
+        for note in &auto_notes {
+            eprintln!(
+                "note: inst `{}` of `{}`: auto-connect filled {}",
+                note.inst_name,
+                note.module_name,
+                note.conns
+                    .iter()
+                    .map(|c| format!("{c};"))
+                    .collect::<Vec<_>>()
+                    .join(" "),
+            );
+        }
+    }
+
     // Rewrite TLM target threads (`thread port.method(args) ...`) into
     // regular threads that drive the req/rsp handshake. Must run before
     // the generic lower_threads, which rejects TLM-bound threads.
@@ -4193,6 +4242,7 @@ fn run_check_multi_opts_with_thread_map_and_params(
     let (mut warnings, overload_map) = checker.check().map_err(|errs| ms.report_errors(errs))?;
     warnings.extend(pipe_reg_warnings);
     warnings.extend(naming_warnings);
+    warnings.extend(auto_warnings);
 
     for w in &warnings {
         let (filename, _, local_offset) = ms.locate(w.span.start);

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3702,10 +3702,30 @@ impl Parser {
         let mut param_assigns = Vec::new();
         let mut connections = Vec::new();
         let mut for_loops = Vec::new();
+        let mut auto_connect: Option<Span> = None;
 
         while !self.check_end_inst() {
             if self.check(TokenKind::For) {
                 for_loops.push(self.parse_inst_for_loop()?);
+                continue;
+            }
+            // `auto;` — auto-connect directive. Recognised contextually
+            // (`auto` is NOT a lexer keyword), so a port genuinely named
+            // `auto` still parses as a connection: the disambiguator is the
+            // token that follows, `;` for the directive vs `<-`/`->` for a
+            // connection.
+            if self.check_ident("auto")
+                && matches!(self.peek_kind_at(self.pos + 1), Some(TokenKind::Semi))
+            {
+                let span = self.advance().span; // consume `auto`
+                self.advance(); // consume `;`
+                if auto_connect.is_some() {
+                    return Err(CompileError::general(
+                        &format!("duplicate `auto;` in inst `{}`", name.name),
+                        span,
+                    ));
+                }
+                auto_connect = Some(span);
                 continue;
             }
             if self.check_param() {
@@ -3885,6 +3905,7 @@ impl Parser {
             param_assigns,
             connections,
             for_loops,
+            auto_connect,
         })
     }
 
@@ -3892,6 +3913,18 @@ impl Parser {
     /// Used inside inst body for-loops.
     fn parse_inst_connection(&mut self) -> Result<Connection, CompileError> {
         let cstart = self.peek_span();
+        // `auto;` is an inst-body directive, not a connection — reject it
+        // inside a wiring `for` loop with a message that says so, instead of
+        // the bare "expected <- or ->" the ident path would produce.
+        if self.check_ident("auto")
+            && matches!(self.peek_kind_at(self.pos + 1), Some(TokenKind::Semi))
+        {
+            return Err(CompileError::general(
+                "`auto;` is not allowed inside an inst-body `for` loop — put it \
+                 directly in the inst body (it applies to the whole inst)",
+                cstart,
+            ));
+        }
         let mut port_name = self.expect_ident()?;
         if self.eat(TokenKind::LBracket) {
             // Inside an inst-body for-loop, the index can be either a literal

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -150,6 +150,27 @@ pub struct BusInfo {
 }
 
 impl BusInfo {
+    /// Build a `BusInfo` straight from its AST declaration.
+    ///
+    /// `resolve()` uses this when populating the global symbol table, and
+    /// pre-resolve passes (`elaborate::auto_connect`) use it to reach
+    /// `effective_signals` without a `SymbolTable` in hand.
+    pub fn from_decl(b: &crate::ast::BusDecl) -> Self {
+        BusInfo {
+            name: b.name.name.clone(),
+            params: b.params.clone(),
+            signals: b
+                .signals
+                .iter()
+                .map(|s| (s.name.name.clone(), s.direction, s.ty.clone()))
+                .collect(),
+            generates: b.generates.clone(),
+            handshakes: b.handshakes.clone(),
+            credit_channels: b.credit_channels.clone(),
+            tlm_methods: b.tlm_methods.clone(),
+        }
+    }
+
     /// Build a param map from this bus's default param values.
     pub fn default_param_map(&self) -> HashMap<String, &Expr> {
         self.params
@@ -823,19 +844,7 @@ pub fn resolve(source_file: &SourceFile) -> Result<SymbolTable, Vec<CompileError
                 if table.globals.contains_key(&b.name.name) {
                     errors.push(CompileError::duplicate(&b.name.name, b.name.span));
                 } else {
-                    let info = BusInfo {
-                        name: b.name.name.clone(),
-                        params: b.params.clone(),
-                        signals: b
-                            .signals
-                            .iter()
-                            .map(|s| (s.name.name.clone(), s.direction, s.ty.clone()))
-                            .collect(),
-                        generates: b.generates.clone(),
-                        handshakes: b.handshakes.clone(),
-                        credit_channels: b.credit_channels.clone(),
-                        tlm_methods: b.tlm_methods.clone(),
-                    };
+                    let info = BusInfo::from_decl(b);
                     table
                         .globals
                         .insert(b.name.name.clone(), (Symbol::Bus(info), b.name.span));

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -40029,3 +40029,122 @@ fn test_auto_connect_noop_warns() {
         "{warnings:?}"
     );
 }
+
+/// A sibling port whose name merely *starts with* the bus port's name plus
+/// `_` must not be mistaken for a per-field binding of that bus.
+///
+/// `BpLeaf` has a bus port `m` (flattening to `m_req_valid`, ...) and an
+/// ordinary port `m_extra`. Connecting `m_extra` explicitly used to make a
+/// `p_`-prefix test believe bus port `m` was already bound, so `auto;`
+/// skipped it and `m` came out dangling — a silent wrong answer rather than
+/// a diagnostic. The fill must be driven by the bus's real field names.
+#[test]
+fn test_auto_connect_bus_not_confused_by_prefix_sibling_port() {
+    let src = "
+domain SysDomain
+  freq_mhz: 100
+end domain SysDomain
+
+bus BpBus
+  param DATA_W: const = 32;
+  req_valid: out Bool;
+  req_ready: in Bool;
+  req_data:  out UInt<DATA_W>;
+end bus BpBus
+
+module BpLeaf
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port m: initiator BpBus<DATA_W=32>;
+  port m_extra: in Bool;
+
+  reg d: UInt<32> reset rst => 0;
+  comb
+    m.req_valid = m_extra;
+    m.req_data = d;
+  end comb
+end module BpLeaf
+
+module BpTop
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port flag: in Bool;
+  port m: initiator BpBus<DATA_W=32>;
+
+  inst u0: BpLeaf
+    m_extra <- flag;
+    auto;
+  end inst u0
+end module BpTop
+";
+    // The bus port must still be filled despite `m_extra` being connected.
+    let notes = auto_connect_notes(src);
+    let (_inst, conns) = notes.first().expect("one auto-connected inst");
+    assert!(
+        conns.iter().any(|c| c == "m -> m"),
+        "bus port `m` must be auto-filled even though sibling `m_extra` is \
+         explicitly connected; got {conns:?}"
+    );
+
+    // And it must reach the emitted SV as the full flattened bundle.
+    let sv = compile_to_sv(src);
+    for sig in [
+        ".m_req_valid(m_req_valid)",
+        ".m_req_ready(m_req_ready)",
+        ".m_req_data(m_req_data)",
+    ] {
+        assert!(sv.contains(sig), "missing {sig} in:\n{sv}");
+    }
+    assert!(sv.contains(".m_extra(flag)"), "{sv}");
+}
+
+/// The converse: a genuine per-field binding still counts as connected, so
+/// `auto;` must NOT also emit a whole-bus connection for the same port
+/// (that would double-drive it).
+#[test]
+fn test_auto_connect_bus_per_field_binding_suppresses_whole_fill() {
+    let src = "
+domain SysDomain
+  freq_mhz: 100
+end domain SysDomain
+
+bus BpBus2
+  req_valid: out Bool;
+  req_ready: in Bool;
+end bus BpBus2
+
+module BpLeaf2
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port m: initiator BpBus2;
+
+  comb
+    m.req_valid = 1;
+  end comb
+end module BpLeaf2
+
+module BpTop2
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port v: out Bool;
+  port r: in Bool;
+
+  inst u0: BpLeaf2
+    m.req_valid -> v;
+    m.req_ready <- r;
+    auto;
+  end inst u0
+end module BpTop2
+";
+    let notes = auto_connect_notes(src);
+    // clk/rst get filled; `m` must not, because it is already bound per-field.
+    if let Some((_inst, conns)) = notes.first() {
+        assert!(
+            !conns.iter().any(|c| c.starts_with("m ")),
+            "per-field-bound bus port must not also be filled whole: {conns:?}"
+        );
+    }
+    let sv = compile_to_sv(src);
+    assert!(sv.contains(".m_req_valid(v)"), "{sv}");
+    assert!(sv.contains(".m_req_ready(r)"), "{sv}");
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -62,6 +62,9 @@ fn compile_to_sv_with_opts(source: &str, opts: &elaborate::ThreadLowerOpts) -> S
     let mut parser = Parser::new(tokens, source);
     let parsed_ast = parser.parse_source_file().expect("parse error");
     let ast = elaborate::elaborate(parsed_ast).expect("elaborate error");
+    let ast = elaborate::expand_auto_connect(ast, false)
+        .expect("auto-connect error")
+        .0;
     let ast = elaborate::lower_tlm_target_threads(ast).expect("tlm_target lowering error");
     let ast = elaborate::lower_tlm_initiator_calls(ast).expect("tlm_initiator lowering error");
     let ast = elaborate::lower_threads_with_opts(ast, opts).expect("lower_threads error");
@@ -79,6 +82,8 @@ fn warnings_after_full_lower(source: &str) -> Vec<String> {
     let mut parser = Parser::new(tokens, source);
     let parsed_ast = parser.parse_source_file().expect("parse error");
     let ast = elaborate::elaborate(parsed_ast).expect("elaborate error");
+    let (ast, _notes, auto_warnings) =
+        elaborate::expand_auto_connect(ast, false).expect("auto-connect error");
     let ast = elaborate::lower_tlm_target_threads(ast).expect("tlm_target lowering error");
     let ast = elaborate::lower_tlm_initiator_calls(ast).expect("tlm_initiator lowering error");
     let ast = elaborate::lower_threads(ast).expect("lower_threads error");
@@ -87,7 +92,11 @@ fn warnings_after_full_lower(source: &str) -> Vec<String> {
     let symbols = resolve::resolve(&ast).expect("resolve error");
     let checker = TypeChecker::new(&symbols, &ast);
     let (warnings, _) = checker.check().expect("type check error");
-    warnings.into_iter().map(|w| w.message).collect()
+    warnings
+        .into_iter()
+        .chain(auto_warnings)
+        .map(|w| w.message)
+        .collect()
 }
 
 fn collect_thread_map(source: &str) -> arch::thread_map::ThreadMap {
@@ -39407,4 +39416,616 @@ end module ClkCtrl
 "#;
     typecheck_errors(source)
         .expect("a net bound by an `inst` output connection must resolve at its read site");
+}
+
+// ── `auto;` auto-connect (issue #754) ────────────────────────────────────────
+//
+// `auto;` fills every child port the explicit connections left unconnected
+// with the identically-named signal in scope. It is a front-end desugar, so
+// the headline test is byte-equality of emitted SV against the hand-written
+// twin — everything else is diagnostics.
+
+/// Run parse → elaborate → auto-connect and return the auto-connect errors.
+fn auto_connect_errors(source: &str) -> Vec<String> {
+    let tokens = lexer::tokenize(source).expect("lexer error");
+    let mut parser = Parser::new(tokens, source);
+    let parsed_ast = parser.parse_source_file().expect("parse error");
+    let ast = elaborate::elaborate(parsed_ast).expect("elaborate error");
+    match elaborate::expand_auto_connect(ast, false) {
+        Ok(_) => Vec::new(),
+        Err(errs) => errs.iter().map(|e| e.to_string()).collect(),
+    }
+}
+
+/// The connection lists `--explain-auto` would print, one entry per inst.
+fn auto_connect_notes(source: &str) -> Vec<(String, Vec<String>)> {
+    let tokens = lexer::tokenize(source).expect("lexer error");
+    let mut parser = Parser::new(tokens, source);
+    let parsed_ast = parser.parse_source_file().expect("parse error");
+    let ast = elaborate::elaborate(parsed_ast).expect("elaborate error");
+    let (_ast, notes, _warnings) =
+        elaborate::expand_auto_connect(ast, false).expect("auto-connect error");
+    notes.into_iter().map(|n| (n.inst_name, n.conns)).collect()
+}
+
+const AC_SUB: &str = "
+domain SysDomain
+  freq_mhz: 100
+end domain SysDomain
+
+module AcSub
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port en: in Bool;
+  port a: in UInt<8>;
+  port y: out UInt<8>;
+
+  reg acc: UInt<8> reset rst => 0;
+  seq on clk rising
+    if en
+      acc <= a;
+    end if
+  end seq
+  comb
+    y = acc;
+  end comb
+end module AcSub
+";
+
+fn ac_top(inst_body: &str) -> String {
+    format!(
+        "{AC_SUB}
+module AcTop
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port en: in Bool;
+  port din: in UInt<8>;
+  port dout: out UInt<8>;
+
+  wire a: UInt<8>;
+  wire y: UInt<8>;
+
+  comb
+    a = din;
+    dout = y;
+  end comb
+
+  inst u0: AcSub
+{inst_body}
+  end inst u0
+end module AcTop
+"
+    )
+}
+
+/// The load-bearing property: `auto;` is a pure desugar, so the SV it
+/// produces is byte-identical to the hand-written connection list.
+#[test]
+fn test_auto_connect_sv_identical_to_explicit() {
+    let auto_sv = compile_to_sv(&ac_top("    auto;"));
+    let explicit_sv = compile_to_sv(&ac_top(
+        "    clk <- clk;
+    rst <- rst;
+    en <- en;
+    a <- a;
+    y -> y;",
+    ));
+    assert_eq!(
+        auto_sv, explicit_sv,
+        "`auto;` must emit exactly what the explicit connection list emits"
+    );
+    assert!(auto_sv.contains(".clk(clk)"), "{auto_sv}");
+    assert!(auto_sv.contains(".y(y)"), "{auto_sv}");
+}
+
+/// Explicit connections win; `auto;` only fills the remainder — including
+/// when the explicit connection is written *after* the directive.
+#[test]
+fn test_auto_connect_explicit_takes_precedence() {
+    let sv = compile_to_sv(&ac_top(
+        "    auto;
+    a <- din;",
+    ));
+    assert!(
+        sv.contains(".a(din)"),
+        "explicit `a <- din` must survive, not be overwritten by `a <- a`:\n{sv}"
+    );
+    assert!(!sv.contains(".a(a)"), "{sv}");
+    // The rest still gets filled.
+    assert!(sv.contains(".en(en)"), "{sv}");
+    assert!(sv.contains(".y(y)"), "{sv}");
+}
+
+#[test]
+fn test_auto_connect_unmatched_input_errors() {
+    let src = format!(
+        "{AC_SUB}
+module AcTop
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port en: in Bool;
+  port dout: out UInt<8>;
+
+  wire y: UInt<8>;
+  comb
+    dout = y;
+  end comb
+
+  inst u0: AcSub
+    auto;
+  end inst u0
+end module AcTop
+"
+    );
+    let errs = auto_connect_errors(&src);
+    assert!(
+        errs.iter()
+            .any(|e| e.contains("no signal `a` in scope for input port `a`")),
+        "{errs:?}"
+    );
+}
+
+#[test]
+fn test_auto_connect_unmatched_output_errors() {
+    let src = format!(
+        "{AC_SUB}
+module AcTop
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port en: in Bool;
+  port din: in UInt<8>;
+
+  wire a: UInt<8>;
+  comb
+    a = din;
+  end comb
+
+  inst u0: AcSub
+    auto;
+  end inst u0
+end module AcTop
+"
+    );
+    let errs = auto_connect_errors(&src);
+    assert!(
+        errs.iter()
+            .any(|e| e.contains("no signal `y` in scope for output port `y`")),
+        "{errs:?}"
+    );
+}
+
+/// The type gate: a concrete width mismatch is an error, not a silent
+/// connection (inst connections are otherwise untyped today — see #737).
+#[test]
+fn test_auto_connect_width_mismatch_errors() {
+    let src = "
+domain SysDomain
+  freq_mhz: 100
+end domain SysDomain
+
+module WSub
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port a: in UInt<16>;
+  port y: out UInt<8>;
+  comb
+    y = a.trunc<8>();
+  end comb
+end module WSub
+
+module WTop
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port din: in UInt<8>;
+  port dout: out UInt<8>;
+
+  wire a: UInt<8>;
+  wire y: UInt<8>;
+  comb
+    a = din;
+    dout = y;
+  end comb
+
+  inst u0: WSub
+    auto;
+  end inst u0
+end module WTop
+";
+    let errs = auto_connect_errors(src);
+    assert!(
+        errs.iter().any(|e| e.contains("type mismatch for port `a`")
+            && e.contains("port is UInt<16>")
+            && e.contains("signal `a` is UInt<8>")),
+        "{errs:?}"
+    );
+}
+
+/// Reset kind/polarity is the classic silent-miscompile shape: the gate
+/// catches it and names the `as Reset<...>` override as the explicit fix.
+#[test]
+fn test_auto_connect_reset_polarity_mismatch_errors() {
+    let src = "
+domain SysDomain
+  freq_mhz: 100
+end domain SysDomain
+
+module RSub
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Async, Low>;
+  port a: in UInt<8>;
+  port y: out UInt<8>;
+  reg acc: UInt<8> reset rst => 0;
+  seq on clk rising
+    acc <= a;
+  end seq
+  comb
+    y = acc;
+  end comb
+end module RSub
+
+module RTop
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync, High>;
+  port din: in UInt<8>;
+  port dout: out UInt<8>;
+
+  wire a: UInt<8>;
+  wire y: UInt<8>;
+  comb
+    a = din;
+    dout = y;
+  end comb
+
+  inst u0: RSub
+    auto;
+  end inst u0
+end module RTop
+";
+    let errs = auto_connect_errors(src);
+    assert!(
+        errs.iter()
+            .any(|e| e.contains("type mismatch for port `rst`")
+                && e.contains("Reset<Async, Low>")
+                && e.contains("Reset<Sync, High>")
+                && e.contains("as Reset<Async, Low>")),
+        "{errs:?}"
+    );
+}
+
+/// The gate is deliberately conservative: when a width stays
+/// param-dependent it defers to the ordinary connection checks rather than
+/// guessing.
+#[test]
+fn test_auto_connect_param_dependent_width_defers() {
+    let src = "
+domain SysDomain
+  freq_mhz: 100
+end domain SysDomain
+
+module PSub
+  param W: const = 8;
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port a: in UInt<W>;
+  port y: out UInt<W>;
+  comb
+    y = a;
+  end comb
+end module PSub
+
+module PTop
+  param W: const = 8;
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port din: in UInt<W>;
+  port dout: out UInt<W>;
+
+  wire a: UInt<W>;
+  wire y: UInt<W>;
+  comb
+    a = din;
+    dout = y;
+  end comb
+
+  inst u0: PSub
+    param W = W;
+    auto;
+  end inst u0
+end module PTop
+";
+    assert!(auto_connect_errors(src).is_empty());
+    let sv = compile_to_sv(src);
+    assert!(sv.contains(".a(a)") && sv.contains(".y(y)"), "{sv}");
+}
+
+/// A whole-bus port fills as one connection and expands to every flattened
+/// bus signal, exactly as an explicit whole-bus connection would.
+#[test]
+fn test_auto_connect_whole_bus_port() {
+    let src = "
+domain SysDomain
+  freq_mhz: 100
+end domain SysDomain
+
+bus AcSimple
+  param DATA_W: const = 32;
+  req_valid: out Bool;
+  req_ready: in Bool;
+  req_data:  out UInt<DATA_W>;
+end bus AcSimple
+
+module BLeaf
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port m: initiator AcSimple<DATA_W=32>;
+  reg d: UInt<32> reset rst => 0;
+  comb
+    m.req_valid = 1;
+    m.req_data = d;
+  end comb
+end module BLeaf
+
+module BTop
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port m: initiator AcSimple<DATA_W=32>;
+
+  inst u0: BLeaf
+    auto;
+  end inst u0
+end module BTop
+";
+    let sv = compile_to_sv(src);
+    for sig in [
+        ".m_req_valid(m_req_valid)",
+        ".m_req_ready(m_req_ready)",
+        ".m_req_data(m_req_data)",
+    ] {
+        assert!(sv.contains(sig), "missing {sig} in:\n{sv}");
+    }
+}
+
+/// `ports[N]` groups on a `regfile` child fill by flattened name, and a
+/// literal count-1 group uses the `<group>_<sig>` spelling that
+/// `normalize_count1_portarray_conns` produces for explicit connections.
+#[test]
+fn test_auto_connect_port_array_groups() {
+    let src = "
+domain SysDomain
+  freq_mhz: 100
+end domain SysDomain
+
+regfile AcRegs
+  param NREGS: const = 8;
+  param T: type = UInt<32>;
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  ports[2] read
+    addr: in UInt<3>;
+    data: out UInt<32>;
+  end ports read
+  ports[1] write
+    en:   in Bool;
+    addr: in UInt<3>;
+    data: in UInt<32>;
+  end ports write
+end regfile AcRegs
+
+module RfTop
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port a0: in UInt<3>;
+  port wen: in Bool;
+  port d0: out UInt<32>;
+
+  wire read0_addr: UInt<3>;
+  wire read1_addr: UInt<3>;
+  wire read0_data: UInt<32>;
+  wire read1_data: UInt<32>;
+  wire write_en: Bool;
+  wire write_addr: UInt<3>;
+  wire write_data: UInt<32>;
+
+  comb
+    read0_addr = a0;
+    read1_addr = a0;
+    write_en = wen;
+    write_addr = a0;
+    write_data = 0;
+    d0 = read0_data;
+  end comb
+
+  inst u0: AcRegs
+    auto;
+  end inst u0
+end module RfTop
+";
+    let notes = auto_connect_notes(src);
+    let (inst, conns) = notes.first().expect("one auto-connected inst");
+    assert_eq!(inst, "u0");
+    // Indexed group → `read0_addr` / `read1_addr`; count-1 group → `write_en`
+    // (NOT `write0_en`).
+    for expected in [
+        "read0_addr <- read0_addr",
+        "read1_data -> read1_data",
+        "write_en <- write_en",
+        "write_data <- write_data",
+    ] {
+        assert!(
+            conns.iter().any(|c| c == expected),
+            "expected `{expected}` in {conns:?}"
+        );
+    }
+    assert!(
+        !conns.iter().any(|c| c.starts_with("write0_")),
+        "count-1 group must not use the indexed spelling: {conns:?}"
+    );
+}
+
+/// `auto;` survives `generate_for` — including the SV-genvar-preserved form,
+/// where the inst stays inside the emitted `for` block.
+#[test]
+fn test_auto_connect_inside_generate_for() {
+    let src = "
+domain SysDomain
+  freq_mhz: 100
+end domain SysDomain
+
+module GCell
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port en: in Bool;
+  port y: out UInt<8>;
+  reg acc: UInt<8> reset rst => 0;
+  seq on clk rising
+    if en
+      acc <= (acc + 1).trunc<8>();
+    end if
+  end seq
+  comb
+    y = acc;
+  end comb
+end module GCell
+
+module GTop
+  param N: const = 3;
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port en: in Bool;
+  port dout: out UInt<8>;
+
+  wire y: UInt<8>;
+
+  generate_for i in 0..N-1
+    inst cell_i: GCell
+      y -> y;
+      auto;
+    end inst cell_i
+  end generate_for
+
+  comb
+    dout = y;
+  end comb
+end module GTop
+";
+    let sv = compile_to_sv(src);
+    assert!(
+        sv.contains(".clk(clk)") && sv.contains(".rst(rst)") && sv.contains(".en(en)"),
+        "{sv}"
+    );
+    assert!(sv.contains(".y(y)"), "{sv}");
+}
+
+/// `auto` is a contextual keyword, not a reserved word: a port genuinely
+/// named `auto` still connects, and the directive skips it as already
+/// connected.
+#[test]
+fn test_auto_connect_auto_still_valid_identifier() {
+    let src = "
+domain SysDomain
+  freq_mhz: 100
+end domain SysDomain
+
+module IdSub
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port auto: in Bool;
+  port y: out Bool;
+  comb
+    y = auto;
+  end comb
+end module IdSub
+
+module IdTop
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  port en: in Bool;
+  port dout: out Bool;
+
+  wire y: Bool;
+  comb
+    dout = y;
+  end comb
+
+  inst u0: IdSub
+    auto <- en;
+    auto;
+  end inst u0
+end module IdTop
+";
+    let sv = compile_to_sv(src);
+    assert!(sv.contains(".auto(en)"), "{sv}");
+    assert!(sv.contains(".clk(clk)") && sv.contains(".y(y)"), "{sv}");
+}
+
+#[test]
+fn test_auto_connect_duplicate_directive_rejected() {
+    let src = ac_top("    auto;\n    auto;");
+    let tokens = lexer::tokenize(&src).expect("lexer error");
+    let mut parser = Parser::new(tokens, &src);
+    let err = parser
+        .parse_source_file()
+        .expect_err("duplicate `auto;` must not parse");
+    assert!(
+        err.to_string().contains("duplicate `auto;` in inst `u0`"),
+        "{err}"
+    );
+}
+
+#[test]
+fn test_auto_connect_in_inst_for_loop_rejected() {
+    let src = "
+domain SysDomain
+  freq_mhz: 100
+end domain SysDomain
+
+module LSub
+  port clk: in Clock<SysDomain>;
+  port ins: in Vec<UInt<8>, 2>;
+  port y: out UInt<8>;
+  comb
+    y = ins[0];
+  end comb
+end module LSub
+
+module LTop
+  port clk: in Clock<SysDomain>;
+  port y: out UInt<8>;
+  inst u0: LSub
+    for k in 0..1
+      auto;
+    end for
+  end inst u0
+end module LTop
+";
+    let tokens = lexer::tokenize(src).expect("lexer error");
+    let mut parser = Parser::new(tokens, src);
+    let err = parser
+        .parse_source_file()
+        .expect_err("`auto;` inside an inst-body for loop must not parse");
+    assert!(
+        err.to_string()
+            .contains("`auto;` is not allowed inside an inst-body `for` loop"),
+        "{err}"
+    );
+}
+
+/// A stale `auto;` that fills nothing is a warning, not silence — it means
+/// the connection list drifted past the directive.
+#[test]
+fn test_auto_connect_noop_warns() {
+    let warnings = warnings_after_full_lower(&ac_top(
+        "    clk <- clk;
+    rst <- rst;
+    en <- en;
+    a <- a;
+    y -> y;
+    auto;",
+    ));
+    assert!(
+        warnings
+            .iter()
+            .any(|w| w.contains("`auto;` in inst `u0` filled no ports")),
+        "{warnings:?}"
+    );
 }


### PR DESCRIPTION
Implements the `auto;` auto-connect directive from #754.

A single `auto;` line inside an `inst` body connects every child port the explicit connections left unconnected to the **identically-named** signal in the enclosing scope. Explicit connections always win, wherever they sit relative to the directive.

```arch
inst alu0: Alu
  a <- Decode.rs1_fwd;    // explicit where the names differ
  b <- Decode.rs2_val;
  auto;                   // clk <- clk, rst <- rst, en <- en, result -> result, ...
end inst alu0
```

## Why

13 of 34 connection lines in `examples/*.arch` (38%) are identical-name `port <- port` boilerplate. `inst` + N connections is also ARCH's worst length offender against the SV reference (`Prob068_countbcd` = 205%). Clock/reset plumbing is the most mechanical *and* most error-prone part of a hierarchical design — and today's unconnected-port check in `typecheck.rs` deliberately **skips** Clock and Reset ports, so a missing `clk` isn't even diagnosed. `auto;` makes the common correct case one line while keeping every fill visible (`--explain-auto`) and checked.

## How

A pure front-end desugar: the new `elaborate::expand_auto_connect` pass rewrites `auto;` into ordinary `Connection`s right after `elaborate()` — at that point inst-body `for` loops are flattened, generate blocks expanded, `connect` sugar appended, and module variants monomorphized (so child port widths resolve). Resolve, typecheck, and all three backends see an ordinary explicit connection set and know nothing about `auto;`.

The headline test asserts the property directly: **emitted SV is byte-identical to the hand-written twin**.

**Fills**: ordinary ports (incl. `Clock`, `Reset`, `Vec`, struct, enum), whole `bus` ports (incl. `Vec<Bus, N>`), and `ports[N]` groups by flattened name (`read0_addr`; `write_en` for a literal count-1 group, matching `normalize_count1_portarray_conns`).

**In scope**: the enclosing construct's ports, its `reg`/`wire`/`let`/`pipe_reg` declarations, flattened bus fields, and the targets of *explicit* inst output connections. Names created by another inst's `auto;` are excluded, so expansion is order-independent.

Works in module bodies, inside `generate_for` / `generate_if` (including the SV-genvar-preserved form), and in `pipeline` stage bodies.

## Safety — both invariants preserved, not weakened

- **All ports connected.** No name match is an error, for inputs *and* outputs. `auto;` never leaves a port dangling and never silently declares a net.
- **No implicit conversion.** Each fill is type-checked against the declared signal before synthesis. A definite mismatch — width, signedness, `Vec` length, reset kind/polarity, clock domain, named type — is an error naming both sides, with the `as Reset<...>` override suggested for the reset case. This matters because inst connections are otherwise **untyped** today (#737), so without the gate `auto;` could wire an inverted reset silently. The comparison is deliberately conservative: param-dependent widths and undeclared inst-output wires defer to the existing checks rather than inventing a type rule here.

`auto` is recognized **contextually** — only as a complete `auto;` statement in an inst body — so it stays a legal identifier everywhere else and a port genuinely named `auto` still connects (`auto <- en;`). Duplicate `auto;` and `auto;` inside an inst-body `for` loop are parse errors. A stale `auto;` that fills nothing warns.

Designs that don't use `auto;` are untouched: the pass early-returns when no directive is present in the file.

## Also in this PR (reuse for the new pass)

- `Item::ports()` / `Item::params()` / `Item::port_arrays()` in `ast.rs`, replacing the duplicated `item_ports` / `item_params` helpers in `main.rs` and `graph.rs`.
- `BusInfo::from_decl` extracted in `resolve.rs` so a pre-resolve pass can reach `effective_signals`.

## Docs

Grammar-surface change, so `doc/ARCH_HDL_Specification.md` (inst-connections section) and `doc/Arch_AI_Reference_Card.md` are updated here, plus the skill reference snapshots (`scripts/sync_skill_snapshots.sh refresh`). The reference card is what the MCP server serves as `get_construct_syntax("module")`, so agents pick this up automatically.

## Verification

- `cargo test` — full suite green (14 new `auto_connect` tests).
- New tests cover: SV byte-equality vs explicit, explicit-wins precedence, unmatched input/output errors, width and reset-polarity gate errors, param-dependent deferral, whole-bus fill, `ports[N]` + count-1 spelling, `generate_for`, `auto` as an identifier, duplicate/for-loop parse errors, and the no-op warning.
- Manually verified end-to-end with `arch check`/`arch build --explain-auto` on module, bus, regfile-`ports[N]`, `generate_for`, and pipeline-stage fixtures.
- `scripts/refactor_diff.sh origin/main` (zero-diff over the regression corpus) runs after this PR opens, per fast-gate-before-PR ordering.

closes #754
