### PR TITLE
feat(fp): UE4M3 as a ScaledVec block scale — NVFP4 (closes #905)

### DIFF
--- a/doc/ARCH_HDL_Specification.md
+++ b/doc/ARCH_HDL_Specification.md
@@ -838,9 +838,10 @@ to a scale, and `is_nan` tests the single code `0x7F`. Because a scale is
 non-negative, `.to_ue4m3()` takes the **magnitude** of its operand (as
 `.to_e8m0()` does) and always clears the padding bit.
 
-`UE4M3` is a scalar type today. Using it as a `ScaledVec` scale is not yet
-supported --- see §3.11 --- because the block operations depend on the scale
-being a power of two.
+`UE4M3` is also a `ScaledVec` scale --- that is what it exists for --- giving
+NVFP4 as `ScaledVec<FP4E2M1, 16, UE4M3>`. The block operations do not need a
+power-of-two scale: `scaled_quantize` never divides by the scale at all, so
+the single-rounding property survives. See §3.11.1.
 
 
 
@@ -1071,7 +1072,12 @@ ScaledVec<Elem, N, Scale>
 Microscaling (MX) formats. The scale is a **parameter, not a fixed type**,
 because the two ecosystems genuinely differ --- MX uses `E8M0`, NVFP4 uses a
 `UE4M3` that is *not* our `FP8E4M3` (unsigned, 7 significant bits, NaN
-`0x7F`). `UE4M3` and NVFP4 are not yet implemented.
+`0x7F`). Both scales are supported:
+
+```arch
+type MXFP4 = ScaledVec<FP4E2M1, 32, E8M0>;
+type NVFP4 = ScaledVec<FP4E2M1, 16, UE4M3>;
+```
 
 The three arguments are constrained:
 
@@ -1080,11 +1086,13 @@ The three arguments are constrained:
     scale has no meaning over wider or integer elements.
   - **`N`** is a const expression `>= 1`. A block with no elements is just a
     bare scale.
-  - **`Scale`** must be `E8M0`. `UE4M3` (§3.10a) exists as a scalar type but
-    is not yet accepted here: unlike `E8M0` its value is not a power of two,
-    so dividing by it is inexact and the block operations' single-rounding
-    property (§3.11.1) does not hold. `FP8E4M3` is **not** a stand-in for
-    either.
+  - **`Scale`** must be `E8M0` (OCP MX) or `UE4M3` (NVFP4, §3.10a).
+    `FP8E4M3` is **not** a stand-in for `UE4M3` --- that one is signed and
+    its NaN is sign-agnostic. The two scales differ in more than width:
+    `E8M0` is a pure power of two with no zero, `UE4M3` carries three
+    mantissa bits, *has* a zero at `0x00`, and reserves `0x7F` (not `0xFF`)
+    for NaN. Those differences reach the surface, so they are spelled out
+    per operation below rather than left implicit.
 
 **A block is one packed word, not an array.** Layout is
 `{ scale[w-1:0], P[N-1], …, P[1], P[0] }` --- scale in the high bits,
@@ -1179,7 +1187,7 @@ applied, and is the only way to read an element (§3.11).
 
 | Selector | Values | Default |
 |---|---|---|
-| `policy` | `floor_pow2`, `ceil_pow2` | `floor_pow2` |
+| `policy` | `floor_pow2`, `ceil_pow2`, `exact` | **scale-dependent** --- see below |
 | `rounding` | `rne` (`rtz`, `rna` reserved) | `rne` |
 
 `floor_pow2` is the OCP §6.3 rule: the shared scale is the largest power of
@@ -1187,16 +1195,35 @@ two that normalizes the block maximum into the element format's top binade.
 Because that binade's largest *representable* value is below its top, some
 elements saturate --- routine under this policy, not a corner case.
 `ceil_pow2` rounds the scale up instead when the block maximum is not already
-a power of two, trading the top element codes for fewer saturations.
+a power of two, trading the top element codes for fewer saturations. `exact`
+takes `X = RNE(amax / elem_max)`, using the scale's mantissa instead of
+discarding it; it is **refused for `E8M0`**, where every value is already a
+power of two and there is no mantissa to use.
 
-Semantics, all of which follow from `E8M0` having no zero and reserving
-`0xFF` for NaN:
+**The default policy depends on the scale**, because one default cannot serve
+both: `floor_pow2` for `E8M0` (OCP §6.3), `exact` for `UE4M3`. Defaulting a
+UE4M3 block to `floor_pow2` would discard all three of its mantissa bits and
+silently produce a power-of-two-scale block where NVFP4 was asked for ---
+numerically a different format from the one every NVFP4 implementation ships.
+Write the policy explicitly if you want the other behaviour; both remain
+available under either scale.
 
-  - An **all-zero** block gets the *minimum* scale `0x00` (which denotes
-    `2^-127`, not zero) and zero elements.
-  - A block containing **any NaN or infinity** gets the NaN scale `0xFF`; its
-    element bits are then don't-care, and `scaled_dequantize` yields NaN in
-    every lane regardless of them.
+Semantics. The first two differ between the scales, and the difference is not
+cosmetic --- `E8M0` has no zero and reserves `0xFF`, `UE4M3` has a zero and
+reserves `0x7F`:
+
+  - An **all-zero** block gets scale code `0x00` and zero elements. For
+    `E8M0` that code denotes the *minimum scale* `2^-127` (the element plane
+    is what makes the block zero); for `UE4M3` it is a genuine **zero**,
+    which is sound precisely because every element is zero too.
+  - A block containing **any NaN or infinity** gets the NaN scale --- `0xFF`
+    for `E8M0`, `0x7F` for `UE4M3` (`0xFF` would set the padding bit `UE4M3`
+    requires to be zero). Its element bits are then don't-care, and
+    `scaled_dequantize` yields NaN in every lane regardless of them.
+  - Where the block maximum is nonzero but the scale would **underflow**, it
+    clamps to the smallest scale that is not zero: `0x00` for `E8M0`, `0x01`
+    for `UE4M3`. Clamping a `UE4M3` scale to `0x00` would set it to zero and
+    erase a block that has a nonzero maximum.
   - Dequantizing a finite element under a finite scale **saturates** to
     ±`FP32` max rather than overflowing to infinity. An element that is
     itself Inf or NaN (`FP8E5M2` / `FP8E4M3` can be) keeps its own result.
@@ -1205,8 +1232,32 @@ Semantics, all of which follow from `E8M0` having no zero and reserving
     all-finite formats (`FP4E2M1`, `FP6E2M3`, `FP6E3M2`) and becomes that
     format's NaN for `FP8E4M3`.
 
