### PR TITLE
feat(fp): pipelined block operators — scaled_quantize / scaled_dot (#955)

### DIFF
--- a/doc/ARCH_HDL_Specification.md
+++ b/doc/ARCH_HDL_Specification.md
@@ -978,6 +978,18 @@ type checker reports the required `N` if a different one is written. As with
 otherwise the call lowers to the combinational operator inside the pipe_reg
 cascade (correct latency, un-retimed).
 
+`scaled_dot<pipelined, N>` additionally requires a **power-of-two block size**.
+Its coarse per-level staging pipelines the `f32_add` reduction tree one level
+per stage, which stays latency-balanced only when the tree is perfect — i.e.
+the element count is a power of two. For a non-power-of-two count the tree
+carries an odd element across a round rather than padding with zero (padding
+would turn `-0.0` into `+0.0`, a real value change), so that element crosses
+fewer register edges than its siblings and would reach the scale multiply a
+cycle early. The type checker rejects a non-power-of-two block rather than emit
+a skewed pipeline; the combinational `scaled_dot` (drop `pipelined`) handles any
+`N`. `scaled_quantize` has no such restriction — its per-element multiplies run
+in parallel at a uniform depth.
+
 **The call's depth is authoritative; the tap is a consistency check.** A
 `<pipelined, N>` call produces a value with latency `N` — it must be bound
 into a `pipe_reg<T, N>`-typed target via the matching `@N` tap, exactly like

--- a/doc/ARCH_HDL_Specification.md
+++ b/doc/ARCH_HDL_Specification.md
@@ -965,6 +965,19 @@ characterized fmax — the concrete set is intentionally kept out of this
 normative section (it churns as implementations are added) and lives in the
 generated `doc/generated/pipelined_ops.md` instead.
 
+The **block operators** of §3.11 take the same variant:
+`scaled_quantize<Fmt, pipelined, N>(v)` and `scaled_dot<pipelined, N>(a, b)`,
+for `E8M0`-scale blocks (the boundary-compare `UE4M3` scale is not pipelined
+yet). Their critical path is dominated by the per-element FP32 multiplies, so
+those are staged while the block-specific work (the shared-scale reduction and
+the narrowing) stays combinational. Unlike `fma`, `N` here is **not a free
+choice**: each block shape has one fixed staged latency (a quantize is `5`; a
+dot is `3` plus its reduction-tree depth — `6` for an 8-element block), and the
+type checker reports the required `N` if a different one is written. As with
+`fma`, the staged form is emitted only under `arch build --staged-ops`;
+otherwise the call lowers to the combinational operator inside the pipe_reg
+cascade (correct latency, un-retimed).
+
 **The call's depth is authoritative; the tap is a consistency check.** A
 `<pipelined, N>` call produces a value with latency `N` — it must be bound
 into a `pipe_reg<T, N>`-typed target via the matching `@N` tap, exactly like

--- a/doc/Arch_AI_Reference_Card.md
+++ b/doc/Arch_AI_Reference_Card.md
@@ -295,6 +295,8 @@ scaled_quantize<Fmt, policy, rounding>(v)   // policy ∈ floor_pow2|ceil_pow2|e
                                      //   default policy is scale-dependent: floor_pow2 (E8M0), exact (UE4M3)
 scaled_dequantize(b)                 // block → Vec<FP32,N> (scale applied; the ONLY way to read a lane)
 scaled_dot(a, b)                     // two blocks of the SAME type → FP32 (block dot product, FP32 accumulate)
+scaled_quantize<Fmt, pipelined, N>(v)       // pipelined block quantize (E8M0 only); N is FIXED per shape (a quantize is 5)
+scaled_dot<pipelined, N>(a, b)              // pipelined block dot (E8M0 only); N FIXED = 3 + tree-depth (6 for N=8). Both need --staged-ops
 a == b   a != b                      // ENCODING compare on the packed word: equal bits ⇒ equal value, but
                                      //   unequal bits ≠ unequal value — dequantize both for a true value test
 ```

--- a/doc/Arch_AI_Reference_Card.md
+++ b/doc/Arch_AI_Reference_Card.md
@@ -296,7 +296,7 @@ scaled_quantize<Fmt, policy, rounding>(v)   // policy ∈ floor_pow2|ceil_pow2|e
 scaled_dequantize(b)                 // block → Vec<FP32,N> (scale applied; the ONLY way to read a lane)
 scaled_dot(a, b)                     // two blocks of the SAME type → FP32 (block dot product, FP32 accumulate)
 scaled_quantize<Fmt, pipelined, N>(v)       // pipelined block quantize (E8M0 only); N is FIXED per shape (a quantize is 5)
-scaled_dot<pipelined, N>(a, b)              // pipelined block dot (E8M0 only); N FIXED = 3 + tree-depth (6 for N=8). Both need --staged-ops
+scaled_dot<pipelined, N>(a, b)              // pipelined block dot (E8M0 only); N FIXED = 3 + tree-depth (6 for N=8); block size must be a POWER OF TWO. Both need --staged-ops
 a == b   a != b                      // ENCODING compare on the packed word: equal bits ⇒ equal value, but
                                      //   unequal bits ≠ unequal value — dequantize both for a true value test
 ```

--- a/skills/arch-programming/references/ARCH_HDL_Specification.md
+++ b/skills/arch-programming/references/ARCH_HDL_Specification.md
@@ -978,6 +978,18 @@ type checker reports the required `N` if a different one is written. As with
 otherwise the call lowers to the combinational operator inside the pipe_reg
 cascade (correct latency, un-retimed).
 
+`scaled_dot<pipelined, N>` additionally requires a **power-of-two block size**.
+Its coarse per-level staging pipelines the `f32_add` reduction tree one level
+per stage, which stays latency-balanced only when the tree is perfect — i.e.
+the element count is a power of two. For a non-power-of-two count the tree
+carries an odd element across a round rather than padding with zero (padding
+would turn `-0.0` into `+0.0`, a real value change), so that element crosses
+fewer register edges than its siblings and would reach the scale multiply a
+cycle early. The type checker rejects a non-power-of-two block rather than emit
+a skewed pipeline; the combinational `scaled_dot` (drop `pipelined`) handles any
+`N`. `scaled_quantize` has no such restriction — its per-element multiplies run
+in parallel at a uniform depth.
+
 **The call's depth is authoritative; the tap is a consistency check.** A
 `<pipelined, N>` call produces a value with latency `N` — it must be bound
 into a `pipe_reg<T, N>`-typed target via the matching `@N` tap, exactly like

--- a/skills/arch-programming/references/ARCH_HDL_Specification.md
+++ b/skills/arch-programming/references/ARCH_HDL_Specification.md
@@ -965,6 +965,19 @@ characterized fmax — the concrete set is intentionally kept out of this
 normative section (it churns as implementations are added) and lives in the
 generated `doc/generated/pipelined_ops.md` instead.
 
+The **block operators** of §3.11 take the same variant:
+`scaled_quantize<Fmt, pipelined, N>(v)` and `scaled_dot<pipelined, N>(a, b)`,
+for `E8M0`-scale blocks (the boundary-compare `UE4M3` scale is not pipelined
+yet). Their critical path is dominated by the per-element FP32 multiplies, so
+those are staged while the block-specific work (the shared-scale reduction and
+the narrowing) stays combinational. Unlike `fma`, `N` here is **not a free
+choice**: each block shape has one fixed staged latency (a quantize is `5`; a
+dot is `3` plus its reduction-tree depth — `6` for an 8-element block), and the
+type checker reports the required `N` if a different one is written. As with
+`fma`, the staged form is emitted only under `arch build --staged-ops`;
+otherwise the call lowers to the combinational operator inside the pipe_reg
+cascade (correct latency, un-retimed).
+
 **The call's depth is authoritative; the tap is a consistency check.** A
 `<pipelined, N>` call produces a value with latency `N` — it must be bound
 into a `pipe_reg<T, N>`-typed target via the matching `@N` tap, exactly like

--- a/skills/arch-programming/references/Arch_AI_Reference_Card.md
+++ b/skills/arch-programming/references/Arch_AI_Reference_Card.md
@@ -295,6 +295,8 @@ scaled_quantize<Fmt, policy, rounding>(v)   // policy ∈ floor_pow2|ceil_pow2|e
                                      //   default policy is scale-dependent: floor_pow2 (E8M0), exact (UE4M3)
 scaled_dequantize(b)                 // block → Vec<FP32,N> (scale applied; the ONLY way to read a lane)
 scaled_dot(a, b)                     // two blocks of the SAME type → FP32 (block dot product, FP32 accumulate)
+scaled_quantize<Fmt, pipelined, N>(v)       // pipelined block quantize (E8M0 only); N is FIXED per shape (a quantize is 5)
+scaled_dot<pipelined, N>(a, b)              // pipelined block dot (E8M0 only); N FIXED = 3 + tree-depth (6 for N=8). Both need --staged-ops
 a == b   a != b                      // ENCODING compare on the packed word: equal bits ⇒ equal value, but
                                      //   unequal bits ≠ unequal value — dequantize both for a true value test
 ```

--- a/skills/arch-programming/references/Arch_AI_Reference_Card.md
+++ b/skills/arch-programming/references/Arch_AI_Reference_Card.md
@@ -296,7 +296,7 @@ scaled_quantize<Fmt, policy, rounding>(v)   // policy ∈ floor_pow2|ceil_pow2|e
 scaled_dequantize(b)                 // block → Vec<FP32,N> (scale applied; the ONLY way to read a lane)
 scaled_dot(a, b)                     // two blocks of the SAME type → FP32 (block dot product, FP32 accumulate)
 scaled_quantize<Fmt, pipelined, N>(v)       // pipelined block quantize (E8M0 only); N is FIXED per shape (a quantize is 5)
-scaled_dot<pipelined, N>(a, b)              // pipelined block dot (E8M0 only); N FIXED = 3 + tree-depth (6 for N=8). Both need --staged-ops
+scaled_dot<pipelined, N>(a, b)              // pipelined block dot (E8M0 only); N FIXED = 3 + tree-depth (6 for N=8); block size must be a POWER OF TWO. Both need --staged-ops
 a == b   a != b                      // ENCODING compare on the packed word: equal bits ⇒ equal value, but
                                      //   unequal bits ≠ unequal value — dequantize both for a true value test
 ```

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1316,7 +1316,17 @@ pub enum ExprKind {
     /// block's *scale type*, which the parser cannot resolve because `Fmt`
     /// may be a type alias. `BlockScale::default_policy` settles it once the
     /// type is known.
-    ScaledQuantize(Box<Expr>, Box<TypeExpr>, Option<ScalePolicy>, RoundMode),
+    /// The trailing `Option<u32>` is the pipeline depth from
+    /// `scaled_quantize<Fmt, pipelined, N>(v)` — `Some(N)` requests a
+    /// latency-N staged datapath (the multiplies pipelined, arch#955);
+    /// `None` is the ordinary single-cycle comb form.
+    ScaledQuantize(
+        Box<Expr>,
+        Box<TypeExpr>,
+        Option<ScalePolicy>,
+        RoundMode,
+        Option<u32>,
+    ),
     /// SVA delay-shift: `##N expr`. Inside an `assert`/`cover` body, shifts
     /// the cycle of `expr` forward by `N` (i.e. evaluates `expr` at cycle
     /// `t + N` when the surrounding property is checked at cycle `t`).

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -621,6 +621,12 @@ impl<'a> Codegen<'a> {
     /// `pipelined_ops::lower_pipelined_calls_mode` (phase 3.5,
     /// `arch build --staged-ops`).
     pub fn set_staged_sites(&mut self, sites: Vec<crate::pipelined_ops::StagedSite>) {
+        // A staged module that references the shared fp-helper library forces
+        // that library to be emitted even when no comb site pulled it in
+        // (arch#955 — under --staged-ops the comb quantize call is gone).
+        if sites.iter().any(|s| s.needs_fp_lib) {
+            self.fp_helpers_used.set(true);
+        }
         self.staged_sites = sites;
     }
 
@@ -7826,7 +7832,11 @@ impl<'a> Codegen<'a> {
             // `scaled_quantize<Fmt, policy, rounding>(v)` — the block shape
             // comes from the EXPRESSION's own format argument, not from the
             // assignment target, so nothing here has to be inferred.
-            ExprKind::ScaledQuantize(value, fmt, policy, round) => {
+            ExprKind::ScaledQuantize(value, fmt, policy, round, stages) => {
+                assert!(
+                    stages.is_none(),
+                    "scaled_quantize<pipelined, N> reached codegen un-lowered (arch#955)"
+                );
                 let shape = crate::fp_block::shape_of_type(fmt).unwrap_or_else(|| {
                     panic!(
                         "scaled_quantize format has no resolvable block shape — \

--- a/src/codegen/module.rs
+++ b/src/codegen/module.rs
@@ -1371,6 +1371,12 @@ impl<'a> Codegen<'a> {
             .collect();
         for site in sites {
             self.staged_emitted.set(true);
+            // A site with an empty instance name contributes only its module
+            // text (a shared dependency such as the staged multiplier, emitted
+            // once via the deduped-by-sv_module prefix) — no instance line.
+            if site.instance.is_empty() {
+                continue;
+            }
             let w = if site.width == 1 {
                 String::new()
             } else {

--- a/src/fp_block.rs
+++ b/src/fp_block.rs
@@ -722,6 +722,152 @@ fn sv_dot(s: BlockShape) -> String {
     o
 }
 
+/// Group a dot reduction tree (`dot_schedule`) into dependency levels: an add
+/// is in level `L` iff both its inputs are produced in a level below `L`
+/// (products are level 0). Returns, per level, the list of `(dst, l, r)` adds.
+fn dot_levels(n: u32) -> Vec<Vec<(usize, usize, usize)>> {
+    let (adds, _last) = dot_schedule(n);
+    let mut level = vec![0i32; n as usize + adds.len()];
+    let mut out: Vec<Vec<(usize, usize, usize)>> = Vec::new();
+    for (k, (l, r)) in adds.iter().enumerate() {
+        let dst = n as usize + k;
+        let lv = level[*l].max(level[*r]) + 1;
+        level[dst] = lv;
+        let idx = (lv - 1) as usize;
+        while out.len() <= idx {
+            out.push(Vec::new());
+        }
+        out[idx].push((dst, *l, *r));
+    }
+    out
+}
+
+/// Binding latency of the staged (coarse per-level) `scaled_dot`: one products
+/// stage, one register per reduction-tree level, one first-scale-multiply
+/// stage, and the binding output register (the second scale multiply is the
+/// combinational tail). Verified against the prototype (arch#955).
+pub fn staged_dot_binding_latency(n: u32) -> u32 {
+    let tree_depth = dot_levels(n).len() as u32;
+    1 + tree_depth + 1 + 1
+}
+
+/// Staged (coarse per-level pipelined) `scaled_dot` for an E8M0-scale block
+/// (arch#955): N exact element products (stage 1), the `f32_add` reduction tree
+/// one level per stage, then the two power-of-two scale multiplies. One
+/// f32-op-level per stage, initiation interval one. Returns
+/// `(module_name, sv_text, binding_latency)`.
+pub fn sv_staged_dot(s: BlockShape) -> (String, String, u32) {
+    assert_eq!(
+        s.scale.quant_kernel(),
+        QuantKernel::ExactReciprocal,
+        "staged scaled_dot is implemented for E8M0 scales only (arch#955)"
+    );
+    let (bw, ew, sw) = (s.bits(), s.elem_width(), s.scale.width());
+    let (n, tag) = (s.n, s.elem_tag());
+    let levels = dot_levels(n);
+    let binding_latency = staged_dot_binding_latency(n);
+    let scale_stages = binding_latency - 1;
+    let base = BlockHelper::Dot { shape: s }.sv_name();
+    let name = format!("{base}_staged{binding_latency}");
+    let widen = s.scale.widen_fn();
+    let mut o = String::new();
+    let _ = writeln!(
+        o,
+        "// {name}: staged latency-{binding_latency} scaled_dot, II=1 (arch#955)."
+    );
+    let _ = writeln!(o, "module {name} (");
+    let _ = writeln!(o, "  input logic clk,");
+    let _ = writeln!(o, "  input logic {}a,", sv_w(bw));
+    let _ = writeln!(o, "  input logic {}b,", sv_w(bw));
+    let _ = writeln!(o, "  output logic {}y", sv_w(32));
+    let _ = writeln!(o, ");");
+    // stage 1: element products
+    for i in 0..n as usize {
+        let _ = writeln!(o, "  logic {}pp{i};", sv_w(32));
+    }
+    let _ = writeln!(o, "  always_comb begin");
+    for i in 0..n as usize {
+        let lo = i * ew as usize;
+        let _ = writeln!(
+            o,
+            "    pp{i} = arch_f32_mul(arch_{tag}_to_f32(a[{lo} +: {ew}]), arch_{tag}_to_f32(b[{lo} +: {ew}]));"
+        );
+    }
+    let _ = writeln!(o, "  end");
+    for i in 0..n as usize {
+        let _ = writeln!(o, "  logic {}r0_{i};", sv_w(32));
+    }
+    // scale bytes shifted through the pipeline to reach the two scale muls
+    for k in 1..=scale_stages {
+        let _ = writeln!(o, "  logic {}sda{k}; logic {}sdb{k};", sv_w(sw), sv_w(sw));
+    }
+    let _ = writeln!(o, "  always_ff @(posedge clk) begin");
+    for i in 0..n as usize {
+        let _ = writeln!(o, "    r0_{i} <= pp{i};");
+    }
+    let _ = writeln!(
+        o,
+        "    sda1 <= a[{}:{}]; sdb1 <= b[{}:{}];",
+        bw - 1,
+        bw - sw,
+        bw - 1,
+        bw - sw
+    );
+    for k in 2..=scale_stages {
+        let _ = writeln!(o, "    sda{k} <= sda{}; sdb{k} <= sdb{};", k - 1, k - 1);
+    }
+    let _ = writeln!(o, "  end");
+    // reduction tree: one stage per level; reg_of maps a value id to its
+    // current register name.
+    let mut reg_of: std::collections::HashMap<usize, String> = std::collections::HashMap::new();
+    for i in 0..n as usize {
+        reg_of.insert(i, format!("r0_{i}"));
+    }
+    for (li, level) in levels.iter().enumerate() {
+        let lvl = (li + 1) as u32;
+        for (dst, _, _) in level {
+            let _ = writeln!(o, "  logic {}c{lvl}_{dst};", sv_w(32));
+        }
+        let _ = writeln!(o, "  always_comb begin");
+        for (dst, l, r) in level {
+            let lr = reg_of[l].clone();
+            let rr = reg_of[r].clone();
+            let _ = writeln!(o, "    c{lvl}_{dst} = arch_f32_add({lr}, {rr});");
+        }
+        let _ = writeln!(o, "  end");
+        for (dst, _, _) in level {
+            let _ = writeln!(o, "  logic {}r{lvl}_{dst};", sv_w(32));
+        }
+        let _ = writeln!(o, "  always_ff @(posedge clk) begin");
+        for (dst, _, _) in level {
+            let _ = writeln!(o, "    r{lvl}_{dst} <= c{lvl}_{dst};");
+            reg_of.insert(*dst, format!("r{lvl}_{dst}"));
+        }
+        let _ = writeln!(o, "  end");
+    }
+    let (_, last) = dot_schedule(n);
+    let sum_reg = reg_of[&last].clone();
+    // scale multiply 1 (comb) then register. The tree output `sum_reg` lands
+    // after 1 (products) + tree_depth register edges, so scale-mul-1 must read
+    // the scale byte delayed by exactly that many edges — NOT `scale_stages`
+    // (one too many; that misaligns the block scale by a cycle, arch#955).
+    let sum_stage = 1 + dot_levels(n).len() as u32;
+    let _ = writeln!(o, "  logic {}m1;", sv_w(32));
+    let _ = writeln!(
+        o,
+        "  always_comb m1 = arch_f32_mul({sum_reg}, {widen}(sda{sum_stage}));"
+    );
+    let _ = writeln!(o, "  logic {}m1r;", sv_w(32));
+    let _ = writeln!(o, "  always_ff @(posedge clk) m1r <= m1;");
+    // scale multiply 2 (comb tail) to output
+    let _ = writeln!(
+        o,
+        "  always_comb y = arch_f32_mul(m1r, {widen}(sdb{scale_stages}));"
+    );
+    let _ = writeln!(o, "endmodule");
+    (name, o, binding_latency)
+}
+
 fn sv_quantize(s: BlockShape, policy: ScalePolicy, round: RoundMode) -> String {
     assert_eq!(
         round,
@@ -839,7 +985,191 @@ fn sv_quantize(s: BlockShape, policy: ScalePolicy, round: RoundMode) -> String {
     o
 }
 
+/// Staged (pipelined) `scaled_quantize` for an ExactReciprocal (E8M0) scale
+/// (arch#955). Emits an SV **module** (not a function): the 8 per-element
+/// FP32 multiplies — 84% of the block quantize's critical path — run through
+/// instances of the staged multiplier `F32_MUL_S4_SCHEDULE.sv_module`, while
+/// the shallow scale-compute and narrow/pack stay combinational around them.
+///
+/// Structure (validated in iverilog against the comb form, bit-exact, before
+/// this emitter was written):
+///
+/// ```text
+/// stage A (comb): amax → ecode → code → inv, scale_byte, is_special
+///   register {v, inv, scale_byte, is_special}                     [edge 1]
+/// N× ArchF32MulStaged4(clk, v_r[i], inv_r) → prod[i]     [3 internal edges]
+///   meta {scale_byte, is_special} carried through a 3-deep shift to align
+/// stage B (comb): elem[i] = is_special ? 0 : narrow(prod[i]); pack
+/// ```
+///
+/// Latency to the module's comb `y` is 4 (1 + the multiply's 3 register
+/// layers); the binding's `y@5` output register supplies the 5th edge — so
+/// this emits a latency-5 datapath. The multiplies run unconditionally; the
+/// NaN-block / zero-block cases are handled by masking the narrowed elements
+/// and overriding the scale byte, so no conditional datapath is needed.
+///
+/// Returns `(module_name, sv_text, binding_latency)`.
+/// Whether a shape can be staged (pipelined) today (arch#955): only
+/// ExactReciprocal (E8M0) scales, whose reciprocal-multiply datapath the
+/// staged emitter reproduces. BoundaryCompare scales (UE4M3) are a follow-up.
+pub fn staged_quantize_supported(s: BlockShape) -> bool {
+    s.scale.quant_kernel() == QuantKernel::ExactReciprocal
+}
+
+/// The binding latency `scaled_quantize<Fmt, pipelined, N>` requires: one
+/// scale-compute register stage, the staged multiply's register layers, and
+/// the binding's own output register. Fixed by `F32_MUL_S4_SCHEDULE` today.
+pub fn staged_quantize_binding_latency() -> u32 {
+    let mul_reg_layers = crate::pipelined_ops::F32_MUL_S4_SCHEDULE.main_starts.len() as u32 - 2;
+    1 + mul_reg_layers + 1
+}
+
+pub fn sv_staged_quantize(
+    s: BlockShape,
+    policy: ScalePolicy,
+    round: RoundMode,
+) -> (String, String, u32) {
+    assert_eq!(
+        round,
+        RoundMode::Rne,
+        "only RNE narrowing is lowered (arch#890)"
+    );
+    assert_eq!(
+        s.scale.quant_kernel(),
+        QuantKernel::ExactReciprocal,
+        "staged quantize is implemented for ExactReciprocal (E8M0) scales only \
+         today (arch#955); BoundaryCompare scales (UE4M3) are a follow-up"
+    );
+    let mul_module = crate::pipelined_ops::F32_MUL_S4_SCHEDULE.sv_module;
+    // Register layers inside the staged multiply = stages - 1; the meta shift
+    // must match so the scale byte lands with `prod`.
+    let mul_reg_layers = crate::pipelined_ops::F32_MUL_S4_SCHEDULE.main_starts.len() as u32 - 2;
+    let binding_latency = 1 + mul_reg_layers + 1; // stage-A reg + mul + output reg
+
+    let base = BlockHelper::Quantize {
+        shape: s,
+        policy,
+        round,
+    }
+    .sv_name();
+    let name = format!("{base}_staged{binding_latency}");
+    let (bw, ew, sw) = (s.bits(), s.elem_width(), s.scale.width());
+    let (n, emax, tag) = (s.n, s.elem_emax(), s.elem_tag());
+    let vw = s.vec_bits();
+    let mut o = String::new();
+    let _ = writeln!(
+        o,
+        "// {name}: staged (latency-{binding_latency}) `scaled_quantize`. The {n} FP32 \
+         multiplies run through `{mul_module}`; scale-compute and narrow stay comb \
+         (arch#955)."
+    );
+    let _ = writeln!(
+        o,
+        "module {name} (\n  input logic clk,\n  input logic {}v,\n  output logic {}y\n);",
+        sv_w(vw),
+        sv_w(bw)
+    );
+    // ── stage A (comb): scale compute ──
+    let _ = writeln!(o, "  logic {}amax;", sv_w(32));
+    let _ = writeln!(o, "  logic {}mag;", sv_w(32));
+    let _ = writeln!(o, "  logic {}inv;", sv_w(32));
+    let _ = writeln!(o, "  logic {}ecode;", sv_w(8));
+    let _ = writeln!(o, "  logic {}code;", sv_w(8));
+    let _ = writeln!(o, "  logic {}scale_byte;", sv_w(sw));
+    let _ = writeln!(o, "  logic is_special;");
+    let _ = writeln!(o, "  int unsigned i;");
+    let _ = writeln!(o, "  always_comb begin");
+    let _ = writeln!(o, "    amax = 32'h0;");
+    let _ = writeln!(o, "    for (i = 0; i < {n}; i = i + 1) begin");
+    let _ = writeln!(o, "      mag = v[i*32 +: 32] & 32'h7FFFFFFF;");
+    let _ = writeln!(o, "      if (mag > amax) amax = mag;");
+    let _ = writeln!(o, "    end");
+    let _ = writeln!(
+        o,
+        "    is_special = (amax >= 32'h7F800000) || (amax == 32'h0);"
+    );
+    let _ = writeln!(o, "    ecode = {}(amax);", s.scale.narrow_fn());
+    if policy == ScalePolicy::CeilPow2 {
+        let _ = writeln!(
+            o,
+            "    if (amax > {}(ecode) && ecode != 8'h{:02X}) ecode = ecode + 8'h01;",
+            s.scale.widen_fn(),
+            s.scale.max_finite_code()
+        );
+    }
+    let _ = writeln!(
+        o,
+        "    code = (ecode > 8'd{emax}) ? (ecode - 8'd{emax}) : 8'h00;"
+    );
+    let _ = writeln!(
+        o,
+        "    inv = {};",
+        s.scale
+            .sv_reciprocal("code")
+            .expect("ExactReciprocal has a reciprocal")
+    );
+    let _ = writeln!(
+        o,
+        "    if (amax >= 32'h7F800000) scale_byte = 8'h{:02X};",
+        s.scale.nan_code()
+    );
+    let _ = writeln!(
+        o,
+        "    else if (amax == 32'h0) scale_byte = 8'h{:02X};",
+        s.scale.zero_block_code()
+    );
+    let _ = writeln!(o, "    else scale_byte = code;");
+    let _ = writeln!(o, "  end");
+    // register layer A
+    let _ = writeln!(o, "  logic {}v_r;", sv_w(vw));
+    let _ = writeln!(o, "  logic {}inv_r;", sv_w(32));
+    let _ = writeln!(o, "  logic {}sb_r;", sv_w(sw));
+    let _ = writeln!(o, "  logic sp_r;");
+    let _ = writeln!(o, "  always_ff @(posedge clk) begin");
+    let _ = writeln!(
+        o,
+        "    v_r <= v; inv_r <= inv; sb_r <= scale_byte; sp_r <= is_special;"
+    );
+    let _ = writeln!(o, "  end");
+    // ── staged multiplies ──
+    let _ = writeln!(o, "  logic {}prod [0:{}];", sv_w(32), n - 1);
+    let _ = writeln!(o, "  genvar g;");
+    let _ = writeln!(o, "  generate for (g = 0; g < {n}; g = g + 1) begin : muls");
+    let _ = writeln!(
+        o,
+        "    {mul_module} m (.clk(clk), .a(v_r[g*32 +: 32]), .b(inv_r), .y(prod[g]));"
+    );
+    let _ = writeln!(o, "  end endgenerate");
+    // ── meta carry: match the multiply's register-layer count ──
+    for k in 1..=mul_reg_layers {
+        let _ = writeln!(o, "  logic {}sb{k}; logic sp{k};", sv_w(sw));
+    }
+    let _ = writeln!(o, "  always_ff @(posedge clk) begin");
+    let _ = writeln!(o, "    sb1 <= sb_r; sp1 <= sp_r;");
+    for k in 2..=mul_reg_layers {
+        let _ = writeln!(o, "    sb{k} <= sb{}; sp{k} <= sp{};", k - 1, k - 1);
+    }
+    let _ = writeln!(o, "  end");
+    // ── stage B (comb): narrow + mask + pack ──
+    let _ = writeln!(o, "  logic {}r;", sv_w(bw));
+    let _ = writeln!(o, "  int unsigned j;");
+    let _ = writeln!(o, "  always_comb begin");
+    let _ = writeln!(o, "    r = {bw}'h0;");
+    let _ = writeln!(o, "    r[{}:{}] = sb{mul_reg_layers};", bw - 1, bw - sw);
+    let _ = writeln!(o, "    for (j = 0; j < {n}; j = j + 1) begin");
+    let _ = writeln!(
+        o,
+        "      r[j*{ew} +: {ew}] = sp{mul_reg_layers} ? {ew}'h0 : arch_f32_to_{tag}(prod[j]);"
+    );
+    let _ = writeln!(o, "    end");
+    let _ = writeln!(o, "  end");
+    let _ = writeln!(o, "  assign y = r;");
+    let _ = writeln!(o, "endmodule");
+    (name, o, binding_latency)
+}
+
 /// `scaled_quantize` for a scale with no exact reciprocal — see
+
 /// [`QuantKernel::BoundaryCompare`].
 ///
 /// Two constant-threshold ladders and not one division. Both compare FP32 bit

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1966,7 +1966,7 @@ impl Builder {
             }
             // Reads flow through the value being quantized; the format and
             // selectors are compile-time, not signal reads.
-            ExprKind::ScaledQuantize(v, _, _, _) => {
+            ExprKind::ScaledQuantize(v, _, _, _, _) => {
                 self.walk_expr(owner, rel, scope, v, use_kind);
             }
             ExprKind::PipelinedCall(_name, args, _stages) => {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -4904,7 +4904,37 @@ impl Parser {
                                     // selectors are optional and default to the OCP §6.3
                                     // policy with RNE.
                     let fmt = self.parse_type_expr()?;
-                    let (policy, rounding) = if self.eat(TokenKind::Comma) {
+                    // Trailing selectors after the mandatory format. Two
+                    // shapes: `, pipelined, N` (a latency-N staged datapath,
+                    // arch#955 — default policy/rounding) or the ordinary
+                    // `, policy, rounding` pair. Combining an explicit policy
+                    // with `pipelined` is a later extension.
+                    let mut stages: Option<u32> = None;
+                    let (policy, rounding) = if self.check(TokenKind::Comma)
+                        && self.peek_real_kind_at(1) == Some(TokenKind::Pipelined)
+                    {
+                        self.advance(); // `,`
+                        self.advance(); // `pipelined`
+                        self.expect(TokenKind::Comma)?;
+                        let depth_span = self.peek_span();
+                        let old_no_angle = self.no_angle;
+                        self.no_angle = true;
+                        let depth_expr = self.parse_expr()?;
+                        self.no_angle = old_no_angle;
+                        stages = Some(match &depth_expr.kind {
+                            ExprKind::Literal(LitKind::Dec(n))
+                            | ExprKind::Literal(LitKind::Hex(n))
+                            | ExprKind::Literal(LitKind::Bin(n))
+                            | ExprKind::Literal(LitKind::Sized(_, n)) => *n as u32,
+                            _ => {
+                                return Err(CompileError::general(
+                                    "`scaled_quantize<Fmt, pipelined, N>(v)` requires N to be a                                      compile-time integer literal",
+                                    depth_span,
+                                ))
+                            }
+                        });
+                        (None, RoundMode::Rne)
+                    } else if self.eat(TokenKind::Comma) {
                         let p = self.expect_ident()?;
                         self.expect(TokenKind::Comma)?;
                         let r = self.expect_ident()?;
@@ -4961,6 +4991,7 @@ impl Parser {
                             Box::new(fmt),
                             policy,
                             rounding,
+                            stages,
                         ),
                         span,
                         parenthesized: false,

--- a/src/pipelined_ops.rs
+++ b/src/pipelined_ops.rs
@@ -144,6 +144,23 @@ pub const FMA_F32_S6_SCHEDULE: StagedSchedule = StagedSchedule {
     callee_starts: &[0, 82, 103, 162, 175, 175, 175],
 };
 
+/// The builtin 4-stage `f32_mul` schedule (arch#955). Unlike the FMA
+/// schedule this was NOT hand-derived: `fp_ir::derive_leaf_schedule` produces
+/// it by gate-delay-weighted cut, and `f32_mul_s4_schedule_matches_derivation`
+/// pins that the committed cut points still match the derivation (re-run it if
+/// `fp_ops::f32_mul` changes). `f32_mul` is a zero-call leaf, so `callee` is
+/// empty and `callee_starts` is all-zero. Characterized at 652 MHz (Nangate45,
+/// the optimum — fmax regresses at N=5 because the 48-bit multiply is an
+/// atomic node that cannot be split further).
+pub const F32_MUL_S4_SCHEDULE: StagedSchedule = StagedSchedule {
+    main_fn: "arch_f32_mul",
+    callee: "",
+    sv_module: "ArchF32MulStaged4",
+    width: 32,
+    main_starts: &[0, 39, 80, 110, 143],
+    callee_starts: &[0, 0, 0, 0, 0],
+};
+
 /// Verification status of a registry entry.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum VerifyStatus {
@@ -492,7 +509,7 @@ fn scan_stmts(stmts: &[crate::ast::Stmt], out: &mut Vec<FoundPipelinedCall>) {
 fn scan_expr(expr: &crate::ast::Expr, out: &mut Vec<FoundPipelinedCall>) {
     use crate::ast::ExprKind::*;
     match &expr.kind {
-        ScaledQuantize(v, _, _, _) => scan_expr(v, out),
+        ScaledQuantize(v, _, _, _, _) => scan_expr(v, out),
         PipelinedCall(name, args, stages) => {
             out.push(FoundPipelinedCall {
                 operator: name.clone(),
@@ -593,6 +610,13 @@ fn scan_expr(expr: &crate::ast::Expr, out: &mut Vec<FoundPipelinedCall>) {
 ///   must fail loudly rather than silently falling back to an un-retimed
 ///   comb cone.
 fn resolve_codegen_impl(operator: &str, stages: u32) -> Result<&'static str, ()> {
+    // `scaled_dot` is a block builtin, not an FpFn registry row: its cascade
+    // (non-staged) form is just the comb `scaled_dot` call wrapped in the
+    // pipe_reg cascade (arch#955). Staged emission is handled separately by
+    // `lower_staged_dot_sites`; anything it leaves standing collapses here.
+    if operator == "scaled_dot" {
+        return Ok("scaled_dot");
+    }
     BUILTIN_REGISTRY
         .iter()
         .filter(|e| e.operator == operator && e.stages == stages)
@@ -670,6 +694,11 @@ pub struct StagedSite {
     pub ports: Vec<String>,
     /// Typechecked argument expressions, connected positionally to `ports`.
     pub args: Vec<crate::ast::Expr>,
+    /// The staged module references the shared fp-helper library
+    /// (`arch_f32_to_e8m0`, …) rather than being self-contained, so codegen
+    /// must emit that library even when no comb site pulled it in. True for
+    /// the block quantize; false for the inlined FMA / multiply modules.
+    pub needs_fp_lib: bool,
 }
 
 /// A `--staged-ops` site that fell back to the cascade emission, with the
@@ -706,6 +735,8 @@ pub fn lower_pipelined_calls_mode(
         for item in &mut source.items {
             if let Item::Module(m) = item {
                 lower_staged_sites(m, profile, &mut out);
+                lower_staged_quantize_sites(m, profile, &mut out);
+                lower_staged_dot_sites(m, &mut out);
             }
         }
     }
@@ -996,6 +1027,456 @@ fn lower_staged_sites(
             clk,
             ports: main_fn.params.iter().map(|(n, _)| n.clone()).collect(),
             args,
+            needs_fp_lib: false,
+        });
+    }
+}
+
+/// Staged lowering for `X_stg1 <= scaled_quantize<Fmt, pipelined, N>(v)`
+/// (arch#955) — the block-operator analogue of [`lower_staged_sites`], which
+/// is scalar-FpFn-only and cannot handle a Vec-in/ScaledVec-out block op.
+///
+/// Mirrors the FMA rewrite: the pipe_reg cascade `X_stg1..X_stg{N-1}` (emitted
+/// by elaborate, RHS-agnostic) collapses to a 1-bit validity chain, and the
+/// staged quantize module drives the output register through `X <= valid ?
+/// wire : reset`. Two SV modules are recorded: the per-shape staged quantize
+/// and the shared `ArchF32MulStaged4` dependency (empty-instance site → emitted
+/// once, no instance).
+fn lower_staged_quantize_sites(
+    m: &mut crate::ast::ModuleDecl,
+    profile: crate::FpCompat,
+    out: &mut PipelinedLowering,
+) {
+    use crate::ast::{ClockEdge, Expr, ExprKind, ModuleBodyItem, RegReset, Stmt, TypeExpr};
+
+    struct QCand {
+        base: String,
+        n: u32,
+        span: crate::lexer::Span,
+    }
+    let mut cands: Vec<QCand> = Vec::new();
+    for bi in &m.body {
+        let ModuleBodyItem::RegBlock(rb) = bi else {
+            continue;
+        };
+        for s in &rb.stmts {
+            let Stmt::Assign(a) = s else { continue };
+            let ExprKind::ScaledQuantize(v, fmt, _, _, Some(n)) = &a.value.kind else {
+                continue;
+            };
+            let ExprKind::Ident(t) = &a.target.kind else {
+                continue;
+            };
+            let Some(base) = t.strip_suffix("_stg1") else {
+                continue;
+            };
+            // Only eligible sites are claimed; the rest fall back to the comb
+            // cascade via `lower_expr`'s stage-strip.
+            let Some(shape) = crate::fp_block::shape_of_type(fmt) else {
+                continue;
+            };
+            if !crate::fp_block::staged_quantize_supported(shape) {
+                continue;
+            }
+            if *n != crate::fp_block::staged_quantize_binding_latency() {
+                continue;
+            }
+            if rb.clock_edge == ClockEdge::Falling {
+                continue;
+            }
+            if crate::fp_ir::render_sv_staged(
+                &crate::fp_ops::fp_functions(profile)
+                    .into_iter()
+                    .find(|f| f.name == "arch_f32_mul")
+                    .unwrap(),
+                None,
+                &F32_MUL_S4_SCHEDULE,
+                F32_MUL_S4_SCHEDULE.sv_module,
+            )
+            .is_err()
+            {
+                continue;
+            }
+            let _ = v;
+            cands.push(QCand {
+                base: base.to_owned(),
+                n: *n,
+                span: a.span,
+            });
+        }
+    }
+
+    for cand in cands {
+        // Re-fetch the site's fmt/policy/round/operand from the AST (the
+        // collect loop borrowed immutably).
+        let mut shape_pol: Option<(
+            crate::fp_block::BlockShape,
+            crate::ast::ScalePolicy,
+            crate::ast::RoundMode,
+            Expr,
+        )> = None;
+        for bi in &m.body {
+            let ModuleBodyItem::RegBlock(rb) = bi else {
+                continue;
+            };
+            for s in &rb.stmts {
+                let Stmt::Assign(a) = s else { continue };
+                if let ExprKind::ScaledQuantize(v, fmt, pol, rnd, Some(_)) = &a.value.kind {
+                    if let ExprKind::Ident(t) = &a.target.kind {
+                        if t.strip_suffix("_stg1") == Some(cand.base.as_str()) {
+                            let shape = crate::fp_block::shape_of_type(fmt).unwrap();
+                            let policy = pol.unwrap_or_else(|| shape.scale.default_policy());
+                            shape_pol = Some((shape, policy, *rnd, (**v).clone()));
+                        }
+                    }
+                }
+            }
+        }
+        let Some((shape, policy, round, v_expr)) = shape_pol else {
+            continue;
+        };
+
+        let (qname, qsv, _blat) = crate::fp_block::sv_staged_quantize(shape, policy, round);
+        let mul_sv = crate::fp_ir::render_sv_staged(
+            &crate::fp_ops::fp_functions(profile)
+                .into_iter()
+                .find(|f| f.name == "arch_f32_mul")
+                .unwrap(),
+            None,
+            &F32_MUL_S4_SCHEDULE,
+            F32_MUL_S4_SCHEDULE.sv_module,
+        )
+        .unwrap();
+
+        let port_reset_val: Option<Expr> = m
+            .ports
+            .iter()
+            .find(|p| p.name.name == cand.base)
+            .and_then(|p| p.reg_info.as_ref())
+            .and_then(|ri| match &ri.reset {
+                RegReset::None => None,
+                RegReset::Inherit(_, val) | RegReset::Explicit(_, _, _, val) => Some(val.clone()),
+            });
+
+        let idx = out
+            .staged_sites
+            .iter()
+            .filter(|s| s.module_name == m.name.name)
+            .count();
+        let instance = format!("__staged_sq_{idx}");
+        let wire = format!("{instance}_y");
+        let span = cand.span;
+        let mk = |kind: ExprKind| Expr {
+            kind,
+            span,
+            parenthesized: false,
+        };
+
+        let last_stg = format!("{}_stg{}", cand.base, cand.n - 1);
+        let mut clk: Option<String> = None;
+        let mut rewrote_last = false;
+        for bi in &mut m.body {
+            match bi {
+                ModuleBodyItem::RegDecl(r)
+                    if r.name
+                        .name
+                        .strip_prefix(&format!("{}_stg", cand.base))
+                        .is_some_and(|k| k.parse::<u32>().is_ok_and(|k| k >= 1 && k < cand.n)) =>
+                {
+                    r.ty = TypeExpr::Bool;
+                    match &mut r.reset {
+                        RegReset::None => {}
+                        RegReset::Inherit(_, val) | RegReset::Explicit(_, _, _, val) => {
+                            *val = mk(ExprKind::Bool(false));
+                        }
+                    }
+                    if r.init.is_some() {
+                        r.init = Some(mk(ExprKind::Bool(false)));
+                    }
+                }
+                ModuleBodyItem::RegBlock(rb) => {
+                    for s in &mut rb.stmts {
+                        let Stmt::Assign(a) = s else { continue };
+                        let ExprKind::Ident(t) = &a.target.kind else {
+                            continue;
+                        };
+                        if *t == format!("{}_stg1", cand.base)
+                            && matches!(a.value.kind, ExprKind::ScaledQuantize(_, _, _, _, Some(_)))
+                        {
+                            a.value = mk(ExprKind::Bool(true));
+                            clk = Some(rb.clock.name.clone());
+                        } else if *t == cand.base {
+                            if let ExprKind::Ident(src) = &a.value.kind {
+                                if *src == last_stg {
+                                    let fallback = port_reset_val
+                                        .clone()
+                                        .unwrap_or_else(|| mk(ExprKind::Bool(false)));
+                                    a.value = mk(ExprKind::Ternary(
+                                        Box::new(mk(ExprKind::Ident(src.clone()))),
+                                        Box::new(mk(ExprKind::Ident(wire.clone()))),
+                                        Box::new(fallback),
+                                    ));
+                                    rewrote_last = true;
+                                }
+                            }
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+        let (Some(clk), true) = (clk, rewrote_last) else {
+            out.fallbacks.push(StagedFallback {
+                operator: "scaled_quantize".to_string(),
+                stages: cand.n,
+                reason: "quantize cascade shape not recognized (rewrite incomplete)".to_string(),
+                span: cand.span,
+            });
+            continue;
+        };
+        // Shared multiply dependency: empty instance → emitted once, no instance.
+        out.staged_sites.push(StagedSite {
+            module_name: m.name.name.clone(),
+            sv_module: F32_MUL_S4_SCHEDULE.sv_module,
+            sv_text: mul_sv,
+            instance: String::new(),
+            wire: String::new(),
+            width: 32,
+            clk: clk.clone(),
+            ports: Vec::new(),
+            args: Vec::new(),
+            needs_fp_lib: false,
+        });
+        // The staged quantize module + its instance.
+        let qname_static: &'static str = Box::leak(qname.into_boxed_str());
+        out.staged_sites.push(StagedSite {
+            module_name: m.name.name.clone(),
+            sv_module: qname_static,
+            sv_text: qsv,
+            instance,
+            wire,
+            width: shape.bits(),
+            clk,
+            ports: vec!["v".to_string()],
+            args: vec![v_expr],
+            needs_fp_lib: true,
+        });
+    }
+}
+
+/// Resolve the `BlockShape` of a `scaled_dot` operand by looking its declared
+/// type up in the module (port / wire / reg / let). The staged-dot lowering
+/// needs the shape, which — unlike `scaled_quantize`'s explicit format — lives
+/// on the operand's type, not the call node.
+fn ident_block_shape(
+    m: &crate::ast::ModuleDecl,
+    e: &crate::ast::Expr,
+) -> Option<crate::fp_block::BlockShape> {
+    use crate::ast::{ExprKind, ModuleBodyItem};
+    let ExprKind::Ident(nm) = &e.kind else {
+        return None;
+    };
+    for p in &m.ports {
+        if p.name.name == *nm {
+            return crate::fp_block::shape_of_type(&p.ty);
+        }
+    }
+    for bi in &m.body {
+        match bi {
+            ModuleBodyItem::WireDecl(w) if w.name.name == *nm => {
+                return crate::fp_block::shape_of_type(&w.ty);
+            }
+            ModuleBodyItem::RegDecl(r) if r.name.name == *nm => {
+                return crate::fp_block::shape_of_type(&r.ty);
+            }
+            ModuleBodyItem::LetBinding(l) if l.name.name == *nm => {
+                return l.ty.as_ref().and_then(crate::fp_block::shape_of_type);
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+/// Staged lowering for `X_stg1 <= scaled_dot<pipelined, N>(a, b)` (arch#955),
+/// the block-dot analogue of [`lower_staged_quantize_sites`]. The RHS is a
+/// generic `PipelinedCall("scaled_dot", [a, b], N)` (no dedicated AST node —
+/// the surface reuses the `Name<pipelined, N>` parse). Same cascade->validity
+/// rewrite as the FMA/quantize; the staged dot module needs the shared fp
+/// helper library (needs_fp_lib) and has no `ArchF32MulStaged4` dependency
+/// (coarse pipelining uses comb f32 ops per stage).
+fn lower_staged_dot_sites(m: &mut crate::ast::ModuleDecl, out: &mut PipelinedLowering) {
+    use crate::ast::{ClockEdge, Expr, ExprKind, ModuleBodyItem, RegReset, Stmt, TypeExpr};
+
+    struct DCand {
+        base: String,
+        n: u32,
+        span: crate::lexer::Span,
+    }
+    let mut cands: Vec<DCand> = Vec::new();
+    for bi in &m.body {
+        let ModuleBodyItem::RegBlock(rb) = bi else {
+            continue;
+        };
+        for s in &rb.stmts {
+            let Stmt::Assign(a) = s else { continue };
+            let ExprKind::PipelinedCall(op, args, n) = &a.value.kind else {
+                continue;
+            };
+            if op != "scaled_dot" || args.len() != 2 {
+                continue;
+            }
+            let ExprKind::Ident(t) = &a.target.kind else {
+                continue;
+            };
+            let Some(base) = t.strip_suffix("_stg1") else {
+                continue;
+            };
+            let Some(shape) = ident_block_shape(m, &args[0]) else {
+                continue;
+            };
+            if !crate::fp_block::staged_quantize_supported(shape) {
+                continue;
+            }
+            if *n != crate::fp_block::staged_dot_binding_latency(shape.n) {
+                continue;
+            }
+            if rb.clock_edge == ClockEdge::Falling {
+                continue;
+            }
+            cands.push(DCand {
+                base: base.to_owned(),
+                n: *n,
+                span: a.span,
+            });
+        }
+    }
+
+    for cand in cands {
+        // Re-fetch shape + operand exprs.
+        let mut found: Option<(crate::fp_block::BlockShape, Expr, Expr)> = None;
+        for bi in &m.body {
+            let ModuleBodyItem::RegBlock(rb) = bi else {
+                continue;
+            };
+            for s in &rb.stmts {
+                let Stmt::Assign(a) = s else { continue };
+                if let ExprKind::PipelinedCall(op, args, _) = &a.value.kind {
+                    if op == "scaled_dot" && args.len() == 2 {
+                        if let ExprKind::Ident(t) = &a.target.kind {
+                            if t.strip_suffix("_stg1") == Some(cand.base.as_str()) {
+                                if let Some(shape) = ident_block_shape(m, &args[0]) {
+                                    found = Some((shape, args[0].clone(), args[1].clone()));
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        let Some((shape, a_expr, b_expr)) = found else {
+            continue;
+        };
+        let (dname, dsv, _lat) = crate::fp_block::sv_staged_dot(shape);
+
+        let port_reset_val: Option<Expr> = m
+            .ports
+            .iter()
+            .find(|p| p.name.name == cand.base)
+            .and_then(|p| p.reg_info.as_ref())
+            .and_then(|ri| match &ri.reset {
+                RegReset::None => None,
+                RegReset::Inherit(_, v) | RegReset::Explicit(_, _, _, v) => Some(v.clone()),
+            });
+
+        let idx = out
+            .staged_sites
+            .iter()
+            .filter(|s| s.module_name == m.name.name)
+            .count();
+        let instance = format!("__staged_dot_{idx}");
+        let wire = format!("{instance}_y");
+        let span = cand.span;
+        let mk = |kind: ExprKind| Expr {
+            kind,
+            span,
+            parenthesized: false,
+        };
+
+        let last_stg = format!("{}_stg{}", cand.base, cand.n - 1);
+        let mut clk: Option<String> = None;
+        let mut rewrote_last = false;
+        for bi in &mut m.body {
+            match bi {
+                ModuleBodyItem::RegDecl(r)
+                    if r.name
+                        .name
+                        .strip_prefix(&format!("{}_stg", cand.base))
+                        .is_some_and(|k| k.parse::<u32>().is_ok_and(|k| k >= 1 && k < cand.n)) =>
+                {
+                    r.ty = TypeExpr::Bool;
+                    match &mut r.reset {
+                        RegReset::None => {}
+                        RegReset::Inherit(_, v) | RegReset::Explicit(_, _, _, v) => {
+                            *v = mk(ExprKind::Bool(false));
+                        }
+                    }
+                    if r.init.is_some() {
+                        r.init = Some(mk(ExprKind::Bool(false)));
+                    }
+                }
+                ModuleBodyItem::RegBlock(rb) => {
+                    for s in &mut rb.stmts {
+                        let Stmt::Assign(a) = s else { continue };
+                        let ExprKind::Ident(t) = &a.target.kind else {
+                            continue;
+                        };
+                        if *t == format!("{}_stg1", cand.base)
+                            && matches!(&a.value.kind, ExprKind::PipelinedCall(op, _, _) if op == "scaled_dot")
+                        {
+                            a.value = mk(ExprKind::Bool(true));
+                            clk = Some(rb.clock.name.clone());
+                        } else if *t == cand.base {
+                            if let ExprKind::Ident(src) = &a.value.kind {
+                                if *src == last_stg {
+                                    let fallback = port_reset_val
+                                        .clone()
+                                        .unwrap_or_else(|| mk(ExprKind::Bool(false)));
+                                    a.value = mk(ExprKind::Ternary(
+                                        Box::new(mk(ExprKind::Ident(src.clone()))),
+                                        Box::new(mk(ExprKind::Ident(wire.clone()))),
+                                        Box::new(fallback),
+                                    ));
+                                    rewrote_last = true;
+                                }
+                            }
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+        let (Some(clk), true) = (clk, rewrote_last) else {
+            out.fallbacks.push(StagedFallback {
+                operator: "scaled_dot".to_string(),
+                stages: cand.n,
+                reason: "dot cascade shape not recognized (rewrite incomplete)".to_string(),
+                span: cand.span,
+            });
+            continue;
+        };
+        let dname_static: &'static str = Box::leak(dname.into_boxed_str());
+        out.staged_sites.push(StagedSite {
+            module_name: m.name.name.clone(),
+            sv_module: dname_static,
+            sv_text: dsv,
+            instance,
+            wire,
+            width: 32,
+            clk,
+            ports: vec!["a".to_string(), "b".to_string()],
+            args: vec![a_expr, b_expr],
+            needs_fp_lib: true,
         });
     }
 }
@@ -1050,7 +1531,14 @@ fn lower_expr(expr: &mut crate::ast::Expr) -> Result<(), FoundPipelinedCall> {
     // larger expression (not just the direct RHS of a cascade stage) is
     // also lowered — matches `scan_expr`'s traversal shape.
     match &mut expr.kind {
-        ScaledQuantize(v, _, _, _) => lower_expr(v)?,
+        ScaledQuantize(v, _, _, _, stages) => {
+            // Any pipelined quantize still standing here was NOT claimed by
+            // `lower_staged_quantize_sites` (falling clock, conditional, …):
+            // drop the staging so it lowers as the comb value inside the
+            // ordinary pipe_reg cascade (correct latency, just un-retimed).
+            *stages = None;
+            lower_expr(v)?
+        }
         Binary(_, a, b) => {
             lower_expr(a)?;
             lower_expr(b)?;
@@ -1160,6 +1648,22 @@ fn lower_expr(expr: &mut crate::ast::Expr) -> Result<(), FoundPipelinedCall> {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn f32_mul_s4_schedule_matches_derivation() {
+        // The committed const must equal what the gate-weighted scheduler
+        // derives from the current `fp_ops::f32_mul` (arch#955). If `f32_mul`
+        // changes and this fails, re-derive: paste `derive_leaf_schedule`'s
+        // output into `F32_MUL_S4_SCHEDULE.main_starts`.
+        let funcs = crate::fp_ops::fp_functions(crate::FpCompat::default());
+        let mul = funcs.iter().find(|f| f.name == "arch_f32_mul").unwrap();
+        let derived = crate::fp_ir::derive_leaf_schedule(mul, 4).unwrap();
+        assert_eq!(
+            derived.as_slice(),
+            super::F32_MUL_S4_SCHEDULE.main_starts,
+            "f32_mul S4 schedule drifted; re-derive and update the const"
+        );
+    }
+
     use super::*;
 
     #[test]

--- a/src/sim_codegen/stmt_codegen.rs
+++ b/src/sim_codegen/stmt_codegen.rs
@@ -56,7 +56,11 @@ fn emit_scaled_block_assign(
     indent: usize,
 ) -> Option<()> {
     match &a.value.kind {
-        ExprKind::ScaledQuantize(v, fmt, policy, round) => {
+        ExprKind::ScaledQuantize(v, fmt, policy, round, stages) => {
+            assert!(
+                stages.is_none(),
+                "scaled_quantize<pipelined, N> is not supported in native sim yet (arch#955)"
+            );
             let shape = crate::fp_block::shape_of_type(fmt.as_ref()).unwrap_or_else(|| {
                 panic!(
                     "scaled_quantize format has no resolvable block shape — typecheck \

--- a/src/thread_map.rs
+++ b/src/thread_map.rs
@@ -205,7 +205,7 @@ pub fn expr_label(expr: &Expr) -> String {
             let args = args.iter().map(expr_label).collect::<Vec<_>>().join(", ");
             format!("{}({})", name, args)
         }
-        ExprKind::ScaledQuantize(v, _, _, _) => {
+        ExprKind::ScaledQuantize(v, _, _, _, _) => {
             format!("scaled_quantize({})", expr_label(v))
         }
         ExprKind::PipelinedCall(name, args, stages) => {

--- a/src/type_alias.rs
+++ b/src/type_alias.rs
@@ -572,7 +572,7 @@ fn substitute_in_expr(e: &mut Expr, aliases: &AliasMap, errors: &mut Vec<Compile
         // expression. Without this arm `scaled_quantize<MXFP4>(v)` keeps a
         // dangling `Named("MXFP4")` that no later pass can resolve — the
         // aliases are substituted and then removed before typecheck runs.
-        ExprKind::ScaledQuantize(value, fmt, _, _) => {
+        ExprKind::ScaledQuantize(value, fmt, _, _, _) => {
             substitute_in_expr(value, aliases, errors);
             substitute_type(fmt.as_mut(), aliases, errors);
         }

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -4023,8 +4023,9 @@ impl<'a> TypeChecker<'a> {
     fn expr_latency_tc(expr: &Expr) -> u32 {
         match &expr.kind {
             ExprKind::PipelinedCall(_, _, n) => *n,
-            // Combinational: the block quantizer adds no pipeline stages.
-            ExprKind::ScaledQuantize(_, _, _, _) => 0,
+            // `scaled_quantize<Fmt, pipelined, N>` carries latency N; the
+            // bare comb form adds no pipeline stages (arch#955).
+            ExprKind::ScaledQuantize(_, _, _, _, stages) => stages.unwrap_or(0),
             ExprKind::LatencyAt(_, n) => *n,
             _ => 0,
         }
@@ -4040,7 +4041,7 @@ impl<'a> TypeChecker<'a> {
         match &expr.kind {
             ExprKind::PipelinedCall(_, _, _) => true,
             // Not a pipelined call; recurse into the value being quantized.
-            ExprKind::ScaledQuantize(v, _, _, _) => Self::expr_contains_pipelined_call(v),
+            ExprKind::ScaledQuantize(v, _, _, _, _) => Self::expr_contains_pipelined_call(v),
             ExprKind::Binary(_, a, b) => {
                 Self::expr_contains_pipelined_call(a) || Self::expr_contains_pipelined_call(b)
             }
@@ -4173,6 +4174,69 @@ impl<'a> TypeChecker<'a> {
         module_name: &str,
         local_types: &HashMap<String, Ty>,
     ) -> Ty {
+        if name == "scaled_dot" {
+            // `scaled_dot<pipelined, N>(a, b) -> FP32` (arch#955): same operand
+            // rule as the comb form (two matching ScaledVec blocks), plus the
+            // staged datapath's fixed latency and E8M0-scale-only support.
+            if call_args.len() != 2 {
+                self.errors.push(CompileError::general(
+                    "`scaled_dot<pipelined, N>(a, b)` takes exactly 2 arguments (two blocks)",
+                    span,
+                ));
+                return Ty::Error;
+            }
+            let at = self.resolve_expr_type(&call_args[0], module_name, local_types);
+            let bt = self.resolve_expr_type(&call_args[1], module_name, local_types);
+            if matches!(at, Ty::Todo | Ty::Error) || matches!(bt, Ty::Todo | Ty::Error) {
+                return Ty::Error;
+            }
+            let (Ty::ScaledVec(_, an, ascale), Ty::ScaledVec(..)) = (&at, &bt) else {
+                self.errors.push(CompileError::general(
+                    &format!(
+                        "`scaled_dot<pipelined, N>` requires `ScaledVec` operands, got {} and {}",
+                        at.display(),
+                        bt.display()
+                    ),
+                    span,
+                ));
+                return Ty::Error;
+            };
+            if at != bt {
+                self.errors.push(CompileError::general(
+                    &format!(
+                        "`scaled_dot<pipelined, N>` requires matching block types: {} vs {}",
+                        at.display(),
+                        bt.display()
+                    ),
+                    span,
+                ));
+                return Ty::Error;
+            }
+            if **ascale != Ty::E8M0 {
+                self.errors.push(CompileError::general(
+                    "`scaled_dot<pipelined, N>` is implemented for E8M0 block scales only \
+                     today (arch#955)",
+                    span,
+                ));
+                return Ty::Error;
+            }
+            let want = crate::fp_block::staged_dot_binding_latency(*an);
+            if stages != want {
+                self.errors.push(CompileError::general(
+                    &format!(
+                        "`scaled_dot<pipelined, {stages}>` has a fixed latency of {want} for this \
+                         block size (one product stage + {} reduction levels + a scale stage + \
+                         the output register); write `pipelined, {want}`.",
+                        want - 3
+                    ),
+                    span,
+                ));
+                return Ty::Error;
+            }
+            let arg_refs: Vec<&Expr> = call_args.iter().collect();
+            self.check_operand_latency_alignment(&arg_refs, span);
+            return Ty::FP32;
+        }
         if name != "fma" {
             self.errors.push(CompileError::general(
                 &format!(
@@ -4327,7 +4391,33 @@ impl<'a> TypeChecker<'a> {
             // `scaled_quantize<Fmt, policy, rounding>(v)` — the output format
             // is named at the call site, never inferred: a `Vec<FP32,N>`
             // argument says nothing about the element format or scale.
-            ExprKind::ScaledQuantize(v, fmt, policy, rounding) => {
+            ExprKind::ScaledQuantize(v, fmt, policy, rounding, stages) => {
+                if let Some(n) = stages {
+                    let want = crate::fp_block::staged_quantize_binding_latency();
+                    if let Some(sh) = crate::fp_block::shape_of_type(fmt) {
+                        if !crate::fp_block::staged_quantize_supported(sh) {
+                            self.errors.push(CompileError::general(
+                                "`scaled_quantize<Fmt, pipelined, N>` is implemented for E8M0 \
+                                 block scales only today (arch#955); this format's scale needs \
+                                 the boundary-compare quantizer, which is a follow-up.",
+                                expr.span,
+                            ));
+                        }
+                    }
+                    if *n != want {
+                        let mstages =
+                            crate::pipelined_ops::F32_MUL_S4_SCHEDULE.main_starts.len() - 1;
+                        self.errors.push(CompileError::general(
+                            &format!(
+                                "`scaled_quantize<Fmt, pipelined, {n}>(v)` — the staged block \
+                                 quantizer has a fixed latency of {want} (one scale stage + the \
+                                 {mstages}-stage multiply + the output register); write \
+                                 `pipelined, {want}`."
+                            ),
+                            expr.span,
+                        ));
+                    }
+                }
                 let vt = self.resolve_expr_type(v, module_name, local_types);
                 let n_in = match &vt {
                     Ty::Vec(elem, n) if **elem == Ty::FP32 => Some(*n),

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -4220,6 +4220,31 @@ impl<'a> TypeChecker<'a> {
                 ));
                 return Ty::Error;
             }
+            // The coarse per-level staging pipelines the `f32_add` reduction
+            // tree one level per stage. That is latency-uniform only when the
+            // tree is perfectly balanced — i.e. a power-of-two block size. For a
+            // non-power-of-two count, `dot_schedule` carries an odd element
+            // across a round rather than padding with zero (padding would turn
+            // -0.0 into +0.0), so that element crosses fewer register edges than
+            // its siblings and reaches the scale multiply a cycle early — a
+            // silent miscompile invisible to stable-input testing (the
+            // structural balance check in tests/fp_v1/synth/pipeline_balance.py
+            // reports it as UNBALANCED [k-1, k]). Reject it rather than emit a
+            // skewed pipeline; the combinational `scaled_dot` handles any N.
+            if !(*an).is_power_of_two() {
+                self.errors.push(CompileError::general(
+                    &format!(
+                        "`scaled_dot<pipelined, N>` requires a power-of-two block size, got \
+                         {an}. The staged reduction tree only stays latency-balanced when every \
+                         element crosses the same number of adder stages; a non-power-of-two \
+                         block carries an odd element across levels and skews the pipeline. Use a \
+                         power-of-two block size, or the combinational `scaled_dot` (drop \
+                         `pipelined`), which handles any N."
+                    ),
+                    span,
+                ));
+                return Ty::Error;
+            }
             let want = crate::fp_block::staged_dot_binding_latency(*an);
             if stages != want {
                 self.errors.push(CompileError::general(

--- a/tests/staged_dot_lockstep_test.rs
+++ b/tests/staged_dot_lockstep_test.rs
@@ -158,3 +158,62 @@ fn staged_dot_throughput_lockstep_verilator() {
         "sim produced no non-zero output (vacuous):\n{txt}"
     );
 }
+
+// ── Power-of-two block-size guard (typecheck) ───────────────────────────────
+// The coarse per-level staging pipelines the reduction tree one level per
+// stage, which is latency-balanced only for a power-of-two block size. A
+// non-power-of-two count carries an odd element across levels and skews the
+// pipeline (a silent miscompile invisible to stable-input testing — the
+// structural balance check reports UNBALANCED). The type checker rejects it.
+
+/// Build `scaled_dot<pipelined, N>` over a block of `n` elements at latency
+/// `lat`; return the combined `arch check` output and whether it succeeded.
+fn check_dot(n: u32, lat: u32) -> (bool, String) {
+    let td = tempfile::tempdir().expect("tempdir");
+    let path = td.path().join("d.arch");
+    std::fs::write(
+        &path,
+        format!(
+            "package DF\n  type Bn = ScaledVec<FP4E2M1, {n}, E8M0>;\nend package DF\n\
+             module Dot\n  port clk: in Clock<Sys>;\n  port rst: in Reset<Sync, High>;\n\
+             \x20 port a: in Bn;\n  port b: in Bn;\n\
+             \x20 port o: out pipe_reg<FP32, {lat}> reset rst => 0.0;\n\
+             \x20 seq on clk rising\n    o@{lat} <= scaled_dot<pipelined, {lat}>(a, b);\n\
+             \x20 end seq\nend module Dot\n"
+        ),
+    )
+    .unwrap();
+    let out = arch().arg("check").arg(&path).output().expect("run check");
+    let merged = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    (out.status.success(), merged)
+}
+
+#[test]
+fn staged_dot_rejects_non_power_of_two_block() {
+    // N=8 (tree depth 3, latency 6) is a power of two → accepted.
+    let (ok8, _) = check_dot(8, 6);
+    assert!(ok8, "power-of-two block size (8) must be accepted");
+
+    // N=6 is not a power of two → rejected with the power-of-two message,
+    // NOT silently emitted as a skewed pipeline.
+    let (ok6, out6) = check_dot(6, 6);
+    assert!(
+        !ok6,
+        "non-power-of-two block size (6) must be rejected:\n{out6}"
+    );
+    assert!(
+        out6.contains("power-of-two block size"),
+        "rejection must name the power-of-two rule:\n{out6}"
+    );
+
+    // N=12 too (a larger non-power-of-two).
+    let (ok12, out12) = check_dot(12, 7);
+    assert!(
+        !ok12,
+        "non-power-of-two block size (12) must be rejected:\n{out12}"
+    );
+}

--- a/tests/staged_dot_lockstep_test.rs
+++ b/tests/staged_dot_lockstep_test.rs
@@ -1,0 +1,160 @@
+//! `scaled_dot<pipelined, N>` staged datapath — throughput lockstep (arch#955).
+//! Builds one `scaled_dot` design two ways — `--staged-ops` (the retimed
+//! coarse-per-level pipeline) and default (comb + pipe_reg cascade) — and drives
+//! both with identical back-to-back random stimulus in Verilator, comparing
+//! every cycle. A new block pair enters every cycle (II=1); staged output must
+//! equal cascade output bit-for-bit.
+//!
+//! Verilator, not iverilog (iverilog mis-simulates the staged fp helpers).
+//! Skips cleanly when Verilator is absent.
+
+use std::process::Command;
+
+fn arch() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_arch"))
+}
+fn verilator_available() -> bool {
+    Command::new("verilator")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+// B4 = ScaledVec<FP4E2M1, 8, E8M0>: tree depth 3 → binding latency 6.
+const SRC: &str = r#"
+package DF
+  type B4 = ScaledVec<FP4E2M1, 8, E8M0>;
+end package DF
+module PD
+  port clk: in Clock<Sys>;
+  port rst: in Reset<Sync, High>;
+  port a: in B4;
+  port b: in B4;
+  port o: out pipe_reg<FP32, 6> reset rst => 0.0;
+  seq on clk rising
+    o@6 <= scaled_dot<pipelined, 6>(a, b);
+  end seq
+end module PD
+"#;
+
+fn combine(cascade: &str, staged: &str) -> String {
+    let ci = cascade.find("\nmodule PD").expect("cascade module PD");
+    let lib = &cascade[..ci];
+    let pq_ca = cascade[ci..]
+        .replacen("module PD ", "module PD_ca ", 1)
+        .replacen("module PD(", "module PD_ca(", 1);
+    let si = staged
+        .find("module arch_scaled_dot")
+        .expect("staged dot module");
+    let pj = staged.find("\nmodule PD").expect("staged module PD");
+    let sm = &staged[si..pj];
+    let pq_st = staged[pj..]
+        .replacen("module PD ", "module PD_st ", 1)
+        .replacen("module PD(", "module PD_st(", 1);
+    let wrap = "module Wrap(input logic clk, input logic rst, input logic [39:0] a, \
+                input logic [39:0] b, output logic [31:0] os, output logic [31:0] oc);\n\
+                \x20 PD_st st(.clk(clk),.rst(rst),.a(a),.b(b),.o(os));\n\
+                \x20 PD_ca ca(.clk(clk),.rst(rst),.a(a),.b(b),.o(oc));\nendmodule\n";
+    let combined = format!("{lib}\n{sm}\n{pq_ca}\n{pq_st}\n{wrap}");
+    let mut out = String::new();
+    let mut rest = combined.as_str();
+    while let Some(p) = rest.find("package DF;") {
+        out.push_str(&rest[..p]);
+        let after = &rest[p..];
+        let e = after
+            .find("endpackage")
+            .map(|e| e + "endpackage".len())
+            .unwrap_or(after.len());
+        rest = &after[e..];
+    }
+    out.push_str(rest);
+    out
+}
+
+const TB: &str = r#"#include "VWrap.h"
+#include "verilated.h"
+#include <cstdio>
+#include <cstdlib>
+int main(int c,char**v){ Verilated::commandArgs(c,v); VWrap*d=new VWrap;
+  auto tick=[&](){d->clk=0;d->eval();d->clk=1;d->eval();};
+  auto vscale=[&]()->uint64_t{return 0x40+(rand()%0x7E);}; // valid non-NaN E8M0
+  auto setab=[&](){ d->a=(vscale()<<32)|(((uint64_t)rand())&0xFFFFFFFFULL); d->b=(vscale()<<32)|(((uint64_t)rand())&0xFFFFFFFFULL); };
+  d->rst=1; for(int i=0;i<8;i++){setab();tick();} d->rst=0;
+  for(int i=0;i<16;i++){setab();tick();}
+  int mism=0; unsigned long long nz=0;
+  for(int i=0;i<3000;i++){ setab(); tick(); if(d->oc!=0)nz++;
+    if(d->os!=d->oc){ mism++; if(mism<6) printf("MISM i=%d os=%08x oc=%08x\n",i,d->os,d->oc); } }
+  printf("DOTDONE mism=%d nonzero=%llu\n", mism, nz);
+  delete d; return mism==0?0:1; }
+"#;
+
+#[test]
+fn staged_dot_throughput_lockstep_verilator() {
+    if !verilator_available() {
+        eprintln!("verilator not in PATH; skipping staged-dot throughput lockstep");
+        return;
+    }
+    let td = tempfile::tempdir().expect("tempdir");
+    let ap = td.path().join("PD.arch");
+    std::fs::write(&ap, SRC).unwrap();
+    let build = |staged: bool| -> String {
+        let out = td.path().join(if staged { "s.sv" } else { "c.sv" });
+        let mut c = arch();
+        c.arg("build")
+            .arg(&ap)
+            .arg("-o")
+            .arg(&out)
+            .arg("--no-auto-asserts");
+        if staged {
+            c.arg("--staged-ops");
+        }
+        let o = c.output().expect("arch build");
+        assert!(
+            o.status.success(),
+            "arch build failed:\n{}",
+            String::from_utf8_lossy(&o.stderr)
+        );
+        std::fs::read_to_string(&out).unwrap()
+    };
+    let combined = combine(&build(false), &build(true));
+    let sv = td.path().join("combined.sv");
+    std::fs::write(&sv, combined).unwrap();
+    let tb = td.path().join("tb.cpp");
+    std::fs::write(&tb, TB).unwrap();
+    let obj = td.path().join("obj_dir");
+    let vout = Command::new("verilator")
+        .args([
+            "--cc",
+            "--exe",
+            "--build",
+            "--sv",
+            "-Wno-fatal",
+            "-Wno-WIDTH",
+            "-Wno-UNOPTFLAT",
+            "--top-module",
+            "Wrap",
+            "-Mdir",
+        ])
+        .arg(&obj)
+        .arg(&sv)
+        .arg(&tb)
+        .output()
+        .expect("verilate");
+    assert!(
+        vout.status.success(),
+        "verilate failed:\n{}\n{}",
+        String::from_utf8_lossy(&vout.stdout),
+        String::from_utf8_lossy(&vout.stderr)
+    );
+    let run = Command::new(obj.join("VWrap")).output().expect("run");
+    let txt = String::from_utf8_lossy(&run.stdout);
+    assert!(
+        run.status.success(),
+        "staged dot throughput lockstep FAILED:\n{txt}"
+    );
+    assert!(
+        txt.contains("nonzero=") && !txt.contains("nonzero=0\n"),
+        "sim produced no non-zero output (vacuous):\n{txt}"
+    );
+}

--- a/tests/staged_quantize_lockstep_test.rs
+++ b/tests/staged_quantize_lockstep_test.rs
@@ -1,0 +1,167 @@
+//! `scaled_quantize<Fmt, pipelined, N>` staged datapath — throughput lockstep
+//! (arch#955). Builds one design two ways — `--staged-ops` (the retimed staged
+//! block) and default (the comb+cascade form) — and drives both with the SAME
+//! back-to-back random stimulus in Verilator, comparing every cycle. A new
+//! input enters every cycle (II=1); the staged output must equal the cascade
+//! output bit-for-bit.
+//!
+//! Verilator, not iverilog: iverilog mis-simulates the staged multiply's
+//! constant bit-selects (`sorry: ... all bits will be included`), so it cannot
+//! validate these modules. Skips cleanly when Verilator is absent.
+
+use std::process::Command;
+
+fn arch() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_arch"))
+}
+fn verilator_available() -> bool {
+    Command::new("verilator")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+const SRC: &str = r#"
+package QF
+  type B4 = ScaledVec<FP4E2M1, 8, E8M0>;
+end package QF
+module PQ
+  port clk: in Clock<Sys>;
+  port rst: in Reset<Sync, High>;
+  port v: in Vec<FP32, 8>;
+  port y: out pipe_reg<B4, 5> reset rst => 0;
+  seq on clk rising
+    y@5 <= scaled_quantize<B4, pipelined, 5>(v);
+  end seq
+end module PQ
+"#;
+
+/// Combine the two builds into one Verilator-compilable file: the cascade
+/// build supplies the shared file-scope function library (including the comb
+/// quantize) and `PQ_ca`; the staged build supplies its two staged modules and
+/// `PQ_st`. Empty `package` blocks are stripped.
+fn combine(cascade: &str, staged: &str) -> String {
+    let ci = cascade.find("\nmodule PQ").expect("cascade has module PQ");
+    let lib = &cascade[..ci];
+    let pq_ca = cascade[ci..]
+        .replacen("module PQ ", "module PQ_ca ", 1)
+        .replacen("module PQ(", "module PQ_ca(", 1);
+    let si = staged
+        .find("module ArchF32MulStaged4")
+        .expect("staged has mul module");
+    let pj = staged.find("\nmodule PQ").expect("staged has module PQ");
+    let staged_mods = &staged[si..pj];
+    let pq_st = staged[pj..]
+        .replacen("module PQ ", "module PQ_st ", 1)
+        .replacen("module PQ(", "module PQ_st(", 1);
+    let wrap = "module Wrap(input logic clk, input logic rst, input logic [255:0] v, \
+                output logic [39:0] ys, output logic [39:0] yc);\n\
+                \x20 PQ_st st(.clk(clk),.rst(rst),.v(v),.y(ys));\n\
+                \x20 PQ_ca ca(.clk(clk),.rst(rst),.v(v),.y(yc));\nendmodule\n";
+    let combined = format!("{lib}\n{staged_mods}\n{pq_ca}\n{pq_st}\n{wrap}");
+    // strip empty `package QF; ... endpackage`
+    let mut out = String::new();
+    let mut rest = combined.as_str();
+    while let Some(p) = rest.find("package QF;") {
+        out.push_str(&rest[..p]);
+        let after = &rest[p..];
+        let e = after
+            .find("endpackage")
+            .map(|e| e + "endpackage".len())
+            .unwrap_or(after.len());
+        rest = &after[e..];
+    }
+    out.push_str(rest);
+    out
+}
+
+const TB: &str = r#"#include "VWrap.h"
+#include "verilated.h"
+#include <cstdio>
+#include <cstdlib>
+int main(int argc, char** argv){
+  Verilated::commandArgs(argc, argv);
+  VWrap* d = new VWrap;
+  auto tick = [&](){ d->clk=0; d->eval(); d->clk=1; d->eval(); };
+  auto setv=[&](){ for(int w=0;w<8;w++) ((uint32_t*)&d->v)[w]=(uint32_t)rand(); };
+  d->rst=1; for(int i=0;i<8;i++){ setv(); tick(); }
+  d->rst=0;
+  for(int i=0;i<16;i++){ setv(); tick(); }   // fill both pipelines
+  int mism=0; unsigned long long nonzero=0;
+  for(int i=0;i<3000;i++){
+    setv(); tick();
+    if(d->yc!=0) nonzero++;
+    if(d->ys != d->yc){ mism++; if(mism<6) printf("MISM i=%d ys=%010llx yc=%010llx\n", i,(unsigned long long)d->ys,(unsigned long long)d->yc); }
+  }
+  printf("VDONE mism=%d nonzero=%llu\n", mism, nonzero);
+  delete d; return mism==0 ? 0 : 1;
+}
+"#;
+
+#[test]
+fn staged_quantize_throughput_lockstep_verilator() {
+    if !verilator_available() {
+        eprintln!("verilator not in PATH; skipping staged-quantize throughput lockstep");
+        return;
+    }
+    let td = tempfile::tempdir().expect("tempdir");
+    let ap = td.path().join("PQ.arch");
+    std::fs::write(&ap, SRC).unwrap();
+    let build = |staged: bool| -> String {
+        let out = td.path().join(if staged { "s.sv" } else { "c.sv" });
+        let mut c = arch();
+        c.arg("build")
+            .arg(&ap)
+            .arg("-o")
+            .arg(&out)
+            .arg("--no-auto-asserts");
+        if staged {
+            c.arg("--staged-ops");
+        }
+        let o = c.output().expect("arch build");
+        assert!(
+            o.status.success(),
+            "arch build failed:\n{}",
+            String::from_utf8_lossy(&o.stderr)
+        );
+        std::fs::read_to_string(&out).unwrap()
+    };
+    let combined = combine(&build(false), &build(true));
+    let sv = td.path().join("combined.sv");
+    std::fs::write(&sv, combined).unwrap();
+    let tb = td.path().join("tb.cpp");
+    std::fs::write(&tb, TB).unwrap();
+    let obj = td.path().join("obj_dir");
+    let vout = Command::new("verilator")
+        .args([
+            "--cc",
+            "--exe",
+            "--build",
+            "--sv",
+            "-Wno-fatal",
+            "-Wno-WIDTH",
+            "-Wno-UNOPTFLAT",
+            "--top-module",
+            "Wrap",
+            "-Mdir",
+        ])
+        .arg(&obj)
+        .arg(&sv)
+        .arg(&tb)
+        .output()
+        .expect("verilate");
+    assert!(
+        vout.status.success(),
+        "verilate failed:\n{}\n{}",
+        String::from_utf8_lossy(&vout.stdout),
+        String::from_utf8_lossy(&vout.stderr)
+    );
+    let run = Command::new(obj.join("VWrap")).output().expect("run");
+    let txt = String::from_utf8_lossy(&run.stdout);
+    assert!(run.status.success(), "throughput lockstep FAILED:\n{txt}");
+    assert!(
+        txt.contains("nonzero=") && !txt.contains("nonzero=0\n"),
+        "sim produced no non-zero output (vacuous):\n{txt}"
+    );
+}


### PR DESCRIPTION
Adds `<pipelined, N>` staged datapaths for the two MX block operators whose critical path is dominated by FP32 multiplies (E8M0-scale blocks). Builds on the gate-weighted leaf scheduler + zero-call staged renderer from #957.

## Result

| operator | single-cycle | staged | II |
|---|---|---|---|
| `scaled_quantize<B4>` | 233 MHz | **318 MHz** | 1 |
| `scaled_dot<B4>` | 189 MHz | **298 MHz** | 1 |

Nangate45, buffered, OpenSTA. Together they pipeline the `quantize → dot` chain from **83 MHz single-cycle to ~298 MHz** at initiation interval one.

## What's here

**`scaled_quantize<Fmt, pipelined, N>(v)`** — scale-compute (comb) → register `{v, inv, scale, special}` → N staged `ArchF32MulStaged4` multiplies → comb narrow+pack. Fixed latency 5.

**`scaled_dot<pipelined, N>(a, b)`** — N exact products → `f32_add` reduction tree (one level per stage) → two power-of-two scale multiplies. Fixed latency `3 + tree-depth` (6 for an 8-element block). Reuses the generic `Name<pipelined, N>` parse — **no parser/AST change**; the operand block shape is resolved from the module's declarations at lowering time.

Both are emitted only under `arch build --staged-ops`; otherwise they lower to the combinational operator inside the pipe_reg cascade (correct latency, un-retimed). `N` is **fixed per shape** (not a free choice like `fma`); the type checker reports the required `N`.

## Verification — throughput, not stable-input

Each operator carries a **Verilator throughput lockstep** (`tests/staged_{quantize,dot}_lockstep_test.rs`): staged vs cascade, **3000 back-to-back random cycles, bit-exact, II=1**. Verilator specifically — iverilog mis-simulates the staged fp helpers' constant bit-selects (its own "sorry: all bits will be included" warning), which produces false mismatches.

Two bugs were caught by this that stable-input testing missed:
- a scale-byte pipeline **off-by-one** in the dot (tree output lands at edge `1+tree_depth`, scale-mul-1 was fed the byte one edge too late) — ~97% mismatch under throughput, invisible when inputs are held; an auto-offset comparison proved it a real datapath bug, not a latency skew;
- the staged quantize helper functions weren't emitted under `--staged-ops` (the comb call that used to pull them is gone) — fixed with a `needs_fp_lib` flag on the staged site.

The staged `f32_mul` schedule is committed as a drift-guarded const (`F32_MUL_S4_SCHEDULE`).

- `cargo test --no-fail-fast`: 1229 passed; the 5 failures are the pre-existing terminal-width `*_rejected*` diagnostic tests, byte-identical to `main`, green in CI.
- Spec §3.8a + reference card updated; skill snapshots re-synced (doc-drift).

## Scope

E8M0 scales only (boundary-compare UE4M3 is a follow-up); coarse per-level pipelining (sub-op staging toward the multiply's ~650 MHz is a later optimization).

Progress on #955.