### PR TITLE
fix(codegen): emit FP helper function bodies as decl-then-assign

### DIFF
--- a/src/fp_ir.rs
+++ b/src/fp_ir.rs
@@ -387,15 +387,24 @@ fn render_sv_fn(f: &FpFn) -> String {
         f.name,
         params.join(", ")
     );
+    // Declarations first, then the assignments — never `logic w _t0 = rhs;`
+    // inside a function body. Two reasons, and the second is the one that
+    // bites: SV requires a block's declarations to precede its first
+    // statement (so these cannot be interleaved), and yosys's built-in
+    // Verilog frontend rejects a declaration carrying an initializer inside
+    // a `function` outright — "Invalid nesting of always blocks and/or
+    // initializations". That is legal SV which Verilator 5.048 and Icarus
+    // both accept, so no simulator gate ever saw it, but it made every
+    // emitted soft-float helper unsynthesizable and took the whole MX/NVFP4
+    // quantizer line with it (arch#932). `fp_block.rs` already emits this
+    // split shape; this brings the IR renderer in line with it.
     for b in &lin.order {
         let id = lin.ids[&(Rc::as_ptr(&b.0) as usize)];
-        let _ = writeln!(
-            s,
-            "  logic {}_t{} = {};",
-            sv_decl_width(b.width()),
-            id,
-            sv_rhs(b, &lin)
-        );
+        let _ = writeln!(s, "  logic {}_t{};", sv_decl_width(b.width()), id);
+    }
+    for b in &lin.order {
+        let id = lin.ids[&(Rc::as_ptr(&b.0) as usize)];
+        let _ = writeln!(s, "  _t{} = {};", id, sv_rhs(b, &lin));
     }
     let _ = writeln!(s, "  {} = {};", f.name, sv_ref(&f.body, &lin));
     let _ = writeln!(s, "endfunction");


### PR DESCRIPTION
## Problem

`render_sv` emits each SSA temp in a soft-float helper as a declaration carrying an initializer:

```sv
function automatic logic [31:0] arch_e8m0_to_f32(input logic [7:0] e);
  logic _t0 = e == 8'hFF;          // ← yosys: "Invalid nesting of always blocks and/or initializations"
```

That is **legal SystemVerilog** — Verilator 5.048 and Icarus 12.0 both accept it. But yosys's built-in Verilog frontend rejects it outright. Every gate in CI is a *simulator* front end, so nothing ever saw this, and **the emitted float library has never been synthesizable**.

The blast radius is the whole float line rather than one helper: the failure is in the shared IR renderer, so it trips at the first helper a design instantiates. That is why `tests/fp_v1` is the largest failure bucket (24 files) in the #932 sweep.

## Measured, before → after

| Design | Before | After |
|---|---|---|
| `tests/fp_v1/ScaledVecType.arch` | synthesizes | synthesizes |
| `tests/fp_v1/ScaledQuant.arch` | **FAILS** @ `:2348` | **synthesizes** |
| `tests/fp_v1/Nvfp4Quant.arch` | **FAILS** @ `:2356` | parses past it |

Flow: `yosys -p "read_verilog -sv x.sv; hierarchy -auto-top; proc; opt; memory; opt; techmap; opt; stat"` (the #932 flow), yosys 0.67.

## Fix

Emit all declarations first, then the initializers as ordinary blocking assignments, preserving `lin.order`.

Semantically identical: the function is `automatic`, so both shapes evaluate on every call, and assignment order is unchanged. The declarations can't simply be interleaved with their assignments — SV requires a block's declarations to precede its first statement. `fp_block.rs` already emits this split shape, so this brings the IR renderer in line with its sibling.

## It retires a workaround in a proof's trust base

`tests/fp_v1/synth/hoist_decls.py` is a checked-in Python rewriter whose sole purpose is applying this exact transform after the fact, and `tests/fp_v1/smt_proof/README.md:64` lists it as part of the renderer proof's **trust base**. Fixing the emitter removes a syntactic rewriter from that trust base.

I verified it is now a **byte-exact no-op** on emitted output (5625 → 5625 lines, `diff` clean), so `run_synth.sh` and `renderer_miter.sh` keep working unchanged. Actually deleting it is a separate change.

## Verification

- `cargo build --release` clean · `cargo fmt --check` clean
- `cargo test --release` — **1225 passed, 0 failed**
- No simulator regression: Verilator + Icarus still accept all three designs. (`ScaledVecType` trips a `MULTITOP` *warning* both before and after — that test file declares two modules; its emitted SV is byte-identical across the change.)
- `hoist_decls.py` no-op confirmed

Emitted output changes by design, so `refactor_diff.sh` is not the gate here. The broader synthesis sweep is running as the long verification and I will post the numbers.

Partial progress on #932 — one of its two yosys-frontend-gap categories. The genuine-defect findings there, including the broken reset in `examples/`, are untouched.