### PR TITLE
test+doc(formal): correct pipelined-latency comment and prove the delay is modeled

### DIFF
--- a/src/formal.rs
+++ b/src/formal.rs
@@ -2467,10 +2467,17 @@ impl<'a> FormalCtx<'a> {
             // pipeline delivers. The earlier refusal was to avoid
             // misrepresenting an *unverified* pipeline as formally checked;
             // that verification now exists, so the comb encoding is faithful.
-            // The pipe_reg latency is modeled the same way `arch formal` v1
-            // models every `@N` register — the pre-existing single-cycle
-            // approximation shared by all pipe_regs, pipelined or not — not a
-            // new approximation introduced here.
+            // Note this handler encodes only the VALUE; it ignores `_stages`.
+            // The N-cycle latency is carried entirely by the `pipe_reg<T, N>`
+            // that receives this value, which `arch formal` expands into N
+            // genuine chained stage registers — the same faithful delay it
+            // gives any `pipe_reg`, pipelined or not. That delay is a bit-exact
+            // N-stage register chain, NOT an approximation: a `pipe_reg`
+            // delayed @N is PROVED equal to an explicit N-deep reg chain and
+            // REFUTED (with the real stage regs in the counterexample) against
+            // an (N-1)-deep one. See tests/formal/pipelined_fma_equiv.arch
+            // (value discharge) and pipelined_fma_wrong_latency_refutes.arch
+            // (the modeled latency is genuinely N, not free).
             PipelinedCall(name, args, _stages) => {
                 let comb = Expr {
                     kind: ExprKind::FunctionCall(name.clone(), args.clone()),

--- a/tests/formal/pipelined_fma_equiv.arch
+++ b/tests/formal/pipelined_fma_equiv.arch
@@ -5,6 +5,20 @@
 // fma delayed through an identical 6-deep pipe_reg. The retiming lemma says
 // they must agree at every cycle. The `is_nan` disjunct makes the equality
 // bit-exact rather than IEEE (NaN != NaN under `==`).
+//
+// WHAT THIS FIXTURE PROVES: value-discharge — the pipelined call delivers the
+// same value as the combinational `fma` (any other value would REFUTE).
+//
+// WHAT IT DOES NOT PROVE: latency correctness. Both sides use `@6`, so the
+// delays cancel and the equality would hold for any common N — this fixture
+// alone cannot catch a mismodeled latency. The two latency guarantees are
+// covered separately:
+//   * that the pipe_reg delay is a genuine N-stage chain (not free) —
+//     pipelined_fma_wrong_latency_refutes.arch (`@6` vs `@5` REFUTES);
+//   * that `op<pipelined, N>` can only bind to an `@N` result of matching
+//     latency — enforced at typecheck (a `y@3 <= fma<pipelined, 6>(...)`
+//     binding is rejected), asserted in formal_test.rs.
+// Do not over-read this fixture as evidence of latency modeling.
 module PipelinedFmaEquiv
   port clk: in Clock<Sys>;
   port rst: in Reset<Sync, High>;

--- a/tests/formal/pipelined_fma_wrong_binding_rejected.arch
+++ b/tests/formal/pipelined_fma_wrong_binding_rejected.arch
@@ -1,0 +1,17 @@
+// A `op<pipelined, N>` result may only be bound to an `@N` write of matching
+// latency. This design binds a `fma<pipelined, 6>` result to a `@3` register,
+// which the type checker rejects ("latency-6 result bound at @3") — before any
+// solver runs. This is the mechanism that actually guarantees the declared
+// pipeline latency at the language surface; the formal encoder never has to
+// re-check it. Asserted in formal_test.rs (front-end error, z3 not required).
+module PipelinedFmaWrongBinding
+  port clk: in Clock<Sys>;
+  port rst: in Reset<Sync, High>;
+  port a: in FP32;
+  port b: in FP32;
+  port c: in FP32;
+  port y: out pipe_reg<FP32, 6> reset rst => 0.0;
+  seq on clk rising
+    y@3 <= fma<pipelined, 6>(a, b, c);
+  end seq
+end module PipelinedFmaWrongBinding

--- a/tests/formal/pipelined_fma_wrong_latency_refutes.arch
+++ b/tests/formal/pipelined_fma_wrong_latency_refutes.arch
@@ -1,0 +1,25 @@
+// Companion to pipelined_fma_equiv.arch that closes the latency gap the
+// symmetric fixture leaves open. Here the pipelined fma feeds a 6-deep
+// pipe_reg (`y@6`) while the combinational fma feeds a 5-deep one (`z@5`), so
+// the two results are one cycle apart. This REFUTES — and the counterexample
+// contains the real per-stage registers (`y_stg1..y_stg5`, `z_stg1..z_stg4`),
+// showing `arch formal` models the `pipe_reg<T, N>` latency as a genuine
+// N-stage register chain rather than a free/single-cycle approximation. If the
+// pipelined path's latency were mismodeled (collapsed, or off by a stage), the
+// delays would realign and this property would flip to PROVED — so the REFUTED
+// verdict is what pins the latency down. The `is_nan` disjunct keeps the
+// compare bit-exact (NaN != NaN under `==`), matching the sibling fixture.
+module PipelinedFmaWrongLatency
+  port clk: in Clock<Sys>;
+  port rst: in Reset<Sync, High>;
+  port a: in FP32;
+  port b: in FP32;
+  port c: in FP32;
+  port y: out pipe_reg<FP32, 6> reset rst => 0.0;
+  port z: out pipe_reg<FP32, 5> reset rst => 0.0;
+  seq on clk rising
+    y@6 <= fma<pipelined, 6>(a, b, c);
+    z@5 <= fma(a, b, c);
+  end seq
+  assert pipelined_neq_wrong_delay: (y == z) or (is_nan(y) and is_nan(z));
+end module PipelinedFmaWrongLatency

--- a/tests/formal_test.rs
+++ b/tests/formal_test.rs
@@ -265,6 +265,64 @@ fn formal_pipelined_fma_equals_delayed_comb() {
     );
 }
 
+/// The sibling `pipelined_fma_equiv.arch` uses `@6` on both sides, so its
+/// equality holds for any common latency — it proves value discharge but says
+/// nothing about latency. This test closes that gap two ways, one per latency
+/// guarantee:
+///
+///   1. The `pipe_reg` delay is a genuine N-stage chain, not free. The
+///      pipelined fma into a 6-deep pipe_reg vs the comb fma into a 5-deep one
+///      are a cycle apart, so the property REFUTES — and the counterexample
+///      carries the real per-stage registers. A collapsed/mismodeled pipeline
+///      latency would realign the delays and flip this to PROVED.
+///
+///   2. A `op<pipelined, N>` result can only bind to a matching-latency `@N`
+///      write. `y@3 <= fma<pipelined, 6>(...)` is rejected by the type checker
+///      ("latency-6 result bound at @3") before any solver runs — this is the
+///      mechanism that actually enforces the declared latency at the surface.
+#[test]
+fn formal_pipelined_fma_wrong_latency_is_caught() {
+    // Half 2 (typecheck rejection) is a front-end error and needs no solver,
+    // so assert it first and unconditionally.
+    let (code, out) = run_formal(
+        "tests/formal/pipelined_fma_wrong_binding_rejected.arch",
+        &["--bound", "4"],
+    );
+    assert_eq!(
+        code, 1,
+        "wrong-latency binding must be rejected at typecheck; got {code}\n{out}"
+    );
+    assert!(
+        out.contains("latency-6 result bound at @3"),
+        "expected the latency-mismatch diagnostic:\n{out}"
+    );
+
+    // Half 1 (REFUTED asymmetric delay) needs z3.
+    if !z3_available() {
+        eprintln!("skipping REFUTED half: z3 not in PATH");
+        return;
+    }
+    // Bound 8 is enough for the @6/@5 divergence to surface (it REFUTES at
+    // cycle 8) and keeps the query cheap (~2s) — well under the 60s per-query
+    // timeout even when `cargo test` runs many solver tests in parallel.
+    let (code, out) = run_formal(
+        "tests/formal/pipelined_fma_wrong_latency_refutes.arch",
+        &["--bound", "8"],
+    );
+    assert_eq!(
+        code, 1,
+        "asymmetric pipe_reg latency (@6 vs @5) must REFUTE; got {code}\n{out}"
+    );
+    assert!(out.contains("REFUTED"), "expected REFUTED:\n{out}");
+    // The counterexample must expose the genuine stage registers — proof the
+    // latency is modeled as an N-stage chain, not a single-cycle stand-in.
+    assert!(
+        out.contains("y_stg5") && out.contains("z_stg4"),
+        "counterexample must contain the real per-stage regs \
+         (6-deep `y`, 5-deep `z`):\n{out}"
+    );
+}
+
 #[test]
 fn formal_emit_smt_file() {
     if !z3_available() {


### PR DESCRIPTION
Review-hardening of #972 (`arch formal` now discharges `op<pipelined, N>` calls instead of refusing them, by encoding the value as the single-cycle operator and letting the `pipe_reg<T, N>` carry the latency). A code review flagged two precision artifacts on that soundness-critical path. **No user-facing syntax/semantics change** — an internal comment and test-quality fix.

## Background: the model *is* latency-faithful (verified)

#972's encoder maps `PipelinedCall(op, args, N)` to `FunctionCall(op, args)` (the value) and lets the receiving `pipe_reg<T, N>` supply the delay. The review verified empirically that this delay is genuine, and I re-confirmed on a freshly built binary:

- `pipe_reg` delayed `@6` **PROVED** equal to an explicit 6-deep reg chain.
- `pipe_reg` delayed `@6` **REFUTED** against a 5-deep one, with the real per-stage registers (`y_stg1..y_stg5`, `z_stg1..z_stg4`) in the counterexample.

So the latency is a bit-exact N-stage register chain, not an approximation.

## Artifact 1 — misleading comment (`src/formal.rs`)

The comment on the `PipelinedCall` handler called the model:

> the pre-existing single-cycle approximation shared by all pipe_regs

That is inaccurate and dangerous here: a future maintainer could read "approximation" on a soundness-critical path and conclude the latency model is loose and safe to weaken, when it is actually a faithful N-stage delay. The comment now describes it accurately — N genuine chained stage registers, PROVED/REFUTED evidence cited — and additionally clarifies that this handler models only the **value** (it ignores `_stages`; the delay is carried entirely by the receiving `pipe_reg`).

## Artifact 2 — fixture overstated what it proves (`tests/formal/pipelined_fma_equiv.arch`)

The fixture compares `fma<pipelined, 6>` against a comb `fma`, but **both sides use `@6`**, so the equality holds by construction for any common latency. It therefore proves **value-discharge only**, not that the latency is modeled — #972's commit message claim that it "would fail if the call were given the wrong latency" is not true of this symmetric fixture.

**(a)** Added a comment to the fixture stating precisely what it proves (value-discharge ≡ the combinational op) and what it does **not** (latency correctness), so it isn't over-read.

**(b)** Added coverage that genuinely catches a wrong latency, in the two places it can go wrong:

- **`pipelined_fma_wrong_latency_refutes.arch`** — pipelined fma into a 6-deep `pipe_reg` (`@6`) vs comb fma into a 5-deep one (`@5`). The one-cycle offset **REFUTES**, and the counterexample carries the real per-stage regs — proving the N-stage delay is modeled, not free. Collapse or misalign the pipeline latency and this flips to PROVED.
- **`pipelined_fma_wrong_binding_rejected.arch`** — `y@3 <= fma<pipelined, 6>(...)` is rejected at typecheck (`latency-6 result bound at @3`), the mechanism that actually enforces the declared latency at the language surface (front-end error, no solver needed).

Both asserted in a new `formal_test.rs` test `formal_pipelined_fma_wrong_latency_is_caught` (typecheck half unconditional; REFUTED half gated on z3, bound 8 to stay well under the 60s per-query timeout under parallel `cargo test`). The existing PROVED fixture is unchanged.

## Verification

- `cargo build --release` — clean.
- `cargo test --release --test formal_test` — **31 passed, 0 failed** (run with z3 4.15.4 present, so the new REFUTED + typecheck assertions actually executed: REFUTED at cycle 8; typecheck rejection confirmed).
- `cargo fmt --check` on changed files — clean; `cargo clippy` — no new warnings from these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)