### PR TITLE
fix(ci): repair CLA signature persistence

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -19,14 +19,16 @@ jobs:
       github.event_name == 'pull_request_target'
     steps:
       - name: CLA Assistant
-        uses: contributor-assistant/github-action@v2.7.0
+        uses: contributor-assistant/github-action@v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
         with:
           path-to-signatures: 'signatures/cla.json'
           path-to-document: 'https://github.com/arch-hdl-lang/arch-com/blob/main/CLA.md'
-          branch: 'main'
+          # Signatures are append-only bot data. Keeping them on a dedicated
+          # branch avoids bypassing the required checks on protected `main`.
+          branch: 'cla-signatures'
           allowlist: dependabot[bot],github-actions[bot]
           custom-notsigned-prcomment: |
             Thank you for your contribution! Before we can merge this PR, we need you to agree to our [Contributor License Agreement](https://github.com/arch-hdl-lang/arch-com/blob/main/CLA.md).

--- a/signatures/cla.json
+++ b/signatures/cla.json
@@ -1,6 +1,14 @@
 {
   "signedContributors": [
     {
+      "name": "teabone113",
+      "id": 209420132,
+      "comment_id": 5149322604,
+      "created_at": "2026-08-01T02:39:18Z",
+      "repoId": 1206621303,
+      "pullRequestNo": 757
+    },
+    {
       "name": "nogate-ai",
       "id": 205731451,
       "comment_id": 4274128412,


### PR DESCRIPTION
## Summary

- restore CLA Assistant to the last resolvable release, v2.6.1
- persist signatures on a dedicated append-only branch instead of protected main
- record teabone113's verified signature from PR #757

## Root cause

CLA Assistant cannot commit signature records directly to protected main because seven required checks are enforced. The subsequent v2.7.0 upgrade also references a tag that does not exist, so current CLA jobs fail before the action starts.

## Validation

- `actionlint .github/workflows/cla.yml`
- YAML parse with Ruby Psych
- `jq empty signatures/cla.json`
- `cargo fmt --check`
- `git diff --check`

The CLA check on this repair PR is expected to fail under the broken workflow on the base branch. All other required checks should pass before the audited admin merge.
