### PR TITLE
feat(fp): checked FP add with IEEE exception flags — core numerics (1/4)

### DIFF
--- a/doc/proposal_fp_flags.md
+++ b/doc/proposal_fp_flags.md
@@ -1,0 +1,114 @@
+# Proposal: FP exception flags — `checked(...)` → `FpResult<T>`
+
+**Status:** design (surface confirmed); implementation pending.
+**Motivation:** the pairwise-summation error bound (Theorem B,
+`proofs/lean_fp_equiv/ArchFpEquiv/F32PairwiseSum.lean`) holds only under a
+*no-overflow / no-underflow throughout* assumption (`SummationSafe`). Overflow to
+`±Inf` and precision-losing underflow are exactly the conditions that **void the
+accuracy guarantee**. Today ARCH returns the IEEE result but exposes no status,
+so a design cannot detect or react to these, and the formal precondition cannot
+be checked at the RTL. This adds per-op FP exception flags, serving both runtime
+(the design branches on them) and formal (auto-assertions discharge
+`SummationSafe`).
+
+## Surface
+
+A built-in generic struct and a `checked(...)` form wrapping one FP op:
+
+```arch
+let r: FpResult<FP32> = checked(a + b);
+comb
+  sum      = r.value;       // FP32 — the ordinary IEEE result
+  ovf_flag = r.overflow;    // Bool
+  und_flag = r.underflow;   // Bool
+  inv_flag = r.invalid;     // Bool
+  inx_flag = r.inexact;     // Bool
+end comb
+```
+
+- `FpResult<T>` is a built-in struct `{ value: T, overflow, underflow, invalid,
+  inexact : Bool }`. Fields are ordinary `Bool`/`T` — wire them anywhere.
+- `checked(e)` requires `e` to be a single FP op (`a + b`, `a - b`, `a * b`,
+  `fma(a,b,c)`) on a supported float type (FP32 first; BF16/FP8 follow the same
+  lowering). Uncomposed: `checked((a+b)*c)` is a type error — wrap each op.
+- Non-`checked` FP ops are unchanged (pure, no flags) — zero cost when unused.
+
+## Flag semantics (IEEE 754, and why they avoid the benign case)
+
+The four flags are computed from signals **already present** in `normround`
+(`src/fp_ops.rs`) — the shared round-and-pack function behind add/mul/fma:
+
+| flag | formula (from `normround` internals) | meaning |
+|---|---|---|
+| `inexact` | `guard \| sticky` (the existing rounding bits) | result was rounded — lost information |
+| `overflow` | `¬biased_le0 ∧ sig≠0 ∧ overflow` (the existing `overflow = biased_n ≥ 255`) | result rounded to `±Inf` |
+| `underflow` | `biased_le0 ∧ sig≠0 ∧ inexact` | result is subnormal **and** inexact |
+| `invalid` | op-level: a non-NaN input produced NaN (`∞+(−∞)`, `0·∞`) | invalid operation |
+
+**Underflow = subnormal-result ∧ inexact is exactly the non-benign case.** With
+this definition, the benign situations produce **no flag** — verified against the
+proof's own cases:
+
+- `big + tiny = big` (the `add_negligible` case): result is `big` (normal),
+  `biased_le0` false → **no underflow** ✓.
+- `2⁻¹⁴⁹ + 2⁻¹⁴⁹ = 2⁻¹⁴⁸` (subnormal but *exact*): `inexact` false → **no
+  underflow** ✓.
+- `a + (−a·(1+ε)) = tiny_subnormal` (catastrophic cancellation): subnormal **and**
+  inexact → **underflow fires** ✓ — precisely the `SummationSafe`-violating case.
+
+No heuristics: "avoid benign" falls out of using *result*-tininess+inexactness,
+the standard IEEE underflow definition, rather than flagging tiny operands.
+
+## Lowering
+
+1. **FP IR** (`src/fp_ops.rs`) — add `normround_flags` returning
+   `(result, overflow, underflow, inexact)` alongside the byte-identical
+   `normround` (the machine-proved rounder stays untouched — its SMT miter and the
+   Lean `arch_f32_add`/`arch_fma_f32` proofs depend on byte-identity). Add
+   `f32_add_checked` / `f32_mul_checked` / `fma_f32_checked` that call
+   `normround_flags`, compute `invalid` from the special-value lattice, and pack
+   `{inexact, invalid, underflow, overflow, value[32]}` into a 36-bit result.
+2. **AST / parser** (`src/ast.rs`, `src/parser.rs`) — `checked(<fpop>)` expression
+   form; `FpResult<T>` type; `r.field` reuses struct field access.
+3. **Typecheck** (`src/typecheck.rs`) — `checked` on an FP op → `FpResult<T>`;
+   field types.
+4. **SV codegen** (`src/codegen/`) — emit `arch_f32_add_checked` (returns the
+   36-bit struct); `FpResult` is an SV `struct packed`; field access → bit slices.
+5. **Sim** (`src/sim_codegen/`) — C++ helper computing the same flags.
+6. **Formal** (`src/formal.rs`, `src/fp_smt_proof.rs`) — SMT model of the checked
+   op; a renderer miter row proving the checked SV ≡ the model.
+
+## Formal tie-in — discharging `SummationSafe` (mechanism #1)
+
+Independently of the runtime struct, an **opt-in** `--fp-checks` flag auto-emits
+concurrent SVA (in `translate_off/on`, reusing the FIFO `_auto_no_overflow` /
+bounds / div0 machinery):
+
+```sv
+_auto_no_fp_overflow_<n>:  assert property (@(posedge clk) disable iff (rst) !<overflow>);
+_auto_no_fp_underflow_<n>: assert property (@(posedge clk) disable iff (rst) !<underflow>);
+```
+
+on every FP op. A design (or formal run) that keeps these low has, at the RTL
+level, established the `SummationSafe` precondition — so the Lean pairwise error
+bound becomes conditional on a **machine-checked hardware property**. This is the
+clean bridge between the proof and the emitted hardware.
+
+## PR sequencing
+
+1. **Core numerics** — `normround_flags` + `*_checked` FP-IR fns + a differential
+   test (overflow→Inf, cancellation→subnormal, benign cases) vs IEEE. Internal,
+   verifiable, de-risks the semantics. (No surface yet.)
+2. **Surface** — `FpResult<T>` type + `checked(...)` (parser/typecheck/codegen/
+   sim), FP32 add end-to-end + `.arch` fixture. **Spec update in the same PR**
+   (grammar-surface → `doc-drift` CI).
+3. **Coverage** — mul/fma/sub; BF16/FP8.
+4. **Formal** — SMT model + renderer miter; the `--fp-checks` auto-assert
+   (discharges `SummationSafe`).
+
+## Notes
+
+- `divzero` omitted (no FP division op in ARCH today); trivially added with one.
+- Flags are **sticky per op-instance** in the struct sense (the op's own flags),
+  not a global accumulating status register — matching the pure, wire-everywhere
+  ARCH style. A design that wants an `fcsr`-style accumulator ORs the flags itself.

--- a/src/fp_ops.rs
+++ b/src/fp_ops.rs
@@ -148,6 +148,66 @@ fn normround(sign: &Bv, sig: &Bv, e0: &Bv) -> Bv {
     )
 }
 
