### PR TITLE
fix(codegen): declare block-helper loop iterators, don't inline them

### DIFF
--- a/src/fp_block.rs
+++ b/src/fp_block.rs
@@ -761,8 +761,17 @@ fn sv_quantize(s: BlockShape, policy: ScalePolicy, round: RoundMode) -> String {
     let _ = writeln!(o, "  logic {}code;", sv_w(8));
     let _ = writeln!(o, "  logic {}r;", sv_w(bw));
     // 1. amax as an unsigned integer max of |v_i| — see the module header.
+    // Loop iterator declared with the other locals, never inline in the
+    // `for` header. A `for (int unsigned i = ...)` nested inside an if/else
+    // arm leaves `i` undriven on the sibling paths, and yosys's `proc` pass
+    // then infers a LATCH per bit-slice of the iterator (arch#932). The
+    // emitted logic is pure combinational quantization, so those latches are
+    // spurious hardware -- but they are real in the netlist, and no simulator
+    // gate can see them. Hoisting the declaration alone clears it; no default
+    // assignment is needed (verified against yosys 0.67).
+    let _ = writeln!(o, "  int unsigned i;");
     let _ = writeln!(o, "  amax = {}'h0;", 32);
-    let _ = writeln!(o, "  for (int unsigned i = 0; i < {n}; i = i + 1) begin");
+    let _ = writeln!(o, "  for (i = 0; i < {n}; i = i + 1) begin");
     let _ = writeln!(o, "    mag = v[i*32 +: 32] & 32'h7FFFFFFF;");
     let _ = writeln!(o, "    if (mag > amax) amax = mag;");
     let _ = writeln!(o, "  end");
@@ -817,7 +826,7 @@ fn sv_quantize(s: BlockShape, policy: ScalePolicy, round: RoundMode) -> String {
             .sv_reciprocal("code")
             .expect("ExactReciprocal kernel implies the scale has one")
     );
-    let _ = writeln!(o, "    for (int unsigned i = 0; i < {n}; i = i + 1) begin");
+    let _ = writeln!(o, "    for (i = 0; i < {n}; i = i + 1) begin");
     let _ = writeln!(
         o,
         "      r[i*{ew} +: {ew}] = arch_f32_to_{tag}(arch_f32_mul(v[i*32 +: 32], inv));"
@@ -881,8 +890,17 @@ fn sv_quantize_boundary(s: BlockShape, policy: ScalePolicy) -> String {
     let _ = writeln!(o, "  logic {}p;", sv_w(ew));
     let _ = writeln!(o, "  logic sgn;");
     let _ = writeln!(o, "  logic {}r;", sv_w(bw));
+    // Loop iterator declared with the other locals, never inline in the
+    // `for` header. A `for (int unsigned i = ...)` nested inside an if/else
+    // arm leaves `i` undriven on the sibling paths, and yosys's `proc` pass
+    // then infers a LATCH per bit-slice of the iterator (arch#932). The
+    // emitted logic is pure combinational quantization, so those latches are
+    // spurious hardware -- but they are real in the netlist, and no simulator
+    // gate can see them. Hoisting the declaration alone clears it; no default
+    // assignment is needed (verified against yosys 0.67).
+    let _ = writeln!(o, "  int unsigned i;");
     let _ = writeln!(o, "  amax = 32'h0;");
-    let _ = writeln!(o, "  for (int unsigned i = 0; i < {n}; i = i + 1) begin");
+    let _ = writeln!(o, "  for (i = 0; i < {n}; i = i + 1) begin");
     let _ = writeln!(o, "    mag = v[i*32 +: 32] & 32'h7FFFFFFF;");
     let _ = writeln!(o, "    if (mag > amax) amax = mag;");
     let _ = writeln!(o, "  end");
@@ -914,7 +932,7 @@ fn sv_quantize_boundary(s: BlockShape, policy: ScalePolicy) -> String {
         );
     }
     let _ = writeln!(o, "    x = {}(code);", s.scale.widen_fn());
-    let _ = writeln!(o, "    for (int unsigned i = 0; i < {n}; i = i + 1) begin");
+    let _ = writeln!(o, "    for (i = 0; i < {n}; i = i + 1) begin");
     let _ = writeln!(o, "      sgn = v[i*32 + 31];");
     let _ = writeln!(o, "      a = v[i*32 +: 32] & 32'h7FFFFFFF;");
     let _ = writeln!(o, "      m = {ew}'h0;");
@@ -970,6 +988,15 @@ fn sv_dequantize(s: BlockShape) -> String {
     let _ = writeln!(o, "  logic {}w;", sv_w(32));
     let _ = writeln!(o, "  logic {}p;", sv_w(32));
     let _ = writeln!(o, "  logic {}r;", sv_w(vw));
+    // Loop iterator declared with the other locals, never inline in the
+    // `for` header. A `for (int unsigned i = ...)` nested inside an if/else
+    // arm leaves `i` undriven on the sibling paths, and yosys's `proc` pass
+    // then infers a LATCH per bit-slice of the iterator (arch#932). The
+    // emitted logic is pure combinational quantization, so those latches are
+    // spurious hardware -- but they are real in the netlist, and no simulator
+    // gate can see them. Hoisting the declaration alone clears it; no default
+    // assignment is needed (verified against yosys 0.67).
+    let _ = writeln!(o, "  int unsigned i;");
     // A NaN scale (code 0xFF) widens to a NaN f32, so every product below is
     // NaN and the element bits are ignored: the block value rule falls out of
     // the multiply rather than needing a branch.
@@ -981,7 +1008,7 @@ fn sv_dequantize(s: BlockShape) -> String {
         bw - sw
     );
     let _ = writeln!(o, "  r = {vw}'h0;");
-    let _ = writeln!(o, "  for (int unsigned i = 0; i < {n}; i = i + 1) begin");
+    let _ = writeln!(o, "  for (i = 0; i < {n}; i = i + 1) begin");
     let _ = writeln!(o, "    w = arch_{tag}_to_f32(b[i*{ew} +: {ew}]);");
     let _ = writeln!(o, "    p = arch_f32_mul(x, w);");
     // A finite element scaled by a finite scale saturates to +-FP32_MAX

--- a/tests/synth_function_body_test.rs
+++ b/tests/synth_function_body_test.rs
@@ -136,3 +136,76 @@ fn early_return_keeps_literal_return() {
         "must NOT rewrite an early return:\n{sv}"
     );
 }
+
+/// Loop iterators must be declared with the function's other locals, never
+/// inline in the `for` header (arch#932).
+///
+/// `for (int unsigned i = 0; ...)` nested inside an if/else arm leaves `i`
+/// undriven on the sibling paths, and yosys's `proc` pass infers a LATCH per
+/// bit-slice of the iterator — 18 of them in `ScaledQuant` alone. The emitted
+/// logic is pure combinational quantization, so those latches are spurious
+/// hardware that no simulator gate can see: Verilator and Icarus both accept
+/// the inline form happily.
+///
+/// The placement matters as much as the hoist. A declaration emitted *after*
+/// the function's first statement is illegal SV — yosys accepts it silently,
+/// Verilator rejects it — so this also pins that every iterator declaration
+/// precedes the first assignment in its function.
+#[test]
+fn block_helper_loop_iterators_are_declared_not_inline() {
+    let td = tempfile::tempdir().expect("tempdir");
+    let sv_path = td.path().join("ScaledQuant.sv");
+    let out = Command::new(env!("CARGO_BIN_EXE_arch"))
+        .arg("build")
+        .arg("tests/fp_v1/ScaledQuant.arch")
+        .arg("-o")
+        .arg(&sv_path)
+        .arg("--no-auto-asserts")
+        .output()
+        .expect("run arch build");
+    assert!(
+        out.status.success(),
+        "arch build failed:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let sv = std::fs::read_to_string(&sv_path).expect("read sv");
+
+    assert!(
+        !sv.contains("for (int"),
+        "loop iterator must not be declared inline in the `for` header — \
+         nested in an if/else arm it yields a latch per bit-slice:\n{sv}"
+    );
+    assert!(
+        sv.contains("int unsigned i;"),
+        "iterator should be declared with the function's other locals:\n{sv}"
+    );
+
+    // Every iterator declaration must precede its function's first statement.
+    for body in sv.split("function automatic").skip(1) {
+        let body = body.split("endfunction").next().unwrap_or("");
+        let Some(decl) = body.find("int unsigned i;") else {
+            continue;
+        };
+        let first_stmt = body
+            .lines()
+            .scan(0usize, |off, l| {
+                let at = *off;
+                *off += l.len() + 1;
+                Some((at, l.trim().to_string()))
+            })
+            .find(|(_, l)| {
+                l.ends_with(';')
+                    && !l.starts_with("logic")
+                    && !l.starts_with("int ")
+                    && !l.starts_with("//")
+            })
+            .map(|(at, _)| at);
+        if let Some(stmt) = first_stmt {
+            assert!(
+                decl < stmt,
+                "iterator declared after the first statement (illegal SV; \
+                 yosys accepts it, Verilator does not):\n{body}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Problem

The MX block helpers emitted their loop iterator inline:

```sv
for (int unsigned i = 0; i < 8; i = i + 1) begin
```

Two of the five loops sit inside an `else` arm, so `i` is **undriven on the sibling paths**. Yosys's `proc` pass then infers a **latch per bit-slice** of the iterator — `i[2:0]`, `i[3]`, `i[31:4]`, three per loop, **18 in `ScaledQuant` alone**.

The emitted logic is pure combinational quantization, so those latches are spurious hardware in the netlist.

**Nothing in CI could see them.** Verilator 5.048 and Icarus 12.0 both accept the inline form, and yosys never got far enough to complain until #950/#951 fixed the frontend gaps that killed it at parse time. The latches were always emitted — they were simply unreachable. This is the "hoist latch" defect listed in #932.

## Fix

Declare the iterator with the function's other locals; leave the header as `for (i = 0; ...)`.

Verified minimal against yosys 0.67 — hoisting the declaration **alone** clears the latches, with no default assignment needed:

| variant | latches |
|---|---|
| `for (int unsigned i = 0; ...)` inside `if` | **3** |
| same loop unconditional | 0 |
| declaration hoisted | **0** |
| hoisted + `i = 0;` default | 0 |

Result:

| design | latches | Verilator | Icarus |
|---|---|---|---|
| `ScaledQuant` | **18 → 0** | OK | OK |
| `ScaledVecType` | 0 → 0 | OK | OK |

## Placement is as load-bearing as the hoist

`sv_dequantize` opens with a statement (`x = <scale>(b[...])`) *before* its `r` assignment, so anchoring the declaration there put it **after a statement** — illegal SV. **Yosys accepted that silently; Verilator rejected it outright.**

That's the same asymmetry as the original bug running the other direction, and the reason the regression test pins ordering and not just presence: neither tool alone is a sufficient gate. It's also a concrete argument for #932's proposal to put synthesis in CI *alongside* the simulators rather than instead of them.

## Verification

- Regression test asserts no `for (int` in emitted output **and** that every iterator declaration precedes its function's first statement. It fails against the pre-fix emitter (13 inline declarations → 0).
- `cargo test --release --no-fail-fast`: **1223 passed / 5 failed — byte-identical to `origin/main`** (same run on unmodified main gives the same totals and the same five names). Those five are `*_rejected*` tests asserting a contiguous diagnostic phrase that miette breaks across a terminal-width wrap; pre-existing, environment-dependent, and green in CI.
- `cargo fmt --check` clean.

Further progress on #932. Its remaining genuine defects, including the broken reset in `examples/`, are untouched.