### PR TITLE
test(lean): auto-build the in-repo Lean proof library instead of failing

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -850,6 +850,22 @@ fn check_construct_proof_smt_file(proof_path: &Path, solver: &str) -> miette::Re
     Ok(())
 }
 
+/// A Lean project directory is only usable once `lake build` has produced its
+/// `.olean` output. `.lake/` is gitignored build output, so a fresh clone or
+/// `git worktree add` has none, and the replay then fails deep inside Lean
+/// with `unknown module prefix 'ArchConstructProof'` — which looks like a
+/// broken proof rather than a missing build. Say what to run instead.
+fn check_lean_project_built(dir: &Path) -> miette::Result<()> {
+    if dir.join(".lake/build/lib/lean").is_dir() {
+        return Ok(());
+    }
+    Err(miette::miette!(
+        "Lean proof project at {} is not built (no .lake/build output) — run `lake build` in \
+         that directory first (it has no external dependencies; takes a few seconds)",
+        dir.display()
+    ))
+}
+
 fn thread_proof_lean_project_dir(explicit_project: Option<&Path>) -> miette::Result<PathBuf> {
     let candidate = if let Some(path) = explicit_project {
         path.to_path_buf()
@@ -864,6 +880,7 @@ fn thread_proof_lean_project_dir(explicit_project: Option<&Path>) -> miette::Res
             candidate.display()
         ));
     }
+    check_lean_project_built(&candidate)?;
     Ok(candidate)
 }
 
@@ -883,6 +900,7 @@ fn construct_proof_lean_project_dir(explicit_project: Option<&Path>) -> miette::
             candidate.display()
         ));
     }
+    check_lean_project_built(&candidate)?;
     Ok(candidate)
 }
 

--- a/tests/formal_test.rs
+++ b/tests/formal_test.rs
@@ -13,6 +13,88 @@ fn z3_available() -> bool {
         .unwrap_or(false)
 }
 