-Scaling by the reciprocal scale is an exact power-of-two multiply in FP32, so
-each element is rounded **once**, from the true `vᵢ / X`.
+**Each element is rounded exactly once, from the true `vᵢ / X`, under both
+scales** --- but for different reasons, and neither involves a division.
+
+  - Under `E8M0` the reciprocal `1/X` is itself a scale code (`2^-(c-127)` is
+    `2^((254-c)-127)`), so the scaling is one exact FP32 multiply and the
+    element narrow is the only rounding.
+  - Under `UE4M3` there is no such identity --- a mantissa-bearing scale has
+    no exactly representable reciprocal, and substituting `vᵢ × fl(1/X)`
+    changes the result on 4.76% of tie-aligned inputs. So the quantizer never
+    forms the quotient at all: it compares `|vᵢ|` against `X × m` for each
+    decision boundary `m` of the element grid, and picks the code the
+    comparisons land in. **Every such product is exact in FP32** --- the
+    scale carries 4 significand bits and a boundary at most 5, so the product
+    needs at most 9 of FP32's 24 --- which makes the comparison a decision
+    rather than an approximation, and the selected code correctly rounded by
+    construction. The scale itself is chosen the same way, against constant
+    thresholds. Ties resolve to even.
+
+A consequence worth stating: the error bounds of §3.11.3 rest on
+single-rounding, so they apply unchanged to `UE4M3` blocks.
+
+The division-free ladder costs one comparison per element-grid boundary: 8
+for `FP4E2M1` (NVFP4's element format), 32 for the `FP6` pair, and 127/124
+for `FP8E4M3`/`FP8E5M2`. A `UE4M3`-scaled block with 8-bit elements is
+therefore legal and correct but comparatively large; the sub-8-bit element
+formats the MX line is actually built on are cheap.
 
 Both conversions are combinational and must be the whole right-hand side of
 an assignment. To index an element, bind the result first:
@@ -1253,16 +1304,34 @@ pairwise summation's error grows as `O(log N)` against a serial accumulator's
 not a no-op in `FP32` (it turns `-0.0` into `+0.0`).
 
 **The two scales are applied one at a time**, as `(Σ ⊗ X^A) ⊗ X^B`, not as a
-pre-formed `X^A · X^B`. Each scale is a power of two, so each multiply is
-exact absent overflow --- but the two E8M0 scales span `2⁻¹²⁷ … 2¹²⁷`, so their
-*product* spans `2⁻²⁵⁴ … 2²⁵⁴` and can overflow to infinity or flush to zero
-even when the final result is perfectly representable. Applying them
+pre-formed `X^A · X^B`. Under `E8M0` each scale is a power of two, so each
+multiply is exact absent overflow --- but the two scales span `2⁻¹²⁷ … 2¹²⁷`,
+so their *product* spans `2⁻²⁵⁴ … 2²⁵⁴` and can overflow to infinity or flush
+to zero even when the final result is perfectly representable. Applying them
 separately has a strictly wider exact domain.
 
-A NaN scale (`0xFF`) on either operand makes the result NaN, which falls out of
-the scale multiply rather than needing a rule. An all-zero block dots to `+0`,
-not NaN --- E8M0 has no zero, so the minimum-scale path multiplies a zero sum
-by the finite `2⁻¹²⁷`.
+Under `UE4M3` the same order is used, and the reason is stronger rather than
+weaker: a `UE4M3` scale is not a power of two, so each scale multiply
+**rounds**. Applying the scales separately means two roundings of a
+correctly-rounded multiply each; pre-forming `X^A · X^B` would round that
+product too and then round again, and the pre-formed product has the narrower
+exact domain besides. The element-pair products stay exact either way --- that
+argument is about the *elements*, which the scale does not touch.
+
+A NaN scale on either operand makes the result NaN, which falls out of the
+scale multiply rather than needing a rule. An all-zero block dots to `+0`, not
+NaN, under both scales: `E8M0`'s minimum-scale path multiplies a zero sum by
+the finite `2⁻¹²⁷`, and `UE4M3`'s zero scale multiplies a zero sum by zero.
+
+**The per-tensor scale of NVFP4 is deliberately not part of the type.** NVFP4
+pairs its per-block `UE4M3` scale with a second, per-*tensor* `FP32` scale. A
+`ScaledVec` is one block, so carrying that value in the block type would
+replicate a per-tensor quantity once per block. Apply it with an ordinary
+`FP32` multiply on the result, or divide it out of the operand before
+quantizing. There is no accuracy lost by keeping it outside: folding it into
+the quantizer would mean comparing against `S × X × m`, and unlike `X × m`
+that product is not exact for an arbitrary `S`, so the fused form would round
+where the split form does not.
 
 **3.11.3 Quantization error bounds**
 
@@ -1306,9 +1375,9 @@ The bound is only claimed where no element saturates; extending a
 than silently wrong (§3.8, in-range side condition).
 
 **Not yet implemented:** `rtz` / `rna` rounding (they need their own element
-rounders in each backend, with their own overflow rules --- arch#890), the `exact` scale
-policy and `stochastic` rounding (see §3.11 for why both are deferred),
-and the `UE4M3` scale.
+rounders in each backend, with their own overflow rules --- arch#890) and
+`stochastic` rounding (it needs an entropy source, which is a datapath
+question rather than a rounding-mode one).
 
 **3.12 Package-scope type aliases**
 

--- a/doc/proposal_mx_block_formats.md
+++ b/doc/proposal_mx_block_formats.md
@@ -302,6 +302,10 @@ narrow miters only, no arith/fma/cmp).
 | **4** | `FP6E2M3`/`FP6E3M2`, MXFP6/MXFP8 aliases, `bound_err` quantization analysis | gappa bounds recorded |
 | **5** | NVFP4: `UE4M3` scale + two-level (per-tensor FP32) scaling | vs TransformerEngine vectors |
 
+Phase 5 shipped in two halves: **5a** the `UE4M3` scalar type (arch#908), **5b**
+the block scale, the `exact` policy and the division-free quantizer
+(arch#905). The per-tensor scale is deliberately outside the type — §9.1.
+
 `fp8_round` is already width-generic (its bias/anchor/`fw` formulas compute
 correctly for E2M1/E2M3/E3M2); only `ocp_top: bool` must become a 3-way enum,
 since FP4/FP6 are **all-finite** — a third overflow rule. The machine-proven
@@ -324,7 +328,7 @@ lands with Phase 2.
 
 | # | Decision | Resolution |
 |---|---|---|
-| 1 | Default scale policy | **`floor_pow2`** (OCP §6.3), with `ceil_pow2` and `exact` also offered |
+| 1 | Default scale policy | **scale-dependent** — `floor_pow2` (OCP §6.3) for `E8M0`, `exact` for `UE4M3`; all three offered under both. *Amended 2026-08-12, see below.* |
 | 2 | Scale for an all-zero block | **`0x00`** (= 2⁻¹²⁷), matching microxcaling |
 | 3 | Shared-exponent clamping | underflow → **`0x00`**; overflow → **`0xFF`** (NaN) |
 | 4 | Element field when `X = 0xFF` | **preserve on store, ignore on load**; documented |
@@ -349,6 +353,40 @@ against that specific order, not against a mathematical sum.
 routine (§2.2), and `saturate` is the only representable overflow behavior for
 E2M1/E2M3/E3M2 anyway. Users wanting NVIDIA-equivalent numerics select
 `ceil_pow2` explicitly.
+
+---
+
+### 9.1 Phase 5b amendments (maintainer sign-off 2026-08-12)
+
+Phase 5b (`UE4M3` as a block scale, arch#905) forced two questions the
+original table either got wrong for the non-power-of-two case or left open.
+
+**#1 amended — the default policy is per-scale, not global.** A single
+`floor_pow2` default reads well until it meets `UE4M3`, whose whole point is
+its three mantissa bits: defaulting to `floor_pow2` would discard them and
+emit a power-of-two-scale block under the NVFP4 name, diverging from every
+shipping NVFP4 implementation without saying so. `E8M0` keeps `floor_pow2`;
+`UE4M3` defaults to `exact`. Both remain selectable under either scale, and
+`exact` is *refused* for `E8M0` rather than silently ignored.
+
+**#11 (new) — the per-tensor FP32 scale stays OUT of the type.** NVFP4 pairs
+its per-block `UE4M3` scale with a per-tensor `FP32` one. A `ScaledVec` is one
+block, so a fourth type parameter would replicate a per-tensor quantity per
+block. Users apply it as an ordinary `FP32` multiply. This costs nothing
+numerically: fusing it into the quantizer would mean comparing against
+`S × X × m`, and that product is *not* exact for arbitrary `S` — where `X × m`
+is — so the fused form would round where the split form does not.
+
+**The §2.2 premise that the block ops need a power-of-two scale turned out to
+be false**, which is why 5b is smaller than the issue predicted. The
+`scaled_quantize` lowering does not divide by the scale at all: it compares
+`|v|` against `X × m` for each element-grid decision boundary `m`, and every
+such product is exact in FP32 (scale 4 significand bits, boundary ≤5, so ≤9 of
+FP32's 24, with no exponent-range escape). Verified over all 126 finite UE4M3
+scales × all five element formats: 0 inexact products and 0 disagreements with
+an exact-rational RNE reference. So single-rounding — and with it the §3.11.3
+error bounds — holds under `UE4M3` unchanged, and no `arch_f32_div` was
+needed. The scale is selected the same way, against constant thresholds.
 
 ---
 

--- a/skills/arch-programming/references/ARCH_HDL_Specification.md
+++ b/skills/arch-programming/references/ARCH_HDL_Specification.md
@@ -838,9 +838,10 @@ to a scale, and `is_nan` tests the single code `0x7F`. Because a scale is
 non-negative, `.to_ue4m3()` takes the **magnitude** of its operand (as
 `.to_e8m0()` does) and always clears the padding bit.
 
-`UE4M3` is a scalar type today. Using it as a `ScaledVec` scale is not yet
-supported --- see §3.11 --- because the block operations depend on the scale
-being a power of two.
+`UE4M3` is also a `ScaledVec` scale --- that is what it exists for --- giving
+NVFP4 as `ScaledVec<FP4E2M1, 16, UE4M3>`. The block operations do not need a
+power-of-two scale: `scaled_quantize` never divides by the scale at all, so
+the single-rounding property survives. See §3.11.1.
 
 
 
@@ -1071,7 +1072,12 @@ ScaledVec<Elem, N, Scale>
 Microscaling (MX) formats. The scale is a **parameter, not a fixed type**,
 because the two ecosystems genuinely differ --- MX uses `E8M0`, NVFP4 uses a
 `UE4M3` that is *not* our `FP8E4M3` (unsigned, 7 significant bits, NaN
-`0x7F`). `UE4M3` and NVFP4 are not yet implemented.
+`0x7F`). Both scales are supported:
+
+```arch
+type MXFP4 = ScaledVec<FP4E2M1, 32, E8M0>;
+type NVFP4 = ScaledVec<FP4E2M1, 16, UE4M3>;
+```
 
 The three arguments are constrained:
 
@@ -1080,11 +1086,13 @@ The three arguments are constrained:
     scale has no meaning over wider or integer elements.
   - **`N`** is a const expression `>= 1`. A block with no elements is just a
     bare scale.
-  - **`Scale`** must be `E8M0`. `UE4M3` (§3.10a) exists as a scalar type but
-    is not yet accepted here: unlike `E8M0` its value is not a power of two,
-    so dividing by it is inexact and the block operations' single-rounding
-    property (§3.11.1) does not hold. `FP8E4M3` is **not** a stand-in for
-    either.
+  - **`Scale`** must be `E8M0` (OCP MX) or `UE4M3` (NVFP4, §3.10a).
+    `FP8E4M3` is **not** a stand-in for `UE4M3` --- that one is signed and
+    its NaN is sign-agnostic. The two scales differ in more than width:
+    `E8M0` is a pure power of two with no zero, `UE4M3` carries three
+    mantissa bits, *has* a zero at `0x00`, and reserves `0x7F` (not `0xFF`)
+    for NaN. Those differences reach the surface, so they are spelled out
+    per operation below rather than left implicit.
 
 **A block is one packed word, not an array.** Layout is
 `{ scale[w-1:0], P[N-1], …, P[1], P[0] }` --- scale in the high bits,
@@ -1179,7 +1187,7 @@ applied, and is the only way to read an element (§3.11).
 
 | Selector | Values | Default |
 |---|---|---|
-| `policy` | `floor_pow2`, `ceil_pow2` | `floor_pow2` |
+| `policy` | `floor_pow2`, `ceil_pow2`, `exact` | **scale-dependent** --- see below |
 | `rounding` | `rne` (`rtz`, `rna` reserved) | `rne` |
 
 `floor_pow2` is the OCP §6.3 rule: the shared scale is the largest power of
@@ -1187,16 +1195,35 @@ two that normalizes the block maximum into the element format's top binade.
 Because that binade's largest *representable* value is below its top, some
 elements saturate --- routine under this policy, not a corner case.
 `ceil_pow2` rounds the scale up instead when the block maximum is not already
-a power of two, trading the top element codes for fewer saturations.
+a power of two, trading the top element codes for fewer saturations. `exact`
+takes `X = RNE(amax / elem_max)`, using the scale's mantissa instead of
+discarding it; it is **refused for `E8M0`**, where every value is already a
+power of two and there is no mantissa to use.
 
-Semantics, all of which follow from `E8M0` having no zero and reserving
-`0xFF` for NaN:
+**The default policy depends on the scale**, because one default cannot serve
+both: `floor_pow2` for `E8M0` (OCP §6.3), `exact` for `UE4M3`. Defaulting a
+UE4M3 block to `floor_pow2` would discard all three of its mantissa bits and
+silently produce a power-of-two-scale block where NVFP4 was asked for ---
+numerically a different format from the one every NVFP4 implementation ships.
+Write the policy explicitly if you want the other behaviour; both remain
+available under either scale.
 
-  - An **all-zero** block gets the *minimum* scale `0x00` (which denotes
-    `2^-127`, not zero) and zero elements.
-  - A block containing **any NaN or infinity** gets the NaN scale `0xFF`; its
-    element bits are then don't-care, and `scaled_dequantize` yields NaN in
-    every lane regardless of them.
+Semantics. The first two differ between the scales, and the difference is not
+cosmetic --- `E8M0` has no zero and reserves `0xFF`, `UE4M3` has a zero and
+reserves `0x7F`:
+
+  - An **all-zero** block gets scale code `0x00` and zero elements. For
+    `E8M0` that code denotes the *minimum scale* `2^-127` (the element plane
+    is what makes the block zero); for `UE4M3` it is a genuine **zero**,
+    which is sound precisely because every element is zero too.
+  - A block containing **any NaN or infinity** gets the NaN scale --- `0xFF`
+    for `E8M0`, `0x7F` for `UE4M3` (`0xFF` would set the padding bit `UE4M3`
+    requires to be zero). Its element bits are then don't-care, and
+    `scaled_dequantize` yields NaN in every lane regardless of them.
+  - Where the block maximum is nonzero but the scale would **underflow**, it
+    clamps to the smallest scale that is not zero: `0x00` for `E8M0`, `0x01`
+    for `UE4M3`. Clamping a `UE4M3` scale to `0x00` would set it to zero and
+    erase a block that has a nonzero maximum.
   - Dequantizing a finite element under a finite scale **saturates** to
     ±`FP32` max rather than overflowing to infinity. An element that is
     itself Inf or NaN (`FP8E5M2` / `FP8E4M3` can be) keeps its own result.
@@ -1205,8 +1232,32 @@ Semantics, all of which follow from `E8M0` having no zero and reserving
     all-finite formats (`FP4E2M1`, `FP6E2M3`, `FP6E3M2`) and becomes that
     format's NaN for `FP8E4M3`.
 
-Scaling by the reciprocal scale is an exact power-of-two multiply in FP32, so
-each element is rounded **once**, from the true `vᵢ / X`.
+**Each element is rounded exactly once, from the true `vᵢ / X`, under both
+scales** --- but for different reasons, and neither involves a division.
+
+  - Under `E8M0` the reciprocal `1/X` is itself a scale code (`2^-(c-127)` is
+    `2^((254-c)-127)`), so the scaling is one exact FP32 multiply and the
+    element narrow is the only rounding.
+  - Under `UE4M3` there is no such identity --- a mantissa-bearing scale has
+    no exactly representable reciprocal, and substituting `vᵢ × fl(1/X)`
+    changes the result on 4.76% of tie-aligned inputs. So the quantizer never
+    forms the quotient at all: it compares `|vᵢ|` against `X × m` for each
+    decision boundary `m` of the element grid, and picks the code the
+    comparisons land in. **Every such product is exact in FP32** --- the
+    scale carries 4 significand bits and a boundary at most 5, so the product
+    needs at most 9 of FP32's 24 --- which makes the comparison a decision
+    rather than an approximation, and the selected code correctly rounded by
+    construction. The scale itself is chosen the same way, against constant
+    thresholds. Ties resolve to even.
+
+A consequence worth stating: the error bounds of §3.11.3 rest on
+single-rounding, so they apply unchanged to `UE4M3` blocks.
+
+The division-free ladder costs one comparison per element-grid boundary: 8
+for `FP4E2M1` (NVFP4's element format), 32 for the `FP6` pair, and 127/124
+for `FP8E4M3`/`FP8E5M2`. A `UE4M3`-scaled block with 8-bit elements is
+therefore legal and correct but comparatively large; the sub-8-bit element
+formats the MX line is actually built on are cheap.
 
 Both conversions are combinational and must be the whole right-hand side of
 an assignment. To index an element, bind the result first:
@@ -1253,16 +1304,34 @@ pairwise summation's error grows as `O(log N)` against a serial accumulator's
 not a no-op in `FP32` (it turns `-0.0` into `+0.0`).
 
 **The two scales are applied one at a time**, as `(Σ ⊗ X^A) ⊗ X^B`, not as a
-pre-formed `X^A · X^B`. Each scale is a power of two, so each multiply is
-exact absent overflow --- but the two E8M0 scales span `2⁻¹²⁷ … 2¹²⁷`, so their
-*product* spans `2⁻²⁵⁴ … 2²⁵⁴` and can overflow to infinity or flush to zero
-even when the final result is perfectly representable. Applying them
+pre-formed `X^A · X^B`. Under `E8M0` each scale is a power of two, so each
+multiply is exact absent overflow --- but the two scales span `2⁻¹²⁷ … 2¹²⁷`,
+so their *product* spans `2⁻²⁵⁴ … 2²⁵⁴` and can overflow to infinity or flush
+to zero even when the final result is perfectly representable. Applying them
 separately has a strictly wider exact domain.
 
-A NaN scale (`0xFF`) on either operand makes the result NaN, which falls out of
-the scale multiply rather than needing a rule. An all-zero block dots to `+0`,
-not NaN --- E8M0 has no zero, so the minimum-scale path multiplies a zero sum
-by the finite `2⁻¹²⁷`.
+Under `UE4M3` the same order is used, and the reason is stronger rather than
+weaker: a `UE4M3` scale is not a power of two, so each scale multiply
+**rounds**. Applying the scales separately means two roundings of a
+correctly-rounded multiply each; pre-forming `X^A · X^B` would round that
+product too and then round again, and the pre-formed product has the narrower
+exact domain besides. The element-pair products stay exact either way --- that
+argument is about the *elements*, which the scale does not touch.
+
+A NaN scale on either operand makes the result NaN, which falls out of the
+scale multiply rather than needing a rule. An all-zero block dots to `+0`, not
+NaN, under both scales: `E8M0`'s minimum-scale path multiplies a zero sum by
+the finite `2⁻¹²⁷`, and `UE4M3`'s zero scale multiplies a zero sum by zero.
+
+**The per-tensor scale of NVFP4 is deliberately not part of the type.** NVFP4
+pairs its per-block `UE4M3` scale with a second, per-*tensor* `FP32` scale. A
+`ScaledVec` is one block, so carrying that value in the block type would
+replicate a per-tensor quantity once per block. Apply it with an ordinary
+`FP32` multiply on the result, or divide it out of the operand before
+quantizing. There is no accuracy lost by keeping it outside: folding it into
+the quantizer would mean comparing against `S × X × m`, and unlike `X × m`
+that product is not exact for an arbitrary `S`, so the fused form would round
+where the split form does not.
 
 **3.11.3 Quantization error bounds**
 
@@ -1306,9 +1375,9 @@ The bound is only claimed where no element saturates; extending a
 than silently wrong (§3.8, in-range side condition).
 
 **Not yet implemented:** `rtz` / `rna` rounding (they need their own element
-rounders in each backend, with their own overflow rules --- arch#890), the `exact` scale
-policy and `stochastic` rounding (see §3.11 for why both are deferred),
-and the `UE4M3` scale.
+rounders in each backend, with their own overflow rules --- arch#890) and
+`stochastic` rounding (it needs an entropy source, which is a datapath
+question rather than a rounding-mode one).
 
 **3.12 Package-scope type aliases**
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1188,11 +1188,16 @@ pub enum TypeExpr {
 /// Shared-scale selection policy for `scaled_quantize` (proposal §3.1).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum ScalePolicy {
-    /// OCP §6.3: largest power of two <= amax. The default (decision #1).
+    /// OCP §6.3: largest power of two <= amax. The default for a
+    /// power-of-two scale (`E8M0`; proposal §9 decision #1).
     FloorPow2,
     /// NVIDIA: round the scale UP instead, trading the top element codes
     /// for fewer saturations.
     CeilPow2,
+    /// `X = RNE(amax / elem_max)` — use the scale's mantissa instead of
+    /// discarding it. Meaningful only for a scale that is *not* a power of
+    /// two, so it is the default for `UE4M3` and refused for `E8M0`.
+    Exact,
 }
 
 /// Element rounding mode for `scaled_quantize`.
@@ -1306,7 +1311,12 @@ pub enum ExprKind {
     /// scale, so `MXFP4` and `MXFP8` are equally valid outputs and there is
     /// nothing to infer from. Carrying a `TypeExpr` inside an expression is
     /// why this needs its own variant — it is the first expression that can.
-    ScaledQuantize(Box<Expr>, Box<TypeExpr>, ScalePolicy, RoundMode),
+    /// `scaled_quantize<Fmt[, policy, rounding]>(v)`. The policy is `None`
+    /// when the call site did not write one: the default depends on the
+    /// block's *scale type*, which the parser cannot resolve because `Fmt`
+    /// may be a type alias. `BlockScale::default_policy` settles it once the
+    /// type is known.
+    ScaledQuantize(Box<Expr>, Box<TypeExpr>, Option<ScalePolicy>, RoundMode),
     /// SVA delay-shift: `##N expr`. Inside an `assert`/`cover` body, shifts
     /// the cycle of `expr` forward by `N` (i.e. evaluates `expr` at cycle
     /// `t + N` when the surrounding property is checked at cycle `t`).

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -7287,7 +7287,7 @@ impl<'a> Codegen<'a> {
                 });
                 let h = crate::fp_block::BlockHelper::Quantize {
                     shape,
-                    policy: *policy,
+                    policy: policy.unwrap_or_else(|| shape.scale.default_policy()),
                     round: *round,
                 };
                 self.fp_helpers_used.set(true);

--- a/src/fp_block.rs
+++ b/src/fp_block.rs
@@ -43,8 +43,7 @@ use crate::ast::{RoundMode, ScalePolicy, TypeExpr};
 use crate::fp_format::{by_type_expr, FpFormatId};
 use std::fmt::Write as _;
 
-/// The scale format of a block. One variant today; `UE4M3` (NVFP4) joins it
-/// in phase 5b (arch#905).
+/// The scale format of a block: `E8M0` (OCP MX) or `UE4M3` (NVFP4).
 ///
 /// **Everything the lowering knows about a scale lives behind this enum.**
 /// That is not decoration — it is the mechanism that makes adding a variant
@@ -70,17 +69,23 @@ use std::fmt::Write as _;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum BlockScale {
     E8m0,
+    Ue4m3,
 }
 
 impl BlockScale {
     fn tag(self) -> &'static str {
         match self {
             BlockScale::E8m0 => "e8m0",
+            BlockScale::Ue4m3 => "ue4m3",
         }
     }
     fn width(self) -> u32 {
         match self {
             BlockScale::E8m0 => 8,
+            // 7 significant bits, stored in 8 with the MSB padded zero (PTX).
+            // The carrier is 8 bits wide, which is why the padding bit has to
+            // be masked rather than assumed — see `nan_code`.
+            BlockScale::Ue4m3 => 8,
         }
     }
 
@@ -88,6 +93,7 @@ impl BlockScale {
     fn widen_fn(self) -> &'static str {
         match self {
             BlockScale::E8m0 => "arch_e8m0_to_f32",
+            BlockScale::Ue4m3 => "arch_ue4m3_to_f32",
         }
     }
 
@@ -95,6 +101,7 @@ impl BlockScale {
     fn narrow_fn(self) -> &'static str {
         match self {
             BlockScale::E8m0 => "arch_f32_to_e8m0",
+            BlockScale::Ue4m3 => "arch_f32_to_ue4m3",
         }
     }
 
@@ -102,6 +109,9 @@ impl BlockScale {
     fn nan_code(self) -> u32 {
         match self {
             BlockScale::E8m0 => 0xFF,
+            // NOT 0xFF: that would set the padding bit UE4M3 requires to be
+            // zero. Its sole NaN is 0x7F.
+            BlockScale::Ue4m3 => 0x7F,
         }
     }
 
@@ -111,6 +121,10 @@ impl BlockScale {
     fn zero_block_code(self) -> u32 {
         match self {
             BlockScale::E8m0 => 0x00,
+            // UE4M3 *does* have a zero, and `0x00` IS it — so unlike E8M0 this
+            // makes the block's scale genuinely zero. Sound because the branch
+            // is only taken when every element is zero, and `0 * 0 == +0`.
+            BlockScale::Ue4m3 => 0x00,
         }
     }
 
@@ -119,30 +133,121 @@ impl BlockScale {
     fn max_finite_code(self) -> u32 {
         match self {
             BlockScale::E8m0 => 0xFE,
+            BlockScale::Ue4m3 => 0x7E,
+        }
+    }
+
+    /// Is every value of this scale a power of two?
+    ///
+    /// Drives two user-visible rules: the `exact` scale policy is refused for
+    /// a power-of-two scale (there is nothing for it to do), and the
+    /// single-rounding argument in the spec is stated differently for each.
+    pub fn is_pow2(self) -> bool {
+        match self {
+            BlockScale::E8m0 => true,
+            BlockScale::Ue4m3 => false,
+        }
+    }
+
+    /// The scale policy used when the call site does not write one.
+    ///
+    /// Not a single global default: `floor_pow2` (proposal §9 decision #1)
+    /// throws away every mantissa bit of a `UE4M3` scale, which would make an
+    /// NVFP4 block numerically a power-of-two-scale format and diverge from
+    /// every shipping NVFP4 implementation. Maintainer sign-off 2026-08-12.
+    pub fn default_policy(self) -> ScalePolicy {
+        match self {
+            BlockScale::E8m0 => ScalePolicy::FloorPow2,
+            BlockScale::Ue4m3 => ScalePolicy::Exact,
+        }
+    }
+
+    /// Every finite value this scale can hold, ascending, indexed by code.
+    ///
+    /// Lives here rather than being derived from `fp_format::FORMATS` because
+    /// **neither scale type has a row there** — deliberately: a format row is
+    /// what makes the float-shaped paths (`is_float`, the arithmetic surface,
+    /// `is_nan`) pick a type up, and a scale is a carrier for exponent-ish
+    /// codes, not a float. That is the arch#837 hazard, hit five times
+    /// already. So the shape is written out once, here, inside the enum that
+    /// already owns every other scale-specific decision.
+    fn grid(self) -> Vec<f64> {
+        match self {
+            // 2^(c-127) for every code but 0xFF (NaN). No zero, no sign.
+            BlockScale::E8m0 => (0u32..=0xFE).map(|c| 2f64.powi(c as i32 - 127)).collect(),
+            // E4M3-shaped magnitudes: 4 exponent bits, bias 7, 3 mantissa
+            // bits, subnormals at 2^-9 granularity, every code but 0x7F.
+            BlockScale::Ue4m3 => (0u32..=0x7E)
+                .map(|c| {
+                    let (e, m) = ((c >> 3) & 0xF, c & 0x7);
+                    if e == 0 {
+                        m as f64 * 2f64.powi(-9)
+                    } else {
+                        (8 + m) as f64 * 2f64.powi(e as i32 - 10)
+                    }
+                })
+                .collect(),
+        }
+    }
+
+    /// How elements are divided by the scale — the one decision that differs
+    /// structurally rather than by a constant. See [`QuantKernel`].
+    fn quant_kernel(self) -> QuantKernel {
+        match self {
+            BlockScale::E8m0 => QuantKernel::ExactReciprocal,
+            BlockScale::Ue4m3 => QuantKernel::BoundaryCompare,
         }
     }
 
     /// SystemVerilog expression for the RECIPROCAL of the scale with code
-    /// `code`.
+    /// `code`, or `None` where no exact reciprocal exists.
     ///
     /// Exact for E8M0: `2^-(c-127) == 2^((254-c)-127)`, so the reciprocal is
     /// just another scale code and the element narrow downstream rounds
     /// exactly once. **A mantissa-bearing scale has no such identity** —
     /// arch#905 measured that substituting `v * fl(1/X)` for `fl(v/X)`
     /// changes the quantized code on 4.76% of tie-aligned inputs — so
-    /// `UE4M3` must not reuse this shape.
-    fn sv_reciprocal(self, code: &str) -> String {
+    /// `UE4M3` returns `None` and uses [`QuantKernel::BoundaryCompare`].
+    fn sv_reciprocal(self, code: &str) -> Option<String> {
         match self {
-            BlockScale::E8m0 => format!("{}(8'd254 - {code})", self.widen_fn()),
+            BlockScale::E8m0 => Some(format!("{}(8'd254 - {code})", self.widen_fn())),
+            BlockScale::Ue4m3 => None,
         }
     }
 
     /// C++ twin of [`BlockScale::sv_reciprocal`].
-    fn cpp_reciprocal(self, code: &str) -> String {
+    fn cpp_reciprocal(self, code: &str) -> Option<String> {
         match self {
-            BlockScale::E8m0 => format!("_{}((uint8_t)(254u - {code}))", self.widen_fn()),
+            BlockScale::E8m0 => Some(format!("_{}((uint8_t)(254u - {code}))", self.widen_fn())),
+            BlockScale::Ue4m3 => None,
         }
     }
+}
+
+/// How `scaled_quantize` turns an FP32 element into an element code.
+///
+/// Both kernels are exactly correctly rounded; they differ in *how* they get
+/// there, because only a power-of-two scale has an exact reciprocal.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum QuantKernel {
+    /// Multiply by `1/X`, which is itself exactly representable, then narrow.
+    /// One multiply per element; the narrow is the sole rounding.
+    ExactReciprocal,
+    /// Never divide at all: compare `|v|` against `X × m` for each RNE
+    /// decision boundary `m` of the element grid.
+    ///
+    /// Sound because **every such product is exact in FP32** — the scale
+    /// carries 4 significand bits and a boundary at most 5, so the product
+    /// needs at most 9 of FP32's 24, and the exponent range cannot overflow
+    /// or go subnormal. Verified over all 126 finite `UE4M3` scales × every
+    /// boundary of all five element formats: 0 inexact products, and 0
+    /// mismatches against an exact-rational RNE reference.
+    ///
+    /// Ties-to-even needs no logic: the boundary between codes `k` and `k+1`
+    /// resolves to whichever is even, and since the grid index *is* the code,
+    /// that is a strict `>` at even `k` and a `>=` at odd `k` — decided at
+    /// generation time, per boundary.
+    BoundaryCompare,
 }
 
 /// A block's static shape: what `scaled_dequantize` needs, and the part of
@@ -191,6 +296,7 @@ pub fn shape_of(elem: &TypeExpr, n: u32, scale: &TypeExpr) -> Option<BlockShape>
     }
     let scale = match scale {
         TypeExpr::E8M0 => BlockScale::E8m0,
+        TypeExpr::UE4M3 => BlockScale::Ue4m3,
         _ => return None,
     };
     Some(BlockShape { elem, n, scale })
@@ -297,6 +403,7 @@ fn policy_tag(p: ScalePolicy) -> &'static str {
     match p {
         ScalePolicy::FloorPow2 => "floor",
         ScalePolicy::CeilPow2 => "ceil",
+        ScalePolicy::Exact => "exact",
     }
 }
 
@@ -349,6 +456,182 @@ fn dot_schedule(n: u32) -> (Vec<(usize, usize)>, usize) {
         cur = nxt;
     }
     (adds, cur[0])
+}
+
+// ── Grids and decision boundaries (the division-free kernel) ────────────────
+//
+// Everything here is DERIVED from `fp_format::FORMATS`, never hand-tabled: a
+// hand-written boundary table is a second source of truth for the rounding
+// rule, and the one thing this file exists to prevent is two sources of truth
+// disagreeing silently in both backends at once.
+
+/// Bit pattern of `(sig / 2^mb) * 2^e` as an FP32, asserting the value is
+/// exactly representable. Every grid point and boundary of every block
+/// element format is, by construction — significands are at most `mant+2`
+/// bits and the exponents sit deep inside FP32's range — so a lossy
+/// conversion here means a format row is wrong, not that rounding is needed.
+fn exact_f32(v: f64) -> u32 {
+    let f = v as f32;
+    debug_assert_eq!(
+        f as f64, v,
+        "block grid value {v} is not exactly representable in FP32"
+    );
+    f.to_bits()
+}
+
+/// The positive representable values of `f`, ascending. **The index into this
+/// vector is the element code**: IEEE-style encodings are monotonic over
+/// non-negative values, and every format's reserved Inf/NaN codes sit at the
+/// top, so enumerating `(exp, mant)` in order yields codes `0, 1, 2, …` with
+/// no gaps.
+fn format_grid(f: &crate::fp_format::FpFormat) -> Vec<f64> {
+    let (eb, mb) = (f.exp_bits, f.mant_bits);
+    let bias = (1i32 << (eb - 1)) - 1;
+    let e_top = (1u32 << eb) - 1;
+    let m_top = (1u32 << mb) - 1;
+    let mut out = Vec::new();
+    for e in 0..(1u32 << eb) {
+        for m in 0..(1u32 << mb) {
+            if f.has_inf && e == e_top {
+                continue; // Inf (m == 0) and every NaN payload
+            }
+            if !f.has_inf && f.has_nan && e == e_top && m == m_top {
+                continue; // OCP E4M3-style: the sole NaN is the all-ones code
+            }
+            let v = if e == 0 {
+                (m as f64) * 2f64.powi(1 - bias - mb as i32)
+            } else {
+                ((1u32 << mb) + m) as f64 * 2f64.powi(e as i32 - bias - mb as i32)
+            };
+            out.push(v);
+        }
+    }
+    out
+}
+
+/// One rung of a decision ladder: `|x| > thr` (or `>=`) selects `code`.
+///
+/// `strict` encodes ties-to-even with no runtime logic. The boundary between
+/// codes `k` and `k+1` is a tie only when `|x|` hits it exactly, and exactly
+/// one of the two codes is even — so the choice is fixed at generation time:
+/// strict `>` when `k` is even (the tie stays at `k`), `>=` when `k` is odd
+/// (the tie moves up to the even `k+1`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Rung {
+    /// FP32 bit pattern of the threshold, or of the *multiplier* applied to
+    /// the scale when the ladder is scaled at runtime.
+    thr: u32,
+    strict: bool,
+    code: u32,
+}
+
+/// The element ladder for format `f`, in ascending order. Thresholds are
+/// multipliers: the emitted code compares `|v|` against `X × thr`.
+///
+/// The last rung is the overflow boundary and only exists for a format that
+/// *has* somewhere to overflow to. For the all-finite sub-8-bit formats
+/// (`FP4E2M1`, `FP6E2M3`, `FP6E3M2` — the OCP MX block elements, NVFP4's
+/// included) there is no such code, so the ladder simply saturates at the top
+/// grid entry, which is what OCP §6.3 requires anyway.
+fn elem_ladder(f: &crate::fp_format::FpFormat) -> (Vec<Rung>, Option<u32>) {
+    let g = format_grid(f);
+    let mut rungs = Vec::with_capacity(g.len());
+    for k in 0..g.len() - 1 {
+        rungs.push(Rung {
+            thr: exact_f32((g[k] + g[k + 1]) / 2.0),
+            strict: k % 2 == 0,
+            code: (k + 1) as u32,
+        });
+    }
+    let overflows = f.has_inf || f.has_nan;
+    let ovf_code = if overflows {
+        let k = g.len() - 1;
+        let ulp = g[k] - g[k - 1];
+        rungs.push(Rung {
+            thr: exact_f32(g[k] + ulp / 2.0),
+            strict: k % 2 == 0,
+            code: 0, // filled in by the emitter: it is the rounder's answer
+        });
+        Some(k as u32)
+    } else {
+        None
+    };
+    (rungs, ovf_code)
+}
+
+/// The scale ladder: which scale code a block maximum selects, under `policy`.
+///
+/// Thresholds are **absolute FP32 constants**, not multipliers — both the
+/// element format's maximum and the scale grid are known at compile time, so
+/// `elem_max × scale_value` folds and the whole scale choice becomes a
+/// constant-threshold priority encoder with no arithmetic at all.
+///
+/// Sound because those products are exact: verified over all 126 finite
+/// `UE4M3` scales × all five element formats, 0 inexact and 0 overflowing.
+/// Returns the code the ladder starts at (used when the block maximum is
+/// below every rung) and the rungs themselves.
+fn scale_ladder(scale: BlockScale, elem_max: f64, policy: ScalePolicy) -> (u32, Vec<Rung>) {
+    debug_assert!(!scale.is_pow2(), "ladder is the non-pow2 path");
+    let g = scale.grid();
+    // Code 0 is *zero* for UE4M3, and a zero scale would erase a block whose
+    // maximum is nonzero. Underflow therefore clamps to the smallest nonzero
+    // scale rather than to code 0 — the same rule as proposal §9 decision #3
+    // ("underflow → the minimum scale"), read against a scale format that has
+    // a zero where E8M0 does not.
+    let lo = 1usize;
+    match policy {
+        ScalePolicy::Exact => (
+            lo as u32,
+            (lo..g.len() - 1)
+                .map(|k| Rung {
+                    thr: exact_f32(elem_max * (g[k] + g[k + 1]) / 2.0),
+                    strict: k % 2 == 0,
+                    code: (k + 1) as u32,
+                })
+                .collect(),
+        ),
+        // floor/ceil restrict the choice to the power-of-two members of the
+        // same grid. `floor` takes a value as soon as the block maximum
+        // reaches it; `ceil` steps to the NEXT power of two as soon as the
+        // maximum exceeds one, which is why the two ladders differ in the
+        // code they select and not only in the strictness of the test.
+        //
+        // `ceil` clamps at the largest power of two in the grid (2^8) rather
+        // than at the largest finite code (448): 448 is not a power of two,
+        // so selecting it would break the policy's own contract. Blocks above
+        // that saturate in the element plane instead.
+        ScalePolicy::FloorPow2 | ScalePolicy::CeilPow2 => {
+            let pow2: Vec<(usize, f64)> = g
+                .iter()
+                .copied()
+                .enumerate()
+                .skip(lo)
+                .filter(|(_, v)| v.log2().fract() == 0.0)
+                .collect();
+            let base = pow2[0].0 as u32;
+            if policy == ScalePolicy::FloorPow2 {
+                let r = pow2
+                    .iter()
+                    .map(|&(k, v)| Rung {
+                        thr: exact_f32(elem_max * v),
+                        strict: false,
+                        code: k as u32,
+                    })
+                    .collect();
+                (base, r)
+            } else {
+                let r = pow2
+                    .windows(2)
+                    .map(|w| Rung {
+                        thr: exact_f32(elem_max * w[0].1),
+                        strict: true,
+                        code: w[1].0 as u32,
+                    })
+                    .collect();
+                (base, r)
+            }
+        }
+    }
 }
 
 /// `[hi:0]` in the `logic [hi:0] ` declaration style `render_sv` uses.
@@ -447,6 +730,9 @@ fn sv_quantize(s: BlockShape, policy: ScalePolicy, round: RoundMode) -> String {
          (arch#890) — reaching here means that gate was removed \
          without adding the rounder variants"
     );
+    if s.scale.quant_kernel() == QuantKernel::BoundaryCompare {
+        return sv_quantize_boundary(s, policy);
+    }
     let name = BlockHelper::Quantize {
         shape: s,
         policy,
@@ -524,12 +810,142 @@ fn sv_quantize(s: BlockShape, policy: ScalePolicy, round: RoundMode) -> String {
     );
     // 5. Multiply by the reciprocal scale, itself an E8M0 code, so the
     //    scaling is exact and the narrow below rounds exactly once.
-    let _ = writeln!(o, "    inv = {};", s.scale.sv_reciprocal("code"));
+    let _ = writeln!(
+        o,
+        "    inv = {};",
+        s.scale
+            .sv_reciprocal("code")
+            .expect("ExactReciprocal kernel implies the scale has one")
+    );
     let _ = writeln!(o, "    for (int unsigned i = 0; i < {n}; i = i + 1) begin");
     let _ = writeln!(
         o,
         "      r[i*{ew} +: {ew}] = arch_f32_to_{tag}(arch_f32_mul(v[i*32 +: 32], inv));"
     );
+    let _ = writeln!(o, "    end");
+    let _ = writeln!(o, "    r[{}:{}] = code;", bw - 1, bw - sw);
+    let _ = writeln!(o, "  end");
+    let _ = writeln!(o, "  {name} = r;");
+    let _ = writeln!(o, "endfunction");
+    o
+}
+
+/// `scaled_quantize` for a scale with no exact reciprocal — see
+/// [`QuantKernel::BoundaryCompare`].
+///
+/// Two constant-threshold ladders and not one division. Both compare FP32 bit
+/// patterns as unsigned integers, which is the numeric comparison here because
+/// every operand is non-negative (the block maximum is sign-cleared, and every
+/// threshold is positive by construction) — the same fact the block-maximum
+/// scan above already rests on.
+fn sv_quantize_boundary(s: BlockShape, policy: ScalePolicy) -> String {
+    let name = BlockHelper::Quantize {
+        shape: s,
+        policy,
+        round: RoundMode::Rne,
+    }
+    .sv_name();
+    let (bw, vw, ew, sw) = (s.bits(), s.vec_bits(), s.elem_width(), s.scale.width());
+    let n = s.n;
+    let tag = s.elem_tag();
+    let (scale_base, scale_rungs) = scale_ladder(s.scale, s.desc().max_finite, policy);
+    let (elem_rungs, ovf) = elem_ladder(s.desc());
+    let mut o = String::new();
+    let _ = writeln!(
+        o,
+        "// {name}: Vec<FP32,{n}> -> {{scale, P[{}..0]}}. Division-free: the \
+         scale ladder is",
+        n - 1
+    );
+    let _ = writeln!(
+        o,
+        "// constant thresholds, the element ladder is `X * boundary`, and every such \
+         product"
+    );
+    let _ = writeln!(
+        o,
+        "// is exact in FP32 — so each element rounds exactly once. See src/fp_block.rs."
+    );
+    let _ = writeln!(
+        o,
+        "function automatic logic {}{name}(input logic {}v);",
+        sv_w(bw),
+        sv_w(vw)
+    );
+    let _ = writeln!(o, "  logic {}amax;", sv_w(32));
+    let _ = writeln!(o, "  logic {}mag;", sv_w(32));
+    let _ = writeln!(o, "  logic {}a;", sv_w(32));
+    let _ = writeln!(o, "  logic {}x;", sv_w(32));
+    let _ = writeln!(o, "  logic {}code;", sv_w(sw));
+    let _ = writeln!(o, "  logic {}m;", sv_w(ew));
+    let _ = writeln!(o, "  logic {}p;", sv_w(ew));
+    let _ = writeln!(o, "  logic sgn;");
+    let _ = writeln!(o, "  logic {}r;", sv_w(bw));
+    let _ = writeln!(o, "  amax = 32'h0;");
+    let _ = writeln!(o, "  for (int unsigned i = 0; i < {n}; i = i + 1) begin");
+    let _ = writeln!(o, "    mag = v[i*32 +: 32] & 32'h7FFFFFFF;");
+    let _ = writeln!(o, "    if (mag > amax) amax = mag;");
+    let _ = writeln!(o, "  end");
+    let _ = writeln!(o, "  r = {bw}'h0;");
+    let _ = writeln!(o, "  if (amax >= 32'h7F800000) begin");
+    let _ = writeln!(
+        o,
+        "    r[{}:{}] = {sw}'h{:02X};",
+        bw - 1,
+        bw - sw,
+        s.scale.nan_code()
+    );
+    let _ = writeln!(o, "  end else if (amax == 32'h0) begin");
+    let _ = writeln!(
+        o,
+        "    r[{}:{}] = {sw}'h{:02X};",
+        bw - 1,
+        bw - sw,
+        s.scale.zero_block_code()
+    );
+    let _ = writeln!(o, "  end else begin");
+    let _ = writeln!(o, "    code = {sw}'h{scale_base:02X};");
+    for rg in &scale_rungs {
+        let op = if rg.strict { ">" } else { ">=" };
+        let _ = writeln!(
+            o,
+            "    if (amax {op} 32'h{:08X}) code = {sw}'h{:02X};",
+            rg.thr, rg.code
+        );
+    }
+    let _ = writeln!(o, "    x = {}(code);", s.scale.widen_fn());
+    let _ = writeln!(o, "    for (int unsigned i = 0; i < {n}; i = i + 1) begin");
+    let _ = writeln!(o, "      sgn = v[i*32 + 31];");
+    let _ = writeln!(o, "      a = v[i*32 +: 32] & 32'h7FFFFFFF;");
+    let _ = writeln!(o, "      m = {ew}'h0;");
+    let cmp_rungs = if ovf.is_some() {
+        &elem_rungs[..elem_rungs.len() - 1]
+    } else {
+        &elem_rungs[..]
+    };
+    for rg in cmp_rungs {
+        let op = if rg.strict { ">" } else { ">=" };
+        let _ = writeln!(
+            o,
+            "      if (a {op} arch_f32_mul(x, 32'h{:08X})) m = {ew}'h{:02X};",
+            rg.thr, rg.code
+        );
+    }
+    let _ = writeln!(o, "      p = {{sgn, m[{}:0]}};", ew - 2);
+    if ovf.is_some() {
+        let top = elem_rungs[elem_rungs.len() - 1];
+        let op = if top.strict { ">" } else { ">=" };
+        // Overflow is delegated to the element format's own rounder rather
+        // than re-derived: feeding it a value that unambiguously overflows
+        // reproduces the `--fp-compat` profile's rule (riscv NaN/Inf vs cuda
+        // satfinite) with no second copy of it to drift.
+        let _ = writeln!(
+            o,
+            "      if (a {op} arch_f32_mul(x, 32'h{:08X})) p = arch_f32_to_{tag}({{sgn, 31'h7F7FFFFF}});",
+            top.thr
+        );
+    }
+    let _ = writeln!(o, "      r[i*{ew} +: {ew}] = p;");
     let _ = writeln!(o, "    end");
     let _ = writeln!(o, "    r[{}:{}] = code;", bw - 1, bw - sw);
     let _ = writeln!(o, "  end");
@@ -734,6 +1150,9 @@ fn cpp_quantize(s: BlockShape, policy: ScalePolicy, round: RoundMode) -> String 
          (arch#890) — reaching here means that gate was removed \
          without adding the rounder variants"
     );
+    if s.scale.quant_kernel() == QuantKernel::BoundaryCompare {
+        return cpp_quantize_boundary(s, policy);
+    }
     let name = BlockHelper::Quantize {
         shape: s,
         policy,
@@ -788,12 +1207,119 @@ fn cpp_quantize(s: BlockShape, policy: ScalePolicy, round: RoundMode) -> String 
         o,
         "    uint8_t code = (ecode > {emax}u) ? (uint8_t)(ecode - {emax}u) : (uint8_t)0u;"
     );
-    let _ = writeln!(o, "    uint32_t inv = {};", s.scale.cpp_reciprocal("code"));
+    let _ = writeln!(
+        o,
+        "    uint32_t inv = {};",
+        s.scale
+            .cpp_reciprocal("code")
+            .expect("ExactReciprocal kernel implies the scale has one")
+    );
     let _ = writeln!(o, "    for (unsigned i = 0; i < {n}u; ++i) {{");
     let _ = writeln!(
         o,
         "      uint32_t p = (uint32_t)_arch_f32_to_{tag}(_arch_f32_mul(v[i], inv));"
     );
+    let _ = writeln!(o, "      _arch_blk_ins(_w, i * {ew}u, {ew}u, p);");
+    let _ = writeln!(o, "    }}");
+    let _ = writeln!(
+        o,
+        "    _arch_blk_ins(_w, {}u, {sw}u, (uint32_t)code);",
+        bw - sw
+    );
+    let _ = writeln!(o, "  }}");
+    let _ = writeln!(o, "  _arch_blk_put(out, _w, {nw});");
+    let _ = writeln!(o, "}}");
+    o
+}
+
+/// C++ twin of [`sv_quantize_boundary`]. Same two ladders, same order, same
+/// constants — the two are meant to be diffable line for line.
+fn cpp_quantize_boundary(s: BlockShape, policy: ScalePolicy) -> String {
+    let name = BlockHelper::Quantize {
+        shape: s,
+        policy,
+        round: RoundMode::Rne,
+    }
+    .cpp_name();
+    let (bw, ew, sw) = (s.bits(), s.elem_width(), s.scale.width());
+    let (n, tag) = (s.n, s.elem_tag());
+    let nw = cpp_words(bw);
+    let (scale_base, scale_rungs) = scale_ladder(s.scale, s.desc().max_finite, policy);
+    let (elem_rungs, ovf) = elem_ladder(s.desc());
+    let mut o = String::new();
+    let _ = writeln!(
+        o,
+        "// {name}: Vec<FP32,{n}> -> block ({bw} bits). Mirrors sv_quantize_boundary in src/fp_block.rs."
+    );
+    let _ = writeln!(o, "template <typename BT>");
+    let _ = writeln!(
+        o,
+        "static inline void {name}(const uint32_t* v, BT& out) {{"
+    );
+    let _ = writeln!(o, "  uint32_t _w[{nw}];");
+    let _ = writeln!(o, "  for (int k = 0; k < {nw}; ++k) _w[k] = 0u;");
+    let _ = writeln!(o, "  uint32_t amax = 0u;");
+    let _ = writeln!(o, "  for (unsigned i = 0; i < {n}u; ++i) {{");
+    let _ = writeln!(o, "    uint32_t mag = v[i] & 0x7FFFFFFFu;");
+    let _ = writeln!(o, "    if (mag > amax) amax = mag;");
+    let _ = writeln!(o, "  }}");
+    let _ = writeln!(o, "  if (amax >= 0x7F800000u) {{");
+    let _ = writeln!(
+        o,
+        "    _arch_blk_ins(_w, {}u, {sw}u, 0x{:02X}u);",
+        bw - sw,
+        s.scale.nan_code()
+    );
+    let _ = writeln!(o, "  }} else if (amax == 0u) {{");
+    let _ = writeln!(
+        o,
+        "    _arch_blk_ins(_w, {}u, {sw}u, 0x{:02X}u);",
+        bw - sw,
+        s.scale.zero_block_code()
+    );
+    let _ = writeln!(o, "  }} else {{");
+    let _ = writeln!(o, "    uint8_t code = 0x{scale_base:02X}u;");
+    for rg in &scale_rungs {
+        let op = if rg.strict { ">" } else { ">=" };
+        let _ = writeln!(
+            o,
+            "    if (amax {op} 0x{:08X}u) code = 0x{:02X}u;",
+            rg.thr, rg.code
+        );
+    }
+    let _ = writeln!(o, "    uint32_t x = _{}(code);", s.scale.widen_fn());
+    let _ = writeln!(o, "    for (unsigned i = 0; i < {n}u; ++i) {{");
+    let _ = writeln!(o, "      uint32_t sgn = v[i] >> 31;");
+    let _ = writeln!(o, "      uint32_t a = v[i] & 0x7FFFFFFFu;");
+    let _ = writeln!(o, "      uint32_t m = 0u;");
+    let cmp_rungs = if ovf.is_some() {
+        &elem_rungs[..elem_rungs.len() - 1]
+    } else {
+        &elem_rungs[..]
+    };
+    for rg in cmp_rungs {
+        let op = if rg.strict { ">" } else { ">=" };
+        let _ = writeln!(
+            o,
+            "      if (a {op} _arch_f32_mul(x, 0x{:08X}u)) m = 0x{:02X}u;",
+            rg.thr, rg.code
+        );
+    }
+    let _ = writeln!(
+        o,
+        "      uint32_t p = (sgn << {}) | (m & 0x{:X}u);",
+        ew - 1,
+        (1u32 << (ew - 1)) - 1
+    );
+    if ovf.is_some() {
+        let top = elem_rungs[elem_rungs.len() - 1];
+        let op = if top.strict { ">" } else { ">=" };
+        let _ = writeln!(
+            o,
+            "      if (a {op} _arch_f32_mul(x, 0x{:08X}u)) p = (uint32_t)_arch_f32_to_{tag}((sgn << 31) | 0x7F7FFFFFu);",
+            top.thr
+        );
+    }
     let _ = writeln!(o, "      _arch_blk_ins(_w, i * {ew}u, {ew}u, p);");
     let _ = writeln!(o, "    }}");
     let _ = writeln!(
@@ -850,6 +1376,7 @@ fn cpp_dequantize(s: BlockShape) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::fp_format::FORMATS;
 
     fn shape(elem: FpFormatId, n: u32) -> BlockShape {
         BlockShape {
@@ -1111,6 +1638,303 @@ mod tests {
                     let d = BlockHelper::Dequantize { shape: s }.sv_name();
                     assert_eq!(seen.insert(d), policy == ScalePolicy::FloorPow2);
                 }
+            }
+        }
+    }
+
+    // ── UE4M3 / NVFP4 (phase 5b, arch#905) ────────────────────────────────
+
+    /// Run a ladder the way both backends do: ascending, later rungs win.
+    fn run_ladder(rungs: &[Rung], base: u32, x: f32, scaled: bool, a: f32) -> u32 {
+        let mut c = base;
+        for rg in rungs {
+            let thr = if scaled {
+                x * f32::from_bits(rg.thr)
+            } else {
+                f32::from_bits(rg.thr)
+            };
+            let hit = if rg.strict { a > thr } else { a >= thr };
+            if hit {
+                c = rg.code;
+            }
+        }
+        c
+    }
+
+    /// Reference RNE onto an ascending grid, INDEPENDENT of the ladder: it
+    /// divides (in f64, correctly rounded to 53 bits) where the ladder only
+    /// ever compares.
+    ///
+    /// Double rounding 53 → ≤4 significand bits is innocuous everywhere
+    /// except exactly on a tie, so ties are settled separately by an exact
+    /// test — `x * mid` is exact in FP32, hence exact in f64, and `v` is an
+    /// FP32 value, so `v == x * mid` is a decision and not an approximation.
+    fn ref_code(grid: &[f64], v: f32, x: f32) -> usize {
+        let q = v as f64 / x as f64;
+        for k in 0..grid.len() - 1 {
+            let mid = (grid[k] + grid[k + 1]) / 2.0;
+            let exact_tie = (v as f64) == (x as f64) * mid;
+            if exact_tie {
+                return if k % 2 == 0 { k } else { k + 1 };
+            }
+            if q < mid {
+                return k;
+            }
+        }
+        grid.len() - 1
+    }
+
+    /// The heart of arch#905: the division-free element ladder must agree
+    /// with a real division on every scale, for every element format.
+    ///
+    /// Swept over all 126 finite UE4M3 scales × the values that can actually
+    /// disagree — every decision boundary exactly, both neighbours one ULP
+    /// away, and every grid point — which is where the reciprocal shortcut
+    /// this replaces fails 4.76% of the time.
+    #[test]
+    fn fp_block_ue4m3_elem_ladder_matches_a_real_divide() {
+        let scale_grid = BlockScale::Ue4m3.grid();
+        for id in [
+            FpFormatId::E2m1,
+            FpFormatId::E2m3,
+            FpFormatId::E3m2,
+            FpFormatId::E4m3,
+            FpFormatId::E5m2,
+        ] {
+            let f = FORMATS.iter().find(|f| f.id == id).unwrap();
+            let g = format_grid(f);
+            let (rungs, ovf) = elem_ladder(f);
+            // The overflow rung is not a grid code, so it is excluded here
+            // and covered by `..._overflow_rung_matches_the_rounder`.
+            let cmp = if ovf.is_some() {
+                &rungs[..rungs.len() - 1]
+            } else {
+                &rungs[..]
+            };
+            let top = (g.len() - 1) as u32;
+            for (code, &xv) in scale_grid.iter().enumerate().skip(1) {
+                let x = xv as f32;
+                let mut probes: Vec<f32> = Vec::new();
+                for k in 0..g.len() - 1 {
+                    let mid = ((g[k] + g[k + 1]) / 2.0) as f32;
+                    let t = x * mid;
+                    probes.push(t);
+                    probes.push(f32::from_bits(t.to_bits() - 1));
+                    probes.push(f32::from_bits(t.to_bits() + 1));
+                }
+                for &gv in &g {
+                    probes.push(x * gv as f32);
+                }
+                for a in probes {
+                    if !a.is_finite() || a == 0.0 {
+                        continue;
+                    }
+                    let want = ref_code(&g, a, x).min(top as usize) as u32;
+                    // Values past the top grid entry belong to the overflow
+                    // rung, not to this ladder.
+                    if a as f64 > g[g.len() - 1] * x as f64 {
+                        continue;
+                    }
+                    let got = run_ladder(cmp, 0, x, true, a);
+                    assert_eq!(
+                        got, want,
+                        "{} scale code {code:#04X} (x={x}) value {a:e}: ladder {got:#X} \
+                         vs divide {want:#X}",
+                        f.type_name
+                    );
+                }
+            }
+        }
+    }
+
+    /// Every `scale × boundary` product the element ladder compares against
+    /// must be EXACT in FP32 — that is the whole reason the ladder is
+    /// correctly rounded, and it is a property of the format tables rather
+    /// than of the emitted code, so it is worth pinning on its own.
+    #[test]
+    fn fp_block_ue4m3_ladder_products_are_exact() {
+        for id in [
+            FpFormatId::E2m1,
+            FpFormatId::E2m3,
+            FpFormatId::E3m2,
+            FpFormatId::E4m3,
+            FpFormatId::E5m2,
+        ] {
+            let f = FORMATS.iter().find(|f| f.id == id).unwrap();
+            let (rungs, _) = elem_ladder(f);
+            for (code, &xv) in BlockScale::Ue4m3.grid().iter().enumerate().skip(1) {
+                for rg in &rungs {
+                    let (x, m) = (xv as f32, f32::from_bits(rg.thr));
+                    let p = x * m;
+                    assert!(p.is_finite() && p != 0.0, "{} code {code:#04X}", f.type_name);
+                    assert_eq!(
+                        p as f64,
+                        x as f64 * m as f64,
+                        "{} scale code {code:#04X}: {x} * {m} rounds in FP32",
+                        f.type_name
+                    );
+                }
+            }
+        }
+    }
+
+    /// `exact` selects `RNE(amax / elem_max)`. Same construction as the
+    /// element ladder, so the same independent check applies.
+    #[test]
+    fn fp_block_ue4m3_exact_scale_ladder_matches_a_real_divide() {
+        let g = BlockScale::Ue4m3.grid();
+        for id in [
+            FpFormatId::E2m1,
+            FpFormatId::E2m3,
+            FpFormatId::E3m2,
+            FpFormatId::E4m3,
+            FpFormatId::E5m2,
+        ] {
+            let f = FORMATS.iter().find(|f| f.id == id).unwrap();
+            let cmax = f.max_finite;
+            let (base, rungs) = scale_ladder(BlockScale::Ue4m3, cmax, ScalePolicy::Exact);
+            for k in 1..g.len() - 1 {
+                let mid = (g[k] + g[k + 1]) / 2.0;
+                let t = (cmax * mid) as f32;
+                for amax in [
+                    t,
+                    f32::from_bits(t.to_bits() - 1),
+                    f32::from_bits(t.to_bits() + 1),
+                    (cmax * g[k]) as f32,
+                ] {
+                    if !amax.is_finite() || amax <= 0.0 {
+                        continue;
+                    }
+                    let want = ref_code(&g, amax, cmax as f32).max(1) as u32;
+                    let got = run_ladder(&rungs, base, 1.0, false, amax);
+                    assert_eq!(
+                        got, want,
+                        "{} amax {amax:e}: scale ladder {got:#04X} vs divide {want:#04X}",
+                        f.type_name
+                    );
+                }
+            }
+        }
+    }
+
+    /// A UE4M3 block must never select scale code `0x00`. That code is a
+    /// genuine ZERO (unlike E8M0's `0x00`, which is its minimum scale), so
+    /// selecting it for a block whose maximum is nonzero would erase the
+    /// whole block on dequantize.
+    #[test]
+    fn fp_block_ue4m3_scale_ladder_never_selects_zero() {
+        for policy in [
+            ScalePolicy::Exact,
+            ScalePolicy::FloorPow2,
+            ScalePolicy::CeilPow2,
+        ] {
+            for id in [FpFormatId::E2m1, FpFormatId::E4m3] {
+                let f = FORMATS.iter().find(|f| f.id == id).unwrap();
+                let (base, rungs) = scale_ladder(BlockScale::Ue4m3, f.max_finite, policy);
+                assert_ne!(base, 0, "{policy:?}/{} base is the zero code", f.type_name);
+                for rg in &rungs {
+                    assert_ne!(rg.code, 0, "{policy:?}/{} rung selects zero", f.type_name);
+                }
+            }
+        }
+    }
+
+    /// The three special scale codes, pinned per scale with their reasons.
+    ///
+    /// These are constants consumed by BOTH backends from one table, so a
+    /// wrong value is wrong identically in the SystemVerilog and the C++ and
+    /// the cross-backend byte-compare cannot see it — the arch#904 shape.
+    /// This test is the only thing standing between a typo here and a silent
+    /// miscompile, so it states the value AND why it is that value.
+    #[test]
+    fn fp_block_special_scale_codes() {
+        // E8M0: no zero encoding, NaN is the all-ones code, so the largest
+        // finite is one below it.
+        assert_eq!(BlockScale::E8m0.nan_code(), 0xFF);
+        assert_eq!(BlockScale::E8m0.zero_block_code(), 0x00);
+        assert_eq!(BlockScale::E8m0.max_finite_code(), 0xFE);
+
+        // UE4M3: 7 significant bits with the MSB padded zero, so the NaN is
+        // 0x7F and NOT 0xFF — 0xFF would set the padding bit the format
+        // requires to be zero. 0x00 is a genuine zero (E8M0's is 2^-127).
+        assert_eq!(BlockScale::Ue4m3.nan_code(), 0x7F);
+        assert_eq!(BlockScale::Ue4m3.zero_block_code(), 0x00);
+        assert_eq!(BlockScale::Ue4m3.max_finite_code(), 0x7E);
+
+        // Cross-checks against the grid, so the codes cannot drift from the
+        // format they describe: the NaN code is one past the last finite
+        // one, and UE4M3's code 0 really is zero while E8M0's really is not.
+        for s in [BlockScale::E8m0, BlockScale::Ue4m3] {
+            let g = s.grid();
+            assert_eq!(g.len() as u32 - 1, s.max_finite_code(), "{s:?}");
+            assert_eq!(s.max_finite_code() + 1, s.nan_code(), "{s:?}");
+            assert!(g.iter().all(|v| *v > 0.0) == s.is_pow2(), "{s:?}");
+        }
+        assert_eq!(BlockScale::Ue4m3.grid()[0], 0.0);
+        assert_ne!(BlockScale::E8m0.grid()[0], 0.0);
+    }
+
+    /// The scale-dependent default (maintainer sign-off 2026-08-12): a
+    /// `floor_pow2` default under UE4M3 would discard all three mantissa bits
+    /// and quietly emit a power-of-two-scale block where NVFP4 was asked for.
+    #[test]
+    fn fp_block_default_policy_is_scale_dependent() {
+        assert_eq!(BlockScale::E8m0.default_policy(), ScalePolicy::FloorPow2);
+        assert_eq!(BlockScale::Ue4m3.default_policy(), ScalePolicy::Exact);
+        assert!(BlockScale::E8m0.is_pow2());
+        assert!(!BlockScale::Ue4m3.is_pow2());
+    }
+
+    /// Only a scale WITHOUT an exact reciprocal takes the division-free path,
+    /// and only a scale WITH one offers a reciprocal. Pins the two halves
+    /// together so a future variant cannot claim both or neither.
+    #[test]
+    fn fp_block_quant_kernel_agrees_with_reciprocal_availability() {
+        for s in [BlockScale::E8m0, BlockScale::Ue4m3] {
+            let has_recip = s.sv_reciprocal("c").is_some();
+            assert_eq!(has_recip, s.cpp_reciprocal("c").is_some());
+            assert_eq!(
+                has_recip,
+                s.quant_kernel() == QuantKernel::ExactReciprocal,
+                "{s:?}"
+            );
+            assert_eq!(has_recip, s.is_pow2(), "{s:?}");
+        }
+    }
+
+    /// The emitted UE4M3 quantizer must contain no divide and no reciprocal
+    /// helper — the entire point of arch#905's kernel.
+    #[test]
+    fn fp_block_ue4m3_quantize_emits_no_division() {
+        let s = BlockShape {
+            elem: FpFormatId::E2m1,
+            n: 16,
+            scale: BlockScale::Ue4m3,
+        };
+        for policy in [
+            ScalePolicy::Exact,
+            ScalePolicy::FloorPow2,
+            ScalePolicy::CeilPow2,
+        ] {
+            let sv = sv_quantize(s, policy, RoundMode::Rne);
+            let cpp = cpp_quantize(s, policy, RoundMode::Rne);
+            for (what, text) in [("sv", &sv), ("cpp", &cpp)] {
+                // Comments carry `/` in file paths and `->` arrows, so the
+                // check is against code lines only.
+                let code: String = text
+                    .lines()
+                    .filter(|l| !l.trim_start().starts_with("//"))
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                assert!(!code.contains('/'), "{what}/{policy:?} contains a divide");
+                assert!(
+                    !code.contains("254"),
+                    "{what}/{policy:?} reuses E8M0's reciprocal identity"
+                );
+                assert!(
+                    code.contains("arch_f32_mul"),
+                    "{what}/{policy:?} lost the scaled-threshold multiply"
+                );
             }
         }
     }

--- a/src/fp_block.rs
+++ b/src/fp_block.rs
@@ -1766,7 +1766,11 @@ mod tests {
                 for rg in &rungs {
                     let (x, m) = (xv as f32, f32::from_bits(rg.thr));
                     let p = x * m;
-                    assert!(p.is_finite() && p != 0.0, "{} code {code:#04X}", f.type_name);
+                    assert!(
+                        p.is_finite() && p != 0.0,
+                        "{} code {code:#04X}",
+                        f.type_name
+                    );
                     assert_eq!(
                         p as f64,
                         x as f64 * m as f64,

--- a/src/fp_format.rs
+++ b/src/fp_format.rs
@@ -284,12 +284,22 @@ pub fn width_of_tag(tag: &str) -> Option<u32> {
 
 /// Storage width of a type usable as a `ScaledVec` element or scale.
 ///
-/// This is `by_type_expr` plus `E8M0`, which is deliberately **not** a float
-/// (no sign, no mantissa, no zero) and therefore has no row in the table —
-/// but is the MX block scale, so it must be measurable here.
+/// This is `by_type_expr` plus the two SCALE types, which are deliberately
+/// **not** floats and therefore have no row in the table — but are what a
+/// block's scale field is, so they must be measurable here.
+///
+/// **Keep this arm in step with [`is_block_scale`].** A scale that is legal
+/// but unmeasurable makes `scaled_vec_width` return `None`, which the sim
+/// turns into a `uint8_t` while the SV emitter's own width walk keeps the
+/// full width — a wide port against a byte-wide variable, silently. That is
+/// how `ScaledVec<UInt<8>,4,E8M0>` failed in phase 2a and how `UE4M3` failed
+/// again in 5b; the `block_member_width_covers_every_legal_scale` test exists
+/// to make the third time a test failure instead.
 pub fn block_member_width(ty: &TypeExpr) -> Option<u32> {
     match ty {
-        TypeExpr::E8M0 => Some(8),
+        // Both scales are 8-bit carriers. UE4M3 has 7 significant bits with
+        // the MSB padded zero (PTX), so the CARRIER is still a byte.
+        TypeExpr::E8M0 | TypeExpr::UE4M3 => Some(8),
         other => by_type_expr(other).map(|f| f.width),
     }
 }
@@ -317,7 +327,7 @@ pub fn is_block_element(ty: &TypeExpr) -> bool {
 /// 7 significant bits, NaN `0x7F`), so reusing our E4M3 here would be a real
 /// bug rather than an approximation.
 pub fn is_block_scale(ty: &TypeExpr) -> bool {
-    matches!(ty, TypeExpr::E8M0)
+    matches!(ty, TypeExpr::E8M0 | TypeExpr::UE4M3)
 }
 
 /// Packed width of `ScaledVec<Elem, N, Scale>` = `scale_w + N * elem_w`.
@@ -529,5 +539,47 @@ mod tests {
         assert_eq!(e2m1.nan_rule, NanRule::NoNan);
         // Every 8-bit-or-wider format still carries full arithmetic.
         assert!(FORMATS.iter().filter(|f| f.width >= 8).all(|f| f.arith));
+    }
+
+    /// Every type `is_block_scale` accepts must also be measurable, and every
+    /// legal (element, scale) pair must yield a width.
+    ///
+    /// This is the structural gate for the failure that has now happened
+    /// twice: `is_block_scale` was widened to admit a new scale while
+    /// `block_member_width` was not, so `scaled_vec_width` returned `None`
+    /// and the sim's fallback sized a 72-bit block as a `uint8_t` — with the
+    /// SV emitter still using the full width. It is invisible to a
+    /// single-backend test and to `arch check`.
+    #[test]
+    fn block_member_width_covers_every_legal_scale() {
+        let scales = [TypeExpr::E8M0, TypeExpr::UE4M3];
+        let elems = [
+            TypeExpr::FP4E2M1,
+            TypeExpr::FP6E2M3,
+            TypeExpr::FP6E3M2,
+            TypeExpr::FP8E4M3,
+            TypeExpr::FP8E5M2,
+        ];
+        for s in &scales {
+            assert!(
+                is_block_scale(s),
+                "test's own scale list is out of date: {s:?}"
+            );
+            assert!(
+                block_member_width(s).is_some(),
+                "{s:?} is a legal block scale but has no width — \
+                 scaled_vec_width will return None and the sim will size the \
+                 block as a byte"
+            );
+            for e in &elems {
+                assert!(
+                    is_block_element(e),
+                    "test's own element list is out of date: {e:?}"
+                );
+                let w = scaled_vec_width(e, 16, s)
+                    .unwrap_or_else(|| panic!("ScaledVec<{e:?}, 16, {s:?}> has no width"));
+                assert_eq!(w, 8 + 16 * block_member_width(e).unwrap());
+            }
+        }
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -4911,13 +4911,14 @@ impl Parser {
                         let policy = match p.name.as_str() {
                             "floor_pow2" => ScalePolicy::FloorPow2,
                             "ceil_pow2" => ScalePolicy::CeilPow2,
+                            "exact" => ScalePolicy::Exact,
                             other => {
                                 return Err(CompileError::general(
                                     &format!(
                                         "unknown scale policy `{other}` — expected `floor_pow2` \
-                                         (OCP §6.3, the default) or `ceil_pow2` (NVIDIA). \
-                                         `exact` is reserved for a non-power-of-two scale \
-                                         (`UE4M3`) and is not implemented"
+                                         (OCP §6.3), `ceil_pow2` (NVIDIA) or `exact` \
+                                         (`RNE(amax / elem_max)`, for a non-power-of-two scale \
+                                         such as `UE4M3`)"
                                     ),
                                     p.span,
                                 ))
@@ -4939,9 +4940,12 @@ impl Parser {
                                 ))
                             }
                         };
-                        (policy, rounding)
+                        (Some(policy), rounding)
                     } else {
-                        (ScalePolicy::FloorPow2, RoundMode::Rne)
+                        // The policy default is scale-dependent and `fmt` may
+                        // be an alias, so leave it unwritten for typecheck to
+                        // settle rather than guessing `floor_pow2` here.
+                        (None, RoundMode::Rne)
                     };
                     // `expect_angle_close`, not `expect(Gt)`: the format may
                     // be written inline (`scaled_quantize<ScaledVec<..>>(v)`),

--- a/src/sim_codegen/stmt_codegen.rs
+++ b/src/sim_codegen/stmt_codegen.rs
@@ -67,7 +67,7 @@ fn emit_scaled_block_assign(
             let name = use_block_helper(
                 crate::fp_block::BlockHelper::Quantize {
                     shape,
-                    policy: *policy,
+                    policy: policy.unwrap_or_else(|| shape.scale.default_policy()),
                     round: *round,
                 },
                 ctx,

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -2921,12 +2921,9 @@ impl<'a> TypeChecker<'a> {
         }
         if !crate::fp_format::is_block_scale(scale) {
             self.errors.push(CompileError::general(
-                "`ScaledVec` scale must be `E8M0` — the MX block scale type. \
-                 `UE4M3` exists as a scalar type but is not yet usable as a \
-                 block scale (arch#905): unlike E8M0 its value is not a power \
-                 of two, so dividing by it is inexact and the block ops' \
-                 single-rounding property does not hold. `FP8E4M3` is NOT a \
-                 substitute for either",
+                "`ScaledVec` scale must be `E8M0` (OCP MX) or `UE4M3` (NVFP4). \
+                 `FP8E4M3` is NOT a substitute for `UE4M3` — that one is \
+                 signed and its NaN is sign-agnostic",
                 span,
             ));
         }
@@ -4116,7 +4113,7 @@ impl<'a> TypeChecker<'a> {
             // `scaled_quantize<Fmt, policy, rounding>(v)` — the output format
             // is named at the call site, never inferred: a `Vec<FP32,N>`
             // argument says nothing about the element format or scale.
-            ExprKind::ScaledQuantize(v, fmt, _policy, rounding) => {
+            ExprKind::ScaledQuantize(v, fmt, policy, rounding) => {
                 let vt = self.resolve_expr_type(v, module_name, local_types);
                 let n_in = match &vt {
                     Ty::Vec(elem, n) if **elem == Ty::FP32 => Some(*n),
@@ -4176,6 +4173,27 @@ impl<'a> TypeChecker<'a> {
                          `rtz` and `rna` need their own element rounders in both backends — \
                          each with its own overflow rule and equivalence proof — rather than \
                          a flag on the existing one",
+                        expr.span,
+                    ));
+                    return Ty::Error;
+                }
+                // `exact` divides by the element maximum instead of snapping
+                // the scale to a power of two, so it only means anything for a
+                // scale that CAN hold a non-power-of-two value. Refused rather
+                // than silently treated as `floor_pow2`, which would quietly
+                // give a different block than the one asked for.
+                //
+                // `fmt` is concrete here: `resolve_type_aliases` substitutes
+                // and then removes every alias before typecheck runs, so
+                // `shape_of_type` sees through `type NVFP4 = ScaledVec<…>`.
+                if *policy == Some(crate::ast::ScalePolicy::Exact)
+                    && crate::fp_block::shape_of_type(fmt).is_some_and(|s| s.scale.is_pow2())
+                {
+                    self.errors.push(CompileError::general(
+                        "`exact` scale policy is meaningless for an `E8M0`-scaled block: \
+                         every value of that scale is already a power of two, so there is \
+                         no mantissa for it to use. Use `floor_pow2` (OCP §6.3) or \
+                         `ceil_pow2` here, or a `UE4M3`-scaled block for `exact`",
                         expr.span,
                     ));
                     return Ty::Error;

--- a/tests/fp_test.rs
+++ b/tests/fp_test.rs
@@ -3573,20 +3573,33 @@ int main() {
     );
 }
 
-/// `UE4M3` is a scalar type today; using it as a block scale is refused with
-/// a message that says why (its value is not a power of two) and where the
-/// work is tracked.
+/// A `UE4M3`-scaled block is a first-class type: declarable as a port, and
+/// assignable as one packed word.
+///
+/// This replaces `fp_ue4m3_not_yet_a_block_scale`, which pinned the phase-5a
+/// refusal ("not yet usable as a block scale ... arch#905"). Phase 5b lifted
+/// it — see `fp_nvfp4_scale_accepted_but_fp8e4m3_is_not` for the acceptance
+/// path and the `FP8E4M3` confusion that is still an error.
 #[test]
-fn fp_ue4m3_not_yet_a_block_scale() {
+fn fp_ue4m3_block_scale_is_a_first_class_type() {
     let src = r#"module Nvfp4Blk
   port b: in ScaledVec<FP4E2M1, 16, UE4M3>;
   port o: out ScaledVec<FP4E2M1, 16, UE4M3>;
   comb o = b; end comb
 end module Nvfp4Blk
 "#;
-    let err = check_err(src, "Nvfp4Blk.arch");
+    let td = tempfile::tempdir().expect("tempdir");
+    let path = td.path().join("Nvfp4Blk.arch");
+    std::fs::write(&path, src).unwrap();
+    let out = arch()
+        .arg("check")
+        .arg(&path)
+        .output()
+        .expect("run arch check");
     assert!(
-        err.contains("not yet usable as a block scale") && err.contains("905"),
-        "the refusal must name the follow-up:\n{err}"
+        out.status.success(),
+        "a UE4M3-scaled block must be a usable port type:\n{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
     );
 }

--- a/tests/fp_test.rs
+++ b/tests/fp_test.rs
@@ -2979,6 +2979,205 @@ fn fp_scaled_quant_sv_matches_sim() {
     }
 }
 
+/// **The phase-5b gate (§8), arch#905.** Same construction as
+/// `fp_scaled_quant_sv_matches_sim`, aimed at the `UE4M3` scale.
+///
+/// This is the comparison that matters most for phase 5b, because the failure
+/// mode it guards is one no structural test can see: the two ladders are
+/// emitted from one table, so a wrong constant or a wrong `>` / `>=` would be
+/// wrong IDENTICALLY in SystemVerilog and in C++ — the shape of arch#904.
+/// Only running both and comparing values catches a table that is
+/// self-consistently wrong, and the `..._matches_a_real_divide` unit tests in
+/// `src/fp_block.rs` are what catch that half.
+#[test]
+fn fp_nvfp4_sv_matches_sim() {
+    fn verilator_available() -> bool {
+        std::process::Command::new("verilator")
+            .arg("--version")
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+    }
+    if !verilator_available() {
+        eprintln!("skipping fp_nvfp4_sv_matches_sim: verilator not in PATH");
+        return;
+    }
+    let manifest = env!("CARGO_MANIFEST_DIR");
+    let td = tempfile::tempdir().expect("tempdir");
+
+    let sim = arch()
+        .arg("sim")
+        .arg(format!("{manifest}/tests/fp_v1/Nvfp4Quant.arch"))
+        .arg("--tb")
+        .arg(format!("{manifest}/tests/fp_v1/tb_nvfp4.cpp"))
+        .arg("--outdir")
+        .arg(td.path().join("sim"))
+        .output()
+        .expect("run arch sim");
+    assert!(
+        sim.status.success(),
+        "arch sim failed:\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&sim.stdout),
+        String::from_utf8_lossy(&sim.stderr)
+    );
+    let sim_txt = transcript(&String::from_utf8_lossy(&sim.stdout));
+
+    let sv = td.path().join("Nvfp4Quant.sv");
+    let build = arch()
+        .arg("build")
+        .arg(format!("{manifest}/tests/fp_v1/Nvfp4Quant.arch"))
+        .arg("-o")
+        .arg(&sv)
+        .output()
+        .expect("run arch build");
+    assert!(
+        build.status.success(),
+        "arch build failed:\nstderr:\n{}",
+        String::from_utf8_lossy(&build.stderr)
+    );
+    let obj = td.path().join("obj");
+    let tb = format!("{manifest}/tests/fp_v1/rtl_diff/tb_nvfp4.sv");
+    let vout = std::process::Command::new("verilator")
+        .args([
+            "--binary",
+            "--timing",
+            "-Wno-WIDTH",
+            "-Wno-UNOPTFLAT",
+            "-Wno-WIDTHTRUNC",
+            "-Wno-WIDTHEXPAND",
+            "-Wno-UNUSEDSIGNAL",
+            "-Wno-MULTITOP",
+            "-Wno-DECLFILENAME",
+            "-Wno-TIMESCALEMOD",
+            "--top-module",
+            "tb",
+            "-o",
+            "sim_nv",
+        ])
+        .arg("-Mdir")
+        .arg(&obj)
+        .arg(&sv)
+        .arg(&tb)
+        .output()
+        .expect("run verilator");
+    assert!(
+        vout.status.success(),
+        "verilator build failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&vout.stdout),
+        String::from_utf8_lossy(&vout.stderr)
+    );
+    let run = std::process::Command::new(obj.join("sim_nv"))
+        .output()
+        .expect("run verilated sim");
+    let sv_txt = transcript(&String::from_utf8_lossy(&run.stdout));
+
+    assert!(
+        !sim_txt.is_empty() && sim_txt.lines().count() > 40,
+        "sim transcript is suspiciously short — a passing comparison of two \
+         empty transcripts would be vacuous:\n{sim_txt}"
+    );
+    if sim_txt != sv_txt {
+        let first = sim_txt
+            .lines()
+            .zip(sv_txt.lines())
+            .enumerate()
+            .find(|(_, (a, b))| a != b)
+            .map(|(i, (a, b))| format!("line {}:\n  sim: {a}\n  sv : {b}", i + 1))
+            .unwrap_or_else(|| "transcripts differ in length".to_string());
+        panic!(
+            "arch build and arch sim disagree on the NVFP4 block conversion.\n{first}\n\n\
+             --- sim ---\n{sim_txt}\n--- sv ---\n{sv_txt}"
+        );
+    }
+
+    // The default policy for a UE4M3 block is `exact`, so the un-annotated
+    // call and the explicit one must be bit-identical — and on a block whose
+    // maximum is not a power of two, `floor_pow2` must NOT be.
+    let sect = |name: &str| -> std::collections::HashMap<String, String> {
+        let mut out = std::collections::HashMap::new();
+        let mut in_sect = false;
+        for l in sim_txt.lines() {
+            if let Some(rest) = l.strip_prefix("== ") {
+                in_sect = rest.trim() == name;
+                continue;
+            }
+            if in_sect {
+                if let Some((k, v)) = l.split_once(' ') {
+                    out.insert(k.trim().to_string(), v.trim().to_string());
+                }
+            }
+        }
+        out
+    };
+    let np = sect("nonpow2");
+    assert_eq!(
+        np.get("qd"),
+        np.get("qe"),
+        "a UE4M3 block must default to the `exact` scale policy:\n{sim_txt}"
+    );
+    assert_ne!(
+        np.get("qe"),
+        np.get("qf"),
+        "on a non-power-of-two maximum `exact` must differ from `floor_pow2` — \
+         that difference IS the scale's mantissa:\n{sim_txt}"
+    );
+}
+
+/// `exact` is refused where it cannot mean anything. Silently treating it as
+/// `floor_pow2` would hand back a different block than the one asked for.
+#[test]
+fn fp_scaled_quant_exact_on_pow2_scale_errors() {
+    let src = r#"module ExactE8
+  port v: in Vec<FP32, 4>;
+  port o: out ScaledVec<FP4E2M1, 4, E8M0>;
+  comb o = scaled_quantize<ScaledVec<FP4E2M1, 4, E8M0>, exact, rne>(v); end comb
+end module ExactE8
+"#;
+    let err = check_err(src, "ExactE8.arch");
+    assert!(
+        err.contains("meaningless") && err.contains("power of two"),
+        "`exact` on an E8M0 block must say why it cannot apply:\n{err}"
+    );
+}
+
+/// The `UE4M3` scale is accepted as a block scale, and `FP8E4M3` still is
+/// not — they are different formats and confusing them is a real bug.
+#[test]
+fn fp_nvfp4_scale_accepted_but_fp8e4m3_is_not() {
+    let ok = r#"module NvOk
+  port v: in Vec<FP32, 16>;
+  port o: out ScaledVec<FP4E2M1, 16, UE4M3>;
+  comb o = scaled_quantize<ScaledVec<FP4E2M1, 16, UE4M3>>(v); end comb
+end module NvOk
+"#;
+    let td = tempfile::tempdir().expect("tempdir");
+    let path = td.path().join("NvOk.arch");
+    std::fs::write(&path, ok).unwrap();
+    let out = arch()
+        .arg("check")
+        .arg(&path)
+        .output()
+        .expect("run arch check");
+    assert!(
+        out.status.success(),
+        "a UE4M3-scaled block must type-check:\n{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let bad = r#"module NvBad
+  port v: in Vec<FP32, 16>;
+  port o: out ScaledVec<FP4E2M1, 16, FP8E4M3>;
+  comb o = scaled_quantize<ScaledVec<FP4E2M1, 16, FP8E4M3>>(v); end comb
+end module NvBad
+"#;
+    let err = check_err(bad, "NvBad.arch");
+    assert!(
+        err.contains("E8M0") && err.contains("UE4M3"),
+        "the scale error must name both legal scales:\n{err}"
+    );
+}
+
 /// `scaled_quantize` needs its output format spelled — it cannot be inferred
 /// from a `Vec<FP32,N>`, since every block format takes FP32 inputs.
 #[test]

--- a/tests/fp_v1/Nvfp4Quant.arch
+++ b/tests/fp_v1/Nvfp4Quant.arch
@@ -1,0 +1,76 @@
+// NVFP4 blocks — a `UE4M3` block scale (phase 5b, arch#905).
+//
+// The point of this fixture is the scale that is NOT a power of two. Every
+// E8M0 block op divides by the scale using an exact reciprocal (`2^-(c-127)`
+// is itself a scale code); UE4M3 carries three mantissa bits and has no such
+// identity, so `scaled_quantize` here uses the division-free kernel instead:
+// two ladders of constant thresholds, with every `scale x boundary` product
+// exact in FP32 so each element still rounds exactly once.
+//
+// Run through BOTH backends against one testbench and byte-compared, like
+// ScaledQuant.arch — that is the §8 gate. The blocks below deliberately span:
+//   - the real NVFP4 shape (E2M1 x 16), whose element format is all-finite;
+//   - an E4M3-element block, which DOES have somewhere to overflow to and so
+//     exercises the profile-dependent overflow rung;
+//   - all three scale policies, including `exact`, which only means anything
+//     for a non-power-of-two scale.
+
+package Nv
+  type NVFP4 = ScaledVec<FP4E2M1, 16, UE4M3>;   // 8 + 16*4 = 72 bits (wide)
+  type NV8   = ScaledVec<FP8E4M3, 8, UE4M3>;    // 8 + 8*8  = 72 bits
+  type MX4   = ScaledVec<FP4E2M1, 16, E8M0>;    // same shape, pow2 scale
+end package Nv
+
+module Nvfp4Quant
+  port v:  in Vec<FP32, 16>;
+  port v8: in Vec<FP32, 8>;
+
+  // `exact` is the default for a UE4M3-scaled block, so `q_def` and
+  // `q_exact` must come out bit-identical. A regression that quietly
+  // restored the global `floor_pow2` default would show up right here.
+  port q_def:   out NVFP4;
+  port q_exact: out NVFP4;
+  port q_floor: out NVFP4;
+  port q_ceil:  out NVFP4;
+
+  // Same element vector, same block size, power-of-two scale — the
+  // side-by-side that shows what the mantissa bits buy.
+  port q_mx: out MX4;
+
+  port q8: out NV8;
+
+  port back:    out Vec<FP32, 16>;
+  port back_mx: out Vec<FP32, 16>;
+  port back8:   out Vec<FP32, 8>;
+
+  port dot:   out FP32;
+  port dot_x: out FP32;
+  port dot8:  out FP32;
+
+  wire b:      NVFP4;
+  wire b_ceil: NVFP4;
+  wire bmx:    MX4;
+  wire b8:     NV8;
+
+  comb
+    b       = scaled_quantize<NVFP4>(v);
+    b_ceil  = scaled_quantize<NVFP4, ceil_pow2, rne>(v);
+    bmx     = scaled_quantize<MX4>(v);
+    b8      = scaled_quantize<NV8, exact, rne>(v8);
+
+    q_def   = b;
+    q_exact = scaled_quantize<NVFP4, exact, rne>(v);
+    q_floor = scaled_quantize<NVFP4, floor_pow2, rne>(v);
+    q_ceil  = b_ceil;
+    q_mx    = bmx;
+    q8      = b8;
+
+    back    = scaled_dequantize(b);
+    back_mx = scaled_dequantize(bmx);
+    back8   = scaled_dequantize(b8);
+
+    dot   = scaled_dot(b, b);
+    dot_x = scaled_dot(b, b_ceil);
+    dot8  = scaled_dot(b8, b8);
+  end comb
+end module Nvfp4Quant

--- a/tests/fp_v1/rtl_diff/tb_nvfp4.sv
+++ b/tests/fp_v1/rtl_diff/tb_nvfp4.sv
@@ -1,0 +1,149 @@
+// SystemVerilog twin of `tests/fp_v1/tb_nvfp4.cpp`.
+//
+// Drives the SAME vectors into the SAME design and prints the SAME
+// transcript, so `fp_nvfp4_sv_matches_sim` can byte-compare the two. That
+// comparison is the §8 gate for phase 5b (arch#905): the UE4M3 quantizer's
+// two constant-threshold ladders are rendered once as SystemVerilog and once
+// as C++ from one descriptor in `src/fp_block.rs`, and this is what proves
+// the two renderings agree on values rather than merely on shape.
+//
+// Keep the vector table below in lock-step with the C++ one — same order,
+// same hex.
+`timescale 1ns/1ps
+
+module tb;
+  localparam int NC = 10;
+
+  logic [15:0][31:0] v;
+  logic  [7:0][31:0] v8;
+  logic [71:0]       q_def, q_exact, q_floor, q_ceil, q_mx, q8;
+  logic [15:0][31:0] back, back_mx;
+  logic  [7:0][31:0] back8;
+  logic [31:0]       dot, dot_x, dot8;
+
+  Nvfp4Quant dut (
+    .v(v), .v8(v8),
+    .q_def(q_def), .q_exact(q_exact), .q_floor(q_floor), .q_ceil(q_ceil),
+    .q_mx(q_mx), .q8(q8),
+    .back(back), .back_mx(back_mx), .back8(back8),
+    .dot(dot), .dot_x(dot_x), .dot8(dot8)
+  );
+
+  string       names [NC];
+  logic [31:0] vecs  [NC][16];
+  logic [31:0] vec8s [NC][8];
+
+  task automatic show(input string name, input logic [71:0] val, input int words);
+    $write("%s", name);
+    for (int w = 0; w < words; w++) $write(" %h", val[w*32 +: 32]);
+    $write("\n");
+  endtask
+
+  task automatic show_vec(input string name, input logic [15:0][31:0] val, input int n);
+    $write("%s", name);
+    for (int i = 0; i < n; i++) $write(" %h", val[i]);
+    $write("\n");
+  endtask
+
+  initial begin
+    // Block maximum 8.0 is a power of two.
+    names[0] = "pow2";
+    vecs[0]  = '{32'h3F800000, 32'hC0000000, 32'h40800000, 32'h3F000000,
+                 32'h41000000, 32'hBE800000, 32'h00000000, 32'h40000000,
+                 32'h3F800000, 32'h40800000, 32'hC1000000, 32'h3F000000,
+                 32'h40000000, 32'h00000000, 32'h3E800000, 32'h40800000};
+    vec8s[0] = '{32'h3F800000, 32'h40000000, 32'h40800000, 32'h3F000000,
+                 32'h41000000, 32'h3F800000, 32'h40400000, 32'h00000000};
+    // Maximum 5.0, so amax/elem_max is also not a power of two: `exact`
+    // vs `floor_pow2`. (6.0 would be vacuous — 6/6 is exactly 1.0.)
+    names[1] = "nonpow2";
+    vecs[1]  = '{32'h3F800000, 32'hC0000000, 32'h40400000, 32'h3F000000,
+                 32'h40A00000, 32'hBE800000, 32'h00000000, 32'h40800000,
+                 32'h3FC00000, 32'h3F400000, 32'hC0400000, 32'h40000000,
+                 32'h3F800000, 32'h40A00000, 32'h3E800000, 32'h3F000000};
+    vec8s[1] = '{32'h40A00000, 32'h40400000, 32'h3FC00000, 32'h3F400000,
+                 32'h40000000, 32'h3F800000, 32'hC0A00000, 32'h3F000000};
+    // All zero: scale code 0x00, a genuine zero for UE4M3.
+    names[2] = "zeros";
+    vecs[2]  = '{32'h0, 32'h0, 32'h0, 32'h0, 32'h0, 32'h0, 32'h0, 32'h0,
+                 32'h0, 32'h0, 32'h0, 32'h0, 32'h0, 32'h0, 32'h0, 32'h0};
+    vec8s[2] = '{32'h0, 32'h0, 32'h0, 32'h0, 32'h0, 32'h0, 32'h0, 32'h0};
+    // Signed zeros only.
+    names[3] = "negzero";
+    vecs[3]  = '{32'h80000000, 32'h0, 32'h80000000, 32'h0,
+                 32'h0, 32'h80000000, 32'h0, 32'h0,
+                 32'h80000000, 32'h0, 32'h0, 32'h0,
+                 32'h80000000, 32'h0, 32'h0, 32'h0};
+    vec8s[3] = '{32'h80000000, 32'h0, 32'h0, 32'h0,
+                 32'h80000000, 32'h0, 32'h0, 32'h0};
+    // NaN forces the NaN scale 0x7F, NOT 0xFF.
+    names[4] = "nan";
+    vecs[4]  = '{32'h3F800000, 32'h7FC00000, 32'h40400000, 32'h3F000000,
+                 32'h40C00000, 32'hBE800000, 32'h00000000, 32'h40800000,
+                 32'h3F800000, 32'h40000000, 32'h3F000000, 32'h40400000,
+                 32'h3F800000, 32'h40800000, 32'h3E800000, 32'h3F000000};
+    vec8s[4] = '{32'h3F800000, 32'h7FC00000, 32'h3F800000, 32'h3F800000,
+                 32'h40000000, 32'h3F800000, 32'h3F800000, 32'h3F800000};
+    // Inf likewise.
+    names[5] = "inf";
+    vecs[5]  = '{32'h3F800000, 32'h7F800000, 32'h40400000, 32'h3F000000,
+                 32'h40C00000, 32'hBE800000, 32'h00000000, 32'h40800000,
+                 32'h3F800000, 32'h40000000, 32'h3F000000, 32'h40400000,
+                 32'h3F800000, 32'h40800000, 32'h3E800000, 32'h3F000000};
+    vec8s[5] = '{32'hFF800000, 32'h3F800000, 32'h3F800000, 32'h3F800000,
+                 32'h40000000, 32'h3F800000, 32'h3F800000, 32'h3F800000};
+    // Subnormals: the scale underflows and clamps at 0x01, not 0x00.
+    names[6] = "subnormal";
+    vecs[6]  = '{32'h00000001, 32'h00000002, 32'h007FFFFF, 32'h00400000,
+                 32'h00000000, 32'h00000003, 32'h00800000, 32'h00000001,
+                 32'h00000002, 32'h00000001, 32'h00000000, 32'h00000004,
+                 32'h00000001, 32'h00200000, 32'h00000000, 32'h00000001};
+    vec8s[6] = '{32'h00000001, 32'h00000002, 32'h00000003, 32'h00000004,
+                 32'h00000001, 32'h00800000, 32'h00000002, 32'h00000001};
+    // Huge magnitudes: the scale saturates at the top UE4M3 code.
+    names[7] = "huge";
+    vecs[7]  = '{32'h7F7FFFFF, 32'h7F000000, 32'h3F800000, 32'h00000000,
+                 32'hFF7FFFFF, 32'h40000000, 32'h40800000, 32'h41000000,
+                 32'h7F000000, 32'h3F800000, 32'h00000000, 32'h40000000,
+                 32'h7F7FFFFF, 32'h40800000, 32'h3F000000, 32'h41000000};
+    vec8s[7] = '{32'h7F7FFFFF, 32'h3F800000, 32'h00000000, 32'h40000000,
+                 32'h7F000000, 32'h40800000, 32'h3F800000, 32'h41000000};
+    // Wide dynamic range inside one block.
+    names[8] = "range";
+    vecs[8]  = '{32'h44800000, 32'h3A83126F, 32'hC4000000, 32'h00000000,
+                 32'h3F800000, 32'hB8D1B717, 32'h43800000, 32'h40000000,
+                 32'h44800000, 32'h3A83126F, 32'h3F800000, 32'h00000000,
+                 32'hC4000000, 32'h43800000, 32'h40000000, 32'h3F800000};
+    vec8s[8] = '{32'h44800000, 32'h3A83126F, 32'h3F800000, 32'h00000000,
+                 32'hC4000000, 32'h43800000, 32'h40000000, 32'h3F800000};
+    // E4M3 elements straddling their own top code (448 / 464 / 480) — the
+    // only vector that fires the overflow rung.
+    names[9] = "e4m3_top";
+    vecs[9]  = '{32'h43E00000, 32'h43F00000, 32'h43600000, 32'h3F800000,
+                 32'h43E00000, 32'hC3F00000, 32'h40000000, 32'h43600000,
+                 32'h43E00000, 32'h43F00000, 32'h3F800000, 32'h40800000,
+                 32'h43600000, 32'h43E00000, 32'h40000000, 32'h3F000000};
+    vec8s[9] = '{32'h43E00000, 32'h43F00000, 32'h43680000, 32'h43600000,
+                 32'hC3E00000, 32'hC3F00000, 32'h3F800000, 32'h40000000};
+
+    for (int c = 0; c < NC; c++) begin
+      for (int i = 0; i < 16; i++) v[i]  = vecs[c][i];
+      for (int i = 0; i < 8;  i++) v8[i] = vec8s[c][i];
+      #1;
+      $display("== %s", names[c]);
+      show("qd ", q_def,   3);
+      show("qe ", q_exact, 3);
+      show("qf ", q_floor, 3);
+      show("qc ", q_ceil,  3);
+      show("qmx", q_mx,    3);
+      show("q8 ", q8,      3);
+      show_vec("bk ", back,    16);
+      show_vec("bmx", back_mx, 16);
+      $write("bk8");
+      for (int i = 0; i < 8; i++) $write(" %h", back8[i]);
+      $write("\n");
+      $display("dot %h %h %h", dot, dot_x, dot8);
+    end
+    $finish;
+  end
+endmodule

--- a/tests/fp_v1/tb_nvfp4.cpp
+++ b/tests/fp_v1/tb_nvfp4.cpp
@@ -1,0 +1,160 @@
+// arch-sim side of the NVFP4 (`UE4M3` block scale) cross-backend check
+// (phase 5b, arch#905).
+//
+// Prints one line per (vector, signal) in a format the SystemVerilog
+// testbench `rtl_diff/tb_nvfp4.sv` reproduces EXACTLY, so
+// `fp_nvfp4_sv_matches_sim` can byte-compare the two transcripts. Same shape
+// as `tb_scaled_quant.cpp` — blocks as 32-bit words, LSB first.
+//
+// The vector set targets what is NEW here rather than re-testing the E8M0
+// paths: a scale that is not a power of two (so `exact` must differ from
+// `floor_pow2`), the scale codes UE4M3 owns and E8M0 does not (`0x7F` is NaN,
+// `0x00` is a genuine zero, and the underflow clamp is `0x01` rather than
+// `0x00` because clamping to zero would erase the block), and element
+// magnitudes that push an E4M3 element past its top code, which is the only
+// place the profile-dependent overflow rung fires.
+#include "VNvfp4Quant.h"
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+
+static VNvfp4Quant dut;
+
+static void print_words(const char *name, uint64_t v, int words) {
+  printf("%s", name);
+  for (int w = 0; w < words; ++w)
+    printf(" %08x", (uint32_t)(v >> (32 * w)));
+  printf("\n");
+}
+template <int W>
+static void print_words(const char *name, const VlWide<W> &v, int words) {
+  printf("%s", name);
+  for (int w = 0; w < words; ++w)
+    printf(" %08x", const_cast<VlWide<W> &>(v).data()[w]);
+  printf("\n");
+}
+static void print_vec(const char *name, const uint32_t *v, int n) {
+  printf("%s", name);
+  for (int i = 0; i < n; ++i)
+    printf(" %08x", v[i]);
+  printf("\n");
+}
+
+struct Case {
+  const char *why;
+  uint32_t v[16]; // raw FP32 bit patterns
+  uint32_t v8[8];
+};
+
+// Raw bit patterns, never float literals — same reasoning as
+// tb_scaled_quant.cpp: a decimal literal would assert the C++ parse too, and
+// the SV twin has to drive identical bits.
+//
+//   1.0=3F800000   2.0=40000000   3.0=40400000   4.0=40800000   6.0=40C00000
+//   0.5=3F000000   1.5=3FC00000   0.75=3F400000  8.0=41000000   0.25=3E800000
+//   448=43E00000   480=43F00000   224=43600000   0.001=3A83126F 1024=44800000
+int main() {
+  const Case cases[] = {
+      // Block maximum 8.0 is a power of two: `exact` can land on a
+      // power-of-two scale too, so this is the case where the three policies
+      // have the best chance of agreeing.
+      {"pow2",
+       {0x3F800000u, 0xC0000000u, 0x40800000u, 0x3F000000u, 0x41000000u, 0xBE800000u,
+        0x00000000u, 0x40000000u, 0x3F800000u, 0x40800000u, 0xC1000000u, 0x3F000000u,
+        0x40000000u, 0x00000000u, 0x3E800000u, 0x40800000u},
+       {0x3F800000u, 0x40000000u, 0x40800000u, 0x3F000000u, 0x41000000u, 0x3F800000u,
+        0x40400000u, 0x00000000u}},
+      // Maximum 5.0 — chosen so that amax/elem_max is ALSO not a power of
+      // two (6.0 would not do: 6/6 is exactly 1.0, so `exact` and
+      // `floor_pow2` would agree and the check below would be vacuous).
+      // This is the case that separates `exact`, which uses the scale's
+      // mantissa, from `floor_pow2`, which throws it away. If a regression
+      // restored the global floor default, `q_def` would stop matching
+      // `q_exact` here.
+      {"nonpow2",
+       {0x3F800000u, 0xC0000000u, 0x40400000u, 0x3F000000u, 0x40A00000u, 0xBE800000u,
+        0x00000000u, 0x40800000u, 0x3FC00000u, 0x3F400000u, 0xC0400000u, 0x40000000u,
+        0x3F800000u, 0x40A00000u, 0x3E800000u, 0x3F000000u},
+       {0x40A00000u, 0x40400000u, 0x3FC00000u, 0x3F400000u, 0x40000000u, 0x3F800000u,
+        0xC0A00000u, 0x3F000000u}},
+      // All zero: scale code 0x00, which for UE4M3 is a genuine ZERO rather
+      // than E8M0's minimum scale. Must not be the NaN code.
+      {"zeros",
+       {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+       {0, 0, 0, 0, 0, 0, 0, 0}},
+      // Signed zeros only — still an all-zero block by magnitude.
+      {"negzero",
+       {0x80000000u, 0, 0x80000000u, 0, 0, 0x80000000u, 0, 0, 0x80000000u, 0, 0, 0,
+        0x80000000u, 0, 0, 0},
+       {0x80000000u, 0, 0, 0, 0x80000000u, 0, 0, 0}},
+      // One NaN anywhere forces the NaN scale — 0x7F for UE4M3, NOT 0xFF:
+      // 0xFF would set the padding bit the format requires to be zero.
+      {"nan",
+       {0x3F800000u, 0x7FC00000u, 0x40400000u, 0x3F000000u, 0x40C00000u, 0xBE800000u,
+        0x00000000u, 0x40800000u, 0x3F800000u, 0x40000000u, 0x3F000000u, 0x40400000u,
+        0x3F800000u, 0x40800000u, 0x3E800000u, 0x3F000000u},
+       {0x3F800000u, 0x7FC00000u, 0x3F800000u, 0x3F800000u, 0x40000000u, 0x3F800000u,
+        0x3F800000u, 0x3F800000u}},
+      // Inf likewise.
+      {"inf",
+       {0x3F800000u, 0x7F800000u, 0x40400000u, 0x3F000000u, 0x40C00000u, 0xBE800000u,
+        0x00000000u, 0x40800000u, 0x3F800000u, 0x40000000u, 0x3F000000u, 0x40400000u,
+        0x3F800000u, 0x40800000u, 0x3E800000u, 0x3F000000u},
+       {0xFF800000u, 0x3F800000u, 0x3F800000u, 0x3F800000u, 0x40000000u, 0x3F800000u,
+        0x3F800000u, 0x3F800000u}},
+      // Subnormal inputs: the scale underflows. UE4M3 clamps at code 0x01,
+      // the smallest NONZERO scale — clamping at 0x00 would make the scale a
+      // true zero and erase a block whose maximum is nonzero.
+      {"subnormal",
+       {1u, 2u, 0x007FFFFFu, 0x00400000u, 0u, 3u, 0x00800000u, 1u, 2u, 1u, 0u, 4u, 1u,
+        0x00200000u, 0u, 1u},
+       {1u, 2u, 3u, 4u, 1u, 0x00800000u, 2u, 1u}},
+      // Huge magnitudes: the scale saturates at the top UE4M3 code and the
+      // elements clamp.
+      {"huge",
+       {0x7F7FFFFFu, 0x7F000000u, 0x3F800000u, 0x00000000u, 0xFF7FFFFFu, 0x40000000u,
+        0x40800000u, 0x41000000u, 0x7F000000u, 0x3F800000u, 0x00000000u, 0x40000000u,
+        0x7F7FFFFFu, 0x40800000u, 0x3F000000u, 0x41000000u},
+       {0x7F7FFFFFu, 0x3F800000u, 0x00000000u, 0x40000000u, 0x7F000000u, 0x40800000u,
+        0x3F800000u, 0x41000000u}},
+      // Wide dynamic range inside one block: the small elements must
+      // quantize to zero rather than wrap.
+      {"range",
+       {0x44800000u, 0x3A83126Fu, 0xC4000000u, 0x00000000u, 0x3F800000u, 0xB8D1B717u,
+        0x43800000u, 0x40000000u, 0x44800000u, 0x3A83126Fu, 0x3F800000u, 0x00000000u,
+        0xC4000000u, 0x43800000u, 0x40000000u, 0x3F800000u},
+       {0x44800000u, 0x3A83126Fu, 0x3F800000u, 0x00000000u, 0xC4000000u, 0x43800000u,
+        0x40000000u, 0x3F800000u}},
+      // E4M3 elements straddling their own top code: 448 is the largest
+      // finite, 464 is the tie that must round DOWN to it, and 480 is the
+      // first magnitude that overflows. This is the only vector that fires
+      // the overflow rung, whose result is delegated to the element format's
+      // own rounder so it follows `--fp-compat`.
+      {"e4m3_top",
+       {0x43E00000u, 0x43F00000u, 0x43600000u, 0x3F800000u, 0x43E00000u, 0xC3F00000u,
+        0x40000000u, 0x43600000u, 0x43E00000u, 0x43F00000u, 0x3F800000u, 0x40800000u,
+        0x43600000u, 0x43E00000u, 0x40000000u, 0x3F000000u},
+       {0x43E00000u, 0x43F00000u, 0x43680000u, 0x43600000u, 0xC3E00000u, 0xC3F00000u,
+        0x3F800000u, 0x40000000u}},
+  };
+
+  for (const Case &c : cases) {
+    for (int i = 0; i < 16; ++i)
+      dut.v[i] = c.v[i];
+    for (int i = 0; i < 8; ++i)
+      dut.v8[i] = c.v8[i];
+    dut.eval();
+    printf("== %s\n", c.why);
+    print_words("qd ", dut.q_def, 3);
+    print_words("qe ", dut.q_exact, 3);
+    print_words("qf ", dut.q_floor, 3);
+    print_words("qc ", dut.q_ceil, 3);
+    print_words("qmx", dut.q_mx, 3);
+    print_words("q8 ", dut.q8, 3);
+    print_vec("bk ", dut.back, 16);
+    print_vec("bmx", dut.back_mx, 16);
+    print_vec("bk8", dut.back8, 8);
+    printf("dot %08x %08x %08x\n", dut.dot, dut.dot_x, dut.dot8);
+  }
+  return 0;
+}


### PR DESCRIPTION
Phase 5b of the MX/NVFP4 line. `ScaledVec<FP4E2M1, 16, UE4M3>` now type-checks, quantizes, dequantizes and dots in both backends. Closes #905.

## The issue's premise turned out to be false

#905 predicted this needed an `arch_f32_div` and would cost the single-rounding property, because every MX block op assumes a power-of-two scale and UE4M3 carries three mantissa bits. **The quantizer never forms the quotient at all.**

Instead of dividing, it compares `|v|` against `X × m` for each RNE decision boundary `m` of the element grid. Every such product is **exact in FP32** — the scale has 4 significand bits and a boundary at most 5, so the product needs at most 9 of FP32's 24, with no exponent-range escape. That makes each comparison a decision rather than an approximation, and the selected code correctly rounded by construction.

Ties-to-even needs no runtime logic: exactly one of the two codes at a boundary is even, so it is a strict `>` at even `k` and a `>=` at odd `k` — fixed at generation time, per boundary. The scale is chosen the same way, against constant thresholds that fold entirely.

**So single-rounding is recovered, not lost, and the §3.11.3 error bounds carry over to UE4M3 unchanged.**

## Evidence

Over all 126 finite UE4M3 scales × all five element formats:

| Check | Result |
|---|---|
| `X × m` exact in FP32 (the property the kernel rests on) | **0 inexact** |
| Ladder vs a real divide — every boundary exactly, both 1-ULP neighbours, every grid point | **0 disagreements** |
| The reciprocal shortcut this replaces | **4.76% wrong** on tie-aligned inputs — reproduces the figure recorded in #908 |
| Emitted E4M3 overflow boundary | **464.0 with a strict `>`** — OCP's documented rule (464 ties down to 448, ≥480 overflows), arrived at from the parity rule rather than transcribed |

**Cross-backend (§8 gate):** `fp_nvfp4_sv_matches_sim` runs Verilator on the emitted SV and the native sim on the emitted C++ over 10 vectors — all-zero, signed-zero, NaN, Inf, subnormal, saturating, wide-range and E4M3-overflow blocks — and byte-compares the transcripts.

## Surface decisions (maintainer-approved 2026-08-12, recorded in `doc/proposal_mx_block_formats.md` §9.1)

- **The default scale policy is now per-scale**: `floor_pow2` for E8M0 (OCP §6.3, unchanged), `exact` for UE4M3. One global default cannot serve both — defaulting UE4M3 to `floor_pow2` discards all three mantissa bits and silently emits a power-of-two-scale block under the NVFP4 name. `exact` is *refused* for E8M0 rather than ignored. This amends proposal §9 decision #1.
- **NVFP4's per-tensor FP32 scale stays out of the type.** A `ScaledVec` is one block, so a fourth type parameter would replicate a per-tensor quantity per block. It costs nothing numerically: fusing it in would compare against `S × X × m`, which is *not* exact for arbitrary `S` — where `X × m` is — so the fused form would round where the split form does not.

## Latent bug found by the gate

The 6th instance of the arch#837 hazard: `block_member_width` knew `E8M0` but not `UE4M3`, so `scaled_vec_width` returned `None` and the sim's fallback sized a 72-bit block as a `uint8_t` while the SV emitter kept the full width. Exactly the phase-2a failure its own doc comment describes. Added `block_member_width_covers_every_legal_scale`, which fails on any future scale admitted by `is_block_scale` but not measurable.

## Verification

- `cargo test` green (2 pre-existing `construct_proof_lean_*` failures are local Lean-toolchain env issues — confirmed identical on clean `origin/main`).
- All new specs **mutation-tested, 4/4 mutants killed**: tie parity, the NaN code, the per-scale default, and the underflow clamp each fail a named test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)