### PR TITLE
fix(comb-graph): ground branch conditions conservatively

### DIFF
--- a/src/comb_graph.rs
+++ b/src/comb_graph.rs
@@ -1980,9 +1980,10 @@ impl GraphBuilder {
     /// Walk a comb-block's statements and add edges from RHS identifiers to
     /// LHS base names. Conditions count as reads of every then/else target.
     fn scan_assignments(&mut self, stmts: &[Stmt], path: &InstPath, bus_ports: &HashSet<String>) {
-        let mut cond_stack: Vec<HashSet<String>> = Vec::new();
+        let mut cond_stack: Vec<HashMap<String, bool>> = Vec::new();
         let mut written: HashSet<String> = HashSet::new();
         let mut ever_written: HashSet<String> = HashSet::new();
+        let mut condition_grounded: HashSet<String> = HashSet::new();
         self.scan_assignments_inner(
             stmts,
             path,
@@ -1990,6 +1991,7 @@ impl GraphBuilder {
             &mut cond_stack,
             &mut written,
             &mut ever_written,
+            &mut condition_grounded,
         );
     }
 
@@ -2022,17 +2024,27 @@ impl GraphBuilder {
     /// wrote it. Writes inside a `for` body are treated as branch-local
     /// (never promoted to the enclosing scope) for the same reason.
     ///
+    /// `condition_grounded` tracks names whose current value is established
+    /// before evaluating a control condition. Unlike `written`, it is
+    /// propagated out of `for` bodies because the graph walk treats the body
+    /// as executing once and existing fold-artifact handling relies on that
+    /// same assumption. Each condition snapshots this set at entry so later
+    /// writes in its body cannot retroactively ground the condition read.
+    ///
     /// `ever_written` (issue #780) tracks a STRICTLY MORE PERMISSIVE
-    /// question, used ONLY to compute the per-edge "grounded" flag (see
-    /// `add_edge_grounded` / `GraphBuilder::is_fold_artifact`) — NEVER to
-    /// decide whether to add an edge at all, which remains governed
-    /// exclusively by `written` as above, unchanged. Where `written` asks
-    /// "is this name DEFINITELY assigned no matter which path got us
-    /// here" (intersection across branches, branch-local across `for`),
-    /// `ever_written` asks "could this name's current value already be
-    /// FIXED by something reachable before this point" (union across
-    /// `if`/`else`/`match` arms, and — unlike `written` — propagated back
-    /// out of a `for` body). Both directions are sound:
+    /// question for ordinary RHS data reads, used ONLY to compute their
+    /// per-edge "grounded" flag (see `add_edge_grounded` /
+    /// `GraphBuilder::is_fold_artifact`) — NEVER to decide whether to add an
+    /// edge at all, which remains governed exclusively by `written` as
+    /// above, unchanged. Where `written` asks "is this name DEFINITELY
+    /// assigned no matter which path got us here" (intersection across
+    /// branches, branch-local across `for`), `ever_written` asks "could this
+    /// name's current value already be FIXED by something reachable before
+    /// this point" (union across `if`/`else`/`match` arms, and — unlike
+    /// `written` — propagated back out of a `for` body). Condition reads use
+    /// the stricter, entry-snapshotted `condition_grounded` set because a
+    /// control dependency is only grounded when its value is established
+    /// before the condition executes. Both directions are sound:
     ///   * Union-not-intersection across mutually exclusive branches is
     ///     safe because whichever branch actually ran, the name's value at
     ///     this point is either that branch's fresh write (fixed) or
@@ -2056,9 +2068,10 @@ impl GraphBuilder {
         stmts: &[Stmt],
         path: &InstPath,
         bus_ports: &HashSet<String>,
-        cond_stack: &mut Vec<HashSet<String>>,
+        cond_stack: &mut Vec<HashMap<String, bool>>,
         written: &mut HashSet<String>,
         ever_written: &mut HashSet<String>,
+        condition_grounded: &mut HashSet<String>,
     ) {
         for stmt in stmts {
             match stmt {
@@ -2097,7 +2110,7 @@ impl GraphBuilder {
                         self.add_edge_grounded(from, to, grounded);
                     }
                     for conds in cond_stack.iter() {
-                        for id in conds {
+                        for (id, grounded) in conds {
                             if already_written && id.as_str() == lhs.as_str() {
                                 continue;
                             }
@@ -2105,19 +2118,27 @@ impl GraphBuilder {
                                 path: path.clone(),
                                 signal: id.clone(),
                             });
-                            let grounded = ever_written.contains(id.as_str());
-                            self.add_edge_grounded(from, to, grounded);
+                            self.add_edge_grounded(from, to, *grounded);
                         }
                     }
                     written.insert(lhs.clone());
+                    condition_grounded.insert(lhs.clone());
                     ever_written.insert(lhs);
                 }
                 Stmt::IfElse(ife) => {
                     let mut cond_ids = HashSet::new();
                     collect_expr_idents_bus(&ife.cond, bus_ports, &mut cond_ids);
-                    cond_stack.push(cond_ids);
+                    let cond_frame: HashMap<String, bool> = cond_ids
+                        .into_iter()
+                        .map(|id| {
+                            let grounded = condition_grounded.contains(&id);
+                            (id, grounded)
+                        })
+                        .collect();
+                    cond_stack.push(cond_frame);
                     let mut then_written = written.clone();
                     let mut then_ever = ever_written.clone();
+                    let mut then_condition_grounded = condition_grounded.clone();
                     self.scan_assignments_inner(
                         &ife.then_stmts,
                         path,
@@ -2125,9 +2146,11 @@ impl GraphBuilder {
                         cond_stack,
                         &mut then_written,
                         &mut then_ever,
+                        &mut then_condition_grounded,
                     );
                     let mut else_written = written.clone();
                     let mut else_ever = ever_written.clone();
+                    let mut else_condition_grounded = condition_grounded.clone();
                     self.scan_assignments_inner(
                         &ife.else_stmts,
                         path,
@@ -2135,6 +2158,7 @@ impl GraphBuilder {
                         cond_stack,
                         &mut else_written,
                         &mut else_ever,
+                        &mut else_condition_grounded,
                     );
                     cond_stack.pop();
                     // Only promote names written on BOTH arms — mutually
@@ -2142,18 +2166,31 @@ impl GraphBuilder {
                     *written = then_written.intersection(&else_written).cloned().collect();
                     // `ever_written`: union — see the doc comment above.
                     *ever_written = then_ever.union(&else_ever).cloned().collect();
+                    *condition_grounded = then_condition_grounded
+                        .intersection(&else_condition_grounded)
+                        .cloned()
+                        .collect();
                 }
                 Stmt::Match(m) => {
                     let mut scrut_ids = HashSet::new();
                     collect_expr_idents_bus(&m.scrutinee, bus_ports, &mut scrut_ids);
-                    cond_stack.push(scrut_ids);
+                    let cond_frame: HashMap<String, bool> = scrut_ids
+                        .into_iter()
+                        .map(|id| {
+                            let grounded = condition_grounded.contains(&id);
+                            (id, grounded)
+                        })
+                        .collect();
+                    cond_stack.push(cond_frame);
                     let mut arm_written: Option<HashSet<String>> = None;
                     let mut arm_ever: Option<HashSet<String>> = None;
+                    let mut arm_condition_grounded: Option<HashSet<String>> = None;
                     for arm in &m.arms {
                         let mut aw = written.clone();
                         let mut ae = ever_written.clone();
+                        let mut acg = condition_grounded.clone();
                         self.scan_assignments_inner(
-                            &arm.body, path, bus_ports, cond_stack, &mut aw, &mut ae,
+                            &arm.body, path, bus_ports, cond_stack, &mut aw, &mut ae, &mut acg,
                         );
                         arm_written = Some(match arm_written {
                             Some(acc) => acc.intersection(&aw).cloned().collect(),
@@ -2163,6 +2200,10 @@ impl GraphBuilder {
                             Some(acc) => acc.union(&ae).cloned().collect(),
                             None => ae,
                         });
+                        arm_condition_grounded = Some(match arm_condition_grounded {
+                            Some(acc) => acc.intersection(&acg).cloned().collect(),
+                            None => acg,
+                        });
                     }
                     cond_stack.pop();
                     if let Some(merged) = arm_written {
@@ -2171,6 +2212,9 @@ impl GraphBuilder {
                     if let Some(merged) = arm_ever {
                         *ever_written = merged;
                     }
+                    if let Some(merged) = arm_condition_grounded {
+                        *condition_grounded = merged;
+                    }
                 }
                 Stmt::For(f) => {
                     // Loop trip count isn't evaluated here; treat the body as
@@ -2178,6 +2222,7 @@ impl GraphBuilder {
                     // into `written` (unchanged from before issue #780).
                     let mut body_written = written.clone();
                     let mut body_ever = ever_written.clone();
+                    let mut body_condition_grounded = condition_grounded.clone();
                     self.scan_assignments_inner(
                         &f.body,
                         path,
@@ -2185,6 +2230,7 @@ impl GraphBuilder {
                         cond_stack,
                         &mut body_written,
                         &mut body_ever,
+                        &mut body_condition_grounded,
                     );
                     // `ever_written` DOES propagate out — see the doc
                     // comment above (issue #780: needed so a LATER, sibling
@@ -2192,6 +2238,7 @@ impl GraphBuilder {
                     // — e.g. `onebit_ecc`'s two-phase parity computation —
                     // sees it as grounded).
                     *ever_written = body_ever;
+                    *condition_grounded = body_condition_grounded;
                 }
                 _ => {}
             }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -27560,6 +27560,110 @@ fn test_comb_loop_mutually_exclusive_branch_write_not_promoted() {
 }
 
 #[test]
+fn test_comb_loop_branch_condition_does_not_use_union_grounding() {
+    // A write to x in one branch must not ground a later condition that reads
+    // x: when that branch is skipped, the condition reads x's unresolved
+    // pre-block value. The two later assignments then form a real cycle
+    // (x -> y through the condition, y -> x through the final assignment).
+    // This must coexist with the union grounding used for ordinary
+    // post-branch sequential folds (arch#780).
+    let source = r#"
+        module M
+          port c: in Bool;
+          port o: out Bool;
+          wire x: Bool;
+          wire y: Bool;
+          comb
+            if c
+              x = false;
+            else
+            end if
+            if x
+              y = false;
+            else
+              y = true;
+            end if
+            x = y;
+            o = x;
+          end comb
+        end module M
+    "#;
+    let ws = errors_from(source);
+    assert!(
+        ws.iter()
+            .any(|m| m.contains("combinational feedback cycle (")),
+        "branch-only x write must not ground the later condition; got: {:?}",
+        ws
+    );
+}
+
+#[test]
+fn test_comb_loop_condition_grounding_is_snapshotted_at_entry() {
+    // The outer condition is evaluated before its body writes x. That write
+    // must not retroactively ground the outer condition's dependency on x.
+    // Otherwise the later y -> x edge can make the real x -> y -> x cycle
+    // look like a fold artifact.
+    let source = r#"
+        module M
+          port o: out Bool;
+          wire x: Bool;
+          wire y: Bool;
+          comb
+            if x
+              x = false;
+              y = true;
+            else
+              y = false;
+            end if
+            x = y;
+            o = x;
+          end comb
+        end module M
+    "#;
+    let ws = errors_from(source);
+    assert!(
+        ws.iter()
+            .any(|m| m.contains("combinational feedback cycle (")),
+        "outer condition must retain its pre-body grounding state; got: {:?}",
+        ws
+    );
+}
+
+#[test]
+fn test_comb_loop_completed_for_grounding_reaches_later_condition() {
+    // A for body is walked once for fold analysis. An unconditional write in
+    // that body fully establishes x, so a later condition may use x as a
+    // grounded control dependency without fabricating x <-> y feedback.
+    let source = r#"
+        module M
+          port a: in Bool;
+          port o: out Bool;
+          wire x: Bool;
+          wire y: Bool;
+          comb
+            for i in 0..0
+              x = a;
+            end for
+            if x
+              y = false;
+            else
+              y = true;
+            end if
+            x = y;
+            o = x;
+          end comb
+        end module M
+    "#;
+    let ws = comb_loop_warnings(source);
+    assert!(
+        !ws.iter()
+            .any(|m| m.contains("combinational feedback cycle (")),
+        "completed for-loop write must ground the later condition; got: {:?}",
+        ws
+    );
+}
+
+#[test]
 fn test_cond_only_grounded_fold_not_flagged_and_verilator_confirms_acyclic() {
     // arch#780, NEGATIVE direction: a self-fold (`p = q +% p;`) whose ONLY
     // prior establishment of `p` is a CONDITIONAL, single-arm write


### PR DESCRIPTION
## Summary

Fix comb-graph fold-artifact classification for control-condition reads.

`ever_written` must remain union-based for ordinary post-branch sequential folds, but a condition dependency must use the value established when the condition executes. This change snapshots condition grounding at `if`/`match` entry, merges it conservatively across branches, and propagates completed `for`-body state consistently with the existing fold analysis.

## Regression coverage

- Branch-only writes no longer suppress a later real feedback cycle.
- Condition grounding is not retroactively changed by writes in the condition body.
- A completed `for` body can ground a later condition without creating a false cycle.
- Existing conditional-only union-grounded fold behavior remains covered by the merged PR #801 regression.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo test --release --test integration_test` — 832 passed
- Independent code review completed with no blocking findings.