+/// The in-repo Lean proof project (`ArchConstructProof` + `ArchThreadLoweringProof`).
+const LEAN_PROJECT_DIR: &str = "proofs/lean_thread_lowering";
+
+/// Locate `lake`: PATH first, then the standard elan install location.
+fn find_lake() -> Option<std::path::PathBuf> {
+    if Command::new("lake")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+    {
+        return Some(std::path::PathBuf::from("lake"));
+    }
+    let home = std::env::var_os("HOME")?;
+    let home_lake = std::path::PathBuf::from(home).join(".elan/bin/lake");
+    home_lake.exists().then_some(home_lake)
+}
+
+/// Make sure the in-repo Lean proof library is built before any replay test
+/// runs, and report whether Lean testing is possible at all.
+///
+/// Why this exists: `proofs/lean_thread_lowering/.lake/` is build output and
+/// is gitignored, so a fresh clone — or, far more often, a fresh
+/// `git worktree add`, which is the standard way to work this repo — has
+/// none. Every Lean replay test then fails with
+///
+/// ```text
+/// error: unknown module prefix 'ArchConstructProof'
+/// No directory 'ArchConstructProof' or file 'ArchConstructProof.olean' ...
+/// ```
+///
+/// which reads exactly like a proof regression but is only a missing build.
+/// The project has no external dependencies (no Mathlib), so a cold build is
+/// ~5s — cheap enough to just do here, once per test binary, instead of
+/// leaving a phantom failure for whoever runs `cargo test` next.
+///
+/// Returns `false` when `lake` is not installed at all — callers then skip,
+/// matching the repo-wide "skip cleanly when the external tool is absent"
+/// convention CI depends on (`.github/workflows/test.yml` installs no Lean
+/// toolchain, so these tests skip there and run on dev machines).
+fn lean_project_ready() -> bool {
+    static READY: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *READY.get_or_init(|| {
+        let Some(lake) = find_lake() else {
+            eprintln!("skipping Lean replay tests: `lake` not found on PATH or in ~/.elan/bin");
+            return false;
+        };
+        // Already built? `lake build` is a fast no-op, but skipping the
+        // process spawn keeps the warm path free.
+        if std::path::Path::new(LEAN_PROJECT_DIR)
+            .join(".lake/build/lib/lean/ArchConstructProof.olean")
+            .exists()
+        {
+            return true;
+        }
+        eprintln!(
+            "building the Lean proof library in {LEAN_PROJECT_DIR} \
+             (first run in this checkout; ~5s, no external deps)"
+        );
+        match Command::new(&lake)
+            .arg("build")
+            .current_dir(LEAN_PROJECT_DIR)
+            .output()
+        {
+            Ok(o) if o.status.success() => true,
+            Ok(o) => {
+                eprintln!(
+                    "skipping Lean replay tests: `lake build` failed in {LEAN_PROJECT_DIR}\n\
+                     stdout:\n{}\nstderr:\n{}",
+                    String::from_utf8_lossy(&o.stdout),
+                    String::from_utf8_lossy(&o.stderr)
+                );
+                false
+            }
+            Err(e) => {
+                eprintln!("skipping Lean replay tests: could not run `lake build`: {e}");
+                false
+            }
+        }
+    })
+}
+
 fn solver_available(name: &str) -> bool {
     Command::new(name)
         .arg("--help")
@@ -390,6 +472,11 @@ end arbiter BusArbiter
 
 #[test]
 fn construct_proof_lean_finds_home_elan_when_lake_not_on_path() {
+    if !lean_project_ready() {
+        return;
+    }
+    // This test is specifically about the ~/.elan fallback, so it needs lake
+    // installed *there* — a PATH-only lake would not exercise it.
     let Some(home) = std::env::var_os("HOME") else {
         eprintln!("skipping: HOME not set");
         return;
@@ -444,15 +531,10 @@ end fifo TxQueue
 
 #[test]
 fn construct_proof_lean_non_power_two_fifo_catches_depth_wrap_bug() {
-    let Some(home) = std::env::var_os("HOME") else {
-        eprintln!("skipping: HOME not set");
-        return;
-    };
-    let home_lake = std::path::PathBuf::from(home).join(".elan/bin/lake");
-    if !home_lake.exists() {
-        eprintln!("skipping: ~/.elan/bin/lake not installed");
+    if !lean_project_ready() {
         return;
     }
+    let lake = find_lake().expect("lean_project_ready() already found lake");
 
     let td = tempfile::tempdir().expect("tempdir");
     let arch_path = td.path().join("NonPow2Fifo.arch");
@@ -516,7 +598,7 @@ end fifo NonPow2Queue
     );
     std::fs::write(&bad_proof_path, bad_proof).expect("write bad proof");
 
-    let output = Command::new(&home_lake)
+    let output = Command::new(&lake)
         .arg("env")
         .arg("lean")
         .arg(&bad_proof_path)


### PR DESCRIPTION
Kills a recurring phantom test failure: **every fresh `git worktree add` starts with two red Lean tests that have nothing to do with the change under test.**

## The failure

`proofs/lean_thread_lowering/.lake/` is build output and is gitignored, so a fresh clone — or, far more often, a fresh worktree, which is the standard way to work this repo — has none. Both Lean replay tests then die with:

```
error: unknown module prefix 'ArchConstructProof'
No directory 'ArchConstructProof' or file 'ArchConstructProof.olean' in the
search path entries: .../proofs/lean_thread_lowering/.lake/build/lib/lean
```

That reads exactly like a broken proof, so it gets re-diagnosed from scratch each time before it can be dismissed — the same class of wasted reconciliation pass CLAUDE.md warns about for stale binaries.

CI never sees it: `.github/workflows/test.yml` installs no Lean toolchain by policy, so these tests take their skip path there. It fires only on machines that *have* lake — i.e. exactly the machines doing proof work.

## The fix

`lean_project_ready()` in `tests/formal_test.rs` builds the library once per test binary (`OnceLock`) when the `.olean` is missing. The project has **no external dependencies** (no Mathlib), so a cold build is ~4.5s — cheap enough to just do rather than leave a trap for the next person.

When `lake` isn't installed at all, the helper returns `false` and callers skip, preserving the repo-wide "skip cleanly when the external tool is absent" convention CI relies on. **CI behavior is therefore unchanged.** Coverage on dev machines goes *up*: a fresh worktree used to yield two red tests, now it yields two real proof checks.

Also folds the two copy-pasted `~/.elan/bin/lake` lookups into one `find_lake()` that checks PATH first, then the elan install. `construct_proof_lean_finds_home_elan_when_lake_not_on_path` keeps its own `~/.elan` check — that path is its subject, not incidental.

## Compiler side

`arch build --check-construct-proof-lean` against an unbuilt project surfaced the same raw Lean module error. Both `*_lean_project_dir()` helpers now check for `.lake/build/lib/lean` and fail with what to run:

```
Lean proof project at proofs/lean_thread_lowering is not built (no .lake/build
output) — run `lake build` in that directory first (it has no external
dependencies; takes a few seconds)
```

## Verification

Reproduced the original condition directly — `rm -rf proofs/lean_thread_lowering/.lake/build`, then:

- `cargo test --test formal_test construct_proof_lean` → prints `building the Lean proof library … (~5s, no external deps)`, rebuilds, **both tests pass** (before this PR: two hard failures).
- `arch build --check-construct-proof-lean` on a `fifo` fixture → emits the actionable message above instead of Lean's internals.
- Full `cargo test` green (822 integration / 70 fp / 29 formal / others, 0 failures); `cargo fmt --all --check` clean.

No issue number — found while running the fast gate for #924 in a fresh worktree.
