### PR TITLE
test(fp): make diagnostic-substring tests robust to forced color

### DIFF
--- a/tests/fp_test.rs
+++ b/tests/fp_test.rs
@@ -2072,6 +2072,32 @@ fn fp_formal_vacuity_guard() {
 // The contract is as much about what is REJECTED as what works: E2M1 is a
 // carrier for conversions and literals, with no operator surface at all.
 
+/// Remove ANSI/VT escape sequences (SGR color, CSI cursor moves) so diagnostic
+/// text can be matched regardless of whether the environment forced color.
+fn strip_ansi(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut chars = s.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c == '\x1b' {
+            // CSI sequence: ESC '[' params… final-byte (0x40..=0x7e). Consume it.
+            if chars.peek() == Some(&'[') {
+                chars.next();
+                while let Some(&d) = chars.peek() {
+                    chars.next();
+                    if ('\u{40}'..='\u{7e}').contains(&d) {
+                        break;
+                    }
+                }
+            }
+            // Any other escape form: the ESC alone is dropped (miette emits only
+            // CSI here); leave following bytes intact.
+        } else {
+            out.push(c);
+        }
+    }
+    out
+}
+
 /// Helper: run `arch check` on inline source, returning combined output and
 /// whether it succeeded.
 fn check_src(name: &str, src: &str) -> (bool, String) {
@@ -2087,8 +2113,12 @@ fn check_src(name: &str, src: &str) -> (bool, String) {
     );
     // miette word-wraps diagnostics AND prefixes continuation lines with a
     // box-drawing gutter, so a phrase can straddle a break as
-    // "storage-only float | format". Strip the gutter glyphs first, then
-    // collapse whitespace, before any substring matching.
+    // "storage-only float | format". It ALSO colorizes when the environment
+    // forces color (e.g. `FORCE_COLOR`), wrapping the gutter glyph in SGR
+    // escapes like "\x1b[31m│\x1b[0m" — those escapes survive the glyph map and
+    // wreck substring matching. Strip ANSI escapes first, then the gutter
+    // glyphs, then collapse whitespace, before any substring matching.
+    let merged = strip_ansi(&merged);
     let stripped: String = merged
         .chars()
         .map(|c| {

--- a/tests/pipelined_operators_test.rs
+++ b/tests/pipelined_operators_test.rs
@@ -41,8 +41,34 @@ fn run_check(src: &str) -> std::process::Output {
 /// substring can straddle a line break. Drop the continuation markers and
 /// collapse all whitespace runs to a single space before substring-matching
 /// so assertions are wrap-insensitive.
+/// Remove ANSI/VT escape sequences so diagnostic text matches regardless of
+/// whether the environment forced color (e.g. `FORCE_COLOR`): a forced-color
+/// run wraps miette's gutter glyph as "\x1b[31m│\x1b[0m", and those escapes
+/// survive the bare-`│` filter below and break substring matching.
+fn strip_ansi(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut chars = s.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c == '\x1b' {
+            if chars.peek() == Some(&'[') {
+                chars.next();
+                while let Some(&d) = chars.peek() {
+                    chars.next();
+                    if ('\u{40}'..='\u{7e}').contains(&d) {
+                        break;
+                    }
+                }
+            }
+        } else {
+            out.push(c);
+        }
+    }
+    out
+}
+
 fn normalize(s: &str) -> String {
-    s.split_whitespace()
+    strip_ansi(s)
+        .split_whitespace()
         .filter(|tok| *tok != "│")
         .collect::<Vec<_>>()
         .join(" ")


### PR DESCRIPTION
## What

Five rejection tests in `fp_test` (fp4/fp6 storage-only) and `pipelined_operators_test` (comb/let/callee `<pipelined,N>`-consumption) fail when the environment **forces color** (`FORCE_COLOR`, and some CI/terminal setups) — surfaced while running the full suite for #968.

## Root cause

Both files already normalize miette's word-wrapped diagnostics: a long message straddles a line break with a box-drawing gutter, so `check_src` maps the `│` glyph to whitespace and `normalize` filters a bare `│`, letting a phrase like `storage-only float format` or `cannot be used in a `comb` block` match across the wrap.

But under forced color, miette wraps that glyph in SGR escapes — `\x1b[31m│\x1b[0m` — and the escape bytes survive the glyph map as their own tokens, so the substring match breaks:

```
region: 'cannot be used in \x1b[31m│\x1b[0m a `comb` block; ...'
```

Confirmed: `env -u FORCE_COLOR` → all five pass; `FORCE_COLOR=3` → all five fail. Pure test-harness fragility — the compiler output is correct, and CI (no `FORCE_COLOR`) is unaffected, which is why #968 merged green.

## Fix

Add a small `strip_ansi` pass (drops CSI escape sequences) ahead of the existing normalization in both `check_src` and `normalize`. No source change.

## Verification

Under `FORCE_COLOR=3` (the failing condition):
- `fp_test`: **73/73** pass
- `pipelined_operators_test`: **14/14** pass

Both remain green without `FORCE_COLOR`. `cargo fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)