### PR TITLE
test(fp): extend staged-op miter to block operators (Lemma B)

### DIFF
--- a/tests/fp_v1/smt_proof/README.md
+++ b/tests/fp_v1/smt_proof/README.md
@@ -328,9 +328,21 @@ passes A and fails B).
   reports `UNBALANCED [1,2]` for a hand-skewed two-stage pipeline and the correct
   latency for the balanced one; sampling at the wrong depth (L=4 or L=6) is `sat`.
 
-Only `fma<pipelined, 6>` is surface-emittable on `main`; the staged block
-operators (`scaled_quantize` / `scaled_dot`, arch#955 / PR #960) get rows in the
-`ops` table as they land — the `ArchF32MulStaged4` leaf they share is a
-split-free mul miter. A bounded slice runs under `cargo test`
-(`tests/staged_fma_equivalence_miter_test.rs`) when yosys/z3 are present; the
-full 510-case proof is the manual long-verification.
+The staged block operators (`scaled_dot`, `scaled_quantize`, arch#955 / PR #960)
+now have rows too, in `balance-only` mode: Lemma B (balance) runs, Lemma A
+(arithmetic) is **deferred as SAT-hard**. Mitering the two independently
+bit-blasted `f32_add` reduction trees has no single collapsing split the way
+fma's one alignment gap does — it times out even at N=2. For the block ops the
+equivalence instead rests on the composition of (a) Lemma B here — which is
+exactly the check that catches the non-power-of-two skew of arch#960, and skew
+generally; (b) the *combinational* schedule miter (`scaled_dot_miter.sh`,
+Theorem A); and (c) the by-construction identity — the staged emitter cuts that
+comb IR into stages without changing operations — formalized generally by the
+Lean retiming lemma. `scaled_dot` is emittable only for power-of-two block sizes
+(the type checker rejects the rest, arch#960); `scaled_quantize`'s per-element
+multiplies are parallel at uniform depth, so any N balances.
+
+A bounded slice (fma Lemma B + a Lemma-A smoke, and both block-op balance
+checks) runs under `cargo test` (`tests/staged_fma_equivalence_miter_test.rs`)
+when yosys/z3 are present; the full 510-case fma proof is the manual
+long-verification.

--- a/tests/fp_v1/smt_proof/staged_ops_miter.sh
+++ b/tests/fp_v1/smt_proof/staged_ops_miter.sh
@@ -57,16 +57,35 @@ DUMP_FP_BIN="${DUMP_FP_BIN:-$(dirname "$ARCH_BIN")/examples/dump_fp}"
 
 # ── operator table ─────────────────────────────────────────────────────────
 # NAME | staged module | latency L (input->out of the staged submodule) | \
-#   render_smt fn | split? (fma alignment split | none)
+#   render_smt fn | mode
 #
-# Only `fma<pipelined,6>` is surface-emittable on main today; the staged block
-# operators (scaled_quantize / scaled_dot) land with arch#955 (PR #960) and get
-# rows here as they merge — the ArchF32MulStaged4 leaf they share is a plain
-# split-free mul miter. The staged fma submodule is latency 5; the extra cycle
-# to the user-visible latency-6 output is the wrapper's reset/valid register,
-# which is an ordinary pipe_reg cascade (verified by the flat renderer miters).
+# mode selects how the arithmetic half (Lemma A) is discharged:
+#   fma          — register-shorted miter vs `arch_fma_f32`, alignment split
+#   balance-only — Lemma B only; Lemma A deferred (see below)
+#
+# The block operators (`scaled_dot`, `scaled_quantize`, arch#955) run
+# `balance-only`. Their arithmetic Lemma A — the register-shorted transfer
+# function equals the combinational block operator — is SAT-hard: mitering the
+# two independently bit-blasted `f32_add` reduction trees has no single
+# collapsing split (unlike fma's one alignment gap), and times out even at N=2.
+# For the block ops the equivalence rests instead on the composition of:
+#   * Lemma B here (the staged pipeline is balanced — the check that catches the
+#     non-power-of-two skew of arch#960, and skew generally);
+#   * the *combinational* block schedule miter (`scaled_dot_miter.sh`, Theorem A
+#     — emitted comb SV == the balanced-pairwise + one-at-a-time-scale schedule);
+#   * the by-construction identity (the staged emitter cuts that same comb IR
+#     into stages without changing operations) formalized generally by the Lean
+#     retiming lemma (proofs/lean_fp_equiv/ArchFpEquiv/StagedPipeline.lean).
+# `scaled_dot` is emittable only for power-of-two block sizes (the type checker
+# rejects the rest — arch#960); `scaled_quantize`'s per-element multiplies are
+# parallel at uniform depth, so any N balances.
+#
+# `L` is the staged *submodule* latency (the user-visible pipe_reg adds one more
+# cycle via the wrapper's reset/valid register, an ordinary pipe_reg cascade).
 ops=(
   "fma6|ArchF32FmaStaged6|5|arch_fma_f32|fma"
+  "dot8|arch_scaled_dot_e2m1_8_e8m0_staged6|5|-|balance-only"
+  "quant8|arch_scaled_quantize_e2m1_8_e8m0_floor_rne_staged5|4|-|balance-only"
 )
 
 # combinationalize: within a staged submodule's always_ff blocks (which are pure
@@ -83,7 +102,7 @@ combinationalize () { # $1 = infile  $2 = module  $3 = outfile
   ' "$1" > "$3"
 }
 
-echo "# module              lemmaB(balance)  lemmaA(arith)   L"
+echo "# module                                        lemmaB(balance)  lemmaA(arith)    L"
 fail=0
 for spec in "${ops[@]}"; do
   IFS='|' read -r name mod L fn split <<<"$spec"
@@ -106,6 +125,39 @@ module ${name}_top
 end module ${name}_top
 ARCH
       ;;
+    dot8)
+      cat > "$d/src.arch" <<'ARCH'
+package DF
+  type B8 = ScaledVec<FP4E2M1, 8, E8M0>;
+end package DF
+module dot8_top
+  port clk: in Clock<Sys>;
+  port rst: in Reset<Sync, High>;
+  port a: in B8;
+  port b: in B8;
+  port o: out pipe_reg<FP32, 6> reset rst => 0.0;
+  seq on clk rising
+    o@6 <= scaled_dot<pipelined, 6>(a, b);
+  end seq
+end module dot8_top
+ARCH
+      ;;
+    quant8)
+      cat > "$d/src.arch" <<'ARCH'
+package QF
+  type B4 = ScaledVec<FP4E2M1, 8, E8M0>;
+end package QF
+module quant8_top
+  port clk: in Clock<Sys>;
+  port rst: in Reset<Sync, High>;
+  port v: in Vec<FP32, 8>;
+  port y: out pipe_reg<B4, 5> reset rst => 0;
+  seq on clk rising
+    y@5 <= scaled_quantize<B4, pipelined, 5>(v);
+  end seq
+end module quant8_top
+ARCH
+      ;;
   esac
   "$ARCH_BIN" build --staged-ops "$d/src.arch" -o "$d/staged.sv" >/dev/null 2>&1
 
@@ -118,6 +170,14 @@ ARCH
   fi
 
   # ── Lemma A: register-shorted arithmetic miter vs render_smt ──────────────
+  if [[ "$split" == "balance-only" ]]; then
+    # Block operators: Lemma A is SAT-hard (see the operator table). The balance
+    # check above is the structural guard; arithmetic equivalence rests on the
+    # comb schedule miter + the by-construction/Lean retiming composition.
+    vA="deferred(block)"
+    printf "%-46s %-16s %-16s %s\n" "$mod" "$vB" "$vA" "$L"
+    continue
+  fi
   combinationalize "$d/staged.sv" "$mod" "$d/comb.v"
   yosys -q -p "read_verilog -sv $d/comb.v; hierarchy -top $mod; proc; flatten; opt_clean; check -assert; write_smt2 $d/comb.smt2" 2>/dev/null
   # specialize yosys's state sort away -> pure QF_BV (combinational: one state)
@@ -187,6 +247,6 @@ SPL
     [[ "$vA" == "unsat" ]] || fail=1
   fi
 
-  printf "%-20s %-16s %-14s %s\n" "$mod" "$vB" "$vA" "$L"
+  printf "%-46s %-16s %-16s %s\n" "$mod" "$vB" "$vA" "$L"
 done
 exit $fail

--- a/tests/staged_fma_equivalence_miter_test.rs
+++ b/tests/staged_fma_equivalence_miter_test.rs
@@ -127,6 +127,101 @@ fn staged_fma_is_balanced_latency_5() {
     );
 }
 
