### PR TITLE
docs(refcard): add MX block-scale surface to the AI reference card (closes #922)

### DIFF
--- a/doc/Arch_AI_Reference_Card.md
+++ b/doc/Arch_AI_Reference_Card.md
@@ -163,8 +163,8 @@ Range `for` = runtime SV loop; value-list `for` = compile-time unroll; `generate
 UInt<N>  SInt<N>  Bool  Bit
 FP32  BF16                                    // IEEE-754 binary32 / bfloat16 (v1; see §2a)
 FP8E4M3  FP8E5M2                              // OCP OFP8 8-bit floats (v1; see §2a)
-FP4E2M1  FP6E2M3  FP6E3M2                     // OCP MX sub-8-bit elements: STORAGE-ONLY (conversions + literals; no + - * / compares / is_nan)
-E8M0                                          // MX block SCALE (2^(e-127)): NOT a float; no zero (0x00 = min scale), 0xFF = NaN; no arithmetic
+FP4E2M1  FP6E2M3  FP6E3M2                     // OCP MX sub-8-bit elements: STORAGE-ONLY as scalars (conversions + literals; no + - * / compares / is_nan) — block ops via ScaledVec, §2a
+E8M0  UE4M3                                    // block SCALE types: NOT floats, no scalar arithmetic. E8M0 = 2^(e-127) (no zero, 0xFF=NaN); UE4M3 = NVFP4 scale (has a zero, 0x7F=NaN) — used as ScaledVec<_,_,Scale>, §2a
 Clock<Domain>  Reset<Sync|Async, High|Low>   // polarity defaults High
 Vec<T,N>
 struct S  { f: T; }
@@ -277,6 +277,29 @@ x.to_uint<N>()   // float→UInt<N>: toward-zero, per-N saturating, negatives/Na
 |---|---|---|
 | `riscv` (default) | `0x7FC00000` / `0x7FC0` | type max |
 | `cuda` | `0x7FFFFFFF` / `0x7FFF` | `0` |
+
+**MX block-scale (`ScaledVec`) — v2.** Block-scaled aggregate for the OCP MX / NVFP4 formats: `N` narrow elements sharing one scale, packed as a single word `{scale, P[N-1..0]}` (width `scale_w + N×elem_w`). The sub-8-bit elements stay STORAGE-ONLY *as scalars* (the caveat in §2 still holds); the *block* is where real numeric ops live — an LLM should quantize into a `ScaledVec` rather than hand-roll scale handling.
+
+```
+ScaledVec<Elem, N, Scale>            // Elem ∈ FP4E2M1|FP6E2M3|FP6E3M2|FP8E4M3|FP8E5M2; N ≥ 1
+                                     //   Scale = E8M0 (OCP MX) or UE4M3 (NVFP4)
+type MXFP4 = ScaledVec<FP4E2M1, 32, E8M0>;    // 8 + 32×4 = 136 bits
+type NVFP4 = ScaledVec<FP4E2M1, 16, UE4M3>;   // UE4M3 ≠ FP8E4M3 (unsigned, 7 sig bits, NaN 0x7F, has a zero)
+```
+
+Only these operations — **no `+ - * /`, no ordered `< >`, no indexing `a[0]`** (all compile errors):
+
+```
+scaled_quantize<Fmt>(v)              // Vec<FP32,N> → block; Fmt REQUIRED (never inferred), len must == N
+scaled_quantize<Fmt, policy, rounding>(v)   // policy ∈ floor_pow2|ceil_pow2|exact; rounding = rne
+                                     //   default policy is scale-dependent: floor_pow2 (E8M0), exact (UE4M3)
+scaled_dequantize(b)                 // block → Vec<FP32,N> (scale applied; the ONLY way to read a lane)
+scaled_dot(a, b)                     // two blocks of the SAME type → FP32 (block dot product, FP32 accumulate)
+a == b   a != b                      // ENCODING compare on the packed word: equal bits ⇒ equal value, but
+                                     //   unequal bits ≠ unequal value — dequantize both for a true value test
+```
+
+`exact` policy is refused for `E8M0` (no mantissa). `port c: in split MXFP4;` splits the SV boundary into `c_scale` + `c_elems` (SV-shape only; body unchanged). Read one element as `scaled_dequantize(b)[i]`. See spec §3.10 / §3.10a / §3.11.
 
 **Pipelined operators (`<pipelined, N>`)** — `fma(a,b,c)` is combinational (latency 0). For a registry-backed staged implementation, declare the depth in the call: `fma<pipelined, N>(...)`. `N` is a compile-time integer literal, looked up against `(operator, profile, N)` in the compiler's builtin registry (`arch ops` lists what's registered). The call's depth is authoritative — bind the result into a matching `pipe_reg<T, N>` tap; a mismatch, an untapped target, or comb/`let` use is a compile error. No auto-alignment: combining a tapped and an untapped operand in one expression errors, naming both cycles.
 

--- a/skills/arch-programming/references/Arch_AI_Reference_Card.md
+++ b/skills/arch-programming/references/Arch_AI_Reference_Card.md
@@ -163,8 +163,8 @@ Range `for` = runtime SV loop; value-list `for` = compile-time unroll; `generate
 UInt<N>  SInt<N>  Bool  Bit
 FP32  BF16                                    // IEEE-754 binary32 / bfloat16 (v1; see §2a)
 FP8E4M3  FP8E5M2                              // OCP OFP8 8-bit floats (v1; see §2a)
-FP4E2M1  FP6E2M3  FP6E3M2                     // OCP MX sub-8-bit elements: STORAGE-ONLY (conversions + literals; no + - * / compares / is_nan)
-E8M0                                          // MX block SCALE (2^(e-127)): NOT a float; no zero (0x00 = min scale), 0xFF = NaN; no arithmetic
+FP4E2M1  FP6E2M3  FP6E3M2                     // OCP MX sub-8-bit elements: STORAGE-ONLY as scalars (conversions + literals; no + - * / compares / is_nan) — block ops via ScaledVec, §2a
+E8M0  UE4M3                                    // block SCALE types: NOT floats, no scalar arithmetic. E8M0 = 2^(e-127) (no zero, 0xFF=NaN); UE4M3 = NVFP4 scale (has a zero, 0x7F=NaN) — used as ScaledVec<_,_,Scale>, §2a
 Clock<Domain>  Reset<Sync|Async, High|Low>   // polarity defaults High
 Vec<T,N>
 struct S  { f: T; }
@@ -277,6 +277,29 @@ x.to_uint<N>()   // float→UInt<N>: toward-zero, per-N saturating, negatives/Na
 |---|---|---|
 | `riscv` (default) | `0x7FC00000` / `0x7FC0` | type max |
 | `cuda` | `0x7FFFFFFF` / `0x7FFF` | `0` |
+
+**MX block-scale (`ScaledVec`) — v2.** Block-scaled aggregate for the OCP MX / NVFP4 formats: `N` narrow elements sharing one scale, packed as a single word `{scale, P[N-1..0]}` (width `scale_w + N×elem_w`). The sub-8-bit elements stay STORAGE-ONLY *as scalars* (the caveat in §2 still holds); the *block* is where real numeric ops live — an LLM should quantize into a `ScaledVec` rather than hand-roll scale handling.
+
+```
+ScaledVec<Elem, N, Scale>            // Elem ∈ FP4E2M1|FP6E2M3|FP6E3M2|FP8E4M3|FP8E5M2; N ≥ 1
+                                     //   Scale = E8M0 (OCP MX) or UE4M3 (NVFP4)
+type MXFP4 = ScaledVec<FP4E2M1, 32, E8M0>;    // 8 + 32×4 = 136 bits
+type NVFP4 = ScaledVec<FP4E2M1, 16, UE4M3>;   // UE4M3 ≠ FP8E4M3 (unsigned, 7 sig bits, NaN 0x7F, has a zero)
+```
+
+Only these operations — **no `+ - * /`, no ordered `< >`, no indexing `a[0]`** (all compile errors):
+
+```
+scaled_quantize<Fmt>(v)              // Vec<FP32,N> → block; Fmt REQUIRED (never inferred), len must == N
+scaled_quantize<Fmt, policy, rounding>(v)   // policy ∈ floor_pow2|ceil_pow2|exact; rounding = rne
+                                     //   default policy is scale-dependent: floor_pow2 (E8M0), exact (UE4M3)
+scaled_dequantize(b)                 // block → Vec<FP32,N> (scale applied; the ONLY way to read a lane)
+scaled_dot(a, b)                     // two blocks of the SAME type → FP32 (block dot product, FP32 accumulate)
+a == b   a != b                      // ENCODING compare on the packed word: equal bits ⇒ equal value, but
+                                     //   unequal bits ≠ unequal value — dequantize both for a true value test
+```
+
+`exact` policy is refused for `E8M0` (no mantissa). `port c: in split MXFP4;` splits the SV boundary into `c_scale` + `c_elems` (SV-shape only; body unchanged). Read one element as `scaled_dequantize(b)[i]`. See spec §3.10 / §3.10a / §3.11.
 
 **Pipelined operators (`<pipelined, N>`)** — `fma(a,b,c)` is combinational (latency 0). For a registry-backed staged implementation, declare the depth in the call: `fma<pipelined, N>(...)`. `N` is a compile-time integer literal, looked up against `(operator, profile, N)` in the compiler's builtin registry (`arch ops` lists what's registered). The call's depth is authoritative — bind the result into a matching `pipe_reg<T, N>` tap; a mismatch, an untapped target, or comb/`let` use is a compile error. No auto-alignment: combining a tapped and an untapped operand in one expression errors, naming both cycles.
 


