### PR TITLE
test(comb-graph): pin match-scrutinee grounding (#941 follow-up)

### DIFF
--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -27664,6 +27664,79 @@ fn test_comb_loop_completed_for_grounding_reaches_later_condition() {
 }
 
 #[test]
+fn test_comb_loop_match_scrutinee_does_not_use_union_grounding() {
+    // The `match` scrutinee-read path shares the condition-grounding snapshot
+    // logic with `if`/`elsif` (src/comb_graph.rs, arch#941). This is the
+    // match analogue of
+    // `test_comb_loop_branch_condition_does_not_use_union_grounding`: `x` is
+    // written only on the `then` arm of a prior `if` (else empty), so it is
+    // NOT established on every path. A later `match x` therefore reads `x`'s
+    // unresolved pre-block value as its scrutinee, and the subsequent `x = y`
+    // closes a real x -> y -> x cycle. If the match scrutinee used the union
+    // grounding of `ever_written`, the branch-only write would wrongly ground
+    // the scrutinee and mask the cycle. Tripwire for the match path diverging
+    // from the if path.
+    let source = r#"
+        module M
+          port c: in Bool;
+          port o: out UInt<2>;
+          wire x: UInt<2>;
+          wire y: UInt<2>;
+          comb
+            if c
+              x = 0;
+            else
+            end if
+            match x
+              0 => y = 0;
+              _ => y = 1;
+            end match
+            x = y;
+            o = x;
+          end comb
+        end module M
+    "#;
+    let ws = errors_from(source);
+    assert!(
+        ws.iter()
+            .any(|m| m.contains("combinational feedback cycle (")),
+        "branch-only x write must not ground the later match scrutinee; got: {:?}",
+        ws
+    );
+}
+
+#[test]
+fn test_comb_loop_grounded_match_scrutinee_not_falsely_flagged() {
+    // Positive companion to the above: when `x` IS established
+    // unconditionally before the `match`, the scrutinee read is grounded and
+    // no false x <-> y feedback may be fabricated. Guards against the arch#941
+    // snapshot logic over-warning on legitimately grounded match scrutinees.
+    let source = r#"
+        module M
+          port a: in UInt<2>;
+          port o: out UInt<2>;
+          wire x: UInt<2>;
+          wire y: UInt<2>;
+          comb
+            x = a;
+            match x
+              0 => y = 0;
+              _ => y = 1;
+            end match
+            o = y;
+          end comb
+        end module M
+    "#;
+    let ws = comb_loop_warnings(source);
+    assert!(
+        !ws.iter()
+            .any(|m| m.contains("combinational feedback cycle (")),
+        "grounded match scrutinee must not be flagged as feedback; got: {:?}",
+        ws
+    );
+}
+
+#[test]
 fn test_cond_only_grounded_fold_not_flagged_and_verilator_confirms_acyclic() {
     // arch#780, NEGATIVE direction: a self-fold (`p = q +% p;`) whose ONLY
     // prior establishment of `p` is a CONDITIONAL, single-arm write


### PR DESCRIPTION
## Summary

PR #941 made comb-graph condition grounding *entry-snapshotted* and stricter than the union-based `ever_written` used for ordinary data folds: a control condition read counts as grounded only when its value is established before the condition executes. The fix applies the same snapshot logic to the `match` scrutinee, but the merged regression tests only exercised the `if`/`elsif`, snapshot, and `for` paths. The `match`-scrutinee path had **no regression guard**, so a future refactor could silently diverge it from the `if` path and re-open the fold-artifact misclassification.

This PR adds that missing coverage. **Test-only — no source change.**

## Tests added

- `test_comb_loop_match_scrutinee_does_not_use_union_grounding` — a branch-only write to `x` must not ground a later `match x`; the real `x -> y -> x` cycle must still be flagged (match analogue of the merged `test_comb_loop_branch_condition_does_not_use_union_grounding`).
- `test_comb_loop_grounded_match_scrutinee_not_falsely_flagged` — an unconditionally grounded `match` scrutinee must not be falsely flagged (guards the stricter logic against over-warning).

## Validation

Verified against a fresh `0.71.0` `--release` build (post-#941):
- both new tests pass;
- full `cargo test --release --test integration_test` green (834 passed, 0 failed);
- `cargo fmt` clean.

_Filed by the daily automated code-review sweep as adjacent-coverage hardening for #941._