### PR TITLE
test(fp): full arithmetic Lemma A for staged scaled_dot via UF abstraction

### DIFF
--- a/tests/fp_v1/smt_proof/README.md
+++ b/tests/fp_v1/smt_proof/README.md
@@ -329,20 +329,36 @@ passes A and fails B).
   latency for the balanced one; sampling at the wrong depth (L=4 or L=6) is `sat`.
 
 The staged block operators (`scaled_dot`, `scaled_quantize`, arch#955 / PR #960)
-now have rows too, in `balance-only` mode: Lemma B (balance) runs, Lemma A
-(arithmetic) is **deferred as SAT-hard**. Mitering the two independently
-bit-blasted `f32_add` reduction trees has no single collapsing split the way
-fma's one alignment gap does — it times out even at N=2. For the block ops the
-equivalence instead rests on the composition of (a) Lemma B here — which is
-exactly the check that catches the non-power-of-two skew of arch#960, and skew
-generally; (b) the *combinational* schedule miter (`scaled_dot_miter.sh`,
-Theorem A); and (c) the by-construction identity — the staged emitter cuts that
-comb IR into stages without changing operations — formalized generally by the
-Lean retiming lemma. `scaled_dot` is emittable only for power-of-two block sizes
-(the type checker rejects the rest, arch#960); `scaled_quantize`'s per-element
-multiplies are parallel at uniform depth, so any N balances.
+have rows too. Both run Lemma B (balance) — the check that catches the
+non-power-of-two skew of arch#960, and skew generally.
 
-A bounded slice (fma Lemma B + a Lemma-A smoke, and both block-op balance
-checks) runs under `cargo test` (`tests/staged_fma_equivalence_miter_test.rs`)
-when yosys/z3 are present; the full 510-case fma proof is the manual
-long-verification.
+**`scaled_dot` also gets a full Lemma A (arithmetic), via uninterpreted-function
+abstraction** (mode `uf-dot`). Bit-blasting the register-shorted staged dot
+against the comb dot times out even at N=2: the reduction tree is seven
+`arch_f32_add`s with independent alignment gaps and no single collapsing split
+(unlike fma's one gap). But the tree is a *straight line* of `arch_f32_add` /
+`arch_f32_mul` / `arch_*_to_f32` calls, so `tests/fp_v1/synth/uf_datapath.py`
+translates both datapaths to SMT with those primitives **declared uninterpreted**
+— the miter then reduces to congruence over the wiring, `unsat` in milliseconds
+for all inputs. That soundly proves the staged datapath applies the *identical
+composition* of primitives as the comb operator; the primitives' own correctness
+(that `arch_f32_add`/`arch_f32_mul` implement IEEE at full FP32) is discharged
+separately by the renderer miters above, at native 32-bit width. Non-vacuity is
+self-checked: corrupting one tree add flips the verdict to `sat`.
+
+**`scaled_quantize` stays `balance-only`** (Lemma A deferred): its per-element
+multiplies are done by staged-multiply *instances* (`ArchF32MulStaged4`), a
+two-level structure the straight-line UF extractor doesn't cover, and its
+parallel-uniform-depth datapath is well covered by balance + the throughput
+lockstep. `scaled_dot` is emittable only for power-of-two block sizes (the type
+checker rejects the rest, arch#960).
+
+Composing the pieces, the staged `scaled_dot` equivalence is now machine-checked
+end to end: Lemma A (UF — same composition) ∘ leaf primitive correctness
+(renderer miters) ∘ Lemma B (balanced latency) ∘ the Lean retiming lemma
+(balanced feed-forward ⟹ `L`-delayed comb function).
+
+A bounded slice — fma Lemma B + a Lemma-A smoke, both block-op balance checks,
+and the `scaled_dot` UF Lemma A (with its mutation) — runs under `cargo test`
+(`tests/staged_fma_equivalence_miter_test.rs`) when yosys/z3/python are present;
+the full 510-case fma proof is the manual long-verification.

--- a/tests/fp_v1/smt_proof/staged_ops_miter.sh
+++ b/tests/fp_v1/smt_proof/staged_ops_miter.sh
@@ -84,7 +84,7 @@ DUMP_FP_BIN="${DUMP_FP_BIN:-$(dirname "$ARCH_BIN")/examples/dump_fp}"
 # cycle via the wrapper's reset/valid register, an ordinary pipe_reg cascade).
 ops=(
   "fma6|ArchF32FmaStaged6|5|arch_fma_f32|fma"
-  "dot8|arch_scaled_dot_e2m1_8_e8m0_staged6|5|-|balance-only"
+  "dot8|arch_scaled_dot_e2m1_8_e8m0_staged6|5|-|uf-dot"
   "quant8|arch_scaled_quantize_e2m1_8_e8m0_floor_rne_staged5|4|-|balance-only"
 )
 
@@ -171,11 +171,37 @@ ARCH
 
   # ── Lemma A: register-shorted arithmetic miter vs render_smt ──────────────
   if [[ "$split" == "balance-only" ]]; then
-    # Block operators: Lemma A is SAT-hard (see the operator table). The balance
-    # check above is the structural guard; arithmetic equivalence rests on the
-    # comb schedule miter + the by-construction/Lean retiming composition.
+    # scaled_quantize: parallel per-element multiplies via staged-multiply
+    # INSTANCES (two-level), so the UF datapath extractor below does not apply.
+    # Balance (above) is the structural guard; arithmetic rests on the throughput
+    # lockstep + the by-construction/Lean retiming composition.
     vA="deferred(block)"
     printf "%-46s %-16s %-16s %s\n" "$mod" "$vB" "$vA" "$L"
+    continue
+  fi
+  if [[ "$split" == "uf-dot" ]]; then
+    # scaled_dot Lemma A via uninterpreted-function abstraction: the tree is a
+    # straight line of `arch_f32_add/mul/*_to_f32` calls, so declaring those
+    # primitives uninterpreted reduces the staged-vs-comb miter to congruence
+    # over the wiring — `unsat` in milliseconds where the bit-blasted version
+    # times out even at N=2. The primitives' own correctness is discharged by
+    # renderer_miter.sh. combfn = staged module name minus the `_stagedN` tag.
+    combfn="${mod%_staged*}"
+    cat > "$d/comb_ref.arch" <<'ARCH'
+package DF
+  type B8 = ScaledVec<FP4E2M1, 8, E8M0>;
+end package DF
+module dot8_comb
+  port a: in B8;
+  port b: in B8;
+  port o: out FP32;
+  comb o = scaled_dot(a, b); end comb
+end module dot8_comb
+ARCH
+    "$ARCH_BIN" build "$d/comb_ref.arch" -o "$d/comb_ref.sv" >/dev/null 2>&1
+    vA=$(python3 "$here/../synth/uf_datapath.py" "$d/comb_ref.sv" "$combfn" "$d/staged.sv" "$mod" 2>/dev/null)
+    [[ "$vA" == "unsat" ]] || fail=1
+    printf "%-46s %-16s %-16s %s\n" "$mod" "$vB" "unsat(uf)" "$L"
     continue
   fi
   combinationalize "$d/staged.sv" "$mod" "$d/comb.v"

--- a/tests/fp_v1/synth/uf_datapath.py
+++ b/tests/fp_v1/synth/uf_datapath.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Translate a straight-line ARCH FP datapath (comb `function` body OR a
+combinationalized staged module body) to SMT2 over UNINTERPRETED fp primitives.
+The primitives (arch_f32_mul/add/sub/fma, arch_*_to_f32) become (declare-fun ...),
+so equality of two datapaths reduces to congruence over their wiring — no
+arithmetic bit-blasting. Import `build_side`; the miter script ties two together.
+"""
+import re
+
+_TOK = re.compile(r'\s*(\+:|[():,\[\]]|[A-Za-z_][A-Za-z0-9_]*|\d+)')
+
+def _toks(s):
+    out, i = [], 0
+    while i < len(s):
+        m = _TOK.match(s, i)
+        if not m:
+            raise SyntaxError(f"bad token near {s[i:i+20]!r}")
+        out.append(m.group(1)); i = m.end()
+    return out
+
+class _P:
+    def __init__(self, ts): self.ts, self.i = ts, 0
+    def peek(self): return self.ts[self.i] if self.i < len(self.ts) else None
+    def eat(self, x=None):
+        t = self.ts[self.i]; self.i += 1
+        if x is not None and t != x:
+            raise SyntaxError(f"want {x!r} got {t!r}")
+        return t
+
+def _parse(p, width, ufs):
+    """Return (smt_expr, bitwidth). `width` maps input/wire name -> bits."""
+    t = p.eat()
+    if p.peek() == '(':                         # CALL: fp primitive
+        p.eat('(')
+        args, argw = [], []
+        while True:
+            e, w = _parse(p, width, ufs)
+            args.append(e); argw.append(w)
+            if p.peek() == ',':
+                p.eat(','); continue
+            break
+        p.eat(')')
+        ufs[t] = (tuple(argw), 32)              # every primitive returns FP32
+        return f"({t} {' '.join(args)})", 32
+    if p.peek() == '[':                         # SLICE of an input
+        p.eat('[')
+        a = int(p.eat()); sep = p.eat(); bnum = int(p.eat()); p.eat(']')
+        if sep == '+:':
+            lo, w = a, bnum; top = lo + w - 1
+        else:
+            top, lo = a, bnum; w = top - lo + 1
+        return f"((_ extract {top} {lo}) {t})", w
+    # bare identifier: an input (raw) or an earlier wire (w_-prefixed)
+    if t in width and width[t] == 'input':
+        return t, None
+    return f"w_{t}", width.get(t)
+
+def build_side(body, inputs, output_lhs, prefix):
+    """body: SV text with `LHS <= RHS;` / `LHS = RHS;` statements (<= == treated
+    the same — the staged registers are shorted). inputs: {name: bits}.
+    output_lhs: wire holding the datapath output. prefix: unique tag for wire defs.
+    Returns (smt_lines, ufs, out_symbol)."""
+    width = {}
+    for n, b in inputs.items():
+        width[n] = 'input'
+    decl = {}
+    for m in re.finditer(r'logic\s*\[(\d+):0\]\s*([A-Za-z_][A-Za-z0-9_]*)\s*;', body):
+        decl[m.group(2)] = int(m.group(1)) + 1
+    ufs, lines, seen = {}, [], set()
+    for lhs, rhs in re.findall(r'([A-Za-z_][A-Za-z0-9_]*)\s*(?:<=|=)\s*([^;]+);', body):
+        if lhs in inputs or lhs in seen:
+            continue
+        seen.add(lhs)
+        # a plain copy `x <= y` (reg short) with y a bare ident/slice is handled by _parse
+        expr, w = _parse(_P(_toks(rhs.strip())), width, ufs)
+        rw = decl.get(lhs, w or 32)
+        width[lhs] = rw
+        lines.append(f"(define-fun {prefix}_w_{lhs} () (_ BitVec {rw}) {_pref(expr, prefix)})")
+    return lines, ufs, f"{prefix}_w_{output_lhs}"
+
+def _pref(expr, prefix):
+    # prefix wire references `w_foo` -> `PREFIX_w_foo` (keep inputs a/b and (_ extract) raw)
+    return re.sub(r'\bw_([A-Za-z0-9_]+)', rf'{prefix}_w_\1', expr)
+
+
+def build_miter(comb_sv, comb_fn, staged_sv, staged_mod, output_port='y',
+                inputs=None, mutate=None):
+    """Emit a QF_UFBV miter proving the combinationalized staged datapath
+    (`staged_mod` in `staged_sv`, registers shorted) computes the same
+    composition of uninterpreted fp primitives as the combinational operator
+    (`comb_fn` function in `comb_sv`). `unsat` = identical wiring for all inputs.
+    `mutate(text)->text` optionally corrupts the staged SV first (non-vacuity
+    check: a real wiring change must flip the verdict to `sat`)."""
+    import re as _re
+    inputs = inputs or {'a': 40, 'b': 40}
+    csrc = open(comb_sv).read()
+    fn = _re.search(r'function automatic logic \[31:0\] ' + _re.escape(comb_fn)
+                    + r'\(([^)]*)\);(.*?)endfunction', csrc, _re.DOTALL)
+    if not fn:
+        raise SystemExit(f"comb function {comb_fn} not found in {comb_sv}")
+    cdefs, cufs, cout = build_side(fn.group(2), inputs, comb_fn, 'C')
+
+    ssrc = open(staged_sv).read()
+    if mutate:
+        ssrc = mutate(ssrc)
+    mod = _re.search(r'module ' + _re.escape(staged_mod) + r'\b.*?endmodule',
+                     ssrc, _re.DOTALL)
+    if not mod:
+        raise SystemExit(f"staged module {staged_mod} not found in {staged_sv}")
+    sdefs, sufs, sout = build_side(mod.group(0), inputs, output_port, 'S')
+
+    ufs = {**cufs, **sufs}
+    out = ["(set-logic QF_UFBV)"]
+    for name, (argw, rw) in sorted(ufs.items()):
+        dom = ' '.join(f"(_ BitVec {w})" for w in argw)
+        out.append(f"(declare-fun {name} ({dom}) (_ BitVec {rw}))")
+    for n, b in inputs.items():
+        out.append(f"(declare-const {n} (_ BitVec {b}))")
+    out += cdefs + sdefs
+    out.append(f"(assert (not (= {sout} {cout})))")
+    out.append("(check-sat)")
+    return '\n'.join(out) + '\n'
+
+
+# ── mutations for the non-vacuity self-check ────────────────────────────────
+def _mut_add_operand(text):
+    # corrupt one reduction-tree add operand (a wiring change that must flip the
+    # verdict to `sat`). Target a staged tree add by its register-named operands
+    # `arch_f32_add(rX, rY)` — helper-function bodies never use those names — and
+    # rewire the second input to the first (self-add), changing the value.
+    import re as _re
+    return _re.sub(r'(arch_f32_add\((r\w+), )(r\w+)(\))',
+                   lambda m: f"{m.group(1)}{m.group(2)}{m.group(4)}"
+                   if m.group(2) != m.group(3) else m.group(0),
+                   text, count=1)
+
+
+MUTATIONS = {'add-operand': _mut_add_operand}
+
+
+def _main(argv):
+    import subprocess as sp
+    import sys as _sys
+    ap = argv[1:]
+    if len(ap) < 4:
+        print("usage: uf_datapath.py COMB_SV COMB_FN STAGED_SV STAGED_MOD "
+              "[OUTPUT_PORT] [--mutate KIND]", file=_sys.stderr)
+        return 2
+    comb_sv, comb_fn, staged_sv, staged_mod = ap[:4]
+    port = 'y'
+    mutate = None
+    rest = ap[4:]
+    i = 0
+    while i < len(rest):
+        if rest[i] == '--mutate':
+            mutate = MUTATIONS[rest[i + 1]]; i += 2
+        else:
+            port = rest[i]; i += 1
+    smt = build_miter(comb_sv, comb_fn, staged_sv, staged_mod, port, mutate=mutate)
+    r = sp.run(['z3', '-in', '-T:120'], input=smt, capture_output=True, text=True)
+    print((r.stdout + r.stderr).strip().splitlines()[-1] if (r.stdout or r.stderr) else "error")
+    return 0
+
+
+if __name__ == '__main__':
+    import sys
+    sys.exit(_main(sys.argv))

--- a/tests/staged_fma_equivalence_miter_test.rs
+++ b/tests/staged_fma_equivalence_miter_test.rs
@@ -264,3 +264,84 @@ fn staged_fma_arithmetic_miter_smoke() {
         "unexpected miter output:\n{stdout}"
     );
 }
+
+/// Lemma A for the staged `scaled_dot` block operator, via UNINTERPRETED-function
+/// abstraction. The register-shorted staged datapath and the combinational
+/// `scaled_dot` are translated to SMT with every fp primitive
+/// (`arch_f32_add`/`arch_f32_mul`/`arch_*_to_f32`) declared uninterpreted, so
+/// the miter reduces to congruence over the wiring — no bit-blasting the fp
+/// adders/multipliers (which times out; see the operator table in
+/// staged_ops_miter.sh). `unsat` proves the two apply the identical composition
+/// for all inputs; the primitives' own correctness is discharged separately by
+/// renderer_miter.sh. Requires z3 + python3.
+#[test]
+fn staged_scaled_dot_uf_arithmetic_equivalence() {
+    if !tool_ok("z3") || !tool_ok("python3") {
+        eprintln!("skipping: z3/python3 not available");
+        return;
+    }
+    let td = tempfile::tempdir().expect("tempdir");
+    // staged design
+    let staged_src = "package DF\n  type B8 = ScaledVec<FP4E2M1, 8, E8M0>;\nend package DF\n\
+        module Dot\n  port clk: in Clock<Sys>;\n  port rst: in Reset<Sync, High>;\n\
+        \x20 port a: in B8;\n  port b: in B8;\n\
+        \x20 port o: out pipe_reg<FP32, 6> reset rst => 0.0;\n\
+        \x20 seq on clk rising\n    o@6 <= scaled_dot<pipelined, 6>(a, b);\n  end seq\n\
+        end module Dot\n";
+    // combinational reference (emits the `arch_scaled_dot_e2m1_8_e8m0` function)
+    let comb_src = "package DF\n  type B8 = ScaledVec<FP4E2M1, 8, E8M0>;\nend package DF\n\
+        module DotC\n  port a: in B8;\n  port b: in B8;\n  port o: out FP32;\n\
+        \x20 comb o = scaled_dot(a, b); end comb\nend module DotC\n";
+    let sa = td.path().join("dot.arch");
+    let ca = td.path().join("dotc.arch");
+    std::fs::write(&sa, staged_src).unwrap();
+    std::fs::write(&ca, comb_src).unwrap();
+    let ssv = td.path().join("staged.sv");
+    let csv = td.path().join("comb.sv");
+    assert!(arch()
+        .args(["build", "--staged-ops"])
+        .arg(&sa)
+        .arg("-o")
+        .arg(&ssv)
+        .output()
+        .unwrap()
+        .status
+        .success());
+    assert!(arch()
+        .arg("build")
+        .arg(&ca)
+        .arg("-o")
+        .arg(&csv)
+        .output()
+        .unwrap()
+        .status
+        .success());
+
+    let driver = repo_root().join("tests/fp_v1/synth/uf_datapath.py");
+    let run = |extra: &[&str]| -> String {
+        let mut c = Command::new("python3");
+        c.arg(&driver)
+            .arg(&csv)
+            .arg("arch_scaled_dot_e2m1_8_e8m0")
+            .arg(&ssv)
+            .arg("arch_scaled_dot_e2m1_8_e8m0_staged6");
+        for e in extra {
+            c.arg(e);
+        }
+        String::from_utf8_lossy(&c.output().expect("run uf_datapath.py").stdout)
+            .trim()
+            .to_string()
+    };
+
+    assert_eq!(
+        run(&[]),
+        "unsat",
+        "staged scaled_dot must apply the same fp composition as the comb operator"
+    );
+    // non-vacuity: a real wiring change must flip the verdict.
+    assert_eq!(
+        run(&["--mutate", "add-operand"]),
+        "sat",
+        "UF miter is vacuous — a corrupted tree add did not change the verdict"
+    );
+}


### PR DESCRIPTION
## What

Closes the arithmetic half that #973 deferred for the staged `scaled_dot`. Bit-blasting the register-shorted staged dot against the comb operator times out **even at N=2** — the reduction tree is seven `arch_f32_add`s with independent alignment gaps and no single collapsing split (fma had one).

The fix is uninterpreted-function abstraction, exactly as discussed:

```
arch_scaled_dot_e2m1_8_e8m0_staged6   balanced@5   unsat(uf)   5
```

## How

The dot tree is a **straight line** of `arch_f32_add` / `arch_f32_mul` / `arch_*_to_f32` calls. `tests/fp_v1/synth/uf_datapath.py` translates both datapaths — the comb `function` and the register-shorted staged module — to SMT with those primitives **declared uninterpreted**. The miter then reduces to congruence over the wiring: **`unsat` in ~0.01s, for all inputs**, proving the staged datapath applies the *identical composition* of primitives as the comb operator.

**Why it's sound:** the primitives' own correctness — that `arch_f32_add`/`arch_f32_mul` implement IEEE at full FP32 — is discharged **separately** by `renderer_miter.sh`, at native 32-bit width (they're in its 24-operator `unsat` set). The UF miter only has to prove the *composition* matches, which is precisely the piece that was previously on the by-construction / throughput-lockstep argument. No width abstraction, no re-proving the adders.

**Non-vacuity** is self-checked: corrupting one tree add operand flips the verdict to `sat`.

## The staged scaled_dot equivalence is now machine-checked end to end

Lemma A (UF — same composition) ∘ leaf primitive correctness (renderer miters) ∘ Lemma B (balanced latency) ∘ the Lean retiming lemma (balanced feed-forward ⟹ `L`-delayed comb function).

## Coverage

New `staged_scaled_dot_uf_arithmetic_equivalence` test (asserts `unsat`, and the mutation `sat`) runs under `cargo test` when z3/python are present; skips otherwise. Full miter test file **5/5**.

`scaled_quantize` stays `balance-only` — its multiplies are staged-multiply *instances* (`ArchF32MulStaged4`, a two-level structure the straight-line extractor doesn't cover); its parallel-uniform-depth datapath is covered by balance + the throughput lockstep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)