### PR DESCRIPTION
## Summary

The compact **AI reference card** (`doc/Arch_AI_Reference_Card.md`) — the doc LLMs consult to generate ARCH — had **zero** mention of the block-scaled MX/NVFP4 family, while the full spec documents it in §3.10 / §3.10a / §3.11. Grep counts on `origin/main` @ 0.71.0 before this PR:

| Construct | Spec | Reference card |
|---|---|---|
| `ScaledVec<Elem,N,Scale>` | 12 | **0** |
| `scaled_quantize` / `scaled_dequantize` | 6 / 8 | **0** |
| `scaled_dot` | 4 | **0** |
| `UE4M3` | 10 | **0** |

An LLM working from the card alone would hand-roll scale handling instead of using the shipped constructs.

The issue (#922) deferred unilateral editing because the MX roadmap was mid-flight (phase 5b / NVFP4 #905 open). That reason has since resolved — **#905 is closed by #926 (merged 2026-08-14)**, so phases 0–5b are all landed. Curating the card is now appropriate.

## Changes (doc-only)

- New **"MX block-scale (`ScaledVec`)"** subsection in §2a: the `ScaledVec<Elem,N,Scale>` type + packing/width, the `scaled_quantize` / `scaled_dequantize` / `scaled_dot` operations, the encoding-only `==`/`!=` semantics, `split` ports, and the scale-dependent default policy (`floor_pow2` for E8M0, `exact` for UE4M3).
- Added `UE4M3` to the §2 type table (it was entirely missing) and annotated the sub-8-bit-element line: the "storage-only" caveat holds **for scalars**; block ops live on `ScaledVec`.
- Re-synced the mirrored snapshot under `skills/arch-programming/references/` (`sync_skill_snapshots.sh refresh`).

Copy is drawn faithfully from spec §3.10/§3.10a/§3.11; maintainers can refine presentation in review.

## Verification

- `sync_skill_snapshots.sh check` → all 9 snapshots in sync.
- `check_doc_drift.sh origin/main` → pass (doc-only). `check_release_doc.sh origin/main` → pass (no version bump).
- Diff vs `origin/main` touches only the card and its snapshot (+50/-4).

_Filed by the daily automated code-review sweep (2026-08-22)._

closes #922