### PR TITLE
fix(codegen): make user-function bodies parseable by yosys

### DIFF
--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -148,6 +148,9 @@ pub struct Codegen<'a> {
     /// `ident_decl_type`/`ident_float_fmt` so float-op dispatch works
     /// inside `function` bodies; empty outside `emit_function`.
     fn_local_types: std::collections::HashMap<String, TypeExpr>,
+    /// SV name to assign to in place of `return` inside the function being
+    /// emitted, or `None` to emit a literal `return` (see `emit_function`).
+    fn_return_target: Option<String>,
     /// Maps call-site span.start → overload index (for overloaded functions only).
     overload_map: std::collections::HashMap<usize, usize>,
     /// Bus port names in the current module → bus name (for FieldAccess rewriting).
@@ -419,6 +422,7 @@ impl<'a> Codegen<'a> {
             pending_functions: Vec::new(),
             file_scopes: Vec::new(),
             fn_local_types: std::collections::HashMap::new(),
+            fn_return_target: None,
             overload_map,
             bus_ports: std::collections::HashMap::new(),
             vec_of_bus_port_count: std::collections::HashMap::new(),
@@ -1256,6 +1260,104 @@ impl<'a> Codegen<'a> {
     /// `pending_functions` is taken and restored because `emit_function`
     /// needs `&mut self` and the same set is re-emitted into every
     /// following construct in the file.
+    /// Does this item contain a `return` anywhere inside it?
+    fn item_has_return(it: &FunctionBodyItem) -> bool {
+        match it {
+            FunctionBodyItem::Return(_) => true,
+            FunctionBodyItem::IfElse(ie) => {
+                ie.then_body.iter().any(Self::item_has_return)
+                    || ie.else_body.iter().any(Self::item_has_return)
+            }
+            FunctionBodyItem::For(fl) => fl.body.iter().any(Self::item_has_return),
+            _ => false,
+        }
+    }
+
+    /// Can this function's `return`s be rewritten to `name = expr;`?
+    ///
+    /// Only when no `return` is an EARLY exit — i.e. no item that contains a
+    /// return is followed by more statements in its block. The unsound shape:
+    ///
+    /// ```text
+    /// if c        ->   if (c) begin
+    ///   return a;         fname = a;
+    /// end if            end
+    /// return b;         fname = b;   // early exit dropped: overwrites `a`
+    /// ```
+    ///
+    /// SV's `return` carries the control transfer; a bare assignment does not.
+    /// Nothing in the 900-file corpus has this shape (49 functions, 58 returns,
+    /// zero early exits), but the language permits it, so a function that does
+    /// keeps emitting a literal `return` — correct, merely not parseable by
+    /// yosys's built-in frontend, which is the status quo for every function
+    /// today (arch#932).
+    fn returns_are_rewritable(items: &[FunctionBodyItem]) -> bool {
+        for (i, it) in items.iter().enumerate() {
+            if Self::item_has_return(it) && i + 1 != items.len() {
+                return false;
+            }
+            let ok = match it {
+                FunctionBodyItem::IfElse(ie) => {
+                    Self::returns_are_rewritable(&ie.then_body)
+                        && Self::returns_are_rewritable(&ie.else_body)
+                }
+                FunctionBodyItem::For(fl) => Self::returns_are_rewritable(&fl.body),
+                _ => true,
+            };
+            if !ok {
+                return false;
+            }
+        }
+        true
+    }
+
+    /// Every `let` declared anywhere in a function body, in first-appearance
+    /// order, as `(name, sv_type)` — deduplicated by name.
+    ///
+    /// Used to emit all declarations directly under the function header so the
+    /// bodies carry only assignments. Two reasons this cannot stay inline:
+    /// SV requires a block's declarations to precede its first statement (a
+    /// `let` after an `if` is already invalid where it stands), and yosys's
+    /// built-in Verilog frontend rejects a declaration carrying an initializer
+    /// inside a `function` at all (arch#932) — legal SV that Verilator and
+    /// Icarus accept, which is why no simulator gate ever caught it.
+    ///
+    /// Dedup by name is what makes hoisting out of `if`/`for` arms safe: the
+    /// compiler already models function locals as one flat namespace
+    /// (`collect_fn_local_types` walks nested bodies into a single map), so a
+    /// name reused across two arms is one variable assigned twice, exactly as
+    /// before — never two declarations.
+    fn collect_fn_let_decls(&mut self, f: &FunctionDecl) -> Vec<(String, String)> {
+        fn walk(items: &[FunctionBodyItem], out: &mut Vec<(String, Option<TypeExpr>)>) {
+            for item in items {
+                match item {
+                    FunctionBodyItem::Let(l) => {
+                        if !out.iter().any(|(n, _)| n == &l.name.name) {
+                            out.push((l.name.name.clone(), l.ty.clone()));
+                        }
+                    }
+                    FunctionBodyItem::IfElse(ie) => {
+                        walk(&ie.then_body, out);
+                        walk(&ie.else_body, out);
+                    }
+                    FunctionBodyItem::For(fl) => walk(&fl.body, out),
+                    _ => {}
+                }
+            }
+        }
+        let mut raw = Vec::new();
+        walk(&f.body, &mut raw);
+        raw.into_iter()
+            .map(|(n, ty)| {
+                let ty_str = match &ty {
+                    Some(ann) => self.emit_type_str(ann),
+                    None => "logic".to_string(),
+                };
+                (n, ty_str)
+            })
+            .collect()
+    }
+
     pub(crate) fn emit_pending_functions(&mut self) {
         let fns = std::mem::take(&mut self.pending_functions);
         for f in &fns {
@@ -1280,6 +1382,18 @@ impl<'a> Codegen<'a> {
             args_str.join(", ")
         ));
         self.indent += 1;
+        // All `let` declarations first — SV allows body declarations only
+        // before the first statement, and yosys rejects decl-with-initializer
+        // in a function outright (arch#932). The bodies below emit bare
+        // assignments.
+        self.fn_return_target = if Self::returns_are_rewritable(&f.body) {
+            Some(sv_name.clone())
+        } else {
+            None
+        };
+        for (name, ty_str) in self.collect_fn_let_decls(f) {
+            self.line(&format!("{ty_str} {name};"));
+        }
         // Hoist temps synthesized inside this body get their declaration
         // spliced here — just past the header, the only place SV allows a
         // body declaration — while the assignment stays in place (arch#846).
@@ -1293,17 +1407,17 @@ impl<'a> Codegen<'a> {
         for item in &f.body {
             match item {
                 FunctionBodyItem::Let(l) => {
-                    let ty_str = if let Some(ann) = &l.ty {
-                        self.emit_type_str(ann)
-                    } else {
-                        "logic".to_string()
-                    };
+                    // Declaration was emitted under the function header by
+                    // `collect_fn_let_decls`; only the assignment belongs here.
                     let val = self.emit_expr_str(&l.value);
-                    self.line(&format!("{} {} = {};", ty_str, l.name.name, val));
+                    self.line(&format!("{} = {};", l.name.name, val));
                 }
                 FunctionBodyItem::Return(expr) => {
                     let val = self.emit_expr_str(expr);
-                    self.line(&format!("return {};", val));
+                    match self.fn_return_target.clone() {
+                        Some(target) => self.line(&format!("{target} = {val};")),
+                        None => self.line(&format!("return {};", val)),
+                    }
                 }
                 FunctionBodyItem::IfElse(ie) => {
                     self.emit_function_if(ie);
@@ -1319,6 +1433,7 @@ impl<'a> Codegen<'a> {
             }
         }
         self.hoist_scope = saved_scope;
+        self.fn_return_target = None;
         self.indent -= 1;
         self.line("endfunction");
         self.line("");
@@ -1784,17 +1899,17 @@ impl<'a> Codegen<'a> {
         for item in items {
             match item {
                 FunctionBodyItem::Let(l) => {
-                    let ty_str = if let Some(ann) = &l.ty {
-                        self.emit_type_str(ann)
-                    } else {
-                        "logic".to_string()
-                    };
+                    // Declaration was emitted under the function header by
+                    // `collect_fn_let_decls`; only the assignment belongs here.
                     let val = self.emit_expr_str(&l.value);
-                    self.line(&format!("{} {} = {};", ty_str, l.name.name, val));
+                    self.line(&format!("{} = {};", l.name.name, val));
                 }
                 FunctionBodyItem::Return(expr) => {
                     let val = self.emit_expr_str(expr);
-                    self.line(&format!("return {};", val));
+                    match self.fn_return_target.clone() {
+                        Some(target) => self.line(&format!("{target} = {val};")),
+                        None => self.line(&format!("return {};", val)),
+                    }
                 }
                 FunctionBodyItem::IfElse(ie) => self.emit_function_if(ie),
                 FunctionBodyItem::For(fl) => self.emit_function_for(fl),

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -18341,7 +18341,9 @@ fn test_vec_sint_index_reads_preserve_signedness() {
     );
     assert!(
         sv.contains("function automatic logic signed [7:0] pick")
-            && sv.contains("return $signed(v[i]);"),
+            // The `return` lowers to an assignment to the function name
+            // (arch#932); what matters here is that `$signed` survives it.
+            && sv.contains("pick = $signed(v[i]);"),
         "{sv}"
     );
     assert!(sv.contains("copied[i] = $signed(values[i]);"), "{sv}");
@@ -34447,8 +34449,12 @@ fn test_nic400_axi4_to_axi3_burst_split_arithmetic_sv() {
     );
     // 2. INCR-stepped sub-burst start address: base + (beats_done << size).
     assert!(
-        flat.contains("logic [ADDR_W-1:0] stepped = done << size;")
-            && flat.contains("return ADDR_W'(base + stepped);"),
+        // Declaration and assignment are emitted separately, and the
+        // `return` became an assignment to the (monomorphized) function
+        // name (arch#932) — so match the math, not the name.
+        flat.contains("logic [ADDR_W-1:0] stepped;")
+            && flat.contains("stepped = done << size;")
+            && flat.contains("ADDR_W'(base + stepped);"),
         "sub-burst start address must step by (i*16)<<size:\n{sv}",
     );
     // 3. AXI3 ar_len is 4-bit and is sub_beats-1.
@@ -34462,7 +34468,12 @@ fn test_nic400_axi4_to_axi3_burst_split_arithmetic_sv() {
     );
     // min(16, remaining) clamp inside sub_beats().
     assert!(
-        flat.contains("if (remaining > 16) begin return 9'd16;"),
+        // Both arms return, so the returns lower to assignments to the
+        // (monomorphized) function name (arch#932) — assert the clamp in
+        // both arms without pinning that name.
+        flat.contains("if (remaining > 16) begin")
+            && flat.contains("= 9'd16; end else begin")
+            && flat.contains("= remaining; end"),
         "sub_beats must clamp to min(16, remaining):\n{sv}",
     );
     // 4. merged RLAST only on the final sub-burst.
@@ -34501,7 +34512,9 @@ fn test_nic400_axi3_to_axi4_limiter_field_mapping_sv() {
     );
     // 3. AXI3 2-bit lock → AXI4 1-bit lock via (l == 1).
     assert!(
-        flat.contains("return l == 1;"),
+        // `return` lowers to an assignment to the (monomorphized) function
+        // name (arch#932) — match the mapping, not the name.
+        flat.contains("= l == 1;"),
         "AXI3 2-bit AxLOCK must map EXCLUSIVE(01)→1, else 0:\n{sv}",
     );
     // 4. MAX_BURST is the programmable cap parameter, default 16.

--- a/tests/snapshots/integration_test__arbiter_custom_hook.snap
+++ b/tests/snapshots/integration_test__arbiter_custom_hook.snap
@@ -15,12 +15,17 @@ module QosArbiter #(
 );
 
   function automatic logic [3:0] QosGrant(input logic [3:0] req_mask, input logic [3:0] last_grant, input logic [7:0] qos);
-    logic [3:0] masked = req_mask & (last_grant ^ 'hF);
-    logic [3:0] fair_pick = masked != 0 ? masked : req_mask;
-    logic urgent = (qos & 'h80) != 0;
-    logic [3:0] pick = urgent ? req_mask : fair_pick;
-    logic [4:0] pick_neg = 5'($unsigned(pick ^ 'hF)) + 1;
-    return pick & 4'(pick_neg);
+    logic [3:0] masked;
+    logic [3:0] fair_pick;
+    logic urgent;
+    logic [3:0] pick;
+    logic [4:0] pick_neg;
+    masked = req_mask & (last_grant ^ 'hF);
+    fair_pick = masked != 0 ? masked : req_mask;
+    urgent = (qos & 'h80) != 0;
+    pick = urgent ? req_mask : fair_pick;
+    pick_neg = 5'($unsigned(pick ^ 'hF)) + 1;
+    QosGrant = pick & 4'(pick_neg);
   endfunction
   
   logic [3:0] last_grant_r;

--- a/tests/snapshots/integration_test__template_basic.snap
+++ b/tests/snapshots/integration_test__template_basic.snap
@@ -16,7 +16,7 @@ module MyArbiter #(
 );
 
   function automatic logic [3:0] FixedGrant(input logic [3:0] req_mask);
-    return req_mask & 4'(~req_mask + 1);
+    FixedGrant = req_mask & 4'(~req_mask + 1);
   endfunction
   
   logic [3:0] grant;

--- a/tests/synth_function_body_test.rs
+++ b/tests/synth_function_body_test.rs
@@ -1,0 +1,138 @@
+//! Regression coverage for arch#932 — emitted `function automatic` bodies
+//! must be parseable by yosys's built-in Verilog frontend.
+//!
+//! Two constructs made every arch-emitted function unsynthesizable, both
+//! legal SystemVerilog that Verilator and Icarus accept, so no simulator
+//! gate ever saw them:
+//!
+//!   * `logic [7:0] d = expr;` — declaration carrying an initializer inside
+//!     a function body ("Invalid nesting of always blocks and/or
+//!     initializations").
+//!   * `return expr;` — rejected outright ("syntax error, unexpected
+//!     TOK_ID").
+//!
+//! Declarations now hoist above the body and `return` becomes an assignment
+//! to the function name — EXCEPT where a return is an early exit, which the
+//! assignment form cannot express; those keep emitting a literal `return`.
+
+use std::process::Command;
+
+fn build_sv(src: &str, name: &str) -> String {
+    let td = tempfile::tempdir().expect("tempdir");
+    let arch_path = td.path().join(format!("{name}.arch"));
+    let sv_path = td.path().join(format!("{name}.sv"));
+    std::fs::write(&arch_path, src).expect("write arch");
+    let out = Command::new(env!("CARGO_BIN_EXE_arch"))
+        .arg("build")
+        .arg(&arch_path)
+        .arg("-o")
+        .arg(&sv_path)
+        .arg("--no-auto-asserts")
+        .output()
+        .expect("run arch build");
+    assert!(
+        out.status.success(),
+        "arch build failed:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    std::fs::read_to_string(&sv_path).expect("read sv")
+}
+
+/// The ordinary shape: declarations hoisted, `return` lowered to an
+/// assignment to the function name.
+#[test]
+fn function_body_hoists_decls_and_assigns_return() {
+    let sv = build_sv(
+        "module SynthFnPlain\n\
+         \x20 port a: in UInt<8>;\n\
+         \x20 port o: out UInt<8>;\n\
+         \x20 function dbl(x: UInt<8>) -> UInt<8>\n\
+         \x20   let d: UInt<8> = x +% x;\n\
+         \x20   return d;\n\
+         \x20 end function dbl\n\
+         \x20 comb\n\
+         \x20   o = dbl(a);\n\
+         \x20 end comb\n\
+         end module SynthFnPlain\n",
+        "SynthFnPlain",
+    );
+    assert!(
+        sv.contains("logic [7:0] d;"),
+        "declaration should be hoisted bare, got:\n{sv}"
+    );
+    assert!(
+        !sv.contains("logic [7:0] d ="),
+        "declaration must not carry an initializer:\n{sv}"
+    );
+    // The return became an assignment to the function's SV name.
+    assert!(
+        sv.contains("dbl = d;"),
+        "return should lower to `<fn> = <expr>;`:\n{sv}"
+    );
+    assert!(
+        !sv.contains("return d;"),
+        "no literal `return` should survive here:\n{sv}"
+    );
+}
+
+/// An if/else where every arm returns is still rewritable — the returns are
+/// each terminal in their block and nothing follows the `if`.
+#[test]
+fn function_if_else_returns_are_rewritten() {
+    let sv = build_sv(
+        "module SynthFnIf\n\
+         \x20 port a: in UInt<8>;\n\
+         \x20 port o: out UInt<8>;\n\
+         \x20 function pick(x: UInt<8>) -> UInt<8>\n\
+         \x20   if x > 10\n\
+         \x20     return x;\n\
+         \x20   else\n\
+         \x20     return 0;\n\
+         \x20   end if\n\
+         \x20 end function pick\n\
+         \x20 comb\n\
+         \x20   o = pick(a);\n\
+         \x20 end comb\n\
+         end module SynthFnIf\n",
+        "SynthFnIf",
+    );
+    assert!(sv.contains("pick = x;"), "then-arm return:\n{sv}");
+    assert!(!sv.contains("return x;"), "no literal return:\n{sv}");
+}
+
+/// THE GUARD. An early return — a returning `if` followed by another
+/// statement — cannot become a bare assignment, because the trailing
+/// statement would run and overwrite it. Such a function must keep its
+/// literal `return`, even though yosys will not parse it: correctness wins
+/// over synthesizability, and this is the status quo, not a regression.
+///
+/// Nothing in the corpus has this shape, so without this test the fallback
+/// path would be entirely unexercised.
+#[test]
+fn early_return_keeps_literal_return() {
+    let sv = build_sv(
+        "module SynthFnEarly\n\
+         \x20 port a: in UInt<8>;\n\
+         \x20 port o: out UInt<8>;\n\
+         \x20 function clamp_lo(x: UInt<8>) -> UInt<8>\n\
+         \x20   if x < 4\n\
+         \x20     return 4;\n\
+         \x20   end if\n\
+         \x20   return x;\n\
+         \x20 end function clamp_lo\n\
+         \x20 comb\n\
+         \x20   o = clamp_lo(a);\n\
+         \x20 end comb\n\
+         end module SynthFnEarly\n",
+        "SynthFnEarly",
+    );
+    assert!(
+        sv.contains("return 4;") && sv.contains("return x;"),
+        "early-exit function must keep literal returns so the early exit \
+         survives; rewriting them would let `return x` overwrite the clamp:\n{sv}"
+    );
+    assert!(
+        !sv.contains("clamp_lo = 4;"),
+        "must NOT rewrite an early return:\n{sv}"
+    );
+}


### PR DESCRIPTION
## Problem

Emitted `function automatic` bodies used two constructs yosys's built-in Verilog frontend rejects — both **legal SystemVerilog** that Verilator 5.048 and Icarus 12.0 accept, so no simulator gate in CI ever saw them:

```sv
logic [7:0] d = expr;   // "Invalid nesting of always blocks and/or initializations"
return expr;            // "syntax error, unexpected TOK_ID"
```

#950 fixed the first for the generated soft-float helper library. This fixes **both** for user-written `function` bodies.

Every ARCH function must reach a `return` (the no-latch rule), so the `return` gap alone made *every* design containing a user function unsynthesizable — and it **masked** the declaration gap, since parsing dies on `return` first. That's why the two must land together to be observable at all; the declaration fix on its own measures as zero change.

## Measured

14 corpus designs declare a user function containing a `let`. Yosys frontend parse:

| | pass | fail |
|---|---|---|
| before | **0** | 14 |
| after | **14** | 0 |

Combined with #950, this takes `tests/fp_v1` from **3/31 → 31/31**.

## Two changes

**1. Declarations hoist above the body**, leaving assignments in place. Deduplicated by name — which is what makes hoisting out of `if`/`for` arms safe. The compiler already models function locals as one flat namespace (`collect_fn_local_types` walks nested bodies into a single map), so a name reused across two arms stays one variable assigned twice, exactly as before, never two declarations.

**2. `return expr;` lowers to `<fn_name> = expr;`** — but only where no return is an early exit. The unsound shape:

```
if c        ->   if (c) begin
  return a;         fname = a;
end if            end
return b;         fname = b;   // early exit dropped: overwrites `a`
```

SV's `return` carries the control transfer; a bare assignment does not. Functions with that shape **keep emitting a literal `return`** — correct, and exactly today's behavior, merely not yosys-parseable. No regression, ever.

## Why the guard is trustworthy

An AST walk over the corpus — 900 files, 49 functions, 58 returns — finds **zero** early exits, so the guard never fires there. The language permits the shape though, so `early_return_keeps_literal_return` pins the fallback with a synthetic case that nothing else in the tree exercises.

Worth noting `sub_beats` in `Nic400Axi4ToAxi3` *looks* like an early return but is an `if`/`else` where both arms return — correctly classified as rewritable, with the `min(16, remaining)` clamp preserved.

## Test changes

Golden assertions that encoded the old emission now assert what they were actually protecting — the `$signed` wrapper, the `base + stepped` arithmetic, the `l == 1` lock mapping, the `min(16, remaining)` clamp — and no longer pin monomorphized names like `sub_addr_5_x_3`.

Two insta snapshots re-accepted after diff review: declarations hoisted, assignments in unchanged source order, every expression byte-identical.

## Verification

- `cargo test --release` — **1228 passed, 0 failed** (1225 baseline + 3 new tests)
- `cargo fmt --check` clean
- Verilator + Icarus unchanged across all 14 designs — 3 pre-existing failures on each side, identical before and after

Further progress on #932; its genuine-defect findings, including the broken reset in `examples/`, remain open.