### PR TITLE
docs(fp): drop duplicated render_sv_staged doc-comment line

### DIFF
--- a/src/fp_ir.rs
+++ b/src/fp_ir.rs
@@ -1045,7 +1045,6 @@ pub fn derive_leaf_schedule(f: &FpFn, stages: u32) -> Result<Vec<usize>, String>
 }
 
 /// Render `main_fn` as a staged pipelined module per `sched`, inlining the
-/// Render `main_fn` as a staged pipelined module per `sched`, inlining the
 /// single nested call to `callee_fn` (the `A_` namespace). See the section
 /// comment above for the emitted structure and the fallback contract.
 pub fn render_sv_staged(


### PR DESCRIPTION
## Problem

Found during the daily code-review of merged PRs. The #955/#957 change (`feat(fp): gate-weighted leaf pipeline scheduler + zero-call staged render`) inserted `derive_leaf_schedule` immediately above `render_sv_staged`, and the diff left `render_sv_staged`'s first doc-comment line duplicated:

```rust
/// Render `main_fn` as a staged pipelined module per `sched`, inlining the
/// Render `main_fn` as a staged pipelined module per `sched`, inlining the
/// single nested call to `callee_fn` (the `A_` namespace). ...
```

(`src/fp_ir.rs:1047-1048` on main.)

## Fix

Delete the duplicate line. Doc-comment only — no code, no behavior, no emitted-output change.

## Verification (fast gate, worktree-fresh)

- `cargo fmt --check` — clean
- `cargo test --release --lib fp_ir` — 11 passed / 0 failed (incl. `staged_leaf_f32_mul_matches_eval_bv`, `leaf_scheduler_f32_mul_is_topological_and_balanced`)

No grammar-surface (`lexer`/`parser`/`ast`) or version files touched, so no doc-drift / release-doc gate applies.