+/// Emit `src` with `--staged-ops`, extract `module` via yosys, and assert the
+/// balance checker reports a uniform pipeline latency of `expect`. Shared by the
+/// staged block-operator Lemma-B guards below. Skips (returns) if the toolchain
+/// is missing.
+fn assert_staged_balanced(src: &str, module: &str, expect: u32) {
+    if !tool_ok("yosys") || !tool_ok("python3") {
+        eprintln!("skipping: yosys/python3 not available");
+        return;
+    }
+    let td = tempfile::tempdir().expect("tempdir");
+    let arch_path = td.path().join("m.arch");
+    std::fs::write(&arch_path, src).unwrap();
+    let sv = td.path().join("m.sv");
+    let out = arch()
+        .args(["build", "--staged-ops"])
+        .arg(&arch_path)
+        .arg("-o")
+        .arg(&sv)
+        .output()
+        .expect("run arch build --staged-ops");
+    assert!(
+        out.status.success(),
+        "arch build --staged-ops failed:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let json = td.path().join("m.json");
+    let ys = format!(
+        "read_verilog -sv {}; hierarchy -top {module}; proc; flatten; opt_clean; \
+         write_json {}",
+        sv.display(),
+        json.display()
+    );
+    let y = Command::new("yosys")
+        .args(["-q", "-p", &ys])
+        .output()
+        .unwrap();
+    assert!(
+        y.status.success(),
+        "yosys failed for {module}:\n{}",
+        String::from_utf8_lossy(&y.stderr)
+    );
+    let balance = repo_root().join("tests/fp_v1/synth/pipeline_balance.py");
+    let out = Command::new("python3")
+        .arg(&balance)
+        .arg(&json)
+        .arg(module)
+        .args(["--expect", &expect.to_string()])
+        .output()
+        .expect("run pipeline_balance.py");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        out.status.success(),
+        "Lemma B FAILED — {module} is not a balanced latency-{expect} pipeline \
+         (skew is a silent miscompile — cf. the arch#960 non-power-of-two dot):\n{}\n{}",
+        stdout,
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+/// Lemma B for the staged `scaled_dot` block operator (arch#955): the N products
+/// → `f32_add` reduction tree → scale multiplies must form a balanced pipeline.
+/// This is the exact check that catches the non-power-of-two skew of arch#960
+/// (there the type checker now rejects non-power-of-two sizes; a power-of-two
+/// block must stay balanced).
+#[test]
+fn staged_scaled_dot_is_balanced() {
+    assert_staged_balanced(
+        "package DF\n  type B8 = ScaledVec<FP4E2M1, 8, E8M0>;\nend package DF\n\
+         module Dot\n  port clk: in Clock<Sys>;\n  port rst: in Reset<Sync, High>;\n\
+         \x20 port a: in B8;\n  port b: in B8;\n\
+         \x20 port o: out pipe_reg<FP32, 6> reset rst => 0.0;\n\
+         \x20 seq on clk rising\n    o@6 <= scaled_dot<pipelined, 6>(a, b);\n  end seq\n\
+         end module Dot\n",
+        "arch_scaled_dot_e2m1_8_e8m0_staged6",
+        5,
+    );
+}
+
+/// Lemma B for the staged `scaled_quantize` block operator (arch#955): its
+/// per-element multiplies run in parallel at uniform depth, so the staged
+/// pipeline is balanced.
+#[test]
+fn staged_scaled_quantize_is_balanced() {
+    assert_staged_balanced(
+        "package QF\n  type B4 = ScaledVec<FP4E2M1, 8, E8M0>;\nend package QF\n\
+         module Quant\n  port clk: in Clock<Sys>;\n  port rst: in Reset<Sync, High>;\n\
+         \x20 port v: in Vec<FP32, 8>;\n\
+         \x20 port y: out pipe_reg<B4, 5> reset rst => 0;\n\
+         \x20 seq on clk rising\n    y@5 <= scaled_quantize<B4, pipelined, 5>(v);\n  end seq\n\
+         end module Quant\n",
+        "arch_scaled_quantize_e2m1_8_e8m0_floor_rne_staged5",
+        4,
+    );
+}
+
 /// Lemma A (smoke) — the register-shorted staged fma equals `arch_fma_f32` on a
 /// bounded slice of the alignment split. Requires yosys + z3 + python3 + the
 /// `dump_fp` example binary. The full 510-way proof is the manual


### PR DESCRIPTION
## What

The #968 follow-up, now unblocked with the staged block operators (#960) on `main`. Extends `staged_ops_miter.sh` with `scaled_dot` and `scaled_quantize` rows in a new **`balance-only`** mode.

```
# module                                              lemmaB(balance)  lemmaA(arith)     L
ArchF32FmaStaged6                                     balanced@5       unsat             5
arch_scaled_dot_e2m1_8_e8m0_staged6                   balanced@5       deferred(block)   5
arch_scaled_quantize_e2m1_8_e8m0_floor_rne_staged5    balanced@4       deferred(block)   4
```

## Lemma B runs; Lemma A is deferred (SAT-hard)

**Lemma B (balance)** is the high-value half — it's exactly the check that catches the **non-power-of-two skew of #960** (and skew generally). Verified: staged `scaled_dot` balanced at latency 5, `scaled_quantize` at 4 (its per-element multiplies run in parallel at uniform depth).

**Lemma A (arithmetic staged ≡ comb)** is deferred: mitering the two independently bit-blasted `f32_add` reduction trees has no single collapsing split the way fma's one alignment gap does — it **times out even at N=2**. For the block ops the equivalence instead rests on the composition already in place:
- Lemma B here (balance);
- the combinational schedule miter (`scaled_dot_miter.sh`, Theorem A — emitted comb SV == the balanced-pairwise + one-at-a-time-scale schedule);
- the by-construction identity (the staged emitter cuts that comb IR into stages without changing operations), formalized generally by the Lean retiming lemma (`StagedPipeline.lean`).

## Coverage under `cargo test`

Two new balance guards run when yosys is present (skip cleanly otherwise): `staged_scaled_dot_is_balanced`, `staged_scaled_quantize_is_balanced`. A future staging change that reintroduces skew now fails a test. Full miter test file 4/4.

`scaled_dot` is emittable only for power-of-two block sizes (the type checker rejects the rest, #960); `scaled_quantize` balances for any N.

🤖 Generated with [Claude Code](https://claude.com/claude-code)