### PR TITLE
docs: build the construct-proof Lean project in new-worktree setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,20 @@ share one working tree) — work in your own linked worktree
 (`git worktree add ../arch-wt-<name> -b <branch>`). No branch is exempt;
 automation that must commit in the primary sets `WORKTREE_ENFORCE_SKIP=1`.
 
+In a **new worktree**, if the Lean toolchain is installed, build the
+construct-proof project once — `.lake/` output is untracked, so a fresh
+worktree has none:
+
+```sh
+(cd proofs/lean_thread_lowering && lake build)   # ~4s; needed by cargo test
+```
+
+Without it the two `construct_proof_lean_*` tests in `tests/formal_test.rs`
+do not skip — they guard on `lake` being available, not on the project being
+built — and fail with `unknown module prefix 'ArchConstructProof'`, which
+looks like a broken proof rather than a missing build. Machines without
+`lake` skip them cleanly. Do not "fix" such a failure by editing the proofs.
+
 After opening a PR, run `scripts/monitor_pr_ci.sh [pr-number-or-url]`. If any
 check fails, inspect the linked logs, fix the branch, push the fix, and rerun
 the monitor. Do not leave a PR with known failing GitHub Actions checks unless

--- a/README.md
+++ b/README.md
@@ -332,6 +332,28 @@ so concurrent sessions don't share one working tree. Both are client-side guards
 (bypass `pre-commit` for a one-off with `WORKTREE_ENFORCE_SKIP=1` or
 `git commit --no-verify`).
 
+### New-worktree setup
+
+`.lake/` build output is untracked, so a freshly created worktree has none.
+If you have the Lean toolchain installed, build the construct-proof project
+once per worktree:
+
+```sh
+(cd proofs/lean_thread_lowering && lake build)   # ~4s; needed by cargo test
+```
+
+Skipping it does not fail cleanly — the two `construct_proof_lean_*` tests in
+`tests/formal_test.rs` guard on `lake` being *available*, not on the project
+being *built*, so they run and fail with `unknown module prefix
+'ArchConstructProof'`, which reads like a broken proof rather than a missing
+build. (Machines without `lake` skip these tests entirely and are unaffected;
+CI installs no Lean toolchain by design — see the dependency-policy note in
+`.github/workflows/test.yml`.)
+
+`proofs/lean_fp_equiv` is a standalone proof project — no cargo test depends
+on it, and it takes ~2.5min to build. See `proofs/lean_fp_equiv/README.md` if
+you need it.
+
 Before opening a PR, run a code-review pass against the branch diff, address or
 accept the findings, then record the reviewed HEAD:
 

--- a/skills/arch-programming/references/README.md
+++ b/skills/arch-programming/references/README.md
@@ -332,6 +332,28 @@ so concurrent sessions don't share one working tree. Both are client-side guards
 (bypass `pre-commit` for a one-off with `WORKTREE_ENFORCE_SKIP=1` or
 `git commit --no-verify`).
 
+### New-worktree setup
+
+`.lake/` build output is untracked, so a freshly created worktree has none.
+If you have the Lean toolchain installed, build the construct-proof project
+once per worktree:
+
+```sh
+(cd proofs/lean_thread_lowering && lake build)   # ~4s; needed by cargo test
+```
+
+Skipping it does not fail cleanly — the two `construct_proof_lean_*` tests in
+`tests/formal_test.rs` guard on `lake` being *available*, not on the project
+being *built*, so they run and fail with `unknown module prefix
+'ArchConstructProof'`, which reads like a broken proof rather than a missing
+build. (Machines without `lake` skip these tests entirely and are unaffected;
+CI installs no Lean toolchain by design — see the dependency-policy note in
+`.github/workflows/test.yml`.)
+
+`proofs/lean_fp_equiv` is a standalone proof project — no cargo test depends
+on it, and it takes ~2.5min to build. See `proofs/lean_fp_equiv/README.md` if
+you need it.
+
 Before opening a PR, run a code-review pass against the branch diff, address or
 accept the findings, then record the reviewed HEAD:
 


### PR DESCRIPTION
## Problem

`.lake/` build output is untracked, so a **freshly created worktree has none**. The two `construct_proof_lean_*` tests in `tests/formal_test.rs` then **fail rather than skip**: their guard checks that `lake` is *available* (on `PATH` or at `~/.elan/bin/lake`), not that `proofs/lean_thread_lowering` has been *built*.

```
unknown module prefix 'ArchConstructProof'
No directory 'ArchConstructProof' or file 'ArchConstructProof.olean' in the
search path entries: .../proofs/lean_thread_lowering/.lake/build/lib/lean
```

which surfaces as:

```
expected valid DEPTH=3 FIFO Lean replay to pass; got 1
```

That reads like a broken proof rather than a missing build — and invites someone to go edit the proofs chasing a regression that does not exist.

## Why it matters

This bites exactly the machines the CI dependency policy relies on. `.github/workflows/test.yml` installs no Lean toolchain, and its header delegates this coverage to *"contributor/agent machines with those tools installed"*. Those machines **have** `lake`, so they do not skip — they get a false failure in every fresh worktree. Machines without `lake` skip cleanly and are unaffected.

Confirmed the compiler and proofs are fine: pointing the same binary at an already-built project prints `Lean construct proof replay OK`. The only missing ingredient was the build artifacts.

## Change

Documents the one-time per-worktree build in both contributor entry points (`README.md`, `AGENTS.md`):

```sh
(cd proofs/lean_thread_lowering && lake build)   # ~4s; needed by cargo test
```

## Verification

Both directions, in a real worktree:

| State | Result |
|---|---|
| `.lake/build` removed | `test result: FAILED. 0 passed; 2 failed` |
| after the documented `lake build` (~4s) | `test result: ok. 2 passed; 0 failed` |

## Scope note

Deliberately scoped to `lean_thread_lowering` — it is the **only** Lean project any cargo test depends on. `proofs/lean_fp_equiv` is standalone (~2.5min to build, no test consumes it) and keeps its own README instructions; called out explicitly so nobody adds it to the hot path.

Docs only; no code or test behavior change.