+/// Rounding result **and** the three IEEE flags computable at round-and-pack:
+/// `(result, overflow, underflow, inexact)`. The `result` is bit-identical to
+/// [`normround`] (same formula) — this is a *separate* function so the
+/// machine-proved `normround` stays byte-identical; the flags reuse its existing
+/// `guard`/`sticky`/`overflow`/`biased_le0` signals:
+/// - `inexact`   = a nonzero bit was dropped (`guard | sticky`),
+/// - `overflow`  = normal-branch result rounded to `±Inf`,
+/// - `underflow` = subnormal-branch result **and** inexact (IEEE tininess +
+///   inexactness — this excludes the benign flush of a negligible addend, whose
+///   result stays normal, and exact subnormal results).
+fn normround_flags(sign: &Bv, sig: &Bv, e0: &Bv) -> (Bv, Bv, Bv, Bv) {
+    let w = sig.width();
+    let w2 = w + 2;
+    let zsig = zext(sig, w2);
+    let p = msb_index(sig);
+    let ev = add(&p, e0);
+    let biased = add(&ev, &cst(127, 16));
+    let biased_le0 = sle(&biased, &cst(0, 16));
+    let k = ite(&biased_le0, &cst(NEG149_16, 16), &sub(&ev, &cst(23, 16)));
+    let sh = sub(&k, e0);
+    let sh_le0 = sle(&sh, &cst(0, 16));
+    let kept_left = shl(&zsig, &neg(&sh));
+    let kept_right = lshr(&zsig, &sh);
+    let kept0 = ite(&sh_le0, &kept_left, &kept_right);
+    let gpos = sub(&sh, &cst(1, 16));
+    let guard = ite(&sh_le0, &cst(0, 1), &extract(&lshr(&zsig, &gpos), 0, 0));
+    let mask = sub(&shl(&cst(1, w2), &gpos), &cst(1, w2));
+    let sticky = ite(&sh_le0, &cst(0, 1), &ne(&band(&zsig, &mask), &cst(0, w2)));
+    let roundup = and(&guard, &or(&sticky, &extract(&kept0, 0, 0)));
+    let kept = add(&kept0, &zext(&roundup, w2));
+    let sub_res = bor(
+        &concat(sign, &cst(0, 31)),
+        &concat(sign, &extract(&kept, 30, 0)),
+    );
+    let carry = is1(&extract(&kept, 24, 24));
+    let biased_n = ite(&carry, &add(&biased, &cst(1, 16)), &biased);
+    let kept_n = ite(&carry, &lshr(&kept, &cst(1, 16)), &kept);
+    let overflow = sge(&biased_n, &cst(255, 16));
+    let inf = concat(sign, &concat(&cst(0xFF, 8), &cst(0, 23)));
+    let packed = concat(
+        sign,
+        &concat(&extract(&biased_n, 7, 0), &extract(&kept_n, 22, 0)),
+    );
+    let norm_res = ite(&overflow, &inf, &packed);
+    let zero = concat(sign, &cst(0, 31));
+    let sig_nz = ne(sig, &cst(0, w));
+    let result = ite(
+        &eq(sig, &cst(0, w)),
+        &zero,
+        &ite(&biased_le0, &sub_res, &norm_res),
+    );
+    let inexact_raw = or(&guard, &sticky);
+    let f_overflow = and(&sig_nz, &and(&bnot(&biased_le0), &overflow));
+    // IEEE: overflow (result → ±Inf) is always inexact, even when the mantissa
+    // was exact (e.g. MAX+MAX), since Inf ≠ the true finite value.
+    let f_inexact = and(&sig_nz, &or(&inexact_raw, &f_overflow));
+    let f_underflow = and(&sig_nz, &and(&biased_le0, &inexact_raw));
+    (result, f_overflow, f_underflow, f_inexact)
+}
+
 // ── predicates / simple ops (as expressions for reuse) ──────────────────────
 
 fn isnan(x: &Bv) -> Bv {
@@ -798,6 +858,78 @@ fn f32_add_core(name: &str, flip_b_sign: bool, p: FpCompat) -> FpFn {
     FpFn::new(name, &[("a", 32), ("b", 32)], 32, body)
 }
 
+/// Checked `f32` add: the ordinary result **plus** the four IEEE flags, packed
+/// into a 36-bit value `{inexact[35], invalid[34], underflow[33], overflow[32],
+/// value[31:0]}`. Backs the surface `checked(a + b) : FpResult<FP32>`. The 32-bit
+/// value is bit-identical to `arch_f32_add` (shares the same body); flags are
+/// gated to the finite path (a propagated `Inf`/`NaN` input is not an overflow),
+/// and `invalid` is the `∞ + (−∞)` case.
+fn f32_add_checked(p: FpCompat) -> FpFn {
+    let a = var("a", 32);
+    let b = var("b", 32);
+    let da = decode(&a);
+    let db = decode(&b);
+    let n = cst(nan32(p), 32);
+    let hi_is_a = sge(&da.eunb, &db.eunb);
+    let pick = |fa: &Bv, fb: &Bv| ite(&hi_is_a, fa, fb);
+    let mant_hi = pick(&da.mant, &db.mant);
+    let mant_lo = pick(&db.mant, &da.mant);
+    let eunb_hi = pick(&da.eunb, &db.eunb);
+    let eunb_lo = pick(&db.eunb, &da.eunb);
+    let sign_hi = pick(&da.sign, &db.sign);
+    let sign_lo = pick(&db.sign, &da.sign);
+    let diff = sub(&eunb_hi, &eunb_lo);
+    let fw = 24 + ADD_G;
+    let hi_field = shl(&zext(&mant_hi, fw), &cst(ADD_G as u128, 16));
+    let lo_ext = shl(&zext(&mant_lo, fw), &cst(ADD_G as u128, 16));
+    let lo_field = lshr(&lo_ext, &diff);
+    let mask = sub(&shl(&cst(1, fw), &diff), &cst(1, fw));
+    let sticky = ne(&band(&lo_ext, &mask), &cst(0, fw));
+    let hi_e = concat(&hi_field, &cst(0, 1));
+    let lo_e = concat(&lo_field, &sticky);
+    let same_sign = eq(&sign_hi, &sign_lo);
+    let ge = uge(&hi_e, &lo_e);
+    let raw = ite(&ge, &sub(&hi_e, &lo_e), &sub(&lo_e, &hi_e));
+    let mw = fw + 2;
+    let mag = ite(
+        &same_sign,
+        &add(&zext(&hi_e, mw), &zext(&lo_e, mw)),
+        &zext(&raw, mw),
+    );
+    let res_sign = ite(&same_sign, &sign_hi, &ite(&ge, &sign_hi, &sign_lo));
+    let e0 = sub(&eunb_hi, &cst((ADD_G + 1) as u128, 16));
+    let (rounded, ovf, unf, inx) = normround_flags(&res_sign, &mag, &e0);
+    let cancel = and(&bnot(&same_sign), &eq(&raw, &cst(0, fw + 1)));
+    let finite = ite(&cancel, &cst(0, 32), &rounded);
+    let both_inf = and(&da.is_inf, &db.is_inf);
+    let inf_a = concat(&da.sign, &concat(&cst(0xFF, 8), &cst(0, 23)));
+    let inf_b = concat(&db.sign, &concat(&cst(0xFF, 8), &cst(0, 23)));
+    let value = ite(
+        &or(&da.is_nan, &db.is_nan),
+        &n,
+        &ite(
+            &both_inf,
+            &ite(&eq(&da.sign, &db.sign), &inf_a, &n),
+            &ite(&da.is_inf, &inf_a, &ite(&db.is_inf, &inf_b, &finite)),
+        ),
+    );
+    // flags fire only on the genuine finite (non-cancelling) datapath
+    let is_special = or(&or(&da.is_nan, &db.is_nan), &or(&da.is_inf, &db.is_inf));
+    let finite_path = and(&bnot(&is_special), &bnot(&cancel));
+    let f_overflow = and(&finite_path, &ovf);
+    let f_underflow = and(&finite_path, &unf);
+    let f_inexact = and(&finite_path, &inx);
+    let f_invalid = and(&both_inf, &ne(&da.sign, &db.sign)); // ∞ + (−∞)
+    let packed = concat(
+        &f_inexact,
+        &concat(
+            &f_invalid,
+            &concat(&f_underflow, &concat(&f_overflow, &value)),
+        ),
+    );
+    FpFn::new("arch_f32_add_checked", &[("a", 32), ("b", 32)], 36, packed)
+}
+
 fn fma_f32(p: FpCompat) -> FpFn {
     let a = var("a", 32);
     let b = var("b", 32);
@@ -1233,6 +1365,7 @@ pub fn fp_functions(p: FpCompat) -> Vec<FpFn> {
         f32_mul(p),
         f32_add_core("arch_f32_add", false, p),
         f32_add_core("arch_f32_sub", true, p),
+        f32_add_checked(p),
         fma_f32(p),
         bf16_to_f32(p),
         f32_to_bf16(p),

--- a/tests/fp_add_checked_test.rs
+++ b/tests/fp_add_checked_test.rs
@@ -1,0 +1,101 @@
+//! Verifies `arch_f32_add_checked` — the value is bit-identical to
+//! `arch_f32_add`, and the four IEEE flags fire exactly on the right cases
+//! (overflow, invalid, benign vs. real underflow), via the FP-IR evaluator.
+
+use std::collections::HashMap;
+
+// Re-expose the IR evaluator + builders through the crate.
+use arch::fp_ir::{call, cst, eval_bv};
+
+fn checked(a: u32, b: u32) -> (u32, bool, bool, bool, bool) {
+    let fns = arch::fp_ops::fp_functions(arch::FpCompat::default());
+    let env = HashMap::new();
+    let got = eval_bv(
+        &call(
+            "arch_f32_add_checked",
+            &[cst(a as u128, 32), cst(b as u128, 32)],
+            36,
+        ),
+        &env,
+        &fns,
+    )
+    .expect("add_checked evaluable");
+    let value = (got & 0xFFFF_FFFF) as u32;
+    let overflow = (got >> 32) & 1 == 1;
+    let underflow = (got >> 33) & 1 == 1;
+    let invalid = (got >> 34) & 1 == 1;
+    let inexact = (got >> 35) & 1 == 1;
+    (value, overflow, underflow, invalid, inexact)
+}
+
+fn plain_add(a: u32, b: u32) -> u32 {
+    let fns = arch::fp_ops::fp_functions(arch::FpCompat::default());
+    let env = HashMap::new();
+    eval_bv(
+        &call(
+            "arch_f32_add",
+            &[cst(a as u128, 32), cst(b as u128, 32)],
+            32,
+        ),
+        &env,
+        &fns,
+    )
+    .expect("add evaluable") as u32
+}
+
+#[test]
+fn value_is_bit_identical_to_arch_f32_add() {
+    let pats: [u32; 8] = [
+        0x0000_0000,
+        0x3F80_0000,
+        0x0000_0001,
+        0x0080_0000,
+        0x7F7F_FFFF,
+        0x4049_0FDB,
+        0xC2C8_0000,
+        0x3400_0000,
+    ];
+    for &a in &pats {
+        for &b in &pats {
+            let (v, ..) = checked(a, b);
+            assert_eq!(v, plain_add(a, b), "value mismatch at {a:#010X}+{b:#010X}");
+        }
+    }
+}
+
+#[test]
+fn flag_cases() {
+    // exact: 1.0 + 1.0 = 2.0, no flags.
+    let (v, ovf, unf, inv, inx) = checked(0x3F80_0000, 0x3F80_0000);
+    assert_eq!(v, 0x4000_0000);
+    assert!(
+        !ovf && !unf && !inv && !inx,
+        "1+1 should be exact, got {ovf} {unf} {inv} {inx}"
+    );
+
+    // overflow: MAX + MAX = +Inf, overflow + inexact, no underflow/invalid.
+    let (v, ovf, unf, inv, inx) = checked(0x7F7F_FFFF, 0x7F7F_FFFF);
+    assert_eq!(v, 0x7F80_0000, "MAX+MAX should be +Inf");
+    assert!(
+        ovf && inx && !unf && !inv,
+        "MAX+MAX flags: {ovf} {unf} {inv} {inx}"
+    );
+
+    // benign: 1.0 + min_subnormal = 1.0, inexact (tiny lost) but NOT underflow
+    // (result is normal). This is the add_negligible case.
+    let (v, ovf, unf, inv, inx) = checked(0x3F80_0000, 0x0000_0001);
+    assert_eq!(v, 0x3F80_0000, "1 + tiny should round to 1");
+    assert!(!unf, "benign: result normal, underflow must be false");
+    assert!(
+        inx && !ovf && !inv,
+        "benign: inexact only, got {ovf} {unf} {inv} {inx}"
+    );
+
+    // invalid: (+Inf) + (-Inf) = NaN, invalid; no over/underflow/inexact.
+    let (_, ovf, unf, inv, inx) = checked(0x7F80_0000, 0xFF80_0000);
+    assert!(inv, "Inf + (-Inf) must set invalid");
+    assert!(
+        !ovf && !unf && !inx,
+        "invalid case: only invalid, got {ovf} {unf} {inv} {inx}"
+    );
+}


### PR DESCRIPTION
**PR 1 of 4** implementing FP exception flags (full design:
`doc/proposal_fp_flags.md`, surface confirmed). This slice is the shared,
verifiable **numerics core** — no surface syntax yet, so it's internal and
low-risk.

## Motivation
The pairwise-summation error bound (Theorem B, `F32PairwiseSum`) holds only under
a *no-overflow / no-underflow throughout* assumption (`SummationSafe`). Overflow
to `±Inf` and precision-losing underflow are exactly what void the accuracy
guarantee. These flags let a design **detect** those conditions — and (PR 4, an
opt-in `--fp-checks` auto-assert) **discharge `SummationSafe` formally** at the
RTL.

## What's here
- **`normround_flags`** — returns `(result, overflow, underflow, inexact)` from
  signals already inside `normround`. The machine-proved `normround` is **left
  byte-identical** (its SMT miter and the Lean `arch_f32_add`/`arch_fma_f32`
  proofs depend on it) — this is a separate fn.
  - `inexact` = bits dropped **or** overflow-to-Inf (IEEE: overflow is always inexact)
  - `overflow` = normal-branch result rounds to `±Inf`
  - `underflow` = subnormal result **and** inexact
- **`f32_add_checked`** — `arch_f32_add_checked(a,b)` → 36-bit
  `{inexact, invalid, underflow, overflow, value[31:0]}`; the 32-bit value is
  bit-identical to `arch_f32_add`; flags gated to the finite path; `invalid` =
  `∞+(−∞)`.
- **`tests/fp_add_checked_test.rs`** — value bit-identical over a pattern grid;
  and the flag cases: exact (none), overflow (`ovf+inexact`), **benign `1+tiny`
  (inexact only, *not* underflow — the `add_negligible` case)**, invalid.

## Why underflow avoids the benign case (verified)
`underflow = subnormal-result ∧ inexact` — so `big + tiny = big` (result normal)
sets **no** underflow, exact subnormals set none, and only inexact-subnormal
(cancellation) fires. Falls out of standard IEEE semantics, no heuristics.

The test **caught a real bug**: exact-mantissa overflow (`MAX+MAX = 2×MAX`) must
still be inexact — fixed.

## Verification
`cargo build` green; new test 2/2; **all `fp_` regression tests green** (57+50+…,
0 failed — proved ops unchanged); `arch_f32_add_checked` emits to SMT + SV. No
user-facing syntax change (surface is PR 2), so `doc-drift` isn't triggered.
