### PR TITLE
fix(synth): add `cleanup` before `buffer` in the nangate45 flow

### DIFF
--- a/tests/fp_v1/synth/nangate45/README.md
+++ b/tests/fp_v1/synth/nangate45/README.md
@@ -30,10 +30,19 @@ report and understate fmax by up to 3.5x (exact-wide FMA: 45 MHz unbuffered vs
 strash
 dch -f
 map
+cleanup
 buffer -N 8
 upsize
 dnsize
 ```
+
+`cleanup` removes dangling combinational logic left inside ABC after `map`.
+On a single operator it is a no-op (zero dangling nodes — verified byte-identical
+netlist and fmax with and without it). It matters only for composite designs
+that instantiate many operators, where `map` leaves a handful of fanout-less
+nodes that make `buffer` abort (`node NNNN has no fanout`); `cleanup` is the
+mapped-safe remover for them. Do **not** substitute `sweep` — it rebuilds the
+network as BDDs, destroying the gate mapping `buffer` needs, and segfaults.
 
 For two BF16 netlists (`Bf16Add`, `Bf16Sub`) ABC's `dch -f` aborts; substitute
 `dc2` for the `dch -f` line for those two operators. The mapping and repair

--- a/tests/fp_v1/synth/nangate45/abc_buffered.script
+++ b/tests/fp_v1/synth/nangate45/abc_buffered.script
@@ -1,6 +1,7 @@
 strash
 dch -f
 map
+cleanup
 buffer -N 8
 upsize
 dnsize


### PR DESCRIPTION
## Problem

`abc_buffered.script`'s `buffer -N 8` aborts with `node NNNN has no fanout` on any netlist that `map` leaves dangling nodes in. This never showed on the single-operator designs the archived flow characterizes, but it blocks **every composite design** — `ScaledQuant` (quantize/dequantize/dot across B4/B6/B8) fails there.

The only symptom yosys surfaces is the downstream `ERROR: Can't open ABC output file`. ABC writes no log of its own, so the real error only appears if you re-run `yosys-abc -f abc.script` by hand in the temp dir.

## Fix

One line — `cleanup` between `map` and `buffer`:

```diff
 strash
 dch -f
 map
+cleanup
 buffer -N 8
 upsize
 dnsize
```

`cleanup` is ABC's mapped-safe dangling-logic remover. On `ScaledQuant` it removes **5 nodes out of 59,432** and the buffered flow then completes:

| flow | area (µm²) | fmax |
|---|---|---|
| unbuffered | 53,504 | 43.85 MHz |
| buffered (this PR) | 63,552 | **83.01 MHz** |

1.9× fmax for +19% area, consistent with the README's documented buffering effect.

## Verification

**No-op on the single-operator flow the archive characterizes.** FMA through the exact paper flow (`-flatten`, buffered) with and without `cleanup`:

```
[orig]  area=12361.02  fmax=198.535 MHz
[clean] area=12361.02  fmax=198.535 MHz
netlists byte-identical
```

`cleanup` only activates where dangling nodes exist (composite designs), so the archived per-operator numbers are unchanged.

**Do not substitute `sweep`.** It rebuilds the network as BDDs, destroying the gate mapping `buffer` needs, and segfaults (exit 139). The README now says so.

## Scope

Non-Rust: `abc_buffered.script` (1 line) + its README block. Only `flow_comb.ys.tmpl` consumes this script; `run_synth.sh` uses the separate non-buffered `flow.ys.tmpl`, untouched. CI's cargo checks are vacuous here — the real verification is the synthesis runs above.

Surfaced while characterizing the block operators for #955.